### PR TITLE
Fixed gridcell waterstate restart calls in restFileMod

### DIFF
--- a/components/elm/src/biogeophys/WaterStateType.F90
+++ b/components/elm/src/biogeophys/WaterStateType.F90
@@ -519,12 +519,6 @@ contains
 
     SHR_ASSERT_ALL((ubound(watsat_col) == (/bounds%endc,nlevgrnd/)) , errMsg(__FILE__, __LINE__))
 
-
-    call restartvar(ncid=ncid, flag=flag, varname='TWS_MONTH_BEGIN', xtype=ncd_double,  &
-         dim1name='gridcell', &
-         long_name='surface watertotal water storage at the beginning of a month', units='mm', &
-          interpinic_flag='interp', readvar=readvar, data=this%tws_month_beg_grc)
-
     call restartvar(ncid=ncid, flag=flag, varname='ENDWB_COL', xtype=ncd_double, &
          dim1name='column', long_name='col-level water mass end of the time step', &
          units='mm', interpinic_flag='interp', readvar=readvar, data=this%endwb_col)

--- a/components/elm/src/main/elm_driver.F90
+++ b/components/elm/src/main/elm_driver.F90
@@ -1478,15 +1478,12 @@ contains
           call t_startf('elm_drv_io_wrest')
           filer = restFile_filename(rdate=rdate)
 
-          call restFile_write( bounds_proc, filer,                                            &
-               atm2lnd_vars, aerosol_vars, canopystate_vars, cnstate_vars,                    &
-               carbonstate_vars, c13_carbonstate_vars, c14_carbonstate_vars, carbonflux_vars, &
-               ch4_vars, energyflux_vars, frictionvel_vars, lakestate_vars,        &
-               nitrogenstate_vars, nitrogenflux_vars, photosyns_vars, soilhydrology_vars,     &
-               soilstate_vars, solarabs_vars, surfalb_vars, temperature_vars,                 &
-               waterflux_vars, waterstate_vars, sedflux_vars,                                 &
-               phosphorusstate_vars,phosphorusflux_vars,                                      &
-               ep_betr, alm_fates, crop_vars, rdate=rdate )
+          call restFile_write( bounds_proc, filer,                          &
+               atm2lnd_vars, aerosol_vars, canopystate_vars, cnstate_vars,  &
+               ch4_vars, energyflux_vars, frictionvel_vars, lakestate_vars, &
+               photosyns_vars, soilhydrology_vars,     &
+               soilstate_vars, solarabs_vars, surfalb_vars,  &
+               sedflux_vars, ep_betr, alm_fates, crop_vars, rdate=rdate )
 
          !----------------------------------------------
          ! pflotran (off now)

--- a/components/elm/src/main/elm_initializeMod.F90
+++ b/components/elm/src/main/elm_initializeMod.F90
@@ -753,32 +753,24 @@ contains
              write(iulog,*)'Reading initial conditions from ',trim(finidat)
           end if
           call getfil( finidat, fnamer, 0 )
-          call restFile_read(bounds_proc, fnamer,                                             &
-               atm2lnd_vars, aerosol_vars, canopystate_vars, cnstate_vars,                    &
-               carbonstate_vars, c13_carbonstate_vars, c14_carbonstate_vars, carbonflux_vars, &
-               ch4_vars, energyflux_vars, frictionvel_vars, lakestate_vars,        &
-               nitrogenstate_vars, nitrogenflux_vars, photosyns_vars, soilhydrology_vars,     &
-               soilstate_vars, solarabs_vars, surfalb_vars, temperature_vars,                 &
-               waterflux_vars, waterstate_vars, sedflux_vars,                                 &
-               phosphorusstate_vars,phosphorusflux_vars,                                      &
-               ep_betr,                                                                       &
-               alm_fates, glc2lnd_vars, crop_vars)
+          call restFile_read(bounds_proc, fnamer,                           &
+               atm2lnd_vars, aerosol_vars, canopystate_vars, cnstate_vars,  &
+               ch4_vars, energyflux_vars, frictionvel_vars, lakestate_vars, &
+               photosyns_vars, soilhydrology_vars,                          &
+               soilstate_vars, solarabs_vars, surfalb_vars,                 &
+               sedflux_vars, ep_betr, alm_fates, glc2lnd_vars, crop_vars)
        end if
 
     else if ((nsrest == nsrContinue) .or. (nsrest == nsrBranch)) then
        if (masterproc) then
           write(iulog,*)'Reading restart file ',trim(fnamer)
        end if
