### PR TITLE
HOMME: add some SCREAM ifdefs, and some minor cleanup

### DIFF
--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -5790,12 +5790,6 @@ Bottom of sponge layer in hPa.
 Default: 0 (use default value based on reference pressure at model top).
 </entry>
 
-<entry id="fine_ne" type="integer" category="se"
-       group="ctl_nl" valid_values="" >
-baseline ne for scalar hypervis tuning
-Default: Set by build-namelist.
-</entry>
-
 <entry id="hypervis_scaling" type="real" category="se"
        group="ctl_nl" valid_values="" >
 Default: Set by build-namelist.

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -5800,11 +5800,6 @@ Default: Set by build-namelist.
 Default: Set by build-namelist.
 </entry>
 
-<entry id="max_hypervis_courant" type="real" category="se"
-       group="ctl_nl" valid_values="" >
-Default: Set by build-namelist.
-</entry>
-
 <!-- tracer transport options -->
 
 <entry id="transport_alg" type="integer" category="se"

--- a/components/homme/dcmip_tests/dcmip2012_test1.1_3d_deformational_flow/preqx/namelist-default.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test1.1_3d_deformational_flow/preqx/namelist-default.nl
@@ -29,7 +29,6 @@
   tol               = 1.e-7
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 0.2549944                 ! vertical coordinate at top of atm 254.9 hPa (12km)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test1.1_3d_deformational_flow/preqx/namelist-lowres.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test1.1_3d_deformational_flow/preqx/namelist-lowres.nl
@@ -29,7 +29,6 @@
   tol               = 1.e-7
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 0.2549944                 ! vertical coordinate at top of atm 254.9 hPa (12km)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test1.2_hadley_meridional_circulation/preqx/namelist-default.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test1.2_hadley_meridional_circulation/preqx/namelist-default.nl
@@ -29,7 +29,6 @@
   tol               = 1.e-7
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 0.2549944                 ! vertical coordinate at top of atm 254.9 hPa (12km)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test1.2_hadley_meridional_circulation/preqx/namelist-lowres.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test1.2_hadley_meridional_circulation/preqx/namelist-lowres.nl
@@ -29,7 +29,6 @@
   tol               = 1.e-7
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 0.2549944                 ! vertical coordinate at top of atm 254.9 hPa (12km)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test1.3_thin_clouds_over_orography/preqx/namelist-default.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test1.3_thin_clouds_over_orography/preqx/namelist-default.nl
@@ -30,7 +30,6 @@
   tol               = 1.e-7
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 0.2549944                 ! vertical coordinate at top of atm 254.9 hPa (12km)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test1.3_thin_clouds_over_orography/preqx/namelist-lowres.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test1.3_thin_clouds_over_orography/preqx/namelist-lowres.nl
@@ -30,7 +30,6 @@
   tol               = 1.e-7
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 0.2549944                 ! vertical coordinate at top of atm 254.9 hPa (12km)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test2.0_steady_state_with_orography/preqx/namelist-default.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.0_steady_state_with_orography/preqx/namelist-default.nl
@@ -24,7 +24,6 @@
   omega             = 0.0                       ! earth angular speed = 0.0
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 2.05e-1                   ! vertical coordinate at top of atm (z=12000m)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test2.0_steady_state_with_orography/preqx/namelist-lowres.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.0_steady_state_with_orography/preqx/namelist-lowres.nl
@@ -25,7 +25,6 @@
   dcmip2_0_zetam    = 0.785                     ! mountain half-width = pi/4
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 2.05e-1                   ! vertical coordinate at top of atm (z=12000m)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test2.0_steady_state_with_orography/theta-l/namelist-h-lowres.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.0_steady_state_with_orography/theta-l/namelist-h-lowres.nl
@@ -26,7 +26,6 @@
   dcmip2_0_zetam    = 0.785                     ! mountain half-width = pi/4
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 2.05e-1                   ! vertical coordinate at top of atm (z=12000m)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test2.0_steady_state_with_orography/theta-l/namelist-h.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.0_steady_state_with_orography/theta-l/namelist-h.nl
@@ -28,7 +28,6 @@
   omega             = 0.0                       ! earth angular speed = 0.0
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 2.05e-1                   ! vertical coordinate at top of atm (z=12000m)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test2.0_steady_state_with_orography/theta-l/namelist-nh.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.0_steady_state_with_orography/theta-l/namelist-nh.nl
@@ -28,7 +28,6 @@
   omega             = 0.0                       ! earth angular speed = 0.0
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 2.05e-1                   ! vertical coordinate at top of atm (z=12000m)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/preqx/namelist-default.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/preqx/namelist-default.nl
@@ -29,7 +29,6 @@
   dcmip2_x_xi       = 4000.0                    ! mountain wavelength   (m)
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/preqx/namelist-lowres.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/preqx/namelist-lowres.nl
@@ -29,7 +29,6 @@
   dcmip2_x_xi       = 8000.0                    ! mountain wavelength   (m)
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/theta-l/namelist-h-lowres.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/theta-l/namelist-h-lowres.nl
@@ -30,7 +30,6 @@
   dcmip2_x_xi       = 8000.0                    ! mountain wavelength   (m)
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/theta-l/namelist-h.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/theta-l/namelist-h.nl
@@ -30,7 +30,6 @@
   dcmip2_x_xi       = 4000.0                    ! mountain wavelength   (m)
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/theta-l/namelist-nh.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.1_nh_mountain_waves_no_shear/theta-l/namelist-nh.nl
@@ -30,7 +30,6 @@
   dcmip2_x_xi       = 4000.0                    ! mountain wavelength   (m)
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/preqx/namelist-default.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/preqx/namelist-default.nl
@@ -31,7 +31,6 @@
   dcmip2_x_xi       = 4000.0                    ! mountain wavelength   (m)
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/preqx/namelist-lowres.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/preqx/namelist-lowres.nl
@@ -30,7 +30,6 @@
   dcmip2_x_xi       = 8000.0                    ! mountain wavelength   (m)
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/theta-l/namelist-h-lowres.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/theta-l/namelist-h-lowres.nl
@@ -31,7 +31,6 @@
   dcmip2_x_xi       = 8000.0                    ! mountain wavelength   (m)
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/theta-l/namelist-h.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/theta-l/namelist-h.nl
@@ -31,7 +31,6 @@
   dcmip2_x_xi       = 4000.0                    ! mountain wavelength   (m)
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/theta-l/namelist-nh.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test2.2_nh_mountain_waves_with_shear/theta-l/namelist-nh.nl
@@ -31,7 +31,6 @@
   dcmip2_x_xi       = 4000.0                    ! mountain wavelength   (m)
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test3.1_nh_gravity_waves/preqx/namelist-default.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test3.1_nh_gravity_waves/preqx/namelist-default.nl
@@ -30,7 +30,6 @@
   omega             = 0.0                       ! earth angular speed = 0.0
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 2.73919e-1                ! vertical coordinate at top of atm (z=10000m)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test3.1_nh_gravity_waves/preqx/namelist-lowres.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test3.1_nh_gravity_waves/preqx/namelist-lowres.nl
@@ -30,7 +30,6 @@
   omega             = 0.0                       ! earth angular speed = 0.0
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 2.73919e-1                ! vertical coordinate at top of atm (z=10000m)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test3.1_nh_gravity_waves/theta-l/namelist-h-lowres.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test3.1_nh_gravity_waves/theta-l/namelist-h-lowres.nl
@@ -31,7 +31,6 @@
   omega             = 0.0                       ! earth angular speed = 0.0
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 2.73919e-1                ! vertical coordinate at top of atm (z=10000m)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test3.1_nh_gravity_waves/theta-l/namelist-h.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test3.1_nh_gravity_waves/theta-l/namelist-h.nl
@@ -31,7 +31,6 @@
   omega             = 0.0                       ! earth angular speed = 0.0
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 2.73919e-1                ! vertical coordinate at top of atm (z=10000m)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test3.1_nh_gravity_waves/theta-l/namelist-nh.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test3.1_nh_gravity_waves/theta-l/namelist-nh.nl
@@ -31,7 +31,6 @@
   omega             = 0.0                       ! earth angular speed = 0.0
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 2.73919e-1                ! vertical coordinate at top of atm (z=10000m)
 /

--- a/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/preqx/h-x1.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/preqx/h-x1.nl
@@ -35,7 +35,6 @@ hypervis_subcycle = 1
 hypervis_subcycle = 1
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = '../vcoord/camm-30.ascii'
 vfile_int = '../vcoord/cami-30.ascii'
 /

--- a/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/theta-l/h-x1-erun1.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/theta-l/h-x1-erun1.nl
@@ -33,7 +33,6 @@ hypervis_scaling=0
 hypervis_order = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = '../vcoord/camm-30.ascii'
 vfile_int = '../vcoord/cami-30.ascii'
 /

--- a/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/theta-l/h-x1-erun2.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/theta-l/h-x1-erun2.nl
@@ -33,7 +33,6 @@ hypervis_scaling=0
 hypervis_order = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = '../vcoord/camm-30.ascii'
 vfile_int = '../vcoord/cami-30.ascii'
 /

--- a/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/theta-l/h-x1-erun3.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/theta-l/h-x1-erun3.nl
@@ -33,7 +33,6 @@ hypervis_scaling=0
 hypervis_order = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = '../vcoord/camm-30.ascii'
 vfile_int = '../vcoord/cami-30.ascii'
 /

--- a/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/theta-l/h-x1.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/theta-l/h-x1.nl
@@ -34,7 +34,6 @@ hypervis_subcycle = 1
 hypervis_subcycle = 1
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = '../vcoord/camm-30.ascii'
 vfile_int = '../vcoord/cami-30.ascii'
 /

--- a/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/theta-l/nh-x1.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/theta-l/nh-x1.nl
@@ -34,7 +34,6 @@ hypervis_subcycle = 1
 hypervis_subcycle = 1
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = '../vcoord/camm-30.ascii'
 vfile_int = '../vcoord/cami-30.ascii'
 /

--- a/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/theta-l/nh-x10.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/theta-l/nh-x10.nl
@@ -34,7 +34,6 @@ hypervis_subcycle = 1
 hypervis_subcycle = 1
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = '../vcoord/camm-30.ascii'
 vfile_int = '../vcoord/cami-30.ascii'
 /

--- a/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/theta-l/nh-x100.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/theta-l/nh-x100.nl
@@ -34,7 +34,6 @@ hypervis_subcycle = 1
 hypervis_subcycle = 1
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = '../vcoord/camm-30.ascii'
 vfile_int = '../vcoord/cami-30.ascii'
 /

--- a/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/theta-l/nh-x1000-erun1.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/theta-l/nh-x1000-erun1.nl
@@ -33,7 +33,6 @@ hypervis_scaling=0
 hypervis_order = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = '../vcoord/camm-30.ascii'
 vfile_int = '../vcoord/cami-30.ascii'
 /

--- a/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/theta-l/nh-x1000-erun2.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/theta-l/nh-x1000-erun2.nl
@@ -33,7 +33,6 @@ hypervis_scaling=0
 hypervis_order = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = '../vcoord/camm-30.ascii'
 vfile_int = '../vcoord/cami-30.ascii'
 /

--- a/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/theta-l/nh-x1000-erun3.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/theta-l/nh-x1000-erun3.nl
@@ -33,7 +33,6 @@ hypervis_scaling=0
 hypervis_order = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = '../vcoord/camm-30.ascii'
 vfile_int = '../vcoord/cami-30.ascii'
 /

--- a/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/theta-l/nh-x1000.nl
+++ b/components/homme/dcmip_tests/dcmip2012_test4.1_baroclinic_instability/theta-l/nh-x1000.nl
@@ -33,7 +33,6 @@ hypervis_order = 2
 hypervis_subcycle = 1    ! NOTE: for tstep>.16, may need to subcycle viscosity
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = '../vcoord/camm-30.ascii'
 vfile_int = '../vcoord/cami-30.ascii'
 /

--- a/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/preqx/namelist-r100-dry.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/preqx/namelist-r100-dry.nl
@@ -30,7 +30,6 @@
   dcmip16_pbl_type  = -1                         ! 0=reed-jablonowski pbl, -1 = none
 /
 &vert_nl
-  vform             = "ccm"
   vfile_mid         = "../vcoord/camm-30.ascii"
   vfile_int         = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/preqx/namelist-r100.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/preqx/namelist-r100.nl
@@ -30,7 +30,6 @@
   dcmip16_pbl_type  = -1                         ! 0=reed-jablonowski pbl, -1 = none
 /
 &vert_nl
-  vform             = "ccm"
   vfile_mid         = "../vcoord/camm-30.ascii"
   vfile_int         = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/preqx/namelist-r400-dry.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/preqx/namelist-r400-dry.nl
