### PR TITLE
add O3 tendency calculations parallel to O3LNZ in Linoz v3

### DIFF
--- a/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam4_resus_mom_soag_tag.in
+++ b/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam4_resus_mom_soag_tag.in
@@ -39,10 +39,8 @@ SPECIES
 * MVKMACR = sum of MVK -> CH2CHCOCH3 + MACR -> CH2CCH3CHO
   MVKO2 -> C4H7O4
   E90 -> O3
-  O3LNZ -> O3
   N2OLNZ -> N2
   NOYLNZ -> N
-  CH4LNZ -> CH4
   H2OLNZ -> H2O
 * MAM4 species
   DMS -> C2H6S
@@ -96,7 +94,7 @@ Solution Classes
 
  Explicit
    CO, C2H6, C3H8, CH3COCH3
-   E90, O3LNZ,N2OLNZ,NOYLNZ,CH4LNZ, H2OLNZ
+   E90, N2OLNZ,NOYLNZ, H2OLNZ
    DMS, SO2, H2SO4, SOAG
    so4_a1,  so4_a2,  so4_a3
    pom_a1,           pom_a3,  pom_a4

--- a/components/eam/src/chemistry/mozart/lin_strat_chem.F90
+++ b/components/eam/src/chemistry/mozart/lin_strat_chem.F90
@@ -39,7 +39,8 @@ module lin_strat_chem
 
   integer :: o3lnz_ndx, n2olnz_ndx, noylnz_ndx, ch4lnz_ndx, h2olnz_ndx
   integer :: o3_ndx, n2o_ndx, ch4_ndx, no_ndx, no2_ndx, hno3_ndx 
-  
+  integer :: uci1_ndx
+ 
   logical :: do_lin_strat_chem, linoz_v2, linoz_v3
 
   real(r8), parameter :: unset_r8   = huge(1.0_r8)
@@ -126,7 +127,7 @@ end subroutine linoz_readnl
     !
     use linoz_data,   only : linoz_data_init, has_linozv3_data, has_linoz_data
     use ppgrid,       only : pver
-    use mo_chem_utls, only : get_spc_ndx
+    use mo_chem_utls, only : get_spc_ndx, get_rxt_ndx
     use cam_history,  only : addfld, horiz_only, add_default
     use physics_buffer, only : physics_buffer_desc
 
@@ -154,15 +155,19 @@ end subroutine linoz_readnl
     n2olnz_ndx  =   get_spc_ndx('N2OLNZ')
     noylnz_ndx  =   get_spc_ndx('NOYLNZ')
     ch4lnz_ndx  =   get_spc_ndx('CH4LNZ')
-    h2olnz_ndx   =  get_spc_ndx('H2OLNZ')
+    h2olnz_ndx  =   get_spc_ndx('H2OLNZ')
 
-    if (o3lnz_ndx <=0 ) then
-       write(iulog,*) 'skip Linoz, need to have tracer O3LNZ at least '
+    uci1_ndx    = get_rxt_ndx('uci1')
+
+    if (uci1_ndx <=0 ) then
+       !write(iulog,*) 'skip Linoz, need to have tracer O3LNZ at least '
+       write(iulog,*) 'skip Linoz, temporally change '
        do_lin_strat_chem = .false.
        return
     end if
 
-    linoz_v3= (o3lnz_ndx > 0 .and. n2olnz_ndx >0  .and. noylnz_ndx >0  .and. ch4lnz_ndx > 0)
+    !linoz_v3= (o3lnz_ndx > 0 .and. n2olnz_ndx >0  .and. noylnz_ndx >0  .and. ch4lnz_ndx > 0)
+    linoz_v3= (n2olnz_ndx >0  .and. noylnz_ndx >0)
     linoz_v2= (o3lnz_ndx > 0 .and. n2olnz_ndx <0  .and. noylnz_ndx <0  .and. ch4lnz_ndx < 0)
 !    write(iulog,*)'linoz_v3=',linoz_v3,'linoz_v2=',linoz_v2
 ! real o3, ch4, n2o tracers

