### PR TITLE
Fix non-standard declarations of 8-byte integers in ESMF in MPAS-Framework

### DIFF
--- a/components/mpas-framework/src/external/esmf_time_f90/ESMF_BaseMod.F90
+++ b/components/mpas-framework/src/external/esmf_time_f90/ESMF_BaseMod.F90
@@ -70,9 +70,21 @@
 
 !------------------------------------------------------------------------------
 !
+      integer, parameter :: &
+                   ESMF_KIND_I1 = selected_int_kind(2), &
+                   ESMF_KIND_I2 = selected_int_kind(4), &
+                   ESMF_KIND_I4 = selected_int_kind(9), &
+                   ESMF_KIND_I8 = selected_int_kind(18), &
+                   ESMF_KIND_R4 = selected_real_kind(3,25), &
+                   ESMF_KIND_R8 = selected_real_kind(6,45), &
+                   ESMF_KIND_C8 = selected_real_kind(3,25), &
+                   ESMF_KIND_C16 = selected_real_kind(6,45)
+
+!------------------------------------------------------------------------------
+!
       type ESMF_Pointer
       private
-          integer*8 :: ptr
+          integer(kind=ESMF_KIND_I8) :: ptr
       end type
 
       type(ESMF_Pointer), parameter :: ESMF_NULL_POINTER = ESMF_Pointer(0), &
@@ -94,18 +106,6 @@
                                         ESMF_DATA_REAL = ESMF_DataType(2), &
                                         ESMF_DATA_LOGICAL = ESMF_DataType(3), &
                                         ESMF_DATA_CHARACTER = ESMF_DataType(4)
-
-!------------------------------------------------------------------------------
-
-      integer, parameter :: &
-                   ESMF_KIND_I1 = selected_int_kind(2), &
-                   ESMF_KIND_I2 = selected_int_kind(4), &
-                   ESMF_KIND_I4 = selected_int_kind(9), &
-                   ESMF_KIND_I8 = selected_int_kind(18), &
-                   ESMF_KIND_R4 = selected_real_kind(3,25), &
-                   ESMF_KIND_R8 = selected_real_kind(6,45), &
-                   ESMF_KIND_C8 = selected_real_kind(3,25), &
-                   ESMF_KIND_C16 = selected_real_kind(6,45)
 
 !------------------------------------------------------------------------------
 
@@ -160,7 +160,7 @@
 !
       type ESMF_BasePointer
       private
-          integer*8 :: base_ptr
+          integer(kind=ESMF_KIND_I8) :: base_ptr
       end type
 
       integer :: global_count = 0
@@ -950,7 +950,7 @@ end function
 !
 ! !ARGUMENTS:
       type(ESMF_Pointer) :: ptype
-      integer*8, intent(in) :: contents
+      integer(kind=ESMF_KIND_I8), intent(in) :: contents
       integer, intent(out), optional :: rc
 
 !
@@ -985,7 +985,7 @@ end function
 !
 !EOP
 ! !REQUIREMENTS:
-      integer*8, parameter :: nullp = 0
+      integer(kind=ESMF_KIND_I8), parameter :: nullp = 0
 
       ptype%ptr = nullp
       if (present(rc)) rc = ESMF_SUCCESS
@@ -999,7 +999,7 @@ end function
       function ESMF_GetPointer(ptype, rc)
 !
 ! !RETURN VALUE:
-      integer*8 :: ESMF_GetPointer
+      integer(kind=ESMF_KIND_I8) :: ESMF_GetPointer
 
 ! !ARGUMENTS:
       type(ESMF_Pointer), intent(in) :: ptype


### PR DESCRIPTION
This PR fixes non-standard declarations of 8-byte integers in ESMF_BaseMod.F90. See the original PR for MPAS at https://github.com/MPAS-Dev/MPAS-Model/pull/959.

The ESMF_BaseMod module contains several non-standard declarations of 8-byte
integer variables. These were identified using the GNU compiler:
```
   ESMF_BaseMod.F90:75:20:

      75 |           integer*8 :: ptr
         |                    1
   Error: GNU Extension: Nonstandard type declaration INTEGER*8 at (1)
```
and also using the NAG compiler:
```
   Error: ESMF_BaseMod.F90, line 75: KIND value (8) does not specify a valid representation method
   Error: ESMF_BaseMod.F90, line 163: KIND value (8) does not specify a valid representation method
```
Since the ESMF_BaseMod module already defines a parameter for selecting 8-byte
integers, namely, ESMF_KIND_I8, all that is needed is to move the definition of
this (and related) parameters to appear earlier in the module and to then use
```
   integer(kind=ESMF_KIND_I8)
```
rather than
```
   integer(kind=8)
```

[BFB]