### PR TITLE
Semi-implicit barotropic mode solver updates 

### DIFF
--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -90,7 +90,8 @@ module ocn_time_integration_si
       numTSIterations ! number of outer timestep iterations
 
    real (kind=RKIND) :: &
-      useVelocityCorrection ! mask for velocity correction
+      useVelocityCorrection, & ! mask for velocity correction
+      self_attraction_and_loading_beta
 
    ! Global variables for the split-implicit time stepper ---------------
    real (kind=RKIND), allocatable,dimension(:)   :: &
@@ -2912,7 +2913,16 @@ module ocn_time_integration_si
       call ocn_time_integrator_si_preconditioner(domain, dt)
       call mpas_timer_stop("preconditioning matrix build")
 
-   !--------------------------------------------------------------------
+      !--------------------------------------------------------------------
+
+      if (config_use_self_attraction_loading) then
+         ! set ssh_sal_on to 1
+         ssh_sal_on = 1
+      else
+         ssh_sal_on = 0
+      endif
+
+      self_attraction_and_loading_beta = config_self_attraction_and_loading_beta
 
    end subroutine ocn_time_integration_si_init!}}}
 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -129,6 +129,8 @@ module ocn_time_integration_si
       nSiLargeIter       ! #iteration for the barotropic system
    character(len=5) :: si_algorithm ! Name of the iterative solver algorithm
 
+   integer :: ssh_sal_on
+
 !***********************************************************************
 
 !***********************************************************************
@@ -272,6 +274,8 @@ module ocn_time_integration_si
       type (field1DReal), pointer :: &
          effectiveDensityField         ! field pointer for halo update
 
+      type (dm_info) :: dminfo
+
       ! State/Tracer arrays, info
       real (kind=RKIND), dimension(:,:,:), pointer ::      &!
          tracersGroupCur,      &! old, new tracer arrays
@@ -352,6 +356,8 @@ module ocn_time_integration_si
       ! End preamble
       !-----------------------------------------------------------------
       ! Begin code
+
+      dminfo = domain % dminfo
 
       call mpas_timer_start("si timestep")
 
@@ -1040,7 +1046,9 @@ module ocn_time_integration_si
                do iCell = 1, nCellsAll
                  sshSubcycleCurWithTides(iCell) = sshSubcycleCur(iCell) &
                             - tidalPotentialEta(iCell)                  &
-                            - config_self_attraction_and_loading_beta   &
+                            - ssh_sal_on * ssh_sal(iCell)               &
+                            - (1 - ssh_sal_on)                          &
+                            * config_self_attraction_and_loading_beta   &
                             * sshSubcycleCur(iCell)
                end do
                !$omp end do
@@ -1973,7 +1981,7 @@ module ocn_time_integration_si
             !$acc update host (surfacePressure)
             !$acc update host(zMid, zTop)
             !$acc exit data copyout(sshNew)
-            !$acc exit data delete(tracersGroupNew)
+            !$acc exit data delete(activeTracersNew)
             !$acc update host(tracersSurfaceValue)
             !$acc update host(normalVelocitySurfaceLayer)
             !$acc exit data delete (atmosphericPressure, seaIcePressure)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -50,6 +50,7 @@ module ocn_time_integration_si
 
    use ocn_effective_density_in_land_ice
    use ocn_surface_land_ice_fluxes
+   use ocn_transport_tests
 
    implicit none
    private
@@ -94,6 +95,22 @@ module ocn_time_integration_si
    ! Global variables for the split-implicit time stepper ---------------
    real (kind=RKIND), allocatable,dimension(:)   :: &
       prec_ivmat    ! an inversed preconditioning matrix
+   real (kind=RKIND), dimension(2) :: &
+      SIcst_allreduce_local2, &! array for local  summations
+      SIcst_allreduce_global2  ! array for global summations
+   real (kind=RKIND), dimension(3) :: &
+      SIcst_allreduce_local3, &! array for local  summations
+      SIcst_allreduce_global3  ! array for global summations
+   real (kind=RKIND), dimension(9) :: &
+      SIcst_allreduce_local9, &! array for local  summations
+      SIcst_allreduce_global9  ! array for global summations
+   real (kind=RKIND), dimension(:,:), allocatable :: &
+      globalReprodSum2fld1, &  ! array for global reproducible sum
+      globalReprodSum2fld2, &  ! array for global reproducible sum
+      globalReprodSum3fld1, &  ! array for global reproducible sum
+      globalReprodSum3fld2, &  ! array for global reproducible sum
+      globalReprodSum9fld1, &  ! array for global reproducible sum
+      globalReprodSum9fld2     ! array for global reproducible sum
    real (kind=RKIND) :: &
       R1_alpha1s_g_dts, &! pre-computed coefficients
       R1_alpha1s_g_dt,  &! pre-computed coefficients
@@ -110,8 +127,8 @@ module ocn_time_integration_si
       si_ismf,          &! SI solver linearization for ISMF cases
       ncpus,            &! Total number of cores
       nSiLargeIter       ! #iteration for the barotropic system
+   character(len=5) :: si_algorithm ! Name of the iterative solver algorithm
 
-   integer :: ssh_sal_on
 !***********************************************************************
 
 !***********************************************************************
@@ -255,8 +272,6 @@ module ocn_time_integration_si
       type (field1DReal), pointer :: &
          effectiveDensityField         ! field pointer for halo update
 
-      type (dm_info) :: dminfo
-
       ! State/Tracer arrays, info
       real (kind=RKIND), dimension(:,:,:), pointer ::      &!
          tracersGroupCur,      &! old, new tracer arrays
@@ -265,6 +280,8 @@ module ocn_time_integration_si
       integer, pointer :: &
          startIndex, endIndex, &! start, end index for tracer groups
          indexSalinity          ! tracer index for salinity
+
+      integer :: iTracer, numTracers, numActiveTracers
 
       type (mpas_pool_iterator_type) :: &
          groupItr               ! iterator for tracer groups
@@ -291,44 +308,26 @@ module ocn_time_integration_si
       ! Forcing pool
       real (kind=RKIND), dimension(:), pointer :: tidalPotentialEta
 
-      ! Semi-implicit variables
-      real (kind=RKIND), dimension(2) :: &
-         SIcst_allreduce_local2, &! array for local  summations
-         SIcst_allreduce_global2  ! array for global summations
-      real (kind=RKIND), dimension(9) :: &
-         SIcst_allreduce_local9, &! array for local  summations
-         SIcst_allreduce_global9,&! array for global summations
-         SIcst_allreduce_temp9    !  temp for global summations
-      integer          , dimension(9) :: &
-         SIcst_allreduce_itemp9   !  temp for partition match mode
-      real (kind=RKIND), dimension(:,:), allocatable :: &
-         globalReprodSum2fld1, &  ! array for global reproducible sum
-         globalReprodSum2fld2, &  ! array for global reproducible sum
-         globalReprodSum9fld1, &  ! array for global reproducible sum
-         globalReprodSum9fld2     ! array for global reproducible sum
-      real (kind=RKIND) ::  &
-                                  !  temp scalars for the SI method
-         SIcst_q0y0        , SIcst_y0y0        , SIcst_q0q0        , &
-         SIcst_q0y0_global , SIcst_y0y0_global , SIcst_q0q0_global , &
-         SIcst_r00r0       , SIcst_r00w0       , SIcst_r00w1       , &
-         SIcst_r00r0_global, SIcst_r00w0_global, SIcst_r00w1_global, &
-         SIcst_r00q0       , SIcst_r00t0       , SIcst_r00v0       , &
-         SIcst_r00q0_global, SIcst_r00t0_global, SIcst_r00v0_global, &
-         SIcst_r00y0       , SIcst_r00s0       , SIcst_r00z0       , &
-         SIcst_r00y0_global, SIcst_r00s0_global, SIcst_r00z0_global, &
-         SIcst_alpha0      , SIcst_beta0       , &
-         SIcst_omega0      , SIcst_rho0        , SIcst_rho1        , &
-         SIcst_gamma1,       resid
-
-      integer ::     &
-         iter,       &! Number of solver iterations
-         siLargeIter  ! Index of the large btr system iteration
-
       real (kind=RKIND), dimension(:), pointer :: &
         seaIcePressure, atmosphericPressure
 
       real (kind=RKIND), dimension(:), pointer :: &
         frazilSurfacePressure, landIcePressure, landIceDraft
+
+      real (kind=RKIND), dimension(:,:,:), pointer :: activeTracersNew
+
+      ! Semi-implicit variables
+      real (kind=RKIND) ::  &        !  temp scalars for the SI method
+         SIcst_q0y0_global , SIcst_y0y0_global , SIcst_q0q0_global , &
+         SIcst_r00r0_global, SIcst_r00w0_global, SIcst_r00w1_global, &
+         SIcst_r00q0_global, SIcst_r00t0_global, SIcst_r00v0_global, &
+         SIcst_r00y0_global, SIcst_r00s0_global, SIcst_r00z0_global, &
+         SIcst_r0rh0_global, SIcst_w0rh0_global, SIcst_gamma0      , &
+         SIcst_alpha0      , SIcst_beta0       ,                     &
+         SIcst_omega0      , SIcst_rho0
+
+      integer ::     &
+         siLargeIter  ! Index of the large btr system iteration
 
       ! These are public variables used from the diagnostics module
       ! indexSurfaceVelocityZonal, indexSurfaceVelocityMeridional
@@ -353,8 +352,6 @@ module ocn_time_integration_si
       ! End preamble
       !-----------------------------------------------------------------
       ! Begin code
-
-      dminfo = domain % dminfo
 
       call mpas_timer_start("si timestep")
 
@@ -447,6 +444,30 @@ module ocn_time_integration_si
       call mpas_pool_get_array(tendPool, 'lowFreqDivergence', &
                                           lowFreqDivergenceTend)
 
+      call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracersNew, 2)
+
+      if (config_transport_tests_flow_id > 0) then
+        ! This is a transport test. Write advection velocity from prescribed
+        ! flow field.
+        call ocn_transport_test_velocity(meshPool, daysSinceStartOfSim, &
+          0.5*dt, normalVelocityCur)
+      endif
+
+#ifdef MPAS_OPENACC
+      !$acc enter data copyin(normalVelocityCur, normalBarotropicVelocityCur, &
+      !$acc   sshCur, layerThicknessCur)
+      !$acc enter data create(normalBaroClinicVelocityCur, normalVelocityNew, &
+      !$acc   normalBaroclinicVelocityNew, sshNew, layerThicknessNew)
+      if (associated(highFreqThicknessNew)) then
+         !$acc enter data copyin(highFreqThicknessCur)
+         !$acc enter data create(highFreqThicknessNew)
+      endif
+      if (associated(lowFreqDivergenceNew)) then
+         !$acc enter data copyin(lowFreqDivergenceCur)
+         !$acc enter data create(lowFreqDivergenceNew)
+      endif
+#endif
+
       ! Initialize * variables that are used to compute baroclinic
       ! tendencies below.
 
@@ -460,8 +481,20 @@ module ocn_time_integration_si
       ! variable subtracts out the barotropic component from the
       ! baroclinic.
 
+#ifdef MPAS_OPENACC
+      !$acc parallel present(normalVelocityCur, normalBarotropicVelocityCur, &
+      !$acc    sshCur, layerThicknessCur, normalBaroClinicVelocityCur, &
+      !$acc    normalVelocityNew, normalBaroclinicVelocityNew, sshNew, &
+      !$acc    layerThicknessNew, minLevelCell, maxLevelCell,          &
+      !$acc    sshSubcycleCur,sshSubcycleNew)
+#endif
+
+#ifdef MPAS_OPENACC
+      !$acc loop collapse(2)
+#else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
+#endif
       do iEdge = 1,nEdgesAll
       do k = 1,nVertLevels
 
@@ -475,19 +508,32 @@ module ocn_time_integration_si
          normalBaroclinicVelocityCur(k,iEdge)
       end do
       end do
+#ifndef MPAS_OPENACC
       !$omp end do
+#endif
 
+#ifdef MPAS_OPENACC
+      !$acc loop gang
+#else
       !$omp do schedule(runtime) private(k)
+#endif
       do iCell = 1, nCellsAll
-         sshNew(iCell)         = sshCur(iCell)
+         sshNew(iCell) = sshCur(iCell)
          sshSubcycleCur(iCell) = sshCur(iCell)
          sshSubcycleNew(iCell) = sshCur(iCell)
-         do k = minLevelCell(iCell), maxLevelCell(iCell)
+#ifdef MPAS_OPENACC
+         !$acc loop vector
+#endif
+         do k = 1,nVertLevels
             layerThicknessNew(k,iCell) = layerThicknessCur(k,iCell)
          end do
       end do
+#ifdef MPAS_OPENACC
+      !$acc end parallel
+#else
       !$omp end do
       !$omp end parallel
+#endif
 
       call mpas_pool_begin_iteration(tracersPool)
       do while ( mpas_pool_get_next_member(tracersPool, groupItr))
@@ -500,44 +546,81 @@ module ocn_time_integration_si
             if ( associated(tracersGroupCur) .and. &
                  associated(tracersGroupNew) ) then
 
+#ifdef MPAS_OPENACC
+               !$acc enter data create(tracersGroupNew)
+               !$acc enter data copyin(tracersGroupCur)
+               !$acc parallel loop gang present(minLevelCell, maxLevelCell, &
+               !$acc    tracersGroupNew, tracersGroupCur)
+#else
                !$omp parallel
                !$omp do schedule(runtime) private(k)
+#endif
                do iCell = 1, nCellsAll
                do k = minLevelCell(iCell), maxLevelCell(iCell)
-                  tracersGroupNew(:,k,iCell) = &
-                  tracersGroupCur(:,k,iCell)
+#ifdef MPAS_OPENACC
+               !$acc loop vector
+#endif
+                  do iTracer = 1,size(tracersGroupCur,1)
+                     tracersGroupNew(iTracer,k,iCell) = &
+                     tracersGroupCur(iTracer,k,iCell)
+                  end do
                end do
                end do
+#ifdef MPAS_OPENACC
+               !$acc exit data copyout(tracersGroupNew)
+               !$acc exit data delete(tracersGroupCur)
+#else
                !$omp end do
                !$omp end parallel
+#endif
             end if
          end if
       end do
 
       if (associated(highFreqThicknessNew)) then
+#ifdef MPAS_OPENACC
+         !$acc parallel loop gang &
+         !$acc    present(highFreqThicknessCur, highFreqThicknessNew)
+#else
          !$omp parallel
          !$omp do schedule(runtime) private(k)
+#endif
          do iCell = 1, nCellsAll
+#ifdef MPAS_OPENACC
+         !$acc loop vector
+#endif
          do k = 1,nVertLevels
             highFreqThicknessNew(k,iCell) = &
             highFreqThicknessCur(k,iCell)
          end do
          end do
+#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
+#endif
       end if
 
       if (associated(lowFreqDivergenceNew)) then
+#ifdef MPAS_OPENACC
+         !$acc parallel loop gang &
+         !$acc    present(lowFreqDivergenceCur, lowFreqDivergenceNew)
+#else
          !$omp parallel
          !$omp do schedule(runtime) private(k)
+#endif
          do iCell = 1, nCellsAll
+#ifdef MPAS_OPENACC
+         !$acc loop vector
+#endif
          do k = 1,nVertLevels
             lowFreqDivergenceNew(k,iCell) = &
             lowFreqDivergenceCur(k,iCell)
          end do
          end do
+#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
+#endif
       endif
 
       call mpas_timer_stop("si prep")
@@ -550,6 +633,35 @@ module ocn_time_integration_si
          call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
          call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
       endif
+
+      if ( config_btr_si_partition_match_mode ) then
+         if (si_algorithm == 'sbicg' ) then
+            allocate( globalReprodSum2fld1(nCellsOwned,2),  &
+                      globalReprodSum2fld2(nCellsOwned,2),  &
+                      globalReprodSum9fld1(nCellsOwned,9),  &
+                      globalReprodSum9fld2(nCellsOwned,9) )
+         else if ( si_algorithm == 'scg' ) then
+            allocate( globalReprodSum2fld1(nCellsOwned,2),  &
+                      globalReprodSum2fld2(nCellsOwned,2),  &
+                      globalReprodSum3fld1(nCellsOwned,3),  &
+                      globalReprodSum3fld2(nCellsOwned,3) )
+         endif
+      endif
+
+#ifdef MPAS_OPENACC
+      !$acc exit data delete(normalVelocityCur, normalBarotropicVelocityCur, &
+      !$acc    sshCur, layerThicknessCur)
+      !$acc exit data copyout(normalBaroClinicVelocityCur, normalVelocityNew, &
+      !$acc    normalBaroclinicVelocityNew, sshNew, layerThicknessNew)
+      if (associated(highFreqThicknessNew)) then
+         !$acc exit data delete(highFreqThicknessCur)
+         !$acc exit data copyout(highFreqThicknessNew)
+      endif
+      if (associated(lowFreqDivergenceNew)) then
+         !$acc exit data delete(lowFreqDivergenceCur)
+         !$acc exit data copyout(lowFreqDivergenceNew)
+      endif
+#endif
 
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       ! BEGIN large outer timestep iteration loop
@@ -568,6 +680,18 @@ module ocn_time_integration_si
 
          stage1_tend_time = min(splitImplicitStep,2)
 
