### PR TITLE
Remove duplicate allocates in ELM column and gridcell data types

### DIFF
--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -7766,8 +7766,6 @@ contains
     allocate(this%actual_immob_nh4_vr             (begc:endc,1:nlevdecomp_full)) ; this%actual_immob_nh4_vr            (:,:) = nan
     allocate(this%smin_no3_to_plant_vr            (begc:endc,1:nlevdecomp_full)) ; this%smin_no3_to_plant_vr           (:,:) = nan
     allocate(this%smin_nh4_to_plant_vr            (begc:endc,1:nlevdecomp_full)) ; this%smin_nh4_to_plant_vr           (:,:) = nan
-    allocate(this%smin_no3_to_plant               (begc:endc))                   ; this%smin_no3_to_plant              (:)   = nan
-    allocate(this%smin_nh4_to_plant               (begc:endc))                   ; this%smin_nh4_to_plant              (:)   = nan
     allocate(this%f_nit                           (begc:endc))                   ; this%f_nit                          (:)   = nan
     allocate(this%f_denit                         (begc:endc))                   ; this%f_denit                        (:)   = nan
     allocate(this%n2_n2o_ratio_denit_vr           (begc:endc,1:nlevdecomp_full)) ; this%n2_n2o_ratio_denit_vr          (:,:) = nan

--- a/components/elm/src/data_types/GridcellDataType.F90
+++ b/components/elm/src/data_types/GridcellDataType.F90
@@ -558,7 +558,6 @@ contains
     allocate(this%tcs_month_beg         (begg:endg));     this%tcs_month_beg         (:) = nan
     allocate(this%tcs_month_end         (begg:endg));     this%tcs_month_end         (:) = nan
     allocate(this%begcb                 (begg:endg));     this%begcb                 (:) = nan
-    allocate(this%begcb                 (begg:endg));     this%begcb                 (:) = nan
     allocate(this%endcb                 (begg:endg));     this%endcb                 (:) = nan
     allocate(this%errcb                 (begg:endg));     this%errcb                 (:) = nan
 


### PR DESCRIPTION
Duplicate allocations lead to memory leaks.

Addresses E3SM-Project/E3SM#4709

[BFB]