### PR TITLE
Add explicit layerThicknessEdge variables

### DIFF
--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1010,7 +1010,7 @@
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_thickness_flux_type" type="character" default_value="centered" units="unitless"
-					description="If 'upwind', use upwind to evaluate the edge-value for layerThickness, i.e., layerThicknessEdge.  The standard MPAS-O approach is 'centered'."
+					description="If 'upwind', use upwind to evaluate the edge-value for layerThickness, i.e., layerThickEdgeFlux.  The standard MPAS-O approach is 'centered'."
 					possible_values="'upwind', 'centered'"
 		/>
 		<nml_option name="config_drying_safety_height" type="real" default_value="1.0e-10" units="m"
@@ -2559,8 +2559,12 @@
 			 description="horizontal velocity, tangential to an edge"
 			 packages="forwardMode;analysisMode"
 		/>
-		<var name="layerThicknessEdge" type="real" dimensions="nVertLevels nEdges Time" units="m"
+		<var name="layerThicknessEdgeCenter" type="real" dimensions="nVertLevels nEdges Time" units="m"
 			 description="layer thickness averaged from cell center to edges"
+			 packages="forwardMode;analysisMode"
+		/>
+		<var name="layerThicknessEdgeFlux" type="real" dimensions="nVertLevels nEdges Time" units="m"
+			 description="layer thickness used for fluxes through edges. May be centered, upwinded, or a combination of the two."
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="layerThicknessVertex" type="real" dimensions="nVertLevels nVertices Time" units="m"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2559,7 +2559,7 @@
 			 description="horizontal velocity, tangential to an edge"
 			 packages="forwardMode;analysisMode"
 		/>
-		<var name="layerThicknessEdgeCenter" type="real" dimensions="nVertLevels nEdges Time" units="m"
+		<var name="layerThicknessEdgeMean" type="real" dimensions="nVertLevels nEdges Time" units="m"
 			 description="layer thickness averaged from cell center to edges"
 			 packages="forwardMode;analysisMode"
 		/>

--- a/components/mpas-ocean/src/analysis_members/Registry_global_stats.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_global_stats.xml
@@ -71,7 +71,7 @@
 				 description="Minimum global value of tangentialVelocity on ocean edges."
 			/>
 			<var name="layerThicknessEdgeMin" array_group="mins" units="m"
-				 description="Minimum global value of layerThicknessEdge on ocean edges."
+				 description="Minimum global value of layerThicknessEdgeFlux on ocean edges."
 			/>
 			<var name="relativeVorticityMin" array_group="mins" units="s^{-1}"
 				 description="Minimum global value of relativeVorticity on ocean vertices."
@@ -170,7 +170,7 @@
 				 description="Maximum global value of tangentialVelocity on ocean edges."
 			/>
 			<var name="layerThicknessEdgeMax" array_group="maxes" units="m"
-				 description="Maximum global value of layerThicknessEdge on ocean edges."
+				 description="Maximum global value of layerThicknessEdgeFlux on ocean edges."
 			/>
 			<var name="relativeVorticityMax" array_group="maxes" units="s^{-1}"
 				 description="Maximum global value of relativeVorticity on ocean vertices."
@@ -269,7 +269,7 @@
 				 description="Accumulated global value of tangentialVelocity on ocean edges."
 			/>
 			<var name="layerThicknessEdgeSum" array_group="sums" units="m^3"
-				 description="Accumulated global value of layerThicknessEdge on ocean edges."
+				 description="Accumulated global value of layerThicknessEdgeFlux on ocean edges."
 			/>
 			<var name="relativeVorticitySum" array_group="sums" units="m^2 s^{-1}"
 				 description="Accumulated global value of relativeVorticity on ocean vertices."
@@ -368,7 +368,7 @@
 				 description="Global root mean square value of tangentialVelocity on ocean edges."
 			/>
 			<var name="layerThicknessEdgeRms" array_group="rms" units="m"
-				 description="Global root mean square value of layerThicknessEdge on ocean edges."
+				 description="Global root mean square value of layerThicknessEdgeFlux on ocean edges."
 			/>
 			<var name="relativeVorticityRms" array_group="rms" units="s^{-1}"
 				 description="Global root mean square value of relativeVorticity on ocean vertices."
@@ -467,7 +467,7 @@
 				 description="Average value of tangentialVelocity on ocean edges."
 			/>
 			<var name="layerThicknessEdgeAvg" array_group="avg" units="m"
-				 description="Average value of layerThicknessEdge on ocean edges."
+				 description="Average value of layerThicknessEdgeFlux on ocean edges."
 			/>
 			<var name="relativeVorticityAvg" array_group="avg" units="s^{-1}"
 				 description="Average value of relativeVorticity on ocean vertices."
@@ -566,7 +566,7 @@
 				 description="Minimum vertical sum of tangentialVelocity on ocean edges."
 			/>
 			<var name="layerThicknessEdgeMinVertSum" array_group="vertSumMin" units="m"
-				 description="Minimum vertical sum of layerThicknessEdge on ocean edges."
+				 description="Minimum vertical sum of layerThicknessEdgeFlux on ocean edges."
 			/>
 			<var name="relativeVorticityMinVertSum" array_group="vertSumMin" units="s^{-1}"
 				 description="Minimum vertical sum of relativeVorticity on ocean vertices."
@@ -665,7 +665,7 @@
 				 description="Maximum vertical sum of tangentialVelocity on ocean edges."
 			/>
 			<var name="layerThicknessEdgeMaxVertSum" array_group="vertSumMax" units="m"
-				 description="Maximum vertical sum of layerThicknessEdge on ocean edges."
+				 description="Maximum vertical sum of layerThicknessEdgeFlux on ocean edges."
 			/>
 			<var name="relativeVorticityMaxVertSum" array_group="vertSumMax" units="s^{-1}"
 				 description="Maximum vertical sum of relativeVorticity on ocean vertices."

--- a/components/mpas-ocean/src/analysis_members/Registry_global_stats.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_global_stats.xml
@@ -70,9 +70,6 @@
 			<var name="tangentialVelocityMin" array_group="mins" units="m s^{-1}"
 				 description="Minimum global value of tangentialVelocity on ocean edges."
 			/>
-			<var name="layerThicknessEdgeMin" array_group="mins" units="m"
-				 description="Minimum global value of layerThicknessEdgeFlux on ocean edges."
-			/>
 			<var name="relativeVorticityMin" array_group="mins" units="s^{-1}"
 				 description="Minimum global value of relativeVorticity on ocean vertices."
 			/>
@@ -168,9 +165,6 @@
 			/>
 			<var name="tangentialVelocityMax" array_group="maxes" units="m s^{-1}"
 				 description="Maximum global value of tangentialVelocity on ocean edges."
-			/>
-			<var name="layerThicknessEdgeMax" array_group="maxes" units="m"
-				 description="Maximum global value of layerThicknessEdgeFlux on ocean edges."
 			/>
 			<var name="relativeVorticityMax" array_group="maxes" units="s^{-1}"
 				 description="Maximum global value of relativeVorticity on ocean vertices."
@@ -268,9 +262,6 @@
 			<var name="tangentialVelocitySum" array_group="sums" units="m^4 s^{-1}"
 				 description="Accumulated global value of tangentialVelocity on ocean edges."
 			/>
-			<var name="layerThicknessEdgeSum" array_group="sums" units="m^3"
-				 description="Accumulated global value of layerThicknessEdgeFlux on ocean edges."
-			/>
 			<var name="relativeVorticitySum" array_group="sums" units="m^2 s^{-1}"
 				 description="Accumulated global value of relativeVorticity on ocean vertices."
 			/>
@@ -366,9 +357,6 @@
 			/>
 			<var name="tangentialVelocityRms" array_group="rms" units="m s^{-1}"
 				 description="Global root mean square value of tangentialVelocity on ocean edges."
-			/>
-			<var name="layerThicknessEdgeRms" array_group="rms" units="m"
-				 description="Global root mean square value of layerThicknessEdgeFlux on ocean edges."
 			/>
 			<var name="relativeVorticityRms" array_group="rms" units="s^{-1}"
 				 description="Global root mean square value of relativeVorticity on ocean vertices."
@@ -466,9 +454,6 @@
 			<var name="tangentialVelocityAvg" array_group="avg" units="m s^{-1}"
 				 description="Average value of tangentialVelocity on ocean edges."
 			/>
-			<var name="layerThicknessEdgeAvg" array_group="avg" units="m"
-				 description="Average value of layerThicknessEdgeFlux on ocean edges."
-			/>
 			<var name="relativeVorticityAvg" array_group="avg" units="s^{-1}"
 				 description="Average value of relativeVorticity on ocean vertices."
 			/>
@@ -565,9 +550,6 @@
 			<var name="tangentialVelocityMinVertSum" array_group="vertSumMin" units="m^2 s^{-1}"
 				 description="Minimum vertical sum of tangentialVelocity on ocean edges."
 			/>
-			<var name="layerThicknessEdgeMinVertSum" array_group="vertSumMin" units="m"
-				 description="Minimum vertical sum of layerThicknessEdgeFlux on ocean edges."
-			/>
 			<var name="relativeVorticityMinVertSum" array_group="vertSumMin" units="s^{-1}"
 				 description="Minimum vertical sum of relativeVorticity on ocean vertices."
 			/>
@@ -663,9 +645,6 @@
 			/>
 			<var name="tangentialVelocityMaxVertSum" array_group="vertSumMax" units="m^2 s^{-1}"
 				 description="Maximum vertical sum of tangentialVelocity on ocean edges."
-			/>
-			<var name="layerThicknessEdgeMaxVertSum" array_group="vertSumMax" units="m"
-				 description="Maximum vertical sum of layerThicknessEdgeFlux on ocean edges."
 			/>
 			<var name="relativeVorticityMaxVertSum" array_group="vertSumMax" units="s^{-1}"
 				 description="Maximum vertical sum of relativeVorticity on ocean vertices."

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_global_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_global_stats.F
@@ -125,7 +125,7 @@ contains
             write (fileID,'(i5,a)') i,'. layerThickness'; i=i+1
             write (fileID,'(i5,a)') i,'. normalVelocity'; i=i+1
             write (fileID,'(i5,a)') i,'. tangentialVelocity'; i=i+1
-            write (fileID,'(i5,a)') i,'. layerThicknessEdge'; i=i+1
+            write (fileID,'(i5,a)') i,'. layerThicknessEdgeFlux'; i=i+1
             write (fileID,'(i5,a)') i,'. relativeVorticity'; i=i+1
             write (fileID,'(i5,a)') i,'. enstrophy = relativeVorticity**2'; i=i+1
             write (fileID,'(i5,a)') i,'. kineticEnergyCell'; i=i+1
@@ -409,7 +409,7 @@ contains
          variableIndex = variableIndex + 1
          call ocn_compute_field_volume_weighted_local_stats_max_level(dminfo, nVertLevels, nEdgesSolve, &
                               minLevelEdgeBot(1:nEdgesSolve), maxLevelEdgeTop(1:nEdgesSolve), areaEdge(1:nEdgesSolve), &
-                              layerThickEdge(:,1:nEdgesSolve), &
+                              layerThickEdgeFlux(:,1:nEdgesSolve), &
                               normalVelocity(:,1:nEdgesSolve), sums_tmp(variableIndex), &
                               sumSquares_tmp(variableIndex), mins_tmp(variableIndex), &
                               maxes_tmp(variableIndex), &
@@ -426,7 +426,7 @@ contains
          variableIndex = variableIndex + 1
          call ocn_compute_field_volume_weighted_local_stats_max_level(dminfo, nVertLevels, nEdgesSolve, &
                               minLevelEdgeBot(1:nEdgesSolve), maxLevelEdgeTop(1:nEdgesSolve), areaEdge(1:nEdgesSolve), &
-                              layerThickEdge(:,1:nEdgesSolve), &
+                              layerThickEdgeFlux(:,1:nEdgesSolve), &
                               tangentialVelocity(:,1:nEdgesSolve), &
                               sums_tmp(variableIndex), sumSquares_tmp(variableIndex), &
                               mins_tmp(variableIndex), maxes_tmp(variableIndex), &
@@ -439,11 +439,11 @@ contains
          verticalSumMins(variableIndex) = min(verticalSumMins(variableIndex), verticalSumMins_tmp(variableIndex))
          verticalSumMaxes(variableIndex) = max(verticalSumMaxes(variableIndex), verticalSumMaxes_tmp(variableIndex))
 
-         ! layerThicknessEdge
+         ! layerThicknessEdgeFlux
          variableIndex = variableIndex + 1
          call ocn_compute_field_area_weighted_local_stats_max_level(dminfo, nVertLevels, nEdgesSolve, &
                             minLevelEdgeBot(1:nEdgesSolve), maxLevelEdgeTop(1:nEdgesSolve), areaEdge(1:nEdgesSolve), &
-                            layerThickEdge(:,1:nEdgesSolve), sums_tmp(variableIndex), &
+                            layerThickEdgeFlux(:,1:nEdgesSolve), sums_tmp(variableIndex), &
                             sumSquares_tmp(variableIndex), mins_tmp(variableIndex), &
                             maxes_tmp(variableIndex), verticalSumMins_tmp(variableIndex), &
                             verticalSumMaxes_tmp(variableIndex))
@@ -514,7 +514,7 @@ contains
          variableIndex = variableIndex + 1
          call ocn_compute_field_volume_weighted_local_stats_max_level(dminfo, nVertLevels, nEdgesSolve, &
                               minLevelEdgeBot(1:nEdgesSolve), maxLevelEdgeTop(1:nEdgesSolve), areaEdge(1:nEdgesSolve), &
-                              layerThickEdge(:,1:nEdgesSolve), &
+                              layerThickEdgeFlux(:,1:nEdgesSolve), &
                               normalizedAbsoluteVorticity(:,1:nEdgesSolve), &
                               sums_tmp(variableIndex), sumSquares_tmp(variableIndex), &
                               mins_tmp(variableIndex), maxes_tmp(variableIndex), &
@@ -1128,7 +1128,7 @@ contains
       averages(variableIndex) = sums(variableIndex)/volumeEdgeGlobal
       rms(variableIndex) = sqrt(sumSquares(variableIndex)/volumeEdgeGlobal)
 
-      ! layerThicknessEdge
+      ! layerThicknessEdgeFlux
       variableIndex = variableIndex + 1
       averages(variableIndex) = sums(variableIndex)/(areaEdgeGlobal*nVertLevels)
       rms(variableIndex) = sqrt(sumSquares(variableIndex)/(areaEdgeGlobal*nVertLevels))

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_global_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_global_stats.F
@@ -125,7 +125,6 @@ contains
             write (fileID,'(i5,a)') i,'. layerThickness'; i=i+1
             write (fileID,'(i5,a)') i,'. normalVelocity'; i=i+1
             write (fileID,'(i5,a)') i,'. tangentialVelocity'; i=i+1
-            write (fileID,'(i5,a)') i,'. layerThicknessEdgeFlux'; i=i+1
             write (fileID,'(i5,a)') i,'. relativeVorticity'; i=i+1
             write (fileID,'(i5,a)') i,'. enstrophy = relativeVorticity**2'; i=i+1
             write (fileID,'(i5,a)') i,'. kineticEnergyCell'; i=i+1
@@ -409,7 +408,7 @@ contains
          variableIndex = variableIndex + 1
          call ocn_compute_field_volume_weighted_local_stats_max_level(dminfo, nVertLevels, nEdgesSolve, &
                               minLevelEdgeBot(1:nEdgesSolve), maxLevelEdgeTop(1:nEdgesSolve), areaEdge(1:nEdgesSolve), &
-                              layerThickEdgeFlux(:,1:nEdgesSolve), &
+                              layerThickEdgeMean(:,1:nEdgesSolve), &
                               normalVelocity(:,1:nEdgesSolve), sums_tmp(variableIndex), &
                               sumSquares_tmp(variableIndex), mins_tmp(variableIndex), &
                               maxes_tmp(variableIndex), &
@@ -426,27 +425,12 @@ contains
          variableIndex = variableIndex + 1
          call ocn_compute_field_volume_weighted_local_stats_max_level(dminfo, nVertLevels, nEdgesSolve, &
                               minLevelEdgeBot(1:nEdgesSolve), maxLevelEdgeTop(1:nEdgesSolve), areaEdge(1:nEdgesSolve), &
-                              layerThickEdgeFlux(:,1:nEdgesSolve), &
+                              layerThickEdgeMean(:,1:nEdgesSolve), &
                               tangentialVelocity(:,1:nEdgesSolve), &
                               sums_tmp(variableIndex), sumSquares_tmp(variableIndex), &
                               mins_tmp(variableIndex), maxes_tmp(variableIndex), &
                               verticalSumMins_tmp(variableIndex), &
                               verticalSumMaxes_tmp(variableIndex))
-         sums(variableIndex) = sums(variableIndex) + sums_tmp(variableIndex)
-         sumSquares(variableIndex) = sumSquares(variableIndex) + sumSquares_tmp(variableIndex)
-         mins(variableIndex) = min(mins(variableIndex), mins_tmp(variableIndex))
-         maxes(variableIndex) = max(maxes(variableIndex), maxes_tmp(variableIndex))
-         verticalSumMins(variableIndex) = min(verticalSumMins(variableIndex), verticalSumMins_tmp(variableIndex))
-         verticalSumMaxes(variableIndex) = max(verticalSumMaxes(variableIndex), verticalSumMaxes_tmp(variableIndex))
-
-         ! layerThicknessEdgeFlux
-         variableIndex = variableIndex + 1
-         call ocn_compute_field_area_weighted_local_stats_max_level(dminfo, nVertLevels, nEdgesSolve, &
-                            minLevelEdgeBot(1:nEdgesSolve), maxLevelEdgeTop(1:nEdgesSolve), areaEdge(1:nEdgesSolve), &
-                            layerThickEdgeFlux(:,1:nEdgesSolve), sums_tmp(variableIndex), &
-                            sumSquares_tmp(variableIndex), mins_tmp(variableIndex), &
-                            maxes_tmp(variableIndex), verticalSumMins_tmp(variableIndex), &
-                            verticalSumMaxes_tmp(variableIndex))
          sums(variableIndex) = sums(variableIndex) + sums_tmp(variableIndex)
          sumSquares(variableIndex) = sumSquares(variableIndex) + sumSquares_tmp(variableIndex)
          mins(variableIndex) = min(mins(variableIndex), mins_tmp(variableIndex))
@@ -514,7 +498,7 @@ contains
          variableIndex = variableIndex + 1
          call ocn_compute_field_volume_weighted_local_stats_max_level(dminfo, nVertLevels, nEdgesSolve, &
                               minLevelEdgeBot(1:nEdgesSolve), maxLevelEdgeTop(1:nEdgesSolve), areaEdge(1:nEdgesSolve), &
-                              layerThickEdgeFlux(:,1:nEdgesSolve), &
+                              layerThickEdgeMean(:,1:nEdgesSolve), &
                               normalizedAbsoluteVorticity(:,1:nEdgesSolve), &
                               sums_tmp(variableIndex), sumSquares_tmp(variableIndex), &
                               mins_tmp(variableIndex), maxes_tmp(variableIndex), &
@@ -1127,11 +1111,6 @@ contains
       variableIndex = variableIndex + 1
       averages(variableIndex) = sums(variableIndex)/volumeEdgeGlobal
       rms(variableIndex) = sqrt(sumSquares(variableIndex)/volumeEdgeGlobal)
-
-      ! layerThicknessEdgeFlux
-      variableIndex = variableIndex + 1
-      averages(variableIndex) = sums(variableIndex)/(areaEdgeGlobal*nVertLevels)
-      rms(variableIndex) = sqrt(sumSquares(variableIndex)/(areaEdgeGlobal*nVertLevels))
 
       ! relativeVorticity
       variableIndex = variableIndex + 1

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_meridional_heat_transport.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_meridional_heat_transport.F
@@ -460,7 +460,7 @@ contains
 
                   do k = 1, kMax
 
-                     ! Compute divergence of huT, i.e. layerThicknessEdge * normalTransportVelocity * temperature, at an edge
+                     ! Compute divergence of huT, i.e. layerThicknessEdgeFlux * normalTransportVelocity * temperature, at an edge
                      ! for meridional heat transport.  Here we use a centered difference to compute the temperature at
                      ! the edge, which is an approximation to the actual edge temperature used in the horizontal
                      ! advection scheme (for example, FCT).  We expect that the error in this approximation is small.
@@ -470,7 +470,7 @@ contains
                      div_huT = 0.0_RKIND
                      do i = 1, nEdgesOnCell(iCell)
                         iEdge = edgesOnCell(i, iCell)
-                        div_huT = div_huT - layerThickEdge(k, iEdge) * normalTransportVelocity(k, iEdge) &
+                        div_huT = div_huT - layerThickEdgeFlux(k, iEdge) * normalTransportVelocity(k, iEdge) &
                              * 0.5_RKIND * (activeTracers(indexTemperature,k,cellsOnEdge(1,iEdge)) &
                              + activeTracers(indexTemperature,k,cellsOnEdge(2,iEdge))) &
                              * edgeSignOnCell(i, iCell) * dvEdge(iEdge)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -887,12 +887,12 @@ module ocn_time_integration_rk4
       ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
       if (associated(highFreqThicknessProvis)) then
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
-            layerThicknessCur,layerThickEdge, normalVelocityProvis, &
+            layerThicknessCur,layerThickEdgeFlux, normalVelocityProvis, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
-            layerThicknessCur,layerThickEdge, normalVelocityProvis, &
+            layerThicknessCur,layerThickEdgeFlux, normalVelocityProvis, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err)
       endif
@@ -955,12 +955,12 @@ module ocn_time_integration_rk4
       ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
       if (associated(highFreqThicknessProvis)) then
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
-            layerThicknessCur, layerThickEdge, normalTransportVelocity, &
+            layerThicknessCur, layerThickEdgeFlux, normalTransportVelocity, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
-            layerThicknessCur, layerThickEdge, normalTransportVelocity, &
+            layerThicknessCur, layerThickEdgeFlux, normalTransportVelocity, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err)
       endif
@@ -1025,12 +1025,12 @@ module ocn_time_integration_rk4
       ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
       if (associated(highFreqThicknessProvis)) then
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
-            layerThicknessCur, layerThickEdge, normalTransportVelocity, &
+            layerThicknessCur, layerThickEdgeFlux, normalTransportVelocity, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
-            layerThicknessCur, layerThickEdge, normalTransportVelocity, &
+            layerThicknessCur, layerThickEdgeFlux, normalTransportVelocity, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err)
       endif
@@ -1086,12 +1086,12 @@ module ocn_time_integration_rk4
       ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
       if (associated(highFreqThicknessProvis)) then
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
-            layerThicknessCur,layerThickEdge, normalVelocityProvis, &
+            layerThicknessCur,layerThickEdgeFlux, normalVelocityProvis, &
             sshCur, rkWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
-            layerThicknessCur,layerThickEdge, normalVelocityProvis, &
+            layerThicknessCur,layerThickEdgeFlux, normalVelocityProvis, &
             sshCur, rkWeight, &
             vertAleTransportTop, err)
       endif
@@ -1100,12 +1100,12 @@ module ocn_time_integration_rk4
 
       if (associated(highFreqThicknessProvis)) then
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
-            layerThicknessCur, layerThickEdge, normalTransportVelocity, &
+            layerThicknessCur, layerThickEdgeFlux, normalTransportVelocity, &
             sshCur, rkWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
-            layerThicknessCur, layerThickEdge, normalTransportVelocity, &
+            layerThicknessCur, layerThickEdgeFlux, normalTransportVelocity, &
             sshCur, rkWeight, &
             vertAleTransportTop, err)
       endif

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -325,7 +325,7 @@ module ocn_time_integration_si
       ! indexSurfaceVelocityZonal, indexSurfaceVelocityMeridional
       ! indexSSHGradientZonal, indexSSHGradientMeridional
       ! barotropicForcing, barotropicThicknessFlux
