### PR TITLE
Change ERP_Ld3.ne4_oQU240.F2010 test to ERP_Ln18.ne4_oQU240.F2010

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -49,7 +49,7 @@ _TESTS = {
     "e3sm_atm_developer" : {
         "inherit" : ("eam_theta_pg2"),
         "tests"   : (
-            "ERP_Ld3.ne4_oQU240.F2010",
+            "ERP_Ln18.ne4_oQU240.F2010",
             "SMS_Ln9.ne4_oQU240.F2010.eam-outfrq9s",
             "SMS.ne4_oQU240.F2010.eam-cosplite",
             "SMS_R_Ld5.ne4_ne4.FSCM5A97.eam-scm",


### PR DESCRIPTION
The ERP_Ld3.ne4_oQU240.F2010 test in the suite currently fails on mappy due to the memory leak test and is apparently related to the writing of restart files and not an actual memory leak. Changing the test to run 18 timesteps instead of 3 days avoids the restart issue and allows the test to pass.

Fixes #4546 
[BFB]