### PR TITLE
Reorganize check_energy

### DIFF
--- a/components/eam/src/physics/cam/check_energy.F90
+++ b/components/eam/src/physics/cam/check_energy.F90
@@ -261,6 +261,8 @@ end subroutine check_energy_get_integrals
     real(r8) :: wv(state%ncol)                     ! vertical integral of water (vapor)
     real(r8) :: wl(state%ncol)                     ! vertical integral of water (liquid)
     real(r8) :: wi(state%ncol)                     ! vertical integral of water (ice)
+    real(r8) :: te(state%ncol)       
+    real(r8) :: tw(state%ncol)
 
     integer lchnk                                  ! chunk identifier
     integer ncol                                   ! number of atmospheric columns
@@ -272,6 +274,7 @@ end subroutine check_energy_get_integrals
     lchnk = state%lchnk
     ncol  = state%ncol
 
+#if 0
 ! Compute vertical integrals of dry static energy and water (vapor, liquid, ice)
     ke = 0._r8
     se = 0._r8
@@ -311,7 +314,6 @@ end subroutine check_energy_get_integrals
        end do
     end if
 
-
 ! Compute vertical integrals of frozen static energy and total water.
     do i = 1, ncol
 !!     state%te_ini(i) = se(i) + ke(i) + (latvap+latice)*wv(i) + latice*wl(i)
@@ -321,6 +323,18 @@ end subroutine check_energy_get_integrals
        state%te_cur(i) = state%te_ini(i)
        state%tw_cur(i) = state%tw_ini(i)
     end do
+#endif
+
+    call energy_helper_eam_def(state%u,state%v,state%T,state%q,state%ps,state%pdel,state%phis, &
+                                   ke,se,wv,wl,wi,wr,ws,te,tw, &
+                                   ncol)
+
+    state%te_ini(:ncol) = te(:ncol)
+    state%tw_ini(:ncol) = tw(:ncol)
+
+    state%te_cur(:ncol) = state%te_ini(:ncol)
+    state%tw_cur(:ncol) = state%tw_ini(:ncol)
+
 
 ! zero cummulative boundary fluxes 
     tend%te_tnd(:ncol) = 0._r8
@@ -395,54 +409,6 @@ end subroutine check_energy_get_integrals
 
     lchnk = state%lchnk
     ncol  = state%ncol