--- a/components/eam/src/chemistry/mozart/lin_strat_chem.F90
+++ b/components/eam/src/chemistry/mozart/lin_strat_chem.F90
@@ -226,7 +226,7 @@ end subroutine linoz_readnl
 
 !--------------------------------------------------------------------
 !--------------------------------------------------------------------
-  subroutine linv3_strat_chem_solve(ncol, lchnk, xvmr, h2ovmr, xsfc, o3e3smcol, o3col,temp, sza, pmid, delta_t, rlats, ltrop, pdeldry, tropFlag )
+  subroutine linv3_strat_chem_solve(ncol, lchnk, xvmr, h2ovmr, xsfc, o3col,temp, sza, pmid, delta_t, rlats, ltrop, pdeldry, chemFlag, tropFlag)
 
 !--------------------------------------------------------------------
 ! linearized ozone chemistry linoz-v3 (o3-n2o-noy-ch4 prognostic equations, h2o diagnosed from ch4) 
@@ -267,7 +267,6 @@ end subroutine linoz_readnl
     real(r8), intent(inout), dimension(ncol ,pver,gas_pcnst) :: xvmr      ! volume mixing ratio for all
     real(r8), intent(in)   , dimension(ncol ,pver) :: h2ovmr              ! h2o vapor volume mixing ratio 
     real(r8), intent(inout)                        :: xsfc(4,ncol)        ! surface o3,n2o,noy,ch4 from linoz table
-    real(r8), intent(in)   , dimension(ncol ,pver) :: o3e3smcol           ! E3SM ozone column above box (mol/cm^2)
     real(r8), intent(in)   , dimension(ncol ,pver) :: o3col               ! Linoz ozone column above box (mol/cm^2)
     real(r8), intent(in)   , dimension(pcols,pver) :: temp                ! temperature (K)
     real(r8), intent(in)   , dimension(ncol )      :: sza                 ! local solar zenith angle
@@ -276,6 +275,7 @@ end subroutine linoz_readnl
     real(r8), intent(in)                           :: rlats(ncol)         ! column latitudes (radians)
     integer,  intent(in)   , dimension(pcols)      :: ltrop               ! chunk index    
     real(r8), intent(in)   , dimension(ncol ,pver) :: pdeldry             !  dry pressure delta about midpoints (Pa) 
+    character(len=*),  intent(in)                  :: chemFlag            ! flag for LNZ tracers
     logical, optional, intent(in)                  :: tropFlag(pcols,pver)! 3D tropospheric level flag
     !
     integer  :: i,k,n,ll,lt0,lt, n_dl !,index_lat,index_month
@@ -312,17 +312,9 @@ end subroutine linoz_readnl
     real(r8), dimension(:,:), pointer :: linoz_cariolle_psc
     real(r8), dimension(:,:), pointer :: linoz_o3lbs
     ! real O3 variables
-    real(r8), dimension(ncol,pver) :: dO3e3sm, dO3e3smCOL
-    real(r8), dimension(ncol,pver) :: PL_O3e3sm
-    real(r8) :: o3_e3sm_old, o3_e3sm_new, delo3_e3sm, delo3_e3sm_psc
-    real(r8), dimension(ncol,pver) :: o3_e3sm_vmr, do3_e3sm, do3_e3sm_psc
-    real(r8), dimension(ncol,pver) :: do3_e3sm_du, do3_e3sm_psc_du
     real(r8), dimension(ncol,pver) :: do3_linoz_du, do3_linoz_psc_du
-    real(r8), dimension(ncol) :: twod_do3_e3sm
-    real(r8), dimension(ncol) :: twod_do3_e3sm_psc
     real(r8), dimension(ncol) :: twod_do3_linoz
     real(r8), dimension(ncol) :: twod_do3_linoz_psc
-    real(r8) ::ss_x_e3sm
     !
     ! parameters
     !
@@ -338,15 +330,19 @@ end subroutine linoz_readnl
     if ( .not. linoz_v3) return
 
 !    write(iulog,*)'inside lin_strat_solve for ndx o3, o3lnz, n2o, noylnz, ch4', o3_ndx, o3lnz_ndx, n2o_ndx, noylnz_ndx, ch4_ndx
