### PR TITLE
update dtime for high res meshes

### DIFF
--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -384,9 +384,9 @@
       <value compset=".+" grid="a%ne60np4">96</value>
       <value compset=".+" grid="a%ne120np4">96</value>
       <value compset=".+" grid="a%ne240np4">144</value>
-      <value compset=".+" grid="a%ne256np4">288</value>
-      <value compset=".+" grid="a%ne512np4">576</value>
-      <value compset=".+" grid="a%ne1024np4">1152</value>
+      <value compset=".+" grid="a%ne256np4">144</value>
+      <value compset=".+" grid="a%ne512np4">432</value>
+      <value compset=".+" grid="a%ne1024np4">864</value>
       <value compset=".+" grid="a%ne0np4_arm_x8v3" >144</value>
       <value compset=".+" grid="a%ne0np4_conus_x4v1" >96</value>
       <value compset=".+" grid="a%ne0np4_northamericax4v1" >48</value>


### PR DESCRIPTION
Set correct ATM_NCPL (which controls the atmosphere timestep, dtime) for ne256, ne512 and ne1024 meshes.
No impact on E3SM. Needed for SCREAM.