### PR TITLE
Initializes uninitialized variables in ndrop.F90

### DIFF
--- a/components/eam/src/physics/cam/ndrop.F90
+++ b/components/eam/src/physics/cam/ndrop.F90
@@ -517,6 +517,10 @@ subroutine dropmixnuc( &
       call physics_ptend_init(ptend, state%psetcols, 'ndrop')
    end if
 
+   !initialize variables to zero
+   ndropmix(:,:) = 0._r8
+   nsource(:,:) = 0._r8
+
    ! overall_main_i_loop
    do i = 1, ncol
 


### PR DESCRIPTION
Variables ndropmix and nsource were uninitialized in ndrop.F90. 
Effectively calculations loop from top_lev ( 100 Pa) to bottom 
level. The levels above 100 Pa as a result were not initialized, 
but the full arrays were sent to outfld, causing problem to PIO 
when NaN are present.

They are both initialized to zero now.

Fixes #4782
[BFB]