### PR TITLE
Hollyhan/mali/add s lmodel

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -55,3 +55,6 @@
 [submodule "externals/mct"]
 	path = externals/mct
 	url = git@github.com:MCSclimate/MCT.git
+[submodule "components/mpas-albany-landice/src/SeaLevelModel"]
+	path = components/mpas-albany-landice/src/SeaLevelModel
+	url = git@github.com:hollyhan/SeaLevelModel.git

--- a/components/mpas-albany-landice/src/Makefile
+++ b/components/mpas-albany-landice/src/Makefile
@@ -18,7 +18,16 @@ analysis_members: shared
 mode_forward: shared analysis_members
 	(cd mode_forward; $(MAKE) FCINCLUDES="$(FCINCLUDES) $(SHARED_INCLUDES)")
 
-core_landice: mode_forward shared analysis_members
+sea_level_model:
+ifeq "$(SLM)" "true"
+	if [ -e SeaLevelModel/.git ]; then \
+		(cd SeaLevelModel; $(MAKE) all FC="$(FC)" FCFLAGS="$(FFLAGS)" FINCLUDES="$(FINCLUDES)") \
+	else \
+                (echo "Missing mpas-ocean/src/SeaLevelModel/.git, did you forget to 'git submodule update --init --recursive' ?"; exit 1) \
+	fi
+endif
+
+core_landice: mode_forward shared analysis_members sea_level_model
 	ar -ru libdycore.a `find . -type f -name "*.o"`
 
 core_input_gen:
@@ -49,3 +58,8 @@ clean:
 	(cd shared; $(MAKE) clean)
 	(cd mode_forward; $(MAKE) clean)
 	(cd analysis_members; $(MAKE) clean)
+ifeq "$(SLM)" "true"
+	if [ -e SeaLevelModel/.git ]; then \
+		(cd SeaLevelModel; $(MAKE) clean) \
+	fi
+endif

--- a/components/mpas-albany-landice/src/Makefile
+++ b/components/mpas-albany-landice/src/Makefile
@@ -5,6 +5,9 @@
 FW = ../../../mpas-framework/src
 SHARED_INCLUDES  = -I$(FW)/framework -I$(FW)/external/esmf_time_f90 -I$(FW)/operators
 SHARED_INCLUDES += -I$(PWD)/shared -I$(PWD)/analysis_members -I$(PWD)/mode_forward
+ifeq "$(SLM)" "true"
+SHARED_INCLUDES += -I$(PWD)/SeaLevelModel
+endif
 
 all: core_landice
 
@@ -15,7 +18,7 @@ analysis_members: shared
 	(cd analysis_members; $(MAKE) FCINCLUDES="$(FCINCLUDES) $(SHARED_INCLUDES)")
 
 
-mode_forward: shared analysis_members
+mode_forward: shared analysis_members sea_level_model
 	(cd mode_forward; $(MAKE) FCINCLUDES="$(FCINCLUDES) $(SHARED_INCLUDES)")
 
 sea_level_model:

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -131,7 +131,12 @@
 	<nml_record name="solidearth" in_defaults="true">
 		<nml_option name="config_uplift_method" type="character" default_value="none" units="unitless"
 		            description="Selection of the method for bedrock uplift calculation."
-		            possible_values="'none', 'data'"
+		            possible_values="'none', 'data', 'sealevelmodel'"
+        />
+                <nml_option name="config_slm_coupling_interval" type="character" default_value="0002-00-00_00:00:00" units="time"
+                            description="Time interval at which the sea-level model is called by MALI"
+                            possible_values="Any positive integer value greater than or equal to 0"
+                    
 		/>
 	</nml_record>
 

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -138,6 +138,15 @@
                             possible_values="Any positive integer value greater than or equal to 0"
                     
 		/>
+                <nml_option name="config_MALI_to_SLM_weights_file" type="character" default_value="mpas_to_grid.nc" units="unitless"
+                    description="File containing the interpolation weights for regridding from MPAS mesh to a Gaussian Grid."
+                    possible_values="Any file name string"
+
+        />
+                <nml_option name="config_SLM_to_MALI_weights_file" type="character" default_value="grid_to_mpas.nc" units="unitless"
+                    description="File containing the interpolation weights for regridding from a Gaussien grid to the MPAS mesh."
+                    possible_values="Any file name string"
+        />
 	</nml_record>
 
 	<nml_record name="calving" in_defaults="true">

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1259,6 +1259,10 @@ is the value of that variable from the *previous* time level!
                 <var name="upliftRate"            type="real"     dimensions="nCells Time"
                      units="m s^{-1}"  description="time rate of change in bedTopography.  This field is prescribed as input and not currently calculated in the model."
                 />
+
+                <var name="upliftDiff"            type="real"     dimensions="nCells Time"
+                     units="m"  description="amount of change in bedTopography.  This field is calculated by the sea-level model over its time step."
+                />
                <!-- Scratch variables related to geometry -->
 	       <var name="cellMaskTemporary" type="integer" dimensions="nCells" units="none"
 	       description="temporary copy of cellMask"

--- a/components/mpas-albany-landice/src/build_options.mk
+++ b/components/mpas-albany-landice/src/build_options.mk
@@ -45,5 +45,11 @@ endif # PHG IF
 override CPPFLAGS += $(EXTERNAL_DYCORE_FLAG)
 # ===================================
 
+# Optional Sea Level model
+ifeq "$(SLM)" "true"
+    override CPPFLAGS += -DUSE_SEALEVELMODEL
+endif
+
+# ===================================
 report_builds:
 	@echo "CORE=landice"

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -267,7 +267,6 @@ subroutine li_bedtopo_solve(domain, err)
             err = ior(err, err_tmp)
 					
 	      else
-	         call mpas_log_write("<<< MPAS alarm is not ringing, SLM is not called!")
 	        ! do nothing for now, but could calculate uplift rate here later instead.
 	      endif
 		else
@@ -334,7 +333,7 @@ subroutine li_bedtopo_solve(domain, err)
 !
 !> \brief   Initializes the sea-level model
 !> \author  Holly Kyeore Han
-!> \date    1 December 2021
+!> \date    January 2021
 !> \details
 !>  This wrapper routine initializes the sea-level solver
 !> (Han et al., 2022, GMD, https://doi.org/10.5281/zenodo.5775235)
@@ -450,7 +449,7 @@ subroutine li_bedtopo_solve(domain, err)
 !
 !> \brief   Solves gravitationally consistent sea-level change
 !> \author  Holly Kyeore Han
-!> \date    1 December 2021
+!> \date    January 2022
 !> \details
 !>  This wrapper routine calls the sea-level solver that takes in
 !>  ice thickness and provides sea-level change (i.e., changes in the
@@ -510,6 +509,7 @@ subroutine li_bedtopo_solve(domain, err)
       starttime_sh = 0 ! get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation)
       dtime_sh = 5
 		
+		call mpas_log_write("A")
      
       call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
@@ -517,11 +517,11 @@ subroutine li_bedtopo_solve(domain, err)
       call mpas_pool_get_array(geometryPool, 'upliftDiff', upliftDiff)
       call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
       call mpas_pool_get_subpool(domain % blocklist % structs, 'velocity', velocityPool)
-		
+		call mpas_log_write("B")
 
       ! Allocate globalArray and gatheredArray only on process 0
       call MPI_COMM_RANK(domain % dminfo % comm, curProc, err)
-         
+      call mpas_log_write("C")   
       if (curProc.eq.0) then
          allocate(globalArray1(nCellsGlobal), gatheredArray1(nCellsGlobal))
          allocate(globalArray2(nCellsGlobal), gatheredArray2(nCellsGlobal))
@@ -531,7 +531,7 @@ subroutine li_bedtopo_solve(domain, err)
       ! Gather only the nCellsOwned from ice thickness (does not include Halos)
       call MPI_GATHERV(thickness, nCellsOwned, MPI_DOUBLE, gatheredArray1, nCellsPerProc, &
                        nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err)
-         
+      call mpas_log_write("D")
       if (curProc.eq.0) then   
                                                
          ! Rearrange thickness into CellID order
@@ -544,14 +544,13 @@ subroutine li_bedtopo_solve(domain, err)
          call write_txt(thickness_slGrid1D, 'mali_iceload','')  
 				
          ! reshape the interpolated data
-         ism_iceload(:,:) = reshape(thickness_slGrid1D, [nglv,2*nglv]) !<<HH why does it not work!? 
-		   call mpas_log_write("<<< D slmTimeStep: $i", intArgs=(/slmTimeStep/))
+         ism_iceload(:,:) = reshape(thickness_slGrid1D, [nglv,2*nglv]) 
 						
 		  ! call the sea-level model
-		   call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt error
+		   call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt boundcheck error
 		   call sl_timewindow(slmTimeStep)
 		   call sl_solver(itersl_sh, slmTimeStep, dtime_sh, starttime_sh, ism_iceload, slm_slchange)
-		   call deallocate_slarrays      ! 8. deallocate memory within the slm
+		   call deallocate_slarrays     
    
          ! HH: interpolate slchange from Gaussian grid to MALI mesh and reshape
          slChange_slGrid1D = reshape(slm_slchange, [nglv*2*nglv])
@@ -569,19 +568,20 @@ subroutine li_bedtopo_solve(domain, err)
          enddo
             
       endif
-			
-      call MPI_SCATTERV(gatheredArray3, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
-                  upliftDiff, nCellsAll, MPI_DOUBLE, 0, domain % dminfo % comm, err) 
-
-      ! update bedTopography
-      bedTopography(:) = bedTopography(:) - upliftDiff(:)
-		
-      call li_update_geometry(geometryPool)
-      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
-		
-      ! scatter updated bedTopo to processors
+			call mpas_log_write("E")
+      ! scatter bedTopography and sea-level change to processors
       call MPI_SCATTERV(gatheredArray2, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
                   bedTopography, nCellsAll, MPI_DOUBLE, 0, domain % dminfo % comm, err) 
+						
+      call MPI_SCATTERV(gatheredArray3, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
+                  upliftDiff, nCellsAll, MPI_DOUBLE, 0, domain % dminfo % comm, err) 
+call mpas_log_write("F")
+      ! update bedTopography
+      bedTopography(:) = bedTopography(:) - upliftDiff(:)
+		call mpas_log_write("G")
+      call li_update_geometry(geometryPool)
+      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+call mpas_log_write("H")
                       
       ! deallocate memory
       if (curProc.eq.0) then
@@ -592,12 +592,8 @@ subroutine li_bedtopo_solve(domain, err)
 
       ! Perform Halo exchange update
       call mpas_dmpar_field_halo_exch(domain,'bedTopography')
-      call mpas_log_write("<<< done SL calculatation!")
-		
-      ! Perform Halo exchange update
-      call mpas_dmpar_field_halo_exch(domain,'bedTopography')
       call mpas_dmpar_field_halo_exch(domain,'upliftDiff')
-
+call mpas_log_write("I")
 
    !--------------------------------------------------------------------
    end subroutine slmodel_solve

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -97,8 +97,10 @@ contains
       err = 0
 
 #ifdef USE_SEALEVELMODEL
+      call mpas_log_write("<<< 1.Successfully called slmodel_init()! >>>") ! Replace with actual call
 		call slmodel_init()
-      call mpas_log_write("<<< Successfully called slmodel_init()! >>>") ! Replace with actual call
+      call mpas_log_write("<<< 2.Successfully called slmodel_init()! >>>") ! Replace with actual call
+		
 #endif
 
    !--------------------------------------------------------------------
@@ -322,8 +324,8 @@ subroutine li_bedtopo_solve(domain, err)
 	subroutine slmodel_init
 	   use sl_model_mod !HH
 		! declare variables
-		integer :: iter_sh, itersl_sh
-		real    :: starttime_sh 
+		integer :: iter_sh, itersl_sh, dtime_sh
+		real    :: starttime_sh
 		! check if we are on the head processor
 		! get initial topography from MALI 
 		     ! gather topography to the headnode
@@ -332,7 +334,9 @@ subroutine li_bedtopo_solve(domain, err)
 		iter_sh = 0 
 		itersl_sh = 1	   ! * note: hardcode itersl_sh == 1. 
 		starttime_sh = 0 ! get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation) 
-	   
+	   dtime_sh = 100
+		
+		call sl_solver_checkpoint(itersl_sh, dtime_sh)
 		call set_planet 
 		call sl_timewindow(iter_sh)
 			 ! * note: read in namelist values. SLM should return dtime from its own namelist file and MALI stores the values

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -20,7 +20,6 @@
 !-----------------------------------------------------------------------
 
 module li_bedtopo
-
    use mpas_derived_types
    use mpas_pool_routines
    use mpas_dmpar
@@ -28,7 +27,9 @@ module li_bedtopo
    use li_mask
    use li_setup
 	use netcdf
-
+!#ifdef USE_SEALEVELMODEL
+	use mpi 
+!#endif   
    implicit none
    private
 
@@ -55,6 +56,19 @@ module li_bedtopo
    integer, dimension(:), allocatable :: fromRowValues, fromColValues
    real, dimension(:), allocatable :: toSValues, fromSValues
    integer:: nMpas, nGrid
+	
+	! MPI variables
+   integer :: nCellsGlobal
+   integer, dimension(:), allocatable :: nCellsDisplacement
+   integer, dimension(:), allocatable :: indexToCellIDGathered
+   integer, dimension(:), allocatable :: nCellsPerProc
+   integer, pointer :: nCellsAll
+	integer, pointer ::  nCellsOwned
+   integer :: iCell, ilm, curProc
+	
+   real (kind=RKIND), dimension(:), allocatable :: globalArray1, gatheredArray1
+   real (kind=RKIND), dimension(:), allocatable :: globalArray2, gatheredArray2
+   real (kind=RKIND), dimension(:), allocatable :: globalArray3, gatheredArray3
 
 !***********************************************************************
 
@@ -76,7 +90,10 @@ contains
 #ifdef USE_SEALEVELMODEL
 		use spharmt 
       use planets_mod
-		use user_specs_mod, only: nglv
+		use user_specs_mod, only: nglv!< for MALI-SLM coupling. Read in from namelist
+		use io_mod !<<HH delete if not used
+		!real, dimension(nglv,2*nglv) ::  ism_iceload, ism_bedrock
+		!real (kind=RKIND), dimension(nglv*2*nglv) :: thickness_slGrid1D, bedrock_slGrid1D
 #endif
       !-----------------------------------------------------------------
       ! input variables
@@ -102,37 +119,66 @@ contains
 	   type (mpas_pool_type), pointer :: geometryPool         !< mesh information
       real (kind=RKIND), dimension(:), pointer :: thickness, bedTopography
 
-!		integer, dimension(512) ::  nglv !< for MALI-SLM coupling. Read in from namelist
 		real, dimension(nglv,2*nglv) ::  ism_iceload, ism_bedrock
 		real (kind=RKIND), dimension(nglv*2*nglv) :: thickness_slGrid1D, bedrock_slGrid1D
-		! No init is needed.
+	!!	! No init is needed.
       err = 0
 
 #ifdef USE_SEALEVELMODEL
-      ! initialize interpolation 
-      call interpolate_init(domain, err)
-		
       ! initialize coupling time step number. initial time is 0
       slmTimeStep = 0
+		
+      ! initialize interpolation 
+      call interpolate_init(domain, err)
+
+      ! Allocate globalArray and gatheredArray only on process 0
+      call MPI_COMM_RANK( domain % dminfo % comm, curProc, err)
+		
+      if (curProc.eq.0) then
+          allocate(globalArray1(nCellsGlobal), gatheredArray1(nCellsGlobal))
+          allocate(globalArray2(nCellsGlobal), gatheredArray2(nCellsGlobal))	 
+      endif
+				
       call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
-      call mpas_log_write("<<< get initial thickness and bedTopo array. mpas_li_bedtopo.F, L110")
 	   call mpas_pool_get_array(geometryPool, 'thickness', thickness)
 	   call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
-
-		! HH: check the fill value in MALI for the outside of the domain.
-		! HH: patch a really big fill value (like 10e6) to thickness and bedtopography in outside of the domain
 		
-		! HH: interpolate thickness and bedTopograpy to the Gaussian grid
-      write(1,*) '<<<BEDTOPO init shape of thickness mali mesh', shape(thickness)
-      write(1,*) '<<<BEDTOPO init shape of BedTopography mali mesh', shape(bedTopography)
-      call interpolate(toColValues, toRowValues, toSvalues, thickness, thickness_slGrid1D)
-      call interpolate(toColValues, toRowValues, toSvalues, bedTopography, bedrock_slGrid1D)
-		! reformat the interpolated data
-		ism_iceload = reshape(thickness_slGrid1D, [nglv,2*nglv])
-		ism_bedrock = reshape(bedrock_slGrid1D, [nglv, 2*nglv])
-	  	
-		! initialize the sea-level solver
-		call slmodel_init(domain % logInfo % outputLog % unitNum, ism_iceload, ism_bedrock)
+	   call mpas_log_write("<<< gather initial thickness and bedTopo array. mpas_li_bedtopo.F, L132")
+
+
+      ! Gather only the nCellsOwned from thickness and bedtopo (does not include Halos)
+      call MPI_GATHERV(thickness, nCellsOwned, MPI_DOUBLE, gatheredArray1, nCellsPerProc, &
+                       nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err)							 
+      call MPI_GATHERV(bedTopography, nCellsOwned, MPI_DOUBLE, gatheredArray2, nCellsPerProc, &
+                       nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err)							 
+     
+	   if (curProc.eq.0) then
+			 call mpas_log_write("<<< we are on the head note. init slmodel")
+         ! Rearrange data into CellID order
+          do iCell = 1,nCellsGlobal
+             globalArray1(indexToCellIDGathered(iCell)) = gatheredArray1(iCell)
+             globalArray2(indexToCellIDGathered(iCell)) = gatheredArray2(iCell)
+          enddo
+
+	   	! HH: interpolate thickness and bedTopograpy to the Gaussian grid
+         call interpolate(toColValues, toRowValues, toSvalues, globalArray1, thickness_slGrid1D)
+         call interpolate(toColValues, toRowValues, toSvalues, globalArray2, bedrock_slGrid1D)
+		   call write_txt(thickness_slGrid1D, 'mali_iceload_init','')
+			
+		   ! HH: check the fill value in MALI for the outside of the domain.
+	   	! HH: patch a really big fill value (like 10e6) to thickness and bedtopography in outside of the domain
+		
+		   ! reformat the interpolated data
+	   	ism_iceload = reshape(thickness_slGrid1D, [nglv,2*nglv])
+	   	ism_bedrock = reshape(bedrock_slGrid1D, [nglv, 2*nglv])
+	   	
+	   	! initialize the sea-level solver
+	   	call slmodel_init(domain % logInfo % outputLog % unitNum, ism_iceload, ism_bedrock)
+          
+         deallocate(globalArray1, gatheredArray1)
+			deallocate(globalArray2, gatheredArray2)
+      endif
+
 #endif
 
    !--------------------------------------------------------------------
@@ -199,8 +245,17 @@ subroutine li_bedtopo_solve(domain, err)
       use mpas_timekeeping 
       use li_mask
       use li_advection
+		
+#ifdef USE_SEALEVELMODEL
 	   use user_specs_mod, only: nglv
 		use io_mod !<<HH delete if not needed
+		
+		real (kind=RKIND), dimension(:), allocatable :: slChange_maliMesh !HH: 4268 is the size of mali mesh
+		real (kind=RKIND), dimension(nglv,2*nglv) ::  ism_iceload, slChange !< for MALI-SLM coupling
+		real (kind=RKIND), dimension(nglv*2*nglv) ::  thickness_slGrid1D, slChange_slGrid1D
+
+#endif
+
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
@@ -229,23 +284,13 @@ subroutine li_bedtopo_solve(domain, err)
       type (mpas_pool_type), pointer :: velocityPool      !< velocity information
 
       real (kind=RKIND), dimension(:), pointer :: thickness, bedTopography, upliftRate
-		!real (kind=RKIND), dimension(:), allocatable :: slChange_maliMesh !HH: edit => not sure why this variable should be a pointer like is done in mpas-o. make it an allocatable variable? 
-		real (kind=RKIND), dimension(:), allocatable :: slChange_maliMesh !HH: 4268 is the size of mali mesh
+
 
       real (kind=RKIND), pointer :: deltat
       integer :: err_tmp, i, j
-		
-	!	integer, dimension(512) ::  nglv !< for MALI-SLM coupling. Read in from namelist
-		real (kind=RKIND), dimension(nglv,2*nglv) ::  ism_iceload, slChange !< for MALI-SLM coupling
-		real (kind=RKIND), dimension(nglv*2*nglv) ::  thickness_slGrid1D, slChange_slGrid1D
-
-      ! MPI Variables
-      integer :: iCell, ilm, curProc
-      real (kind=RKIND), dimension(:), allocatable :: globalArray, gatheredArray
-		
+			
       err = 0
       err_tmp = 0
-
 
       ! Set needed variables and pointers
       call mpas_pool_get_config(liConfigs, 'config_uplift_method', config_uplift_method)
@@ -273,6 +318,7 @@ subroutine li_bedtopo_solve(domain, err)
          end do
 
 		elseif (trim(config_uplift_method)=='sealevelmodel') then
+	       call mpas_log_write("<<< A, L342")
 
 	        call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
   		     call mpas_pool_get_array(geometryPool, 'thickness', thickness)
@@ -293,61 +339,109 @@ subroutine li_bedtopo_solve(domain, err)
 				err = ior(err, err_tmp)
 				
 				slmTimeStep = slmTimeStep + 1
-		       write(1,*) '<<< SL alarm is ringing'
+		      call mpas_log_write("<<< SL alarm is ringing")
 
 	         ! Allocate globalArray and gatheredArray only on process 0
-	         !call MPI_COMM_RANK( dminfo % comm, curProc, err)
-	        ! if (curProc.eq.0) then
-	         !    allocate(globalArray(nCellsGlobal), gatheredArray(nCellsGlobal))
-	         !endif
-
-				write(1,*) '<<<shape of thickness mali mesh', shape(thickness)
-
-				! HH: gather thickness to the head processor
-				! HH: interpolate thickness to Gaussian grid
-				write(1,*)'<<< interpolate onto Gaussian grid'
+	         call MPI_COMM_RANK(domain % dminfo % comm, curProc, err)
 				
-            call interpolate(toColValues, toRowValues, toSvalues, thickness, thickness_slGrid1D)
-				call write_txt(thickness_slGrid1D, 'mali_iceload2','')
+	         if (curProc.eq.0) then
+	            allocate(globalArray1(nCellsGlobal), gatheredArray1(nCellsGlobal))
+					allocate(globalArray2(nCellsGlobal), gatheredArray2(nCellsGlobal))
+	            allocate(globalArray3(nCellsGlobal), gatheredArray3(nCellsGlobal))
+	         endif
+								
+	         ! Gather only the nCellsOwned from ice thickness (does not include Halos)
+	         call MPI_GATHERV(thickness, nCellsOwned, MPI_DOUBLE, gatheredArray1, nCellsPerProc, &
+	                          nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err)
+				call mpas_log_write("<<< thickness gathered")
 				
-				! reshape the interpolated data
-				ism_iceload(:,:) = reshape(thickness_slGrid1D, [nglv ,2*nglv])
-				write(1,*) '<<< Calling SLM now mpas_li_bedtopo L305, slmTimeStep', slmTimeStep
-				call slmodel_solve(slmTimeStep, ism_iceload, slChange)
+            if (curProc.eq.0) then	
+					call mpas_log_write("<<< we are on the head node L369")
+													             
+			      ! Rearrange thickness into CellID order
+			      do iCell = 1,nCellsGlobal
+			         globalArray1(indexToCellIDGathered(iCell)) = gatheredArray1(iCell)
+			      enddo
+
+					! interpolate thickness to Gaussian grid					
+               call interpolate(toColValues, toRowValues, toSvalues, globalArray1, thickness_slGrid1D)
+				  	call mpas_log_write('<<<shape of global array mesh $i', intArgs=(/shape(globalArray1)/))
+					call mpas_log_write('<<<shape of global array mesh $i', intArgs=(/shape(thickness_slGrid1D)/))
+				   call write_txt(thickness_slGrid1D, 'mali_iceload','')  !HH check iceload. output text file is of wrong size in parallel computing
+				  
+				   ! reshape the interpolated data
+				   ism_iceload(:,:) = reshape(thickness_slGrid1D, [nglv,2*nglv]) !<<HH why does it not work!? 
+				   call mpas_log_write("<<< Calling SLM now mpas_li_bedtopo L305 slmStep $i", intArgs=(/slmTimeStep/))
+
+					! call the sea-level solver
+					call mpas_log_write("<<< Calling slmodel_solve")
+				   call slmodel_solve(slmTimeStep, ism_iceload, slChange)
 				
