### PR TITLE
For cori use 4 nodes as the default for land-only tests

### DIFF
--- a/components/elm/cime_config/config_pes.xml
+++ b/components/elm/cime_config/config_pes.xml
@@ -59,7 +59,7 @@
         </nthrds>
       </pes>
     </mach>
-    <mach name="theta|perlmutter|cori-knl|cori-haswell|jlse">
+    <mach name="theta|jlse|pm-gpu|pm-cpu">
       <pes compset="any" pesize="any">
         <comment>elm: default, 1 node x MAX_MPITASKS_PER_NODE mpi x 1 omp @ root 0</comment>
         <ntasks>
@@ -71,6 +71,21 @@
           <ntasks_glc>-1</ntasks_glc>
           <ntasks_wav>-1</ntasks_wav>
           <ntasks_cpl>-1</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
+    <mach name="cori-knl|cori-haswell">
+      <pes compset="any" pesize="any">
+        <comment>elm: default, 1 node x MAX_MPITASKS_PER_NODE mpi x 1 omp @ root 0</comment>
+        <ntasks>
+          <ntasks_atm>-4</ntasks_atm>
+          <ntasks_lnd>-4</ntasks_lnd>
+          <ntasks_rof>-4</ntasks_rof>
+          <ntasks_ice>-4</ntasks_ice>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_glc>-4</ntasks_glc>
+          <ntasks_wav>-4</ntasks_wav>
+          <ntasks_cpl>-4</ntasks_cpl>
         </ntasks>
       </pes>
     </mach>

--- a/components/mpas-albany-landice/cime_config/config_pes.xml
+++ b/components/mpas-albany-landice/cime_config/config_pes.xml
@@ -87,7 +87,7 @@
         </nthrds>
       </pes>
     </mach>
-    <mach name="theta|perlmutter|cori-knl|cori-haswell|jlse">
+    <mach name="theta|pm-gpu|pm-cpu|cori-knl|cori-haswell|jlse">
       <pes compset="any" pesize="any">
         <comment>mali: default, 1 node x MAX_MPITASKS_PER_NODE mpi x 1 omp @ root 0</comment>
         <ntasks>

--- a/components/mpas-ocean/cime_config/config_pes.xml
+++ b/components/mpas-ocean/cime_config/config_pes.xml
@@ -72,7 +72,7 @@
         </nthrds>
       </pes>
     </mach>
-    <mach name="theta|perlmutter|cori-knl|cori-haswell|jlse">
+    <mach name="theta|pm-gpu|pm-cpu|cori-knl|cori-haswell|jlse">
       <pes compset="any" pesize="any">
         <comment>mpas-ocean: default, 1 node x MAX_MPITASKS_PER_NODE mpi x 1 omp @ root 0</comment>
         <ntasks>

--- a/components/mpas-seaice/cime_config/config_pes.xml
+++ b/components/mpas-seaice/cime_config/config_pes.xml
@@ -59,7 +59,7 @@
         </nthrds>
       </pes>
     </mach>
-    <mach name="theta|perlmutter|cori-knl|cori-haswell|jlse">
+    <mach name="theta|pm-gpu|pm-cpu|cori-knl|cori-haswell|jlse">
       <pes compset="any" pesize="any">
         <comment>seaice: default, 1 node x MAX_MPITASKS_PER_NODE mpi x 1 omp @ root 0</comment>
         <ntasks>


### PR DESCRIPTION
For cori use 4 nodes as the default for land-only tests (as it was before changes to layouts)

Change the machine name perlmutter to now be: pm-gpu and/or pm-cpu

Fixes #4959
Fixes #4981
[bfb]