### PR TITLE
Differentiate input and input/output streams in MPAS stream manager

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -130,33 +130,31 @@ module li_core
 
       if (config_do_restart) then
          call mpas_log_write("This is a restart: read stream 'restart'.")
+         call mpas_timer_start('io_read', .false.)
          call mpas_stream_mgr_read(domain % streamManager, streamID='restart', ierr=err_tmp)
+         call mpas_timer_stop('io_read')
          err = ior(err, err_tmp)
+         call mpas_timer_start('reset_io_alarms', .false.)
+         call MPAS_stream_mgr_reset_alarms(domain % streamManager, streamID='restart', ierr=err_tmp)
+         err = ior(err, err_tmp)
+         call mpas_timer_stop('reset_io_alarms')
       else
-         call mpas_log_write("This is not a restart: read stream 'input'.")
-         call mpas_stream_mgr_read(domain % streamManager, streamID='input', ierr=err_tmp)
+         call mpas_log_write("This is not a restart: read input streams with alarm ringing at initial time.")
+         call mpas_log_write("  (Streams with input_interval='initial_only', " // &
+                             "plus streams whose input_interval matches the start time.)")
+         call mpas_timer_start('io_read', .false.)
+         call mpas_stream_mgr_read(domain % streamManager, readInputOutputStreams=.false., ierr=err_tmp)
+         call mpas_timer_stop('io_read')
          err = ior(err, err_tmp)
+         call mpas_timer_start('reset_io_alarms', .false.)
+         call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_INPUT, ierr=err_tmp)
+         err = ior(err, err_tmp)
+         call mpas_timer_stop('reset_io_alarms')
       end if
-      call MPAS_stream_mgr_reset_alarms(domain % streamManager, streamID='restart', ierr=err_tmp)
-      err = ior(err, err_tmp)
-      call MPAS_stream_mgr_reset_alarms(domain % streamManager, streamID='input', ierr=err_tmp)
-      err = ior(err, err_tmp)
+      call mpas_timer_start('reset_io_alarms', .false.)
       call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_OUTPUT, ierr=err_tmp)
       err = ior(err, err_tmp)
-
-      !
-      ! Read the remaining input streams
-      !
-      call mpas_log_write("Looking for other input streams set for 'initial_only'.")
-      call mpas_timer_start('io_read', .false.)
-      call mpas_stream_mgr_read(domain % streamManager, ierr=err_tmp)
-      err = ior(err, err_tmp)
-      call mpas_timer_stop('io_read')
-      call mpas_timer_start('reset_io_alarms', .false.)
-      call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_INPUT, ierr=err_tmp)
-      err = ior(err, err_tmp)
       call mpas_timer_stop('reset_io_alarms')
-      call mpas_log_write("Finished reading 'initial_only' input streams.")
 
       !
       ! Read time-varying inputs, if present (i.e., forcing)