-				! HH: interpolate slchange from Gaussian grid to MALI mesh and reshape
-				slChange_slGrid1D = reshape(slChange, [nglv*2*nglv])
-				allocate(slChange_maliMesh(size(bedTopography)))
-				write(1,*) '<<<shape of bedTopography', shape(bedTopography), size(bedTopography)
+				   call mpas_log_write("<<< reshape and interpolate slm output onto mali mesh")
+				  	call mpas_log_write('<<<shape of global array mesh $i', intArgs=(/shape(slChange)/))
 
-				! interpolate sea-level change from GL grid to MALI mesh.
-            call interpolate(fromColValues, fromRowValues, fromSValues, slChange_slGrid1D, slChange_maliMesh)
-			   write(1,*) '<<< shape of slChange on Mali mesh', shape(slChange_maliMesh), size(slChange_maliMesh)
+				   ! HH: interpolate slchange from Gaussian grid to MALI mesh and reshape
+				   slChange_slGrid1D = reshape(slChange, [nglv*2*nglv])
+			      !allocate(slChange_maliMesh(size(bedTopography)))
 
-				!<<<HH: test interpolation back to SLM grid
-            call interpolate(toColValues, toRowValues, toSvalues, slChange_maliMesh, slChange_slGrid1D)
-            call write_txt(slChange_slGrid1D,'SLC_back','')
+				   ! interpolate sea-level change from GL grid to MALI mesh.
+					call interpolate(fromColValues, fromRowValues, fromSValues, slChange_slGrid1D, globalArray3)
+              ! call interpolate(fromColValues, fromRowValues, fromSValues, slChange_slGrid1D, slChange_maliMesh)
+
+				   !<<<HH: test interpolation back to SLM grid
+               call interpolate(toColValues, toRowValues, toSvalues, globalArray3, slChange_slGrid1D)
+               call write_txt(slChange_slGrid1D,'SLC_back','')
 				 
-				! HH: scatter slm_bedTopo to processors
-
-				! update bedTopography
-				bedTopography(:) = bedTopography(:) - slChange_maliMesh(:)
+	            ! Rearrange back to index order
+	            do iCell = 1,nCellsGlobal
+	                gatheredArray3(iCell) = globalArray3(indexToCellIDGathered(iCell))
+	            enddo
+					
+				   call mpas_log_write("<<< update bedtopo")
+					
+		         call mpas_reset_clock_alarm(domain % clock, 'slmCouplingInterval', ierr=err_tmp)
+		         err = ior(err, err_tmp)
+				   call mpas_log_write("<<<end curProc=0")
+					
+				endif
 				
+	         call MPI_SCATTERV(gatheredArray3, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
+	                     globalArray3, nCellsAll, MPI_DOUBLE, 0, domain % dminfo % comm, err) 
+			 				   call mpas_log_write("<<< rearrange back to index order")
+			  ! update bedTopography
+				bedTopography(:) = bedTopography(:) - globalArray3(:)
+				
+			   ! scatter updated bedTopo to processors
+			   call mpas_log_write("<<< scatter back bedtopo")
+	         !call MPI_SCATTERV(gatheredArray2, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
+	         !             bedTopography, size(bedTopography), MPI_DOUBLE, 0, domain % dminfo % comm, err) 
+			   call MPI_SCATTERV(gatheredArray2, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
+			                bedTopography, nCellsAll, MPI_DOUBLE, 0, domain % dminfo % comm, err) 
+								 !HH would values is bedTopography replaced by the new values? 
+								 
 				! deallocate memory
-				deallocate(slChange_maliMesh)
+	         if (curProc.eq.0) then
+	            deallocate(globalArray1, gatheredArray1)
+					deallocate(globalArray2, gatheredArray2)
+					deallocate(globalArray3, gatheredArray3)
+	         endif
 
-		      call mpas_reset_clock_alarm(domain % clock, 'slmCouplingInterval', ierr=err_tmp)
-		      err = ior(err, err_tmp)
+	         ! Perform Halo exchange update
+	         call mpas_dmpar_field_halo_exch(domain,'bedTopography')
+			   call mpas_log_write("<<< done SL calculatation!")
+
 			else
-				!write(6,*) '<<< mpas alarm is not rining. SLM is not called>>>'
+				
 			 ! do nothing for now, but could calculate uplift rate here later instead.
 		   endif
 		else
 			call mpas_log_write("'sealevelmodel' should be selected for option 'config_uplift_method'", MPAS_LOG_ERR)
 		endif
-
+      
+		! Perform Halo exchange update
+      call mpas_dmpar_field_halo_exch(domain,'bedTopography')
       call li_update_geometry(geometryPool)
-      !call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
 
 #endif
 
@@ -457,7 +551,7 @@ subroutine li_bedtopo_solve(domain, err)
 	   call sl_solver_init(itersl_sh, starttime_sh, ism_iceload, ism_bedrock)
 	   call deallocate_slarrays ! Deallocate arrays that are set from sl_timewindow()
 	   !call check_call_slmodel ! do i need this?
-	   flush(unit_num) ! HH: is this needed?
+	!   flush(unit_num) ! HH: is this needed?
 
    !--------------------------------------------------------------------
 	end subroutine slmodel_init
@@ -506,8 +600,6 @@ subroutine li_bedtopo_solve(domain, err)
 
 		integer ::  itersl_sh, dtime_sh
 		real    :: starttime_sh
-	 !  integer, parameter :: nglv = 512       		 !HH get this value from namelist later
-
 
 		! 1. check if we are on the head node
 		! 2. check if SLM should be called. If SLM should be called, then:
@@ -521,9 +613,15 @@ subroutine li_bedtopo_solve(domain, err)
 		itersl_sh = 1	   ! * note: hardcode itersl_sh == 1.
 		starttime_sh = 0 ! get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation)
 	   dtime_sh = 2
+		call mpas_log_write("<<< sl_solver_checkpoint")
 		call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt error
+		call mpas_log_write("<<< sl_timewindow")
 		call sl_timewindow(slmTimeStep)
+		call mpas_log_write("<<< sl_solver")
+		
 		call sl_solver(itersl_sh, slmTimeStep, dtime_sh, starttime_sh, ism_iceload, slm_slchange)
+		call mpas_log_write("<<< deallocate slarray")
+		
 		call deallocate_slarrays		! 8. deallocate memory within the slm
 
 		! 9. read in and interpolate the new bedrock topography from SLM to MALI grid
@@ -554,7 +652,7 @@ subroutine li_bedtopo_solve(domain, err)
 !
 !  routine interpolate
 !
-!> \brief   Perform interpolation
+!> \brief   Perform interpolation between MALI mesh and SLM grid
 !> \author  Holly Han
 !> \date    December 2021
 !> \details
@@ -601,7 +699,6 @@ subroutine li_bedtopo_solve(domain, err)
               rhs = rhs + dataIn(nCol) * sValues(n)
               n = n + 1
           end do
-			 !write(1,*) '<<< shapedataOut and nRow', shape(dataOut), nRow
           dataOut(nRow) = rhs
           rhs = 0
       end do
@@ -650,10 +747,10 @@ subroutine li_bedtopo_solve(domain, err)
       ! local variables
       !-----------------------------------------------------------------
 
-      type (mpas_pool_type), pointer :: meshPool          !< mesh information
 
       character (len=StrKIND), pointer :: config_MALI_to_SLM_weights_file
       character (len=StrKIND), pointer :: config_SLM_to_MALI_weights_file
+      type (mpas_pool_type), pointer :: meshPool          !< mesh information
 
       ! NetCDF and weights file variables
       integer :: toNcId, toNsDimId, toRowId, toColId, toSId
@@ -665,7 +762,7 @@ subroutine li_bedtopo_solve(domain, err)
 
       ! MPI variables
       integer :: curProc
-      integer, pointer ::  nCells
+     ! integer, pointer ::  nCells
       integer, dimension(:), pointer :: indexToCellID
       integer :: iProc, l, ilm, nProcs
 
@@ -674,29 +771,44 @@ subroutine li_bedtopo_solve(domain, err)
       call mpas_pool_get_config(liConfigs, 'config_MALI_to_SLM_weights_file', config_MALI_to_SLM_weights_file)
       call mpas_pool_get_config(liConfigs, 'config_SLM_to_MALI_weights_file', config_SLM_to_MALI_weights_file)
       
-		!block_ptr => domain % blocklist
-     ! do while ( associated( block_ptr ) )
-      !    call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
-      !    call mpas_pool_get_dimension(meshPool, 'nCells', nCells) 
-       !   block_ptr => block_ptr % next
-     ! end do
-     ! call mpas_pool_get_array(meshPool, 'indexToCellID', indexToCellID)
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
+      call mpas_pool_get_dimension(meshPool, 'nCells', nCellsAll)	
+		call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsOwned)
+      call mpas_pool_get_array(meshPool, 'indexToCellID', indexToCellID)
 
-     ! call MPI_COMM_RANK( domain % dminfo % comm, curProc, err)
-     ! call MPI_COMM_SIZE( domain % dminfo % comm, nProcs, err)
+      ! Begin MPI portion
+      call MPI_COMM_RANK( domain % dminfo % comm, curProc, err)
+      call MPI_COMM_SIZE( domain % dminfo % comm, nProcs, err)
 
+		
       ! perform the initialization on the head processor
-    !  if (curProc.eq.0) then
-	!		allocate(nCellsPerProc(nProcs))
-	!		allocate(nCellsDisplacement(nProcs))
-	!	endif
+      if (curProc.eq.0) then
+ 			allocate(nCellsPerProc(nProcs))
+			allocate(nCellsDisplacement(nProcs))
+		endif
+		
+      ! Gather nCellsOwned
+      call MPI_GATHER( nCellsOwned, 1, MPI_INTEGER, nCellsPerProc, 1, MPI_INTEGER, &
+                       0, domain % dminfo % comm, err)
+		
+      ! Set Displacement variable for GATHERV command
+      if (curProc.eq.0) then
+         nCellsGlobal = sum(nCellsPerProc)
+			allocate(indexToCellIDGathered(nCellsGlobal))
+         nCellsDisplacement(1) = 0
+			if (nProcs > 1) then
+			   do iProc=2,nProcs
+			      nCellsDisplacement(iProc) = nCellsDisplacement(iProc-1) + nCellsPerProc(iProc-1)
+            enddo
+         endif
+      endif
 
-	!	! gather nCells
-		!call MPI_GATHER( )
+      ! Gather indexToCellID
+      call MPI_GATHERV( indexToCellID, nCellsOwned, MPI_INTEGER, indexToCellIDGathered, &
+              nCellsPerProc, nCellsDisplacement, MPI_INTEGER, 0, domain % dminfo % comm, err)
 
-	!	if (curProc.eq.0) then
-		!	mpasToGridFile = '/Users/hollyhan/Desktop/RESEARCH/Regridding/Regrid_MPAS-SLM/mapfile_MALI_to_SLM_ESMF.nc'
-		!	gridToMpasFile = '/Users/hollyhan/Desktop/RESEARCH/Regridding/Regrid_MPAS-SLM/mapfile_SLM_to_MALI_ESMF.nc'
+	   !initialize interpoation
+	 	if (curProc.eq.0) then
          mpasToGridFile = trim(config_MALI_to_SLM_weights_file)
          gridToMpasFile = trim(config_MALI_to_SLM_weights_file)
 
@@ -740,7 +852,7 @@ subroutine li_bedtopo_solve(domain, err)
          call check( nf90_get_var(fromNcId, fromRowId, fromRowValues(:) ) ,err)
          call check( nf90_get_var(fromNcId, fromSId, fromSValues(:) ) ,err)
 
-     ! endif
+      endif
 
    !--------------------------------------------------------------------
    end subroutine interpolate_init

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -67,7 +67,10 @@ contains
 
    subroutine li_bedtopo_init(domain, err)
 #ifdef USE_SEALEVELMODEL
+		use spharmt 
       use planets_mod
+		use io_mod
+		!use user_specs_mod
 #endif
       !-----------------------------------------------------------------
       ! input variables
@@ -94,10 +97,8 @@ contains
       err = 0
 
 #ifdef USE_SEALEVELMODEL
-      ! add calls to code in the sea level model inside ifdefs only.
-      call mpas_log_write("<<< Compiled successfully with Sea Level Model! >>>") ! Replace with actual call
-      call earth_init()
-      call mpas_log_write("<<< Successfully called earth_init! >>>") ! Replace with actual call
+		call slmodel_init()
+      call mpas_log_write("<<< Successfully called slmodel_init()! >>>") ! Replace with actual call
 #endif
 
    !--------------------------------------------------------------------
@@ -194,6 +195,23 @@ subroutine li_bedtopo_solve(domain, err)
       real (kind=RKIND), pointer :: deltat
       integer :: err_tmp
 
+		!HH: variables for the sea-level solver module --------------------
+		integer :: i, itersl_sh, iter_sh, dtime_sh
+		real :: starttime_sh                ! start time of the simulation 
+		integer :: iargc, nargs             ! Arguments read in from a bash script                           
+		character(16) :: carg(20)           ! Arguments from a bash script
+
+		! Reading in arguments from a bash script
+	!	nargs = iargc()
+	!	do i=1,nargs
+	!	   call getarg(i, carg(i))
+	!	enddo
+	!	read (carg(1),*) itersl_sh
+	!	read (carg(2),*) iter_sh      ! the coupling time step we are on (in years)
+	!	read (carg(3),*) dtime_sh     ! coupling time (in years)
+	!	read (carg(4),*) starttime_sh ! start time of the simulation (in years)
+		!HH: variables for the sea-level solver module --------------------
+		
       err = 0
       err_tmp = 0
 
@@ -230,6 +248,19 @@ subroutine li_bedtopo_solve(domain, err)
 #ifdef USE_SEALEVELMODEL
       ! add calls to code in the sea level model inside ifdefs only.
       call mpas_log_write("<<< Compiled successfully with Sea Level Model! >>>") ! Replace with actual call
+		
+		!HH
+		!-------------------------------------------------------------------------------------------	
+     ! elseif (trim(config_uplift_method)=='slmodel') then !HH
+			
+		!	call sl_solver_checkpoint(itersl_sh, dtime_sh)
+		!	call set_planet 
+		!	call sl_timewindow(iter_sh)
+			
+	    !  elseif (iter_sh .gt. 0) then 
+	!		   call sl_solver(itersl_sh, iter_sh, dtime_sh, starttime_sh) !dtime_sh should come from nml.
+	!		endif
+		!-------------------------------------------------------------------------------------------	
 #endif
 
 
@@ -287,6 +318,50 @@ subroutine li_bedtopo_solve(domain, err)
 
 
    ! private subroutines
+
+	subroutine slmodel_init
+	   use sl_model_mod !HH
+		! declare variables
+		integer :: iter_sh, itersl_sh
+		real    :: starttime_sh 
+		! check if we are on the head processor
+		! get initial topography from MALI 
+		     ! gather topography to the headnode
+		! interpolate init topo from MALI grid to SLM grid
+		! pass interpolated topo from MALI to SLM
+		iter_sh = 0 
+		itersl_sh = 1	   ! * note: hardcode itersl_sh == 1. 
+		starttime_sh = 0 ! get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation) 
+	   
+		call set_planet 
+		call sl_timewindow(iter_sh)
+			 ! * note: read in namelist values. SLM should return dtime from its own namelist file and MALI stores the values
+	   call sl_solver_init(itersl_sh, starttime_sh)
+	end subroutine slmodel_init
+	
+	subroutine slmodel_solve
+		! check if we are on the head node
+		! check if SLM should be called. If SLM should be called, then:
+		   ! get new iceload from MALI
+			    !gather iceload to the head node 
+	    	! interpolate iceload from MALI to SLM grid
+		   ! pass interpolated iceload from MALI to SLM 
+		   ! get itersl_sh, iter_sh, dtime_sh, starttime_sh
+			! call set_planet & sl_timewindow
+         ! call sl_solver
+			! read in and interpolate the new bedrock topography from SLM to MALI grid
+			   ! option 1 (initial choice): set bed topography relative to geoid 
+				! option 2: keep track of both surfaces or one? 
+			! scatter topography to all processors. 
+	end subroutine slmodel_solve
+	
+	! last step (refer to the MPAS Ocean model)
+	subroutine interp_li_to_slm
+	end subroutine interp_li_to_slm
+	
+	subroutine interp_slm_to_li
+	end subroutine interp_slm_to_li
+	
 
 
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -70,7 +70,7 @@ contains
 		use spharmt 
       use planets_mod
 		use io_mod
-		!use user_specs_mod
+		use user_specs_mod, only: dt1
 #endif
       !-----------------------------------------------------------------
       ! input variables
@@ -87,6 +87,7 @@ contains
       !-----------------------------------------------------------------
 
       integer, intent(out) :: err !< Output: error flag
+		integer :: dtime_sl, iter_sl
 
       !-----------------------------------------------------------------
       ! local variables
@@ -97,10 +98,11 @@ contains
       err = 0
 
 #ifdef USE_SEALEVELMODEL
-      call mpas_log_write("<<< 1.Successfully called slmodel_init()! >>>") ! Replace with actual call
-		call slmodel_init()
-      call mpas_log_write("<<< 2.Successfully called slmodel_init()! >>>") ! Replace with actual call
-		
+      write(6,*)'<<< Calling slmodel_init from li_bedtopo_init! >>>'
+		call mpas_log_write("<<< Calling slmodel_init()! >>>") 
+		call slmodel_init
+		write(6,*)'<<< Successfully called slmodel_init! >>>' ! Replace with actual call
+	   call mpas_log_write("<<< Successfully called slmodel_init()! >>>") 
 #endif
 
    !--------------------------------------------------------------------
@@ -164,6 +166,7 @@ contains
 !-----------------------------------------------------------------------
 subroutine li_bedtopo_solve(domain, err)
 
+      use mpas_timekeeping 
       use li_mask
       use li_advection
 
@@ -189,6 +192,7 @@ subroutine li_bedtopo_solve(domain, err)
 
       type (block_type), pointer :: block
       character (len=StrKIND), pointer :: config_uplift_method
+		character (len=StrKIND), pointer :: config_slm_coupling_interval
       type (mpas_pool_type), pointer :: meshPool          !< mesh information
       type (mpas_pool_type), pointer :: geometryPool      !< geometry information
       type (mpas_pool_type), pointer :: velocityPool      !< velocity information
@@ -225,21 +229,35 @@ subroutine li_bedtopo_solve(domain, err)
             block => block % next
          end do
 
+		elseif (trim(config_uplift_method)=='sealevelmodel') then
+			call mpas_log_write("<<< Sea level model is coupled to MALI >>>")
       else
          call mpas_log_write("Unknown option selected for 'config_uplift_method'", MPAS_LOG_ERR)
       endif
 
-
 #ifdef USE_SEALEVELMODEL
-      call mpas_log_write("<<< Calling slmodel_solve! >>>") ! Replace with actual call
-		call slmodel_solve
-      call mpas_log_write("<<< Called slmodel_solve successfully! >>>") ! Replace with actual call
+      if (trim(config_uplift_method)=='sealevelmodel') then
+			call mpas_pool_get_config(liConfigs, 'config_slm_coupling_interval', config_slm_coupling_interval)
+		   if (mpas_is_alarm_ringing(domain % clock, 'slmCouplingInterval', ierr=err_tmp)) then 
+				err = ior(err, err_tmp)
+			  
+		      call slmodel_solve
+			   write(6,*) "<<< Called slmodel_solve successfully! >>>" 
+            call mpas_log_write("<<< Called slmodel_solve successfully! >>>")
+		      call mpas_reset_clock_alarm(domain % clock, 'slmCouplingInterval', ierr=err_tmp)
+		      err = ior(err, err_tmp)
+			else
+				write(6,*) '<<< mpas alarm is not reading. SLM is not called>>>'
+			 ! do nothing for now, but could calculate uplift rate here later instead. 
+		   endif
+		else
+			call mpas_log_write("'sealevelmodel' should be selected for option 'config_uplift_method'", MPAS_LOG_ERR)
+		endif
 #endif
-
 
       ! === error check
       if (err > 0) then
-          call mpas_log_write("An error has occurred in li_bedtopo_solve.", MPAS_LOG_ERR)
+          call mpas_log_write("An error has occurred in li_bedtopo_solve.")
       endif
 
    !--------------------------------------------------------------------
@@ -305,15 +323,13 @@ subroutine li_bedtopo_solve(domain, err)
 		iter_sh = 0 
 		itersl_sh = 1	   ! * note: hardcode itersl_sh == 1. 
 		starttime_sh = 0 ! get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation) 
-	   dtime_sh = 100
-		
-		!call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt error
-		call set_planet 
+	   dtime_sh = 2
+		call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt error
 		call sl_timewindow(iter_sh)
 			 ! * note: read in namelist values. SLM should return dtime from its own namelist file and MALI stores the values
-	   !call sl_solver_init(itersl_sh, starttime_sh)  !Uncomment this after fixing the spharmt error
-		! Deallocate arrays that are set from sl_timewindow()
-	   call deallocate_slarrays
+	   call sl_solver_init(itersl_sh, starttime_sh)  !Uncomment this after fixing the spharmt error
+	   call deallocate_slarrays ! Deallocate arrays that are set from sl_timewindow()
+		!call check_call_slmodel ?
 	end subroutine slmodel_init
 	
 	
@@ -332,11 +348,16 @@ subroutine li_bedtopo_solve(domain, err)
 		! 5. get itersl_sh, iter_sh, dtime_sh, starttime_sh
 		
 	   ! 6. call sl_checkpoint & set_planet & sl_timewindow
-		!call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt error
-		call set_planet
+		itersl_sh = 1	   ! * note: hardcode itersl_sh == 1. 
+		starttime_sh = 0 ! get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation) 
+	   dtime_sh = 2
+	   iter_sh = 1
+		call mpas_log_write("A")
+		call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt error
+		call mpas_log_write("B")
 		call sl_timewindow(iter_sh)
       ! 7.  call sl_solver
-		!call sl_solver(itersl_sh, iter_sh, dtime_sh, starttime_sh) !Uncomment this after fixing the spharmt error
+		call sl_solver(itersl_sh, iter_sh, dtime_sh, starttime_sh) !Uncomment this after fixing the spharmt error
 		! 8. deallocate memory within the slm
 		call deallocate_slarrays
 		
@@ -345,6 +366,17 @@ subroutine li_bedtopo_solve(domain, err)
 				! option 2: keep track of both surfaces or one? 
 		! 10. scatter topography to all processors. 
 	end subroutine slmodel_solve
+	
+	!subroutine sl_get_iter(nmelt)
+	!	integer :: iter
+	!	iter = nmelt
+	!end subroutine sl_get_iter
+
+	!subroutine check_call_slmodel(iter_sl, dtime_sl)
+	!	integer :: iter_sl, dtime_sl, timestepNumber
+	!	write(6,*)'CHECK Completed timestep.  New time is: ', iter_sl, dtime_sl, timestepNumber
+	!end subroutine check_call_slmodel
+	
 	
 	! last step (refer to the MPAS Ocean model)
 	subroutine interp_li_to_slm

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -46,7 +46,7 @@ module li_bedtopo
    !--------------------------------------------------------------------
    ! Private module variables
    !--------------------------------------------------------------------
