### PR TITLE
Turn off Redi diagonal terms for shallow columns 

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -571,6 +571,7 @@ add_default($nl, 'config_Redi_use_surface_taper');
 add_default($nl, 'config_Redi_N2_based_taper_enable');
 add_default($nl, 'config_Redi_N2_based_taper_min');
 add_default($nl, 'config_Redi_N2_based_taper_limit_term1');
+add_default($nl, 'config_Redi_min_layers_diag_terms');
 
 ############################################
 # Namelist group: GM_eddy_parameterization #

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -114,6 +114,7 @@ add_default($nl, 'config_Redi_use_surface_taper');
 add_default($nl, 'config_Redi_N2_based_taper_enable');
 add_default($nl, 'config_Redi_N2_based_taper_min');
 add_default($nl, 'config_Redi_N2_based_taper_limit_term1');
+add_default($nl, 'config_Redi_min_layers_diag_terms');
 
 ############################################
 # Namelist group: GM_eddy_parameterization #

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -152,6 +152,7 @@
 <config_Redi_N2_based_taper_enable>.true.</config_Redi_N2_based_taper_enable>
 <config_Redi_N2_based_taper_min>0.1</config_Redi_N2_based_taper_min>
 <config_Redi_N2_based_taper_limit_term1>.true.</config_Redi_N2_based_taper_limit_term1>
+<config_Redi_min_layers_diag_terms>6</config_Redi_min_layers_diag_terms>
 
 <!-- GM_eddy_parameterization -->
 <config_use_GM>.true.</config_use_GM>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -493,6 +493,14 @@ Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_Redi_min_layers_diag_terms" type="integer"
+	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
+Redi diagonal terms (2 and 3) are turned off from layer 1 through config_Redi_min_layers_diag_terms-1, and on from config_Redi_min_layers_diag_terms to nVertLevels. The Redi diagonal terms are not guaranteed to produce bounded tracer fields, and in practice produce growing temperatures in a few columns with fewer than 5 vertical cells. Redi is meant for isopycnal mixing in the deep ocean, so not applying Redi diagonal terms in very shallow regions is an acceptable solution.
+
+Valid values: any integer between 0 (all layers on) and nVertLevels (all layers off)
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- GM_eddy_parameterization -->
 

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -348,6 +348,14 @@
 					description="If true, Redi term 3 is on"
 					possible_values=".true. or .false."
 		/>
+		<nml_option name="config_Redi_min_layers_term2" type="integer" default_value="0" units="NA"
+					description="min layers for Redi to work in that column"
+					possible_values="any integer>0"
+		/>
+		<nml_option name="config_Redi_min_layers_term3" type="integer" default_value="0" units="NA"
+					description="min layers for Redi to work in that column"
+					possible_values="any integer>0"
+		/>
 	</nml_record>
 	<nml_record name="GM_eddy_parameterization" mode="forward">
 		<nml_option name="config_use_GM" type="logical" default_value=".false." units="NA"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -340,6 +340,14 @@
 					description="If true, the N2 lim iting is applied to the horizontal diffusion term"
 					possible_values=".true. or .false."
 		/>
+		<nml_option name="config_Redi_use_term2" type="logical" default_value=".true." units="unitless"
+					description="If true, Redi term 2 is on"
+					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_Redi_use_term3" type="logical" default_value=".true." units="unitless"
+					description="If true, Redi term 3 is on"
+					possible_values=".true. or .false."
+		/>
 	</nml_record>
 	<nml_record name="GM_eddy_parameterization" mode="forward">
 		<nml_option name="config_use_GM" type="logical" default_value=".false." units="NA"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -340,20 +340,8 @@
 					description="If true, the N2 lim iting is applied to the horizontal diffusion term"
 					possible_values=".true. or .false."
 		/>
-		<nml_option name="config_Redi_use_term2" type="logical" default_value=".true." units="unitless"
-					description="If true, Redi term 2 is on"
-					possible_values=".true. or .false."
-		/>
-		<nml_option name="config_Redi_use_term3" type="logical" default_value=".true." units="unitless"
-					description="If true, Redi term 3 is on"
-					possible_values=".true. or .false."
-		/>
-		<nml_option name="config_Redi_min_layers_term2" type="integer" default_value="0" units="NA"
-					description="min layers for Redi to work in that column"
-					possible_values="any integer>0"
-		/>
-		<nml_option name="config_Redi_min_layers_term3" type="integer" default_value="0" units="NA"
-					description="min layers for Redi to work in that column"
+		<nml_option name="config_Redi_min_layers_diag_terms" type="integer" default_value="5" units="NA"
+					description="min layers for Redi to work in that column for diagonal terms, term 2 and term 3"
 					possible_values="any integer>0"
 		/>
 	</nml_record>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -337,12 +337,12 @@
 					possible_values="greater than zero and less than 1"
 		/>
 		<nml_option name="config_Redi_N2_based_taper_limit_term1" type="logical" default_value=".true." units="unitless"
