### PR TITLE
Corrected coupling of ice biogeochemistry for MARBL

### DIFF
--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -2128,6 +2128,7 @@ contains
               if ( iceFluxDOCField % isActive ) then
                  iceFluxDOC(1,i) = x2o_o % rAttr(index_x2o_Fioi_doc1, n)
                  iceFluxDOC(2,i) = x2o_o % rAttr(index_x2o_Fioi_doc2, n)
+                 iceFluxDOC(3,i) = x2o_o % rAttr(index_x2o_Fioi_doc3, n)
               endif
               if ( iceFluxDONField % isActive ) then
                  iceFluxDON(i) = x2o_o % rAttr(index_x2o_Fioi_don1, n)
@@ -2496,6 +2497,7 @@ contains
                                                avgOceanSurfaceDMS, &
                                                avgOceanSurfaceDMSP, &
                                                avgOceanSurfaceDOCr, &
+                                               avgOceanSurfaceDOCSum, &
                                                avgOceanSurfaceFeParticulate, &
                                                avgOceanSurfaceFeDissolved
 
@@ -2579,6 +2581,7 @@ contains
         call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceSiO3', avgOceanSurfaceSiO3)
         call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceNH4', avgOceanSurfaceNH4)
         call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceDOCr', avgOceanSurfaceDOCr)
+        call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceDOCSum', avgOceanSurfaceDOCSum)
         call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceFeParticulate', avgOceanSurfaceFeParticulate)
         call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceFeDissolved', avgOceanSurfaceFeDissolved)
      endif
@@ -2665,6 +2668,10 @@ contains
           o2x_o % rAttr(index_o2x_So_algae2, n) = max(0.0_RKIND,avgOceanSurfacePhytoC(2,i))
           o2x_o % rAttr(index_o2x_So_algae3, n) = max(0.0_RKIND,avgOceanSurfacePhytoC(3,i))
           o2x_o % rAttr(index_o2x_So_dic1,   n) = max(0.0_RKIND,avgOceanSurfaceDIC(i))
+          o2x_o % rAttr(index_o2x_So_doc1,   n) = max(0.0_RKIND,avgOceanSurfaceDOCSum(i))
+          o2x_o % rAttr(index_o2x_So_doc2,   n) = max(0.0_RKIND,avgOceanSurfaceDOCSum(i))
+          o2x_o % rAttr(index_o2x_So_doc3,   n) = max(0.0_RKIND,avgOceanSurfaceDOCSum(i))
+          o2x_o % rAttr(index_o2x_So_don1,   n) = 0.0_RKIND
           o2x_o % rAttr(index_o2x_So_no3,    n) = max(0.0_RKIND,avgOceanSurfaceNO3(i))
           o2x_o % rAttr(index_o2x_So_sio3,   n) = max(0.0_RKIND,avgOceanSurfaceSiO3(i))
           o2x_o % rAttr(index_o2x_So_nh4,    n) = max(0.0_RKIND,avgOceanSurfaceNH4(i))
@@ -2679,7 +2686,8 @@ contains
        if (config_use_MacroMoleculesTracers .and. config_use_MacroMoleculesTracers_sea_ice_coupling) then
           o2x_o % rAttr(index_o2x_So_doc1, n) = max(0.0_RKIND,avgOceanSurfaceDOC(1,i))
           o2x_o % rAttr(index_o2x_So_doc2, n) = max(0.0_RKIND,avgOceanSurfaceDOC(2,i))
-          o2x_o % rAttr(index_o2x_So_don1, n) = max(0.0_RKIND,avgOceanSurfaceDON(i))
+          o2x_o % rAttr(index_o2x_So_doc3, n) = max(0.0_RKIND,avgOceanSurfaceDOC(3,i))
+          o2x_o % rAttr(index_o2x_So_don1, n) = 0.0_RKIND
        endif
 !      o2x_o % rAttr(index_o2x_Faoo_fco2_ocn, n) = CO2Flux(i)
 !      o2x_o % rAttr(index_o2x_Faoo_fdms_ocn, n) = DMSFlux(i)

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -2497,7 +2497,7 @@ contains
                                                avgOceanSurfaceDMS, &
                                                avgOceanSurfaceDMSP, &
                                                avgOceanSurfaceDOCr, &
-                                               avgOceanSurfaceDOCSum, &
+                                               avgOceanSurfaceDOCSemiLabile, &
                                                avgOceanSurfaceFeParticulate, &
                                                avgOceanSurfaceFeDissolved
 
@@ -2581,7 +2581,7 @@ contains
         call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceSiO3', avgOceanSurfaceSiO3)
         call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceNH4', avgOceanSurfaceNH4)
         call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceDOCr', avgOceanSurfaceDOCr)
-        call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceDOCSum', avgOceanSurfaceDOCSum)
+        call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceDOCSemiLabile', avgOceanSurfaceDOCSemiLabile)
         call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceFeParticulate', avgOceanSurfaceFeParticulate)
         call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceFeDissolved', avgOceanSurfaceFeDissolved)
      endif
@@ -2668,9 +2668,9 @@ contains
           o2x_o % rAttr(index_o2x_So_algae2, n) = max(0.0_RKIND,avgOceanSurfacePhytoC(2,i))
           o2x_o % rAttr(index_o2x_So_algae3, n) = max(0.0_RKIND,avgOceanSurfacePhytoC(3,i))
           o2x_o % rAttr(index_o2x_So_dic1,   n) = max(0.0_RKIND,avgOceanSurfaceDIC(i))
