### PR TITLE
Fix MPASSI BGC restarting for branch runs

### DIFF
--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -442,6 +442,8 @@ contains
         ! Turn on restarts
         call mpas_pool_get_config(domain % configs, "config_do_restart", tempLogicalConfig)
         tempLogicalConfig = .true.
+        call mpas_pool_get_config(domain % configs, "config_do_restart_bgc", tempLogicalConfig)
+        tempLogicalConfig = .true.
         call mpas_pool_get_config(domain % configs, "config_do_restart_hbrine", tempLogicalConfig)
         tempLogicalConfig = .true.
         call mpas_pool_get_config(domain % configs, "config_do_restart_snow_density", tempLogicalConfig)


### PR DESCRIPTION
Branch runs currently are not BFB when mpassi BGC is enabled, due to a missing setting in the seaice driver. This PR fixes that issue.

[BFB] for all tested configurations