-					description="If true, the N2 lim iting is applied to the horizontal diffusion term"
+					description="If true, the N2 limiting is applied to the horizontal diffusion term"
 					possible_values=".true. or .false."
 		/>
-		<nml_option name="config_Redi_min_layers_diag_terms" type="integer" default_value="5" units="NA"
-					description="min layers for Redi to work in that column for diagonal terms, term 2 and term 3"
-					possible_values="any integer>0"
+		<nml_option name="config_Redi_min_layers_diag_terms" type="integer" default_value="6" units="NA"
+					description="Redi diagonal terms (2 and 3) are turned off from layer 1 through config_Redi_min_layers_diag_terms-1, and on from config_Redi_min_layers_diag_terms to nVertLevels. The Redi diagonal terms are not guaranteed to produce bounded tracer fields, and in practice produce growing temperatures in a few columns with fewer than 5 vertical cells. Redi is meant for isopycnal mixing in the deep ocean, so not applying Redi diagonal terms in very shallow regions is an acceptable solution."
+					possible_values="any integer between 0 (all layers on) and nVertLevels (all layers off)"
 		/>
 	</nml_record>
 	<nml_record name="GM_eddy_parameterization" mode="forward">

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -130,7 +130,7 @@ contains
 
       integer :: iCell, iEdge, cell1, cell2, iCellSelf
       integer :: i, k, iTr, nTracers, nCells, nEdges, nCellsP1
-      logical :: local_Redi_use_term2, local_Redi_use_term3
+      logical :: use_Redi_diag_terms
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray, nEdgesArray
 
@@ -203,15 +203,10 @@ contains
       !$omp         kappaRediEdgeVal, iTr, tracer_turb_flux, flux, flux_term2, flux_term3, &
       !$omp         dTracerDx)
       do iCell = 1, nCells
-         if (maxLevelCell(iCell)>config_Redi_min_layers_term2) then
-            local_Redi_use_term2 = .true.
+         if (maxLevelCell(iCell)>config_Redi_min_layers_diag_terms) then
+            use_Redi_diag_terms = .true.
          else
-            local_Redi_use_term2 = .false.
-         endif
-         if (maxLevelCell(iCell)>config_Redi_min_layers_term3) then
-            local_Redi_use_term3 = .true.
-         else
-            local_Redi_use_term3 = .false.
+            use_Redi_diag_terms = .false.
          endif
 
          redi_term1(:, :, iCell) = 0.0_RKIND
@@ -270,7 +265,7 @@ contains
                                (tracers(iTr, minLevelEdgeBot(iEdge) - 1, cell2) - tracers(iTr, minLevelEdgeBot(iEdge), cell2))/(zMid(minLevelEdgeBot(iEdge) - 1, cell2) - zMid(minLevelEdgeBot(iEdge), cell2))
                endif
 
-if (config_Redi_use_term2 .and. local_Redi_use_term2) then ! mrp testing
+if (use_Redi_diag_terms) then ! mrp testing
                redi_term2(iTr, k, iCell) = redi_term2(iTr, k, iCell) - edgeSignOnCell(i, iCell)*flux_term2*invAreaCell
                redi_term2_edge(iTr, k, iEdge) = -flux_term2
 endif
@@ -303,7 +298,7 @@ endif
                                 /(zMid(k, cell1) - zMid(k + 1, cell1)) &
                                 + slopeTriadDown(k, 2, iEdge)*(tracers(iTr, k, cell2) - tracers(iTr, k + 1, cell2)) &
                                 /(zMid(k, cell2) - zMid(k + 1, cell2)))
-if (config_Redi_use_term2 .and. local_Redi_use_term2) then ! mrp testing
+if (use_Redi_diag_terms) then ! mrp testing
                   redi_term2(iTr, k, iCell) = redi_term2(iTr, k, iCell) - edgeSignOnCell(i, iCell)*flux_term2* &
                                 invAreaCell
                   redi_term2_edge(iTr, k, iEdge) = -flux_term2