-          o2x_o % rAttr(index_o2x_So_doc1,   n) = max(0.0_RKIND,avgOceanSurfaceDOCSum(i))
-          o2x_o % rAttr(index_o2x_So_doc2,   n) = max(0.0_RKIND,avgOceanSurfaceDOCSum(i))
-          o2x_o % rAttr(index_o2x_So_doc3,   n) = max(0.0_RKIND,avgOceanSurfaceDOCSum(i))
+          o2x_o % rAttr(index_o2x_So_doc1,   n) = max(0.0_RKIND,avgOceanSurfaceDOCSemiLabile(i))
+          o2x_o % rAttr(index_o2x_So_doc2,   n) = max(0.0_RKIND,avgOceanSurfaceDOCSemiLabile(i))
+          o2x_o % rAttr(index_o2x_So_doc3,   n) = max(0.0_RKIND,avgOceanSurfaceDOCSemiLabile(i))
           o2x_o % rAttr(index_o2x_So_don1,   n) = 0.0_RKIND
           o2x_o % rAttr(index_o2x_So_no3,    n) = max(0.0_RKIND,avgOceanSurfaceNO3(i))
           o2x_o % rAttr(index_o2x_So_sio3,   n) = max(0.0_RKIND,avgOceanSurfaceSiO3(i))

--- a/components/mpas-ocean/src/shared/mpas_ocn_time_average_coupled.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_time_average_coupled.F
@@ -74,7 +74,7 @@ module ocn_time_average_coupled
                                                     avgOceanSurfaceDMS, &
                                                     avgOceanSurfaceDMSP, &
                                                     avgOceanSurfaceDOCr, &
-                                                    avgOceanSurfaceDOCSum, &
+                                                    avgOceanSurfaceDOCSemiLabile, &
                                                     avgOceanSurfaceFeParticulate, &
                                                     avgOceanSurfaceFeDissolved
 
@@ -130,7 +130,7 @@ module ocn_time_average_coupled
            call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceSiO3', avgOceanSurfaceSiO3)
            call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceNH4', avgOceanSurfaceNH4)
            call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceDOCr', avgOceanSurfaceDOCr)
-           call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceDOCSum', avgOceanSurfaceDOCSum)
+           call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceDOCSemiLabile', avgOceanSurfaceDOCSemiLabile)
            call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceFeParticulate', avgOceanSurfaceFeParticulate)
            call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceFeDissolved', avgOceanSurfaceFeDissolved)
 
@@ -142,7 +142,7 @@ module ocn_time_average_coupled
               avgOceanSurfacePhytoC(:,iCell) = 0.0_RKIND
 
               avgOceanSurfaceDIC(iCell) = 0.0_RKIND
-              avgOceanSurfaceDOCSum(iCell) = 0.0_RKIND
+              avgOceanSurfaceDOCSemiLabile(iCell) = 0.0_RKIND
               avgOceanSurfaceNO3(iCell) = 0.0_RKIND
               avgOceanSurfaceSiO3(iCell) = 0.0_RKIND
               avgOceanSurfaceNH4(iCell) = 0.0_RKIND
@@ -231,7 +231,7 @@ module ocn_time_average_coupled
 
         real (kind=RKIND), dimension(:), pointer :: avgOceanSurfaceDIC, &
                                                     avgOceanSurfaceDON, &
-                                                    avgOceanSurfaceDOCSum, &
+                                                    avgOceanSurfaceDOCSemiLabile, &
                                                     avgOceanSurfaceNO3, &
                                                     avgOceanSurfaceSiO3, &
                                                     avgOceanSurfaceNH4, &
@@ -311,7 +311,7 @@ module ocn_time_average_coupled
 
          call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfacePhytoC', avgOceanSurfacePhytoC)
          call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceDIC', avgOceanSurfaceDIC)
-         call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceDOCSum', avgOceanSurfaceDOCSum)
+         call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceDOCSemiLabile', avgOceanSurfaceDOCSemiLabile)
          call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceNO3', avgOceanSurfaceNO3)
          call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceSiO3', avgOceanSurfaceSiO3)
          call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceNH4', avgOceanSurfaceNH4)
@@ -340,7 +340,7 @@ module ocn_time_average_coupled
 
            avgOceanSurfaceDIC(iCell) = ( avgOceanSurfaceDIC(iCell) * nAccumulatedCoupled &
               + ecosysTracers(dic_ind_MPAS,1,iCell) ) / ( nAccumulatedCoupled + 1)
