### PR TITLE
Add the default land use time series file for NA RRM

### DIFF
--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -437,6 +437,8 @@ lnd/clm2/surfdata_map/surfdata_twpx4v1_simyr2000_c170706.nc</fsurdat>
  use_crop=".false."  >lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850-2015_c180306.nc</flanduse_timeseries>
  <flanduse_timeseries hgrid="ne30np4.pg2"  sim_year_range="1850-2000" 
  use_crop=".false."  >lnd/clm2/surfdata_map/landuse.timeseries_ne30np4.pg2_hist_simyr1850-2015_c210113.nc</flanduse_timeseries>
+ <flanduse_timeseries hgrid="ne0np4_northamericax4v1.pg2"  sim_year_range="1850-2000" 
+ use_crop=".false."  >lnd/clm2/surfdata_map/landuse.timeseries_ne0np4_northamericax4v1.pg2_hist_simyr1850-2015_c211015.nc</flanduse_timeseries>
 <flanduse_timeseries hgrid="ne16np4" sim_year_range="1850-2000"
  use_crop=".false."  >lnd/clm2/surfdata_map/surfdata.pftdyn_ne16np4_hist_simyr1850-2005_c160803.nc</flanduse_timeseries>
 <flanduse_timeseries hgrid="ne11np4" sim_year_range="1850-2000"


### PR DESCRIPTION
The land use time series setting is missing for the North America (NA) 
regionally refined model settings. This PR adds the default file for the 
DECK historical runs. 

[BFB] only impact historical simulation with NARRM
[NML] specify the flanduse_timeseries file.

------------------
Additional notes: 
-------------------
We need this to be merged ASAP, so don't need to rely on the user name list settings for the production runs. The NA RRM DECK historical runs are waiting for this PR to start.

Thanks @bishtgautam for creating this file promptly!

The test was successful at chrysalis:/lcrc/group/e3sm/ac.qtang/E3SMv2/v2.NARRM.historical_0101/tests/S_2x5_ndays