### PR TITLE
Make surfaceTemperatureFluxWithoutRunoff private in omp pragma

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
@@ -540,7 +540,7 @@ contains
       ! indices on tracerGroup are (iTracer, iLevel, iCell)
       if (.not. bulkThicknessFluxOff) then
          !$omp parallel
-         !$omp do schedule(runtime)
+         !$omp do schedule(runtime) private(surfaceTemperatureFluxWithoutRunoff)
          do iCell = 1, nCells
 
            ! Accumulate fluxes that use the surface temperature


### PR DESCRIPTION
This PR adds surfaceTemperatureFluxWithoutRunoff to an omp pragma to be private for a loop in the mpas-ocean routine ocn_surface_bulk_forcing_active_tracers. It was causing some tests to be irreproducible when run with threading on.

Fixes #4732
[non-BFB] for some threaded tests