### PR TITLE
Minor fixes to Hommexx, for building theta-l_kokkos in non-standalone mode

### DIFF
--- a/components/homme/cmake/Kokkos.cmake
+++ b/components/homme/cmake/Kokkos.cmake
@@ -1,38 +1,45 @@
+set (KOKKOS_LIBRARIES "kokkoscore;kokkoscontainers")
+set (KOKKOS_TPL_LIBRARIES "dl")
+
 set (KOKKOS_INSTALLATION_NEEDED FALSE CACHE BOOL "")
-if (NOT DEFINED E3SM_KOKKOS_PATH)
-  # Build kokkos submodule if user did not specify KOKKOS_PATH.
+if (DEFINED E3SM_KOKKOS_PATH)
+  message (STATUS "The E3SM installation of kokkos in ${E3SM_KOKKOS_PATH} will be used. Here are the details:")
+  set (KOKKOS_INCLUDE_DIR ${E3SM_KOKKOS_PATH}/include)
+  set (KOKKOS_LIBRARY_DIR ${E3SM_KOKKOS_PATH}/lib64)
+
+  message ("    KOKKOS_INCLUDE_DIR: ${KOKKOS_INCLUDE_DIR}")
+  message ("    KOKKOS_LIBRARY_DIR: ${KOKKOS_LIBRARY_DIR}")
+  message ("    KOKKOS_LIBRARIES:   ${KOKKOS_LIBRARIES}")
+  set (KOKKOS_LIBS_ARE_TARGETS FALSE)
+elseif (E3SM_INTERNAL_KOKKOS_ALREADY_BUILT)
+  message (STATUS "All kokkos libraries needed by Homme are already built by this cmake project.\n")
+  set (KOKKOS_LIBS_ARE_TARGETS TRUE)
+else()
+  # As last resort, build kokkos submodule
   set (KOKKOS_SRC ${CMAKE_SOURCE_DIR}/../../externals/kokkos)
   set (KOKKOS_BUILD_DIR ${CMAKE_BINARY_DIR}/kokkos/build)
 
   # kokkos-containers is likely not needed, but it's built anyways,
   # so we may as well add its include path. kokkos-algorithms may
   # be used for the Kokkos_Random.hpp header.
