### PR TITLE
Limit EAM tri-grid pelayout to Anvil

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -1460,8 +1460,8 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%ne30np4.*_l%r05_oi%EC.+">
-    <mach name="sandiatoss3|cori-knl|cori-haswell|theta|anvil|bebop">
+  <grid name="a%ne30np4.pg2_l%r05_oi%EC30to60E2r2_r%null_g%null_w%null_z%null_m%EC30to60E2r2">
+    <mach name="anvil|bebop">
       <pes compset="any" pesize="any">
         <comment>pelayout for tri-grid tests with EAM</comment>
         <ntasks>


### PR DESCRIPTION
Limit EAM tri-grid pelayout to Anvil and Bebop and specify full grid name for
- SMS_Ln5.ne30pg2_r05_EC30to60E2r2.BGCEXP_LNDATM_CNPRDCTC_1850
- SMS_Ln5.ne30pg2_r05_EC30to60E2r2.BGCEXP_LNDATM_CNPRDCTC_20TR

[BFB]