### PR TITLE
Add CMakeLists.txt to cmake_macros

### DIFF
--- a/cime_config/machines/cmake_macros/CMakeLists.txt
+++ b/cime_config/machines/cmake_macros/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_policy(SET CMP0057 NEW)
+cmake_minimum_required(VERSION 3.5)
+project(cime LANGUAGES C Fortran)
+include(../Macros.cmake)


### PR DESCRIPTION
This will be used in the next CIME update for the latest
build system features (support for version checking in macros).

[BFB]