### PR TITLE
Initial implementation of BGC carbon budget in the coupler

### DIFF
--- a/driver-mct/cime_config/namelist_definition_drv.xml
+++ b/driver-mct/cime_config/namelist_definition_drv.xml
@@ -1019,6 +1019,20 @@
     </values>
   </entry>
 
+  <entry id="do_bgc_budgets">
+    <type>logical</type>
+    <category>budget</category>
+    <group>seq_infodata_inparm</group>
+    <desc>
+      logical that turns on BGC diagnostic budgets, false means BGC budgets will never be written
+    </desc>
+    <values>
+      <value>.false.</value>
+      <value BGC_MODE="CO2.*">.true.</value>
+      <value BGC_MODE=".*_OI">.true.</value>
+    </values>
+  </entry>
+
   <entry id="do_histinit">
     <type>logical</type>
     <category>history</category>

--- a/driver-mct/main/cime_comp_mod.F90
+++ b/driver-mct/main/cime_comp_mod.F90
@@ -145,6 +145,9 @@ module cime_comp_mod
   use seq_diag_mct, only : seq_diag_zero_mct , seq_diag_avect_mct, seq_diag_lnd_mct
   use seq_diag_mct, only : seq_diag_rof_mct  , seq_diag_ocn_mct  , seq_diag_atm_mct
   use seq_diag_mct, only : seq_diag_ice_mct  , seq_diag_accum_mct, seq_diag_print_mct
+  use seq_diagBGC_mct, only : seq_diagBGC_zero_mct , seq_diagBGC_avect_mct, seq_diagBGC_lnd_mct
+  use seq_diagBGC_mct, only : seq_diagBGC_rof_mct  , seq_diagBGC_ocn_mct  , seq_diagBGC_atm_mct
+  use seq_diagBGC_mct, only : seq_diagBGC_ice_mct  , seq_diagBGC_accum_mct
 
   ! list of fields transferred between components
   use seq_flds_mod, only : seq_flds_a2x_fluxes, seq_flds_x2a_fluxes
@@ -2329,6 +2332,7 @@ contains
     call t_adj_detailf(+2)
 
     call seq_diag_zero_mct(mode='all')
+    call seq_diagBGC_zero_mct(mode='all')
     if (read_restart .and. iamin_CPLID) then
 
        if (iamroot_CPLID) then
@@ -4646,12 +4650,15 @@ contains
        call t_drvstartf ('CPL:BUDGET1',cplrun=lcplrun,budget=.true.,barrier=mpicom_CPLID)
        if (lnd_present) then
           call seq_diag_lnd_mct(lnd(ens1), fractions_lx(ens1), infodata, do_l2x=.true., do_x2l=.true.)
+          call seq_diagBGC_lnd_mct(lnd(ens1), fractions_lx(ens1), infodata, do_l2x=.true., do_x2l=.true.)
        endif
        if (rof_present) then
           call seq_diag_rof_mct(rof(ens1), fractions_rx(ens1), infodata)
+          call seq_diagBGC_rof_mct(rof(ens1), fractions_rx(ens1), infodata)
        endif
        if (ice_present) then
           call seq_diag_ice_mct(ice(ens1), fractions_ix(ens1), infodata, do_x2i=.true.)
+          call seq_diagBGC_ice_mct(ice(ens1), fractions_ix(ens1), infodata, do_x2i=.true.)
        endif
        call t_drvstopf  ('CPL:BUDGET1',cplrun=lcplrun,budget=.true.)
     end if
@@ -4683,14 +4690,17 @@ contains
        call t_drvstartf ('CPL:BUDGET2',cplrun=lcplrun,budget=.true.,barrier=mpicom_CPLID)
        if (atm_present) then
           call seq_diag_atm_mct(atm(ens1), fractions_ax(ens1), infodata, do_a2x=.true., do_x2a=.true.)
+          call seq_diagBGC_atm_mct(atm(ens1), fractions_ax(ens1), infodata, do_a2x=.true., do_x2a=.true.)
        endif
        if (ice_present) then
           call seq_diag_ice_mct(ice(ens1), fractions_ix(ens1), infodata, do_i2x=.true.)
+          call seq_diagBGC_ice_mct(ice(ens1), fractions_ix(ens1), infodata, do_i2x=.true.)
        endif
        call t_drvstopf  ('CPL:BUDGET2',cplrun=lcplrun,budget=.true.)
 
        call t_drvstartf ('CPL:BUDGET3',cplrun=lcplrun,budget=.true.,barrier=mpicom_CPLID)
        call seq_diag_accum_mct()
+       call seq_diagBGC_accum_mct()
        call t_drvstopf  ('CPL:BUDGET3',cplrun=lcplrun,budget=.true.)
 
        call t_drvstartf ('CPL:BUDGETF',cplrun=lcplrun,budget=.true.,barrier=mpicom_CPLID)
@@ -4700,6 +4710,7 @@ contains
                budget_ltend, infodata)
        endif
        call seq_diag_zero_mct(EClock=EClock_d)
+       call seq_diagBGC_zero_mct(EClock=EClock_d)
 
        call t_drvstopf  ('CPL:BUDGETF',cplrun=lcplrun,budget=.true.)
     end if
@@ -4730,6 +4741,8 @@ contains
        call t_drvstartf ('CPL:BUDGET0',cplrun=lcplrun,budget=.true.,barrier=mpicom_CPLID)
        xao_ox => prep_aoflux_get_xao_ox() ! array over all instances
        call seq_diag_ocn_mct(ocn(ens1), xao_ox(1), fractions_ox(ens1), infodata, &
+            do_o2x=.true., do_x2o=.true., do_xao=.true.)
+       call seq_diagBGC_ocn_mct(ocn(ens1), xao_ox(1), fractions_ox(ens1), infodata, &
             do_o2x=.true., do_x2o=.true., do_xao=.true.)
        call t_drvstopf ('CPL:BUDGET0',cplrun=lcplrun,budget=.true.)
     end if

--- a/driver-mct/main/cime_comp_mod.F90
+++ b/driver-mct/main/cime_comp_mod.F90
@@ -507,6 +507,7 @@ module cime_comp_mod
 
   !--- history & budgets ---
   logical :: do_budgets              ! heat/water budgets on
+  logical :: do_bgc_budgets          ! BGC budgets on
   logical :: do_histinit             ! initial hist file
   logical :: do_histavg              ! histavg on or off
   logical :: do_hist_r2x             ! create aux files: r2x
@@ -1130,6 +1131,7 @@ contains
          drv_threading=drv_threading               , &
          do_histinit=do_histinit                   , &
          do_budgets=do_budgets                     , &
+         do_bgc_budgets=do_bgc_budgets             , &
          budget_inst=budget_inst                   , &
          budget_daily=budget_daily                 , &
          budget_month=budget_month                 , &
@@ -4650,15 +4652,21 @@ contains
        call t_drvstartf ('CPL:BUDGET1',cplrun=lcplrun,budget=.true.,barrier=mpicom_CPLID)
        if (lnd_present) then
           call seq_diag_lnd_mct(lnd(ens1), fractions_lx(ens1), infodata, do_l2x=.true., do_x2l=.true.)
-          call seq_diagBGC_lnd_mct(lnd(ens1), fractions_lx(ens1), infodata, do_l2x=.true., do_x2l=.true.)
+          if (do_bgc_budgets) then
+             call seq_diagBGC_lnd_mct(lnd(ens1), fractions_lx(ens1), infodata, do_l2x=.true., do_x2l=.true.)
+          endif
        endif
        if (rof_present) then
           call seq_diag_rof_mct(rof(ens1), fractions_rx(ens1), infodata)
-          call seq_diagBGC_rof_mct(rof(ens1), fractions_rx(ens1), infodata)
+          if (do_bgc_budgets) then
+             call seq_diagBGC_rof_mct(rof(ens1), fractions_rx(ens1), infodata)
+          endif
        endif
        if (ice_present) then
           call seq_diag_ice_mct(ice(ens1), fractions_ix(ens1), infodata, do_x2i=.true.)
-          call seq_diagBGC_ice_mct(ice(ens1), fractions_ix(ens1), infodata, do_x2i=.true.)
+          if (do_bgc_budgets) then
+             call seq_diagBGC_ice_mct(ice(ens1), fractions_ix(ens1), infodata, do_x2i=.true.)
+          endif
        endif
        call t_drvstopf  ('CPL:BUDGET1',cplrun=lcplrun,budget=.true.)
     end if
@@ -4690,27 +4698,35 @@ contains
        call t_drvstartf ('CPL:BUDGET2',cplrun=lcplrun,budget=.true.,barrier=mpicom_CPLID)
        if (atm_present) then
           call seq_diag_atm_mct(atm(ens1), fractions_ax(ens1), infodata, do_a2x=.true., do_x2a=.true.)
-          call seq_diagBGC_atm_mct(atm(ens1), fractions_ax(ens1), infodata, do_a2x=.true., do_x2a=.true.)
+          if (do_bgc_budgets) then
+             call seq_diagBGC_atm_mct(atm(ens1), fractions_ax(ens1), infodata, do_a2x=.true., do_x2a=.true.)
+          endif
        endif
        if (ice_present) then
           call seq_diag_ice_mct(ice(ens1), fractions_ix(ens1), infodata, do_i2x=.true.)
-          call seq_diagBGC_ice_mct(ice(ens1), fractions_ix(ens1), infodata, do_i2x=.true.)
+          if (do_bgc_budgets) then
+             call seq_diagBGC_ice_mct(ice(ens1), fractions_ix(ens1), infodata, do_i2x=.true.)
+          endif
        endif
        call t_drvstopf  ('CPL:BUDGET2',cplrun=lcplrun,budget=.true.)
 
        call t_drvstartf ('CPL:BUDGET3',cplrun=lcplrun,budget=.true.,barrier=mpicom_CPLID)
        call seq_diag_accum_mct()
-       call seq_diagBGC_accum_mct()
+       if (do_bgc_budgets) then
+          call seq_diagBGC_accum_mct()
+       endif
        call t_drvstopf  ('CPL:BUDGET3',cplrun=lcplrun,budget=.true.)
 
        call t_drvstartf ('CPL:BUDGETF',cplrun=lcplrun,budget=.true.,barrier=mpicom_CPLID)
        if (.not. dead_comps) then
