### PR TITLE
Update OpenMP-offload tests

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -60,7 +60,6 @@
 
   <machine MACH="miller">
     <DESC> ORNL AF cluster 800-node AMD Epyc 2-sockets 64-cores per node</DESC>
-    <NODENAME_REGEX>login.*</NODENAME_REGEX>
     <OS>CNL</OS>
     <COMPILERS>gnu,cray,intel</COMPILERS>
     <MPILIBS>mpt</MPILIBS>

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -436,7 +436,6 @@ _TESTS = {
 
     "e3sm_gpuomp" : {
         "tests"    : (
-                 "SMS_Ln9.ne4pg2_ne4pg2.F-MMFOMP.eam-single_thread",
                  "SMS_Ld1.T62_oEC60to30v3.DTESTM",
                  )
     },


### PR DESCRIPTION
Update OpenMP-offload tests:
- remove `SMS_Ln9.ne4pg2_ne4pg2.F-MMFOMP.eam-single_thread` from `e3sm_gpuomp`
- adjust Miller `NODENAME_REGEX` to avoid login node name conflicts

[BFB]