### PR TITLE
Change NTASKS_ to NTASKS_PER_INST_ for mpaso and mali

### DIFF
--- a/components/mpas-albany-landice/cime_config/buildnml
+++ b/components/mpas-albany-landice/cime_config/buildnml
@@ -33,7 +33,7 @@ def buildnml(case, caseroot, compname):
     #ninst_glc        = case.get_value("NINST_GLC")
     ninst_glc = 1 # Change if you want multiple instances... though this isn't coded yet.
     ninst_glc_real    = case.get_value("NINST_GLC")
-    ntasks_glc        = case.get_value("NTASKS_GLC")
+    ntasks_glc        = case.get_value("NTASKS_PER_INST_GLC")
     rundir            = case.get_value("RUNDIR")
     run_type          = case.get_value("RUN_TYPE")
     run_refcase       = case.get_value("RUN_REFCASE")

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -43,7 +43,7 @@ def buildnml(case, caseroot, compname):
     ninst_ocn         = 1 # Change if you want multiple instances... though this isn't coded yet.
     ninst_ocn_real    = case.get_value("NINST_OCN")
     nthrds_ocn        = case.get_value("NTHRDS_OCN")
-    ntasks_ocn        = case.get_value("NTASKS_OCN")
+    ntasks_ocn        = case.get_value("NTASKS_PER_INST_OCN")
     rundir            = case.get_value("RUNDIR")
     run_type          = case.get_value("RUN_TYPE")
     run_refcase       = case.get_value("RUN_REFCASE")


### PR DESCRIPTION
Modifies the buildnml scripts for mpas-ocean and mpas-albany-landice to use values for NTASKS_PER_INST_ instead of NTASKS_, to be consistent with changes to mpas-seaice made in [PR #4654](https://github.com/E3SM-Project/E3SM/pull/4654).

[BFB]