### PR TITLE
Adds submesoscale parameterization for mpas-ocean

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -606,8 +606,10 @@ add_default($nl, 'config_GMRedi_Rossby_ramp_max');
 # Namelist group: eddy_parameterization #
 #########################################
 
-add_default($nl, 'config_mixedLayerDepths_crit_dens_threshold');
-add_default($nl, 'config_mld_reference_depth');
+add_default($nl, 'config_eddyMLD_dens_threshold');
+add_default($nl, 'config_eddyMLD_reference_depth');
+add_default($nl, 'config_eddyMLD_reference_pressure');
+add_default($nl, 'config_eddyMLD_use_old');
 
 ####################################
 # Namelist group: Rayleigh_damping #

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -568,6 +568,16 @@ add_default($nl, 'config_Redi_horizontal_taper');
 add_default($nl, 'config_Redi_horizontal_ramp_min');
 add_default($nl, 'config_Redi_horizontal_ramp_max');
 
+######################################################
+# Namelist group: submesoscale_eddy_parameterization #
+######################################################
+
+add_default($nl, 'config_submesoscale_enable');
+add_default($nl, 'config_submesoscale_tau');
+add_default($nl, 'config_submesoscale_Ce');
+add_default($nl, 'config_submesoscale_Lfmin');
+add_default($nl, 'config_submesoscale_ds_max');
+
 ############################################
 # Namelist group: GM_eddy_parameterization #
 ############################################
@@ -591,6 +601,13 @@ add_default($nl, 'config_GM_horizontal_ramp_min');
 add_default($nl, 'config_GM_horizontal_ramp_max');
 add_default($nl, 'config_GMRedi_Rossby_ramp_min');
 add_default($nl, 'config_GMRedi_Rossby_ramp_max');
+
+#########################################
+# Namelist group: eddy_parameterization #
+#########################################
+
+add_default($nl, 'config_mixedLayerDepths_crit_dens_threshold');
+add_default($nl, 'config_mld_reference_depth');
 
 ####################################
 # Namelist group: Rayleigh_damping #
@@ -1291,9 +1308,7 @@ add_default($nl, 'config_AM_mixedLayerDepths_output_stream');
 add_default($nl, 'config_AM_mixedLayerDepths_write_on_startup');
 add_default($nl, 'config_AM_mixedLayerDepths_compute_on_startup');
 add_default($nl, 'config_AM_mixedLayerDepths_Tthreshold');
-add_default($nl, 'config_AM_mixedLayerDepths_Dthreshold');
 add_default($nl, 'config_AM_mixedLayerDepths_crit_temp_threshold');
-add_default($nl, 'config_AM_mixedLayerDepths_crit_dens_threshold');
 add_default($nl, 'config_AM_mixedLayerDepths_reference_pressure');
 add_default($nl, 'config_AM_mixedLayerDepths_Tgradient');
 add_default($nl, 'config_AM_mixedLayerDepths_Dgradient');