-          call seq_diag_print_mct(EClock_d,stop_alarm,budget_inst, &
+          call seq_diag_print_mct(EClock_d,stop_alarm,do_bgc_budgets, budget_inst, &
                budget_daily, budget_month, budget_ann, budget_ltann, &
                budget_ltend, infodata)
        endif
        call seq_diag_zero_mct(EClock=EClock_d)
-       call seq_diagBGC_zero_mct(EClock=EClock_d)
+       if (do_bgc_budgets) then
+          call seq_diagBGC_zero_mct(EClock=EClock_d)
+       endif
 
        call t_drvstopf  ('CPL:BUDGETF',cplrun=lcplrun,budget=.true.)
     end if
@@ -4742,8 +4758,10 @@ contains
        xao_ox => prep_aoflux_get_xao_ox() ! array over all instances
        call seq_diag_ocn_mct(ocn(ens1), xao_ox(1), fractions_ox(ens1), infodata, &
             do_o2x=.true., do_x2o=.true., do_xao=.true.)
-       call seq_diagBGC_ocn_mct(ocn(ens1), xao_ox(1), fractions_ox(ens1), infodata, &
-            do_o2x=.true., do_x2o=.true., do_xao=.true.)
+       if (do_bgc_budgets) then
+          call seq_diagBGC_ocn_mct(ocn(ens1), xao_ox(1), fractions_ox(ens1), infodata, &
+               do_o2x=.true., do_x2o=.true., do_xao=.true.)
+       endif
        call t_drvstopf ('CPL:BUDGET0',cplrun=lcplrun,budget=.true.)
     end if
   end subroutine cime_run_calc_budgets3

--- a/driver-mct/main/seq_diagBGC_mct.F90
+++ b/driver-mct/main/seq_diagBGC_mct.F90
@@ -399,16 +399,19 @@ contains
     !EOP
 
     !----- local -----
-    type(mct_aVect), pointer :: a2x_a        ! model to drv bundle
-    type(mct_aVect), pointer :: x2a_a        ! drv to model bundle
+    type(mct_aVect), pointer :: a2x_a         ! model to drv bundle
+    type(mct_aVect), pointer :: x2a_a         ! drv to model bundle
     type(mct_ggrid), pointer :: dom_a
-    integer(in)              :: k,n,ic,nf,ip      ! generic index
-    integer(in)              :: kArea             ! index of area field in aVect
-    integer(in)              :: kLat              ! index of lat field in aVect
-    integer(in)              :: kl,ka,ko,ki       ! fraction indices
-    integer(in)              :: lSize             ! size of aVect
-    real(r8)                 :: ca_a       ! area of a grid cell
+    character(CL)            :: atm_gnam      ! atm grid
+    character(CL)            :: lnd_gnam      ! lnd grid
+    integer(in)              :: k,n,ic,nf,ip  ! generic index
+    integer(in)              :: kArea         ! index of area field in aVect
+    integer(in)              :: kLat          ! index of lat field in aVect
+    integer(in)              :: kl,ka,ko,ki   ! fraction indices
+    integer(in)              :: lSize         ! size of aVect
+    real(r8)                 :: ca_a          ! area of a grid cell
     logical,save             :: first_time    = .true.
+    logical,save             :: samegrid_al   ! samegrid atm and lnd
 
     !----- formats -----
     character(*),parameter :: subName = '(seq_diagBGC_atm_mct) '
@@ -424,9 +427,21 @@ contains
     kArea = mct_aVect_indexRA(dom_a%data,afldname)
     kLat  = mct_aVect_indexRA(dom_a%data,latname)
     ka    = mct_aVect_indexRA(frac_a,afracname)
-    kl    = mct_aVect_indexRA(frac_a,lfracname)
     ko    = mct_aVect_indexRA(frac_a,ofracname)
     ki    = mct_aVect_indexRA(frac_a,ifracname)
+    if (first_time) then
+       call seq_infodata_getData(infodata , &
+            lnd_gnam=lnd_gnam             , &
+            atm_gnam=atm_gnam             )
+       samegrid_al = .true.
+       if (trim(atm_gnam) /= trim(lnd_gnam)) samegrid_al = .false.
+    end if
+
+    if (samegrid_al) then
+       kl = mct_aVect_indexRA(frac_a,lfracname)
+    else
+       kl = mct_aVect_indexRA(frac_a,lfrinname)
+    endif
 
     !---------------------------------------------------------------------------
     ! add values found in this bundle to the budget table

--- a/driver-mct/main/seq_diagBGC_mct.F90
+++ b/driver-mct/main/seq_diagBGC_mct.F90
@@ -145,11 +145,11 @@ module seq_diagBGC_mct
   ! !PUBLIC DATA MEMBERS
 
   !--- time-averaged (annual?) global budget diagnostics ---
-  !--- note: call sum0 then save budg_dataG and budg_ns on restart from/to root pe ---
-  real(r8),public :: budg_dataL(f_size,c_size,p_size) ! local sum, valid on all pes
-  real(r8),public :: budg_dataG(f_size,c_size,p_size) ! global sum, valid only on root pe
-  real(r8),public :: budg_ns   (f_size,c_size,p_size) ! counter, valid only on root pe
-  real(r8),public :: dataGpr   (f_size,c_size,p_size) ! values to print, scaled and such
+  !--- note: call sum0 then save budg_dataGBGC and budg_nsBGC on restart from/to root pe ---
+  real(r8),public :: budg_dataL   (f_size,c_size,p_size) ! local sum, valid on all pes
+  real(r8),public :: budg_dataGBGC(f_size,c_size,p_size) ! global sum, valid only on root pe
+  real(r8),public :: budg_nsBGC   (f_size,c_size,p_size) ! counter, valid only on root pe
+  real(r8),public :: dataGpr      (f_size,c_size,p_size) ! values to print, scaled and such
 
   character(len=*),parameter :: afldname  = 'aream'
   character(len=*),parameter :: latname   = 'lat'
@@ -249,23 +249,23 @@ contains
        do ip = 1,p_size
           if (ip == p_inst) then
              budg_dataL(:,:,ip) = 0.0_r8
-             budg_dataG(:,:,ip) = 0.0_r8
-             budg_ns(:,:,ip) = 0.0_r8
+             budg_dataGBGC(:,:,ip) = 0.0_r8
+             budg_nsBGC(:,:,ip) = 0.0_r8
           endif
           if (ip==p_day .and. sec==0) then
              budg_dataL(:,:,ip) = 0.0_r8
-             budg_dataG(:,:,ip) = 0.0_r8
-             budg_ns(:,:,ip) = 0.0_r8
+             budg_dataGBGC(:,:,ip) = 0.0_r8
+             budg_nsBGC(:,:,ip) = 0.0_r8
           endif
           if (ip==p_mon .and. day==1 .and. sec==0) then
              budg_dataL(:,:,ip) = 0.0_r8
-             budg_dataG(:,:,ip) = 0.0_r8
-             budg_ns(:,:,ip) = 0.0_r8
+             budg_dataGBGC(:,:,ip) = 0.0_r8
+             budg_nsBGC(:,:,ip) = 0.0_r8
           endif
           if (ip==p_ann .and. mon==1 .and. day==1 .and. sec==0) then
              budg_dataL(:,:,ip) = 0.0_r8
-             budg_dataG(:,:,ip) = 0.0_r8
-             budg_ns(:,:,ip) = 0.0_r8
+             budg_dataGBGC(:,:,ip) = 0.0_r8
+             budg_nsBGC(:,:,ip) = 0.0_r8
           endif
        enddo
     endif
@@ -273,28 +273,28 @@ contains
     if (present(mode)) then
        if (trim(mode) == 'inst') then
           budg_dataL(:,:,p_inst) = 0.0_r8
-          budg_dataG(:,:,p_inst) = 0.0_r8
-          budg_ns(:,:,p_inst) = 0.0_r8
+          budg_dataGBGC(:,:,p_inst) = 0.0_r8
+          budg_nsBGC(:,:,p_inst) = 0.0_r8
        elseif (trim(mode) == 'day') then
           budg_dataL(:,:,p_day) = 0.0_r8
-          budg_dataG(:,:,p_day) = 0.0_r8
-          budg_ns(:,:,p_day) = 0.0_r8
+          budg_dataGBGC(:,:,p_day) = 0.0_r8
+          budg_nsBGC(:,:,p_day) = 0.0_r8
        elseif (trim(mode) == 'mon') then
           budg_dataL(:,:,p_mon) = 0.0_r8
-          budg_dataG(:,:,p_mon) = 0.0_r8
-          budg_ns(:,:,p_mon) = 0.0_r8
+          budg_dataGBGC(:,:,p_mon) = 0.0_r8
+          budg_nsBGC(:,:,p_mon) = 0.0_r8
        elseif (trim(mode) == 'ann') then
           budg_dataL(:,:,p_ann) = 0.0_r8
-          budg_dataG(:,:,p_ann) = 0.0_r8
-          budg_ns(:,:,p_ann) = 0.0_r8
+          budg_dataGBGC(:,:,p_ann) = 0.0_r8
+          budg_nsBGC(:,:,p_ann) = 0.0_r8
        elseif (trim(mode) == 'inf') then
           budg_dataL(:,:,p_inf) = 0.0_r8
-          budg_dataG(:,:,p_inf) = 0.0_r8
-          budg_ns(:,:,p_inf) = 0.0_r8
+          budg_dataGBGC(:,:,p_inf) = 0.0_r8
+          budg_nsBGC(:,:,p_inf) = 0.0_r8
        elseif (trim(mode) == 'all') then
           budg_dataL(:,:,:) = 0.0_r8
-          budg_dataG(:,:,:) = 0.0_r8
-          budg_ns(:,:,:) = 0.0_r8
+          budg_dataGBGC(:,:,:) = 0.0_r8
+          budg_nsBGC(:,:,:) = 0.0_r8
        else
           call shr_sys_abort(subname//' ERROR in mode '//trim(mode))
        endif
@@ -333,7 +333,7 @@ contains
     do ip = p_inst+1,p_size
        budg_dataL(:,:,ip) = budg_dataL(:,:,ip) + budg_dataL(:,:,p_inst)
     enddo
-    budg_ns(:,:,:) = budg_ns(:,:,:) + 1.0_r8
+    budg_nsBGC(:,:,:) = budg_nsBGC(:,:,:) + 1.0_r8
 
   end subroutine seq_diagBGC_accum_mct
 
@@ -368,7 +368,7 @@ contains
     call seq_comm_setptrs(CPLID,mpicom=mpicom)
     budg_dataGtmp = 0.0_r8
     call shr_mpi_sum(budg_dataL,budg_dataGtmp,mpicom,subName)
-    budg_dataG = budg_dataG + budg_dataGtmp
+    budg_dataGBGC = budg_dataGBGC + budg_dataGtmp
     budg_dataL = 0.0_r8
 
   end subroutine seq_diagBGC_sum0_mct
@@ -1000,7 +1000,6 @@ contains
     !EOP
 
     !--- local ---
-    logical          :: sumdone     ! has a sum been computed yet
 
     !-------------------------------------------------------------------------------
 
@@ -1008,19 +1007,13 @@ contains
     ! prepare instantaneous budget data for printing
     !-------------------------------------------------------------------------------
 
-    sumdone = .false.
+    call seq_diagBGC_sum0_mct()
+    dataGpr = budg_dataGBGC
 
-    if (.not.sumdone) then
-      call seq_diagBGC_sum0_mct()
-      dataGpr = budg_dataG
-      sumdone = .true.
-
-      !  old budget normalizations (global area and 1e9 for carbon)
-      dataGpr = dataGpr/(4.0_r8*shr_const_pi)
-      dataGpr(f_c:f_c_end,:,:) = dataGpr(f_c:f_c_end,:,:) * 1.0e9_r8
-      dataGpr = dataGpr/budg_ns
-
-   endif
+    !  old budget normalizations (global area and 1e9 for carbon)
+    dataGpr = dataGpr/(4.0_r8*shr_const_pi)
+    dataGpr(f_c:f_c_end,:,:) = dataGpr(f_c:f_c_end,:,:) * 1.0e9_r8
+    dataGpr = dataGpr/budg_nsBGC
 
   end subroutine seq_diagBGC_preprint_mct
 
@@ -1043,8 +1036,8 @@ contains
     ! !INPUT/OUTPUT PARAMETERS:
 
     type(ESMF_Clock) , intent(in) :: EClock
-    integer          , intent(in) :: ip
-    integer          , intent(in) :: plev        ! print level
+    integer(in)      , intent(in) :: ip
+    integer(in)      , intent(in) :: plev        ! print level
 
     !EOP
 

--- a/driver-mct/main/seq_diagBGC_mct.F90
+++ b/driver-mct/main/seq_diagBGC_mct.F90
@@ -1,0 +1,1516 @@
+!===============================================================================
+!
+! !MODULE: seq_diagBGC_mod -- computes spatial \& time averages of fluxed BGC
+!                              quatities
+!
+! !DESCRIPTION:
+!    The coupler is required to do certain diagnostics, those calculations are
+!    located in this module.
+!
+! !REMARKS:
+!    E3SM sign convention for fluxes is positive downward with hierarchy being
+!       atm/glc/lnd/rof/ice/ocn
+!    Sign convention:
+!       positive value <=> the model is gaining water, heat, momentum, etc.
+!    Unit convention:
+!       water flux    ~ (kg/s)/m^2
+!       salt  flux    ~ (kg/s)/m^2
+!
+! !REVISION HISTORY:
+!    2012-aug-20 - T. Craig    - add rof component
+!    2008-jul-10 - T. Craig    - updated budget implementation
+!    2007-may-07 - B. Kauffman - initial port to cpl7.
+!    2002-nov-21 - R. Jacob    - initial port to cpl6.
+!    199x-mmm-dd - B. Kauffman - original version in cpl4.
+!
+! !INTERFACE: ------------------------------------------------------------------
+
+module seq_diagBGC_mct
+  ! !USES:
+
+  use shr_kind_mod, only: r8 => shr_kind_r8, in=>shr_kind_in
+  use shr_kind_mod, only: i8 => shr_kind_i8,  cl=>shr_kind_cl, cs=>shr_kind_cs
+  use shr_sys_mod, only : shr_sys_abort, shr_sys_flush
+  use shr_mpi_mod, only : shr_mpi_max, shr_mpi_sum
+  use shr_const_mod, only: shr_const_rearth, shr_const_pi, shr_const_isspval
+  use mct_mod, only: mct_ggrid, mct_avect, mct_avect_lsize, mct_string, &
+       mct_string_tochar, mct_gsmap, mct_aVect_indexRA, MCT_AVECT_NRATTR, &
+       mct_string_clean, mct_avect_getrlist
+  use esmf, only : esmf_clock
+  use shr_log_mod, only: s_logunit=>shr_log_unit
+  use seq_comm_mct, only: logunit, cplid, seq_comm_setptrs, seq_comm_clean
+  use seq_timemgr_mod, only : seq_timemgr_EClockGetData
+  use component_type_mod, only : COMPONENT_GET_DOM_CX, COMPONENT_GET_C2X_CX, &
+       COMPONENT_GET_X2C_CX, COMPONENT_TYPE
+  use seq_infodata_mod, only : seq_infodata_type, seq_infodata_getdata
+  use shr_reprosum_mod, only: shr_reprosum_calc
+
+  implicit none
+  save
+  private
+
+  ! !PUBLIC TYPES:
+
+  ! none
+
+  !PUBLIC MEMBER FUNCTIONS:
+
+  public seq_diagBGC_zero_mct
+  public seq_diagBGC_atm_mct
+  public seq_diagBGC_lnd_mct
+  public seq_diagBGC_rof_mct
+  public seq_diagBGC_glc_mct
+  public seq_diagBGC_ocn_mct
+  public seq_diagBGC_ice_mct
+  public seq_diagBGC_accum_mct
+  public seq_diagBGC_sum0_mct
+  public seq_diagBGC_preprint_mct
+  public seq_diagBGC_print_mct
+  public seq_diagBGC_avect_mct
+  public seq_diagBGC_avloc_mct
+  public seq_diagBGC_avdiff_mct
+
+  !EOP
+
+  !----------------------------------------------------------------------------
+  ! Local data
+  !----------------------------------------------------------------------------
+
+  !----- local constants -----
+
+  !--- C for component ---
+  !--- "r" is receive in the coupler, "s" is send from the coupler
+
+  integer(in),parameter :: c_size = 22
+
+  integer(in),parameter :: c_atm_as   = 1 ! model index: atm
+  integer(in),parameter :: c_atm_ar   = 2 ! model index: atm
+  integer(in),parameter :: c_inh_is   = 3 ! model index: ice, northern
+  integer(in),parameter :: c_inh_ir   = 4 ! model index: ice, northern
+  integer(in),parameter :: c_ish_is   = 5 ! model index: ice, southern
+  integer(in),parameter :: c_ish_ir   = 6 ! model index: ice, southern
+  integer(in),parameter :: c_lnd_ls   = 7 ! model index: lnd
+  integer(in),parameter :: c_lnd_lr   = 8 ! model index: lnd
+  integer(in),parameter :: c_ocn_os   = 9 ! model index: ocn
+  integer(in),parameter :: c_ocn_or   =10 ! model index: ocn
+  integer(in),parameter :: c_rof_rs   =11 ! model index: rof
+  integer(in),parameter :: c_rof_rr   =12 ! model index: rof
+  integer(in),parameter :: c_glc_gs   =13 ! model index: glc
+  integer(in),parameter :: c_glc_gr   =14 ! model index: glc
+  ! --- on atm grid ---
+  integer(in),parameter :: c_inh_as   =15 ! model index: ice, northern
+  integer(in),parameter :: c_inh_ar   =16 ! model index: ice, northern
+  integer(in),parameter :: c_ish_as   =17 ! model index: ice, southern
+  integer(in),parameter :: c_ish_ar   =18 ! model index: ice, southern
+  integer(in),parameter :: c_lnd_as   =19 ! model index: lnd
+  integer(in),parameter :: c_lnd_ar   =20 ! model index: lnd
+  integer(in),parameter :: c_ocn_as   =21 ! model index: ocn
+  integer(in),parameter :: c_ocn_ar   =22 ! model index: ocn
+
+  character(len=8),parameter :: cname(c_size) = &
+       (/' c2a_atm',' a2c_atm',' c2i_inh',' i2c_inh',' c2i_ish',' i2c_ish', &
+         ' c2l_lnd',' l2c_lnd',' c2o_ocn',' o2c_ocn',' c2r_rof',' r2c_rof', &
+         ' c2g_glc',' g2c_glc',' c2a_inh',' a2c_inh',' c2a_ish',' a2c_ish', &
+         ' c2a_lnd',' a2c_lnd',' c2a_ocn',' a2c_ocn' /)
+
+  !--- F for field ---
+
+  integer(in),parameter :: f_area      = 1     ! area (wrt to unit sphere)
+  integer(in),parameter :: f_csurf     = 2     ! carbon : surface
+  integer(in),parameter :: f_cblack    = 3     ! carbon : black carbon
+  integer(in),parameter :: f_corgnc    = 4     ! carbon : organic
+
+  integer(in),parameter :: f_size     = f_corgnc      ! Total array size of all elements
+  integer(in),parameter :: f_a        = f_area        ! 1st index for area
+  integer(in),parameter :: f_a_end    = f_area        ! last index for area
+  integer(in),parameter :: f_c        = f_csurf       ! 1st index for carbon
+  integer(in),parameter :: f_c_end    = f_corgnc      ! Last index for carbon
+
+  character(len=12),parameter :: fname(f_size) = &
+       (/'        area',' surf carbon','black carbon','orgnc carbon' /)
+
+  !--- P for period ---
+
+  integer(in),parameter :: p_size = 5
+
+  integer(in),parameter :: p_inst = 1
+  integer(in),parameter :: p_day  = 2
+  integer(in),parameter :: p_mon  = 3
+  integer(in),parameter :: p_ann  = 4
+  integer(in),parameter :: p_inf  = 5
+
+  character(len=8),parameter :: pname(p_size) = &
+       (/'    inst','   daily',' monthly','  annual','all_time' /)
+
+  ! !PUBLIC DATA MEMBERS
+
+  !--- time-averaged (annual?) global budget diagnostics ---
+  !--- note: call sum0 then save budg_dataG and budg_ns on restart from/to root pe ---
+  real(r8),public :: budg_dataL(f_size,c_size,p_size) ! local sum, valid on all pes
+  real(r8),public :: budg_dataG(f_size,c_size,p_size) ! global sum, valid only on root pe
+  real(r8),public :: budg_ns   (f_size,c_size,p_size) ! counter, valid only on root pe
+  real(r8),public :: dataGpr   (f_size,c_size,p_size) ! values to print, scaled and such
+
+  character(len=*),parameter :: afldname  = 'aream'
+  character(len=*),parameter :: latname   = 'lat'
+  character(len=*),parameter :: afracname = 'afrac'
+  character(len=*),parameter :: lfracname = 'lfrac'
+  character(len=*),parameter :: lfrinname = 'lfrin'
+  character(len=*),parameter :: ofracname = 'ofrac'
+  character(len=*),parameter :: ifracname = 'ifrac'
+
+  character(*),parameter :: modName = "(seq_diagBGC_mct) "
+
+  integer(in),parameter :: debug = 0 ! internal debug level
+
+  ! !PRIVATE DATA MEMBERS
+
+  integer :: index_a2x_Faxa_bcphidry
+  integer :: index_a2x_Faxa_bcphodry
+  integer :: index_a2x_Faxa_bcphiwet
+  integer :: index_a2x_Faxa_ocphidry
+  integer :: index_a2x_Faxa_ocphodry
+  integer :: index_a2x_Faxa_ocphiwet
+
+  integer :: index_x2a_Fall_fco2_lnd
+  integer :: index_x2a_Faoo_fco2_ocn
+
+  integer :: index_l2x_Fall_fco2_lnd
+
+  integer :: index_x2l_Faxa_bcphidry
+  integer :: index_x2l_Faxa_bcphodry
+  integer :: index_x2l_Faxa_bcphiwet
+  integer :: index_x2l_Faxa_ocphidry
+  integer :: index_x2l_Faxa_ocphodry
+  integer :: index_x2l_Faxa_ocphiwet
+
+  integer :: index_o2x_Faoo_fco2_ocn
+
+  integer :: index_x2o_Faxa_bcphidry
+  integer :: index_x2o_Faxa_bcphodry
+  integer :: index_x2o_Faxa_bcphiwet
+  integer :: index_x2o_Faxa_ocphidry
+  integer :: index_x2o_Faxa_ocphodry
+  integer :: index_x2o_Faxa_ocphiwet
+
+  integer :: index_x2i_Faxa_bcphidry
+  integer :: index_x2i_Faxa_bcphodry
+  integer :: index_x2i_Faxa_bcphiwet
+  integer :: index_x2i_Faxa_ocphidry
+  integer :: index_x2i_Faxa_ocphodry
+  integer :: index_x2i_Faxa_ocphiwet
+
+  integer :: index_g2x_Fogg_rofl
+  integer :: index_g2x_Fogg_rofi
+  integer :: index_g2x_Figg_rofi
+
+  !===============================================================================
+contains
+  !===============================================================================
+
+  !===============================================================================
+  !BOP ===========================================================================
+  !
+  ! !IROUTINE: seq_diagBGC_zero_mct - zero out global budget diagnostic data.
+  !
+  ! !DESCRIPTION:
+  !    Zero out global budget diagnostic data.
+  !
+  ! !REVISION HISTORY:
+  !    2008-jul-11 - T. Craig - update
+  !
+  ! !INTERFACE: ------------------------------------------------------------------
+
+  subroutine seq_diagBGC_zero_mct(EClock,mode)
+
+    ! !INPUT/OUTPUT PARAMETERS:
+
+    type(ESMF_Clock), intent(in),optional :: EClock
+    character(len=*), intent(in),optional :: mode
+
+    !EOP
+
+    integer(IN) :: ip,yr,mon,day,sec
+    !----- formats -----
+    character(*),parameter :: subName = '(seq_diagBGC_zero_mct) '
+
+    !-------------------------------------------------------------------------------
+    !
+    !-------------------------------------------------------------------------------
+
+    if (.not. present(EClock) .and. .not. present(mode)) then
+       call shr_sys_abort(subName//' ERROR EClock or mode should be present')
+    endif
+
+    if (present(EClock)) then
+       call seq_timemgr_EClockGetData(EClock,curr_yr=yr, &
+            curr_mon=mon,curr_day=day,curr_tod=sec)
+
+       do ip = 1,p_size
+          if (ip == p_inst) then
+             budg_dataL(:,:,ip) = 0.0_r8
+             budg_dataG(:,:,ip) = 0.0_r8
+             budg_ns(:,:,ip) = 0.0_r8
+          endif
+          if (ip==p_day .and. sec==0) then
+             budg_dataL(:,:,ip) = 0.0_r8
+             budg_dataG(:,:,ip) = 0.0_r8
+             budg_ns(:,:,ip) = 0.0_r8
+          endif
+          if (ip==p_mon .and. day==1 .and. sec==0) then
+             budg_dataL(:,:,ip) = 0.0_r8
+             budg_dataG(:,:,ip) = 0.0_r8
+             budg_ns(:,:,ip) = 0.0_r8
+          endif
+          if (ip==p_ann .and. mon==1 .and. day==1 .and. sec==0) then
+             budg_dataL(:,:,ip) = 0.0_r8
+             budg_dataG(:,:,ip) = 0.0_r8
+             budg_ns(:,:,ip) = 0.0_r8
+          endif
+       enddo
+    endif
+
+    if (present(mode)) then
+       if (trim(mode) == 'inst') then
+          budg_dataL(:,:,p_inst) = 0.0_r8
+          budg_dataG(:,:,p_inst) = 0.0_r8
+          budg_ns(:,:,p_inst) = 0.0_r8
+       elseif (trim(mode) == 'day') then
+          budg_dataL(:,:,p_day) = 0.0_r8
+          budg_dataG(:,:,p_day) = 0.0_r8
+          budg_ns(:,:,p_day) = 0.0_r8
+       elseif (trim(mode) == 'mon') then
+          budg_dataL(:,:,p_mon) = 0.0_r8
+          budg_dataG(:,:,p_mon) = 0.0_r8
+          budg_ns(:,:,p_mon) = 0.0_r8
+       elseif (trim(mode) == 'ann') then
+          budg_dataL(:,:,p_ann) = 0.0_r8
+          budg_dataG(:,:,p_ann) = 0.0_r8
+          budg_ns(:,:,p_ann) = 0.0_r8
+       elseif (trim(mode) == 'inf') then
+          budg_dataL(:,:,p_inf) = 0.0_r8
+          budg_dataG(:,:,p_inf) = 0.0_r8
+          budg_ns(:,:,p_inf) = 0.0_r8
+       elseif (trim(mode) == 'all') then
+          budg_dataL(:,:,:) = 0.0_r8
+          budg_dataG(:,:,:) = 0.0_r8
+          budg_ns(:,:,:) = 0.0_r8
+       else
+          call shr_sys_abort(subname//' ERROR in mode '//trim(mode))
+       endif
+    endif
+
+  end subroutine seq_diagBGC_zero_mct
+
+  !===============================================================================
+  !BOP ===========================================================================
+  !
+  ! !IROUTINE: seq_diagBGC_accum_mct - accum out global budget diagnostic data.
+  !
+  ! !DESCRIPTION:
+  !    Accum out global budget diagnostic data.
+  !
+  ! !REVISION HISTORY:
+  !    2008-jul-11 - T. Craig - update
+  !
+  ! !INTERFACE: ------------------------------------------------------------------
+
+  subroutine seq_diagBGC_accum_mct()
+
+    ! !INPUT/OUTPUT PARAMETERS:
+
+    !EOP
+
+    integer(in) :: ip
+
+    !----- formats -----
+    character(*),parameter :: subName = '(seq_diagBGC_accum_mct) '
+
+    !-------------------------------------------------------------------------------
+    !
+    !-------------------------------------------------------------------------------
+
+    do ip = p_inst+1,p_size
+       budg_dataL(:,:,ip) = budg_dataL(:,:,ip) + budg_dataL(:,:,p_inst)
+    enddo
+    budg_ns(:,:,:) = budg_ns(:,:,:) + 1.0_r8
+
+  end subroutine seq_diagBGC_accum_mct
+
+  !===============================================================================
+  !BOP ===========================================================================
+  !
+  ! !IROUTINE: seq_diagBGC_sum0_mct - sum local to global on root
+  !
+  ! !DESCRIPTION:
+  !    Sum local values to global on root
+  !
+  ! !REVISION HISTORY:
+  !    2008-jul-19 - T. Craig - update
+  !
+  ! !INTERFACE: ------------------------------------------------------------------
+
+  subroutine seq_diagBGC_sum0_mct()
+
+    ! !INPUT/OUTPUT PARAMETERS:
+
+    !EOP
+
+    real(r8) :: budg_dataGtmp(f_size,c_size,p_size) ! temporary sum
+    integer(in)      :: mpicom      ! mpi comm
+    !----- formats -----
+    character(*),parameter :: subName = '(seq_diagBGC_sum0_mct) '
+
+    !-------------------------------------------------------------------------------
+    !
+    !-------------------------------------------------------------------------------
+
+    call seq_comm_setptrs(CPLID,mpicom=mpicom)
+    budg_dataGtmp = 0.0_r8
+    call shr_mpi_sum(budg_dataL,budg_dataGtmp,mpicom,subName)
+    budg_dataG = budg_dataG + budg_dataGtmp
+    budg_dataL = 0.0_r8
+
+  end subroutine seq_diagBGC_sum0_mct
+
+  !===============================================================================
+  !BOP ===========================================================================
+  !
+  ! !IROUTINE: seq_diagBGC_atm_mct - compute global atm input/output flux diagnostics
+  !
+  ! !DESCRIPTION:
+  !     Compute global atm input/output flux diagnostics
+  !
+  ! !REVISION HISTORY:
+  !    2008-jul-10 - T. Craig - update
+  !
+  ! !INTERFACE: ------------------------------------------------------------------
+
+  subroutine seq_diagBGC_atm_mct( atm, frac_a, infodata, do_a2x, do_x2a)
+
+    ! !INPUT/OUTPUT PARAMETERS:
+
+    type(component_type)    , intent(in)           :: atm    ! component type for instance1
+    type(mct_aVect)         , intent(in)           :: frac_a ! frac bundle
+    type(seq_infodata_type) , intent(in)           :: infodata
+    logical                 , intent(in), optional :: do_a2x
+    logical                 , intent(in), optional :: do_x2a
+
+    !EOP
+
+    !----- local -----
+    type(mct_aVect), pointer :: a2x_a        ! model to drv bundle
+    type(mct_aVect), pointer :: x2a_a        ! drv to model bundle
+    type(mct_ggrid), pointer :: dom_a
+    integer(in)              :: k,n,ic,nf,ip      ! generic index
+    integer(in)              :: kArea             ! index of area field in aVect
+    integer(in)              :: kLat              ! index of lat field in aVect
+    integer(in)              :: kl,ka,ko,ki       ! fraction indices
+    integer(in)              :: lSize             ! size of aVect
+    real(r8)                 :: ca_a       ! area of a grid cell
+    logical,save             :: first_time    = .true.
+
+    !----- formats -----
+    character(*),parameter :: subName = '(seq_diagBGC_atm_mct) '
+
+    !-------------------------------------------------------------------------------
+    !
+    !-------------------------------------------------------------------------------
+
+    dom_a => component_get_dom_cx(atm)
+    a2x_a => component_get_c2x_cx(atm)
+    x2a_a => component_get_x2c_cx(atm)
+
+    kArea = mct_aVect_indexRA(dom_a%data,afldname)
+    kLat  = mct_aVect_indexRA(dom_a%data,latname)
+    ka    = mct_aVect_indexRA(frac_a,afracname)
+    kl    = mct_aVect_indexRA(frac_a,lfracname)
+    ko    = mct_aVect_indexRA(frac_a,ofracname)
+    ki    = mct_aVect_indexRA(frac_a,ifracname)
+
+    !---------------------------------------------------------------------------
+    ! add values found in this bundle to the budget table
+    !---------------------------------------------------------------------------
+
+    ip = p_inst
+
+    if (present(do_a2x)) then
+       if (first_time) then
+          index_a2x_Faxa_bcphidry = mct_aVect_indexRA(a2x_a,'Faxa_bcphidry')
+          index_a2x_Faxa_bcphodry = mct_aVect_indexRA(a2x_a,'Faxa_bcphodry')
+          index_a2x_Faxa_bcphiwet = mct_aVect_indexRA(a2x_a,'Faxa_bcphiwet')
+          index_a2x_Faxa_ocphidry = mct_aVect_indexRA(a2x_a,'Faxa_ocphidry')
+          index_a2x_Faxa_ocphodry = mct_aVect_indexRA(a2x_a,'Faxa_ocphodry')
+          index_a2x_Faxa_ocphiwet = mct_aVect_indexRA(a2x_a,'Faxa_ocphiwet')
+       end if
+
+       lSize = mct_avect_lSize(a2x_a)
+       do n=1,lSize
+          do k=1,4
+             if (k == 1) then
+                ic = c_atm_ar
+                ca_a = -dom_a%data%rAttr(kArea,n) * frac_a%rAttr(ka,n)
+             elseif (k == 2) then
+                ic = c_lnd_ar
+                ca_a =  dom_a%data%rAttr(kArea,n) * frac_a%rAttr(kl,n)
+             elseif (k == 3) then
+                ic = c_ocn_ar
+                ca_a =  dom_a%data%rAttr(kArea,n) * frac_a%rAttr(ko,n)
+             elseif (k == 4) then
+                if (dom_a%data%rAttr(kLat,n) > 0.0_r8) then
+                   ic = c_inh_ar
+                else
+                   ic = c_ish_ar
+                endif
+                ca_a = dom_a%data%rAttr(kArea,n) * frac_a%rAttr(ki,n)
+             endif
+
+             nf = f_area  ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_a
+             nf = f_cblack; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_a*a2x_a%rAttr(index_a2x_Faxa_bcphidry,n) &
+                                                                        + ca_a*a2x_a%rAttr(index_a2x_Faxa_bcphodry,n) &
+                                                                        + ca_a*a2x_a%rAttr(index_a2x_Faxa_bcphiwet,n)
+             nf = f_corgnc; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_a*a2x_a%rAttr(index_a2x_Faxa_ocphidry,n) &
+                                                                        + ca_a*a2x_a%rAttr(index_a2x_Faxa_ocphodry,n) &
+                                                                        + ca_a*a2x_a%rAttr(index_a2x_Faxa_ocphiwet,n)
+          enddo
+       enddo
+    end if
+
+    if (present(do_x2a)) then
+       if (first_time) then
+          index_x2a_Fall_fco2_lnd = mct_aVect_indexRA(x2a_a,'Fall_fco2_lnd',perrWith='quiet')
+          index_x2a_Faoo_fco2_ocn = mct_aVect_indexRA(x2a_a,'Faoo_fco2_ocn',perrWith='quiet')
+       end if
+
+       lSize = mct_avect_lSize(x2a_a)
+       do n=1,lSize
+          do k=1,4
+             if (k == 1) then
+                ic = c_atm_as
+                ca_a = -dom_a%data%rAttr(kArea,n) * frac_a%rAttr(ka,n)
+             elseif (k == 2) then
+                ic = c_lnd_as
+                ca_a =  dom_a%data%rAttr(kArea,n) * frac_a%rAttr(kl,n)
+             elseif (k == 3) then
+                ic = c_ocn_as
+                ca_a =  dom_a%data%rAttr(kArea,n) * frac_a%rAttr(ko,n)
+             elseif (k == 4) then
+                if (dom_a%data%rAttr(kLat,n) > 0.0_r8) then
+                   ic = c_inh_as
+                else
+                   ic = c_ish_as
+                endif
+                ca_a = dom_a%data%rAttr(kArea,n) * frac_a%rAttr(ki,n)
+             endif
+
+             nf = f_area  ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_a
+             if (index_x2a_Fall_fco2_lnd /= 0) then
+                nf = f_csurf ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_a*x2a_a%rAttr(index_x2a_Fall_fco2_lnd,n)
+             end if
+             if (index_x2a_Faoo_fco2_ocn /= 0) then
+                nf = f_csurf ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_a*x2a_a%rAttr(index_x2a_Faoo_fco2_ocn,n)
+             end if
+
+          enddo
+       enddo
+    end if
+
+    first_time = .false.
+
+  end subroutine seq_diagBGC_atm_mct
+
+  !===============================================================================
+  !BOP ===========================================================================
+  !
+  ! !IROUTINE: seq_diagBGC_lnd_mct - compute global lnd input/output flux diagnostics
+  !
+  ! !DESCRIPTION:
+  !     Compute global lnd input/output flux diagnostics
+  !
+  ! !REVISION HISTORY:
+  !    2008-jul-10 - T. Craig - update
+  !
+  ! !INTERFACE: ------------------------------------------------------------------
+
+  subroutine seq_diagBGC_lnd_mct( lnd, frac_l, infodata, do_l2x, do_x2l)
+
+    type(component_type)    , intent(in)           :: lnd    ! component type for instance1
+    type(mct_aVect)         , intent(in)           :: frac_l ! frac bundle
+    type(seq_infodata_type) , intent(in)           :: infodata
+    logical                 , intent(in), optional :: do_l2x
+    logical                 , intent(in), optional :: do_x2l
+
+    !EOP
+
+    !----- local -----
+    type(mct_aVect), pointer :: l2x_l        ! model to drv bundle
+    type(mct_aVect), pointer :: x2l_l        ! drv to model bundle
+    type(mct_ggrid), pointer :: dom_l
+    integer(in)              :: n,ic,nf,ip ! generic index
+    integer(in)              :: kArea        ! index of area field in aVect
+    integer(in)              :: kl           ! fraction indices
+    integer(in)              :: lSize        ! size of aVect
+    real(r8)                 :: ca_l         ! area of a grid cell
+    logical,save             :: first_time    = .true.
+
+    !----- formats -----
+    character(*),parameter :: subName = '(seq_diagBGC_lnd_mct) '
+
+    !-------------------------------------------------------------------------------
+    !
+    !-------------------------------------------------------------------------------
+
+    !---------------------------------------------------------------------------
+    ! add values found in this bundle to the budget table
+    !---------------------------------------------------------------------------
+
+    dom_l => component_get_dom_cx(lnd)
+    l2x_l => component_get_c2x_cx(lnd)
+    x2l_l => component_get_x2c_cx(lnd)
+
+    ip = p_inst
+
+    kArea = mct_aVect_indexRA(dom_l%data,afldname)
+    kl    = mct_aVect_indexRA(frac_l,lfrinname)
+
+    if (present(do_l2x)) then
+       if (first_time) then
+          index_l2x_Fall_fco2_lnd = mct_aVect_indexRA(l2x_l,'Fall_fco2_lnd',perrWith='quiet')
+       end if
+
+       lSize = mct_avect_lSize(l2x_l)
+       ic = c_lnd_lr
+       do n=1,lSize
+          ca_l =  dom_l%data%rAttr(kArea,n) * frac_l%rAttr(kl,n)
+          nf = f_area  ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_l
+          if (index_x2a_Fall_fco2_lnd /= 0) then
+             nf = f_csurf ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_l*l2x_l%rAttr(index_l2x_Fall_fco2_lnd,n)
+          end if
+       end do
+    end if
+
+    if (present(do_x2l)) then
+       if (first_time) then
+          index_x2l_Faxa_bcphidry = mct_aVect_indexRA(x2l_l,'Faxa_bcphidry')
+          index_x2l_Faxa_bcphodry = mct_aVect_indexRA(x2l_l,'Faxa_bcphodry')
+          index_x2l_Faxa_bcphiwet = mct_aVect_indexRA(x2l_l,'Faxa_bcphiwet')
+          index_x2l_Faxa_ocphidry = mct_aVect_indexRA(x2l_l,'Faxa_ocphidry')
+          index_x2l_Faxa_ocphodry = mct_aVect_indexRA(x2l_l,'Faxa_ocphodry')
+          index_x2l_Faxa_ocphiwet = mct_aVect_indexRA(x2l_l,'Faxa_ocphiwet')
+       end if
+
+       lSize = mct_avect_lSize(x2l_l)
+       ic = c_lnd_ls
+       do n=1,lSize
+          ca_l =  dom_l%data%rAttr(kArea,n) * frac_l%rAttr(kl,n)
+          nf = f_area  ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_l
+          nf = f_cblack; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_l*x2l_l%rAttr(index_x2l_Faxa_bcphidry,n) &
+                                                                     + ca_l*x2l_l%rAttr(index_x2l_Faxa_bcphodry,n) &
+                                                                     + ca_l*x2l_l%rAttr(index_x2l_Faxa_bcphiwet,n)
+          nf = f_corgnc; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_l*x2l_l%rAttr(index_x2l_Faxa_ocphidry,n) &
+                                                                     + ca_l*x2l_l%rAttr(index_x2l_Faxa_ocphodry,n) &
+                                                                     + ca_l*x2l_l%rAttr(index_x2l_Faxa_ocphiwet,n)
+       end do
+    end if
+
+    first_time = .false.
+
+  end subroutine seq_diagBGC_lnd_mct
+
+  !===============================================================================
+  !BOP ===========================================================================
+  !
+  ! !IROUTINE: seq_diagBGC_rof_mct - compute global rof input/output flux diagnostics
+  !
+  ! !DESCRIPTION:
+  !     Compute global rof input/output flux diagnostics
+  !
+  ! !REVISION HISTORY:
+  !    2008-jul-10 - T. Craig - update
+  !
+  ! !INTERFACE: ------------------------------------------------------------------
+
+  subroutine seq_diagBGC_rof_mct( rof, frac_r, infodata)
+
+    type(component_type)    , intent(in) :: rof    ! component type for instance1
+    type(mct_aVect)         , intent(in) :: frac_r ! frac bundle
+    type(seq_infodata_type) , intent(in) :: infodata
+
+    !EOP
+
+    !----- local -----
+    type(mct_aVect), pointer :: r2x_r
+    type(mct_aVect), pointer :: x2r_r
+    type(mct_ggrid), pointer :: dom_r
+    integer(in)              :: n,ic,nf,ip      ! generic index
+    integer(in)              :: kArea             ! index of area field in aVect
+    integer(in)              :: lSize             ! size of aVect
+    real(r8)                 :: ca_r    ! area of a grid cell
+    logical,save             :: first_time    = .true.
+
+    !----- formats -----
+    character(*),parameter :: subName = '(seq_diagBGC_rof_mct) '
+
+    !-------------------------------------------------------------------------------
+    !
+    !-------------------------------------------------------------------------------
+
+    !---------------------------------------------------------------------------
+    ! add values found in this bundle to the budget table
+    !---------------------------------------------------------------------------
+
+    dom_r => component_get_dom_cx(rof)
+    r2x_r => component_get_c2x_cx(rof)
+    x2r_r => component_get_x2c_cx(rof)
+
+!    if (first_time) then
+!    end if
+
+    ip = p_inst
+    ic = c_rof_rr
+    kArea = mct_aVect_indexRA(dom_r%data,afldname)
+    lSize = mct_avect_lSize(x2r_r)
+    do n=1,lSize
+       ca_r =  dom_r%data%rAttr(kArea,n)
+    end do
+
+!    if (first_time) then
+!    end if
+
+    ip = p_inst
+    ic = c_rof_rs
+    kArea = mct_aVect_indexRA(dom_r%data,afldname)
+    lSize = mct_avect_lSize(r2x_r)
+    do n=1,lSize
+       ca_r =  dom_r%data%rAttr(kArea,n)
+    end do
+
+    first_time = .false.
+
+  end subroutine seq_diagBGC_rof_mct
+
+  !===============================================================================
+  !BOP ===========================================================================
+  !
+  ! !IROUTINE: seq_diagBGC_glc_mct - compute global glc input/output flux diagnostics
+  !
+  ! !DESCRIPTION:
+  !     Compute global glc input/output flux diagnostics
+  !
+  ! !REVISION HISTORY:
+  !    2008-jul-10 - T. Craig - update
+  !
+  ! !INTERFACE: ------------------------------------------------------------------
+
+  subroutine seq_diagBGC_glc_mct( glc, frac_g, infodata)
+
+    type(component_type)    , intent(in) :: glc    ! component type for instance1
+    type(mct_aVect)         , intent(in) :: frac_g ! frac bundle
+    type(seq_infodata_type) , intent(in) :: infodata
+
+    !EOP
+
+    !----- local -----
+    type(mct_aVect), pointer :: g2x_g
+    type(mct_aVect), pointer :: x2g_g
+    type(mct_ggrid), pointer :: dom_g
+    integer(in)              :: n,ic,nf,ip      ! generic index
+    integer(in)              :: kArea             ! index of area field in aVect
+    integer(in)              :: lSize             ! size of aVect
+    real(r8)                 :: ca_g ! area of a grid cell
+    logical,save             :: first_time = .true.
+
+    !----- formats -----
+    character(*),parameter :: subName = '(seq_diagBGC_glc_mct) '
+
+    !-------------------------------------------------------------------------------
+    !
+    !-------------------------------------------------------------------------------
+
+    !---------------------------------------------------------------------------
+    ! add values found in this bundle to the budget table
+    !---------------------------------------------------------------------------
+
+    dom_g => component_get_dom_cx(glc)
+    g2x_g => component_get_c2x_cx(glc)
+    x2g_g => component_get_x2c_cx(glc)
+
+!    if (first_time) then
+!    end if
+
+    ip = p_inst
+    ic = c_glc_gs
+    kArea = mct_aVect_indexRA(dom_g%data,afldname)
+    lSize = mct_avect_lSize(g2x_g)
+    do n=1,lSize
+       ca_g =  dom_g%data%rAttr(kArea,n)
+    end do
+
+    first_time = .false.
+
+  end subroutine seq_diagBGC_glc_mct
+
+  !BOP ===========================================================================
+  !
+  ! !IROUTINE: seq_diagBGC_ocn_mct - compute global ocn input/output flux diagnostics
+  !
+  ! !DESCRIPTION:
+  !     Compute global ocn input/output flux diagnostics
+  !
+  ! !REVISION HISTORY:
+  !    2008-jul-10 - T. Craig - update
+  !
+  ! !INTERFACE: ------------------------------------------------------------------
+
+  subroutine seq_diagBGC_ocn_mct( ocn, xao_o, frac_o, infodata, do_o2x, do_x2o, do_xao)
+
+    type(component_type)    , intent(in)          :: ocn    ! component type for instance1
+    type(mct_aVect)         , intent(in)          :: frac_o ! frac bundle
+    type(mct_aVect)         , intent(in)          :: xao_o
+    type(seq_infodata_type) , intent(in)          :: infodata
+    logical                 , intent(in),optional :: do_o2x
+    logical                 , intent(in),optional :: do_x2o
+    logical                 , intent(in),optional :: do_xao
+
+    !EOP
+
+    !----- local -----
+    type(mct_aVect), pointer :: o2x_o        ! model to drv bundle
+    type(mct_aVect), pointer :: x2o_o        ! drv to model bundle
+    type(mct_ggrid), pointer :: dom_o
+    integer(in)              :: n,nf,ic,ip ! generic index
+    integer(in)              :: kArea        ! index of area field in aVect
+    integer(in)              :: ko,ki  ! fraction indices
+    integer(in)              :: lSize        ! size of aVect
+    real(r8)                 :: ca_i,ca_o  ! area of a grid cell
+    logical,save             :: first_time    = .true.
+
+    !----- formats -----
+    character(*),parameter :: subName = '(seq_diagBGC_ocn_mct) '
+
+    !-------------------------------------------------------------------------------
+    !
+    !-------------------------------------------------------------------------------
+
+    if (.not. present(do_o2x) .and. &
+        .not. present(do_x2o) .and. &
+        .not. present(do_xao)) then
+       call shr_sys_abort(subName//"ERROR: must input a bundle")
+    end if
+
+    !---------------------------------------------------------------------------
+    ! add values found in this bundle to the budget table
+    !---------------------------------------------------------------------------
+
+    dom_o => component_get_dom_cx(ocn)
+    o2x_o => component_get_c2x_cx(ocn)
+    x2o_o => component_get_x2c_cx(ocn)
+
+    ip = p_inst
+
+    kArea = mct_aVect_indexRA(dom_o%data,afldname)
+    ko    = mct_aVect_indexRA(frac_o,ofracname)
+    ki    = mct_aVect_indexRA(frac_o,ifracname)
+
+    if (present(do_o2x)) then
+       if (first_time) then
+          index_o2x_Faoo_fco2_ocn = mct_aVect_indexRA(o2x_o,'Faoo_fco2_ocn',perrWith='quiet')
+       end if
+
+       lSize = mct_avect_lSize(o2x_o)
+       ic = c_ocn_or
+       do n=1,lSize
+          ca_o =  dom_o%data%rAttr(kArea,n) * frac_o%rAttr(ko,n)
+          ca_i =  dom_o%data%rAttr(kArea,n) * frac_o%rAttr(ki,n)
+          nf = f_area ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_o
+          if (index_x2a_Faoo_fco2_ocn /= 0) then
+             nf = f_csurf; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Faoo_fco2_ocn,n)
+          end if
+       end do
+    end if
+
+    if (present(do_x2o)) then
+       if (first_time) then
+          index_x2o_Faxa_bcphidry = mct_aVect_indexRA(x2o_o,'Faxa_bcphidry')
+          index_x2o_Faxa_bcphodry = mct_aVect_indexRA(x2o_o,'Faxa_bcphodry')
+          index_x2o_Faxa_bcphiwet = mct_aVect_indexRA(x2o_o,'Faxa_bcphiwet')
+          index_x2o_Faxa_ocphidry = mct_aVect_indexRA(x2o_o,'Faxa_ocphidry')
+          index_x2o_Faxa_ocphodry = mct_aVect_indexRA(x2o_o,'Faxa_ocphodry')
+          index_x2o_Faxa_ocphiwet = mct_aVect_indexRA(x2o_o,'Faxa_ocphiwet')
+       end if
+
+       lSize = mct_avect_lSize(x2o_o)
+       ic = c_ocn_os
+       do n=1,lSize
+          ca_o =  dom_o%data%rAttr(kArea,n) * frac_o%rAttr(ko,n)
+          ca_i =  dom_o%data%rAttr(kArea,n) * frac_o%rAttr(ki,n)
+          nf = f_area  ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_o
+
+          nf = f_cblack; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Faxa_bcphidry,n) &
+                                                                     + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Faxa_bcphodry,n) &
+                                                                     + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Faxa_bcphiwet,n)
+          nf = f_corgnc; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Faxa_ocphidry,n) &
+                                                                     + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Faxa_ocphodry,n) &
+                                                                     + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Faxa_ocphiwet,n)
+       end do
+    end if
+
+    first_time = .false.
+
+  end subroutine seq_diagBGC_ocn_mct
+
+  !===============================================================================
+  !BOP ===========================================================================
+  !
+  ! !IROUTINE: seq_diagBGC_ice_mct - compute global ice input/output flux diagnostics
+  !
+  ! !DESCRIPTION:
+  !     Compute global ice input/output flux diagnostics
+  !
+  ! !REVISION HISTORY:
+  !    2008-jul-10 - T. Craig - update
+  !
+  ! !INTERFACE: ------------------------------------------------------------------
+
+  subroutine seq_diagBGC_ice_mct( ice, frac_i, infodata, do_i2x, do_x2i)
+
+    type(component_type)    , intent(in)           :: ice    ! component type for instance1
+    type(mct_aVect)         , intent(in)           :: frac_i ! frac bundle
+    type(seq_infodata_type) , intent(in)           :: infodata
+    logical                 , intent(in), optional :: do_i2x
+    logical                 , intent(in), optional :: do_x2i
+
+    !EOP
+
+    !----- local -----
+    type(mct_aVect), pointer :: i2x_i        ! model to drv bundle
+    type(mct_aVect), pointer :: x2i_i        ! drv to model bundle
+    type(mct_ggrid), pointer :: dom_i
+    integer(in)              :: n,ic,nf,ip ! generic index
+    integer(in)              :: kArea        ! index of area field in aVect
+    integer(in)              :: kLat         ! index of lat field in aVect
+    integer(in)              :: ko,ki  ! fraction indices
+    integer(in)              :: lSize        ! size of aVect
+    real(r8)                 :: ca_i,ca_o ! area of a grid cell
+    logical,save             :: first_time        = .true.
+
+    !----- formats -----
+    character(*),parameter :: subName = '(seq_diagBGC_ice_mct) '
+
+    !-------------------------------------------------------------------------------
+
+    !---------------------------------------------------------------------------
+    ! add values found in this bundle to the budget table
+    !---------------------------------------------------------------------------
+
+    dom_i => component_get_dom_cx(ice)
+    i2x_i => component_get_c2x_cx(ice)
+    x2i_i => component_get_x2c_cx(ice)
+
+    ip = p_inst
+
+    kArea = mct_aVect_indexRA(dom_i%data,afldname)
+    kLat  = mct_aVect_indexRA(dom_i%data,latname)
+    ki    = mct_aVect_indexRA(frac_i,ifracname)
+    ko    = mct_aVect_indexRA(frac_i,ofracname)
+
+    if (present(do_i2x)) then
+!       if (first_time) then
+!       endif
+
+       lSize = mct_avect_lSize(i2x_i)
+       do n=1,lSize
+          if (dom_i%data%rAttr(kLat,n) > 0.0_r8) then
+             ic = c_inh_ir
+          else
+             ic = c_ish_ir
+          endif
+          ca_o =  dom_i%data%rAttr(kArea,n) * frac_i%rAttr(ko,n)
+          ca_i =  dom_i%data%rAttr(kArea,n) * frac_i%rAttr(ki,n)
+          nf = f_area  ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i
+       end do
+    end if
+
+    if (present(do_x2i)) then
+       if (first_time) then
+          index_x2i_Faxa_bcphidry = mct_aVect_indexRA(x2i_i,'Faxa_bcphidry')
+          index_x2i_Faxa_bcphodry = mct_aVect_indexRA(x2i_i,'Faxa_bcphodry')
+          index_x2i_Faxa_bcphiwet = mct_aVect_indexRA(x2i_i,'Faxa_bcphiwet')
+          index_x2i_Faxa_ocphidry = mct_aVect_indexRA(x2i_i,'Faxa_ocphidry')
+          index_x2i_Faxa_ocphodry = mct_aVect_indexRA(x2i_i,'Faxa_ocphodry')
+          index_x2i_Faxa_ocphiwet = mct_aVect_indexRA(x2i_i,'Faxa_ocphiwet')
+       end if
+
+       lSize = mct_avect_lSize(x2i_i)
+       do n=1,lSize
+          if (dom_i%data%rAttr(kLat,n) > 0.0_r8) then
+             ic = c_inh_is
+          else
+             ic = c_ish_is
+          endif
+          ca_o =  dom_i%data%rAttr(kArea,n) * frac_i%rAttr(ko,n)
+          ca_i =  dom_i%data%rAttr(kArea,n) * frac_i%rAttr(ki,n)
+          nf = f_area  ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i
+          nf = f_cblack; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i*x2i_i%rAttr(index_x2i_Faxa_bcphidry,n) &
+                                                                     + ca_i*x2i_i%rAttr(index_x2i_Faxa_bcphodry,n) &
+                                                                     + ca_i*x2i_i%rAttr(index_x2i_Faxa_bcphiwet,n)
+          nf = f_corgnc; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i*x2i_i%rAttr(index_x2i_Faxa_ocphidry,n) &
+                                                                     + ca_i*x2i_i%rAttr(index_x2i_Faxa_ocphodry,n) &
+                                                                     + ca_i*x2i_i%rAttr(index_x2i_Faxa_ocphiwet,n)
+       end do
+    end if
+
+    first_time = .false.
+
+  end subroutine seq_diagBGC_ice_mct
+
+  !===============================================================================
+  !BOP ===========================================================================
+  !
+  ! !IROUTINE: seq_diagBGC_preprint_mct - print global BGC budget diagnostics
+  !
+  ! !DESCRIPTION:
+  !   Print global BGC budget diagnostics.
+  !
+  ! !REVISION HISTORY:
+  !
+  ! !INTERFACE: ------------------------------------------------------------------
+
+  SUBROUTINE seq_diagBGC_preprint_mct
+
+    implicit none
+
+    ! !INPUT/OUTPUT PARAMETERS:
+
+    !EOP
+
+    !--- local ---
+    logical          :: sumdone     ! has a sum been computed yet
+
+    !-------------------------------------------------------------------------------
+
+    !-------------------------------------------------------------------------------
+    ! prepare instantaneous budget data for printing
+    !-------------------------------------------------------------------------------
+
+    sumdone = .false.
+
+    if (.not.sumdone) then
+      call seq_diagBGC_sum0_mct()
+      dataGpr = budg_dataG
+      sumdone = .true.
+
+      !  old budget normalizations (global area and 1e9 for carbon)
+      dataGpr = dataGpr/(4.0_r8*shr_const_pi)
+      dataGpr(f_c:f_c_end,:,:) = dataGpr(f_c:f_c_end,:,:) * 1.0e9_r8
+      dataGpr = dataGpr/budg_ns
+
+   endif
+
+  end subroutine seq_diagBGC_preprint_mct
+
+  !===============================================================================
+  !BOP ===========================================================================
+  !
+  ! !IROUTINE: seq_diagBGC_print_mct - print global BGC budget diagnostics
+  !
+  ! !DESCRIPTION:
+  !   Print global BGC budget diagnostics.
+  !
+  ! !REVISION HISTORY:
+  !
+  ! !INTERFACE: ------------------------------------------------------------------
+
+  SUBROUTINE seq_diagBGC_print_mct(EClock, ip, plev)
+
+    implicit none
+
+    ! !INPUT/OUTPUT PARAMETERS:
+
+    type(ESMF_Clock) , intent(in) :: EClock
+    integer          , intent(in) :: ip
+    integer          , intent(in) :: plev        ! print level
+
+    !EOP
+
+    !--- local ---
+    integer(in)      :: ic,nf,is    ! data array indicies
+    integer(in)      :: ica,icl,icn,ics,ico
+    integer(in)      :: icar,icxs,icxr,icas
+    integer(in)      :: cdate,sec   ! coded date, seconds
+    integer(in)      :: yr,mon,day  ! date
+    integer(in)      :: iam         ! pe number
+    character(len=40):: str         ! string
+
+    !----- formats -----
+    character(*),parameter :: subName = '(seq_diagBGC_print_mct) '
+    character(*),parameter :: F00   = "('(seq_diagBGC_print_mct) ',4a)"
+
+    !----- formats -----
+    character(*),parameter :: FAH="(4a,i9,i6)"
+    character(*),parameter :: FA0= "('    ',12x,6(6x,a8,1x))"
+    character(*),parameter :: FA1= "('    ',a12,6f15.8)"
+    character(*),parameter :: FA0r="('    ',12x,8(6x,a8,1x))"
+    character(*),parameter :: FA1r="('    ',a12,8f15.8)"
+!JW    character(*),parameter :: FA1r="('    ',a12,8e15.4)"
+
+    !-------------------------------------------------------------------------------
+
+    !-------------------------------------------------------------------------------
+    ! print instantaneous budget data
+    !-------------------------------------------------------------------------------
+
+    call seq_comm_setptrs(CPLID,iam=iam)
+    call seq_timemgr_EClockGetData(EClock,curr_yr=yr, &
+         curr_mon=mon,curr_day=day,curr_tod=sec)
+    cdate = yr*10000+mon*100+day
+
+   if (plev > 0) then
+      ! ---- doprint ---- doprint ---- doprint ----
+
+      ! ---------------------------------------------------------
+      ! ---- detail atm budgets and breakdown into components ---
+      ! ---------------------------------------------------------
+
+      if (plev >= 3) then
+         do ic = 1,2
+            if (ic == 1) then
+               ica = c_atm_ar
+               icl = c_lnd_ar
+               icn = c_inh_ar
+               ics = c_ish_ar
+               ico = c_ocn_ar
+               str = "ATM_to_CPL"
+            elseif (ic == 2) then
+               ica = c_atm_as
+               icl = c_lnd_as
+               icn = c_inh_as
+               ics = c_ish_as
+               ico = c_ocn_as
+               str = "CPL_TO_ATM"
+            else
+               call shr_sys_abort(subname//' ERROR in ic index code 411')
+            endif
+
+            write(logunit,*) ' '
+            write(logunit,FAH) subname,trim(str)//' CARBON BUDGET (kg/m2s*1e9): period = ',trim(pname(ip)),': date = ',cdate,sec
+            write(logunit,FA0) cname(ica),cname(icl),cname(icn),cname(ics),cname(ico),' *SUM*  '
+            do nf = f_c, f_c_end
+               write(logunit,FA1)    fname(nf),dataGpr(nf,ica,ip),dataGpr(nf,icl,ip), &
+                    dataGpr(nf,icn,ip),dataGpr(nf,ics,ip),dataGpr(nf,ico,ip), &
+                    dataGpr(nf,ica,ip)+dataGpr(nf,icl,ip)+ &
+                    dataGpr(nf,icn,ip)+dataGpr(nf,ics,ip)+dataGpr(nf,ico,ip)
+            enddo
+            write(logunit,FA1)    '   *SUM*'   ,sum(dataGpr(f_c:f_c_end,ica,ip)),sum(dataGpr(f_c:f_c_end,icl,ip)), &
+                 sum(dataGpr(f_c:f_c_end,icn,ip)),sum(dataGpr(f_c:f_c_end,ics,ip)),sum(dataGpr(f_c:f_c_end,ico,ip)), &
+                 sum(dataGpr(f_c:f_c_end,ica,ip))+sum(dataGpr(f_c:f_c_end,icl,ip))+ &
+                 sum(dataGpr(f_c:f_c_end,icn,ip))+sum(dataGpr(f_c:f_c_end,ics,ip))+sum(dataGpr(f_c:f_c_end,ico,ip))
+         enddo
+      endif   ! plev
+
+      ! ---------------------------------------------------------
+      ! ---- detail lnd/ocn/ice component budgets ----
+      ! ---------------------------------------------------------
+
+      if (plev >= 2) then
+         do ic = 1,4
+            if (ic == 1) then
+               icar = c_lnd_ar
+               icxs = c_lnd_ls
+               icxr = c_lnd_lr
+               icas = c_lnd_as
+               str = "LND"
+            elseif (ic == 2) then
+               icar = c_ocn_ar
+               icxs = c_ocn_os
+               icxr = c_ocn_or
+               icas = c_ocn_as
+               str = "OCN"
+            elseif (ic == 3) then
+               icar = c_inh_ar
+               icxs = c_inh_is
+               icxr = c_inh_ir
+               icas = c_inh_as
+               str = "ICE_NH"
+            elseif (ic == 4) then
+               icar = c_ish_ar
+               icxs = c_ish_is
+               icxr = c_ish_ir
+               icas = c_ish_as
+               str = "ICE_SH"
+            else
+               call shr_sys_abort(subname//' ERROR in ic index code 412')
+            endif
+
+            write(logunit,*) ' '
+            write(logunit,FAH) subname,trim(str)//' CARBON BUDGET (kg/m2s*1e9): period = ',trim(pname(ip)),': date = ',cdate,sec
+            write(logunit,FA0) cname(icar),cname(icxs),cname(icxr),cname(icas),' *SUM*  '
+            do nf = f_c, f_c_end
+               write(logunit,FA1)    fname(nf),-dataGpr(nf,icar,ip),dataGpr(nf,icxs,ip), &
+                    dataGpr(nf,icxr,ip),-dataGpr(nf,icas,ip), &
+                    -dataGpr(nf,icar,ip)+dataGpr(nf,icxs,ip)+ &
+                    dataGpr(nf,icxr,ip)-dataGpr(nf,icas,ip)
+            enddo
+            write(logunit,FA1)    '   *SUM*',-sum(dataGpr(f_c:f_c_end,icar,ip)),sum(dataGpr(f_c:f_c_end,icxs,ip)), &
+                 sum(dataGpr(f_c:f_c_end,icxr,ip)),-sum(dataGpr(f_c:f_c_end,icas,ip)), &
+                 -sum(dataGpr(f_c:f_c_end,icar,ip))+sum(dataGpr(f_c:f_c_end,icxs,ip))+ &
+                 sum(dataGpr(f_c:f_c_end,icxr,ip))-sum(dataGpr(f_c:f_c_end,icas,ip))
+
+         enddo
+      endif   ! plev
+
+      ! ---------------------------------------------------------
+      ! ---- net summary budgets ----
+      ! ---------------------------------------------------------
+
+      if (plev >= 1) then
+
+         write(logunit,*) ' '
+         write(logunit,FAH) subname,'NET CARBON BUDGET (kg/m2s*1e9): period = ',trim(pname(ip)),': date = ',cdate,sec
+         write(logunit,FA0r) '     atm','     lnd','     rof','     ocn','  ice nh','  ice sh','     glc',' *SUM*  '
+         do nf = f_c, f_c_end
+            write(logunit,FA1r)   fname(nf),dataGpr(nf,c_atm_ar,ip)+dataGpr(nf,c_atm_as,ip), &
+                 dataGpr(nf,c_lnd_lr,ip)+dataGpr(nf,c_lnd_ls,ip), &
+                 dataGpr(nf,c_rof_rr,ip)+dataGpr(nf,c_rof_rs,ip), &
+                 dataGpr(nf,c_ocn_or,ip)+dataGpr(nf,c_ocn_os,ip), &
+                 dataGpr(nf,c_inh_ir,ip)+dataGpr(nf,c_inh_is,ip), &
+                 dataGpr(nf,c_ish_ir,ip)+dataGpr(nf,c_ish_is,ip), &
+                 dataGpr(nf,c_glc_gr,ip)+dataGpr(nf,c_glc_gs,ip), &
+                 dataGpr(nf,c_atm_ar,ip)+dataGpr(nf,c_atm_as,ip)+ &
+                 dataGpr(nf,c_lnd_lr,ip)+dataGpr(nf,c_lnd_ls,ip)+ &
+                 dataGpr(nf,c_rof_rr,ip)+dataGpr(nf,c_rof_rs,ip)+ &
+                 dataGpr(nf,c_ocn_or,ip)+dataGpr(nf,c_ocn_os,ip)+ &
+                 dataGpr(nf,c_inh_ir,ip)+dataGpr(nf,c_inh_is,ip)+ &
+                 dataGpr(nf,c_ish_ir,ip)+dataGpr(nf,c_ish_is,ip)+ &
+                 dataGpr(nf,c_glc_gr,ip)+dataGpr(nf,c_glc_gs,ip)
+         enddo
+         write(logunit,FA1r)'   *SUM*',sum(dataGpr(f_c:f_c_end,c_atm_ar,ip))+sum(dataGpr(f_c:f_c_end,c_atm_as,ip)), &
+              sum(dataGpr(f_c:f_c_end,c_lnd_lr,ip))+sum(dataGpr(f_c:f_c_end,c_lnd_ls,ip)), &
+              sum(dataGpr(f_c:f_c_end,c_rof_rr,ip))+sum(dataGpr(f_c:f_c_end,c_rof_rs,ip)), &
+              sum(dataGpr(f_c:f_c_end,c_ocn_or,ip))+sum(dataGpr(f_c:f_c_end,c_ocn_os,ip)), &
+              sum(dataGpr(f_c:f_c_end,c_inh_ir,ip))+sum(dataGpr(f_c:f_c_end,c_inh_is,ip)), &
+              sum(dataGpr(f_c:f_c_end,c_ish_ir,ip))+sum(dataGpr(f_c:f_c_end,c_ish_is,ip)), &
+              sum(dataGpr(f_c:f_c_end,c_glc_gr,ip))+sum(dataGpr(f_c:f_c_end,c_glc_gs,ip)), &
+              sum(dataGpr(f_c:f_c_end,c_atm_ar,ip))+sum(dataGpr(f_c:f_c_end,c_atm_as,ip))+ &
+              sum(dataGpr(f_c:f_c_end,c_lnd_lr,ip))+sum(dataGpr(f_c:f_c_end,c_lnd_ls,ip))+ &
+              sum(dataGpr(f_c:f_c_end,c_rof_rr,ip))+sum(dataGpr(f_c:f_c_end,c_rof_rs,ip))+ &
+              sum(dataGpr(f_c:f_c_end,c_ocn_or,ip))+sum(dataGpr(f_c:f_c_end,c_ocn_os,ip))+ &
+              sum(dataGpr(f_c:f_c_end,c_inh_ir,ip))+sum(dataGpr(f_c:f_c_end,c_inh_is,ip))+ &
+              sum(dataGpr(f_c:f_c_end,c_ish_ir,ip))+sum(dataGpr(f_c:f_c_end,c_ish_is,ip))+ &
+              sum(dataGpr(f_c:f_c_end,c_glc_gr,ip))+sum(dataGpr(f_c:f_c_end,c_glc_gs,ip))
+      endif
+
+      write(logunit,*) ' '
+      ! ---- doprint ---- doprint ---- doprint ----
+   endif  ! plev > 0
+
+  end subroutine seq_diagBGC_print_mct
+
+  !===============================================================================
+  !BOP ===========================================================================
+  !
+  ! !IROUTINE: seq_diagBGC_avect_mct - print global budget diagnostics
+  !
+  ! !DESCRIPTION:
+  !   Print global diagnostics for AV/ID.
+  !
+  ! !REVISION HISTORY:
+  !
+  ! !INTERFACE: ------------------------------------------------------------------
+
+  SUBROUTINE seq_diagBGC_avect_mct(infodata, id, av, dom, gsmap, comment)
+
+    implicit none
+
+    ! !INPUT/OUTPUT PARAMETERS:
+
+    type(seq_infodata_type) , intent(in)           :: infodata
+    integer(in)             , intent(in)           :: ID
+    type(mct_aVect)         , intent(in)           :: av
+    type(mct_gGrid)         , pointer              :: dom
+    type(mct_gsMap)         , pointer              :: gsmap
+    character(len=*)        , intent(in), optional :: comment
+
+    !EOP
+
+    !--- local ---
+    logical                          :: bfbflag
+    integer(in)                      :: n,k         ! counters
+    integer(in)                      :: npts,nptsg  ! number of local/global pts in AV
+    integer(in)                      :: kflds       ! number of fields in AV
+    real(r8),                pointer :: sumbuf (:)  ! sum buffer
+    real(r8),                pointer :: maxbuf (:)  ! max buffer
+    real(r8),                pointer :: sumbufg(:)  ! sum buffer reduced
+    real(r8),                pointer :: maxbufg(:)  ! max buffer reduced
+    integer(i8),             pointer :: isumbuf (:) ! integer local sum
+    integer(i8),             pointer :: isumbufg(:) ! integer global sum
+    integer(i8)                      :: ihuge       ! huge
+    integer(in)                      :: mpicom      ! mpi comm
+    integer(in)                      :: iam         ! pe number
+    integer(in)                      :: km,ka       ! field indices
+    integer(in)                      :: ns          ! size of local AV
+    integer(in)                      :: rcode       ! allocate return code
+    real(r8),                pointer :: weight(:)   ! weight
+    real(r8), allocatable            :: weighted_data(:,:) ! weighted data
+    type(mct_string)                 :: mstring     ! mct char type
+    character(CL)                    :: lcomment    ! should be long enough
+    character(CL)                    :: itemc       ! string converted to char
+
+    !----- formats -----
+    character(*),parameter :: subName = '(seq_diagBGC_avect_mct) '
+    character(*),parameter :: F00   = "('(seq_diagBGC_avect_mct) ',4a)"
+
+    !-------------------------------------------------------------------------------
+    ! print instantaneous budget data
+    !-------------------------------------------------------------------------------
+
+    call seq_comm_setptrs(ID, mpicom=mpicom, iam=iam)
+    call seq_infodata_GetData(infodata, bfbflag=bfbflag)
+
+    lcomment = ''
+    if (present(comment)) then
+       lcomment=trim(comment)
+    endif
+
+    ns = mct_aVect_lsize(AV)
+    npts = mct_aVect_lsize(dom%data)
+    if (ns /= npts) call shr_sys_abort(trim(subname)//' ERROR: size of AV,dom')
+    km = mct_aVect_indexRA(dom%data,'mask')
+    ka = mct_aVect_indexRA(dom%data,afldname)
+    kflds = mct_aVect_nRattr(AV)
+    allocate(sumbufg(kflds),stat=rcode)
+    if (rcode /= 0) call shr_sys_abort(trim(subname)//' allocate sumbufg')
+
+    npts = mct_aVect_lsize(AV)
+    allocate(weight(npts),stat=rcode)
+    if (rcode /= 0) call shr_sys_abort(trim(subname)//' allocate weight')
+
+    weight(:) = 1.0_r8
+    do n = 1,npts
+       if (dom%data%rAttr(km,n) <= 1.0e-06_R8) then
+          weight(n) = 0.0_r8
+       else
+          weight(n) = dom%data%rAttr(ka,n)*shr_const_rearth*shr_const_rearth
+       endif
+    enddo
+
+    if (bfbflag) then
+       allocate(weighted_data(npts,kflds),stat=rcode)
+       if (rcode /= 0) call shr_sys_abort(trim(subname)//' allocate weighted_data')
+
+       weighted_data = 0.0_r8
+       do n = 1,npts
+          do k = 1,kflds
+             if (.not. shr_const_isspval(AV%rAttr(k,n))) then
+                weighted_data(n,k) = AV%rAttr(k,n)*weight(n)
+             endif
+          enddo
+       enddo
+
+       call shr_reprosum_calc (weighted_data, sumbufg, npts, npts, kflds, &
+                               commid=mpicom)
+
+       deallocate(weighted_data)
+
+    else
+       allocate(sumbuf(kflds),stat=rcode)
+       if (rcode /= 0) call shr_sys_abort(trim(subname)//' allocate sumbuf')
+       sumbuf = 0.0_r8
+
+       do n = 1,npts
+          do k = 1,kflds
+             if (.not. shr_const_isspval(AV%rAttr(k,n))) then
+                sumbuf(k) = sumbuf(k) + AV%rAttr(k,n)*weight(n)
+             endif
+          enddo
+       enddo
+
+       !--- global reduction ---
+       call shr_mpi_sum(sumbuf,sumbufg,mpicom,subname)
+
+       deallocate(sumbuf)
+
+    endif
+    deallocate(weight)
+
+    if (iam == 0) then
+       !      write(logunit,*) 'sdAV: *** writing ',trim(lcomment),': k fld min/max/sum ***'
+       do k = 1,kflds
+          call mct_aVect_getRList(mstring,k,AV)
+          itemc = mct_string_toChar(mstring)
+          call mct_string_clean(mstring)
+          if (len_trim(lcomment) > 0) then
+             write(logunit,100) 'xxx','sorr',k,sumbufg(k),trim(lcomment),trim(itemc)
+          else
+             write(logunit,101) 'xxx','sorr',k,sumbufg(k),trim(itemc)
+          endif
+       enddo
+       call shr_sys_flush(logunit)
+    endif
+
+    deallocate(sumbufg)
+
+100 format('comm_diag ',a3,1x,a4,1x,i3,es26.19,1x,a,1x,a)
+101 format('comm_diag ',a3,1x,a4,1x,i3,es26.19,1x,a)
+
+  end subroutine seq_diagBGC_avect_mct
+
+  !===============================================================================
+  !BOP ===========================================================================
+  !
+  ! !IROUTINE: seq_diagBGC_avloc_mct - print local budget diagnostics
+  !
+  ! !DESCRIPTION:
+  !   Print local diagnostics for AV/ID.
+  !
+  ! !REVISION HISTORY:
+  !
+  ! !INTERFACE: ------------------------------------------------------------------
+
+  SUBROUTINE seq_diagBGC_avloc_mct(av, comment)
+
+    implicit none
+
+    ! !INPUT/OUTPUT PARAMETERS:
+
+    type(mct_aVect) , intent(in)           :: av
+    character(len=*), intent(in), optional :: comment
+
+    !EOP
+
+    !--- local ---
+    integer(in)                      :: n,k         ! counters
+    integer(in)                      :: npts        ! number of local/global pts in AV
+    integer(in)                      :: kflds       ! number of fields in AV
+    real(r8),                pointer :: sumbuf (:)  ! sum buffer
+    type(mct_string)                 :: mstring     ! mct char type
+    character(CL)                    :: lcomment    ! should be long enough
+    character(CL)                    :: itemc       ! string converted to char
+
+    !----- formats -----
+    character(*),parameter :: subName = '(seq_diagBGC_avloc_mct) '
+    character(*),parameter :: F00   = "('(seq_diagBGC_avloc_mct) ',4a)"
+
+    !-------------------------------------------------------------------------------
+    ! print instantaneous budget data
+    !-------------------------------------------------------------------------------
+
+    lcomment = ''
+    if (present(comment)) then
+       lcomment=trim(comment)
+    endif
+
+    npts = mct_aVect_lsize(AV)
+    kflds = mct_aVect_nRattr(AV)
+    allocate(sumbuf(kflds))
+
+    sumbuf = 0.0_r8
+    do n = 1,npts
+       do k = 1,kflds
+          !      if (.not. shr_const_isspval(AV%rAttr(k,n))) then
+          sumbuf(k) = sumbuf(k) + AV%rAttr(k,n)
+          !      endif
+       enddo
+    enddo
+
+    do k = 1,kflds
+       call mct_aVect_getRList(mstring,k,AV)
+       itemc = mct_string_toChar(mstring)
+       call mct_string_clean(mstring)
+       if (len_trim(lcomment) > 0) then
+          write(logunit,100) 'xxx','sorr',k,sumbuf(k),trim(lcomment),trim(itemc)
+       else
+          write(logunit,101) 'xxx','sorr',k,sumbuf(k),trim(itemc)
+       endif
+    enddo
+    call shr_sys_flush(logunit)
+
+    deallocate(sumbuf)
+
+100 format('avloc_diag ',a3,1x,a4,1x,i3,es26.19,1x,a,1x,a)
+101 format('avloc_diag ',a3,1x,a4,1x,i3,es26.19,1x,a)
+
+  end subroutine seq_diagBGC_avloc_mct
+
+  !===============================================================================
+  !BOP ===========================================================================
+  !
+  ! !IROUTINE: seq_diagBGC_avdiff_mct - print global budget diagnostics
+  !
+  ! !DESCRIPTION:
+  !   Print global diagnostics for AV/ID.
+  !
+  ! !REVISION HISTORY:
+  !
+  ! !INTERFACE: ------------------------------------------------------------------
+
+  SUBROUTINE seq_diagBGC_avdiff_mct(AV1,AV2,ID,comment)
+
+    implicit none
+
+    ! !INPUT/OUTPUT PARAMETERS:
+
+    type(mct_aVect) , intent(in) :: AV1
+    type(mct_aVect) , intent(in) :: AV2
+    integer         , intent(in) :: ID
+    character(len=*), intent(in), optional :: comment
+
+    !EOP
+
+    !--- local ---
+    integer(in)      :: n,k,n1,k1,n2,k2         ! counters
+    integer(in)      :: iam         ! pe number
+    integer(in)      :: cnt         ! counter
+    real(r8)         :: adiff,rdiff ! diff values
+    type(mct_string) :: mstring     ! mct char type
+    character(len=64):: lcomment    ! should be long enough
+
+    !----- formats -----
+    character(*),parameter :: subName = '(seq_diagBGC_avdiff_mct) '
+    character(*),parameter :: F00   = "('(seq_diagBGC_avdiff_mct) ',4a)"
+
+    !-------------------------------------------------------------------------------
+    ! print instantaneous budget data
+    !-------------------------------------------------------------------------------
+
+    call seq_comm_setptrs(ID,iam=iam)
+
+    lcomment = ''
+    if (present(comment)) then
+       lcomment=trim(comment)
+    endif
+
+    n1 = mct_aVect_lsize(AV1)
+    k1 = mct_aVect_nRattr(AV1)
+    n2 = mct_aVect_lsize(AV2)
+    k2 = mct_aVect_nRattr(AV2)
+
+    if (n1 /= n2 .or. k1 /= k2) then
+       write(s_logunit,*) subname,trim(lcomment),' AV sizes different ',n1,n2,k1,k2
+       return
+    endif
+
+    do k = 1,k1
+       cnt = 0
+       adiff = 0.
+       rdiff = 0.
+       do n = 1,n1
+          if (AV1%rAttr(k,n) /= AV2%rAttr(k,n)) then
+             cnt = cnt + 1
+             adiff = max(adiff, abs(AV1%rAttr(k,n)-AV2%rAttr(k,n)))
+             rdiff = max(rdiff, abs(AV1%rAttr(k,n)-AV2%rAttr(k,n))/(abs(AV1%rAttr(k,n))+abs(AV2%rAttr(k,n))))
+          endif
+       enddo
+       if (cnt > 0) then
+          call mct_aVect_getRList(mstring,k,AV1)
+          write(s_logunit,*) subname,trim(lcomment),' AVs fld k diff ', &
+               iam,mct_string_toChar(mstring),cnt,adiff,rdiff, &
+               minval(AV1%rAttr(k,:)),minval(AV1%rAttr(k,:)), &
+               maxval(AV1%rAttr(k,:)),maxval(AV2%rAttr(k,:))
+          call mct_string_clean(mstring)
+       endif
+    enddo
+
+  end subroutine seq_diagBGC_avdiff_mct
+
+end module seq_diagBGC_mct

--- a/driver-mct/main/seq_diagBGC_mct.F90
+++ b/driver-mct/main/seq_diagBGC_mct.F90
@@ -33,6 +33,7 @@ module seq_diagBGC_mct
   use shr_sys_mod, only : shr_sys_abort, shr_sys_flush
   use shr_mpi_mod, only : shr_mpi_max, shr_mpi_sum
   use shr_const_mod, only: shr_const_rearth, shr_const_pi, shr_const_isspval
+  use shr_const_mod, only: shr_const_mwc, shr_const_mwco2
   use mct_mod, only: mct_ggrid, mct_avect, mct_avect_lsize, mct_string, &
        mct_string_tochar, mct_gsmap, mct_aVect_indexRA, MCT_AVECT_NRATTR, &
        mct_string_clean, mct_avect_getrlist
@@ -162,6 +163,8 @@ module seq_diagBGC_mct
   character(*),parameter :: modName = "(seq_diagBGC_mct) "
 
   integer(in),parameter :: debug = 0 ! internal debug level
+
+  real(r8),parameter :: CO2toC = shr_const_mwc/shr_const_mwco2
 
   ! !PRIVATE DATA MEMBERS
 
@@ -520,10 +523,12 @@ contains
 
              nf = f_area  ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_a
              if (index_x2a_Fall_fco2_lnd /= 0) then
-                nf = f_csurf ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_a*x2a_a%rAttr(index_x2a_Fall_fco2_lnd,n)
+                nf = f_csurf ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) &
+                                                    + ca_a*x2a_a%rAttr(index_x2a_Fall_fco2_lnd,n)*CO2toC
              end if
              if (index_x2a_Faoo_fco2_ocn /= 0) then
-                nf = f_csurf ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_a*x2a_a%rAttr(index_x2a_Faoo_fco2_ocn,n)
+                nf = f_csurf ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) &
+                                                    + ca_a*x2a_a%rAttr(index_x2a_Faoo_fco2_ocn,n)*CO2toC
              end if
 
           enddo
@@ -599,7 +604,8 @@ contains
           ca_l =  dom_l%data%rAttr(kArea,n) * frac_l%rAttr(kl,n)
           nf = f_area  ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_l
           if (index_x2a_Fall_fco2_lnd /= 0) then
-             nf = f_csurf ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_l*l2x_l%rAttr(index_l2x_Fall_fco2_lnd,n)
+             nf = f_csurf ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) &
+                                                 + ca_l*l2x_l%rAttr(index_l2x_Fall_fco2_lnd,n)*CO2toC
           end if
        end do
     end if
@@ -839,7 +845,8 @@ contains
           ca_i =  dom_o%data%rAttr(kArea,n) * frac_o%rAttr(ki,n)
           nf = f_area ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_o
           if (index_x2a_Faoo_fco2_ocn /= 0) then
-             nf = f_csurf; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Faoo_fco2_ocn,n)
+             nf = f_csurf; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) &
+                                                + (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Faoo_fco2_ocn,n)*CO2toC
           end if
        end do
     end if

--- a/driver-mct/main/seq_diagBGC_mct.F90
+++ b/driver-mct/main/seq_diagBGC_mct.F90
@@ -13,15 +13,10 @@
 !    Sign convention:
 !       positive value <=> the model is gaining water, heat, momentum, etc.
 !    Unit convention:
-!       water flux    ~ (kg/s)/m^2
-!       salt  flux    ~ (kg/s)/m^2
+!       carbon flux   ~ (kg-C/s)/m^2
 !
 ! !REVISION HISTORY:
-!    2012-aug-20 - T. Craig    - add rof component
-!    2008-jul-10 - T. Craig    - updated budget implementation
-!    2007-may-07 - B. Kauffman - initial port to cpl7.
-!    2002-nov-21 - R. Jacob    - initial port to cpl6.
-!    199x-mmm-dd - B. Kauffman - original version in cpl4.
+!    2022-apr-12 - J. Wolfe    - initial budget implementation
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
@@ -220,7 +215,7 @@ contains
   !    Zero out global budget diagnostic data.
   !
   ! !REVISION HISTORY:
-  !    2008-jul-11 - T. Craig - update
+  !    2022-apr-12 - J. Wolfe - initial budget implementation
   !
   ! !INTERFACE: ------------------------------------------------------------------
 
@@ -314,7 +309,7 @@ contains
   !    Accum out global budget diagnostic data.
   !
   ! !REVISION HISTORY:
-  !    2008-jul-11 - T. Craig - update
+  !    2022-apr-12 - J. Wolfe - initial budget implementation
   !
   ! !INTERFACE: ------------------------------------------------------------------
 
@@ -349,7 +344,7 @@ contains
   !    Sum local values to global on root
   !
   ! !REVISION HISTORY:
-  !    2008-jul-19 - T. Craig - update
+  !    2022-apr-12 - J. Wolfe - initial budget implementation
   !
   ! !INTERFACE: ------------------------------------------------------------------
 
@@ -385,7 +380,7 @@ contains
   !     Compute global atm input/output flux diagnostics
   !
   ! !REVISION HISTORY:
-  !    2008-jul-10 - T. Craig - update
+  !    2022-apr-12 - J. Wolfe - initial budget implementation
   !
   ! !INTERFACE: ------------------------------------------------------------------
 
@@ -548,7 +543,7 @@ contains
   !     Compute global lnd input/output flux diagnostics
   !
   ! !REVISION HISTORY:
-  !    2008-jul-10 - T. Craig - update
+  !    2022-apr-12 - J. Wolfe - initial budget implementation
   !
   ! !INTERFACE: ------------------------------------------------------------------
 
@@ -647,7 +642,7 @@ contains
   !     Compute global rof input/output flux diagnostics
   !
   ! !REVISION HISTORY:
-  !    2008-jul-10 - T. Craig - update
+  !    2022-apr-12 - J. Wolfe - initial budget implementation
   !
   ! !INTERFACE: ------------------------------------------------------------------
 
@@ -719,7 +714,7 @@ contains
   !     Compute global glc input/output flux diagnostics
   !
   ! !REVISION HISTORY:
-  !    2008-jul-10 - T. Craig - update
+  !    2022-apr-12 - J. Wolfe - initial budget implementation
   !
   ! !INTERFACE: ------------------------------------------------------------------
 
@@ -779,7 +774,7 @@ contains
   !     Compute global ocn input/output flux diagnostics
   !
   ! !REVISION HISTORY:
-  !    2008-jul-10 - T. Craig - update
+  !    2022-apr-12 - J. Wolfe - initial budget implementation
   !
   ! !INTERFACE: ------------------------------------------------------------------
 
@@ -890,7 +885,7 @@ contains
   !     Compute global ice input/output flux diagnostics
   !
   ! !REVISION HISTORY:
-  !    2008-jul-10 - T. Craig - update
+  !    2022-apr-12 - J. Wolfe - initial budget implementation
   !
   ! !INTERFACE: ------------------------------------------------------------------
 
@@ -995,6 +990,7 @@ contains
   !   Print global BGC budget diagnostics.
   !
   ! !REVISION HISTORY:
+  !    2022-apr-12 - J. Wolfe - initial budget implementation
   !
   ! !INTERFACE: ------------------------------------------------------------------
 
@@ -1033,6 +1029,7 @@ contains
   !   Print global BGC budget diagnostics.
   !
   ! !REVISION HISTORY:
+  !    2022-apr-12 - J. Wolfe - initial budget implementation
   !
   ! !INTERFACE: ------------------------------------------------------------------
 
@@ -1067,7 +1064,6 @@ contains
     character(*),parameter :: FA1= "('    ',a12,6f15.8)"
     character(*),parameter :: FA0r="('    ',12x,8(6x,a8,1x))"
     character(*),parameter :: FA1r="('    ',a12,8f15.8)"
-!JW    character(*),parameter :: FA1r="('    ',a12,8e15.4)"
 
     !-------------------------------------------------------------------------------
 
@@ -1349,7 +1345,6 @@ contains
     deallocate(weight)
 
     if (iam == 0) then
-       !      write(logunit,*) 'sdAV: *** writing ',trim(lcomment),': k fld min/max/sum ***'
        do k = 1,kflds
           call mct_aVect_getRList(mstring,k,AV)
           itemc = mct_string_toChar(mstring)

--- a/driver-mct/main/seq_diagBGC_mct.F90
+++ b/driver-mct/main/seq_diagBGC_mct.F90
@@ -128,7 +128,7 @@ module seq_diagBGC_mct
   integer(in),parameter :: f_c_end    = f_corgnc      ! Last index for carbon
 
   character(len=12),parameter :: fname(f_size) = &
-       (/'        area',' surf carbon','black carbon','orgnc carbon' /)
+       (/'        area',' surface co2','black carbon','orgnc carbon' /)
 
   !--- P for period ---
 
@@ -1017,9 +1017,9 @@ contains
     call seq_diagBGC_sum0_mct()
     dataGpr = budg_dataGBGC
 
-    !  old budget normalizations (global area and 1e9 for carbon)
+    !  old budget normalizations (global area and 1e10 for carbon)
     dataGpr = dataGpr/(4.0_r8*shr_const_pi)
-    dataGpr(f_c:f_c_end,:,:) = dataGpr(f_c:f_c_end,:,:) * 1.0e9_r8
+    dataGpr(f_c:f_c_end,:,:) = dataGpr(f_c:f_c_end,:,:) * 1.0e10_r8
     dataGpr = dataGpr/budg_nsBGC
 
   end subroutine seq_diagBGC_preprint_mct
@@ -1108,7 +1108,7 @@ contains
             endif
 
             write(logunit,*) ' '
-            write(logunit,FAH) subname,trim(str)//' CARBON BUDGET (kg/m2s*1e9): period = ',trim(pname(ip)),': date = ',cdate,sec
+            write(logunit,FAH) subname,trim(str)//' CARBON BUDGET (kg-C/m2s*1e10): period = ',trim(pname(ip)),': date = ',cdate,sec
             write(logunit,FA0) cname(ica),cname(icl),cname(icn),cname(ics),cname(ico),' *SUM*  '
             do nf = f_c, f_c_end
                write(logunit,FA1)    fname(nf),dataGpr(nf,ica,ip),dataGpr(nf,icl,ip), &
@@ -1158,7 +1158,7 @@ contains
             endif
 
             write(logunit,*) ' '
-            write(logunit,FAH) subname,trim(str)//' CARBON BUDGET (kg/m2s*1e9): period = ',trim(pname(ip)),': date = ',cdate,sec
+            write(logunit,FAH) subname,trim(str)//' CARBON BUDGET (kg-C/m2s*1e10): period = ',trim(pname(ip)),': date = ',cdate,sec
             write(logunit,FA0) cname(icar),cname(icxs),cname(icxr),cname(icas),' *SUM*  '
             do nf = f_c, f_c_end
                write(logunit,FA1)    fname(nf),-dataGpr(nf,icar,ip),dataGpr(nf,icxs,ip), &
@@ -1181,7 +1181,7 @@ contains
       if (plev >= 1) then
 
          write(logunit,*) ' '
-         write(logunit,FAH) subname,'NET CARBON BUDGET (kg/m2s*1e9): period = ',trim(pname(ip)),': date = ',cdate,sec
+         write(logunit,FAH) subname,'NET CARBON BUDGET (kg-C/m2s*1e10): period = ',trim(pname(ip)),': date = ',cdate,sec
          write(logunit,FA0r) '     atm','     lnd','     rof','     ocn','  ice nh','  ice sh','     glc',' *SUM*  '
          do nf = f_c, f_c_end
             write(logunit,FA1r)   fname(nf),dataGpr(nf,c_atm_ar,ip)+dataGpr(nf,c_atm_as,ip), &

--- a/driver-mct/main/seq_diag_mct.F90
+++ b/driver-mct/main/seq_diag_mct.F90
@@ -45,7 +45,8 @@ module seq_diag_mct
   use component_type_mod, only : COMPONENT_GET_DOM_CX, COMPONENT_GET_C2X_CX, &
        COMPONENT_GET_X2C_CX, COMPONENT_TYPE
   use seq_infodata_mod, only : seq_infodata_type, seq_infodata_getdata
-  use shr_reprosum_mod, only: shr_reprosum_calc
+  use shr_reprosum_mod, only : shr_reprosum_calc
+  use seq_diagBGC_mct,  only : seq_diagBGC_preprint_mct, seq_diagBGC_print_mct
 
   implicit none
   save
@@ -1833,6 +1834,7 @@ contains
        if (plev > 0) then
           ! ---- doprint ---- doprint ---- doprint ----
 
+          call seq_diagBGC_preprint_mct()
           if (.not.sumdone) then
              call seq_diag_sum0_mct()
              dataGpr = budg_dataG
@@ -2191,8 +2193,10 @@ contains
 
           endif
 
-          write(logunit,*) ' '
           ! ---- doprint ---- doprint ---- doprint ----
+
+          call seq_diagBGC_print_mct(EClock, ip, plev) 
+
        endif  ! plev > 0
     enddo  ! ip = 1,p_size
 

--- a/driver-mct/main/seq_diag_mct.F90
+++ b/driver-mct/main/seq_diag_mct.F90
@@ -1751,7 +1751,7 @@ contains
   !
   ! !INTERFACE: ------------------------------------------------------------------
 
-  SUBROUTINE seq_diag_print_mct(EClock, stop_alarm, &
+  SUBROUTINE seq_diag_print_mct(EClock, stop_alarm, do_bgc_budg, &
        budg_print_inst,  budg_print_daily,  budg_print_month,  &
        budg_print_ann,  budg_print_ltann,  budg_print_ltend, infodata)
 
@@ -1761,6 +1761,7 @@ contains
 
     type(ESMF_Clock) , intent(in) :: EClock
     logical          , intent(in) :: stop_alarm
+    logical          , intent(in) :: do_bgc_budg
     integer          , intent(in) :: budg_print_inst
     integer          , intent(in) :: budg_print_daily
     integer          , intent(in) :: budg_print_month
@@ -1834,7 +1835,9 @@ contains
        if (plev > 0) then
           ! ---- doprint ---- doprint ---- doprint ----
 
-          call seq_diagBGC_preprint_mct()
+          if (do_bgc_budg) then
+             call seq_diagBGC_preprint_mct()
+          endif
           if (.not.sumdone) then
              call seq_diag_sum0_mct()
              dataGpr = budg_dataG
@@ -2195,7 +2198,9 @@ contains
 
           ! ---- doprint ---- doprint ---- doprint ----
 
-          call seq_diagBGC_print_mct(EClock, ip, plev) 
+          if (do_bgc_budg) then
+             call seq_diagBGC_print_mct(EClock, ip, plev) 
+          endif
 
        endif  ! plev > 0
     enddo  ! ip = 1,p_size

--- a/driver-mct/main/seq_diag_mct.F90
+++ b/driver-mct/main/seq_diag_mct.F90
@@ -1834,11 +1834,13 @@ contains
 
        if (plev > 0) then
           ! ---- doprint ---- doprint ---- doprint ----
-
-          if (do_bgc_budg) then
-             call seq_diagBGC_preprint_mct()
-          endif
+  
           if (.not.sumdone) then
+
+             if (do_bgc_budg) then
+                call seq_diagBGC_preprint_mct()
+             endif
+
              call seq_diag_sum0_mct()
              dataGpr = budg_dataG
              sumdone = .true.

--- a/driver-mct/shr/seq_infodata_mod.F90
+++ b/driver-mct/shr/seq_infodata_mod.F90
@@ -134,6 +134,7 @@ MODULE seq_infodata_mod
      character(SHR_KIND_CL)  :: cpl_seq_option  ! coupler sequencing option
 
      logical                 :: do_budgets      ! do heat/water budgets diagnostics
+     logical                 :: do_bgc_budgets  ! do BGC budgets diagnostics
      logical                 :: do_histinit     ! write out initial history file
      integer                 :: budget_inst     ! instantaneous budget level
      integer                 :: budget_daily    ! daily budget level
@@ -385,6 +386,7 @@ CONTAINS
     character(SHR_KIND_CL) :: cpl_seq_option     ! coupler sequencing option
 
     logical                :: do_budgets         ! do heat/water budgets diagnostics
+    logical                :: do_bgc_budgets     ! do BGC budgets diagnostics
     logical                :: do_histinit        ! write out initial history file
     integer                :: budget_inst        ! instantaneous budget level
     integer                :: budget_daily       ! daily budget level
@@ -451,7 +453,7 @@ CONTAINS
          ice_gnam, rof_gnam, glc_gnam, wav_gnam,           &
          atm_gnam, lnd_gnam, ocn_gnam, iac_gnam, cpl_decomp,         &
          shr_map_dopole, vect_map, aoflux_grid, do_histinit,  &
-         do_budgets, drv_threading,                        &
+         do_budgets, do_bgc_budgets, drv_threading,        &
          budget_inst, budget_daily, budget_month,          &
          budget_ann, budget_ltann, budget_ltend,           &
          histaux_a2x,histaux_a2x1hri,histaux_a2x1hr,       &
@@ -545,6 +547,7 @@ CONTAINS
        cpl_decomp            = 0
        cpl_seq_option        = 'CESM1_MOD'
        do_budgets            = .false.
+       do_bgc_budgets        = .false.
        do_histinit           = .false.
        budget_inst           = 0
        budget_daily          = 0
@@ -680,6 +683,7 @@ CONTAINS
        infodata%cpl_decomp            = cpl_decomp
        infodata%cpl_seq_option        = cpl_seq_option
        infodata%do_budgets            = do_budgets
+       infodata%do_bgc_budgets        = do_bgc_budgets
        infodata%do_histinit           = do_histinit
        infodata%budget_inst           = budget_inst
        infodata%budget_daily          = budget_daily
@@ -999,8 +1003,8 @@ CONTAINS
        shr_map_dopole, vect_map, aoflux_grid, flux_epbalfact,             &
        nextsw_cday, precip_fact, flux_epbal, flux_albav,                  &
        glc_g2lupdate, atm_aero, run_barriers, esmf_map_flag,              &
-       do_budgets, do_histinit, drv_threading, flux_diurnal,              &
-       ocn_surface_flux_scheme, &
+       do_budgets, do_bgc_budgets, do_histinit, drv_threading,            &
+       flux_diurnal, ocn_surface_flux_scheme,                             &
        coldair_outbreak_mod, &
        flux_convergence, flux_max_iteration,                              &
        budget_inst, budget_daily, budget_month, wall_time_limit,          &
@@ -1098,6 +1102,7 @@ CONTAINS
     integer,                optional, intent(OUT) :: cpl_decomp              ! coupler decomp
     character(len=*),       optional, intent(OUT) :: cpl_seq_option          ! coupler sequencing option
     logical,                optional, intent(OUT) :: do_budgets              ! heat/water budgets
+    logical,                optional, intent(OUT) :: do_bgc_budgets          ! BGC budgets
     logical,                optional, intent(OUT) :: do_histinit             ! initial history file
     integer,                optional, intent(OUT) :: budget_inst             ! inst budget
     integer,                optional, intent(OUT) :: budget_daily            ! daily budget
@@ -1280,6 +1285,7 @@ CONTAINS
     if ( present(cpl_decomp)     ) cpl_decomp     = infodata%cpl_decomp
     if ( present(cpl_seq_option) ) cpl_seq_option = infodata%cpl_seq_option
     if ( present(do_budgets)     ) do_budgets     = infodata%do_budgets
+    if ( present(do_bgc_budgets) ) do_bgc_budgets = infodata%do_bgc_budgets
     if ( present(do_histinit)    ) do_histinit    = infodata%do_histinit
     if ( present(budget_inst)    ) budget_inst    = infodata%budget_inst
     if ( present(budget_daily)   ) budget_daily   = infodata%budget_daily
@@ -1544,8 +1550,8 @@ CONTAINS
        shr_map_dopole, vect_map, aoflux_grid, run_barriers,               &
        nextsw_cday, precip_fact, flux_epbal, flux_albav,                  &
        glc_g2lupdate, atm_aero, esmf_map_flag, wall_time_limit,           &
-       do_budgets, do_histinit, drv_threading, flux_diurnal,              &
-       precip_downscaling_method,                                         &
+       do_budgets, do_bgc_budgets, do_histinit, drv_threading,            &
+       flux_diurnal, precip_downscaling_method,                           &
        ocn_surface_flux_scheme,                                           &
        coldair_outbreak_mod,                                              &
        flux_convergence, flux_max_iteration,                              &
@@ -1642,6 +1648,7 @@ CONTAINS
     integer,                optional, intent(IN)    :: cpl_decomp              ! coupler decomp
     character(len=*),       optional, intent(IN)    :: cpl_seq_option          ! coupler sequencing option
     logical,                optional, intent(IN)    :: do_budgets              ! heat/water budgets
+    logical,                optional, intent(IN)    :: do_bgc_budgets          ! BGC budgets
     logical,                optional, intent(IN)    :: do_histinit             ! initial history file
     integer,                optional, intent(IN)    :: budget_inst             ! inst budget
     integer,                optional, intent(IN)    :: budget_daily            ! daily budget
@@ -1823,6 +1830,7 @@ CONTAINS
     if ( present(cpl_decomp)     ) infodata%cpl_decomp     = cpl_decomp
     if ( present(cpl_seq_option) ) infodata%cpl_seq_option = cpl_seq_option
     if ( present(do_budgets)     ) infodata%do_budgets     = do_budgets
+    if ( present(do_bgc_budgets) ) infodata%do_bgc_budgets = do_bgc_budgets
     if ( present(do_histinit)    ) infodata%do_histinit    = do_histinit
     if ( present(budget_inst)    ) infodata%budget_inst    = budget_inst
     if ( present(budget_daily)   ) infodata%budget_daily   = budget_daily
@@ -2127,6 +2135,7 @@ CONTAINS
     call shr_mpi_bcast(infodata%cpl_decomp,              mpicom)
     call shr_mpi_bcast(infodata%cpl_seq_option,          mpicom)
     call shr_mpi_bcast(infodata%do_budgets,              mpicom)
+    call shr_mpi_bcast(infodata%do_bgc_budgets,          mpicom)
     call shr_mpi_bcast(infodata%do_histinit,             mpicom)
     call shr_mpi_bcast(infodata%budget_inst,             mpicom)
     call shr_mpi_bcast(infodata%budget_daily,            mpicom)
@@ -2829,6 +2838,7 @@ CONTAINS
     write(logunit,F0A) subname,'cpl_seq_option           = ', trim(infodata%cpl_seq_option)
     write(logunit,F0S) subname,'cpl_decomp               = ', infodata%cpl_decomp
     write(logunit,F0L) subname,'do_budgets               = ', infodata%do_budgets
+    write(logunit,F0L) subname,'do_bgc_budgets           = ', infodata%do_bgc_budgets
     write(logunit,F0L) subname,'do_histinit              = ', infodata%do_histinit
     write(logunit,F0S) subname,'budget_inst              = ', infodata%budget_inst
     write(logunit,F0S) subname,'budget_daily             = ', infodata%budget_daily

--- a/share/util/shr_const_mod.F90
+++ b/share/util/shr_const_mod.F90
@@ -26,6 +26,9 @@ MODULE shr_const_mod
    real(R8),parameter :: SHR_CONST_RGAS    = SHR_CONST_AVOGAD*SHR_CONST_BOLTZ       ! Universal gas constant ~ J/K/kmole
    real(R8),parameter :: SHR_CONST_MWDAIR  = 28.966_R8       ! molecular weight dry air ~ kg/kmole
    real(R8),parameter :: SHR_CONST_MWWV    = 18.016_R8       ! molecular weight water vapor
+   real(R8),parameter :: SHR_CONST_MWC     = 12.0107_R8      ! molecular weight carbon
+   real(R8),parameter :: SHR_CONST_MWO     = 15.9994_R8      ! molecular weight oxygen
+   real(R8),parameter :: SHR_CONST_MWCO2   = 44.0095_R8      ! molecular weight carbon dioxide
    real(R8),parameter :: SHR_CONST_RDAIR   = SHR_CONST_RGAS/SHR_CONST_MWDAIR        ! Dry air gas constant     ~ J/K/kg
    real(R8),parameter :: SHR_CONST_RWV     = SHR_CONST_RGAS/SHR_CONST_MWWV          ! Water vapor gas constant ~ J/K/kg
    real(R8),parameter :: SHR_CONST_ZVIR    = (SHR_CONST_RWV/SHR_CONST_RDAIR)-1.0_R8 ! RWV/RDAIR - 1.0


### PR DESCRIPTION
Brings in a new coupler carbon budget which is implemented similarly to the current heat and water budgets, but in a separate source file. The output is intermingled with that from the other budgets, so that the monthly budget tables are all output before the annual ones, for example. The BGC budget is controlled overall by the BUDGETS flag found in env_run.xml but also has its own "do_bgc_budgets" flag that is included in the driver seq_infodata_inparm namelist and can be set by user_nl_cpl. By default it is off unless the compset includes BGC fluxes, in which case it is set to true.

[NML]
[BFB]