### PR TITLE
Add horizontal tapering function to mesoscale eddy parameterizations (AMOC PR 2/6)

### DIFF
--- a/cime_config/testmods_dirs/allactive/wcprodrrm/user_nl_mpaso
+++ b/cime_config/testmods_dirs/allactive/wcprodrrm/user_nl_mpaso
@@ -15,6 +15,7 @@
 ! SourceMods/src.mpaso/streams.ocean
 !----------------------------------------------------------------------------------
 
-config_gm_closure = 'constant'
- config_eddying_resolution_taper = 'ramp'
+ config_gm_closure = 'constant'
+ config_redi_horizontal_taper = 'ramp'
+ config_gm_horizontal_taper = 'ramp'
  config_use_redi = .true.

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -589,8 +589,8 @@ add_default($nl, 'config_GM_EG_Rhines_factor');
 add_default($nl, 'config_GM_horizontal_taper');
 add_default($nl, 'config_GM_horizontal_ramp_min');
 add_default($nl, 'config_GM_horizontal_ramp_max');
-add_default($nl, 'config_GM_Rossby_ramp_min');
-add_default($nl, 'config_GM_Rossby_ramp_max');
+add_default($nl, 'config_GMRedi_Rossby_ramp_min');
+add_default($nl, 'config_GMRedi_Rossby_ramp_max');
 
 ####################################
 # Namelist group: Rayleigh_damping #

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -589,6 +589,8 @@ add_default($nl, 'config_GM_EG_Rhines_factor');
 add_default($nl, 'config_GM_horizontal_taper');
 add_default($nl, 'config_GM_horizontal_ramp_min');
 add_default($nl, 'config_GM_horizontal_ramp_max');
+add_default($nl, 'config_GM_Rossby_ramp_min');
+add_default($nl, 'config_GM_Rossby_ramp_max');
 
 ####################################
 # Namelist group: Rayleigh_damping #

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -580,6 +580,7 @@ add_default($nl, 'config_Redi_min_layers_diag_terms');
 add_default($nl, 'config_use_GM');
 add_default($nl, 'config_GM_closure');
 add_default($nl, 'config_GM_constant_kappa');
+add_default($nl, 'config_gm_enable_horizontal_resolution_function');
 add_default($nl, 'config_GM_constant_bclModeSpeed');
 add_default($nl, 'config_GM_minBclModeSpeed_method');
 add_default($nl, 'config_GM_spatially_variable_min_kappa');

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -550,14 +550,6 @@ add_default($nl, 'config_Leith_parameter');
 add_default($nl, 'config_Leith_dx');
 add_default($nl, 'config_Leith_visc2_max');
 
-####################################################
-# Namelist group: mesoscale_eddy_parameterizations #
-####################################################
-
-add_default($nl, 'config_eddying_resolution_taper');
-add_default($nl, 'config_eddying_resolution_ramp_min');
-add_default($nl, 'config_eddying_resolution_ramp_max');
-
 #########################################
 # Namelist group: Redi_isopycnal_mixing #
 #########################################
@@ -572,6 +564,9 @@ add_default($nl, 'config_Redi_N2_based_taper_enable');
 add_default($nl, 'config_Redi_N2_based_taper_min');
 add_default($nl, 'config_Redi_N2_based_taper_limit_term1');
 add_default($nl, 'config_Redi_min_layers_diag_terms');
+add_default($nl, 'config_Redi_horizontal_taper');
+add_default($nl, 'config_Redi_horizontal_ramp_min');
+add_default($nl, 'config_Redi_horizontal_ramp_max');
 
 ############################################
 # Namelist group: GM_eddy_parameterization #
@@ -580,7 +575,6 @@ add_default($nl, 'config_Redi_min_layers_diag_terms');
 add_default($nl, 'config_use_GM');
 add_default($nl, 'config_GM_closure');
 add_default($nl, 'config_GM_constant_kappa');
-add_default($nl, 'config_gm_enable_horizontal_resolution_function');
 add_default($nl, 'config_GM_constant_bclModeSpeed');
 add_default($nl, 'config_GM_minBclModeSpeed_method');
 add_default($nl, 'config_GM_spatially_variable_min_kappa');
@@ -592,6 +586,9 @@ add_default($nl, 'config_GM_EG_riMin');
 add_default($nl, 'config_GM_EG_kappa_factor');
 add_default($nl, 'config_GM_EG_Rossby_factor');
 add_default($nl, 'config_GM_EG_Rhines_factor');
+add_default($nl, 'config_GM_horizontal_taper');
+add_default($nl, 'config_GM_horizontal_ramp_min');
+add_default($nl, 'config_GM_horizontal_ramp_max');
 
 ####################################
 # Namelist group: Rayleigh_damping #