-
+    if (chemFlag == 'LNZ') then
         o3_vmr =  xvmr(:,:, o3lnz_ndx)
        n2o_vmr =  xvmr(:,:,n2olnz_ndx)
        noy_vmr =  xvmr(:,:,noylnz_ndx)
        ch4_vmr =  xvmr(:,:,ch4lnz_ndx)
        h2o_vmr =  xvmr(:,:,h2olnz_ndx)
-
-       o3_e3sm_vmr = xvmr(:,:, o3_ndx)
-
+    else
+        o3_vmr =  xvmr(:,:, o3_ndx)
+       n2o_vmr =  xvmr(:,:,n2o_ndx)
+       noy_vmr =  xvmr(:,:,noylnz_ndx)
+       ch4_vmr =  xvmr(:,:,ch4_ndx)
+       h2o_vmr =  xvmr(:,:,h2olnz_ndx)
+    endif
     ! associate the field pointers
        
     !
@@ -368,9 +364,6 @@ end subroutine linoz_readnl
        dTemp(:,:)   =  temp(:,:)     - linoz_t_clim(:,:)
        dCOL(:,:)     =  o3col(:,:)*convert_to_du - linoz_o3col_clim(:,:)
 
-       dO3e3sm(:,:)     =  o3_e3sm_vmr(:,:)  - linoz_o3_clim(:,:)
-       dO3e3smCOL(:,:)  =  o3e3smcol(:,:)*convert_to_du - linoz_o3col_clim(:,:)
- 
 ! potential water 2*ch4 +h2o !it might be better to get maxch4 3-4 years back in time but this will do for now 
 ! upated yearly o3,n2o,noy and ch4 value are stored at xx_clim in linoz file at the bottom padding layer
 ! output surface constant concentration to control surface sink/source
@@ -402,15 +395,6 @@ end subroutine linoz_readnl
             +  linoz_dPmL_dh2o    * dH2O  &
             +  linoz_dPmL_dT      * dTemp &
             +  linoz_dPmL_dO3col  * dCOL
-
-       PL_O3e3sm =  linoz_PmL_clim             &       
-            +  linoz_dPmL_dn2o    * dN2O  &
-            +  linoz_dPmL_dnoy    * dNOY  &
-            +  linoz_dPmL_dch4    * dCH4  &
-            +  linoz_dPmL_dh2o    * dH2O  &
-            +  linoz_dPmL_dT      * dTemp &
-            +  linoz_dPmL_dO3col  * dO3e3smCOL
-! 
 ! 
 !pointer to pn2o
        linoz_PmL_clim     => fields(pn2o_PmL_clim_ndx)     %data(:,:,lchnk )
@@ -516,8 +500,6 @@ end subroutine linoz_readnl
        o3col_du_diag     = 0._r8
        o3clim_linoz_diag = 0._r8
        ss_o3             = 0._r8
-
-       do3_e3sm          = 0._r8
     !
     ! convert lats from radians to degrees
     !
@@ -548,7 +530,7 @@ end subroutine linoz_readnl
              noy_old=   noy_vmr(i,k)
              ch4_old=   ch4_vmr(i,k)
              h2o_old=   h2o_vmr(i,k)
-             o3_e3sm_old=   o3_e3sm_vmr(i,k)
+    
           ! climatological ozone
              o3_clim = linoz_o3_clim(i,k)
           ! diagnostic for output
@@ -559,16 +541,11 @@ end subroutine linoz_readnl
              ss_x= o3_clim - PL_O3(i,k)/linoz_dPml_dO3X(i,k)             
              delo3 = (ss_x -o3_old)* (1.0_r8 - exp(linoz_dPmL_dO3X(i,k)*delta_t))
              o3_new = o3_old + delo3
-             ! for real O3 
-             ss_x_e3sm= o3_clim - PL_O3e3sm(i,k)/linoz_dPml_dO3X(i,k)             
-             delo3_e3sm = (ss_x_e3sm -o3_e3sm_old)* (1.0_r8 - exp(linoz_dPmL_dO3X(i,k)*delta_t))
-             o3_e3sm_new = o3_e3sm_old + delo3_e3sm
 !diagnostics
              do3_linoz(i,k) = (o3_new - o3_old)/delta_t
              o3clim_linoz_diag(i,k) = o3_clim
              ss_o3(i,k) = ss_x    
  
