### PR TITLE
Correct NODENAME_REGEX for Perlmutter

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -57,7 +57,7 @@
   -->
   <machine MACH="perlmutter">
     <DESC>Perlmutter at NERSC.  Phase1 only: Each GPU node has single AMD EPYC 7713 64-Core (Milan) and 4 nvidia A100's.</DESC>
-    <NODENAME_REGEX>perlmutter</NODENAME_REGEX>
+    <NODENAME_REGEX>$ENV{NERSC_HOST}:perlmutter</NODENAME_REGEX>
     <OS>Linux</OS>
     <COMPILERS>gnu,gnugpu,nvidia,nvidiagpu</COMPILERS>
     <MPILIBS>mpich</MPILIBS>


### PR DESCRIPTION
On Perlmutter, CIME is using the NERSC_HOST env variable (set to "perlmutter") to auto-detect machine.
My previous PR did not set this correctly.
Should be `<NODENAME_REGEX>$ENV{NERSC_HOST}:perlmutter</NODENAME_REGEX>`

[bfb]