@@ -345,7 +340,7 @@ endif
                                layerThicknessEdge(k, iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadDown(k, 2, iEdge)* &
                                (tracers(iTr, k, cell2) - tracers(iTr, k + 1, cell2))/(zMid(k, cell2) - zMid(k + 1, cell2))
                endif
-if (config_Redi_use_term2 .and. local_Redi_use_term2) then ! mrp testing
+if (use_Redi_diag_terms) then ! mrp testing
                redi_term2(iTr, k, iCell) = redi_term2(iTr, k, iCell) - edgeSignOnCell(i, iCell)*flux_term2 &
                                 *invAreaCell
                redi_term2_edge(iTr, k, iEdge) = -flux_term2
@@ -366,7 +361,7 @@ endif
          end do
          redi_term3_topOfCell(:, maxLevelCell(iCell) + 1, iCell) = 0.0_RKIND
 
-if (config_Redi_use_term3 .and. local_Redi_use_term3) then ! mrp testing
+if ( use_Redi_diag_terms) then ! mrp testing
          do k = minLevelCell(iCell), maxLevelCell(iCell)
             do iTr = 1, nTracers
                ! Add tendency for Term 3: d/dz ( h S grad phi) = ( S grad phi) fluxes
@@ -431,22 +426,17 @@ endif
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell, k, iTr, i, iEdge)
       do iCell = 1, nCells
-         if (maxLevelCell(iCell)>config_Redi_min_layers_term2) then
-            local_Redi_use_term2 = .true.
+         if (maxLevelCell(iCell)>config_Redi_min_layers_diag_terms) then
+            use_Redi_diag_terms = .true.
          else
-            local_Redi_use_term2 = .false.
-         endif
-         if (maxLevelCell(iCell)>config_Redi_min_layers_term3) then
-            local_Redi_use_term3 = .true.
-         else
-            local_Redi_use_term3 = .false.
+            use_Redi_diag_terms = .false.
          endif
 
          invAreaCell = 1.0_RKIND/areaCell(iCell)
          do k = minLevelCell(iCell), maxLevelCell(iCell)
             do iTr = 1, ntracers
                tend(iTr, k, iCell) = tend(iTr, k, iCell) + redi_term1(iTr, k, iCell)