-       call restFile_read(bounds_proc, fnamer,                                             &
-            atm2lnd_vars, aerosol_vars, canopystate_vars, cnstate_vars,                    &
-            carbonstate_vars, c13_carbonstate_vars, c14_carbonstate_vars, carbonflux_vars, &
-            ch4_vars, energyflux_vars, frictionvel_vars, lakestate_vars,        &
-            nitrogenstate_vars, nitrogenflux_vars, photosyns_vars, soilhydrology_vars,     &
-            soilstate_vars, solarabs_vars, surfalb_vars, temperature_vars,                 &
-            waterflux_vars, waterstate_vars, sedflux_vars,                                 &
-            phosphorusstate_vars,phosphorusflux_vars,                                      &
-            ep_betr,                                                                       &
-            alm_fates, glc2lnd_vars, crop_vars)
+       call restFile_read(bounds_proc, fnamer,                           &
+            atm2lnd_vars, aerosol_vars, canopystate_vars, cnstate_vars,  &
+            ch4_vars, energyflux_vars, frictionvel_vars, lakestate_vars ,&
+            photosyns_vars, soilhydrology_vars,                          &
+            soilstate_vars, solarabs_vars, surfalb_vars,                 &
+            sedflux_vars, ep_betr, alm_fates, glc2lnd_vars, crop_vars)
 
     end if
 
@@ -805,32 +797,24 @@ contains
          call ep_betr%set_active(bounds_proc, col_pp)
        endif
        ! Create new template file using cold start
-       call restFile_write(bounds_proc, finidat_interp_dest,                               &
-            atm2lnd_vars, aerosol_vars, canopystate_vars, cnstate_vars,                    &
-            carbonstate_vars, c13_carbonstate_vars, c14_carbonstate_vars, carbonflux_vars, &
-            ch4_vars, energyflux_vars, frictionvel_vars, lakestate_vars,        &
-            nitrogenstate_vars, nitrogenflux_vars, photosyns_vars, soilhydrology_vars,     &
-            soilstate_vars, solarabs_vars, surfalb_vars, temperature_vars,                 &
-            waterflux_vars, waterstate_vars, sedflux_vars,                                 &
-            phosphorusstate_vars,phosphorusflux_vars,                                      &
-            ep_betr,                                                                       &
-            alm_fates, crop_vars)
+       call restFile_write(bounds_proc, finidat_interp_dest,             &
+            atm2lnd_vars, aerosol_vars, canopystate_vars, cnstate_vars,  &
+            ch4_vars, energyflux_vars, frictionvel_vars, lakestate_vars, &
+            photosyns_vars, soilhydrology_vars,          &
+            soilstate_vars, solarabs_vars, surfalb_vars, &
+            sedflux_vars, ep_betr, alm_fates, crop_vars)
 
        ! Interpolate finidat onto new template file
        call getfil( finidat_interp_source, fnamer,  0 )
        call initInterp(filei=fnamer, fileo=finidat_interp_dest, bounds=bounds_proc)
 
        ! Read new interpolated conditions file back in
