### PR TITLE
Add CRM variance transport of momentum

### DIFF
--- a/components/eam/bld/configure
+++ b/components/eam/bld/configure
@@ -1455,8 +1455,8 @@ else {
 
         # MMF variance transport tracers
         if (defined $opts{'use_MMF_VT'}) {
-            $nadv += 2; # add tracers for CRM t and q variance transport
-            if ($print>=2) { print "Advected variance constituent added for MMF: 2$eol"; }
+            $nadv += 3; # add tracers for CRM variance transport if t, q, and u
+            if ($print>=2) { print "Advected variance constituent added for MMF: 3$eol"; }
         }
 
     }

--- a/components/eam/src/physics/crm/crm_history.F90
+++ b/components/eam/src/physics/crm/crm_history.F90
@@ -272,10 +272,13 @@ subroutine crm_history_init(species_class)
    ! MMF CRM variance transport
    call addfld('MMF_VT_T'     ,(/'lev'/), 'A',' ','CRM T Variance')
    call addfld('MMF_VT_Q'     ,(/'lev'/), 'A',' ','CRM Q Variance')
+   call addfld('MMF_VT_U'     ,(/'lev'/), 'A',' ','CRM U Variance')
    call addfld('MMF_VT_TEND_T',(/'lev'/), 'A',' ','CRM T Variance Tendency')
    call addfld('MMF_VT_TEND_Q',(/'lev'/), 'A',' ','CRM Q Variance Tendency')
+   call addfld('MMF_VT_TEND_U',(/'lev'/), 'A',' ','CRM U Variance Tendency')
    call addfld('MMF_VT_TLS',    (/'lev'/), 'A','kg/kg/s','L.S. VT Forcing for LSE' )
    call addfld('MMF_VT_QLS',    (/'lev'/), 'A','kg/kg/s','L.S. VT Forcing for QT' )
+   call addfld('MMF_VT_ULS',    (/'lev'/), 'A','kg/kg/s','L.S. VT Forcing for U' )
 
    !----------------------------------------------------------------------------
    ! mixing diagnostics for dropmixnuc in the GCM grid
@@ -414,7 +417,7 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
    logical :: use_ECPP
    logical :: use_MMF_VT
    character(len=16) :: MMF_microphysics_scheme
-   integer :: idx_vt_t, idx_vt_q
+   integer :: idx_vt_t, idx_vt_q, idx_vt_u
 
    !----------------------------------------------------------------------------
 
@@ -647,12 +650,16 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
    if (use_MMF_VT) then
       call cnst_get_ind( 'VT_T', idx_vt_t )
       call cnst_get_ind( 'VT_Q', idx_vt_q )
+      call cnst_get_ind( 'VT_U', idx_vt_u )
       call outfld('MMF_VT_T',      state%q(:,:,idx_vt_t),                   ncol, lchnk )
       call outfld('MMF_VT_Q',      state%q(:,:,idx_vt_q),                   ncol, lchnk )
+      call outfld('MMF_VT_U',      state%q(:,:,idx_vt_u),                   ncol, lchnk )
       call outfld('MMF_VT_TEND_T', ptend%q(:,:,idx_vt_t),                   ncol, lchnk )
       call outfld('MMF_VT_TEND_Q', ptend%q(:,:,idx_vt_q),                   ncol, lchnk )
+      call outfld('MMF_VT_TEND_U', ptend%q(:,:,idx_vt_u),                   ncol, lchnk )
       call outfld('MMF_VT_TLS',    crm_output%t_vt_ls(icol_beg:icol_end,:), ncol, lchnk )
       call outfld('MMF_VT_QLS',    crm_output%q_vt_ls(icol_beg:icol_end,:), ncol, lchnk )
+      call outfld('MMF_VT_ULS',    crm_output%u_vt_ls(icol_beg:icol_end,:), ncol, lchnk )
    end if
 
    !----------------------------------------------------------------------------

--- a/components/eam/src/physics/crm/crm_input_module.F90
+++ b/components/eam/src/physics/crm/crm_input_module.F90
@@ -47,6 +47,7 @@ module crm_input_module
 
       real(crm_rknd), allocatable :: t_vt(:,:)           ! CRM input of variance used for forcing tendency
       real(crm_rknd), allocatable :: q_vt(:,:)           ! CRM input of variance used for forcing tendency
+      real(crm_rknd), allocatable :: u_vt(:,:)           ! CRM input of variance used for forcing tendency
 
    end type crm_input_type
    !------------------------------------------------------------------------------------------------
@@ -121,6 +122,8 @@ contains
       if (.not. allocated(input%q_vt)) allocate(input%q_vt(ncrms,nlev))
       call prefetch(input%t_vt)
       call prefetch(input%q_vt)
+      if (.not. allocated(input%u_vt)) allocate(input%u_vt(ncrms,nlev))
+      call prefetch(input%u_vt)
 
       ! Initialize
       input%zmid    = 0
@@ -159,6 +162,7 @@ contains
 
       input%t_vt = 0
       input%q_vt = 0
+      input%u_vt = 0
 
    end subroutine crm_input_initialize
    !------------------------------------------------------------------------------------------------
@@ -202,6 +206,7 @@ contains
 
       if (allocated(input%t_vt)) deallocate(input%t_vt)
       if (allocated(input%q_vt)) deallocate(input%q_vt)
+      if (allocated(input%u_vt)) deallocate(input%u_vt)
 
    end subroutine crm_input_finalize 
 

