### PR TITLE
Time step size definition in si_init

### DIFF
--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -743,8 +743,9 @@ module ocn_time_integration_si
          !
          ! The split-implicit barotropic mode solver
          !    - uses the preconditioned communication-avoiding
-         !      (single-reduction) BiCGStab method 
-         !      (Cool and Vanroose, 2017) as a linear iterative solver
+         !      (single-global synchronization) BiCGStab method 
+         !      as a linear iterative solver
+         !      (Kang et al., in preparation)
          !                    
          !    - solves the nonlinear barotropic system but deals with
          !      it as the linear system by introducing the outer and                     
@@ -766,7 +767,7 @@ module ocn_time_integration_si
          !                     obtain SSH at time (n+1) 
          !          Stage 2.7. The barotropic velocity update
          !
-         !    - requires 'config_n_ts_iter=2'
+         !    - recommends to set 'config_n_ts_iter=2'
          !         :Time line of variables
          !
          !          Start of large outer time step iteration loop
@@ -787,7 +788,7 @@ module ocn_time_integration_si
          !                SSH and BtrVel at time (n+1)
          !
          !
-         ! Reference: Kang et al. (2021): A scalable split-implicit
+         ! Reference: Kang et al. (2021): A scalable semi-implicit 
          !            barotropic mode solver for the MPAS-Ocean, JAMES
          !
          !
@@ -3441,10 +3442,7 @@ module ocn_time_integration_si
       alpha2= 1.0_RKIND - alpha1
 
       ! Get time step size to compute coefficients for the SI solver
-      read(config_dt(1:2),*) ihh
-      read(config_dt(4:5),*) imm
-      read(config_dt(7:8),*) iss
-      dt_si = ihh * 3600.0_RKIND + imm * 60.0_RKIND + iss
+      dt_si = dt
 
       ! Determination of nSiLargeIter (the barotropic system 
       !                                large iteration loop)
@@ -3580,6 +3578,7 @@ module ocn_time_integration_si
 
          nPrecVec = nCellsHalo2nd ! length of preconditioning vector
          nPrecMatPacked = (nPrecVec*(nPrecVec+1))/2
+                                  ! Packed size of preconditiong matrix
 
          allocate(prec_ivmat(1:nPrecMatPacked))
                   prec_ivmat(:) = 0.0_RKIND
@@ -3640,8 +3639,9 @@ module ocn_time_integration_si
       elseif ( trim(config_btr_si_preconditioner) == &
                                         'block_jacobi' ) then
 
-         nPrecVec = nCells ! length of preconditioning vector
+         nPrecVec = nCells        ! length of preconditioning vector
          nPrecMatPacked = (nPrecVec*(nPrecVec+1))/2
+                                  ! Packed size of preconditiong matrix
 
          allocate(prec_ivmat(1:nPrecMatPacked))
                   prec_ivmat(:) = 0.0_RKIND


### PR DESCRIPTION
This PR changes time step size definition (parsed from config_dt -> passing in 'dt' itself) in si_init routine and revises some comments.

This PR passed `PEM_Ln9_D.T62_oQU240.GMPAS-IAF.cori-knl_gnu` with `config_btr_si_partition_match_mode=.true.` except `COMPARE_base_modpes`. Although the PR modifies only the semi-implicit code (`config_time_integrator='split_implicit'`), the split-explicit code (`config_time_integrator='split_explicit'`) also does not pass `COMPARE_base_modpes`. It seems there is a problem in other portions of E3SM.

[BFB]