### PR TITLE
Update module versions on Perlmutter (including to gnu v10)

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -171,6 +171,9 @@
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
       <env name="PERL5LIB">/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch</env>
     </environment_variables>
+    <resource_limits>
+      <resource name="RLIMIT_STACK">-1</resource>
+    </resource_limits>
   </machine>
 
   <machine MACH="spock">

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -120,8 +120,7 @@
 
       <modules compiler="gnu.*">
 	<command name="load">PrgEnv-gnu/8.2.0</command>
-	<command name="load">gcc/9.3.0</command>
-	<!--command name="load">gcc/10.3.0</command-->
+	<command name="load">gcc/10.3.0</command>
       </modules>
 
       <modules compiler="nvidia.*">
@@ -150,10 +149,10 @@
       <modules>
 	<command name="load">cray-libsci</command>
 	<command name="load">craype</command>
-	<command name="load">cray-mpich/8.1.11</command>
-	<command name="load">cray-hdf5-parallel/1.12.0.7</command>
-	<command name="load">cray-netcdf-hdf5parallel/4.7.4.7</command>
-	<command name="load">cray-parallel-netcdf/1.12.1.7</command>
+	<command name="load">cray-mpich/8.1.13</command>
+	<command name="load">cray-hdf5-parallel/1.12.1.1</command>
+	<command name="load">cray-netcdf-hdf5parallel/4.8.1.1</command>
+	<command name="load">cray-parallel-netcdf/1.12.2.1</command>
 	<command name="load">cmake/3.22.0</command>
       </modules>
     </module_system>


### PR DESCRIPTION
For Perlmutter, updating versions of modules to default. 
For the GNU compiler version, update to 10 (though current default is now 11).

Note that updating to gnu v10 requires https://github.com/E3SM-Project/E3SM/pull/4822
(Specifically, adding -fallow-argument-mismatch -fallow-invalid-boz)

Also removed the soft limit for stacksize for PM.

Fixes: https://github.com/E3SM-Project/E3SM/issues/4811