@@ -29,7 +29,6 @@
   dcmip16_pbl_type  = -1                        ! 0=reed-jablonowski pbl, -1 = none
 /
 &vert_nl
-  vform             = "ccm"
   vfile_mid         = "../vcoord/camm-30.ascii"
   vfile_int         = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/preqx/namelist-r400.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/preqx/namelist-r400.nl
@@ -29,7 +29,6 @@
   dcmip16_pbl_type  = -1                        ! 0=reed-jablonowski pbl, -1 = none
 /
 &vert_nl
-  vform             = "ccm"
   vfile_mid         = "../vcoord/camm-30.ascii"
   vfile_int         = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/preqx/namelist-r50-dry.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/preqx/namelist-r50-dry.nl
@@ -30,7 +30,6 @@
   dcmip16_pbl_type  = -1                         ! 0=reed-jablonowski pbl, -1 = none
 /
 &vert_nl
-  vform             = "ccm"
   vfile_mid         = "../vcoord/camm-30.ascii"
   vfile_int         = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/preqx/namelist-r50.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/preqx/namelist-r50.nl
@@ -30,7 +30,6 @@
   dcmip16_pbl_type  = -1                         ! 0=reed-jablonowski pbl, -1 = none
 /
 &vert_nl
-  vform             = "ccm"
   vfile_mid         = "../vcoord/camm-30.ascii"
   vfile_int         = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/checkE-run1.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/checkE-run1.nl
@@ -30,7 +30,6 @@
   dcmip16_pbl_type  = -1                        ! 0=reed-jablonowski pbl, -1 = none
 /
 &vert_nl
-  vform             = "ccm"
   vfile_mid         = "../vcoord/camm-30.ascii"
   vfile_int         = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/checkE-run2.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/checkE-run2.nl
@@ -32,7 +32,6 @@
   dcmip16_pbl_type  = -1                        ! 0=reed-jablonowski pbl, -1 = none
 /
 &vert_nl
-  vform             = "ccm"
   vfile_mid         = "../vcoord/camm-30.ascii"
   vfile_int         = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-ne1024.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-ne1024.nl
@@ -32,7 +32,6 @@
   dcmip16_pbl_type  = -1                         ! 0=reed-jablonowski pbl, -1 = none
 /
 &vert_nl
-  vform             = "ccm"
   vfile_mid         = "../vcoord/camm-30.ascii"
   vfile_int         = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-ne120.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-ne120.nl
@@ -31,7 +31,6 @@
   dcmip16_pbl_type  = -1                         ! 0=reed-jablonowski pbl, -1 = none
 /
 &vert_nl
-  vform             = "ccm"
   vfile_mid         = "../vcoord/camm-30.ascii"
   vfile_int         = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-ne2048.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-ne2048.nl
@@ -31,7 +31,6 @@
   dcmip16_pbl_type  = -1                         ! 0=reed-jablonowski pbl, -1 = none
 /
 &vert_nl
-  vform             = "ccm"
   vfile_mid         = "../vcoord/camm-30.ascii"
   vfile_int         = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-ne256.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-ne256.nl
@@ -32,7 +32,6 @@
   dcmip16_pbl_type  = -1                         ! 0=reed-jablonowski pbl, -1 = none
 /
 &vert_nl
-  vform             = "ccm"
   vfile_mid         = "../vcoord/camm-30.ascii"
   vfile_int         = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-ne3072.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-ne3072.nl
@@ -31,7 +31,6 @@
   dcmip16_pbl_type  = -1                         ! 0=reed-jablonowski pbl, -1 = none
 /
 &vert_nl
-  vform             = "ccm"
   vfile_mid         = "../vcoord/camm-30.ascii"
   vfile_int         = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-ne4096.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-ne4096.nl
@@ -31,7 +31,6 @@
   dcmip16_pbl_type  = -1                         ! 0=reed-jablonowski pbl, -1 = none
 /
 &vert_nl
-  vform             = "ccm"
   vfile_mid         = "../vcoord/camm-30.ascii"
   vfile_int         = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-ne512.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-ne512.nl
@@ -31,7 +31,6 @@
   dcmip16_pbl_type  = -1                         ! 0=reed-jablonowski pbl, -1 = none
 /
 &vert_nl
-  vform             = "ccm"
   vfile_mid         = "../vcoord/camm-30.ascii"
   vfile_int         = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-r100-dry.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-r100-dry.nl
@@ -30,7 +30,6 @@
   dcmip16_pbl_type  = -1                         ! 0=reed-jablonowski pbl, -1 = none
 /
 &vert_nl
-  vform             = "ccm"
   vfile_mid         = "../vcoord/camm-30.ascii"
   vfile_int         = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-r100-h.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-r100-h.nl
@@ -30,7 +30,6 @@
   dcmip16_pbl_type  = -1                         ! 0=reed-jablonowski pbl, -1 = none
 /
 &vert_nl
-  vform             = "ccm"
   vfile_mid         = "../vcoord/camm-30.ascii"
   vfile_int         = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-r100.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-r100.nl
@@ -30,7 +30,6 @@
   dcmip16_pbl_type  = -1                         ! 0=reed-jablonowski pbl, -1 = none
 /
 &vert_nl
-  vform             = "ccm"
   vfile_mid         = "../vcoord/camm-30.ascii"
   vfile_int         = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-r400.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-r400.nl
@@ -30,7 +30,6 @@
   dcmip16_pbl_type  = -1                        ! 0=reed-jablonowski pbl, -1 = none
 /
 &vert_nl
-  vform             = "ccm"
   vfile_mid         = "../vcoord/camm-30.ascii"
   vfile_int         = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-r50.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test1_baroclinic_wave/theta-l/namelist-r50.nl
@@ -30,7 +30,6 @@
   dcmip16_pbl_type  = -1                         ! 0=reed-jablonowski pbl, -1 = none
 /
 &vert_nl
-  vform             = "ccm"
   vfile_mid         = "../vcoord/camm-30.ascii"
   vfile_int         = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test2_tropical_cyclone/preqx/namelist-r100.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test2_tropical_cyclone/preqx/namelist-r100.nl
@@ -29,7 +29,6 @@
   dcmip16_pbl_type  = 0                         ! 0=basic pbl,   1= bryan pbl
 /
 &vert_nl
-  vform         = "ccm"
   vfile_mid     = "../vcoord/camm-30.ascii"
   vfile_int     = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test2_tropical_cyclone/preqx/namelist-r400.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test2_tropical_cyclone/preqx/namelist-r400.nl
@@ -29,7 +29,6 @@
   dcmip16_pbl_type  = 0                         ! 0=basic pbl,   1= bryan pbl
 /
 &vert_nl
-  vform         = "ccm"
   vfile_mid     = "../vcoord/camm-30.ascii"
   vfile_int     = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test2_tropical_cyclone/preqx/namelist-r50.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test2_tropical_cyclone/preqx/namelist-r50.nl
@@ -29,7 +29,6 @@
   dcmip16_pbl_type  = 0                         ! 0=basic pbl,   1= bryan pbl
 /
 &vert_nl
-  vform         = "ccm"
   vfile_mid     = "../vcoord/camm-30.ascii"
   vfile_int     = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test2_tropical_cyclone/theta-l/namelist-r100.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test2_tropical_cyclone/theta-l/namelist-r100.nl
@@ -29,7 +29,6 @@
   dcmip16_pbl_type  = 0                         ! 0=basic pbl,   1= bryan pbl
 /
 &vert_nl
-  vform         = "ccm"
   vfile_mid     = "../vcoord/camm-30.ascii"
   vfile_int     = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test2_tropical_cyclone/theta-l/namelist-r400.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test2_tropical_cyclone/theta-l/namelist-r400.nl
@@ -29,7 +29,6 @@
   dcmip16_pbl_type  = 0                         ! 0=basic pbl,   1= bryan pbl
 /
 &vert_nl
-  vform         = "ccm"
   vfile_mid     = "../vcoord/camm-30.ascii"
   vfile_int     = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test2_tropical_cyclone/theta-l/namelist-r50-h.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test2_tropical_cyclone/theta-l/namelist-r50-h.nl
@@ -30,7 +30,6 @@
   dcmip16_pbl_type  = 0                         ! 0=basic pbl,   1= bryan pbl
 /
 &vert_nl
-  vform         = "ccm"
   vfile_mid     = "../vcoord/camm-30.ascii"
   vfile_int     = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test2_tropical_cyclone/theta-l/namelist-r50.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test2_tropical_cyclone/theta-l/namelist-r50.nl
@@ -29,7 +29,6 @@
   dcmip16_pbl_type  = 0                         ! 0=basic pbl,   1= bryan pbl
 /
 &vert_nl
-  vform         = "ccm"
   vfile_mid     = "../vcoord/camm-30.ascii"
   vfile_int     = "../vcoord/cami-30.ascii"
 /

--- a/components/homme/dcmip_tests/dcmip2016_test3_supercell/theta-l/namelist-animation.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test3_supercell/theta-l/namelist-animation.nl
@@ -34,7 +34,6 @@
   theta_hydrostatic_mode = .false.
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
 /
 &analysis_nl

--- a/components/homme/dcmip_tests/dcmip2016_test3_supercell/theta-l/namelist-explicit-r100.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test3_supercell/theta-l/namelist-explicit-r100.nl
@@ -35,7 +35,6 @@
   theta_hydrostatic_mode = .false.
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
 /
 &analysis_nl

--- a/components/homme/dcmip_tests/dcmip2016_test3_supercell/theta-l/namelist-r100-x1.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test3_supercell/theta-l/namelist-r100-x1.nl
@@ -35,7 +35,6 @@
   theta_hydrostatic_mode = .false.
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
 /
 &analysis_nl

--- a/components/homme/dcmip_tests/dcmip2016_test3_supercell/theta-l/namelist-r100-x2.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test3_supercell/theta-l/namelist-r100-x2.nl
@@ -35,7 +35,6 @@
   theta_hydrostatic_mode = .false.
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
 /
 &analysis_nl

--- a/components/homme/dcmip_tests/dcmip2016_test3_supercell/theta-l/namelist-r100-x4.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test3_supercell/theta-l/namelist-r100-x4.nl
@@ -35,7 +35,6 @@
   theta_hydrostatic_mode = .false.
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
 /
 &analysis_nl

--- a/components/homme/dcmip_tests/dcmip2016_test3_supercell/theta-l/namelist-r100.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test3_supercell/theta-l/namelist-r100.nl
@@ -35,7 +35,6 @@
   theta_hydrostatic_mode = .false.
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
 /
 &analysis_nl

--- a/components/homme/dcmip_tests/dcmip2016_test3_supercell/theta-l/namelist-r200.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test3_supercell/theta-l/namelist-r200.nl
@@ -35,7 +35,6 @@
   theta_hydrostatic_mode = .false.
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
 /
 &analysis_nl

--- a/components/homme/dcmip_tests/dcmip2016_test3_supercell/theta-l/namelist-r400.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test3_supercell/theta-l/namelist-r400.nl
@@ -35,7 +35,6 @@
   theta_hydrostatic_mode = .false.
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
 /
 &analysis_nl

--- a/components/homme/dcmip_tests/dcmip2016_test3_supercell/theta-l/namelist-r50.nl
+++ b/components/homme/dcmip_tests/dcmip2016_test3_supercell/theta-l/namelist-r50.nl
@@ -35,7 +35,6 @@
   theta_hydrostatic_mode = .false.
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
 /
 &analysis_nl

--- a/components/homme/src/preqx/share/prim_advance_mod.F90
+++ b/components/homme/src/preqx/share/prim_advance_mod.F90
@@ -581,7 +581,7 @@ contains
   !  For correct scaling, dt2 should be the same 'dt2' used in the leapfrog advace
   !
   !
-  use control_mod, only : nu, nu_div, nu_s, hypervis_order, hypervis_subcycle, nu_p, nu_top, psurf_vis, swest
+  use control_mod, only : nu, nu_div, nu_s, hypervis_order, hypervis_subcycle, nu_p, nu_top, swest
   use hybvcoord_mod, only : hvcoord_t
   use derivative_mod, only : derivative_t, laplace_sphere_wk, vlaplace_sphere_wk
   use edgetype_mod, only : EdgeBuffer_t, EdgeDescriptor_t

--- a/components/homme/src/share/control_mod.F90
+++ b/components/homme/src/share/control_mod.F90
@@ -150,7 +150,6 @@ module control_mod
   integer,                          public  :: vanalytic = 0  ! if 1, test initializes vertical coords
   real (kind=real_kind),            public  :: vtop = 0.1     ! top coordinate level for analytic vcoords
 