--- a/components/eam/src/physics/crm/crm_output_module.F90
+++ b/components/eam/src/physics/crm/crm_output_module.F90
@@ -90,6 +90,8 @@ module crm_output_module
       real(crm_rknd), allocatable :: q_vt_tend (:,:)       ! CRM output tendency for QT  variance transport
       real(crm_rknd), allocatable :: t_vt_ls   (:,:)       ! large-scale LSE variance transport tendency from GCM
       real(crm_rknd), allocatable :: q_vt_ls   (:,:)       ! large-scale QT  variance transport tendency from GCM
+      real(crm_rknd), allocatable :: u_vt_tend (:,:)       ! CRM output tendency for U variance transport
+      real(crm_rknd), allocatable :: u_vt_ls   (:,:)       ! large-scale U variance transport tendency from GCM
 
       ! These are all time and spatial averages, on the GCM grid
       real(crm_rknd), allocatable :: cld   (:,:)      ! cloud fraction
@@ -253,6 +255,8 @@ contains
       if (.not. allocated(output%q_vt_tend))  allocate(output%q_vt_tend(ncol,nlev))
       if (.not. allocated(output%t_vt_ls  ))  allocate(output%t_vt_ls  (ncol,nlev))
       if (.not. allocated(output%q_vt_ls  ))  allocate(output%q_vt_ls  (ncol,nlev))
+      if (.not. allocated(output%u_vt_tend))  allocate(output%u_vt_tend(ncol,nlev))
+      if (.not. allocated(output%u_vt_ls  ))  allocate(output%u_vt_ls  (ncol,nlev))
 
       if (.not. allocated(output%cld   )) allocate(output%cld   (ncol,nlev))  ! cloud fraction
       if (.not. allocated(output%gicewp)) allocate(output%gicewp(ncol,nlev))  ! ice water path
@@ -304,6 +308,8 @@ contains
       call prefetch(output%q_vt_tend )
       call prefetch(output%t_vt_ls   )
       call prefetch(output%q_vt_ls   )
+      call prefetch(output%u_vt_tend )
+      call prefetch(output%u_vt_ls   )
 
       call prefetch(output%cld    )
       call prefetch(output%gicewp )
@@ -418,6 +424,8 @@ contains
       output%q_vt_tend = 0
       output%t_vt_ls   = 0
       output%q_vt_ls   = 0
+      output%u_vt_tend = 0
+      output%u_vt_ls   = 0
 
       output%cld    = 0
       output%gicewp = 0
@@ -539,6 +547,8 @@ contains
       if (allocated(output%q_vt_tend)) deallocate(output%q_vt_tend)
       if (allocated(output%t_vt_ls))   deallocate(output%t_vt_ls)
       if (allocated(output%q_vt_ls))   deallocate(output%q_vt_ls)
+      if (allocated(output%u_vt_tend)) deallocate(output%u_vt_tend)
+      if (allocated(output%u_vt_ls))   deallocate(output%u_vt_ls)
 
       if (allocated(output%cld)) deallocate(output%cld)
       if (allocated(output%gicewp)) deallocate(output%gicewp)

--- a/components/eam/src/physics/crm/samxx/cpp_interface_mod.F90
+++ b/components/eam/src/physics/crm/samxx/cpp_interface_mod.F90
@@ -30,6 +30,7 @@ module cpp_interface_mod
                    crm_output_clhgh, crm_output_clmed, crm_output_cllow, &
                    crm_output_sltend, crm_output_qltend, crm_output_qcltend, crm_output_qiltend, &
                    crm_output_t_vt_tend, crm_output_q_vt_tend, crm_output_t_vt_ls, crm_output_q_vt_ls, &
+                   crm_input_u_vt, crm_output_u_vt_tend, crm_output_u_vt_ls, &
 #ifdef MMF_MOMENTUM_FEEDBACK
                    crm_output_ultend, crm_output_vltend, &
 #endif 
@@ -73,6 +74,7 @@ module cpp_interface_mod
                                       crm_output_clhgh, crm_output_clmed, crm_output_cllow, &
                                       crm_output_sltend, crm_output_qltend, crm_output_qcltend, &
                                       crm_output_t_vt_tend, crm_output_q_vt_tend, crm_output_t_vt_ls, crm_output_q_vt_ls, &
+                                      crm_input_u_vt, crm_output_u_vt_tend, crm_output_u_vt_ls, &
 #ifdef MMF_MOMENTUM_FEEDBACK
                                       crm_output_ultend, crm_output_vltend, &
 #endif

