### PR TITLE
Update to gnu v9 for cori-haswell and cori-knl

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -346,11 +346,11 @@
       </modules>
 
       <modules compiler="gnu">
-        <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.5</command>
+        <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.9</command>
         <command name="rm">gcc</command>
-        <command name="load">gcc/8.3.0</command>
+        <command name="load">gcc/9.3.0</command>
         <command name="rm">cray-libsci</command>
-        <command name="load">cray-libsci/19.06.1</command>
+        <command name="load">cray-libsci/20.09.1</command>
       </modules>
 
       <modules>
@@ -499,11 +499,11 @@
       </modules>
 
       <modules compiler="gnu">
-        <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.5</command>
+        <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.9</command>
         <command name="rm">gcc</command>
-        <command name="load">gcc/8.3.0</command>
+        <command name="load">gcc/9.3.0</command>
         <command name="rm">cray-libsci</command>
-        <command name="load">cray-libsci/19.06.1</command>
+        <command name="load">cray-libsci/20.09.1</command>
       </modules>
 
       <modules>


### PR DESCRIPTION
Update cray-libsci as well on Cori

Fixes #4808

GNU builds will not be bfb