@@ -1664,7 +1661,6 @@ my @groups = qw(run_modes
                 hmix_leith
                 redi_isopycnal_mixing
                 gm_eddy_parameterization
-                mesoscale_eddy_parameterizations
                 rayleigh_damping
                 cvmix
                 gotm

--- a/components/mpas-ocean/bld/build-namelist-group-list
+++ b/components/mpas-ocean/bld/build-namelist-group-list
@@ -8,7 +8,6 @@ my @groups = qw(run_modes
                 hmix_del2
                 hmix_del4
                 hmix_leith
-                mesoscale_eddy_parameterizations
                 redi_isopycnal_mixing
                 gm_eddy_parameterization
                 rayleigh_damping

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -132,6 +132,8 @@ add_default($nl, 'config_GM_EG_Rhines_factor');
 add_default($nl, 'config_GM_horizontal_taper');
 add_default($nl, 'config_GM_horizontal_ramp_min');
 add_default($nl, 'config_GM_horizontal_ramp_max');
+add_default($nl, 'config_GM_Rossby_ramp_min');
+add_default($nl, 'config_GM_Rossby_ramp_max');
 
 ####################################
 # Namelist group: Rayleigh_damping #

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -132,8 +132,8 @@ add_default($nl, 'config_GM_EG_Rhines_factor');
 add_default($nl, 'config_GM_horizontal_taper');
 add_default($nl, 'config_GM_horizontal_ramp_min');
 add_default($nl, 'config_GM_horizontal_ramp_max');
-add_default($nl, 'config_GM_Rossby_ramp_min');
-add_default($nl, 'config_GM_Rossby_ramp_max');
+add_default($nl, 'config_GMRedi_Rossby_ramp_min');
+add_default($nl, 'config_GMRedi_Rossby_ramp_max');
 
 ####################################
 # Namelist group: Rayleigh_damping #

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -123,6 +123,7 @@ add_default($nl, 'config_Redi_min_layers_diag_terms');
 add_default($nl, 'config_use_GM');
 add_default($nl, 'config_GM_closure');
 add_default($nl, 'config_GM_constant_kappa');
+add_default($nl, 'config_gm_enable_horizontal_resolution_function');
 add_default($nl, 'config_GM_constant_bclModeSpeed');
 add_default($nl, 'config_GM_minBclModeSpeed_method');
 add_default($nl, 'config_GM_spatially_variable_min_kappa');

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -93,14 +93,6 @@ add_default($nl, 'config_Leith_parameter');
 add_default($nl, 'config_Leith_dx');
 add_default($nl, 'config_Leith_visc2_max');
 
-####################################################
-# Namelist group: mesoscale_eddy_parameterizations #
-####################################################
-
-add_default($nl, 'config_eddying_resolution_taper');
-add_default($nl, 'config_eddying_resolution_ramp_min');
-add_default($nl, 'config_eddying_resolution_ramp_max');
-
 #########################################
 # Namelist group: Redi_isopycnal_mixing #
 #########################################
@@ -115,6 +107,9 @@ add_default($nl, 'config_Redi_N2_based_taper_enable');
 add_default($nl, 'config_Redi_N2_based_taper_min');
 add_default($nl, 'config_Redi_N2_based_taper_limit_term1');
 add_default($nl, 'config_Redi_min_layers_diag_terms');
+add_default($nl, 'config_Redi_horizontal_taper');
+add_default($nl, 'config_Redi_horizontal_ramp_min');
+add_default($nl, 'config_Redi_horizontal_ramp_max');
 
 ############################################
 # Namelist group: GM_eddy_parameterization #
@@ -123,7 +118,6 @@ add_default($nl, 'config_Redi_min_layers_diag_terms');
 add_default($nl, 'config_use_GM');
 add_default($nl, 'config_GM_closure');
 add_default($nl, 'config_GM_constant_kappa');
-add_default($nl, 'config_gm_enable_horizontal_resolution_function');
 add_default($nl, 'config_GM_constant_bclModeSpeed');
 add_default($nl, 'config_GM_minBclModeSpeed_method');
 add_default($nl, 'config_GM_spatially_variable_min_kappa');
@@ -135,6 +129,9 @@ add_default($nl, 'config_GM_EG_riMin');
 add_default($nl, 'config_GM_EG_kappa_factor');
 add_default($nl, 'config_GM_EG_Rossby_factor');
 add_default($nl, 'config_GM_EG_Rhines_factor');
+add_default($nl, 'config_GM_horizontal_taper');
+add_default($nl, 'config_GM_horizontal_ramp_min');
+add_default($nl, 'config_GM_horizontal_ramp_max');
 
 ####################################
 # Namelist group: Rayleigh_damping #

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -188,8 +188,8 @@
 <config_GM_horizontal_ramp_min ocn_grid="WCAtl12to45E2r4">30e3</config_GM_horizontal_ramp_min>
 <config_GM_horizontal_ramp_max>30e3</config_GM_horizontal_ramp_max>
 <config_GM_horizontal_ramp_max ocn_grid="WCAtl12to45E2r4">40e3</config_GM_horizontal_ramp_max>
-<config_GM_Rossby_ramp_min>0.5</config_GM_Rossby_ramp_min>
-<config_GM_Rossby_ramp_max>3.0</config_GM_Rossby_ramp_max>
+<config_GMRedi_Rossby_ramp_min>0.5</config_GMRedi_Rossby_ramp_min>
+<config_GMRedi_Rossby_ramp_max>3.0</config_GMRedi_Rossby_ramp_max>
 
 <!-- Rayleigh_damping -->
 <config_Rayleigh_friction>.false.</config_Rayleigh_friction>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -188,6 +188,8 @@
 <config_GM_horizontal_ramp_min ocn_grid="WCAtl12to45E2r4">30e3</config_GM_horizontal_ramp_min>
 <config_GM_horizontal_ramp_max>30e3</config_GM_horizontal_ramp_max>
 <config_GM_horizontal_ramp_max ocn_grid="WCAtl12to45E2r4">40e3</config_GM_horizontal_ramp_max>
+<config_GM_Rossby_ramp_min>0.5</config_GM_Rossby_ramp_min>
+<config_GM_Rossby_ramp_max>3.0</config_GM_Rossby_ramp_max>
 
 <!-- Rayleigh_damping -->
 <config_Rayleigh_friction>.false.</config_Rayleigh_friction>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -174,6 +174,7 @@
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="WCAtl12to45E2r4">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="SOwISC12to60E2r4">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="ECwISC30to60E2r1">600.0</config_GM_constant_kappa>
+<config_gm_enable_horizontal_resolution_function>.false.</config_gm_enable_horizontal_resolution_function>
 <config_GM_constant_bclModeSpeed>0.3</config_GM_constant_bclModeSpeed>
 <config_GM_minBclModeSpeed_method>'constant'</config_GM_minBclModeSpeed_method>
 <config_GM_spatially_variable_min_kappa>300.0</config_GM_spatially_variable_min_kappa>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -130,13 +130,6 @@
 <config_Leith_dx>15000.0</config_Leith_dx>
 <config_Leith_visc2_max>2.5e3</config_Leith_visc2_max>
 
-<!-- mesoscale_eddy_parameterizations -->
-<config_eddying_resolution_taper>'ramp'</config_eddying_resolution_taper>
-<config_eddying_resolution_ramp_min>20e3</config_eddying_resolution_ramp_min>
-<config_eddying_resolution_ramp_min ocn_grid="WCAtl12to45E2r4">30e3</config_eddying_resolution_ramp_min>
-<config_eddying_resolution_ramp_max>30e3</config_eddying_resolution_ramp_max>
-<config_eddying_resolution_ramp_max ocn_grid="WCAtl12to45E2r4">40e3</config_eddying_resolution_ramp_max>
-
 <!-- Redi_isopycnal_mixing -->
 <config_use_Redi>.true.</config_use_Redi>
 <config_use_Redi ocn_grid="oRRS30to10v3">.false.</config_use_Redi>
@@ -153,6 +146,11 @@
 <config_Redi_N2_based_taper_min>0.1</config_Redi_N2_based_taper_min>
 <config_Redi_N2_based_taper_limit_term1>.true.</config_Redi_N2_based_taper_limit_term1>
 <config_Redi_min_layers_diag_terms>6</config_Redi_min_layers_diag_terms>
+<config_Redi_horizontal_taper>'ramp'</config_Redi_horizontal_taper>
+<config_Redi_horizontal_ramp_min>20e3</config_Redi_horizontal_ramp_min>
+<config_Redi_horizontal_ramp_min ocn_grid="WCAtl12to45E2r4">30e3</config_Redi_horizontal_ramp_min>
+<config_Redi_horizontal_ramp_max>30e3</config_Redi_horizontal_ramp_max>
+<config_Redi_horizontal_ramp_max ocn_grid="WCAtl12to45E2r4">40e3</config_Redi_horizontal_ramp_max>
 
 <!-- GM_eddy_parameterization -->
 <config_use_GM>.true.</config_use_GM>
@@ -174,7 +172,6 @@
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="WCAtl12to45E2r4">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="SOwISC12to60E2r4">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="ECwISC30to60E2r1">600.0</config_GM_constant_kappa>
-<config_gm_enable_horizontal_resolution_function>.false.</config_gm_enable_horizontal_resolution_function>
 <config_GM_constant_bclModeSpeed>0.3</config_GM_constant_bclModeSpeed>
 <config_GM_minBclModeSpeed_method>'constant'</config_GM_minBclModeSpeed_method>
 <config_GM_spatially_variable_min_kappa>300.0</config_GM_spatially_variable_min_kappa>
@@ -186,6 +183,11 @@
 <config_GM_EG_kappa_factor>3.0</config_GM_EG_kappa_factor>
 <config_GM_EG_Rossby_factor>2.0</config_GM_EG_Rossby_factor>
 <config_GM_EG_Rhines_factor>0.3</config_GM_EG_Rhines_factor>
+<config_GM_horizontal_taper>'ramp'</config_GM_horizontal_taper>
+<config_GM_horizontal_ramp_min>20e3</config_GM_horizontal_ramp_min>
+<config_GM_horizontal_ramp_min ocn_grid="WCAtl12to45E2r4">30e3</config_GM_horizontal_ramp_min>
+<config_GM_horizontal_ramp_max>30e3</config_GM_horizontal_ramp_max>
+<config_GM_horizontal_ramp_max ocn_grid="WCAtl12to45E2r4">40e3</config_GM_horizontal_ramp_max>
 
 <!-- Rayleigh_damping -->
 <config_Rayleigh_friction>.false.</config_Rayleigh_friction>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -404,9 +404,9 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_Redi_closure" type="char*1024"
 	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
-Control what type of function is used for Redi $\kappa$.
+Control what type of function is used for Redi $\kappa$. For 'equalGM', RediKappa is set to gmBolusKappa, so picks up the closure used by GM.
 
-Valid values: 'constant', 'data'
+Valid values: 'constant', 'equalGM', 'data'
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -637,17 +637,17 @@ Valid values: Any positive real value.
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_GM_Rossby_ramp_min" type="real"
+<entry id="config_GMRedi_Rossby_ramp_min" type="real"
 	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
-Minimum value of the ratio between grid-cell size (dcEdge) and Rossby radius for GM $\kappa$ ramp function.  Used when config_GM_horizontal_taper is set to RossbyRadius.
+Minimum value of the ratio between grid-cell size (dcEdge) and Rossby radius for GM and Redi $\kappa$ ramp functions. Used when config_GM_horizontal_taper and/or config_Redi_horizontal_taper are set to RossbyRadius.
 
 Valid values: Any positive real value.
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_GM_Rossby_ramp_max" type="real"
+<entry id="config_GMRedi_Rossby_ramp_max" type="real"
 	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
-Maximum value of the ratio between grid-cell size (dcEdge) and Rossby radius for GM $\kappa$ ramp function.  Used when config_GM_horizontal_taper is set to RossbyRadius.
+Maximum value of the ratio between grid-cell size (dcEdge) and Rossby radius for GM and Redi $\kappa$ ramp functions. Used when config_GM_horizontal_taper and/or config_Redi_horizontal_taper are set to RossbyRadius.
 
 Valid values: Any positive real value.
 Default: Defined in namelist_defaults.xml

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -637,6 +637,22 @@ Valid values: Any positive real value.
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_GM_Rossby_ramp_min" type="real"
+	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
+Minimum value of the ratio between grid-cell size (dcEdge) and Rossby radius for GM $\kappa$ ramp function.  Used when config_GM_horizontal_taper is set to RossbyRadius.
+
+Valid values: Any positive real value.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_GM_Rossby_ramp_max" type="real"
+	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
+Maximum value of the ratio between grid-cell size (dcEdge) and Rossby radius for GM $\kappa$ ramp function.  Used when config_GM_horizontal_taper is set to RossbyRadius.
+
+Valid values: Any positive real value.
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- Rayleigh_damping -->
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -404,9 +404,9 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_Redi_closure" type="char*1024"
 	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
-Control what type of function is used for Redi $\kappa$. For 'equalGM', RediKappa is set to gmBolusKappa, so picks up the closure used by GM.
+Control what type of function is used for Redi $\kappa$.
 
-Valid values: 'constant', 'equalGM', 'data'
+Valid values: 'constant', 'data'
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -528,6 +528,14 @@ Valid values: MISSING POSSIBLE VALUES
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_gm_enable_horizontal_resolution_function" type="logical"
+	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
+Flag to enable the resolution tapering in the horizontal following Hallberg (2013) - https://doi.org/10.1016/j.ocemod.2013.08.007
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
 <entry id="config_GM_constant_bclModeSpeed" type="real"
 	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
 The parameter setting for the first baroclinic mode speed for the vertical stream function boundary value problem. This appears as $c$ in eqn 16a of Ferrari et al. 2010 (https://doi.org/10.1016/j.ocemod.2010.01.004).

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -392,33 +392,6 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 
-<!-- mesoscale_eddy_parameterizations -->
-
-<entry id="config_eddying_resolution_taper" type="char*1024"
-	category="mesoscale_eddy_parameterizations" group="mesoscale_eddy_parameterizations">
-Control how the Redi and GM Bolus $\kappa$ value varies as a function of horizontal resolution
-
-Valid values: 'none' and 'ramp'
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_eddying_resolution_ramp_min" type="real"
-	category="mesoscale_eddy_parameterizations" group="mesoscale_eddy_parameterizations">
-Minimum value in grid cell size for Redi and GM $\kappa$ ramp function.  Here cell size refers to dcEdge. Used when config_eddying_resolution_taper is set to ramp.
-
-Valid values: Any positive real value.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_eddying_resolution_ramp_max" type="real"
-	category="mesoscale_eddy_parameterizations" group="mesoscale_eddy_parameterizations">
-Maximum value in grid cell size for Redi and GM $\kappa$ ramp function.  Here cell size refers to dcEdge. Used when config_eddying_resolution_taper is set to ramp.
-
-Valid values: Any positive real value.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-
 <!-- Redi_isopycnal_mixing -->
 
 <entry id="config_use_Redi" type="logical"
@@ -501,6 +474,30 @@ Valid values: any integer between 0 (all layers on) and nVertLevels (all layers 
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_Redi_horizontal_taper" type="char*1024"
+	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
+Control how the Redi $\kappa$ value varies as a function of horizontal resolution. 'none' is constant, 'ramp' is strictly based on resolution, 'RossbyRadius' follows Hallberg (2013) - https://doi.org/10.1016/j.ocemod.2013.08.007
+
+Valid values: 'none', 'ramp', 'RossbyRadius'
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_Redi_horizontal_ramp_min" type="real"
+	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
+Minimum value in grid cell size for Redi $\kappa$ ramp function.  Here cell size refers to dcEdge. Used when config_Redi_horizontal_taper is set to ramp.
+
+Valid values: Any positive real value.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_Redi_horizontal_ramp_max" type="real"
+	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
+Maximum value in grid cell size for Redi $\kappa$ ramp function.  Here cell size refers to dcEdge. Used when config_Redi_horizontal_taper is set to ramp.
+
+Valid values: Any positive real value.
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- GM_eddy_parameterization -->
 
@@ -525,14 +522,6 @@ Default: Defined in namelist_defaults.xml
 Coefficient of standard GM parametrization of eddy transport (Bolus component), $\kappa$. Only used when config_GM_closure is set to constant.
 
 Valid values: MISSING POSSIBLE VALUES
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_gm_enable_horizontal_resolution_function" type="logical"
-	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
-Flag to enable the resolution tapering in the horizontal following Hallberg (2013) - https://doi.org/10.1016/j.ocemod.2013.08.007
-
-Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -621,6 +610,30 @@ Default: Defined in namelist_defaults.xml
 factor multiplying the Rhines length in the scheme from Eden Greatbatch (2008) Ocean Modeling -- Equation (28)
 
 Valid values: small positive values less than equal to one
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_GM_horizontal_taper" type="char*1024"
+	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
+Control how the GM Bolus value varies as a function of horizontal resolution. 'none' is constant, 'ramp' is strictly based on resolution, 'RossbyRadius' follows Hallberg (2013) - https://doi.org/10.1016/j.ocemod.2013.08.007
+
+Valid values: 'none', 'ramp', 'RossbyRadius'
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_GM_horizontal_ramp_min" type="real"
+	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
+Minimum value in grid cell size for GM $\kappa$ ramp function.  Here cell size refers to dcEdge. Used when config_GM_horizontal_taper is set to ramp.
+
+Valid values: Any positive real value.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_GM_horizontal_ramp_max" type="real"
+	category="GM_eddy_parameterization" group="GM_eddy_parameterization">
+Maximum value in grid cell size for GM $\kappa$ ramp function.  Here cell size refers to dcEdge. Used when config_GM_horizontal_taper is set to ramp.
+
+Valid values: Any positive real value.
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2875,6 +2875,10 @@
 			 description="Horizontal tapering for GM. Varies between 0 and 1."
 			 packages="gm"
 		/>
+		<var name="RossbyRadius" type="real" dimensions="nEdges Time" units="m"
+			 description="Rossby Radius, computed in GM routine for some settings"
+			 packages="gm"
+		/>
 		<var name="surfaceFluxAttenuationCoefficient" type="real" dimensions="nCells Time" units="m"
 			description="The spatially-dependent length scale of exponential decay of surface fluxes. Fluxes are multiplied by $e^{z/\gamma}$, where this coefficient is $\gamma$."
 		/>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -411,6 +411,14 @@
 					description="Maximum value in grid cell size for GM $\kappa$ ramp function.  Here cell size refers to dcEdge. Used when config_GM_horizontal_taper is set to ramp."
 					possible_values="Any positive real value."
 		/>
+		<nml_option name="config_GM_Rossby_ramp_min" type="real" default_value="0.5" units="unitless"
+					description="Minimum value of the ratio between grid-cell size (dcEdge) and Rossby radius for GM $\kappa$ ramp function.  Used when config_GM_horizontal_taper is set to RossbyRadius."
+					possible_values="Any positive real value."
+		/>
+		<nml_option name="config_GM_Rossby_ramp_max" type="real" default_value="3.0" units="unitless"
+					description="Maximum value of the ratio between grid-cell size (dcEdge) and Rossby radius for GM $\kappa$ ramp function.  Used when config_GM_horizontal_taper is set to RossbyRadius."
+					possible_values="Any positive real value."
+		/>
 	</nml_record>
 	<nml_record name="Rayleigh_damping" mode="forward">
 		<nml_option name="config_Rayleigh_friction" type="logical" default_value=".false." units="unitless"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -411,12 +411,12 @@
 					description="Maximum value in grid cell size for GM $\kappa$ ramp function.  Here cell size refers to dcEdge. Used when config_GM_horizontal_taper is set to ramp."
 					possible_values="Any positive real value."
 		/>
-		<nml_option name="config_GM_Rossby_ramp_min" type="real" default_value="0.5" units="unitless"
-					description="Minimum value of the ratio between grid-cell size (dcEdge) and Rossby radius for GM $\kappa$ ramp function.  Used when config_GM_horizontal_taper is set to RossbyRadius."
+		<nml_option name="config_GMRedi_Rossby_ramp_min" type="real" default_value="0.5" units="unitless"
+					description="Minimum value of the ratio between grid-cell size (dcEdge) and Rossby radius for GM and Redi $\kappa$ ramp functions. Used when config_GM_horizontal_taper and/or config_Redi_horizontal_taper are set to RossbyRadius."
 					possible_values="Any positive real value."
 		/>
-		<nml_option name="config_GM_Rossby_ramp_max" type="real" default_value="3.0" units="unitless"
-					description="Maximum value of the ratio between grid-cell size (dcEdge) and Rossby radius for GM $\kappa$ ramp function.  Used when config_GM_horizontal_taper is set to RossbyRadius."
+		<nml_option name="config_GMRedi_Rossby_ramp_max" type="real" default_value="3.0" units="unitless"
+					description="Maximum value of the ratio between grid-cell size (dcEdge) and Rossby radius for GM and Redi $\kappa$ ramp functions. Used when config_GM_horizontal_taper and/or config_Redi_horizontal_taper are set to RossbyRadius."
 					possible_values="Any positive real value."
 		/>
 	</nml_record>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2860,11 +2860,11 @@
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="gmBolusKappa" type="real" dimensions="nEdges Time" units="m^2 s^{-1}"
-			 description="GM Bolus Kappa value.  This is constant in time, and set at init based on the constant or ramp fuction."
+			 description="GM Bolus Kappa value.  On output, it has NOT been multiplied by the horizontal taper array gmHorizontalTaper, because that is applied at the end to the normalGMBolusVelocity variable, not to the gmBolusKappa."
 			 packages="gm"
 		/>
 		<var name="RediKappa" type="real" dimensions="nEdges Time" units="m^2 s^{-1}"
-			 description="Redi Kappa value.  This is constant in time, and set at init based on the constant or ramp fuction."
+			 description="Redi Kappa value.  On output, it has already been multiplied by the horizontal taper array RediHorizontalTaper (as opposed to gmBolusKappa, which has not been multiplied by the horizontal taper)."
 			 packages="gm"
 		/>
 		<var name="RediHorizontalTaper" type="real" dimensions="nEdges Time" units="unitless"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -295,8 +295,8 @@
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_Redi_closure" type="character" default_value="constant" units="unitless"
-					description="Control what type of function is used for Redi $\kappa$. For 'equalGM', RediKappa is set to gmBolusKappa, so picks up the closure used by GM."
-					possible_values="'constant', 'equalGM', 'data'"
+					description="Control what type of function is used for Redi $\kappa$."
+					possible_values="'constant', 'data'"
 		/>
 		<nml_option name="config_Redi_constant_kappa" type="real" default_value="600.0" units="m^2 s^{-1}"
 					description="The Redi diffusion coefficient. Only used when config_Redi_closure = 'constant'."

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -289,20 +289,6 @@
 					possible_values="any positive real"
 		/>
 	</nml_record>
-	<nml_record name="mesoscale_eddy_parameterizations" mode="forward">
-		<nml_option name="config_eddying_resolution_taper" type="character" default_value="ramp" units="unitless"
-					description="Control how the Redi and GM Bolus $\kappa$ value varies as a function of horizontal resolution"
-					possible_values="'none' and 'ramp'"
-		/>
-		<nml_option name="config_eddying_resolution_ramp_min" type="real" default_value="20e3" units="m"
-					description="Minimum value in grid cell size for Redi and GM $\kappa$ ramp function.  Here cell size refers to dcEdge. Used when config_eddying_resolution_taper is set to ramp."
-					possible_values="Any positive real value."
-		/>
-		<nml_option name="config_eddying_resolution_ramp_max" type="real" default_value="30e3" units="m"
-					description="Maximum value in grid cell size for Redi and GM $\kappa$ ramp function.  Here cell size refers to dcEdge. Used when config_eddying_resolution_taper is set to ramp."
-					possible_values="Any positive real value."
-		/>
-	</nml_record>
 	<nml_record name="Redi_isopycnal_mixing" mode="forward">
 		<nml_option name="config_use_Redi" type="logical" default_value=".false." units="unitless"
 					description="If true, Redi isopycnal mixing is turned on"
@@ -344,6 +330,18 @@
 					description="Redi diagonal terms (2 and 3) are turned off from layer 1 through config_Redi_min_layers_diag_terms-1, and on from config_Redi_min_layers_diag_terms to nVertLevels. The Redi diagonal terms are not guaranteed to produce bounded tracer fields, and in practice produce growing temperatures in a few columns with fewer than 5 vertical cells. Redi is meant for isopycnal mixing in the deep ocean, so not applying Redi diagonal terms in very shallow regions is an acceptable solution."
 					possible_values="any integer between 0 (all layers on) and nVertLevels (all layers off)"
 		/>
+		<nml_option name="config_Redi_horizontal_taper" type="character" default_value="ramp" units="unitless"
+					description="Control how the Redi Bolus $\kappa$ value varies as a function of horizontal resolution. 'none' is constant, 'ramp' is strictly based on resolution, 'RossbyRadius' follows Hallberg (2013) - https://doi.org/10.1016/j.ocemod.2013.08.007"
+					possible_values="'none', 'ramp', 'RossbyRadius'"
+		/>
+		<nml_option name="config_Redi_horizontal_ramp_min" type="real" default_value="20e3" units="m"
+					description="Minimum value in grid cell size for Redi $\kappa$ ramp function.  Here cell size refers to dcEdge. Used when config_Redi_horizontal_taper is set to ramp."
+					possible_values="Any positive real value."
+		/>
+		<nml_option name="config_Redi_horizontal_ramp_max" type="real" default_value="30e3" units="m"
+					description="Maximum value in grid cell size for Redi $\kappa$ ramp function.  Here cell size refers to dcEdge. Used when config_Redi_horizontal_taper is set to ramp."
+					possible_values="Any positive real value."
+		/>
 	</nml_record>
 	<nml_record name="GM_eddy_parameterization" mode="forward">
 		<nml_option name="config_use_GM" type="logical" default_value=".false." units="NA"
@@ -356,10 +354,6 @@
 		/>
 		<nml_option name="config_GM_constant_kappa" type="real" default_value="600.0" units="m^2 s^{-1}"
 					description="Coefficient of standard GM parametrization of eddy transport (Bolus component), $\kappa$. Only used when config_GM_closure is set to constant."
-		/>
-		<nml_option name="config_gm_enable_horizontal_resolution_function" type="logical" default_value=".false." units="unitless"
-					description="Flag to enable the resolution tapering in the horizontal following Hallberg (2013) - https://doi.org/10.1016/j.ocemod.2013.08.007"
-					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_GM_constant_bclModeSpeed" type="real" default_value="0.3" units="m/s"
 					description="The parameter setting for the first baroclinic mode speed for the vertical stream function boundary value problem. This appears as $c$ in eqn 16a of Ferrari et al. 2010 (https://doi.org/10.1016/j.ocemod.2010.01.004)."
@@ -404,6 +398,18 @@
 		<nml_option name="config_GM_EG_Rhines_factor" type="real" default_value="0.3" units="NA"
 					description="factor multiplying the Rhines length in the scheme from Eden Greatbatch (2008) Ocean Modeling -- Equation (28)"
 					possible_values="small positive values less than equal to one"
+		/>
+		<nml_option name="config_GM_horizontal_taper" type="character" default_value="ramp" units="unitless"
+					description="Control how the GM Bolus $\kappa$ value varies as a function of horizontal resolution. 'none' is constant, 'ramp' is strictly based on resolution, 'RossbyRadius' follows Hallberg (2013) - https://doi.org/10.1016/j.ocemod.2013.08.007"
+					possible_values="'none', 'ramp', 'RossbyRadius'"
+		/>
+		<nml_option name="config_GM_horizontal_ramp_min" type="real" default_value="20e3" units="m"
+					description="Minimum value in grid cell size for GM $\kappa$ ramp function.  Here cell size refers to dcEdge. Used when config_GM_horizontal_taper is set to ramp."
+					possible_values="Any positive real value."
+		/>
+		<nml_option name="config_GM_horizontal_ramp_max" type="real" default_value="30e3" units="m"
+					description="Maximum value in grid cell size for GM $\kappa$ ramp function.  Here cell size refers to dcEdge. Used when config_GM_horizontal_taper is set to ramp."
+					possible_values="Any positive real value."
 		/>
 	</nml_record>
 	<nml_record name="Rayleigh_damping" mode="forward">
@@ -2702,7 +2708,7 @@
 			packages="forwardMode;analysisMode"
 		/>
 		<var name="betaEdge" type="real" dimensions="nEdges Time" units="m^{-1} s^{-1}"
-			description="meridional gradient of the coriolis parameter"
+			description="meridional gradient of the coriolis parameter, used in GM"
 		/>
 		<var name="gmKappaScaling" type="real" dimensions="nVertLevelsP1 nEdges Time" units="NA" default_value="1.0"
 			description="spatially and depth varying GM kappa.  The scaling is based on the Brunt Vaisala Frequency relative to a maximum value below the mixed layer, follows from Danabasoglu and Marshall 2007.  If config_GM_closure is not set to N2_dependent the scaling value is set to 1 everywhere."
@@ -2861,8 +2867,12 @@
 			 description="Redi Kappa value.  This is constant in time, and set at init based on the constant or ramp fuction."
 			 packages="gm"
 		/>
-		<var name="gmResolutionTaper" type="real" dimensions="nEdges Time" units="m^2 s^{-1}"
-			 description="resolution tapering for GM and Redi"
+		<var name="RediHorizontalTaper" type="real" dimensions="nEdges Time" units="unitless"
+			 description="Horizontal tapering for Redi. Varies between 0 and 1."
+			 packages="gm"
+		/>
+		<var name="gmHorizontalTaper" type="real" dimensions="nEdges Time" units="unitless"
+			 description="Horizontal tapering for GM. Varies between 0 and 1."
 			 packages="gm"
 		/>
 		<var name="surfaceFluxAttenuationCoefficient" type="real" dimensions="nCells Time" units="m"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2249,13 +2249,13 @@
 		<var name="kiteAreasOnVertex" type="real" dimensions="vertexDegree nVertices" units="m^2"
 			 description="Area of the portions of each dual cell that are part of each cellsOnVertex."
 		/>
-		<var name="fEdge" type="real" dimensions="nEdges" units="s^{-1}"
+		<var name="fEdge" type="real" dimensions="nEdges" units="radians s^{-1}"
 			 description="Coriolis parameter at edges."
 		/>
-		<var name="fVertex" type="real" dimensions="nVertices" units="s^{-1}"
+		<var name="fVertex" type="real" dimensions="nVertices" units="radians s^{-1}"
 			 description="Coriolis parameter at vertices."
 		/>
-		<var name="fCell" type="real" dimensions="nCells" units="s^{-1}"
+		<var name="fCell" type="real" dimensions="nCells" units="radians s^{-1}"
 			 description="Coriolis parameter at cell centers."
 		/>
 		<var name="bottomDepth" type="real" dimensions="nCells" units="m"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2833,10 +2833,6 @@
 			 description="GM stream function"
 			 packages="forwardMode;analysisMode"
 		/>
-		<var name="gmStreamFuncTopOfCell" type="real" dimensions="nVertLevels nCells Time" units="m^2 s^{-1}"
-			 description="GM stream function reconstructed to the cell centers"
-			 packages="forwardMode;analysisMode"
-		/>
 		<var name="GMStreamFuncX" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2 s^{-1}"
 			 description="GM stream function"
 			 packages="forwardMode;analysisMode"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -331,7 +331,7 @@
 					possible_values="any integer between 0 (all layers on) and nVertLevels (all layers off)"
 		/>
 		<nml_option name="config_Redi_horizontal_taper" type="character" default_value="ramp" units="unitless"
-					description="Control how the Redi Bolus $\kappa$ value varies as a function of horizontal resolution. 'none' is constant, 'ramp' is strictly based on resolution, 'RossbyRadius' follows Hallberg (2013) - https://doi.org/10.1016/j.ocemod.2013.08.007"
+					description="Control how the Redi $\kappa$ value varies as a function of horizontal resolution. 'none' is constant, 'ramp' is strictly based on resolution, 'RossbyRadius' follows Hallberg (2013) - https://doi.org/10.1016/j.ocemod.2013.08.007"
 					possible_values="'none', 'ramp', 'RossbyRadius'"
 		/>
 		<nml_option name="config_Redi_horizontal_ramp_min" type="real" default_value="20e3" units="m"
@@ -400,7 +400,7 @@
 					possible_values="small positive values less than equal to one"
 		/>
 		<nml_option name="config_GM_horizontal_taper" type="character" default_value="ramp" units="unitless"
-					description="Control how the GM Bolus $\kappa$ value varies as a function of horizontal resolution. 'none' is constant, 'ramp' is strictly based on resolution, 'RossbyRadius' follows Hallberg (2013) - https://doi.org/10.1016/j.ocemod.2013.08.007"
+					description="Control how the GM Bolus value varies as a function of horizontal resolution. 'none' is constant, 'ramp' is strictly based on resolution, 'RossbyRadius' follows Hallberg (2013) - https://doi.org/10.1016/j.ocemod.2013.08.007"
 					possible_values="'none', 'ramp', 'RossbyRadius'"
 		/>
 		<nml_option name="config_GM_horizontal_ramp_min" type="real" default_value="20e3" units="m"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -357,6 +357,10 @@
 		<nml_option name="config_GM_constant_kappa" type="real" default_value="600.0" units="m^2 s^{-1}"
 					description="Coefficient of standard GM parametrization of eddy transport (Bolus component), $\kappa$. Only used when config_GM_closure is set to constant."
 		/>
+		<nml_option name="config_gm_enable_horizontal_resolution_function" type="logical" default_value=".false." units="unitless"
+					description="Flag to enable the resolution tapering in the horizontal following Hallberg (2013) - https://doi.org/10.1016/j.ocemod.2013.08.007"
+					possible_values=".true. or .false."
+		/>
 		<nml_option name="config_GM_constant_bclModeSpeed" type="real" default_value="0.3" units="m/s"
 					description="The parameter setting for the first baroclinic mode speed for the vertical stream function boundary value problem. This appears as $c$ in eqn 16a of Ferrari et al. 2010 (https://doi.org/10.1016/j.ocemod.2010.01.004)."
 					possible_values="Positive real numbers"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -295,8 +295,8 @@
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_Redi_closure" type="character" default_value="constant" units="unitless"
-					description="Control what type of function is used for Redi $\kappa$."
-					possible_values="'constant', 'data'"
+					description="Control what type of function is used for Redi $\kappa$. For 'equalGM', RediKappa is set to gmBolusKappa, so picks up the closure used by GM."
+					possible_values="'constant', 'equalGM', 'data'"
 		/>
 		<nml_option name="config_Redi_constant_kappa" type="real" default_value="600.0" units="m^2 s^{-1}"
 					description="The Redi diffusion coefficient. Only used when config_Redi_closure = 'constant'."
@@ -2708,7 +2708,7 @@
 			packages="forwardMode;analysisMode"
 		/>
 		<var name="betaEdge" type="real" dimensions="nEdges Time" units="m^{-1} s^{-1}"
-			description="meridional gradient of the coriolis parameter, used in GM"
+			description="meridional gradient of the coriolis parameter, used in the mesoscale eddy parameterization schemes"
 		/>
 		<var name="gmKappaScaling" type="real" dimensions="nVertLevelsP1 nEdges Time" units="NA" default_value="1.0"
 			description="spatially and depth varying GM kappa.  The scaling is based on the Brunt Vaisala Frequency relative to a maximum value below the mixed layer, follows from Danabasoglu and Marshall 2007.  If config_GM_closure is not set to N2_dependent the scaling value is set to 1 everywhere."

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -183,7 +183,7 @@ module ocn_diagnostics_variables
 
    real (kind=RKIND), pointer :: globalVerticalStretchMax, globalVerticalStretchMin
    real (kind=RKIND), dimension(:), pointer :: betaEdge
-   real (kind=RKIND), dimension(:), pointer :: RediHorizontalTaper, gmHorizontalTaper
+   real (kind=RKIND), dimension(:), pointer :: RediHorizontalTaper, gmHorizontalTaper, RossbyRadius
 
    ! Semi-implicit Array Pointers
    real (kind=RKIND), dimension(:), pointer :: SIvec_r0,SIvec_r00,SIvec_r1 ,SIvec_rh0,SIvec_rh1,SIvec_ph0,SIvec_ph1
@@ -260,6 +260,8 @@ contains
                    RediHorizontalTaper)
          call mpas_pool_get_array(diagnosticsPool, 'gmHorizontalTaper', &
                    gmHorizontalTaper)
+         call mpas_pool_get_array(diagnosticsPool, 'RossbyRadius', &
+                   RossbyRadius)
       end if
 
       if ( config_compute_active_tracer_budgets ) then
@@ -740,8 +742,9 @@ contains
          !$acc                   RediKappaScaling,  &
          !$acc                   rediLimiterCount,  &
          !$acc                   RediKappaSfcTaper, &
-         !$acc                   RediHorizontalTaper  &
-         !$acc                   gmHorizontalTaper  &
+         !$acc                   RediHorizontalTaper,  &
+         !$acc                   gmHorizontalTaper,  &
+         !$acc                   RossbyRadius  &
          !$acc                   )
       end if
       if ( config_compute_active_tracer_budgets ) then
@@ -976,8 +979,9 @@ contains
          !$acc                   RediKappaScaling,  &
          !$acc                   rediLimiterCount,  &
          !$acc                   RediKappaSfcTaper, &
-         !$acc                   RediHorizontalTaper  &
-         !$acc                   gmHorizontalTaper  &
+         !$acc                   RediHorizontalTaper,  &
+         !$acc                   gmHorizontalTaper,  &
+         !$acc                   RossbyRadius  &
          !$acc                   )
       end if
       if ( config_compute_active_tracer_budgets ) then
@@ -1170,7 +1174,8 @@ contains
                  rediLimiterCount,  &
                  RediKappaSfcTaper, &
                  RediHorizontalTaper, &
-                 gmHorizontalTaper)
+                 gmHorizontalTaper, &
+                 RossbyRadius)
       end if
       if ( config_compute_active_tracer_budgets ) then
          nullify(activeTracerHorMixTendency,              &

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -98,8 +98,7 @@ module ocn_diagnostics_variables
       transportVelocityX, transportVelocityY, transportVelocityZ, transportVelocityZonal, &
       transportVelocityMeridional, GMBolusVelocityX, GMBolusVelocityY, &
       GMBolusVelocityZ, GMBolusVelocityZonal, GMBolusVelocityMeridional, gmStreamFuncTopOfEdge, &
-      GMStreamFuncX, GMStreamFuncY, GMStreamFuncZ, GMStreamFuncZonal, GMStreamFuncMeridional, &
-      gmStreamFuncTopOfCell
+      GMStreamFuncX, GMStreamFuncY, GMStreamFuncZ, GMStreamFuncZonal, GMStreamFuncMeridional
 
    real (kind=RKIND), dimension(:,:), pointer :: rx1Edge
    real (kind=RKIND), dimension(:,:), pointer :: rx1Cell
@@ -385,8 +384,6 @@ contains
          ! GM-related fields
          call mpas_pool_get_array(diagnosticsPool, 'cGMphaseSpeed', &
                    cGMphaseSpeed)
-         call mpas_pool_get_array(diagnosticsPool, 'gmStreamFuncTopOfCell', &
-                   gmStreamFuncTopOfCell)
          call mpas_pool_get_array(diagnosticsPool, 'gmStreamFuncTopOfEdge', &
                    gmStreamFuncTopOfEdge)
          call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncX', &
@@ -700,7 +697,6 @@ contains
          !$acc                   vertAleTransportTop,             &
          !$acc                   GMBolusVelocityZonal,            &
          !$acc                   bulkRichardsonNumber,            &
-         !$acc                   gmStreamFuncTopOfCell,           &
          !$acc                   gmStreamFuncTopOfEdge,           &
          !$acc                   indexSSHGradientZonal,           &
          !$acc                   relativeVorticityCell,           &
@@ -936,7 +932,6 @@ contains
          !$acc                   vertAleTransportTop,             &
          !$acc                   GMBolusVelocityZonal,            &
          !$acc                   bulkRichardsonNumber,            &
-         !$acc                   gmStreamFuncTopOfCell,           &
          !$acc                   gmStreamFuncTopOfEdge,           &
          !$acc                   indexSSHGradientZonal,           &
          !$acc                   relativeVorticityCell,           &
@@ -1133,7 +1128,6 @@ contains
                  vertAleTransportTop,             &
                  GMBolusVelocityZonal,            &
                  bulkRichardsonNumber,            &
-                 gmStreamFuncTopOfCell,           &
                  gmStreamFuncTopOfEdge,           &
                  indexSSHGradientZonal,           &
                  relativeVorticityCell,           &

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -183,7 +183,7 @@ module ocn_diagnostics_variables
 
    real (kind=RKIND), pointer :: globalVerticalStretchMax, globalVerticalStretchMin
    real (kind=RKIND), dimension(:), pointer :: betaEdge
-   real (kind=RKIND), dimension(:), pointer :: gmResolutionTaper
+   real (kind=RKIND), dimension(:), pointer :: RediHorizontalTaper, gmHorizontalTaper
 
    ! Semi-implicit Array Pointers
    real (kind=RKIND), dimension(:), pointer :: SIvec_r0,SIvec_r00,SIvec_r1 ,SIvec_rh0,SIvec_rh1,SIvec_ph0,SIvec_ph1
@@ -242,7 +242,7 @@ contains
                    wettingVelocityField)
       end if
 