@@ -1681,7 +1696,9 @@ my @groups = qw(run_modes
                 hmix_del4
                 hmix_leith
                 redi_isopycnal_mixing
+                submesoscale_eddy_parameterization
                 gm_eddy_parameterization
+                eddy_parameterization
                 rayleigh_damping
                 cvmix
                 gotm

--- a/components/mpas-ocean/bld/build-namelist-group-list
+++ b/components/mpas-ocean/bld/build-namelist-group-list
@@ -9,7 +9,9 @@ my @groups = qw(run_modes
                 hmix_del4
                 hmix_leith
                 redi_isopycnal_mixing
+                submesoscale_eddy_parameterization
                 gm_eddy_parameterization
+                eddy_parameterization
                 rayleigh_damping
                 cvmix
                 gotm

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -149,8 +149,10 @@ add_default($nl, 'config_GMRedi_Rossby_ramp_max');
 # Namelist group: eddy_parameterization #
 #########################################
 
-add_default($nl, 'config_mixedLayerDepths_crit_dens_threshold');
-add_default($nl, 'config_mld_reference_depth');
+add_default($nl, 'config_eddyMLD_dens_threshold');
+add_default($nl, 'config_eddyMLD_reference_depth');
+add_default($nl, 'config_eddyMLD_reference_pressure');
+add_default($nl, 'config_eddyMLD_use_old');
 
 ####################################
 # Namelist group: Rayleigh_damping #

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -111,6 +111,16 @@ add_default($nl, 'config_Redi_horizontal_taper');
 add_default($nl, 'config_Redi_horizontal_ramp_min');
 add_default($nl, 'config_Redi_horizontal_ramp_max');
 
+######################################################
+# Namelist group: submesoscale_eddy_parameterization #
+######################################################
+
+add_default($nl, 'config_submesoscale_enable');
+add_default($nl, 'config_submesoscale_tau');
+add_default($nl, 'config_submesoscale_Ce');
+add_default($nl, 'config_submesoscale_Lfmin');
+add_default($nl, 'config_submesoscale_ds_max');
+
 ############################################
 # Namelist group: GM_eddy_parameterization #
 ############################################
@@ -134,6 +144,13 @@ add_default($nl, 'config_GM_horizontal_ramp_min');
 add_default($nl, 'config_GM_horizontal_ramp_max');
 add_default($nl, 'config_GMRedi_Rossby_ramp_min');
 add_default($nl, 'config_GMRedi_Rossby_ramp_max');
+
+#########################################
+# Namelist group: eddy_parameterization #
+#########################################
+
+add_default($nl, 'config_mixedLayerDepths_crit_dens_threshold');
+add_default($nl, 'config_mld_reference_depth');
 
 ####################################
 # Namelist group: Rayleigh_damping #
@@ -763,9 +780,7 @@ add_default($nl, 'config_AM_mixedLayerDepths_output_stream');
 add_default($nl, 'config_AM_mixedLayerDepths_write_on_startup');
 add_default($nl, 'config_AM_mixedLayerDepths_compute_on_startup');
 add_default($nl, 'config_AM_mixedLayerDepths_Tthreshold');
-add_default($nl, 'config_AM_mixedLayerDepths_Dthreshold');
 add_default($nl, 'config_AM_mixedLayerDepths_crit_temp_threshold');
-add_default($nl, 'config_AM_mixedLayerDepths_crit_dens_threshold');
 add_default($nl, 'config_AM_mixedLayerDepths_reference_pressure');
 add_default($nl, 'config_AM_mixedLayerDepths_Tgradient');
 add_default($nl, 'config_AM_mixedLayerDepths_Dgradient');

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -153,7 +153,7 @@
 <config_Redi_horizontal_ramp_max ocn_grid="WCAtl12to45E2r4">40e3</config_Redi_horizontal_ramp_max>
 
 <!-- submesoscale_eddy_parameterization -->
-<config_submesoscale_enable>.true.</config_submesoscale_enable>
+<config_submesoscale_enable>.false.</config_submesoscale_enable>
 <config_submesoscale_tau>172800</config_submesoscale_tau>
 <config_submesoscale_Ce>0.06</config_submesoscale_Ce>
 <config_submesoscale_Lfmin>1000.0</config_submesoscale_Lfmin>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -152,6 +152,13 @@
 <config_Redi_horizontal_ramp_max>30e3</config_Redi_horizontal_ramp_max>
 <config_Redi_horizontal_ramp_max ocn_grid="WCAtl12to45E2r4">40e3</config_Redi_horizontal_ramp_max>
 
+<!-- submesoscale_eddy_parameterization -->
+<config_submesoscale_enable>.true.</config_submesoscale_enable>
+<config_submesoscale_tau>172800</config_submesoscale_tau>
+<config_submesoscale_Ce>0.06</config_submesoscale_Ce>
+<config_submesoscale_Lfmin>1000.0</config_submesoscale_Lfmin>
+<config_submesoscale_ds_max>100000.0</config_submesoscale_ds_max>
+
 <!-- GM_eddy_parameterization -->
 <config_use_GM>.true.</config_use_GM>
 <config_use_GM ocn_grid="oRRS30to10v3">.false.</config_use_GM>
@@ -190,6 +197,10 @@
 <config_GM_horizontal_ramp_max ocn_grid="WCAtl12to45E2r4">40e3</config_GM_horizontal_ramp_max>
 <config_GMRedi_Rossby_ramp_min>0.5</config_GMRedi_Rossby_ramp_min>
 <config_GMRedi_Rossby_ramp_max>3.0</config_GMRedi_Rossby_ramp_max>
+
+<!-- eddy_parameterization -->
+<config_mixedLayerDepths_crit_dens_threshold>0.03</config_mixedLayerDepths_crit_dens_threshold>
+<config_mld_reference_depth>10</config_mld_reference_depth>
 
 <!-- Rayleigh_damping -->
 <config_Rayleigh_friction>.false.</config_Rayleigh_friction>
@@ -725,9 +736,7 @@
 <config_AM_mixedLayerDepths_write_on_startup>.false.</config_AM_mixedLayerDepths_write_on_startup>
 <config_AM_mixedLayerDepths_compute_on_startup>.true.</config_AM_mixedLayerDepths_compute_on_startup>
 <config_AM_mixedLayerDepths_Tthreshold>.true.</config_AM_mixedLayerDepths_Tthreshold>
-<config_AM_mixedLayerDepths_Dthreshold>.true.</config_AM_mixedLayerDepths_Dthreshold>
 <config_AM_mixedLayerDepths_crit_temp_threshold>0.2</config_AM_mixedLayerDepths_crit_temp_threshold>
-<config_AM_mixedLayerDepths_crit_dens_threshold>0.03</config_AM_mixedLayerDepths_crit_dens_threshold>
 <config_AM_mixedLayerDepths_reference_pressure>1.0E5</config_AM_mixedLayerDepths_reference_pressure>
 <config_AM_mixedLayerDepths_Tgradient>.false.</config_AM_mixedLayerDepths_Tgradient>
 <config_AM_mixedLayerDepths_Dgradient>.false.</config_AM_mixedLayerDepths_Dgradient>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -199,8 +199,10 @@
 <config_GMRedi_Rossby_ramp_max>3.0</config_GMRedi_Rossby_ramp_max>
 
 <!-- eddy_parameterization -->
-<config_mixedLayerDepths_crit_dens_threshold>0.03</config_mixedLayerDepths_crit_dens_threshold>
-<config_mld_reference_depth>10</config_mld_reference_depth>
+<config_eddyMLD_dens_threshold>0.03</config_eddyMLD_dens_threshold>
+<config_eddyMLD_reference_depth>10</config_eddyMLD_reference_depth>
+<config_eddyMLD_reference_pressure>1.0e5</config_eddyMLD_reference_pressure>
+<config_eddyMLD_use_old>.true.</config_eddyMLD_use_old>
 
 <!-- Rayleigh_damping -->
 <config_Rayleigh_friction>.false.</config_Rayleigh_friction>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -699,7 +699,7 @@ Default: Defined in namelist_defaults.xml
 
 <!-- eddy_parameterization -->
 
-<entry id="config_mixedLayerDepths_crit_dens_threshold" type="real"
+<entry id="config_eddyMLD_dens_threshold" type="real"
 	category="eddy_parameterization" group="eddy_parameterization">
 potential density change relative to surface for mixed layer depth threshold method.  This calculation is used for the Redi tapering, GM N2_dependent bolus kappa, and the submesoscale eddy parameterization
 
@@ -707,11 +707,27 @@ Valid values: suggested range 0.01 less than or equal to thresh less than or equ
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_mld_reference_depth" type="real"
+<entry id="config_eddyMLD_reference_depth" type="real"
 	category="eddy_parameterization" group="eddy_parameterization">
 reference depth for threshold computation
 
 Valid values: any positive real, near 10
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_eddyMLD_reference_pressure" type="real"
+	category="eddy_parameterization" group="eddy_parameterization">
+reference pressure for original mixed layer depth calculation
+
+Valid values: positive reals around 1.0e5
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_eddyMLD_use_old" type="logical"
+	category="eddy_parameterization" group="eddy_parameterization">
+switches from old dThreshMLD calculation to new (fixed one)
+
+Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -529,7 +529,7 @@ Default: Defined in namelist_defaults.xml
 	category="submesoscale_eddy_parameterization" group="submesoscale_eddy_parameterization">
 minimum frontal width (meters)
 
-Valid values: between 500 and 2000m
+Valid values: between 200 and 5000m
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -499,6 +499,49 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 
+<!-- submesoscale_eddy_parameterization -->
+
+<entry id="config_submesoscale_enable" type="logical"
+	category="submesoscale_eddy_parameterization" group="submesoscale_eddy_parameterization">
+flag to enable the FK2011 parameterization for submesoscale eddies
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_submesoscale_tau" type="real"
+	category="submesoscale_eddy_parameterization" group="submesoscale_eddy_parameterization">
+timescale for frictional slumping of front (in seconds)
+
+Valid values: positive reals, between 1-10 days
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_submesoscale_Ce" type="real"
+	category="submesoscale_eddy_parameterization" group="submesoscale_eddy_parameterization">
+efficiency of submesoscale eddies
+
+Valid values: 0.06 - 0.08
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_submesoscale_Lfmin" type="real"
+	category="submesoscale_eddy_parameterization" group="submesoscale_eddy_parameterization">
+minimum frontal width (meters)
+
+Valid values: between 500 and 2000m
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_submesoscale_ds_max" type="real"
+	category="submesoscale_eddy_parameterization" group="submesoscale_eddy_parameterization">
+maximum grid scale to scale up buoyancy gradient
+
+Valid values: around 1 degree
+Default: Defined in namelist_defaults.xml
+</entry>
+
+
 <!-- GM_eddy_parameterization -->
 
 <entry id="config_use_GM" type="logical"
@@ -650,6 +693,25 @@ Default: Defined in namelist_defaults.xml
 Maximum value of the ratio between grid-cell size (dcEdge) and Rossby radius for GM and Redi $\kappa$ ramp functions. Used when config_GM_horizontal_taper and/or config_Redi_horizontal_taper are set to RossbyRadius.
 
 Valid values: Any positive real value.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+
+<!-- eddy_parameterization -->
+
+<entry id="config_mixedLayerDepths_crit_dens_threshold" type="real"
+	category="eddy_parameterization" group="eddy_parameterization">
+potential density change relative to surface for mixed layer depth threshold method.  This calculation is used for the Redi tapering, GM N2_dependent bolus kappa, and the submesoscale eddy parameterization
+
+Valid values: suggested range 0.01 less than or equal to thresh less than or equal to 0.5
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_mld_reference_depth" type="real"
+	category="eddy_parameterization" group="eddy_parameterization">
+reference depth for threshold computation
+
+Valid values: any positive real, near 10
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -4020,27 +4082,11 @@ Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_AM_mixedLayerDepths_Dthreshold" type="logical"
-	category="AM_mixedLayerDepths" group="AM_mixedLayerDepths">
-Logical flag that determines if MLDs are calculated using a critical density threshold
-
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
 <entry id="config_AM_mixedLayerDepths_crit_temp_threshold" type="real"
 	category="AM_mixedLayerDepths" group="AM_mixedLayerDepths">
 temperature change relative to surface for threshold method
 
 Valid values: all real positive values, suggested range 0.2 less than or equal to thresh less than or equal to 1
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_AM_mixedLayerDepths_crit_dens_threshold" type="real"
-	category="AM_mixedLayerDepths" group="AM_mixedLayerDepths">
-potential density change relative to surface for threshold method
-
-Valid values: suggested range 0.01 less than or equal to thresh less than or equal to 0.5
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -1125,6 +1125,8 @@ def buildnml(case, caseroot, compname):
             lines.append('    <var name="mocStreamvalLatAndDepthGM"/>')
             lines.append('    <var name="mocStreamvalLatAndDepthRegionGM"/>')
 
+        lines.append('    <var name="mocStreamvalLatAndDepthMLE"/>')
+        lines.append('    <var name="mocStreamvalLatAndDepthRegionMLE"/>')
         lines.append('    <var_struct name="tracersSurfaceFlux"/>')
         lines.append('    <var name="penetrativeTemperatureFlux"/>')
         lines.append('    <var name="latentHeatFlux"/>')

--- a/components/mpas-ocean/cime_config/config_pes.xml
+++ b/components/mpas-ocean/cime_config/config_pes.xml
@@ -235,34 +235,34 @@
     <mach name="chrysalis">
       <pes compset="DATM.+MPASO" pesize="any">
         <comment>mpas-ocean+chrysalis: standard-res, compset=DATM+MPASO, 15x32x2 NODESxMPIxOMP</comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
+        <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
         <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
         <ntasks>
-          <ntasks_atm>320</ntasks_atm>
-          <ntasks_lnd>320</ntasks_lnd>
-          <ntasks_rof>320</ntasks_rof>
-          <ntasks_ice>320</ntasks_ice>
-          <ntasks_ocn>640</ntasks_ocn>
-          <ntasks_glc>320</ntasks_glc>
-          <ntasks_wav>320</ntasks_wav>
-          <ntasks_cpl>320</ntasks_cpl>
+          <ntasks_atm>160</ntasks_atm>
+          <ntasks_lnd>160</ntasks_lnd>
+          <ntasks_rof>160</ntasks_rof>
+          <ntasks_ice>160</ntasks_ice>
+          <ntasks_ocn>320</ntasks_ocn>
+          <ntasks_glc>160</ntasks_glc>
+          <ntasks_wav>160</ntasks_wav>
+          <ntasks_cpl>160</ntasks_cpl>
         </ntasks>
         <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
+          <nthrds_atm>2</nthrds_atm>
+          <nthrds_lnd>2</nthrds_lnd>
+          <nthrds_rof>2</nthrds_rof>
+          <nthrds_ice>2</nthrds_ice>
+          <nthrds_ocn>2</nthrds_ocn>
+          <nthrds_glc>2</nthrds_glc>
+          <nthrds_wav>2</nthrds_wav>
+          <nthrds_cpl>2</nthrds_cpl>
         </nthrds>
         <rootpe>
           <rootpe_atm>0</rootpe_atm>
           <rootpe_lnd>0</rootpe_lnd>
           <rootpe_rof>0</rootpe_rof>
           <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>320</rootpe_ocn>
+          <rootpe_ocn>160</rootpe_ocn>
           <rootpe_glc>0</rootpe_glc>
           <rootpe_wav>0</rootpe_wav>
           <rootpe_cpl>0</rootpe_cpl>

--- a/components/mpas-ocean/cime_config/config_pes.xml
+++ b/components/mpas-ocean/cime_config/config_pes.xml
@@ -235,34 +235,34 @@
     <mach name="chrysalis">
       <pes compset="DATM.+MPASO" pesize="any">
         <comment>mpas-ocean+chrysalis: standard-res, compset=DATM+MPASO, 15x32x2 NODESxMPIxOMP</comment>
-        <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
+        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
         <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
         <ntasks>
-          <ntasks_atm>160</ntasks_atm>
-          <ntasks_lnd>160</ntasks_lnd>
-          <ntasks_rof>160</ntasks_rof>
-          <ntasks_ice>160</ntasks_ice>
-          <ntasks_ocn>320</ntasks_ocn>
-          <ntasks_glc>160</ntasks_glc>
-          <ntasks_wav>160</ntasks_wav>
-          <ntasks_cpl>160</ntasks_cpl>
+          <ntasks_atm>320</ntasks_atm>
+          <ntasks_lnd>320</ntasks_lnd>
+          <ntasks_rof>320</ntasks_rof>
+          <ntasks_ice>320</ntasks_ice>
+          <ntasks_ocn>640</ntasks_ocn>
+          <ntasks_glc>320</ntasks_glc>
+          <ntasks_wav>320</ntasks_wav>
+          <ntasks_cpl>320</ntasks_cpl>
         </ntasks>
         <nthrds>
-          <nthrds_atm>2</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_glc>2</nthrds_glc>
-          <nthrds_wav>2</nthrds_wav>
-          <nthrds_cpl>2</nthrds_cpl>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
         </nthrds>
         <rootpe>
           <rootpe_atm>0</rootpe_atm>
           <rootpe_lnd>0</rootpe_lnd>
           <rootpe_rof>0</rootpe_rof>
           <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>160</rootpe_ocn>
+          <rootpe_ocn>320</rootpe_ocn>
           <rootpe_glc>0</rootpe_glc>
           <rootpe_wav>0</rootpe_wav>
           <rootpe_cpl>0</rootpe_cpl>

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -974,7 +974,7 @@ contains
             call ocn_frazil_forcing_build_arrays(domain, meshPool, forcingPool, statePool, ierr)
 
             call ocn_eddy_compute_mixed_layer_depth(statePool)
-            if (config_use_GM.or.config_submesoscale_enable) then
+            if (config_use_GM .or. config_submesoscale_enable) then
                 call ocn_eddy_compute_buoyancy_gradient()
             end if
 

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -973,7 +973,7 @@ contains
 
             call ocn_frazil_forcing_build_arrays(domain, meshPool, forcingPool, statePool, ierr)
 
-            call ocn_eddy_compute_mixed_layer_depth(statePool)
+            call ocn_eddy_compute_mixed_layer_depth(statePool, forcingPool)
             if (config_use_GM .or. config_submesoscale_enable) then
                 call ocn_eddy_compute_buoyancy_gradient()
             end if

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -60,6 +60,8 @@ module ocn_comp_mct
    use ocn_tracer_surface_restoring
    use ocn_gm
    use ocn_config
+   use ocn_submesoscale_eddies
+   use ocn_eddy_parameterization_helpers
 !
 ! !PUBLIC MEMBER FUNCTIONS:
   implicit none
@@ -971,6 +973,16 @@ contains
 
             call ocn_frazil_forcing_build_arrays(domain, meshPool, forcingPool, statePool, ierr)
 
+            call ocn_eddy_compute_mixed_layer_depth(statePool)
+            if (config_use_GM.or.config_submesoscale_enable) then
+                call ocn_eddy_compute_buoyancy_gradient()
+            end if
+
+            if (config_submesoscale_enable) then
+                call mpas_timer_start("submesoscale eddy velocity compute", .false.)
+                call ocn_submesoscale_compute_velocity()
+                call mpas_timer_stop("submesoscale eddy velocity compute")
+            end if
             ! Compute normalGMBolusVelocity, relativeSlope and RediDiffVertCoef if respective flags are turned on
             if (config_use_Redi.or.config_use_GM) then
               call ocn_gm_compute_Bolus_velocity(statePool, meshPool, scratchPool, timeLevelIn=1)

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2840,7 +2840,7 @@
 		/>
 		<var name="normalMLEvelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
 			description="Velocity from mixed layer eddies (fox kemper 2011 submesoscale parameterization)"
-			 packages="submeso"
+			packages="submeso"
 		/>
 		<var name="cGMphaseSpeed" type="real" dimensions="nEdges Time" units="m s^-1"
 			description="phase speed for the bolus velocity calculation"
@@ -2866,8 +2866,8 @@
 			packages="gm"
 		/>
 		<var name="gradBuoyEddy" type="real" dimensions="nVertLevelsP1 nEdges Time" units="s^-2"
-		    description="horizontal gradient of buoyancy at cell edge and interfaces in vertical.  this is used for the GM parameterization and the submesoscale eddy parameterization"
-			packages="gm;submeso"
+			description="horizontal gradient of buoyancy at cell edge and interfaces in vertical.  this is used for the GM parameterization and the submesoscale eddy parameterization"
+			 packages="gm;submeso"
 		/>
 		<var name="mleVelocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			description="Bolus velocity in fox-kemper mle parameterization, zonal-direction"
@@ -2877,17 +2877,17 @@
 			description="Bolus velocity in fox-kemper mle parameterization, meridional-direction"
 			packages="gm;submeso"
 		/>
-	    <var name="eddyVelocityX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
-			 description="Bolus velocity in Gent-McWilliams eddy or submesoscale parameterization, x-direction"
-			 packages="gm;submeso"
+		<var name="eddyVelocityX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+			description="Bolus velocity in Gent-McWilliams eddy or submesoscale parameterization, x-direction"
+			packages="gm;submeso"
 		/>
 		<var name="eddyVelocityY" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
-			 description="Bolus velocity in Gent-McWilliams or submesoscale eddy parameterization, y-direction"
-			 packages="gm;submeso"
+			description="Bolus velocity in Gent-McWilliams or submesoscale eddy parameterization, y-direction"
+			packages="gm;submeso"
 		/>
 		<var name="eddyVelocityZ" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
-			 description="eddy Bolus velocity in Gent-McWilliams or submesoscale eddy parameterization, z-direction"
-			 packages="gm;submeso"
+			description="eddy Bolus velocity in Gent-McWilliams or submesoscale eddy parameterization, z-direction"
+			packages="gm;submeso"
 		/>
 		<var name="GMBolusVelocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			 description="Bolus velocity in Gent-McWilliams eddy parameterization, zonal-direction"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2702,12 +2702,11 @@
 		/>
 		<var name="vertGMBolusVelocityTop" type="real" dimensions="nVertLevelsP1 nCells Time" units="m s^-1"
 			 description="vertical tracer-transport velocity defined at center (horizontally) and top (vertically) of cell.  This is not the vertical ALE transport, but is Eulerian (fixed-frame) in the vertical, and computed from the continuity equation from the horizontal GM Bolus velocity."
-			 packages="forwardMode;analysisMode"
+			 packages="gm"
 		/>
 		<var name="vertMLEBolusVelocityTop" type="real" dimensions="nVertLevelsP1 nCells Time" units="m s^-1"
 			 description="vertical tracer-transport velocity defined at center (horizontally) and top (vertically) of cell.  This is not the vertical ALE transport, but is Eulerian (fixed-frame) in the vertical, and computed from the continuity equation from the horizontal MLE (submesoscale) Bolus velocity."
-			 packages="forwardMode;analysisMode"
-
+			 packages="submeso"
 		/>
 		<var name="tangentialVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
 			 description="horizontal velocity, tangential to an edge"
@@ -2837,15 +2836,15 @@
 		/>
 		<var name="normalGMBolusVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
 			 description="Bolus velocity in Gent-McWilliams eddy parameterization"
-			 packages="forwardMode;analysisMode"
+			 packages="gm"
 		/>
 		<var name="normalMLEvelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
 			description="Velocity from mixed layer eddies (fox kemper 2011 submesoscale parameterization)"
-			 packages="forwardMode;analysisMode"
+			 packages="submeso"
 		/>
 		<var name="cGMphaseSpeed" type="real" dimensions="nEdges Time" units="m s^-1"
 			description="phase speed for the bolus velocity calculation"
-			packages="forwardMode;analysisMode"
+			packages="gm"
 		/>
 		<var name="betaEdge" type="real" dimensions="nEdges Time" units="m^-1 s^-1"
 			description="meridional gradient of the coriolis parameter, used in the mesoscale eddy parameterization schemes"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2844,7 +2844,6 @@
 		/>
 		<var name="normalGMBolusVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
 			 description="Bolus velocity in Gent-McWilliams eddy parameterization"
-			 packages="gm"
 		/>
 		<var name="normalMLEvelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
 			description="Velocity from mixed layer eddies (fox kemper 2011 submesoscale parameterization)"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -358,7 +358,7 @@
 					/>
 		<nml_option name="config_submesoscale_Lfmin" type="real" default_value="1000" units="m"
 					description="minimum frontal width (meters)"
-					possible_values="between 500 and 2000m"
+					possible_values="between 200 and 5000m"
 					/>
 		<nml_option name="config_submesoscale_ds_max" type="real" default_value="100000" units="m"
 					description="maximum grid scale to scale up buoyancy gradient"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2865,7 +2865,7 @@
 			description="count of times redi limiter is invoked on a timestep"
 			packages="gm"
 		/>
-	    <var name="gradBuoyEddy" type="real" dimensions="nVertLevelsP1 nEdges Time" units="s^-2"
+		<var name="gradBuoyEddy" type="real" dimensions="nVertLevelsP1 nEdges Time" units="s^-2"
 		    description="horizontal gradient of buoyancy at cell edge and interfaces in vertical.  this is used for the GM parameterization and the submesoscale eddy parameterization"
 			packages="gm;submeso"
 		/>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2111,8 +2111,8 @@
 
 			<stream name="mesh"/>
 			<var name="k33"/>
-			<var name="GMBolusVelocityX"/>
-			<var name="GMBolusVelocityY"/>
+			<var name="eddyVelocityX"/>
+			<var name="eddyVelocityY"/>
 			<var name="normalGMBolusVelocity"/>
 			<var name="vertGMBolusVelocityTop"/>
 			<var name="gmStreamFuncTopOfEdge"/>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1519,6 +1519,7 @@
 		<package name="cullCells" description="This package controls variables that provide information on what cells should be culled."/>
 		<package name="tracerBudget" description="This package controls variables that record the tracer budget."/>
 		<package name="gm" description="This package is for GM variables, which are only needed at lower resolutions."/>
+		<package name="submeso" description="This package is for submesoscale eddy (MLE) variables, needed at resolutions greater than O(1km)"/>
 		<package name="tidalPotentialForcingPKG" description="This package controls variables required for tidal potential forcing"/>
 		<package name="topographicWaveDragPKG" description="This package controls variables required for topographic wave drag"/>
 		<package name="gotmPKG" description="This package is for GOTM variables, which are only needed when using GOTM for the vertical turbulence closure."/>
@@ -2867,35 +2868,35 @@
 		/>
 	    <var name="gradBuoyEddy" type="real" dimensions="nVertLevelsP1 nEdges Time" units="s^-2"
 		    description="horizontal gradient of buoyancy at cell edge and interfaces in vertical.  this is used for the GM parameterization and the submesoscale eddy parameterization"
-			packages="forwardMode"
+			packages="gm;submeso"
 		/>
 		<var name="mleVelocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			description="Bolus velocity in fox-kemper mle parameterization, zonal-direction"
-			packages="forwardMode;analysisMode"
+			packages="gm;submeso"
 		/>
 		<var name="mleVelocityMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			description="Bolus velocity in fox-kemper mle parameterization, meridional-direction"
-			packages="forwardMode;analysisMode"
+			packages="gm;submeso"
 		/>
 	    <var name="eddyVelocityX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="Bolus velocity in Gent-McWilliams eddy or submesoscale parameterization, x-direction"
-			 packages="forwardMode;analysisMode"
+			 packages="gm;submeso"
 		/>
 		<var name="eddyVelocityY" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="Bolus velocity in Gent-McWilliams or submesoscale eddy parameterization, y-direction"
-			 packages="forwardMode;analysisMode"
+			 packages="gm;submeso"
 		/>
 		<var name="eddyVelocityZ" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="eddy Bolus velocity in Gent-McWilliams or submesoscale eddy parameterization, z-direction"
-			 packages="forwardMode;analysisMode"
+			 packages="gm;submeso"
 		/>
 		<var name="GMBolusVelocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			 description="Bolus velocity in Gent-McWilliams eddy parameterization, zonal-direction"
-			 packages="forwardMode;analysisMode"
+			 packages="gm;submeso"
 		/>
 		<var name="GMBolusVelocityMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			 description="Bolus velocity in Gent-McWilliams eddy parameterization, meridional-direction"
-			 packages="forwardMode;analysisMode"
+			 packages="gm;submeso"
 		/>
 		<var name="RiTopOfCell" type="real" dimensions="nVertLevelsP1 nCells Time" units="1"
 			 description="gradient Richardson number defined at the center (horizontally) and top (vertically)"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2869,18 +2869,6 @@
 		    description="horizontal gradient of buoyancy at cell edge and interfaces in vertical.  this is used for the GM parameterization and the submesoscale eddy parameterization"
 			packages="forwardMode"
 		/>
-		<var name="mleVelocityX" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
-			description="Bolus velocity in fox-kemper mle parameterization, x-direction"
-			packages="forwardMode;analysisMode"
-		/>
-		<var name="mleVelocityY" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
-			description="Bolus velocity in fox-kemper mle parameterization, y-direction"
-			packages="forwardMode;analysisMode"
-		/>
-		<var name="mleVelocityZ" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
-			description="Bolus velocity in fox-kemper mle parameterization, z-direction"
-			packages="forwardMode;analysisMode"
-		/>
 		<var name="mleVelocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			description="Bolus velocity in fox-kemper mle parameterization, zonal-direction"
 			packages="forwardMode;analysisMode"
@@ -2889,16 +2877,16 @@
 			description="Bolus velocity in fox-kemper mle parameterization, meridional-direction"
 			packages="forwardMode;analysisMode"
 		/>
-	    <var name="GMBolusVelocityX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
-			 description="Bolus velocity in Gent-McWilliams eddy parameterization, x-direction"
+	    <var name="eddyVelocityX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+			 description="Bolus velocity in Gent-McWilliams eddy or submesoscale parameterization, x-direction"
 			 packages="forwardMode;analysisMode"
 		/>
-		<var name="GMBolusVelocityY" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
-			 description="Bolus velocity in Gent-McWilliams eddy parameterization, y-direction"
+		<var name="eddyVelocityY" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+			 description="Bolus velocity in Gent-McWilliams or submesoscale eddy parameterization, y-direction"
 			 packages="forwardMode;analysisMode"
 		/>
-		<var name="GMBolusVelocityZ" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
-			 description="Bolus velocity in Gent-McWilliams eddy parameterization, z-direction"
+		<var name="eddyVelocityZ" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+			 description="eddy Bolus velocity in Gent-McWilliams or submesoscale eddy parameterization, z-direction"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="GMBolusVelocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
@@ -2985,9 +2973,6 @@
 		/>
 		<var name="indMLD" type="integer" dimensions="nCells Time"
 			description="index of model where mixed layer depth occurs (always one past)"
-		/>
-		<var name="indMLDedge" type="integer" dimensions="nEdges Time"
-			description="index of model where mixed layer depth occurs on edges"
 		/>
 		<var name="dThreshMLD" type="real" dimensions="nCells Time" units="m"
 			description="mixed layer depth based on density threshold"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -356,11 +356,11 @@
 					description="efficiency of submesoscale eddies"
 					possible_values="0.06 - 0.08"
 					/>
-		<nml_option name="config_submesoscale_Lfmin" type="real" default_value="1000" units="m"
+		<nml_option name="config_submesoscale_Lfmin" type="real" default_value="1000.0" units="m"
 					description="minimum frontal width (meters)"
 					possible_values="between 200 and 5000m"
 					/>
-		<nml_option name="config_submesoscale_ds_max" type="real" default_value="100000" units="m"
+		<nml_option name="config_submesoscale_ds_max" type="real" default_value="100000.0" units="m"
 					description="maximum grid scale to scale up buoyancy gradient"
 					possible_values="around 1 degree"
 					/>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -344,7 +344,7 @@
 		/>
 	</nml_record>
 	<nml_record name="submesoscale_eddy_parameterization" mode="forward">
-	    <nml_option name="config_submesoscale_enable" type="logical" default_value=".false." units="NA"
+	    <nml_option name="config_submesoscale_enable" type="logical" default_value=".false." 
 		            description="flag to enable the FK2011 parameterization for submesoscale eddies"
 					possible_values=".true. or .false."
 					/>
@@ -352,7 +352,7 @@
 		            description="timescale for frictional slumping of front (in seconds)"
 					possible_values="positive reals, between 1-10 days"
 					/>
-        <nml_option name="config_submesoscale_Ce" type="real" default_value="0.06" units="NA"
+        <nml_option name="config_submesoscale_Ce" type="real" default_value="0.06"
 		            description="efficiency of submesoscale eddies"
 					possible_values="0.06 - 0.08"
 					/>
@@ -2703,7 +2703,7 @@
 			 description="vertical tracer-transport velocity defined at center (horizontally) and top (vertically) of cell.  This is not the vertical ALE transport, but is Eulerian (fixed-frame) in the vertical, and computed from the continuity equation from the horizontal GM Bolus velocity."
 			 packages="forwardMode;analysisMode"
 		/>
-		<var name="vertMLEBolusVelocityTop" type="real" dimensions="nVertLevelsP1 nCells Time" units="m s^{-1}"
+		<var name="vertMLEBolusVelocityTop" type="real" dimensions="nVertLevelsP1 nCells Time" units="m s^-1"
 			 description="vertical tracer-transport velocity defined at center (horizontally) and top (vertically) of cell.  This is not the vertical ALE transport, but is Eulerian (fixed-frame) in the vertical, and computed from the continuity equation from the horizontal MLE (submesoscale) Bolus velocity."
 			 packages="forwardMode;analysisMode"
 
@@ -2838,7 +2838,7 @@
 			 description="Bolus velocity in Gent-McWilliams eddy parameterization"
 			 packages="forwardMode;analysisMode"
 		/>
-	    <var name="normalMLEvelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-1}"
+	    <var name="normalMLEvelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
 		     description="Velocity from mixed layer eddies (fox kemper 2011 submesoscale parameterization)"
 			 packages="forwardMode;analysisMode"
 		/>
@@ -2865,27 +2865,27 @@
 			description="count of times redi limiter is invoked on a timestep"
 			packages="gm"
 		/>
-	    <var name="gradBuoyEddy" type="real" dimensions="nVertLevelsP1 nEdges Time" units="s^{-2}"
+	    <var name="gradBuoyEddy" type="real" dimensions="nVertLevelsP1 nEdges Time" units="s^-2"
 		    description="horizontal gradient of buoyancy at cell edge and interfaces in vertical.  this is used for the GM parameterization and the submesoscale eddy parameterization"
 			packages="forwardMode"
 		/>
-		<var name="mleVelocityX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="mleVelocityX" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			description="Bolus velocity in fox-kemper mle parameterization, x-direction"
 			packages="forwardMode;analysisMode"
 		/>
-		<var name="mleVelocityY" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="mleVelocityY" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			description="Bolus velocity in fox-kemper mle parameterization, y-direction"
 			packages="forwardMode;analysisMode"
 		/>
-		<var name="mleVelocityZ" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="mleVelocityZ" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			description="Bolus velocity in fox-kemper mle parameterization, z-direction"
 			packages="forwardMode;analysisMode"
 		/>
-		<var name="mleVelocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="mleVelocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			description="Bolus velocity in fox-kemper mle parameterization, zonal-direction"
 			packages="forwardMode;analysisMode"
 		/>
-		<var name="mleVelocityMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="mleVelocityMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			description="Bolus velocity in fox-kemper mle parameterization, meridional-direction"
 			packages="forwardMode;analysisMode"
 		/>
@@ -2986,7 +2986,7 @@
 		<var name="indMLD" type="integer" dimensions="nCells Time"
 			description="index of model where mixed layer depth occurs (always one past)"
 		/>
-	     <var name="indMLDedge" type="integer" dimensions="nEdges Time" units="unitless"
+	     <var name="indMLDedge" type="integer" dimensions="nEdges Time"
 			description="index of model where mixed layer depth occurs on edges"
 		/>
 	    <var name="dThreshMLD" type="real" dimensions="nCells Time" units="m"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -343,6 +343,28 @@
 					possible_values="Any positive real value."
 		/>
 	</nml_record>
+	<nml_record name="submesoscale_eddy_parameterization" mode="forward">
+	    <nml_option name="config_submesoscale_enable" type="logical" default_value=".false." units="NA"
+		            description="flag to enable the FK2011 parameterization for submesoscale eddies"
+					possible_values=".true. or .false."
+					/>
+	    <nml_option name="config_submesoscale_tau" type="real" default_value="172800" units="s"
+		            description="timescale for frictional slumping of front (in seconds)"
+					possible_values="positive reals, between 1-10 days"
+					/>
+        <nml_option name="config_submesoscale_Ce" type="real" default_value="0.06" units="NA"
+		            description="efficiency of submesoscale eddies"
+					possible_values="0.06 - 0.08"
+					/>
+        <nml_option name="config_submesoscale_Lfmin" type="real" default_value="1000" units="m"
+		            description="minimum frontal width (meters)"
+					possible_values="between 500 and 2000m"
+ 					/>
+        <nml_option name="config_submesoscale_ds_max" type="real" default_value="100000" units="m"
+		            description="maximum grid scale to scale up buoyancy gradient"
+					possible_values="around 1 degree"
+					/>
+	</nml_record>
 	<nml_record name="GM_eddy_parameterization" mode="forward">
 		<nml_option name="config_use_GM" type="logical" default_value=".false."
 					description="If true, the standard GM for the tracer advection and mixing is turned on."
@@ -420,6 +442,16 @@
 					possible_values="Any positive real value."
 		/>
 	</nml_record>
+	<nml_record name="eddy_parameterization" mode="forward">
+	    <nml_option name="config_mixedLayerDepths_crit_dens_threshold" type="real" default_value="0.03" units="kgm^-3"
+       			    description="potential density change relative to surface for mixed layer depth threshold method.  This calculation is used for the Redi tapering, GM N2_dependent bolus kappa, and the submesoscale eddy parameterization"
+              		possible_values="suggested range 0.01 less than or equal to thresh less than or equal to 0.5"
+        />
+        <nml_option name="config_mld_reference_depth" type="real" default_value="10" units="m"
+                    description="reference depth for threshold computation"
+                    possible_values="any positive real, near 10" 
+        />
+    </nml_record>
 	<nml_record name="Rayleigh_damping" mode="forward">
 		<nml_option name="config_Rayleigh_friction" type="logical" default_value=".false."
 					description="If true, Rayleigh friction is included in the momentum equation at every depth level."
@@ -2670,6 +2702,10 @@
 		<var name="vertGMBolusVelocityTop" type="real" dimensions="nVertLevelsP1 nCells Time" units="m s^-1"
 			 description="vertical tracer-transport velocity defined at center (horizontally) and top (vertically) of cell.  This is not the vertical ALE transport, but is Eulerian (fixed-frame) in the vertical, and computed from the continuity equation from the horizontal GM Bolus velocity."
 			 packages="forwardMode;analysisMode"
+		/>
+		<var name="vertMLEBolusVelocityTop" type="real" dimensions="nVertLevelsP1 nCells Time" units="m s^{-1}"
+			 description="vertical tracer-transport velocity defined at center (horizontally) and top (vertically) of cell.  This is not the vertical ALE transport, but is Eulerian (fixed-frame) in the vertical, and computed from the continuity equation from the horizontal MLE (submesoscale) Bolus velocity."
+			 packages="forwardMode;analysisMode"
 
 		/>
 		<var name="tangentialVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
@@ -2802,6 +2838,10 @@
 			 description="Bolus velocity in Gent-McWilliams eddy parameterization"
 			 packages="forwardMode;analysisMode"
 		/>
+	    <var name="normalMLEvelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-1}"
+		     description="Velocity from mixed layer eddies (fox kemper 2011 submesoscale parameterization)"
+			 packages="forwardMode;analysisMode"
+		/>
 		<var name="cGMphaseSpeed" type="real" dimensions="nEdges Time" units="m s^-1"
 			description="phase speed for the bolus velocity calculation"
 			packages="forwardMode;analysisMode"
@@ -2825,7 +2865,31 @@
 			description="count of times redi limiter is invoked on a timestep"
 			packages="gm"
 		/>
-		<var name="GMBolusVelocityX" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
+	    <var name="gradBuoyEddy" type="real" dimensions="nVertLevelsP1 nEdges Time" units="s^{-2}"
+		    description="horizontal gradient of buoyancy at cell edge and interfaces in vertical.  this is used for the GM parameterization and the submesoscale eddy parameterization"
+			packages="forwardMode"
+		/>
+		<var name="mleVelocityX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+			description="Bolus velocity in fox-kemper mle parameterization, x-direction"
+			packages="forwardMode;analysisMode"
+		/>
+		<var name="mleVelocityY" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+			description="Bolus velocity in fox-kemper mle parameterization, y-direction"
+			packages="forwardMode;analysisMode"
+		/>
+		<var name="mleVelocityZ" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+			description="Bolus velocity in fox-kemper mle parameterization, z-direction"
+			packages="forwardMode;analysisMode"
+		/>
+		<var name="mleVelocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+			description="Bolus velocity in fox-kemper mle parameterization, zonal-direction"
+			packages="forwardMode;analysisMode"
+		/>
+		<var name="mleVelocityMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+			description="Bolus velocity in fox-kemper mle parameterization, meridional-direction"
+			packages="forwardMode;analysisMode"
+		/>
+	    <var name="GMBolusVelocityX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
 			 description="Bolus velocity in Gent-McWilliams eddy parameterization, x-direction"
 			 packages="forwardMode;analysisMode"
 		/>
@@ -2922,6 +2986,12 @@
 		<var name="indMLD" type="integer" dimensions="nCells Time"
 			description="index of model where mixed layer depth occurs (always one past)"
 		/>
+	     <var name="indMLDedge" type="integer" dimensions="nEdges Time" units="unitless"
+			description="index of model where mixed layer depth occurs on edges"
+		/>
+	    <var name="dThreshMLD" type="real" dimensions="nCells Time" units="m"
+             description="mixed layer depth based on density threshold"
+        />
 		<var name="slopeTriadUp" type="real" dimensions="nVertLevels TWO nEdges Time" units="non-dimensional" default_value="0.0"
 			 description="Magnitude of slope of isopycnal surface, using triad through this cell and edge, angled up. Uses expansion of equation of state."
 			 packages="forwardMode;analysisMode"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -344,24 +344,24 @@
 		/>
 	</nml_record>
 	<nml_record name="submesoscale_eddy_parameterization" mode="forward">
-	    <nml_option name="config_submesoscale_enable" type="logical" default_value=".false." 
-		            description="flag to enable the FK2011 parameterization for submesoscale eddies"
+		<nml_option name="config_submesoscale_enable" type="logical" default_value=".false." 
+					description="flag to enable the FK2011 parameterization for submesoscale eddies"
 					possible_values=".true. or .false."
 					/>
-	    <nml_option name="config_submesoscale_tau" type="real" default_value="172800" units="s"
-		            description="timescale for frictional slumping of front (in seconds)"
+		<nml_option name="config_submesoscale_tau" type="real" default_value="172800" units="s"
+					description="timescale for frictional slumping of front (in seconds)"
 					possible_values="positive reals, between 1-10 days"
 					/>
-        <nml_option name="config_submesoscale_Ce" type="real" default_value="0.06"
-		            description="efficiency of submesoscale eddies"
+		<nml_option name="config_submesoscale_Ce" type="real" default_value="0.06"
+					description="efficiency of submesoscale eddies"
 					possible_values="0.06 - 0.08"
 					/>
-        <nml_option name="config_submesoscale_Lfmin" type="real" default_value="1000" units="m"
-		            description="minimum frontal width (meters)"
+		<nml_option name="config_submesoscale_Lfmin" type="real" default_value="1000" units="m"
+					description="minimum frontal width (meters)"
 					possible_values="between 500 and 2000m"
- 					/>
-        <nml_option name="config_submesoscale_ds_max" type="real" default_value="100000" units="m"
-		            description="maximum grid scale to scale up buoyancy gradient"
+					/>
+		<nml_option name="config_submesoscale_ds_max" type="real" default_value="100000" units="m"
+					description="maximum grid scale to scale up buoyancy gradient"
 					possible_values="around 1 degree"
 					/>
 	</nml_record>
@@ -2838,8 +2838,8 @@
 			 description="Bolus velocity in Gent-McWilliams eddy parameterization"
 			 packages="forwardMode;analysisMode"
 		/>
-	    <var name="normalMLEvelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
-		     description="Velocity from mixed layer eddies (fox kemper 2011 submesoscale parameterization)"
+		<var name="normalMLEvelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
+			description="Velocity from mixed layer eddies (fox kemper 2011 submesoscale parameterization)"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="cGMphaseSpeed" type="real" dimensions="nEdges Time" units="m s^-1"
@@ -2986,12 +2986,12 @@
 		<var name="indMLD" type="integer" dimensions="nCells Time"
 			description="index of model where mixed layer depth occurs (always one past)"
 		/>
-	     <var name="indMLDedge" type="integer" dimensions="nEdges Time"
+		<var name="indMLDedge" type="integer" dimensions="nEdges Time"
 			description="index of model where mixed layer depth occurs on edges"
 		/>
-	    <var name="dThreshMLD" type="real" dimensions="nCells Time" units="m"
-             description="mixed layer depth based on density threshold"
-        />
+		<var name="dThreshMLD" type="real" dimensions="nCells Time" units="m"
+			description="mixed layer depth based on density threshold"
+		/>
 		<var name="slopeTriadUp" type="real" dimensions="nVertLevels TWO nEdges Time" units="non-dimensional" default_value="0.0"
 			 description="Magnitude of slope of isopycnal surface, using triad through this cell and edge, angled up. Uses expansion of equation of state."
 			 packages="forwardMode;analysisMode"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -330,7 +330,7 @@
 					description="Redi diagonal terms (2 and 3) are turned off from layer 1 through config_Redi_min_layers_diag_terms-1, and on from config_Redi_min_layers_diag_terms to nVertLevels. The Redi diagonal terms are not guaranteed to produce bounded tracer fields, and in practice produce growing temperatures in a few columns with fewer than 5 vertical cells. Redi is meant for isopycnal mixing in the deep ocean, so not applying Redi diagonal terms in very shallow regions is an acceptable solution."
 					possible_values="any integer between 0 (all layers on) and nVertLevels (all layers off)"
 		/>
-		<nml_option name="config_Redi_horizontal_taper" type="character" default_value="ramp" units="unitless"
+		<nml_option name="config_Redi_horizontal_taper" type="character" default_value="ramp"
 					description="Control how the Redi $\kappa$ value varies as a function of horizontal resolution. 'none' is constant, 'ramp' is strictly based on resolution, 'RossbyRadius' follows Hallberg (2013) - https://doi.org/10.1016/j.ocemod.2013.08.007"
 					possible_values="'none', 'ramp', 'RossbyRadius'"
 		/>
@@ -421,7 +421,7 @@
 					description="factor multiplying the Rhines length in the scheme from Eden Greatbatch (2008) Ocean Modeling -- Equation (28)"
 					possible_values="small positive values less than equal to one"
 		/>
-		<nml_option name="config_GM_horizontal_taper" type="character" default_value="ramp" units="unitless"
+		<nml_option name="config_GM_horizontal_taper" type="character" default_value="ramp"
 					description="Control how the GM Bolus value varies as a function of horizontal resolution. 'none' is constant, 'ramp' is strictly based on resolution, 'RossbyRadius' follows Hallberg (2013) - https://doi.org/10.1016/j.ocemod.2013.08.007"
 					possible_values="'none', 'ramp', 'RossbyRadius'"
 		/>
@@ -433,23 +433,23 @@
 					description="Maximum value in grid cell size for GM $\kappa$ ramp function.  Here cell size refers to dcEdge. Used when config_GM_horizontal_taper is set to ramp."
 					possible_values="Any positive real value."
 		/>
-		<nml_option name="config_GMRedi_Rossby_ramp_min" type="real" default_value="0.5" units="unitless"
+		<nml_option name="config_GMRedi_Rossby_ramp_min" type="real" default_value="0.5"
 					description="Minimum value of the ratio between grid-cell size (dcEdge) and Rossby radius for GM and Redi $\kappa$ ramp functions. Used when config_GM_horizontal_taper and/or config_Redi_horizontal_taper are set to RossbyRadius."
 					possible_values="Any positive real value."
 		/>
-		<nml_option name="config_GMRedi_Rossby_ramp_max" type="real" default_value="3.0" units="unitless"
+		<nml_option name="config_GMRedi_Rossby_ramp_max" type="real" default_value="3.0"
 					description="Maximum value of the ratio between grid-cell size (dcEdge) and Rossby radius for GM and Redi $\kappa$ ramp functions. Used when config_GM_horizontal_taper and/or config_Redi_horizontal_taper are set to RossbyRadius."
 					possible_values="Any positive real value."
 		/>
 	</nml_record>
 	<nml_record name="eddy_parameterization" mode="forward">
-	    <nml_option name="config_eddyMLD_dens_threshold" type="real" default_value="0.03" units="kgm^-3"
-       			    description="potential density change relative to surface for mixed layer depth threshold method.  This calculation is used for the Redi tapering, GM N2_dependent bolus kappa, and the submesoscale eddy parameterization"
-              		possible_values="suggested range 0.01 less than or equal to thresh less than or equal to 0.5"
-        />
-        <nml_option name="config_eddyMLD_reference_depth" type="real" default_value="10" units="m"
-                    description="reference depth for threshold computation"
-                    possible_values="any positive real, near 10" 
+		<nml_option name="config_eddyMLD_dens_threshold" type="real" default_value="0.03" units="kg m^-3"
+					description="potential density change relative to surface for mixed layer depth threshold method.  This calculation is used for the Redi tapering, GM N2_dependent bolus kappa, and the submesoscale eddy parameterization"
+					possible_values="suggested range 0.01 less than or equal to thresh less than or equal to 0.5"
+		/>
+		<nml_option name="config_eddyMLD_reference_depth" type="real" default_value="10" units="m"
+					description="reference depth for threshold computation"
+					possible_values="any positive real, near 10" 
 		/>
 		<nml_option name="config_eddyMLD_reference_pressure" type="real" default_value="1.0e5" units="Pa"
 					description="reference pressure for original mixed layer depth calculation"
@@ -459,7 +459,7 @@
 					description="switches from old dThreshMLD calculation to new (fixed one)"
 					possible_values=".true. or .false."
 		/>
-    </nml_record>
+	</nml_record>
 	<nml_record name="Rayleigh_damping" mode="forward">
 		<nml_option name="config_Rayleigh_friction" type="logical" default_value=".false."
 					description="If true, Rayleigh friction is included in the momentum equation at every depth level."
@@ -2884,15 +2884,15 @@
 			description="Bolus velocity in fox-kemper mle parameterization, meridional-direction"
 			packages="gm;submeso"
 		/>
-		<var name="eddyVelocityX" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="eddyVelocityX" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			description="Bolus velocity in Gent-McWilliams eddy or submesoscale parameterization, x-direction"
 			packages="gm;submeso"
 		/>
-		<var name="eddyVelocityY" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="eddyVelocityY" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			description="Bolus velocity in Gent-McWilliams or submesoscale eddy parameterization, y-direction"
 			packages="gm;submeso"
 		/>
-		<var name="eddyVelocityZ" type="real" dimensions="nVertLevels nCells Time" units="m s^{-1}"
+		<var name="eddyVelocityZ" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			description="eddy Bolus velocity in Gent-McWilliams or submesoscale eddy parameterization, z-direction"
 			packages="gm;submeso"
 		/>
@@ -3028,11 +3028,11 @@
 			 description="Redi Kappa value.  On output, it has already been multiplied by the horizontal taper array RediHorizontalTaper (as opposed to gmBolusKappa, which has not been multiplied by the horizontal taper)."
 			 packages="gm"
 		/>
-		<var name="RediHorizontalTaper" type="real" dimensions="nEdges Time" units="unitless"
+		<var name="RediHorizontalTaper" type="real" dimensions="nEdges Time"
 			 description="Horizontal tapering for Redi. Varies between 0 and 1."
 			 packages="gm"
 		/>
-		<var name="gmHorizontalTaper" type="real" dimensions="nEdges Time" units="unitless"
+		<var name="gmHorizontalTaper" type="real" dimensions="nEdges Time"
 			 description="Horizontal tapering for GM. Varies between 0 and 1."
 			 packages="gm"
 		/>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -443,14 +443,22 @@
 		/>
 	</nml_record>
 	<nml_record name="eddy_parameterization" mode="forward">
-	    <nml_option name="config_mixedLayerDepths_crit_dens_threshold" type="real" default_value="0.03" units="kgm^-3"
+	    <nml_option name="config_eddyMLD_dens_threshold" type="real" default_value="0.03" units="kgm^-3"
        			    description="potential density change relative to surface for mixed layer depth threshold method.  This calculation is used for the Redi tapering, GM N2_dependent bolus kappa, and the submesoscale eddy parameterization"
               		possible_values="suggested range 0.01 less than or equal to thresh less than or equal to 0.5"
         />
-        <nml_option name="config_mld_reference_depth" type="real" default_value="10" units="m"
+        <nml_option name="config_eddyMLD_reference_depth" type="real" default_value="10" units="m"
                     description="reference depth for threshold computation"
                     possible_values="any positive real, near 10" 
-        />
+		/>
+		<nml_option name="config_eddyMLD_reference_pressure" type="real" default_value="1.0e5" units="Pa"
+					description="reference pressure for original mixed layer depth calculation"
+					possible_values="positive reals around 1.0e5"
+		/>
+		<nml_option name="config_eddyMLD_use_old" type="logical" default_value=".true."
+					description="switches from old dThreshMLD calculation to new (fixed one)"
+					possible_values=".true. or .false."
+		/>
     </nml_record>
 	<nml_record name="Rayleigh_damping" mode="forward">
 		<nml_option name="config_Rayleigh_friction" type="logical" default_value=".false."

--- a/components/mpas-ocean/src/analysis_members/Registry_mixed_layer_depths.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_mixed_layer_depths.xml
@@ -23,17 +23,9 @@
 			description="Logical flag that determines if MLDs are calculated using a critical temperature threshold"
 			possible_values=".true. or .false."
 		/>
-		<nml_option name="config_AM_mixedLayerDepths_Dthreshold" type="logical" default_value=".true."
-			description="Logical flag that determines if MLDs are calculated using a critical density threshold"
-			possible_values=".true. or .false."
-		/>
 		<nml_option name="config_AM_mixedLayerDepths_crit_temp_threshold" type="real" default_value="0.2" units="C"
 			description="temperature change relative to surface for threshold method"
 			possible_values="all real positive values, suggested range 0.2 less than or equal to thresh less than or equal to 1"
-		/>
-		<nml_option name="config_AM_mixedLayerDepths_crit_dens_threshold" type="real" default_value="0.03" units="kg m^-3"
-			description="potential density change relative to surface for threshold method"
-			possible_values="suggested range 0.01 less than or equal to thresh less than or equal to 0.5"
 		/>
 		<nml_option name="config_AM_mixedLayerDepths_reference_pressure" type="real" default_value="1.0E5" units="N m^-2"
 			description="reference pressure for threshold computation"
@@ -67,9 +59,6 @@
 		<var name="tThreshMLD" type="real" dimensions="nCells Time" units="m"
 			 description="mixed layer depth based on temperature threshold"
 		/>
-		<var name="dThreshMLD" type="real" dimensions="nCells Time" units="m"
-			 description="mixed layer depth based on density threshold"
-    />
 		<var name="tGradMLD" type="real" dimensions="nCells Time" units="m"
 			 description="mixed layer depth based on gradient of temperature"
 		/>
@@ -101,7 +90,6 @@
 			<stream name="mesh"/>
 			<var name="xtime"/>
 			<var name="tThreshMLD"/>
-			<var name="dThreshMLD"/>
 			<var name="tGradMLD"/>
 			<var name="dGradMLD"/>
 		</stream>

--- a/components/mpas-ocean/src/analysis_members/Registry_moc_streamfunction.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_moc_streamfunction.xml
@@ -61,7 +61,7 @@
 		<var name="mocStreamvalLatAndDepthGM" type="real" dimensions="nMocStreamfunctionBinsP1 nVertLevels Time" units="sverdrups"
 			description="The value of the MOC streamfunction for each latitude-bin (first dimension) and depth (second dimension) based on the Gent McWilliams Bolus Velocity"
 		/>
-	<var name="mocStreamvalLatAndDepthMLE" type="real" dimensions="nMocStreamfunctionBinsP1 nVertLevels Time" units="sverdrups"
+		<var name="mocStreamvalLatAndDepthMLE" type="real" dimensions="nMocStreamfunctionBinsP1 nVertLevels Time" units="sverdrups"
 			description="The value of the MOC streamfunction for each latitude-bin (first dimension) and depth (second dimension) based on the Submesoscale eddy Bolus Velocity"
 		/>
 		<var name="mocStreamvalLatAndDepthRegionGM" type="real" dimensions="nMocStreamfunctionBinsP1 nVertLevels nRegions Time" units="sverdrups"

--- a/components/mpas-ocean/src/analysis_members/Registry_moc_streamfunction.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_moc_streamfunction.xml
@@ -67,7 +67,7 @@
 		<var name="mocStreamvalLatAndDepthRegionGM" type="real" dimensions="nMocStreamfunctionBinsP1 nVertLevels nRegions Time" units="sverdrups"
 			description="The value of the MOC streamfunction for each latitude-bin (first dimension) and depth (second dimension) based on the Gent McWilliams Bolus Velocity"
 		/>
-	<var name="mocStreamvalLatAndDepthRegionMLE" type="real" dimensions="nMocStreamfunctionBinsP1 nVertLevels nRegions Time" units="sverdrups"
+		<var name="mocStreamvalLatAndDepthRegionMLE" type="real" dimensions="nMocStreamfunctionBinsP1 nVertLevels nRegions Time" units="sverdrups"
 			description="The value of the MOC streamfunction for each latitude-bin (first dimension) and depth (second dimension) based on the Submesoscale eddy Bolus Velocity"
 		/>
 		<var name="binBoundaryMocStreamfunction" type="real" dimensions="nMocStreamfunctionBinsP1" units="varies"

--- a/components/mpas-ocean/src/analysis_members/Registry_moc_streamfunction.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_moc_streamfunction.xml
@@ -61,8 +61,14 @@
 		<var name="mocStreamvalLatAndDepthGM" type="real" dimensions="nMocStreamfunctionBinsP1 nVertLevels Time" units="sverdrups"
 			description="The value of the MOC streamfunction for each latitude-bin (first dimension) and depth (second dimension) based on the Gent McWilliams Bolus Velocity"
 		/>
+	<var name="mocStreamvalLatAndDepthMLE" type="real" dimensions="nMocStreamfunctionBinsP1 nVertLevels Time" units="sverdrups"
+			description="The value of the MOC streamfunction for each latitude-bin (first dimension) and depth (second dimension) based on the Submesoscale eddy Bolus Velocity"
+		/>
 		<var name="mocStreamvalLatAndDepthRegionGM" type="real" dimensions="nMocStreamfunctionBinsP1 nVertLevels nRegions Time" units="sverdrups"
 			description="The value of the MOC streamfunction for each latitude-bin (first dimension) and depth (second dimension) based on the Gent McWilliams Bolus Velocity"
+		/>
+	<var name="mocStreamvalLatAndDepthRegionMLE" type="real" dimensions="nMocStreamfunctionBinsP1 nVertLevels nRegions Time" units="sverdrups"
+			description="The value of the MOC streamfunction for each latitude-bin (first dimension) and depth (second dimension) based on the Submesoscale eddy Bolus Velocity"
 		/>
 		<var name="binBoundaryMocStreamfunction" type="real" dimensions="nMocStreamfunctionBinsP1" units="varies"
 			 description="Coordinate of southern edge of meridional heat transport bin, either in latitude or y, for plotting."
@@ -89,6 +95,8 @@
 			<var name="mocStreamvalLatAndDepthRegion"/>
 			<var name="mocStreamvalLatAndDepthGM"/>
 			<var name="mocStreamvalLatAndDepthRegionGM"/>
+			<var name="mocStreamvalLatAndDepthMLE"/>
+			<var name="mocStreamvalLatAndDepthRegionMLE"/>
 			<var name="binBoundaryMocStreamfunction"/>
 			<var name="refBottomDepth"/>
 

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_high_frequency_output.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_high_frequency_output.F
@@ -325,21 +325,23 @@ contains
          call mpas_pool_get_array(highFrequencyOutputAMPool, 'meridionalBaroclinicVelAt250m', meridionalBaroclinicVelAt250m)
          call mpas_pool_get_array(highFrequencyOutputAMPool, 'meridionalBaroclinicVelAtBottom', meridionalBaroclinicVelAtBottom)
 
-         call mpas_pool_get_array(highFrequencyOutputAMPool, 'normalGMBolusVelAtSFC', normalGMBolusVelAtSFC)
-         call mpas_pool_get_array(highFrequencyOutputAMPool, 'normalGMBolusVelAt250m', normalGMBolusVelAt250m)
-         call mpas_pool_get_array(highFrequencyOutputAMPool, 'normalGMBolusVelAtBottom', normalGMBolusVelAtBottom)
+         if (config_use_gm) then
+            call mpas_pool_get_array(highFrequencyOutputAMPool, 'normalGMBolusVelAtSFC', normalGMBolusVelAtSFC)
+            call mpas_pool_get_array(highFrequencyOutputAMPool, 'normalGMBolusVelAt250m', normalGMBolusVelAt250m)
+            call mpas_pool_get_array(highFrequencyOutputAMPool, 'normalGMBolusVelAtBottom', normalGMBolusVelAtBottom)
 
-         call mpas_pool_get_array(highFrequencyOutputAMPool, 'tangentialGMBolusVelAtSFC', tangentialGMBolusVelAtSFC)
-         call mpas_pool_get_array(highFrequencyOutputAMPool, 'tangentialGMBolusVelAt250m', tangentialGMBolusVelAt250m)
-         call mpas_pool_get_array(highFrequencyOutputAMPool, 'tangentialGMBolusVelAtBottom', tangentialGMBolusVelAtBottom)
+            call mpas_pool_get_array(highFrequencyOutputAMPool, 'tangentialGMBolusVelAtSFC', tangentialGMBolusVelAtSFC)
+            call mpas_pool_get_array(highFrequencyOutputAMPool, 'tangentialGMBolusVelAt250m', tangentialGMBolusVelAt250m)
+            call mpas_pool_get_array(highFrequencyOutputAMPool, 'tangentialGMBolusVelAtBottom', tangentialGMBolusVelAtBottom)
 
-         call mpas_pool_get_array(highFrequencyOutputAMPool, 'zonalGMBolusVelAtSFC', zonalGMBolusVelAtSFC)
-         call mpas_pool_get_array(highFrequencyOutputAMPool, 'zonalGMBolusVelAt250m', zonalGMBolusVelAt250m)
-         call mpas_pool_get_array(highFrequencyOutputAMPool, 'zonalGMBolusVelAtBottom', zonalGMBolusVelAtBottom)
+            call mpas_pool_get_array(highFrequencyOutputAMPool, 'zonalGMBolusVelAtSFC', zonalGMBolusVelAtSFC)
+            call mpas_pool_get_array(highFrequencyOutputAMPool, 'zonalGMBolusVelAt250m', zonalGMBolusVelAt250m)
+            call mpas_pool_get_array(highFrequencyOutputAMPool, 'zonalGMBolusVelAtBottom', zonalGMBolusVelAtBottom)
 
-         call mpas_pool_get_array(highFrequencyOutputAMPool, 'meridionalGMBolusVelAtSFC', meridionalGMBolusVelAtSFC)
-         call mpas_pool_get_array(highFrequencyOutputAMPool, 'meridionalGMBolusVelAt250m', meridionalGMBolusVelAt250m)
-         call mpas_pool_get_array(highFrequencyOutputAMPool, 'meridionalGMBolusVelAtBottom', meridionalGMBolusVelAtBottom)
+            call mpas_pool_get_array(highFrequencyOutputAMPool, 'meridionalGMBolusVelAtSFC', meridionalGMBolusVelAtSFC)
+            call mpas_pool_get_array(highFrequencyOutputAMPool, 'meridionalGMBolusVelAt250m', meridionalGMBolusVelAt250m)
+            call mpas_pool_get_array(highFrequencyOutputAMPool, 'meridionalGMBolusVelAtBottom', meridionalGMBolusVelAtBottom)
+         end if
 
          call mpas_pool_get_array(highFrequencyOutputAMPool, 'BruntVaisalaFreqTopAtSFC', BruntVaisalaFreqTopAtSFC)
          call mpas_pool_get_array(highFrequencyOutputAMPool, 'BruntVaisalaFreqTopAt250m', BruntVaisalaFreqTopAt250m)
@@ -419,17 +421,49 @@ contains
          activeTracersAtSurface(2,:) = activeTracers(2,1,:)
          activeTracersAt250m(1,:) = activeTracers(1,iLevel0250,:)
          activeTracersAt250m(2,:) = activeTracers(2,iLevel0250,:)
-         vertGMvelocitySFC(:) = vertGMBolusVelocityTop(1,:)
          vertTransportVelocitySFC(:) = vertTransportVelocityTop(1,:)
          vertVelSFC(:) = vertVelocityTop(1,:)
-         vertGMvelocityAt250m(:) = vertGMBolusVelocityTop(iLevel0250,:)
          vertTransportVelocityAt250m(:) = vertTransportVelocityTop(iLevel0250,:)
          vertVelAt250m(:) = vertVelocityTop(iLevel0250,:)
 
+         if (config_use_gm) then
+            vertGMvelocitySFC(:) = vertGMBolusVelocityTop(1,:)
+            vertGMvelocityAt250m(:) = vertGMBolusVelocityTop(iLevel0250,:)
+            do iEdge = 1, nEdges
+               normalGMBolusVelAtSFC(iEdge) = normalGMBolusVelocity(1,iEdge)
+               normalGMBolusVelAt250m(iEdge) = normalGMBolusVelocity(iLevel0250,iEdge)
+               normalGMBolusVelAtBottom(iEdge) = normalGMBolusVelocity(maxLevelEdgeBot(iEdge),iEdge)
+            end do
+
+            do iEdge = 1, nEdges
+              tangentialGMBolusVelAtSFC(iEdge) = 0.0_RKIND
+              tangentialGMBolusVelAt250m(iEdge) = 0.0_RKIND
+              tangentialGMBolusVelAtBottom(iEdge) = 0.0_RKIND
+              do i = 1, nEdgesOnEdge(iEdge)
+                eoe = edgesOnEdge(i,iEdge)
+                tangentialGMBolusVelAtSFC(iEdge) = tangentialGMBolusVelAtSFC(iEdge) + weightsOnEdge(i,iEdge) * normalGMBolusVelAtSFC(eoe)
+                tangentialGMBolusVelAt250m(iEdge) = tangentialGMBolusVelAt250m(iEdge) + weightsOnEdge(i,iEdge) * normalGMBolusVelAt250m(eoe)
+                tangentialGMBolusVelAtBottom(iEdge) = tangentialGMBolusVelAtBottom(iEdge) + weightsOnEdge(i,iEdge) * normalGMBolusVelAtBottom(eoe)
+              end do
+
+              zonalGMBolusVelAtSFC(iEdge) = normalGMBolusVelAtSFC(iEdge)*cos(angleEdge(iEdge)) &
+                - tangentialGMBolusVelAtSFC(iEdge)*sin(angleEdge(iEdge))
+              meridionalGMBolusVelAtSFC(iEdge) = normalGMBolusVelAtSFC(iEdge)*sin(angleEdge(iEdge)) &
+                + tangentialGMBolusVelAtSFC(iEdge)*cos(angleEdge(iEdge))
+
+              zonalGMBolusVelAt250m(iEdge) = normalGMBolusVelAt250m(iEdge)*cos(angleEdge(iEdge)) &
+                - tangentialGMBolusVelAt250m(iEdge)*sin(angleEdge(iEdge))
+              meridionalGMBolusVelAt250m(iEdge) = normalGMBolusVelAt250m(iEdge)*sin(angleEdge(iEdge)) &
+                + tangentialGMBolusVelAt250m(iEdge)*cos(angleEdge(iEdge))
+
+              zonalGMBolusVelAtBottom(iEdge) = normalGMBolusVelAtBottom(iEdge)*cos(angleEdge(iEdge)) &
+                - tangentialGMBolusVelAtBottom(iEdge)*sin(angleEdge(iEdge))
+              meridionalGMBolusVelAtBottom(iEdge) = normalGMBolusVelAtBottom(iEdge)*sin(angleEdge(iEdge)) &
+                + tangentialGMBolusVelAtBottom(iEdge)*cos(angleEdge(iEdge))
+            end do
+         end if
+
          do iEdge = 1, nEdges
-           normalGMBolusVelAtSFC(iEdge) = normalGMBolusVelocity(1,iEdge)
-           normalGMBolusVelAt250m(iEdge) = normalGMBolusVelocity(iLevel0250,iEdge)
-           normalGMBolusVelAtBottom(iEdge) = normalGMBolusVelocity(maxLevelEdgeBot(iEdge),iEdge)
 
            tangentialVelAtSFC(iEdge) = tangentialVelocity(1,iEdge)
            tangentialVelAt250m(iEdge) = tangentialVelocity(iLevel0250,iEdge)
@@ -453,33 +487,6 @@ contains
                                   - tangentialVelAtBottom(iEdge)*sin(angleEdge(iEdge))
            meridionalVelAtBottom(iEdge) = normalVelAtBottom(iEdge)*sin(angleEdge(iEdge)) &
                                        + tangentialVelAtBottom(iEdge)*cos(angleEdge(iEdge))
-         end do
-
-         do iEdge = 1, nEdges
-           tangentialGMBolusVelAtSFC(iEdge) = 0.0_RKIND
-           tangentialGMBolusVelAt250m(iEdge) = 0.0_RKIND
-           tangentialGMBolusVelAtBottom(iEdge) = 0.0_RKIND
-           do i = 1, nEdgesOnEdge(iEdge)
-             eoe = edgesOnEdge(i,iEdge)
-             tangentialGMBolusVelAtSFC(iEdge) = tangentialGMBolusVelAtSFC(iEdge) + weightsOnEdge(i,iEdge) * normalGMBolusVelAtSFC(eoe)
-             tangentialGMBolusVelAt250m(iEdge) = tangentialGMBolusVelAt250m(iEdge) + weightsOnEdge(i,iEdge) * normalGMBolusVelAt250m(eoe)
-             tangentialGMBolusVelAtBottom(iEdge) = tangentialGMBolusVelAtBottom(iEdge) + weightsOnEdge(i,iEdge) * normalGMBolusVelAtBottom(eoe)
-           end do
-
-           zonalGMBolusVelAtSFC(iEdge) = normalGMBolusVelAtSFC(iEdge)*cos(angleEdge(iEdge)) &
-             - tangentialGMBolusVelAtSFC(iEdge)*sin(angleEdge(iEdge))
-           meridionalGMBolusVelAtSFC(iEdge) = normalGMBolusVelAtSFC(iEdge)*sin(angleEdge(iEdge)) &
-             + tangentialGMBolusVelAtSFC(iEdge)*cos(angleEdge(iEdge))
-
-           zonalGMBolusVelAt250m(iEdge) = normalGMBolusVelAt250m(iEdge)*cos(angleEdge(iEdge)) &
-             - tangentialGMBolusVelAt250m(iEdge)*sin(angleEdge(iEdge))
-           meridionalGMBolusVelAt250m(iEdge) = normalGMBolusVelAt250m(iEdge)*sin(angleEdge(iEdge)) &
-             + tangentialGMBolusVelAt250m(iEdge)*cos(angleEdge(iEdge))
-
-           zonalGMBolusVelAtBottom(iEdge) = normalGMBolusVelAtBottom(iEdge)*cos(angleEdge(iEdge)) &
-             - tangentialGMBolusVelAtBottom(iEdge)*sin(angleEdge(iEdge))
-           meridionalGMBolusVelAtBottom(iEdge) = normalGMBolusVelAtBottom(iEdge)*sin(angleEdge(iEdge)) &
-             + tangentialGMBolusVelAtBottom(iEdge)*cos(angleEdge(iEdge))
          end do
 
          do iCell=1,nCells

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -174,13 +174,13 @@ contains
       real (kind=RKIND), dimension(:,:), allocatable :: pressureAdjustedForLandIce 
 
       real (kind=RKIND), dimension(:), pointer :: tThreshMLD, tGradientMLD, landIceDraft
-      real (kind=RKIND), dimension(:), pointer :: dThreshMLD, dGradientMLD, landIcePressure
+      real (kind=RKIND), dimension(:), pointer :: dGradientMLD, landIcePressure
       integer, dimension(:), pointer :: landIceMask
       real (kind=RKIND), dimension(:,:,:), pointer :: tracers
       integer :: interp_local
       real (kind=RKIND), allocatable, dimension(:,:) :: densityGradient, temperatureGradient
-      real (kind=RKIND) :: mldTemp,dTempThres, dDenThres, dTempGrad, dDenGrad
-      real (kind=RKIND) :: dz,temp_ref_lev, den_ref_lev, dV, dVm1, dVp1, localVals(6)
+      real (kind=RKIND) :: mldTemp,dTempThres, dTempGrad, dDenGrad
+      real (kind=RKIND) :: dz,temp_ref_lev, dV, dVm1, dVp1, localVals(6)
       real (kind=RKIND), dimension(:), pointer :: latCell, lonCell
       err = 0
 
@@ -293,73 +293,6 @@ contains
                end if
 
           end if !end tThresh MLD search
-
-         if(config_AM_mixedLayerDepths_Dthreshold) then
-            call mpas_pool_get_array(mixedLayerDepthsAMPool, 'dThreshMLD',dThreshMLD)
-
-            !$omp parallel
-            !$omp do schedule(runtime) &
-            !$omp private(refIndex, found_den_mld, k, localvals, den_ref_lev, dVp1, dV, mldTemp)
-            do iCell = 1,nCells
-
-               !Initialize RefIndex for cases of very shallow columns
-               refIndex = maxLevelCell(iCell)
-               found_den_mld = .false.
-
-               do k=1, maxLevelCell(iCell)-1
-                  if(pressureAdjustedForLandIce(k+1,iCell) > config_AM_mixedLayerDepths_reference_pressure) then
-                     localvals(2:3)=potentialDensity(k:k+1,iCell)
-                     localvals(5:6)=pressureAdjustedForLandIce(k:k+1,iCell)
-
-                     call interp_bw_levels(localVals(2),localVals(3),localVals(5),localVals(6), &
-                                   config_AM_mixedLayerDepths_reference_pressure,interp_local,den_ref_lev)
-                     refIndex=k
-                    exit
-                   end if
-               end do
-
-               do k=refIndex,maxLevelCell(iCell)-1
-
-                    if(.not. found_den_mld .and. abs(potentialDensity(k+1,iCell) - den_ref_lev) .ge. &
-                             config_AM_mixedLayerDepths_crit_dens_threshold) then
-                        dVp1 = abs(potentialDensity(k+1,iCell) - den_ref_lev)
-                        dV   = abs(potentialDensity(k  ,iCell) - den_ref_lev)
-                        localVals(2:3)=zMid(k:k+1,iCell)
-                        call interp_bw_levels(localVals(2),localVals(3), dV, dVp1, config_AM_mixedLayerDepths_crit_dens_threshold,     &
-                                   interp_local, mldTemp)!, dVm1, localVals(1))
-                        mldTemp=max(mldTemp,zMid(k+1,iCell)) !make sure MLD isn't deeper than zMid(k+1)
-                        dThreshMLD(iCell)=abs(min(mldTemp,zMid(k,iCell))) !MLD should be deeper than zMid(k)
-                        indMLD(iCell) = k+1
-                        found_den_mld = .true.
-                        exit
-                     end if
-               end do
-
-! if the mixed layer depth is not found, it is set to the depth of the bottom most level
-
-                    if(.not. found_den_mld) then
-                      dThreshMLD(iCell) = abs(zMid(maxLevelCell(iCell),iCell))
-                      indMLD(iCell) = maxLevelCell(iCell)
-                    end if
-             end do !iCell
-             !$omp end do
-             !$omp end parallel
-
-             if (associated(landIceMask) ) then
-               !$omp parallel
-               !$omp do schedule(runtime)
-               do iCell = 1, nCells
-                  dThreshMLD(iCell) = dThreshMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
-               end do
-               !$omp end do
-               !$omp end parallel
-
-
-             end if
-
-
-        end if !end dThresh MLD search
-
 
 ! Compute the mixed layer depth based on a gradient threshold in temperature and density
         if(config_AM_mixedLayerDepths_Tgradient) then

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -30,6 +30,7 @@ module ocn_mixed_layer_depths
    use ocn_constants
    use ocn_config
    use ocn_diagnostics_variables
+   use ocn_eddy_parameterization_helpers
 
    implicit none
    private
@@ -216,6 +217,9 @@ contains
          call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
          call mpas_pool_get_array(meshPool, 'latCell', latCell)
          call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
+
+         !need to call the mixed layer depth computation for compute on startup 
+         call ocn_eddy_compute_mixed_layer_depth(statePool, forcingPool)
 
          nCells = nCellsArray( size(nCellsArray) )
          allocate(pressureAdjustedForLandIce(nVertLevels, size(pressure,2)))

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_heat_budget.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_heat_budget.F
@@ -103,17 +103,7 @@ contains
       !
       !-----------------------------------------------------------------
 
-      logical, pointer :: dThresholdFlag, mldON
       err = 0
-
-      call mpas_pool_get_config(domain%configs, 'config_AM_mixedLayerDepths_Dthreshold', dThresholdFlag)
-      call mpas_pool_get_config(domain%configs, 'config_AM_mixedLayerDepths_enable', mldON)
-
-      if (.not. mldON .and. .not. dThresholdFlag) THEN
-         call mpas_log_write("ML Heat Budget AM requires config_AM_mixedLayerDepths_enable and " &
-                             //"config_AM_mixedLayerDepths_Dthreshold to both be true", MPAS_LOG_CRIT)
-         err = 1
-      endif
 
    end subroutine ocn_init_mixed_layer_heat_budget !}}}
 
