### PR TITLE
Modifies large(L) PE-Layout for RRM WCYCLE grid for Cori-KNL

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -9526,7 +9526,7 @@
         </rootpe>
       </pes>      
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+" pesize="L">
-        <comment> mmod147a32x4 s=2.7 </comment>
+        <comment> 160 nodes 32x8 s=2.2 - 2.8 </comment>
         <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
         <MAX_TASKS_PER_NODE>272</MAX_TASKS_PER_NODE>
         <ntasks>

--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -9528,21 +9528,21 @@
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+" pesize="L">
         <comment> mmod147a32x4 s=2.7 </comment>
         <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
+        <MAX_TASKS_PER_NODE>272</MAX_TASKS_PER_NODE>
         <ntasks>
           <ntasks_atm>3680</ntasks_atm>
           <ntasks_lnd>1024</ntasks_lnd>
           <ntasks_rof>2656</ntasks_rof>
           <ntasks_ice>3680</ntasks_ice>
-          <ntasks_ocn>1024</ntasks_ocn>
+          <ntasks_ocn>1440</ntasks_ocn>
           <ntasks_cpl>3680</ntasks_cpl>
         </ntasks>
         <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>4</nthrds_rof>
-          <nthrds_ice>4</nthrds_ice>
-          <nthrds_ocn>4</nthrds_ocn>
+          <nthrds_atm>8</nthrds_atm>
+          <nthrds_lnd>8</nthrds_lnd>
+          <nthrds_rof>8</nthrds_rof>
+          <nthrds_ice>8</nthrds_ice>
+          <nthrds_ocn>8</nthrds_ocn>
           <nthrds_cpl>1</nthrds_cpl>
         </nthrds>
         <rootpe>


### PR DESCRIPTION
The PE-Layout is modified to match the simulations which are
being run on Cori-KNL