-  integer              , public :: fine_ne = -1               ! set for refined exodus meshes (variable viscosity)
   real (kind=real_kind), public :: max_hypervis_courant = 1d99! upper bound for Courant number
                                                               ! (only used for variable viscosity, recommend 1.9 in namelist)
   real (kind=real_kind), public :: nu      = 7.0D5            ! viscosity (momentum equ)

--- a/components/homme/src/share/control_mod.F90
+++ b/components/homme/src/share/control_mod.F90
@@ -150,8 +150,6 @@ module control_mod
   integer,                          public  :: vanalytic = 0  ! if 1, test initializes vertical coords
   real (kind=real_kind),            public  :: vtop = 0.1     ! top coordinate level for analytic vcoords
 
-  real (kind=real_kind), public :: max_hypervis_courant = 1d99! upper bound for Courant number
-                                                              ! (only used for variable viscosity, recommend 1.9 in namelist)
   real (kind=real_kind), public :: nu      = 7.0D5            ! viscosity (momentum equ)
   real (kind=real_kind), public :: nu_div  = -1               ! viscsoity (momentum equ, div component)
   real (kind=real_kind), public :: nu_s    = -1               ! default = nu   T equ. viscosity

--- a/components/homme/src/share/control_mod.F90
+++ b/components/homme/src/share/control_mod.F90
@@ -164,8 +164,6 @@ module control_mod
                                                               !   >1  apply timesplit from hyperviscosity
   integer, public :: hypervis_subcycle_q=1                    ! number of subcycles for hyper viscsosity timestep on TRACERS
   integer, public :: hypervis_order=0                         ! laplace**hypervis_order.  0=not used  1=regular viscosity, 2=grad**4
-  integer, public :: psurf_vis = 0                            ! 0 = use laplace on eta surfaces
-                                                              ! 1 = use (approx.) laplace on p surfaces
 
   real (kind=real_kind), public :: hypervis_scaling=0         ! use tensor hyperviscosity
 

--- a/components/homme/src/share/control_mod.F90
+++ b/components/homme/src/share/control_mod.F90
@@ -125,7 +125,6 @@ module control_mod
   integer              , public :: runtype 
   integer              , public :: timerdetail 
   integer              , public :: numnodes 
-  logical              , public :: uselapi
   character(len=MAX_STRING_LEN)    , public :: restartfile 
   character(len=MAX_STRING_LEN)    , public :: restartdir
 

--- a/components/homme/src/share/control_mod.F90
+++ b/components/homme/src/share/control_mod.F90
@@ -148,7 +148,6 @@ module control_mod
 
   character(len=MAX_STRING_LEN)    ,public  :: vfile_int=""   ! vertical formulation (ecmwf,ccm1)
   character(len=MAX_STRING_LEN)    ,public  :: vfile_mid=""   ! vertical grid spacing (equal,unequal)
-  character(len=MAX_STRING_LEN)    ,public  :: vform = ""     ! vertical coordinate system (sigma,hybrid)
   integer,                          public  :: vanalytic = 0  ! if 1, test initializes vertical coords
   real (kind=real_kind),            public  :: vtop = 0.1     ! top coordinate level for analytic vcoords
 

--- a/components/homme/src/share/control_mod.F90
+++ b/components/homme/src/share/control_mod.F90
@@ -120,7 +120,6 @@ module control_mod
   character(len=MAX_STRING_LEN)    , public :: test_case
   !most tests don't have forcing
   logical                          , public :: test_with_forcing = .false. 
-  integer              , public :: tasknum
   integer              , public :: statefreq      ! output frequency of synopsis of system state (steps)
   integer              , public :: restartfreq
   integer              , public :: runtype 

--- a/components/homme/src/share/cxx/prim_cxx_driver_base.F90
+++ b/components/homme/src/share/cxx/prim_cxx_driver_base.F90
@@ -35,7 +35,7 @@ module prim_cxx_driver_base
                                  prim_init1_compose,                          &
                                  MetaVertex, GridEdge, deriv1
     use compose_mod,      only : compose_control_kokkos_init_and_fin
-#ifndef CAM
+#if !defined(CAM) && !defined(SCREAM)
     use prim_driver_base, only : prim_init1_no_cam
 #endif
 
@@ -67,7 +67,7 @@ module prim_cxx_driver_base
     ! Don't let any other components that use Kokkos control init/finalization.
     call compose_control_kokkos_init_and_fin(.false.)
 
-#ifndef CAM
+#if !defined(CAM) && !defined(SCREAM)
     call prim_init1_no_cam(par)
 #endif
 

--- a/components/homme/src/share/global_norms_mod.F90
+++ b/components/homme/src/share/global_norms_mod.F90
@@ -258,7 +258,7 @@ contains
     use reduction_mod, only : ParallelMin,ParallelMax
     use physical_constants, only : scale_factor_inv, scale_factor,dd_pi
     use control_mod, only : nu, nu_q, nu_div, hypervis_order, nu_top,  &
-                            fine_ne, max_hypervis_courant, hypervis_scaling, dcmip16_mu,dcmip16_mu_s,dcmip16_mu_q
+                            max_hypervis_courant, hypervis_scaling, dcmip16_mu,dcmip16_mu_s,dcmip16_mu_q
     use control_mod, only : tstep_type
     use parallel_mod, only : abortmp, global_shared_buf, global_shared_sum
     use edgetype_mod, only : EdgeBuffer_t 

--- a/components/homme/src/share/global_norms_mod.F90
+++ b/components/homme/src/share/global_norms_mod.F90
@@ -258,7 +258,7 @@ contains
     use reduction_mod, only : ParallelMin,ParallelMax
     use physical_constants, only : scale_factor_inv, scale_factor,dd_pi
     use control_mod, only : nu, nu_q, nu_div, hypervis_order, nu_top,  &
-                            max_hypervis_courant, hypervis_scaling, dcmip16_mu,dcmip16_mu_s,dcmip16_mu_q
+                            hypervis_scaling, dcmip16_mu,dcmip16_mu_s,dcmip16_mu_q
     use control_mod, only : tstep_type
     use parallel_mod, only : abortmp, global_shared_buf, global_shared_sum
     use edgetype_mod, only : EdgeBuffer_t 

--- a/components/homme/src/share/namelist_mod.F90
+++ b/components/homme/src/share/namelist_mod.F90
@@ -214,7 +214,7 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     integer  :: ierr
     character(len=80) :: errstr, arg
     real(kind=real_kind) :: dt_max, se_tstep
-#if defined(CAM) || defined(SCREAM
+#if defined(CAM) || defined(SCREAM)
     character(len=MAX_STRING_LEN) :: se_topology
     integer :: se_partmethod
     integer :: se_ne

--- a/components/homme/src/share/namelist_mod.F90
+++ b/components/homme/src/share/namelist_mod.F90
@@ -107,7 +107,7 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
 
 
 !PLANAR setup
-#ifndef CAM
+#if !defined(CAM) && !defined(SCREAM)
   use control_mod, only:              &
     set_planar_defaults,&
     bubble_T0, &
@@ -126,7 +126,8 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
 #endif
 
 
-#ifndef CAM
+! control parameters for dcmip stand-alone tests
+#if !defined(CAM) && !defined(SCREAM)
   use control_mod, only:              &
     pertlim,                          &
     dcmip2_0_h0,                      &
@@ -142,7 +143,7 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
 
   use thread_mod,     only: nthreads, omp_set_num_threads, omp_get_max_threads, vthreads
   use dimensions_mod, only: ne, ne_x, ne_y, np, nnodes, nmpi_per_node, npart, qsize, qsize_d, set_mesh_dimensions
-#ifdef CAM
+#if defined(CAM) || defined(SCREAM)
   use time_mod,       only: tstep, nsplit, smooth
 #else
   use time_mod,       only: tstep, ndays,nmax, nendstep,secpday, smooth, secphr, nsplit
@@ -151,7 +152,7 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
        partitionfornodes, mpireal_t, mpilogical_t, mpiinteger_t, mpichar_t
   use cg_mod,         only: cg_no_debug
 
-#ifndef CAM
+#if !defined(CAM) && !defined(SCREAM)
   use interpolate_mod, only : vector_uvars, vector_vvars, max_vecvars, interpolate_analysis, replace_vec_by_vordiv
   use common_io_mod, only : &
        output_prefix,       &
@@ -197,7 +198,7 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
   ! read in the namelists...
   ! ============================================
 
-#ifdef CAM
+#if defined(CAM) || defined(SCREAM)
   subroutine readnl(par, NLFileName)
     use units, only : getunit, freeunit
 #ifndef HOMME_WITHOUT_PIOLIBRARY
@@ -219,7 +220,7 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     integer  :: ierr
     character(len=80) :: errstr, arg
     real(kind=real_kind) :: dt_max, se_tstep
-#ifdef CAM
+#if defined(CAM) || defined(SCREAM
     character(len=MAX_STRING_LEN) :: se_topology
     integer :: se_partmethod
     integer :: se_ne
@@ -235,7 +236,7 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
                       Z2_MAP_METHOD,             &         ! Zoltan2 processor mapping (network-topology aware) method.
                       TOPOLOGY,                  &         ! mesh topology
                       GEOMETRY,                  &         ! mesh geometry
-#ifdef CAM
+#if defined(CAM) || defined(SCREAM)
       se_partmethod,     &
       se_topology,       &
       se_ne,             &
@@ -316,7 +317,7 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
       se_fv_phys_remap_alg
 
 
-#ifdef CAM
+#if defined(CAM) || defined(SCREAM)
     namelist  /ctl_nl/ SE_NSPLIT,  &                ! number of dynamics steps per physics timestep
       se_tstep
 #else
@@ -417,7 +418,7 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     npart         = 1
     uselapi       = .TRUE.
     se_tstep=-1
-#ifndef CAM
+#if !defined(CAM) && !defined(SCREAM)
     ndays         = 0
     nmax          = 12
     nthreads = 1
@@ -463,7 +464,7 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
 
     if (par%masterproc) then
        write(iulog,*)"reading ctl namelist..."
-#if defined(CAM)
+#if defined(CAM) || defined(SCREAM)
        unitn=getunit()
        open( unitn, file=trim(nlfilename), status='old' )
        ierr = 1
@@ -504,7 +505,7 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
        ! moviefreq and restartfreq are interpreted to be in units of days.
        ! Both must be converted to numbers of steps.
        ! ================================================
-#ifndef CAM
+#if !defined(CAM) && !defined(SCREAM)
        if (tstep <= 0) then
           call abortmp('tstep must be > 0')
        end if
@@ -528,7 +529,7 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
           endif
        endif
 
-#ifndef CAM
+#if !defined(CAM) && !defined(SCREAM)
 
 !checks before the next NL
 !check on ne
@@ -700,11 +701,11 @@ endif
        close(unit=7)
 #endif
 #endif
-! ^ ifndef CAM
+! ^ if !defined(CAM) && !defined(SCREAM)
        ierr = timestep_make_subcycle_parameters_consistent(par, rsplit, qsplit, &
             dt_remap_factor, dt_tracer_factor)
 
-#ifdef CAM
+#if defined(CAM) || defined(SCREAM)
        limiter_option=se_limiter_option
        partmethod = se_partmethod
        ne         = se_ne
@@ -746,7 +747,7 @@ endif
     call MPI_bcast(restartfreq,     1,MPIinteger_t,par%root,par%comm,ierr)
     call MPI_bcast(runtype,         1,MPIinteger_t,par%root,par%comm,ierr)
 
-#ifndef CAM
+#if !defined(CAM) && !defined(SCREAM)
     if(test_case == "dcmip2012_test4") then
        rearth = rearth/dcmip4_X
        omega = omega*dcmip4_X
@@ -830,7 +831,7 @@ endif
     call MPI_bcast(planar_slice ,1,MPIlogical_t,par%root,par%comm,ierr)
 
 !PLANAR
-#ifndef CAM
+#if !defined(CAM) && !defined (SCREAM)
     call MPI_bcast(bubble_T0 ,1,MPIreal_t   ,par%root,par%comm,ierr)
     call MPI_bcast(bubble_dT ,1,MPIreal_t   ,par%root,par%comm,ierr)
     call MPI_bcast(bubble_xycenter,1,MPIreal_t   ,par%root,par%comm,ierr)
@@ -882,7 +883,7 @@ endif
     call MPI_bcast(vanalytic, 1,              MPIinteger_t, par%root, par%comm,ierr)
     call MPI_bcast(vtop     , 1,              MPIreal_t   , par%root, par%comm,ierr)
 
-#ifndef CAM
+#if !defined(CAM) && !defined(SCREAM)
 #ifndef HOMME_WITHOUT_PIOLIBRARY
     call MPI_bcast(output_prefix,MAX_STRING_LEN,MPIChar_t  ,par%root,par%comm,ierr)
     call MPI_bcast(output_timeunits ,max_output_streams,MPIinteger_t,par%root,par%comm,ierr)
