### PR TITLE
Fix filename interval for 2 analysis member restarts

### DIFF
--- a/components/mpas-ocean/src/analysis_members/Registry_eliassen_palm.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_eliassen_palm.xml
@@ -643,7 +643,7 @@
 			type="input;output"
 			mode="forward;analysis"
 			filename_template="restarts/eliassenPalm_restart.$Y-$M-$D.nc"
-			filename_interval="01-00-00_00:00:00"
+			filename_interval="output_interval"
 			input_interval="initial_only"
 			output_interval="stream:restart:output_interval"
 			packages="eliassenPalmAMPKG"

--- a/components/mpas-ocean/src/analysis_members/Registry_time_filters.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_time_filters.xml
@@ -103,7 +103,7 @@
 		<stream name="timeFiltersRestart" type="input;output"
 				mode="forward;analysis"
 				filename_template="restarts/timeFiltersRestart.$Y-$M-$D_$h.nc"
-				filename_interval="01-00-00_00:00:00"
+				filename_interval="output_interval"
 				input_interval="initial_only"
 				output_interval="stream:restart:output_interval"
 				packages="timeFiltersAMPKG"


### PR DESCRIPTION
The Eliassen-Palm and time-filters analysis members both had hard-coded restart file intervals of 1 year.  This causes restarts with these analysis members to fail in situations where the restart interval does not match the file interval.  This merge changes the filename interval to be the same as the output interval to match restart streams in all other analysis members.