### PR TITLE
re-enable imex unit tests

### DIFF
--- a/components/homme/src/theta-l/share/imex_mod.F90
+++ b/components/homme/src/theta-l/share/imex_mod.F90
@@ -498,10 +498,7 @@ contains
     minjacerr=0
     if (hybrid%masterthread) write(iulog,*)'Running IMEX Jacobian unit test...'
     do ie=nets,nete
-       do k=1,nlev
-          dp3d(:,:,k) = ( hvcoord%hyai(k+1) - hvcoord%hyai(k) )*hvcoord%ps0 + &
-               ( hvcoord%hybi(k+1) - hvcoord%hybi(k) )*elem(ie)%state%ps_v(:,:,tl%n0)
-       enddo
+       dp3d(:,:,:) = elem(ie)%state%dp3d(:,:,:,tl%n0)
        vtheta_dp(:,:,:) = elem(ie)%state%vtheta_dp(:,:,:,tl%n0)
        phi_i(:,:,:)         = elem(ie)%state%phinh_i(:,:,:,tl%n0)
        phis(:,:)          = elem(ie)%state%phis(:,:)

--- a/components/homme/src/theta-l/share/model_init_mod.F90
+++ b/components/homme/src/theta-l/share/model_init_mod.F90
@@ -108,11 +108,9 @@ contains
     enddo 
 
 
-    ! unit test for analytic jacobian used by IMEX methods
-#if 0
+    ! unit test for analytic jacobian and tri-diag solve used by IMEX methods
     if (.not. theta_hydrostatic_mode) &
          call test_imex_jacobian(elem,hybrid,hvcoord,tl,nets,nete)
-#endif
 
     !$omp master
     ! 


### PR DESCRIPTION
turn on (during startup) IMEX test of analytic jacobian ( verify that it it agrees with numerical approximation)  
turn on (during startup) test of the @ambrad tridiagonal solver
[BFB]