-             do3_e3sm(i,k) = (o3_e3sm_new - o3_e3sm_old)/delta_t
 !             o3col_du_diag(i,k) = o3col_du      
 !n2o  
              dn2op   = max(P_n2o(i,k)* delta_t, 0.0_r8)  !(dp/dt *dt in vmr)
@@ -591,7 +568,6 @@ end subroutine linoz_readnl
           ! use only if abs(latitude) > 40.
           !
              delo3_psc = 0._r8
-             delo3_e3sm_psc = 0._r8
              if ( abs(lats(i)) > 40._r8  ) then   
                 if ( (chlorine_loading-chlorine_loading_bgnd) > 0._r8 ) then
                    if ( temp(i,k) <= psc_T ) then
@@ -614,13 +590,10 @@ end subroutine linoz_readnl
                          delo3_psc= o3_old*(psc_loss -1._r8)
                          o3_new =o3_new + delo3_psc !o3_new:update from gas chem loss
 
-                         delo3_e3sm_psc = o3_e3sm_old*(psc_loss-1._r8)
-                         o3_e3sm_new = o3_e3sm_new + delo3_e3sm_psc
                       !
                       ! output diagnostic
                       !
                          do3_linoz_psc(i,k) = delo3_psc/delta_t
-                         do3_e3sm_psc(i,k) = delo3_e3sm_psc/delta_t
                       !
                       end if
                    end if
@@ -628,23 +601,22 @@ end subroutine linoz_readnl
              end if
           !
           ! update vmr
+           if (chemFlag == 'LNZ') then
+              xvmr(i,k,  o3lnz_ndx) =   o3_new
+              xvmr(i,k, n2olnz_ndx)   = n2o_new
+              xvmr(i,k, noylnz_ndx)   = noy_new
+              xvmr(i,k, ch4lnz_ndx)   = ch4_new
+              xvmr(i,k, h2olnz_ndx)   = h2o_new
+           else
+          !update real o3, ch4, n2o      
+              if(o3_ndx  > 0) xvmr(i,k, o3_ndx ) =  delo3   + delo3_psc +  xvmr(i,k, o3_ndx )
+              if(ch4_ndx > 0) xvmr(i,k, ch4_ndx) =  delch4  +  xvmr(i,k, ch4_ndx)
+              if(n2o_ndx > 0) xvmr(i,k, n2o_ndx) =  (dn2op + dn2ol)  +  xvmr(i,k, n2o_ndx)
+              if(no_ndx >0)  xvmr(i,k, no_ndx)   =  0.05 *(dnoyp + dnoyl) + xvmr(i,k, no_ndx)
+              if(no2_ndx>0)  xvmr(i,k, no2_ndx)  =  0.05 *(dnoyp + dnoyl) + xvmr(i,k, no2_ndx)
+              if(hno3_ndx>0) xvmr(i,k,hno3_ndx)  =  0.90 *(dnoyp + dnoyl) + xvmr(i,k, hno3_ndx)
+           endif
            
-           xvmr(i,k,  o3lnz_ndx) =   o3_new
-           xvmr(i,k, n2olnz_ndx)   = n2o_new
-           xvmr(i,k, noylnz_ndx)   = noy_new
-           xvmr(i,k, ch4lnz_ndx)   = ch4_new
-           xvmr(i,k, h2olnz_ndx)   = h2o_new
-           
-!update real o3, ch4, n2o      
-!           if(o3_ndx  > 0) xvmr(i,k, o3_ndx ) =  delo3   +  xvmr(i,k, o3_ndx )
-           !if(o3_ndx  > 0) xvmr(i,k, o3_ndx ) =  delo3   + delo3_psc +  xvmr(i,k, o3_ndx )
-           if(o3_ndx  > 0) xvmr(i,k, o3_ndx ) =  o3_e3sm_new
-           if(ch4_ndx > 0) xvmr(i,k, ch4_ndx) =  delch4  +  xvmr(i,k, ch4_ndx)
-           if(n2o_ndx > 0) xvmr(i,k, n2o_ndx) =  (dn2op + dn2ol)  +  xvmr(i,k, n2o_ndx)
-           if(no_ndx >0)  xvmr(i,k, no_ndx)   =  0.05 *(dnoyp + dnoyl) + xvmr(i,k, no_ndx)
-           if(no2_ndx>0)  xvmr(i,k, no2_ndx)  =  0.05 *(dnoyp + dnoyl) + xvmr(i,k, no2_ndx)
-           if(hno3_ndx>0) xvmr(i,k,hno3_ndx)  =  0.90 *(dnoyp + dnoyl) + xvmr(i,k, hno3_ndx)
-
         end do LOOP_LEV
 
        !use tropospheric specific humidity
