### PR TITLE
Parameterizations of sub-grid topographic effects on solar radiation in ELM

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -44,7 +44,8 @@ _TESTS = {
             "SMS.MOS_USRDAT.RMOSGPCC.mosart-unstructure",
             "SMS.r05_r05.IELM.elm-topounit",
             "ERS.ELM_USRDAT.I1850ELM.elm-usrdat",
-            "ERS.r05_r05.IELM.elm-V2_ELM_MOSART_features"
+            "ERS.r05_r05.IELM.elm-V2_ELM_MOSART_features",
+            "ERS.f09_f09.IELM.elm-solar_rad"
             )
         },
 

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -555,6 +555,11 @@ this mask will have smb calculated over the entire global land surface
 <!--flndtopo hgrid="ne30np4.pg2"      >lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_simyr1850_c201210.nc</flndtopo-->
 <flndtopo hgrid="ne30np4.pg2"      >lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr1850_c210402.nc</flndtopo>
 
+<!-- datasets for TOP solar radiation parameterization -->
+<!--  ***********  Resolution dependent:   *********** -->
+<!--ftopdat>same as fsurfdat </ftopdat-->
+<use_top_solar_rad>.false.</use_top_solar_rad>
+
 <!-- SNICAR (SNow, ICe, and Aerosol Radiative model) datasets -->
 <!--  ***********  Resolution independent:   ***********  -->
 <fsnowoptics >lnd/clm2/snicardata/snicar_optics_5bnd_mam_c160322.nc</fsnowoptics>

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -581,6 +581,13 @@ If TRUE, use implicit method to calculate stresses output to atmosphere.
 If TRUE, use an extra gustiness supplied by the atmosphere in addition to mean wind.
 </entry>
 
+<!-- TOP solar radiation parameterization                        -->
+<entry id="use_top_solar_rad" type="logical" category="elm_physics"
+       group="elm_inparm" valid_values="" value=".false.">
+If TRUE, TOP solar radiation parameterization will be activated, which considers the effects of sub-grid topography.
+</entry>
+<!-- End TOP solar radiation parameterization                   -->
+
 <!-- ========================================================================================  -->
 <!-- Former CPP tokens -->
 <!-- ========================================================================================  -->

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/solar_rad/shell_commands
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/solar_rad/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange NTASKS=48

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/solar_rad/user_nl_elm
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/solar_rad/user_nl_elm
@@ -1,0 +1,2 @@
+fsurdat = '$DIN_LOC_ROOT/lnd/clm2/surfdata_map/surfdata_0.9x1.25_simyr2000_c210914.nc'
+use_top_solar_rad = .true.

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/solar_rad/user_nl_elm
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/solar_rad/user_nl_elm
@@ -1,2 +1,2 @@
-fsurdat = '$DIN_LOC_ROOT/lnd/clm2/surfdata_map/surfdata_0.9x1.25_simyr2000_c210914.nc'
+fsurdat = '$DIN_LOC_ROOT/lnd/clm2/surfdata_map/surfdata_0.9x1.25_simyr2000_c220129.nc'
 use_top_solar_rad = .true.

--- a/components/elm/src/biogeophys/SurfaceAlbedoMod.F90
+++ b/components/elm/src/biogeophys/SurfaceAlbedoMod.F90
@@ -14,7 +14,7 @@ module SurfaceAlbedoMod
   use landunit_varcon   , only : istsoil, istcrop, istdlak
   use elm_varcon        , only : grlnd, namep, namet
   use elm_varpar        , only : numrad, nlevcan, nlevsno, nlevcan
-  use elm_varctl        , only : fsurdat, iulog, subgridflag, use_snicar_frc, use_fates, use_snicar_ad
+  use elm_varctl        , only : fsurdat, iulog, subgridflag, use_snicar_frc, use_fates, use_snicar_ad, use_top_solar_rad
   use VegetationPropertiesType    , only : veg_vp
   use SnowSnicarMod     , only : sno_nbr_aer, SNICAR_RT, SNICAR_AD_RT, DO_SNO_AER, DO_SNO_OC
   use AerosolType       , only : aerosol_type
@@ -43,6 +43,11 @@ module SurfaceAlbedoMod
   ! !PRIVATE MEMBER FUNCTIONS:
   private :: SoilAlbedo    ! Determine ground surface albedo
   private :: TwoStream     ! Two-stream fluxes for canopy radiative transfer
+  private :: Albedo_TOP_Adjustment_novegsol     ! TOP solar radiation parameterization for non-vegetation
+  private :: Albedo_TOP_Adjustment_vegsol_direct     ! TOP solar radiation parameterization for direct radiation over non-vegetation
+  private :: Albedo_TOP_Adjustment_vegsol_diffuse     ! TOP solar radiation parameterization for diffuse radiation over non-vegetation
+
+  !
   !
   ! Coefficient for calculating ice "fraction" for lake surface albedo
   ! From D. Mironov (2010) Boreal Env. Research
@@ -939,7 +944,8 @@ contains
                coszen_patch(bounds%begp:bounds%endp), &
                rho(bounds%begp:bounds%endp, :), &
                tau(bounds%begp:bounds%endp, :), &
-               canopystate_vars, surfalb_vars)
+               canopystate_vars, surfalb_vars, &
+               nextsw_cday, declinp1)
 
     endif
 
@@ -962,6 +968,11 @@ contains
           albi(p,ib) = albgri(c,ib)
        end do
     end do
+
+    if (use_top_solar_rad) then
+       call Albedo_TOP_Adjustment_novegsol(bounds, num_novegsol, filter_novegsol, nextsw_cday, &
+	                                  coszen_patch(bounds%begp:bounds%endp), declinp1, surfalb_vars)
+    endif
 
      end associate
 
@@ -1103,7 +1114,7 @@ contains
    subroutine TwoStream(bounds, &
         filter_vegsol, num_vegsol, &
         coszen, rho, tau, &
-        canopystate_vars, surfalb_vars)
+        canopystate_vars, surfalb_vars, nextsw_cday, decl)
      !
      ! !DESCRIPTION:
      ! Two-stream fluxes for canopy radiative transfer
@@ -1126,11 +1137,14 @@ contains
      type(bounds_type)      , intent(in)    :: bounds
      integer                , intent(in)    :: filter_vegsol (:)        ! filter for vegetated patches with coszen>0
      integer                , intent(in)    :: num_vegsol               ! number of vegetated patches where coszen>0
-     real(r8), intent(in)  :: coszen( bounds%begp: )   ! cosine solar zenith angle for next time step [pft]
-     real(r8), intent(in)  :: rho( bounds%begp: , 1: ) ! leaf/stem refl weighted by fraction LAI and SAI [pft, numrad]
-     real(r8), intent(in)  :: tau( bounds%begp: , 1: ) ! leaf/stem tran weighted by fraction LAI and SAI [pft, numrad]
+     real(r8)               , intent(in)    :: coszen( bounds%begp: )   ! cosine solar zenith angle for next time step [pft]
+     real(r8)               , intent(in)    :: rho( bounds%begp: , 1: ) ! leaf/stem refl weighted by fraction LAI and SAI [pft, numrad]
+     real(r8)               , intent(in)    :: tau( bounds%begp: , 1: ) ! leaf/stem tran weighted by fraction LAI and SAI [pft, numrad]
      type(canopystate_type) , intent(in)    :: canopystate_vars
      type(surfalb_type)     , intent(inout) :: surfalb_vars
+     real(r8)               , intent(in)    :: nextsw_cday              ! calendar day at Greenwich (1.00, ..., days/year)
+     real(r8)               , intent(in)    :: decl                     ! declination angle (radians) for next time step
+     
      !
      ! !LOCAL VARIABLES:
      integer  :: fp,p,c,iv        ! array indices