+         call mpas_pool_get_array(statePool, 'normalVelocity', &
+                           normalVelocityCur, stage1_tend_time)
+
+#ifdef MPAS_OPENACC
+         !$acc enter data copyin(layerThicknessCur, normalVelocityCur, sshCur)
+         !$acc update device(layerThickEdgeFlux)
+         if (config_use_freq_filtered_thickness .or. associated(highFreqThicknessNew) ) then
+            !$acc enter data create(highFreqThicknessNew)
+            !$acc enter data copyin(highFreqThicknessCur, highFreqThicknessTend)
+         endif
+#endif
+
          ! ---  update halos for diagnostic ocean boundary layer depth
          if (config_use_cvmix_kpp) then
             call mpas_timer_start("si halo diag obd")
@@ -580,7 +704,6 @@ module ocn_time_integration_si
 
          call mpas_dmpar_field_halo_exch(domain, &
                                  'normalizedRelativeVorticityEdge')
-
          if (config_mom_del4 > 0.0_RKIND) then
            call mpas_dmpar_field_halo_exch(domain, 'divergence')
            call mpas_dmpar_field_halo_exch(domain, 'relativeVorticity')
@@ -608,9 +731,17 @@ module ocn_time_integration_si
 
             call mpas_timer_stop("si freq-filtered-thick halo update")
 
+#ifdef MPAS_OPENACC
+            !$acc parallel loop gang present(minLevelCell, maxLevelCell, &
+            !$acc    highFreqThicknessNew, highFreqThicknessCur, highFreqThicknessTend)
+#else
             !$omp parallel
             !$omp do schedule(runtime) private(k)
+#endif
             do iCell = 1, nCellsAll
+#ifdef MPAS_OPENACC
+            !$acc loop vector
+#endif
             do k = minLevelCell(iCell), maxLevelCell(iCell)
                ! this is h^{hf}_{n+1}
                highFreqThicknessNew(k,iCell) = &
@@ -618,8 +749,10 @@ module ocn_time_integration_si
                highFreqThicknessTend(k,iCell)
             end do
             end do
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
+#endif
 
          endif ! freq filtered thickness
 
@@ -627,41 +760,33 @@ module ocn_time_integration_si
          call mpas_timer_start("si bcl vel")
          call mpas_timer_start('si bcl vel tend')
 
-         call mpas_pool_get_array(statePool, 'normalVelocity', &
-                           normalVelocityCur, stage1_tend_time)
-
          ! compute vertAleTransportTop.  Use u (rather than &
          ! normalTransportVelocity) for momentum advection.
          ! Use the most recent time level available.
 
-#ifdef MPAS_OPENACC
-         !$acc enter data copyin(layerThicknessCur, normalVelocityCur, sshCur)
-         !$acc update device(layerThickEdgeFlux)
-#endif
          if (associated(highFreqThicknessNew)) then
-#ifdef MPAS_OPENACC
-            !$acc enter data copyin(highFreqThicknessNew)
-#endif
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdgeFlux, normalVelocityCur, sshCur, dt, &
                  vertAleTransportTop, err, highFreqThicknessNew)
-#ifdef MPAS_OPENACC
-            !$acc exit data delete(highFreqThicknessNew)
-#endif
          else
             call ocn_vert_transport_velocity_top(meshPool, &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdgeFlux, normalVelocityCur, sshCur, dt, &
                  vertAleTransportTop, err)
          endif
+
 #ifdef MPAS_OPENACC
          !$acc exit data delete(layerThicknessCur, normalVelocityCur, sshCur)
          !$acc update host(vertAleTransportTop)
+         if (config_use_freq_filtered_thickness .or. associated(highFreqThicknessNew) ) then
+            !$acc exit data copyout(highFreqThicknessNew)
+            !$acc exit data delete(highFreqThicknessCur, highFreqThicknessTend)
+         endif
 #endif
 
          call ocn_tend_vel(domain, tendPool, statePool, forcingPool, &
-                           stage1_tend_time, dminfo, dt)
+                           stage1_tend_time, domain % dminfo, dt)
 
          call mpas_timer_stop('si bcl vel tend')
 
@@ -760,10 +885,10 @@ module ocn_time_integration_si
          call mpas_timer_stop('si halo barotropicForcing')
 
          call mpas_timer_stop("si bcl vel")
+
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
          ! END baroclinic iterations on linear Coriolis term
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
 
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
          ! Stage 2: Barotropic velocity (2D) prediction, split-implicit
@@ -775,15 +900,19 @@ module ocn_time_integration_si
          !      as a linear iterative solver
          !      (Kang et al., in preparation)
          !                    
+         !    - uses the s-step conjugate gradient method (Chronopoulos
+         !      and Gear, 1989) when 'config_btr_si_partition_match_mode'
+         !      is turned on
+         !                    
          !    - solves the nonlinear barotropic system but deals with
          !      it as the linear system by introducing the outer and                     
          !      inner solver iteration (the solver matrix is updated                    
-         !      for every time step and inner solver iteration.)                    
+         !      for every time step and inner solver iteration.)
          !                    
          !    - works with 'ras', 'block_jacobi', 'jacobi', 'none'
          !      preconditioners
          !                    
-         !    - consists of seven substages                    
+         !    - consists of seven substages
          !         :Stage 2.1. Initialization and preparation of vars
          !                     before outer iterations
          !          Stage 2.2. Computation of the initial residual
@@ -842,12 +971,6 @@ module ocn_time_integration_si
             !$omp end parallel
          endif
 
-         if ( config_btr_si_partition_match_mode ) then
-            allocate( globalReprodSum2fld1(nCellsOwned,2),  &
-                      globalReprodSum2fld2(nCellsOwned,2),  &
-                      globalReprodSum9fld1(nCellsOwned,9),  &
-                      globalReprodSum9fld2(nCellsOwned,9) )
-         endif
 
          !-------------------------------------------------------------!
          ! BEGIN Large barotropic system iteration loop
@@ -917,8 +1040,8 @@ module ocn_time_integration_si
                do iCell = 1, nCellsAll
                  sshSubcycleCurWithTides(iCell) = sshSubcycleCur(iCell) &
                             - tidalPotentialEta(iCell)                  &
-                            - ssh_sal_on * ssh_sal(iCell)               &
-                            - (1 - ssh_sal_on) * config_self_attraction_and_loading_beta * sshSubcycleCur(iCell)
+                            - config_self_attraction_and_loading_beta   &
+                            * sshSubcycleCur(iCell)
                end do
                !$omp end do
                !$omp end parallel
@@ -1007,37 +1130,8 @@ module ocn_time_integration_si
             !$omp end parallel
    
             ! Preconditioning --------------------------------------------!
-   
-            if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-               ! RAS preconditioning: Use BLAS for the symmetric 
-               !                      matrix-vector multiplication
-#ifdef USE_LAPACK
-               call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
-                          SIvec_r0(1:nPrecVec) , 1, 0.0_RKIND,  &
-                          SIvec_rh0(1:nPrecVec), 1)
-#endif
-   
-            elseif ( trim(config_btr_si_preconditioner) == &
-                                              'block_jacobi' ) then
-               ! Block-Jacobi preconditioning: Use BLAS for the symmetric 
-               !                               matrix-vector multiplication
-#ifdef USE_LAPACK
-               call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
-                          SIvec_r0(1:nPrecVec) , 1, 0.0_RKIND,  &
-                          SIvec_rh0(1:nPrecVec), 1)
-#endif
-   
-            elseif ( trim(config_btr_si_preconditioner) == &
-                                                    'jacobi' ) then
-               ! Jacobi preconditioning
-               SIvec_rh0(1:nPrecVec) = SIvec_r0(1:nPrecVec) &
-                                     * prec_ivmat(1:nPrecVec)
-   
-            elseif ( trim(config_btr_si_preconditioner) == &
-                                                      'none' ) then
-               ! No preconditioning
-               SIvec_rh0(1:nPrecVec) = SIvec_r0(1:nPrecVec)
-            end if
+
+            call si_precond(SIvec_r0,SIvec_rh0)
    
             call mpas_timer_start("si halo r0")
             call mpas_dmpar_field_halo_exch(domain, 'SIvec_rh0')
@@ -1045,187 +1139,66 @@ module ocn_time_integration_si
    
             ! SpMV -------------------------------------------------------!
    
-            !$omp parallel
-            !$omp do schedule(runtime) &
-            !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeCur, &
-            !$omp         thicknessSumCur,sshDiffCur,fluxAx,sshCurArea )
-            do iCell = 1, nPrecVec
-   
-               sshTendAx = 0.0_RKIND
-   
-               do i = 1, nEdgesOnCell(iCell)
-                  iEdge = edgesOnCell(i, iCell)
-   
-                  cell1 = cellsOnEdge(1, iEdge)
-                  cell2 = cellsOnEdge(2, iEdge)
-   
-                  ! Interpolation sshEdge
-                  sshEdgeCur = 0.5_RKIND * (  sshSubcycleCur(cell1) &
-                                            + sshSubcycleCur(cell2))
-   
-                  ! method 1, matches method 0 without pbcs,
-                  ! works with pbcs.
-                  thicknessSumCur = si_ismf * sshEdgeCur    &
-                                  + min(bottomDepth(cell1), &
-                                        bottomDepth(cell2))
-   
-                  ! nabla (ssh^0)
-                  sshDiffCur = (SIvec_rh0(cell2)- SIvec_rh0(cell1)) &
-                             / dcEdge(iEdge)
-                      fluxAx = thicknessSumCur * sshDiffCur
-                   sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
-                             * fluxAx * dvEdge(iEdge)
-               end do ! i
-   
-               sshCurArea = (1.0_RKIND/(gravity*dt_si**2.0*alpha1**2.0)) &
-                          * SIvec_rh0(iCell) * areaCell(iCell)
-   
-               SIvec_w0(iCell) = -sshCurArea - sshTendAx
-   
-            end do ! iCell
-            !$omp end do
-            !$omp end parallel
-   
+            call si_matvec_mul(SIvec_rh0,SIvec_w0,sshSubcycleCur)
+
+            if ( si_algorithm == 'sbicg' ) then !!!
+
             ! Preconditioning --------------------------------------------!
-   
-            if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-               ! RAS preconditioning: Use BLAS
-               ! for the symmetric matrix-vector multiplication
-#ifdef USE_LAPACK
-               call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
-                          SIvec_w0(1:nPrecVec) , 1, 0.0_RKIND,  &
-                          SIvec_wh0(1:nPrecVec), 1)
-#endif
-   
-            elseif ( trim(config_btr_si_preconditioner) == &
-                                              'block_jacobi' ) then
-               ! Block-Jacobi preconditioning: Use BLAS 
-               ! for the symmetric matrix-vector multiplication
-#ifdef USE_LAPACK
-               call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
-                          SIvec_w0(1:nPrecVec), 1, 0.0_RKIND,   &
-                          SIvec_wh0(1:nPrecVec),1)
-#endif
-   
-            elseif ( trim(config_btr_si_preconditioner) == &
-                                                    'jacobi' ) then
-               ! Jacobi preconditioning
-               SIvec_wh0(1:nPrecVec) = SIvec_w0(1:nPrecVec) &
-                                     * prec_ivmat(1:nPrecVec)
-   
-            elseif ( trim(config_btr_si_preconditioner) == &
-                                                      'none' ) then
-               ! No preconditioning
-               SIvec_wh0(1:nPrecVec) = SIvec_w0(1:nPrecVec)
-            end if
-   
-            call mpas_timer_start("si halo r0")
-            call mpas_dmpar_field_halo_exch(domain, 'SIvec_wh0')
-            call mpas_timer_stop("si halo r0")
-   
-            ! SpMV -------------------------------------------------------!
-   
-            !$omp parallel
-            !$omp do schedule(runtime) &
-            !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeCur, &
-            !$omp         thicknessSumCur,sshDiffCur,fluxAx,sshCurArea )
-            do iCell = 1, nPrecVec
-   
-               sshTendAx = 0.0_RKIND
-   
-               do i = 1, nEdgesOnCell(iCell)
-   
-                  iEdge = edgesOnCell(i, iCell)
-   
-                  cell1 = cellsOnEdge(1, iEdge)
-                  cell2 = cellsOnEdge(2, iEdge)
-   
-                  ! Interpolation sshEdge
-                  sshEdgeCur = 0.5_RKIND * (  sshSubcycleCur(cell1) &
-                                            + sshSubcycleCur(cell2))
-   
-                  ! method 1, matches method 0 without pbcs,
-                  ! works with pbcs.
-                  thicknessSumCur = si_ismf * sshEdgeCur    &
-                                  + min(bottomDepth(cell1), &
-                                        bottomDepth(cell2))
-   
-                  ! nabla (ssh^0)
-                  sshDiffCur = (SIvec_wh0(cell2)- SIvec_wh0(cell1)) &
-                             / dcEdge(iEdge)
-   
-                  fluxAx = thicknessSumCur * sshDiffCur
-   
-                  sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
-                            * fluxAx * dvEdge(iEdge)
-               end do ! i
-   
-               sshCurArea = R1_alpha1s_g_dts * SIvec_wh0(iCell) &
-                          * areaCell(iCell)
-   
-               SIvec_t0(iCell) = -sshCurArea - sshTendAx
-   
-               SIvec_ph0(iCell) = 0.0_RKIND
-               SIvec_sh0(iCell) = 0.0_RKIND
-               SIvec_z0(iCell)  = 0.0_RKIND
-               SIvec_zh0(iCell) = 0.0_RKIND
-               SIvec_v0(iCell)  = 0.0_RKIND
-               SIvec_s0(iCell)  = 0.0_RKIND
-   
-            end do ! iCell
-            !$omp end do
-            !$omp end parallel
-   
-            ! Reduction --------------------------------------------------!
 
-            if ( config_btr_si_partition_match_mode ) then
-
-               ! Reproducible sum of multiple fields over products
-    
-               do iCell = 1,nCellsOwned
-                  globalReprodSum2fld1(iCell,1) = SIvec_r00(iCell)
-                  globalReprodSum2fld1(iCell,2) = SIvec_r00(iCell)
-
-                  globalReprodSum2fld2(iCell,1) = SIvec_r0(iCell)
-                  globalReprodSum2fld2(iCell,2) = SIvec_w0(iCell)
-               end do
-
-               SIcst_allreduce_global2(:) =                   &
-                  mpas_global_sum_nfld(globalReprodSum2fld1, &
-                                       globalReprodSum2fld2, &
-                                       domain%dminfo%comm)
-
-            else
-
-               SIcst_r00r0 = 0.0_RKIND
-               SIcst_r00w0 = 0.0_RKIND
+               call si_precond(SIvec_w0,SIvec_wh0)
       
-               do iCell = 1, nCellsOwned
-                  SIcst_r00r0 = SIcst_r00r0 + SIvec_r00(iCell) &
-                                            * SIvec_r0(iCell)
-                  SIcst_r00w0 = SIcst_r00w0 + SIvec_r00(iCell) &
-                                            * SIvec_w0(iCell)
-               end do ! iCell
+               call mpas_timer_start("si halo r0")
+               call mpas_dmpar_field_halo_exch(domain, 'SIvec_wh0')
+               call mpas_timer_stop("si halo r0")
       
-               SIcst_allreduce_local2(1) = SIcst_r00r0
-               SIcst_allreduce_local2(2) = SIcst_r00w0
+               ! SpMV -------------------------------------------------------!
       
-               ! Global sum across CPUs
+               call si_matvec_mul(SIvec_wh0,SIvec_t0,sshSubcycleCur)
+   
+               ! Reduction --------------------------------------------------!
+   
                call mpas_timer_start("si reduction r0")
-               call mpas_dmpar_sum_real_array(domain % dminfo, 2,      &
-                                              SIcst_allreduce_local2,  &
-                                              SIcst_allreduce_global2)
+               call si_global_reduction(SIcst_allreduce_local2, &
+                                   SIcst_allreduce_global2,     &
+                                   globalReprodSum2fld1,        &
+                                   globalReprodSum2fld2,        &
+                                   si_algorithm,2,domain,       &
+                                   SIvec_r00,SIvec_r0,SIvec_w0)
                call mpas_timer_stop ("si reduction r0")
    
-            endif
+               SIcst_r00r0_global = SIcst_allreduce_global2(1)
+               SIcst_r00w0_global = SIcst_allreduce_global2(2)
+      
+               SIcst_rho0   = SIcst_r00r0_global
+               SIcst_alpha0 = SIcst_rho0 / SIcst_r00w0_global
+               SIcst_beta0  = 0.0_RKIND
+               SIcst_omega0 = 0.0_RKIND
+
+            else if ( si_algorithm == 'scg' ) then !!!
+           
+               do iCell = 1, nPrecVec
+                  SIvec_s0(iCell)  = 0.0_RKIND
+                  SIvec_z0(iCell)  = 0.0_RKIND
+               end do ! iCell
    