-      if ( config_use_GM ) then
+      if (config_use_GM.or.config_use_Redi) then
          call mpas_pool_get_array(diagnosticsPool, 'RediKappa', &
                    RediKappa)
          call mpas_pool_get_array(diagnosticsPool, 'RediKappaScaling', &
@@ -256,8 +256,10 @@ contains
                    gmBolusKappa)
          call mpas_pool_get_array(diagnosticsPool, 'gmKappaScaling', &
                    gmKappaScaling)
-         call mpas_pool_get_array(diagnosticsPool, 'gmResolutionTaper', &
-                   gmResolutionTaper)
+         call mpas_pool_get_array(diagnosticsPool, 'RediHorizontalTaper', &
+                   RediHorizontalTaper)
+         call mpas_pool_get_array(diagnosticsPool, 'gmHorizontalTaper', &
+                   gmHorizontalTaper)
       end if
 
       if ( config_compute_active_tracer_budgets ) then
@@ -730,7 +732,7 @@ contains
          !$acc                   wettingVelocity              &
          !$acc                   )
       end if
-      if ( config_use_GM ) then
+      if (config_use_GM.or.config_use_Redi) then
          !$acc enter data create(                   &
          !$acc                   RediKappa,         &
          !$acc                   gmBolusKappa,      &
@@ -738,7 +740,8 @@ contains
          !$acc                   RediKappaScaling,  &
          !$acc                   rediLimiterCount,  &
          !$acc                   RediKappaSfcTaper, &
-         !$acc                   gmResolutionTaper  &
+         !$acc                   RediHorizontalTaper  &
+         !$acc                   gmHorizontalTaper  &
          !$acc                   )
       end if
       if ( config_compute_active_tracer_budgets ) then
