### PR TITLE
Fix the lnd to atm direct fluxes for trigrid configurations

### DIFF
--- a/driver-mct/main/prep_atm_mod.F90
+++ b/driver-mct/main/prep_atm_mod.F90
@@ -280,8 +280,8 @@ contains
     type(mct_aVect), intent(inout) :: x2a_a
     !
     ! Local workspace
-    real(r8) :: fracl, fraci, fraco, fracl_nm
-    integer  :: n,ka,ki,kl,ko,kx,kof,kif,klf,klf_nm,i,i1,o1
+    real(r8) :: fracl, fraci, fraco
+    integer  :: n,ka,ki,kl,ko,kx,kof,kif,klf,i,i1,o1
     integer  :: lsize
     integer  :: index_x2a_Sf_lfrac
     integer  :: index_x2a_Sf_ifrac
@@ -504,7 +504,7 @@ contains
 
     !--- document fraction operations ---
     if (first_time) then
-       mrgstr(index_x2a_sf_lfrac) = trim(mrgstr(index_x2a_sf_lfrac))//' = fractions_a%lfrac'
+       mrgstr(index_x2a_sf_lfrac) = trim(mrgstr(index_x2a_sf_lfrac))//' = fractions_a%'//trim(fracstr)
        mrgstr(index_x2a_sf_ifrac) = trim(mrgstr(index_x2a_sf_ifrac))//' = fractions_a%ifrac'
        mrgstr(index_x2a_sf_ofrac) = trim(mrgstr(index_x2a_sf_ofrac))//' = fractions_a%ofrac'
     endif
@@ -557,7 +557,7 @@ contains
        if (first_time) then
           if (lindx(ka) > 0) then
              if (lmerge(ka)) then
-                mrgstr(ka) = trim(mrgstr(ka))//' + lfrac*l2x%'//trim(field_lnd(lindx(ka)))
+                mrgstr(ka) = trim(mrgstr(ka))//' + '//trim(fracstr)//'*l2x%'//trim(field_lnd(lindx(ka)))
              else
                 mrgstr(ka) = trim(mrgstr(ka))//' = '//trim(fracstr)//'*l2x%'//trim(field_lnd(lindx(ka)))
              end if

--- a/driver-mct/main/prep_atm_mod.F90
+++ b/driver-mct/main/prep_atm_mod.F90
@@ -481,21 +481,20 @@ contains
     ! Update surface fractions
 
     kif=mct_aVect_indexRA(fractions_a,"ifrac")
-    klf=mct_aVect_indexRA(fractions_a,"lfrac")
     kof=mct_aVect_indexRA(fractions_a,"ofrac")
+    if (samegrid_al) then
+       klf = mct_aVect_indexRA(fractions_a,"lfrac")
+       fracstr = 'lfrac'
+    else
+       klf = mct_aVect_indexRA(fractions_a,"lfrin")
+       fracstr = 'lfrin'
+    endif
+
     lsize = mct_avect_lsize(x2a_a)
 
     index_x2a_Sf_lfrac = mct_aVect_indexRA(x2a_a,'Sf_lfrac')
     index_x2a_Sf_ifrac = mct_aVect_indexRA(x2a_a,'Sf_ifrac')
     index_x2a_Sf_ofrac = mct_aVect_indexRA(x2a_a,'Sf_ofrac')
-
-    if (samegrid_al) then
-       klf_nm = mct_aVect_indexRA(fractions_a,"lfrac")
-       fracstr = 'lfrac'
-    else
-       klf_nm = mct_aVect_indexRA(fractions_a,"lfrin")
-       fracstr = 'lfrin'
-    endif
 
     do n = 1,lsize
        x2a_a%rAttr(index_x2a_Sf_lfrac,n) = fractions_a%Rattr(klf,n)
@@ -589,14 +588,13 @@ contains
 
        do n = 1,lsize
           fracl = fractions_a%Rattr(klf,n)
-          fracl_nm = fractions_a%Rattr(klf_nm,n)
           fraci = fractions_a%Rattr(kif,n)
           fraco = fractions_a%Rattr(kof,n)
           if (lindx(ka) > 0 .and. fracl > 0._r8) then
              if (lmerge(ka)) then
                 x2a_a%rAttr(ka,n) = x2a_a%rAttr(ka,n) + l2x_a%rAttr(lindx(ka),n) * fracl
              else