-
+   integer, save :: slmTimeStep
 
 
 !***********************************************************************
@@ -87,7 +87,6 @@ contains
       !-----------------------------------------------------------------
 
       integer, intent(out) :: err !< Output: error flag
-		integer :: dtime_sl, iter_sl
 
       !-----------------------------------------------------------------
       ! local variables
@@ -98,6 +97,8 @@ contains
       err = 0
 
 #ifdef USE_SEALEVELMODEL
+      ! initialize coupling time step number. initial time is 0
+      slmTimeStep = 0 
       write(6,*)'<<< Calling slmodel_init from li_bedtopo_init! >>>'
 		call mpas_log_write("<<< Calling slmodel_init()! >>>") 
 		call slmodel_init
@@ -204,6 +205,7 @@ subroutine li_bedtopo_solve(domain, err)
       err = 0
       err_tmp = 0
 
+
       ! Set needed variables and pointers
       call mpas_pool_get_config(liConfigs, 'config_uplift_method', config_uplift_method)
       if (trim(config_uplift_method)=='none') then
@@ -230,24 +232,25 @@ subroutine li_bedtopo_solve(domain, err)
          end do
 
 		elseif (trim(config_uplift_method)=='sealevelmodel') then
-			call mpas_log_write("<<< Sea level model is coupled to MALI >>>")
+			 ! do nothing
       else
          call mpas_log_write("Unknown option selected for 'config_uplift_method'", MPAS_LOG_ERR)
       endif
 
 #ifdef USE_SEALEVELMODEL
-      if (trim(config_uplift_method)=='sealevelmodel') then
+		if (trim(config_uplift_method)=='sealevelmodel') then
 			call mpas_pool_get_config(liConfigs, 'config_slm_coupling_interval', config_slm_coupling_interval)
 		   if (mpas_is_alarm_ringing(domain % clock, 'slmCouplingInterval', ierr=err_tmp)) then 
 				err = ior(err, err_tmp)
-			  
-		      call slmodel_solve
-			   write(6,*) "<<< Called slmodel_solve successfully! >>>" 
-            call mpas_log_write("<<< Called slmodel_solve successfully! >>>")
+			   write(6,*) '<<< mpas alarm is rining from li_bedtopo.F L246>>>'
+				slmTimeStep = slmTimeStep + 1
+			   write(6,*) '<<< HH: NMELT COUPLING timestep number, L247>>>', slmTimeStep
+		      call slmodel_solve(slmTimeStep)
+            call mpas_log_write("<<< coupling interval reached: Calling the slmodel solver >>>")
 		      call mpas_reset_clock_alarm(domain % clock, 'slmCouplingInterval', ierr=err_tmp)
 		      err = ior(err, err_tmp)
 			else
-				write(6,*) '<<< mpas alarm is not reading. SLM is not called>>>'
+				write(6,*) '<<< mpas alarm is not rining. SLM is not called>>>'
 			 ! do nothing for now, but could calculate uplift rate here later instead. 
 		   endif
 		else
@@ -307,38 +310,39 @@ subroutine li_bedtopo_solve(domain, err)
    end subroutine li_bedtopo_finalize
 
 
-
    ! private subroutines
 
 	subroutine slmodel_init
 	   use sl_model_mod !HH
+
 		! declare variables
-		integer :: iter_sh, itersl_sh, dtime_sh
+		integer :: slmTimeStep, itersl_sh, dtime_sh
 		real    :: starttime_sh
 		! 1. check if we are on the head processor, if yes, then:
 		! 2. get initial topography from MALI 
 		     ! 2-1. gather topography to the headnode
 		! 3. interpolate init topo from MALI grid to SLM grid
 		! 4. pass interpolated topo from MALI to SLM
-		iter_sh = 0 
+
 		itersl_sh = 1	   ! * note: hardcode itersl_sh == 1. 
 		starttime_sh = 0 ! get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation) 
 	   dtime_sh = 2
 		call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt error
-		call sl_timewindow(iter_sh)
+		call sl_timewindow(slmTimeStep)
 			 ! * note: read in namelist values. SLM should return dtime from its own namelist file and MALI stores the values
-	   call sl_solver_init(itersl_sh, starttime_sh)  !Uncomment this after fixing the spharmt error
+	   call sl_solver_init(itersl_sh, starttime_sh)  
 	   call deallocate_slarrays ! Deallocate arrays that are set from sl_timewindow()
-		!call check_call_slmodel ?
+		!call check_call_slmodel ! do i need this?
 	end subroutine slmodel_init
 	
 	
-	subroutine slmodel_solve
+	subroutine slmodel_solve(slmTimeStep)
 		use sl_model_mod
 		
-		integer :: iter_sh, itersl_sh, dtime_sh
+		integer, intent(in):: slmTimeStep
+		integer ::  itersl_sh, dtime_sh
 		real    :: starttime_sh
-		
+
 		! 1. check if we are on the head node
 		! 2. check if SLM should be called. If SLM should be called, then:
 		    ! 2-1. get new iceload from MALI
@@ -351,26 +355,16 @@ subroutine li_bedtopo_solve(domain, err)
 		itersl_sh = 1	   ! * note: hardcode itersl_sh == 1. 
 		starttime_sh = 0 ! get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation) 
 	   dtime_sh = 2
-	   iter_sh = 1
-		call mpas_log_write("A")
 		call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt error
-		call mpas_log_write("B")
-		call sl_timewindow(iter_sh)
-      ! 7.  call sl_solver
-		call sl_solver(itersl_sh, iter_sh, dtime_sh, starttime_sh) !Uncomment this after fixing the spharmt error
-		! 8. deallocate memory within the slm
-		call deallocate_slarrays
+		call sl_timewindow(slmTimeStep)
+		call sl_solver(itersl_sh, slmTimeStep, dtime_sh, starttime_sh)       ! 7.  call sl_solver
+		call deallocate_slarrays		! 8. deallocate memory within the slm
 		
 		! 9. read in and interpolate the new bedrock topography from SLM to MALI grid
 			   ! option 1 (initial choice): set bed topography relative to geoid 
 				! option 2: keep track of both surfaces or one? 
 		! 10. scatter topography to all processors. 
 	end subroutine slmodel_solve
-	
-	!subroutine sl_get_iter(nmelt)
-	!	integer :: iter
-	!	iter = nmelt
-	!end subroutine sl_get_iter
 
 	!subroutine check_call_slmodel(iter_sl, dtime_sl)
 	!	integer :: iter_sl, dtime_sl, timestepNumber

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -196,23 +196,6 @@ subroutine li_bedtopo_solve(domain, err)
       real (kind=RKIND), dimension(:), pointer :: bedTopography, upliftRate
       real (kind=RKIND), pointer :: deltat
       integer :: err_tmp
-
-		!HH: variables for the sea-level solver module --------------------
-		integer :: i, itersl_sh, iter_sh, dtime_sh
-		real :: starttime_sh                ! start time of the simulation 
-		integer :: iargc, nargs             ! Arguments read in from a bash script                           
-		character(16) :: carg(20)           ! Arguments from a bash script
-
-		! Reading in arguments from a bash script
-	!	nargs = iargc()
-	!	do i=1,nargs
-	!	   call getarg(i, carg(i))
-	!	enddo
-	!	read (carg(1),*) itersl_sh
-	!	read (carg(2),*) iter_sh      ! the coupling time step we are on (in years)
-	!	read (carg(3),*) dtime_sh     ! coupling time (in years)
-	!	read (carg(4),*) starttime_sh ! start time of the simulation (in years)
-		!HH: variables for the sea-level solver module --------------------
 		
       err = 0
       err_tmp = 0
@@ -248,21 +231,9 @@ subroutine li_bedtopo_solve(domain, err)
 
 
 #ifdef USE_SEALEVELMODEL
-      ! add calls to code in the sea level model inside ifdefs only.
-      call mpas_log_write("<<< Compiled successfully with Sea Level Model! >>>") ! Replace with actual call
-		
-		!HH
-		!-------------------------------------------------------------------------------------------	
-     ! elseif (trim(config_uplift_method)=='slmodel') then !HH
-			
-		!	call sl_solver_checkpoint(itersl_sh, dtime_sh)
-		!	call set_planet 
-		!	call sl_timewindow(iter_sh)
-			
-	    !  elseif (iter_sh .gt. 0) then 
-	!		   call sl_solver(itersl_sh, iter_sh, dtime_sh, starttime_sh) !dtime_sh should come from nml.
-	!		endif
-		!-------------------------------------------------------------------------------------------	
+      call mpas_log_write("<<< Calling slmodel_solve! >>>") ! Replace with actual call
+		call slmodel_solve
+      call mpas_log_write("<<< Called slmodel_solve successfully! >>>") ! Replace with actual call
 #endif
 
 
@@ -326,37 +297,53 @@ subroutine li_bedtopo_solve(domain, err)
 		! declare variables
 		integer :: iter_sh, itersl_sh, dtime_sh
 		real    :: starttime_sh
-		! check if we are on the head processor
-		! get initial topography from MALI 
-		     ! gather topography to the headnode
-		! interpolate init topo from MALI grid to SLM grid
-		! pass interpolated topo from MALI to SLM
+		! 1. check if we are on the head processor, if yes, then:
+		! 2. get initial topography from MALI 
+		     ! 2-1. gather topography to the headnode
+		! 3. interpolate init topo from MALI grid to SLM grid
+		! 4. pass interpolated topo from MALI to SLM
 		iter_sh = 0 
 		itersl_sh = 1	   ! * note: hardcode itersl_sh == 1. 
 		starttime_sh = 0 ! get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation) 
 	   dtime_sh = 100
 		
-		call sl_solver_checkpoint(itersl_sh, dtime_sh)
+		!call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt error
 		call set_planet 
 		call sl_timewindow(iter_sh)
 			 ! * note: read in namelist values. SLM should return dtime from its own namelist file and MALI stores the values
-	   call sl_solver_init(itersl_sh, starttime_sh)
+	   !call sl_solver_init(itersl_sh, starttime_sh)  !Uncomment this after fixing the spharmt error
+		! Deallocate arrays that are set from sl_timewindow()
+	   call deallocate_slarrays
 	end subroutine slmodel_init
 	
+	
 	subroutine slmodel_solve
-		! check if we are on the head node
-		! check if SLM should be called. If SLM should be called, then:
-		   ! get new iceload from MALI
-			    !gather iceload to the head node 
-	    	! interpolate iceload from MALI to SLM grid
-		   ! pass interpolated iceload from MALI to SLM 
-		   ! get itersl_sh, iter_sh, dtime_sh, starttime_sh
-			! call set_planet & sl_timewindow
-         ! call sl_solver
-			! read in and interpolate the new bedrock topography from SLM to MALI grid
+		use sl_model_mod
+		
+		integer :: iter_sh, itersl_sh, dtime_sh
+		real    :: starttime_sh
+		
+		! 1. check if we are on the head node
+		! 2. check if SLM should be called. If SLM should be called, then:
+		    ! 2-1. get new iceload from MALI
+			 ! 2-2. gather iceload to the head node 
+	   ! 3. interpolate iceload from MALI to SLM grid
+		! 4. pass interpolated iceload from MALI to SLM 
+		! 5. get itersl_sh, iter_sh, dtime_sh, starttime_sh
+		
+	   ! 6. call sl_checkpoint & set_planet & sl_timewindow
+		!call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt error
+		call set_planet
+		call sl_timewindow(iter_sh)
+      ! 7.  call sl_solver
+		!call sl_solver(itersl_sh, iter_sh, dtime_sh, starttime_sh) !Uncomment this after fixing the spharmt error
+		! 8. deallocate memory within the slm
+		call deallocate_slarrays
+		
+		! 9. read in and interpolate the new bedrock topography from SLM to MALI grid
 			   ! option 1 (initial choice): set bed topography relative to geoid 
 				! option 2: keep track of both surfaces or one? 
-			! scatter topography to all processors. 
+		! 10. scatter topography to all processors. 
 	end subroutine slmodel_solve
 	
 	! last step (refer to the MPAS Ocean model)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -11,11 +11,11 @@
 !  li_bedtopo
 !
 !> \MPAS land-ice bedtopo driver
-!> \author Matt Hoffman
-!> \date   20 June 2019
+!> \author Matt Hoffman and Holly Han (modified)
+!> \date   20 June 2019, January 2022 (modified)
 !> \details
-!>  This module contains the routines for bed topography for solid earth changes
-!>
+!>  This module contains the routines for
+!>  bed topography for solid earth changes
 !
 !-----------------------------------------------------------------------
 
@@ -66,9 +66,9 @@ module li_bedtopo
    integer, pointer ::  nCellsOwned
    integer :: iCell, ilm, curProc
    
-   real (kind=RKIND), dimension(:), allocatable :: globalArray1, gatheredArray1
-   real (kind=RKIND), dimension(:), allocatable :: globalArray2, gatheredArray2
-   real (kind=RKIND), dimension(:), allocatable :: globalArray3, gatheredArray3, globalArray4
+   real (kind=RKIND), dimension(:), allocatable :: globalArrayIce, gatheredArrayIce
+   real (kind=RKIND), dimension(:), allocatable :: globalArrayBedTopo, gatheredArrayBedTopo
+   real (kind=RKIND), dimension(:), allocatable :: globalArraySLC, gatheredArraySLC
 
 !***********************************************************************
 
@@ -79,8 +79,8 @@ contains
 !  routine li_bedtopo_init
 !
 !> \brief   Initializes bedtopo solver
-!> \author  Matt Hoffman and Holly Kyeore Han
-!> \date    20 June 2019 (original), modified 1 December 2021
+!> \author  Matt Hoffman and Holly Han (modified)
+!> \date    20 June 2019 (original), December 2021 (modified)
 !> \details
 !>  This routine initializes the bedtopo solver.
 !
@@ -170,8 +170,8 @@ contains
 !  subroutine li_bedtopo_solve
 !
 !> \brief   Updates bed topography
-!> \author  Matt Hoffman and Holly Han
-!> \date    20 June 2019 (original), 1 December 2021 (modified)
+!> \author  Matt Hoffman and Holly Han (modified)
+!> \date    20 June 2019 (original), December 2021 (modified)
 !> \details
 !>  This routine updates the bed topography.  Currently the only option
 !>  is a data field passed in as input.
@@ -182,7 +182,7 @@ subroutine li_bedtopo_solve(domain, err)
       use mpas_timekeeping 
       use li_mask
       use li_advection
-      
+
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
@@ -243,7 +243,9 @@ subroutine li_bedtopo_solve(domain, err)
          end do
 
       elseif (trim(config_uplift_method)=='sealevelmodel') then
-			 ! do nothing
+
+			call mpas_log_write("Sea-level model is used to calculate changes in bedTopography")
+
       else
          call mpas_log_write("Unknown option selected for 'config_uplift_method'", MPAS_LOG_ERR)
       endif
@@ -252,18 +254,18 @@ subroutine li_bedtopo_solve(domain, err)
 
       if (trim(config_uplift_method)=='sealevelmodel') then
 			call mpas_pool_get_config(liConfigs, 'config_slm_coupling_interval', config_slm_coupling_interval)
-			
-	      if (mpas_is_alarm_ringing(domain % clock, 'slmCouplingInterval', ierr=err_tmp)) then 
+
+	      if (mpas_is_alarm_ringing(domain % clock, 'slmCouplingInterval', ierr=err_tmp)) then
 	         err = ior(err, err_tmp)
-				
+
 				slmTimeStep = slmTimeStep + 1
-				
+
 	         call mpas_log_write("<<< SL alarm is ringing. slmTimeStep: $i", intArgs=(/slmTimeStep/))
-            call slmodel_solve(slmTimeStep, domain) 
-				
+            call slmodel_solve(slmTimeStep, domain)
+
             call mpas_reset_clock_alarm(domain % clock, 'slmCouplingInterval', ierr=err_tmp)
             err = ior(err, err_tmp)
-					
+
 	      else
 	        ! do nothing for now, but could calculate uplift rate here later instead.
 	      endif
@@ -279,7 +281,6 @@ subroutine li_bedtopo_solve(domain, err)
 
    !--------------------------------------------------------------------
    end subroutine li_bedtopo_solve
-
 
 
 
@@ -331,7 +332,7 @@ subroutine li_bedtopo_solve(domain, err)
 !
 !> \brief   Initializes the sea-level model
 !> \author  Holly Kyeore Han
-!> \date    January 2021
+!> \date    January 2022
 !> \details
 !>  This wrapper routine initializes the sea-level solver
 !> (Han et al., 2022, GMD, https://doi.org/10.5281/zenodo.5775235)
@@ -352,23 +353,25 @@ subroutine li_bedtopo_solve(domain, err)
       !-----------------------------------------------------------------
       ! input/output variables
       !-----------------------------------------------------------------
-      
+
       type (domain_type), intent(inout) :: domain  !< Input/Output: domain object
       type (block_type), pointer :: block         !< Input/output: Block object
       type (mpas_pool_type), pointer :: geometryPool !< mesh information
-         
+
       !-----------------------------------------------------------------
       ! output variables
       !-----------------------------------------------------------------
-      
+
       integer, intent(out) :: err !< Output: error flag
-      
+
       !-----------------------------------------------------------------
       ! local variables
       !-----------------------------------------------------------------
-      
+
       real (kind=RKIND), dimension(:), pointer :: thickness, bedTopography
-      real, dimension(nglv,2*nglv) :: ism_iceload, ism_bedrock
+		real (kind=RKIND), dimension(:), allocatable :: mask_mesh
+      real (kind=RKIND), dimension(nglv,2*nglv) :: ism_iceload, ism_bedrock, ism_mask
+		real (kind=RKIND), dimension(nglv*2*nglv) :: mask_slGrid1D
       real (kind=RKIND), dimension(nglv*2*nglv) :: thickness_slGrid1D
       real (kind=RKIND), dimension(nglv*2*nglv) :: bedrock_slGrid1D
 
@@ -381,65 +384,66 @@ subroutine li_bedtopo_solve(domain, err)
       itersl_sh = 1      ! <<<HH* note: hardcode itersl_sh == 1.
       starttime_sh = 0 ! <<<HH get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation)
       dtime_sh = 5
-     ! * note: when reading in namelist values, SLM should return dtime from its own namelist file and MALI stores the values
-     
+      ! * note: when reading in namelist values, SLM should return dtime from its own namelist file and MALI stores the values
+
       ! initialize interpolation 
       call interpolate_init(domain, err)
-      
+
       ! Allocate globalArray and gatheredArray only on process 0
       call MPI_COMM_RANK( domain % dminfo % comm, curProc, err)
-      
-      if (curProc.eq.0) then
-          allocate(globalArray1(nCellsGlobal), gatheredArray1(nCellsGlobal))
-          allocate(globalArray2(nCellsGlobal), gatheredArray2(nCellsGlobal))    
-      endif
 
       call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
 
+      if (curProc.eq.0) then
+          allocate(globalArrayIce(nCellsGlobal), gatheredArrayIce(nCellsGlobal))
+          allocate(globalArrayBedTopo(nCellsGlobal), gatheredArrayBedTopo(nCellsGlobal))
+			 allocate(mask_mesh(nCellsGlobal))
+      endif
+
       ! Gather only the nCellsOwned from thickness and bedtopo (does not include Halos)
-      call MPI_GATHERV(thickness, nCellsOwned, MPI_DOUBLE, gatheredArray1, nCellsPerProc, &
-                       nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err)                      
-      call MPI_GATHERV(bedTopography, nCellsOwned, MPI_DOUBLE, gatheredArray2, nCellsPerProc, &
-                       nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err)         
-         
+      call MPI_GATHERV(thickness, nCellsOwned, MPI_DOUBLE, gatheredArrayIce, nCellsPerProc, &
+                       nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err)
+      call MPI_GATHERV(bedTopography, nCellsOwned, MPI_DOUBLE, gatheredArrayBedTopo, nCellsPerProc, &
+                       nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err)
+
       if (curProc.eq.0) then
 
          ! Rearrange data into CellID order
          do iCell = 1,nCellsGlobal
-            globalArray1(indexToCellIDGathered(iCell)) = gatheredArray1(iCell)
-            globalArray2(indexToCellIDGathered(iCell)) = gatheredArray2(iCell)
+            globalArrayIce(indexToCellIDGathered(iCell)) = gatheredArrayIce(iCell)
+            globalArrayBedTopo(indexToCellIDGathered(iCell)) = gatheredArrayBedTopo(iCell)
+				mask_mesh(indexToCellIDGathered(iCell)) = 1
          enddo
 
-           ! HH: interpolate thickness and bedTopograpy to the Gaussian grid
-         call interpolate(toColValues, toRowValues, toSvalues, globalArray1, thickness_slGrid1D)
-         call interpolate(toColValues, toRowValues, toSvalues, globalArray2, bedrock_slGrid1D)
-         call write_txt(thickness_slGrid1D, 'mali_iceload_init','')
-         
-         ! HH: check the fill value in MALI for the outside of the domain.
-         ! HH: patch a really big fill value (like 10e6) to thickness and bedtopography in outside of the domain
-      
+         ! interpolate thickness, bedTopograpy, mesh mask to the Gaussian grid
+         call interpolate(toColValues, toRowValues, toSvalues, globalArrayIce, thickness_slGrid1D)
+         call interpolate(toColValues, toRowValues, toSvalues, globalArrayBedTopo, bedrock_slGrid1D)
+			call interpolate(toColValues, toRowValues, toSvalues, mask_mesh, mask_slGrid1D)
+
          ! reformat the interpolated data
          ism_iceload = reshape(thickness_slGrid1D, [nglv,2*nglv])
          ism_bedrock = reshape(bedrock_slGrid1D, [nglv, 2*nglv])
-         
+         ism_mask = reshape(mask_slGrid1D, [nglv, 2*nglv])
+
          ! define unit_num for writing output messages
          unit_num = domain % logInfo % outputLog % unitNum
-         
+
          call sl_set_unit_num(unit_num)
          call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt error
          call sl_timewindow(slmTimeStep)
-         call sl_solver_init(itersl_sh, starttime_sh, ism_iceload, ism_bedrock)
+         call sl_solver_init(itersl_sh, starttime_sh, ism_iceload, ism_bedrock, ism_mask)
          call deallocate_slarrays ! Deallocate arrays that are set from sl_timewindow()
-        
-         deallocate(globalArray1, gatheredArray1)
-         deallocate(globalArray2, gatheredArray2)
 
+         deallocate(globalArrayIce, gatheredArrayIce)
+         deallocate(globalArrayBedTopo, gatheredArrayBedTopo)
+			deallocate(mask_mesh)
       endif
 
    !--------------------------------------------------------------------
    end subroutine slmodel_init
+
 
 
 !***********************************************************************
@@ -463,14 +467,14 @@ subroutine li_bedtopo_solve(domain, err)
       use sl_model_mod
       use user_specs_mod, only: nglv
       use io_mod !<<HH delete if not needed
-		
+
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
-		
+
       type (domain_type), intent(inout) :: domain  !< Input/Output: domain object
 	   integer, intent(in) :: slmTimeStep
-			
+
       !-----------------------------------------------------------------
       ! input/output variables
       !-----------------------------------------------------------------
@@ -480,35 +484,34 @@ subroutine li_bedtopo_solve(domain, err)
       !-----------------------------------------------------------------
 
       integer :: err !< Output: error flag
-		
+
       !-----------------------------------------------------------------
       ! local variables
       !-----------------------------------------------------------------
-		
+
       type (mpas_pool_type), pointer :: meshPool          !< mesh information
       type (mpas_pool_type), pointer :: geometryPool      !< geometry information
       type (mpas_pool_type), pointer :: velocityPool      !< velocity information
-			
+
       real (kind=RKIND), dimension(:), pointer :: bedTopography, thickness
 		real (kind=RKIND), dimension(:), pointer :: upliftDiff