-      ! layerThickEdge, normalTransportVelocity, normalGMBolusVelocity
+      ! layerThickEdgeFlux, normalTransportVelocity, normalGMBolusVelocity
       ! vertAleTransportTop
       ! velocityX, velocityY, velocityZ
       ! velocityZonal, velocityMeridional
@@ -624,7 +624,7 @@ module ocn_time_integration_si
 
 #ifdef MPAS_OPENACC
          !$acc enter data copyin(layerThicknessCur, normalVelocityCur, sshCur)
-         !$acc update device(layerThickEdge)
+         !$acc update device(layerThickEdgeFlux)
 #endif
          if (associated(highFreqThicknessNew)) then
 #ifdef MPAS_OPENACC
@@ -632,7 +632,7 @@ module ocn_time_integration_si
 #endif
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
-                 layerThickEdge, normalVelocityCur, sshCur, dt, &
+                 layerThickEdgeFlux, normalVelocityCur, sshCur, dt, &
                  vertAleTransportTop, err, highFreqThicknessNew)
 #ifdef MPAS_OPENACC
             !$acc exit data delete(highFreqThicknessNew)
@@ -640,7 +640,7 @@ module ocn_time_integration_si
          else
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
-                 layerThickEdge, normalVelocityCur, sshCur, dt, &
+                 layerThickEdgeFlux, normalVelocityCur, sshCur, dt, &
                  vertAleTransportTop, err)
          endif
 #ifdef MPAS_OPENACC
@@ -702,16 +702,16 @@ module ocn_time_integration_si
                ! initialize thicknessSum with a nonzero value to avoid
                ! a NaN.
                normalThicknessFluxSum =                          &
-                    layerThickEdge(minLevelEdgeBot(iEdge),iEdge) &
+                    layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge) &
                   * uTemp(minLevelEdgeBot(iEdge))
                thicknessSum = &
-                    layerThickEdge(minLevelEdgeBot(iEdge),iEdge)
+                    layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
 
                do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                   normalThicknessFluxSum = normalThicknessFluxSum + &
-                                 layerThickEdge(k,iEdge)*uTemp(k)
+                                 layerThickEdgeFlux(k,iEdge)*uTemp(k)
                   thicknessSum = thicknessSum + &
-                                 layerThickEdge(k,iEdge)
+                                 layerThickEdgeFlux(k,iEdge)
                enddo
                barotropicForcing(iEdge) = &
                               normalThicknessFluxSum/thicknessSum/dt
@@ -2531,17 +2531,17 @@ module ocn_time_integration_si
             ! initialize thicknessSum with a nonzero value to avoid
             ! a NaN.
             normalThicknessFluxSum  &
-               = layerThickEdge(minLevelEdgeBot(iEdge),iEdge) &
+               = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge) &
                * uTemp(minLevelEdgeBot(iEdge))
             thicknessSum &
-               = layerThickEdge(minLevelEdgeBot(iEdge),iEdge)
+               = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
 
             do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                normalThicknessFluxSum = normalThicknessFluxSum + &
-                                        layerThickEdge(k,iEdge)* &
+                                        layerThickEdgeFlux(k,iEdge)* &
                                         uTemp(k)
                thicknessSum = thicknessSum + &
-                              layerThickEdge(k,iEdge)
+                              layerThickEdgeFlux(k,iEdge)
             enddo
 
             normalVelocityCorrection = useVelocityCorrection* &
@@ -2598,12 +2598,12 @@ module ocn_time_integration_si
          ! compute vertAleTransportTop.  Use normalTransportVelocity
          ! for advection of layerThickness and tracers.
          ! Use time level 1 values of layerThickness and
-         ! layerThickEdge because layerThickness has not yet
+         ! layerThickEdgeFlux because layerThickness has not yet
          ! been computed for time level 2.
          call mpas_timer_start('thick vert trans vel top')
 #ifdef MPAS_OPENACC
          !$acc enter data copyin(layerThicknessCur, sshCur)
-         !$acc update device(layerThickEdge, normalTransportVelocity)
+         !$acc update device(layerThickEdgeFlux, normalTransportVelocity)
 #endif
          if (associated(highFreqThicknessNew)) then
 #ifdef MPAS_OPENACC
@@ -2611,7 +2611,7 @@ module ocn_time_integration_si
 #endif
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
-                 layerThickEdge, normalTransportVelocity, sshCur, &
+                 layerThickEdgeFlux, normalTransportVelocity, sshCur, &
                  dt, vertAleTransportTop, err, highFreqThicknessNew)
 #ifdef MPAS_OPENACC
             !$acc exit data delete(highFreqThicknessNew)
@@ -2619,7 +2619,7 @@ module ocn_time_integration_si
          else
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
-                 layerThickEdge, normalTransportVelocity, sshCur, &
+                 layerThickEdgeFlux, normalTransportVelocity, sshCur, &
                  dt, vertAleTransportTop, err)
          endif
 #ifdef MPAS_OPENACC
@@ -2809,7 +2809,7 @@ module ocn_time_integration_si
 #endif
 
             ! Efficiency note: We really only need this to compute
-            ! layerThickEdge, density, pressure, and SSH
+            ! layerThickEdgeFlux, density, pressure, and SSH
             ! in this diagnostics solve.
             call ocn_diagnostic_solve(dt, statePool, forcingPool, &
                                       meshPool, scratchPool, &
@@ -2885,7 +2885,7 @@ module ocn_time_integration_si
                do k= minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                   activeTracerHorizontalAdvectionEdgeFlux(:,k,iEdge) = &
                   activeTracerHorizontalAdvectionEdgeFlux(:,k,iEdge) / &
-                       layerThickEdge(k,iEdge)
+                       layerThickEdgeFlux(k,iEdge)
                enddo
                enddo
                !$omp end do
@@ -3092,7 +3092,7 @@ module ocn_time_integration_si
       ! Call ocean diagnostic solve in preparation for vertical mixing.
       ! Note it is called again after vertical mixing, because u and
       ! tracers change. For Richardson vertical mixing, only density,
-      ! layerThickEdge, and kineticEnergyCell need to be computed.
+      ! layerThickEdgeFlux, and kineticEnergyCell need to be computed.
       ! For kpp, more variables may be needed.  Either way, this could
       ! be made more efficient by only computing what is needed for the
       ! implicit vmix routine that follows.

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -264,7 +264,7 @@ module ocn_time_integration_split
       ! indexSurfaceVelocityZonal, indexSurfaceVelocityMeridional
       ! indexSSHGradientZonal, indexSSHGradientMeridional
       ! barotropicForcing, barotropicThicknessFlux
-      ! layerThickEdge, normalTransportVelocity, normalGMBolusVelocity
+      ! layerThickEdgeFlux, normalTransportVelocity, normalGMBolusVelocity
       ! vertAleTransportTop
       ! velocityX, velocityY, velocityZ
       ! velocityZonal, velocityMeridional
@@ -563,7 +563,7 @@ module ocn_time_integration_split
 
 #ifdef MPAS_OPENACC
          !$acc enter data copyin(layerThicknessCur, normalVelocityCur, sshCur)
-         !$acc update device(layerThickEdge)
+         !$acc update device(layerThickEdgeFlux)
 #endif
          if (associated(highFreqThicknessNew)) then
 #ifdef MPAS_OPENACC
@@ -571,7 +571,7 @@ module ocn_time_integration_split
 #endif
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
-                 layerThickEdge, normalVelocityCur, sshCur, dt, &
+                 layerThickEdgeFlux, normalVelocityCur, sshCur, dt, &
                  vertAleTransportTop, err, highFreqThicknessNew)
 #ifdef MPAS_OPENACC
             !$acc exit data delete(highFreqThicknessNew)
@@ -579,7 +579,7 @@ module ocn_time_integration_split
          else
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
-                 layerThickEdge, normalVelocityCur, sshCur, dt, &
+                 layerThickEdgeFlux, normalVelocityCur, sshCur, dt, &
                  vertAleTransportTop, err)
          endif
 #ifdef MPAS_OPENACC
@@ -639,15 +639,15 @@ module ocn_time_integration_split
                ! on land boundaries maxLevelEdgeTop=0, but we want to
                ! initialize thicknessSum with a nonzero value to avoid
                ! a NaN.
-               normalThicknessFluxSum = layerThickEdge(minLevelEdgeBot(iEdge),iEdge)* &
+               normalThicknessFluxSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)* &
                                         uTemp(minLevelEdgeBot(iEdge))
-               thicknessSum = layerThickEdge(minLevelEdgeBot(iEdge),iEdge)
+               thicknessSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
 
                do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                   normalThicknessFluxSum = normalThicknessFluxSum + &
-                                 layerThickEdge(k,iEdge)*uTemp(k)
+                                 layerThickEdgeFlux(k,iEdge)*uTemp(k)
                   thicknessSum = thicknessSum + &
-                                 layerThickEdge(k,iEdge)
+                                 layerThickEdgeFlux(k,iEdge)
                enddo
                barotropicForcing(iEdge) = splitFact* &
                               normalThicknessFluxSum/thicknessSum/dt
@@ -1441,16 +1441,16 @@ module ocn_time_integration_split
                ! on land boundaries maxLevelEdgeTop=0, but I want to
                ! initialize thicknessSum with a nonzero value to avoid
                ! a NaN.
-               normalThicknessFluxSum = layerThickEdge(minLevelEdgeBot(iEdge),iEdge)* &
+               normalThicknessFluxSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)* &
                                         uTemp(minLevelEdgeBot(iEdge))
-               thicknessSum  = layerThickEdge(minLevelEdgeBot(iEdge),iEdge)
+               thicknessSum  = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
 
                do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                   normalThicknessFluxSum = normalThicknessFluxSum + &
-                                           layerThickEdge(k,iEdge)*&
+                                           layerThickEdgeFlux(k,iEdge)*&
                                            uTemp(k)
                   thicknessSum = thicknessSum + &
-                                 layerThickEdge(k,iEdge)
+                                 layerThickEdgeFlux(k,iEdge)
                enddo
 
                normalVelocityCorrection = useVelocityCorrection* &
@@ -1508,12 +1508,12 @@ module ocn_time_integration_split
          ! compute vertAleTransportTop.  Use normalTransportVelocity
          ! for advection of layerThickness and tracers.
          ! Use time level 1 values of layerThickness and
-         ! layerThickEdge because layerThickness has not yet
+         ! layerThickEdgeFlux because layerThickness has not yet
          ! been computed for time level 2.
          call mpas_timer_start('thick vert trans vel top')
 #ifdef MPAS_OPENACC
          !$acc enter data copyin(layerThicknessCur, sshCur)
-         !$acc update device(layerThickEdge, normalTransportVelocity)
+         !$acc update device(layerThickEdgeFlux, normalTransportVelocity)
 #endif
          if (associated(highFreqThicknessNew)) then
 #ifdef MPAS_OPENACC
@@ -1521,7 +1521,7 @@ module ocn_time_integration_split
 #endif
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
-                 layerThickEdge, normalTransportVelocity, sshCur, &
+                 layerThickEdgeFlux, normalTransportVelocity, sshCur, &
                  dt, vertAleTransportTop, err, highFreqThicknessNew)
 #ifdef MPAS_OPENACC
             !$acc exit data delete(highFreqThicknessNew)
@@ -1529,7 +1529,7 @@ module ocn_time_integration_split
          else
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
-                 layerThickEdge, normalTransportVelocity, sshCur, &
+                 layerThickEdgeFlux, normalTransportVelocity, sshCur, &
                  dt, vertAleTransportTop, err)
          endif
 #ifdef MPAS_OPENACC
@@ -1717,7 +1717,7 @@ module ocn_time_integration_split
 #endif
 
             ! Efficiency note: We really only need this to compute
