### PR TITLE
set SCREAM to run with adjust_ps=.false.

### DIFF
--- a/components/homme/src/share/prim_driver_base.F90
+++ b/components/homme/src/share/prim_driver_base.F90
@@ -1591,7 +1591,7 @@ contains
      adjust_ps=.true.   ! stay on reference levels for Eulerian case
   else
 #ifdef SCREAM
-     adjust_ps=.false.  ! Lagrangian case should adjusting dp3d
+     adjust_ps=.false.  ! Lagrangian case should adjust dp3d
 #else     
      adjust_ps=.true.   ! Preserve buggy v2 behavoir, for now
 #endif     

--- a/components/homme/src/share/prim_driver_base.F90
+++ b/components/homme/src/share/prim_driver_base.F90
@@ -1590,7 +1590,11 @@ contains
   if (dt_remap_factor==0) then
      adjust_ps=.true.   ! stay on reference levels for Eulerian case
   else
-     adjust_ps=.true.   ! Lagrangian case can support adjusting dp3d or ps
+#ifdef SCREAM
+     adjust_ps=.false.  ! Lagrangian case should adjusting dp3d
+#else     
+     adjust_ps=.true.   ! Preserve buggy v2 behavoir, for now
+#endif     
   endif
 #else
   adjust_ps=.true.      ! preqx requires forcing to stay on reference levels


### PR DESCRIPTION
dont reproduce buggy behavior used in E3SM v1/v2

[BFB]
In the SCREAM model, will be non-BFB, with minor impacts on climate

This address #4693, but only for the scream code base, and thus this PR should not close #4693
