### PR TITLE
For Cori, update modules for maint-2.0 after March 16th maintenance 

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -342,15 +342,15 @@
       </modules>
 
       <modules compiler="intel">
-        <command name="load">PrgEnv-intel/6.0.5</command>
+        <command name="load">PrgEnv-intel/6.0.10</command>
         <command name="rm">intel</command>
         <command name="load">intel/19.0.3.199</command>
       </modules>
 
       <modules compiler="gnu">
-        <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.9</command>
+        <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.10</command>
         <command name="rm">gcc</command>
-        <command name="load">gcc/9.3.0</command>
+        <command name="load">gcc/10.3.0</command>
         <command name="rm">cray-libsci</command>
         <command name="load">cray-libsci/20.09.1</command>
       </modules>
@@ -378,10 +378,8 @@
       </modules>
 
       <modules>
-        <command name="rm">git</command>
-        <command name="load">git</command>
         <command name="rm">cmake</command>
-        <command name="load">cmake/3.21.3</command>
+        <command name="load">cmake</command>
         <command name="load">perl5-extras</command>
       </modules>
     </module_system>
@@ -491,19 +489,19 @@
       </modules>
 
       <modules mpilib="impi">
-        <command name="swap">cray-mpich impi/2020</command>
+        <command name="swap">cray-mpich impi/2020.up4</command>
       </modules>
 
       <modules compiler="intel">
-        <command name="load">PrgEnv-intel/6.0.5</command>
+        <command name="load">PrgEnv-intel/6.0.10</command>
         <command name="rm">intel</command>
         <command name="load">intel/19.0.3.199</command>
       </modules>
 
       <modules compiler="gnu">
-        <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.9</command>
+        <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.10</command>
         <command name="rm">gcc</command>
-        <command name="load">gcc/9.3.0</command>
+        <command name="load">gcc/10.3.0</command>
         <command name="rm">cray-libsci</command>
         <command name="load">cray-libsci/20.09.1</command>
       </modules>
@@ -531,10 +529,8 @@
       </modules>
 
       <modules>
-        <command name="rm">git</command>
-        <command name="load">git</command>
         <command name="rm">cmake</command>
-        <command name="load">cmake/3.21.3</command>
+        <command name="load">cmake</command>
         <command name="load">perl5-extras</command>
       </modules>
 
@@ -561,7 +557,6 @@
       <env name="MPICH_GNI_DYNAMIC_CONN">disabled</env>
     </environment_variables>
     <environment_variables compiler="intel">
-      <!--env name="FORT_BUFFERED">yes</env-->
       <env name="MPICH_MEMORY_REPORT">1</env>
     </environment_variables>
   </machine>


### PR DESCRIPTION
Updating module settings after Cori maintenance on maint-2.0.
Similar to https://github.com/E3SM-Project/E3SM/pull/4839.
Expecting BFB

Fixes https://github.com/E3SM-Project/E3SM/issues/4842