### PR TITLE
Remove unused variables in MPAS-Ocean

### DIFF
--- a/components/mpas-framework/Makefile
+++ b/components/mpas-framework/Makefile
@@ -312,7 +312,7 @@ intel-mpi:
 	"CFLAGS_OPT = -O3" \
 	"CXXFLAGS_OPT = -O3" \
 	"LDFLAGS_OPT = -O3" \
-	"FFLAGS_DEBUG = -g -convert big_endian -free -CU -CB -check all -fpe0 -traceback" \
+	"FFLAGS_DEBUG = -g -convert big_endian -free -CU -CB -check all -fpe0 -traceback -Wunused-variable" \
 	"CFLAGS_DEBUG = -g -traceback" \
 	"CXXFLAGS_DEBUG = -g -traceback" \
 	"LDFLAGS_DEBUG = -g -fpe0 -traceback" \
@@ -339,7 +339,7 @@ gfortran:
 	"CFLAGS_OPT = -O3 -m64" \
 	"CXXFLAGS_OPT = -O3 -m64" \
 	"LDFLAGS_OPT = -O3 -m64" \
-	"FFLAGS_DEBUG = -g -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form -fbounds-check -fbacktrace -ffpe-trap=invalid,zero,overflow" \
+	"FFLAGS_DEBUG = -g -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form -fbounds-check -fbacktrace -ffpe-trap=invalid,zero,overflow -Wunused" \
 	"CFLAGS_DEBUG = -g -m64" \
 	"CXXFLAGS_DEBUG = -O3 -m64" \
 	"LDFLAGS_DEBUG = -g -m64" \

--- a/components/mpas-framework/Makefile
+++ b/components/mpas-framework/Makefile
@@ -312,7 +312,7 @@ intel-mpi:
 	"CFLAGS_OPT = -O3" \
 	"CXXFLAGS_OPT = -O3" \
 	"LDFLAGS_OPT = -O3" \
-	"FFLAGS_DEBUG = -g -convert big_endian -free -CU -CB -check all -fpe0 -traceback -Wunused-variable" \
+	"FFLAGS_DEBUG = -g -convert big_endian -free -CU -CB -check all -fpe0 -traceback" \
 	"CFLAGS_DEBUG = -g -traceback" \
 	"CXXFLAGS_DEBUG = -g -traceback" \
 	"LDFLAGS_DEBUG = -g -fpe0 -traceback" \
@@ -339,7 +339,7 @@ gfortran:
 	"CFLAGS_OPT = -O3 -m64" \
 	"CXXFLAGS_OPT = -O3 -m64" \
 	"LDFLAGS_OPT = -O3 -m64" \
-	"FFLAGS_DEBUG = -g -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form -fbounds-check -fbacktrace -ffpe-trap=invalid,zero,overflow -Wunused" \
+	"FFLAGS_DEBUG = -g -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form -fbounds-check -fbacktrace -ffpe-trap=invalid,zero,overflow" \
 	"CFLAGS_DEBUG = -g -m64" \
 	"CXXFLAGS_DEBUG = -O3 -m64" \
 	"LDFLAGS_DEBUG = -g -m64" \

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -2100,7 +2100,7 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_disable_vel_coriolis" type="logical"
 	category="debug" group="debug">
-Diables tendencies on the velocity field from the Coriolis force and momentum advection.
+Disables tendencies on the velocity field from the Coriolis force and momentum advection.
 
 Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1296,7 +1296,7 @@
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_disable_vel_coriolis" type="logical" default_value=".false." units="unitless"
-					description="Diables tendencies on the velocity field from the Coriolis force and momentum advection."
+					description="Disables tendencies on the velocity field from the Coriolis force and momentum advection."
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_disable_vel_pgrad" type="logical" default_value=".false." units="unitless"

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_global_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_global_stats.F
@@ -229,8 +229,7 @@ contains
       integer :: err_tmp
       integer :: nCellsGlobal, nEdgesGlobal, nVerticesGlobal, iTracer
       integer :: iEdge, variableIndex, nVariables, nSums, nMaxes, nMins
-      integer :: k, i, fileID
-      integer :: timeYYYY, timeMM, timeDD, timeH, timeM, timeS
+      integer :: i, fileID
       integer, pointer :: nVertLevels, nCellsSolve, nEdgesSolve, nVerticesSolve, num_activeTracers
 
       integer, parameter :: kMaxVariables = 1024 ! this must be a little more than double the number of variables to be reduced