-           avgOceanSurfaceDOCSum(iCell) = ( avgOceanSurfaceDOCSum(iCell) * nAccumulatedCoupled &
+           avgOceanSurfaceDOCSemiLabile(iCell) = ( avgOceanSurfaceDOCSemiLabile(iCell) * nAccumulatedCoupled &
               + ecosysTracers(doc_ind_MPAS,1,iCell) ) / ( nAccumulatedCoupled + 1)
            avgOceanSurfaceSiO3(iCell) = ( avgOceanSurfaceSiO3(iCell) * nAccumulatedCoupled &
               + ecosysTracers(sio3_ind_MPAS,1,iCell) ) / ( nAccumulatedCoupled + 1)

--- a/components/mpas-ocean/src/shared/mpas_ocn_time_average_coupled.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_time_average_coupled.F
@@ -74,6 +74,7 @@ module ocn_time_average_coupled
                                                     avgOceanSurfaceDMS, &
                                                     avgOceanSurfaceDMSP, &
                                                     avgOceanSurfaceDOCr, &
+                                                    avgOceanSurfaceDOCSum, &
                                                     avgOceanSurfaceFeParticulate, &
                                                     avgOceanSurfaceFeDissolved
 
@@ -129,6 +130,7 @@ module ocn_time_average_coupled
            call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceSiO3', avgOceanSurfaceSiO3)
            call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceNH4', avgOceanSurfaceNH4)
            call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceDOCr', avgOceanSurfaceDOCr)
+           call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceDOCSum', avgOceanSurfaceDOCSum)
            call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceFeParticulate', avgOceanSurfaceFeParticulate)
            call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceFeDissolved', avgOceanSurfaceFeDissolved)
 
@@ -140,6 +142,7 @@ module ocn_time_average_coupled
               avgOceanSurfacePhytoC(:,iCell) = 0.0_RKIND
 
               avgOceanSurfaceDIC(iCell) = 0.0_RKIND
+              avgOceanSurfaceDOCSum(iCell) = 0.0_RKIND
               avgOceanSurfaceNO3(iCell) = 0.0_RKIND
               avgOceanSurfaceSiO3(iCell) = 0.0_RKIND
               avgOceanSurfaceNH4(iCell) = 0.0_RKIND
@@ -228,6 +231,7 @@ module ocn_time_average_coupled
 
         real (kind=RKIND), dimension(:), pointer :: avgOceanSurfaceDIC, &
                                                     avgOceanSurfaceDON, &
+                                                    avgOceanSurfaceDOCSum, &
                                                     avgOceanSurfaceNO3, &
                                                     avgOceanSurfaceSiO3, &
                                                     avgOceanSurfaceNH4, &
@@ -307,6 +311,7 @@ module ocn_time_average_coupled
 
          call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfacePhytoC', avgOceanSurfacePhytoC)
          call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceDIC', avgOceanSurfaceDIC)
+         call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceDOCSum', avgOceanSurfaceDOCSum)
          call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceNO3', avgOceanSurfaceNO3)
          call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceSiO3', avgOceanSurfaceSiO3)
          call mpas_pool_get_array(ecosysSeaIceCoupling, 'avgOceanSurfaceNH4', avgOceanSurfaceNH4)
@@ -335,6 +340,8 @@ module ocn_time_average_coupled
 
            avgOceanSurfaceDIC(iCell) = ( avgOceanSurfaceDIC(iCell) * nAccumulatedCoupled &
               + ecosysTracers(dic_ind_MPAS,1,iCell) ) / ( nAccumulatedCoupled + 1)
+           avgOceanSurfaceDOCSum(iCell) = ( avgOceanSurfaceDOCSum(iCell) * nAccumulatedCoupled &
+              + ecosysTracers(doc_ind_MPAS,1,iCell) ) / ( nAccumulatedCoupled + 1)
            avgOceanSurfaceSiO3(iCell) = ( avgOceanSurfaceSiO3(iCell) * nAccumulatedCoupled &
               + ecosysTracers(sio3_ind_MPAS,1,iCell) ) / ( nAccumulatedCoupled + 1)
            avgOceanSurfaceNO3(iCell) = ( avgOceanSurfaceNO3(iCell) * nAccumulatedCoupled &

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_ecosys.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_ecosys.F
@@ -1987,7 +1987,8 @@ contains
             ecosysSurfaceFlux(dic_alt_co2_ind_MPAS,iCell) =  &
                ecosysSurfaceFlux(dic_alt_co2_ind_MPAS,iCell) + iceFluxDIC(iCell)
             ecosysSurfaceFlux(doc_ind_MPAS,iCell) =  &
-               ecosysSurfaceFlux(doc_ind_MPAS,iCell) + iceFluxDOC(1,iCell) + iceFluxDOC(2,iCell)
+               ecosysSurfaceFlux(doc_ind_MPAS,iCell) + iceFluxDOC(1,iCell) + iceFluxDOC(2,iCell) &
+               + iceFluxDOC(3,iCell)
 ! this is just a placeholder
             ecosysSurfaceFlux(donr_ind_MPAS,iCell) =  &
                ecosysSurfaceFlux(donr_ind_MPAS,iCell) + iceFluxDOCr(iCell)

--- a/components/mpas-ocean/src/tracer_groups/Registry_MacroMolecules.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_MacroMolecules.xml
@@ -121,8 +121,8 @@
 			</var_array>
 		</var_struct>
 		<var_struct name="MacroMoleculesSeaIceCoupling" time_levs="1" packages="MacroMoleculesTracersPKG">
-			<var name="avgOceanSurfaceDOC" type="real" dimensions="TWO nCells Time" units="mmolC m^{-3}"
-				description="Ocean Surface Organics concentration: (1,2)=>(polysaccharides,lipids)"
+			<var name="avgOceanSurfaceDOC" type="real" dimensions="R3 nCells Time" units="mmolC m^{-3}"
+				description="Ocean Surface Organics concentration: (1,2,3)=>(polysaccharides,lipids,proteins)"
 			/>
 			<var name="avgOceanSurfaceDON" type="real" dimensions="nCells Time" units="mmolN m^{-3}"
 				description="Ocean Surface Organic Proteins concentration"

--- a/components/mpas-ocean/src/tracer_groups/Registry_ecosys.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_ecosys.xml
@@ -687,6 +687,9 @@
 			<var name="avgOceanSurfaceDIC" type="real" dimensions="nCells Time" units="mmol C m^{-3}"
 				description="Ocean Surface DIC concentration"
 			/>
+			<var name="avgOceanSurfaceDOCSum" type="real" dimensions="nCells Time" units="mmol C m^{-3}"
+				description="Total Ocean Surface DOC concentration"
+			/>
 			<var name="avgOceanSurfaceNO3" type="real" dimensions="nCells Time" units="mmol N m^{-3}"
 				description="Ocean Surface NO3 concentration"
 			/>
@@ -732,8 +735,8 @@
 			<var name="iceFluxDust" type="real" dimensions="nCells Time" units="kg m^{-2} s"
 				description="Surface dust flux from sea ice"
 			/>
-			<var name="iceFluxDOC" type="real" dimensions="TWO nCells Time" units="mmol C m^{-2} s"
-				description="Surface Organics flux from sea ice: (1,2)=>(polysaccharides,lipids)"
+			<var name="iceFluxDOC" type="real" dimensions="R3 nCells Time" units="mmol C m^{-2} s"
+				description="Surface Organics flux from sea ice: (1,2,3)=>(polysaccharides,lipids,proteins)"
 			/>
 			<var name="iceFluxDON" type="real" dimensions="nCells Time" units="mmol N m^{-2} s"
 				description="Surface Organic Proteins flux from sea ice"

--- a/components/mpas-ocean/src/tracer_groups/Registry_ecosys.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_ecosys.xml
@@ -687,8 +687,8 @@
 			<var name="avgOceanSurfaceDIC" type="real" dimensions="nCells Time" units="mmol C m^{-3}"
 				description="Ocean Surface DIC concentration"
 			/>
-			<var name="avgOceanSurfaceDOCSum" type="real" dimensions="nCells Time" units="mmol C m^{-3}"
-				description="Total Ocean Surface DOC concentration"
+			<var name="avgOceanSurfaceDOCSemiLabile" type="real" dimensions="nCells Time" units="mmol C m^{-3}"
+				description="Total Ocean Surface DOC semi-labile concentration"
 			/>
 			<var name="avgOceanSurfaceNO3" type="real" dimensions="nCells Time" units="mmol N m^{-3}"
 				description="Ocean Surface NO3 concentration"

--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -676,6 +676,7 @@ if ($ice_bgc eq 'ice_bgc') {
         add_default($nl, 'config_use_iron', 'val'=>".false.");
 }
 add_default($nl, 'config_use_chlorophyll');
+add_default($nl, 'config_use_macromolecules');
 add_default($nl, 'config_use_modal_aerosols');
 add_default($nl, 'config_use_zaerosols');
 add_default($nl, 'config_skeletal_bgc_flux_type');

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -193,6 +193,7 @@ add_default($nl, 'config_use_skeletal_biochemistry');
 add_default($nl, 'config_use_nitrate');
 add_default($nl, 'config_use_carbon');
 add_default($nl, 'config_use_chlorophyll');
+add_default($nl, 'config_use_macromolecules');
 add_default($nl, 'config_use_ammonium');
 add_default($nl, 'config_use_silicate');
 add_default($nl, 'config_use_DMS');

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -188,6 +188,7 @@
 <config_use_nitrate>false</config_use_nitrate>
 <config_use_carbon>false</config_use_carbon>
 <config_use_chlorophyll>false</config_use_chlorophyll>
+<config_use_macromolecules>false</config_use_macromolecules>
 <config_use_ammonium>false</config_use_ammonium>
 <config_use_silicate>false</config_use_silicate>
 <config_use_DMS>false</config_use_DMS>

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -955,6 +955,14 @@ Valid values: false
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_use_macromolecules" type="logical"
+	category="biogeochemistry" group="biogeochemistry">
+Use ocean macromolecule to determine DOC fractions in ice-ocean coupling
+
+Valid values: true or false
+Default: Defined in namelist_defaults.xml
+</entry>
+
 <entry id="config_use_ammonium" type="logical"
 	category="biogeochemistry" group="biogeochemistry">
 Use the ammonium tracer

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -1866,7 +1866,8 @@ contains
       oceanDMSPConc,               &
       oceanHumicsConc,             &
       carbonToNitrogenRatioAlgae,  &
-      carbonToNitrogenRatioDON
+      carbonToNitrogenRatioDON,    &
+      DOCPoolFractions
 
    real (kind=RKIND), dimension(:,:), pointer :: &
       oceanAlgaeConc,              &
@@ -1960,6 +1961,8 @@ contains
          call mpas_pool_get_array(biogeochemistry, 'oceanZAerosolConc', oceanZAerosolConc)
          call mpas_pool_get_array(biogeochemistry, 'carbonToNitrogenRatioAlgae', carbonToNitrogenRatioAlgae)
          call mpas_pool_get_array(biogeochemistry, 'carbonToNitrogenRatioDON', carbonToNitrogenRatioDON)
+         call mpas_pool_get_array(biogeochemistry, 'DOCPoolFractions', DOCPoolFractions)
+
          if (config_use_zaerosols) then
             call mpas_pool_get_array(biogeochemistry, "atmosBlackCarbonFlux", atmosBlackCarbonFlux)
             call mpas_pool_get_array(biogeochemistry, "atmosDustFlux", atmosDustFlux)
@@ -2056,12 +2059,13 @@ contains
         if (config_use_column_biogeochemistry) then
            oceanAlgaeConc(1,i)           = x2i_i % rAttr(index_x2i_So_algae1, n)
            oceanAlgaeConc(2,i)           = x2i_i % rAttr(index_x2i_So_algae2, n)
-           oceanAlgaeConc(3,i)           = x2i_i % rAttr(index_x2i_So_algae3, n)
-           oceanDOCConc(1,i)             = x2i_i % rAttr(index_x2i_So_doc1, n)
-           oceanDOCConc(2,i)             = x2i_i % rAttr(index_x2i_So_doc2, n)
+           oceanAlgaeConc(3,i)           = 0.0_RKIND !x2i_i % rAttr(index_x2i_So_algae3, n)
+           oceanDOCConc(1,i)             = x2i_i % rAttr(index_x2i_So_doc1, n) * DOCPoolFractions(1)
+           oceanDOCConc(2,i)             = x2i_i % rAttr(index_x2i_So_doc2, n) * DOCPoolFractions(2)
            oceanDOCConc(3,i)             = 0.0_RKIND
-           oceanDICConc(1,i)             = x2i_i % rAttr(index_x2i_So_dic1, n) !JW not used, set to 0?
-           oceanDONConc(1,i)             = x2i_i % rAttr(index_x2i_So_don1, n)
+           oceanDICConc(1,i)             = x2i_i % rAttr(index_x2i_So_dic1, n)
+           oceanDONConc(1,i)             = x2i_i % rAttr(index_x2i_So_don1, n) * DOCPoolFractions(3) &
+              /carbonToNitrogenRatioDON(1)
            oceanNitrateConc(i)           = x2i_i % rAttr(index_x2i_So_no3, n)
            oceanSilicateConc(i)          = x2i_i % rAttr(index_x2i_So_sio3, n)
            oceanAmmoniumConc(i)          = x2i_i % rAttr(index_x2i_So_nh4, n)
@@ -2573,7 +2577,7 @@ contains
                i2x_i % rAttr(index_i2x_Fioi_algae3,n) = oceanAlgaeFlux(3,i) * carbonToNitrogenRatioAlgae(3)
                i2x_i % rAttr(index_i2x_Fioi_doc1  ,n) = oceanDOCFlux(1,i)
                i2x_i % rAttr(index_i2x_Fioi_doc2  ,n) = oceanDOCFlux(2,i)
-               i2x_i % rAttr(index_i2x_Fioi_doc3  ,n) = oceanDOCFlux(3,i) !JW set to 0?
+               i2x_i % rAttr(index_i2x_Fioi_doc3  ,n) = oceanDONFlux(3,i) * carbonToNitrogenRatioDON(1)
                i2x_i % rAttr(index_i2x_Fioi_dic1  ,n) = oceanDICFlux(1,i)
                i2x_i % rAttr(index_i2x_Fioi_don1  ,n) = oceanDONFlux(1,i)
                i2x_i % rAttr(index_i2x_Fioi_no3   ,n) = oceanNitrateFlux(i)

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -161,7 +161,7 @@
 			description="Specifies the third dimension of the modal aerosol optical parameter matrix"
 		/>
 		<dim name="nAlgae"
-			definition="3"
+			definition="2"
 			description="Number of algal species in use"
 		/>
 		<dim name="nDOC"
@@ -794,6 +794,11 @@
 			description="Use the chlorophyll tracer (currently not implemented!)"
 			possible_values="false"
 			icepack_name="tr_bgc_chl"
+		/>
+		<nml_option name="config_use_macromolecules" type="logical" default_value="false" units="unitless"
+			description="Use ocean macromolecule to determine DOC fractions in ice-ocean coupling"
+			possible_values="true or false"
+			icepack_name="use_macromolecules"
 		/>
 		<nml_option name="config_use_ammonium" type="logical" default_value="false" units="unitless"
 			description="Use the ammonium tracer"
@@ -4089,6 +4094,7 @@
 		<var name="verticalShortwaveGrid"		type="real"	dimensions="nIceLayersP1"				name_in_code="verticalShortwaveGrid"		packages="pkgColumnBiogeochemistry;pkgColumnPackage"/>
 		<var name="carbonToNitrogenRatioAlgae"		type="real"	dimensions="maxAlgaeType"				name_in_code="carbonToNitrogenRatioAlgae"/>
 		<var name="carbonToNitrogenRatioDON"		type="real"	dimensions="maxDONType"				name_in_code="carbonToNitrogenRatioDON"/>
+		<var name="DOCPoolFractions"		type="real"	dimensions="maxDOCType"				name_in_code="DOCPoolFractions"/>
 	</var_struct>
 
 	<!-- prescribed ice mode -->

--- a/components/mpas-seaice/src/column/ice_algae.F90
+++ b/components/mpas-seaice/src/column/ice_algae.F90
@@ -2239,8 +2239,8 @@
               reactb(nlt_bgc_DMS)   = DMS_s   - DMS_r
        endif
        if (tr_bgc_C) then
-       if (abs(dC) > maxval(abs(reactb(:)))*1.0e-13_dbl_kind .or. &
-          abs(dN) > maxval(abs(reactb(:)))*1.0e-13_dbl_kind) then
+          if (abs(dC) > max(puny,maxval(abs(reactb(:)))*1.0e-13_dbl_kind) .or. &
+            abs(dN) > max(puny,maxval(abs(reactb(:)))*1.0e-13_dbl_kind)) then
             conserve_C = .false.
             write(warning, *) 'Conservation error!'
             call add_warning(warning)

--- a/components/mpas-seaice/src/column/ice_colpkg.F90
+++ b/components/mpas-seaice/src/column/ice_colpkg.F90
@@ -533,10 +533,11 @@
          doc, don, dic, fed, fep, zaeros, hum,  &
          ocean_bio_all, &
          max_algae, max_doc, max_dic, max_don,  max_fe, max_nbtrcr, max_aero, &
-         l_stop, stop_label)
+         DOCPoolFractions, use_macromolecules, l_stop, stop_label)
 
       use ice_constants_colpkg, only: c0, c1, c2, p1, p15, p5
