### PR TITLE
Fix restart issue for CO2 diagnostics in EAM

### DIFF
--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -1373,9 +1373,7 @@ subroutine phys_run2(phys_state, ztodt, phys_tend, pbuf2d,  cam_out, &
              phys_state(c)%tc_mnst(:ncol) = phys_state(c)%tc_curr(:ncol)
           end if
        end do
-       if ( is_last_step() ) then
-          call co2_diags_store_fields(phys_state, pbuf2d)
-       end if
+       call co2_diags_store_fields(phys_state, pbuf2d)
     end if
 
     call t_startf ('physpkg_st2')


### PR DESCRIPTION
Prevent failure in the CO2 diagnostics checker in EAM when using restart files produced on time steps not equal to the last time step in EAM.  The fix is accomplished by removing the logical flag controlling when co2_diags_store_fields is called.

Fixes https://github.com/E3SM-Project/E3SM/issues/4935
[BFB]