### PR TITLE
For pm-cpu, add env variable to change how libfabric handles MPI buffers as work-around

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -262,6 +262,7 @@
       <env name="OMP_PLACES">threads</env>
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
       <env name="PERL5LIB">/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch</env>
+      <env name="FI_CXI_RX_MATCH_MODE">software</env>
     </environment_variables>
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>


### PR DESCRIPTION
For pm-cpu, add env variable to change how libfabric handles MPI buffers. 
temporarily use software instead of hardware as a work-around until HPE network
engineers have a fix. Adding this variable allow several tests to work that were
otherwise failing with runtime error.

Fixes https://github.com/E3SM-Project/E3SM/issues/5057

[bfb]