@@ -240,7 +239,7 @@ contains
       type (MPAS_Time_type) :: xtime_timeType, simulationStartTime_timeType
       type (MPAS_TimeInterval_type) :: timeStep
 
-      real (kind=RKIND) :: localCFL, localSum, dt, currentVolume
+      real (kind=RKIND) :: localCFL, dt, currentVolume
       real (kind=RKIND), pointer :: volumeCellGlobal, volumeEdgeGlobal, CFLNumberGlobal, areaCellGlobal, &
                                     areaEdgeGlobal, areaTriangleGlobal, totalVolumeChange, netFreshwaterInput, &
                                     absoluteFreshWaterConservation, relativeFreshWaterConservation, &
@@ -264,7 +263,7 @@ contains
       real (kind=RKIND), dimension(:), pointer :: minGlobalStats,maxGlobalStats,sumGlobalStats, averages, rms, verticalSumMins, &
           verticalSumMaxes
       real (kind=RKIND), dimension(kMaxVariables) :: sumSquares, reductions, sums, mins, maxes
-      real (kind=RKIND), dimension(kMaxVariables) :: sums_tmp, sumSquares_tmp, mins_tmp, maxes_tmp, averages_tmp, &
+      real (kind=RKIND), dimension(kMaxVariables) :: sums_tmp, sumSquares_tmp, mins_tmp, maxes_tmp, &
              verticalSumMins_tmp, verticalSumMaxes_tmp
 
       real (kind=RKIND), dimension(:,:), allocatable :: enstrophy, normalizedAbsoluteVorticity, workArray
@@ -1488,7 +1487,7 @@ contains
       localVertSumMax
 
       integer :: elementIndex
-      real (kind=RKIND) :: colSum, colRMS, colSumAbs
+      real (kind=RKIND) :: colSum, colRMS
 
       localSum = 0.0_RKIND
       localRMS = 0.0_RKIND
@@ -1526,8 +1525,7 @@ contains
          localVertSumMax
 
       integer :: elementIndex
-      real (kind=RKIND) :: thicknessWeightedColSum, thicknessWeightedColRMS, thicknessWeightedColSumAbs
-      real (kind=RKIND), dimension(nVertLevels, nElements) :: hTimesField
+      real (kind=RKIND) :: thicknessWeightedColSum, thicknessWeightedColRMS
 
       localSum = 0.0_RKIND
       localRMS = 0.0_RKIND

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_lagrangian_particle_tracking_interpolations.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_lagrangian_particle_tracking_interpolations.F
@@ -235,7 +235,7 @@ module ocn_lagrangian_particle_tracking_interpolations
     real (kind=RKIND), dimension(:), allocatable :: lambda
     real (kind=RKIND), dimension(:,:), allocatable :: pointVertex
     real (kind=RKIND), dimension(3) :: pointInterp
-    real (kind=RKIND) :: xp,yp,zp , sumArea, kiteArea
+    real (kind=RKIND) :: sumArea, kiteArea
     logical, pointer :: is_periodic
     real(kind=RKIND), pointer :: x_period, y_period
 
@@ -358,7 +358,6 @@ module ocn_lagrangian_particle_tracking_interpolations
     real (kind=RKIND), dimension(:), allocatable :: lambda
     real (kind=RKIND), dimension(3) :: pointInterp
     real (kind=RKIND), dimension(:,:), allocatable :: pointVertex
-    real (kind=RKIND) :: xp,yp,zp
 
     ucReconstructX = 0.0_RKIND
     ucReconstructY = 0.0_RKIND

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_particle_list.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_particle_list.F
@@ -137,7 +137,7 @@ contains
 !> \author  Phillip Wolfram
 !> \date    07/01/2014
 !> \details
-!>  This routine builds and allocates particlces following initalization
+!>  This routine builds and allocates particles following initalization
 !
 !-----------------------------------------------------------------------
    subroutine mpas_particle_list_build_and_assign_particle_list(domain,err) !{{{

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_particle_list.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_particle_list.F
@@ -3456,7 +3456,7 @@ end subroutine allocate_list_particlelists !}}}
      integer :: MPI_TYPE
      type (mpas_list_of_particle_list_type), dimension(:), pointer :: listSend, listRecv
 
-     integer :: i, j, ii, numProcs, numFields, numRecv, numSends, numReals, numInts
+     integer :: i, j, ii, numProcs, numRecv, numSends, numReals, numInts
      integer, dimension(:), pointer :: recvRequestID, sendRequestID
      integer :: mpi_ierr
      type (mpas_pool_type), pointer :: lagrPartTrackPool

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_pointwise_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_pointwise_stats.F
@@ -134,7 +134,7 @@ contains
       logical :: fieldActive
 
       logical :: keepField