-       call restFile_read(bounds_proc, finidat_interp_dest,                                &
-            atm2lnd_vars, aerosol_vars, canopystate_vars, cnstate_vars,                    &
-            carbonstate_vars, c13_carbonstate_vars, c14_carbonstate_vars, carbonflux_vars, &
-            ch4_vars, energyflux_vars, frictionvel_vars, lakestate_vars,        &
-            nitrogenstate_vars, nitrogenflux_vars, photosyns_vars, soilhydrology_vars,     &
-            soilstate_vars, solarabs_vars, surfalb_vars, temperature_vars,                 &
-            waterflux_vars, waterstate_vars, sedflux_vars,                                 &
-            phosphorusstate_vars,phosphorusflux_vars,                                      &
-            ep_betr,                                                                       &
-            alm_fates, glc2lnd_vars, crop_vars)
+       call restFile_read(bounds_proc, finidat_interp_dest,              &
+            atm2lnd_vars, aerosol_vars, canopystate_vars, cnstate_vars,  &
+            ch4_vars, energyflux_vars, frictionvel_vars, lakestate_vars, &
+            photosyns_vars, soilhydrology_vars,            &
+            soilstate_vars, solarabs_vars, surfalb_vars,   &
+            sedflux_vars, ep_betr, alm_fates, glc2lnd_vars, crop_vars)
 
        ! Reset finidat to now be finidat_interp_dest
        ! (to be compatible with routines still using finidat)

--- a/components/elm/src/main/restFileMod.F90
+++ b/components/elm/src/main/restFileMod.F90
@@ -21,14 +21,8 @@ module restFileMod
   use elm_varcon           , only : c13ratio, c14ratio
   use elm_varcon           , only : nameg, namet, namel, namec, namep, nameCohort
   use CH4Mod               , only : ch4_type
-  use CNCarbonFluxType     , only : carbonflux_type
-  use CNCarbonStateType    , only : carbonstate_type
   use CNStateType          , only : cnstate_type
-  use CNNitrogenFluxType   , only : nitrogenflux_type
-  use CNNitrogenStateType  , only : nitrogenstate_type
   
-  use PhosphorusFluxType     , only : phosphorusflux_type
-  use PhosphorusStateType    , only : phosphorusstate_type
 
   use ELMFatesInterfaceMod , only : hlm_fates_interface_type
 
@@ -43,9 +37,6 @@ module restFileMod
   use SoilStateType        , only : soilstate_type
   use SolarAbsorbedType    , only : solarabs_type
   use SurfaceAlbedoType    , only : surfalb_type
-  use TemperatureType      , only : temperature_type
-  use WaterfluxType        , only : waterflux_type
-  use WaterstateType       , only : waterstate_type
   use atm2lndType          , only : atm2lnd_type
   use lnd2atmType          , only : lnd2atm_type
   use glc2lndMod           , only : glc2lnd_type
@@ -72,7 +63,7 @@ module restFileMod
   use VegetationDataType   , only : veg_cf, c13_veg_cf, c14_veg_cf
   use VegetationDataType   , only : veg_ns, veg_nf
   use VegetationDataType   , only : veg_ps, veg_pf
-  use GridcellDataType     , only : grc_cs
+  use GridcellDataType     , only : grc_cs, grc_ws 
   
   !
   ! !PUBLIC TYPES:
@@ -109,16 +100,12 @@ module restFileMod
 contains
 
   !-----------------------------------------------------------------------