-      use ice_zbgc_shared, only: R_S2N, zbgc_frac_init, zbgc_init_frac, remap_zbgc
+      use ice_zbgc_shared, only: R_S2N, zbgc_frac_init, zbgc_init_frac, remap_zbgc, &
+           doc_pool_fractions
 
       ! column package includes
       use ice_colpkg_tracers, only: nt_fbri, nt_bgc_S, nt_sice, nt_zbgc_frac, &
@@ -562,21 +563,23 @@
          max_fe, &
          max_nbtrcr, &
          max_aero
- 
+
       real (kind=dbl_kind), dimension (nblyr+1), intent(inout) :: &
          igrid     ! biology vertical interface points
- 
-      real (kind=dbl_kind), dimension (nilyr+1), intent(inout) :: &
-         cgrid     ! CICE vertical coordinate   
 
-      logical (kind=log_kind), intent(in) :: & 
-         restart_bgc ! if .true., read bgc restart file
+      real (kind=dbl_kind), dimension (nilyr+1), intent(inout) :: &
+         cgrid     ! CICE vertical coordinate
+
+      logical (kind=log_kind), intent(in) :: &
+         restart_bgc, & ! if .true., read bgc restart file
+         use_macromolecules ! if .true., doc ocean fractions are determined &
+                            ! by the ocean macromolecules subroutine
 
       real (kind=dbl_kind), dimension(nilyr, ncat), intent(in) :: &
          sicen     ! salinity on the cice grid
 
       real (kind=dbl_kind), dimension (:,:), intent(inout) :: &
