### PR TITLE
remove duplicate config variables in ocean

### DIFF
--- a/components/mpas-framework/src/tools/registry/gen_inc.c
+++ b/components/mpas-framework/src/tools/registry/gen_inc.c
@@ -614,21 +614,12 @@ int parse_namelist_records_from_registry(ezxml_t registry)/*{{{*/
 
 			if(strncmp(nmlopttype, "real", 1024) == 0){
 				fortprintf(fd, "      real (kind=RKIND) :: %s = %lf\n", nmloptname, (double)atof(nmloptval));
-				fortprintf(fcd, "      real (kind=RKIND), pointer :: %s\n", nmloptname);
-				if (strstr(nmloptname, "config_") == nmloptname ) {
-                   fortprintf(fcd, "      real (kind=RKIND) :: varinp_%s\n", nmloptname+7);
-                }
+				fortprintf(fcd, "      real (kind=RKIND) :: %s\n", nmloptname);
 			} else if(strncmp(nmlopttype, "integer", 1024) == 0){
 				fortprintf(fd, "      integer :: %s = %d\n", nmloptname, atoi(nmloptval));
-				fortprintf(fcd, "      integer, pointer :: %s\n", nmloptname);
-				if (strstr(nmloptname, "config_") == nmloptname ) {
-				   fortprintf(fcd, "      integer :: varinp_%s\n", nmloptname+7);
-                }
+				fortprintf(fcd, "      integer :: %s\n", nmloptname);
 			} else if(strncmp(nmlopttype, "logical", 1024) == 0){
-				fortprintf(fcd, "      logical, pointer :: %s\n", nmloptname);
-				if (strstr(nmloptname, "config_") == nmloptname ) {
-				   fortprintf(fcd, "      logical :: varinp_%s\n", nmloptname+7);
-                }
+				fortprintf(fcd, "      logical :: %s\n", nmloptname);
 				if(strncmp(nmloptval, "true", 1024) == 0 || strncmp(nmloptval, ".true.", 1024) == 0){
 					fortprintf(fd, "      logical :: %s = .true.\n", nmloptname);
 				} else {
@@ -636,10 +627,7 @@ int parse_namelist_records_from_registry(ezxml_t registry)/*{{{*/
 				}
 			} else if(strncmp(nmlopttype, "character", 1024) == 0){
 					fortprintf(fd, "      character (len=StrKIND) :: %s = '%s'\n", nmloptname, nmloptval);
-					fortprintf(fcd, "      character (len=StrKIND), pointer :: %s\n", nmloptname);
-				    if (strstr(nmloptname, "config_") == nmloptname ) {
-				    	fortprintf(fcd, "      character (len=StrKIND) :: varinp_%s\n", nmloptname+7);
-                    }
+					fortprintf(fcd, "      character (len=StrKIND) :: %s\n", nmloptname);
 			}
 		}
 		fortprintf(fd, "\n");
@@ -728,10 +716,7 @@ int parse_namelist_records_from_registry(ezxml_t registry)/*{{{*/
 			nmloptname = ezxml_attr(nmlopt_xml, "name");
 
 			fortprintf(fd, "      call mpas_pool_add_config(%s, '%s', %s)\n", pool_name, nmloptname, nmloptname);
-			fortprintf(fcg, "      call mpas_pool_get_config(configPool, '%s', %s)\n", nmloptname, nmloptname);
-		    if (strstr(nmloptname, "config_") == nmloptname ) {
-			   fortprintf(fcg, "      call mpas_pool_get_config_scalar(configPool, '%s', varinp_%s)\n", nmloptname, nmloptname+7);
-            }
+			fortprintf(fcg, "      call mpas_pool_get_config_scalar(configPool, '%s', %s)\n", nmloptname, nmloptname);
 		}
 		fortprintf(fd, "\n");
 		fortprintf(fcg, "\n");

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_high_frequency_output.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_high_frequency_output.F
@@ -350,7 +350,6 @@ contains
          call mpas_pool_get_array(highFrequencyOutputAMPool, 'vertVelSFC', vertVelSFC)
 
          ! split explicit specific arrays