@@ -663,36 +635,34 @@ end subroutine linoz_readnl
      end do LOOP_COL
 !    save the passed-in o3col for all layers rather than just the stratosphere
      o3col_du_diag(:ncol,:pver) = o3col(:ncol,:pver) * convert_to_du
-     do3_e3sm_du(:ncol,:) = pdeldry(:ncol,:)*do3_e3sm(:ncol,:)*avogadro*rgrav/mw_air*convert_to_du*1.e3_r8
-     do3_e3sm_psc_du(:ncol,:) = pdeldry(:ncol,:)*do3_e3sm_psc(:ncol,:)*avogadro*rgrav/mw_air*convert_to_du*1.e3_r8
      do3_linoz_du(:ncol,:) = pdeldry(:ncol,:)*do3_linoz(:ncol,:)*avogadro*rgrav/mw_air*convert_to_du*1.e3_r8
      do3_linoz_psc_du(:ncol,:) = pdeldry(:ncol,:)*do3_linoz_psc(:ncol,:)*avogadro*rgrav/mw_air*convert_to_du*1.e3_r8
 
-     twod_do3_e3sm = 0._r8
-     twod_do3_e3sm_psc = 0._r8
      twod_do3_linoz = 0._r8
      twod_do3_linoz_psc = 0._r8
      do k = 1, pver
-        twod_do3_e3sm(:)      = twod_do3_e3sm(:)      + do3_e3sm(:,k) 
-        twod_do3_e3sm_psc(:)  = twod_do3_e3sm_psc(:)  + do3_e3sm_psc(:,k) 
         twod_do3_linoz(:)     = twod_do3_linoz(:)     + do3_linoz(:,k) 
         twod_do3_linoz_psc(:) = twod_do3_linoz_psc(:) + do3_linoz_psc(:,k) 
      end do 
     ! output
     !
-     call outfld( 'LINOZ_DO3LNZ' , do3_linoz              , ncol, lchnk )
-     call outfld( 'LINOZ_DO3LNZ_PSC', do3_linoz_psc          , ncol, lchnk )
-     call outfld( 'LINOZ_SSO3'   , ss_o3                  , ncol, lchnk )
-     call outfld( 'LINOZ_O3COL'  , o3col_du_diag          , ncol, lchnk )
-     call outfld( 'LINOZ_O3CLIM' , o3clim_linoz_diag      , ncol, lchnk )
-     call outfld( 'LINOZ_SZA'    ,(sza*radians_to_degrees), ncol, lchnk )
-     call outfld( 'LINOZ_DO3'    , do3_e3sm              , ncol, lchnk )
-     call outfld( 'LINOZ_DO3_PSC', do3_e3sm_psc          , ncol, lchnk )
 
