### PR TITLE
For Perlmutter, change NODENAME_REGEX to be "perlmutter"

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -57,7 +57,7 @@
   -->
   <machine MACH="perlmutter">
     <DESC>Perlmutter at NERSC.  Phase1 only: Each GPU node has single AMD EPYC 7713 64-Core (Milan) and 4 nvidia A100's.</DESC>
-    <NODENAME_REGEX>login</NODENAME_REGEX>
+    <NODENAME_REGEX>perlmutter</NODENAME_REGEX>
     <OS>Linux</OS>
     <COMPILERS>gnu,gnugpu,nvidia,nvidiagpu</COMPILERS>
     <MPILIBS>mpich</MPILIBS>


### PR DESCRIPTION
Change the NODENAME_REGEX to be perlmutter to avoid conflicts with machines using "login".

This change was possible after https://github.com/ESMCI/cime/issues/4133
It does require that users have proper setting of env var NERSC_HOST.

login34% env | grep NERSC_HOST
NERSC_HOST=perlmutter

Fixes https://github.com/E3SM-Project/E3SM/issues/4774

[bfb]