-            SIcst_r00r0_global = SIcst_allreduce_global2(1)
-            SIcst_r00w0_global = SIcst_allreduce_global2(2)
+               ! Reduction --------------------------------------------------!
+               call mpas_timer_start("si reduction r0")
+               call si_global_reduction(SIcst_allreduce_local2, &
+                                   SIcst_allreduce_global2,     &
+                                   globalReprodSum2fld1,        &
+                                   globalReprodSum2fld2,        &
+                                   si_algorithm,2,domain,       &
+                                   SIvec_r0,SIvec_w0,SIvec_rh0)
+               call mpas_timer_stop ("si reduction r0")
    
-            SIcst_rho0   = SIcst_r00r0_global
-            SIcst_alpha0 = SIcst_rho0 / SIcst_r00w0_global
-            SIcst_beta0  = 0.0_RKIND
-            SIcst_omega0 = 0.0_RKIND
+               SIcst_r0rh0_global = SIcst_allreduce_global2(1)
+               SIcst_w0rh0_global = SIcst_allreduce_global2(2)
+   
+               SIcst_alpha0 = SIcst_r0rh0_global / SIcst_w0rh0_global
+               SIcst_beta0  = 0.0_RKIND
+               SIcst_gamma0 = SIcst_r0rh0_global
+   
+            end if !!!
    
             call mpas_timer_stop("si btr residual")
    
@@ -1236,379 +1209,17 @@ module ocn_time_integration_si
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    
             call mpas_timer_start("si btr iteration")
-   
-            iter = 0
-            resid = (tolerance_outer+100.0)**2.0
-   
-            !-------------------------------------------------------------!
-            do while ( dsqrt(resid) > tolerance_outer )
-            !-------------------------------------------------------------!
-   
-               iter = iter + 1
-   
-               !$omp parallel
-               !$omp do schedule(runtime)
-               do iCell = 1, nPrecVec
-                  SIvec_ph1(iCell) =  SIvec_rh0(iCell) + SIcst_beta0      &
-                                   * (SIvec_ph0(iCell) - SIcst_omega0     &
-                                                       * SIvec_sh0(iCell))
-   
-                  SIvec_s1(iCell)  =  SIvec_w0(iCell)  + SIcst_beta0      &
-                                   * (SIvec_s0(iCell)  - SIcst_omega0     &
-                                                       * SIvec_z0(iCell))
-   
-                  SIvec_sh1(iCell) =  SIvec_wh0(iCell) + SIcst_beta0      &
-                                   * (SIvec_sh0(iCell) - SIcst_omega0     &
-                                                       * SIvec_zh0(iCell))
-   
-                  SIvec_z1(iCell)  =  SIvec_t0(iCell)  + SIcst_beta0      &
-                                   * (SIvec_z0(iCell)  - SIcst_omega0     &
-                                                       * SIvec_v0(iCell))
-   
-                  SIvec_q0(iCell)  =  SIvec_r0(iCell)  - SIcst_alpha0     &
-                                                       * SIvec_s1(iCell)
-   
-                  SIvec_qh0(iCell) =  SIvec_rh0(iCell) - SIcst_alpha0     &
-                                                       * SIvec_sh1(iCell)
-   
-                  SIvec_y0(iCell)  =  SIvec_w0(iCell)  - SIcst_alpha0     &
-                                                       * SIvec_z1(iCell)
-               end do ! iCell
-               !$omp end do
-               !$omp end parallel
-   
-               ! Preconditioning -----------------------------------------!
-   
-               if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-                  ! RAS preconditioning: Use BLAS 
-                  ! for the symmetric matrix-vector multiplication
-#ifdef USE_LAPACK
-                  call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
-                             SIvec_z1(1:nPrecVec), 1, 0.0_RKIND,   &
-                             SIvec_zh1(1:nPrecVec),1)
-#endif
-   
-               elseif ( trim(config_btr_si_preconditioner) == &
-                                                 'block_jacobi' ) then
-                  ! Block-Jacobi preconditioning: Use BLAS 
-                  ! for the symmetric matrix-vector multiplication
-#ifdef USE_LAPACK
-                  call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
-                             SIvec_z1(1:nPrecVec), 1, 0.0_RKIND,   &
-                             SIvec_zh1(1:nPrecVec),1)
-#endif
-   
-               elseif ( trim(config_btr_si_preconditioner) == &
-                                                       'jacobi' ) then
-                  ! Jacobi preconditioning
-                  SIvec_zh1(1:nPrecVec) = SIvec_z1(1:nPrecVec) &
-                                        * prec_ivmat(1:nPrecVec)
-   
-               elseif ( trim(config_btr_si_preconditioner) == &
-                                                         'none' ) then
-                  ! No preconditioning
-                  SIvec_zh1(1:nPrecVec) = SIvec_z1(1:nPrecVec)
-               end if
-   
-               call mpas_timer_start("si halo iter")
-               call mpas_dmpar_field_halo_exch(domain, 'SIvec_zh1')
-               call mpas_timer_stop("si halo iter")
-   
-   
-               ! SpMV ----------------------------------------------------!
-   
-               !$omp parallel
-               !$omp do schedule(runtime) &
-               !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeLag, &
-               !$omp         thicknessSumLag,sshDiffLag,fluxAx,sshLagArea )
-               do iCell = 1, nPrecVec
-                  sshTendAx = 0.0_RKIND
-   
-                  do i = 1, nEdgesOnCell(iCell)
-                     iEdge = edgesOnCell(i, iCell)
-   
-                     cell1 = cellsOnEdge(1, iEdge)
-                     cell2 = cellsOnEdge(2, iEdge)
-   
-                     ! Interpolation sshEdge
-                     sshEdgeLag = 0.5_RKIND * (  sshSubcycleCur(cell1)   &
-                                               + sshSubcycleCur(cell2) )
-   
-                     ! method 1, matches method 0 without pbcs,
-                     ! works with pbcs.
-                     thicknessSumLag = si_ismf * sshEdgeLag    &
-                                     + min(bottomDepth(cell1), &
-                                           bottomDepth(cell2))
-   
-                     ! nabla (ssh^0)
-                     sshDiffLag = (SIvec_zh1(cell2)-SIvec_zh1(cell1)) &
-                                / dcEdge(iEdge)
-   
-                     fluxAx = thicknessSumLag * sshDiffLag
-   
-                     sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
-                               * fluxAx * dvEdge(iEdge)
-                  end do ! i
-   
-                  sshLagArea = R1_alpha1s_g_dts * SIvec_zh1(iCell) &
-                             * areaCell(iCell)
-   
-                  SIvec_v0(iCell) = -sshLagArea - sshTendAx
-   
-               end do ! iCell
-               !$omp end do
-               !$omp end parallel
-   
-               ! Reduction -----------------------------------------------!
-               if ( config_btr_si_partition_match_mode ) then
 
-                  ! Reproducible sum of multiple fields over products
-                   
-                  do iCell = 1,nCellsOwned
-                     globalReprodSum9fld1(iCell,1) = SIvec_r00(iCell)
-                     globalReprodSum9fld1(iCell,2) = SIvec_r00(iCell)
-                     globalReprodSum9fld1(iCell,3) = SIvec_q0(iCell)
-                     globalReprodSum9fld1(iCell,4) = SIvec_y0(iCell)
-                     globalReprodSum9fld1(iCell,5) = SIvec_r00(iCell)
-                     globalReprodSum9fld1(iCell,6) = SIvec_r00(iCell)
-                     globalReprodSum9fld1(iCell,7) = SIvec_r00(iCell)
-                     globalReprodSum9fld1(iCell,8) = SIvec_r00(iCell)
-                     globalReprodSum9fld1(iCell,9) = SIvec_q0(iCell)
-   
-                     globalReprodSum9fld2(iCell,1) = SIvec_s1(iCell)
-                     globalReprodSum9fld2(iCell,2) = SIvec_z1(iCell)
-                     globalReprodSum9fld2(iCell,3) = SIvec_y0(iCell)
-                     globalReprodSum9fld2(iCell,4) = SIvec_y0(iCell)
-                     globalReprodSum9fld2(iCell,5) = SIvec_q0(iCell)
-                     globalReprodSum9fld2(iCell,6) = SIvec_y0(iCell)
-                     globalReprodSum9fld2(iCell,7) = SIvec_t0(iCell)
-                     globalReprodSum9fld2(iCell,8) = SIvec_v0(iCell)
-                     globalReprodSum9fld2(iCell,9) = SIvec_q0(iCell)
-                  end do
-   
-                  SIcst_allreduce_global9(:) =                   &
-                     mpas_global_sum_nfld(globalReprodSum9fld1, &
-                                          globalReprodSum9fld2, &
-                                          domain%dminfo%comm)
-   
-               else
+            if ( si_algorithm == 'sbicg' ) then
+               call si_solver_sbicg(domain,                           &
+                    sshSubcycleNew,sshSubcycleCur,tolerance_outer,    &
+                    SIcst_alpha0,SIcst_beta0,SIcst_gamma0,SIcst_rho0)
+            else if ( si_algorithm == 'scg' ) then
+               call si_solver_scg(domain,                          &
+                    sshSubcycleNew,sshSubcycleCur,tolerance_outer, &
+                    SIcst_alpha0,SIcst_beta0,SIcst_gamma0)
+            endif
 
-                  SIcst_r00s0 = 0.0_RKIND
-                  SIcst_r00z0 = 0.0_RKIND
-                  SIcst_q0y0  = 0.0_RKIND
-                  SIcst_y0y0  = 0.0_RKIND
-                  SIcst_r00q0 = 0.0_RKIND
-                  SIcst_r00y0 = 0.0_RKIND
-                  SIcst_r00t0 = 0.0_RKIND
-                  SIcst_r00v0 = 0.0_RKIND
-                  SIcst_q0q0  = 0.0_RKIND
-      
-                  do iCell = 1,nCellsOwned
-                     SIcst_r00s0 = SIcst_r00s0 + SIvec_r00(iCell) &
-                                               * SIvec_s1(iCell) ! s1
-      
-                     SIcst_r00z0 = SIcst_r00z0 + SIvec_r00(iCell) &
-                                               * SIvec_z1(iCell) ! z1
-      
-                     SIcst_q0y0  = SIcst_q0y0  + SIvec_q0(iCell)  &
-                                               * SIvec_y0(iCell)
-      
-                     SIcst_y0y0  = SIcst_y0y0  + SIvec_y0(iCell)  &
-                                               * SIvec_y0(iCell)
-      
-                     SIcst_r00q0 = SIcst_r00q0 + SIvec_r00(iCell) &
-                                               * SIvec_q0(iCell)
-      
-                     SIcst_r00y0 = SIcst_r00y0 + SIvec_r00(iCell) &
-                                               * SIvec_y0(iCell)
-      
-                     SIcst_r00t0 = SIcst_r00t0 + SIvec_r00(iCell) &
-                                               * SIvec_t0(iCell)
-      
-                     SIcst_r00v0 = SIcst_r00v0 + SIvec_r00(iCell) &
-                                               * SIvec_v0(iCell)
-      
-                     SIcst_q0q0 = SIcst_q0q0   + SIvec_q0(iCell) &
-                                               * SIvec_q0(iCell)
-                  end do
-   
-                  SIcst_allreduce_local9(1) = SIcst_r00s0
-                  SIcst_allreduce_local9(2) = SIcst_r00z0
-                  SIcst_allreduce_local9(3) = SIcst_q0y0 
-                  SIcst_allreduce_local9(4) = SIcst_y0y0 
-                  SIcst_allreduce_local9(5) = SIcst_r00q0
-                  SIcst_allreduce_local9(6) = SIcst_r00y0
-                  SIcst_allreduce_local9(7) = SIcst_r00t0
-                  SIcst_allreduce_local9(8) = SIcst_r00v0
-                  SIcst_allreduce_local9(9) = SIcst_q0q0
-      
-                  ! Global sum across CPUs
-                  call mpas_timer_start("si reduction iter")
-                  call mpas_dmpar_sum_real_array(domain % dminfo, 9,      &
-                                                 SIcst_allreduce_local9,  &
-                                                 SIcst_allreduce_global9)
-                  call mpas_timer_stop("si reduction iter")
-   
-               endif
-   
-               SIcst_r00s0_global = SIcst_allreduce_global9(1) 
-               SIcst_r00z0_global = SIcst_allreduce_global9(2)
-               SIcst_q0y0_global  = SIcst_allreduce_global9(3)
-               SIcst_y0y0_global  = SIcst_allreduce_global9(4)
-               SIcst_r00q0_global = SIcst_allreduce_global9(5)
-               SIcst_r00y0_global = SIcst_allreduce_global9(6)
-               SIcst_r00t0_global = SIcst_allreduce_global9(7)
-               SIcst_r00v0_global = SIcst_allreduce_global9(8)
-               SIcst_q0q0_global  = SIcst_allreduce_global9(9)
-   
-               ! Omega0
-               SIcst_omega0 = SIcst_q0y0_global / SIcst_y0y0_global
-   
-               ! Residual
-               ! = (r1,r1) = (q0,q0) - 2*Omega*(q0,y0) + Omega**2*(y0,y0)
-               resid = SIcst_q0q0_global &
-                     - 2.0_RKIND * SIcst_omega0 * SIcst_q0y0_global  &
-                     + SIcst_omega0**2.0_RKIND  * SIcst_y0y0_global
-   
-               !$omp parallel
-               !$omp do schedule(runtime)
-               do iCell = 1,nPrecVec
-                  sshSubcycleNew(iCell) = sshSubcycleNew(iCell)           &
-                                        + SIcst_alpha0 * SIvec_ph1(iCell) &
-                                        + SIcst_omega0 * SIvec_qh0(iCell)
-   
-                  SIvec_r1(iCell)  = SIvec_q0(iCell) - SIcst_omega0       &
-                                   * SIvec_y0(iCell)
-   
-                  SIvec_rh1(iCell) =  SIvec_qh0(iCell) - SIcst_omega0     &
-                                   * (SIvec_wh0(iCell) - SIcst_alpha0     &
-                                                       * SIvec_zh1(iCell))
-   
-                  SIvec_w1(iCell)  =   SIvec_y0(iCell) - SIcst_omega0     &
-                                   * ( SIvec_t0(iCell) - SIcst_alpha0     &
-                                                       * SIvec_v0(iCell))
-               end do
-               !$omp end do
-               !$omp end parallel
-   
-               ! Preconditioning -----------------------------------------!
-   
-               if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-                  ! RAS preconditioning: Use BLAS 
-                  ! for the symmetric matrix-vector multiplication
-#ifdef USE_LAPACK
-                  call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
-                             SIvec_w1(1:nPrecVec), 1, 0.0_RKIND,   &
-                             SIvec_wh1(1:nPrecVec),1)
-#endif
-   
-               elseif ( trim(config_btr_si_preconditioner) == &
-                                                 'block_jacobi' ) then
-                  ! Block-Jacobi preconditioning: Use BLAS 
-                  ! for the symmetric matrix-vector multiplication
-#ifdef USE_LAPACK
-                  call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
-                             SIvec_w1(1:nPrecVec), 1, 0.0_RKIND,   &
-                             SIvec_wh1(1:nPrecVec),1)
-#endif
-   
-               elseif ( trim(config_btr_si_preconditioner) == &
-                                                       'jacobi' ) then
-                  ! Jacobi preconditioning
-                  SIvec_wh1(1:nPrecVec) = SIvec_w1(1:nPrecVec)  &
-                                        * prec_ivmat(1:nPrecVec)
-   
-               elseif ( trim(config_btr_si_preconditioner) == &
-                                                         'none' ) then
-                  ! No preconditioning
-                  SIvec_wh1(1:nPrecVec) = SIvec_w1(1:nPrecVec)
-               end if
-   
-               call mpas_timer_start("si halo iter")
-               call mpas_dmpar_field_halo_exch(domain, 'SIvec_wh1')
-               call mpas_timer_stop("si halo iter")
-   
-   
-               ! SpMV ----------------------------------------------------!
-   
-               !$omp parallel
-               !$omp do schedule(runtime) &
-               !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeLag, &
-               !$omp         thicknessSumLag,sshDiffLag,fluxAx,sshLagArea )
-               do iCell = 1, nPrecVec
-                  sshTendAx = 0.0_RKIND
-   
-                  do i = 1, nEdgesOnCell(iCell)
-                     iEdge = edgesOnCell(i, iCell)
-   
-                     cell1 = cellsOnEdge(1, iEdge)
-                     cell2 = cellsOnEdge(2, iEdge)
-   
-                     ! Interpolation sshEdge
-                     sshEdgeLag = 0.5_RKIND * (  sshSubcycleCur(cell1)   &
-                                               + sshSubcycleCur(cell2) )
-   
-                     ! method 1, matches method 0 without pbcs,
-                     ! works with pbcs.
-                     thicknessSumLag = si_ismf * sshEdgeLag    &
-                                     + min(bottomDepth(cell1), &
-                                           bottomDepth(cell2))
-   
-                     ! nabla (ssh^0)
-                     sshDiffLag = (SIvec_wh1(cell2)-SIvec_wh1(cell1)) &
-                                / dcEdge(iEdge)
-   
-                     fluxAx = thicknessSumLag * sshDiffLag
-   
-                     sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
-                               * fluxAx * dvEdge(iEdge)
-                  end do ! i
-   
-                  sshLagArea = R1_alpha1s_g_dts * SIvec_wh1(iCell) &
-                             * areaCell(iCell)
-   
-                  SIvec_t1(iCell) = -sshLagArea - sshTendAx
-               end do ! iCell
-               !$omp end do
-               !$omp end parallel
-
-               SIcst_rho1 = SIcst_r00q0_global - SIcst_omega0 * SIcst_r00y0_global 
-   
-               SIcst_gamma1 = SIcst_r00y0_global - SIcst_omega0 * SIcst_r00t0_global  &
-                                          + SIcst_omega0 * SIcst_alpha0 &
-                                                         * SIcst_r00v0_global
-    
-               SIcst_beta0 = (SIcst_alpha0/SIcst_omega0) &
-                           * (SIcst_rho1 / SIcst_rho0)
-   
-               SIcst_alpha0 = SIcst_rho1 &
-                            / ( SIcst_gamma1 + SIcst_beta0 * SIcst_r00s0_global   &
-                                             - SIcst_beta0 * SIcst_omega0  &
-                                                           * SIcst_r00z0_global )
-               SIcst_rho0         = SIcst_rho1
-
-               !$omp parallel
-               !$omp do schedule(runtime)
-               do iCell = 1,nPrecVec
-                  SIvec_r0(iCell) = SIvec_r1(iCell)
-                  SIvec_s0(iCell) = SIvec_s1(iCell)
-                  SIvec_z0(iCell) = SIvec_z1(iCell)
-                  SIvec_w0(iCell) = SIvec_w1(iCell)
-                  SIvec_t0(iCell) = SIvec_t1(iCell)
-   
-                  SIvec_rh0(iCell) = SIvec_rh1(iCell)
-                  SIvec_sh0(iCell) = SIvec_sh1(iCell)
-                  SIvec_ph0(iCell) = SIvec_ph1(iCell)
-                  SIvec_wh0(iCell) = SIvec_wh1(iCell)
-                  SIvec_zh0(iCell) = SIvec_zh1(iCell)
-               end do ! iCell
-               !$omp end do
-               !$omp end parallel
-   
-            !-------------------------------------------------------------!
-            end do ! do iter
-            !-------------------------------------------------------------!
-   
             !   boundary update on sshNew
             call mpas_timer_start("si halo iter")
             call mpas_dmpar_field_halo_exch(domain, 'sshSubcycle', &
@@ -1803,621 +1414,94 @@ module ocn_time_integration_si
             !$omp end parallel
    
             ! Preconditioning --------------------------------------------!
-   
-            if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-               ! RAS preconditioning: Use BLAS
-               ! for the symmetric matrix-vector multiplication
-#ifdef USE_LAPACK
-               call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
-                          SIvec_r0(1:nPrecVec), 1, 0.0_RKIND,   &
-                          SIvec_rh0(1:nPrecVec),1)
-#endif
-   
-            elseif ( trim(config_btr_si_preconditioner) == &
-                                              'block_jacobi' ) then
-               ! Block-Jacobi preconditioning: Use BLAS 
-               ! for the symmetric matrix-vector multiplication
-#ifdef USE_LAPACK
-               call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
-                          SIvec_r0(1:nPrecVec), 1, 0.0_RKIND,   &
-                          SIvec_rh0(1:nPrecVec),1)
-#endif
-   
-            elseif ( trim(config_btr_si_preconditioner) == &
-                                                    'jacobi' ) then
-               ! Jacobi preconditioning
-               SIvec_rh0(1:nPrecVec) = SIvec_r0(1:nPrecVec) &
-                                     * prec_ivmat(1:nPrecVec)
-   
-            elseif ( trim(config_btr_si_preconditioner) == &
-                                                      'none' ) then
-               ! No preconditioning
-               SIvec_rh0(1:nPrecVec) = SIvec_r0(1:nPrecVec)
-            end if
+
+            call si_precond(SIvec_r0,SIvec_rh0)
    
             call mpas_timer_start("si halo r0")
             call mpas_dmpar_field_halo_exch(domain, 'SIvec_rh0')
             call mpas_timer_stop("si halo r0")
    