-     call outfld( 'LINOZ_2DDO3'       , twod_do3_e3sm              , ncol, lchnk )
-     call outfld( 'LINOZ_2DDO3_PSC'   , twod_do3_e3sm_psc          , ncol, lchnk )
-     call outfld( 'LINOZ_2DDO3LNZ'    , twod_do3_linoz             , ncol, lchnk )
-     call outfld( 'LINOZ_2DDO3LNZ_PSC', twod_do3_linoz_psc         , ncol, lchnk )
+     if (chemFlag == 'LNZ') then
+        call outfld( 'LINOZ_SSO3'   , ss_o3                  , ncol, lchnk )
+        call outfld( 'LINOZ_O3COL'  , o3col_du_diag          , ncol, lchnk )
+        call outfld( 'LINOZ_O3CLIM' , o3clim_linoz_diag      , ncol, lchnk )
+        call outfld( 'LINOZ_SZA'    ,(sza*radians_to_degrees), ncol, lchnk )
+ 
+        call outfld( 'LINOZ_DO3LNZ'      , do3_linoz              , ncol, lchnk )
+        call outfld( 'LINOZ_DO3LNZ_PSC'  , do3_linoz_psc          , ncol, lchnk )
+        call outfld( 'LINOZ_2DDO3LNZ'    , twod_do3_linoz             , ncol, lchnk )
+        call outfld( 'LINOZ_2DDO3LNZ_PSC', twod_do3_linoz_psc         , ncol, lchnk )
+     else
+        call outfld( 'LINOZ_DO3'         , do3_linoz              , ncol, lchnk )
+        call outfld( 'LINOZ_DO3_PSC'     , do3_linoz_psc          , ncol, lchnk )
+        call outfld( 'LINOZ_2DDO3'       , twod_do3_linoz              , ncol, lchnk )
+        call outfld( 'LINOZ_2DDO3_PSC'   , twod_do3_linoz_psc          , ncol, lchnk )
+     endif
 
     return
   end subroutine linv3_strat_chem_solve

--- a/components/eam/src/chemistry/mozart/lin_strat_chem.F90
+++ b/components/eam/src/chemistry/mozart/lin_strat_chem.F90
@@ -173,11 +173,11 @@ end subroutine linoz_readnl
     no2_ndx  =   get_spc_ndx('NO2')
     hno3_ndx =   get_spc_ndx('HNO3')
 
-!   if(masterproc)then
-!    write(iulog,*)'in subroutine lin_strat_chem_inti'
-!    write(iulog,*)'O3LNZ=',o3lnz_ndx,'N2OLNZ=',n2olnz_ndx,'NOYLNZ=',noylnz_ndx,'H2OLNZ=',h2olnz_ndx
-!    write(iulog,*)'O3=',o3_ndx,'CH4=',ch4_ndx,'N2O=',n2o_ndx,'NO=',no_ndx,'NO2=',no2_ndx,'HNO3=',hno3_ndx
-!   end if
+   !if(masterproc)then
+   ! write(iulog,*)'in subroutine lin_strat_chem_inti'
+   ! write(iulog,*)'O3LNZ=',o3lnz_ndx,'N2OLNZ=',n2olnz_ndx,'NOYLNZ=',noylnz_ndx,'H2OLNZ=',h2olnz_ndx
+   ! write(iulog,*)'O3=',o3_ndx,'CH4=',ch4_ndx,'N2O=',n2o_ndx,'NO=',no_ndx,'NO2=',no2_ndx,'HNO3=',hno3_ndx
+   !end if
     
 !     
 !   initialize the linoz data
@@ -339,13 +339,12 @@ end subroutine linoz_readnl
        h2o_vmr =  xvmr(:,:,h2olnz_ndx)
     else
         o3_vmr =  xvmr(:,:, o3_ndx)
-       n2o_vmr =  xvmr(:,:,n2o_ndx)
+       n2o_vmr =  xvmr(:,:,n2olnz_ndx)
        noy_vmr =  xvmr(:,:,noylnz_ndx)
        ch4_vmr =  xvmr(:,:,ch4_ndx)
        h2o_vmr =  xvmr(:,:,h2olnz_ndx)
     endif
     ! associate the field pointers
-       
     !
     !Linoz climatological data 
        linoz_o3_clim      => fields(o3_clim_ndx)      %data(:,:,lchnk )

--- a/components/eam/src/chemistry/mozart/lin_strat_chem.F90
+++ b/components/eam/src/chemistry/mozart/lin_strat_chem.F90
@@ -658,6 +658,11 @@ end subroutine linoz_readnl
         call outfld( 'LINOZ_2DDO3LNZ'    , twod_do3_linoz             , ncol, lchnk )
         call outfld( 'LINOZ_2DDO3LNZ_PSC', twod_do3_linoz_psc         , ncol, lchnk )
      else