@@ -184,7 +174,7 @@ contains
           activeTracerNonLocalMLTend, activeTracerHorMixMLTend, activeTracerVertMixMLTend, &
           activeTracerHorAdvectionMLTend, activeTracerVertAdvectionMLTend, activeTracersML, &
           layerThickness, activeTracersTendML
-      real(kind=RKIND), dimension(:), pointer ::  dThreshMLD, bruntVaisalaFreqML
+      real(kind=RKIND), dimension(:), pointer :: bruntVaisalaFreqML
       real(kind=RKIND) :: depth, difference
       err = 0
 
@@ -222,7 +212,6 @@ contains
          call mpas_pool_get_array(mixedLayerHeatBudgetAMPool, 'activeTracersML', activeTracersML)
          call mpas_pool_get_array(mixedLayerHeatBudgetAMPool, 'activeTracersTendML', activeTracersTendML)
          call mpas_pool_get_array(mixedLayerHeatBudgetAMPool, 'bruntVaisalaFreqML', bruntVaisalaFreqML)
-         call mpas_pool_get_array(mixedLayerDepthsAMPool, 'dThreshMLD', dThreshMLD)
          call mpas_pool_get_dimension(tracersPool, 'index_temperature', index_temperature)
          call mpas_pool_get_array(tracersPool, 'activeTracers', tracers, timeLevel)
          call mpas_pool_get_array(tracerTendPool, 'activeTracersTend', tracerTend)

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_moc_streamfunction.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_moc_streamfunction.F
@@ -510,8 +510,8 @@ contains
             end do
             do k = 2, nVertLevels
                mocStreamValLatAndDepthRegionLocal(1, k, iTransect) = &
-                  mocStreamValLatAndDepthRegionLocal(1, k + 1, iTransect) &
-                  + sumTransport(k + 1, iTransect)
+                  mocStreamValLatAndDepthRegionLocal(1, k - 1, iTransect) &
+                  + sumTransport(k - 1, iTransect)
             end do
          end do
 
@@ -608,8 +608,8 @@ contains
               end do
               do k = 2, nVertLevels
                  mocStreamValLatAndDepthRegionLocal(1, k, iTransect) = &
-                    mocStreamValLatAndDepthRegionLocal(1, k + 1, iTransect) &
-                    + sumTransport(k + 1, iTransect)
+                    mocStreamValLatAndDepthRegionLocal(1, k - 1, iTransect) &
+                    + sumTransport(k - 1, iTransect)
               end do
            end do
 
@@ -714,8 +714,8 @@ contains
               end do
               do k = 2, nVertLevels
                  mocStreamValLatAndDepthRegionLocal(1, k, iTransect) = &
-                    mocStreamValLatAndDepthRegionLocal(1, k + 1, iTransect) &
-                    + sumTransport(k + 1, iTransect)
+                    mocStreamValLatAndDepthRegionLocal(1, k - 1, iTransect) &
+                    + sumTransport(k - 1, iTransect)
               end do
            end do
 

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_moc_streamfunction.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_moc_streamfunction.F
@@ -578,7 +578,6 @@ contains
            call mpas_pool_get_dimension(block % dimensions, 'nEdgesSolve', nEdgesSolve)
            call mpas_pool_get_array(transectPool,'transectEdgeMaskSigns',transectEdgeMaskSigns)
            call mpas_pool_get_array(transectPool,'transectEdgeMasks',transectEdgeMasks)
-           normalVelocity => normalGMBolusVelocity
            call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
            call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
            call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
@@ -602,18 +601,14 @@ contains
                     sumTransport(k,iTransect) = sumTransport(k,iTransect) + &
                        transectEdgeMaskSigns(currentTransect,iEdge) &
                        * transectEdgeMasks(currentTransect, iEdge) &
-                       * (normalMLEvelocity(k,iEdge) + normalVelocity(k,iEdge)) &
-                       *dvEdge(iEdge) &
+                       * normalGMBolusVelocity(k,iEdge)*dvEdge(iEdge) &
                        * 0.5_RKIND*(layerThickness(k,c1) + layerThickness(k,c2))
                  end do
               end do
-          !    do k = 2, nVertLevels
-
-              mocStreamValLatAndDepthRegionLocal(1, nVertLevels, iTransect) = -sumTransport(nVertLevels,iTransect)
-              do k = nVertLevels-1,1,-1
+              do k = 2, nVertLevels
                  mocStreamValLatAndDepthRegionLocal(1, k, iTransect) = &
                     mocStreamValLatAndDepthRegionLocal(1, k + 1, iTransect) &
-                    - sumTransport(k + 1, iTransect)
+                    + sumTransport(k + 1, iTransect)
               end do
            end do
 
@@ -625,12 +620,11 @@ contains
                  do i = 1, regionsInAddGroup
                     currentRegion = regionsInGroup(i, regionGroupNumber)
                     sumVertBinVelocityRegion(iBin, k, i) = sumVertBinVelocityRegion(iBin, k, i) + &
-                          ((vertGMBolusVelocityTop(k, iCell) +vertMLEBolusVelocityTop(k,iCell)) * &
+                          (vertGMBolusVelocityTop(k, iCell) * &
                           areaCell(iCell) * regionCellMasks(currentRegion, iCell))
                  end do
                  sumVertBinVelocity(iBin, k) = sumVertBinVelocity(iBin, k) + &
-                          ((vertGMBolusVelocityTop(k, iCell) + vertMLEBolusVelocityTop(k,iCell)) &
-                          * areaCell(iCell))
+                          (vertGMBolusVelocityTop(k, iCell) * areaCell(iCell))
               end do
            end do
 
@@ -664,6 +658,112 @@ contains
        !Add GM bolus contribution to resolved streamfunction to create total streamfunction
        mocStreamvalLatAndDepthRegion = mocStreamvalLatAndDepthRegion + mocStreamvalLatAndDepthRegionGM
        mocStreamvalLatAndDepth = mocStreamvalLatAndDepth + mocStreamvalLatAndDepthGM
+
+     endif !config_use_GM
+
+     if(config_submesoscale_enable) THEN !compute submesoscale eddy bolus contribution to the streamfunction
+       block => domain % blocklist
+       do while (associated(block))
+           call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+           call mpas_pool_get_subpool(block % structs, 'mocStreamfunctionAM', mocStreamfunctionAMPool)
+
+           call mpas_pool_get_array(mocStreamfunctionAMPool, 'binBoundaryMocStreamfunction', binBoundaryMocStreamfunction)
+
+           binWidth = (binBoundaryMocStreamfunction(nMocStreamfunctionBinsUsed + 1) - binBoundaryMocStreamfunction(1)) &
+           / nMocStreamfunctionBinsUsed
+
+           call mpas_pool_get_dimension(block % dimensions, 'nCellsSolve', nCellsSolve)
+
+           call mpas_pool_get_array(meshPool, 'latCell', latCell)
+           call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
+
+           call mpas_pool_get_array(regionPool, 'regionCellMasks', regionCellMasks)
+
+           !!!! TRANSECT DOMAINSPLIT VARIABLES
+           call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+           call mpas_pool_get_dimension(block % dimensions, 'nEdgesSolve', nEdgesSolve)
+           call mpas_pool_get_array(transectPool,'transectEdgeMaskSigns',transectEdgeMaskSigns)
+           call mpas_pool_get_array(transectPool,'transectEdgeMasks',transectEdgeMasks)
+           call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
+           call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
+           call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+           call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
+
+           !!!! TRANSECT CALCULATION
+           sumTransport = 0.0_RKIND
+           mocStreamValLatAndDepthLocal = 0.0_RKIND
+           mocStreamValLatAndDepthTotal = 0.0_RKIND
+           sumVertBinVelocity = 0.0_RKIND
+           mocStreamValLatAndDepthRegionLocal = 0.0_RKIND
+           mocStreamValLatAndDepthRegionTotal = 0.0_RKIND
+           sumVertBinVelocityRegion = 0.0_RKIND
+
+           do iTransect = 1,transectsInAddGroup
+              currentTransect = transectsInGroup(iTransect, transectGroupNumber)
+              do iEdge = 1,nEdgesSolve
+                 c1 = cellsOnEdge(1,iEdge)
+                 c2 = cellsOnEdge(2,iEdge)
+                 do k = 1, maxLevelEdgeTop(iEdge)
+                    sumTransport(k,iTransect) = sumTransport(k,iTransect) + &
+                       transectEdgeMaskSigns(currentTransect,iEdge) &
+                       * transectEdgeMasks(currentTransect, iEdge) &
+                       * normalMLEvelocity(k,iEdge)*dvEdge(iEdge) &
+                       * 0.5_RKIND*(layerThickness(k,c1) + layerThickness(k,c2))
+                 end do
+              end do
+              do k = 2, nVertLevels
+                 mocStreamValLatAndDepthRegionLocal(1, k, iTransect) = &
+                    mocStreamValLatAndDepthRegionLocal(1, k + 1, iTransect) &
+                    + sumTransport(k + 1, iTransect)
+              end do
+           end do
+
+           !!!! END TRANSECT CALCULATION
+
+           do iCell = 1,nCellsSolve
+              iBin = MAX(int((latCell(iCell) - binBoundaryMocStreamfunction(1)) / binWidth), 2)
+              do k = 1,maxLevelCell(iCell)
+                 do i = 1, regionsInAddGroup
+                    currentRegion = regionsInGroup(i, regionGroupNumber)
+                    sumVertBinVelocityRegion(iBin, k, i) = sumVertBinVelocityRegion(iBin, k, i) + &
+                          (vertMLEBolusVelocityTop(k,iCell) * &
+                          areaCell(iCell) * regionCellMasks(currentRegion, iCell))
+                 end do
+                 sumVertBinVelocity(iBin, k) = sumVertBinVelocity(iBin, k) + &
+                          (vertMLEBolusVelocityTop(k,iCell) * areaCell(iCell))
+              end do
+           end do
+
+           do i = 1, regionsInAddGroup
+              do k = 1,nVertLevels
+                 do iBin = 2, nMocStreamfunctionBinsUsed + 1
+                    mocStreamValLatAndDepthLocal(iBin, k) = mocStreamValLatAndDepthLocal(iBin-1, k) &
+                       + sumVertBinVelocity(iBin, k)
+                    mocStreamValLatAndDepthRegionLocal(iBin, k, i) = mocStreamValLatAndDepthRegionLocal(iBin-1, k, i) &
+                       + sumVertBinVelocityRegion(iBin, k, i)
+                 end do
+              end do
+           end do
+
+           block => block % next
+       end do
+
+       call mpas_dmpar_sum_real_array(dminfo, nVertLevels * (nMocStreamfunctionBinsUsed + 1), mocStreamValLatAndDepthLocal, &
+           mocStreamvalLatAndDepthTotal)
+
+       call mpas_dmpar_sum_real_array(dminfo, nVertLevels * (nMocStreamfunctionBinsUsed + 1) * maxRegionsInGroup, &
+           mocStreamValLatAndDepthRegionLocal, mocStreamvalLatAndDepthRegionTotal)
+
+       call mpas_pool_get_subpool(domain % blocklist % structs, 'mocStreamfunctionAM', mocStreamfunctionAMPool)
+       call mpas_pool_get_array(mocStreamfunctionAMPool, 'mocStreamvalLatAndDepthMLE', mocStreamvalLatAndDepthMLE)
+       mocStreamvalLatAndDepthMLE = mocStreamvalLatAndDepthTotal * m3ps_to_Sv
+
+       call mpas_pool_get_array(mocStreamfunctionAMPool, 'mocStreamvalLatAndDepthRegionMLE', mocStreamvalLatAndDepthRegionMLE)
+       mocStreamvalLatAndDepthRegionMLE = mocStreamvalLatAndDepthRegionTotal * m3ps_to_Sv
+
+       !Add submesoscale eddy bolus contribution to resolved streamfunction to create total streamfunction
+       mocStreamvalLatAndDepthRegion = mocStreamvalLatAndDepthRegion + mocStreamvalLatAndDepthRegionMLE
+       mocStreamvalLatAndDepth = mocStreamvalLatAndDepth + mocStreamvalLatAndDepthMLE
 
      endif !config_use_GM
 

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_moc_streamfunction.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_moc_streamfunction.F
@@ -507,10 +507,12 @@ contains
                      * 0.5_RKIND*(layerThickness(k,c1) + layerThickness(k,c2))
                end do
             end do
-            do k = 2, nVertLevels
+            mocStreamValLatAndDepthRegionLocal(1, nVertLevels, iTransect) = &
+                  - sumTransport(nVertLevels, iTransect)
+            do k = nVertLevels-1,1,-1
                mocStreamValLatAndDepthRegionLocal(1, k, iTransect) = &
-                  mocStreamValLatAndDepthRegionLocal(1, k - 1, iTransect) &
-                  + sumTransport(k - 1, iTransect)
+                  mocStreamValLatAndDepthRegionLocal(1, k + 1, iTransect) &
+                  - sumTransport(k + 1, iTransect)
             end do
          end do
 
@@ -602,14 +604,18 @@ contains
                     sumTransport(k,iTransect) = sumTransport(k,iTransect) + &
                        transectEdgeMaskSigns(currentTransect,iEdge) &
                        * transectEdgeMasks(currentTransect, iEdge) &
-                       * normalVelocity(k,iEdge)*dvEdge(iEdge) &
+                       * (normalMLEvelocity(k,iEdge) + normalVelocity(k,iEdge)) &
+                       *dvEdge(iEdge) &
                        * 0.5_RKIND*(layerThickness(k,c1) + layerThickness(k,c2))
                  end do
               end do
-              do k = 2, nVertLevels
+          !    do k = 2, nVertLevels
+
+              mocStreamValLatAndDepthRegionLocal(1, nVertLevels, iTransect) = -sumTransport(nVertLevels,iTransect)
+              do k = nVertLevels-1,1,-1
                  mocStreamValLatAndDepthRegionLocal(1, k, iTransect) = &
-                    mocStreamValLatAndDepthRegionLocal(1, k - 1, iTransect) &
-                    + sumTransport(k - 1, iTransect)
+                    mocStreamValLatAndDepthRegionLocal(1, k + 1, iTransect) &
+                    - sumTransport(k + 1, iTransect)
               end do
            end do
 
@@ -620,10 +626,13 @@ contains
               do k = 1,maxLevelCell(iCell)
                  do i = 1, regionsInAddGroup
                     currentRegion = regionsInGroup(i, regionGroupNumber)
-                    sumVertBinVelocityRegion(iBin, k, i) = sumVertBinVelocityRegion(iBin, k, i) + (vertGMBolusVelocityTop(k, iCell) * &
+                    sumVertBinVelocityRegion(iBin, k, i) = sumVertBinVelocityRegion(iBin, k, i) + &
+                          ((vertGMBolusVelocityTop(k, iCell) +vertMLEBolusVelocityTop(k,iCell)) * &
                           areaCell(iCell) * regionCellMasks(currentRegion, iCell))
                  end do
-                 sumVertBinVelocity(iBin, k) = sumVertBinVelocity(iBin, k) + (vertGMBolusVelocityTop(k, iCell) * areaCell(iCell))
+                 sumVertBinVelocity(iBin, k) = sumVertBinVelocity(iBin, k) + &
+                          ((vertGMBolusVelocityTop(k, iCell) + vertMLEBolusVelocityTop(k,iCell)) &
+                          * areaCell(iCell))
               end do
            end do
 

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_moc_streamfunction.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_moc_streamfunction.F
@@ -507,12 +507,10 @@ contains
                      * 0.5_RKIND*(layerThickness(k,c1) + layerThickness(k,c2))
                end do
             end do
-            mocStreamValLatAndDepthRegionLocal(1, nVertLevels, iTransect) = &
-                  - sumTransport(nVertLevels, iTransect)
-            do k = nVertLevels-1,1,-1
+            do k = 2, nVertLevels
                mocStreamValLatAndDepthRegionLocal(1, k, iTransect) = &
                   mocStreamValLatAndDepthRegionLocal(1, k + 1, iTransect) &
-                  - sumTransport(k + 1, iTransect)
+                  + sumTransport(k + 1, iTransect)
             end do
          end do
 

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_moc_streamfunction.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_moc_streamfunction.F
@@ -327,7 +327,7 @@ contains
       real (kind=RKIND), dimension(:), pointer :: latCell
       real (kind=RKIND), dimension(:), pointer ::  areaCell, binBoundaryMocStreamfunction
       real (kind=RKIND), dimension(:,:), pointer :: mocStreamvalLatAndDepth, mocStreamValLatAndDepthTotal
-      real (kind=RKIND), dimension(:,:), pointer :: mocStreamvalLatAndDepthGM
+      real (kind=RKIND), dimension(:,:), pointer :: mocStreamvalLatAndDepthGM, mocStreamvalLatAndDepthMLE
       real (kind=RKIND), dimension(:,:), pointer :: sumVertBinVelocity
 
       !!!! TRANSECT VARIABLES !!!!
@@ -352,7 +352,8 @@ contains
       integer :: currentRegion, i
       real (kind=RKIND), dimension(:,:,:), pointer :: mocStreamValLatAndDepthRegionLocal, &
                          mocStreamvalLatAndDepthRegion, mocStreamValLatAndDepthRegionTotal, &
-                         sumVertBinVelocityRegion, mocStreamvalLatAndDepthRegionGM
+                         sumVertBinVelocityRegion, mocStreamvalLatAndDepthRegionGM, &
+                         mocStreamvalLatAndDepthRegionMLE
       integer, dimension(:, :), pointer :: regionCellMasks, regionVertexMasks, regionsInGroup
       character (len=STRKIND), dimension(:), pointer :: regionNames, regionGroupNames
       integer, dimension(:), pointer ::  nRegionsInGroup

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_moc_streamfunction.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_moc_streamfunction.F
@@ -766,7 +766,7 @@ contains
        mocStreamvalLatAndDepthRegion = mocStreamvalLatAndDepthRegion + mocStreamvalLatAndDepthRegionMLE
        mocStreamvalLatAndDepth = mocStreamvalLatAndDepth + mocStreamvalLatAndDepthMLE
 
-     endif !config_use_GM
+     endif !config_submesoscale_enable
 
      deallocate(mocStreamvalLatAndDepthTotal)
      deallocate(mocStreamvalLatAndDepthLocal)

--- a/components/mpas-ocean/src/driver/mpas_ocn_core_interface.F
+++ b/components/mpas-ocean/src/driver/mpas_ocn_core_interface.F
@@ -130,6 +130,7 @@ module ocn_core_interface
       logical, pointer :: inSituEOSActive
       logical, pointer :: variableShortwaveActive
       logical, pointer :: gmActive
+      logical, pointer :: submesoActive
       logical, pointer :: timeVaryingAtmosphericForcingPKGActive
       logical, pointer :: timeVaryingLandIceForcingPKGActive
       logical, pointer :: gotmPKGActive
@@ -161,6 +162,7 @@ module ocn_core_interface
       logical, pointer :: config_use_tidal_potential_forcing
       logical, pointer :: config_use_topographic_wave_drag
       logical, pointer :: config_use_GM
+      logical, pointer :: config_submesoscale_enable
       logical, pointer :: config_use_Redi
       logical, pointer :: config_use_vegetation_drag
       logical, pointer :: config_use_time_varying_atmospheric_forcing
@@ -353,6 +355,15 @@ module ocn_core_interface
       call mpas_pool_get_config(configPool, 'config_use_Redi', config_use_Redi)
       if (config_use_GM.or.config_use_Redi) then
          gmActive = .true.
+      end if
+
+      !
+      ! test for use of gm
+      !
+      call mpas_pool_get_package(packagePool, 'submesoActive', submesoActive)
+      call mpas_pool_get_config(configPool, 'config_submesoscale_enable', config_submesoscale_enable)
+      if (config_submesoscale_enable) then
+         submesoActive = .true.
       end if
 
       ! test for time-varying forcing

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -43,6 +43,7 @@ module ocn_forward_mode
    use ocn_test
    use ocn_mesh
 
+   use ocn_eddy_parameterization_helpers
    use ocn_thick_hadv
    use ocn_thick_vadv
    use ocn_thick_ale
@@ -75,6 +76,7 @@ module ocn_forward_mode
    use ocn_tracer_CFC
    use ocn_tracer_surface_restoring
    use ocn_gm
+   use ocn_submesoscale_eddies
 
    use ocn_high_freq_thickness_hmix_del2
 
@@ -441,6 +443,8 @@ module ocn_forward_mode
       ierr = ior(ierr,err_tmp)
       call ocn_gm_init(domain, err_tmp)
       ierr = ior(ierr,err_tmp)
+      call ocn_submesoscale_init(err_tmp)
+      ierr = ior(ierr,err_tmp)
       call ocn_tracer_nonlocalflux_init(err_tmp)
       ierr = ior(ierr,err_tmp)
       call ocn_tracer_ecosys_init(domain, err_tmp)
@@ -675,6 +679,14 @@ module ocn_forward_mode
            call ocn_tidal_forcing_build_array(domain, meshPool, forcingPool, statePool, err)
 
            ! Compute normalGMBolusVelocity, relativeSlope and RediDiffVertCoef if respective flags are turned on
+
+           call ocn_eddy_compute_mixed_layer_depth(statePool)
+           if (config_use_GM.or.config_submesoscale_enable) then
+               call mpas_timer_start("submesoscale eddy velocity compute", .false.)
+               call ocn_eddy_compute_buoyancy_gradient()
+               call mpas_timer_stop("submesoscale eddy velocity compute")
+           end if
+
            if (config_use_Redi.or.config_use_GM) then
                call ocn_gm_compute_Bolus_velocity(statePool, meshPool, scratchPool, timeLevelIn=1)
            end if

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -680,8 +680,8 @@ module ocn_forward_mode
 
            ! Compute normalGMBolusVelocity, relativeSlope and RediDiffVertCoef if respective flags are turned on
 
-           call ocn_eddy_compute_mixed_layer_depth(statePool)
-           if (config_use_GM.or.config_submesoscale_enable) then
+           call ocn_eddy_compute_mixed_layer_depth(statePool, forcingPool)
+           if (config_use_GM .or. config_submesoscale_enable) then
                call mpas_timer_start("submesoscale eddy velocity compute", .false.)
                call ocn_eddy_compute_buoyancy_gradient()
                call mpas_timer_stop("submesoscale eddy velocity compute")
@@ -832,6 +832,8 @@ module ocn_forward_mode
       call ocn_analysis_finalize(domain, ierr)
 
       call ocn_vmix_gotm_finalize(domain, ierr)
+
+      call ocn_submesoscale_finalize()
 
       call mpas_destroy_clock(domain % clock, ierr)
 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -1320,6 +1320,7 @@ module ocn_time_integration_rk4
       end if
       if (config_submesoscale_enable) then
          !$acc update device (normalMLEvelocity)
+      end if
       !$acc enter data copyin(atmosphericPressure, seaIcePressure)
       !$acc enter data copyin(sshCur)
       !$acc enter data copyin(activeTracersCur)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -794,7 +794,7 @@ module ocn_time_integration_rk4
 
          ! add submesoscale aend gm components if requested
          call ocn_GM_add_to_transport_vel(normalTransportVelocity, nEdges, nVertLevels)
-         call ocn_MLE_add_to_transport_vel(normalTransportVelocity)
+         call ocn_MLE_add_to_transport_vel(normalTransportVelocity, nEdges)
 
          ! ------------------------------------------------------------------
          ! End: Accumulating various parameterizations of the transport velocity
@@ -964,7 +964,7 @@ module ocn_time_integration_rk4
 
       ! add submesoscale and GM contributions if requested
       call ocn_GM_add_to_transport_vel(normalTransportVelocity, nEdges, nVertLevels)
-      call ocn_MLE_add_to_transport_vel(normalTransportVelocity)
+      call ocn_MLE_add_to_transport_vel(normalTransportVelocity, nEdges)
 
       ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
       if (associated(highFreqThicknessProvis)) then
@@ -1036,7 +1036,7 @@ module ocn_time_integration_rk4
       !$omp end parallel
 
       call ocn_GM_add_to_transport_vel(normalTransportVelocity, nEdges, nVertLevels)
-      call ocn_MLE_add_to_transport_vel(normalTransportVelocity)
+      call ocn_MLE_add_to_transport_vel(normalTransportVelocity, nEdges)
 
       ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
       if (associated(highFreqThicknessProvis)) then
@@ -1387,7 +1387,7 @@ module ocn_time_integration_rk4
 
       ! add submesoscale and GM contributions if requested
       call ocn_GM_add_to_transport_vel(normalTransportVelocity, nEdges, nVertLevels)
-      call ocn_MLE_add_to_transport_vel(normalTransportVelocity)
+      call ocn_MLE_add_to_transport_vel(normalTransportVelocity, nEdges)
 
       ! ------------------------------------------------------------------
       ! End: Accumulating various parametrizations of the transport velocity

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -819,8 +819,8 @@ module ocn_time_integration_rk4
 
          call ocn_time_average_coupled_accumulate(statePool, forcingPool, 2)
 
-         if (config_use_GM) then
-            call ocn_reconstruct_gm_vectors(meshPool)
+         if (config_use_GM .or. config_submesoscale_enable) then
+            call ocn_reconstruct_eddy_vectors(meshPool)
          end if
 
          block => block % next

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -954,13 +954,15 @@ module ocn_time_integration_rk4
       call mpas_pool_get_array(provisStatePool, 'normalVelocity', normalVelocityProvis, 1)
       call mpas_pool_get_array(provisStatePool, 'highFreqThickness', highFreqThicknessProvis, 1)
 
-      !$omp parallel
-      !$omp do schedule(runtime)
-      do iEdge = 1, nEdges
-         normalTransportVelocity(:, iEdge) = normalVelocityProvis(:, iEdge)
-      end do
-      !$omp end do
-      !$omp end parallel
+      if (config_use_GM .or. config_submesoscale_enable) then
+         !$omp parallel
+         !$omp do schedule(runtime)
+         do iEdge = 1, nEdges
+            normalTransportVelocity(:, iEdge) = normalVelocityProvis(:, iEdge)
+         end do
+         !$omp end do
+         !$omp end parallel
+      end if
 
       ! add submesoscale and GM contributions if requested
       call ocn_GM_add_to_transport_vel(normalTransportVelocity, nEdges, nVertLevels)
@@ -1027,13 +1029,15 @@ module ocn_time_integration_rk4
       call mpas_pool_get_array(provisStatePool, 'normalVelocity', normalVelocityProvis, 1)
       call mpas_pool_get_array(provisStatePool, 'highFreqThickness', highFreqThicknessProvis, 1)
 
-      !$omp parallel
-      !$omp do schedule(runtime)
-      do iEdge = 1, nEdges
-         normalTransportVelocity(:, iEdge) = normalVelocityProvis(:, iEdge)
-      end do
-      !$omp end do
-      !$omp end parallel
+      if (config_use_GM .or. config_submesoscale_enable) then
+         !$omp parallel
+         !$omp do schedule(runtime)
+         do iEdge = 1, nEdges
+            normalTransportVelocity(:, iEdge) = normalVelocityProvis(:, iEdge)
+         end do
+         !$omp end do
+         !$omp end parallel
+      end if
 
       call ocn_GM_add_to_transport_vel(normalTransportVelocity, nEdges, nVertLevels)
       call ocn_MLE_add_to_transport_vel(normalTransportVelocity, nEdges)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -33,6 +33,7 @@ module ocn_time_integration_rk4
    use ocn_diagnostics
    use ocn_diagnostics_variables
    use ocn_gm
+   use ocn_submesoscale_eddies
 
    use ocn_equation_of_state
    use ocn_vmix
@@ -644,6 +645,7 @@ module ocn_time_integration_rk4
 
          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
          call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
+         call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
          call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
          call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
          call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
@@ -710,8 +712,13 @@ module ocn_time_integration_rk4
 
 #ifdef MPAS_OPENACC
          !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
-         !$acc update device (normalTransportVelocity, &
-         !$acc                normalGMBolusVelocity, normalMLEvelocity)
+         !$acc update device (normalTransportVelocity)
+         if (config_use_gm) then
+            !$acc update device (normalGMBolusVelocity)
+         end if
+         if (config_submesoscale_enable) then
+            !$acc update device (normalMLEvelocity)
+         end if
          !$acc enter data copyin(atmosphericPressure, seaIcePressure)
          !$acc enter data copyin(sshNew)
          !$acc enter data copyin(activeTracersNew)
@@ -732,8 +739,13 @@ module ocn_time_integration_rk4
 #ifdef MPAS_OPENACC
          !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
          !$acc update host(relativeVorticity, circulation)
+         if (config_use_gm) then
+            !$acc update host(vertGMBolusVelocityTop)
+         end if
+         if (config_submesoscale_enable) then
+            !$acc update host(vertMLEBolusVelocityTop)
+         end if
          !$acc update host(vertTransportVelocityTop, &
-         !$acc             vertGMBolusVelocityTop, &
          !$acc             relativeVorticityCell, &
          !$acc             divergence, &
          !$acc             kineticEnergyCell, &
@@ -780,17 +792,10 @@ module ocn_time_integration_rk4
          !$omp end do
          !$omp end parallel
 
-         if (config_use_GM) then
-            !$omp parallel
-            !$omp do schedule(runtime)
-            do iEdge = 1, nEdges
-               normalTransportVelocity(:, iEdge) = normalTransportVelocity(:, iEdge) + &
-                                                   normalGMBolusVelocity(:, iEdge)   + &
-                                                   normalMLEvelocity(:, iEdge)
-            end do
-            !$omp end do
-            !$omp end parallel
-         end if
+         ! add submesoscale aend gm components if requested
+         call ocn_GM_add_to_transport_vel(normalTransportVelocity, nEdges, nVertLevels)
+         call ocn_MLE_add_to_transport_vel(normalTransportVelocity)
+
          ! ------------------------------------------------------------------
          ! End: Accumulating various parameterizations of the transport velocity
          ! ------------------------------------------------------------------
@@ -923,7 +928,7 @@ module ocn_time_integration_rk4
       real (kind=RKIND), dimension(:, :), pointer ::  normalVelocityProvis, highFreqThicknessProvis
 
       integer :: iEdge
-      integer, pointer :: nEdges
+      integer, pointer :: nEdges, nVertLevels
       logical, pointer :: config_filter_btr_mode
 
       err = 0
@@ -941,6 +946,7 @@ module ocn_time_integration_rk4
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
       call mpas_pool_get_dimension(block % dimensions, 'nEdges', nEdges)
+      call mpas_pool_get_dimension(block % dimensions, 'nVertLevels', nVertLevels)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
       call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityCur, 1)
@@ -948,17 +954,17 @@ module ocn_time_integration_rk4
       call mpas_pool_get_array(provisStatePool, 'normalVelocity', normalVelocityProvis, 1)
       call mpas_pool_get_array(provisStatePool, 'highFreqThickness', highFreqThicknessProvis, 1)
 
-      if (config_use_GM) then
-            !$omp parallel
-            !$omp do schedule(runtime)
-            do iEdge = 1, nEdges
-               normalTransportVelocity(:, iEdge) = normalVelocityProvis(:, iEdge)  + &
-                                                   normalGMBolusVelocity(:, iEdge) + &
-                                                   normalMLEvelocity(:, iEdge)
-            end do
-            !$omp end do
-            !$omp end parallel
-         end if
+      !$omp parallel
+      !$omp do schedule(runtime)
+      do iEdge = 1, nEdges
+         normalTransportVelocity(:, iEdge) = normalVelocityProvis(:, iEdge)
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      ! add submesoscale and GM contributions if requested
+      call ocn_GM_add_to_transport_vel(normalTransportVelocity, nEdges, nVertLevels)
+      call ocn_MLE_add_to_transport_vel(normalTransportVelocity)
 
       ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
       if (associated(highFreqThicknessProvis)) then
@@ -996,7 +1002,7 @@ module ocn_time_integration_rk4
       logical, pointer :: config_filter_btr_mode
 
       integer :: iEdge
-      integer, pointer :: nEdges
+      integer, pointer :: nEdges, nVertLevels
       err = 0
 
       call mpas_pool_get_config(block % configs, 'config_filter_btr_mode', config_filter_btr_mode)
@@ -1013,6 +1019,7 @@ module ocn_time_integration_rk4
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
       call mpas_pool_get_dimension(block % dimensions, 'nEdges', nEdges)
+      call mpas_pool_get_dimension(block % dimensions, 'nVertLevels', nVertLevels)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThicknessCur, 1)
       call mpas_pool_get_array(statePool, 'ssh', sshCur, 1)
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityCur, 1)
@@ -1020,17 +1027,16 @@ module ocn_time_integration_rk4
       call mpas_pool_get_array(provisStatePool, 'normalVelocity', normalVelocityProvis, 1)
       call mpas_pool_get_array(provisStatePool, 'highFreqThickness', highFreqThicknessProvis, 1)
 
