### PR TITLE
HOMME: remove one occurrence of the CPP ifndef SCREAM

### DIFF
--- a/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
+++ b/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
@@ -366,9 +366,7 @@ contains
     use perf_mod,       only : t_startf, t_stopf
     use prim_state_mod, only : prim_printstate
     use theta_f2c_mod,  only : prim_run_subcycle_c, cxx_push_results_to_f90
-#ifndef SCREAM
     use theta_f2c_mod,  only : push_forcing_to_c
-#endif
     !
     ! Inputs
     !


### PR DESCRIPTION
The guarded function (push_forcing_to_c) is used unguarded later on, so a link error would ensue. Since the C function is compiled regardless of the SCREAM macro, the simple solution is to remove this ifndef guard.

NOTE: this should NOT affect any code/build that does not define the SCREAM macro. Such codes/builds were already preprocessing the file as if the ifndef wasn't there at all.