-
-#if 0
-    ! Compute vertical integrals of dry static energy and water (vapor, liquid, ice)
-    ke = 0._r8
-    se = 0._r8
-    wv = 0._r8
-    wl = 0._r8
-    wi = 0._r8
-    wr = 0._r8
-    ws = 0._r8
-
-    do k = 1, pver
-       do i = 1, ncol
-          ke(i) = ke(i) + 0.5_r8*(state%u(i,k)**2 + state%v(i,k)**2)*state%pdel(i,k)/gravit
-          se(i) = se(i) +         state%t(i,k)*cpair*state%pdel(i,k)/gravit
-          wv(i) = wv(i) + state%q(i,k,1       )*state%pdel(i,k)/gravit
-       end do
-    end do
-    do i = 1, ncol
-       se(i) = se(i) + state%phis(i)*state%ps(i)/gravit
-    end do
-
-    ! Don't require cloud liq/ice to be present.  Allows for adiabatic/ideal phys.
-    if (icldliq > 1  .and.  icldice > 1) then
-       do k = 1, pver
-          do i = 1, ncol
-             wl(i) = wl(i) + state%q(i,k,icldliq)*state%pdel(i,k)/gravit
-             wi(i) = wi(i) + state%q(i,k,icldice)*state%pdel(i,k)/gravit
-          end do
-       end do
-    end if
-
-    if (irain   > 1  .and.  isnow   > 1 ) then
-       do k = 1, pver
-          do i = 1, ncol
-             wr(i) = wr(i) + state%q(i,k,irain)*state%pdel(i,k)/gravit
-             ws(i) = ws(i) + state%q(i,k,isnow)*state%pdel(i,k)/gravit
-          end do
-       end do
-    end if
-
-    ! Compute vertical integrals of frozen static energy and total water.
-    do i = 1, ncol
-!!     te(i) = se(i) + ke(i) + (latvap+latice)*wv(i) + latice*wl(i)
-       te(i) = se(i) + ke(i) + (latvap+latice)*wv(i) + latice*( wl(i) + wr(i) )
-       tw(i) = wv(i) + wl(i) + wi(i) + wr(i) + ws(i)
-    end do
-#endif
 
     call energy_helper_eam_def(state%u,state%v,state%T,state%q,state%ps,state%pdel,state%phis, &
                                    ke,se,wv,wl,wi,wr,ws,te,tw, &

--- a/components/eam/src/physics/cam/check_energy.F90
+++ b/components/eam/src/physics/cam/check_energy.F90
@@ -260,7 +260,7 @@ end subroutine check_energy_get_integrals
     real(r8) :: wl(state%ncol)                     ! vertical integral of water (liquid)
     real(r8) :: wi(state%ncol)                     ! vertical integral of water (ice)
 
-    real(r8),allocatable :: cpairv_loc(:,:,:)
+!    real(r8),allocatable :: cpairv_loc(:,:,:)
 
     integer lchnk                                  ! chunk identifier
     integer ncol                                   ! number of atmospheric columns
@@ -283,15 +283,15 @@ end subroutine check_energy_get_integrals
     ! If psetcols == pcols, cpairv is the correct size and just copy into cpairv_loc
     ! If psetcols > pcols and all cpairv match cpair, then assign the constant cpair
 
-    if (state%psetcols == pcols) then
-       allocate (cpairv_loc(state%psetcols,pver,begchunk:endchunk))
-       cpairv_loc(:,:,:) = cpairv(:,:,:)
-    else if (state%psetcols > pcols .and. all(cpairv(:,:,:) == cpair)) then
-       allocate(cpairv_loc(state%psetcols,pver,begchunk:endchunk))
-       cpairv_loc(:,:,:) = cpair
-    else
-       call endrun('check_energy_timestep_init: cpairv is not allowed to vary when subcolumns are turned on')
-    end if
+!    if (state%psetcols == pcols) then
+!       allocate (cpairv_loc(state%psetcols,pver,begchunk:endchunk))
+!       cpairv_loc(:,:,:) = cpairv(:,:,:)
+!    else if (state%psetcols > pcols .and. all(cpairv(:,:,:) == cpair)) then
+!       allocate(cpairv_loc(state%psetcols,pver,begchunk:endchunk))
+!       cpairv_loc(:,:,:) = cpair
+!    else
+!       call endrun('check_energy_timestep_init: cpairv is not allowed to vary when subcolumns are turned on')
+!    end if
 
 ! Compute vertical integrals of dry static energy and water (vapor, liquid, ice)
     ke = 0._r8
@@ -305,7 +305,8 @@ end subroutine check_energy_get_integrals
     do k = 1, pver
        do i = 1, ncol
           ke(i) = ke(i) + 0.5_r8*(state%u(i,k)**2 + state%v(i,k)**2)*state%pdel(i,k)/gravit
-          se(i) = se(i) +         state%t(i,k)*cpairv_loc(i,k,lchnk)*state%pdel(i,k)/gravit
+          !se(i) = se(i) +         state%t(i,k)*cpairv_loc(i,k,lchnk)*state%pdel(i,k)/gravit
+          se(i) = se(i) +         state%t(i,k)*cpair*state%pdel(i,k)/gravit
           wv(i) = wv(i) + state%q(i,k,1       )*state%pdel(i,k)/gravit
        end do
     end do
@@ -354,7 +355,7 @@ end subroutine check_energy_get_integrals
        call pbuf_set_field(pbuf, teout_idx, state%te_ini, col_type=col_type)
     end if
 
-    deallocate(cpairv_loc)
+!    deallocate(cpairv_loc)
 
   end subroutine check_energy_timestep_init
 
@@ -409,7 +410,7 @@ end subroutine check_energy_get_integrals
     real(r8) :: te(state%ncol)                     ! vertical integral of total energy
     real(r8) :: tw(state%ncol)                     ! vertical integral of total water
 
-    real(r8),allocatable :: cpairv_loc(:,:,:)
+!    real(r8),allocatable :: cpairv_loc(:,:,:)
 
     integer lchnk                                  ! chunk identifier
     integer ncol                                   ! number of atmospheric columns
@@ -432,15 +433,15 @@ end subroutine check_energy_get_integrals
     ! If psetcols == pcols, cpairv is the correct size and just copy into cpairv_loc
     ! If psetcols > pcols and all cpairv match cpair, then assign the constant cpair
 
-    if (state%psetcols == pcols) then
-       allocate (cpairv_loc(state%psetcols,pver,begchunk:endchunk))
-       cpairv_loc(:,:,:) = cpairv(:,:,:)
-    else if (state%psetcols > pcols .and. all(cpairv(:,:,:) == cpair)) then
-       allocate(cpairv_loc(state%psetcols,pver,begchunk:endchunk))
-       cpairv_loc(:,:,:) = cpair
-    else
-       call endrun('check_energy_chng: cpairv is not allowed to vary when subcolumns are turned on')
-    end if
+!    if (state%psetcols == pcols) then
+!       allocate (cpairv_loc(state%psetcols,pver,begchunk:endchunk))
+!       cpairv_loc(:,:,:) = cpairv(:,:,:)
+!    else if (state%psetcols > pcols .and. all(cpairv(:,:,:) == cpair)) then
+!       allocate(cpairv_loc(state%psetcols,pver,begchunk:endchunk))
+!       cpairv_loc(:,:,:) = cpair
+!    else
+!       call endrun('check_energy_chng: cpairv is not allowed to vary when subcolumns are turned on')
+!    end if
 
     ! Compute vertical integrals of dry static energy and water (vapor, liquid, ice)
     ke = 0._r8
@@ -454,7 +455,8 @@ end subroutine check_energy_get_integrals
     do k = 1, pver
        do i = 1, ncol
           ke(i) = ke(i) + 0.5_r8*(state%u(i,k)**2 + state%v(i,k)**2)*state%pdel(i,k)/gravit
-          se(i) = se(i) +         state%t(i,k)*cpairv_loc(i,k,lchnk)*state%pdel(i,k)/gravit
+          !se(i) = se(i) +         state%t(i,k)*cpairv_loc(i,k,lchnk)*state%pdel(i,k)/gravit
+          se(i) = se(i) +         state%t(i,k)*cpair*state%pdel(i,k)/gravit
           wv(i) = wv(i) + state%q(i,k,1       )*state%pdel(i,k)/gravit
        end do
     end do
@@ -561,7 +563,7 @@ end subroutine check_energy_get_integrals
        state%tw_cur(i) = tw(i)
     end do
 
-    deallocate(cpairv_loc)
+!    deallocate(cpairv_loc)
 
   end subroutine check_energy_chng
 

--- a/components/eam/src/physics/cam/check_energy.F90
+++ b/components/eam/src/physics/cam/check_energy.F90
@@ -260,8 +260,6 @@ end subroutine check_energy_get_integrals
     real(r8) :: wl(state%ncol)                     ! vertical integral of water (liquid)
     real(r8) :: wi(state%ncol)                     ! vertical integral of water (ice)
 
-!    real(r8),allocatable :: cpairv_loc(:,:,:)
-
     integer lchnk                                  ! chunk identifier
     integer ncol                                   ! number of atmospheric columns
     integer  i,k                                   ! column, level indices
@@ -279,20 +277,6 @@ end subroutine check_energy_get_integrals
     call cnst_get_ind('RAINQM', ixrain, abrtf=.false.)
     call cnst_get_ind('SNOWQM', ixsnow, abrtf=.false.)
 
-    ! cpairv_loc needs to be allocated to a size which matches state and ptend
-    ! If psetcols == pcols, cpairv is the correct size and just copy into cpairv_loc
-    ! If psetcols > pcols and all cpairv match cpair, then assign the constant cpair
-
-!    if (state%psetcols == pcols) then
-!       allocate (cpairv_loc(state%psetcols,pver,begchunk:endchunk))
-!       cpairv_loc(:,:,:) = cpairv(:,:,:)
-!    else if (state%psetcols > pcols .and. all(cpairv(:,:,:) == cpair)) then
-!       allocate(cpairv_loc(state%psetcols,pver,begchunk:endchunk))
-!       cpairv_loc(:,:,:) = cpair
-!    else
-!       call endrun('check_energy_timestep_init: cpairv is not allowed to vary when subcolumns are turned on')
-!    end if
-
 ! Compute vertical integrals of dry static energy and water (vapor, liquid, ice)
     ke = 0._r8
     se = 0._r8
@@ -305,7 +289,6 @@ end subroutine check_energy_get_integrals
     do k = 1, pver
        do i = 1, ncol
           ke(i) = ke(i) + 0.5_r8*(state%u(i,k)**2 + state%v(i,k)**2)*state%pdel(i,k)/gravit
-          !se(i) = se(i) +         state%t(i,k)*cpairv_loc(i,k,lchnk)*state%pdel(i,k)/gravit
           se(i) = se(i) +         state%t(i,k)*cpair*state%pdel(i,k)/gravit
           wv(i) = wv(i) + state%q(i,k,1       )*state%pdel(i,k)/gravit
        end do
@@ -354,8 +337,6 @@ end subroutine check_energy_get_integrals
     if (is_first_step()) then
        call pbuf_set_field(pbuf, teout_idx, state%te_ini, col_type=col_type)
     end if
-
-!    deallocate(cpairv_loc)
 
   end subroutine check_energy_timestep_init
 
@@ -410,8 +391,6 @@ end subroutine check_energy_get_integrals
     real(r8) :: te(state%ncol)                     ! vertical integral of total energy
     real(r8) :: tw(state%ncol)                     ! vertical integral of total water
 
-!    real(r8),allocatable :: cpairv_loc(:,:,:)
-
     integer lchnk                                  ! chunk identifier
     integer ncol                                   ! number of atmospheric columns
     integer  i,k                                   ! column, level indices
@@ -429,20 +408,6 @@ end subroutine check_energy_get_integrals
     call cnst_get_ind('RAINQM', ixrain, abrtf=.false.)
     call cnst_get_ind('SNOWQM', ixsnow, abrtf=.false.)
 
-    ! cpairv_loc needs to be allocated to a size which matches state and ptend
-    ! If psetcols == pcols, cpairv is the correct size and just copy into cpairv_loc
-    ! If psetcols > pcols and all cpairv match cpair, then assign the constant cpair
-
-!    if (state%psetcols == pcols) then
-!       allocate (cpairv_loc(state%psetcols,pver,begchunk:endchunk))
-!       cpairv_loc(:,:,:) = cpairv(:,:,:)
-!    else if (state%psetcols > pcols .and. all(cpairv(:,:,:) == cpair)) then
-!       allocate(cpairv_loc(state%psetcols,pver,begchunk:endchunk))
-!       cpairv_loc(:,:,:) = cpair
-!    else
-!       call endrun('check_energy_chng: cpairv is not allowed to vary when subcolumns are turned on')
-!    end if
-
     ! Compute vertical integrals of dry static energy and water (vapor, liquid, ice)
     ke = 0._r8
     se = 0._r8
@@ -455,7 +420,6 @@ end subroutine check_energy_get_integrals
     do k = 1, pver
        do i = 1, ncol
           ke(i) = ke(i) + 0.5_r8*(state%u(i,k)**2 + state%v(i,k)**2)*state%pdel(i,k)/gravit
-          !se(i) = se(i) +         state%t(i,k)*cpairv_loc(i,k,lchnk)*state%pdel(i,k)/gravit
           se(i) = se(i) +         state%t(i,k)*cpair*state%pdel(i,k)/gravit
           wv(i) = wv(i) + state%q(i,k,1       )*state%pdel(i,k)/gravit
        end do
@@ -562,8 +526,6 @@ end subroutine check_energy_get_integrals
        state%te_cur(i) = te(i)
        state%tw_cur(i) = tw(i)
     end do
-
-!    deallocate(cpairv_loc)
 
   end subroutine check_energy_chng
 

--- a/components/eam/src/physics/cam/check_energy.F90
+++ b/components/eam/src/physics/cam/check_energy.F90
@@ -1144,13 +1144,14 @@ subroutine qflx_gmean(state, tend, cam_in, dtime, nstep)
     integer, intent(in) :: ncol                   
     integer :: i,k                            
 
-    if(icldliq > 1  .and.  icldice > 1 .and. irain > 1 .and. isnow > 1) then
-      do i = 1, ncol
-        call energy_helper_eam_def_column(u(i,:),v(i,:),T(i,:),q(i,1:pver,1:pcnst),ps(i),pdel(i,:),phis(i), &
+    if (icldliq > 1  .and.  icldice > 1 .and. irain > 1 .and. isnow > 1) then
+       do i = 1, ncol
+          call energy_helper_eam_def_column(u(i,:),v(i,:),T(i,:),q(i,1:pver,1:pcnst),&
+                                   ps(i),pdel(i,:),phis(i), &
                                    ke(i),se(i),wv(i),wl(i),wi(i),wr(i),ws(i),te(i),tw(i) )                             
-      enddo
+       enddo
     else
-      call endrun('energy_helper...column is not implemented if water forms do not exist')
+       call endrun('energy_helper...column is not implemented if water forms do not exist')
     endif
 
   end subroutine energy_helper_eam_def
@@ -1194,37 +1195,37 @@ subroutine qflx_gmean(state, tend, cam_in, dtime, nstep)
 
     !keep it bfb and fast
     if (present(teloc) .and. present(psterm))then
-    teloc = 0.0; psterm = 0.0
-    do k = 1, pver
+       teloc = 0.0; psterm = 0.0
+       do k = 1, pver
           teloc(k) = 0.5_r8*(u(k)**2 + v(k)**2)*pdel(k)/gravit &
                    + t(k)*cpair*pdel(k)/gravit &
                    + (latvap+latice)*q(k,1       )*pdel(k)/gravit
-             teloc(k) = teloc(k) &
-                      + latice*(q(k,icldliq) + q(k,irain))*pdel(k)/gravit
-    end do
-    psterm = phis*ps/gravit
+          teloc(k) = teloc(k) &
+                   + latice*(q(k,icldliq) + q(k,irain))*pdel(k)/gravit
+       end do
+       psterm = phis*ps/gravit
     endif
 
     do k = 1, pver
-          ke = ke + 0.5_r8*(u(k)**2 + v(k)**2)*pdel(k)/gravit
-          se = se +         t(k)*cpair*pdel(k)/gravit
-          wv = wv + q(k,1      )*pdel(k)/gravit
+       ke = ke + 0.5_r8*(u(k)**2 + v(k)**2)*pdel(k)/gravit
+       se = se +         t(k)*cpair*pdel(k)/gravit
+       wv = wv + q(k,1      )*pdel(k)/gravit
     end do
     se = se + phis*ps/gravit
 
-       do k = 1, pver
-             wl = wl + q(k,icldliq)*pdel(k)/gravit
-             wi = wi + q(k,icldice)*pdel(k)/gravit
-       end do
+    do k = 1, pver
+       wl = wl + q(k,icldliq)*pdel(k)/gravit
+       wi = wi + q(k,icldice)*pdel(k)/gravit
+    end do
 
-       do k = 1, pver
-             wr = wr + q(k,irain)*pdel(k)/gravit
-             ws = ws + q(k,isnow)*pdel(k)/gravit
-       end do
+    do k = 1, pver
+       wr = wr + q(k,irain)*pdel(k)/gravit
+       ws = ws + q(k,isnow)*pdel(k)/gravit
+    end do
 
     ! Compute vertical integrals of frozen static energy and total water.
-       te = se + ke + (latvap+latice)*wv + latice*( wl + wr )
-       tw = wv + wl + wi + wr + ws
+    te = se + ke + (latvap+latice)*wv + latice*( wl + wr )
+    tw = wv + wl + wi + wr + ws
 
   end subroutine energy_helper_eam_def_column
 

--- a/components/eam/src/physics/cam/constituents.F90
+++ b/components/eam/src/physics/cam/constituents.F90
@@ -35,6 +35,7 @@ module constituents
   public cnst_read_iv         ! query whether constituent initial values are read from initial file
   public cnst_chk_dim         ! check that number of constituents added equals dimensions (pcnst)
   public cnst_cam_outfld      ! Returns true if default CAM output was specified in the cnst_add calls.
+  public setup_moist_indices  ! sets indices for 4 water forms
 
 ! Public data
 
@@ -45,6 +46,9 @@ module constituents
 
 ! Namelist variables
   logical, public :: readtrace = .true.             ! true => obtain initial tracer data from IC file
+
+!water form indices
+  integer, public, protected :: icldice = -1, icldliq = -1, irain = -1, isnow = -1
 
 !
 ! Constants for each tracer
@@ -434,5 +438,19 @@ function cnst_cam_outfld(m)
 end function cnst_cam_outfld
 
 !==============================================================================
+
+
+subroutine setup_moist_indices()
+
+   implicit none
+
+   call cnst_get_ind('CLDICE', icldice, abrtf=.false.)
+   call cnst_get_ind('CLDLIQ', icldliq, abrtf=.false.)
+   call cnst_get_ind('RAINQM', irain, abrtf=.false.)
+   call cnst_get_ind('SNOWQM', isnow, abrtf=.false.)
+
+ end subroutine setup_moist_indices
+
+
 
 end module constituents

--- a/components/eam/src/physics/cam/physics_types.F90
+++ b/components/eam/src/physics/cam/physics_types.F90
@@ -296,7 +296,7 @@ contains
 !       allocate (rairv_loc(state%psetcols,pver,begchunk:endchunk))
 !       rairv_loc(:,:,:) = rairv(:,:,:)
 !    else if (state%psetcols > pcols .and. all(rairv(:,:,:) == rair)) then
-!       allocate(rairv_loc(state%psetcols,pver,begchunk:endchunk))
+       allocate(rairv_loc(state%psetcols,pver,begchunk:endchunk))
        rairv_loc(:,:,:) = rair
 !    else
 !       call endrun('physics_update_main: rairv_loc is not allowed to vary when subcolumns are turned on')

--- a/components/eam/src/physics/cam/physics_types.F90
+++ b/components/eam/src/physics/cam/physics_types.F90
@@ -236,7 +236,7 @@ contains
 
     real(r8) :: zvirv(state%psetcols,pver)  ! Local zvir array pointer
 
-    real(r8),allocatable :: cpairv_loc(:,:,:)
+!    real(r8),allocatable :: cpairv_loc(:,:,:)
     real(r8),allocatable :: rairv_loc(:,:,:)
 
     ! PERGRO limits cldliq/ice for macro/microphysics:
@@ -283,24 +283,24 @@ contains
     ! cpairv_loc and rairv_loc need to be allocated to a size which matches state and ptend
     ! If psetcols == pcols, the cpairv is the correct size and just copy
     ! If psetcols > pcols and all cpairv match cpair, then assign the constant cpair
-    if (state%psetcols == pcols) then
-       allocate (cpairv_loc(state%psetcols,pver,begchunk:endchunk))
-       cpairv_loc(:,:,:) = cpairv(:,:,:)
-    else if (state%psetcols > pcols .and. all(cpairv(:,:,:) == cpair)) then
-       allocate(cpairv_loc(state%psetcols,pver,begchunk:endchunk))
-       cpairv_loc(:,:,:) = cpair
-    else
-       call endrun('physics_update_main: cpairv is not allowed to vary when subcolumns are turned on')
-    end if
-    if (state%psetcols == pcols) then
-       allocate (rairv_loc(state%psetcols,pver,begchunk:endchunk))
-       rairv_loc(:,:,:) = rairv(:,:,:)
-    else if (state%psetcols > pcols .and. all(rairv(:,:,:) == rair)) then
-       allocate(rairv_loc(state%psetcols,pver,begchunk:endchunk))
+!    if (state%psetcols == pcols) then
+!       allocate (cpairv_loc(state%psetcols,pver,begchunk:endchunk))
+!       cpairv_loc(:,:,:) = cpairv(:,:,:)
+!    else if (state%psetcols > pcols .and. all(cpairv(:,:,:) == cpair)) then
+!       allocate(cpairv_loc(state%psetcols,pver,begchunk:endchunk))
+!       cpairv_loc(:,:,:) = cpair
+!    else
+!       call endrun('physics_update_main: cpairv is not allowed to vary when subcolumns are turned on')
+!    end if
+!    if (state%psetcols == pcols) then
+!       allocate (rairv_loc(state%psetcols,pver,begchunk:endchunk))
+!       rairv_loc(:,:,:) = rairv(:,:,:)
+!    else if (state%psetcols > pcols .and. all(rairv(:,:,:) == rair)) then
+!       allocate(rairv_loc(state%psetcols,pver,begchunk:endchunk))
        rairv_loc(:,:,:) = rair
-    else
-       call endrun('physics_update_main: rairv_loc is not allowed to vary when subcolumns are turned on')
-    end if
+!    else
+!       call endrun('physics_update_main: rairv_loc is not allowed to vary when subcolumns are turned on')
+!    end if
 
     !-----------------------------------------------------------------------
     call phys_getopts(state_debug_checks_out=state_debug_checks)
@@ -419,11 +419,11 @@ contains
               ixo, ixo2, ixh, pcnst, state%lchnk, ncol)
     endif
    
-    if ( waccmx_is('ionosphere') .or. waccmx_is('neutral') ) then 
-      zvirv(:,:) = shr_const_rwv / rairv_loc(:,:,state%lchnk) - 1._r8
-    else
+!    if ( waccmx_is('ionosphere') .or. waccmx_is('neutral') ) then 
+!      zvirv(:,:) = shr_const_rwv / rairv_loc(:,:,state%lchnk) - 1._r8
+!    else
       zvirv(:,:) = zvir    
-    endif
+!    endif
 
     !-------------------------------------------------------------------------------------------
     ! Update dry static energy(moved from above for WACCM-X so updating after cpairv_loc update)
@@ -431,10 +431,10 @@ contains
     if(ptend%ls) then
        do k = ptend%top_level, ptend%bot_level
           if (present(tend)) &
-               tend%dtdt(:ncol,k) = tend%dtdt(:ncol,k) + ptend%s(:ncol,k)/cpairv_loc(:ncol,k,state%lchnk)
+               tend%dtdt(:ncol,k) = tend%dtdt(:ncol,k) + ptend%s(:ncol,k)/cpair
 ! we first assume that dS is really dEn, En=enthalpy=c_p*T, then 
 ! dT = dEn/c_p, so, state%t += ds/c_p.
-          state%t(:ncol,k) = state%t(:ncol,k) + ptend%s(:ncol,k)/cpairv_loc(:ncol,k,state%lchnk) * dt
+          state%t(:ncol,k) = state%t(:ncol,k) + ptend%s(:ncol,k)/cpair * dt
        end do
     end if
 
@@ -448,7 +448,7 @@ contains
                           state%zi    , state%zm      ,&
                           ncol)
        do k = ptend%top_level, ptend%bot_level