@@ -1171,39 +1185,42 @@ contains
      ! Enforce expected array sizes
 
      associate(&
-          xl           =>    veg_vp%xl                       , & ! Input:  [real(r8) (:)   ]  ecophys const - leaf/stem orientation index
+          xl            =>    veg_vp%xl                           , & ! Input:  [real(r8) (:)   ]  ecophys const - leaf/stem orientation index
 
-          t_veg        =>    veg_es%t_veg        , & ! Input:  [real(r8) (:)   ]  vegetation temperature (Kelvin)
+          t_veg         =>    veg_es%t_veg                        , & ! Input:  [real(r8) (:)   ]  vegetation temperature (Kelvin)
 
-          fwet         =>    veg_ws%fwet          , & ! Input:  [real(r8) (:)   ]  fraction of canopy that is wet (0 to 1)
+          fwet          =>    veg_ws%fwet                         , & ! Input:  [real(r8) (:)   ]  fraction of canopy that is wet (0 to 1)
 
-          elai         =>    canopystate_vars%elai_patch         , & ! Input:  [real(r8) (:)   ]  one-sided leaf area index with burying by snow
-          esai         =>    canopystate_vars%esai_patch         , & ! Input:  [real(r8) (:)   ]  one-sided stem area index with burying by snow
+          elai          =>    canopystate_vars%elai_patch         , & ! Input:  [real(r8) (:)   ]  one-sided leaf area index with burying by snow
+          esai          =>    canopystate_vars%esai_patch         , & ! Input:  [real(r8) (:)   ]  one-sided stem area index with burying by snow
 
-          tlai_z       =>    surfalb_vars%tlai_z_patch           , & ! Input:  [real(r8) (:,:) ]  tlai increment for canopy layer
-          tsai_z       =>    surfalb_vars%tsai_z_patch           , & ! Input:  [real(r8) (:,:) ]  tsai increment for canopy layer
-          nrad         =>    surfalb_vars%nrad_patch             , & ! Input:  [integer  (:)   ]  number of canopy layers, above snow for radiative transfer
-          albgrd       =>    surfalb_vars%albgrd_col             , & ! Input:  [real(r8) (:,:) ]  ground albedo (direct) (column-level)
-          albgri       =>    surfalb_vars%albgri_col             , & ! Input:  [real(r8) (:,:) ]  ground albedo (diffuse)(column-level)
-
-          fsun_z       =>    surfalb_vars%fsun_z_patch           , & ! Output: [real(r8) (:,:) ]  sunlit fraction of canopy layer
-          vcmaxcintsun =>    surfalb_vars%vcmaxcintsun_patch     , & ! Output: [real(r8) (:)   ]  leaf to canopy scaling coefficient, sunlit leaf vcmax
-          vcmaxcintsha =>    surfalb_vars%vcmaxcintsha_patch     , & ! Output: [real(r8) (:)   ]  leaf to canopy scaling coefficient, shaded leaf vcmax
-          fabd_sun_z   =>    surfalb_vars%fabd_sun_z_patch       , & ! Output: [real(r8) (:,:) ]  absorbed sunlit leaf direct  PAR (per unit lai+sai) for each canopy layer
-          fabd_sha_z   =>    surfalb_vars%fabd_sha_z_patch       , & ! Output: [real(r8) (:,:) ]  absorbed shaded leaf direct  PAR (per unit lai+sai) for each canopy layer
-          fabi_sun_z   =>    surfalb_vars%fabi_sun_z_patch       , & ! Output: [real(r8) (:,:) ]  absorbed sunlit leaf diffuse PAR (per unit lai+sai) for each canopy layer
-          fabi_sha_z   =>    surfalb_vars%fabi_sha_z_patch       , & ! Output: [real(r8) (:,:) ]  absorbed shaded leaf diffuse PAR (per unit lai+sai) for each canopy layer
-          albd         =>    surfalb_vars%albd_patch             , & ! Output: [real(r8) (:,:) ]  surface albedo (direct)
-          albi         =>    surfalb_vars%albi_patch             , & ! Output: [real(r8) (:,:) ]  surface albedo (diffuse)
-          fabd         =>    surfalb_vars%fabd_patch             , & ! Output: [real(r8) (:,:) ]  flux absorbed by canopy per unit direct flux
-          fabd_sun     =>    surfalb_vars%fabd_sun_patch         , & ! Output: [real(r8) (:,:) ]  flux absorbed by sunlit canopy per unit direct flux
-          fabd_sha     =>    surfalb_vars%fabd_sha_patch         , & ! Output: [real(r8) (:,:) ]  flux absorbed by shaded canopy per unit direct flux
-          fabi         =>    surfalb_vars%fabi_patch             , & ! Output: [real(r8) (:,:) ]  flux absorbed by canopy per unit diffuse flux
-          fabi_sun     =>    surfalb_vars%fabi_sun_patch         , & ! Output: [real(r8) (:,:) ]  flux absorbed by sunlit canopy per unit diffuse flux
-          fabi_sha     =>    surfalb_vars%fabi_sha_patch         , & ! Output: [real(r8) (:,:) ]  flux absorbed by shaded canopy per unit diffuse flux
-          ftdd         =>    surfalb_vars%ftdd_patch             , & ! Output: [real(r8) (:,:) ]  down direct flux below canopy per unit direct flx
-          ftid         =>    surfalb_vars%ftid_patch             , & ! Output: [real(r8) (:,:) ]  down diffuse flux below canopy per unit direct flx
-          ftii         =>    surfalb_vars%ftii_patch               & ! Output: [real(r8) (:,:) ]  down diffuse flux below canopy per unit diffuse flx
+          tlai_z        =>    surfalb_vars%tlai_z_patch           , & ! Input:  [real(r8) (:,:) ]  tlai increment for canopy layer
+          tsai_z        =>    surfalb_vars%tsai_z_patch           , & ! Input:  [real(r8) (:,:) ]  tsai increment for canopy layer
+          nrad          =>    surfalb_vars%nrad_patch             , & ! Input:  [integer  (:)   ]  number of canopy layers, above snow for radiative transfer
+          albgrd        =>    surfalb_vars%albgrd_col             , & ! Input:  [real(r8) (:,:) ]  ground albedo (direct) (column-level)
+          albgri        =>    surfalb_vars%albgri_col             , & ! Input:  [real(r8) (:,:) ]  ground albedo (diffuse)(column-level)
+          
+          fd_top_adjust =>   surfalb_vars%fd_top_adjust           , & ! Input: TOP adjusted factor for direct radiation 
+	  fi_top_adjust =>   surfalb_vars%fi_top_adjust           , & ! Input: TOP adjusted factor for diffuse radiation 
+          
+          fsun_z        =>    surfalb_vars%fsun_z_patch           , & ! Output: [real(r8) (:,:) ]  sunlit fraction of canopy layer
+          vcmaxcintsun  =>    surfalb_vars%vcmaxcintsun_patch     , & ! Output: [real(r8) (:)   ]  leaf to canopy scaling coefficient, sunlit leaf vcmax
+          vcmaxcintsha  =>    surfalb_vars%vcmaxcintsha_patch     , & ! Output: [real(r8) (:)   ]  leaf to canopy scaling coefficient, shaded leaf vcmax
+          fabd_sun_z    =>    surfalb_vars%fabd_sun_z_patch       , & ! Output: [real(r8) (:,:) ]  absorbed sunlit leaf direct  PAR (per unit lai+sai) for each canopy layer
+          fabd_sha_z    =>    surfalb_vars%fabd_sha_z_patch       , & ! Output: [real(r8) (:,:) ]  absorbed shaded leaf direct  PAR (per unit lai+sai) for each canopy layer
+          fabi_sun_z    =>    surfalb_vars%fabi_sun_z_patch       , & ! Output: [real(r8) (:,:) ]  absorbed sunlit leaf diffuse PAR (per unit lai+sai) for each canopy layer
+          fabi_sha_z    =>    surfalb_vars%fabi_sha_z_patch       , & ! Output: [real(r8) (:,:) ]  absorbed shaded leaf diffuse PAR (per unit lai+sai) for each canopy layer
+          albd          =>    surfalb_vars%albd_patch             , & ! Output: [real(r8) (:,:) ]  surface albedo (direct)
+          albi          =>    surfalb_vars%albi_patch             , & ! Output: [real(r8) (:,:) ]  surface albedo (diffuse)
+          fabd          =>    surfalb_vars%fabd_patch             , & ! Output: [real(r8) (:,:) ]  flux absorbed by canopy per unit direct flux
+          fabd_sun      =>    surfalb_vars%fabd_sun_patch         , & ! Output: [real(r8) (:,:) ]  flux absorbed by sunlit canopy per unit direct flux
+          fabd_sha      =>    surfalb_vars%fabd_sha_patch         , & ! Output: [real(r8) (:,:) ]  flux absorbed by shaded canopy per unit direct flux
+          fabi          =>    surfalb_vars%fabi_patch             , & ! Output: [real(r8) (:,:) ]  flux absorbed by canopy per unit diffuse flux
+          fabi_sun      =>    surfalb_vars%fabi_sun_patch         , & ! Output: [real(r8) (:,:) ]  flux absorbed by sunlit canopy per unit diffuse flux
+          fabi_sha      =>    surfalb_vars%fabi_sha_patch         , & ! Output: [real(r8) (:,:) ]  flux absorbed by shaded canopy per unit diffuse flux
+          ftdd          =>    surfalb_vars%ftdd_patch             , & ! Output: [real(r8) (:,:) ]  down direct flux below canopy per unit direct flx
+          ftid          =>    surfalb_vars%ftid_patch             , & ! Output: [real(r8) (:,:) ]  down diffuse flux below canopy per unit direct flx
+          ftii          =>    surfalb_vars%ftii_patch               & ! Output: [real(r8) (:,:) ]  down diffuse flux below canopy per unit diffuse flx
           )
 
     ! Calculate two-stream parameters that are independent of waveband:
@@ -1268,7 +1285,8 @@ contains
           ! because the product omega*betai, omega*betad is used in solution.
           ! Also, the transmittances and reflectances (tau, rho) are linear
           ! weights of leaf and stem values.
-
+          cosz = max(0.001_r8, coszen(p))
+          
           omegal = rho(p,ib) + tau(p,ib)
           asu = 0.5_r8*omegal*gdir(p)/temp0(p) *temp2(p)
           betadl = (1._r8+avmu(p)*twostext(p))/(omegal*avmu(p)*twostext(p))*asu
@@ -1339,6 +1357,11 @@ contains
           ftid(p,ib) = h4*s2/sigma + h5*s1 + h6/s1
           ftdd(p,ib) = s2
           fabd(p,ib) = 1._r8 - albd(p,ib) - (1._r8-albgrd(c,ib))*ftdd(p,ib) - (1._r8-albgri(c,ib))*ftid(p,ib)
+  
+          if (use_top_solar_rad) then
+            call Albedo_TOP_Adjustment_vegsol_direct( p, ib, nextsw_cday, &
+	                              cosz, decl, surfalb_vars)
+          endif
 
           a1 = h1 / sigma * (1._r8 - s2*s2) / (2._r8 * twostext(p)) &
              + h2         * (1._r8 - s2*s1) / (twostext(p) + h) &
@@ -1348,7 +1371,8 @@ contains
              + h5         * (1._r8 - s2*s1) / (twostext(p) + h) &
              + h6         * (1._r8 - s2/s1) / (twostext(p) - h)
 
-          fabd_sun(p,ib) = (1._r8 - omega(p,ib)) * ( 1._r8 - s2 + 1._r8 / avmu(p) * (a1 + a2) )
+
+          fabd_sun(p,ib) = (1._r8 - omega(p,ib)) * ( 1._r8 - s2 + 1._r8 / avmu(p) * (a1 + a2) ) * fd_top_adjust(p,ib)
           fabd_sha(p,ib) = fabd(p,ib) - fabd_sun(p,ib)
 
           ! Diffuse
@@ -1370,10 +1394,16 @@ contains
           ftii(p,ib) = h9*s1 + h10/s1
           fabi(p,ib) = 1._r8 - albi(p,ib) - (1._r8-albgri(c,ib))*ftii(p,ib)
 
+          if (use_top_solar_rad) then
+            call Albedo_TOP_Adjustment_vegsol_diffuse(p, ib, nextsw_cday, &
+	                              cosz, decl, surfalb_vars)
+          endif
+          
           a1 = h7 * (1._r8 - s2*s1) / (twostext(p) + h) +  h8 * (1._r8 - s2/s1) / (twostext(p) - h)
           a2 = h9 * (1._r8 - s2*s1) / (twostext(p) + h) + h10 * (1._r8 - s2/s1) / (twostext(p) - h)
 
-          fabi_sun(p,ib) = (1._r8 - omega(p,ib)) / avmu(p) * (a1 + a2)
+
+	  fabi_sun(p,ib) = (1._r8 - omega(p,ib)) / avmu(p) * (a1 + a2) * fi_top_adjust(p,ib)  
           fabi_sha(p,ib) = fabi(p,ib) - fabi_sun(p,ib)
 
           ! Repeat two-stream calculations for each canopy layer to calculate derivatives.
@@ -1500,7 +1530,7 @@ contains
 
                 d_ftid = -twostext(p)*h4/sigma*s2 - h*h5*s1 + h*h6/s1 + dh5*s1 + dh6/s1
                 d_fabd = -(dh2+dh3) + (1._r8-albgrd(c,ib))*twostext(p)*s2 - (1._r8-albgri(c,ib))*d_ftid
