### PR TITLE
Add MPI process stride for tasks exclusively owned by a component

### DIFF
--- a/driver-mct/cime_config/config_component.xml
+++ b/driver-mct/cime_config/config_component.xml
@@ -2374,6 +2374,25 @@
 
   </entry>
 
+  <entry id="EXCL_STRIDE">
+    <type>integer</type>
+    <values>
+      <value compclass="ATM">0</value>
+      <value compclass="CPL">0</value>
+      <value compclass="OCN">0</value>
+      <value compclass="WAV">0</value>
+      <value compclass="GLC">0</value>
+      <value compclass="ICE">0</value>
+      <value compclass="ROF">0</value>
+      <value compclass="LND">0</value>
+      <value compclass="ESP">0</value>
+      <value compclass="IAC">0</value>
+    </values>
+    <group>mach_pes</group>
+    <file>env_mach_pes.xml</file>
+    <desc>Stride of MPI tasks owned exclusively by a component. If 0, exclusivity is disabled.</desc>
+  </entry>
+
   <entry id="TOTALPES">
     <type>integer</type>
     <default_value>0</default_value>

--- a/driver-mct/cime_config/namelist_definition_drv.xml
+++ b/driver-mct/cime_config/namelist_definition_drv.xml
@@ -2549,6 +2549,14 @@
     </values>
   </entry>
 
+  <entry id="atm_excl_stride" modify_via_xml="EXCL_STRIDE_ATM">
+    <type>integer</type>
+    <category>cime_pes</category>
+    <group>cime_pes</group>
+    <desc>Stride of MPI tasks owned exclusively by a component.</desc>
+    <values><value>$EXCL_STRIDE_ATM</value></values>
+  </entry>
+
   <entry id="lnd_ntasks" modify_via_xml="NTASKS_LND">
     <type>integer</type>
     <category>cime_pes</category>
@@ -2612,6 +2620,14 @@
     <values>
       <value>$NINST_LND_LAYOUT</value>
     </values>
+  </entry>
+
+  <entry id="lnd_excl_stride" modify_via_xml="EXCL_STRIDE_LND">
+    <type>integer</type>
+    <category>cime_pes</category>
+    <group>cime_pes</group>
+    <desc>Stride of MPI tasks owned exclusively by a component.</desc>
+    <values><value>$EXCL_STRIDE_LND</value></values>
   </entry>
 
   <entry id="ice_ntasks" modify_via_xml="NTASKS_ICE">
@@ -2679,6 +2695,14 @@
     </values>
   </entry>
 
+  <entry id="ice_excl_stride" modify_via_xml="EXCL_STRIDE_ICE">
+    <type>integer</type>
+    <category>cime_pes</category>
+    <group>cime_pes</group>
+    <desc>Stride of MPI tasks owned exclusively by a component.</desc>
+    <values><value>$EXCL_STRIDE_ICE</value></values>
+  </entry>
+
   <entry id="ocn_ntasks" modify_via_xml="NTASKS_OCN">
     <type>integer</type>
     <category>cime_pes</category>
@@ -2742,6 +2766,14 @@
     <values>
       <value>$NINST_OCN_LAYOUT</value>
     </values>
+  </entry>
+
+  <entry id="ocn_excl_stride" modify_via_xml="EXCL_STRIDE_OCN">
+    <type>integer</type>
+    <category>cime_pes</category>
+    <group>cime_pes</group>
+    <desc>Stride of MPI tasks owned exclusively by a component.</desc>
+    <values><value>$EXCL_STRIDE_OCN</value></values>
   </entry>
 
   <entry id="glc_ntasks" modify_via_xml="NTASKS_GLC">
@@ -2809,6 +2841,14 @@
     </values>
   </entry>
 
+  <entry id="glc_excl_stride" modify_via_xml="EXCL_STRIDE_GLC">
+    <type>integer</type>
+    <category>cime_pes</category>
+    <group>cime_pes</group>
+    <desc>Stride of MPI tasks owned exclusively by a component.</desc>
+    <values><value>$EXCL_STRIDE_GLC</value></values>
+  </entry>
+
   <entry id="wav_ntasks" modify_via_xml="NTASKS_WAV">
     <type>integer</type>
     <category>cime_pes</category>