-          state%s(:ncol,k) = state%t(:ncol,k  )*cpairv_loc(:ncol,k,state%lchnk)&
+          state%s(:ncol,k) = state%t(:ncol,k  )*cpair &
                            + gravit*state%zm(:ncol,k) + state%phis(:ncol)
        end do
     end if
@@ -459,7 +459,9 @@ contains
 
     if (state_debug_checks) call physics_state_check(state, ptend%name)
 
-    deallocate(cpairv_loc, rairv_loc)
+!    deallocate(cpairv_loc, rairv_loc)
+!    deallocate(cpairv_loc)
+    deallocate(rairv_loc)
 
     ! Deallocate ptend
     call physics_ptend_dealloc(ptend)
@@ -1259,14 +1261,14 @@ end subroutine physics_ptend_copy
        state%rpdel (:ncol,k  ) = 1._r8/ state%pdel(:ncol,k  )
     end do
 
-    if ( waccmx_is('ionosphere') .or. waccmx_is('neutral') ) then 
-      zvirv(:,:) = shr_const_rwv / rairv(:,:,state%lchnk) - 1._r8
-    else
-      zvirv(:,:) = zvir    
-    endif
+!    if ( waccmx_is('ionosphere') .or. waccmx_is('neutral') ) then 
+!      zvirv(:,:) = shr_const_rwv / rairv(:,:,state%lchnk) - 1._r8
+!    else
+!      zvirv(:,:) = zvir    
+!    endif
 
 ! compute new T,z from new s,q,dp
