### PR TITLE
Fixed fsurdat filename for SSP585 on ne120np4

### DIFF
--- a/components/clm/bld/namelist_files/use_cases/2015-2100_SSP585HR_transient.xml
+++ b/components/clm/bld/namelist_files/use_cases/2015-2100_SSP585HR_transient.xml
@@ -38,6 +38,6 @@
 <check_dynpft_consistency>.false.</check_dynpft_consistency>
 <check_finidat_fsurdat_consistency>.false.</check_finidat_fsurdat_consistency>
 <do_harvest use_cn=".true.">.true.</do_harvest>
-<fsurdat>lnd/clm2/surfdata_map/surfdata_ne120np4_simyr2015_c210903.nc</fsurdat>
+<fsurdat>lnd/clm2/surfdata_map/surfdata_ne120np4_SSP5_RCP85_simyr2015_c210903.nc</fsurdat>
 
 </namelist_defaults>


### PR DESCRIPTION
The fsurdat filename for SSP585 on ne120np4 specified in the
use_case file did not match the file provided for the compset.

[BFB]