-         trcrn     ! subset of tracer array (only bgc) 
+         trcrn     ! subset of tracer array (only bgc)
 
       real (kind=dbl_kind), intent(in) :: &
          sss       ! sea surface salinity (ppt)
@@ -610,6 +613,9 @@
       real (kind=dbl_kind), dimension (:), intent(inout) :: &
          ocean_bio_all   ! fixed order, all values even for tracers false
 
+      real (kind=dbl_kind), dimension (:), intent(out) :: &
+         DOCPoolFractions   ! Fraction of DOC in polysacharids, lipids, and proteins
+
       logical (kind=log_kind), intent(inout) :: &
          l_stop            ! if true, print diagnostics and abort on return
 
@@ -641,6 +647,13 @@
       zspace(1)       = p5*zspace(1)
       zspace(nblyr+1) = p5*zspace(nblyr+1)
       ntrcr_bgc       = ntrcr-ntrcr_o
+
+      DOCPoolFractions(:) = c1
+      if (.not. use_macromolecules) then
+        do mm = 1,max_doc
+           DOCPoolFractions(mm) = doc_pool_fractions(mm)
+        end do
+      end if
 
       call colpkg_init_OceanConcArray(max_nbtrcr,                &
                                  max_algae, max_don,  max_doc,   &

--- a/components/mpas-seaice/src/column/ice_zbgc_shared.F90
+++ b/components/mpas-seaice/src/column/ice_zbgc_shared.F90
@@ -29,11 +29,15 @@
          R_Fe2C     , & ! algal Fe to carbon (umol/mmol)
          R_Fe2N         ! algal Fe to N (umol/mmol)
 
-      real (kind=dbl_kind), dimension(max_don), public :: & 
+      real (kind=dbl_kind), dimension(max_don), public :: &
          R_Fe2DON       ! Fe to N of DON (nmol/umol)
 
-      real (kind=dbl_kind), dimension(max_doc), public :: &  
+      real (kind=dbl_kind), dimension(max_doc), public :: &
          R_Fe2DOC       ! Fe to C of DOC (nmol/umol)
+
+      ! polysaccharids, lipids, proteins+nucleic acids (Lonborg et al. 2020)
+      real (kind=dbl_kind), dimension(max_doc), parameter, public :: &
+         doc_pool_fractions = (/0.26_dbl_kind, 0.17_dbl_kind, 0.57_dbl_kind/)
 
       real (kind=dbl_kind), parameter, public :: &
          R_gC2molC  = 12.01_dbl_kind ! mg/mmol C

--- a/components/mpas-seaice/src/shared/mpas_seaice_column.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_column.F
@@ -13033,7 +13033,8 @@ contains
          config_use_skeletal_biochemistry, &
          config_do_restart_zsalinity, &
          config_do_restart_bgc, &
-         config_do_restart_hbrine
+         config_do_restart_hbrine, &
+         config_use_macromolecules
 
     real(kind=RKIND), pointer :: &
          config_dt, &
@@ -13052,7 +13053,8 @@ contains
          biologyGrid, &           ! bgrid
          verticalShortwaveGrid, & ! swgrid
          interfaceGrid, &         ! icgrid
-         rayleighCriteriaReal
+         rayleighCriteriaReal, &
+         DOCPoolFractions
 
     real(kind=RKIND), dimension(:,:), pointer :: &
          oceanAlgaeConc, &
@@ -13116,6 +13118,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_use_vertical_tracers", config_use_vertical_tracers)
     call MPAS_pool_get_config(domain % configs, "config_dt", config_dt)
     call MPAS_pool_get_config(domain % configs, "config_snow_porosity_at_ice_surface", config_snow_porosity_at_ice_surface)
+    call MPAS_pool_get_config(domain % configs, "config_use_macromolecules", config_use_macromolecules)
 
     abortFlag = .false.
 
@@ -13156,6 +13159,7 @@ contains
        call MPAS_pool_get_array(biogeochemistry, "oceanHumicsConc", oceanHumicsConc)
        call MPAS_pool_get_array(biogeochemistry, "oceanZAerosolConc", oceanZAerosolConc)
        call MPAS_pool_get_array(biogeochemistry, "newlyFormedIce", newlyFormedIce)
+       call MPAS_pool_get_array(biogeochemistry, "DOCPoolFractions", DOCPoolFractions)
 
        call MPAS_pool_get_subpool(block % structs, "ocean_coupling", ocean_coupling)
        call MPAS_pool_get_array(ocean_coupling, "seaSurfaceSalinity", seaSurfaceSalinity)
@@ -13252,6 +13256,8 @@ contains
                   maxIronType, &
                   nZBGCTracers, &
                   maxAerosolType, &
+                  DOCPoolFractions, &
+                  config_use_macromolecules, &
                   abortFlag, &
                   abortMessage)
 

