### PR TITLE
Make adjust_ps consistent with SCREAM

### DIFF
--- a/components/homme/src/share/prim_driver_base.F90
+++ b/components/homme/src/share/prim_driver_base.F90
@@ -1597,7 +1597,11 @@ contains
   if (dt_remap_factor==0) then
      adjust_ps=.true.   ! stay on reference levels for Eulerian case
   else
+#ifdef SCREAM
+     adjust_ps=.false.  ! Lagrangian case can support adjusting dp3d or ps
+#else
      adjust_ps=.true.   ! Lagrangian case can support adjusting dp3d or ps
+#endif
   endif
 #else
   adjust_ps=.true.      ! preqx requires forcing to stay on reference levels


### PR DESCRIPTION
Make setting of `adjust_ps` consistent with SCREAM repo. We want to allow
`adjust_ps=.false.` for SCREAM, but retain `adjust_ps=.true.` for E3SM to
remain BFB for v2. This change was originally made downstream in SCREAM, but causes
conflicts between the two repos, and prevents EAM compsets from being
BFB between the E3SM and SCREAM repos. Moving this change upstream,
protected in an `ifdef`, allows the two repos to be consistent, and keeps
EAM compsets BFB between the SCREAM and E3SM repos. This also sets the
precedent for allowing changes upstream in E3SM that should apply only
to SCREAM configurations, protected in `ifdef SCREAM`. To enable, we
simply need to add the `-cppdefs '-DSCREAM'` flag to `CAM_CONFIG_OPTS`
for SCREAM compsets.

[BFB]