### PR TITLE
Homme, physgrid: Remove reshape use in low-level code.

### DIFF
--- a/components/homme/test_execs/thetal_kokkos_ut/gllfvremap_interface.F90
+++ b/components/homme/test_execs/thetal_kokkos_ut/gllfvremap_interface.F90
@@ -108,7 +108,7 @@ contains
     real (c_double), intent(in) :: spheremp(n*n), dp(n*n)
     real (c_double), intent(inout) :: qmin, qmax, q(n*n)
 
-    call limiter1_clip_and_sum(n, spheremp, qmin, qmax, dp, q)
+    call limiter1_clip_and_sum(n*n, spheremp, qmin, qmax, dp, q)
   end subroutine limiter1_clip_and_sum_f90
 
   subroutine calc_dp_fv_f90(nf, ps, dp_fv) bind(c)


### PR DESCRIPTION
Noel noticed on PM that the AMD compilers have trouble with optimizing
reshape. Remove the use of reshape.

[BFB] except thetah-sl-dcmip16_test1pg2 in the HOMME suite of homme_integration