--- a/components/mpas-seaice/testing_and_setup/configurations/aerosol_shortwave_physics/namelist.seaice
+++ b/components/mpas-seaice/testing_and_setup/configurations/aerosol_shortwave_physics/namelist.seaice
@@ -140,6 +140,7 @@
     config_use_humics = false
     config_use_DON = false
     config_use_iron = false
+    config_use_macromolecules = false
     config_use_modal_aerosols = false
     config_use_zaerosols = true
     config_skeletal_bgc_flux_type = 'Jin2006'

--- a/components/mpas-seaice/testing_and_setup/configurations/prescribed_ice/namelist.seaice
+++ b/components/mpas-seaice/testing_and_setup/configurations/prescribed_ice/namelist.seaice
@@ -140,6 +140,7 @@
     config_use_humics = false
     config_use_DON = false
     config_use_iron = false
+    config_use_macromolecules = false
     config_use_modal_aerosols = false
     config_use_zaerosols = false
     config_skeletal_bgc_flux_type = 'Jin2006'

--- a/components/mpas-seaice/testing_and_setup/configurations/snicar_shortwave/namelist.seaice
+++ b/components/mpas-seaice/testing_and_setup/configurations/snicar_shortwave/namelist.seaice
@@ -140,6 +140,7 @@
     config_use_humics = false
     config_use_DON = false
     config_use_iron = false
