### PR TITLE
Chem tracers budget for various vertical blocks

### DIFF
--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1158,6 +1158,15 @@
 <history_clubb>      .false.   </history_clubb>
 <history_gaschmbudget>         .false.  </history_gaschmbudget>
 <history_gaschmbudget_2D>      .false.  </history_gaschmbudget_2D>
+<history_gaschmbudget_2D_levels>   .false.  </history_gaschmbudget_2D_levels>
+<gaschmbudget_2D_L1_s>         1        </gaschmbudget_2D_L1_s>
+<gaschmbudget_2D_L1_e>         25       </gaschmbudget_2D_L1_e>
+<gaschmbudget_2D_L2_s>         26       </gaschmbudget_2D_L2_s>
+<gaschmbudget_2D_L2_e>         40       </gaschmbudget_2D_L2_e>
+<gaschmbudget_2D_L3_s>         41       </gaschmbudget_2D_L3_s>
+<gaschmbudget_2D_L3_e>         58       </gaschmbudget_2D_L3_e>
+<gaschmbudget_2D_L4_s>         59       </gaschmbudget_2D_L4_s>
+<gaschmbudget_2D_L4_e>         72       </gaschmbudget_2D_L4_e>
 
 <!-- BSINGH - ndrop.F90 "repeated g1 equation" bug fix flag -->
 <fix_g1_err_ndrop>             .false.  </fix_g1_err_ndrop>

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -3644,6 +3644,60 @@ Switch for gas chemistry tracers 2D budget diagnostic output
 Default: .false.
 </entry>
 
+<entry id="history_gaschmbudget_2D_levels" type="logical"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch for gas chemistry tracers 2D budget diagnostic output within certain levels
+Default: .false.
+</entry>
+
+<entry id="gaschmbudget_2D_L1_s" type="integer" category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Start layer of L1 for gas chemistry tracers 2D budget diagnostic output
+Default: 1
+</entry>
+
+<entry id="gaschmbudget_2D_L1_e" type="integer" category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+End layer of L1 for gas chemistry tracers 2D budget diagnostic output
+Default: 25
+</entry>
+
+<entry id="gaschmbudget_2D_L2_s" type="integer" category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Start layer of L2 for gas chemistry tracers 2D budget diagnostic output
+Default: 26
+</entry>
+
+<entry id="gaschmbudget_2D_L2_e" type="integer" category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+End layer of L2 for gas chemistry tracers 2D budget diagnostic output
+Default: 40
+</entry>
+
+<entry id="gaschmbudget_2D_L3_s" type="integer" category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Start layer of L3 for gas chemistry tracers 2D budget diagnostic output
+Default: 41
+</entry>
+
+<entry id="gaschmbudget_2D_L3_e" type="integer" category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+End layer of L3 for gas chemistry tracers 2D budget diagnostic output
+Default: 58
+</entry>
+
+<entry id="gaschmbudget_2D_L4_s" type="integer" category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Start layer of L4 for gas chemistry tracers 2D budget diagnostic output
+Default: 59
+</entry>
+
+<entry id="gaschmbudget_2D_L4_e" type="integer" category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+End layer of L4 for gas chemistry tracers 2D budget diagnostic output
+Default: 72
+</entry>
+
 <entry id="history_waccm" type="logical"  category="diagnostics"
        group="phys_ctl_nl" valid_values="" >
 Switch for diagnostic output used primarily for WACCM runs.

--- a/components/eam/src/chemistry/mozart/chemistry.F90
+++ b/components/eam/src/chemistry/mozart/chemistry.F90
@@ -1554,7 +1554,7 @@ end function chem_is_active
 
              if (gaschmbudget_2D_L1_e .lt. gaschmbudget_2D_L1_s .or. gaschmbudget_2D_L2_e .lt. gaschmbudget_2D_L2_s .or. &
                  gaschmbudget_2D_L3_e .lt. gaschmbudget_2D_L3_s .or. gaschmbudget_2D_L4_e .lt. gaschmbudget_2D_L4_s ) then
-                   call endrun('chem_readnl: ERROR 2D chem diags layers')
+                   call endrun('chem_readnl: ERROR 2D chem diags layers, layer ending index is less than starting index')
              end if
 
              do k= gaschmbudget_2D_L1_s, gaschmbudget_2D_L1_e ! 0-90 hPa