+        call outfld( 'LINOZ_SSO3'   , ss_o3                  , ncol, lchnk )
+        call outfld( 'LINOZ_O3COL'  , o3col_du_diag          , ncol, lchnk )
+        call outfld( 'LINOZ_O3CLIM' , o3clim_linoz_diag      , ncol, lchnk )
+        call outfld( 'LINOZ_SZA'    ,(sza*radians_to_degrees), ncol, lchnk )
+
         call outfld( 'LINOZ_DO3'         , do3_linoz              , ncol, lchnk )
         call outfld( 'LINOZ_DO3_PSC'     , do3_linoz_psc          , ncol, lchnk )
         call outfld( 'LINOZ_2DDO3'       , twod_do3_linoz              , ncol, lchnk )

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -1056,13 +1056,17 @@ contains
           if(linoz_v2) call linv2_strat_chem_solve( ncol, lchnk, vmr,              col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev )                  
           if(linoz_v3) then
                        call h2o_to_vmr(q(:,:,1), qvmr, mbar, ncol )  
-                       call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,1), col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry )
+                       call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry, 'LNZ')
+                       !pass in column O3 
+                       call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,1), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry, 'CHEM')
           endif
         else
           if(linoz_v2) call linv2_strat_chem_solve( ncol, lchnk, vmr,              col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev, tropFlag=tropFlag )                  
           if(linoz_v3) then
                        call h2o_to_vmr(q(:,:,1), qvmr, mbar, ncol )  
-                       call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,1), col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry, tropFlag=tropFlag )
+                       call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry, 'LNZ', tropFlag=tropFlag)
+                       !pass in column O3 
+                       call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,1), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry, 'CHEM')
           endif
           call fstrat_efold_decay(ncol, vmr, delt, troplev, tropFlag=tropFlag) !if chemuci is on
        endif

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -1065,8 +1065,13 @@ contains
           if(linoz_v3) then
                        call h2o_to_vmr(q(:,:,1), qvmr, mbar, ncol )  
                        !call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry, 'LNZ', tropFlag=tropFlag)
-                       !pass in column O3 
-                       call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,1), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry, 'CHEM',tropFlag=tropFlag)
+                       !pass in column O3
+                       if (O3lnz_ndx > 0) then
+                          write(iulog,*) 'mo_gas_phase_chemdr: calling LINOZv3 for chemUCI+linozv3 mechanism, O3LNZ should not exist'
+                          call endrun('mo_gas_phase_chemdr: calling LINOZv3 for chemUCI+linozv3 mechanism, O3LNZ should not exist')
+                       else 
+                          call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,1), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry, 'CHEM',tropFlag=tropFlag)
+                       endif
           endif
           call fstrat_efold_decay(ncol, vmr, delt, troplev, tropFlag=tropFlag) !if chemuci is on
        endif

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -1047,6 +1047,7 @@ contains
 
 !
     ! LINOZ
+    ! col_dens(:,:,1) is for O3; col_dens(:,:,1) is for O2; col_dens(:,:,1) is for O3LNZ
     if (masterproc)write(iulog,*)'do_lin_strat_chem=',do_lin_strat_chem,'linoz_v2=',linoz_v2,'linoz_v3=',linoz_v3
     
     xsfc(:,:)=0    
@@ -1055,13 +1056,13 @@ contains
           if(linoz_v2) call linv2_strat_chem_solve( ncol, lchnk, vmr,              col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev )                  
           if(linoz_v3) then
                        call h2o_to_vmr(q(:,:,1), qvmr, mbar, ncol )  
-                       call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev )
+                       call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,1), col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry )
           endif
         else
           if(linoz_v2) call linv2_strat_chem_solve( ncol, lchnk, vmr,              col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev, tropFlag=tropFlag )                  
           if(linoz_v3) then
                        call h2o_to_vmr(q(:,:,1), qvmr, mbar, ncol )  