+    config_use_macromolecules = false
     config_use_modal_aerosols = false
     config_use_zaerosols = false
     config_skeletal_bgc_flux_type = 'Jin2006'

--- a/components/mpas-seaice/testing_and_setup/configurations/snow_tracer_physics/namelist.seaice
+++ b/components/mpas-seaice/testing_and_setup/configurations/snow_tracer_physics/namelist.seaice
@@ -140,6 +140,7 @@
     config_use_humics = false
     config_use_DON = false
     config_use_iron = false
+    config_use_macromolecules = false
     config_use_modal_aerosols = false
     config_use_zaerosols = false
     config_skeletal_bgc_flux_type = 'Jin2006'

--- a/components/mpas-seaice/testing_and_setup/configurations/standard_bgc/namelist.seaice
+++ b/components/mpas-seaice/testing_and_setup/configurations/standard_bgc/namelist.seaice
@@ -140,6 +140,7 @@
     config_use_humics = true
     config_use_DON = true
     config_use_iron = true
+    config_use_macromolecules = false
     config_use_modal_aerosols = false
     config_use_zaerosols = true
     config_skeletal_bgc_flux_type = 'Jin2006'

--- a/components/mpas-seaice/testing_and_setup/configurations/standard_physics/namelist.seaice
+++ b/components/mpas-seaice/testing_and_setup/configurations/standard_physics/namelist.seaice
@@ -140,6 +140,7 @@
     config_use_humics = false
     config_use_DON = false
     config_use_iron = false
+    config_use_macromolecules = false
     config_use_modal_aerosols = false
     config_use_zaerosols = false
     config_skeletal_bgc_flux_type = 'Jin2006'

--- a/components/mpas-seaice/testing_and_setup/configurations/standard_physics_single_cell/namelist.seaice
+++ b/components/mpas-seaice/testing_and_setup/configurations/standard_physics_single_cell/namelist.seaice
@@ -136,6 +136,7 @@
     config_use_humics = false
     config_use_DON = false
     config_use_iron = false
+    config_use_macromolecules = false
     config_use_modal_aerosols = false
     config_use_zaerosols = false
     config_skeletal_bgc_flux_type = 'Jin2006'

--- a/components/mpas-seaice/testing_and_setup/testcases/advection/namelist.seaice.advection
+++ b/components/mpas-seaice/testing_and_setup/testcases/advection/namelist.seaice.advection
@@ -139,6 +139,7 @@
     config_use_humics = false
     config_use_DON = false
     config_use_iron = false
+    config_use_macromolecules = false
     config_use_modal_aerosols = false
     config_use_zaerosols = false
     config_skeletal_bgc_flux_type = 'Jin2006'

--- a/components/mpas-seaice/testing_and_setup/testcases/error_analysis/namelist.seaice.strain
+++ b/components/mpas-seaice/testing_and_setup/testcases/error_analysis/namelist.seaice.strain
@@ -140,6 +140,7 @@
     config_use_humics = false
     config_use_DON = false
     config_use_iron = false
+    config_use_macromolecules = false
     config_use_modal_aerosols = false
     config_use_zaerosols = false
     config_skeletal_bgc_flux_type = 'Jin2006'

--- a/components/mpas-seaice/testing_and_setup/testcases/ridging_1D/namelist.seaice.ridging_1D
+++ b/components/mpas-seaice/testing_and_setup/testcases/ridging_1D/namelist.seaice.ridging_1D
@@ -142,6 +142,7 @@
     config_use_humics = false
     config_use_DON = false
     config_use_iron = false
+    config_use_macromolecules = false
     config_use_modal_aerosols = false
     config_use_zaerosols = false
     config_skeletal_bgc_flux_type = 'Jin2006'

--- a/components/mpas-seaice/testing_and_setup/testcases/ridging_island/namelist.seaice.ridging_island
+++ b/components/mpas-seaice/testing_and_setup/testcases/ridging_island/namelist.seaice.ridging_island
@@ -140,6 +140,7 @@
     config_use_humics = false
     config_use_DON = false
     config_use_iron = false
+    config_use_macromolecules = false
     config_use_modal_aerosols = false
     config_use_zaerosols = false
     config_skeletal_bgc_flux_type = 'Jin2006'

--- a/components/mpas-seaice/testing_and_setup/testcases/spherical_operators/strain/namelist.seaice.strain
+++ b/components/mpas-seaice/testing_and_setup/testcases/spherical_operators/strain/namelist.seaice.strain
@@ -140,6 +140,7 @@
     config_use_humics = false
     config_use_DON = false
     config_use_iron = false