-            ! layerThickEdge, density, pressure, and SSH
+            ! layerThickEdgeFlux, density, pressure, and SSH
             ! in this diagnostics solve.
             call ocn_diagnostic_solve(dt, statePool, forcingPool, &
                                       meshPool, scratchPool, &
@@ -1795,7 +1795,7 @@ module ocn_time_integration_split
                do k= minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                   activeTracerHorizontalAdvectionEdgeFlux(:,k,iEdge) = &
                   activeTracerHorizontalAdvectionEdgeFlux(:,k,iEdge) / &
-                       layerThickEdge(k,iEdge)
+                       layerThickEdgeFlux(k,iEdge)
                enddo
                enddo
                !$omp end do
@@ -2020,7 +2020,7 @@ module ocn_time_integration_split
       ! Call ocean diagnostic solve in preparation for vertical mixing.
       ! Note it is called again after vertical mixing, because u and
       ! tracers change. For Richardson vertical mixing, only density,
-      ! layerThickEdge, and kineticEnergyCell need to be computed.
+      ! layerThickEdgeFlux, and kineticEnergyCell need to be computed.
       ! For kpp, more variables may be needed.  Either way, this could
       ! be made more efficient by only computing what is needed for the
       ! implicit vmix routine that follows.

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -212,8 +212,8 @@ contains
 #endif
 
       ! inputs: layerThickness, normalVelocity
-      ! output: layerThickEdgeCenter, layerThickEdgeFlux
-      call ocn_diagnostic_solve_layerThicknessEdge(normalVelocity, layerThickness, layerThickEdgeCenter, layerThickEdgeFlux)
+      ! output: layerThickEdgeMean, layerThickEdgeFlux
+      call ocn_diagnostic_solve_layerThicknessEdge(normalVelocity, layerThickness, layerThickEdgeMean, layerThickEdgeFlux)
 
       ! inputs: normalVelocity
       ! outputs: relativeVorticity, circulation
@@ -398,7 +398,7 @@ contains
 #ifdef MPAS_OPENACC
       !! Listing outputs by first routine that modifies variable
       !! ocn_diagnostic_solve_layerThicknessEdge :: layerThickEdgeFlux, (diagnostics array)
-      !!                                            layerThickEdgeCenter (diagnostics array)
+      !!                                            layerThickEdgeMean (diagnostics array)
       !! ocn_relativeVorticity_circulation       :: relativeVorticity, (diagnostics array)
       !!                                            circulation (diagnostics array)
       !! ocn_diagnostic_solve_vortVel            :: vertTransportVelocityTop, (diagnostics array)
@@ -584,16 +584,16 @@ contains
 !  routine ocn_diagnostic_solve_layerThicknessEdge
 !
 !> \brief   Computes diagnostic variables layerThickEdgeFlux and
-!>          layerThickEdgeCenter
+!>          layerThickEdgeMean
 !> \author  Matt Turner
 !> \date    October 2020
 !> \details
 !>  This routine computes the diagnostic variables layerThickEdgeFlux and
-!>  layerThickEdgeCenter
+!>  layerThickEdgeMean
 !
 !-----------------------------------------------------------------------
    subroutine ocn_diagnostic_solve_layerThicknessEdge(normalVelocity, layerThickness, &
-                layerThicknessEdgeCenter, layerThicknessEdgeFlux)!{{{
+                layerThicknessEdgeMean, layerThicknessEdgeFlux)!{{{
 
       implicit none
 
@@ -614,9 +614,9 @@ contains
       !
       !-----------------------------------------------------------------
 
-      real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         layerThicknessEdgeCenter, & !< Output: centered layer thickness on edge
-         layerThicknessEdgeFlux        !< Output: centered layer thickness on edge
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         layerThicknessEdgeMean, & !< Output: centered layer thickness on edge
+         layerThicknessEdgeFlux    !< Output: flux-related layer thickness on edge
 
       !-----------------------------------------------------------------
       !
@@ -634,19 +634,19 @@ contains
       nEdges = nEdgesAll
 
 #ifdef MPAS_OPENACC
-      !$acc parallel loop present(normalVelocity, layerThickness, minLevelEdgeBot, maxLevelEdgeTop, layerThicknessEdgeCenter, cellsOnEdge)
+      !$acc parallel loop present(normalVelocity, layerThickness, minLevelEdgeBot, maxLevelEdgeTop, layerThicknessEdgeMean, cellsOnEdge)
 #else
       !$omp parallel
       !$omp do schedule(runtime) private(cell1, cell2, k)
 #endif
       do iEdge = 1, nEdges
-        ! initialize layerThicknessEdgeCenter to avoid divide by zero and NaN problems.
-        layerThicknessEdgeCenter(:, iEdge) = -1.0e34_RKIND
+        ! initialize layerThicknessEdgeMean to avoid divide by zero and NaN problems.
+        layerThicknessEdgeMean(:, iEdge) = -1.0e34_RKIND
         cell1 = cellsOnEdge(1,iEdge)
         cell2 = cellsOnEdge(2,iEdge)
         do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
           ! central differenced
-          layerThicknessEdgeCenter(k,iEdge) = 0.5_RKIND * (layerThickness(k,cell1) + layerThickness(k,cell2))
+          layerThicknessEdgeMean(k,iEdge) = 0.5_RKIND * (layerThickness(k,cell1) + layerThickness(k,cell2))
         end do
       end do
 #ifndef MPAS_OPENACC
@@ -654,7 +654,7 @@ contains
       !$omp end parallel
 #endif
       if (trim(config_thickness_flux_type) .eq. 'centered') then
-        layerThicknessEdgeFlux = layerThicknessEdgeCenter
+        layerThicknessEdgeFlux = layerThicknessEdgeMean
       else
         if (config_use_wetting_drying .and. (trim(config_thickness_flux_type) .ne. 'centered')) then
           if ( trim(config_thickness_flux_type) .eq. 'upwind') then

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -188,7 +188,7 @@ contains
 
       !! tracersSurfaceValue calc                :: minLevelCell (mesh array)
       !! normalVelocitySurfaceLayer calc         :: minLevelEdgeBot (mesh array)
-      !! surfaceFluxAttenuationCoefficientRunoff :: layerThickEdge (diagnostics array)
+      !! surfaceFluxAttenuationCoefficientRunoff :: layerThickEdgeFlux (diagnostics array)
       !! ocn_diagnostic_solve_ssh                :: ssh, (not on device)
       !!                                            landIceDraft (not on device)
 
@@ -212,20 +212,20 @@ contains
 #endif
 
       ! inputs: layerThickness, normalVelocity
-      ! output: layerThickEdge
-      call ocn_diagnostic_solve_layerThicknessEdge(normalVelocity, layerThickness, layerThickEdge)
+      ! output: layerThickEdgeCenter, layerThickEdgeFlux
+      call ocn_diagnostic_solve_layerThicknessEdge(normalVelocity, layerThickness, layerThickEdgeCenter, layerThickEdgeFlux)
 
       ! inputs: normalVelocity
       ! outputs: relativeVorticity, circulation
       call ocn_relativeVorticity_circulation(relativeVorticity, circulation, normalVelocity, err)
 
-      ! inputs: relativeVorticity, layerThicknessEdge, normalVelocity, normalTransportVelocity, 
+      ! inputs: relativeVorticity, layerThickEdgeFlux, normalVelocity, normalTransportVelocity, 
       !         normalGMBolusVelocity
       ! outputs: vertTransportVelocityTop, vertGMBolusVelocityTop, relativeVorticityCell, 
       !          divergence, kineticEnergyCell, tangentialVelocity
       ! in and out: vertVelocityTop
       call ocn_diagnostic_solve_vortVel(relativeVorticity, &
-             layerThickEdge, normalVelocity, normalTransportVelocity, &
+             layerThickEdgeFlux, normalVelocity, normalTransportVelocity, &
              normalGMBolusVelocity, vertVelocityTop, vertTransportVelocityTop, &
              vertGMBolusVelocityTop, relativeVorticityCell, divergence, &
              kineticEnergyCell, tangentialVelocity)
@@ -360,11 +360,11 @@ contains
          ! average tracer values over the ocean surface layer
          ! the ocean surface layer is generally assumed to be about 0.1 of the boundary layer depth
          !
-         ! inputs: layerThickness, activeTracers, layerThicknessEdge, normalVelocity
+         ! inputs: layerThickness, activeTracers, layerThicknessEdgeFlux, normalVelocity
          ! outputs: tracersSurfaceLayerValue, indexSurfaceLayerDepth, normalVelocitySurfaceLayer,
          !          surfaceFluxAttenuationCoefficient, surfaceFluxAttenuationCoefficientRunoff
          call ocn_diagnostic_solve_surfaceLayer(layerThickness, activeTracers, &
-                layerThickEdge, normalVelocity, tracersSurfaceLayerValue,  &
+                layerThickEdgeFlux, normalVelocity, tracersSurfaceLayerValue, &
                 indexSurfaceLayerDepth, normalVelocitySurfaceLayer, &
                 sfcFlxAttCoeff, surfaceFluxAttenuationCoefficientRunoff)
 
@@ -397,7 +397,8 @@ contains
 
 #ifdef MPAS_OPENACC
       !! Listing outputs by first routine that modifies variable
-      !! ocn_diagnostic_solve_layerThicknessEdge :: layerThickEdge (diagnostics array)
+      !! ocn_diagnostic_solve_layerThicknessEdge :: layerThickEdgeFlux, (diagnostics array)
+      !!                                            layerThickEdgeCenter (diagnostics array)
       !! ocn_relativeVorticity_circulation       :: relativeVorticity, (diagnostics array)
       !!                                            circulation (diagnostics array)
       !! ocn_diagnostic_solve_vortVel            :: vertTransportVelocityTop, (diagnostics array)
@@ -434,7 +435,7 @@ contains
       !! ocn_diagnostic_solve_ssh                :: pressureAdjustedSSH, (diagnostics array)
       !!                                            gradSSH (diagnostics array)
 
-!     !$acc update host(layerThickEdge)
+!     !$acc update host(layerThickEdgeFlux, layerThickEdgeCenter)
 !     !$acc update host(relativeVorticity, circulation)
 !     !$acc update host(vertTransportVelocityTop, &
 !     !$acc             vertGMBolusVelocityTop, &
@@ -582,15 +583,17 @@ contains
 !
 !  routine ocn_diagnostic_solve_layerThicknessEdge
 !
-!> \brief   Computes diagnostic variable layerThicknessEdge
+!> \brief   Computes diagnostic variables layerThickEdgeFlux and
+!>          layerThickEdgeCenter
 !> \author  Matt Turner
 !> \date    October 2020
 !> \details
-!>  This routine computes the diagnostic variable layerThicknessEdge
+!>  This routine computes the diagnostic variables layerThickEdgeFlux and
+!>  layerThickEdgeCenter
 !
 !-----------------------------------------------------------------------
    subroutine ocn_diagnostic_solve_layerThicknessEdge(normalVelocity, layerThickness, &
-                layerThicknessEdge)!{{{
+                layerThicknessEdgeCenter, layerThicknessEdgeFlux)!{{{
 
       implicit none
 
@@ -611,8 +614,9 @@ contains
       !
       !-----------------------------------------------------------------
 
-      real (kind=RKIND), dimension(:,:), intent(out) :: &
-         layerThicknessEdge     !< Output: layer thickness on edge
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         layerThicknessEdgeCenter, & !< Output: centered layer thickness on edge
+         layerThicknessEdgeFlux        !< Output: centered layer thickness on edge
 
       !-----------------------------------------------------------------
       !
@@ -629,49 +633,50 @@ contains
 
       nEdges = nEdgesAll
 
-      if (.not. config_use_wetting_drying .or. (config_use_wetting_drying .and. (trim(config_thickness_flux_type) .eq. 'centered'))) then
 #ifdef MPAS_OPENACC
-        !$acc parallel loop present(normalVelocity, layerThickness, minLevelEdgeBot, maxLevelEdgeTop, layerThicknessEdge, cellsOnEdge)
+      !$acc parallel loop present(normalVelocity, layerThickness, minLevelEdgeBot, maxLevelEdgeTop, layerThicknessEdgeCenter, cellsOnEdge)
 #else
-        !$omp parallel
-        !$omp do schedule(runtime) private(cell1, cell2, k)
+      !$omp parallel
+      !$omp do schedule(runtime) private(cell1, cell2, k)
 #endif
-        do iEdge = 1, nEdges
-          ! initialize layerThicknessEdge to avoid divide by zero and NaN problems.
-          layerThicknessEdge(:, iEdge) = -1.0e34_RKIND
-          cell1 = cellsOnEdge(1,iEdge)
-          cell2 = cellsOnEdge(2,iEdge)
-          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-            ! central differenced
-            layerThicknessEdge(k,iEdge) = 0.5_RKIND * (layerThickness(k,cell1) + layerThickness(k,cell2))
-          end do
+      do iEdge = 1, nEdges
+        ! initialize layerThicknessEdgeCenter to avoid divide by zero and NaN problems.
+        layerThicknessEdgeCenter(:, iEdge) = -1.0e34_RKIND
+        cell1 = cellsOnEdge(1,iEdge)
+        cell2 = cellsOnEdge(2,iEdge)
+        do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+          ! central differenced
+          layerThicknessEdgeCenter(k,iEdge) = 0.5_RKIND * (layerThickness(k,cell1) + layerThickness(k,cell2))
         end do
+      end do
 #ifndef MPAS_OPENACC
-        !$omp end do
-        !$omp end parallel
+      !$omp end do
+      !$omp end parallel
 #endif
+      if (trim(config_thickness_flux_type) .eq. 'centered') then
+        layerThicknessEdgeFlux = layerThicknessEdgeCenter
       else
         if (config_use_wetting_drying .and. (trim(config_thickness_flux_type) .ne. 'centered')) then
           if ( trim(config_thickness_flux_type) .eq. 'upwind') then
 #ifdef MPAS_OPENACC
-            !$acc parallel loop present(normalVelocity, layerThickness, minLevelEdgeBot, maxLevelEdgeTop, layerThicknessEdge, cellsOnEdge)
+            !$acc parallel loop present(normalVelocity, layerThickness, minLevelEdgeBot, maxLevelEdgeTop, layerThicknessEdgeFlux, cellsOnEdge)
 #else
             !$omp parallel
             !$omp do schedule(runtime) private(cell1, cell2, k)
 #endif
             do iEdge = 1, nEdges
-              ! initialize layerThicknessEdge to avoid divide by zero and NaN problems.
-              layerThicknessEdge(:, iEdge) = -1.0e34_RKIND
+              ! initialize layerThicknessEdgeFlux to avoid divide by zero and NaN problems.
+              layerThicknessEdgeFlux(:, iEdge) = -1.0e34_RKIND
               cell1 = cellsOnEdge(1,iEdge)
               cell2 = cellsOnEdge(2,iEdge)
               do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                 ! upwind
                 if (normalVelocity(k, iEdge) > 0.0_RKIND) then
-                  layerThicknessEdge(k,iEdge) = layerThickness(k,cell1)
+                  layerThicknessEdgeFlux(k,iEdge) = layerThickness(k,cell1)
                 elseif (normalVelocity(k, iEdge) < 0.0_RKIND) then
-                  layerThicknessEdge(k,iEdge) = layerThickness(k,cell2)
+                  layerThicknessEdgeFlux(k,iEdge) = layerThickness(k,cell2)
                 else
-                  layerThicknessEdge(k,iEdge) = max(layerThickness(k,cell1), layerThickness(k,cell2))
+                  layerThicknessEdgeFlux(k,iEdge) = max(layerThickness(k,cell1), layerThickness(k,cell2))
                 end if
               end do
             end do
@@ -1230,7 +1235,7 @@ contains
 !
 !-----------------------------------------------------------------------
    subroutine ocn_diagnostic_solve_surfaceLayer(layerThickness, activeTracers, &
-                layerThicknessEdge, normalVelocity, tracersSurfaceLayerValue,  &
+                layerThicknessEdgeFlux, normalVelocity, tracersSurfaceLayerValue,  &
                 indexSurfaceLayerDepth, normalVelocitySurfaceLayer, &
                 surfaceFluxAttenuationCoefficient, surfaceFluxAttenuationCoefficientRunoff)!{{{
 
@@ -1247,7 +1252,7 @@ contains
       real (kind=RKIND), dimension(:,:,:), intent(in) :: &
         activeTracers
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-        layerThicknessEdge
+        layerThicknessEdgeFlux
       real (kind=RKIND), dimension(:,:), intent(in) :: &
         normalVelocity
 
@@ -1343,7 +1348,7 @@ contains
 #ifdef MPAS_OPENACC
         !$acc parallel loop gang vector &
         !$acc          present(normalVelocitySurfaceLayer, cellsOnEdge, maxLevelEdgeTop, &
-        !$acc                  layerThicknessEdge, normalVelocity, minLevelEdgeBot) &
+        !$acc                  layerThicknessEdgeFlux, normalVelocity, minLevelEdgeBot) &
         !$acc          private(cell1, cell2, rSurfaceLayer, sumSurfaceLayer, k)
 #else
         !$omp parallel
@@ -1360,10 +1365,10 @@ contains
 #endif
           do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
            rSurfaceLayer = k
-           sumSurfaceLayer = sumSurfaceLayer + layerThicknessEdge(k,iEdge)
+           sumSurfaceLayer = sumSurfaceLayer + layerThicknessEdgeFlux(k,iEdge)
            if(sumSurfaceLayer.gt.surfaceLayerDepth) then
-             sumSurfaceLayer = sumSurfaceLayer - layerThicknessEdge(k,iEdge)
-             rSurfaceLayer = int(k-1) + (surfaceLayerDepth-sumSurfaceLayer)/layerThicknessEdge(k,iEdge)
+             sumSurfaceLayer = sumSurfaceLayer - layerThicknessEdgeFlux(k,iEdge)
+             rSurfaceLayer = int(k-1) + (surfaceLayerDepth-sumSurfaceLayer)/layerThicknessEdgeFlux(k,iEdge)
              exit
            endif
           end do
@@ -1373,12 +1378,12 @@ contains
 #endif
           do k = minLevelEdgeBot(iEdge),int(rSurfaceLayer)
             normalVelocitySurfaceLayer(iEdge) = normalVelocitySurfaceLayer(iEdge) + normalVelocity(k,iEdge) &
-                                              * layerThicknessEdge(k,iEdge)
+                                              * layerThicknessEdgeFlux(k,iEdge)
           end do
           k=int(rSurfaceLayer)+1
           if(k.le.maxLevelEdgeTop(iEdge)) then
             normalVelocitySurfaceLayer(iEdge) = (normalVelocitySurfaceLayer(iEdge) + fraction(rSurfaceLayer) &
-                                              * normalVelocity(k,iEdge) * layerThicknessEdge(k,iEdge)) / surfaceLayerDepth
+                                              * normalVelocity(k,iEdge) * layerThicknessEdgeFlux(k,iEdge)) / surfaceLayerDepth
           end if
         enddo
 #ifndef MPAS_OPENACC
@@ -1421,7 +1426,7 @@ contains
 !
 !-----------------------------------------------------------------------
    subroutine ocn_diagnostic_solve_vortVel(relativeVorticity, &
-                layerThicknessEdge, normalVelocity, normalTransportVelocity, &
+                layerThicknessEdgeFlux, normalVelocity, normalTransportVelocity, &
                 normalGMBolusVelocity, vertVelocityTop, vertTransportVelocityTop, &
                 vertGMBolusVelocityTop, relativeVorticityCell, divergence, &
                 kineticEnergyCell, tangentialVelocity)!{{{
@@ -1437,7 +1442,7 @@ contains
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          relativeVorticity
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdge
+         layerThicknessEdgeFlux
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          normalVelocity
       real (kind=RKIND), dimension(:,:), intent(in) :: &
@@ -1528,7 +1533,7 @@ contains
       !$acc parallel loop gang vector &
       !$acc          present(divergence, kineticEnergyCell, &
       !$acc                  areaCell, nEdgesOnCell, edgesOnCell, edgeSignOnCell, dcEdge, dvEdge, &
-      !$acc                  maxLevelCell, normalVelocity, divergence, layerThicknessEdge, &
+      !$acc                  maxLevelCell, normalVelocity, divergence, layerThicknessEdgeFlux, &
       !$acc                  normalTransportVelocity, normalGMBolusVelocity, vertVelocityTop, &
       !$acc                  vertTransportVelocityTop, vertGMBolusVelocityTop, invAreaCell, &
       !$acc                  minLevelCell) &
@@ -1556,16 +1561,16 @@ contains
                r_tmp = dvEdge_temp * normalVelocity(k, iEdge) * invAreaCell1
 
                divergence(k, iCell) = divergence(k, iCell) - edgeSignOnCell_temp * r_tmp
-               div_hu(k) = div_hu(k) - layerThicknessEdge(k, iEdge) * edgeSignOnCell_temp * r_tmp
+               div_hu(k) = div_hu(k) - layerThicknessEdgeFlux(k, iEdge) * edgeSignOnCell_temp * r_tmp
                kineticEnergyCell(k, iCell) = kineticEnergyCell(k, iCell) &
                                               + 0.25 * r_tmp * dcEdge_temp * normalVelocity(k,iEdge)
                ! Compute vertical velocity from the horizontal total transport
                div_huTransport(k) = div_huTransport(k) &
-                                    - layerThicknessEdge(k, iEdge) * edgeSignOnCell_temp &
+                                    - layerThicknessEdgeFlux(k, iEdge) * edgeSignOnCell_temp &
                                     * dvEdge_temp * normalTransportVelocity(k, iEdge) * invAreaCell1
                ! Compute vertical velocity from the horizontal GM Bolus velocity
                div_huGMBolus(k) = div_huGMBolus(k) &
-                                  - layerThicknessEdge(k, iEdge) * edgeSignOnCell_temp * dvEdge_temp &
+                                  - layerThicknessEdgeFlux(k, iEdge) * edgeSignOnCell_temp * dvEdge_temp &
                                   * normalGMBolusVelocity(k, iEdge) * invAreaCell1
             end do
          end do
@@ -2034,7 +2039,7 @@ contains
 !>  cell.
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, oldLayerThickness, layerThicknessEdge, &
+   subroutine ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, oldLayerThickness, layerThicknessEdgeFlux, &
      normalVelocity, oldSSH, dt, vertAleTransportTop, err, newHighFreqThickness)!{{{
 
       !-----------------------------------------------------------------
@@ -2053,7 +2058,7 @@ contains
          oldLayerThickness    !< Input: layer thickness at old time
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdge     !< Input: layerThickness interpolated to an edge
+         layerThicknessEdgeFlux     !< Input: layerThickness interpolated to an edge
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          normalVelocity     !< Input: transport
@@ -2132,7 +2137,7 @@ contains
 
       !$acc parallel loop &
       !$acc          present(invAreaCell, nEdgesOnCell, edgesOnCell, maxLevelEdgeTop, &
-      !$acc                  layerThicknessEdge, normalVelocity, dvEdge, edgeSignOnCell, &
+      !$acc                  layerThicknessEdgeFlux, normalVelocity, dvEdge, edgeSignOnCell, &
       !$acc                  oldSSH, projectedSSH, minLevelEdgeBot) &
       !$acc          private(div_hu_btr, invAreaCell1, i, iEdge, flux, k, kmin, kmax)
 #else
@@ -2149,7 +2154,7 @@ contains
             kmax = maxLevelEdgeTop(iEdge)
 
             do k = kmin, kmax
-               flux = layerThicknessEdge(k, iEdge) * normalVelocity(k, iEdge) * dvEdge(iEdge) * edgeSignOnCell(i, iCell) &
+               flux = layerThicknessEdgeFlux(k, iEdge) * normalVelocity(k, iEdge) * dvEdge(iEdge) * edgeSignOnCell(i, iCell) &
                     * invAreaCell1
                div_hu(k,iCell) = div_hu(k,iCell) - flux
                div_hu_btr = div_hu_btr - flux
@@ -2330,13 +2335,13 @@ contains
         ! thicknessSum is initialized outside the loop because on land boundaries
         ! maxLevelEdgeTop=0, but I want to initialize thicknessSum with a
         ! nonzero value to avoid a NaN.
-        normalThicknessFluxSum = layerThickEdge(maxLevelEdgeBot(iEdge),iEdge) * &
+        normalThicknessFluxSum = layerThickEdgeFlux(maxLevelEdgeBot(iEdge),iEdge) * &
                                  tend_normalVelocity(maxLevelEdgeBot(iEdge),iEdge)
-        thicknessSum  = layerThickEdge(maxLevelEdgeBot(iEdge),iEdge)
+        thicknessSum  = layerThickEdgeFlux(maxLevelEdgeBot(iEdge),iEdge)
 
         do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
-          normalThicknessFluxSum = normalThicknessFluxSum + layerThickEdge(k,iEdge) * tend_normalVelocity(k,iEdge)
-          thicknessSum  =  thicknessSum + layerThickEdge(k,iEdge)
+          normalThicknessFluxSum = normalThicknessFluxSum + layerThickEdgeFlux(k,iEdge) * tend_normalVelocity(k,iEdge)
+          thicknessSum  =  thicknessSum + layerThickEdgeFlux(k,iEdge)
         enddo
 
         vertSum = normalThicknessFluxSum / thicknessSum

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -628,7 +628,7 @@ contains
 
       !
       ! Compute height on cell edges at velocity locations
-      !   Namelist options control the order of accuracy of the reconstructed layerThicknessEdge value
+      !   Namelist options control the order of accuracy of the reconstructed layerThicknessEdgeFlux value
       !
 
       nEdges = nEdgesAll

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -57,7 +57,7 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:,:), pointer :: BruntVaisalaFreqTop
    real (kind=RKIND), dimension(:,:), pointer :: tangentialVelocity
    real (kind=RKIND), dimension(:,:), pointer :: layerThickEdgeFlux
-   real (kind=RKIND), dimension(:,:), pointer :: layerThickEdgeCenter
+   real (kind=RKIND), dimension(:,:), pointer :: layerThickEdgeMean
    real (kind=RKIND), dimension(:,:), pointer :: kineticEnergyCell
    real (kind=RKIND), dimension(:,:), pointer :: vertVelocityTop
    real (kind=RKIND), dimension(:,:), pointer :: vertTransportVelocityTop
@@ -418,8 +418,8 @@ contains
 
          call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdgeFlux', &
                    layerThickEdgeFlux)
-         call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdgeCenter', &
-                   layerThickEdgeCenter)
+         call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdgeMean', &
+                   layerThickEdgeMean)
 
          call mpas_pool_get_array(diagnosticsPool, &
                   'normalizedRelativeVorticityEdge', &
@@ -676,7 +676,7 @@ contains
          !$acc                   GMStreamFuncY,                   &
          !$acc                   GMStreamFuncZ,                   &
          !$acc                   layerThickEdgeFlux,              &
-         !$acc                   layerThickEdgeCenter,            &
+         !$acc                   layerThickEdgeMean,              &
          !$acc                   slopeTriadDown,                  &
          !$acc                   normRelVortEdge,                 &
          !$acc                   surfaceVelocity,                 &
@@ -914,7 +914,7 @@ contains
          !$acc                   GMStreamFuncY,                   &
          !$acc                   GMStreamFuncZ,                   &
          !$acc                   layerThickEdgeFlux,              &
-         !$acc                   layerThickEdgeCenter,            &
+         !$acc                   layerThickEdgeMean,              &
          !$acc                   slopeTriadDown,                  &
          !$acc                   normRelVortEdge,                 &
          !$acc                   surfaceVelocity,                 &
@@ -1113,7 +1113,7 @@ contains
                  GMStreamFuncY,                   &
                  GMStreamFuncZ,                   &
                  layerThickEdgeFlux,              &
-                 layerThickEdgeCenter,            &
+                 layerThickEdgeMean,              &
                  slopeTriadDown,                  &
                  normRelVortEdge,                 &
                  surfaceVelocity,                 &

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -56,7 +56,8 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:,:), pointer :: salineContractCoeff
    real (kind=RKIND), dimension(:,:), pointer :: BruntVaisalaFreqTop
    real (kind=RKIND), dimension(:,:), pointer :: tangentialVelocity
-   real (kind=RKIND), dimension(:,:), pointer :: layerThickEdge
+   real (kind=RKIND), dimension(:,:), pointer :: layerThickEdgeFlux
+   real (kind=RKIND), dimension(:,:), pointer :: layerThickEdgeCenter
    real (kind=RKIND), dimension(:,:), pointer :: kineticEnergyCell
    real (kind=RKIND), dimension(:,:), pointer :: vertVelocityTop
    real (kind=RKIND), dimension(:,:), pointer :: vertTransportVelocityTop
@@ -415,8 +416,10 @@ contains
          call mpas_pool_get_array(diagnosticsPool, 'vertGMBolusVelocityTop', &
                    vertGMBolusVelocityTop)
 
-         call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdge', &
-                   layerThickEdge)
+         call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdgeFlux', &
+                   layerThickEdgeFlux)
+         call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdgeCenter', &
+                   layerThickEdgeCenter)
 
          call mpas_pool_get_array(diagnosticsPool, &
                   'normalizedRelativeVorticityEdge', &
@@ -672,7 +675,8 @@ contains
          !$acc                   GMStreamFuncX,                   &
          !$acc                   GMStreamFuncY,                   &
          !$acc                   GMStreamFuncZ,                   &
-         !$acc                   layerThickEdge,                  &
+         !$acc                   layerThickEdgeFlux,              &
+         !$acc                   layerThickEdgeCenter,            &
          !$acc                   slopeTriadDown,                  &
          !$acc                   normRelVortEdge,                 &
          !$acc                   surfaceVelocity,                 &
@@ -909,7 +913,8 @@ contains
          !$acc                   GMStreamFuncX,                   &
          !$acc                   GMStreamFuncY,                   &
          !$acc                   GMStreamFuncZ,                   &
-         !$acc                   layerThickEdge,                  &
+         !$acc                   layerThickEdgeFlux,              &
+         !$acc                   layerThickEdgeCenter,            &
          !$acc                   slopeTriadDown,                  &
          !$acc                   normRelVortEdge,                 &
          !$acc                   surfaceVelocity,                 &
@@ -1107,7 +1112,8 @@ contains
                  GMStreamFuncX,                   &
                  GMStreamFuncY,                   &
                  GMStreamFuncZ,                   &
-                 layerThickEdge,                  &
+                 layerThickEdgeFlux,              &
+                 layerThickEdgeCenter,            &
                  slopeTriadDown,                  &
                  normRelVortEdge,                 &
                  surfaceVelocity,                 &

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -643,7 +643,7 @@ contains
               do k=minLevelEdgeBot(iEdge)+1,maxLevelEdgeTop(iEdge)
                  BruntVaisalaFreqTopEdge = 0.5_RKIND*(max(BruntVaisalaFreqTop(k,cell1),0.0_RKIND) + &
                                           max(BruntVaisalaFreqTop(k,cell2),0.0_RKIND))
-                 shearEdgeInv = (0.5_RKIND*(layerThickEdgeFlux(k-1,iEdge) + layerThickEdgeFlux(k,iEdge)))**2.0 &
+                 shearEdgeInv = (0.5_RKIND*(layerThickEdgeMean(k-1,iEdge) + layerThickEdgeMean(k,iEdge)))**2.0 &
                     / (  (normalVelocity(k-1,iEdge) - normalVelocity(k,iEdge))**2.0 &
                        + (tangentialVelocity(k-1,iEdge) - tangentialVelocity(k,iEdge))**2.0 &
                        + 1.0e-18_RKIND )

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -473,8 +473,8 @@ contains
             ! The interpolation can only be carried out on non-boundary edges
             if (maxLevelEdgeTop(iEdge) .GE. minLevelEdgeBot(iEdge)) then
                do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
-                  h1 = layerThickEdgeCenter(k-1,iEdge)
-                  h2 = layerThickEdgeCenter(k,iEdge)
+                  h1 = layerThickEdgeMean(k-1,iEdge)
+                  h2 = layerThickEdgeMean(k,iEdge)
                   ! Using second-order interpolation below
                   gradDensityTopOfEdge(k,iEdge) = (h2 * gradDensityEdge(k-1,iEdge) + h1 * &
                                 gradDensityEdge(k,iEdge)) / (h1 + h2)
@@ -592,7 +592,7 @@ contains
               cell2 = cellsOnEdge(2, iEdge)
 
               k = minLevelEdgeBot(iEdge)+1
-              zEdge = -layerThickEdgeCenter(k-1,iEdge)
+              zEdge = -layerThickEdgeMean(k-1,iEdge)
               do while(zEdge > -config_GM_Visbeck_max_depth .and. k < maxLevelEdgeTop(iEdge))
                 lt1 = 0.5_RKIND*(layerThickness(k,cell1) + layerThickness(k-1,cell1))
                 lt2 = 0.5_RKIND*(layerThickness(k,cell2) + layerThickness(k-1,cell2))
@@ -604,7 +604,7 @@ contains
                 countN2 = countN2 + 1
 
                 k = k + 1
-                zEdge = zEdge - layerThickEdgeCenter(k-1,iEdge)
+                zEdge = zEdge - layerThickEdgeMean(k-1,iEdge)
               end do
 
               if (countN2 > 0) then
@@ -680,10 +680,10 @@ contains
 
                BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k, cell1) + BruntVaisalaFreqTop(k, cell2))
                BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
-               tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThickEdgeCenter(k - 1, iEdge) &
-                                                                     *layerThickEdgeCenter(k, iEdge)) - BruntVaisalaFreqTopEdge
-               tridiagC(k - 1) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdgeCenter(k, iEdge) &
-                                 /(layerThickEdgeCenter(k - 1, iEdge) + layerThickEdgeCenter(k, iEdge))
+               tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThickEdgeMean(k - 1, iEdge) &
+                                                                     *layerThickEdgeMean(k, iEdge)) - BruntVaisalaFreqTopEdge
+               tridiagC(k - 1) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdgeMean(k, iEdge) &
+                                 /(layerThickEdgeMean(k - 1, iEdge) + layerThickEdgeMean(k, iEdge))
                rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gravity/rho_sw &
                                       *gradDensityConstZTopOfEdge(k,iEdge)
 
@@ -691,12 +691,12 @@ contains
                do k = minLevelEdgeBot(iEdge) + 2, maxLevelEdgeTop(iEdge) - 1
                   BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k, cell1) + BruntVaisalaFreqTop(k, cell2))
                   BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
-                  tridiagA(k - 2) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdgeCenter(k - 1, iEdge) &
-                                    /(layerThickEdgeCenter(k - 1, iEdge) + layerThickEdgeCenter(k, iEdge))
-                  tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThickEdgeCenter(k - 1, iEdge) &
-                                                                        *layerThickEdgeCenter(k, iEdge)) - BruntVaisalaFreqTopEdge
-                  tridiagC(k - 1) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdgeCenter(k, iEdge) &
-                                    /(layerThickEdgeCenter(k - 1, iEdge) + layerThickEdgeCenter(k, iEdge))
+                  tridiagA(k - 2) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdgeMean(k - 1, iEdge) &
+                                    /(layerThickEdgeMean(k - 1, iEdge) + layerThickEdgeMean(k, iEdge))
+                  tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThickEdgeMean(k - 1, iEdge) &
+                                                                        *layerThickEdgeMean(k, iEdge)) - BruntVaisalaFreqTopEdge
+                  tridiagC(k - 1) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdgeMean(k, iEdge) &
+                                    /(layerThickEdgeMean(k - 1, iEdge) + layerThickEdgeMean(k, iEdge))
                   rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gravity/rho_sw &
                                          *gradDensityConstZTopOfEdge(k,iEdge)
                end do
@@ -705,10 +705,10 @@ contains
                k = maxLevelEdgeTop(iEdge)
                BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k, cell1) + BruntVaisalaFreqTop(k, cell2))
                BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
-               tridiagA(k - 2) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdgeCenter(k - 1, iEdge) &
-                                 /(layerThickEdgeCenter(k - 1, iEdge) + layerThickEdgeCenter(k, iEdge))
-               tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThickEdgeCenter(k - 1, iEdge) &
-                                                                     *layerThickEdgeCenter(k, iEdge)) - BruntVaisalaFreqTopEdge
+               tridiagA(k - 2) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdgeMean(k - 1, iEdge) &
+                                 /(layerThickEdgeMean(k - 1, iEdge) + layerThickEdgeMean(k, iEdge))
+               tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThickEdgeMean(k - 1, iEdge) &
+                                                                     *layerThickEdgeMean(k, iEdge)) - BruntVaisalaFreqTopEdge
                rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gravity/rho_sw &
                                       *gradDensityConstZTopOfEdge(k,iEdge)
                ! Total number of rows