-                       call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev, tropFlag=tropFlag )
+                       call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,1), col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry, tropFlag=tropFlag )
           endif
           call fstrat_efold_decay(ncol, vmr, delt, troplev, tropFlag=tropFlag) !if chemuci is on
        endif

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -1056,7 +1056,7 @@ contains
           if(linoz_v2) call linv2_strat_chem_solve( ncol, lchnk, vmr,              col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev )                  
           if(linoz_v3) then
                        call h2o_to_vmr(q(:,:,1), qvmr, mbar, ncol )  
-                       call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry, 'LNZ')
+                       !call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry, 'LNZ')
                        !pass in column O3 
                        call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,1), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry, 'CHEM')
           endif
@@ -1064,9 +1064,9 @@ contains
           if(linoz_v2) call linv2_strat_chem_solve( ncol, lchnk, vmr,              col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev, tropFlag=tropFlag )                  
           if(linoz_v3) then
                        call h2o_to_vmr(q(:,:,1), qvmr, mbar, ncol )  
-                       call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry, 'LNZ', tropFlag=tropFlag)
+                       !call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry, 'LNZ', tropFlag=tropFlag)
                        !pass in column O3 
-                       call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,1), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry, 'CHEM')
+                       call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,1), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry, 'CHEM',tropFlag=tropFlag)
           endif
           call fstrat_efold_decay(ncol, vmr, delt, troplev, tropFlag=tropFlag) !if chemuci is on
        endif

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -26,7 +26,8 @@ module mo_gas_phase_chemdr
   character(len=fieldname_len) :: gas_ac_name_2D(gas_pcnst)
 
   integer :: o3_ndx, synoz_ndx, so4_ndx, h2o_ndx, o2_ndx, o_ndx, hno3_ndx, dst_ndx, cldice_ndx, e90_ndx
-!  integer :: o3lnz_ndx, n2olnz_ndx, noylnz_ndx, ch4lnz_ndx
+  !integer :: o3lnz_ndx, n2olnz_ndx, noylnz_ndx, ch4lnz_ndx
+  integer :: o3lnz_ndx
   integer :: uci1_ndx
   integer :: het1_ndx
   integer :: ndx_cldfr, ndx_cmfdqr, ndx_nevapr, ndx_cldtop, ndx_prain, ndx_sadsulf
@@ -82,7 +83,7 @@ contains
     dst_ndx = get_spc_ndx( dust_names(1) )
     synoz_ndx = get_extfrc_ndx( 'SYNOZ' )
     e90_ndx  = get_spc_ndx('E90')
-!    o3lnz_ndx =   get_spc_ndx('O3LNZ')
+    o3lnz_ndx =   get_spc_ndx('O3LNZ')
 !    n2olnz_ndx =  get_spc_ndx('N2OLNZ')
 !    noylnz_ndx =  get_spc_ndx('NOYLNZ')
 !    ch4lnz_ndx =  get_spc_ndx('CH4LNZ')
@@ -253,6 +254,7 @@ contains
     use mo_mass_xforms,    only : mmr2vmr, vmr2mmr, h2o_to_vmr, mmr2vmri
     use orbit,             only : zenith
     use UCI_cloudJ_interface, only : cloudJ_interface
+    use cam_abortutils,    only : endrun
 !
 ! LINOZ
 !
@@ -1066,7 +1068,7 @@ contains
                        call h2o_to_vmr(q(:,:,1), qvmr, mbar, ncol )  
                        !call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry, 'LNZ', tropFlag=tropFlag)
                        !pass in column O3
-                       if (O3lnz_ndx > 0) then
+                       if (o3lnz_ndx > 0) then
                           write(iulog,*) 'mo_gas_phase_chemdr: calling LINOZv3 for chemUCI+linozv3 mechanism, O3LNZ should not exist'
                           call endrun('mo_gas_phase_chemdr: calling LINOZv3 for chemUCI+linozv3 mechanism, O3LNZ should not exist')
                        else 


### PR DESCRIPTION
Pass real O3 into Linoz v3 and use for the O3 tenedency calculations to parallel O3LNZ. In the Linoz code, variables named "_e3sm" are associated with real O3.