-      integer :: iConst, iDim, iDim2
+      integer :: iConst, iDim
 
       integer, pointer :: nPoints
 
@@ -833,8 +833,8 @@ contains
       type (block_type), pointer :: block
 
       integer, pointer :: nPoints, nCells
-      integer :: iPoint, i
-      integer, dimension(:), pointer :: pointCellGlobalID, pointCellLocalID, indexToPointCellLocalID
+      integer :: iPoint
+      integer, dimension(:), pointer :: pointCellLocalID
 
       character (len=*), parameter :: AMName = 'pointwiseStats'
 
@@ -845,7 +845,6 @@ contains
       real (kind=RKIND), dimension(:, :, :, :), pointer :: ptr4DReal1, ptr4DReal2
       real (kind=RKIND), dimension(:, :, :, :, :), pointer :: ptr5DReal1, ptr5DReal2
 
-      integer, pointer :: ptr0DInt1, ptr0DInt2
       integer, dimension(:), pointer :: ptr1DInt1, ptr1DInt2
       integer, dimension(:, :), pointer :: ptr2DInt1, ptr2DInt2
       integer, dimension(:, :, :), pointer :: ptr3DInt1, ptr3DInt2
@@ -855,7 +854,6 @@ contains
       type (mpas_pool_iterator_type) :: poolItr
       type (mpas_pool_field_info_type) :: fieldInfo
       integer :: nElements
-      integer, dimension(:), pointer :: arrShape
 
       real (kind=RKIND), dimension(:), pointer :: tempRealArrLocal, tempRealArrGlobal
       integer, dimension(:), pointer :: tempIntArrLocal, tempIntArrGlobal

