### PR TITLE
Work around a Cuda issue.

### DIFF
--- a/components/homme/src/share/compose/cedr_bfb_tree_allreduce.cpp
+++ b/components/homme/src/share/compose/cedr_bfb_tree_allreduce.cpp
@@ -83,8 +83,12 @@ void BfbTreeAllReducer<ES>
   const auto nf = nfield_;
   cedr_assert(ns.levels[0].nodes.size() == static_cast<size_t>(nlocal_));
 
-  // We want to be behaviorally const but still permit lazy finish_setup.
-  if ( ! bd_.size()) const_cast<Me*>(this)->finish_setup();
+  { // We want to be behaviorally const but still permit lazy finish_setup.
+    //   Cuda 10.1.105 with GCC 8.5.0 incorrectly misses the const_cast; for
+    // some reason, adding remove_const fixes that.
+    typedef typename std::remove_const<Me>::type MeLcl;
+    if ( ! bd_.size()) const_cast<MeLcl*>(this)->finish_setup();
+  }
 
   const auto buf_host = get_send_host(send);
 

--- a/components/homme/src/share/compose/compose_cedr.cpp
+++ b/components/homme/src/share/compose/compose_cedr.cpp
@@ -484,11 +484,10 @@ void CDR<MT>::init_tracers (const bool need_conservation) {
 
 template <typename MT>
 void CDR<MT>::get_buffers_sizes (size_t& s1, size_t &s2) {
-  if (ko::OnGpu<ko::MachineTraits::DES>::value) {
+  if (ko::OnGpu<ko::MachineTraits::DES>::value)
     s1 = s2 = 0;
-    return;
-  }
-  cdr->get_buffers_sizes(s1, s2);
+  else
+    cdr->get_buffers_sizes(s1, s2);
 }
 
 template <typename MT>

--- a/components/homme/src/share/compose/compose_cedr.cpp
+++ b/components/homme/src/share/compose/compose_cedr.cpp
@@ -358,7 +358,7 @@ struct ReproSumReducer :
         send = typename RealList::HostMirror("send", nlocal*count);
         recv = typename RealList::HostMirror("recv", count);
       }
-      cedr_assert(send.size() == nlocal*count);
+      cedr_assert(static_cast<int>(send.size()) == nlocal*count);
       ko::deep_copy(send, ConstRealList(sendbuf, nlocal*count));
       sendptr = send.data();
       rcvptr = recv.data();