@@ -731,7 +731,7 @@ contains
          do iEdge = 1, nEdges
             do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                normalGMBolusVelocity(k, iEdge) = gmResolutionTaper(iEdge) * (gmStreamFuncTopOfEdge(k, iEdge) &
-                      - gmStreamFuncTopOfEdge(k + 1, iEdge)) /layerThickEdgeCenter(k, iEdge)
+                      - gmStreamFuncTopOfEdge(k + 1, iEdge)) /layerThickEdgeMean(k, iEdge)
             end do
          end do
          !$omp end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -473,8 +473,8 @@ contains
             ! The interpolation can only be carried out on non-boundary edges
             if (maxLevelEdgeTop(iEdge) .GE. minLevelEdgeBot(iEdge)) then
                do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
-                  h1 = layerThickEdge(k-1,iEdge)
-                  h2 = layerThickEdge(k,iEdge)
+                  h1 = layerThickEdgeCenter(k-1,iEdge)
+                  h2 = layerThickEdgeCenter(k,iEdge)
                   ! Using second-order interpolation below
                   gradDensityTopOfEdge(k,iEdge) = (h2 * gradDensityEdge(k-1,iEdge) + h1 * &
                                 gradDensityEdge(k,iEdge)) / (h1 + h2)
@@ -592,7 +592,7 @@ contains
               cell2 = cellsOnEdge(2, iEdge)
 
               k = minLevelEdgeBot(iEdge)+1