-		
-      real (kind=RKIND), dimension(:), allocatable :: slChange_maliMesh 
-      real (kind=RKIND), dimension(nglv,2*nglv) ::  ism_iceload
-	   real (kind=RKIND), dimension(nglv,2*nglv) ::  slm_slchange
-      real (kind=RKIND), dimension(nglv*2*nglv) ::  thickness_slGrid1D, slChange_slGrid1D
-		
-      integer :: i, j !<<<HH
+
+      real (kind=RKIND), dimension(:), allocatable :: slChange_maliMesh, mask_mesh
+      real (kind=RKIND), dimension(nglv,2*nglv) :: ism_iceload, ism_mask
+	   real (kind=RKIND), dimension(nglv,2*nglv) :: slm_slchange
+      real (kind=RKIND), dimension(nglv*2*nglv) :: thickness_slGrid1D, slChange_slGrid1D
+		real (kind=RKIND), dimension(nglv*2*nglv) :: mask_slGrid1D
+
 		integer :: err_tmp
-		
+
       integer ::  itersl_sh, dtime_sh
       real    :: starttime_sh
-		
+
 		err_tmp = 0
       itersl_sh = 1      ! * note: hardcode itersl_sh == 1.
       starttime_sh = 0 ! get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation)
       dtime_sh = 5
 
-      ! set variables needed
       call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
@@ -520,57 +523,57 @@ subroutine li_bedtopo_solve(domain, err)
       call MPI_COMM_RANK(domain % dminfo % comm, curProc, err)
 
       if (curProc.eq.0) then
-         allocate(globalArray1(nCellsGlobal), gatheredArray1(nCellsGlobal))
-         allocate(globalArray2(nCellsGlobal), gatheredArray2(nCellsGlobal))
-         allocate(globalArray3(nCellsGlobal), gatheredArray3(nCellsGlobal))
+         allocate(globalArrayIce(nCellsGlobal), gatheredArrayIce(nCellsGlobal))
+         allocate(globalArrayBedTopo(nCellsGlobal), gatheredArrayBedTopo(nCellsGlobal))
+         allocate(globalArraySLC(nCellsGlobal), gatheredArraySLC(nCellsGlobal))
+			allocate(mask_mesh(nCellsGlobal))
       endif
-              
+
       ! Gather only the nCellsOwned from ice thickness (does not include Halos)
-      call MPI_GATHERV(thickness, nCellsOwned, MPI_DOUBLE, gatheredArray1, nCellsPerProc, &
+      call MPI_GATHERV(thickness, nCellsOwned, MPI_DOUBLE, gatheredArrayIce, nCellsPerProc, &
                        nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err)
 
-      if (curProc.eq.0) then   
-                                               
+      if (curProc.eq.0) then
+
          ! Rearrange thickness into CellID order
          do iCell = 1,nCellsGlobal
-            globalArray1(indexToCellIDGathered(iCell)) = gatheredArray1(iCell)
+            globalArrayIce(indexToCellIDGathered(iCell)) = gatheredArrayIce(iCell)
+				mask_mesh(indexToCellIDGathered(iCell)) = 1
          enddo
 
-         ! interpolate thickness to Gaussian grid               
-         call interpolate(toColValues, toRowValues, toSvalues, globalArray1, thickness_slGrid1D)
-         call write_txt(thickness_slGrid1D, 'mali_iceload','')  
-				
+         ! interpolate thickness to Gaussian grid
+         call interpolate(toColValues, toRowValues, toSvalues, globalArrayIce, thickness_slGrid1D)
+			call interpolate(toColValues, toRowValues, toSvalues, mask_mesh, mask_slGrid1D)
+         call write_txt(thickness_slGrid1D, 'mali_iceload','')
+
          ! reshape the interpolated data
-         ism_iceload(:,:) = reshape(thickness_slGrid1D, [nglv,2*nglv]) 
-						
-		  ! call the sea-level model
+         ism_iceload(:,:) = reshape(thickness_slGrid1D, [nglv,2*nglv])
+			ism_mask = reshape(mask_slGrid1D, [nglv, 2*nglv])
+
+		   ! call the sea-level model
 		   call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt boundcheck error
 		   call sl_timewindow(slmTimeStep)
-		   call sl_solver(itersl_sh, slmTimeStep, dtime_sh, starttime_sh, ism_iceload, slm_slchange)
-		   call deallocate_slarrays     
-   
-         ! HH: interpolate slchange from Gaussian grid to MALI mesh and reshape
+		   call sl_solver(itersl_sh, slmTimeStep, dtime_sh, starttime_sh, ism_iceload, ism_mask, slm_slchange)
+		   call deallocate_slarrays
+
+         ! interpolate slchange from Gaussian grid to MALI mesh and reshape
          slChange_slGrid1D = reshape(slm_slchange, [nglv*2*nglv])
 
          ! interpolate sea-level change from GL grid to MALI mesh.
-         call interpolate(fromColValues, fromRowValues, fromSValues, slChange_slGrid1D, globalArray3)
-
-         !<<<HH: test interpolation back to SLM grid
-         call interpolate(toColValues, toRowValues, toSvalues, globalArray3, slChange_slGrid1D)
-         call write_txt(slChange_slGrid1D,'SLC_back','')
+         call interpolate(fromColValues, fromRowValues, fromSValues, slChange_slGrid1D, globalArraySLC)
           
          ! Rearrange back to index order
          do iCell = 1,nCellsGlobal
-             gatheredArray3(iCell) = globalArray3(indexToCellIDGathered(iCell))
+             gatheredArraySLC(iCell) = globalArraySLC(indexToCellIDGathered(iCell))
          enddo
             
       endif
 
       ! scatter bedTopography and sea-level change to processors
-      call MPI_SCATTERV(gatheredArray2, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
+      call MPI_SCATTERV(gatheredArrayBedTopo, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
                   bedTopography, nCellsAll, MPI_DOUBLE, 0, domain % dminfo % comm, err) 
 						
-      call MPI_SCATTERV(gatheredArray3, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
+      call MPI_SCATTERV(gatheredArraySLC, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
                   upliftDiff, nCellsAll, MPI_DOUBLE, 0, domain % dminfo % comm, err) 
 
       ! update bedTopography
@@ -578,12 +581,13 @@ subroutine li_bedtopo_solve(domain, err)
 
       call li_update_geometry(geometryPool)
       call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
-                      
+
       ! deallocate memory
       if (curProc.eq.0) then
-         deallocate(globalArray1, gatheredArray1)
-         deallocate(globalArray2, gatheredArray2)
-         deallocate(globalArray3, gatheredArray3)
+         deallocate(globalArrayIce, gatheredArrayIce)
+         deallocate(globalArrayBedTopo, gatheredArrayBedTopo)
+         deallocate(globalArraySLC, gatheredArraySLC)
+			deallocate(mask_mesh)
       endif
 
       ! Perform Halo exchange update
@@ -593,20 +597,6 @@ subroutine li_bedtopo_solve(domain, err)
    !--------------------------------------------------------------------
    end subroutine slmodel_solve
 
-
-   !++++++++++++++++++++++++++++++++++++++++
-   !subroutine check_call_slmodel(iter_sl, dtime_sl)
-   !   integer :: iter_sl, dtime_sl, timestepNumber
-   !   write(6,*)'CHECK Completed timestep.  New time is: ', iter_sl, dtime_sl, timestepNumber
-   !end subroutine check_call_slmodel
-
-   ! last step (refer to the MPAS Ocean model)
-   subroutine interp_li_to_slm
-   end subroutine interp_li_to_slm
-
-   subroutine interp_slm_to_li
-   end subroutine interp_slm_to_li
-   !++++++++++++++++++++++++++++++++++++++++++++++
 
 
 !***********************************************************************
@@ -666,6 +656,7 @@ subroutine li_bedtopo_solve(domain, err)
 
    !--------------------------------------------------------------------
    end subroutine interpolate
+
 
 
 !***********************************************************************
@@ -817,6 +808,7 @@ subroutine li_bedtopo_solve(domain, err)
 
    !--------------------------------------------------------------------
    end subroutine interpolate_init
+
 
 
 !***********************************************************************

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -27,6 +27,7 @@ module li_bedtopo
    use mpas_log
    use li_mask
    use li_setup
+	use netcdf
 
    implicit none
    private
@@ -46,8 +47,14 @@ module li_bedtopo
    !--------------------------------------------------------------------
    ! Private module variables
    !--------------------------------------------------------------------
-   integer, save :: slmTimeStep
+   ! sea-level model timestep
+	integer, save :: slmTimeStep
 
+   ! Interpolation weights variables
+   integer, dimension(:), allocatable :: toRowValues, toColValues
+   integer, dimension(:), allocatable :: fromRowValues, fromColValues
+   real, dimension(:), allocatable :: toSValues, fromSValues
+   integer:: nMpas, nGrid
 
 !***********************************************************************
 
@@ -58,8 +65,8 @@ contains
 !  routine li_bedtopo_init
 !
 !> \brief   Initializes bedtopo solver
-!> \author  Matt Hoffman
-!> \date    20 June 2019
+!> \author  Matt Hoffman and Holly Kyeore Han
+!> \date    20 June 2019 (original), modified 1 December 2021
 !> \details
 !>  This routine initializes the bedtopo solver.
 !
@@ -69,8 +76,7 @@ contains
 #ifdef USE_SEALEVELMODEL
 		use spharmt 
       use planets_mod
-		use io_mod
-		use user_specs_mod, only: dt1
+		use user_specs_mod, only: nglv
 #endif
       !-----------------------------------------------------------------
       ! input variables
@@ -81,6 +87,7 @@ contains
       !-----------------------------------------------------------------
 
       type (domain_type), intent(inout) :: domain  !< Input/Output: domain object
+	   type (block_type), pointer :: block         !< Input/output: Block object
 
       !-----------------------------------------------------------------
       ! output variables
@@ -91,19 +98,41 @@ contains
       !-----------------------------------------------------------------
       ! local variables
       !-----------------------------------------------------------------
+    
+	   type (mpas_pool_type), pointer :: geometryPool         !< mesh information
+      real (kind=RKIND), dimension(:), pointer :: thickness, bedTopography
 
-
-      ! No init is needed.
+!		integer, dimension(512) ::  nglv !< for MALI-SLM coupling. Read in from namelist
+		real, dimension(nglv,2*nglv) ::  ism_iceload, ism_bedrock
+		real (kind=RKIND), dimension(nglv*2*nglv) :: thickness_slGrid1D, bedrock_slGrid1D
+		! No init is needed.
       err = 0
 
 #ifdef USE_SEALEVELMODEL
+      ! initialize interpolation 
+      call interpolate_init(domain, err)
+		
       ! initialize coupling time step number. initial time is 0
-      slmTimeStep = 0 
-      write(6,*)'<<< Calling slmodel_init from li_bedtopo_init! >>>'
-		call mpas_log_write("<<< Calling slmodel_init()! >>>") 
-		call slmodel_init
-		write(6,*)'<<< Successfully called slmodel_init! >>>' ! Replace with actual call
-	   call mpas_log_write("<<< Successfully called slmodel_init()! >>>") 
+      slmTimeStep = 0
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
+      call mpas_log_write("<<< get initial thickness and bedTopo array. mpas_li_bedtopo.F, L110")
+	   call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+	   call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
+
+		! HH: check the fill value in MALI for the outside of the domain.
+		! HH: patch a really big fill value (like 10e6) to thickness and bedtopography in outside of the domain
+		
+		! HH: interpolate thickness and bedTopograpy to the Gaussian grid
+      write(1,*) '<<<BEDTOPO init shape of thickness mali mesh', shape(thickness)
+      write(1,*) '<<<BEDTOPO init shape of BedTopography mali mesh', shape(bedTopography)
+      call interpolate(toColValues, toRowValues, toSvalues, thickness, thickness_slGrid1D)
+      call interpolate(toColValues, toRowValues, toSvalues, bedTopography, bedrock_slGrid1D)
+		! reformat the interpolated data
+		ism_iceload = reshape(thickness_slGrid1D, [nglv,2*nglv])
+		ism_bedrock = reshape(bedrock_slGrid1D, [nglv, 2*nglv])
+	  	
+		! initialize the sea-level solver
+		call slmodel_init(domain % logInfo % outputLog % unitNum, ism_iceload, ism_bedrock)
 #endif
 
    !--------------------------------------------------------------------
@@ -158,8 +187,8 @@ contains
 !  subroutine li_bedtopo_solve
 !
 !> \brief   Updates bed topography
-!> \author  Matt Hoffman
-!> \date    20 June 2019
+!> \author  Matt Hoffman and Holly Han
+!> \date    20 June 2019 (original), 1 December 2021 (modified)
 !> \details
 !>  This routine updates the bed topography.  Currently the only option
 !>  is a data field passed in as input.
@@ -170,7 +199,8 @@ subroutine li_bedtopo_solve(domain, err)
       use mpas_timekeeping 
       use li_mask
       use li_advection
-
+	   use user_specs_mod, only: nglv
+		use io_mod !<<HH delete if not needed
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
@@ -198,9 +228,20 @@ subroutine li_bedtopo_solve(domain, err)
       type (mpas_pool_type), pointer :: geometryPool      !< geometry information
       type (mpas_pool_type), pointer :: velocityPool      !< velocity information
 
-      real (kind=RKIND), dimension(:), pointer :: bedTopography, upliftRate
+      real (kind=RKIND), dimension(:), pointer :: thickness, bedTopography, upliftRate
+		!real (kind=RKIND), dimension(:), allocatable :: slChange_maliMesh !HH: edit => not sure why this variable should be a pointer like is done in mpas-o. make it an allocatable variable? 
+		real (kind=RKIND), dimension(:), allocatable :: slChange_maliMesh !HH: 4268 is the size of mali mesh
+
       real (kind=RKIND), pointer :: deltat
-      integer :: err_tmp
+      integer :: err_tmp, i, j
+		
+	!	integer, dimension(512) ::  nglv !< for MALI-SLM coupling. Read in from namelist
+		real (kind=RKIND), dimension(nglv,2*nglv) ::  ism_iceload, slChange !< for MALI-SLM coupling
+		real (kind=RKIND), dimension(nglv*2*nglv) ::  thickness_slGrid1D, slChange_slGrid1D
+
+      ! MPI Variables
+      integer :: iCell, ilm, curProc
+      real (kind=RKIND), dimension(:), allocatable :: globalArray, gatheredArray
 		
       err = 0
       err_tmp = 0
@@ -232,7 +273,14 @@ subroutine li_bedtopo_solve(domain, err)
          end do
 
 		elseif (trim(config_uplift_method)=='sealevelmodel') then
-			 ! do nothing
+
+	        call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
+  		     call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+		     call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
+
+           call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
+           call mpas_pool_get_subpool(domain % blocklist % structs, 'velocity', velocityPool)
+
       else
          call mpas_log_write("Unknown option selected for 'config_uplift_method'", MPAS_LOG_ERR)
       endif
@@ -240,22 +288,67 @@ subroutine li_bedtopo_solve(domain, err)
 #ifdef USE_SEALEVELMODEL
 		if (trim(config_uplift_method)=='sealevelmodel') then
 			call mpas_pool_get_config(liConfigs, 'config_slm_coupling_interval', config_slm_coupling_interval)
+
 		   if (mpas_is_alarm_ringing(domain % clock, 'slmCouplingInterval', ierr=err_tmp)) then 
 				err = ior(err, err_tmp)
-			   write(6,*) '<<< mpas alarm is rining from li_bedtopo.F L246>>>'
+				
 				slmTimeStep = slmTimeStep + 1
-			   write(6,*) '<<< HH: NMELT COUPLING timestep number, L247>>>', slmTimeStep
-		      call slmodel_solve(slmTimeStep)
-            call mpas_log_write("<<< coupling interval reached: Calling the slmodel solver >>>")
+		       write(1,*) '<<< SL alarm is ringing'
+
+	         ! Allocate globalArray and gatheredArray only on process 0
+	         !call MPI_COMM_RANK( dminfo % comm, curProc, err)
+	        ! if (curProc.eq.0) then
+	         !    allocate(globalArray(nCellsGlobal), gatheredArray(nCellsGlobal))
+	         !endif
+
+				write(1,*) '<<<shape of thickness mali mesh', shape(thickness)
+
+				! HH: gather thickness to the head processor
+				! HH: interpolate thickness to Gaussian grid
+				write(1,*)'<<< interpolate onto Gaussian grid'
+				
+            call interpolate(toColValues, toRowValues, toSvalues, thickness, thickness_slGrid1D)
+				call write_txt(thickness_slGrid1D, 'mali_iceload2','')
+				
+				! reshape the interpolated data
+				ism_iceload(:,:) = reshape(thickness_slGrid1D, [nglv ,2*nglv])
+				write(1,*) '<<< Calling SLM now mpas_li_bedtopo L305, slmTimeStep', slmTimeStep
+				call slmodel_solve(slmTimeStep, ism_iceload, slChange)
+				
+				! HH: interpolate slchange from Gaussian grid to MALI mesh and reshape
+				slChange_slGrid1D = reshape(slChange, [nglv*2*nglv])
+				allocate(slChange_maliMesh(size(bedTopography)))
+				write(1,*) '<<<shape of bedTopography', shape(bedTopography), size(bedTopography)
+
+				! interpolate sea-level change from GL grid to MALI mesh.
+            call interpolate(fromColValues, fromRowValues, fromSValues, slChange_slGrid1D, slChange_maliMesh)
+			   write(1,*) '<<< shape of slChange on Mali mesh', shape(slChange_maliMesh), size(slChange_maliMesh)
+
+				!<<<HH: test interpolation back to SLM grid
+            call interpolate(toColValues, toRowValues, toSvalues, slChange_maliMesh, slChange_slGrid1D)
+            call write_txt(slChange_slGrid1D,'SLC_back','')
+				 
+				! HH: scatter slm_bedTopo to processors
+
+				! update bedTopography
+				bedTopography(:) = bedTopography(:) - slChange_maliMesh(:)
+				
+				! deallocate memory
+				deallocate(slChange_maliMesh)
+
 		      call mpas_reset_clock_alarm(domain % clock, 'slmCouplingInterval', ierr=err_tmp)
 		      err = ior(err, err_tmp)
 			else
-				write(6,*) '<<< mpas alarm is not rining. SLM is not called>>>'
-			 ! do nothing for now, but could calculate uplift rate here later instead. 
+				!write(6,*) '<<< mpas alarm is not rining. SLM is not called>>>'
+			 ! do nothing for now, but could calculate uplift rate here later instead.
 		   endif
 		else
 			call mpas_log_write("'sealevelmodel' should be selected for option 'config_uplift_method'", MPAS_LOG_ERR)
 		endif
+
+      call li_update_geometry(geometryPool)
+      !call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+
 #endif
 
       ! === error check
@@ -264,7 +357,6 @@ subroutine li_bedtopo_solve(domain, err)
       endif
 
    !--------------------------------------------------------------------
-
    end subroutine li_bedtopo_solve
 
 
@@ -312,36 +404,110 @@ subroutine li_bedtopo_solve(domain, err)
 
    ! private subroutines
 
-	subroutine slmodel_init
-	   use sl_model_mod !HH
+!***********************************************************************
+!
+!  routine slmodel_init
+!
+!> \brief   Initializes the sea-level model
+!> \author  Holly Kyeore Han
+!> \date    1 December 2021
+!> \details
+!>  This wrapper routine initialized the sea-level solver
+!> (Han et al., 2021, GMD, https://doi.org/10.5281/zenodo.5775235)
+!
+!-----------------------------------------------------------------------
 
-		! declare variables
-		integer :: slmTimeStep, itersl_sh, dtime_sh
+	subroutine slmodel_init(unit_num, ism_iceload, ism_bedrock)
+	   use sl_model_mod
+	   use user_specs_mod, only: nglv
+
+      !-----------------------------------------------------------------
+	   ! input variables
+	   !-----------------------------------------------------------------
+
+		integer, intent(in) :: unit_num
+	   real, dimension(nglv,2*nglv), intent(in)  ::  ism_iceload, ism_bedrock
+
+		!-----------------------------------------------------------------
+	   ! input/output variables
+	   !-----------------------------------------------------------------
+
+	   !-----------------------------------------------------------------
+	   ! output variables
+	   !-----------------------------------------------------------------
+
+		!-----------------------------------------------------------------
+	   ! local variables
+	   !-----------------------------------------------------------------
+
+		integer :: slmTimeStep, itersl_sh, dtime_sh !get these values from namelist
 		real    :: starttime_sh
-		! 1. check if we are on the head processor, if yes, then:
-		! 2. get initial topography from MALI 
-		     ! 2-1. gather topography to the headnode
-		! 3. interpolate init topo from MALI grid to SLM grid
-		! 4. pass interpolated topo from MALI to SLM
+	 !  integer, parameter :: nglv = 512           !HH get this value from namelist later
 
-		itersl_sh = 1	   ! * note: hardcode itersl_sh == 1. 
-		starttime_sh = 0 ! get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation) 
+
+		itersl_sh = 1	   ! * note: hardcode itersl_sh == 1.
+		starttime_sh = 0 ! get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation)
 	   dtime_sh = 2
+
+		call sl_set_unit_num(unit_num)
 		call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt error
+		slmTimestep = 0 !<<<HH: hardcode it until making the namelist file
 		call sl_timewindow(slmTimeStep)
 			 ! * note: read in namelist values. SLM should return dtime from its own namelist file and MALI stores the values
-	   call sl_solver_init(itersl_sh, starttime_sh)  
+	   call sl_solver_init(itersl_sh, starttime_sh, ism_iceload, ism_bedrock)
 	   call deallocate_slarrays ! Deallocate arrays that are set from sl_timewindow()
-		!call check_call_slmodel ! do i need this?
+	   !call check_call_slmodel ! do i need this?
+	   flush(unit_num) ! HH: is this needed?
+
+   !--------------------------------------------------------------------
 	end subroutine slmodel_init
-	
-	
-	subroutine slmodel_solve(slmTimeStep)
-		use sl_model_mod
-		
-		integer, intent(in):: slmTimeStep
+
+
+!***********************************************************************
+!
+!  routine slmodel_solve
+!
+!> \brief   Solves gravitationally consistent sea-level change
+!> \author  Holly Kyeore Han
+!> \date    1 December 2021
+!> \details
+!>  This wrapper routine calls the sea-level solver that takes in
+!>  ice thickness and provides sea-level change (i.e., changes in the
+!>  heights of the sea surface and the solid Earth surface associated
+!>  with ice sheet changes. The sea-levle model is taken and modified
+!>  from Han et al. (2021, GMD, https://doi.org/10.5281/zenodo.5775235)
+!
+!-----------------------------------------------------------------------
+
+   subroutine slmodel_solve(slmTimeStep, ism_iceload, slm_slchange)
+
+      use sl_model_mod
+      use user_specs_mod, only: nglv
+
+      !-----------------------------------------------------------------
+	   ! input variables
+	   !-----------------------------------------------------------------
+
+      integer, intent(in):: slmTimeStep
+      real, dimension(nglv,2*nglv), intent(in)  ::  ism_iceload
+
+		!-----------------------------------------------------------------
+	   ! input/output variables
+	   !-----------------------------------------------------------------
+
+	   !-----------------------------------------------------------------
+	   ! output variables
+	   !-----------------------------------------------------------------
+      real, dimension(nglv,2*nglv), intent(out) ::  slm_slchange
+
+		!-----------------------------------------------------------------
+	   ! local variables
+	   !-----------------------------------------------------------------
+
 		integer ::  itersl_sh, dtime_sh
 		real    :: starttime_sh
+	 !  integer, parameter :: nglv = 512       		 !HH get this value from namelist later
+
 
 		! 1. check if we are on the head node
 		! 2. check if SLM should be called. If SLM should be called, then:
@@ -350,37 +516,257 @@ subroutine li_bedtopo_solve(domain, err)
 	   ! 3. interpolate iceload from MALI to SLM grid
 		! 4. pass interpolated iceload from MALI to SLM 
 		! 5. get itersl_sh, iter_sh, dtime_sh, starttime_sh
-		
+
 	   ! 6. call sl_checkpoint & set_planet & sl_timewindow
-		itersl_sh = 1	   ! * note: hardcode itersl_sh == 1. 
-		starttime_sh = 0 ! get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation) 
+		itersl_sh = 1	   ! * note: hardcode itersl_sh == 1.
+		starttime_sh = 0 ! get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation)
 	   dtime_sh = 2
 		call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt error
 		call sl_timewindow(slmTimeStep)
-		call sl_solver(itersl_sh, slmTimeStep, dtime_sh, starttime_sh)       ! 7.  call sl_solver
+		call sl_solver(itersl_sh, slmTimeStep, dtime_sh, starttime_sh, ism_iceload, slm_slchange)
 		call deallocate_slarrays		! 8. deallocate memory within the slm
-		
+
 		! 9. read in and interpolate the new bedrock topography from SLM to MALI grid
 			   ! option 1 (initial choice): set bed topography relative to geoid 
 				! option 2: keep track of both surfaces or one? 
 		! 10. scatter topography to all processors. 
+
+	!--------------------------------------------------------------------
 	end subroutine slmodel_solve
 
+
+	!++++++++++++++++++++++++++++++++++++++++
 	!subroutine check_call_slmodel(iter_sl, dtime_sl)
 	!	integer :: iter_sl, dtime_sl, timestepNumber
 	!	write(6,*)'CHECK Completed timestep.  New time is: ', iter_sl, dtime_sl, timestepNumber
 	!end subroutine check_call_slmodel
-	
-	
+
 	! last step (refer to the MPAS Ocean model)
 	subroutine interp_li_to_slm
 	end subroutine interp_li_to_slm
-	
+
 	subroutine interp_slm_to_li
 	end subroutine interp_slm_to_li
+	!++++++++++++++++++++++++++++++++++++++++++++++
+
+
+!***********************************************************************
+!
+!  routine interpolate
+!
+!> \brief   Perform interpolation
+!> \author  Holly Han
+!> \date    December 2021
+!> \details
+!>  This routine contains the sparse matrix multiplication
+!>  algorithm to interpolate between MPAS and Gaussian Grid.
+!>  Note: This routine is an exact copy of the inerpolation 
+!>  routine written by Kristin Barton in the code
+!>  mpas_ocn_vel_self_attraction_loading.F in MPAS-Ocean 
+!
+!-----------------------------------------------------------------------
+
+   subroutine interpolate(colValues, rowValues, sValues, dataIn, dataOut)
+      use io_mod
+      !-----------------------------------------------------------------
+	   ! input variables
+	   !-----------------------------------------------------------------
+
+      integer, dimension(:) :: rowValues, colValues
+		real (kind=RKIND), dimension(:) :: sValues, dataIn
+
+	   !-----------------------------------------------------------------
+	   ! input/output variables
+	   !-----------------------------------------------------------------
+
+	   !-----------------------------------------------------------------
+	   ! output variables
+	   !-----------------------------------------------------------------
+
+	   real (kind=RKIND), dimension(:) :: dataOut
+
+	   !-----------------------------------------------------------------
+	   ! local variables
+	   !-----------------------------------------------------------------
+
+      real (kind=RKIND) :: rhs = 0
+      integer :: n_S, n, nRow, nCol
+
+      n_S = size(sValues)
+      n = 1
+      do while (n .LE. n_S)
+          nRow = rowValues(n)
+          do while ( rowValues(n) .EQ. nRow )
+              nCol = colValues(n)
+              rhs = rhs + dataIn(nCol) * sValues(n)
+              n = n + 1
+          end do
+			 !write(1,*) '<<< shapedataOut and nRow', shape(dataOut), nRow
+          dataOut(nRow) = rhs
+          rhs = 0
+      end do
+
+   !--------------------------------------------------------------------
+	end subroutine interpolate
+
+
+!***********************************************************************
+!
+!  routine interpolate_init
+!
+!> \brief   Sets up interpolation between MALI and SLM native grids
+!> \author  Holly Han
+!> \date    December 2021
+!> \details
+!>  This routine reads in map (weight) files needed to interpolate
+!>  values of ice thicknesss, bedTopography, sea-level change
+!>  between native grid of MALI (unstructured) and SLM (Gaussian).
+!>  It also gathers and scatters data from and to multiple processors.
+!>  Note: A big portion of the routine is copied from routine
+!>  'ocn_vel_self_attraction_loading_init' written by Kristin Barton
+!>  in the code smpas_ocn_vel_self_attraction_loading.F in MPAS-Ocean
+!
+!-----------------------------------------------------------------------
+
+   subroutine interpolate_init(domain, err)
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
 	
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+
+      type (domain_type), intent(inout) :: domain    !< Input/output: Domain
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), pointer :: meshPool          !< mesh information
+
+      character (len=StrKIND), pointer :: config_MALI_to_SLM_weights_file
+      character (len=StrKIND), pointer :: config_SLM_to_MALI_weights_file
+
+      ! NetCDF and weights file variables
+      integer :: toNcId, toNsDimId, toRowId, toColId, toSId
+      integer :: fromNcId, fromNsDimId, fromRowId, fromColId, fromSId
+      integer:: nMpasDimId, nGridDimId, toNsLen, fromNsLen
+      character (len = NF90_MAX_NAME) :: toNsName, fromNsName, nMpasName, nGridName
+      integer, pointer :: n_s
+      character(len=StrKIND) :: mpasToGridFile, gridToMpasFile
+
+      ! MPI variables
+      integer :: curProc
+      integer, pointer ::  nCells
+      integer, dimension(:), pointer :: indexToCellID
+      integer :: iProc, l, ilm, nProcs
+
+	   err = 0
+
+      call mpas_pool_get_config(liConfigs, 'config_MALI_to_SLM_weights_file', config_MALI_to_SLM_weights_file)
+      call mpas_pool_get_config(liConfigs, 'config_SLM_to_MALI_weights_file', config_SLM_to_MALI_weights_file)
+      
+		!block_ptr => domain % blocklist
+     ! do while ( associated( block_ptr ) )
+      !    call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+      !    call mpas_pool_get_dimension(meshPool, 'nCells', nCells) 
+       !   block_ptr => block_ptr % next
+     ! end do
+     ! call mpas_pool_get_array(meshPool, 'indexToCellID', indexToCellID)
+
+     ! call MPI_COMM_RANK( domain % dminfo % comm, curProc, err)
+     ! call MPI_COMM_SIZE( domain % dminfo % comm, nProcs, err)
+
+      ! perform the initialization on the head processor
+    !  if (curProc.eq.0) then
+	!		allocate(nCellsPerProc(nProcs))
+	!		allocate(nCellsDisplacement(nProcs))
+	!	endif
+
+	!	! gather nCells
+		!call MPI_GATHER( )
+
+	!	if (curProc.eq.0) then
+		!	mpasToGridFile = '/Users/hollyhan/Desktop/RESEARCH/Regridding/Regrid_MPAS-SLM/mapfile_MALI_to_SLM_ESMF.nc'
+		!	gridToMpasFile = '/Users/hollyhan/Desktop/RESEARCH/Regridding/Regrid_MPAS-SLM/mapfile_SLM_to_MALI_ESMF.nc'
+         mpasToGridFile = trim(config_MALI_to_SLM_weights_file)
+         gridToMpasFile = trim(config_MALI_to_SLM_weights_file)
+
+         ! Open netcdf weights files
+         call check( nf90_open(path = mpasToGridFile, mode = nf90_nowrite, ncid = toNcId) ,err)
+         call check( nf90_open(path = gridToMpasFile, mode = nf90_nowrite, ncid = fromNcId) ,err)
+
+         ! Get dimension ID
+         call check( nf90_inq_dimid(fromNcId, "n_s", fromNsDimId) ,err)
+         call check( nf90_inq_dimid(toNcId, "n_a", nMpasDimId) ,err)
+			call check( nf90_inq_dimid(toNcId, "n_s", toNsDimId) ,err)
+         call check( nf90_inq_dimid(fromNcId, "n_a", nGridDimId) ,err)
+
+         ! Get Variable IDs
+         call check( nf90_inq_varid(toNcId, "row", toRowId) ,err)
+         call check( nf90_inq_varid(toNcId, "col", toColId) ,err)
+         call check( nf90_inq_varid(toNcId, "S", toSId) ,err)
+         call check( nf90_inq_varid(fromNcId, "row", fromRowId) ,err)
+         call check( nf90_inq_varid(fromNcId, "col", fromColId) ,err)
+         call check( nf90_inq_varid(fromNcId, "S", fromSId) ,err)
+
+         ! Get Dimension Length
+         call check( nf90_inquire_dimension(toNcId, toNsDimId, toNsName, toNsLen) ,err)
+         call check( nf90_inquire_dimension(fromNcId, fromNsDimId, fromNsName, fromNsLen) ,err)
+         call check( nf90_inquire_dimension(toNcId, nMpasDimId, nMpasName, nMpas) ,err)
+         call check( nf90_inquire_dimension(fromNcId, nGridDimId, nGridName, nGrid) ,err)
+
+         ! Allocate matrices to read data into
+         allocate ( toRowValues (toNsLen) )
+         allocate ( toColValues (toNsLen) )
+         allocate ( toSValues (toNsLen) )
+         allocate ( fromRowValues (fromNsLen) )
+         allocate ( fromColValues (fromNsLen) )
+         allocate ( fromSValues (fromNsLen) )
+
+         ! Retrieve data
+         call check( nf90_get_var(toNcId, toColId, toColValues(:) ) ,err)
+         call check( nf90_get_var(toNcId, toRowId, toRowValues(:) ) ,err)
+         call check( nf90_get_var(toNcId, toSId, toSValues(:) ) ,err)
+         call check( nf90_get_var(fromNcId, fromColId, fromColValues(:) ) ,err)
+         call check( nf90_get_var(fromNcId, fromRowId, fromRowValues(:) ) ,err)
+         call check( nf90_get_var(fromNcId, fromSId, fromSValues(:) ) ,err)
+
+     ! endif
+
+   !--------------------------------------------------------------------
+   end subroutine interpolate_init
 
 
+!***********************************************************************
+!
+!  routine check
+!
+!> \brief   Check status of netcdf operations
+!> \author  Holly Han
+!> \date    December 2021
+!> \details
+!>  This routine checks to status of the netcdf file
+!
+!-----------------------------------------------------------------------
+
+   subroutine check(status, err)
+      integer, intent ( in) :: status
+	   integer, intent(inout) :: err
+
+	   if(status /= nf90_noerr) then
+	      err = 1
+	   end if
+   !--------------------------------------------------------------------	
+   end subroutine check
 
 
 !***********************************************************************

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -66,7 +66,9 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine li_bedtopo_init(domain, err)
-
+#ifdef USE_SEALEVELMODEL
+      use planets_mod
+#endif
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
@@ -94,6 +96,8 @@ contains
 #ifdef USE_SEALEVELMODEL
       ! add calls to code in the sea level model inside ifdefs only.
       call mpas_log_write("<<< Compiled successfully with Sea Level Model! >>>") ! Replace with actual call
+      call earth_init()
+      call mpas_log_write("<<< Successfully called earth_init! >>>") ! Replace with actual call
 #endif
 
    !--------------------------------------------------------------------

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -183,16 +183,6 @@ subroutine li_bedtopo_solve(domain, err)
       use li_mask
       use li_advection
       
-#ifdef USE_SEALEVELMODEL
-      use user_specs_mod, only: nglv
-      use io_mod !<<HH delete if not needed
-      
-      real (kind=RKIND), dimension(:), allocatable :: slChange_maliMesh !HH: 4268 is the size of mali mesh
-      real (kind=RKIND), dimension(nglv,2*nglv) ::  ism_iceload, slChange !< for MALI-SLM coupling
-      real (kind=RKIND), dimension(nglv*2*nglv) ::  thickness_slGrid1D, slChange_slGrid1D
-
-#endif
-
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
@@ -214,19 +204,16 @@ subroutine li_bedtopo_solve(domain, err)
       !-----------------------------------------------------------------
 
       type (block_type), pointer :: block
+	   character (len=StrKIND), pointer :: config_slm_coupling_interval
       character (len=StrKIND), pointer :: config_uplift_method
-      character (len=StrKIND), pointer :: config_slm_coupling_interval
       type (mpas_pool_type), pointer :: meshPool          !< mesh information
       type (mpas_pool_type), pointer :: geometryPool      !< geometry information
       type (mpas_pool_type), pointer :: velocityPool      !< velocity information
 
-      real (kind=RKIND), dimension(:), pointer :: thickness, bedTopography, upliftRate
-      real (kind=RKIND), dimension(:), pointer :: upliftDiff
-
-
+      real (kind=RKIND), dimension(:), pointer :: bedTopography, upliftRate
       real (kind=RKIND), pointer :: deltat
-      integer :: err_tmp, i, j
-         
+      integer :: err_tmp
+
       err = 0
       err_tmp = 0
 
@@ -256,130 +243,36 @@ subroutine li_bedtopo_solve(domain, err)
          end do
 
       elseif (trim(config_uplift_method)=='sealevelmodel') then
-
-         call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
-           call mpas_pool_get_array(geometryPool, 'thickness', thickness)
-         call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
-         call mpas_pool_get_array(geometryPool, 'upliftDiff', upliftDiff)
-         call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
-         call mpas_pool_get_subpool(domain % blocklist % structs, 'velocity', velocityPool)
+			
+			call mpas_log_write("Sea-level model is used to calculate changes in bedTopography")
 
       else
          call mpas_log_write("Unknown option selected for 'config_uplift_method'", MPAS_LOG_ERR)
       endif
 
 #ifdef USE_SEALEVELMODEL
+
       if (trim(config_uplift_method)=='sealevelmodel') then
-         call mpas_pool_get_config(liConfigs, 'config_slm_coupling_interval', config_slm_coupling_interval)
-
-         if (mpas_is_alarm_ringing(domain % clock, 'slmCouplingInterval', ierr=err_tmp)) then 
+			call mpas_pool_get_config(liConfigs, 'config_slm_coupling_interval', config_slm_coupling_interval)
+			
+	      if (mpas_is_alarm_ringing(domain % clock, 'slmCouplingInterval', ierr=err_tmp)) then 
+	         err = ior(err, err_tmp)
+				
+				slmTimeStep = slmTimeStep + 1
+				
+	         call mpas_log_write("<<< SL alarm is ringing. slmTimeStep: $i", intArgs=(/slmTimeStep/))
+            call slmodel_solve(slmTimeStep, domain) 
+				
+            call mpas_reset_clock_alarm(domain % clock, 'slmCouplingInterval', ierr=err_tmp)
             err = ior(err, err_tmp)
-            
-            slmTimeStep = slmTimeStep + 1
-            call mpas_log_write("<<< SL alarm is ringing")
-
-            ! Allocate globalArray and gatheredArray only on process 0
-            call MPI_COMM_RANK(domain % dminfo % comm, curProc, err)
-            
-            if (curProc.eq.0) then
-               allocate(globalArray1(nCellsGlobal), gatheredArray1(nCellsGlobal))
-               allocate(globalArray2(nCellsGlobal), gatheredArray2(nCellsGlobal))
-               allocate(globalArray3(nCellsGlobal), gatheredArray3(nCellsGlobal))
-            endif
-            
-                        
-            ! Gather only the nCellsOwned from ice thickness (does not include Halos)
-            call MPI_GATHERV(thickness, nCellsOwned, MPI_DOUBLE, gatheredArray1, nCellsPerProc, &
-                             nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err)
-            call mpas_log_write("<<< thickness gathered")
-            
-            if (curProc.eq.0) then   
-               call mpas_log_write("<<< we are on the head node L369")
-                                                    
-               ! Rearrange thickness into CellID order
-               do iCell = 1,nCellsGlobal
-                  globalArray1(indexToCellIDGathered(iCell)) = gatheredArray1(iCell)
-               enddo
-
-               ! interpolate thickness to Gaussian grid               
-               call interpolate(toColValues, toRowValues, toSvalues, globalArray1, thickness_slGrid1D)
-               call write_txt(thickness_slGrid1D, 'mali_iceload','')  !HH check iceload. output text file is of wrong size in parallel computing
-              
-               ! reshape the interpolated data
-               ism_iceload(:,:) = reshape(thickness_slGrid1D, [nglv,2*nglv]) !<<HH why does it not work!? 
-               call mpas_log_write("<<< Calling SLM now mpas_li_bedtopo L305 slmStep $i", intArgs=(/slmTimeStep/))
-
-               ! call the sea-level solver
-               call mpas_log_write("<<< Calling slmodel_solve")
-               call slmodel_solve(slmTimeStep, ism_iceload, slChange)
-            
-               call mpas_log_write("<<< reshape and interpolate slm output onto mali mesh")
-                 call mpas_log_write('<<<shape of global array mesh $i', intArgs=(/shape(slChange)/))
-
-               ! HH: interpolate slchange from Gaussian grid to MALI mesh and reshape
-               slChange_slGrid1D = reshape(slChange, [nglv*2*nglv])
-               !allocate(slChange_maliMesh(size(bedTopography)))
-
-               ! interpolate sea-level change from GL grid to MALI mesh.
-               call interpolate(fromColValues, fromRowValues, fromSValues, slChange_slGrid1D, globalArray3)
-              ! call interpolate(fromColValues, fromRowValues, fromSValues, slChange_slGrid1D, slChange_maliMesh)
-
-               !<<<HH: test interpolation back to SLM grid
-               call interpolate(toColValues, toRowValues, toSvalues, globalArray3, slChange_slGrid1D)
-               call write_txt(slChange_slGrid1D,'SLC_back','')
-             
-               ! Rearrange back to index order
-               do iCell = 1,nCellsGlobal
-                   gatheredArray3(iCell) = globalArray3(indexToCellIDGathered(iCell))
-               enddo
-               
-               call mpas_log_write("<<< update bedtopo")
-               
-               call mpas_reset_clock_alarm(domain % clock, 'slmCouplingInterval', ierr=err_tmp)
-               err = ior(err, err_tmp)
-               call mpas_log_write("<<<end curProc=0")
-               
-            endif
-            
-            call MPI_SCATTERV(gatheredArray3, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
-                        upliftDiff, nCellsAll, MPI_DOUBLE, 0, domain % dminfo % comm, err) 
-                         call mpas_log_write("<<< rearrange back to index order")
-           ! update bedTopography
-            bedTopography(:) = bedTopography(:) - upliftDiff(:)
-            
-            ! scatter updated bedTopo to processors
-            call mpas_log_write("<<< scatter back bedtopo")
-            !call MPI_SCATTERV(gatheredArray2, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
-            !             bedTopography, size(bedTopography), MPI_DOUBLE, 0, domain % dminfo % comm, err) 
-            call MPI_SCATTERV(gatheredArray2, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
-                         bedTopography, nCellsAll, MPI_DOUBLE, 0, domain % dminfo % comm, err) 
-                         !HH would values is bedTopography replaced by the new values? 
-                         
-            ! deallocate memory
-            if (curProc.eq.0) then
-               deallocate(globalArray1, gatheredArray1)
-               deallocate(globalArray2, gatheredArray2)
-               deallocate(globalArray3, gatheredArray3)
-            endif
-
-            ! Perform Halo exchange update
-            call mpas_dmpar_field_halo_exch(domain,'bedTopography')
-            call mpas_log_write("<<< done SL calculatation!")
-
-         else
-            call mpas_log_write("<<< MPAS alarm is not ringing, SLM is not called!")
-          ! do nothing for now, but could calculate uplift rate here later instead.
-         endif
-      else
+					
+	      else
+	         call mpas_log_write("<<< MPAS alarm is not ringing, SLM is not called!")
+	        ! do nothing for now, but could calculate uplift rate here later instead.
+	      endif
+		else
          call mpas_log_write("'sealevelmodel' should be selected for option 'config_uplift_method'", MPAS_LOG_ERR)
-      endif
-      
-      ! Perform Halo exchange update
-      call mpas_dmpar_field_halo_exch(domain,'bedTopography')
-      call mpas_dmpar_field_halo_exch(domain,'upliftDiff')
-      call li_update_geometry(geometryPool)
-      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
-
+		endif
 #endif
 
       ! === error check
@@ -487,7 +380,7 @@ subroutine li_bedtopo_solve(domain, err)
       real    :: starttime_sh
 
       ! initialize coupling time step number. initial time is 0
-      slmTimeStep = 0.  !<<<HH: hardcode it until making the namelist file
+      slmTimeStep = 0  !<<<HH: hardcode it until making the namelist file
       itersl_sh = 1      ! <<<HH* note: hardcode itersl_sh == 1.
       starttime_sh = 0 ! <<<HH get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation)
       dtime_sh = 5