-   
             ! SpMV -------------------------------------------------------!
-   
-            !$omp parallel
-            !$omp do schedule(runtime) &
-            !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeLag, &
-            !$omp         thicknessSumLag,sshDiffLag,fluxAx,sshLagArea )
-            do iCell = 1, nPrecVec
-   
-               sshTendAx = 0.0_RKIND
-   
-               do i = 1, nEdgesOnCell(iCell)
-                  iEdge = edgesOnCell(i, iCell)
-   
-                  cell1 = cellsOnEdge(1, iEdge)
-                  cell2 = cellsOnEdge(2, iEdge)
-   
-                  ! Interpolation sshEdge
-                  sshEdgeLag = 0.5_RKIND * (sshNew(cell1) + sshNew(cell2))
-   
-                  ! method 1, matches method 0 without pbcs,
-                  ! works with pbcs.
-                  thicknessSumLag = si_ismf * sshEdgeLag    &
-                                  + min(bottomDepth(cell1), &
-                                        bottomDepth(cell2))
-   
-                  ! nabla (ssh^0)
-                  sshDiffLag = (SIvec_rh0(cell2)- SIvec_rh0(cell1)) &
-                             / dcEdge(iEdge)
-   
-                  fluxAx = thicknessSumLag * sshDiffLag
-   
-                  sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
-                            * fluxAx * dvEdge(iEdge)
-               end do ! i
-   
-               sshLagArea = R1_alpha1s_g_dts * SIvec_rh0(iCell) &
-                                             * areaCell(iCell)
-   
-               SIvec_w0(iCell) = -sshLagArea - sshTendAx
-   
-            end do ! iCell
-            !$omp end do
-            !$omp end parallel
-   
+
+            call si_matvec_mul(SIvec_rh0,SIvec_w0,sshNew)
+
+            if ( si_algorithm == 'sbicg' ) then !!!
+
             ! Preconditioning --------------------------------------------!
-   
-            if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-               ! RAS preconditioning: Use BLAS
-               ! the for symmetric matrix-vector multiplication
-#ifdef USE_LAPACK
-               call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
-                          SIvec_w0(1:nPrecVec), 1, 0.0_RKIND,   &
-                          SIvec_wh0(1:nPrecVec),1)
-#endif
-   
-            elseif ( trim(config_btr_si_preconditioner) == &
-                                              'block_jacobi' ) then
-               ! Block-Jacobi preconditioning: Use BLAS
-               ! for the symmetric matrix-vector multiplication
-#ifdef USE_LAPACK
-               call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
-                          SIvec_w0(1:nPrecVec), 1, 0.0_RKIND,   &
-                          SIvec_wh0(1:nPrecVec),1)
-#endif
-   
-            elseif ( trim(config_btr_si_preconditioner) == &
-                                                    'jacobi' ) then
-               ! Jacobi preconditioning
-               SIvec_wh0(1:nPrecVec) = SIvec_w0(1:nPrecVec) &
-                                     * prec_ivmat(1:nPrecVec)
-   
-            elseif ( trim(config_btr_si_preconditioner) == &
-                                                      'none' ) then
-               ! No preconditioning
-               SIvec_wh0(1:nPrecVec) = SIvec_w0(1:nPrecVec)
-            end if
-   
-            call mpas_timer_start("si halo r0")
-            call mpas_dmpar_field_halo_exch(domain, 'SIvec_wh0')
-            call mpas_timer_stop("si halo r0")
-   
-   
-            ! SpMV -------------------------------------------------------!
-            !$omp parallel
-            !$omp do schedule(runtime) &
-            !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeLag, &
-            !$omp         thicknessSumLag,sshDiffLag,fluxAx,sshLagArea )
-            do iCell = 1, nPrecVec
-   
-               sshTendAx = 0.0_RKIND
-   
-               do i = 1, nEdgesOnCell(iCell)
-                  iEdge = edgesOnCell(i, iCell)
-   
-                  cell1 = cellsOnEdge(1, iEdge)
-                  cell2 = cellsOnEdge(2, iEdge)
-   
-                  ! Interpolation sshEdge
-                  sshEdgeLag = 0.5_RKIND * (  sshNew(cell1)   &
-                                            + sshNew(cell2) )
-   
-                  ! method 1, matches method 0 without pbcs,
-                  ! works with pbcs.
-                  thicknessSumLag = si_ismf * sshEdgeLag    &
-                                  + min(bottomDepth(cell1), &
-                                        bottomDepth(cell2))
-   
-                  ! nabla (ssh^0)
-                  sshDiffLag = (SIvec_wh0(cell2) - SIvec_wh0(cell1)) &
-                             / dcEdge(iEdge)
-   
-                  fluxAx = thicknessSumLag * sshDiffLag
-   
-                  sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
-                            * fluxAx * dvEdge(iEdge)
-               end do ! i
-   
-               sshLagArea = R1_alpha1s_g_dts * SIvec_wh0(iCell) &
-                          * areaCell(iCell)
-   
-               SIvec_t0(iCell) = -sshLagArea - sshTendAx
-   
-               SIvec_ph0(iCell) = 0.0_RKIND
-               SIvec_sh0(iCell) = 0.0_RKIND
-               SIvec_z0(iCell)  = 0.0_RKIND
-               SIvec_zh0(iCell) = 0.0_RKIND
-               SIvec_v0(iCell)  = 0.0_RKIND
-               SIvec_s0(iCell)  = 0.0_RKIND
-   
-            end do ! iCell
-            !$omp end do
-            !$omp end parallel
-   
-   
-            ! Reduction -----------------------------------------------!
-            if ( config_btr_si_partition_match_mode ) then
 
-               ! Reproducible sum of multiple fields over products
-    
-               do iCell = 1,nCellsOwned
-                  globalReprodSum2fld1(iCell,1) = SIvec_r00(iCell)
-                  globalReprodSum2fld1(iCell,2) = SIvec_r00(iCell)
-
-                  globalReprodSum2fld2(iCell,1) = SIvec_r0(iCell)
-                  globalReprodSum2fld2(iCell,2) = SIvec_w0(iCell)
-               end do
-
-               SIcst_allreduce_global2(:) =                   &
-                  mpas_global_sum_nfld(globalReprodSum2fld1, &
-                                       globalReprodSum2fld2, &
-                                       domain%dminfo%comm)
-
-            else
-
-               SIcst_r00r0 = 0.0_RKIND
-               SIcst_r00w0 = 0.0_RKIND
+               call si_precond(SIvec_w0,SIvec_wh0)
       
-               do iCell = 1, nCellsOwned
-                  SIcst_r00r0 = SIcst_r00r0 + SIvec_r00(iCell) &
-                                            * SIvec_r0(iCell)
-                  SIcst_r00w0 = SIcst_r00w0 + SIvec_r00(iCell) &
-                                            * SIvec_w0(iCell)
-               end do ! iCell
+               call mpas_timer_start("si halo r0")
+               call mpas_dmpar_field_halo_exch(domain, 'SIvec_wh0')
+               call mpas_timer_stop("si halo r0")
       
-               SIcst_allreduce_local2(1) = SIcst_r00r0
-               SIcst_allreduce_local2(2) = SIcst_r00w0
+               ! SpMV -------------------------------------------------------!
       
-               ! Global sum across CPUs
+               call si_matvec_mul(SIvec_wh0,SIvec_t0,sshNew)
+   
+               ! Reduction --------------------------------------------------!
+   
                call mpas_timer_start("si reduction r0")
-               call mpas_dmpar_sum_real_array(domain % dminfo, 2,      &
-                                              SIcst_allreduce_local2,  &
-                                              SIcst_allreduce_global2)
+               call si_global_reduction(SIcst_allreduce_local2, &
+                                   SIcst_allreduce_global2,     &
+                                   globalReprodSum2fld1,        &
+                                   globalReprodSum2fld2,        &
+                                   si_algorithm,2,domain,       &
+                                   SIvec_r00,SIvec_r0,SIvec_w0)
                call mpas_timer_stop ("si reduction r0")
    
-            endif
+               SIcst_r00r0_global = SIcst_allreduce_global2(1)
+               SIcst_r00w0_global = SIcst_allreduce_global2(2)
+      
+               SIcst_rho0   = SIcst_r00r0_global
+               SIcst_alpha0 = SIcst_rho0 / SIcst_r00w0_global
+               SIcst_beta0  = 0.0_RKIND
+               SIcst_omega0 = 0.0_RKIND
+
+            else if ( si_algorithm == 'scg' ) then !!!
+           
+               do iCell = 1, nPrecVec
+                  SIvec_s0(iCell)  = 0.0_RKIND
+                  SIvec_z0(iCell)  = 0.0_RKIND
+               end do ! iCell
    
+               ! Reduction --------------------------------------------------!
+               call mpas_timer_start("si reduction r0")
+               call si_global_reduction(SIcst_allreduce_local2, &
+                                   SIcst_allreduce_global2,     &
+                                   globalReprodSum2fld1,        &
+                                   globalReprodSum2fld2,        &
+                                   si_algorithm,2,domain,       &
+                                   SIvec_r0,SIvec_w0,SIvec_rh0)
+               call mpas_timer_stop ("si reduction r0")
    
-            SIcst_r00r0_global = SIcst_allreduce_global2(1)
-            SIcst_r00w0_global = SIcst_allreduce_global2(2)
+               SIcst_r0rh0_global = SIcst_allreduce_global2(1)
+               SIcst_w0rh0_global = SIcst_allreduce_global2(2)
    
-            SIcst_rho0   = SIcst_r00r0_global
-            SIcst_alpha0 = SIcst_rho0 / SIcst_r00w0_global
-            SIcst_beta0  = 0.0_RKIND
-            SIcst_omega0 = 0.0_RKIND
+               SIcst_alpha0 = SIcst_r0rh0_global / SIcst_w0rh0_global
+               SIcst_beta0  = 0.0_RKIND
+               SIcst_gamma0 = SIcst_r0rh0_global
    
+            end if !!!
+
             call mpas_timer_stop("si btr residual")
-   
    
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             ! Stage 2.6 : Main (inner) solver iterations
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    
             call mpas_timer_start("si btr iteration")
-   
-            iter = 0
-            resid = SIcst_r00r0_global
-   
-            !-------------------------------------------------------------!
-            do while ( dsqrt(resid) > tolerance_inner )
-            !-------------------------------------------------------------!
-   
-               iter = iter + 1
-   
-               !$omp parallel
-               !$omp do schedule(runtime)
-               do iCell = 1, nPrecVec
-                  SIvec_ph1(iCell) =  SIvec_rh0(iCell) + SIcst_beta0      &
-                                   * (SIvec_ph0(iCell) - SIcst_omega0     &
-                                                       * SIvec_sh0(iCell))
-   
-                  SIvec_s1(iCell)  =  SIvec_w0(iCell)  + SIcst_beta0      &
-                                   * (SIvec_s0(iCell)  - SIcst_omega0     &
-                                                       * SIvec_z0(iCell))
-   
-                  SIvec_sh1(iCell) =  SIvec_wh0(iCell) + SIcst_beta0      &
-                                   * (SIvec_sh0(iCell) - SIcst_omega0     &
-                                                       * SIvec_zh0(iCell))
-   
-                  SIvec_z1(iCell)  =  SIvec_t0(iCell)  + SIcst_beta0      &
-                                   * (SIvec_z0(iCell)  - SIcst_omega0     &
-                                                       * SIvec_v0(iCell))
-   
-                  SIvec_q0(iCell)  =  SIvec_r0(iCell)  - SIcst_alpha0     &
-                                                       * SIvec_s1(iCell)
-   
-                  SIvec_qh0(iCell) =  SIvec_rh0(iCell) - SIcst_alpha0     &
-                                                       * SIvec_sh1(iCell)
-   
-                  SIvec_y0(iCell)  =  SIvec_w0(iCell)  - SIcst_alpha0     &
-                                                       * SIvec_z1(iCell)
-               end do ! iCell
-               !$omp end do
-               !$omp end parallel
-   
-               ! Preconditioning -----------------------------------------!
-               if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-                  ! RAS preconditioning: Use BLAS
-                  ! for the symmetric matrix-vector multiplication
-#ifdef USE_LAPACK
-                  call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
-                             SIvec_z1(1:nPrecVec), 1, 0.0_RKIND,   &
-                             SIvec_zh1(1:nPrecVec),1)
-#endif
-   
-               elseif ( trim(config_btr_si_preconditioner) == &
-                                                 'block_jacobi' ) then
-                  ! Block-Jacobi preconditioning: Use BLAS 
-                  ! for the symmetric matrix-vector multiplication
-#ifdef USE_LAPACK
-                  call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
-                             SIvec_z1(1:nPrecVec), 1, 0.0_RKIND,   &
-                             SIvec_zh1(1:nPrecVec),1)
-#endif
-   
-               elseif ( trim(config_btr_si_preconditioner) == &
-                                                       'jacobi' ) then
-                  ! Jacobi preconditioning
-                  SIvec_zh1(1:nPrecVec) = SIvec_z1(1:nPrecVec) &
-                                        * prec_ivmat(1:nPrecVec)
-   
-               elseif ( trim(config_btr_si_preconditioner) == &
-                                                         'none' ) then
-                  ! No preconditioning
-                  SIvec_zh1(1:nPrecVec) = SIvec_z1(1:nPrecVec)
-               end if
-   
-               call mpas_timer_start("si halo iter")
-               call mpas_dmpar_field_halo_exch(domain, 'SIvec_zh1')
-               call mpas_timer_stop("si halo iter")
-   
-   
-               ! SpMV ----------------------------------------------------!
-   
-               !$omp parallel
-               !$omp do schedule(runtime) &
-               !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeLag, &
-               !$omp         thicknessSumLag,sshDiffLag,fluxAx,sshLagArea )
-               do iCell = 1, nPrecVec
-                  sshTendAx = 0.0_RKIND
-   
-                  do i = 1, nEdgesOnCell(iCell)
-                     iEdge = edgesOnCell(i, iCell)
-   
-                     cell1 = cellsOnEdge(1, iEdge)
-                     cell2 = cellsOnEdge(2, iEdge)
-   
-                     ! Interpolation sshEdge
-                     sshEdgeLag = 0.5_RKIND * (  sshNew(cell1)   &
-                                               + sshNew(cell2) )
-   
-                     ! method 1, matches method 0 without pbcs,
-                     ! works with pbcs.
-                     thicknessSumLag = si_ismf * sshEdgeLag    &
-                                     + min(bottomDepth(cell1), &
-                                           bottomDepth(cell2))
-   
-                     ! nabla (ssh^0)
-                     sshDiffLag = (SIvec_zh1(cell2)-SIvec_zh1(cell1)) &
-                                / dcEdge(iEdge)
-   
-                     fluxAx = thicknessSumLag * sshDiffLag
-   
-                     sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
-                               * fluxAx * dvEdge(iEdge)
-                  end do ! i
-   
-                  sshLagArea = R1_alpha1s_g_dts * SIvec_zh1(iCell) &
-                             * areaCell(iCell)
-   
-                  SIvec_v0(iCell) = -sshLagArea - sshTendAx
-   
-               end do ! iCell
-               !$omp end do
-               !$omp end parallel
-   
-               ! Reduction -----------------------------------------------!
 
