### PR TITLE
Adds omp critical directives for ice warnings (for maint2.0)

### DIFF
--- a/components/mpas-seaice/src/column/ice_warnings.F90
+++ b/components/mpas-seaice/src/column/ice_warnings.F90
@@ -42,7 +42,7 @@ contains
     integer :: &
          nWarningsArray, & ! size of warnings array at start
          iWarning ! warning index
-    !$omp critical ice_warnings_add_warning
+    !$omp critical (ice_warnings_add_warning_critical)
     ! check if warnings array is not allocated
     if (.not. allocated(warnings)) then
 
@@ -90,7 +90,7 @@ contains
 
     ! add the new warning
     warnings(nWarnings) = trim(warning)
-    !$omp end critical ice_warnings_add_warning
+    !$omp end critical (ice_warnings_add_warning_critical)
   end subroutine add_warning
 
 !=======================================================================

--- a/components/mpas-seaice/src/column/ice_warnings.F90
+++ b/components/mpas-seaice/src/column/ice_warnings.F90
@@ -42,7 +42,7 @@ contains
     integer :: &
          nWarningsArray, & ! size of warnings array at start
          iWarning ! warning index
-    !$omp critical
+    !$omp critical ice_warnings_add_warning
     ! check if warnings array is not allocated
     if (.not. allocated(warnings)) then
 
@@ -90,7 +90,7 @@ contains
 
     ! add the new warning
     warnings(nWarnings) = trim(warning)
-    !$omp end critical
+    !$omp end critical ice_warnings_add_warning
   end subroutine add_warning
 
 !=======================================================================

--- a/components/mpas-seaice/src/column/ice_warnings.F90
+++ b/components/mpas-seaice/src/column/ice_warnings.F90
@@ -42,7 +42,7 @@ contains
     integer :: &
          nWarningsArray, & ! size of warnings array at start
          iWarning ! warning index
-
+    !$omp critical
     ! check if warnings array is not allocated
     if (.not. allocated(warnings)) then
 
@@ -90,7 +90,7 @@ contains
 
     ! add the new warning
     warnings(nWarnings) = trim(warning)
-
+    !$omp end critical
   end subroutine add_warning
 
 !=======================================================================


### PR DESCRIPTION
While running some ensemble members for v2 on Cori-KNL, we occasional hit errors like
"forrtl: severe (151): allocatable array is already allocated" pointing to ice_warnings.f90
file. Adding an "omp critical" section in this file fixes these errors.

[BFB]