### PR TITLE
Added field to sea ice carbon conservation

### DIFF
--- a/components/mpas-seaice/src/analysis_members/Registry_seaice_conservation_check.xml
+++ b/components/mpas-seaice/src/analysis_members/Registry_seaice_conservation_check.xml
@@ -178,69 +178,131 @@
 		/>
 	</var_struct>
 	<var_struct name="conservationCheckCarbonAM" time_levs="1" packages="conservationCheckAMPKG">
-		<var name="relativeErrorBounds" type="real" dimensions="Time" units=""
-			description="accumulated relative error bounds"
+		<var name="relativeErrorBounds"
+		     type="real"
+		     dimensions="Time"
+		     units=""
+		     description="accumulated relative error bounds"
 		/>
-		<var name="initialCarbon" type="real" dimensions="nHemispheres Time" units="kg"
-			description="Total initial carbon of ice and snow"
+		<var name="initialCarbon"
+		     type="real"
+		     dimensions="nHemispheres Time"
+		     units="kg"
+		     description="Total initial carbon of ice and snow"
 		/>
-		<var name="finalCarbon" type="real" dimensions="nHemispheres Time" units="kg"
-			description="Total final carbon of ice and snow"
+		<var name="finalCarbon"
+		     type="real"
+		     dimensions="nHemispheres Time"
+		     units="kg"
+		     description="Total final carbon of ice and snow"
 		/>
-		<var name="carbonChange" type="real" dimensions="nHemispheres Time" units="kg"
-			description="Total carbon change of ice and snow during time step"
+		<var name="carbonChange"
+		     type="real"
+		     dimensions="nHemispheres Time"
+		     units="kg"
+		     description="Total carbon change of ice and snow during time step"
 		/>
-		<var name="carbonChangeFlux" type="real" dimensions="nHemispheres Time" units="kg/m2s"
-			description="Total carbon change flux of ice and snow during time step"
+		<var name="carbonChangeFlux"
+		     type="real"
+		     dimensions="nHemispheres Time"
+		     units="kg m-2 s-1"
+		     description="Total carbon change flux of ice and snow during time step"
 		/>
-		<var name="netCarbonFlux" type="real" dimensions="nHemispheres Time" units="kg/s"
-			description="Net carbon flux to sea ice"
+		<var name="netCarbonFlux"
+		     type="real"
+		     dimensions="nHemispheres Time"
+		     units="kg s-1"
+		     description="Net carbon flux to sea ice"
 		/>
-		<var name="absoluteCarbonError" type="real" dimensions="nHemispheres Time" units="kg"
-			description="Absolute carbon conservation error"
+		<var name="absoluteCarbonError"
+		     type="real"
+		     dimensions="nHemispheres Time"
+		     units="kg"
+		     description="Absolute carbon conservation error"
 		/>
-		<var name="relativeCarbonError" type="real" dimensions="nHemispheres Time" units="None"
-			description="Relative carbon conservation error"
+		<var name="relativeCarbonError"
+		     type="real"
+		     dimensions="nHemispheres Time"
+		     units="None"
+		     description="Relative carbon conservation error"
 		/>
-		<var name="accumAbsoluteCarbonError" type="real" dimensions="nHemispheres Time" units="kg"
-			description="Accumulated since start absolute carbon conservation error"
+		<var name="accumAbsoluteCarbonError"
+		     type="real"
+		     dimensions="nHemispheres Time"
+		     units="kg"
+		     description="Accumulated since start absolute carbon conservation error"
 		/>
-		<var name="accumRelativeCarbonError" type="real" dimensions="nHemispheres Time" units="None"
-			description="Accumulated since start relative carbon conservation error"
+		<var name="accumRelativeCarbonError"
+		     type="real"
+		     dimensions="nHemispheres Time"
+		     units="None"
+		     description="Accumulated since start relative carbon conservation error"
 		/>
-		<var name="carbonConsOceanCarbonFlux" type="real" dimensions="nHemispheres Time" units="kg/s"
-			description="Total ocean carbon flux, positive into the ocean"
+		<var name="carbonConsOceanCarbonFlux"
+		     type="real"
+		     dimensions="nHemispheres Time"
+		     units="kg s-1"
+		     description="Total ocean carbon flux, positive into the ocean"
 		/>
-		<var name="carbonConsOceanCarbonFluxCheck" type="real" dimensions="nHemispheres Time" units="kg/s"
-			description="Total ocean carbon flux computed
-				     from individual passed fluxes, positive into the ocean"
+		<var name="carbonConsOceanCarbonFluxCheck"
+		     type="real"
+		     dimensions="nHemispheres Time"
+		     units="kg s-1"
+		     description="Total ocean carbon flux computed from individual passed fluxes, positive into the ocean"
 		/>
-		<var name="carbonConsDiatomFlux" type="real" dimensions="nHemispheres Time" units="kg/s"
-			description="Total algal diatom carbon flux, positive into the ocean"
+		<var name="carbonConsDiatomFlux"
+		     type="real"
+		     dimensions="nHemispheres Time"
+		     units="kg s-1"
+		     description="Total algal diatom carbon flux, positive into the ocean"
 		/>
