### PR TITLE
Allow up to 15 EAM history tapes

### DIFF
--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -1334,7 +1334,7 @@ Default: 5.e-13
 
 <!-- History and Initial Conditions Output -->
 
-<entry id="avgflag_pertape" type="char*1(10)"  category="history"
+<entry id="avgflag_pertape" type="char*1(15)"  category="history"
        group="cam_history_nl" valid_values="A,B,I,X,M" >
 Sets the averaging flag for all variables on a particular history file
 series. Valid values are:
@@ -1418,6 +1418,36 @@ List of fields to exclude from the 10th history file (by default the name
 of this file contains the string "h9").
 Default: none
 </entry>
+<entry id="fexcl11" type="char*24(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+List of fields to exclude from the 11th history file (by default the name
+of this file contains the string "h10").
+Default: none
+</entry>
+<entry id="fexcl12" type="char*24(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+List of fields to exclude from the 12th history file (by default the name
+of this file contains the string "h11").
+Default: none
+</entry>
+<entry id="fexcl13" type="char*24(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+List of fields to exclude from the 13th history file (by default the name
+of this file contains the string "h12").
+Default: none
+</entry>
+<entry id="fexcl14" type="char*24(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+List of fields to exclude from the 14th history file (by default the name
+of this file contains the string "h13").
+Default: none
+</entry>
+<entry id="fexcl15" type="char*24(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+List of fields to exclude from the 15th history file (by default the name
+of this file contains the string "h14").
+Default: none
+</entry>
 
 <entry id="fincl1" type="char*26(750)"  category="history"
        group="cam_history_nl" valid_values="" >
@@ -1489,6 +1519,36 @@ Same as <varname>fincl1</varname>, but for the 10th history file (by default
 the name of this file contains the string "h9").
 Default: none.
 </entry>
+<entry id="fincl11" type="char*26(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as <varname>fincl1</varname>, but for the 11th history file (by default
+the name of this file contains the string "h10").
+Default: none.
+</entry>
+<entry id="fincl12" type="char*26(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as <varname>fincl1</varname>, but for the 12th history file (by default
+the name of this file contains the string "h11").
+Default: none.
+</entry>
+<entry id="fincl13" type="char*26(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as <varname>fincl1</varname>, but for the 13th history file (by default
+the name of this file contains the string "h12").
+Default: none.
+</entry>
+<entry id="fincl14" type="char*26(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as <varname>fincl1</varname>, but for the 14th history file (by default
+the name of this file contains the string "h13").
+Default: none.
+</entry>
+<entry id="fincl15" type="char*26(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as <varname>fincl1</varname>, but for the 15th history file (by default
+the name of this file contains the string "h14").
+Default: none.
+</entry>
 
 <entry id="clubb_history" type="logical"  category="history"
        group="clubb_his_nl" valid_values="" >
@@ -1536,7 +1596,7 @@ Name of the IOP case so case specific adjustments can be made in CLUBB.
 Default: none.
 </entry>
 
-<entry id="collect_column_output" type="logical(10)" category="history"
+<entry id="collect_column_output" type="logical(15)" category="history"
    group="cam_history_nl" valid_values="">
 Collect all column data into a single field and output in ncol format,
 much faster than default when you have a lot of columns.
@@ -1593,6 +1653,26 @@ Same as <varname>fincl1lonlat</varname>, but for 9th history file.
        group="cam_history_nl" valid_values="" >
 Same as <varname>fincl1lonlat</varname>, but for 10th history file.
 </entry>
+<entry id="fincl11lonlat" type="char*128(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as <varname>fincl1lonlat</varname>, but for 11th history file.
+</entry>
+<entry id="fincl12lonlat" type="char*128(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as <varname>fincl1lonlat</varname>, but for 12th history file.
+</entry>
+<entry id="fincl13lonlat" type="char*128(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as <varname>fincl1lonlat</varname>, but for 13th history file.
+</entry>
+<entry id="fincl14lonlat" type="char*128(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as <varname>fincl1lonlat</varname>, but for 14th history file.
+</entry>
+<entry id="fincl15lonlat" type="char*128(750)"  category="history"
+       group="cam_history_nl" valid_values="" >
+Same as <varname>fincl1lonlat</varname>, but for 15th history file.
+</entry>
 
 
 <entry id="fwrtpr1" type="char*26(750)"  category="history"
