### PR TITLE
Hommexx: Expand GllFvRemap API to support additional EAMxx use cases.

### DIFF
--- a/components/homme/src/share/cxx/GllFvRemap.cpp
+++ b/components/homme/src/share/cxx/GllFvRemap.cpp
@@ -20,7 +20,6 @@ void init_gllfvremap_c (int nelemd, int np, int nf, int nf_max,
                         CF90Ptr fv_metdet, CF90Ptr g2f_remapd,
                         CF90Ptr f2g_remapd, CF90Ptr D_f, CF90Ptr Dinv_f) {
   auto& c = Context::singleton();
-  auto& s = c.get<SimulationParams>();
   auto& g = c.get<GllFvRemap>();
   g.init_data(nf, nf_max, theta_hydrostatic_mode, fv_metdet, g2f_remapd,
               f2g_remapd, D_f, Dinv_f);
@@ -28,6 +27,10 @@ void init_gllfvremap_c (int nelemd, int np, int nf, int nf_max,
 
 GllFvRemap::GllFvRemap () {
   m_impl.reset(new GllFvRemapImpl());
+}
+
+void GllFvRemap::setup () {
+  m_impl->setup();
 }
 
 void GllFvRemap::reset (const SimulationParams& params) {
@@ -59,8 +62,8 @@ void GllFvRemap
 void GllFvRemap
 ::run_dyn_to_fv_phys (const int time_idx, const Phys1T& ps, const Phys1T& phis,
                       const Phys2T& T, const Phys2T& omega, const Phys3T& uv,
-                      const Phys3T& q) {
-  m_impl->run_dyn_to_fv_phys(time_idx, ps, phis, T, omega, uv, q);
+                      const Phys3T& q, const Phys2T* dp) {
+  m_impl->run_dyn_to_fv_phys(time_idx, ps, phis, T, omega, uv, q, dp);
 }
 
 void GllFvRemap
@@ -70,6 +73,12 @@ void GllFvRemap
 }
 
 void GllFvRemap::run_fv_phys_to_dyn_dss () { m_impl->run_fv_phys_to_dyn_dss(); }
+
+void GllFvRemap
+::remap_tracer_dyn_to_fv_phys (const int time_idx, const int nq,
+                               const CPhys3T& q_dyn, const Phys3T& q_fv) {
+  m_impl->remap_tracer_dyn_to_fv_phys(time_idx, nq, q_dyn, q_fv);
+}
 
 } // Namespace Homme
 

--- a/components/homme/src/share/cxx/GllFvRemapImpl.cpp
+++ b/components/homme/src/share/cxx/GllFvRemapImpl.cpp
@@ -37,20 +37,28 @@ static int calc_nslot (const int nelemd, const int nq) {
 }
 
 GllFvRemapImpl::GllFvRemapImpl ()
-  : m_hvcoord(Context::singleton().get<HybridVCoord>()),
-    m_elements(Context::singleton().get<Elements>()),
-    m_state(m_elements.m_state),
-    m_derived(m_elements.m_derived),
-    m_forcing(Context::singleton().get<ElementsForcing>()),
-    m_geometry(Context::singleton().get<ElementsGeometry>()),
-    m_tracers(Context::singleton().get<Tracers>()),
-    // throwaway settings
+  : // throwaway settings
     m_tp_ne(1,1,1), m_tp_ne_qsize(1,1,1), m_tp_ne_dss(1,1,1),
     m_tu_ne(m_tp_ne), m_tu_ne_qsize(m_tp_ne_qsize), m_tu_ne_dss(m_tp_ne_dss)
-{}
+{
+  setup();
+}
+
+void GllFvRemapImpl::setup () {
+  const auto& c = Context::singleton();
+  m_hvcoord = c.get<HybridVCoord>();
+  m_elements = c.get<Elements>();
+  m_state = m_elements.m_state;
+  m_derived = m_elements.m_derived;
+  m_forcing = c.get<ElementsForcing>();
+  m_geometry = c.get<ElementsGeometry>();
+  m_tracers = c.get<Tracers>();
+}
 
 void GllFvRemapImpl::reset (const SimulationParams& params) {
   const auto num_elems = Context::singleton().get<Connectivity>().get_num_local_elements();
+
+  if (m_data.nelemd == num_elems and m_data.qsize == params.qsize) return;
 
   m_data.qsize = params.qsize;
   Errors::runtime_check(m_data.qsize > 0, "GllFvRemapImpl requires qsize > 0");
@@ -65,8 +73,7 @@ void GllFvRemapImpl::reset (const SimulationParams& params) {
   m_tu_ne_dss = TeamUtils<ExecSpace>(m_tp_ne_dss);
 
   if (Context::singleton().get<Connectivity>().get_comm().root())
-    printf("gfr> nelemd %d qsize %d\n",
-           m_data.nelemd, m_data.qsize);
+    printf("gfr> nelemd %d qsize %d\n", m_data.nelemd, m_data.qsize);
 }
 
 int GllFvRemapImpl::requested_buffer_size () const {
@@ -126,7 +133,7 @@ void GllFvRemapImpl
   using Kokkos::deep_copy;
 
   if (nf <= 1)
-    Errors::runtime_abort("GllFvRemap: In physics grid configuratoin nf x nf,"
+    Errors::runtime_abort("GllFvRemap: In physics grid configuration nf x nf,"
                           " nf must be > 1.", Errors::err_not_implemented);
 
   auto& sp = Context::singleton().get<SimulationParams>();
@@ -326,7 +333,8 @@ f2g_scalar_dp (const KernelVariables& kv, const int nf2, const int np2, const in
 
 void GllFvRemapImpl
 ::run_dyn_to_fv_phys (const int timeidx, const Phys1T& ps, const Phys1T& phis, const Phys2T& Ts,
-                      const Phys2T& omegas, const Phys3T& uvs, const Phys3T& qs) {
+                      const Phys2T& omegas, const Phys3T& uvs, const Phys3T& qs,
+                      const Phys2T* dp_fv_out_ptr) {
   // Impl only for theta-l until ElementOps is provided in preqx_kokkos.
 #ifdef MODEL_THETA_L
   using Kokkos::parallel_for;
@@ -380,10 +388,21 @@ void GllFvRemapImpl
   const auto D_f = m_data.D_f;
   const auto dp_fv = m_derived.m_divdp_proj; // store dp_fv between kernels
   const auto hvcoord = m_hvcoord;
+  
   const bool use_moisture = m_data.use_moisture;
   const bool theta_hydrostatic_mode = m_data.theta_hydrostatic_mode;
+
+  const bool want_dp_fv_out = dp_fv_out_ptr != nullptr;
+  VPhys2T dp_fv_out;
+  if (want_dp_fv_out) {
+    const auto& dp = *dp_fv_out_ptr;
+    dp_fv_out = VPhys2T(real2pack(dp), dp.extent_int(0), dp.extent_int(1),
+                        dp.extent_int(2)/packn);
+  }
+  
   EquationOfState eos; eos.init(theta_hydrostatic_mode, hvcoord);
   ElementOps ops; ops.init(hvcoord);
+
   const auto tu_ne = m_tu_ne;
 
   const auto fe = KOKKOS_LAMBDA (const MT& team) {
@@ -395,6 +414,9 @@ void GllFvRemapImpl
     const auto rw2 = Kokkos::subview(buf11, kv.team_idx, all, all, all);
     const auto r2w = Kokkos::subview(buf20, kv.team_idx, all, all, all, all);
     const EVU<Real*> rw1s(pack2real(rw1), nreal_per_slot1);
+
+    const auto ttrf = Kokkos::TeamThreadRange(kv.team, nf2);
+    const auto tvr = Kokkos::ThreadVectorRange(kv.team, nlevpk);
     
     const evucr1 fv_metdet_ie(&fv_metdet(ie,0), nf2),
       gll_metdet_ie(&gll_metdet(ie,0,0), np2);
@@ -406,6 +428,8 @@ void GllFvRemapImpl
              ps_v_ie, wrk, evur2(&ps(ie,0), nf2, 1));
       kv.team_barrier();
       calc_dp_fv(team, hvcoord, nf2, nlevpk, EVU<Real*>(&ps(ie,0), nf2), dp_fv_ie);
+      if (want_dp_fv_out)
+        loop_ik(ttrf, tvr, [&] (int i, int k) { dp_fv_out(ie,i,k) = dp_fv_ie(i,k); });
       kv.team_barrier();
     }
 
@@ -424,8 +448,6 @@ void GllFvRemapImpl
 
     { // T
       const auto ttrg = Kokkos::TeamThreadRange(kv.team, np2);
-      const auto ttrf = Kokkos::TeamThreadRange(kv.team, nf2);
-      const auto tvr = Kokkos::ThreadVectorRange(kv.team, nlevpk);
       
       const EVU<Scalar[NP][NP][NUM_LEV]> w1g(rw1.data()), w2g(rw2.data()), w3g(&r2w(0,0,0,0)),
         w4g(&r2w(1,0,0,0));
@@ -540,6 +562,7 @@ run_fv_phys_to_dyn (const int timeidx, const CPhys2T& Ts, const CPhys3T& uvs,
   const int nreal_per_slot1 = np2*max_num_lev_pack;
   const auto nf2 = m_data.nf2;
   const auto qsize = m_data.qsize;
+  const auto uv_ndim = uvs.extent_int(2);
 
   const auto buf10 = m_data.buf1[0];
   const auto buf11 = m_data.buf1[1];
@@ -548,8 +571,8 @@ run_fv_phys_to_dyn (const int timeidx, const CPhys2T& Ts, const CPhys3T& uvs,
 #ifndef NDEBUG
   const auto nelemd = m_data.nelemd;
   assert(Ts.extent_int(0) >= nelemd && Ts.extent_int(1) >= nf2 && Ts.extent_int(2) % packn == 0);
-  assert(uvs.extent_int(0) >= nelemd && uvs.extent_int(1) >= nf2 && uvs.extent_int(2) == 2 &&
-         uvs.extent_int(3) % packn == 0);
+  assert(uvs.extent_int(0) >= nelemd && uvs.extent_int(1) >= nf2 &&
+         (uv_ndim == 2 || uv_ndim == 3) && uvs.extent_int(3) % packn == 0);
   assert(qs.extent_int(0) >= nelemd && qs.extent_int(1) >= nf2 && qs.extent_int(2) >= qsize &&
          qs.extent_int(3) % packn == 0);
 #endif
@@ -585,6 +608,10 @@ run_fv_phys_to_dyn (const int timeidx, const CPhys2T& Ts, const CPhys3T& uvs,
     KernelVariables kv(team, tu_ne);
     const auto ie = kv.ie;
 
+    const auto ttrg = Kokkos::TeamThreadRange(kv.team, np2);
+    const auto ttrf = Kokkos::TeamThreadRange(kv.team, nf2);
+    const auto tvr = Kokkos::ThreadVectorRange(kv.team, nlevpk);
+
     const auto all = Kokkos::ALL();
     const auto rw1 = Kokkos::subview(buf10, kv.team_idx, all, all, all);
     const auto r2w = Kokkos::subview(buf20, kv.team_idx, all, all, all, all);
@@ -604,17 +631,20 @@ run_fv_phys_to_dyn (const int timeidx, const CPhys2T& Ts, const CPhys3T& uvs,
       kv.team_barrier();
     }
 
-    // (u,v)
-    remapd<true>(team, np2, nf2, nlevpk, f2g_remapd,
-                 evur3(&Dinv_f(ie,0,0,0), nf2, 2, 2), 1, evur3(&D_g(ie,0,0,0), np2, 2, 2),
-                 evucs3(&uv(ie,0,0,0), nf2, 2, nlevpk), evus3(r2w.data(), nf2, 2, nlevpk),
-                 EVU<Scalar[3][NP*NP][NUM_LEV]>(&fm(ie,0,0,0,0)));
+    { // (u,v)
+      EVU<Scalar[3][NP*NP][NUM_LEV]> fm_ie(&fm(ie,0,0,0,0));
+      remapd<true>(team, np2, nf2, nlevpk, f2g_remapd,
+                   evur3(&Dinv_f(ie,0,0,0), nf2, 2, 2), 1, evur3(&D_g(ie,0,0,0), np2, 2, 2),
+                   evucs3(&uv(ie,0,0,0), nf2, uv_ndim, nlevpk), evus3(r2w.data(), nf2, 2, nlevpk),
+                   fm_ie);
+      if (uv_ndim == 3) {
+        // FM in Homme includes a component for omega, but the physics don't
+        // modify omega. Thus, zero FM so that the third component is 0.
+        loop_ik(ttrg, tvr, [&] (int i, int k) { fm_ie(2,i,k) = 0; });
+      }
+    }
 
     { // T
-      const auto ttrg = Kokkos::TeamThreadRange(kv.team, np2);
-      const auto ttrf = Kokkos::TeamThreadRange(kv.team, nf2);
-      const auto tvr = Kokkos::ThreadVectorRange(kv.team, nlevpk);
-
       const EVU<Scalar[NP][NP][NUM_LEV]> w1g(rw1.data()), w3g(&r2w(0,0,0,0)),
         w4g(&r2w(1,0,0,0));
       const EVU<Scalar*[NUM_LEV]> w3f(&r2w(0,0,0,0), nf2);
@@ -768,6 +798,103 @@ void GllFvRemapImpl::run_fv_phys_to_dyn_dss () {
   Kokkos::fence();
   Kokkos::parallel_for(m_tp_ne_dss, f);
   m_dss_be->exchange(m_geometry.m_rspheremp);
+}
+
+void GllFvRemapImpl
+::remap_tracer_dyn_to_fv_phys (const int timeidx, const int nq,
+                               const CPhys3T& qs_dyn, const Phys3T& qs_fv) {
+#ifdef MODEL_THETA_L
+  using Kokkos::parallel_for;
+
+  const int np2 = GllFvRemapImpl::np2;
+  const int nlevpk = num_lev_pack;
+  const int nreal_per_slot1 = np2*max_num_lev_pack;
+  const auto nf2 = m_data.nf2;
+  const auto qsize = m_data.qsize;
+
+  const auto buf10 = m_data.buf1[0];
+  const auto buf11 = m_data.buf1[1];
+
+  Errors::runtime_check(nq <= qsize,
+                        "GllFvRemap::remap_tracer_dyn_to_fv_phys: nq must be <= qsize.");
+
+#ifndef NDEBUG
+  const auto nelemd = m_data.nelemd;
+  assert(qs_dyn.extent_int(0) >= nelemd && qs_dyn.extent_int(1) >= nq && qs_dyn.extent_int(2) >= np2 &&
+         qs_dyn.extent_int(3) % packn == 0);
+  assert(qs_fv.extent_int(0) >= nelemd && qs_fv.extent_int(1) >= nf2 && qs_fv.extent_int(2) >= nq &&
+         qs_fv.extent_int(3) % packn == 0);
+#endif
+
+  CVPhys3T
+    q_dyn(creal2pack(qs_dyn), qs_dyn.extent_int(0), qs_dyn.extent_int(1), qs_dyn.extent_int(2),
+          qs_dyn.extent_int(3)/packn);
+  VPhys3T
+    q_fv(real2pack(qs_fv), qs_fv.extent_int(0), qs_fv.extent_int(1), qs_fv.extent_int(2),
+          qs_fv.extent_int(3)/packn);
+
+  const auto dp3d = m_state.m_dp3d;
+  const auto ps_v = m_state.m_ps_v;
+  const auto gll_metdet = m_geometry.m_metdet;
+  const auto fv_metdet = m_data.fv_metdet;
+  const auto w_ff = m_data.w_ff;
+  const auto g2f_remapd = m_data.g2f_remapd;
+  const auto dp_fv = m_derived.m_divdp_proj; // store dp_fv between kernels
+  const auto hvcoord = m_hvcoord;
+  
+  ElementOps ops; ops.init(hvcoord);
+
+  // dp
+  const auto tu_ne = m_tu_ne;
+  const auto fe = KOKKOS_LAMBDA (const MT& team) {
+    KernelVariables kv(team, tu_ne);
+    const auto ie = kv.ie;
+
+    const auto all = Kokkos::ALL();
+    const auto rw1 = Kokkos::subview(buf10, kv.team_idx, all, all, all);
+    const EVU<Real*> rw1s(pack2real(rw1), nreal_per_slot1);
+    
+    const evucr1 fv_metdet_ie(&fv_metdet(ie,0), nf2),
+      gll_metdet_ie(&gll_metdet(ie,0,0), np2);
+
+    const evus2 dp_fv_ie(&dp_fv(ie,0,0,0), nf2, nlevpk); {
+      const evur2 ps_v_ie(&ps_v(ie,timeidx,0,0), np2, 1), wrk(rw1s.data(), np2, 1),
+        ps_v_fv_ie(rw1s.data() + np2, nf2, 1);
+      remapd(team, nf2, np2, 1, g2f_remapd, gll_metdet_ie, w_ff, fv_metdet_ie,
+             ps_v_ie, wrk, ps_v_fv_ie);
+      kv.team_barrier();
+      calc_dp_fv(team, hvcoord, nf2, nlevpk, EVU<Real*>(ps_v_fv_ie.data(), nf2),
+                 dp_fv_ie);
+    }
+  };
+  Kokkos::fence();
+  Kokkos::parallel_for(m_tp_ne, fe);
+
+  // q
+  const auto dp_g = m_state.m_dp3d;
+  const auto tp_ne_nq = Homme::get_default_team_policy<ExecSpace>(m_data.nelemd * nq);
+  const auto tu_ne_nq = TeamUtils<ExecSpace>(tp_ne_nq);
+  const auto feq = KOKKOS_LAMBDA (const MT& team) {
+    KernelVariables kv(team, nq, tu_ne_nq);
+    const auto ie = kv.ie, iq = kv.iq;
+
+    const auto all = Kokkos::ALL();
+    const auto rw1 = Kokkos::subview(buf10, kv.team_idx, all, all, all);
+    const auto rw2 = Kokkos::subview(buf11, kv.team_idx, all, all, all);
+
+    const evucr1 fv_metdet_ie(&fv_metdet(ie,0), nf2),
+      gll_metdet_ie(&gll_metdet(ie,0,0), np2);
+    const EVU<const Scalar**> dp_fv_ie(&dp_fv(ie,0,0,0), nf2, nlevpk);
+    
+    g2f_mixing_ratio(
+      kv, np2, nf2, nlevpk, g2f_remapd, gll_metdet_ie, w_ff, fv_metdet_ie,
+      evucs_np2_nlev(&dp_g(ie,timeidx,0,0,0)), dp_fv_ie, evucs_np2_nlev(&q_dyn(ie,iq,0,0)),
+      evus_np2_nlev(rw1.data()), evus_np2_nlev(rw2.data()), iq,
+      evus3(&q_fv(ie,0,0,0), q_fv.extent_int(1), q_fv.extent_int(2), q_fv.extent_int(3)));
+  };
+  Kokkos::fence();
+  Kokkos::parallel_for(tp_ne_nq, feq);
+#endif  
 }
 
 } // namespace Homme

--- a/components/homme/src/share/cxx/GllFvRemapImpl.hpp
+++ b/components/homme/src/share/cxx/GllFvRemapImpl.hpp
@@ -80,13 +80,13 @@ struct GllFvRemapImpl {
     {}
   };
 
-  const HybridVCoord m_hvcoord;
-  const Elements m_elements;
-  const ElementsState m_state;
-  const ElementsDerivedState m_derived;
-  const ElementsForcing m_forcing;
-  const ElementsGeometry m_geometry;
-  const Tracers m_tracers;
+  HybridVCoord m_hvcoord;
+  Elements m_elements;
+  ElementsState m_state;
+  ElementsDerivedState m_derived;
+  ElementsForcing m_forcing;
+  ElementsGeometry m_geometry;
+  Tracers m_tracers;
   Data m_data;
 
   TeamPolicy m_tp_ne, m_tp_ne_qsize, m_tp_ne_dss;
@@ -95,6 +95,7 @@ struct GllFvRemapImpl {
   std::shared_ptr<BoundaryExchange> m_extrema_be, m_dss_be;
 
   GllFvRemapImpl();
+  void setup();
 
   KOKKOS_INLINE_FUNCTION
   size_t shmem_size (const int team_size) const {
@@ -112,10 +113,13 @@ struct GllFvRemapImpl {
 
   void run_dyn_to_fv_phys(const int time_idx, const Phys1T& ps, const Phys1T& phis,
                           const Phys2T& T, const Phys2T& omega, const Phys3T& uv,
-                          const Phys3T& q);
+                          const Phys3T& q, const Phys2T* dp);
   void run_fv_phys_to_dyn(const int time_idx, const CPhys2T& T, const CPhys3T& uv,
                           const CPhys3T& q);
   void run_fv_phys_to_dyn_dss();
+
+  void remap_tracer_dyn_to_fv_phys(const int time_idx, const int nq,
+                                   const CPhys3T& q_dyn, const Phys3T& q_fv);
 
   /* Compute pressure level increments on the FV grid given ps on the FV grid.
      Directly projecting dp_gll to dp_fv disagrees numerically with the loop in

--- a/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
@@ -22,6 +22,7 @@
 #include "SphereOperators.hpp"
 #include "TimeLevel.hpp"
 #include "Tracers.hpp"
+#include "GllFvRemap.hpp"
 #include "VerticalRemapManager.hpp"
 #include "mpi/BoundaryExchange.hpp"
 #include "mpi/MpiBuffersManager.hpp"
@@ -417,6 +418,14 @@ void init_functors_c (const bool& allocate_buffer)
     auto& dirk = Context::singleton().get<DirkFunctor>();
     dirk.init_buffers(fbm);
   }
+  // The SCREAM-side Hommexx interface will initialize GllFvRemap if it's
+  // needed. But it expects the Homme-side Hommexx interface to init buffers, so
+  // do that here.
+  if (c.has<GllFvRemap>()) {
+    auto& gfr = c.get<GllFvRemap>();
+    gfr.setup();
+    gfr.init_buffers(fbm);
+  }
 }
 
 void init_elements_2d_c (const int& ie,
@@ -566,6 +575,12 @@ void init_boundary_exchanges_c ()
   // HyperviscosityFunctor's BE's
   auto& hvf = c.get<HyperviscosityFunctor>();
   hvf.init_boundary_exchanges();
+
+  if (c.has<GllFvRemap>()) {
+    auto& gfr = c.get<GllFvRemap>();
+    gfr.reset(params);
+    gfr.init_boundary_exchanges();
+  }
 }
 
 } // extern "C"


### PR DESCRIPTION
* Add remap_tracer_dyn_to_fv_phys to map nonstandard IC fields from dyn to phys
  grids. Ultimately this method should not be needed, but it might be used in
  some EAMxx development work.
* Add unit test for remap_tracer_dyn_to_fv_phys.
* Update cxx_f90_interface_theta.cpp to initialize the GllFvRemap object
  properly according to EAMxx procedure.

[BFB]