-         call mpas_pool_get_config(ocnConfigs, 'config_time_integrator', config_time_integrator)
          if ( config_time_integrator == trim('split_explicit') .or.  config_time_integrator == trim('split_implicit') ) then
            call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', normalBaroclinicVelocity, 1)
            call mpas_pool_get_array(statePool, 'normalBarotropicVelocity', normalBarotropicVelocity, 1)

--- a/components/mpas-ocean/src/driver/mpas_ocn_core.F
+++ b/components/mpas-ocean/src/driver/mpas_ocn_core.F
@@ -66,7 +66,7 @@ module ocn_core
 
       ierr = 0
 
-      call mpas_pool_get_config(domain % configs, 'config_ocean_run_mode', config_ocean_run_mode)
+      call mpas_pool_get_config_scalar(domain % configs, 'config_ocean_run_mode', config_ocean_run_mode)
 
       numThreads = mpas_threading_get_max_threads()
 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -1910,16 +1910,12 @@ module ocn_time_integration_split
                          'debugTracers' .and. &
                          config_reset_debugTracers_near_surface) then
 
-! varinp_reset_debugTracers_top_nLayers = config_reset_debugTracers_top_nLayers
-! note that varinp_... is the scalar analog to the config... input variables
-! OpenACC complains about the pointer config... version
-
                         !$omp parallel
                         !$omp do schedule(runtime) private(k, lat)
                         do iCell = 1, nCellsAll
 
                            ! Reset tracer1 to 2 in top n layers
-                           do k = minLevelCell(iCell), minLevelCell(iCell)+varinp_reset_debugTracers_top_nLayers-1
+                           do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers-1
                                 tracersGroupNew(1,k,iCell) = 2.0_RKIND
                            end do
 
@@ -1931,11 +1927,11 @@ module ocn_time_integration_split
                                 .or.lat>- 2.5.and.lat<  2.5 &
                                 .or.lat> 35.0.and.lat< 40.0 &
                                 .or.lat> 55.0.and.lat< 60.0 ) then
-                              do k = minLevelCell(iCell), minLevelCell(iCell)+varinp_reset_debugTracers_top_nLayers-1
+                              do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers-1
                                  tracersGroupNew(2,k,iCell) = 2.0_RKIND
                               end do
                            else
-                              do k = minLevelCell(iCell), minLevelCell(iCell)+varinp_reset_debugTracers_top_nLayers-1
+                              do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers-1
                                  tracersGroupNew(2,k,iCell) = 1.0_RKIND
                               end do
                            end if
@@ -1949,11 +1945,11 @@ module ocn_time_integration_split
                                 .or.lat> 10.0.and.lat< 15.0 &
                                 .or.lat> 30.0.and.lat< 35.0 &
                                 .or.lat> 50.0.and.lat< 55.0 ) then
-                              do k = minLevelCell(iCell), minLevelCell(iCell)+varinp_reset_debugTracers_top_nLayers-1
+                              do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers-1
                                  tracersGroupNew(3,k,iCell) = 2.0_RKIND
                               end do
                            else
-                              do k = minLevelCell(iCell), minLevelCell(iCell)+varinp_reset_debugTracers_top_nLayers-1
+                              do k = minLevelCell(iCell), minLevelCell(iCell)+config_reset_debugTracers_top_nLayers-1
                                  tracersGroupNew(3,k,iCell) = 1.0_RKIND
                               end do
                            end if

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -1453,8 +1453,8 @@ contains
       !$omp do schedule(runtime)
 #endif
       do iCell = 1, nCells
