### PR TITLE
FATES API 23

### DIFF
--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -124,7 +124,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- ================================================================== -->
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
-<fates_paramfile >lnd/clm2/paramdata/fates_params_12pft_api17.c211116.nc</fates_paramfile>
+<fates_paramfile >lnd/clm2/paramdata/fates_params_api.22.1.0_12pft_c220307.nc</fates_paramfile>
 
 <!-- soil order related parameters (relative to {csmdata}) -->
 <fsoilordercon             >lnd/clm2/paramdata/CNP_parameters_c131108.nc</fsoilordercon>

--- a/components/elm/src/main/elmfates_interfaceMod.F90
+++ b/components/elm/src/main/elmfates_interfaceMod.F90
@@ -323,6 +323,13 @@ verbose_output = .false.
         else
            call set_fates_ctrlparms('nu_com',cval='RD')
         end if
+        
+        ! Tell fates which decomposition method is being used by the host land model
+        if (use_century_decomp) then 
+           call set_fates_ctrlparms('decomp_method',cval='CENTURY')
+        else
+           call set_fates_ctrlparms('decomp_method',cval='NONE')
+        end if
 
         ! ELM ALWAYS has nitrogen and phosphorus "on"
         ! These may be in a non-limiting status (ie when supplements)

--- a/components/elm/src/main/elmfates_interfaceMod.F90
+++ b/components/elm/src/main/elmfates_interfaceMod.F90
@@ -59,6 +59,7 @@ module ELMFatesInterfaceMod
    use elm_varctl        , only : nsrest, nsrBranch
    use elm_varctl        , only : fates_inventory_ctrl_filename
    use elm_varctl        , only : use_lch4
+   use elm_varctl        , only : use_century_decomp
    use elm_varcon        , only : tfrz
    use elm_varcon        , only : spval
    use elm_varcon        , only : denice

--- a/components/elm/src/main/elmfates_interfaceMod.F90
+++ b/components/elm/src/main/elmfates_interfaceMod.F90
@@ -299,7 +299,7 @@ contains
 
      if (use_fates) then
 
-verbose_output = .false.
+        verbose_output = .false.
         call FatesInterfaceInit(iulog, verbose_output)
 
         ! Force FATES parameters that are recieve type, to the unset value
@@ -329,7 +329,7 @@ verbose_output = .false.
         if (use_century_decomp) then 
            call set_fates_ctrlparms('decomp_method',cval='CENTURY')
         else
-           call set_fates_ctrlparms('decomp_method',cval='NONE')
+           call set_fates_ctrlparms('decomp_method',cval='CTC')
         end if
 
         ! ELM ALWAYS has nitrogen and phosphorus "on"


### PR DESCRIPTION
Align E3SM with fates api 22.1 and api 23.  Update the optical parameters in the fates parameter file (https://github.com/ESCOMP/CTSM/releases/tag/ctsm5.1.dev084) and the additional of logic in elmfates_interfaceMod to set the decomposition type via a new `decomp_method` parameter.

[non-BFB]