### PR TITLE
Add Time coordinate

### DIFF
--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -137,6 +137,10 @@
 					description="Selection of the type of calendar that should be used in the simulation."
 					possible_values="'gregorian', 'gregorian_noleap'"
 		/>
+		<nml_option name="config_output_reference_time" type="character" default_value="0001-01-01_00:00:00" units="unitless"
+					description="Reference time used in the units attribute of Time in output files."
+					possible_values="'YYYY-MM-DD_HH:MM:SS'"
+		/>
 	</nml_record>
 	<nml_record name="io" mode="forward;analysis">
 		<nml_option name="config_write_output_on_startup" type="logical" default_value=".true." units="unitless"
@@ -2431,6 +2435,9 @@
 	<var_struct name="diagnostics" time_levs="1">
 		<var name="xtime" type="text" dimensions="Time" units="unitless"
 			 description="model time, with format 'YYYY-MM-DD_HH:MM:SS'"
+		/>
+		<var name="Time" type="real" dimensions="Time"
+			 description="time"
 		/>
 		<var name="simulationStartTime" type="text" dimensions="" units="unitless" default_value="'no_date_available'"
 			 description="start time of first simulation, with format 'YYYY-MM-DD_HH:MM:SS'"

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -150,17 +150,22 @@ module ocn_forward_mode
          block              ! structure with all data for a given block
 
       type (mpas_pool_type), pointer :: &
-         meshPool           ! structure containing mesh data
+         diagnosticsPool    ! structure containing diagnostics data
 
       type (MPAS_Time_type) :: &
          xtime_timeType,               &! current time
          simulationStartTime_timeType, &! start time whole simulation
+         referenceTime_timeType,       &! reference time for Time coordinate
          startTime,                    &! start time this run
          alarmTime                      ! alarm for salinity restoring
+
+      type (field0DReal), pointer :: TimeField    ! to add units
 
       type (MPAS_TimeInterval_type) :: &
          timeStep,      &! time step in time manager form
          alarmTimeStep   ! alarm interval in time manager form
+
+      character (len=StrKIND) :: units
 
       ! End preamble
       !-------------
@@ -315,8 +320,25 @@ module ocn_forward_mode
       ! compute time since start of simulation, in days
       call mpas_set_time(xtime_timeType, dateTimeString=xtime)
       call mpas_set_time(simulationStartTime_timeType, dateTimeString=simulationStartTime)
-      call mpas_get_timeInterval(xtime_timeType - simulationStartTime_timeType,dt=daysSinceStartOfSim)
+      call mpas_get_timeInterval(xtime_timeType - simulationStartTime_timeType, dt=daysSinceStartOfSim)
       daysSinceStartOfSim = daysSinceStartOfSim*days_per_second
+
+      call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
+
+      ! add units of "days since <ref_date>" to Time
+      write(units, '(a10,a20)') 'days since', &
+           config_output_reference_time(1:10)//" "//config_output_reference_time(12:19)
+      call mpas_pool_get_Field(diagnosticsPool, 'Time', TimeField)
+      call mpas_add_att(TimeField % attLists(1) % attList, 'units', units)
+
+      ! Add calendar attribute to Time
+      call mpas_pool_get_config(domain % configs, 'config_calendar_type', config_calendar_type)
+      call mpas_add_att(TimeField % attLists(1) % attList, 'calendar', config_calendar_type)
+
+      ! compute Time as days since config_output_reference_time
+      call mpas_set_time(referenceTime_timeType, dateTimeString=config_output_reference_time)
+      call mpas_get_timeInterval(xtime_timeType - referenceTime_timeType, dt=Time)
+      Time = Time*days_per_second
 
       ! Update any mesh fields that may have been modified during init
       call ocn_meshUpdateFields(domain)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration.F
@@ -111,8 +111,9 @@ module ocn_time_integration
       !-----------------------------------------------------------------
 
       type (MPAS_Time_type) :: &
-         xtime_timeType,              &! current time in time type
-         simulationStartTime_timeType  ! start time in time type
+         xtime_timeType,               &! current time in time type
+         simulationStartTime_timeType, &! start time in time type
+         referenceTime_timeType         ! reference time for Time coordinate
 
       ! End preamble
       !-------------
@@ -142,6 +143,14 @@ module ocn_time_integration
            dt=daysSinceStartOfSim)
 
       daysSinceStartOfSim = daysSinceStartOfSim*days_per_second
+
+      call mpas_set_time(referenceTime_timeType, &
+                         dateTimeString=config_output_reference_time)
+      call mpas_get_timeInterval( &
+           xtime_timeType - referenceTime_timeType, &
+           dt=Time)
+
+      Time = Time*days_per_second
 
    !--------------------------------------------------------------------
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -153,6 +153,7 @@ module ocn_diagnostics_variables
       activeTracerVertMixTendency
 
    real (kind=RKIND), pointer :: daysSinceStartOfSim
+   real (kind=RKIND), pointer :: Time
    character (len=StrKIND), pointer :: xtime, simulationStartTime
 
    real (kind=RKIND), dimension(:,:), pointer :: bulkRichardsonNumber
@@ -538,6 +539,7 @@ contains
       call mpas_pool_get_array(diagnosticsPool, &
                "daysSinceStartOfSim", &
                 daysSinceStartOfSim)
+      call mpas_pool_get_array(diagnosticsPool, 'Time', Time)
       call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
       call mpas_pool_get_array(diagnosticsPool, 'simulationStartTime', &
                 simulationStartTime)
@@ -824,6 +826,7 @@ contains
       !$acc                   pressureAdjustedSSH,                     &
       !$acc                   tracersSurfaceValue,                     &
       !$acc                   daysSinceStartOfSim,                     &
+      !$acc                   Time,                                    &
       !$acc                   simulationStartTime,                     &
       !$acc                   boundaryLayerDepthSmooth,                &
       !$acc                   surfaceFluxAttenuationCoefficientRunoff  &
@@ -1063,6 +1066,7 @@ contains
       !$acc                   pressureAdjustedSSH,                     &
       !$acc                   tracersSurfaceValue,                     &
       !$acc                   daysSinceStartOfSim,                     &
+      !$acc                   Time,                                    &
       !$acc                   simulationStartTime,                     &
       !$acc                   boundaryLayerDepthSmooth,                &
       !$acc                   surfaceFluxAttenuationCoefficientRunoff  &
@@ -1251,6 +1255,7 @@ contains
               pressureAdjustedSSH,                     &
               tracersSurfaceValue,                     &
               daysSinceStartOfSim,                     &
+              Time,                                    &
               simulationStartTime,                     &
               boundaryLayerDepthSmooth,                &
               surfaceFluxAttenuationCoefficientRunoff)


### PR DESCRIPTION
This variable has CF-compliant units and calendar.  To accommodate the CF-compliant units, a new config option has been added to supply the reference time, 0001-01-01 by default.