-                d_fabd_sun = (1._r8 - omega(p,ib)) * (twostext(p)*s2 + 1._r8 / avmu(p) * (da1 + da2))
+                d_fabd_sun = (1._r8 - omega(p,ib)) * (twostext(p)*s2 + 1._r8 / avmu(p) * (da1 + da2)) * fd_top_adjust(p,ib)
                 d_fabd_sha = d_fabd - d_fabd_sun
 
                 fabd_sun_z(p,iv) = max(d_fabd_sun, 0._r8)
@@ -1566,7 +1596,7 @@ contains
 
                 d_ftii = -h * h9 * s1 + h * h10 / s1 + dh9 * s1 + dh10 / s1
                 d_fabi = -(dh7+dh8) - (1._r8-albgri(c,ib))*d_ftii
-                d_fabi_sun = (1._r8 - omega(p,ib)) / avmu(p) * (da1 + da2)
+                d_fabi_sun = (1._r8 - omega(p,ib)) / avmu(p) * (da1 + da2) * fi_top_adjust(p,ib)
                 d_fabi_sha = d_fabi - d_fabi_sun
 
                 fabi_sun_z(p,iv) = max(d_fabi_sun, 0._r8)
@@ -1589,5 +1619,559 @@ contains
      end associate
 
     end subroutine TwoStream
