### PR TITLE
Updates carbon conservation analysis member

### DIFF
--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -1016,6 +1016,7 @@ add_default($nl, 'config_AM_conservationCheck_compute_on_startup');
 add_default($nl, 'config_AM_conservationCheck_write_on_startup');
 add_default($nl, 'config_AM_conservationCheck_write_to_logfile');
 add_default($nl, 'config_AM_conservationCheck_restart_stream');
+add_default($nl, 'config_AM_conservationCheck_carbon_failure_abort');
 
 ##########################################
 # Namelist group: AM_geographicalVectors #

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -532,6 +532,7 @@ add_default($nl, 'config_AM_conservationCheck_compute_on_startup');
 add_default($nl, 'config_AM_conservationCheck_write_on_startup');
 add_default($nl, 'config_AM_conservationCheck_write_to_logfile');
 add_default($nl, 'config_AM_conservationCheck_restart_stream');
+add_default($nl, 'config_AM_conservationCheck_carbon_failure_abort');
 
 ##########################################
 # Namelist group: AM_geographicalVectors #

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -459,7 +459,7 @@
 <config_AM_conservationCheck_write_on_startup>false</config_AM_conservationCheck_write_on_startup>
 <config_AM_conservationCheck_write_to_logfile>true</config_AM_conservationCheck_write_to_logfile>
 <config_AM_conservationCheck_restart_stream>'conservationCheckRestart'</config_AM_conservationCheck_restart_stream>
-<config_AM_conservationCheck_carbon_failure_abort>'false'</config_AM_conservationCheck_carbon_failure_abort>
+<config_AM_conservationCheck_carbon_failure_abort>false</config_AM_conservationCheck_carbon_failure_abort>
 
 <!-- AM_geographicalVectors -->
 <config_AM_geographicalVectors_enable>true</config_AM_geographicalVectors_enable>

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -459,6 +459,7 @@
 <config_AM_conservationCheck_write_on_startup>false</config_AM_conservationCheck_write_on_startup>
 <config_AM_conservationCheck_write_to_logfile>true</config_AM_conservationCheck_write_to_logfile>
 <config_AM_conservationCheck_restart_stream>'conservationCheckRestart'</config_AM_conservationCheck_restart_stream>
+<config_AM_conservationCheck_carbon_failure_abort>'false'</config_AM_conservationCheck_carbon_failure_abort>
 
 <!-- AM_geographicalVectors -->
 <config_AM_geographicalVectors_enable>true</config_AM_geographicalVectors_enable>

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -2880,6 +2880,14 @@ Valid values: A restart stream with state of the conservation check.
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_AM_conservationCheck_carbon_failure_abort" type="logical"
+	category="AM_conservationCheck" group="AM_conservationCheck">
+If true, abort if carbon conservation fails bounds check.
+
+Valid values: true or false
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- AM_geographicalVectors -->
 

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -874,7 +874,7 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_use_special_boundaries_tracers" type="logical"
 	category="column_tracers" group="column_tracers">
-Zero out tracers in given boundary cells.
+Modify tracers in given boundary cells.
 
 Valid values: true or false
 Default: Defined in namelist_defaults.xml

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -450,6 +450,9 @@ contains
         tempLogicalConfig = .true.
         call mpas_pool_get_config(domain % configs, "config_do_restart_zsalinity", tempLogicalConfig)
         tempLogicalConfig = .true.
+        call mpas_pool_get_config(domain % configs, "config_do_restart_bgc", tempLogicalConfig)
+        tempLogicalConfig = .true.
+
 
         ! Set start time to be read from file
         call mpas_pool_get_config(domain % configs, "config_start_time", tempCharConfig)

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -4094,7 +4094,25 @@
 		<var name="verticalShortwaveGrid"		type="real"	dimensions="nIceLayersP1"				name_in_code="verticalShortwaveGrid"		packages="pkgColumnBiogeochemistry;pkgColumnPackage"/>
 		<var name="carbonToNitrogenRatioAlgae"		type="real"	dimensions="maxAlgaeType"				name_in_code="carbonToNitrogenRatioAlgae"/>
 		<var name="carbonToNitrogenRatioDON"		type="real"	dimensions="maxDONType"				name_in_code="carbonToNitrogenRatioDON"/>
-		<var name="DOCPoolFractions"		type="real"	dimensions="maxDOCType"				name_in_code="DOCPoolFractions"/>
+		<var name="DOCPoolFractions"			type="real"	dimensions="maxDOCType"	  			name_in_code="DOCPoolFractions"/>
+	</var_struct>
+	<!-- Diagnostics Biogeochemistry -->
+	<var_struct name="diagnostics_biogeochemistry" time_levs="1">
+		<var name="bgridPorosityIceCell"			type="real"	dimensions="nBioLayersP1 nCells Time"			name_in_code="bgridPorosityIceCell"
+			units=""
+			description="Cell ice volume weighted average brine porosity on ice interface biological grid"
+			packages="pkgColumnBiogeochemistry;pkgColumnPackage"
+		/>
+		<var name="bgridSalinityIceCell"			type="real"	dimensions="nBioLayersP1 nCells Time"			name_in_code="bgridSalinityIceCell"
+			units="ppt"
+			description="Cell ice volume weighted average salinity on ice interface biological grid"
+			packages="pkgColumnBiogeochemistry;pkgColumnPackage"
+		/>
+		<var name="bgridTemperatureIceCell"		type="real"	dimensions="nBioLayersP1 nCells Time"			name_in_code="bgridTemperatureIceCell"
+			units="oC"
+			description="Cell ice volume weighted average temperature on ice interface biological grid"
+			packages="pkgColumnBiogeochemistry;pkgColumnPackage"
+		/>
 	</var_struct>
 
 	<!-- prescribed ice mode -->

--- a/components/mpas-seaice/src/analysis_members/Registry_seaice_conservation_check.xml
+++ b/components/mpas-seaice/src/analysis_members/Registry_seaice_conservation_check.xml
@@ -27,6 +27,10 @@
 			description="Name of the restart stream the analysis member will use to initialize itself if restart is enabled."
 			possible_values="A restart stream with state of the conservation check."
 		/>
+		<nml_option name="config_AM_conservationCheck_carbon_failure_abort" type="logical" default_value="false" units="unitless"
+			description="If true, abort if carbon conservation fails bounds check."
+			possible_values="true or false"
+		/>
 	</nml_record>
 	<packages>
 		<package name="conservationCheckAMPKG" description="This package includes variables required for the conservationCheck analysis member."/>
@@ -174,29 +178,69 @@
 		/>
 	</var_struct>
 	<var_struct name="conservationCheckCarbonAM" time_levs="1" packages="conservationCheckAMPKG">
-		<var name="initialCarbon" type="real" dimensions="nHemispheres Time" units="mmol"
+		<var name="relativeErrorBounds" type="real" dimensions="Time" units=""
+			description="accumulated relative error bounds"
+		/>
+		<var name="initialCarbon" type="real" dimensions="nHemispheres Time" units="kg"
 			description="Total initial carbon of ice and snow"
 		/>
-		<var name="finalCarbon" type="real" dimensions="nHemispheres Time" units="mmol"
+		<var name="finalCarbon" type="real" dimensions="nHemispheres Time" units="kg"
 			description="Total final carbon of ice and snow"
 		/>
-		<var name="carbonChange" type="real" dimensions="nHemispheres Time" units="mmol"
+		<var name="carbonChange" type="real" dimensions="nHemispheres Time" units="kg"
 			description="Total carbon change of ice and snow during time step"
 		/>
-		<var name="carbonChangeFlux" type="real" dimensions="nHemispheres Time" units="mmol/m2s"
+		<var name="carbonChangeFlux" type="real" dimensions="nHemispheres Time" units="kg/m2s"
 			description="Total carbon change flux of ice and snow during time step"
 		/>
-		<var name="netCarbonFlux" type="real" dimensions="nHemispheres Time" units="mmol/s"
+		<var name="netCarbonFlux" type="real" dimensions="nHemispheres Time" units="kg/s"
 			description="Net carbon flux to sea ice"
 		/>
-		<var name="absoluteCarbonError" type="real" dimensions="nHemispheres Time" units="mmol"
+		<var name="absoluteCarbonError" type="real" dimensions="nHemispheres Time" units="kg"
 			description="Absolute carbon conservation error"
 		/>
 		<var name="relativeCarbonError" type="real" dimensions="nHemispheres Time" units="None"
 			description="Relative carbon conservation error"
 		/>
-		<var name="carbonConsOceanCarbonFlux" type="real" dimensions="nHemispheres Time" units="mmol/s"
+		<var name="accumAbsoluteCarbonError" type="real" dimensions="nHemispheres Time" units="kg"
+			description="Accumulated since start absolute carbon conservation error"
+		/>
+		<var name="accumRelativeCarbonError" type="real" dimensions="nHemispheres Time" units="None"
+			description="Accumulated since start relative carbon conservation error"
+		/>
+		<var name="carbonConsOceanCarbonFlux" type="real" dimensions="nHemispheres Time" units="kg/s"
 			description="Total ocean carbon flux, positive into the ocean"