@@ -1046,7 +1047,7 @@ end if
     end if
 #endif
 
-#ifndef CAM
+#if !defined(CAM) && !defined(SCREAM)
 !standalone homme does not support ftype=1 (cause it is identical to ftype=0).
 !also, standalone ftype=0 is the same as standalone ftype=2.
     if ((ftype == 0).or.(ftype == 2).or.(ftype == 3).or.(ftype == 4).or.(ftype == -1)) then
@@ -1060,10 +1061,10 @@ end if
     endif
 
 !=======================================================================================================!
-#ifdef CAM
+#if defined(CAM) || defined(SCREAM)
     nmpi_per_node=1
 #endif
-#ifndef CAM
+#if !defined(CAM) && !defined(SCREAM)
     call MPI_bcast(interpolate_analysis, 7,MPIlogical_t,par%root,par%comm,ierr)
     call MPI_bcast(interp_nlat , 1,MPIinteger_t,par%root,par%comm,ierr)
     call MPI_bcast(interp_nlon , 1,MPIinteger_t,par%root,par%comm,ierr)
@@ -1123,7 +1124,7 @@ end if
 
        write(iulog,*)"readnl: topology      = ",TRIM( TOPOLOGY )
        write(iulog,*)"readnl: geometry      = ",TRIM( geometry )
-#ifndef CAM
+#if !defined(CAM) && !defined(SCREAM)
        write(iulog,*)"readnl: test_case     = ",TRIM(test_case)
        write(iulog,*)"readnl: omega         = ",omega
        write(iulog,*)"readnl: sub_case      = ",sub_case
@@ -1179,7 +1180,7 @@ end if
        
        write(iulog,*)"readnl: vert_remap_q_alg  = ",vert_remap_q_alg
        write(iulog,*)"readnl: vert_remap_u_alg  = ",vert_remap_u_alg
-#ifdef CAM
+#if defined(CAM) || defined(SCREAM)
        write(iulog,*)"readnl: se_nsplit         = ", NSPLIT
        write(iulog,*)"readnl: se_tstep         = ", tstep
        write(iulog,*)"readnl: se_ftype          = ",ftype
@@ -1221,7 +1222,7 @@ end if
           write(iulog,*) "initial_total_mass = ",initial_total_mass
        end if
 
-#ifndef CAM
+#if !defined(CAM) && !defined(SCREAM)
 #ifndef HOMME_WITHOUT_PIOLIBRARY
        write(iulog,*)"  analysis: output_prefix = ",TRIM(output_prefix)
        write(iulog,*)"  analysis: io_stride = ",io_stride
@@ -1265,7 +1266,7 @@ end if
        write(iulog,*)""
 #endif
 
-#ifndef CAM
+#if !defined(CAM) && !defined(SCREAM)
        write(iulog,*)" analysis interpolation = ", interpolate_analysis
 
        if(any(interpolate_analysis)) then
@@ -1278,7 +1279,7 @@ end if
 #endif
 ! ^ ifndef CAM
 
-#ifndef CAM
+#if !defined(CAM) && !defined(SCREAM)
 #ifdef HOMME_SHA1
       write(iulog,*)"HOMME SHA = ", HOMME_SHA1
 #endif

--- a/components/homme/src/share/namelist_mod.F90
+++ b/components/homme/src/share/namelist_mod.F90
@@ -29,7 +29,6 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     geometry,      &       ! Mesh geometry
     test_case,     &       ! test case
     planar_slice,     &
-    uselapi,       &
     numnodes,      &
     sub_case,      &
     statefreq,     &       ! number of steps per printstate call
@@ -249,7 +248,6 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
       Z2_MAP_METHOD,  &
       vthreads,      &             ! number of vertical/column threads per horizontal thread
       npart,         &
-      uselapi,       &
       numnodes,      &
       ne,            &             ! element resolution factor
       ne_x,            &             ! element resolution factor in x-dir for planar
@@ -406,7 +404,6 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     COORD_TRANSFORM_METHOD = SPHERE_COORDS
     Z2_MAP_METHOD = Z2_NO_TASK_MAPPING
     npart         = 1
-    uselapi       = .TRUE.
     se_tstep=-1
 #if !defined(CAM) && !defined(SCREAM)
     ndays         = 0
@@ -851,8 +848,6 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
 
     call MPI_bcast(restartfile,MAX_STRING_LEN,MPIChar_t ,par%root,par%comm,ierr)
     call MPI_bcast(restartdir,MAX_STRING_LEN,MPIChar_t ,par%root,par%comm,ierr)
-
-    call MPI_bcast(uselapi,1,MPIlogical_t,par%root,par%comm,ierr)
 
     if (integration == "full_imp") then
        call MPI_bcast(precon_method,MAX_STRING_LEN,MPIChar_t,par%root,par%comm,ierr)

--- a/components/homme/src/share/namelist_mod.F90
+++ b/components/homme/src/share/namelist_mod.F90
@@ -55,7 +55,6 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     prescribed_wind, &
     ftype,         &
     limiter_option,&
-    max_hypervis_courant, &
     nu,            &
     nu_s,          &
     nu_q,          &
@@ -275,7 +274,6 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
       disable_diagnostics, &
       prescribed_wind, &
       se_ftype,        &           ! forcing type
-      max_hypervis_courant, &
       nu,            &
       nu_s,          &
       nu_q,          &
@@ -778,7 +776,6 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     call MPI_bcast(vert_remap_q_alg,1, MPIinteger_t, par%root,par%comm,ierr)
     call MPI_bcast(vert_remap_u_alg,1, MPIinteger_t, par%root,par%comm,ierr)
 
-    call MPI_bcast(max_hypervis_courant,1,MPIreal_t, par%root,par%comm,ierr)
     call MPI_bcast(nu,              1, MPIreal_t   , par%root,par%comm,ierr)
     call MPI_bcast(nu_s,            1, MPIreal_t   , par%root,par%comm,ierr)
     call MPI_bcast(nu_q,            1, MPIreal_t   , par%root,par%comm,ierr)

--- a/components/homme/src/share/namelist_mod.F90
+++ b/components/homme/src/share/namelist_mod.F90
@@ -85,7 +85,6 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     u_perturb,     &        ! J&W baroclinic test perturbation size
     moisture,      &
     use_moisture,      &
-    vform,         &
     vfile_mid,     &
     vfile_int,     &
     vanalytic,     &
@@ -360,7 +359,6 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
       bubble_rh_background, &
       bubble_prec_type
     namelist /vert_nl/        &
-      vform,              &
       vfile_mid,          &
       vfile_int,          &
       vanalytic,          & ! use analytically generated vertical levels
@@ -579,11 +577,9 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
 #else
          read(*,nml=vert_nl)
 #endif
-         vform      = trim(adjustl(vform))
          vfile_mid  = trim(adjustl(vfile_mid))
          vfile_int  = trim(adjustl(vfile_int))
 
-         write(iulog,*) '  vform =',trim(vform)
          write(iulog,*) '  vfile_mid=',trim(vfile_mid)
          write(iulog,*) '  vfile_int=',trim(vfile_int)
          write(iulog,*) '  vanalytic=',vanalytic
@@ -877,7 +873,6 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
        call MPI_bcast(tol        ,1,MPIreal_t   ,par%root,par%comm,ierr)
     end if
 
-    call MPI_bcast(vform    , MAX_STRING_LEN, MPIChar_t   , par%root, par%comm,ierr)
     call MPI_bcast(vfile_mid, MAX_STRING_LEN, MPIChar_t   , par%root, par%comm,ierr)
     call MPI_bcast(vfile_int, MAX_STRING_LEN, MPIChar_t   , par%root, par%comm,ierr)
     call MPI_bcast(vanalytic, 1,              MPIinteger_t, par%root, par%comm,ierr)

--- a/components/homme/src/share/namelist_mod.F90
+++ b/components/homme/src/share/namelist_mod.F90
@@ -55,7 +55,6 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     prescribed_wind, &
     ftype,         &
     limiter_option,&
-    fine_ne,       &
     max_hypervis_courant, &
     nu,            &
     nu_s,          &
@@ -276,7 +275,6 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
       disable_diagnostics, &
       prescribed_wind, &
       se_ftype,        &           ! forcing type
-      fine_ne,         &
       max_hypervis_courant, &
       nu,            &
       nu_s,          &
@@ -780,7 +778,6 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     call MPI_bcast(vert_remap_q_alg,1, MPIinteger_t, par%root,par%comm,ierr)
     call MPI_bcast(vert_remap_u_alg,1, MPIinteger_t, par%root,par%comm,ierr)
 
-    call MPI_bcast(fine_ne,         1, MPIinteger_t, par%root,par%comm,ierr)
     call MPI_bcast(max_hypervis_courant,1,MPIreal_t, par%root,par%comm,ierr)
     call MPI_bcast(nu,              1, MPIreal_t   , par%root,par%comm,ierr)
     call MPI_bcast(nu_s,            1, MPIreal_t   , par%root,par%comm,ierr)

--- a/components/homme/src/share/namelist_mod.F90
+++ b/components/homme/src/share/namelist_mod.F90
@@ -200,7 +200,7 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
 
 #if defined(CAM) || defined(SCREAM)
   subroutine readnl(par, NLFileName)
-    use units, only : getunit, freeunit
+    use shr_file_mod,      only: getunit=>shr_file_getUnit, freeunit=>shr_file_freeUnit
 #ifndef HOMME_WITHOUT_PIOLIBRARY
     use mesh_mod, only : MeshOpen
 #endif
@@ -531,24 +531,24 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
 
 #if !defined(CAM) && !defined(SCREAM)
 
-!checks before the next NL
-!check on ne
-if (topology == "plane" .and. ne /= 0) then
-call abortmp('cannot set ne for planar topology, use ne_x and ne_y instead')
-end if
+       !checks before the next NL
+       !check on ne
+       if (topology == "plane" .and. ne /= 0) then
+          call abortmp('cannot set ne for planar topology, use ne_x and ne_y instead')
+       end if
 
-!setting default PLANAR values if they are not set in ctl_nl
-call set_planar_defaults()
+       !setting default PLANAR values if they are not set in ctl_nl
+       call set_planar_defaults()
 
-!checks on planar tests
-if (test_case(1:7)=="planar_") then
+       !checks on planar tests
+       if (test_case(1:7)=="planar_") then
 
-!check on Lx, Ly
-if(lx .le. 0.d0 .or. ly .le. 0.d0) then
-call abortmp('for planar tests, planar_lx and planar_ly should be >0')
-endif
+       !check on Lx, Ly
+       if(lx .le. 0.d0 .or. ly .le. 0.d0) then
+          call abortmp('for planar tests, planar_lx and planar_ly should be >0')
+       endif
 
-endif
+       endif
 
 
 #ifdef _PRIM

--- a/components/homme/src/share/namelist_mod.F90
+++ b/components/homme/src/share/namelist_mod.F90
@@ -70,7 +70,6 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     interp_lon0,    &
     hypervis_scaling,   &  ! use tensor HV instead of scalar coefficient
     disable_diagnostics, & ! use to disable diagnostics for timing reasons
-    psurf_vis,    &
     hypervis_order,       &
     hypervis_subcycle,    &
     hypervis_subcycle_tom,&
@@ -286,7 +285,6 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
       dcmip16_mu_q,   &
       dcmip16_prec_type,&
       dcmip16_pbl_type,&
-      psurf_vis,     &
       hypervis_order,    &
       hypervis_subcycle, &
       hypervis_subcycle_tom, &
@@ -792,7 +790,6 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     call MPI_bcast(dcmip16_pbl_type , 1, MPIinteger_t, par%root,par%comm,ierr)
 
     call MPI_bcast(disable_diagnostics,1,MPIlogical_t,par%root,par%comm,ierr)
-    call MPI_bcast(psurf_vis,1,MPIinteger_t   ,par%root,par%comm,ierr)
     call MPI_bcast(hypervis_order,1,MPIinteger_t   ,par%root,par%comm,ierr)
     call MPI_bcast(hypervis_scaling,1,MPIreal_t   ,par%root,par%comm,ierr)
     call MPI_bcast(hypervis_subcycle,1,MPIinteger_t   ,par%root,par%comm,ierr)

--- a/components/homme/src/share/namelist_mod.F90
+++ b/components/homme/src/share/namelist_mod.F90
@@ -32,7 +32,6 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     uselapi,       &
     numnodes,      &
     sub_case,      &
-    tasknum,       &       ! used dg model in AIX machine
     statefreq,     &       ! number of steps per printstate call
     restartfreq,   &
     restartfile,   &       ! name of the restart file for INPUT