-      if (config_use_GM) then
-         !$omp parallel
-         !$omp do schedule(runtime)
-         do iEdge = 1, nEdges
-            normalTransportVelocity(:, iEdge) = normalVelocityProvis(:, iEdge) + &
-                                                normalGMBolusVelocity(:,iEdge) + &
-                                                normalMLEvelocity(:,iEdge)
-         end do
-         !$omp end do
-         !$omp end parallel
-      end if
+      !$omp parallel
+      !$omp do schedule(runtime)
+      do iEdge = 1, nEdges
+         normalTransportVelocity(:, iEdge) = normalVelocityProvis(:, iEdge)
+      end do
+      !$omp end do
+      !$omp end parallel
+
+      call ocn_GM_add_to_transport_vel(normalTransportVelocity, nEdges, nVertLevels)
+      call ocn_MLE_add_to_transport_vel(normalTransportVelocity)
 
       ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
       if (associated(highFreqThicknessProvis)) then
@@ -1141,7 +1147,7 @@ module ocn_time_integration_rk4
 
       logical, pointer :: config_prescribe_velocity, config_prescribe_thickness, config_use_GM
 
-      integer, pointer :: nCells, nEdges
+      integer, pointer :: nCells, nEdges, nVertLevels
       integer :: iCell, iEdge, k
 
       type (mpas_pool_type), pointer :: statePool, tendPool, meshPool, scratchPool
@@ -1179,7 +1185,7 @@ module ocn_time_integration_rk4
 
       call mpas_pool_get_dimension(block % dimensions, 'nCells', nCells)
       call mpas_pool_get_dimension(block % dimensions, 'nEdges', nEdges)
-
+      call mpas_pool_get_dimension(block % dimensions, 'nVertLevels', nVertLevels)
       call mpas_pool_get_subpool(block % structs, 'state', statePool)
       call mpas_pool_get_subpool(block % structs, 'tend', tendPool)
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
@@ -1304,8 +1310,12 @@ module ocn_time_integration_rk4
 
 #ifdef MPAS_OPENACC
       !$acc enter data copyin(layerThicknessCur, normalVelocityCur)
-      !$acc update device (normalTransportVelocity, &
-      !$acc                normalGMBolusVelocity,normalMLEvelocity)
+      !$acc update device (normalTransportVelocity)
+      if (config_use_gm) then
+         !$acc update device (normalGMBolusVelocity)
+      end if
+      if (config_submesoscale_enable) then
+         !$acc update device (normalMLEvelocity)
       !$acc enter data copyin(atmosphericPressure, seaIcePressure)
       !$acc enter data copyin(sshCur)
       !$acc enter data copyin(activeTracersCur)
@@ -1322,8 +1332,13 @@ module ocn_time_integration_rk4
 #ifdef MPAS_OPENACC
       !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
       !$acc update host(relativeVorticity, circulation)
+      if (config_use_gm) then
+         !$acc update host(vertGMBolusVelocityTop)
+      end if
+      if (config_submesoscale_enable) then
+         !$acc update host(vertMLEBolusVelocityTop)
+      end if
       !$acc update host(vertTransportVelocityTop, &
-      !$acc             vertGMBolusVelocityTop, &
       !$acc             relativeVorticityCell, &
       !$acc             divergence, &
       !$acc             kineticEnergyCell, &
@@ -1370,17 +1385,10 @@ module ocn_time_integration_rk4
       !$omp end do
       !$omp end parallel
 
-      if (config_use_GM) then
-         !$omp parallel
-         !$omp do schedule(runtime)
-         do iEdge = 1, nEdges
-            normalTransportVelocity(:, iEdge) = normalTransportVelocity(:, iEdge) + &
-                                                   normalGMBolusVelocity(:,iEdge) + &
-                                                   normalMLEvelocity(:,iEdge)
-         end do
-         !$omp end do
-         !$omp end parallel
-      end if
+      ! add submesoscale and GM contributions if requested
+      call ocn_GM_add_to_transport_vel(normalTransportVelocity, nEdges, nVertLevels)
+      call ocn_MLE_add_to_transport_vel(normalTransportVelocity)
+
       ! ------------------------------------------------------------------
       ! End: Accumulating various parametrizations of the transport velocity
       ! ------------------------------------------------------------------
@@ -1598,6 +1606,12 @@ module ocn_time_integration_rk4
       !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
       !$acc update device (normalTransportVelocity, &
       !$acc                normalGMBolusVelocity,normalMLEvelocity)
+      if (config_use_gm) then
+         !$acc update device (normalGMBolusVelocity)
+      end if
+      if (config_submesoscale_enable) then
+         !$acc update device (normalMLEvelocity)
+      end if
       !$acc enter data copyin(atmosphericPressure, seaIcePressure)
       !$acc enter data copyin(sshNew)
       !$acc enter data copyin(activeTracersNew)
@@ -1614,8 +1628,13 @@ module ocn_time_integration_rk4
 #ifdef MPAS_OPENACC
       !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
       !$acc update host(relativeVorticity, circulation)
+      if (config_use_gm) then
+         !$acc update host(vertGMBolusVelocityTop)
+      end if
+      if (config_submesoscale_enable) then
+         !$acc update host(vertMLEBolusVelocityTop)
+      end if
       !$acc update host(vertTransportVelocityTop, &
-      !$acc             vertGMBolusVelocityTop, &
       !$acc             relativeVorticityCell, &
       !$acc             divergence, &
       !$acc             kineticEnergyCell, &

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -711,7 +711,7 @@ module ocn_time_integration_rk4
 #ifdef MPAS_OPENACC
          !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
          !$acc update device (normalTransportVelocity, &
-         !$acc                normalGMBolusVelocity)
+         !$acc                normalGMBolusVelocity, normalMLEvelocity)
          !$acc enter data copyin(atmosphericPressure, seaIcePressure)
          !$acc enter data copyin(sshNew)
          !$acc enter data copyin(activeTracersNew)
@@ -784,7 +784,9 @@ module ocn_time_integration_rk4
             !$omp parallel
             !$omp do schedule(runtime)
             do iEdge = 1, nEdges
-               normalTransportVelocity(:, iEdge) = normalTransportVelocity(:, iEdge) + normalGMBolusVelocity(:, iEdge)
+               normalTransportVelocity(:, iEdge) = normalTransportVelocity(:, iEdge) + &
+                                                   normalGMBolusVelocity(:, iEdge)   + &
+                                                   normalMLEvelocity(:, iEdge)
             end do
             !$omp end do
             !$omp end parallel
@@ -950,7 +952,9 @@ module ocn_time_integration_rk4
             !$omp parallel
             !$omp do schedule(runtime)
             do iEdge = 1, nEdges
-               normalTransportVelocity(:, iEdge) = normalVelocityProvis(:, iEdge) + normalGMBolusVelocity(:, iEdge)
+               normalTransportVelocity(:, iEdge) = normalVelocityProvis(:, iEdge)  + &
+                                                   normalGMBolusVelocity(:, iEdge) + &
+                                                   normalMLEvelocity(:, iEdge)
             end do
             !$omp end do
             !$omp end parallel
@@ -1020,7 +1024,9 @@ module ocn_time_integration_rk4
          !$omp parallel
          !$omp do schedule(runtime)
          do iEdge = 1, nEdges
-            normalTransportVelocity(:, iEdge) = normalVelocityProvis(:, iEdge) + normalGMBolusVelocity(:,iEdge)
+            normalTransportVelocity(:, iEdge) = normalVelocityProvis(:, iEdge) + &
+                                                normalGMBolusVelocity(:,iEdge) + &
+                                                normalMLEvelocity(:,iEdge)
          end do
          !$omp end do
          !$omp end parallel
@@ -1299,7 +1305,7 @@ module ocn_time_integration_rk4
 #ifdef MPAS_OPENACC
       !$acc enter data copyin(layerThicknessCur, normalVelocityCur)
       !$acc update device (normalTransportVelocity, &
-      !$acc                normalGMBolusVelocity)
+      !$acc                normalGMBolusVelocity,normalMLEvelocity)
       !$acc enter data copyin(atmosphericPressure, seaIcePressure)
       !$acc enter data copyin(sshCur)
       !$acc enter data copyin(activeTracersCur)
@@ -1368,7 +1374,9 @@ module ocn_time_integration_rk4
          !$omp parallel
          !$omp do schedule(runtime)
          do iEdge = 1, nEdges
-            normalTransportVelocity(:, iEdge) = normalTransportVelocity(:, iEdge) + normalGMBolusVelocity(:,iEdge)
+            normalTransportVelocity(:, iEdge) = normalTransportVelocity(:, iEdge) + &
+                                                   normalGMBolusVelocity(:,iEdge) + &
+                                                   normalMLEvelocity(:,iEdge)
          end do
          !$omp end do
          !$omp end parallel
@@ -1589,7 +1597,7 @@ module ocn_time_integration_rk4
 #ifdef MPAS_OPENACC
       !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
       !$acc update device (normalTransportVelocity, &
-      !$acc                normalGMBolusVelocity)
+      !$acc                normalGMBolusVelocity,normalMLEvelocity)
       !$acc enter data copyin(atmosphericPressure, seaIcePressure)
       !$acc enter data copyin(sshNew)
       !$acc enter data copyin(activeTracersNew)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -340,7 +340,7 @@ module ocn_time_integration_si
       ! barotropicForcing, barotropicThicknessFlux
       ! layerThickEdgeFlux, layerThickEdgeMean,
       ! normalTransportVelocity, normalGMBolusVelocity
-      ! vertAleTransportTop
+      ! vertAleTransportTop, normalMLEvelocity
       ! velocityX, velocityY, velocityZ
       ! velocityZonal, velocityMeridional
       ! gradSSH, gradSSHX, gradSSHY, gradSSHZ
@@ -1677,7 +1677,8 @@ module ocn_time_integration_si
             ! normalBaroclinicVelocity + uBolus
             uTemp(:) = normalBarotropicVelocityNew(iEdge) &
                    + normalBaroclinicVelocityNew(:,iEdge) &
-                   +       normalGMBolusVelocity(:,iEdge)
+                   +       normalGMBolusVelocity(:,iEdge) &
+                   +           normalMLEvelocity(:,iEdge)
 
             ! thicknessSum is initialized outside the loop because
             ! on land boundaries maxLevelEdgeTop=0, but I want to
@@ -1717,6 +1718,7 @@ module ocn_time_integration_si
                         *(normalBarotropicVelocityNew(iEdge)   + &
                           normalBaroclinicVelocityNew(k,iEdge) + &
                           normalGMBolusVelocity(k,iEdge) + &
+                          normalMLEvelocity(k,iEdge) + &
                           normalVelocityCorrection )
             enddo
 
@@ -1875,7 +1877,7 @@ module ocn_time_integration_si
 #ifdef MPAS_OPENACC
             !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
             !$acc update device (normalTransportVelocity, &
-            !$acc                normalGMBolusVelocity)
+            !$acc                normalGMBolusVelocity, normalMLEvelocity)
             !$acc enter data copyin(atmosphericPressure, seaIcePressure)
             !$acc enter data copyin(sshNew)
             !$acc enter data copyin(activeTracersNew)
@@ -2276,7 +2278,7 @@ module ocn_time_integration_si
 #ifdef MPAS_OPENACC
       !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
       !$acc update device (normalTransportVelocity, &
-      !$acc                normalGMBolusVelocity)
+      !$acc                normalGMBolusVelocity,normalMLEvelocity)
       !$acc enter data copyin(atmosphericPressure, seaIcePressure)
       !$acc enter data copyin(sshNew)
       !$acc enter data copyin(activeTracersNew)
@@ -2402,7 +2404,7 @@ module ocn_time_integration_si
          !$acc enter data copyin(layerThicknessCur)
       endif
       !$acc update device (normalTransportVelocity, &
-      !$acc                normalGMBolusVelocity)
+      !$acc                normalGMBolusVelocity,normalMLEvelocity)
       !$acc enter data copyin(atmosphericPressure, seaIcePressure)
       !$acc enter data copyin(sshNew)
       !$acc enter data copyin(tracersGroupNew)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -43,6 +43,7 @@ module ocn_time_integration_si
    use ocn_diagnostics_variables
    use ocn_diagnostics
    use ocn_gm
+   use ocn_submesoscale_eddies
 
    use ocn_equation_of_state
    use ocn_vmix
@@ -240,7 +241,7 @@ module ocn_time_integration_si
          fluxb2,           &
          fluxAx
 
-      real (kind=RKIND), dimension(:), allocatable:: &
+      real (kind=RKIND), dimension(:,:), allocatable:: &
          uTemp
 
       real (kind=RKIND), dimension(:), allocatable :: &
@@ -813,47 +814,50 @@ module ocn_time_integration_si
             ! Only need to loop over owned cells, since there is a halo
             ! exchange immediately after this computation.
 
-            allocate(uTemp(nVertLevels))
+            allocate(uTemp(nVertLevels,nEdgesOwned))
 
-            !$omp parallel
-            !$omp do schedule(runtime) &
-            !$omp private(k, cell1, cell2, uTemp, &
-            !$omp         normalThicknessFluxSum, thicknessSum)
+            !$omp parallel 
+            !$omp do schedule(runtime)
             do iEdge = 1, nEdgesOwned
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
-               ! could put this after with 
-               ! uTemp(maxleveledgetop+1:nvertlevels)=0
-               uTemp = 0.0_RKIND
+               uTemp(:,iEdge) = 0.0_RKIND
                do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-
                   ! normalBaroclinicVelocityNew =
                   ! normalBaroclinicVelocityOld +
                   !                dt*(-f*normalBaroclinicVelocityPerp
                   !                    + T(u*,w*,p*) + g*grad(SSH*) )
                   ! Here uNew is a work variable containing
                   !  -fEdge(iEdge)*normalBaroclinicVelocityPerp(k,iEdge)
-                  uTemp(k) = normalBaroclinicVelocityCur(k,iEdge) &
+                  uTemp(k,iEdge) = normalBaroclinicVelocityCur(k,iEdge) &
                            + dt * (normalVelocityTend(k,iEdge) &
                            + normalVelocityNew(k,iEdge) &
                            + gravity * &
                              (sshNew(cell2) - sshNew(cell1)) &
                              /dcEdge(iEdge) )
-               enddo ! vertical
+               end do
+            end do
+            !$omp end do
+            !$omp end parallel
 
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(k, cell1, cell2, &
+            !$omp         normalThicknessFluxSum, thicknessSum)
+            do iEdge = 1, nEdgesOwned
                ! thicknessSum is initialized outside the loop because
                ! on land boundaries maxLevelEdgeTop=0, but we want to
                ! initialize thicknessSum with a nonzero value to avoid
                ! a NaN.
                normalThicknessFluxSum =                          &
                     layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge) &
-                  * uTemp(minLevelEdgeBot(iEdge))
+                  * uTemp(minLevelEdgeBot(iEdge),iEdge)
                thicknessSum = &
                     layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
 
                do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                   normalThicknessFluxSum = normalThicknessFluxSum + &
-                                 layerThickEdgeFlux(k,iEdge)*uTemp(k)
+                                 layerThickEdgeFlux(k,iEdge)*uTemp(k,iEdge)
                   thicknessSum = thicknessSum + &
                                  layerThickEdgeFlux(k,iEdge)
                enddo
@@ -868,7 +872,7 @@ module ocn_time_integration_si
                   !        {\bf u}^{'}_{k,n} +{\bf u}'_{k,n+1}\right)
                   ! so that normalBaroclinicVelocityNew is at time n+1/2
                   normalBaroclinicVelocityNew(k,iEdge) = 0.5_RKIND*( &
-                  normalBaroclinicVelocityCur(k,iEdge) + uTemp(k) - &
+                  normalBaroclinicVelocityCur(k,iEdge) + uTemp(k,iEdge) - &
                          dt * barotropicForcing(iEdge))
                enddo
 
@@ -1663,22 +1667,47 @@ module ocn_time_integration_si
          ! {\bf u}_k^{avg} \right)
          ! \left/ \sum_{k=1}^{N^{edge}} h_{k,*}^{edge}   \right.
 
-         allocate(uTemp(nVertLevels))
          nEdges = nEdgesHalo(config_num_halos-1 )
+         allocate(uTemp(nVertLevels,nEdges))
 
          !$omp parallel
-         !$omp do schedule(runtime) &
-         !$omp private(k, uTemp, normalThicknessFluxSum, &
-         !$omp         thicknessSum, normalVelocityCorrection)
+         !$omp do schedule(runtime)
          do iEdge = 1, nEdges
-
             ! velocity for normalVelocityCorrectionection is
             ! normalBarotropicVelocity +
             ! normalBaroclinicVelocity + uBolus
-            uTemp(:) = normalBarotropicVelocityNew(iEdge) &
-                   + normalBaroclinicVelocityNew(:,iEdge) &
-                   +       normalGMBolusVelocity(:,iEdge) &
-                   +           normalMLEvelocity(:,iEdge)
+            uTemp(:,iEdge) = normalBarotropicVelocityNew(iEdge) &
+                         + normalBaroclinicVelocityNew(:,iEdge)
+         end do
+         !$omp end do
+         !$omp end parallel
+
+         !add GM and submesoscale contributions if requested
+         call ocn_GM_add_to_transport_vel(uTemp, nEdges, nVertLevels)
+         call ocn_MLE_add_to_transport_vel(uTemp)
+
+         !$omp parallel
+         !$omp do schedule(runtime) &
+         !$omp private(k)
+         do iEdge = 1, nEdges
+            do k = 1, nVertLevels
+               normalTransportVelocity(k,iEdge) =  &
+                        normalBarotropicVelocityNew(iEdge)   + &
+                        normalBaroclinicVelocityNew(k,iEdge)
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
+
+         ! add GM and submesoscale contributions if requested
+         call ocn_GM_add_to_transport_vel(normalTransportVelocity, nEdges, nVertLevels)
+         call ocn_MLE_add_to_transport_vel(normalTransportVelocity)
+
+         !$omp parallel
+         !$omp do schedule(runtime) &
+         !$omp private(k, normalThicknessFluxSum, &
+         !$omp         thicknessSum, normalVelocityCorrection)
+         do iEdge = 1, nEdges
 
             ! thicknessSum is initialized outside the loop because
             ! on land boundaries maxLevelEdgeTop=0, but I want to
@@ -1686,14 +1715,14 @@ module ocn_time_integration_si
             ! a NaN.
             normalThicknessFluxSum  &
                = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge) &
-               * uTemp(minLevelEdgeBot(iEdge))
+               * uTemp(minLevelEdgeBot(iEdge),iEdge)
             thicknessSum &
                = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
 
             do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                normalThicknessFluxSum = normalThicknessFluxSum + &
                                         layerThickEdgeFlux(k,iEdge)* &
-                                        uTemp(k)
+                                        uTemp(k,iEdge)
                thicknessSum = thicknessSum + &
                               layerThickEdgeFlux(k,iEdge)
             enddo
@@ -1715,10 +1744,7 @@ module ocn_time_integration_si
                !    I think it is not needed because
                !    normalGMBolusVelocity=0 when GM not on.
                normalTransportVelocity(k,iEdge) = edgeMask(k,iEdge) &
