### PR TITLE
Revive capability to run FIDEAL compset

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -101,7 +101,7 @@ _TESTS = {
             "ERS_Ld5.ne4_oQU240.F2010.eam-rrtmgpxx",
             "REP_Ln5.ne4_oQU240.F2010",
             "SMS_Ld9.ne4pg2_oQU480.F2010.eam-thetahy_sl_pg2_mass",
-            "SMS_Ld9.ne4_ne4.FIDEAL",
+            "ERP_Ld9.ne4_ne4.FIDEAL",
             )
         },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -101,6 +101,7 @@ _TESTS = {
             "ERS_Ld5.ne4_oQU240.F2010.eam-rrtmgpxx",
             "REP_Ln5.ne4_oQU240.F2010",
             "SMS_Ld9.ne4pg2_oQU480.F2010.eam-thetahy_sl_pg2_mass",
+            "SMS_Ld9.ne4_ne4.FIDEAL",
             )
         },
 

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -1555,19 +1555,17 @@ if ( $prescribed_aero_model ne 'none' ) {
 
 # Construct the aerosol part of the rad_climate string array by looping over
 # the aerosol names and getting the default properties file for each:
-if ($aer_model != 'none') {
-    foreach my $name (@aero_names) {
-        my $source = shift(@aerosources);
-        my $file;
-        if ($source =~ 'M') {
+foreach my $name (@aero_names) {
+    my $source = shift(@aerosources);
+    my $file;
+    if ($source =~ 'M') {
         $file = "${name}_file";
-        } else {
-            $file = "${aer_model}_$name";
-        }
-        my $rel_filepath = get_default_value($file);
-        my $abs_filepath = set_abs_filepath($rel_filepath, $inputdata_rootdir);
-        $radval .= "," . quote_string($source . $name . ":" . $abs_filepath);
+    } else {
+        $file = "${aer_model}_$name";
     }
+    my $rel_filepath = get_default_value($file);
+    my $abs_filepath = set_abs_filepath($rel_filepath, $inputdata_rootdir);
+    $radval .= "," . quote_string($source . $name . ":" . $abs_filepath);
 }
 
 # Eruptive volcanic aerosols can be run with either BAM or MAM.

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -550,7 +550,6 @@ if ($dyn =~ /se/) {add_default($nl, 'vect_map', 'val'=>'cart3d');}
 
 # Adiabatic or Ideal physics
 my $phys = $cfg->get('phys');
-# TODO: I do not think these are used in E3SM anymore, and should be removed.
 if ($phys eq 'adiabatic') { add_default($nl, 'atm_adiabatic',  'val'=>'.true.'); }
 if ($phys eq 'ideal')     { add_default($nl, 'atm_ideal_phys', 'val'=>'.true.'); }
 

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -1586,7 +1586,7 @@ if ($nl->get_value('strat_aero_feedback') =~ /$TRUE/io) {
     $radval .= "," . quote_string("N:H2SO4M:" . $abs_filepath);
 }
 
-if (!$ideal_or_adia_or_aqua) {
+if ( !($phys eq 'ideal' or $phys eq 'adiabatic') ) {
     add_default($nl, 'rad_climate', 'val'=>$radval);
 }
 

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -779,11 +779,9 @@ if ($opts{'ignore_ic_date'}) {
     # Don't set any attribute for date matching.  By putting this option first it
     # will take precedence in the case that the user has set both -ignore_ic_date
     # and -ignore_ic_year
-}
-elsif ($opts{'ignore_ic_year'}) {
+} elsif ($opts{'ignore_ic_year'}) {
     $atts{'ic_md'} = $ic_date;
-}
-else {
+} else {
     # if neither option specified then match full date
     $atts{'ic_ymd'} = $ic_date;
 }
@@ -806,7 +804,6 @@ add_default($nl,'microp_aero_wsub_scheme');
 add_default($nl,'microp_aero_wsubmin');
 add_default($nl,'use_preexisting_ice');
 
-
 #BSINGH - (when .true.)calculate solar zenith angle averaged over a time step.
 #In default model, solar zenith angle is held constant over time.
 #This flag is kept to test b4b with the default code(this must be REMOVED when we decide to make it default)
@@ -817,11 +814,14 @@ add_default($nl,'use_rad_dt_cosz');
 #if 0., no rayleigh friction is applied
 add_default($nl, 'raytau0');
 
-# these options werre added for global RCE and they only work with RRTMGP
-my $rad_pkg = $cfg->get('rad');
-if ($rad_pkg eq 'rrtmgp') {
-  add_default($nl,'do_aerosol_rad');
-  add_default($nl,'fixed_total_solar_irradiance');
+# these options were added for global RCE and they only work with RRTMGP
+my $rad_pkg = 'none';
+if (!(($phys eq 'ideal') or ($phys eq 'adiabatic'))) {
+    my $rad_pkg = $cfg->get('rad');
+    if ($rad_pkg eq 'rrtmgp') {
+      add_default($nl,'do_aerosol_rad');
+      add_default($nl,'fixed_total_solar_irradiance');
+    }
 }
 
 #
@@ -866,6 +866,7 @@ if (defined $nl->get_value('solar_const') and
 
 }
 
+# TODO: should this include rrtmgp as well?
 if ($rad_pkg eq 'rrtmg' or $chem =~ /waccm_mozart/) {
 
    if (defined $nl->get_value('solar_const')) {
@@ -921,14 +922,15 @@ if ($co2_cycle) {
     # transient run ...
     if ($sim_year =~ /(\d+)-(\d+)/) {
 
-	add_default($nl, 'co2_readflux_fuel', 'val'=>'.true.');
+        add_default($nl, 'co2_readflux_fuel', 'val'=>'.true.');
 
-	# Check whether user has explicitly turned off reading the fossil fuel dataset.
-	# (user specification has higher precedence than the true value set above)
-	if ($nl->get_value('co2_readflux_fuel') =~ /$TRUE/io) {
-	    add_default($nl, 'co2flux_fuel_file', 'sim_year'=>$sim_year);
-	}
-
+        # Check whether user has explicitly turned off reading the fossil fuel dataset.
+        # (user specification has higher precedence than the true value set above)
+        if ($nl->get_value('co2_readflux_fuel') =~ /$TRUE/io) {
+            add_default($nl, 'co2flux_fuel_file', 'sim_year'=>$sim_year);
+        }
+        
+        # change the default value from '.true.' to '.false.'
         add_default($nl, 'co2_readflux_aircraft', 'val'=>'.false.');
 
         # Check whether user has explicitly turned off reading the aircraft CO2 dataset.
@@ -941,7 +943,7 @@ if ($co2_cycle) {
 
             add_default($nl, 'aircraft_datapath');
             add_default($nl, 'aircraft_type', 'val'=>'SERIAL');
-	}		   
+        }
     }
 }
 
@@ -954,12 +956,6 @@ my $co2_cycle_rad_passive = ($nl->get_value('co2_cycle_rad_passive') =~ /$TRUE/i
 # If test tracers have been requested, set tracers_flag=.true.
 if ($cfg->get('nadv_tt')) { add_default($nl, 'tracers_flag', 'val'=>'.true.'); }
 if ($cfg->get('age_of_air_trcs')) { add_default($nl, 'aoa_tracers_flag', 'val'=>'.true.'); }
-
-# If phys option is "cam3" then turn on the CAM3 prescribed ozone and aerosols
-if ($phys eq 'cam3' and !$aqua_mode) {
-    add_default($nl, 'cam3_ozone_data_on', 'val'=>'.true.');
-    add_default($nl, 'cam3_aero_data_on', 'val'=>'.true.');
-}
 
 # Defaults for radiatively active constituents
 
@@ -1067,26 +1063,26 @@ my $prescribed_aero_model = $nl->get_value('prescribed_aero_model');
 if (defined $prescribed_aero_model) {
     # Strip the quotes from namelist input
     $prescribed_aero_model =~ s/['"]//g;                 #"'
-}
-else {
+} else {
     $prescribed_aero_model = 'none';
     if ($chem eq 'none' or $chem eq 'waccm_ghg' or $chem eq 'super_fast_llnl' or $chem eq 'waccm_mozart' or $chem eq 'waccm_mozart_sulfur') {
-	# If no chemistry then there must be prescribed aerosols unless physics
-	# package is adiabatic or ideal.
-	if ($phys eq 'default') {
-	    $prescribed_aero_model = 'modal';
-	}
-	elsif ($phys eq 'cam4' or $phys eq 'cam3') {
-	    $prescribed_aero_model = 'bulk';
-	}
+        # If no chemistry then there must be prescribed aerosols unless physics
+        # package is adiabatic or ideal.
+        if ($phys eq 'default') {
+            $prescribed_aero_model = 'modal';
+        }
     }
 }
 
 
-# $aer_model is either 'bam' or 'mam'.  This token is used in the element names that
+# $aer_model is 'none', 'bam', or 'mam'.  This token is used in the element names that
 # are constructed to get the default physprops files.
-my $aer_model = 'bam';
-if ($prescribed_aero_model eq 'modal' or $chem =~ /_mam/) {$aer_model = 'mam';}
+my $aer_model = 'none';
+if ($prescribed_aero_model eq 'modal' or $chem =~ /_mam/) {
+  $aer_model = 'mam';
+} elsif($chem =~ /_bam/) {
+  $aer_model = 'bam';
+}
 
 if ($aer_model eq 'mam' ) {
 
@@ -1134,8 +1130,7 @@ if ($aer_model eq 'mam' ) {
 	    [qw(so4_c2 soa_c2 ncl_c2)],
 	    [qw(dst_c3 ncl_c3 so4_c3)],
 	    );
-    }
-    else{
+    } else {
 	 @mode_spec     = (
             [qw(so4_a1 pom_a1 soa_a1 bc_a1 dst_a1 ncl_a1)],
             [qw(so4_a2 soa_a2 ncl_a2)],
@@ -1295,8 +1290,7 @@ if ($aer_model eq 'mam' ) {
 	    [qw(A A A)],
 	    [qw(A A A)],
 	    );
-    }
-    else{
+    } else{
 	@mode_spec     = (
             [qw(so4_a1 pom_a1 soa_a1 bc_a1 dst_a1 ncl_a1 mom_a1)],
             [qw(so4_a2 soa_a2 ncl_a2 mom_a2)],
@@ -1448,7 +1442,7 @@ if ($aer_model eq 'mam' ) {
   # water refractive index properties needed for modal optics calculations
   add_default($nl, 'water_refindex_file');
 
-} else {
+} elsif($aer_model eq 'bam') {
 
   # bulk aerosol contributions
 
@@ -1533,11 +1527,11 @@ if ( $prescribed_aero_model ne 'none' ) {
   if ($moz_aero_data =~ /$TRUE/io ) {
       # If user has not set prescribed_aero_file, then use defaults
       unless (defined $nl->get_value('prescribed_aero_file')) {
-	  my @settings = ('prescribed_aero_datapath', 'prescribed_aero_file', 'prescribed_aero_type',
-			'prescribed_aero_cycle_yr');
-	  foreach my $setting (@settings) {
-	      add_default($nl, $setting, 'aer_model'=>$aer_model);
-	  }
+          my @settings = ('prescribed_aero_datapath', 'prescribed_aero_file', 'prescribed_aero_type',
+                'prescribed_aero_cycle_yr');
+          foreach my $setting (@settings) {
+              add_default($nl, $setting, 'aer_model'=>$aer_model);
+          }
       }
   }
 
@@ -1546,36 +1540,39 @@ if ( $prescribed_aero_model ne 'none' ) {
   if ( (($moz_aero_data =~ /$TRUE/io) or ($cam3_aero_data =~ /$TRUE/io)) and !$aqua_mode ) {
       # If user has not set aerodep_flx_file, then use defaults
       unless (defined $nl->get_value('aerodep_flx_file')) {
-	  my @settings = ('aerodep_flx_datapath', 'aerodep_flx_file', 'aerodep_flx_type',
-			'aerodep_flx_cycle_yr');
-	  foreach my $setting (@settings) {
-	      add_default($nl, $setting, 'aer_model'=>$aer_model);
-	  }
+          my @settings = ('aerodep_flx_datapath', 'aerodep_flx_file', 'aerodep_flx_type',
+                'aerodep_flx_cycle_yr');
+          foreach my $setting (@settings) {
+              add_default($nl, $setting, 'aer_model'=>$aer_model);
+          }
       }
   }
 }
 
 # Construct the aerosol part of the rad_climate string array by looping over
 # the aerosol names and getting the default properties file for each:
-foreach my $name (@aero_names) {
-    my $source = shift(@aerosources);
-    my $file;
-    if ($source =~ 'M') {
-	$file = "${name}_file";
+if ($aer_model != 'none') {
+    foreach my $name (@aero_names) {
+        my $source = shift(@aerosources);
+        my $file;
+        if ($source =~ 'M') {
+        $file = "${name}_file";
+        } else {
+            $file = "${aer_model}_$name";
+        }
+        my $rel_filepath = get_default_value($file);
+        my $abs_filepath = set_abs_filepath($rel_filepath, $inputdata_rootdir);
+        $radval .= "," . quote_string($source . $name . ":" . $abs_filepath);
     }
-    else {
-	$file = "${aer_model}_$name";
-    }
-    my $rel_filepath = get_default_value($file);
-    my $abs_filepath = set_abs_filepath($rel_filepath, $inputdata_rootdir);
-    $radval .= "," . quote_string($source . $name . ":" . $abs_filepath);
 }
 
 # Eruptive volcanic aerosols can be run with either BAM or MAM.
-if ($rad_volcaero_mmr) {
-    my $rel_filepath = get_default_value("VOLC_MMR");
-    my $abs_filepath = set_abs_filepath($rel_filepath, $inputdata_rootdir);
-    $radval .= "," . quote_string("N:VOLC_MMR:" . $abs_filepath);
+if (($aer_model eq 'mam') or ($aer_model eq 'bam')) {
+    if ($rad_volcaero_mmr) {
+        my $rel_filepath = get_default_value("VOLC_MMR");
+        my $abs_filepath = set_abs_filepath($rel_filepath, $inputdata_rootdir);
+        $radval .= "," . quote_string("N:VOLC_MMR:" . $abs_filepath);
+    }
 }
 
 # Stratospheric sulfur aerosols 
@@ -1585,7 +1582,9 @@ if ($nl->get_value('strat_aero_feedback') =~ /$TRUE/io) {
     $radval .= "," . quote_string("N:H2SO4M:" . $abs_filepath);
 }
 
-add_default($nl, 'rad_climate', 'val'=>$radval);
+if (! (($phys eq 'ideal') or ($phys eq 'adiabatic'))) {
+    add_default($nl, 'rad_climate', 'val'=>$radval);
+}
 
 # Cloud optics; for MMF be specific about which optics package to use
 if ($rad_pkg eq 'rrtmg' or $rad_pkg eq 'rrtmgp') {

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -550,8 +550,16 @@ if ($dyn =~ /se/) {add_default($nl, 'vect_map', 'val'=>'cart3d');}
 
 # Adiabatic or Ideal physics
 my $phys = $cfg->get('phys');
+# TODO: I do not think these are used in E3SM anymore, and should be removed.
 if ($phys eq 'adiabatic') { add_default($nl, 'atm_adiabatic',  'val'=>'.true.'); }
 if ($phys eq 'ideal')     { add_default($nl, 'atm_ideal_phys', 'val'=>'.true.'); }
+
+# Ideal physics option
+# TODO: roll this into phys option so that ideal physics is identified not by phys="ideal", but
+# "held-suarez", "held-suarez-williamson", "held-suarez-lin-williamson", etc.
+if ($phys eq 'ideal') {
+    add_default($nl, 'ideal_phys_option', 'val'=>'held-suarez');
+}
 
 # Aqua planet 
 my $aqua_mode = $cfg->get('aquaplanet');
@@ -816,7 +824,7 @@ add_default($nl, 'raytau0');
 
 # these options were added for global RCE and they only work with RRTMGP
 my $rad_pkg = 'none';
-if (!(($phys eq 'ideal') or ($phys eq 'adiabatic'))) {
+if (!$ideal_or_adia_or_aqua) {
     my $rad_pkg = $cfg->get('rad');
     if ($rad_pkg eq 'rrtmgp') {
       add_default($nl,'do_aerosol_rad');
@@ -1582,7 +1590,7 @@ if ($nl->get_value('strat_aero_feedback') =~ /$TRUE/io) {
     $radval .= "," . quote_string("N:H2SO4M:" . $abs_filepath);
 }
 
-if (! (($phys eq 'ideal') or ($phys eq 'adiabatic'))) {
+if (!$ideal_or_adia_or_aqua) {
     add_default($nl, 'rad_climate', 'val'=>$radval);
 }
 

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -822,13 +822,10 @@ add_default($nl,'use_rad_dt_cosz');
 add_default($nl, 'raytau0');
 
 # these options were added for global RCE and they only work with RRTMGP
-my $rad_pkg = 'none';
-if (!$ideal_or_adia_or_aqua) {
-    my $rad_pkg = $cfg->get('rad');
-    if ($rad_pkg eq 'rrtmgp') {
-      add_default($nl,'do_aerosol_rad');
-      add_default($nl,'fixed_total_solar_irradiance');
-    }
+my $rad_pkg = $cfg->get('rad');
+if ($rad_pkg eq 'rrtmgp') {
+  add_default($nl,'do_aerosol_rad');
+  add_default($nl,'fixed_total_solar_irradiance');
 }
 
 #

--- a/components/eam/bld/config_files/definition.xml
+++ b/components/eam/bld/config_files/definition.xml
@@ -71,7 +71,7 @@ PBL package: uw (University of Washington), hb (Holtslag and Boville), hbr
  For the MMF a "none" is set by default, but a separate version of 
  the HB scheme is used for stability.
 </entry>
-<entry id="rad" valid_values="rrtmg,rrtmgp" value="">
+<entry id="rad" valid_values="rrtmg,rrtmgp,none" value="">
 Radiative transfer calculation: 
 rrtmg (RRTMG; http://rtweb.aer.com/rrtm_frame.html), rrtmgp (RRTMGP; https://github.com/earth-system-radiation/rte-rrtmgp).
 </entry>

--- a/components/eam/bld/configure
+++ b/components/eam/bld/configure
@@ -1036,6 +1036,7 @@ my $rad_pkg = 'rrtmg';
 if (defined $opts{'rad'}) {
     $rad_pkg = lc($opts{'rad'});
 }
+if ($phys_pkg =~ /ideal|adiabatic/) { $rad_pkg = 'none'; }
 $cfg_ref->set('rad', $rad_pkg);
 
 if ($print>=2) { print "Radiation package: $rad_pkg$eol"; }
@@ -2610,7 +2611,13 @@ sub write_filepath
     print $fh "$camsrcdir/eam/src/chemistry/utils\n";
 
     # Add source code directories for selected radiation package
-    if ($rad eq 'rrtmg') {
+    # Note: need to add rad code even for rad none because source code in CAM
+    # physics folder needs constants defined in radconstants.F90. A better
+    # approach would be to separate components/eam/src/physics/cam into
+    # something like physics/share, physics/eam, and physics/ideal, and then
+    # only include the modules actually needed by the code. This would remove
+    # the need to build a rad package when no rad package is used.
+    if ($rad eq 'rrtmg' or $rad eq 'none') {
         print $fh "$camsrcdir/eam/src/physics/rrtmg\n";
         print $fh "$camsrcdir/eam/src/physics/rrtmg/ext/rrtmg_mcica\n";
         print $fh "$camsrcdir/eam/src/physics/rrtmg/ext/rrtmg_lw\n";

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -11,7 +11,6 @@
 <dtime dyn="se"                    >1800</dtime>
 <dtime dyn="se"    hgrid="ne4np4"  >7200</dtime>
 <dtime dyn="se"    hgrid="ne11np4" >7200</dtime>
-<dtime dyn="se"    hgrid="ne16np4" >1800</dtime>
 <dtime dyn="se"    hgrid="ne30np4" >1800</dtime>
 <dtime dyn="se"    hgrid="ne45np4" >1200</dtime>
 <dtime dyn="se"    hgrid="ne60np4" >1800</dtime>
@@ -1314,6 +1313,9 @@
 <se_tstep dyn_target="theta-l" hgrid="ne0np4_enax4v1"> 75 </se_tstep>
 <se_tstep dyn_target="theta-l" hgrid="ne0np4_twpx4v1"> 75 </se_tstep>
 
+<dt_remap_factor     dyn_target="theta-l" hgrid="ne16np4"> 3    </dt_remap_factor>
+<dt_tracer_factor    dyn_target="theta-l" hgrid="ne16np4"> 3    </dt_tracer_factor>
+<hypervis_subcycle_q dyn_target="theta-l" hgrid="ne16np4"> 3    </hypervis_subcycle_q>
 
 <se_tstep            dyn_target="theta-l" hgrid="ne240np4"> 37.5 </se_tstep>
 <dt_tracer_factor    dyn_target="theta-l" hgrid="ne240np4"> 8    </dt_tracer_factor>

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -156,7 +156,8 @@
 <bnd_topo hgrid="ne0np4_twpx4v1" >atm/cam/topo/USGS_twpx4v1_tensor12x_consistentSGH_170629.nc</bnd_topo>
 
 <!-- ieflx_opt 0: atmonly, 3: coupled -->
-<ieflx_opt  ocn="docn" >0</ieflx_opt>
+<ieflx_opt  ocn="socn"  >0</ieflx_opt>
+<ieflx_opt  ocn="docn"  >0</ieflx_opt>
 <ieflx_opt  ocn="mpaso" >3</ieflx_opt>
 
 <!-- Bulk aerosol physical properties (includes optics) -->
@@ -1641,12 +1642,13 @@ with se_tstep, dt_remap_factor, dt_tracer_factor set to -1
 <!-- set default parameter values for v2, moved from use_case file -->
 
 <!-- Ice nucleation mods-->
+<use_hetfrz_classnuc               >.false.</use_hetfrz_classnuc>
+<hist_hetfrz_classnuc              >.false.</hist_hetfrz_classnuc>
 <use_hetfrz_classnuc phys="default">.true.</use_hetfrz_classnuc>
 <use_hetfrz_classnuc MMF_microphysics_scheme="sam1mom">.false.</use_hetfrz_classnuc>
-<use_preexisting_ice phys="default">.false.</use_preexisting_ice>
-<hist_hetfrz_classnuc phys="default">.false.</hist_hetfrz_classnuc>
+<use_preexisting_ice               >.false.</use_preexisting_ice>
 <micro_mg_dcs_tdep phys="default">.true.</micro_mg_dcs_tdep>
-<microp_aero_wsub_scheme phys="default">1</microp_aero_wsub_scheme>
+<microp_aero_wsub_scheme               >1</microp_aero_wsub_scheme>
 
 <!-- For Polar mods-->
 <sscav_tuning phys="default">.true.</sscav_tuning>
@@ -1694,13 +1696,13 @@ with se_tstep, dt_remap_factor, dt_tracer_factor set to -1
 <zmconv_trigdcape_ull phys="default"> .true.     </zmconv_trigdcape_ull>
 <cld_sed phys="default" microphys="mg2"> 1.0D0      </cld_sed>
 <effgw_beres phys="default"> 0.35       </effgw_beres>
-<gw_convect_hcf phys="default"> 10.0       </gw_convect_hcf>
+<gw_convect_hcf               > 10.0       </gw_convect_hcf>
 <effgw_oro phys="default"> 0.375      </effgw_oro>
 <use_gw_energy_fix phys="default"> .true.      </use_gw_energy_fix>
 <clubb_C14 phys="default"> 2.5D0      </clubb_C14>
 <clubb_tk1 phys="default"> 268.15D0   </clubb_tk1>
 <dust_emis_fact phys="default"> 1.50D0     </dust_emis_fact>
-<linoz_psc_T phys="default"> 197.5      </linoz_psc_T>
+<linoz_psc_T               > 197.5      </linoz_psc_T>
 <micro_mincdnc phys="default" microphys="mg2"> 10.D6      </micro_mincdnc>
 <clubb_C1 phys="default"> 2.4        </clubb_C1>
 <clubb_C11 phys="default"> 0.70       </clubb_C11>
@@ -1730,7 +1732,7 @@ with se_tstep, dt_remap_factor, dt_tracer_factor set to -1
 <zmconv_mx_bot_lyr_adj phys="default"> 1          </zmconv_mx_bot_lyr_adj>
 <prc_exp1 phys="default"  microphys="mg2"> -1.40D0    </prc_exp1>
 <micro_mg_accre_enhan_fac phys="default" microphys="mg2"> 1.75D0     </micro_mg_accre_enhan_fac>
-<microp_aero_wsubmin phys="default"> 0.001D0    </microp_aero_wsubmin>
+<microp_aero_wsubmin               > 0.001D0    </microp_aero_wsubmin>
 <so4_sz_thresh_icenuc phys="default"> 0.080e-6   </so4_sz_thresh_icenuc>
 <micro_mg_berg_eff_factor phys="default" clubb_sgs="1"> 0.7D0      </micro_mg_berg_eff_factor>
 <cldfrc_dp1  phys="default"> 0.018D0    </cldfrc_dp1>

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -367,6 +367,7 @@
 
 <radiation_scheme rad="rrtmg">rrtmg</radiation_scheme>
 <radiation_scheme rad="rrtmgp">rrtmgp</radiation_scheme>
+<radiation_scheme rad="none">none</radiation_scheme>
 
 <!-- CAM-Chem ozone (2000 climatology) -->
 <prescribed_ozone_datapath>atm/cam/ozone</prescribed_ozone_datapath>

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -3430,6 +3430,12 @@ cache file to be consistent with how CAM was built.
 Default: set by build-namelist
 </entry>
 
+<entry id="ideal_phys_option" type="char*128" group="phys_ctl_nl"
+       valid_values="held-suarez,held-suarez-williamson,held-suarez-lin-williamson">
+Type of idealized physics configuration to use if running cam_physpkg="ideal".
+Default: held-suarez
+</entry>
+
 <entry id="cam_chempkg" type="char*16" category="build"
        group="phys_ctl_nl" valid_values="waccm_mozart,waccm_ghg,trop_mozart,
                                          trop_ghg,trop_bam,trop_mam3,trop_mam4,trop_mam4_resus_soag,

--- a/components/eam/src/control/cam_control_mod.F90
+++ b/components/eam/src/control/cam_control_mod.F90
@@ -65,7 +65,7 @@ subroutine cam_ctrl_set_physics_type(phys_package)
   character(len=*), parameter :: subname = 'cam_ctrl_set_physics_type'
 
   adiabatic = trim(phys_package) == 'adiabatic'
-  ideal_phys = trim(phys_package) == 'held_suarez'
+  ideal_phys = trim(phys_package) == 'ideal'
   moist_physics = .not. (adiabatic .or. ideal_phys)
   if (adiabatic .and. ideal_phys) then
     call endrun (subname//': FATAL: Only one of ADIABATIC or HELD_SUAREZ can be .true.')

--- a/components/eam/src/dynamics/se/dyn_comp.F90
+++ b/components/eam/src/dynamics/se/dyn_comp.F90
@@ -284,7 +284,7 @@ CONTAINS
 
                 elem(ie)%state%q(:,:,:,:)=0.0_r8
 
-                temperature(:,:,:)=0.0_r8
+                temperature(:,:,:)=300.0_r8
                 ps=ps0
                 call set_thermostate(elem(ie),ps,temperature,hvcoord)
 

--- a/components/eam/src/physics/cam/phys_control.F90
+++ b/components/eam/src/physics/cam/phys_control.F90
@@ -55,6 +55,7 @@ character(len=16) :: shallow_scheme       = unset_str  ! shallow convection pack
 character(len=16) :: eddy_scheme          = unset_str  ! vertical diffusion package
 character(len=16) :: microp_scheme        = unset_str  ! microphysics package
 character(len=16) :: macrop_scheme        = unset_str  ! macrophysics package
+character(len=128) :: ideal_phys_option   = unset_str  ! Option for idealized physics
 character(len=16) :: radiation_scheme     = unset_str  ! radiation package
 integer           :: srf_flux_avg         = unset_int  ! 1 => smooth surface fluxes, 0 otherwise
 integer           :: conv_water_in_rad    = unset_int  ! 0==> No; 1==> Yes-Arithmetic average;
@@ -210,7 +211,7 @@ subroutine phys_ctl_readnl(nlfile)
       mam_amicphys_optaa, n_so4_monolayers_pcage,micro_mg_accre_enhan_fac, &
       l_tracer_aero, l_vdiff, l_rayleigh, l_gw_drag, l_ac_energy_chk, &
       l_bc_energy_fix, l_dry_adj, l_st_mac, l_st_mic, l_rad, prc_coef1,prc_exp,prc_exp1,cld_sed,mg_prc_coeff_fix, &
-      rrtmg_temp_fix
+      rrtmg_temp_fix, ideal_phys_option
    !-----------------------------------------------------------------------------
 
    if (masterproc) then
@@ -238,6 +239,7 @@ subroutine phys_ctl_readnl(nlfile)
    call mpibcast(microp_scheme,    len(microp_scheme)    , mpichar, 0, mpicom)
    call mpibcast(radiation_scheme, len(radiation_scheme) , mpichar, 0, mpicom)
    call mpibcast(macrop_scheme,    len(macrop_scheme)    , mpichar, 0, mpicom)
+   call mpibcast(ideal_phys_option,len(ideal_phys_option), mpichar, 0, mpicom)
    call mpibcast(srf_flux_avg,                    1 , mpiint,  0, mpicom)
    call mpibcast(MMF_microphysics_scheme, len(MMF_microphysics_scheme) , mpichar, 0, mpicom)
    call mpibcast(MMF_orientation_angle,           1 , mpir8,   0, mpicom)
@@ -457,7 +459,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
                         history_aerosol_out, history_aero_optics_out, history_eddy_out, &
                         history_budget_out, history_budget_histfile_num_out, history_waccm_out, &
                         history_clubb_out, ieflx_opt_out, conv_water_in_rad_out, cam_chempkg_out, &
-                        prog_modal_aero_out, macrop_scheme_out, &
+                        prog_modal_aero_out, macrop_scheme_out, ideal_phys_option_out, &
                         use_MMF_out, use_ECPP_out, MMF_microphysics_scheme_out, &
                         MMF_orientation_angle_out, use_MMF_VT_out, MMF_VT_wn_max_out, &
                         use_crm_accel_out, crm_accel_factor_out, crm_accel_uv_out, &
@@ -490,6 +492,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
    character(len=16), intent(out), optional :: microp_scheme_out
    character(len=16), intent(out), optional :: radiation_scheme_out
    character(len=16), intent(out), optional :: macrop_scheme_out
+   character(len=128), intent(out), optional :: ideal_phys_option_out 
    character(len=16), intent(out), optional :: MMF_microphysics_scheme_out
    real(r8),          intent(out), optional :: MMF_orientation_angle_out
    logical,           intent(out), optional :: use_MMF_out
@@ -578,6 +581,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
 
    if ( present(use_subcol_microp_out   ) ) use_subcol_microp_out    = use_subcol_microp
    if ( present(macrop_scheme_out       ) ) macrop_scheme_out        = macrop_scheme
+   if ( present(ideal_phys_option_out   ) ) ideal_phys_option_out    = ideal_phys_option
    if ( present(atm_dep_flux_out        ) ) atm_dep_flux_out         = atm_dep_flux
    if ( present(history_aerosol_out     ) ) history_aerosol_out      = history_aerosol
    if ( present(history_aero_optics_out ) ) history_aero_optics_out  = history_aero_optics

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -1018,7 +1018,7 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
     
     if ( adiabatic .or. ideal_phys )then
        call t_stopf ('physpkg_st1')
-	
+
        call t_startf ('bc_physics')
        call phys_run1_adiabatic_or_ideal(ztodt, phys_state, phys_tend,  pbuf2d)
        call t_stopf ('bc_physics')
@@ -1145,6 +1145,8 @@ subroutine phys_run1_adiabatic_or_ideal(ztodt, phys_state, phys_tend,  pbuf2d)
     integer(i8)         :: sysclock_max    ! system clock max value
     real(r8)            :: chunk_cost      ! measured cost per chunk
 
+    character(len=128)  :: ideal_phys_option
+
     ! physics buffer field for total energy
     real(r8), pointer, dimension(:) :: teout
     logical, SAVE :: first_exec_of_phys_run1_adiabatic_or_ideal  = .TRUE.
@@ -1159,6 +1161,8 @@ subroutine phys_run1_adiabatic_or_ideal(ztodt, phys_state, phys_tend,  pbuf2d)
     endif
 
     call system_clock(count=beg_proc_cnt)
+
+    call phys_getopts(ideal_phys_option_out=ideal_phys_option)
 
 !$OMP PARALLEL DO SCHEDULE(STATIC,1) &
 !$OMP PRIVATE (c, beg_chnk_cnt, flx_heat, end_chnk_cnt, sysclock_rate, sysclock_max, chunk_cost)
@@ -1182,7 +1186,7 @@ subroutine phys_run1_adiabatic_or_ideal(ztodt, phys_state, phys_tend,  pbuf2d)
 
        if ( ideal_phys )then
           call t_startf('tphysidl')
-          call tphysidl(ztodt, phys_state(c), phys_tend(c))
+          call tphysidl(ztodt, phys_state(c), phys_tend(c), trim(ideal_phys_option))
           call t_stopf('tphysidl')
        end if
 


### PR DESCRIPTION
Revive the capability to run the FIDEAL atmosphere/dynamics-only compset, which uses idealized physics using Held-Suarez forcing (and modifications thereof). Also adds a namelist option (`ideal_phys_option`) to select the type of forcing used to represent the idealized physics, with valid values of `held-suarez`, `held-suarez-williamson`, and `held-suarez-lin-williamson`. Adds a test to `e3sm_atm_integration` for the revived compset.

[BFB]