-if (config_Redi_use_term3 .and. local_Redi_use_term3) then ! mrp testing
+if ( use_Redi_diag_terms) then ! mrp testing
                tend(iTr, k, iCell) = tend(iTr, k, iCell) + rediKappaCell(iCell)*2.0_RKIND* &
                                      (RediKappaSfcTaper(k, iCell)*RediKappaScaling(k, iCell)* &
                                       redi_term3_topOfCell(iTr, k, iCell) - RediKappaSfcTaper(k + 1, iCell) &
@@ -455,7 +445,7 @@ endif
             end do
          end do
 
-if (config_Redi_use_term2 .and. local_Redi_use_term2) then ! mrp testing
+if (use_Redi_diag_terms) then ! mrp testing
          do i = 1, nEdgesOnCell(iCell)
             if (cellsOnCell(i, iCell) .eq. nCellsP1) cycle
             iEdge = edgesOnCell(i, iCell)

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -240,6 +240,7 @@ contains
                redi_term1(iTr, k, iCell) = redi_term1(iTr, k, iCell) - (1.0_RKIND + term1TaperFactor* &
                                            (kappaRediEdgeVal - 1.0_RKIND))*edgeSignOnCell(i, iCell)*flux*invAreaCell
 
+               ! Term 2: div( h S dphi/dz)
                flux_term2 = coef*kappaRediEdgeVal*RediKappa(iEdge)*layerThicknessEdge(k, iEdge)* &
                             0.25_RKIND* &
                             (slopeTriadDown(k, 1, iEdge)*(tracers(iTr, k, cell1) - tracers(iTr, k + 1, cell1)) &
@@ -257,8 +258,10 @@ contains
                                (tracers(iTr, minLevelEdgeBot(iEdge) - 1, cell2) - tracers(iTr, minLevelEdgeBot(iEdge), cell2))/(zMid(minLevelEdgeBot(iEdge) - 1, cell2) - zMid(minLevelEdgeBot(iEdge), cell2))
                endif
 
+if (config_Redi_use_term2) then ! mrp testing
                redi_term2(iTr, k, iCell) = redi_term2(iTr, k, iCell) - edgeSignOnCell(i, iCell)*flux_term2*invAreaCell
                redi_term2_edge(iTr, k, iEdge) = -flux_term2
+endif
             end do
 
             do k = minLevelEdgeBot(iEdge) + 1, maxLevelEdgeTop(iEdge) - 1
@@ -288,10 +291,11 @@ contains
                                 /(zMid(k, cell1) - zMid(k + 1, cell1)) &
                                 + slopeTriadDown(k, 2, iEdge)*(tracers(iTr, k, cell2) - tracers(iTr, k + 1, cell2)) &
                                 /(zMid(k, cell2) - zMid(k + 1, cell2)))
+if (config_Redi_use_term2) then ! mrp testing
                   redi_term2(iTr, k, iCell) = redi_term2(iTr, k, iCell) - edgeSignOnCell(i, iCell)*flux_term2* &
                                 invAreaCell
                   redi_term2_edge(iTr, k, iEdge) = -flux_term2
-
+endif
                   dTracerDx = (tracers(iTr, k, cell2) - tracers(iTr, k, cell1))*dvEdge(iEdge)*0.25_RKIND
                   fluxRediZTop(iTr, k) = fluxRediZTop(iTr, k) + &
                                          0.5_RKIND*(slopeTriadUp(k, iCellSelf, iEdge) + slopeTriadDown(k - 1, iCellSelf, iEdge)) &
@@ -329,10 +333,11 @@ contains
                                layerThicknessEdge(k, iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadDown(k, 2, iEdge)* &
                                (tracers(iTr, k, cell2) - tracers(iTr, k + 1, cell2))/(zMid(k, cell2) - zMid(k + 1, cell2))
                endif
+if (config_Redi_use_term2) then ! mrp testing
                redi_term2(iTr, k, iCell) = redi_term2(iTr, k, iCell) - edgeSignOnCell(i, iCell)*flux_term2 &
                                 *invAreaCell
                redi_term2_edge(iTr, k, iEdge) = -flux_term2
-
+endif
                dTracerDx = (tracers(iTr, k, cell2) - tracers(iTr, k, cell1))*dvEdge(iEdge)*0.25_RKIND
                fluxRediZTop(iTr, k) = fluxRediZTop(iTr, k) + &
                                       0.5_RKIND*(slopeTriadUp(k, iCellSelf, iEdge) + slopeTriadDown(k - 1, iCellSelf, iEdge)) &
@@ -359,7 +364,9 @@ contains
                             * invAreaCell - RediKappaSfcTaper(k + 1, iCell)*RediKappaScaling(k + 1, iCell) &
                             *fluxRediZTop(iTr, k + 1) * invAreaCell)
 
+if (config_Redi_use_term3) then ! mrp testing
                redi_term3(iTr, k, iCell) = redi_term3(iTr, k, iCell) + flux_term3
+endif
             end do
          end do
       end do ! iCell
@@ -416,13 +423,16 @@ contains
          do k = minLevelCell(iCell), maxLevelCell(iCell)
             do iTr = 1, ntracers
                tend(iTr, k, iCell) = tend(iTr, k, iCell) + redi_term1(iTr, k, iCell)
+if (config_Redi_use_term3) then ! mrp testing
                tend(iTr, k, iCell) = tend(iTr, k, iCell) + rediKappaCell(iCell)*2.0_RKIND* &
                                      (RediKappaSfcTaper(k, iCell)*RediKappaScaling(k, iCell)* &
                                       redi_term3_topOfCell(iTr, k, iCell) - RediKappaSfcTaper(k + 1, iCell) &
                                       *RediKappaScaling(k + 1, iCell)*redi_term3_topOfCell(iTr, k + 1, iCell))
+endif
             end do
          end do
 
+if (config_Redi_use_term2) then ! mrp testing
          do i = 1, nEdgesOnCell(iCell)
             if (cellsOnCell(i, iCell) .eq. nCellsP1) cycle
             iEdge = edgesOnCell(i, iCell)
@@ -433,6 +443,7 @@ contains
             end do
          end do
       end do ! iCell
+endif
       !$omp end do
       !$omp end parallel
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -130,6 +130,7 @@ contains
 
       integer :: iCell, iEdge, cell1, cell2, iCellSelf
       integer :: i, k, iTr, nTracers, nCells, nEdges, nCellsP1
+      logical :: local_Redi_use_term2, local_Redi_use_term3
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray, nEdgesArray
 
@@ -202,6 +203,17 @@ contains
       !$omp         kappaRediEdgeVal, iTr, tracer_turb_flux, flux, flux_term2, flux_term3, &
       !$omp         dTracerDx)
       do iCell = 1, nCells
+         if (maxLevelCell(iCell)>config_Redi_min_layers_term2) then
+            local_Redi_use_term2 = .true.
+         else
+            local_Redi_use_term2 = .false.
+         endif
+         if (maxLevelCell(iCell)>config_Redi_min_layers_term3) then
+            local_Redi_use_term3 = .true.
+         else
+            local_Redi_use_term3 = .false.
+         endif
+
          redi_term1(:, :, iCell) = 0.0_RKIND
          redi_term2(:, :, iCell) = 0.0_RKIND
          redi_term3(:, :, iCell) = 0.0_RKIND
