### PR TITLE
Updates carbon budget in ELM

### DIFF
--- a/components/elm/src/biogeochem/CNPBudgetMod.F90
+++ b/components/elm/src/biogeochem/CNPBudgetMod.F90
@@ -625,7 +625,7 @@ contains
          end_totprodc              => grc_cs%end_totprodc          , & ! Input: [real(r8) (:)] (gC/m2) total column wood product carbon
          end_ctrunc                => grc_cs%end_ctrunc            , & ! Input: [real(r8) (:)] (gC/m2) total column truncation carbon sink
          end_cropseedc_deficit     => grc_cs%end_cropseedc_deficit , & ! Input: [real(r8) (:)] (gC/m2) column carbon pool for seeding new growth
-         errcb                     => grc_cs%errcb                 , & ! Input: [real(r8) (:)] (gC/m^2/s)total SOM C loss by erosion
+         errcb                     => grc_cs%errcb                 , & ! Input: [real(r8) (:)] (gC/m^2) carbon mass balance error
          gpp                       => grc_cf%gpp                   , & ! Input: [real(r8) (:)] (gC/m2/s) gross primary production
          er                        => grc_cf%er                    , & ! Input: [real(r8) (:)] (gC/m2/s) total ecosystem respiration, autotrophic + heterotrophic
          fire_closs                => grc_cf%fire_closs            , & ! Input: [real(r8) (:)] (gC/m2/s) total column-level fire C loss

--- a/components/elm/src/biogeochem/CNPBudgetMod.F90
+++ b/components/elm/src/biogeochem/CNPBudgetMod.F90
@@ -387,21 +387,29 @@ contains
              budg_fluxL(:,ip)  = 0.0_r8
              budg_fluxG(:,ip)  = 0.0_r8
              budg_fluxN(:,ip)  = 0.0_r8
+             budg_stateL(:,ip) = 0.0_r8
+             budg_stateG(:,ip) = 0.0_r8
           endif
           if (ip==p_day .and. sec==0) then
              budg_fluxL(:,ip)  = 0.0_r8
              budg_fluxG(:,ip)  = 0.0_r8
              budg_fluxN(:,ip)  = 0.0_r8
+             budg_stateL(:,ip) = 0.0_r8
+             budg_stateG(:,ip) = 0.0_r8
           endif
           if (ip==p_mon .and. day==1 .and. sec==0) then
              budg_fluxL(:,ip)  = 0.0_r8
              budg_fluxG(:,ip)  = 0.0_r8
              budg_fluxN(:,ip)  = 0.0_r8
+             budg_stateL(:,ip) = 0.0_r8
+             budg_stateG(:,ip) = 0.0_r8
           endif
           if (ip==p_ann .and. mon==1 .and. day==1 .and. sec==0) then
              budg_fluxL(:,ip)  = 0.0_r8
              budg_fluxG(:,ip)  = 0.0_r8
              budg_fluxN(:,ip)  = 0.0_r8
+             budg_stateL(:,ip) = 0.0_r8
+             budg_stateG(:,ip) = 0.0_r8
           endif
        enddo
 

--- a/components/elm/src/biogeochem/EcosystemBalanceCheckMod.F90
+++ b/components/elm/src/biogeochem/EcosystemBalanceCheckMod.F90
@@ -885,7 +885,7 @@ contains
          end_totprodc              => grc_cs%end_totprodc          , & ! Output: [real(r8) (:) ] (gC/m2) total column wood product carbon
          end_ctrunc                => grc_cs%end_ctrunc            , & ! Output: [real(r8) (:) ] (gC/m2) total column truncation carbon sink
          end_cropseedc_deficit     => grc_cs%end_cropseedc_deficit , & ! Output: [real(r8) (:) ] (gC/m2) column carbon pool for seeding new growth
-         grc_errcb                 => grc_cs%errcb                 , & ! Output: [real(r8) (:) ] (gC/m^2/s)total SOM C loss by erosion
+         grc_errcb                 => grc_cs%errcb                 , & ! Output: [real(r8) (:) ] carbon balance error for the timestep (gC/m**2)
          grc_dwt_conv_cflux        => grc_cf%dwt_conv_cflux        , & !Input: [real(r8) (:) ]  carbon mass, beginning of time step (gC/m**2)
          grc_dwt_seedc_to_leaf     => grc_cf%dwt_seedc_to_leaf     , & !Input: [real(r8) (:) ]  carbon mass, beginning of time step (gC/m**2)
          grc_dwt_seedc_to_deadstem => grc_cf%dwt_seedc_to_deadstem , & !Input: [real(r8) (:) ]  carbon mass, beginning of time step (gC/m**2)

--- a/components/elm/src/data_types/GridcellDataType.F90
+++ b/components/elm/src/data_types/GridcellDataType.F90
@@ -614,6 +614,10 @@ contains
          avgflag='I', long_name='total carbon storage at the end of a month', &
          ptr_lnd=this%tcs_month_end)
 
+    call hist_addfld1d (fname='CMASS_BALANCE_ERROR',  units='gC/m^2',  &
+         avgflag='A', long_name='Gridcell carbon mass balance error', &
+         ptr_lnd=this%errcb)
+
     !-----------------------------------------------------------------------
     ! set cold-start initial values for select members of grc_cs
     !-----------------------------------------------------------------------


### PR DESCRIPTION
- Resets the carbon states to zero at the beginning of the integration time
- Adds grid-level carbon balance error to the history file
- Changes the absolute error threshold to relative error threshold

[BFB]