+		/>
+		<var name="carbonConsOceanCarbonFluxCheck" type="real" dimensions="nHemispheres Time" units="kg/s"
+			description="Total ocean carbon flux computed
+				     from individual passed fluxes, positive into the ocean"
+		/>
+		<var name="carbonConsDiatomFlux" type="real" dimensions="nHemispheres Time" units="kg/s"
+			description="Total algal diatom carbon flux, positive into the ocean"
+		/>
+		<var name="carbonConsSmallAlgaeFlux" type="real" dimensions="nHemispheres Time" units="kg/s"
+			description="Total small algae carbon flux, positive into the ocean"
+		/>
+		<var name="carbonConsDOC1Flux" type="real" dimensions="nHemispheres Time" units="kg/s"
+			description="Total dissolved organic carbon
+				     (polysaccharids) carbon flux, positive into the ocean"
+		/>
+		<var name="carbonConsDOC2Flux" type="real" dimensions="nHemispheres Time" units="kg/s"
+			description="Total dissolved organic carbon
+				     (lipids) carbon flux, positive into the ocean"
+		/>
+		<var name="carbonConsDONCarbonFlux" type="real" dimensions="nHemispheres Time" units="kg/s"
+			description="Total dissolved organic carbon
+				     (proteins) flux, positive into the ocean"
+		/>
+		<var name="carbonConsDICFlux" type="real" dimensions="nHemispheres Time" units="kg/s"
+			description="Total dissolved inorganic carbon flux, positive into the ocean"
+		/>
+		<var name="carbonConsHumicsFlux" type="real" dimensions="nHemispheres Time" units="kg/s"
+			description="Total dissolved humics carbon flux, positive into the ocean"
+		/>
+		<var name="carbonConsSemiLabileDOCFlux" type="real" dimensions="nHemispheres Time" units="kg/s"
+			description="Total semi-labile DOC flux, positive into the ocean"
 		/>
 	</var_struct>
 	<streams>
@@ -254,9 +298,19 @@
 			<var name="carbonChange"/>
 			<var name="carbonChangeFlux"/>
 			<var name="carbonConsOceanCarbonFlux"/>
+			<var name="carbonConsOceanCarbonFluxCheck"/>
 			<var name="netCarbonFlux"/>
 			<var name="absoluteCarbonError"/>
 			<var name="relativeCarbonError"/>
+			<var name="carbonConsDiatomFlux"/>
+			<var name="carbonConsSmallAlgaeFlux"/>
+			<var name="carbonConsDOC1Flux"/>
+			<var name="carbonConsDOC2Flux"/>
+			<var name="carbonConsDONCarbonFlux"/>
+			<var name="carbonConsDICFlux"/>
+			<var name="carbonConsHumicsFlux"/>
+			<var name="carbonConsSemiLabileDOCFlux"/>
+			<var name="relativeErrorBounds"/>
 		</stream>
 
 		<stream name="conservationCheckRestart_contents"
@@ -287,6 +341,9 @@
 			<var name="saltConsOceanSaltFlux"/>
 			<var name="saltConsFrazilSaltFlux"/>
 			<var name="initialCarbon"/>
+			<var name="accumAbsoluteCarbonError"/>
+			<var name="accumRelativeCarbonError"/>
+			<var name="relativeErrorBounds"/>
 			<var name="carbonConsOceanCarbonFlux"/>
 		</stream>
 

--- a/components/mpas-seaice/src/analysis_members/mpas_seaice_conservation_check.F
+++ b/components/mpas-seaice/src/analysis_members/mpas_seaice_conservation_check.F
@@ -1688,11 +1688,21 @@ contains
 
    subroutine carbon_conservation(domain, err)
 
+      use seaice_constants, only: &
+           gramsCarbonPerMolCarbon
+
       type (domain_type), intent(inout) :: &
            domain
 
       integer, intent(out) :: &
            err !< Output: error flag
+
+      integer, pointer :: &
+           maxAlgaeType, &
+           maxDOCType, &
+           maxDICType, &
+           maxDONType, &
+           maxIronType
 
       type(block_type), pointer :: &
            blockPtr
@@ -1709,13 +1719,40 @@ contains
            carbonChangeFlux, &
            netCarbonFlux, &
            absoluteCarbonError, &
-           relativeCarbonError
+           relativeCarbonError, &
+           iceAreaCell, &
+           accumAbsoluteCarbonError, &
+           accumRelativeCarbonError
 
       real(kind=RKIND), dimension(:), pointer :: &
-           carbonConsOceanCarbonFlux
+           carbonConsOceanCarbonFlux, &
+           carbonConsOceanCarbonFluxCheck, &
+           carbonConsDiatomFlux, &
+           carbonConsSmallAlgaeFlux, &
+           carbonConsDOC1Flux, &
+           carbonConsDOC2Flux, &
+           carbonConsDICFlux, &
+           carbonConsDONCarbonFlux, &
+           carbonConsHumicsFlux, &
+           carbonConsSemiLabileDOCFlux
+
+      real(kind=RKIND), pointer :: &
+           config_ratio_C_to_N_diatoms, &
+           config_ratio_C_to_N_small_plankton, &
+           config_ratio_C_to_N_phaeocystis, &
+           config_ratio_C_to_N_proteins
 
       real(kind=RKIND) :: &
-           totalOceanCarbonCell
+           totalOceanCarbonCell, &
+           totalOceanCarbonCellCheck, &
+           totalOceanDiatomCell, &
+           totalOceanSmallAlgaeCell, &
+           totalOceanDOC1Cell, &
+           totalOceanDOC2Cell, &
+           totalOceanDONCarbonCell, &
+           totalOceanDICCell, &
+           totalOceanHumicsCell, &
+           totalOceanSemiLabileDOCCell
 
       real(kind=RKIND), dimension(:), allocatable :: &
            sumArray, &
@@ -1723,26 +1760,41 @@ contains
 
       type(MPAS_pool_type), pointer :: &
            meshPool, &
+           tracersAggregatePool, &
            biogeochemistryPool
 
       real(kind=RKIND), dimension(:), pointer :: &
            areaCell, &
-           totalOceanCarbonFlux
+           totalOceanCarbonFlux, &
+           oceanHumicsFlux
+
+      real(kind=RKIND), dimension(:,:), pointer :: &
+           oceanBioFluxes, &
+           oceanAlgaeFlux, &
+           oceanDOCFlux, &
+           oceanDICFlux, &
+           oceanDONFlux
 
       integer, dimension(:,:), pointer :: &
            cellInHemisphere
 
       real(kind=RKIND), pointer :: &
            dt, &
-           earthArea
+           earthArea, &
+           relativeErrorBounds
 
       logical, pointer :: &
-           config_AM_conservationCheck_write_to_logfile
+           config_AM_conservationCheck_write_to_logfile, &
+           config_AM_conservationCheck_carbon_failure_abort
 
       integer, pointer :: &
            nCellsSolve, &
            nHemispheres, &
            nAccumulate
+
+      type (MPAS_Time_Type) :: &
+           currTime, &
+           startTime
 
       integer :: &
            iCell, &
@@ -1750,26 +1802,39 @@ contains
            iSumPrev, &
            ierr
 
-      integer, parameter :: &
-           nVars = 1
-
       integer :: &
+           nVars, &
+           nZBGC, &
            nSums
 
       real(kind=RKIND) :: &
-           fluxScale
+           fluxScale, &
+           relativeErrorStepBound
+
+      character(len=strKIND) :: &
+           timeStr, &
+           timeStrStart
+
+      character(len=16) :: &
+           valStr
 
       err = 0
+      relativeErrorStepBound = 1.0E-7 ! mass conservation relative error bound 1e-5
 
       call MPAS_pool_get_config(domain % configs, "config_dt", dt)
       call MPAS_pool_get_config(domain % configs, "config_AM_conservationCheck_write_to_logfile", &
                                                    config_AM_conservationCheck_write_to_logfile)
+      call MPAS_pool_get_config(domain % configs, "config_AM_conservationCheck_carbon_failure_abort", &
+                                                   config_AM_conservationCheck_carbon_failure_abort)
 
       !-------------------------------------------------------------
       ! Net carbon flux to ice
       !-------------------------------------------------------------
 
       call MPAS_pool_get_dimension(domain % blocklist % dimensions, "nHemispheres", nHemispheres)
+
+      nVars = 10
+
       nSums = nHemispheres * nVars
 
       allocate(sumArray(nSums))
@@ -1784,20 +1849,90 @@ contains
 
          call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
          call MPAS_pool_get_subpool(blockPtr % structs, "biogeochemistry", biogeochemistryPool)
+         call MPAS_pool_get_subpool(blockPtr % structs, "tracers_aggregate", tracersAggregatePool)
          call MPAS_pool_get_subpool(blockPtr % structs, "conservationCheckAM", conservationCheckAMPool)
 