--- a/components/eam/src/physics/crm/samxx/crm.cpp
+++ b/components/eam/src/physics/crm/samxx/crm.cpp
@@ -40,6 +40,7 @@ extern "C" void crm(int ncrms_in, int pcols_in, real dt_gl, int plev, real *crm_
                     real *crm_output_clhgh_p, real *crm_output_clmed_p, real *crm_output_cllow_p, 
                     real *crm_output_sltend_p, real *crm_output_qltend_p, real *crm_output_qcltend_p, real *crm_output_qiltend_p, 
                     real *crm_output_t_vt_tend_p, real *crm_output_q_vt_tend_p, real *crm_output_t_vt_ls_p, real *crm_output_q_vt_ls_p,
+                    real *crm_input_u_vt_p, real *crm_output_u_vt_tend_p, real *crm_output_u_vt_ls_p,
 #ifdef MMF_MOMENTUM_FEEDBACK
                     real *crm_output_ultend_p, real *crm_output_vltend_p,
 #endif
@@ -72,7 +73,7 @@ extern "C" void crm(int ncrms_in, int pcols_in, real dt_gl, int plev, real *crm_
 #ifdef MMF_ESMT
                          crm_input_ul_esmt_p, crm_input_vl_esmt_p,
 #endif 
-                         crm_input_t_vt_p, crm_input_q_vt_p,
+                         crm_input_t_vt_p, crm_input_q_vt_p, crm_input_u_vt_p,
                          crm_state_u_wind_p, crm_state_v_wind_p, crm_state_w_wind_p, crm_state_temperature_p, 
                          crm_state_qt_p, crm_state_qp_p, crm_state_qn_p, crm_rad_qrad_p, crm_output_subcycle_factor_p, 
                          lat0_p, long0_p, gcolp_p, crm_output_cltot_p, crm_output_clhgh_p, crm_output_clmed_p, 
@@ -97,6 +98,7 @@ extern "C" void crm(int ncrms_in, int pcols_in, real dt_gl, int plev, real *crm_
                crm_output_cltot_p, crm_output_clhgh_p, crm_output_clmed_p, crm_output_cllow_p, 
                crm_output_sltend_p, crm_output_qltend_p, crm_output_qcltend_p, crm_output_qiltend_p, 
                crm_output_t_vt_tend_p, crm_output_q_vt_tend_p, crm_output_t_vt_ls_p, crm_output_q_vt_ls_p,
+               crm_output_u_vt_tend_p, crm_output_u_vt_ls_p,
 #ifdef MMF_MOMENTUM_FEEDBACK
                crm_output_ultend_p, crm_output_vltend_p,
 #endif
@@ -139,6 +141,7 @@ extern "C" void crm(int ncrms_in, int pcols_in, real dt_gl, int plev, real *crm_
                            crm_output_cltot_p, crm_output_clhgh_p, crm_output_clmed_p, crm_output_cllow_p, 
                            crm_output_sltend_p, crm_output_qltend_p, crm_output_qcltend_p, crm_output_qiltend_p, 
                            crm_output_t_vt_tend_p, crm_output_q_vt_tend_p, crm_output_t_vt_ls_p, crm_output_q_vt_ls_p, 
+                           crm_output_u_vt_tend_p, crm_output_u_vt_ls_p,
 #ifdef MMF_MOMENTUM_FEEDBACK
                            crm_output_ultend_p, crm_output_vltend_p,
 #endif

--- a/components/eam/src/physics/crm/samxx/crm_variance_transport.cpp
+++ b/components/eam/src/physics/crm/samxx/crm_variance_transport.cpp
@@ -106,10 +106,14 @@ void VT_diagnose() {
   YAKL_SCOPE( t_vt          , :: t_vt);
   YAKL_SCOPE( q_vt          , :: q_vt);
   YAKL_SCOPE( ncrms         , :: ncrms);
+  YAKL_SCOPE( u             , :: u);
+  YAKL_SCOPE( u_vt_pert     , :: u_vt_pert);
+  YAKL_SCOPE( u_vt          , :: u_vt);
 
   // local variables
   real2d t_mean("t_mean", nzm, ncrms);
   real2d q_mean("q_mean", nzm, ncrms);
+  real2d u_mean("u_mean", nzm, ncrms);
 
   int idx_qt = index_water_vapor;
 
@@ -123,6 +127,8 @@ void VT_diagnose() {
       q_mean(k,icrm) = 0.0;
       t_vt(k,icrm) = 0.0;
       q_vt(k,icrm) = 0.0;
+      u_mean(k,icrm) = 0.0;
+      u_vt(k,icrm) = 0.0;
   });
 
   // do k = 1,nzm
@@ -132,6 +138,7 @@ void VT_diagnose() {
   parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     yakl::atomicAdd( t_mean(k,icrm) , t(k,j+offy_s,i+offx_s,icrm) );
     yakl::atomicAdd( q_mean(k,icrm) , micro_field(idx_qt,k,j+offy_s,i+offx_s,icrm) );
+    yakl::atomicAdd( u_mean(k,icrm) , u(k,j+offy_u,i+offx_u,icrm) );
   });
 
   // do k = 1,nzm
@@ -139,6 +146,7 @@ void VT_diagnose() {
   parallel_for( SimpleBounds<2>(nzm,ncrms) , YAKL_LAMBDA (int k, int icrm) {
       t_mean(k,icrm) = t_mean(k,icrm) * factor_xy ;
       q_mean(k,icrm) = q_mean(k,icrm) * factor_xy ;
+      u_mean(k,icrm) = u_mean(k,icrm) * factor_xy ;
   });
 
   //----------------------------------------------------------------------------
@@ -149,6 +157,7 @@ void VT_diagnose() {
 
     real4d tmp_t("tmp_t", nzm, ny, nx, ncrms);
     real4d tmp_q("tmp_q", nzm, ny, nx, ncrms);
+    real4d tmp_u("tmp_u", nzm, ny, nx, ncrms);
 
     // do k = 1,nzm
     //   do j = 1,ny
@@ -159,10 +168,13 @@ void VT_diagnose() {
       tmp_q(k,j,i,icrm) = micro_field(idx_qt,k,j+offy_s,i+offx_s,icrm);
       tmp_t(k,j,i,icrm) = tmp_t(k,j,i,icrm) - t_mean(k,icrm);
       tmp_q(k,j,i,icrm) = tmp_q(k,j,i,icrm) - q_mean(k,icrm);
+      tmp_u(k,j,i,icrm) = u(k,j+offy_u,i+offx_u,icrm);
+      tmp_u(k,j,i,icrm) = tmp_u(k,j,i,icrm) - u_mean(k,icrm);
     });
 
     VT_filter( VT_wn_max, tmp_t, t_vt_pert );
     VT_filter( VT_wn_max, tmp_q, q_vt_pert );
+    VT_filter( VT_wn_max, tmp_u, u_vt_pert );
 
   } else { // use total variance
 
@@ -173,6 +185,7 @@ void VT_diagnose() {
     parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
       t_vt_pert(k,j,i,icrm) = t(k,j+offy_s,i+offx_s,icrm) - t_mean(k,icrm);
       q_vt_pert(k,j,i,icrm) = micro_field(idx_qt,k,j+offy_s,i+offx_s,icrm) - q_mean(k,icrm);
+      u_vt_pert(k,j,i,icrm) = u(k,j+offy_u,i+offx_u,icrm) - u_mean(k,icrm);
     });
     
   }
@@ -188,6 +201,7 @@ void VT_diagnose() {
   parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
     yakl::atomicAdd( t_vt(k,icrm) , t_vt_pert(k,j,i,icrm) * t_vt_pert(k,j,i,icrm) );
     yakl::atomicAdd( q_vt(k,icrm) , q_vt_pert(k,j,i,icrm) * q_vt_pert(k,j,i,icrm) );
+    yakl::atomicAdd( u_vt(k,icrm) , u_vt_pert(k,j,i,icrm) * u_vt_pert(k,j,i,icrm) );
   });
 
 
@@ -196,6 +210,7 @@ void VT_diagnose() {
   parallel_for( SimpleBounds<2>(nzm,ncrms) , YAKL_LAMBDA (int k, int icrm) {
     t_vt(k,icrm) = t_vt(k,icrm) * factor_xy ;
     q_vt(k,icrm) = q_vt(k,icrm) * factor_xy ;
+    u_vt(k,icrm) = u_vt(k,icrm) * factor_xy ;
   });
 
   //----------------------------------------------------------------------------
@@ -216,10 +231,15 @@ void VT_forcing() {
   YAKL_SCOPE( q_vt         , :: q_vt);
   YAKL_SCOPE( ncrms        , :: ncrms);
   YAKL_SCOPE( dtn          , :: dtn);
+  YAKL_SCOPE( u            , :: u);
+  YAKL_SCOPE( u_vt_pert    , :: u_vt_pert);
+  YAKL_SCOPE( u_vt         , :: u_vt);
+  YAKL_SCOPE( u_vt_tend    , :: u_vt_tend);
 
   // local variables
   real2d t_pert_scale("t_pert_scale", nzm, ncrms);
   real2d q_pert_scale("q_pert_scale", nzm, ncrms);
+  real2d u_pert_scale("u_pert_scale", nzm, ncrms);
 
   int idx_qt = index_water_vapor;
 
@@ -253,6 +273,13 @@ void VT_forcing() {
     // enforce maximum scaling
     t_pert_scale(k,icrm) = min( t_pert_scale(k,icrm), pert_scale_max );
     q_pert_scale(k,icrm) = min( q_pert_scale(k,icrm), pert_scale_max );
+
+    u_pert_scale(k,icrm) = 1.0;
+    real tmp_u_scale = -1.0;
+    if (u_vt(k,icrm)>0.0) { tmp_u_scale = 1.0 + dtn * u_vt_tend(k,icrm) / u_vt(k,icrm); }
+    if (tmp_u_scale>0.0) { u_pert_scale(k,icrm) = sqrt( tmp_u_scale ); }
+    u_pert_scale(k,icrm) = max( u_pert_scale(k,icrm), pert_scale_min );
+    u_pert_scale(k,icrm) = min( u_pert_scale(k,icrm), pert_scale_max );
   });
 
   //----------------------------------------------------------------------------
@@ -267,6 +294,8 @@ void VT_forcing() {
     real qtend_loc = ( q_pert_scale(k,icrm) * q_vt_pert(k,j,i,icrm) - q_vt_pert(k,j,i,icrm) ) / dtn;
     t(k,j+offy_s,i+offx_s,icrm)                  = t(k,j+offy_s,i+offx_s,icrm)                  + ttend_loc * dtn;
     micro_field(idx_qt,k,j+offy_s,i+offx_s,icrm) = micro_field(idx_qt,k,j+offy_s,i+offx_s,icrm) + qtend_loc * dtn;
+    real utend_loc = ( u_pert_scale(k,icrm) * u_vt_pert(k,j,i,icrm) - u_vt_pert(k,j,i,icrm) ) / dtn;
+    u(k,j+offy_u,i+offx_u,icrm) = u(k,j+offy_u,i+offx_u,icrm) + utend_loc * dtn;
   });
 
   //----------------------------------------------------------------------------

--- a/components/eam/src/physics/crm/samxx/post_timeloop.cpp
+++ b/components/eam/src/physics/crm/samxx/post_timeloop.cpp
@@ -174,7 +174,11 @@ void post_timeloop() {
   YAKL_SCOPE( t_vt_tend               , :: t_vt_tend );
   YAKL_SCOPE( q_vt_tend               , :: q_vt_tend );
   YAKL_SCOPE( use_VT                  , :: use_VT );
- 
+  YAKL_SCOPE( crm_output_u_vt_tend    , :: crm_output_u_vt_tend);
+  YAKL_SCOPE( crm_input_u_vt          , :: crm_input_u_vt);
+  YAKL_SCOPE( u_vt                    , :: u_vt);
+  YAKL_SCOPE( crm_output_u_vt_ls      , :: crm_output_u_vt_ls);
+  YAKL_SCOPE( u_vt_tend               , :: u_vt_tend);
 
   factor_xyt = factor_xy/((real) nstop);
   real tmp1 = crm_nx_rad_fac*crm_ny_rad_fac/((real) nstop);
@@ -312,9 +316,11 @@ void post_timeloop() {
         int l = plev-(k+1);
         crm_output_t_vt_tend(k,icrm) = ( t_vt(l,icrm) - crm_input_t_vt(k,icrm) ) * icrm_run_time;
         crm_output_q_vt_tend(k,icrm) = ( q_vt(l,icrm) - crm_input_q_vt(k,icrm) ) * icrm_run_time;
+        crm_output_u_vt_tend(k,icrm) = ( u_vt(l,icrm) - crm_input_u_vt(k,icrm) ) * icrm_run_time;
       } else {
         crm_output_t_vt_tend(k,icrm) = 0.0;
         crm_output_q_vt_tend(k,icrm) = 0.0;
+        crm_output_u_vt_tend(k,icrm) = 0.0;
       }
     }
   });
