### PR TITLE
remove O3LNZ from LINOZv2

### DIFF
--- a/components/eam/chem_proc/inputs/pp_chemUCI_mam4_resus_mom_soag_tag.in
+++ b/components/eam/chem_proc/inputs/pp_chemUCI_mam4_resus_mom_soag_tag.in
@@ -1,3 +1,4 @@
+
 Comments
      "last touch 20200326 - QT"
      "Modified by Juno Hsu and Qi Tang - 4/9/2020"
@@ -39,7 +40,6 @@ SPECIES
 * MVKMACR = sum of MVK -> CH2CHCOCH3 + MACR -> CH2CCH3CHO
   MVKO2 -> C4H7O4
   E90 -> O3
-  O3LNZ -> O3
 
 
 * MAM4 species
@@ -94,7 +94,7 @@ Solution Classes
 
  Explicit
    CO, C2H6, C3H8, CH3COCH3
-   E90, O3LNZ
+   E90
    DMS, SO2, H2SO4, SOAG
    so4_a1,  so4_a2,  so4_a3
    pom_a1,           pom_a3,  pom_a4

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -1055,7 +1055,8 @@ contains
     xsfc(:,:)=0    
     if ( do_lin_strat_chem ) then
        if (uci1_ndx <= 0) then
-          if(linoz_v2) call linv2_strat_chem_solve( ncol, lchnk, vmr,              col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev )                  
+          !if(linoz_v2) call linv2_strat_chem_solve( ncol, lchnk, vmr,              col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev )                  
+          if(linoz_v2) call linv2_strat_chem_solve( ncol, lchnk, vmr,              col_dens(:,:,1), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry, 'CHEM' )                  
           if(linoz_v3) then
                        call h2o_to_vmr(q(:,:,1), qvmr, mbar, ncol )  
                        !call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry, 'LNZ')
@@ -1063,7 +1064,8 @@ contains
                        call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,1), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry, 'CHEM')
           endif
         else
-          if(linoz_v2) call linv2_strat_chem_solve( ncol, lchnk, vmr,              col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev, tropFlag=tropFlag )                  
+          !if(linoz_v2) call linv2_strat_chem_solve( ncol, lchnk, vmr,              col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev, tropFlag=tropFlag )                  
+          if(linoz_v2) call linv2_strat_chem_solve( ncol, lchnk, vmr,              col_dens(:,:,1), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry, 'CHEM', tropFlag=tropFlag )                  
           if(linoz_v3) then
                        call h2o_to_vmr(q(:,:,1), qvmr, mbar, ncol )  
                        !call linv3_strat_chem_solve( ncol, lchnk, vmr, qvmr, xsfc,  col_dens(:,:,3), tfld, zen_angle, pmid, delt, rlats, troplev, pdeldry, 'LNZ', tropFlag=tropFlag)


### PR DESCRIPTION
This is the parallel change to Linoz v3 to remove the tracer O3LNZ.

(cherry picked from commit da6ef40182cdec8c1e7892471eab0e2b9d77164e)