-    if (adjust_te) then
+!    if (adjust_te) then
 !!! OG with fix to total energy (removed geopotential term)
 !!! this call needs to be replaced. This code in not active, so, fixes are not
 !!! implemented.
@@ -1275,7 +1277,7 @@ end subroutine physics_ptend_copy
 !            state%s     , state%q(:,:,1), state%phis , rairv(:,:,state%lchnk), &
 !            gravit, cpairv(:,:,state%lchnk), zvirv, &
 !            state%t     , state%zi      , state%zm   , ncol)
-    end if
+!    end if
 
   end subroutine physics_dme_adjust
 !-----------------------------------------------------------------------

--- a/components/eam/src/physics/cam/physics_types.F90
+++ b/components/eam/src/physics/cam/physics_types.F90
@@ -7,7 +7,7 @@ module physics_types
 
   use shr_kind_mod, only: r8 => shr_kind_r8
   use ppgrid,       only: pcols, pver, psubcols
-  use constituents, only: pcnst, qmin, cnst_name
+  use constituents, only: pcnst, qmin, cnst_name, icldliq, icldice
   use geopotential, only: geopotential_t
   use physconst,    only: zvir, gravit, cpair, rair, cpairv, rairv
   use dycore,       only: dycore_is
@@ -226,7 +226,6 @@ contains
 !
 !---------------------------Local storage-------------------------------
     integer :: i,k,m                               ! column,level,constituent indices
