### PR TITLE
Add mode specification to conservation check streams

### DIFF
--- a/components/mpas-ocean/src/analysis_members/Registry_conservation_check.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_conservation_check.xml
@@ -200,6 +200,7 @@
 	</var_struct>
 	<streams>
 		<stream name="conservationCheckOutput" type="output"
+				mode="forward;analysis"
 				filename_template="analysis_members/conservationCheck.nc"
 				filename_interval="none"
 				output_interval="00-00-00_01:00:00"
@@ -262,6 +263,7 @@
 
 		<stream name="conservationCheckRestart"
 				type="input;output"
+				mode="forward;analysis"
 				filename_template="restarts/restart.AM.conservationCheck.$Y-$M-$D_$h.$m.$s.nc"
 				filename_interval="output_interval"
 				clobber_mode="replace_files"


### PR DESCRIPTION
Currently, the conservation check analysis member does not specify its MPAS mode. This was an oversight. Without including this, the conservation check stream is included in MPAS init mode. This can cause an error, and it is never needed for init mode anyway. All the other analysis members include these lines.

[BFB]