@@ -514,8 +407,8 @@ subroutine li_bedtopo_solve(domain, err)
       call MPI_GATHERV(bedTopography, nCellsOwned, MPI_DOUBLE, gatheredArray2, nCellsPerProc, &
                        nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err)         
          
-        if (curProc.eq.0) then
-          call mpas_log_write("<<< we are on the head note. init slmodel")
+      if (curProc.eq.0) then
+         call mpas_log_write("<<< we are on the head node. init slmodel")
          ! Rearrange data into CellID order
          do iCell = 1,nCellsGlobal
             globalArray1(indexToCellIDGathered(iCell)) = gatheredArray1(iCell)
@@ -525,19 +418,19 @@ subroutine li_bedtopo_solve(domain, err)
            ! HH: interpolate thickness and bedTopograpy to the Gaussian grid
          call interpolate(toColValues, toRowValues, toSvalues, globalArray1, thickness_slGrid1D)
          call interpolate(toColValues, toRowValues, toSvalues, globalArray2, bedrock_slGrid1D)
-          call write_txt(thickness_slGrid1D, 'mali_iceload_init','')
+         call write_txt(thickness_slGrid1D, 'mali_iceload_init','')
          
-          ! HH: check the fill value in MALI for the outside of the domain.
-           ! HH: patch a really big fill value (like 10e6) to thickness and bedtopography in outside of the domain
+         ! HH: check the fill value in MALI for the outside of the domain.
+         ! HH: patch a really big fill value (like 10e6) to thickness and bedtopography in outside of the domain
       
-           ! reformat the interpolated data
-           ism_iceload = reshape(thickness_slGrid1D, [nglv,2*nglv])
-           ism_bedrock = reshape(bedrock_slGrid1D, [nglv, 2*nglv])
+         ! reformat the interpolated data
+         ism_iceload = reshape(thickness_slGrid1D, [nglv,2*nglv])
+         ism_bedrock = reshape(bedrock_slGrid1D, [nglv, 2*nglv])
          
          ! define unit_num for writing output messages
          unit_num = domain % logInfo % outputLog % unitNum
          
-           call sl_set_unit_num(unit_num)
+         call sl_set_unit_num(unit_num)
          call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt error
          call sl_timewindow(slmTimeStep)
          call sl_solver_init(itersl_sh, starttime_sh, ism_iceload, ism_bedrock)
@@ -567,18 +460,19 @@ subroutine li_bedtopo_solve(domain, err)
 !
 !-----------------------------------------------------------------------
 
-   subroutine slmodel_solve(slmTimeStep, ism_iceload, slm_slchange)
-
+   subroutine slmodel_solve(slmTimeStep, domain)
+      use li_advection
       use sl_model_mod
       use user_specs_mod, only: nglv
-
+      use io_mod !<<HH delete if not needed
+		
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
-
-      integer, intent(in):: slmTimeStep
-      real, dimension(nglv,2*nglv), intent(in)  ::  ism_iceload
-
+		
+      type (domain_type), intent(inout) :: domain  !< Input/Output: domain object
+	   integer, intent(in) :: slmTimeStep
+			
       !-----------------------------------------------------------------
       ! input/output variables
       !-----------------------------------------------------------------
@@ -586,42 +480,124 @@ subroutine li_bedtopo_solve(domain, err)
       !-----------------------------------------------------------------
       ! output variables
       !-----------------------------------------------------------------
-      real, dimension(nglv,2*nglv), intent(out) ::  slm_slchange
 
+      integer :: err !< Output: error flag
+		
       !-----------------------------------------------------------------
       ! local variables
       !-----------------------------------------------------------------