@@ -1632,15 +1712,15 @@ the 6th history file.
 Default: none
 </entry>
 
-<entry id="hfilename_spec" type="char*256(10)"  category="history"
+<entry id="hfilename_spec" type="char*256(15)"  category="history"
        group="cam_history_nl" valid_values="" >
 
-Array of history filename specifiers.  The filenames of up to ten history
+Array of history filename specifiers.  The filenames of up to fifteen history
 output files can be controlled via this variable.  Filename specifiers give
 generic formats for the filenames with specific date and time components,
-file series number (0-9), and caseid, filled in when the files are
+file series number (0-14), and caseid, filled in when the files are
 created. The following strings are expanded when the filename is created:
-%c=caseid; %t=file series number (0-9); %y=year (normally 4 digits, more
+%c=caseid; %t=file series number (0-14); %y=year (normally 4 digits, more
 digits if needed); %m=month; %d=day; %s=seconds into current day; %%=%
 symbol.  Note that the caseid may be set using the namelist
 variable <varname>case_name</varname>.
@@ -1655,7 +1735,7 @@ in the specifier, it will be interpreted as a directory name and the
 corresponding directories will have to be created in the model execution
 directory (directory given to configure with -cam_exedir option) before
 model execution.  The first element is for the primary history file which
-is output by default as a monthly history file.  Entries 2 through 10 are
+is output by default as a monthly history file.  Entries 2 through 15 are
 user specified auxilliary output files.
 
 Defaults: "%c.cam2.h0.%y-%m.nc", "%c.cam2.h1.%y-%m-%d-%s.nc", ...,
@@ -1720,15 +1800,15 @@ include required AND optional fields on IC file.
 Default: FALSE
 </entry>
 
-<entry id="mfilt" type="integer(10)"  category="history"
+<entry id="mfilt" type="integer(15)"  category="history"
        group="cam_history_nl" valid_values="" >
 Array containing the maximum number of time samples written to a history
 file.  The first value applies to the primary history file, the second
 through sixth to the auxillary history files.
-Default: 1,30,30,30,30,30,30,30,30,30
+Default: 1,30,30,30,30,30,30,30,30,30,30,30,30,30,30
 </entry>
 
-<entry id="lcltod_start" type="integer(10)"  category="history"
+<entry id="lcltod_start" type="integer(15)"  category="history"
        group="cam_history_nl" valid_values="" >
 Array containing the starting time of day for local time history averaging. 
 Used in conjuction with lcltod_stop. If lcltod_stop is less than lcltod_start, 
@@ -1738,7 +1818,7 @@ applies to the primary hist. file, the second to the first aux. hist. file, etc.
 Default: none
 </entry>
 
-<entry id="lcltod_stop" type="integer(10)"  category="history"
+<entry id="lcltod_stop" type="integer(15)"  category="history"
        group="cam_history_nl" valid_values="" >
 Array containing the stopping time of day for local time history averaging. 
 Used in conjuction with lcltod_start. If lcltod_stop is less than lcltod_start, 
@@ -1748,7 +1828,7 @@ applies to the primary hist. file, the second to the first aux. hist. file, etc.
 Default: none
 </entry>
 
-<entry id="ndens" type="integer(10)"  category="history"
+<entry id="ndens" type="integer(15)"  category="history"
        group="cam_history_nl" valid_values="1,2" > 
 
 Array specifying the precision of real data written to each history file
@@ -1759,7 +1839,7 @@ Default: 2,2,2,2,2,2,2,2,2,2
 </entry>
 
 
-<entry id="nhtfrq" type="integer(10)"  category="history"
+<entry id="nhtfrq" type="integer(15)"  category="history"
        group="cam_history_nl" valid_values="" > 
 
 Array of write frequencies for each history file series.
@@ -1769,17 +1849,17 @@ Only the first file series may be a monthly average.  If
 timesteps.  If <varname>nhtfrq(i)</varname> &lt; 0, frequency is specified
 as number of hours.
 
-Default: 0,-24,-24,-24,-24,-24,-24,-24,-24,-24
+Default: 0,-24,-24,-24,-24,-24,-24,-24,-24,-24,-24,-24,-24,-24,-24
 </entry>
 
-<entry id="interpolate_output" type="logical(10)" category="history"
+<entry id="interpolate_output" type="logical(15)" category="history"
     group="cam_history_nl" valid_values="">
 If interpolate_output(k) = .true., then the k'th history file will be
 interpolated to a lat/lon grid before output.
 Default: .false.
 </entry>
 
-<entry id="interpolate_nlat" type="integer(10)" category="history"
+<entry id="interpolate_nlat" type="integer(15)" category="history"
     group="cam_history_nl" valid_values="">
 Size of latitude dimension of grid for interpolated output.
 If interpolate_nlat and interpolate_nlon are zero, reasonable values
@@ -1787,7 +1867,7 @@ will be chosen by the dycore based on the run resolution.
 Default: 0
 </entry>
 
-<entry id="interpolate_nlon" type="integer(10)" category="history"
+<entry id="interpolate_nlon" type="integer(15)" category="history"
     group="cam_history_nl" valid_values="">
 Size of longitude dimension of grid for interpolated output.
 If interpolate_nlat and interpolate_nlon are zero, reasonable values
@@ -1795,7 +1875,7 @@ will be chosen by the dycore based on the run resolution.
 Default: 0
 </entry>
 
-<entry id="interpolate_type" type="integer(10)" category="history"
+<entry id="interpolate_type" type="integer(15)" category="history"
     group="cam_history_nl" valid_values="0,1">
 Selects interpolation method for output on lat/lon grid.
 0: Use SE's native high-order method.
@@ -1803,7 +1883,7 @@ Selects interpolation method for output on lat/lon grid.
 Default: 1 (bilinear)
 </entry>
 
-<entry id="interpolate_gridtype" type="integer(10)" category="history"
+<entry id="interpolate_gridtype" type="integer(15)" category="history"
     group="cam_history_nl" valid_values="1,2,3">
 Selects output grid type for lat/lon interpolated output.
 1: Equally spaced, including poles (FV scalars output grid).

--- a/components/eam/src/control/cam_history.F90
+++ b/components/eam/src/control/cam_history.F90
@@ -486,6 +486,11 @@ CONTAINS
     character(len=fieldname_lenp2) :: fincl8(pflds)
     character(len=fieldname_lenp2) :: fincl9(pflds)
     character(len=fieldname_lenp2) :: fincl10(pflds)
+    character(len=fieldname_lenp2) :: fincl11(pflds)
+    character(len=fieldname_lenp2) :: fincl12(pflds)
+    character(len=fieldname_lenp2) :: fincl13(pflds)
+    character(len=fieldname_lenp2) :: fincl14(pflds)
+    character(len=fieldname_lenp2) :: fincl15(pflds)
 
     character(len=max_chars)       :: fincl1lonlat(pflds)
     character(len=max_chars)       :: fincl2lonlat(pflds)
@@ -497,6 +502,11 @@ CONTAINS
     character(len=max_chars)       :: fincl8lonlat(pflds)
     character(len=max_chars)       :: fincl9lonlat(pflds)
     character(len=max_chars)       :: fincl10lonlat(pflds)
+    character(len=max_chars)       :: fincl11lonlat(pflds)
+    character(len=max_chars)       :: fincl12lonlat(pflds)
+    character(len=max_chars)       :: fincl13lonlat(pflds)
+    character(len=max_chars)       :: fincl14lonlat(pflds)
+    character(len=max_chars)       :: fincl15lonlat(pflds)
 
     character(len=fieldname_len)   :: fexcl1(pflds)
     character(len=fieldname_len)   :: fexcl2(pflds)
@@ -508,6 +518,11 @@ CONTAINS
     character(len=fieldname_len)   :: fexcl8(pflds)
     character(len=fieldname_len)   :: fexcl9(pflds)
     character(len=fieldname_len)   :: fexcl10(pflds)
+    character(len=fieldname_len)   :: fexcl11(pflds)
+    character(len=fieldname_len)   :: fexcl12(pflds)
+    character(len=fieldname_len)   :: fexcl13(pflds)
+    character(len=fieldname_len)   :: fexcl14(pflds)
+    character(len=fieldname_len)   :: fexcl15(pflds)
 
     character(len=fieldname_lenp2) :: fwrtpr1(pflds)
     character(len=fieldname_lenp2) :: fwrtpr2(pflds)
@@ -519,6 +534,11 @@ CONTAINS
     character(len=fieldname_lenp2) :: fwrtpr8(pflds)
     character(len=fieldname_lenp2) :: fwrtpr9(pflds)
     character(len=fieldname_lenp2) :: fwrtpr10(pflds)
+    character(len=fieldname_lenp2) :: fwrtpr11(pflds)
+    character(len=fieldname_lenp2) :: fwrtpr12(pflds)
+    character(len=fieldname_lenp2) :: fwrtpr13(pflds)
+    character(len=fieldname_lenp2) :: fwrtpr14(pflds)
+    character(len=fieldname_lenp2) :: fwrtpr15(pflds)
 
     integer                        :: interpolate_nlat(size(interpolate_info))
     integer                        :: interpolate_nlon(size(interpolate_info))
@@ -529,14 +549,18 @@ CONTAINS
     namelist /cam_history_nl/ ndens, nhtfrq, mfilt, inithist, inithist_nsteps, &
          inithist_all, avgflag_pertape, empty_htapes, lcltod_start, lcltod_stop, &
          fincl1lonlat, fincl2lonlat, fincl3lonlat, fincl4lonlat, fincl5lonlat, &
-         fincl6lonlat, fincl7lonlat, fincl8lonlat, fincl9lonlat,               &
-         fincl10lonlat, collect_column_output, hfilename_spec,                 &
+         fincl6lonlat, fincl7lonlat, fincl8lonlat, fincl9lonlat, fincl10lonlat,&
+         fincl11lonlat,fincl12lonlat,fincl13lonlat,fincl14lonlat,fincl15lonlat,&
+         collect_column_output, hfilename_spec,                                &
          fincl1,  fincl2,  fincl3,  fincl4,  fincl5,                           &
          fincl6,  fincl7,  fincl8,  fincl9,  fincl10,                          &
+         fincl11, fincl12, fincl13, fincl14, fincl15,                          &
          fexcl1,  fexcl2,  fexcl3,  fexcl4,  fexcl5,                           &
          fexcl6,  fexcl7,  fexcl8,  fexcl9,  fexcl10,                          &
+         fexcl11, fexcl12, fexcl13, fexcl14, fexcl15,                          &
          fwrtpr1, fwrtpr2, fwrtpr3, fwrtpr4, fwrtpr5,                          &
          fwrtpr6, fwrtpr7, fwrtpr8, fwrtpr9, fwrtpr10,                         &
+         fwrtpr11,fwrtpr12,fwrtpr13,fwrtpr14,fwrtpr15,                         &
          interpolate_nlat, interpolate_nlon,                                   &
          interpolate_gridtype, interpolate_type, interpolate_output
 
@@ -576,6 +600,11 @@ CONTAINS
       fincl8(f)        = ' '         
       fincl9(f)        = ' '         
       fincl10(f)       = ' '         
+      fincl11(f)       = ' '         
+      fincl12(f)       = ' '         
+      fincl13(f)       = ' '         
+      fincl14(f)       = ' '         
+      fincl15(f)       = ' '         
       fincl1lonlat(f)  = ' '
       fincl2lonlat(f)  = ' '
       fincl3lonlat(f)  = ' '
@@ -586,6 +615,11 @@ CONTAINS
       fincl8lonlat(f)  = ' '
       fincl9lonlat(f)  = ' '
       fincl10lonlat(f) = ' '
+      fincl11lonlat(f) = ' '
+      fincl12lonlat(f) = ' '
+      fincl13lonlat(f) = ' '
+      fincl14lonlat(f) = ' '
+      fincl15lonlat(f) = ' '
       fexcl1(f)        = ' '
       fexcl2(f)        = ' '
       fexcl3(f)        = ' '
@@ -596,6 +630,11 @@ CONTAINS
       fexcl8(f)        = ' '
       fexcl9(f)        = ' '
       fexcl10(f)       = ' '
+      fexcl11(f)       = ' '
+      fexcl12(f)       = ' '
+      fexcl13(f)       = ' '
+      fexcl14(f)       = ' '
+      fexcl15(f)       = ' '
       fwrtpr1(f)       = ' '
       fwrtpr2(f)       = ' '
       fwrtpr3(f)       = ' '
@@ -606,6 +645,11 @@ CONTAINS
       fwrtpr8(f)       = ' '
       fwrtpr9(f)       = ' '
       fwrtpr10(f)      = ' '
+      fwrtpr11(f)      = ' '
+      fwrtpr12(f)      = ' '
+      fwrtpr13(f)      = ' '
+      fwrtpr14(f)      = ' '
+      fwrtpr15(f)      = ' '
     end do
 
     if (trim(history_namelist) /= 'cam_history_nl') then
@@ -636,6 +680,11 @@ CONTAINS
         fincl(f, 8) = fincl8(f)
         fincl(f, 9) = fincl9(f)
         fincl(f,10) = fincl10(f)
+        fincl(f,11) = fincl11(f)
+        fincl(f,12) = fincl12(f)
+        fincl(f,13) = fincl13(f)
+        fincl(f,14) = fincl14(f)
+        fincl(f,15) = fincl15(f)
 
         fincllonlat(f, 1) = fincl1lonlat(f)
         fincllonlat(f, 2) = fincl2lonlat(f)
@@ -647,6 +696,11 @@ CONTAINS
         fincllonlat(f, 8) = fincl8lonlat(f)
         fincllonlat(f, 9) = fincl9lonlat(f)
         fincllonlat(f,10) = fincl10lonlat(f)
+        fincllonlat(f,11) = fincl11lonlat(f)
+        fincllonlat(f,12) = fincl12lonlat(f)
+        fincllonlat(f,13) = fincl13lonlat(f)
+        fincllonlat(f,14) = fincl14lonlat(f)
+        fincllonlat(f,15) = fincl15lonlat(f)
 
         fexcl(f, 1) = fexcl1(f)
         fexcl(f, 2) = fexcl2(f)
@@ -658,6 +712,11 @@ CONTAINS
         fexcl(f, 8) = fexcl8(f)
         fexcl(f, 9) = fexcl9(f)
         fexcl(f,10) = fexcl10(f)
+        fexcl(f,11) = fexcl11(f)
+        fexcl(f,12) = fexcl12(f)
+        fexcl(f,13) = fexcl13(f)
+        fexcl(f,14) = fexcl14(f)
+        fexcl(f,15) = fexcl15(f)
 
         fwrtpr(f, 1) = fwrtpr1(f)
         fwrtpr(f, 2) = fwrtpr2(f)
@@ -669,6 +728,11 @@ CONTAINS
         fwrtpr(f, 8) = fwrtpr8(f)
         fwrtpr(f, 9) = fwrtpr9(f)
         fwrtpr(f,10) = fwrtpr10(f)
+        fwrtpr(f,11) = fwrtpr11(f)
+        fwrtpr(f,12) = fwrtpr12(f)
+        fwrtpr(f,13) = fwrtpr13(f)
+        fwrtpr(f,14) = fwrtpr14(f)
+        fwrtpr(f,15) = fwrtpr15(f)
       end do
 
       !

--- a/components/eam/src/control/cam_history_support.F90
+++ b/components/eam/src/control/cam_history_support.F90
@@ -33,7 +33,7 @@ module cam_history_support
 
   integer, parameter, public :: pflds  = 1000      ! max number of fields for namelist entries fincl and fexcl
                                                    ! also used in write restart
-  integer, parameter, public :: ptapes = 12        ! max number of tapes
+  integer, parameter, public :: ptapes = 17        ! max number of tapes
 
   ! A special symbol for declaring a field which has no vertical or
   ! non-grid dimensions. It is here (rather than cam_history) so that it


### PR DESCRIPTION
The "SPECIAL" v2 production runs require more than 10 EAM history output tapes (https://acme-climate.atlassian.net/wiki/spaces/EWCG/pages/1850376218/E3SMv2+history+variable+namelists+for+production+runs), exceeding the current limit (10 tapes). This PR includes changes to both the code and namelist variables and increases the limit to 15 tapes.

We should merge this to both maint-2.0 and master, but when I issued the PR for merging to maint-2.0 (https://github.com/E3SM-Project/E3SM/pull/4891), lots of unrelated commits were included (We only need the two commits in the present PR). I am not sure how to fix the PR to maint-2.0, so closed it for now.

The tests are successful and located at /lcrc/group/e3sm/ac.qtang/E3SMv2/test-output-maint-2.0.v2.NARRM.amip/tests.