-    integer :: ixcldice, ixcldliq                  ! indices for CLDICE and CLDLIQ
     integer :: ixnumice, ixnumliq
     integer :: ixnumsnow, ixnumrain
     integer :: ncol                                ! number of columns
@@ -302,8 +301,6 @@ contains
     end if
 
    ! Update constituents, all schemes use time split q: no tendency kept
-    call cnst_get_ind('CLDICE', ixcldice, abrtf=.false.)
-    call cnst_get_ind('CLDLIQ', ixcldliq, abrtf=.false.)
     ! Check for number concentration of cloud liquid and cloud ice (if not present
     ! the indices will be set to -1)
     call cnst_get_ind('NUMICE', ixnumice, abrtf=.false.)
@@ -361,25 +358,25 @@ contains
 
     ! Special tests for cloud liquid and ice:
     ! Enforce a minimum non-zero value.
-    if (ixcldliq > 1) then
-       if(ptend%lq(ixcldliq)) then
+    if (icldliq > 1) then
+       if(ptend%lq(icldliq)) then
 #ifdef PERGRO
           if ( any(ptend%name == pergro_cldlim_names) ) &
-               call state_cnst_min_nz(1.e-12_r8, ixcldliq, ixnumliq)
+               call state_cnst_min_nz(1.e-12_r8, icldliq, ixnumliq)
 #endif
           if ( any(ptend%name == cldlim_names) ) &
