### PR TITLE
run_e3sm: Replace default case name and case group

### DIFF
--- a/run_e3sm.template.sh
+++ b/run_e3sm.template.sh
@@ -24,8 +24,10 @@ readonly PROJECT="e3sm"
 # Simulation
 readonly COMPSET="WCYCL1850"
 readonly RESOLUTION="ne30pg2_EC30to60E2r2"
-readonly CASE_NAME="v2.LR.piControl"
-readonly CASE_GROUP="v2.LR"
+# BEFORE RUNNING : CHANGE the following CASE_NAME to desired value
+readonly CASE_NAME="your_casename"
+# If this is part of a simulation campaign, ask your group lead about using a case_group label
+# readonly CASE_GROUP=""
 
 # Code and compilation
 readonly CHECKOUT="20210806"
@@ -245,18 +247,33 @@ create_newcase() {
 
     echo $'\n----- Starting create_newcase -----\n'
 
-    ${CODE_ROOT}/cime/scripts/create_newcase \
-        --case ${CASE_NAME} \
-        --case-group ${CASE_GROUP} \
-        --output-root ${CASE_ROOT} \
-        --script-root ${CASE_SCRIPTS_DIR} \
-        --handle-preexisting-dirs u \
-        --compset ${COMPSET} \
-        --res ${RESOLUTION} \
-        --machine ${MACHINE} \
-        --project ${PROJECT} \
-        --walltime ${WALLTIME} \
-        --pecount ${PELAYOUT}
+	if [[ -z "$CASE_GROUP" ]]; then
+		${CODE_ROOT}/cime/scripts/create_newcase \
+			--case ${CASE_NAME} \
+			--output-root ${CASE_ROOT} \
+			--script-root ${CASE_SCRIPTS_DIR} \
+			--handle-preexisting-dirs u \
+			--compset ${COMPSET} \
+			--res ${RESOLUTION} \
+			--machine ${MACHINE} \
+			--project ${PROJECT} \
+			--walltime ${WALLTIME} \
+			--pecount ${PELAYOUT}
+	else
+		${CODE_ROOT}/cime/scripts/create_newcase \
+			--case ${CASE_NAME} \
+			--case-group ${CASE_GROUP} \
+			--output-root ${CASE_ROOT} \
+			--script-root ${CASE_SCRIPTS_DIR} \
+			--handle-preexisting-dirs u \
+			--compset ${COMPSET} \
+			--res ${RESOLUTION} \
+			--machine ${MACHINE} \
+			--project ${PROJECT} \
+			--walltime ${WALLTIME} \
+			--pecount ${PELAYOUT}
+	fi
+	
 
     if [ $? != 0 ]; then
       echo $'\nNote: if create_newcase failed because sub-directory already exists:'


### PR DESCRIPTION
This is required to avoid unwarranted usage of case_group that
interferes with aggregation of various production simulation campaigns.

Similar to https://github.com/E3SM-Project/E3SM/pull/4922 for maint-2.0 instead of master branch

[BFB]