-                        *(normalBarotropicVelocityNew(iEdge)   + &
-                          normalBaroclinicVelocityNew(k,iEdge) + &
-                          normalGMBolusVelocity(k,iEdge) + &
-                          normalMLEvelocity(k,iEdge) + &
+                        *(normalTransportVelocity(k,iEdge) + & 
                           normalVelocityCorrection )
             enddo
 
@@ -1876,8 +1902,13 @@ module ocn_time_integration_si
 
 #ifdef MPAS_OPENACC
             !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
-            !$acc update device (normalTransportVelocity, &
-            !$acc                normalGMBolusVelocity, normalMLEvelocity)
+            !$acc update device (normalTransportVelocity)
+            if (config_use_gm) then
+               !$acc update device (normalGMBolusVelocity)
+            end if
+            if (config_submesoscale_enable) then
+               !$acc update device (normalMLEvelocity)
+            end if
             !$acc enter data copyin(atmosphericPressure, seaIcePressure)
             !$acc enter data copyin(sshNew)
             !$acc enter data copyin(activeTracersNew)
@@ -1972,8 +2003,13 @@ module ocn_time_integration_si
 #ifdef MPAS_OPENACC
             !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
             !$acc update host(relativeVorticity, circulation)
+            if (config_use_gm) then
+               !$acc update host(vertGMBolusVelocityTop)
+            end if
+            if (config_submesoscale_enable) then
+               !$acc update host(vertMLEBolusVelocityTop)
+            end if
             !$acc update host(vertTransportVelocityTop, &
-            !$acc             vertGMBolusVelocityTop, &
             !$acc             relativeVorticityCell, &
             !$acc             divergence, &
             !$acc             kineticEnergyCell, &
@@ -2277,8 +2313,13 @@ module ocn_time_integration_si
       ! implicit vmix routine that follows.
 #ifdef MPAS_OPENACC
       !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
-      !$acc update device (normalTransportVelocity, &
-      !$acc                normalGMBolusVelocity,normalMLEvelocity)
+      !$acc update device (normalTransportVelocity)
+      if (config_use_gm) then
+         !$acc update device (normalGMBolusVelocity)
+      end if
+      if (config_submesoscale_enable) then
+         !$acc update device (normalMLEvelocity)
+      end if
       !$acc enter data copyin(atmosphericPressure, seaIcePressure)
       !$acc enter data copyin(sshNew)
       !$acc enter data copyin(activeTracersNew)
@@ -2296,8 +2337,13 @@ module ocn_time_integration_si
 #ifdef MPAS_OPENACC
       !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
       !$acc update host(relativeVorticity, circulation)
+      if (config_use_gm) then
+         !$acc update host (vertGMBolusVelocityTop)
+      end if
+      if (config_submesoscale_enable) then
+         !$acc update host (vertMLEBolusVelocityTop)
+      end if
       !$acc update host(vertTransportVelocityTop, &
-      !$acc             vertGMBolusVelocityTop, &
       !$acc             relativeVorticityCell, &
       !$acc             divergence, &
       !$acc             kineticEnergyCell, &
@@ -2335,12 +2381,6 @@ module ocn_time_integration_si
 
       call mpas_dmpar_field_halo_exch(domain, 'surfaceFrictionVelocity')
 
-      ! Compute normalGMBolusVelocity; it will be added to the
-      ! baroclinic modes in Stage 2 above.
-      !if (config_use_GM.or.config_use_Redi) then
-      !   call ocn_gm_compute_Bolus_velocity(statePool, &
-      !             meshPool, scratchPool, timeLevelIn=2)
-      !end if
       call ocn_vmix_implicit(dt, meshPool, statePool, forcingPool, &
                              scratchPool, err, 2)
 
@@ -2403,8 +2443,13 @@ module ocn_time_integration_si
       if (config_prescribe_thickness) then
          !$acc enter data copyin(layerThicknessCur)
       endif
-      !$acc update device (normalTransportVelocity, &
-      !$acc                normalGMBolusVelocity,normalMLEvelocity)
+      !$acc update device (normalTransportVelocity)
+      if (config_use_gm) then
+         !$acc update device (normalGMBolusVelocity)
+      end if
+      if (config_submesoscale_enable) then
+         !$acc update device (normalMLEvelocity)
+      end if
       !$acc enter data copyin(atmosphericPressure, seaIcePressure)
       !$acc enter data copyin(sshNew)
       !$acc enter data copyin(tracersGroupNew)
@@ -2462,13 +2507,6 @@ module ocn_time_integration_si
       call ocn_effective_density_in_land_ice_update(meshPool, &
                                        forcingPool, statePool, err)
 
-      !! Compute normalGMBolusVelocity; it will be added to
-      !! normalVelocity in Stage 2 of the next cycle.
-      !if (config_use_GM.or.config_use_Redi) then
-      !   call ocn_gm_compute_Bolus_velocity(statePool, diagnosticsPool,&
-      !                           meshPool, scratchPool, timeLevelIn=2)
-      !end if
-
       call mpas_timer_start('si final mpas reconstruct', .false.)
 
 #ifdef MPAS_OPENACC
@@ -2517,8 +2555,13 @@ module ocn_time_integration_si
 #ifdef MPAS_OPENACC
       !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
       !$acc update host(relativeVorticity, circulation)
+      if (config_use_gm) then
+         !$acc update host(vertGMBolusVelocityTop)
+      end if
+      if (config_submesoscale_enable) then
+         !$acc update host(vertMLEBolusVelocityTop)
+      end if
       !$acc update host(vertTransportVelocityTop, &
-      !$acc             vertGMBolusVelocityTop, &
       !$acc             relativeVorticityCell, &
       !$acc             divergence, &
       !$acc             kineticEnergyCell, &

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -1684,7 +1684,7 @@ module ocn_time_integration_si
 
          !add GM and submesoscale contributions if requested
          call ocn_GM_add_to_transport_vel(uTemp, nEdges, nVertLevels)
-         call ocn_MLE_add_to_transport_vel(uTemp)
+         call ocn_MLE_add_to_transport_vel(uTemp, nEdges)
 
          !$omp parallel
          !$omp do schedule(runtime) &
@@ -1701,7 +1701,7 @@ module ocn_time_integration_si
 
          ! add GM and submesoscale contributions if requested
          call ocn_GM_add_to_transport_vel(normalTransportVelocity, nEdges, nVertLevels)
-         call ocn_MLE_add_to_transport_vel(normalTransportVelocity)
+         call ocn_MLE_add_to_transport_vel(normalTransportVelocity, nEdges)
 
          !$omp parallel
          !$omp do schedule(runtime) &

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -2566,8 +2566,8 @@ module ocn_time_integration_si
 #endif
       call ocn_time_average_coupled_accumulate(statePool,forcingPool,2)
 
-      if (config_use_GM) then
-         call ocn_reconstruct_gm_vectors(meshPool)
+      if (config_use_GM .or. config_submesoscale_enable) then
+         call ocn_reconstruct_eddy_vectors(meshPool)
       end if
 
       if (trim(config_land_ice_flux_mode) == 'coupled') then

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -1569,7 +1569,7 @@ module ocn_time_integration_split
             allocate(uTemp(nVertLevels,nEdges))
 
             !Compute uTemp
-            ! velocity for normalVelocityCorrectionection is
+            ! velocity for normalVelocityCorrection is
             ! normalBarotropicVelocity +
             ! normalBaroclinicVelocity + uBolus
             !$omp parallel
@@ -1633,13 +1633,10 @@ module ocn_time_integration_split
                   ! normalTransportVelocity = normalBarotropicVelocity
                   !                         + normalBaroclinicVelocity
                   !                         + normalGMBolusVelocity
+                  !                         + normalMLEvelocity 
                   !                         + normalVelocityCorrection
-                  ! This is u used in advective terms for layerThickness
+                  ! This is the velocity used in advective terms for layerThickness
                   ! and tracers in tendency calls in stage 3.
-                  !mrp note: in QC version, there is an if
-                  !    (config_use_GM) on adding normalGMBolusVelocity
-                  !    I think it is not needed because
-                  !    normalGMBolusVelocity=0 when GM not on.
                   normalTransportVelocity(k,iEdge) = edgeMask(k,iEdge)*( &
                              normalTransportVelocity(k,iEdge) + &
                              normalVelocityCorrection)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -37,6 +37,7 @@ module ocn_time_integration_split
    use ocn_diagnostics_variables
    use ocn_diagnostics
    use ocn_gm
+   use ocn_submesoscale_eddies
 
    use ocn_equation_of_state
    use ocn_vmix
@@ -186,7 +187,7 @@ module ocn_time_integration_split
          sshCell1,         &! sea sfc height in neighboring cells
          sshCell2
 
-      real (kind=RKIND), dimension(:), allocatable:: &
+      real (kind=RKIND), dimension(:,:), allocatable:: &
          uTemp
 
       real (kind=RKIND), dimension(:), allocatable :: &
@@ -724,7 +725,7 @@ module ocn_time_integration_split
             ! Only need to loop over owned cells, since there is a halo
             ! exchange immediately after this computation.
 
-            allocate(uTemp(nVertLevels))
+            allocate(uTemp(nVertLevels,nEdgesOwned))
 
             !$omp parallel
             !$omp do schedule(runtime) &
@@ -734,7 +735,7 @@ module ocn_time_integration_split
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
                ! could put this after with uTemp(maxleveledgetop+1:nvertlevels)=0
-               uTemp = 0.0_RKIND
+               uTemp(:,iEdge) = 0.0_RKIND
                do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
 
                   ! normalBaroclinicVelocityNew =
@@ -743,7 +744,7 @@ module ocn_time_integration_split
                   !                    + T(u*,w*,p*) + g*grad(SSH*) )
                   ! Here uNew is a work variable containing
                   !  -fEdge(iEdge)*normalBaroclinicVelocityPerp(k,iEdge)
-                  uTemp(k) = normalBaroclinicVelocityCur(k,iEdge) &
+                  uTemp(k,iEdge) = normalBaroclinicVelocityCur(k,iEdge) &
                            + dt * (normalVelocityTend(k,iEdge) &
                            + normalVelocityNew(k,iEdge) &
                            + splitFact*gravity * &
@@ -756,12 +757,12 @@ module ocn_time_integration_split
                ! initialize thicknessSum with a nonzero value to avoid
                ! a NaN.
                normalThicknessFluxSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)* &
-                                        uTemp(minLevelEdgeBot(iEdge))
+                                        uTemp(minLevelEdgeBot(iEdge),iEdge)
                thicknessSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
 
                do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                   normalThicknessFluxSum = normalThicknessFluxSum + &
-                                 layerThickEdgeFlux(k,iEdge)*uTemp(k)
+                                 layerThickEdgeFlux(k,iEdge)*uTemp(k,iEdge)
                   thicknessSum = thicknessSum + &
                                  layerThickEdgeFlux(k,iEdge)
                enddo
@@ -776,7 +777,7 @@ module ocn_time_integration_split
                   !        {\bf u}^{'}_{k,n} +{\bf u}'_{k,n+1}\right)
                   ! so that normalBaroclinicVelocityNew is at time n+1/2
                   normalBaroclinicVelocityNew(k,iEdge) = 0.5_RKIND*( &
-                  normalBaroclinicVelocityCur(k,iEdge) + uTemp(k) - &
+                  normalBaroclinicVelocityCur(k,iEdge) + uTemp(k,iEdge) - &
                          dt * barotropicForcing(iEdge))
 
                enddo
@@ -835,13 +836,28 @@ module ocn_time_integration_split
 
                   ! This is u used in advective terms for layerThickness and tracers
                   ! in tendency calls in stage 3.
-                  normalTransportVelocity(k,iEdge) = edgeMask(k,iEdge) &
-                                *(normalBaroclinicVelocityNew(k,iEdge) &
-                                      + normalGMBolusVelocity(k,iEdge) &
-                                      + normalMLEvelocity(k,iEdge))
+                  normalTransportVelocity(k,iEdge) = normalBaroclinicVelocityNew(k,iEdge)
+
 
                enddo ! vertical
             end do  ! iEdge
+            !$omp end do
+            !$omp end parallel
+
+            !add GM and MLE (submesoscale) velocities if requested
+            call ocn_GM_add_to_transport_vel(normalTransportVelocity, nEdgesAll, &
+                                             nVertLevels)
+            call ocn_MLE_add_to_transport_vel(normalTransportvelocity, nEdgesAll)
+
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(k)
+            do iEdge=1, nEdgesAll
+               do k = 1, nVertLevels
+                  normalTransportVelocity(k,iEdge) = edgeMask(k,iEdge)* &
+                                  normalTransportVelocity(k,iEdge)
+               end do
+            end do
             !$omp end do
             !$omp end parallel
 
@@ -1549,35 +1565,61 @@ module ocn_time_integration_split
             ! {\bf u}_k^{avg} \right)
             ! \left/ \sum_{k=1}^{N^{edge}} h_{k,*}^{edge}   \right.
 
-            allocate(uTemp(nVertLevels))
             nEdges = nEdgesHalo(config_num_halos-1 )
+            allocate(uTemp(nVertLevels,nEdges))
+
+            !Compute uTemp
+            ! velocity for normalVelocityCorrectionection is
+            ! normalBarotropicVelocity +
+            ! normalBaroclinicVelocity + uBolus
+            !$omp parallel
+            !$omp do schedule(runtime)
+            do iEdge = 1, nEdges
+               uTemp(:,iEdge) = normalBarotropicVelocityNew(iEdge) &
+                            + normalBaroclinicVelocityNew(:,iEdge)
+            end do
+            !$omp end do
+            !$omp end parallel
+
+            call ocn_GM_add_to_transport_vel(uTemp, nEdges, &
+                                             nVertLevels)
+            call ocn_MLE_add_to_transport_vel(uTemp, nEdges)
 
             !$omp parallel
             !$omp do schedule(runtime) &
-            !$omp private(k, uTemp, normalThicknessFluxSum, &
+            !$omp private(k)
+            do iEdge = 1, nEdges
+               do k = 1, nVertLevels
+                  normalTransportVelocity(k,iEdge) =  &
+                             normalBarotropicVelocityNew(iEdge)   + &
+                             normalBaroclinicVelocityNew(k,iEdge)
+               end do
+            end do
+            !$omp end do
+            !$omp end parallel
+            call ocn_GM_add_to_transport_vel(normalTransportVelocity, nEdges, &
+                                             nVertLevels)
+            call ocn_MLE_add_to_transport_vel(normalTransportVelocity, nEdges)
+
+
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(k, normalThicknessFluxSum, &
             !$omp         thicknessSum, normalVelocityCorrection)
             do iEdge = 1, nEdges
-
-               ! velocity for normalVelocityCorrectionection is
-               ! normalBarotropicVelocity +
-               ! normalBaroclinicVelocity + uBolus
-               uTemp(:) = normalBarotropicVelocityNew(iEdge) &
-                      + normalBaroclinicVelocityNew(:,iEdge) &
-                      +       normalGMBolusVelocity(:,iEdge) &
-                      +           normalMLEvelocity(:,iEdge)
 
                ! thicknessSum is initialized outside the loop because
                ! on land boundaries maxLevelEdgeTop=0, but I want to
                ! initialize thicknessSum with a nonzero value to avoid
                ! a NaN.
                normalThicknessFluxSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)* &
-                                        uTemp(minLevelEdgeBot(iEdge))
+                                        uTemp(minLevelEdgeBot(iEdge),iEdge)
                thicknessSum  = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
 
                do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                   normalThicknessFluxSum = normalThicknessFluxSum + &
                                            layerThickEdgeFlux(k,iEdge)*&
-                                           uTemp(k)
+                                           uTemp(k,iEdge)
                   thicknessSum = thicknessSum + &
                                  layerThickEdgeFlux(k,iEdge)
                enddo
@@ -1598,12 +1640,9 @@ module ocn_time_integration_split
                   !    (config_use_GM) on adding normalGMBolusVelocity
                   !    I think it is not needed because
                   !    normalGMBolusVelocity=0 when GM not on.
-                  normalTransportVelocity(k,iEdge) = edgeMask(k,iEdge) &
-                           *(normalBarotropicVelocityNew(iEdge)   + &
-                             normalBaroclinicVelocityNew(k,iEdge) + &
-                             normalGMBolusVelocity(k,iEdge) + &
-                             normalMLEvelocity(k,iEdge) + &
-                             normalVelocityCorrection )
+                  normalTransportVelocity(k,iEdge) = edgeMask(k,iEdge)*( &
+                             normalTransportVelocity(k,iEdge) + &
+                             normalVelocityCorrection)
                enddo
 
             end do ! iEdge
@@ -1705,11 +1744,16 @@ module ocn_time_integration_split
             !$acc enter data copyin(lowFreqDivergenceTend)
          endif
          if (splitExplicitStep < numTSIterations) then
-            !$acc update device (normalTransportVelocity, &
-            !$acc                normalGMBolusVelocity)
+            !$acc update device (normalTransportVelocity)
             !$acc enter data copyin(atmosphericPressure, seaIcePressure)
             !$acc enter data copyin(sshNew)
             !$acc update device(tracersSurfaceValue)
+            if ( associated(normalGMBolusVelocity) ) then
+               !$acc update device (normalGMBolusVelocity)
+            end if
+            if ( associated(normalMLEVelocity) ) then
+               !$acc update device (normalMLEvelocity)
+            end if
             if ( associated(frazilSurfacePressure) ) then
                !$acc enter data copyin(frazilSurfacePressure)
             endif
@@ -2257,12 +2301,17 @@ module ocn_time_integration_split
             !$acc exit data delete(lowFreqDivergenceTend)
          endif
          if (splitExplicitStep < numTSIterations) then
+            if (config_use_gm) then
+               !$acc update host(vertGMBolusVelocityTop)
+            end if
+            if (config_submesoscale_enable) then
+               !$acc update host(vertMLEBolusVelocityTop)
+            end if
             !$acc exit data delete (atmosphericPressure, seaIcePressure)
             !$acc exit data copyout(sshNew)
             !$acc update host(layerThickEdgeMean)
             !$acc update host(relativeVorticity, circulation)
             !$acc update host(vertTransportVelocityTop, &
-            !$acc             vertGMBolusVelocityTop, &
             !$acc             relativeVorticityCell, &
             !$acc             divergence, &
             !$acc             kineticEnergyCell, &
@@ -2324,8 +2373,13 @@ module ocn_time_integration_split
       ! implicit vmix routine that follows.
 #ifdef MPAS_OPENACC
       !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
-      !$acc update device (normalTransportVelocity, &
-      !$acc                normalGMBolusVelocity, normalMLEvelocity)
+      !$acc update device (normalTransportVelocity)
+      if (config_use_gm) then
+         !$acc update device (normalGMBolusVelocity)
+      end if
+      if (config_submesoscale_enable) then
+         !$acc update device (normalMLEVelocity)
+      end if
       !$acc enter data copyin(atmosphericPressure, seaIcePressure)
       !$acc enter data copyin(sshNew)
       !$acc enter data copyin(activeTracersNew)
@@ -2346,8 +2400,13 @@ module ocn_time_integration_split
 #ifdef MPAS_OPENACC
       !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
       !$acc update host(relativeVorticity, circulation)
+      if (config_use_gm) then
+         !$acc update host (vertGMBolusVelocityTop)
+      end if
+      if (config_submesoscale_enable) then
+         !$acc update host (vertMLEBolusVelocityTop)
+      end if
       !$acc update host(vertTransportVelocityTop, &
-      !$acc             vertGMBolusVelocityTop, &
       !$acc             relativeVorticityCell, &
       !$acc             divergence, &
       !$acc             kineticEnergyCell, &
@@ -2383,12 +2442,6 @@ module ocn_time_integration_split
       !$acc exit data delete(layerThicknessNew, normalVelocityNew)
 #endif
 
-      ! Compute normalGMBolusVelocity; it will be added to the
-      ! baroclinic modes in Stage 2 above.
-      !if (config_use_GM.or.config_use_Redi) then
-      !   call ocn_gm_compute_Bolus_velocity(statePool, &
-      !             meshPool, scratchPool, timeLevelIn=2)
-      !end if
       call ocn_vmix_implicit(dt, meshPool, statePool, forcingPool, &
                              scratchPool, err, 2)
 
@@ -2468,8 +2521,13 @@ module ocn_time_integration_split
       if (config_prescribe_thickness) then
          !$acc enter data copyin(layerThicknessCur)
       endif
-      !$acc update device (normalTransportVelocity, &
-      !$acc                normalGMBolusVelocity, normalMLEvelocity)
+      !$acc update device (normalTransportVelocity)
+      if (config_use_gm) then
+         !$acc update device (normalGMBolusVelocity)
+      end if
+      if (config_submesoscale_enable) then
+         !$acc update device (normalMLEvelocity)
+      end if
       !$acc enter data copyin(atmosphericPressure, seaIcePressure)
       !$acc enter data copyin(sshNew)
       !$acc enter data copyin(activeTracersNew)
@@ -2526,13 +2584,6 @@ module ocn_time_integration_split
       call ocn_effective_density_in_land_ice_update(meshPool, &
                                        forcingPool, statePool, err)
 
-      !! Compute normalGMBolusVelocity; it will be added to
-      !! normalVelocity in Stage 2 of the next cycle.
-      !if (config_use_GM.or.config_use_Redi) then
-      !   call ocn_gm_compute_Bolus_velocity(statePool, diagnosticsPool,&
-      !                           meshPool, scratchPool, timeLevelIn=2)
-      !end if
-
       call mpas_timer_start('se final mpas reconstruct', .false.)
 
 #ifdef MPAS_OPENACC
@@ -2580,8 +2631,13 @@ module ocn_time_integration_split
 #ifdef MPAS_OPENACC
       !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
       !$acc update host(relativeVorticity, circulation)
+      if (config_use_gm) then
+         !$acc update host(vertGMBolusVelocityTop)
+      end if
+      if (config_submesoscale_enable) then
+         !$acc update host(vertMLEBolusVelocityTop)
+      end if
       !$acc update host(vertTransportVelocityTop, &
-      !$acc             vertGMBolusVelocityTop, &
       !$acc             relativeVorticityCell, &
       !$acc             divergence, &
       !$acc             kineticEnergyCell, &

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -275,7 +275,7 @@ module ocn_time_integration_split
       ! barotropicForcing, barotropicThicknessFlux
       ! layerThickEdgeFlux, layerThickEdgeMean,
       ! normalTransportVelocity, normalGMBolusVelocity
-      ! vertAleTransportTop
+      ! vertAleTransportTop, normalMLEvelocity
       ! velocityX, velocityY, velocityZ
       ! velocityZonal, velocityMeridional
       ! gradSSH, gradSSHX, gradSSHY, gradSSHZ
@@ -837,7 +837,8 @@ module ocn_time_integration_split
                   ! in tendency calls in stage 3.
                   normalTransportVelocity(k,iEdge) = edgeMask(k,iEdge) &
                                 *(normalBaroclinicVelocityNew(k,iEdge) &
-                                      + normalGMBolusVelocity(k,iEdge))
+                                      + normalGMBolusVelocity(k,iEdge) &
+                                      + normalMLEvelocity(k,iEdge))
 
                enddo ! vertical
             end do  ! iEdge
@@ -1562,7 +1563,8 @@ module ocn_time_integration_split
                ! normalBaroclinicVelocity + uBolus
                uTemp(:) = normalBarotropicVelocityNew(iEdge) &
                       + normalBaroclinicVelocityNew(:,iEdge) &
-                      +       normalGMBolusVelocity(:,iEdge)
+                      +       normalGMBolusVelocity(:,iEdge) &
+                      +           normalMLEvelocity(:,iEdge)
 
                ! thicknessSum is initialized outside the loop because
                ! on land boundaries maxLevelEdgeTop=0, but I want to
@@ -1600,6 +1602,7 @@ module ocn_time_integration_split
                            *(normalBarotropicVelocityNew(iEdge)   + &
                              normalBaroclinicVelocityNew(k,iEdge) + &
                              normalGMBolusVelocity(k,iEdge) + &
+                             normalMLEvelocity(k,iEdge) + &
                              normalVelocityCorrection )
                enddo
 
@@ -2322,7 +2325,7 @@ module ocn_time_integration_split
 #ifdef MPAS_OPENACC
       !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
       !$acc update device (normalTransportVelocity, &
-      !$acc                normalGMBolusVelocity)
+      !$acc                normalGMBolusVelocity, normalMLEvelocity)
       !$acc enter data copyin(atmosphericPressure, seaIcePressure)
       !$acc enter data copyin(sshNew)
       !$acc enter data copyin(activeTracersNew)
@@ -2466,7 +2469,7 @@ module ocn_time_integration_split
          !$acc enter data copyin(layerThicknessCur)
       endif
       !$acc update device (normalTransportVelocity, &
-      !$acc                normalGMBolusVelocity)
+      !$acc                normalGMBolusVelocity, normalMLEvelocity)
       !$acc enter data copyin(atmosphericPressure, seaIcePressure)
       !$acc enter data copyin(sshNew)
       !$acc enter data copyin(activeTracersNew)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -1576,13 +1576,16 @@ module ocn_time_integration_split
             !$omp do schedule(runtime)
             do iEdge = 1, nEdges
                uTemp(:,iEdge) = normalBarotropicVelocityNew(iEdge) &
-                            + normalBaroclinicVelocityNew(:,iEdge)
+                            + normalBaroclinicVelocityNew(:,iEdge) &
+                      +       normalGMBolusVelocity(:,iEdge)
             end do
             !$omp end do
             !$omp end parallel
 
-            call ocn_GM_add_to_transport_vel(uTemp, nEdges, &
-                                             nVertLevels)
+            ! mrp turn off separate GM addition for bfb match.
+            ! normalGMBolusVelocity added in previous loop.
+            !call ocn_GM_add_to_transport_vel(uTemp, nEdges, &
+            !                                 nVertLevels)
             call ocn_MLE_add_to_transport_vel(uTemp, nEdges)
 
             !$omp parallel
@@ -1637,9 +1640,11 @@ module ocn_time_integration_split
                   !                         + normalVelocityCorrection
                   ! This is the velocity used in advective terms for layerThickness
                   ! and tracers in tendency calls in stage 3.
-                  normalTransportVelocity(k,iEdge) = edgeMask(k,iEdge)*( &
-                             normalTransportVelocity(k,iEdge) + &
-                             normalVelocityCorrection)
+                  normalTransportVelocity(k,iEdge) = edgeMask(k,iEdge) &
+                           *(normalBarotropicVelocityNew(iEdge)   + &
+                             normalBaroclinicVelocityNew(k,iEdge) + &
+                             normalGMBolusVelocity(k,iEdge) + &
+                             normalVelocityCorrection )
                enddo
 
             end do ! iEdge

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -2630,8 +2630,8 @@ module ocn_time_integration_split
 
       call ocn_time_average_coupled_accumulate(statePool,forcingPool,2)
 
-      if (config_use_GM) then
-         call ocn_reconstruct_gm_vectors(meshPool)
+      if (config_use_GM .or. config_submesoscale_enable) then
+         call ocn_reconstruct_eddy_vectors(meshPool)
       end if
 
       if (trim(config_land_ice_flux_mode) == 'coupled') then

--- a/components/mpas-ocean/src/ocean.cmake
+++ b/components/mpas-ocean/src/ocean.cmake
@@ -32,6 +32,8 @@ list(APPEND RAW_SOURCES
 
   core_ocean/shared/mpas_ocn_init_routines.F
   core_ocean/shared/mpas_ocn_gm.F
+  core_ocean/shared/mpas_ocn_submesoscale_eddies.F
+  core_ocean/shared/mpas_ocn_eddy_parameterization_helpers.F
   core_ocean/shared/mpas_ocn_diagnostics.F
   core_ocean/shared/mpas_ocn_diagnostics_variables.F
   core_ocean/shared/mpas_ocn_mesh.F

--- a/components/mpas-ocean/src/shared/Makefile
+++ b/components/mpas-ocean/src/shared/Makefile
@@ -2,6 +2,8 @@
 
 OBJS = mpas_ocn_init_routines.o \
 	   mpas_ocn_gm.o \
+	   mpas_ocn_eddy_parameterization_helpers.o \
+	   mpas_ocn_submesoscale_eddies.o \
 	   mpas_ocn_diagnostics.o \
 	   mpas_ocn_diagnostics_variables.o \
 	   mpas_ocn_thick_ale.o \
@@ -76,11 +78,11 @@ OBJS = mpas_ocn_init_routines.o \
 
 all: $(OBJS)
 
-mpas_ocn_init_routines.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics.o mpas_ocn_diagnostics_variables.o mpas_ocn_gm.o mpas_ocn_forcing.o mpas_ocn_surface_land_ice_fluxes.o
+mpas_ocn_init_routines.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics.o mpas_ocn_diagnostics_variables.o mpas_ocn_gm.o mpas_ocn_submesoscale_eddies.o mpas_ocn_forcing.o mpas_ocn_surface_land_ice_fluxes.o
 
 mpas_ocn_tendency.o: mpas_ocn_high_freq_thickness_hmix_del2.o mpas_ocn_tracer_surface_restoring.o mpas_ocn_thick_surface_flux.o mpas_ocn_tracer_short_wave_absorption.o mpas_ocn_tracer_advection.o mpas_ocn_tracer_hmix.o mpas_ocn_tracer_nonlocalflux.o mpas_ocn_surface_bulk_forcing.o mpas_ocn_surface_land_ice_fluxes.o mpas_ocn_tracer_surface_flux_to_tend.o mpas_ocn_tracer_interior_restoring.o mpas_ocn_tracer_exponential_decay.o mpas_ocn_tracer_ideal_age.o mpas_ocn_tracer_TTD.o mpas_ocn_vmix.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_frazil_forcing.o mpas_ocn_tidal_forcing.o mpas_ocn_tracer_ecosys.o mpas_ocn_tracer_DMS.o mpas_ocn_tracer_MacroMolecules.o mpas_ocn_tracer_CFC.o mpas_ocn_diagnostics.o mpas_ocn_wetting_drying.o mpas_ocn_vel_self_attraction_loading.o  mpas_ocn_vel_tidal_potential.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o mpas_ocn_thick_hadv.o mpas_ocn_thick_vadv.o mpas_ocn_vel_hadv_coriolis.o mpas_ocn_vel_pressure_grad.o mpas_ocn_vel_vadv.o mpas_ocn_vel_hmix.o mpas_ocn_vel_forcing.o
 
-mpas_ocn_diagnostics.o: mpas_ocn_thick_ale.o mpas_ocn_equation_of_state.o mpas_ocn_gm.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o mpas_ocn_surface_land_ice_fluxes.o mpas_ocn_vertical_advection.o
+mpas_ocn_diagnostics.o: mpas_ocn_thick_ale.o mpas_ocn_equation_of_state.o mpas_ocn_gm.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o mpas_ocn_surface_land_ice_fluxes.o mpas_ocn_vertical_advection.o mpas_ocn_submesoscale_eddies.o
 
 mpas_ocn_diagnostics_variables.o: mpas_ocn_config.o
 
@@ -96,7 +98,11 @@ mpas_ocn_thick_vadv.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o
 
 mpas_ocn_thick_surface_flux.o: mpas_ocn_forcing.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o
 
-mpas_ocn_gm.o:  mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o
+mpas_ocn_gm.o:  mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o mpas_ocn_submesoscale_eddies.o
+
+mpas_ocn_submesoscale_eddies.o:  mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o mpas_ocn_mesh.o
+
+mpas_ocn_eddy_parameterization_helpers.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o mpas_ocn_mesh.o
 
 mpas_ocn_vel_pressure_grad.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -1607,7 +1607,7 @@ contains
       real (kind=RKIND), dimension(:), allocatable:: div_huGMBolus
 
 #ifdef MPAS_OPENACC
-      !$acc declare device_resident(div_hu, div_huTransport, div_huGMBolus, div_huMLEBolus)
+      !$acc declare device_resident(div_huGMBolus)
 #endif
 
       ! Need owned cells for relativeVorticityCell
@@ -1619,7 +1619,7 @@ contains
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector &
       !$acc          present(nEdgesOnCell, edgesOnCell, edgeSignonCell, dcEdge, dvEdge, &
-      !$acc                  areaCell, layerThicknessEdgeFlux, normalGMBolusVelocity, &
+      !$acc                  normalGMBolusVelocity, &
       !$acc                  vertGMBolusVelocityTop, invAreaCell, minLevelCell) &
       !$acc          private(invAreaCell1, i, iEdge, edgeSignOnCell_temp, dcEdge_temp, &
       !$acc                  dvEdge_temp, k)
@@ -1718,7 +1718,7 @@ contains
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector &
       !$acc          present(nEdgesOnCell, edgesOnCell, edgeSignonCell, dcEdge, dvEdge, &
-      !$acc                  areaCell, layerThicknessEdgeFlux, normalMLEVelocity, &
+      !$acc                  areaCell, normalMLEVelocity, &
       !$acc                  vertMLEBolusVelocityTop, invAreaCell, minLevelCell) &
       !$acc          private(invAreaCell1, i, iEdge, edgeSignOnCell_temp, dcEdge_temp, &
       !$acc                  dvEdge_temp, k)

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -61,7 +61,7 @@ module ocn_diagnostics
              ocn_vert_transport_velocity_top, &
              ocn_fuperp, &
              ocn_filter_btr_mode_tend_vel, &
-             ocn_reconstruct_gm_vectors, &
+             ocn_reconstruct_eddy_vectors, &
              ocn_compute_kpp_input_fields, &
              ocn_validate_state, &
              ocn_build_log_filename, &
@@ -3095,7 +3095,7 @@ contains
 
 !***********************************************************************
 !
-!  routine ocn_reconstruct_gm_vectors
+!  routine ocn_reconstruct_eddy_vectors
 !
 !> \brief   Computes cell-centered vector diagnostics
 !> \author  Mark Petersen
@@ -3105,11 +3105,11 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_reconstruct_gm_vectors(meshPool) !{{{
+   subroutine ocn_reconstruct_eddy_vectors(meshPool) !{{{
 
       type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
 
-      call mpas_timer_start('reconstruct gm vecs')
+      call mpas_timer_start('reconstruct eddy vecs')
 
       call mpas_reconstruct(meshPool, normalTransportVelocity,          &
                        transportVelocityX,            &
@@ -3120,17 +3120,17 @@ contains
                       )
 
       call mpas_reconstruct(meshPool, normalGMBolusVelocity,          &
-                       GMBolusVelocityX,            &
-                       GMBolusVelocityY,            &
-                       GMBolusVelocityZ,            &
+                       eddyVelocityX,            &
+                       eddyVelocityY,            &
+                       eddyVelocityZ,            &
                        GMBolusVelocityZonal,        &
                        GMBolusVelocityMeridional    &
                       )
 
       call mpas_reconstruct(meshPool, normalMLEvelocity,          &
-                       mleVelocityX,            &
-                       mleVelocityY,            &
-                       mleVelocityZ,            &
+                       eddyVelocityX,            &
+                       eddyVelocityY,            &
+                       eddyVelocityZ,            &
                        mleVelocityZonal,        &
                        mleVelocityMeridional    &
                       )
@@ -3143,9 +3143,9 @@ contains
                       GMStreamFuncMeridional    &
                      )
 
-      call mpas_timer_stop('reconstruct gm vecs')
+      call mpas_timer_stop('reconstruct eddy vecs')
 
-   end subroutine ocn_reconstruct_gm_vectors!}}}
+   end subroutine ocn_reconstruct_eddy_vectors!}}}
 
 
 !***********************************************************************

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -232,13 +232,13 @@ contains
       ! inputs: relativeVorticity, layerThickEdgeFlux, normalVelocity, normalTransportVelocity, 
       !         normalGMBolusVelocity
       ! outputs: vertTransportVelocityTop, vertGMBolusVelocityTop, relativeVorticityCell, 
-      !          divergence, kineticEnergyCell, tangentialVelocity
+      !          divergence, kineticEnergyCell, tangentialVelocity, vertMLEBolusVelocityTop
       ! in and out: vertVelocityTop
       call ocn_diagnostic_solve_vortVel(relativeVorticity, &
              layerThickEdgeFlux, normalVelocity, normalTransportVelocity, &
-             normalGMBolusVelocity, vertVelocityTop, vertTransportVelocityTop, &
-             vertGMBolusVelocityTop, relativeVorticityCell, divergence, &
-             kineticEnergyCell, tangentialVelocity)
+             normalGMBolusVelocity, normalMLEvelocity, vertVelocityTop, vertTransportVelocityTop, &
+             vertGMBolusVelocityTop, vertMLEBolusVelocityTop, relativeVorticityCell, &
+             divergence, kineticEnergyCell, tangentialVelocity)
 
       if ( configVertAdvMethod == vertAdvRemap ) then
 
@@ -1563,9 +1563,9 @@ contains
 !-----------------------------------------------------------------------
    subroutine ocn_diagnostic_solve_vortVel(relativeVorticity, &
                 layerThicknessEdgeFlux, normalVelocity, normalTransportVelocity, &
-                normalGMBolusVelocity, vertVelocityTop, vertTransportVelocityTop, &
-                vertGMBolusVelocityTop, relativeVorticityCell, divergence, &
-                kineticEnergyCell, tangentialVelocity)!{{{
+                normalGMBolusVelocity, normalMLEVelocity, vertVelocityTop, vertTransportVelocityTop, &
+                vertGMBolusVelocityTop, vertMLEBolusVelocityTop, relativeVorticityCell, &
+                divergence, kineticEnergyCell, tangentialVelocity)!{{{
 
       implicit none
 
@@ -1585,6 +1585,8 @@ contains
          normalTransportVelocity
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          normalGMBolusVelocity
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalMLEVelocity
 
       !-----------------------------------------------------------------
       !
@@ -1598,6 +1600,8 @@ contains
          vertTransportVelocityTop
       real (kind=RKIND), dimension(:,:), intent(out) :: &
          vertGMBolusVelocityTop
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         vertMLEBolusVelocityTop
       real (kind=RKIND), dimension(:,:), intent(out) :: &
          relativeVorticityCell
       real (kind=RKIND), dimension(:,:), intent(out) :: &
@@ -1621,8 +1625,10 @@ contains
       real(kind=RKIND) :: dcEdge_temp, dvEdge_temp, r_tmp, weightsOnEdge_temp
 
       real (kind=RKIND), dimension(:), allocatable:: div_hu,div_huTransport,div_huGMBolus
+      real (kind=RKIND), dimension(:), allocatable:: div_huMLEBolus
+
 #ifdef MPAS_OPENACC
-      !$acc declare device_resident(div_hu, div_huTransport, div_huGMBolus)
+      !$acc declare device_resident(div_hu, div_huTransport, div_huGMBolus, div_huMLEBolus)
 #endif
 
       ! Need owned cells for relativeVorticityCell
@@ -1664,6 +1670,7 @@ contains
       ! Compute divergence, kinetic energy, and vertical velocity
       !
       allocate(div_hu(nVertLevels),div_huTransport(nVertLevels),div_huGMBolus(nVertLevels))
+      allocate(div_huMLEBolus(nVertLevels))
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector &
@@ -1672,7 +1679,7 @@ contains
       !$acc                  maxLevelCell, normalVelocity, divergence, layerThicknessEdgeFlux, &
       !$acc                  normalTransportVelocity, normalGMBolusVelocity, vertVelocityTop, &
       !$acc                  vertTransportVelocityTop, vertGMBolusVelocityTop, invAreaCell, &
-      !$acc                  minLevelCell) &
+      !$acc                  minLevelCell,vertMLEBolusVelocityTop, normalMLEVelocity) &
       !$acc          private(invAreaCell1, i, iEdge, edgeSignOnCell_temp, dcEdge_temp, &
       !$acc                  dvEdge_temp, k, r_tmp)
 #else
@@ -1687,6 +1694,7 @@ contains
          div_hu(:) = 0.0_RKIND
          div_huTransport(:) = 0.0_RKIND
          div_huGMBolus(:) = 0.0_RKIND
+         div_huMLEBolus(:) = 0.0_RKIND
          invAreaCell1 = invAreaCell(iCell)
          do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
@@ -1708,6 +1716,9 @@ contains
                div_huGMBolus(k) = div_huGMBolus(k) &
                                   - layerThicknessEdgeFlux(k, iEdge) * edgeSignOnCell_temp * dvEdge_temp &
                                   * normalGMBolusVelocity(k, iEdge) * invAreaCell1
+               div_huMLEBolus(k) = div_huMLEBolus(k) &
+                                  - layerThicknessEdgeFlux(k, iEdge) * edgeSignOnCell_temp * dvEdge_temp &
+                                  * normalMLEVelocity(k, iEdge) * invAreaCell1
             end do
          end do
          ! Vertical velocity at bottom (maxLevelCell(iCell)+1) is zero, initialized above.
@@ -1717,6 +1728,7 @@ contains
             vertVelocityTop(k,iCell) = vertVelocityTop(k+1,iCell) - div_hu(k)
             vertTransportVelocityTop(k,iCell) = vertTransportVelocityTop(k+1,iCell) - div_huTransport(k)
             vertGMBolusVelocityTop(k,iCell) = vertGMBolusVelocityTop(k+1,iCell) - div_huGMBolus(k)
+            vertMLEBolusVelocityTop(k,iCell) = vertMLEBolusVelocityTop(k+1,iCell) - div_huMLEBolus(k)
          end do
       end do
 #ifndef MPAS_OPENACC
@@ -3113,6 +3125,14 @@ contains
                        GMBolusVelocityZ,            &
                        GMBolusVelocityZonal,        &
                        GMBolusVelocityMeridional    &
+                      )
+
+      call mpas_reconstruct(meshPool, normalMLEvelocity,          &
+                       mleVelocityX,            &
+                       mleVelocityY,            &
+                       mleVelocityZ,            &
+                       mleVelocityZonal,        &
+                       mleVelocityMeridional    &
                       )
 
       call mpas_reconstruct(meshPool, gmStreamFuncTopOfEdge,          &

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -1669,32 +1669,116 @@ contains
       !
       ! Compute divergence, kinetic energy, and vertical velocity
       !
-      allocate(div_hu(nVertLevels),div_huTransport(nVertLevels),div_huGMBolus(nVertLevels))
-      allocate(div_huMLEBolus(nVertLevels))
+      allocate(div_hu(nVertLevels),div_huTransport(nVertLevels))
+
+      if (config_submesoscale_enable) then
+         allocate(div_huMLEBolus(nVertLevels))
+#ifdef MPAS_OPENACC
+         !$acc parallel loop gang vector &
+         !$acc          present(nEdgesOnCell, edgesOnCell, edgeSignonCell, dcEdge, dvEdge, &
+         !$acc                  areaCell, layerThicknessEdgeFlux, normalMLEBolusVelocity, &
+         !$acc                  vertMLEBolusVelocityTop, invAreaCell, minLevelCell) &
+         !$acc          private(invAreaCell1, i, iEdge, edgeSignOnCell_temp, dcEdge_temp, &
+         !$acc                  dvEdge_temp, k)
+#else
+         !$omp parallel
+         !$omp do schedule(runtime) &
+         !$omp private(i, iEdge, invAreaCell1, edgeSignOnCell_temp, dcEdge_temp, dvEdge_temp, &
+         !$omp         k, div_huMLEBolus)
+#endif
+         do iCell = 1, nCells
+            div_huGMBolus(:) = 0.0_RKIND
+            invAreaCell1 = invAreaCell(iCell)
+            do i = 1, nEdgesOnCell(iCell)
+               iEdge = edgesOnCell(i, iCell)
+               edgeSignOnCell_temp = edgeSignOnCell(i, iCell)
+               dcEdge_temp = dcEdge(iEdge)
+               dvEdge_temp = dvEdge(iEdge)
+               do k = minLevelCell(iCell), maxLevelCell(iCell)
+                  ! Compute vertical velocity from the horizontal GM Bolus velocity
+                  div_huMLEBolus(k) = div_huMLEBolus(k) &
+                                     - layerThicknessEdgeFlux(k, iEdge) * edgeSignOnCell_temp * dvEdge_temp &
+                                     * normalMLEBolusVelocity(k, iEdge) * invAreaCell1
+               end do
+            end do
+            ! Vertical velocity at bottom (maxLevelCell(iCell)+1) is zero, initialized above.
+            vertMLEBolusVelocityTop(1:minLevelCell(iCell)-1, iCell) = 0.0_RKIND
+            vertMLEBolusVelocityTop(maxLevelCell(iCell)+1, iCell) = 0.0_RKIND
+            do k = maxLevelCell(iCell), 1, -1
+               vertMLEBolusVelocityTop(k,iCell) = vertMLEBolusVelocityTop(k+1,iCell) - div_huGMBolus(k)
+            end do
+         end do
+#ifndef MPAS_OPENACC
+         !$omp end do
+         !$omp end parallel
+#endif
+         deallocate(div_huMLEBolus)
+      end if !config_submesoscale_enable
+
+      if (config_use_gm) then
+         allocate(div_huGMBolus(nVertLevels))
+#ifdef MPAS_OPENACC
+         !$acc parallel loop gang vector &
+         !$acc          present(nEdgesOnCell, edgesOnCell, edgeSignonCell, dcEdge, dvEdge, &
+         !$acc                  areaCell, layerThicknessEdgeFlux, normalGMBolusVelocity, &
+         !$acc                  vertGMBolusVelocityTop, invAreaCell, minLevelCell) &
+         !$acc          private(invAreaCell1, i, iEdge, edgeSignOnCell_temp, dcEdge_temp, &
+         !$acc                  dvEdge_temp, k)
+#else
+         !$omp parallel
+         !$omp do schedule(runtime) &
+         !$omp private(i, iEdge, invAreaCell1, edgeSignOnCell_temp, dcEdge_temp, dvEdge_temp, &
+         !$omp         k, div_huGMBolus)
+#endif
+         do iCell = 1, nCells
+            div_huGMBolus(:) = 0.0_RKIND
+            invAreaCell1 = invAreaCell(iCell)
+            do i = 1, nEdgesOnCell(iCell)
+               iEdge = edgesOnCell(i, iCell)
+               edgeSignOnCell_temp = edgeSignOnCell(i, iCell)
+               dcEdge_temp = dcEdge(iEdge)
+               dvEdge_temp = dvEdge(iEdge)
+               do k = minLevelCell(iCell), maxLevelCell(iCell)
+                  ! Compute vertical velocity from the horizontal GM Bolus velocity
+                  div_huGMBolus(k) = div_huGMBolus(k) &
+                                     - layerThicknessEdgeFlux(k, iEdge) * edgeSignOnCell_temp * dvEdge_temp &
+                                     * normalGMBolusVelocity(k, iEdge) * invAreaCell1
+               end do
+            end do
+            ! Vertical velocity at bottom (maxLevelCell(iCell)+1) is zero, initialized above.
+            vertGMBolusVelocityTop(1:minLevelCell(iCell)-1, iCell) = 0.0_RKIND
+            vertGMBolusVelocityTop(maxLevelCell(iCell)+1, iCell) = 0.0_RKIND
+            do k = maxLevelCell(iCell), 1, -1
+               vertGMBolusVelocityTop(k,iCell) = vertGMBolusVelocityTop(k+1,iCell) - div_huGMBolus(k)
+            end do
+         end do
+#ifndef MPAS_OPENACC
+         !$omp end do
+         !$omp end parallel
+#endif
+         deallocate(div_huGMBolus)
+      end if !config_use_gm
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector &
       !$acc          present(divergence, kineticEnergyCell, &
       !$acc                  areaCell, nEdgesOnCell, edgesOnCell, edgeSignOnCell, dcEdge, dvEdge, &
       !$acc                  maxLevelCell, normalVelocity, divergence, layerThicknessEdgeFlux, &
-      !$acc                  normalTransportVelocity, normalGMBolusVelocity, vertVelocityTop, &
-      !$acc                  vertTransportVelocityTop, vertGMBolusVelocityTop, invAreaCell, &
-      !$acc                  minLevelCell,vertMLEBolusVelocityTop, normalMLEVelocity) &
+      !$acc                  normalTransportVelocity, vertVelocityTop, vertTransportVelocityTop, &
+      !$acc                  invAreaCell, minLevelCell) &
       !$acc          private(invAreaCell1, i, iEdge, edgeSignOnCell_temp, dcEdge_temp, &
       !$acc                  dvEdge_temp, k, r_tmp)
 #else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp private(i, iEdge, invAreaCell1, edgeSignOnCell_temp, dcEdge_temp, dvEdge_temp, &
-      !$omp         k, r_tmp, div_hu, div_huTransport, div_huGMBolus)
+      !$omp         k, r_tmp, div_hu, div_huTransport)
 #endif
       do iCell = 1, nCells
          divergence(:, iCell) = 0.0_RKIND
          kineticEnergyCell(:, iCell) = 0.0_RKIND
          div_hu(:) = 0.0_RKIND
          div_huTransport(:) = 0.0_RKIND
-         div_huGMBolus(:) = 0.0_RKIND
-         div_huMLEBolus(:) = 0.0_RKIND
          invAreaCell1 = invAreaCell(iCell)
          do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
@@ -1712,13 +1796,6 @@ contains
                div_huTransport(k) = div_huTransport(k) &
                                     - layerThicknessEdgeFlux(k, iEdge) * edgeSignOnCell_temp &
                                     * dvEdge_temp * normalTransportVelocity(k, iEdge) * invAreaCell1
-               ! Compute vertical velocity from the horizontal GM Bolus velocity
-               div_huGMBolus(k) = div_huGMBolus(k) &
-                                  - layerThicknessEdgeFlux(k, iEdge) * edgeSignOnCell_temp * dvEdge_temp &
-                                  * normalGMBolusVelocity(k, iEdge) * invAreaCell1
-               div_huMLEBolus(k) = div_huMLEBolus(k) &
-                                  - layerThicknessEdgeFlux(k, iEdge) * edgeSignOnCell_temp * dvEdge_temp &
-                                  * normalMLEVelocity(k, iEdge) * invAreaCell1
             end do
          end do
          ! Vertical velocity at bottom (maxLevelCell(iCell)+1) is zero, initialized above.
@@ -1727,8 +1804,6 @@ contains
          do k = maxLevelCell(iCell), 1, -1
             vertVelocityTop(k,iCell) = vertVelocityTop(k+1,iCell) - div_hu(k)
             vertTransportVelocityTop(k,iCell) = vertTransportVelocityTop(k+1,iCell) - div_huTransport(k)
-            vertGMBolusVelocityTop(k,iCell) = vertGMBolusVelocityTop(k+1,iCell) - div_huGMBolus(k)
-            vertMLEBolusVelocityTop(k,iCell) = vertMLEBolusVelocityTop(k+1,iCell) - div_huMLEBolus(k)
          end do
       end do
 #ifndef MPAS_OPENACC
@@ -1736,7 +1811,7 @@ contains
       !$omp end parallel
 #endif
 
-      deallocate(div_hu,div_huTransport,div_huGMBolus)
+      deallocate(div_hu,div_huTransport)
 
       nEdges = nEdgesHalo( 2 )
 #ifdef MPAS_OPENACC

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -236,9 +236,18 @@ contains
       ! in and out: vertVelocityTop
       call ocn_diagnostic_solve_vortVel(relativeVorticity, &
              layerThickEdgeFlux, normalVelocity, normalTransportVelocity, &
-             normalGMBolusVelocity, normalMLEvelocity, vertVelocityTop, vertTransportVelocityTop, &
-             vertGMBolusVelocityTop, vertMLEBolusVelocityTop, relativeVorticityCell, &
+             vertVelocityTop, vertTransportVelocityTop, relativeVorticityCell, &
              divergence, kineticEnergyCell, tangentialVelocity)
+
+      !compute vertical velocity due to gm bolus velocity if requested
+      if (config_use_gm) then
+         call ocn_diagnostic_solve_GMvel(layerThickEdgeFlux, normalGMBolusVelocity, vertGMBolusVelocityTop)
+      end if
+
+      !compute vertical velocity due to submesoscale eddies (MLE) velocity if requested
+      if (config_submesoscale_enable) then
+         call ocn_diagnostic_solve_MLEvel(layerThickEdgeFlux, normalMLEVelocity, vertMLEBolusVelocityTop)
+      end if
 
       if ( configVertAdvMethod == vertAdvRemap ) then
 
@@ -1551,6 +1560,206 @@ contains
 
 !***********************************************************************
 !
+!  routine ocn_diagnostic_solve_GMvel
+!
+!> \brief   Computes vertical velocity from GM bolus velocity
+!> \author  Luke Van Roekel
+!> \date    August 2022
+!> \details
+!>  This routine computes the diagnostic vertical velocity from 
+!>    the normal velocity due to GM bolus velocity
+!
+!-----------------------------------------------------------------------
+   subroutine ocn_diagnostic_solve_GMvel(layerThickEdgeFlux, normalGMBolusVelocity, &
+                                         vertGMBolusVelocityTop)!{{{
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickEdgeFlux,     &
+         normalGMBolusVelocity
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         vertGMBolusVelocityTop
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: nCells, nEdges
+      integer :: iCell, iVertex, iEdge
+      integer :: i, j, k
+      integer :: edgeSignOnCell_temp, eoe
+      real(kind=RKIND) :: invAreaCell1
+      real(kind=RKIND) :: dcEdge_temp, dvEdge_temp, r_tmp, weightsOnEdge_temp
+
+      real (kind=RKIND), dimension(:), allocatable:: div_huGMBolus
+
+#ifdef MPAS_OPENACC
+      !$acc declare device_resident(div_hu, div_huTransport, div_huGMBolus, div_huMLEBolus)
+#endif
+
+      ! Need owned cells for relativeVorticityCell
+      nCells = nCellsOwned
+
+      if (.not. config_use_gm) return
+
+      allocate(div_huGMBolus(nVertLevels))
+#ifdef MPAS_OPENACC
+      !$acc parallel loop gang vector &
+      !$acc          present(nEdgesOnCell, edgesOnCell, edgeSignonCell, dcEdge, dvEdge, &
+      !$acc                  areaCell, layerThicknessEdgeFlux, normalGMBolusVelocity, &
+      !$acc                  vertGMBolusVelocityTop, invAreaCell, minLevelCell) &
+      !$acc          private(invAreaCell1, i, iEdge, edgeSignOnCell_temp, dcEdge_temp, &
+      !$acc                  dvEdge_temp, k)
+#else
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(i, iEdge, invAreaCell1, edgeSignOnCell_temp, dcEdge_temp, dvEdge_temp, &
+      !$omp         k, div_huGMBolus)
+#endif
+      do iCell = 1, nCells
+         div_huGMBolus(:) = 0.0_RKIND
+         invAreaCell1 = invAreaCell(iCell)
+         do i = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i, iCell)
+            edgeSignOnCell_temp = edgeSignOnCell(i, iCell)
+            dcEdge_temp = dcEdge(iEdge)
+            dvEdge_temp = dvEdge(iEdge)
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
+               ! Compute vertical velocity from the horizontal GM Bolus velocity
+               div_huGMBolus(k) = div_huGMBolus(k) &
+                                  - layerThickEdgeFlux(k, iEdge) * edgeSignOnCell_temp * dvEdge_temp &
+                                  * normalGMBolusVelocity(k, iEdge) * invAreaCell1
+            end do
+         end do
+         ! Vertical velocity at bottom (maxLevelCell(iCell)+1) is zero, initialized above.
+         vertGMBolusVelocityTop(1:minLevelCell(iCell)-1, iCell) = 0.0_RKIND
+         vertGMBolusVelocityTop(maxLevelCell(iCell)+1, iCell) = 0.0_RKIND
+         do k = maxLevelCell(iCell), 1, -1
+            vertGMBolusVelocityTop(k,iCell) = vertGMBolusVelocityTop(k+1,iCell) - div_huGMBolus(k)
+         end do
+      end do
+#ifndef MPAS_OPENACC
+      !$omp end do
+      !$omp end parallel
+#endif
+      deallocate(div_huGMBolus)
+
+   end subroutine ocn_diagnostic_solve_GMvel!}}}
+
+!***********************************************************************
+!
+!  routine ocn_diagnostic_solve_MLEvel
+!
+!> \brief   Computes vertical velocity from MLE bolus velocity
+!> \author  Luke Van Roekel
+!> \date    August 2022
+!> \details
+!>  This routine computes the diagnostic vertical velocity from 
+!>    the normal velocity due to MLE (submesoscale eddy) bolus velocity
+!
+!-----------------------------------------------------------------------
+   subroutine ocn_diagnostic_solve_MLEvel(layerThickEdgeFlux, normalMLEVelocity, &
+                                         vertMLEBolusVelocityTop)!{{{
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickEdgeFlux,     &
+         normalMLEVelocity
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: &
+         vertMLEBolusVelocityTop
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: nCells, nEdges
+      integer :: iCell, iVertex, iEdge
+      integer :: i, j, k
+      integer :: edgeSignOnCell_temp, eoe
+      real(kind=RKIND) :: invAreaCell1
+      real(kind=RKIND) :: dcEdge_temp, dvEdge_temp, r_tmp, weightsOnEdge_temp
+
+      real (kind=RKIND), dimension(:), allocatable:: div_huMLEBolus
+
+#ifdef MPAS_OPENACC
+      !$acc declare device_resident(div_huMLEBolus)
+#endif
+
+      nCells = nCellsOwned
+      if (.not. config_submesoscale_enable) return
+
+      allocate(div_huMLEBolus(nVertLevels))
+#ifdef MPAS_OPENACC
+      !$acc parallel loop gang vector &
+      !$acc          present(nEdgesOnCell, edgesOnCell, edgeSignonCell, dcEdge, dvEdge, &
+      !$acc                  areaCell, layerThicknessEdgeFlux, normalMLEVelocity, &
+      !$acc                  vertMLEBolusVelocityTop, invAreaCell, minLevelCell) &
+      !$acc          private(invAreaCell1, i, iEdge, edgeSignOnCell_temp, dcEdge_temp, &
+      !$acc                  dvEdge_temp, k)
+#else
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(i, iEdge, invAreaCell1, edgeSignOnCell_temp, dcEdge_temp, dvEdge_temp, &
+      !$omp         k, div_huMLEBolus)
+#endif
+      do iCell = 1, nCells
+         div_huMLEBolus(:) = 0.0_RKIND
+         invAreaCell1 = invAreaCell(iCell)
+         do i = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i, iCell)
+            edgeSignOnCell_temp = edgeSignOnCell(i, iCell)
+            dcEdge_temp = dcEdge(iEdge)
+            dvEdge_temp = dvEdge(iEdge)
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
+               ! Compute vertical velocity from the horizontal GM Bolus velocity
+               div_huMLEBolus(k) = div_huMLEBolus(k) &
+                                   - layerThickEdgeFlux(k, iEdge) * edgeSignOnCell_temp * dvEdge_temp &
+                                   * normalMLEVelocity(k, iEdge) * invAreaCell1
+            end do
+         end do
+         ! Vertical velocity at bottom (maxLevelCell(iCell)+1) is zero, initialized above.
+         vertMLEBolusVelocityTop(1:minLevelCell(iCell)-1, iCell) = 0.0_RKIND
+         vertMLEBolusVelocityTop(maxLevelCell(iCell)+1, iCell) = 0.0_RKIND
+         do k = maxLevelCell(iCell), 1, -1
+            vertMLEBolusVelocityTop(k,iCell) = vertMLEBolusVelocityTop(k+1,iCell) - div_huMLEBolus(k)
+         end do
+      end do
+#ifndef MPAS_OPENACC
+      !$omp end do
+      !$omp end parallel
+#endif
+      deallocate(div_huMLEBolus)
+
+   end subroutine ocn_diagnostic_solve_MLEvel!}}}
+
+!***********************************************************************
+!
 !  routine ocn_diagnostic_solve_vortVel
 !
 !> \brief   Computes diagnostic variables for vorticity and velocity
