### PR TITLE
run_e3sm script: Replace default case name and case group placeholders

### DIFF
--- a/run_e3sm.template.sh
+++ b/run_e3sm.template.sh
@@ -24,8 +24,10 @@ readonly PROJECT="e3sm"
 # Simulation
 readonly COMPSET="WCYCL1850"
 readonly RESOLUTION="ne30pg2_EC30to60E2r2"
-readonly CASE_NAME="v2.LR.piControl"
-readonly CASE_GROUP="v2.LR"
+# TODO: CHANGE the following CASE_NAME to desired values
+readonly CASE_NAME="your_casename"
+# If this is part of a simulation campaign, ask your group lead about using a case_group label
+readonly CASE_GROUP=""
 
 # Code and compilation
 readonly CHECKOUT="20210806"

--- a/run_e3sm.template.sh
+++ b/run_e3sm.template.sh
@@ -24,7 +24,7 @@ readonly PROJECT="e3sm"
 # Simulation
 readonly COMPSET="WCYCL1850"
 readonly RESOLUTION="ne30pg2_EC30to60E2r2"
-# TODO: CHANGE the following CASE_NAME to desired values
+# BEFORE RUNNING : CHANGE the following CASE_NAME to desired value
 readonly CASE_NAME="your_casename"
 # If this is part of a simulation campaign, ask your group lead about using a case_group label
 # readonly CASE_GROUP=""
@@ -262,7 +262,7 @@ create_newcase() {
 	else
 		${CODE_ROOT}/cime/scripts/create_newcase \
 			--case ${CASE_NAME} \
-			--case-group $(CASE_GROUP) \
+			--case-group ${CASE_GROUP} \
 			--output-root ${CASE_ROOT} \
 			--script-root ${CASE_SCRIPTS_DIR} \
 			--handle-preexisting-dirs u \

--- a/run_e3sm.template.sh
+++ b/run_e3sm.template.sh
@@ -27,7 +27,7 @@ readonly RESOLUTION="ne30pg2_EC30to60E2r2"
 # TODO: CHANGE the following CASE_NAME to desired values
 readonly CASE_NAME="your_casename"
 # If this is part of a simulation campaign, ask your group lead about using a case_group label
-readonly CASE_GROUP=""
+# readonly CASE_GROUP=""
 
 # Code and compilation
 readonly CHECKOUT="20210806"
@@ -247,18 +247,33 @@ create_newcase() {
 
     echo $'\n----- Starting create_newcase -----\n'
 
-    ${CODE_ROOT}/cime/scripts/create_newcase \
-        --case ${CASE_NAME} \
-        --case-group ${CASE_GROUP} \
-        --output-root ${CASE_ROOT} \
-        --script-root ${CASE_SCRIPTS_DIR} \
-        --handle-preexisting-dirs u \
-        --compset ${COMPSET} \
-        --res ${RESOLUTION} \
-        --machine ${MACHINE} \
-        --project ${PROJECT} \
-        --walltime ${WALLTIME} \
-        --pecount ${PELAYOUT}
+	if [[ -z "$CASE_GROUP" ]]; then
+		${CODE_ROOT}/cime/scripts/create_newcase \
+			--case ${CASE_NAME} \
+			--output-root ${CASE_ROOT} \
+			--script-root ${CASE_SCRIPTS_DIR} \
+			--handle-preexisting-dirs u \
+			--compset ${COMPSET} \
+			--res ${RESOLUTION} \
+			--machine ${MACHINE} \
+			--project ${PROJECT} \
+			--walltime ${WALLTIME} \
+			--pecount ${PELAYOUT}
+	else
+		${CODE_ROOT}/cime/scripts/create_newcase \
+			--case ${CASE_NAME} \
+			--case-group $(CASE_GROUP) \
+			--output-root ${CASE_ROOT} \
+			--script-root ${CASE_SCRIPTS_DIR} \
+			--handle-preexisting-dirs u \
+			--compset ${COMPSET} \
+			--res ${RESOLUTION} \
+			--machine ${MACHINE} \
+			--project ${PROJECT} \
+			--walltime ${WALLTIME} \
+			--pecount ${PELAYOUT}
+	fi
+	
 
     if [ $? != 0 ]; then
       echo $'\nNote: if create_newcase failed because sub-directory already exists:'


### PR DESCRIPTION
Replace default case name and case group placeholders.
This is required to avoid unwarranted usage of case_group that
interferes with aggregation of various production simulation campaigns.

[BFB]

Testing:
I was able to run ./create_newcase with --case-group "" as defined.