@@ -1592,6 +1592,7 @@ end function chem_is_active
              call outfld(trim(solsym(n))//'_2DTDO_L3', Diff_layers(:ncol,3), pcols, lchnk)
              call outfld(trim(solsym(n))//'_2DTDO_L4', Diff_layers(:ncol,4), pcols, lchnk)
 
+             ! for the tropospheric budget diagnostics
              if (trim(solsym(n))=='O3' .or. trim(solsym(n))=='O3LNZ' .or. &
                  trim(solsym(n))=='N2OLNZ' .or. trim(solsym(n))=='CH4LNZ') then
                 ftem_layers = 0.0_r8
@@ -1599,21 +1600,16 @@ end function chem_is_active
                 do k=1,pver
                    ftem_layers(:ncol,1) = ftem_layers(:ncol,1) + ftem(:ncol,k) * tropFlagInt(:ncol,k)
                    gas_ac_layers(:ncol,1) = gas_ac_layers(:ncol,1) + gas_ac(:ncol,k) * tropFlagInt(:ncol,k)
-                   ftem_layers(:ncol,2) = ftem_layers(:ncol,2) + ftem(:ncol,k) * (1.0 - tropFlagInt(:ncol,k))
-                   gas_ac_layers(:ncol,2) = gas_ac_layers(:ncol,2) + gas_ac(:ncol,k) * (1.0 - tropFlagInt(:ncol,k))
                 end do
                 call outfld(trim(solsym(n))//'_2DMSB_trop', ftem_layers(:ncol,1), pcols, lchnk )
-                call outfld(trim(solsym(n))//'_2DMSB_stra', ftem_layers(:ncol,2), pcols, lchnk )
 
                 if( nstep == 0 ) then
                    Diff_layers(:ncol,:) = 0.0_r8
                 else
                    Diff_layers(:ncol,:) = 0.0_r8
                    Diff_layers(:ncol,1) = (ftem_layers(:ncol,1) - gas_ac_layers(:ncol,1))/dt
-                   Diff_layers(:ncol,2) = (ftem_layers(:ncol,2) - gas_ac_layers(:ncol,2))/dt
                 end if
                 call outfld(trim(solsym(n))//'_2DTDO_trop', Diff_layers(:ncol,1), pcols, lchnk)
-                call outfld(trim(solsym(n))//'_2DTDO_stra', Diff_layers(:ncol,2), pcols, lchnk)
              end if
 
            end if ! history_gaschmbudget_2D_levels

--- a/components/eam/src/chemistry/mozart/chemistry.F90
+++ b/components/eam/src/chemistry/mozart/chemistry.F90
@@ -1376,7 +1376,8 @@ end function chem_is_active
     use physconst,           only : rga
     use phys_control,        only : phys_getopts
     use mo_chem_utls,        only : get_spc_ndx
-    
+    use cam_abortutils,      only: endrun
+ 
     implicit none
 
 !-----------------------------------------------------------------------
@@ -1406,6 +1407,7 @@ end function chem_is_active
     integer  :: tropLev(pcols)
     integer  :: tmp_tropLev(pcols)
     logical  :: tropFlag(pcols,pver)      ! 3D tropospheric level flag
+    real(r8) :: tropFlagInt(pcols,pver)   ! 3D tropospheric level flag integer, troposphere 1, others 0
     real(r8) :: ncldwtr(pcols,pver)                ! droplet number concentration (#/kg)
     real(r8), pointer :: pblh(:)
     real(r8), pointer :: prain(:,:)
@@ -1415,10 +1417,22 @@ end function chem_is_active
     real(r8), pointer :: cldtop(:)
     real(r8), pointer, dimension(:) :: gas_ac_2D
     real(r8), pointer, dimension(:,:) :: gas_ac
+    real(r8) :: gas_ac_layers(pcols,4)
     real(r8) :: Diff(pcols,pver) ! tmp space
+    real(r8) :: Diff_layers(pcols,4) ! tmp space
     real(r8) :: ftem(pcols,pver) ! tmp space
+    real(r8) :: ftem_layers(pcols,4) ! tmp space
     logical :: history_gaschmbudget ! output gas chemistry tracer concentrations and tendencies
     logical :: history_gaschmbudget_2D
+    logical :: history_gaschmbudget_2D_levels
+    integer :: gaschmbudget_2D_L1_s
+    integer :: gaschmbudget_2D_L1_e
+    integer :: gaschmbudget_2D_L2_s
+    integer :: gaschmbudget_2D_L2_e
+    integer :: gaschmbudget_2D_L3_s
+    integer :: gaschmbudget_2D_L3_e
+    integer :: gaschmbudget_2D_L4_s
+    integer :: gaschmbudget_2D_L4_e
     integer ::  gas_ac_idx
     integer :: nstep
 
@@ -1432,7 +1446,16 @@ end function chem_is_active
     nstep = get_nstep()
 
     call phys_getopts(history_gaschmbudget_out = history_gaschmbudget, &
-                   history_gaschmbudget_2D_out = history_gaschmbudget_2D)
+                   history_gaschmbudget_2D_out = history_gaschmbudget_2D, &
+            history_gaschmbudget_2D_levels_out = history_gaschmbudget_2D_levels, &
+                      gaschmbudget_2D_L1_s_out = gaschmbudget_2D_L1_s, &
+                      gaschmbudget_2D_L1_e_out = gaschmbudget_2D_L1_e, &
+                      gaschmbudget_2D_L2_s_out = gaschmbudget_2D_L2_s, &
+                      gaschmbudget_2D_L2_e_out = gaschmbudget_2D_L2_e, &
+                      gaschmbudget_2D_L3_s_out = gaschmbudget_2D_L3_s, &
+                      gaschmbudget_2D_L3_e_out = gaschmbudget_2D_L3_e, &
+                      gaschmbudget_2D_L4_s_out = gaschmbudget_2D_L4_s, &
+                      gaschmbudget_2D_L4_e_out = gaschmbudget_2D_L4_e )
 
     chem_dt = chem_freq*dt
 
@@ -1464,7 +1487,7 @@ end function chem_is_active
     if (e90_ndx <= 0) then
       call tropopause_find(state, tropLev, primary=TROP_ALG_HYBSTOB, backup=TROP_ALG_CLIMATE)
     else
-      call tropopause_e90_3d(state, tmp_tropLev, tropLev, tropFlag)
+      call tropopause_e90_3d(state, tmp_tropLev, tropLev, tropFlag, tropFlagInt)
     end if
 
     tim_ndx = pbuf_old_tim_idx()
@@ -1478,7 +1501,7 @@ end function chem_is_active
 !-----------------------------------------------------------------------
 ! output gas concentration and tendency
 !-----------------------------------------------------------------------
-    if (history_gaschmbudget .or. history_gaschmbudget_2D) then
+    if (history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels) then
       do m = 1,pcnst
          n = map2chm(m)
          if (n > 0 .and. (.not. any( aer_species == n ))) then
@@ -1502,10 +1525,11 @@ end function chem_is_active
            end if
            !
            if (history_gaschmbudget_2D) then
-             do k=2,pver
-               ftem(:ncol,1) = ftem(:ncol,1) + ftem(:ncol,k)
+             ftem_layers = 0.0_r8
+             do k=1,pver
+               ftem_layers(:ncol,1) = ftem_layers(:ncol,1) + ftem(:ncol,k)
              end do
-             call outfld(trim(solsym(n))//'_2DMSB', ftem(:ncol,1), pcols, lchnk )
+             call outfld(trim(solsym(n))//'_2DMSB', ftem_layers(:ncol,1), pcols, lchnk )
 
              gas_ac_idx = pbuf_get_index(gas_ac_name_2D(n))
              call pbuf_get_field(pbuf, gas_ac_idx, gas_ac_2D )
@@ -1516,10 +1540,84 @@ end function chem_is_active
                 !end if
 
              else
-                Diff(:ncol,1) = (ftem(:ncol,1) - gas_ac_2D(:ncol))/dt
+                Diff(:ncol,1) = (ftem_layers(:ncol,1) - gas_ac_2D(:ncol))/dt
              end if
              call outfld(trim(solsym(n))//'_2DTDO', Diff(:ncol,1), pcols, lchnk )
            end if
+           ! HHLEE 20210923
+           if (history_gaschmbudget_2D_levels ) then
+             ftem_layers = 0.0_r8
+             gas_ac_layers = 0.0_r8
+
+             gas_ac_idx = pbuf_get_index(gas_ac_name(n))
+             call pbuf_get_field(pbuf, gas_ac_idx, gas_ac )
+
+             if (gaschmbudget_2D_L1_e .lt. gaschmbudget_2D_L1_s .or. gaschmbudget_2D_L2_e .lt. gaschmbudget_2D_L2_s .or. &
+                 gaschmbudget_2D_L3_e .lt. gaschmbudget_2D_L3_s .or. gaschmbudget_2D_L4_e .lt. gaschmbudget_2D_L4_s ) then
+                   call endrun('chem_readnl: ERROR 2D chem diags layers')
+             end if
+
+             do k= gaschmbudget_2D_L1_s, gaschmbudget_2D_L1_e ! 0-90 hPa
+               ftem_layers(:ncol,1) = ftem_layers(:ncol,1) + ftem(:ncol,k)
+               gas_ac_layers(:ncol,1) = gas_ac_layers(:ncol,1) + gas_ac(:ncol,k)
+             end do
+             do k= gaschmbudget_2D_L2_s, gaschmbudget_2D_L2_e ! 90-300 hPa
+               ftem_layers(:ncol,2) = ftem_layers(:ncol,2) + ftem(:ncol,k)
+               gas_ac_layers(:ncol,2) = gas_ac_layers(:ncol,2) + gas_ac(:ncol,k)
+             end do
+             do k= gaschmbudget_2D_L3_s, gaschmbudget_2D_L3_e ! 300-850 hPa
+               ftem_layers(:ncol,3) = ftem_layers(:ncol,3) + ftem(:ncol,k)
+               gas_ac_layers(:ncol,3) = gas_ac_layers(:ncol,3) + gas_ac(:ncol,k)
+             end do
+             do k= gaschmbudget_2D_L4_s, gaschmbudget_2D_L4_e ! 850 hPa - surface
+               ftem_layers(:ncol,4) = ftem_layers(:ncol,4) + ftem(:ncol,k)
+               gas_ac_layers(:ncol,4) = gas_ac_layers(:ncol,4) + gas_ac(:ncol,k)
+             end do
+             call outfld(trim(solsym(n))//'_2DMSB_L1', ftem_layers(:ncol,1), pcols, lchnk)
+             call outfld(trim(solsym(n))//'_2DMSB_L2', ftem_layers(:ncol,2), pcols, lchnk)
+             call outfld(trim(solsym(n))//'_2DMSB_L3', ftem_layers(:ncol,3), pcols, lchnk)
+             call outfld(trim(solsym(n))//'_2DMSB_L4', ftem_layers(:ncol,4), pcols, lchnk)
+
+             if( nstep == 0 ) then
+                Diff_layers(:ncol,:) = 0.0_r8
+             else
+                Diff_layers(:ncol,:) = 0.0_r8
+                Diff_layers(:ncol,1) = (ftem_layers(:ncol,1) - gas_ac_layers(:ncol,1))/dt
+                Diff_layers(:ncol,2) = (ftem_layers(:ncol,2) - gas_ac_layers(:ncol,2))/dt
+                Diff_layers(:ncol,3) = (ftem_layers(:ncol,3) - gas_ac_layers(:ncol,3))/dt
+                Diff_layers(:ncol,4) = (ftem_layers(:ncol,4) - gas_ac_layers(:ncol,4))/dt
+             end if
+             call outfld(trim(solsym(n))//'_2DTDO_L1', Diff_layers(:ncol,1), pcols, lchnk)
+             call outfld(trim(solsym(n))//'_2DTDO_L2', Diff_layers(:ncol,2), pcols, lchnk)
+             call outfld(trim(solsym(n))//'_2DTDO_L3', Diff_layers(:ncol,3), pcols, lchnk)
+             call outfld(trim(solsym(n))//'_2DTDO_L4', Diff_layers(:ncol,4), pcols, lchnk)
+
+             if (trim(solsym(n))=='O3' .or. trim(solsym(n))=='O3LNZ' .or. &
+                 trim(solsym(n))=='N2OLNZ' .or. trim(solsym(n))=='CH4LNZ') then
+                ftem_layers = 0.0_r8
+                gas_ac_layers = 0.0_r8
+                do k=1,pver
+                   ftem_layers(:ncol,1) = ftem_layers(:ncol,1) + ftem(:ncol,k) * tropFlagInt(:ncol,k)
+                   gas_ac_layers(:ncol,1) = gas_ac_layers(:ncol,1) + gas_ac(:ncol,k) * tropFlagInt(:ncol,k)
+                   ftem_layers(:ncol,2) = ftem_layers(:ncol,2) + ftem(:ncol,k) * (1.0 - tropFlagInt(:ncol,k))
+                   gas_ac_layers(:ncol,2) = gas_ac_layers(:ncol,2) + gas_ac(:ncol,k) * (1.0 - tropFlagInt(:ncol,k))
+                end do
+                call outfld(trim(solsym(n))//'_2DMSB_trop', ftem_layers(:ncol,1), pcols, lchnk )
+                call outfld(trim(solsym(n))//'_2DMSB_stra', ftem_layers(:ncol,2), pcols, lchnk )
+
+                if( nstep == 0 ) then
+                   Diff_layers(:ncol,:) = 0.0_r8
+                else
+                   Diff_layers(:ncol,:) = 0.0_r8
+                   Diff_layers(:ncol,1) = (ftem_layers(:ncol,1) - gas_ac_layers(:ncol,1))/dt
+                   Diff_layers(:ncol,2) = (ftem_layers(:ncol,2) - gas_ac_layers(:ncol,2))/dt
+                end if
+                call outfld(trim(solsym(n))//'_2DTDO_trop', Diff_layers(:ncol,1), pcols, lchnk)
+                call outfld(trim(solsym(n))//'_2DTDO_stra', Diff_layers(:ncol,2), pcols, lchnk)
+             end if
+
+           end if ! history_gaschmbudget_2D_levels
+
          end if
       end do
     end if
@@ -1528,7 +1626,9 @@ end function chem_is_active
 ! call Neu wet dep scheme
 !-----------------------------------------------------------------------
     call neu_wetdep_tend(lchnk,ncol,state%q,state%pmid,state%pdeldry,state%zi,state%t,dt, &
-         prain, nevapr, cldfr, cmfdqr, ptend%q)
+         prain, nevapr, cldfr, cmfdqr, ptend%q, history_gaschmbudget_2D_levels, &
+         gaschmbudget_2D_L1_s, gaschmbudget_2D_L1_e, gaschmbudget_2D_L2_s, gaschmbudget_2D_L2_e, &
+         gaschmbudget_2D_L3_s, gaschmbudget_2D_L3_e, gaschmbudget_2D_L4_s, gaschmbudget_2D_L4_e )
 
 !-----------------------------------------------------------------------
 ! compute tendencies and surface fluxes
@@ -1547,7 +1647,8 @@ end function chem_is_active
                           chem_dt, state%ps, xactive_prates, do_cloudj_photolysis, &
                           fsds, cam_in%ts, cam_in%asdir, cam_in%ocnfrac, cam_in%icefrac, &
                           cam_out%precc, cam_out%precl, cam_in%snowhland, ghg_chem, state%latmapback, &
-                          chem_name, drydepflx, cam_in%cflx, ptend%q, pbuf, ixcldliq, ixcldice, tropFlag=tropFlag)
+                          chem_name, drydepflx, cam_in%cflx, ptend%q, pbuf, ixcldliq, ixcldice, tropFlag=tropFlag, &
+                          tropFlagInt=tropFlagInt)
 
     call t_stopf( 'chemdr' )
 

--- a/components/eam/src/chemistry/mozart/mo_chm_diags.F90
+++ b/components/eam/src/chemistry/mozart/mo_chm_diags.F90
@@ -89,6 +89,15 @@ contains
     logical :: history_verbose      ! produce verbose history output
     logical :: history_gaschmbudget ! output gas chemistry tracer concentrations and tendencies
     logical :: history_gaschmbudget_2D ! output 2D gas chemistry tracer concentrations and tendencies
+    logical :: history_gaschmbudget_2D_levels ! output 2D gas chemistry tracer concentrations and tendencies
+    integer :: gaschmbudget_2D_L1_s
+    integer :: gaschmbudget_2D_L1_e
+    integer :: gaschmbudget_2D_L2_s
+    integer :: gaschmbudget_2D_L2_e
+    integer :: gaschmbudget_2D_L3_s
+    integer :: gaschmbudget_2D_L3_e
+    integer :: gaschmbudget_2D_L4_s
+    integer :: gaschmbudget_2D_L4_e
     integer :: bulkaero_species(20)
 
     !-----------------------------------------------------------------------
@@ -98,7 +107,16 @@ contains
                        history_verbose_out = history_verbose,  &
                        cam_chempkg_out     = chempkg, &
                        history_gaschmbudget_out = history_gaschmbudget, &
-                       history_gaschmbudget_2D_out = history_gaschmbudget_2D)
+                    history_gaschmbudget_2D_out = history_gaschmbudget_2D, &
+             history_gaschmbudget_2D_levels_out = history_gaschmbudget_2D_levels, &
+                       gaschmbudget_2D_L1_s_out = gaschmbudget_2D_L1_s, &
+                       gaschmbudget_2D_L1_e_out = gaschmbudget_2D_L1_e, &
+                       gaschmbudget_2D_L2_s_out = gaschmbudget_2D_L2_s, &
+                       gaschmbudget_2D_L2_e_out = gaschmbudget_2D_L2_e, &
+                       gaschmbudget_2D_L3_s_out = gaschmbudget_2D_L3_s, &
+                       gaschmbudget_2D_L3_e_out = gaschmbudget_2D_L3_e, &
+                       gaschmbudget_2D_L4_s_out = gaschmbudget_2D_L4_s, &
+                       gaschmbudget_2D_L4_e_out = gaschmbudget_2D_L4_e )
 
     if (masterproc) then
        if (history_gaschmbudget) then
@@ -106,6 +124,9 @@ contains
        endif
        if (history_gaschmbudget_2D) then
           write(iulog,*) 'chm_diags_inti: history_gaschmbudget_2D = ', history_gaschmbudget_2D
+       endif
+       if (history_gaschmbudget_2D_levels) then
+          write(iulog,*) 'chm_diags_inti: history_gaschmbudget_2D_levels = ', history_gaschmbudget_2D_levels
        endif
     endif
 
@@ -327,6 +348,13 @@ contains
              call addfld( trim(spc_name)//'_2DMSL', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration after Linoz')
              call addfld( trim(spc_name)//'_2DMSS', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration after surface emission')
              call addfld( trim(spc_name)//'_2DMSD', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration after dry deposition')
+             call addfld( trim(spc_name)//'_2DMSE', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration after explicit solver')
+             call addfld( trim(spc_name)//'_2DMSI', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration after implicit solver')
+             call addfld( trim(spc_name)//'_2DMSA', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration after aero_model_gasaerexch')
+             call addfld( trim(spc_name)//'_2DMSN', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration after rest negative values to zero')
+             call addfld( trim(spc_name)//'_2DMSU', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration after setting upper boundary values')
+             call addfld( trim(spc_name)//'_2DMSC', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration after setting lower boundary values')
+             call addfld( trim(spc_name)//'_2DMSW', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration after wet scaving')
              call addfld( trim(spc_name)//'_2DTDE', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency due to explicit solver')
              call addfld( trim(spc_name)//'_2DTDI', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency due to implicit solver')
              call addfld( trim(spc_name)//'_2DTDA', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency due to aero_model_gasaerexch')
@@ -337,6 +365,97 @@ contains
              call addfld( trim(spc_name)//'_2DTDS', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency due to surface emission')
              call addfld( trim(spc_name)//'_2DTDD', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency due to dry deposition')
              call addfld( trim(spc_name)//'_2DTDO', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency due to processes outside of chemistry')
+          endif
+          if (history_gaschmbudget_2D_levels) then
+             call addfld( trim(spc_name)//'_2DMSB_L1', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration from top-of-model to 90 hPa before wet deposition and gas chem solver')
+             call addfld( trim(spc_name)//'_2DMSL_L1', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration from top-of-model to 90 hPa after Linoz')
+             call addfld( trim(spc_name)//'_2DMSS_L1', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration from top-of-model to 90 hPa after surface emission')
+             call addfld( trim(spc_name)//'_2DMSD_L1', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration from top-of-model to 90 hPa after dry deposition')
+             call addfld( trim(spc_name)//'_2DTDE_L1', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from top-of-model to 90 hPa due to explicit solver')
+             call addfld( trim(spc_name)//'_2DTDI_L1', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from top-of-model to 90 hPa due to implicit solver')
+             call addfld( trim(spc_name)//'_2DTDA_L1', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from top-of-model to 90 hPa due to aero_model_gasaerexch')
+             call addfld( trim(spc_name)//'_2DTDL_L1', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from top-of-model to 90 hPa due to Linoz')
+             call addfld( trim(spc_name)//'_2DTDN_L1', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from top-of-model to 90 hPa due to reset negative values to zero')
+             call addfld( trim(spc_name)//'_2DTDU_L1', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from top-of-model to 90 hPa due to setting upper boundary values')
+             call addfld( trim(spc_name)//'_2DTDB_L1', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from top-of-model to 90 hPa due to setting lower boundary values')
+             call addfld( trim(spc_name)//'_2DTDS_L1', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from top-of-model to 90 hPa due to surface emission')
+             call addfld( trim(spc_name)//'_2DTDD_L1', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from top-of-model to 90 hPa due to dry deposition')
+             call addfld( trim(spc_name)//'_2DTDO_L1', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from top-of-model to 90 hPa due to processes outside of chemistry')
+
+             call addfld( trim(spc_name)//'_2DMSB_L2', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration from 90 to 300 hPa before wet deposition and gas chem solver')           
+             call addfld( trim(spc_name)//'_2DMSL_L2', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration from 90 to 300 hPa after Linoz')
+             call addfld( trim(spc_name)//'_2DMSS_L2', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration from 90 to 300 hPa after surface emission')
+             call addfld( trim(spc_name)//'_2DMSD_L2', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration from 90 to 300 hPa after dry deposition')
+             call addfld( trim(spc_name)//'_2DTDE_L2', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 90 to 300 hPa due to explicit solver')
+             call addfld( trim(spc_name)//'_2DTDI_L2', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 90 to 300 hPa due to implicit solver')
+             call addfld( trim(spc_name)//'_2DTDA_L2', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 90 to 300 hPa due to aero_model_gasaerexch')
+             call addfld( trim(spc_name)//'_2DTDL_L2', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 90 to 300 hPa due to Linoz')
+             call addfld( trim(spc_name)//'_2DTDN_L2', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 90 to 300 hPa due to reset negative values to zero')
+             call addfld( trim(spc_name)//'_2DTDU_L2', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 90 to 300 hPa due to setting upper boundary values')
+             call addfld( trim(spc_name)//'_2DTDB_L2', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 90 to 300 hPa due to setting lower boundary values')
+             call addfld( trim(spc_name)//'_2DTDS_L2', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 90 to 300 hPa due to surface emission')
+             call addfld( trim(spc_name)//'_2DTDD_L2', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 90 to 300 hPa due to dry deposition')
+             call addfld( trim(spc_name)//'_2DTDO_L2', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 90 to 300 hPa due to processes outside of chemistry')
+
+             call addfld( trim(spc_name)//'_2DMSB_L3', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration from 300 to 850 hPa before wet deposition and gas chem solver')           
+             call addfld( trim(spc_name)//'_2DMSL_L3', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration from 300 to 850 hPa after Linoz')
+             call addfld( trim(spc_name)//'_2DMSS_L3', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration from 300 to 850 hPa after surface emission')
+             call addfld( trim(spc_name)//'_2DMSD_L3', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration from 300 to 850 hPa after dry deposition')
+             call addfld( trim(spc_name)//'_2DTDE_L3', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 300 to 850 hPa due to explicit solver')
+             call addfld( trim(spc_name)//'_2DTDI_L3', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 300 to 850 hPa due to implicit solver')
+             call addfld( trim(spc_name)//'_2DTDA_L3', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 300 to 850 hPa due to aero_model_gasaerexch')
+             call addfld( trim(spc_name)//'_2DTDL_L3', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 300 to 850 hPa due to Linoz')
+             call addfld( trim(spc_name)//'_2DTDN_L3', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 300 to 850 hPa due to reset negative values to zero')
+             call addfld( trim(spc_name)//'_2DTDU_L3', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 300 to 850 hPa due to setting upper boundary values')
+             call addfld( trim(spc_name)//'_2DTDB_L3', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 300 to 850 hPa due to setting lower boundary values')
+             call addfld( trim(spc_name)//'_2DTDS_L3', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 300 to 850 hPa due to surface emission')
+             call addfld( trim(spc_name)//'_2DTDD_L3', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 300 to 850 hPa due to dry deposition')
+             call addfld( trim(spc_name)//'_2DTDO_L3', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 300 to 850 hPa due to processes outside of chemistry')
+
+             call addfld( trim(spc_name)//'_2DMSB_L4', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration from 850 hPa to surface before wet deposition and gas chem solver')           
+             call addfld( trim(spc_name)//'_2DMSL_L4', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration from 850 hPa to surface after Linoz')
+             call addfld( trim(spc_name)//'_2DMSS_L4', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration from 850 hPa to surface after surface emission')
+             call addfld( trim(spc_name)//'_2DMSD_L4', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration from 850 hPa to surface after dry deposition')
+             call addfld( trim(spc_name)//'_2DTDE_L4', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 850 hPa to surface due to explicit solver')
+             call addfld( trim(spc_name)//'_2DTDI_L4', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 850 hPa to surface due to implicit solver')
+             call addfld( trim(spc_name)//'_2DTDA_L4', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 850 hPa to surface due to aero_model_gasaerexch')
+             call addfld( trim(spc_name)//'_2DTDL_L4', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 850 hPa to surface due to Linoz')
+             call addfld( trim(spc_name)//'_2DTDN_L4', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 850 hPa to surface due to reset negative values to zero')
+             call addfld( trim(spc_name)//'_2DTDU_L4', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 850 hPa to surface due to setting upper boundary values')
+             call addfld( trim(spc_name)//'_2DTDB_L4', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 850 hPa to surface due to setting lower boundary values')
+             call addfld( trim(spc_name)//'_2DTDS_L4', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 850 hPa to surface due to surface emission')
+             call addfld( trim(spc_name)//'_2DTDD_L4', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 850 hPa to surface due to dry deposition')
+             call addfld( trim(spc_name)//'_2DTDO_L4', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency from 850 hPa to surface due to processes outside of chemistry')
+
+             call addfld( trim(spc_name)//'_2DMSB_trop', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration in troposphere before wet deposition and gas chem solver')           
+             call addfld( trim(spc_name)//'_2DMSL_trop', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration in troposphere after Linoz')
+             call addfld( trim(spc_name)//'_2DMSS_trop', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration in troposphere after surface emission')
+             call addfld( trim(spc_name)//'_2DMSD_trop', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration in troposphere after dry deposition')
+             call addfld( trim(spc_name)//'_2DTDE_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to explicit solver')
+             call addfld( trim(spc_name)//'_2DTDI_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to implicit solver')
+             call addfld( trim(spc_name)//'_2DTDA_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to aero_model_gasaerexch')
+             call addfld( trim(spc_name)//'_2DTDL_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to Linoz')
+             call addfld( trim(spc_name)//'_2DTDN_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to reset negative values to zero')
+             call addfld( trim(spc_name)//'_2DTDU_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to setting upper boundary values')
+             call addfld( trim(spc_name)//'_2DTDB_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to setting lower boundary values')
+             call addfld( trim(spc_name)//'_2DTDS_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to surface emission')
+             call addfld( trim(spc_name)//'_2DTDD_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to dry deposition')
+             call addfld( trim(spc_name)//'_2DTDO_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to processes outside of chemistry')
+
+             call addfld( trim(spc_name)//'_2DMSB_stra', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration in stratosphere before wet deposition and gas chem solver')           
+             call addfld( trim(spc_name)//'_2DMSL_stra', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration in stratosphere after Linoz')
+             call addfld( trim(spc_name)//'_2DMSS_stra', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration in stratosphere after surface emission')
+             call addfld( trim(spc_name)//'_2DMSD_stra', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration in stratosphere after dry deposition')
+             call addfld( trim(spc_name)//'_2DTDE_stra', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in stratosphere due to explicit solver')
+             call addfld( trim(spc_name)//'_2DTDI_stra', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in stratosphere due to implicit solver')
+             call addfld( trim(spc_name)//'_2DTDA_stra', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in stratosphere due to aero_model_gasaerexch')
+             call addfld( trim(spc_name)//'_2DTDL_stra', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in stratosphere due to Linoz')
+             call addfld( trim(spc_name)//'_2DTDN_stra', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in stratosphere due to reset negative values to zero')
+             call addfld( trim(spc_name)//'_2DTDU_stra', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in stratosphere due to setting upper boundary values')
+             call addfld( trim(spc_name)//'_2DTDB_stra', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in stratosphere due to setting lower boundary values')
+             call addfld( trim(spc_name)//'_2DTDS_stra', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in stratosphere due to surface emission')
+             call addfld( trim(spc_name)//'_2DTDD_stra', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in stratosphere due to dry deposition')
+             call addfld( trim(spc_name)//'_2DTDO_stra', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in stratosphere due to processes outside of chemistry')
           endif
        endif
 
@@ -371,6 +490,13 @@ contains
                 call add_default( trim(spc_name)//'_2DMSL', 2, ' ' )
                 call add_default( trim(spc_name)//'_2DMSS', 2, ' ' )
                 call add_default( trim(spc_name)//'_2DMSD', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSI', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSE', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSA', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSN', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSU', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSC', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSW', 2, ' ' )
                 call add_default( trim(spc_name)//'_2DTDE', 1, ' ' )
                 call add_default( trim(spc_name)//'_2DTDI', 1, ' ' )
                 call add_default( trim(spc_name)//'_2DTDA', 1, ' ' )
@@ -381,6 +507,85 @@ contains
                 call add_default( trim(spc_name)//'_2DTDS', 1, ' ' )
                 call add_default( trim(spc_name)//'_2DTDD', 1, ' ' )
                 call add_default( trim(spc_name)//'_2DTDO', 1, ' ' )
+             endif
+             if (history_gaschmbudget_2D_levels) then
+                call add_default( trim(spc_name)//'_2DMSB_L1', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSL_L1', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSS_L1', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSD_L1', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DTDE_L1', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDI_L1', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDA_L1', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDL_L1', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDN_L1', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDU_L1', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDB_L1', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDS_L1', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDD_L1', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDO_L1', 1, ' ' )
+
+                call add_default( trim(spc_name)//'_2DMSB_L2', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSL_L2', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSS_L2', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSD_L2', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DTDE_L2', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDI_L2', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDA_L2', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDL_L2', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDN_L2', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDU_L2', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDB_L2', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDS_L2', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDD_L2', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDO_L2', 1, ' ' )
+
+                call add_default( trim(spc_name)//'_2DMSB_L3', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSL_L3', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSS_L3', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSD_L3', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DTDE_L3', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDI_L3', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDA_L3', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDL_L3', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDN_L3', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDU_L3', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDB_L3', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDS_L3', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDD_L3', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDO_L3', 1, ' ' )
+
+                call add_default( trim(spc_name)//'_2DMSB_L4', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSL_L4', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSS_L4', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSD_L4', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DTDE_L4', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDI_L4', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDA_L4', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDL_L4', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDN_L4', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDU_L4', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDB_L4', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDS_L4', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDD_L4', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDO_L4', 1, ' ' )
+
+             if (trim(spc_name) == 'O3' .or. trim(spc_name) == 'O3LNZ' .or. &
+                 trim(spc_name) == 'N2OLNZ' .or. trim(spc_name) == 'CH4LNZ' ) then
+                call add_default( trim(spc_name)//'_2DMSB_trop', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSL_trop', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSS_trop', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSD_trop', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DTDE_trop', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDI_trop', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDA_trop', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDL_trop', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDN_trop', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDU_trop', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDB_trop', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDS_trop', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDD_trop', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDO_trop', 1, ' ' )
+             endif
              endif
           endif
        endif
@@ -424,7 +629,7 @@ contains
     call add_default( 'TROPMASSB', 1, ' ' )
     call add_default( 'TROPMASST', 1, ' ' )
 
-    if (history_gaschmbudget .or. history_gaschmbudget_2D) then
+    if (history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels) then
        call add_default( 'AREA', 1, ' ' )
     endif
 
@@ -1040,7 +1245,7 @@ contains
 
   end subroutine het_diags
 
-  subroutine gaschmmass_diags( lchnk, ncol, vmr, vmr_old, pdeldry, mbar, rdelt, flag )
+  subroutine gaschmmass_diags( lchnk, ncol, vmr, vmr_old, pdeldry, mbar, rdelt, flag, tropFlagInt)
     !--------------------------------------------------------------------
     !	... utility routine to output gas chemistry tracer concentrations
     !--------------------------------------------------------------------
@@ -1061,21 +1266,42 @@ contains
     real(r8), intent(in)  :: mbar(ncol,pver)
     real(r8), intent(in)  :: rdelt        ! inverse of timestep (1/s)
     character(len=*), intent(in)  :: flag ! flag for diagnostic output locations
+    real(r8), optional, intent(in) :: tropFlagInt(ncol, pver)
 
     !--------------------------------------------------------------------
     !	... local variables
     !--------------------------------------------------------------------
     integer  :: k, m
     real(r8) :: wrk(ncol,pver)
+    real(r8) :: wrk_sum(ncol)
+    real(r8) :: wrk_stra(ncol)
     logical  :: history_gaschmbudget ! output gas chemistry tracer concentrations and tendencies
     logical  :: history_gaschmbudget_2D ! output 2D gas chemistry tracer concentrations and tendencies
+    logical  :: history_gaschmbudget_2D_levels ! output 2D gas chemistry tracer concentrations and tendencies within certain layers
+    integer  :: gaschmbudget_2D_L1_s ! Start layer of L1 for gas chemistry tracer budget 
+    integer  :: gaschmbudget_2D_L1_e ! End layer of L1 for gas chemistry trracer budget
+    integer  :: gaschmbudget_2D_L2_s
+    integer  :: gaschmbudget_2D_L2_e
+    integer  :: gaschmbudget_2D_L3_s
+    integer  :: gaschmbudget_2D_L3_e
+    integer  :: gaschmbudget_2D_L4_s
+    integer  :: gaschmbudget_2D_L4_e
 
     !-----------------------------------------------------------------------
 
     call phys_getopts( history_gaschmbudget_out = history_gaschmbudget, &
-                       history_gaschmbudget_2D_out = history_gaschmbudget_2D)
+                       history_gaschmbudget_2D_out = history_gaschmbudget_2D, &
+                       history_gaschmbudget_2D_levels_out = history_gaschmbudget_2D_levels, &
+                       gaschmbudget_2D_L1_s_out = gaschmbudget_2D_L1_s, &
+                       gaschmbudget_2D_L1_e_out = gaschmbudget_2D_L1_e, &
+                       gaschmbudget_2D_L2_s_out = gaschmbudget_2D_L2_s, &
+                       gaschmbudget_2D_L2_e_out = gaschmbudget_2D_L2_e, &
+                       gaschmbudget_2D_L3_s_out = gaschmbudget_2D_L3_s, &
+                       gaschmbudget_2D_L3_e_out = gaschmbudget_2D_L3_e, &
+                       gaschmbudget_2D_L4_s_out = gaschmbudget_2D_L4_s, &
+                       gaschmbudget_2D_L4_e_out = gaschmbudget_2D_L4_e )
 
-    if ( .not. history_gaschmbudget .and. .not. history_gaschmbudget_2D ) return
+    if ( .not. history_gaschmbudget .and. .not. history_gaschmbudget_2D .and. .not. history_gaschmbudget_2D_levels) return
 
     do m = 1,gas_pcnst
        
@@ -1092,7 +1318,8 @@ contains
             endif
             call outfld( trim(solsym(m))//'_'//flag, wrk(:ncol,:), ncol ,lchnk )
           else
-            if (flag=='2DMSL' .or. flag=='2DMSS' .or. flag=='2DMSD') then
+            !if (flag(1:5)=='2DMSL' .or. flag(1:5)=='2DMSS' .or. flag(1:5)=='2DMSD') then
+            if (flag(1:4)=='2DMS') then
                ! kg/m2
                wrk(:ncol,:) = adv_mass(m)*vmr(:ncol,:,m)/mbar(:ncol,:) &
                                 *pdeldry(:ncol,:)*rgrav
@@ -1101,10 +1328,46 @@ contains
                wrk(:ncol,:) = adv_mass(m)*(vmr(:ncol,:,m)-vmr_old(:ncol,:,m)) &
                                 /mbar(:ncol,:)*pdeldry(:ncol,:)*rgrav*rdelt
             endif
-            do k=2,pver
-               wrk(:ncol,1) = wrk(:ncol,1) + wrk(:ncol,k)
-            enddo
-            call outfld( trim(solsym(m))//'_'//flag, wrk(:ncol,1), ncol ,lchnk )
+
+            wrk_sum(:ncol) = 0.0_r8
+            wrk_stra(:ncol) = 0.0_r8
+            if (len(flag) >= 6 .and. flag(6:8) == '_L1') then
+               do k = gaschmbudget_2D_L1_s, gaschmbudget_2D_L1_e
+                  wrk_sum(:ncol) = wrk_sum(:ncol) + wrk(:ncol,k)
+               enddo
+               call outfld( trim(solsym(m))//'_'//flag, wrk_sum(:ncol), ncol ,lchnk )
+            elseif (len(flag) >= 6 .and. flag(6:8) == '_L2') then
+               do k = gaschmbudget_2D_L2_s, gaschmbudget_2D_L2_e
+                  wrk_sum(:ncol) = wrk_sum(:ncol) + wrk(:ncol,k)
+               enddo
+               call outfld( trim(solsym(m))//'_'//flag, wrk_sum(:ncol), ncol ,lchnk )
+            elseif (len(flag) >= 6 .and. flag(6:8) == '_L3') then
+               do k = gaschmbudget_2D_L3_s, gaschmbudget_2D_L3_e
+                  wrk_sum(:ncol) = wrk_sum(:ncol) + wrk(:ncol,k)
+               enddo
+               call outfld( trim(solsym(m))//'_'//flag, wrk_sum(:ncol), ncol ,lchnk )
+            elseif (len(flag) >= 6 .and. flag(6:8) == '_L4') then
+               do k = gaschmbudget_2D_L4_s, gaschmbudget_2D_L4_e
+                  wrk_sum(:ncol) = wrk_sum(:ncol) + wrk(:ncol,k)
+               enddo
+               call outfld( trim(solsym(m))//'_'//flag, wrk_sum(:ncol), ncol ,lchnk )
+            elseif (len(flag) >= 6 .and. flag(6:10) == '_trop') then
+               if (trim(solsym(m))=='O3' .or. trim(solsym(m))=='O3LNZ' .or. &
+                   trim(solsym(m))=='N2OLNZ' .or. trim(solsym(m))=='CH4LNZ') then
+                  do k = 1, pver
+                     wrk_sum(:ncol) = wrk_sum(:ncol) + wrk(:ncol,k) * tropFlagInt(:ncol,k)
+                     wrk_stra(:ncol) = wrk_stra(:ncol) + wrk(:ncol,k) * (1.0 - tropFlagInt(:ncol,k))
+                  enddo
+                  call outfld( trim(solsym(m))//'_'//flag, wrk_sum(:ncol), ncol ,lchnk )
+                  call outfld( trim(solsym(m))//'_'//flag(1:5)//'_stra', wrk_stra(:ncol), ncol ,lchnk )
+               endif
+            else
+               do k=2,pver
+                  wrk(:ncol,1) = wrk(:ncol,1) + wrk(:ncol,k)
+               enddo
+               call outfld( trim(solsym(m))//'_'//flag, wrk(:ncol,1), ncol ,lchnk )
+            endif
+
           endif
        endif
 

--- a/components/eam/src/chemistry/mozart/mo_chm_diags.F90
+++ b/components/eam/src/chemistry/mozart/mo_chm_diags.F90
@@ -442,20 +442,6 @@ contains
              call addfld( trim(spc_name)//'_2DTDD_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to dry deposition')
              call addfld( trim(spc_name)//'_2DTDO_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to processes outside of chemistry')
 
-             call addfld( trim(spc_name)//'_2DMSB_stra', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration in stratosphere before wet deposition and gas chem solver')           
-             call addfld( trim(spc_name)//'_2DMSL_stra', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration in stratosphere after Linoz')
-             call addfld( trim(spc_name)//'_2DMSS_stra', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration in stratosphere after surface emission')
-             call addfld( trim(spc_name)//'_2DMSD_stra', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration in stratosphere after dry deposition')
-             call addfld( trim(spc_name)//'_2DTDE_stra', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in stratosphere due to explicit solver')
-             call addfld( trim(spc_name)//'_2DTDI_stra', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in stratosphere due to implicit solver')
-             call addfld( trim(spc_name)//'_2DTDA_stra', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in stratosphere due to aero_model_gasaerexch')
-             call addfld( trim(spc_name)//'_2DTDL_stra', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in stratosphere due to Linoz')
-             call addfld( trim(spc_name)//'_2DTDN_stra', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in stratosphere due to reset negative values to zero')
-             call addfld( trim(spc_name)//'_2DTDU_stra', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in stratosphere due to setting upper boundary values')
-             call addfld( trim(spc_name)//'_2DTDB_stra', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in stratosphere due to setting lower boundary values')
-             call addfld( trim(spc_name)//'_2DTDS_stra', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in stratosphere due to surface emission')
-             call addfld( trim(spc_name)//'_2DTDD_stra', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in stratosphere due to dry deposition')
-             call addfld( trim(spc_name)//'_2DTDO_stra', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in stratosphere due to processes outside of chemistry')
           endif
        endif
 
@@ -1274,7 +1260,6 @@ contains
     integer  :: k, m
     real(r8) :: wrk(ncol,pver)
     real(r8) :: wrk_sum(ncol)
-    real(r8) :: wrk_stra(ncol)
     logical  :: history_gaschmbudget ! output gas chemistry tracer concentrations and tendencies
     logical  :: history_gaschmbudget_2D ! output 2D gas chemistry tracer concentrations and tendencies
     logical  :: history_gaschmbudget_2D_levels ! output 2D gas chemistry tracer concentrations and tendencies within certain layers
@@ -1330,7 +1315,6 @@ contains
             endif
 
             wrk_sum(:ncol) = 0.0_r8
-            wrk_stra(:ncol) = 0.0_r8
             if (len(flag) >= 6 .and. flag(6:8) == '_L1') then
                do k = gaschmbudget_2D_L1_s, gaschmbudget_2D_L1_e
                   wrk_sum(:ncol) = wrk_sum(:ncol) + wrk(:ncol,k)
@@ -1356,10 +1340,8 @@ contains
                    trim(solsym(m))=='N2OLNZ' .or. trim(solsym(m))=='CH4LNZ') then
                   do k = 1, pver
                      wrk_sum(:ncol) = wrk_sum(:ncol) + wrk(:ncol,k) * tropFlagInt(:ncol,k)
-                     wrk_stra(:ncol) = wrk_stra(:ncol) + wrk(:ncol,k) * (1.0 - tropFlagInt(:ncol,k))
                   enddo
                   call outfld( trim(solsym(m))//'_'//flag, wrk_sum(:ncol), ncol ,lchnk )
-                  call outfld( trim(solsym(m))//'_'//flag(1:5)//'_stra', wrk_stra(:ncol), ncol ,lchnk )
                endif
             else
                do k=2,pver

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -103,6 +103,7 @@ module physpkg
   logical           :: is_cmip6_volc !true if cmip6 style volcanic file is read otherwise false
   logical :: history_gaschmbudget ! output gas chemistry tracer concentrations and tendencies
   logical :: history_gaschmbudget_2D ! output 2D gas chemistry tracer concentrations and tendencies
+  logical :: history_gaschmbudget_2D_levels ! output 2D gas chemistry tracer concentrations and tendencies within certain layers
 
   !======================================================================= 
 contains
@@ -184,7 +185,8 @@ subroutine phys_register
                       pergro_test_active_out   = pergro_test_active, &
                       pergro_mods_out          = pergro_mods, &
                       history_gaschmbudget_out = history_gaschmbudget, &
-                   history_gaschmbudget_2D_out = history_gaschmbudget_2D)
+                   history_gaschmbudget_2D_out = history_gaschmbudget_2D, &
+            history_gaschmbudget_2D_levels_out = history_gaschmbudget_2D_levels)
 
     ! Initialize dyn_time_lvls
     call pbuf_init_time()
@@ -273,12 +275,12 @@ subroutine phys_register
 
        ! NB: has to be after chem_register to use tracer names
        ! Fields for gas chemistry tracers
-       if (history_gaschmbudget .or. history_gaschmbudget_2D) then
+       if (history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels) then
          call chm_diags_inti_ac() ! to get aer_species
          do m = 1,gas_pcnst
             if (.not. any( aer_species == m )) then
               spc_name = trim(solsym(m))
-              if (history_gaschmbudget) then
+              if (history_gaschmbudget .or. history_gaschmbudget_2D_levels) then
                 gas_ac_name(m) = 'ac_'//spc_name
                 call pbuf_add_field(gas_ac_name(m), 'global', dtype_r8, (/pcols,pver/), gas_ac_idx)
               end if


### PR DESCRIPTION
We try to look at the budget closure for chemistry tracers in different vertical blocks and troposphere. 

For this diagnostic, the user needs to add the followings in his/her namelist:
 **history_gaschmbudget_2D_levels = .true.
 gaschmbudget_2D_L1_s =  1
 gaschmbudget_2D_L1_e = 25
 gaschmbudget_2D_L2_s = 26
 gaschmbudget_2D_L2_e = 40
 gaschmbudget_2D_L3_s = 41
 gaschmbudget_2D_L3_e = 58
 gaschmbudget_2D_L4_s = 59
 gaschmbudget_2D_L4_e = 72**

Output example: 
https://compy-dtn.pnl.gov/leeh925/20211011.3D_diags/