### PR TITLE
Use a shared local Perl lib on ANL machines

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -857,6 +857,9 @@
     <environment_variables SMP_PRESENT="TRUE">
       <env name="OMP_STACKSIZE">64M</env>
     </environment_variables>
+    <environment_variables>
+      <env name="PERL5LIB">/soft/apps/packages/climate/perl5/lib/perl5</env>
+    </environment_variables>
   </machine>
 
   <machine MACH="anlgce">
@@ -921,6 +924,9 @@
     </environment_variables>
     <environment_variables SMP_PRESENT="TRUE">
       <env name="OMP_STACKSIZE">64M</env>
+    </environment_variables>
+    <environment_variables>
+      <env name="PERL5LIB">/nfs/gce/projects/climate/software/perl5/lib/perl5</env>
     </environment_variables>
   </machine>
 


### PR DESCRIPTION
Some E3SM cases use the Switch module of Perl. However, on ANL
machines, Switch.pm is not available in the default Perl paths.

Setting env var to point to the shared local Perl lib (contains Switch.pm)
installed in the climate directory on ANL machines.

On anlworkstation and anlgce, E3SM users no longer need to install
a local Perl lib in their home directories and use it to locate Switch.pm.

[BFB]