### PR TITLE
For Cori, update module versions in maint-1.0 after March 16th maintenance.

### DIFF
--- a/cime/config/e3sm/machines/config_compilers.xml
+++ b/cime/config/e3sm/machines/config_compilers.xml
@@ -426,6 +426,8 @@ for mct, etc.
   <!-- -ffree-line-length-none and -ffixed-line-length-none need to be in FFLAGS rather than in FIXEDFLAGS/FREEFLAGS
        so that these are passed to cmake builds (cmake builds don't use FIXEDFLAGS and FREEFLAGS). -->
   <FFLAGS> -mcmodel=medium -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none </FFLAGS>
+  <!-- for gnu v10 and above, we are using these flags to avoid build errors -->
+  <!--ADD_FFLAGS> -fallow-argument-mismatch -fallow-invalid-boz</ADD_FFLAGS-->
   <CFLAGS> -mcmodel=medium </CFLAGS>
   <FFLAGS_NOOPT> -O0 </FFLAGS_NOOPT>
   <FC_AUTO_R8> -fdefault-real-8 </FC_AUTO_R8>

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -138,25 +138,25 @@
     </modules>
 
     <modules mpilib="mpt">
-      <command name="swap">cray-mpich cray-mpich/7.7.6</command>
+      <command name="swap">cray-mpich cray-mpich/7.7.10</command>
     </modules>
 
     <modules compiler="intel">
-      <command name="load">PrgEnv-intel/6.0.5</command>
+      <command name="load">PrgEnv-intel/6.0.10</command>
       <command name="rm">intel</command>
       <command name="load">intel/19.0.3.199</command>
     </modules>
 
     <modules compiler="gnu">
-      <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.5</command>
+      <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.10</command>
       <command name="rm">gcc</command>
-      <command name="load">gcc/8.2.0</command>
+      <command name="load">gcc/10.3.0</command>
       <command name="rm">cray-libsci</command>
-      <command name="load">cray-libsci/19.02.1</command>
+      <command name="load">cray-libsci/20.09.1</command>
     </modules>
 
     <modules>
-      <command name="swap">craype craype/2.5.18</command>
+      <command name="swap">craype craype/2.6.2</command>
       <command name="rm">pmi</command>
       <command name="load">pmi/5.0.14</command>
       <command name="rm">craype-mic-knl</command>
@@ -167,21 +167,19 @@
       <command name="rm">cray-netcdf-hdf5parallel</command>
       <command name="rm">cray-hdf5-parallel</command>
       <command name="rm">cray-parallel-netcdf</command>
-      <command name="load">cray-netcdf/4.6.1.3</command>
-      <command name="load">cray-hdf5/1.10.2.0</command>
+      <command name="load">cray-netcdf/4.6.3.2</command>
+      <command name="load">cray-hdf5/1.10.5.2</command>
     </modules>
     <modules mpilib="!mpi-serial">
       <command name="rm">cray-netcdf-hdf5parallel</command>
-      <command name="load">cray-netcdf-hdf5parallel/4.6.1.3</command>
-      <command name="load">cray-hdf5-parallel/1.10.2.0</command>
-      <command name="load">cray-parallel-netcdf/1.8.1.4</command>
+      <command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
+      <command name="load">cray-hdf5-parallel/1.10.5.2</command>
+      <command name="load">cray-parallel-netcdf/1.11.1.1</command>
     </modules>
 
     <modules>
-      <command name="rm">git</command>
-      <command name="load">git</command>
       <command name="rm">cmake</command>
-      <command name="load">cmake/3.21.3</command>
+      <command name="load">cmake</command>
       <command name="load">perl5-extras</command>
     </modules>
   </module_system>
@@ -285,29 +283,29 @@
     </modules>
 
     <modules mpilib="mpt">
-      <command name="swap">cray-mpich cray-mpich/7.7.6</command>
+      <command name="swap">cray-mpich cray-mpich/7.7.10</command>
     </modules>
 
     <modules mpilib="impi">
-      <command name="swap">cray-mpich impi/2019.up3</command>
+      <command name="swap">cray-mpich impi/2020.up4</command>
     </modules>
 
     <modules compiler="intel">
-      <command name="load">PrgEnv-intel/6.0.5</command>
+      <command name="load">PrgEnv-intel/6.0.10</command>
       <command name="rm">intel</command>
-      <command name="load">intel/18.0.1.163</command>
+      <command name="load">intel/19.0.3.199</command>
     </modules>
 
     <modules compiler="gnu">
-      <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.5</command>
+      <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.10</command>
       <command name="rm">gcc</command>
-      <command name="load">gcc/8.2.0</command>
+      <command name="load">gcc/10.3.0</command>
       <command name="rm">cray-libsci</command>
-      <command name="load">cray-libsci/19.02.1</command>
+      <command name="load">cray-libsci/20.09.1</command>
     </modules>
 
     <modules>
-      <command name="swap">craype craype/2.5.18</command>
+      <command name="swap">craype craype/2.6.2</command>
       <command name="rm">pmi</command>
       <command name="load">pmi/5.0.14</command>
       <command name="rm">craype-haswell</command>
@@ -318,20 +316,19 @@
       <command name="rm">cray-netcdf-hdf5parallel</command>
       <command name="rm">cray-hdf5-parallel</command>
       <command name="rm">cray-parallel-netcdf</command>
-      <command name="load">cray-netcdf/4.6.1.3</command>
-      <command name="load">cray-hdf5/1.10.2.0</command>
+      <command name="load">cray-netcdf/4.6.3.2</command>
+      <command name="load">cray-hdf5/1.10.5.2</command>
     </modules>
     <modules mpilib="!mpi-serial">
       <command name="rm">cray-netcdf-hdf5parallel</command>
-      <command name="load">cray-netcdf-hdf5parallel/4.6.1.3</command>
-      <command name="load">cray-hdf5-parallel/1.10.2.0</command>
-      <command name="load">cray-parallel-netcdf/1.8.1.4</command>
+      <command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
+      <command name="load">cray-hdf5-parallel/1.10.5.2</command>
+      <command name="load">cray-parallel-netcdf/1.11.1.1</command>
     </modules>
+
     <modules>
-      <command name="rm">git</command>
-      <command name="load">git</command>
       <command name="rm">cmake</command>
-      <command name="load">cmake/3.21.3</command>
+      <command name="load">cmake</command>
       <command name="load">perl5-extras</command>
     </modules>
 


### PR DESCRIPTION
This includes an unavoidable version change for the Intel compiler from 18 to 19,
so would expect results to be non BFB. The older compiler no longer
available.

Fixes https://github.com/E3SM-Project/E3SM/issues/4840

[NBFB]