### PR TITLE
Double ELM-erosion nodes to avoid OOM and OOT errors

### DIFF
--- a/components/eam/cime_config/config_pes.xml
+++ b/components/eam/cime_config/config_pes.xml
@@ -1142,6 +1142,27 @@
           <nthrds_cpl>1</nthrds_cpl>
         </nthrds>
       </pes>
+      <pes compset=".*EAM.+ELM.+MPASSI.+DOCN.+SGLC_SWAV_SIAC_SESP_BGC.*" pesize="any">
+        <comment>summit|ascent pelayout for tri-grid BGC tests with EAM+DOCN </comment>
+        <MAX_MPITASKS_PER_NODE>42</MAX_MPITASKS_PER_NODE>
+        <MAX_TASKS_PER_NODE>84</MAX_TASKS_PER_NODE>
+        <ntasks>
+          <ntasks_atm>-4</ntasks_atm>
+          <ntasks_lnd>-4</ntasks_lnd>
+          <ntasks_rof>-4</ntasks_rof>
+          <ntasks_ice>-4</ntasks_ice>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_cpl>-4</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>2</nthrds_atm>
+          <nthrds_lnd>2</nthrds_lnd>
+          <nthrds_rof>2</nthrds_rof>
+          <nthrds_ice>2</nthrds_ice>
+          <nthrds_ocn>2</nthrds_ocn>
+          <nthrds_cpl>2</nthrds_cpl>
+        </nthrds>
+      </pes>
     </mach>
   </grid>
   <grid name="a%ne30np4.pg2_l%.+_oi%oEC60to30v3">

--- a/components/elm/cime_config/config_pes.xml
+++ b/components/elm/cime_config/config_pes.xml
@@ -243,23 +243,8 @@
         </ntasks>
       </pes>
     </mach>
-    <mach name="anvil">
-      <pes compset=".*ELM%CNPRDCTCBC.+" pesize="any">
-        <comment>elm: anvil PEs for grid l%1.9x2.5|l%0.9x1.25|l%360x720cru</comment>
-        <ntasks>
-          <ntasks_atm>-8</ntasks_atm>
-          <ntasks_lnd>-8</ntasks_lnd>
-          <ntasks_rof>-8</ntasks_rof>
-          <ntasks_ice>-8</ntasks_ice>
-          <ntasks_ocn>-8</ntasks_ocn>
-          <ntasks_glc>-8</ntasks_glc>
-          <ntasks_wav>-8</ntasks_wav>
-          <ntasks_cpl>-8</ntasks_cpl>
-        </ntasks>
-      </pes>
-    </mach>
     <mach name="ascent|summit">
-      <pes compset=".*ELM%CNPRDCTCBC.+" pesize="any">
+      <pes compset="any" pesize="any">
         <comment>elm: ascent|summit PEs for grid l%1.9x2.5|l%0.9x1.25|l%360x720cru</comment>
         <ntasks>
           <ntasks_atm>-2</ntasks_atm>
@@ -270,6 +255,23 @@
           <ntasks_glc>-2</ntasks_glc>
           <ntasks_wav>-2</ntasks_wav>
           <ntasks_cpl>-2</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="l%360x720cru">
+    <mach name="anvil">
+      <pes compset="any" pesize="any">
+        <comment>elm: anvil PEs for grid l%360x720cru</comment>
+        <ntasks>
+          <ntasks_atm>-8</ntasks_atm>
+          <ntasks_lnd>-8</ntasks_lnd>
+          <ntasks_rof>-8</ntasks_rof>
+          <ntasks_ice>-8</ntasks_ice>
+          <ntasks_ocn>-8</ntasks_ocn>
+          <ntasks_glc>-8</ntasks_glc>
+          <ntasks_wav>-8</ntasks_wav>
+          <ntasks_cpl>-8</ntasks_cpl>
         </ntasks>
       </pes>
     </mach>

--- a/components/elm/cime_config/config_pes.xml
+++ b/components/elm/cime_config/config_pes.xml
@@ -275,6 +275,19 @@
         </ntasks>
       </pes>
     </mach>
+    <mach name="ascent|summit">
+      <pes compset=".*ELM%CN.*" pesize="any">
+        <comment>elm: ascent|summit PEs for grid l%360x720cru</comment>
+        <ntasks>
+          <ntasks_atm>-1</ntasks_atm>
+          <ntasks_lnd>-1</ntasks_lnd>
+          <ntasks_rof>-1</ntasks_rof>
+          <ntasks_ice>-1</ntasks_ice>
+          <ntasks_ocn>-1</ntasks_ocn>
+          <ntasks_cpl>-1</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
   </grid>
   <grid name="l%0.47x0.63" >
     <mach name="any">

--- a/components/elm/cime_config/config_pes.xml
+++ b/components/elm/cime_config/config_pes.xml
@@ -243,6 +243,36 @@
         </ntasks>
       </pes>
     </mach>
+    <mach name="anvil">
+      <pes compset=".*ELM%CNPRDCTCBC.+" pesize="any">
+        <comment>elm: anvil PEs for grid l%1.9x2.5|l%0.9x1.25|l%360x720cru</comment>
+        <ntasks>
+          <ntasks_atm>-8</ntasks_atm>
+          <ntasks_lnd>-8</ntasks_lnd>
+          <ntasks_rof>-8</ntasks_rof>
+          <ntasks_ice>-8</ntasks_ice>
+          <ntasks_ocn>-8</ntasks_ocn>
+          <ntasks_glc>-8</ntasks_glc>
+          <ntasks_wav>-8</ntasks_wav>
+          <ntasks_cpl>-8</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
+    <mach name="ascent|summit">
+      <pes compset=".*ELM%CNPRDCTCBC.+" pesize="any">
+        <comment>elm: ascent|summit PEs for grid l%1.9x2.5|l%0.9x1.25|l%360x720cru</comment>
+        <ntasks>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_glc>-2</ntasks_glc>
+          <ntasks_wav>-2</ntasks_wav>
+          <ntasks_cpl>-2</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
   </grid>
   <grid name="l%0.47x0.63" >
     <mach name="any">

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/erosion/shell_commands
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/erosion/shell_commands
@@ -1,2 +1,10 @@
 #!/bin/bash
 ./xmlchange ELM_BLDNML_OPTS="-crop -irrig .true." -append
+
+# on Ascent+PGI, run with 4x42x2 (nodes x mpi x threads)
+if [ `./xmlquery --value MACH` == ascent ]&&[ `./xmlquery --value COMPILER` = pgi ]; then
+  ./xmlchange MAX_MPITASKS_PER_NODE=42
+  ./xmlchange MAX_TASKS_PER_NODE=84
+  ./xmlchange NTASKS=-4
+  ./xmlchange NTHRDS=2
+fi


### PR DESCRIPTION
`ERS.hcru_hcru.I20TRGSWCNPRDCTCBC.elm-erosion` (from E3SM-Project/E3SM#5085) has memory and wall-time errors with default PEs:
- increase ELM-erosion PEs: Ascent 1x84x1->4x42x2, Anvil 4->8 nodes
- increase other ELM PEs: 1->2 nodes
- increase BGC+DOCN PEs: 2x84x1->4x42x2

[BFB]