### PR TITLE
Adding CRYO1850-4xCO2 compset

### DIFF
--- a/cime_config/allactive/config_compsets.xml
+++ b/cime_config/allactive/config_compsets.xml
@@ -278,6 +278,11 @@
 </compset>
 
 <compset>
+  <alias>CRYO1850-4xCO2</alias>
+  <lname>1850SOI_EAM%CMIP6-4xCO2_ELM%SPBC_MPASSI%DIB_MPASO%IBISMF_MOSART_SGLC_SWAV</lname>
+</compset>
+
+<compset>
   <alias>CRYO1950</alias>
   <lname>1950SOI_EAM%CMIP6_ELM%SPBC_MPASSI%DIB_MPASO%IBISMF_MOSART_SGLC_SWAV</lname>
 </compset>


### PR DESCRIPTION
Adds a new Cryosphere compset that is similar to WCYCL1850-4xCO2, except uses Cryosphere settings for Antarctic runoff (disables Antarctic runoff from the coupler to the ocn, includes ice-shelf melt fluxes and data icebergs).

[BFB] for all currently tested configurations.