-               call state_cnst_min_nz(1.e-36_r8, ixcldliq, ixnumliq)
+               call state_cnst_min_nz(1.e-36_r8, icldliq, ixnumliq)
        end if
     end if
 
-    if (ixcldice > 1) then
-       if(ptend%lq(ixcldice)) then
+    if (icldice > 1) then
+       if(ptend%lq(icldice)) then
 #ifdef PERGRO
           if ( any(ptend%name == pergro_cldlim_names) ) &
-               call state_cnst_min_nz(1.e-12_r8, ixcldice, ixnumice)
+               call state_cnst_min_nz(1.e-12_r8, icldice, ixnumice)
 #endif
           if ( any(ptend%name == cldlim_names) ) &
-               call state_cnst_min_nz(1.e-36_r8, ixcldice, ixnumice)
+               call state_cnst_min_nz(1.e-36_r8, icldice, ixnumice)
        end if
     end if
 

--- a/components/eam/src/physics/cam/physics_types.F90
+++ b/components/eam/src/physics/cam/physics_types.F90
@@ -339,23 +339,6 @@ contains
 
     end do
 
-    !------------------------------------------------------------------------
-    ! This is a temporary fix for the large H, H2 in WACCM-X
-    ! Well, it was supposed to be temporary, but it has been here
-    ! for a while now.
-    !------------------------------------------------------------------------
-    if ( waccmx_is('ionosphere') .or. waccmx_is('neutral') ) then
-       call cnst_get_ind('H', ixh)
-       do k = ptend%top_level, ptend%bot_level
-          state%q(:ncol,k,ixh) = min(state%q(:ncol,k,ixh), 0.01_r8)
-       end do
-
-       call cnst_get_ind('H2', ixh2)
-       do k = ptend%top_level, ptend%bot_level
-          state%q(:ncol,k,ixh2) = min(state%q(:ncol,k,ixh2), 6.e-5_r8)
-       end do
-    endif
-
     ! Special tests for cloud liquid and ice:
     ! Enforce a minimum non-zero value.
     if (icldliq > 1) then