@@ -965,7 +968,7 @@ contains
          !$acc                   wettingVelocity              &
          !$acc                   )
       end if
-      if ( config_use_GM ) then
+      if (config_use_GM.or.config_use_Redi) then
          !$acc exit data delete(                    &
          !$acc                   RediKappa,         &
          !$acc                   gmBolusKappa,      &
@@ -973,7 +976,8 @@ contains
          !$acc                   RediKappaScaling,  &
          !$acc                   rediLimiterCount,  &
          !$acc                   RediKappaSfcTaper, &
-         !$acc                   gmResolutionTaper  &
+         !$acc                   RediHorizontalTaper  &
+         !$acc                   gmHorizontalTaper  &
          !$acc                   )
       end if
       if ( config_compute_active_tracer_budgets ) then
@@ -1158,14 +1162,15 @@ contains
       if ( trim(config_ocean_run_mode) == 'forward' ) then
          nullify(wettingVelocity)
       end if
-      if ( config_use_GM ) then
+      if (config_use_GM.or.config_use_Redi) then
          nullify(RediKappa,         &
                  gmBolusKappa,      &
                  gmKappaScaling,    &
                  RediKappaScaling,  &
                  rediLimiterCount,  &
                  RediKappaSfcTaper, &
-                 gmResolutionTaper)
+                 RediHorizontalTaper, &
+                 gmHorizontalTaper)
       end if
       if ( config_compute_active_tracer_budgets ) then
          nullify(activeTracerHorMixTendency,              &

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -634,7 +634,7 @@ contains
 
                 eddyLength = max(dcEdge(iEdge), min(c_Visbeck/(1.0E-15_RKIND + abs(fEdge(iEdge))), &
                                 sqrt(c_Visbeck/ (2.0_RKIND*betaEdge(iEdge)))))
-                eddyTime = 1.0_RKIND / (max(abs(fEdge(iEdge)), sqrt(2.0_RKIND*c_Visbeck*betaEdge(iEdge))) /  &
+                eddyTime = 1.0_RKIND / (1.0E-11_RKIND + max(abs(fEdge(iEdge)), sqrt(2.0_RKIND*c_Visbeck*betaEdge(iEdge))) /  &
                                       (1.0E-11_RKIND + sqrt(sumRi)))
                 gmBolusKappa(iEdge) = config_GM_Visbeck_alpha * eddyLength**2.0_RKIND / (1.0E-15 + eddyTime)
                 gmBolusKappa(iEdge) = max(config_GM_spatially_variable_min_kappa, min(gmBolusKappa(iEdge),  &

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -46,7 +46,7 @@ module ocn_gm
    ! Config options
    real(kind=RKIND), parameter :: epsGM = 1.0e-12_RKIND
 
-   ! The following logical variables are used to configure the three 
+   ! The following logical variables are used to configure the three
    ! available GM closures (constant, N2_dependent, Visbeck, EdenGreatbatch)
    logical :: local_config_GM_compute_Visbeck
    logical :: local_config_GM_lat_variable_c2
@@ -240,7 +240,7 @@ contains
          allocate(k33Norm(nVertLevels + 1))
 
          if ( config_Redi_N2_based_taper_enable ) then
-   
+
             !$omp parallel
             !$omp do schedule(runtime) private(maxLocation, k, BruntVaisalaFreqTopEdge, maxN)
             do iCell = 1, nCells
@@ -250,7 +250,7 @@ contains
                  k = k + 1
                  maxN = max(maxN,max(BruntVaisalaFreqTop(k, iCell), 0.0_RKIND))
                enddo
-   
+
                maxLocation = k
                do k = maxLocation, maxLevelCell(iCell)
                   BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTop(k, iCell), 0.0_RKIND)
@@ -262,14 +262,14 @@ contains
             !$omp end do
             !$omp end parallel
          end if
-   
+
          if (config_Redi_use_surface_taper) then
             !$omp parallel
             !$omp do schedule (runtime) private(zMLD, k)
             do iCell = 1, nCells
                k = max(minLevelCell(iCell), indMLD(iCell))
                zMLD = ssh(iCell) - zMid(k, iCell)
-   
+
                do k = minLevelCell(iCell), indMLD(iCell)
                   RediKappaSfcTaper(k, iCell) = abs((ssh(iCell) - zMid(k, iCell))/(zMLD))
                end do
@@ -277,7 +277,7 @@ contains
             !$omp end do
             !$omp end parallel
          end if
-   
+
          nCells = nCellsArray(3)
          !$omp parallel
          !$omp do schedule(runtime)  &
@@ -304,7 +304,7 @@ contains
             dzTop(maxLevelCell(iCell) + 1) = -1e-15_RKIND
             dTdzTop(maxLevelCell(iCell) + 1) = -1e-15_RKIND
             dSdzTop(maxLevelCell(iCell) + 1) = -1e-15_RKIND
-   
+
             do i = 1, nEdgesOnCell(iCell)
                iEdge = edgesOnCell(i, iCell)
                cell1 = cellsOnEdge(1, iEdge)
@@ -316,7 +316,7 @@ contains
                end if
                dcEdgeInv = 1.0_RKIND/dcEdge(iEdge)
                areaEdge = dcEdge(iEdge)*dvEdge(iEdge)
-   
+
                do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                   drhoDT = -thermExpCoeff(k, iCell)
                   drhoDS = salineContractCoeff(k, iCell)
@@ -327,7 +327,7 @@ contains
                           - activeTracers(indexSalinity, k, cell1)) &
                          *dcEdgeInv
                   drhoDx = drhoDT*dTdx + drhoDS*dSdx
-   
+
                   ! Always compute *Up on the top cell and *Down on the bottom
                   ! cell, even though they are never used. This avoids an if
                   ! statement or separate computation for top and bottom.
@@ -339,7 +339,7 @@ contains
                      -drhoDx/ &
                      (drhoDT*dTdzTop(k + 1) &
                       + drhoDS*dSdzTop(k + 1) + 1E-15_RKIND)
-   
+
                   ! set taper of slope ('F' function from Danabasoglu and McWilliams 95)
                   if (abs(slopeTriadDown(k, iCellSelf, iEdge)) > 0.6_RKIND*config_redi_maximum_slope) then
                      slopeTaperDown = 0.0_RKIND
@@ -359,35 +359,35 @@ contains
                                     config_Redi_maximum_slope - 1.0_RKIND)*(4.0_RKIND - abs(10.0_RKIND* &
                                     abs(slopeTriadUp(k, iCellSelf, iEdge))/config_Redi_maximum_slope - 4.0_RKIND)))
                   end if
-   
+
                   slopeTaperUp = 1.0_RKIND + slopeTaperFactor*(slopeTaperUp - 1.0_RKIND)
                   slopeTaperDown = 1.0_RKIND + slopeTaperFactor*(slopeTaperDown - 1.0_RKIND)
-   
+
                   sfcTaper = min(RediKappaSfcTaper(k, cell1), RediKappaSfcTaper(k, cell2))
                   sfcTaperUp = 1.0_RKIND + sfcTaperFactor*(sfcTaper - 1.0_RKIND)
                   sfcTaperDown = 1.0_RKIND + sfcTaperFactor*(sfcTaper - 1.0_RKIND)
-   
+
                   slopeTriadUp(k, iCellSelf, iEdge) = &
                      slopeTaperUp*sfcTaperUp*slopeTriadUp(k, iCellSelf, iEdge)
                   slopeTriadDown(k, iCellSelf, iEdge) = &
                      slopeTaperDown*sfcTaperDown*slopeTriadDown(k, iCellSelf, iEdge)
-   
+
                   ! Griffies 1998 eqn 34
                   if (k > minLevelCell(iCell)) then
                      k33(k, iCell) = k33(k, iCell) +  &
                                      areaEdge*dzTop(k)*slopeTriadUp(k, iCellSelf, iEdge)**2
                      k33Norm(k) = k33Norm(k) + areaEdge*dzTop(k)
                   end if
-   
+
                   !Taper Redi by tapering the slopes
                   k33(k + 1, iCell) = k33(k + 1, iCell) +  &
                                       areaEdge*dzTop(k + 1)*slopeTriadDown(k, iCellSelf, iEdge)**2
                   k33Norm(k + 1) = k33Norm(k + 1) + areaEdge*dzTop(k + 1)
-   
-   
+
+
                end do ! maxLevelEdgeTop(iEdge)
             end do ! nEdgesOnCell(iCell)
-   
+
             ! Normalize k33
             do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
                k33(k, iCell) = k33(k, iCell)/k33Norm(k)*RediKappaScaling(k, iCell)
@@ -456,7 +456,7 @@ contains
          end do
          !$omp end do
          !$omp end parallel
- 
+
          ! Compute density gradient (gradDensityEdge) and gradient of zMid (gradZMidEdge)
          ! along the constant coordinate surface.
          ! The computed variables lives at edge and mid-layer depth
@@ -487,7 +487,7 @@ contains
                                 gradZMidEdge(k,iEdge)) / (h1 + h2)
                end do
 
-               ! Approximation of values on the top and bottom interfaces through the idea of having ghost cells 
+               ! Approximation of values on the top and bottom interfaces through the idea of having ghost cells
                ! above the top and below the bottom layers of the same depths and density.
                gradDensityTopOfEdge(minLevelEdgeBot(iEdge),iEdge) = gradDensityEdge(minLevelEdgeBot(iEdge),iEdge)
                gradDensityTopOfEdge(maxLevelEdgeTop(iEdge)+1,iEdge) = gradDensityEdge(maxLevelEdgeTop(iEdge),iEdge)
@@ -566,7 +566,7 @@ contains
                   ltSum = ltSum + 0.5*(lt1+lt2)
                end do
 