@@ -2872,6 +2912,14 @@
     <values>
       <value>$NINST_WAV_LAYOUT</value>
     </values>
+  </entry>
+
+  <entry id="wav_excl_stride" modify_via_xml="EXCL_STRIDE_WAV">
+    <type>integer</type>
+    <category>cime_pes</category>
+    <group>cime_pes</group>
+    <desc>Stride of MPI tasks owned exclusively by a component.</desc>
+    <values><value>$EXCL_STRIDE_WAV</value></values>
   </entry>
 
   <entry id="iac_ntasks" modify_via_xml="NTASKS_IAC">
@@ -2939,6 +2987,14 @@
     </values>
   </entry>
 
+  <entry id="iac_excl_stride" modify_via_xml="EXCL_STRIDE_IAC">
+    <type>integer</type>
+    <category>cime_pes</category>
+    <group>cime_pes</group>
+    <desc>Stride of MPI tasks owned exclusively by a component.</desc>
+    <values><value>$EXCL_STRIDE_IAC</value></values>
+  </entry>
+
   <entry id="rof_ntasks" modify_via_xml="NTASKS_ROF">
     <type>integer</type>
     <category>cime_pes</category>
@@ -3002,6 +3058,14 @@
     <values>
       <value>$NINST_ROF_LAYOUT</value>
     </values>
+  </entry>
+
+  <entry id="rof_excl_stride" modify_via_xml="EXCL_STRIDE_ROF">
+    <type>integer</type>
+    <category>cime_pes</category>
+    <group>cime_pes</group>
+    <desc>Stride of MPI tasks owned exclusively by a component.</desc>
+    <values><value>$EXCL_STRIDE_ROF</value></values>
   </entry>
 
   <entry id="esp_ntasks" modify_via_xml="NTASKS_ESP">
@@ -3069,6 +3133,14 @@
     </values>
   </entry>
 
+  <entry id="esp_excl_stride" modify_via_xml="EXCL_STRIDE_ESP">
+    <type>integer</type>
+    <category>cime_pes</category>
+    <group>cime_pes</group>
+    <desc>Stride of MPI tasks owned exclusively by a component.</desc>
+    <values><value>$EXCL_STRIDE_ESP</value></values>
+  </entry>
+
   <entry  id="cpl_ntasks" modify_via_xml="NTASKS_CPL">
     <type>integer</type>
     <category>cime_pes</category>
@@ -3119,6 +3191,14 @@
     <values>
       <value>$PSTRID_CPL</value>
     </values>
+  </entry>
+
+  <entry id="cpl_excl_stride" modify_via_xml="EXCL_STRIDE_CPL">
+    <type>integer</type>
+    <category>cime_pes</category>
+    <group>cime_pes</group>
+    <desc>Stride of MPI tasks owned exclusively by a component.</desc>
+    <values><value>$EXCL_STRIDE_CPL</value></values>
   </entry>
 
   <entry id="info_taskmap_model">

--- a/driver-mct/main/cime_comp_mod.F90
+++ b/driver-mct/main/cime_comp_mod.F90
@@ -2495,7 +2495,8 @@ contains
          glc(ens1)%iamroot_compid .or. &
          rof(ens1)%iamroot_compid .or. &
          wav(ens1)%iamroot_compid .or. &
-         iac(ens1)%iamroot_compid) then
+         iac(ens1)%iamroot_compid .or. &
+         info_mprof == 2) then
 
        write(logunit,105) ' memory_write: model date = ',ymd,tod, &
             ' memory = ',msize,' MB (highwater)    ',mrss,' MB (usage)', &
@@ -3350,7 +3351,8 @@ contains
                glc(ens1)%iamroot_compid .or. &
                wav(ens1)%iamroot_compid .or. &
                rof(ens1)%iamroot_compid .or. &
-               iac(ens1)%iamroot_compid)) then
+               iac(ens1)%iamroot_compid .or. &
+               info_mprof == 2)) then
 
              write(logunit,105) ' memory_write: model date = ',ymd,tod, &
                   ' memory = ',msize,' MB (highwater)    ',mrss,' MB (usage)', &


### PR DESCRIPTION
This lets a component run exclusively on an MPI task: e.g. ATM on 6 MPI tasks for 6 GPUs on a Summit node.

[NML] - due to new excl_stride namelist variables