+    config_use_macromolecules = false
     config_use_modal_aerosols = false
     config_use_zaerosols = false
     config_skeletal_bgc_flux_type = 'Jin2006'

--- a/components/mpas-seaice/testing_and_setup/testcases/spherical_operators/strain_stress_divergence/namelist.seaice.strain_stress_divergence
+++ b/components/mpas-seaice/testing_and_setup/testcases/spherical_operators/strain_stress_divergence/namelist.seaice.strain_stress_divergence
@@ -140,6 +140,7 @@
     config_use_humics = false
     config_use_DON = false
     config_use_iron = false
+    config_use_macromolecules = false
     config_use_modal_aerosols = false
     config_use_zaerosols = false
     config_skeletal_bgc_flux_type = 'Jin2006'

--- a/components/mpas-seaice/testing_and_setup/testcases/spherical_operators/stress_divergence/namelist.seaice.stress_divergence
+++ b/components/mpas-seaice/testing_and_setup/testcases/spherical_operators/stress_divergence/namelist.seaice.stress_divergence
@@ -140,6 +140,7 @@
     config_use_humics = false
     config_use_DON = false
     config_use_iron = false
+    config_use_macromolecules = false
     config_use_modal_aerosols = false
     config_use_zaerosols = false
     config_skeletal_bgc_flux_type = 'Jin2006'

--- a/components/mpas-seaice/testing_and_setup/testcases/square/1D_velocity_hex/namelist.seaice.square
+++ b/components/mpas-seaice/testing_and_setup/testcases/square/1D_velocity_hex/namelist.seaice.square
@@ -140,6 +140,7 @@
     config_use_humics = false
     config_use_DON = false
     config_use_iron = false
+    config_use_macromolecules = false
     config_use_modal_aerosols = false
     config_use_zaerosols = false
     config_skeletal_bgc_flux_type = 'Jin2006'

--- a/components/mpas-seaice/testing_and_setup/testcases/square/1D_velocity_quad/namelist.seaice.square
+++ b/components/mpas-seaice/testing_and_setup/testcases/square/1D_velocity_quad/namelist.seaice.square
@@ -140,6 +140,7 @@
     config_use_humics = false
     config_use_DON = false
     config_use_iron = false
+    config_use_macromolecules = false
     config_use_modal_aerosols = false
     config_use_zaerosols = false
     config_skeletal_bgc_flux_type = 'Jin2006'

--- a/components/mpas-seaice/testing_and_setup/testcases/square/operators_strain/namelist.seaice.strain
+++ b/components/mpas-seaice/testing_and_setup/testcases/square/operators_strain/namelist.seaice.strain
@@ -140,6 +140,7 @@
     config_use_humics = false
     config_use_DON = false
     config_use_iron = false
+    config_use_macromolecules = false
     config_use_modal_aerosols = false
     config_use_zaerosols = false
     config_skeletal_bgc_flux_type = 'Jin2006'

--- a/components/mpas-seaice/testing_and_setup/testcases/square/operators_strain_stress_divergence/namelist.seaice.strain_stress_divergence
+++ b/components/mpas-seaice/testing_and_setup/testcases/square/operators_strain_stress_divergence/namelist.seaice.strain_stress_divergence
@@ -140,6 +140,7 @@
     config_use_humics = false
     config_use_DON = false
     config_use_iron = false
+    config_use_macromolecules = false
     config_use_modal_aerosols = false
     config_use_zaerosols = false
     config_skeletal_bgc_flux_type = 'Jin2006'

--- a/components/mpas-seaice/testing_and_setup/testcases/square/operators_stress_divergence/namelist.seaice.stress_divergence
+++ b/components/mpas-seaice/testing_and_setup/testcases/square/operators_stress_divergence/namelist.seaice.stress_divergence
@@ -140,6 +140,7 @@
     config_use_humics = false
     config_use_DON = false
     config_use_iron = false
+    config_use_macromolecules = false
     config_use_modal_aerosols = false
     config_use_zaerosols = false
     config_skeletal_bgc_flux_type = 'Jin2006'

--- a/components/mpas-seaice/testing_and_setup/testcases/square/square_hex_sb/namelist.seaice.square
+++ b/components/mpas-seaice/testing_and_setup/testcases/square/square_hex_sb/namelist.seaice.square
@@ -139,6 +139,7 @@
     config_use_humics = false
     config_use_DON = false
     config_use_iron = false
+    config_use_macromolecules = false
     config_use_modal_aerosols = false
     config_use_zaerosols = false
     config_skeletal_bgc_flux_type = 'Jin2006'

--- a/components/mpas-seaice/testing_and_setup/testcases/square/square_quadhex/namelist.seaice.square
+++ b/components/mpas-seaice/testing_and_setup/testcases/square/square_quadhex/namelist.seaice.square
@@ -140,6 +140,7 @@
     config_use_humics = false
     config_use_DON = false
     config_use_iron = false
+    config_use_macromolecules = false
     config_use_modal_aerosols = false
     config_use_zaerosols = false
     config_skeletal_bgc_flux_type = 'Jin2006'


### PR DESCRIPTION
Adds coupling of refractory DOC with sea ice humics
Also adds option to couple sea ice DOC with the macromolecules or the
MARBL DOC pool.
Corrects coupling of DON to conserve carbon



Changes are BFB without ocean/ice BGC and non-BFB with the ocean/ice BGC components active.
Code has run 25 years in ocean-ice coupled configuration on EC30to60E2r2 with no ice initial conditions. Analysis of years 19-21 is here: https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.jeffery/E3SMv2-CBGC/v2.MARBL/mpas_analysis/

New carbon conservation analysis members are still needed in the ocean and updates in the sea ice before we can confirm that the coupling conserves carbon.

Fixes #4637

[NML]
[non-BFB] 