### PR TITLE
Update Chrysalis to OpenMPI-4.1.3

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1661,12 +1661,12 @@
         <command name="load">intel-mkl/2020.4.304-g2qaxzf</command>
       </modules>
       <modules compiler="intel" mpilib="openmpi">
-        <command name="load">openmpi/4.1.2-k5epdq6</command>
-        <command name="load">hdf5/1.8.16-kyyksst</command>
-        <command name="load">netcdf-c/4.4.1-rrkbpws</command>
-        <command name="load">netcdf-cxx/4.2-2hotooj</command>
-        <command name="load">netcdf-fortran/4.4.4-znpfscr</command>
-        <command name="load">parallel-netcdf/1.11.0-c6fn7rw</command>
+        <command name="load">openmpi/4.1.3-pin4k7o</command>
+        <command name="load">hdf5/1.10.7-eewgp6v</command>
+        <command name="load">netcdf-c/4.4.1-ihoo4zq</command>
+        <command name="load">netcdf-cxx/4.2-soitsxm</command>
+        <command name="load">netcdf-fortran/4.4.4-tplolxh</command>
+        <command name="load">parallel-netcdf/1.11.0-gvcfihh</command>
       </modules>
       <modules compiler="intel" mpilib="impi">
         <command name="load">intel-mpi/2019.9.304-tkzvizk</command>
@@ -1681,12 +1681,12 @@
         <command name="load">intel-mkl/2020.4.304-n3b5fye</command>
       </modules>
       <modules compiler="gnu" mpilib="openmpi">
-        <command name="load">openmpi/4.1.2-zdskwit</command>
-        <command name="load">hdf5/1.8.16-oh66njw</command>
-        <command name="load">netcdf-c/4.4.1-54pwnbt</command>
-        <command name="load">netcdf-cxx/4.2-zgdnfys</command>
-        <command name="load">netcdf-fortran/4.4.4-fkyjosv</command>
-        <command name="load">parallel-netcdf/1.11.0-x6vnnuz</command>
+        <command name="load">openmpi/4.1.3-sxfyy4k</command>
+        <command name="load">hdf5/1.10.7-j3zxncu</command>
+        <command name="load">netcdf-c/4.4.1-7ohuiwq</command>
+        <command name="load">netcdf-cxx/4.2-tkg465k</command>
+        <command name="load">netcdf-fortran/4.4.4-k2zu3y5</command>
+        <command name="load">parallel-netcdf/1.11.0-mirrcz7</command>
       </modules>
       <modules compiler="gnu" mpilib="impi">
         <command name="load">intel-mpi/2019.9.304-jdih7h5</command>


### PR DESCRIPTION
Update Chrysalis to OpenMPI-4.1.3

Addresses E3SM-Project/E3SM#4819

[BFB]