### PR TITLE
Fixed use_case files for SSP370 and SSP585 for maint-2.0

### DIFF
--- a/components/eam/bld/namelist_files/use_cases/SSP370_eam_CMIP6.xml
+++ b/components/eam/bld/namelist_files/use_cases/SSP370_eam_CMIP6.xml
@@ -19,84 +19,10 @@
 <prescribed_volcaero_type    >CYCLICAL						       </prescribed_volcaero_type    >
 <prescribed_volcaero_cycle_yr>1                                                        </prescribed_volcaero_cycle_yr>
 
-<!-- Sea Surface Temperatures (SST) are specified using SSTICE in config_compsets.xml -->
-
-<!-- Ice nucleation mods-->
-<use_hetfrz_classnuc>.true.</use_hetfrz_classnuc>
-<use_preexisting_ice>.false.</use_preexisting_ice>
-<hist_hetfrz_classnuc>.false.</hist_hetfrz_classnuc>
-<micro_mg_dcs_tdep>.true.</micro_mg_dcs_tdep>
-<microp_aero_wsub_scheme>1</microp_aero_wsub_scheme>
-
-<!-- For Polar mods-->
-<sscav_tuning>.true.</sscav_tuning>
-<convproc_do_aer>.true.</convproc_do_aer>
-<convproc_do_gas>.false.</convproc_do_gas>
-<convproc_method_activate>2</convproc_method_activate>
-<demott_ice_nuc>.true.</demott_ice_nuc>
-<liqcf_fix>.true.</liqcf_fix>
-<regen_fix>.true.</regen_fix>
-<resus_fix>.true.</resus_fix>
-<mam_amicphys_optaa>1</mam_amicphys_optaa>
-
-<fix_g1_err_ndrop>.true.</fix_g1_err_ndrop>
-<ssalt_tuning>.true.</ssalt_tuning>
-
 <!-- For comprehensive history -->
 <history_amwg>.true.</history_amwg>
 <history_aerosol>.true.</history_aerosol>
 <history_aero_optics>.true.</history_aero_optics>
-
-<!-- File for BC dep in snow feature -->
-<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c160322.nc</fsnowoptics>
-
-<!-- Radiation bugfix -->
-<use_rad_dt_cosz>.true.</use_rad_dt_cosz>
-
-<!-- Tunable parameters for 72 layer model -->
-
-<ice_sed_ai>500.0</ice_sed_ai>
-<cldfrc_dp1>0.045D0</cldfrc_dp1>
-<clubb_ice_deep>16.e-6</clubb_ice_deep>
-<clubb_ice_sh>50.e-6</clubb_ice_sh>
-<clubb_liq_deep>8.e-6</clubb_liq_deep>  
-<clubb_liq_sh>10.e-6</clubb_liq_sh>
-<clubb_C2rt>1.75D0</clubb_C2rt>
-<zmconv_c0_lnd>0.007</zmconv_c0_lnd>
-<zmconv_c0_ocn>0.007</zmconv_c0_ocn>
-<zmconv_dmpdz>-0.7e-3</zmconv_dmpdz>
-<zmconv_ke>5.e-6</zmconv_ke>
-<effgw_oro>0.25</effgw_oro>
-<seasalt_emis_scale>0.85</seasalt_emis_scale>
-<dust_emis_fact>1.38D0</dust_emis_fact>
-<clubb_gamma_coef>0.32</clubb_gamma_coef>
-<clubb_gamma_coefb>0.32</clubb_gamma_coefb>
-<clubb_C8>4.3</clubb_C8>
-<cldfrc2m_rhmaxi>1.05D0</cldfrc2m_rhmaxi>
-<clubb_c_K10>0.3</clubb_c_K10>
-<clubb_c_K10h>0.3</clubb_c_K10h>
-<effgw_beres>0.4</effgw_beres>
-<do_tms>.false.</do_tms>
-<so4_sz_thresh_icenuc>0.05e-6</so4_sz_thresh_icenuc>
-<n_so4_monolayers_pcage>8.0D0</n_so4_monolayers_pcage>
-<micro_mg_accre_enhan_fac>1.5D0</micro_mg_accre_enhan_fac>
-<zmconv_tiedke_add>0.8D0</zmconv_tiedke_add>
-<zmconv_cape_cin>1</zmconv_cape_cin>
-<zmconv_mx_bot_lyr_adj>2</zmconv_mx_bot_lyr_adj>
-<taubgnd>2.5D-3</taubgnd>
-<clubb_C1>1.335</clubb_C1>
-<clubb_C1b>1.335</clubb_C1b>
-<raytau0>5.0D0</raytau0>
-<prc_coef1>30500.0D0</prc_coef1>
-<prc_exp>3.19D0</prc_exp>
-<prc_exp1>-1.2D0</prc_exp1>
-<clubb_C14>1.06D0</clubb_C14>
-<relvar_fix>.true.</relvar_fix>
-<mg_prc_coeff_fix>.true.</mg_prc_coeff_fix>
-<rrtmg_temp_fix>.true.</rrtmg_temp_fix>
-
-<!-- Energy fixer options -->
-<ieflx_opt  > 2     </ieflx_opt>
 
 <!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
 <ext_frc_type>INTERP_MISSING_MONTHS</ext_frc_type>