-		<var name="carbonConsSmallAlgaeFlux" type="real" dimensions="nHemispheres Time" units="kg/s"
-			description="Total small algae carbon flux, positive into the ocean"
+		<var name="carbonConsSmallAlgaeFlux"
+		     type="real"
+		     dimensions="nHemispheres Time"
+		     units="kg s-1"
+		     description="Total small algae carbon flux, positive into the ocean"
 		/>
-		<var name="carbonConsDOC1Flux" type="real" dimensions="nHemispheres Time" units="kg/s"
-			description="Total dissolved organic carbon
-				     (polysaccharids) carbon flux, positive into the ocean"
+		<var name="carbonConsDOC1Flux"
+		     type="real"
+		     dimensions="nHemispheres Time"
+		     units="kg s-1"
+		     description="Total dissolved organic carbon (polysaccharids) carbon flux, positive into the ocean"
 		/>
-		<var name="carbonConsDOC2Flux" type="real" dimensions="nHemispheres Time" units="kg/s"
-			description="Total dissolved organic carbon
-				     (lipids) carbon flux, positive into the ocean"
+		<var name="carbonConsDOC2Flux"
+		     type="real"
+		     dimensions="nHemispheres Time"
+		     units="kg s-1"
+		     description="Total dissolved organic carbon (lipids) carbon flux, positive into the ocean"
 		/>
-		<var name="carbonConsDONCarbonFlux" type="real" dimensions="nHemispheres Time" units="kg/s"
-			description="Total dissolved organic carbon
-				     (proteins) flux, positive into the ocean"
+		<var name="carbonConsDONCarbonFlux"
+		     type="real"
+		     dimensions="nHemispheres Time"
+		     units="kg s-1"
+		     description="Total dissolved organic carbon (proteins) flux, positive into the ocean"
 		/>
-		<var name="carbonConsDICFlux" type="real" dimensions="nHemispheres Time" units="kg/s"
-			description="Total dissolved inorganic carbon flux, positive into the ocean"
+		<var name="carbonConsDICFlux"
+		     type="real"
+		     dimensions="nHemispheres Time"
+		     units="kg s-1"
+		     description="Total dissolved inorganic carbon flux, positive into the ocean"
 		/>
-		<var name="carbonConsHumicsFlux" type="real" dimensions="nHemispheres Time" units="kg/s"
-			description="Total dissolved humics carbon flux, positive into the ocean"
+		<var name="carbonConsHumicsFlux"
+		     type="real"
+		     dimensions="nHemispheres Time"
+		     units="kg s-1"
+		     description="Total dissolved humics carbon flux, positive into the ocean"
 		/>
-		<var name="carbonConsSemiLabileDOCFlux" type="real" dimensions="nHemispheres Time" units="kg/s"
-			description="Total semi-labile DOC flux, positive into the ocean"
+		<var name="carbonConsSemiLabileDOCFlux"
+		     type="real"
+		     dimensions="nHemispheres Time"
+		     units="kg s-1"
+		     description="Total semi-labile DOC flux, positive into the ocean"
+		/>
+		<var name="carbonConsTOCFlux"
+		     type="real"
+		     dimensions="nHemispheres Time"
+		     units="kg s-1"
+		     description="Total organic carbon flux, positive into the ocean"
 		/>
 	</var_struct>
 	<streams>
@@ -307,9 +369,10 @@
 			<var name="carbonConsDOC1Flux"/>
 			<var name="carbonConsDOC2Flux"/>
 			<var name="carbonConsDONCarbonFlux"/>
-			<var name="carbonConsDICFlux"/>
 			<var name="carbonConsHumicsFlux"/>
 			<var name="carbonConsSemiLabileDOCFlux"/>
+			<var name="carbonConsDICFlux"/>
+			<var name="carbonConsTOCFlux"/>
 			<var name="relativeErrorBounds"/>
 		</stream>
 

--- a/components/mpas-seaice/src/analysis_members/mpas_seaice_conservation_check.F
+++ b/components/mpas-seaice/src/analysis_members/mpas_seaice_conservation_check.F
@@ -1732,6 +1732,7 @@ contains
            carbonConsDOC1Flux, &
            carbonConsDOC2Flux, &
            carbonConsDICFlux, &
+           carbonConsTOCFlux, &
            carbonConsDONCarbonFlux, &
            carbonConsHumicsFlux, &
            carbonConsSemiLabileDOCFlux
@@ -1954,6 +1955,7 @@ contains
       call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsDOC2Flux", carbonConsDOC2Flux)
       call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsDONCarbonFlux", carbonConsDONCarbonFlux)
       call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsDICFlux", carbonConsDICFlux)