-         surfaceFluxAttenuationCoefficient(iCell) = varinp_flux_attenuation_coefficient
-         surfaceFluxAttenuationCoefficientRunoff(iCell) = varinp_flux_attenuation_coefficient_runoff
+         surfaceFluxAttenuationCoefficient(iCell) = config_flux_attenuation_coefficient
+         surfaceFluxAttenuationCoefficientRunoff(iCell) = config_flux_attenuation_coefficient_runoff
       end do
 #ifndef MPAS_OPENACC
       !$omp end do
@@ -2754,7 +2754,7 @@ contains
          velocityMagnitude = sqrt(kineticEnergyCell(minLevelCell(cell1),cell1) + kineticEnergyCell(minLevelCell(cell2),cell2))
          landIceEdgeFraction = 0.5_RKIND*(landIceFraction(cell1)+landIceFraction(cell2))
 
-         topDrag(iEdge) = - rho_sw * landIceEdgeFraction * varinp_land_ice_flux_topDragCoeff &
+         topDrag(iEdge) = - rho_sw * landIceEdgeFraction * config_land_ice_flux_topDragCoeff &
                           * velocityMagnitude * normalVelocity(minLevelEdgeBot(iEdge),iEdge)
 
       end do
@@ -2772,13 +2772,13 @@ contains
       do iCell = 1, nCellsAll
          ! the magnitude of the top drag is CD*u**2 = CD*(2*KE)
          topDragMag(iCell) = rho_sw * landIceFraction(iCell) &
-                           * 2.0_RKIND * varinp_land_ice_flux_topDragCoeff *  kineticEnergyCell(minLevelCell(iCell),iCell)
+                           * 2.0_RKIND * config_land_ice_flux_topDragCoeff *  kineticEnergyCell(minLevelCell(iCell),iCell)
 
          ! the friction velocity is the square root of the top drag + variance of tidal velocity
          ! (computed regardless of land-ice coverage)
-         landIceFrictionVelocity(iCell) = sqrt(varinp_land_ice_flux_topDragCoeff * &
+         landIceFrictionVelocity(iCell) = sqrt(config_land_ice_flux_topDragCoeff * &
                                    (2.0_RKIND * kineticEnergyCell(minLevelCell(iCell),iCell) &
-                                   + varinp_land_ice_flux_rms_tidal_velocity**2))
+                                   + config_land_ice_flux_rms_tidal_velocity**2))
       end do
 #ifndef MPAS_OPENACC
       !$omp end do
@@ -2795,7 +2795,7 @@ contains
          blTempScratch(iCell) = 0.0_RKIND
          blSaltScratch(iCell) = 0.0_RKIND
          do iLevel = minLevelCell(iCell), maxLevelCell(iCell)
-            dz = min(layerThickness(iLevel,iCell),varinp_land_ice_flux_boundaryLayerThickness-blThickness)
+            dz = min(layerThickness(iLevel,iCell),config_land_ice_flux_boundaryLayerThickness-blThickness)
             if(dz <= 0.0_RKIND) exit
             blTempScratch(iCell) = blTempScratch(iCell) + activeTracers(indexTval, iLevel, iCell)*dz
             blSaltScratch(iCell) = blSaltScratch(iCell) + activeTracers(indexSval, iLevel, iCell)*dz
@@ -2819,16 +2819,16 @@ contains
       do iCell = 1, nCellsAll
          landIceBoundaryLayerTracers(indexBLTval, iCell) = blTempScratch(iCell)
          landIceBoundaryLayerTracers(indexBLSval, iCell) = blSaltScratch(iCell)
-         if(varinp_land_ice_flux_boundaryLayerNeighborWeight > 0.0_RKIND) then
+         if(config_land_ice_flux_boundaryLayerNeighborWeight > 0.0_RKIND) then
             weightSum = 1.0_RKIND
             do i = 1, nEdgesOnCell(iCell)
                cell2 = cellsOnCell(i,iCell)
 
                landIceBoundaryLayerTracers(indexBLTval, iCell) = landIceBoundaryLayerTracers(indexBLTval, iCell) &
