### PR TITLE
Avoiding SC assumption when indexing the MeanMonthFlow array

### DIFF
--- a/components/mosart/src/wrm/WRM_modules.F90
+++ b/components/mosart/src/wrm/WRM_modules.F90
@@ -604,7 +604,9 @@ MODULE WRM_modules
      !--- return and do nothing under certain conditions
      !---------------------------------------------
 
-     if (damID > ctlSubwWRM%LocalNumDam .OR. damID <= 0 .or. WRMUnit%MeanMthFlow(damID,13) <= 0.01_r8) then
+     if (damID > ctlSubwWRM%LocalNumDam .OR. damID <= 0) then
+        return
+     elseif (WRMUnit%MeanMthFlow(damID,13) <= 0.01_r8) then
         return
      end if
 


### PR DESCRIPTION
Since the Fortran standard does not support short circuit evaluation,
avoiding indexing the array when the index can be <= 0.

Fixes E3SM-Project/E3SM#4727

[BFB]