### PR TITLE
For Perlmutter, remove a line to load environment module that is no longer needed

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -130,13 +130,11 @@
       </modules>
 
       <modules compiler="gnugpu">
-	<command name="load">cpe-cuda</command>
 	<command name="load">cudatoolkit</command>
 	<command name="load">craype-accel-nvidia80</command>
       </modules>
 
       <modules compiler="nvidiagpu">
-	<command name="load">cpe-cuda</command>
 	<command name="load">cudatoolkit</command>
 	<command name="load">craype-accel-nvidia80</command>
       </modules>


### PR DESCRIPTION

NERSC made changes again to default env for Perlmutter.
We need to remove the line loading cpe-cuda module as this will override the GNU version.
So that basically, the build will continue using GNU v10, when we actually want GNU v9.
Only affects gpu builds (ie gnugpu, not gnu).

[bfb]

Fixes https://github.com/E3SM-Project/E3SM/issues/4741