-              zEdge = -layerThickEdge(k-1,iEdge)
+              zEdge = -layerThickEdgeCenter(k-1,iEdge)
               do while(zEdge > -config_GM_Visbeck_max_depth .and. k < maxLevelEdgeTop(iEdge))
                 lt1 = 0.5_RKIND*(layerThickness(k,cell1) + layerThickness(k-1,cell1))
                 lt2 = 0.5_RKIND*(layerThickness(k,cell2) + layerThickness(k-1,cell2))
@@ -604,7 +604,7 @@ contains
                 countN2 = countN2 + 1
 
                 k = k + 1
-                zEdge = zEdge - layerThickEdge(k-1,iEdge)
+                zEdge = zEdge - layerThickEdgeCenter(k-1,iEdge)
               end do
 
               if (countN2 > 0) then
@@ -643,7 +643,7 @@ contains
               do k=minLevelEdgeBot(iEdge)+1,maxLevelEdgeTop(iEdge)
                  BruntVaisalaFreqTopEdge = 0.5_RKIND*(max(BruntVaisalaFreqTop(k,cell1),0.0_RKIND) + &
                                           max(BruntVaisalaFreqTop(k,cell2),0.0_RKIND))
-                 shearEdgeInv = (0.5_RKIND*(layerThickEdge(k-1,iEdge) + layerThickEdge(k,iEdge)))**2.0 &
+                 shearEdgeInv = (0.5_RKIND*(layerThickEdgeFlux(k-1,iEdge) + layerThickEdgeFlux(k,iEdge)))**2.0 &
                     / (  (normalVelocity(k-1,iEdge) - normalVelocity(k,iEdge))**2.0 &
                        + (tangentialVelocity(k-1,iEdge) - tangentialVelocity(k,iEdge))**2.0 &
                        + 1.0e-18_RKIND )
@@ -680,10 +680,10 @@ contains
 
                BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k, cell1) + BruntVaisalaFreqTop(k, cell2))
                BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
-               tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThickEdge(k - 1, iEdge) &
-                                                                     *layerThickEdge(k, iEdge)) - BruntVaisalaFreqTopEdge
-               tridiagC(k - 1) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdge(k, iEdge) &
-                                 /(layerThickEdge(k - 1, iEdge) + layerThickEdge(k, iEdge))
+               tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThickEdgeCenter(k - 1, iEdge) &
+                                                                     *layerThickEdgeCenter(k, iEdge)) - BruntVaisalaFreqTopEdge
+               tridiagC(k - 1) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdgeCenter(k, iEdge) &
+                                 /(layerThickEdgeCenter(k - 1, iEdge) + layerThickEdgeCenter(k, iEdge))
                rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gravity/rho_sw &
                                       *gradDensityConstZTopOfEdge(k,iEdge)
 
@@ -691,12 +691,12 @@ contains
                do k = minLevelEdgeBot(iEdge) + 2, maxLevelEdgeTop(iEdge) - 1
                   BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k, cell1) + BruntVaisalaFreqTop(k, cell2))
                   BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
-                  tridiagA(k - 2) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdge(k - 1, iEdge) &
-                                    /(layerThickEdge(k - 1, iEdge) + layerThickEdge(k, iEdge))
-                  tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThickEdge(k - 1, iEdge) &
-                                                                        *layerThickEdge(k, iEdge)) - BruntVaisalaFreqTopEdge
-                  tridiagC(k - 1) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdge(k, iEdge) &
-                                    /(layerThickEdge(k - 1, iEdge) + layerThickEdge(k, iEdge))
+                  tridiagA(k - 2) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdgeCenter(k - 1, iEdge) &
+                                    /(layerThickEdgeCenter(k - 1, iEdge) + layerThickEdgeCenter(k, iEdge))
+                  tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThickEdgeCenter(k - 1, iEdge) &
+                                                                        *layerThickEdgeCenter(k, iEdge)) - BruntVaisalaFreqTopEdge
+                  tridiagC(k - 1) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdgeCenter(k, iEdge) &
+                                    /(layerThickEdgeCenter(k - 1, iEdge) + layerThickEdgeCenter(k, iEdge))
                   rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gravity/rho_sw &
                                          *gradDensityConstZTopOfEdge(k,iEdge)
                end do
@@ -705,10 +705,10 @@ contains
                k = maxLevelEdgeTop(iEdge)
                BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k, cell1) + BruntVaisalaFreqTop(k, cell2))
                BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
-               tridiagA(k - 2) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdge(k - 1, iEdge) &
-                                 /(layerThickEdge(k - 1, iEdge) + layerThickEdge(k, iEdge))
-               tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThickEdge(k - 1, iEdge) &
-                                                                     *layerThickEdge(k, iEdge)) - BruntVaisalaFreqTopEdge
+               tridiagA(k - 2) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdgeCenter(k - 1, iEdge) &
+                                 /(layerThickEdgeCenter(k - 1, iEdge) + layerThickEdgeCenter(k, iEdge))
+               tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThickEdgeCenter(k - 1, iEdge) &
+                                                                     *layerThickEdgeCenter(k, iEdge)) - BruntVaisalaFreqTopEdge
                rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gravity/rho_sw &
                                       *gradDensityConstZTopOfEdge(k,iEdge)
                ! Total number of rows
@@ -731,7 +731,7 @@ contains
          do iEdge = 1, nEdges
             do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                normalGMBolusVelocity(k, iEdge) = gmResolutionTaper(iEdge) * (gmStreamFuncTopOfEdge(k, iEdge) &
-                      - gmStreamFuncTopOfEdge(k + 1, iEdge)) /layerThickEdge(k, iEdge)
+                      - gmStreamFuncTopOfEdge(k + 1, iEdge)) /layerThickEdgeCenter(k, iEdge)
             end do
          end do
          !$omp end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
@@ -1117,7 +1117,7 @@ contains
             !$omp end parallel
          endif ! compute budgets
 
