### PR TITLE
Update modules for Cori on maint-1.2

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -304,7 +304,7 @@
       </modules>
 
       <modules>
-        <command name="swap">craype craype/2.5.18</command>
+        <command name="swap">craype craype/2.6.2</command>
         <command name="rm">pmi</command>
         <command name="load">pmi/5.0.14</command>
         <command name="rm">craype-haswell</command>
@@ -315,18 +315,19 @@
         <command name="rm">cray-netcdf-hdf5parallel</command>
         <command name="rm">cray-hdf5-parallel</command>
         <command name="rm">cray-parallel-netcdf</command>
-        <command name="load">cray-netcdf/4.6.1.3</command>
-        <command name="load">cray-hdf5/1.10.2.0</command>
+        <command name="load">cray-netcdf/4.6.3.2</command>
+        <command name="load">cray-hdf5/1.10.5.2</command>
       </modules>
       <modules mpilib="!mpi-serial">
         <command name="rm">cray-netcdf-hdf5parallel</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.6.1.3</command>
-        <command name="load">cray-hdf5-parallel/1.10.2.0</command>
-        <command name="load">cray-parallel-netcdf/1.8.1.4</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
+        <command name="load">cray-hdf5-parallel/1.10.5.2</command>
+        <command name="load">cray-parallel-netcdf/1.11.1.1</command>
       </modules>
+
       <modules>
         <command name="rm">cmake</command>
-        <command name="load">cmake/3.21.3</command>
+        <command name="load">cmake</command>
         <command name="load">perl5-extras</command>
       </modules>
 

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -133,25 +133,25 @@
       </modules>
 
       <modules mpilib="mpt">
-        <command name="swap">cray-mpich cray-mpich/7.7.6</command>
+        <command name="swap">cray-mpich cray-mpich/7.7.10</command>
       </modules>
 
       <modules compiler="intel">
-        <command name="load">PrgEnv-intel/6.0.5</command>
+        <command name="load">PrgEnv-intel/6.0.10</command>
         <command name="rm">intel</command>
         <command name="load">intel/19.0.3.199</command>
       </modules>
 
       <modules compiler="gnu">
-        <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.5</command>
+        <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.10</command>
         <command name="rm">gcc</command>
-        <command name="load">gcc/8.2.0</command>
+        <command name="load">gcc/10.3.0</command>
         <command name="rm">cray-libsci</command>
-        <command name="load">cray-libsci/19.02.1</command>
+        <command name="load">cray-libsci/20.09.1</command>
       </modules>
 
       <modules>
-        <command name="swap">craype craype/2.5.18</command>
+        <command name="swap">craype craype/2.6.2</command>
         <command name="rm">pmi</command>
         <command name="load">pmi/5.0.14</command>
         <command name="rm">craype-mic-knl</command>
@@ -162,19 +162,19 @@
         <command name="rm">cray-netcdf-hdf5parallel</command>
         <command name="rm">cray-hdf5-parallel</command>
         <command name="rm">cray-parallel-netcdf</command>
-        <command name="load">cray-netcdf/4.6.1.3</command>
-        <command name="load">cray-hdf5/1.10.2.0</command>
+        <command name="load">cray-netcdf/4.6.3.2</command>
+        <command name="load">cray-hdf5/1.10.5.2</command>
       </modules>
       <modules mpilib="!mpi-serial">
         <command name="rm">cray-netcdf-hdf5parallel</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.6.1.3</command>
-        <command name="load">cray-hdf5-parallel/1.10.2.0</command>
-        <command name="load">cray-parallel-netcdf/1.8.1.4</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
+        <command name="load">cray-hdf5-parallel/1.10.5.2</command>
+        <command name="load">cray-parallel-netcdf/1.11.1.1</command>
       </modules>
 
       <modules>
         <command name="rm">cmake</command>
-        <command name="load">cmake/3.21.3</command>
+        <command name="load">cmake</command>
         <command name="load">perl5-extras</command>
       </modules>
     </module_system>
@@ -276,31 +276,31 @@
       </modules>
 
       <modules mpilib="mpt">
-        <command name="swap">cray-mpich cray-mpich/7.7.6</command>
+        <command name="swap">cray-mpich cray-mpich/7.7.10</command>
       </modules>
 
       <modules mpilib="impi">
-        <command name="swap">cray-mpich impi/2018.up2</command>
+        <command name="swap">cray-mpich impi/2020.up4</command>
       </modules>
 
       <modules compiler="intel">
-        <command name="load">PrgEnv-intel/6.0.5</command>
+        <command name="load">PrgEnv-intel/6.0.10</command>
         <command name="rm">intel</command>
-        <command name="load">intel/18.0.1.163</command>
+        <command name="load">intel/19.0.3.199</command>
       </modules>
 
       <modules compiler="intel19">
-        <command name="load">PrgEnv-intel/6.0.5</command>
+        <command name="load">PrgEnv-intel/6.0.10</command>
         <command name="rm">intel</command>
         <command name="load">intel/19.0.3.199</command>
       </modules>
 
       <modules compiler="gnu">
-        <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.5</command>
+        <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.10</command>
         <command name="rm">gcc</command>
-        <command name="load">gcc/8.2.0</command>
+        <command name="load">gcc/10.3.0</command>
         <command name="rm">cray-libsci</command>
-        <command name="load">cray-libsci/19.02.1</command>
+        <command name="load">cray-libsci/20.09.1</command>
       </modules>
 
       <modules>


### PR DESCRIPTION
Updating module settings after Cori maintenance.
Similar to https://github.com/E3SM-Project/E3SM/pull/4839.
The default intel compiler for cori-knl is now v19, and will not be BFB.

Fixes https://github.com/E3SM-Project/E3SM/issues/4845