@@ -258,7 +270,7 @@ contains
                                (tracers(iTr, minLevelEdgeBot(iEdge) - 1, cell2) - tracers(iTr, minLevelEdgeBot(iEdge), cell2))/(zMid(minLevelEdgeBot(iEdge) - 1, cell2) - zMid(minLevelEdgeBot(iEdge), cell2))
                endif
 
-if (config_Redi_use_term2) then ! mrp testing
+if (config_Redi_use_term2 .and. local_Redi_use_term2) then ! mrp testing
                redi_term2(iTr, k, iCell) = redi_term2(iTr, k, iCell) - edgeSignOnCell(i, iCell)*flux_term2*invAreaCell
                redi_term2_edge(iTr, k, iEdge) = -flux_term2
 endif
@@ -291,7 +303,7 @@ endif
                                 /(zMid(k, cell1) - zMid(k + 1, cell1)) &
                                 + slopeTriadDown(k, 2, iEdge)*(tracers(iTr, k, cell2) - tracers(iTr, k + 1, cell2)) &
                                 /(zMid(k, cell2) - zMid(k + 1, cell2)))
-if (config_Redi_use_term2) then ! mrp testing
+if (config_Redi_use_term2 .and. local_Redi_use_term2) then ! mrp testing
                   redi_term2(iTr, k, iCell) = redi_term2(iTr, k, iCell) - edgeSignOnCell(i, iCell)*flux_term2* &
                                 invAreaCell
                   redi_term2_edge(iTr, k, iEdge) = -flux_term2
@@ -333,7 +345,7 @@ endif
                                layerThicknessEdge(k, iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadDown(k, 2, iEdge)* &
                                (tracers(iTr, k, cell2) - tracers(iTr, k + 1, cell2))/(zMid(k, cell2) - zMid(k + 1, cell2))
                endif
-if (config_Redi_use_term2) then ! mrp testing
+if (config_Redi_use_term2 .and. local_Redi_use_term2) then ! mrp testing
                redi_term2(iTr, k, iCell) = redi_term2(iTr, k, iCell) - edgeSignOnCell(i, iCell)*flux_term2 &
                                 *invAreaCell
                redi_term2_edge(iTr, k, iEdge) = -flux_term2
@@ -354,6 +366,7 @@ endif
          end do
          redi_term3_topOfCell(:, maxLevelCell(iCell) + 1, iCell) = 0.0_RKIND
 
+if (config_Redi_use_term3 .and. local_Redi_use_term3) then ! mrp testing
          do k = minLevelCell(iCell), maxLevelCell(iCell)
             do iTr = 1, nTracers
                ! Add tendency for Term 3: d/dz ( h S grad phi) = ( S grad phi) fluxes
@@ -364,11 +377,10 @@ endif
                             * invAreaCell - RediKappaSfcTaper(k + 1, iCell)*RediKappaScaling(k + 1, iCell) &
                             *fluxRediZTop(iTr, k + 1) * invAreaCell)
 
-if (config_Redi_use_term3) then ! mrp testing
                redi_term3(iTr, k, iCell) = redi_term3(iTr, k, iCell) + flux_term3
-endif
             end do
          end do
+endif
       end do ! iCell
       !$omp end do
       !$omp end parallel
@@ -419,11 +431,22 @@ endif
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell, k, iTr, i, iEdge)
       do iCell = 1, nCells
+         if (maxLevelCell(iCell)>config_Redi_min_layers_term2) then
+            local_Redi_use_term2 = .true.
+         else
+            local_Redi_use_term2 = .false.
+         endif
+         if (maxLevelCell(iCell)>config_Redi_min_layers_term3) then
+            local_Redi_use_term3 = .true.
+         else
+            local_Redi_use_term3 = .false.
+         endif
+
          invAreaCell = 1.0_RKIND/areaCell(iCell)
          do k = minLevelCell(iCell), maxLevelCell(iCell)
             do iTr = 1, ntracers
                tend(iTr, k, iCell) = tend(iTr, k, iCell) + redi_term1(iTr, k, iCell)