-               if ( config_btr_si_partition_match_mode ) then
+            if ( si_algorithm == 'sbicg' ) then
+               call si_solver_sbicg(domain,                           &
+                    sshSubcycleNew,sshNew,tolerance_inner,            &
+                    SIcst_alpha0,SIcst_beta0,SIcst_gamma0,SIcst_rho0)
+            else if ( si_algorithm == 'scg' ) then
+               call si_solver_scg(domain,                  &
+                    sshSubcycleNew,sshNew,tolerance_inner, &
+                    SIcst_alpha0,SIcst_beta0,SIcst_gamma0)
+            endif
 
-                  ! Reproducible sum of multiple fields over products
-                   
-                  do iCell = 1,nCellsOwned
-                     globalReprodSum9fld1(iCell,1) = SIvec_r00(iCell)
-                     globalReprodSum9fld1(iCell,2) = SIvec_r00(iCell)
-                     globalReprodSum9fld1(iCell,3) = SIvec_q0(iCell)
-                     globalReprodSum9fld1(iCell,4) = SIvec_y0(iCell)
-                     globalReprodSum9fld1(iCell,5) = SIvec_r00(iCell)
-                     globalReprodSum9fld1(iCell,6) = SIvec_r00(iCell)
-                     globalReprodSum9fld1(iCell,7) = SIvec_r00(iCell)
-                     globalReprodSum9fld1(iCell,8) = SIvec_r00(iCell)
-                     globalReprodSum9fld1(iCell,9) = SIvec_q0(iCell)
-   
-                     globalReprodSum9fld2(iCell,1) = SIvec_s1(iCell)
-                     globalReprodSum9fld2(iCell,2) = SIvec_z1(iCell)
-                     globalReprodSum9fld2(iCell,3) = SIvec_y0(iCell)
-                     globalReprodSum9fld2(iCell,4) = SIvec_y0(iCell)
-                     globalReprodSum9fld2(iCell,5) = SIvec_q0(iCell)
-                     globalReprodSum9fld2(iCell,6) = SIvec_y0(iCell)
-                     globalReprodSum9fld2(iCell,7) = SIvec_t0(iCell)
-                     globalReprodSum9fld2(iCell,8) = SIvec_v0(iCell)
-                     globalReprodSum9fld2(iCell,9) = SIvec_q0(iCell)
-                  end do
-   
-                  SIcst_allreduce_global9(:) =                   &
-                     mpas_global_sum_nfld(globalReprodSum9fld1, &
-                                          globalReprodSum9fld2, &
-                                          domain%dminfo%comm)
-   
-               else
-
-                  SIcst_r00s0 = 0.0_RKIND
-                  SIcst_r00z0 = 0.0_RKIND
-                  SIcst_q0y0  = 0.0_RKIND
-                  SIcst_y0y0  = 0.0_RKIND
-                  SIcst_r00q0 = 0.0_RKIND
-                  SIcst_r00y0 = 0.0_RKIND
-                  SIcst_r00t0 = 0.0_RKIND
-                  SIcst_r00v0 = 0.0_RKIND
-                  SIcst_q0q0  = 0.0_RKIND
-      
-                  do iCell = 1,nCellsOwned
-                     SIcst_r00s0 = SIcst_r00s0 + SIvec_r00(iCell) &
-                                               * SIvec_s1(iCell) ! s1
-      
-                     SIcst_r00z0 = SIcst_r00z0 + SIvec_r00(iCell) &
-                                               * SIvec_z1(iCell) ! z1
-      
-                     SIcst_q0y0  = SIcst_q0y0  + SIvec_q0(iCell)  &
-                                               * SIvec_y0(iCell)
-      
-                     SIcst_y0y0  = SIcst_y0y0  + SIvec_y0(iCell)  &
-                                               * SIvec_y0(iCell)
-      
-                     SIcst_r00q0 = SIcst_r00q0 + SIvec_r00(iCell) &
-                                               * SIvec_q0(iCell)
-      
-                     SIcst_r00y0 = SIcst_r00y0 + SIvec_r00(iCell) &
-                                               * SIvec_y0(iCell)
-      
-                     SIcst_r00t0 = SIcst_r00t0 + SIvec_r00(iCell) &
-                                               * SIvec_t0(iCell)
-      
-                     SIcst_r00v0 = SIcst_r00v0 + SIvec_r00(iCell) &
-                                               * SIvec_v0(iCell)
-      
-                     SIcst_q0q0 = SIcst_q0q0   + SIvec_q0(iCell) &
-                                               * SIvec_q0(iCell)
-                  end do
-      
-                  SIcst_allreduce_local9(1) = SIcst_r00s0
-                  SIcst_allreduce_local9(2) = SIcst_r00z0
-                  SIcst_allreduce_local9(3) = SIcst_q0y0 
-                  SIcst_allreduce_local9(4) = SIcst_y0y0 
-                  SIcst_allreduce_local9(5) = SIcst_r00q0
-                  SIcst_allreduce_local9(6) = SIcst_r00y0
-                  SIcst_allreduce_local9(7) = SIcst_r00t0
-                  SIcst_allreduce_local9(8) = SIcst_r00v0
-                  SIcst_allreduce_local9(9) = SIcst_q0q0
-      
-                  ! Global sum across CPUs
-                  call mpas_timer_start("si reduction iter")
-                  call mpas_dmpar_sum_real_array(domain % dminfo, 9,      &
-                                                 SIcst_allreduce_local9,  &
-                                                 SIcst_allreduce_global9)
-                  call mpas_timer_stop("si reduction iter")
-      
-               endif
-   
-               SIcst_r00s0_global = SIcst_allreduce_global9(1) 
-               SIcst_r00z0_global = SIcst_allreduce_global9(2)
-               SIcst_q0y0_global  = SIcst_allreduce_global9(3)
-               SIcst_y0y0_global  = SIcst_allreduce_global9(4)
-               SIcst_r00q0_global = SIcst_allreduce_global9(5)
-               SIcst_r00y0_global = SIcst_allreduce_global9(6)
-               SIcst_r00t0_global = SIcst_allreduce_global9(7)
-               SIcst_r00v0_global = SIcst_allreduce_global9(8)
-               SIcst_q0q0_global  = SIcst_allreduce_global9(9)
-   
-               ! Omega0
-               SIcst_omega0 = SIcst_q0y0_global / SIcst_y0y0_global
-   
-               ! Residual
-               resid = SIcst_q0q0_global &
-                     - 2.0_RKIND * SIcst_omega0 * SIcst_q0y0_global  &
-                     + SIcst_omega0**2.0_RKIND  * SIcst_y0y0_global
-   
-               !$omp parallel
-               !$omp do schedule(runtime)
-               do iCell = 1,nPrecVec
-                  sshSubcycleNew(iCell) = sshSubcycleNew(iCell)           &
-                                        + SIcst_alpha0 * SIvec_ph1(iCell) &
-                                        + SIcst_omega0 * SIvec_qh0(iCell)
-   
-                  SIvec_r1(iCell)  = SIvec_q0(iCell) - SIcst_omega0       &
-                                   * SIvec_y0(iCell)
-   
-                  SIvec_rh1(iCell) =  SIvec_qh0(iCell) - SIcst_omega0     &
-                                   * (SIvec_wh0(iCell) - SIcst_alpha0     &
-                                                       * SIvec_zh1(iCell))
-   
-                  SIvec_w1(iCell)  =   SIvec_y0(iCell) - SIcst_omega0     &
-                                   * ( SIvec_t0(iCell) - SIcst_alpha0     &
-                                                       * SIvec_v0(iCell))
-               end do
-               !$omp end do
-               !$omp end parallel
-   
-               ! Preconditioning -----------------------------------------!
-               if ( trim(config_btr_si_preconditioner) == 'ras' ) then
-                  ! RAS preconditioning: Use BLAS 
-                  ! for the symmetric matrix-vector multiplication
-#ifdef USE_LAPACK
-                  call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
-                             SIvec_w1(1:nPrecVec), 1, 0.0_RKIND,   &
-                             SIvec_wh1(1:nPrecVec),1)
-#endif
-   
-               elseif ( trim(config_btr_si_preconditioner) == &
-                                                 'block_jacobi' ) then
-                  ! Block-Jacobi preconditioning: Use BLAS
-                  ! for the symmetric matrix-vector multiplication
-#ifdef USE_LAPACK
-                  call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
-                             SIvec_w1(1:nPrecVec), 1, 0.0_RKIND,   &
-                             SIvec_wh1(1:nPrecVec),1)
-#endif
-   
-               elseif ( trim(config_btr_si_preconditioner) == &
-                                                       'jacobi' ) then
-                  ! Jacobi preconditioning
-                  SIvec_wh1(1:nPrecVec) = SIvec_w1(1:nPrecVec) &
-                                        * prec_ivmat(1:nPrecVec)
-   
-               elseif ( trim(config_btr_si_preconditioner) == &
-                                                         'none' ) then
-                  ! No preconditioning
-                  SIvec_wh1(1:nPrecVec) = SIvec_w1(1:nPrecVec)
-               end if
-   
-               call mpas_timer_start("si halo iter")
-               call mpas_dmpar_field_halo_exch(domain, 'SIvec_wh1')
-               call mpas_timer_stop("si halo iter")
-   
-               ! SpMV ----------------------------------------------------!
-   
-               !$omp parallel
-               !$omp do schedule(runtime) &
-               !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdgeLag, &
-               !$omp         thicknessSumLag,sshDiffLag,fluxAx,sshLagArea )
-               do iCell = 1, nPrecVec
-                  sshTendAx = 0.0_RKIND
-   
-                  do i = 1, nEdgesOnCell(iCell)
-                     iEdge = edgesOnCell(i, iCell)
-   
-                     cell1 = cellsOnEdge(1, iEdge)
-                     cell2 = cellsOnEdge(2, iEdge)
-   
-                     ! Interpolation sshEdge
-                     sshEdgeLag = 0.5_RKIND * (  sshNew(cell1)   &
-                                               + sshNew(cell2) )
-   
-                     ! method 1, matches method 0 without pbcs, 
-                     ! works with pbcs.
-                     thicknessSumLag = si_ismf * sshEdgeLag    &
-                                     + min(bottomDepth(cell1), &
-                                           bottomDepth(cell2))
-   
-                     ! nabla (ssh^0)
-                     sshDiffLag = (SIvec_wh1(cell2)-SIvec_wh1(cell1)) &
-                                / dcEdge(iEdge)
-   
-                     fluxAx = thicknessSumLag * sshDiffLag
-   
-                     sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
-                               * fluxAx * dvEdge(iEdge)
-                  end do ! i
-   
-                  sshLagArea = R1_alpha1s_g_dts * SIvec_wh1(iCell) &
-                             * areaCell(iCell)
-   
-                  SIvec_t1(iCell) = -sshLagArea - sshTendAx
-               end do ! iCell
-               !$omp end do
-               !$omp end parallel
-   
-               SIcst_rho1 = SIcst_r00q0_global - SIcst_omega0 * SIcst_r00y0_global 
-   
-               SIcst_gamma1 = SIcst_r00y0_global - SIcst_omega0 * SIcst_r00t0_global  &
-                                          + SIcst_omega0 * SIcst_alpha0 &
-                                                         * SIcst_r00v0_global
-    
-               SIcst_beta0 = (SIcst_alpha0/SIcst_omega0) &
-                           * (SIcst_rho1 / SIcst_rho0)
-   
-               SIcst_alpha0 = SIcst_rho1 &
-                            / ( SIcst_gamma1 + SIcst_beta0 * SIcst_r00s0_global   &
-                                             - SIcst_beta0 * SIcst_omega0  &
-                                                           * SIcst_r00z0_global )
-               SIcst_rho0 = SIcst_rho1
-
-               !$omp parallel
-               !$omp do schedule(runtime)
-               do iCell = 1,nPrecVec
-                  SIvec_r0(iCell) = SIvec_r1(iCell)
-                  SIvec_s0(iCell) = SIvec_s1(iCell)
-                  SIvec_z0(iCell) = SIvec_z1(iCell)
-                  SIvec_w0(iCell) = SIvec_w1(iCell)
-                  SIvec_t0(iCell) = SIvec_t1(iCell)
-   
-                  SIvec_rh0(iCell) = SIvec_rh1(iCell)
-                  SIvec_sh0(iCell) = SIvec_sh1(iCell)
-                  SIvec_ph0(iCell) = SIvec_ph1(iCell)
-                  SIvec_wh0(iCell) = SIvec_wh1(iCell)
-                  SIvec_zh0(iCell) = SIvec_zh1(iCell)
-               end do ! iCell
-               !$omp end do
-               !$omp end parallel
-   
-               if ( iter > int(mean_num_cells*5) ) then
-                  call mpas_log_write(&
-                  '******************************************************')
-                  call mpas_log_write(&
-                  'Iteration number exceeds Max. #iteration: PROGRAM STOP')
-                  call mpas_log_write(&
-                  'Current #Iteration = $i ', intArgs=(/ iter /) )
-                  call mpas_log_write(&
-                  'Max.    #Iteration = $i ', &
-                  intArgs=(/ int(mean_num_cells*5) /) )
-                  call mpas_log_write(&
-                  '******************************************************')
-                  call mpas_log_write('',MPAS_LOG_CRIT)
-               endif
-   
-            !-------------------------------------------------------------!
-            end do ! do iter
-            !-------------------------------------------------------------!
-   
             ! boundary update on SSHnew
             call mpas_timer_start("si halo iter")
             call mpas_dmpar_field_halo_exch(domain, 'sshSubcycle', timeLevel=2)
