### PR TITLE
For GCP, adjust default layouts for some common tests

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -182,14 +182,14 @@
       <pes compset="any" pesize="any">
         <comment>none</comment>
         <ntasks>
-          <ntasks_atm>16</ntasks_atm>
-          <ntasks_lnd>16</ntasks_lnd>
-          <ntasks_rof>16</ntasks_rof>
+          <ntasks_atm>30</ntasks_atm>
+          <ntasks_lnd>30</ntasks_lnd>
+          <ntasks_rof>30</ntasks_rof>
           <ntasks_ice>16</ntasks_ice>
           <ntasks_ocn>16</ntasks_ocn>
           <ntasks_glc>16</ntasks_glc>
-          <ntasks_wav>16</ntasks_wav>
-          <ntasks_cpl>16</ntasks_cpl>
+          <ntasks_wav>30</ntasks_wav>
+          <ntasks_cpl>30</ntasks_cpl>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>
@@ -7385,7 +7385,71 @@
       </pes>
     </mach>
   </grid>
- <grid name="a%ne30np4.pg2_l%.+_oi%oEC60to30v3">
+  <grid name="a%ne30.+_oi%oEC60to30v3">
+    <mach name="gcp">
+      <!--Pes setting: grid          is a%ne30np4_l%ne30np4_oi%oEC60to30v3_r%r05_g%null_w%null_z%null_m%oEC60to30v3 
+          Pes setting: compset       is 2010_EAM%CMIP6_ELM%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV_SIAC_SESP -->
+      <pes compset=".*EAM.+ELM.+DOCN" pesize="any">
+        <comment> -compset A_WCYCL* -res ne30pg2_oECv3 without MPASO on 8 nodes </comment>
+        <ntasks>
+          <ntasks_atm>240</ntasks_atm>
+          <ntasks_lnd>240</ntasks_lnd>
+          <ntasks_rof>240</ntasks_rof>
+          <ntasks_ice>240</ntasks_ice>
+          <ntasks_ocn>240</ntasks_ocn>
+          <ntasks_cpl>240</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>2</nthrds_atm>
+          <nthrds_lnd>2</nthrds_lnd>
+          <nthrds_rof>2</nthrds_rof>
+          <nthrds_ice>2</nthrds_ice>
+          <nthrds_ocn>2</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>0</rootpe_ocn>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+   </mach>
+  </grid>
+  <grid name="a%ne30.+_oi%.*EC.*to">
+    <mach name="gcp">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+" pesize="any">
+        <comment> -compset A_WCYCL* -res ne30pg2_oECv3 with MPASO on 11 nodes </comment>
+        <ntasks>
+          <ntasks_atm>240</ntasks_atm>
+          <ntasks_lnd>240</ntasks_lnd>
+          <ntasks_rof>240</ntasks_rof>
+          <ntasks_ice>240</ntasks_ice>
+          <ntasks_ocn>84</ntasks_ocn>
+          <ntasks_cpl>240</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>2</nthrds_atm>
+          <nthrds_lnd>2</nthrds_lnd>
+          <nthrds_rof>2</nthrds_rof>
+          <nthrds_ice>2</nthrds_ice>
+          <nthrds_ocn>2</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>240</rootpe_ocn>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+   </mach>
+  </grid>  
+  <grid name="a%ne30np4.pg2_l%.+_oi%oEC60to30v3">
     <mach name="compy">
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+" pesize="XS">
         <comment> -compset A_WCYCL* -res ne30pg2_oECv3 on 11 nodes pure-MPI, ~2.8 sypd </comment>

--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -574,9 +574,9 @@
 
    <batch_system MACH="gcp" type="slurm" >
      <queues>
-       <queue walltimemax="01:00:00" default="true">compute-30</queue>
-       <queue walltimemax="01:00:00" default="true">computep</queue>	 <!--enable_placement-->
-       <queue walltimemax="02:00:00" default="true">compute</queue>
+       <queue walltimemax="01:30:00" default="true">compute-30</queue>
+       <queue walltimemax="01:30:00" default="true">computep</queue>	 <!--enable_placement-->
+       <queue walltimemax="01:30:00" default="true">compute</queue>
      </queues>
    </batch_system>
    

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -3501,12 +3501,12 @@
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf-config))}</env>
       <env name="OPENBLAS_PATH">/apps/spack/opt/spack/linux-centos7-skylake_avx512/gcc-8.5.0/openblas-0.3.17-avqlf5r7hpzvwesfqg25awhqrpypwgfe</env>
       <env name="LAPACK_PATH">/apps/spack/opt/spack/linux-centos7-skylake_avx512/gcc-8.5.0/netlib-lapack-3.9.1-gton74muo2csn5l3bzf636276ig6h3yx</env>
+      <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
     </environment_variables>
 
     <environment_variables SMP_PRESENT="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
       <env name="OMP_PLACES">threads</env>
-      <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
     </environment_variables>
   </machine>
 


### PR DESCRIPTION
Add PE layouts for common configs of tests on GCP.
Change default walltime for jobs on GCP.
Always turn off HDF5 file locking.

Fixes https://github.com/E3SM-Project/E3SM/issues/4765
[bfb]