@@ -380,19 +363,6 @@ contains
        end if
     end if
 
-    !------------------------------------------------------------------------
-    ! Get indices for molecular weights and call WACCM-X physconst_update
-    !------------------------------------------------------------------------
-    if ( waccmx_is('ionosphere') .or. waccmx_is('neutral') ) then 
-      call cnst_get_ind('O', ixo)
-      call cnst_get_ind('O2', ixo2)
-      call cnst_get_ind('N', ixn)             
-
-      call physconst_update(state%q, state%t, &
-              cnst_mw(ixo), cnst_mw(ixo2), cnst_mw(ixh), cnst_mw(ixn), &
-              ixo, ixo2, ixh, pcnst, state%lchnk, ncol)
-    endif
-   
     zvirv(:,:) = zvir    
     rairv_loc(:,:) = rair
 

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -24,7 +24,8 @@ module physpkg
   use phys_grid,        only: get_ncols_p, print_cost_p, update_cost_p, phys_proc_cost
   use phys_gmean,       only: gmean_mass
   use ppgrid,           only: begchunk, endchunk, pcols, pver, pverp, psubcols
-  use constituents,     only: pcnst, cnst_name, cnst_get_ind
+  use constituents,     only: pcnst, cnst_name, cnst_get_ind, &
+                              setup_moist_indices, icldice, icldliq, irain, isnow
   use camsrfexch,       only: cam_out_t, cam_in_t
 
   use cam_control_mod,  only: ideal_phys, adiabatic
@@ -365,7 +366,6 @@ subroutine phys_inidat( cam_out, pbuf2d )
     logical :: found=.false., found2=.false.
     integer :: ierr
     character(len=8) :: dim1name, dim2name
-    integer :: ixcldice, ixcldliq
     integer                   :: grid_id  ! grid ID for data mapping
     nullify(tptr,tptr3d,tptr3d_2,cldptr,convptr_3d)
 
@@ -525,7 +525,6 @@ subroutine phys_inidat( cam_out, pbuf2d )
              call pbuf_set_field(pbuf2d, m, tptr3d, (/1,1,n/),(/pcols,pver,1/))
           end do
        else
-          call cnst_get_ind('CLDICE', ixcldice)
           call infld('CLDICE',fh_ini,dim1name, 'lev', dim2name, 1, pcols, 1, pver, begchunk, endchunk, &
              tptr3d, found, gridname='physgrid')
           if(found) then
@@ -556,8 +555,6 @@ subroutine phys_inidat( cam_out, pbuf2d )
           end do
        else
           allocate(tptr3d_2(pcols,pver,begchunk:endchunk))     