-  SET (KOKKOS_INCLUDE_DIR
+  set (KOKKOS_INCLUDE_DIR
        ${KOKKOS_SRC}/core/src
        ${KOKKOS_SRC}/containers/src
        ${KOKKOS_SRC}/algorithms/src
        ${KOKKOS_BUILD_DIR})
-  SET (KOKKOS_LIBRARY_DIR ${KOKKOS_BUILD_DIR})
-  message ("Using Kokkos built internally to E3SM, in ${KOKKOS_BUILD_DIR}")
-  if (NOT E3SM_INTERNAL_KOKKOS_ALREADY_BUILT)
-    # Nobody else already added kokkos subdirectory, so we will do it
-    set (KOKKOS_INSTALLATION_NEEDED TRUE)
-    set (E3SM_INTERNAL_KOKKOS_ALREADY_BUILT TRUE)
-  endif()
+  set (KOKKOS_LIBRARY_DIR ${KOKKOS_BUILD_DIR})
+  message ("Building Kokkos (from E3SM internal submodule) in ${KOKKOS_BUILD_DIR}")
 
-else ()
-  message ("The installation of kokkos in ${E3SM_KOKKOS_PATH} will be used.")
-  SET (KOKKOS_INCLUDE_DIR ${E3SM_KOKKOS_PATH}/include)
-  SET (KOKKOS_LIBRARY_DIR ${E3SM_KOKKOS_PATH}/lib64)
+  # Make a note that we need to add the kokkos subdir (in the cmake sense)
+  set (KOKKOS_INSTALLATION_NEEDED TRUE)
+
+  # Notify that E3SM's internal kokkos is built
+  set (E3SM_INTERNAL_KOKKOS_ALREADY_BUILT TRUE)
+
+  # Make a note that, since kokkos is built internally, it's a valid cmake target
+  # (in particular, we don't need to set compile/include/link flags)
+  set (KOKKOS_LIBS_ARE_TARGETS TRUE)
 endif ()
-
-SET (KOKKOS_LIBRARIES "kokkoscore;kokkoscontainers")
-SET (KOKKOS_TPL_LIBRARIES "dl")
-
-MESSAGE (STATUS "Kokkos installation found! Here are the details:")
-MESSAGE ("    KOKKOS_INCLUDE_DIR: ${KOKKOS_INCLUDE_DIR}")
-MESSAGE ("    KOKKOS_LIBRARY_DIR: ${KOKKOS_LIBRARY_DIR}")
-MESSAGE ("    KOKKOS_LIBRARIES:   ${KOKKOS_LIBRARIES}")
 
 macro(install_kokkos_if_needed)
   if (KOKKOS_INSTALLATION_NEEDED)
@@ -44,6 +51,10 @@ macro(install_kokkos_if_needed)
 endmacro()
 
 macro(link_to_kokkos targetName)
-  TARGET_INCLUDE_DIRECTORIES(${targetName} SYSTEM PUBLIC ${KOKKOS_INCLUDE_DIR})
-  TARGET_LINK_LIBRARIES(${targetName} ${KOKKOS_TPL_LIBRARIES} ${KOKKOS_LIBRARIES} -L${KOKKOS_LIBRARY_DIR})
+  if (KOKKOS_LIBS_ARE_TARGETS)
+    target_link_libraries (${targetName} ${KOKKOS_LIBRARIES})
+  else()
+    target_include_directories(${targetName} SYSTEM PUBLIC ${KOKKOS_INCLUDE_DIR})
+    target_link_libraries(${targetName} ${KOKKOS_TPL_LIBRARIES} ${KOKKOS_LIBRARIES} -L${KOKKOS_LIBRARY_DIR})
+  endif()
 endmacro(link_to_kokkos)

--- a/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
+++ b/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
@@ -422,14 +422,16 @@ contains
 
     call TimeLevel_Qdp(tl, dt_tracer_factor, n0_qdp, np1_qdp)
 
+#if !defined(CAM) && !defined(SCREAM)
+    ! Test forcing is only for standalone Homme (and only for some tests/configurations)
     if (compute_forcing_and_push_to_c) then
-!    if ( .true. ) then
       call compute_test_forcing(elem,hybrid,hvcoord,tl%n0,n0_qdp,max(dt_q,dt_remap),nets,nete,tl)
       call t_startf('push_to_cxx')
       call push_forcing_to_c(elem_derived_FM,   elem_derived_FVTheta, elem_derived_FT, &
                              elem_derived_FPHI, elem_derived_FQ)
       call t_stopf('push_to_cxx')
     endif
+#endif
 
     call prim_run_subcycle_c(dt,nstep_c,nm1_c,n0_c,np1_c,nextOutputStep)
 
@@ -442,8 +444,6 @@ contains
     call init_logic_for_push_to_f(tl,statefreq,nextOutputStep,compute_diagnostics)
 
     if (push_to_f) then
-!    if (MODULO(tl%nstep,statefreq)==0 .or. tl%nstep >= nextOutputStep .or. compute_diagnostics) then
-!    if (.true.) then
       ! Set pointers to states
       elem_state_v_ptr         = c_loc(elem_state_v)
       elem_state_w_i_ptr       = c_loc(elem_state_w_i)


### PR DESCRIPTION
Two mods:

- fix driver mod for theta-l_kokkos, to compile test forcing stuff only in standalone mode (fixes link error).
- change Kokkos.cmake script, so that it does not add _assumed_ include/link folders/libs when Kokkos is built externally (fixes hundreds of non-existent include dir in SCREAM).

BFB.