@@ -146,6 +72,9 @@
 <linoz_data_file            >linoz_1850-2500_CMIP6_Hist_SSP370_10deg_58km_c20210202.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >INTERP_MISSING_MONTHS</linoz_data_type>
+
+<!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
+<drydep_list            >'H2O2', 'H2SO4', 'SO2'</drydep_list>
 
 <!-- sim_year used for CLM datasets and SSTs forcings -->
 <sim_year>2015-2100</sim_year>

--- a/components/eam/bld/namelist_files/use_cases/SSP585_eam_CMIP6.xml
+++ b/components/eam/bld/namelist_files/use_cases/SSP585_eam_CMIP6.xml
@@ -19,84 +19,10 @@
 <prescribed_volcaero_type    >CYCLICAL						       </prescribed_volcaero_type    >
 <prescribed_volcaero_cycle_yr>1                                                        </prescribed_volcaero_cycle_yr>
 
-<!-- Sea Surface Temperatures (SST) are specified using SSTICE in config_compsets.xml -->
-
-<!-- Ice nucleation mods-->
-<use_hetfrz_classnuc>.true.</use_hetfrz_classnuc>
-<use_preexisting_ice>.false.</use_preexisting_ice>
-<hist_hetfrz_classnuc>.false.</hist_hetfrz_classnuc>
-<micro_mg_dcs_tdep>.true.</micro_mg_dcs_tdep>
-<microp_aero_wsub_scheme>1</microp_aero_wsub_scheme>
-
-<!-- For Polar mods-->
-<sscav_tuning>.true.</sscav_tuning>
-<convproc_do_aer>.true.</convproc_do_aer>
-<convproc_do_gas>.false.</convproc_do_gas>
-<convproc_method_activate>2</convproc_method_activate>
-<demott_ice_nuc>.true.</demott_ice_nuc>
-<liqcf_fix>.true.</liqcf_fix>
-<regen_fix>.true.</regen_fix>
-<resus_fix>.true.</resus_fix>
-<mam_amicphys_optaa>1</mam_amicphys_optaa>
-
-<fix_g1_err_ndrop>.true.</fix_g1_err_ndrop>
-<ssalt_tuning>.true.</ssalt_tuning>
-
 <!-- For comprehensive history -->
 <history_amwg>.true.</history_amwg>
 <history_aerosol>.true.</history_aerosol>
 <history_aero_optics>.true.</history_aero_optics>
