### PR TITLE
For gnu compiler version 9 and above, adjust compiler flag for one mpas source

### DIFF
--- a/cime_config/machines/Depends.gnu.cmake
+++ b/cime_config/machines/Depends.gnu.cmake
@@ -4,8 +4,11 @@ list(APPEND MPAS_ICE_SHORTWAVE
   ${CMAKE_BINARY_DIR}/core_seaice/column/ice_shortwave.f90
 )
 
+# For optimized GNU builds that use v9 or higher, remove an optimization on one file
 if (NOT DEBUG)
-  foreach(ITEM IN LISTS MPAS_ICE_SHORTWAVE)
-    e3sm_add_flags("${ITEM}" "-fno-tree-pta") # avoids an error that shows up in solver with gnu9 and higher
-  endforeach()
+  if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 9)
+    foreach(ITEM IN LISTS MPAS_ICE_SHORTWAVE)
+      e3sm_add_flags("${ITEM}" "-fno-tree-pta") # avoids an error that shows up in solver with gnu9 and higher
+    endforeach()
+  endif()
 endif()

--- a/cime_config/machines/Depends.gnu.cmake
+++ b/cime_config/machines/Depends.gnu.cmake
@@ -1,1 +1,11 @@
 e3sm_add_flags("eam/src/dynamics/fv/geopk.F90" "-fcray-pointer")
+
+list(APPEND MPAS_ICE_SHORTWAVE
+  ${CMAKE_BINARY_DIR}/core_seaice/column/ice_shortwave.f90
+)
+
+if (NOT DEBUG)
+  foreach(ITEM IN LISTS MPAS_ICE_SHORTWAVE)
+    e3sm_add_flags("${ITEM}" "-fno-tree-pta") # avoids an error that shows up in solver with gnu9 and higher
+  endforeach()
+endif()


### PR DESCRIPTION
As a work-around for a runtime error with certain tests fail (with `ERROR:  picard convergence failed!`), slightly adjusting the optimization flags for one source file (`mpas-seaice/src/column/ice_shortwave.F90`) seems to work.
This only happens with GNU compiler version 9 and above, and only with non-DEBUG builds -- this PR should only affect such.

We simply leave the `-O2` or `-O1` setting (depending on the machine defaults) and then add: `-fno-tree-pta`, which turns off "points-to" analysis on tress (from man page: "Perform function-local points-to analysis on trees. This flag is enabled by default at -O and higher.")

The test I mostly used to debug this issue was some form of `SMS.T62_oQU120_ais20.MPAS_LISIO_TEST`

Using `SMS_P128x2.ne30pg2_ne30pg2.F2010-CICE`, I did not see any performance differences on Perlmutter.

Fixes https://github.com/E3SM-Project/E3SM/issues/4584