-                 + cellMask(minLevelCell(cell2),cell2)*varinp_land_ice_flux_boundaryLayerNeighborWeight*blTempScratch(cell2)
+                 + cellMask(minLevelCell(cell2),cell2)*config_land_ice_flux_boundaryLayerNeighborWeight*blTempScratch(cell2)
                landIceBoundaryLayerTracers(indexBLSval, iCell) = landIceBoundaryLayerTracers(indexBLSval, iCell) &
-                 + cellMask(minLevelCell(cell2),cell2)*varinp_land_ice_flux_boundaryLayerNeighborWeight*blSaltScratch(cell2)
-               weightSum = weightSum + cellMask(minLevelCell(cell2),cell2)*varinp_land_ice_flux_boundaryLayerNeighborWeight
+                 + cellMask(minLevelCell(cell2),cell2)*config_land_ice_flux_boundaryLayerNeighborWeight*blSaltScratch(cell2)
+               weightSum = weightSum + cellMask(minLevelCell(cell2),cell2)*config_land_ice_flux_boundaryLayerNeighborWeight
             end do
             landIceBoundaryLayerTracers(:, iCell) = landIceBoundaryLayerTracers(:, iCell)/weightSum
          end if
@@ -2848,9 +2848,9 @@ contains
          do iCell = 1, nCellsAll
             ! transfer coefficients from namelist
             landIceTracerTransferVelocities(indexHeatTransval, iCell) = landIceFrictionVelocity(iCell) &
-                                             * varinp_land_ice_flux_jenkins_heat_transfer_coefficient
+                                             * config_land_ice_flux_jenkins_heat_transfer_coefficient
             landIceTracerTransferVelocities(indexSaltTransval, iCell) = landIceFrictionVelocity(iCell) &
-                                             * varinp_land_ice_flux_jenkins_salt_transfer_coefficient
+                                             * config_land_ice_flux_jenkins_salt_transfer_coefficient
          end do
 #ifndef MPAS_OPENACC
          !$omp end do
@@ -2899,7 +2899,7 @@ contains
 #endif
       do iCell = 1, nCellsAll
          if(landIceMask(iCell) == 1) then
-            sfcFlxAttCoeff(iCell) = varinp_land_ice_flux_attenuation_coefficient
+            sfcFlxAttCoeff(iCell) = config_land_ice_flux_attenuation_coefficient
          end if
       end do
 #ifndef MPAS_OPENACC

--- a/components/mpas-ocean/src/shared/mpas_ocn_equation_of_state.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_equation_of_state.F
@@ -495,17 +495,17 @@ contains
       real (kind=RKIND) :: coeff_mushy
 
       if(inLandIceCavity) then
-         coeff_0 = varinp_land_ice_cavity_freezing_temperature_coeff_0
-         coeff_S = varinp_land_ice_cavity_freezing_temperature_coeff_S
-         coeff_p = varinp_land_ice_cavity_freezing_temperature_coeff_p
-         coeff_pS = varinp_land_ice_cavity_freezing_temperature_coeff_pS
+         coeff_0 = config_land_ice_cavity_freezing_temperature_coeff_0
+         coeff_S = config_land_ice_cavity_freezing_temperature_coeff_S
+         coeff_p = config_land_ice_cavity_freezing_temperature_coeff_p
+         coeff_pS = config_land_ice_cavity_freezing_temperature_coeff_pS
          coeff_mushy = 0.0_RKIND
       else
-         coeff_0 = varinp_open_ocean_freezing_temperature_coeff_0
-         coeff_S = varinp_open_ocean_freezing_temperature_coeff_S
-         coeff_p = varinp_open_ocean_freezing_temperature_coeff_p
-         coeff_pS = varinp_open_ocean_freezing_temperature_coeff_pS
-         az1_liq = varinp_open_ocean_freezing_temperature_coeff_mushy_az1_liq
+         coeff_0 = config_open_ocean_freezing_temperature_coeff_0
+         coeff_S = config_open_ocean_freezing_temperature_coeff_S
+         coeff_p = config_open_ocean_freezing_temperature_coeff_p
+         coeff_pS = config_open_ocean_freezing_temperature_coeff_pS
+         az1_liq = config_open_ocean_freezing_temperature_coeff_mushy_az1_liq
          coeff_mushy = 1.0_RKIND / az1_liq
       end if
 
