### PR TITLE
Improve Kokkos initialization and finalization.

### DIFF
--- a/components/homme/src/share/compose/compose_slmm.cpp
+++ b/components/homme/src/share/compose/compose_slmm.cpp
@@ -234,7 +234,11 @@ void slmm_finalize () {
 }
 } // namespace homme
 
+static bool in_charge_of_kokkos = false;
+
 static void initialize_kokkos () {
+  if (Kokkos::is_initialized()) return;
+  in_charge_of_kokkos = true;
   std::vector<char*> args;
 #ifdef KOKKOS_ENABLE_CUDA
   int nd;
@@ -284,7 +288,8 @@ void kokkos_init () {
 
 void kokkos_finalize () {
   amb::dev_init_threads();
-  Kokkos::finalize();
+  if (in_charge_of_kokkos && Kokkos::is_initialized())
+    Kokkos::finalize();
   amb::dev_fin_threads();
 }
 

--- a/driver-mct/main/cime_comp_mod.F90
+++ b/driver-mct/main/cime_comp_mod.F90
@@ -3495,14 +3495,14 @@ contains
     call seq_timemgr_EClockGetData( EClock_d, stepno=endstep)
     call shr_mem_getusage(msize,mrss)
 
-    call component_final(EClock_a, atm, atm_final)
-    call component_final(EClock_l, lnd, lnd_final)
-    call component_final(EClock_r, rof, rof_final)
-    call component_final(EClock_i, ice, ice_final)
-    call component_final(EClock_o, ocn, ocn_final)
-    call component_final(EClock_g, glc, glc_final)
-    call component_final(EClock_w, wav, wav_final)
     call component_final(EClock_w, iac, iac_final)
+    call component_final(EClock_w, wav, wav_final)
+    call component_final(EClock_g, glc, glc_final)
+    call component_final(EClock_o, ocn, ocn_final)
+    call component_final(EClock_i, ice, ice_final)
+    call component_final(EClock_r, rof, rof_final)
+    call component_final(EClock_l, lnd, lnd_final)
+    call component_final(EClock_a, atm, atm_final)
 
     !------------------------------------------------------------------------
     ! End the run cleanly


### PR DESCRIPTION
When multiple components use Kokkos, we need to be careful about initializing
and finalizing Kokkos. Each can occur only once, and finalization must occur
after the last component using Kokkos has deallocated its views.

This commit modifies cime_comp_mod to finalize components in the opposite order
that it initializes them. Then a component can use is_initialized to determine
if it is in charge of initializing and finalizing Kokkos. In this commit, I've
modified SL transport to follow this pattern.

Fixes #4606.

[BFB]