@@ -2450,7 +1534,7 @@ module ocn_time_integration_si
                normalBarotropicVelocitySubcycleNew(iEdge)              &
                   = temp_mask                                          &
                   * (normalBarotropicVelocityCur(iEdge)                &
-                  - dt_si * (-barotropicCoriolisTerm(iEdge) + gravity     &
+                  - dt_si * (-barotropicCoriolisTerm(iEdge) + gravity  &
                           *normalBarotropicVelocityNew(iEdge)          &
                           /dcEdge(iEdge) - barotropicForcing(iEdge)))
             end do ! iEdge
@@ -2464,7 +1548,7 @@ module ocn_time_integration_si
                CoriolisTerm = 0.0_RKIND
                do i = 1, nEdgesOnEdge(iEdge)
                   eoe = edgesOnEdge(i,iEdge)
-                  CoriolisTerm =  CoriolisTerm + weightsOnEdge(i,iEdge)   &
+                  CoriolisTerm =  CoriolisTerm + weightsOnEdge(i,iEdge)     &
                                * 0.5_RKIND                                  &
                                * ( normalBarotropicVelocitySubcycleNew(eoe) &
                                   +normalBarotropicVelocityCur(eoe) )       &
@@ -2487,7 +1571,7 @@ module ocn_time_integration_si
                normalBarotropicVelocitySubcycleNew(iEdge)              &
                   = temp_mask                                          &
                   * (normalBarotropicVelocityCur(iEdge)                &
-                  - dt_si * (-barotropicCoriolisTerm(iEdge) + gravity     &
+                  - dt_si * (-barotropicCoriolisTerm(iEdge) + gravity  &
                           *normalBarotropicVelocityNew(iEdge)          &
                           /dcEdge(iEdge) - barotropicForcing(iEdge)))
             end do ! iEdge
@@ -2555,11 +1639,6 @@ module ocn_time_integration_si
          !-------------------------------------------------------------!
          ! END   Large barotropic system iteration loop
          !-------------------------------------------------------------!
-
-         if ( config_btr_si_partition_match_mode ) then
-            deallocate( globalReprodSum2fld1,globalReprodSum2fld2,  &
-                        globalReprodSum9fld1,globalReprodSum9fld2 )
-         endif
 
          ! Check that you can compute SSH using the total sum or the
          ! individual increments over the barotropic subcycles.
@@ -2790,7 +1869,7 @@ module ocn_time_integration_si
             !$acc                normalGMBolusVelocity)
             !$acc enter data copyin(atmosphericPressure, seaIcePressure)
             !$acc enter data copyin(sshNew)
-            !$acc enter data copyin(tracersGroupNew)
+            !$acc enter data copyin(activeTracersNew)
             !$acc update device(tracersSurfaceValue)
             if ( associated(frazilSurfacePressure) ) then
                !$acc enter data copyin(frazilSurfacePressure)
@@ -2939,8 +2018,10 @@ module ocn_time_integration_si
                                   dt*layerThicknessTend(k,iCell)
             end do
             end do
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
+#endif
 
             if (config_compute_active_tracer_budgets) then
 
@@ -2983,8 +2064,10 @@ module ocn_time_integration_si
                              layerThicknessNew(k,iCell)
                end do
                end do
+#ifndef MPAS_OPENACC
                !$omp end do
                !$omp end parallel
+#endif
             endif
 
             call mpas_pool_begin_iteration(tracersPool)
@@ -3020,8 +2103,10 @@ module ocn_time_integration_si
                         layerThicknessNew(k,iCell)
                      end do
                      end do
+#ifndef MPAS_OPENACC
                      !$omp end do
                      !$omp end parallel
+#endif
 
                      ! limit salinity in separate loop
                      if (trim(groupItr%memberName) == &
@@ -3035,8 +2120,10 @@ module ocn_time_integration_si
                            tracersGroupNew(indexSalinity,k,iCell))
                         end do
                         end do
+#ifndef MPAS_OPENACC
                         !$omp end do
                         !$omp end parallel
+#endif
                      end if
 
                      ! Reset debugTracers to fixed value at the surface
@@ -3088,8 +2175,10 @@ module ocn_time_integration_si
                               end do
                            end if
                         end do ! cells
+#ifndef MPAS_OPENACC
                         !$omp end do
                         !$omp end parallel
+#endif
                      end if ! debug tracers
                   end if ! use tracer group
                end if ! tracer
@@ -3109,8 +2198,10 @@ module ocn_time_integration_si
                   lowFreqDivergenceTend(k,iCell)
                end do
                end do
+#ifndef MPAS_OPENACC
                !$omp end do
                !$omp end parallel
+#endif
             end if
 
             ! Recompute final u to go on to next step.
@@ -3139,8 +2230,10 @@ module ocn_time_integration_si
                                normalBaroclinicVelocityCur(k,iEdge)
             end do
             end do ! iEdges
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
+#endif
 
             endif ! splitImplicitStep
 
@@ -3152,6 +2245,16 @@ module ocn_time_integration_si
       ! END large iteration loop
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+      if ( config_btr_si_partition_match_mode ) then
+         if ( si_algorithm == 'sbicg' ) then
+            deallocate( globalReprodSum2fld1,globalReprodSum2fld2,  &
+                        globalReprodSum9fld1,globalReprodSum9fld2 )
+         else if ( si_algorithm == 'scg' ) then
+            deallocate( globalReprodSum2fld1,globalReprodSum2fld2,  &
+                        globalReprodSum3fld1,globalReprodSum3fld2 )
+         end if
+      endif
+
       call mpas_timer_start("si implicit vert mix")
 
       ! Call ocean diagnostic solve in preparation for vertical mixing.
@@ -3161,18 +2264,13 @@ module ocn_time_integration_si
       ! For kpp, more variables may be needed.  Either way, this could
       ! be made more efficient by only computing what is needed for the
       ! implicit vmix routine that follows.
-
-      call mpas_pool_get_array(forcingPool, 'seaIcePressure', seaIcePressure)
-      call mpas_pool_get_array(forcingPool, 'atmosphericPressure', atmosphericPressure)
-      call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
-
 #ifdef MPAS_OPENACC
       !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
       !$acc update device (normalTransportVelocity, &
       !$acc                normalGMBolusVelocity)
       !$acc enter data copyin(atmosphericPressure, seaIcePressure)
       !$acc enter data copyin(sshNew)
-      !$acc enter data copyin(tracersGroupNew)
+      !$acc enter data copyin(activeTracersNew)
       !$acc update device(tracersSurfaceValue)
       if ( associated(frazilSurfacePressure) ) then
          !$acc enter data copyin(frazilSurfacePressure)
@@ -3199,18 +2297,10 @@ module ocn_time_integration_si
       !$acc update host (surfacePressure)
       !$acc update host(zMid, zTop)
       !$acc exit data copyout(sshNew)
-      !$acc exit data delete(tracersGroupNew)
+      !$acc exit data delete(activeTracersNew)
       !$acc update host(tracersSurfaceValue)
       !$acc update host(normalVelocitySurfaceLayer)
       !$acc exit data delete (atmosphericPressure, seaIcePressure)
-      if ( associated(frazilSurfacePressure) ) then
-         !$acc exit data delete(frazilSurfacePressure)
-      endif
-      if (landIcePressureOn) then
-         !$acc exit data delete(landIcePressure)
-         !$acc exit data delete(landIceDraft)
-      endif
-      !$acc exit data delete(layerThicknessNew, normalVelocityNew)
       !$acc update host(density, potentialDensity, displacedDensity)
       !$acc update host(thermExpCoeff,  &
       !$acc&            salineContractCoeff)
@@ -3222,6 +2312,14 @@ module ocn_time_integration_si
       !$acc             normalVelocitySurfaceLayer, &
       !$acc             sfcFlxAttCoeff, &
       !$acc             surfaceFluxAttenuationCoefficientRunoff)
+      if ( associated(frazilSurfacePressure) ) then
+         !$acc exit data delete(frazilSurfacePressure)
+      endif
+      if (landIcePressureOn) then
+         !$acc exit data delete(landIcePressure)
+         !$acc exit data delete(landIceDraft)
+      endif
+      !$acc exit data delete(layerThicknessNew, normalVelocityNew)
 #endif
 
       call mpas_dmpar_field_halo_exch(domain, 'surfaceFrictionVelocity')
@@ -3807,12 +2905,6 @@ module ocn_time_integration_si
       call mpas_timer_stop("preconditioning matrix build")
 
    !--------------------------------------------------------------------
-      if (config_use_self_attraction_loading) then
-         ! set ssh_sal_on to 1
-         ssh_sal_on = 1
-      else
-         ssh_sal_on = 0
-      endif
 
    end subroutine ocn_time_integration_si_init!}}}
 
@@ -3828,6 +2920,7 @@ module ocn_time_integration_si
 !>  split-implicit time stepper.
 !
 !-----------------------------------------------------------------------
+
    subroutine ocn_time_integrator_si_preconditioner(domain, dt)!{{{
 
       !-----------------------------------------------------------------
@@ -3867,6 +2960,7 @@ module ocn_time_integration_si
                           !    of an uppder digonal matrix
 
       integer ::  i, j, info, itmp1
+
       real (kind=RKIND) :: thicknessSum, fluxAx, temp1
 
       ! End preamble
@@ -3882,19 +2976,26 @@ module ocn_time_integration_si
       nCellsHalo1st = nCellsHalo(1)
       nCellsHalo2nd = nCellsHalo(2)
 
+      si_algorithm = 'sbicg' ! Default iterative solver algorithm
+
       call mpas_log_write('   config_btr_si_preconditioner: ' &
                            // trim(config_btr_si_preconditioner) )
 
       if ( trim(config_btr_si_preconditioner) == 'ras' .or. &
            trim(config_btr_si_preconditioner) == 'block_jacobi') then
-         if ( int(mean_num_cells) > 3000 ) then
+         if ( int(mean_num_cells) > 1200 ) then
             call mpas_log_write( &
-            '      nCells per core is larger than 3000.')
+            '      nCells per core is larger than 1200.')
             call mpas_log_write( &
             '      Because of memory and computational efficiency,')
             call mpas_log_write( &
             '      the preconditioner is configured as jacobi.')
             config_btr_si_preconditioner = 'jacobi'
+            call mpas_log_write( &
+            '      The solver algorithm is configured as scg.')
+            call mpas_log_write( &
+            '      (Default is sbicg.)')
+            si_algorithm = 'scg'
          endif
       endif
 
@@ -3906,6 +3007,11 @@ module ocn_time_integration_si
          config_btr_si_preconditioner = 'jacobi'
          call mpas_log_write( &
          '       The bit-for-bit allreduce is used.')
+         call mpas_log_write( &
+         '       The solver algorithm is configured as scg.')
+         call mpas_log_write( &
+         '       (Default is sbicg.)')
+         si_algorithm = 'scg'
       endif
 
       ! Restricted Additive Schwarz preconditioner --------------------!
@@ -4090,6 +3196,752 @@ module ocn_time_integration_si
       endif ! config_btr_si_preconditioner
 
    end subroutine ocn_time_integrator_si_preconditioner !}}}
