### PR TITLE
Update CIME submodule

### DIFF
--- a/.circleci/checkout.sh
+++ b/.circleci/checkout.sh
@@ -2,4 +2,5 @@
 
 # Replace all ssh URLs to submodules with HTTP URLs
 sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
-git submodule update --init
+sed -i 's/git@github.com:/https:\/\/github.com\//' cime/.gitmodules
+git submodule update --init --recursive

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -79,7 +79,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/..)
 
 # Set global targets
 add_custom_target(genf90
-  DEPENDS ${CIMEROOT}/src/externals/genf90/genf90.pl)
+  DEPENDS ${CIMEROOT}/CIME/non_py/externals/genf90/genf90.pl)
 
 # Build E3SM components
 set(IDX 0)

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # Common CMakeLists.txt: a framework for building all CIME components and more
 #
-# This is a port of cime/scripts/Tools/Makefile. As more components are ported to
+# This is a port of cime/CIME/Tools/Makefile. As more components are ported to
 # CMake, the directory level of this file will rise to the top-level directory.
 #
 # We will prefer space-separated strings over lists

--- a/components/cmake/build_model.cmake
+++ b/components/cmake/build_model.cmake
@@ -179,7 +179,7 @@ function(build_model COMP_CLASS COMP_NAME)
     get_filename_component(BASENAME ${SRC_FILE} NAME)
     add_custom_command (
       OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${BASENAME}
-      COMMAND ${CIMEROOT}/src/externals/genf90/genf90.pl
+      COMMAND ${CIMEROOT}/CIME/non_py/externals/genf90/genf90.pl
       ${PROJECT_SOURCE_DIR}/${SRC_FILE}.in > ${CMAKE_CURRENT_BINARY_DIR}/${BASENAME}
       DEPENDS ${PROJECT_SOURCE_DIR}/${SRC_FILE}.in genf90)
     list(REMOVE_ITEM SOURCES ${SRC_FILE})

--- a/components/elm/bld/configure
+++ b/components/elm/bld/configure
@@ -177,7 +177,7 @@ my %cfg = ();           # build configuration
 # Look for them in the directory that contains the configure script.
 
 my $cesmroot   = abs_path( "$cfgdir/../../../");
-my $casecfgdir = "$cesmroot/cime/scripts/Tools";
+my $casecfgdir = "$cesmroot/cime/CIME/Tools";
 my $perl5lib   = "$cesmroot/cime/utils/perl5lib/";
 
 # The Build::Config module provides utilities to store and manipulate the configuration.

--- a/components/homme/CMakeLists.txt
+++ b/components/homme/CMakeLists.txt
@@ -359,7 +359,7 @@ message("-- NetCDF_C_PATH = ${NetCDF_C_PATH}")
 message("-- PnetCDF_Fortran_PATH = ${PnetCDF_Fortran_PATH}")
 message("-- PnetCDF_C_PATH = ${PnetCDF_C_PATH}")
 # pio needs cime/externals/genf90/genf90.pl
-SET(GENF90_PATH ${CMAKE_CURRENT_SOURCE_DIR}/utils/cime/src/externals/genf90)
+SET(GENF90_PATH ${CMAKE_CURRENT_SOURCE_DIR}/utils/cime/CIME/non_py/externals/genf90)
 if (HOMME_USE_SCORPIO)
   SET(PIO_ENABLE_TOOLS OFF CACHE BOOL "Disabling Scorpio tool build")
   ADD_SUBDIRECTORY(utils/externals/scorpio)

--- a/components/homme/CMakeLists.txt
+++ b/components/homme/CMakeLists.txt
@@ -328,7 +328,7 @@ IF (${ENABLE_NANOTIMERS})
     ADD_DEFINITIONS(-DBIT64)
   ENDIF ()
 ENDIF ()
-ADD_SUBDIRECTORY(utils/cime/src/share/timing)
+ADD_SUBDIRECTORY(utils/cime/CIME/non_py/src/timing)
 
 
 # CMAKE_CURRENT_SOURCE_DIR == homme

