### PR TITLE
fix calculation of the ML-averaged Brunt-Vaisala frequency

### DIFF
--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_heat_budget.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_heat_budget.F
@@ -176,6 +176,7 @@ contains
       integer, pointer :: nVertLevels, nCellsSolve
       integer :: iTracer, k, iCell, num_tracers
       integer, dimension(:), pointer :: maxLevelCell
+      integer, pointer :: index_temperature
 
       real(kind=RKIND), dimension(:, :, :), pointer :: &
           tracers, tracerTend
@@ -222,7 +223,7 @@ contains
          call mpas_pool_get_array(mixedLayerHeatBudgetAMPool, 'activeTracersTendML', activeTracersTendML)
          call mpas_pool_get_array(mixedLayerHeatBudgetAMPool, 'bruntVaisalaFreqML', bruntVaisalaFreqML)
          call mpas_pool_get_array(mixedLayerDepthsAMPool, 'dThreshMLD', dThreshMLD)
-
+         call mpas_pool_get_dimension(tracersPool, 'index_temperature', index_temperature)
          call mpas_pool_get_array(tracersPool, 'activeTracers', tracers, timeLevel)
          call mpas_pool_get_array(tracerTendPool, 'activeTracersTend', tracerTend)
 
@@ -255,7 +256,7 @@ contains
 
                   activeTracerForcingMLTend(iTracer, iCell) = activeTracerForcingMLTend(iTracer, iCell) + &
                                                          activeTracerSurfaceFluxTendency(iTracer, k, iCell)*layerThickness(k, iCell)
-                  if (iTracer == 1) THEN
+                  if (iTracer == index_temperature) THEN
                      activeTracerForcingMLTend(iTracer, iCell) = activeTracerForcingMLTend(iTracer, iCell) + &
                                                                  temperatureShortWaveTendency(k, iCell)*layerThickness(k, iCell)
                   endif
@@ -286,7 +287,7 @@ contains
                                                             activeTracerNonLocalTendency(iTracer, k, iCell)*difference
                activeTracerForcingMLTend(iTracer, iCell) = activeTracerForcingMLTend(iTracer, iCell) + &
                                                            activeTracerSurfaceFluxTendency(iTracer, k, iCell)*difference
-               if (iTracer == 1) THEN
+               if (iTracer == index_temperature) THEN
                   activeTracerForcingMLTend(iTracer, iCell) = activeTracerForcingMLTend(iTracer, iCell) + &
                                                               temperatureShortWaveTendency(k, iCell)*difference
                endif
@@ -305,7 +306,7 @@ contains
                activeTracerNonLocalMLTend(iTracer, iCell) = activeTracerNonLocalMLTend(iTracer, iCell)/dThreshMLD(iCell)
                activeTracerForcingMLTend(iTracer, iCell) = activeTracerForcingMLTend(iTracer, iCell)/dThreshMLD(iCell)
             end do
-            bruntVaisalaFreqML(iCell) = bruntVaisalaFreqML(iCell) + BruntVaisalaFreqTop(k, iCell)*layerThickness(k, iCell)
+            bruntVaisalaFreqML(iCell) = bruntVaisalaFreqML(iCell) + BruntVaisalaFreqTop(k, iCell)*difference
             bruntVaisalaFreqML(iCell) = bruntVaisalaFreqML(iCell)/dThreshMLD(iCell)
          end do
 

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_heat_budget.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_heat_budget.F
@@ -271,7 +271,7 @@ contains
                k = k + 1
                depth = depth + layerThickness(k, iCell)
             end do
-            !need the clearn up of how much is left to get to MLD mld - depth
+            !add partial thickness of last layer to get to MLD
             depth = depth - layerThickness(k, iCell)
             difference = dThreshMLD(iCell) - depth
             do iTracer = 1, num_tracers


### PR DESCRIPTION
This PR is correcting a bug in the calculation of the mixed-layer-averaged Brunt-Vaisala frequency
Changes included:
 1. Bug fix: corrected last layer thickness to partial in bruntVaisalaFreqML calculation
 2. Minor tweak: fetch index_temp as best practice (instead of assuming index_temp=1)
@vanroekel agreed this was a bug
@xylar read through the changes

Testing:
Following @xylar's suggestions, I ran the **compass nightly** and **PR** test suites on the new branch (with E3SM-Project/E3SM master as the baseline). 

**All tests passed**, except for the PHC_analysis_test, which returned the expected result in the log, i.e. that the **bruntVaisalaFreqML** variable in mixedLayerHeatBudget.0001-01-01.nc is different across both branches: 
20211221.mpaso.master.pr.anvil/ocean/global_ocean/QU240/PHC/analysis_test/forward/analysis_members/mixedLayerHeatBudget.0001-01-01.nc
bruntVaisalaFreqML  Time index: 0, 1, 2, 3
0: l1: 1.39087854710057e-01 l2: 3.78211615308643e-03 linf: 4.73636383462982e-04
1: l1: 1.43059632404768e-01 l2: 4.07490791830357e-03 linf: 5.16298006610050e-04
2: l1: 1.30955216565953e-01 l2: 3.95262852740002e-03 linf: 5.22962151300133e-04
3: l1: 1.16779244836792e-01 l2: 3.76342985792116e-03 linf: 5.19467445683437e-04

The log also reports some changes in speed (-20-20% range) when comparing timer of various compute/write steps, but small changes do not raise any concerns for me. Let me know if that is something that should be of concern. 
The tests were all run on anvil with the intel-mpi compiler.

[BFB]