### PR TITLE
Specify EAM in compset to avoid PE layout matching issue on cori

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -1462,7 +1462,7 @@
   </grid>
   <grid name="a%ne30np4.*_l%r05_oi%EC.+">
     <mach name="sandiatoss3|cori-knl|cori-haswell|theta|anvil|bebop">
-      <pes compset="any" pesize="any">
+      <pes compset="EAM." pesize="any">
         <comment>pelayout for tri-grid tests with EAM</comment>
         <ntasks>
           <ntasks_atm>-8</ntasks_atm>

--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -1460,8 +1460,8 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%ne30np4.*_l%r05_oi%EC.+">
-    <mach name="sandiatoss3|cori-knl|cori-haswell|theta|anvil|bebop">
+  <grid name="a%ne30np4.pg2_l%r05_oi%EC30to60E2r2_r%null_g%null_w%null_z%null_m%EC30to60E2r2">
+    <mach name="anvil|bebop">
       <pes compset="EAM." pesize="any">
         <comment>pelayout for tri-grid tests with EAM</comment>
         <ntasks>


### PR DESCRIPTION
Fixes a bug where a new default trigrid layout caused an error on cori-knl due to "more than one PE layout matches given PE specs" by specifying that EAM is part of the corresponding compset.

Fixes #4870
[BFB]