### PR TITLE
Corrected FV metric terms in sea ice dynamics

### DIFF
--- a/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver_weak.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver_weak.F
@@ -629,9 +629,9 @@ contains
 
           ! metric terms
           stressDivergenceU(iVertex) = stressDivergenceU(iVertex) - &
-               (tan(latVertexRotated(iVertex)) * stress12Vertex * 2.0_RKIND) / sphereRadius
+               (tan(latVertexRotated(iVertex)) * stress12Vertex) / sphereRadius
           stressDivergenceV(iVertex) = stressDivergenceV(iVertex) + &
-               (tan(latVertexRotated(iVertex)) * (stress11Vertex - stress22Vertex)) / sphereRadius
+               (tan(latVertexRotated(iVertex)) * stress11Vertex) / sphereRadius
 
        endif ! solveVelocity
 


### PR DESCRIPTION
Corrected metric terms in the FV formulation of the sea ice dynamics. The FV formulation is not used by E3SM. 

Fixes https://github.com/E3SM-Project/E3SM/issues/4994

[BFB]