+    
+!----------------------------------------------------------------------
+  subroutine Albedo_TOP_Adjustment_novegsol(bounds, num_novegsol, filter_novegsol, &
+                                  nextsw_cday, coszen, decl, surfalb_vars)
+! !DESCRIPTION:
+! Adjust surface albedo by accounting for sub-grid topographic effect on surface solar radiation
+!
+
+! !USES:
+    use shr_orb_mod
+    use elm_varctl  , only: iulog
+
+!
+! !ARGUMENTS:
+    implicit none
+    type(bounds_type)  , intent(in)   :: bounds                     ! bounds
+    integer            , intent(in)   :: num_novegsol               ! number of pfts in non-urban filter
+    integer            , intent(in)   :: filter_novegsol(:)         ! bounds%endg-bounds%endg+1 pft filter for non-urban points
+    real(r8)           , intent(in)   :: nextsw_cday                ! calendar day at Greenwich (1.00, ..., days/year)
+    real(r8)           , intent(in)   :: coszen( bounds%begp: )     ! cos solar zenith angle next time step [gridcell]
+    real(r8)           , intent(in)   :: decl                       ! declination angle (radians) for next time step
+    type(surfalb_type) , intent(inout):: surfalb_vars
+ 
+!
+! !CALLED FROM:
+! subroutine SurfaceAlbedo
+
+! !OTHER LOCAL VARIABLES:
+!
+    real(r8), parameter :: mpe = 1.e-06_r8                ! prevents overflow for division by zero
+    real(r8), parameter :: pi = 3.14159265358979323846_r8 ! pi
+    integer  :: fp,fc,g,c,p                               ! indices
+    integer  :: ib                                        ! band index
+    integer  :: ic                                        ! 0=unit incoming direct; 1=unit incoming diffuse
+    integer  :: izen
+    real(r8) :: lon_180                                   ! lon starting from -180
+    real(r8) :: cosz                                      ! cosine solar zenith angle for next time step
+    real(r8) :: sinz                                      ! sine of solar zenith angle
+    real(r8) :: azi_angle                                 ! solar azimuth angle
+    real(r8) :: next_tod                                  ! time of day for nextsw_cday in second
+    real(r8) :: solar_inc                                 ! (solar incident angle) / cos(slope) / cosz
+    real(r8) :: f_dir                                     ! adjustment factor for direct flux
+    real(r8) :: f_rdir, f_rdir_temp                       ! adjustment factor for reflected-direct flux
+    real(r8) :: f_dif                                     ! adjustment factor for diffuse flux
+    real(r8) :: f_rdif, f_rdif_temp                       ! adjustment factor for reflected-diffuse flux
+    real(r8) :: fd_prime                                  ! temp adjustment factor for direct flux
+    real(r8) :: fi_prime                                  ! temp adjustment factor for diffuse flux
+    real(r8) :: albd_adjust                               ! adjusted albedo for direct flux
+    real(r8) :: albi_adjust                               ! adjusted albedo for diffuse flux
+    real(r8) :: ftemp1, ftemp2, dzen1, dzen2
+    real(r8) :: local_timeofday                           ! local time of day (second)
+    real(r8) :: coeff_dir(3,0:7)                          ! regression coefficients for f_dir
+    real(r8) :: coeff_rdir(3,0:7)                         ! regression coefficients for f_rdir
+    real(r8) :: coeff_dif(4,0:7)                          ! regression coefficients for f_dif
+    real(r8) :: coeff_rdif(3,0:7)                         ! regression coefficients for f_rdif
+
+    data coeff_dir(:,1) /2.045E+1_r8, 6.792E-1_r8, -2.103E+1_r8/
+    data coeff_dir(:,2) /1.993E+0_r8, 9.284E-1_r8, -2.911E+0_r8/
+    data coeff_dir(:,3) /5.900E-2_r8, 9.863E-1_r8, -1.045E+0_r8/
+    data coeff_dir(:,4) /5.270E-3_r8, 9.942E-1_r8, -9.995E-1_r8/
+    data coeff_dir(:,5) /2.977E-3_r8, 9.959E-1_r8, -9.990E-1_r8/
+    data coeff_dir(:,6) /2.977E-3_r8, 9.959E-1_r8, -9.990E-1_r8/
+    data coeff_dir(:,7) /8.347E-3_r8,       0._r8, -8.393E-3_r8/
+
+    data coeff_rdir(:,1) / 2.351E-1_r8, 1.590E-1_r8, -2.332E-1_r8/
+    data coeff_rdir(:,2) / 1.368E-1_r8, 1.642E-1_r8, -1.358E-1_r8/
+    data coeff_rdir(:,3) / 1.254E-1_r8, 1.653E-1_r8, -1.247E-1_r8/
+    data coeff_rdir(:,4) / 1.274E-1_r8, 1.635E-1_r8, -1.267E-1_r8/
+    data coeff_rdir(:,5) / 1.314E-1_r8, 1.623E-1_r8, -1.307E-1_r8/
+    data coeff_rdir(:,6) / 1.359E-1_r8, 1.620E-1_r8, -1.352E-1_r8/
+    data coeff_rdir(:,7) /-4.463E-6_r8, 1.556E-1_r8,  1.287E-3_r8/
+
+    data coeff_dif(:,1) /3.146E-7_r8, 4.385E+0_r8, 6.723E-3_r8, -4.382E+0_r8/
+    data coeff_dif(:,2) /6.001E-7_r8, 4.068E+0_r8, 2.456E-2_r8, -4.085E+0_r8/
+    data coeff_dif(:,3) /7.436E-7_r8, 3.911E+0_r8, 5.606E-2_r8, -3.960E+0_r8/
+    data coeff_dif(:,4) /7.806E-7_r8, 3.763E+0_r8, 1.049E-1_r8, -3.863E+0_r8/
+    data coeff_dif(:,5) /7.581E-7_r8, 3.559E+0_r8, 1.734E-1_r8, -3.727E+0_r8/
+    data coeff_dif(:,6) /7.015E-7_r8, 3.298E+0_r8, 2.543E-1_r8, -3.547E+0_r8/
+    data coeff_dif(:,7) /6.359E-7_r8, 2.984E+0_r8,       0._r8, -2.984E+0_r8/
+
+    data coeff_rdif(:,1) / 1.493E-1_r8, 1.621E-1_r8, -1.483E-1_r8/
+    data coeff_rdif(:,2) / 1.462E-1_r8, 1.654E-1_r8, -1.454E-1_r8/
+    data coeff_rdif(:,3) / 1.454E-1_r8, 1.673E-1_r8, -1.446E-1_r8/
+    data coeff_rdif(:,4) / 1.465E-1_r8, 1.683E-1_r8, -1.457E-1_r8/
+    data coeff_rdif(:,5) / 1.443E-1_r8, 1.682E-1_r8, -1.435E-1_r8/
+    data coeff_rdif(:,6) / 1.446E-1_r8, 1.686E-1_r8, -1.439E-1_r8/
+    data coeff_rdif(:,7) /-3.427E-6_r8, 1.576E-1_r8,  1.199E-3_r8/
+
+     ! Enforce expected array sizes
+    SHR_ASSERT_ALL((ubound(coszen) == (/bounds%endp/)),         errMsg(__FILE__, __LINE__))
+
+    ! Assign local pointers to derived subtypes components (gridcell-level)
+
+    associate(&
+          lat            =>    grc_pp%lat                         , & ! Input:   latitude             
+          lon            =>    grc_pp%lon                         , & ! Input:   longitude               
+          pgridcell      =>    veg_pp%gridcell                    , & ! Input:   gridcell 
+          pcolumn        =>    veg_pp%column                      , & ! Input:   column 
+          stdev_elev     =>    grc_pp%stdev_elev                  , & ! Input:   standard deviation of elevation 
+          sky_view       =>    grc_pp%sky_view                    , & ! Input:   sky view factor
+          terrain_config =>    grc_pp%terrain_config              , & ! Input:   terrain configuration factor
+	  sinsl_cosas    =>    grc_pp%sinsl_cosas                 , & ! Input:   sin(slope) * cos(aspect)
+          sinsl_sinas    =>    grc_pp%sinsl_sinas                 , & ! Input:   sin(slope) * sin(aspect)
+          albd           =>    surfalb_vars%albd_patch            , & ! Output:  surface albedo (direct)               
+          albi           =>    surfalb_vars%albi_patch            , & ! Output:  surface albedo (diffuse)              
+          fabd           =>    surfalb_vars%fabd_patch            , & ! Output:  flux absorbed by canopy per unit direct flux
+          fabi           =>    surfalb_vars%fabi_patch            , & ! Output:  flux absorbed by canopy per unit diffuse flux
+          ftdd           =>    surfalb_vars%ftdd_patch            , & ! Output:  down direct flux below canopy per unit direct flux
+          ftid           =>    surfalb_vars%ftid_patch            , & ! Output:  down diffuse flux below canopy per unit direct flux
+          ftii           =>    surfalb_vars%ftii_patch            , & ! Output:  down diffuse flux below canopy per unit diffuse flux
+          fd_top_adjust  =>   surfalb_vars%fd_top_adjust          , & ! Output:  adjusted factor for direct radiation
+          fi_top_adjust  =>   surfalb_vars%fi_top_adjust            & ! Output:  adjusted factor for diffuse radiation
+          )
+
+
+
+     coeff_dir(:,0) = coeff_dir(:,1)
+     coeff_rdir(:,0) = coeff_rdir(:,1)
+     coeff_dif(:,0) = coeff_dif(:,1)
+     coeff_rdif(:,0) = coeff_rdif(:,1)
+
+     next_tod = 86400._r8 * (nextsw_cday - int(nextsw_cday))
+
+     do fp = 1,num_novegsol
+        p = filter_novegsol(fp)
+        g = pgridcell(p)
+        !c = pcolumn(p)
+        cosz = coszen(p)
+        fd_top_adjust(p,1:numrad) = 1._r8
+        fi_top_adjust(p,1:numrad) = 1._r8
+	   
+       ! make sure the lon is between 0-180 
+        lon_180 = lon(g)
+         if (lon_180 > pi) lon_180 = lon_180-2._r8*pi    
+    
+         if (cosz > 0._r8 .and. abs(lat(g)) < 1.047_r8 .and. stdev_elev(g) > 0._r8) then
+            local_timeofday = next_tod + lon_180 / pi * 180._r8 * 240._r8
+
+            if (local_timeofday >= 86400._r8) then
+               local_timeofday = local_timeofday - 86400._r8
+            endif
+    
+            if (local_timeofday < 0._r8) then
+               local_timeofday = local_timeofday + 86400._r8
+            endif
+          
+            if (cosz == 1._r8) then
+               azi_angle = 0._r8
+               sinz = 0._r8
+               solar_inc = 1._r8
+            else
+               sinz = sqrt(1._r8-cosz*cosz)
+               azi_angle = (sin(lat(g))*cosz-sin(decl)) / (cos(lat(g))*sinz) !decl
+               azi_angle = max(-1._r8,min(1._r8,azi_angle))
+               azi_angle = acos(-azi_angle)
+               if (local_timeofday >=43200._r8) then
+                  azi_angle = 2._r8*pi - azi_angle
+               endif
+               azi_angle = pi / 2._r8 - azi_angle
+               !write(iulog,*)  'lon180, ',azi_angle !test          
+               solar_inc = 1._r8 + (sinz/cosz)*(cos(azi_angle)*sinsl_cosas(g)+sin(azi_angle)*sinsl_sinas(g))
+            endif
+
+            izen = int((cosz + 0.05_r8) / 0.15_r8)
+            dzen1 = (cosz - (izen * 0.15_r8 - 0.05_r8)) / 0.15_r8
+            dzen2 = 1._r8 - dzen1
+
+            ftemp1 = coeff_dir(1,izen) * sky_view(g) + &
+                     coeff_dir(2,izen) * solar_inc + coeff_dir(3,izen)
+            ftemp2 = coeff_dir(1,izen+1) * sky_view(g) + &
+                     coeff_dir(2,izen+1) * solar_inc + coeff_dir(3,izen+1)
+            f_dir = ftemp2 * dzen1 + ftemp1 * dzen2
+            f_dir = max(-1._r8,f_dir)
+
+            ftemp1 = coeff_rdir(1,izen) * sky_view(g) + &
+                     coeff_rdir(2,izen) * terrain_config(g) + coeff_rdir(3,izen)
+            ftemp2 = coeff_rdir(1,izen+1) * sky_view(g) + &
+                     coeff_rdir(2,izen+1) * terrain_config(g) + coeff_rdir(3,izen+1)
+            f_rdir_temp = ftemp2 * dzen1 + ftemp1 * dzen2
+
+            ftemp1 = coeff_dif(1,izen) * stdev_elev(g) + &
+                     coeff_dif(2,izen) * sky_view(g) + &
+                     coeff_dif(3,izen) * solar_inc + coeff_dif(4,izen)
+            ftemp2 = coeff_dif(1,izen+1) * stdev_elev(g) + &
+                     coeff_dif(2,izen+1) * sky_view(g) + &
+                     coeff_dif(3,izen+1) * solar_inc + coeff_dif(4,izen+1)
+            f_dif = ftemp2 * dzen1 + ftemp1 * dzen2
+            f_dif = max(-1._r8,f_dif) 
+
+            ftemp1 = coeff_rdif(1,izen) * sky_view(g) + &
+                     coeff_rdif(2,izen) * terrain_config(g) + coeff_rdif(3,izen)
+            ftemp2 = coeff_rdif(1,izen+1) * sky_view(g) + &
+                     coeff_rdif(2,izen+1) * terrain_config(g) + coeff_rdif(3,izen+1)
+            f_rdif_temp = ftemp2 * dzen1 + ftemp1 * dzen2
+
+            do ib = 1, numrad
+               f_rdir = f_rdir_temp * (albd(p,ib) / 0.1_r8)
+               f_rdif = f_rdif_temp * (albi(p,ib) / 0.1_r8)
+
+               fd_prime = 1._r8 + f_dir + f_rdir
+               fi_prime = 1._r8 + f_dif + f_rdif
+
+               albd_adjust = fd_prime * albd(p,ib) - (fd_prime-1._r8)
+               albi_adjust = fi_prime * albi(p,ib) - (fi_prime-1._r8)
+
+               if (albd_adjust <= 0._r8) then 
+                  albd_adjust = 0._r8
+                  fd_prime = 1._r8 / (1._r8 - albd(p,ib))
+               endif
+
+               if (albi_adjust <= 0._r8) then
+                  albi_adjust = 0._r8
+                  fi_prime = 1._r8 / (1._r8 - albi(p,ib))
+               endif
+
+               albd(p,ib) = albd_adjust
+               fabd(p,ib) = fabd(p,ib) * fd_prime
+               ftdd(p,ib) = ftdd(p,ib) * fd_prime
+               ftid(p,ib) = ftid(p,ib) * fd_prime
+               fd_top_adjust(p,ib) = fd_prime
+
+               albi(p,ib) = albi_adjust
+               fabi(p,ib) = fabi(p,ib) * fi_prime
+               ftii(p,ib) = ftii(p,ib) * fi_prime
+               fi_top_adjust(p,ib) = fi_prime
+            enddo
+         endif
+      enddo
+	
+     end associate
+
+  end subroutine Albedo_TOP_Adjustment_novegsol
+
+
+!----------------------------------------------------------------------
+  subroutine Albedo_TOP_Adjustment_vegsol_direct(p, ib, &
+                                  nextsw_cday, cosz, decl, surfalb_vars)
+! !DESCRIPTION:
+! Adjust surface albedo by accounting for sub-grid topographic effect on surface solar radiation
+!
+
+! !USES:
+    use shr_orb_mod
+    use elm_varctl  , only: iulog
+
+!
+! !ARGUMENTS:
+    implicit none
+    real(r8)          , intent(in)    :: nextsw_cday                   ! calendar day at Greenwich (1.00, ..., days/year)
+    real(r8)          , intent(in)    :: cosz                          ! cos solar zenith angle next time step [col]
+    real(r8)          , intent(in)    :: decl                          ! declination angle (radians) for next time step
+    integer           , intent(in)    :: p      
+    integer           , intent(in)    :: ib  
+    type(surfalb_type), intent(inout) :: surfalb_vars
+   
+!
+! !CALLED FROM:
+! subroutine SurfaceAlbedo
+
+!
+! !OTHER LOCAL VARIABLES:
+!
+    real(r8), parameter :: mpe = 1.e-06_r8                ! prevents overflow for division by zero
+    real(r8), parameter :: pi = 3.14159265358979323846_r8 ! pi
+    integer  :: g                                         ! indices
+    integer  :: izen
+    real(r8) :: lon_180                                   ! lon starting from -180
+    real(r8) :: sinz                                      ! sine of solar zenith angle
+    real(r8) :: azi_angle                                 ! solar azimuth angle
+    real(r8) :: next_tod                                  ! time of day for nextsw_cday in second
+    real(r8) :: solar_inc                                 ! (solar incident angle) / cos(slope) / cosz
+    real(r8) :: f_dir                                     ! adjustment factor for direct flux
+    real(r8) :: f_rdir, f_rdir_temp                       ! adjustment factor for reflected-direct flux
+    real(r8) :: fd_prime                                  ! temp adjustment factor for direct flux
+    real(r8) :: albd_adjust                               ! adjusted albedo for direct flux
+    real(r8) :: ftemp1, ftemp2, dzen1, dzen2
+    real(r8) :: local_timeofday                           ! local time of day (second)
+    real(r8) :: coeff_dir(3,0:7)                          ! regression coefficients for f_dir
+    real(r8) :: coeff_rdir(3,0:7)                         ! regression coefficients for f_rdir
+
+
+    data coeff_dir(:,1) /2.045E+1_r8, 6.792E-1_r8, -2.103E+1_r8/
+    data coeff_dir(:,2) /1.993E+0_r8, 9.284E-1_r8, -2.911E+0_r8/
+    data coeff_dir(:,3) /5.900E-2_r8, 9.863E-1_r8, -1.045E+0_r8/
+    data coeff_dir(:,4) /5.270E-3_r8, 9.942E-1_r8, -9.995E-1_r8/
+    data coeff_dir(:,5) /2.977E-3_r8, 9.959E-1_r8, -9.990E-1_r8/
+    data coeff_dir(:,6) /2.977E-3_r8, 9.959E-1_r8, -9.990E-1_r8/
+    data coeff_dir(:,7) /8.347E-3_r8,       0._r8, -8.393E-3_r8/
+
+    data coeff_rdir(:,1) / 2.351E-1_r8, 1.590E-1_r8, -2.332E-1_r8/
+    data coeff_rdir(:,2) / 1.368E-1_r8, 1.642E-1_r8, -1.358E-1_r8/
+    data coeff_rdir(:,3) / 1.254E-1_r8, 1.653E-1_r8, -1.247E-1_r8/
+    data coeff_rdir(:,4) / 1.274E-1_r8, 1.635E-1_r8, -1.267E-1_r8/
+    data coeff_rdir(:,5) / 1.314E-1_r8, 1.623E-1_r8, -1.307E-1_r8/
+    data coeff_rdir(:,6) / 1.359E-1_r8, 1.620E-1_r8, -1.352E-1_r8/
+    data coeff_rdir(:,7) /-4.463E-6_r8, 1.556E-1_r8,  1.287E-3_r8/
+
+
+! Assign local pointers to derived subtypes components (gridcell-level)
+
+   associate(&
+          lat            =>    grc_pp%lat                         , & ! Input:   latitude            
+          lon            =>    grc_pp%lon                         , & ! Input:   longitude              
+          pgridcell      =>    veg_pp%gridcell                    , & ! Input:   gridcell
+          pcolumn        =>    veg_pp%column                      , & ! Input:   column
+          stdev_elev     =>    grc_pp%stdev_elev                  , & ! Input:   standard deviation of elevation
+          sky_view       =>    grc_pp%sky_view                    , & ! Input:   sky view factor
+          terrain_config =>    grc_pp%terrain_config              , & ! Input:   terrain configuration factor
+	  sinsl_cosas    =>    grc_pp%sinsl_cosas                 , & ! Input:   sin(slope) * cos(aspect)
+	  sinsl_sinas    =>    grc_pp%sinsl_sinas                 , & ! Input:   sin(slope) * cos(aspect)
+          albd           =>    surfalb_vars%albd_patch            , & ! Output:  surface albedo (direct)               
+          fabd           =>    surfalb_vars%fabd_patch            , & ! Output:  flux absorbed by canopy per unit direct flux
+          ftdd           =>    surfalb_vars%ftdd_patch            , & ! Output:  down direct flux below canopy per unit direct flux
+          ftid           =>    surfalb_vars%ftid_patch            , & ! Output:  down diffuse flux below canopy per unit direct flux
+          fd_top_adjust  =>    surfalb_vars%fd_top_adjust           & ! Output:  adjusted factor for direct radiation 
+          )
+
+    coeff_dir(:,0) = coeff_dir(:,1)
+    coeff_rdir(:,0) = coeff_rdir(:,1)
+
+    next_tod = 86400._r8 * (nextsw_cday - int(nextsw_cday))
+
+    g = pgridcell(p)
+    fd_top_adjust(p,ib) = 1._r8
+
+    ! make sure the lon is between 0-180
+    lon_180 = lon(g)
+    if (lon_180 > pi) lon_180 = lon_180-2._r8*pi
+
+    if (cosz > 0._r8 .and. abs(lat(g)) < 1.047_r8 .and. stdev_elev(g) > 0._r8) then
+       local_timeofday = next_tod + lon_180 / pi * 180._r8 * 240._r8
+
+       if (local_timeofday >= 86400._r8) then
+          local_timeofday = local_timeofday - 86400._r8
+       endif
+          
+       if (local_timeofday < 0._r8) then
+          local_timeofday = local_timeofday + 86400._r8
+       endif
+          
+       if (cosz == 1._r8) then
+          azi_angle = 0._r8
+          sinz = 0._r8
+          solar_inc = 1._r8
+       else
+          sinz = sqrt(1._r8-cosz*cosz)
+          azi_angle = (sin(lat(g))*cosz-sin(decl)) / (cos(lat(g))*sinz) !decl
+          azi_angle = max(-1._r8,min(1._r8,azi_angle))
+          azi_angle = acos(-azi_angle)
+          if (local_timeofday >=43200._r8) then
+             azi_angle = 2._r8*pi - azi_angle
+          endif
+          azi_angle = pi / 2._r8 - azi_angle
+          solar_inc = 1._r8 + (sinz/cosz)*(cos(azi_angle)*sinsl_cosas(g)+sin(azi_angle)*sinsl_sinas(g))
+       endif
+
+       izen = int((cosz + 0.05_r8) / 0.15_r8)
+       dzen1 = (cosz - (izen * 0.15_r8 - 0.05_r8)) / 0.15_r8
+       dzen2 = 1._r8 - dzen1
+
+       ftemp1 = coeff_dir(1,izen) * sky_view(g) + &
+                coeff_dir(2,izen) * solar_inc + coeff_dir(3,izen)
+       ftemp2 = coeff_dir(1,izen+1) * sky_view(g) + &
+                coeff_dir(2,izen+1) * solar_inc + coeff_dir(3,izen+1)
+       f_dir = ftemp2 * dzen1 + ftemp1 * dzen2
+       f_dir = max(-1._r8,f_dir)
+
+       ftemp1 = coeff_rdir(1,izen) * sky_view(g) + &
+                coeff_rdir(2,izen) * terrain_config(g) + coeff_rdir(3,izen)
+       ftemp2 = coeff_rdir(1,izen+1) * sky_view(g) + &
+                coeff_rdir(2,izen+1) * terrain_config(g) + coeff_rdir(3,izen+1)
+       f_rdir_temp = ftemp2 * dzen1 + ftemp1 * dzen2
+
+       f_rdir = f_rdir_temp * (albd(p,ib) / 0.1_r8)     
+
+       fd_prime = 1._r8 + f_dir + f_rdir
+
+       albd_adjust = fd_prime * albd(p,ib) - (fd_prime-1._r8)
+
+       if (albd_adjust <= 0._r8) then 
+          albd_adjust = 0._r8
+          fd_prime = 1._r8 / (1._r8 - albd(p,ib))
+       endif
+
+       albd(p,ib) = albd_adjust
+       fabd(p,ib) = fabd(p,ib) * fd_prime
+       ftdd(p,ib) = ftdd(p,ib) * fd_prime
+       ftid(p,ib) = ftid(p,ib) * fd_prime
+       fd_top_adjust(p,ib) = fd_prime
+    endif
+	
+     end associate
+
+  end subroutine Albedo_TOP_Adjustment_vegsol_direct
+
+!----------------------------------------------------------------------
+  subroutine Albedo_TOP_Adjustment_vegsol_diffuse(p, ib, &
+                                  nextsw_cday, cosz, decl, surfalb_vars)
+! !DESCRIPTION:
+! Adjust surface albedo by accounting for sub-grid topographic effect on surface solar radiation
+!
+
+! !USES:
+    use shr_orb_mod
+    use elm_varctl  , only: iulog
+
+!
+! !ARGUMENTS:
+    implicit none
+  
+    real(r8)          , intent(in) :: nextsw_cday                   ! calendar day at Greenwich (1.00, ..., days/year)
+    real(r8)          , intent(in) :: cosz                          ! cos solar zenith angle next time step [col]
+    real(r8)          , intent(in) :: decl                          ! declination angle (radians) for next time step
+    integer           , intent(in) :: p      
+    integer           , intent(in) :: ib      
+    type(surfalb_type), intent(inout) :: surfalb_vars
+   
+!
+! !CALLED FROM:
+! subroutine TwoStream
+
+! !OTHER LOCAL VARIABLES:
+!
+    real(r8), parameter :: mpe = 1.e-06_r8                ! prevents overflow for division by zero
+    real(r8), parameter :: pi = 3.14159265358979323846_r8 ! pi
+    integer  :: g                                         ! indices
+    integer  :: izen
+    real(r8) :: lon_180                                   ! lon starting from -180
+    real(r8) :: sinz                                      ! sine of solar zenith angle
+    real(r8) :: azi_angle                                 ! solar azimuth angle
+    real(r8) :: next_tod                                  ! time of day for nextsw_cday in second
+    real(r8) :: solar_inc                                 ! (solar incident angle) / cos(slope) / cosz
+    real(r8) :: f_dif                                     ! adjustment factor for diffuse flux
+    real(r8) :: f_rdif, f_rdif_temp                       ! adjustment factor for reflected-diffuse flux
+    real(r8) :: fi_prime                                  ! temp adjustment factor for diffuse flux
+    real(r8) :: albi_adjust                               ! adjusted albedo for diffuse flux
+    real(r8) :: ftemp1, ftemp2, dzen1, dzen2
+    real(r8) :: local_timeofday                           ! local time of day (second)
+    real(r8) :: coeff_dif(4,0:7)                          ! regression coefficients for f_dif
+    real(r8) :: coeff_rdif(3,0:7)                         ! regression coefficients for f_rdif
+
+
+    data coeff_dif(:,1) /3.146E-7_r8, 4.385E+0_r8, 6.723E-3_r8, -4.382E+0_r8/
+    data coeff_dif(:,2) /6.001E-7_r8, 4.068E+0_r8, 2.456E-2_r8, -4.085E+0_r8/
+    data coeff_dif(:,3) /7.436E-7_r8, 3.911E+0_r8, 5.606E-2_r8, -3.960E+0_r8/
+    data coeff_dif(:,4) /7.806E-7_r8, 3.763E+0_r8, 1.049E-1_r8, -3.863E+0_r8/
+    data coeff_dif(:,5) /7.581E-7_r8, 3.559E+0_r8, 1.734E-1_r8, -3.727E+0_r8/
+    data coeff_dif(:,6) /7.015E-7_r8, 3.298E+0_r8, 2.543E-1_r8, -3.547E+0_r8/
+    data coeff_dif(:,7) /6.359E-7_r8, 2.984E+0_r8,       0._r8, -2.984E+0_r8/
+
+    data coeff_rdif(:,1) / 1.493E-1_r8, 1.621E-1_r8, -1.483E-1_r8/
+    data coeff_rdif(:,2) / 1.462E-1_r8, 1.654E-1_r8, -1.454E-1_r8/
+    data coeff_rdif(:,3) / 1.454E-1_r8, 1.673E-1_r8, -1.446E-1_r8/
+    data coeff_rdif(:,4) / 1.465E-1_r8, 1.683E-1_r8, -1.457E-1_r8/
+    data coeff_rdif(:,5) / 1.443E-1_r8, 1.682E-1_r8, -1.435E-1_r8/
+    data coeff_rdif(:,6) / 1.446E-1_r8, 1.686E-1_r8, -1.439E-1_r8/
+    data coeff_rdif(:,7) /-3.427E-6_r8, 1.576E-1_r8,  1.199E-3_r8/
+
+! Assign local pointers to derived subtypes components (gridcell-level)
+
+   associate(&
+          lat            =>    grc_pp%lat                         , & ! Input:   latitude              
+          lon            =>    grc_pp%lon                         , & ! Input:   longitude              
+          pgridcell      =>    veg_pp%gridcell                    , & ! Input:   gridcell
+          pcolumn        =>    veg_pp%column                      , & ! Input:   column
+          stdev_elev     =>    grc_pp%stdev_elev                  , & ! Input:   standard deviation of elevation
+          sky_view       =>    grc_pp%sky_view                    , & ! Input:   sky view factor
+	  terrain_config =>    grc_pp%terrain_config              , & ! Input:   terrain configuration factor
+	  sinsl_cosas    =>    grc_pp%sinsl_cosas                 , & ! Input:   sin(slope) * cos(aspect)
+	  sinsl_sinas    =>    grc_pp%sinsl_sinas                 , & ! Input:   sin(slope) * sin(aspect)
+          albi           =>    surfalb_vars%albi_patch            , & ! Output:  surface albedo (diffuse)              
+          fabi           =>    surfalb_vars%fabi_patch            , & ! Output:  flux absorbed by canopy per unit diffuse flux
+          ftii           =>    surfalb_vars%ftii_patch            , & ! Output:  down diffuse flux below canopy per unit diffuse flux
+          fi_top_adjust  =>    surfalb_vars%fi_top_adjust           & ! Output:  adjusted factor for diffuse radiation
+          )
+
+    coeff_dif(:,0) = coeff_dif(:,1)
+    coeff_rdif(:,0) = coeff_rdif(:,1)
+
+    next_tod = 86400._r8 * (nextsw_cday - int(nextsw_cday))
+    
+    g = pgridcell(p)
+    fi_top_adjust(p,ib) = 1._r8
+       
+    ! make sure the lon is between 0-180
+    lon_180 = lon(g)
+    if (lon_180 > pi) lon_180 = lon_180-2._r8*pi
+
+    if (cosz > 0._r8 .and. abs(lat(g)) < 1.047_r8 .and. stdev_elev(g) > 0._r8) then
+          local_timeofday = next_tod + lon_180 / pi * 180._r8 * 240._r8  ! need to check make sure is 0-180
+
+          if (local_timeofday >= 86400._r8) then
+             local_timeofday = local_timeofday - 86400._r8
+          endif
+    
+          if (local_timeofday < 0._r8) then
+             local_timeofday = local_timeofday + 86400._r8
+          endif
+          
+          if (cosz == 1._r8) then
+             azi_angle = 0._r8
+             sinz = 0._r8
+             solar_inc = 1._r8
+          else
+             sinz = sqrt(1._r8-cosz*cosz)
+             azi_angle = (sin(lat(g))*cosz-sin(decl)) / (cos(lat(g))*sinz) !decl
+             azi_angle = max(-1._r8,min(1._r8,azi_angle))
+             azi_angle = acos(-azi_angle)
+             if (local_timeofday >=43200._r8) then
+                azi_angle = 2._r8*pi - azi_angle
+             endif
+             azi_angle = pi / 2._r8 - azi_angle
+             solar_inc = 1._r8 + (sinz/cosz)*(cos(azi_angle)*sinsl_cosas(g)+sin(azi_angle)*sinsl_sinas(g))
+          endif
+
+          izen = int((cosz + 0.05_r8) / 0.15_r8)
+          dzen1 = (cosz - (izen * 0.15_r8 - 0.05_r8)) / 0.15_r8
+          dzen2 = 1._r8 - dzen1
+
+          ftemp1 = coeff_dif(1,izen) * stdev_elev(g) + &
+                   coeff_dif(2,izen) * sky_view(g) + &
+                   coeff_dif(3,izen) * solar_inc + coeff_dif(4,izen)
+          ftemp2 = coeff_dif(1,izen+1) * stdev_elev(g) + &
+                   coeff_dif(2,izen+1) * sky_view(g) + &
+                   coeff_dif(3,izen+1) * solar_inc + coeff_dif(4,izen+1)
+          f_dif = ftemp2 * dzen1 + ftemp1 * dzen2
+          f_dif = max(-1._r8,f_dif) 
+
+          ftemp1 = coeff_rdif(1,izen) * sky_view(g) + &
+                   coeff_rdif(2,izen) * terrain_config(g) + coeff_rdif(3,izen)
+          ftemp2 = coeff_rdif(1,izen+1) * sky_view(g) + &
+                   coeff_rdif(2,izen+1) * terrain_config(g) + coeff_rdif(3,izen+1)
+          f_rdif_temp = ftemp2 * dzen1 + ftemp1 * dzen2
+
+          f_rdif = f_rdif_temp * (albi(p,ib) / 0.1_r8)
+
+          fi_prime = 1._r8 + f_dif + f_rdif
+
+          albi_adjust = fi_prime * albi(p,ib) - (fi_prime-1._r8)  
+
+          if (albi_adjust <= 0._r8) then
+             albi_adjust = 0._r8
+             fi_prime = 1._r8 / (1._r8 - albi(p,ib))
+          endif
+
+          albi(p,ib) = albi_adjust
+          fabi(p,ib) = fabi(p,ib) * fi_prime
+          ftii(p,ib) = ftii(p,ib) * fi_prime
+          fi_top_adjust(p,ib) = fi_prime
+    endif
+	
+     end associate
+
+  end subroutine Albedo_TOP_Adjustment_vegsol_diffuse
 
 end module SurfaceAlbedoMod