-if (config_Redi_use_term3) then ! mrp testing
+if (config_Redi_use_term3 .and. local_Redi_use_term3) then ! mrp testing
                tend(iTr, k, iCell) = tend(iTr, k, iCell) + rediKappaCell(iCell)*2.0_RKIND* &
                                      (RediKappaSfcTaper(k, iCell)*RediKappaScaling(k, iCell)* &
                                       redi_term3_topOfCell(iTr, k, iCell) - RediKappaSfcTaper(k + 1, iCell) &
@@ -432,7 +455,7 @@ endif
             end do
          end do
 
-if (config_Redi_use_term2) then ! mrp testing
+if (config_Redi_use_term2 .and. local_Redi_use_term2) then ! mrp testing
          do i = 1, nEdgesOnCell(iCell)
             if (cellsOnCell(i, iCell) .eq. nCellsP1) cycle
             iEdge = edgesOnCell(i, iCell)
@@ -442,8 +465,8 @@ if (config_Redi_use_term2) then ! mrp testing
                end do
             end do
          end do
-      end do ! iCell
 endif
+      end do ! iCell
       !$omp end do
       !$omp end parallel
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -201,9 +201,9 @@ contains
       !$omp do schedule(runtime) &
       !$omp private(fluxRediZTop, invAreaCell, i, iEdge, cell1, cell2, iCellSelf, r_tmp, coef, k, &
       !$omp         kappaRediEdgeVal, iTr, tracer_turb_flux, flux, flux_term2, flux_term3, &
-      !$omp         dTracerDx)
+      !$omp         dTracerDx, use_Redi_diag_terms)
       do iCell = 1, nCells
-         if (maxLevelCell(iCell)>config_Redi_min_layers_diag_terms) then
+         if (maxLevelCell(iCell) .ge. config_Redi_min_layers_diag_terms) then
             use_Redi_diag_terms = .true.
          else
             use_Redi_diag_terms = .false.
@@ -247,6 +247,8 @@ contains
                redi_term1(iTr, k, iCell) = redi_term1(iTr, k, iCell) - (1.0_RKIND + term1TaperFactor* &
                                            (kappaRediEdgeVal - 1.0_RKIND))*edgeSignOnCell(i, iCell)*flux*invAreaCell
 
+               if (.not.use_Redi_diag_terms) cycle
+
                ! Term 2: div( h S dphi/dz)
                flux_term2 = coef*kappaRediEdgeVal*RediKappa(iEdge)*layerThicknessEdge(k, iEdge)* &
                             0.25_RKIND* &
@@ -265,10 +267,8 @@ contains
                                (tracers(iTr, minLevelEdgeBot(iEdge) - 1, cell2) - tracers(iTr, minLevelEdgeBot(iEdge), cell2))/(zMid(minLevelEdgeBot(iEdge) - 1, cell2) - zMid(minLevelEdgeBot(iEdge), cell2))
                endif
 
-if (use_Redi_diag_terms) then ! mrp testing
                redi_term2(iTr, k, iCell) = redi_term2(iTr, k, iCell) - edgeSignOnCell(i, iCell)*flux_term2*invAreaCell
                redi_term2_edge(iTr, k, iEdge) = -flux_term2
-endif
             end do
 
             do k = minLevelEdgeBot(iEdge) + 1, maxLevelEdgeTop(iEdge) - 1
@@ -288,6 +288,8 @@ endif
                   redi_term1(iTr, k, iCell) = redi_term1(iTr, k, iCell) - (1.0_RKIND + term1TaperFactor* &
                                               (kappaRediEdgeVal - 1.0_RKIND))*edgeSignOnCell(i, iCell)*flux*invAreaCell
 
+                  if (.not.use_Redi_diag_terms) cycle
+
                   flux_term2 = coef*RediKappa(iEdge)*kappaRediEdgeVal*layerThicknessEdge(k, iEdge)* &
                                0.25_RKIND* &
                                (slopeTriadUp(k, 1, iEdge)*(tracers(iTr, k - 1, cell1) - tracers(iTr, k, cell1)) &
@@ -298,11 +300,10 @@ endif
                                 /(zMid(k, cell1) - zMid(k + 1, cell1)) &
                                 + slopeTriadDown(k, 2, iEdge)*(tracers(iTr, k, cell2) - tracers(iTr, k + 1, cell2)) &
                                 /(zMid(k, cell2) - zMid(k + 1, cell2)))
-if (use_Redi_diag_terms) then ! mrp testing
                   redi_term2(iTr, k, iCell) = redi_term2(iTr, k, iCell) - edgeSignOnCell(i, iCell)*flux_term2* &
                                 invAreaCell
                   redi_term2_edge(iTr, k, iEdge) = -flux_term2
-endif
+
                   dTracerDx = (tracers(iTr, k, cell2) - tracers(iTr, k, cell1))*dvEdge(iEdge)*0.25_RKIND
                   fluxRediZTop(iTr, k) = fluxRediZTop(iTr, k) + &
                                          0.5_RKIND*(slopeTriadUp(k, iCellSelf, iEdge) + slopeTriadDown(k - 1, iCellSelf, iEdge)) &
