### PR TITLE
Removed Cf from sea ice constants

### DIFF
--- a/components/mpas-seaice/src/column/constants/cice/ice_constants_colpkg.F90
+++ b/components/mpas-seaice/src/column/constants/cice/ice_constants_colpkg.F90
@@ -55,7 +55,6 @@
          cprho    = cp_ocn*rhow       ,&! for ocean mixed layer (J kg / K m^3)
 
          ! for ice strength
-         Cf       = 17._dbl_kind      ,&! ratio of ridging work to PE change in ridging 
          Cp       = 0.5_dbl_kind*gravit*(rhow-rhoi)*rhoi/rhow ,&! proport const for PE 
          Pstar    = 2.75e4_dbl_kind   ,&! constant in Hibler strength formula 
                                         ! (kstrength = 0) 

--- a/components/mpas-seaice/src/column/ice_colpkg.F90
+++ b/components/mpas-seaice/src/column/ice_colpkg.F90
@@ -3514,8 +3514,9 @@
                                       vicen,    &
                                       strength)
 
-      use ice_constants_colpkg, only: p333, c0, c1, c2, Cf, Cp, Pstar, Cstar, &
+      use ice_constants_colpkg, only: p333, c0, c1, c2, Cp, Pstar, Cstar, &
           rhoi, puny
+      use ice_colpkg_shared, only: Cf
       use ice_mechred, only: asum_ridging, ridge_itd
 
       integer (kind=int_kind), intent(in) :: & 


### PR DESCRIPTION
The sea ice parameter Cf (config_ratio_ridging_work_to_PE) was incorrectly set in both constants and shared parameters in the column package, so that changing config_ratio_ridging_work_to_PE had no effect. Removed Cf from constants.

Fixes https://github.com/E3SM-Project/E3SM/issues/4701

[BFB] (Unless config_ratio_ridging_work_to_PE changed)