### PR TITLE
Fixes CIME import paths in template files

### DIFF
--- a/cime_config/machines/template.case.run
+++ b/cime_config/machines/template.case.run
@@ -14,7 +14,7 @@ DO NOT RUN THIS SCRIPT MANUALLY
 import os, sys
 os.chdir( '{{ caseroot }}')
 
-_LIBDIR = os.path.join("{{ cimeroot }}", "scripts", "Tools")
+_LIBDIR = os.path.join("{{ cimeroot }}", "CIME", "Tools")
 sys.path.append(_LIBDIR)
 
 from standard_script_setup          import *

--- a/cime_config/machines/template.case.run.sh
+++ b/cime_config/machines/template.case.run.sh
@@ -10,7 +10,7 @@
 cd {{ caseroot }}
 
 # Set PYTHONPATH so we can make cime calls if needed
-LIBDIR={{ cimeroot }}/scripts/lib
+LIBDIR={{ cimeroot }}
 export PYTHONPATH=$LIBDIR:$PYTHONPATH
 
 # setup environment

--- a/cime_config/machines/template.case.test
+++ b/cime_config/machines/template.case.test
@@ -10,7 +10,7 @@ DO NOT RUN THIS SCRIPT MANUALLY
 import os, sys
 os.chdir( '{{ caseroot }}')
 
-_LIBDIR = os.path.join("{{ cimeroot }}", "scripts", "Tools")
+_LIBDIR = os.path.join("{{ cimeroot }}", "CIME", "Tools")
 sys.path.append(_LIBDIR)
 
 from standard_script_setup import *

--- a/cime_config/machines/template.st_archive
+++ b/cime_config/machines/template.st_archive
@@ -12,7 +12,7 @@ is called by case.submit on batch systems.
 import sys, os, time
 os.chdir( '{{ caseroot }}')
 
-_LIBDIR = os.path.join("{{ cimeroot }}", "scripts", "Tools")
+_LIBDIR = os.path.join("{{ cimeroot }}", "CIME", "Tools")
 sys.path.append(_LIBDIR)
 
 from standard_script_setup          import *


### PR DESCRIPTION
Fixes CIME imports for `template.case.run.sh` and `template.case.st_archive`.

Also fixes imports for `template.case.run` and `template.case.test`, not sure if these are needed as they're only called by CIME, which fixes up the import paths when executing the scripts.

[BFB]