--- a/components/homme/src/preqx/CMakeLists.txt
+++ b/components/homme/src/preqx/CMakeLists.txt
@@ -13,7 +13,7 @@ SET(SRC_SHARE_DIR     ${HOMME_SOURCE_DIR}/src/share)
 SET(TRILINOS_ZOLTAN_DIR ${HOMME_SOURCE_DIR}/src/zoltan)
 SET(TEST_SRC_DIR      ${HOMME_SOURCE_DIR}/src/test_src)
 
-SET(UTILS_TIMING_DIR  ${HOMME_BINARY_DIR}/utils/cime/src/share/timing)
+SET(UTILS_TIMING_DIR  ${HOMME_BINARY_DIR}/utils/cime/CIME/non_py/src/timing)
 
 # Make INCLUDE_DIRS global so the tests can access it
 SET (EXEC_INCLUDE_DIRS ${PIO_INCLUDE_DIRS} ${UTILS_TIMING_DIR})

--- a/components/homme/src/preqx_acc/CMakeLists.txt
+++ b/components/homme/src/preqx_acc/CMakeLists.txt
@@ -14,7 +14,7 @@ SET(UTILS_SHARE_DIR   ${HOMME_SOURCE_DIR}/utils/csm_share)
 SET(SRC_DIR           ${HOMME_SOURCE_DIR}/src)
 SET(SRC_SHARE_DIR     ${HOMME_SOURCE_DIR}/src/share)
 SET(TEST_SRC_DIR      ${HOMME_SOURCE_DIR}/src/test_src)