-                x2a_a%rAttr(ka,n) = l2x_a%rAttr(lindx(ka),n) * fracl_nm
+                x2a_a%rAttr(ka,n) = l2x_a%rAttr(lindx(ka),n) * fracl
              end if
           end if
           if (iindx(ka) > 0 .and. fraci > 0._r8) then

--- a/driver-mct/main/seq_diag_mct.F90
+++ b/driver-mct/main/seq_diag_mct.F90
@@ -622,17 +622,20 @@ contains
     !EOP
 
     !----- local -----
-    type(mct_aVect), pointer :: a2x_a        ! model to drv bundle
-    type(mct_aVect), pointer :: x2a_a        ! drv to model bundle
+    type(mct_aVect), pointer :: a2x_a             ! model to drv bundle
+    type(mct_aVect), pointer :: x2a_a             ! drv to model bundle
     type(mct_ggrid), pointer :: dom_a
+    character(CL)            :: atm_gnam          ! atm grid
+    character(CL)            :: lnd_gnam          ! lnd grid
     integer(in)              :: k,n,ic,nf,ip      ! generic index
     integer(in)              :: kArea             ! index of area field in aVect
     integer(in)              :: kLat              ! index of lat field in aVect
     integer(in)              :: kl,ka,ko,ki       ! fraction indices
     integer(in)              :: lSize             ! size of aVect
-    real(r8)                 :: ca_a       ! area of a grid cell
+    real(r8)                 :: ca_a              ! area of a grid cell
     logical,save             :: first_time    = .true.
     logical,save             :: flds_wiso_atm = .false.
+    logical,save             :: samegrid_al       ! samegrid atm and lnd
 
     !----- formats -----
     character(*),parameter :: subName = '(seq_diag_atm_mct) '
@@ -648,9 +651,22 @@ contains
     kArea = mct_aVect_indexRA(dom_a%data,afldname)
     kLat  = mct_aVect_indexRA(dom_a%data,latname)
     ka    = mct_aVect_indexRA(frac_a,afracname)
-    kl    = mct_aVect_indexRA(frac_a,lfracname)
+    kl    = mct_aVect_indexRA(frac_a,lfrinname)
     ko    = mct_aVect_indexRA(frac_a,ofracname)
     ki    = mct_aVect_indexRA(frac_a,ifracname)
+    if (first_time) then
+       call seq_infodata_getData(infodata , &
+            lnd_gnam=lnd_gnam             , &
+            atm_gnam=atm_gnam             )
+       samegrid_al = .true.
+       if (trim(atm_gnam) /= trim(lnd_gnam)) samegrid_al = .false.
+    end if
+
+    if (samegrid_al) then
+       kl = mct_aVect_indexRA(frac_a,lfracname)
+    else
+       kl = mct_aVect_indexRA(frac_a,lfrinname)
+    endif
 
     !---------------------------------------------------------------------------
     ! add values found in this bundle to the budget table

--- a/driver-mct/shr/seq_flds_mod.F90
+++ b/driver-mct/shr/seq_flds_mod.F90
@@ -2908,7 +2908,7 @@ contains
        longname = 'Surface flux of CO2 from land'
        stdname  = 'surface_upward_flux_of_carbon_dioxide_where_land'
        units    = 'moles m-2 s-1'
-       attname  = 'Fall_foc2_lnd'
+       attname  = 'Fall_fco2_lnd'
        call metadata_set(attname, longname, stdname, units)
 
        call seq_flds_add(o2x_fluxes, "Faoo_fco2_ocn")
@@ -2950,7 +2950,7 @@ contains
        longname = 'Surface flux of CO2 from land'
        stdname  = 'surface_upward_flux_of_carbon_dioxide_where_land'
        units    = 'moles m-2 s-1'
-       attname  = 'Fall_foc2_lnd'
+       attname  = 'Fall_fco2_lnd'
        call metadata_set(attname, longname, stdname, units)
 
        call seq_flds_add(o2x_fluxes, "Faoo_fco2_ocn")


### PR DESCRIPTION
The process of creating a carbon budget pointed out that we have to been handling the "direct" lnd-to-atm fluxes incorrectly for trigrid configurations. The new budget will come in separately, but this brings in the coupler changes as well as a consistent update to the heat and energy budgets.

[non-BFB] for trigrid simulations

do not merge until further testing