### PR TITLE
fix component namelist creation bugs when NINST>1

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -4772,7 +4772,7 @@ sub check_input_files {
 
     my $fh;
     if (defined $inputdata_rootdir) {
-	open $fh, '>', $outfile or die "check_input_files: error opening $outfile: $!";
+	open $fh, '>>', $outfile or die "check_input_files: error opening $outfile: $!";
     }
 
     # Look through all namelist groups

--- a/components/eam/cime_config/buildnml
+++ b/components/eam/cime_config/buildnml
@@ -202,8 +202,9 @@ def buildnml(case, caseroot, compname):
         # call build-namelist
         # -----------------------------------------------------
 
-        if os.path.exists(os.path.join(casebuild, "eam.input_data_list")):
-            os.remove(os.path.join(casebuild, "eam.input_data_list"))
+        if inst_counter ==1:
+           if os.path.exists(os.path.join(casebuild, "eam.input_data_list")):
+              os.remove(os.path.join(casebuild, "eam.input_data_list"))
 
         cam_buildnml_cmd =  os.path.join(srcroot, "components/eam/bld/build-namelist")
         cam_buildnml_cmd += " -infile {}/cesm_namelist".format(eamconf_dir)

--- a/components/elm/cime_config/buildnml
+++ b/components/elm/cime_config/buildnml
@@ -138,8 +138,9 @@ def buildnml(case, caseroot, compname):
         # create elmconf/namelist
         # -----------------------------------------------------
 
-        if os.path.exists("{}/Buildconf/elm.input_data_list".format(caseroot)):
-            os.remove("{}/Buildconf/elm.input_data_list".format(caseroot))
+        if inst_counter ==1:
+            if os.path.exists("{}/Buildconf/elm.input_data_list".format(caseroot)):
+                os.remove("{}/Buildconf/elm.input_data_list".format(caseroot))
 
         elmicfile = ""
         elm_startfile = ""

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -40,7 +40,7 @@ def buildnml(case, caseroot, compname):
     #ninst_ice       = case.get_value("NINST_ICE")
     ninst_ice        = 1 # Change if you want multiple instances... though this isn't coded yet.
     ninst_ice_real   = case.get_value("NINST_ICE")
-    ntasks_ice       = case.get_value("NTASKS_ICE")
+    ntasks_ice       = case.get_value("NTASKS_PER_INST_ICE")
     rundir           = case.get_value("RUNDIR")
     run_type         = case.get_value("RUN_TYPE")
     run_refcase      = case.get_value("RUN_REFCASE")


### PR DESCRIPTION
A few bug fixes when running with NINST>1, as is done in the E3SM nbfb test suite

MPAS sea ice component should use NTASKS_PER_INST_ICE instead of NTASKS_ICE when determining which partition file to use

Ensure ATM and LND put the initial conditions from all ensemble members into the inputdata file list 

Similar fixes should probably be applied to the MPAS ocean (NTASKS_PER_INST_OCN) and ensemble member inputdata parsing for both MPAS ocean and ice.  Not done in this PR since we currently dont use this capability.  

fixes #4648, #4645

[BFB]