-
+		
+      type (mpas_pool_type), pointer :: meshPool          !< mesh information
+      type (mpas_pool_type), pointer :: geometryPool      !< geometry information
+      type (mpas_pool_type), pointer :: velocityPool      !< velocity information
+			
+      real (kind=RKIND), dimension(:), pointer :: bedTopography, thickness
+		real (kind=RKIND), dimension(:), pointer :: upliftDiff
+		
+      real (kind=RKIND), dimension(:), allocatable :: slChange_maliMesh 
+      real (kind=RKIND), dimension(nglv,2*nglv) ::  ism_iceload
+	   real (kind=RKIND), dimension(nglv,2*nglv) ::  slm_slchange
+      real (kind=RKIND), dimension(nglv*2*nglv) ::  thickness_slGrid1D, slChange_slGrid1D
+		
+      integer :: i, j !<<<HH
+		integer :: err_tmp
+		
       integer ::  itersl_sh, dtime_sh
       real    :: starttime_sh
-
-      ! 1. check if we are on the head node
-      ! 2. check if SLM should be called. If SLM should be called, then:
-          ! 2-1. get new iceload from MALI
-          ! 2-2. gather iceload to the head node 
-      ! 3. interpolate iceload from MALI to SLM grid
-      ! 4. pass interpolated iceload from MALI to SLM 
-      ! 5. get itersl_sh, iter_sh, dtime_sh, starttime_sh
-
-      ! 6. call sl_checkpoint & set_planet & sl_timewindow
+		
+		err_tmp = 0
       itersl_sh = 1      ! * note: hardcode itersl_sh == 1.
       starttime_sh = 0 ! get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation)
       dtime_sh = 5
-      call mpas_log_write("<<< sl_solver_checkpoint")
-      call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt error
-      call mpas_log_write("<<< sl_timewindow")
-      call sl_timewindow(slmTimeStep)
-      call mpas_log_write("<<< sl_solver")
-      
-      call sl_solver(itersl_sh, slmTimeStep, dtime_sh, starttime_sh, ism_iceload, slm_slchange)
-      call mpas_log_write("<<< deallocate slarray")
-      
-      call deallocate_slarrays      ! 8. deallocate memory within the slm
+		
+     
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
+      call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+      call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
+      call mpas_pool_get_array(geometryPool, 'upliftDiff', upliftDiff)
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'velocity', velocityPool)
+		
 
-      ! 9. read in and interpolate the new bedrock topography from SLM to MALI grid
-            ! option 1 (initial choice): set bed topography relative to geoid 
-            ! option 2: keep track of both surfaces or one? 
-      ! 10. scatter topography to all processors. 
+      ! Allocate globalArray and gatheredArray only on process 0
+      call MPI_COMM_RANK(domain % dminfo % comm, curProc, err)
+         
+      if (curProc.eq.0) then
+         allocate(globalArray1(nCellsGlobal), gatheredArray1(nCellsGlobal))
+         allocate(globalArray2(nCellsGlobal), gatheredArray2(nCellsGlobal))
+         allocate(globalArray3(nCellsGlobal), gatheredArray3(nCellsGlobal))
+      endif
+              
+      ! Gather only the nCellsOwned from ice thickness (does not include Halos)
+      call MPI_GATHERV(thickness, nCellsOwned, MPI_DOUBLE, gatheredArray1, nCellsPerProc, &
+                       nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err)
+         
+      if (curProc.eq.0) then   
+                                               
+         ! Rearrange thickness into CellID order
+         do iCell = 1,nCellsGlobal
+            globalArray1(indexToCellIDGathered(iCell)) = gatheredArray1(iCell)
+         enddo
+
+         ! interpolate thickness to Gaussian grid               
+         call interpolate(toColValues, toRowValues, toSvalues, globalArray1, thickness_slGrid1D)
+         call write_txt(thickness_slGrid1D, 'mali_iceload','')  
+				
+         ! reshape the interpolated data
+         ism_iceload(:,:) = reshape(thickness_slGrid1D, [nglv,2*nglv]) !<<HH why does it not work!? 
+		   call mpas_log_write("<<< D slmTimeStep: $i", intArgs=(/slmTimeStep/))
+						
+		  ! call the sea-level model
+		   call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt error
+		   call sl_timewindow(slmTimeStep)
+		   call sl_solver(itersl_sh, slmTimeStep, dtime_sh, starttime_sh, ism_iceload, slm_slchange)
+		   call deallocate_slarrays      ! 8. deallocate memory within the slm
+   
+         ! HH: interpolate slchange from Gaussian grid to MALI mesh and reshape
+         slChange_slGrid1D = reshape(slm_slchange, [nglv*2*nglv])
+
+         ! interpolate sea-level change from GL grid to MALI mesh.
+         call interpolate(fromColValues, fromRowValues, fromSValues, slChange_slGrid1D, globalArray3)
+
+         !<<<HH: test interpolation back to SLM grid
+         call interpolate(toColValues, toRowValues, toSvalues, globalArray3, slChange_slGrid1D)
+         call write_txt(slChange_slGrid1D,'SLC_back','')
+          
+         ! Rearrange back to index order
+         do iCell = 1,nCellsGlobal
+             gatheredArray3(iCell) = globalArray3(indexToCellIDGathered(iCell))
+         enddo
+            
+      endif
+			
+      call MPI_SCATTERV(gatheredArray3, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
+                  upliftDiff, nCellsAll, MPI_DOUBLE, 0, domain % dminfo % comm, err) 
+
+      ! update bedTopography
+      bedTopography(:) = bedTopography(:) - upliftDiff(:)
+		
+      call li_update_geometry(geometryPool)
+      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+		
+      ! scatter updated bedTopo to processors
+      call MPI_SCATTERV(gatheredArray2, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
+                  bedTopography, nCellsAll, MPI_DOUBLE, 0, domain % dminfo % comm, err) 
+                      
+      ! deallocate memory
+      if (curProc.eq.0) then
+         deallocate(globalArray1, gatheredArray1)
+         deallocate(globalArray2, gatheredArray2)
+         deallocate(globalArray3, gatheredArray3)
+      endif
+
+      ! Perform Halo exchange update
+      call mpas_dmpar_field_halo_exch(domain,'bedTopography')
+      call mpas_log_write("<<< done SL calculatation!")
+		
+      ! Perform Halo exchange update
+      call mpas_dmpar_field_halo_exch(domain,'bedTopography')
+      call mpas_dmpar_field_halo_exch(domain,'upliftDiff')
+
 
    !--------------------------------------------------------------------
    end subroutine slmodel_solve

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -243,9 +243,7 @@ subroutine li_bedtopo_solve(domain, err)
          end do
 
       elseif (trim(config_uplift_method)=='sealevelmodel') then
-			
-			call mpas_log_write("Sea-level model is used to calculate changes in bedTopography")
-
+			 ! do nothing
       else
          call mpas_log_write("Unknown option selected for 'config_uplift_method'", MPAS_LOG_ERR)
       endif
@@ -407,7 +405,7 @@ subroutine li_bedtopo_solve(domain, err)
                        nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err)         
          
       if (curProc.eq.0) then
-         call mpas_log_write("<<< we are on the head node. init slmodel")
+
          ! Rearrange data into CellID order
          do iCell = 1,nCellsGlobal
             globalArray1(indexToCellIDGathered(iCell)) = gatheredArray1(iCell)
@@ -437,6 +435,7 @@ subroutine li_bedtopo_solve(domain, err)
         
          deallocate(globalArray1, gatheredArray1)
          deallocate(globalArray2, gatheredArray2)
+
       endif
 
    !--------------------------------------------------------------------
@@ -508,20 +507,18 @@ subroutine li_bedtopo_solve(domain, err)
       itersl_sh = 1      ! * note: hardcode itersl_sh == 1.
       starttime_sh = 0 ! get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation)
       dtime_sh = 5
-		
-		call mpas_log_write("A")
-     
+
+      ! set variables needed
       call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(geometryPool, 'upliftDiff', upliftDiff)
       call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
       call mpas_pool_get_subpool(domain % blocklist % structs, 'velocity', velocityPool)
-		call mpas_log_write("B")
 
       ! Allocate globalArray and gatheredArray only on process 0
       call MPI_COMM_RANK(domain % dminfo % comm, curProc, err)
-      call mpas_log_write("C")   
+
       if (curProc.eq.0) then
          allocate(globalArray1(nCellsGlobal), gatheredArray1(nCellsGlobal))
          allocate(globalArray2(nCellsGlobal), gatheredArray2(nCellsGlobal))
@@ -531,7 +528,7 @@ subroutine li_bedtopo_solve(domain, err)
       ! Gather only the nCellsOwned from ice thickness (does not include Halos)
       call MPI_GATHERV(thickness, nCellsOwned, MPI_DOUBLE, gatheredArray1, nCellsPerProc, &
                        nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err)
-      call mpas_log_write("D")
+
       if (curProc.eq.0) then   
                                                
          ! Rearrange thickness into CellID order
@@ -568,20 +565,19 @@ subroutine li_bedtopo_solve(domain, err)
          enddo
             
       endif
-			call mpas_log_write("E")
+
       ! scatter bedTopography and sea-level change to processors
       call MPI_SCATTERV(gatheredArray2, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
                   bedTopography, nCellsAll, MPI_DOUBLE, 0, domain % dminfo % comm, err) 
 						
       call MPI_SCATTERV(gatheredArray3, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
                   upliftDiff, nCellsAll, MPI_DOUBLE, 0, domain % dminfo % comm, err) 
-call mpas_log_write("F")
+
       ! update bedTopography
       bedTopography(:) = bedTopography(:) - upliftDiff(:)
-		call mpas_log_write("G")
+
       call li_update_geometry(geometryPool)
       call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
-call mpas_log_write("H")
                       
       ! deallocate memory
       if (curProc.eq.0) then
@@ -593,7 +589,6 @@ call mpas_log_write("H")
       ! Perform Halo exchange update
       call mpas_dmpar_field_halo_exch(domain,'bedTopography')
       call mpas_dmpar_field_halo_exch(domain,'upliftDiff')
-call mpas_log_write("I")
 
    !--------------------------------------------------------------------
    end subroutine slmodel_solve

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -26,9 +26,9 @@ module li_bedtopo
    use mpas_log
    use li_mask
    use li_setup
-	use netcdf
+   use netcdf
 !#ifdef USE_SEALEVELMODEL
-	use mpi 
+   use mpi 
 !#endif   
    implicit none
    private
@@ -49,23 +49,23 @@ module li_bedtopo
    ! Private module variables
    !--------------------------------------------------------------------
    ! sea-level model timestep
-	integer, save :: slmTimeStep
+   integer, save :: slmTimeStep
 
    ! Interpolation weights variables
    integer, dimension(:), allocatable :: toRowValues, toColValues
    integer, dimension(:), allocatable :: fromRowValues, fromColValues
    real, dimension(:), allocatable :: toSValues, fromSValues
    integer:: nMpas, nGrid
-	
-	! MPI variables
+   
+   ! MPI variables
    integer :: nCellsGlobal
    integer, dimension(:), allocatable :: nCellsDisplacement
    integer, dimension(:), allocatable :: indexToCellIDGathered
    integer, dimension(:), allocatable :: nCellsPerProc
    integer, pointer :: nCellsAll
-	integer, pointer ::  nCellsOwned
+   integer, pointer ::  nCellsOwned
    integer :: iCell, ilm, curProc
-	
+   
    real (kind=RKIND), dimension(:), allocatable :: globalArray1, gatheredArray1
    real (kind=RKIND), dimension(:), allocatable :: globalArray2, gatheredArray2
    real (kind=RKIND), dimension(:), allocatable :: globalArray3, gatheredArray3, globalArray4
@@ -87,14 +87,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine li_bedtopo_init(domain, err)
-#ifdef USE_SEALEVELMODEL
-		use spharmt 
-      use planets_mod
-		use user_specs_mod, only: nglv!< for MALI-SLM coupling. Read in from namelist
-		use io_mod !<<HH delete if not used
-		!real, dimension(nglv,2*nglv) ::  ism_iceload, ism_bedrock
-		!real (kind=RKIND), dimension(nglv*2*nglv) :: thickness_slGrid1D, bedrock_slGrid1D
-#endif
+
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
@@ -104,7 +97,6 @@ contains
       !-----------------------------------------------------------------
 
       type (domain_type), intent(inout) :: domain  !< Input/Output: domain object
-	   type (block_type), pointer :: block         !< Input/output: Block object
 
       !-----------------------------------------------------------------
       ! output variables
@@ -115,69 +107,14 @@ contains
       !-----------------------------------------------------------------
       ! local variables
       !-----------------------------------------------------------------
-    
-	   type (mpas_pool_type), pointer :: geometryPool         !< mesh information
-      real (kind=RKIND), dimension(:), pointer :: thickness, bedTopography
 
-		real, dimension(nglv,2*nglv) ::  ism_iceload, ism_bedrock
-		real (kind=RKIND), dimension(nglv*2*nglv) :: thickness_slGrid1D, bedrock_slGrid1D
-	!!	! No init is needed.
+      ! No init is needed.
       err = 0
 
 #ifdef USE_SEALEVELMODEL
-      ! initialize coupling time step number. initial time is 0
-      slmTimeStep = 0
-		
-      ! initialize interpolation 
-      call interpolate_init(domain, err)
 
-      ! Allocate globalArray and gatheredArray only on process 0
-      call MPI_COMM_RANK( domain % dminfo % comm, curProc, err)
-		
-      if (curProc.eq.0) then
-          allocate(globalArray1(nCellsGlobal), gatheredArray1(nCellsGlobal))
-          allocate(globalArray2(nCellsGlobal), gatheredArray2(nCellsGlobal))	 
-      endif
-				
-      call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
-	   call mpas_pool_get_array(geometryPool, 'thickness', thickness)
-	   call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
-		
-	   call mpas_log_write("<<< gather initial thickness and bedTopo array. mpas_li_bedtopo.F, L132")
-
-
-      ! Gather only the nCellsOwned from thickness and bedtopo (does not include Halos)
-      call MPI_GATHERV(thickness, nCellsOwned, MPI_DOUBLE, gatheredArray1, nCellsPerProc, &
-                       nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err)							 
-      call MPI_GATHERV(bedTopography, nCellsOwned, MPI_DOUBLE, gatheredArray2, nCellsPerProc, &
-                       nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err)							 
-     
-	   if (curProc.eq.0) then
-			 call mpas_log_write("<<< we are on the head note. init slmodel")
-         ! Rearrange data into CellID order
-          do iCell = 1,nCellsGlobal
-             globalArray1(indexToCellIDGathered(iCell)) = gatheredArray1(iCell)
-             globalArray2(indexToCellIDGathered(iCell)) = gatheredArray2(iCell)
-          enddo
-
-	   	! HH: interpolate thickness and bedTopograpy to the Gaussian grid
-         call interpolate(toColValues, toRowValues, toSvalues, globalArray1, thickness_slGrid1D)
-         call interpolate(toColValues, toRowValues, toSvalues, globalArray2, bedrock_slGrid1D)
-		   call write_txt(thickness_slGrid1D, 'mali_iceload_init','')
-			
-		   ! HH: check the fill value in MALI for the outside of the domain.
-	   	! HH: patch a really big fill value (like 10e6) to thickness and bedtopography in outside of the domain
-		
-		   ! reformat the interpolated data
-	   	ism_iceload = reshape(thickness_slGrid1D, [nglv,2*nglv])
-	   	ism_bedrock = reshape(bedrock_slGrid1D, [nglv, 2*nglv])
-	   	
-	   	! initialize the sea-level solver
-	   	call slmodel_init(domain % logInfo % outputLog % unitNum, ism_iceload, ism_bedrock)
-          
-         deallocate(globalArray1, gatheredArray1)
-			deallocate(globalArray2, gatheredArray2)
-      endif
+      ! initialize the 1D sea-level model
+      call slmodel_init(domain, err)
 
 #endif
 
@@ -245,14 +182,14 @@ subroutine li_bedtopo_solve(domain, err)
       use mpas_timekeeping 
       use li_mask
       use li_advection
-		
+      
 #ifdef USE_SEALEVELMODEL
-	   use user_specs_mod, only: nglv
-		use io_mod !<<HH delete if not needed
-		
-		real (kind=RKIND), dimension(:), allocatable :: slChange_maliMesh !HH: 4268 is the size of mali mesh
-		real (kind=RKIND), dimension(nglv,2*nglv) ::  ism_iceload, slChange !< for MALI-SLM coupling
-		real (kind=RKIND), dimension(nglv*2*nglv) ::  thickness_slGrid1D, slChange_slGrid1D
+      use user_specs_mod, only: nglv
+      use io_mod !<<HH delete if not needed
+      
+      real (kind=RKIND), dimension(:), allocatable :: slChange_maliMesh !HH: 4268 is the size of mali mesh
+      real (kind=RKIND), dimension(nglv,2*nglv) ::  ism_iceload, slChange !< for MALI-SLM coupling
+      real (kind=RKIND), dimension(nglv*2*nglv) ::  thickness_slGrid1D, slChange_slGrid1D
 
 #endif
 
@@ -278,18 +215,18 @@ subroutine li_bedtopo_solve(domain, err)
 
       type (block_type), pointer :: block
       character (len=StrKIND), pointer :: config_uplift_method
-		character (len=StrKIND), pointer :: config_slm_coupling_interval
+      character (len=StrKIND), pointer :: config_slm_coupling_interval
       type (mpas_pool_type), pointer :: meshPool          !< mesh information
       type (mpas_pool_type), pointer :: geometryPool      !< geometry information
       type (mpas_pool_type), pointer :: velocityPool      !< velocity information
 
       real (kind=RKIND), dimension(:), pointer :: thickness, bedTopography, upliftRate
-		real (kind=RKIND), dimension(:), pointer :: upliftDiff
+      real (kind=RKIND), dimension(:), pointer :: upliftDiff
 
 
       real (kind=RKIND), pointer :: deltat
       integer :: err_tmp, i, j
-			
+         
       err = 0
       err_tmp = 0
 
@@ -318,128 +255,126 @@ subroutine li_bedtopo_solve(domain, err)
             block => block % next
          end do
 
-		elseif (trim(config_uplift_method)=='sealevelmodel') then
-	       call mpas_log_write("<<< A, L322")
+      elseif (trim(config_uplift_method)=='sealevelmodel') then
 
-	        call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
-  		     call mpas_pool_get_array(geometryPool, 'thickness', thickness)
-		     call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
-           call mpas_pool_get_array(geometryPool, 'upliftDiff', upliftDiff)
-           call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
-           call mpas_pool_get_subpool(domain % blocklist % structs, 'velocity', velocityPool)
- 	       call mpas_log_write("<<< A, L330")
+         call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
+           call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+         call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
+         call mpas_pool_get_array(geometryPool, 'upliftDiff', upliftDiff)
+         call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
+         call mpas_pool_get_subpool(domain % blocklist % structs, 'velocity', velocityPool)
 
       else
          call mpas_log_write("Unknown option selected for 'config_uplift_method'", MPAS_LOG_ERR)
       endif
 
 #ifdef USE_SEALEVELMODEL
-		if (trim(config_uplift_method)=='sealevelmodel') then
-			call mpas_pool_get_config(liConfigs, 'config_slm_coupling_interval', config_slm_coupling_interval)
+      if (trim(config_uplift_method)=='sealevelmodel') then
+         call mpas_pool_get_config(liConfigs, 'config_slm_coupling_interval', config_slm_coupling_interval)
 
-		   if (mpas_is_alarm_ringing(domain % clock, 'slmCouplingInterval', ierr=err_tmp)) then 
-				err = ior(err, err_tmp)
-				
-				slmTimeStep = slmTimeStep + 1
-		      call mpas_log_write("<<< SL alarm is ringing")
+         if (mpas_is_alarm_ringing(domain % clock, 'slmCouplingInterval', ierr=err_tmp)) then 
+            err = ior(err, err_tmp)
+            
+            slmTimeStep = slmTimeStep + 1
+            call mpas_log_write("<<< SL alarm is ringing")
 
-	         ! Allocate globalArray and gatheredArray only on process 0
-	         call MPI_COMM_RANK(domain % dminfo % comm, curProc, err)
-				
-	         if (curProc.eq.0) then
-	            allocate(globalArray1(nCellsGlobal), gatheredArray1(nCellsGlobal))
-					allocate(globalArray2(nCellsGlobal), gatheredArray2(nCellsGlobal))
-	            allocate(globalArray3(nCellsGlobal), gatheredArray3(nCellsGlobal))
-	         endif
-				
-								
-	         ! Gather only the nCellsOwned from ice thickness (does not include Halos)
-	         call MPI_GATHERV(thickness, nCellsOwned, MPI_DOUBLE, gatheredArray1, nCellsPerProc, &
-	                          nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err)
-				call mpas_log_write("<<< thickness gathered")
-				
-            if (curProc.eq.0) then	
-					call mpas_log_write("<<< we are on the head node L369")
-													             
-			      ! Rearrange thickness into CellID order
-			      do iCell = 1,nCellsGlobal
-			         globalArray1(indexToCellIDGathered(iCell)) = gatheredArray1(iCell)
-			      enddo
+            ! Allocate globalArray and gatheredArray only on process 0
+            call MPI_COMM_RANK(domain % dminfo % comm, curProc, err)
+            
+            if (curProc.eq.0) then
+               allocate(globalArray1(nCellsGlobal), gatheredArray1(nCellsGlobal))
+               allocate(globalArray2(nCellsGlobal), gatheredArray2(nCellsGlobal))
+               allocate(globalArray3(nCellsGlobal), gatheredArray3(nCellsGlobal))
+            endif
+            
+                        
+            ! Gather only the nCellsOwned from ice thickness (does not include Halos)
+            call MPI_GATHERV(thickness, nCellsOwned, MPI_DOUBLE, gatheredArray1, nCellsPerProc, &
+                             nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err)
+            call mpas_log_write("<<< thickness gathered")
+            
+            if (curProc.eq.0) then   
+               call mpas_log_write("<<< we are on the head node L369")
+                                                    
+               ! Rearrange thickness into CellID order
+               do iCell = 1,nCellsGlobal
+                  globalArray1(indexToCellIDGathered(iCell)) = gatheredArray1(iCell)
+               enddo
 
-					! interpolate thickness to Gaussian grid					
+               ! interpolate thickness to Gaussian grid               
                call interpolate(toColValues, toRowValues, toSvalues, globalArray1, thickness_slGrid1D)
-				   call write_txt(thickness_slGrid1D, 'mali_iceload','')  !HH check iceload. output text file is of wrong size in parallel computing
-				  
-				   ! reshape the interpolated data
-				   ism_iceload(:,:) = reshape(thickness_slGrid1D, [nglv,2*nglv]) !<<HH why does it not work!? 
-				   call mpas_log_write("<<< Calling SLM now mpas_li_bedtopo L305 slmStep $i", intArgs=(/slmTimeStep/))
+               call write_txt(thickness_slGrid1D, 'mali_iceload','')  !HH check iceload. output text file is of wrong size in parallel computing
+              
+               ! reshape the interpolated data
+               ism_iceload(:,:) = reshape(thickness_slGrid1D, [nglv,2*nglv]) !<<HH why does it not work!? 
+               call mpas_log_write("<<< Calling SLM now mpas_li_bedtopo L305 slmStep $i", intArgs=(/slmTimeStep/))
 
-					! call the sea-level solver
-					call mpas_log_write("<<< Calling slmodel_solve")
-				   call slmodel_solve(slmTimeStep, ism_iceload, slChange)
-				
-				   call mpas_log_write("<<< reshape and interpolate slm output onto mali mesh")
-				  	call mpas_log_write('<<<shape of global array mesh $i', intArgs=(/shape(slChange)/))
+               ! call the sea-level solver
+               call mpas_log_write("<<< Calling slmodel_solve")
+               call slmodel_solve(slmTimeStep, ism_iceload, slChange)
+            
+               call mpas_log_write("<<< reshape and interpolate slm output onto mali mesh")
+                 call mpas_log_write('<<<shape of global array mesh $i', intArgs=(/shape(slChange)/))
 