-  subroutine restFile_write( bounds, file,                                            &
-       atm2lnd_vars, aerosol_vars, canopystate_vars, cnstate_vars,                    &
-       carbonstate_vars, c13_carbonstate_vars, c14_carbonstate_vars, carbonflux_vars, &
-       ch4_vars, energyflux_vars, frictionvel_vars, lakestate_vars,        &
-       nitrogenstate_vars, nitrogenflux_vars, photosyns_vars, soilhydrology_vars,     &
-       soilstate_vars, solarabs_vars, surfalb_vars, temperature_vars,                 &
-       waterflux_vars, waterstate_vars, sedflux_vars,                                 &
-       phosphorusstate_vars, phosphorusflux_vars,                                     &
-       ep_betr,                                                                       &
-       alm_fates, crop_vars,                                                          &
+  subroutine restFile_write( bounds, file,                          &
+       atm2lnd_vars, aerosol_vars, canopystate_vars, cnstate_vars,  &
+       ch4_vars, energyflux_vars, frictionvel_vars, lakestate_vars, &
+       photosyns_vars, soilhydrology_vars,                          &
+       soilstate_vars, solarabs_vars, surfalb_vars,                 &
+       sedflux_vars, ep_betr, alm_fates, crop_vars,                 &
        rdate, noptr)
     !
     ! !DESCRIPTION:
@@ -137,27 +124,16 @@ contains
     type(aerosol_type)             , intent(in)    :: aerosol_vars
     type(canopystate_type)         , intent(inout) :: canopystate_vars ! due to EDrest call
     type(cnstate_type)             , intent(inout) :: cnstate_vars
-    type(carbonstate_type)         , intent(inout) :: carbonstate_vars
-    type(carbonstate_type)         , intent(in)    :: c13_carbonstate_vars
-    type(carbonstate_type)         , intent(in)    :: c14_carbonstate_vars
-    type(carbonflux_type)          , intent(inout) :: carbonflux_vars
     type(ch4_type)                 , intent(in)    :: ch4_vars
     type(energyflux_type)          , intent(in)    :: energyflux_vars
     type(frictionvel_type)         , intent(inout) :: frictionvel_vars
     type(lakestate_type)           , intent(in)    :: lakestate_vars
-    type(nitrogenstate_type)       , intent(inout) :: nitrogenstate_vars
-    type(nitrogenflux_type)        , intent(in)    :: nitrogenflux_vars
     type(photosyns_type)           , intent(in)    :: photosyns_vars
     type(sedflux_type)             , intent(in)    :: sedflux_vars
     type(soilhydrology_type)       , intent(in)    :: soilhydrology_vars
     type(soilstate_type)           , intent(inout) :: soilstate_vars
     type(solarabs_type)            , intent(in)    :: solarabs_vars
     type(surfalb_type)             , intent(in)    :: surfalb_vars
-    type(temperature_type)         , intent(in)    :: temperature_vars
-    type(waterstate_type)          , intent(inout) :: waterstate_vars  ! due to EDrest call
-    type(waterflux_type)           , intent(in)    :: waterflux_vars
-    type(phosphorusstate_type)     , intent(inout) :: phosphorusstate_vars
-    type(phosphorusflux_type)      , intent(in)    :: phosphorusflux_vars
     class(betr_simulation_alm_type), intent(inout):: ep_betr
     type(hlm_fates_interface_type) , intent(inout) :: alm_fates
     type(crop_type)                , intent(inout) :: crop_vars
@@ -217,8 +193,6 @@ contains
     call soilstate_vars%restart (bounds, ncid, flag='define')
 
     call solarabs_vars%restart (bounds, ncid, flag='define')
-
-    call waterflux_vars%restart (bounds, ncid, flag='define')
     
     call grc_wf%Restart (bounds, ncid, flag='define')
 
@@ -234,8 +208,8 @@ contains
 
     call veg_es%Restart (bounds, ncid, flag='define')
 
-    call waterstate_vars%restart (bounds, ncid, flag='define', &
-         watsat_col=soilstate_vars%watsat_col(bounds%begc:bounds%endc,:))
+    
+    call grc_ws%Restart(bounds, ncid, flag='define')
     
     call lun_ws%Restart (bounds, ncid, flag='define')
 
@@ -355,8 +329,6 @@ contains
 
     call solarabs_vars%restart (bounds, ncid, flag='write')
 
-    call waterflux_vars%restart (bounds, ncid, flag='write')
-    
     call grc_wf%Restart (bounds, ncid, flag='write')
 
     call col_wf%Restart (bounds, ncid, flag='write')
@@ -371,9 +343,8 @@ contains
 
     call veg_es%Restart (bounds, ncid, flag='write')
 
-    call waterstate_vars%restart (bounds, ncid, flag='write',  &
-         watsat_col=soilstate_vars%watsat_col(bounds%begc:bounds%endc,:) )
-
+    call grc_ws%Restart(bounds, ncid, flag='write')
+    
     call lun_ws%Restart (bounds, ncid, flag='write')
 
     call col_ws%Restart (bounds, ncid, flag='write', &
@@ -479,15 +450,12 @@ contains
   end subroutine restFile_write
 
   !-----------------------------------------------------------------------
-  subroutine restFile_read( bounds, file,                                             &
-       atm2lnd_vars, aerosol_vars, canopystate_vars, cnstate_vars,                    &
-       carbonstate_vars, c13_carbonstate_vars, c14_carbonstate_vars, carbonflux_vars, &
-       ch4_vars, energyflux_vars, frictionvel_vars, lakestate_vars,        &
-       nitrogenstate_vars, nitrogenflux_vars, photosyns_vars, soilhydrology_vars,     &
-       soilstate_vars, solarabs_vars, surfalb_vars, temperature_vars,                 &
-       waterflux_vars, waterstate_vars, sedflux_vars,                                 &
-       phosphorusstate_vars,phosphorusflux_vars,                                      &
-       ep_betr,                                                                       &
+  subroutine restFile_read( bounds, file,                           &
+       atm2lnd_vars, aerosol_vars, canopystate_vars, cnstate_vars,  &
+       ch4_vars, energyflux_vars, frictionvel_vars, lakestate_vars, &
+       photosyns_vars, soilhydrology_vars,                          &
+       soilstate_vars, solarabs_vars, surfalb_vars,                 &
+       sedflux_vars, ep_betr,                                       &
        alm_fates, glc2lnd_vars, crop_vars)
     !
     ! !DESCRIPTION:
@@ -512,27 +480,16 @@ contains
     type(aerosol_type)             , intent(inout) :: aerosol_vars
     type(canopystate_type)         , intent(inout) :: canopystate_vars
     type(cnstate_type)             , intent(inout) :: cnstate_vars
-    type(carbonstate_type)         , intent(inout) :: carbonstate_vars
-    type(carbonstate_type)         , intent(inout) :: c13_carbonstate_vars
-    type(carbonstate_type)         , intent(inout) :: c14_carbonstate_vars
-    type(carbonflux_type)          , intent(inout) :: carbonflux_vars
     type(ch4_type)                 , intent(inout) :: ch4_vars
     type(energyflux_type)          , intent(inout) :: energyflux_vars
     type(frictionvel_type)         , intent(inout) :: frictionvel_vars
     type(lakestate_type)           , intent(inout) :: lakestate_vars
-    type(nitrogenstate_type)       , intent(inout) :: nitrogenstate_vars
-    type(nitrogenflux_type)        , intent(inout) :: nitrogenflux_vars
     type(photosyns_type)           , intent(inout) :: photosyns_vars
     type(sedflux_type)             , intent(inout) :: sedflux_vars
     type(soilhydrology_type)       , intent(inout) :: soilhydrology_vars
     type(soilstate_type)           , intent(inout) :: soilstate_vars
     type(solarabs_type)            , intent(inout) :: solarabs_vars
-    type(temperature_type)         , intent(inout) :: temperature_vars
     type(surfalb_type)             , intent(inout) :: surfalb_vars
-    type(waterstate_type)          , intent(inout) :: waterstate_vars
-    type(waterflux_type)           , intent(inout) :: waterflux_vars
-    type(phosphorusstate_type)     , intent(inout) :: phosphorusstate_vars
-    type(phosphorusflux_type)      , intent(inout) :: phosphorusflux_vars
     class(betr_simulation_alm_type), intent(inout) :: ep_betr
     type(hlm_fates_interface_type) , intent(inout) :: alm_fates
     type(glc2lnd_type)             , intent(inout) :: glc2lnd_vars
@@ -595,8 +552,6 @@ contains
 
     call solarabs_vars%restart (bounds, ncid, flag='read')
 
-    call waterflux_vars%restart (bounds, ncid, flag='read')
-    
     call grc_wf%Restart (bounds, ncid, flag='read')
 
     call col_wf%Restart (bounds, ncid, flag='read')
@@ -611,8 +566,7 @@ contains
 
     call veg_es%Restart (bounds, ncid, flag='read')
 
-    call waterstate_vars%restart (bounds, ncid,  flag='read', &
-         watsat_col=soilstate_vars%watsat_col(bounds%begc:bounds%endc,:) )
+    call grc_ws%Restart(bounds, ncid, flag='read')
 
     call lun_ws%Restart (bounds, ncid, flag='read')
 


### PR DESCRIPTION
When grc_ws replaced part of waterstate_vars, restFileMod was not adjusted.
References to all unused data types were also removed from restFileMod.

Tested on chrysalis and resolved restart comparison errors.
Tested against e3sm_developer test suite.
Fixes #4649
[BFB]