-
-<!-- File for BC dep in snow feature -->
-<fsnowoptics>lnd/clm2/snicardata/snicar_optics_5bnd_mam_c160322.nc</fsnowoptics>
-
-<!-- Radiation bugfix -->
-<use_rad_dt_cosz>.true.</use_rad_dt_cosz>
-
-<!-- Tunable parameters for 72 layer model -->
-
-<ice_sed_ai>500.0</ice_sed_ai>
-<cldfrc_dp1>0.045D0</cldfrc_dp1>
-<clubb_ice_deep>16.e-6</clubb_ice_deep>
-<clubb_ice_sh>50.e-6</clubb_ice_sh>
-<clubb_liq_deep>8.e-6</clubb_liq_deep>  
-<clubb_liq_sh>10.e-6</clubb_liq_sh>
-<clubb_C2rt>1.75D0</clubb_C2rt>
-<zmconv_c0_lnd>0.007</zmconv_c0_lnd>
-<zmconv_c0_ocn>0.007</zmconv_c0_ocn>
-<zmconv_dmpdz>-0.7e-3</zmconv_dmpdz>
-<zmconv_ke>5.e-6</zmconv_ke>
-<effgw_oro>0.25</effgw_oro>
-<seasalt_emis_scale>0.85</seasalt_emis_scale>
-<dust_emis_fact>1.38D0</dust_emis_fact>
-<clubb_gamma_coef>0.32</clubb_gamma_coef>
-<clubb_gamma_coefb>0.32</clubb_gamma_coefb>
-<clubb_C8>4.3</clubb_C8>
-<cldfrc2m_rhmaxi>1.05D0</cldfrc2m_rhmaxi>
-<clubb_c_K10>0.3</clubb_c_K10>
-<clubb_c_K10h>0.3</clubb_c_K10h>
-<effgw_beres>0.4</effgw_beres>
-<do_tms>.false.</do_tms>
-<so4_sz_thresh_icenuc>0.05e-6</so4_sz_thresh_icenuc>
-<n_so4_monolayers_pcage>8.0D0</n_so4_monolayers_pcage>
-<micro_mg_accre_enhan_fac>1.5D0</micro_mg_accre_enhan_fac>
-<zmconv_tiedke_add>0.8D0</zmconv_tiedke_add>
-<zmconv_cape_cin>1</zmconv_cape_cin>
-<zmconv_mx_bot_lyr_adj>2</zmconv_mx_bot_lyr_adj>
-<taubgnd>2.5D-3</taubgnd>
-<clubb_C1>1.335</clubb_C1>
-<clubb_C1b>1.335</clubb_C1b>
-<raytau0>5.0D0</raytau0>
-<prc_coef1>30500.0D0</prc_coef1>
-<prc_exp>3.19D0</prc_exp>
-<prc_exp1>-1.2D0</prc_exp1>
-<clubb_C14>1.06D0</clubb_C14>
-<relvar_fix>.true.</relvar_fix>
-<mg_prc_coeff_fix>.true.</mg_prc_coeff_fix>
-<rrtmg_temp_fix>.true.</rrtmg_temp_fix>
-
-<!-- Energy fixer options -->
-<ieflx_opt  > 2     </ieflx_opt>
 
 <!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
 <ext_frc_type>INTERP_MISSING_MONTHS</ext_frc_type>
@@ -146,6 +72,9 @@
 <linoz_data_file            >linoz_1850-2500_CMIP6_Hist_SSP585_10deg_58km_c20190414.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >INTERP_MISSING_MONTHS</linoz_data_type>
+
+<!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
+<drydep_list            >'H2O2', 'H2SO4', 'SO2'</drydep_list>
 
 <!-- sim_year used for CLM datasets and SSTs forcings -->
 <sim_year>2015-2100</sim_year>

--- a/components/elm/bld/namelist_files/use_cases/2015-2100_SSP370_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/2015-2100_SSP370_transient.xml
@@ -32,8 +32,14 @@
 
 <!-- CMIP6 DECK compsets -->
 
-<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_simyr1850_2015_c211105.nc </fsurdat>
+<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_SSP3_RCP70_simyr2015_c220420.nc </fsurdat>
 <flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30pg2_SSP3_RCP70_simyr2015-2100_c211015.nc</flanduse_timeseries>
+
+<!-- Add following for hybrid run of SSP370 continuing from a historical simulation -->
+
+<check_finidat_fsurdat_consistency>.false.</check_finidat_fsurdat_consistency>
+<check_finidat_year_consistency>.true.</check_finidat_year_consistency>
+<check_finidat_pct_consistency>.true.</check_finidat_pct_consistency>
 <check_dynpft_consistency>.false.</check_dynpft_consistency>
 
 </namelist_defaults>

--- a/components/elm/bld/namelist_files/use_cases/2015-2100_SSP585_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/2015-2100_SSP585_transient.xml
@@ -32,8 +32,14 @@
 
 <!-- CMIP6 DECK compsets -->
 
-<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_simyr1850_2015_c211105.nc </fsurdat>
+<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_SSP5_RCP85_simyr2015_c220420.nc </fsurdat>
 <flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30pg2_SSP5_RCP85_simyr2015-2100_c220310.nc</flanduse_timeseries>
+
+<!-- Add following for hybrid run of SSP370 continuing from a historical simulation -->
+
+<check_finidat_fsurdat_consistency>.false.</check_finidat_fsurdat_consistency>
+<check_finidat_year_consistency>.true.</check_finidat_year_consistency>
+<check_finidat_pct_consistency>.true.</check_finidat_pct_consistency>
 <check_dynpft_consistency>.false.</check_dynpft_consistency>
 
 </namelist_defaults>


### PR DESCRIPTION
The EAM use_case files for SSP370 and SSP585 contained parameter settings
meant for EAMv1 that need to be cleared. surfdata_map files for ELM are
updated to use one for simyr2015 that is consistent with the starting year
of the SSP scenarios. Several consistency check flags that are typically
used for hybrid runs are specified as default.

The initial SSP370 and SSP585 use_case files went into maint-2.0 via PR #4880.

[BFB] except for SSP370 and SSP585.