-				   ! HH: interpolate slchange from Gaussian grid to MALI mesh and reshape
-				   slChange_slGrid1D = reshape(slChange, [nglv*2*nglv])
-			      !allocate(slChange_maliMesh(size(bedTopography)))
+               ! HH: interpolate slchange from Gaussian grid to MALI mesh and reshape
+               slChange_slGrid1D = reshape(slChange, [nglv*2*nglv])
+               !allocate(slChange_maliMesh(size(bedTopography)))
 
-				   ! interpolate sea-level change from GL grid to MALI mesh.
-					call interpolate(fromColValues, fromRowValues, fromSValues, slChange_slGrid1D, globalArray3)
+               ! interpolate sea-level change from GL grid to MALI mesh.
+               call interpolate(fromColValues, fromRowValues, fromSValues, slChange_slGrid1D, globalArray3)
               ! call interpolate(fromColValues, fromRowValues, fromSValues, slChange_slGrid1D, slChange_maliMesh)
 
-				   !<<<HH: test interpolation back to SLM grid
+               !<<<HH: test interpolation back to SLM grid
                call interpolate(toColValues, toRowValues, toSvalues, globalArray3, slChange_slGrid1D)
                call write_txt(slChange_slGrid1D,'SLC_back','')
-				 
-	            ! Rearrange back to index order
-	            do iCell = 1,nCellsGlobal
-	                gatheredArray3(iCell) = globalArray3(indexToCellIDGathered(iCell))
-	            enddo
-					
-				   call mpas_log_write("<<< update bedtopo")
-					
-		         call mpas_reset_clock_alarm(domain % clock, 'slmCouplingInterval', ierr=err_tmp)
-		         err = ior(err, err_tmp)
-				   call mpas_log_write("<<<end curProc=0")
-					
-				endif
-				
-	         call MPI_SCATTERV(gatheredArray3, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
-	                     upliftDiff, nCellsAll, MPI_DOUBLE, 0, domain % dminfo % comm, err) 
-			 				   call mpas_log_write("<<< rearrange back to index order")
-			  ! update bedTopography
-				bedTopography(:) = bedTopography(:) - upliftDiff(:)
-				
-			   ! scatter updated bedTopo to processors
-			   call mpas_log_write("<<< scatter back bedtopo")
-	         !call MPI_SCATTERV(gatheredArray2, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
-	         !             bedTopography, size(bedTopography), MPI_DOUBLE, 0, domain % dminfo % comm, err) 
-			   call MPI_SCATTERV(gatheredArray2, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
-			                bedTopography, nCellsAll, MPI_DOUBLE, 0, domain % dminfo % comm, err) 
-								 !HH would values is bedTopography replaced by the new values? 
-								 
-				! deallocate memory
-	         if (curProc.eq.0) then
-	            deallocate(globalArray1, gatheredArray1)
-					deallocate(globalArray2, gatheredArray2)
-					deallocate(globalArray3, gatheredArray3)
-	         endif
+             
+               ! Rearrange back to index order
+               do iCell = 1,nCellsGlobal
+                   gatheredArray3(iCell) = globalArray3(indexToCellIDGathered(iCell))
+               enddo
+               
+               call mpas_log_write("<<< update bedtopo")
+               
+               call mpas_reset_clock_alarm(domain % clock, 'slmCouplingInterval', ierr=err_tmp)
+               err = ior(err, err_tmp)
+               call mpas_log_write("<<<end curProc=0")
+               
+            endif
+            
+            call MPI_SCATTERV(gatheredArray3, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
+                        upliftDiff, nCellsAll, MPI_DOUBLE, 0, domain % dminfo % comm, err) 
+                         call mpas_log_write("<<< rearrange back to index order")
+           ! update bedTopography
+            bedTopography(:) = bedTopography(:) - upliftDiff(:)
+            
+            ! scatter updated bedTopo to processors
+            call mpas_log_write("<<< scatter back bedtopo")
+            !call MPI_SCATTERV(gatheredArray2, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
+            !             bedTopography, size(bedTopography), MPI_DOUBLE, 0, domain % dminfo % comm, err) 
+            call MPI_SCATTERV(gatheredArray2, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
+                         bedTopography, nCellsAll, MPI_DOUBLE, 0, domain % dminfo % comm, err) 
+                         !HH would values is bedTopography replaced by the new values? 
+                         
+            ! deallocate memory
+            if (curProc.eq.0) then
+               deallocate(globalArray1, gatheredArray1)
+               deallocate(globalArray2, gatheredArray2)
+               deallocate(globalArray3, gatheredArray3)
+            endif
 
-	         ! Perform Halo exchange update
-	         call mpas_dmpar_field_halo_exch(domain,'bedTopography')
-			   call mpas_log_write("<<< done SL calculatation!")
+            ! Perform Halo exchange update
+            call mpas_dmpar_field_halo_exch(domain,'bedTopography')
+            call mpas_log_write("<<< done SL calculatation!")
 
-			else
-				call mpas_log_write("<<< MPAS alarm is not ringing, SLM is not called!")
-			 ! do nothing for now, but could calculate uplift rate here later instead.
-		   endif
-		else
-			call mpas_log_write("'sealevelmodel' should be selected for option 'config_uplift_method'", MPAS_LOG_ERR)
-		endif
+         else
+            call mpas_log_write("<<< MPAS alarm is not ringing, SLM is not called!")
+          ! do nothing for now, but could calculate uplift rate here later instead.
+         endif
+      else
+         call mpas_log_write("'sealevelmodel' should be selected for option 'config_uplift_method'", MPAS_LOG_ERR)
+      endif
       
-		! Perform Halo exchange update
+      ! Perform Halo exchange update
       call mpas_dmpar_field_halo_exch(domain,'bedTopography')
       call mpas_dmpar_field_halo_exch(domain,'upliftDiff')
       call li_update_geometry(geometryPool)
@@ -508,55 +443,112 @@ subroutine li_bedtopo_solve(domain, err)
 !> \author  Holly Kyeore Han
 !> \date    1 December 2021
 !> \details
-!>  This wrapper routine initialized the sea-level solver
-!> (Han et al., 2021, GMD, https://doi.org/10.5281/zenodo.5775235)
+!>  This wrapper routine initializes the sea-level solver
+!> (Han et al., 2022, GMD, https://doi.org/10.5281/zenodo.5775235)
 !
 !-----------------------------------------------------------------------
 
-	subroutine slmodel_init(unit_num, ism_iceload, ism_bedrock)
-	   use sl_model_mod
-	   use user_specs_mod, only: nglv
+   subroutine slmodel_init(domain, err)
+      use sl_model_mod
+      use user_specs_mod, only: nglv
+      use spharmt
+      use planets_mod
+      use io_mod !<<HH delete if not
 
       !-----------------------------------------------------------------
-	   ! input variables
-	   !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
 
-		integer, intent(in) :: unit_num
-	   real, dimension(nglv,2*nglv), intent(in)  ::  ism_iceload, ism_bedrock
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      
+      type (domain_type), intent(inout) :: domain  !< Input/Output: domain object
+      type (block_type), pointer :: block         !< Input/output: Block object
+      type (mpas_pool_type), pointer :: geometryPool !< mesh information
+         
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      
+      integer, intent(out) :: err !< Output: error flag
+      
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+      
+      real (kind=RKIND), dimension(:), pointer :: thickness, bedTopography
+      real, dimension(nglv,2*nglv) :: ism_iceload, ism_bedrock
+      real (kind=RKIND), dimension(nglv*2*nglv) :: thickness_slGrid1D
+      real (kind=RKIND), dimension(nglv*2*nglv) :: bedrock_slGrid1D
 
-		!-----------------------------------------------------------------
-	   ! input/output variables
-	   !-----------------------------------------------------------------
+      integer :: unit_num
+      integer :: slmTimeStep, itersl_sh, dtime_sh !get these values from namelist
+      real    :: starttime_sh
 
-	   !-----------------------------------------------------------------
-	   ! output variables
-	   !-----------------------------------------------------------------
+      ! initialize coupling time step number. initial time is 0
+      slmTimeStep = 0.  !<<<HH: hardcode it until making the namelist file
+      itersl_sh = 1      ! <<<HH* note: hardcode itersl_sh == 1.
+      starttime_sh = 0 ! <<<HH get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation)
+      dtime_sh = 5
+     ! * note: when reading in namelist values, SLM should return dtime from its own namelist file and MALI stores the values
+     
+      ! initialize interpolation 
+      call interpolate_init(domain, err)
+      
+      ! Allocate globalArray and gatheredArray only on process 0
+      call MPI_COMM_RANK( domain % dminfo % comm, curProc, err)
+      
+      if (curProc.eq.0) then
+          allocate(globalArray1(nCellsGlobal), gatheredArray1(nCellsGlobal))
+          allocate(globalArray2(nCellsGlobal), gatheredArray2(nCellsGlobal))    
+      endif
 
-		!-----------------------------------------------------------------
-	   ! local variables
-	   !-----------------------------------------------------------------
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
+      call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+      call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
 
-		integer :: slmTimeStep, itersl_sh, dtime_sh !get these values from namelist
-		real    :: starttime_sh
-	 !  integer, parameter :: nglv = 512           !HH get this value from namelist later
+      ! Gather only the nCellsOwned from thickness and bedtopo (does not include Halos)
+      call MPI_GATHERV(thickness, nCellsOwned, MPI_DOUBLE, gatheredArray1, nCellsPerProc, &
+                       nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err)                      
+      call MPI_GATHERV(bedTopography, nCellsOwned, MPI_DOUBLE, gatheredArray2, nCellsPerProc, &
+                       nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err)         
+         
+        if (curProc.eq.0) then
+          call mpas_log_write("<<< we are on the head note. init slmodel")
+         ! Rearrange data into CellID order
+         do iCell = 1,nCellsGlobal
+            globalArray1(indexToCellIDGathered(iCell)) = gatheredArray1(iCell)
+            globalArray2(indexToCellIDGathered(iCell)) = gatheredArray2(iCell)
+         enddo
 
-
-		itersl_sh = 1	   ! * note: hardcode itersl_sh == 1.
-		starttime_sh = 0 ! get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation)
-	   dtime_sh = 5
-
-		call sl_set_unit_num(unit_num)
-		call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt error
-		slmTimestep = 0 !<<<HH: hardcode it until making the namelist file
-		call sl_timewindow(slmTimeStep)
-			 ! * note: read in namelist values. SLM should return dtime from its own namelist file and MALI stores the values
-	   call sl_solver_init(itersl_sh, starttime_sh, ism_iceload, ism_bedrock)
-	   call deallocate_slarrays ! Deallocate arrays that are set from sl_timewindow()
-	   !call check_call_slmodel ! do i need this?
-	!   flush(unit_num) ! HH: is this needed?
+           ! HH: interpolate thickness and bedTopograpy to the Gaussian grid
+         call interpolate(toColValues, toRowValues, toSvalues, globalArray1, thickness_slGrid1D)
+         call interpolate(toColValues, toRowValues, toSvalues, globalArray2, bedrock_slGrid1D)
+          call write_txt(thickness_slGrid1D, 'mali_iceload_init','')
+         
+          ! HH: check the fill value in MALI for the outside of the domain.
+           ! HH: patch a really big fill value (like 10e6) to thickness and bedtopography in outside of the domain
+      
+           ! reformat the interpolated data
+           ism_iceload = reshape(thickness_slGrid1D, [nglv,2*nglv])
+           ism_bedrock = reshape(bedrock_slGrid1D, [nglv, 2*nglv])
+         
+         ! define unit_num for writing output messages
+         unit_num = domain % logInfo % outputLog % unitNum
+         
+           call sl_set_unit_num(unit_num)
+         call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt error
+         call sl_timewindow(slmTimeStep)
+         call sl_solver_init(itersl_sh, starttime_sh, ism_iceload, ism_bedrock)
+         call deallocate_slarrays ! Deallocate arrays that are set from sl_timewindow()
+        
+         deallocate(globalArray1, gatheredArray1)
+         deallocate(globalArray2, gatheredArray2)
+      endif
 
    !--------------------------------------------------------------------
-	end subroutine slmodel_init
+   end subroutine slmodel_init
 
 
 !***********************************************************************
@@ -581,73 +573,73 @@ subroutine li_bedtopo_solve(domain, err)
       use user_specs_mod, only: nglv
 
       !-----------------------------------------------------------------
-	   ! input variables
-	   !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
 
       integer, intent(in):: slmTimeStep
       real, dimension(nglv,2*nglv), intent(in)  ::  ism_iceload
 
-		!-----------------------------------------------------------------
-	   ! input/output variables
-	   !-----------------------------------------------------------------
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
 
-	   !-----------------------------------------------------------------
-	   ! output variables
-	   !-----------------------------------------------------------------
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
       real, dimension(nglv,2*nglv), intent(out) ::  slm_slchange
 
-		!-----------------------------------------------------------------
-	   ! local variables
-	   !-----------------------------------------------------------------
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
 
-		integer ::  itersl_sh, dtime_sh
-		real    :: starttime_sh
+      integer ::  itersl_sh, dtime_sh
+      real    :: starttime_sh
 
-		! 1. check if we are on the head node
-		! 2. check if SLM should be called. If SLM should be called, then:
-		    ! 2-1. get new iceload from MALI
-			 ! 2-2. gather iceload to the head node 
-	   ! 3. interpolate iceload from MALI to SLM grid
-		! 4. pass interpolated iceload from MALI to SLM 
-		! 5. get itersl_sh, iter_sh, dtime_sh, starttime_sh
+      ! 1. check if we are on the head node
+      ! 2. check if SLM should be called. If SLM should be called, then:
+          ! 2-1. get new iceload from MALI
+          ! 2-2. gather iceload to the head node 
+      ! 3. interpolate iceload from MALI to SLM grid
+      ! 4. pass interpolated iceload from MALI to SLM 
+      ! 5. get itersl_sh, iter_sh, dtime_sh, starttime_sh
 
-	   ! 6. call sl_checkpoint & set_planet & sl_timewindow
-		itersl_sh = 1	   ! * note: hardcode itersl_sh == 1.
-		starttime_sh = 0 ! get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation)
-	   dtime_sh = 5
-		call mpas_log_write("<<< sl_solver_checkpoint")
-		call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt error
-		call mpas_log_write("<<< sl_timewindow")
-		call sl_timewindow(slmTimeStep)
-		call mpas_log_write("<<< sl_solver")
-		
-		call sl_solver(itersl_sh, slmTimeStep, dtime_sh, starttime_sh, ism_iceload, slm_slchange)
-		call mpas_log_write("<<< deallocate slarray")
-		
-		call deallocate_slarrays		! 8. deallocate memory within the slm
+      ! 6. call sl_checkpoint & set_planet & sl_timewindow
+      itersl_sh = 1      ! * note: hardcode itersl_sh == 1.
+      starttime_sh = 0 ! get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation)
+      dtime_sh = 5
+      call mpas_log_write("<<< sl_solver_checkpoint")
+      call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt error
+      call mpas_log_write("<<< sl_timewindow")
+      call sl_timewindow(slmTimeStep)
+      call mpas_log_write("<<< sl_solver")
+      
+      call sl_solver(itersl_sh, slmTimeStep, dtime_sh, starttime_sh, ism_iceload, slm_slchange)
+      call mpas_log_write("<<< deallocate slarray")
+      
+      call deallocate_slarrays      ! 8. deallocate memory within the slm
 
-		! 9. read in and interpolate the new bedrock topography from SLM to MALI grid
-			   ! option 1 (initial choice): set bed topography relative to geoid 
-				! option 2: keep track of both surfaces or one? 
-		! 10. scatter topography to all processors. 
+      ! 9. read in and interpolate the new bedrock topography from SLM to MALI grid
+            ! option 1 (initial choice): set bed topography relative to geoid 
+            ! option 2: keep track of both surfaces or one? 
+      ! 10. scatter topography to all processors. 
 
-	!--------------------------------------------------------------------
-	end subroutine slmodel_solve
+   !--------------------------------------------------------------------
+   end subroutine slmodel_solve
 
 
-	!++++++++++++++++++++++++++++++++++++++++
-	!subroutine check_call_slmodel(iter_sl, dtime_sl)
-	!	integer :: iter_sl, dtime_sl, timestepNumber
-	!	write(6,*)'CHECK Completed timestep.  New time is: ', iter_sl, dtime_sl, timestepNumber
-	!end subroutine check_call_slmodel
+   !++++++++++++++++++++++++++++++++++++++++
+   !subroutine check_call_slmodel(iter_sl, dtime_sl)
+   !   integer :: iter_sl, dtime_sl, timestepNumber
+   !   write(6,*)'CHECK Completed timestep.  New time is: ', iter_sl, dtime_sl, timestepNumber
+   !end subroutine check_call_slmodel
 
-	! last step (refer to the MPAS Ocean model)
-	subroutine interp_li_to_slm
-	end subroutine interp_li_to_slm
+   ! last step (refer to the MPAS Ocean model)
+   subroutine interp_li_to_slm
+   end subroutine interp_li_to_slm
 
-	subroutine interp_slm_to_li
-	end subroutine interp_slm_to_li
-	!++++++++++++++++++++++++++++++++++++++++++++++
+   subroutine interp_slm_to_li
+   end subroutine interp_slm_to_li
+   !++++++++++++++++++++++++++++++++++++++++++++++
 
 
 !***********************************************************************
@@ -669,25 +661,25 @@ subroutine li_bedtopo_solve(domain, err)
    subroutine interpolate(colValues, rowValues, sValues, dataIn, dataOut)
       use io_mod
       !-----------------------------------------------------------------
-	   ! input variables
-	   !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
 
       integer, dimension(:) :: rowValues, colValues
-		real (kind=RKIND), dimension(:) :: sValues, dataIn
+      real (kind=RKIND), dimension(:) :: sValues, dataIn
 
-	   !-----------------------------------------------------------------
-	   ! input/output variables
-	   !-----------------------------------------------------------------
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
 
-	   !-----------------------------------------------------------------
-	   ! output variables
-	   !-----------------------------------------------------------------
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
 
-	   real (kind=RKIND), dimension(:) :: dataOut
+      real (kind=RKIND), dimension(:) :: dataOut
 
-	   !-----------------------------------------------------------------
-	   ! local variables
-	   !-----------------------------------------------------------------
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
 
       real (kind=RKIND) :: rhs = 0
       integer :: n_S, n, nRow, nCol
@@ -706,7 +698,7 @@ subroutine li_bedtopo_solve(domain, err)
       end do
 
    !--------------------------------------------------------------------
-	end subroutine interpolate
+   end subroutine interpolate
 
 
 !***********************************************************************
@@ -733,7 +725,7 @@ subroutine li_bedtopo_solve(domain, err)
       ! input variables
       !-----------------------------------------------------------------
 
-	
+   
       !-----------------------------------------------------------------
       ! input/output variables
       !-----------------------------------------------------------------
@@ -768,39 +760,39 @@ subroutine li_bedtopo_solve(domain, err)
       integer, dimension(:), pointer :: indexToCellID
       integer :: iProc, l, ilm, nProcs
 
-	   err = 0
+      err = 0
 
       call mpas_pool_get_config(liConfigs, 'config_MALI_to_SLM_weights_file', config_MALI_to_SLM_weights_file)
       call mpas_pool_get_config(liConfigs, 'config_SLM_to_MALI_weights_file', config_SLM_to_MALI_weights_file)
       
       call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
-      call mpas_pool_get_dimension(meshPool, 'nCells', nCellsAll)	
-		call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsOwned)
+      call mpas_pool_get_dimension(meshPool, 'nCells', nCellsAll)   
+      call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsOwned)
       call mpas_pool_get_array(meshPool, 'indexToCellID', indexToCellID)
 
       ! Begin MPI portion
       call MPI_COMM_RANK( domain % dminfo % comm, curProc, err)
       call MPI_COMM_SIZE( domain % dminfo % comm, nProcs, err)
 
-		
+      
       ! perform the initialization on the head processor
       if (curProc.eq.0) then
- 			allocate(nCellsPerProc(nProcs))
-			allocate(nCellsDisplacement(nProcs))
-		endif
-		
+          allocate(nCellsPerProc(nProcs))
+         allocate(nCellsDisplacement(nProcs))
+      endif
+      
       ! Gather nCellsOwned
       call MPI_GATHER( nCellsOwned, 1, MPI_INTEGER, nCellsPerProc, 1, MPI_INTEGER, &
                        0, domain % dminfo % comm, err)
-		
+      
       ! Set Displacement variable for GATHERV command
       if (curProc.eq.0) then
          nCellsGlobal = sum(nCellsPerProc)
-			allocate(indexToCellIDGathered(nCellsGlobal))
+         allocate(indexToCellIDGathered(nCellsGlobal))
          nCellsDisplacement(1) = 0
-			if (nProcs > 1) then
-			   do iProc=2,nProcs
-			      nCellsDisplacement(iProc) = nCellsDisplacement(iProc-1) + nCellsPerProc(iProc-1)
+         if (nProcs > 1) then
+            do iProc=2,nProcs
+               nCellsDisplacement(iProc) = nCellsDisplacement(iProc-1) + nCellsPerProc(iProc-1)
             enddo
          endif
       endif
@@ -809,8 +801,8 @@ subroutine li_bedtopo_solve(domain, err)
       call MPI_GATHERV( indexToCellID, nCellsOwned, MPI_INTEGER, indexToCellIDGathered, &
               nCellsPerProc, nCellsDisplacement, MPI_INTEGER, 0, domain % dminfo % comm, err)
 
-	   !initialize interpoation
-	 	if (curProc.eq.0) then
+      !initialize interpoation
+       if (curProc.eq.0) then
          mpasToGridFile = trim(config_MALI_to_SLM_weights_file)
          gridToMpasFile = trim(config_MALI_to_SLM_weights_file)
 
@@ -821,7 +813,7 @@ subroutine li_bedtopo_solve(domain, err)
          ! Get dimension ID
          call check( nf90_inq_dimid(fromNcId, "n_s", fromNsDimId) ,err)
          call check( nf90_inq_dimid(toNcId, "n_a", nMpasDimId) ,err)
-			call check( nf90_inq_dimid(toNcId, "n_s", toNsDimId) ,err)
+         call check( nf90_inq_dimid(toNcId, "n_s", toNsDimId) ,err)
          call check( nf90_inq_dimid(fromNcId, "n_a", nGridDimId) ,err)
 
          ! Get Variable IDs
@@ -874,12 +866,12 @@ subroutine li_bedtopo_solve(domain, err)
 
    subroutine check(status, err)
       integer, intent ( in) :: status
-	   integer, intent(inout) :: err
+      integer, intent(inout) :: err
 
-	   if(status /= nf90_noerr) then
-	      err = 1
-	   end if
-   !--------------------------------------------------------------------	
+      if(status /= nf90_noerr) then
+         err = 1
+      end if
+   !--------------------------------------------------------------------   
    end subroutine check
 
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -91,6 +91,11 @@ contains
       ! No init is needed.
       err = 0
 
+#ifdef USE_SEALEVELMODEL
+      ! add calls to code in the sea level model inside ifdefs only.
+      call mpas_log_write("<<< Compiled successfully with Sea Level Model! >>>") ! Replace with actual call
+#endif
+
    !--------------------------------------------------------------------
 
    end subroutine li_bedtopo_init
@@ -218,7 +223,10 @@ subroutine li_bedtopo_solve(domain, err)
       endif
 
 
-
+#ifdef USE_SEALEVELMODEL
+      ! add calls to code in the sea level model inside ifdefs only.
+      call mpas_log_write("<<< Compiled successfully with Sea Level Model! >>>") ! Replace with actual call
+#endif
 
 
       ! === error check

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -68,7 +68,7 @@ module li_bedtopo
 	
    real (kind=RKIND), dimension(:), allocatable :: globalArray1, gatheredArray1
    real (kind=RKIND), dimension(:), allocatable :: globalArray2, gatheredArray2