-               ! Compute the minimum allowed speed of the first baroclinic mode. 
+               ! Compute the minimum allowed speed of the first baroclinic mode.
                ! If config_GM_minBclModeSpeed_method='constant' use local_config_GM_constant_bclModeSpeed.
                ! If config_GM_minBclModeSpeed_method='computed' use Brunt-Vaisala frequency on this edge.
                ! See initialization of these variables in this modules init routine.
@@ -944,7 +944,7 @@ contains
 
       type(block_type), pointer :: block
       type(mpas_pool_type), pointer :: meshPool
-      real(kind=RKIND), dimension(:), pointer :: dcEdge 
+      real(kind=RKIND), dimension(:), pointer :: dcEdge
 
       integer :: iEdge
       integer, pointer :: nEdges
@@ -1091,7 +1091,7 @@ contains
             coef = 1.0_RKIND &
                     /(config_GM_horizontal_ramp_max - config_GM_horizontal_ramp_min)
             !$omp parallel
-            !$omp do schedule(runtime) 
+            !$omp do schedule(runtime)
             do iEdge = 1, nEdges
                if (dcEdge(iEdge) <= config_GM_horizontal_ramp_min) then
                   gmHorizontalTaper(iEdge) = 0.0_RKIND

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -726,14 +726,14 @@ contains
 
                ! Ramp the parameterization between the given min and max values
                ! of the ratio of the cell width to the Rossby radius
-               if (dc_Lr <= config_GM_Rossby_ramp_min) then
+               if (dc_Lr <= config_GMRedi_Rossby_ramp_min) then
                   RossbyRadiusTaper(iEdge) = 0.0_RKIND
-               else if (dc_Lr >= config_GM_Rossby_ramp_max) then
+               else if (dc_Lr >= config_GMRedi_Rossby_ramp_max) then
                   RossbyRadiusTaper(iEdge) = 1.0_RKIND
                else
                   ! a linear ramp between the min and max of dc_Lr
-                  RossbyRadiusTaper(iEdge) = (dc_Lr - config_GM_Rossby_ramp_min) / &
-                     (config_GM_Rossby_ramp_max - config_GM_Rossby_ramp_min)
+                  RossbyRadiusTaper(iEdge) = (dc_Lr - config_GMRedi_Rossby_ramp_min) / &
+                     (config_GMRedi_Rossby_ramp_max - config_GMRedi_Rossby_ramp_min)
                end if
             end do
             !$omp end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -140,7 +140,7 @@ contains
       real(kind=RKIND), dimension(:), allocatable :: dzTop, dTdzTop, dSdzTop, k33Norm
       real(kind=RKIND), dimension(:), allocatable :: RossbyRadiusTaper
       real(kind=RKIND) :: c_Visbeck   ! baroclinic wave speed from Visbeck parameterization
-      real(kind=RKIND) :: c_mode1, resolution
+      real(kind=RKIND) :: c_mode1, resolution, dc_Lr
       ! Dimensions
       integer :: nCells, nEdges
       integer, pointer :: nVertLevels
@@ -690,7 +690,7 @@ contains
             call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
 
             !$omp parallel
-            !$omp do schedule(runtime) private(k, cell1, cell2, sum_hN, lt1, lt2, c_mode1, resolution)
+            !$omp do schedule(runtime) private(k, cell1, cell2, sum_hN, lt1, lt2, c_mode1, resolution, dc_Lr)
             do iEdge = 1, nEdges
                cell1 = cellsOnEdge(1, iEdge)
                cell2 = cellsOnEdge(2, iEdge)
@@ -723,13 +723,18 @@ contains
                RossbyRadius(iEdge) = c_mode1*sqrt( 1.0_RKIND / &
                   (fEdge(iEdge)*fEdge(iEdge) + 2.0_RKIND*betaEdge(iEdge)*c_mode1 + 1.0E-15_RKIND))
 
-               ! If the RossbyRadius is larger than two cell widths, then this
-               ! edge is sufficiently well-resolved, and turn off the
-               ! parameterization.
-               if (RossbyRadius(iEdge).ge.2.0_RKIND*dcEdge(iEdge) .or. c_mode1.lt.0.1_RKIND) then
+               dc_Lr = dcEdge(iEdge)/RossbyRadius(iEdge)
+
+               ! Ramp the parameterization between the given min and max values
+               ! of the ratio of the cell width to the Rossby radius
+               if (dc_Lr <= config_GM_Rossby_ramp_min .or. c_mode1.lt.0.1_RKIND) then
                   RossbyRadiusTaper(iEdge) = 0.0_RKIND
-               else
+               else if (dc_Lr >= config_GM_Rossby_ramp_max) then
                   RossbyRadiusTaper(iEdge) = 1.0_RKIND
+               else
+                  ! a linear ramp between the min and max of dc_Lr
+                  RossbyRadiusTaper(iEdge) = (dc_Lr - config_GM_Rossby_ramp_min) / &
+                     (config_GM_Rossby_ramp_max - config_GM_Rossby_ramp_min)
                end if
             end do
             !$omp end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -758,19 +758,7 @@ contains
             deallocate (RossbyRadiusTaper)
          end if
 
