### PR TITLE
remove unused variables

### DIFF
--- a/components/homme/src/share/hybvcoord_mod.F90
+++ b/components/homme/src/share/hybvcoord_mod.F90
@@ -24,8 +24,6 @@ type, public :: hvcoord_t
   real(r8) hybm(plev)   ! ps  component of hybrid coordinate - midpoints
   real(r8) etam(plev)   ! eta-levels at midpoints
   real(r8) etai(plevp)  ! eta-levels at interfaces
-  real(r8) d_etam(plev)   ! Delta eta at midpoints
-  real(r8) d_etai(plevp)  ! Delta eta at interfaces
   real(r8) dp0(plev)      ! average layer thickness
 end type
 
@@ -177,20 +175,10 @@ end function
 
   ! get eta level deltas:
   do k=1,plev
-     hvcoord%d_etam(k)=hvcoord%etai(k+1)-hvcoord%etai(k)
      ! compute this way so it is BFB with older code:
      hvcoord%dp0(k) = ( hvcoord%hyai(k+1) - hvcoord%hyai(k) )*hvcoord%ps0 + &
           ( hvcoord%hybi(k+1) - hvcoord%hybi(k) )*hvcoord%ps0
-     !hvcoord%dp0(k) = hvcoord%d_etam(k)*hvcoord%ps0
   enddo
-  do k=2,plev
-     ! same as (d_etam(k)+d_etam(k-1)/2
-     hvcoord%d_etai(k)=hvcoord%etam(k)-hvcoord%etam(k-1)
-  enddo
-  ! dont include the 1/2, to make for easier weigthed averaging of interface
-  ! quantities to midpoints
-  hvcoord%d_etai(1)=hvcoord%d_etam(1)         ! /2
-  hvcoord%d_etai(plev+1)=hvcoord%d_etam(plev) ! /2
 
   ! ======================================================================
   ! Test that midpoint A,B is mean of interface A,B


### PR DESCRIPTION
Remove two unused variables.  
Causes roundoff level changes in some standalone HOMME tests due to change in loop structure and size of hyvcoord struct.

[BFB] except for some standalone HOMME tests
