### PR TITLE
New YAKL 2022-02-18

### DIFF
--- a/components/eam/src/physics/crm/samxx/accelerate_crm.cpp
+++ b/components/eam/src/physics/crm/samxx/accelerate_crm.cpp
@@ -52,7 +52,7 @@ void accelerate_crm(int nstep, int nstop, bool &ceaseflag) {
   //   for (int j=0; j<ny; j++) {
   //     for (int i=0; i<nx; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     // calculate tendency * dtn
     yakl::atomicAdd( tbaccel(k,icrm) , t(k,j+offy_s,i+offx_s,icrm) * crm_accel_coef );
     yakl::atomicAdd( qtbaccel(k,icrm) , (qcl(k,j,i,icrm) + qci(k,j,i,icrm) + qv(k,j,i,icrm)) * crm_accel_coef );
@@ -144,7 +144,7 @@ void accelerate_crm(int nstep, int nstop, bool &ceaseflag) {
   //   for (int j=0; j<ny; j++) {
   //     for (int i=0; i<nx; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     if (micro_field(idx_qt,k,j+offy_s,i+offx_s,icrm) < 0.0) {
       yakl::atomicAdd( qneg(k,icrm) , micro_field(idx_qt,k,j+offy_s,i+offx_s,icrm) ); 
     }

--- a/components/eam/src/physics/crm/samxx/advect2_mom_z.cpp
+++ b/components/eam/src/physics/crm/samxx/advect2_mom_z.cpp
@@ -48,7 +48,7 @@ void advect2_mom_z() {
     //   for (int j=0; j<ny; j++) {
     //     for (int i=0; i<nx; i++) {
     //       for (int icrm=0; icrm<ncrms; icrm++) {
-    parallel_for( SimpleBounds<4>(nzm-1,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+    parallel_for( SimpleBounds<4>(nzm-1,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
       real dz25=1.0/(4.0*dz(icrm));
       int kb = k-1;
       real rhoi = dz25 * rhow(k+1,icrm);
@@ -66,7 +66,7 @@ void advect2_mom_z() {
     //   for (int j=0; j<ny; j++) {
     //     for (int i=0; i<nx; i++) {
     //       for (int icrm=0; icrm<ncrms; icrm++) {
-    parallel_for( SimpleBounds<4>(nzm-1,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+    parallel_for( SimpleBounds<4>(nzm-1,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
       real dz25=1.0/(4.0*dz(icrm));
       int kb = k-1;
       real rhoi = dz25 * rhow(k+1,icrm);

--- a/components/eam/src/physics/crm/samxx/advect_scalar.cpp
+++ b/components/eam/src/physics/crm/samxx/advect_scalar.cpp
@@ -39,7 +39,7 @@ void advect_scalar(real4d &f, real2d &fadv, real2d &flux) {
     //   for (int j=0; j<ny; j++) {
     //     for (int i=0; i<nx; i++) {
     //       for (int icrm=0; icrm<ncrms; icrm++) {
-    parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+    parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
       real tmp = f(k,j+offy_s,i+offx_s,icrm)-f0(k,j+offy_s,i+offx_s,icrm);
       yakl::atomicAdd(fadv(k,icrm),tmp);
     });
@@ -87,7 +87,7 @@ void advect_scalar(real5d &f, int ind_f, real2d &fadv, real2d &flux) {
     //   for (int j=0; j<ny; j++) {
     //     for (int i=0; i<nx; i++) {
     //       for (int icrm=0; icrm<ncrms; icrm++) {
-    parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+    parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
       real tmp = f(ind_f,k,j+offy_s,i+offx_s,icrm)-f0(k,j+offy_s,i+offx_s,icrm);
       yakl::atomicAdd(fadv(k,icrm),tmp);
     });
@@ -134,7 +134,7 @@ void advect_scalar(real5d &f, int ind_f, real3d &fadv, int ind_fadv, real3d &flu
     //   for (int j=0; j<ny; j++) {
     //     for (int i=0; i<nx; i++) {
     //       for (int icrm=0; icrm<ncrms; icrm++) {
-    parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+    parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
       real tmp = f(ind_f,k,j+offy_s,i+offx_s,icrm)-f0(k,j+offy_s,i+offx_s,icrm);
       yakl::atomicAdd(fadv(ind_fadv,k,icrm),tmp);
     });

--- a/components/eam/src/physics/crm/samxx/advect_scalar2D.cpp
+++ b/components/eam/src/physics/crm/samxx/advect_scalar2D.cpp
@@ -94,7 +94,7 @@ void advect_scalar2D(real4d &f, real2d &flux) {
   // for (int k=0; k<nzm; k++) {
   //  for (int i=0; i<nx+4; i++) {
   //    for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<3>(nzm,nx+4,ncrms) , YAKL_DEVICE_LAMBDA (int k, int i, int icrm) {
+  parallel_for( SimpleBounds<3>(nzm,nx+4,ncrms) , YAKL_LAMBDA (int k, int i, int icrm) {
     if (i >= 2 && i <= nx+1) {
       yakl::atomicAdd(flux(k,icrm),www(k,j,i,icrm));
     }
@@ -163,7 +163,7 @@ void advect_scalar2D(real4d &f, real2d &flux) {
     // for (int k=0; k<nzm; k++) {
     //  for (int i=0; i<nx+1; i++) {
     //    for (int icrm=0; icrm<ncrms; icrm++) {
-    parallel_for( SimpleBounds<3>(nzm,nx+1,ncrms) , YAKL_DEVICE_LAMBDA (int k, int i, int icrm) {
+    parallel_for( SimpleBounds<3>(nzm,nx+1,ncrms) , YAKL_LAMBDA (int k, int i, int icrm) {
       int ib=i-1;
       uuu(k,j,i+offx_uuu,icrm) =
             pp2(uuu(k,j,i+offx_uuu,icrm))*min(1.0,min(mx(k,j,i+offx_m,icrm), mn(k,j,ib+offx_m,icrm))) -
@@ -290,7 +290,7 @@ void advect_scalar2D(real5d &f, int ind_f, real2d &flux) {
   // for (int k=0; k<nzm; k++) {
   //  for (int i=0; i<nx+4; i++) {
   //    for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<3>(nzm,nx+4,ncrms) , YAKL_DEVICE_LAMBDA (int k, int i, int icrm) {
+  parallel_for( SimpleBounds<3>(nzm,nx+4,ncrms) , YAKL_LAMBDA (int k, int i, int icrm) {
     if (i >= 2 && i <= nx+1) {
       yakl::atomicAdd(flux(k,icrm),www(k,j,i,icrm));
     }
@@ -362,7 +362,7 @@ void advect_scalar2D(real5d &f, int ind_f, real2d &flux) {
     // for (int k=0; k<nzm; k++) {
     //  for (int i=0; i<nx+1; i++) {
     //    for (int icrm=0; icrm<ncrms; icrm++) {
-    parallel_for( SimpleBounds<3>(nzm,nx+1,ncrms) , YAKL_DEVICE_LAMBDA (int k, int i, int icrm) {
+    parallel_for( SimpleBounds<3>(nzm,nx+1,ncrms) , YAKL_LAMBDA (int k, int i, int icrm) {
       int ib=i-1;
       uuu(k,j,i+offx_uuu,icrm)= pp2(uuu(k,j,i+offx_uuu,icrm))*min(1.0,min(mx(k,j,i+offx_m,icrm), mn(k,j,ib+offx_m,icrm))) -
                        pn2(uuu(k,j,i+offx_uuu,icrm))*min(1.0,min(mx(k,j,ib+offx_m,icrm),mn(k,j,i+offx_m,icrm)));
@@ -486,7 +486,7 @@ void advect_scalar2D(real5d &f, int ind_f, real3d &flux, int ind_flux) {
   // for (int k=0; k<nzm; k++) {
   //  for (int i=0; i<nx+4; i++) {
   //    for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<3>(nzm,nx+4,ncrms) , YAKL_DEVICE_LAMBDA (int k, int i, int icrm) {
+  parallel_for( SimpleBounds<3>(nzm,nx+4,ncrms) , YAKL_LAMBDA (int k, int i, int icrm) {
     if (i >= 2 && i <= nx+1) {
       yakl::atomicAdd(flux(ind_flux,k,icrm),www(k,j,i,icrm));
     }
@@ -557,7 +557,7 @@ void advect_scalar2D(real5d &f, int ind_f, real3d &flux, int ind_flux) {
     // for (int k=0; k<nzm; k++) {
     //  for (int i=0; i<nx+1; i++) {
     //    for (int icrm=0; icrm<ncrms; icrm++) {
-    parallel_for( SimpleBounds<3>(nzm,nx+1,ncrms) , YAKL_DEVICE_LAMBDA (int k, int i, int icrm) {
+    parallel_for( SimpleBounds<3>(nzm,nx+1,ncrms) , YAKL_LAMBDA (int k, int i, int icrm) {
       int ib=i-1;
       uuu(k,j,i+offx_uuu,icrm)= pp2(uuu(k,j,i+offx_uuu,icrm))*min(1.0,min(mx(k,j,i+offx_m,icrm), mn(k,j,ib+offx_m,icrm))) -
                                 pn2(uuu(k,j,i+offx_uuu,icrm))*min(1.0,min(mx(k,j,ib+offx_m,icrm),mn(k,j,i+offx_m,icrm)));

--- a/components/eam/src/physics/crm/samxx/advect_scalar3D.cpp
+++ b/components/eam/src/physics/crm/samxx/advect_scalar3D.cpp
@@ -142,7 +142,7 @@ void advect_scalar3D(real4d &f, real2d &flux) {
   //   for (int j=0; j<ny+4; j++) {
   //     for (int i=0; i<nx+4; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<4>(nzm,ny+4,nx+4,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm,ny+4,nx+4,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     if (i >= 2 && i <= nx+1 && j >= 2 && j <= ny+1) {
       yakl::atomicAdd(flux(k,icrm),www(k,j,i,icrm));
     }
@@ -256,7 +256,7 @@ void advect_scalar3D(real4d &f, real2d &flux) {
     //   for (int j=0; j<ny+1; j++) {
     //     for (int i=0; i<nx+1; i++) {
     //       for (int icrm=0; icrm<ncrms; icrm++) {
-    parallel_for( SimpleBounds<4>(nzm,ny+1,nx+1,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+    parallel_for( SimpleBounds<4>(nzm,ny+1,nx+1,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
       if (j <= ny-1) {
         int ib=i-1;
         uuu(k,j+offy_uuu,i+offx_uuu,icrm) = 
@@ -439,7 +439,7 @@ void advect_scalar3D(real5d &f, int ind_f, real2d &flux) {
   //   for (int j=0; j<ny+4; j++) {
   //     for (int i=0; i<nx+4; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<4>(nzm,ny+4,nx+4,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm,ny+4,nx+4,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     if (i >= 2 && i <= nx+1 && j >= 2 && j <= ny+1) {
       yakl::atomicAdd(flux(k,icrm),www(k,j,i,icrm));
     }
@@ -553,7 +553,7 @@ void advect_scalar3D(real5d &f, int ind_f, real2d &flux) {
     //   for (int j=0; j<ny+1; j++) {
     //     for (int i=0; i<nx+1; i++) {
     //       for (int icrm=0; icrm<ncrms; icrm++) {
-    parallel_for( SimpleBounds<4>(nzm,ny+1,nx+1,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+    parallel_for( SimpleBounds<4>(nzm,ny+1,nx+1,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
       if (j <= ny-1) {
         int ib=i-1;
         uuu(k,j+offy_uuu,i+offx_uuu,icrm) = 
@@ -738,7 +738,7 @@ void advect_scalar3D(real5d &f, int ind_f, real3d &flux, int ind_flux) {
   //   for (int j=0; j<ny+4; j++) {
   //     for (int i=0; i<nx+4; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<4>(nzm,ny+4,nx+4,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm,ny+4,nx+4,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     if (i >= 2 && i <= nx+1 && j >= 2 && j <= ny+1) {
       yakl::atomicAdd(flux(ind_flux,k,icrm),www(k,j,i,icrm));
     }
@@ -879,7 +879,7 @@ void advect_scalar3D(real5d &f, int ind_f, real3d &flux, int ind_flux) {
     //   for (int j=0; j<ny+1; j++) {
     //     for (int i=0; i<nx+1; i++) {
     //       for (int icrm=0; icrm<ncrms; icrm++) {
-    parallel_for( SimpleBounds<4>(nzm,ny+1,nx+1,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+    parallel_for( SimpleBounds<4>(nzm,ny+1,nx+1,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
       if (j <= ny-1) {
         int ib=i-1;
         uuu(k,j+offy_uuu,i+offx_uuu,icrm) = 

--- a/components/eam/src/physics/crm/samxx/crm_variance_transport.cpp
+++ b/components/eam/src/physics/crm/samxx/crm_variance_transport.cpp
@@ -16,8 +16,8 @@ void VT_filter(int filter_wn_max, real4d &f_in, real4d &f_out) {
   
   yakl::RealFFT1D<nx> fftx;
   yakl::RealFFT1D<fftySize> ffty;
-  fftx.init(fftx.trig);
-  ffty.init(ffty.trig);
+  fftx.init();
+  ffty.init();
 
   //----------------------------------------------------------------------------
   // Forward Fourier transform

--- a/components/eam/src/physics/crm/samxx/crm_variance_transport.cpp
+++ b/components/eam/src/physics/crm/samxx/crm_variance_transport.cpp
@@ -129,7 +129,7 @@ void VT_diagnose() {
   //  do j = 1,ny
   //    do i = 1,nx
   //      do icrm = 1,ncrms
-  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     yakl::atomicAdd( t_mean(k,icrm) , t(k,j+offy_s,i+offx_s,icrm) );
     yakl::atomicAdd( q_mean(k,icrm) , qv(k,j,i,icrm) + qcl(k,j,i,icrm) + qci(k,j,i,icrm) );
   });
@@ -185,7 +185,7 @@ void VT_diagnose() {
   //   do j = 1,ny
   //     do i = 1,nx
   //       do icrm = 1,ncrms
-  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     yakl::atomicAdd( t_vt(k,icrm) , t_vt_pert(k,j,i,icrm) * t_vt_pert(k,j,i,icrm) );
     yakl::atomicAdd( q_vt(k,icrm) , q_vt_pert(k,j,i,icrm) * q_vt_pert(k,j,i,icrm) );
   });

--- a/components/eam/src/physics/crm/samxx/crmsurface.cpp
+++ b/components/eam/src/physics/crm/samxx/crmsurface.cpp
@@ -30,7 +30,7 @@ void crmsurface(real1d &bflx) {
   //  for (int j=0; j<ny; j++) {
   //   for (int i=0; i<nx; i++) {
   //     for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<3>(ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int j, int i, int icrm) {
+  parallel_for( SimpleBounds<3>(ny,nx,ncrms) , YAKL_LAMBDA (int j, int i, int icrm) {
     real tmp2 = (0.5*(u(0,j+offy_u,i+1+offx_u,icrm)+u(0,j+offy_u,i+offx_u,icrm))+ug);
     real tmp3 = (0.5*(v(0,j+YES3D+offy_v,i+offx_v,icrm)+v(0,j+offy_v,i+offx_v,icrm))+vg);
     real u_h0 = max(1.0,sqrt(tmp2*tmp2+tmp3*tmp3));

--- a/components/eam/src/physics/crm/samxx/damping.cpp
+++ b/components/eam/src/physics/crm/samxx/damping.cpp
@@ -39,7 +39,7 @@ void damping() {
   });
 
   // for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<2>(nzm,ncrms) , YAKL_DEVICE_LAMBDA (int k, int icrm) {
+  parallel_for( SimpleBounds<2>(nzm,ncrms) , YAKL_LAMBDA (int k, int icrm) {
     if(z(nzm-1,icrm)-z(k,icrm) < fractional_damp_depth*z(nzm-1,icrm)) {
       do_damping(k,icrm)=1;
     } else {
@@ -75,7 +75,7 @@ void damping() {
   //   for (int j=0; j<ny; j++) {
   //     for (int i=0; i<nx; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     real tmp;
 
     tmp = u(k,offy_u+j,offx_u+i,icrm)/( (real) nx * (real) ny );

--- a/components/eam/src/physics/crm/samxx/diagnose.cpp
+++ b/components/eam/src/physics/crm/samxx/diagnose.cpp
@@ -61,7 +61,7 @@ void diagnose() {
   //   for (int j=0; j<ny; j++) {
   //     for (int i=0; i<nx; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     real coef1 = rho(k,icrm)*dz(icrm)*adz(k,icrm)*dtfactor;
     tabs(k,j,i,icrm) = t(k,j+offy_s,i+offx_s,icrm)-gamaz(k,icrm)+ fac_cond *
                        (qcl(k,j,i,icrm)+qpl(k,j,i,icrm)) + fac_sub *(qci(k,j,i,icrm) + qpi(k,j,i,icrm));
@@ -115,7 +115,7 @@ void diagnose() {
   //   for (int j=0; j<ny; j++) {
   //     for (int i=0; i<nx; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     real coef1 = rho(k,icrm)*dz(icrm)*adz(k,icrm)*dtfactor;
     // Saturated water vapor path with respect to water. Can be used
     // with water vapor path (= pw) to compute column-average

--- a/components/eam/src/physics/crm/samxx/diffuse_mom2D.cpp
+++ b/components/eam/src/physics/crm/samxx/diffuse_mom2D.cpp
@@ -76,7 +76,7 @@ void diffuse_mom2D(real5d &tk) {
   // for (int k=0; k<nzm-1; k++) {
   //  for (int i=0; i<nx; i++) {
   //    for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<3>(nzm-1,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int i, int icrm) {
+  parallel_for( SimpleBounds<3>(nzm-1,nx,ncrms) , YAKL_LAMBDA (int k, int i, int icrm) {
     int kc=k+1;
     real rdz=1.0/dz(icrm);
     real rdz2 = rdz*rdz * grdf_z(k,icrm);
@@ -99,7 +99,7 @@ void diffuse_mom2D(real5d &tk) {
   
   //     for (int i=0; i<nx; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<2>(nx,ncrms) , YAKL_DEVICE_LAMBDA (int i, int icrm) {
+  parallel_for( SimpleBounds<2>(nx,ncrms) , YAKL_LAMBDA (int i, int icrm) {
     real rdz=1.0/dz(icrm);
     real rdz2 = rdz*rdz * grdf_z(nzm-2,icrm);
     real tkz=rdz2*grdf_z(nzm-1,icrm)*tk(0,nzm-1,j+offy_d,i+offx_d,icrm);

--- a/components/eam/src/physics/crm/samxx/diffuse_mom3D.cpp
+++ b/components/eam/src/physics/crm/samxx/diffuse_mom3D.cpp
@@ -121,7 +121,7 @@ void diffuse_mom3D(real5d &tk) {
   //   for (int j=0; j<ny; j++) {
   //     for (int i=0; i<nx; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<4>(nzm-1,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm-1,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     int jb=j-1;
     int kc=k+1;
     int ib=i-1;
@@ -149,7 +149,7 @@ void diffuse_mom3D(real5d &tk) {
   //   for (int j=0; j<ny; j++) {
   //     for (int i=0; i<nx; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<3>(ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int j, int i, int icrm) {
+  parallel_for( SimpleBounds<3>(ny,nx,ncrms) , YAKL_LAMBDA (int j, int i, int icrm) {
     real rdz=1.0/dz(icrm);
     real rdz2 = rdz*rdz * grdf_z(nzm-2,icrm);
     real tkz=rdz2*grdf_z(nzm-1,icrm)*tk(0,nzm-1,j+offy_d,i+offx_d,icrm);

--- a/components/eam/src/physics/crm/samxx/diffuse_scalar.cpp
+++ b/components/eam/src/physics/crm/samxx/diffuse_scalar.cpp
@@ -29,7 +29,7 @@ void diffuse_scalar(real5d &tkh, int ind_tkh, real4d &f, real3d &fluxb, real3d &
   //   for (int j=0; j<ny; j++) {
   //     for (int i=0; i<nx; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     real tmp = f(k,j+offy_s,i+offx_s,icrm)-df(k,j+offy_s,i+offx_s,icrm);
     yakl::atomicAdd(fdiff(k,icrm),tmp);
   });
@@ -64,7 +64,7 @@ void diffuse_scalar(real5d &tkh, int ind_tkh, real5d &f, int ind_f, real3d &flux
   //   for (int j=0; j<ny; j++) {
   //     for (int i=0; i<nx; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     real tmp = f(ind_f,k,j+offy_s,i+offx_s,icrm)-df(k,j+offy_s,i+offx_s,icrm);
     yakl::atomicAdd(fdiff(k,icrm),tmp);
   });
@@ -99,7 +99,7 @@ void diffuse_scalar(real5d &tkh, int ind_tkh, real5d &f, int ind_f, real4d &flux
   //   for (int j=0; j<ny; j++) {
   //     for (int i=0; i<nx; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     real tmp = f(ind_f,k,j+offy_s,i+offx_s,icrm)-df(k,j+offy_s,i+offx_s,icrm);
     yakl::atomicAdd(fdiff(ind_fdiff,k,icrm),tmp);
   });

--- a/components/eam/src/physics/crm/samxx/diffuse_scalar2D.cpp
+++ b/components/eam/src/physics/crm/samxx/diffuse_scalar2D.cpp
@@ -59,7 +59,7 @@ void diffuse_scalar2D(real4d &field, real3d &fluxb, real3d &fluxt, real5d &tkh,
     // for (int k=0; k<nzm; k++) {
     //  for (int i=0; i<nx; i++) {
     //    for (int icrm=0; icrm<ncrms; icrm++) {
-    parallel_for( SimpleBounds<3>(nzm,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int i, int icrm) {
+    parallel_for( SimpleBounds<3>(nzm,nx,ncrms) , YAKL_LAMBDA (int k, int i, int icrm) {
       if (k <= nzm-2) {
         int kc=k+1;
         real rhoi = rhow(kc,icrm)/adzw(kc,icrm);
@@ -148,7 +148,7 @@ void diffuse_scalar2D(real5d &field, int ind_field, real3d &fluxb, real3d &fluxt
     // for (int k=0; k<nzm; k++) {
     //  for (int i=0; i<nx; i++) {
     //    for (int icrm=0; icrm<ncrms; icrm++) {
-    parallel_for( SimpleBounds<3>(nzm,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int i, int icrm) {
+    parallel_for( SimpleBounds<3>(nzm,nx,ncrms) , YAKL_LAMBDA (int k, int i, int icrm) {
       if (k <= nzm-2) {
         int kc=k+1;
         real rhoi = rhow(kc,icrm)/adzw(kc,icrm);
@@ -237,7 +237,7 @@ void diffuse_scalar2D(real5d &field, int ind_field, real4d &fluxb, int ind_fluxb
     // for (int k=0; k<nzm; k++) {
     //  for (int i=0; i<nx; i++) {
     //    for (int icrm=0; icrm<ncrms; icrm++) {
-    parallel_for( SimpleBounds<3>(nzm,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int i, int icrm) {
+    parallel_for( SimpleBounds<3>(nzm,nx,ncrms) , YAKL_LAMBDA (int k, int i, int icrm) {
       if (k <= nzm-2) {
         int kc=k+1;
         real rhoi = rhow(kc,icrm)/adzw(kc,icrm);

--- a/components/eam/src/physics/crm/samxx/diffuse_scalar3D.cpp
+++ b/components/eam/src/physics/crm/samxx/diffuse_scalar3D.cpp
@@ -82,7 +82,7 @@ void diffuse_scalar3D(real4d &field, real3d &fluxb, real3d &fluxt, real5d &tkh,
     //   for (int j=0; j<ny; j++) {
     //     for (int i=0; i<nx; i++) {
     //       for (int icrm=0; icrm<ncrms; icrm++) {
-    parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+    parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
       if (k <= nzm-2) {
         int kc=k+1;
         real rhoi = rhow(kc,icrm)/adzw(kc,icrm);
@@ -200,7 +200,7 @@ void diffuse_scalar3D(real5d &field, int ind_field, real3d &fluxb, real3d &fluxt
     //   for (int j=0; j<ny; j++) {
     //     for (int i=0; i<nx; i++) {
     //       for (int icrm=0; icrm<ncrms; icrm++) {
-    parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+    parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
       if (k <= nzm-2) {
         int kc=k+1;
         real rhoi = rhow(kc,icrm)/adzw(kc,icrm);
@@ -318,7 +318,7 @@ void diffuse_scalar3D(real5d &field, int ind_field, real4d &fluxb, int ind_fluxb
     //   for (int j=0; j<ny; j++) {
     //     for (int i=0; i<nx; i++) {
     //       for (int icrm=0; icrm<ncrms; icrm++) {
-    parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+    parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
       if (k <= nzm-2) {
         int kc=k+1;
         real rhoi = rhow(kc,icrm)/adzw(kc,icrm);

--- a/components/eam/src/physics/crm/samxx/forcing.cpp
+++ b/components/eam/src/physics/crm/samxx/forcing.cpp
@@ -29,7 +29,7 @@ void forcing() {
   //   for (int j=0; j<ny; j++) {
   //     for (int i=0; i<nx; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     t(k, j+offy_s, i+offx_s, icrm) = t(k, j+offy_s, i+offx_s, icrm) + ttend(k,icrm) * dtn;
     micro_field(index_water_vapor, k, j+offy_s, i+offx_s, icrm) = 
           micro_field(index_water_vapor, k, j+offy_s, i+offx_s, icrm) + qtend(k,icrm) * dtn;

--- a/components/eam/src/physics/crm/samxx/ice_fall.cpp
+++ b/components/eam/src/physics/crm/samxx/ice_fall.cpp
@@ -30,7 +30,7 @@ void ice_fall() {
   // for (int j=0; j<ny; j++) {
   //  for (int i=0; i<nx; i++) {
   //    for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<3>(ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int j, int i, int icrm) {
+  parallel_for( SimpleBounds<3>(ny,nx,ncrms) , YAKL_LAMBDA (int j, int i, int icrm) {
     for(int k=0; k < nzm; k++) {
       if(qcl(k,j,i,icrm)+qci(k,j,i,icrm) > 0.0 && tabs(k,j,i,icrm) < 273.15) {
         yakl::atomicMin(kmin(icrm),k);
@@ -113,7 +113,7 @@ void ice_fall() {
   //   for (int j=0; j<ny; j++) {
   //     for (int i=0; i<nx; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<4>(nz,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nz,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     if ( k >= max(0,kmin(icrm)-2) && k <= kmax(icrm) ) {
       real coef = dtn/(dz(icrm)*adz(k,icrm)*rho(k,icrm));
       // The cloud ice increment is the difference of the fluxes.

--- a/components/eam/src/physics/crm/samxx/kurant.cpp
+++ b/components/eam/src/physics/crm/samxx/kurant.cpp
@@ -30,7 +30,7 @@ void kurant () {
   //   for (int j=0; j<ny; j++) {
   //     for (int i=0; i<nx; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     real tmp;
     tmp = fabs(w(k,j+offy_w,i+offx_w,icrm));
     yakl::atomicMax(wm(k,icrm),tmp);

--- a/components/eam/src/physics/crm/samxx/microphysics.cpp
+++ b/components/eam/src/physics/crm/samxx/microphysics.cpp
@@ -200,7 +200,7 @@ void precip_fall(int hydro_type, real4d &omega) {
     //   for (int j=0; j<ny; j++) {
     //     for (int i=0; i<nx; i++) {
     //       for (int icrm=0; icrm<ncrms; icrm++) {
-    parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+    parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
       int kc=k+1;
       // Update precipitation mass fraction.
       // Note that fz is the total flux, including both the

--- a/components/eam/src/physics/crm/samxx/post_icycle.cpp
+++ b/components/eam/src/physics/crm/samxx/post_icycle.cpp
@@ -64,7 +64,7 @@ void post_icycle() {
   // for (int j=0; j<ny; j++) {
   //  for (int i=0; i<nx; i++) {
   //    for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<3>(ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int j, int i, int icrm) {
+  parallel_for( SimpleBounds<3>(ny,nx,ncrms) , YAKL_LAMBDA (int j, int i, int icrm) {
     for (int k=0; k<nzm; k++) {
       int l = plev-(k+1);
       real tmp1 = rho(nz-(k+1)-1,icrm)*adz(nz-(k+1)-1,icrm)*dz(icrm)*(qcl(nz-(k+1)-1,j,i,icrm)+qci(nz-(k+1)-1,j,i,icrm));
@@ -119,7 +119,7 @@ void post_icycle() {
   //   for (int j=0; j<ny; j++) {
   //     for (int i=0; i<nx; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     // Reduced radiation method allows for fewer radiation calculations
     // by collecting statistics and doing radiation over column groups
     int i_rad = i / (nx/crm_nx_rad);
@@ -149,7 +149,7 @@ void post_icycle() {
   //  for (int i=0; i<nx; i++) {
   //    for (int icrm=0; icrm<ncrms; icrm++) {
   //      for (int k=0; k<nzm+1; k++) {
-  parallel_for( SimpleBounds<4>(nzm+1,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm+1,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     int l=plev+1-(k+1);
     int kx;
     real qsat;
@@ -177,7 +177,7 @@ void post_icycle() {
   // for (int j=0; j<ny; j++) {
   //  for (int i=0; i<nx; i++) {
   //    for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<3>(ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int j, int i, int icrm) {
+  parallel_for( SimpleBounds<3>(ny,nx,ncrms) , YAKL_LAMBDA (int j, int i, int icrm) {
     if(cwp(j,i,icrm) > cwp_threshold) {
       yakl::atomicAdd(crm_output_cltot(icrm) , cttemp(j,i,icrm));
     }

--- a/components/eam/src/physics/crm/samxx/post_timeloop.cpp
+++ b/components/eam/src/physics/crm/samxx/post_timeloop.cpp
@@ -252,7 +252,7 @@ void post_timeloop() {
   //  for (int i=0; i<nx; i++) {
   //    for (int j=0; j<ny; j++) {
   //      for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     int l = plev-(k+1);
 
     real tmp = (qpl(k,j,i,icrm)+qpi(k,j,i,icrm))*crm_input_pdel(l,icrm);
@@ -384,7 +384,7 @@ void post_timeloop() {
   //   for (int j=0; j<ny; j++) {
   //     for (int i=0; i<nx; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     int l = plev-(k+1);
     yakl::atomicAdd(crm_output_qc_mean(l,icrm) , qcl(k,j,i,icrm));
     yakl::atomicAdd(crm_output_qi_mean(l,icrm) , qci(k,j,i,icrm));
@@ -430,7 +430,7 @@ void post_timeloop() {
   // for (int j=0; j<ny; j++) {
   //  for (int i=0; i<nx; i++) {
   //    for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<3>(ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int j, int i, int icrm) {
+  parallel_for( SimpleBounds<3>(ny,nx,ncrms) , YAKL_LAMBDA (int j, int i, int icrm) {
     precsfc(j,i,icrm) = precsfc(j,i,icrm)*dz(icrm)/dt/((real) nstop);
     precssfc(j,i,icrm) = precssfc(j,i,icrm)*dz(icrm)/dt/((real) nstop);
     if (precsfc(j,i,icrm) > 10.0/86400.0) {
@@ -467,7 +467,7 @@ void post_timeloop() {
 
   // for (int k=0; k<plev; k++) {
   //  for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<2>(plev,ncrms) , YAKL_DEVICE_LAMBDA (int k, int icrm) {
+  parallel_for( SimpleBounds<2>(plev,ncrms) , YAKL_LAMBDA (int k, int icrm) {
     crm_output_mu_crm(k,icrm)=0.5*(mui_crm(k,icrm)+mui_crm(k+1,icrm));
     crm_output_md_crm(k,icrm)=0.5*(mdi_crm(k,icrm)+mdi_crm(k+1,icrm));
     crm_output_mu_crm(k,icrm)=crm_output_mu_crm(k,icrm)*ggr/100.0;          //kg/m2/s --> mb/s

--- a/components/eam/src/physics/crm/samxx/pre_timeloop.cpp
+++ b/components/eam/src/physics/crm/samxx/pre_timeloop.cpp
@@ -349,7 +349,7 @@ void pre_timeloop() {
   //   for (int j=0; j<ny; j++) {
   //     for (int i=0; i<nx; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     t(k,j+offy_s,i+offx_s,icrm) = tabs(k,j,i,icrm)+gamaz(k,icrm)-fac_cond*qcl(k,j,i,icrm)-fac_sub*qci(k,j,i,icrm) -
                                                                  fac_cond*qpl(k,j,i,icrm)-fac_sub*qpi(k,j,i,icrm);
 

--- a/components/eam/src/physics/crm/samxx/precip_proc.cpp
+++ b/components/eam/src/physics/crm/samxx/precip_proc.cpp
@@ -43,7 +43,7 @@ void precip_proc(real5d &q, int ind_q, real5d &qp, int ind_qp) {
   //   for (int j=0; j<ny; j++) {
   //     for (int i=0; i<nx; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     //-------     Autoconversion/accretion
     real omn, omp, omg, qcc, qii, autor, autos, accrr, qrr, accrcs, accris,
          qss, accrcg, accrig, tmp, qgg, dq, qsatt, qsat;

--- a/components/eam/src/physics/crm/samxx/pressure.cpp
+++ b/components/eam/src/physics/crm/samxx/pressure.cpp
@@ -51,8 +51,8 @@ void pressure() {
 
     yakl::RealFFT1D<nx> fftx;
     yakl::RealFFT1D<fftySize> ffty;
-    fftx.init(fftx.trig);
-    ffty.init(ffty.trig);
+    fftx.init();
+    ffty.init();
 
     // for (int k=0; k<nzslab; k++) {
     //  for (int j=0; j<ny; j++) {

--- a/components/eam/src/physics/crm/samxx/scalar_momentum.cpp
+++ b/components/eam/src/physics/crm/samxx/scalar_momentum.cpp
@@ -107,7 +107,7 @@ void scalar_momentum_pgf( real4d& scalar_wind, real4d& tend ) {
    // compute forward fft of w
    //-----------------------------------------
    yakl::RealFFT1D<nx> fftx;
-   fftx.init(fftx.trig);
+   fftx.init();
 
    // for (int k=0; k<nzm; k++) {
    //   for (int j=0; j<ny; j++) {

--- a/components/eam/src/physics/crm/samxx/scalar_momentum.cpp
+++ b/components/eam/src/physics/crm/samxx/scalar_momentum.cpp
@@ -81,7 +81,7 @@ void scalar_momentum_pgf( real4d& scalar_wind, real4d& tend ) {
    //  for (int j=0; j<ny; j++) {
    //    for (int i=0; i<nx; i++) {
    //      for (int icrm=0; icrm<ncrms; icrm++) {
-   parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+   parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
       // real tmp = scalar_wind(k,j,i,icrm) / real(nx);
       yakl::atomicAdd( scalar_wind_avg(k,j,icrm) , scalar_wind(k,j,i,icrm) / real(nx) );
       // note that w is on interface levels - need to interpolate to mid-levels
@@ -187,7 +187,7 @@ void scalar_momentum_pgf( real4d& scalar_wind, real4d& tend ) {
    //  for (int j=0; j<ny; j++) {
    //    for (int i=0; i<nx; i++) {
    //      for (int icrm=0; icrm<ncrms; icrm++) {
-   parallel_for( SimpleBounds<4>(nzm-1,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+   parallel_for( SimpleBounds<4>(nzm-1,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
       if (i>0) {
          b(k+1,j,i,icrm) = b(k+1,j,i,icrm) - a(k+1,j,i,icrm) / b(k,j,i,icrm) * c(k,j,i,icrm);
          pgf_hat(k+1,j,i,icrm) = pgf_hat(k+1,j,i,icrm) - a(k+1,j,i,icrm) / b(k,j,i,icrm) * pgf_hat(k,j,i,icrm);
@@ -232,7 +232,7 @@ void scalar_momentum_pgf( real4d& scalar_wind, real4d& tend ) {
    // for (int k=0; k<nzm; k++) {
    //   for (int j=0; j<ny; j++) {
    //     for (int icrm=0; icrm<ncrms; icrm++) {
-   parallel_for( SimpleBounds<3>(nzm,ny,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int icrm) {
+   parallel_for( SimpleBounds<3>(nzm,ny,ncrms) , YAKL_LAMBDA (int k, int j, int icrm) {
       SArray<real,1,nx+2> ftmp;
       for (int i=0; i<nx2; i++) { ftmp(i) = pgf_hat(k,j,i,icrm); }
       fftx.inverse(ftmp, fftx.trig, yakl::FFT_SCALE_ECMWF);

--- a/components/eam/src/physics/crm/samxx/sgs.cpp
+++ b/components/eam/src/physics/crm/samxx/sgs.cpp
@@ -25,7 +25,7 @@ void kurant_sgs(real &cfl) {
   //   for (int j=0; j<ny; j++) {
   //     for (int i=0; i<nx; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     yakl::atomicMax( tkhmax(k,icrm) , sgs_field_diag(1,k,offy_d+j,offx_d+i,icrm) );
   });
 

--- a/components/eam/src/physics/crm/samxx/test/build/cmakescript.sh
+++ b/components/eam/src/physics/crm/samxx/test/build/cmakescript.sh
@@ -129,6 +129,7 @@ cd ..
 ## GET THE NETCDF LINKING FLAGS
 ############################################################################
 NCFLAGS="`$NFHOME/bin/nf-config --flibs` `$NCHOME/bin/nc-config --libs`"
+NCFLAGS=`echo "$NCFLAGS" | xargs`
 printf "NetCDF Flags: $NCFLAGS\n\n"
 
 

--- a/components/eam/src/physics/crm/samxx/test/build/thatchroof_gpu_debug.sh
+++ b/components/eam/src/physics/crm/samxx/test/build/thatchroof_gpu_debug.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+unset YAKL_ARCH
+unset NCRMS
+
+export NCHOME=${NETCDF_PATH}
+export NFHOME=${NETCDF_PATH}
+export NCRMS=42
+export CC=mpicc
+export CXX=mpic++
+export FC=mpif90
+export FFLAGS="-O0 -g -ffree-line-length-none -I${NETCDF_PATH}/include"
+export YAKL_HOME="`pwd`/../../../../../../../../externals/YAKL"
+export YAKL_ARCH="CUDA"
+export YAKL_CUDA_FLAGS="-arch sm_35 -O0 -g -DYAKL_DEBUG"
+
+

--- a/components/eam/src/physics/crm/samxx/test/build/thatchroof_gpu_opt.sh
+++ b/components/eam/src/physics/crm/samxx/test/build/thatchroof_gpu_opt.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+unset YAKL_ARCH
+unset NCRMS
+
+export NCHOME=${NETCDF_PATH}
+export NFHOME=${NETCDF_PATH}
+export NCRMS=42
+export CC=mpicc
+export CXX=mpic++
+export FC=mpif90
+export FFLAGS="-O3 -ffree-line-length-none -I${NETCDF_PATH}/include"
+export YAKL_HOME="`pwd`/../../../../../../../../externals/YAKL"
+export YAKL_ARCH="CUDA"
+export YAKL_CUDA_FLAGS="-arch sm_35 -O3 --use_fast_math"
+
+

--- a/components/eam/src/physics/crm/samxx/tke_full.cpp
+++ b/components/eam/src/physics/crm/samxx/tke_full.cpp
@@ -194,7 +194,7 @@ void tke_full(real5d &tke, int ind_tke, real5d &tk, int ind_tk, real5d &tkh, int
   //   for (int j=0; j<ny; j++) {
   //     for (int i=0; i<nx; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
-  parallel_for( SimpleBounds<4>(nzm-1,ny,nx,ncrms) , YAKL_DEVICE_LAMBDA (int k, int j, int i, int icrm) {
+  parallel_for( SimpleBounds<4>(nzm-1,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     real grd, Ce1, Ce2, cx, cy, cz, tkmax, smix, ratio, Cee, a_prod_sh, a_prod_bu,
          a_diss, tmp, buoy_sgs;
 


### PR DESCRIPTION
Upgrading to the latest YAKL. Includes performance improvements for CUDA and HIP as well as a bug (memory leak) fix for the pool allocator. The new YAKL also has a fully functioning SYCL backend for Intel GPUs.

CUDA has what appears to be a compiler bug in the FFT routines. These have been worked around in the new YAKL. The FFT API changed by no longer requiring a parameter to init(). This has been reflected in pressure.cpp and crm_variance_transport.cpp

An issue with the standalone samxx has been fixed, and new machine files have been added. 

This PR passes `./create_test SMS_Ld10_P6x7.ne4pg2_ne4pg2.F-MMFXX.summit_gnugpu.eam-rrtmgpxx`

[BFB]