-         if (config_Redi_closure == 'equalGM') then
-            ! Set Redi closure to be the same as the GM closure, i.e. if
-            ! config_GM_closure is EdenGreatbatch or Visbeck, you will see those
-            ! same closure fields in RediKappa. The horizontal tapering still
-            ! comes from the config_Redi_horizontal_taper flag, not GM.
-            !$omp parallel
-            !$omp do schedule(runtime)
-            do iEdge=1, nEdges
-               RediKappa(iEdge) = RediHorizontalTaper(iEdge) * gmBolusKappa(iEdge)
-            end do
-            !$omp end do
-            !$omp end parallel
-         else if (config_Redi_closure == 'constant'.and. &
+         if (config_Redi_closure == 'constant'.and. &
                    config_Redi_horizontal_taper == 'RossbyRadius') then
             !$omp parallel
             !$omp do schedule(runtime)

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -940,7 +940,7 @@ contains
 
       integer, intent(out) :: err !< Output: error flag
 
-      real(kind=RKIND) :: sphereRadius
+      real(kind=RKIND) :: sphereRadius, coef
 
       type(block_type), pointer :: block
       type(mpas_pool_type), pointer :: meshPool
@@ -1075,7 +1075,7 @@ contains
             call mpas_dmpar_finalize(domain%dminfo)
          end if
 
-         ! Add horizontal taper
+         ! Initialize horizontal taper
          if (config_GM_horizontal_taper == 'none' .or. &
              config_GM_horizontal_taper == 'RossbyRadius') then
             ! For 'RossbyRadius', the taper is recomputed at every time step.
@@ -1088,6 +1088,8 @@ contains
             !$omp end do
             !$omp end parallel
          else if (config_GM_horizontal_taper == 'ramp') then
+            coef = 1.0_RKIND &
+                    /(config_GM_horizontal_ramp_max - config_GM_horizontal_ramp_min)
             !$omp parallel
             !$omp do schedule(runtime) 
             do iEdge = 1, nEdges
@@ -1096,8 +1098,7 @@ contains
                else if (dcEdge(iEdge) >= config_GM_horizontal_ramp_max) then
                   gmHorizontalTaper(iEdge) = 1.0_RKIND
                else
-                  gmHorizontalTaper(iEdge) = 1.0_RKIND &
-                     /(config_GM_horizontal_ramp_max - config_GM_horizontal_ramp_min) &
+                  gmHorizontalTaper(iEdge) = coef &
                      *(dcEdge(iEdge) - config_GM_horizontal_ramp_min)
                end if
             end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -711,7 +711,6 @@ contains
                ! c_m = 1/pi integral(N dz )
 
                c_mode1 = max(1.0E-5_RKIND, sum_hN/3.141592_RKIND)
-               cGMphaseSpeed(iEdge) = c_mode1
 
                ! See Hallberg (2013) https://doi.org/10.1016/j.ocemod.2013.08.007
                ! just after eqn 4 the defines the deformation
@@ -727,7 +726,7 @@ contains
 
                ! Ramp the parameterization between the given min and max values
                ! of the ratio of the cell width to the Rossby radius
-               if (dc_Lr <= config_GM_Rossby_ramp_min .or. c_mode1.lt.0.1_RKIND) then
+               if (dc_Lr <= config_GM_Rossby_ramp_min) then
                   RossbyRadiusTaper(iEdge) = 0.0_RKIND
                else if (dc_Lr >= config_GM_Rossby_ramp_max) then
                   RossbyRadiusTaper(iEdge) = 1.0_RKIND
@@ -994,7 +993,7 @@ contains
          if (config_GM_minBclModeSpeed_method=='constant') then
             gm_minBclModeSpeed_compute_on = 0.0_RKIND
             gm_minBclModeSpeed_constant = config_GM_constant_bclModeSpeed
-         elseif (config_GM_minBclModeSpeed_method=='computed') then
+         else if (config_GM_minBclModeSpeed_method=='computed') then
             gm_minBclModeSpeed_compute_on = 1.0_RKIND
             gm_minBclModeSpeed_constant = 0.0_RKIND
          else

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -130,7 +130,7 @@ contains
       integer, dimension(:, :), pointer :: cellsOnEdge, edgesOnCell
       integer                          :: i, k, iEdge, cell1, cell2, iCell, N, iCellSelf, maxLocation
       real(kind=RKIND)                 :: h1, h2, areaEdge, BruntVaisalaFreqTopEdge, rtmp
-      real(kind=RKIND)                 :: sumN2, countN2, maxN, ltSum
+      real(kind=RKIND)                 :: sum_hN, countN2, maxN, ltSum
       real(kind=RKIND)                 :: sumRi, RiTopOfEdge, zEdge, zMLD, sfcTaper
       real(kind=RKIND) :: dcEdgeInv, drhoDx, drhoDT, drhoDS, dTdx, dSdx
       real(kind=RKIND) :: slopeTaperUp, slopeTaperDown, sfcTaperUp, sfcTaperDown, invAreaCell
@@ -548,11 +548,11 @@ contains
          ! config_GM_spatially_variable_baroclinic_mode
          if (local_config_GM_lat_variable_c2) then
             !$omp parallel
-            !$omp do schedule(runtime) private(k, cell1, cell2, sumN2, lt1, lt2, ltSum, c_min)
+            !$omp do schedule(runtime) private(k, cell1, cell2, sum_hN, lt1, lt2, ltSum, c_min)
             do iEdge = 1, nEdges
                cell1 = cellsOnEdge(1, iEdge)
                cell2 = cellsOnEdge(2, iEdge)
-               sumN2 = 0.0_RKIND
+               sum_hN = 0.0_RKIND
                lt1 = 0.0_RKIND
                lt2 = 0.0_RKIND
                ltSum = epsGM
@@ -560,7 +560,7 @@ contains
 
                   lt1 = 0.5_RKIND*(layerThickness(k,cell1) + layerThickness(k-1,cell1))
                   lt2 = 0.5_RKIND*(layerThickness(k,cell2) + layerThickness(k-1,cell2))
-                  sumN2 = sumN2 + 0.5_RKIND*(lt1*sqrt(max(BruntVaisalaFreqTop(k,cell1),0.0_RKIND)) + &
+                  sum_hN = sum_hN + 0.5_RKIND*(lt1*sqrt(max(BruntVaisalaFreqTop(k,cell1),0.0_RKIND)) + &
                                 lt2*sqrt(max(BruntVaisalaFreqTop(k,cell2),0.0_RKIND)))
 
                   ltSum = ltSum + 0.5*(lt1+lt2)
@@ -575,11 +575,11 @@ contains
                ! the condition c/N < dz.  The condition is an estimate, but
                ! tries to insure that the streamfunction is well resolved even
                ! for the thickest layers.
-               c_min = gm_minBclModeSpeed_constant + gm_minBclModeSpeed_compute_on*max(0.01_RKIND,sumN2/ltSum*(0.5*(lt1+lt2)))
+               c_min = gm_minBclModeSpeed_constant + gm_minBclModeSpeed_compute_on*max(0.01_RKIND,sum_hN/ltSum*(0.5*(lt1+lt2)))
 
                ! Compute the speed of the first baroclinic mode from the Brunt-Vaisala frequency.
                cGMphaseSpeed(iEdge) = max(c_min,                          &
-                                          sumN2/(config_GM_spatially_variable_baroclinic_mode*3.141592_RKIND))
+                                          sum_hN/(config_GM_spatially_variable_baroclinic_mode*3.141592_RKIND))
 
             end do
             !$omp end do
@@ -600,12 +600,12 @@ contains
          if (local_config_GM_compute_Visbeck) then
            call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
            !$omp parallel
-           !$omp do schedule(runtime) private(k, cell1, cell2, sumN2, ltSum, sumRi, countN2, &
+           !$omp do schedule(runtime) private(k, cell1, cell2, sum_hN, ltSum, sumRi, countN2, &
            !$omp             zEdge, RiTopOfEdge, BruntVaisalaFreqTopEdge, lt1, lt2, c_Visbeck, &
            !$omp             eddyLength, eddyTime)
            do iEdge = 1, nEdges
               k=minLevelEdgeBot(iEdge)
-              sumN2 = 0.0_RKIND
+              sum_hN = 0.0_RKIND
               ltSum = 0.0_RKIND
               sumRi = 0.0_RKIND
               countN2 = 0
@@ -617,7 +617,7 @@ contains
               do while(zEdge > -config_GM_Visbeck_max_depth .and. k < maxLevelEdgeTop(iEdge))
                 lt1 = 0.5_RKIND*(layerThickness(k,cell1) + layerThickness(k-1,cell1))
                 lt2 = 0.5_RKIND*(layerThickness(k,cell2) + layerThickness(k-1,cell2))
-                sumN2 = sumN2 + 0.5_RKIND*(lt1*max(BruntVaisalaFreqTop(k,cell1),0.0_RKIND) + &
+                sum_hN = sum_hN + 0.5_RKIND*(lt1*max(BruntVaisalaFreqTop(k,cell1),0.0_RKIND) + &
                                 lt2*max(BruntVaisalaFreqTop(k,cell2),0.0_RKIND))
                 sumRi = sumRi + 0.5_RKIND*(lt1*max(RiTopOfCell(k,cell1),0.0_RKIND) + &
                                     lt2*max(RiTopOfCell(k,cell2),0.0_RKIND))
@@ -629,7 +629,7 @@ contains
               end do
 
               if (countN2 > 0) then
-                c_Visbeck = sqrt(sumN2*ltsum)
+                c_Visbeck = sqrt(sum_hN*ltsum)
                 sumRi = sumRi / (ltsum + 1.0E-11_RKIND)
 
                 eddyLength = max(dcEdge(iEdge), min(c_Visbeck/(1.0E-15_RKIND + abs(fEdge(iEdge))), &
@@ -690,39 +690,40 @@ contains
             call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
 
             !$omp parallel
-            !$omp do schedule(runtime) private(k, cell1, cell2, sumN2, lt1, lt2, c_mode1, resolution)
+            !$omp do schedule(runtime) private(k, cell1, cell2, sum_hN, lt1, lt2, c_mode1, resolution)
             do iEdge = 1, nEdges
                cell1 = cellsOnEdge(1, iEdge)
                cell2 = cellsOnEdge(2, iEdge)
-               sumN2 = 0.0
+               sum_hN = 0.0
 
                do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)-1
 
                   lt1 = 0.5_RKIND*(layerThickness(k,cell1) + layerThickness(k-1,cell1))
                   lt2 = 0.5_RKIND*(layerThickness(k,cell2) + layerThickness(k-1,cell2))
-                  sumN2 = sumN2 + 0.5_RKIND*(lt1*sqrt(max(BruntVaisalaFreqTop(k,cell1),0.0_RKIND)) + &
+                  sum_hN = sum_hN + 0.5_RKIND*(lt1*sqrt(max(BruntVaisalaFreqTop(k,cell1),0.0_RKIND)) + &
                                   lt2*sqrt(max(BruntVaisalaFreqTop(k,cell2),0.0_RKIND)))
                end do
 
                ! See Hallberg (2013) https://doi.org/10.1016/j.ocemod.2013.08.007
-               ! eqn 4 for the first-mode baroclinic gravity wave speed:
+               ! eqn 4 for the first-mode baroclinic gravity wave speed in m/s
                ! c_g = sqrt( g drho h1 h2 / ( rho0 (h1+h2) )
                ! here c_mode1 is the square of c_g:
-               ! c_mode1 = c_g^2 ~ abs ( h^2 * g/rho0 drho/dz ) = h*N^2
+               ! c_mode1 = c_g ~ sqrt ( h^2 * g/rho0 drho/dz ) ~ h*N
                ! at an edge where N^2 = BruntVaisalaFreq = -g/rho0 * drho/dz
                ! note BruntVaisalaFreqTop is actually N^2, not N.
-               c_mode1 = max(1.0E-5_RKIND, sumN2/3.141592_RKIND)
+               c_mode1 = max(1.0E-5_RKIND, sum_hN/3.141592_RKIND)
                cGMphaseSpeed(iEdge) = c_mode1
 
                ! just after eqn 4 in Hallberg (2013) he defines the deformation
                ! radius as:
                ! L = sqrt( c_g^2/ ( f^2 + 2*beta*c_g) )
-               ! Here resolution = L / dcEdge is the ratio, so resolution>2 is
-               ! considered sufficiently well resolved, i.e. the Rossby Radius 
-               ! is at least two cells wide.
-               resolution = sqrt(c_mode1 / (fEdge(iEdge)**2.0 + betaEdge(iEdge)*c_mode1 + 1.0E-15_RKIND)) &
-                            / dcEdge(iEdge)
-               if (resolution .ge. 2.0 .or. c_mode1 .lt. 0.1_RKIND) then
+               RossbyRadius(iEdge) = sqrt(c_mode1*c_mode1 / &
+                  (fEdge(iEdge)*fEdge(iEdge) + 2.0_RKIND*betaEdge(iEdge)*c_mode1 + 1.0E-15_RKIND))
+
+               ! If the RossbyRadius is larger than two cell widths, then this
+               ! edge is sufficiently well-resolved, and turn off the
+               ! parameterization.
+               if (RossbyRadius(iEdge).ge.2.0*dcEdge(iEdge) .or. c_mode1 .lt. 0.1_RKIND) then
                   RossbyRadiusTaper(iEdge) = 0.0_RKIND
                else
                   RossbyRadiusTaper(iEdge) = 1.0_RKIND

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -704,8 +704,22 @@ contains
                                   lt2*sqrt(max(BruntVaisalaFreqTop(k,cell2),0.0_RKIND)))
                end do
 
+               ! See Hallberg (2013) https://doi.org/10.1016/j.ocemod.2013.08.007
+               ! eqn 4 for the first-mode baroclinic gravity wave speed:
+               ! c_g = sqrt( g drho h1 h2 / ( rho0 (h1+h2) )
+               ! here c_mode1 is the square of c_g:
+               ! c_mode1 = c_g^2 ~ abs ( h^2 * g/rho0 drho/dz ) = h*N^2
+               ! at an edge where N^2 = BruntVaisalaFreq = -g/rho0 * drho/dz
+               ! note BruntVaisalaFreqTop is actually N^2, not N.
                c_mode1 = max(1.0E-5_RKIND, sumN2/3.141592_RKIND)
                cGMphaseSpeed(iEdge) = c_mode1
+
+               ! just after eqn 4 in Hallberg (2013) he defines the deformation
+               ! radius as:
+               ! L = sqrt( c_g^2/ ( f^2 + 2*beta*c_g) )
+               ! Here resolution = L / dcEdge is the ratio, so resolution>2 is
+               ! considered sufficiently well resolved, i.e. the Rossby Radius 
+               ! is at least two cells wide.
                resolution = sqrt(c_mode1 / (fEdge(iEdge)**2.0 + betaEdge(iEdge)*c_mode1 + 1.0E-15_RKIND)) &
                             / dcEdge(iEdge)
                if (resolution .ge. 2.0 .or. c_mode1 .lt. 0.1_RKIND) then
@@ -741,6 +755,10 @@ contains
          end if
 
          if (config_Redi_closure == 'equalGM') then
+            ! Set Redi closure to be the same as the GM closure, i.e. if
+            ! config_GM_closure is EdenGreatbatch or Visbeck, you will see those
+            ! same closure fields in RediKappa. The horizontal tapering still
+            ! comes from the config_Redi_horizontal_taper flag, not GM.
             !$omp parallel
             !$omp do schedule(runtime)
             do iEdge=1, nEdges

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -715,16 +715,6 @@ contains
             !$omp end parallel
          end if
 
-         if(config_Redi_closure == 'equalGM') then
-           !$omp parallel
-           !$omp do schedule(runtime)
-           do iEdge=1,nEdges
-              RediKappa(iEdge) = gmBolusKappa(iEdge)
-           end do
-           !$omp end do
-           !$omp end parallel
-         end if
-
          !!$omp parallel
          !!$omp do schedule(runtime) private(cell1, cell2, k, &
          !!$omp             BruntVaisalaFreqTopEdge, N) &

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -138,6 +138,7 @@ contains
       real(kind=RKIND) :: sigma, Lr, Length, L_rhines, shearEdgeInv
       real (kind=RKIND) :: eddyLength, eddyTime
       real(kind=RKIND), dimension(:), allocatable :: dzTop, dTdzTop, dSdzTop, k33Norm
+      real(kind=RKIND), dimension(:), allocatable :: RossbyRadiusTaper
       real(kind=RKIND) :: c_Visbeck   ! baroclinic wave speed from Visbeck parameterization
       real(kind=RKIND) :: c_mode1, resolution
       ! Dimensions
@@ -683,7 +684,9 @@ contains
          endif
 
          nEdges = nEdgesArray(3)
-         if(config_gm_enable_horizontal_resolution_function) then
+         if (config_GM_horizontal_taper == 'RossbyRadius'.or. &
+             config_Redi_horizontal_taper == 'RossbyRadius') then
+            allocate (RossbyRadiusTaper(nEdges))
             call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
 
             !$omp parallel
@@ -706,10 +709,51 @@ contains
                resolution = sqrt(c_mode1 / (fEdge(iEdge)**2.0 + betaEdge(iEdge)*c_mode1 + 1.0E-15_RKIND)) &
                             / dcEdge(iEdge)
                if (resolution .ge. 2.0 .or. c_mode1 .lt. 0.1_RKIND) then
-                  gmResolutionTaper(iEdge) = 0.0_RKIND
+                  RossbyRadiusTaper(iEdge) = 0.0_RKIND
                else
-                  gmResolutionTaper(iEdge) = 1.0_RKIND
+                  RossbyRadiusTaper(iEdge) = 1.0_RKIND
                end if
+            end do
+            !$omp end do
+            !$omp end parallel
+
+            if (config_GM_horizontal_taper == 'RossbyRadius') then
+               !$omp parallel
+               !$omp do schedule(runtime)
+               do iEdge = 1,nEdges
+                  gmHorizontalTaper(iEdge) = RossbyRadiusTaper(iEdge)
+               end do
+               !$omp end do
+               !$omp end parallel
+            end if
+
+            if (config_Redi_horizontal_taper == 'RossbyRadius') then
+               !$omp parallel
+               !$omp do schedule(runtime)
+               do iEdge = 1,nEdges
+                  RediHorizontalTaper(iEdge) = RossbyRadiusTaper(iEdge)
+               end do
+               !$omp end do
+               !$omp end parallel
+            end if
+
+            deallocate (RossbyRadiusTaper)
+         end if
+
+         if (config_Redi_closure == 'equalGM') then
+            !$omp parallel
+            !$omp do schedule(runtime)
+            do iEdge=1, nEdges
+               RediKappa(iEdge) = RediHorizontalTaper(iEdge) * gmBolusKappa(iEdge)
+            end do
+            !$omp end do
+            !$omp end parallel
+         else if (config_Redi_closure == 'constant'.and. &
+                   config_Redi_horizontal_taper == 'RossbyRadius') then
+            !$omp parallel
+            !$omp do schedule(runtime)
+            do iEdge=1, nEdges
+               RediKappa(iEdge) = RediHorizontalTaper(iEdge) * config_Redi_constant_kappa
             end do
             !$omp end do
             !$omp end parallel
@@ -782,7 +826,7 @@ contains
          !$omp do schedule(runtime) private(k)
          do iEdge = 1, nEdges
             do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-               normalGMBolusVelocity(k, iEdge) = gmResolutionTaper(iEdge) * (gmStreamFuncTopOfEdge(k, iEdge) &
+               normalGMBolusVelocity(k, iEdge) = gmHorizontalTaper(iEdge) * (gmStreamFuncTopOfEdge(k, iEdge) &
                       - gmStreamFuncTopOfEdge(k + 1, iEdge)) /layerThickEdgeMean(k, iEdge)
             end do
          end do
@@ -945,22 +989,16 @@ contains
 
          RediGMinitValue = 1.0_RKIND
          !compute beta
-         if(config_GM_closure == 'Visbeck'.or. &
-            config_GM_closure == 'visbeck'.or. &
-            config_GM_closure == 'EdenGreatbatch'.or. &
-            config_GM_closure == 'edengreatbatch'.or. &
-            config_GM_closure == 'edenGreatbatch'.or. &
-            config_gm_enable_horizontal_resolution_function) then
-            call mpas_pool_get_config(meshPool, 'sphere_radius', sphere_radius)
-            call mpas_pool_get_array(meshPool, 'latEdge', latEdge)
-            !$omp parallel
-            !$omp do schedule(runtime)
-            do iEdge=1,nEdges
-               betaEdge(iEdge) = 2.0_RKIND*omega*cos(latEdge(iEdge)) / sphere_radius
-            end do
-            !$omp end do
-            !$omp end parallel
-         end if
+         call mpas_pool_get_config(meshPool, 'sphere_radius', sphere_radius)
+         call mpas_pool_get_array(meshPool, 'latEdge', latEdge)
+         !$omp parallel
+         !$omp do schedule(runtime)
+         do iEdge=1,nEdges
+            betaEdge(iEdge) = 2.0_RKIND*omega*cos(latEdge(iEdge)) / sphere_radius
+         end do
+         !$omp end do
+         !$omp end parallel
+
          if (config_GM_closure == 'constant') then
             local_config_GM_lat_variable_c2 = .false.
             local_config_GM_kappa_lat_depth_variable = .false.
@@ -1027,36 +1065,36 @@ contains
             call mpas_dmpar_finalize(domain%dminfo)
          end if
 
-         ! Add resolution taper
-         if (config_eddying_resolution_taper == 'none' .or. &
-             config_gm_enable_horizontal_resolution_function) then
+         ! Add horizontal taper
+         if (config_GM_horizontal_taper == 'none' .or. &
+             config_GM_horizontal_taper == 'RossbyRadius') then
+            ! For 'RossbyRadius', the taper is recomputed at every time step.
+            ! but just set to one here
             !$omp parallel
             !$omp do schedule(runtime)
             do iEdge = 1,nEdges
-               gmResolutionTaper(iEdge) = 1.0_RKIND
+               gmHorizontalTaper(iEdge) = 1.0_RKIND
             end do
             !$omp end do
             !$omp end parallel
-            ! Nothing to do, as we just keep the same assignment as above.
-         else if (config_eddying_resolution_taper == 'ramp' .and. &
-                  .not. config_gm_enable_horizontal_resolution_function) then
+         else if (config_GM_horizontal_taper == 'ramp') then
             !$omp parallel
             !$omp do schedule(runtime) 
             do iEdge = 1, nEdges
-               if (dcEdge(iEdge) <= config_eddying_resolution_ramp_min) then
-                  gmResolutionTaper(iEdge) = 0.0_RKIND
-               else if (dcEdge(iEdge) >= config_eddying_resolution_ramp_max) then
-                  gmResolutionTaper(iEdge) = 1.0_RKIND 
+               if (dcEdge(iEdge) <= config_GM_horizontal_ramp_min) then
+                  gmHorizontalTaper(iEdge) = 0.0_RKIND
+               else if (dcEdge(iEdge) >= config_GM_horizontal_ramp_max) then
+                  gmHorizontalTaper(iEdge) = 1.0_RKIND
                else
-                  gmResolutionTaper(iEdge) = 1.0_RKIND &
-                                        /(config_eddying_resolution_ramp_max - config_eddying_resolution_ramp_min) &
-                                        *(dcEdge(iEdge) - config_eddying_resolution_ramp_min)
+                  gmHorizontalTaper(iEdge) = 1.0_RKIND &
+                     /(config_GM_horizontal_ramp_max - config_GM_horizontal_ramp_min) &
+                     *(dcEdge(iEdge) - config_GM_horizontal_ramp_min)
                end if
             end do
             !$omp end do
             !$omp end parallel
          else
-            call mpas_log_write('Invalid choice of config_eddying_resolution_taper.', MPAS_LOG_CRIT)
+            call mpas_log_write('Invalid choice of config_GM_horizontal_taper.', MPAS_LOG_CRIT)
             err = 1
             call mpas_dmpar_finalize(domain%dminfo)
          end if

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -685,7 +685,7 @@ contains
          nEdges = nEdgesArray(3)
          if(config_gm_enable_horizontal_resolution_function) then
             !$omp parallel
-            !$omp do schedule(runtime) private(k, cell1, cell2, sumN2, lt1, lt2)
+            !$omp do schedule(runtime) private(k, cell1, cell2, sumN2, lt1, lt2, c_mode1, resolution)
             do iEdge = 1, nEdges
                cell1 = cellsOnEdge(1, iEdge)
                cell2 = cellsOnEdge(2, iEdge)

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -139,6 +139,7 @@ contains
       real (kind=RKIND) :: eddyLength, eddyTime
       real(kind=RKIND), dimension(:), allocatable :: dzTop, dTdzTop, dSdzTop, k33Norm
       real(kind=RKIND) :: c_Visbeck   ! baroclinic wave speed from Visbeck parameterization
+      real(kind=RKIND) :: c_mode1, resolution
       ! Dimensions
       integer :: nCells, nEdges
       integer, pointer :: nVertLevels
@@ -698,15 +699,15 @@ contains
                                   lt2*sqrt(max(BruntVaisalaFreqTop(k,cell2),0.0_RKIND)))
                end do
 
-!               c_mode1 = max(0.0_RKIND, sumN2/(3.141592_RKIND))
-!               cGMphasespeed(iEdge) = c_mode1
-!               resolution = sqrt(c_mode1 / (fEdge(iEdge)**2.0 + betaEdge(iEdge)*c_mode1 + 1.0E-15_RKIND)) &
-!                            / dcEdge(iEdge)
-!               if (resolution .ge. 2.0 .or. c_mode1 .lt. 0.1_RKIND) then
-!                  gmResolutionTaper(iEdge) = 0.0_RKIND
-!               else
-!                  gmResolutionTaper(iEdge) = 1.0_RKIND
-!               end if
+               c_mode1 = max(0.0_RKIND, sumN2/(3.141592_RKIND))
+               cGMphaseSpeed(iEdge) = c_mode1
+               resolution = sqrt(c_mode1 / (fEdge(iEdge)**2.0 + betaEdge(iEdge)*c_mode1 + 1.0E-15_RKIND)) &
+                            / dcEdge(iEdge)
+               if (resolution .ge. 2.0 .or. c_mode1 .lt. 0.1_RKIND) then
+                  gmResolutionTaper(iEdge) = 0.0_RKIND
+               else
+                  gmResolutionTaper(iEdge) = 1.0_RKIND
+               end if
             end do
             !$omp end do
             !$omp end parallel

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -684,6 +684,8 @@ contains
 
          nEdges = nEdgesArray(3)
          if(config_gm_enable_horizontal_resolution_function) then
+            call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
+
             !$omp parallel
             !$omp do schedule(runtime) private(k, cell1, cell2, sumN2, lt1, lt2, c_mode1, resolution)
             do iEdge = 1, nEdges

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -699,7 +699,7 @@ contains
                                   lt2*sqrt(max(BruntVaisalaFreqTop(k,cell2),0.0_RKIND)))
                end do
 
-               c_mode1 = max(0.0_RKIND, sumN2/(3.141592_RKIND))
+               c_mode1 = max(1.0E-5_RKIND, sumN2/3.141592_RKIND)
                cGMphaseSpeed(iEdge) = c_mode1
                resolution = sqrt(c_mode1 / (fEdge(iEdge)**2.0 + betaEdge(iEdge)*c_mode1 + 1.0E-15_RKIND)) &
                             / dcEdge(iEdge)

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -717,7 +717,8 @@ contains
                ! just after eqn 4 in Hallberg (2013) he defines the deformation
                ! radius as:
                ! L = sqrt( c_g^2/ ( f^2 + 2*beta*c_g) )
-               RossbyRadius(iEdge) = sqrt(c_mode1*c_mode1 / &
+               !   = c_g * sqrt(1/( f^2 + 2*beta*c_g) )  (note c_g is guaranteed non-negative)
+               RossbyRadius(iEdge) = c_mode1*sqrt( 1.0_RKIND / &
                   (fEdge(iEdge)*fEdge(iEdge) + 2.0_RKIND*betaEdge(iEdge)*c_mode1 + 1.0E-15_RKIND))
 
                ! If the RossbyRadius is larger than two cell widths, then this

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -932,7 +932,7 @@ contains
       integer, pointer :: nEdges
       integer, pointer :: nVertLevels
       real(kind=RKIND), pointer :: sphere_radius
-      real(kind=RKIND), dimension(:), pointer   :: latEdge, betaEdge, fEdge, &
+      real(kind=RKIND), dimension(:), pointer   :: latEdge, fEdge, &
             gmResolutionTaper, gmBolusKappa
       integer, dimension(:, :), pointer :: cellsOnEdge
 
@@ -1036,7 +1036,6 @@ contains
             local_config_GM_compute_Visbeck = .true.
             local_config_GM_compute_EdenGreatbatch = .false.
 
-            call mpas_pool_get_array(diagnosticsPool, 'betaEdge', betaEdge)
             call mpas_pool_get_array(meshPool, 'latEdge', latEdge)
             call mpas_pool_get_config(meshPool, 'sphere_radius', sphere_radius)
             !$omp parallel
@@ -1054,7 +1053,6 @@ contains
             local_config_GM_compute_Visbeck = .false.
             local_config_GM_compute_EdenGreatbatch = .true.
 
-            call mpas_pool_get_array(diagnosticsPool, 'betaEdge', betaEdge)
             call mpas_pool_get_array(meshPool, 'latEdge', latEdge)
             call mpas_pool_get_config(meshPool, 'sphere_radius', sphere_radius)
             !$omp parallel

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -1028,7 +1028,6 @@ contains
             !$omp parallel
             !$omp do schedule(runtime)
             do iEdge=1,nEdges
-              betaEdge(iEdge) = 2.0_RKIND*omega*cos(latEdge(iEdge)) / sphere_radius
               gmBolusKappa(iEdge) = config_GM_spatially_variable_max_kappa
             end do
             !$omp end do
@@ -1045,7 +1044,6 @@ contains
             !$omp parallel
             !$omp do schedule(runtime)
             do iEdge=1,nEdges
-              betaEdge(iEdge) = 2.0_RKIND*omega*cos(latEdge(iEdge)) / sphere_radius
               gmBolusKappa(iEdge) = config_GM_spatially_variable_max_kappa
             end do
             !$omp end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -704,27 +704,29 @@ contains
                                   lt2*sqrt(max(BruntVaisalaFreqTop(k,cell2),0.0_RKIND)))
                end do
 
-               ! See Hallberg (2013) https://doi.org/10.1016/j.ocemod.2013.08.007
-               ! eqn 4 for the first-mode baroclinic gravity wave speed in m/s
-               ! c_g = sqrt( g drho h1 h2 / ( rho0 (h1+h2) )
-               ! here c_mode1 is the square of c_g:
-               ! c_mode1 = c_g ~ sqrt ( h^2 * g/rho0 drho/dz ) ~ h*N
-               ! at an edge where N^2 = BruntVaisalaFreq = -g/rho0 * drho/dz
-               ! note BruntVaisalaFreqTop is actually N^2, not N.
+               ! See Chelton (1998)
+               ! https://journals.ametsoc.org/view/journals/phoc/28/3/1520-0485_1998_028_0433_gvotfb_2.0.co_2.xml
+               ! eqn 2.2a, also Appendix A,
+               ! for the first-mode (m=1) baroclinic gravity wave speed in m/s
+               ! c_m = 1/pi integral(N dz )
+
                c_mode1 = max(1.0E-5_RKIND, sum_hN/3.141592_RKIND)
                cGMphaseSpeed(iEdge) = c_mode1
 
-               ! just after eqn 4 in Hallberg (2013) he defines the deformation
+               ! See Hallberg (2013) https://doi.org/10.1016/j.ocemod.2013.08.007
+               ! just after eqn 4 the defines the deformation
                ! radius as:
                ! L = sqrt( c_g^2/ ( f^2 + 2*beta*c_g) )
                !   = c_g * sqrt(1/( f^2 + 2*beta*c_g) )  (note c_g is guaranteed non-negative)
+               ! This comes from a combination of Chelton (1998) eqns 2.3a and
+               ! 2.3b, with a smooth transition in between.
                RossbyRadius(iEdge) = c_mode1*sqrt( 1.0_RKIND / &
                   (fEdge(iEdge)*fEdge(iEdge) + 2.0_RKIND*betaEdge(iEdge)*c_mode1 + 1.0E-15_RKIND))
 
                ! If the RossbyRadius is larger than two cell widths, then this
                ! edge is sufficiently well-resolved, and turn off the
                ! parameterization.
-               if (RossbyRadius(iEdge).ge.2.0*dcEdge(iEdge) .or. c_mode1 .lt. 0.1_RKIND) then
+               if (RossbyRadius(iEdge).ge.2.0_RKIND*dcEdge(iEdge) .or. c_mode1.lt.0.1_RKIND) then
                   RossbyRadiusTaper(iEdge) = 0.0_RKIND
                else
                   RossbyRadiusTaper(iEdge) = 1.0_RKIND

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -789,33 +789,6 @@ contains
          !$omp end do
          !$omp end parallel
 
-         nCells = nCellsArray(1)
-
-         ! Interpolate gmStreamFuncTopOfEdge to cell centers for visualization
-         !$omp parallel
-         !$omp do schedule(runtime) private(i, iEdge, areaEdge, k, rtmp)
-         do iCell = 1, nCells
-            gmStreamFuncTopOfCell(:, iCell) = 0.0_RKIND
-            do i = 1, nEdgesOnCell(iCell)
-               iEdge = edgesOnCell(i, iCell)
-
-               areaEdge = 0.25_RKIND*dcEdge(iEdge)*dvEdge(iEdge)
-
-               do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-                  rtmp = 0.5_RKIND*(gmStreamFuncTopOfEdge(k, iEdge) + gmStreamFuncTopOfEdge(k + 1, iEdge))*areaEdge
-                  gmStreamFuncTopOfCell(k, iCell) = gmStreamFuncTopOfCell(k, iCell) + gmResolutionTaper(iEdge) * rtmp
-               end do
-            end do
-         end do
-         !$omp end do
-
-         !$omp do schedule(runtime)
-         do iCell = 1, nCells
-            gmStreamFuncTopOfCell(:, iCell) = gmStreamFuncTopOfCell(:, iCell)/areaCell(iCell)
-         end do
-         !$omp end do
-         !$omp end parallel
-
          deallocate (rightHandSide)
          deallocate (tridiagA)
          deallocate (tridiagB)

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -682,6 +682,46 @@ contains
          endif
 
          nEdges = nEdgesArray(3)
+         if(config_gm_enable_horizontal_resolution_function) then
+            !$omp parallel
+            !$omp do schedule(runtime) private(k, cell1, cell2, sumN2, lt1, lt2)
+            do iEdge = 1, nEdges
+               cell1 = cellsOnEdge(1, iEdge)
+               cell2 = cellsOnEdge(2, iEdge)
+               sumN2 = 0.0
+
+               do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)-1
+
+                  lt1 = 0.5_RKIND*(layerThickness(k,cell1) + layerThickness(k-1,cell1))
+                  lt2 = 0.5_RKIND*(layerThickness(k,cell2) + layerThickness(k-1,cell2))
+                  sumN2 = sumN2 + 0.5_RKIND*(lt1*sqrt(max(BruntVaisalaFreqTop(k,cell1),0.0_RKIND)) + &
+                                  lt2*sqrt(max(BruntVaisalaFreqTop(k,cell2),0.0_RKIND)))
+               end do
+
+!               c_mode1 = max(0.0_RKIND, sumN2/(3.141592_RKIND))
+!               cGMphasespeed(iEdge) = c_mode1
+!               resolution = sqrt(c_mode1 / (fEdge(iEdge)**2.0 + betaEdge(iEdge)*c_mode1 + 1.0E-15_RKIND)) &
+!                            / dcEdge(iEdge)
+!               if (resolution .ge. 2.0 .or. c_mode1 .lt. 0.1_RKIND) then
+!                  gmResolutionTaper(iEdge) = 0.0_RKIND
+!               else
+!                  gmResolutionTaper(iEdge) = 1.0_RKIND
+!               end if
+            end do
+            !$omp end do
+            !$omp end parallel
+         end if
+
+         if(config_Redi_closure == 'equalGM') then
+           !$omp parallel
+           !$omp do schedule(runtime)
+           do iEdge=1,nEdges
+              RediKappa(iEdge) = gmBolusKappa(iEdge)
+           end do
+           !$omp end do
+           !$omp end parallel
+         end if
+
          !!$omp parallel
          !!$omp do schedule(runtime) private(cell1, cell2, k, &
          !!$omp             BruntVaisalaFreqTopEdge, N) &
@@ -943,6 +983,23 @@ contains
          end if
 
          RediGMinitValue = 1.0_RKIND
+         !compute beta
+         if(config_GM_closure == 'Visbeck'.or. &
+            config_GM_closure == 'visbeck'.or. &
+            config_GM_closure == 'EdenGreatbatch'.or. &
+            config_GM_closure == 'edengreatbatch'.or. &
+            config_GM_closure == 'edenGreatbatch'.or. &
+            config_gm_enable_horizontal_resolution_function) then
+            call mpas_pool_get_config(meshPool, 'sphere_radius', sphere_radius)
+            call mpas_pool_get_array(meshPool, 'latEdge', latEdge)
+            !$omp parallel
+            !$omp do schedule(runtime)
+            do iEdge=1,nEdges
+               betaEdge(iEdge) = 2.0_RKIND*omega*cos(latEdge(iEdge)) / sphere_radius
+            end do
+            !$omp end do
+            !$omp end parallel
+         end if
          if (config_GM_closure == 'constant') then
             local_config_GM_lat_variable_c2 = .false.
             local_config_GM_kappa_lat_depth_variable = .false.
@@ -1014,7 +1071,8 @@ contains
          end if
 
          ! Add resolution taper
-         if (config_eddying_resolution_taper == 'none') then
+         if (config_eddying_resolution_taper == 'none' .or. &
+             config_gm_enable_horizontal_resolution_function) then
             !$omp parallel
             !$omp do schedule(runtime)
             do iEdge = 1,nEdges
@@ -1023,7 +1081,8 @@ contains
             !$omp end do
             !$omp end parallel
             ! Nothing to do, as we just keep the same assignment as above.
-         else if (config_eddying_resolution_taper == 'ramp') then
+         else if (config_eddying_resolution_taper == 'ramp' .and. &
+                  .not. config_gm_enable_horizontal_resolution_function) then
             !$omp parallel
             !$omp do schedule(runtime) 
             do iEdge = 1, nEdges

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -925,15 +925,13 @@ contains
 
       type(block_type), pointer :: block
       type(mpas_pool_type), pointer :: meshPool
-      type(mpas_pool_type), pointer :: diagnosticsPool
       real(kind=RKIND), dimension(:), pointer :: dcEdge 
 
       integer :: iEdge
       integer, pointer :: nEdges
       integer, pointer :: nVertLevels
       real(kind=RKIND), pointer :: sphere_radius
-      real(kind=RKIND), dimension(:), pointer   :: latEdge, fEdge, &
-            gmResolutionTaper, gmBolusKappa
+      real(kind=RKIND), dimension(:), pointer   :: latEdge, fEdge
       integer, dimension(:, :), pointer :: cellsOnEdge
 
       err = 0
@@ -943,14 +941,11 @@ contains
       block => domain%blocklist
       do while (associated(block))
          call mpas_pool_get_subpool(block%structs, 'mesh', meshPool)
-         call mpas_pool_get_subpool(block%structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
          call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
          call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-         call mpas_pool_get_array(diagnosticsPool, 'gmBolusKappa', gmBolusKappa)
          call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
          call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
-         call mpas_pool_get_array(diagnosticsPool, 'gmResolutionTaper', gmResolutionTaper)
          if (config_Redi_use_slope_taper) then
             slopeTaperFactor = 1.0_RKIND
          else

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -506,6 +506,7 @@ contains
       real(kind=RKIND), dimension(:), pointer :: RediKappa, RediKappaData
       real(kind=RKIND), dimension(:), pointer :: RediHorizontalTaper
       real(kind=RKIND), dimension(:), pointer :: dcEdge
+      real(kind=RKIND) :: coef
       integer, dimension(:,:), pointer :: cellsOnEdge
 
       integer :: k, iEdge
@@ -533,7 +534,7 @@ contains
          call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
          call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
 
-         ! Resolution taper
+         ! Initialize horizonal taper
          if (config_Redi_horizontal_taper == 'none' .or. &
              config_Redi_horizontal_taper == 'RossbyRadius') then
             ! For 'RossbyRadius', the taper is recomputed at every time step in
@@ -546,6 +547,8 @@ contains
             !$omp end do
             !$omp end parallel
          else if (config_Redi_horizontal_taper == 'ramp') then
+            coef = 1.0_RKIND &
+                    /(config_Redi_horizontal_ramp_max - config_Redi_horizontal_ramp_min)
             !$omp parallel
             !$omp do schedule(runtime) 
             do iEdge=1,nEdges
@@ -554,9 +557,8 @@ contains
                else if (dcEdge(iEdge) >= config_Redi_horizontal_ramp_max) then
                   RediHorizontalTaper(iEdge) = 1.0_RKIND
                else
-                  RediHorizontalTaper(iEdge) = RediHorizontalTaper(iEdge) &
-                     *(dcEdge(iEdge) - config_Redi_horizontal_ramp_min) &
-                     /(config_Redi_horizontal_ramp_max - config_Redi_horizontal_ramp_min)
+                  RediHorizontalTaper(iEdge) = coef &
+                      *(dcEdge(iEdge) - config_Redi_horizontal_ramp_min)
                end if
             end do
             !$omp end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -534,7 +534,27 @@ contains
          call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
          call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
 
-         ! Initialize horizonal taper
+
+         ! initialize Redi kappa array
+         if (config_Redi_closure == 'constant') then
+            !$omp parallel
+            !$omp do schedule(runtime)
+            do iEdge = 1, nEdges
+               RediKappa(iEdge) = config_Redi_constant_kappa
+            end do
+            !$omp end do
+            !$omp end parallel
+         else if (config_Redi_closure == 'data') then
+            ! read RediKappa in from input
+            call mpas_log_write("config_Redi_closure = 'data'. "// &
+                                "Make sure that the variable RediKappa is read in from an input file.")
+         else
+            call mpas_log_write('Invalid choice of config_Redi_closure.', MPAS_LOG_CRIT)
+            err = 1
+            call mpas_dmpar_finalize(domain%dminfo)
+         end if
+
+         ! Initialize horizontal taper
          if (config_Redi_horizontal_taper == 'none' .or. &
              config_Redi_horizontal_taper == 'RossbyRadius') then
             ! For 'RossbyRadius', the taper is recomputed at every time step in
@@ -553,44 +573,23 @@ contains
             !$omp do schedule(runtime) 
             do iEdge=1,nEdges
                if (dcEdge(iEdge) <= config_Redi_horizontal_ramp_min) then
+                  RediKappa(iEdge) = 0.0_RKIND
                   RediHorizontalTaper(iEdge) = 0.0_RKIND
                else if (dcEdge(iEdge) >= config_Redi_horizontal_ramp_max) then
+                  ! nothing to do, i.e. RediKappa(iCell) = RediKappa(iCell)
                   RediHorizontalTaper(iEdge) = 1.0_RKIND
                else
+                  RediKappa(iEdge) = RediKappa(iEdge) &
+                                     *(dcEdge(iEdge) - config_Redi_horizontal_ramp_min) &
+                                     /(config_Redi_horizontal_ramp_max - config_Redi_horizontal_ramp_min)
                   RediHorizontalTaper(iEdge) = coef &
                       *(dcEdge(iEdge) - config_Redi_horizontal_ramp_min)
                end if
-            end do
+            end do ! iEdge
             !$omp end do
             !$omp end parallel
          else
             call mpas_log_write('Invalid choice of config_Redi_horizontal_taper.', MPAS_LOG_CRIT)
-            err = 1
-            call mpas_dmpar_finalize(domain%dminfo)
-         end if
-
-         ! initialize Redi kappa array
-         if (config_Redi_closure == 'constant') then
-            !$omp parallel
-            !$omp do schedule(runtime)
-            do iEdge = 1, nEdges
-               RediKappa(iEdge) = RediHorizontalTaper(iEdge) * config_Redi_constant_kappa
-            end do
-            !$omp end do
-            !$omp end parallel
-         else if (config_Redi_closure == 'data') then
-            ! read RediKappa in from input
-            call mpas_log_write("config_Redi_closure = 'data'. "// &
-                                "Make sure that the variable RediKappa is read in from an input file.")
-            !$omp parallel
-            !$omp do schedule(runtime)
-            do iEdge = 1, nEdges
-               RediKappa(iEdge) = RediHorizontalTaper(iEdge) * RediKappa(iEdge)
-            end do
-            !$omp end do
-            !$omp end parallel
-         else
-            call mpas_log_write('Invalid choice of config_Redi_closure.', MPAS_LOG_CRIT)
             err = 1
             call mpas_dmpar_finalize(domain%dminfo)
          end if

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -570,10 +570,7 @@ contains
          end if
 
          ! initialize Redi kappa array
-         if (config_Redi_closure == 'constant'.or. &
-             config_Redi_closure == 'equalGM') then
-            ! For 'equalGM' RediKappa is updated every step. Just
-            ! initialize here.
+         if (config_Redi_closure == 'constant') then
             !$omp parallel
             !$omp do schedule(runtime)
             do iEdge = 1, nEdges

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -178,6 +178,12 @@ contains
       allocate (redi_term2_edge(nTracers, nVertLevels, nEdges))
       allocate (redi_term3_topOfCell(nTracers, nVertLevels + 1, nCells))
 
+      ! RediKappa changes every time step if either:
+      !   config_Redi_horizontal_taper == 'RossbyRadius'  
+      !   config_Redi_closure == 'equalGM'
+      ! in that case, RediKappa is updated every time step in mpas_ocn_gm.F
+      ! For static RediKappa, it is set on init and remains unchanged.
+
       nCells = nCellsArray(2)
       !$omp parallel
       !$omp do schedule(runtime) private(i, iEdge)
@@ -498,6 +504,7 @@ contains
       type(mpas_pool_type), pointer :: forcingPool
 
       real(kind=RKIND), dimension(:), pointer :: RediKappa, RediKappaData
+      real(kind=RKIND), dimension(:), pointer :: RediHorizontalTaper
       real(kind=RKIND), dimension(:), pointer :: dcEdge
       integer, dimension(:,:), pointer :: cellsOnEdge
 
@@ -521,49 +528,70 @@ contains
          call mpas_pool_get_subpool(block%structs, 'forcing', forcingPool)
          call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
          call mpas_pool_get_array(diagnosticsPool, 'RediKappa', RediKappa)
+         call mpas_pool_get_array(diagnosticsPool, 'RediHorizontalTaper', RediHorizontalTaper)
          call mpas_pool_get_array(forcingPool, 'RediKappaData', RediKappaData)
          call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
          call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-         ! initialize Redi kappa array
-         if (config_Redi_closure == 'constant') then
+
+         ! Resolution taper
+         if (config_Redi_horizontal_taper == 'none' .or. &
+             config_Redi_horizontal_taper == 'RossbyRadius') then
+            ! For 'RossbyRadius', the taper is recomputed at every time step in
+            ! the ocn_GM_compute_Bolus_velocity subroutine
             !$omp parallel
             !$omp do schedule(runtime)
-            do iEdge = 1, nEdges
-               RediKappa(iEdge) = config_Redi_constant_kappa
+            do iEdge = 1,nEdges
+               RediHorizontalTaper(iEdge) = 1.0_RKIND
             end do
             !$omp end do
             !$omp end parallel
-          else if (config_Redi_closure == 'data') then
-            ! read RediKappa in from input
-            call mpas_log_write("config_Redi_closure = 'data'. "// &
-                                "Make sure that the variable RediKappa is read in from an input file.")
+         else if (config_Redi_horizontal_taper == 'ramp') then
+            !$omp parallel
+            !$omp do schedule(runtime) 
+            do iEdge=1,nEdges
+               if (dcEdge(iEdge) <= config_Redi_horizontal_ramp_min) then
+                  RediHorizontalTaper(iEdge) = 0.0_RKIND
+               else if (dcEdge(iEdge) >= config_Redi_horizontal_ramp_max) then
+                  RediHorizontalTaper(iEdge) = 1.0_RKIND
+               else
+                  RediHorizontalTaper(iEdge) = RediHorizontalTaper(iEdge) &
+                     *(dcEdge(iEdge) - config_Redi_horizontal_ramp_min) &
+                     /(config_Redi_horizontal_ramp_max - config_Redi_horizontal_ramp_min)
+               end if
+            end do
+            !$omp end do
+            !$omp end parallel
          else
-            call mpas_log_write('Invalid choice of config_Redi_closure.', MPAS_LOG_CRIT)
+            call mpas_log_write('Invalid choice of config_Redi_horizontal_taper.', MPAS_LOG_CRIT)
             err = 1
             call mpas_dmpar_finalize(domain%dminfo)
          end if
 
-         ! Add resolution taper
-         if (config_eddying_resolution_taper == 'none') then
-            ! Nothing to do, as we just keep the same assignment as above.
-         else if (config_eddying_resolution_taper == 'ramp') then
+         ! initialize Redi kappa array
+         if (config_Redi_closure == 'constant'.or. &
+             config_Redi_closure == 'equalGM') then
+            ! For 'equalGM' RediKappa is updated every step. Just
+            ! initialize here.
             !$omp parallel
-            !$omp do schedule(runtime) 
-            do iEdge=1,nEdges
-               if (dcEdge(iEdge) <= config_eddying_resolution_ramp_min) then
-                  RediKappa(iEdge) = 0.0_RKIND
-               else if (dcEdge(iEdge) >= config_eddying_resolution_ramp_max) then
-                  ! nothing to do, i.e. RediKappa(iCell) = RediKappa(iCell)
-               else
-                  RediKappa(iEdge) = RediKappa(iEdge) &
-                                     *(dcEdge(iEdge) - config_eddying_resolution_ramp_min) &
-                                     /(config_eddying_resolution_ramp_max - config_eddying_resolution_ramp_min)
-               end if
-            end do ! iCell
+            !$omp do schedule(runtime)
+            do iEdge = 1, nEdges
+               RediKappa(iEdge) = RediHorizontalTaper(iEdge) * config_Redi_constant_kappa
+            end do
+            !$omp end do
+            !$omp end parallel
+         else if (config_Redi_closure == 'data') then
+            ! read RediKappa in from input
+            call mpas_log_write("config_Redi_closure = 'data'. "// &
+                                "Make sure that the variable RediKappa is read in from an input file.")
+            !$omp parallel
+            !$omp do schedule(runtime)
+            do iEdge = 1, nEdges
+               RediKappa(iEdge) = RediHorizontalTaper(iEdge) * RediKappa(iEdge)
+            end do
             !$omp end do
             !$omp end parallel
          else
-            call mpas_log_write('Invalid choice of config_eddying_resolution_taper.', MPAS_LOG_CRIT)
+            call mpas_log_write('Invalid choice of config_Redi_closure.', MPAS_LOG_CRIT)
             err = 1
             call mpas_dmpar_finalize(domain%dminfo)
          end if


### PR DESCRIPTION
This PR adds a new 'RossbyRadius' option to the horizontal tapering of GM and Redi, which is based on Hallberg (2013) - https://doi.org/10.1016/j.ocemod.2013.08.007, which turns the parameterization on if the Rossby Radius is resolved by at least two cells. These flags are:
```
config_Redi_horizontal_taper = 'ramp' (default), 'none', 'RossbyRadius' (new) 
config_GM_horizontal_taper = 'ramp' (default), 'none', 'RossbyRadius' (new) 
```
This PR replaces the variable `gmResolutionTaper`, which was used for both GM and Redi, to the separate variables `RediHorizontalTaper` and `gmHorizontalTaper` so that Redi and GM tapering can be chosen separately, and it is clear in the code. Logic was added to the GM and Redi schemes so that the there is a base value in the arrays for Redi Kappa and GM Kappa. The base value is then multiplied by the taper array, which has a value between 0 and 1. Arrays that are static in time are computed on init. Under the following conditions, the arrays are recomputed at every time step:
```
config_Redi_horizontal_taper = 'RossbyRadius' (recompute RediHorizontalTaper and RediKappa)
config_GM_horizontal_taper =  'RossbyRadius' (recompute gmHorizontalTaper)
```

[NML] adds MPAS-Ocean namelist options
[BFB]