@@ -1563,8 +1772,7 @@ contains
 !-----------------------------------------------------------------------
    subroutine ocn_diagnostic_solve_vortVel(relativeVorticity, &
                 layerThicknessEdgeFlux, normalVelocity, normalTransportVelocity, &
-                normalGMBolusVelocity, normalMLEVelocity, vertVelocityTop, vertTransportVelocityTop, &
-                vertGMBolusVelocityTop, vertMLEBolusVelocityTop, relativeVorticityCell, &
+                vertVelocityTop, vertTransportVelocityTop, relativeVorticityCell, &
                 divergence, kineticEnergyCell, tangentialVelocity)!{{{
 
       implicit none
@@ -1583,10 +1791,6 @@ contains
          normalVelocity
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          normalTransportVelocity
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         normalGMBolusVelocity
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         normalMLEVelocity
 
       !-----------------------------------------------------------------
       !
@@ -1598,10 +1802,6 @@ contains
          vertVelocityTop
       real (kind=RKIND), dimension(:,:), intent(out) :: &
          vertTransportVelocityTop
-      real (kind=RKIND), dimension(:,:), intent(out) :: &
-         vertGMBolusVelocityTop
-      real (kind=RKIND), dimension(:,:), intent(out) :: &
-         vertMLEBolusVelocityTop
       real (kind=RKIND), dimension(:,:), intent(out) :: &
          relativeVorticityCell
       real (kind=RKIND), dimension(:,:), intent(out) :: &
@@ -1624,11 +1824,10 @@ contains
       real(kind=RKIND) :: invAreaCell1
       real(kind=RKIND) :: dcEdge_temp, dvEdge_temp, r_tmp, weightsOnEdge_temp
 
-      real (kind=RKIND), dimension(:), allocatable:: div_hu,div_huTransport,div_huGMBolus
-      real (kind=RKIND), dimension(:), allocatable:: div_huMLEBolus
+      real (kind=RKIND), dimension(:), allocatable:: div_hu,div_huTransport
 
 #ifdef MPAS_OPENACC
-      !$acc declare device_resident(div_hu, div_huTransport, div_huGMBolus, div_huMLEBolus)
+      !$acc declare device_resident(div_hu, div_huTransport)
 #endif
 
       ! Need owned cells for relativeVorticityCell
@@ -1670,94 +1869,6 @@ contains
       ! Compute divergence, kinetic energy, and vertical velocity
       !
       allocate(div_hu(nVertLevels),div_huTransport(nVertLevels))
-
-      if (config_submesoscale_enable) then
-         allocate(div_huMLEBolus(nVertLevels))
-#ifdef MPAS_OPENACC
-         !$acc parallel loop gang vector &
-         !$acc          present(nEdgesOnCell, edgesOnCell, edgeSignonCell, dcEdge, dvEdge, &
-         !$acc                  areaCell, layerThicknessEdgeFlux, normalMLEVelocity, &
-         !$acc                  vertMLEBolusVelocityTop, invAreaCell, minLevelCell) &
-         !$acc          private(invAreaCell1, i, iEdge, edgeSignOnCell_temp, dcEdge_temp, &
-         !$acc                  dvEdge_temp, k)
-#else
-         !$omp parallel
-         !$omp do schedule(runtime) &
-         !$omp private(i, iEdge, invAreaCell1, edgeSignOnCell_temp, dcEdge_temp, dvEdge_temp, &
-         !$omp         k, div_huMLEBolus)
-#endif
-         do iCell = 1, nCells
-            div_huGMBolus(:) = 0.0_RKIND
-            invAreaCell1 = invAreaCell(iCell)
-            do i = 1, nEdgesOnCell(iCell)
-               iEdge = edgesOnCell(i, iCell)
-               edgeSignOnCell_temp = edgeSignOnCell(i, iCell)
-               dcEdge_temp = dcEdge(iEdge)
-               dvEdge_temp = dvEdge(iEdge)
-               do k = minLevelCell(iCell), maxLevelCell(iCell)
-                  ! Compute vertical velocity from the horizontal GM Bolus velocity
-                  div_huMLEBolus(k) = div_huMLEBolus(k) &
-                                     - layerThicknessEdgeFlux(k, iEdge) * edgeSignOnCell_temp * dvEdge_temp &
-                                     * normalMLEVelocity(k, iEdge) * invAreaCell1
-               end do
-            end do
-            ! Vertical velocity at bottom (maxLevelCell(iCell)+1) is zero, initialized above.
-            vertMLEBolusVelocityTop(1:minLevelCell(iCell)-1, iCell) = 0.0_RKIND
-            vertMLEBolusVelocityTop(maxLevelCell(iCell)+1, iCell) = 0.0_RKIND
-            do k = maxLevelCell(iCell), 1, -1
-               vertMLEBolusVelocityTop(k,iCell) = vertMLEBolusVelocityTop(k+1,iCell) - div_huGMBolus(k)
-            end do
-         end do
-#ifndef MPAS_OPENACC
-         !$omp end do
-         !$omp end parallel
-#endif
-         deallocate(div_huMLEBolus)
-      end if !config_submesoscale_enable
-
-      if (config_use_gm) then
-         allocate(div_huGMBolus(nVertLevels))
-#ifdef MPAS_OPENACC
-         !$acc parallel loop gang vector &
-         !$acc          present(nEdgesOnCell, edgesOnCell, edgeSignonCell, dcEdge, dvEdge, &
-         !$acc                  areaCell, layerThicknessEdgeFlux, normalGMBolusVelocity, &
-         !$acc                  vertGMBolusVelocityTop, invAreaCell, minLevelCell) &
-         !$acc          private(invAreaCell1, i, iEdge, edgeSignOnCell_temp, dcEdge_temp, &
-         !$acc                  dvEdge_temp, k)
-#else
-         !$omp parallel
-         !$omp do schedule(runtime) &
-         !$omp private(i, iEdge, invAreaCell1, edgeSignOnCell_temp, dcEdge_temp, dvEdge_temp, &
-         !$omp         k, div_huGMBolus)
-#endif
-         do iCell = 1, nCells
-            div_huGMBolus(:) = 0.0_RKIND
-            invAreaCell1 = invAreaCell(iCell)
-            do i = 1, nEdgesOnCell(iCell)
-               iEdge = edgesOnCell(i, iCell)
-               edgeSignOnCell_temp = edgeSignOnCell(i, iCell)
-               dcEdge_temp = dcEdge(iEdge)
-               dvEdge_temp = dvEdge(iEdge)
-               do k = minLevelCell(iCell), maxLevelCell(iCell)
-                  ! Compute vertical velocity from the horizontal GM Bolus velocity
-                  div_huGMBolus(k) = div_huGMBolus(k) &
-                                     - layerThicknessEdgeFlux(k, iEdge) * edgeSignOnCell_temp * dvEdge_temp &
-                                     * normalGMBolusVelocity(k, iEdge) * invAreaCell1
-               end do
-            end do
-            ! Vertical velocity at bottom (maxLevelCell(iCell)+1) is zero, initialized above.
-            vertGMBolusVelocityTop(1:minLevelCell(iCell)-1, iCell) = 0.0_RKIND
-            vertGMBolusVelocityTop(maxLevelCell(iCell)+1, iCell) = 0.0_RKIND
-            do k = maxLevelCell(iCell), 1, -1
-               vertGMBolusVelocityTop(k,iCell) = vertGMBolusVelocityTop(k+1,iCell) - div_huGMBolus(k)
-            end do
-         end do
-#ifndef MPAS_OPENACC
-         !$omp end do
-         !$omp end parallel
-#endif
-         deallocate(div_huGMBolus)
-      end if !config_use_gm
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector &
@@ -3194,7 +3305,8 @@ contains
                        transportVelocityMeridional    &
                       )
 
-      call mpas_reconstruct(meshPool, normalGMBolusVelocity,          &
+      if(config_use_gm) then 
+         call mpas_reconstruct(meshPool, normalGMBolusVelocity,          &
                        eddyVelocityX,            &
                        eddyVelocityY,            &
                        eddyVelocityZ,            &
@@ -3202,7 +3314,17 @@ contains
                        GMBolusVelocityMeridional    &
                       )
 
-      call mpas_reconstruct(meshPool, normalMLEvelocity,          &
+         call mpas_reconstruct(meshPool, gmStreamFuncTopOfEdge,          &
+                      GMStreamFuncX,            &
+                      GMStreamFuncY,            &
+                      GMStreamFuncZ,            &
+                      GMStreamFuncZonal,        &
+                      GMStreamFuncMeridional    &
+                     )
+      end if
+
+      if (config_submesoscale_enable) then
+         call mpas_reconstruct(meshPool, normalMLEvelocity,          &
                        eddyVelocityX,            &
                        eddyVelocityY,            &
                        eddyVelocityZ,            &
@@ -3210,13 +3332,7 @@ contains
                        mleVelocityMeridional    &
                       )
 
-      call mpas_reconstruct(meshPool, gmStreamFuncTopOfEdge,          &
-                      GMStreamFuncX,            &
-                      GMStreamFuncY,            &
-                      GMStreamFuncZ,            &
-                      GMStreamFuncZonal,        &
-                      GMStreamFuncMeridional    &
-                     )
+      end if
 
       call mpas_timer_stop('reconstruct eddy vecs')
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -1737,7 +1737,7 @@ contains
             dcEdge_temp = dcEdge(iEdge)
             dvEdge_temp = dvEdge(iEdge)
             do k = minLevelCell(iCell), maxLevelCell(iCell)
-               ! Compute vertical velocity from the horizontal GM Bolus velocity
+               ! Compute vertical velocity from the horizontal MLE (submesoscale eddy)  Bolus velocity
                div_huMLEBolus(k) = div_huMLEBolus(k) &
                                    - layerThickEdgeFlux(k, iEdge) * edgeSignOnCell_temp * dvEdge_temp &
                                    * normalMLEVelocity(k, iEdge) * invAreaCell1

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -1676,7 +1676,7 @@ contains
 #ifdef MPAS_OPENACC
          !$acc parallel loop gang vector &
          !$acc          present(nEdgesOnCell, edgesOnCell, edgeSignonCell, dcEdge, dvEdge, &
-         !$acc                  areaCell, layerThicknessEdgeFlux, normalMLEBolusVelocity, &
+         !$acc                  areaCell, layerThicknessEdgeFlux, normalMLEVelocity, &
          !$acc                  vertMLEBolusVelocityTop, invAreaCell, minLevelCell) &
          !$acc          private(invAreaCell1, i, iEdge, edgeSignOnCell_temp, dcEdge_temp, &
          !$acc                  dvEdge_temp, k)
@@ -1698,7 +1698,7 @@ contains
                   ! Compute vertical velocity from the horizontal GM Bolus velocity
                   div_huMLEBolus(k) = div_huMLEBolus(k) &
                                      - layerThicknessEdgeFlux(k, iEdge) * edgeSignOnCell_temp * dvEdge_temp &
-                                     * normalMLEBolusVelocity(k, iEdge) * invAreaCell1
+                                     * normalMLEVelocity(k, iEdge) * invAreaCell1
                end do
             end do
             ! Vertical velocity at bottom (maxLevelCell(iCell)+1) is zero, initialized above.

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -99,10 +99,10 @@ module ocn_diagnostics_variables
 
    real (kind=RKIND), dimension(:,:), pointer :: &
       transportVelocityX, transportVelocityY, transportVelocityZ, transportVelocityZonal, &
-      transportVelocityMeridional, GMBolusVelocityX, GMBolusVelocityY, &
-      GMBolusVelocityZ, GMBolusVelocityZonal, GMBolusVelocityMeridional, gmStreamFuncTopOfEdge, &
+      transportVelocityMeridional, eddyVelocityX, eddyVelocityY, &
+      eddyVelocityZ, GMBolusVelocityZonal, GMBolusVelocityMeridional, gmStreamFuncTopOfEdge, &
       GMStreamFuncX, GMStreamFuncY, GMStreamFuncZ, GMStreamFuncZonal, GMStreamFuncMeridional, &
-      mleVelocityX, mleVelocityY, mleVelocityZ, mleVelocityZonal, mleVelocityMeridional
+      mleVelocityZonal, mleVelocityMeridional
 
    real (kind=RKIND), dimension(:,:), pointer :: rx1Edge
    real (kind=RKIND), dimension(:,:), pointer :: rx1Cell
@@ -127,7 +127,7 @@ module ocn_diagnostics_variables
    real(kind=RKIND), dimension(:), pointer   :: cGMphaseSpeed
    real(kind=RKIND), dimension(:,:,:), pointer :: slopeTriadUp, slopeTriadDown
 
-   integer, dimension(:), pointer :: indMLD, indMLDedge
+   integer, dimension(:), pointer :: indMLD
    real(kind=RKIND), dimension(:), pointer :: dThreshMLD
    real (kind=RKIND), dimension(:,:), pointer :: velocityX, velocityY, velocityZ
 
@@ -417,12 +417,6 @@ contains
                    GMStreamFuncZonal)
          call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncMeridional', &
                    GMStreamFuncMeridional)
-         call mpas_pool_get_array(diagnosticsPool, 'mleVelocityX', &
-                   mleVelocityX)
-         call mpas_pool_get_array(diagnosticsPool, 'mleVelocityY', &
-                   mleVelocityY)
-         call mpas_pool_get_array(diagnosticsPool, 'mleVelocityZ', &
-                   mleVelocityZ)
          call mpas_pool_get_array(diagnosticsPool, 'mleVelocityZonal', &
                    mleVelocityZonal)
          call mpas_pool_get_array(diagnosticsPool, 'mleVelocityMeridional', &
@@ -437,12 +431,12 @@ contains
                    mleVelocityZonal)
          call mpas_pool_get_array(diagnosticsPool, 'mleVelocityMeridional', &
                    mleVelocityMeridional)
-       call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityX', &
-                   GMBolusVelocityX)
-         call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityY', &
-                   GMBolusVelocityY)
-         call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityZ', &
-                   GMBolusVelocityZ)
+       call mpas_pool_get_array(diagnosticsPool, 'eddyVelocityX', &
+                   eddyVelocityX)
+         call mpas_pool_get_array(diagnosticsPool, 'eddyVelocityY', &
+                   eddyVelocityY)
+         call mpas_pool_get_array(diagnosticsPool, 'eddyVelocityZ', &
+                   eddyVelocityZ)
          call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityZonal', &
                    GMBolusVelocityZonal)
          call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityMeridional', &
@@ -623,7 +617,6 @@ contains
                'modifyLandIcePressureMask', &
                 modifyLandIcePressureMask)
       call mpas_pool_get_array(diagnosticsPool, 'indMLD', indMLD)
-      call mpas_pool_get_array(diagnosticsPool, 'indMLDedge', indMLDedge)
       call mpas_pool_get_array(diagnosticsPool, 'dThreshMLD', dThreshMLD)
       call mpas_pool_get_array(diagnosticsPool, 'surfacePressure', &
                 surfacePressure)
@@ -724,12 +717,9 @@ contains
          !$acc                   normRelVortEdge,                 &
          !$acc                   surfaceVelocity,                 &
          !$acc                   vertVelocityTop,                 &
-         !$acc                   mleVelocityX,                &
-         !$acc                   mleVelocityY,                &
-         !$acc                   mleVelocityZ,                &
-         !$acc                   GMBolusVelocityX,                &
-         !$acc                   GMBolusVelocityY,                &
-         !$acc                   GMBolusVelocityZ,                &
+         !$acc                   eddyVelocityX,                &
+         !$acc                   eddyVelocityY,                &
+         !$acc                   eddyVelocityZ,                &
          !$acc                   vertNonLocalFlux,                &
          !$acc                   vertViscTopOfEdge,               &
          !$acc                   gradSSHMeridional,               &
@@ -859,7 +849,6 @@ contains
       !$acc                   zTop,                                    &
       !$acc                   xtime,                                   &
       !$acc                   indMLD,                                  &
-      !$acc                   indMLDedge,                              &
       !$acc                   dThreshMLD,                              &
       !$acc                   density,                                 &
       !$acc                   betaEdge,                                &
@@ -976,12 +965,9 @@ contains
          !$acc                   normRelVortEdge,                 &
          !$acc                   surfaceVelocity,                 &
          !$acc                   vertVelocityTop,                 &
-         !$acc                   mleVelocityX,                &
-         !$acc                   mleVelocityY,                &
-         !$acc                   mleVelocityZ,                &
-         !$acc                   GMBolusVelocityX,                &
-         !$acc                   GMBolusVelocityY,                &
-         !$acc                   GMBolusVelocityZ,                &
+         !$acc                   eddyVelocityX,                &
+         !$acc                   eddyVelocityY,                &
+         !$acc                   eddyVelocityZ,                &
          !$acc                   vertNonLocalFlux,                &
          !$acc                   vertViscTopOfEdge,               &
          !$acc                   gradSSHMeridional,               &
@@ -1111,7 +1097,6 @@ contains
       !$acc                   zTop,                                    &
       !$acc                   xtime,                                   &
       !$acc                   indMLD,                                  &
-      !$acc                   indMLDedge,                              &
       !$acc                   dThreshMLD,                              &
       !$acc                   density,                                 &
       !$acc                   betaEdge,                                &
@@ -1186,12 +1171,9 @@ contains
                  normRelVortEdge,                 &
                  surfaceVelocity,                 &
                  vertVelocityTop,                 &
-                 GMBolusVelocityX,                &
-                 GMBolusVelocityY,                &
-                 GMBolusVelocityZ,                &
-                 mleVelocityX,                &
-                 mleVelocityY,                &
-                 mleVelocityZ,                &
+                 eddyVelocityX,                &
+                 eddyVelocityY,                &
+                 eddyVelocityZ,                &
                  vertNonLocalFlux,                &
                  vertViscTopOfEdge,               &
                  gradSSHMeridional,               &
@@ -1312,7 +1294,6 @@ contains
               zTop,                                    &
               xtime,                                   &
               indMLD,                                  &
-              indMLDedge,                              &
               dThreshMLD,                              &
               density,                                 &
               betaEdge,                                &

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -62,7 +62,9 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:,:), pointer :: vertVelocityTop
    real (kind=RKIND), dimension(:,:), pointer :: vertTransportVelocityTop
    real (kind=RKIND), dimension(:,:), pointer :: vertGMBolusVelocityTop
+   real (kind=RKIND), dimension(:,:), pointer :: vertMLEBolusVelocityTop
    real (kind=RKIND), dimension(:,:), pointer :: normalGMBolusVelocity
+   real (kind=RKIND), dimension(:,:), pointer :: normalMLEvelocity
    real (kind=RKIND), dimension(:,:), pointer :: normalTransportVelocity
    real (kind=RKIND), dimension(:,:), pointer :: RiTopOfCell
    real (kind=RKIND), dimension(:,:), pointer :: RiTopOfEdge
@@ -99,7 +101,8 @@ module ocn_diagnostics_variables
       transportVelocityX, transportVelocityY, transportVelocityZ, transportVelocityZonal, &
       transportVelocityMeridional, GMBolusVelocityX, GMBolusVelocityY, &
       GMBolusVelocityZ, GMBolusVelocityZonal, GMBolusVelocityMeridional, gmStreamFuncTopOfEdge, &
-      GMStreamFuncX, GMStreamFuncY, GMStreamFuncZ, GMStreamFuncZonal, GMStreamFuncMeridional
+      GMStreamFuncX, GMStreamFuncY, GMStreamFuncZ, GMStreamFuncZonal, GMStreamFuncMeridional, &
+      mleVelocityX, mleVelocityY, mleVelocityZ, mleVelocityZonal, mleVelocityMeridional
 
    real (kind=RKIND), dimension(:,:), pointer :: rx1Edge
    real (kind=RKIND), dimension(:,:), pointer :: rx1Cell
@@ -119,11 +122,13 @@ module ocn_diagnostics_variables
    real(kind=RKIND), dimension(:,:), pointer :: RediKappaScaling
    real(kind=RKIND), dimension(:,:), pointer :: RediKappaSfcTaper
    real(kind=RKIND), dimension(:,:), pointer :: k33
+   real(kind=RKIND), dimension(:,:), pointer :: gradBuoyEddy
    real(kind=RKIND), dimension(:), pointer   :: gmBolusKappa
    real(kind=RKIND), dimension(:), pointer   :: cGMphaseSpeed
    real(kind=RKIND), dimension(:,:,:), pointer :: slopeTriadUp, slopeTriadDown
 
-   integer, dimension(:), pointer :: indMLD
+   integer, dimension(:), pointer :: indMLD, indMLDedge
+   real(kind=RKIND), dimension(:), pointer :: dThreshMLD
    real (kind=RKIND), dimension(:,:), pointer :: velocityX, velocityY, velocityZ
 
    real (kind=RKIND), dimension(:,:), pointer :: vertAleTransportTop
@@ -263,6 +268,11 @@ contains
                    gmHorizontalTaper)
          call mpas_pool_get_array(diagnosticsPool, 'RossbyRadius', &
                    RossbyRadius)
+      end if
+
+      if (config_use_GM .or. config_submesoscale_enable) then
+         call mpas_pool_get_array(diagnosticsPool, 'gradBuoyEddy', &
+                   gradBuoyEddy)
       end if
 
       if ( config_compute_active_tracer_budgets ) then
@@ -407,7 +417,27 @@ contains
                    GMStreamFuncZonal)
          call mpas_pool_get_array(diagnosticsPool, 'GMStreamFuncMeridional', &
                    GMStreamFuncMeridional)
-         call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityX', &
+         call mpas_pool_get_array(diagnosticsPool, 'mleVelocityX', &
+                   mleVelocityX)
+         call mpas_pool_get_array(diagnosticsPool, 'mleVelocityY', &
+                   mleVelocityY)
+         call mpas_pool_get_array(diagnosticsPool, 'mleVelocityZ', &
+                   mleVelocityZ)
+         call mpas_pool_get_array(diagnosticsPool, 'mleVelocityZonal', &
+                   mleVelocityZonal)
+         call mpas_pool_get_array(diagnosticsPool, 'mleVelocityMeridional', &
+                   mleVelocityMeridional)
+         call mpas_pool_get_array(diagnosticsPool, 'mleVelocityX', &
+                   mleVelocityX)
+         call mpas_pool_get_array(diagnosticsPool, 'mleVelocityY', &
+                   mleVelocityY)
+         call mpas_pool_get_array(diagnosticsPool, 'mleVelocityZ', &
+                   mleVelocityZ)
+         call mpas_pool_get_array(diagnosticsPool, 'mleVelocityZonal', &
+                   mleVelocityZonal)
+         call mpas_pool_get_array(diagnosticsPool, 'mleVelocityMeridional', &
+                   mleVelocityMeridional)
+       call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityX', &
                    GMBolusVelocityX)
          call mpas_pool_get_array(diagnosticsPool, 'GMBolusVelocityY', &
                    GMBolusVelocityY)
@@ -419,8 +449,12 @@ contains
                    GMBolusVelocityMeridional)
          call mpas_pool_get_array(diagnosticsPool, 'normalGMBolusVelocity', &
                    normalGMBolusVelocity)
+         call mpas_pool_get_array(diagnosticsPool, 'normalMLEvelocity', &
+                   normalMLEvelocity)
          call mpas_pool_get_array(diagnosticsPool, 'vertGMBolusVelocityTop', &
                    vertGMBolusVelocityTop)
+         call mpas_pool_get_array(diagnosticsPool, 'vertMLEBolusVelocityTop', &
+                   vertMLEBolusVelocityTop)
 
          call mpas_pool_get_array(diagnosticsPool, 'layerThicknessEdgeFlux', &
                    layerThickEdgeFlux)
@@ -589,6 +623,8 @@ contains
                'modifyLandIcePressureMask', &
                 modifyLandIcePressureMask)
       call mpas_pool_get_array(diagnosticsPool, 'indMLD', indMLD)
+      call mpas_pool_get_array(diagnosticsPool, 'indMLDedge', indMLDedge)
+      call mpas_pool_get_array(diagnosticsPool, 'dThreshMLD', dThreshMLD)
       call mpas_pool_get_array(diagnosticsPool, 'surfacePressure', &
                 surfacePressure)
 
@@ -688,6 +724,9 @@ contains
          !$acc                   normRelVortEdge,                 &
          !$acc                   surfaceVelocity,                 &
          !$acc                   vertVelocityTop,                 &
+         !$acc                   mleVelocityX,                &
+         !$acc                   mleVelocityY,                &
+         !$acc                   mleVelocityZ,                &
          !$acc                   GMBolusVelocityX,                &
          !$acc                   GMBolusVelocityY,                &
          !$acc                   GMBolusVelocityZ,                &
@@ -710,12 +749,15 @@ contains
          !$acc                   BruntVaisalaFreqTop,             &
          !$acc                   vertAleTransportTop,             &
          !$acc                   GMBolusVelocityZonal,            &
+         !$acc                   mleVelocityZonal,            &
          !$acc                   bulkRichardsonNumber,            &
          !$acc                   gmStreamFuncTopOfEdge,           &
          !$acc                   indexSSHGradientZonal,           &
          !$acc                   relativeVorticityCell,           &
          !$acc                   normalGMBolusVelocity,           &
+         !$acc                   normalMLEvelocity,               &
          !$acc                   vertGMBolusVelocityTop,          &
+         !$acc                   vertMLEBolusVelocityTop,         &
          !$acc                   transportVelocityZonal,          &
          !$acc                   GMStreamFuncMeridional,          &
          !$acc                   indexSurfaceLayerDepth,          &
@@ -728,6 +770,7 @@ contains
          !$acc                   bulkRichardsonNumberBuoy,        &
          !$acc                   tracersSurfaceLayerValue,        &
          !$acc                   GMBolusVelocityMeridional,       &
+         !$acc                   mleVelocityMeridional,       &
          !$acc                   bulkRichardsonNumberShear,       &
          !$acc                   indexSurfaceVelocityZonal,       &
          !$acc                   normalVelocitySurfaceLayer,      &
@@ -756,6 +799,9 @@ contains
          !$acc                   gmHorizontalTaper,  &
          !$acc                   RossbyRadius  &
          !$acc                   )
+      end if
+      if (config_use_GM.or.config_submesoscale_enable) then
+         !$acc enter data create(gradBuoyEddy)
       end if
       if ( config_compute_active_tracer_budgets ) then
          !$acc enter data create(                                         &
@@ -813,6 +859,8 @@ contains
       !$acc                   zTop,                                    &
       !$acc                   xtime,                                   &
       !$acc                   indMLD,                                  &
+      !$acc                   indMLDedge,                              &
+      !$acc                   dThreshMLD,                              &
       !$acc                   density,                                 &
       !$acc                   betaEdge,                                &
       !$acc                   pressure,                                &
@@ -928,6 +976,9 @@ contains
          !$acc                   normRelVortEdge,                 &
          !$acc                   surfaceVelocity,                 &
          !$acc                   vertVelocityTop,                 &
+         !$acc                   mleVelocityX,                &
+         !$acc                   mleVelocityY,                &
+         !$acc                   mleVelocityZ,                &
          !$acc                   GMBolusVelocityX,                &
          !$acc                   GMBolusVelocityY,                &
          !$acc                   GMBolusVelocityZ,                &
@@ -950,12 +1001,15 @@ contains
          !$acc                   BruntVaisalaFreqTop,             &
          !$acc                   vertAleTransportTop,             &
          !$acc                   GMBolusVelocityZonal,            &
+         !$acc                   mleVelocityZonal,            &
          !$acc                   bulkRichardsonNumber,            &
          !$acc                   gmStreamFuncTopOfEdge,           &
          !$acc                   indexSSHGradientZonal,           &
          !$acc                   relativeVorticityCell,           &
          !$acc                   normalGMBolusVelocity,           &
+         !$acc                   normalMLEvelocity,               &
          !$acc                   vertGMBolusVelocityTop,          &
+         !$acc                   vertMLEBolusVelocityTop,         &
          !$acc                   transportVelocityZonal,          &
          !$acc                   GMStreamFuncMeridional,          &
          !$acc                   indexSurfaceLayerDepth,          &
@@ -967,6 +1021,7 @@ contains
          !$acc                   vertTransportVelocityTop,        &
          !$acc                   bulkRichardsonNumberBuoy,        &
          !$acc                   tracersSurfaceLayerValue,        &
+         !$acc                   mleVelocityMeridional,       &
          !$acc                   GMBolusVelocityMeridional,       &
          !$acc                   bulkRichardsonNumberShear,       &
          !$acc                   indexSurfaceVelocityZonal,       &
@@ -996,6 +1051,9 @@ contains
          !$acc                   gmHorizontalTaper,  &
          !$acc                   RossbyRadius  &
          !$acc                   )
+      end if
+      if (config_use_GM.or.config_submesoscale_enable) then
+         !$acc exit data delete(gradBuoyEddy)
       end if
       if ( config_compute_active_tracer_budgets ) then
          !$acc exit data delete(                                          &
@@ -1053,6 +1111,8 @@ contains
       !$acc                   zTop,                                    &
       !$acc                   xtime,                                   &
       !$acc                   indMLD,                                  &
+      !$acc                   indMLDedge,                              &
+      !$acc                   dThreshMLD,                              &
       !$acc                   density,                                 &
       !$acc                   betaEdge,                                &
       !$acc                   pressure,                                &
@@ -1129,6 +1189,9 @@ contains
                  GMBolusVelocityX,                &
                  GMBolusVelocityY,                &
                  GMBolusVelocityZ,                &
+                 mleVelocityX,                &
+                 mleVelocityY,                &
+                 mleVelocityZ,                &
                  vertNonLocalFlux,                &
                  vertViscTopOfEdge,               &
                  gradSSHMeridional,               &
@@ -1148,12 +1211,15 @@ contains
                  BruntVaisalaFreqTop,             &
                  vertAleTransportTop,             &
                  GMBolusVelocityZonal,            &
+                 mleVelocityZonal,            &
                  bulkRichardsonNumber,            &
                  gmStreamFuncTopOfEdge,           &
                  indexSSHGradientZonal,           &
                  relativeVorticityCell,           &
                  normalGMBolusVelocity,           &
+                 normalMLEvelocity,               &
                  vertGMBolusVelocityTop,          &
+                 vertMLEBolusVelocityTop,         &
                  transportVelocityZonal,          &
                  GMStreamFuncMeridional,          &
                  indexSurfaceLayerDepth,          &
@@ -1165,6 +1231,7 @@ contains
                  vertTransportVelocityTop,        &
                  bulkRichardsonNumberBuoy,        &
                  tracersSurfaceLayerValue,        &
+                 mleVelocityMeridional,       &
                  GMBolusVelocityMeridional,       &
                  bulkRichardsonNumberShear,       &
                  indexSurfaceVelocityZonal,       &
@@ -1189,6 +1256,9 @@ contains
                  RediHorizontalTaper, &
                  gmHorizontalTaper, &
                  RossbyRadius)
+      end if
+      if (config_use_GM.or.config_submesoscale_enable) then
+         nullify(gradBuoyEddy)
       end if
       if ( config_compute_active_tracer_budgets ) then
          nullify(activeTracerHorMixTendency,              &
@@ -1242,6 +1312,8 @@ contains
               zTop,                                    &
               xtime,                                   &
               indMLD,                                  &
+              indMLDedge,                              &
+              dThreshMLD,                              &
               density,                                 &
               betaEdge,                                &
               pressure,                                &

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -421,17 +421,7 @@ contains
                    mleVelocityZonal)
          call mpas_pool_get_array(diagnosticsPool, 'mleVelocityMeridional', &
                    mleVelocityMeridional)