-SET(UTILS_TIMING_DIR  ${HOMME_BINARY_DIR}/utils/cime/src/share/timing)
+SET(UTILS_TIMING_DIR  ${HOMME_BINARY_DIR}/utils/cime/CIME/non_py/src/timing)
 
 # Make INCLUDE_DIRS global so the tests can access it
 SET (EXEC_INCLUDE_DIRS ${PIO_INCLUDE_DIRS}

--- a/components/homme/src/preqx_kokkos/CMakeLists.txt
+++ b/components/homme/src/preqx_kokkos/CMakeLists.txt
@@ -15,8 +15,8 @@ MACRO(PREQX_KOKKOS_SETUP)
   SET(TRILINOS_ZOLTAN_DIR   ${HOMME_SOURCE_DIR}/src/zoltan)
   SET(TEST_SRC_DIR          ${HOMME_SOURCE_DIR}/src/test_src)
 
-  SET(UTILS_TIMING_SRC_DIR  ${HOMME_SOURCE_DIR}/utils/cime/src/share/timing)
-  SET(UTILS_TIMING_DIR      ${HOMME_BINARY_DIR}/utils/cime/src/share/timing)
+  SET(UTILS_TIMING_SRC_DIR  ${HOMME_SOURCE_DIR}/utils/cime/CIME/non_py/src/timing)
+  SET(UTILS_TIMING_DIR      ${HOMME_BINARY_DIR}/utils/cime/CIME/non_py/src/timing)
 
   # Make INCLUDE_DIRS global so the tests can access it
   SET (EXEC_LIB_INCLUDE_DIRS

--- a/components/homme/src/share/compose/CMakeLists.txt
+++ b/components/homme/src/share/compose/CMakeLists.txt
@@ -1,6 +1,6 @@
 include_directories (
   ${CMAKE_CURRENT_BINARY_DIR}
-  ${HOMME_SOURCE_DIR}/utils/cime/src/share/timing)
+  ${HOMME_SOURCE_DIR}/utils/cime/CIME/non_py/src/timing)
 if (ENABLE_HORIZ_OPENMP)
   add_definitions(-DHORIZ_OPENMP)
 endif ()

--- a/components/homme/src/sweqx/CMakeLists.txt
+++ b/components/homme/src/sweqx/CMakeLists.txt
@@ -8,7 +8,7 @@ SET(TARGET_DIR        ${HOMME_SOURCE_DIR}/src/sweqx)
 SET(SRC_BASE          ${HOMME_SOURCE_DIR}/src)
 SET(SRC_SHARE         ${HOMME_SOURCE_DIR}/src/share)
 SET(SRC_UTILS         ${HOMME_SOURCE_DIR}/utils/csm_share)
-SET(UTILS_TIMING_DIR  ${HOMME_BINARY_DIR}/utils/cime/src/share/timing)
+SET(UTILS_TIMING_DIR  ${HOMME_BINARY_DIR}/utils/cime/CIME/non_py/src/timing)
 
 # Find F90 files in target directory
 FILE(GLOB TARGET_F90  ${TARGET_DIR}/*.F90)

--- a/components/homme/src/theta-l/CMakeLists.txt
+++ b/components/homme/src/theta-l/CMakeLists.txt
@@ -9,7 +9,7 @@ SET(UTILS_SHARE_DIR   ${HOMME_SOURCE_DIR}/utils/csm_share)
 SET(SRC_DIR           ${HOMME_SOURCE_DIR}/src)
 SET(SRC_SHARE_DIR     ${HOMME_SOURCE_DIR}/src/share)
 SET(TEST_SRC_DIR      ${HOMME_SOURCE_DIR}/src/test_src)
-SET(UTILS_TIMING_DIR  ${HOMME_BINARY_DIR}/utils/cime/src/share/timing)
+SET(UTILS_TIMING_DIR  ${HOMME_BINARY_DIR}/utils/cime/CIME/non_py/src/timing)
 SET(ARKODE_DIR        ${HOMME_SOURCE_DIR}/src/arkode)
 
 # Make INCLUDE_DIRS global so the tests can access it

--- a/components/homme/src/theta-l_kokkos/CMakeLists.txt
+++ b/components/homme/src/theta-l_kokkos/CMakeLists.txt
@@ -12,8 +12,8 @@ MACRO(THETAL_KOKKOS_SETUP)
   SET(TEST_SRC_DIR      ${HOMME_SOURCE_DIR}/src/test_src)
   SET(ARKODE_DIR        ${HOMME_SOURCE_DIR}/src/arkode)
 
-  SET(UTILS_TIMING_SRC_DIR  ${CMAKE_SOURCE_DIR}/utils/cime/src/share/timing)
-  SET(UTILS_TIMING_DIR      ${CMAKE_BINARY_DIR}/utils/cime/src/share/timing)
+  SET(UTILS_TIMING_SRC_DIR  ${CMAKE_SOURCE_DIR}/utils/cime/CIME/non_py/src/timing)
+  SET(UTILS_TIMING_DIR      ${CMAKE_BINARY_DIR}/utils/cime/CIME/non_py/src/timing)
 
   # Make INCLUDE_DIRS global so the tests can access it
   SET (EXEC_LIB_INCLUDE_DIRS

--- a/components/homme/src/tool/CMakeLists.txt
+++ b/components/homme/src/tool/CMakeLists.txt
@@ -7,7 +7,7 @@ SET(UTILS_SHARE_DIR   ${HOMME_SOURCE_DIR}/utils/csm_share)
 SET(SRC_DIR           ${HOMME_SOURCE_DIR}/src)
 SET(SRC_SHARE_DIR     ${HOMME_SOURCE_DIR}/src/share)
 SET(TEST_SRC_DIR      ${HOMME_SOURCE_DIR}/src/test_src)
-SET(UTILS_TIMING_DIR  ${HOMME_BINARY_DIR}/utils/cime/src/share/timing)
+SET(UTILS_TIMING_DIR  ${HOMME_BINARY_DIR}/utils/cime/CIME/non_py/src/timing)
 # Use theta-l to define the dycore-specific data structures.
 SET(DYCORE_DIR        ${HOMME_SOURCE_DIR}/src/theta-l)
 SET(DYCORE_SHARE_DIR  ${HOMME_SOURCE_DIR}/src/theta-l/share)

--- a/components/homme/test/tool/cori.job
+++ b/components/homme/test/tool/cori.job
@@ -15,7 +15,7 @@ set exe = $WDIR/src/tool/homme_tool
 # compile the tool
 cd $WDIR
 if (! -x $exe ) then
-  set output = `$TOOLDIR/../../../../cime/scripts/Tools/get_case_env`
+  set output = `$TOOLDIR/../../../../cime/CIME/Tools/get_case_env`
   eval $output
   cmake -C $TOOLDIR/../../cmake/machineFiles/cori-knl.cmake  -DPREQX_PLEV=128  $TOOLDIR/../..
   make -j4 homme_tool

--- a/components/homme/test/tool/template.job
+++ b/components/homme/test/tool/template.job
@@ -16,7 +16,7 @@ set mesh = ne${NE}np${NPTS}
 
 cd $WDIR
 if (!  -x $exe ) then
-  # configure  set output = `$TOOLDIR/../../../../cime/scripts/Tools/get_case_env`
+  # configure  set output = `$TOOLDIR/../../../../cime/CIME/Tools/get_case_env`
   eval $output
   cmake -C $MACH -DPREQX_NP=$NPTS -DPREQX_PLEV=26 $TOOLDIR/../..
   # compile the tool

--- a/components/homme/test/tool/test.job
+++ b/components/homme/test/tool/test.job
@@ -19,7 +19,7 @@ set exe = $WDIR/src/tool/homme_tool
 cd $WDIR
 if (!  -x $exe ) then
   # configure                                                                                                                                         
-  set output = `$TOOLDIR/../../../../cime/scripts/Tools/get_case_env`
+  set output = `$TOOLDIR/../../../../cime/CIME/Tools/get_case_env`
   eval $output
   cmake -C $MACH -DPREQX_PLEV=26 $TOOLDIR/../..
   # compile the tool                                                                                                                                  

--- a/components/homme/test_execs/preqx_kokkos_ut/CMakeLists.txt
+++ b/components/homme/test_execs/preqx_kokkos_ut/CMakeLists.txt
@@ -3,7 +3,7 @@ SET(SRC_SHARE_DIR    ${HOMME_SOURCE_DIR}/src/share)
 SET(SRC_PREQX_DIR    ${HOMME_SOURCE_DIR}/src/preqx_kokkos)
 SET(PREQX_UT_DIR     ${CMAKE_CURRENT_SOURCE_DIR})
 SET(UTILS_SHARE_DIR  ${HOMME_SOURCE_DIR}/utils/csm_share)
-SET(UTILS_TIMING_DIR ${HOMME_SOURCE_DIR}/utils/cime/src/share/timing)
+SET(UTILS_TIMING_DIR ${HOMME_SOURCE_DIR}/utils/cime/CIME/non_py/src/timing)
 
 ### Build a 'preqx_kokkos' library ###
 # We do this once, and link against it for all unit tests. This reduces compilation times

--- a/components/homme/test_execs/share_kokkos_ut/CMakeLists.txt
+++ b/components/homme/test_execs/share_kokkos_ut/CMakeLists.txt
@@ -3,7 +3,7 @@ SET(SRC_SHARE_DIR    ${HOMME_SOURCE_DIR}/src/share)
 SET(SRC_PREQX_DIR    ${HOMME_SOURCE_DIR}/src/preqx_kokkos)
 SET(SHARE_UT_DIR     ${CMAKE_CURRENT_SOURCE_DIR})
 SET(UTILS_SHARE_DIR  ${HOMME_SOURCE_DIR}/utils/csm_share)
-SET(UTILS_TIMING_DIR ${HOMME_SOURCE_DIR}/utils/cime/src/share/timing)
+SET(UTILS_TIMING_DIR ${HOMME_SOURCE_DIR}/utils/cime/CIME/non_py/src/timing)
 
 # Place common CPP definitions here.
 # Note: need CUDA_BUILD and HOMMEXX_BFB_TESTING here, since the share

--- a/components/homme/test_execs/thetal_kokkos_ut/CMakeLists.txt
+++ b/components/homme/test_execs/thetal_kokkos_ut/CMakeLists.txt
@@ -4,8 +4,8 @@ SET(SRC_THETA_DIR    ${HOMME_SOURCE_DIR}/src/theta-l_kokkos)
 SET(SHARE_UT_DIR     ${CMAKE_CURRENT_SOURCE_DIR}/../share_kokkos_ut)
 SET(THETA_UT_DIR     ${CMAKE_CURRENT_SOURCE_DIR})
 SET(UTILS_SHARE_DIR  ${HOMME_SOURCE_DIR}/utils/csm_share)
-SET(UTILS_TIMING_SRC_DIR ${HOMME_SOURCE_DIR}/utils/cime/src/share/timing)
-SET(UTILS_TIMING_BIN_DIR ${HOMME_BINARY_DIR}/utils/cime/src/share/timing)
+SET(UTILS_TIMING_SRC_DIR ${HOMME_SOURCE_DIR}/utils/cime/CIME/non_py/src/timing)
+SET(UTILS_TIMING_BIN_DIR ${HOMME_BINARY_DIR}/utils/cime/CIME/non_py/src/timing)
 
 ### Build a 'theta-l_kokkos' library ###
 # We do this once, and link against it for all unit tests. This reduces compilation times

--- a/driver-mct/cime_config/config_component.xml
+++ b/driver-mct/cime_config/config_component.xml
@@ -103,10 +103,10 @@
 
   <entry id="UTILROOT">
     <type>char</type>
-    <default_value>$CIMEROOT/scripts/Tools</default_value>
+    <default_value>$CIMEROOT/CIME/Tools</default_value>
     <group>case_der</group>
     <file>env_case.xml</file>
-    <desc>Scripts root utils directory location (setup automatically to $CIMEROOT/scripts/Tools - DO NOT EDIT)</desc>
+    <desc>Scripts root utils directory location (setup automatically to $CIMEROOT/CIME/Tools - DO NOT EDIT)</desc>
   </entry>
 
   <!-- ===================================================================== -->

--- a/driver-moab/cime_config/config_component.xml
+++ b/driver-moab/cime_config/config_component.xml
@@ -103,10 +103,10 @@
 
   <entry id="UTILROOT">
     <type>char</type>
-    <default_value>$CIMEROOT/scripts/Tools</default_value>
+    <default_value>$CIMEROOT/CIME/Tools</default_value>
     <group>case_der</group>
     <file>env_case.xml</file>
-    <desc>Scripts root utils directory location (setup automatically to $CIMEROOT/scripts/Tools - DO NOT EDIT)</desc>
+    <desc>Scripts root utils directory location (setup automatically to $CIMEROOT/CIME/Tools - DO NOT EDIT)</desc>
   </entry>
 
   <!-- ===================================================================== -->


### PR DESCRIPTION
Update CIME submodule
    
... to 524842660578d7b8f72df78a77bd302f9d128b44
    
Changes:
1) Make sure CIME machine matches probed machine
2) Update neon data server for input files
3) New SystemTestsCompareN test type
4) Extend configure to get cmake macros files from the .cime directory
5) BIG: restructure CIME to match what would be expected in a standard python pacakge!
6) wait_for_tests: Try multiple ctest drop methods
7) Allow special XML syntax for init_path and cmd_path
8) Add Total_Build time to end of build_times.txt
    
Fixes:
1) Fix the path for PTS_DOMAIN_FILE
2) Fix config_machines xsd to allow more compilers
3) Fix xmlchange tests
4) Remove Machines warning
5) Using --retry in create_newcase was causing generated baseline to be removed
6) Fix run_tests.py when no machine is given
7) Fixes for machine check
8) Fixes issue with model detection on E3SM machines.

Fixes #4875 
    
[BFB]