@@ -348,6 +354,7 @@ void post_timeloop() {
     if (use_VT) {
       crm_output_t_vt_tend(k,icrm) = 0.;
       crm_output_q_vt_tend(k,icrm) = 0.;
+      crm_output_u_vt_tend(k,icrm) = 0.;
     }
   });
 
@@ -566,6 +573,7 @@ void post_timeloop() {
     if (use_VT) {
       crm_output_t_vt_ls   (l,icrm) = t_vt_tend(k,icrm);
       crm_output_q_vt_ls   (l,icrm) = q_vt_tend(k,icrm);
+      crm_output_u_vt_ls   (l,icrm) = u_vt_tend(k,icrm);
     }
   });
 

--- a/components/eam/src/physics/crm/samxx/pre_timeloop.cpp
+++ b/components/eam/src/physics/crm/samxx/pre_timeloop.cpp
@@ -156,6 +156,9 @@ void pre_timeloop() {
   YAKL_SCOPE( t_vt                    , :: t_vt );
   YAKL_SCOPE( q_vt                    , :: q_vt );
   YAKL_SCOPE( use_VT                  , :: use_VT );
+  YAKL_SCOPE( crm_input_u_vt          , :: crm_input_u_vt);
+  YAKL_SCOPE( u_vt_tend               , :: u_vt_tend);
+  YAKL_SCOPE( u_vt                    , :: u_vt);
   
 
   crm_accel_ceaseflag = false;
@@ -409,6 +412,7 @@ void pre_timeloop() {
       // variance transport input forcing
       t_vt_tend(k,icrm) = ( crm_input_t_vt(l,icrm) - t_vt(k,icrm) )*idt_gl ;
       q_vt_tend(k,icrm) = ( crm_input_q_vt(l,icrm) - q_vt(k,icrm) )*idt_gl ;
+      u_vt_tend(k,icrm) = ( crm_input_u_vt(l,icrm) - u_vt(k,icrm) )*idt_gl ;
     }
   });
 

