### PR TITLE
Homme: Rework HOMME_ENABLE_COMPOSE symbol machinery for use in EAMxx.

### DIFF
--- a/components/homme/CMakeLists.txt
+++ b/components/homme/CMakeLists.txt
@@ -436,7 +436,6 @@ if (HOMME_ENABLE_COMPOSE)
     # Fortran dycore(s) and the homme_tool exec do need composef90
     set (HOMME_BUILD_COMPOSE_F90 TRUE)
   endif()
-  add_definitions(-DHOMME_ENABLE_COMPOSE)
 else ()
   message (STATUS "COMPOSE semi-Lagrangian transport was explicitly disabled")
 endif()

--- a/components/homme/src/share/compose_mod.F90
+++ b/components/homme/src/share/compose_mod.F90
@@ -1,3 +1,7 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 module compose_mod
 
   implicit none

--- a/components/homme/src/share/cxx/ComposeTransportImplTrajectory.cpp
+++ b/components/homme/src/share/cxx/ComposeTransportImplTrajectory.cpp
@@ -310,6 +310,16 @@ KOKKOS_FUNCTION static void calc_vertically_lagrangian_levels (
 #endif
     };
     cti::loop_ijk<cti::num_lev_pack>(kv, f_v);
+    if (cti::num_lev_pack == cti::max_num_lev_pack) {
+      // Re-zero eta_dot_dpdn at bottom.
+      RNlevp edds(cti::pack2real(edd));
+      const auto f = [&] (const int idx) {
+        const int i = idx / NP, j = idx % NP;
+        const int bottom = cti::num_phys_lev;
+        edds(i,j,bottom) = 0;
+      };
+      parallel_for(ttr, f);
+    }
   }
 
   reconstruct_and_limit_dp(kv, dp3d, dt, dp_tol, *eta_dot_dpdn[0], dprecon);

--- a/components/homme/src/theta-l/config.h.cmake.in
+++ b/components/homme/src/theta-l/config.h.cmake.in
@@ -74,3 +74,6 @@
 
 /* Detect whether this is a kokkos target */
 #cmakedefine01 KOKKOS_TARGET
+
+/* Detect whether COMPOSE passive tracer transport is enabled */
+#cmakedefine HOMME_ENABLE_COMPOSE

--- a/components/homme/src/theta-l_kokkos/config.h.cmake.in
+++ b/components/homme/src/theta-l_kokkos/config.h.cmake.in
@@ -72,3 +72,6 @@
 
 /* Detect whether this is a kokkos target */
 #cmakedefine01 KOKKOS_TARGET
+
+/* Detect whether COMPOSE passive tracer transport is enabled */
+#cmakedefine HOMME_ENABLE_COMPOSE

--- a/components/homme/src/tool/config.h.cmake.in
+++ b/components/homme/src/tool/config.h.cmake.in
@@ -35,3 +35,6 @@
 
 /* Quadruple-precision */
 #cmakedefine01 HOMME_QUAD_PREC
+
+/* Detect whether COMPOSE passive tracer transport is enabled */
+#cmakedefine HOMME_ENABLE_COMPOSE


### PR DESCRIPTION
Modify how HOMME_ENABLE_COMPOSE is defined in HOMME's cmake system, affecting standalone HOMME and EAMxx. This enables running SL transport in EAMxx v1.

[BFB]