+
+!***********************************************************************
+!
+!  routine si_matvec_mul
+!
+!> \brief   Matrix-vector multiplication for iterative solvers
+!
+!> \author  Hyun-Gyu Kang
+!
+!> \details
+!   This routine performs a matrix-vector multiplication for iterative
+!   solvers.
+!
+!-----------------------------------------------------------------------
+
+   subroutine si_matvec_mul(SIvec_in,SIvec_out,ssh)
+
+      real(kind=RKIND),dimension(:),pointer,intent(in)  :: &
+          SIvec_in, &! Input SI vector
+          ssh        ! Intermediate ssh
+
+      real(kind=RKIND),dimension(:),pointer,intent(out) :: &
+          SIvec_out  ! Output SI vector
+
+      real(kind=RKIND) :: sshTendAx, sshEdge, thicknessSum, sshDiff
+      real(kind=RKIND) :: fluxAx, sshArea
+
+      integer :: iEdge, cell1, cell2, i, iCell
+ 
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(sshTendAx,iEdge,cell1,cell2,sshEdge, &
+      !$omp         thicknessSum,sshDiff,fluxAx,sshArea )
+      do iCell = 1, nPrecVec
+         sshTendAx = 0.0_RKIND
+
+         do i = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i, iCell)
+
+            cell1 = cellsOnEdge(1, iEdge)
+            cell2 = cellsOnEdge(2, iEdge)
+
+            ! Interpolation sshEdge
+            sshEdge = 0.5_RKIND * (  ssh(cell1)   &
+                                   + ssh(cell2) )
+
+            ! method 1, matches method 0 without pbcs,
+            ! works with pbcs.
+            thicknessSum = si_ismf * sshEdge    &
+                         + min(bottomDepth(cell1), &
+                               bottomDepth(cell2))
+
+            ! nabla (ssh^0)
+            sshDiff = (SIvec_in(cell2)-SIvec_in(cell1)) &
+                    / dcEdge(iEdge)
+
+            fluxAx = thicknessSum * sshDiff
+
+            sshTendAx = sshTendAx + edgeSignOnCell(i, iCell) &
+                      * fluxAx * dvEdge(iEdge)
+         end do ! i
+
+         sshArea = R1_alpha1s_g_dts * SIvec_in(iCell) &
+                    * areaCell(iCell)
+
+         SIvec_out(iCell) = -sshArea - sshTendAx
+
+      end do ! iCell
+      !$omp end do
+      !$omp end parallel
+      
+   end subroutine si_matvec_mul
+
+!***********************************************************************
+!
+!  routine si_precond
+!
+!> \brief   Preconditioning for iterative solvers
+!
+!> \author  Hyun-Gyu Kang
+!
+!> \details
+!   This routine performs preconditioing for iterative solvers.
+!
+!-----------------------------------------------------------------------
+
+   subroutine si_precond(SIvec_in,SIvec_out)
+
+      real(kind=RKIND), dimension(:), pointer, intent(in)  :: SIvec_in
+                                        ! Input SI vector
+
+      real(kind=RKIND), dimension(:), pointer, intent(out) :: SIvec_out
+                                        ! SI vector to be preconditioned
+
+      ! Preconditioning --------------------------------------------!
+      if ( trim(config_btr_si_preconditioner) == 'ras' ) then
+         ! RAS preconditioning: Use BLAS for the symmetric 
+         !                      matrix-vector multiplication
+#ifdef USE_LAPACK
+      call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+                 SIvec_in(1:nPrecVec) , 1, 0.0_RKIND,  &
+                 SIvec_out(1:nPrecVec), 1)
+#endif
+      elseif ( trim(config_btr_si_preconditioner) == &
+                                        'block_jacobi' ) then
+         ! Block-Jacobi preconditioning: Use BLAS for the symmetric 
+         !                               matrix-vector multiplication
+#ifdef USE_LAPACK
+      call DSPMV('U', nPrecVec, 1.0_RKIND, prec_ivmat, &
+                 SIvec_in(1:nPrecVec) , 1, 0.0_RKIND,  &
+                 SIvec_out(1:nPrecVec), 1)
+#endif
+      elseif ( trim(config_btr_si_preconditioner) == &
+                                              'jacobi' ) then
+         ! Jacobi preconditioning
+         SIvec_out(1:nPrecVec) = SIvec_in(1:nPrecVec) &
+                               * prec_ivmat(1:nPrecVec)
+   
+      elseif ( trim(config_btr_si_preconditioner) == &
+                                                'none' ) then
+         ! No preconditioning
+         SIvec_out(1:nPrecVec) = SIvec_in(1:nPrecVec)
+      end if
+   end subroutine si_precond
+
+!***********************************************************************
+!
+!  routine si_global_reduction
+!
+!> \brief   Global reduction for iterative solvers
+!
+!> \author  Hyun-Gyu Kang
+!
+!> \details
+!   This routine performs global reduction for iterative solvers.
+!   It uses a reproducible global summation when
+!   'config_btr_si_partition_match_mode' is turned on.
+!
+!-----------------------------------------------------------------------
+
+   subroutine si_global_reduction(localProd,globalProd,       &
+                             reprodSum1,reprodSum2,           &
+                             si_algorithm,nfld,domain,        &
+                             SIvec_1,SIvec_2,SIvec_3,SIvec_4, &
+                             SIvec_5,SIvec_6,SIvec_7,SIvec_8)  
+
+      type (domain_type), intent(in) :: &
+         domain  !< [inout] model state to advance forward
+
+      real(kind=RKIND), dimension(:), pointer, intent(in) :: &
+         SIvec_1,SIvec_2 ! SI vectors
+      real(kind=RKIND), dimension(:), pointer, intent(in), optional :: &
+         SIvec_3,SIvec_4,SIvec_5,SIvec_6,SIvec_7,SIvec_8 ! SI vectors
+
+      character(*), intent(in) :: si_algorithm ! Solver algorithm
+
+      integer, intent(in) :: nfld ! Number of reductions
+
+      real(kind=RKIND), dimension(:,:), intent(out) :: &
+         reprodSum1,reprodSum2 ! Array for reprod. global summation
+
+      real(kind=RKIND), dimension(:), intent(out) :: &
+         localProd,globalProd ! Array for global summation
+
+      real(kind=RKIND) :: &
+         SIcst_r0rh0,SIcst_w0rh0,SIcst_r0r0,SIcst_r00r0,SIcst_r00w0, &
+         SIcst_r00s0,SIcst_r00z0,SIcst_q0y0,SIcst_y0y0,SIcst_r00q0,  &
+         SIcst_r00y0,SIcst_r00t0,SIcst_r00v0,SIcst_q0q0 
+
+      integer :: iCell
+
+      if ( si_algorithm == 'scg' .and. nfld == 2 ) then !!!
+   
+         if ( config_btr_si_partition_match_mode ) then
+    
+            ! Reproducible sum of multiple fields over products
+            do iCell = 1,nCellsOwned
+               reprodSum1(iCell,1) = SIvec_1(iCell) !r0
+               reprodSum1(iCell,2) = SIvec_2(iCell) !w0
+    
+               reprodSum2(iCell,1) = SIvec_3(iCell) !rh0
+               reprodSum2(iCell,2) = SIvec_3(iCell) !rh0
+            end do
+        
+            globalProd(:) = 0.0_RKIND
+            globalProd(:) =                   &
+               mpas_global_sum_nfld(reprodSum1, &
+                                    reprodSum2, &
+                                    domain%dminfo%comm)
+         else
+    
+            SIcst_r0rh0 = 0.0_RKIND
+            SIcst_w0rh0 = 0.0_RKIND
+    
+            do iCell = 1, nCellsOwned
+               SIcst_r0rh0 = SIcst_r0rh0 + SIvec_1(iCell) &
+                                         * SIvec_3(iCell)
+               SIcst_w0rh0 = SIcst_w0rh0 + SIvec_2(iCell) &
+                                         * SIvec_3(iCell)
+            end do ! iCell
+    
+            localProd(1) = SIcst_r0rh0
+            localProd(2) = SIcst_w0rh0
+    
+            ! Global sum across CPUs
+            call mpas_dmpar_sum_real_array(domain % dminfo, nfld,      &
+                                           localProd,  &
+                                           globalProd)
+         endif
+   
+      elseif ( si_algorithm == 'scg' .and. nfld == 3 ) then !!!
+   
+         if ( config_btr_si_partition_match_mode ) then
+   
+            ! Reproducible sum of multiple fields over products
+            do iCell = 1,nCellsOwned
+               reprodSum1(iCell,1) = SIvec_1(iCell) !r1
+               reprodSum1(iCell,2) = SIvec_2(iCell) !w1
+               reprodSum1(iCell,3) = SIvec_1(iCell) !r1
+      
+               reprodSum2(iCell,1) = SIvec_3(iCell) !rh1
+               reprodSum2(iCell,2) = SIvec_3(iCell) !rh1
+               reprodSum2(iCell,3) = SIvec_1(iCell)  !r1
+            end do
+      
+            globalProd(:) = 0.0_RKIND
+            globalProd(:) =                   &
+               mpas_global_sum_nfld(reprodSum1, &
+                                    reprodSum2, &
+                                    domain%dminfo%comm)
+         else
+   
+            SIcst_r0rh0 = 0.0_RKIND
+            SIcst_w0rh0 = 0.0_RKIND
+            SIcst_r0r0  = 0.0_RKIND
+         
+            do iCell = 1,nCellsOwned
+               SIcst_r0rh0 = SIcst_r0rh0 + SIvec_1(iCell) &
+                                         * SIvec_3(iCell) ! s1
+         
+               SIcst_w0rh0 = SIcst_w0rh0 + SIvec_2(iCell) &
+                                         * SIvec_3(iCell) ! z1
+   
+               SIcst_r0r0  = SIcst_r0r0  + SIvec_1(iCell) &
+                                         * SIvec_1(iCell) ! z1
+            end do
+      
+            localProd(1) = SIcst_r0rh0
+            localProd(2) = SIcst_w0rh0
+            localProd(3) = SIcst_r0r0
+         
+            ! Global sum across CPUs
+            call mpas_dmpar_sum_real_array(domain % dminfo, nfld,      &
+                                           localProd,  &
+                                           globalProd)
+   
+         endif
+   
+      elseif ( si_algorithm == 'sbicg' .and. nfld == 2 ) then !!!
+
+         if ( config_btr_si_partition_match_mode ) then
+
+            ! Reproducible sum of multiple fields over products
+ 
+            do iCell = 1,nCellsOwned
+               globalReprodSum2fld1(iCell,1) = SIvec_1(iCell) !r00
+               globalReprodSum2fld1(iCell,2) = SIvec_1(iCell) !r00
+
+               globalReprodSum2fld2(iCell,1) = SIvec_2(iCell) !r0
+               globalReprodSum2fld2(iCell,2) = SIvec_3(iCell) !w0
+            end do
+
+            SIcst_allreduce_global2(:) =                   &
+               mpas_global_sum_nfld(globalReprodSum2fld1, &
+                                    globalReprodSum2fld2, &
+                                    domain%dminfo%comm)
+
+         else
+
+            SIcst_r00r0 = 0.0_RKIND
+            SIcst_r00w0 = 0.0_RKIND
+   
+            do iCell = 1, nCellsOwned
+               SIcst_r00r0 = SIcst_r00r0 + SIvec_1(iCell) &
+                                         * SIvec_2(iCell)
+               SIcst_r00w0 = SIcst_r00w0 + SIvec_1(iCell) &
+                                         * SIvec_3(iCell)
+            end do ! iCell
+   
+            SIcst_allreduce_local2(1) = SIcst_r00r0
+            SIcst_allreduce_local2(2) = SIcst_r00w0
+   
+            ! Global sum across CPUs
+            call mpas_dmpar_sum_real_array(domain % dminfo, 2,      &
+                                           SIcst_allreduce_local2,  &
+                                           SIcst_allreduce_global2)
+
+         endif
+
+      elseif ( si_algorithm == 'sbicg' .and. nfld == 9 ) then !!!
+
+         if ( config_btr_si_partition_match_mode ) then
+ 
+            ! Reproducible sum of multiple fields over products
+             
+            do iCell = 1,nCellsOwned
+               globalReprodSum9fld1(iCell,1) = SIvec_1(iCell) !r00
+               globalReprodSum9fld1(iCell,2) = SIvec_1(iCell) !r00
+               globalReprodSum9fld1(iCell,3) = SIvec_2(iCell) !q0
+               globalReprodSum9fld1(iCell,4) = SIvec_3(iCell) !y0
+               globalReprodSum9fld1(iCell,5) = SIvec_1(iCell) !r00
+               globalReprodSum9fld1(iCell,6) = SIvec_1(iCell) !r00
+               globalReprodSum9fld1(iCell,7) = SIvec_1(iCell) !r00
+               globalReprodSum9fld1(iCell,8) = SIvec_1(iCell) !r00
+               globalReprodSum9fld1(iCell,9) = SIvec_2(iCell) !q0
+    
+               globalReprodSum9fld2(iCell,1) = SIvec_4(iCell) !s1
+               globalReprodSum9fld2(iCell,2) = SIvec_5(iCell) !z1
+               globalReprodSum9fld2(iCell,3) = SIvec_3(iCell) !y0
+               globalReprodSum9fld2(iCell,4) = SIvec_3(iCell) !y0
+               globalReprodSum9fld2(iCell,5) = SIvec_2(iCell) !q0
+               globalReprodSum9fld2(iCell,6) = SIvec_3(iCell) !y0
+               globalReprodSum9fld2(iCell,7) = SIvec_6(iCell) !t0
+               globalReprodSum9fld2(iCell,8) = SIvec_7(iCell) !v0
+               globalReprodSum9fld2(iCell,9) = SIvec_2(iCell) !q0
+            end do
+    
+            SIcst_allreduce_global9(:) =                   &
+               mpas_global_sum_nfld(globalReprodSum9fld1, &
+                                    globalReprodSum9fld2, &
+                                    domain%dminfo%comm)
+    
+         else
+ 
+            SIcst_r00s0 = 0.0_RKIND
+            SIcst_r00z0 = 0.0_RKIND
+            SIcst_q0y0  = 0.0_RKIND
+            SIcst_y0y0  = 0.0_RKIND
+            SIcst_r00q0 = 0.0_RKIND
+            SIcst_r00y0 = 0.0_RKIND
+            SIcst_r00t0 = 0.0_RKIND
+            SIcst_r00v0 = 0.0_RKIND
+            SIcst_q0q0  = 0.0_RKIND
+       
+            do iCell = 1,nCellsOwned
+               SIcst_r00s0 = SIcst_r00s0 + SIvec_1(iCell) &
+                                         * SIvec_4(iCell) ! s1
+       
+               SIcst_r00z0 = SIcst_r00z0 + SIvec_1(iCell) &
+                                         * SIvec_5(iCell) ! z1
+       
+               SIcst_q0y0  = SIcst_q0y0  + SIvec_2(iCell)  &
+                                         * SIvec_3(iCell)
+       
+               SIcst_y0y0  = SIcst_y0y0  + SIvec_3(iCell)  &
+                                         * SIvec_3(iCell)
+       
+               SIcst_r00q0 = SIcst_r00q0 + SIvec_1(iCell) &
+                                         * SIvec_2(iCell)
+       
+               SIcst_r00y0 = SIcst_r00y0 + SIvec_1(iCell) &
+                                         * SIvec_3(iCell)
+       
+               SIcst_r00t0 = SIcst_r00t0 + SIvec_1(iCell) &
+                                         * SIvec_6(iCell)
+       
+               SIcst_r00v0 = SIcst_r00v0 + SIvec_1(iCell) &
+                                         * SIvec_7(iCell)
+       
+               SIcst_q0q0 = SIcst_q0q0   + SIvec_2(iCell) &
+                                         * SIvec_2(iCell)
+            end do
+    
+            SIcst_allreduce_local9(1) = SIcst_r00s0
+            SIcst_allreduce_local9(2) = SIcst_r00z0
+            SIcst_allreduce_local9(3) = SIcst_q0y0 
+            SIcst_allreduce_local9(4) = SIcst_y0y0 
+            SIcst_allreduce_local9(5) = SIcst_r00q0
+            SIcst_allreduce_local9(6) = SIcst_r00y0
+            SIcst_allreduce_local9(7) = SIcst_r00t0
+            SIcst_allreduce_local9(8) = SIcst_r00v0
+            SIcst_allreduce_local9(9) = SIcst_q0q0
+       
+            ! Global sum across CPUs
+            call mpas_timer_start("si reduction iter")
+            call mpas_dmpar_sum_real_array(domain % dminfo, 9,      &
+                                           SIcst_allreduce_local9,  &
+                                           SIcst_allreduce_global9)
+            call mpas_timer_stop("si reduction iter")
+    
+         endif
+
+      endif !!!
+   
+   end subroutine si_global_reduction
+
+!***********************************************************************
+!
+!  routine si_solver_scg
+!
+!> \brief   Linear iterative solver:
+!              The s-step conjugate gradient algorithm
+!> \author  Hyun-Gyu Kang
+!
+!> \details
+!   This routine solves a linear system iteratively using 
+!   the s-step conjugate gradient algorithm 
+!   (Chronopoulos and Gear, 1989).
+!
+!-----------------------------------------------------------------------
+
+   subroutine si_solver_scg(domain,sshSolved,ssh,tolerance,       &
+                            SIcst_alpha0,SIcst_beta0,SIcst_gamma0)
+
+      type (domain_type), intent(inout) :: &
+         domain  !< [inout] model state to advance forward
+
+      real(kind=RKIND), dimension(:), pointer, intent(in) :: &
+         ssh                                    ! Intermediate ssh
+
+      real(kind=RKIND), dimension(:), pointer, intent(inout) :: &
+         sshSolved                              ! ssh to be solved
+
+      real(kind=RKIND), intent(in) :: tolerance ! Tolerance of solver
+
+      real(kind=RKIND), intent(inout) :: &
+         SIcst_alpha0,SIcst_beta0,SIcst_gamma0  ! Initial reductions
+
+      real(kind=RKIND) :: &
+         SIcst_beta1,SIcst_alpha1,SIcst_gamma1,resid,SIcst_omega0, &
+         SIcst_r0rh0_global,SIcst_w0rh0_global
+
+      integer :: iter, iCell
+
+      iter = 0
+      resid = (tolerance+100.0)**2.0
+
+      !-------------------------------------------------------------!
+      do while ( dsqrt(resid) > tolerance )
+      !-------------------------------------------------------------!
+
+         iter = iter + 1
+
+         !$omp parallel
+         !$omp do schedule(runtime)
+         do iCell = 1, nPrecVec
+            SIvec_z1(iCell) = SIvec_rh0(iCell) &
+                            + SIcst_beta0 * SIvec_z0(iCell)
+
+            SIvec_s1(iCell) = SIvec_w0(iCell) &
+                            + SIcst_beta0 * SIvec_s0(iCell)
+
+            sshSolved(iCell) = sshSolved(iCell) &
+                            + SIcst_alpha0 * SIvec_z1(iCell)
+
+            SIvec_r1(iCell) = SIvec_r0(iCell) &
+                            - SIcst_alpha0 * SIvec_s1(iCell)
+         end do ! iCell
+         !$omp end do
+         !$omp end parallel
+  
+         ! Preconditioning -----------------------------------------!
+         call si_precond(SIvec_r1,SIvec_rh1)
+  
+         call mpas_timer_start("si halo iter")
+         call mpas_dmpar_field_halo_exch(domain, 'SIvec_rh1')
+         call mpas_timer_stop("si halo iter")
+  
+  
+         ! SpMV ----------------------------------------------------!
+         call si_matvec_mul(SIvec_rh1,SIvec_w1,ssh)
+  
+         ! Reduction -----------------------------------------------!
+
+         call mpas_timer_start("si reduction iter")
+         call si_global_reduction(SIcst_allreduce_local3,&
+                             SIcst_allreduce_global3,    &
+                             globalReprodSum3fld1,       &
+                             globalReprodSum3fld2,       &
+                             si_algorithm,3,domain,      &
+                             SIvec_r1,SIvec_w1,SIvec_rh1)
+         call mpas_timer_stop("si reduction iter")
+  
+         SIcst_r0rh0_global = SIcst_allreduce_global3(1) 
+         SIcst_w0rh0_global = SIcst_allreduce_global3(2)
+                      resid = SIcst_allreduce_global3(3)
+
+         ! Omega0
+         SIcst_gamma1 = SIcst_r0rh0_global
+         SIcst_omega0 = SIcst_w0rh0_global
+         SIcst_beta1  = SIcst_gamma1 / SIcst_gamma0
+         SIcst_alpha1 = SIcst_gamma1                            &
+                      /(SIcst_omega0 - SIcst_beta1*SIcst_gamma1 &
+                                     / SIcst_alpha0 )
+
+         !$omp parallel
+         !$omp do schedule(runtime)
+         do iCell = 1,nPrecVec
+            SIvec_r0(iCell)  = SIvec_r1(iCell)
+            SIvec_s0(iCell)  = SIvec_s1(iCell)
+            SIvec_w0(iCell)  = SIvec_w1(iCell)
+            SIvec_z0(iCell)  = SIvec_z1(iCell)
+            SIvec_rh0(iCell) = SIvec_rh1(iCell)
+         end do ! iCell
+         !$omp end do
+         !$omp end parallel
+
+         SIcst_beta0  = SIcst_beta1
+         SIcst_alpha0 = SIcst_alpha1
+         SIcst_gamma0 = SIcst_gamma1
+
+         if ( iter > int(mean_num_cells*5) ) then
+            call mpas_log_write(&
+            '******************************************************')
+            call mpas_log_write(&
+            'Iteration number exceeds Max. #iteration: PROGRAM STOP')
+            call mpas_log_write(&
+            'Current #Iteration = $i ', intArgs=(/ iter /) )
+            call mpas_log_write(&
+            'Max.    #Iteration = $i ', &
+            intArgs=(/ int(mean_num_cells*5) /) )
+            call mpas_log_write(&
+            '******************************************************')
+            call mpas_log_write('',MPAS_LOG_CRIT)
+         endif
+
+      !-------------------------------------------------------------!
+      end do ! do iter
+      !-------------------------------------------------------------!
+     
+   end subroutine si_solver_scg
+
+!***********************************************************************
+!
+!  routine si_solver_sbicg
+!
+!> \brief   Linear iterative solver:
+!              The single-reduction bi-conjugate gradient
+!              stabilization algorithm
+!
+!> \author  Hyun-Gyu Kang
+!
+!> \details
+!   This routine solves a linear system iteratively using 
+!   the single-reduction bi-conjugate gradient stabilization algorithm.
+!
+!-----------------------------------------------------------------------
+
+   subroutine si_solver_sbicg(domain,sshSolved,ssh,tolerance,       &
+                 SIcst_alpha0,SIcst_beta0,SIcst_gamma0,SIcst_rho0)
+
+      type (domain_type), intent(inout) :: &
+         domain  !< [inout] model state to advance forward
+
+      real(kind=RKIND), dimension(:), pointer, intent(in) :: &
+         ssh                                    ! Intermediate ssh
+
+      real(kind=RKIND), dimension(:), pointer, intent(inout) :: &
+         sshSolved                              ! ssh to be solved
+
+      real(kind=RKIND), intent(in) :: tolerance ! Tolerance of solver
+
+      real(kind=RKIND), intent(inout) :: &
+         SIcst_alpha0,SIcst_beta0,SIcst_gamma0,SIcst_rho0
+                                                ! Initial reductions
+
+      real(kind=RKIND) :: &
+         SIcst_beta1,SIcst_alpha1,SIcst_gamma1,resid,SIcst_omega0, &
+         SIcst_r0rh0_global,SIcst_w0rh0_global,SIcst_q0q0_global,  &
+         SIcst_q0y0_global,SIcst_r00q0_global,SIcst_r00s0_global,  &
+         SIcst_r00t0_global,SIcst_r00v0_global,SIcst_r00y0_global, &
+         SIcst_r00z0_global,SIcst_rho1,SIcst_y0y0_global
+
+      integer :: iter, iCell
+
+      iter = 0
+      resid = (tolerance+100.0)**2.0
+
+      !-------------------------------------------------------------!
+      do while ( dsqrt(resid) > tolerance )
+      !-------------------------------------------------------------!
+ 
+         iter = iter + 1
+ 
+         !$omp parallel
+         !$omp do schedule(runtime)
+         do iCell = 1, nPrecVec
+            SIvec_ph1(iCell) =  SIvec_rh0(iCell) + SIcst_beta0      &
+                             * (SIvec_ph0(iCell) - SIcst_omega0     &
+                                                 * SIvec_sh0(iCell))
+ 
+            SIvec_s1(iCell)  =  SIvec_w0(iCell)  + SIcst_beta0      &
+                             * (SIvec_s0(iCell)  - SIcst_omega0     &
+                                                 * SIvec_z0(iCell))
+ 
+            SIvec_sh1(iCell) =  SIvec_wh0(iCell) + SIcst_beta0      &
+                             * (SIvec_sh0(iCell) - SIcst_omega0     &
+                                                 * SIvec_zh0(iCell))
+ 
+            SIvec_z1(iCell)  =  SIvec_t0(iCell)  + SIcst_beta0      &
+                             * (SIvec_z0(iCell)  - SIcst_omega0     &
+                                                 * SIvec_v0(iCell))
+ 
+            SIvec_q0(iCell)  =  SIvec_r0(iCell)  - SIcst_alpha0     &
+                                                 * SIvec_s1(iCell)
+ 
+            SIvec_qh0(iCell) =  SIvec_rh0(iCell) - SIcst_alpha0     &
+                                                 * SIvec_sh1(iCell)
+ 
+            SIvec_y0(iCell)  =  SIvec_w0(iCell)  - SIcst_alpha0     &
+                                                 * SIvec_z1(iCell)
+         end do ! iCell
+         !$omp end do
+         !$omp end parallel
+ 
+         ! Preconditioning -----------------------------------------!
+ 
+         call si_precond(SIvec_z1,SIvec_zh1)
+ 
+         call mpas_timer_start("si halo iter")
+         call mpas_dmpar_field_halo_exch(domain, 'SIvec_zh1')
+         call mpas_timer_stop("si halo iter")
+ 
+ 
+         ! SpMV ----------------------------------------------------!
+ 
+         call si_matvec_mul(SIvec_zh1,SIvec_v0,ssh)
+ 
+         ! Reduction -----------------------------------------------!
+ 
+         call mpas_timer_start("si reduction iter")
+         call si_global_reduction(SIcst_allreduce_local9,          &
+                             SIcst_allreduce_global9,              &
+                             globalReprodSum9fld1,                 &
+                             globalReprodSum9fld2,                 &
+                             si_algorithm,9,domain,                &
+                             SIvec_r00,SIvec_q0,SIvec_y0,SIvec_s1, &
+                             SIvec_z1,SIvec_t0,SIvec_v0)
+         call mpas_timer_stop("si reduction iter")
+ 
+         SIcst_r00s0_global = SIcst_allreduce_global9(1) 
+         SIcst_r00z0_global = SIcst_allreduce_global9(2)
+         SIcst_q0y0_global  = SIcst_allreduce_global9(3)
+         SIcst_y0y0_global  = SIcst_allreduce_global9(4)
+         SIcst_r00q0_global = SIcst_allreduce_global9(5)
+         SIcst_r00y0_global = SIcst_allreduce_global9(6)
+         SIcst_r00t0_global = SIcst_allreduce_global9(7)
+         SIcst_r00v0_global = SIcst_allreduce_global9(8)
+         SIcst_q0q0_global  = SIcst_allreduce_global9(9)
+ 
+         ! Omega0
+         SIcst_omega0 = SIcst_q0y0_global / SIcst_y0y0_global
+ 
+         ! Residual
+         resid = SIcst_q0q0_global &
+               - 2.0_RKIND * SIcst_omega0 * SIcst_q0y0_global  &
+               + SIcst_omega0**2.0_RKIND  * SIcst_y0y0_global
+ 
+         !$omp parallel
+         !$omp do schedule(runtime)
+         do iCell = 1,nPrecVec
+            sshSolved(iCell) = sshSolved(iCell)           &
+                                  + SIcst_alpha0 * SIvec_ph1(iCell) &
+                                  + SIcst_omega0 * SIvec_qh0(iCell)
+ 
+            SIvec_r1(iCell)  = SIvec_q0(iCell) - SIcst_omega0       &
+                             * SIvec_y0(iCell)
+ 
+            SIvec_rh1(iCell) =  SIvec_qh0(iCell) - SIcst_omega0     &
+                             * (SIvec_wh0(iCell) - SIcst_alpha0     &
+                                                 * SIvec_zh1(iCell))
+ 
+            SIvec_w1(iCell)  =   SIvec_y0(iCell) - SIcst_omega0     &
+                             * ( SIvec_t0(iCell) - SIcst_alpha0     &
+                                                 * SIvec_v0(iCell))
+         end do
+         !$omp end do
+         !$omp end parallel
+ 
+         ! Preconditioning -----------------------------------------!
+ 
+         call si_precond(SIvec_w1,SIvec_wh1)
+ 
+         call mpas_timer_start("si halo iter")
+         call mpas_dmpar_field_halo_exch(domain, 'SIvec_wh1')
+         call mpas_timer_stop("si halo iter")
+ 
+         ! SpMV ----------------------------------------------------!
+ 
+         call si_matvec_mul(SIvec_wh1,SIvec_t1,ssh)
+ 
+         SIcst_rho1 = SIcst_r00q0_global - SIcst_omega0 * SIcst_r00y0_global 
+ 
+         SIcst_gamma1 = SIcst_r00y0_global - SIcst_omega0 * SIcst_r00t0_global  &
+                                    + SIcst_omega0 * SIcst_alpha0 &
+                                                   * SIcst_r00v0_global
+ 
+         SIcst_beta0 = (SIcst_alpha0/SIcst_omega0) &
+                     * (SIcst_rho1 / SIcst_rho0)
+ 
+         SIcst_alpha0 = SIcst_rho1 &
+                      / ( SIcst_gamma1 + SIcst_beta0 * SIcst_r00s0_global   &
+                                       - SIcst_beta0 * SIcst_omega0  &
+                                                     * SIcst_r00z0_global )
+         SIcst_rho0 = SIcst_rho1
+ 
+         !$omp parallel
+         !$omp do schedule(runtime)
+         do iCell = 1,nPrecVec
+           SIvec_r0(iCell) = SIvec_r1(iCell)
+           SIvec_s0(iCell) = SIvec_s1(iCell)
+           SIvec_z0(iCell) = SIvec_z1(iCell)
+           SIvec_w0(iCell) = SIvec_w1(iCell)
+           SIvec_t0(iCell) = SIvec_t1(iCell)
+
+           SIvec_rh0(iCell) = SIvec_rh1(iCell)
+           SIvec_sh0(iCell) = SIvec_sh1(iCell)
+           SIvec_ph0(iCell) = SIvec_ph1(iCell)
+           SIvec_wh0(iCell) = SIvec_wh1(iCell)
+           SIvec_zh0(iCell) = SIvec_zh1(iCell)
+        end do ! iCell
+        !$omp end do
+        !$omp end parallel
+
+        if ( iter > int(mean_num_cells*5) ) then
+           call mpas_log_write(&
+           '******************************************************')
+           call mpas_log_write(&
+           'Iteration number exceeds Max. #iteration: PROGRAM STOP')
+           call mpas_log_write(&
+           'Current #Iteration = $i ', intArgs=(/ iter /) )
+           call mpas_log_write(&
+           'Max.    #Iteration = $i ', &
+           intArgs=(/ int(mean_num_cells*5) /) )
+           call mpas_log_write(&
+           '******************************************************')
+           call mpas_log_write('',MPAS_LOG_CRIT)
+        endif
+
+     !-------------------------------------------------------------!
+     end do ! do iter
+     !-------------------------------------------------------------!
+
+   end subroutine si_solver_sbicg
+
+!***********************************************************************
 
 end module ocn_time_integration_si
 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -3221,11 +3221,11 @@ module ocn_time_integration_si
 
    subroutine si_matvec_mul(SIvec_in,SIvec_out,ssh)
 
