### PR TITLE
Fix a potential stack buffer overflow in GPTLget_memusage.c

### DIFF
--- a/share/timing/GPTLget_memusage.c
+++ b/share/timing/GPTLget_memusage.c
@@ -108,7 +108,7 @@ int GPTLget_memusage (int *size, int *rss, int *share, int *text, int *datastack
 #elif (defined HAVE_SLASHPROC)
   FILE *fd;                       /* file descriptor for fopen */
   int pid;                        /* process id */
-  char file[19];                  /* full path to file in /proc */
+  char file[20];                  /* full path to file in /proc */
   int dum;                        /* placeholder for unused return arguments */
   int ret;                        /* function return value */
   static int pg_sz = -1;          /* page size */

--- a/share/timing/GPTLget_memusage.c
+++ b/share/timing/GPTLget_memusage.c
@@ -108,7 +108,7 @@ int GPTLget_memusage (int *size, int *rss, int *share, int *text, int *datastack
 #elif (defined HAVE_SLASHPROC)
   FILE *fd;                       /* file descriptor for fopen */
   int pid;                        /* process id */
-  char file[20];                  /* full path to file in /proc */
+  char file[24];                  /* full path to file in /proc */
   int dum;                        /* placeholder for unused return arguments */
   int ret;                        /* function return value */
   static int pg_sz = -1;          /* page size */


### PR DESCRIPTION
Increase the size of a local char array in GPTLget_memusage.c to
accommodate large process ids up to 2^22 (4194304).

Note that an error-checking on OS process id in old GPTL code which
assumes that a pid is less than 999999 has been removed.

Fixes #4982

[BFB]