@@ -258,7 +257,6 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
       ne,            &             ! element resolution factor
       ne_x,            &             ! element resolution factor in x-dir for planar
       ne_y,            &             ! element resolution factor in y-dir for planar
-      tasknum,       &
       statefreq,     &             ! number of steps per printstate call
       integration,   &             ! integration method
       theta_hydrostatic_mode,       &   
@@ -430,7 +428,6 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     restartdir    = "./restart/"
     runtype       = 0
     statefreq     = 1
-    tasknum       =-1
     integration   = "explicit"
     moisture      = "dry"
     nu_top=0
@@ -733,7 +730,6 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     call MPI_bcast(TOPOLOGY,        MAX_STRING_LEN,MPIChar_t  ,par%root,par%comm,ierr)
     call MPI_bcast(geometry,        MAX_STRING_LEN,MPIChar_t  ,par%root,par%comm,ierr)
     call MPI_bcast(test_case,       MAX_STRING_LEN,MPIChar_t  ,par%root,par%comm,ierr)
-    call MPI_bcast(tasknum,         1,MPIinteger_t,par%root,par%comm,ierr)
     call MPI_bcast(ne,              1,MPIinteger_t,par%root,par%comm,ierr)
     call MPI_bcast(ne_x,              1,MPIinteger_t,par%root,par%comm,ierr)
     call MPI_bcast(ne_y,              1,MPIinteger_t,par%root,par%comm,ierr)

--- a/components/homme/src/share/prim_driver_base.F90
+++ b/components/homme/src/share/prim_driver_base.F90
@@ -41,7 +41,7 @@ module prim_driver_base
   public :: prim_init1, prim_init2 , prim_run_subcycle, prim_finalize
   public :: prim_init1_geometry, prim_init1_elem_arrays, prim_init1_buffers, prim_init1_cleanup
   public :: prim_init1_compose
-#ifndef CAM
+#if !defined(CAM) && !defined(SCREAM)
   public :: prim_init1_no_cam
 #endif
 
@@ -96,7 +96,7 @@ contains
     !       as well as to inject code in between pieces that is needed to
     !       properly setup the C++ structures.
 
-#ifndef CAM
+#if !defined(CAM) && !defined(SCREAM)
     ! Initialize a few things that CAM would take care of (e.g., parsing namelist)
     call prim_init1_no_cam (par)
 #endif
@@ -142,7 +142,7 @@ contains
   end subroutine prim_init1
 
 
-#ifndef CAM
+#if !defined(CAM) && !defined(SCREAM)
   subroutine prim_init1_no_cam(par)
     use mesh_mod,       only : MeshUseMeshFile, MeshCubeElemCount
     use cube_mod,       only : CubeElemCount

--- a/components/homme/src/share/prim_driver_base.F90
+++ b/components/homme/src/share/prim_driver_base.F90
@@ -739,7 +739,7 @@ contains
   subroutine prim_init2(elem, hybrid, nets, nete, tl, hvcoord)
 
     use control_mod,          only: runtype, test_case, &
-                                    debug_level, vfile_int, vform, vfile_mid, &
+                                    debug_level, vfile_int, vfile_mid, &
                                     topology, dt_remap_factor, dt_tracer_factor,&
                                     sub_case, limiter_option, nu, nu_q, nu_div, tstep_type, hypervis_subcycle, &
                                     hypervis_subcycle_q, hypervis_subcycle_tom

--- a/components/homme/src/share/prim_implicit_mod.F90
+++ b/components/homme/src/share/prim_implicit_mod.F90
@@ -920,7 +920,7 @@ contains
     !          fp(:,:,:,:) = fp(:,:,:,:) +  nu_s*laplacian**order ( T )
     !
     use dimensions_mod, only : np, np, nlev
-    use control_mod, only : nu, nu_div, nu_s, hypervis_order, hypervis_subcycle, nu_p, nu_top, psurf_vis
+    use control_mod, only : nu, nu_div, nu_s, hypervis_order, hypervis_subcycle, nu_p, nu_top
     use hybrid_mod, only : hybrid_t
     use hybvcoord_mod, only : hvcoord_t
     use element_mod, only : element_t
@@ -1151,7 +1151,7 @@ contains
     !          ft(:,:,:,np) = ft(:,:,:,np) +  nu_s*laplacian**order ( T )
     !
     use dimensions_mod, only : np, np, nlev, nc, max_corner_elem
-    use control_mod, only : nu, nu_div, nu_s, hypervis_order, hypervis_subcycle, nu_p, nu_top, psurf_vis, swest
+    use control_mod, only : nu, nu_div, nu_s, hypervis_order, hypervis_subcycle, nu_p, nu_top, swest
     use hybrid_mod, only : hybrid_t
     use hybvcoord_mod, only : hvcoord_t
     use element_mod, only : element_t