--- a/components/elm/src/biogeophys/SurfaceAlbedoMod.F90
+++ b/components/elm/src/biogeophys/SurfaceAlbedoMod.F90
@@ -1205,11 +1205,11 @@ contains
           albgri        =>    surfalb_vars%albgri_col             , & ! Input:  [real(r8) (:,:) ]  ground albedo (diffuse)(column-level)
           
           fd_top_adjust =>    surfalb_vars%fd_top_adjust          , & ! Input: TOP adjusted factor for direct radiation 
-	      fi_top_adjust =>    surfalb_vars%fi_top_adjust          , & ! Input: TOP adjusted factor for diffuse radiation
+	  fi_top_adjust =>    surfalb_vars%fi_top_adjust          , & ! Input: TOP adjusted factor for diffuse radiation
           f_dir         =>    surfalb_vars%f_dir                  , & ! Input: TOP adjusted factor for direct radiation 
-	      f_rdir        =>    surfalb_vars%f_rdir                 , & ! Input: TOP adjusted factor for diffuse radiation 
-          f_dif         =>    surfalb_vars%f_dif                  , & ! Input: TOP adjusted factor for direct radiation 
-	      f_rdif        =>    surfalb_vars%f_rdif                 , & ! Input: TOP adjusted factor for diffuse radiation 
+	  f_rdir        =>    surfalb_vars%f_rdir                 , & ! Input: TOP adjusted factor for reflected-direct radiation 
+          f_dif         =>    surfalb_vars%f_dif                  , & ! Input: TOP adjusted factor for diffuse radiation 
+	  f_rdif        =>    surfalb_vars%f_rdif                 , & ! Input: TOP adjusted factor for reflected-diffuse radiation 
           
           fsun_z        =>    surfalb_vars%fsun_z_patch           , & ! Output: [real(r8) (:,:) ]  sunlit fraction of canopy layer
           vcmaxcintsun  =>    surfalb_vars%vcmaxcintsun_patch     , & ! Output: [real(r8) (:)   ]  leaf to canopy scaling coefficient, sunlit leaf vcmax