--- a/components/mpas-ocean/src/shared/mpas_ocn_constants.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_constants.F
@@ -96,7 +96,6 @@ contains
    subroutine ocn_constants_init(configPool, packagePool)!{{{
        type (mpas_pool_type), pointer :: configPool
        type (mpas_pool_type), pointer :: packagePool
-       integer :: n
 
        real (kind=RKIND), pointer :: config_density0
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -1150,7 +1150,6 @@ contains
       real(kind=RKIND) :: coef, shearSquared, delU2, shearMean
       integer :: iCell, k, i, iEdge
       integer :: nCells
-      real(kind=RKIND) :: invAreaCell1
 
       !
       ! Brunt-Vaisala frequency (this has units of s^{-2})

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -7,7 +7,7 @@
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  ocn_diagnostics
+!  ocn_diagnostics_variables
 !
 !> \brief MPAS ocean diagnostics variable definitions
 !> \author Matt Turner

--- a/components/mpas-ocean/src/shared/mpas_ocn_effective_density_in_land_ice.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_effective_density_in_land_ice.F
@@ -112,7 +112,7 @@ contains
       real (kind=RKIND) :: weightSum
 
       integer :: iCell, cell2, i
-      integer, pointer :: nCells, nEdges
+      integer, pointer :: nCells
 
       integer, dimension(:,:), pointer :: cellsOnCell, cellMask
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_equation_of_state.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_equation_of_state.F
@@ -148,7 +148,7 @@ contains
       type (mpas_pool_type), pointer :: tracersPool
 
       integer, dimension(:), pointer :: maxLevelCell
-      integer :: iCell, k, nVertLevels, indexT, indexS
+      integer :: nVertLevels, indexT, indexS
       integer, pointer :: indexTptr, indexSptr
       integer :: timeLevel
 
@@ -297,7 +297,7 @@ contains
 
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
       integer, dimension(:), pointer :: maxLevelCell
-      integer :: iCell, k, nVertLevels, indexT, indexS
+      integer :: nVertLevels, indexT, indexS
       integer, pointer :: indexTptr, indexSptr
       integer :: timeLevel
 
@@ -536,7 +536,7 @@ contains
       logical, intent(in) :: inLandIceCavity !< Input: flag indicating if the freezing temperature is computed
                                              !         in land ice cavities or in open ocean
 
-      real (kind=RKIND), pointer :: coeff_S, coeff_p, coeff_pS, az1_liq
+      real (kind=RKIND), pointer :: coeff_S, coeff_pS, az1_liq
       real (kind=RKIND) :: coeff_mushy
 
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -126,18 +126,18 @@ contains
       real(kind=RKIND), dimension(:), pointer   :: areaCell, dcEdge, dvEdge, tridiagA, tridiagB, tridiagC, rightHandSide
       integer, dimension(:), pointer   :: minLevelEdgeBot, maxLevelEdgeTop, minLevelCell, maxLevelCell, nEdgesOnCell
       integer, dimension(:, :), pointer :: cellsOnEdge, edgesOnCell
-      integer                          :: i, k, iEdge, cell1, cell2, iCell, N, iter, iCellSelf, maxLocation
-      real(kind=RKIND)                 :: h1, h2, areaEdge, c, BruntVaisalaFreqTopEdge, rtmp
-      real(kind=RKIND)                 :: sumN2, countN2, maxN, kappaSum, ltSum
-      real(kind=RKIND)                 :: sumRi, RiTopOfEdge, zEdge, zMLD, sshEdge, sfcTaper
-      real(kind=RKIND) :: dcEdgeInv, drhoDx, drhoDT, drhoDS, dTdx, dSdx, BVFcent
+      integer                          :: i, k, iEdge, cell1, cell2, iCell, N, iCellSelf, maxLocation
+      real(kind=RKIND)                 :: h1, h2, areaEdge, BruntVaisalaFreqTopEdge, rtmp
+      real(kind=RKIND)                 :: sumN2, countN2, maxN, ltSum
+      real(kind=RKIND)                 :: sumRi, RiTopOfEdge, zEdge, zMLD, sfcTaper
+      real(kind=RKIND) :: dcEdgeInv, drhoDx, drhoDT, drhoDS, dTdx, dSdx
       real(kind=RKIND) :: slopeTaperUp, slopeTaperDown, sfcTaperUp, sfcTaperDown, invAreaCell
-      real(kind=RKIND) :: lt1, lt2, dzdxTopOfEdge, drhodz1, drhodz2, dTdz, dSdz
-      real(kind=RKIND) :: L, sigma, Lr, Length, L_rhines, shearEdgeInv
+      real(kind=RKIND) :: lt1, lt2
+      real(kind=RKIND) :: sigma, Lr, Length, L_rhines, shearEdgeInv
       real(kind=RKIND), dimension(:), allocatable :: dzTop, dTdzTop, dSdzTop, k33Norm
       real(kind=RKIND) :: c_Visbeck   ! baroclinic wave speed from Visbeck parameterization
       ! Dimensions
-      integer :: nsmooth, nCells, nEdges
+      integer :: nCells, nEdges
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray, nEdgesArray
 
@@ -874,7 +874,7 @@ contains
       real(kind=RKIND), pointer :: sphere_radius
       real(kind=RKIND), dimension(:), pointer   :: latEdge, betaEdge, fEdge, &
             gmResolutionTaper, gmBolusKappa
-      integer, dimension(:, :), pointer :: cellsOnEdge, edgesOncell
+      integer, dimension(:, :), pointer :: cellsOnEdge
 
       err = 0
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_init_routines.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_init_routines.F
@@ -99,11 +99,10 @@ contains
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: statePool, tracersPool
       type (mpas_pool_type), pointer :: forcingPool, scratchPool
-      integer :: i, iEdge, iCell, k
+      integer :: iEdge, iCell
       integer :: err1
 
       integer, dimension(:,:), pointer :: boundaryCellTmp
-      integer, dimension(:,:), pointer :: edgeSignOnCellTmp, edgeSignOnVertexTmp
       real (kind=RKIND), dimension(:,:), pointer :: layerThickness
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocity
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_mesh.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_mesh.F
@@ -919,7 +919,7 @@ contains
          meshPool                 ! mesh variables in MPAS pool structure
 
       ! temporary pointers for converting masks
-      integer i, k, n          ! loop indices
+      integer k, n          ! loop indices
       integer, dimension(:, :), pointer :: &
          edgeMaskTmp, &
          vertexMaskTmp, &
@@ -1409,7 +1409,7 @@ contains
       !-----------------------------------------------------------------
       ! Local variables
       !-----------------------------------------------------------------
-      integer :: iCell, iEdge, iVertex, i, j, k
+      integer :: iCell, iEdge, iVertex, i, j
 
       ! End preamble
       !-------------

--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
@@ -312,10 +312,8 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: iCell, nCells, nEdges
+      integer :: iCell, nCells
       integer, dimension(:), pointer :: nCellsArray
-
-      integer, dimension(:,:), pointer :: cellsOnEdge
 
       real (kind=RKIND), dimension(:), pointer :: evaporationFlux, snowFlux
       real (kind=RKIND), dimension(:), pointer :: seaIceFreshWaterFlux, icebergFreshWaterFlux, riverRunoffFlux, iceRunoffFlux

--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -423,8 +423,6 @@ contains
       !
       !-----------------------------------------------------------------
 
-      type (mpas_pool_type), pointer :: tracersPool
-
       integer :: iCell, nCells
       integer, dimension(:), pointer :: nCellsArray
 
@@ -811,11 +809,9 @@ contains
     !
     !-----------------------------------------------------------------
 
-    real (kind=RKIND) :: T0, transferVelocityRatio, Tlatent, a, b, c, eta, &
+    real (kind=RKIND) :: T0, transferVelocityRatio, Tlatent, a, b, c, &
                          dTf_dS
     integer :: iCell
-
-    logical :: coupled
 
     real (kind=RKIND), parameter :: minInterfaceSalinity = 0.001_RKIND
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
@@ -557,9 +557,6 @@ contains
          config_use_tracerGroup_idealAge_forcing,     &
          config_use_tracerGroup_ttd_forcing
 
-      real (kind=RKIND), pointer :: &
-         salinity_restoring_constant_piston_velocity
-
       real (kind=RKIND), dimension(:), pointer, contiguous :: &
          penetrativeTemperatureFlux, &! heat flux penetrating below sfc
          tracerGroupExponentialDecayRate ! exp decay rate for forcing

--- a/components/mpas-ocean/src/shared/mpas_ocn_thick_ale.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_thick_ale.F
@@ -109,14 +109,14 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: iCell, k, i, kMax, kMin
+      integer :: iCell, k, kMax, kMin
       integer, pointer :: nVertLevels
       integer :: nCells
       integer, dimension(:), pointer :: maxLevelCell
       integer, dimension(:), pointer :: minLevelCell
       integer, dimension(:), pointer :: nCellsArray
 
-      real (kind=RKIND) :: weightSum, thicknessSum, remainder, newThickness, thicknessWithRemainder
+      real (kind=RKIND) :: weightSum, thicknessSum, remainder, newThickness
       real (kind=RKIND), dimension(:), pointer :: vertCoordMovementWeights
       real (kind=RKIND), dimension(:), allocatable :: &
          prelim_ALE_thickness,   & !> ALE thickness at new time

--- a/components/mpas-ocean/src/shared/mpas_ocn_thick_hadv.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_thick_hadv.F
@@ -110,14 +110,14 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: iEdge, cell1, cell2, k, i, iCell, nCells
+      integer :: iEdge, k, i, iCell, nCells
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray
 
       integer, dimension(:), pointer :: minLevelEdgeBot, maxLevelEdgeTop, MaxLevelCell, nEdgesOnCell
       integer, dimension(:,:), pointer :: cellsOnEdge, edgesOnCell, edgeSignOnCell
 
-      real (kind=RKIND) :: flux, invAreaCell, invAreaCell1, invAreaCell2
+      real (kind=RKIND) :: flux, invAreaCell
       real (kind=RKIND), dimension(:), pointer :: dvEdge, areaCell
 
       !-----------------------------------------------------------------

--- a/components/mpas-ocean/src/shared/mpas_ocn_thick_surface_flux.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_thick_surface_flux.F
@@ -116,7 +116,6 @@ contains
       !-----------------------------------------------------------------
 
       integer :: iCell, k, nCells
-      integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray
       integer, dimension(:), pointer :: minLevelCell, maxLevelCell
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tidal_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tidal_forcing.F
@@ -201,19 +201,14 @@ contains
       integer :: iCell, k, nCells
       integer, dimension(:), pointer :: nCellsArray
       integer, pointer, dimension(:) :: minLevelCell, maxLevelCell
-      integer, pointer :: nVertLevels
-      real (kind=RKIND) :: dt
 
-      type (MPAS_time_type) :: currentTime
       real (kind=RKIND), pointer, dimension(:)     :: ssh
-      real (kind=RKIND), pointer, dimension(:,:)   :: zMid
       real (kind=RKIND), pointer, dimension(:,:)   :: layerThickness
 
       ! local variables
       real (kind=RKIND) :: totalDepth, tidalHeight
 
-      character (len=StrKIND), pointer :: simulationStartTime, xtime
-      type (MPAS_Time_type) :: startTime, xtime_timeType, simulationStartTime_timeType
+      character (len=StrKIND), pointer :: xtime
 
       if ( .not. tidalfluxOn ) return
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_time_varying_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_time_varying_forcing.F
@@ -332,7 +332,6 @@ contains
          windStressCoefficient, &
          rhoAir, &
          ramp, &
-         currentTime, &
          windStressCoefficientLimit
 
     integer, pointer :: &
@@ -483,8 +482,6 @@ contains
 !    character(len=StrKIND), pointer :: config_dt
 
     type (MPAS_timeInterval_type) :: timeStepESMF
-
-    character(len=StrKIND) :: timeStamp
 
     real (kind=RKIND) :: dtSim
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_CFC.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_CFC.F
@@ -148,7 +148,7 @@ contains
                                         CFC12FluxDiagnostics,  &
                                         CFCAuxiliary
 
-      integer :: numColumns, column, iCell, iTracer, iLevelSurface
+      integer :: numColumns, column, iCell, iLevelSurface
 
       real (kind=RKIND), dimension(:), pointer :: &
          pCFC11,   &

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_DMS.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_DMS.F
@@ -173,7 +173,7 @@ contains
       !-----------------------------------------------------------------
 
       ! source/sink wants cm instead of m
-      real (kind=RKIND) :: zTop, zBot, convertLengthScale = 100.0_RKIND
+      real (kind=RKIND) :: convertLengthScale = 100.0_RKIND
 
       integer :: iCell, iLevel, iTracer, numColumns, column, iLevelSurface
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_MacroMolecules.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_MacroMolecules.F
@@ -152,9 +152,9 @@ contains
 
       ! source/sink wants cm instead of m
 
-      real (kind=RKIND) :: zTop, zBot, convertLengthScale = 100.0_RKIND
+      real (kind=RKIND) :: convertLengthScale = 100.0_RKIND
 
-      integer :: iCell, iLevel, iTracer, numColumns, column
+      integer :: iCell, iLevel, numColumns, column
 
       call mpas_timer_start("MacroMolecules source-sink")
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_TTD.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_TTD.F
@@ -110,7 +110,7 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: iCell, iLevel, iTracer
+      integer :: iCell
 
       !move to ocean constants
       real (kind=RKIND), parameter :: c0 = 0.0_RKIND

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_mono.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_mono.F
@@ -101,7 +101,7 @@ module ocn_tracer_advection_mono
          i, iCell, iEdge, &! horz indices
          cell1, cell2,    &! neighbor cell indices
          nCells, nEdges,  &! numbers of cells or edges
-         k,k2,kmin, kmax, &! vert index variants
+         k,kmin, kmax, &! vert index variants
          kmin1, kmax1,    &! vert index variants
          iTracer,         &! tracer index
          numTracers        ! total number of tracers
@@ -115,7 +115,6 @@ module ocn_tracer_advection_mono
          flux,              &! flux temporary
          tracerWeight,      &! tracer weighting temporary
          invAreaCell1,      &! inverse cell area
-         invAreaCell2,      &! inverse cell area
          coef1, coef3        ! temporary coefficients
 
       real (kind=RKIND), dimension(:), allocatable :: &

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_shared.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_shared.F
@@ -361,7 +361,7 @@ module ocn_tracer_advection_shared
          polynomial_order = 2  ! option for polynomial order, forced to 2
 
       integer :: &
-         i, j, k, n,   &! loop counters
+         i, j, n,   &! loop counters
          ip1, ip2,     &! temps for i+1, i+2
          iCell, iEdge, &! loop indices for cell, edge loops
          ma, na, cell_add, mw

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_ecosys.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_ecosys.F
@@ -781,7 +781,7 @@ contains
 
       real (kind=RKIND) :: zTop, zBot
 
-      integer :: iCell, iLevel, iTracer, numColumns, column, autotroph, n
+      integer :: iCell, iLevel, numColumns, column, autotroph, n
 
       err = 0
 
@@ -1697,7 +1697,7 @@ contains
       type (mpas_pool_type), pointer :: ecosysAuxiliary,  &  ! additional forcing fields
                                         ecosysSeaIceCoupling
 
-      integer :: numColumns, column, iCell, iTracer, iLevelSurface, n
+      integer :: numColumns, column, iCell, iLevelSurface, n
 
 ! input flux components in forcing pool
       real (kind=RKIND), dimension(:), pointer :: &
@@ -2162,7 +2162,7 @@ contains
          riverFluzDOC
 
       ! scalars
-      integer :: nTracers, numColumnsMax, iLevel, n, marbl_actual_tracer_cnt
+      integer :: nTracers, numColumnsMax, iLevel, n
 
       ! scalar pointers
       integer, pointer :: nVertLevels, index_dummy, nCellsSolve

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del2.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del2.F
@@ -116,7 +116,6 @@ contains
 
       integer :: iCell, iEdge, cell1, cell2
       integer :: i, k, iTracer, num_tracers, nCells
-      integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray
 
       integer, dimension(:), pointer :: minLevelEdgeBot, maxLevelEdgeTop, nEdgesOnCell

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del4.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del4.F
@@ -115,7 +115,7 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: iEdge, num_tracers, nCells, nEdges
+      integer :: iEdge, num_tracers, nCells
       integer :: iTracer, k, iCell, cell1, cell2, i
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray, nEdgesArray
@@ -123,7 +123,7 @@ contains
       integer, dimension(:), pointer :: minLevelEdgeBot, maxLevelEdgeTop, minLevelCell, maxLevelCell, nEdgesOnCell
       integer, dimension(:,:), pointer :: edgeMask, cellsOnEdge, edgesOnCell, edgeSignOnCell
 
-      real (kind=RKIND) :: invAreaCell1, invAreaCell2, tracer_turb_flux, flux, invdcEdge, r_tmp1, r_tmp2
+      real (kind=RKIND) :: invAreaCell1, tracer_turb_flux, flux, invdcEdge, r_tmp1, r_tmp2
 
       real (kind=RKIND), dimension(:), pointer :: dcEdge, dvEdge, areaCell, meshScalingDel4
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -129,15 +129,15 @@ contains
       !-----------------------------------------------------------------
 
       integer :: iCell, iEdge, cell1, cell2, iCellSelf
-      integer :: i, k, iTr, nTracers, nCells, nEdges, km1, kp1, nCellsP1
+      integer :: i, k, iTr, nTracers, nCells, nEdges, nCellsP1
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray, nEdgesArray
 
       integer, dimension(:), pointer :: minLevelEdgeBot, maxLevelEdgeTop, nEdgesOnCell, minLevelCell, maxLevelCell
       integer, dimension(:, :), pointer :: cellsOnEdge, edgesOnCell, edgeSignOnCell, cellsOnCell
 
-      real(kind=RKIND) :: tempTracer, invAreaCell1, invAreaCell2, invAreaCell, areaEdge
-      real(kind=RKIND) :: flux, flux_term1, flux_term2, flux_term3, dTracerDx, coef
+      real(kind=RKIND) :: tempTracer, invAreaCell
+      real(kind=RKIND) :: flux, flux_term2, flux_term3, dTracerDx, coef
       real(kind=RKIND) :: r_tmp, tracer_turb_flux, kappaRediEdgeVal
       real(kind=RKIND), dimension(:), pointer :: areaCell, dvEdge, dcEdge
       real(kind=RKIND), dimension(:), allocatable :: minimumVal
@@ -478,7 +478,7 @@ contains
       integer, dimension(:,:), pointer :: cellsOnEdge
 
       integer :: k, iEdge
-      integer, pointer :: nVertLevels, nEdges
+      integer, pointer :: nEdges
 
       err = 0
 
@@ -496,7 +496,6 @@ contains
          call mpas_pool_get_subpool(block%structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block%structs, 'forcing', forcingPool)
          call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-         call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
          call mpas_pool_get_array(diagnosticsPool, 'RediKappa', RediKappa)
          call mpas_pool_get_array(forcingPool, 'RediKappaData', RediKappaData)
          call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_short_wave_absorption_jerlov.F
@@ -244,7 +244,6 @@ contains
 !-----------------------------------------------------------------------
 
 !
-      integer :: k, nVertLevels
       integer,  parameter :: num_water_types = 5  ! max number of different water types
 
       ! I don't understand what the previous two lines are for.  They appear unnecessary

--- a/components/mpas-ocean/src/shared/mpas_ocn_transport_tests.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_transport_tests.F
@@ -109,7 +109,6 @@ module ocn_transport_tests
                                       forcingPool, &
                                       tracersPool
     integer, pointer :: nVertLevels, &
-                        nVertLevelsP1,&
                         nCellsSolve, &
                         nEdgesSolve, &
                         nEdge, &
@@ -131,8 +130,7 @@ module ocn_transport_tests
                                                 fEdge, &
                                                 fVertex, &
                                                 xCell, &
-                                                yCell, &
-                                                interfaceLocations
+                                                yCell
     real (kind=RKIND), dimension(:,:), pointer :: layerThickness, &
                                                   restingThickness, &
                                                   normalVelocity
@@ -143,8 +141,7 @@ module ocn_transport_tests
     integer :: iCell, &
                iEdge, &
                iVertex, &
-               k, &
-               kML
+               k
 
     real (kind=RKIND) :: vs
 
@@ -614,7 +611,7 @@ subroutine ocn_transport_test_velocity(meshPool, days_since_start, dt, normalVel
 
   pure function great_circle_dist_ll(lon1, lat1, lon2, lat2, radius) result(dist)
     real(RKIND), intent(in) :: lon1, lat1, lon2, lat2, radius
-    real(RKIND) :: dist, xA, yA, zA, xB, yB, zB, cp1, cp2, cp3, cpnorm, dotprod
+    real(RKIND) :: dist, xA, yA, zA, xB, yB, zB
     call lonlat2xyz(lon1, lat1, xA, yA, zA)
     call lonlat2xyz(lon2, lat2, xB, yB, zB)
     dist = radius*great_circle_dist_xyz(xA, yA, zA, xB, yB, zB)

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_pressure_grad.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_pressure_grad.F
@@ -146,7 +146,7 @@ contains
       !-----------------------------------------------------------------
 
       integer ::           &
-         iEdge, iCell, k,  &! loop indices for edge, cell, vertical loops
+         iEdge, k,  &! loop indices for edge, cell, vertical loops
          cell1, cell2,     &! neighbor cell indices across edge
          kMin, kMax         ! shallowest and deepest active layer
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -1055,16 +1055,15 @@ contains
       integer, dimension(:), pointer :: nCellsArray, nEdgesArray
       real (kind=RKIND), dimension(:), pointer :: bottomDrag, ssh, bottomDepth   ! needed for depth-variable computation
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, layerThickness
-      real (kind=RKIND), dimension(:,:), pointer :: nonLocalSurfaceTracerFlux, tracerGroupSurfaceFlux
+      real (kind=RKIND), dimension(:,:), pointer :: tracerGroupSurfaceFlux
       real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroup
       real (kind=RKIND), dimension(:,:,:), allocatable :: nonLocalFluxTend
-      integer, dimension(:), pointer :: maxLevelCell, minLevelCell, maxLevelEdgeTop, minLevelEdgeTop, minLevelEdgeBot
+      integer, dimension(:), pointer :: maxLevelEdgeTop, minLevelEdgeTop, minLevelEdgeBot
       integer, dimension(:,:), pointer :: cellsOnEdge
 
       type (mpas_pool_iterator_type) :: groupItr
 
       character (len=StrKIND) :: modifiedGroupName
-      integer, pointer :: indexTempFlux, indexSaltFlux, nVertLevels
       err = 0
 
       call mpas_timer_start('vmix imp')
@@ -1082,15 +1081,12 @@ contains
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
       call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
 
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'minLevelCell', maxLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'minLevelEdgeTop', minLevelEdgeTop)
       call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
 
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
       call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
@@ -151,15 +151,15 @@ contains
 
       integer, dimension(:,:), pointer :: edgesOnCell, cellsOnEdge, cellsOnCell, cellMask
 
-      integer :: k, i, iCell, jCell, iNeighbor, iter, timeLevel, kIndexOBL, kav, iEdge, nCells
+      integer :: k, i, iCell, iNeighbor, timeLevel, kIndexOBL, kav, iEdge, nCells
       integer :: edgeCount, nEdges, topIndex, nsmooth, kpp_stage
       integer, pointer :: nVertLevels, nVertLevelsP1
       integer, dimension(:), pointer :: nCellsArray
       integer, dimension(:), allocatable :: surfaceAverageIndex
 
-      real (kind=RKIND) :: x, r, layerSum, bulkRichardsonNumberStop, sfc_layer_depth
+      real (kind=RKIND) :: x, bulkRichardsonNumberStop, sfc_layer_depth
       real (kind=RKIND) :: normalVelocityAv, delU2, areaSum, blTemp
-      real (kind=RKIND) :: sigma, turbulentScalarVelocityScalePoint
+      real (kind=RKIND) :: sigma
       real (kind=RKIND), dimension(:), allocatable :: Nsqr_iface, turbulentScalarVelocityScale, &
                                                       deltaVelocitySquared, normalVelocitySum, &
                                                       potentialDensitySum, RiTemp,              &
@@ -833,7 +833,6 @@ contains
       integer, intent(out) :: err !< Output: error flag
 
       integer, pointer :: nVertLevels
-      type (block_type), pointer :: block
 
       !
       ! assume no errors during initialization and set to 1 when error is encountered


### PR DESCRIPTION
This is simply clean-up. I removed variables that created warnings when using the gnu `-Wunused` flag. It is better for performance and clarity to remove unused variables. In addition, E3SM build logs include unused variable warnings, so this cleans that up a bit. I also fixed a few typos on comments.

[BFB]