--- a/components/homme/src/share/compose/compose_cedr.cpp
+++ b/components/homme/src/share/compose/compose_cedr.cpp
@@ -431,8 +431,7 @@ CDR<MT>::CDR (Int cdr_alg_, Int ngblcell_, Int nlclcell_, Int nlev_, Int qsize_,
     cdr_over_super_levels(threed && Alg::is_caas(alg)),
     caas_in_suplev(alg == Alg::qlt_super_level_local_caas && nsublev > 1),
     hard_zero(hard_zero_),
-    p(p_), inited_tracers_(false),
-    run(cdr_alg_ != 42)
+    p(p_), run(cdr_alg_ != 42), inited_tracers_(false)
 {
   const Int n_id_in_suplev = caas_in_suplev ? 1 : nsublev;
   if (Alg::is_qlt(alg)) {

--- a/components/homme/src/share/compose/compose_cedr_qlt.cpp
+++ b/components/homme/src/share/compose/compose_cedr_qlt.cpp
@@ -178,18 +178,24 @@ QLT<ES>::QLT (const cedr::mpi::Parallel::Ptr& p, const cedr::Int& ncells,
   : cedr::qlt::QLT<ES>(p, ncells, tree, options)
 {
   if (vertical_levels) {
-    cedr_throw_if(ko::OnGpu<ES>::value,
-                  "QLT does not yet support vertical_levels on gpu.");
-    vld_ = std::make_shared<VerticalLevelsData>(vertical_levels);
+    if (ko::OnGpu<ES>::value)
+      cedr_throw_if(ko::OnGpu<ES>::value,
+                    "QLT does not yet support vertical_levels on gpu.");
+    else
+      vld_ = std::make_shared<VerticalLevelsData>(vertical_levels);
   }
 }
 
 template <typename ES>
 void QLT<ES>::run () {
-  if (ko::OnGpu<ES>::value) {
+  if (ko::OnGpu<ES>::value)
     Super::run();
-    return;
-  }
+  else
+    runimpl();
+}
+
+template <typename ES>
+void QLT<ES>::runimpl () {
   static const int mpitag = 42;
   using cedr::Int;
   using cedr::Real;

--- a/components/homme/src/share/compose/compose_cedr_qlt.hpp
+++ b/components/homme/src/share/compose/compose_cedr_qlt.hpp
@@ -17,6 +17,7 @@ class QLT : public cedr::qlt::QLT<ES> {
 
   void reconcile_vertical(const Int problem_type, const Int bd_os,
                           const Int bis, const Int bie);
+  void runimpl();
 
 public:
   QLT(const cedr::mpi::Parallel::Ptr& p, const cedr::Int& ncells,

--- a/components/homme/src/share/compose/compose_homme.hpp
+++ b/components/homme/src/share/compose/compose_homme.hpp
@@ -142,7 +142,13 @@ struct HommeFormatArray {
     static_assert(rank == 2, "rank 2 array");
     assert(i >= 0);
     assert(ie_data_ptr[ie]);
+    // These routines are not used on the GPU, but they can be called from
+    // KOKKOS_FUNCTIONs on CPU in GPU builds. Avoid nvcc warnings as follows:
+#ifdef __CUDA_ARCH__
+    return unused();
+#else
     return *(ie_data_ptr[ie] + i);
+#endif
   }
   COMPOSE_FORCEINLINE_FUNCTION 
   T& operator() (const Int& ie, const Int& k, const Int& lev) const {
@@ -151,7 +157,11 @@ struct HommeFormatArray {
     assert(lev >= 0);
     assert(ie_data_ptr[ie]);
     check(ie, k, lev);
+#ifdef __CUDA_ARCH__
+    return unused();
+#else
     return *(ie_data_ptr[ie] + lev*np2 + k);
+#endif
   }
   COMPOSE_FORCEINLINE_FUNCTION 
   T& operator() (const Int& ie, const Int& q_or_timelev, const Int& k,
@@ -162,7 +172,11 @@ struct HommeFormatArray {
     assert(lev >= 0);
     assert(ie_data_ptr[ie]);
     check(ie, k, lev, q_or_timelev);
+#ifdef __CUDA_ARCH__
+    return unused();
+#else
     return *(ie_data_ptr[ie] + (q_or_timelev*nlev + lev)*np2 + k);
+#endif
   }
   COMPOSE_FORCEINLINE_FUNCTION 
   T& operator() (const Int& ie, const Int& timelev, const Int& q, const Int& k,
@@ -174,7 +188,11 @@ struct HommeFormatArray {
     assert(lev >= 0);
     assert(ie_data_ptr[ie]);
     check(ie, k, lev, q, timelev);
+#ifdef __CUDA_ARCH__
+    return unused();
+#else
     return *(ie_data_ptr[ie] + ((timelev*qsized + q)*nlev + lev)*np2 + k);
+#endif
   }
 
 private:
@@ -182,10 +200,17 @@ private:
   std::vector<T*> ie_data_ptr;
   const Int nlev, qsized, ntimelev;
 
+#ifdef KOKKOS_ENABLE_CUDA
+  COMPOSE_INLINE_FUNCTION static T& unused () {
+    static T unused = 0;
+    return unused;
+  }
+#endif
+
   COMPOSE_FORCEINLINE_FUNCTION
   void check (Int ie, Int k = -1, Int lev = -1, Int q_or_timelev = -1,
               Int timelev = -1) const {
-#ifdef COMPOSE_BOUNDS_CHECK
+#if defined COMPOSE_BOUNDS_CHECK && ! defined __CUDA_ARCH__
     assert(ie >= 0 && ie < static_cast<Int>(ie_data_ptr.size()));
     if (k >= 0) assert(k < np2);
     if (lev >= 0) assert(lev < nlev);

--- a/components/homme/src/share/compose/compose_homme.hpp
+++ b/components/homme/src/share/compose/compose_homme.hpp
@@ -203,6 +203,7 @@ private:
 #ifdef KOKKOS_ENABLE_CUDA
   COMPOSE_INLINE_FUNCTION static T& unused () {
     static T unused = 0;
+    assert(0);
     return unused;
   }
 #endif

--- a/components/homme/src/share/compose/compose_slmm.cpp
+++ b/components/homme/src/share/compose/compose_slmm.cpp
@@ -316,15 +316,15 @@ void slmm_init_impl (
 
 void slmm_query_bufsz (homme::Int* sendsz, homme::Int* recvsz) {
   slmm_assert(homme::g_csl_mpi);
-  if (ko::OnGpu<ko::MachineTraits::DES>::value) {
+  if (ko::OnGpu<ko::MachineTraits::DES>::value)
     *sendsz = *recvsz = 0;
-    return;
+  else {
+    homme::Int s = 0, r = 0;
+    for (const auto e : homme::g_csl_mpi->sendsz) s += e;
+    for (const auto e : homme::g_csl_mpi->recvsz) r += e;
+    *sendsz = s;
+    *recvsz = r;
   }
-  homme::Int s = 0, r = 0;
-  for (const auto e : homme::g_csl_mpi->sendsz) s += e;
-  for (const auto e : homme::g_csl_mpi->recvsz) r += e;
-  *sendsz = s;
-  *recvsz = r;
 }
 
 void slmm_init_plane (homme::Real Sx, homme::Real Sy, homme::Real Lx, homme::Real Ly) {

--- a/components/homme/src/share/compose/compose_slmm_departure_point.cpp
+++ b/components/homme/src/share/compose/compose_slmm_departure_point.cpp
@@ -26,7 +26,6 @@ void fill_normals (LocalMesh<ko::MachineTraits::HES>& m) {
 // continuous rather than periodic coordinate values.
 void make_continuous (const Plane& p, LocalMesh<ko::MachineTraits::HES>& m) {
   slmm_assert(m.tgt_elem >= 0 && m.tgt_elem <= nslices(m.e));
-  const auto tcell = slice(m.e, m.tgt_elem);
   // Geometric center of cell.
   const auto getctr = [&] (const Int ie, Real ctr[3]) {
     const auto cell = slice(m.e, ie);

--- a/components/homme/src/share/compose/compose_slmm_departure_point.hpp
+++ b/components/homme/src/share/compose/compose_slmm_departure_point.hpp
@@ -261,7 +261,6 @@ void fill_perim (LocalMesh<ES>& m) {
   std::vector<Int> external_edges;
   find_external_edges(m, external_edges);
   const Int nee = external_edges.size();
-  const bool already = m.perimp.size() > 0;
   m.perimp = typename LocalMesh<ES>::Ints("perimp", nee);
   m.perimnml = typename LocalMesh<ES>::Ints("perimnml", nee);
   for (Int k = 0; k < nee; ++k) {

--- a/components/homme/src/share/compose/compose_slmm_islmpi.cpp
+++ b/components/homme/src/share/compose/compose_slmm_islmpi.cpp
@@ -566,7 +566,7 @@ void comm_lid_on_rank (IslMpi<MT>& cm, const Rank2Gids& rank2rmtgids,
     mpi::waitany(count, reqs.data(), &idx);
     const Int* rmtlids = recv.data() + recvptr[idx];
     const auto& gids = rank2rmtgids.at(recvrank[idx]);
-    slmm_assert(recvptr[idx+1] - recvptr[idx] == gids.size());
+    slmm_assert(recvptr[idx+1] - recvptr[idx] == static_cast<int>(gids.size()));
     Int i = 0;
     for (auto gid: gids)
       gid2rmt_owning_lid[gid] = rmtlids[i++];

--- a/components/homme/src/share/compose/compose_slmm_islmpi_adp.cpp
+++ b/components/homme/src/share/compose/compose_slmm_islmpi_adp.cpp
@@ -84,7 +84,6 @@ void analyze_dep_points (IslMpi<MT>& cm, const Int& nets, const Int& nete,
   const auto& plane = cm.advecter->get_plane();
 #ifdef COMPOSE_PORT
   const auto myrank = cm.p->rank();
-  const Int nrmtrank = static_cast<Int>(cm.ranks.size()) - 1;
   const Int np2 = cm.np2, nlev = cm.nlev;
   const auto& own_dep_mask = cm.own_dep_mask;
   cm.bla.zero();

--- a/components/homme/src/share/compose/compose_slmm_islmpi_pack.cpp
+++ b/components/homme/src/share/compose/compose_slmm_islmpi_pack.cpp
@@ -135,14 +135,8 @@ void pack_dep_points_sendbuf_pass1_scan (IslMpi<MT>& cm) {
           *#x) *#lev *#lid *#rank
  */
 template <typename MT>
-void pack_dep_points_sendbuf_pass1 (IslMpi<MT>& cm) {
+void pack_dep_points_sendbuf_pass1_noscan (IslMpi<MT>& cm) {
 #ifdef COMPOSE_PORT
-# ifndef COMPOSE_PACK_NOSCAN
-  if (ko::OnGpu<typename MT::DES>::value) {
-    pack_dep_points_sendbuf_pass1_scan(cm);
-    return;
-  }
-# endif
   ko::fence();
   deep_copy(cm.nx_in_rank_h, cm.nx_in_rank);
   deep_copy(cm.nx_in_lid_h, cm.nx_in_lid);
@@ -213,6 +207,16 @@ void pack_dep_points_sendbuf_pass1 (IslMpi<MT>& cm) {
                     ko::View<Real*, typename MT::HES>(cm.sendbuf_meta_h(ri).data(), n));
   }
 #endif
+}
+
+template <typename MT>
+void pack_dep_points_sendbuf_pass1 (IslMpi<MT>& cm) {
+#if defined COMPOSE_PORT && ! defined COMPOSE_PACK_NOSCAN
+  if (ko::OnGpu<typename MT::DES>::value)
+    pack_dep_points_sendbuf_pass1_scan(cm);
+  else
+#endif
+    pack_dep_points_sendbuf_pass1_noscan(cm);
 }
 
 template <typename MT>

--- a/components/homme/src/share/compose/compose_slmm_islmpi_q.cpp
+++ b/components/homme/src/share/compose/compose_slmm_islmpi_q.cpp
@@ -594,13 +594,7 @@ void calc_rmt_q_pass2 (IslMpi<MT>& cm) {
 #endif // COMPOSE_PORT
 
 template <Int np, typename MT>
-void calc_rmt_q_pass1 (IslMpi<MT>& cm) {
-#if defined COMPOSE_PORT && ! defined COMPOSE_PACK_NOSCAN
-  if (ko::OnGpu<typename MT::DES>::value) {
-    calc_rmt_q_pass1_scan<np>(cm);
-    return;
-  }
-#endif
+void calc_rmt_q_pass1_noscan (IslMpi<MT>& cm) {
   const Int nrmtrank = static_cast<Int>(cm.ranks.size()) - 1;
 #ifdef COMPOSE_PORT_SEPARATE_VIEWS
   for (Int ri = 0; ri < nrmtrank; ++ri)
@@ -665,6 +659,16 @@ void calc_rmt_q_pass1 (IslMpi<MT>& cm) {
   cm.nrmt_qs_extrema = qcnt;
   deep_copy(cm.rmt_xs, cm.rmt_xs_h);
   deep_copy(cm.rmt_qs_extrema, cm.rmt_qs_extrema_h);
+}
+
+template <Int np, typename MT>
+void calc_rmt_q_pass1 (IslMpi<MT>& cm) {
+#if defined COMPOSE_PORT && ! defined COMPOSE_PACK_NOSCAN
+  if (ko::OnGpu<typename MT::DES>::value)
+    calc_rmt_q_pass1_scan<np>(cm);
+  else
+#endif
+    calc_rmt_q_pass1_noscan<np>(cm);
 }
 
 template <Int np, typename MT>

--- a/components/homme/src/share/compose/compose_test.hpp
+++ b/components/homme/src/share/compose/compose_test.hpp
@@ -135,6 +135,7 @@ public:
     case CosineBells: return inputs[2];
     case SlottedCylinders: return inputs[3];
     case CorrelatedCosineBells: return inputs[4];
+    case nshapes: break;
     }
     throw std::runtime_error("Should not be here.");
   }

--- a/components/homme/src/share/compose_mod.F90
+++ b/components/homme/src/share/compose_mod.F90
@@ -106,11 +106,12 @@ module compose_mod
      end subroutine cedr_sl_set_dp3d
 
      subroutine cedr_sl_set_dp(ie, dp) bind(c)
+       use iso_c_binding , only : c_int, c_double
        use kinds         , only : real_kind
        use dimensions_mod, only : nlev, np
        use element_state,  only : timelevels
-       integer, value, intent(in) :: ie
-       real(kind=real_kind), intent(in) :: dp(np,np,nlev)
+       integer(kind=c_int), value, intent(in) :: ie
+       real(kind=c_double), intent(in) :: dp(np,np,nlev)
      end subroutine cedr_sl_set_dp
 
      subroutine cedr_sl_set_Q(ie, Q) bind(c)
@@ -128,25 +129,25 @@ module compose_mod
      subroutine cedr_sl_run_global(minq, maxq, nets, nete) bind(c)
        use iso_c_binding, only: c_int, c_double
        use dimensions_mod, only : nlev, np, qsize
+       integer(kind=c_int), value, intent(in) :: nets, nete
        real(kind=c_double), intent(in) :: minq(np,np,nlev,qsize,nets:nete)
        real(kind=c_double), intent(in) :: maxq(np,np,nlev,qsize,nets:nete)
-       integer(kind=c_int), value, intent(in) :: nets, nete
      end subroutine cedr_sl_run_global
 
      subroutine cedr_sl_run_local(minq, maxq, nets, nete, use_ir, limiter_option) bind(c)
        use iso_c_binding, only: c_int, c_double
        use dimensions_mod, only : nlev, np, qsize
+       integer(kind=c_int), value, intent(in) :: nets, nete, use_ir, limiter_option
        real(kind=c_double), intent(in) :: minq(np,np,nlev,qsize,nets:nete)
        real(kind=c_double), intent(in) :: maxq(np,np,nlev,qsize,nets:nete)
-       integer(kind=c_int), value, intent(in) :: nets, nete, use_ir, limiter_option
      end subroutine cedr_sl_run_local
 
      subroutine cedr_sl_check(minq, maxq, nets, nete) bind(c)
        use iso_c_binding, only: c_int, c_double
        use dimensions_mod, only : nlev, np, qsize
+       integer(kind=c_int), value, intent(in) :: nets, nete
        real(kind=c_double), intent(in) :: minq(np,np,nlev,qsize,nets:nete)
        real(kind=c_double), intent(in) :: maxq(np,np,nlev,qsize,nets:nete)
-       integer(kind=c_int), value, intent(in) :: nets, nete
      end subroutine cedr_sl_check
 
      subroutine slmm_init_local_mesh(ie, neigh_corners, num_neighbors, pinside, &
@@ -424,9 +425,9 @@ contains
     use repro_sum_mod, only: repro_sum
 #endif
 
+    integer(kind=c_int), value, intent(in) :: nlocal, nfld, comm
     real(kind=c_double), intent(in) :: send(nlocal,nfld)
     real(kind=c_double), intent(out) :: recv(nfld)
-    integer(kind=c_int), value, intent(in) :: nlocal, nfld, comm
 
     call repro_sum(send, recv, nlocal, nlocal, nfld, commid=comm)
   end subroutine compose_repro_sum

--- a/components/homme/src/share/cxx/ComposeTransportImpl.hpp
+++ b/components/homme/src/share/cxx/ComposeTransportImpl.hpp
@@ -64,8 +64,8 @@ struct ComposeTransportImpl {
 
     Data ()
       : nelemd(-1), qsize(-1), limiter_option(9), cdr_check(0), hv_q(0),
-        hv_subcycle_q(0), independent_time_steps(false), nu_q(0), hv_scaling(0),
-        dp_tol(-1), geometry_type(0)
+        hv_subcycle_q(0), geometry_type(0), nu_q(0), hv_scaling(0), dp_tol(-1),
+        independent_time_steps(false)
     {}
   };
 

--- a/components/homme/src/share/cxx/ComposeTransportImplGeneral.cpp
+++ b/components/homme/src/share/cxx/ComposeTransportImplGeneral.cpp
@@ -20,17 +20,15 @@ static int calc_nslot (const int nelemd) {
 }
 
 ComposeTransportImpl::ComposeTransportImpl ()
-  : m_tp_ne(1,1,1), m_tu_ne(m_tp_ne), // throwaway settings
-    m_tp_ne_qsize(1,1,1), m_tu_ne_qsize(m_tp_ne_qsize), // throwaway settings
-    m_tp_ne_hv_q(1,1,1), m_tu_ne_hv_q(m_tp_ne_hv_q) // throwaway settings
+  : m_tp_ne(1,1,1), m_tp_ne_qsize(1,1,1), m_tp_ne_hv_q(1,1,1), // throwaway settings
+    m_tu_ne(m_tp_ne), m_tu_ne_qsize(m_tp_ne_qsize), m_tu_ne_hv_q(m_tp_ne_hv_q)
 {
   setup();
 }
 
 ComposeTransportImpl::ComposeTransportImpl (const int num_elems)
-  : m_tp_ne(1,1,1), m_tu_ne(m_tp_ne), // throwaway settings
-    m_tp_ne_qsize(1,1,1), m_tu_ne_qsize(m_tp_ne_qsize), // throwaway settings
-    m_tp_ne_hv_q(1,1,1), m_tu_ne_hv_q(m_tp_ne_hv_q) // throwaway settings
+  : m_tp_ne(1,1,1), m_tp_ne_qsize(1,1,1), m_tp_ne_hv_q(1,1,1), // throwaway settings
+    m_tu_ne(m_tp_ne), m_tu_ne_qsize(m_tp_ne_qsize), m_tu_ne_hv_q(m_tp_ne_hv_q)
 {}
 
 void ComposeTransportImpl::setup () {

--- a/components/homme/src/share/cxx/ComposeTransportImplTrajectory.cpp
+++ b/components/homme/src/share/cxx/ComposeTransportImplTrajectory.cpp
@@ -446,7 +446,7 @@ void ComposeTransportImpl::calc_trajectory (const int np1, const Real dt) {
       const auto dep_pts = Homme::subview(m_dep_pts, ie);
       const auto f = [&] (const int i, const int j, const int k) {
         // dp = p1 - dt v/scale_factor
-        Scalar dp[3], r = 0;
+        Scalar dp[3];
         for (int d = 0; d < 3; ++d) {
           const auto vel_cart = (vec_sphere2cart(0,d,i,j)*vstar(0,i,j,k) +
                                  vec_sphere2cart(1,d,i,j)*vstar(1,i,j,k));

--- a/components/homme/src/share/cxx/GllFvRemapImpl.cpp
+++ b/components/homme/src/share/cxx/GllFvRemapImpl.cpp
@@ -287,7 +287,6 @@ g2f_mixing_ratio (const KernelVariables& kv, const int np2, const int nf2, const
                   const WT& w1, const WT& w2, const int iqf, const QT& qf) {
   using g = GllFvRemapImpl;
   using Kokkos::parallel_for;
-  const auto ttrg = Kokkos::TeamThreadRange(kv.team, np2);
   const auto ttrf = Kokkos::TeamThreadRange(kv.team, nf2);
   const auto tvr  = Kokkos::ThreadVectorRange(kv.team, nlev);
 

--- a/components/homme/test_execs/thetal_kokkos_ut/compose_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/compose_ut.cpp
@@ -392,14 +392,14 @@ TEST_CASE ("compose_transport_testing") {
       ct.test_2d(bfb, nmax, eval_c);
       if (s.get_comm().root()) {
         const Real f = bfb ? 0 : 1;
-        const auto n = s.nlev*s.qsize;
+        const int n = s.nlev*s.qsize;
         // When not a BFB build, still expect l2 error to be the same to a few digits.
-        for (size_t i = 0; i < n; ++i) REQUIRE(almost_equal(eval_f[i], eval_c[i], f*1e-3));
+        for (int i = 0; i < n; ++i) REQUIRE(almost_equal(eval_f[i], eval_c[i], f*1e-3));
         // Mass conservation error should be within a factor of 10 of each other.
-        for (size_t i = n; i < n + s.qsize; ++i) REQUIRE(almost_equal(eval_f[i], eval_c[i], f*10));
+        for (int i = n; i < n + s.qsize; ++i) REQUIRE(almost_equal(eval_f[i], eval_c[i], f*10));
         // And mass conservation itself should be small.
-        for (size_t i = n; i < n + s.qsize; ++i) REQUIRE(std::abs(eval_f[i]) <= 20*tol);
-        for (size_t i = n; i < n + s.qsize; ++i) REQUIRE(std::abs(eval_c[i]) <= 20*tol);
+        for (int i = n; i < n + s.qsize; ++i) REQUIRE(std::abs(eval_f[i]) <= 20*tol);
+        for (int i = n; i < n + s.qsize; ++i) REQUIRE(std::abs(eval_c[i]) <= 20*tol);
         //todo add an l2 ceiling for some select tracers as a function of ne
       }
     }


### PR DESCRIPTION
Cuda 10.1.105 with gcc 8.5.0 erroneously reports an error for a certain line. Details are in SCREAM issue 1277. This PR works around the issue. I studied the issue in part using `-Wall -pedantic` with various compiler versions and thus have also fixed some miscellaneous warnings in SL and physgrid remap code.

[BFB]