@@ -541,13 +541,13 @@ contains
 
 
       if(inLandIceCavity) then
-         coeff_S = varinp_land_ice_cavity_freezing_temperature_coeff_S
-         coeff_pS = varinp_land_ice_cavity_freezing_temperature_coeff_pS
+         coeff_S = config_land_ice_cavity_freezing_temperature_coeff_S
+         coeff_pS = config_land_ice_cavity_freezing_temperature_coeff_pS
          coeff_mushy = 0.0_RKIND
       else
-         coeff_S = varinp_open_ocean_freezing_temperature_coeff_S
-         coeff_pS = varinp_open_ocean_freezing_temperature_coeff_pS
-         az1_liq = varinp_open_ocean_freezing_temperature_coeff_mushy_az1_liq
+         coeff_S = config_open_ocean_freezing_temperature_coeff_S
+         coeff_pS = config_open_ocean_freezing_temperature_coeff_pS
+         az1_liq = config_open_ocean_freezing_temperature_coeff_mushy_az1_liq
          coeff_mushy = 1.0_RKIND / az1_liq
       end if
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
@@ -104,14 +104,7 @@ module ocn_vel_self_attraction_loading
     real(kind=RKIND), dimension(:),   allocatable :: Snm_local, SnmRe_local, SnmIm_local
     real(kind=RKIND), dimension(:,:), allocatable :: Snm_local_reproSum, SnmRe_local_reproSum, SnmIm_local_reproSum
     real(kind=RKIND), dimension(:),   allocatable :: sshSmoothed
-    integer, pointer :: nCellsOwned
-    integer, pointer :: nCellsAll
-    real(kind=RKIND), dimension(:), pointer :: latCell
-    real(kind=RKIND), dimension(:), pointer :: lonCell
-    real(kind=RKIND), dimension(:), pointer :: areaCell
-    real(kind=RKIND), dimension(:), pointer :: distanceToCoast
     real(kind=RKIND), dimension(:), pointer :: coastalSmoothingFactor
-    real(kind=RKIND), pointer :: sphere_radius
     integer, dimension(:,:), allocatable :: blockIdxForward
     integer, dimension(:,:), allocatable :: blockIdxInverse
     integer :: nBlocks
@@ -848,8 +841,8 @@ contains
                 do iCell = 1,nCellsAll
                     complexExpRe(iCell,m+1)    = cos(real(m,RKIND)*lonCell(iCell))
                     complexExpIm(iCell,m+1)    = sin(real(m,RKIND)*lonCell(iCell))
-                    complexFactorRe(iCell,m+1) = complexExpRe(iCell,m+1) * areaCell(iCell)/sphere_radius**2
-                    complexFactorIm(iCell,m+1) = complexExpIm(iCell,m+1) * areaCell(iCell)/sphere_radius**2
+                    complexFactorRe(iCell,m+1) = complexExpRe(iCell,m+1) * areaCell(iCell)/sphereRadius**2
+                    complexFactorIm(iCell,m+1) = complexExpIm(iCell,m+1) * areaCell(iCell)/sphereRadius**2
                 enddo
             enddo
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
@@ -33,6 +33,7 @@ module ocn_vel_self_attraction_loading
     use ocn_diagnostics
     use ocn_diagnostics_variables
     use ocn_config
+    use ocn_mesh
     use netcdf
     use mpas_global_sum_mod
 #ifdef _MPI
@@ -611,7 +612,7 @@ contains
 
         ! Config variables
         type (block_type), pointer :: block_ptr