-   real (kind=RKIND), dimension(:), allocatable :: globalArray3, gatheredArray3
+   real (kind=RKIND), dimension(:), allocatable :: globalArray3, gatheredArray3, globalArray4
 
 !***********************************************************************
 
@@ -284,6 +284,7 @@ subroutine li_bedtopo_solve(domain, err)
       type (mpas_pool_type), pointer :: velocityPool      !< velocity information
 
       real (kind=RKIND), dimension(:), pointer :: thickness, bedTopography, upliftRate
+		real (kind=RKIND), dimension(:), pointer :: upliftDiff
 
 
       real (kind=RKIND), pointer :: deltat
@@ -318,14 +319,15 @@ subroutine li_bedtopo_solve(domain, err)
          end do
 
 		elseif (trim(config_uplift_method)=='sealevelmodel') then
-	       call mpas_log_write("<<< A, L342")
+	       call mpas_log_write("<<< A, L322")
 
 	        call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
   		     call mpas_pool_get_array(geometryPool, 'thickness', thickness)
 		     call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
-
+           call mpas_pool_get_array(geometryPool, 'upliftDiff', upliftDiff)
            call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
            call mpas_pool_get_subpool(domain % blocklist % structs, 'velocity', velocityPool)
+ 	       call mpas_log_write("<<< A, L330")
 
       else
          call mpas_log_write("Unknown option selected for 'config_uplift_method'", MPAS_LOG_ERR)
@@ -349,6 +351,7 @@ subroutine li_bedtopo_solve(domain, err)
 					allocate(globalArray2(nCellsGlobal), gatheredArray2(nCellsGlobal))
 	            allocate(globalArray3(nCellsGlobal), gatheredArray3(nCellsGlobal))
 	         endif
+				
 								
 	         ! Gather only the nCellsOwned from ice thickness (does not include Halos)
 	         call MPI_GATHERV(thickness, nCellsOwned, MPI_DOUBLE, gatheredArray1, nCellsPerProc, &
@@ -365,8 +368,6 @@ subroutine li_bedtopo_solve(domain, err)
 
 					! interpolate thickness to Gaussian grid					
                call interpolate(toColValues, toRowValues, toSvalues, globalArray1, thickness_slGrid1D)
-				  	call mpas_log_write('<<<shape of global array mesh $i', intArgs=(/shape(globalArray1)/))
-					call mpas_log_write('<<<shape of global array mesh $i', intArgs=(/shape(thickness_slGrid1D)/))
 				   call write_txt(thickness_slGrid1D, 'mali_iceload','')  !HH check iceload. output text file is of wrong size in parallel computing
 				  
 				   ! reshape the interpolated data
@@ -406,10 +407,10 @@ subroutine li_bedtopo_solve(domain, err)
 				endif
 				
 	         call MPI_SCATTERV(gatheredArray3, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
-	                     globalArray3, nCellsAll, MPI_DOUBLE, 0, domain % dminfo % comm, err) 
+	                     upliftDiff, nCellsAll, MPI_DOUBLE, 0, domain % dminfo % comm, err) 
 			 				   call mpas_log_write("<<< rearrange back to index order")
 			  ! update bedTopography
-				bedTopography(:) = bedTopography(:) - globalArray3(:)
+				bedTopography(:) = bedTopography(:) - upliftDiff(:)
 				
 			   ! scatter updated bedTopo to processors
 			   call mpas_log_write("<<< scatter back bedtopo")
@@ -431,7 +432,7 @@ subroutine li_bedtopo_solve(domain, err)
 			   call mpas_log_write("<<< done SL calculatation!")
 
 			else
-				
+				call mpas_log_write("<<< MPAS alarm is not ringing, SLM is not called!")
 			 ! do nothing for now, but could calculate uplift rate here later instead.
 		   endif
 		else
@@ -440,6 +441,7 @@ subroutine li_bedtopo_solve(domain, err)
       
 		! Perform Halo exchange update
       call mpas_dmpar_field_halo_exch(domain,'bedTopography')
+      call mpas_dmpar_field_halo_exch(domain,'upliftDiff')
       call li_update_geometry(geometryPool)
       call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
 
@@ -541,7 +543,7 @@ subroutine li_bedtopo_solve(domain, err)
 
 		itersl_sh = 1	   ! * note: hardcode itersl_sh == 1.
 		starttime_sh = 0 ! get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation)
-	   dtime_sh = 2
+	   dtime_sh = 5
 
 		call sl_set_unit_num(unit_num)
 		call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt error
@@ -612,7 +614,7 @@ subroutine li_bedtopo_solve(domain, err)
 	   ! 6. call sl_checkpoint & set_planet & sl_timewindow
 		itersl_sh = 1	   ! * note: hardcode itersl_sh == 1.
 		starttime_sh = 0 ! get itersl_sh,, starttime_sh (from MALI simulation, needs manipulation)
-	   dtime_sh = 2
+	   dtime_sh = 5
 		call mpas_log_write("<<< sl_solver_checkpoint")
 		call sl_solver_checkpoint(itersl_sh, dtime_sh) !Uncomment this after fixing the spharmt error
 		call mpas_log_write("<<< sl_timewindow")

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -433,17 +433,13 @@ module li_core
             timestepNumber = timestepNumber + 1
             block => block % next
          end do
-			
-         write(6,*) '<<< 2. mpas_li_core.F L442: Starting timestep number', timestepNumber
-			
+
          call mpas_log_write('Starting timestep number $i', intArgs=(/timestepNumber/), flushNow=.true.)
 
          ! ===
          ! === Perform Timestep
          ! ===
          call mpas_timer_start("time integration")
-		   write(6,*)'<<< 2.25 mpas_li_core.F L461: call li_timestep from mpas_li_time_integration.F'
-			call mpas_log_write('<<< mpas_li_core.F L461: call li_timestep')
          call li_timestep(domain, err_tmp)
          err = ior(err,err_tmp)
 
@@ -1137,14 +1133,11 @@ module li_core
       ierr = ior(ierr, err_tmp)
 
       ! Set up the coupling time interval if MALI is coupled to sea-level model 
-	   write(6,*)'<<< 1. (mpas_li_core.F L1134: config uplift method:  '   , config_uplift_method
       if (trim(config_uplift_method) == "sealevelmodel") then
-			write(6,*)'<<< Setting up an alarm for MALI-SLM coupling time interval>>>'
 			call mpas_set_timeInterval(slm_coupling_interval, timeString=config_slm_coupling_interval, ierr=err_tmp)
          ierr = ior(ierr,err_tmp)
 	      call mpas_add_clock_alarm(core_clock, 'slmCouplingInterval', alarmTime=startTime, &
 	           alarmTimeInterval=slm_coupling_interval, ierr=err_tmp)
-         ! Reset the alarm for checking for force setting of the adaptive timestep interval
          if (mpas_is_alarm_ringing(core_clock, 'slmCouplingInterval', ierr=err_tmp)) then
             ierr = ior(ierr, err_tmp)
 		      call mpas_reset_clock_alarm(core_clock, 'slmCouplingInterval', ierr=err_tmp)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -70,6 +70,7 @@ module li_core
       use li_setup
       use li_constants
       use li_subglacial_hydro
+      use li_bedtopo
 !!!      use mpas_tracer_advection
 !!!      use li_global_diagnostics
 
@@ -285,6 +286,10 @@ module li_core
 
       ! Initialize subglacial hydrology solver
       call li_SGH_init(domain, err_tmp)
+      err = ior(err, err_tmp)
+
+      ! Initialize bed topo module
+      call li_bedtopo_init(domain, err_tmp)
       err = ior(err, err_tmp)
 
       ! initialize analysis driver

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -381,11 +381,13 @@ module li_core
       integer, pointer :: config_stats_interval   !< interval (number of timesteps) for writing stats
       character(len=StrKIND), pointer :: config_restart_timestamp_name
       character(len=StrKIND), pointer :: config_velocity_solver
+		character (len=StrKIND), pointer :: config_uplift_method
       ! Variables needed for printing timestamps
       type (MPAS_Time_Type) :: currTime
       character(len=StrKIND) :: timeStamp
       logical :: isRinging
       integer :: restartTimestampUnit
+		integer :: ninner
 
       integer :: err, err_tmp, err_tmp2, globalErr
 		
@@ -397,8 +399,9 @@ module li_core
       call mpas_pool_get_config(liConfigs, 'config_restart_timestamp_name', config_restart_timestamp_name)
       call mpas_pool_get_config(liConfigs, 'config_stats_interval', config_stats_interval)
       call mpas_pool_get_config(liConfigs, 'config_velocity_solver', config_velocity_solver)
-
-      call mpas_timer_start("land ice core run")
+      call mpas_pool_get_config(liConfigs, 'config_uplift_method', config_uplift_method)
+      
+		call mpas_timer_start("land ice core run")
 
       ! initialize time step number.  initial time is 0
       block => domain % blocklist
@@ -408,7 +411,12 @@ module li_core
          timestepNumber = 0
          block => block % next
       end do
-
+		
+		!initialize coupling time step number. initial time is 0
+		if (trim(config_uplift_method)=='sealevelmodel') then
+         ninner = 0         
+		endif
+		
       ! ===
       ! Solve initial state before beginning time stepping
       ! ===
@@ -430,14 +438,26 @@ module li_core
             timestepNumber = timestepNumber + 1
             block => block % next
          end do
-         write(6,*) '<<< HH: Starting timestep number', timestepNumber
+			
+         write(6,*) '<<< 2. mpas_li_core.F L442: Starting timestep number', timestepNumber
+
+			
+         if (trim(config_uplift_method)=='sealevelmodel') then
+			   if (mpas_is_alarm_ringing(domain % clock, 'slmCouplingInterval', ierr=err_tmp)) then
+                 ninner = ninner + 1
+					  write(6,*) '<<< mpas alarm is rining from li_core.F L448>>>'
+					  write(6,*) '<<< HH: NMELT COUPLING timestep number, L449>>>', ninner
+				endif	
+			endif 
+			
          call mpas_log_write('Starting timestep number $i', intArgs=(/timestepNumber/), flushNow=.true.)
 
          ! ===
          ! === Perform Timestep
          ! ===
          call mpas_timer_start("time integration")
-
+		   write(6,*)'<<< 2.25 mpas_li_core.F L461: call li_timestep from mpas_li_time_integration.F'
+			call mpas_log_write('<<< mpas_li_core.F L461: call li_timestep')
          call li_timestep(domain, err_tmp)
          err = ior(err,err_tmp)
 
@@ -571,7 +591,6 @@ module li_core
 
    !--------------------------------------------------------------------
    end function li_core_run
-
 
 
 !***********************************************************************
@@ -1132,15 +1151,19 @@ module li_core
       ierr = ior(ierr, err_tmp)
 
       ! Set up the coupling time interval if MALI is coupled to sea-level model 
-	   write(6,*)'<<< (mpas_li_core.F L1134: config uplift method:  '   , config_uplift_method
+	   write(6,*)'<<< 1. (mpas_li_core.F L1134: config uplift method:  '   , config_uplift_method
       if (trim(config_uplift_method) == "sealevelmodel") then
 			write(6,*)'<<< Setting up an alarm for MALI-SLM coupling time interval>>>'
 			call mpas_set_timeInterval(slm_coupling_interval, timeString=config_slm_coupling_interval, ierr=err_tmp)
          ierr = ior(ierr,err_tmp)
-			write(6,*) '<<< mpas_li_core.F L1139: config_slm_coupling_interval = ', config_slm_coupling_interval
 	      call mpas_add_clock_alarm(core_clock, 'slmCouplingInterval', alarmTime=startTime, &
 	           alarmTimeInterval=slm_coupling_interval, ierr=err_tmp)
-			write(6,*) '<<< mpas_li_core.F L1142: Added alarm clock'
+         ! Reset the alarm for checking for force setting of the adaptive timestep interval
+         if (mpas_is_alarm_ringing(core_clock, 'slmCouplingInterval', ierr=err_tmp)) then
+            ierr = ior(ierr, err_tmp)
+		      call mpas_reset_clock_alarm(core_clock, 'slmCouplingInterval', ierr=err_tmp)
+		      ierr = ior(ierr, err_tmp)	
+			endif			  
 		endif		
 		
       ! === error check

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -387,7 +387,6 @@ module li_core
       character(len=StrKIND) :: timeStamp
       logical :: isRinging
       integer :: restartTimestampUnit
-		integer :: ninner
 
       integer :: err, err_tmp, err_tmp2, globalErr
 		
@@ -412,10 +411,6 @@ module li_core
          block => block % next
       end do
 		
-		!initialize coupling time step number. initial time is 0
-		if (trim(config_uplift_method)=='sealevelmodel') then
-         ninner = 0         
-		endif
 		
       ! ===
       ! Solve initial state before beginning time stepping
@@ -440,15 +435,6 @@ module li_core
          end do
 			
          write(6,*) '<<< 2. mpas_li_core.F L442: Starting timestep number', timestepNumber
-
-			
-         if (trim(config_uplift_method)=='sealevelmodel') then
-			   if (mpas_is_alarm_ringing(domain % clock, 'slmCouplingInterval', ierr=err_tmp)) then
-                 ninner = ninner + 1
-					  write(6,*) '<<< mpas alarm is rining from li_core.F L448>>>'
-					  write(6,*) '<<< HH: NMELT COUPLING timestep number, L449>>>', ninner
-				endif	
-			endif 
 			
          call mpas_log_write('Starting timestep number $i', intArgs=(/timestepNumber/), flushNow=.true.)
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -347,6 +347,7 @@ module li_core
       use li_setup
       use li_statistics
       use li_time_integration
+		use li_bedtopo 
 
       implicit none
 
@@ -387,8 +388,7 @@ module li_core
       integer :: restartTimestampUnit
 
       integer :: err, err_tmp, err_tmp2, globalErr
-
-
+		
       err = 0
       err_tmp = 0
       globalErr = 0
@@ -430,7 +430,7 @@ module li_core
             timestepNumber = timestepNumber + 1
             block => block % next
          end do
-
+         write(6,*) '<<< HH: Starting timestep number', timestepNumber
          call mpas_log_write('Starting timestep number $i', intArgs=(/timestepNumber/), flushNow=.true.)
 
          ! ===
@@ -1042,11 +1042,13 @@ module li_core
       type (MPAS_Time_Type) :: startTime, stopTime, alarmStartTime
       type (MPAS_TimeInterval_type) :: runDuration, timeStep, alarmTimeStep
       type (MPAS_TimeInterval_type) :: adaptDtForceInterval
+	   type (MPAS_TimeInterval_type) :: slm_coupling_interval
       character (len=StrKIND), pointer :: config_start_time, config_run_duration, config_stop_time, &
          config_output_interval, config_restart_interval ! MPAS standard configs
       character (len=StrKIND), pointer :: config_dt  ! MPAS LI-specific config option
       character (len=StrKIND), pointer :: config_adaptive_timestep_force_interval  ! MPAS LI-specific config option
       character (len=StrKIND), pointer :: config_restart_timestamp_name
+		character (len=StrKIND), pointer :: config_uplift_method, config_slm_coupling_interval
       character (len=StrKIND) :: restartTimeStamp !< string to be read from file
       integer, pointer :: config_year_digits
       integer :: err_tmp
@@ -1065,7 +1067,8 @@ module li_core
       call mpas_pool_get_config(configs, 'config_stop_time', config_stop_time)
       call mpas_pool_get_config(configs, 'config_restart_timestamp_name', config_restart_timestamp_name)
       call mpas_pool_get_config(configs, 'config_adaptive_timestep_force_interval', config_adaptive_timestep_force_interval)
-
+		call mpas_pool_get_config(configs, 'config_uplift_method', config_uplift_method)
+		call mpas_pool_get_config(configs, 'config_slm_coupling_interval', config_slm_coupling_interval)
 
       ! Set time to the user-specified start time OR use a restart time from file
       if ( trim(config_start_time) == "file" ) then
@@ -1128,6 +1131,18 @@ module li_core
       endif
       ierr = ior(ierr, err_tmp)
 
+      ! Set up the coupling time interval if MALI is coupled to sea-level model 
+	   write(6,*)'<<< (mpas_li_core.F L1134: config uplift method:  '   , config_uplift_method
+      if (trim(config_uplift_method) == "sealevelmodel") then
+			write(6,*)'<<< Setting up an alarm for MALI-SLM coupling time interval>>>'
+			call mpas_set_timeInterval(slm_coupling_interval, timeString=config_slm_coupling_interval, ierr=err_tmp)
+         ierr = ior(ierr,err_tmp)
+			write(6,*) '<<< mpas_li_core.F L1139: config_slm_coupling_interval = ', config_slm_coupling_interval
+	      call mpas_add_clock_alarm(core_clock, 'slmCouplingInterval', alarmTime=startTime, &
+	           alarmTimeInterval=slm_coupling_interval, ierr=err_tmp)
+			write(6,*) '<<< mpas_li_core.F L1142: Added alarm clock'
+		endif		
+		
       ! === error check
       if (ierr > 0) then
           call mpas_log_write("An error has occurred in li_simulation_clock_init.", MPAS_LOG_ERR)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration.F
@@ -159,7 +159,6 @@ module li_time_integration
          block => block % next
       end do
 
-
       ! ===
       ! === Perform timestep
       ! ===
@@ -203,7 +202,6 @@ module li_time_integration
       call mpas_get_time(curr_time=currTime, dateTimeString=timeStamp, ierr=err_tmp)
       err = ior(err, err_tmp)
       call mpas_log_write('  Completed timestep.  New time is: ' // trim(timeStamp), flushNow=.true.)
-
 
       block => domain % blocklist
       do while (associated(block))

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -202,6 +202,7 @@ module li_time_integration_fe
 ! It's not clear when the best time to do this is.
 ! Seems cleaner to do it either before or after all of the time evolution of the ice
 ! is complete.  Putting it after.
+      ! ! ! write(6,*) '<<< 3. mpas_li_time_integration_fe.F L205: li_bedtopo_solve '
       call li_bedtopo_solve(domain, err=err_tmp)
       err = ior(err, err_tmp)
 

--- a/components/mpas-albany-landice/src/shared/mpas_li_setup.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_setup.F
@@ -39,7 +39,7 @@ module li_setup
    type (mpas_pool_type), public, pointer :: liConfigs  !< Public parameter: pool of config options
    type (mpas_pool_type), public, pointer :: liPackages
 
-
+	
    !--------------------------------------------------------------------
    !
    ! Public member functions

--- a/components/mpas-framework/Makefile
+++ b/components/mpas-framework/Makefile
@@ -335,11 +335,11 @@ gfortran:
 	"CC_SERIAL = gcc" \
 	"CXX_SERIAL = g++" \
 	"FFLAGS_PROMOTION = -fdefault-real-8 -fdefault-double-8" \
-	"FFLAGS_OPT = -O3 -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form" \
+	"FFLAGS_OPT = -O3 -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form -ffpe-summary=none" \
 	"CFLAGS_OPT = -O3 -m64" \
 	"CXXFLAGS_OPT = -O3 -m64" \
 	"LDFLAGS_OPT = -O3 -m64" \
-	"FFLAGS_DEBUG = -g -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form -fbounds-check -fbacktrace -ffpe-trap=invalid,zero,overflow" \
+	"FFLAGS_DEBUG = -g -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form -fbounds-check -fbacktrace -ffpe-trap=invalid,zero,overflow -ffpe-summary=none" \
 	"CFLAGS_DEBUG = -g -m64" \
 	"CXXFLAGS_DEBUG = -O3 -m64" \
 	"LDFLAGS_DEBUG = -g -m64" \
@@ -362,11 +362,11 @@ gfortran-clang:
 	"CC_SERIAL = clang" \
 	"CXX_SERIAL = clang++" \
 	"FFLAGS_PROMOTION = -fdefault-real-8 -fdefault-double-8" \
-	"FFLAGS_OPT = -O3 -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form" \
+	"FFLAGS_OPT = -O3 -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form -ffpe-summary=none" \
 	"CFLAGS_OPT = -O3 -m64" \
 	"CXXFLAGS_OPT = -O3 -m64" \
 	"LDFLAGS_OPT = -O3 -m64" \
-	"FFLAGS_DEBUG = -g -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form -fbounds-check -fbacktrace -ffpe-trap=invalid,zero,overflow" \
+	"FFLAGS_DEBUG = -g -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form -fbounds-check -fbacktrace -ffpe-trap=invalid,zero,overflow -ffpe-summary=none" \
 	"CFLAGS_DEBUG = -g -m64" \
 	"CXXFLAGS_DEBUG = -O3 -m64" \
 	"LDFLAGS_DEBUG = -g -m64" \
@@ -454,11 +454,11 @@ gnu-nersc:
 	"CC_SERIAL = cc" \
 	"CXX_SERIAL = CC" \
 	"FFLAGS_PROMOTION = -fdefault-real-8 -fdefault-double-8" \
-	"FFLAGS_OPT = -O3 -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form" \
+	"FFLAGS_OPT = -O3 -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form -ffpe-summary=none" \
 	"CFLAGS_OPT = -O3 -m64" \
 	"CXXFLAGS_OPT = -O3 -m64" \
 	"LDFLAGS_OPT = -O3 -m64" \
-	"FFLAGS_DEBUG = -g -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form" \
+	"FFLAGS_DEBUG = -g -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form -fbounds-check -fbacktrace -ffpe-trap=invalid,zero,overflow -ffpe-summary=none" \
 	"CFLAGS_DEBUG = -g -m64" \
 	"CXXFLAGS_DEBUG = -g -m64" \
 	"LDFLAGS_DEBUG = -g -m64" \

--- a/components/mpas-framework/Makefile
+++ b/components/mpas-framework/Makefile
@@ -339,7 +339,7 @@ gfortran:
 	"CFLAGS_OPT = -O3 -m64" \
 	"CXXFLAGS_OPT = -O3 -m64" \
 	"LDFLAGS_OPT = -O3 -m64" \
-	"FFLAGS_DEBUG = -g -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form -fbounds-check -fbacktrace -ffpe-trap=invalid,zero,overflow -ffpe-summary=none" \
+	"FFLAGS_DEBUG = -g -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form -fbacktrace -ffpe-trap=overflow -ffpe-summary=none" \
 	"CFLAGS_DEBUG = -g -m64" \
 	"CXXFLAGS_DEBUG = -O3 -m64" \
 	"LDFLAGS_DEBUG = -g -m64" \
@@ -366,7 +366,7 @@ gfortran-clang:
 	"CFLAGS_OPT = -O3 -m64" \
 	"CXXFLAGS_OPT = -O3 -m64" \
 	"LDFLAGS_OPT = -O3 -m64" \
-	"FFLAGS_DEBUG = -g -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form -fbounds-check -fbacktrace -ffpe-trap=invalid,zero,overflow -ffpe-summary=none" \
+	"FFLAGS_DEBUG = -g -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form -fbacktrace -ffpe-trap=invalid,zero,overflow -ffpe-summary=none" \
 	"CFLAGS_DEBUG = -g -m64" \
 	"CXXFLAGS_DEBUG = -O3 -m64" \
 	"LDFLAGS_DEBUG = -g -m64" \


### PR DESCRIPTION
Hi @matthewhoffman 

I'm opening a pull request as an interim review of the MALI code coupled to a 1D sea-level model [https://github.com/hollyhan/SeaLevelModel/tree/SLM-MALI-Coupling](url).  

The updated MALI code (mostly the code 'mpas_li_bedtopo.F') optionally builds a 1D sea-level model from the top level directory (/mpas-albany-landice), calls the 1D sea-level model at every prescribed SLM coupling time interval,  interpolates and exchanges model data such as thickness, bedtopography and sea-level change data between the regional MALI mesh and global SLM (gaussian) grid, and uses MPI to gather and scatter the model data when simulations run on multiple processors. 

Remaining task in completing this coupling work is to update the namelist file such at some of the sea-level model parameters are defined in MALI rather than in a sea-level module file ('user_specs_mod.f90')

Thank you!
Holly 
