### PR TITLE
Two small changes to Hommexx for SCREAM

### DIFF
--- a/components/homme/src/share/cxx/ComposeTransportImplGeneral.cpp
+++ b/components/homme/src/share/cxx/ComposeTransportImplGeneral.cpp
@@ -29,7 +29,9 @@ ComposeTransportImpl::ComposeTransportImpl ()
 ComposeTransportImpl::ComposeTransportImpl (const int num_elems)
   : m_tp_ne(1,1,1), m_tp_ne_qsize(1,1,1), m_tp_ne_hv_q(1,1,1), // throwaway settings
     m_tu_ne(m_tp_ne), m_tu_ne_qsize(m_tp_ne_qsize), m_tu_ne_hv_q(m_tp_ne_hv_q)
-{}
+{
+  nslot = calc_nslot(m_geometry.num_elems());
+}
 
 void ComposeTransportImpl::setup () {
   m_hvcoord = Context::singleton().get<HybridVCoord>();

--- a/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
+++ b/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
@@ -530,8 +530,9 @@ contains
     push_to_f = .false.
 
 #elif defined(SCREAM)
-!SCREAM run, do nothing
-
+!SCREAM run, only compute_diagnostics
+    push_to_f = compute_diagnostics
+    
 #elif defined(CAM)
 !CAM run, push at the end of nsplit loop
     if (nsplit_iter == nsplit) then


### PR DESCRIPTION
* Fix ComposeTransport num_elems constructor. Not needed right now, but follow the intent of that constructor.
* Fix transferring data from C++ to F90 data structures for Homme diagnostics.

Fixes SCREAM issue 1749 (https://github.com/E3SM-Project/scream/issues/1749).

[BFB]