@@ -1762,7 +1762,7 @@ contains
           stdev_elev     =>    grc_pp%stdev_elev                  , & ! Input:   standard deviation of elevation 
           sky_view       =>    grc_pp%sky_view                    , & ! Input:   sky view factor
           terrain_config =>    grc_pp%terrain_config              , & ! Input:   terrain configuration factor
-	      sinsl_cosas    =>    grc_pp%sinsl_cosas                 , & ! Input:   sin(slope) * cos(aspect)
+	  sinsl_cosas    =>    grc_pp%sinsl_cosas                 , & ! Input:   sin(slope) * cos(aspect)
           sinsl_sinas    =>    grc_pp%sinsl_sinas                 , & ! Input:   sin(slope) * sin(aspect)
           albd           =>    surfalb_vars%albd_patch            , & ! Output:  surface albedo (direct)               
           albi           =>    surfalb_vars%albi_patch            , & ! Output:  surface albedo (diffuse)              
@@ -1774,9 +1774,9 @@ contains
           fd_top_adjust  =>    surfalb_vars%fd_top_adjust         , & ! Output:  TOP adjusted factor for direct radiation
           fi_top_adjust  =>    surfalb_vars%fi_top_adjust         , & ! Output:  TOP adjusted factor for diffuse radiation
           f_dir          =>    surfalb_vars%f_dir                 , & ! Output:  TOP adjusted factor for direct radiation 
-	      f_rdir         =>    surfalb_vars%f_rdir                , & ! Output:  TOP adjusted factor for reflected_direct radiation 
+	  f_rdir         =>    surfalb_vars%f_rdir                , & ! Output:  TOP adjusted factor for reflected_direct radiation 
           f_dif          =>    surfalb_vars%f_dif                 , & ! Output:  TOP adjusted factor for diffuse radiation 
-	      f_rdif         =>    surfalb_vars%f_rdif                  & ! Output:  TOP adjusted factor for reflected_diffuse radiation 
+	  f_rdif         =>    surfalb_vars%f_rdif                  & ! Output:  TOP adjusted factor for reflected_diffuse radiation 
           )
 
 

--- a/components/elm/src/biogeophys/SurfaceAlbedoMod.F90
+++ b/components/elm/src/biogeophys/SurfaceAlbedoMod.F90
@@ -1640,7 +1640,7 @@ contains
                    d_fabi_sun = (1._r8 - omega(p,ib)) / avmu(p) * (da1 + da2) * fi_top_adjust(p,ib)
                 else
                    d_fabi_sun = (1._r8 - omega(p,ib)) / avmu(p) * (da1 + da2)
-                end
+                endif
                 d_fabi_sha = d_fabi - d_fabi_sun
 
                 fabi_sun_z(p,iv) = max(d_fabi_sun, 0._r8)

--- a/components/elm/src/biogeophys/SurfaceAlbedoType.F90
+++ b/components/elm/src/biogeophys/SurfaceAlbedoType.F90
@@ -78,6 +78,10 @@ module SurfaceAlbedoType
 
      real(r8), pointer :: fd_top_adjust        (:,:) => null() !adjustment factor for direct flux (numrad)
      real(r8), pointer :: fi_top_adjust        (:,:) => null() !adjustment factor for diffuse flux (numrad)
+     real(r8), pointer :: f_dir                (:,:) => null() !adjustment factor for direct flux (numrad)
+     real(r8), pointer :: f_rdir               (:,:) => null() !adjustment factor for reflected-direct flux (numrad)
+     real(r8), pointer :: f_dif                (:,:) => null() !adjustment factor for diffuse flux (numrad)
+     real(r8), pointer :: f_rdif               (:,:) => null() !adjustment factor for reflected-diffuse flux (numrad)
      
      real(r8), pointer :: ftdd_patch           (:,:) => null() ! patch down direct flux below canopy per unit direct flx    (numrad)
      real(r8), pointer :: ftid_patch           (:,:) => null() ! patch down diffuse flux below canopy per unit direct flx   (numrad)
@@ -268,8 +272,12 @@ contains
     allocate(this%albd_patch         (begp:endp,numrad))       ; this%albd_patch         (:,:) =spval
     allocate(this%albi_patch         (begp:endp,numrad))       ; this%albi_patch         (:,:) =spval
 
-    allocate(this%fd_top_adjust      (begp:endp,numrad))       ; this%fd_top_adjust      (:,:) =spval
-    allocate(this%fi_top_adjust      (begp:endp,numrad))       ; this%fi_top_adjust      (:,:) =spval
+    allocate(this%fd_top_adjust      (begp:endp,numrad))       ; this%fd_top_adjust      (:,:) =1._r8
+    allocate(this%fi_top_adjust      (begp:endp,numrad))       ; this%fi_top_adjust      (:,:) =1._r8
+    allocate(this%f_dir              (begp:endp,numrad))       ; this%f_dir              (:,:) =0._r8
+    allocate(this%f_rdir             (begp:endp,numrad))       ; this%f_rdir             (:,:) =0._r8
+    allocate(this%f_dif              (begp:endp,numrad))       ; this%f_dif              (:,:) =0._r8
+    allocate(this%f_rdif             (begp:endp,numrad))       ; this%f_rdif             (:,:) =0._r8
     
     allocate(this%ftdd_patch         (begp:endp,numrad))       ; this%ftdd_patch         (:,:) =spval
     allocate(this%ftid_patch         (begp:endp,numrad))       ; this%ftid_patch         (:,:) =spval