@@ -322,6 +323,8 @@ endif
                redi_term1(iTr, k, iCell) = redi_term1(iTr, k, iCell) - (1.0_RKIND + term1TaperFactor* &
                                            (kappaRediEdgeVal - 1.0_RKIND))*edgeSignOnCell(i, iCell)*flux*invAreaCell
 
+               if (.not.use_Redi_diag_terms) cycle
+
                ! For bottom layer, only use triads pointing up:
                flux_term2 = coef*kappaRediEdgeVal*RediKappa(iEdge)*layerThicknessEdge(k, iEdge)* &
                             0.25_RKIND* &
@@ -340,11 +343,10 @@ endif
                                layerThicknessEdge(k, iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadDown(k, 2, iEdge)* &
                                (tracers(iTr, k, cell2) - tracers(iTr, k + 1, cell2))/(zMid(k, cell2) - zMid(k + 1, cell2))
                endif
-if (use_Redi_diag_terms) then ! mrp testing
                redi_term2(iTr, k, iCell) = redi_term2(iTr, k, iCell) - edgeSignOnCell(i, iCell)*flux_term2 &
                                 *invAreaCell
                redi_term2_edge(iTr, k, iEdge) = -flux_term2
-endif
+
                dTracerDx = (tracers(iTr, k, cell2) - tracers(iTr, k, cell1))*dvEdge(iEdge)*0.25_RKIND
                fluxRediZTop(iTr, k) = fluxRediZTop(iTr, k) + &
                                       0.5_RKIND*(slopeTriadUp(k, iCellSelf, iEdge) + slopeTriadDown(k - 1, iCellSelf, iEdge)) &
@@ -352,30 +354,31 @@ endif
             end do
          end do ! nEdgesOnCell(iCell)
 
-         ! impose no-flux boundary conditions at top and bottom of column
-         fluxRediZTop(:, 1:minLevelCell(iCell)) = 0.0_RKIND
-         fluxRediZTop(:, maxLevelCell(iCell) + 1) = 0.0_RKIND
-         redi_term3_topOfCell(:, 1:minLevelCell(iCell), iCell) = 0.0_RKIND
-         do k = minLevelCell(iCell) + 1, maxLevelCell(iCell)
-            redi_term3_topOfCell(:, k, iCell) = fluxRediZTop(:, k) * invAreaCell
-         end do
-         redi_term3_topOfCell(:, maxLevelCell(iCell) + 1, iCell) = 0.0_RKIND
-
-if ( use_Redi_diag_terms) then ! mrp testing
-         do k = minLevelCell(iCell), maxLevelCell(iCell)
-            do iTr = 1, nTracers
-               ! Add tendency for Term 3: d/dz ( h S grad phi) = ( S grad phi) fluxes
-               ! 2.0 in next line is because a dot product on a C-grid
-               ! requires a factor of 1/2 to average to the cell center.
-               flux_term3 = rediKappaCell(iCell)*2.0_RKIND* &
-                            (RediKappaSfcTaper(k, iCell)*RediKappaScaling(k, iCell)*fluxRediZTop(iTr, k)  &
-                            * invAreaCell - RediKappaSfcTaper(k + 1, iCell)*RediKappaScaling(k + 1, iCell) &
-                            *fluxRediZTop(iTr, k + 1) * invAreaCell)
-
-               redi_term3(iTr, k, iCell) = redi_term3(iTr, k, iCell) + flux_term3
+         if ( use_Redi_diag_terms) then
+            ! impose no-flux boundary conditions at top and bottom of column
+            fluxRediZTop(:, 1:minLevelCell(iCell)) = 0.0_RKIND
+            fluxRediZTop(:, maxLevelCell(iCell) + 1) = 0.0_RKIND
+            redi_term3_topOfCell(:, 1:minLevelCell(iCell), iCell) = 0.0_RKIND
+            do k = minLevelCell(iCell) + 1, maxLevelCell(iCell)
+               redi_term3_topOfCell(:, k, iCell) = fluxRediZTop(:, k) * invAreaCell
             end do
-         end do
-endif
+            redi_term3_topOfCell(:, maxLevelCell(iCell) + 1, iCell) = 0.0_RKIND
+
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
+               do iTr = 1, nTracers
+                  ! Add tendency for Term 3: d/dz ( h S grad phi) = ( S grad phi) fluxes
+                  ! 2.0 in next line is because a dot product on a C-grid
+                  ! requires a factor of 1/2 to average to the cell center.
+                  flux_term3 = rediKappaCell(iCell)*2.0_RKIND* &
+                               (RediKappaSfcTaper(k, iCell)*RediKappaScaling(k, iCell)*fluxRediZTop(iTr, k)  &
+                               * invAreaCell - RediKappaSfcTaper(k + 1, iCell)*RediKappaScaling(k + 1, iCell) &
+                               *fluxRediZTop(iTr, k + 1) * invAreaCell)
+
+                  redi_term3(iTr, k, iCell) = redi_term3(iTr, k, iCell) + flux_term3
+               end do
+            end do
+         end if
+
       end do ! iCell
       !$omp end do
       !$omp end parallel
@@ -426,36 +429,33 @@ endif
       !$omp parallel
       !$omp do schedule(runtime) private(invAreaCell, k, iTr, i, iEdge)
       do iCell = 1, nCells
-         if (maxLevelCell(iCell)>config_Redi_min_layers_diag_terms) then
-            use_Redi_diag_terms = .true.
-         else
-            use_Redi_diag_terms = .false.
-         endif
-
          invAreaCell = 1.0_RKIND/areaCell(iCell)
          do k = minLevelCell(iCell), maxLevelCell(iCell)
             do iTr = 1, ntracers
                tend(iTr, k, iCell) = tend(iTr, k, iCell) + redi_term1(iTr, k, iCell)
-if ( use_Redi_diag_terms) then ! mrp testing
-               tend(iTr, k, iCell) = tend(iTr, k, iCell) + rediKappaCell(iCell)*2.0_RKIND* &
-                                     (RediKappaSfcTaper(k, iCell)*RediKappaScaling(k, iCell)* &
-                                      redi_term3_topOfCell(iTr, k, iCell) - RediKappaSfcTaper(k + 1, iCell) &
-                                      *RediKappaScaling(k + 1, iCell)*redi_term3_topOfCell(iTr, k + 1, iCell))
-endif
             end do
          end do
 
-if (use_Redi_diag_terms) then ! mrp testing
-         do i = 1, nEdgesOnCell(iCell)
-            if (cellsOnCell(i, iCell) .eq. nCellsP1) cycle
-            iEdge = edgesOnCell(i, iCell)
-            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+         if (maxLevelCell(iCell) .ge. config_Redi_min_layers_diag_terms) then
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
                do iTr = 1, ntracers
-                  tend(iTr, k, iCell) = tend(iTr, k, iCell) + edgeSignOnCell(i, iCell)*invAreaCell*redi_term2_edge(iTr, k, iEdge)
+                  tend(iTr, k, iCell) = tend(iTr, k, iCell) + rediKappaCell(iCell)*2.0_RKIND* &
+                                        (RediKappaSfcTaper(k, iCell)*RediKappaScaling(k, iCell)* &
+                                         redi_term3_topOfCell(iTr, k, iCell) - RediKappaSfcTaper(k + 1, iCell) &
+                                         *RediKappaScaling(k + 1, iCell)*redi_term3_topOfCell(iTr, k + 1, iCell))
                end do
             end do
-         end do
-endif
+
+            do i = 1, nEdgesOnCell(iCell)
+               if (cellsOnCell(i, iCell) .eq. nCellsP1) cycle
+               iEdge = edgesOnCell(i, iCell)
+               do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+                  do iTr = 1, ntracers
+                     tend(iTr, k, iCell) = tend(iTr, k, iCell) + edgeSignOnCell(i, iCell)*invAreaCell*redi_term2_edge(iTr, k, iEdge)
+                  end do
+               end do
+            end do
+         end if
       end do ! iCell
       !$omp end do
       !$omp end parallel


### PR DESCRIPTION
The MPAS-Ocean Redi diagonal terms are not guaranteed to produce bounded tracer fields, and in practice produce growing temperatures in a few ocean columns with fewer than 5 vertical cells in particular simulations. Redi is meant for isopycnal mixing in the deep ocean, so not applying Redi diagonal terms in very shallow regions is an acceptable solution. The problematic behavior is described in https://github.com/MPAS-Dev/compass/issues/308. 

Here we add the flag `config_Redi_min_layers_diag_terms`. Redi diagonal terms (2 and 3) are turned off from layer 1 through `config_Redi_min_layers_diag_terms-1`, and on from `config_Redi_min_layers_diag_terms` through `nVertLevels`. 

If `config_Redi_min_layers_diag_terms` is set to 1, Redi will be applied as before this PR, and simulations should compare bit-for-bit or machine precision to previous simulations.

We are adding the default `config_Redi_min_layers_diag_terms=6` (no Redi applied in columns with 5 or fewer vertical cells). I found in sensitivity tests that values of 5 and 6 produce no non-monotonic warming in the problematic case of WC14 ocean-only spin-up with no surface forcing and rough bathymetry (the most challenging case, see https://github.com/MPAS-Dev/compass/issues/308) but a value of 4 produces increasing temperatures.

[NML]
[non-BFB]
Fixes #4784