+         call MPAS_pool_get_config(blockPtr % configs, "config_ratio_C_to_N_diatoms", config_ratio_C_to_N_diatoms)
+         call MPAS_pool_get_config(blockPtr % configs, "config_ratio_C_to_N_small_plankton", config_ratio_C_to_N_small_plankton)
+         call MPAS_pool_get_config(blockPtr % configs, "config_ratio_C_to_N_phaeocystis", config_ratio_C_to_N_phaeocystis)
+         call MPAS_pool_get_config(blockPtr % configs, "config_ratio_C_to_N_proteins", config_ratio_C_to_N_proteins)
+         call MPAS_pool_get_dimension(blockPtr % dimensions, "maxAlgaeType", maxAlgaeType)
+         call MPAS_pool_get_dimension(blockPtr % dimensions, "maxDOCType", maxDOCType)
+         call MPAS_pool_get_dimension(blockPtr % dimensions, "maxDICType", maxDICType)
+         call MPAS_pool_get_dimension(blockPtr % dimensions, "maxDONType", maxDONType)
+         call MPAS_pool_get_dimension(blockPtr % dimensions, "maxIronType", maxIronType)
+
+
+         call MPAS_pool_get_array(tracersAggregatePool, "iceAreaCell", iceAreaCell)
          call MPAS_pool_get_array(meshPool, "areaCell", areaCell)
          call MPAS_pool_get_array(biogeochemistryPool, "totalOceanCarbonFlux", totalOceanCarbonFlux)
+         call MPAS_pool_get_array(biogeochemistryPool, "oceanBioFluxes", oceanBioFluxes)
+         call MPAS_pool_get_array(biogeochemistryPool, "oceanAlgaeFlux", oceanAlgaeFlux)
+         call MPAS_pool_get_array(biogeochemistryPool, "oceanDOCFlux", oceanDOCFlux)
+         call MPAS_pool_get_array(biogeochemistryPool, "oceanDICFlux", oceanDICFlux)
+         call MPAS_pool_get_array(biogeochemistryPool, "oceanDONFlux", oceanDONFlux)
+         call MPAS_pool_get_array(biogeochemistryPool, "oceanHumicsFlux", oceanHumicsFlux)
          call MPAS_pool_get_array(conservationCheckAMPool, "cellInHemisphere", cellInHemisphere)
 
          do iCell = 1, nCellsSolve
 
-            ! carbon flux to ocean
-            totalOceanCarbonCell = totalOceanCarbonFlux(iCell) * areaCell(iCell)
+            ! compute total carbon flux to ocean from individual fluxes
+
+            nZBGC = 1
+            totalOceanDiatomCell = oceanAlgaeFlux(nZBGC,iCell) * areaCell(iCell) * &
+               config_ratio_C_to_N_diatoms * gramsCarbonPerMolCarbon * 1.0e-6_RKIND * &
+               iceAreaCell(iCell)
+            nZBGC = nZBGC+1
+            totalOceanSmallAlgaeCell = oceanAlgaeFlux(nZBGC,iCell) * areaCell(iCell) * &
+               config_ratio_C_to_N_small_plankton * gramsCarbonPerMolCarbon * 1.0e-6_RKIND * &
+               iceAreaCell(iCell)
+            nZBGC = 1
+            totalOceanDOC1Cell = oceanDOCFlux(nZBGC,iCell) * areaCell(iCell) * &
+               gramsCarbonPerMolCarbon * 1.0e-6_RKIND * &
+               iceAreaCell(iCell)
+            nZBGC = nZBGC+1
+            totalOceanDOC2Cell = oceanDOCFlux(nZBGC,iCell) * areaCell(iCell) * &
+               gramsCarbonPerMolCarbon * 1.0e-6_RKIND * &
+               iceAreaCell(iCell)
+
+            nZBGC = 1
+            totalOceanDICCell = oceanDICFlux(nZBGC,iCell) * areaCell(iCell) * &
+               gramsCarbonPerMolCarbon * 1.0e-6_RKIND * &
+               iceAreaCell(iCell)
+
+            nZBGC = 1
+            totalOceanDONCarbonCell = oceanDONFlux(nZBGC,iCell) * areaCell(iCell) * &
+               config_ratio_C_to_N_proteins * gramsCarbonPerMolCarbon * 1.0e-6_RKIND * &
+               iceAreaCell(iCell)
+
+            totalOceanSemiLabileDOCCell = totalOceanDONCarbonCell + totalOceanDOC1Cell + &
+               totalOceanDOC2Cell
+
+            totalOceanHumicsCell = oceanHumicsFlux(iCell) * areaCell(iCell) * &
+               gramsCarbonPerMolCarbon * 1.0e-6_RKIND * &
+               iceAreaCell(iCell)
+
+            totalOceanCarbonCellCheck = totalOceanHumicsCell + totalOceanDONCarbonCell + &
+               totalOceanDOC2Cell + totalOceanDOC1Cell + totalOceanDiatomCell + totalOceanSmallAlgaeCell + &
+               totalOceanDICCell
+
+            ! carbon flux to ocean computed in code
+            totalOceanCarbonCell = totalOceanCarbonFlux(iCell) * areaCell(iCell) * &
+               gramsCarbonPerMolCarbon * 1.0e-6_RKIND
+
             do iHemisphere = 1, nHemispheres
                iSumPrev = (iHemisphere-1) * nVars
                if (cellInHemisphere(iHemisphere,iCell) == 1) then
-                  sumArray(iHemisphere) = sumArray(iHemisphere) + totalOceanCarbonCell
+                  sumArray(iSumPrev+1) = sumArray(iSumPrev+1) + totalOceanCarbonCell
+                  sumArray(iSumPrev+2) = sumArray(iSumPrev+2) + totalOceanCarbonCellCheck
+                  sumArray(iSumPrev+3) = sumArray(iSumPrev+3) + totalOceanDiatomCell
+                  sumArray(iSumPrev+4) = sumArray(iSumPrev+4) + totalOceanSmallAlgaeCell
+                  sumArray(iSumPrev+5) = sumArray(iSumPrev+5) + totalOceanDOC1Cell
+                  sumArray(iSumPrev+6) = sumArray(iSumPrev+6) + totalOceanDOC2Cell
+                  sumArray(iSumPrev+7) = sumArray(iSumPrev+7) + totalOceanDICCell
+                  sumArray(iSumPrev+8) = sumArray(iSumPrev+8) + totalOceanDONCarbonCell
+                  sumArray(iSumPrev+9) = sumArray(iSumPrev+9) + totalOceanHumicsCell
+                  sumArray(iSumPrev+10)= sumArray(iSumPrev+10) + totalOceanSemiLabileDOCCell
                endif
             enddo ! iHemisphere
 
@@ -1811,11 +1946,29 @@ contains
 
       ! accumulate fluxes
       call MPAS_pool_get_subpool(domain % blocklist % structs, "conservationCheckCarbonAM", conservationCheckCarbonAMPool)
-
       call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsOceanCarbonFlux", carbonConsOceanCarbonFlux)
+      call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsOceanCarbonFluxCheck", carbonConsOceanCarbonFluxCheck)
+      call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsDiatomFlux", carbonConsDiatomFlux)
+      call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsSmallAlgaeFlux", carbonConsSmallAlgaeFlux)
+      call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsDOC1Flux", carbonConsDOC1Flux)
+      call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsDOC2Flux", carbonConsDOC2Flux)
+      call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsDONCarbonFlux", carbonConsDONCarbonFlux)
+      call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsDICFlux", carbonConsDICFlux)
+      call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsHumicsFlux", carbonConsHumicsFlux)
+      call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsSemiLabileDOCFlux", carbonConsSemiLabileDOCFlux)
 
       do iHemisphere = 1, nHemispheres
-         carbonConsOceanCarbonFlux(iHemisphere) = carbonConsOceanCarbonFlux(iHemisphere) + sumArrayOut(iHemisphere)
+         iSumPrev = (iHemisphere-1) * nVars
+         carbonConsOceanCarbonFlux(iHemisphere) = carbonConsOceanCarbonFlux(iHemisphere) + sumArrayOut(iSumPrev+1)
+         carbonConsOceanCarbonFluxCheck(iHemisphere) = carbonConsOceanCarbonFluxCheck(iHemisphere) + sumArrayOut(iSumPrev+2)
+         carbonConsDiatomFlux(iHemisphere) = carbonConsDiatomFlux(iHemisphere) + sumArrayOut(iSumPrev+3)
+         carbonConsSmallAlgaeFlux(iHemisphere) = carbonConsSmallAlgaeFlux(iHemisphere) + sumArrayOut(iSumPrev+4)
+         carbonConsDOC1Flux(iHemisphere) = carbonConsDOC1Flux(iHemisphere) + sumArrayOut(iSumPrev+5)
+         carbonConsDOC2Flux(iHemisphere) = carbonConsDOC2Flux(iHemisphere) + sumArrayOut(iSumPrev+6)
+         carbonConsDICFlux(iHemisphere) = carbonConsDICFlux(iHemisphere) + sumArrayOut(iSumPrev+7)
+         carbonConsDONCarbonFlux(iHemisphere) = carbonConsDONCarbonFlux(iHemisphere) + sumArrayOut(iSumPrev+8)
+         carbonConsHumicsFlux(iHemisphere) = carbonConsHumicsFlux(iHemisphere) + sumArrayOut(iSumPrev+9)
+         carbonConsSemiLabileDOCFlux(iHemisphere) = carbonConsSemiLabileDOCFlux(iHemisphere) + sumArrayOut(iSumPrev+10)
       enddo ! iHemisphere
 
       ! cleanup