--- a/components/eam/src/physics/crm/samxx/vars.cpp
+++ b/components/eam/src/physics/crm/samxx/vars.cpp
@@ -194,6 +194,9 @@ void allocate() {
   q_vt_tend        = real2d( "q_vt_tend      "                        , nzm    , ncrms ); 
   t_vt_pert        = real4d( "t_vt_pert      "     , nzm , ny         , nx     , ncrms ); 
   q_vt_pert        = real4d( "q_vt_pert      "     , nzm , ny         , nx     , ncrms ); 
+  u_vt             = real2d( "u_vt           "                        , nzm    , ncrms ); 
+  u_vt_tend        = real2d( "u_vt_tend      "                        , nzm    , ncrms ); 
+  u_vt_pert        = real4d( "u_vt_pert      "     , nzm , ny         , nx     , ncrms ); 
 
   yakl::memset(t00               ,0.);
   yakl::memset(tln               ,0.);
@@ -385,6 +388,9 @@ void allocate() {
   yakl::memset(q_vt_pert         ,0.);
   yakl::memset(t_vt              ,0.);
   yakl::memset(q_vt              ,0.);
+  yakl::memset(u_vt_tend         ,0.);
+  yakl::memset(u_vt_pert         ,0.);
+  yakl::memset(u_vt              ,0.);
 }
 
 
@@ -670,6 +676,9 @@ void finalize() {
   q_vt_tend        = real2d();
   t_vt_pert        = real4d();
   q_vt_pert        = real4d();
+  u_vt             = real2d();
+  u_vt_tend        = real2d();
+  u_vt_pert        = real4d();
 }
 
 
@@ -681,7 +690,7 @@ void create_and_copy_inputs(real *crm_input_bflxls_p, real *crm_input_wndls_p, r
 #ifdef MMF_ESMT
                             real *crm_input_ul_esmt_p, real *crm_input_vl_esmt_p,
 #endif
-                            real *crm_input_t_vt_p, real *crm_input_q_vt_p,
+                            real *crm_input_t_vt_p, real *crm_input_q_vt_p, real *crm_input_u_vt_p,
                             real *crm_state_u_wind_p, real *crm_state_v_wind_p, real *crm_state_w_wind_p, real *crm_state_temperature_p, 
                             real *crm_state_qt_p, real *crm_state_qp_p, real *crm_state_qn_p, real *crm_rad_qrad_p, real *crm_output_subcycle_factor_p, 
                             real *lat0_p, real *long0_p, int *gcolp_p, real *crm_output_cltot_p, real *crm_output_clhgh_p, real *crm_output_clmed_p,
@@ -708,6 +717,7 @@ void create_and_copy_inputs(real *crm_input_bflxls_p, real *crm_input_wndls_p, r
 #endif
   realHost2d crm_input_t_vt           = realHost2d( "crm_input_t_vt         ",crm_input_t_vt_p                             , plev       , pcols);  
   realHost2d crm_input_q_vt           = realHost2d( "crm_input_q_vt         ",crm_input_q_vt_p                             , plev       , pcols); 
+  realHost2d crm_input_u_vt           = realHost2d( "crm_input_u_vt         ",crm_input_u_vt_p                             , plev       , pcols); 
   realHost4d crm_state_u_wind          = realHost4d( "crm_state_u_wind        ",crm_state_u_wind_p         , crm_nz, crm_ny    , crm_nx    , pcols);
   realHost4d crm_state_v_wind          = realHost4d( "crm_state_v_wind        ",crm_state_v_wind_p         , crm_nz, crm_ny    , crm_nx    , pcols);
   realHost4d crm_state_w_wind          = realHost4d( "crm_state_w_wind        ",crm_state_w_wind_p         , crm_nz, crm_ny    , crm_nx    , pcols);
@@ -746,6 +756,7 @@ void create_and_copy_inputs(real *crm_input_bflxls_p, real *crm_input_wndls_p, r
 #endif 
   ::crm_input_t_vt           = real2d( "crm_input_t_vt         "                   , plev       , pcols); 
   ::crm_input_q_vt           = real2d( "crm_input_q_vt         "                   , plev       , pcols); 
+  ::crm_input_u_vt           = real2d( "crm_input_u_vt         "                   , plev       , pcols); 
   ::crm_state_u_wind          = real4d( "crm_state_u_wind        ", crm_nz, crm_ny    , crm_nx    , pcols);
   ::crm_state_v_wind          = real4d( "crm_state_v_wind        ", crm_nz, crm_ny    , crm_nx    , pcols);
   ::crm_state_w_wind          = real4d( "crm_state_w_wind        ", crm_nz, crm_ny    , crm_nx    , pcols);
@@ -812,6 +823,8 @@ void create_and_copy_inputs(real *crm_input_bflxls_p, real *crm_input_wndls_p, r
   ::crm_output_q_vt_tend      = real2d( "crm_output_q_vt_tend    "                   , plev       , pcols); 
   ::crm_output_t_vt_ls        = real2d( "crm_output_t_vt_ls      "                   , plev       , pcols); 
   ::crm_output_q_vt_ls        = real2d( "crm_output_q_vt_ls      "                   , plev       , pcols); 
+  ::crm_output_u_vt_tend      = real2d( "crm_output_u_vt_tend    "                   , plev       , pcols); 
+  ::crm_output_u_vt_ls        = real2d( "crm_output_u_vt_ls      "                   , plev       , pcols); 
 #ifdef MMF_MOMENTUM_FEEDBACK
   ::crm_output_ultend         = real2d( "crm_output_ultend       "                   , plev       , pcols); 
   ::crm_output_vltend         = real2d( "crm_output_vltend       "                   , plev       , pcols); 
@@ -860,6 +873,7 @@ void create_and_copy_inputs(real *crm_input_bflxls_p, real *crm_input_wndls_p, r
 #endif
   crm_input_t_vt         .deep_copy_to(::crm_input_t_vt         );
   crm_input_q_vt         .deep_copy_to(::crm_input_q_vt         );
+  crm_input_u_vt         .deep_copy_to(::crm_input_u_vt         );
   crm_state_u_wind        .deep_copy_to(::crm_state_u_wind        );
   crm_state_v_wind        .deep_copy_to(::crm_state_v_wind        );
   crm_state_w_wind        .deep_copy_to(::crm_state_w_wind        );
@@ -894,6 +908,7 @@ void copy_outputs(real *crm_state_u_wind_p, real *crm_state_v_wind_p, real *crm_
                   real *crm_output_clhgh_p, real *crm_output_clmed_p, real *crm_output_cllow_p, 
                   real *crm_output_sltend_p, real *crm_output_qltend_p, real *crm_output_qcltend_p, real *crm_output_qiltend_p,
                   real *crm_output_t_vt_tend_p, real *crm_output_q_vt_tend_p, real *crm_output_t_vt_ls_p, real *crm_output_q_vt_ls_p, 
+                  real *crm_output_u_vt_tend_p, real *crm_output_u_vt_ls_p,
 #ifdef MMF_MOMENTUM_FEEDBACK
                   real *crm_output_ultend_p, real *crm_output_vltend_p,
 #endif
@@ -970,6 +985,8 @@ void copy_outputs(real *crm_state_u_wind_p, real *crm_state_v_wind_p, real *crm_
   realHost2d crm_output_q_vt_tend      = realHost2d( "crm_output_q_vt_tend    ",crm_output_q_vt_tend_p                        , plev       , pcols); 
   realHost2d crm_output_t_vt_ls        = realHost2d( "crm_output_t_vt_ls      ",crm_output_t_vt_ls_p                          , plev       , pcols); 
   realHost2d crm_output_q_vt_ls        = realHost2d( "crm_output_q_vt_ls      ",crm_output_q_vt_ls_p                          , plev       , pcols); 
+  realHost2d crm_output_u_vt_tend      = realHost2d( "crm_output_u_vt_tend    ",crm_output_u_vt_tend_p                        , plev       , pcols); 
+  realHost2d crm_output_u_vt_ls        = realHost2d( "crm_output_u_vt_ls      ",crm_output_u_vt_ls_p                          , plev       , pcols); 
 #ifdef MMF_MOMENTUM_FEEDBACK
   realHost2d crm_output_ultend         = realHost2d( "crm_output_ultend       ",crm_output_ultend_p                           , plev       , pcols); 
   realHost2d crm_output_vltend         = realHost2d( "crm_output_vltend       ",crm_output_vltend_p                           , plev       , pcols); 
@@ -1059,6 +1076,8 @@ void copy_outputs(real *crm_state_u_wind_p, real *crm_state_v_wind_p, real *crm_
   crm_output_q_vt_tend      .deep_copy_to( ::crm_output_q_vt_tend       ); 
   crm_output_t_vt_ls        .deep_copy_to( ::crm_output_t_vt_ls         ); 
   crm_output_q_vt_ls        .deep_copy_to( ::crm_output_q_vt_ls         ); 
+  crm_output_u_vt_tend      .deep_copy_to( ::crm_output_u_vt_tend       ); 
+  crm_output_u_vt_ls        .deep_copy_to( ::crm_output_u_vt_ls         ); 
 #ifdef MMF_MOMENTUM_FEEDBACK
   crm_output_ultend         .deep_copy_to( ::crm_output_ultend          ); 
   crm_output_vltend         .deep_copy_to( ::crm_output_vltend          ); 
@@ -1100,6 +1119,7 @@ void copy_outputs_and_destroy(real *crm_state_u_wind_p, real *crm_state_v_wind_p
                               real *crm_output_clhgh_p, real *crm_output_clmed_p, real *crm_output_cllow_p, 
                               real *crm_output_sltend_p, real *crm_output_qltend_p, real *crm_output_qcltend_p, real *crm_output_qiltend_p,
                               real *crm_output_t_vt_tend_p, real *crm_output_q_vt_tend_p, real *crm_output_t_vt_ls_p, real *crm_output_q_vt_ls_p, 
+                              real *crm_output_u_vt_tend_p, real *crm_output_u_vt_ls_p, 
 #ifdef MMF_MOMENTUM_FEEDBACK
                               real *crm_output_ultend_p, real *crm_output_vltend_p,
 #endif
@@ -1177,6 +1197,8 @@ void copy_outputs_and_destroy(real *crm_state_u_wind_p, real *crm_state_v_wind_p
   realHost2d crm_output_q_vt_tend      = realHost2d( "crm_output_q_vt_tend    ",crm_output_q_vt_tend_p                        , plev       , pcols); 
   realHost2d crm_output_t_vt_ls        = realHost2d( "crm_output_t_vt_ls      ",crm_output_t_vt_ls_p                          , plev       , pcols); 
   realHost2d crm_output_q_vt_ls        = realHost2d( "crm_output_q_vt_ls      ",crm_output_q_vt_ls_p                          , plev       , pcols); 
+  realHost2d crm_output_u_vt_tend      = realHost2d( "crm_output_u_vt_tend    ",crm_output_u_vt_tend_p                        , plev       , pcols); 
+  realHost2d crm_output_u_vt_ls        = realHost2d( "crm_output_u_vt_ls      ",crm_output_u_vt_ls_p                          , plev       , pcols); 
 #ifdef MMF_MOMENTUM_FEEDBACK
   realHost2d crm_output_ultend         = realHost2d( "crm_output_ultend       ",crm_output_ultend_p                           , plev       , pcols); 
   realHost2d crm_output_vltend         = realHost2d( "crm_output_vltend       ",crm_output_vltend_p                           , plev       , pcols); 
@@ -1267,6 +1289,8 @@ void copy_outputs_and_destroy(real *crm_state_u_wind_p, real *crm_state_v_wind_p
   ::crm_output_q_vt_tend    .deep_copy_to(crm_output_q_vt_tend    );
   ::crm_output_t_vt_ls      .deep_copy_to(crm_output_t_vt_ls      );
   ::crm_output_q_vt_ls      .deep_copy_to(crm_output_q_vt_ls      );
+  ::crm_output_u_vt_tend    .deep_copy_to(crm_output_u_vt_tend    );
+  ::crm_output_u_vt_ls      .deep_copy_to(crm_output_u_vt_ls      );
 #ifdef MMF_MOMENTUM_FEEDBACK
   ::crm_output_ultend       .deep_copy_to(crm_output_ultend       );
   ::crm_output_vltend       .deep_copy_to(crm_output_vltend       );
@@ -1312,6 +1336,7 @@ void copy_outputs_and_destroy(real *crm_state_u_wind_p, real *crm_state_v_wind_p
 #endif
   ::crm_input_t_vt           = real2d();
   ::crm_input_q_vt           = real2d();
+  ::crm_input_u_vt           = real2d();
   ::crm_state_u_wind          = real4d();
   ::crm_state_v_wind          = real4d();
   ::crm_state_w_wind          = real4d();
@@ -1378,6 +1403,8 @@ void copy_outputs_and_destroy(real *crm_state_u_wind_p, real *crm_state_v_wind_p
   ::crm_output_q_vt_tend      = real2d();
   ::crm_output_t_vt_ls        = real2d();
   ::crm_output_q_vt_ls        = real2d();
+  ::crm_output_u_vt_tend      = real2d();
+  ::crm_output_u_vt_ls        = real2d();
 #ifdef MMF_MOMENTUM_FEEDBACK
   ::crm_output_ultend         = real2d();
   ::crm_output_vltend         = real2d();
@@ -1546,6 +1573,9 @@ void perturb_arrays() {
     perturb( q_vt_pert        , mag );
     perturb( t_vt             , mag );
     perturb( q_vt             , mag );
+    perturb( u_vt_tend        , mag );
+    perturb( u_vt_pert        , mag );
+    perturb( u_vt             , mag );
   #endif
 }
 
@@ -1652,6 +1682,9 @@ real2d t_vt_tend      ;
 real2d q_vt_tend      ;
 real4d t_vt_pert      ;
 real4d q_vt_pert      ;
+real2d u_vt           ;
+real2d u_vt_tend      ;
+real4d u_vt_pert      ;
 
 real1d fcorz           ;
 real1d fcor            ;
@@ -1769,6 +1802,7 @@ real2d crm_input_vl_esmt;
 #endif
 real2d crm_input_t_vt ;
 real2d crm_input_q_vt ;
+real2d crm_input_u_vt ;
 real4d crm_state_u_wind;
 real4d crm_state_v_wind;
 real4d crm_state_w_wind; 
@@ -1835,6 +1869,8 @@ real2d crm_output_t_vt_tend;
 real2d crm_output_q_vt_tend;
 real2d crm_output_t_vt_ls;
 real2d crm_output_q_vt_ls;
+real2d crm_output_u_vt_tend;
+real2d crm_output_u_vt_ls;
 #ifdef MMF_MOMENTUM_FEEDBACK
 real2d crm_output_ultend;
 real2d crm_output_vltend;

--- a/components/eam/src/physics/crm/samxx/vars.h
+++ b/components/eam/src/physics/crm/samxx/vars.h
@@ -61,7 +61,7 @@ void create_and_copy_inputs(real *crm_input_bflxls_p, real *crm_input_wndls_p, r
 #ifdef MMF_ESMT
                             real *crm_input_ul_esmt_p, real *crm_input_vl_esmt_p,
 #endif 
-                            real *crm_input_t_vt_p, real *crm_input_q_vt_p,
+                            real *crm_input_t_vt_p, real *crm_input_q_vt_p, real *crm_input_u_vt_p,
                             real *crm_state_u_wind_p, real *crm_state_v_wind_p, real *crm_state_w_wind_p, real *crm_state_temperature_p, 
                             real *crm_state_qt_p, real *crm_state_qp_p, real *crm_state_qn_p, real *crm_rad_qrad_p, real *crm_output_subcycle_factor_p, 
                             real *lat0_p, real *long0_p, int *gcolp_p, real *crm_output_cltot_p, real *crm_output_clhgh_p, real *crm_output_clmed_p,
@@ -84,6 +84,7 @@ void copy_outputs(real *crm_state_u_wind_p, real *crm_state_v_wind_p, real *crm_
                   real *crm_output_sltend_p, real *crm_output_qltend_p, real *crm_output_qcltend_p, real *crm_output_qiltend_p, 
                   real *crm_output_t_vt_tend_p, real *crm_output_q_vt_tend_p,
                   real *crm_output_t_vt_ls_p, real *crm_output_q_vt_ls_p,
+                  real *crm_output_u_vt_tend_p, real *crm_output_u_vt_ls_p,
 #ifdef MMF_MOMENTUM_FEEDBACK
                   real *crm_output_ultend_p, real *crm_output_vltend_p,
 #endif
@@ -112,6 +113,7 @@ void copy_outputs_and_destroy(real *crm_state_u_wind_p, real *crm_state_v_wind_p
                               real *crm_output_sltend_p, real *crm_output_qltend_p, real *crm_output_qcltend_p, real *crm_output_qiltend_p, 
                               real *crm_output_t_vt_tend_p, real *crm_output_q_vt_tend_p,
                               real *crm_output_t_vt_ls_p, real *crm_output_q_vt_ls_p,
+                              real *crm_output_u_vt_tend_p, real *crm_output_u_vt_ls_p,
 #ifdef MMF_MOMENTUM_FEEDBACK
                               real *crm_output_ultend_p, real *crm_output_vltend_p, 
 #endif
@@ -344,6 +346,9 @@ extern real2d t_vt_tend      ;
 extern real2d q_vt_tend      ;
 extern real4d t_vt_pert      ;
 extern real4d q_vt_pert      ;
+extern real2d u_vt           ;
+extern real2d u_vt_tend      ;
+extern real4d u_vt_pert      ;
 
 extern real1d fcorz           ;
 extern real1d fcor            ;
@@ -456,6 +461,7 @@ extern real2d crm_input_vl_esmt;
 #endif
 extern real2d crm_input_t_vt ;
 extern real2d crm_input_q_vt ;
+extern real2d crm_input_u_vt ;
 extern real4d crm_state_u_wind;
 extern real4d crm_state_v_wind;
 extern real4d crm_state_w_wind; 
@@ -522,6 +528,8 @@ extern real2d crm_output_t_vt_tend;
 extern real2d crm_output_q_vt_tend;
 extern real2d crm_output_t_vt_ls;
 extern real2d crm_output_q_vt_ls;
+extern real2d crm_output_u_vt_tend;
+extern real2d crm_output_u_vt_ls;
 #ifdef MMF_MOMENTUM_FEEDBACK
 extern real2d crm_output_ultend; 
 extern real2d crm_output_vltend; 


### PR DESCRIPTION
This PR enhances the CRM variance transport (VT) by including momentum, which was previously ignored due to concerns over how the VT tendencies would be affected by the anelastic pressure solver. Further analysis has shown that including momentum VT helps to further alleviate the checkerboard pattern problem, albeit only slight. 

NOTE - this breaks the fortran CRM code, which is no longer tested/supported. Also, future PR will enable VT by default, which will also affect our ability to run the fortran code (both OMP and OpenACC versions).