@@ -405,7 +413,10 @@ contains
 
     this%fd_top_adjust  (begp:endp, :) = 1.0_r8
     this%fi_top_adjust  (begp:endp, :) = 1.0_r8
-    
+    this%f_dir          (begp:endp, :) = 0.0_r8
+    this%f_rdir         (begp:endp, :) = 0.0_r8
+    this%f_dif          (begp:endp, :) = 0.0_r8
+    this%f_rdif         (begp:endp, :) = 0.0_r8
   end subroutine InitCold
 
   !---------------------------------------------------------------------
@@ -763,6 +774,36 @@ contains
          dim1name='pft', dim2name='numrad', switchdim=.true., &
          long_name='down diffuse flux below veg per unit diffuse flux', units='', &
          interpinic_flag='interp', readvar=readvar, data=this%ftii_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='fd_top_adjust', xtype=ncd_double,  &
+         dim1name='pft', dim2name='numrad', switchdim=.true., &
+         long_name='sub-grid topographic factor for direct radiation', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%fd_top_adjust)
+         
+    call restartvar(ncid=ncid, flag=flag, varname='fi_top_adjust', xtype=ncd_double,  &
+         dim1name='pft', dim2name='numrad', switchdim=.true., &
+         long_name='sub-grid topographic factor for diffuse radiation', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%fi_top_adjust)
+
+    call restartvar(ncid=ncid, flag=flag, varname='f_dir', xtype=ncd_double,  &
+         dim1name='pft', dim2name='numrad', switchdim=.true., &
+         long_name='sub-grid topographic factor for direct radiation', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%f_dir)
+         
+    call restartvar(ncid=ncid, flag=flag, varname='f_rdir', xtype=ncd_double,  &
+         dim1name='pft', dim2name='numrad', switchdim=.true., &
+         long_name='sub-grid topographic factor for reflected-direct radiation', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%f_rdir)
+
+    call restartvar(ncid=ncid, flag=flag, varname='f_dif', xtype=ncd_double,  &
+         dim1name='pft', dim2name='numrad', switchdim=.true., &
+         long_name='sub-grid topographic factor for diffuse radiation', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%f_dif)
+         
+    call restartvar(ncid=ncid, flag=flag, varname='f_rdif', xtype=ncd_double,  &
+         dim1name='pft', dim2name='numrad', switchdim=.true., &
+         long_name='sub-grid topographic factor for reflected-diffuse radiation', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%f_rdif)
 
     !--------------------------------
     ! variables needed for SNICAR

--- a/components/elm/src/biogeophys/SurfaceAlbedoType.F90
+++ b/components/elm/src/biogeophys/SurfaceAlbedoType.F90
@@ -353,16 +353,6 @@ contains
     call hist_addfld2d (fname='ALBI', units='proportion', type2d='numrad', &
          avgflag='A', long_name='surface albedo (indirect)', &
          ptr_patch=this%albi_patch, default='inactive', c2l_scale_type='urbanf')
-	
-    this%fd_top_adjust(begp:endp,:) = spval
-    call hist_addfld2d (fname='fd_top_adjust', units='none', type2d='numrad', &
-         avgflag='A', long_name='fd_top_adjust', &
-         ptr_patch=this%fd_top_adjust)
-		 
-    this%fi_top_adjust(begp:endp,:) = spval
-    call hist_addfld2d (fname='fi_top_adjust', units='none', type2d='numrad', &
-         avgflag='A', long_name='fi_top_adjust', &
-         ptr_patch=this%fi_top_adjust)
     
   end subroutine InitHistory
 

--- a/components/elm/src/biogeophys/SurfaceAlbedoType.F90
+++ b/components/elm/src/biogeophys/SurfaceAlbedoType.F90
@@ -76,6 +76,9 @@ module SurfaceAlbedoType
      real(r8), pointer :: albsnd_hst_col       (:,:) => null() ! col snow albedo, direct , for history files (col,bnd) [frc]
      real(r8), pointer :: albsni_hst_col       (:,:) => null() ! col snow albedo, diffuse, for history files (col,bnd) [frc]
 
+     real(r8), pointer :: fd_top_adjust        (:,:) => null() !adjustment factor for direct flux (numrad)
+     real(r8), pointer :: fi_top_adjust        (:,:) => null() !adjustment factor for diffuse flux (numrad)
+     
      real(r8), pointer :: ftdd_patch           (:,:) => null() ! patch down direct flux below canopy per unit direct flx    (numrad)
      real(r8), pointer :: ftid_patch           (:,:) => null() ! patch down diffuse flux below canopy per unit direct flx   (numrad)
      real(r8), pointer :: ftii_patch           (:,:) => null() ! patch down diffuse flux below canopy per unit diffuse flx  (numrad)
@@ -265,6 +268,9 @@ contains
     allocate(this%albd_patch         (begp:endp,numrad))       ; this%albd_patch         (:,:) =spval
     allocate(this%albi_patch         (begp:endp,numrad))       ; this%albi_patch         (:,:) =spval
 
+    allocate(this%fd_top_adjust      (begp:endp,numrad))       ; this%fd_top_adjust      (:,:) =spval
+    allocate(this%fi_top_adjust      (begp:endp,numrad))       ; this%fi_top_adjust      (:,:) =spval
+    
     allocate(this%ftdd_patch         (begp:endp,numrad))       ; this%ftdd_patch         (:,:) =spval
     allocate(this%ftid_patch         (begp:endp,numrad))       ; this%ftid_patch         (:,:) =spval
     allocate(this%ftii_patch         (begp:endp,numrad))       ; this%ftii_patch         (:,:) =spval
@@ -339,7 +345,17 @@ contains
     call hist_addfld2d (fname='ALBI', units='proportion', type2d='numrad', &
          avgflag='A', long_name='surface albedo (indirect)', &
          ptr_patch=this%albi_patch, default='inactive', c2l_scale_type='urbanf')
-
+	
+    this%fd_top_adjust(begp:endp,:) = spval
+    call hist_addfld2d (fname='fd_top_adjust', units='none', type2d='numrad', &
+         avgflag='A', long_name='fd_top_adjust', &
+         ptr_patch=this%fd_top_adjust)
+		 
+    this%fi_top_adjust(begp:endp,:) = spval
+    call hist_addfld2d (fname='fi_top_adjust', units='none', type2d='numrad', &
+         avgflag='A', long_name='fi_top_adjust', &
+         ptr_patch=this%fi_top_adjust)
+    
   end subroutine InitHistory
 
   !-----------------------------------------------------------------------
@@ -387,6 +403,9 @@ contains
     this%ftid_patch     (begp:endp, :) = 0.0_r8
     this%ftii_patch     (begp:endp, :) = 1.0_r8
 
+    this%fd_top_adjust  (begp:endp, :) = 1.0_r8
+    this%fi_top_adjust  (begp:endp, :) = 1.0_r8
+    
   end subroutine InitCold
 
   !---------------------------------------------------------------------

--- a/components/elm/src/data_types/GridcellType.F90
+++ b/components/elm/src/data_types/GridcellType.F90
@@ -46,7 +46,13 @@ module GridcellType
      integer , pointer :: pftf         (:) => null() ! ending pft index for each gridcell
      integer , pointer :: npfts        (:) => null() ! number of patches for each gridcell
 
-     ! Physical properties
+     real(r8), pointer :: stdev_elev   (:) => null()     ! standard deviation of elevation within a gridcell
+     real(r8), pointer :: sky_view     (:) => null()     ! mean of (sky view factor / cos(slope))
+     real(r8), pointer :: terrain_config (:) => null()   ! mean of (terrain configuration factor / cos(slope))
+     real(r8), pointer :: sinsl_cosas  (:) => null()     ! sin(slope)*cos(aspect) / cos(slope)
+     real(r8), pointer :: sinsl_sinas  (:) => null()     ! sin(slope)*sin(aspect) / cos(slope)
+     
+     ! Daylength
      real(r8) , pointer :: max_dayl    (:) => null() ! maximum daylength for this grid cell (seconds)
      real(r8) , pointer :: dayl        (:) => null() ! daylength (seconds)
      real(r8) , pointer :: prev_dayl   (:) => null() ! daylength from previous timestep (seconds)
@@ -104,6 +110,12 @@ contains
     allocate(this%pftf      (begg:endg)) ; this%pftf      (:) = ispval
     allocate(this%npfts     (begg:endg)) ; this%npfts     (:) = ispval
 
+    allocate(this%stdev_elev(begg:endg)) ; this%stdev_elev(:) = ispval        ! standard deviation of elevation within a gridcell
+    allocate(this%sky_view  (begg:endg)) ; this%sky_view  (:) = ispval        ! mean of (sky view factor / cos(slope))
+    allocate(this%terrain_config(begg:endg)) ; this%terrain_config(:) = ispval! mean of (terrain configuration factor / cos(slope))
+    allocate(this%sinsl_cosas(begg:endg)) ; this%sinsl_cosas(:) = ispval      ! sin(slope)*cos(aspect) / cos(slope)
+    allocate(this%sinsl_sinas(begg:endg)) ; this%sinsl_sinas(:) = ispval      ! sin(slope)*sin(aspect) / cos(slope)
+    
     ! This is initiailized in module DayLength
     allocate(this%max_dayl  (begg:endg)) ; this%max_dayl  (:) = nan
     allocate(this%dayl      (begg:endg)) ; this%dayl      (:) = nan
@@ -151,6 +163,12 @@ contains
     deallocate(this%froudenum        )
     deallocate(this%MaxElevation     )
     deallocate(this%landunit_indices )
+    deallocate(this%stdev_elev       ) 
+    deallocate(this%sky_view         ) 
+    deallocate(this%terrain_config   ) 
+    deallocate(this%sinsl_cosas      )
+    deallocate(this%sinsl_sinas      )
+    
   end subroutine grc_pp_clean
 
 end module GridcellType

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -52,7 +52,8 @@ module controlMod
   use elm_varctl              , only: startdate_add_temperature, startdate_add_co2
   use elm_varctl              , only: add_temperature, add_co2
   use elm_varctl              , only: const_climate_hist
-  
+  use elm_varctl              , only: use_top_solar_rad
+  !
   ! !PUBLIC TYPES:
   implicit none
   save
@@ -306,6 +307,9 @@ contains
     namelist /elm_inparm/ &
          use_erosion, ero_ccycle
 