@@ -1855,14 +2008,25 @@ contains
 
          ! absolute error
          call MPAS_pool_get_array(conservationCheckCarbonAMPool, "absoluteCarbonError", absoluteCarbonError)
+         call MPAS_pool_get_array(conservationCheckCarbonAMPool, "accumAbsoluteCarbonError", accumAbsoluteCarbonError)
          absoluteCarbonError(:) = netCarbonFlux(:) * dt - carbonChange(:)
 
          ! rescale fluxes
          carbonConsOceanCarbonFlux(:) = carbonConsOceanCarbonFlux(:) * fluxScale
-         netCarbonFlux(:)              = netCarbonFlux(:)              * fluxScale
+         carbonConsDiatomFlux(:) = carbonConsDiatomFlux(:) * fluxScale
+         carbonConsSmallAlgaeFlux(:) = carbonConsSmallAlgaeFlux(:) * fluxScale
+         carbonConsDOC1Flux(:) = carbonConsDOC1Flux(:) * fluxScale
+         carbonConsDOC2Flux(:) = carbonConsDOC2Flux(:) * fluxScale
+         carbonConsDONCarbonFlux(:) = carbonConsDONCarbonFlux(:) * fluxScale
+         carbonConsDICFlux(:) = carbonConsDICFlux(:) * fluxScale
+         carbonConsHumicsFlux(:) = carbonConsHumicsFlux(:) * fluxScale
+         carbonConsSemiLabileDOCFlux(:) = carbonConsSemiLabileDOCFlux(:) * fluxScale
+         carbonConsOceanCarbonFluxCheck(:) = carbonConsOceanCarbonFluxCheck(:) * fluxScale
+         netCarbonFlux(:)             = netCarbonFlux(:)             * fluxScale
 
          ! compute the final carbon error
          call MPAS_pool_get_array(conservationCheckCarbonAMPool, "relativeCarbonError", relativeCarbonError)
+         call MPAS_pool_get_array(conservationCheckCarbonAMPool, "accumRelativeCarbonError", accumRelativeCarbonError)
          do iHemisphere = 1, nHemispheres
             if (abs(finalCarbon(iHemisphere)) > 0.0) then
                relativeCarbonError(iHemisphere) = absoluteCarbonError(iHemisphere) / finalCarbon(iHemisphere)
@@ -1871,31 +2035,72 @@ contains
             endif
          enddo ! iHemisphere
 
-         !-------------------------------------------------------------
-         ! Output to log file
-         !-------------------------------------------------------------
+         call MPAS_pool_get_array(conservationCheckCarbonAMPool, "relativeErrorBounds", relativeErrorBounds)
+         relativeErrorBounds = relativeErrorBounds + relativeErrorStepBound
 
-         if (config_AM_conservationCheck_write_to_logfile) then
+         startTime = mpas_get_clock_time(domain % clock, MPAS_START_TIME, ierr=ierr)
+         currTime = mpas_get_clock_time(domain % clock, MPAS_NOW, ierr=ierr)
 