--- a/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
@@ -62,7 +62,14 @@ void init_simulation_params_c (const int& remap_alg, const int& limiter_option, 
   Errors::check_option("init_simulation_params_c","nu",nu,0.0,Errors::ComparisonOp::GT);
   Errors::check_option("init_simulation_params_c","nu_div",nu_div,0.0,Errors::ComparisonOp::GT);
   Errors::check_option("init_simulation_params_c","theta_advection_form",theta_adv_form,{0,1});
+#ifndef SCREAM
   Errors::check_option("init_simulation_params_c","nsplit",nsplit,1,Errors::ComparisonOp::GE);
+#else
+  if (nsplit<1) {
+    printf ("Note: nsplit=%d, while nsplit must be >=1. We know SCREAM does not know nsplit until runtime, so this is fine.\n"
+            "      Make sure nsplit is set to a valid value before calling prim_advance_subcycle!\n",nsplit);
+  }
+#endif
 
   // Get the simulation params struct
   SimulationParams& params = Context::singleton().create<SimulationParams>();

--- a/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
+++ b/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
@@ -391,6 +391,9 @@ contains
     integer :: n0_qdp, np1_qdp
     real(kind=real_kind) :: dt_remap, dt_q
 
+    if (nsplit<1) then
+      call abortmp ('nsplit_is less than 1.')
+    endif
     if (nsplit_iteration < 1 .or. nsplit_iteration > nsplit) then
       call abortmp ('nsplit_iteration out of range')
     endif

--- a/components/homme/test/ASP/advection/explicit.nl.sed
+++ b/components/homme/test/ASP/advection/explicit.nl.sed
@@ -41,7 +41,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "vcoord/aspL60_mid.ascii"
 vfile_int     = "vcoord/aspL60_int.ascii"
 /

--- a/components/homme/test/ASP/baroclinic/explicit26.nl.sed
+++ b/components/homme/test/ASP/baroclinic/explicit26.nl.sed
@@ -41,7 +41,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "vcoord/camm-26.fbin.littleendian"
 vfile_int     = "vcoord/cami-26.fbin.littleendian"
 /

--- a/components/homme/test/ASP/baroclinic/run.job
+++ b/components/homme/test/ASP/baroclinic/run.job
@@ -53,7 +53,6 @@ set u_perturb = 1         # size of perturbation (0 or 1)
 set rotate = 0            # rotation, in degrees.  0, 45 and 90
 
 # other defaults:
-set psurf = 0
 set npdg=0
 set nu_p = 0
 set nu_div = -1
@@ -226,7 +225,6 @@ set sfreq = `echo "$sfreq / $tstep " | bc`
 #       set name = HOMME-$caseno-$rindex-$qindex-$resolution-L26-nu$nu-sub$qsplit
 #    endif
 # endif
-# if ( $psurf == 1 ) set name = $name-psurf
 
 set name = jwasp-ne${ne}-nu$nu
 if ( $nu != $nu_div ) then
@@ -258,7 +256,7 @@ set run = $wdir/$name
 cd $input
 rm -f $run/explicit.nl
 sed s/NE/$ne/ explicit26.nl.sed |\
-sed s/TSTEP/"$tstep qsplit=$qsplit rsplit=$rsplit psurf_vis=$psurf  "/ |\
+sed s/TSTEP/"$tstep qsplit=$qsplit rsplit=$rsplit "/ |\
 sed s/SFREQ/$sfreq/ |\
 sed s/tracer_advection_formulation.\*/"tstep_type = $RK2  hypervis_subcycle = $hsub"/ |\
 sed s/NU1/$nu/ | sed s/NU2/$nu_q/ | \

--- a/components/homme/test/ASP/baroclinic/run.job.cpu
+++ b/components/homme/test/ASP/baroclinic/run.job.cpu
@@ -27,7 +27,6 @@ set vcoord = $HOMME/test/vcoord          # location of vertical coordinate files
 set qsize = 106             # number of tracers  (0 or 4)
 set u_perturb = 1         # size of perturbation (0 or 1)
 set rotate = 0            # rotation, in degrees.  0, 45 and 90
-set psurf = 0
 set npdg=0
 set nu_p = 0
 set nu_div = -1
@@ -94,7 +93,7 @@ mkdir $wdir/movies
 cd $input
 rm -f $wdir/explicit.nl
 sed s/NE/$ne/ explicit26.nl.sed |\
-sed s/TSTEP/"$tstep rsplit=$rsplit qsplit=$qsplit psurf_vis=$psurf  "/ |\
+sed s/TSTEP/"$tstep rsplit=$rsplit qsplit=$qsplit "/ |\
 sed s/SFREQ/$sfreq/ |\
 sed s/tracer_advection_formulation.\*/"tracer_advection_formulation=$tadv  tstep_type = $RK2  "/ |\
 sed s/NU1/$nu/ | sed s/NU2/$nu_q/                    |\

--- a/components/homme/test/ASP/baroclinic/run.job.gpu
+++ b/components/homme/test/ASP/baroclinic/run.job.gpu
@@ -28,7 +28,6 @@ set vcoord = $HOMME/test/vcoord          # location of vertical coordinate files
 set qsize = 106             # number of tracers  (0 or 4)
 set u_perturb = 1         # size of perturbation (0 or 1)
 set rotate = 0            # rotation, in degrees.  0, 45 and 90
-set psurf = 0
 set npdg=0
 set nu_p = 0
 set nu_div = -1
@@ -95,7 +94,7 @@ mkdir $wdir/movies
 cd $input
 rm -f $wdir/explicit.nl
 sed s/NE/$ne/ explicit26.nl.sed |\
-sed s/TSTEP/"$tstep rsplit=$rsplit qsplit=$qsplit psurf_vis=$psurf  "/ |\
+sed s/TSTEP/"$tstep rsplit=$rsplit qsplit=$qsplit "/ |\
 sed s/SFREQ/$sfreq/ |\
 sed s/tracer_advection_formulation.\*/"tracer_advection_formulation=$tadv  tstep_type = $RK2  "/ |\
 sed s/NU1/$nu/ | sed s/NU2/$nu_q/                    |\

--- a/components/homme/test/ASP/gravity/explicit20.nl.sed
+++ b/components/homme/test/ASP/gravity/explicit20.nl.sed
@@ -38,7 +38,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_int     = "vcoord/aspL20_int.N_0.01.ascii"
 vfile_mid     = "vcoord/aspL20_mid.N_0.01.ascii"
 /

--- a/components/homme/test/ASP/mountain/explicit26.nl.sed
+++ b/components/homme/test/ASP/mountain/explicit26.nl.sed
@@ -37,7 +37,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "vcoord/camm-26.fbin.littleendian"
 vfile_int     = "vcoord/cami-26.fbin.littleendian"
 /

--- a/components/homme/test/ASP/rossby/explicit26.nl.sed
+++ b/components/homme/test/ASP/rossby/explicit26.nl.sed
@@ -37,7 +37,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "vcoord/camm-26.fbin.littleendian"
 vfile_int     = "vcoord/cami-26.fbin.littleendian"
 /

--- a/components/homme/test/baroclinic/debug20.nl.sed
+++ b/components/homme/test/baroclinic/debug20.nl.sed
@@ -34,7 +34,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "vcoord/sabm-20.fbin.littleendian"
 vfile_int     = "vcoord/sabi-20.fbin.littleendian"
 /

--- a/components/homme/test/baroclinic/default.exp.nl
+++ b/components/homme/test/baroclinic/default.exp.nl
@@ -34,7 +34,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "vcoord/sabm-20.fbin.littleendian"
 vfile_int     = "vcoord/sabi-20.fbin.littleendian"
 /

--- a/components/homme/test/baroclinic/default.nl
+++ b/components/homme/test/baroclinic/default.nl
@@ -34,7 +34,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "vcoord/sabm-20.fbin.littleendian"
 vfile_int     = "vcoord/sabi-20.fbin.littleendian"
 /

--- a/components/homme/test/baroclinic/explicit.nl
+++ b/components/homme/test/baroclinic/explicit.nl
@@ -30,7 +30,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "../vcoord/camm-26.fbin"
 vfile_int     = "../vcoord/cami-26.fbin"
 /

--- a/components/homme/test/baroclinic/explicit20.nl.sed
+++ b/components/homme/test/baroclinic/explicit20.nl.sed
@@ -34,7 +34,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "vcoord/sabm-20.fbin.littleendian"
 vfile_int     = "vcoord/sabi-20.fbin.littleendian"
 /

--- a/components/homme/test/baroclinic/explicit26.nl.sed
+++ b/components/homme/test/baroclinic/explicit26.nl.sed
@@ -34,7 +34,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "vcoord/camm-26.fbin.littleendian"
 vfile_int     = "vcoord/cami-26.fbin.littleendian"
 /

--- a/components/homme/test/baroclinic/implicit.nl
+++ b/components/homme/test/baroclinic/implicit.nl
@@ -46,7 +46,6 @@ kcut_fm       = 2
 /
 
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "../vcoord/camm-26.fbin.littleendian"
 vfile_int     = "../vcoord/cami-26.fbin.littleendian"
 /

--- a/components/homme/test/baroclinic/semi_imp.nl
+++ b/components/homme/test/baroclinic/semi_imp.nl
@@ -34,7 +34,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "../vcoord/sabm-20.fbin.littleendian"
 vfile_int     = "../vcoord/sabi-20.fbin.littleendian"
 /

--- a/components/homme/test/benchmarks/NGGPS/nggps-ne256-sl.nl
+++ b/components/homme/test/benchmarks/NGGPS/nggps-ne256-sl.nl
@@ -42,7 +42,6 @@ hypervis_subcycle_q=1
 
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = './sabm-128.ascii'
 vfile_int = './sabi-128.ascii'
 /

--- a/components/homme/test/benchmarks/NGGPS/nggps-ne256.nl
+++ b/components/homme/test/benchmarks/NGGPS/nggps-ne256.nl
@@ -35,7 +35,6 @@ hypervis_subcycle=1
 hypervis_subcycle_q=1
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = './sabm-128.ascii'
 vfile_int = './sabi-128.ascii'
 /

--- a/components/homme/test/benchmarks/NGGPS/nggps-ne256.nl-20150401
+++ b/components/homme/test/benchmarks/NGGPS/nggps-ne256.nl-20150401
@@ -54,7 +54,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = './sabm-128.ascii'
 vfile_int = './sabi-128.ascii'
 /

--- a/components/homme/test/benchmarks/NGGPS/nggps-nh-ne1024.nl
+++ b/components/homme/test/benchmarks/NGGPS/nggps-nh-ne1024.nl
@@ -56,7 +56,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform     = "ccm"
 vfile_mid = '/gpfs/alpine/scratch/ambradl/cli115/vcoord/sabm-128.ascii'
 vfile_int = '/gpfs/alpine/scratch/ambradl/cli115/vcoord/sabi-128.ascii'
 /

--- a/components/homme/test/benchmarks/NGGPS/nggps-nh-ne1024.nl-20190124
+++ b/components/homme/test/benchmarks/NGGPS/nggps-nh-ne1024.nl-20190124
@@ -34,7 +34,6 @@ hypervis_subcycle=1
 hypervis_subcycle_q=1
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = './sabm-128.ascii'
 vfile_int = './sabi-128.ascii'
 /

--- a/components/homme/test/benchmarks/NGGPS/nggps-nh-ne1024.nl-20200602
+++ b/components/homme/test/benchmarks/NGGPS/nggps-nh-ne1024.nl-20200602
@@ -37,7 +37,6 @@ hypervis_subcycle_tom  = 0
 /
 
 &vert_nl
-vform         = "ccm"
 vfile_mid = './sabm-128.ascii'
 vfile_int = './sabi-128.ascii'
 /

--- a/components/homme/test/benchmarks/NGGPS/nggps-nh-ne256.nl
+++ b/components/homme/test/benchmarks/NGGPS/nggps-nh-ne256.nl
@@ -35,7 +35,6 @@ hypervis_subcycle=1
 hypervis_subcycle_q=1
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = './sabm-128.ascii'
 vfile_int = './sabi-128.ascii'
 /

--- a/components/homme/test/benchmarks/NGGPS/nggps-tiny.nl
+++ b/components/homme/test/benchmarks/NGGPS/nggps-tiny.nl
@@ -33,7 +33,6 @@ hypervis_subcycle=1
 hypervis_subcycle_q=1
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = './sabm-128.ascii'
 vfile_int = './sabi-128.ascii'
 /

--- a/components/homme/test/benchmarks/v1/v1-ne120-sl.nl
+++ b/components/homme/test/benchmarks/v1/v1-ne120-sl.nl
@@ -37,7 +37,6 @@ hypervis_order = 2
 hypervis_subcycle=4    ! ne30: 3  ne120: 4
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = './acme-72m.ascii'
 vfile_int = './acme-72i.ascii'
 /

--- a/components/homme/test/benchmarks/v1/v1-ne120-thetal-nh-euler.nl
+++ b/components/homme/test/benchmarks/v1/v1-ne120-thetal-nh-euler.nl
@@ -41,7 +41,6 @@ limiter_option = 9 ! this is diff from what's for preqx
 vert_remap_q_alg = 1
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = './acme-72m.ascii'
 vfile_int = './acme-72i.ascii'
 /

--- a/components/homme/test/benchmarks/v1/v1-ne120-thetal-nh-sl.nl
+++ b/components/homme/test/benchmarks/v1/v1-ne120-thetal-nh-sl.nl
@@ -44,7 +44,6 @@ limiter_option = 9 ! this is diff from what's for preqx
 vert_remap_q_alg = 1
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = './acme-72m.ascii'
 vfile_int = './acme-72i.ascii'
 /

--- a/components/homme/test/benchmarks/v1/v1-ne120.nl
+++ b/components/homme/test/benchmarks/v1/v1-ne120.nl
@@ -34,7 +34,6 @@ hypervis_order = 2
 hypervis_subcycle=4    ! ne30: 3  ne120: 4
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = './acme-72m.ascii'
 vfile_int = './acme-72i.ascii'
 /

--- a/components/homme/test/benchmarks/v1/v1-ne30.nl
+++ b/components/homme/test/benchmarks/v1/v1-ne30.nl
@@ -34,7 +34,6 @@ hypervis_order = 2
 hypervis_subcycle=3    ! ne30: 3  ne120: 4
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = './acme-72m.ascii'
 vfile_int = './acme-72i.ascii'
 /

--- a/components/homme/test/benchmarks/v1/v1-tiny.nl
+++ b/components/homme/test/benchmarks/v1/v1-tiny.nl
@@ -33,7 +33,6 @@ hypervis_order = 2
 hypervis_subcycle=3    ! ne30: 3  ne120: 4
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid = './acme-72m.ascii'
 vfile_int = './acme-72i.ascii'
 /

--- a/components/homme/test/bubble/nh-dry.nl
+++ b/components/homme/test/bubble/nh-dry.nl
@@ -52,7 +52,6 @@
   bubble_dT=0.5
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 2.73919e-1                ! vertical coordinate at top of atm (z=10000m)
 /

--- a/components/homme/test/bubble/nh-moist-kessler.nl
+++ b/components/homme/test/bubble/nh-moist-kessler.nl
@@ -58,7 +58,6 @@
   bubble_moist_dq=0.2
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 2.73919e-1                ! vertical coordinate at top of atm (z=10000m)
 /

--- a/components/homme/test/bubble/nh-moist-rj.nl
+++ b/components/homme/test/bubble/nh-moist-rj.nl
@@ -59,7 +59,6 @@
   bubble_prec_type=1
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 2.73919e-1                ! vertical coordinate at top of atm (z=10000m)
 /

--- a/components/homme/test/held_suarez0/explicit.nl
+++ b/components/homme/test/held_suarez0/explicit.nl
@@ -29,7 +29,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "../vcoord/sabm-20.fbin"
 vfile_int     = "../vcoord/sabi-20.fbin"
 /

--- a/components/homme/test/held_suarez0/explicit20.nl.sed
+++ b/components/homme/test/held_suarez0/explicit20.nl.sed
@@ -37,7 +37,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "/home/mataylo/homme/test/vcoord/sabm-20.ascii"
 vfile_int     = "/home/mataylo/homme/test/vcoord/sabi-20.ascii"
 /

--- a/components/homme/test/held_suarez0/explicit26.nl.sed
+++ b/components/homme/test/held_suarez0/explicit26.nl.sed
@@ -32,7 +32,6 @@ hypervis_subcycle_tom = 1
 se_ftype=0
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "../vcoord/camm-26.ascii"
 vfile_int     = "../vcoord/cami-26.ascii"
 /

--- a/components/homme/test/held_suarez0/explicit72.nl.sed
+++ b/components/homme/test/held_suarez0/explicit72.nl.sed
@@ -34,7 +34,6 @@ hypervis_subcycle = 2
 hypervis_subcycle_tom = 1
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "../vcoord/acme-72m.ascii"
 vfile_int     = "../vcoord/acme-72i.ascii"
 /

--- a/components/homme/test/held_suarez0/implicit.nl
+++ b/components/homme/test/held_suarez0/implicit.nl
@@ -31,7 +31,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "../vcoord/camm-26.fbin.littleendian"
 vfile_int     = "../vcoord/cami-26.fbin.littleendian"
 /

--- a/components/homme/test/held_suarez0/restart20.nl.sed
+++ b/components/homme/test/held_suarez0/restart20.nl.sed
@@ -36,7 +36,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "/home/mataylo/homme/test/vcoord/sabm-20.fbin.littleendian"
 vfile_int     = "/home/mataylo/homme/test/vcoord/sabi-20.fbin.littleendian"
 /

--- a/components/homme/test/jw_baroclinic/d200hydro-15levels.nl
+++ b/components/homme/test/jw_baroclinic/d200hydro-15levels.nl
@@ -33,7 +33,6 @@ theta_hydrostatic_mode = .true.
   tol               = 1.e-7
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 2.05e-1                   ! vertical coordinate at top of atm (z=12000m)
 /

--- a/components/homme/test/jw_baroclinic/debug26.nl.sed
+++ b/components/homme/test/jw_baroclinic/debug26.nl.sed
@@ -39,7 +39,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "vcoord/camm-26.fbin.littleendian"
 vfile_int     = "vcoord/cami-26.fbin.littleendian"
 /

--- a/components/homme/test/jw_baroclinic/default.nl
+++ b/components/homme/test/jw_baroclinic/default.nl
@@ -39,7 +39,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "vcoord/camm-26.fbin.littleendian"
 vfile_int     = "vcoord/cami-26.fbin.littleendian"
 /

--- a/components/homme/test/jw_baroclinic/explicit26.nl.sed
+++ b/components/homme/test/jw_baroclinic/explicit26.nl.sed
@@ -38,7 +38,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "vcoord/camm-26.fbin.littleendian"
 vfile_int     = "vcoord/cami-26.fbin.littleendian"
 /

--- a/components/homme/test/jw_baroclinic/jw_baroclinic.nl
+++ b/components/homme/test/jw_baroclinic/jw_baroclinic.nl
@@ -50,7 +50,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "./camm-30.ascii"
 vfile_int     = "./cami-30.ascii"
 /

--- a/components/homme/test/jw_baroclinic/openacc_work/jw_baroclinic.nl
+++ b/components/homme/test/jw_baroclinic/openacc_work/jw_baroclinic.nl
@@ -51,7 +51,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "./camm-30.ascii"
 vfile_int     = "./cami-30.ascii"
 /

--- a/components/homme/test/mtest/m1-ne30.nl
+++ b/components/homme/test/mtest/m1-ne30.nl
@@ -25,7 +25,6 @@
   omega             = 0.0                       ! earth angular speed = 0.0
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
 /

--- a/components/homme/test/mtest/m2-ne60.nl
+++ b/components/homme/test/mtest/m2-ne60.nl
@@ -26,7 +26,6 @@
   omega             = 0.0                       ! earth angular speed = 0.0
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
 /

--- a/components/homme/test/mtest/m3-ne60.nl
+++ b/components/homme/test/mtest/m3-ne60.nl
@@ -25,7 +25,6 @@
   omega             = 0.0                       ! earth angular speed = 0.0
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
 /

--- a/components/homme/test/reg_test/namelists/baro2b-omp.nl
+++ b/components/homme/test/reg_test/namelists/baro2b-omp.nl
@@ -46,7 +46,6 @@ kcut_fm       = 2
 /
 
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "vcoord/camm-26.ascii"
 vfile_int     = "vcoord/cami-26.ascii"
 /

--- a/components/homme/test/reg_test/namelists/baro2b-omp.nl
+++ b/components/homme/test/reg_test/namelists/baro2b-omp.nl
@@ -15,7 +15,6 @@ runtype                      = 0
 tstep                        = 150
 qsplit                       = 4
 rk_stage_user                = 3
-psurf_vis                    = 0  
 integration                  = "explicit"
 smooth                       = 0
 nu                           = 1e16

--- a/components/homme/test/reg_test/namelists/baro2b.nl
+++ b/components/homme/test/reg_test/namelists/baro2b.nl
@@ -46,7 +46,6 @@ kcut_fm       = 2
 /
 
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "vcoord/camm-26.ascii"
 vfile_int     = "vcoord/cami-26.ascii"
 /

--- a/components/homme/test/reg_test/namelists/baro2b.nl
+++ b/components/homme/test/reg_test/namelists/baro2b.nl
@@ -15,7 +15,6 @@ runtype                      = 0
 tstep                        = 150
 qsplit                       = 4
 rk_stage_user                = 3
-psurf_vis                    = 0  
 integration                  = "explicit"
 smooth                       = 0
 nu                           = 1e16

--- a/components/homme/test/reg_test/namelists/baro2c-run1.nl
+++ b/components/homme/test/reg_test/namelists/baro2c-run1.nl
@@ -28,7 +28,6 @@ limiter_option = 8
 filter_freq   = 0
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "vcoord/camm-26.ascii"
 vfile_int     = "vcoord/cami-26.ascii"
 /

--- a/components/homme/test/reg_test/namelists/baro2c-run2-omp.nl
+++ b/components/homme/test/reg_test/namelists/baro2c-run2-omp.nl
@@ -40,7 +40,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "vcoord/camm-26.ascii"
 vfile_int     = "vcoord/cami-26.ascii"
 /

--- a/components/homme/test/reg_test/namelists/baro2c-run2.nl
+++ b/components/homme/test/reg_test/namelists/baro2c-run2.nl
@@ -40,7 +40,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "vcoord/camm-26.ascii"
 vfile_int     = "vcoord/cami-26.ascii"
 /

--- a/components/homme/test/reg_test/namelists/baro2d-imp.nl
+++ b/components/homme/test/reg_test/namelists/baro2d-imp.nl
@@ -46,7 +46,6 @@ kcut_fm       = 2
 /
 
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "vcoord/camm-26.ascii"
 vfile_int     = "vcoord/cami-26.ascii"
 /

--- a/components/homme/test/reg_test/namelists/baro2d.nl
+++ b/components/homme/test/reg_test/namelists/baro2d.nl
@@ -34,7 +34,6 @@ filter_freq   = 0
 /
 
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "vcoord/camm-26.ascii"
 vfile_int     = "vcoord/cami-26.ascii"
 /

--- a/components/homme/test/reg_test/namelists/baroCamMoist-omp3.nl
+++ b/components/homme/test/reg_test/namelists/baroCamMoist-omp3.nl
@@ -36,7 +36,6 @@ filter_freq   = 0
 /
 
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "vcoord/camm-26.ascii"
 vfile_int     = "vcoord/cami-26.ascii"
 /

--- a/components/homme/test/reg_test/namelists/baroCamMoist-omp4.nl
+++ b/components/homme/test/reg_test/namelists/baroCamMoist-omp4.nl
@@ -36,7 +36,6 @@ filter_freq   = 0
 /
 
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "vcoord/camm-26.ascii"
 vfile_int     = "vcoord/cami-26.ascii"
 /

--- a/components/homme/test/reg_test/namelists/baroCamMoist.nl
+++ b/components/homme/test/reg_test/namelists/baroCamMoist.nl
@@ -36,7 +36,6 @@ filter_freq   = 0
 /
 
 &vert_nl
-vform         = "ccm"
 vfile_mid     = "vcoord/camm-26.ascii"
 vfile_int     = "vcoord/cami-26.ascii"
 /

--- a/components/homme/test/reg_test/namelists/preqx-TC-ftype4.nl
+++ b/components/homme/test/reg_test/namelists/preqx-TC-ftype4.nl
@@ -30,7 +30,6 @@
   se_ftype          = 4
 /
 &vert_nl
-  vform         = "ccm"
   vfile_mid     = "./vcoord/camm-30.ascii"
   vfile_int     = "./vcoord/cami-30.ascii"
 /

--- a/components/homme/test/reg_test/namelists/preqx-nhgw-slice.nl
+++ b/components/homme/test/reg_test/namelists/preqx-nhgw-slice.nl
@@ -35,7 +35,6 @@
   hypervis_subcycle_q = 1
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 2.73919e-1                ! vertical coordinate at top of atm (z=10000m)
 /

--- a/components/homme/test/reg_test/namelists/preqx-nhgw.nl
+++ b/components/homme/test/reg_test/namelists/preqx-nhgw.nl
@@ -34,7 +34,6 @@
   hypervis_subcycle_q = 1
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 2.73919e-1                ! vertical coordinate at top of atm (z=10000m)
 /

--- a/components/homme/test/reg_test/namelists/preqx.nl
+++ b/components/homme/test/reg_test/namelists/preqx.nl
@@ -50,7 +50,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform     = "ccm"
 vfile_mid = './vcoord/${HOMME_TEST_VCOORD_MID_FILE}'
 vfile_int = './vcoord/${HOMME_TEST_VCOORD_INT_FILE}'
 /

--- a/components/homme/test/reg_test/namelists/swimtc5.nl
+++ b/components/homme/test/reg_test/namelists/swimtc5.nl
@@ -11,7 +11,6 @@ test_case         = 'swtc5'
 ne                = 16
 ndays             = 1
 statefreq         = 960
-tasknum           = 0
 restartfreq       = -1
 restartfile       = "./restart/R000000050"
 runtype           = 0

--- a/components/homme/test/reg_test/namelists/swtc1.nl
+++ b/components/homme/test/reg_test/namelists/swtc1.nl
@@ -11,7 +11,6 @@ test_case         = 'swtc1'
 ne                = 10
 ndays             = 12
 statefreq         = 180
-tasknum           = 0
 restartfreq       = -1
 restartfile       = "./restart/R000000050"
 runtype           = 0

--- a/components/homme/test/reg_test/namelists/swtc2.nl
+++ b/components/homme/test/reg_test/namelists/swtc2.nl
@@ -10,7 +10,6 @@ topology      = "cube"
 test_case     = "swtc2"
 ndays         = 1
 statefreq = 80
-tasknum       = 0
 restartfreq   = -1
 restartfile   = "./restart/R000000050"
 runtype       = 0

--- a/components/homme/test/reg_test/namelists/swtc5.nl
+++ b/components/homme/test/reg_test/namelists/swtc5.nl
@@ -11,7 +11,6 @@ test_case         = 'swtc5'
 ne                = 30
 ndays             = 15
 statefreq         = 960
-tasknum           = 0
 restartfreq       = -1
 restartfile       = "./restart/R000000050"
 runtype           = 0

--- a/components/homme/test/reg_test/namelists/swtc5omp.nl
+++ b/components/homme/test/reg_test/namelists/swtc5omp.nl
@@ -11,7 +11,6 @@ test_case         = 'swtc5'
 ne                = 30
 ndays             = 15
 statefreq         = 960
-tasknum           = 0
 restartfreq       = -1
 restartfile       = "./restart/R000000050"
 runtype           = 0

--- a/components/homme/test/reg_test/namelists/theta-fdc12-test21.nl
+++ b/components/homme/test/reg_test/namelists/theta-fdc12-test21.nl
@@ -29,7 +29,6 @@
   vert_remap_q_alg  = 1
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
 /

--- a/components/homme/test/reg_test/namelists/theta-fdc12-test22.nl
+++ b/components/homme/test/reg_test/namelists/theta-fdc12-test22.nl
@@ -29,7 +29,6 @@
   vert_remap_q_alg  = 1
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
 /

--- a/components/homme/test/reg_test/namelists/theta-fdc12-test3.nl
+++ b/components/homme/test/reg_test/namelists/theta-fdc12-test3.nl
@@ -24,7 +24,6 @@
   vert_remap_q_alg  = 1
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
 /

--- a/components/homme/test/reg_test/namelists/theta-sl.nl
+++ b/components/homme/test/reg_test/namelists/theta-sl.nl
@@ -57,7 +57,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform     = "ccm"
 vfile_mid = './vcoord/${HOMME_TEST_VCOORD_MID_FILE}'
 vfile_int = './vcoord/${HOMME_TEST_VCOORD_INT_FILE}'
 /

--- a/components/homme/test/reg_test/namelists/theta.nl
+++ b/components/homme/test/reg_test/namelists/theta.nl
@@ -52,7 +52,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform     = "ccm"
 vfile_mid = './vcoord/${HOMME_TEST_VCOORD_MID_FILE}'
 vfile_int = './vcoord/${HOMME_TEST_VCOORD_INT_FILE}'
 /

--- a/components/homme/test/reg_test/namelists/thetah-TC-ftype4.nl
+++ b/components/homme/test/reg_test/namelists/thetah-TC-ftype4.nl
@@ -31,7 +31,6 @@
   se_ftype          = 4
 /
 &vert_nl
-  vform         = "ccm"
   vfile_mid     = "./vcoord/camm-30.ascii"
   vfile_int     = "./vcoord/cami-30.ascii"
 /

--- a/components/homme/test/reg_test/namelists/thetah-TC.nl
+++ b/components/homme/test/reg_test/namelists/thetah-TC.nl
@@ -30,7 +30,6 @@
   dcmip16_pbl_type  = 0                         ! 0=basic pbl,   1= bryan pbl
 /
 &vert_nl
-  vform         = "ccm"
   vfile_mid     = "./vcoord/camm-30.ascii"
   vfile_int     = "./vcoord/cami-30.ascii"
 /

--- a/components/homme/test/reg_test/namelists/thetah-nhgw-slice.nl
+++ b/components/homme/test/reg_test/namelists/thetah-nhgw-slice.nl
@@ -36,7 +36,6 @@
   hypervis_subcycle_q = 1
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 2.73919e-1                ! vertical coordinate at top of atm (z=10000m)
 /

--- a/components/homme/test/reg_test/namelists/thetah-nhgw.nl
+++ b/components/homme/test/reg_test/namelists/thetah-nhgw.nl
@@ -35,7 +35,6 @@
   hypervis_subcycle_q = 1
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 2.73919e-1                ! vertical coordinate at top of atm (z=10000m)
 /

--- a/components/homme/test/reg_test/namelists/thetah-sl-dcmip16_test1pg2.nl
+++ b/components/homme/test/reg_test/namelists/thetah-sl-dcmip16_test1pg2.nl
@@ -36,7 +36,6 @@
   nu_q = 0
 /
 &vert_nl
-  vform             = "ccm"
   vfile_mid         = "vcoord/camm-30.ascii"
   vfile_int         = "vcoord/cami-30.ascii"
 /

--- a/components/homme/test/reg_test/namelists/thetah-sl-test11conv-r0t1-cdr30-rrm.nl
+++ b/components/homme/test/reg_test/namelists/thetah-sl-test11conv-r0t1-cdr30-rrm.nl
@@ -37,7 +37,6 @@
   nu_q = 0
 /
 &vert_nl
-  vform             = "ccm"
   vanalytic         = 1
   vtop              = 0.2549944
 /

--- a/components/homme/test/reg_test/namelists/thetah-sl-test11conv-r1t2-cdr20.nl
+++ b/components/homme/test/reg_test/namelists/thetah-sl-test11conv-r1t2-cdr20.nl
@@ -36,7 +36,6 @@
   semi_lagrange_hv_q = 1
 /
 &vert_nl
-  vform             = "ccm"
   vanalytic         = 1
   vtop              = 0.2549944
 /

--- a/components/homme/test/reg_test/namelists/thetah-test22.nl
+++ b/components/homme/test/reg_test/namelists/thetah-test22.nl
@@ -36,7 +36,6 @@
   tol               = 1.e-7
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
 /

--- a/components/homme/test/reg_test/namelists/thetahs1.nl
+++ b/components/homme/test/reg_test/namelists/thetahs1.nl
@@ -54,7 +54,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform     = "ccm"
 vfile_mid = './vcoord/${HOMME_TEST_VCOORD_MID_FILE}'
 vfile_int = './vcoord/${HOMME_TEST_VCOORD_INT_FILE}'
 /

--- a/components/homme/test/reg_test/namelists/thetahs2.nl
+++ b/components/homme/test/reg_test/namelists/thetahs2.nl
@@ -55,7 +55,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform     = "ccm"
 vfile_mid = './vcoord/${HOMME_TEST_VCOORD_MID_FILE}'
 vfile_int = './vcoord/${HOMME_TEST_VCOORD_INT_FILE}'
 /

--- a/components/homme/test/reg_test/namelists/thetahs3.nl
+++ b/components/homme/test/reg_test/namelists/thetahs3.nl
@@ -55,7 +55,6 @@ wght_fm       = 0.10D0
 kcut_fm       = 2
 /
 &vert_nl
-vform     = "ccm"
 vfile_mid = './vcoord/${HOMME_TEST_VCOORD_MID_FILE}'
 vfile_int = './vcoord/${HOMME_TEST_VCOORD_INT_FILE}'
 /

--- a/components/homme/test/reg_test/namelists/thetanh-TC-nudiv.nl
+++ b/components/homme/test/reg_test/namelists/thetanh-TC-nudiv.nl
@@ -31,7 +31,6 @@
   dcmip16_pbl_type  = 0                         ! 0=basic pbl,   1= bryan pbl
 /
 &vert_nl
-  vform         = "ccm"
   vfile_mid     = "./vcoord/camm-30.ascii"
   vfile_int     = "./vcoord/cami-30.ascii"
 /

--- a/components/homme/test/reg_test/namelists/thetanh-TC-nutop.nl
+++ b/components/homme/test/reg_test/namelists/thetanh-TC-nutop.nl
@@ -31,7 +31,6 @@
   dcmip16_pbl_type  = 0                         ! 0=basic pbl,   1= bryan pbl
 /
 &vert_nl
-  vform         = "ccm"
   vfile_mid     = "./vcoord/camm-30.ascii"
   vfile_int     = "./vcoord/cami-30.ascii"
 /

--- a/components/homme/test/reg_test/namelists/thetanh-TC.nl
+++ b/components/homme/test/reg_test/namelists/thetanh-TC.nl
@@ -32,7 +32,6 @@
   dcmip16_pbl_type  = 0                         ! 0=basic pbl,   1= bryan pbl
 /
 &vert_nl
-  vform         = "ccm"
   vfile_mid     = "./vcoord/camm-30.ascii"
   vfile_int     = "./vcoord/cami-30.ascii"
 /

--- a/components/homme/test/reg_test/namelists/thetanh-c-TC.nl
+++ b/components/homme/test/reg_test/namelists/thetanh-c-TC.nl
@@ -30,7 +30,6 @@
   dcmip16_pbl_type  = 0                         ! 0=basic pbl,   1= bryan pbl
 /
 &vert_nl
-  vform         = "ccm"
   vfile_mid     = "./vcoord/camm-30.ascii"
   vfile_int     = "./vcoord/cami-30.ascii"
 /

--- a/components/homme/test/reg_test/namelists/thetanh-dry-bubble.nl
+++ b/components/homme/test/reg_test/namelists/thetanh-dry-bubble.nl
@@ -52,7 +52,6 @@
   bubble_dT=0.5
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 2.73919e-1                ! vertical coordinate at top of atm (z=10000m)
 /

--- a/components/homme/test/reg_test/namelists/thetanh-moist-bubble.nl
+++ b/components/homme/test/reg_test/namelists/thetanh-moist-bubble.nl
@@ -60,7 +60,6 @@
   bubble_prec_type=0
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 2.73919e-1                ! vertical coordinate at top of atm (z=10000m)
 /

--- a/components/homme/test/reg_test/namelists/thetanh-nhgw-slice.nl
+++ b/components/homme/test/reg_test/namelists/thetanh-nhgw-slice.nl
@@ -36,7 +36,6 @@
   hypervis_subcycle_q = 1
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 2.73919e-1                ! vertical coordinate at top of atm (z=10000m)
 /

--- a/components/homme/test/reg_test/namelists/thetanh-nhgw.nl
+++ b/components/homme/test/reg_test/namelists/thetanh-nhgw.nl
@@ -35,7 +35,6 @@
   hypervis_subcycle_q = 1
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 2.73919e-1                ! vertical coordinate at top of atm (z=10000m)
 /

--- a/components/homme/test/reg_test/namelists/thetanh-test22.nl
+++ b/components/homme/test/reg_test/namelists/thetanh-test22.nl
@@ -36,7 +36,6 @@
   tol               = 1.e-7
 /
 &vert_nl
-  vform             = "ccm"                     ! vertical coordinate type "ccm"=hybrid pressure/terrain
   vanalytic         = 1                         ! set vcoords in initialization routine
   vtop              = 3.2818e-2                 ! vertical coordinate at top of atm (z=30km)
 /

--- a/components/homme/test/reg_test/namelists/thetanh.nl
+++ b/components/homme/test/reg_test/namelists/thetanh.nl
@@ -31,7 +31,6 @@
   theta_hydrostatic_mode = .${HOMME_TEST_HYDROSTATIC_MODE}.
 /
 &vert_nl
-  vform         = "ccm"
   vfile_mid     = "./vcoord/${HOMME_TEST_VCOORD_MID_FILE}"
   vfile_int     = "./vcoord/${HOMME_TEST_VCOORD_INT_FILE}"
 /

--- a/components/homme/test/reg_test/namelists/thetanhwet-TC.nl
+++ b/components/homme/test/reg_test/namelists/thetanhwet-TC.nl
@@ -30,7 +30,6 @@
   dcmip16_pbl_type  = 0                         ! 0=basic pbl,   1= bryan pbl
 /
 &vert_nl
-  vform         = "ccm"
   vfile_mid     = "./vcoord/camm-30.ascii"
   vfile_int     = "./vcoord/cami-30.ascii"
 /

--- a/components/homme/test/reg_test/namelists/tool-zinterpolate.nl
+++ b/components/homme/test/reg_test/namelists/tool-zinterpolate.nl
@@ -6,7 +6,6 @@ mesh_file='none'
 &vert_nl
 ! for E3SM output, set this correctly:
 !vanalytic=0
-!vform         = "ccm"
 !vfile_mid     = "/home/mataylo/codes/homme/test/vcoord/acme-72m.ascii"
 !vfile_int     = "/home/mataylo/codes/homme/test/vcoord/acme-72i.ascii"
 /                                                                                                                 

--- a/components/homme/test/sw_conservative/sjtc1_long.nl
+++ b/components/homme/test/sw_conservative/sjtc1_long.nl
@@ -11,7 +11,6 @@ test_case     = "swsj1"
 ne            = 24
 ndays         = 12
 statefreq     = 8640
-tasknum       = 0
 restartfreq   = -1
 restartfile   = "./restart/R000000050"
 runtype       = 0

--- a/components/homme/test/sw_conservative/sjtc1_short.nl
+++ b/components/homme/test/sw_conservative/sjtc1_short.nl
@@ -11,7 +11,6 @@ test_case     = "swsj1"
 ne            = 24
 ndays         = 1
 statefreq     = 8640
-tasknum       = 0
 restartfreq   = -1
 restartfile   = "./restart/R000000050"
 runtype       = 0

--- a/components/homme/test/sw_conservative/swtc1.nl
+++ b/components/homme/test/sw_conservative/swtc1.nl
@@ -11,7 +11,6 @@ test_case     = "swtc1"
 ne            = 6
 ndays	      = 12
 statefreq     = 720
-tasknum       = 0
 restartfreq   = -1
 restartfile   = "./restart/R000000050"
 runtype       = 0

--- a/components/homme/test/sw_conservative/swtc2-tensor-hv.nl
+++ b/components/homme/test/sw_conservative/swtc2-tensor-hv.nl
@@ -10,7 +10,6 @@ topology      = "cube"
 test_case     = "swtc2"
 ndays         = 12
 statefreq     = 1440
-tasknum       = 0
 restartfreq   = -1
 restartfile   = "./restart/R000000050"
 runtype       = 0

--- a/components/homme/test/sw_conservative/swtc2.nl
+++ b/components/homme/test/sw_conservative/swtc2.nl
@@ -12,7 +12,6 @@ ne=48
 ntrac=1
 ndays         = 12
 statefreq     = 1440
-tasknum       = 0
 restartfreq   = -1
 restartfile   = "./restart/R000000050"
 runtype       = 0

--- a/components/homme/test/sw_conservative/swtc5-tensor-hv.nl
+++ b/components/homme/test/sw_conservative/swtc5-tensor-hv.nl
@@ -10,7 +10,6 @@ topology      = "cube"
 test_case     = "swtc5"
 ndays         = 15
 statefreq     = 1440
-tasknum       = 0
 restartfreq   = -1
 restartfile   = "./restart/R000000050"
 runtype       = 0

--- a/components/homme/test/sw_conservative/swtc5-var-hv.nl
+++ b/components/homme/test/sw_conservative/swtc5-var-hv.nl
@@ -10,7 +10,6 @@ topology      = "cube"
 test_case     = "swtc5"
 ndays         = 15
 statefreq     = 1440
-tasknum       = 0
 restartfreq   = -1
 restartfile   = "./restart/R000000050"
 runtype       = 0

--- a/components/homme/test/sw_conservative/swtc5-var-hv.nl
+++ b/components/homme/test/sw_conservative/swtc5-var-hv.nl
@@ -27,7 +27,6 @@ hypervis_power = 4
 mesh_file = '/home/onguba/homme7/test/mesh_refine/grids/grid_10_x8_iter10halo2.g'
 which_vlaplace=2
 hypervis_scaling = 0
-!max_hypervis_courant = 1.9
 /
 &solver_nl
 precon_method = "block_jacobi"

--- a/components/homme/test/sw_conservative/swtc5-var-hv.nl
+++ b/components/homme/test/sw_conservative/swtc5-var-hv.nl
@@ -27,7 +27,6 @@ hypervis_power = 4
 mesh_file = '/home/onguba/homme7/test/mesh_refine/grids/grid_10_x8_iter10halo2.g'
 which_vlaplace=2
 hypervis_scaling = 0
-fine_ne = 240
 !max_hypervis_courant = 1.9
 /
 &solver_nl

--- a/components/homme/test/sw_conservative/swtc6-tensor-hv.nl
+++ b/components/homme/test/sw_conservative/swtc6-tensor-hv.nl
@@ -10,7 +10,6 @@ topology      = "cube"
 test_case     = "swtc6"
 ndays         = 15
 statefreq     = 1440
-tasknum       = 0
 restartfreq   = -1
 restartfile   = "./restart/R000000050"
 runtype       = 0

--- a/components/homme/test/sw_conservative/swtc6high.nl
+++ b/components/homme/test/sw_conservative/swtc6high.nl
@@ -11,7 +11,6 @@ test_case     = "swtc5"
 ne=48
 ndays         = 15
 statefreq     = 1440
-tasknum       = 0
 restartfreq   = -1
 restartfile   = "./restart/R000000050"
 runtype       = 0

--- a/components/homme/test/tool/namelists/interpolate-eam.nl
+++ b/components/homme/test/tool/namelists/interpolate-eam.nl
@@ -6,7 +6,6 @@ mesh_file='none'
 &vert_nl
 ! for E3SM output, set this correctly:
 !vanalytic=0
-vform         = "ccm"
 vfile_mid     = "/global/u2/t/taylorm/codes/acme/components/homme/test/vcoord/scream-128m.ascii"
 vfile_int     = "/global/u2/t/taylorm/codes/acme/components/homme/test/vcoord/scream-128i.ascii"
 /

--- a/components/homme/test/tool/namelists/interpolate.nl
+++ b/components/homme/test/tool/namelists/interpolate.nl
@@ -6,7 +6,6 @@ mesh_file='none'
 &vert_nl
 ! for E3SM output, set this correctly:
 !vanalytic=0
-!vform         = "ccm"
 !vfile_mid     = "/home/mataylo/codes/homme/test/vcoord/acme-72m.ascii"
 !vfile_int     = "/home/mataylo/codes/homme/test/vcoord/acme-72i.ascii"
 /


### PR DESCRIPTION
I added some ifdefs handling the `SCREAM` macro, mostly in namelist_mod (plus a couple occurrences in `prim_[cxx]_driver_base.F90` init routines). These are needed in order for SCREAM to use the `readnl` subroutine in Homme (rather than dangerously rolling its own namelist parsing, which is what it was doing before).

In addition, there are two cleanups:
- remove some warnings (unused vars, initialization order, inconsistent tabs);
- removed a few namelist options that were never used, either in `components/homme` or `components/eam`. By that I mean that no F90 module or C/CXX file was ever using, save for their appearance in control_mod and namelist_mod (which was just parsing them from nl file, and setting them in control_mod).

Notes: 
- The ifdef logics should not change anything for both EAM and standalone Homme.
- @oksanaguba @mt5555 I split the removal of the namelist options into separate commits, so that if one of them is indeed to be kept, I can simply revert that single commit.
- The PR changes 190 files, but most of them are homme namelists, where the purged namelist options have been removed.
- I added the 'HOMME' label (rather than 'HOMME standalone'), since this PR also touches the eam/bld folder, in order to remove a couple of the purged namelist options from `namelist_definition.xml`.