### PR TITLE
Fix error in mpassi when config_conservation_check is set to true

### DIFF
--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -481,6 +481,7 @@ add_default($nl, 'config_pio_stride');
 add_default($nl, 'config_write_output_on_startup');
 add_default($nl, 'config_test_case_diag');
 add_default($nl, 'config_test_case_diag_type');
+add_default($nl, 'config_full_abort_write');
 
 #################################
 # Namelist group: decomposition #

--- a/components/mpas-seaice/src/shared/mpas_seaice_advection_incremental_remap.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_advection_incremental_remap.F
@@ -2394,7 +2394,7 @@ contains
     real(kind=RKIND), pointer :: &
          dynamicsTimeStep
 
-    logical, pointer :: &
+    logical :: &
          abortFlag ! abort flag
 
     ! assign pointers


### PR DESCRIPTION
Contains two small bug fixes that showed up when config_conservation_check was set to true in a fully-coupled BGC configuration.

Fixes #5049 

[NML]
[BFB]