-            call mpas_log_write('-----------------------------------------------------------------------------')
-            call mpas_log_write(' Carbon conservation check')
-            call mpas_log_write(' ')
-            call mpas_log_write(' Initial carbon              (mmol) = '//trim(hemisphere_format(initialCarbon)))
-            call mpas_log_write(' Final carbon                (mmol) = '//trim(hemisphere_format(finalCarbon)))
-            call mpas_log_write(' Carbon change               (mmol) = '//trim(hemisphere_format(carbonChange)))
-            call mpas_log_write(' Carbon change flux      (mmol/m2s) = '//trim(hemisphere_format(carbonChange)))
-            call mpas_log_write(' ')
-            call mpas_log_write(' Ocean carbon flux       (mmol/m2s) = '//trim(hemisphere_format(carbonConsOceanCarbonFlux)))
-            call mpas_log_write(' ')
-            call mpas_log_write(' Net carbon change           (mmol) = '//trim(hemisphere_format((netCarbonFlux * dt) / fluxScale)))
-            call mpas_log_write(' Net carbon flux         (mmol/m2s) = '//trim(hemisphere_format(netCarbonFlux)))
-            call mpas_log_write(' ')
-            call mpas_log_write(' Absolute carbon error       (mmol) = '//trim(hemisphere_format(absoluteCarbonError)))
-            call mpas_log_write(' Absolute carbon error/s (mmol/m2s) = '//trim(hemisphere_format((absoluteCarbonError * fluxScale) / dt)))
-            call mpas_log_write(' Relative carbon error              = '//trim(hemisphere_format(relativeCarbonError)))
+         call MPAS_get_time(currTime, dateTimeString=timeStr, ierr=ierr)
+         call MPAS_get_time(startTime, dateTimeString=timeStrStart, ierr=ierr)
 
+         if (trim(timeStr) /= trim(timeStrStart)) then
+            accumRelativeCarbonError(:) = accumRelativeCarbonError(:) + relativeCarbonError(:)
+            accumAbsoluteCarbonError(:) = accumAbsoluteCarbonError(:) + absoluteCarbonError(:)
+            !-------------------------------------------------------------
+            ! Output to log file
+            !-------------------------------------------------------------
+
+            if (config_AM_conservationCheck_write_to_logfile) then
+
+               call mpas_log_write('-----------------------------------------------------------------------------')
+               call mpas_log_write(' Carbon conservation check')
+               call mpas_log_write(' ')
+               call mpas_log_write(' Initial carbon              (kg) = '//trim(hemisphere_format(initialCarbon)))
+               call mpas_log_write(' Final carbon                (kg) = '//trim(hemisphere_format(finalCarbon)))
+               call mpas_log_write(' Carbon change               (kg) = '//trim(hemisphere_format(carbonChange)))
+               call mpas_log_write(' Carbon change flux      (kg/m2s) = '//trim(hemisphere_format(carbonChangeFlux)))
+               call mpas_log_write(' ')
+               call mpas_log_write(' Ocean carbon flux       (kg/m2s) = '//trim(hemisphere_format(carbonConsOceanCarbonFlux)))
+               call mpas_log_write(' ')
+               call mpas_log_write(' Individual ocean carbon fluxes     :')
+               call mpas_log_write(' Ocean diatom flux       (kg/m2s) = '//trim(hemisphere_format(carbonConsDiatomFlux)))
+               call mpas_log_write(' Ocean small algae flux  (kg/m2s) = '//trim(hemisphere_format(carbonConsSmallAlgaeFlux)))
+               call mpas_log_write(' Ocean polysaccharid flux(kg/m2s) = '//trim(hemisphere_format(carbonConsDOC1Flux)))
+               call mpas_log_write(' Ocean lipid flux        (kg/m2s) = '//trim(hemisphere_format(carbonConsDOC2Flux)))
+               call mpas_log_write(' Ocean DIC flux          (kg/m2s) = '//trim(hemisphere_format(carbonConsDICFlux)))
+               call mpas_log_write(' Ocean DON flux          (kg/m2s) = '//trim(hemisphere_format(carbonConsDONCarbonFlux)))
+               call mpas_log_write(' Ocean humics flux       (kg/m2s) = '//trim(hemisphere_format(carbonConsHumicsFlux)))
+               call mpas_log_write(' Sum of ocean fluxes     (kg/m2s) = '//trim(hemisphere_format(carbonConsOceanCarbonFluxCheck)))
+               call mpas_log_write(' ')
+
+               call mpas_log_write(' Total semilabile DOCflux(kg/m2s) = '//trim(hemisphere_format(carbonConsSemiLabileDOCFlux)))
+               call mpas_log_write(' ')
+               call mpas_log_write(' Net carbon change           (kg) = '//trim(hemisphere_format((netCarbonFlux * dt) / fluxScale)))
+               call mpas_log_write(' Net carbon flux         (kg/m2s) = '//trim(hemisphere_format(netCarbonFlux)))
+               call mpas_log_write(' ')
+               call mpas_log_write(' Absolute carbon error       (kg) = '//trim(hemisphere_format(absoluteCarbonError)))
+               call mpas_log_write(' Absolute carbon error/s (kg/m2s) = '//trim(hemisphere_format((absoluteCarbonError * fluxScale) / dt)))
+               call mpas_log_write(' Relative carbon error            = '//trim(hemisphere_format(relativeCarbonError)))
+
+               call mpas_log_write(' ')
+               call mpas_log_write(' Total run accumulated error ')
+               call mpas_log_write(' Accum. absolute carbon error (kg)= '//trim(hemisphere_format(accumAbsoluteCarbonError)))
+               call mpas_log_write(' Accum. relative carbon error     = '//trim(hemisphere_format(accumRelativeCarbonError)))
+               write(valStr,fmt=' (es15.6)') relativeErrorBounds
+
+               call mpas_log_write(' Accum. relative error bounds     = '//trim(valStr))
+            endif
+            if ((MAXVAL(abs(accumRelativeCarbonError(:))) > relativeErrorBounds) .or. &
+                (MAXVAL(abs(relativeCarbonError(:))) > relativeErrorStepBound) ) then
+               if (config_AM_conservationCheck_carbon_failure_abort) then
+                  call mpas_log_write('maximum accumulated relative $r carbon error exceeds bounds: $r or relative carbon error $r exceeds step bounds: $r', MPAS_LOG_CRIT, &
+                     realArgs=(/MAXVAL(abs(accumRelativeCarbonError(:))), relativeErrorBounds, MAXVAL(abs(relativeCarbonError(:))), relativeErrorStepBound /))
+               else
+                  call mpas_log_write('WARNING: accumulated relative carbon error exceeds bounds ')
+               endif
+            endif
          endif
-
       endif
 
     end subroutine carbon_conservation
@@ -2299,6 +2504,9 @@ contains
 
     subroutine compute_total_carbon(domain, totalCarbon)
 
+      use seaice_constants, only: &
+           gramsCarbonPerMolCarbon
+
       type (domain_type), intent(inout) :: &
            domain
 
@@ -2358,7 +2566,8 @@ contains
          do iCell = 1, nCellsSolve
 
             ! ice carbon mass (mmols)
-            carbonCell = totalCarbonContentCell(iCell) * areaCell(iCell)
+            carbonCell = totalCarbonContentCell(iCell) * areaCell(iCell) * &
+                         gramsCarbonPerMolCarbon * 1.0e-6_RKIND
 
             do iHemisphere = 1, nHemispheres
                if (cellInHemisphere(iHemisphere,iCell) == 1) then
@@ -2693,7 +2902,16 @@ contains
            saltConsFrazilSaltFlux
 
       real(kind=RKIND), dimension(:), pointer :: &
-           carbonConsOceanCarbonFlux
+           carbonConsOceanCarbonFlux, &
+           carbonConsOceanCarbonFluxCheck, &
+           carbonConsDiatomFlux, &
+           carbonConsSmallAlgaeFlux, &
+           carbonConsDOC1Flux, &
+           carbonConsDOC2Flux, &
+           carbonConsDICFlux, &
+           carbonConsDONCarbonFlux, &
+           carbonConsHumicsFlux, &
+           carbonConsSemiLabileDOCFlux
 
       ! number of accumulations
       call MPAS_pool_get_subpool(domain % blocklist % structs, "conservationCheckAM", conservationCheckAMPool)
@@ -2758,8 +2976,26 @@ contains
       call MPAS_pool_get_subpool(domain % blocklist % structs, "conservationCheckCarbonAM", conservationCheckCarbonAMPool)
 
       call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsOceanCarbonFlux", carbonConsOceanCarbonFlux)
+      call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsOceanCarbonFluxCheck", carbonConsOceanCarbonFluxCheck)
+      call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsDiatomFlux", carbonConsDiatomFlux)
+      call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsSmallAlgaeFlux", carbonConsSmallAlgaeFlux)
+      call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsDOC1Flux", carbonConsDOC1Flux)
+      call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsDOC2Flux", carbonConsDOC2Flux)
+      call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsDICFlux", carbonConsDICFlux)
+      call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsDONCarbonFlux", carbonConsDONCarbonFlux)
+      call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsHumicsFlux", carbonConsHumicsFlux)
+      call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsSemiLabileDOCFlux", carbonConsSemiLabileDOCFlux)
 
       carbonConsOceanCarbonFlux(:)  = 0.0_RKIND
+      carbonConsOceanCarbonFluxCheck(:)  = 0.0_RKIND
+      carbonConsDiatomFlux(:)  = 0.0_RKIND
+      carbonConsSmallAlgaeFlux(:)  = 0.0_RKIND
+      carbonConsDOC1Flux(:)  = 0.0_RKIND
+      carbonConsDOC2Flux(:)  = 0.0_RKIND
+      carbonConsDICFlux(:)  = 0.0_RKIND
+      carbonConsDONCarbonFlux(:)  = 0.0_RKIND
+      carbonConsHumicsFlux(:)  = 0.0_RKIND
+      carbonConsSemiLabileDOCFlux(:)  = 0.0_RKIND
 
     end subroutine reset_accumulated_variables
 

--- a/components/mpas-seaice/src/column/constants/cesm/ice_constants_colpkg.F90
+++ b/components/mpas-seaice/src/column/constants/cesm/ice_constants_colpkg.F90
@@ -90,7 +90,8 @@
 !tcx note cice snowpatch = 0.02
 
          ! biogeochemistry
-         sk_l = 0.03_dbl_kind      ! (m) skeletal layer thickness
+         R_gC2molC = SHR_CONST_MOL_MASS_C, & ! molar mass of carbon
+         sk_l = 0.03_dbl_kind                ! (m) skeletal layer thickness
 
       integer (kind=int_kind), parameter, public :: &
          nspint = 3             ,& ! number of solar spectral intervals

--- a/components/mpas-seaice/src/column/constants/cice/ice_constants_colpkg.F90
+++ b/components/mpas-seaice/src/column/constants/cice/ice_constants_colpkg.F90
@@ -76,6 +76,7 @@
          snowpatch = 0.02_dbl_kind, & ! parameter for fractional snow area (m)
 
          ! biogeochemistry
+         R_gC2molC = 12.0107   , & ! molar mass of carbon
          sk_l = 0.03_dbl_kind      ! (m) skeletal layer thickness
 
       integer (kind=int_kind), parameter, public :: & 

--- a/components/mpas-seaice/src/column/ice_algae.F90
+++ b/components/mpas-seaice/src/column/ice_algae.F90
@@ -42,13 +42,13 @@
                          n_don,                     &
                          n_fed,        n_fep,       &
                          n_zaero,      first_ice,   &
-                         hice_old,     ocean_bio,   & 
+                         hice_old,     ocean_bio,   &
                          bphin,        iphin,       &
                          iDin,         sss,         &
                          fswthrul,                  &
                          dh_top,       dh_bot,      &
                          dh_top_chl,   dh_bot_chl,  &
-                         zfswin,                    & 
+                         zfswin,                    &
                          hbri,         hbri_old,    &
                          darcy_V,      darcy_V_chl, &
                          bgrid,        cgrid,       &
@@ -62,7 +62,10 @@
                          PP_net,       ice_bio_net, &
                          snow_bio_net, grow_net,    &
                          totalChla,                 &
-                         flux_bion,                 &
+                         flux_bion,    iSin,        &
+                         bioPorosityIceCell,        &
+                         bioSalinityIceCell,        &
+                         bioTemperatureIceCell,     &
                          l_stop,       stop_label)
 
       use ice_aerosol, only: update_snow_bgc
@@ -127,9 +130,10 @@
 
       real (kind=dbl_kind), dimension (nblyr+1), intent(in) :: &
          igrid      , & ! biology vertical interface points
-         iTin       , & ! salinity vertical interface points
+         iTin       , & ! Temperature vertical interface points
          iphin      , & ! Porosity on the igrid
-         iDin           ! Diffusivity/h on the igrid (1/s)
+         iDin       , & ! Diffusivity/h on the igrid (1/s)
+         iSin           ! Salinity on vertical interface points (ppt)
 
       real (kind=dbl_kind), dimension (nilyr+1), intent(in) :: &
          cgrid            , &  ! CICE vertical coordinate
@@ -164,6 +168,11 @@
          upNO       , & ! tot nitrate uptake rate (mmol/m^2/d) times aice
          upNH       , & ! tot ammonium uptake rate (mmol/m^2/d) times aice
          totalChla      ! total chla (mg chla/m^2)
+
+      real (kind=dbl_kind), dimension (nblyr+1), intent(inout):: &  ! diagnostics
+          bioPorosityIceCell , & ! porosity on vertical interface points
+          bioSalinityIceCell , & ! salinity on vertical interface points (ppt)
+          bioTemperatureIceCell  ! temperature on vertical interface points (oC)
 
       logical (kind=log_kind), intent(in) :: &
          first_ice      ! initialized values should be used
@@ -351,7 +360,7 @@
                                nbtrcr,       aicen,      &
                                vicen,        vsnon,      &
                                ntrcr,        iphin,      &
-                               trcrn,                    &
+                               trcrn,        aice_old,   &
                                flux_bion,    flux_bio,   &
                                upNOn,        upNHn,      &
                                upNO,         upNH,       &
@@ -360,7 +369,11 @@
                                PP_net,       ice_bio_net,&
                                snow_bio_net, grow_alg,   &
                                grow_net,     totalChla,  &
-                               nslyr)
+                               nslyr,        iTin,       &
+                               iSin,                     &
+                               bioPorosityIceCell,       &
+                               bioSalinityIceCell,       &
+                               bioTemperatureIceCell)
 
       if (write_flux_diag) then
          if (aicen > c0) then

--- a/components/mpas-seaice/src/column/ice_colpkg.F90
+++ b/components/mpas-seaice/src/column/ice_colpkg.F90
@@ -5403,7 +5403,8 @@
                            aicen_init, vicen_init, aicen, vicen, vsnon, &
                            aice0, trcrn, vsnon_init, skl_bgc, &
                            max_algae, max_nbtrcr, &
-                           flux_bion, &
+                           flux_bion, bioPorosityIceCell, &
+                           bioSalinityIceCell, bioTemperatureIceCell, &
                            l_stop, stop_label)
 
       use ice_algae, only: zbio, sklbio
@@ -5455,6 +5456,11 @@
 
       real (kind=dbl_kind), dimension (:,:), intent(out) :: &
          flux_bion      ! per categeory ice to ocean biogeochemistry flux (mmol/m2/s)
+
+      real (kind=dbl_kind), dimension (:), intent(inout) :: &
+         bioPorosityIceCell, & ! category average porosity on the interface bio grid
+         bioSalinityIceCell, & ! (ppt) category average porosity on the interface bio grid
+         bioTemperatureIceCell ! (oC) category average porosity on the interface bio grid
 
       real (kind=dbl_kind), dimension (:,:), intent(inout) :: &
          Zoo            , & ! N losses accumulated in timestep (ie. zooplankton/bacteria)
@@ -5542,10 +5548,11 @@
          iphin       , & ! porosity
          ibrine_sal  , & ! brine salinity  (ppt)
          ibrine_rho  , & ! brine_density (kg/m^3)
+         iSin        , & ! Salinity on the interface grid (ppt)
          iTin            ! Temperature on the interface grid (oC)
 
       real (kind=dbl_kind) :: &
-         sloss            ! brine flux contribution from surface runoff (g/m^2)
+         sloss           ! brine flux contribution from surface runoff (g/m^2)
 
       real (kind=dbl_kind), dimension (ncat) :: &
          hbrnInitial, & ! inital brine height
@@ -5565,6 +5572,9 @@
       zspace(nblyr+1) = p5*zspace(nblyr+1)
 
       l_stop = .false.
+      bioPorosityIceCell(:) = c0
+      bioSalinityIceCell(:) = c0
+      bioTemperatureIceCell(:) = c0
 
       do n = 1, ncat
 
@@ -5639,7 +5649,7 @@
                                 first_ice(n),     bSin,        brine_sal,         &
                                 brine_rho,        iphin,       ibrine_rho,        &
                                 ibrine_sal,       sice_rho(n), sloss,             &
-                                salinz(1:nilyr),  l_stop,      stop_label)
+                                salinz(1:nilyr),  iSin(:),     l_stop,      stop_label)
 
                   if (l_stop) return
                else
@@ -5658,7 +5668,8 @@
                                    bphi_o,        phi_snow,      bSin(:),     &
                                    brine_sal(:),  brine_rho(:),  iphin(:),    &
                                    ibrine_rho(:), ibrine_sal(:), sice_rho(n), &
-                                   iDi(:,n),      l_stop,        stop_label)
+                                   iDi(:,n),      iSin(:),       l_stop,      &
+                                   stop_label)
 
                endif ! solve_zsal
 
@@ -5756,7 +5767,9 @@
                           PP_net,                ice_bio_net (:),        &
                           snow_bio_net(:),       grow_net,               &
                           totalChla,                                     &
-                          flux_bion(:,n),                                &
+                          flux_bion(:,n),        iSin,                   &
+                          bioPorosityIceCell(:), bioSalinityIceCell(:),  &
+                          bioTemperatureIceCell(:),                      &
                           l_stop,                stop_label)
 
                if (l_stop) return

--- a/components/mpas-seaice/src/shared/mpas_seaice_column.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_column.F
@@ -3584,6 +3584,7 @@ contains
     type(MPAS_pool_type), pointer :: &
          mesh, &
          biogeochemistry, &
+         diagnostics_biogeochemistry, &
          icestate, &
          tracers, &
          shortwave, &
@@ -3708,6 +3709,11 @@ contains
          oceanBioFluxesCategory, &
          brineFraction
 
+    real(kind=RKIND), dimension(:,:), pointer :: &
+         bgridTemperatureIceCell, &
+         bgridSalinityIceCell, &
+         bgridPorosityIceCell
+
     integer, dimension(:,:), pointer :: &
          newlyFormedIce
 
@@ -3775,6 +3781,7 @@ contains
        call MPAS_pool_get_subpool(block % structs, "icestate", icestate)
        call MPAS_pool_get_subpool(block % structs, "tracers", tracers)
        call MPAS_pool_get_subpool(block % structs, "biogeochemistry", biogeochemistry)
+       call MPAS_pool_get_subpool(block % structs, "diagnostics_biogeochemistry", diagnostics_biogeochemistry)
        call MPAS_pool_get_subpool(block % structs, "shortwave", shortwave)
        call MPAS_pool_get_subpool(block % structs, "atmos_coupling", atmos_coupling)
        call MPAS_pool_get_subpool(block % structs, "melt_growth_rates", melt_growth_rates)
@@ -3863,6 +3870,10 @@ contains
        call MPAS_pool_get_array(biogeochemistry, "oceanDMSPConc",oceanDMSPConc)
        call MPAS_pool_get_array(biogeochemistry, "oceanHumicsConc",oceanHumicsConc)
        call MPAS_pool_get_array(biogeochemistry, "oceanZAerosolConc",oceanZAerosolConc)
+
+       call MPAS_pool_get_array(diagnostics_biogeochemistry, "bgridPorosityIceCell",bgridPorosityIceCell)
+       call MPAS_pool_get_array(diagnostics_biogeochemistry, "bgridSalinityIceCell",bgridSalinityIceCell)
+       call MPAS_pool_get_array(diagnostics_biogeochemistry, "bgridTemperatureIceCell",bgridTemperatureIceCell)
 
        call MPAS_pool_get_array(ocean_coupling, "seaSurfaceTemperature", seaSurfaceTemperature)
        call MPAS_pool_get_array(ocean_coupling, "seaSurfaceSalinity", seaSurfaceSalinity)
@@ -4052,6 +4063,9 @@ contains
                maxAlgaeType, &
                nZBGCTracers, &
                oceanBioFluxesCategory(:,:,iCell), &
+               bgridPorosityIceCell(:,iCell), &
+               bgridSalinityIceCell(:,iCell), &
+               bgridTemperatureIceCell(:,iCell), &
                abortFlag, &
                abortMessage)
           call column_write_warnings(abortFlag)
@@ -13023,6 +13037,7 @@ contains
 
     type(MPAS_pool_type), pointer :: &
          biogeochemistry, &
+         diagnostics_biogeochemistry, &
          ocean_coupling, &
          tracers
 
@@ -13129,6 +13144,7 @@ contains
     do while (associated(block))
 
        call MPAS_pool_get_subpool(block % structs, "biogeochemistry", biogeochemistry)
+       call MPAS_pool_get_subpool(block % structs, "diagnostics_biogeochemistry", diagnostics_biogeochemistry)
 
        call MPAS_pool_get_array(biogeochemistry, "bioPorosity", bioPorosity)
        call MPAS_pool_get_array(biogeochemistry, "bioDiffusivity", bioDiffusivity)
@@ -13138,6 +13154,7 @@ contains
        call MPAS_pool_get_array(biogeochemistry, "oceanBioConcentrations", oceanBioConcentrations)
        call MPAS_pool_get_array(biogeochemistry, "totalVerticalBiologyIce", totalVerticalBiologyIce)
        call MPAS_pool_get_array(biogeochemistry, "totalVerticalBiologySnow", totalVerticalBiologySnow)
+
        call MPAS_pool_get_array(biogeochemistry, "bioTracerShortwave", bioTracerShortwave)
        call MPAS_pool_get_array(biogeochemistry, "interfaceBiologyGrid", interfaceBiologyGrid)
        call MPAS_pool_get_array(biogeochemistry, "interfaceGrid", interfaceGrid)
@@ -13194,7 +13211,6 @@ contains
             config_snow_porosity_at_ice_surface)
 
        do iCell = 1, nCellsSolve
-
           if (.not. config_do_restart_hbrine) then
              ! initialize newly formed ice
              newlyFormedIce(:,iCell) = 1
@@ -13747,7 +13763,8 @@ contains
     type(block_type), pointer :: block
 
     type(MPAS_pool_type), pointer :: &
-         biogeochemistryPool
+         biogeochemistryPool, &
+         diagnostics_biogeochemistryPool
 
     ! biogeochemistry
     real(kind=RKIND), dimension(:), pointer :: &
@@ -13764,7 +13781,10 @@ contains
          atmosIceBioFluxes, &
          snowIceBioFluxes, &
          totalVerticalBiologyIce, &
-         totalVerticalBiologySnow
+         totalVerticalBiologySnow, &
+         bgridPorosityIceCell, &
+         bgridSalinityIceCell, &
+         bgridTemperatureIceCell
 
     real(kind=RKIND), dimension(:,:,:), pointer :: &
          bioTracerShortwave
@@ -13791,15 +13811,22 @@ contains
           if (config_use_column_biogeochemistry) then
 
              call MPAS_pool_get_subpool(block % structs, "biogeochemistry", biogeochemistryPool)
+             call MPAS_pool_get_subpool(block % structs, "diagnostics_biogeochemistry", diagnostics_biogeochemistryPool)
 
              if (config_use_vertical_biochemistry) then
                 call MPAS_pool_get_array(biogeochemistryPool, "primaryProduction", primaryProduction)
                 call MPAS_pool_get_array(biogeochemistryPool, "totalChlorophyll", totalChlorophyll)
                 call MPAS_pool_get_array(biogeochemistryPool, "netSpecificAlgalGrowthRate", netSpecificAlgalGrowthRate)
+                call MPAS_pool_get_array(diagnostics_biogeochemistryPool, "bgridSalinityIceCell", bgridSalinityIceCell)
+                call MPAS_pool_get_array(diagnostics_biogeochemistryPool, "bgridPorosityIceCell", bgridPorosityIceCell)
+                call MPAS_pool_get_array(diagnostics_biogeochemistryPool, "bgridTemperatureIceCell", bgridTemperatureIceCell)
 
                 primaryProduction          = 0.0_RKIND
                 totalChlorophyll           = 0.0_RKIND
                 netSpecificAlgalGrowthRate = 0.0_RKIND
+                bgridSalinityIceCell       = 0.0_RKIND
+                bgridPorosityIceCell       = 0.0_RKIND
+                bgridTemperatureIceCell    = 0.0_RKIND
 
              end if
 
@@ -13819,6 +13846,7 @@ contains
              call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalBiologyIce", totalVerticalBiologyIce)
              call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalBiologySnow", totalVerticalBiologySnow)
              call MPAS_pool_get_array(biogeochemistryPool, "totalCarbonContentCell", totalCarbonContentCell)
+
 
              netBrineHeight             = 0.0_RKIND
              oceanBioFluxes             = 0.0_RKIND

--- a/components/mpas-seaice/src/shared/mpas_seaice_constants.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_constants.F
@@ -34,7 +34,8 @@ module seaice_constants
        vonkar, &
        iceruf, &
        zref, &
-       sk_l
+       sk_l, &
+       R_gC2molC
 
   private
   save
@@ -93,7 +94,8 @@ module seaice_constants
 
    ! biogeochemistry constants
    real(kind=RKIND), parameter, public :: &
-        skeletalLayerThickness = sk_l
+        skeletalLayerThickness = sk_l      , &
+        gramsCarbonPerMolCarbon = R_gC2molC    ! g carbon per mol carbon
 
 
 end module seaice_constants

--- a/components/mpas-seaice/testing_and_setup/configurations/aerosol_shortwave_physics/namelist.seaice
+++ b/components/mpas-seaice/testing_and_setup/configurations/aerosol_shortwave_physics/namelist.seaice
@@ -381,6 +381,7 @@
     config_AM_conservationCheck_compute_on_startup = false
     config_AM_conservationCheck_write_on_startup = false
     config_AM_conservationCheck_write_to_logfile = true
+    config_AM_conservationCheck_carbon_failure_abort = false
 /
 &AM_geographicalVectors
     config_AM_geographicalVectors_enable = false

--- a/components/mpas-seaice/testing_and_setup/configurations/prescribed_ice/namelist.seaice
+++ b/components/mpas-seaice/testing_and_setup/configurations/prescribed_ice/namelist.seaice
@@ -382,6 +382,7 @@
     config_AM_conservationCheck_compute_on_startup = false
     config_AM_conservationCheck_write_on_startup = false
     config_AM_conservationCheck_write_to_logfile = true
+    config_AM_conservationCheck_carbon_failure_abort = false
 /
 &AM_geographicalVectors
     config_AM_geographicalVectors_enable = false

--- a/components/mpas-seaice/testing_and_setup/configurations/snicar_shortwave/namelist.seaice
+++ b/components/mpas-seaice/testing_and_setup/configurations/snicar_shortwave/namelist.seaice
@@ -382,6 +382,7 @@
     config_AM_conservationCheck_compute_on_startup = false
     config_AM_conservationCheck_write_on_startup = false
     config_AM_conservationCheck_write_to_logfile = true
+    config_AM_conservationCheck_carbon_failure_abort = false
 /
 &AM_geographicalVectors
     config_AM_geographicalVectors_enable = false

--- a/components/mpas-seaice/testing_and_setup/configurations/snow_tracer_physics/namelist.seaice
+++ b/components/mpas-seaice/testing_and_setup/configurations/snow_tracer_physics/namelist.seaice
@@ -382,6 +382,7 @@
     config_AM_conservationCheck_compute_on_startup = false
     config_AM_conservationCheck_write_on_startup = false
     config_AM_conservationCheck_write_to_logfile = true
+    config_AM_conservationCheck_carbon_failure_abort = false
 /
 &AM_geographicalVectors
     config_AM_geographicalVectors_enable = false

--- a/components/mpas-seaice/testing_and_setup/configurations/standard_bgc/namelist.seaice
+++ b/components/mpas-seaice/testing_and_setup/configurations/standard_bgc/namelist.seaice
@@ -381,6 +381,7 @@
     config_AM_conservationCheck_compute_on_startup = false
     config_AM_conservationCheck_write_on_startup = false
     config_AM_conservationCheck_write_to_logfile = true
+    config_AM_conservationCheck_carbon_failure_abort = true
 /
 &AM_geographicalVectors
     config_AM_geographicalVectors_enable = false

--- a/components/mpas-seaice/testing_and_setup/configurations/standard_physics/namelist.seaice
+++ b/components/mpas-seaice/testing_and_setup/configurations/standard_physics/namelist.seaice
@@ -376,12 +376,13 @@
     config_AM_ridgingDiagnostics_write_on_startup = false
 /
 &AM_conservationCheck
-    config_AM_conservationCheck_enable = false
+    config_AM_conservationCheck_enable = true
     config_AM_conservationCheck_compute_interval = 'dt'
     config_AM_conservationCheck_output_stream = 'conservationCheckOutput'
     config_AM_conservationCheck_compute_on_startup = false
     config_AM_conservationCheck_write_on_startup = false
     config_AM_conservationCheck_write_to_logfile = true
+    config_AM_conservationCheck_carbon_failure_abort = false
 /
 &AM_geographicalVectors
     config_AM_geographicalVectors_enable = false

--- a/components/mpas-seaice/testing_and_setup/configurations/standard_physics/namelist.seaice
+++ b/components/mpas-seaice/testing_and_setup/configurations/standard_physics/namelist.seaice
@@ -376,7 +376,7 @@
     config_AM_ridgingDiagnostics_write_on_startup = false
 /
 &AM_conservationCheck
-    config_AM_conservationCheck_enable = true
+    config_AM_conservationCheck_enable = false
     config_AM_conservationCheck_compute_interval = 'dt'
     config_AM_conservationCheck_output_stream = 'conservationCheckOutput'
     config_AM_conservationCheck_compute_on_startup = false

--- a/components/mpas-seaice/testing_and_setup/configurations/standard_physics_single_cell/namelist.seaice
+++ b/components/mpas-seaice/testing_and_setup/configurations/standard_physics_single_cell/namelist.seaice
@@ -375,6 +375,7 @@
     config_AM_conservationCheck_compute_on_startup = false
     config_AM_conservationCheck_write_on_startup = false
     config_AM_conservationCheck_write_to_logfile = true
+    config_AM_conservationCheck_carbon_failure_abort = false
 /
 &AM_geographicalVectors
     config_AM_geographicalVectors_enable = false

--- a/components/mpas-seaice/testing_and_setup/testcases/advection/namelist.seaice.advection
+++ b/components/mpas-seaice/testing_and_setup/testcases/advection/namelist.seaice.advection
@@ -381,6 +381,7 @@
     config_AM_conservationCheck_compute_on_startup = false
     config_AM_conservationCheck_write_on_startup = false
     config_AM_conservationCheck_write_to_logfile = true
+    config_AM_conservationCheck_carbon_failure_abort = false
 /
 &AM_geographicalVectors
     config_AM_geographicalVectors_enable = false

--- a/components/mpas-seaice/testing_and_setup/testcases/error_analysis/namelist.seaice.strain
+++ b/components/mpas-seaice/testing_and_setup/testcases/error_analysis/namelist.seaice.strain
@@ -382,6 +382,7 @@
     config_AM_conservationCheck_compute_on_startup = false
     config_AM_conservationCheck_write_on_startup = false
     config_AM_conservationCheck_write_to_logfile = true
+    config_AM_conservationCheck_carbon_failure_abort = false
 /
 &AM_geographicalVectors
     config_AM_geographicalVectors_enable = false

--- a/components/mpas-seaice/testing_and_setup/testcases/ridging_1D/namelist.seaice.ridging_1D
+++ b/components/mpas-seaice/testing_and_setup/testcases/ridging_1D/namelist.seaice.ridging_1D
@@ -384,6 +384,7 @@
     config_AM_conservationCheck_compute_on_startup = false
     config_AM_conservationCheck_write_on_startup = false
     config_AM_conservationCheck_write_to_logfile = true
+    config_AM_conservationCheck_carbon_failure_abort = false
 /
 &AM_geographicalVectors
     config_AM_geographicalVectors_enable = false

--- a/components/mpas-seaice/testing_and_setup/testcases/ridging_island/namelist.seaice.ridging_island
+++ b/components/mpas-seaice/testing_and_setup/testcases/ridging_island/namelist.seaice.ridging_island
@@ -382,6 +382,7 @@
     config_AM_conservationCheck_compute_on_startup = false
     config_AM_conservationCheck_write_on_startup = false
     config_AM_conservationCheck_write_to_logfile = true
+    config_AM_conservationCheck_carbon_failure_abort = false
 /
 &AM_geographicalVectors
     config_AM_geographicalVectors_enable = false

--- a/components/mpas-seaice/testing_and_setup/testcases/spherical_operators/strain/namelist.seaice.strain
+++ b/components/mpas-seaice/testing_and_setup/testcases/spherical_operators/strain/namelist.seaice.strain
@@ -382,6 +382,7 @@
     config_AM_conservationCheck_compute_on_startup = false
     config_AM_conservationCheck_write_on_startup = false
     config_AM_conservationCheck_write_to_logfile = true
+    config_AM_conservationCheck_carbon_failure_abort = false
 /
 &AM_geographicalVectors
     config_AM_geographicalVectors_enable = false

--- a/components/mpas-seaice/testing_and_setup/testcases/spherical_operators/strain_stress_divergence/namelist.seaice.strain_stress_divergence
+++ b/components/mpas-seaice/testing_and_setup/testcases/spherical_operators/strain_stress_divergence/namelist.seaice.strain_stress_divergence
@@ -382,6 +382,7 @@
     config_AM_conservationCheck_compute_on_startup = false
     config_AM_conservationCheck_write_on_startup = false
     config_AM_conservationCheck_write_to_logfile = true
+    config_AM_conservationCheck_carbon_failure_abort = false
 /
 &AM_geographicalVectors
     config_AM_geographicalVectors_enable = false

--- a/components/mpas-seaice/testing_and_setup/testcases/spherical_operators/stress_divergence/namelist.seaice.stress_divergence
+++ b/components/mpas-seaice/testing_and_setup/testcases/spherical_operators/stress_divergence/namelist.seaice.stress_divergence
@@ -382,6 +382,7 @@
     config_AM_conservationCheck_compute_on_startup = false
     config_AM_conservationCheck_write_on_startup = false
     config_AM_conservationCheck_write_to_logfile = true
+    config_AM_conservationCheck_carbon_failure_abort = false
 /
 &AM_geographicalVectors
     config_AM_geographicalVectors_enable = false

--- a/components/mpas-seaice/testing_and_setup/testcases/square/1D_velocity_hex/namelist.seaice.square
+++ b/components/mpas-seaice/testing_and_setup/testcases/square/1D_velocity_hex/namelist.seaice.square
@@ -382,6 +382,7 @@
     config_AM_conservationCheck_compute_on_startup = false
     config_AM_conservationCheck_write_on_startup = false
     config_AM_conservationCheck_write_to_logfile = true
+    config_AM_conservationCheck_carbon_failure_abort = false
 /
 &AM_geographicalVectors
     config_AM_geographicalVectors_enable = false

--- a/components/mpas-seaice/testing_and_setup/testcases/square/1D_velocity_quad/namelist.seaice.square
+++ b/components/mpas-seaice/testing_and_setup/testcases/square/1D_velocity_quad/namelist.seaice.square
@@ -382,6 +382,7 @@
     config_AM_conservationCheck_compute_on_startup = false
     config_AM_conservationCheck_write_on_startup = false
     config_AM_conservationCheck_write_to_logfile = true
+    config_AM_conservationCheck_carbon_failure_abort = false
 /
 &AM_geographicalVectors
     config_AM_geographicalVectors_enable = false

--- a/components/mpas-seaice/testing_and_setup/testcases/square/operators_strain/namelist.seaice.strain
+++ b/components/mpas-seaice/testing_and_setup/testcases/square/operators_strain/namelist.seaice.strain
@@ -382,6 +382,7 @@
     config_AM_conservationCheck_compute_on_startup = false
     config_AM_conservationCheck_write_on_startup = false
     config_AM_conservationCheck_write_to_logfile = true
+    config_AM_conservationCheck_carbon_failure_abort = false
 /
 &AM_geographicalVectors
     config_AM_geographicalVectors_enable = false

--- a/components/mpas-seaice/testing_and_setup/testcases/square/operators_strain_stress_divergence/namelist.seaice.strain_stress_divergence
+++ b/components/mpas-seaice/testing_and_setup/testcases/square/operators_strain_stress_divergence/namelist.seaice.strain_stress_divergence
@@ -382,6 +382,7 @@
     config_AM_conservationCheck_compute_on_startup = false
     config_AM_conservationCheck_write_on_startup = false
     config_AM_conservationCheck_write_to_logfile = true
+    config_AM_conservationCheck_carbon_failure_abort = false
 /
 &AM_geographicalVectors
     config_AM_geographicalVectors_enable = false

--- a/components/mpas-seaice/testing_and_setup/testcases/square/operators_stress_divergence/namelist.seaice.stress_divergence
+++ b/components/mpas-seaice/testing_and_setup/testcases/square/operators_stress_divergence/namelist.seaice.stress_divergence
@@ -382,6 +382,7 @@
     config_AM_conservationCheck_compute_on_startup = false
     config_AM_conservationCheck_write_on_startup = false
     config_AM_conservationCheck_write_to_logfile = true
+    config_AM_conservationCheck_carbon_failure_abort = false
 /
 &AM_geographicalVectors
     config_AM_geographicalVectors_enable = false

--- a/components/mpas-seaice/testing_and_setup/testcases/square/square_hex_sb/namelist.seaice.square
+++ b/components/mpas-seaice/testing_and_setup/testcases/square/square_hex_sb/namelist.seaice.square
@@ -381,6 +381,7 @@
     config_AM_conservationCheck_compute_on_startup = false
     config_AM_conservationCheck_write_on_startup = false
     config_AM_conservationCheck_write_to_logfile = true
+    config_AM_conservationCheck_carbon_failure_abort = false
 /
 &AM_geographicalVectors
     config_AM_geographicalVectors_enable = false

--- a/components/mpas-seaice/testing_and_setup/testcases/square/square_quadhex/namelist.seaice.square
+++ b/components/mpas-seaice/testing_and_setup/testcases/square/square_quadhex/namelist.seaice.square
@@ -382,6 +382,7 @@
     config_AM_conservationCheck_compute_on_startup = false
     config_AM_conservationCheck_write_on_startup = false
     config_AM_conservationCheck_write_to_logfile = true
+    config_AM_conservationCheck_carbon_failure_abort = false
 /
 &AM_geographicalVectors
     config_AM_geographicalVectors_enable = false

--- a/components/mpas-seaice/testing_and_setup/testing/DATA/get_data.py
+++ b/components/mpas-seaice/testing_and_setup/testing/DATA/get_data.py
@@ -50,9 +50,9 @@ manifestFile = open("manifest","r")
 
 filenames = manifestFile.readlines()
 for filename in filenames:
-    if (not os.path.exists(os.path.dirname(string.strip(filename)))):
-        os.makedirs(os.path.dirname(string.strip(filename)))
-    download_file(url + string.strip(filename), string.strip(filename), proxy)
+    if (not os.path.exists(os.path.dirname(filename.strip()))):
+        os.makedirs(os.path.dirname(filename.strip()))
+    download_file(url + filename.strip(), filename.strip(), proxy)
 
 manifestFile.close()
     

--- a/share/util/shr_const_mod.F90
+++ b/share/util/shr_const_mod.F90
@@ -24,6 +24,7 @@ MODULE shr_const_mod
    real(R8),parameter :: SHR_CONST_BOLTZ   = 1.38065e-23_R8  ! Boltzmann's constant ~ J/K/molecule
    real(R8),parameter :: SHR_CONST_AVOGAD  = 6.02214e26_R8   ! Avogadro's number ~ molecules/kmole
    real(R8),parameter :: SHR_CONST_RGAS    = SHR_CONST_AVOGAD*SHR_CONST_BOLTZ       ! Universal gas constant ~ J/K/kmole
+   real(R8),parameter :: SHR_CONST_MOL_MASS_C = 12.0107_R8   ! carbon molar mass
    real(R8),parameter :: SHR_CONST_MWDAIR  = 28.966_R8       ! molecular weight dry air ~ kg/kmole
    real(R8),parameter :: SHR_CONST_MWWV    = 18.016_R8       ! molecular weight water vapor
    real(R8),parameter :: SHR_CONST_RDAIR   = SHR_CONST_RGAS/SHR_CONST_MWDAIR        ! Dry air gas constant     ~ J/K/kg


### PR DESCRIPTION
1. tracks individual ocean-ice carbon  fluxes
2. computes accumulated error, relative errors, error bounds over the run
3. adds flag option to end the run if carbon errors exceed bounds
4. Also added three additional diagnostics
5. Adds molecular weight of carbon as a shared constant for all carbon conservation calculations
6. Non-BFB change is a correction in merge-fluxes-bgc which uses the initial ice area to merge BGC fluxes rather than the ice area after step therm 1.

Passes all tests in the sea ice testing suite. 

[NML]
[non-BFB] only for runs with active sea ice BGC.