### PR TITLE
Corrects coupling of ocean surface DON with sea ice DON.

### DIFF
--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -2064,7 +2064,7 @@ contains
            oceanDOCConc(2,i)             = x2i_i % rAttr(index_x2i_So_doc2, n) * DOCPoolFractions(2)
            oceanDOCConc(3,i)             = 0.0_RKIND
            oceanDICConc(1,i)             = x2i_i % rAttr(index_x2i_So_dic1, n)
-           oceanDONConc(1,i)             = x2i_i % rAttr(index_x2i_So_don1, n) * DOCPoolFractions(3) &
+           oceanDONConc(1,i)             = x2i_i % rAttr(index_x2i_So_doc3, n) * DOCPoolFractions(3) &
               /carbonToNitrogenRatioDON(1)
            oceanNitrateConc(i)           = x2i_i % rAttr(index_x2i_So_no3, n)
            oceanSilicateConc(i)          = x2i_i % rAttr(index_x2i_So_sio3, n)


### PR DESCRIPTION
Replaces index_x2i_So_don1 with index_x2i_So_doc3 in ice_comp_mct.
non-BFB with ocean and sea ice BGC active.
BFB otherwise.
Fixes issue #4698