### PR TITLE
After recent PR, correct PE layout for "S" size of ne102pg2 F cases using CICE

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -6801,7 +6801,7 @@
           <ntasks_ocn>5440</ntasks_ocn>
           <ntasks_glc>64</ntasks_glc>
           <ntasks_wav>64</ntasks_wav>
-          <ntasks_cpl>85</ntasks_cpl>
+          <ntasks_cpl>5440</ntasks_cpl>
         </ntasks>
         <nthrds>
           <nthrds_atm>4</nthrds_atm>


### PR DESCRIPTION
After recent PR 4696, correct PE layout for "S" size of ne102pg2 F cases using CICE

Fixes #4704
[bfb]