-        type (mpas_pool_type), pointer :: forcingPool, meshPool
+        type (mpas_pool_type), pointer :: forcingPool
 
         ! NetCDF and weights file variables
         integer :: toNcId, toNsDimId, toRowId, toColId, toSId
@@ -624,7 +625,7 @@ contains
         ! SHTns routine variables
         character(len=StrKIND) :: loadLoveFile
         integer :: mmax, mres, layout, norm
-        integer, pointer :: nphi, nlat
+        integer :: nphi, nlat
         real(dp),parameter :: pi=acos(-1.0_dp)
         real(dp), pointer :: cosTheta(:), sinTheta(:)
         real(dp) :: eps_polar
@@ -665,29 +666,14 @@ contains
           call mpas_log_write('config_use_self_attraction_loading = .true. requires config_use_tidal_potential_forcing = .true.' , MPAS_LOG_CRIT)
         endif
 
-        call mpas_pool_get_config(ocnConfigs, 'config_mpas_to_grid_weights_file', config_mpas_to_grid_weights_file)
-        call mpas_pool_get_config(ocnConfigs, 'config_grid_to_mpas_weights_file', config_grid_to_mpas_weights_file)
-        call mpas_pool_get_config(ocnConfigs, 'config_self_attraction_loading_compute_interval', config_self_attraction_loading_compute_interval)
-        call mpas_pool_get_config(ocnConfigs, 'config_nLatitude', nlat)
-        call mpas_pool_get_config(ocnConfigs, 'config_nLongitude', nphi)
-        call mpas_pool_get_config(ocnConfigs, 'config_ocean_run_mode', config_ocean_run_mode)
+        nlat = config_nLatitude
+        nphi = config_nLongitude
 
         block_ptr => domain % blocklist
-        do while(associated(block_ptr))
-          call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
-          call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
+        call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
 
-          call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsOwned)
-          call mpas_pool_get_dimension(meshPool, 'nCells', nCellsAll)
-          call mpas_pool_get_array(meshPool, 'latCell', latCell)
-          call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
-          call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-          call mpas_pool_get_array(meshPool, 'distanceToCoast', distanceToCoast)
-          call mpas_pool_get_config(meshPool, 'sphere_radius', sphere_radius)
-          call mpas_pool_get_array(forcingPool, 'coastalSmoothingFactor', coastalSmoothingFactor)
-
-          block_ptr => block_ptr % next
-        end do
+        call mpas_pool_get_array(forcingPool, 'coastalSmoothingFactor', &
+                                               coastalSmoothingFactor)
 
         ! Set up coastal ssh smoothing
         allocate(sshSmoothed(nCellsAll))
@@ -720,8 +706,6 @@ contains
 #ifndef USE_SHTNS
             call mpas_log_write('MPAS-Ocean must be compiled with USE_SHTNS=true for serial SAL option.', MPAS_LOG_CRIT)
 #endif
-
-            call mpas_pool_get_array(meshPool, 'indexToCellID', indexToCellID)
 
             ! Begin MPI portion
             call MPI_COMM_RANK( domain % dminfo % comm, curProc, err_tmp)


### PR DESCRIPTION
Removes the auto-generation of duplicate config scalars (varinp_name) that were introduced in a previous commit for safety when adding the get_config_scalar routine. 

This is bit for bit except with Intel which is performing a peculiar optimization in the time_integration_split routine with the config_btr_ weights. When these are pointers you get bit-for-bit with current master, but when they're scalars you get roundoff level changes even though the values of the weights are equivalent. I've been able to reproduce this effect on the current master using a local temp scalar instead of the pointer to demonstrate it's not a bug being introduced.

Note: the non-BFB behavior above was for mpas-o standalone, which uses a different optimization level for intel. Testing in E3SM shows BFB results with current master.

It was bit for bit on other compilers like nvhpc on Summit.

[BFB]