### PR TITLE
MPAS Standalone: Fix check for LAPACK libraries

### DIFF
--- a/components/mpas-framework/Makefile
+++ b/components/mpas-framework/Makefile
@@ -609,11 +609,11 @@ ifeq "$(USE_LAPACK)" "true"
 ifndef LAPACK
 $(error LAPACK is not set.  Please set LAPACK to the LAPACK install directory when USE_LAPACK=true)
 endif
-ifneq (, $(shell ls $(LAPACK)/liblapack.*))
+ifneq ($(wildcard $(LAPACK)/liblapack.*), )
 	LIBS += -L$(LAPACK)
-else ifneq (, $(shell ls $(LAPACK)/lib/liblapack.*))
+else ifneq ($(wildcard $(LAPACK)/lib/liblapack.*), )
 	LIBS += -L$(LAPACK)/lib
-else ifneq (, $(shell ls $(LAPACK)/lib64/liblapack.*))
+else ifneq ($(wildcard $(LAPACK)/lib64/liblapack.*), )
 	LIBS += -L$(LAPACK)/lib64
 else
 $(error liblapack.* does NOT exist in $(LAPACK) or $(LAPACK)/lib)


### PR DESCRIPTION
Previously, there were error messages like:
```
ls: cannot access '/global/cfs/cdirs/e3sm/software/compass/cori-haswell/spack/spack_for_mache_1.4.1/var/spack/environments/dev_compass_1_1_0-alpha_4_gnu_mpt_netlib_lapack_petsc/.spack-env/view/liblapack.*': No such file or directory
```
even though this just means that the correct directory for LAPACK had not yet been found.

[BFB]