### PR TITLE
Ocean/nonhydro

### DIFF
--- a/components/mpas-framework/Makefile
+++ b/components/mpas-framework/Makefile
@@ -335,7 +335,7 @@ gfortran:
 	"CC_SERIAL = gcc" \
 	"CXX_SERIAL = g++" \
 	"FFLAGS_PROMOTION = -fdefault-real-8 -fdefault-double-8" \
-	"FFLAGS_OPT = -O3 -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form -ffpe-summary=none" \
+	"FFLAGS_OPT = -O3 -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form" \
 	"CFLAGS_OPT = -O3 -m64" \
 	"CXXFLAGS_OPT = -O3 -m64" \
 	"LDFLAGS_OPT = -O3 -m64" \
@@ -362,7 +362,7 @@ gfortran-clang:
 	"CC_SERIAL = clang" \
 	"CXX_SERIAL = clang++" \
 	"FFLAGS_PROMOTION = -fdefault-real-8 -fdefault-double-8" \
-	"FFLAGS_OPT = -O3 -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form -ffpe-summary=none" \
+	"FFLAGS_OPT = -O3 -m64 -ffree-line-length-none -fconvert=big-endian -ffree-form" \
 	"CFLAGS_OPT = -O3 -m64" \
 	"CXXFLAGS_OPT = -O3 -m64" \
 	"LDFLAGS_OPT = -O3 -m64" \
@@ -577,7 +577,26 @@ CPPINCLUDES =
 FCINCLUDES =
 LIBS =
 
-#
+# Add links to PETSC links if requested
+ifeq "$(USE_PETSC)" "true"
+ifndef PETSC
+$(error PETSC is not set.  Please set PETSC to the PETSC install directory when USE_PETSC=true)
+endif
+ifneq (, $(shell ls $(PETSC)/lib/libpetsc.*))
+	LIBS += -L$(PETSC)/lib
+	CPPINCLUDES += -I$(PETSC)/include
+	FCINCLUDES += -I$(PETSC)/include
+else ifneq (, $(shell ls $(PETSC)/libpetsc.*))
+	LIBS += -L$(PETSC)
+	CPPINCLUDES += -I$(PETSC)
+	FCINCLUDES += -I$(PETSC)
+else
+$(error libpetsc.* does NOT exist in $(PETSC) or $(PETSC)/lib)
+endif
+	LIBS += -lpetsc
+	override CPPFLAGS += -DUSE_PETSC
+endif
+
 # If user has indicated a PIO2 library, define USE_PIO2 pre-processor macro
 #
 ifeq "$(USE_PIO2)" "true"
@@ -593,7 +612,7 @@ ifneq ($(wildcard $(PIO)/lib), )
 else
 	PIO_LIB = $(PIO)
 endif
-LIBS = -L$(PIO_LIB)
+LIBS += -L$(PIO_LIB)
 
 #
 # Regardless of PIO library version, look for an include subdirectory of PIO path
@@ -976,7 +995,7 @@ pio_test:
 	@#
 	@echo "Checking for a usable PIO library..."
 	@($(FC) pio1.f90 $(FCINCLUDES) $(FFLAGS) $(LDFLAGS) $(LIBS) -o pio1.out &> /dev/null && echo "=> PIO 1 detected") || \
-	 ($(FC) pio2.f90 $(FCINCLUDES) $(FFLAGS) $(LDFLAGS) $(LIBS) -o pio2.out &> /dev/null && echo "=> PIO 2 detected") || \
+	 ($(FC) pio2.f90 $(FCINCLUDES) $(FFLAGS) $(LDFLAGS) $(LIBS) -o pio2.out && echo "=> PIO 2 detected") || \
 	 (echo "************ ERROR ************"; \
 	  echo "Failed to compile a PIO test program"; \
 	  echo "Please ensure the PIO environment variable is set to the PIO installation directory"; \

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -776,6 +776,21 @@ add_default($nl, 'config_topographic_wave_drag_coeff');
 
 add_default($nl, 'config_density0');
 
+###########################################
+# Namelist group: nonhydrostatic_pressure #
+###########################################
+
+add_default($nl, 'config_enable_nonhydrostatic_mode');
+add_default($nl, 'config_nonhydrostatic_solve_surface_boundary_condition');
+add_default($nl, 'config_enable_vertMomentum_disable_nonHydro');
+add_default($nl, 'config_nonhydrostatic_remove_rhs_mean');
+add_default($nl, 'config_nonhydrostatic_preconditioner');
+add_default($nl, 'config_nonhydrostatic_solver_type');
+add_default($nl, 'config_petsc_rtol');
+add_default($nl, 'config_petsc_atol');
+add_default($nl, 'config_petsc_maxit');
+add_default($nl, 'config_use_constant_forced_pgf');
+
 #####################################
 # Namelist group: pressure_gradient #
 #####################################
@@ -1674,6 +1689,7 @@ my @groups = qw(run_modes
                 advection
                 bottom_drag
                 ocean_constants
+                nonhydrostatic_pressure
                 pressure_gradient
                 eos
                 eos_linear

--- a/components/mpas-ocean/bld/build-namelist-group-list
+++ b/components/mpas-ocean/bld/build-namelist-group-list
@@ -23,6 +23,7 @@ my @groups = qw(run_modes
                 advection
                 bottom_drag
                 ocean_constants
+                nonhydrostatic_pressure
                 pressure_gradient
                 eos
                 eos_linear

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -309,6 +309,21 @@ add_default($nl, 'config_topographic_wave_drag_coeff');
 
 add_default($nl, 'config_density0');
 
+###########################################
+# Namelist group: nonhydrostatic_pressure #
+###########################################
+
+add_default($nl, 'config_enable_nonhydrostatic_mode');
+add_default($nl, 'config_nonhydrostatic_solve_surface_boundary_condition');
+add_default($nl, 'config_enable_vertMomentum_disable_nonHydro');
+add_default($nl, 'config_nonhydrostatic_remove_rhs_mean');
+add_default($nl, 'config_nonhydrostatic_preconditioner');
+add_default($nl, 'config_nonhydrostatic_solver_type');
+add_default($nl, 'config_petsc_rtol');
+add_default($nl, 'config_petsc_atol');
+add_default($nl, 'config_petsc_maxit');
+add_default($nl, 'config_use_constant_forced_pgf');
+
 #####################################
 # Namelist group: pressure_gradient #
 #####################################

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -342,6 +342,18 @@
 <!-- ocean_constants -->
 <config_density0>1026.0</config_density0>
 
+<!-- nonhydrostatic_pressure -->
+<config_enable_nonhydrostatic_mode>.false.</config_enable_nonhydrostatic_mode>
+<config_nonhydrostatic_solve_surface_boundary_condition>'noGradient'</config_nonhydrostatic_solve_surface_boundary_condition>
+<config_enable_vertMomentum_disable_nonHydro>.false.</config_enable_vertMomentum_disable_nonHydro>
+<config_nonhydrostatic_remove_rhs_mean>.true.</config_nonhydrostatic_remove_rhs_mean>
+<config_nonhydrostatic_preconditioner>'jacobi'</config_nonhydrostatic_preconditioner>
+<config_nonhydrostatic_solver_type>'pipecgrr'</config_nonhydrostatic_solver_type>
+<config_petsc_rtol>1.0e-10</config_petsc_rtol>
+<config_petsc_atol>1.0E-20</config_petsc_atol>
+<config_petsc_maxit>10000</config_petsc_maxit>
+<config_use_constant_forced_pgf>.false.</config_use_constant_forced_pgf>
+
 <!-- pressure_gradient -->
 <config_pressure_gradient_type>'Jacobian_from_TS'</config_pressure_gradient_type>
 <config_common_level_weight>0.5</config_common_level_weight>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1564,6 +1564,88 @@ Valid values: any positive real, but typically 1000-1035
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<!-- nonhydrostatic_pressure -->
+
+<entry id="config_enable_nonhydrostatic_mode" type="logical"
+        category="nonhydrostatic_pressure" group="nonhydrostatic_pressure">
+Flag to enable the nonhydrostatic pressure calculation
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_nonhydrostatic_solve_surface_boundary_condition" type="char*1024"
+        category="nonhydrostatic_pressure" group="nonhydrostatic_pressure">
+setting for surface boundary condition for the pressure correction solve
+
+Valid values: noGradient or no pressure
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_enable_vertMomentum_disable_nonHydro" type="logical"
+        category="nonhydrostatic_pressure" group="nonhydrostatic_pressure">
+flag to enable hydrostatic pressure with vertical momentum tendencies
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_nonhydrostatic_remove_rhs_mean" type="logical"
+        category="nonhydrostatic_pressure" group="nonhydrostatic_pressure">
+flag to enabling mean from the right hand side of the nonhydro solve
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_nonhydrostatic_preconditioner" type="char*1024"
+        category="nonhydrostatic_pressure" group="nonhydrostatic_pressure">
+String describing preconditioner to use, recommended options -- jacobi, bjacobi, ilu
+
+Valid values: jacobi, bjacobi, ilu
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_nonhydrostatic_solver_type" type="char*1024"
+        category="nonhydrostatic_pressure" group="nonhydrostatic_pressure">
+String describing the solver context, recommended types -- pipecgrr, pipecg, cg, bcgs, gmres
+
+Valid values: pipecgrr, pipecg, cg, bcgs, gmres
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_petsc_rtol" type="real"
+        category="nonhydrostatic_pressure" group="nonhydrostatic_pressure">
+relative tolerance for the norm in petsc convergence
+
+Valid values: very small positive reals
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_petsc_atol" type="real"
+        category="nonhydrostatic_pressure" group="nonhydrostatic_pressure">
+absolute tolerance for the norm in petsc convergence
+
+Valid values: very small positive reals
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_petsc_maxit" type="integer"
+        category="nonhydrostatic_pressure" group="nonhydrostatic_pressure">
+maximum number of iterations in petsc solve
+
+Valid values: positive integers
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_use_constant_forced_pgf" type="logical"
+        category="nonhydrostatic_pressure" group="nonhydrostatic_pressure">
+logical to enable a constant pressure gradient that is added to rest of PGF NOTE: need to remove after rebasing on to master...
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- pressure_gradient -->
 

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1541,6 +1541,7 @@
 		<package name="tidalPotentialForcingPKG" description="This package controls variables required for tidal potential forcing"/>
 		<package name="topographicWaveDragPKG" description="This package controls variables required for topographic wave drag"/>
 		<package name="gotmPKG" description="This package is for GOTM variables, which are only needed when using GOTM for the vertical turbulence closure."/>
+                <package name="nonHydrostaticMode" description="This package is for variables needed for the nonHydrostatic capabilities"/>
 	</packages>
 
 	<streams>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -424,6 +424,75 @@
 					possible_values="Any positive real value."
 		/>
 	</nml_record>
+        <nml_record name="twoEquationModel" mode="forward">
+                <nml_option name="config_use_two_equation_turbulence_model" type="logical" default_value=".false." units="NA"
+                                        description="If true, use the GLS model extended to three dimensions"
+                                        possible_values=".true. or .false."
+                />
+                <nml_option name="config_two_equation_hor_adv_order" type="integer" default_value="3" units="NA"
+                                        description="order for horizontal advection of TKE and glsPsi"
+                                        possible_values="2, 3, 4"
+                />
+                <nml_option name="config_two_equation_coef_3rd_order" type="real" default_value="0.25" units="NA"
+                                        description="Reconstruction of 3rd-order reconstruction to blend with 4th-order reconstuction"
+                                        possible_values="any real between 0 and 1"
+                />
+                <nml_option name="config_two_equation_vert_adv_order" type="integer" default_value="3" units="NA"
+                                        description="order for vertical advection of TKE and glsPsi"
+                                        possible_values="2, 3, 4"
+                />
+                <nml_option name="config_two_equation_check_monotonicity" type="logical" default_value=".false." units="NA"
+                                        description="flag to determine whether or not to check for monotonicity in advection"
+                                        possible_values=".true. or .false."
+                />
+                <nml_option name="config_LES_mode" type="logical" default_value=".false." units="unitless"
+                                        description="logical to enable LES mode, requires config_use_two_equation_model='.true.'"
+                                        possible_values=".true. or .false."
+                />
+                <nml_option name="smagorinsky_coefficient" type="real" default_value="0.18" units="unitless"
+                                        description="Smagorinsky coefficient for the LES closure"
+                                        possible_values="usually between 0.1 and 0.2"
+                />
+                <nml_option name="config_two_equation_model_choice" type="character" default_value="epsilon" units="NA"
+                                        description="choice for psi equation in the two equation model"
+                                        possible_values="'epsilon', 'omega', 'kl', 'ktau', user-defined"
+                                        />
+                <nml_option name="config_user_c_mu" type="real" default_value="0.5477" units="NA"
+                                        description="choice for the c_mu constant if user wishes to define the model. only used if config_two_equation_model_choice = 'user-defined'"
+                                        possible_values="small positive reals near 0.5"
+                />
+                <nml_option name="config_user_sigma_k" type="real" default_value="1.0" units="NA"
+                                        description="choice for the sigma_k constant if user wishes to define the model. only used if config_two_equation_model_choice = 'user-defined'"
+                                        possible_values="values around 1-2"
+                />
+                <nml_option name="config_user_sigma_psi" type="real" default_value="1.3" units="NA"
+                                        description="choice for the sigma_psi constant if user wishes to define the model. only used if config_two_equation_model_choice = 'user-defined'"
+                                        possible_values="Positive reals"
+                />
+                <nml_option name="config_user_c_psi1" type="real" default_value="1.44" units="NA"
+                                        description="choice for the c_psi1 constant if user wishes to define the model. only used if config_two_equation_model_choice = 'user-defined'"
+                                        possible_values="small positive reals around 0-2"
+                />
+                <nml_option name="config_user_c_psi2" type="real" default_value="1.92" units="NA"
+                                        description="choice for the c_psi2 constant if user wishes to define the model. only used if config_two_equation_model_choice = 'user-defined'"
+                                        possible_values="positive reals around 0-2"
+                />
+                <nml_option name="config_user_c_psi3" type="real" default_value="-0.692" units="NA"
+                                        description="choice for the c_psi3 constant if user wishes to define the model. only used if config_two_equation_model_choice = 'user-defined'"
+                                        possible_values="positive reals"
+                />
+                <nml_option name="config_user_c_p" type="real" default_value="3.0" units="NA"
+                                        description="choice for the p constant used in determining dissipation, only used if config_two_equation_model_choice = 'user-defined'"
+                                        possible_values="positive reals"
+                />
+                <nml_option name="config_user_c_m" type="real" default_value="1.5" units="NA"
+                                        description="choice for the m constant used in determining dissipation, only used if config_two_equation_model_choice= 'user-defined'"
+                                        possible_values="reals"
+                />
+                <nml_option name="config_user_c_n" type="real" default_value="-1.0" units="NA"
+                                        description="choice for the n constant used in determining dissipation, only used if config_two_equation_model_choice = 'user-defined'"
+                />
+        </nml_record>
 	<nml_record name="cvmix" mode="forward">
 		<nml_option name="config_use_cvmix" type="logical" default_value=".true." units="NA"
 					description="If true, use the Community Vertical MIXing routines to compute vertical diffusivity and viscosity"
@@ -2312,6 +2381,15 @@
 		<var name="fCell" type="real" dimensions="nCells" units="s^{-1}"
 			 description="Coriolis parameter at cell centers."
 		/>
+                <var name="boundaryCellMask" type="integer" dimensions="nVertLevels nCells" units="unitless"
+                         description="cell mask for boundary cells"
+                />
+    		<var name="boundaryNormalAngle" type="real" dimensions="nVertLevels nCells" units="radians"
+       			 description="angle of the boundary normal relative to east/west"
+    		/>
+                <var name="distanceToBoundary" type="real" dimensions="nVertLevels nCells" units="m"
+                         description="distance to solid boundary, only used for idealized case"
+                />
 		<var name="bottomDepth" type="real" dimensions="nCells" units="m"
 			 description="Depth of the bottom of the ocean. Given as a positive distance from sea level."
 		/>
@@ -2842,6 +2920,18 @@
 			 description="vertical viscosity defined at the cell center (horizontally) and top (vertically)"
 			 packages="forwardMode;analysisMode"
 		/>
+                <var name="dynamicViscosity" type="real" dimensions="nVertLevelsP1 nCells Time" units="Ns/m^2"
+                         description="dynamic viscosity of water as a function of temperature and salinity"
+                         packages="forwardMode;analysisMode"
+                />
+                <var name="uStar" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+                  	 description="stress velocity for wall bounded flows"
+                  	 packages="forwardMode;analysisMode"
+    		/>
+    		<var name="yPlus" type="real" dimensions="nVertLevels nCells Time" units="m"
+       			 description="boundary normal coordinate"
+      		         packages="forwardMode;analysisMode"
+    		/>
 		<var name="vertDiffTopOfCell" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2 s^{-1}"
 			 description="vertical diffusion defined at the cell center (horizontally) and top (vertically)"
 			 packages="forwardMode;analysisMode"
@@ -2903,6 +2993,27 @@
 		<var name="indMLD" type="integer" dimensions="nCells Time" units="unitless"
 			description="index of model where mixed layer depth occurs (always one past)"
 		/>
+                <var name="ugrad" type="real" dimensions="R3 nVertLevels nCells Time" units="s^{-1}"
+                        description="three-dimensional gradient of zonal velocity"
+                />
+                <var name="vgrad" type="real" dimensions="R3 nVertLevels nCells Time" units="s^{-1}"
+                        description="three-dimensional gradient of meridional velocity"
+                />
+                <var name="wgrad" type="real" dimensions="R3 nVertLevels nCells Time" units="s^{-1}"
+                        description="three-dimensional gradient of vertical velocity"
+                />
+                <var name="tgrad" type="real" dimensions="R3 nVertLevels nCells Time" units="s^{-1}"
+                        description="three-dimensional gradient of temperature"
+                />
+                <var name="sgrad" type="real" dimensions="R3 nVertLevels nCells Time" units="s^{-1}"
+                        description="three-dimensional gradient of salinity"
+                />
+                <var name="Sh" type="real" dimensions="nVertLevels nCells Time" units="unitless"
+                        description="Structure function for heat and salt -- may want to consider separating at some point"
+                />
+                <var name="Sm" type="real" dimensions="nVertLevels nCells Time" units="unitless"
+                        description="Structure function for momentum"
+                />
 		<var name="slopeTriadUp" type="real" dimensions="nVertLevels TWO nEdges Time" units="non-dimensional" default_value="0.0"
 			 description="Magnitude of slope of isopycnal surface, using triad through this cell and edge, angled up. Uses expansion of equation of state."
 			 packages="forwardMode;analysisMode"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2148,11 +2148,17 @@
 			 description="sea surface height"
 		/>
                 <var name="verticalVelocity" type="real" dimensions="nVertLevelsP1 nCells Time" units="m s^{-1}"
-       		description="prognostic vertical velocity, only used when config_enable_nonhydrostatic_mode = .true."
+       		         description="prognostic vertical velocity, only used when config_enable_nonhydrostatic_mode = .true."
     		/>
-               <var name="nonhydrostaticPressure" type="real" dimensions="nVertLevels nCells Time" units="N m^{-2}"
-       	       description="nonHydrostatic pressure , set to zero if config_enable_nonhydrostatic_mode = .false."
-               />
+                <var name="nonhydrostaticPressure" type="real" dimensions="nVertLevels nCells Time" units="N m^{-2}"
+       	                 description="nonHydrostatic pressure , set to zero if config_enable_nonhydrostatic_mode = .false."
+                />
+                <var name="tke" type="real" dimensions="nVertLevels nCells Time" units="m^2 s^{-2}"
+                         description="Turbulence Kinetic Energy for the two equation turbulence closure"
+                />
+                <var name="glsPsi" type="real" dimensions="nVertLevels nCells Time" units="variable"
+                         description="psi variable for the two equation turbulence closure (see Umlauf and Burchard 2003).  The units here depend on the choice of variables in the GLS scheme"
+                />
 
 		<!-- FIELDS FOR FREQUENCY FILTERED THICKNESS -->
 		<var name="highFreqThickness" type="real" dimensions="nVertLevels nCells Time" units="m"
@@ -2510,6 +2516,13 @@
 			 description="time tendency of sea-surface height"
 			 packages="forwardMode"
 		/>
+                <var name="tendTKE" type="real" dimensions="nVertLevels nCells Time" units="m^2 s^{-3}" name_in_code="tendTKE"
+                         description="time tendency of turbulence kinetic energy"
+                         packages="forwardMode"
+                />
+                <var name="tendglsPsi" type="real" dimensions="nVertLevels nCells Time" units="m^2 s^{-4}" name_in_code="tendglsPsi"
+                         description="time tendency of psi variable from Umlauf and Burchard (2003)"
+                />
 		<var name="tendHighFreqThickness" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}" name_in_code="highFreqThickness"
 			 description="time tendency of high frequency-filtered layer thickness"
 			 packages="thicknessFilter"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -244,6 +244,14 @@
 					description="If true, Laplacian horizontal mixing is used on the tracer equation."
 					possible_values=".true. or .false."
 		/>
+                <nml_option name="config_use_vertMom_del2" type="logical" default_value=".false." units="unitless"
+                                        description="If true, Laplacian horizontal mixing is used on the vertical momentum equation."
+                                        possible_values=".true. or .false."
+                />
+                <nml_option name="config_vertMom_del2" type="real" default_value="0.0" units="m^2 s^{-1}"
+                                        description="Horizontal viscosity, $\nu_{2h}$. If config_hmix_use_ref_cell_width = .true. then $\nu_h$ = config_mom_del2*(cellWidth / config_hmix_use_ref_cell_width). If config_hmix_use_ref_cell_width = .false. then it is referenced to the smallest cell."
+                                        possible_values="any positive real"
+                />
 		<nml_option name="config_tracer_del2" type="real" default_value="10.0" units="m^2 s^{-1}"
 					description="Horizontal diffusion, $\kappa_{2h}$. If config_hmix_use_ref_cell_width = .true. then $\kappa_h$ = config_tracer_del2*(cellWidth / config_hmix_use_ref_cell_width). If config_hmix_use_ref_cell_width = .false. then it is referenced to the smallest cell."
 					possible_values="any positive real"
@@ -1024,6 +1032,48 @@
 					possible_values="any positive real, but typically 1000-1035"
 		/>
 	</nml_record>
+        <nml_record name="nonhydrostatic_pressure">
+            <nml_option name="config_enable_nonhydrostatic_mode" type="logical" default_value=".false." units="unitless"
+                                        description="Flag to enable the nonhydrostatic pressure calculation"
+                                        possible_values=".true. or .false."
+                />
+            <nml_option name="config_nonhydrostatic_solve_surface_boundary_condition" type="character" default_value="noGradient" units="unitless"
+                                    description="setting for surface boundary condition for the pressure correction solve"
+                                        possible_values="noGradient or no pressure"
+                />
+                <nml_option name="config_enable_vertMomentum_disable_nonHydro" type="logical" default_value=".false." units="unitless"
+                                        description="flag to enable hydrostatic pressure with vertical momentum tendencies"
+                                        possible_values=".true. or .false."
+                />
+                <nml_option name="config_nonhydrostatic_remove_rhs_mean" type="logical" default_value=".true." units="unitless"
+                                        description="flag to enabling mean from the right hand side of the nonhydro solve"
+                                        possible_values=".true. or .false."
+                />
+                <nml_option name="config_nonhydrostatic_preconditioner" type="character" default_value="jacobi" units="unitless"
+                                        description="String describing preconditioner to use, recommended options -- jacobi, bjacobi, ilu" 
+                                        possible_values="jacobi, bjacobi, ilu"
+                />
+                <nml_option name="config_nonhydrostatic_solver_type" type="character" default_value="pipecgrr" units="unitless"
+                                        description="String describing the solver context, recommended types -- pipecgrr, pipecg, cg, bcgs, gmres" 
+                                        possible_values="pipecgrr, pipecg, cg, bcgs, gmres"
+                />
+                <nml_option name="config_petsc_rtol" type="real" default_value="1.0e-10" units="unitless"
+                                        description="relative tolerance for the norm in petsc convergence"
+                                        possible_values="very small positive reals"
+                />
+                <nml_option name="config_petsc_atol" type="real" default_value="1.0E-20" units="unitless"
+                                        description="absolute tolerance for the norm in petsc convergence"
+                                        possible_values="very small positive reals"
+                />
+                <nml_option name="config_petsc_maxit" type="integer" default_value="10000" units="unitless"
+                                        description="maximum number of iterations in petsc solve"
+                                        possible_values="positive integers"
+                />
+                <nml_option name="config_use_constant_forced_pgf" type="logical" default_value=".false." units="unitless"
+                                        description="logical to enable a constant pressure gradient that is added to rest of PGF NOTE: need to remove after rebasing on to master..."
+                                        possible_values=".true. or .false."
+                />
+        </nml_record>
 	<nml_record name="pressure_gradient" mode="forward">
 		<nml_option name="config_pressure_gradient_type" type="character" default_value="pressure_and_zmid" units="unitless"
 					description="Form of pressure gradient terms in momentum equation. For most applications, the gradient of pressure and layer mid-depth are appropriate.  For isopycnal coordinates, one may use the gradient of the Montgomery potential.  The sea surface height gradient (ssh_gradient) option is for barotropic, depth-averaged pressure."
@@ -1221,6 +1271,10 @@
 					description="If true, $h^{hf}$ is included in the desired ALE thickness, and the prognostic equations for $D^{lf}$ and $h^{hf}$ are integrated in the code."
 					possible_values=".true. or .false."
 		/>
+                <nml_option name="config_disable_ALE" type="logical" default_value=".false." units="unitless"
+                                        description="flag to disable the ALE coordinate and revert to eulerian mode NOTE: only works for RK4 at present"
+                                        possible_values=".true. or .false."
+                />
 		<nml_option name="config_thickness_filter_timescale" type="real" default_value="5.0" units="days"
 					description="Filter time scale for the low-frequency baroclinic divergence, $\tau_{Dlf}$."
 					possible_values="any positive real value, but typically 5 days."
@@ -1299,6 +1353,18 @@
 					description="Disables tendencies on the velocity field from the Coriolis force and momentum advection."
 					possible_values=".true. or .false."
 		/>
+                <nml_option name="config_disable_vvel_all_tend" type="logical" default_value=".false." units="unitless"
+                                        description="Disables all tendencies on the vertical velocity field."
+                                        possible_values=".true. or .false."
+                />
+                <nml_option name="config_disable_vvel_coriolis" type="logical" default_value=".false." units="unitless"
+                                        description="Disables tendencies on the vertical velocity field from the Coriolis force."
+                                        possible_values=".true. or .false."
+                />
+                <nml_option name="config_disable_vvel_adv" type="logical" default_value=".false." units="unitless"
+                                        description="Disables advection of vertical velocity"
+                                        possible_values=".true. or .false."
+                />
 		<nml_option name="config_disable_vel_pgrad" type="logical" default_value=".false." units="unitless"
 					description="Disables tendencies on the velocity field from the horizontal pressure gradient."
 					possible_values=".true. or .false."
@@ -2012,6 +2078,12 @@
 		<var name="ssh" type="real" dimensions="nCells Time" units="m"
 			 description="sea surface height"
 		/>
+                <var name="verticalVelocity" type="real" dimensions="nVertLevelsP1 nCells Time" units="m s^{-1}"
+       		description="prognostic vertical velocity, only used when config_enable_nonhydrostatic_mode = .true."
+    		/>
+               <var name="nonhydrostaticPressure" type="real" dimensions="nVertLevels nCells Time" units="N m^{-2}"
+       	       description="nonHydrostatic pressure , set to zero if config_enable_nonhydrostatic_mode = .false."
+               />
 
 		<!-- FIELDS FOR FREQUENCY FILTERED THICKNESS -->
 		<var name="highFreqThickness" type="real" dimensions="nVertLevels nCells Time" units="m"
@@ -2349,6 +2421,9 @@
 			 description="time tendency of normal component of velocity"
 			 packages="forwardMode"
 		/>
+                <var name="tendVerticalVelocity" type="real" dimensions="nVertLevelsP1 nCells Time" units="m s^{-2}" name_in_code="verticalVelocityTend"
+                         description="time tendency of the vertical velocity (Only active for non hydrostatic mode)"
+                />
 		<var name="tendLayerThickness" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}" name_in_code="layerThickness"
 			 description="time tendency of layer thickness"
 			 packages="forwardMode"
@@ -2376,6 +2451,9 @@
 		<var name="daysSinceStartOfSim" type="real" dimensions="Time" units="days"
 			 description="Time since simulationStartTime, for plotting"
 	 	/>
+                <var name="nhPressureCorrection" type="real" dimensions="nVertLevels nCells Time" units="unitless"
+                         description="the pressure correction coming from the poisson pressure equation"
+                />
 		<var name="salinitySurfaceRestoringTendency" type="real" dimensions="nCells Time" units="m PSU/s" packages="activeTracersSurfaceRestoringPKG"
 			 description="salinity tendency due to surface restoring"
 		/>
@@ -2391,6 +2469,24 @@
 		<var name="temperatureShortWaveTendency" dimensions="nVertLevels nCells Time" units="degrees Celsius per second" packages="tracerBudget" name_in_code="temperatureShortWaveTendency" type="real"
 				 description="potential temperature tendency due to penetrating shortwave"
 		/>
+                <var name="velocityHmixTend" dimensions="nVertLevels nEdges Time" units="m/s^2" type="real"
+                  description="tendency of normal velocitydue to horizontal mixing"
+                />
+                <var name="velocityVmixTend" dimensions="nVertLevels nEdges Time" units="m/s^2" type="real"
+                  description="tendency of normal velocity due to vertical mixing"
+                />
+                <var name="velocityCoriolisTend" dimensions="nVertLevels nEdges Time" units="m/s^2" type="real"
+                  description="tendency of normal velocity due to Coriolis"
+                />
+                <var name="velocityPGFtend" dimensions="nVertLevels nEdges Time" units="m/s^2" type="real"
+                  description="tendency of normal velocity due to PGF"
+                />
+                <var name="velocityVadvTend" dimensions="nVertLevels nEdges Time" units="m/s^2" type="real"
+                  description="tendency of normal velocity due to vertical advection"
+                />
+                <var name="velocityForcingTend" dimensions="nVertLevels nEdges Time" units="m/s^2" type="real"
+                  description="tendency of normal velocity due to top and bottom forcing"
+                />
 		<var_array name="activeTracerHorMixTendency" type="real" dimensions="nVertLevels nCells Time" packages="tracerBudget">
 			<var name="temperatureHorMixTendency" array_group="activeTracerHmixTendGroup" units="degrees Celsius per second" name_in_code="temperatureHorMixTendency"
 				description="potential temperature tendency due to horizontal mixing (including Redi)"

--- a/components/mpas-ocean/src/driver/mpas_ocn_core_interface.F
+++ b/components/mpas-ocean/src/driver/mpas_ocn_core_interface.F
@@ -110,6 +110,7 @@ module ocn_core_interface
       integer :: err_tmp
 
       logical, pointer :: forwardModeActive
+      logical, pointer :: nonHydrostaticModeActive
       logical, pointer :: analysisModeActive
       logical, pointer :: initModeActive
       logical, pointer :: thicknessFilterActive
@@ -160,6 +161,7 @@ module ocn_core_interface
       logical, pointer :: config_use_topographic_wave_drag
       logical, pointer :: config_use_GM
       logical, pointer :: config_use_Redi
+      logical, pointer :: config_enable_nonhydrostatic_mode
       logical, pointer :: config_use_vegetation_drag
       logical, pointer :: config_use_time_varying_atmospheric_forcing
       logical, pointer :: config_use_time_varying_land_ice_forcing
@@ -338,6 +340,15 @@ module ocn_core_interface
       call mpas_pool_get_config(configPool, 'config_use_topographic_wave_drag', config_use_topographic_wave_drag)
       if (config_use_topographic_wave_drag) then
          topographicWaveDragPKGActive = .true.
+      end if
+
+      !
+      ! test for nonHydrostatic pressure
+      !
+      call mpas_pool_get_package(packagePool, 'nonHydrostaticModeActive', nonHydrostaticModeActive)
+      call mpas_pool_get_config(configPool, 'config_enable_nonhydrostatic_mode', config_enable_nonhydrostatic_mode)
+      if (config_enable_nonhydrostatic_mode) then
+         nonHydrostaticModeActive = .true.
       end if
 
       !

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -80,6 +80,7 @@ module ocn_forward_mode
    use ocn_tracer_surface_restoring
    use ocn_gm
    use ocn_compute_nonhydrostatic_pressure
+   use ocn_two_equation_model
 
    use ocn_high_freq_thickness_hmix_del2
 
@@ -316,6 +317,11 @@ module ocn_forward_mode
         call ocn_nonhydrostatic_solver_init(domain % dminfo % comm, err_tmp)
         ierr = ior(ierr, err_tmp)
       endif
+
+      if(config_use_two_equation_turbulence_model) then
+        call ocn_two_equation_init(domain, err_tmp)
+        ierr = ior(ierr, err_tmp)
+      end if
 
       call ocn_init_routines_block(block, dt, ierr)
 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -48,6 +48,11 @@ module ocn_forward_mode
    use ocn_thick_ale
    use ocn_thick_surface_flux
 
+   use ocn_vvel_pgrad
+   use ocn_vvel_coriolis
+   use ocn_vvel_advection
+   use ocn_vvel_hmix_del2
+
    use ocn_vel_pressure_grad
    use ocn_vel_vadv
    use ocn_vel_hmix
@@ -74,6 +79,7 @@ module ocn_forward_mode
    use ocn_tracer_CFC
    use ocn_tracer_surface_restoring
    use ocn_gm
+   use ocn_compute_nonhydrostatic_pressure
 
    use ocn_high_freq_thickness_hmix_del2
 
@@ -297,6 +303,19 @@ module ocn_forward_mode
 
       timeStep = mpas_get_clock_timestep(domain % clock, ierr=err_tmp)
       call mpas_get_timeInterval(timeStep, dt=dt)
+
+      if(config_enable_nonhydrostatic_mode) then
+        call ocn_vvel_advection_init(err_tmp)
+        ierr = ior(ierr, err_tmp)
+        call ocn_vvel_coriolis_init(err_tmp)
+        ierr = ior(ierr, err_tmp)
+        call ocn_vvel_pgf_init(err_tmp)
+        ierr = ior(ierr, err_tmp)
+        call ocn_vvel_hmix_del2_init(err_tmp)
+        ierr = ior(ierr, err_tmp)
+        call ocn_nonhydrostatic_solver_init(domain % dminfo % comm, err_tmp)
+        ierr = ior(ierr, err_tmp)
+      endif
 
       call ocn_init_routines_block(block, dt, ierr)
 
@@ -812,6 +831,10 @@ module ocn_forward_mode
       call mpas_destroy_clock(domain % clock, ierr)
 
       call mpas_decomp_destroy_decomp_list(domain % decompositions)
+
+      if(config_enable_nonhydrostatic_mode .and. .not. config_enable_vertMomentum_disable_nonHydro) then
+         call ocn_nonhydrostatic_solver_finalize()
+      end if
 
    end function ocn_forward_mode_finalize!}}}
 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -34,6 +34,7 @@ module ocn_time_integration_rk4
    use ocn_diagnostics_variables
    use ocn_gm
 
+   use ocn_compute_nonhydrostatic_pressure
    use ocn_equation_of_state
    use ocn_vmix
    use ocn_time_average_coupled
@@ -108,6 +109,7 @@ module ocn_time_integration_rk4
 
       integer :: rk_step
 
+      type (dm_info) :: dminfo
       type (mpas_pool_type), pointer :: nextProvisPool, prevProvisPool
 
       real (kind=RKIND), dimension(4) :: rk_weights, rk_substep_weights
@@ -134,6 +136,8 @@ module ocn_time_integration_rk4
       logical, pointer :: config_verify_not_dry
       logical, pointer :: config_prevent_drying
       logical, pointer :: config_zero_drying_velocity
+      logical, pointer :: config_enable_nonhydrostatic_mode
+      logical, pointer :: config_enable_vertMomentum_disable_nonHydro
       character (len=StrKIND), pointer :: config_land_ice_flux_mode
 
       ! State indices
@@ -150,18 +154,22 @@ module ocn_time_integration_rk4
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocityProvis, layerThicknessProvis
       real (kind=RKIND), dimension(:,:), pointer :: highFreqThicknessProvis
       real (kind=RKIND), dimension(:,:), pointer :: lowFreqDivergenceProvis
+      real (kind=RKIND), dimension(:,:), pointer :: verticalVelocityProvis
       real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroupProvis
 
       ! Tend Array Pointers
       real (kind=RKIND), dimension(:,:), pointer :: highFreqThicknessTend, lowFreqDivergenceTend, normalVelocityTend, &
-                                                    layerThicknessTend
+                                                    layerThicknessTend, verticalVelocityTend
       real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroupTend
 
       ! State Array Pointers
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocityCur, normalVelocityNew
+      real (kind=RKIND), dimension(:,:), pointer :: verticalVelocityCur, verticalVelocityNew
       real (kind=RKIND), dimension(:,:), pointer :: layerThicknessCur, layerThicknessNew
       real (kind=RKIND), dimension(:,:), pointer :: highFreqThicknessCur, highFreqThicknessNew
       real (kind=RKIND), dimension(:,:), pointer :: lowFreqDivergenceCur, lowFreqDivergenceNew
+      real (kind=RKIND), dimension(:,:), pointer :: nonhydrostaticPressure, nonhydrostaticPressureOld
+
       real (kind=RKIND), dimension(:), pointer :: sshCur, sshNew
 
       real (kind=RKIND), dimension(:,:,:), pointer :: tracerGroup, tracersCur, tracersNew
@@ -205,6 +213,8 @@ module ocn_time_integration_rk4
       call mpas_pool_get_config(domain % configs, 'config_zero_drying_velocity', config_zero_drying_velocity)
       call mpas_pool_get_config(domain % configs, 'config_use_tidal_forcing', config_use_tidal_forcing)
       call mpas_pool_get_config(domain % configs, 'config_tidal_forcing_type', config_tidal_forcing_type)
+      call mpas_pool_get_config(domain % configs, 'config_enable_nonhydrostatic_mode', config_enable_nonhydrostatic_mode)
+      call mpas_pool_get_config(domain % configs, 'config_enable_vertMomentum_disable_nonHydro', config_enable_vertMomentum_disable_nonHydro)
 
       !
       ! Initialize time_levs(2) with state at current time
@@ -231,6 +241,11 @@ module ocn_time_integration_rk4
          call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityNew, 2)
          call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
          call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessNew, 2)
+
+         if(config_enable_nonhydrostatic_mode) then
+            call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityCur, 1)
+            call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityNew, 2)
+         end if
 
          call mpas_pool_get_array(statePool, 'highFreqThickness', highFreqThicknessCur, 1)
          call mpas_pool_get_array(statePool, 'highFreqThickness', highFreqThicknessNew, 2)
@@ -260,6 +275,18 @@ module ocn_time_integration_rk4
          end do
          !$omp end do
          !$omp end parallel
+
+         if(config_enable_nonhydrostatic_mode) then
+           !$omp parallel
+           !$omp do schedule(runtime) private(k)
+           do iCell = 1, nCells
+              do k = 1, maxLevelCell(iCell)
+                 verticalVelocityNew(k,iCell) = verticalVelocityCur(k, iCell)
+              end do
+           end do
+           !$omp end do
+           !$omp end parallel
+         end if
 
          call mpas_pool_begin_iteration(tracersPool)
          do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
@@ -484,27 +511,38 @@ module ocn_time_integration_rk4
              call mpas_timer_stop("RK4-prevent drying")
         end if
 
+        !FIXME - LVR - ALE is not working with non hydrostatic, for now implement switch to disable
         ! Compute tendencies for velocity, thickness, and tracers.
         ! In RK4 notation, we are computing the right hand side f(t,y),
         ! which is the same as k_j / h.
         call mpas_timer_start("RK4 vel/thick tendency computations")
-
         block => domain % blocklist
         do while (associated(block))
            call ocn_time_integrator_rk4_compute_vel_tends( block, dt, rk_substep_weights(rk_step), err )
 
+           if(.not. config_disable_ALE) then
            call ocn_time_integrator_rk4_compute_thick_tends( block, dt, rk_substep_weights(rk_step), err )
+         endif
            block => block % next
         end do
-
         call mpas_timer_stop("RK4 vel/thick tendency computations")
 
+        if (config_enable_nonhydrostatic_mode) then
+           call mpas_timer_start("RK4 vvel tendency computations")
+           block => domain % blocklist
+           do while (associated(block))
+              call ocn_time_integrator_rk4_compute_vvel_tends( block, dt, rk_substep_weights(rk_step), err )
+              block => block % next
+           end do
+           call mpas_timer_stop("RK4 vvel tendency computations")
+        end if
         ! Update halos for prognostic variables.
 
         call mpas_timer_start("RK4 vel/thick prognostic halo update")
 
         call mpas_dmpar_field_halo_exch(domain, 'tendNormalVelocity')
         call mpas_dmpar_field_halo_exch(domain, 'tendLayerThickness')
+        call mpas_dmpar_field_halo_exch(domain, 'tendVerticalVelocity')
 
         call mpas_timer_stop("RK4 vel/thick prognostic halo update")
 
@@ -590,11 +628,11 @@ module ocn_time_integration_rk4
       !  A little clean up at the end: rescale tracer fields and compute diagnostics for new state
       !
       call mpas_timer_start("RK4-cleanup phase")
-
       ! Rescale tracers
       block => domain % blocklist
       do while(associated(block))
-        call ocn_time_integrator_rk4_cleanup(block, dt, err)
+        dminfo = domain % dminfo
+        call ocn_time_integrator_rk4_cleanup(block, dt, dminfo, err)
 
         block => block % next
       end do
@@ -610,6 +648,7 @@ module ocn_time_integration_rk4
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
       call mpas_dmpar_field_halo_exch(domain, 'normalVelocity', timeLevel=2)
+      call mpas_dmpar_field_halo_exch(domain, 'verticalVelocity', timeLevel=2)
 
       call mpas_pool_begin_iteration(tracersPool)
       do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
@@ -646,7 +685,21 @@ module ocn_time_integration_rk4
          call mpas_pool_get_array(forcingPool, 'tidalInputMask', tidalInputMask)
          call mpas_pool_get_array(forcingPool, 'tidalBCValue', tidalBCValue)
 
+      if (config_enable_nonhydrostatic_mode) then
 
+         call mpas_pool_get_array(statePool, 'nonhydrostaticPressure', nonhydrostaticPressure, 2)
+         call mpas_pool_get_array(statePool, 'nonhydrostaticPressure', nonhydrostaticPressureOld, 1)
+
+         call mpas_timer_start('RK4 NH pressure tend halo pressure')
+         call mpas_dmpar_field_halo_exch(domain, 'nonhydrostaticPressure', timeLevel=2)
+         call mpas_dmpar_field_halo_exch(domain, 'nonhydrostaticPressure', timeLevel=1)
+         call mpas_dmpar_field_halo_exch(domain, 'nhPressureCorrection')
+         call mpas_timer_stop('RK4 NH pressure tend halo pressure')
+
+            call ocn_nonhydrostatic_pressure_update_velocity(normalVelocityNew, verticalVelocityNew, &
+                 layerThicknessNew, layerThickEdge, nonhydrostaticPressure, nonhydrostaticPressureOld, &
+                 nhPressureCorrection, dt)
+      end if
          if (config_prescribe_velocity) then
             !$omp parallel
             !$omp do schedule(runtime)
@@ -655,6 +708,16 @@ module ocn_time_integration_rk4
             end do
             !$omp end do
             !$omp end parallel
+
+            if (config_enable_nonhydrostatic_mode) then
+               !$omp parallel
+               !$omp do schedule(runtime)
+               do iCell = 1, nCells
+                  verticalVelocityNew(:, iCell) = verticalVelocityCur(:, iCell)
+               end do
+               !$omp end do
+               !$omp end parallel
+            end if
          end if
 
          if (config_prescribe_thickness) then
@@ -784,6 +847,7 @@ module ocn_time_integration_rk4
 
       real (kind=RKIND), dimension(:), pointer :: sshCur
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessCur, normalVelocityCur
+      real (kind=RKIND), dimension(:, :), pointer :: verticalVelocity
       real (kind=RKIND), dimension(:, :), pointer ::  normalVelocityProvis, highFreqThicknessProvis
 
       logical, pointer :: config_filter_btr_mode
@@ -805,6 +869,7 @@ module ocn_time_integration_rk4
       call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
       call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityCur, 1)
+      call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocity, 1)
 
       call mpas_pool_get_array(provisStatePool, 'normalVelocity', normalVelocityProvis, 1)
       call mpas_pool_get_array(provisStatePool, 'highFreqThickness', highFreqThicknessProvis, 1)
@@ -813,20 +878,22 @@ module ocn_time_integration_rk4
       if (associated(highFreqThicknessProvis)) then
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
             layerThicknessCur,layerThickEdge, normalVelocityProvis, &
-            sshCur, rkSubstepWeight, &
-            vertAleTransportTop, err, highFreqThicknessProvis)
+            verticalVelocity, sshCur, rkSubstepWeight, &
+            vertAleTransportTop, nhPressureCorrection, err, highFreqThicknessProvis)
       else
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
             layerThicknessCur,layerThickEdge, normalVelocityProvis, &
-            sshCur, rkSubstepWeight, &
-            vertAleTransportTop, err)
+            verticalVelocity, sshCur, rkSubstepWeight, &
+            vertAleTransportTop, nhPressureCorrection, err)
       endif
 
       call ocn_tend_vel(tendPool, provisStatePool, forcingPool, 1, dt)
 
    end subroutine ocn_time_integrator_rk4_compute_vel_tends!}}}
 
-   subroutine ocn_time_integrator_rk4_compute_thick_tends(block, dt, rkSubstepWeight, err)!{{{
+   subroutine ocn_time_integrator_rk4_compute_vvel_tends(block, dt, &
+     rkSubstepWeight, err)
+
       type (block_type), intent(in) :: block
       real (kind=RKIND), intent(in) :: dt
       real (kind=RKIND), intent(in) :: rkSubstepWeight
@@ -839,7 +906,9 @@ module ocn_time_integration_rk4
 
       real (kind=RKIND), dimension(:), pointer :: sshCur
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessCur, normalVelocityCur
+      real (kind=RKIND), dimension(:, :), pointer :: verticalVelocityCur
       real (kind=RKIND), dimension(:, :), pointer ::  normalVelocityProvis, highFreqThicknessProvis
+      real (kind=RKIND), dimension(:, :), pointer ::  verticalVelocityProvis
 
       integer :: iEdge
       integer, pointer :: nEdges
@@ -863,6 +932,69 @@ module ocn_time_integration_rk4
       call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
       call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityCur, 1)
+      call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityCur, 1)
+
+      call mpas_pool_get_array(provisStatePool, 'verticalVelocity', verticalVelocityProvis, 1)
+      call mpas_pool_get_array(provisStatePool, 'normalVelocity', normalVelocityProvis, 1)
+      call mpas_pool_get_array(provisStatePool, 'highFreqThickness', highFreqThicknessProvis, 1)
+
+      ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
+      if (associated(highFreqThicknessProvis)) then
+         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
+            layerThicknessCur,layerThickEdge, normalVelocityProvis, &
+            verticalVelocityProvis, sshCur, rkSubstepWeight, &
+            vertAleTransportTop, nhPressureCorrection, err, highFreqThicknessProvis)
+      else
+         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
+            layerThicknessCur,layerThickEdge, normalVelocityProvis, &
+            verticalVelocityProvis, sshCur, rkSubstepWeight, &
+            vertAleTransportTop, nhPressureCorrection, err)
+      endif
+
+      call ocn_tend_vvel(tendPool, provisStatePool, forcingPool, meshPool, 1, dt)
+
+   end subroutine ocn_time_integrator_rk4_compute_vvel_tends
+
+   subroutine ocn_time_integrator_rk4_compute_thick_tends(block, dt, rkSubstepWeight, err)!{{{
+      type (block_type), intent(in) :: block
+      real (kind=RKIND), intent(in) :: dt
+      real (kind=RKIND), intent(in) :: rkSubstepWeight
+      integer, intent(out) :: err
+
+      type (mpas_pool_type), pointer :: meshPool, verticalMeshPool
+      type (mpas_pool_type), pointer :: statePool, forcingPool
+      type (mpas_pool_type), pointer :: scratchPool, tendPool, provisStatePool
+      type (mpas_pool_type), pointer :: tracersPool
+
+      real (kind=RKIND), dimension(:), pointer :: sshCur
+      real (kind=RKIND), dimension(:, :), pointer :: layerThicknessCur, normalVelocityCur
+      real (kind=RKIND), dimension(:, :), pointer :: verticalVelocity
+      real (kind=RKIND), dimension(:, :), pointer ::  normalVelocityProvis, highFreqThicknessProvis
+      real (kind=RKIND), dimension(:, :), pointer ::  verticalVelocityProvis
+
+      integer :: iEdge
+      integer, pointer :: nEdges
+      logical, pointer :: config_filter_btr_mode
+
+      err = 0
+
+      call mpas_pool_get_config(block % configs, 'config_filter_btr_mode', config_filter_btr_mode)
+
+      call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+      call mpas_pool_get_subpool(block % structs, 'verticalMesh', verticalMeshPool)
+      call mpas_pool_get_subpool(block % structs, 'state', statePool)
+      call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
+      call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
+      call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
+      call mpas_pool_get_subpool(block % structs, 'provis_state', provisStatePool)
+
+      call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
+
+      call mpas_pool_get_dimension(block % dimensions, 'nEdges', nEdges)
+      call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
+      call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
+      call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityCur, 1)
+      call mpas_pool_get_array(provisStatePool, 'verticalVelocity', verticalVelocity, 1)
 
       call mpas_pool_get_array(provisStatePool, 'normalVelocity', normalVelocityProvis, 1)
       call mpas_pool_get_array(provisStatePool, 'highFreqThickness', highFreqThicknessProvis, 1)
@@ -881,13 +1013,13 @@ module ocn_time_integration_rk4
       if (associated(highFreqThicknessProvis)) then
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
             layerThicknessCur, layerThickEdge, normalTransportVelocity, &
-            sshCur, rkSubstepWeight, &
-            vertAleTransportTop, err, highFreqThicknessProvis)
+            verticalVelocity, sshCur, rkSubstepWeight, &
+            vertAleTransportTop, nhPressureCorrection, err, highFreqThicknessProvis)
       else
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
             layerThicknessCur, layerThickEdge, normalTransportVelocity, &
-            sshCur, rkSubstepWeight, &
-            vertAleTransportTop, err)
+            verticalVelocity, sshCur, rkSubstepWeight, &
+            vertAleTransportTop, nhPressureCorrection, err)
       endif
 
       call ocn_tend_thick(tendPool, forcingPool, meshPool)
@@ -908,6 +1040,7 @@ module ocn_time_integration_rk4
 
       real (kind=RKIND), dimension(:), pointer :: sshCur
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessCur, normalVelocityCur
+      real (kind=RKIND), dimension(:, :), pointer :: verticalVelocity
       real (kind=RKIND), dimension(:, :), pointer ::  normalVelocityProvis, highFreqThicknessProvis
 
       logical, pointer :: config_filter_btr_mode
@@ -951,13 +1084,13 @@ module ocn_time_integration_rk4
       if (associated(highFreqThicknessProvis)) then
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
             layerThicknessCur, layerThickEdge, normalTransportVelocity, &
-            sshCur, rkSubstepWeight, &
-            vertAleTransportTop, err, highFreqThicknessProvis)
+            verticalVelocity, sshCur, rkSubstepWeight, &
+            vertAleTransportTop, nhPressureCorrection, err, highFreqThicknessProvis)
       else
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
             layerThicknessCur, layerThickEdge, normalTransportVelocity, &
-            sshCur, rkSubstepWeight, &
-            vertAleTransportTop, err)
+            verticalVelocity, sshCur, rkSubstepWeight, &
+            vertAleTransportTop, nhPressureCorrection, err)
       endif
 
       if (config_filter_btr_mode) then
@@ -982,6 +1115,7 @@ module ocn_time_integration_rk4
 
       real (kind=RKIND), dimension(:), pointer :: sshCur
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessCur, normalVelocityCur
+      real (kind=RKIND), dimension(:, :), pointer :: verticalVelocity
       real (kind=RKIND), dimension(:, :), pointer ::  normalVelocityProvis, highFreqThicknessProvis
 
       logical, pointer :: config_filter_btr_mode
@@ -1004,6 +1138,7 @@ module ocn_time_integration_rk4
       call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
       call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityCur, 1)
+      call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocity, 1)
 
       call mpas_pool_get_array(provisStatePool, 'normalVelocity', normalVelocityProvis, 1)
       call mpas_pool_get_array(provisStatePool, 'highFreqThickness', highFreqThicknessProvis, 1)
@@ -1012,13 +1147,13 @@ module ocn_time_integration_rk4
       if (associated(highFreqThicknessProvis)) then
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
             layerThicknessCur,layerThickEdge, normalVelocityProvis, &
-            sshCur, rkWeight, &
-            vertAleTransportTop, err, highFreqThicknessProvis)
+            verticalVelocity, sshCur, rkWeight, &
+            vertAleTransportTop, nhPressureCorrection, err, highFreqThicknessProvis)
       else
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
             layerThicknessCur,layerThickEdge, normalVelocityProvis, &
-            sshCur, rkWeight, &
-            vertAleTransportTop, err)
+            verticalVelocity, sshCur, rkWeight, &
+            vertAleTransportTop, nhPressureCorrection, err)
       endif
 
       call ocn_tend_vel(tendPool, provisStatePool, forcingPool, 1, dt)
@@ -1026,13 +1161,13 @@ module ocn_time_integration_rk4
       if (associated(highFreqThicknessProvis)) then
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
             layerThicknessCur, layerThickEdge, normalTransportVelocity, &
-            sshCur, rkWeight, &
-            vertAleTransportTop, err, highFreqThicknessProvis)
+            verticalVelocity, sshCur, rkWeight, &
+            vertAleTransportTop, nhPressureCorrection, err, highFreqThicknessProvis)
       else
          call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
             layerThicknessCur, layerThickEdge, normalTransportVelocity, &
-            sshCur, rkWeight, &
-            vertAleTransportTop, err)
+            verticalVelocity, sshCur, rkWeight, &
+            vertAleTransportTop, nhPressureCorrection, err)
       endif
 
       call ocn_tend_thick(tendPool, forcingPool, meshPool)
@@ -1064,6 +1199,8 @@ module ocn_time_integration_rk4
       real (kind=RKIND), dimension(:, :), pointer :: normalVelocityCur, normalVelocityProvis, normalVelocityTend
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessCur, layerThicknessProvis, layerThicknessTend
       real (kind=RKIND), dimension(:, :), pointer :: lowFreqDivergenceCur, lowFreqDivergenceProvis, lowFreqDivergenceTend
+      real (kind=RKIND), dimension(:, :), pointer :: verticalVelocityCur, verticalVelocityTend
+      real (kind=RKIND), dimension(:, :), pointer :: verticalVelocityProvis
 
       real (kind=RKIND), dimension(:, :, :), pointer :: tracersGroupCur, tracersGroupProvis, tracersGroupTend
 
@@ -1111,6 +1248,12 @@ module ocn_time_integration_rk4
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
 
+      if(config_enable_nonhydrostatic_mode) then
+         call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityCur, 1)
+         call mpas_pool_get_array(tendPool, 'verticalVelocityTend', verticalVelocityTend)
+         call mpas_pool_get_array(provisStatePool, 'verticalVelocity', verticalVelocityProvis, 1)
+      end if
+
       !$omp parallel
       !$omp do schedule(runtime) private(k)
       do iEdge = 1, nEdges
@@ -1131,6 +1274,19 @@ module ocn_time_integration_rk4
       end do
       !$omp end do
       !$omp end parallel
+
+      if (config_enable_nonhydrostatic_mode) then
+         !$omp parallel
+         !$omp do schedule(runtime) private(k)
+         do iCell = 1, nCells
+            do k = 1, maxLevelCell(iCell)
+               verticalVelocityProvis(k, iCell) = verticalVelocityCur(k, iCell) + rkSubstepWeight &
+                                                * verticalVelocityTend(k, iCell)
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
+      end if
 
       call mpas_pool_begin_iteration(tracersPool)
       do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
@@ -1181,6 +1337,17 @@ module ocn_time_integration_rk4
          end do
          !$omp end do
          !$omp end parallel
+
+         if (config_enable_nonhydrostatic_mode) then
+            !$omp parallel
+            !$omp do schedule(runtime)
+            do iCell = 1, nCells
+               verticalVelocityProvis(:,iCell) = verticalVelocityCur(:, iCell)
+            end do
+            !$omp end do
+            !$omp end parallel
+        end if
+
       end if
 
       if (config_prescribe_thickness) then
@@ -1236,6 +1403,8 @@ module ocn_time_integration_rk4
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessNew, layerThicknessTend
       real (kind=RKIND), dimension(:, :), pointer :: highFreqThicknessNew, highFreqThicknessTend
       real (kind=RKIND), dimension(:, :), pointer :: lowFreqDivergenceNew, lowFreqDivergenceTend
+      real (kind=RKIND), dimension(:, :), pointer :: verticalVelocityNew
+      real (kind=RKIND), dimension(:, :), pointer :: verticalVelocityTend
 
       real (kind=RKIND), dimension(:, :, :), pointer :: tracersGroupNew, tracersGroupTend
 
@@ -1271,6 +1440,11 @@ module ocn_time_integration_rk4
       call mpas_pool_get_array(tendPool, 'normalVelocity', normalVelocityTend)
       call mpas_pool_get_array(tendPool, 'layerThickness', layerThicknessTend)
 
+      if (config_enable_nonhydrostatic_mode) then
+         call mpas_pool_get_array(tendPool, 'verticalVelocityTend', verticalVelocityTend)
+         call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityNew, 2)
+      end if
+
       call mpas_pool_get_array(tendPool, 'highFreqThickness', highFreqThicknessTend)
       call mpas_pool_get_array(tendPool, 'lowFreqDivergence', lowFreqDivergenceTend)
 
@@ -1293,6 +1467,16 @@ module ocn_time_integration_rk4
       end do
       !$omp end do
       !$omp end parallel
+
+      if (config_enable_nonhydrostatic_mode) then
+         !$omp parallel
+         !$omp do schedule(runtime)
+         do iCell = 1, nCells
+            verticalVelocityNew(:, iCell) = verticalVelocityNew(:, iCell) + rkWeight * verticalVelocityTend(:, iCell)
+         end do
+         !$omp end do
+         !$omp end parallel
+      end if
 
       call mpas_pool_begin_iteration(tracersPool)
       do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
@@ -1343,8 +1527,9 @@ module ocn_time_integration_rk4
 
    end subroutine ocn_time_integrator_rk4_accumulate_update!}}}
 
-   subroutine ocn_time_integrator_rk4_cleanup(block, dt, err)!{{{
+   subroutine ocn_time_integrator_rk4_cleanup(block, dt, dminfo, err)!{{{
       type (block_type), intent(in) :: block
+      type (dm_info), intent(in) :: dminfo
       real (kind=RKIND), intent(in) :: dt
       integer, intent(out) :: err
 
@@ -1356,6 +1541,8 @@ module ocn_time_integration_rk4
       type (mpas_pool_type), pointer :: tracersPool
 
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessNew, normalVelocityNew
+      real (kind=RKIND), dimension(:, :), pointer :: verticalVelocityNew
+      real (kind=RKIND), dimension(:, :), pointer :: nonhydrostaticPressure
       real (kind=RKIND), dimension(:, :, :), pointer :: tracersGroupNew
 
       integer, dimension(:), pointer :: minLevelCell, maxLevelCell
@@ -1390,6 +1577,10 @@ module ocn_time_integration_rk4
       call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
+      if (config_enable_nonhydrostatic_mode) then
+         call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityNew, 2)
+      end if
+
       call mpas_pool_begin_iteration(tracersPool)
       do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
          if ( groupItr % memberType == MPAS_POOL_FIELD ) then
@@ -1411,6 +1602,11 @@ module ocn_time_integration_rk4
       call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, scratchPool, tracersPool, 2)
 
       call ocn_vmix_implicit(dt, meshPool, statePool, forcingPool, scratchPool, err, 2)
+
+      if (config_enable_nonhydrostatic_mode .and. .not. config_enable_vertMomentum_disable_nonHydro) then
+         call ocn_nonhydrostatic_pressure_tend(normalVelocityNew, verticalVelocityNew, layerThicknessNew, &
+              layerThickEdge, nhPressureCorrection, dminfo % comm, dt)
+      end if
 
    end subroutine ocn_time_integrator_rk4_cleanup!}}}
 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -33,6 +33,7 @@ module ocn_time_integration_rk4
    use ocn_diagnostics
    use ocn_diagnostics_variables
    use ocn_gm
+   use ocn_two_equation_model
 
    use ocn_compute_nonhydrostatic_pressure
    use ocn_equation_of_state
@@ -137,6 +138,7 @@ module ocn_time_integration_rk4
       logical, pointer :: config_prevent_drying
       logical, pointer :: config_zero_drying_velocity
       logical, pointer :: config_enable_nonhydrostatic_mode
+      logical, pointer :: config_use_two_equation_turbulence_model
       logical, pointer :: config_enable_vertMomentum_disable_nonHydro
       character (len=StrKIND), pointer :: config_land_ice_flux_mode
 
@@ -156,6 +158,8 @@ module ocn_time_integration_rk4
       real (kind=RKIND), dimension(:,:), pointer :: lowFreqDivergenceProvis
       real (kind=RKIND), dimension(:,:), pointer :: verticalVelocityProvis
       real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroupProvis
+      real (kind=RKIND), dimension(:,:), pointer :: tkeProvis
+      real (kind=RKIND), dimension(:,:), pointer :: glsPsiProvis
 
       ! Tend Array Pointers
       real (kind=RKIND), dimension(:,:), pointer :: highFreqThicknessTend, lowFreqDivergenceTend, normalVelocityTend, &
@@ -165,6 +169,7 @@ module ocn_time_integration_rk4
       ! State Array Pointers
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocityCur, normalVelocityNew
       real (kind=RKIND), dimension(:,:), pointer :: verticalVelocityCur, verticalVelocityNew
+      real (kind=RKIND), dimension(:,:), pointer :: tkeNew, tkeCur, glsPsiNew, glsPsiCur
       real (kind=RKIND), dimension(:,:), pointer :: layerThicknessCur, layerThicknessNew
       real (kind=RKIND), dimension(:,:), pointer :: highFreqThicknessCur, highFreqThicknessNew
       real (kind=RKIND), dimension(:,:), pointer :: lowFreqDivergenceCur, lowFreqDivergenceNew
@@ -214,6 +219,7 @@ module ocn_time_integration_rk4
       call mpas_pool_get_config(domain % configs, 'config_use_tidal_forcing', config_use_tidal_forcing)
       call mpas_pool_get_config(domain % configs, 'config_tidal_forcing_type', config_tidal_forcing_type)
       call mpas_pool_get_config(domain % configs, 'config_enable_nonhydrostatic_mode', config_enable_nonhydrostatic_mode)
+      call mpas_pool_get_config(domain % configs, 'config_use_two_equation_turbulence_model', config_use_two_equation_turbulence_model)
       call mpas_pool_get_config(domain % configs, 'config_enable_vertMomentum_disable_nonHydro', config_enable_vertMomentum_disable_nonHydro)
 
       !
@@ -245,6 +251,13 @@ module ocn_time_integration_rk4
          if(config_enable_nonhydrostatic_mode) then
             call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityCur, 1)
             call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityNew, 2)
+         end if
+
+         if(config_use_two_equation_turbulence_model) then
+            call mpas_pool_get_array(statePool, 'tke', tkeNew, 2)
+            call mpas_pool_get_array(statePool, 'tke', tkeCur, 1)
+            call mpas_pool_get_array(statePool, 'glsPsi', glsPsiNew, 2)
+            call mpas_pool_get_array(statePool, 'glsPsi', glsPsiCur, 1)
          end if
 
          call mpas_pool_get_array(statePool, 'highFreqThickness', highFreqThicknessCur, 1)
@@ -286,6 +299,30 @@ module ocn_time_integration_rk4
            end do
            !$omp end do
            !$omp end parallel
+         end if
+
+         if(config_use_two_equation_turbulence_model) then
+            !$omp parallel
+            !$omp do schedule(runtime) private(k)
+            do iCell = 1, nCells
+               do k = 1, maxLevelCell(iCell)
+                  tkeNew(k,iCell) = tkeCur(k,iCell)
+               end do
+            end do
+            !$omp end do
+            !$omp end parallel
+
+            if(.not. config_LES_mode) then
+               !$omp parallel
+               !$omp do schedule(runtime) private(k)
+               do iCell = 1, nCells
+                  do k = 1, maxLevelCell(iCell)
+                     glsPsiNew(k,iCell) = glsPsiCur(k,iCell)
+                  end do
+               end do
+               !$omp end do
+               !$omp end parallel
+            end if
          end if
 
          call mpas_pool_begin_iteration(tracersPool)
@@ -536,6 +573,15 @@ module ocn_time_integration_rk4
            end do
            call mpas_timer_stop("RK4 vvel tendency computations")
         end if
+        if (config_use_two_equation_turbulence_model) then
+           call mpas_timer_start("RK4 tke psi tendency computations")
+           block => domain % blocklist
+           do while (associated(block))
+             call ocn_time_integrator_rk4_compute_tke_psi_tends( block, dt, rk_substep_weights(rk_step), err )
+             block => block % next
+           end do
+           call mpas_timer_stop("RK4 tke psi tendency computations")
+        end if
         ! Update halos for prognostic variables.
 
         call mpas_timer_start("RK4 vel/thick prognostic halo update")
@@ -543,6 +589,8 @@ module ocn_time_integration_rk4
         call mpas_dmpar_field_halo_exch(domain, 'tendNormalVelocity')
         call mpas_dmpar_field_halo_exch(domain, 'tendLayerThickness')
         call mpas_dmpar_field_halo_exch(domain, 'tendVerticalVelocity')
+        call mpas_dmpar_field_halo_exch(domain, 'tendTKE')
+        call mpas_dmpar_field_halo_exch(domain, 'tendglsPsi')
 
         call mpas_timer_stop("RK4 vel/thick prognostic halo update")
 
@@ -637,6 +685,12 @@ module ocn_time_integration_rk4
         block => block % next
       end do
 
+      if (config_use_two_equation_turbulence_model) then
+         call mpas_pool_get_array(statePool, 'tke', tkeNew, 2)
+         call mpas_pool_get_array(statePool, 'glsPsi', glsPsiNew, 2)
+         call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessNew, 2)
+         call ocn_compute_two_equation_diff(tkeNew, glsPsiNew, layerThicknessNew, dt, err)
+      end if
       call mpas_timer_start("RK4-implicit vert mix")
       ! Update halo on u and tracers, which were just updated for implicit vertical mixing.  If not done,
       ! this leads to lack of volume conservation.  It is required because halo updates in RK4 are only
@@ -649,6 +703,9 @@ module ocn_time_integration_rk4
 
       call mpas_dmpar_field_halo_exch(domain, 'normalVelocity', timeLevel=2)
       call mpas_dmpar_field_halo_exch(domain, 'verticalVelocity', timeLevel=2)
+      call mpas_dmpar_field_halo_exch(domain, 'tke', timeLevel=2)
+      call mpas_dmpar_field_halo_exch(domain, 'glsPsi', timeLevel=2)
+      call mpas_dmpar_field_halo_exch(domain, 'layerThickness', timeLevel=2)
 
       call mpas_pool_begin_iteration(tracersPool)
       do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
@@ -658,6 +715,20 @@ module ocn_time_integration_rk4
       end do
 
       call mpas_timer_stop("RK4-implicit vert mix halos")
+
+      if (config_use_two_equation_turbulence_model) then
+         call mpas_timer_start("Two equation model diff compute")
+         block => domain % blocklist
+         do while(associated(block))
+            call mpas_pool_get_subpool(block % structs, 'state', statePool)
+            call mpas_pool_get_array(statePool, 'tke', tkeNew, 2)
+            call mpas_pool_get_array(statePool, 'glsPsi', glsPsiNew, 2)
+            call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessNew, 2)
+            call ocn_compute_two_equation_diff(tkeNew, glsPsiNew, layerThicknessNew, dt, err)
+            block => block % next
+         end do
+         call mpas_timer_stop("Two equation model diff compute")
+      end if
 
       call mpas_timer_stop("RK4-implicit vert mix")
 
@@ -1102,6 +1173,85 @@ module ocn_time_integration_rk4
 
    end subroutine ocn_time_integrator_rk4_compute_tracer_tends!}}}
 
+   subroutine ocn_time_integrator_rk4_compute_tke_psi_tends(block, dt, &
+     rkSubstepWeight, err)
+
+      type (block_type), intent(in) :: block
+      real (kind=RKIND), intent(in) :: dt
+      real (kind=RKIND), intent(in) :: rkSubstepWeight
+      integer, intent(out) :: err
+
+      type (mpas_pool_type), pointer :: meshPool, verticalMeshPool
+      type (mpas_pool_type), pointer :: statePool, forcingPool
+      type (mpas_pool_type), pointer :: scratchPool, tendPool, provisStatePool
+      type (mpas_pool_type), pointer :: tracersPool
+
+      real (kind=RKIND), dimension(:), pointer :: sshCur
+      real (kind=RKIND), dimension(:, :), pointer :: layerThicknessCur, verticalVelocityCur
+      real (kind=RKIND), dimension(:, :), pointer :: normalTransportVelocity, normalVelocityCur
+      real (kind=RKIND), dimension(:, :), pointer :: normalVelocityProvis
+      real (kind=RKIND), dimension(:, :), pointer :: verticalVelocityProvis, highFreqThicknessProvis
+      real (kind=RKIND), dimension(:, :), pointer :: tendTKE, tendglsPsi, tkeNew, glsPsiNew
+      real (kind=RKIND), dimension(:, :, :), pointer :: activeTracersNew
+
+      logical, pointer :: config_filter_btr_mode
+
+      err = 0
+
+      call mpas_pool_get_config(block % configs, 'config_filter_btr_mode', config_filter_btr_mode)
+
+      call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+      call mpas_pool_get_subpool(block % structs, 'verticalMesh', verticalMeshPool)
+      call mpas_pool_get_subpool(block % structs, 'state', statePool)
+      call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
+      call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
+      call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
+      call mpas_pool_get_subpool(block % structs, 'provis_state', provisStatePool)
+
+      call mpas_pool_get_subpool(provisStatePool, 'tracers', tracersPool)
+
+      call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracersNew, 1)
+      call mpas_pool_get_array(provisStatePool, 'tke', tkeNew, 1)
+      call mpas_pool_get_array(provisStatePool, 'glsPsi', glsPsiNew, 1)
+      call mpas_pool_get_array(tendPool, 'tendTKE', tendTKE)
+      call mpas_pool_get_array(tendPool, 'tendglsPsi', tendglsPsi)
+
+      call mpas_pool_get_array(provisStatePool, 'layerThickness', layerThicknessCur, 1)
+      call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
+      call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityCur, 1)
+      call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityCur, 1)
+
+      call mpas_pool_get_array(provisStatePool, 'verticalVelocity', verticalVelocityProvis, 1)
+      call mpas_pool_get_array(provisStatePool, 'normalVelocity', normalVelocityProvis, 1)
+      call mpas_pool_get_array(provisStatePool, 'highFreqThickness', highFreqThicknessProvis, 1)
+
+      ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
+      if (associated(highFreqThicknessProvis)) then
+         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
+            layerThicknessCur,layerThickEdge, normalVelocityProvis, &
+            verticalVelocityProvis, sshCur, rkSubstepWeight, &
+            vertAleTransportTop, nhPressureCorrection, err, highFreqThicknessProvis)
+      else
+         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
+            layerThicknessCur,layerThickEdge, normalVelocityProvis, &
+            verticalVelocityProvis, sshCur, rkSubstepWeight, &
+            vertAleTransportTop, nhPressureCorrection, err)
+      endif
+
+      !this may be needed, but perhaps being a timestep behind is no problem
+      call mpas_reconstruct(meshPool,  normalVelocityProvis, &
+                            velocityX, velocityY, velocityZ,   &
+                            velocityZonal, velocityMeridional, &
+                            includeHalos = .true.)
+!halo exchange??
+
+      call ocn_compute_KPP_input_fields(statePool, forcingPool, meshPool, 2)
+      call ocn_compute_two_equation_tendency(tendTKE, tendglsPsi, tkeNew, glsPsiNew, velocityZonal,&
+                                     velocityMeridional, normalVelocityProvis, verticalVelocityProvis, &
+                                     layerThicknessCur, activeTracersNew, dt, err)
+
+   end subroutine ocn_time_integrator_rk4_compute_tke_psi_tends
+
    subroutine ocn_time_integrator_rk4_compute_tends(block, dt, rkWeight, err)!{{{
       type (block_type), intent(in) :: block
       real (kind=RKIND), intent(in) :: dt
@@ -1403,7 +1553,8 @@ module ocn_time_integration_rk4
       real (kind=RKIND), dimension(:, :), pointer :: layerThicknessNew, layerThicknessTend
       real (kind=RKIND), dimension(:, :), pointer :: highFreqThicknessNew, highFreqThicknessTend
       real (kind=RKIND), dimension(:, :), pointer :: lowFreqDivergenceNew, lowFreqDivergenceTend
-      real (kind=RKIND), dimension(:, :), pointer :: verticalVelocityNew
+      real (kind=RKIND), dimension(:, :), pointer :: verticalVelocityNew, tkeNew, glsPsiNew
+      real (kind=RKIND), dimension(:, :), pointer :: tendTKE, tendglsPsi
       real (kind=RKIND), dimension(:, :), pointer :: verticalVelocityTend
 
       real (kind=RKIND), dimension(:, :, :), pointer :: tracersGroupNew, tracersGroupTend
@@ -1445,6 +1596,13 @@ module ocn_time_integration_rk4
          call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityNew, 2)
       end if
 
+      if (config_use_two_equation_turbulence_model) then
+         call mpas_pool_get_array(statePool, 'tke', tkeNew, 2)
+         call mpas_pool_get_array(statePool, 'glsPsi', glsPsiNew, 2)
+         call mpas_pool_get_array(tendPool, 'tendTKE', tendTKE)
+         call mpas_pool_get_array(tendPool, 'tendglsPsi', tendglsPsi)
+      end if
+
       call mpas_pool_get_array(tendPool, 'highFreqThickness', highFreqThicknessTend)
       call mpas_pool_get_array(tendPool, 'lowFreqDivergence', lowFreqDivergenceTend)
 
@@ -1476,6 +1634,26 @@ module ocn_time_integration_rk4
          end do
          !$omp end do
          !$omp end parallel
+      end if
+
+      if (config_use_two_equation_turbulence_model) then
+         !$omp parallel
+         !$omp do schedule(runtime)
+         do iCell = 1, nCells
+            tkeNew(:, iCell) = max(tkeNew(:, iCell) + rkWeight * tendTKE(:, iCell),0.0_RKIND)
+         end do
+         !$omp end do
+         !$omp end parallel
+
+         if(config_LES_mode) then
+            !$omp parallel
+            !$omp do schedule(runtime)
+            do iCell = 1, nCells
+               glsPsiNew(:, iCell) = max(glsPsiNew(:, iCell) + rkWeight * tendglsPsi(:, iCell),0.0_RKIND)
+            end do
+            !$omp end do 
+            !$omp end parallel
+         end if
       end if
 
       call mpas_pool_begin_iteration(tracersPool)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -268,6 +268,8 @@ module ocn_time_integration_rk4
          call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
          call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
 
+         print*, dt
+
          ! Lower k-loop limit of 1 rather than minLevel* needed in *New = *Cur
          ! assignments below are needed to maintain bit-for-bit results
 
@@ -1137,6 +1139,7 @@ module ocn_time_integration_rk4
       call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
       call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityCur, 1)
+      call mpas_pool_get_array(provisStatePool, 'verticalVelocity', verticalVelocity, 1)
 
       call mpas_pool_get_array(provisStatePool, 'normalVelocity', normalVelocityProvis, 1)
       call mpas_pool_get_array(provisStatePool, 'highFreqThickness', highFreqThicknessProvis, 1)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -43,6 +43,7 @@ module ocn_time_integration_si
    use ocn_diagnostics
    use ocn_gm
 
+   use ocn_two_equation_model   
    use ocn_compute_nonhydrostatic_pressure
    use ocn_equation_of_state
    use ocn_vmix
@@ -251,6 +252,10 @@ module ocn_time_integration_si
          tracerGroupIdealAgeMask,     &! mask for resetting surface ideal age
          verticalVelocityNew,         &! Vertical Velocity at new time
          verticalVelocityCur,         &! Vertical Velocity at current time
+         tkeNew,                      &! TKE at new time
+         tkeCur,                      &! TKE at current time
+         glsPsiNew,                   &! glsPsi at new time
+         glsPsiCur,                   &! glsPsi at current time
          nonhydrostaticPressure,      &! nhpressure at new time
          nonhydrostaticPressureOld     ! nh pressure at current time
 
@@ -286,7 +291,8 @@ module ocn_time_integration_si
          highFreqThicknessTend, &! thickness tendency for high-freq iter
          lowFreqDivergenceTend, &! thickness tendency for low freq
          layerThicknessTend,    &! main thickness tendency
-
+         tendTKE,               &! TKE tendency
+         tendglsPsi,            &! glsPsi tendency
          verticalVelocityTend    ! tendency of vertical velocity
 
       real (kind=RKIND), dimension(:,:,:), pointer :: &
@@ -510,17 +516,44 @@ module ocn_time_integration_si
          end if
       end do
 
-!         if(config_enable_nonhydrostatic_mode) then
+!      if(config_enable_nonhydrostatic_mode) then
+         !$omp parallel
+         !$omp do schedule(runtime) private(k)
+         do iCell=1,nCellsAll
+            do k = 2, maxLevelCell(iCell)
+               verticalVelocityNew(k,iCell) = verticalVelocityCur(k,iCell)
+           end do
+         end do
+         !$omp end do
+         !$omp end parallel
+!      end if
+      if (config_use_two_equation_turbulence_model) then
+         call mpas_pool_get_array(statePool,'tke',tkeNew,2)
+         call mpas_pool_get_array(statePool,'tke',tkeCur,1)
+         call mpas_pool_get_array(statePool,'glsPsi',glsPsiNew,2)
+         call mpas_pool_get_array(statePool,'glsPsi',glsPsiCur,1)
+         !$omp parallel
+         !$omp do schedule(runtime) private(k)
+         do iCell = 1, nCellsAll
+            do k = 1, nVertLevels
+               tkeNew(k,iCell) = tkeCur(k,iCell)
+            end do
+         end do
+         !$omp end do 
+         !$omp end parallel
+   
+         if(.not. config_LES_mode) then
             !$omp parallel
             !$omp do schedule(runtime) private(k)
-            do iCell=1,nCellsAll
-               do k = 2, maxLevelCell(iCell)
-                  verticalVelocityNew(k,iCell) = verticalVelocityCur(k,iCell)
+            do iCell = 1, nCellsAll
+               do k = 1, nVertLevels
+                  glsPsiNew(k,iCell) = glsPsiCur(k,iCell)
                end do
             end do
-            !$omp end do
+            !$omp end do 
             !$omp end parallel
-!         end if
+         end if
+      end if
 
       if (associated(highFreqThicknessNew)) then
          !$omp parallel
@@ -2661,6 +2694,22 @@ module ocn_time_integration_si
             call ocn_tend_vvel(tendPool, statePool, & 
                           forcingPool, meshPool, 2, dt)
          end if
+         if(config_use_two_equation_turbulence_model) then
+            call mpas_pool_get_array(tendPool, 'tendTKE', tendTKE)
+            call mpas_pool_get_array(tendPool, 'tendglsPsi', tendglsPsi)
+            call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityNew, 2)
+            call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityNew, 2)
+            call mpas_pool_get_array(tracersPool, 'activeTracers', tracersGroupNew, 2)
+            call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessNew, 2)
+            call mpas_pool_get_array(statePool, 'tke', tkeNew, 2)
+            call mpas_pool_get_array(statePool, 'glsPsi', glsPsiNew, 2)
+            !Note we need the virtual fluxes from KPP for the k-psi formulation
+            call ocn_compute_KPP_input_fields(statePool, forcingPool, meshPool, 2)
+
+            call ocn_compute_two_equation_tendency(tendTKE, tendglsPsi, tkeNew, glsPsiNew, velocityZonal, &
+                       velocityMeridional, normalVelocityNew, verticalVelocityNew, layerThicknessNew, &
+                       tracersGroupNew, dt, err)
+         end if
          call mpas_timer_stop('si tracer tend')
 
          ! update halo for tracer tendencies
@@ -2692,10 +2741,15 @@ module ocn_time_integration_si
          call mpas_pool_get_array(tracersTendPool,'activeTracersTend', &
                                                    activeTracersTend)
          if(config_enable_nonhydrostatic_mode) then
-               call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityCur, 1)
-               call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityNew, 2)
-               call mpas_pool_get_array(tendPool, 'verticalVelocityTend', verticalVelocityTend)
-            end if
+            call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityCur, 1)
+            call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityNew, 2)
+            call mpas_pool_get_array(tendPool, 'verticalVelocityTend', verticalVelocityTend)
+         end if
+
+         if(config_use_two_equation_turbulence_model) then
+            call mpas_pool_get_array(tendPool, 'tendTKE', tendTKE)
+            call mpas_pool_get_array(tendPool, 'tendglsPsi', tendglsPsi)
+         end if
 
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
          !  If iterating, reset variables for next iteration
@@ -2713,18 +2767,46 @@ module ocn_time_integration_si
             ! then all the tracers needed the last time through.
 
             if(config_enable_nonhydrostatic_mode) then
+               !$omp parallel
+               !$omp do schedule(runtime) private(k, temp_h)
+               do iCell=1,nCells
+                  do k=2,maxLevelCell(iCell)
+                     temp_h = verticalVelocityCur(k,iCell) + dt * verticalVelocityTend(k,iCell)
+                     verticalVelocityNew(k,iCell) = 0.5_RKIND*(verticalVelocityCur(k,iCell) + temp_h)
+                  end do
+               end do
+               !$omp end do
+               !$omp end parallel
+            end if
+
+            if(config_use_two_equation_turbulence_model) then
+               !$omp parallel
+               !$omp do schedule(runtime) private(k, temp_h)
+               do iCell = 1, nCells
+                  do k = 1, maxLevelCell(iCell)
+                     temp_h = tkeCur(k,ICell) + dt * tendTKE(k,iCell)
+                     tkeNew(k,iCell) = max(0.0_RKIND, 0.5_RKIND*(tkeCur(k,iCell) + temp_h))
+
+                     temp_h = glsPsiCur(k,iCell) + dt * tendglsPsi(k,iCell)
+                     glsPsiNew(k,iCell) = max(0.0_RKIND, 0.5_RKIND*(glsPsiCur(k,iCell) + temp_h))
+                  end do
+               end do
+               !$omp end do
+               !$omp end parallel
+
+               if(.not. config_LES_mode) then
                   !$omp parallel
                   !$omp do schedule(runtime) private(k, temp_h)
-                  do iCell=1,nCells
-                     do k=2,maxLevelCell(iCell)
-                        temp_h = verticalVelocityCur(k,iCell) + dt * verticalVelocityTend(k,iCell)
-                        verticalVelocityNew(k,iCell) = 0.5_RKIND*(verticalVelocityCur(k,iCell) + temp_h)
+                  do iCell = 1, nCells
+                     do k = 1, maxLevelCell(iCell)
+                        temp_h = glsPsiCur(k,iCell) + dt * tendglsPsi(k,iCell)
+                        glsPsiNew(k,iCell) = max(0.0_RKIND, 0.5_RKIND*(glsPsiCur(k,iCell) + temp_h))
                      end do
                   end do
                   !$omp end do
                   !$omp end parallel
                end if
-
+            end if
 
             !$omp parallel
             !$omp do schedule(runtime) private(i, k, temp_h, temp)
@@ -2824,6 +2906,41 @@ module ocn_time_integration_si
             end do
             !$omp end do
             !$omp end parallel
+
+            if(config_enable_nonhydrostatic_mode) then
+                  !$omp parallel
+                  !$omp do schedule(runtime) private(k)
+                  do iCell=1,nCells
+                     do k=1,maxLevelCell(iCell)
+                        verticalVelocityNew(k,iCell) = verticalVelocityCur(k,iCell) + dt*verticalVelocityTend(k,iCell)
+                     end do
+                  end do
+                  !$omp end do
+                  !$omp end parallel
+               end if
+
+               if(config_use_two_equation_turbulence_model) then
+                  !$omp parallel
+                  !$omp do schedule(runtime) private(k)
+                  do iCell=1,nCells
+                     do k=1,maxLevelCell(iCell)
+                        tkeNew(k,iCell) = max(0.0_RKIND, tkeCur(k,iCell) + dt*tendTKE(k,iCell))
+                     end do
+                  end do 
+                  !$omp end do
+                  !$omp end parallel
+                  if(.not. config_LES_mode) then
+                     !$omp parallel
+                     !$omp do schedule(runtime) private(k)
+                     do iCell=1,nCells
+                        do k=1,maxLevelCell(iCell)
+                           glsPsiNew(k,iCell) = max(0.0_RKIND, glsPsiCur(k,iCell) + dt*tendglsPsi(k,iCell))
+                        end do
+                     end do
+                     !$omp end do
+                     !$omp end parallel
+                  end if
+               end if
 
             if (config_compute_active_tracer_budgets) then
 
@@ -3072,6 +3189,13 @@ module ocn_time_integration_si
                                       timeLevel=2)
       call mpas_timer_stop('si vmix halos normalVelFld')
 
+      if (config_use_two_equation_turbulence_model) then
+         call mpas_pool_get_array(statePool, 'tke', tkeNew, 2)
+         call mpas_pool_get_array(statePool, 'glsPsi', glsPsiNew, 2)
+         call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessNew, 2)
+         call ocn_compute_two_equation_diff(tkeNew, glsPsiNew, layerThicknessNew, dt, err)
+      end if
+
       if(config_enable_nonhydrostatic_mode) then
             call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityNew, 2)
             call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityCur, 1)
@@ -3091,7 +3215,6 @@ module ocn_time_integration_si
             call ocn_nonhydrostatic_pressure_update_velocity(normalVelocityNew, verticalVelocityNew, &
               layerThicknessNew, layerThickEdge, nonhydrostaticPressure, nonhydrostaticPressureOld, &
               nhPressureCorrection, dt)
-
       end if
 
       call mpas_pool_begin_iteration(tracersPool)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -43,6 +43,7 @@ module ocn_time_integration_si
    use ocn_diagnostics
    use ocn_gm
 
+   use ocn_compute_nonhydrostatic_pressure
    use ocn_equation_of_state
    use ocn_vmix
    use ocn_time_average_coupled
@@ -247,7 +248,11 @@ module ocn_time_integration_si
          highFreqThicknessNew,        &! high frq thick at new     time
          lowFreqDivergenceCur,        &! low frq div    at current time
          lowFreqDivergenceNew,        &! low frq div    at new     time
-         tracerGroupIdealAgeMask       ! mask for resetting surface ideal age
+         tracerGroupIdealAgeMask,     &! mask for resetting surface ideal age
+         verticalVelocityNew,         &! Vertical Velocity at new time
+         verticalVelocityCur,         &! Vertical Velocity at current time
+         nonhydrostaticPressure,      &! nhpressure at new time
+         nonhydrostaticPressureOld     ! nh pressure at current time
 
       type (field1DReal), pointer :: &
          effectiveDensityField         ! field pointer for halo update
@@ -264,6 +269,9 @@ module ocn_time_integration_si
       type (mpas_pool_iterator_type) :: &
          groupItr               ! iterator for tracer groups
 
+      type (dm_info) :: dminfo
+
+
       character (len=StrKIND) :: &
          modifiedGroupName,    &! constructed tracer group names
          configName             ! constructed config names for tracers
@@ -277,7 +285,9 @@ module ocn_time_integration_si
          normalVelocityTend,    &! normal velocity tendency
          highFreqThicknessTend, &! thickness tendency for high-freq iter
          lowFreqDivergenceTend, &! thickness tendency for low freq
-         layerThicknessTend      ! main thickness tendency
+         layerThicknessTend,    &! main thickness tendency
+
+         verticalVelocityTend    ! tendency of vertical velocity
 
       real (kind=RKIND), dimension(:,:,:), pointer :: &
          tracersGroupTend,      &! tendencies for tracer groups
@@ -427,7 +437,12 @@ module ocn_time_integration_si
                                           highFreqThicknessTend)
       call mpas_pool_get_array(tendPool, 'lowFreqDivergence', &
                                           lowFreqDivergenceTend)
-
+      call mpas_pool_get_array(tendPool, 'verticalVelocityTend', &
+                                          verticalVelocityTend)
+      call mpas_pool_get_array(statePool, 'verticalVelocity', &
+                                          verticalVelocityNew, 2)
+      call mpas_pool_get_array(statePool, 'verticalVelocity', &
+                                          verticalVelocityCur, 1)
       ! Initialize * variables that are used to compute baroclinic
       ! tendencies below.
 
@@ -494,6 +509,18 @@ module ocn_time_integration_si
             end if
          end if
       end do
+
+!         if(config_enable_nonhydrostatic_mode) then
+            !$omp parallel
+            !$omp do schedule(runtime) private(k)
+            do iCell=1,nCellsAll
+               do k = 2, maxLevelCell(iCell)
+                  verticalVelocityNew(k,iCell) = verticalVelocityCur(k,iCell)
+               end do
+            end do
+            !$omp end do
+            !$omp end parallel
+!         end if
 
       if (associated(highFreqThicknessNew)) then
          !$omp parallel
@@ -616,16 +643,17 @@ module ocn_time_integration_si
 #endif
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
-                 layerThickEdge, normalVelocityCur, sshCur, dt, &
-                 vertAleTransportTop, err, highFreqThicknessNew)
+                 layerThickEdge, normalVelocityCur, verticalVelocityCur, &
+                 sshCur, dt, vertAleTransportTop, nhPressureCorrection, &
+                 err, highFreqThicknessNew)
 #ifdef MPAS_OPENACC
             !$acc exit data delete(highFreqThicknessNew)
 #endif
          else
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
-                 layerThickEdge, normalVelocityCur, sshCur, dt, &
-                 vertAleTransportTop, err)
+                 layerThickEdge, normalVelocityCur, verticalVelocityCur, &
+                 sshCur, dt, vertAleTransportTop, nhPressureCorrection, err)
          endif
 #ifdef MPAS_OPENACC
          !$acc exit data delete(layerThicknessCur, normalVelocityCur, sshCur)
@@ -1151,7 +1179,7 @@ module ocn_time_integration_si
                SIcst_r00w0 = SIcst_r00w0 + SIvec_r00(iCell) &
                                          * SIvec_w0(iCell)
             end do ! iCell
-   
+
             SIcst_allreduce_local2(1) = SIcst_r00r0
             SIcst_allreduce_local2(2) = SIcst_r00w0
    
@@ -1182,7 +1210,7 @@ module ocn_time_integration_si
    
             SIcst_r00r0_global = SIcst_allreduce_global2(1)
             SIcst_r00w0_global = SIcst_allreduce_global2(2)
-   
+
             SIcst_rho0   = SIcst_r00r0_global
             SIcst_alpha0 = SIcst_rho0 / SIcst_r00w0_global
             SIcst_beta0  = 0.0_RKIND
@@ -2595,16 +2623,16 @@ module ocn_time_integration_si
 #endif
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
-                 layerThickEdge, normalTransportVelocity, sshCur, &
-                 dt, vertAleTransportTop, err, highFreqThicknessNew)
+                 layerThickEdge, normalTransportVelocity, verticalVelocityNew, sshCur, &
+                 dt, vertAleTransportTop, nhPressureCorrection, err, highFreqThicknessNew)
 #ifdef MPAS_OPENACC
             !$acc exit data delete(highFreqThicknessNew)
 #endif
          else
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
-                 layerThickEdge, normalTransportVelocity, sshCur, &
-                 dt, vertAleTransportTop, err)
+                 layerThickEdge, normalTransportVelocity, verticalVelocityNew, sshCur, &
+                 dt, vertAleTransportTop, nhPressureCorrection, err)
          endif
 #ifdef MPAS_OPENACC
          !$acc exit data delete(layerThicknessCur, sshCur)
@@ -2629,6 +2657,10 @@ module ocn_time_integration_si
                               meshPool, swForcingPool, &
                               dt, activeTracersOnly, 2)
 
+         if(config_enable_nonhydrostatic_mode) then
+            call ocn_tend_vvel(tendPool, statePool, & 
+                          forcingPool, meshPool, 2, dt)
+         end if
          call mpas_timer_stop('si tracer tend')
 
          ! update halo for tracer tendencies
@@ -2659,6 +2691,11 @@ module ocn_time_integration_si
                                                 normalVelocityCur, 1)
          call mpas_pool_get_array(tracersTendPool,'activeTracersTend', &
                                                    activeTracersTend)
+         if(config_enable_nonhydrostatic_mode) then
+               call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityCur, 1)
+               call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityNew, 2)
+               call mpas_pool_get_array(tendPool, 'verticalVelocityTend', verticalVelocityTend)
+            end if
 
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
          !  If iterating, reset variables for next iteration
@@ -2674,6 +2711,20 @@ module ocn_time_integration_si
 
             ! Only need T & S for earlier iterations,
             ! then all the tracers needed the last time through.
+
+            if(config_enable_nonhydrostatic_mode) then
+                  !$omp parallel
+                  !$omp do schedule(runtime) private(k, temp_h)
+                  do iCell=1,nCells
+                     do k=2,maxLevelCell(iCell)
+                        temp_h = verticalVelocityCur(k,iCell) + dt * verticalVelocityTend(k,iCell)
+                        verticalVelocityNew(k,iCell) = 0.5_RKIND*(verticalVelocityCur(k,iCell) + temp_h)
+                     end do
+                  end do
+                  !$omp end do
+                  !$omp end parallel
+               end if
+
 
             !$omp parallel
             !$omp do schedule(runtime) private(i, k, temp_h, temp)
@@ -3020,6 +3071,28 @@ module ocn_time_integration_si
       call mpas_dmpar_field_halo_exch(domain, 'normalVelocity', &
                                       timeLevel=2)
       call mpas_timer_stop('si vmix halos normalVelFld')
+
+      if(config_enable_nonhydrostatic_mode) then
+            call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityNew, 2)
+            call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityCur, 1)
+            call mpas_pool_get_array(statePool, 'nonhydrostaticPressure', nonhydrostaticPressure,2)
+            call mpas_pool_get_array(statePool, 'nonhydrostaticPressure', nonhydrostaticPressureOld,1)
+
+            dminfo = domain % dminfo
+            call ocn_nonhydrostatic_pressure_tend(normalVelocityNew, verticalVelocityNew, &
+              layerThicknessNew, layerThickEdge, nhPressureCorrection, dminfo % comm, dt)
+
+            call mpas_timer_start('se NHpressure tend halo pressure')
+            call mpas_dmpar_field_halo_exch(domain, 'nonhydrostaticPressure', timeLevel=2)
+            call mpas_dmpar_field_halo_exch(domain, 'nonhydrostaticPressure', timelevel=1)
+            call mpas_dmpar_field_halo_exch(domain, 'nhPressureCorrection')
+            call mpas_timer_stop('se NHpressure tend halo pressure')
+
+            call ocn_nonhydrostatic_pressure_update_velocity(normalVelocityNew, verticalVelocityNew, &
+              layerThicknessNew, layerThickEdge, nonhydrostaticPressure, nonhydrostaticPressureOld, &
+              nhPressureCorrection, dt)
+
+      end if
 
       call mpas_pool_begin_iteration(tracersPool)
       do while ( mpas_pool_get_next_member(tracersPool, groupItr) )

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -38,6 +38,7 @@ module ocn_time_integration_split
    use ocn_diagnostics
    use ocn_gm
 
+   use ocn_compute_nonhydrostatic_pressure
    use ocn_equation_of_state
    use ocn_vmix
    use ocn_time_average_coupled
@@ -129,6 +130,8 @@ module ocn_time_integration_split
       ! Local variables
       !-----------------------------------------------------------------
 
+      type (dm_info) :: dminfo
+
       type (block_type), pointer :: &
          block ! structure with subdomain data
 
@@ -210,7 +213,11 @@ module ocn_time_integration_split
          highFreqThicknessNew,        &! high frq thick at new     time
          lowFreqDivergenceCur,        &! low frq div    at current time
          lowFreqDivergenceNew,        &! low frq div    at new     time
-         tracerGroupIdealAgeMask       ! mask for resetting surface ideal age
+         tracerGroupIdealAgeMask,     & ! mask for resetting surface ideal age
+         verticalVelocityCur,         &! vertical velocity at current time
+         verticalVelocityNew,         &! vertical velocity at new time
+         nonhydrostaticPressure,      &! nonhydro pressure at new time
+         nonhydrostaticPressureOld     ! nonhdyro pressure at current time 
 
       type (field1DReal), pointer :: &
          effectiveDensityField         ! field pointer for halo update
@@ -240,7 +247,8 @@ module ocn_time_integration_split
          normalVelocityTend,    &! normal velocity tendency
          highFreqThicknessTend, &! thickness tendency for high-freq iter
          lowFreqDivergenceTend, &! thickness tendency for low freq
-         layerThicknessTend      ! main thickness tendency
+         layerThicknessTend,    &! main thickness tendency
+         verticalVelocityTend    ! vertical velocity tendency
 
       real (kind=RKIND), dimension(:,:,:), pointer :: &
          tracersGroupTend,      &! tendencies for tracer groups
@@ -304,6 +312,12 @@ module ocn_time_integration_split
                                              tracersTendPool)
 
       !*** Retrieve state variables at two time levels
+      if(config_enable_nonhydrostatic_mode) then
+         call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityCur, 1)
+         call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityNew, 2)
+         call mpas_pool_get_array(statePool, 'nonhydrostaticPressure', nonhydrostaticPressure, 2)
+         call mpas_pool_get_array(statePool, 'nonhydrostaticPressure', nonhydrostaticPressureOld, 1)
+      end if
 
       call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', &
                                            normalBaroclinicVelocityCur, 1)
@@ -455,6 +469,18 @@ module ocn_time_integration_split
          !$omp end parallel
       endif
 
+      if(config_enable_nonhydrostatic_mode) then
+         !$omp parallel
+         !$omp do schedule(runtime) private(k)
+         do iCell = 1, nCellsAll
+            do k = 2, maxLevelCell(iCell)
+               verticalVelocityNew(k,iCell) = verticalVelocityCur(k,iCell)
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
+      end if
+
       call mpas_timer_stop("se prep")
 
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -534,6 +560,8 @@ module ocn_time_integration_split
 
          call mpas_pool_get_array(statePool, 'normalVelocity', &
                            normalVelocityCur, stage1_tend_time)
+         call mpas_pool_get_array(statePool, 'verticalVelocity', &
+                           verticalVelocityCur, stage1_tend_time)
 
          ! compute vertAleTransportTop.  Use u (rather than &
          ! normalTransportVelocity) for momentum advection.
@@ -549,16 +577,19 @@ module ocn_time_integration_split
 #endif
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
-                 layerThickEdge, normalVelocityCur, sshCur, dt, &
-                 vertAleTransportTop, err, highFreqThicknessNew)
+                 layerThickEdge, normalVelocityCur, &
+                 verticalVelocityCur, sshCur, dt, &
+                 vertAleTransportTop, nhPressureCorrection, &
+                 err, highFreqThicknessNew)
 #ifdef MPAS_OPENACC
             !$acc exit data delete(highFreqThicknessNew)
 #endif
          else
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
-                 layerThickEdge, normalVelocityCur, sshCur, dt, &
-                 vertAleTransportTop, err)
+                 layerThickEdge, normalVelocityCur, &
+                 verticalVelocityCur, sshCur, dt, &
+                 vertAleTransportTop, nhPressureCorrection, err)
          endif
 #ifdef MPAS_OPENACC
          !$acc exit data delete(layerThicknessCur, normalVelocityCur, sshCur)
@@ -1496,19 +1527,22 @@ module ocn_time_integration_split
          if (associated(highFreqThicknessNew)) then
 #ifdef MPAS_OPENACC
             !$acc enter data copyin(highFreqThicknessNew)
-#endif
+#endif 
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
-                 layerThickEdge, normalTransportVelocity, sshCur, &
-                 dt, vertAleTransportTop, err, highFreqThicknessNew)
+                 layerThickEdge, normalTransportVelocity, &
+                 verticalVelocityCur, sshCur, &
+                 dt, vertAleTransportTop, nhPressureCorrection, &
+                 err, highFreqThicknessNew)
 #ifdef MPAS_OPENACC
             !$acc exit data delete(highFreqThicknessNew)
 #endif
          else
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
-                 layerThickEdge, normalTransportVelocity, sshCur, &
-                 dt, vertAleTransportTop, err)
+                 layerThickEdge, normalTransportVelocity, &
+                 verticalVelocityCur, sshCur, &
+                 dt, vertAleTransportTop, nhPressureCorrection, err)
          endif
 #ifdef MPAS_OPENACC
          !$acc exit data delete(layerThicknessCur, sshCur)
@@ -1551,6 +1585,8 @@ module ocn_time_integration_split
             end if
          end do
          call mpas_timer_stop("se halo tracers")
+         if(config_enable_nonhydrostatic_mode) call ocn_tend_vvel(tendPool, statePool, &
+                          forcingPool, meshPool, 2, dt)
 
          call mpas_timer_start('se loop fini')
          call mpas_pool_get_array(tracersPool, 'activeTracers', &
@@ -1561,6 +1597,14 @@ module ocn_time_integration_split
                                                 normalVelocityCur, 1)
          call mpas_pool_get_array(tracersTendPool,'activeTracersTend', &
                                                    activeTracersTend)
+         if(config_enable_nonhydrostatic_mode) then
+            call mpas_pool_get_array(statePool, 'verticalVelocity', &
+                                                verticalVelocityCur, 1)
+            call mpas_pool_get_array(statePool, 'verticalVelocity', &
+                                                verticalVelocityNew, 2)
+            call mpas_pool_get_array(tendPool, 'verticalVelocityTend', &
+                                                verticalVelocityTend)
+         end if
 
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
          !  If iterating, reset variables for next iteration
@@ -1604,6 +1648,20 @@ module ocn_time_integration_split
             end do ! iCell
             !$omp end do
             !$omp end parallel
+
+            if(config_enable_nonhydrostatic_mode) then
+              !$omp parallel
+              !$omp do schedule(runtime) private(k, temp_h)
+              do iCell = 1, nCells
+                 do k = 2, maxLevelCell(iCell)
+                    temp_h = verticalVelocityCur(k,iCell) + dt * verticalVelocityTend(k,iCell)
+                    verticalVelocityNew(k,iCell) = 0.5_RKIND*(verticalVelocityCur(k,iCell) + temp_h)
+                 end do
+              end do
+              !$omp end do
+              !$omp end parallel
+            end if
+
 
             if (config_use_freq_filtered_thickness) then
 
@@ -1675,6 +1733,19 @@ module ocn_time_integration_split
             end do
             !$omp end do
             !$omp end parallel
+
+            if(config_enable_nonhydrostatic_mode) then
+               !$omp parallel
+               !$omp do schedule(runtime) private(k)
+               do iCell = 1, nCells
+                  do k = 1, maxLevelCell(iCell)
+                     verticalVelocityNew(k,iCell) = verticalVelocityCur(k,iCell) + dt * verticalVelocityTend(k,iCell)
+                  end do
+               end do
+               !$omp end do
+               !$omp end parallel
+            end if
+
 
             if (config_compute_active_tracer_budgets) then
 
@@ -1917,6 +1988,29 @@ module ocn_time_integration_split
       ! and tracer fields.  So this update is required to communicate
       ! the change due to implicit vertical mixing across the boundary.
 
+      if(config_enable_nonhydrostatic_mode) then
+        dminfo = domain % dminfo
+         call ocn_nonhydrostatic_pressure_tend(normalVelocityNew, &
+              verticalVelocityNew, layerThicknessNew, layerThickEdge, &
+              nhPressureCorrection, dminfo % comm, dt)
+
+         !call mpas_timer_start('se NHpressure tend halo pressure')
+         !call mpas_dmpar_field_halo_exch(domain, 'nonhydrostaticPressure', timeLevel=2)
+         !call mpas_timer_stop('se NHpressure tend halo pressure')
+
+         call mpas_timer_start('se NH pressure tend halo pressure')
+         call mpas_dmpar_field_halo_exch(domain, 'nonhydrostaticPressure', timeLevel=2)
+         call mpas_dmpar_field_halo_exch(domain, 'nonhydrostaticPressure', timeLevel=1)
+         call mpas_dmpar_field_halo_exch(domain, 'nhPressureCorrection')
+         call mpas_timer_stop('se NH pressure tend halo pressure')
+
+         call ocn_nonhydrostatic_pressure_update_velocity(normalVelocityNew, &
+              verticalVelocityNew, layerThicknessNew, layerThickEdge, &
+              nonhydrostaticPressure, nonhydrostaticPressureOld, &
+              nhPressureCorrection, dt)
+      end if
+
+
       call mpas_timer_start('se vmix halos')
 
       call mpas_timer_start('se vmix halos normalVelFld')
@@ -1927,7 +2021,8 @@ module ocn_time_integration_split
       call mpas_pool_begin_iteration(tracersPool)
       do while ( mpas_pool_get_next_member(tracersPool, groupItr) )
          if (groupItr%memberType == MPAS_POOL_FIELD) then
-
+            call mpas_dmpar_field_halo_exch(domain, &
+                         groupItr%memberName, timeLevel=2)
             ! Reset iAge to zero where mask == 0
             if (config_use_idealAgeTracers.and.trim(groupItr%memberName) == 'idealAgeTracers') then
                 call mpas_pool_get_array(tracersPool, &

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -39,6 +39,7 @@ module ocn_time_integration_split
    use ocn_gm
 
    use ocn_compute_nonhydrostatic_pressure
+   use ocn_two_equation_model
    use ocn_equation_of_state
    use ocn_vmix
    use ocn_time_average_coupled
@@ -217,7 +218,11 @@ module ocn_time_integration_split
          verticalVelocityCur,         &! vertical velocity at current time
          verticalVelocityNew,         &! vertical velocity at new time
          nonhydrostaticPressure,      &! nonhydro pressure at new time
-         nonhydrostaticPressureOld     ! nonhdyro pressure at current time 
+         nonhydrostaticPressureOld,   &! nonhdyro pressure at current time
+         tkeNew,                      &! tke at new time
+         tkeCur,                      &! tke at current time
+         glsPsiNew,                   &! glsPsi at new time
+         glsPsiCur                     ! glsPsi at current time
 
       type (field1DReal), pointer :: &
          effectiveDensityField         ! field pointer for halo update
@@ -248,7 +253,9 @@ module ocn_time_integration_split
          highFreqThicknessTend, &! thickness tendency for high-freq iter
          lowFreqDivergenceTend, &! thickness tendency for low freq
          layerThicknessTend,    &! main thickness tendency
-         verticalVelocityTend    ! vertical velocity tendency
+         verticalVelocityTend,  &! vertical velocity tendency
+         tendglsPsi,            &! glsPsi tendency
+         tendTKE                 ! tke tendency
 
       real (kind=RKIND), dimension(:,:,:), pointer :: &
          tracersGroupTend,      &! tendencies for tracer groups
@@ -317,6 +324,14 @@ module ocn_time_integration_split
          call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityNew, 2)
          call mpas_pool_get_array(statePool, 'nonhydrostaticPressure', nonhydrostaticPressure, 2)
          call mpas_pool_get_array(statePool, 'nonhydrostaticPressure', nonhydrostaticPressureOld, 1)
+      end if
+      if(config_use_two_equation_turbulence_model) then
+         call mpas_pool_get_array(statePool, 'tke', tkeNew, 2)
+         call mpas_pool_get_array(statePool, 'tke', tkeCur, 1)
+         call mpas_pool_get_array(statePool, 'glsPsi', glsPsiNew, 2)
+         call mpas_pool_get_array(statePool, 'glsPsi', glsPsiCur, 1)
+         call mpas_pool_get_array(tendPool, 'tendTKE', tendTKE)
+         call mpas_pool_get_array(tendPool, 'tendglsPsi', tendglsPsi)
       end if
 
       call mpas_pool_get_array(statePool, 'normalBaroclinicVelocity', &
@@ -479,6 +494,30 @@ module ocn_time_integration_split
          end do
          !$omp end do
          !$omp end parallel
+      end if
+
+      if(config_use_two_equation_turbulence_model) then
+         !$omp parallel
+         !$omp do schedule(runtime) private(k)
+         do iCell = 1, nCells
+            do k = 2, maxLevelCell(iCell)
+               tkeNew(k,iCell) = tkeCur(k,iCell)
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
+
+         if(.not. config_LES_mode) then
+            !$omp parallel
+            !$omp do schedule(runtime) private(k)
+            do iCell = 1, nCells
+               do k = 2, maxLevelCell(iCell)
+                  glsPsiNew(k,iCell) = glsPsiCur(k,iCell)
+               end do
+            end do
+            !$omp end do
+            !$omp end parallel
+         end if
       end if
 
       call mpas_timer_stop("se prep")
@@ -1527,7 +1566,7 @@ module ocn_time_integration_split
          if (associated(highFreqThicknessNew)) then
 #ifdef MPAS_OPENACC
             !$acc enter data copyin(highFreqThicknessNew)
-#endif 
+#endif
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdge, normalTransportVelocity, &
@@ -1587,6 +1626,15 @@ module ocn_time_integration_split
          call mpas_timer_stop("se halo tracers")
          if(config_enable_nonhydrostatic_mode) call ocn_tend_vvel(tendPool, statePool, &
                           forcingPool, meshPool, 2, dt)
+         if(config_use_two_equation_turbulence_model) then
+            call mpas_pool_get_array(tracersPool, 'activeTracers', tracersGroupNew, 2)
+            call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocityNew, 2)!
+            call ocn_compute_KPP_input_fields(statePool, forcingPool, meshPool, 2)
+
+            call ocn_compute_two_equation_tendency(tendTKE, tendglsPsi, tkeNew, glsPsiNew, velocityZonal, &
+                       velocityMeridional, normalVelocityNew, verticalVelocityNew, layerThicknessNew, &
+                       tracersGroupNew, dt, err)
+         end if
 
          call mpas_timer_start('se loop fini')
          call mpas_pool_get_array(tracersPool, 'activeTracers', &
@@ -1604,6 +1652,10 @@ module ocn_time_integration_split
                                                 verticalVelocityNew, 2)
             call mpas_pool_get_array(tendPool, 'verticalVelocityTend', &
                                                 verticalVelocityTend)
+         end if
+         if(config_use_two_equation_turbulence_model) then
+            call mpas_pool_get_array(tendPool, 'tendTKE', tendTKE)
+            call mpas_pool_get_array(tendPool, 'tendglsPsi', tendglsPsi)
          end if
 
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -1662,6 +1714,30 @@ module ocn_time_integration_split
               !$omp end parallel
             end if
 
+            if(config_use_two_equation_turbulence_model) then
+               !$omp parallel
+               !$omp do schedule(runtime) private(k, temp_h)
+               do iCell = 1, nCells
+                  do k = 1, maxLevelCell(iCell)
+                     temp_h = tkeCur(k,iCell) + dt * tendTKE(k,iCell)
+                     tkeNew(k,iCell) = max(0.0_RKIND, 0.5_RKIND*(tkeCur(k,iCell) + temp_h))
+                  end do
+               end do
+               !$omp end do
+               !$omp end parallel
+               if (.not. config_LES_mode) then
+                  !$omp parallel
+                  !$omp do schedule(runtime) private(k, temp_h)
+                  do iCell = 1, nCells
+                     do k = 1, maxLevelCell(iCell)
+                        temp_h = glsPsiCur(k,iCell) + dt * tendglsPsi(k,iCell)
+                        glsPsiNew(k,iCell) = max(0.0_RKIND, 0.5_RKIND*(glsPsiCur(k,iCell) + temp_h))
+                     end do
+                  end do
+                  !$omp end do
+                  !$omp end parallel
+               end if
+            end if
 
             if (config_use_freq_filtered_thickness) then
 
@@ -1746,6 +1822,28 @@ module ocn_time_integration_split
                !$omp end parallel
             end if
 
+            if(config_use_two_equation_turbulence_model) then
+               !$omp parallel
+               !$omp do schedule(runtime) private(k)
+               do iCell = 1, nCells
+                  do k = 1, maxLevelCell(iCell)
+                     tkeNew(k,iCell) = max(0.0_RKIND, tkeCur(k,iCell) + dt * tendTKE(k,iCell))
+                  end do
+               end do
+               !$omp end do
+               !$omp end parallel
+               if (.not. config_LES_mode) then
+                  !$omp parallel
+                  !$omp do schedule(runtime) private(k)
+                  do iCell = 1, nCells
+                     do k = 1, maxLevelCell(iCell)
+                        glsPsiNew(k,iCell) = max(0.0_RKIND, glsPsiCur(k,iCell) + dt * tendglsPsi(k,iCell))
+                     end do
+                  end do
+                  !$omp end do
+                  !$omp end parallel
+               end if
+            end if
 
             if (config_compute_active_tracer_budgets) then
 
@@ -1971,6 +2069,10 @@ module ocn_time_integration_split
                                 scratchPool, tracersPool, 2)
 
       call mpas_dmpar_field_halo_exch(domain, 'surfaceFrictionVelocity')
+
+      if (config_use_two_equation_turbulence_model) then
+           call ocn_compute_two_equation_diff(tkeNew, glsPsiNew, layerThicknessNew, dt, err)
+      end if
 
       ! Compute normalGMBolusVelocity; it will be added to the
       ! baroclinic modes in Stage 2 above.

--- a/components/mpas-ocean/src/shared/Makefile
+++ b/components/mpas-ocean/src/shared/Makefile
@@ -133,7 +133,7 @@ mpas_ocn_vel_vadv.o: mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_vel_hmix.o: mpas_ocn_vel_hmix_del2.o mpas_ocn_vel_hmix_leith.o mpas_ocn_vel_hmix_del4.o mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_vel_hmix_del2.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_vel_hmix_del2.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_vel_hmix_leith.o: mpas_ocn_constants.o mpas_ocn_config.o
 
@@ -165,7 +165,7 @@ mpas_ocn_nonhydrostatic_pressure_solve.o: mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_tracer_hmix.o: mpas_ocn_tracer_hmix_del2.o mpas_ocn_tracer_hmix_del4.o mpas_ocn_tracer_hmix_redi.o
 
-mpas_ocn_tracer_hmix_del2.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_tracer_hmix_del2.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_tracer_hmix_del4.o: mpas_ocn_constants.o mpas_ocn_config.o
 

--- a/components/mpas-ocean/src/shared/Makefile
+++ b/components/mpas-ocean/src/shared/Makefile
@@ -79,7 +79,15 @@ OBJS = mpas_ocn_init_routines.o \
 	   mpas_ocn_wetting_drying.o \
 	   mpas_ocn_vel_tidal_potential.o \
 	   mpas_ocn_vel_forcing_topographic_wave_drag.o \
-	   mpas_ocn_transport_tests.o
+	   mpas_ocn_transport_tests.o \
+           mpas_ocn_two_equation_model_driver.o \
+           mpas_ocn_two_equation_structure_functions.o \
+           mpas_ocn_two_equation_model_driver.o \
+           mpas_ocn_tke_glsPsi_transport.o \
+           mpas_ocn_tke_advection_mono.o \
+           mpas_ocn_glsPsi_advection_mono.o \
+           mpas_ocn_shear_production.o \
+           mpas_ocn_buoyancy_production.o
 
 all: $(OBJS)
 
@@ -104,6 +112,20 @@ mpas_ocn_thick_vadv.o: mpas_ocn_constants.o mpas_ocn_config.o
 mpas_ocn_thick_surface_flux.o: mpas_ocn_forcing.o mpas_ocn_constants.o mpas_ocn_config.o
 
 mpas_ocn_gm.o:  mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o
+
+mpas_ocn_two_equation_model_driver.o: mpas_ocn_tracer_advection_shared.o mpas_ocn_mesh.o mpas_ocn_tke_advection_mono.o mpas_ocn_glsPsi_advection_mono.o mpas_ocn_tke_glsPsi_transport.o mpas_ocn_shear_production.o mpas_ocn_buoyancy_production.o mpas_ocn_diagnostics_variables.o mpas_ocn_two_equation_structure_functions.o mpas_ocn_config.o
+
+mpas_ocn_two_equation_structure_functions.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o
+
+mpas_ocn_tke_advection_mono.o: mpas_ocn_constants.o mpas_ocn_mesh.o
+
+mpas_ocn_glsPsi_advection.o: mpas_ocn_constants.o mpas_ocn_mesh.o
+
+mpas_ocn_tke_glsPsi_transport.o: mpas_ocn_diagnostics_variables.o mpas_ocn_mesh.o mpas_ocn_constants.o mpas_ocn_config.o
+
+mpas_ocn_shear_production.o: mpas_ocn_constants.o mpas_ocn_diagnostics_variables.o mpas_ocn_config.o mpas_ocn_mesh.o
+
+mpas_ocn_buoyancy_production.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_vel_pressure_grad.o: mpas_ocn_constants.o mpas_ocn_config.o
 

--- a/components/mpas-ocean/src/shared/Makefile
+++ b/components/mpas-ocean/src/shared/Makefile
@@ -27,6 +27,13 @@ OBJS = mpas_ocn_init_routines.o \
 	   mpas_ocn_vel_forcing_surface_stress.o \
 	   mpas_ocn_vel_forcing_explicit_bottom_drag.o \
 	   mpas_ocn_vel_pressure_grad.o \
+		 mpas_ocn_vvel_vert_advection.o \
+		 mpas_ocn_vvel_horiz_advection.o \
+		 mpas_ocn_vvel_coriolis.o \
+		 mpas_ocn_vvel_hmix_del2.o \
+		 mpas_ocn_vvel_advection.o \
+		 mpas_ocn_vvel_pgf.o \
+		 mpas_ocn_nonhydrostatic_pressure_solve.o \
 	   mpas_ocn_vmix.o \
 	   mpas_ocn_vmix_coefs_redi.o \
 	   mpas_ocn_vmix_cvmix.o \
@@ -78,7 +85,7 @@ all: $(OBJS)
 
 mpas_ocn_init_routines.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics.o mpas_ocn_gm.o mpas_ocn_forcing.o mpas_ocn_surface_land_ice_fluxes.o
 
-mpas_ocn_tendency.o: mpas_ocn_high_freq_thickness_hmix_del2.o mpas_ocn_tracer_surface_restoring.o mpas_ocn_thick_surface_flux.o mpas_ocn_tracer_short_wave_absorption.o mpas_ocn_tracer_advection.o mpas_ocn_tracer_hmix.o mpas_ocn_tracer_nonlocalflux.o mpas_ocn_surface_bulk_forcing.o mpas_ocn_surface_land_ice_fluxes.o mpas_ocn_tracer_surface_flux_to_tend.o mpas_ocn_tracer_interior_restoring.o mpas_ocn_tracer_exponential_decay.o mpas_ocn_tracer_ideal_age.o mpas_ocn_tracer_TTD.o mpas_ocn_vmix.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_frazil_forcing.o mpas_ocn_tidal_forcing.o mpas_ocn_tracer_ecosys.o mpas_ocn_tracer_DMS.o mpas_ocn_tracer_MacroMolecules.o mpas_ocn_tracer_CFC.o mpas_ocn_diagnostics.o mpas_ocn_wetting_drying.o mpas_ocn_tidal_potential_forcing.o mpas_ocn_vel_tidal_potential.o mpas_ocn_mesh.o
+mpas_ocn_tendency.o: mpas_ocn_high_freq_thickness_hmix_del2.o mpas_ocn_tracer_surface_restoring.o mpas_ocn_thick_surface_flux.o mpas_ocn_tracer_short_wave_absorption.o mpas_ocn_tracer_advection.o mpas_ocn_tracer_hmix.o mpas_ocn_tracer_nonlocalflux.o mpas_ocn_surface_bulk_forcing.o mpas_ocn_surface_land_ice_fluxes.o mpas_ocn_tracer_surface_flux_to_tend.o mpas_ocn_tracer_interior_restoring.o mpas_ocn_tracer_exponential_decay.o mpas_ocn_tracer_ideal_age.o mpas_ocn_tracer_TTD.o mpas_ocn_vmix.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_frazil_forcing.o mpas_ocn_tidal_forcing.o mpas_ocn_tracer_ecosys.o mpas_ocn_tracer_DMS.o mpas_ocn_tracer_MacroMolecules.o mpas_ocn_tracer_CFC.o mpas_ocn_diagnostics.o mpas_ocn_wetting_drying.o mpas_ocn_tidal_potential_forcing.o mpas_ocn_vel_tidal_potential.o mpas_ocn_mesh.o mpas_ocn_vvel_pgrad.o mpas_ocn_vvel_advection.o mpas_ocn_vvel_coriolis.o mpas_ocn_vvel_hmix_del2.o
 
 mpas_ocn_diagnostics.o: mpas_ocn_thick_ale.o mpas_ocn_equation_of_state.o mpas_ocn_gm.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o mpas_ocn_surface_land_ice_fluxes.o
 
@@ -119,6 +126,20 @@ mpas_ocn_vel_forcing_topographic_wave_drag.o: mpas_ocn_constants.o mpas_ocn_conf
 mpas_ocn_vel_forcing_explicit_bottom_drag.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_forcing.o
 
 mpas_ocn_vel_hadv_coriolis.o: mpas_ocn_constants.o mpas_ocn_config.o
+
+mpas_ocn_vvel_coriolis.o: mpas_ocn_constants.o mpas_ocn_config.o
+
+mpas_ocn_vvel_pgf.o: mpas_ocn_diagnostics_variables.o mpas_ocn_constants.o mpas_ocn_config.o
+
+mpas_ocn_vvel_vert_advection.o: mpas_ocn_mesh.o mpas_ocn_tracer_advection_shared.o mpas_ocn_constants.o mpas_ocn_config.o
+
+mpas_ocn_vvel_horiz_advection.o: mpas_ocn_tracer_advection_shared.o mpas_ocn_mesh.o mpas_ocn_constants.o mpas_ocn_diagnostics_variables.o mpas_ocn_config.o
+
+mpas_ocn_vvel_hmix_del2.o: mpas_ocn_diagnostics_variables.o mpas_ocn_constants.o mpas_ocn_config.o
+
+mpas_ocn_vvel_advection.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_vvel_horiz_advection.o mpas_ocn_vvel_vert_advection.o
+
+mpas_ocn_nonhydrostatic_pressure_solve.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o
 
 mpas_ocn_tracer_hmix.o: mpas_ocn_tracer_hmix_del2.o mpas_ocn_tracer_hmix_del4.o mpas_ocn_tracer_hmix_redi.o
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_buoyancy_production.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_buoyancy_production.F
@@ -1,0 +1,154 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_buoyancy_production
+!
+!> \brief MPAS ocean buoyancy production calculation 
+!> \author Luke Van Roekel
+!> \date   July 2021
+!> \details
+!>  This module contains the computation for buoyancy production 
+!>  for the two equation turbulence model
+!>
+!
+!-----------------------------------------------------------------------
+
+module ocn_buoyancy_production
+
+   use mpas_timer
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_threading
+   use mpas_constants
+
+   use ocn_constants
+   use ocn_config
+   use ocn_mesh
+   use ocn_diagnostics_variables
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: ocn_buoyancy_production_compute
+
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+!
+!  routine ocn_buoyancy_production_compute
+!
+!> \brief   Computes Buoyancy production term  
+!> \author  Luke Van Roekel 
+!> \date    July 2021
+!> \details
+!>  This routine computes the buoyancy production tendency for the 
+!>  two equation turbulence model, applies turbulence for the tke and 
+!>  dissipation in the same calculation.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_buoyancy_production_compute(tkeTend, glsPsiTend, glsPsi, &
+                                              tke, c_psi3, surfaceBuoyancyForcing, &
+                                              err)!{{{
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tkeTend, glsPsiTend          !< Input/Output: velocity tendency
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         glsPsi, tke
+
+      real (kind=RKIND), dimension(:), intent(in) :: surfaceBuoyancyForcing
+
+      real (kind=RKIND), intent(in) :: c_psi3
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, iEdge, cell1, cell2
+      integer :: i, k, nCells
+      integer, pointer :: nVertLevels
+
+      real (kind=RKIND) :: invAreaCell
+      real (kind=RKIND) :: buoyancyProduction, diffMid 
+
+      err = 0
+
+      call mpas_timer_start("buoyancy production compute")
+
+      !
+      ! compute a boundary mask to enforce insulating boundary conditions in the horizontal
+      !
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(k, diffMid, c_psi3, buoyancyProduction)
+      do iCell = 1, nCellsOwned
+         k = 1
+         diffMid = 0.5_RKIND*(vertDiffTopOfCell(k+1,iCell) + vertDiffTopOfCell(k,iCell))
+         buoyancyProduction = 0.5_RKIND*(gravity*thermExpCoeff(k,iCell)*tgrad(3,k,iCell)*diffMid - &
+                              gravity*salineContractCoeff(k,iCell)*sgrad(3,k,iCell)*diffMid - &
+                              surfaceBuoyancyForcing(iCell)) 
+
+
+         tkeTend(k,iCell) = tkeTend(k,iCell) + buoyancyProduction
+         glsPsiTend(k,iCell) = glsPsiTend(k,iCell) + glsPsi(k,iCell)/(tke(k,iCell) + 1.0E-15_RKIND)* &
+                               c_psi3*buoyancyProduction
+
+         do k=2,maxLevelCell(iCell)
+            diffMid = 0.5_RKIND*(vertDiffTopOfCell(k+1,iCell) + vertDiffTopOfCell(k,iCell))
+            buoyancyProduction = gravity*thermExpCoeff(k,iCell)*tgrad(3,k,iCell)*diffMid - &
+                                 gravity*salineContractCoeff(k,iCell)*sgrad(3,k,iCell)*diffMid
+
+            tkeTend(k,iCell) = tkeTend(k,iCell) + buoyancyProduction
+            glsPsiTend(k,iCell) = glsPsiTend(k,iCell) + glsPsi(k,iCell)/(tke(k,iCell) + 1.0E-15_RKIND)* &
+                                                  c_psi3*buoyancyProduction
+         end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      call mpas_timer_stop("buoyancy production compute")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_buoyancy_production_compute!}}}
+
+end module ocn_buoyancy_production
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+! vim: foldmethod=marker

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -111,7 +111,7 @@ contains
       real (kind=RKIND), dimension(:), pointer :: &
         ssh,  seaIcePressure, atmosphericPressure
       real (kind=RKIND), dimension(:,:), pointer :: &
-        layerThickness, normalVelocity
+        layerThickness, normalVelocity, verticalVelocity, nonhydrostaticPressure
 
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
 
@@ -144,8 +144,10 @@ contains
       call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, timeLevel)
 
+      call mpas_pool_get_array(statePool, 'nonhydrostaticPressure', nonhydrostaticPressure, timeLevel)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
+      call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocity, timeLevel)
       call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
 
       call mpas_pool_get_array(forcingPool, 'seaIcePressure', seaIcePressure)
@@ -225,7 +227,7 @@ contains
       ! in and out: vertVelocityTop
       call ocn_diagnostic_solve_vortVel(relativeVorticity, &
              layerThickEdge, normalVelocity, normalTransportVelocity, &
-             normalGMBolusVelocity, vertVelocityTop, vertTransportVelocityTop, &
+             normalGMBolusVelocity, verticalVelocity, vertVelocityTop, vertTransportVelocityTop, &
              vertGMBolusVelocityTop, relativeVorticityCell, divergence, &
              kineticEnergyCell, tangentialVelocity)
 
@@ -1006,7 +1008,7 @@ contains
 
       nCells = nCellsAll
       nVertices = nVerticesAll
-      nEdges = nCellsAll
+      nEdges = nEdgesAll
       apvm_scale_factor = config_apvm_scale_factor;
 
       ! Diagnostics required for the Anticipated Potential Vorticity Method (apvm).
@@ -1029,8 +1031,8 @@ contains
          do iEdge = 1,nEdges
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
-            vertex1 = verticesOnedge(1, iEdge)
-            vertex2 = verticesOnedge(2, iEdge)
+            vertex1 = verticesOnEdge(1, iEdge)
+            vertex2 = verticesOnEdge(2, iEdge)
 
             invLength = 1.0_RKIND / dcEdge(iEdge)
             ! Compute gradient of PV in normal direction
@@ -1426,9 +1428,10 @@ contains
 !-----------------------------------------------------------------------
    subroutine ocn_diagnostic_solve_vortVel(relativeVorticity, &
                 layerThicknessEdge, normalVelocity, normalTransportVelocity, &
-                normalGMBolusVelocity, vertVelocityTop, vertTransportVelocityTop, &
-                vertGMBolusVelocityTop, relativeVorticityCell, divergence, &
-                kineticEnergyCell, tangentialVelocity)!{{{
+                normalGMBolusVelocity, verticalVelocity, vertVelocityTop, &
+                vertTransportVelocityTop, vertGMBolusVelocityTop, &
+                relativeVorticityCell, divergence, kineticEnergyCell,&
+                tangentialVelocity)!{{{
 
       implicit none
 
@@ -1456,7 +1459,7 @@ contains
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         vertVelocityTop
+         vertVelocityTop, verticalVelocity
       real (kind=RKIND), dimension(:,:), intent(out) :: &
          vertTransportVelocityTop
       real (kind=RKIND), dimension(:,:), intent(out) :: &
@@ -1586,6 +1589,20 @@ contains
       !$omp end do
       !$omp end parallel
 #endif
+
+      !LVR: 20201204 -- add in new vertical velocity prognostic variable
+      if(.not. config_enable_nonhydrostatic_mode .or. config_enable_vertMomentum_disable_nonHydro) then
+        !$omp parallel
+        !$omp do schedule(runtime) &
+        !$omp private(k)
+        do iCell=1,nCells
+          do k=1,maxLevelCell(iCell)+1
+            verticalVelocity(k,iCell) = vertVelocityTop(k,iCell)
+          enddo
+        enddo
+        !$omp end do
+        !$omp end parallel
+      endif
 
       deallocate(div_hu,div_huTransport,div_huGMBolus)
 
@@ -2039,7 +2056,8 @@ contains
 !
 !-----------------------------------------------------------------------
    subroutine ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, oldLayerThickness, layerThicknessEdge, &
-     normalVelocity, oldSSH, dt, vertAleTransportTop, err, newHighFreqThickness)!{{{
+     normalVelocity, verticalVelocity, oldSSH, dt, vertAleTransportTop, nhPressureCorrection, err, &
+     newHighFreqThickness)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -2065,8 +2083,16 @@ contains
       real (kind=RKIND), dimension(:), intent(in) :: &
          oldSSH     !< Input: sea surface height at old time
 
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        verticalVelocity !predicted velocity, ale is motion relative to grid
+                         !this is needed since nonhydrostatic predicts velocity
+                         ! in hydrostatic mode this is set to vertVelocityTop from diagnostic_solve
+
       real (kind=RKIND), dimension(:,:), intent(in), optional :: &
          newHighFreqThickness   !< Input: high frequency thickness.  Alters ALE thickness.
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         nhPressureCorrection
 
       real (kind=RKIND), intent(in) :: &
          dt     !< Input: time step
@@ -2088,7 +2114,7 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: iEdge, iCell, k, i, nCells, kmin, kmax
+      integer :: iEdge, iCell, k, i, nCells, cell1, cell2, kmin, kmax
 
       real (kind=RKIND) :: flux, invAreaCell1, div_hu_btr
       integer, dimension(:,:), pointer :: edgeSignOnCell
@@ -2211,6 +2237,25 @@ contains
       !$omp end parallel
 #endif
 
+      if(config_enable_nonhydrostatic_mode) then
+        !FIXME - need to add vertGMBolusVelocity here
+        !$omp parallel
+        !$omp do schedule(runtime) private(k)
+        do iCell = 1,nCells
+           vertAleTransportTop(1,iCell) = 0.0_RKIND
+           vertAleTransportTop(maxLevelCell(iCell)+1,iCell) = 0.0_RKIND
+           do k = maxLevelCell(iCell),2,-1
+             vertAleTransportTop(k,iCell) = vertAleTransportTop(k+1,iCell) - div_hu(k,iCell) &
+                - (ALE_Thickness(k,iCell) - oldLayerThickness(k,iCell))/dt
+           end do
+           if(config_disable_ALE) then
+              k=1
+              vertAleTransportTop(k,iCell) = vertAleTransportTop(k+1,iCell) - div_hu(k,iCell)
+           end if
+        end do
+        !$omp end do
+        !$omp end parallel
+      end if
       deallocate(div_hu, &
                  projectedSSH, &
                  ALE_Thickness)

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -141,6 +141,10 @@ module ocn_diagnostics_variables
       velocityForcingTend, &
       velocityPGFtend
 
+   real (kind=RKIND), dimension(:,:,:), pointer :: ugrad, vgrad, wgrad
+   real (kind=RKIND), dimension(:,:,:), pointer :: tgrad, sgrad
+   real (kind=RKIND), dimension(:,:), pointer :: Sm, Sh
+
    real (kind=RKIND), dimension(:,:), pointer :: vertDiffTopOfCell
    real (kind=RKIND), dimension(:,:,:), pointer :: vertNonLocalFlux
    integer, dimension(:,:), pointer :: rediLimiterCount
@@ -203,6 +207,7 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:), pointer :: SIvec_z0,SIvec_z1 ,SIvec_zh0,SIvec_zh1
 
    real (kind=RKIND), dimension(:,:), pointer :: nhPressureCorrection
+   real (kind=RKIND), dimension(:,:), pointer :: dynamicViscosity, uStar, yPlus
 
    !--------------------------------------------------------------------
    !
@@ -602,6 +607,16 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'velocityCoriolisTend', velocityCoriolisTend)
 
       call mpas_pool_get_array(diagnosticsPool, 'nhPressureCorrection', nhPressureCorrection)
+      call mpas_pool_get_array(diagnosticsPool, 'dynamicViscosity', dynamicViscosity)
+      call mpas_pool_get_array(diagnosticsPool, 'yPlus', yPlus)
+      call mpas_pool_get_array(diagnosticsPool, 'uStar', uStar)
+      call mpas_pool_get_array(diagnosticsPool, 'ugrad', ugrad)
+      call mpas_pool_get_array(diagnosticsPool, 'vgrad', vgrad)
+      call mpas_pool_get_array(diagnosticsPool, 'wgrad', wgrad)
+      call mpas_pool_get_array(diagnosticsPool, 'tgrad', tgrad)
+      call mpas_pool_get_array(diagnosticsPool, 'sgrad', sgrad)
+      call mpas_pool_get_array(diagnosticsPool, 'Sm', Sm)
+      call mpas_pool_get_array(diagnosticsPool, 'Sh', Sh)
 
       ! Semi-implicit Array Pointer retrievals
       if (trim(config_time_integrator) == 'split_implicit') then
@@ -751,8 +766,16 @@ contains
          !$acc                   velocityHmixTend,                &
          !$acc                   velocityVmixTend,                &
          !$acc                   velocityCoriolisTend,            &
-         !$acc                   nhPressureCorrection             &
-         !$acc                   )
+         !$acc                   nhPressureCorrection,            &
+         !$acc                   dynamicViscosity                 &
+         !$acc                   yPlus,                           &
+         !$acc                   uStar,                           &
+         !$acc                   ugrad,                           &
+         !$acc                   vgrad,                           &
+         !$acc                   wgrad,                           &
+         !$acc                   Sm,                              &
+         !$acc                   Sh                               &
+         !$acc                   ) 
       end if
       if ( trim(config_ocean_run_mode) == 'forward' ) then
          !$acc enter data copyin( &
@@ -995,7 +1018,15 @@ contains
          !$acc                   velocityHmixTend,                &
          !$acc                   velocityVmixTend,                &
          !$acc                   velocityCoriolisTend,            &
-         !$acc                   nhPressureCorrection             &
+         !$acc                   nhPressureCorrection,            &
+         !$acc                   dynamicViscosity,                &
+         !$acc                   yPlus,                           &
+         !$acc                   uStar,                           &
+         !$acc                   ugrad,                           &
+         !$acc                   vgrad,                           &
+         !$acc                   wgrad,                           &
+         !$acc                   Sm,                              &
+         !$acc                   Sh                               &
          !$acc                   )
       end if
       if ( trim(config_ocean_run_mode) == 'forward' ) then
@@ -1200,7 +1231,15 @@ contains
                  velocityHmixTend,                &
                  velocityVadvTend,                &
                  velocityPGFtend,                 &
-                 velocityForcingTend)
+                 velocityForcingTend,             &
+                 dynamicViscosity,                &
+                 yPlus,                           &
+                 uStar,                           &
+                 ugrad,                           &
+                 vgrad,                           &
+                 wgrad,                           &
+                 Sh,                              &
+                 Sm)
       end if
       if ( trim(config_ocean_run_mode) == 'forward' ) then
          nullify(wettingVelocity)

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -133,6 +133,14 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:,:), pointer :: wettingVelocity
    type (field2DReal), pointer :: wettingVelocityField
 
+   real (kind=RKIND), dimension(:,:), pointer :: &
+      velocityVmixtend, &
+      velocityHmixtend, &
+      velocityCoriolisTend, &
+      velocityVadvTend, &
+      velocityForcingTend, &
+      velocityPGFtend
+
    real (kind=RKIND), dimension(:,:), pointer :: vertDiffTopOfCell
    real (kind=RKIND), dimension(:,:,:), pointer :: vertNonLocalFlux
    integer, dimension(:,:), pointer :: rediLimiterCount
@@ -193,6 +201,8 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:), pointer :: SIvec_t0,SIvec_t1 ,SIvec_q0 ,SIvec_q1 ,SIvec_qh0
    real (kind=RKIND), dimension(:), pointer :: SIvec_w0,SIvec_w1 ,SIvec_wh0,SIvec_wh1,SIvec_y0
    real (kind=RKIND), dimension(:), pointer :: SIvec_z0,SIvec_z1 ,SIvec_zh0,SIvec_zh1
+
+   real (kind=RKIND), dimension(:,:), pointer :: nhPressureCorrection
 
    !--------------------------------------------------------------------
    !
@@ -584,6 +594,14 @@ contains
       call mpas_pool_get_array(diagnosticsPool, 'indMLD', indMLD)
       call mpas_pool_get_array(diagnosticsPool, 'surfacePressure', &
                 surfacePressure)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityForcingTend', velocityForcingTend)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityPGFtend', velocityPGFtend)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityVadvTend', velocityVadvTend)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityHmixTend', velocityHmixTend)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityVmixTend', velocityVmixTend)
+      call mpas_pool_get_array(diagnosticsPool, 'velocityCoriolisTend', velocityCoriolisTend)
+
+      call mpas_pool_get_array(diagnosticsPool, 'nhPressureCorrection', nhPressureCorrection)
 
       ! Semi-implicit Array Pointer retrievals
       if (trim(config_time_integrator) == 'split_implicit') then
@@ -726,7 +744,14 @@ contains
          !$acc                   transportVelocityMeridional,     &
          !$acc                   penetrativeTemperatureFluxOBL,   &
          !$acc                   indexSurfaceVelocityMeridional,  &
-         !$acc                   normalizedRelativeVorticityCell  &
+         !$acc                   normalizedRelativeVorticityCell, &
+         !$acc                   velocityPGFtend,                 &
+         !$acc                   velocityForcingTend,             &
+         !$acc                   velocityVadvTend,                &
+         !$acc                   velocityHmixTend,                &
+         !$acc                   velocityVmixTend,                &
+         !$acc                   velocityCoriolisTend,            &
+         !$acc                   nhPressureCorrection             &
          !$acc                   )
       end if
       if ( trim(config_ocean_run_mode) == 'forward' ) then
@@ -963,7 +988,14 @@ contains
          !$acc                   transportVelocityMeridional,     &
          !$acc                   penetrativeTemperatureFluxOBL,   &
          !$acc                   indexSurfaceVelocityMeridional,  &
-         !$acc                   normalizedRelativeVorticityCell  &
+         !$acc                   normalizedRelativeVorticityCell, &
+         !$acc                   velocityPGFtend,                 &
+         !$acc                   velocityForcingTend,             &
+         !$acc                   velocityVadvTend,                &
+         !$acc                   velocityHmixTend,                &
+         !$acc                   velocityVmixTend,                &
+         !$acc                   velocityCoriolisTend,            &
+         !$acc                   nhPressureCorrection             &
          !$acc                   )
       end if
       if ( trim(config_ocean_run_mode) == 'forward' ) then
@@ -1161,7 +1193,14 @@ contains
                  transportVelocityMeridional,     &
                  penetrativeTemperatureFluxOBL,   &
                  indexSurfaceVelocityMeridional,  &
-                 normalizedRelativeVorticityCell)
+                 normalizedRelativeVorticityCell, &
+                 nhPressureCorrection,            &
+                 velocityCoriolisTend,            &
+                 velocityVmixTend,                &
+                 velocityHmixTend,                &
+                 velocityVadvTend,                &
+                 velocityPGFtend,                 &
+                 velocityForcingTend)
       end if
       if ( trim(config_ocean_run_mode) == 'forward' ) then
          nullify(wettingVelocity)

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -134,8 +134,8 @@ module ocn_diagnostics_variables
    type (field2DReal), pointer :: wettingVelocityField
 
    real (kind=RKIND), dimension(:,:), pointer :: &
-      velocityVmixtend, &
-      velocityHmixtend, &
+      velocityVmixTend, &
+      velocityHmixTend, &
       velocityCoriolisTend, &
       velocityVadvTend, &
       velocityForcingTend, &

--- a/components/mpas-ocean/src/shared/mpas_ocn_glsPsi_advection_mono.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_glsPsi_advection_mono.F
@@ -341,7 +341,7 @@ module ocn_glsPsi_advection_mono
         !$omp parallel
         !$omp do schedule(runtime) &
         !$omp private(invAreaCell1, i, iEdge, cell1, cell2, signedFactor, k, &
-        !$omp         tkeUpwindNew, tkeMinNew, tkeMaxNew, scaleFactor)
+        !$omp         scaleFactor)
         do iCell = 1, nCells
           invAreaCell1 = 1.0_RKIND / areaCell(iCell)
 
@@ -668,7 +668,7 @@ module ocn_glsPsi_advection_mono
         nCells = nCellsHalo( 1 )
         !$omp parallel
         !$omp do schedule(runtime) &
-        !$omp private(k, tkeMinNew, tkeMaxNew, tkeUpwindNew, scaleFactor)
+        !$omp private(k, scaleFactor)
         do iCell = 1, nCells
 
           ! Build the scale factors to limit flux for FCT
@@ -756,7 +756,7 @@ module ocn_glsPsi_advection_mono
           nCells = nCellsOwned
           ! Check for monotonicity of new tke value
           !$omp parallel
-          !$omp do schedule(runtime) private(k, tkeNew)
+          !$omp do schedule(runtime) private(k)
           do iCell = 1, nCells
           do k = 1, maxLevelCell(iCell)
              ! workTend on the RHS is the total vertical advection tendency

--- a/components/mpas-ocean/src/shared/mpas_ocn_glsPsi_advection_mono.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_glsPsi_advection_mono.F
@@ -1,0 +1,897 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_glsPsi_advection_mono
+!
+!> \brief MPAS monotonic glsPsi advection with FCT
+!> \author Luke Van Roekel
+!> \date   updated June 2021
+!> \details
+!>  This module contains routines for monotonic advection of glsPsi (Umlauf and Burchard 2003)
+!>  using a Flux Corrected Transport (FCT) algorithm, which is based on 
+!>  the tracer advection mono routines.
+!
+!-------------------------------------------------------------------------------
+
+module ocn_glsPsi_advection_mono
+
+   ! module includes
+#ifdef _ADV_TIMERS
+   use mpas_timer
+#endif
+   use mpas_kind_types
+   use mpas_derived_types
+   use mpas_dmpar
+   use mpas_pool_routines
+   use mpas_io_units
+   use mpas_threading
+   use mpas_tracer_advection_helpers
+
+   use ocn_mesh
+   use ocn_constants
+
+   implicit none
+   private
+   save
+
+   ! module private variables
+   real (kind=RKIND) ::  &
+      coef3rdOrder        !< high-order horizontal coefficient
+   logical ::            &
+      monotonicityCheck   !< flag to check monotonicity
+   integer ::            &
+      vertOrder           !< choice of order for vertical advection
+   integer, parameter :: &! enum for supported vertical algorithm order
+      vertOrder2 = 2,    &!< 2nd order scheme
+      vertOrder3 = 3,    &!< 3rd order scheme
+      vertOrder4 = 4      !< 4th order scheme
+
+   ! These temporary allocatable arrays will eventually be moved back into
+   ! the tendency routine, but must be declared here for now so that they
+   ! retain the shared attribute. Once the threading model has been changed,
+   ! these should become thread private again with reduced size
+
+   real (kind=RKIND), dimension(:,:), allocatable :: &
+      glsPsiMax,     &! max glsPsi in neighbors for limiting
+      glsPsiMin,     &! min glsPsi in neighbors for limiting
+      hNewInv,       &! inverse of new layer thickness
+      hProv,         &! provisional layer thickness
+      hProvInv,      &! inverse of provisional layer thickness
+      flxIn,         &! flux coming into each cell
+      flxOut,        &! flux going out of each cell
+      workTend,      &! temp for holding some tendency values
+      lowOrderFlx,   &! low order flux for FCT
+      highOrderFlx    ! high order flux for FCT
+
+   ! public method interfaces
+   public :: ocn_glsPsi_advection_mono_tend, &
+             ocn_glsPsi_advection_mono_init
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+
+   contains
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine ocn_glsPsi_advection_mono_tend
+!
+!> \brief MPAS monotonic glsPsi horizontal advection tendency with FCT
+!> \author Luke Van Roekel 
+!> \date   updated June 2021
+!> \details
+!>  This routine computes the monotonic glsPsi horizontal advection tendency
+!>  using a flux-corrected transport (FCT) algorithm.  This is based on the 
+!>  tracer advection mono routines.
+!
+!-------------------------------------------------------------------------------
+
+   subroutine ocn_glsPsi_advection_mono_tend(tend, glsPsi, layerThickness,    &
+                                             normalThicknessFlux, w, dt,       &
+                                             advCoefs, advCoefs3rd,            &
+                                             nAdvCellsForEdge, advCellsForEdge,&
+                                             highOrderAdvectionMask)
+
+      !*** Input/Output parameters
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend            !< [in,out] glsPsi tendency to which advection added
+
+      !*** Input parameters
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         glsPsi                 !< [in] Current glsPsi values
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness      !< [in] Thickness
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalThicknessFlux !< [in] Thichness weighted velocitiy
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         w                   !< [in] Vertical velocity
+      real (kind=RKIND), intent(in) :: &
+         dt                  !< [in] Timestep
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         advCoefs            !< [in] Coefficients for 2nd order advection
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         advCoefs3rd         !< [in] Coeffs for missing 3rd/4th order advection
+      integer, dimension(:), intent(in) :: &
+         nAdvCellsForEdge    !< [in] Number of advection cells for each edge
+      integer, dimension(:,:), intent(in) :: &
+         advCellsForEdge     !< [in] List of advection cells for each edge
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         highOrderAdvectionMask !< [in] Mask for high order advection
+
+      !*** Local variables
+
+      integer ::          &
+         i, iCell, iEdge, &! horz indices
+         cell1, cell2,    &! neighbor cell indices
+         nCells, nEdges,  &! numbers of cells or edges
+         k,k2,kmax         ! vert index variants
+
+      real (kind=RKIND) ::  &
+         signedFactor,      &! temp factor including flux sign
+         glsPsiNew,         &! updated glsPsi
+         glsPsiMinNew,      &! updated glsPsi minimum
+         glsPsiMaxNew,      &! updated glsPsi maximum
+         glsPsiUpwindNew,   &! glsPsi updated with upwind flx
+         scaleFactor,       &! factor for normalizing fluxes
+         flux,              &! flux temporary
+         glsPsiWeight,      &! glsPsi weighting temporary
+         invAreaCell1,      &! inverse cell area
+         invAreaCell2,      &! inverse cell area
+         verticalWeightK,   &! vertical weighting
+         verticalWeightKm1, &! vertical weighting
+         coef1, coef3        ! temporary coefficients
+
+      real (kind=RKIND), dimension(nVertLevels) :: &
+         wgtTmp,            &! vertical temporaries
+         flxTmp, sgnTmp      !    for high-order flux computation
+
+      real (kind=RKIND), parameter :: &
+         eps = 1.e-10_RKIND  ! small number to avoid numerical difficulties
+
+      ! end of preamble
+      !----------------
+      ! begin code
+
+#ifdef _ADV_TIMERS
+      call mpas_timer_start('startup')
+#endif
+      ! Get dimensions
+      nCells = nCellsAll
+      nEdges = nEdgesAll
+
+      ! allocate temporary arrays
+      allocate(glsPsiMin   (nVertLevels  ,nCells), &
+               glsPsiMax   (nVertLevels  ,nCells), &
+               hNewInv     (nVertLevels  ,nCells), &
+               hProv       (nVertLevels  ,nCells), &
+               hProvInv    (nVertLevels  ,nCells), &
+               flxIn       (nVertLevels  ,nCells+1), &
+               flxOut      (nVertLevels  ,nCells+1), &
+               workTend    (nVertLevels  ,nCells+1), &
+               lowOrderFlx (nVertLevels+1,max(nCells,nEdges)+1), &
+               highOrderFlx(nVertLevels+1,max(nCells,nEdges)+1))
+
+      ! Compute some provisional layer thicknesses
+      ! Note: This assumes we are in the first part of the horizontal/
+      ! vertical operator splitting, which is true because currently
+      ! we dont flip order and horizontal is always first.
+      ! See notes in commit 2cd4a89d.
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(invAreaCell1, kmax, k, i, iEdge, signedFactor)
+      do iCell = 1, nCells
+        invAreaCell1 = dt/areaCell(iCell)
+        kmax = maxLevelCell(iCell)
+        do k = 1, kmax
+          hProv(k, iCell) = layerThickness(k, iCell)
+        end do
+        do i = 1, nEdgesOnCell(iCell)
+          iEdge = edgesOnCell(i,iCell)
+          signedFactor = invAreaCell1*dvEdge(iEdge)*edgeSignOnCell(i,iCell)
+          ! Provisional layer thickness is after horizontal thickness flux only
+          do k = 1, kmax
+            hProv(k, iCell) = hProv(k, iCell) &
+                            + signedFactor*normalThicknessFlux(k,iEdge)
+          end do
+        end do
+        ! New layer thickness is after horizontal and vertical thickness flux
+        do k = 1, kmax
+          hProvInv(k,iCell) = 1.0_RKIND/ hProv(k,iCell)
+          hNewInv (k,iCell) = 1.0_RKIND/(hProv(k,iCell) - &
+                                         dt*w(k,iCell) + dt*w(k+1, iCell))
+        end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+#ifdef _ADV_TIMERS
+      call mpas_timer_stop('startup')
+#endif
+
+#ifdef _ADV_TIMERS
+      call mpas_timer_start('cell init')
+#endif
+      ! reset nCells to include all cells
+      nCells = nCellsAll
+
+      ! Compute the high and low order horizontal fluxes.
+#ifdef _ADV_TIMERS
+      call mpas_timer_stop('cell init')
+      call mpas_timer_start('horiz flux')
+#endif
+
+      ! set nCells to first halo level
+      nCells = nCellsHalo( 1 )
+
+      ! Determine bounds on glsPsi (glsPsiMin and glsPsiMax) from
+      ! surrounding cells for later limiting.
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(k, i, cell2, kmax)
+      do iCell = 1, nCells
+         do k=1, maxLevelCell(iCell)
+            glsPsiMin(k,iCell) = glsPsi(k,iCell)
+            glsPsiMax(k,iCell) = glsPsi(k,iCell)
+         end do
+         do i = 1, nEdgesOnCell(iCell)
+            cell2 = cellsOnCell(i,iCell)
+            kmax  = min(maxLevelCell(iCell), &
+                        maxLevelCell(cell2))
+            do k=1, kmax
+              glsPsiMax(k,iCell) = max(glsPsiMax(k,iCell), &
+                                       glsPsi(k,cell2))
+              glsPsiMin(k,iCell) = min(glsPsiMin(k,iCell), &
+                                       glsPsi(k,cell2))
+            end do ! k loop
+         end do ! i loop over nEdgesOnCell
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      ! Need all the edges around the 1 halo cells and owned cells
+      nEdges = nEdgesHalo( 2 )
+
+      ! Compute the high order horizontal flux
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(cell1, cell2, k, wgtTmp, sgnTmp, flxTmp, i, iCell, coef1, coef3, &
+      !$omp         glsPsiWeight)
+      do iEdge = 1, nEdges
+         cell1 = cellsOnEdge(1, iEdge)
+         cell2 = cellsOnEdge(2, iEdge)
+
+         ! compute some common intermediate factors
+         do k = 1, nVertLevels
+            wgtTmp(k) = normalThicknessFlux   (k,iEdge)* &
+                        highOrderAdvectionMask(k,iEdge)
+            sgnTmp(k) = sign(1.0_RKIND, &
+                             normalThicknessFlux(k,iEdge))
+            flxTmp(k) = 0.0_RKIND
+         end do
+
+         ! Compute 3rd or 4th fluxes where requested.
+         do i = 1, nAdvCellsForEdge(iEdge)
+            iCell = advCellsForEdge(i,iEdge)
+            coef1 = advCoefs       (i,iEdge)
+            coef3 = advCoefs3rd    (i,iEdge)*coef3rdOrder
+            do k = 1, maxLevelCell(iCell)
+              flxTmp(k) = flxTmp(k) + glsPsi(k,iCell)* &
+                          wgtTmp(k)*(coef1 + coef3*sgnTmp(k))
+            end do ! k loop
+          end do ! i loop over nAdvCellsForEdge
+
+          do k=1,nVertLevels
+             highOrderFlx(k,iEdge) = flxTmp(k)
+          end do
+
+          ! Compute 2nd order fluxes where needed.
+          ! Also compute low order upwind horizontal flux (monotonic and diffused)
+          ! Remove low order flux from the high order flux
+          ! Store left over high order flux in highOrderFlx array
+          do k = 1, maxLevelEdgeTop(iEdge)
+            glsPsiWeight = (1.0_RKIND - highOrderAdvectionMask(k, iEdge)) &
+                         * (dvEdge(iEdge) * 0.5_RKIND)                 &
+                         * normalThicknessFlux(k, iEdge)
+
+            lowOrderFlx(k,iEdge) = dvEdge(iEdge) * &
+               (max(0.0_RKIND,normalThicknessFlux(k,iEdge))*glsPsi(k,cell1) &
+              + min(0.0_RKIND,normalThicknessFlux(k,iEdge))*glsPsi(k,cell2))
+
+            highOrderFlx(k, iEdge) = highOrderFlx(k, iedge) &
+                                   + glsPsiWeight * (glsPsi(k, cell1) &
+                                                   + glsPsi(k, cell2))
+
+            highOrderFlx(k,iEdge) = highOrderFlx(k,iEdge) &
+                                  -  lowOrderFlx(k,iEdge)
+          end do ! k loop
+        end do ! iEdge loop
+        !$omp end do
+        !$omp end parallel
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('horiz flux')
+        call mpas_timer_start('scale factor build')
+#endif
+        ! Initialize flux arrays for all cells
+        nCells = nCellsHalo(size(nCellsHalo))
+
+        !$omp parallel
+        !$omp do schedule(runtime)
+        do iCell = 1, nCells+1
+        do k=1, nVertLevels
+           workTend(k, iCell) = 0.0_RKIND
+           flxIn   (k, iCell) = 0.0_RKIND
+           flxOut  (k, iCell) = 0.0_RKIND
+        end do ! k loop
+        end do ! iCell loop
+        !$omp end do
+        !$omp end parallel
+
+        ! Need one halo of cells around owned cells
+        nCells = nCellsHalo( 1 )
+
+        !$omp parallel
+        !$omp do schedule(runtime) &
+        !$omp private(invAreaCell1, i, iEdge, cell1, cell2, signedFactor, k, &
+        !$omp         tkeUpwindNew, tkeMinNew, tkeMaxNew, scaleFactor)
+        do iCell = 1, nCells
+          invAreaCell1 = 1.0_RKIND / areaCell(iCell)
+
+          ! Finish computing the low order horizontal fluxes
+          ! Upwind fluxes are accumulated in workTend
+          do i = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i, iCell)
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            signedFactor = edgeSignOnCell(i, iCell) * invAreaCell1
+
+            do k = 1, maxLevelEdgeTop(iEdge)
+              ! Here workTend is the advection tendency due to the
+              ! upwind (low order) fluxes.
+              workTend(k,iCell) = workTend(k,iCell) &
+                                + signedFactor*lowOrderFlx(k,iEdge)
+
+              ! Accumulate remaining high order fluxes
+              flxOut(k,iCell) = flxOut(k,iCell) + min(0.0_RKIND,  &
+                                signedFactor*highOrderFlx(k,iEdge))
+              flxIn (k,iCell) = flxIn (k,iCell) + max(0.0_RKIND,  &
+                                signedFactor*highOrderFlx(k,iEdge))
+
+            end do
+          end do
+
+          ! Build the factors for the FCT
+          ! Computed using the bounds that were computed previously,
+          ! and the bounds on the newly updated value
+          ! Factors are placed in the flxIn and flxOut arrays
+          do k = 1, maxLevelCell(iCell)
+            ! Here workTend is the upwind tendency
+            glsPsiUpwindNew = (glsPsi(k,iCell)*layerThickness(k,iCell) &
+                             + dt*workTend(k,iCell)) * hProvInv(k,iCell)
+            glsPsiMinNew = glsPsiUpwindNew &
+                         + dt*flxOut(k,iCell)*hProvInv(k,iCell)
+            glsPsiMaxNew = glsPsiUpwindNew &
+                         + dt*flxIn (k,iCell)*hProvInv(k,iCell)
+
+            scaleFactor = (glsPsiMax(k,iCell) - glsPsiUpwindNew)/ &
+                          (glsPsiMaxNew - glsPsiUpwindNew + eps)
+            flxIn (k,iCell) = min(1.0_RKIND, max(0.0_RKIND, scaleFactor))
+
+            scaleFactor = (glsPsiUpwindNew - glsPsiMin(k,iCell))/ &
+                          (glsPsiUpwindNew - glsPsiMinNew + eps)
+            flxOut(k,iCell) = min(1.0_RKIND, max(0.0_RKIND, scaleFactor))
+          end do ! k loop
+        end do ! iCell loop
+        !$omp end do
+        !$omp end parallel
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('scale factor build')
+        call mpas_timer_start('rescale horiz fluxes')
+#endif
+        ! Need all of the edges around owned cells
+        nEdges = nEdgesHalo( 1 )
+        !  rescale the high order horizontal fluxes
+        !$omp parallel
+        !$omp do schedule(runtime) private(cell1, cell2, k)
+        do iEdge = 1, nEdges
+          cell1 = cellsOnEdge(1,iEdge)
+          cell2 = cellsOnEdge(2,iEdge)
+          do k = 1, maxLevelEdgeTop(iEdge)
+            highOrderFlx(k,iEdge) = max(0.0_RKIND,highOrderFlx(k,iEdge))* &
+                                    min(flxOut(k,cell1), flxIn (k,cell2)) &
+                                  + min(0.0_RKIND,highOrderFlx(k,iEdge))* &
+                                    min(flxIn (k,cell1), flxOut(k,cell2))
+          end do ! k loop
+        end do ! iEdge loop
+        !$omp end do
+        !$omp end parallel
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('rescale horiz fluxes')
+        call mpas_timer_start('flux accumulate')
+#endif
+
+        nCells = nCellsOwned
+        ! Accumulate the scaled high order vertical tendencies, and the upwind tendencies
+        !$omp parallel
+        !$omp do schedule(runtime) private(invAreaCell1, signedFactor, i, iEdge, k)
+        do iCell = 1, nCells
+          invAreaCell1 = 1.0_RKIND / areaCell(iCell)
+
+          ! Accumulate the scaled high order horizontal tendencies
+          do i = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i, iCell)
+            signedFactor = invAreaCell1 * edgeSignOnCell(i, iCell)
+            do k = 1, maxLevelEdgeTop(iEdge)
+              ! workTend on the RHS is the upwind tendency
+              ! workTend on the LHS is the total horizontal advection tendency
+              workTend(k,iCell) = workTend(k,iCell) &
+                                + signedFactor * highOrderFlx(k, iEdge)
+            end do
+          end do
+
+          do k = 1, maxLevelCell(iCell)
+            ! workTend on the RHS is the total horizontal advection tendency
+            ! glsPsi on LHS is the  provisional tke after horizontal fluxes only.
+            tend(k,iCell) = tend(k,iCell) + workTend(k,iCell)
+          end do
+
+        end do ! iCell loop
+        !$omp end do
+        !$omp end parallel
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('flux accumulate')
+#endif
+        if (monotonicityCheck) then
+           nCells = nCellsOwned
+           ! Check tke values against local min,max to detect
+           ! non-monotone values and write warning if found
+           !$omp parallel
+           !$omp do schedule(runtime) private(k)
+           do iCell = 1, nCells
+           do k = 1, maxLevelCell(iCell)
+              if(glsPsi(k,iCell) < glsPsiMin(k, iCell)-eps) then
+                 call mpas_log_write( &
+                    'Horizontal minimum out of bounds on glsPsi: $r $r ', &
+                    MPAS_LOG_WARN,                      &
+                    realArgs=(/ glsPsiMin(k, iCell), glsPsi(k,iCell) /) )
+              end if
+
+              if(glsPsi(k,iCell) > glsPsiMax(k,iCell)+eps) then
+                 call mpas_log_write( &
+                    'Horizontal maximum out of bounds on tke: $r $r ', &
+                    MPAS_LOG_WARN,                      &
+                    realArgs=(/ glsPsiMax(k, iCell), glsPsi(k,iCell) /) )
+              end if
+           end do
+           end do
+           !$omp end do
+           !$omp end parallel
+        end if ! monotonicity check
+
+        !-----------------------------------------------------------------------
+        !
+        !  Horizontal advection complete
+        !  Begin vertical advection
+        !
+        !-----------------------------------------------------------------------
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_start('cell init')
+#endif
+        nCells = nCellsHalo( size(nCellsHalo) )
+        ! Initialize variables for use in this portion of the computation. 
+        !$omp parallel
+        !$omp do schedule(runtime) private(k)
+        do iCell = 1, nCells
+          do k=1, nVertLevels
+            highOrderFlx(k, iCell) = 0.0_RKIND
+            workTend(k, iCell) = 0.0_RKIND
+          end do ! k loop
+          highOrderFlx(nVertLevels+1, iCell) = 0.0_RKIND
+
+        end do ! iCell loop
+        !$omp end do
+        !$omp end parallel
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('cell init')
+#endif
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_start('vertical flux')
+#endif
+
+        ! Need all owned and 1 halo cells
+        nCells = nCellsHalo( 1 )
+
+        ! Determine bounds on glsPsi from neighbor values for limiting
+        !$omp parallel
+        !$omp do schedule(runtime) private(kmax, k)
+        do iCell = 1, nCells
+          kmax = maxLevelCell(iCell)
+
+          ! take care of top cell
+          glsPsiMax(1,iCell) = max(glsPsi(1,iCell), glsPsi(2,iCell))
+          glsPsiMin(1,iCell) = min(glsPsi(1,iCell), glsPsi(2,iCell))
+          do k=2,kmax-1
+            glsPsiMax(k,iCell) = max(glsPsi(k-1,iCell), &
+                                     glsPsi(k  ,iCell), &
+                                     glsPsi(k+1,iCell))
+            glsPsiMin(k,iCell) = min(glsPsi(k-1,iCell), &
+                                     glsPsi(k  ,iCell), &
+                                     glsPsi(k+1,iCell))
+          end do
+          ! finish with bottom cell
+          glsPsiMax(kmax,iCell) = max(glsPsi(kmax  ,iCell), &
+                                      glsPsi(kmax-1,iCell))
+          glsPsiMin(kmax,iCell) = min(glsPsi(kmax  ,iCell), &
+                                      glsPsi(kmax-1,iCell))
+        end do ! cell loop
+        !$omp end do
+        !$omp end parallel
+
+        ! Compute the high order vertical fluxes based on order selected.
+        ! Special cases for top and bottom layers handled in following loop.
+
+        select case (vertOrder)
+        case (vertOrder4)
+
+          !$omp parallel
+          !$omp do schedule(runtime) private(kmax, k)
+          do iCell = 1, nCells
+            kmax = maxLevelCell(iCell)
+            do k=3,kmax-1
+              highOrderFlx(k, iCell) = w(k,iCell)*( &
+                  7.0_RKIND*(glsPsi(k  ,iCell) + glsPsi(k-1,iCell)) - &
+                            (glsPsi(k+1,iCell) + glsPsi(k-2,iCell)))/ &
+                  12.0_RKIND
+
+            end do
+          end do ! cell loop
+          !$omp end do
+          !$omp end parallel
+
+        case (vertOrder3)
+
+          !$omp parallel
+          !$omp do schedule(runtime) private(kmax, k)
+          do iCell = 1, nCells
+            kmax = maxLevelCell(iCell)
+            do k=3,kmax-1
+              highOrderFlx(k, iCell) = (w(k,iCell)* &
+                   (7.0_RKIND*(glsPsi(k  ,iCell) + glsPsi(k-1,iCell)) - &
+                              (glsPsi(k+1,iCell) + glsPsi(k-2,iCell))) - &
+                        coef3rdOrder*abs(w(k,iCell))* &
+                             ((glsPsi(k+1,iCell) - glsPsi(k-2,iCell)) - &
+                    3.0_RKIND*(glsPsi(k  ,iCell) - glsPsi(k-1,iCell))))/ &
+                   12.0_RKIND
+
+
+            end do
+          end do ! cell loop
+          !$omp end do
+          !$omp end parallel
+
+       case (vertOrder2)
+
+          !$omp parallel
+          !$omp do schedule(runtime) private(kmax, k, verticalWeightK, verticalWeightKm1)
+          do iCell = 1, nCells
+            kmax = maxLevelCell(iCell)
+            do k=3,kmax-1
+              verticalWeightK   = hProv(k-1,iCell) / &
+                                 (hProv(k  ,iCell) + hProv(k-1,iCell))
+              verticalWeightKm1 = hProv(k  ,iCell) / &
+                                 (hProv(k  ,iCell) + hProv(k-1,iCell))
+              highOrderFlx(k,iCell) = w(k,iCell)* &
+                                 (verticalWeightK  *glsPsi(k  ,iCell) + &
+                                  verticalWeightKm1*glsPsi(k-1,iCell))
+            end do
+          end do ! cell loop
+          !$omp end do
+          !$omp end parallel
+
+        end select ! vertical order
+
+        ! Treat special cases for high order flux
+        ! Compute low order upwind vertical flux (monotonic and diffused)
+        ! Remove low order flux from the high order flux.
+        ! Store left over high order flux in highOrderFlx array.
+        !$omp parallel
+        !$omp do schedule(runtime) private(kmax, verticalWeightK, verticalWeightKm1, k)
+        do iCell = 1, nCells
+          kmax = maxLevelCell(iCell)
+          ! Next-to-top cell in column is second-order
+          highOrderFlx(1,iCell) = 0.0_RKIND
+          if (kmax > 1) then
+            verticalWeightK   = hProv(1,iCell) / &
+                               (hProv(2,iCell) + hProv(1, iCell))
+            verticalWeightKm1 = hProv(2,iCell) / &
+                               (hProv(2,iCell) + hProv(1, iCell))
+            highOrderFlx(2,iCell) = w(2,iCell)* &
+                               (verticalWeightK  *glsPsi(2,iCell) + &
+                                verticalWeightKm1*glsPsi(1,iCell))
+          end if
+          ! Deepest vertical cell in column is second order
+          k = max(2,kmax)
+          verticalWeightK   = hProv(k-1,iCell) / &
+                             (hProv(k  ,iCell) + hProv(k-1,iCell))
+          verticalWeightKm1 = hProv(k  ,iCell) / &
+                             (hProv(k  ,iCell) + hProv(k-1,iCell))
+          highOrderFlx(k,iCell) = w(k,iCell)* &
+                             (verticalWeightK  *glsPsi(k  ,iCell) + &
+                              verticalWeightKm1*glsPsi(k-1,iCell))
+          highOrderFlx(k+1,iCell) = 0.0_RKIND
+
+          ! Compute low order (upwind) flux and remove from high order
+          lowOrderFlx(1,iCell) = 0.0_RKIND
+          do k = 2, kmax
+            lowOrderFlx(k,iCell) = &
+                min(0.0_RKIND,w(k,iCell))*glsPsi(k-1,iCell) + &
+                max(0.0_RKIND,w(k,iCell))*glsPsi(k  ,iCell)
+            highOrderFlx(k,iCell) = highOrderFlx(k,iCell) - &
+                                     lowOrderFlx(k,iCell)
+          end do ! k loop
+          lowOrderFlx(kmax+1,iCell) = 0.0_RKIND
+
+          ! Upwind fluxes are accumulated in workTend
+          ! flxIn contains the total remaining high order flux into iCell
+          !          it is positive.
+          ! flxOut contains the total remaining high order flux out of iCell
+          !           it is negative
+          do k = 1, kmax
+            workTend(k,iCell) = lowOrderFlx(k+1,iCell) &
+                              - lowOrderFlx(k  ,iCell)
+            flxIn (k, iCell) = max(0.0_RKIND, highOrderFlx(k+1, iCell)) &
+                             - min(0.0_RKIND, highOrderFlx(k  , iCell))
+            flxOut(k, iCell) = min(0.0_RKIND, highOrderFlx(k+1, iCell)) &
+                             - max(0.0_RKIND, highOrderFlx(k  , iCell))
+          end do ! k Loop
+        end do ! iCell Loop
+        !$omp end do
+        !$omp end parallel
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('vertical flux')
+        call mpas_timer_start('scale factor build')
+#endif
+        ! Need one halo of cells around owned cells
+        nCells = nCellsHalo( 1 )
+        !$omp parallel
+        !$omp do schedule(runtime) &
+        !$omp private(k, tkeMinNew, tkeMaxNew, tkeUpwindNew, scaleFactor)
+        do iCell = 1, nCells
+
+          ! Build the scale factors to limit flux for FCT
+          ! Computed using the bounds that were computed previously,
+          ! and the bounds on the newly updated value
+          ! Factors are placed in the flxIn and flxOut arrays
+
+          do k = 1, maxLevelCell(iCell)
+            ! workTend on the RHS is the upwind tendency
+            glsPsiMinNew = (glsPsi(k,iCell)*hProv(k,iCell) &
+                         + dt*(workTend(k,iCell)+flxOut(k,iCell))) &
+                         * hNewInv(k,iCell)
+            glsPsiMaxNew = (glsPsi(k,iCell)*hProv(k,iCell) &
+                         + dt*(workTend(k,iCell)+flxIn(k,iCell))) &
+                         * hNewInv(k,iCell)
+            glsPsiUpwindNew = (glsPsi(k,iCell)*hProv(k,iCell) &
+                            + dt*workTend(k,iCell)) * hNewInv(k,iCell)
+
+            scaleFactor = (glsPsiMax(k,iCell)-glsPsiUpwindNew)/ &
+                          (glsPsiMaxNew-glsPsiUpwindNew+eps)
+            flxIn (k,iCell) = min(1.0_RKIND, max(0.0_RKIND, scaleFactor))
+
+            scaleFactor = (glsPsiUpwindNew-glsPsiMin(k,iCell))/ &
+                          (glsPsiUpwindNew-glsPsiMinNew+eps)
+            flxOut(k,iCell) = min(1.0_RKIND, max(0.0_RKIND, scaleFactor))
+          end do ! k loop
+        end do ! iCell loop
+        !$omp end do
+        !$omp end parallel
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('scale factor build')
+        call mpas_timer_start('flux accumulate')
+#endif
+
+        nCells = nCellsOwned
+        ! Accumulate the scaled high order vertical tendencies
+        ! and the upwind tendencies
+        !$omp parallel
+        !$omp do schedule(runtime) private(kmax, k, flux)
+        do iCell = 1, nCells
+          kmax = maxLevelCell(iCell)
+          ! rescale the high order vertical flux
+          do k = 2, kmax
+            flux =  highOrderFlx(k,iCell)
+            highOrderFlx(k,iCell) = max(0.0_RKIND,flux)*   &
+                                    min(flxOut(k  ,iCell), &
+                                        flxIn (k-1,iCell)) &
+                                  + min(0.0_RKIND,flux)*   &
+                                    min(flxOut(k-1,iCell), &
+                                        flxIn (k  ,iCell))
+          end do ! k loop
+
+          do k = 1,kmax
+            ! workTend on the RHS is the upwind tendency
+            ! workTend on the LHS is the total vertical advection tendency
+            workTend(k, iCell) = workTend(k, iCell)       &
+                               + (highOrderFlx(k+1,iCell) &
+                                - highOrderFlx(k  ,iCell))
+            tend(k,iCell) = tend(k,iCell) + workTend(k,iCell)
+          end do ! k loop
+
+        end do ! iCell loop
+        !$omp end do
+        !$omp end parallel
+
+        !normalize final tendency by volume to get right units since glsPsi
+        ! is not thickness weighted, requires that advection be called first
+
+        !$omp parallel
+        !$omp do schedule(runtime) private(k)
+        do iCell=1,nCells
+           do k=1,maxLevelCell(iCell)
+              tend(k,iCell) = tend(k,iCell) / (hProv(k,iCell)*areaCell(iCell))
+           end do
+        end do
+        !$omp end do
+        !$omp end parallel
+
+        ! Compute advection diagnostics and monotonicity checks if requested
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('flux accumulate')
+        call mpas_timer_start('advect diags')
+#endif
+        if (monotonicityCheck) then
+          nCells = nCellsOwned
+          ! Check for monotonicity of new tke value
+          !$omp parallel
+          !$omp do schedule(runtime) private(k, tkeNew)
+          do iCell = 1, nCells
+          do k = 1, maxLevelCell(iCell)
+             ! workTend on the RHS is the total vertical advection tendency
+             glsPsiNew = (glsPsi(k, iCell)*hProv(k, iCell) &
+                          + dt*workTend(k, iCell))*hNewInv(k, iCell)
+
+             if (glsPsiNew < glsPsi(k, iCell)-eps) then
+                call mpas_log_write( &
+                   'Vertical minimum out of bounds on glsPsi: $i $i $r $r ',&
+                   MPAS_LOG_WARN, intArgs=(/k, iCell/), &
+                   realArgs=(/ glsPsiMin(k, iCell), glsPsiNew /) )
+             end if
+
+             if (glsPsiNew > glsPsiMax(k,iCell)+eps) then
+                call mpas_log_write( &
+                   'Vertical maximum out of bounds on glsPsi: $i $i $r $r ',&
+                    MPAS_LOG_WARN, intArgs=(/k, iCell/), &
+                    realArgs=(/ glsPsiMax(k, iCell), glsPsiNew /) )
+             end if
+          end do
+          end do
+          !$omp end do
+          !$omp end parallel
+        end if ! monotonicity check
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('advect diags')
+#endif
+
+#ifdef _ADV_TIMERS
+      call mpas_timer_start('deallocates')
+#endif
+      deallocate(glsPsiMin,    &
+                 glsPsiMax,    &
+                 hNewInv,      &
+                 hProv,        &
+                 hProvInv,     &
+                 flxIn,        &
+                 flxOut,       &
+                 workTend,     &
+                 lowOrderFlx,  &
+                 highOrderFlx)
+
+#ifdef _ADV_TIMERS
+      call mpas_timer_stop('deallocates')
+#endif
+
+   end subroutine ocn_glsPsi_advection_mono_tend!}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine ocn_glsPsi_advection_mono_init
+!
+!> \brief MPAS initialize monotonic glsPsi advection tendency with FCT
+!> \author Luke Van Roekel
+!> \date   updated June 2021
+!> \details
+!>  This routine initializes monotonic glsPsi advection quantities for
+!>  the flux-corrected transport (FCT) algorithm.  Based on the tracer advection
+!>  mono routine
+!
+!-------------------------------------------------------------------------------
+
+   subroutine ocn_glsPsi_advection_mono_init(nHalos, horizAdvOrder,        &
+                                             vertAdvOrder, inCoef3rdOrder, &
+                                             checkMonotonicity, err)!{{{
+
+      !*** input parameters
+
+      integer, intent(in) :: &
+         nHalos               !< [in] number of halos in current simulation
+      integer, intent(in) :: &
+         horizAdvOrder        !< [in] order for horizontal advection
+      integer, intent(in) :: &
+         vertAdvOrder         !< [in] order for vertical advection
+      real (kind=RKIND), intent(in) :: &
+         inCoef3rdOrder       !< [in] coefficient for blending advection orders
+      logical, intent(in) :: &
+         checkMonotonicity    !< [in] flag to check monotonicity of tracers
+
+      !*** output parameters
+
+      integer, intent(out) :: &
+         err                   !< [out] error flag
+
+      ! end of preamble
+      !----------------
+      ! begin code
+
+      err = 0 ! initialize error code to success
+
+      ! Check that the halo is wide enough for FCT
+      if (nHalos < 3) then
+         call mpas_log_write( &
+            'Monotonic advection cannot be used with less than 3 halos.', &
+            MPAS_LOG_CRIT)
+         err = -1
+      end if
+
+      ! Set blending coefficient if 3rd order horizontal advection chosen
+      select case (horizAdvOrder)
+      case (2)
+         coef3rdOrder = 0.0_RKIND
+      case (3)
+         coef3rdOrder = inCoef3rdOrder
+      case (4)
+         coef3rdOrder = 0.0_RKIND
+      case default
+         coef3rdOrder = 0.0_RKIND
+         call mpas_log_write( &
+            'Invalid value for horizontal advection order, defaulting to 2',&
+            MPAS_LOG_WARN)
+      end select ! horizontal advection order
+
+      ! Set vertical advection order
+      select case (vertAdvOrder)
+      case (2)
+         vertOrder = vertOrder2
+      case (3)
+         vertOrder = vertOrder3
+      case (4)
+         vertOrder = vertOrder4
+      case default
+         vertOrder = vertOrder2
+         call mpas_log_write( &
+            'Invalid value for vertical advection order, defaulting to 2', &
+            MPAS_LOG_WARN)
+      end select ! vertical advection order
+
+      ! Set flag for checking monotonicity
+      monotonicityCheck = checkMonotonicity
+
+   end subroutine ocn_glsPsi_advection_mono_init!}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+
+end module ocn_glsPsi_advection_mono
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-ocean/src/shared/mpas_ocn_mesh.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_mesh.F
@@ -157,6 +157,13 @@ module ocn_mesh
    real(kind=RKIND), public, dimension(:, :), allocatable :: &
       edgeAreaFractionOfCell
 
+   real(kind=RKIND), public, dimension(:,:), pointer :: &    
+      boundaryNormalAngle, &
+      distanceToBoundary
+
+   integer, public, dimension(:,:), pointer :: &
+      boundaryCellMask
+
    !}}}
 
    !----------------------------------------------------------------------------
@@ -487,6 +494,12 @@ contains
                                boundaryVertexTmp)
       call mpas_pool_get_array(meshPool, 'boundaryCell', &
                                boundaryCellTmp)
+      call mpas_pool_get_array(meshPool, 'boundaryCellMask',&
+                               boundaryCellMask)
+      call mpas_pool_get_array(meshPool, 'distanceToBoundary', &
+                               distanceToBoundary)
+      call mpas_pool_get_array(meshPool, 'boundaryNormalAngle', &
+                               boundaryNormalAngle)
 
       allocate ( &
             edgeMask(nVertLevels, nEdgesAll+1), &
@@ -654,7 +667,10 @@ contains
          !$acc                   edgeNormalVectors,        &
          !$acc                   localVerticalUnitVectors, &
          !$acc                   cellTangentPlane,         &
-         !$acc                   coeffs_reconstruct)
+         !$acc                   coeffs_reconstruct,       &
+         !$acc                   boundaryCellMask,         &
+         !$acc                   boundaryNormalAngle,      &
+         !$acc                   distanceToBoundary)
 
 !-------------------------------------------------------------------------------
 
@@ -783,7 +799,9 @@ contains
       !$acc                  edgeNormalVectors, &
       !$acc                  localVerticalUnitVectors, &
       !$acc                  cellTangentPlane,  &
-      !$acc                  coeffs_reconstruct)
+      !$acc                  coeffs_reconstruct,       &
+      !$acc                  boundaryNormalAngle, &
+      !$acc                  distanceToBoundary)
 
       ! Reset all scalars to zero
       onSphere  = .false.
@@ -864,7 +882,10 @@ contains
                edgeNormalVectors, &
                localVerticalUnitVectors, &
                cellTangentPlane, &
-               coeffs_reconstruct)
+               coeffs_reconstruct, &
+               boundaryCellMask, &
+               boundaryNormalAngle, &
+               distanceToBoundary)
 
 #ifdef MPAS_OPENACC
       !$acc exit data delete(edgeAreaFractionOfCell)
@@ -1210,7 +1231,10 @@ contains
       !$acc               edgeNormalVectors,        &
       !$acc               localVerticalUnitVectors, &
       !$acc               cellTangentPlane,         &
-      !$acc               coeffs_reconstruct)
+      !$acc               coeffs_reconstruct,       &
+      !$acc               boundaryCellMask,         &
+      !$acc               boundaryNormalAngle,      &
+      !$acc               distanceToBoundary)
 
 !-------------------------------------------------------------------------------
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_nonhydrostatic_pressure_solve.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_nonhydrostatic_pressure_solve.F
@@ -1,0 +1,1049 @@
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_compute_nonhydrostatic_pressure
+!
+!> \brief MPAS ocean module to solve for the nonhydrostatic pressure correction
+!> \author Luke Van Roekel
+!> \date January 2021
+!> \details
+!    This module will derive the nonhydrostatic pressure correction
+!     uses petsc with the ILU preconditioner for solving
+!
+!-----------------------------------------------------------------------
+
+#ifdef USE_PETSC
+#define PETSC_USE_FORTRAN_MODULES 1 
+!#include "petsc/finclude/petscsys.h"
+!#include "petsc/finclude/petscvec.h"
+!#include "petsc/finclude/petscmat.h"
+!#include "petsc/finclude/petscpc.h"
+!#include "petsc/finclude/petscksp.h"
+#include "petsc/finclude/petsc.h"
+#endif
+
+module ocn_compute_nonhydrostatic_pressure
+
+  use mpas_derived_types
+  use mpas_pool_routines
+  use mpas_timer
+  use mpas_constants
+  use mpas_log
+
+  use ocn_constants
+  use ocn_config
+  use ocn_mesh
+  use ocn_diagnostics_variables
+
+#ifdef USE_PETSC
+  !PETSC includes for the matrix solve
+  use petscsys
+  use petscvec
+  use petscmat
+  use petscpc
+  use petscksp
+  use petsc
+#endif
+  implicit none
+  private
+  save
+
+  !--------------------------------------------------------------------
+  !
+  ! Public member functions
+  !
+  !--------------------------------------------------------------------
+
+  public :: ocn_nonhydrostatic_pressure_tend, &
+            ocn_nonhydrostatic_solver_init,   &
+            ocn_nonhydrostatic_solver_fill_matvec, &
+            ocn_nonhydrostatic_solver_finalize, &
+            ocn_nonhydrostatic_pressure_solve, &
+            ocn_nonhydrostatic_pressure_update_velocity
+
+  !--------------------------------------------------------------------
+  !
+  ! Private module variables
+  !
+  !--------------------------------------------------------------------
+
+  double precision :: norm ! norm of solution error
+#ifdef USE_PETSC
+  PetscInt ::  i, j, II, JJ, m, n, its, Istart, Iend
+  PetscInt ::  row, col, ione, globalM, first, last, firstVal
+  PetscInt :: overlap,nlocal
+  PetscErrorCode :: petsc_err, ierr2
+  PetscMPIInt :: petsc_rank, petsc_size
+  PetscBool :: flag
+  PetscScalar :: v, one, neg_one
+  Vec :: x, b, u, negOneVec ! approximate solution, right hand side vector, exact solution vector
+  Mat :: Amat ! Matrix that defines the system
+  Mat :: Pmat ! Preconditioner Matrix
+  KSP :: ksp ! krylov subspace method context
+  KSP,allocatable,dimension(:) :: subksp
+  PetscRandom :: rctx ! random number generator
+  PC :: pc, subpc ! preconditioner context
+  PCType :: ptype ! flag to set type of preconditioner MAYBE make this a NL option?
+  PetscReal :: tol 
+
+  !Stuff for the new vecscatter
+  IS :: origIS, destIS !PETSc index sets
+  VecScatter :: scatter ! PETSc vec scatter context computed once and reused
+  Vec :: local_x ! local value of things to grab from global vector
+  PetscInt,allocatable,dimension(:) :: destIndex, origIndex
+  PetscScalar,pointer :: values(:)
+#endif
+
+  real(kind=RKIND) :: surfaceBoundaryConditionTop, surfaceBoundaryConditionBottom
+
+  contains
+
+    subroutine ocn_nonhydrostatic_pressure_tend(normalVelocityNew, &
+      verticalVelocityNew, layerThickness, layerThicknessEdge, &
+      nhPressureCorrection, mpi_comm, dt)
+
+    real,dimension(:,:), intent(in) :: normalVelocityNew, verticalVelocityNew, &
+      layerThickness, layerThicknessEdge
+
+    real(kind=RKIND), intent(in) :: dt
+
+    real,dimension(:,:), intent(inout) :: nhPressureCorrection
+
+    integer, intent(in) :: mpi_comm
+
+    logical :: reuse_preconditioner 
+
+    reuse_preconditioner = .false.
+
+    !call mpas_timer_start('NH solve - matrix fill',.false.)
+    !call ocn_nonhydrostatic_solver_fill_matVec(normalVelocityNew, &
+    !  verticalVelocityNew, layerThickness, layerThicknessEdge, mpi_comm, dt)
+
+    !call mpas_timer_stop('NH solve - matrix fill')
+
+    !call ocn_nonhydrostatic_pressure_solve(mpi_comm, reuse_preconditioner, nhPressureCorrection)
+
+    call ocn_nonhydrostatic_solver_everything(normalVelocityNew, &
+       verticalVelocityNew, layerThickness, layerThicknessEdge, mpi_comm, &
+       dt, nhPressureCorrection)
+
+  end subroutine ocn_nonhydrostatic_pressure_tend
+
+  !--------------------------------------------------------------------
+  ! 
+  ! routine ocn_nonhydrostatic_pressure_update_velocity
+  !
+  !> \brief  Update the normal and vertical velocity 
+  !> \author  Luke Van Roekel
+  !> \date    February 2021
+  !> \details
+  !>  creates KSP solver context, gets preconditioner and solves
+  !
+  !--------------------------------------------------------------------
+
+  subroutine ocn_nonhydrostatic_pressure_update_velocity(normalVelocityNew, &
+      verticalVelocityNew, layerThickness, layerThicknessEdge,           &
+      nonhydrostaticPressure, nonhydrostaticPressureOld,                 &
+      nhPressureCorrection, dt)
+
+    real(KIND=RKIND),intent(in) :: dt
+
+    real(KIND=RKIND),dimension(:,:), intent(inout) ::  &
+      normalVelocityNew,    &
+      verticalVelocityNew
+
+    real(KIND=RKIND),dimension(:,:),intent(in) :: &
+      layerThicknessEdge, &
+      layerThickness
+
+    real(KIND=RKIND),dimension(:,:),intent(inout) :: &
+      nonhydrostaticPressure, &
+      nonhydrostaticPressureOld, &
+      nhPressureCorrection
+
+    integer :: cell1, cell2, nEdges, iCell, iEdge, nCells, i, k
+
+    real(kind=RKIND), dimension(nVertLevels) :: div_hu
+
+    real(kind=RKIND) :: invAreaCell, r_tmp
+
+    nEdges = nEdgesHalo(2)
+
+    call mpas_timer_start('NH solve - update velocity',.false.)
+    ! loop over edges to update normalVelocity
+    !$omp parallel
+    !$omp do schedule(runtime) &
+    !$omp private(k, cell1, cell2)
+    do iEdge=1,nEdges
+       cell1 = cellsOnEdge(1,iEdge)
+       cell2 = cellsOnEdge(2,iEdge)
+       do k = 1,maxLevelEdgeTop(iEdge)
+          normalVelocityNew(k,iEdge) = normalVelocityNew(k,iEdge) - dt * &
+            (nhPressureCorrection(k,cell2) - nhPressureCorrection(k,cell1)) / &
+            dcEdge(iEdge)*edgeMask(k,iEdge) 
+       end do
+    end do
+    !$omp end do
+    !$omp end parallel
+
+    nCells = nCellsHalo( 1 )
+
+    !$omp parallel
+    !$omp do schedule(runtime) &
+    !$omp private(i, r_tmp, iEdge, invAreaCell, k, div_hu)
+    do iCell = 1, nCells
+       div_hu(:) = 0.0_RKIND
+       invAreaCell = 1.0_RKIND / areaCell(iCell)
+       do i = 1,nEdgesOnCell(iCell)
+          iEdge = edgesOnCell(i, iCell)
+          do k = 1,maxLevelEdgeTop(iEdge)
+             r_tmp = dvEdge(iEdge)*normalVelocityNew(k,iEdge)*invAreaCell
+             div_hu(k) = div_hu(k) - layerThicknessEdge(k,iEdge)*edgeSignOnCell(i,iCell)*r_tmp
+          end do
+       end do
+
+       verticalVelocityNew(maxLevelCell(iCell) + 1, iCell) = 0.0_RKIND
+       do k=maxLevelCell(iCell),1,-1
+          verticalVelocityNew(k,iCell) = verticalVelocityNew(k+1,iCell) - div_hu(k)
+       end do
+    end do
+    !$omp end do
+    !$omp end parallel
+
+    !Update the nonhydrostatic pressure to be second order accurate
+
+    !$omp parallel
+    !$omp do schedule(runtime) &
+    !$omp private(k)
+    do iCell=1,nCells
+       do k = 1,maxLevelCell(iCell)
+          !nonhydrostaticPressure(k,iCell) = 0.0_RKIND*nonhydrostaticPressureOld(k,iCell) + &
+          nonhydrostaticPressure(k,iCell) = nonhydrostaticPressureOld(k,iCell) + &
+                  nhPressureCorrection(k,iCell)
+       end do 
+    end do
+    print*, 'nonhydrostaticPressure ', nonhydrostaticPressure(10,100)
+    print*, 'nhPressureCorrection ', nhPressureCorrection(10,100)
+    !$omp end do
+    !$omp end parallel
+
+    call mpas_timer_stop('NH solve - update velocity')
+
+  end subroutine ocn_nonhydrostatic_pressure_update_velocity
+
+  !--------------------------------------------------------------------
+  ! 
+  ! routine ocn_nonhydrostatic_solver_everything
+  !
+  !> \brief   Create the matrix and right-hand-side and then solve the
+  !>          linear system
+  !> \author  Sara Calandrini, Darren Engwirda
+  !> \date    November 2021
+  !> \details
+  !>  creates KSP solver context, gets preconditioner and solves
+  !
+  !--------------------------------------------------------------------
+
+  subroutine ocn_nonhydrostatic_solver_everything(normalVelocityNew, &
+      verticalVelocityNew, layerThickness, layerThicknessEdge, mpi_comm, &
+      dt, nhPressureCorrection)
+
+     implicit none
+
+     real(kind=RKIND), dimension(:,:), intent(in) :: normalVelocityNew, &
+                                                     verticalVelocityNew
+     real(kind=RKIND), dimension(:,:), intent(in) :: layerThickness, &
+                                                     layerThicknessEdge
+     real(kind=RKIND), intent(in) :: dt
+     real(kind=RKIND), dimension(:,:), intent(inout) :: nhPressureCorrection
+     integer, intent(in) :: mpi_comm
+
+  !--------------------------------------------------------------------
+  !
+  ! subroutine variables
+  !
+  !--------------------------------------------------------------------
+
+     integer :: k, iCell, jCell, iEdge, jEdge, iCell3d, jCell3d
+     integer :: nnzRowMax, vecSpot
+     real(kind=RKIND) :: xEdge, thicknessUpper, thicknessLower
+     real(kind=RKIND), dimension(nVertLevels) :: div   
+
+#ifdef USE_PETSC
+     PetscScalar :: insertVal
+     PetscInt :: itNum
+
+     call mpas_timer_start('NH solve - matrix',.false.)
+
+     ! form matrix: del^2(q) = 1/dt * div(u*)
+
+     !nnzRowMax = 9 * 2 + 4  ! do this better
+     nnzRowMax = 1 + 2 + 7
+
+     call MatZeroEntries(Amat, petsc_err)
+
+     do iCell = 1, nCellsOwned
+
+        ! x-part of del^2 operator
+
+        do jEdge = 1, nEdgesOnCell(iCell)
+
+           iEdge = edgesOnCell(jEdge,iCell)
+           jCell = cellsOnCell(jEdge,iCell)
+
+           xEdge = dvEdge(iEdge) / dcEdge(iEdge)
+
+           do k = 1, maxLevelCell(iCell)
+              if (boundaryEdge(k,iEdge) .ge. 1) cycle
+
+              ! this map could actually create unreferenced rows, etc
+              ! when cells are masked out under bathymetry?
+              iCell3d = (indexToCellId(iCell) - 1) * nVertLevels + k - 1
+              jCell3d = (indexToCellId(jCell) - 1) * nVertLevels + k - 1   
+     
+              insertVal = +1 * layerThicknessEdge(k,iEdge) * xEdge
+              call MatSetValues(Amat, 1, iCell3d, 1, jCell3d, insertVal, ADD_VALUES, petsc_err)
+              insertVal = -1 * layerThicknessEdge(k,iEdge) * xEdge
+              call MatSetValues(Amat, 1, iCell3d, 1, iCell3d, insertVal, ADD_VALUES, petsc_err)
+           end do
+
+        end do
+
+        ! for non-flat bathymetry
+        do k = maxLevelCell(iCell)+1, nVertLevels
+           iCell3D = (indexToCellId(iCell) - 1) * nVertLevels + k - 1
+           insertVal = 1.0_RKIND
+           call MatSetValues(Amat, 1, iCell3d, 1, iCell3d, insertVal, ADD_VALUES, petsc_err)
+        end do
+
+        ! z-part of del^2 operator
+
+        ! first layer upper q = 0
+        ! first layer lower
+        k = 1 !minLevelCell(iCell)
+
+        thicknessUpper = 1.0E-15_RKIND + 0.5_RKIND * ( &
+           layerThickness(k,iCell) )
+        thicknessLower = 1.0E-15_RKIND + 0.5_RKIND * ( &
+           layerThickness(k,iCell) + layerThickness(k+1,iCell))
+
+        iCell3d = (indexToCellId(iCell) - 1) * nVertLevels + k - 1
+
+        insertVal = surfaceBoundaryConditionTop*(-1 * areaCell(iCell) / thicknessUpper)
+        call MatSetValues(Amat, 1, iCell3d, 1, iCell3d, insertVal, ADD_VALUES, petsc_err)
+
+        iCell3d = (indexToCellId(iCell) - 1) * nVertLevels + k - 1
+        jCell3d = (indexToCellId(iCell) - 1) * nVertLevels + (k+1) - 1
+
+        insertVal = +1 * areaCell(iCell) / thicknessLower
+        call MatSetValues(Amat, 1, iCell3d, 1, jCell3d, insertVal, ADD_VALUES, petsc_err)
+        insertVal = -1 * areaCell(iCell) / thicknessLower
+        call MatSetValues(Amat, 1, iCell3d, 1, iCell3d, insertVal, ADD_VALUES, petsc_err)
+
+
+        do k = 2, maxLevelCell(iCell) - 1
+
+           thicknessUpper = 1.0E-15_RKIND + 0.5_RKIND * ( &
+              layerThickness(k,iCell) + layerThickness(k-1,iCell))
+           thicknessLower = 1.0E-15_RKIND + 0.5_RKIND * ( &
+              layerThickness(k,iCell) + layerThickness(k+1,iCell))
+
+           ! upper
+           iCell3d = (indexToCellId(iCell) - 1) * nVertLevels + k - 1
+           jCell3d = (indexToCellId(iCell) - 1) * nVertLevels + (k-1) - 1   
+      
+           insertVal = +1 * areaCell(iCell) / thicknessUpper
+           call MatSetValues(Amat, 1, iCell3d, 1, jCell3d, insertVal, ADD_VALUES, petsc_err)
+           insertVal = -1 * areaCell(iCell) / thicknessUpper
+           call MatSetValues(Amat, 1, iCell3d, 1, iCell3d, insertVal, ADD_VALUES, petsc_err)
+       
+           ! lower
+           iCell3d = (indexToCellId(iCell) - 1) * nVertLevels + k - 1
+           jCell3d = (indexToCellId(iCell) - 1) * nVertLevels + (k+1) - 1
+ 
+           insertVal = +1 * areaCell(iCell) / thicknessLower
+           call MatSetValues(Amat, 1, iCell3d, 1, jCell3d, insertVal, ADD_VALUES, petsc_err)
+           insertVal = -1 * areaCell(iCell) / thicknessLower
+           call MatSetValues(Amat, 1, iCell3d, 1, iCell3d, insertVal, ADD_VALUES, petsc_err)   
+
+        end do
+
+        ! final layer upper
+        ! final layer lower dq/dz = 0
+        k = maxLevelCell(iCell)
+
+        thicknessUpper = 1.0E-15_RKIND + 0.5_RKIND * ( &
+           layerThickness(k,iCell) + layerThickness(k-1,iCell))
+        thicknessLower = 1.0E-15_RKIND + 0.5_RKIND * ( &
+           layerThickness(k,iCell) )
+
+        iCell3d = (indexToCellId(iCell) - 1) * nVertLevels + k - 1
+
+        insertVal = surfaceBoundaryConditionBottom*(-1 * areaCell(iCell) / thicknessLower)
+        call MatSetValues(Amat, 1, iCell3d, 1, iCell3d, insertVal, ADD_VALUES, petsc_err)
+
+        iCell3d = (indexToCellId(iCell) - 1) * nVertLevels + k - 1
+        jCell3d = (indexToCellId(iCell) - 1) * nVertLevels + (k-1) - 1
+         
+        insertVal = +1 * areaCell(iCell) / thicknessUpper
+        call MatSetValues(Amat, 1, iCell3d, 1, jCell3d, insertVal, ADD_VALUES, petsc_err)
+        insertVal = -1 * areaCell(iCell) / thicknessUpper
+        call MatSetValues(Amat, 1, iCell3d, 1, iCell3d, insertVal, ADD_VALUES, petsc_err)
+        
+        ! for non-flat bathymetry
+        do k = maxLevelCell(iCell)+1, nVertLevels
+           iCell3D = (indexToCellId(iCell) - 1) * nVertLevels + k - 1
+           insertVal = 1.0_RKIND
+           call MatSetValues(Amat, 1, iCell3d, 1, iCell3d, insertVal, ADD_VALUES, petsc_err)
+        end do
+ 
+     end do
+
+     call MatAssemblyBegin(Amat,MAT_FINAL_ASSEMBLY,petsc_err)
+     call MatAssemblyEnd(Amat,MAT_FINAL_ASSEMBLY,petsc_err) 
+
+     call mpas_timer_stop('NH solve - matrix')
+
+     ! form vector: del^2(q) = 1/dt * div(u*) 
+
+     call mpas_timer_start('NH solve - rhs',.false.)
+
+     call vecZeroEntries(b,petsc_err)
+
+     do iCell = 1, nCellsOwned
+
+        div(:) = 0.0_RKIND
+
+        ! x-part of 1/dt * div(u*)
+
+        do jEdge = 1, nEdgesOnCell(iCell)
+
+           iEdge = edgesOnCell(jEdge,iCell)
+
+           do k = 1, maxLevelCell(iCell)
+
+              div(k) = div(k) - &
+                 edgeSignOnCell(jEdge,iCell) * dvEdge(iEdge) * &
+                    normalVelocityNew(k,iEdge) * layerThicknessEdge(k,iEdge)
+
+           end do
+
+        end do
+
+        ! z-part of 1/dt * div(u*)
+
+        do k = 1, maxLevelCell(iCell)
+
+           div(k) = div(k) + areaCell(iCell) * ( &
+              verticalVelocityNew(k,iCell) - verticalVelocityNew(k+1,iCell))
+
+        end do
+
+       ! copy into full rhs vector
+
+        do k = 1, maxLevelCell(iCell)
+           iCell3d = (indexToCellId(iCell) - 1) * nVertLevels + k - 1
+           insertVal = div(k) / dt
+           call VecSetValues(b, 1, iCell3d, insertVal, INSERT_VALUES, petsc_err)
+        end do 
+
+     end do
+
+     call VecAssemblyBegin(b,petsc_err)
+     call VecAssemblyEnd(b,petsc_err)
+
+     call mpas_timer_stop('NH solve - rhs')
+
+     ! PCG solver: del^2(q) = 1/dt * div(u*)
+
+     call mpas_timer_start('NH solve - solver',.false.)
+
+     call KSPCreate(mpi_comm, ksp, petsc_err)
+     call KSPSetType(ksp, config_nonhydrostatic_solver_type, petsc_err)
+     call KSPSetOperators(ksp,Amat,Amat,petsc_err)
+     call KSPGetPC(ksp,pc,petsc_err)
+     call PCSetType(pc,config_nonhydrostatic_preconditioner,petsc_err)
+     call KSPSetFromOptions(ksp,petsc_err)
+     call KSPSetTolerances(ksp,config_petsc_rtol,config_petsc_atol,1.0E4,config_petsc_maxit,petsc_err)
+     call KSPSolve(ksp, b, x, petsc_err)
+     call KSPGetIterationNumber(ksp, itNum, petsc_err)
+     print *, 'iteration count = ',itNum
+     call KSPSetInitialGuessNonzero(ksp,PETSC_TRUE,petsc_err)
+     call KSPDestroy(ksp,ierr2)
+
+     !now update the nonhydrostaticPressure array unpack into k,iCell
+     call VecScatterBegin(scatter, x, local_x, INSERT_VALUES, SCATTER_FORWARD, petsc_err)
+     call VecScatterEnd(scatter, x, local_x, INSERT_VALUES, SCATTER_FORWARD, petsc_err)
+     call VecGetArrayReadF90(local_x, values, petsc_err)
+
+     !$omp parallel
+     !$omp do schedule(runtime) private(k,vecSpot)
+     do iCell=1,nCellsOwned
+        do k=1,maxLevelCell(iCell)
+          !vecSpot = (indexToCellId(iCell) - 1) * nVertLevels + k - 1
+          !nhPressureCorrection(k,iCell) = values(vecSpot+1)
+          vecSpot = (iCell - 1) * nVertLevels + k - 1
+          nhPressureCorrection(k,iCell) = values(vecSpot+1)
+        end do 
+     end do
+     print*, nhPressureCorrection(10,100)
+     !$omp end do
+     !$omp end parallel 
+
+     call mpas_timer_stop('NH solve - solver') 
+#endif
+
+  end subroutine ocn_nonhydrostatic_solver_everything
+
+  !--------------------------------------------------------------------
+  ! 
+  ! routine ocn_nonhydrostatic_pressure_solve_mat
+  !
+  !> \brief   
+  !> \author  Luke Van Roekel
+  !> \date    February 2021
+  !> \details
+  !>  creates KSP solver context, gets preconditioner and solves
+  !
+  !--------------------------------------------------------------------
+
+  subroutine ocn_nonhydrostatic_pressure_solve(mpi_comm, reuse_preconditioner, nhPressureCorrection)
+
+    integer, intent(in) :: mpi_comm
+    logical, intent(in) :: reuse_preconditioner
+    real(kind=RKIND),dimension(:,:), intent(out) :: nhPressureCorrection
+#ifdef USE_PETSC
+    PetscScalar :: x_array(m)
+    PetscOffset :: i_x
+    PetscInt :: itNum
+    Vec :: uu
+
+    integer :: vecSpot, iCell, k, reason
+
+    overlap=2
+#endif
+
+    call mpas_timer_start('NH solve - pressure solve total',.false.)
+
+#ifdef USE_PETSC
+    !Get version number as some function calls are dependent on that
+    call KSPCreate(mpi_comm, ksp, petsc_err)
+    if(petsc_err .ne. 0) then
+       call mpas_log_write("error: petsc create solver context failed, error code = $i", mpas_log_crit, &
+             intArgs=(/petsc_err/))
+    end if
+
+    if(reuse_preconditioner) then
+       call KSPSetReusePreconditioner(ksp, PETSC_TRUE, petsc_err)
+    else
+       call KSPSetReusePreconditioner(ksp, PETSC_FALSE, petsc_err)
+    end if
+
+    call KSPSetOperators(ksp,Amat,Amat,petsc_err)
+    if(petsc_err .ne. 0) then
+       call mpas_log_write("error: petsc set operaters failed, error code = $i", mpas_log_crit, &
+             intArgs=(/petsc_err/))
+    end if
+
+    call KSPSetType(ksp, config_nonhydrostatic_solver_type, petsc_err)
+    if(petsc_err .ne. 0) then
+       call mpas_log_write("error: petsc set type failed, error code = $i", mpas_log_crit, &
+             intArgs=(/petsc_err/))
+    end if
+
+    if(.not. reuse_preconditioner) then
+       call mpas_timer_start('NH solve - create preconditioner',.false.)
+       call KSPGetPC(ksp,pc,petsc_err)
+       if(petsc_err .ne. 0) then
+          call mpas_log_write("error: petsc getPC failed, error code = $i", mpas_log_crit, &
+             intArgs=(/petsc_err/))
+       end if
+
+       call PCSetType(pc,config_nonhydrostatic_preconditioner,petsc_err)
+       if(petsc_err .ne. 0) then
+          call mpas_log_write("error: petsc PCsetType failed, error code = $i", mpas_log_crit, &
+             intArgs=(/petsc_err/))
+       end if
+       call mpas_timer_stop('NH solve - create preconditioner')
+    end if
+
+    if(config_nonhydrostatic_preconditioner == 'asm') then
+      call mpas_timer_start('NH solve - create ASM preconditioner',.false.)
+      call PCASMSetOverlap(pc,overlap,petsc_err)
+      call KSPSetFromOptions(ksp,petsc_err)
+      call KSPSetUp(ksp,petsc_err)
+      call PCASMGetSubKSP(pc,nlocal,firstVal,PETSC_NULL_KSP,petsc_err)
+      allocate(subksp(nlocal))
+      call PCASMGetSubKSP(pc,nlocal,firstVal,subksp,petsc_err)
+
+      do i=1,nlocal
+         call KSPgetPC(subksp(i),subpc,petsc_err)
+         call PCSetType(subpc,PCILU,petsc_err)
+         call KSPSetType(subksp(i),KSPGMRES,petsc_err)
+         call KSPSetTolerances(subksp(i),config_petsc_rtol,config_petsc_atol,1.0E4,config_petsc_maxit,petsc_err)
+      end do
+      call mpas_timer_stop('NH solve - create ASM preconditioner')
+    else
+       call KSPSetTolerances(ksp,config_petsc_rtol,config_petsc_atol,1.0E4,config_petsc_maxit, petsc_err)
+    end if
+
+    call mpas_timer_start('NH solve - actual solve',.false.)
+    !now that things are set up, we solve the matrix equation
+    call KSPSolve(ksp, b, x, petsc_err)
+    if(petsc_err .ne. 0) then
+       call mpas_log_write("error: petsc solve failed, error code = $i", mpas_log_crit, &
+          intArgs=(/petsc_err/))
+    end if
+
+    !check convergence of solution
+    call KSPGetConvergedReason(ksp,reason,petsc_err)
+    if(reason < 0) then
+      print *, reason
+       call mpas_log_write("error: petsc failed to converge", mpas_log_crit)
+    end if
+
+    call KSPGetIterationNumber(ksp, itNum, petsc_err)
+    print *, 'iteration count = ',itNum
+    call mpas_timer_stop('NH solve - actual solve')
+    !Set next initial guess at solution equal to current solution
+    call KSPSetInitialGuessNonzero(ksp,PETSC_TRUE,petsc_err)
+    if(petsc_err < 0) then
+       call mpas_log_write("error: petsc set next initial guess failed, error code = $i", mpas_log_crit, &
+          intArgs=(/petsc_err/))
+    end if
+
+    call mpas_timer_start('NH solve - unpack solution',.false.)
+    !now update the nonhydrostaticPressure array unpack into k,iCell
+    call VecScatterBegin(scatter, x, local_x, INSERT_VALUES, SCATTER_FORWARD, petsc_err)
+    call VecScatterEnd(scatter, x, local_x, INSERT_VALUES, SCATTER_FORWARD, petsc_err)
+    call VecGetArrayReadF90(local_x, values, petsc_err)
+
+    !$omp parallel
+    !$omp do schedule(runtime) private(k,vecSpot)
+    do iCell=1,nCellsOwned
+       do k=1,maxLevelCell(iCell)
+         vecSpot = (iCell-1)*nVertLevels + k
+         nhPressureCorrection(k,iCell) = values(vecSpot)
+       end do
+    end do
+    !$omp end do
+    !$omp end parallel
+
+    call mpas_timer_stop('NH solve - unpack solution')
+    if(config_nonhydrostatic_preconditioner == 'asm') deallocate(subksp)
+#endif
+    call mpas_timer_stop('NH solve - pressure solve total')
+
+  end subroutine ocn_nonhydrostatic_pressure_solve
+
+  !--------------------------------------------------------------------
+  ! 
+  ! routine ocn_nonhydrostatic_pressure_fill_matvec 
+  !
+  !> \brief   fills matrix and vector for pressure solve 
+  !> \author  Luke Van Roekel
+  !> \date    February 2021
+  !> \details
+  !>  Fills matrix on LHS for pressure solve and the RHS vector
+  !
+  !--------------------------------------------------------------------
+
+  subroutine ocn_nonhydrostatic_solver_fill_matVec(normalVelocityNew, &
+      verticalVelocityNew, layerThickness, layerThicknessEdge, mpi_comm, dt)
+
+    real(kind=RKIND),dimension(:,:), intent(in) :: normalVelocityNew, verticalVelocityNew
+    
+    real(kind=RKIND),dimension(:,:), intent(in) :: layerThickness, layerThicknessEdge
+
+    real(kind=RKIND), intent(in) :: dt
+
+    integer, intent(in) :: mpi_comm
+
+  !--------------------------------------------------------------------
+  !
+  ! subroutine variables
+  !
+  !--------------------------------------------------------------------
+
+   integer :: jj,cell1, cell2, neighborInd, j, iEdge, iCell, k, matIndex
+#ifdef USE_PETSC
+   PetscScalar :: insertVal, rhsSum
+   PetscInt :: i
+#endif
+   real :: termSign, edge_tmp
+
+   !Make sure all entries are zero so there is no unintended overwrite
+#ifdef USE_PETSC
+   call MatZeroEntries(Amat, petsc_err)
+   do iCell = 1,nCellsOwned
+     !add the points with iCell and k, k+1, k-1i
+     !at the top of the domain and bottom (maxLevelCell+1, fill things in with zeros below
+     ! should only contain an icell entry to get derivatives right. better BCs now
+     ! the conversion to matrix space is i = nVertLevels*(iCell-1) + nVertLevelsi
+     do j=1,nEdgesOnCell(iCell)
+        iEdge = edgesOnCell(j, iCell)
+        cell1 = cellsOnEdge(1,iEdge)
+        cell2 = cellsOnEdge(2,iEdge)
+
+        edge_tmp = dvEdge(iEdge)*dt*edgeSignOnCell(j,iCell)/(dcEdge(iEdge))
+
+        if(cell1 == iCell) then
+          neighborInd = cell2
+        else
+          neighborInd = cell1
+        end if
+
+        do k=1,maxLevelEdgeTop(iEdge)
+          row = (indexToCellId(iCell)-1)*nVertLevels + k - 1
+          col = (indexToCellId(cell2)-1)*nVertLevels + k - 1
+          insertVal = -edge_tmp*layerThicknessEdge(k,iEdge)
+          call MatSetValues(Amat, 1, row, 1, col, insertVal, ADD_VALUES, petsc_err)
+
+          col = (indexToCellId(cell1)-1)*nVertLevels + k - 1
+          insertVal = edge_tmp*layerThicknessEdge(k,iEdge)
+          call MatSetValues(Amat, 1, row, 1, col, insertVal, ADD_VALUES, petsc_err)
+        end do
+     end do !End loop over edges
+     ! So now do the iCell, k (and k-1 k + 1)
+     k = 1
+     col = (indexToCellId(iCell) - 1)*nVertLevels + k - 1
+     row = (indexToCellId(iCell) - 1)*nVertLevels + k - 1
+     ! k value
+     insertVal = -dt*areaCell(iCell)*(1.0_RKIND / (0.5_RKIND*(layerThickness(k,iCell) + layerThickness(k+1,iCell) + 1.0E-15_RKIND)) + &
+                    surfaceBoundaryConditionTop*2.0_RKIND / (layerThickness(k,iCell) + 1.0E-15_RKIND))
+     call MatSetValues(Amat, 1, row, 1, col, insertVal, ADD_VALUES, petsc_err)
+
+     ! k + 1 value
+     col = (indexToCellId(iCell) - 1)*nVertLevels + (k+1) - 1
+     insertVal = dt*areaCell(iCell) / (0.5_RKIND*(layerThickness(k,iCell) + layerThickness(k+1,iCell) + 1.0E-15_RKIND))
+     call MatSetValues(Amat, 1, row, 1, col, insertVal, ADD_VALUES, petsc_err)
+
+     do k=2,maxLevelCell(iCell)-1
+        col = (indexToCellId(iCell) - 1)*nVertLevels + (k-1) - 1
+        row = (indexToCellId(iCell) - 1)*nVertLevels + k - 1
+        insertVal = dt*areaCell(iCell) / (0.5_RKIND*(layerThickness(k-1,iCell) + layerThickness(k,iCell)) + 1.0E-15_RKIND)
+        call MatSetValues(Amat, 1, row, 1, col, insertVal, ADD_VALUES, petsc_err)
+
+        ! k value
+        col = (indexToCellId(iCell) - 1)*nVertLevels + k - 1
+        insertVal = -dt*areaCell(iCell)*(1.0/(0.5_RKIND*(layerThickness(k-1,iCell) + layerThickness(k,iCell) + 1.0E-15_RKIND)) + &
+                         1.0/(0.5_RKIND*(layerThickness(k,iCell) + layerThickness(k+1,iCell) + 1.0E-15_RKIND)))
+        call MatSetValues(Amat, 1, row, 1, col, insertVal, ADD_VALUES, petsc_err)
+
+        ! k+1 value
+        col = (indexToCellId(iCell) - 1)*nVertLevels + (k+1) - 1
+        insertVal = dt*areaCell(iCell)/(0.5_RKIND*(layerThickness(k,iCell) + layerThickness(k+1,iCell) + 1.0E-15_RKIND))
+        call MatSetValues(Amat, 1, row, 1, col, insertVal, ADD_VALUES, petsc_err)
+     end do !k loop
+     k = maxLevelCell(iCell)
+     !k-1 value
+     col = (indexToCellId(iCell) - 1)*nVertLevels + (k-1) - 1
+     row = (indexToCellId(iCell) - 1)*nVertLevels + k - 1
+     insertVal = dt*areaCell(iCell) / (0.5_RKIND*(layerThickness(k-1,iCell) + layerThickness(k,iCell)) + 1.0E-15_RKIND)
+     call MatSetValues(Amat, 1, row, 1, col, insertVal, ADD_VALUES, petsc_err)
+
+     !k value
+     col = (indexToCellId(iCell) - 1)*nVertLevels + k - 1 
+     insertVal = -dt*areaCell(iCell)*(1.0/(0.5_RKIND*(layerThickness(k-1,iCell) + layerThickness(k,iCell) + 1.0E-15_RKIND)) + &
+                  surfaceBoundaryConditionBottom*2.0_RKIND / (layerThickness(k,iCell) + 1.0E-15_RKIND))
+     call MatSetValues(Amat, 1, row, 1, col, insertVal, ADD_VALUES, petsc_err)
+  end do !iCell loop
+  call MatAssemblyBegin(Amat,MAT_FINAL_ASSEMBLY,petsc_err)
+  call MatAssemblyEnd(Amat,MAT_FINAL_ASSEMBLY,petsc_err)
+  ! next fill RHS vector 'b'
+  call vecZeroEntries(b,petsc_err)
+  do iCell=1,nCellsOwned
+     do k=1,maxLevelCell(iCell)
+        insertVal = areaCell(iCell)*(verticalVelocityNew(k,iCell) - verticalVelocityNew(k+1,iCell))
+        row = (indexToCellId(iCell) - 1)*nVertLevels + k - 1
+        call VecSetValues(b, 1, row, insertVal, ADD_VALUES, petsc_err)
+     enddo
+  enddo
+  do iCell=1,nCellsOwned
+        do j=1,nEdgesOnCell(iCell)
+           iEdge = edgesOnCell(j,iCell)
+
+           do k=1,maxLevelEdgeTop(iEdge)
+              insertVal = -layerThicknessEdge(k,iEdge)*dvEdge(iEdge)*edgeSignOnCell(j,iCell)* &
+                          normalVelocityNew(k,iEdge)
+              row = (indexToCellId(iCell) - 1)*nVertLevels + k - 1
+              call VecSetValues(b, 1, row, insertVal, ADD_VALUES, petsc_err)
+           end do
+        end do
+  end do
+  call VecAssemblyBegin(b,petsc_err)
+  call VecAssemblyEnd(b,petsc_err)
+
+  if (config_nonhydrostatic_remove_rhs_mean) then
+     call VecSum(b, rhsSum, petsc_err)
+     rhsSum = rhsSum / globalM
+     call VecAXPY(b, rhsSum, negOneVec, petsc_err)
+  end if
+#endif
+
+  end subroutine ocn_nonhydrostatic_solver_fill_matVec
+
+  !--------------------------------------------------------------------
+  ! IIIIII
+  ! routine ocn_nonhydrostatic_solver_init
+  !
+  !> \brief   Initializes matricesIIIIII and vectors for PETSC solve
+  !> \author  Luke Van Roekel
+  !> \date    February 2021
+  !> \details
+  !>  Initializese the matrix for the nonhydrostatic solve, automatically
+  !>  determines what is owned by processor.  Does not fill values.
+  !
+  !--------------------------------------------------------------------
+
+  subroutine ocn_nonhydrostatic_solver_init(mpi_comm, ierr)
+
+    integer, intent(in) :: mpi_comm
+    integer, intent(inout) :: ierr
+    integer :: commsize, globalCells
+    real(kind=RKIND) :: decimals, version
+#ifdef USE_PETSC
+    PetscInt :: major, minor, subminor, release, locRow, locCol, locals(nCellsOwned)
+    PetscReal :: val
+    ISLocalToGlobalMapping :: mapping
+#endif
+    integer :: k, iCell, iter, nnzRowMax
+
+    !nnzRowMax = 9 * 2 + 4
+    nnzRowMax = 1 + 2 + 7
+
+#ifndef USE_PETSC
+    call mpas_log_write("nonhydrostatic solver requires PETSC library compiled and linked", &
+                        mpas_log_crit)
+#endif
+
+    if(config_nonhydrostatic_solve_surface_boundary_condition == 'noGradient') then
+       surfaceBoundaryConditionTop = 0.0_RKIND
+       surfaceBoundaryConditionBottom = 0.0_RKIND
+    elseif(config_nonhydrostatic_solve_surface_boundary_condition == 'noPressure') then
+       surfaceBoundaryConditionTop = 1.0_RKIND
+       surfaceBoundaryConditionBottom = 1.0_RKIND
+    elseif(config_nonhydrostatic_solve_surface_boundary_condition == 'pressureTopGradientBottom') then
+       surfaceBoundaryConditionTop = 1.0_RKIND
+       surfaceBoundaryConditionBottom = 0.0_RKIND
+    else
+       surfaceBoundaryConditionTop = 0.0_RKIND
+       surfaceBoundaryConditionBottom = 1.0_RKIND
+    endif
+
+    call MPI_comm_size(mpi_comm, commsize, ierr)
+
+#ifdef USE_PETSC
+    call PetscInitialize(PETSC_NULL_CHARACTER,petsc_err)
+    if(petsc_err .ne. 0) then
+      call mpas_log_write("error: petsc initialize failed, error code = $i", mpas_log_crit, &
+        intargs=(/petsc_err/))
+      ierr = petsc_err
+    endif
+
+    call PetscGetVersionNumber(major, minor, subminor, release, petsc_err)
+    if(petsc_err .ne. 0) then
+      call mpas_log_write("ERROR: Petsc GetVersionNumber failed, error code = $i", MPAS_LOG_CRIT, &
+        intArgs=(/petsc_err/))
+      ierr = petsc_err
+    end if
+
+    !Solver routines require version to be greater than 3.5
+    decimals = floor(log10(float(minor))) + 1
+    version = float(major) + float(minor) / 10.0_RKIND**decimals
+    if(version < 3.05) then
+      call mpas_log_write("ERROR: Petsc Version required to be greater than 3.5, you are using $r", &
+        MPAS_LOG_CRIT, realArgs=(/version/))
+      ierr = petsc_err
+    end if
+
+    m = nCellsOwned * nVertLevels
+    call PetscOptionsGetInt(PETSC_NULL_OPTIONS,PETSC_NULL_CHARACTER,'-m',m,flag,petsc_err)
+    if(petsc_err .ne. 0) then
+      call mpas_log_write("ERROR: Petsc OptionsGetInt failed, error code = $i", MPAS_LOG_CRIT, &
+        intArgs=(/petsc_err/))
+      ierr = petsc_err
+    endif
+
+    call MatCreate(mpi_comm, Amat, petsc_err)
+    if(petsc_err .ne. 0) then
+      call mpas_log_write("ERROR: Petsc MatCreate failed, error code = $i", MPAS_LOG_CRIT, &
+        intArgs=(/petsc_err/))
+      ierr = petsc_err
+    endif
+
+    call MatSetSizes(Amat, m, m, PETSC_DETERMINE, PETSC_DETERMINE, petsc_err)
+    if(petsc_err .ne. 0) then
+      call mpas_log_write("ERROR: Petsc MatSetSizes failed, error code = $i", MPAS_LOG_CRIT, &
+        intArgs=(/petsc_err/))
+      ierr = petsc_err
+    endif
+
+    call MatSetType( Amat, MATAIJ, petsc_err )
+    if( commsize == 1) then
+      call MatSetType( Amat, MATAIJ, petsc_err )
+      call MatSetFromOptions(Amat,petsc_err)
+      call MatSeqAIJSetPreallocation(Amat, nnzRowMax, PETSC_NULL_INTEGER, petsc_err)
+    else
+      call MatSetType( Amat, MATMPIAIJ, petsc_err )
+      call MatSetFromOptions(Amat,petsc_err)
+      call MatMPIAIJSetPreallocation(Amat,2*nnzRowMax, PETSC_NULL_INTEGER, 2*nnzRowMax, PETSC_NULL_INTEGER, petsc_err)
+    end if
+
+    !call MatSetFromOptions(Amat,petsc_err)
+    !if(petsc_err .ne. 0) then
+    !  call mpas_log_write("ERROR: Petsc MatSetFromOptions failed, error_code = $i", MPAS_LOG_CRIT, &
+    !    intArgs=(/petsc_err/))
+    !  ierr = petsc_err
+    !endif
+
+    !call MatSetUp(Amat,petsc_err)
+    !if(petsc_err .ne. 0) then
+    !  call mpas_log_write("ERROR: Petsc MatSetUp failed, error_code = $i", MPAS_LOG_CRIT, &
+    !    intArgs=(/petsc_err/))
+    !  ierr = petsc_err
+    !endif
+
+    call MatGetOwnershipRange(Amat,Istart,Iend,petsc_err)
+    if(petsc_err .ne. 0) then
+      call mpas_log_write("ERROR: Petsc MatGetOwnershipRange failed, error_code = $i", MPAS_LOG_CRIT, &
+        intArgs=(/petsc_err/))
+      ierr = petsc_err
+    endif
+
+    call MatGetSize(Amat, globalM, globalM, petsc_err)
+    if(petsc_err .ne. 0) then
+      call mpas_log_write("ERROR: Petsc MatGetSize failed, error_code = $i", MPAS_LOG_CRIT, &
+        intArgs=(/petsc_err/))
+      ierr = petsc_err
+    endif
+
+    call MatGetLocalSize(Amat,locRow,locCol,petsc_err)
+
+    print*, m, globalM, locRow, locCol
+
+    call VecCreate(mpi_comm, b, petsc_err)
+    if(petsc_err .ne. 0) then
+      call mpas_log_write("ERROR: Petsc VecCreate failed, error_code = $i", MPAS_LOG_CRIT, &
+        intArgs=(/petsc_err/))
+      ierr = petsc_err
+    endif
+
+    call VecSetSizes(b, m, globalM, petsc_err)
+    if ( commsize == 1 ) then
+       call VecSetType(b, VECSEQ, petsc_err)
+    else
+       call VecSetType(b, VECMPI, petsc_err)
+    end if
+
+    if(petsc_err .ne. 0) then
+      call mpas_log_write("ERROR: Petsc VecSetSizes failed, error_code = $i", MPAS_LOG_CRIT, &
+        intArgs=(/petsc_err/))
+      ierr = petsc_err
+    endif
+
+    call VecDuplicate(b, x, petsc_err)
+    if(petsc_err .ne. 0) then
+      call mpas_log_write("ERROR: Petsc VecCreate Duplicate, error_code = $i", MPAS_LOG_CRIT, &
+        intArgs=(/petsc_err/))
+      ierr = petsc_err
+    endif
+
+    call VecSetSizes(x, m, globalM, petsc_err)
+    if(petsc_err .ne. 0) then
+      call mpas_log_write("ERROR: Petsc VecSetSizes failed, error_code = $i", MPAS_LOG_CRIT, &
+        intArgs=(/petsc_err/))
+      ierr = petsc_err
+    endif
+
+    call VecGetOwnershipRange(x,first,last,petsc_err)
+
+    call VecDuplicate(b, negOneVec, petsc_err)
+    if(petsc_err .ne. 0) then
+      call mpas_log_write("ERROR: Petsc VecCreate Duplicate, error_code = $i", MPAS_LOG_CRIT, &
+        intArgs=(/petsc_err/))
+      ierr = petsc_err
+    endif
+
+    call VecSetSizes(negOneVec, m, globalM, petsc_err)
+    if(petsc_err .ne. 0) then
+      call mpas_log_write("ERROR: Petsc VecSetSizes failed, error_code = $i", MPAS_LOG_CRIT, &
+        intArgs=(/petsc_err/))
+      ierr = petsc_err
+    endif
+
+    call VecGetOwnershipRange(negOneVec,first,last,petsc_err)
+
+    call VecCreate(mpi_comm, local_x, petsc_err)
+    if(petsc_err .ne. 0) then
+      call mpas_log_write("ERROR: Petsc VecCreate failed, error_code = $i", MPAS_LOG_CRIT, &
+        intArgs=(/petsc_err/))
+      ierr = petsc_err
+    endif
+
+    call VecSetSizes(local_x, m, PETSC_DETERMINE, petsc_err)
+    if ( commsize == 1 ) then
+       call VecSetType(local_x, VECSEQ, petsc_err)
+    else
+       call VecSetType(local_x, VECMPI, petsc_err)
+    end if
+
+    allocate(destIndex(globalM), origIndex(globalM))
+    ! Try a better way with Index Sets and Vec Scatter for some communication
+    ! later move this first part to init as we don't have to do it every time FIXME!
+    iter = 1
+    do iCell = 1,nCellsOwned
+      do k=1,nVertLevels
+         destIndex(iter) = (iCell-1)*nVertLevels + k - 1 + first
+         origIndex(iter) = (indexToCellID(iCell)-1)*nVertLevels + k - 1
+         call VecSetValues(negOneVec, 1, origIndex(iter), -1.0_RKIND, INSERT_VALUES, petsc_err)
+         iter = iter + 1
+      end do
+    end do
+
+    call VecAssemblyBegin(negOneVec, petsc_err)
+    call VecAssemblyEnd(negOneVec, petsc_err)
+
+    call ISCreateGeneral(mpi_comm, globalM, origIndex, PETSC_COPY_VALUES, origIS, petsc_err)
+    call ISCreateGeneral(mpi_comm, globalM, destIndex, PETSC_COPY_VALUES, destIS, petsc_err)
+    call VecScatterCreate(x, origIS, local_x, destIS, scatter, petsc_err)
+    
+#endif
+
+    end subroutine ocn_nonhydrostatic_solver_init
+
+  !--------------------------------------------------------------------
+  ! 
+  ! routine ocn_nonhydrostatic_solver_finalize
+  !
+  !> \brief   Destroys matrices and vectors for PETSC solve
+  !> \author  Luke Van Roekel
+  !> \date    February 2021
+  !> \details
+  !>   Destroys matrices and frees memory, finalizes Petsc 
+  !
+  !--------------------------------------------------------------------
+
+  subroutine ocn_nonhydrostatic_solver_finalize()
+
+#ifdef USE_PETSC
+    !stuff for PETSC_finalize from the scatter routine
+    call ISDestroy(origIS, petsc_err)
+    call ISDestroy(destIS, petsc_err)
+    call VecScatterDestroy(scatter, petsc_err)
+
+    call MatDestroy(Amat,petsc_err)
+    call VecDestroy(b,petsc_err)
+    call VecDestroy(x,petsc_err)
+    call VecDestroy(negOneVec,petsc_err)
+    !call KSPDestroy(ksp,ierr2)
+    call VecDestroy(local_x,petsc_err)
+ 
+    !LPV FIXME : for some reason this causes error "Corrupt argument"
+    !disable for now
+    !call PetscFinalize(petsc_err)
+#endif
+
+  end subroutine ocn_nonhydrostatic_solver_finalize  
+
+end module ocn_compute_nonhydrostatic_pressure
+

--- a/components/mpas-ocean/src/shared/mpas_ocn_nonhydrostatic_pressure_solve.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_nonhydrostatic_pressure_solve.F
@@ -221,8 +221,8 @@ module ocn_compute_nonhydrostatic_pressure
                   nhPressureCorrection(k,iCell)
        end do 
     end do
-    print*, 'nonhydrostaticPressure ', nonhydrostaticPressure(10,100)
-    print*, 'nhPressureCorrection ', nhPressureCorrection(10,100)
+    !print*, 'nonhydrostaticPressure ', nonhydrostaticPressure(10,100)
+    !print*, 'nhPressureCorrection ', nhPressureCorrection(10,100)
     !$omp end do
     !$omp end parallel
 
@@ -485,7 +485,7 @@ module ocn_compute_nonhydrostatic_pressure
           nhPressureCorrection(k,iCell) = values(vecSpot+1)
         end do 
      end do
-     print*, nhPressureCorrection(10,100)
+     !print*, nhPressureCorrection(10,100)
      !$omp end do
      !$omp end parallel 
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_shear_production.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_shear_production.F
@@ -118,7 +118,7 @@ contains
 
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(k, c_psi2, viscMid, shearProduction)
+      !$omp private(k, viscMid, shearProduction)
       do iCell = 1, nCellsOwned
         do k=1,maxLevelCell(iCell)
             viscMid = 0.5_RKIND*(vertViscTopOfCell(k,iCell) + vertViscTopOfCell(k+1,iCell))

--- a/components/mpas-ocean/src/shared/mpas_ocn_shear_production.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_shear_production.F
@@ -1,0 +1,153 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_shear_production
+!
+!> \brief MPAS two equation turbulence model shear production
+!> \author Luke Van Roekel 
+!> \date   June 2021
+!> \details
+!>  This module contains the routines for computing shear production term 
+!>  for the two equation turbulence closure
+!>
+!
+!-----------------------------------------------------------------------
+
+module ocn_shear_production
+
+   use mpas_timer
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_threading
+
+   use ocn_constants
+   use ocn_diagnostics_variables
+   use ocn_config
+   use ocn_mesh
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: ocn_shear_production_compute
+
+   !--------------------------------------------------------------------
+   !
+   ! Private module variables
+   !
+   !--------------------------------------------------------------------
+
+
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+!
+!  routine ocn_shear_production_compute
+!
+!> \brief   Computes shear production term for the two equation model 
+!> \author  Luke Van Roekel
+!> \date    July 2021
+!> \details
+!>  This routine computes the shear production term for the  
+!>  two equation model.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_shear_production_compute(tkeTend, glsPsiTend, tke, glsPsi, &
+                  c_psi1, surfaceFrictionVelocity, c_mu, err)
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tkeTend,glsPsiTend          !< Input/Output:  tendencies
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         tke, glsPsi          !< Input: tke and psi variable at current timestep 
+
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         surfaceFrictionVelocity 
+
+      real (kind=RKIND), intent(in) :: c_psi1, c_mu
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, iEdge, cell1, cell2
+      integer :: i, k, nCells
+
+      real (kind=RKIND) :: invAreaCell
+      real (kind=RKIND) :: shearProduction, viscMid
+
+      err = 0
+
+      call mpas_timer_start("shear production compute")
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(k, c_psi2, viscMid, shearProduction)
+      do iCell = 1, nCellsOwned
+        do k=1,maxLevelCell(iCell)
+            viscMid = 0.5_RKIND*(vertViscTopOfCell(k,iCell) + vertViscTopOfCell(k+1,iCell))
+            shearProduction = 2.0_RKIND*(viscMid*ugrad(1,k,iCell) - tke(k,iCell)/3.0_RKIND)* &
+                              ugrad(1,k,iCell) + viscMid*(ugrad(2,k,iCell) + vgrad(1,k,iCell))* &
+                              ugrad(2,k,iCell) + viscMid*(ugrad(3,k,iCell) + wgrad(1,k,iCell))* &
+                              ugrad(3,k,iCell) + viscMid*(ugrad(2,k,iCell) + vgrad(1,k,iCell))* &
+                              vgrad(1,k,iCell) + 2.0_RKIND*(viscMid*vgrad(2,k,iCell) -          &
+                              tke(k,iCell)/3.0_RKIND)*vgrad(2,k,iCell) + viscMid*(vgrad(3,k,iCell) + &
+                              wgrad(2,k,iCell))*vgrad(3,k,iCell) + viscMid*(ugrad(3,k,iCell) +  &
+                              wgrad(1,k,iCell))*wgrad(1,k,iCell) + viscMid*(vgrad(3,k,iCell) +  &
+                              wgrad(2,k,iCell))*wgrad(2,k,iCell) + 2.0_RKIND*(viscMid*wgrad(3,k,iCell) - &
+                              tke(k,iCell)/3.0_RKIND)*wgrad(3,k,iCell)
+            tkeTend(k,iCell) = tkeTend(k,iCell) + shearProduction
+            glsPsiTend(k,iCell) = glsPsiTend(k,iCell) + glsPsi(k,iCell)/(tke(k,iCell) + 1.0E-15_RKIND) &
+                                  *c_psi1*shearProduction
+         end do 
+         !TODO - need a bottom drag term here.
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      call mpas_timer_stop("shear production compute")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_shear_production_compute
+
+end module ocn_shear_production
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+! vim: foldmethod=marker

--- a/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
@@ -26,7 +26,6 @@ module ocn_tendency
    use mpas_timer
    use mpas_threading
    use ocn_diagnostics
-   use ocn_diagnostics_variables
    use ocn_constants
    use ocn_config
    use ocn_mesh
@@ -35,6 +34,7 @@ module ocn_tendency
    use ocn_surface_land_ice_fluxes
    use ocn_frazil_forcing
    use ocn_tidal_forcing
+   use ocn_diagnostics_variables
 
    use ocn_tracer_hmix
    use ocn_high_freq_thickness_hmix_del2
@@ -65,6 +65,11 @@ module ocn_tendency
    use ocn_wetting_drying
    use ocn_vel_tidal_potential
 
+   use ocn_vvel_pgrad
+   use ocn_vvel_coriolis
+   use ocn_vvel_advection
+   use ocn_vvel_hmix_del2
+
    implicit none
    private
    save
@@ -85,7 +90,8 @@ module ocn_tendency
              ocn_tend_vel, &
              ocn_tend_tracer, &
              ocn_tend_freq_filtered_thickness, &
-             ocn_tendency_init
+             ocn_tendency_init, &
+             ocn_tend_vvel
 
    !--------------------------------------------------------------------
    !
@@ -228,6 +234,133 @@ contains
 
 !***********************************************************************
 !
+!  routine ocn_tend_vvel
+!
+!> \brief   Computes vertical velocity tendency
+!> \author  Luke Van Roekel
+!> \date    January 2021
+!> \details
+!>  This routine computes the vertical velocity tendency for the ocean
+!
+!-----------------------------------------------------------------------
+
+subroutine ocn_tend_vvel(tendPool, statePool, forcingPool, meshPool, &
+                        timeLevelIn, dt)!{{{
+
+   implicit none
+
+   type (mpas_pool_type), intent(inout) :: tendPool !< Input/Output: Tendency structure
+   type (mpas_pool_type), intent(in) :: statePool !< Input: State information
+   type (mpas_pool_type), intent(inout) :: forcingPool !< Input: Forcing information
+   type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
+   real (kind=RKIND), intent(in) :: dt
+   integer, intent(in), optional :: timeLevelIn !< Input: Time level for state fields
+
+   type (mpas_pool_type), pointer :: tracersPool
+
+   real (kind=RKIND), dimension(:,:), pointer :: &
+     normalVelocity, tangentialVelocity, density, potentialDensity, zMid, pressure, &
+     layerThickness, nonhydrostaticPressure, &
+     tend_normalVelocity, circulation, relativeVorticity, viscosity, kineticEnergyCell, &
+     normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, &
+     montgomeryPotential, divergence, vertViscTopOfEdge, &
+     inSituThermalExpansionCoeff, inSituSalineContractionCoeff, verticalVelocity, &
+     tend_verticalVelocity
+
+   ! Scratch Arrays
+   ! normalThicknessFlux: Flux of thickness through an edge
+   !               units: m^{2} s^{-1}
+   real (kind=RKIND), dimension(:,:), allocatable :: normalThicknessFlux
+
+   integer :: timeLevel
+
+   integer :: err, iEdge, iCell, k
+   integer, pointer :: nVertLevels, indexTemperature, indexSalinity, nEdges, nCells
+   integer, dimension(:), pointer :: maxLevelCell
+
+   if (present(timeLevelIn)) then
+      timeLevel = timeLevelIn
+   else
+      timeLevel = 1
+   end if
+
+   call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
+   call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+
+   call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+
+   call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocity, timeLevel)
+   call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
+   call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
+   call mpas_pool_get_array(statePool, 'nonhydrostaticPressure', nonhydrostaticPressure, timeLevel)
+
+   call mpas_pool_get_array(tendPool, 'verticalVelocityTend', tend_verticalVelocity)
+
+   allocate(normalThicknessFlux(nVertLevels, nEdges+1))
+
+   !
+   ! transport velocity for the tracer.
+   !
+   !$omp parallel
+   !$omp do schedule(runtime) & 
+   !$omp private(k)
+   do iEdge = 1, nEdges
+      do k = 1, nVertLevels
+         normalThicknessFlux(k, iEdge) = normalTransportVelocity(k, iEdge) * layerThickEdge(k, iEdge)
+      end do
+   end do
+   !$omp end do
+   !$omp end parallel
+
+   !
+   ! velocity tendency: start accumulating tendency terms
+   !
+   !$omp parallel
+   !$omp do schedule(runtime)
+   do iCell = 1, nCells
+      tend_verticalVelocity(:, iCell) = 0.0_RKIND
+   end do
+   !$omp end do
+   !$omp end parallel
+
+   if(config_disable_vvel_all_tend) return
+
+   call mpas_timer_start("ocn_tend_vvel")
+   !
+   ! velocity tendency: nonlinear Coriolis term and grad of kinetic energy
+   !
+   call ocn_vvel_coriolis_tend(meshPool, normalVelocity, tend_verticalVelocity, err)
+
+   !
+   ! velocity tendency: horizontal and vertical advection
+   !
+   call ocn_vvel_advection_tend(meshPool, verticalVelocity, normalThicknessFlux, &
+                                        layerThickness, vertAleTransportTop, dt, &
+                                        tend_verticalVelocity)
+
+   !
+   ! velocity tendency: pressure gradient
+   !
+   call ocn_vvel_pgf_tend(meshPool, layerThickness, nonhydrostaticPressure, &
+        tend_verticalVelocity, err)
+
+   !
+   ! velocity tendency: del2 dissipation, CALL STRAIGHT to hmix_del2 FOR NOW!!!
+   ! \nu_2 \nabla^2 u
+   !   computed as \nu( \nabla divergence + k \times \nabla relativeVorticity )
+   !   strictly only valid for config_mom_del2 == constant
+   !
+   call ocn_vvel_hmix_del2_tend(layerThickEdge, verticalVelocity, &
+        tend_verticalVelocity, err)
+
+
+   call mpas_timer_stop("ocn_tend_vvel")
+   deallocate(normalThicknessFlux)
+
+end subroutine ocn_tend_vvel!}}}
+
+!***********************************************************************
+!
 !  routine ocn_tend_vel
 !
 !> \brief   Computes velocity tendency
@@ -292,7 +425,9 @@ contains
 
       real (kind=RKIND), dimension(:,:), pointer, contiguous :: &
          normalVelocity,     &! normal velocity
-         layerThickness
+         layerThickness, &
+         nonhydrostaticPressure, &
+         verticalVelocity
 
       real (kind=RKIND), dimension(:,:,:), pointer, contiguous :: &
          activeTracers
@@ -320,6 +455,10 @@ contains
       call mpas_pool_get_array(statePool,   'ssh', ssh, timeLevel)
       call mpas_pool_get_array(tracersPool, 'activeTracers', &
                                              activeTracers, timeLevel)
+      call mpas_pool_get_array(statePool, 'nonhydrostaticPressure', &
+                                             nonhydrostaticPressure, timeLevel)
+      call mpas_pool_get_array(statePool, 'verticalVelocity', &
+                                             verticalVelocity, timeLevel)
 
       call mpas_pool_get_dimension(tracersPool, 'index_temperature', &
                                                  indexTemperature)
@@ -340,7 +479,8 @@ contains
       !$acc               density, normRelVortEdge, montgomeryPotential, pressure, &
       !$acc               thermExpCoeff, salineContractCoeff, tangentialVelocity, &
       !$acc               layerThickEdge, kineticEnergyCell, sfcFlxAttCoeff, potentialDensity, &
-      !$acc               vertAleTransportTop, vertViscTopOfEdge, wettingVelocity)
+      !$acc               vertAleTransportTop, vertViscTopOfEdge, wettingVelocity, &
+      !$acc               verticalVelocity, nhPressureCorrection)
       !$acc enter data &
       !$acc    copyin(tendVel, sfcStress, sfcStressMag, &
       !$acc    ssh, normalVelocity, &
@@ -391,25 +531,50 @@ contains
       ! Add top drag to surface stress
       call ocn_surface_land_ice_fluxes_vel( &
                                        sfcStress, sfcStressMag, err)
+      do iEdge=1,nEdgesOwned
+         do k=1,nVertLevels
+            velocityCoriolisTend(k,iEdge) = tendVel(k,iEdge)
+         end do
+      end do
 
       ! Add nonlinear Coriolis term and horizontal advection of
       ! momentum, formulated as grad of kinetic energy
       call ocn_vel_hadv_coriolis_tend(normRelVortEdge, &
                                       normPlanetVortEdge, &
                                       layerThickEdge, normalVelocity, &
-                                      kineticEnergyCell, tendVel, err)
+                                      kineticEnergyCell, verticalVelocity, &
+                                      tendVel, err)
+      do iEdge = 1,nEdgesOwned
+         do k=1,nVertLevels
+            velocityCoriolisTend(k,iEdge) = tendVel(k,iEdge) - velocityCoriolisTend(k,iEdge)
+            velocityVadvTend(k,iEdge) = tendVel(k,iEdge)
+         end do
+      end do
 
       ! Add vertical advection term -w du/dz
       call ocn_vel_vadv_tend(normalVelocity, layerThickEdge, &
                              vertAleTransportTop, tendVel, err)
+      do iEdge = 1,nEdgesOwned
+         do k=1,nVertLevels
+            velocityVadvTend(k,iEdge) = tendVel(k,iEdge) - velocityVadvTend(k,iEdge)
+            velocityPGFTend(k,iEdge) = tendVel(k,iEdge)
+         end do
+      end do
 
       ! Add pressure gradient
-      call ocn_vel_pressure_grad_tend(ssh, pressure, surfacePressure, &
+      call ocn_vel_pressure_grad_tend(ssh, nonhydrostaticPressure, &
+                               pressure, surfacePressure, &
                                montgomeryPotential, zMid, &
                                density, potentialDensity, &
                                indxTemp, indxSalt, activeTracers, &
                                thermExpCoeff, salineContractCoeff, &
                                tendVel, err)
+      do iEdge=1,nEdgesOwned
+         do k=1,nVertLevels
+            velocityPGFtend(k,iEdge) = tendVel(k,iEdge) - velocityPGFtend(k,iEdge)
+            velocityHmixtend(k,iEdge) = tendVel(k,iEdge)
+         end do
+      end do
 
       ! Add tidal potential (if needed) 
       call ocn_compute_tidal_potential_forcing(err)
@@ -417,14 +582,32 @@ contains
         ! for split explicit, tidal forcing is added in barotropic subcycles
         call ocn_vel_tidal_potential_tend(ssh,surfacePressure, tendVel, err)
       endif
+      do iEdge=1,nEdgesOwned
+         do k=1,nVertLevels
+            velocityHmixtend(k,iEdge) = tendVel(k,iEdge) - velocityHmixtend(k,iEdge)
+            velocityForcingtend(k,iEdge) = tendVel(k,iEdge)
+         end do
+      end do
+
 
       ! Add horizontal mixing
-      call ocn_vel_hmix_tend(divergence, relativeVorticity, tendVel,err)
+      call ocn_vel_hmix_tend(divergence, relativeVorticity, viscosity, tendVel,err)
+      do iEdge=1,nEdgesOwned
+         do k=1,nVertLevels
+            velocityHmixtend(k,iEdge) = tendVel(k,iEdge) - velocityHmixtend(k,iEdge)
+            velocityForcingtend(k,iEdge) = tendVel(k,iEdge)
+         end do
+      end do
 
       ! Add forcing and bottom drag
       call ocn_vel_forcing_tend(normalVelocity, sfcFlxAttCoeff, &
                                 sfcStress, kineticEnergyCell, &
                                 layerThickEdge, tendVel, err)
+      do iEdge=1,nEdgesOwned
+         do k=1,nVertLevels
+            velocityForcingTend(k,iEdge) = tendVel(k,iEdge) - velocityForcingTend(k,iEdge)
+         end do
+      end do
 
       ! vertical mixing treated implicitly in a later routine
       ! adjust total velocity tendency based on wetting/drying

--- a/components/mpas-ocean/src/shared/mpas_ocn_tke_advection_mono.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tke_advection_mono.F
@@ -1,0 +1,894 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_tke_advection_mono
+!
+!> \brief MPAS monotonic tke advection with FCT
+!> \author Luke Van Roekel
+!> \date   updated June 2021
+!> \details
+!>  This module contains routines for monotonic advection of tke
+!>  using a Flux Corrected Transport (FCT) algorithm, which is based on 
+!>  the tracer advection mono routines.
+!
+!-------------------------------------------------------------------------------
+
+module ocn_tke_advection_mono
+
+   ! module includes
+#ifdef _ADV_TIMERS
+   use mpas_timer
+#endif
+   use mpas_kind_types
+   use mpas_derived_types
+   use mpas_dmpar
+   use mpas_pool_routines
+   use mpas_io_units
+   use mpas_threading
+   use mpas_tracer_advection_helpers
+
+   use ocn_constants
+   use ocn_mesh
+
+   implicit none
+   private
+   save
+
+   ! module private variables
+   real (kind=RKIND) ::  &
+      coef3rdOrder        !< high-order horizontal coefficient
+   logical ::            &
+      monotonicityCheck   !< flag to check monotonicity
+   integer ::            &
+      vertOrder           !< choice of order for vertical advection
+   integer, parameter :: &! enum for supported vertical algorithm order
+      vertOrder2 = 2,    &!< 2nd order scheme
+      vertOrder3 = 3,    &!< 3rd order scheme
+      vertOrder4 = 4      !< 4th order scheme
+
+   ! These temporary allocatable arrays will eventually be moved back into
+   ! the tendency routine, but must be declared here for now so that they
+   ! retain the shared attribute. Once the threading model has been changed,
+   ! these should become thread private again with reduced size
+
+   real (kind=RKIND), dimension(:,:), allocatable :: &
+      tkeMax,     &! max tke in neighbors for limiting
+      tkeMin,     &! min tke in neighbors for limiting
+      hNewInv,       &! inverse of new layer thickness
+      hProv,         &! provisional layer thickness
+      hProvInv,      &! inverse of provisional layer thickness
+      flxIn,         &! flux coming into each cell
+      flxOut,        &! flux going out of each cell
+      workTend,      &! temp for holding some tendency values
+      lowOrderFlx,   &! low order flux for FCT
+      highOrderFlx    ! high order flux for FCT
+
+   ! public method interfaces
+   public :: ocn_tke_advection_mono_tend, &
+             ocn_tke_advection_mono_init
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+
+   contains
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine ocn_tke_advection_mono_tend
+!
+!> \brief MPAS monotonic tke horizontal advection tendency with FCT
+!> \author Luke Van Roekel 
+!> \date   updated June 2021
+!> \details
+!>  This routine computes the monotonic tke horizontal advection tendency
+!>  using a flux-corrected transport (FCT) algorithm.  This is based on the 
+!>  tracer advection mono routines.
+!
+!-------------------------------------------------------------------------------
+
+   subroutine ocn_tke_advection_mono_tend(tend, tke, layerThickness,    &
+                                             normalThicknessFlux, w, dt,       &
+                                             advCoefs, advCoefs3rd,            &
+                                             nAdvCellsForEdge, advCellsForEdge,&
+                                             highOrderAdvectionMask)
+
+      !*** Input/Output parameters
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend            !< [in,out] Tracer tendency to which advection added
+
+      !*** Input parameters
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         tke                 !< [in] Current tke values
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness      !< [in] Thickness
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalThicknessFlux !< [in] Thichness weighted velocitiy
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         w                   !< [in] Vertical velocity
+      real (kind=RKIND), intent(in) :: &
+         dt                  !< [in] Timestep
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         advCoefs            !< [in] Coefficients for 2nd order advection
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         advCoefs3rd         !< [in] Coeffs for missing 3rd/4th order advection
+      integer, dimension(:), intent(in) :: &
+         nAdvCellsForEdge    !< [in] Number of advection cells for each edge
+      integer, dimension(:,:), intent(in) :: &
+         advCellsForEdge     !< [in] List of advection cells for each edge
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         highOrderAdvectionMask !< [in] Mask for high order advection
+
+      !*** Local variables
+
+      integer ::          &
+         i, iCell, iEdge, &! horz indices
+         cell1, cell2,    &! neighbor cell indices
+         nCells, nEdges,  &! numbers of cells or edges
+         k,k2,kmax
+
+      real (kind=RKIND) ::  &
+         signedFactor,      &! temp factor including flux sign
+         tkeNew,         &! updated tke 
+         tkeMinNew,      &! updated tke minimum
+         tkeMaxNew,      &! updated tke maximum
+         tkeUpwindNew,   &! tke updated with upwind flx
+         scaleFactor,       &! factor for normalizing fluxes
+         flux,              &! flux temporary
+         tkeWeight,      &! tke weighting temporary
+         invAreaCell1,      &! inverse cell area
+         invAreaCell2,      &! inverse cell area
+         verticalWeightK,   &! vertical weighting
+         verticalWeightKm1, &! vertical weighting
+         coef1, coef3        ! temporary coefficients
+
+      real (kind=RKIND), dimension(nVertLevels) :: &
+         wgtTmp,            &! vertical temporaries for
+         flxTmp, sgnTmp      !   high-order flux computation
+
+      real (kind=RKIND), parameter :: &
+         eps = 1.e-10_RKIND  ! small number to avoid numerical difficulties
+
+      ! end of preamble
+      !----------------
+      ! begin code
+
+#ifdef _ADV_TIMERS
+      call mpas_timer_start('startup')
+#endif
+      ! Get dimensions
+      nCells = nCellsAll
+      nEdges = nEdgesAll
+
+      ! allocate temporary arrays
+      allocate(tkeMin   (nVertLevels  ,nCells), &
+               tkeMax   (nVertLevels  ,nCells), &
+               hNewInv     (nVertLevels  ,nCells), &
+               hProv       (nVertLevels  ,nCells), &
+               hProvInv    (nVertLevels  ,nCells), &
+               flxIn       (nVertLevels  ,nCells+1), &
+               flxOut      (nVertLevels  ,nCells+1), &
+               workTend    (nVertLevels  ,nCells+1), &
+               lowOrderFlx (nVertLevels+1,max(nCells,nEdges)+1), &
+               highOrderFlx(nVertLevels+1,max(nCells,nEdges)+1))
+
+      ! Compute some provisional layer thicknesses
+      ! Note: This assumes we are in the first part of the horizontal/
+      ! vertical operator splitting, which is true because currently
+      ! we dont flip order and horizontal is always first.
+      ! See notes in commit 2cd4a89d.
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(invAreaCell1, kmax, k, i, iEdge, signedFactor)
+      do iCell = 1, nCells
+        invAreaCell1 = dt/areaCell(iCell)
+        kmax = maxLevelCell(iCell)
+        do k = 1, kmax
+          hProv(k, iCell) = layerThickness(k, iCell)
+        end do
+        do i = 1, nEdgesOnCell(iCell)
+          iEdge = edgesOnCell(i,iCell)
+          signedFactor = invAreaCell1*dvEdge(iEdge)*edgeSignOnCell(i,iCell)
+          ! Provisional layer thickness is after horizontal thickness flux only
+          do k = 1, kmax
+            hProv(k, iCell) = hProv(k, iCell) &
+                            + signedFactor*normalThicknessFlux(k,iEdge)
+          end do
+        end do
+        ! New layer thickness is after horizontal and vertical thickness flux
+        do k = 1, kmax
+          hProvInv(k,iCell) = 1.0_RKIND/ hProv(k,iCell)
+          hNewInv (k,iCell) = 1.0_RKIND/(hProv(k,iCell) - &
+                                         dt*w(k,iCell) + dt*w(k+1, iCell))
+        end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+#ifdef _ADV_TIMERS
+      call mpas_timer_stop('startup')
+#endif
+
+#ifdef _ADV_TIMERS
+      call mpas_timer_start('cell init')
+#endif
+      ! reset nCells to include all cells
+      nCells = nCellsHalo( size(nCellsHalo) )
+
+      ! Compute the high and low order horizontal fluxes.
+#ifdef _ADV_TIMERS
+      call mpas_timer_stop('cell init')
+      call mpas_timer_start('horiz flux')
+#endif
+
+      ! set nCells to first halo level
+      nCells = nCellsHalo( 1 )
+
+      ! Determine bounds on tke (tkeMin and tkeMax) from
+      ! surrounding cells for later limiting.
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(k, i, cell2, kmax)
+      do iCell = 1, nCells
+         do k=1, maxLevelCell(iCell)
+            tkeMin(k,iCell) = tke(k,iCell)
+            tkeMax(k,iCell) = tke(k,iCell)
+         end do
+         do i = 1, nEdgesOnCell(iCell)
+            cell2 = cellsOnCell(i,iCell)
+            kmax  = min(maxLevelCell(iCell), &
+                        maxLevelCell(cell2))
+            do k=1, kmax
+              tkeMax(k,iCell) = max(tkeMax(k,iCell), &
+                                       tke(k,cell2))
+              tkeMin(k,iCell) = min(tkeMin(k,iCell), &
+                                       tke(k,cell2))
+            end do ! k loop
+         end do ! i loop over nEdgesOnCell
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      ! Need all the edges around the 1 halo cells and owned cells
+      nEdges = nEdgesHalo( 2 )
+
+      ! Compute the high order horizontal flux
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(cell1, cell2, k, wgtTmp, sgnTmp, flxTmp, i, iCell, coef1, coef3, &
+      !$omp         tkeWeight)
+      do iEdge = 1, nEdges
+         cell1 = cellsOnEdge(1, iEdge)
+         cell2 = cellsOnEdge(2, iEdge)
+
+         ! compute some common intermediate factors
+         do k = 1, nVertLevels
+            wgtTmp(k) = normalThicknessFlux   (k,iEdge)* &
+                        highOrderAdvectionMask(k,iEdge)
+            sgnTmp(k) = sign(1.0_RKIND, &
+                             normalThicknessFlux(k,iEdge))
+            flxTmp(k) = 0.0_RKIND
+         end do
+
+         ! Compute 3rd or 4th fluxes where requested.
+         do i = 1, nAdvCellsForEdge(iEdge)
+            iCell = advCellsForEdge(i,iEdge)
+            coef1 = advCoefs       (i,iEdge)
+            coef3 = advCoefs3rd    (i,iEdge)*coef3rdOrder
+            do k = 1, maxLevelCell(iCell)
+              flxTmp(k) = flxTmp(k) + tke(k,iCell)* &
+                          wgtTmp(k)*(coef1 + coef3*sgnTmp(k))
+            end do ! k loop
+          end do ! i loop over nAdvCellsForEdge
+
+          do k=1,nVertLevels
+             highOrderFlx(k,iEdge) = flxTmp(k)
+          end do
+
+          ! Compute 2nd order fluxes where needed.
+          ! Also compute low order upwind horizontal flux (monotonic and diffused)
+          ! Remove low order flux from the high order flux
+          ! Store left over high order flux in highOrderFlx array
+          do k = 1, maxLevelEdgeTop(iEdge)
+            tkeWeight = (1.0_RKIND - highOrderAdvectionMask(k, iEdge)) &
+                         * (dvEdge(iEdge) * 0.5_RKIND)                 &
+                         * normalThicknessFlux(k, iEdge)
+
+            lowOrderFlx(k,iEdge) = dvEdge(iEdge) * &
+               (max(0.0_RKIND,normalThicknessFlux(k,iEdge))*tke(k,cell1) &
+              + min(0.0_RKIND,normalThicknessFlux(k,iEdge))*tke(k,cell2))
+
+            highOrderFlx(k, iEdge) = highOrderFlx(k, iedge) &
+                                   + tkeWeight * (tke(k, cell1) &
+                                                   + tke(k, cell2))
+
+            highOrderFlx(k,iEdge) = highOrderFlx(k,iEdge) &
+                                  -  lowOrderFlx(k,iEdge)
+          end do ! k loop
+        end do ! iEdge loop
+        !$omp end do
+        !$omp end parallel
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('horiz flux')
+        call mpas_timer_start('scale factor build')
+#endif
+        ! Initialize flux arrays for all cells
+        nCells = nCellsHalo(size(nCellsHalo))
+
+        !$omp parallel
+        !$omp do schedule(runtime)
+        do iCell = 1, nCells+1
+        do k=1, nVertLevels
+           workTend(k, iCell) = 0.0_RKIND
+           flxIn   (k, iCell) = 0.0_RKIND
+           flxOut  (k, iCell) = 0.0_RKIND
+        end do ! k loop
+        end do ! iCell loop
+        !$omp end do
+        !$omp end parallel
+
+        ! Need one halo of cells around owned cells
+        nCells = nCellsHalo( 1 )
+
+        !$omp parallel
+        !$omp do schedule(runtime) &
+        !$omp private(invAreaCell1, i, iEdge, cell1, cell2, signedFactor, k, &
+        !$omp         tkeUpwindNew, tkeMinNew, tkeMaxNew, scaleFactor)
+        do iCell = 1, nCells
+          invAreaCell1 = 1.0_RKIND / areaCell(iCell)
+
+          ! Finish computing the low order horizontal fluxes
+          ! Upwind fluxes are accumulated in workTend
+          do i = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i, iCell)
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            signedFactor = edgeSignOnCell(i, iCell) * invAreaCell1
+
+            do k = 1, maxLevelEdgeTop(iEdge)
+              ! Here workTend is the advection tendency due to the
+              ! upwind (low order) fluxes.
+              workTend(k,iCell) = workTend(k,iCell) &
+                                + signedFactor*lowOrderFlx(k,iEdge)
+
+              ! Accumulate remaining high order fluxes
+              flxOut(k,iCell) = flxOut(k,iCell) + min(0.0_RKIND,  &
+                                signedFactor*highOrderFlx(k,iEdge))
+              flxIn (k,iCell) = flxIn (k,iCell) + max(0.0_RKIND,  &
+                                signedFactor*highOrderFlx(k,iEdge))
+
+            end do
+          end do
+
+          ! Build the factors for the FCT
+          ! Computed using the bounds that were computed previously,
+          ! and the bounds on the newly updated value
+          ! Factors are placed in the flxIn and flxOut arrays
+          do k = 1, maxLevelCell(iCell)
+            ! Here workTend is the upwind tendency
+            tkeUpwindNew = (tke(k,iCell)*layerThickness(k,iCell) &
+                             + dt*workTend(k,iCell)) * hProvInv(k,iCell)
+            tkeMinNew = tkeUpwindNew &
+                         + dt*flxOut(k,iCell)*hProvInv(k,iCell)
+            tkeMaxNew = tkeUpwindNew &
+                         + dt*flxIn (k,iCell)*hProvInv(k,iCell)
+
+            scaleFactor = (tkeMax(k,iCell) - tkeUpwindNew)/ &
+                          (tkeMaxNew - tkeUpwindNew + eps)
+            flxIn (k,iCell) = min(1.0_RKIND, max(0.0_RKIND, scaleFactor))
+
+            scaleFactor = (tkeUpwindNew - tkeMin(k,iCell))/ &
+                          (tkeUpwindNew - tkeMinNew + eps)
+            flxOut(k,iCell) = min(1.0_RKIND, max(0.0_RKIND, scaleFactor))
+          end do ! k loop
+        end do ! iCell loop
+        !$omp end do
+        !$omp end parallel
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('scale factor build')
+        call mpas_timer_start('rescale horiz fluxes')
+#endif
+        ! Need all of the edges around owned cells
+        nEdges = nEdgesHalo( 1 )
+        !  rescale the high order horizontal fluxes
+        !$omp parallel
+        !$omp do schedule(runtime) private(cell1, cell2, k)
+        do iEdge = 1, nEdges
+          cell1 = cellsOnEdge(1,iEdge)
+          cell2 = cellsOnEdge(2,iEdge)
+          do k = 1, maxLevelEdgeTop(iEdge)
+            highOrderFlx(k,iEdge) = max(0.0_RKIND,highOrderFlx(k,iEdge))* &
+                                    min(flxOut(k,cell1), flxIn (k,cell2)) &
+                                  + min(0.0_RKIND,highOrderFlx(k,iEdge))* &
+                                    min(flxIn (k,cell1), flxOut(k,cell2))
+          end do ! k loop
+        end do ! iEdge loop
+        !$omp end do
+        !$omp end parallel
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('rescale horiz fluxes')
+        call mpas_timer_start('flux accumulate')
+#endif
+
+        nCells = nCellsOwned
+        ! Accumulate the scaled high order vertical tendencies, and the upwind tendencies
+        !$omp parallel
+        !$omp do schedule(runtime) private(invAreaCell1, signedFactor, i, iEdge, k)
+        do iCell = 1, nCells
+          invAreaCell1 = 1.0_RKIND / areaCell(iCell)
+
+          ! Accumulate the scaled high order horizontal tendencies
+          do i = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i, iCell)
+            signedFactor = invAreaCell1 * edgeSignOnCell(i, iCell)
+            do k = 1, maxLevelEdgeTop(iEdge)
+              ! workTend on the RHS is the upwind tendency
+              ! workTend on the LHS is the total horizontal advection tendency
+              workTend(k,iCell) = workTend(k,iCell) &
+                                + signedFactor * highOrderFlx(k, iEdge)
+            end do
+          end do
+
+          do k = 1, maxLevelCell(iCell)
+            ! workTend on the RHS is the total horizontal advection tendency
+            ! tke on LHS is the  provisional tke after horizontal fluxes only.
+            tend(k,iCell) = tend(k,iCell) + workTend(k,iCell)
+          end do
+
+        end do ! iCell loop
+        !$omp end do
+        !$omp end parallel
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('flux accumulate')
+#endif
+        if (monotonicityCheck) then
+           nCells = nCellsOwned
+           ! Check tke values against local min,max to detect
+           ! non-monotone values and write warning if found
+           !$omp parallel
+           !$omp do schedule(runtime) private(k)
+           do iCell = 1, nCells
+           do k = 1, maxLevelCell(iCell)
+              if(tke(k,iCell) < tkeMin(k, iCell)-eps) then
+                 call mpas_log_write( &
+                    'Horizontal minimum out of bounds on tke: $r $r ', &
+                    MPAS_LOG_WARN,                      &
+                    realArgs=(/ tkeMin(k, iCell), tke(k,iCell) /) )
+              end if
+
+              if(tke(k,iCell) > tkeMax(k,iCell)+eps) then
+                 call mpas_log_write( &
+                    'Horizontal maximum out of bounds on tke: $r $r ', &
+                    MPAS_LOG_WARN,                      &
+                    realArgs=(/ tkeMax(k, iCell), tke(k,iCell) /) )
+              end if
+           end do
+           end do
+           !$omp end do
+           !$omp end parallel
+        end if ! monotonicity check
+
+        !-----------------------------------------------------------------------
+        !
+        !  Horizontal advection complete
+        !  Begin vertical advection
+        !
+        !-----------------------------------------------------------------------
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_start('cell init')
+#endif
+        nCells = nCellsHalo( size(nCellsHalo) )
+        ! Initialize variables for use in this portion of the computation. 
+        !$omp parallel
+        !$omp do schedule(runtime) private(k)
+        do iCell = 1, nCells
+          do k=1, nVertLevels
+            highOrderFlx(k, iCell) = 0.0_RKIND
+            workTend(k, iCell) = 0.0_RKIND
+          end do ! k loop
+          highOrderFlx(nVertLevels+1, iCell) = 0.0_RKIND
+
+        end do ! iCell loop
+        !$omp end do
+        !$omp end parallel
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('cell init')
+#endif
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_start('vertical flux')
+#endif
+
+        ! Need all owned and 1 halo cells
+        nCells = nCellsHalo( 1 )
+
+        ! Determine bounds on tke from neighbor values for limiting
+        !$omp parallel
+        !$omp do schedule(runtime) private(kmax, k)
+        do iCell = 1, nCells
+          kmax = maxLevelCell(iCell)
+
+          ! take care of top cell
+          tkeMax(1,iCell) = max(tke(1,iCell), tke(2,iCell))
+          tkeMin(1,iCell) = min(tke(1,iCell), tke(2,iCell))
+          do k=2,kmax-1
+            tkeMax(k,iCell) = max(tke(k-1,iCell), &
+                                     tke(k  ,iCell), &
+                                     tke(k+1,iCell))
+            tkeMin(k,iCell) = min(tke(k-1,iCell), &
+                                     tke(k  ,iCell), &
+                                     tke(k+1,iCell))
+          end do
+          ! finish with bottom cell
+          tkeMax(kmax,iCell) = max(tke(kmax  ,iCell), &
+                                      tke(kmax-1,iCell))
+          tkeMin(kmax,iCell) = min(tke(kmax  ,iCell), &
+                                      tke(kmax-1,iCell))
+        end do ! cell loop
+        !$omp end do
+        !$omp end parallel
+
+        ! Compute the high order vertical fluxes based on order selected.
+        ! Special cases for top and bottom layers handled in following loop.
+
+        select case (vertOrder)
+        case (vertOrder4)
+
+          !$omp parallel
+          !$omp do schedule(runtime) private(kmax, k)
+          do iCell = 1, nCells
+            kmax = maxLevelCell(iCell)
+            do k=3,kmax-1
+              highOrderFlx(k, iCell) = w(k,iCell)*( &
+                  7.0_RKIND*(tke(k  ,iCell) + tke(k-1,iCell)) - &
+                            (tke(k+1,iCell) + tke(k-2,iCell)))/ &
+                  12.0_RKIND
+
+            end do
+          end do ! cell loop
+          !$omp end do
+          !$omp end parallel
+
+        case (vertOrder3)
+
+          !$omp parallel
+          !$omp do schedule(runtime) private(kmax, k)
+          do iCell = 1, nCells
+            kmax = maxLevelCell(iCell)
+            do k=3,kmax-1
+              highOrderFlx(k, iCell) = (w(k,iCell)* &
+                   (7.0_RKIND*(tke(k  ,iCell) + tke(k-1,iCell)) - &
+                              (tke(k+1,iCell) + tke(k-2,iCell))) - &
+                        coef3rdOrder*abs(w(k,iCell))* &
+                             ((tke(k+1,iCell) - tke(k-2,iCell)) - &
+                    3.0_RKIND*(tke(k  ,iCell) - tke(k-1,iCell))))/ &
+                   12.0_RKIND
+
+
+            end do
+          end do ! cell loop
+          !$omp end do
+          !$omp end parallel
+
+       case (vertOrder2)
+
+          !$omp parallel
+          !$omp do schedule(runtime) private(kmax, k, verticalWeightK, verticalWeightKm1)
+          do iCell = 1, nCells
+            kmax = maxLevelCell(iCell)
+            do k=3,kmax-1
+              verticalWeightK   = hProv(k-1,iCell) / &
+                                 (hProv(k  ,iCell) + hProv(k-1,iCell))
+              verticalWeightKm1 = hProv(k  ,iCell) / &
+                                 (hProv(k  ,iCell) + hProv(k-1,iCell))
+              highOrderFlx(k,iCell) = w(k,iCell)* &
+                                 (verticalWeightK  *tke(k  ,iCell) + &
+                                  verticalWeightKm1*tke(k-1,iCell))
+            end do
+          end do ! cell loop
+          !$omp end do
+          !$omp end parallel
+
+        end select ! vertical order
+
+        ! Treat special cases for high order flux
+        ! Compute low order upwind vertical flux (monotonic and diffused)
+        ! Remove low order flux from the high order flux.
+        ! Store left over high order flux in highOrderFlx array.
+        !$omp parallel
+        !$omp do schedule(runtime) private(kmax, verticalWeightK, verticalWeightKm1, k)
+        do iCell = 1, nCells
+          kmax = maxLevelCell(iCell)
+          ! Next-to-top cell in column is second-order
+          highOrderFlx(1,iCell) = 0.0_RKIND
+          if (kmax > 1) then
+            verticalWeightK   = hProv(1,iCell) / &
+                               (hProv(2,iCell) + hProv(1, iCell))
+            verticalWeightKm1 = hProv(2,iCell) / &
+                               (hProv(2,iCell) + hProv(1, iCell))
+            highOrderFlx(2,iCell) = w(2,iCell)* &
+                               (verticalWeightK  *tke(2,iCell) + &
+                                verticalWeightKm1*tke(1,iCell))
+          end if
+          ! Deepest vertical cell in column is second order
+          k = max(2,kmax)
+          verticalWeightK   = hProv(k-1,iCell) / &
+                             (hProv(k  ,iCell) + hProv(k-1,iCell))
+          verticalWeightKm1 = hProv(k  ,iCell) / &
+                             (hProv(k  ,iCell) + hProv(k-1,iCell))
+          highOrderFlx(k,iCell) = w(k,iCell)* &
+                             (verticalWeightK  *tke(k  ,iCell) + &
+                              verticalWeightKm1*tke(k-1,iCell))
+          highOrderFlx(k+1,iCell) = 0.0_RKIND
+
+          ! Compute low order (upwind) flux and remove from high order
+          lowOrderFlx(1,iCell) = 0.0_RKIND
+          do k = 2, kmax
+            lowOrderFlx(k,iCell) = &
+                min(0.0_RKIND,w(k,iCell))*tke(k-1,iCell) + &
+                max(0.0_RKIND,w(k,iCell))*tke(k  ,iCell)
+            highOrderFlx(k,iCell) = highOrderFlx(k,iCell) - &
+                                     lowOrderFlx(k,iCell)
+          end do ! k loop
+          lowOrderFlx(kmax+1,iCell) = 0.0_RKIND
+
+          ! Upwind fluxes are accumulated in workTend
+          ! flxIn contains the total remaining high order flux into iCell
+          !          it is positive.
+          ! flxOut contains the total remaining high order flux out of iCell
+          !           it is negative
+          do k = 1, kmax
+            workTend(k,iCell) = lowOrderFlx(k+1,iCell) &
+                              - lowOrderFlx(k  ,iCell)
+            flxIn (k, iCell) = max(0.0_RKIND, highOrderFlx(k+1, iCell)) &
+                             - min(0.0_RKIND, highOrderFlx(k  , iCell))
+            flxOut(k, iCell) = min(0.0_RKIND, highOrderFlx(k+1, iCell)) &
+                             - max(0.0_RKIND, highOrderFlx(k  , iCell))
+          end do ! k Loop
+        end do ! iCell Loop
+        !$omp end do
+        !$omp end parallel
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('vertical flux')
+        call mpas_timer_start('scale factor build')
+#endif
+        ! Need one halo of cells around owned cells
+        nCells = nCellsHalo( 1 )
+        !$omp parallel
+        !$omp do schedule(runtime) &
+        !$omp private(k, tkeMinNew, tkeMaxNew, tkeUpwindNew, scaleFactor)
+        do iCell = 1, nCells
+
+          ! Build the scale factors to limit flux for FCT
+          ! Computed using the bounds that were computed previously,
+          ! and the bounds on the newly updated value
+          ! Factors are placed in the flxIn and flxOut arrays
+
+          do k = 1, maxLevelCell(iCell)
+            ! workTend on the RHS is the upwind tendency
+            tkeMinNew = (tke(k,iCell)*hProv(k,iCell) &
+                         + dt*(workTend(k,iCell)+flxOut(k,iCell))) &
+                         * hNewInv(k,iCell)
+            tkeMaxNew = (tke(k,iCell)*hProv(k,iCell) &
+                         + dt*(workTend(k,iCell)+flxIn(k,iCell))) &
+                         * hNewInv(k,iCell)
+            tkeUpwindNew = (tke(k,iCell)*hProv(k,iCell) &
+                            + dt*workTend(k,iCell)) * hNewInv(k,iCell)
+
+            scaleFactor = (tkeMax(k,iCell)-tkeUpwindNew)/ &
+                          (tkeMaxNew-tkeUpwindNew+eps)
+            flxIn (k,iCell) = min(1.0_RKIND, max(0.0_RKIND, scaleFactor))
+
+            scaleFactor = (tkeUpwindNew-tkeMin(k,iCell))/ &
+                          (tkeUpwindNew-tkeMinNew+eps)
+            flxOut(k,iCell) = min(1.0_RKIND, max(0.0_RKIND, scaleFactor))
+          end do ! k loop
+        end do ! iCell loop
+        !$omp end do
+        !$omp end parallel
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('scale factor build')
+        call mpas_timer_start('flux accumulate')
+#endif
+
+        nCells = nCellsOwned
+        ! Accumulate the scaled high order vertical tendencies
+        ! and the upwind tendencies
+        !$omp parallel
+        !$omp do schedule(runtime) private(kmax, k, flux)
+        do iCell = 1, nCells
+          kmax = maxLevelCell(iCell)
+          ! rescale the high order vertical flux
+          do k = 2, kmax
+            flux =  highOrderFlx(k,iCell)
+            highOrderFlx(k,iCell) = max(0.0_RKIND,flux)*   &
+                                    min(flxOut(k  ,iCell), &
+                                        flxIn (k-1,iCell)) &
+                                  + min(0.0_RKIND,flux)*   &
+                                    min(flxOut(k-1,iCell), &
+                                        flxIn (k  ,iCell))
+          end do ! k loop
+
+          do k = 1,kmax
+            ! workTend on the RHS is the upwind tendency
+            ! workTend on the LHS is the total vertical advection tendency
+            workTend(k, iCell) = workTend(k, iCell)       &
+                               + (highOrderFlx(k+1,iCell) &
+                                - highOrderFlx(k  ,iCell))
+            tend(k,iCell) = tend(k,iCell) + workTend(k,iCell)
+          end do ! k loop
+
+        end do ! iCell loop
+        !$omp end do
+        !$omp end parallel
+
+        !$omp parallel
+        !$omp do schedule(runtime) private(k)
+        do iCell=1,nCells
+           do k=1,maxLevelCell(iCell)
+              tend(k,iCell) = tend(k,iCell) / (areaCell(iCell)*hProv(k,iCell))
+           end do
+        end do
+        !$omp end do
+        !$omp end parallel
+
+        ! Compute advection diagnostics and monotonicity checks if requested
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('flux accumulate')
+        call mpas_timer_start('advect diags')
+#endif
+        if (monotonicityCheck) then
+          nCells = nCellsOwned
+          ! Check for monotonicity of new tke value
+          !$omp parallel
+          !$omp do schedule(runtime) private(k, tkeNew)
+          do iCell = 1, nCells
+          do k = 1, maxLevelCell(iCell)
+             ! workTend on the RHS is the total vertical advection tendency
+             tkeNew = (tke(k, iCell)*hProv(k, iCell) &
+                          + dt*workTend(k, iCell))*hNewInv(k, iCell)
+
+             if (tkeNew < tke(k, iCell)-eps) then
+                call mpas_log_write( &
+                   'Vertical minimum out of bounds on tke: $i $i $r $r ',&
+                   MPAS_LOG_WARN, intArgs=(/k, iCell/), &
+                   realArgs=(/ tkeMin(k, iCell), tkeNew /) )
+             end if
+
+             if (tkeNew > tkeMax(k,iCell)+eps) then
+                call mpas_log_write( &
+                   'Vertical maximum out of bounds on tke: $i $i $r $r ',&
+                    MPAS_LOG_WARN, intArgs=(/k, iCell/), &
+                    realArgs=(/ tkeMax(k, iCell), tkeNew /) )
+             end if
+          end do
+          end do
+          !$omp end do
+          !$omp end parallel
+        end if ! monotonicity check
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('advect diags')
+#endif
+
+#ifdef _ADV_TIMERS
+      call mpas_timer_start('deallocates')
+#endif
+      deallocate(tkeMin,    &
+                 tkeMax,    &
+                 hNewInv,      &
+                 hProv,        &
+                 hProvInv,     &
+                 flxIn,        &
+                 flxOut,       &
+                 workTend,     &
+                 lowOrderFlx,  &
+                 highOrderFlx)
+
+#ifdef _ADV_TIMERS
+      call mpas_timer_stop('deallocates')
+#endif
+
+   end subroutine ocn_tke_advection_mono_tend!}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine ocn_tke_advection_mono_init
+!
+!> \brief MPAS initialize monotonic tke advection tendency with FCT
+!> \author Luke Van Roekel
+!> \date   updated June 2021
+!> \details
+!>  This routine initializes monotonic tke advection quantities for
+!>  the flux-corrected transport (FCT) algorithm.  Based on the tracer advection
+!>  mono routine
+!
+!-------------------------------------------------------------------------------
+
+   subroutine ocn_tke_advection_mono_init(nHalos, horizAdvOrder,        &
+                                             vertAdvOrder, inCoef3rdOrder, &
+                                             checkMonotonicity, err)!{{{
+
+      !*** input parameters
+
+      integer, intent(in) :: &
+         nHalos               !< [in] number of halos in current simulation
+      integer, intent(in) :: &
+         horizAdvOrder        !< [in] order for horizontal advection
+      integer, intent(in) :: &
+         vertAdvOrder         !< [in] order for vertical advection
+      real (kind=RKIND), intent(in) :: &
+         inCoef3rdOrder       !< [in] coefficient for blending advection orders
+      logical, intent(in) :: &
+         checkMonotonicity    !< [in] flag to check monotonicity of tracers
+
+      !*** output parameters
+
+      integer, intent(out) :: &
+         err                   !< [out] error flag
+
+      ! end of preamble
+      !----------------
+      ! begin code
+
+      err = 0 ! initialize error code to success
+
+      ! Check that the halo is wide enough for FCT
+      if (nHalos < 3) then
+         call mpas_log_write( &
+            'Monotonic advection cannot be used with less than 3 halos.', &
+            MPAS_LOG_CRIT)
+         err = -1
+      end if
+
+      ! Set blending coefficient if 3rd order horizontal advection chosen
+      select case (horizAdvOrder)
+      case (2)
+         coef3rdOrder = 0.0_RKIND
+      case (3)
+         coef3rdOrder = inCoef3rdOrder
+      case (4)
+         coef3rdOrder = 0.0_RKIND
+      case default
+         coef3rdOrder = 0.0_RKIND
+         call mpas_log_write( &
+            'Invalid value for horizontal advection order, defaulting to 2',&
+            MPAS_LOG_WARN)
+      end select ! horizontal advection order
+
+      ! Set vertical advection order
+      select case (vertAdvOrder)
+      case (2)
+         vertOrder = vertOrder2
+      case (3)
+         vertOrder = vertOrder3
+      case (4)
+         vertOrder = vertOrder4
+      case default
+         vertOrder = vertOrder2
+         call mpas_log_write( &
+            'Invalid value for vertical advection order, defaulting to 2', &
+            MPAS_LOG_WARN)
+      end select ! vertical advection order
+
+      ! Set flag for checking monotonicity
+      monotonicityCheck = checkMonotonicity
+
+   end subroutine ocn_tke_advection_mono_init!}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+
+end module ocn_tke_advection_mono
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-ocean/src/shared/mpas_ocn_tke_glsPsi_transport.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tke_glsPsi_transport.F
@@ -1,0 +1,533 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_tke_glsPsi_transport
+!
+!> \brief MPAS ocean tke transport calculation 
+!> \author Luke Van Roekel 
+!> \date   July 2021
+!> \details
+!>  This module contains the main driver routine for computing
+!>  the diffusive transport of TKE for the two equation model 
+!>
+!
+!-----------------------------------------------------------------------
+
+module ocn_tke_glsPsi_transport
+
+   use mpas_timer
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_threading
+
+   use ocn_diagnostics_variables
+   use ocn_mesh
+   use ocn_constants
+   use ocn_config
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: ocn_tke_transport_horizontal_compute, &
+             ocn_tke_transport_vertical_compute,   &
+             ocn_glsPsi_transport_horizontal_compute, &
+             ocn_glsPsi_transport_vertical_compute
+
+   !--------------------------------------------------------------------
+   !
+   ! Private member functions
+   !
+   !--------------------------------------------------------------------
+
+   private :: turb_tridiagonal_solve
+
+   real(kind=RKIND) :: eddyDiff2
+
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+!
+!  routine ocn_tke_transport_horizontal_compute
+!
+!> \brief   Computes horizontal Laplacian tendency term for tke 
+!> \author  Luke Van Roekel
+!> \date    July 2021
+!> \details
+!>  This routine computes the horizontal mixing tendency for tke 
+!>  this is a parameterized form of the turbulent transport term
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_tke_transport_horizontal_compute(tke, tkeTend, sigma_k, err)
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        tke !< Input: tke at current timestep
+      real (kind=RKIND), intent(in) :: sigma_k
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tkeTend          !< Input/Output: tke tendency
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, iEdge, cell1, cell2
+      integer :: j, i, k, iCellValid
+
+      real (kind=RKIND) :: invAreaCell
+      real (kind=RKIND) :: tke_turb_flux, flux, r_tmp
+
+      err = 0
+
+      call mpas_timer_start("tke horizontal turbulent transport")
+
+      !
+      ! compute a boundary mask to enforce insulating boundary conditions in the horizontal
+      !
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(invAreaCell, i, iEdge, cell1, cell2, r_tmp, k, &
+      !$omp         tke_turb_flux, flux)
+      do iCell = 1, nCellsOwned
+        invAreaCell = 1.0_RKIND / areaCell(iCell)
+        do i = 1, nEdgesOnCell(iCell)
+          iEdge = edgesOnCell(i, iCell)
+          cell1 = cellsOnEdge(1,iEdge)
+          cell2 = cellsOnEdge(2,iEdge)
+
+          r_tmp = dvEdge(iEdge) / dcEdge(iEdge)
+
+          do k = 1, maxLevelEdgeTop(iEdge)
+             ! \kappa_2 \nabla \phi on edge
+             tke_turb_flux = tke(k, cell2) - tke(k, cell1)
+
+             eddyDiff2 = 0.25_RKIND*(vertDiffTopOfCell(k,cell1) + vertDiffTopOfCell(k,cell2) + &
+                                     vertDiffTopOfCell(k+1,cell1) + vertDiffTopOfCell(k+1,cell2))/sigma_k
+             eddyDiff2 = eddyDiff2 + 0.25_RKIND*(dynamicViscosity(k,cell1) + dynamicViscosity(k,cell2) + &
+                                                 dynamicViscosity(k+1,cell1) + dynamicViscosity(k+1,cell2))/rho_sw
+
+             ! div(h \kappa_2 \nabla \phi) at cell center
+             flux = eddyDiff2 * layerThickEdge(k, iEdge) * tke_turb_flux * r_tmp
+
+             tkeTend(k, iCell) = tkeTend(k, iCell) - edgeSignOnCell(i, iCell) * flux * invAreaCell
+          end do
+
+        end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      !Implements the horizontal boundary condition
+      if(config_two_equation_model_choice == 'epsilon') then
+         call mpas_log_write('BCs not yet implemented for k-eps scheme, choose a different model',MPAS_LOG_CRIT)
+      else
+         !Go through find boundary cell = 1 and add -tke(icell)*eddyDiff2*....
+
+         do iCell=1,nCellsOwned
+            do k=1,maxLevelCell(iCell)
+               if(boundaryCellMask(k,iCell) == 1) then
+                  do j=1,nEdgesOnCell(iCell)
+                     iEdge = edgesOnCell(j,iCell)
+                     cell1 = cellsOnEdge(1,iEdge)
+                     cell2 = cellsOnEdge(2,iEdge)
+                     if(cell1 < 1) then
+                        iCellValid = cell2
+                     else
+                        iCellValid = cell1
+                     endif
+
+                     eddyDiff2 = 0.25_RKIND*(vertDiffTopOfCell(k,iCellValid) + vertDiffTopOfCell(k+1,iCellValid))
+                     eddyDiff2 = eddyDiff2+0.5_RKIND*(dynamicViscosity(k,iCellValid) + dynamicViscosity(k+1,iCellValid))/rho_sw
+                     tke_turb_flux = -tke(k,iCellValid) !Assumes k=0 in boundary condition
+                     ! div(h \kappa_2 \nabla \phi) at cell center
+                     flux = eddyDiff2 * layerThickEdge(k, iEdge) * tke_turb_flux * dvEdge(iEdge)/dcEdge(iEdge)
+
+                     tkeTend(k, iCellValid) = tkeTend(k, iCellValid) - edgeSignOnCell(i, iCellValid) * flux * invAreaCell
+                  end do !nEdges loop
+               end if !end cell mask if
+            end do
+         end do !nCells
+      end if !config_two_equation_model_choice
+
+      call mpas_timer_stop("tke horizontal turbulent transport")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tke_transport_horizontal_compute
+
+!***********************************************************************
+!
+!  routine ocn_tke_transport_vertical_compute
+!
+!> \brief   Compute vertical component of parameterized tke transport
+!> \author  Luke Van Roekel
+!> \date    July 2021
+!> \details
+!>  This routine initializes a variety of quantities related to
+!>  Laplacian horizontal velocity mixing in the ocean.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_tke_transport_vertical_compute(tke,layerThickness,sigma_k,dt)
+
+      real(kind=RKIND), dimension(:,:), intent(inout) :: tke
+      real(kind=RKIND), dimension(:,:), intent(in) :: layerThickness
+      real(kind=RKIND), intent(in) :: dt
+      integer :: iCell, k, N
+      real (kind=RKIND), dimension(nVertLevels) :: A,B,C,tkeTmp,rhs
+      real (kind=RKIND), intent(in) :: sigma_k
+
+      call mpas_timer_start("tke vertical turbulent transport")
+
+      !$omp parallel
+      !$omp schedule(runtime) private(N, A, B, C, rhs, tkeTmp, k)
+      do iCell=1,nCellsOwned
+         N = maxLevelCell(iCell)
+         A(1) = 0.0_RKIND
+         do k = 2, N
+            A(k) = -2.0_RKIND*dt*(dynamicViscosity(k,iCell)/rho_sw+vertViscTopOfCell(k,iCell)/sigma_k) &
+                  / (layerThickness(k-1,iCell) + layerThickness(k,iCell)) &
+                  / layerThickness(k,iCell)
+         end do
+
+         do k = 1, N-1
+            C(k) = -2.0_RKIND*dt*(dynamicViscosity(k+1,iCell)/rho_sw+vertViscTopOfCell(k+1,iCell)/sigma_k) &
+                  / (layerThickness(k,iCell) + layerThickness(k+1,iCell)) &
+                  / layerThickness(k,iCell)
+         end do
+         C(N) = 0.0_RKIND
+
+         do k = 1, N
+            B(k) = 1.0_RKIND - C(k) - A(k)
+         end do
+
+         rhs(:) = tke(:,iCell)
+         tkeTmp(:) = 0.0_RKIND
+         call turb_tridiagonal_solve(A(2:N), B, C(1:N-1), rhs(:), tkeTmp, &
+                                N)
+
+         tke(1:N,iCell) = tkeTmp(1:N)
+         tke(N+1:nVertLevels,iCell) = 0.0_RKIND
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      call mpas_timer_stop("tke vertical turbulent transport")
+
+   end subroutine ocn_tke_transport_vertical_compute
+
+!***********************************************************************
+!
+!  routine ocn_glsPsi_transport_horizontal_compute
+!
+!> \brief   Computes horizontal Laplacian tendency term for glsPsi 
+!> \author  Luke Van Roekel
+!> \date    July 2021
+!> \details
+!>  This routine computes the horizontal mixing tendency for glsPsi 
+!>  this is a parameterized form of the turbulent transport term
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_glsPsi_transport_horizontal_compute(glsPsi, glsPsiTend, &
+                    c_psi2, sigma_psi, err)
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        glsPsi !< Input: tke at current timestep
+      real (kind=RKIND), intent(in) :: sigma_psi
+      real (kind=RKIND) :: c_psi2
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         glsPsiTend          !< Input/Output: tke tendency
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, iEdge, cell1, cell2, iCellValid
+      integer :: j, i, k
+
+      real (kind=RKIND) :: bcValue, invAreaCell
+      real (kind=RKIND) :: glsPsi_turb_flux, flux, r_tmp
+
+      err = 0
+
+      call mpas_timer_start("glsPsi horizontal turbulent transport")
+
+      !
+      ! compute a boundary mask to enforce insulating boundary conditions in the horizontal
+      !
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(invAreaCell, i, iEdge, cell1, cell2, r_tmp, k, &
+      !$omp         glsPsi_turb_flux, flux)
+      do iCell = 1, nCellsOwned
+        invAreaCell = 1.0_RKIND / areaCell(iCell)
+        do i = 1, nEdgesOnCell(iCell)
+          iEdge = edgesOnCell(i, iCell)
+          cell1 = cellsOnEdge(1,iEdge)
+          cell2 = cellsOnEdge(2,iEdge)
+
+          r_tmp = dvEdge(iEdge) / dcEdge(iEdge)
+
+          do k = 1, maxLevelEdgeTop(iEdge)
+             ! \kappa_2 \nabla \phi on edge
+             glsPsi_turb_flux = glsPsi(k, cell2) - glsPsi(k, cell1)
+
+             eddyDiff2 = 0.25_RKIND*(vertDiffTopOfCell(k,cell1) + vertDiffTopOfCell(k,cell2) + &
+                                     vertDiffTopOfCell(k+1,cell1) + vertDiffTopOfCell(k+1,cell2))/sigma_psi
+             eddyDiff2 = eddyDiff2+0.25_RKIND*(dynamicViscosity(k,cell1)   + dynamicViscosity(k,cell2) + &
+                                               dynamicViscosity(k+1,cell1) + dynamicViscosity(k+1,cell2))/rho_sw
+
+             ! div(h \kappa_2 \nabla \phi) at cell center
+             flux = eddyDiff2 * layerThickEdge(k, iEdge) * glsPsi_turb_flux * r_tmp
+
+             glsPsiTend(k, iCell) = glsPsiTend(k, iCell) - edgeSignOnCell(i, iCell) * flux * invAreaCell
+          end do
+
+        end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      !Implements the horizontal boundary condition
+      if(config_two_equation_model_choice == 'epsilon') then
+         call mpas_log_write('BCs not yet implemented for k-eps scheme, choose a different model',MPAS_LOG_CRIT)
+      else if(config_two_equation_model_choice == 'omega') then
+         !Go through find boundary cell = 1 and add -tke(icell)*eddyDiff2*....
+
+         do iCell=1,nCellsOwned
+            do k=1,maxLevelCell(iCell)
+               if(boundaryCellMask(k,iCell) == 1) then
+                  do j=1,nEdgesOnCell(iCell)
+                     iEdge = edgesOnCell(j,iCell)
+                     cell1 = cellsOnEdge(1,iEdge)
+                     cell2 = cellsOnEdge(2,iEdge)
+                     if(cell1 < 1 .or. cell2 < 1) then
+                        if(cell1 < 1) then
+                           iCellValid = cell2
+                        else
+                           iCellValid = cell1
+                        endif
+                        eddyDiff2 = 0.25_RKIND*(vertDiffTopOfCell(k,iCellValid) + vertDiffTopOfCell(k+1,iCellValid))
+                        eddyDiff2 = eddyDiff2+0.5_RKIND*(dynamicViscosity(k,iCellValid) + dynamicViscosity(k+1,iCellValid))/rho_sw
+                        bcValue = 60.0_RKIND*dynamicViscosity(k,iCellValid)/rho_sw/(c_psi2*distanceToBoundary(k,iCellValid))
+                        glsPsi_turb_flux = bcValue - glsPsi(k,iCellValid) !Assumes k=0 in boundary condition
+                        ! div(h \kappa_2 \nabla \phi) at cell center
+                        flux = eddyDiff2 * layerThickEdge(k, iEdge) * glsPsi_turb_flux * dvEdge(iEdge)/dcEdge(iEdge)
+
+                        glsPsiTend(k, iCellValid) = glsPsiTend(k, iCellValid) - flux * invAreaCell
+                     end if
+                  end do !nEdges loop
+               end if !end cell mask if
+            end do
+         end do !nCells
+      else !kl and tau schemes
+         !Go through find boundary cell = 1 and add -tke(icell)*eddyDiff2*....
+
+         do iCell=1,nCellsOwned
+            do k=1,maxLevelCell(iCell)
+               if(boundaryCellMask(k,iCell) == 1) then
+                  do j=1,nEdgesOnCell(iCell)
+                     iEdge = edgesOnCell(j,iCell)
+                     cell1 = cellsOnEdge(1,iEdge)
+                     cell2 = cellsOnEdge(2,iEdge)
+                     if(cell1 < 1 .or. cell2 < 1) then
+                        eddyDiff2 = 0.25_RKIND*(vertDiffTopOfCell(k,iCell) + vertDiffTopOfCell(k+1,iCell))
+                        glsPsi_turb_flux = -glsPsi(k,iCell) !Assumes k=0 in boundary condition
+                        ! div(h \kappa_2 \nabla \phi) at cell center
+                        flux = eddyDiff2 * layerThickEdge(k, iEdge) * glsPsi_turb_flux * dvEdge(iEdge)/dcEdge(iEdge)
+
+                        glsPsiTend(k, iCell) = glsPsiTend(k, iCell) - flux * invAreaCell
+                     end if
+                  end do !nEdges loop
+               end if !end cell mask if
+            end do
+         end do !nCells
+      end if !config_two_equation_model_choice
+
+      call mpas_timer_stop("glsPsi horizontal turbulent transport")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_glsPsi_transport_horizontal_compute
+
+!***********************************************************************
+!
+!  routine ocn_glsPsi_transport_vertical_compute
+!
+!> \brief   Compute vertical component of parameterized glsPsi transport
+!> \author  Luke Van Roekel
+!> \date    July 2021
+!> \details
+!>  This routine initializes a variety of quantities related to
+!>  parameterized glsPsi transport in the horizontal in the ocean.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_glsPsi_transport_vertical_compute(glsPsi,layerThickness,sigma_psi,dt)
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: glsPsi
+      real (kind=RKIND), dimension(:,:), intent(in) :: layerThickness
+      real (kind=RKIND), intent(in) :: dt
+      integer :: iCell, k, N
+      real (kind=RKIND), dimension(nVertLevels) :: A,B,C,dissTmp,rhs
+      real (kind=RKIND),intent(in) :: sigma_psi
+
+      call mpas_timer_start("glsPsi vertical turbulent transport")
+
+      !$omp parallel
+      !$omp schedule(runtime) private(N, A, B, C, rhs, dissTmp, k)
+      do iCell=1,nCellsOwned
+         N = maxLevelCell(iCell)
+         A(1) = 0.0_RKIND
+         do k = 2, N
+            A(k) = -2.0_RKIND*dt*(dynamicViscosity(k,iCell)/rho_sw+vertViscTopOfCell(k,iCell)/sigma_psi) &
+                  / (layerThickness(k-1,iCell) + layerThickness(k,iCell)) &
+                  / layerThickness(k,iCell)
+         end do
+
+         do k = 1, N-1
+            C(k) = -2.0_RKIND*dt*(dynamicViscosity(k+1,iCell)/rho_sw+vertViscTopOfCell(k+1,iCell)/sigma_psi) &
+                  / (layerThickness(k,iCell) + layerThickness(k+1,iCell)) &
+                  / layerThickness(k,iCell)
+         end do
+         C(N) = 0.0_RKIND
+
+         do k = 1, N
+            B(k) = 1.0_RKIND - C(k) - A(k)
+         end do
+
+         rhs(:) = glsPsi(:,iCell)
+         dissTmp(:) = 0.0_RKIND
+
+         call turb_tridiagonal_solve(A(2:N), B, C(1:N-1), rhs(:), dissTmp, &
+                                N)
+
+         glsPsi(1:N,iCell) = dissTmp(1:N)
+         glsPsi(N+1:nVertLevels,iCell) = 0.0_RKIND
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      call mpas_timer_stop("glsPsi vertical turbulent transport")
+
+   end subroutine ocn_glsPsi_transport_vertical_compute
+
+!***********************************************************************
+
+   subroutine turb_tridiagonal_solve(a,b,c,r,x,n) !{{{!
+!
+      !-----------------------------------------------------------------!
+      !!
+      ! input variables!
+      !!
+      !-----------------------------------------------------------------!
+!
+      integer,intent(in) :: n!
+      real (KIND=RKIND), dimension(n), intent(in) :: a,b,c,r!
+!
+      !-----------------------------------------------------------------!
+      !!
+      ! output variables!
+      !!
+      !-----------------------------------------------------------------!
+!
+      real (KIND=RKIND), dimension(n), intent(out) :: x!
+!
+      !-----------------------------------------------------------------!
+      !!
+      ! local variables!
+      !!
+      !-----------------------------------------------------------------!
+
+      real (KIND=RKIND), dimension(n) :: bTemp,rTemp!
+      real (KIND=RKIND) :: m!
+      integer i!
+!
+      ! Use work variables for b and r!
+      bTemp(1) = b(1)!
+      rTemp(1) = r(1)!
+!
+      ! First pass: set the coefficients!
+      do i = 2,n!
+         m = a(i-1)/bTemp(i-1)!
+         bTemp(i) = b(i) - m*c(i-1)!
+         rTemp(i) = r(i) - m*rTemp(i-1)!
+      end do!
+!
+      x(n) = rTemp(n)/bTemp(n)!
+       ! Second pass: back-substition!
+      do i = n-1, 1, -1!
+         x(i) = (rTemp(i) - c(i)*x(i+1))/bTemp(i)!
+      end do!
+!
+   end subroutine turb_tridiagonal_solve
+
+end module ocn_tke_glsPsi_transport
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+! vim: foldmethod=marker

--- a/components/mpas-ocean/src/shared/mpas_ocn_tke_glsPsi_transport.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tke_glsPsi_transport.F
@@ -222,7 +222,8 @@ contains
       call mpas_timer_start("tke vertical turbulent transport")
 
       !$omp parallel
-      !$omp schedule(runtime) private(N, A, B, C, rhs, tkeTmp, k)
+      !$omp do schedule(runtime) &
+      !$omp private(N, A, B, C, rhs, tkeTmp, k)
       do iCell=1,nCellsOwned
          N = maxLevelCell(iCell)
          A(1) = 0.0_RKIND
@@ -440,7 +441,8 @@ contains
       call mpas_timer_start("glsPsi vertical turbulent transport")
 
       !$omp parallel
-      !$omp schedule(runtime) private(N, A, B, C, rhs, dissTmp, k)
+      !$omp do schedule(runtime) &
+      !$omp private(N, A, B, C, rhs, dissTmp, k)
       do iCell=1,nCellsOwned
          N = maxLevelCell(iCell)
          A(1) = 0.0_RKIND

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_mono.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_mono.F
@@ -330,6 +330,7 @@ module ocn_tracer_advection_mono
            do k = 1, nVertLevels
               wgtTmp(k) = normalThicknessFlux(k,iEdge)* &
                           advMaskHighOrder(k,iEdge)
+              !print*, 'normalThicknessFlux(k,iEdge) ', normalThicknessFlux(k,iEdge)
               sgnTmp(k) = sign(1.0_RKIND, &
                                normalThicknessFlux(k,iEdge))
               flxTmp(k) = 0.0_RKIND

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del2.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del2.F
@@ -29,6 +29,8 @@ module ocn_tracer_hmix_del2
 
    use ocn_constants
    use ocn_config
+   use ocn_mesh
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -57,7 +59,7 @@ module ocn_tracer_hmix_del2
 
    logical :: del2On
    real (kind=RKIND) :: eddyDiff2
-
+   real (kind=RKIND), dimension(:,:), allocatable :: eddyDiff
 
 !***********************************************************************
 
@@ -115,7 +117,7 @@ contains
       !-----------------------------------------------------------------
 
       integer :: iCell, iEdge, cell1, cell2
-      integer :: i, k, iTracer, num_tracers, nCells
+      integer :: i, k, iTracer, num_tracers, nCells, nEdges
       integer, dimension(:), pointer :: nCellsArray
 
       integer, dimension(:), pointer :: minLevelEdgeBot, maxLevelEdgeTop, nEdgesOnCell
@@ -149,6 +151,36 @@ contains
       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
 
       nCells = nCellsArray( 1 )
+      nEdges = nEdgesHalo(3)
+
+      allocate(eddyDiff(nVertLevels,nEdges))
+
+      if(config_use_two_equation_turbulence_model) then
+         !$omp parallel
+         !$omp do schedule(runtime) private(k, i, iEdge, cell1, cell2)
+         do iCell = 1, nCells
+            do i = 1, nEdgesOnCell(iCell)
+               iEdge = edgesOnCell(i, iCell)
+               cell1 = cellsOnEdge(1,iEdge)
+               cell2 = cellsOnEdge(2,iEdge)
+               do k = 1, maxLevelEdgeTop(iEdge)
+                  eddyDiff(k,iEdge) = 0.5_RKIND*(vertDiffTopOfCell(k,cell1) + vertDiffTopOfCell(k,cell2))
+               end do
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
+         else
+         !$omp parallel
+         !$omp do schedule(runtime) private(k)
+         do iEdge = 1, nEdges
+            do k = 1, maxLevelEdgeTop(iEdge)
+               eddyDiff(k,iEdge) = eddyDiff2 * meshScalingDel2(iEdge)
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
+      end if
 
       !
       ! compute a boundary mask to enforce insulating boundary conditions in the horizontal
@@ -164,7 +196,8 @@ contains
           cell1 = cellsOnEdge(1,iEdge)
           cell2 = cellsOnEdge(2,iEdge)
 
-          r_tmp = meshScalingDel2(iEdge) * eddyDiff2 * dvEdge(iEdge) / dcEdge(iEdge)
+          !r_tmp = meshScalingDel2(iEdge) * eddyDiff2 * dvEdge(iEdge) / dcEdge(iEdge)
+          r_tmp = dvEdge(iEdge) / dcEdge(iEdge)
 
           do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
             do iTracer = 1, num_tracers
@@ -172,7 +205,8 @@ contains
               tracer_turb_flux = tracers(iTracer, k, cell2) - tracers(iTracer, k, cell1)
 
               ! div(h \kappa_2 \nabla \phi) at cell center
-              flux = layerThicknessEdge(k, iEdge) * tracer_turb_flux * r_tmp
+              !flux = layerThicknessEdge(k, iEdge) * tracer_turb_flux * r_tmp
+              flux = layerThicknessEdge(k, iEdge) * tracer_turb_flux * r_tmp * eddyDiff(k,iEdge)
 
               tend(iTracer, k, iCell) = tend(iTracer, k, iCell) - edgeSignOnCell(i, iCell) * flux * invAreaCell
             end do
@@ -183,6 +217,7 @@ contains
       !$omp end do
       !$omp end parallel
 
+      deallocate(eddyDiff)
       call mpas_timer_stop("tracer del2")
 
    !--------------------------------------------------------------------

--- a/components/mpas-ocean/src/shared/mpas_ocn_two_equation_model_driver.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_two_equation_model_driver.F
@@ -1,0 +1,658 @@
+! Copyright (c) 2013-2018,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_two_equation_model
+!
+!> \brief MPAS ocean two equation model driver
+!> \author Luke Van Roekel
+!> \date   June 2021
+!> \details
+!>    This module contains all necessary routines to compute 
+!>    tendencies for the two equation turbulence closure 
+!>    this is primarily meant to be for nonhydrostatic mode, but could be
+!>    extended to the hydrostatic code as a GOTM replacement.
+!!
+!-----------------------------------------------------------------------
+
+module ocn_two_equation_model
+
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_kind_types
+   use mpas_dmpar
+   use mpas_log
+   use ocn_constants
+   use ocn_mesh
+   use ocn_tke_advection_mono
+   use ocn_glsPsi_advection_mono
+   use ocn_tke_glsPsi_transport
+   use ocn_shear_production
+   use ocn_buoyancy_production
+   use ocn_diagnostics_variables
+   use ocn_two_equation_structure_functions
+   use ocn_config
+   use ocn_tracer_advection_shared
+
+   implicit none
+   private
+   save
+
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+
+   !--------------------------------------------------------------------
+   !
+   ! Public Member Functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: ocn_two_equation_init, &
+             ocn_compute_two_equation_tendency, &
+             ocn_compute_strain, &
+             ocn_compute_two_equation_dissipation, &
+             ocn_compute_two_equation_diff, &
+             ocn_compute_two_equation_molecular_viscosity
+
+   !--------------------------------------------------------------------
+   !
+   ! Private module variables
+   !
+   !--------------------------------------------------------------------
+
+   real(kind=RKIND) :: &
+      c_mu, c_psi1, c_psi2, c_psi3, sigma_k, sigma_psi, c_p, c_m, c_n
+
+   logical :: twoEquationMixingOn
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+!
+!   routine ocn_compute_two_equation_dissipation
+!>  \brief    Compute the tendency terms for the k and psi terms 
+!>  \author   Luke Van Roekel
+!>  \date     June 2021
+!>  \details
+!>            
+!>            
+!>            
+!>            
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_compute_two_equation_dissipation(tke, glsPsi, tkeTend, glsPsiTend)
+
+     real(kind=RKIND), dimension(:,:), intent(in) :: tke,        & ! tke at current time level
+                                                     glsPsi        ! generalized variable from 
+                                                                   ! Umlauf and Burchard 2003
+
+     real(kind=RKIND), dimension(:,:), intent(inout) :: tkeTend,    & ! Tendency of TKE
+                                                        glsPsiTend    ! tendency of Psi variable
+
+     real(kind=RKIND) :: dissipation
+
+     integer :: iCell, k
+
+     do iCell = 1, nCellsOwned
+        do k = 1, maxLevelCell(iCell)
+           dissipation = c_mu**(3.0+c_p/c_n)*tke(k,iCell)**(1.5+c_m/c_n)* &
+                         glsPsi(k,iCell)**(-1.0/c_n)
+           tkeTend(k,iCell) = tkeTend(k,iCell) - dissipation
+           glsPsiTend(k,iCell) = glsPsiTend(k,iCell) - c_psi2*glsPsi(k,iCell) / &
+                                 (tke(k,iCell) + 1.0E-15_RKIND)*dissipation
+        end do
+     end do
+
+   end subroutine ocn_compute_two_equation_dissipation
+
+!***********************************************************************
+!
+!   routine ocn_compute_two_equation_tendency
+!>  \brief    Compute the tendency terms for the k and psi terms 
+!>  \author   Luke Van Roekel
+!>  \date     June 2021
+!>  \details
+!>            
+!>            
+!>            
+!>            
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_compute_two_equation_tendency(tkeTend, glsPsiTend, tke, glsPsi, velocityZonal, &
+                    velocityMeridional, normalVelocity, verticalVelocity, layerThickness,        &
+                    activeTracers, dt, err)
+
+     real(kind=RKIND),dimension(:,:), intent(in) :: velocityZonal, velocityMeridional, &
+                                                    normalVelocity, layerThickness,    &
+                                                    verticalVelocity, tke, glsPsi
+
+     real(kind=RKIND),dimension(:,:), intent(inout) :: tkeTend, glsPsiTend
+
+     real (kind=RKIND), dimension(:,:,:), intent(in) :: activeTracers
+     real(kind=RKIND),dimension(:,:), allocatable :: normalThicknessFlux
+
+     integer,intent(inout) :: err
+
+     real(kind=RKIND), intent(in) :: dt
+
+     integer :: iCell, k, nCells, nEdges, iEdge
+
+     nCells = nCellsHalo(2)
+
+     do iCell=1,nCells
+        do k=1,nVertLevels
+           tkeTend(k,iCell) = 0.0_RKIND
+           glsPsiTend(k,iCell) = 0.0_RKIND
+        end do
+     end do
+
+     nEdges = nEdgesAll
+     allocate(normalThicknessFlux(nVertLevels,nEdges))
+     do iEdge=1,nEdges
+        do k=1,nVertLevels
+           normalThicknessFlux(k,iEdge) = normalVelocity(k,iEdge)*layerThickEdge(k,iEdge)
+        end do
+     end do
+
+     !Compute the strain for the remaining terms in the tendency
+     call ocn_compute_strain(velocityZonal, velocityMeridional,  &
+                verticalVelocity, activeTracers, layerThickness, err)
+     call ocn_compute_two_equation_molecular_viscosity(activeTracers)
+
+     call ocn_tke_advection_mono_tend(tkeTend, tke, layerThickness,    &
+                                      normalThicknessFlux, verticalVelocity, dt,       &
+                                      advCoefs, advCoefs3rd,            &
+                                      nAdvCellsForEdge, advCellsForEdge,&
+                                      advMaskHighOrder)
+
+     call ocn_tke_transport_horizontal_compute(tke, tkeTend, sigma_k, err) 
+
+     if (.not. config_LES_mode) then
+
+        call ocn_glsPsi_advection_mono_tend(glsPsiTend, glsPsi, layerThickness,    &
+                                            normalThicknessFlux, verticalVelocity, dt,       &
+                                            advCoefs, advCoefs3rd,            &
+                                            nAdvCellsForEdge, advCellsForEdge,&
+                                            advMaskHighOrder)
+
+         call ocn_glsPsi_transport_horizontal_compute(glsPsi, glsPsiTend, c_psi2, sigma_psi, err)
+
+     endif
+
+     call ocn_compute_two_equation_dissipation(tke, glsPsi, tkeTend, glsPsiTend)
+     call ocn_buoyancy_production_compute(tkeTend, glsPsiTend, glsPsi, tke, c_psi3, &
+                                          surfaceBuoyancyForcing, err)
+     call ocn_shear_production_compute(tkeTend, glsPsiTend, tke, glsPsi, c_psi1, &
+                                       surfaceFrictionVelocity, c_mu, err)
+     deallocate(normalThicknessFlux)
+  end subroutine ocn_compute_two_equation_tendency
+
+!***********************************************************************
+!
+!   routine ocn_compute_two_equation_diff
+!>  \brief    Computes the diffusivity for the two equation model
+!>  \author   Luke Van Roekel
+!>  \date     May 2021
+!>  \details
+!>            Computes the diffusivity/viscosity for the two equation model
+!>            this is based on the tke and dissipation and diagnosed length 
+!>            scale
+!>
+!>            The diffusivity and viscosity are placed in the vertDiffTopOfCell
+!>            and vertViscTopOfCell arrays respectively
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_compute_two_equation_diff(tke, glsPsi, layerThickness, dt, err)
+
+     real(kind=RKIND),dimension(:,:), intent(inout) :: glsPsi, tke
+     
+     real(kind=RKIND),dimension(:,:), intent(in) :: layerThickness
+
+     integer,intent(inout) :: err
+
+     real(kind=RKIND), intent(in) :: dt
+
+     real(kind=RKIND) :: length, dissipation, length_grid, length_stable, dcAv
+     integer :: j, iCell, k, nCells, nEdges, iEdge, spot(2)
+
+     !compute new diffusivity based on older values
+     call ocn_canuto_structure_function_compute(Sm, Sh, tke, glsPsi, c_p, c_m, c_n, c_mu)
+     nCells = nCellsHalo(1)
+
+     if (config_LES_mode) then
+        !$omp parallel
+        !$omp do schedule(runtime) private(k,iEdge,dcAv,length_grid,length_stable,length)
+        do iCell=1,nCells
+           dcAv = 0.0_RKIND
+           do j=1,nEdgesOnCell(iCell)
+              iEdge = edgesOnCell(j, iCell)
+              dcAv = dcAv + dcEdge(iEdge)
+           end do
+           dcAv = dcAv / (1.0E-15_RKIND + nEdgesOnCell(iCell))
+           do k=2,maxLevelCell(iCell)
+              !compute length scale
+              !define the viscosity
+              length_grid = sqrt(dcAv * 0.5_RKIND*(layerThickness(k-1,iCell) + layerThickness(k,iCell)))
+              length_stable = 0.76_RKIND*sqrt(tke(k,iCell))/ &
+                              (sqrt(max(BruntVaisalaFreqTop(k,iCell),0.0_RKIND)) + &
+                                                             1.0E-15_RKIND)
+              length = min(length_grid, length_stable)
+              vertViscTopOfCell(k,iCell) = smagorinsky_coefficient*length*sqrt(tke(k,iCell))
+              vertDiffTopOfCell(k,iCell) = vertViscTopOfCell(k,iCell) !Assume turbulent Pr of 1
+           end do
+        end do
+        !$omp end do
+        !$omp end parallel
+     else
+        !$omp parallel
+        !$omp do schedule(runtime) private(k,length,dissipation)
+        do iCell=1,nCells
+           vertViscTopOfCell(1,iCell) = 0.0_RKIND
+           vertViscTopOfCell(maxLevelCell(iCell)+1:nVertLevels,iCell) = 0.0_RKIND
+           do k=2,maxLevelCell(iCell)
+              dissipation = c_mu**(3.0+c_p/c_n)*tke(k,iCell)**(1.5+c_m/c_n)* &
+                            glsPsi(k,iCell)**(-1.0/c_n)
+              length = c_mu**3*tke(k,iCell)**1.5/(1.0E-15_RKIND + dissipation)
+              vertViscTopOfCell(k,iCell) = length*Sm(k,iCell)*sqrt(tke(k,iCell))
+           end do
+        end do
+        !$omp end do 
+        !$omp end parallel
+     end if
+
+     call ocn_tke_transport_vertical_compute(tke,layerThickness,sigma_k,dt)
+     if(.not. config_LES_mode) then
+        call ocn_glsPsi_transport_vertical_compute(glsPsi,layerThickness,sigma_psi,dt)
+     end if
+
+     if (config_LES_mode) then
+       if(minval(tke) < 0) then
+         spot = minloc(tke)
+         print *, 'tke = ', tke(:,spot(2))
+         print *, 'vdiff = ',vertViscTopOfCell(:,spot(2))
+         print *, 'dyn = ',dynamicViscosity(:,spot(2))
+         print *, 'minval = ',minval(tke)
+         print *, 'minloc = ',minloc(tke)
+       endif
+        !$omp parallel
+        !$omp do schedule(runtime) private(k,dcAv,iEdge,length_grid,length_stable,length)
+        do iCell=1,nCells
+           dcAv = 0.0_RKIND
+           do j=1,nEdgesOnCell(iCell)
+              iEdge = edgesOnCell(j, iCell)
+              dcAv = dcAv + dcEdge(iEdge)
+           end do
+           dcAv = dcAv / (1.0E-15_RKIND + nEdgesOnCell(iCell))
+           do k=2,maxLevelCell(iCell)
+              !compute length scale
+              !define the viscosity
+              length_grid = sqrt(dcAv * 0.5_RKIND*(layerThickness(k-1,iCell) + layerThickness(k,iCell)))
+              length_stable = 0.76_RKIND*sqrt(max(tke(k,iCell),0.0_RKIND))/(sqrt(max(BruntVaisalaFreqTop(k,iCell),0.0_RKIND)) + &
+                                                             1.0E-15_RKIND)
+              length = min(length_grid, length_stable)
+              vertViscTopOfCell(k,iCell) = smagorinsky_coefficient*length*sqrt(tke(k,iCell)) + &
+                              dynamicViscosity(k,iCell)/rho_sw
+              vertDiffTopOfCell(k,iCell) = vertViscTopOfCell(k,iCell) !Assume turbulent Pr of 1
+           end do
+        end do
+        !$omp end do
+        !$omp end parallel
+     else
+       ! Recompute now that everything is fully up to date
+        call ocn_canuto_structure_function_compute(Sm, Sh, tke, glsPsi, c_p, c_m, c_n, c_mu)
+        !$omp parallel
+        !$omp do schedule(runtime) private(k,dissipation,length)
+        do iCell=1,nCells
+           vertDiffTopOfCell(1,iCell) = 0.0_RKIND
+           vertViscTopOfCell(1,iCell) = 0.0_RKIND
+           vertDiffTopOfCell(maxLevelCell(iCell)+1:nVertLevels,iCell) = 0.0_RKIND
+           vertViscTopOfCell(maxLevelCell(iCell)+1:nVertLevels,iCell) = 0.0_RKIND
+           do k=2,maxLevelCell(iCell)
+              dissipation = c_mu**(3.0+c_p/c_n)*tke(k,iCell)**(1.5+c_m/c_n)* &
+                            glsPsi(k,iCell)**(-1.0/c_n)
+              length = c_mu**3*tke(k,iCell)**1.5/(1.0E-15_RKIND + dissipation)
+              vertViscTopOfCell(k,iCell) = length*Sm(k,iCell)*sqrt(tke(k,iCell))
+              vertDiffTopOfCell(k,iCell) = length*Sh(k,iCell)*sqrt(tke(k,iCell))
+           end do
+        end do
+        !$omp end do 
+        !$omp end parallel
+     end if
+
+   end subroutine ocn_compute_two_equation_diff
+
+!***********************************************************************
+!
+!   routine ocn_compute_strain
+!>  \brief    Computes the strain rate tensor magnitude for smagorinsky 
+!>  \author   Luke Van Roekel
+!>  \date     May 2021
+!>  \details
+!>            Computes the strain rate tensor at cell centers.  Uses
+!>            the vector reconstruct coefficients to get x and y derivs
+!>            For 2D need dudx, dudy, dvdx, dvdy
+!>            For 3D adding dwdx and dwdy
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_compute_strain(velocityZonal, velocityMeridional,  &
+                verticalVelocity, activeTracers, layerThickness, err)
+
+     real(kind=RKIND),dimension(:,:),intent(in) :: &
+         velocityZonal, &  !Input: Zonal Velocity for gradients
+         velocityMeridional, & !Input: Meridional Velocity for gradients
+         layerThickness
+
+     real(kind=RKIND),dimension(:,:),intent(in),optional :: &
+         verticalVelocity !Input: optionally for nonhydrostaticMode include w
+
+     real(kind=RKIND),dimension(:,:,:),intent(in) :: &
+         activeTracers
+
+     integer, intent(in) :: err
+
+     integer :: iCell, iEdge, j, k, cell1, cell2
+
+     ! initialize gradients
+
+     do iCell=1,nCellsOwned
+        ugrad(:,:,iCell) = 0.0_RKIND
+        vgrad(:,:,iCell) = 0.0_RKIND
+        tgrad(:,:,iCell) = 0.0_RKIND
+
+        do j = 1,nEdgesOnCell(iCell) !for device may be better to move next lines inside k loop
+           iEdge = edgesOnCell(j,iCell)
+           cell1 = cellsOnEdge(1,iEdge)
+           cell2 = cellsOnEdge(2,iEdge)
+           do k = 1,maxLevelEdgeTop(iEdge)
+              tgrad(1,k,iCell) = tgrad(1,k,iCell) + coeffs_reconstruct(1,j,iCell) * edgeSignOnCell(j,iCell) * &
+                            (activeTracers(1,k,cell2) - activeTracers(1,k,cell1)) / dcEdge(iEdge) *   &
+                            edgeMask(k,iEdge)
+              tgrad(2,k,iCell) = tgrad(2,k,iCell) + coeffs_reconstruct(2,j,iCell) * edgeSignOnCell(j,iCell) * &
+                            (activeTracers(1,k,cell2) - activeTracers(1,k,cell1)) / dcEdge(iEdge) *   &
+                            edgeMask(k,iEdge)
+              sgrad(1,k,iCell) = sgrad(1,k,iCell) + coeffs_reconstruct(1,j,iCell) * edgeSignOnCell(j,iCell) * &
+                            (activeTracers(2,k,cell2) - activeTracers(2,k,cell1)) / dcEdge(iEdge) *   &
+                            edgeMask(k,iEdge)
+              sgrad(2,k,iCell) = sgrad(2,k,iCell) + coeffs_reconstruct(2,j,iCell) * edgeSignOnCell(j,iCell) * &
+                            (activeTracers(2,k,cell2) - activeTracers(2,k,cell1)) / dcEdge(iEdge) *   &
+                            edgeMask(k,iEdge)
+              ugrad(1,k,iCell) = ugrad(1,k,iCell) + coeffs_reconstruct(1,j,iCell) * edgeSignOnCell(j,iCell) * &
+                            (velocityZonal(k,cell2) - velocityZonal(k,cell1)) / dcEdge(iEdge) *   &
+                            edgeMask(k,iEdge)
+              ugrad(2,k,iCell) = ugrad(2,k,iCell) + coeffs_reconstruct(2,j,iCell) * edgeSignOnCell(j,iCell) * &
+                            (velocityZonal(k,cell2) - velocityZonal(k,cell1)) / dcEdge(iEdge) *   &
+                            edgeMask(k,iEdge)
+              vgrad(1,k,iCell) = vgrad(1,k,iCell) + coeffs_reconstruct(1,j,iCell) * edgeSignOnCell(j,iCell) * &
+                            (velocityMeridional(k,cell2) - velocityMeridional(k,cell1)) /         &
+                            dcEdge(iEdge) * edgeMask(k,iEdge)
+              vgrad(2,k,iCell) = vgrad(2,k,iCell) + coeffs_reconstruct(2,j,iCell) * edgeSignOnCell(j,iCell) * &
+                            (velocityMeridional(k,cell2) - velocityMeridional(k,cell1)) /         &
+                            dcEdge(iEdge) * edgeMask(k,iEdge)
+          end do 
+       end do !end n edges loop
+
+       ! instead of doing this put in surface BCs for generation
+       ! compute dudz dvdz
+       ugrad(3,1,iCell) = (velocityZonal(1,iCell) - velocityZonal(2,iCell)) /   &
+                            (0.5_RKIND*(layerThickness(1,iCell) + layerThickness(2,iCell)))
+       vgrad(3,1,iCell) = (velocityMeridional(1,iCell) - velocityMeridional(2,iCell)) /   &
+                            (0.5_RKIND*(layerThickness(1,iCell) + layerThickness(2,iCell)))
+       tgrad(3,1,iCell) = (activeTracers(1,1,iCell) - activeTracers(1,2,iCell)) /   &
+                            (0.5_RKIND*(layerThickness(1,iCell) + layerThickness(2,iCell)))
+       sgrad(3,1,iCell) = (activeTracers(2,1,iCell) - activeTracers(2,2,iCell)) /   &
+                            (0.5_RKIND*(layerThickness(1,iCell) + layerThickness(2,iCell)))
+
+       do k=2,maxLevelCell(iCell)
+          tgrad(3,k,iCell) = 0.5_RKIND*(tgrad(3,k-1,iCell) + (activeTracers(1,k-1,iCell) - activeTracers(1,k,iCell)) / &
+                        (0.5_RKIND*(layerThickness(k-1,iCell) + layerThickness(k,iCell))))
+          sgrad(3,k,iCell) = 0.5_RKIND*(sgrad(3,k-1,iCell) + (activeTracers(2,k-1,iCell) - activeTracers(2,k,iCell)) / &
+                        (0.5_RKIND*(layerThickness(k-1,iCell) + layerThickness(k,iCell))))
+          ugrad(3,k,iCell) = 0.5_RKIND*(ugrad(3,k-1,iCell) + (velocityZonal(k-1,iCell) - velocityZonal(k,iCell)) / &
+                        (0.5_RKIND*(layerThickness(k-1,iCell) + layerThickness(k,iCell))))
+          vgrad(3,k,iCell) = 0.5_RKIND*(vgrad(3,k-1,iCell) + (velocityMeridional(k-1,iCell) - velocityMeridional(k,iCell)) / &
+                        (0.5_RKIND*(layerThickness(k-1,iCell) + layerThickness(k,iCell))))
+       end do
+
+    end do ! end cell loop
+
+    ! add w part if requested 
+    if(present(verticalVelocity)) then
+       do iCell=1,nCellsOwned
+          wgrad(:,:,iCell) = 0.0_RKIND
+
+          do j = 1,nEdgesOnCell(iCell) !for device may be better to move next lines inside k loop
+             iEdge = edgesOnCell(j,iCell)
+             cell1 = cellsOnEdge(1,iEdge)
+             cell2 = cellsOnEdge(2,iEdge)
+         
+             do k=1,maxLevelEdgeTop(iEdge)
+                wgrad(1,k,iCell) = wgrad(1,k,iCell) + coeffs_reconstruct(1,j,iCell) * edgeSignOnCell(j,iCell) * &
+                             (verticalVelocity(k,cell2) - verticalVelocity(k,cell1)) / dcEdge(iEdge) * &
+                             edgeMask(k,iEdge)
+                wgrad(2,k,iCell) = wgrad(2,k,iCell) + coeffs_reconstruct(2,j,iCell) * edgeSignOnCell(j,iCell) * &
+                             (verticalVelocity(k,cell2) - verticalVelocity(k,cell1)) / dcEdge(iEdge) * &
+                             edgeMask(k,iEdge)
+             end do
+
+          end do !end n edges loop
+
+          do k=2,maxLevelCell(iCell)
+             wgrad(3,k,iCell) = (verticalVelocity(k-1,iCell) - verticalVelocity(k,iCell)) / &
+                         ((layerThickness(k,iCell)))
+          end do
+
+       end do !end icell loop
+    end if !if present w 
+
+ end subroutine ocn_compute_strain
+
+!***********************************************************************
+!
+!   routine ocn_two_equation_init
+!>  \brief    Configures options for the two equation model 
+!>  \author   Luke Van Roekel
+!>  \date     May 2021
+!>  \details
+!>            Initializes variables and allocates internal variables for 
+!>            computing strain tensor and k and psi 
+!
+!----------------------------------------------------------------------
+
+   subroutine ocn_two_equation_init( domain, err )
+
+      type (domain_type), intent(inout) :: domain
+      type (mpas_pool_type), pointer :: statePool
+      type (mpas_pool_type), pointer :: meshPool
+      integer, intent(out) :: err
+      real(kind=RKIND), dimension(:,:), pointer :: layerThickness
+      real(kind=RKIND), dimension(:,:), pointer :: distanceToBoundary
+      real(kind=RKIND), dimension(:,:), pointer :: boundaryNormalAngle
+
+      integer :: cell1, cell2, iEdge, k
+
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
+      twoEquationMixingOn = .false.
+      if(config_use_two_equation_turbulence_model) then
+
+         twoEquationMixingOn = .true.
+
+         if (config_two_equation_model_choice == 'kl') then !MY 1982
+            c_mu = 0.5544_RKIND
+            sigma_k = 1.96_RKIND
+            sigma_psi = 1.96_RKIND
+            c_psi1 = 0.9_RKIND
+            c_psi2 = 0.5_RKIND
+            c_psi3 = 0.9_RKIND
+            c_p = 0.0_RKIND
+            c_m = 1.0_RKIND
+            c_n = 1.0_RKIND
+         elseif (config_two_equation_model_choice == 'epsilon') then ! Rotta 87
+            c_mu = 0.5477_RKIND
+            sigma_k = 1.0_RKIND
+            sigma_psi = 1.3_RKIND
+            c_psi1 = 1.44_RKIND
+            c_psi2 = 1.92_RKIND
+            c_psi3 = -0.629_RKIND
+            c_p = 3.0_RKIND
+            c_m = 3.0_RKIND / 2.0_RKIND
+            c_n = -1.0_RKIND
+        elseif (config_two_equation_model_choice == 'omega') then !Wilcox 88
+            c_mu = 0.5477_RKIND
+            sigma_k = 2.0_RKIND
+            sigma_psi = 2.0_RKIND
+            c_psi1 = 0.555_RKIND
+            c_psi2 = 0.833_RKIND
+            c_psi3 = -0.642_RKIND
+            c_p = -1.0_RKIND
+            c_m = 0.5_RKIND
+            c_n = -1.0_RKIND
+         elseif (config_two_equation_model_choice == 'ktau') then !Zilinkivech Wilcox 88
+            c_mu = 0.5477_RKIND
+            sigma_k = 1.46_RKIND
+            sigma_psi = 10.8_RKIND
+            c_psi1 = 0.173_RKIND
+            c_psi2 = 0.225_RKIND
+            c_psi3 = 0.0_RKIND
+            c_p = -3.0_RKIND
+            c_m = 0.5_RKIND
+            c_n = 1.0_RKIND
+         elseif (config_two_equation_model_choice == 'user-defined') then
+            c_mu = config_user_c_mu
+            sigma_k = config_user_sigma_k
+            sigma_psi = config_user_sigma_psi
+            c_psi1 = config_user_c_psi1
+            c_psi2 = config_user_c_psi2
+            c_psi3 = config_user_c_psi3
+            c_p = config_user_c_p
+            c_m = config_user_c_m
+            c_n = config_user_c_n
+         else !invalid choice 
+            call mpas_log_write("Unknown option for config_two_equation_model_choice, valid values are: " // &
+                                  " 'epsilon', 'kl', 'omega', 'ktau', 'user-defined'", MPAS_LOG_CRIT)
+         endif
+
+         if(config_use_cvmix) then
+            call mpas_log_write("Cannot use two equation turbulence closure and cvmix at the same time: " // &
+                    "set either config_use_cvmix or config_use_two_equation_model to .false.", MPAS_LOG_CRIT)
+         end if
+
+         !init advection of tke and glsPsi
+
+         call ocn_tke_advection_mono_init(config_num_halos, config_two_equation_hor_adv_order,        &
+                                                config_two_equation_vert_adv_order,              &
+                                                config_two_equation_coef_3rd_order,              &
+                                                config_two_equation_check_monotonicity, err)
+
+         call ocn_glsPsi_advection_mono_init(config_num_halos, config_two_equation_hor_adv_order,        &
+                                                config_two_equation_vert_adv_order,                 &
+                                                config_two_equation_coef_3rd_order,                 &
+                                                config_two_equation_check_monotonicity, err)
+
+         call mpas_pool_get_array(meshPool, 'distanceToBoundary', distanceToBoundary)
+         call mpas_pool_get_array(meshPool, 'boundaryNormalAngle', boundaryNormalAngle)
+         if(.not. associated(distanceToBoundary)) then
+            distanceToBoundary(:,:) = 1.0E50_RKIND
+            ! make an assumption that the distance to boundary is just dcEdge/2.0 when edgeMask==0
+            do iEdge=1,nEdgesAll
+               do k=1,nVertLevels
+                  if(edgeMask(k,iEdge) == 0) then
+                     cell1 = cellsOnEdge(1,iEdge)
+                     cell2 = cellsOnedge(2,iEdge)
+                     distanceToBoundary(k,cell1) = dcEdge(iEdge)/2.0_RKIND
+                     distanceToBoundary(k,cell2) = dcEdge(iEdge)/2.0_RKIND
+                  endif
+               end do
+            end do
+         end if
+
+         if(.not. associated(boundaryNormalAngle)) then
+            if(config_two_equation_model_choice == 'epsilon') then
+               call mpas_log_write("Unable to use k-epsilon configuration without specifying the " // &
+                        "boundaryNormalAngle array", MPAS_LOG_CRIT)
+            end if
+         end if
+      end if
+
+   end subroutine ocn_two_equation_init
+
+   subroutine ocn_compute_two_equation_molecular_viscosity(activeTracers)
+
+     !computes the molecular viscosity of water following Sharqawy et al (2010)
+     real(kind=RKIND),dimension(:,:,:), intent(in) :: activeTracers
+     real(kind=RKIND) :: A, B, C, dcEdgeAverage
+     real(kind=RKIND) :: tAvg, sAvg, viscAvg, A1, B1, freshwaterMu
+
+     real(kind=RKIND) :: boundaryTangentialVel
+     integer :: iCell, j, k
+
+     A = 2.414E-5_RKIND
+     B = 247.8_RKIND
+     C = 140.0_RKIND
+
+     do iCell=1,nCellsAll
+        !compute dcEdgeAverage
+        dcEdgeAverage = 0.0_RKIND
+        do j=1,nEdgesOnCell(iCell)
+           dcEdgeAverage = dcEdgeAverage + dcEdge(edgesOnCell(j,iCell))
+        end do
+        dcEdgeAverage = dcEdgeAverage / nEdgesOnCell(iCell) + 1.0E-15_RKIND
+        dynamicViscosity(1,iCell) = 0.0_RKIND
+        do k = 1,maxLevelCell(iCell)-1
+           tAvg = 0.5_RKIND*(activeTracers(1,k,iCell) + activeTracers(1,k+1,iCell))
+           sAvg = 0.5_RKIND*(activeTracers(2,k,iCell) + activeTracers(2,k+1,iCell)) / 1000.0_RKIND
+           viscAvg = 1.0E-15_RKIND + 0.5_RKIND*(dynamicViscosity(k,iCell) + dynamicViscosity(k+1,iCell))
+!           freshwaterMu = A*10.0_RKIND**(B/(tAvg + 273.15_RKIND - C))
+           freshwaterMu = 4.2844E-5 + (0.157_RKIND*(tAvg + 64.993_RKIND)**2.0 - 91.296_RKIND)**(-1.0)
+           A1 = 1.541_RKIND + 0.01998*tAvg - 9.52E-5_RKIND*tAvg**2.0
+           B1 = 7.974_RKIND - 0.07561*tAvg + 4.724E-4_RKIND*tAvg**2.0
+           dynamicViscosity(k+1,iCell) = freshwaterMu*(1.0_RKIND + &
+                                        A1*sAvg + &
+                                        B1*sAvg**2)
+          if(dynamicViscosity(k+1,iCell) < 0) then
+            print *, activeTracers(1,:,iCell)
+            print *, 'hi',k, tavg,savg, viscavg, freshwaterMu, A1, B1, dynamicViscosity(k+1,iCell)
+            stop
+          endif
+           boundaryTangentialVel = velocityZonal(k,iCell)*sin(boundaryNormalAngle(k,iCell)) + &
+                                  velocityMeridional(k,iCell)*cos(boundaryNormalAngle(k,iCell))
+           !need to find the edge in question and then use that dcEdge -- maybe just do average for performance reasons?
+
+           uStar(k,iCell) = sqrt(boundaryCellMask(k,iCell)*abs(boundaryTangentialVel/(0.5_RKIND*dcEdgeAverage)) &
+                          * viscAvg/rho_sw)
+           yPlus(k,iCell) = uStar(k,iCell)*distanceToBoundary(k,iCell) / (viscAvg/rho_sw)
+        end do
+        k=maxLevelCell(iCell)
+        dynamicViscosity(maxLevelCell(iCell)+1:nVertLevels+1,iCell) = 0.0_RKIND
+
+        viscAvg = 0.5_RKIND*(dynamicViscosity(k,iCell) + dynamicViscosity(k+1,iCell))
+        boundaryTangentialVel = velocityZonal(k,iCell)*sin(boundaryNormalAngle(k,iCell)) + &
+                                  velocityMeridional(k,iCell)*cos(boundaryNormalAngle(k,iCell))
+           !need to find the edge in question and then use that dcEdge -- maybe just do average for performance reasons?
+
+        uStar(k,iCell) = sqrt(boundaryCellMask(k,iCell)*abs(boundaryTangentialVel/(0.5_RKIND*dcEdgeAverage)) &
+                          * viscAvg/rho_sw)
+        yPlus(k,iCell) = uStar(k,iCell)*distanceToBoundary(k,iCell) / (viscAvg/rho_sw)
+
+     end do
+
+     !compute ustar
+
+   end subroutine ocn_compute_two_equation_molecular_viscosity
+end module ocn_two_equation_model
+

--- a/components/mpas-ocean/src/shared/mpas_ocn_two_equation_structure_functions.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_two_equation_structure_functions.F
@@ -1,0 +1,163 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_two_equation_structure_functions
+!
+!> \brief MPAS ocean structure functions calculation 
+!> \author Luke Van Roekel
+!> \date   July 2021
+!> \details
+!>  This module contains the computation for structure functions  
+!>  for the two equation turbulence model viscosity/diffusivity calculation
+!>
+!
+!-----------------------------------------------------------------------
+
+module ocn_two_equation_structure_functions
+
+   use mpas_timer
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_threading
+   use mpas_constants
+
+   use ocn_constants
+   use ocn_config
+   use ocn_mesh
+   use ocn_diagnostics_variables
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: ocn_canuto_structure_function_compute
+
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+!
+!  routine ocn_structure_function_compute
+!
+!> \brief   Computes structure functions for diffusivity and viscosity  
+!> \author  Luke Van Roekel 
+!> \date    July 2021
+!> \details
+!>  This routine computes the structure functions for the viscosity and
+!>  diffusivity in the two equation model, follows Canuto et al (2001)
+!>  Canuto, V. M., Howard, A., Cheng, Y., & Dubovikov, M. S. (2001). 
+!>     Ocean Turbulence. Part I: One-Point Closure Model—Momentum and 
+!>     Heat Vertical Diffusivities, Journal of Physical Oceanography, 
+!>     31(6), 1413-1426
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_canuto_structure_function_compute(Sm, Sh, tke, glsPsi, c_p, &
+                  c_m, c_n, c_mu)!{{{
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+                        Sm, Sh ! structure functions
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+                        tke, glsPsi ! input variables for calculation
+
+      real (kind=RKIND), intent(in) :: c_p, c_m, c_n, c_mu
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      real(kind=RKIND), parameter :: lambda1 = 0.107_RKIND,  &
+                                     lambda2 = 0.0032_RKIND, &
+                                     lambda3 = 0.0864_RKIND, &
+                                     lambda4 = 0.12_RKIND,   &
+                                     lambda5 = 11.9_RKIND,   &
+                                     lambda6 = 0.4_RKIND,    &
+                                     lambda7 = 0.0_RKIND,    &
+                                     lambda8 = 0.48_RKIND
+
+      real(kind=RKIND) :: d0, d1, d2, d3, d4, d5, riMid, bvfMid
+
+      real(kind=RKIND) :: tau, D, dissipation, s0, s1, s2, s3, s4, s5, s6
+
+      integer :: k, iCell
+
+      d0 = 3.0_RKIND*lambda5**2.0
+      d1 = lambda5*(7.0_RKIND*lambda4 + 3.0_RKIND*lambda8)
+      d2 = lambda5**2.0*(3.0_RKIND*lambda3**2.0 - lambda2**2.0) -  &
+           0.75_RKIND*(lambda6**2.0 - lambda7**2.0)
+      d3 = lambda4*(4.0_RKIND*lambda4 + 3.0_RKIND*lambda8)
+      d4 = lambda4*(lambda2*lambda6 - 3.0_RKIND*lambda3*lambda7 - &
+           lambda5*(lambda2**2.0 - lambda3**2.0)) + lambda5*      &
+           lambda8*(3.0_RKIND*lambda3**2.0 - lambda2**2.0)
+      d5 = 0.25_RKIND*(lambda2**2.0 - 3.0_RKIND*lambda3**2.0)*    &
+           (lambda6**2.0 - lambda7**2.0)
+
+      s0 = 1.5_RKIND*lambda1*lambda5**2.0
+      s1 = -lambda4*(lambda6 + lambda7) + 2.0_RKIND*lambda4*lambda5* &
+              (lambda1 - 1.0_RKIND/3.0_RKIND*lambda2 - lambda3) +    &
+              1.5_RKIND*lambda1*lambda5*lambda8
+      s2 = -3.0_RKIND/8.0_RKIND*lambda1*(lambda6**2.0 - lambda7**2.0)
+      s4 = 2.0_RKIND*lambda5
+      s5 = 2.0_RKIND*lambda4
+      s6 = 2.0_RKIND/3.0_RKIND*lambda5*(3.0_RKIND*lambda3**2.0 - lambda2**2.0) - &
+            0.5_RKIND*lambda5*lambda1*(3.0_RKIND*lambda3 - lambda2) + &
+            3.0_RKIND/4.0_RKIND*lambda1*(lambda6 - lambda7)
+
+      do iCell=1,nCellsOwned
+         do k=1,maxLevelCell(iCell)-1
+            dissipation = c_mu**(3.0+c_p/c_n)*tke(k,iCell)**(1.5+c_m/c_n)* &
+                                        glsPsi(k,iCell)**(-1.0/c_n)
+            tau = 2.0_RKIND*tke(k,iCell)/(dissipation + 1.0E-15_RKIND)
+            bvfMid = 0.5_RKIND*(bruntVaisalaFreqTop(k,iCell) +              &
+                                bruntVaisalaFreqTop(k+1,iCell))
+            riMid = 0.5_RKIND*(RiTopOfCell(k,iCell) + RiTopOfCell(k+1,iCell))
+            D = d0 + d1*tau**2.0*bvfMid + d2*tau**2.0* &
+                bvfMid / (1.0E-15_RKIND + riMid) &
+                + d3*tau**4.0*bvfMid**2.0 + d4*tau**4.0* &
+                bvfMid**2.0 / (1.0E-15_RKIND +           &
+                riMid) + d5*tau**4.0*bvfMid**2.0 / &
+                (1.0E-15_RKIND + riMid**2.0)
+            Sm(k,iCell) = (s0 + s1*tau**2.0*bvfMid + &
+                          s2*tau**2.0*bvfMid /       &
+                          (1.0E-15_RKIND + riMid)) / (D + 1.0E-15_RKIND)
+            Sh(k,iCell) = (s4 + s5*tau**2.0*bvfMid + &
+                          s6*tau**2.0*bvfMid /       &
+                          (1.0E-15_RKIND + riMid)) / (D + 1.0E-15_RKIND)
+        end do
+        Sm(maxLevelCell(iCell):nVertLevels,iCell) = 0.0_RKIND
+        Sh(maxLevelCell(iCell):nVertLevels,iCell) = 0.0_RKIND
+     end do
+
+   end subroutine ocn_canuto_structure_function_compute
+
+end module ocn_two_equation_structure_functions
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+! vim: foldmethod=marker

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_hadv_coriolis.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_hadv_coriolis.F
@@ -259,7 +259,7 @@ contains
         !Add in the tendency for coriolis from vertical velocity
         !$omp parallel
         !$omp do schedule(runtime) &
-        !$omp private(cell1, cell2, wav)
+        !$omp private(cell1, cell2)
         do iEdge = 1, nEdgesAll
            cell1 = cellsOnEdge(1,iEdge)
            cell2 = cellsOnEdge(2,iEdge)

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_hadv_coriolis.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_hadv_coriolis.F
@@ -79,7 +79,7 @@ contains
    subroutine ocn_vel_hadv_coriolis_tend(normRelVortEdge, &
                                       normPlanetVortEdge, &
                                       layerThickEdge, normalVelocity, &
-                                      kineticEnergyCell, tend, err)!{{{
+                                      kineticEnergyCell, verticalVelocity, tend, err)!{{{
 
       !-----------------------------------------------------------------
       ! input variables
@@ -90,7 +90,10 @@ contains
          normPlanetVortEdge, &!< [in] planetary vorticity/thickness at edge
          layerThickEdge,     &!< [in] layer thickness on edge
          normalVelocity,     &!< [in] Horizontal velocity
-         kineticEnergyCell    !< [in] Kinetic Energy
+         kineticEnergyCell    !< [in] Kinetic Energyi
+
+      real (kind=RKIND), dimension(:,:), intent(in), optional :: &
+         verticalVelocity    !< vertical velocity for non-hydrostatic mode only
 
       !-----------------------------------------------------------------
       ! input/output variables
@@ -251,6 +254,29 @@ contains
       !$omp end do
       !$omp end parallel
 #endif
+
+      if(config_enable_nonHydrostatic_mode) then
+        !Add in the tendency for coriolis from vertical velocity
+        !$omp parallel
+        !$omp do schedule(runtime) &
+        !$omp private(cell1, cell2, wav)
+        do iEdge = 1, nEdgesAll
+           cell1 = cellsOnEdge(1,iEdge)
+           cell2 = cellsOnEdge(2,iEdge)
+
+           !k-indexing can't be right here?
+           !do k=1,maxLevelEdgeTop(iEdge)
+           !   wav = 0.25_RKIND * (verticalVelocity(k,cell1) +
+           !   verticalVelocity(k,cell2) + &
+           !           verticalVelocity(k+1,cell1) +
+           !           verticalVelocity(k+1,cell2))
+           !   tend(k, iEdge) = tend(k,iEdge) -
+           !   2.0_RKIND*omega*cos(latEdge(iEdge))*wav
+           !end do
+        end do
+        !$omp end do
+        !$omp end parallel
+      endif
 
       !$acc exit data delete(tmpVorticity, qArr)
       deallocate(qArr,tmpVorticity)

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix.F
@@ -80,7 +80,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_hmix_tend(div, relVort, tend, err)!{{{
+   subroutine ocn_vel_hmix_tend(div, relVort, viscosity, tend, err)!{{{
 
       !-----------------------------------------------------------------
       ! input variables
@@ -95,7 +95,8 @@ contains
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         tend            !< [inout] accumulated velocity tendency
+         tend,        &!< [inout] accumulated velocity tendency
+         viscosity
 
       !-----------------------------------------------------------------
       ! output variables
@@ -125,7 +126,7 @@ contains
       ! note that the user can choose multiple options and the
       !   tendencies will be added together
 
-      call ocn_vel_hmix_del2_tend(div, relVort, tend, err1)
+      call ocn_vel_hmix_del2_tend(div, relVort, viscosity, tend, err1)
       err = ior(err1, err)
 
       call ocn_vel_hmix_leith_tend(div, relVort, tend, err1)

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix_del2.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix_del2.F
@@ -24,6 +24,7 @@ module ocn_vel_hmix_del2
    use ocn_constants
    use ocn_config
    use ocn_mesh
+   use ocn_diagnostics_variables
 
    implicit none
    private
@@ -137,29 +138,29 @@ contains
       !$acc            dcEdgeInv, dvEdgeInv, visc2)
 #else
 
-!      if(config_use_two_equation_turbulence_model) then
-!         !$omp parallel
-!         !$omp do schedule(runtime) private(cell1, cell2, k)
-!         do iEdge = 1, nEdgesOwned
-!            cell1 = cellsOnEdge(1,iEdge)
-!            cell2 = cellsOnEdge(2,iEdge)
-!            do k = 1, maxLevelEdgeTop(iEdge)
-!               viscosity(k,iEdge) = 0.5_RKIND*(vertDiffTopOfCell(k,cell1) + vertDiffTopOfCell(k,cell2))
-!            end do
-!         end do
-!         !$omp end do
-!         !$omp end parallel
-!      else
-!         !$omp parallel
-!         !$omp do schedule(runtime) private(k)
-!         do iEdge = 1, nEdgesOwned
-!            do k = 1, maxLevelEdgeTop(iEdge)
-!               viscosity(k,iEdge) = viscDel2 * meshScalingDel2(iEdge)
-!            end do
-!         end do
-!         !$omp end do
-!         !$omp end parallel
-!      end if
+      if(config_use_two_equation_turbulence_model) then
+         !$omp parallel
+         !$omp do schedule(runtime) private(cell1, cell2, k)
+         do iEdge = 1, nEdgesOwned
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            do k = 1, maxLevelEdgeTop(iEdge)
+               viscosity(k,iEdge) = 0.5_RKIND*(vertDiffTopOfCell(k,cell1) + vertDiffTopOfCell(k,cell2))
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
+      else
+         !$omp parallel
+         !$omp do schedule(runtime) private(k)
+         do iEdge = 1, nEdgesOwned
+            do k = 1, maxLevelEdgeTop(iEdge)
+               viscosity(k,iEdge) = viscDel2 * meshScalingDel2(iEdge)
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
+      end if
 
       !$omp parallel
       !$omp do schedule(runtime) &
@@ -175,7 +176,7 @@ contains
          dcEdgeInv = 1.0_RKIND / dcEdge(iEdge)
          dvEdgeInv = 1.0_RKIND / dvEdge(iEdge)
 
-         visc2 =  viscDel2*meshScalingDel2(iEdge)
+         !visc2 =  viscDel2*meshScalingDel2(iEdge)
 
          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
 
@@ -190,7 +191,8 @@ contains
                    -(relVort(k,vertex2)-relVort(k,vertex1))*dvEdgeInv
 
             tend(k,iEdge) = tend(k,iEdge) + &
-                            edgeMask(k,iEdge)*visc2*uDiff
+                            !edgeMask(k,iEdge)*visc2*uDiff
+                            edgeMask(k,iEdge)*viscosity(k,iEdge)*uDiff
 
          end do
       end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix_del2.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix_del2.F
@@ -77,7 +77,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_hmix_del2_tend(div, relVort, tend, err)!{{{
+   subroutine ocn_vel_hmix_del2_tend(div, relVort, viscosity, tend, err)!{{{
 
       !-----------------------------------------------------------------
       ! input variables
@@ -92,7 +92,8 @@ contains
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         tend            !< [inout] accumulated velocity tendency
+         tend,          &!< [inout] accumulated velocity tendency
+         viscosity
 
       !-----------------------------------------------------------------
       ! output variables
@@ -135,6 +136,31 @@ contains
       !$acc    private(k, cell1, cell2, uDiff, vertex1, vertex2, &
       !$acc            dcEdgeInv, dvEdgeInv, visc2)
 #else
+
+!      if(config_use_two_equation_turbulence_model) then
+!         !$omp parallel
+!         !$omp do schedule(runtime) private(cell1, cell2, k)
+!         do iEdge = 1, nEdgesOwned
+!            cell1 = cellsOnEdge(1,iEdge)
+!            cell2 = cellsOnEdge(2,iEdge)
+!            do k = 1, maxLevelEdgeTop(iEdge)
+!               viscosity(k,iEdge) = 0.5_RKIND*(vertDiffTopOfCell(k,cell1) + vertDiffTopOfCell(k,cell2))
+!            end do
+!         end do
+!         !$omp end do
+!         !$omp end parallel
+!      else
+!         !$omp parallel
+!         !$omp do schedule(runtime) private(k)
+!         do iEdge = 1, nEdgesOwned
+!            do k = 1, maxLevelEdgeTop(iEdge)
+!               viscosity(k,iEdge) = viscDel2 * meshScalingDel2(iEdge)
+!            end do
+!         end do
+!         !$omp end do
+!         !$omp end parallel
+!      end if
+
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp    private(k, cell1, cell2, uDiff, vertex1, vertex2, &

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_pressure_grad.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_pressure_grad.F
@@ -93,7 +93,8 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_pressure_grad_tend(ssh, pressure, surfacePressure, &
+   subroutine ocn_vel_pressure_grad_tend(ssh, nonhydrostaticPressure, &
+                                  pressure, surfacePressure, &
                                   montgomeryPotential, zMid, &
                                   density, potentialDensity, &
                                   indxT, indxS, tracers, &
@@ -119,7 +120,8 @@ contains
          montgomeryPotential, &!< [in] Mongomery potential
          zMid,                &!< [in] z-coordinate at layer mid-depth
          density,             &!< [in] density
-         potentialDensity      !< [in] potentialDensity
+         potentialDensity,    &!< [in] potentialDensity
+         nonhydrostaticPressure     !< Input: nonhydrostatic pressure correction
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          thermExpCoeff,       &!< [in] in situ thermal expansion coeff
@@ -146,7 +148,7 @@ contains
       !-----------------------------------------------------------------
 
       integer ::           &
-         iEdge, k,  &! loop indices for edge, cell, vertical loops
+         iEdge, iCell, k,  &! loop indices for edge, cell, vertical loops
          cell1, cell2,     &! neighbor cell indices across edge
          kMin, kMax         ! shallowest and deepest active layer
 
@@ -158,7 +160,9 @@ contains
          zStar, zC, zGamma,&! z coordinate combination for Jacobian
          rhoL, rhoR,       &! density neighbors for Jacobian
          TL, TR,           &! temperature neighbors for Jacobian
-         SL, SR             ! salinity neighbors for Jacobian
+         SL, SR, dqdza      ! salinity neighbors for Jacobian
+
+      real (kind=RKIND), dimension(:), allocatable :: dqdz
 
       real (kind=RKIND), dimension(:,:), allocatable :: &
          JacobianDxDs,     &! Jacobian in density * Dx * DS
@@ -257,6 +261,51 @@ contains
          !$omp end parallel
 #endif
 
+         if(config_enable_nonhydrostatic_mode) then
+           allocate(dqdz(nVertLevels))
+            !$omp parallel
+            !$omp do schedule(runtime) private(cell1, cell2, invdcEdge, k, dqdz)
+            do iEdge=1,nEdgesOwned
+               cell1 = cellsOnEdge(1,iEdge)
+               cell2 = cellsOnEdge(2,iEdge)
+               invdcEdge = 1.0_RKIND / dcEdge(iEdge)
+               dqdz(:) = 0.0_RKIND
+
+          !    if(maxLevelEdgeTop(iEdge) > 0) then
+              ! Compute dq/dz (assume q=0 at the surface)
+!               dqdz(1) = 0.25_RKIND*(-2.0_RKIND*nonhydrostaticPressure(1,cell1) / (zMid(1,cell1) - &
+!                          zMid(2,cell1)) - 2.0_RKIND*nonhydrostaticPressure(1,cell2) / &
+!                          (zMid(1,cell2) - zMid(2,cell2)) + (nonhydrostaticPressure(1,cell1) - &
+!                          nonhydrostaticPressure(2,cell1)) / (zMid(1,cell1) - zMid(2,cell1)) + &
+!                          (nonhydrostaticPressure(1,cell2) - nonhydrostaticPressure(2,cell2)) / &
+!                           (zMid(1,cell2) - zMid(2,cell2)))
+!               do k=2,maxLevelEdgeTop(iEdge)-1
+!                  dqdz(k) = 0.5_RKIND*((nonhydrostaticPressure(k-1,cell1) - nonhydrostaticPressure(k+1,cell1)) / &
+!                             (zMid(k-1,cell1) - zMid(k+1,cell1)) + (nonhydrostaticPressure(k-1,cell2) - &
+!                             nonhydrostaticPressure(k+1,cell2)) / (zMid(k-1,cell2) - zMid(k,cell2)))
+!               end do
+!
+!               k = maxLevelEdgeTop(iEdge)
+!               dqdz(k) = 0.25_RKIND*((nonhydrostaticPressure(k-1,cell1) - nonhydrostaticPressure(k,cell1)) / &
+!                          (zMid(k-1,cell1) - zMid(k,cell1)) + (nonhydrostaticPressure(k-1,cell2) - &
+!                          nonhydrostaticPressure(k,cell2)) / (zMid(k-1,cell2) - zMid(k,cell2)) + &
+!                          2.0_RKIND*nonhydrostaticPressure(k,cell1) / (zMid(k-1,cell1) - zMid(k,cell1)) + &
+!                          2.0_RKIND*nonhydrostaticPressure(k,cell2) / (zMid(k-1,cell2) - zMid(k,cell2)))
+
+               !FIXME: may need to revisit later for sloping surfaces, but okay for now
+               !only for strongly varying layer thickness
+               do k=1,maxLevelEdgeTop(iEdge)
+                  tend(k,iEdge) = tend(k,iEdge) + edgeMask(k,iEdge) * invdcEdge * ( &
+                    - ( nonhydrostaticPressure(k,cell2) -             &
+                    nonhydrostaticPressure(k,cell1) ) + 0.0_RKIND*dqdz(k)*density0Inv*        &
+                    (zMid(k,cell2) - zMid(k,cell1)))
+               enddo
+
+           end do
+           !$omp end do
+           !$omp end parallel
+           deallocate(dqdz)
+        endif
       case (pGradTypeMontPot)
 
          ! For pure isopycnal coordinates, this is just grad(M),
@@ -290,6 +339,21 @@ contains
          !$omp end do
          !$omp end parallel
 #endif
+
+         !$omp parallel
+         !$omp do schedule(runtime) private(cell1, cell2, invdcEdge, k)
+         do iEdge=1,nEdgesOwned
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            invdcEdge = 1.0_RKIND / dcEdge(iEdge)
+
+            do k=1,maxLevelEdgeTop(iEdge)
+               tend(k,iEdge) = tend(k,iEdge) + edgeMask(k,iEdge) * invdcEdge * ( &
+                 - ( nonhydrostaticPressure(k,cell2) - nonhydrostaticPressure(k,cell1) ) )
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
 
       case (pGradTypeMontPotDens)
 
@@ -425,8 +489,46 @@ contains
          !$omp end parallel
 #endif
 
-         !$acc exit data delete(JacobianDxDs)
-         deallocate(JacobianDxDs)
+         if(config_enable_nonhydrostatic_mode) then
+            !$omp parallel
+            !$omp do schedule(runtime) private(cell1, cell2, invdcEdge, k)
+            do iEdge=1,nEdgesOwned
+               cell1 = cellsOnEdge(1,iEdge)
+               cell2 = cellsOnEdge(2,iEdge)
+               invdcEdge = 1.0_RKIND / dcEdge(iEdge)
+
+               k=1
+               dqdza = 0.5_RKIND*((nonhydrostaticPressure(k,cell1) - nonhydrostaticPressure(k+1,cell1)          &
+                  ) / (zMid(k,cell1) - zMid(k+1,cell1)) + (nonhydrostaticPressure(k,cell2) - &
+                  nonhydrostaticPressure(k+1,cell2)) / (zMid(k,cell2) - zMid(k+1,cell2)))
+               tend(k,iEdge) = tend(k,iEdge) + edgeMask(k,iEdge) * invdcEdge * ( &
+                  - density0Inv * ( nonhydrostaticPressure(k,cell2) - nonhydrostaticPressure(k,cell1) ) &
+                  - dqdza*( zMid(k,cell2) - zMid(k,cell1) ) )
+
+               do k=2,maxLevelEdgeTop(iEdge)-1
+                  dqdza = 0.5_RKIND*((nonhydrostaticPressure(k-1,cell1) - nonhydrostaticPressure(k+1,cell1)) &
+                    / (zMid(k-1,cell1) - zMid(k+1,cell1)) + (nonhydrostaticPressure(k-1,cell2) - &
+                    nonhydrostaticPressure(k+1,cell2)) / (zMid(k-1,cell2) - zMid(k+1,cell2)))
+
+                  tend(k,iEdge) = tend(k,iEdge) + edgeMask(k,iEdge) * invdcEdge * ( &
+                    - density0Inv * ( nonhydrostaticPressure(k,cell2) - &
+                    nonhydrostaticPressure(k,cell1) ) - dqdza * (zMid(k,cell2) - zMid(k,cell1)))
+               enddo
+               k=maxLevelEdgeTop(iEdge)
+               dqdza = 0.5_RKIND*((nonhydrostaticPressure(k-1,cell1) - nonhydrostaticPressure(k,cell1)) / &
+                 (zMid(k-1,cell1) - zMid(k,cell1)) + (nonhydrostaticPressure(k-1,cell2) - &
+                 nonhydrostaticPressure(k,cell2)) / (zMid(k-1,cell2) - zMid(k,cell1)))
+               tend(k,iEdge) = tend(k,iEdge) + edgeMask(k,iEdge) * invdcEdge * ( &
+                 -density0Inv * ( nonhydrostaticPressure(k,cell2) - nonhydrostaticPressure(k,cell1) ) - &
+                 dqdza * (zMid(k,cell2) - zMid(k,cell1)))
+
+           end do
+           !$omp end do
+           !$omp end parallel
+        endif
+
+        deallocate(JacobianDxDs)
+        !$acc exit data delete(JacobianDxDs)
 
      case (pGradTypeJacobTS)
 
@@ -552,6 +654,44 @@ contains
          !$omp end do
          !$omp end parallel
 #endif
+
+         if(config_enable_nonhydrostatic_mode) then
+            !$omp parallel
+            !$omp do schedule(runtime) private(cell1, cell2, invdcEdge, k)
+            do iEdge=1,nEdgesOwned
+               cell1 = cellsOnEdge(1,iEdge)
+               cell2 = cellsOnEdge(2,iEdge)
+               invdcEdge = 1.0_RKIND / dcEdge(iEdge)
+
+               k=1
+               dqdza = 0.5_RKIND*((nonhydrostaticPressure(k,cell1) - nonhydrostaticPressure(k+1,cell1)          &
+                  ) / (zMid(k,cell1) - zMid(k+1,cell1)) + (nonhydrostaticPressure(k,cell2) - &
+                  nonhydrostaticPressure(k+1,cell2)) / (zMid(k,cell2) - zMid(k+1,cell2)))
+               tend(k,iEdge) = tend(k,iEdge) + edgeMask(k,iEdge) * invdcEdge * ( &
+                  - density0Inv * ( nonhydrostaticPressure(k,cell2) - nonhydrostaticPressure(k,cell1) ) &
+                  - dqdza*( zMid(k,cell2) - zMid(k,cell1) ) )
+
+               do k=2,maxLevelEdgeTop(iEdge)-1
+                  dqdza = 0.5_RKIND*((nonhydrostaticPressure(k-1,cell1) - nonhydrostaticPressure(k+1,cell1)) &
+                    / (zMid(k-1,cell1) - zMid(k+1,cell1)) + (nonhydrostaticPressure(k-1,cell2) - &
+                    nonhydrostaticPressure(k+1,cell2)) / (zMid(k-1,cell2) - zMid(k+1,cell2)))
+
+                  tend(k,iEdge) = tend(k,iEdge) + edgeMask(k,iEdge) * invdcEdge * ( &
+                    - density0Inv * ( nonhydrostaticPressure(k,cell2) - &
+                    nonhydrostaticPressure(k,cell1) ) - dqdza * (zMid(k,cell2) - zMid(k,cell1)))
+               enddo
+               k=maxLevelEdgeTop(iEdge)
+               dqdza = 0.5_RKIND*((nonhydrostaticPressure(k-1,cell1) - nonhydrostaticPressure(k,cell1)) / &
+                 (zMid(k-1,cell1) - zMid(k,cell1)) + (nonhydrostaticPressure(k-1,cell2) - &
+                 nonhydrostaticPressure(k,cell2)) / (zMid(k-1,cell2) - zMid(k,cell1)))
+               tend(k,iEdge) = tend(k,iEdge) + edgeMask(k,iEdge) * invdcEdge * ( &
+                 -density0Inv * ( nonhydrostaticPressure(k,cell2) - nonhydrostaticPressure(k,cell1) ) - &
+                 dqdza * (zMid(k,cell2) - zMid(k,cell1)))
+
+           end do
+           !$omp end do
+           !$omp end parallel
+        endif
 
          !$acc exit data delete (JacobianDxDs, JacobianTz, JacobianSz)
          deallocate(JacobianDxDs, JacobianTz, JacobianSz)

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -142,6 +142,8 @@ contains
 
       err = 0
 
+      if (config_use_two_equation_turbulence_model) return
+
       if (present(timeLevelIn)) then
          timeLevel = timeLevelIn
       else

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -51,8 +51,11 @@ module ocn_vmix
    !
    !--------------------------------------------------------------------
 
+   private :: tridiagonal_solve
+
    public :: ocn_vmix_coefs, &
              ocn_vel_vmix_tend_implicit, &
+             ocn_vertVel_vmix_tend_implicit, &
              ocn_tracer_vmix_tend_implicit, &
              ocn_vmix_init, &
              ocn_vmix_implicit
@@ -512,6 +515,141 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_vel_vmix_tend_implicit!}}}
+
+!***********************************************************************
+!
+   !  routine ocn_verVel_vmix_tend_implicit
+   !
+   !> \brief   Computes tendencies for implicit vertical momentum vertical
+   !mixing
+   !> \author  Luke Van Roekel
+   !> \date    December 2020
+   !> \details
+   !>  This routine computes the tendencies for implicit vertical mixing for
+   !>  vertical momentum using computed coefficients.
+   !
+   !-----------------------------------------------------------------------
+
+   subroutine ocn_vertVel_vmix_tend_implicit(meshPool, dt, vertViscTopOfCell, layerThickness, & !{{{
+                                         verticalVelocity, err)
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: &
+         meshPool          !< Input: mesh information
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         vertViscTopOfCell !< Input: vertical mixing coefficients
+
+      real (kind=RKIND), intent(in) :: &
+         dt            !< Input: time step
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness !< Input: thickness at cell center
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         verticalVelocity             !< Input: velocity
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, k, N, nCells
+      integer, pointer :: nVertLevels
+      integer, dimension(:), pointer :: nCellsArray
+
+      integer, dimension(:), pointer :: maxLevelCell
+      real(kind=RKIND) :: viscAv
+      integer, dimension(:,:), pointer :: cellsOnEdge
+
+      real (kind=RKIND), dimension(:), allocatable :: A, B, C, velTemp
+
+      err = 0
+
+      if(.not.velVmixOn) return
+
+      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+
+      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
+
+      nCells = nCellsArray( 1 )
+
+      allocate(A(nVertLevels+1),B(nVertLevels+1),C(nVertLevels+1),velTemp(nVertLevels+1))
+      A(1) = 0.0_RKIND
+      B(1) = 0.0_RKIND
+      C(1) = 0.0_RKIND
+
+      !$omp parallel
+      !$omp do schedule(runtime) private(viscAv, N, A, B, C, velTemp, k) 
+      do iCell = 1, nCells
+        N = maxLevelCell(iCell)+1
+        if (N .gt. 0) then
+        A(N) = 0.0_RKIND
+        C(N) = 0.0_RKIND
+
+        ! A is lower diagonal term
+        do k = 2, N-1
+            viscAv = 0.5_RKIND*(vertViscTopOfCell(k-1,iCell) + vertViscTopOfCell(k,iCell))
+            A(k) = dt*viscAv / layerThickness(k-1,iCell) / (0.5_RKIND* &
+                    (layerThickness(k-1,iCell) + layerThickness(k,iCell)))
+!            A(k) = -2.0_RKIND*dt*vertViscTopOfEdge(k,iEdge) &
+!               / (layerThicknessEdge(k-1,iEdge) + layerThicknessEdge(k,iEdge)) &
+!               / layerThicknessEdge(k,iEdge)
+         enddo
+         ! C is upper diagonal term
+         do k = 2, N-1
+           viscAv = 0.5_RKIND*(vertViscTopOfCell(k,iCell) + vertViscTopOfCell(k+1,iCell))
+           C(k) = dt*viscAv / layerThickness(k,iCell) / (0.5_RKIND* &
+                   (layerThickness(k,iCell) + layerThickness(k-1,iCell)))
+!            A(k) = -2.0_RKIND*dt*vertViscTopOfEdge(k,iEdge) &
+!            C(k) = -2.0_RKIND*dt*vertViscTopOfEdge(k+1,iEdge) &
+!               / (layerThicknessEdge(k,iEdge) + layerThicknessEdge(k+1,iEdge)) &
+!               / layerThicknessEdge(k,iEdge)
+         enddo
+
+         ! B is diagonal term
+         do k = 1, N
+            B(k) = 1.0_RKIND - A(k) - C(k)
+         enddo
+
+         call tridiagonal_solve(A(2:N),B,C(1:N-1),verticalVelocity(:,iCell),velTemp,N)
+
+         verticalVelocity(1:N,iCell) = velTemp(1:N)
+        end if
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      deallocate(A,B,C,velTemp)
+
+   !--------------------------------------------------------------------
+
+ end subroutine ocn_vertVel_vmix_tend_implicit!}}}
+
 
 !***********************************************************************
 !
@@ -1108,7 +1246,7 @@ contains
 
       integer :: iCell, timeLevel, k, cell1, cell2, iEdge, iTracer, num_tracers, nCells, nEdges, N, Nsurf
       real (kind=RKIND), dimension(:), pointer :: bottomDrag, ssh
-      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, layerThickness
+      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, layerThickness, verticalVelocity
       real (kind=RKIND), dimension(:,:), pointer :: tracerGroupSurfaceFlux
       real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroup
       real (kind=RKIND), dimension(:,:,:), allocatable :: nonLocalFluxTend
@@ -1130,6 +1268,7 @@ contains
 
       call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceFlux', tracersSurfaceFluxPool)
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
+      call mpas_pool_get_array(statePool, 'verticalVelocity', verticalVelocity, timeLevel)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
       call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
 
@@ -1236,6 +1375,20 @@ contains
       !$acc exit data copyout(normalVelocity)
 #endif
       call mpas_timer_stop('vmix solve momentum')
+      !
+      !  If nonhydrostatic is enabled compute vertical velocity diffusion
+      !
+      if (config_enable_nonhydrostatic_mode) then
+         call ocn_vertVel_vmix_tend_implicit(meshPool, dt, vertViscTopOfCell, layerThickness, &
+                                               verticalVelocity, err)
+      endif 
+
+      nEdges = nEdgesOwned 
+      do iEdge=1,nEdges
+         do k=1,nVertLevels
+            velocityVmixTend(k,iEdge) = (normalVelocity(k,iEdge) - velocityvmixtend(k,iEdge)) / dt
+         end do
+      end do
 
       !
       !  Implicit vertical solve for all tracers
@@ -1405,6 +1558,70 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_vmix_init!}}}
+
+!***********************************************************************
+!
+!  routine tridiagonal_solve
+!
+!> \brief   Solve the matrix equation Ax=r for x, where A is tridiagonal.
+!> \author  Mark Petersen
+!> \date    September 2011
+!> \details
+!>  Solve the matrix equation Ax=r for x, where A is tridiagonal.
+!>  A is an nxn matrix, with:
+!>  a sub-diagonal, filled from 1:n-1 (a(1) appears on row 2)
+!>  b diagonal, filled from 1:n
+!>  c sup-diagonal, filled from 1:n-1  (c(1) apears on row 1)
+!
+!-----------------------------------------------------------------------
+   subroutine tridiagonal_solve(a,b,c,r,x,n) !{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      integer,intent(in) :: n
+      real (KIND=RKIND), dimension(n), intent(in) :: a,b,c,r
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (KIND=RKIND), dimension(n), intent(out) :: x
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      real (KIND=RKIND), dimension(n) :: bTemp,rTemp
+      real (KIND=RKIND) :: m
+      integer i
+
+      ! Use work variables for b and r
+      bTemp(1) = b(1)
+      rTemp(1) = r(1)
+
+      ! First pass: set the coefficients
+      do i = 2,n
+         m = a(i-1)/bTemp(i-1)
+         bTemp(i) = b(i) - m*c(i-1)
+         rTemp(i) = r(i) - m*rTemp(i-1)
+      end do
+
+      x(n) = rTemp(n)/bTemp(n)
+       ! Second pass: back-substition
+      do i = n-1, 1, -1
+         x(i) = (rTemp(i) - c(i)*x(i+1))/bTemp(i)
+      end do
+
+   end subroutine tridiagonal_solve !}}}
+
 !***********************************************************************
 
 end module ocn_vmix

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -1347,6 +1347,13 @@ contains
       !$acc update host(vertViscTopOfEdge)
 #endif
 
+      nEdges = nEdgesOwned
+      do iEdge=1,nEdges
+         do k=1,nVertLevels
+            velocityVmixTend(k,iEdge) = normalVelocity(k,iEdge)
+         end do
+      end do
+
       !
       !  Implicit vertical solve for momentum
       !
@@ -1388,7 +1395,7 @@ contains
       nEdges = nEdgesOwned 
       do iEdge=1,nEdges
          do k=1,nVertLevels
-            velocityVmixTend(k,iEdge) = (normalVelocity(k,iEdge) - velocityvmixtend(k,iEdge)) / dt
+            velocityVmixTend(k,iEdge) = (normalVelocity(k,iEdge) - velocityVmixTend(k,iEdge)) / dt
          end do
       end do
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_vvel_advection.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vvel_advection.F
@@ -1,0 +1,167 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_vvel_advection
+!
+!> \brief MPAS ocean vertical velocity advection driver
+!> \authors Luke Van Roekel, Darren Engwirda, Sara Calandrini
+!> \date   November 2021
+!> \details
+!>  This module contains initialization and driver routines for computing (non-hydrostatic) 
+!>  vertical velocity advection tendencies. It is based, in part, on the tracer advection 
+!>  code.
+!>
+!
+!-------------------------------------------------------------------------------
+
+module ocn_vvel_advection
+
+   ! module includes
+   use mpas_kind_types
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_sort
+   use mpas_hash
+   use mpas_timer
+
+   use ocn_vvel_horiz_advection
+   use ocn_vvel_vert_advection
+
+   use ocn_constants
+   use ocn_config
+
+   implicit none
+   private
+   save
+
+   ! public module method interfaces
+   public :: ocn_vvel_advection_init,         &
+             ocn_vvel_advection_tend
+
+   ! privat module variables
+   logical :: vvelAdvOn !< flag to turn on tracer advection
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+
+   contains
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine ocn_vvel_advection_tend
+!
+!> \brief MPAS ocean vertical velocity advection tendency
+!> \author Luke Van Roekel, Darren Engwirda, Sara Calandrini
+!> \date   November 2021
+!> \details
+!>  This routine is the driver routine for computing vvel advection
+!>  tendencies. It simply calls submodule tendency routines based on choice of
+!>  algorithm.
+!
+!-------------------------------------------------------------------------------
+
+   subroutine ocn_vvel_advection_tend(meshPool, verticalVelocity, normalThicknessFlux,       &
+                                        layerThickness, vertAleTransportTop, dt,          &
+                                        tend)!{{{
+
+      implicit none
+
+      !*** Input/Output parameters
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend            !< [in,out] vertical velocity tendency to which advection added
+
+      !*** Input parameters
+
+      type (mpas_pool_type), intent(in) :: &
+         meshPool                     !< [in] mesh information
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         verticalVelocity             !< [in] non-hydrostatic vertical velocity
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalThicknessFlux          !< [in] thickness weighted horizontal velocity
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness               !< [in] thickness field at cell centers
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         vertAleTransportTop          !< [in] velocity through layer top levels
+      real (kind=RKIND), intent(in) :: &
+         dt                           !< [in] time-step
+
+      ! end of preamble
+      !----------------
+      ! begin code
+
+      ! immediate return if tracer advection not selected
+      if(.not. vvelAdvOn) return
+
+      call mpas_timer_start("Vertical Velocity adv")
+
+      call ocn_vvel_horiz_advection_tend(verticalVelocity, normalThicknessFlux, &
+         layerThickness, dt, meshPool, tend)
+
+      call ocn_vvel_vert_advection_tend(verticalVelocity, layerThickness, dt, &
+         vertAleTransportTop, tend)
+
+      call mpas_timer_stop("Vertical Velocity adv")
+
+   end subroutine ocn_vvel_advection_tend!}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine ocn_vvel_advection_init
+!
+!> \brief MPAS ocean vertical velocity advection tendency
+!> \author Luke Van Roekel, Darren Engwirda, Sara Calandrini
+!> \date   November 2021
+!> \details
+!>  This routine is the driver for initializing various (non-hydrostatic) 
+!>  vertical velocity advection choices and variables.
+!
+!-------------------------------------------------------------------------------
+
+   subroutine ocn_vvel_advection_init(err)!{{{
+
+      implicit none
+
+      !*** output parameters
+
+      integer, intent(out) :: err !< [out] Error flag
+
+      ! end preamble
+      !-------------
+      ! begin code
+
+      err = 0 ! initialize error code to success
+
+      ! set some basic flags for options
+      vvelAdvOn = .not. config_disable_vvel_adv
+
+      ! set all other options from submodule initialization routines
+      if (err.eq.0) then     
+         call ocn_vvel_horiz_advection_init(err)
+      end if 
+
+      if (err.eq.0) then
+         call ocn_vvel_vert_advection_init (err)
+      end if 
+
+      ! if an error is returned from init routines, write an error
+      ! message and return a non-zero error code
+      if (err /= 0) then 
+         err = 1
+         call mpas_log_write(                                 &
+            'Error encountered during vertical velocity advection init', &
+            MPAS_LOG_ERR, masterOnly=.true.)
+      endif
+
+   end subroutine ocn_vvel_advection_init!}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+
+end module ocn_vvel_advection
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-ocean/src/shared/mpas_ocn_vvel_coriolis.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vvel_coriolis.F
@@ -1,0 +1,199 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_vel_hadv_coriolis
+!
+!> \brief MPAS ocean tendency of coriolis for vertical momentum equation
+!> \author Luke Van Roekel, Darren Engwirda, Sara Calandrini
+!> \date   December 2020, updated November 2021
+!> \details
+!>  This module contains the routine for computing
+!>  tendencies from the vertical momentum coriolis force.
+!>
+!
+!-----------------------------------------------------------------------
+
+module ocn_vvel_coriolis
+
+   use mpas_timer
+   use mpas_derived_types
+   use mpas_pool_routines
+   use ocn_constants
+   use ocn_config
+   use mpas_constants
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: ocn_vvel_coriolis_tend, &
+             ocn_vvel_coriolis_init
+
+   !--------------------------------------------------------------------
+   !
+   ! Private module variables
+   !
+   !--------------------------------------------------------------------
+
+   logical :: vertCoriolisOn
+
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+!
+!  routine ocn_vvel_coriolis_tend
+!
+!> \brief   Computes tendency term for coriolis force for vertical momentum equation
+!> \author  Luke Van Roekel
+!> \date    January 2021
+!> \details
+!>  This routine computes the coriolis tendencies for vertical momentum based 
+!>  on current state.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_vvel_coriolis_tend(meshPool, velocityZonal, tend, err)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         velocityZonal    !< Input: Horizontal velocity
+
+      type (mpas_pool_type), intent(in) :: &
+         meshPool          !< Input: mesh information
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend          !< Input/Output: velocity tendency
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+ 
+      integer, dimension(:), pointer :: maxLevelCell      
+
+      integer :: k, iCell, nCells 
+      integer, pointer :: nVertLevels
+      integer, dimension(:), pointer :: nCellsArray
+      real (kind=RKIND) :: fCellExtended
+      real (kind=RKIND), dimension(:), pointer :: latCell 
+
+      err = 0
+
+      if ( .not. vertCoriolisOn ) return
+
+      call mpas_timer_start("vertical velocity coriolis")
+
+      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+
+      call mpas_pool_get_array(meshPool, 'latCell', latCell)
+
+      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+
+      nCells = nCellsArray( 2 )
+
+      !FIXME: zonalvelocity may be a bad choice here as it's not updated during a 
+      !timestep but maybe not the worst assumption.
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(k, iCell, fCellExtended) 
+      do iCell= 1, nCells
+
+         fCellExtended = 2.0_RKIND * omega * cos(latCell(iCell))
+
+         tend(1,iCell) = tend(1,iCell) + fCellExtended * velocityZonal(1,iCell)
+
+         do k = 2, maxLevelCell(iCell)
+            tend(k,iCell) = tend(k,iCell) + 0.5_RKIND * &
+               fCellExtended * (velocityZonal(k,iCell) + velocityZonal(k-1,iCell))
+         end do
+
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      call mpas_timer_stop("vertical velocity coriolis")
+
+   !--------------------------------------------------------------------
+
+ end subroutine ocn_vvel_coriolis_tend!}}}
+
+!***********************************************************************
+!
+!  routine ocn_vvel_pgf_init
+!
+!> \brief   Initializes ocean vertical momentum PGF tendencies
+!> \author  Luke Van Roekel
+!> \date    January 2021
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_vvel_coriolis_init(err)!{{{
+
+   !--------------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      !
+      ! Output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      err = 0
+
+      vertCoriolisOn = .true.
+      if ( config_disable_vvel_coriolis .or.  &
+          .not. config_enable_nonhydrostatic_mode ) vertCoriolisOn = .false.
+
+   !--------------------------------------------------------------------
+
+ end subroutine ocn_vvel_coriolis_init!}}}
+
+!***********************************************************************
+
+end module ocn_vvel_coriolis
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+! vim: foldmethod=marker

--- a/components/mpas-ocean/src/shared/mpas_ocn_vvel_hmix_del2.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vvel_hmix_del2.F
@@ -1,0 +1,256 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_tracer_hmix_del2
+!
+!> \brief MPAS ocean horizontal tracer mixing driver
+!> \author Doug Jacobsen, Mark Petersen, Todd Ringler
+!> \date   September 2011
+!> \details
+!>  This module contains the main driver routine for computing
+!>  horizontal mixing tendencies.
+!>
+!>  It provides an init and a tend function. Each are described below.
+!
+!-----------------------------------------------------------------------
+
+module ocn_vvel_hmix_del2
+
+   use mpas_timer
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_threading
+
+   use ocn_constants
+   use ocn_config
+   use ocn_mesh
+   use ocn_diagnostics_variables
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: ocn_vvel_hmix_del2_tend, &
+             ocn_vvel_hmix_del2_init
+
+   !--------------------------------------------------------------------
+   !
+   ! Private module variables
+   !
+   !--------------------------------------------------------------------
+
+   logical :: del2On
+   real (kind=RKIND) :: eddyVisc2
+   real (kind=RKIND), dimension(:,:), allocatable :: eddyViscArr
+
+
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+!
+!  routine vvel_hmix_del2_tend
+!
+!> \brief   Computes Laplacian tendency term for horizontal vertical velocity mixing
+!> \author  Luke Van Roekel -- Copied from tracer_hmix_del2
+!> \date    December 2020
+!> \details
+!>  This routine computes the horizontal mixing tendency for vertical velocity
+!>  based on current state using a Laplacian parameterization.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_vvel_hmix_del2_tend(layerThicknessEdge, verticalVelocity, tend, err)!{{{
+
+      implicit none
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThicknessEdge !< Input: thickness at edges
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+        verticalVelocity !< Input: tracer quantities
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend          !< Input/Output: velocity tendency
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, iEdge, cell1, cell2
+      integer :: i, k, nCells, nEdges
+
+      real (kind=RKIND) :: invAreaCell
+      real (kind=RKIND) :: vvel_turb_flux, flux, r_tmp
+
+      err = 0
+
+      if (.not.del2On) return
+
+      call mpas_timer_start("vertical velocity del2")
+
+      nCells = nCellsOwned
+      nEdges = nEdgesHalo( 1 )
+
+      allocate(eddyViscArr(nVertLevels+1, nEdges))
+
+!      if(config_use_two_equation_turbulence_model) then
+!         ! Put viscosity into an array
+!         !$omp parallel
+!         !$omp schedule(runtime) private(k,i,iEdge,cell1,cell2)
+!         do iCell = 1, nCells
+!            do i = 1, nEdgesOnCell(iCell)
+!               iEdge = edgesOnCell(i, iCell)
+!               cell1 = cellsOnEdge(1,iEdge)
+!               cell2 = cellsOnEdge(2,iEdge)
+!               do k=1,maxLevelEdgeTop(iEdge)-1
+!                  eddyViscArr(k,iEdge) = 0.25_RKIND*(vertViscTopOfCell(k,cell1) + &
+!                                      vertViscTopOfCell(k,cell2) + vertViscTopOfCell(k+1,cell1) + &
+!                                      vertViscTopOfCell(k+1,cell2))
+!               end do
+!               eddyViscArr(maxLevelEdgeTop(iEdge), iEdge) = eddyViscArr(maxLevelEdgeTop(iEdge)-1,iEdge)
+!               eddyViscArr(maxLevelEdgeTop(iEdge)+1, iEdge) = 0.0_RKIND
+!            end do
+!         end do
+!         !$omp end do
+!         !$omp end parallel
+!      else !constant del2
+!         !$omp parallel
+!         !$omp schedule(runtime) private(k)
+!         do iEdge=1,nEdges
+!            do k=1,maxLevelEdgeTop(iEdge)
+!               eddyViscArr(k,iEdge) = meshScalingDel2(iEdge)*eddyVisc2
+!            end do
+!         end do
+!         !$omp end do
+!         !$omp end parallel
+!      end if
+
+      !
+      ! compute a boundary mask to enforce insulating boundary conditions in the horizontal
+      !
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(invAreaCell, i, iEdge, cell1, cell2, r_tmp, k, &
+      !$omp         vvel_turb_flux, flux)
+      do iCell = 1, nCells
+        invAreaCell = 1.0_RKIND / areaCell(iCell)
+        do i = 1, nEdgesOnCell(iCell)
+          iEdge = edgesOnCell(i, iCell)
+          cell1 = cellsOnEdge(1,iEdge)
+          cell2 = cellsOnEdge(2,iEdge)
+
+          !r_tmp = dvEdge(iEdge) / dcEdge(iEdge)
+          r_tmp = meshScalingDel2(iEdge) * eddyVisc2 * dvEdge(iEdge) / dcEdge(iEdge)
+
+          do k = 2, maxLevelEdgeTop(iEdge)
+              ! \kappa_2 \nabla \phi on edge
+              vvel_turb_flux = verticalVelocity(k, cell2) - verticalVelocity(k, cell1)
+
+              ! div(h \kappa_2 \nabla \phi) at cell center
+              flux = 0.5_RKIND*(layerThicknessEdge(k, iEdge) + layerThicknessEdge(k-1,iEdge)) &
+                        * vvel_turb_flux * r_tmp
+
+              !tend(k, iCell) = tend(k, iCell) - eddyViscArr(k,iEdge) * edgeSignOnCell(i, iCell) * flux * invAreaCell
+              tend(k, iCell) = tend(k, iCell) - edgeSignOnCell(i, iCell) * flux * invAreaCell
+          end do
+        end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      deallocate(eddyViscArr)
+      call mpas_timer_stop("vertical velocity del2")
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_vvel_hmix_del2_tend!}}}
+
+!***********************************************************************
+!
+!  routine ocn_vvel_hmix_del2_init
+!
+!> \brief   Initializes ocean vertical velocity horizontal mixing quantities
+!> \author  Doug Jacobsen, Mark Petersen, Todd Ringler
+!> \date    September 2011
+!> \details
+!>  This routine initializes a variety of quantities related to
+!>  Laplacian horizontal velocity mixing in the ocean.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_vvel_hmix_del2_init(err)!{{{
+
+   !--------------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      !
+      ! call individual init routines for each parameterization
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      err = 0
+
+      del2on = .false.
+
+      !if ( config_use_vertMom_del2 .or. config_use_two_equation_turbulence_model ) then
+      if ( config_use_vertMom_del2 ) then
+         if ( config_vertMom_del2 > 0.0_RKIND ) then
+            del2On = .true.
+            eddyVisc2 = config_vertMom_del2
+         endif
+      endif
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_vvel_hmix_del2_init!}}}
+
+!***********************************************************************
+
+end module ocn_vvel_hmix_del2
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+! vim: foldmethod=marker

--- a/components/mpas-ocean/src/shared/mpas_ocn_vvel_hmix_del2.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vvel_hmix_del2.F
@@ -138,7 +138,8 @@ contains
       if(config_use_two_equation_turbulence_model) then
          ! Put viscosity into an array
          !$omp parallel
-         !$omp schedule(runtime) private(k,i,iEdge,cell1,cell2)
+         !$omp do schedule(runtime) &
+         !$omp private(k,i,iEdge,cell1, cell2)
          do iCell = 1, nCells
             do i = 1, nEdgesOnCell(iCell)
                iEdge = edgesOnCell(i, iCell)
@@ -157,7 +158,8 @@ contains
          !$omp end parallel
       else !constant del2
          !$omp parallel
-         !$omp schedule(runtime) private(k)
+         !$omp do schedule(runtime) &
+         !$omp private(k)
          do iEdge=1,nEdges
             do k=1,maxLevelEdgeTop(iEdge)
                eddyViscArr(k,iEdge) = meshScalingDel2(iEdge)*eddyVisc2

--- a/components/mpas-ocean/src/shared/mpas_ocn_vvel_hmix_del2.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vvel_hmix_del2.F
@@ -135,37 +135,37 @@ contains
 
       allocate(eddyViscArr(nVertLevels+1, nEdges))
 
-!      if(config_use_two_equation_turbulence_model) then
-!         ! Put viscosity into an array
-!         !$omp parallel
-!         !$omp schedule(runtime) private(k,i,iEdge,cell1,cell2)
-!         do iCell = 1, nCells
-!            do i = 1, nEdgesOnCell(iCell)
-!               iEdge = edgesOnCell(i, iCell)
-!               cell1 = cellsOnEdge(1,iEdge)
-!               cell2 = cellsOnEdge(2,iEdge)
-!               do k=1,maxLevelEdgeTop(iEdge)-1
-!                  eddyViscArr(k,iEdge) = 0.25_RKIND*(vertViscTopOfCell(k,cell1) + &
-!                                      vertViscTopOfCell(k,cell2) + vertViscTopOfCell(k+1,cell1) + &
-!                                      vertViscTopOfCell(k+1,cell2))
-!               end do
-!               eddyViscArr(maxLevelEdgeTop(iEdge), iEdge) = eddyViscArr(maxLevelEdgeTop(iEdge)-1,iEdge)
-!               eddyViscArr(maxLevelEdgeTop(iEdge)+1, iEdge) = 0.0_RKIND
-!            end do
-!         end do
-!         !$omp end do
-!         !$omp end parallel
-!      else !constant del2
-!         !$omp parallel
-!         !$omp schedule(runtime) private(k)
-!         do iEdge=1,nEdges
-!            do k=1,maxLevelEdgeTop(iEdge)
-!               eddyViscArr(k,iEdge) = meshScalingDel2(iEdge)*eddyVisc2
-!            end do
-!         end do
-!         !$omp end do
-!         !$omp end parallel
-!      end if
+      if(config_use_two_equation_turbulence_model) then
+         ! Put viscosity into an array
+         !$omp parallel
+         !$omp schedule(runtime) private(k,i,iEdge,cell1,cell2)
+         do iCell = 1, nCells
+            do i = 1, nEdgesOnCell(iCell)
+               iEdge = edgesOnCell(i, iCell)
+               cell1 = cellsOnEdge(1,iEdge)
+               cell2 = cellsOnEdge(2,iEdge)
+               do k=1,maxLevelEdgeTop(iEdge)-1
+                  eddyViscArr(k,iEdge) = 0.25_RKIND*(vertViscTopOfCell(k,cell1) + &
+                                      vertViscTopOfCell(k,cell2) + vertViscTopOfCell(k+1,cell1) + &
+                                      vertViscTopOfCell(k+1,cell2))
+               end do
+               eddyViscArr(maxLevelEdgeTop(iEdge), iEdge) = eddyViscArr(maxLevelEdgeTop(iEdge)-1,iEdge)
+               eddyViscArr(maxLevelEdgeTop(iEdge)+1, iEdge) = 0.0_RKIND
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
+      else !constant del2
+         !$omp parallel
+         !$omp schedule(runtime) private(k)
+         do iEdge=1,nEdges
+            do k=1,maxLevelEdgeTop(iEdge)
+               eddyViscArr(k,iEdge) = meshScalingDel2(iEdge)*eddyVisc2
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
+      end if
 
       !
       ! compute a boundary mask to enforce insulating boundary conditions in the horizontal
@@ -181,8 +181,8 @@ contains
           cell1 = cellsOnEdge(1,iEdge)
           cell2 = cellsOnEdge(2,iEdge)
 
-          !r_tmp = dvEdge(iEdge) / dcEdge(iEdge)
-          r_tmp = meshScalingDel2(iEdge) * eddyVisc2 * dvEdge(iEdge) / dcEdge(iEdge)
+          !r_tmp = meshScalingDel2(iEdge) * eddyVisc2 * dvEdge(iEdge) / dcEdge(iEdge)
+          r_tmp = dvEdge(iEdge) / dcEdge(iEdge)
 
           do k = 2, maxLevelEdgeTop(iEdge)
               ! \kappa_2 \nabla \phi on edge
@@ -192,8 +192,8 @@ contains
               flux = 0.5_RKIND*(layerThicknessEdge(k, iEdge) + layerThicknessEdge(k-1,iEdge)) &
                         * vvel_turb_flux * r_tmp
 
-              !tend(k, iCell) = tend(k, iCell) - eddyViscArr(k,iEdge) * edgeSignOnCell(i, iCell) * flux * invAreaCell
-              tend(k, iCell) = tend(k, iCell) - edgeSignOnCell(i, iCell) * flux * invAreaCell
+              !tend(k, iCell) = tend(k, iCell) - edgeSignOnCell(i, iCell) * flux * invAreaCell
+              tend(k, iCell) = tend(k, iCell) - eddyViscArr(k,iEdge) * edgeSignOnCell(i, iCell) * flux * invAreaCell
           end do
         end do
       end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_vvel_horiz_advection.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vvel_horiz_advection.F
@@ -1,0 +1,187 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_vvel_horiz_advection
+!
+!> \brief MPAS horizontal advection for (non-hydrostatic) vertical velocity
+!> \author Luke Van Roekel, Darren Engwirda, Sara Calandrini
+!> \date   January 2021, updated Novermber 2021
+!> \details
+!>  This module contains routines for horizontal advection of vertical velocity
+!>  via a simple TRiSK-type scheme at vertical levels (ie. half-layers).
+!
+!-------------------------------------------------------------------------------
+
+module ocn_vvel_horiz_advection
+
+   ! module includes
+   use mpas_kind_types
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_io_units
+   use mpas_threading
+   use ocn_config
+   use ocn_mesh
+   use ocn_tracer_advection_shared
+   use ocn_diagnostics_variables
+
+   implicit none
+   private
+   save 
+
+   ! public method interfaces
+   public :: ocn_vvel_horiz_advection_tend, &
+             ocn_vvel_horiz_advection_init
+
+   contains
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine ocn_vvel_horiz_advection_tend
+!
+!> \brief MPAS horizontal advection tendency for (non-hydrostatic) vertical velocity
+!> \author Luke Van Roekel, Darren Engwirda, Sara Calandrini
+!> \date   12/21/20, updated 11/19/2021
+!> \details
+!>  NOTE this is only active for non-hydrostatic mode
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_vvel_horiz_advection_tend(verticalVelocity, &
+      normalThicknessFlux, layerThickness, dt, meshPool, tend)!{{{ 
+
+      implicit none
+
+      !*** input parameters
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         verticalVelocity                   !< [in] non-hydrostatic vertical velocity
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalThicknessFlux                !< [in] normal thickness flux uh at edges
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness                     !< [in] layer thickness at cells
+      real (kind=RKIND), intent(in) :: dt   !< [in] time-step
+      type (mpas_pool_type), intent(in) :: meshPool !< [in] mesh information
+
+      !*** output parameters
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend                                       !< [out] vvel tendencies
+
+      integer :: iCell, iEdge, jEdge, k, cell1, cell2
+      integer :: nVertLevels, nCells, nEdges
+      real (kind=RKIND) :: vertVelocityFlux
+ 
+      real (kind=RKIND), dimension(:), allocatable :: invVolCell
+      real (kind=RKIND), dimension(:,:), allocatable :: horizFlux
+
+      ! Get dimensions
+      nVertLevels = size(verticalVelocity,dim=1)
+
+      ! Initialize pointers
+      nCells = nCellsHalo( 1 ) !1
+      nEdges = nEdgesHalo( 2 ) !2
+      allocate(invVolCell(nVertLevels))
+      allocate(horizFlux(nVertLevels, nEdges)) 
+
+      !$omp parallel
+      !$omp do schedule(runtime)
+      do iEdge = 1, nEdges
+         horizFlux(:, iEdge) = 0.0_RKIND
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      ! compute edge fluxes for div(u*h*w)
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(k, cell1, cell2, vertVelocityFlux)
+      do iEdge = 1, nEdges 
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+         do k = 1, maxLevelEdgeTop(iEdge)
+            if (k .gt. 1) then
+               vertVelocityFlux = &
+                  0.5_RKIND * (normalThicknessFlux(k-1,iEdge) + &
+                               normalThicknessFlux(k-0,iEdge)) * &
+                  0.5_RKIND * (verticalVelocity(k,cell1) + verticalVelocity(k,cell2))
+            else
+               vertVelocityFlux = & ! surface
+                  1.0_RKIND * (normalThicknessFlux(k-0,iEdge)) * &
+                  0.5_RKIND * (verticalVelocity(k,cell1) + verticalVelocity(k,cell2))
+            end if
+
+            horizFlux(k,iEdge) = &
+               edgeMask(k,iEdge) * dvEdge(iEdge) * vertVelocityFlux
+         end do
+      end do
+      !$omp end do
+      !$omp end parallel
+     
+      ! eval. tendencies as div(u*h*w) / (A*h)
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(k, iEdge, jEdge, invVolCell)
+      do iCell = 1, nCells
+         invVolCell(:) =-1.0e34_RKIND
+         invVolCell(1) = 1.0_RKIND / (areaCell(iCell) * layerThickness(1,iCell))
+         do k = 2, maxLevelCell(iCell)
+            invVolCell(k) = 2.0_RKIND / ( &
+               areaCell(iCell) * (layerThickness(k-1,iCell) + layerThickness(k-0,iCell)))
+         end do
+
+         do jEdge = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(jEdge,iCell)
+            do k = 1, maxLevelEdgeTop(iEdge)
+               tend(k,iCell) = tend(k,iCell) + &
+                  edgeSignOnCell(jEdge,iCell) * invVolCell(k) * horizFlux(k,iEdge)  
+            end do
+         end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      deallocate(horizFlux)
+      deallocate(invVolCell) 
+
+   end subroutine ocn_vvel_horiz_advection_tend!}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine ocn_vvel_horiz_advection_init
+!
+!> \brief MPAS initialize vertical velocity advection tendency.
+!> \author Luke Van Roekel, Darren Engwirda, Sara Calandrini
+!> \date   12/21/2020, updated 11/19/2021
+!> \details
+!>  This routine initializes constants and choices for the (non-hydrostatic) 
+!>  vertical velocity advection tendency
+!
+!-------------------------------------------------------------------------------
+
+   subroutine ocn_vvel_horiz_advection_init(err) !{{{ 
+
+      implicit none
+
+      !*** input parameters 
+
+      !*** output parameters
+
+      integer, intent(out) :: err !< [out] Error Flag
+
+      err = 0 ! set error code to success
+     
+      ! don't have actual choices for vvel advection here, unlike tracers       
+
+   end subroutine ocn_vvel_horiz_advection_init!}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+
+end module ocn_vvel_horiz_advection
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-ocean/src/shared/mpas_ocn_vvel_pgrad.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vvel_pgrad.F
@@ -1,0 +1,190 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_vvel_pgrad
+!
+!> \brief MPAS ocean tendency of pressure gradient force for vertical momentum equation
+!> \author Luke Van Roekel, Darren Engwirda, Sara Calandrini
+!> \date   January 2021, updated November 2021
+!> \details
+!>  This module contains the routine for computing
+!>  tendencies from the vertical momentum coriolis force.
+!>
+!
+!-----------------------------------------------------------------------
+
+module ocn_vvel_pgrad
+
+   use mpas_timer
+   use mpas_derived_types
+   use mpas_pool_routines
+   use ocn_constants
+   use ocn_config
+   use ocn_diagnostics_variables
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: ocn_vvel_pgf_tend, &
+             ocn_vvel_pgf_init
+
+   !--------------------------------------------------------------------
+   !
+   ! Private module variables
+   !
+   !--------------------------------------------------------------------
+
+   logical :: vertPGFOn
+
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+!
+!  routine ocn_vvel_pgf_tend
+!
+!> \brief   Computes tendency term for pressure gradient in vertical momentum equation
+!> \author  Luke Van Roekel, Darren Engwirda, Sara Calandrini
+!> \date    January 2021, updated November 2021
+!> \details
+
+!>  This routine computes the PGF tendencies for the vertical momentum based on 
+!>  current state.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_vvel_pgf_tend(meshPool, layerThickness, nhPressure, tend, err)!{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness                     !< Input: layer thickness at cells
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         nhPressure                         !< Input: pressure (nonhydrostatic)        
+
+      type (mpas_pool_type), intent(in) :: &
+         meshPool           !< Input: mesh information
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend          !< Input/Output: velocity tendency
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: j, k, i, iCell, nCells
+      integer, pointer :: nVertLevels
+      integer, dimension(:), pointer :: maxLevelCell, nCellsArray
+
+      err = 0
+
+      if ( .not. vertPGFOn ) return
+
+      call mpas_timer_start("vertical velocity PGF")
+
+      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+
+      nCells = nCellsArray( 2 )
+
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(k)
+      do iCell= 1, nCells
+         tend(1,iCell) = tend(1,iCell) - & ! nhPressure = 0.0 at surface
+            2.0_RKIND * (-nhPressure(1,iCell)) / layerThickness(1,iCell)
+         do k = 2, maxLevelCell(iCell)
+            tend(k,iCell) = tend(k,iCell) - &
+               2.0_RKIND * (nhPressure(k-1,iCell) - nhPressure(k,iCell)) &
+                  / (layerThickness(k-1,iCell) + layerThickness(k,iCell)) 
+         end do
+
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      call mpas_timer_stop("vertical velocity PGF")
+
+   !--------------------------------------------------------------------
+
+ end subroutine ocn_vvel_pgf_tend!}}}
+
+!***********************************************************************
+!
+!  routine ocn_vvel_pgf_init
+!
+!> \brief   Initializes ocean momentum PGF tendencies
+!> \author  Luke Van Roekel
+!> \date    January 2021
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_vvel_pgf_init(err)!{{{
+
+   !--------------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      !
+      ! Output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      err = 0
+
+      vertPGFOn = .true.
+      if ( .not. config_enable_nonhydrostatic_mode ) vertPGFOn = .false.
+
+   !--------------------------------------------------------------------
+
+ end subroutine ocn_vvel_pgf_init!}}}
+
+!***********************************************************************
+
+end module ocn_vvel_pgrad
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+! vim: foldmethod=marker

--- a/components/mpas-ocean/src/shared/mpas_ocn_vvel_vert_advection.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vvel_vert_advection.F
@@ -1,0 +1,135 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_vvel_vert_advection
+!
+!> \brief MPAS vertical advection for (non-hydrostatic)
+!> \author Luke Van Roekel, Darren Engwirda, Sara Calandrini
+!> \date   January 2021
+!> \details
+!>  This module contains routines for advection of (non-hydrostatic) vertical 
+!>  velocity.
+!
+!-------------------------------------------------------------------------------
+
+module ocn_vvel_vert_advection
+
+   ! module includes
+   use mpas_kind_types
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_io_units
+   use mpas_threading
+   use ocn_mesh
+   use ocn_tracer_advection_shared
+
+   implicit none
+   private
+   save
+
+   ! public method interfaces
+   public :: ocn_vvel_vert_advection_tend, &
+             ocn_vvel_vert_advection_init
+
+   contains
+
+!||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine ocn_vvel_vert_advection_tend
+!
+!> \brief MPAS vertical advection tendency for (non-hydrostatic) vertical velocity
+!> \author Luke Van Roekel, Darren Engwirda, Sara Calandrini
+!> \date   12/22/2020, updated 11/20/2021
+!> \details
+!>  NOTE this is only active for non-hydrostatic mode
+!
+!-----------------------------------------------------------------------
+   
+   subroutine ocn_vvel_vert_advection_tend(verticalVelocity, layerThickness, dt, &
+      vertAleTransportTop, tend)!{{{
+
+      implicit none 
+
+      !*** input parameters 
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: & 
+         verticalVelocity !< Input: non-hydrostatic vertical velocity
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness !< Input: layer thickness at cells
+      real (kind=RKIND), intent(in) :: dt !< Input: time-step
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         vertAleTransportTop !< Input: velocity through layer top levels
+      
+      !*** output parameters
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend !< Output: vvel tendencies
+
+      integer :: iCell, k 
+      real (kind=RKIND) :: levelThickness, vertVelocityUp, vertVelocityDn
+
+      ! -w_ale * dw/dz
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(k, levelThickness, vertVelocityUp, vertVelocityDn)
+      do iCell = 1, nCellsOwned
+         ! w_ale = 0.0 at k==1
+         do k = 2, maxLevelCell(iCell)
+            levelThickness = &
+               0.5_RKIND * (layerThickness(k-1,iCell) + layerThickness(k,iCell))
+
+            vertVelocityUp = &
+               0.5_RKIND * (verticalVelocity(k-1,iCell) + verticalVelocity(k,iCell))
+            vertVelocityDn = &
+               0.5_RKIND * (verticalVelocity(k+1,iCell) + verticalVelocity(k,iCell))
+
+            tend(k,iCell) = tend(k,iCell) - &
+               vertAleTransportTop(k,iCell) * &
+                  (vertVelocityUp - vertVelocityDn) / levelThickness
+         end do
+      end do
+      !$omp end do
+      !$omp end parallel
+
+   end subroutine ocn_vvel_vert_advection_tend!}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine ocn_vvel_vert_advection_init
+!
+!> \brief MPAS initialize vertical velocity advection tendency.
+!> \author Luke Van Roekel, Darren Engwirda, Sara Calandrini
+!> \date   January 2021, updated November 2021
+!> \details
+!>  This routine initializes constants and choices for the (non-hydrostatic) 
+!>  vertical velocity advection tendency
+!
+!-------------------------------------------------------------------------------
+
+   subroutine ocn_vvel_vert_advection_init(err) !{{{
+
+      implicit none
+
+      !*** input parameters
+
+      !*** output parameters
+
+      integer, intent(out) :: err !< [out] Error Flag  
+
+      err = 0 ! set error code to success
+
+      ! don't have actual choices for vvel advection here, unlike tracers
+
+   end subroutine ocn_vvel_vert_advection_init!}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+
+end module ocn_vvel_vert_advection
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||


### PR DESCRIPTION
This is a nonhydrostatic version of MPAS-O. This nonhydrostatic model enables new physics, allowing the correct representation of, for example, high-resolution internal waves dynamics, which are not well represented by the hydrostatic approximation. New vertical momentum and pressure terms are added in the formulation, and a coupled elliptic system is formed for the solution of the nonhydrostatic pressure correction. At every time step, this system is solved with the PETSc library using preconditioned iterative Krylov solvers. The flag _config_enable_nonhydrostatic_mode_ can be used to turn on and off the nonhydrostatic capabilities.