### PR TITLE
add '-O1 -hfp0' flags for crayclang compiler

### DIFF
--- a/cime_config/machines/cmake_macros/crayclang_crusher.cmake
+++ b/cime_config/machines/cmake_macros/crayclang_crusher.cmake
@@ -5,6 +5,8 @@ if (compile_threaded)
   string(APPEND LDFLAGS " -fopenmp")
 endif()
 
+string(APPEND FFLAGS " -O1 -hfp0")
+
 string(APPEND SLIBS " -L$ENV{PNETCDF_PATH}/lib -lpnetcdf")
 set(NETCDF_PATH "$ENV{NETCDF_DIR}")
 set(PNETCDF_PATH "$ENV{PNETCDF_DIR}")


### PR DESCRIPTION
Change:

- adds '-O1 -hfp0' flags for crayclang to reduce NaN-related errors

This change updates only "crayclang_crusher.cmake"

Among 45 test cases in e3sm_developer test suite, 30 tests are passed. This PR is mainly for E3SM users who need to run E3SM on Crusher until the NaN value-related issue on Cray compiler is resolved.

[crayclang_testresults.txt](https://github.com/E3SM-Project/E3SM/files/8566388/crayclang_testresults.txt)
