### PR TITLE
Add test for new ELM and MOSART features

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -42,7 +42,8 @@ _TESTS = {
             "ERS.MOS_USRDAT.RMOSGPCC.mosart-mos_usrdat",
             "SMS.MOS_USRDAT.RMOSGPCC.mosart-unstructure",
             "SMS.r05_r05.IELM.elm-topounit",
-            "ERS.ELM_USRDAT.I1850ELM.elm-usrdat"
+            "ERS.ELM_USRDAT.I1850ELM.elm-usrdat",
+            "ERS.r05_05.IELM.elm-V2_ELM_MOSART_features"
             )
         },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -43,7 +43,7 @@ _TESTS = {
             "SMS.MOS_USRDAT.RMOSGPCC.mosart-unstructure",
             "SMS.r05_r05.IELM.elm-topounit",
             "ERS.ELM_USRDAT.I1850ELM.elm-usrdat",
-            "ERS.r05_05.IELM.elm-V2_ELM_MOSART_features"
+            "ERS.r05_r05.IELM.elm-V2_ELM_MOSART_features"
             )
         },
 

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/V2_ELM_MOSART_features/shell_commands
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/V2_ELM_MOSART_features/shell_commands
@@ -1,0 +1,2 @@
+#!/bin/bash
+./xmlchange --id ELM_BLDNML_OPTS --val "-bgc cn -irrig .true."

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/V2_ELM_MOSART_features/user_nl_elm
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/V2_ELM_MOSART_features/user_nl_elm
@@ -1,0 +1,10 @@
+ fsurdat = '$DIN_LOC_ROOT/lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr1850_c211019.nc'
+ flanduse_timeseries = '$DIN_LOC_ROOT/lnd/clm2/surfdata_map/landuse.timeseries_0.5x0.5_HIST_simyr1850-2015_c211019.nc'
+ do_transient_pfts = .true
+ do_transient_crops = .true.
+ irrigate = .true.
+ create_crop_landunit = .true.
+ tw_irr = .true.
+ extra_gw_irr = .false.
+ firrig_data = .true.
+ use_lake_wat_storage=.true.

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/V2_ELM_MOSART_features/user_nl_mosart
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/V2_ELM_MOSART_features/user_nl_mosart
@@ -2,4 +2,7 @@ paraFile = '$DIN_LOC_ROOT/rof/mosart/global_reservoir_halfdegree_c20200917.nc'
 frivinp_rtm = '$DIN_LOC_ROOT/rof/mosart/MOSART_Global_half_20210422.nc'
 wrmflag = .true.
 inundflag = .true.
+rtmhist_mfilt=1
+rtmhist_nhtfrq=-24
+
 

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/V2_ELM_MOSART_features/user_nl_mosart
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/V2_ELM_MOSART_features/user_nl_mosart
@@ -1,0 +1,5 @@
+paraFile = '$DIN_LOC_ROOT/rof/mosart/global_reservoir_halfdegree_c20200917.nc'
+frivinp_rtm = '$DIN_LOC_ROOT/rof/mosart/MOSART_Global_half_20210422.nc'
+wrmflag = .true.
+inundflag = .true.
+


### PR DESCRIPTION
A new test is added to e3sm_land_developer testing suite with the following land features turned on: 
two-way irrigation, lake storage, bgc mode, and transient mode. It also turns on two river features:
inundation and water management. These features were developed for V2 BGC simulations.

[BFB]