### PR TITLE
Set memleak tolerance at 15% for FATES tests on Cori

### DIFF
--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/fates_eca/shell_commands
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/fates_eca/shell_commands
@@ -2,3 +2,5 @@
 if [ `./xmlquery --value MACH` == bebop ]; then ./xmlchange --id LND_PIO_TYPENAME --val netcdf; fi
 ./xmlchange --append ELM_BLDNML_OPTS="-nutrient cnp -nutrient_comp_pathway eca -soil_decomp century"
 ./xmlchange NTHRDS=1
+# increase memory leak tolerance to 15% for FATES tests on Cori
+if [[ `./xmlquery --value MACH` =~ ^cori-(knl|haswell)$ ]]; then ./xmlchange TEST_MEMLEAK_TOLERANCE=0.15; fi

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/fates_rd/shell_commands
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/fates_rd/shell_commands
@@ -2,3 +2,5 @@
 if [ `./xmlquery --value MACH` == bebop ]; then ./xmlchange --id LND_PIO_TYPENAME --val netcdf; fi
 ./xmlchange --append ELM_BLDNML_OPTS="-nutrient cnp -nutrient_comp_pathway rd -soil_decomp ctc"
 ./xmlchange NTHRDS=1
+# increase memory leak tolerance to 15% for FATES tests on Cori
+if [[ `./xmlquery --value MACH` =~ ^cori-(knl|haswell)$ ]]; then ./xmlchange TEST_MEMLEAK_TOLERANCE=0.15; fi

--- a/driver-mct/cime_config/config_component.xml
+++ b/driver-mct/cime_config/config_component.xml
@@ -896,6 +896,22 @@
     <desc>logical to diagnose model timing at the end of the run</desc>
   </entry>
 
+  <entry id="TEST_MEMLEAK_TOLERANCE">
+    <type>real</type>
+    <default_value>0.10</default_value>
+    <group>run_flags</group>
+    <file>env_run.xml</file>
+    <desc>Expected relative memory usage growth for test</desc>
+  </entry>
+
+  <entry id="TEST_TPUT_TOLERANCE">
+    <type>real</type>
+    <default_value>0.25</default_value>
+    <group>run_flags</group>
+    <file>env_run.xml</file>
+    <desc>Expected throughput deviation</desc>
+  </entry>
+
   <entry id="PROFILE_PAPI_ENABLE">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
@@ -2703,22 +2719,6 @@
     <group>test</group>
     <file>env_test.xml</file>
     <desc>supplied or computed test id</desc>
-  </entry>
-
-  <entry id="TEST_MEMLEAK_TOLERANCE">
-    <type>real</type>
-    <default_value>0.10</default_value>
-    <group>test</group>
-    <file>env_test.xml</file>
-    <desc>Expected relative memory usage growth for test</desc>
-  </entry>
-
-  <entry id="TEST_TPUT_TOLERANCE">
-    <type>real</type>
-    <default_value>0.25</default_value>
-    <group>test</group>
-    <file>env_test.xml</file>
-    <desc>Expected throughput deviation</desc>
   </entry>
 
   <entry id="GENERATE_BASELINE">


### PR DESCRIPTION
Set memleak tolerance at 15% for FATES tests on Cori with testmods.

Addresses E3SM-Project/E3SM#4709

[BFB]

Testing: https://my.cdash.org/viewTest.php?buildid=2115850