-         call mpas_pool_get_array(diagnosticsPool, 'mleVelocityX', &
-                   mleVelocityX)
-         call mpas_pool_get_array(diagnosticsPool, 'mleVelocityY', &
-                   mleVelocityY)
-         call mpas_pool_get_array(diagnosticsPool, 'mleVelocityZ', &
-                   mleVelocityZ)
-         call mpas_pool_get_array(diagnosticsPool, 'mleVelocityZonal', &
-                   mleVelocityZonal)
-         call mpas_pool_get_array(diagnosticsPool, 'mleVelocityMeridional', &
-                   mleVelocityMeridional)
-       call mpas_pool_get_array(diagnosticsPool, 'eddyVelocityX', &
+         call mpas_pool_get_array(diagnosticsPool, 'eddyVelocityX', &
                    eddyVelocityX)
          call mpas_pool_get_array(diagnosticsPool, 'eddyVelocityY', &
                    eddyVelocityY)
@@ -717,9 +707,9 @@ contains
          !$acc                   normRelVortEdge,                 &
          !$acc                   surfaceVelocity,                 &
          !$acc                   vertVelocityTop,                 &
-         !$acc                   eddyVelocityX,                &
-         !$acc                   eddyVelocityY,                &
-         !$acc                   eddyVelocityZ,                &
+         !$acc                   eddyVelocityX,                   &
+         !$acc                   eddyVelocityY,                   &
+         !$acc                   eddyVelocityZ,                   &
          !$acc                   vertNonLocalFlux,                &
          !$acc                   vertViscTopOfEdge,               &
          !$acc                   gradSSHMeridional,               &
@@ -739,7 +729,7 @@ contains
          !$acc                   BruntVaisalaFreqTop,             &
          !$acc                   vertAleTransportTop,             &
          !$acc                   GMBolusVelocityZonal,            &
-         !$acc                   mleVelocityZonal,            &
+         !$acc                   mleVelocityZonal,                &
          !$acc                   bulkRichardsonNumber,            &
          !$acc                   gmStreamFuncTopOfEdge,           &
          !$acc                   indexSSHGradientZonal,           &
@@ -760,7 +750,7 @@ contains
          !$acc                   bulkRichardsonNumberBuoy,        &
          !$acc                   tracersSurfaceLayerValue,        &
          !$acc                   GMBolusVelocityMeridional,       &
-         !$acc                   mleVelocityMeridional,       &
+         !$acc                   mleVelocityMeridional,           &
          !$acc                   bulkRichardsonNumberShear,       &
          !$acc                   indexSurfaceVelocityZonal,       &
          !$acc                   normalVelocitySurfaceLayer,      &
@@ -965,9 +955,9 @@ contains
          !$acc                   normRelVortEdge,                 &
          !$acc                   surfaceVelocity,                 &
          !$acc                   vertVelocityTop,                 &
-         !$acc                   eddyVelocityX,                &
-         !$acc                   eddyVelocityY,                &
-         !$acc                   eddyVelocityZ,                &
+         !$acc                   eddyVelocityX,                   &
+         !$acc                   eddyVelocityY,                   &
+         !$acc                   eddyVelocityZ,                   &
          !$acc                   vertNonLocalFlux,                &
          !$acc                   vertViscTopOfEdge,               &
          !$acc                   gradSSHMeridional,               &
@@ -987,7 +977,7 @@ contains
          !$acc                   BruntVaisalaFreqTop,             &
          !$acc                   vertAleTransportTop,             &
          !$acc                   GMBolusVelocityZonal,            &
-         !$acc                   mleVelocityZonal,            &
+         !$acc                   mleVelocityZonal,                &
          !$acc                   bulkRichardsonNumber,            &
          !$acc                   gmStreamFuncTopOfEdge,           &
          !$acc                   indexSSHGradientZonal,           &
@@ -1007,7 +997,7 @@ contains
          !$acc                   vertTransportVelocityTop,        &
          !$acc                   bulkRichardsonNumberBuoy,        &
          !$acc                   tracersSurfaceLayerValue,        &
-         !$acc                   mleVelocityMeridional,       &
+         !$acc                   mleVelocityMeridional,           &
          !$acc                   GMBolusVelocityMeridional,       &
          !$acc                   bulkRichardsonNumberShear,       &
          !$acc                   indexSurfaceVelocityZonal,       &
@@ -1171,9 +1161,9 @@ contains
                  normRelVortEdge,                 &
                  surfaceVelocity,                 &
                  vertVelocityTop,                 &
-                 eddyVelocityX,                &
-                 eddyVelocityY,                &
-                 eddyVelocityZ,                &
+                 eddyVelocityX,                   &
+                 eddyVelocityY,                   &
+                 eddyVelocityZ,                   &
                  vertNonLocalFlux,                &
                  vertViscTopOfEdge,               &
                  gradSSHMeridional,               &
@@ -1193,7 +1183,7 @@ contains
                  BruntVaisalaFreqTop,             &
                  vertAleTransportTop,             &
                  GMBolusVelocityZonal,            &
-                 mleVelocityZonal,            &
+                 mleVelocityZonal,                &
                  bulkRichardsonNumber,            &
                  gmStreamFuncTopOfEdge,           &
                  indexSSHGradientZonal,           &
@@ -1213,7 +1203,7 @@ contains
                  vertTransportVelocityTop,        &
                  bulkRichardsonNumberBuoy,        &
                  tracersSurfaceLayerValue,        &
-                 mleVelocityMeridional,       &
+                 mleVelocityMeridional,           &
                  GMBolusVelocityMeridional,       &
                  bulkRichardsonNumberShear,       &
                  indexSurfaceVelocityZonal,       &

--- a/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
@@ -233,7 +233,7 @@ module ocn_eddy_parameterization_helpers
 
        !$omp parallel
        !$omp do schedule(runtime) &
-       !$omp private(refIndex, found_den_mld, k, localvals, den_ref_lev, dVp1, dV, mldTemp)
+       !$omp private(refIndex, found_den_mld, k, coeffs, den_ref_lev, dVp1, dV, mldTemp)
        do iCell = 1,nCells
 
           !Initialize RefIndex for cases of very shallow columns

--- a/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
@@ -166,8 +166,8 @@ module ocn_eddy_parameterization_helpers
      do iEdge = 1, nEdges
         if (maxLevelEdgeTop(iEdge) .GE. minLevelEdgeBot(iEdge)) then
            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)+1
-              gradBuoyEddy(k,iEdge) = gravity*(gradDensityTopOfEdge(k,iEdge) - dDensityDzTopOfEdge(k,iEdge) &
-                                             * gradZMidTopOfEdge(k,iEdge))/rho_sw
+              gradBuoyEddy(k,iEdge) = (gradDensityTopOfEdge(k,iEdge) - dDensityDzTopOfEdge(k,iEdge) &
+                                             * gradZMidTopOfEdge(k,iEdge))
            end do
         end if
      end do
@@ -193,79 +193,218 @@ module ocn_eddy_parameterization_helpers
   !>   The calculation is moved out of analysis members for this reason
   !***********************************************************************
 
-  subroutine ocn_eddy_compute_mixed_layer_depth(statePool)
+  subroutine ocn_eddy_compute_mixed_layer_depth(statePool, forcingPool)
 
-     type (mpas_pool_type), pointer, intent(in) :: statePool
+     type (mpas_pool_type), pointer, intent(in) :: statePool, forcingPool
 
      integer :: iEdge, nEdges, refIndex, cell1, cell2, nCells, k, iCell
      real(kind=RKIND) :: dDenThres, den_ref_lev
      real(kind=RKIND),dimension(:), allocatable :: depth
      integer, dimension(:), pointer :: landIceMask
      real (kind=RKIND), dimension(:,:), pointer :: layerThickness
+     real (kind=RKIND), dimension(:), pointer :: landIceDraft, landIcePressure
      logical :: found_den_mld
-     real (kind=RKIND) :: dV, dVp1, refDepth, coeffs(2), mldTemp
+     real (kind=RKIND) :: dV, dVp1, refDepth, coeffs(2), mldTemp, dz
+     real (kind=RKIND), dimension(:,:), allocatable :: pressureAdjustedForLandIce
 
-     call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
      nCells = nCellsAll
 
-     allocate(depth(nVertLevels))
-     refDepth = config_mld_reference_depth
+     if ( config_eddyMLD_use_old ) then
+       call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
+       call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
+       call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
 
-    !$omp parallel
-    !$omp do schedule(runtime) &
-    !$omp private(depth, refIndex, coeffs, found_den_mld, k, den_ref_lev, dVp1, dV, mldTemp)
-    do iCell = 1,nCells
+       allocate(pressureAdjustedForLandIce(nVertLevels, size(pressure,2)))
 
-       found_den_mld = .false.
-
-       depth(1) = 0.5_RKIND*layerThickness(1,iCell)
-       do k=2,maxLevelCell(iCell)
-          depth(k) = depth(k-1) + 0.5_RKIND*(layerThickness(k-1,iCell) + &
-                                             layerThickness(k  ,iCell))
-       end do
-
-       do k=1, maxLevelCell(iCell)-1
-          if(depth(k+1) >= refDepth) then
-             coeffs(2) = (potentialDensity(k+1,iCell) - potentialDensity(k,iCell)) &
-                          / (depth(k+1) - depth(k))
-             coeffs(1) = potentialDensity(k,iCell) - coeffs(2)*depth(k)
-
-             den_ref_lev = coeffs(2)*refDepth + coeffs(1)
-
-             refIndex=k
-             exit
-          end if
-       end do
-
-       do k=refIndex,maxLevelCell(iCell)-1
-
-          if(.not. found_den_mld .and. (potentialDensity(k+1,iCell) - den_ref_lev) .ge. &
-                   config_mixedLayerDepths_crit_dens_threshold) then
-             dVp1 = (potentialDensity(k+1,iCell) - den_ref_lev)
-             dV   = (potentialDensity(k  ,iCell) - den_ref_lev)
-
-             coeffs(2) = (depth(k+1) - depth(k)) / (dVp1 - dV)
-             coeffs(1) = depth(k) - coeffs(2)*dV
-
-             mldTemp = coeffs(2)*config_mixedLayerDepths_crit_dens_threshold + coeffs(1)
-             mldTemp=min(mldTemp,depth(k+1)) !make sure MLD isn't deeper than zMid(k+1)
-             dThreshMLD(iCell)=abs(max(mldTemp,depth(k))) !MLD should be deeper than zMid(k)
-             indMLD(iCell) = k+1
-             found_den_mld = .true.
-             exit
-          end if
-       end do
-
-       ! if the mixed layer depth is not found, it is set to the depth of the bottom most level
-       if(.not. found_den_mld) then
-          dThreshMLD(iCell) = depth(maxLevelCell(iCell))
-          indMLD(iCell) = maxLevelCell(iCell)
+       pressureAdjustedForLandIce(:,:) = pressure(:,:)
+       !If landice cavity remove land ice pressure to search for ML depth
+       if ( associated(landIcePressure) ) then
+         !$omp parallel
+         !$omp do schedule(runtime) private(k)
+         do iCell = 1,nCells
+           do k = 1,maxLevelCell(iCell)
+              pressureAdjustedForLandIce(k,iCell) = pressureAdjustedForLandIce(k,iCell)   &
+                                                          - landIcePressure(iCell)
+           end do
+         end do
+         !$omp end do
+         !$omp end parallel
        end if
-    end do !iCell
-    !$omp end do
-    !$omp end parallel
 
-    deallocate(depth)
-  end subroutine ocn_eddy_compute_mixed_layer_depth
+       !$omp parallel
+       !$omp do schedule(runtime) &
+       !$omp private(refIndex, found_den_mld, k, localvals, den_ref_lev, dVp1, dV, mldTemp)
+       do iCell = 1,nCells
+
+          !Initialize RefIndex for cases of very shallow columns
+          refIndex = maxLevelCell(iCell)
+          found_den_mld = .false.
+
+          do k=1, maxLevelCell(iCell)-1
+             if(pressureAdjustedForLandIce(k+1,iCell) > config_eddyMLD_reference_pressure) then
+
+                coeffs(2) = (potentialDensity(k+1,iCell) - potentialDensity(k,iCell)) /  &
+                            (pressureAdjustedForLandIce(k+1,iCell) - pressureAdjustedForLandIce(k,iCell))
+                coeffs(1) = potentialDensity(k,iCell) - coeffs(2)*pressureAdjustedForLandIce(k,iCell)
+
+                den_ref_lev = coeffs(2)*config_eddyMLD_reference_pressure + coeffs(1)
+
+                refIndex=k
+                exit
+             end if
+          end do
+
+          do k=refIndex,maxLevelCell(iCell)-1
+
+            if(.not. found_den_mld .and. abs(potentialDensity(k+1,iCell) - den_ref_lev) .ge. &
+                     config_eddyMLD_dens_threshold) then
+                dVp1 = abs(potentialDensity(k+1,iCell) - den_ref_lev)
+                dV   = abs(potentialDensity(k  ,iCell) - den_ref_lev)
+
+                coeffs(2) = (zMid(k+1,iCell) - zMid(k,iCell)) / (dVp1 - dV)
+                coeffs(1) = zMid(k,iCell) - coeffs(2)*dV
+
+                mldTemp = coeffs(2)*config_eddyMLD_dens_threshold + coeffs(1)
+
+                mldTemp=max(mldTemp,zMid(k+1,iCell)) !make sure MLD isn't deeper than zMid(k+1)
+                dThreshMLD(iCell)=abs(min(mldTemp,zMid(k,iCell))) !MLD should be deeper than zMid(k)
+                indMLD(iCell) = k+1
+                found_den_mld = .true.
+                exit
+             end if
+          end do
+
+          ! if the mixed layer depth is not found, it is set to the depth of the bottom most level
+
+          if(.not. found_den_mld) then
+             dThreshMLD(iCell) = abs(zMid(maxLevelCell(iCell),iCell))
+             indMLD(iCell) = maxLevelCell(iCell)
+          end if
+        end do !iCell
+        !$omp end do
+        !$omp end parallel
+
+        if (associated(landIceMask) ) then
+          !$omp parallel
+          !$omp do schedule(runtime)
+          do iCell = 1, nCells
+             dThreshMLD(iCell) = dThreshMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
+          end do
+          !$omp end do
+          !$omp end parallel
+        end if
+
+        deallocate(pressureAdjustedForLandIce)
+
+    else ! fixed mixed layer depth code
+       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
+       allocate(depth(nVertLevels))
+       refDepth = config_eddyMLD_reference_depth
+
+       !$omp parallel
+       !$omp do schedule(runtime) &
+       !$omp private(depth, refIndex, coeffs, found_den_mld, k, den_ref_lev, dVp1, dV, mldTemp)
+       do iCell = 1,nCells
+
+          found_den_mld = .false.
+
+          depth(1) = 0.5_RKIND*layerThickness(1,iCell)
+          do k=2,maxLevelCell(iCell)
+             depth(k) = depth(k-1) + 0.5_RKIND*(layerThickness(k-1,iCell) + &
+                                                layerThickness(k  ,iCell))
+          end do
+
+          do k=1, maxLevelCell(iCell)-1
+             if(depth(k+1) >= refDepth) then
+                coeffs(2) = (potentialDensity(k+1,iCell) - potentialDensity(k,iCell)) &
+                             / (depth(k+1) - depth(k))
+                coeffs(1) = potentialDensity(k,iCell) - coeffs(2)*depth(k)
+
+                den_ref_lev = coeffs(2)*refDepth + coeffs(1)
+
+                refIndex=k
+                exit
+             end if
+          end do
+
+          do k=refIndex,maxLevelCell(iCell)-1
+
+             if(.not. found_den_mld .and. (potentialDensity(k+1,iCell) - den_ref_lev) .ge. &
+                      config_eddyMLD_dens_threshold) then
+                dVp1 = (potentialDensity(k+1,iCell) - den_ref_lev)
+                dV   = (potentialDensity(k  ,iCell) - den_ref_lev)
+
+                coeffs(2) = (depth(k+1) - depth(k)) / (dVp1 - dV)
+                coeffs(1) = depth(k) - coeffs(2)*dV
+
+                mldTemp = coeffs(2)*config_eddyMLD_dens_threshold + coeffs(1)
+                mldTemp=min(mldTemp,depth(k+1)) !make sure MLD isn't deeper than zMid(k+1)
+                dThreshMLD(iCell)=abs(max(mldTemp,depth(k))) !MLD should be deeper than zMid(k)
+                indMLD(iCell) = k+1
+                found_den_mld = .true.
+                exit
+             end if
+          end do
+
+          ! if the mixed layer depth is not found, it is set to the depth of the bottom most level
+          if(.not. found_den_mld) then
+             dThreshMLD(iCell) = depth(maxLevelCell(iCell))
+             indMLD(iCell) = maxLevelCell(iCell)
+          end if
+       end do !iCell
+       !$omp end do
+       !$omp end parallel
+
+       deallocate(depth)
+
+    end if !end mld calculation choice
+
+end subroutine ocn_eddy_compute_mixed_layer_depth
+
+!***********************************************************************
+!
+!  routine interp_mld
+!
+!> \brief   Interpolates between model layers
+!> \author  Luke Van Roekel
+!> \date    September 2015
+!> \details
+!>  This routine conducts computations to compute various field values
+!>     between model levels (in pressure or depth) or could interpolate
+!>      between temperature/salinity/density values.  Interpolations are
+!>      of the form
+!>       y = coeffs(1)*x^3 + coeffs(2)*x^2 + coeffs(3)*x + coeffs(4)
+!
+!-----------------------------------------------------------------------
+
+   subroutine interp_mld(y0,y1,x0,x1,xT,interp_f,yT,xm1,ym1)
+
+   integer,intent(in) :: interp_f  ! linear, quadratic, or spline
+   real(kind=RKIND),intent(in)  :: y0,y1,x0,x1,xT
+   real(kind=RKIND),intent(inout) :: yT
+   real(kind=RKIND),optional,intent(in) :: xm1,ym1
+                ! these values are to match the slope at a given point
+
+!------------------------------------------------------------------------
+!
+!  Local variables for the interpolations
+!
+!------------------------------------------------------------------------
+
+   real(kind=RKIND) :: coeffs(4)   ! stores the coefficients for the interp
+   real(kind=RKIND) :: Minv(4,4)   ! holds values for computing quad and spline
+   real(kind=RKIND) :: det
+   real(kind=RKIND) :: rhs(4)
+   integer :: k,k2
+
+   coeffs(:) = 0.0_RKIND
+   Minv(:,:) = 0.0_RKIND
+   rhs(:)    = 0.0_RKIND
+
+          coeffs(2) = (y1-y0)/(x1-x0)
+          coeffs(1) = y0 - coeffs(2)*x0
+
+     yT = coeffs(4)*xT**3 + coeffs(3)*xT**2 + coeffs(2)*xT + coeffs(1)
+   end subroutine interp_mld
 
 end module ocn_eddy_parameterization_helpers

--- a/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
@@ -62,7 +62,7 @@ module ocn_eddy_parameterization_helpers
      !
      !-----------------------------------------------------------------
 
-     integer :: k, nEdges, nCells, iCell, iEdge, cell1, cell2, indMLDedge
+     integer :: k, nEdges, nCells, iCell, iEdge, cell1, cell2
      ! gradDensityEdge: Normal gradient of density
      !           units: none
      real(kind=RKIND), dimension(:, :), allocatable :: gradDensityEdge, gradDensityTopOfEdge, &
@@ -265,17 +265,6 @@ module ocn_eddy_parameterization_helpers
     !$omp end do
     !$omp end parallel
 
-    nEdges = nEdgesHalo(1)
-    !$omp parallel
-    !$omp do schedule(runtime) &
-    !$omp private(cell1,cell2)
-    do iEdge=1,nEdgesAll
-       cell1 = cellsOnEdge(1,iEdge)
-       cell2 = cellsOnEdge(2,iEdge)
-       indMLDedge(iEdge) = min(indMLD(cell1),indMLD(cell2))
-    enddo
-    !$omp end do
-    !$omp end parallel
     deallocate(depth)
   end subroutine ocn_eddy_compute_mixed_layer_depth
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
@@ -1,0 +1,282 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+
+module ocn_eddy_parameterization_helpers
+
+   use mpas_pool_routines
+   use mpas_derived_types
+   use mpas_constants
+   use mpas_threading
+   use mpas_timer
+
+   use ocn_constants
+   use ocn_config
+   use ocn_diagnostics_variables
+   use ocn_mesh
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: ocn_eddy_compute_buoyancy_gradient, &
+             ocn_eddy_compute_mixed_layer_depth
+
+
+  !***********************************************************************
+
+  contains
+
+  !***********************************************************************
+  !
+  !  routine ocn_eddy_compute_buoyancy_gradient
+  !
+  !> \brief Computes fixed depth horizontal buoyancy gradient 
+  !> \details
+  !>  Computes the horizontal buoyancy gradient on fixed depth levels. 
+  !>  This quantity is extracted from mpas_ocn_gm as it is needed for both
+  !>  the GM eddy parameterization and the submesoscale eddy parameterization
+  !***********************************************************************
+
+  subroutine ocn_eddy_compute_buoyancy_gradient()
+
+     !-----------------------------------------------------------------
+     !
+     ! local variables
+     !
+     !-----------------------------------------------------------------
+
+     integer :: k, nEdges, nCells, iCell, iEdge, cell1, cell2, indMLDedge
+     ! gradDensityEdge: Normal gradient of density
+     !           units: none
+     real(kind=RKIND), dimension(:, :), allocatable :: gradDensityEdge, gradDensityTopOfEdge, &
+        dDensityDzTopOfCell, dDensityDzTopOfEdge, &
+        gradZMidEdge, gradZMidTopOfEdge
+     real(kind=RKIND) :: rtmp, h1, h2
+     real(kind=RKIND), parameter :: epsGM = 1.0E-12_RKIND
+
+     nCells = nCellsAll
+     nEdges = nEdgesAll
+     allocate(gradDensityEdge(nVertLevels, nEdges), &
+              dDensityDzTopOfCell(nVertLevels+1, nCells+1), &
+              gradDensityTopOfEdge(nVertLevels+1, nEdges), &
+              dDensityDzTopOfEdge(nVertLevels+1, nEdges), &
+              gradZMidEdge(nVertLevels, nEdges), &
+              gradZMidTopOfEdge(nVertLevels+1, nEdges))
+
+     !$omp parallel
+     !$omp do schedule(runtime) private(k)
+     do iEdge=1,nEdgesAll
+        do k=1,nVertLevels
+           gradDensityEdge(k,iEdge) = 0.0_RKIND
+        end do
+     end do
+     !$omp end do
+     !$omp end parallel
+
+     nEdges = nEdgesHalo(2)
+     !$omp parallel
+     !$omp do schedule(runtime) private(k, rtmp)
+     do iCell = 1, nCells
+        do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
+           rtmp = (displacedDensity(k-1,iCell) - density(k,iCell)) / (zMid(k-1,iCell) - zMid(k,iCell))
+           dDensityDzTopOfCell(k,iCell) = min(rtmp, -epsGM)
+        end do
+        ! Approximation of dDensityDzTopOfCell on the top and bottom interfaces through the idea of having
+        ! ghost cells above the top and below the bottom layers of the same depths and density.
+        ! Essentially, this enforces the boundary condition (d density)/dz = 0 at the top and bottom.
+        dDensityDzTopOfCell(1:minLevelCell(iCell),iCell) = 0.0_RKIND
+        dDensityDzTopOfCell(maxLevelCell(iCell)+1,iCell) = 0.0_RKIND
+     end do
+     !$omp end do
+     !$omp end parallel
+
+     nEdges = nEdgesHalo( 2 )
+
+     ! Interpolate dDensityDzTopOfCell to edge and layer interface
+     !$omp parallel
+     !$omp do schedule(runtime) private(k, cell1, cell2)
+     do iEdge = 1, nEdges
+        do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)+1
+           cell1 = cellsOnEdge(1,iEdge)
+           cell2 = cellsOnEdge(2,iEdge)
+           dDensityDzTopOfEdge(k,iEdge) = 0.5_RKIND * (dDensityDzTopOfCell(k,cell1) + dDensityDzTopOfCell(k,cell2))
+        end do
+     end do
+     !$omp end do
+     !$omp end parallel
+
+     ! Compute density gradient (gradDensityEdge) and gradient of zMid (gradZMidEdge)
+     ! along the constant coordinate surface.
+     ! The computed variables lives at edge and mid-layer depth
+     !$omp parallel
+     !$omp do schedule(runtime) private(cell1, cell2, k)
+     do iEdge = 1, nEdges
+        cell1 = cellsOnEdge(1,iEdge)
+        cell2 = cellsOnEdge(2,iEdge)
+
+        do k=minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
+           gradDensityEdge(k,iEdge) = (density(k,cell2) - density(k,cell1)) / dcEdge(iEdge)
+           gradZMidEdge(k,iEdge) = (zMid(k,cell2) - zMid(k,cell1)) / dcEdge(iEdge)
+        end do
+     end do
+     !$omp end do
+
+     !$omp do schedule(runtime) private(k, h1, h2)
+     do iEdge = 1, nEdges
+        ! The interpolation can only be carried out on non-boundary edges
+        if (maxLevelEdgeTop(iEdge) .GE. minLevelEdgeBot(iEdge)) then
+           do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
+              h1 = layerThickEdgeMean(k-1,iEdge)
+              h2 = layerThickEdgeMean(k,iEdge)
+              ! Using second-order interpolation below
+              gradDensityTopOfEdge(k,iEdge) = (h2 * gradDensityEdge(k-1,iEdge) + h1 * &
+                                               gradDensityEdge(k,iEdge)) / (h1 + h2)
+              gradZMidTopOfEdge(k,iEdge) = (h2 * gradZMidEdge(k-1,iEdge) + h1 * &
+                                            gradZMidEdge(k,iEdge)) / (h1 + h2)
+           end do
+
+           ! Approximation of values on the top and bottom interfaces through the idea of having ghost cells
+           ! above the top and below the bottom layers of the same depths and density.
+           gradDensityTopOfEdge(minLevelEdgeBot(iEdge),iEdge) = gradDensityEdge(minLevelEdgeBot(iEdge),iEdge)
+           gradDensityTopOfEdge(maxLevelEdgeTop(iEdge)+1,iEdge) = gradDensityEdge(maxLevelEdgeTop(iEdge),iEdge)
+           gradZMidTopOfEdge(minLevelEdgeBot(iEdge),iEdge) = gradZMidEdge(minLevelEdgeBot(iEdge),iEdge)
+           gradZMidTopOfEdge(maxLevelEdgeTop(iEdge)+1,iEdge) = gradZMidEdge(maxLevelEdgeTop(iEdge),iEdge)
+        end if
+     end do
+     !$omp end do
+
+     !$omp do schedule(runtime) private(k)
+     do iEdge = 1, nEdges
+        if (maxLevelEdgeTop(iEdge) .GE. minLevelEdgeBot(iEdge)) then
+           do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)+1
+              gradBuoyEddy(k,iEdge) = gravity*(gradDensityTopOfEdge(k,iEdge) - dDensityDzTopOfEdge(k,iEdge) &
+                                             * gradZMidTopOfEdge(k,iEdge))/rho_sw
+           end do
+        end if
+     end do
+     !$omp end do
+     !$omp end parallel
+     deallocate(gradDensityEdge, &
+                dDensityDzTopOfCell, &
+                gradDensityTopOfEdge, &
+                dDensityDzTopOfEdge, &
+                gradZMidEdge, &
+                gradZMidTopOfEdge)
+
+  end subroutine ocn_eddy_compute_buoyancy_gradient
+
+  !***********************************************************************
+  !
+  !  routine ocn_eddy_compute_mixed_layer_depth
+  !
+  !> \brief   Computes the density threshold based mixed layer depth
+  !> \details
+  !>   Computes the density threshold based mixed layer depth.  This 
+  !>   quantity is required by the submesoscale and redi parameterizations
+  !>   The calculation is moved out of analysis members for this reason
+  !***********************************************************************
+
+  subroutine ocn_eddy_compute_mixed_layer_depth(statePool)
+
+     type (mpas_pool_type), pointer, intent(in) :: statePool
+
+     integer :: iEdge, nEdges, refIndex, cell1, cell2, nCells, k, iCell
+     real(kind=RKIND) :: dDenThres, den_ref_lev
+     real(kind=RKIND),dimension(:), allocatable :: depth
+     integer, dimension(:), pointer :: landIceMask
+     real (kind=RKIND), dimension(:,:), pointer :: layerThickness
+     logical :: found_den_mld
+     real (kind=RKIND) :: dV, dVp1, refDepth, coeffs(2), mldTemp
+
+     call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
+     nCells = nCellsAll
+
+     allocate(depth(nVertLevels))
+     refDepth = config_mld_reference_depth
+
+    !$omp parallel
+    !$omp do schedule(runtime) &
+    !$omp private(depth, refIndex, coeffs, found_den_mld, k, den_ref_lev, dVp1, dV, mldTemp)
+    do iCell = 1,nCells
+
+       found_den_mld = .false.
+
+       depth(1) = 0.5_RKIND*layerThickness(1,iCell)
+       do k=2,maxLevelCell(iCell)
+          depth(k) = depth(k-1) + 0.5_RKIND*(layerThickness(k-1,iCell) + &
+                                             layerThickness(k  ,iCell))
+       end do
+
+       do k=1, maxLevelCell(iCell)-1
+          if(depth(k+1) >= refDepth) then
+             coeffs(2) = (potentialDensity(k+1,iCell) - potentialDensity(k,iCell)) &
+                          / (depth(k+1) - depth(k))
+             coeffs(1) = potentialDensity(k,iCell) - coeffs(2)*depth(k)
+
+             den_ref_lev = coeffs(2)*refDepth + coeffs(1)
+
+             refIndex=k
+             exit
+          end if
+       end do
+
+       do k=refIndex,maxLevelCell(iCell)-1
+
+          if(.not. found_den_mld .and. (potentialDensity(k+1,iCell) - den_ref_lev) .ge. &
+                   config_mixedLayerDepths_crit_dens_threshold) then
+             dVp1 = (potentialDensity(k+1,iCell) - den_ref_lev)
+             dV   = (potentialDensity(k  ,iCell) - den_ref_lev)
+
+             coeffs(2) = (depth(k+1) - depth(k)) / (dVp1 - dV)
+             coeffs(1) = depth(k) - coeffs(2)*dV
+
+             mldTemp = coeffs(2)*config_mixedLayerDepths_crit_dens_threshold + coeffs(1)
+             mldTemp=min(mldTemp,depth(k+1)) !make sure MLD isn't deeper than zMid(k+1)
+             dThreshMLD(iCell)=abs(max(mldTemp,depth(k))) !MLD should be deeper than zMid(k)
+             indMLD(iCell) = k+1
+             found_den_mld = .true.
+             exit
+          end if
+       end do
+
+       ! if the mixed layer depth is not found, it is set to the depth of the bottom most level
+       if(.not. found_den_mld) then
+          dThreshMLD(iCell) = depth(maxLevelCell(iCell))
+          indMLD(iCell) = maxLevelCell(iCell)
+       end if
+    end do !iCell
+    !$omp end do
+    !$omp end parallel
+
+    nEdges = nEdgesHalo(1)
+    !$omp parallel
+    !$omp do schedule(runtime) &
+    !$omp private(cell1,cell2)
+    do iEdge=1,nEdgesAll
+       cell1 = cellsOnEdge(1,iEdge)
+       cell2 = cellsOnEdge(2,iEdge)
+       indMLDedge(iEdge) = min(indMLD(cell1),indMLD(cell2))
+    enddo
+    !$omp end do
+    !$omp end parallel
+    deallocate(depth)
+  end subroutine ocn_eddy_compute_mixed_layer_depth
+
+end module ocn_eddy_parameterization_helpers

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -16,6 +16,7 @@ module ocn_gm
    use ocn_constants
    use ocn_config
    use ocn_diagnostics_variables
+   use ocn_submesoscale_eddies
 
    implicit none
    private
@@ -146,12 +147,6 @@ contains
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray, nEdgesArray
 
-      ! gradDensityEdge: Normal gradient of density
-      !           units: none
-      real(kind=RKIND), dimension(:, :), allocatable :: gradDensityEdge, gradDensityTopOfEdge, &
-        gradDensityConstZTopOfEdge, dDensityDzTopOfCell, dDensityDzTopOfEdge, &
-        gradZMidEdge, gradZMidTopOfEdge
-
       type(mpas_pool_type), pointer :: tracersPool
       real(kind=RKIND), dimension(:, :, :), pointer :: activeTracers
       integer, pointer :: indexTemperature, indexSalinity
@@ -196,19 +191,10 @@ contains
       nCells = nCellsArray(size(nCellsArray))
       nEdges = nEdgesArray(size(nEdgesArray))
 
-      allocate(gradDensityEdge(nVertLevels, nEdges), &
-               dDensityDzTopOfCell(nVertLevels+1, nCells+1), &
-               gradDensityTopOfEdge(nVertLevels+1, nEdges), &
-               dDensityDzTopOfEdge(nVertLevels+1, nEdges), &
-               gradZMidEdge(nVertLevels, nEdges), &
-               gradZMidTopOfEdge(nVertLevels+1, nEdges), &
-               gradDensityConstZTopOfEdge(nVertLevels+1, nEdges))
-
       !$omp parallel
       !$omp do schedule(runtime) private(k)
       do iEdge = 1, nEdges
          do k = 1, nVertLevels
-            gradDensityEdge(k, iEdge) = 0.0_RKIND
             normalGMBolusVelocity(k, iEdge) = 0.0_RKIND
          end do
       end do
@@ -364,6 +350,12 @@ contains
                   slopeTaperDown = 1.0_RKIND + slopeTaperFactor*(slopeTaperDown - 1.0_RKIND)
 
                   sfcTaper = min(RediKappaSfcTaper(k, cell1), RediKappaSfcTaper(k, cell2))
+                  if(k < indMLDedge(iEdge)) then
+                    sfcTaper = 0.0_RKIND
+                  else
+                    sfcTaper = 1.0_RKIND
+                  end if
+
                   sfcTaperUp = 1.0_RKIND + sfcTaperFactor*(sfcTaper - 1.0_RKIND)
                   sfcTaperDown = 1.0_RKIND + sfcTaperFactor*(sfcTaper - 1.0_RKIND)
 
@@ -424,90 +416,6 @@ contains
       !--------------------------------------------------------------------
 
       if (config_use_GM) then
-         nEdges = nEdgesArray(3)
-         !$omp parallel
-         !$omp do schedule(runtime) private(k, rtmp)
-         do iCell = 1, nCells
-            do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
-               rtmp = (displacedDensity(k-1,iCell) - density(k,iCell)) / (zMid(k-1,iCell) - zMid(k,iCell))
-               dDensityDzTopOfCell(k,iCell) = min(rtmp, -epsGM)
-            end do
-
-            ! Approximation of dDensityDzTopOfCell on the top and bottom interfaces through the idea of having
-            ! ghost cells above the top and below the bottom layers of the same depths and density.
-            ! Essentially, this enforces the boundary condition (d density)/dz = 0 at the top and bottom.
-            dDensityDzTopOfCell(1:minLevelCell(iCell),iCell) = 0.0_RKIND
-            dDensityDzTopOfCell(maxLevelCell(iCell)+1,iCell) = 0.0_RKIND
-         end do
-         !$omp end do
-         !$omp end parallel
-
-         nEdges = nEdgesArray( 3 )
-
-         ! Interpolate dDensityDzTopOfCell to edge and layer interface
-         !$omp parallel
-         !$omp do schedule(runtime) private(k, cell1, cell2)
-         do iEdge = 1, nEdges
-            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)+1
-               cell1 = cellsOnEdge(1,iEdge)
-               cell2 = cellsOnEdge(2,iEdge)
-               dDensityDzTopOfEdge(k,iEdge) = 0.5_RKIND * (dDensityDzTopOfCell(k,cell1) + dDensityDzTopOfCell(k,cell2))
-            end do
-         end do
-         !$omp end do
-         !$omp end parallel
-
-         ! Compute density gradient (gradDensityEdge) and gradient of zMid (gradZMidEdge)
-         ! along the constant coordinate surface.
-         ! The computed variables lives at edge and mid-layer depth
-         !$omp parallel
-         !$omp do schedule(runtime) private(cell1, cell2, k)
-         do iEdge = 1, nEdges
-            cell1 = cellsOnEdge(1,iEdge)
-            cell2 = cellsOnEdge(2,iEdge)
-
-            do k=minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
-               gradDensityEdge(k,iEdge) = (density(k,cell2) - density(k,cell1)) / dcEdge(iEdge)
-               gradZMidEdge(k,iEdge) = (zMid(k,cell2) - zMid(k,cell1)) / dcEdge(iEdge)
-            end do
-         end do
-         !$omp end do
-
-         !$omp do schedule(runtime) private(k, h1, h2)
-         do iEdge = 1, nEdges
-            ! The interpolation can only be carried out on non-boundary edges
-            if (maxLevelEdgeTop(iEdge) .GE. minLevelEdgeBot(iEdge)) then
-               do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
-                  h1 = layerThickEdgeMean(k-1,iEdge)
-                  h2 = layerThickEdgeMean(k,iEdge)
-                  ! Using second-order interpolation below
-                  gradDensityTopOfEdge(k,iEdge) = (h2 * gradDensityEdge(k-1,iEdge) + h1 * &
-                                gradDensityEdge(k,iEdge)) / (h1 + h2)
-                  gradZMidTopOfEdge(k,iEdge) = (h2 * gradZMidEdge(k-1,iEdge) + h1 * &
-                                gradZMidEdge(k,iEdge)) / (h1 + h2)
-               end do
-
-               ! Approximation of values on the top and bottom interfaces through the idea of having ghost cells
-               ! above the top and below the bottom layers of the same depths and density.
-               gradDensityTopOfEdge(minLevelEdgeBot(iEdge),iEdge) = gradDensityEdge(minLevelEdgeBot(iEdge),iEdge)
-               gradDensityTopOfEdge(maxLevelEdgeTop(iEdge)+1,iEdge) = gradDensityEdge(maxLevelEdgeTop(iEdge),iEdge)
-               gradZMidTopOfEdge(minLevelEdgeBot(iEdge),iEdge) = gradZMidEdge(minLevelEdgeBot(iEdge),iEdge)
-               gradZMidTopOfEdge(maxLevelEdgeTop(iEdge)+1,iEdge) = gradZMidEdge(maxLevelEdgeTop(iEdge),iEdge)
-            end if
-         end do
-         !$omp end do
-
-         !$omp do schedule(runtime) private(k)
-         do iEdge = 1, nEdges
-            if (maxLevelEdgeTop(iEdge) .GE. minLevelEdgeBot(iEdge)) then
-               do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)+1
-                  gradDensityConstZTopOfEdge(k,iEdge) = gradDensityTopOfEdge(k,iEdge) - dDensityDzTopOfEdge(k,iEdge) &
-                                                   * gradZMidTopOfEdge(k,iEdge)
-               end do
-            end if
-         end do
-         !$omp end do
-         !$omp end parallel
 
          nEdges = nEdgesArray(3)
          ! For config_GM_closure = 'N2_dependent' use a scaling to taper gmBolusKappa
