### PR TITLE
MPAS Standalone: Add OpenMP support to gnu-nersc

### DIFF
--- a/components/mpas-framework/Makefile
+++ b/components/mpas-framework/Makefile
@@ -445,11 +445,14 @@ gnu-nersc:
 	"CFLAGS_DEBUG = -g -m64" \
 	"CXXFLAGS_DEBUG = -g -m64" \
 	"LDFLAGS_DEBUG = -g -m64" \
+	"FFLAGS_OMP = -fopenmp" \
+	"CFLAGS_OMP = -fopenmp" \
 	"BUILD_TARGET = $(@)" \
 	"CORE = $(CORE)" \
 	"DEBUG = $(DEBUG)" \
 	"SERIAL = $(SERIAL)" \
 	"USE_PAPI = $(USE_PAPI)" \
+	"OPENMP = $(OPENMP)" \
 	"USE_SHTNS = $(USE_SHTNS)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI $(FILE_OFFSET) $(ZOLTAN_DEFINE)" )
 


### PR DESCRIPTION
For some reason this was omitted when OpenMP support was added 8 years ago: https://github.com/MPAS-Dev/MPAS/pull/445

This has become a problem in compass because we switched to building with OpenMP on by default: https://github.com/MPAS-Dev/compass/pull/364
Does not impact E3SM builds

[BFB]