-      real(kind=RKIND),dimension(:),pointer,intent(in)  :: &
+      real(kind=RKIND),dimension(:),intent(in)  :: &
           SIvec_in, &! Input SI vector
           ssh        ! Intermediate ssh
 
-      real(kind=RKIND),dimension(:),pointer,intent(out) :: &
+      real(kind=RKIND),dimension(:),intent(out) :: &
           SIvec_out  ! Output SI vector
 
       real(kind=RKIND) :: sshTendAx, sshEdge, thicknessSum, sshDiff
@@ -3292,10 +3292,10 @@ module ocn_time_integration_si
 
    subroutine si_precond(SIvec_in,SIvec_out)
 
-      real(kind=RKIND), dimension(:), pointer, intent(in)  :: SIvec_in
+      real(kind=RKIND), dimension(:), intent(in)  :: SIvec_in
                                         ! Input SI vector
 
-      real(kind=RKIND), dimension(:), pointer, intent(out) :: SIvec_out
+      real(kind=RKIND), dimension(:), intent(out) :: SIvec_out
                                         ! SI vector to be preconditioned
 
       ! Preconditioning --------------------------------------------!
@@ -3353,9 +3353,9 @@ module ocn_time_integration_si
       type (domain_type), intent(in) :: &
          domain  !< [inout] model state to advance forward
 
-      real(kind=RKIND), dimension(:), pointer, intent(in) :: &
+      real(kind=RKIND), dimension(:), intent(in) :: &
          SIvec_1,SIvec_2 ! SI vectors
-      real(kind=RKIND), dimension(:), pointer, intent(in), optional :: &
+      real(kind=RKIND), dimension(:), intent(in), optional :: &
          SIvec_3,SIvec_4,SIvec_5,SIvec_6,SIvec_7,SIvec_8 ! SI vectors
 
       character(*), intent(in) :: si_algorithm ! Solver algorithm

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -3219,7 +3219,7 @@ module ocn_time_integration_si
 !
 !-----------------------------------------------------------------------
 
-   subroutine si_matvec_mul(SIvec_in,SIvec_out,ssh)
+   subroutine si_matvec_mul(SIvec_in,SIvec_out,ssh) !{{{
 
       real(kind=RKIND),dimension(:),intent(in)  :: &
           SIvec_in, &! Input SI vector
@@ -3327,7 +3327,7 @@ module ocn_time_integration_si
          ! No preconditioning
          SIvec_out(1:nPrecVec) = SIvec_in(1:nPrecVec)
       end if
-   end subroutine si_precond
+   end subroutine si_precond !}}}
 
 !***********************************************************************
 !
@@ -3344,7 +3344,7 @@ module ocn_time_integration_si
 !
 !-----------------------------------------------------------------------
 
-   subroutine si_global_reduction(localProd,globalProd,       &
+   subroutine si_global_reduction(localProd,globalProd,       & !{{{
                              reprodSum1,reprodSum2,           &
                              si_algorithm,nfld,domain,        &
                              SIvec_1,SIvec_2,SIvec_3,SIvec_4, &
@@ -3379,6 +3379,8 @@ module ocn_time_integration_si
    
          if ( config_btr_si_partition_match_mode ) then
     
+            !$omp parallel
+            !$omp do schedule(runtime)
             ! Reproducible sum of multiple fields over products
             do iCell = 1,nCellsOwned
                reprodSum1(iCell,1) = SIvec_1(iCell) !r0
@@ -3387,6 +3389,8 @@ module ocn_time_integration_si
                reprodSum2(iCell,1) = SIvec_3(iCell) !rh0
                reprodSum2(iCell,2) = SIvec_3(iCell) !rh0
             end do
+            !$omp end do
+            !$omp end parallel
         
             globalProd(:) = 0.0_RKIND
             globalProd(:) =                   &
@@ -3419,6 +3423,8 @@ module ocn_time_integration_si
          if ( config_btr_si_partition_match_mode ) then
    
             ! Reproducible sum of multiple fields over products
+            !$omp parallel
+            !$omp do schedule(runtime)
             do iCell = 1,nCellsOwned
                reprodSum1(iCell,1) = SIvec_1(iCell) !r1
                reprodSum1(iCell,2) = SIvec_2(iCell) !w1
@@ -3428,6 +3434,8 @@ module ocn_time_integration_si
                reprodSum2(iCell,2) = SIvec_3(iCell) !rh1
                reprodSum2(iCell,3) = SIvec_1(iCell)  !r1
             end do
+            !$omp end do
+            !$omp end parallel
       
             globalProd(:) = 0.0_RKIND
             globalProd(:) =                   &
@@ -3468,6 +3476,8 @@ module ocn_time_integration_si
 
             ! Reproducible sum of multiple fields over products
  
+            !$omp parallel
+            !$omp do schedule(runtime)
             do iCell = 1,nCellsOwned
                globalReprodSum2fld1(iCell,1) = SIvec_1(iCell) !r00
                globalReprodSum2fld1(iCell,2) = SIvec_1(iCell) !r00
@@ -3475,6 +3485,8 @@ module ocn_time_integration_si
                globalReprodSum2fld2(iCell,1) = SIvec_2(iCell) !r0
                globalReprodSum2fld2(iCell,2) = SIvec_3(iCell) !w0
             end do
+            !$omp end do
+            !$omp end parallel
 
             SIcst_allreduce_global2(:) =                   &
                mpas_global_sum_nfld(globalReprodSum2fld1, &
@@ -3509,6 +3521,8 @@ module ocn_time_integration_si
  
             ! Reproducible sum of multiple fields over products
              
+            !$omp parallel
+            !$omp do schedule(runtime)
             do iCell = 1,nCellsOwned
                globalReprodSum9fld1(iCell,1) = SIvec_1(iCell) !r00
                globalReprodSum9fld1(iCell,2) = SIvec_1(iCell) !r00
@@ -3530,6 +3544,8 @@ module ocn_time_integration_si
                globalReprodSum9fld2(iCell,8) = SIvec_7(iCell) !v0
                globalReprodSum9fld2(iCell,9) = SIvec_2(iCell) !q0
             end do
+            !$omp end do
+            !$omp end parallel
     
             SIcst_allreduce_global9(:) =                   &
                mpas_global_sum_nfld(globalReprodSum9fld1, &
@@ -3598,7 +3614,7 @@ module ocn_time_integration_si
 
       endif !!!
    
-   end subroutine si_global_reduction
+   end subroutine si_global_reduction !}}}
 
 !***********************************************************************
 !
@@ -3615,7 +3631,7 @@ module ocn_time_integration_si
 !
 !-----------------------------------------------------------------------
 
-   subroutine si_solver_scg(domain,sshSolved,ssh,tolerance,       &
+   subroutine si_solver_scg(domain,sshSolved,ssh,tolerance,       & !{{{
                             SIcst_alpha0,SIcst_beta0,SIcst_gamma0)
 
       type (domain_type), intent(inout) :: &
@@ -3734,7 +3750,7 @@ module ocn_time_integration_si
       end do ! do iter
       !-------------------------------------------------------------!
      
-   end subroutine si_solver_scg
+   end subroutine si_solver_scg !}}}
 
 !***********************************************************************
 !
@@ -3752,7 +3768,7 @@ module ocn_time_integration_si
 !
 !-----------------------------------------------------------------------
 
-   subroutine si_solver_sbicg(domain,sshSolved,ssh,tolerance,       &
+   subroutine si_solver_sbicg(domain,sshSolved,ssh,tolerance,       & !{{{
                  SIcst_alpha0,SIcst_beta0,SIcst_gamma0,SIcst_rho0)
 
       type (domain_type), intent(inout) :: &
@@ -3947,7 +3963,7 @@ module ocn_time_integration_si
      end do ! do iter
      !-------------------------------------------------------------!
 
-   end subroutine si_solver_sbicg
+   end subroutine si_solver_sbicg !}}}
 
 !***********************************************************************
 


### PR DESCRIPTION
This PR updates the semi-implicit barotropic mode solver :
  - Restructure and make codes simpler in the main time-stepping code
  - Make subroutines for the semi-implicit solver (preconditioining, matrix-vector multiplications, global reductions)
  - Provide the s-step conjugate gradient method when `config_btr_si_partition_match_mode` is turned on to provide  a faster symmetric iterative solver
  - Small changes in stage 1 and 3 to match the split-explicit code

Below is PASS/FAIL test results:
- With default options
FAIL PEM_Ln9_D.T62_oQU240.GMPAS-IAF.cori-knl_intel (FAIL is expected for PEM tests.)
PASS PET_Ln9.T62_oQU240.GMPAS-IAF.cori-knl_intel
PASS SMS.T62_oEC60to30v3wLI.GMPAS-DIB-IAF-ISMF.cori-knl_intel
PASS SMS.T62_oQU120_ais20.MPAS_LISIO_TEST.cori-knl_intel

- With `config_btr_si_partition_match_mode=.true.`
PASS PEM_Ln9_D.T62_oQU240.GMPAS-IAF.cori-knl_intel
PASS PET_Ln9.T62_oQU240.GMPAS-IAF.cori-knl_intel
PASS SMS.T62_oEC60to30v3wLI.GMPAS-DIB-IAF-ISMF.cori-knl_intel
PASS SMS.T62_oQU120_ais20.MPAS_LISIO_TEST.cori-knl_intel