@@ -806,8 +714,7 @@ contains
                                                                      *layerThickEdgeMean(k, iEdge)) - BruntVaisalaFreqTopEdge
                tridiagC(k - 1) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdgeMean(k, iEdge) &
                                  /(layerThickEdgeMean(k - 1, iEdge) + layerThickEdgeMean(k, iEdge))
-               rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gravity/rho_sw &
-                                      *gradDensityConstZTopOfEdge(k,iEdge)
+               rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gradBuoyEddy(k,iEdge) 
 
                ! Second to next to the last rows
                do k = minLevelEdgeBot(iEdge) + 2, maxLevelEdgeTop(iEdge) - 1
@@ -819,8 +726,7 @@ contains
                                                                         *layerThickEdgeMean(k, iEdge)) - BruntVaisalaFreqTopEdge
                   tridiagC(k - 1) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdgeMean(k, iEdge) &
                                     /(layerThickEdgeMean(k - 1, iEdge) + layerThickEdgeMean(k, iEdge))
-                  rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gravity/rho_sw &
-                                         *gradDensityConstZTopOfEdge(k,iEdge)
+                  rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gradBuoyEddy(k,iEdge)
                end do
 
                ! Last row
@@ -831,8 +737,7 @@ contains
                                  /(layerThickEdgeMean(k - 1, iEdge) + layerThickEdgeMean(k, iEdge))
                tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThickEdgeMean(k - 1, iEdge) &
                                                                      *layerThickEdgeMean(k, iEdge)) - BruntVaisalaFreqTopEdge
-               rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gravity/rho_sw &
-                                      *gradDensityConstZTopOfEdge(k,iEdge)
+               rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gradBuoyEddy(k,iEdge)
                ! Total number of rows
                N = maxLevelEdgeTop(iEdge) - minLevelEdgeBot(iEdge)
 
@@ -865,13 +770,6 @@ contains
          deallocate (tridiagC)
 
       end if !end config_use_GM
-      deallocate(gradDensityEdge, &
-              dDensityDzTopOfCell, &
-              gradDensityTopOfEdge, &
-              dDensityDzTopOfEdge, &
-              gradZMidEdge, &
-              gradZMidTopOfEdge, &
-              gradDensityConstZTopOfEdge)
 
       call mpas_timer_stop('gm bolus velocity')
 
@@ -988,14 +886,7 @@ contains
          end if
 
          if (config_Redi_use_surface_taper) then
-            if (config_AM_mixedLayerDepths_enable .and. config_AM_mixedLayerDepths_Dthreshold) then
-               sfcTaperFactor = 1.0_RKIND
-            else
-               call mpas_log_write('Redi Surface tapering requires MLD AM enabled with dThresh option selected.', &
-                                   MPAS_LOG_CRIT)
-               err = 1
-               call mpas_dmpar_finalize(domain%dminfo)
-            end if
+            sfcTaperFactor = 1.0_RKIND
          else
             sfcTaperFactor = 0.0_RKIND
          end if

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -35,7 +35,8 @@ module ocn_gm
    !--------------------------------------------------------------------
 
    public :: ocn_GM_compute_Bolus_velocity, &
-             ocn_GM_init
+             ocn_GM_init,                   &
+             ocn_GM_add_to_transport_vel
 
    !--------------------------------------------------------------------
    !
@@ -144,7 +145,7 @@ contains
       real(kind=RKIND) :: c_mode1, resolution, dc_Lr
       ! Dimensions
       integer :: nCells, nEdges
-      integer, pointer :: nVertLevels, indMLDedge
+      integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray, nEdgesArray
 
       type(mpas_pool_type), pointer :: tracersPool
@@ -350,12 +351,6 @@ contains
                   slopeTaperDown = 1.0_RKIND + slopeTaperFactor*(slopeTaperDown - 1.0_RKIND)
 
                   sfcTaper = min(RediKappaSfcTaper(k, cell1), RediKappaSfcTaper(k, cell2))
-                  indMLDedge = max(indMLD(cell1),indMLD(cell2))
-                  if(k < indMLDedge) then
-                    sfcTaper = 0.0_RKIND
-                  else
-                    sfcTaper = 1.0_RKIND
-                  end if
 
                   sfcTaperUp = 1.0_RKIND + sfcTaperFactor*(sfcTaper - 1.0_RKIND)
                   sfcTaperDown = 1.0_RKIND + sfcTaperFactor*(sfcTaper - 1.0_RKIND)
@@ -715,7 +710,8 @@ contains
                                                                      *layerThickEdgeMean(k, iEdge)) - BruntVaisalaFreqTopEdge
                tridiagC(k - 1) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdgeMean(k, iEdge) &
                                  /(layerThickEdgeMean(k - 1, iEdge) + layerThickEdgeMean(k, iEdge))
-               rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gradBuoyEddy(k,iEdge) 
+               rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gravity/rho_sw* &
+                                            gradBuoyEddy(k,iEdge) 
 
                ! Second to next to the last rows
                do k = minLevelEdgeBot(iEdge) + 2, maxLevelEdgeTop(iEdge) - 1
@@ -727,7 +723,8 @@ contains
                                                                         *layerThickEdgeMean(k, iEdge)) - BruntVaisalaFreqTopEdge
                   tridiagC(k - 1) = 2.0_RKIND*cGMphaseSpeed(iEdge)**2/layerThickEdgeMean(k, iEdge) &
                                     /(layerThickEdgeMean(k - 1, iEdge) + layerThickEdgeMean(k, iEdge))
-                  rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gradBuoyEddy(k,iEdge)
+                  rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gravity/rho_sw* &
+                                             gradBuoyEddy(k,iEdge)
                end do
 
                ! Last row
@@ -738,7 +735,8 @@ contains
                                  /(layerThickEdgeMean(k - 1, iEdge) + layerThickEdgeMean(k, iEdge))
                tridiagB(k - 1) = -2.0_RKIND*cGMphaseSpeed(iEdge)**2/(layerThickEdgeMean(k - 1, iEdge) &
                                                                      *layerThickEdgeMean(k, iEdge)) - BruntVaisalaFreqTopEdge
-               rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gradBuoyEddy(k,iEdge)
+               rightHandSide(k - 1) = gmBolusKappa(iEdge)*gmKappaScaling(k,iEdge)*gravity/rho_sw* &
+                                            gradBuoyEddy(k,iEdge)
                ! Total number of rows
                N = maxLevelEdgeTop(iEdge) - minLevelEdgeBot(iEdge)
 
@@ -837,6 +835,42 @@ contains
       end do
 
    end subroutine tridiagonal_solve !}}}
+
+!***********************************************************************
+!
+!  routine ocn_GM_add_to_transport_velocity
+!
+!> \brief   Adds GM to transportVel 
+!> \details
+!>  Adds the GM bolus velocity to the normal transport velocity if enabled  
+!
+!-----------------------------------------------------------------------
+
+    subroutine ocn_GM_add_to_transport_vel(normalTransportVelocity, &
+                                           nEdges, nVertLevels)!{{{
+
+       real (kind=RKIND), dimension(:,:), intent(inout) :: &
+            normalTransportVelocity
+
+       integer, intent(in) :: nEdges, nVertLevels
+
+       integer :: iEdge, k
+
+       if (.not. config_use_gm) return
+
+       !$omp parallel 
+       !$omp do schedule(runtime) &
+       !$omp private(k)
+       do iEdge = 1, nEdges
+          do k = 1, nVertLevels
+             normalTransportVelocity(k,iEdge) = normalTransportVelocity(k,iEdge) + &
+                                    normalGMBolusVelocity(k,iEdge)
+          end do
+       end do
+       !$omp end do
+       !$omp end parallel
+
+    end subroutine ocn_GM_add_to_transport_vel!}}}
 
 !***********************************************************************
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -144,7 +144,7 @@ contains
       real(kind=RKIND) :: c_mode1, resolution, dc_Lr
       ! Dimensions
       integer :: nCells, nEdges
-      integer, pointer :: nVertLevels
+      integer, pointer :: nVertLevels, indMLDedge
       integer, dimension(:), pointer :: nCellsArray, nEdgesArray
 
       type(mpas_pool_type), pointer :: tracersPool
@@ -350,7 +350,8 @@ contains
                   slopeTaperDown = 1.0_RKIND + slopeTaperFactor*(slopeTaperDown - 1.0_RKIND)
 
                   sfcTaper = min(RediKappaSfcTaper(k, cell1), RediKappaSfcTaper(k, cell2))
-                  if(k < indMLDedge(iEdge)) then
+                  indMLDedge = max(indMLD(cell1),indMLD(cell2))
+                  if(k < indMLDedge) then
                     sfcTaper = 0.0_RKIND
                   else
                     sfcTaper = 1.0_RKIND

--- a/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
@@ -92,10 +92,13 @@ module ocn_submesoscale_eddies
      allocate(streamFunction(nVertLevels+1))
      allocate(zEdge(nVertLevels+1))
 
-     !compute the mixed layer average buoyancy gradient and bvf**2
-     !This is thickness weighted to allow for non uniform grid spacing
-     !NOTE, it is assumed that the value of bvf**2 at the bottom of cell 1 
-     !   applies to the entire first cell
+     !compute the mixed layer average buoyancy gradient and bvf
+     !This is thickness weighted to allow for non uniform grid spacing, 
+     !and centered on layer interfaces. The mixed layer goes from the 
+     !ocean top layer to mid-depth of layer(indMLDedge)
+     !NOTE, gradBuoyEddy and BFV are defined at the top cell interface 
+     !and not valid for minLevelCell, so properties for the top layer 
+     !rely on the values at (minLevelCell+1).
      !$omp parallel
      !$omp do schedule(runtime) &
      !$omp private(cell1,cell2,bvfML,zEdge,streamFunction,gradBuoyML,hML,bvfAv, &
@@ -109,6 +112,7 @@ module ocn_submesoscale_eddies
         bvfML = 0.0_RKIND
         gradBuoyML = 0.0_RKIND
         !the BFV is defined at cell interfaces in the vertical so there is an offset in index
+        !this is the top half layer, assuming homogeneity of top layer
         bvfAv = sqrt(0.5_RKIND*(max(BruntVaisalaFreqTop(minLevelCell(cell1)+1,cell1),1.0E-20_RKIND) + &
                        max(BruntVaisalaFreqTop(minLevelCell(cell2)+1,cell2),1.0E-20_RKIND)))
         hML = 0.5_RKIND*layerThickEdgeMean(minLevelEdgeBot(iEdge),iEdge)

--- a/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
@@ -36,10 +36,12 @@ module ocn_submesoscale_eddies
    !--------------------------------------------------------------------
 
    public :: ocn_submesoscale_compute_velocity, &
-             ocn_submesoscale_init
+             ocn_submesoscale_init,             &
+             ocn_submesoscale_finalize,         &
+             ocn_MLE_add_to_transport_vel
 
    real(kind=RKIND) :: tau, LfMin, Ce, dsMax
-
+   real(kind=RKIND),dimension(:),allocatable :: time_scale
 
   !***********************************************************************
 
@@ -90,6 +92,10 @@ module ocn_submesoscale_eddies
      allocate(streamFunction(nVertLevels+1))
      allocate(zEdge(nVertLevels+1))
 
+     !compute the mixed layer average buoyancy gradient and bvf**2
+     !This is thickness weighted to allow for non uniform grid spacing
+     !NOTE, it is assumed that the value of bvf**2 at the bottom of cell 1 
+     !   applies to the entire first cell
      !$omp parallel
      !$omp do schedule(runtime) &
      !$omp private(cell1,cell2,bvfML,zEdge,streamFunction,gradBuoyML,hML,bvfAv, &
@@ -102,6 +108,7 @@ module ocn_submesoscale_eddies
         streamFunction(:) = 0.0_RKIND
         bvfML = 0.0_RKIND
         gradBuoyML = 0.0_RKIND
+        !the BFV is defined at cell interfaces in the vertical so there is an offset in index
         bvfAv = sqrt(0.5_RKIND*(max(BruntVaisalaFreqTop(minLevelCell(cell1)+1,cell1),1.0E-20_RKIND) + &
                        max(BruntVaisalaFreqTop(minLevelCell(cell2)+1,cell2),1.0E-20_RKIND)))
         hML = 0.5_RKIND*layerThickEdgeMean(minLevelEdgeBot(iEdge),iEdge)
@@ -114,10 +121,11 @@ module ocn_submesoscale_eddies
         end if
 
         indMLDedge = min(indMLD(cell1),indMLD(cell2))
-        do k = minLevelEdgeBot(iEdge)+2,indMLDedge
+        do k = minLevelEdgeBot(iEdge)+1,indMLDedge
            hAv = 0.5_RKIND*(layerThickEdgeMean(k,iEdge) + layerThickEdgeMean(k-1,iEdge))
            bvfML = bvfML + hAv*bvfAv
            hML = hML + hAv
+           !the bvfAV is updated after bvfML due to the offset in index from cell center versus cell top
            bvfAv = sqrt(0.5_RKIND*(max(BruntVaisalaFreqTop(k,cell1),1.0E-20_RKIND) + &
                               max(BruntVaisalaFreqTop(k,cell2),1.0E-20_RKIND)))
            gradBuoyML = gradBuoyML + hAv*gradBuoyEddy(k,iEdge)
@@ -132,15 +140,15 @@ module ocn_submesoscale_eddies
          end do
 
         zMLD = 0.5_RKIND*(dThreshMLD(cell1)+dThreshMLD(cell2))
-        Lf = max(Lfmin, abs(gradBuoyML)*zMLD / (1.0E-20_RKIND + fEdge(iEdge)**2), &
-                  bvfML*zMLD / abs(fEdge(iEdge)))
+        Lf = max(Lfmin, abs(gradBuoyML)*zMLD / time_scale(iEdge)**2.0, &
+                 bvfML*zMLD / time_scale(iEdge))
 
         ds = min(dcEdge(iEdge),dsMax)
 
         do k = minLevelEdgeTop(iEdge)+1,maxLevelEdgeTop(iEdge)
            mu = max(0.0_RKIND,(1.0_RKIND - (2.0_RKIND*zEdge(k) / zMLD + 1.0_RKIND)**2.0)* &
                     (1.0_RKIND + 5.0_RKIND/21.0_RKIND*(2.0_RKIND*zEdge(k)/zMLD + 1.0_RKIND)**2.0))
-           streamFunction(k) = Ce*ds/Lf*zMLD**2.0*gradBuoyML/sqrt(fEdge(iEdge)**2.0 + tau**(-2.0))*mu
+           streamFunction(k) = Ce*ds/Lf*zMLD**2.0*gradBuoyML/time_scale(iEdge)*mu
         end do
 
         ! integrate in vertical to get the velocity
@@ -159,6 +167,41 @@ module ocn_submesoscale_eddies
 
   !***********************************************************************
   !
+  !  routine ocn_add_MLE_to_transport_vel
+  !
+  !> \brief   Submesoscale parameterization add to transport Vel
+  !> \details
+  !>  adds the MLE induced velocity to the transport velocity 
+  !>  
+  !***********************************************************************
+
+  subroutine ocn_MLE_add_to_transport_vel(normalTransportVelocity, nEdges)
+
+     real(kind=RKIND), dimension(:,:), intent(inout) :: &
+         normalTransportVelocity
+
+     integer, intent(in) :: nEdges
+
+     integer :: iEdge, k
+
+     if (.not. config_submesoscale_enable) return
+
+     !$omp parallel
+     !$omp do schedule(runtime) &
+     !$omp private(k)
+     do iEdge = 1, nEdges
+        do k = 1, nVertLevels
+           normalTransportVelocity(k,iEdge) = normalTransportVelocity(k,iEdge) + &
+               normalMLEvelocity(k,iEdge)
+        end do
+     end do
+     !$omp end do
+     !$omp end parallel
+
+  end subroutine ocn_MLE_add_to_transport_vel
+
+  !***********************************************************************
+  !
   !  routine ocn_submesoscale_init
   !
   !> \brief   Submesoscale parameterization init
@@ -171,12 +214,30 @@ module ocn_submesoscale_eddies
 
      integer, intent(out) :: err !< Output: error flag
 
+     integer :: iEdge
+
      err = 0
      Ce = config_submesoscale_ce
      Lfmin = config_submesoscale_lfmin
      dsmax = config_submesoscale_ds_max
      tau = config_submesoscale_tau
 
+     allocate(time_scale(nEdgesAll))
+
+     !$omp parallel
+     !$omp do schedule(runtime)
+     do iEdge=1,nEdgesAll
+        time_scale(iEdge) = sqrt(fEdge(iEdge)**2 + tau**(-2.0))
+     end do
+     !$omp end do
+     !$omp end parallel
+
    end subroutine ocn_submesoscale_init
+
+   subroutine ocn_submesoscale_finalize()
+
+     deallocate(time_scale)
+
+   end subroutine ocn_submesoscale_finalize
 
 end module ocn_submesoscale_eddies

--- a/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
@@ -123,11 +123,10 @@ module ocn_submesoscale_eddies
         indMLDedge = min(indMLD(cell1),indMLD(cell2))
         do k = minLevelEdgeBot(iEdge)+1,indMLDedge
            hAv = 0.5_RKIND*(layerThickEdgeMean(k,iEdge) + layerThickEdgeMean(k-1,iEdge))
-           bvfML = bvfML + hAv*bvfAv
-           hML = hML + hAv
-           !the bvfAV is updated after bvfML due to the offset in index from cell center versus cell top
            bvfAv = sqrt(0.5_RKIND*(max(BruntVaisalaFreqTop(k,cell1),1.0E-20_RKIND) + &
                               max(BruntVaisalaFreqTop(k,cell2),1.0E-20_RKIND)))
+           bvfML = bvfML + hAv*bvfAv
+           hML = hML + hAv
            gradBuoyML = gradBuoyML + hAv*gradBuoyEddy(k,iEdge)
         end do
         bvfML = bvfML / (1.0E-20_RKIND + hML)
@@ -136,7 +135,7 @@ module ocn_submesoscale_eddies
         !compute depths and shape function
 
         do k = minLevelEdgeTop(iEdge)+1,maxLevelEdgeTop(iEdge)+1
-           zEdge(k) = zedge(k-1) - layerThickEdgeMean(k-1,iEdge)
+           zEdge(k) = zEdge(k-1) - layerThickEdgeMean(k-1,iEdge)
          end do
 
         zMLD = 0.5_RKIND*(dThreshMLD(cell1)+dThreshMLD(cell2))
@@ -219,7 +218,7 @@ module ocn_submesoscale_eddies
      err = 0
      Ce = config_submesoscale_ce
      Lfmin = config_submesoscale_lfmin
-     dsmax = config_submesoscale_ds_max
+     dsMax = config_submesoscale_ds_max
      tau = config_submesoscale_tau
 
      allocate(time_scale(nEdgesAll))

--- a/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
@@ -76,7 +76,7 @@ module ocn_submesoscale_eddies
      !
      !-----------------------------------------------------------------
 
-     integer :: k, nEdges, nCells, iCell, iEdge, cell1, cell2
+     integer :: k, nEdges, nCells, iCell, iEdge, cell1, cell2, indMLDedge
 
      real(kind=RKIND),dimension(:),allocatable :: &
         streamFunction, &
@@ -113,7 +113,8 @@ module ocn_submesoscale_eddies
            cycle
         end if
 
-        do k = minLevelEdgeBot(iEdge)+2,indMLDedge(iEdge)
+        indMLDedge = min(indMLD(cell1),indMLD(cell2))
+        do k = minLevelEdgeBot(iEdge)+2,indMLDedge
            hAv = 0.5_RKIND*(layerThickEdgeMean(k,iEdge) + layerThickEdgeMean(k-1,iEdge))
            bvfML = bvfML + hAv*bvfAv
            hML = hML + hAv

--- a/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
@@ -1,0 +1,181 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+
+module ocn_submesoscale_eddies
+
+   use mpas_pool_routines
+   use mpas_derived_types
+   use mpas_constants
+   use mpas_threading
+   use mpas_timer
+
+   use ocn_constants
+   use ocn_config
+   use ocn_diagnostics_variables
+   use ocn_mesh
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: ocn_submesoscale_compute_velocity, &
+             ocn_submesoscale_init
+
+   real(kind=RKIND) :: tau, LfMin, Ce, dsMax
+
+
+  !***********************************************************************
+
+  contains
+
+  !***********************************************************************
+  !
+  !  routine ocn_submesoscale_compute_velocity
+  !
+  !> \brief   Computes velocity from submesoscale eddies
+  !> \details
+  !>  This routine implements the Fox-Kemper et al 2011 submesoscale 
+  !>  parameterization (https://doi.org/10.1016/j.ocemod.2010.09.002).
+  !>  The transport velocity from the submesoscales is given by a 
+  !>  stream function which is given as
+  !>
+  !>  Psi = C_e*Delta_S/L_f*H^2 int(bGrad_H)/sqrt(f^2+tau^-2)*mu(z)
+  !>
+  !>  here C_e is a specified efficiency, Delta_s is taken as 
+  !>  min(dcEdge,dsMax), H is the mixed layer depth, L_f is the subgrid
+  !>  frontal width that is scaled to the coarse grid, f is the 
+  !>  coriolis parameter, and tau is a time scale specified to prevent 
+  !>  the singularity near the equator.  the horizontal buoyancy gradient
+  !>  is integrated over the mixed layer depth and mu(z) is a non-dimensional
+  !>  shape function that is zero below the mixed layer depth
+  !>
+  !***********************************************************************
+
+  subroutine ocn_submesoscale_compute_velocity()
+
+     !-----------------------------------------------------------------
+     !
+     ! local variables
+     !
+     !-----------------------------------------------------------------
+
+     integer :: k, nEdges, nCells, iCell, iEdge, cell1, cell2
+
+     real(kind=RKIND),dimension(:),allocatable :: &
+        streamFunction, &
+        zEdge
+
+     real(kind=RKIND) :: mu, zMLD, bvfML, hML, gradBuoyML, ds, Lf, bvfAv, &
+        hAv, bldEdge, ustarEdge
+
+     nEdges = nEdgesHalo(2)
+
+     allocate(streamFunction(nVertLevels+1))
+     allocate(zEdge(nVertLevels+1))
+
+     !$omp parallel
+     !$omp do schedule(runtime) &
+     !$omp private(cell1,cell2,bvfML,zEdge,streamFunction,gradBuoyML,hML,bvfAv)
+     !$omp private(bvfML,zMLD,Lf,ds,mu,k)
+     do iEdge=1,nEdges
+        cell1 = cellsOnEdge(1,iEdge)
+        cell2 = cellsOnEdge(2,iEdge)
+
+        zEdge(:) = 0.0_RKIND
+        streamFunction(:) = 0.0_RKIND
+        bvfML = 0.0_RKIND
+        gradBuoyML = 0.0_RKIND
+        bvfAv = sqrt(0.5_RKIND*(max(BruntVaisalaFreqTop(minLevelCell(cell1)+1,cell1),1.0E-20_RKIND) + &
+                       max(BruntVaisalaFreqTop(minLevelCell(cell2)+1,cell2),1.0E-20_RKIND)))
+        hML = 0.5_RKIND*layerThickEdgeMean(minLevelEdgeBot(iEdge),iEdge)
+        bvfML = bvfML + hML*bvfAv
+        if (minLevelEdgeTop(iEdge) .ge. 1) then
+           gradBuoyML = hML*gradBuoyEddy(minLevelEdgeTop(iEdge)+1,iEdge)
+           bvfML = hML*bvfAv
+        else
+           cycle
+        end if
+
+        do k = minLevelEdgeBot(iEdge)+2,indMLDedge(iEdge)
+           hAv = 0.5_RKIND*(layerThickEdgeMean(k,iEdge) + layerThickEdgeMean(k-1,iEdge))
+           bvfML = bvfML + hAv*bvfAv
+           hML = hML + hAv
+           bvfAv = sqrt(0.5_RKIND*(max(BruntVaisalaFreqTop(k,cell1),1.0E-20_RKIND) + &
+                              max(BruntVaisalaFreqTop(k,cell2),1.0E-20_RKIND)))
+           gradBuoyML = gradBuoyML + hAv*gradBuoyEddy(k,iEdge)
+        end do
+        bvfML = bvfML / (1.0E-20_RKIND + hML)
+        gradBuoyML = gradBuoyML / (1.0E-20_RKIND + hML)
+
+        !compute depths and shape function
+
+        do k = minLevelEdgeTop(iEdge)+1,maxLevelEdgeTop(iEdge)+1
+           zEdge(k) = zedge(k-1) - layerThickEdgeMean(k-1,iEdge)
+         end do
+
+        zMLD = 0.5_RKIND*(dThreshMLD(cell1)+dThreshMLD(cell2))
+        Lf = max(Lfmin, abs(gradBuoyML)*zMLD / (1.0E-20_RKIND + fEdge(iEdge)**2), &
+                  bvfML*zMLD / abs(fEdge(iEdge)))
+
+        ds = min(dcEdge(iEdge),dsMax)
+
+        do k = minLevelEdgeTop(iEdge)+1,maxLevelEdgeTop(iEdge)
+           mu = max(0.0_RKIND,(1.0_RKIND - (2.0_RKIND*zEdge(k) / zMLD + 1.0_RKIND)**2.0)* &
+                    (1.0_RKIND + 5.0_RKIND/21.0_RKIND*(2.0_RKIND*zEdge(k)/zMLD + 1.0_RKIND)**2.0))
+           streamFunction(k) = Ce*ds/Lf*zMLD**2.0*gradBuoyML/sqrt(fEdge(iEdge)**2.0 + tau**(-2.0))*mu
+        end do
+
+        ! integrate in vertical to get the velocity
+        do k = minLevelEdgeTop(iEdge),maxLevelEdgeTop(iEdge)
+           normalMLEvelocity(k,iEdge) = -(streamFunction(k) - streamFunction(k+1)) / layerThickEdgeMean(k,iEdge)
+        end do
+
+    end do!iEdge loop
+    !$omp end do
+    !$omp end parallel
+
+    deallocate(streamFunction)
+    deallocate(zEdge)
+
+  end subroutine ocn_submesoscale_compute_velocity
+
+  !***********************************************************************
+  !
+  !  routine ocn_submesoscale_init
+  !
+  !> \brief   Submesoscale parameterization init
+  !> \details
+  !>  Initializes parameters related to the submesoscale eddy parameterization 
+  !>  
+  !***********************************************************************
+
+  subroutine ocn_submesoscale_init(err)
+
+     integer, intent(out) :: err !< Output: error flag
+
+     err = 0
+     Ce = config_submesoscale_ce
+     Lfmin = config_submesoscale_lfmin
+     dsmax = config_submesoscale_ds_max
+     tau = config_submesoscale_tau
+
+   end subroutine ocn_submesoscale_init
+
+end module ocn_submesoscale_eddies

--- a/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
@@ -92,8 +92,8 @@ module ocn_submesoscale_eddies
 
      !$omp parallel
      !$omp do schedule(runtime) &
-     !$omp private(cell1,cell2,bvfML,zEdge,streamFunction,gradBuoyML,hML,bvfAv)
-     !$omp private(bvfML,zMLD,Lf,ds,mu,k)
+     !$omp private(cell1,cell2,bvfML,zEdge,streamFunction,gradBuoyML,hML,bvfAv, &
+     !$omp         zMLD,Lf,ds,mu,k)
      do iEdge=1,nEdges
         cell1 = cellsOnEdge(1,iEdge)
         cell2 = cellsOnEdge(2,iEdge)

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -238,10 +238,10 @@ contains
 
             k = minLevelEdgeBot(iEdge)
             kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
-                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))!* &
+                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))
             k = 1
             kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
-                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))!* &
+                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))
 
             do iTr = 1, nTracers
                tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -238,14 +238,10 @@ contains
 
             k = minLevelEdgeBot(iEdge)
             kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
-                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))* &
-                               0.25_RKIND*(RediKappaSfcTaper(k, cell1) + RediKappaSfcTaper(k, cell2) + &
-                                           RediKappaSfcTaper(k + 1, cell1) + RediKappaSfcTaper(k + 1, cell2))
+                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))!* &
             k = 1
             kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
-                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))* &
-                               0.25_RKIND*(RediKappaSfcTaper(k, cell1) + RediKappaSfcTaper(k, cell2) + &
-                                           RediKappaSfcTaper(k + 1, cell1) + RediKappaSfcTaper(k + 1, cell2))
+                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))!* &
 
             do iTr = 1, nTracers
                tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)
@@ -280,9 +276,7 @@ contains
             do k = minLevelEdgeBot(iEdge) + 1, maxLevelEdgeTop(iEdge) - 1
 
                kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
-                                              RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))*0.25_RKIND* &
-                                  (RediKappaSfcTaper(k, cell1) + RediKappaSfcTaper(k, cell2) + &
-                                   RediKappaSfcTaper(k + 1, cell1) + RediKappaSfcTaper(k + 1, cell2))
+                                              RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))!*0.25_RKIND* &
 
                do iTr = 1, nTracers
                   ! \kappa_2 \nabla \phi on edge
@@ -319,9 +313,7 @@ contains
 
             k = maxLevelEdgeTop(iEdge)
             kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
-                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))* &
-                               0.25_RKIND*(RediKappaSfcTaper(k, cell1) + RediKappaSfcTaper(k, cell2) + &
-                                           RediKappaSfcTaper(k + 1, cell1) + RediKappaSfcTaper(k + 1, cell2))
+                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))!* &
 
             do iTr = 1, nTracers
                tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)
@@ -376,8 +368,8 @@ contains
                   ! 2.0 in next line is because a dot product on a C-grid
                   ! requires a factor of 1/2 to average to the cell center.
                   flux_term3 = rediKappaCell(iCell)*2.0_RKIND* &
-                               (RediKappaSfcTaper(k, iCell)*RediKappaScaling(k, iCell)*fluxRediZTop(iTr, k)  &
-                               * invAreaCell - RediKappaSfcTaper(k + 1, iCell)*RediKappaScaling(k + 1, iCell) &
+                               (RediKappaScaling(k, iCell)*fluxRediZTop(iTr, k)  &
+                               * invAreaCell - RediKappaScaling(k + 1, iCell) &
                                *fluxRediZTop(iTr, k + 1) * invAreaCell)
 
                   redi_term3(iTr, k, iCell) = redi_term3(iTr, k, iCell) + flux_term3
@@ -446,9 +438,9 @@ contains
             do k = minLevelCell(iCell), maxLevelCell(iCell)
                do iTr = 1, ntracers
                   tend(iTr, k, iCell) = tend(iTr, k, iCell) + rediKappaCell(iCell)*2.0_RKIND* &
-                                        (RediKappaSfcTaper(k, iCell)*RediKappaScaling(k, iCell)* &
-                                         redi_term3_topOfCell(iTr, k, iCell) - RediKappaSfcTaper(k + 1, iCell) &
-                                         *RediKappaScaling(k + 1, iCell)*redi_term3_topOfCell(iTr, k + 1, iCell))
+                                        (RediKappaScaling(k, iCell)* &
+                                         redi_term3_topOfCell(iTr, k, iCell) - &
+                                         RediKappaScaling(k + 1, iCell)*redi_term3_topOfCell(iTr, k + 1, iCell))
                end do
             end do
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -238,10 +238,14 @@ contains
 
             k = minLevelEdgeBot(iEdge)
             kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
-                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))
+                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))* &
+                               0.25_RKIND*(RediKappaSfcTaper(k, cell1) + RediKappaSfcTaper(k, cell2) + &
+                                           RediKappaSfcTaper(k + 1, cell1) + RediKappaSfcTaper(k + 1, cell2))
             k = 1
             kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
-                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))
+                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))* &
+                               0.25_RKIND*(RediKappaSfcTaper(k, cell1) + RediKappaSfcTaper(k, cell2) + &
+                                           RediKappaSfcTaper(k + 1, cell1) + RediKappaSfcTaper(k + 1, cell2))
 
             do iTr = 1, nTracers
                tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)
@@ -276,7 +280,9 @@ contains
             do k = minLevelEdgeBot(iEdge) + 1, maxLevelEdgeTop(iEdge) - 1
 
                kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
-                                              RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))
+                                              RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))*0.25_RKIND* &
+                                  (RediKappaSfcTaper(k, cell1) + RediKappaSfcTaper(k, cell2) + &
+                                   RediKappaSfcTaper(k + 1, cell1) + RediKappaSfcTaper(k + 1, cell2))
 
                do iTr = 1, nTracers
                   ! \kappa_2 \nabla \phi on edge
@@ -313,7 +319,9 @@ contains
 
             k = maxLevelEdgeTop(iEdge)
             kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
-                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))
+                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))* &
+                               0.25_RKIND*(RediKappaSfcTaper(k, cell1) + RediKappaSfcTaper(k, cell2) + &
+                                           RediKappaSfcTaper(k + 1, cell1) + RediKappaSfcTaper(k + 1, cell2))
 
             do iTr = 1, nTracers
                tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)
@@ -368,8 +376,8 @@ contains
                   ! 2.0 in next line is because a dot product on a C-grid
                   ! requires a factor of 1/2 to average to the cell center.
                   flux_term3 = rediKappaCell(iCell)*2.0_RKIND* &
-                               (RediKappaScaling(k, iCell)*fluxRediZTop(iTr, k)  &
-                               * invAreaCell - RediKappaScaling(k + 1, iCell) &
+                               (RediKappaSfcTaper(k, iCell)*RediKappaScaling(k, iCell)*fluxRediZTop(iTr, k)  &
+                               * invAreaCell - RediKappaSfcTaper(k + 1, iCell)*RediKappaScaling(k + 1, iCell) &
                                *fluxRediZTop(iTr, k + 1) * invAreaCell)
 
                   redi_term3(iTr, k, iCell) = redi_term3(iTr, k, iCell) + flux_term3
@@ -438,9 +446,9 @@ contains
             do k = minLevelCell(iCell), maxLevelCell(iCell)
                do iTr = 1, ntracers
                   tend(iTr, k, iCell) = tend(iTr, k, iCell) + rediKappaCell(iCell)*2.0_RKIND* &
-                                        (RediKappaScaling(k, iCell)* &
-                                         redi_term3_topOfCell(iTr, k, iCell) - &
-                                         RediKappaScaling(k + 1, iCell)*redi_term3_topOfCell(iTr, k + 1, iCell))
+                                        (RediKappaSfcTaper(k, iCell)*RediKappaScaling(k, iCell)* &
+                                         redi_term3_topOfCell(iTr, k, iCell) - RediKappaSfcTaper(k + 1, iCell) &
+                                         *RediKappaScaling(k + 1, iCell)*redi_term3_topOfCell(iTr, k + 1, iCell))
                end do
             end do
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -276,7 +276,7 @@ contains
             do k = minLevelEdgeBot(iEdge) + 1, maxLevelEdgeTop(iEdge) - 1
 
                kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
-                                              RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))!*0.25_RKIND* &
+                                              RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))
 
                do iTr = 1, nTracers
                   ! \kappa_2 \nabla \phi on edge
@@ -313,7 +313,7 @@ contains
 
             k = maxLevelEdgeTop(iEdge)
             kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
-                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))!* &
+                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))
 
             do iTr = 1, nTracers
                tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)


### PR DESCRIPTION
Adds the [Fox-Kemper et al 2011](https://doi.org/10.1016/j.ocemod.2010.09.002) parameterization for submesocale eddies.
There is also a substantial eddy parameterization reorganization as the
buoyancy gradient that was calculated within GM is also needed for this
parameterization.  There are also cases when we will run with the
submeso parameterization and not GM so that calculation is separate.
The density threshold MLD is also removed from the analysis member as it
is required by numerous calculations in the forward model now.

The contributions of submesoscale eddy velocity to AMOC is also added to
the MOC streamfunction computation

Description of new parameterization is as follows. This appears in the file
`components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F`.
```
  !>  This routine implements the Fox-Kemper et al 2011 submesoscale 
  !>  parameterization (https://doi.org/10.1016/j.ocemod.2010.09.002).
  !>  The transport velocity from the submesoscales is given by a 
  !>  stream function which is given as
  !>
  !>  Psi = C_e*Delta_S/L_f*H^2 int(bGrad_H)/sqrt(f^2+tau^-2)*mu(z)
  !>
  !>  here C_e is a specified efficiency, Delta_s is taken as 
  !>  min(dcEdge,dsMax), H is the mixed layer depth, L_f is the subgrid
  !>  frontal width that is scaled to the coarse grid, f is the 
  !>  coriolis parameter, and tau is a time scale specified to prevent 
  !>  the singularity near the equator.  The horizontal buoyancy gradient
  !>  is integrated over the mixed layer depth and mu(z) is a non-dimensional
  !>  shape function that is zero below the mixed layer depth
```

[NML]
[BFB] - stealth feature not turned on by default