### PR TITLE
Update ocean and sea ice ICs for ARRM60to10 mesh

### DIFF
--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -189,12 +189,12 @@ def buildnml(case, caseroot, compname):
         decomp_date = '180723'
         decomp_prefix = 'mpas-o.graph.info.'
         restoring_file = 'sss.monthlyClimatology.PHC2_salx.2004_08_03.ARRM60to10.190129.nc'
-        analysis_mask_file = 'ARRM60to10_SingleRegionAtlanticWTransportTransects_masks.nc'
+        analysis_mask_file = 'ARRM60to10_mocBasinsAndTransects20210623.nc'
         ic_date = '180715'
         ic_prefix = 'ocean.ARRM60to10'
         if ocn_ic_mode == 'spunup':
-            ic_date = '200422'
-            ic_prefix = 'ocean.ARRM60to10.restart_grizzly'
+            ic_date = '210204'
+            ic_prefix = 'mpaso.oARRM60to10.rstFromG-cori'
 
     elif ocn_grid == 'oARRM60to6':
         decomp_date = '180820'

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -186,8 +186,8 @@ def buildnml(case, caseroot, compname):
         grid_date = '180715'
         grid_prefix = 'seaice.ARRM60to10'
         if ice_ic_mode == 'spunup':
-            grid_date = '200422'
-            grid_prefix = 'seaice.ARRM60to10.restart_grizzly'
+            grid_date = '210204'
+            grid_prefix = 'mpassi.oARRM60to10.rstFromG-cori'
 
     elif ice_grid == 'oARRM60to6':
         decomp_date = '180820'


### PR DESCRIPTION
Updates the ocean and sea ice initial conditions for spun-up compsets using the `ARRM60to10` grid. This is needed to replace the existing sea ice initial condition, which has one snow layer, and is not compatible with v2. These new ocean and sea ice initial conditions are generated from restarts from a one month G-case using cold start initial conditions.

This also updates the ocean analysis mask file to include additional regions in addition to just `Atlantic`, which was the only one in the previous file it is replacing.

Fixes #4797

[BFB] for all configurations that do not use the `ARRM60to10` ocean / sea-ice mesh, or use this mesh with cold-start initial conditions (i.e. G-cases).
[non-BFB] for configurations that use the `ARRM60to10` mesh with spun-up ocean / sea-ice initial conditions (i.e. B-cases).