@@ -170,10 +168,10 @@ module li_core
       do while (associated(stream_cursor))
          if (stream_cursor % direction == MPAS_STREAM_INPUT) then
             ! Only consider streams of direction input (don't consider input/output streams)
-            if ((trim(stream_cursor % name) == 'input') .or. &
-                (trim(stream_cursor % name) == 'restart')) then
-               ! Don't attempt to interact with these two special streams
-               ! (even though restart is not type input, including to be safe)
+            if (trim(stream_cursor % name) == 'restart') then
+               ! Don't want to read the special 'restart' stream here
+               ! Note could also use the readInputOutputStreams optional argument to mpas_stream_mgr_read below instead.
+               ! That would provide more general behavior of ignoring any INPUT_OUTPUT stream, not just 'restart'.
                stream_cursor => stream_cursor % next
                cycle
             endif

--- a/components/mpas-framework/src/framework/mpas_stream_manager.F
+++ b/components/mpas-framework/src/framework/mpas_stream_manager.F
@@ -3438,9 +3438,13 @@ module mpas_stream_manager
     !>  that require saving of the actualWhen time.  Attempts to use i/o error
     !>  codes to ignore streams without xtime were found to be unreliable due to
     !>  pervasive occurrence of the generic MPAS_IO_ERR_PIO error.
+    !>  The optional output argument "readInputOutputStreams" provides the ability
+    !>  to include or exclude streams with the INPUT_OUTPUT direction.  There may
+    !>  be situations where it is desired to only read strictly direction INPUT
+    !>  streams.  The default value is .true. for backwards compatibility.
     !
     !-----------------------------------------------------------------------
-    subroutine MPAS_stream_mgr_read(manager, streamID, timeLevel, mgLevel, rightNow, when, whence, saveActualWhen, ierr) !{{{
+    subroutine MPAS_stream_mgr_read(manager, streamID, timeLevel, mgLevel, rightNow, when, whence, saveActualWhen, readInputOutputStreams, ierr) !{{{
 
         implicit none
 
@@ -3452,6 +3456,7 @@ module mpas_stream_manager
         character (len=*), intent(in), optional :: when
         integer, intent(in), optional :: whence
         logical, intent(in), optional :: saveActualWhen
+        logical, intent(in), optional :: readInputOutputStreams
         integer, intent(out), optional :: ierr
 
         type (MPAS_stream_list_type), pointer :: stream_cursor
@@ -3465,6 +3470,7 @@ module mpas_stream_manager
         type (MPAS_Time_type) :: now_time 
         character (len=StrKIND) :: actualWhen_local
         logical :: local_saveActualWhen
+        logical :: local_readInputOutputStreams
         type (MPAS_Time_type) :: actualWhen_time
         integer :: threadNum
         logical :: readStreams
@@ -3516,6 +3522,12 @@ module mpas_stream_manager
             local_saveActualWhen = .false.
         end if
 
+        if (present(readInputOutputStreams)) then
+            local_readInputOutputStreams = readInputOutputStreams
+        else
+            local_readInputOutputStreams = .true.
+        end if
+
         if ( threadNum == 0 ) then
            !
            ! If a stream is specified, we process just that stream; otherwise,
@@ -3528,8 +3540,17 @@ module mpas_stream_manager
                    STREAM_DEBUG_WRITE('-- Handling read of stream '//trim(stream_cursor % name))
    
                    ! Verify that the stream is an input stream
-                   if (stream_cursor % direction == MPAS_STREAM_INPUT .or. stream_cursor % direction == MPAS_STREAM_INPUT_OUTPUT) then
-                      readStreams = .true.
+                   if (local_readInputOutputStreams) then
+                      if (stream_cursor % direction == MPAS_STREAM_INPUT .or. stream_cursor % direction == MPAS_STREAM_INPUT_OUTPUT) then
+                         readStreams = .true.
+                      endif
+                   else
+                      if (stream_cursor % direction == MPAS_STREAM_INPUT) then
+                         readStreams = .true.
+                      endif
+                   endif
+
+                   if (readStreams) then
                       if (local_saveActualWhen) then
                          call read_stream(manager, stream_cursor, local_timeLevel, local_mgLevel, local_rightNow, local_when, &
                                        local_whence, actualWhen_local, local_ierr)
@@ -3547,19 +3568,33 @@ module mpas_stream_manager
 
                if ( .not. readStreams ) then
                    STREAM_ERROR_WRITE('No input stream matching '//trim(streamID)//' exists in call to MPAS_stream_mgr_read().')
+                   if (.not. local_readInputOutputStreams) then
+                      STREAM_ERROR_WRITE('This may be because requested stream is direction INPUT/OUTPUT but only streams with')
+                      STREAM_ERROR_WRITE(' strictly INPUT direction were requested by this call.')
+                   endif
                    if (present(ierr)) ierr = MPAS_STREAM_MGR_ERROR
                    return 
                end if
-           else
+           else  ! try to read any stream of input direction
                nullify(stream_cursor)
                stream_cursor => manager % streams % head
                do while (associated(stream_cursor))
                    STREAM_DEBUG_WRITE('-- Handling read of stream '//trim(stream_cursor % name))
-   
+
+                   ! Determine if we should attempt this stream
+                   readStreams = .false.
+                   if (local_readInputOutputStreams) then
+                      if (stream_cursor % direction == MPAS_STREAM_INPUT .or. stream_cursor % direction == MPAS_STREAM_INPUT_OUTPUT) then
+                         readStreams = .true.
+                      endif
+                   else
+                      if (stream_cursor % direction == MPAS_STREAM_INPUT) then
+                         readStreams = .true.
+                      endif
+                   endif
+
                    ! Verify that the stream is an input stream
-                   if (stream_cursor % direction == MPAS_STREAM_INPUT .or. &
-                       stream_cursor % direction == MPAS_STREAM_INPUT_OUTPUT) then
-   
+                   if (readStreams) then
                        !
                        ! What should be the meaning of actualWhen if we read multiple streams in this call?
                        !


### PR DESCRIPTION
This PR improves the MPAS Stream Manager by introducing an optional argument to differentiate between streams of direction INPUT and direction INPUT_OUTPUT.  Previously, the mpas_stream_mgr_read() routine ignored the difference
between streams of direction INPUT and direction INPUT_OUTPUT (i.e. restart streams).  However, there are situation where it would be desirable to read only truly direction INPUT streams.  One example is at the initial time of a coldstart run - one would typically want to read any input streams without reading the restart stream (which does not exist yet).  This PR adds an optional argument to force mpas_stream_mgr_read to ignore INPUT_OUTPUT streams and only read truly INPUT streams.  Its default value maintains the previous behavior.  A second commit modifies the MALI driver to make use of this new capability to improve and simplify the input stream handling at the initial time of a MALI simulation.

[BFB]