### PR TITLE
Use F2010-CICE for extra coverage tests for ena and twp rrm

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -182,8 +182,8 @@ _TESTS = {
     "e3sm_extra_coverage" : {
         "inherit" : ("e3sm_atm_extra_coverage", "e3sm_ocnice_extra_coverage"),
         "tests"   : (
-            "SMS_D_Ln5.enax4v1_enax4v1.F2010",
-            "SMS_D_Ln5.twpx4v1_twpx4v1.F2010",
+            "SMS_D_Ln5.enax4v1_enax4v1.F2010-CICE",
+            "SMS_D_Ln5.twpx4v1_twpx4v1.F2010-CICE",
             )
         },
 


### PR DESCRIPTION
F2010 is being used in extra coverage test suite for enax4v1 and
twpx4v1, and the tests failed to proceed.  Change to use compset
F2010-CICE as no mpas mesh has been configured to work with these
two atm RRM meshes.

[BFB]