-         call ocn_tracer_hmix_tend(meshPool, layerThickEdgeFlux, &
+         call ocn_tracer_hmix_tend(meshPool, layerThickEdgeCenter, &
                                    layerThickness, zMid, tracerGroup, &
                                    RediKappa, slopeTriadUp, &
                                    slopeTriadDown, dt, isActiveTracer, &

--- a/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
@@ -201,7 +201,7 @@ contains
       ! for explanation of divergence operator.
       !
       call ocn_thick_hadv_tend(normalTransportVelocity, &
-                               layerThickEdge, tendThick, err)
+                               layerThickEdgeFlux, tendThick, err)
 
       ! Compute vertical advection term -d/dz(hw)
       call ocn_thick_vadv_tend(vertAleTransportTop, &
@@ -345,7 +345,7 @@ contains
       !$acc update device(zMid, divergence, relativeVorticity, normPlanetVortEdge, &
       !$acc               density, normRelVortEdge, montgomeryPotential, pressure, &
       !$acc               thermExpCoeff, salineContractCoeff, tangentialVelocity, &
-      !$acc               layerThickEdge, kineticEnergyCell, sfcFlxAttCoeff, potentialDensity, &
+      !$acc               layerThickEdgeFlux, kineticEnergyCell, sfcFlxAttCoeff, potentialDensity, &
       !$acc               vertAleTransportTop, vertViscTopOfEdge, wettingVelocity)
       !$acc enter data &
       !$acc    copyin(tendVel, sfcStress, sfcStressMag, &
@@ -402,11 +402,11 @@ contains
       ! momentum, formulated as grad of kinetic energy
       call ocn_vel_hadv_coriolis_tend(normRelVortEdge, &
                                       normPlanetVortEdge, &
-                                      layerThickEdge, normalVelocity, &
+                                      layerThickEdgeFlux, normalVelocity, &
                                       kineticEnergyCell, tendVel, err)
 
       ! Add vertical advection term -w du/dz
-      call ocn_vel_vadv_tend(normalVelocity, layerThickEdge, &
+      call ocn_vel_vadv_tend(normalVelocity, layerThickEdgeFlux, &
                              vertAleTransportTop, tendVel, err)
 
       ! Add pressure gradient
@@ -430,7 +430,7 @@ contains
       ! Add forcing and bottom drag
       call ocn_vel_forcing_tend(normalVelocity, sfcFlxAttCoeff, &
                                 sfcStress, kineticEnergyCell, &
-                                layerThickEdge, tendVel, err)
+                                layerThickEdgeCenter, tendVel, err)
 
       ! vertical mixing treated implicitly in a later routine
       ! adjust total velocity tendency based on wetting/drying
@@ -503,7 +503,7 @@ contains
 
       ! these variables input from shared diagnostics module:
       !    normalTransportVelocity - transport velocity across edge
-      !    layerThickEdge          - layer thickness on edge
+      !    layerThickEdgeFlux          - layer thickness on edge
 
       !-----------------------------------------------------------------
       ! input/output variables
@@ -648,14 +648,14 @@ contains
       !$acc            copyin(layerThickness)
       !TEMPORARY - once diagnotics module ported, these should already
       !            be on the device
-      !$acc update device (normalTransportVelocity, layerThickEdge, &
+      !$acc update device (normalTransportVelocity, layerThickEdgeFlux, &
       !$acc                vertAleTransportTop)
 
       ! compute transport velocity to use for all tracers
 #ifdef MPAS_OPENACC
       !$acc parallel loop collapse(2) &
       !$acc    present(normalThicknessFlux, normalTransportVelocity, &
-      !$acc            layerThickEdge)
+      !$acc            layerThickEdgeFlux)
 #else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
@@ -664,7 +664,7 @@ contains
       do k = 1,nVertLevels
          normalThicknessFlux(k,iEdge) = &
                  normalTransportVelocity(k,iEdge)* &
-                 layerThickEdge(k, iEdge)
+                 layerThickEdgeFlux(k, iEdge)
       end do
       end do
 #ifndef MPAS_OPENACC
@@ -1117,7 +1117,7 @@ contains
             !$omp end parallel
          endif ! compute budgets
 
-         call ocn_tracer_hmix_tend(meshPool, layerThickEdge, &
+         call ocn_tracer_hmix_tend(meshPool, layerThickEdgeFlux, &
                                    layerThickness, zMid, tracerGroup, &
                                    RediKappa, slopeTriadUp, &
                                    slopeTriadDown, dt, isActiveTracer, &
@@ -1417,7 +1417,7 @@ contains
             iEdge = edgesOnCell(i, iCell)
 
             do k = 1, maxLevelEdgeTop(iEdge)
-               flux = layerThickEdge(k,iEdge)*normalVelocity(k,iEdge)* &
+               flux = layerThickEdgeFlux(k,iEdge)*normalVelocity(k,iEdge)* &
                       dvEdge(iEdge)*edgeSignOnCell(i,iCell)*invAreaCell
                div_hu(k) = div_hu(k) - flux
                div_hu_btr = div_hu_btr - flux

--- a/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
@@ -430,7 +430,7 @@ contains
       ! Add forcing and bottom drag
       call ocn_vel_forcing_tend(normalVelocity, sfcFlxAttCoeff, &
                                 sfcStress, kineticEnergyCell, &
-                                layerThickEdgeCenter, tendVel, err)
+                                layerThickEdgeMean, tendVel, err)
 
       ! vertical mixing treated implicitly in a later routine
       ! adjust total velocity tendency based on wetting/drying
@@ -503,7 +503,7 @@ contains
 
       ! these variables input from shared diagnostics module:
       !    normalTransportVelocity - transport velocity across edge
-      !    layerThickEdgeFlux          - layer thickness on edge
+      !    layerThickEdgeFlux      - flux-related layer thickness on edge
 
       !-----------------------------------------------------------------
       ! input/output variables
@@ -1117,7 +1117,7 @@ contains
             !$omp end parallel
          endif ! compute budgets
 
-         call ocn_tracer_hmix_tend(meshPool, layerThickEdgeCenter, &
+         call ocn_tracer_hmix_tend(meshPool, layerThickEdgeMean, &
                                    layerThickness, zMid, tracerGroup, &
                                    RediKappa, slopeTriadUp, &
                                    slopeTriadDown, dt, isActiveTracer, &

--- a/components/mpas-ocean/src/shared/mpas_ocn_thick_hadv.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_thick_hadv.F
@@ -71,7 +71,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_thick_hadv_tend(normalVelocity, layerThicknessEdge, tend, err)!{{{
+   subroutine ocn_thick_hadv_tend(normalVelocity, layerThickEdgeFlux, tend, err)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -83,7 +83,7 @@ contains
          normalVelocity    !< Input: velocity
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdge     !< Input: flux-related thickness at edge
+         layerThickEdgeFlux     !< Input: flux-related thickness at edge
 
       !-----------------------------------------------------------------
       !
@@ -140,7 +140,7 @@ contains
         do i = 1, nEdgesOnCell(iCell)
           iEdge = edgesOnCell(i, iCell)
           do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-            flux = normalVelocity(k, iEdge) * dvEdge(iEdge) * layerThicknessEdge(k, iEdge)
+            flux = normalVelocity(k, iEdge) * dvEdge(iEdge) * layerThickEdgeFlux(k, iEdge)
             tend(k, iCell) = tend(k, iCell) + edgeSignOnCell(i, iCell) * flux * invAreaCell
           end do
         end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_thick_hadv.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_thick_hadv.F
@@ -83,7 +83,7 @@ contains
          normalVelocity    !< Input: velocity
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdge     !< Input: thickness at edge
+         layerThicknessEdge     !< Input: flux-related thickness at edge
 
       !-----------------------------------------------------------------
       !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix.F
@@ -79,7 +79,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_hmix_tend(meshPool, layerThicknessEdge, layerThickness, zMid, tracers, &
+   subroutine ocn_tracer_hmix_tend(meshPool, layerThickEdgeMean, layerThickness, zMid, tracers, &
                                    RediKappa, slopeTriadUp, slopeTriadDown, dt, isActiveTracer,          &
                                    RediKappaSfcTaper, RediKappaScaling, rediLimiterCount, tend, err)!{{{
 
@@ -95,7 +95,7 @@ contains
          RediKappa
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdge, &!< Input: flux-related thickness at edge
+         layerThickEdgeMean, &!< Input: mean thickness at edge
          layerThickness,     &!< Input: thickness at centers
          zMid                 !< Input: Z coordinate at the center of a cell
       real (kind=RKIND), dimension(:,:), intent(in), optional :: &
@@ -148,10 +148,10 @@ contains
 
       call mpas_timer_start("tracer hmix")
 
-      call ocn_tracer_hmix_del2_tend(meshPool, layerThicknessEdge, tracers, tend, err1)
-      call ocn_tracer_hmix_del4_tend(meshPool, layerThicknessEdge, tracers, tend, err2)
+      call ocn_tracer_hmix_del2_tend(meshPool, layerThickEdgeMean, tracers, tend, err1)
+      call ocn_tracer_hmix_del4_tend(meshPool, layerThickEdgeMean, tracers, tend, err2)
       if (config_use_Redi) then
-        call ocn_tracer_hmix_Redi_tend(meshPool, layerThickness, layerThicknessEdge, zMid, tracers, &
+        call ocn_tracer_hmix_Redi_tend(meshPool, layerThickness, layerThickEdgeMean, zMid, tracers, &
                                      RediKappa, dt, isActiveTracer,        &
                                      slopeTriadUp, slopeTriadDown, RediKappaSfcTaper, &
                                      RediKappaScaling, rediLimiterCount, tend, err1)

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix.F
@@ -95,7 +95,7 @@ contains
          RediKappa
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdge, &!< Input: thickness at edge
+         layerThicknessEdge, &!< Input: flux-related thickness at edge
          layerThickness,     &!< Input: thickness at centers
          zMid                 !< Input: Z coordinate at the center of a cell
       real (kind=RKIND), dimension(:,:), intent(in), optional :: &

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del2.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del2.F
@@ -86,7 +86,7 @@ contains
       type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdge !< Input: flux-related thickness at edges
+         layerThicknessEdge !< Input: mean thickness at edges
 
       real (kind=RKIND), dimension(:,:,:), intent(in) :: &
         tracers !< Input: tracer quantities

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del2.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del2.F
@@ -76,7 +76,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_hmix_del2_tend(meshPool, layerThicknessEdge, tracers, tend, err)!{{{
+   subroutine ocn_tracer_hmix_del2_tend(meshPool, layerThickEdgeMean, tracers, tend, err)!{{{
       !-----------------------------------------------------------------
       !
       ! input variables
@@ -86,7 +86,7 @@ contains
       type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdge !< Input: mean thickness at edges
+         layerThickEdgeMean !< Input: mean thickness at edges
 
       real (kind=RKIND), dimension(:,:,:), intent(in) :: &
         tracers !< Input: tracer quantities
@@ -172,7 +172,7 @@ contains
               tracer_turb_flux = tracers(iTracer, k, cell2) - tracers(iTracer, k, cell1)
 
               ! div(h \kappa_2 \nabla \phi) at cell center
-              flux = layerThicknessEdge(k, iEdge) * tracer_turb_flux * r_tmp
+              flux = layerThickEdgeMean(k, iEdge) * tracer_turb_flux * r_tmp
 
               tend(iTracer, k, iCell) = tend(iTracer, k, iCell) - edgeSignOnCell(i, iCell) * flux * invAreaCell
             end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del2.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del2.F
@@ -86,7 +86,7 @@ contains
       type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdge !< Input: thickness at edges
+         layerThicknessEdge !< Input: flux-related thickness at edges
 
       real (kind=RKIND), dimension(:,:,:), intent(in) :: &
         tracers !< Input: tracer quantities

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del4.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del4.F
@@ -84,7 +84,7 @@ contains
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdge    !< Input: flux-related thickness at edge
+         layerThicknessEdge    !< Input: mean thickness at edge
 
       type (mpas_pool_type), intent(in) :: &
          meshPool          !< Input: mesh information

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del4.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del4.F
@@ -75,7 +75,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_hmix_del4_tend(meshPool, layerThicknessEdge, tracers, tend, err)!{{{
+   subroutine ocn_tracer_hmix_del4_tend(meshPool, layerThickEdgeMean, tracers, tend, err)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -84,7 +84,7 @@ contains
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdge    !< Input: mean thickness at edge
+         layerThickEdgeMean    !< Input: mean thickness at edge
 
       type (mpas_pool_type), intent(in) :: &
          meshPool          !< Input: mesh information
@@ -186,8 +186,8 @@ contains
           do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
             do iTracer = 1, num_tracers * edgeMask(k, iEdge)
 
-              r_tmp1 = invdcEdge * layerThicknessEdge(k, iEdge) * tracers(iTracer, k, cell1)
-              r_tmp2 = invdcEdge * layerThicknessEdge(k, iEdge) * tracers(iTracer, k, cell2)
+              r_tmp1 = invdcEdge * layerThickEdgeMean(k, iEdge) * tracers(iTracer, k, cell1)
+              r_tmp2 = invdcEdge * layerThickEdgeMean(k, iEdge) * tracers(iTracer, k, cell2)
 
               delsq_tracer(iTracer, k, iCell) = delsq_tracer(iTracer, k, iCell) - edgeSignOnCell(i, iCell) &
                                               * (r_tmp2 - r_tmp1) * invAreaCell1

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del4.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del4.F
@@ -84,7 +84,7 @@ contains
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdge    !< Input: thickness at edge
+         layerThicknessEdge    !< Input: flux-related thickness at edge
 
       type (mpas_pool_type), intent(in) :: &
          meshPool          !< Input: mesh information

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -89,7 +89,7 @@ contains
          RediKappa
 
       real(kind=RKIND), dimension(:, :), intent(in) :: &
-         layerThicknessEdge, &!< Input: thickness at edge
+         layerThicknessEdge, &!< Input: flux-related thickness at edge
          zMid, &!< Input: Z coordinate at the center of a cell
          RediKappaSfcTaper, &!< Input: vertical structure of GM/Redi limiter
          RediKappaScaling, &

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -89,7 +89,7 @@ contains
          RediKappa
 
       real(kind=RKIND), dimension(:, :), intent(in) :: &
-         layerThicknessEdge, &!< Input: flux-related thickness at edge
+         layerThicknessEdge, &!< Input: mean thickness at edge
          zMid, &!< Input: Z coordinate at the center of a cell
          RediKappaSfcTaper, &!< Input: vertical structure of GM/Redi limiter
          RediKappaScaling, &

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -73,7 +73,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_hmix_Redi_tend(meshPool, layerThickness, layerThicknessEdge, zMid, tracers, &
+   subroutine ocn_tracer_hmix_Redi_tend(meshPool, layerThickness, layerThickEdgeMean, zMid, tracers, &
                                         RediKappa, dt, isActiveTracer, slopeTriadUp, slopeTriadDown, &
                                         RediKappaSfcTaper, RediKappaScaling, rediLimiterCount, tend, err)!{{{
 
@@ -89,7 +89,7 @@ contains
          RediKappa
 
       real(kind=RKIND), dimension(:, :), intent(in) :: &
-         layerThicknessEdge, &!< Input: mean thickness at edge
+         layerThickEdgeMean, &!< Input: mean thickness at edge
          zMid, &!< Input: Z coordinate at the center of a cell
          RediKappaSfcTaper, &!< Input: vertical structure of GM/Redi limiter
          RediKappaScaling, &
@@ -236,11 +236,11 @@ contains
 
             do iTr = 1, nTracers
                tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)
-               flux = layerThicknessEdge(k, iEdge)*tracer_turb_flux*r_tmp*RediKappa(iEdge)
+               flux = layerThickEdgeMean(k, iEdge)*tracer_turb_flux*r_tmp*RediKappa(iEdge)
                redi_term1(iTr, k, iCell) = redi_term1(iTr, k, iCell) - (1.0_RKIND + term1TaperFactor* &
                                            (kappaRediEdgeVal - 1.0_RKIND))*edgeSignOnCell(i, iCell)*flux*invAreaCell
 
-               flux_term2 = coef*kappaRediEdgeVal*RediKappa(iEdge)*layerThicknessEdge(k, iEdge)* &
+               flux_term2 = coef*kappaRediEdgeVal*RediKappa(iEdge)*layerThickEdgeMean(k, iEdge)* &
                             0.25_RKIND* &
                             (slopeTriadDown(k, 1, iEdge)*(tracers(iTr, k, cell1) - tracers(iTr, k + 1, cell1)) &
                              /(zMid(k, cell1) - zMid(k + 1, cell1)) &
@@ -248,12 +248,12 @@ contains
                              /(zMid(k, cell2) - zMid(k + 1, cell2)))
                if (minLevelCell(cell1) < minLevelEdgeBot(iEdge)) then
                   flux_term2 = flux_term2 + coef*RediKappa(iEdge)* &
-                               layerThicknessEdge(minLevelEdgeBot(iEdge), iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadUp(minLevelEdgeBot(iEdge), 1, iEdge)* &
+                               layerThickEdgeMean(minLevelEdgeBot(iEdge), iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadUp(minLevelEdgeBot(iEdge), 1, iEdge)* &
                                (tracers(iTr, minLevelEdgeBot(iEdge) - 1, cell1) - tracers(iTr, minLevelEdgeBot(iEdge), cell1))/(zMid(minLevelEdgeBot(iEdge) - 1, cell1) - zMid(minLevelEdgeBot(iEdge), cell1))
                endif
                if (minLevelCell(cell2) < minLevelEdgeBot(iEdge)) then
                   flux_term2 = flux_term2 + coef*RediKappa(iEdge)* &
-                               layerThicknessEdge(minLevelEdgeBot(iEdge), iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadUp(minLevelEdgeBot(iEdge), 2, iEdge)* &
+                               layerThickEdgeMean(minLevelEdgeBot(iEdge), iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadUp(minLevelEdgeBot(iEdge), 2, iEdge)* &
                                (tracers(iTr, minLevelEdgeBot(iEdge) - 1, cell2) - tracers(iTr, minLevelEdgeBot(iEdge), cell2))/(zMid(minLevelEdgeBot(iEdge) - 1, cell2) - zMid(minLevelEdgeBot(iEdge), cell2))
                endif
 
@@ -273,12 +273,12 @@ contains
                   tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)
 
                   ! div(h \kappa_2 \nabla \phi) at cell center
-                  flux = layerThicknessEdge(k, iEdge)*tracer_turb_flux*r_tmp*RediKappa(iEdge)
+                  flux = layerThickEdgeMean(k, iEdge)*tracer_turb_flux*r_tmp*RediKappa(iEdge)
 
                   redi_term1(iTr, k, iCell) = redi_term1(iTr, k, iCell) - (1.0_RKIND + term1TaperFactor* &
                                               (kappaRediEdgeVal - 1.0_RKIND))*edgeSignOnCell(i, iCell)*flux*invAreaCell
 
-                  flux_term2 = coef*RediKappa(iEdge)*kappaRediEdgeVal*layerThicknessEdge(k, iEdge)* &
+                  flux_term2 = coef*RediKappa(iEdge)*kappaRediEdgeVal*layerThickEdgeMean(k, iEdge)* &
                                0.25_RKIND* &
                                (slopeTriadUp(k, 1, iEdge)*(tracers(iTr, k - 1, cell1) - tracers(iTr, k, cell1)) &
                                 /(zMid(k - 1, cell1) - zMid(k, cell1)) &
@@ -307,12 +307,12 @@ contains
 
             do iTr = 1, nTracers
                tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)
-               flux = layerThicknessEdge(k, iEdge)*tracer_turb_flux*r_tmp*RediKappa(iEdge)
+               flux = layerThickEdgeMean(k, iEdge)*tracer_turb_flux*r_tmp*RediKappa(iEdge)
                redi_term1(iTr, k, iCell) = redi_term1(iTr, k, iCell) - (1.0_RKIND + term1TaperFactor* &
                                            (kappaRediEdgeVal - 1.0_RKIND))*edgeSignOnCell(i, iCell)*flux*invAreaCell
 
                ! For bottom layer, only use triads pointing up:
-               flux_term2 = coef*kappaRediEdgeVal*RediKappa(iEdge)*layerThicknessEdge(k, iEdge)* &
+               flux_term2 = coef*kappaRediEdgeVal*RediKappa(iEdge)*layerThickEdgeMean(k, iEdge)* &
                             0.25_RKIND* &
                             (slopeTriadUp(k, 1, iEdge)*(tracers(iTr, k - 1, cell1) - tracers(iTr, k, cell1)) &
                              /(zMid(k - 1, cell1) - zMid(k, cell1)) &
@@ -321,12 +321,12 @@ contains
 
                if (maxLevelCell(cell1) > maxLevelEdgeTop(iEdge)) then
                   flux_term2 = flux_term2 + coef*RediKappa(iEdge)* &
-                               layerThicknessEdge(k, iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadDown(k, 1, iEdge)* &
+                               layerThickEdgeMean(k, iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadDown(k, 1, iEdge)* &
                                (tracers(iTr, k, cell1) - tracers(iTr, k + 1, cell1))/(zMid(k, cell1) - zMid(k + 1, cell1))
                endif
                if (maxLevelCell(cell2) > maxLevelEdgeTop(iEdge)) then
                   flux_term2 = flux_term2 + coef*RediKappa(iEdge)* &
-                               layerThicknessEdge(k, iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadDown(k, 2, iEdge)* &
+                               layerThickEdgeMean(k, iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadDown(k, 2, iEdge)* &
                                (tracers(iTr, k, cell2) - tracers(iTr, k + 1, cell2))/(zMid(k, cell2) - zMid(k + 1, cell2))
                endif
                redi_term2(iTr, k, iCell) = redi_term2(iTr, k, iCell) - edgeSignOnCell(i, iCell)*flux_term2 &

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing.F
@@ -86,7 +86,7 @@ contains
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          normalVelocity,    &!< [in] Normal velocity at edges
          kineticEnergyCell, &!< [in] kinetic energy at cell
-         layerThicknessEdge  !< [in] centered thickness at edge
+         layerThicknessEdge  !< [in] mean thickness at edge
 
       real (kind=RKIND), dimension(:), intent(in) :: &
          sfcFlxAttCoeff, &!< [in] attenuation coefficient for sfc fluxes

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing.F
@@ -77,7 +77,7 @@ contains
 
    subroutine ocn_vel_forcing_tend(normalVelocity, sfcFlxAttCoeff, &
                                    surfaceStress, kineticEnergyCell, &
-                                   layerThicknessEdge, tend, err)!{{{
+                                   layerThickEdgeMean, tend, err)!{{{
 
       !-----------------------------------------------------------------
       ! input variables
@@ -86,7 +86,7 @@ contains
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          normalVelocity,    &!< [in] Normal velocity at edges
          kineticEnergyCell, &!< [in] kinetic energy at cell
-         layerThicknessEdge  !< [in] mean thickness at edge
+         layerThickEdgeMean  !< [in] mean thickness at edge
 
       real (kind=RKIND), dimension(:), intent(in) :: &
          sfcFlxAttCoeff, &!< [in] attenuation coefficient for sfc fluxes
@@ -120,11 +120,11 @@ contains
       err = 0
 
       call ocn_vel_forcing_surface_stress_tend(sfcFlxAttCoeff, &
-                   surfaceStress, layerThicknessEdge, tend, err1)
+                   surfaceStress, layerThickEdgeMean, tend, err1)
       err = ior(err, err1)
 
       call ocn_vel_forcing_explicit_bottom_drag_tend(normalVelocity, &
-                   kineticEnergyCell, layerThicknessEdge, tend, err1)
+                   kineticEnergyCell, layerThickEdgeMean, tend, err1)
       err = ior(err, err1)
 
       call ocn_vel_forcing_topographic_wave_drag_tend(normalVelocity, &

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing.F
@@ -86,7 +86,7 @@ contains
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          normalVelocity,    &!< [in] Normal velocity at edges
          kineticEnergyCell, &!< [in] kinetic energy at cell
-         layerThicknessEdge  !< [in] thickness at edge
+         layerThicknessEdge  !< [in] centered thickness at edge
 
       real (kind=RKIND), dimension(:), intent(in) :: &
          sfcFlxAttCoeff, &!< [in] attenuation coefficient for sfc fluxes

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_explicit_bottom_drag.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_explicit_bottom_drag.F
@@ -76,16 +76,16 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_vel_forcing_explicit_bottom_drag_tend(normVelocity, &
-                                 KECell, layerThickEdge, tend, err) !{{{
+                                 KECell, layerThickEdgeMean, tend, err) !{{{
 
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         normVelocity,  &!< [in] normal velocity
-         KECell,        &!< [in] kinetic energy at cell
-         layerThickEdge  !< [in] centered layer thickness at edge
+         normVelocity,      &!< [in] normal velocity
+         KECell,            &!< [in] kinetic energy at cell
+         layerThickEdgeMean  !< [in] mean layer thickness at edge
 
       !-----------------------------------------------------------------
       ! input/output variables
@@ -130,7 +130,7 @@ contains
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
       !$acc    present(cellsOnEdge, maxLevelEdgeTop, KECell, &
-      !$acc            tend, normVelocity, layerThickEdge) &
+      !$acc            tend, normVelocity, layerThickEdgeMean) &
       !$acc    private(k, cell1, cell2)
 #else
       !$omp parallel
@@ -144,7 +144,7 @@ contains
         if (k > 0) then
            tend(k,iEdge) = tend(k,iEdge) - dragCoeff* &
                            sqrt(KECell(k,cell1) + KECell(k,cell2))* &
-                           normVelocity(k,iEdge)/layerThickEdge(k,iEdge)
+                           normVelocity(k,iEdge)/layerThickEdgeMean(k,iEdge)
         end if
 
       enddo

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_explicit_bottom_drag.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_explicit_bottom_drag.F
@@ -85,7 +85,7 @@ contains
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          normVelocity,  &!< [in] normal velocity
          KECell,        &!< [in] kinetic energy at cell
-         layerThickEdge  !< [in] layer thickness at edge
+         layerThickEdge  !< [in] centered layer thickness at edge
 
       !-----------------------------------------------------------------
       ! input/output variables

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_surface_stress.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_surface_stress.F
@@ -88,7 +88,7 @@ contains
          sfcFlxAttCoeff  !< [in] attenuation coefficient for sfc fluxes
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThickEdge  !< [in] thickness at edge
+         layerThickEdge  !< [in] centered thickness at edge
 
       !-----------------------------------------------------------------
       ! input/output variables

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_surface_stress.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_surface_stress.F
@@ -88,7 +88,7 @@ contains
          sfcFlxAttCoeff  !< [in] attenuation coefficient for sfc fluxes
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThickEdge  !< [in] centered thickness at edge
+         layerThickEdge  !< [in] mean thickness at edge
 
       !-----------------------------------------------------------------
       ! input/output variables

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_surface_stress.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_surface_stress.F
@@ -77,7 +77,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_vel_forcing_surface_stress_tend(sfcFlxAttCoeff, &
-                               sfcStress, layerThickEdge, tend, err)!{{{
+                               sfcStress, layerThickEdgeMean, tend, err)!{{{
 
       !-----------------------------------------------------------------
       ! input variables
@@ -88,7 +88,7 @@ contains
          sfcFlxAttCoeff  !< [in] attenuation coefficient for sfc fluxes
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThickEdge  !< [in] mean thickness at edge
+         layerThickEdgeMean  !< [in] mean thickness at edge
 
       !-----------------------------------------------------------------
       ! input/output variables
@@ -135,7 +135,7 @@ contains
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
       !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, edgeMask, &
-      !$acc            sfcFlxAttCoeff, sfcStress, layerThickEdge, &
+      !$acc            sfcFlxAttCoeff, sfcStress, layerThickEdgeMean, &
       !$acc            tend) &
       !$acc    private(k, kmax, cell1, cell2, zBot, zTop, &
       !$acc            attCoeff, attDepth, remainingStress, &
@@ -158,7 +158,7 @@ contains
         remainingStress = 1.0_RKIND
         kmax = maxLevelEdgeTop(iEdge)
         do k = minLevelEdgeBot(iEdge), kmax
-           zBot = zTop - layerThickEdge(k,iEdge)
+           zBot = zTop - layerThickEdgeMean(k,iEdge)
            attDepth = max(zBot/attCoeff, maxAttDepth)
 
            transCoeffBot = exp(attDepth)
@@ -168,7 +168,7 @@ contains
 
            tend(k,iEdge) =  tend(k,iEdge) + &
                             edgeMask(k,iEdge)*sfcStress(iEdge) * &
-                            absorb/rho_sw/layerThickEdge(k,iEdge)
+                            absorb/rho_sw/layerThickEdgeMean(k,iEdge)
 
            zTop = zBot
            transCoeffTop = transCoeffBot
@@ -181,7 +181,7 @@ contains
            tend(kmax,iEdge) = tend(kmax,iEdge) &
                             + edgeMask(kmax,iEdge)*sfcStress(iEdge)* &
                               remainingStress/rho_sw/ &
-                              layerThickEdge(kmax,iEdge)
+                              layerThickEdgeMean(kmax,iEdge)
         end if
       enddo
 #ifndef MPAS_OPENACC

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_hadv_coriolis.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_hadv_coriolis.F
@@ -78,7 +78,7 @@ contains
 
    subroutine ocn_vel_hadv_coriolis_tend(normRelVortEdge, &
                                       normPlanetVortEdge, &
-                                      layerThickEdge, normalVelocity, &
+                                      layerThickEdgeFlux, normalVelocity, &
                                       kineticEnergyCell, tend, err)!{{{
 
       !-----------------------------------------------------------------
@@ -88,7 +88,7 @@ contains
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          normRelVortEdge,    &!< [in] relative vorticity/thickness at edge
          normPlanetVortEdge, &!< [in] planetary vorticity/thickness at edge
-         layerThickEdge,     &!< [in] layer thickness on edge
+         layerThickEdgeFlux,     &!< [in] layer thickness on edge
          normalVelocity,     &!< [in] Horizontal velocity
          kineticEnergyCell    !< [in] Kinetic Energy
 
@@ -189,7 +189,7 @@ contains
       !$acc parallel loop &
       !$acc    present(nEdgesOnEdge, edgesOnEdge, weightsOnEdge, &
       !$acc            minLevelEdgeBot, maxLevelEdgeTop, qArr, tmpVorticity, &
-      !$acc            normalVelocity, layerThickEdge) &
+      !$acc            normalVelocity, layerThickEdgeFlux) &
       !$acc    private(k, j, eoe, edgeWeight, avgVorticity, kmin, kmax)
 #else
       !$omp parallel
@@ -214,7 +214,7 @@ contains
                                tmpVorticity(k,eoe))
                qArr(k,iEdge) = qArr(k,iEdge) + &
                                edgeWeight*normalVelocity(k,eoe)* &
-                               avgVorticity*layerThickEdge(k,eoe)
+                               avgVorticity*layerThickEdgeFlux(k,eoe)
             end do
 
          end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_vadv.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_vadv.F
@@ -72,7 +72,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_vadv_tend(normalVelocity, layerThickEdge, &
+   subroutine ocn_vel_vadv_tend(normalVelocity, layerThickEdgeFlux, &
                                 vertAleTransportTop, tend, err)!{{{
 
       !-----------------------------------------------------------------
@@ -81,7 +81,7 @@ contains
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          normalVelocity,     &!< [in] Horizontal velocity
-         layerThickEdge,     &!< [in] Layer thickness at edge
+         layerThickEdgeFlux,     &!< [in] Layer thickness at edge
          vertAleTransportTop  !< [in] Vertical velocity on top layer
 
       !-----------------------------------------------------------------
@@ -131,7 +131,7 @@ contains
       !$acc parallel loop &
       !$acc    present(cellsOnEdge, minLevelEdgeBot, maxLevelEdgeTop, w_dudzTopEdge, &
       !$acc            vertAleTransportTop, normalVelocity, &
-      !$acc            layerThickEdge) &
+      !$acc            layerThickEdgeFlux) &
       !$acc    private(cell1, cell2, k, kmin, kmax, wAvg)
 #else
       !$omp parallel
@@ -155,8 +155,8 @@ contains
             w_dudzTopEdge(k,iEdge) = wAvg* &
                                      (normalVelocity(k-1,iEdge) - &
                                       normalVelocity(k,  iEdge))/ &
-                         (0.5_RKIND*(layerThickEdge(k-1,iEdge) + &
-                                     layerThickEdge(k  ,iEdge)))
+                         (0.5_RKIND*(layerThickEdgeFlux(k-1,iEdge) + &
+                                     layerThickEdgeFlux(k  ,iEdge)))
          end do
          ! transport is zero at bottom
          w_dudzTopEdge(kmax+1,iEdge) = 0.0_RKIND

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -233,6 +233,9 @@ contains
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          layerThickness !< Input: thickness at cell center
 
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThicknessEdge !< Input: centered thickness at edge
+
       !-----------------------------------------------------------------
       !
       ! input/output variables
@@ -241,9 +244,6 @@ contains
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
          normalVelocity             !< Input: velocity
-
-      real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         layerThicknessEdge        !< Input: thickness at edge
 
       !-----------------------------------------------------------------
       !
@@ -288,13 +288,10 @@ contains
         N = maxLevelEdgeTop(iEdge)
         if (N .gt. 0) then
 
-         ! layerThicknessEdge is computed in compute_solve_diag, and is not available yet,
-         ! so recompute layerThicknessEdge here.
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
          edgeThicknessTotal = 0.0_RKIND
          do k = Nsurf, N
-            layerThicknessEdge(k,iEdge) = 0.5_RKIND * (layerThickness(k,cell1) + layerThickness(k,cell2))
             edgeThicknessTotal = edgeThicknessTotal + layerThicknessEdge(k,iEdge)
          enddo
 
@@ -396,6 +393,9 @@ contains
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          layerThickness !< Input: thickness at cell center
 
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThicknessEdge !< Input: centered thickness at edge
+
       !-----------------------------------------------------------------
       !
       ! input/output variables
@@ -404,9 +404,6 @@ contains
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
          normalVelocity             !< Input: velocity
-
-      real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         layerThicknessEdge        !< Input: thickness at edge
 
       !-----------------------------------------------------------------
       !
@@ -449,13 +446,8 @@ contains
         Nsurf = minLevelEdgeBot(iEdge)
         if (N .gt. 0) then
 
-         ! layerThicknessEdge is computed in compute_solve_diag, and is not available yet,
-         ! so recompute layerThicknessEdge here.
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
-         do k = Nsurf, N
-            layerThicknessEdge(k,iEdge) = 0.5_RKIND * (layerThickness(k,cell1) + layerThickness(k,cell2))
-         enddo
 
          ! tridiagonal matrix algorithm
          C(Nsurf)     = -2.0_RKIND*dt*vertViscTopOfEdge(Nsurf+1,iEdge) &
@@ -551,6 +543,9 @@ contains
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          layerThickness !< Input: thickness at cell center
 
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThicknessEdge !< Input: centered thickness at edge
+
        real (kind=RKIND), dimension(:), intent(in) :: &
          bottomDrag !< Input: bottomDrag at cell centeres
 
@@ -562,9 +557,6 @@ contains
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
          normalVelocity             !< Input: velocity
-
-      real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         layerThicknessEdge        !< Input: thickness at edge
 
       !-----------------------------------------------------------------
       !
@@ -608,14 +600,8 @@ contains
         N = maxLevelEdgeTop(iEdge)
         if (N .gt. 0) then
 
-         ! layerThicknessEdge is computed in compute_solve_diag, and is not available yet,
-         ! so recompute layerThicknessEdge here.
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
-         do k = Nsurf, N
-            layerThicknessEdge(k,iEdge) = 0.5_RKIND * (layerThickness(k,cell1) + layerThickness(k,cell2))
-         end do
-
          ! average cell-based implicit bottom drag to edges
          implicitCd = 0.5_RKIND*(bottomDrag(cell1) + bottomDrag(cell2))
 
@@ -717,6 +703,9 @@ contains
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          layerThickness !< Input: thickness at cell center
 
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThicknessEdge !< Input: centered thickness at edge
+
        real (kind=RKIND), dimension(:), intent(in) :: &
          bottomDrag !< Input: bottomDrag at cell centeres
 
@@ -730,9 +719,6 @@ contains
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
          normalVelocity             !< Input: velocity
-
-      real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         layerThicknessEdge        !< Input: thickness at edge
 
       !-----------------------------------------------------------------
       !
@@ -828,13 +814,8 @@ contains
         N = maxLevelEdgeTop(iEdge)
         if (N .gt. 0) then
 
-         ! layerThicknessEdge is computed in compute_solve_diag, and is not available yet,
-         ! so recompute layerThicknessEdge here.
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
-         do k = Nsurf, N
-            layerThicknessEdge(k,iEdge) = 0.5_RKIND * (layerThickness(k,cell1) + layerThickness(k,cell2))
-         end do
 
          ! average cell-based implicit bottom drag to edges and convert Mannings n to Cd
          if (config_use_implicit_bottom_roughness) then

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -213,7 +213,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_vel_vmix_tend_implicit_rayleigh(dt, kineticEnergyCell, vertViscTopOfEdge, layerThickness, & !{{{
-                                         layerThicknessEdge, normalVelocity, err)
+                                                  layerThickEdgeMean, normalVelocity, err)
 
       !-----------------------------------------------------------------
       !
@@ -234,7 +234,7 @@ contains
          layerThickness !< Input: thickness at cell center
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdge !< Input: mean thickness at edge
+         layerThickEdgeMean !< Input: mean thickness at edge
 
       !-----------------------------------------------------------------
       !
@@ -275,7 +275,7 @@ contains
       !$acc enter data create(bTemp, C, rTemp)
 
       !$acc parallel loop present(maxLevelEdgeTop, minLevelEdgeBot, cellsOnEdge, &
-      !$acc    layerThicknessEdge, layerThickness, vertViscTopOfEdge, normalVelocity, &
+      !$acc    layerThickEdgeMean, layerThickness, vertViscTopOfEdge, normalVelocity, &
       !$acc    kineticEnergyCell) &
       !$acc    private(Nsurf, N, cell1, cell2, edgeThicknessTotal, A, bTemp, C, m, rTemp, k)
 #else
@@ -292,13 +292,13 @@ contains
          cell2 = cellsOnEdge(2,iEdge)
          edgeThicknessTotal = 0.0_RKIND
          do k = Nsurf, N
-            edgeThicknessTotal = edgeThicknessTotal + layerThicknessEdge(k,iEdge)
+            edgeThicknessTotal = edgeThicknessTotal + layerThickEdgeMean(k,iEdge)
          enddo
 
          ! tridiagonal matrix algorithm
          C(Nsurf) = -2.0_RKIND*dt*vertViscTopOfEdge(Nsurf+1,iEdge) &
-                / (layerThicknessEdge(Nsurf,iEdge) + layerThicknessEdge(Nsurf+1,iEdge)) &
-                / layerThicknessEdge(Nsurf,iEdge)
+                / (layerThickEdgeMean(Nsurf,iEdge) + layerThickEdgeMean(Nsurf+1,iEdge)) &
+                / layerThickEdgeMean(Nsurf,iEdge)
          bTemp(Nsurf) = 1.0_RKIND - C(Nsurf) &
             ! added Rayleigh terms
             + dt*rayleighDampingCoef/((1.0_RKIND - rayleighDepthVariable) + rayleighDepthVariable*edgeThicknessTotal)
@@ -307,12 +307,12 @@ contains
          ! first pass: set the coefficients
          do k = Nsurf+1, N-1
             A        = -2.0_RKIND*dt*vertViscTopOfEdge(k,iEdge) &
-                   / (layerThicknessEdge(k-1,iEdge) + layerThicknessEdge(k,iEdge)) &
-                   / layerThicknessEdge(k,iEdge)
+                   / (layerThickEdgeMean(k-1,iEdge) + layerThickEdgeMean(k,iEdge)) &
+                   / layerThickEdgeMean(k,iEdge)
             m        = A/bTemp(k-1)
             C(k)     = -2.0_RKIND*dt*vertViscTopOfEdge(k+1,iEdge) &
-                   / (layerThicknessEdge(k,iEdge) + layerThicknessEdge(k+1,iEdge)) &
-                   / layerThicknessEdge(k,iEdge)
+                   / (layerThickEdgeMean(k,iEdge) + layerThickEdgeMean(k+1,iEdge)) &
+                   / layerThickEdgeMean(k,iEdge)
             bTemp(k) = 1.0_RKIND - A - C(k) &
                    ! added Rayleigh terms
                    + dt*(rayleighDampingCoef/((1.0_RKIND - rayleighDepthVariable) + rayleighDepthVariable*edgeThicknessTotal)) &
@@ -321,8 +321,8 @@ contains
          enddo
 
          A = -2.0_RKIND*dt*vertViscTopOfEdge(N,iEdge) &
-           / (layerThicknessEdge(N-1,iEdge) + layerThicknessEdge(N,iEdge)) &
-           / layerThicknessEdge(N,iEdge)
+           / (layerThickEdgeMean(N-1,iEdge) + layerThickEdgeMean(N,iEdge)) &
+           / layerThickEdgeMean(N,iEdge)
          m = A/bTemp(N-1)
 
          ! x(N) = rTemp(N) / bTemp(N)
@@ -330,7 +330,7 @@ contains
          ! using sqrt(2.0*kineticEnergyEdge(k,iEdge))
          normalVelocity(N,iEdge) = (normalVelocity(N,iEdge) - m*rTemp(N-1)) &
              / (1.0_RKIND - A + dt*implicitBottomDragCoef &
-             * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThicknessEdge(N,iEdge) &
+             * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeMean(N,iEdge) &
              ! added Rayleigh terms
              + dt*(rayleighBottomDampingCoef + rayleighDampingCoef &
              / ((1.0_RKIND - rayleighDepthVariable) + rayleighDepthVariable*edgeThicknessTotal)) &
@@ -373,7 +373,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_vel_vmix_tend_implicit(dt, kineticEnergyCell, vertViscTopOfEdge, layerThickness, & !{{{
-                                         layerThicknessEdge, normalVelocity, err)
+                                         layerThickEdgeMean, normalVelocity, err)
 
       !-----------------------------------------------------------------
       !
@@ -394,7 +394,7 @@ contains
          layerThickness !< Input: thickness at cell center
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdge !< Input: centered thickness at edge
+         layerThickEdgeMean !< Input: mean thickness at edge
 
       !-----------------------------------------------------------------
       !
@@ -434,7 +434,7 @@ contains
       !$acc enter data create(bTemp, C, rTemp)
 
       !$acc parallel loop present(maxLevelEdgeTop, minLevelEdgeBot, cellsOnEdge, &
-      !$acc    layerThicknessEdge, layerThickness, vertViscTopOfEdge, normalVelocity, &
+      !$acc    layerThickEdgeMean, layerThickness, vertViscTopOfEdge, normalVelocity, &
       !$acc    kineticEnergyCell) &
       !$acc    private(Nsurf, N, cell1, cell2, A, bTemp, C, m, rTemp, k)
 #else
@@ -451,27 +451,27 @@ contains
 
          ! tridiagonal matrix algorithm
          C(Nsurf)     = -2.0_RKIND*dt*vertViscTopOfEdge(Nsurf+1,iEdge) &
-                    / (layerThicknessEdge(Nsurf,iEdge) + layerThicknessEdge(Nsurf+1,iEdge)) &
-                    / layerThicknessEdge(Nsurf,iEdge)
+                    / (layerThickEdgeMean(Nsurf,iEdge) + layerThickEdgeMean(Nsurf+1,iEdge)) &
+                    / layerThickEdgeMean(Nsurf,iEdge)
          bTemp(Nsurf) = 1.0_RKIND - C(Nsurf)
          rTemp(Nsurf) = normalVelocity(Nsurf,iEdge)
 
          ! first pass: set the coefficients
          do k = Nsurf+1, N-1
             A        = -2.0_RKIND*dt*vertViscTopOfEdge(k,iEdge) &
-                   / (layerThicknessEdge(k-1,iEdge) + layerThicknessEdge(k,iEdge)) &
-                   / layerThicknessEdge(k,iEdge)
+                   / (layerThickEdgeMean(k-1,iEdge) + layerThickEdgeMean(k,iEdge)) &
+                   / layerThickEdgeMean(k,iEdge)
             m        = A/bTemp(k-1)
             C(k)     = -2.0_RKIND*dt*vertViscTopOfEdge(k+1,iEdge) &
-                   / (layerThicknessEdge(k,iEdge) + layerThicknessEdge(k+1,iEdge)) &
-                   / layerThicknessEdge(k,iEdge)
+                   / (layerThickEdgeMean(k,iEdge) + layerThickEdgeMean(k+1,iEdge)) &
+                   / layerThickEdgeMean(k,iEdge)
             bTemp(k) = 1.0_RKIND - A - C(k) - m*C(k-1)
             rTemp(k) = normalVelocity(k,iEdge) - m*rTemp(k-1)
          enddo
 
          A = -2.0_RKIND*dt*vertViscTopOfEdge(N,iEdge) &
-           / (layerThicknessEdge(N-1,iEdge) + layerThicknessEdge(N,iEdge)) &
-           / layerThicknessEdge(N,iEdge)
+           / (layerThickEdgeMean(N-1,iEdge) + layerThickEdgeMean(N,iEdge)) &
+           / layerThickEdgeMean(N,iEdge)
          m = A/bTemp(N-1)
 
          ! x(N) = rTemp(N) / bTemp(N)
@@ -479,7 +479,7 @@ contains
          ! using sqrt(2.0*kineticEnergyEdge(k,iEdge))
          normalVelocity(N,iEdge) = (normalVelocity(N,iEdge) - m*rTemp(N-1)) &
              / (1.0_RKIND - A + dt*implicitBottomDragCoef &
-             * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThicknessEdge(N,iEdge) &
+             * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeMean(N,iEdge) &
              - m*C(N-1))
          ! second pass: back substitution
          do k = N-1, Nsurf, -1
@@ -523,7 +523,7 @@ contains
 
    subroutine ocn_vel_vmix_tend_implicit_spatially_variable(bottomDrag, dt, kineticEnergyCell, & !{{{
                                          vertViscTopOfEdge, layerThickness, &
-                                         layerThicknessEdge, normalVelocity, err)
+                                         layerThickEdgeMean, normalVelocity, err)
 
       !-----------------------------------------------------------------
       !
@@ -544,7 +544,7 @@ contains
          layerThickness !< Input: thickness at cell center
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdge !< Input: centered thickness at edge
+         layerThickEdgeMean !< Input: mean thickness at edge
 
        real (kind=RKIND), dimension(:), intent(in) :: &
          bottomDrag !< Input: bottomDrag at cell centeres
@@ -589,7 +589,7 @@ contains
       !$acc enter data create(bottomDrag)
 
       !$acc parallel loop present(maxLevelEdgeTop, minLevelEdgeBot, cellsOnEdge, &
-      !$acc    layerThicknessEdge, layerThickness, vertViscTopOfEdge, normalVelocity, &
+      !$acc    layerThickEdgeMean, layerThickness, vertViscTopOfEdge, normalVelocity, &
       !$acc    kineticEnergyCell, bottomDrag) &
       !$acc    private(Nsurf, N, cell1, cell2, implicitCd, A, bTemp, C, m, rTemp, k)
 #else
@@ -607,27 +607,27 @@ contains
 
          ! tridiagonal matrix algorithm
          C(Nsurf)     = -2.0_RKIND*dt*vertViscTopOfEdge(Nsurf+1,iEdge) &
-                    / (layerThicknessEdge(Nsurf,iEdge) + layerThicknessEdge(Nsurf+1,iEdge)) &
-                    / layerThicknessEdge(Nsurf,iEdge)
+                    / (layerThickEdgeMean(Nsurf,iEdge) + layerThickEdgeMean(Nsurf+1,iEdge)) &
+                    / layerThickEdgeMean(Nsurf,iEdge)
          bTemp(Nsurf) = 1.0_RKIND - C(Nsurf)
          rTemp(Nsurf) = normalVelocity(Nsurf,iEdge)
 
          ! first pass: set the coefficients
          do k = Nsurf+1, N-1
             A        = -2.0_RKIND*dt*vertViscTopOfEdge(k,iEdge) &
-                   / (layerThicknessEdge(k-1,iEdge) + layerThicknessEdge(k,iEdge)) &
-                   / layerThicknessEdge(k,iEdge)
+                   / (layerThickEdgeMean(k-1,iEdge) + layerThickEdgeMean(k,iEdge)) &
+                   / layerThickEdgeMean(k,iEdge)
             m        = A/bTemp(k-1)
             C(k)     = -2.0_RKIND*dt*vertViscTopOfEdge(k+1,iEdge) &
-                   / (layerThicknessEdge(k,iEdge) + layerThicknessEdge(k+1,iEdge)) &
-                   / layerThicknessEdge(k,iEdge)
+                   / (layerThickEdgeMean(k,iEdge) + layerThickEdgeMean(k+1,iEdge)) &
+                   / layerThickEdgeMean(k,iEdge)
             bTemp(k) = 1.0_RKIND - A - C(k) - m*C(k-1)
             rTemp(k) = normalVelocity(k,iEdge) - m*rTemp(k-1)
          enddo
 
          A = -2.0_RKIND*dt*vertViscTopOfEdge(N,iEdge) &
-           / (layerThicknessEdge(N-1,iEdge) + layerThicknessEdge(N,iEdge)) &
-           / layerThicknessEdge(N,iEdge)
+           / (layerThickEdgeMean(N-1,iEdge) + layerThickEdgeMean(N,iEdge)) &
+           / layerThickEdgeMean(N,iEdge)
          m = A/bTemp(N-1)
 
          ! x(N) = rTemp(N) / bTemp(N)
@@ -635,7 +635,7 @@ contains
          ! using sqrt(2.0*kineticEnergyEdge(k,iEdge))
          normalVelocity(N,iEdge) = (normalVelocity(N,iEdge) - m*rTemp(N-1)) &
              / (1.0_RKIND - A + dt*implicitCD &
-             * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThicknessEdge(N,iEdge) &
+             * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeMean(N,iEdge) &
              - m*C(N-1))
          ! second pass: back substitution
          do k = N-1, Nsurf, -1
@@ -680,7 +680,7 @@ contains
 
    subroutine ocn_vel_vmix_tend_implicit_spatially_variable_mannings(forcingPool, bottomDrag, dt, & !{{{
                                          kineticEnergyCell, vertViscTopOfEdge, layerThickness, &
-                                         layerThicknessEdge, normalVelocity, ssh, err)
+                                         layerThickEdgeMean, normalVelocity, ssh, err)
 
       !-----------------------------------------------------------------
       !
@@ -704,7 +704,7 @@ contains
          layerThickness !< Input: thickness at cell center
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdge !< Input: centered thickness at edge
+         layerThickEdgeMean !< Input: mean thickness at edge
 
        real (kind=RKIND), dimension(:), intent(in) :: &
          bottomDrag !< Input: bottomDrag at cell centeres
@@ -803,7 +803,7 @@ contains
       !$acc enter data create(vegetationManning)
 
       !$acc parallel loop present(maxLevelEdgeTop, minLevelEdgeBot, cellsOnEdge, &
-      !$acc    layerThicknessEdge, layerThickness, vertViscTopOfEdge, normalVelocity, &
+      !$acc    layerThickEdgeMean, layerThickness, vertViscTopOfEdge, normalVelocity, &
       !$acc    kineticEnergyCell, bottomDrag, vegetationManning, ssh, bottomDepth) &
       !$acc    private(Nsurf, N, cell1, cell2, implicitCd, A, bTemp, C, m, rTemp, k)
 #else
@@ -837,27 +837,27 @@ contains
 
          ! tridiagonal matrix algorithm
          C(Nsurf)     = -2.0_RKIND*dt*vertViscTopOfEdge(Nsurf+1,iEdge) &
-                    / (layerThicknessEdge(Nsurf,iEdge) + layerThicknessEdge(Nsurf+1,iEdge)) &
-                    / layerThicknessEdge(Nsurf,iEdge)
+                    / (layerThickEdgeMean(Nsurf,iEdge) + layerThickEdgeMean(Nsurf+1,iEdge)) &
+                    / layerThickEdgeMean(Nsurf,iEdge)
          bTemp(Nsurf) = 1.0_RKIND - C(Nsurf)
          rTemp(Nsurf) = normalVelocity(Nsurf,iEdge)
 
          ! first pass: set the coefficients
          do k = Nsurf+1, N-1
             A        = -2.0_RKIND*dt*vertViscTopOfEdge(k,iEdge) &
-                   / (layerThicknessEdge(k-1,iEdge) + layerThicknessEdge(k,iEdge)) &
-                   / layerThicknessEdge(k,iEdge)
+                   / (layerThickEdgeMean(k-1,iEdge) + layerThickEdgeMean(k,iEdge)) &
+                   / layerThickEdgeMean(k,iEdge)
             m        = A/bTemp(k-1)
             C(k)     = -2.0_RKIND*dt*vertViscTopOfEdge(k+1,iEdge) &
-                   / (layerThicknessEdge(k,iEdge) + layerThicknessEdge(k+1,iEdge)) &
-                   / layerThicknessEdge(k,iEdge)
+                   / (layerThickEdgeMean(k,iEdge) + layerThickEdgeMean(k+1,iEdge)) &
+                   / layerThickEdgeMean(k,iEdge)
             bTemp(k) = 1.0_RKIND - A - C(k) - m*C(k-1)
             rTemp(k) = normalVelocity(k,iEdge) - m*rTemp(k-1)
          enddo
 
          A = -2.0_RKIND*dt*vertViscTopOfEdge(N,iEdge) &
-           / (layerThicknessEdge(N-1,iEdge) + layerThicknessEdge(N,iEdge)) &
-           / layerThicknessEdge(N,iEdge)
+           / (layerThickEdgeMean(N-1,iEdge) + layerThickEdgeMean(N,iEdge)) &
+           / layerThickEdgeMean(N,iEdge)
          m = A/bTemp(N-1)
 
          ! x(N) = rTemp(N) / bTemp(N)
@@ -865,7 +865,7 @@ contains
          ! using sqrt(2.0*kineticEnergyEdge(k,iEdge))
          normalVelocity(N,iEdge) = (normalVelocity(N,iEdge) - m*rTemp(N-1)) &
              / (1.0_RKIND - A + dt*implicitCD &
-             * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThicknessEdge(N,iEdge) &
+             * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeMean(N,iEdge) &
              - m*C(N-1))
          ! second pass: back substitution
          do k = N-1, Nsurf, -1

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -1215,22 +1215,22 @@ contains
 #endif
       if (config_use_implicit_bottom_drag_variable) then
         call ocn_vel_vmix_tend_implicit_spatially_variable(bottomDrag, dt, kineticEnergyCell, &
-          vertViscTopOfEdge, layerThickness, layerThickEdge, normalVelocity, err)
+          vertViscTopOfEdge, layerThickness, layerThickEdgeCenter, normalVelocity, err)
       else if (config_use_implicit_bottom_drag_variable_mannings.or. &
                config_use_implicit_bottom_roughness) then
         ! update bottomDrag via Cd=g*n^2*h^(-1/3)
         call ocn_vel_vmix_tend_implicit_spatially_variable_mannings(forcingPool, bottomDrag, &
           dt, kineticEnergyCell, &
-          vertViscTopOfEdge, layerThickness, layerThickEdge, normalVelocity, &
+          vertViscTopOfEdge, layerThickness, layerThickEdgeCenter, normalVelocity, &
           ssh, err)
       else if (config_Rayleigh_friction.or. &
                config_Rayleigh_bottom_friction.or. &
                config_Rayleigh_damping_depth_variable) then
         call ocn_vel_vmix_tend_implicit_rayleigh(dt, kineticEnergyCell, &
-          vertViscTopOfEdge, layerThickness, layerThickEdge, normalVelocity, err)
+          vertViscTopOfEdge, layerThickness, layerThickEdgeCenter, normalVelocity, err)
       else
         call ocn_vel_vmix_tend_implicit(dt, kineticEnergyCell, &
-          vertViscTopOfEdge, layerThickness, layerThickEdge, normalVelocity, err)
+          vertViscTopOfEdge, layerThickness, layerThickEdgeCenter, normalVelocity, err)
       end if
 #ifdef MPAS_OPENACC
       !$acc exit data copyout(normalVelocity)

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -234,7 +234,7 @@ contains
          layerThickness !< Input: thickness at cell center
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdge !< Input: centered thickness at edge
+         layerThicknessEdge !< Input: mean thickness at edge
 
       !-----------------------------------------------------------------
       !
@@ -1196,22 +1196,22 @@ contains
 #endif
       if (config_use_implicit_bottom_drag_variable) then
         call ocn_vel_vmix_tend_implicit_spatially_variable(bottomDrag, dt, kineticEnergyCell, &
-          vertViscTopOfEdge, layerThickness, layerThickEdgeCenter, normalVelocity, err)
+          vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, err)
       else if (config_use_implicit_bottom_drag_variable_mannings.or. &
                config_use_implicit_bottom_roughness) then
         ! update bottomDrag via Cd=g*n^2*h^(-1/3)
         call ocn_vel_vmix_tend_implicit_spatially_variable_mannings(forcingPool, bottomDrag, &
           dt, kineticEnergyCell, &
-          vertViscTopOfEdge, layerThickness, layerThickEdgeCenter, normalVelocity, &
+          vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, &
           ssh, err)
       else if (config_Rayleigh_friction.or. &
                config_Rayleigh_bottom_friction.or. &
                config_Rayleigh_damping_depth_variable) then
         call ocn_vel_vmix_tend_implicit_rayleigh(dt, kineticEnergyCell, &
-          vertViscTopOfEdge, layerThickness, layerThickEdgeCenter, normalVelocity, err)
+          vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, err)
       else
         call ocn_vel_vmix_tend_implicit(dt, kineticEnergyCell, &
-          vertViscTopOfEdge, layerThickness, layerThickEdgeCenter, normalVelocity, err)
+          vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, err)
       end if
 #ifdef MPAS_OPENACC
       !$acc exit data copyout(normalVelocity)

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
@@ -523,13 +523,13 @@ contains
                  deltaVelocitySquared(1:minLevelCell(iCell)) = 0.0_RKIND
 
                  normalVelocitySum(minLevelCell(iCell)) = normalVelocity(minLevelCell(iCell), iEdge)* &
-                                                          layerThickEdgeFlux(minLevelCell(iCell),iEdge)
-                 layerThicknessEdgeSum(minLevelCell(iCell)) = layerThickEdgeFlux(minLevelCell(iCell),iEdge)
+                                                          layerThickEdgeMean(minLevelCell(iCell),iEdge)
+                 layerThicknessEdgeSum(minLevelCell(iCell)) = layerThickEdgeMean(minLevelCell(iCell),iEdge)
 
                  do kIndexOBL = minLevelCell(iCell)+1, maxLevelCell(iCell)
                     normalVelocitySum(kIndexOBL) = normalVelocitySum(kIndexOBL-1) + &
-                                      layerThickEdgeFlux(kIndexOBL, iEdge)*normalVelocity(kIndexOBL, iEdge)
-                    layerThicknessEdgeSum(kIndexOBL) = layerThicknessEdgeSum(kIndexOBL-1) + layerThickEdgeFlux(kIndexOBL, iEdge)
+                                      layerThickEdgeMean(kIndexOBL, iEdge)*normalVelocity(kIndexOBL, iEdge)
+                    layerThicknessEdgeSum(kIndexOBL) = layerThicknessEdgeSum(kIndexOBL-1) + layerThickEdgeMean(kIndexOBL, iEdge)
                  end do
 
                  do kIndexOBL = minLevelCell(iCell), maxLevelCell(iCell)

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
@@ -523,13 +523,13 @@ contains
                  deltaVelocitySquared(1:minLevelCell(iCell)) = 0.0_RKIND
 
                  normalVelocitySum(minLevelCell(iCell)) = normalVelocity(minLevelCell(iCell), iEdge)* &
-                                                          layerThickEdge(minLevelCell(iCell),iEdge)
-                 layerThicknessEdgeSum(minLevelCell(iCell)) = layerThickEdge(minLevelCell(iCell),iEdge)
+                                                          layerThickEdgeFlux(minLevelCell(iCell),iEdge)
+                 layerThicknessEdgeSum(minLevelCell(iCell)) = layerThickEdgeFlux(minLevelCell(iCell),iEdge)
 
                  do kIndexOBL = minLevelCell(iCell)+1, maxLevelCell(iCell)
                     normalVelocitySum(kIndexOBL) = normalVelocitySum(kIndexOBL-1) + &
-                                      layerThickEdge(kIndexOBL, iEdge)*normalVelocity(kIndexOBL, iEdge)
-                    layerThicknessEdgeSum(kIndexOBL) = layerThicknessEdgeSum(kIndexOBL-1) + layerThickEdge(kIndexOBL, iEdge)
+                                      layerThickEdgeFlux(kIndexOBL, iEdge)*normalVelocity(kIndexOBL, iEdge)
+                    layerThicknessEdgeSum(kIndexOBL) = layerThicknessEdgeSum(kIndexOBL-1) + layerThickEdgeFlux(kIndexOBL, iEdge)
                  end do
 
                  do kIndexOBL = minLevelCell(iCell), maxLevelCell(iCell)

--- a/components/mpas-ocean/src/shared/mpas_ocn_wetting_drying.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_wetting_drying.F
@@ -319,7 +319,7 @@ contains
 !>  to prevent cells from drying.
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_wetting_drying_wettingVelocity(meshPool, layerThicknessEdgeFlux, layerThicknessCur, layerThicknessProvis, &
+   subroutine ocn_wetting_drying_wettingVelocity(meshPool, layerThickEdgeFlux, layerThicknessCur, layerThicknessProvis, &
 
        normalVelocity, dt, wettingVelocity, err)!{{{
 
@@ -339,7 +339,7 @@ contains
          layerThicknessProvis    !< Input: provisional layer thickness
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdgeFlux  !< Input: layerThickness interpolated to an edge
+         layerThickEdgeFlux  !< Input: flux-related layerThickness at an edge
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          normalVelocity     !< Input: transport
@@ -413,7 +413,7 @@ contains
               ! only consider divergence flux leaving the cell
               if ( normalVelocity(k, iEdge) * edgeSignOnCell(i, iCell) < 0.0_RKIND ) then
                 divOutFlux = divOutFlux + normalVelocity(k, iEdge) * edgeSignOnCell(i, iCell) &
-                  * layerThicknessEdgeFlux(k, iEdge) * dvEdge(iEdge)  * invAreaCell
+                  * layerThickEdgeFlux(k, iEdge) * dvEdge(iEdge)  * invAreaCell
               end if
             end if
           end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_wetting_drying.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_wetting_drying.F
@@ -277,7 +277,7 @@ contains
 
      ! ensure cells stay wet by selectively damping cells with a damping tendency to make sure tendency doesn't dry cells
 
-     call ocn_wetting_drying_wettingVelocity(meshPool, layerThickEdge, layerThicknessCur, layerThicknessProvis, &
+     call ocn_wetting_drying_wettingVelocity(meshPool, layerThickEdgeFlux, layerThicknessCur, layerThicknessProvis, &
                                              normalTransportVelocity, rkSubstepWeight, wettingVelocity, err)
 
      ! prevent drying from happening with selective wettingVelocity
@@ -319,7 +319,7 @@ contains
 !>  to prevent cells from drying.
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_wetting_drying_wettingVelocity(meshPool, layerThicknessEdge, layerThicknessCur, layerThicknessProvis, &
+   subroutine ocn_wetting_drying_wettingVelocity(meshPool, layerThicknessEdgeFlux, layerThicknessCur, layerThicknessProvis, &
 
        normalVelocity, dt, wettingVelocity, err)!{{{
 
@@ -339,7 +339,7 @@ contains
          layerThicknessProvis    !< Input: provisional layer thickness
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdge     !< Input: layerThickness interpolated to an edge
+         layerThicknessEdgeFlux  !< Input: layerThickness interpolated to an edge
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          normalVelocity     !< Input: transport
@@ -413,7 +413,7 @@ contains
               ! only consider divergence flux leaving the cell
               if ( normalVelocity(k, iEdge) * edgeSignOnCell(i, iCell) < 0.0_RKIND ) then
                 divOutFlux = divOutFlux + normalVelocity(k, iEdge) * edgeSignOnCell(i, iCell) &
-                  * layerThicknessEdge(k, iEdge) * dvEdge(iEdge)  * invAreaCell
+                  * layerThicknessEdgeFlux(k, iEdge) * dvEdge(iEdge)  * invAreaCell
               end if
             end if
           end do


### PR DESCRIPTION
This PR replaces the existing `layerThicknessEdge` variable with two variables: `layerThicknessEdgeMean` refers to the mean of the neighboring cell-centered `layerThickness`, and `layerThicknessEdgeFlux` refers to the `layerThicknessEdge` used to flux momentum and tracers. When `config_thickness_flux_type = 'centered'` `layerThicknessEdgeFlux = layerThicknessEdgeMean`, but when `config_thickness_flux_type = 'upwind'` `layerThicknessEdgeFlux` is upwinded. 

Prior to this PR, when `config_thickness_flux_type = 'upwind'` `layerThicknessEdge` was upwinded everywhere. This PR uses `layerThicknessEdgeFlux` for horizontal advection terms and `layerThicknessEdgeMean` elsewhere, such as for mixing parameterizations. This change is in preparation for adding additional options for thickness fluxes. 

This PR also removes `layerThicknessEdge` from global stats, since it did not offer much information not given by the global stats for `layerThickness`.