### PR TITLE
Add SMS_D_Ld3.T62_oQU120.CMPASO-IAF to e3sm_integration

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -169,6 +169,7 @@ _TESTS = {
             "SMS_Ld2.ne30_oECv3.BGCEXP_CNTL_CNPECACNT_1850.elm-bgcexp",
             "SMS_Ld2.ne30_oECv3.BGCEXP_CNTL_CNPRDCTC_1850.elm-bgcexp",
             "SMS_D_Ld1.T62_oEC60to30v3.DTESTM",
+            "SMS_D_Ld3.T62_oQU120.CMPASO-IAF",
             "SMS_D_Ld1.ne30pg2_r05_EC30to60E2r2.WCYCL1850",
             "ERP_Ln9.ne4pg2_ne4pg2.F-MMFXX.eam-mmf_fixed_subcycle",
             "ERS_Ln9.ne4pg2_ne4pg2.F-MMFXX.eam-mmf_use_VT",


### PR DESCRIPTION
This PR adds a new test SMS_D_Ld3.T62_oQU120.CMPASO-IAF to e3sm_integration as a follow-up to [PR #4733](https://github.com/E3SM-Project/E3SM/pull/4733), which was uncovered from running this test by hand.

[BFB]