+    namelist /elm_inparm/ &
+         use_top_solar_rad
+    
     ! ----------------------------------------------------------------------
     ! Default values
     ! ----------------------------------------------------------------------
@@ -802,7 +806,8 @@ contains
     call mpi_bcast (albice, 2, MPI_REAL8,0, mpicom, ier)
     call mpi_bcast (more_vertlayers,1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (const_climate_hist, 1, MPI_LOGICAL, 0, mpicom, ier)
-
+    call mpi_bcast (use_top_solar_rad, 1, MPI_LOGICAL, 0, mpicom, ier)  ! TOP solar radiation parameterization
+    
     ! glacier_mec variables
     call mpi_bcast (create_glacier_mec_landunit, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (maxpatch_glcmec, 1, MPI_INTEGER, 0, mpicom, ier)
@@ -967,6 +972,13 @@ contains
     else
        write(iulog,*) '   atm topographic data = ',trim(fatmtopo)
     end if
+    
+    if (use_top_solar_rad) then
+        write(iulog,*) '  use TOP solar radiation parameterization instead of PP'
+    else
+        write(iulog,*) '   use_top_solar_rad is False, so do not run TOP solar radiation parameterization'
+    end if
+    
     if (use_cn) then
        if (suplnitro /= suplnNon)then
           write(iulog,*) '   Supplemental Nitrogen mode is set to run over Patches: ', &
@@ -1079,6 +1091,9 @@ contains
     write(iulog,*) '   implicit_stress   = ', implicit_stress
     write(iulog,*) '   atm_gustiness   = ', atm_gustiness
     write(iulog,*) '   more vertical layers = ', more_vertlayers
+    
+    write(iulog,*) '   Sub-grid topographic effects on solar radiation   = ', use_top_solar_rad  ! TOP solar radiation parameterization
+     
     if (nsrest == nsrContinue) then
        write(iulog,*) 'restart warning:'
        write(iulog,*) '   Namelist not checked for agreement with initial run.'

--- a/components/elm/src/main/elm_initializeMod.F90
+++ b/components/elm/src/main/elm_initializeMod.F90
@@ -64,7 +64,7 @@ contains
     use soilorder_varcon          , only: soilorder_conrd
     use decompInitMod             , only: decompInit_lnd, decompInit_clumps, decompInit_gtlcp
     use domainMod                 , only: domain_check, ldomain, domain_init
-    use surfrdMod                 , only: surfrd_get_globmask, surfrd_get_grid, surfrd_get_topo, surfrd_get_data
+    use surfrdMod                 , only: surfrd_get_globmask, surfrd_get_grid, surfrd_get_topo, surfrd_get_data,surfrd_get_topo_for_solar_rad
     use controlMod                , only: control_init, control_print, NLFilename
     use ncdio_pio                 , only: ncd_pio_init
     use initGridCellsMod          , only: initGridCells, initGhostGridCells
@@ -82,6 +82,7 @@ contains
     use reweightMod               , only: reweight_wrapup
     use ELMFatesInterfaceMod      , only: ELMFatesGlobals
     use topounit_varcon           , only: max_topounits, has_topounit, topounit_varcon_init    
+    use elm_varctl                , only: use_top_solar_rad
     !
     ! !LOCAL VARIABLES:
     integer           :: ier                     ! error status
@@ -220,7 +221,17 @@ contains
           write(iulog,*) 'Attempting to read atm topo from ',trim(flndtopo)
           call shr_sys_flush(iulog)
        endif
-       call surfrd_get_topo(ldomain, flndtopo)
+
+       call surfrd_get_topo(ldomain, flndtopo)  
+    endif    
+    
+    if (fsurdat /= " " .and. use_top_solar_rad) then
+       if (masterproc) then
+          write(iulog,*) 'Attempting to read topo parameters for TOP solar radiation parameterization from ',trim(fsurdat)
+          call shr_sys_flush(iulog)
+       endif
+       call surfrd_get_topo_for_solar_rad(ldomain, fsurdat)  
+
     endif
     
     !-------------------------------------------------------------------------

--- a/components/elm/src/main/elm_varctl.F90
+++ b/components/elm/src/main/elm_varctl.F90
@@ -358,6 +358,8 @@ module elm_varctl
   logical, public :: use_atm_downscaling_to_topunit  = .false.
   character(len = SHR_KIND_CS), public :: precip_downscaling_method  = 'ERMM' ! Precip downscaling method values can be ERMM or FNM
   logical, public :: use_lake_wat_storage = .false.
+  logical, public :: use_top_solar_rad   = .false.  ! TOP : sub-grid topographic effect on surface solar radiation
+
 
   !----------------------------------------------------------
   ! VSFM switches

--- a/components/elm/src/main/initGridCellsMod.F90
+++ b/components/elm/src/main/initGridCellsMod.F90
@@ -220,6 +220,13 @@ contains
           grc_pp%londeg(gdc) = ldomain%lonc(gdc) 
           grc_pp%lat(gdc)    = grc_pp%latdeg(gdc) * SHR_CONST_PI/180._r8  
           grc_pp%lon(gdc)    = grc_pp%londeg(gdc) * SHR_CONST_PI/180._r8
+
+          grc_pp%stdev_elev(gdc)     = ldomain%stdev_elev(gdc)
+          grc_pp%sky_view(gdc)       = ldomain%sky_view(gdc)
+          grc_pp%terrain_config(gdc) = ldomain%terrain_config(gdc)
+          grc_pp%sinsl_cosas(gdc)    = ldomain%sinsl_cosas(gdc)
+          grc_pp%sinsl_sinas(gdc)    = ldomain%sinsl_sinas(gdc)
+          
        enddo
 
        ! Fill in subgrid datatypes

--- a/components/elm/src/utils/domainMod.F90
+++ b/components/elm/src/utils/domainMod.F90
@@ -176,6 +176,12 @@ contains
     domain%firrig   = 0.7_r8    
     domain%f_surf   = 1.0_r8
     domain%f_grd    = 0.0_r8
+    
+    domain%stdev_elev        = 0.0_r8
+    domain%sky_view          = 1.0_r8
+    domain%terrain_config    = 0.0_r8
+    domain%sinsl_cosas       = 0.0_r8
+    domain%sinsl_sinas       = 0.0_r8
 
     domain%set      = .true.
     if (domain%nbeg == 1 .and. domain%nend == domain%ns) then

--- a/components/elm/src/utils/domainMod.F90
+++ b/components/elm/src/utils/domainMod.F90
@@ -45,6 +45,12 @@ module domainMod
      logical          :: set        ! flag to check if domain is set
      logical          :: decomped   ! decomposed locally or global copy
 
+     real(r8),pointer :: stdev_elev(:)     ! standard deviation of elevation within a gridcell
+     real(r8),pointer :: sky_view(:)       ! mean of (sky view factor / cos(slope))
+     real(r8),pointer :: terrain_config(:) ! mean of (terrain configuration factor / cos(slope))
+     real(r8),pointer :: sinsl_cosas(:)    ! sin(slope)*cos(aspect) / cos(slope)
+     real(r8),pointer :: sinsl_sinas(:)    ! sin(slope)*sin(aspect) / cos(slope)
+     
      ! pflotran:beg-----------------------------------------------------
      integer          :: nv           ! number of vertices
      real(r8),pointer :: latv(:,:)    ! latitude of grid cell's vertices (deg)
@@ -122,7 +128,10 @@ contains
     allocate(domain%mask(nb:ne),domain%frac(nb:ne),domain%latc(nb:ne), &
              domain%pftm(nb:ne),domain%area(nb:ne),domain%firrig(nb:ne),domain%lonc(nb:ne), &
              domain%topo(nb:ne),domain%f_surf(nb:ne),domain%f_grd(nb:ne),domain%num_tunits_per_grd(nb:ne),domain%glcmask(nb:ne), &
-             domain%xCell(nb:ne),domain%yCell(nb:ne),stat=ier)
+             domain%xCell(nb:ne),domain%yCell(nb:ne), &
+             domain%stdev_elev(nb:ne),domain%sky_view(nb:ne),domain%terrain_config(nb:ne), &
+             domain%sinsl_cosas(nb:ne),domain%sinsl_sinas(nb:ne),stat=ier)
+
     if (ier /= 0) then
        call shr_sys_abort('domain_init ERROR: allocate mask, frac, lat, lon, area ')
     endif
@@ -207,9 +216,11 @@ end subroutine domain_init
           write(iulog,*) 'domain_clean: cleaning ',domain%ni,domain%nj
        endif
        deallocate(domain%mask,domain%frac,domain%latc, &
-             domain%pftm,domain%area,domain%firrig,domain%lonc, &
-             domain%topo,domain%f_surf,domain%f_grd,domain%num_tunits_per_grd,domain%glcmask, &
-             domain%xCell,domain%yCell,stat=ier)
+            domain%pftm,domain%area,domain%firrig,domain%lonc, &
+            domain%topo,domain%f_surf,domain%f_grd,domain%num_tunits_per_grd,domain%glcmask, &
+            domain%xCell,domain%yCell, &
+            domain%stdev_elev,domain%sky_view,domain%terrain_config, &
+            domain%sinsl_cosas,domain%sinsl_sinas,stat=ier)
        if (ier /= 0) then
           call shr_sys_abort('domain_clean ERROR: deallocate mask, frac, lat, lon, area ')
        endif
@@ -293,6 +304,11 @@ end subroutine domain_clean
     write(iulog,*) '  domain_check area      = ',minval(domain%area),maxval(domain%area)
     write(iulog,*) '  domain_check pftm      = ',minval(domain%pftm),maxval(domain%pftm)
     write(iulog,*) '  domain_check glcmask   = ',minval(domain%glcmask),maxval(domain%glcmask)
+    write(iulog,*) '  domain_check stdev_elev     = ',minval(domain%stdev_elev),maxval(domain%stdev_elev)
+    write(iulog,*) '  domain_check sky_view       = ',minval(domain%sky_view),maxval(domain%sky_view)
+    write(iulog,*) '  domain_check terrain_config = ',minval(domain%terrain_config),maxval(domain%terrain_config)
+    write(iulog,*) '  domain_check sinsl_cosas    = ',minval(domain%sinsl_cosas),maxval(domain%sinsl_cosas)
+    write(iulog,*) '  domain_check sinsl_sinas    = ',minval(domain%sinsl_sinas),maxval(domain%sinsl_sinas)
     write(iulog,*) ' '
   endif
 


### PR DESCRIPTION
A well-validated sub-grid topographic (TOP) parameterization is added in ELM
that quantifies the effects of sub-grid topography on solar radiation flux
including the shadow effects and multi-scattering between adjacent terrain.
The new parameterization can be turned on by `use_top_solar_rad = .true.`
A test for the new parameterization is added.

[BFB]