### PR TITLE
Add grid support for the ne30pg2_oRRS30to10v3 resolution

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -4411,8 +4411,8 @@
     </gridmap>
 
     <gridmap ocn_grid="oRRS30to10v3" rof_grid="r05">
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oRRS30to10v3_smoothed.r150e300.171109.nc</map>
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_oRRS30to10v3_smoothed.r150e300.171109.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oRRS30to10v3_smoothed.r150e300.210317.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_oRRS30to10v3_smoothed.r150e300.210317.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="oRRS30to10v3wLI" rof_grid="r05">

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -1853,6 +1853,16 @@
       <mask>EC30to60E2r2</mask>
     </model_grid>
 
+    <model_grid alias="ne30pg2_oRRS30to10v3">
+      <grid name="atm">ne30np4.pg2</grid>
+      <grid name="lnd">ne30np4.pg2</grid>
+      <grid name="ocnice">oRRS30to10v3</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS30to10v3</mask>
+    </model_grid>
+
     <model_grid alias="ne30pg2_WC14to60E2r3">
       <grid name="atm">ne30np4.pg2</grid>
       <grid name="lnd">ne30np4.pg2</grid>
@@ -2361,6 +2371,8 @@
       <file grid="ice|ocn" mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_ARRM60to10.200527.nc</file>
       <file grid="atm|lnd" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_EC30to60E2r2.201005.nc</file>
       <file grid="ice|ocn" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_EC30to60E2r2.201005.nc</file>
+      <file grid="atm|lnd" mask="oRRS30to10v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_oRRS30to10v3.210316.nc</file>
+      <file grid="ice|ocn" mask="oRRS30to10v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_oRRS30to10v3.210316.nc</file>
       <file grid="atm|lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_WC14to60E2r3.200929.nc</file>
       <file grid="ice|ocn" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_WC14to60E2r3.200929.nc</file>
       <file grid="atm|lnd" mask="WCAtl12to45E2r4">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_WCAtl12to45E2r4.210318.nc</file>
@@ -3038,6 +3050,14 @@
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_EC30to60E2r2_bilin.201005.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/EC30to60E2r2/map_EC30to60E2r2_to_ne30pg2_mono.201005.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/EC30to60E2r2/map_EC30to60E2r2_to_ne30pg2_mono.201005.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne30np4.pg2" ocn_grid="oRRS30to10v3">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_oRRS30to10v3_mono.210316.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_oRRS30to10v3_bilin.210316.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_oRRS30to10v3_bilin.210316.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS30to10v3/map_oRRS30to10v3_to_ne30pg2_mono.210316.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS30to10v3/map_oRRS30to10v3_to_ne30pg2_mono.210316.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4.pg2" ocn_grid="WC14to60E2r3">

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -151,8 +151,8 @@ def buildnml(case, caseroot, compname):
         ic_date = '171128'
         ic_prefix = 'oRRS30to10v3'
         if ocn_ic_mode == 'spunup':
-            logger.warning("WARNING: The specified compset is requesting ocean ICs spunup from a G-case")
-            logger.warning("         But no file available for this grid.")
+            ic_date = '220517'
+            ic_prefix = 'mpaso.oRRS30to10v3.rstFromG-anvil'
 
     elif ocn_grid == 'oRRS30to10v3wLI':
         decomp_date = '171109'

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -149,8 +149,8 @@ def buildnml(case, caseroot, compname):
         grid_date = '171128'
         grid_prefix = 'seaice.RRS30to10v3'
         if ice_ic_mode == 'spunup':
-            logger.warning("WARNING: The specified compset is requesting seaice ICs spunup from a G-case")
-            logger.warning("         But no file available for this grid.")
+            grid_date = '220517'
+            grid_prefix = 'mpassi.oRRS30to10v3.rstFromG-anvil'
 
     elif ice_grid == 'oRRS30to10v3wLI':
         decomp_date = '171109'


### PR DESCRIPTION
Brings in all necessary changes to run the ne30pg2_oRRS30to10v3 resolution in a fully-coupled configuration, including new spunup one/ice initial conditions. All new files are staged on the inputdata repo.

[BFB] for all currently tested configurations