-          call cnst_get_ind('CLDICE', ixcldice)
-          call cnst_get_ind('CLDLIQ', ixcldliq)
           call infld('CLDICE',fh_ini,dim1name, 'lev', dim2name, 1, pcols, 1, pver, begchunk, endchunk, &
                tptr3d, found, gridname='physgrid')
           call infld('CLDLIQ',fh_ini,dim1name, 'lev', dim2name, 1, pcols, 1, pver, begchunk, endchunk, &
@@ -763,8 +760,11 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
 
     !initialize physics update interface routine
     call physics_update_init()
+
     ! Initialize subcol scheme
     call subcol_init(pbuf2d)
+
+    call setup_moist_indices()
 
     ! diag_init makes addfld calls for dynamics fields that are output from
     ! the physics decomposition
@@ -1422,7 +1422,6 @@ subroutine tphysac (ztodt,   cam_in,  &
     use gw_drag,            only: gw_tend
     use vertical_diffusion, only: vertical_diffusion_tend
     use rayleigh_friction,  only: rayleigh_friction_tend
-    use constituents,       only: cnst_get_ind
     use physics_types,      only: physics_state, physics_tend, physics_ptend,    &
          physics_dme_adjust, set_dry_to_wet, physics_state_check
     use majorsp_diffusion,  only: mspd_intr  ! WACCM-X major diffusion
@@ -1480,7 +1479,6 @@ subroutine tphysac (ztodt,   cam_in,  &
     integer :: ncol                                 ! number of atmospheric columns
     integer i,k,m                 ! Longitude, level indices
     integer :: yr, mon, day, tod       ! components of a date
-    integer :: ixcldice, ixcldliq      ! constituent indices for cloud liquid and ice water.
 
     logical :: labort                            ! abort flag
 
@@ -1792,11 +1790,9 @@ if (l_ac_energy_chk) then
 
 
     ! Scale dry mass and energy (does nothing if dycore is EUL or SLD)
-    call cnst_get_ind('CLDLIQ', ixcldliq)
-    call cnst_get_ind('CLDICE', ixcldice)
     tmp_q     (:ncol,:pver) = state%q(:ncol,:pver,1)
-    tmp_cldliq(:ncol,:pver) = state%q(:ncol,:pver,ixcldliq)
-    tmp_cldice(:ncol,:pver) = state%q(:ncol,:pver,ixcldice)
+    tmp_cldliq(:ncol,:pver) = state%q(:ncol,:pver,icldliq)
+    tmp_cldice(:ncol,:pver) = state%q(:ncol,:pver,icldice)
     call physics_dme_adjust(state, tend, qini, ztodt)
 !!!   REMOVE THIS CALL, SINCE ONLY Q IS BEING ADJUSTED. WON'T BALANCE ENERGY. TE IS SAVED BEFORE THIS
 !!!   call check_energy_chng(state, tend, "drymass", nstep, ztodt, zero, zero, zero, zero)
@@ -1980,7 +1976,6 @@ subroutine tphysbc (ztodt,               &
     integer ierr
 
     integer  i,k,m,ihist                       ! Longitude, level, constituent indices
-    integer :: ixcldice, ixcldliq              ! constituent indices for cloud liquid and ice water.
     ! for macro/micro co-substepping
     integer :: macmic_it                       ! iteration variables
     real(r8) :: cld_macmic_ztodt               ! modified timestep
@@ -2274,11 +2269,9 @@ if (l_bc_energy_fix) then
     ! Save state for convective tendency calculations.
     call diag_conv_tend_ini(state, pbuf)
 
-    call cnst_get_ind('CLDLIQ', ixcldliq)
-    call cnst_get_ind('CLDICE', ixcldice)
     qini     (:ncol,:pver) = state%q(:ncol,:pver,       1)
-    cldliqini(:ncol,:pver) = state%q(:ncol,:pver,ixcldliq)
-    cldiceini(:ncol,:pver) = state%q(:ncol,:pver,ixcldice)
+    cldliqini(:ncol,:pver) = state%q(:ncol,:pver,icldliq)
+    cldiceini(:ncol,:pver) = state%q(:ncol,:pver,icldice)
 
 
     call outfld('TEOUT', teout       , pcols, lchnk   )

--- a/components/eam/src/physics/crm/physpkg.F90
+++ b/components/eam/src/physics/crm/physpkg.F90
@@ -24,7 +24,7 @@ module physpkg
   use phys_grid,               only: get_ncols_p, print_cost_p, update_cost_p
   use phys_gmean,              only: gmean_mass
   use ppgrid,                  only: begchunk, endchunk, pcols, pver, pverp
-  use constituents,            only: pcnst, cnst_name, cnst_get_ind
+  use constituents,            only: pcnst, cnst_name, cnst_get_ind, setup_moist_indices
   use camsrfexch,              only: cam_out_t, cam_in_t
   use phys_control,            only: phys_do_flux_avg, phys_getopts
   use scamMod,                 only: single_column, scm_crm_mode
@@ -583,6 +583,8 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
 
   ! diag_init makes addfld calls for dyn fields that are output from the physics decomp
   call diag_init()
+
+  call setup_moist_indices()
 
   call check_energy_init()
 


### PR DESCRIPTION
Removing allocates for cpair and rair variables, since they are always set to dry constants, 
in parts that are related to energy calculations.
Removing repeated code in check_energy wrt TE and total water.
Removing calls to strings comparisons in physpkg and in check_energy. 
Removing some if-statements related to waccm (mostly regarding energy routines).
There are such calls (waccm and string comparison) in other places, esp. in parametrizations, leaving them for now.

[bfb]