+      call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsTOCFlux", carbonConsTOCFlux)
       call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsHumicsFlux", carbonConsHumicsFlux)
       call MPAS_pool_get_array(conservationCheckCarbonAMPool, "carbonConsSemiLabileDOCFlux", carbonConsSemiLabileDOCFlux)
 
@@ -2023,6 +2025,9 @@ contains
          carbonConsSemiLabileDOCFlux(:) = carbonConsSemiLabileDOCFlux(:) * fluxScale
          carbonConsOceanCarbonFluxCheck(:) = carbonConsOceanCarbonFluxCheck(:) * fluxScale
          netCarbonFlux(:)             = netCarbonFlux(:)             * fluxScale
+         carbonConsTOCFlux(:) = carbonConsDiatomFlux(:) + carbonConsSmallAlgaeFlux(:) + &
+            carbonConsDOC1Flux(:) + carbonConsDOC2Flux(:) + carbonConsDONCarbonFlux(:) + &
+            carbonConsHumicsFlux(:)
 
          ! compute the final carbon error
          call MPAS_pool_get_array(conservationCheckCarbonAMPool, "relativeCarbonError", relativeCarbonError)
@@ -2075,6 +2080,8 @@ contains
                call mpas_log_write(' ')
 
                call mpas_log_write(' Total semilabile DOCflux(kg/m2s) = '//trim(hemisphere_format(carbonConsSemiLabileDOCFlux)))
+               call mpas_log_write(' Total inorganic C flux  (kg/m2s) = '//trim(hemisphere_format(carbonConsDICFlux)))
+               call mpas_log_write(' Total organic C flux    (kg/m2s) = '//trim(hemisphere_format(carbonConsTOCFlux)))
                call mpas_log_write(' ')
                call mpas_log_write(' Net carbon change           (kg) = '//trim(hemisphere_format((netCarbonFlux * dt) / fluxScale)))
                call mpas_log_write(' Net carbon flux         (kg/m2s) = '//trim(hemisphere_format(netCarbonFlux)))

--- a/components/mpas-seaice/src/column/constants/cesm/ice_constants_colpkg.F90
+++ b/components/mpas-seaice/src/column/constants/cesm/ice_constants_colpkg.F90
@@ -90,14 +90,14 @@
 !tcx note cice snowpatch = 0.02
 
          ! biogeochemistry
-         R_gC2molC = SHR_CONST_MOL_MASS_C, & ! molar mass of carbon
-         sk_l = 0.03_dbl_kind                ! (m) skeletal layer thickness
+         R_gC2molC = SHR_CONST_MWC, & ! molar mass of carbon
+         sk_l = 0.03_dbl_kind         ! (m) skeletal layer thickness
 
       integer (kind=int_kind), parameter, public :: &
          nspint = 3             ,& ! number of solar spectral intervals
          nspint_5bd = 5            ! number of solar spectral intervals with config_use_snicar_ad
 
-      ! weights for albedos 
+      ! weights for albedos
       ! 4 Jan 2007 BPB  Following are appropriate for complete cloud
       ! in a summer polar atmosphere with 1.5m bare sea ice surface:
       ! .636/.364 vis/nir with only 0.5% direct for each band.
@@ -126,7 +126,7 @@
       real(kind=dbl_kind),public :: decln  ! solar declination angle in radians
       real(kind=dbl_kind),public :: eccf   ! earth orbit eccentricity factor
       logical(kind=log_kind),public :: log_print ! Flags print of status/error
-    
+
       ! snow parameters
       real (kind=dbl_kind), parameter, public :: &
          snwlvlfac =   0.3_dbl_kind, & ! 30% rule: fractional increase in snow depth

--- a/share/util/shr_const_mod.F90
+++ b/share/util/shr_const_mod.F90
@@ -24,7 +24,6 @@ MODULE shr_const_mod
    real(R8),parameter :: SHR_CONST_BOLTZ   = 1.38065e-23_R8  ! Boltzmann's constant ~ J/K/molecule
    real(R8),parameter :: SHR_CONST_AVOGAD  = 6.02214e26_R8   ! Avogadro's number ~ molecules/kmole
    real(R8),parameter :: SHR_CONST_RGAS    = SHR_CONST_AVOGAD*SHR_CONST_BOLTZ       ! Universal gas constant ~ J/K/kmole
-   real(R8),parameter :: SHR_CONST_MOL_MASS_C = 12.0107_R8   ! carbon molar mass
    real(R8),parameter :: SHR_CONST_MWDAIR  = 28.966_R8       ! molecular weight dry air ~ kg/kmole
    real(R8),parameter :: SHR_CONST_MWWV    = 18.016_R8       ! molecular weight water vapor
    real(R8),parameter :: SHR_CONST_MWC     = 12.0107_R8      ! molecular weight carbon


### PR DESCRIPTION
-Computes and outputs total organic carbon to be consistent with coupler output.
-Updates registry format of carbon conservation to new standard.
-Removes redundant SHR_CONST_MOL_MASS_C in favor of SHR_CONST_MWC to be consistent with other components

BFB