### PR TITLE
Cosmetic clean-up of ZM

### DIFF
--- a/components/eam/src/physics/cam/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm_conv.F90
@@ -1,47 +1,38 @@
 
 module zm_conv
+   !----------------------------------------------------------------------------
+   !
+   ! Zhang-McFarlane convection scheme
+   !
+   ! Author: Byron Boville
+   ! Apr 2006: RBN: Code added to perform a dilute ascent for closure of the CM mass flux
+   !                based on an entraining plume a la Raymond and Blythe (1992)
+   !----------------------------------------------------------------------------
+   use shr_kind_mod,    only: r8 => shr_kind_r8
+   use spmd_utils,      only: masterproc
+   use ppgrid,          only: pcols, pver, pverp
+   use cloud_fraction,  only: cldfrc_fice
+   use physconst,       only: cpair, epsilo, gravit, latice, latvap, tmelt, rair, &
+                              cpwv, cpliq, rh2o
+   use cam_abortutils,  only: endrun
+   use cam_logfile,     only: iulog
 
-!---------------------------------------------------------------------------------
-! Purpose:
-!
-! Interface from Zhang-McFarlane convection scheme, includes evaporation of convective 
-! precip from the ZM scheme
-!
-! Apr 2006: RBN: Code added to perform a dilute ascent for closure of the CM mass flux
-!                based on an entraining plume a la Raymond and Blythe (1992)
-!
-! Author: Byron Boville, from code in tphysbc
-!
-!---------------------------------------------------------------------------------
-  use shr_kind_mod,    only: r8 => shr_kind_r8
-  use spmd_utils,      only: masterproc
-  use ppgrid,          only: pcols, pver, pverp
-  use cloud_fraction,  only: cldfrc_fice
-  use physconst,       only: cpair, epsilo, gravit, latice, latvap, tmelt, rair, &
-                             cpwv, cpliq, rh2o
-  use cam_abortutils,      only: endrun
-  use cam_logfile,     only: iulog
+   implicit none
+   save
+   private
 
-  implicit none
-
-  save
-  private                         ! Make default type private to the module
-!
-! PUBLIC: interfaces
-!
-  public zmconv_readnl            ! read zmconv_nl namelist
-  public zm_convi                 ! ZM schemea
-  public zm_convr                 ! ZM schemea
-  public zm_conv_evap             ! evaporation of precip from ZM schemea
-  public convtran                 ! convective transport
-  public momtran                  ! convective momentum transport
-  public trigdcape_ull            ! true if to use dcape-ULL trigger
-  public trig_dcape_only          ! true if to use dcape only trigger
-  public trig_ull_only            ! true if to ULL along with default CAPE-based trigger
-
-!
-! Private data
-!
+   ! Public interfaces
+   public zmconv_readnl            ! read zmconv_nl namelist
+   public zm_convi                 ! ZM schemea
+   public zm_convr                 ! ZM schemea
+   public zm_conv_evap             ! evaporation of precip from ZM schemea
+   public convtran                 ! convective transport
+   public momtran                  ! convective momentum transport
+   public trigdcape_ull            ! true if to use dcape-ULL trigger
+   public trig_dcape_only          ! true if to use dcape only trigger
+   public trig_ull_only            ! true if to ULL along with default CAPE-based trigger
+   !----------------------------------------------------------------------------
+   ! Private data
    real(r8), parameter :: unset_r8   = huge(1.0_r8)
    integer , parameter :: unset_int  = huge(1)
    real(r8) :: zmconv_c0_lnd         = unset_r8    
@@ -62,13 +53,15 @@ module zm_conv
    real(r8) cpres      ! specific heat at constant pressure in j/kg-degk.
    real(r8), parameter :: capelmt = 70._r8  ! threshold value for cape for deep convection.
 
-!DCAPE-ULL, including options for DCAPE_only and ull_only
+   !DCAPE-ULL, including options for DCAPE_only and ull_only
    real(r8), parameter :: trigdcapelmt = 0._r8  ! threshold value of dcape for deep convection
    logical :: trigdcape_ull    = .false. !true to use DCAPE trigger and ULL 
    logical :: trig_dcape_only  = .false. !true to use DCAPE trigger, ULL not used
    logical :: trig_ull_only    = .false. !true to use ULL along with default CAPE-based trigger
    integer, allocatable :: dcapemx(:) ! save maxi from 1st call for CAPE calculation and used in 2nd call when DCAPE-ULL active
-!  May need to change to use local variable !  as passed via dummy argument. For now, making it threadprivate as follows,
+   
+   ! May need to change to use local variable as passed via dummy argument. 
+   ! For now, making it threadprivate as follows,
 !$omp threadprivate (dcapemx)
 
    real(r8) :: ke           ! Tunable evaporation efficiency set from namelist input zmconv_ke
@@ -85,13 +78,10 @@ module zm_conv
    real(r8),parameter :: c3 = 243.5_r8
    real(r8) :: tfreez
    real(r8) :: eps1
-      
-
    logical :: no_deep_pbl ! default = .false.
                           ! no_deep_pbl = .true. eliminates deep convection entirely within PBL 
    
-
-!moved from moistconvection.F90
+   ! moved from moistconvection.F90
    real(r8) :: rgrav       ! reciprocal of grav
    real(r8) :: rgas        ! gas constant for dry air
    real(r8) :: grav        ! = gravit
@@ -102,6 +92,9 @@ module zm_conv
    real(r8) :: tp_fac = unset_r8  ! PMA tunes tpert 
 
 contains
+
+!-------------------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 subroutine zmconv_readnl(nlfile)
 
@@ -122,6 +115,7 @@ subroutine zmconv_readnl(nlfile)
    !-----------------------------------------------------------------------------
 
    zmconv_tau = 3600._r8
+
    if (masterproc) then
       unitn = getunit()
       open( unitn, file=trim(nlfile), status='old' )
@@ -136,36 +130,28 @@ subroutine zmconv_readnl(nlfile)
       call freeunit(unitn)
 
       ! set local variables
-      c0_lnd         = zmconv_c0_lnd
-      c0_ocn         = zmconv_c0_ocn
-      ke             = zmconv_ke
-      tau            = zmconv_tau
-      trigdcape_ull  = zmconv_trigdcape_ull
-      trig_dcape_only  = zmconv_trig_dcape_only
-      trig_ull_only  = zmconv_trig_ull_only
-      tiedke_add     = zmconv_tiedke_add
-      num_cin        = zmconv_cape_cin
-      mx_bot_lyr_adj = zmconv_mx_bot_lyr_adj
-      dmpdz          = zmconv_dmpdz
-      tp_fac         = zmconv_tp_fac
+      c0_lnd          = zmconv_c0_lnd
+      c0_ocn          = zmconv_c0_ocn
+      ke              = zmconv_ke
+      tau             = zmconv_tau
+      trigdcape_ull   = zmconv_trigdcape_ull
+      trig_dcape_only = zmconv_trig_dcape_only
+      trig_ull_only   = zmconv_trig_ull_only
+      tiedke_add      = zmconv_tiedke_add
+      num_cin         = zmconv_cape_cin
+      mx_bot_lyr_adj  = zmconv_mx_bot_lyr_adj
+      dmpdz           = zmconv_dmpdz
+      tp_fac          = zmconv_tp_fac
       
       if ( zmconv_alfa /= unset_r8 ) then
-           alfa_scalar = zmconv_alfa
+         alfa_scalar = zmconv_alfa
       else
-           alfa_scalar = 0.1_r8
+         alfa_scalar = 0.1_r8
       end if
 
-      if (trigdcape_ull) then 
-         write(iulog,*)'**** ZMCONV-DCAPE trigger with unrestricted launch level:', trigdcape_ull
-      endif
-
-      if (trig_dcape_only) then 
-         write(iulog,*)'**** ZM scheme uses DCAPE-only trigger:', trig_dcape_only
-      endif
-
-      if (trig_ull_only) then 
-         write(iulog,*)'**** ZM scheme uses unrestricted launch level along with default CAPE-based trigger:', trig_ull_only
-      endif
+      if (trigdcape_ull)   write(iulog,*)'**** ZM uses DCAPE trigger and unrestricted launch level:', trigdcape_ull
+      if (trig_dcape_only) write(iulog,*)'**** ZM uses only DCAPE trigger:', trig_dcape_only
+      if (trig_ull_only)   write(iulog,*)'**** ZM uses only unrestricted launch level:', trig_ull_only
 
    end if
 
@@ -183,21 +169,18 @@ subroutine zmconv_readnl(nlfile)
    call mpibcast(tiedke_add,        1, mpir8,  0, mpicom)
    call mpibcast(num_cin,           1, mpiint, 0, mpicom)
    call mpibcast(mx_bot_lyr_adj,    1, mpiint, 0, mpicom)
-   call mpibcast(tp_fac,       1, mpir8,  0, mpicom)
+   call mpibcast(tp_fac,            1, mpir8,  0, mpicom)
 #endif
 
 end subroutine zmconv_readnl
 
+!-------------------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 subroutine zm_convi(limcnv_in, no_deep_pbl_in)
 
-   use dycore,       only: dycore_is, get_resolution
-
    integer, intent(in)           :: limcnv_in       ! top interface level limit for convection
    logical, intent(in), optional :: no_deep_pbl_in  ! no_deep_pbl = .true. eliminates ZM convection entirely within PBL 
-
-   ! local variables
-   character(len=32)   :: hgrid           ! horizontal grid specifier
 
    ! Initialization of ZM constants
    limcnv = limcnv_in
@@ -216,11 +199,6 @@ subroutine zm_convi(limcnv_in, no_deep_pbl_in)
       no_deep_pbl = .false.
    endif
 
-   ! tau=4800. were used in canadian climate center. however, in echam3 t42, 
-   ! convection is too weak, thus adjusted to 2400.
-
-   hgrid = get_resolution()
-
    if ( masterproc ) then
       write(iulog,*) 'tuning parameters zm_convi: tau',tau
       write(iulog,*) 'tuning parameters zm_convi: c0_lnd',c0_lnd, ', c0_ocn', c0_ocn 
@@ -234,7 +212,8 @@ subroutine zm_convi(limcnv_in, no_deep_pbl_in)
 
 end subroutine zm_convi
 
-
+!-------------------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 subroutine zm_convr(lchnk   ,ncol    , &
                     t       ,qh      ,prec    ,jctop   ,jcbot   , &
@@ -246,193 +225,159 @@ subroutine zm_convr(lchnk   ,ncol    , &
                     dp      ,dsubcld ,jt      ,maxg    ,ideep   , &
                     lengath ,ql      ,rliq    ,landfrac, &
                     t_star  ,q_star, dcape)
-!----------------------------------------------------------------------- 
-! 
-! Purpose: 
-! Main driver for zhang-mcfarlane convection scheme 
-! 
-! Method: 
-! performs deep convective adjustment based on mass-flux closure
-! algorithm.
-! 
-! Author:guang jun zhang, m.lazare, n.mcfarlane. CAM Contact: P. Rasch
-!
-! This is contributed code not fully standardized by the CAM core group.
-! All variables have been typed, where most are identified in comments
-! The current procedure will be reimplemented in a subsequent version
-! of the CAM where it will include a more straightforward formulation
-! and will make use of the standard CAM nomenclature
-! 
-!-----------------------------------------------------------------------
+   !---------------------------------------------------------------------------- 
+   ! Main driver for zhang-mcfarlane convection scheme 
+   ! (performs deep convective adjustment using a mass-flux closure)
+   ! Author:guang jun zhang, m.lazare, n.mcfarlane. CAM Contact: P. Rasch
+   !----------------------------------------------------------------------------
    use phys_control, only: cam_physpkg_is
    use time_manager, only: is_first_step
-!
-! ************************ index of variables **********************
-!
-!  wg * alpha    array of vertical differencing used (=1. for upstream).
-!  w  * cape     convective available potential energy.
-!  wg * capeg    gathered convective available potential energy.
-!  c  * capelmt  threshold value for cape for deep convection.
-!  ic  * cpres    specific heat at constant pressure in j/kg-degk.
-!  i  * dpp      
-!  ic  * delt     length of model time-step in seconds.
-!  wg * dp       layer thickness in mbs (between upper/lower interface).
-!  wg * dqdt     mixing ratio tendency at gathered points.
-!  wg * dsdt     dry static energy ("temp") tendency at gathered points.
-!  wg * dudt     u-wind tendency at gathered points.
-!  wg * dvdt     v-wind tendency at gathered points.
-!  wg * dsubcld  layer thickness in mbs between lcl and maxi.
-!  ic  * grav     acceleration due to gravity in m/sec2.
-!  wg * du       detrainment in updraft. specified in mid-layer
-!  wg * ed       entrainment in downdraft.
-!  wg * eu       entrainment in updraft.
-!  wg * hmn      moist static energy.
-!  wg * hsat     saturated moist static energy.
-!  w  * ideep    holds position of gathered points vs longitude index.
-!  ic  * pver     number of model levels.
-!  wg * j0       detrainment initiation level index.
-!  wg * jd       downdraft   initiation level index.
-!  ic  * jlatpr   gaussian latitude index for printing grids (if needed).
-!  wg * jt       top  level index of deep cumulus convection.
-!  w  * lcl      base level index of deep cumulus convection.
-!  wg * lclg     gathered values of lcl.
-!  w  * lel      index of highest theoretical convective plume.
-!  wg * lelg     gathered values of lel.
-!  w  * lon      index of onset level for deep convection.
-!  w  * maxi     index of level with largest moist static energy.
-!  wg * maxg     gathered values of maxi.
-!  wg * mb       cloud base mass flux.
-!  wg * mc       net upward (scaled by mb) cloud mass flux.
-!  wg * md       downward cloud mass flux (positive up).
-!  wg * mu       upward   cloud mass flux (positive up). specified
-!                at interface
-!  ic  * msg      number of missing moisture levels at the top of model.
-!  w  * p        grid slice of ambient mid-layer pressure in mbs.
-!  i  * pblt     row of pbl top indices.
-!  w  * pcpdh    scaled surface pressure.
-!  w  * pf       grid slice of ambient interface pressure in mbs.
-!  wg * pg       grid slice of gathered values of p.
-!  w  * q        grid slice of mixing ratio.
-!  wg * qd       grid slice of mixing ratio in downdraft.
-!  wg * qg       grid slice of gathered values of q.
-!  i/o * qh       grid slice of specific humidity.
-!  w  * qh0      grid slice of initial specific humidity.
-!  wg * qhat     grid slice of upper interface mixing ratio.
-!  wg * ql       grid slice of cloud liquid water.
-!  wg * qs       grid slice of saturation mixing ratio.
-!  w  * qstp     grid slice of parcel temp. saturation mixing ratio.
-!  wg * qstpg    grid slice of gathered values of qstp.
-!  wg * qu       grid slice of mixing ratio in updraft.
-!  ic  * rgas     dry air gas constant.
-!  wg * rl       latent heat of vaporization.
-!  w  * s        grid slice of scaled dry static energy (t+gz/cp).
-!  wg * sd       grid slice of dry static energy in downdraft.
-!  wg * sg       grid slice of gathered values of s.
-!  wg * shat     grid slice of upper interface dry static energy.
-!  wg * su       grid slice of dry static energy in updraft.
-!  i/o * t       
-!  o  * jctop    row of top-of-deep-convection indices passed out.
-!  O  * jcbot    row of base of cloud indices passed out.
-!  wg * tg       grid slice of gathered values of t.
-!  w  * tl       row of parcel temperature at lcl.
-!  wg * tlg      grid slice of gathered values of tl.
-!  w  * tp       grid slice of parcel temperatures.
-!  wg * tpg      grid slice of gathered values of tp.
-!  i/o * u        grid slice of u-wind (real).
-!  wg * ug       grid slice of gathered values of u.
-!  i/o * utg      grid slice of u-wind tendency (real).
-!  i/o * v        grid slice of v-wind (real).
-!  w  * va       work array re-used by called subroutines.
-!  wg * vg       grid slice of gathered values of v.
-!  i/o * vtg      grid slice of v-wind tendency (real).
-!  i  * w        grid slice of diagnosed large-scale vertical velocity.
-!  w  * z        grid slice of ambient mid-layer height in metres.
-!  w  * zf       grid slice of ambient interface height in metres.
-!  wg * zfg      grid slice of gathered values of zf.
-!  wg * zg       grid slice of gathered values of z.
-!
-!-----------------------------------------------------------------------
-!
-! multi-level i/o fields:
-!  i      => input arrays.
-!  i/o    => input/output arrays.
-!  w      => work arrays.
-!  wg     => work arrays operating only on gathered points.
-!  ic     => input data constants.
-!  c      => data constants pertaining to subroutine itself.
-!
-! input arguments
-!
-   integer, intent(in) :: lchnk                   ! chunk identifier
-   integer, intent(in) :: ncol                    ! number of atmospheric columns
-
-   real(r8), intent(in) :: t(pcols,pver)          ! grid slice of temperature at mid-layer.
-   real(r8), intent(in) :: qh(pcols,pver)   ! grid slice of specific humidity.
+   ! ************************ index of variables **********************
+   !  w  * cape     convective available potential energy.
+   !  wg * capeg    gathered convective available potential energy.
+   !  c  * capelmt  threshold value for cape for deep convection.
+   !  ic  * cpres    specific heat at constant pressure in j/kg-degk.
+   !  i  * dpp      
+   !  ic  * delt    length of model time-step in seconds.
+   !  wg * dp       layer thickness in mbs (between upper/lower interface).
+   !  wg * dqdt     mixing ratio tendency at gathered points.
+   !  wg * dsdt     dry static energy ("temp") tendency at gathered points.
+   !  wg * dudt     u-wind tendency at gathered points.
+   !  wg * dvdt     v-wind tendency at gathered points.
+   !  wg * dsubcld  layer thickness in mbs between lcl and maxi.
+   !  ic  * grav    acceleration due to gravity in m/sec2.
+   !  wg * du       detrainment in updraft. specified in mid-layer
+   !  wg * ed       entrainment in downdraft.
+   !  wg * eu       entrainment in updraft.
+   !  wg * hmn      moist static energy.
+   !  wg * hsat     saturated moist static energy.
+   !  w  * ideep    holds position of gathered points vs longitude index.
+   !  ic  * pver    number of model levels.
+   !  wg * j0       detrainment initiation level index.
+   !  wg * jd       downdraft   initiation level index.
+   !  ic  * jlatpr  gaussian latitude index for printing grids (if needed).
+   !  wg * jt       top  level index of deep cumulus convection.
+   !  w  * lcl      base level index of deep cumulus convection.
+   !  wg * lclg     gathered values of lcl.
+   !  w  * lel      index of highest theoretical convective plume.
+   !  wg * lelg     gathered values of lel.
+   !  w  * lon      index of onset level for deep convection.
+   !  w  * maxi     index of level with largest moist static energy.
+   !  wg * maxg     gathered values of maxi.
+   !  wg * mb       cloud base mass flux.
+   !  wg * mc       net upward (scaled by mb) cloud mass flux.
+   !  wg * md       downward cloud mass flux (positive up).
+   !  wg * mu       upward   cloud mass flux (positive up). specified at interface
+   !  ic  * msg     number of missing moisture levels at the top of model.
+   !  w  * p        grid slice of ambient mid-layer pressure in mbs.
+   !  i  * pblt     row of pbl top indices.
+   !  w  * pcpdh    scaled surface pressure.
+   !  w  * pf       grid slice of ambient interface pressure in mbs.
+   !  wg * pg       grid slice of gathered values of p.
+   !  w  * q        grid slice of mixing ratio.
+   !  wg * qd       grid slice of mixing ratio in downdraft.
+   !  wg * qg       grid slice of gathered values of q.
+   !  i/o * qh      grid slice of specific humidity.
+   !  w  * qh0      grid slice of initial specific humidity.
+   !  wg * qhat     grid slice of upper interface mixing ratio.
+   !  wg * ql       grid slice of cloud liquid water.
+   !  wg * qs       grid slice of saturation mixing ratio.
+   !  w  * qstp     grid slice of parcel temp. saturation mixing ratio.
+   !  wg * qstpg    grid slice of gathered values of qstp.
+   !  wg * qu       grid slice of mixing ratio in updraft.
+   !  ic  * rgas    dry air gas constant.
+   !  wg * rl       latent heat of vaporization.
+   !  w  * s        grid slice of scaled dry static energy (t+gz/cp).
+   !  wg * sd       grid slice of dry static energy in downdraft.
+   !  wg * sg       grid slice of gathered values of s.
+   !  wg * shat     grid slice of upper interface dry static energy.
+   !  wg * su       grid slice of dry static energy in updraft.
+   !  i/o * t       
+   !  o  * jctop    row of top-of-deep-convection indices passed out.
+   !  O  * jcbot    row of base of cloud indices passed out.
+   !  wg * tg       grid slice of gathered values of t.
+   !  w  * tl       row of parcel temperature at lcl.
+   !  wg * tlg      grid slice of gathered values of tl.
+   !  w  * tp       grid slice of parcel temperatures.
+   !  wg * tpg      grid slice of gathered values of tp.
+   !  i/o * u       grid slice of u-wind (real).
+   !  wg * ug       grid slice of gathered values of u.
+   !  i/o * utg     grid slice of u-wind tendency (real).
+   !  i/o * v       grid slice of v-wind (real).
+   !  w  * va       work array re-used by called subroutines.
+   !  wg * vg       grid slice of gathered values of v.
+   !  i/o * vtg     grid slice of v-wind tendency (real).
+   !  i  * w        grid slice of diagnosed large-scale vertical velocity.
+   !  w  * z        grid slice of ambient mid-layer height in metres.
+   !  w  * zf       grid slice of ambient interface height in metres.
+   !  wg * zfg      grid slice of gathered values of zf.
+   !  wg * zg       grid slice of gathered values of z.
+   !----------------------------------------------------------------------------
+   ! multi-level i/o fields:
+   !  i      => input arrays.
+   !  i/o    => input/output arrays.
+   !  w      => work arrays.
+   !  wg     => work arrays operating only on gathered points.
+   !  ic     => input data constants.
+   !  c      => data constants pertaining to subroutine itself.
+   !----------------------------------------------------------------------------
+   ! input arguments
+   integer, intent(in) :: lchnk                    ! chunk identifier
+   integer, intent(in) :: ncol                     ! number of atmospheric columns
+   real(r8), intent(in) :: t(pcols,pver)           ! grid slice of temperature at mid-layer.
+   real(r8), intent(in) :: qh(pcols,pver)          ! grid slice of specific humidity.
    real(r8), intent(in) :: pap(pcols,pver)     
    real(r8), intent(in) :: paph(pcols,pver+1)
-   real(r8), intent(in) :: dpp(pcols,pver)        ! local sigma half-level thickness (i.e. dshj).
+   real(r8), intent(in) :: dpp(pcols,pver)         ! local sigma half-level thickness (i.e. dshj).
    real(r8), intent(in) :: zm(pcols,pver)
    real(r8), intent(in) :: geos(pcols)
    real(r8), intent(in) :: zi(pcols,pver+1)
    real(r8), intent(in) :: pblh(pcols)
    real(r8), intent(in) :: tpert(pcols)
-   real(r8), intent(in) :: landfrac(pcols) ! RBN Landfrac
-
-!DCAPE-ULL
-   real(r8), intent(in), pointer, dimension(:,:) :: t_star ! intermediate T between n and n-1 time step
-   real(r8), intent(in), pointer, dimension(:,:) :: q_star ! intermediate q between n and n-1 time step
-
-
-!
-! output arguments
-!
-   real(r8), intent(out) :: qtnd(pcols,pver)           ! specific humidity tendency (kg/kg/s)
-   real(r8), intent(out) :: heat(pcols,pver)           ! heating rate (dry static energy tendency, W/kg)
+   real(r8), intent(in) :: landfrac(pcols)
+   real(r8), intent(in), pointer, dimension(:,:) :: t_star ! intermediate T between time n and n-1 for DCAPE
+   real(r8), intent(in), pointer, dimension(:,:) :: q_star ! intermediate q between time n and n-1 for DCAPE
+   !----------------------------------------------------------------------------
+   ! output arguments
+   real(r8), intent(out) :: qtnd(pcols,pver)   ! specific humidity tendency (kg/kg/s)
+   real(r8), intent(out) :: heat(pcols,pver)   ! heating rate (dry static energy tendency, W/kg)
    real(r8), intent(out) :: mcon(pcols,pverp)
-   real(r8), intent(out) :: dlf(pcols,pver)    ! scattrd version of the detraining cld h2o tend
+   real(r8), intent(out) :: dlf(pcols,pver)    ! scattered version of the detraining cld h2o tend
    real(r8), intent(out) :: pflx(pcols,pverp)  ! scattered precip flux at each level
    real(r8), intent(out) :: cme(pcols,pver)
    real(r8), intent(out) :: cape(pcols)        ! w  convective available potential energy.
    real(r8), intent(out) :: zdu(pcols,pver)
-   real(r8), intent(out) :: rprd(pcols,pver)     ! rain production rate
-! move these vars from local storage to output so that convective
-! transports can be done in outside of conv_cam.
+   real(r8), intent(out) :: rprd(pcols,pver)   ! rain production rate
+   ! move these vars from local storage to output so that convective
+   ! transports can be done in outside of conv_cam.
    real(r8), intent(out) :: mu(pcols,pver)
    real(r8), intent(out) :: eu(pcols,pver)
    real(r8), intent(out) :: du(pcols,pver)
    real(r8), intent(out) :: md(pcols,pver)
    real(r8), intent(out) :: ed(pcols,pver)
-   real(r8), intent(out) :: dp(pcols,pver)       ! wg layer thickness in mbs (between upper/lower interface).
-   real(r8), intent(out) :: dsubcld(pcols)       ! wg layer thickness in mbs between lcl and maxi.
-   real(r8), intent(out) :: jctop(pcols)  ! o row of top-of-deep-convection indices passed out.
-   real(r8), intent(out) :: jcbot(pcols)  ! o row of base of cloud indices passed out.
-   real(r8), intent(out) :: prec(pcols)
-   real(r8), intent(out) :: rliq(pcols) ! reserved liquid (not yet in cldliq) for energy integrals
-   real(r8), intent(out) :: dcape(pcols)           ! output dynamical CAPE
-
+   real(r8), intent(out) :: dp(pcols,pver)     ! wg layer thickness in mbs (between upper/lower interface).
+   real(r8), intent(out) :: dsubcld(pcols)     ! wg layer thickness in mbs between lcl and maxi.
+   real(r8), intent(out) :: jctop(pcols)       ! o row of top-of-deep-convection indices passed out.
+   real(r8), intent(out) :: jcbot(pcols)       ! o row of base of cloud indices passed out.
+   real(r8), intent(out) :: prec(pcols)        ! precipitation
+   real(r8), intent(out) :: rliq(pcols)        ! reserved liquid (not yet in cldliq) for energy integrals
+   real(r8), intent(out) :: dcape(pcols)       ! output dynamical CAPE
+   !----------------------------------------------------------------------------
+   ! Local work variables
    real(r8) zs(pcols)
-   real(r8) dlg(pcols,pver)    ! gathrd version of the detraining cld h2o tend
-   real(r8) pflxg(pcols,pverp) ! gather precip flux at each level
-   real(r8) cug(pcols,pver)    ! gathered condensation rate
-   real(r8) evpg(pcols,pver)   ! gathered evap rate of rain in downdraft
-   real(r8) mumax(pcols)
-   integer jt(pcols)                          ! wg top  level index of deep cumulus convection.
-   integer maxg(pcols)                        ! wg gathered values of maxi.
-   integer ideep(pcols)                       ! w holds position of gathered points vs longitude index.
+   real(r8) dlg(pcols,pver)            ! gathrd version of the detraining cld h2o tend
+   real(r8) pflxg(pcols,pverp)         ! gather precip flux at each level
+   real(r8) cug(pcols,pver)            ! gathered condensation rate
+   real(r8) evpg(pcols,pver)           ! gathered evap rate of rain in downdraft
+   real(r8) mumax(pcols)               ! upper bound for cloud base mass flux
+   integer jt(pcols)                   ! wg top level index of deep cumulus convection.
+   integer maxg(pcols)                 ! wg gathered values of maxi.
+   integer ideep(pcols)                ! w holds position of gathered points vs longitude index.
    integer lengath
-!     diagnostic field used by chem/wetdep codes
-   real(r8) ql(pcols,pver)                    ! wg grid slice of cloud liquid water.
-!
-   real(r8) pblt(pcols)           ! i row of pbl top indices.
+   ! diagnostic field used by chem/wetdep codes
+   real(r8) ql(pcols,pver)             ! w grid slice of cloud liquid water.
+   real(r8) pblt(pcols)                ! i row of pbl top indices.
 
-
-
-
-!
-!-----------------------------------------------------------------------
-!
-! general work fields (local variables):
-!
    real(r8) q(pcols,pver)              ! w  grid slice of mixing ratio.
    real(r8) p(pcols,pver)              ! w  grid slice of ambient mid-layer pressure in mbs.
    real(r8) z(pcols,pver)              ! w  grid slice of ambient mid-layer height in metres.
@@ -463,11 +408,10 @@ subroutine zm_convr(lchnk   ,ncol    , &
    integer maxi(pcols)                 ! w  index of level with largest moist static energy.
    integer index(pcols)
    real(r8) precip
-!
-! gathered work fields:
-!
+   !----------------------------------------------------------------------------
+   ! gathered work variables
    real(r8) qg(pcols,pver)             ! wg grid slice of gathered values of q.
-   real(r8) tg(pcols,pver)             ! w  grid slice of temperature at interface.
+   real(r8) tg(pcols,pver)             ! wg grid slice of temperature at interface.
    real(r8) pg(pcols,pver)             ! wg grid slice of gathered values of p.
    real(r8) zg(pcols,pver)             ! wg grid slice of gathered values of z.
    real(r8) sg(pcols,pver)             ! wg grid slice of gathered values of s.
@@ -485,12 +429,10 @@ subroutine zm_convr(lchnk   ,ncol    , &
 
    integer lclg(pcols)       ! wg gathered values of lcl.
    integer lelg(pcols)
-!
-! work fields arising from gathered calculations.
-!
+
+   ! work variables arising from gathered calculations
    real(r8) dqdt(pcols,pver)           ! wg mixing ratio tendency at gathered points.
    real(r8) dsdt(pcols,pver)           ! wg dry static energy ("temp") tendency at gathered points.
-!      real(r8) alpha(pcols,pver)      ! array of vertical differencing used (=1. for upstream).
    real(r8) sd(pcols,pver)             ! wg grid slice of dry static energy in downdraft.
    real(r8) qd(pcols,pver)             ! wg grid slice of mixing ratio in downdraft.
    real(r8) mc(pcols,pver)             ! wg net upward (scaled by mb) cloud mass flux.
@@ -501,12 +443,9 @@ subroutine zm_convr(lchnk   ,ncol    , &
    real(r8) shat(pcols,pver)           ! wg grid slice of upper interface dry static energy.
    real(r8) hmn(pcols,pver)            ! wg moist static energy.
    real(r8) hsat(pcols,pver)           ! wg saturated moist static energy.
-   real(r8) qlg(pcols,pver)
+   real(r8) qlg(pcols,pver)            ! wg liq water of updraft
    real(r8) dudt(pcols,pver)           ! wg u-wind tendency at gathered points.
    real(r8) dvdt(pcols,pver)           ! wg v-wind tendency at gathered points.
-!      real(r8) ud(pcols,pver)
-!      real(r8) vd(pcols,pver)
-
    real(r8) mb(pcols)                  ! wg cloud base mass flux.
 
    integer jlcl(pcols)
@@ -524,23 +463,21 @@ subroutine zm_convr(lchnk   ,ncol    , &
    real(r8) qdifr
    real(r8) sdifr
 
-!
-!--------------------------Data statements------------------------------
-!
-! Set internal variable "msg" (convection limit) to "limcnv-1"
-!
+
+   !----------------------------------------------------------------------------
+   ! Data Statements
+
+   ! Set internal variable "msg" (convection limit) to "limcnv-1"
    msg = limcnv - 1
-!
-! initialize necessary arrays.
-! zero out variables not used in cam
-!
+
+   ! initialize necessary arrays.
+   ! zero out variables not used in cam
    qtnd(:,:) = 0._r8
    heat(:,:) = 0._r8
    mcon(:,:) = 0._r8
    rliq(:ncol)   = 0._r8
-!
-! initialize convective tendencies
-!
+   
+   ! initialize convective tendencies
    prec(:ncol) = 0._r8
    do k = 1,pver
       do i = 1,ncol
@@ -563,18 +500,16 @@ subroutine zm_convr(lchnk   ,ncol    , &
       pflx(i,pverp) = 0
       pflxg(i,pverp) = 0
    end do
-!
+
    do i = 1,ncol
       pblt(i) = pver
       dsubcld(i) = 0._r8
-
       jctop(i) = pver
       jcbot(i) = 1
    end do
-!
-! calculate local pressure (mbs) and height (m) for both interface
-! and mid-layer locations.
-!
+
+   ! calculate local pressure (mbs) and height (m) 
+   ! for both interface and mid-layer locations.
    do i = 1,ncol
       zs(i) = geos(i)*rgrav
       pf(i,pver+1) = paph(i,pver+1)*0.01_r8
@@ -588,17 +523,16 @@ subroutine zm_convr(lchnk   ,ncol    , &
          zf(i,k) = zi(i,k) + zs(i)
       end do
    end do
-!
+
    do k = pver - 1,msg + 1,-1
       do i = 1,ncol
          if (abs(z(i,k)-zs(i)-pblh(i)) < (zf(i,k)-zf(i,k+1))*0.5_r8) pblt(i) = k
       end do
    end do
-!
-! store incoming specific humidity field for subsequent calculation
-! of precipitation (through change in storage).
-! define dry static energy (normalized by cp).
-!
+
+   ! store incoming specific humidity field for subsequent calculation
+   ! of precipitation (through change in storage).
+   ! define dry static energy (normalized by cp).
    do k = 1,pver
       do i = 1,ncol
          q(i,k) = qh(i,k)
@@ -618,61 +552,46 @@ subroutine zm_convr(lchnk   ,ncol    , &
       dsubcld(i) = 0._r8
    end do
 
-   if( cam_physpkg_is('cam3')) then
+   ! Evaluate Tparcel, qs(Tparcel), buoyancy and CAPE, 
+   ! lcl, lel, parcel launch level at index maxi()=hmax
 
-      !  For cam3 physics package, call non-dilute
+   ! 1. First call, iclosure = .true., standard calculation, scanning for launching level up to 600 hPa
+   ! 2. Second call, iclosure = .faklse. pass the launch level from 1st call to determine CAPE at previous step
+   !    The differewnce of CAPE values from the two calls is DCAPE, based on the same launch level
 
-      call buoyan(lchnk   ,ncol    , &
-                  q       ,t       ,p       ,z       ,pf       , &
-                  tp      ,qstp    ,tl      ,rl      ,cape     , &
-                  pblt    ,lcl     ,lel     ,lon     ,maxi     , &
-                  rgas    ,grav    ,cpres   ,msg     , &
-                  tpert   )
-   else
-
-      !  Evaluate Tparcel, qs(Tparcel), buoyancy and CAPE, 
-      !     lcl, lel, parcel launch level at index maxi()=hmax
-      !
-
-      ! 1. First call, iclosure = .true., standard calculation, scanning for launching level up to 600 hPa
-      ! 2. Second call, iclosure = .faklse. pass the launch level from 1st call to determine CAPE at previous step
-      !    The differewnce of CAPE values from the two calls is DCAPE, based on the same launch level
-
-         iclosure = .true.
-         call buoyan_dilute(lchnk   ,ncol    , &
-                  q       ,t       ,p       ,z       ,pf       , &
-                  tp      ,qstp    ,tl      ,rl      ,cape     , &
-                  pblt    ,lcl     ,lel     ,lon     ,maxi     , &
-                  rgas    ,grav    ,cpres   ,msg     , &
-                  tpert   ,iclosure)
-         
-      if (trigdcape_ull .or. trig_dcape_only) then
-         if (.not. allocated(dcapemx)) then
-            allocate (dcapemx(pcols), stat=ierror)
-            if ( ierror /= 0 ) call endrun('ZM_CONVR error: allocation error dcapemx')
-         endif
-         dcapemx(:ncol) = maxi(:ncol)
+   iclosure = .true.
+   call buoyan_dilute(lchnk   ,ncol    , &
+            q       ,t       ,p       ,z       ,pf       , &
+            tp      ,qstp    ,tl      ,rl      ,cape     , &
+            pblt    ,lcl     ,lel     ,lon     ,maxi     , &
+            rgas    ,grav    ,cpres   ,msg     , &
+            tpert   ,iclosure)
+      
+   if (trigdcape_ull .or. trig_dcape_only) then
+      if (.not. allocated(dcapemx)) then
+         allocate (dcapemx(pcols), stat=ierror)
+         if ( ierror /= 0 ) call endrun('ZM_CONVR error: allocation error dcapemx')
       endif
+      dcapemx(:ncol) = maxi(:ncol)
+   endif
 
-      !DCAPE-ULL
-      if (.not. is_first_step() .and. (trigdcape_ull .or. trig_dcape_only)) then
-         iclosure = .false.
-         call buoyan_dilute(lchnk   ,ncol    , &
-                 q_star  ,t_star     ,p       ,z       ,pf       , &
-                 tpm1    ,qstpm1  ,tlm1    ,rl      ,capem1   , &
-                 pblt    ,lclm1   ,lelm1   ,lonm1   ,maxim1   , &
-                 rgas    ,grav    ,cpres   ,msg     , &
-                 tpert   ,iclosure)
+   !DCAPE-ULL
+   if (.not. is_first_step() .and. (trigdcape_ull .or. trig_dcape_only)) then
+      iclosure = .false.
+      call buoyan_dilute(lchnk   ,ncol    , &
+              q_star  ,t_star     ,p       ,z       ,pf       , &
+              tpm1    ,qstpm1  ,tlm1    ,rl      ,capem1   , &
+              pblt    ,lclm1   ,lelm1   ,lonm1   ,maxim1   , &
+              rgas    ,grav    ,cpres   ,msg     , &
+              tpert   ,iclosure)
 
-          dcape(:ncol) = (cape(:ncol)-capem1(:ncol))/(delt*2._r8)
-      endif
-   end if
+       dcape(:ncol) = (cape(:ncol)-capem1(:ncol))/(delt*2._r8)
+   endif
 
-!
-! determine whether grid points will undergo some deep convection
-! (ideep=1) or not (ideep=0), based on values of cape,lcl,lel
-! (require cape.gt. 0 and lel<lcl as minimum conditions).
-!
+   ! determine whether grid points will undergo some deep convection
+   ! (ideep=1) or not (ideep=0), based on values of cape,lcl,lel
+   ! (require cape.gt. 0 and lel<lcl as minimum conditions).
+
    capelmt_wk = capelmt   ! capelmt_wk default to capelmt for default trigger
 
    if ((trigdcape_ull .or. trig_dcape_only) .and. (.not. is_first_step()) )  &
@@ -680,25 +599,24 @@ subroutine zm_convr(lchnk   ,ncol    , &
 
    lengath = 0
    do i=1,ncol
-     if (trigdcape_ull .or. trig_dcape_only) then
-     ! DCAPE-ULL
-      if (is_first_step()) then
-         !Will this cause restart to be non-BFB
-           if (cape(i) > capelmt) then
-              lengath = lengath + 1
-              index(lengath) = i
-           end if
-       else if (cape(i) > 0.0_r8 .and. dcape(i) > trigdcapelmt) then
-           ! use constant 0 or a separate threshold for capt because capelmt is for default trigger
-           lengath = lengath + 1
-           index(lengath) = i
-       endif
-     else
-      if (cape(i) > capelmt) then
-         lengath = lengath + 1
-         index(lengath) = i
+      if (trigdcape_ull .or. trig_dcape_only) then
+         ! DCAPE-ULL
+         if (is_first_step()) then
+            if (cape(i) > capelmt) then
+               lengath = lengath + 1
+               index(lengath) = i
+            end if
+         else if (cape(i) > 0.0_r8 .and. dcape(i) > trigdcapelmt) then
+            ! use constant 0 or a separate threshold for capt because capelmt is for default trigger
+            lengath = lengath + 1
+            index(lengath) = i
+         endif
+      else
+         if (cape(i) > capelmt) then
+            lengath = lengath + 1
+            index(lengath) = i
+         end if
       end if
-     end if
    end do
 
    if (lengath.eq.0) return
@@ -706,9 +624,8 @@ subroutine zm_convr(lchnk   ,ncol    , &
       i=index(ii)
       ideep(ii)=i
    end do
-!
-! obtain gathered arrays necessary for ensuing calculations.
-!
+
+   ! obtain gathered arrays necessary for ensuing calculations.
    do k = 1,pver
       do i = 1,lengath
          dp(i,k) = 0.01_r8*dpp(ideep(i),k)
@@ -724,7 +641,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
          vg(i,k) = 0._r8
       end do
    end do
-!
+
    do i = 1,lengath
       zfg(i,pver+1) = zf(ideep(i),pver+1)
    end do
@@ -737,10 +654,9 @@ subroutine zm_convr(lchnk   ,ncol    , &
       landfracg(i) = landfrac(ideep(i))
       tpertg(i) = tpert(ideep(i))
    end do
-!
-! calculate sub-cloud layer pressure "thickness" for use in
-! closure and tendency routines.
-!
+
+   ! calculate sub-cloud layer pressure "thickness" for use in
+   ! closure and tendency routines.
    do k = msg + 1,pver
       do i = 1,lengath
          if (k >= maxg(i)) then
@@ -748,14 +664,12 @@ subroutine zm_convr(lchnk   ,ncol    , &
          end if
       end do
    end do
-!
-! define array of factors (alpha) which defines interfacial
-! values, as well as interfacial values for (q,s) used in
-! subsequent routines.
-!
+
+   ! define array of factors which defines interfacial
+   ! values, as well as interfacial values for (q,s) used in
+   ! subsequent routines.
    do k = msg + 2,pver
       do i = 1,lengath
-!            alpha(i,k) = 0.5
          sdifr = 0._r8
          qdifr = 0._r8
          if (sg(i,k) > 0._r8 .or. sg(i,k-1) > 0._r8) &
@@ -774,10 +688,8 @@ subroutine zm_convr(lchnk   ,ncol    , &
          end if
       end do
    end do
-!
-! obtain cloud properties.
-!
 
+   ! obtain cloud properties.
    call cldprp(lchnk   , &
                qg      ,tg      ,ug      ,vg      ,pg      , &
                zg      ,sg      ,mu      ,eu      ,du      , &
@@ -789,9 +701,8 @@ subroutine zm_convr(lchnk   ,ncol    , &
                rgas    ,grav    ,cpres   ,msg     , &
                pflxg   ,evpg    ,cug     ,rprdg   ,limcnv  , &
                landfracg, tpertg) !PMA adds tpert to the calculation
-!
-! convert detrainment from units of "1/m" to "1/mb".
-!
+
+   ! convert detrainment from units of "1/m" to "1/mb".
    do k = msg + 1,pver
       do i = 1,lengath
          du   (i,k) = du   (i,k)* (zfg(i,k)-zfg(i,k+1))/dp(i,k)
@@ -813,9 +724,8 @@ subroutine zm_convr(lchnk   ,ncol    , &
                 lclg    ,lelg    ,jt      ,maxg    ,1       , &
                 lengath ,rgas    ,grav    ,cpres   ,rl      , &
                 msg     ,capelmt_wk )
-!
-! limit cloud base mass flux to theoretical upper bound.
-!
+
+   ! limit cloud base mass flux to theoretical upper bound.
    do i=1,lengath
       mumax(i) = 0
    end do
@@ -832,9 +742,9 @@ subroutine zm_convr(lchnk   ,ncol    , &
          mb(i) = 0._r8
       endif
    end do
+
    ! If no_deep_pbl = .true., don't allow convection entirely 
    ! within PBL (suggestion of Bjorn Stevens, 8-2000)
-
    if (no_deep_pbl) then
       do i=1,lengath
          if (zm(ideep(i),jt(i)) < pblh(ideep(i))) mb(i) = 0
@@ -857,9 +767,8 @@ subroutine zm_convr(lchnk   ,ncol    , &
          pflxg(i,k+1)= pflxg(i,k+1)*mb(i)*100._r8/grav
       end do
    end do
-!
-! compute temperature and moisture changes due to convection.
-!
+
+   ! compute temperature and moisture changes due to convection.
    call q1q2_pjr(lchnk   , &
                  dqdt    ,dsdt    ,qg      ,qs      ,qu      , &
                  su      ,du      ,qhat    ,shat    ,dp      , &
@@ -868,16 +777,14 @@ subroutine zm_convr(lchnk   ,ncol    , &
                  cpres   ,rl      ,msg     ,          &
                  dlg     ,evpg    ,cug     )
 
-! gather back temperature and mixing ratio.
-!
+   ! gather back temperature and mixing ratio.
+
    do k = msg + 1,pver
 #ifdef CPRCRAY
 !DIR$ CONCURRENT
 #endif
       do i = 1,lengath
-!
-! q is updated to compute net precip.
-!
+         ! q is updated to compute net precip.
          q(ideep(i),k) = qh(ideep(i),k) + 2._r8*delt*dqdt(i,k)
          qtnd(ideep(i),k) = dqdt (i,k)
          cme (ideep(i),k) = cmeg (i,k)
@@ -890,32 +797,30 @@ subroutine zm_convr(lchnk   ,ncol    , &
          ql  (ideep(i),k) = qlg  (i,k)
       end do
    end do
-!
+
 #ifdef CPRCRAY
 !DIR$ CONCURRENT
 #endif
    do i = 1,lengath
       jctop(ideep(i)) = jt(i)
-!++bee
       jcbot(ideep(i)) = maxg(i)
-!--bee
       pflx(ideep(i),pverp) = pflxg(i,pverp)
    end do
 
-! Compute precip by integrating change in water vapor minus detrained cloud water
+   ! Compute precip by integrating change in water vapor minus detrained cloud water
    do k = pver,msg + 1,-1
       do i = 1,ncol
          prec(i) = prec(i) - dpp(i,k)* (q(i,k)-qh(i,k)) - dpp(i,k)*dlf(i,k)*2*delt
       end do
    end do
 
-! obtain final precipitation rate in m/s.
+   ! obtain final precipitation rate in m/s.
    do i = 1,ncol
       prec(i) = rgrav*max(prec(i),0._r8)/ (2._r8*delt)/1000._r8
    end do
 
-! Compute reserved liquid (not yet in cldliq) for energy integrals.
-! Treat rliq as flux out bottom, to be added back later.
+   ! Compute reserved liquid (not yet in cldliq) for energy integrals.
+   ! Treat rliq as flux out bottom, to be added back later.
    do k = 1, pver
       do i = 1, ncol
          rliq(i) = rliq(i) + dlf(i,k)*dpp(i,k)/gravit
@@ -926,288 +831,236 @@ subroutine zm_convr(lchnk   ,ncol    , &
    return
 end subroutine zm_convr
 
-!===============================================================================
-subroutine zm_conv_evap(ncol,lchnk, &
-     t,pmid,pdel,q, &
-     tend_s, tend_s_snwprd, tend_s_snwevmlt, tend_q, &
-     prdprec, cldfrc, deltat,  &
-     prec, snow, ntprprd, ntsnprd, flxprec, flxsnow )
+!-------------------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
-!-----------------------------------------------------------------------
-! Compute tendencies due to evaporation of rain from ZM scheme
-!--
-! Compute the total precipitation and snow fluxes at the surface.
-! Add in the latent heat of fusion for snow formation and melt, since it not dealt with
-! in the Zhang-MacFarlane parameterization.
-! Evaporate some of the precip directly into the environment using a Sundqvist type algorithm
-!-----------------------------------------------------------------------
+subroutine zm_conv_evap(ncol,lchnk, t,pmid,pdel,q, &
+                        tend_s, tend_s_snwprd, tend_s_snwevmlt, tend_q, &
+                        prdprec, cldfrc, deltat,  &
+                        prec, snow, ntprprd, ntsnprd, flxprec, flxsnow )
+   !-----------------------------------------------------------------------
+   ! Compute tendencies due to evaporation of rain from ZM scheme
+   ! Compute the total precipitation and snow fluxes at the surface.
+   ! Add in the latent heat of fusion for snow formation and melt, since it not dealt with
+   ! in the Zhang-MacFarlane parameterization.
+   ! Evaporate some of the precip directly into the environment using a Sundqvist type algorithm
+   !-----------------------------------------------------------------------
+   use wv_saturation,  only: qsat
+   use phys_grid, only: get_rlat_all_p
+   !----------------------------------------------------------------------------
+   ! interface arguments
+   integer, intent(in   ) :: ncol, lchnk                             ! number of columns and chunk index
+   real(r8),intent(in   ), dimension(pcols,pver) :: t                ! temperature (K)
+   real(r8),intent(in   ), dimension(pcols,pver) :: pmid             ! midpoint pressure (Pa) 
+   real(r8),intent(in   ), dimension(pcols,pver) :: pdel             ! layer thickness (Pa)
+   real(r8),intent(in   ), dimension(pcols,pver) :: q                ! water vapor (kg/kg)
+   real(r8),intent(inout), dimension(pcols,pver) :: tend_s           ! heating rate (J/kg/s)
+   real(r8),intent(inout), dimension(pcols,pver) :: tend_q           ! water vapor tendency (kg/kg/s)
+   real(r8),intent(  out), dimension(pcols,pver) :: tend_s_snwprd    ! Heating rate of snow production
+   real(r8),intent(  out), dimension(pcols,pver) :: tend_s_snwevmlt  ! Heating rate of evap/melting of snow
+   real(r8),intent(in   ) :: prdprec(pcols,pver)                     ! precipitation production (kg/ks/s)
+   real(r8),intent(in   ) :: cldfrc(pcols,pver)                      ! cloud fraction
+   real(r8),intent(in   ) :: deltat                                  ! time step
+   real(r8),intent(inout) :: prec(pcols)                             ! Convective-scale preciptn rate
+   real(r8),intent(  out) :: snow(pcols)                             ! Convective-scale snowfall rate
+   real(r8),intent(  out) :: flxprec(pcols,pverp)                    ! Convective-scale flux of precip at interfaces (kg/m2/s)
+   real(r8),intent(  out) :: flxsnow(pcols,pverp)                    ! Convective-scale flux of snow   at interfaces (kg/m2/s)
+   real(r8),intent(  out) :: ntprprd(pcols,pver)                     ! net precip production in layer
+   real(r8),intent(  out) :: ntsnprd(pcols,pver)                     ! net snow production in layer
+   !----------------------------------------------------------------------------
+   ! Local variables
+   real(r8) :: es(pcols,pver)            ! Saturation vapor pressure
+   real(r8) :: fice(pcols,pver)          ! ice fraction in precip production
+   real(r8) :: fsnow_conv(pcols,pver)    ! snow fraction in precip production
+   real(r8) :: qs(pcols,pver)            ! saturation specific humidity
+   real(r8) :: work1                     ! temp variable
+   real(r8) :: work2                     ! temp variable
+   real(r8) :: evpvint(pcols)            ! vertical integral of evaporation
+   real(r8) :: evpprec(pcols)            ! evaporation of precipitation (kg/kg/s)
+   real(r8) :: evpsnow(pcols)            ! evaporation of snowfall (kg/kg/s)
+   real(r8) :: snowmlt(pcols)            ! snow melt tendency in layer
+   real(r8) :: flxsntm(pcols)            ! flux of snow into layer, after melting
+   real(r8) :: evplimit                  ! temp variable for evaporation limits
+   integer :: i,k                        ! loop iterators
+   !----------------------------------------------------------------------------
 
-    use wv_saturation,  only: qsat
-    use phys_grid, only: get_rlat_all_p
+   ! convert input precip to kg/m2/s
+   prec(:ncol) = prec(:ncol)*1000._r8
 
-!------------------------------Arguments--------------------------------
-    integer,intent(in) :: ncol, lchnk             ! number of columns and chunk index
-    real(r8),intent(in), dimension(pcols,pver) :: t          ! temperature (K)
-    real(r8),intent(in), dimension(pcols,pver) :: pmid       ! midpoint pressure (Pa) 
-    real(r8),intent(in), dimension(pcols,pver) :: pdel       ! layer thickness (Pa)
-    real(r8),intent(in), dimension(pcols,pver) :: q          ! water vapor (kg/kg)
-    real(r8),intent(inout), dimension(pcols,pver) :: tend_s     ! heating rate (J/kg/s)
-    real(r8),intent(inout), dimension(pcols,pver) :: tend_q     ! water vapor tendency (kg/kg/s)
-    real(r8),intent(out  ), dimension(pcols,pver) :: tend_s_snwprd ! Heating rate of snow production
-    real(r8),intent(out  ), dimension(pcols,pver) :: tend_s_snwevmlt ! Heating rate of evap/melting of snow
-    
+   ! determine saturation vapor pressure
+   call qsat(t(1:ncol, 1:pver), pmid(1:ncol, 1:pver), &
+            es(1:ncol, 1:pver), qs(1:ncol, 1:pver))
 
+   ! determine ice fraction in rain production (use cloud water parameterization fraction at present)
+   call cldfrc_fice(ncol, t, fice, fsnow_conv)
 
-    real(r8), intent(in   ) :: prdprec(pcols,pver)! precipitation production (kg/ks/s)
-    real(r8), intent(in   ) :: cldfrc(pcols,pver) ! cloud fraction
-    real(r8), intent(in   ) :: deltat             ! time step
+   ! zero the flux integrals on the top boundary
+   flxprec(:ncol,1) = 0._r8
+   flxsnow(:ncol,1) = 0._r8
+   evpvint(:ncol)   = 0._r8
 
-    real(r8), intent(inout) :: prec(pcols)        ! Convective-scale preciptn rate
-    real(r8), intent(out)   :: snow(pcols)        ! Convective-scale snowfall rate
-!
-!---------------------------Local storage-------------------------------
+   do k = 1, pver
+      do i = 1, ncol
 
-    real(r8) :: es    (pcols,pver)    ! Saturation vapor pressure
-    real(r8) :: fice   (pcols,pver)    ! ice fraction in precip production
-    real(r8) :: fsnow_conv(pcols,pver) ! snow fraction in precip production
-    real(r8) :: qs   (pcols,pver)    ! saturation specific humidity
-    real(r8),intent(out) :: flxprec(pcols,pverp)   ! Convective-scale flux of precip at interfaces (kg/m2/s)
-    real(r8),intent(out) :: flxsnow(pcols,pverp)   ! Convective-scale flux of snow   at interfaces (kg/m2/s)
-    real(r8),intent(out) :: ntprprd(pcols,pver)    ! net precip production in layer
-    real(r8),intent(out) :: ntsnprd(pcols,pver)    ! net snow production in layer
-    real(r8) :: work1                  ! temp variable (pjr)
-    real(r8) :: work2                  ! temp variable (pjr)
+         ! Melt snow falling into layer, if necessary. 
+         if (t(i,k) > tmelt) then
+            flxsntm(i) = 0._r8
+            snowmlt(i) = flxsnow(i,k) * gravit/ pdel(i,k)
+         else
+            flxsntm(i) = flxsnow(i,k)
+            snowmlt(i) = 0._r8
+         end if
 
-    real(r8) :: evpvint(pcols)         ! vertical integral of evaporation
-    real(r8) :: evpprec(pcols)         ! evaporation of precipitation (kg/kg/s)
-    real(r8) :: evpsnow(pcols)         ! evaporation of snowfall (kg/kg/s)
-    real(r8) :: snowmlt(pcols)         ! snow melt tendency in layer
-    real(r8) :: flxsntm(pcols)         ! flux of snow into layer, after melting
+         ! relative humidity depression must be > 0 for evaporation
+         evplimit = max(1._r8 - q(i,k)/qs(i,k), 0._r8)
 
-    real(r8) :: evplimit               ! temp variable for evaporation limits
-    real(r8) :: rlat(pcols)
+         ! total evaporation depends on flux in the top of the layer
+         ! flux prec is the net production above layer minus evaporation into environmet
+         evpprec(i) = ke * (1._r8 - cldfrc(i,k)) * evplimit * sqrt(flxprec(i,k))
 
-    integer :: i,k                     ! longitude,level indices
+         ! Don't let evaporation supersaturate layer (approx). 
+         ! Layer may already be saturated.
+         ! Currently does not include heating/cooling change to qs
+         evplimit   = max(0._r8, (qs(i,k)-q(i,k)) / deltat)
 
+         ! Don't evaporate more than is falling into the layer - do not evaporate rain formed
+         ! in this layer but if precip production is negative, remove from the available precip
+         ! Negative precip production occurs because of evaporation in downdrafts.
+         evplimit   = min(evplimit, flxprec(i,k) * gravit / pdel(i,k))
 
-!-----------------------------------------------------------------------
+         ! Total evaporation cannot exceed input precipitation
+         evplimit   = min(evplimit, (prec(i) - evpvint(i)) * gravit / pdel(i,k))
 
-! convert input precip to kg/m2/s
-    prec(:ncol) = prec(:ncol)*1000._r8
+         evpprec(i) = min(evplimit, evpprec(i))
 
-! determine saturation vapor pressure
-    call qsat(t(1:ncol, 1:pver), pmid(1:ncol, 1:pver), &
-         es(1:ncol, 1:pver), qs(1:ncol, 1:pver))
+         ! evaporation of snow depends on snow fraction of total precipitation in the top after melting
+         if (flxprec(i,k) > 0._r8) then
+            ! prevent roundoff problems
+            work1 = min(max(0._r8,flxsntm(i)/flxprec(i,k)),1._r8)
+            evpsnow(i) = evpprec(i) * work1
+         else
+            evpsnow(i) = 0._r8
+         end if
 
-! determine ice fraction in rain production (use cloud water parameterization fraction at present)
-    call cldfrc_fice(ncol, t, fice, fsnow_conv)
+         ! vertically integrated evaporation
+         evpvint(i) = evpvint(i) + evpprec(i) * pdel(i,k)/gravit
 
-! zero the flux integrals on the top boundary
-    flxprec(:ncol,1) = 0._r8
-    flxsnow(:ncol,1) = 0._r8
-    evpvint(:ncol)   = 0._r8
-
-    do k = 1, pver
-       do i = 1, ncol
-
-! Melt snow falling into layer, if necessary. 
-          if (t(i,k) > tmelt) then
-             flxsntm(i) = 0._r8
-             snowmlt(i) = flxsnow(i,k) * gravit/ pdel(i,k)
-          else
-             flxsntm(i) = flxsnow(i,k)
-             snowmlt(i) = 0._r8
-          end if
-
-! relative humidity depression must be > 0 for evaporation
-          evplimit = max(1._r8 - q(i,k)/qs(i,k), 0._r8)
-
-! total evaporation depends on flux in the top of the layer
-! flux prec is the net production above layer minus evaporation into environmet
-          evpprec(i) = ke * (1._r8 - cldfrc(i,k)) * evplimit * sqrt(flxprec(i,k))
-!**********************************************************
-!!          evpprec(i) = 0.    ! turn off evaporation for now
-!**********************************************************
-
-! Don't let evaporation supersaturate layer (approx). Layer may already be saturated.
-! Currently does not include heating/cooling change to qs
-          evplimit   = max(0._r8, (qs(i,k)-q(i,k)) / deltat)
-
-! Don't evaporate more than is falling into the layer - do not evaporate rain formed
-! in this layer but if precip production is negative, remove from the available precip
-! Negative precip production occurs because of evaporation in downdrafts.
-!!$          evplimit   = flxprec(i,k) * gravit / pdel(i,k) + min(prdprec(i,k), 0.)
-          evplimit   = min(evplimit, flxprec(i,k) * gravit / pdel(i,k))
-
-! Total evaporation cannot exceed input precipitation
-          evplimit   = min(evplimit, (prec(i) - evpvint(i)) * gravit / pdel(i,k))
-
-          evpprec(i) = min(evplimit, evpprec(i))
-
-! evaporation of snow depends on snow fraction of total precipitation in the top after melting
-          if (flxprec(i,k) > 0._r8) then
-!            evpsnow(i) = evpprec(i) * flxsntm(i) / flxprec(i,k)
-!            prevent roundoff problems
-             work1 = min(max(0._r8,flxsntm(i)/flxprec(i,k)),1._r8)
-             evpsnow(i) = evpprec(i) * work1
-          else
-             evpsnow(i) = 0._r8
-          end if
-
-! vertically integrated evaporation
-          evpvint(i) = evpvint(i) + evpprec(i) * pdel(i,k)/gravit
-
-! net precip production is production - evaporation
-          ntprprd(i,k) = prdprec(i,k) - evpprec(i)
-! net snow production is precip production * ice fraction - evaporation - melting
-!pjrworks ntsnprd(i,k) = prdprec(i,k)*fice(i,k) - evpsnow(i) - snowmlt(i)
-!pjrwrks2 ntsnprd(i,k) = prdprec(i,k)*fsnow_conv(i,k) - evpsnow(i) - snowmlt(i)
-! the small amount added to flxprec in the work1 expression has been increased from 
-! 1e-36 to 8.64e-11 (1e-5 mm/day).  This causes the temperature based partitioning
-! scheme to be used for small flxprec amounts.  This is to address error growth problems.
+         ! net precip production is production - evaporation
+         ntprprd(i,k) = prdprec(i,k) - evpprec(i)
+         ! net snow production is precip production * ice fraction - evaporation - melting
+         !pjrworks ntsnprd(i,k) = prdprec(i,k)*fice(i,k) - evpsnow(i) - snowmlt(i)
+         !pjrwrks2 ntsnprd(i,k) = prdprec(i,k)*fsnow_conv(i,k) - evpsnow(i) - snowmlt(i)
+         ! the small amount added to flxprec in the work1 expression has been increased from 
+         ! 1e-36 to 8.64e-11 (1e-5 mm/day).  This causes the temperature based partitioning
+         ! scheme to be used for small flxprec amounts.  This is to address error growth problems.
 #ifdef PERGRO
-          work1 = min(max(0._r8,flxsnow(i,k)/(flxprec(i,k)+8.64e-11_r8)),1._r8)
+         work1 = min(max(0._r8,flxsnow(i,k)/(flxprec(i,k)+8.64e-11_r8)),1._r8)
 #else
-          if (flxprec(i,k).gt.0._r8) then
-             work1 = min(max(0._r8,flxsnow(i,k)/flxprec(i,k)),1._r8)
-          else
-             work1 = 0._r8
-          endif
+         if (flxprec(i,k).gt.0._r8) then
+            work1 = min(max(0._r8,flxsnow(i,k)/flxprec(i,k)),1._r8)
+         else
+            work1 = 0._r8
+         endif
 #endif
-          work2 = max(fsnow_conv(i,k), work1)
-          if (snowmlt(i).gt.0._r8) work2 = 0._r8
-!         work2 = fsnow_conv(i,k)
-          ntsnprd(i,k) = prdprec(i,k)*work2 - evpsnow(i) - snowmlt(i)
-          tend_s_snwprd  (i,k) = prdprec(i,k)*work2*latice
-          tend_s_snwevmlt(i,k) = - ( evpsnow(i) + snowmlt(i) )*latice
+         work2 = max(fsnow_conv(i,k), work1)
+         if (snowmlt(i).gt.0._r8) work2 = 0._r8
+         ntsnprd(i,k) = prdprec(i,k)*work2 - evpsnow(i) - snowmlt(i)
+         tend_s_snwprd  (i,k) = prdprec(i,k)*work2*latice
+         tend_s_snwevmlt(i,k) = - ( evpsnow(i) + snowmlt(i) )*latice
 
-! precipitation fluxes
-          flxprec(i,k+1) = flxprec(i,k) + ntprprd(i,k) * pdel(i,k)/gravit
-          flxsnow(i,k+1) = flxsnow(i,k) + ntsnprd(i,k) * pdel(i,k)/gravit
+         ! precipitation fluxes
+         flxprec(i,k+1) = flxprec(i,k) + ntprprd(i,k) * pdel(i,k)/gravit
+         flxsnow(i,k+1) = flxsnow(i,k) + ntsnprd(i,k) * pdel(i,k)/gravit
 
-! protect against rounding error
-          flxprec(i,k+1) = max(flxprec(i,k+1), 0._r8)
-          flxsnow(i,k+1) = max(flxsnow(i,k+1), 0._r8)
-! more protection (pjr)
-!         flxsnow(i,k+1) = min(flxsnow(i,k+1), flxprec(i,k+1))
+         ! protect against rounding error
+         flxprec(i,k+1) = max(flxprec(i,k+1), 0._r8)
+         flxsnow(i,k+1) = max(flxsnow(i,k+1), 0._r8)
 
-! heating (cooling) and moistening due to evaporation 
-! - latent heat of vaporization for precip production has already been accounted for
-! - snow is contained in prec
-          tend_s(i,k)   =-evpprec(i)*latvap + ntsnprd(i,k)*latice
-          tend_q(i,k) = evpprec(i)
-       end do
-    end do
+         ! heating (cooling) and moistening due to evaporation 
+         ! - latent heat of vaporization for precip production has already been accounted for
+         ! - snow is contained in prec
+         tend_s(i,k)   =-evpprec(i)*latvap + ntsnprd(i,k)*latice
+         tend_q(i,k) = evpprec(i)
+      end do
+   end do
 
-! set output precipitation rates (m/s)
-    prec(:ncol) = flxprec(:ncol,pver+1) / 1000._r8
-    snow(:ncol) = flxsnow(:ncol,pver+1) / 1000._r8
+   ! set output precipitation rates (m/s)
+   prec(:ncol) = flxprec(:ncol,pver+1) / 1000._r8
+   snow(:ncol) = flxsnow(:ncol,pver+1) / 1000._r8
 
-!**********************************************************
-!!$    tend_s(:ncol,:)   = 0.      ! turn heating off
-!**********************************************************
+end subroutine zm_conv_evap
 
-  end subroutine zm_conv_evap
-
-
+!-------------------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 subroutine convtran(lchnk   , &
                     doconvtran,q       ,ncnst   ,mu      ,md      , &
                     du      ,eu      ,ed      ,dp      ,dsubcld , &
                     jt      ,mx      ,ideep   ,il1g    ,il2g    , &
                     nstep   ,fracis  ,dqdt    ,dpdry   )
-!----------------------------------------------------------------------- 
-! 
-! Purpose: 
-! Convective transport of trace species
-!
-! Mixing ratios may be with respect to either dry or moist air
-! 
-! Method: 
-! <Describe the algorithm(s) used in the routine.> 
-! <Also include any applicable external references.> 
-! 
-! Author: P. Rasch
-! 
-!-----------------------------------------------------------------------
+   !---------------------------------------------------------------------------- 
+   ! Convective transport of trace species
+   ! (mixing ratios may be with respect to either dry or moist air)
+   ! Author: P. Rasch
+   !----------------------------------------------------------------------------
    use shr_kind_mod, only: r8 => shr_kind_r8
    use constituents,    only: cnst_get_type_byind
    use ppgrid
    use cam_abortutils, only: endrun
-
    implicit none
-!-----------------------------------------------------------------------
-!
-! Input arguments
-!
-   integer, intent(in) :: lchnk                 ! chunk identifier
-   integer, intent(in) :: ncnst                 ! number of tracers to transport
-   logical, intent(in) :: doconvtran(ncnst)     ! flag for doing convective transport
-   real(r8), intent(in) :: q(pcols,pver,ncnst)  ! Tracer array including moisture
-   real(r8), intent(in) :: mu(pcols,pver)       ! Mass flux up
-   real(r8), intent(in) :: md(pcols,pver)       ! Mass flux down
-   real(r8), intent(in) :: du(pcols,pver)       ! Mass detraining from updraft
-   real(r8), intent(in) :: eu(pcols,pver)       ! Mass entraining from updraft
-   real(r8), intent(in) :: ed(pcols,pver)       ! Mass entraining from downdraft
-   real(r8), intent(in) :: dp(pcols,pver)       ! Delta pressure between interfaces
-   real(r8), intent(in) :: dsubcld(pcols)       ! Delta pressure from cloud base to sfc
+   !----------------------------------------------------------------------------
+   ! Interface arguments
+   integer, intent(in) :: lchnk                     ! chunk identifier
+   integer, intent(in) :: ncnst                     ! number of tracers to transport
+   logical, intent(in) :: doconvtran(ncnst)         ! flag for doing convective transport
+   real(r8), intent(in) :: q(pcols,pver,ncnst)      ! Tracer array including moisture
+   real(r8), intent(in) :: mu(pcols,pver)           ! Mass flux up
+   real(r8), intent(in) :: md(pcols,pver)           ! Mass flux down
+   real(r8), intent(in) :: du(pcols,pver)           ! Mass detraining from updraft
+   real(r8), intent(in) :: eu(pcols,pver)           ! Mass entraining from updraft
+   real(r8), intent(in) :: ed(pcols,pver)           ! Mass entraining from downdraft
+   real(r8), intent(in) :: dp(pcols,pver)           ! Delta pressure between interfaces
+   real(r8), intent(in) :: dsubcld(pcols)           ! Delta pressure from cloud base to sfc
    real(r8), intent(in) :: fracis(pcols,pver,ncnst) ! fraction of tracer that is insoluble
-
-   integer, intent(in) :: jt(pcols)         ! Index of cloud top for each column
-   integer, intent(in) :: mx(pcols)         ! Index of cloud top for each column
-   integer, intent(in) :: ideep(pcols)      ! Gathering array
-   integer, intent(in) :: il1g              ! Gathered min lon indices over which to operate
-   integer, intent(in) :: il2g              ! Gathered max lon indices over which to operate
-   integer, intent(in) :: nstep             ! Time step index
-
-   real(r8), intent(in) :: dpdry(pcols,pver)       ! Delta pressure between interfaces
-
-
-! input/output
-
+   integer, intent(in) :: jt(pcols)                 ! Index of cloud top for each column
+   integer, intent(in) :: mx(pcols)                 ! Index of cloud top for each column
+   integer, intent(in) :: ideep(pcols)              ! Gathering array
+   integer, intent(in) :: il1g                      ! Gathered min lon indices over which to operate
+   integer, intent(in) :: il2g                      ! Gathered max lon indices over which to operate
+   integer, intent(in) :: nstep                     ! Time step index
+   real(r8), intent(in) :: dpdry(pcols,pver)        ! Delta pressure between interfaces
    real(r8), intent(out) :: dqdt(pcols,pver,ncnst)  ! Tracer tendency array
-
-!--------------------------Local Variables------------------------------
-
-   integer i                 ! Work index
-   integer k                 ! Work index
-   integer kbm               ! Highest altitude index of cloud base
-   integer kk                ! Work index
-   integer kkp1              ! Work index
-   integer km1               ! Work index
-   integer kp1               ! Work index
-   integer ktm               ! Highest altitude index of cloud top
-   integer m                 ! Work index
-
-   real(r8) cabv                 ! Mix ratio of constituent above
-   real(r8) cbel                 ! Mix ratio of constituent below
-   real(r8) cdifr                ! Normalized diff between cabv and cbel
-   real(r8) chat(pcols,pver)     ! Mix ratio in env at interfaces
-   real(r8) cond(pcols,pver)     ! Mix ratio in downdraft at interfaces
-   real(r8) const(pcols,pver)    ! Gathered tracer array
-   real(r8) fisg(pcols,pver)     ! gathered insoluble fraction of tracer
-   real(r8) conu(pcols,pver)     ! Mix ratio in updraft at interfaces
-   real(r8) dcondt(pcols,pver)   ! Gathered tend array
-   real(r8) small                ! A small number
-   real(r8) mbsth                ! Threshold for mass fluxes
-   real(r8) mupdudp              ! A work variable
-   real(r8) minc                 ! A work variable
-   real(r8) maxc                 ! A work variable
-   real(r8) fluxin               ! A work variable
-   real(r8) fluxout              ! A work variable
-   real(r8) netflux              ! A work variable
-
-   real(r8) dutmp(pcols,pver)       ! Mass detraining from updraft
-   real(r8) eutmp(pcols,pver)       ! Mass entraining from updraft
-   real(r8) edtmp(pcols,pver)       ! Mass entraining from downdraft
-   real(r8) dptmp(pcols,pver)    ! Delta pressure between interfaces
-!-----------------------------------------------------------------------
-!
+   !----------------------------------------------------------------------------
+   ! Local Variables
+   integer i,m                         ! Work indices
+   integer k,km1,kp1                   ! Work indices
+   integer kk,kkp1                     ! Work indices
+   integer kbm                         ! Highest altitude index of cloud base
+   integer ktm                         ! Highest altitude index of cloud top
+   real(r8) cabv                       ! Mix ratio of constituent above
+   real(r8) cbel                       ! Mix ratio of constituent below
+   real(r8) cdifr                      ! Normalized diff between cabv and cbel
+   real(r8) chat(pcols,pver)           ! Mix ratio in env at interfaces
+   real(r8) cond(pcols,pver)           ! Mix ratio in downdraft at interfaces
+   real(r8) const(pcols,pver)          ! Gathered tracer array
+   real(r8) fisg(pcols,pver)           ! gathered insoluble fraction of tracer
+   real(r8) conu(pcols,pver)           ! Mix ratio in updraft at interfaces
+   real(r8) dcondt(pcols,pver)         ! Gathered tend array
+   real(r8) small                      ! A small number
+   real(r8) mbsth                      ! Threshold for mass fluxes
+   real(r8) mupdudp                    ! A work variable
+   real(r8) minc,maxc                  ! Work variables
+   real(r8) fluxin,fluxout             ! Work variables
+   real(r8) netflux                    ! A work variable
+   real(r8) dutmp(pcols,pver)          ! Mass detraining from updraft
+   real(r8) eutmp(pcols,pver)          ! Mass entraining from updraft
+   real(r8) edtmp(pcols,pver)          ! Mass entraining from downdraft
+   real(r8) dptmp(pcols,pver)          ! Delta pressure between interfaces
+   !----------------------------------------------------------------------------
    small = 1.e-36_r8
-! mbsth is the threshold below which we treat the mass fluxes as zero (in mb/s)
-   mbsth = 1.e-15_r8
+   mbsth = 1.e-15_r8 ! threshold below which we treat the mass fluxes as zero (in mb/s)
 
-! Find the highest level top and bottom levels of convection
+   ! Find the highest level top and bottom levels of convection
    ktm = pver
    kbm = pver
    do i = il1g, il2g
@@ -1215,7 +1068,7 @@ subroutine convtran(lchnk   , &
       kbm = min(kbm,mx(i))
    end do
 
-! Loop ever each constituent
+   ! Loop ever each constituent
    do m = 2, ncnst
       if (doconvtran(m)) then
 
@@ -1238,9 +1091,8 @@ subroutine convtran(lchnk   , &
                end do
             end do
          endif
-!        dptmp = dp
 
-! Gather up the constituent and set tend to zero
+         ! Gather up the constituent and set tend to zero
          do k = 1,pver
             do i =il1g,il2g
                const(i,k) = q(ideep(i),k,m)
@@ -1248,9 +1100,9 @@ subroutine convtran(lchnk   , &
             end do
          end do
 
-! From now on work only with gathered data
+         ! ***** From now on work only with gathered data *****
 
-! Interpolate environment tracer values to interfaces
+         ! Interpolate environment tracer values to interfaces
          do k = 1,pver
             km1 = max(1,k-1)
             do i = il1g, il2g
@@ -1262,28 +1114,28 @@ subroutine convtran(lchnk   , &
                   cdifr = abs(const(i,k)-const(i,km1))/max(maxc,small)
                endif
 
-! If the two layers differ significantly use a geometric averaging
-! procedure
+               ! If the two layers differ significantly 
+               ! use a geometric averaging procedure
                if (cdifr > 1.E-6_r8) then
                   cabv = max(const(i,km1),maxc*1.e-12_r8)
                   cbel = max(const(i,k),maxc*1.e-12_r8)
                   chat(i,k) = log(cabv/cbel)/(cabv-cbel)*cabv*cbel
 
-               else             ! Small diff, so just arithmetic mean
+               else ! Small diff, so just arithmetic mean
                   chat(i,k) = 0.5_r8* (const(i,k)+const(i,km1))
                end if
 
-! Provisional up and down draft values
+               ! Provisional up and down draft values
                conu(i,k) = chat(i,k)
                cond(i,k) = chat(i,k)
 
-!              provisional tends
+               ! provisional tends
                dcondt(i,k) = 0._r8
 
             end do
          end do
 
-! Do levels adjacent to top and bottom
+         ! Do levels adjacent to top and bottom
          k = 2
          km1 = 1
          kk = pver
@@ -1297,7 +1149,7 @@ subroutine convtran(lchnk   , &
             endif
          end do
 
-! Updraft from bottom to top
+         ! Updraft from bottom to top
          do kk = pver-1,1,-1
             kkp1 = min(pver,kk+1)
             do i = il1g,il2g
@@ -1309,7 +1161,7 @@ subroutine convtran(lchnk   , &
             end do
          end do
 
-! Downdraft from top to bottom
+         ! Downdraft from top to bottom
          do k = 3,pver
             km1 = max(1,k-1)
             do i = il1g,il2g
@@ -1320,34 +1172,17 @@ subroutine convtran(lchnk   , &
             end do
          end do
 
-
          do k = ktm,pver
             km1 = max(1,k-1)
             kp1 = min(pver,k+1)
             do i = il1g,il2g
-
-! version 1 hard to check for roundoff errors
-!               dcondt(i,k) =
-!     $                  +(+mu(i,kp1)* (conu(i,kp1)-chat(i,kp1))
-!     $                    -mu(i,k)*   (conu(i,k)-chat(i,k))
-!     $                    +md(i,kp1)* (cond(i,kp1)-chat(i,kp1))
-!     $                    -md(i,k)*   (cond(i,k)-chat(i,k))
-!     $                   )/dp(i,k)
-
-! version 2 hard to limit fluxes
-!               fluxin =  mu(i,kp1)*conu(i,kp1) + mu(i,k)*chat(i,k)
-!     $                 -(md(i,k)  *cond(i,k)   + md(i,kp1)*chat(i,kp1))
-!               fluxout = mu(i,k)*conu(i,k)     + mu(i,kp1)*chat(i,kp1)
-!     $                 -(md(i,kp1)*cond(i,kp1) + md(i,k)*chat(i,k))
-
-! version 3 limit fluxes outside convection to mass in appropriate layer
-! these limiters are probably only safe for positive definite quantitities
-! it assumes that mu and md already satify a courant number limit of 1
+               ! limit fluxes outside convection to mass in appropriate layer
+               ! these limiters are probably only safe for positive definite quantitities
+               ! it assumes that mu and md already satify a courant number limit of 1
                fluxin =  mu(i,kp1)*conu(i,kp1)+ mu(i,k)*min(chat(i,k),const(i,km1)) &
                          -(md(i,k)  *cond(i,k) + md(i,kp1)*min(chat(i,kp1),const(i,kp1)))
                fluxout = mu(i,k)*conu(i,k) + mu(i,kp1)*min(chat(i,kp1),const(i,k)) &
                          -(md(i,kp1)*cond(i,kp1) + md(i,k)*min(chat(i,k),const(i,k)))
-
                netflux = fluxin - fluxout
                if (abs(netflux) < max(fluxin,fluxout)*1.e-12_r8) then
                   netflux = 0._r8
@@ -1355,8 +1190,7 @@ subroutine convtran(lchnk   , &
                dcondt(i,k) = netflux/dptmp(i,k)
             end do
          end do
-! %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-!
+
 #ifdef CPRCRAY
 !DIR$ NOINTERCHANGE
 #endif
@@ -1364,34 +1198,20 @@ subroutine convtran(lchnk   , &
             km1 = max(1,k-1)
             do i = il1g,il2g
                if (k == mx(i)) then
-
-! version 1
-!                  dcondt(i,k) = (1./dsubcld(i))*
-!     $              (-mu(i,k)*(conu(i,k)-chat(i,k))
-!     $               -md(i,k)*(cond(i,k)-chat(i,k))
-!     $              )
-
-! version 2
-!                  fluxin =  mu(i,k)*chat(i,k) - md(i,k)*cond(i,k)
-!                  fluxout = mu(i,k)*conu(i,k) - md(i,k)*chat(i,k)
-! version 3
                   fluxin =  mu(i,k)*min(chat(i,k),const(i,km1)) - md(i,k)*cond(i,k)
                   fluxout = mu(i,k)*conu(i,k) - md(i,k)*min(chat(i,k),const(i,k))
-
                   netflux = fluxin - fluxout
                   if (abs(netflux) < max(fluxin,fluxout)*1.e-12_r8) then
                      netflux = 0._r8
                   endif
-!                  dcondt(i,k) = netflux/dsubcld(i)
                   dcondt(i,k) = netflux/dptmp(i,k)
                else if (k > mx(i)) then
-!                  dcondt(i,k) = dcondt(i,k-1)
                   dcondt(i,k) = 0._r8
                end if
             end do
          end do
 
-! Initialize to zero everywhere, then scatter tendency back to full array
+         ! Initialize to zero everywhere, then scatter tendency back to full array
          dqdt(:,:,m) = 0._r8
          do k = 1,pver
             kp1 = min(pver,k+1)
@@ -1403,207 +1223,152 @@ subroutine convtran(lchnk   , &
             end do
          end do
 
-      end if      ! for doconvtran
+      end if ! doconvtran
 
    end do
 
    return
 end subroutine convtran
 
-!=========================================================================================
+!-------------------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 subroutine momtran(lchnk, ncol, &
                     domomtran,q       ,ncnst   ,mu      ,md    , &
                     du      ,eu      ,ed      ,dp      ,dsubcld , &
                     jt      ,mx      ,ideep   ,il1g    ,il2g    , &
-                    nstep   ,dqdt    ,pguall     ,pgdall, icwu, icwd, dt, seten    )
-!----------------------------------------------------------------------- 
-! 
-! Purpose: 
-! Convective transport of momentum
-!
-! Mixing ratios may be with respect to either dry or moist air
-! 
-! Method: 
-! Based on the convtran subroutine by P. Rasch
-! <Also include any applicable external references.> 
-! 
-! Author: J. Richter and P. Rasch
-! 
-!-----------------------------------------------------------------------
+                    nstep   ,dqdt    ,pguall  ,pgdall  , icwu, icwd, dt, seten )
+   !----------------------------------------------------------------------------
+   ! Convective transport of momentum
+   ! (mixing ratios may be with respect to either dry or moist air)
+   ! Author: J. Richter and P. Rasch
+   !----------------------------------------------------------------------------
    use shr_kind_mod, only: r8 => shr_kind_r8
    use constituents,    only: cnst_get_type_byind
    use ppgrid
    use cam_abortutils, only: endrun
-
    implicit none
-!-----------------------------------------------------------------------
-!
-! Input arguments
-!
-   integer, intent(in) :: lchnk                 ! chunk identifier
-   integer, intent(in) :: ncol                  ! number of atmospheric columns
-   integer, intent(in) :: ncnst                 ! number of tracers to transport
-   logical, intent(in) :: domomtran(ncnst)      ! flag for doing convective transport
-   real(r8), intent(in) :: q(pcols,pver,ncnst)  ! Wind array
-   real(r8), intent(in) :: mu(pcols,pver)       ! Mass flux up
-   real(r8), intent(in) :: md(pcols,pver)       ! Mass flux down
-   real(r8), intent(in) :: du(pcols,pver)       ! Mass detraining from updraft
-   real(r8), intent(in) :: eu(pcols,pver)       ! Mass entraining from updraft
-   real(r8), intent(in) :: ed(pcols,pver)       ! Mass entraining from downdraft
-   real(r8), intent(in) :: dp(pcols,pver)       ! Delta pressure between interfaces
-   real(r8), intent(in) :: dsubcld(pcols)       ! Delta pressure from cloud base to sfc
-   real(r8), intent(in)    :: dt                       !  time step in seconds : 2*delta_t
+   !----------------------------------------------------------------------------   
+   ! Interface arguments
+   integer, intent(in) :: lchnk                       ! chunk identifier
+   integer, intent(in) :: ncol                        ! number of atmospheric columns
+   integer, intent(in) :: ncnst                       ! number of tracers to transport
+   logical, intent(in) :: domomtran(ncnst)            ! flag for doing convective transport
+   real(r8),intent(in) :: q(pcols,pver,ncnst)         ! Wind array
+   real(r8),intent(in) :: mu(pcols,pver)              ! Mass flux up
+   real(r8),intent(in) :: md(pcols,pver)              ! Mass flux down
+   real(r8),intent(in) :: du(pcols,pver)              ! Mass detraining from updraft
+   real(r8),intent(in) :: eu(pcols,pver)              ! Mass entraining from updraft
+   real(r8),intent(in) :: ed(pcols,pver)              ! Mass entraining from downdraft
+   real(r8),intent(in) :: dp(pcols,pver)              ! Delta pressure between interfaces
+   real(r8),intent(in) :: dsubcld(pcols)              ! Delta pressure from cloud base to sfc
+   real(r8),intent(in) :: dt                          ! time step in seconds : 2*delta_t
+   integer, intent(in) :: jt(pcols)                   ! Index of cloud top for each column
+   integer, intent(in) :: mx(pcols)                   ! Index of cloud top for each column
+   integer, intent(in) :: ideep(pcols)                ! Gathering array
+   integer, intent(in) :: il1g                        ! Gathered min lon indices over which to operate
+   integer, intent(in) :: il2g                        ! Gathered max lon indices over which to operate
+   integer, intent(in) :: nstep                       ! Time step index
+   real(r8),intent(out) :: dqdt(pcols,pver,ncnst)     ! Tracer tendency array
+   real(r8),intent(out) ::  pguall(pcols,pver,ncnst)  ! Apparent force from  updraft PG
+   real(r8),intent(out) ::  pgdall(pcols,pver,ncnst)  ! Apparent force from  downdraft PG
+   real(r8),intent(out) ::  icwu(pcols,pver,ncnst)    ! In-cloud winds in updraft
+   real(r8),intent(out) ::  icwd(pcols,pver,ncnst)    ! In-cloud winds in downdraft
+   real(r8),intent(out) ::  seten(pcols,pver)         ! dry static energy tendency
 
-   integer, intent(in) :: jt(pcols)         ! Index of cloud top for each column
-   integer, intent(in) :: mx(pcols)         ! Index of cloud top for each column
-   integer, intent(in) :: ideep(pcols)      ! Gathering array
-   integer, intent(in) :: il1g              ! Gathered min lon indices over which to operate
-   integer, intent(in) :: il2g              ! Gathered max lon indices over which to operate
-   integer, intent(in) :: nstep             ! Time step index
-
-
-
-! input/output
-
-   real(r8), intent(out) :: dqdt(pcols,pver,ncnst)  ! Tracer tendency array
-
-!--------------------------Local Variables------------------------------
-
-   integer i                 ! Work index
-   integer k                 ! Work index
-   integer kbm               ! Highest altitude index of cloud base
-   integer kk                ! Work index
-   integer kkp1              ! Work index
-   integer kkm1              ! Work index
-   integer km1               ! Work index
-   integer kp1               ! Work index
-   integer ktm               ! Highest altitude index of cloud top
-   integer m                 ! Work index
-   integer ii                 ! Work index
-
-   real(r8) cabv                 ! Mix ratio of constituent above
-   real(r8) cbel                 ! Mix ratio of constituent below
-   real(r8) cdifr                ! Normalized diff between cabv and cbel
-   real(r8) chat(pcols,pver)     ! Mix ratio in env at interfaces
-   real(r8) cond(pcols,pver)     ! Mix ratio in downdraft at interfaces
-   real(r8) const(pcols,pver)    ! Gathered wind array
-   real(r8) conu(pcols,pver)     ! Mix ratio in updraft at interfaces
-   real(r8) dcondt(pcols,pver)   ! Gathered tend array
-   real(r8) small                ! A small number
-   real(r8) mbsth                ! Threshold for mass fluxes
-   real(r8) mupdudp              ! A work variable
-   real(r8) minc                 ! A work variable
-   real(r8) maxc                 ! A work variable
-   real(r8) fluxin               ! A work variable
-   real(r8) fluxout              ! A work variable
-   real(r8) netflux              ! A work variable
-
-   real(r8) momcu                ! constant for updraft pressure gradient term
-   real(r8) momcd                ! constant for downdraft pressure gradient term
-   real(r8) sum                  ! sum
-   real(r8) sum2                  ! sum2
- 
-   real(r8) mududp(pcols,pver) ! working variable
-   real(r8) mddudp(pcols,pver)     ! working variable
-
-   real(r8) pgu(pcols,pver)      ! Pressure gradient term for updraft
-   real(r8) pgd(pcols,pver)      ! Pressure gradient term for downdraft
-
-   real(r8),intent(out) ::  pguall(pcols,pver,ncnst)      ! Apparent force from  updraft PG
-   real(r8),intent(out) ::  pgdall(pcols,pver,ncnst)      ! Apparent force from  downdraft PG
-
-   real(r8),intent(out) ::  icwu(pcols,pver,ncnst)      ! In-cloud winds in updraft
-   real(r8),intent(out) ::  icwd(pcols,pver,ncnst)      ! In-cloud winds in downdraft
-
-   real(r8),intent(out) ::  seten(pcols,pver) ! Dry static energy tendency
-   real(r8)                 gseten(pcols,pver) ! Gathered dry static energy tendency
-
-   real(r8)  mflux(pcols,pverp,ncnst)   ! Gathered momentum flux
-
-   real(r8)  wind0(pcols,pver,ncnst)       !  gathered  wind before time step
-   real(r8)  windf(pcols,pver,ncnst)       !  gathered  wind after time step
+   !----------------------------------------------------------------------------
+   ! Local variables
+   integer i,m,ii                      ! Work indices
+   integer kk,kkp1,kkm1                ! Work indices
+   integer k,kp1,km1                   ! Work indices
+   integer kbm                         ! Highest altitude index of cloud base
+   integer ktm                         ! Highest altitude index of cloud top
+   real(r8) cabv                       ! Mix ratio of constituent above
+   real(r8) cbel                       ! Mix ratio of constituent below
+   real(r8) cdifr                      ! Normalized diff between cabv and cbel
+   real(r8) chat(pcols,pver)           ! Mix ratio in env at interfaces
+   real(r8) cond(pcols,pver)           ! Mix ratio in downdraft at interfaces
+   real(r8) const(pcols,pver)          ! Gathered wind array
+   real(r8) conu(pcols,pver)           ! Mix ratio in updraft at interfaces
+   real(r8) dcondt(pcols,pver)         ! Gathered tend array
+   real(r8) small                      ! A small number
+   real(r8) mbsth                      ! Threshold for mass fluxes
+   real(r8) mupdudp                    ! A work variable
+   real(r8) minc,maxc                  ! Work variables
+   real(r8) fluxin,fluxout             ! Work variables
+   real(r8) netflux                    ! A work variable
+   real(r8) momcu                      ! constant for updraft pressure gradient term
+   real(r8) momcd                      ! constant for downdraft pressure gradient term
+   real(r8) sum,sum2                   ! sums
+   real(r8) mududp(pcols,pver)         ! work variable
+   real(r8) mddudp(pcols,pver)         ! work variable
+   real(r8) pgu(pcols,pver)            ! Pressure gradient term for updraft
+   real(r8) pgd(pcols,pver)            ! Pressure gradient term for downdraft
+   real(r8)  gseten(pcols,pver)        ! gathered dry static energy tendency
+   real(r8)  mflux(pcols,pverp,ncnst)  ! gathered momentum flux
+   real(r8)  wind0(pcols,pver,ncnst)   ! gathered  wind before time step
+   real(r8)  windf(pcols,pver,ncnst)   ! gathered  wind after time step
    real(r8) fkeb, fket, ketend_cons, ketend, utop, ubot, vtop, vbot, gset2
-   
-
-!-----------------------------------------------------------------------
-!
-
-! Initialize outgoing fields
-   pguall(:,:,:)     = 0.0_r8
-   pgdall(:,:,:)     = 0.0_r8
-! Initialize in-cloud winds to environmental wind
-   icwu(:ncol,:,:)       = q(:ncol,:,:)
-   icwd(:ncol,:,:)       = q(:ncol,:,:)
-
-! Initialize momentum flux and  final winds
-   mflux(:,:,:)       = 0.0_r8
-   wind0(:,:,:)         = 0.0_r8
-   windf(:,:,:)         = 0.0_r8
-
-! Initialize dry static energy
-
-   seten(:,:)         = 0.0_r8
-   gseten(:,:)         = 0.0_r8
-
-! Define constants for parameterization
-
+   !----------------------------------------------------------------------------
+   ! Initialize outgoing fields
+   pguall(:,:,:) = 0.0_r8
+   pgdall(:,:,:) = 0.0_r8
+   ! Initialize in-cloud winds to environmental wind
+   icwu(:ncol,:,:) = q(:ncol,:,:)
+   icwd(:ncol,:,:) = q(:ncol,:,:)
+   ! Initialize momentum flux and  final winds
+   mflux(:,:,:) = 0.0_r8
+   wind0(:,:,:) = 0.0_r8
+   windf(:,:,:) = 0.0_r8
+   ! Initialize dry static energy
+   seten(:,:)  = 0.0_r8
+   gseten(:,:) = 0.0_r8
+   !----------------------------------------------------------------------------
+   ! Define constants for parameterization
    momcu = 0.4_r8
    momcd = 0.4_r8
-
    small = 1.e-36_r8
-! mbsth is the threshold below which we treat the mass fluxes as zero (in mb/s)
+   ! mbsth is the threshold below which we treat the mass fluxes as zero (in mb/s)
    mbsth = 1.e-15_r8
-
-! Find the highest level top and bottom levels of convection
+   !----------------------------------------------------------------------------
+   ! Find the highest level top and bottom levels of convection
    ktm = pver
    kbm = pver
    do i = il1g, il2g
       ktm = min(ktm,jt(i))
       kbm = min(kbm,mx(i))
    end do
-
-! Loop ever each wind component
-   do m = 1, ncnst                    !start at m = 1 to transport momentum
+   !----------------------------------------------------------------------------
+   ! Loop ever each wind component - start at m=1 to transport momentum
+   do m = 1, ncnst
       if (domomtran(m)) then
 
-! Gather up the winds and set tend to zero
+         ! Gather up the winds and set tend to zero
          do k = 1,pver
             do i =il1g,il2g
                const(i,k) = q(ideep(i),k,m)
-                wind0(i,k,m) = const(i,k)
+               wind0(i,k,m) = const(i,k)
             end do
          end do
 
+         ! ***** From now on work only with gathered data *****
 
-! From now on work only with gathered data
-
-! Interpolate winds to interfaces
-
+         ! Interpolate winds to interfaces
          do k = 1,pver
             km1 = max(1,k-1)
             do i = il1g, il2g
-
                ! use arithmetic mean
                chat(i,k) = 0.5_r8* (const(i,k)+const(i,km1))
-
-! Provisional up and down draft values
+               ! Provisional up and down draft values
                conu(i,k) = chat(i,k)
                cond(i,k) = chat(i,k)
-
-!              provisional tends
+               ! provisional tends
                dcondt(i,k) = 0._r8
-
             end do
          end do
 
-
-!
-! Pressure Perturbation Term
-! 
-
-      !Top boundary:  assume mu is zero 
-
+         ! Pressure Perturbation Term
+         ! Top boundary:  assume mu is zero 
          k=1
          pgu(:il2g,k) = 0.0_r8
          pgd(:il2g,k) = 0.0_r8
@@ -1612,44 +1377,29 @@ subroutine momtran(lchnk, ncol, &
             km1 = max(1,k-1)
             kp1 = min(pver,k+1)
             do i = il1g,il2g
-            
                !interior points
-
                mududp(i,k) =  ( mu(i,k) * (const(i,k)- const(i,km1))/dp(i,km1) &
                            +  mu(i,kp1) * (const(i,kp1) - const(i,k))/dp(i,k))
-
                pgu(i,k) = - momcu * 0.5_r8 * mududp(i,k)
-                           
-
                mddudp(i,k) =  ( md(i,k) * (const(i,k)- const(i,km1))/dp(i,km1) &
                            +  md(i,kp1) * (const(i,kp1) - const(i,k))/dp(i,k))
-
                pgd(i,k) = - momcd * 0.5_r8 * mddudp(i,k)
-
-
             end do
          end do
 
-       ! bottom boundary 
-       k = pver
-       km1 = max(1,k-1)
-       do i=il1g,il2g
-
-          mududp(i,k) =   mu(i,k) * (const(i,k)- const(i,km1))/dp(i,km1)
-          pgu(i,k) = - momcu *  mududp(i,k)
-          
-          mddudp(i,k) =   md(i,k) * (const(i,k)- const(i,km1))/dp(i,km1) 
-
-          pgd(i,k) = - momcd * mddudp(i,k)
-          
-       end do
+         ! bottom boundary 
+         k = pver
+         km1 = max(1,k-1)
+         do i=il1g,il2g
+            mududp(i,k) =   mu(i,k) * (const(i,k)- const(i,km1))/dp(i,km1)
+            pgu(i,k) = - momcu *  mududp(i,k)
+            mddudp(i,k) =   md(i,k) * (const(i,k)- const(i,km1))/dp(i,km1) 
+            pgd(i,k) = - momcd * mddudp(i,k)
+         end do
        
+         ! In-cloud velocity calculations
 
-!
-! In-cloud velocity calculations
-!
-
-! Do levels adjacent to top and bottom
+         ! Do levels adjacent to top and bottom
          k = 2
          km1 = 1
          kk = pver
@@ -1657,59 +1407,45 @@ subroutine momtran(lchnk, ncol, &
          do i = il1g,il2g
             mupdudp = mu(i,kk) + du(i,kk)*dp(i,kk)
             if (mupdudp > mbsth) then
-                 
                conu(i,kk) = (+eu(i,kk)*const(i,kk)*dp(i,kk)+pgu(i,kk)*dp(i,kk))/mupdudp
             endif
             if (md(i,k) < -mbsth) then
                cond(i,k) =  (-ed(i,km1)*const(i,km1)*dp(i,km1))-pgd(i,km1)*dp(i,km1)/md(i,k)
-            endif
-
-                        
+            endif         
          end do
 
-
-
-! Updraft from bottom to top
+         ! Updraft from bottom to top
          do kk = pver-1,1,-1
             kkm1 = max(1,kk-1)
             kkp1 = min(pver,kk+1)
             do i = il1g,il2g
                mupdudp = mu(i,kk) + du(i,kk)*dp(i,kk)
                if (mupdudp > mbsth) then
-            
                   conu(i,kk) = (  mu(i,kkp1)*conu(i,kkp1)+eu(i,kk)* &
                                   const(i,kk)*dp(i,kk)+pgu(i,kk)*dp(i,kk))/mupdudp
                endif
             end do
-
          end do
 
-
-! Downdraft from top to bottom
+         ! Downdraft from top to bottom
          do k = 3,pver
             km1 = max(1,k-1)
             do i = il1g,il2g
                if (md(i,k) < -mbsth) then
-                            
                   cond(i,k) =  (  md(i,km1)*cond(i,km1)-ed(i,km1)*const(i,km1) &
                                   *dp(i,km1)-pgd(i,km1)*dp(i,km1) )/md(i,k)
-
                endif
             end do
          end do
 
-
          sum = 0._r8
          sum2 = 0._r8
-
 
          do k = ktm,pver
             km1 = max(1,k-1)
             kp1 = min(pver,k+1)
             do i = il1g,il2g
                ii = ideep(i)
-	
-! version 1 hard to check for roundoff errors
                dcondt(i,k) =  &
                            +(mu(i,kp1)* (conu(i,kp1)-chat(i,kp1)) &
                            -mu(i,k)*   (conu(i,k)-chat(i,k))      &
@@ -1720,33 +1456,30 @@ subroutine momtran(lchnk, ncol, &
             end do
          end do
 
-  ! dcont for bottom layer
-          !
+         
 #ifdef CPRCRAY
-          !DIR$ NOINTERCHANGE
+!DIR$ NOINTERCHANGE
 #endif
-          do k = kbm,pver
-             km1 = max(1,k-1)
-             do i = il1g,il2g
-                if (k == mx(i)) then
+         ! dcont for bottom layer
+         do k = kbm,pver
+            km1 = max(1,k-1)
+            do i = il1g,il2g
+               if (k == mx(i)) then
+                  dcondt(i,k) = (1._r8/dp(i,k))*   &  
+                       (-mu(i,k)*(conu(i,k)-chat(i,k)) &
+                       -md(i,k)*(cond(i,k)-chat(i,k))  )
+               end if
+            end do
+         end do
 
-                   ! version 1
-                   dcondt(i,k) = (1._r8/dp(i,k))*   &  
-                        (-mu(i,k)*(conu(i,k)-chat(i,k)) &
-                        -md(i,k)*(cond(i,k)-chat(i,k)) &
-                        )
-                end if
-             end do
-          end do
-
-! Initialize to zero everywhere, then scatter tendency back to full array
+         ! Initialize to zero everywhere, then scatter tendency back to full array
          dqdt(:,:,m) = 0._r8
 
          do k = 1,pver
             do i = il1g,il2g
                ii = ideep(i)
                dqdt(ii,k,m) = dcondt(i,k)
-    ! Output apparent force on the mean flow from pressure gradient
+               ! Output apparent force on the mean flow from pressure gradient
                pguall(ii,k,m) = -pgu(i,k)
                pgdall(ii,k,m) = -pgd(i,k)
                icwu(ii,k,m)   =  conu(i,k)
@@ -1754,383 +1487,66 @@ subroutine momtran(lchnk, ncol, &
             end do
          end do
 
-          ! Calculate momentum flux in units of mb*m/s2 
+         ! Calculate momentum flux in units of mb*m/s2 
+         do k = ktm,pver
+            do i = il1g,il2g
+               ii = ideep(i)
+               mflux(i,k,m) = &
+                    -mu(i,k)*   (conu(i,k)-chat(i,k))      &
+                    -md(i,k)*   (cond(i,k)-chat(i,k))
+            end do
+         end do
 
-          do k = ktm,pver
-             do i = il1g,il2g
-                ii = ideep(i)
-                mflux(i,k,m) = &
-                     -mu(i,k)*   (conu(i,k)-chat(i,k))      &
-                     -md(i,k)*   (cond(i,k)-chat(i,k))
-             end do
-          end do
+         ! Calculate winds at the end of the time step 
+         do k = ktm,pver
+            do i = il1g,il2g
+               ii = ideep(i)
+               km1 = max(1,k-1)
+               kp1 = k+1
+               windf(i,k,m) = const(i,k)    -   (mflux(i,kp1,m) - mflux(i,k,m)) * dt /dp(i,k)
+            end do
+         end do
 
-
-          ! Calculate winds at the end of the time step 
-
-          do k = ktm,pver
-             do i = il1g,il2g
-                ii = ideep(i)
-                km1 = max(1,k-1)
-                kp1 = k+1
-                windf(i,k,m) = const(i,k)    -   (mflux(i,kp1,m) - mflux(i,k,m)) * dt /dp(i,k)
-
-             end do
-          end do
-
-       end if      ! for domomtran
+      end if ! domomtran
    end do
 
- ! Need to add an energy fix to account for the dissipation of kinetic energy
-    ! Formulation follows from Boville and Bretherton (2003)
-    ! formulation by PJR
+   ! Need to add an energy fix to account for the dissipation of kinetic energy
+   ! Formulation follows from Boville and Bretherton (2003)
 
-    do k = ktm,pver
-       km1 = max(1,k-1)
-       kp1 = min(pver,k+1)
-       do i = il1g,il2g
+   do k = ktm,pver
+      km1 = max(1,k-1)
+      kp1 = min(pver,k+1)
+      do i = il1g,il2g
+         ! calculate the KE fluxes at top and bot of layer 
+         ! based on a discrete approximation to b&b eq(35) F_KE = u*F_u + v*F_v at interface
+         utop = (wind0(i,k,1)+wind0(i,km1,1))/2._r8
+         vtop = (wind0(i,k,2)+wind0(i,km1,2))/2._r8
+         ubot = (wind0(i,kp1,1)+wind0(i,k,1))/2._r8
+         vbot = (wind0(i,kp1,2)+wind0(i,k,2))/2._r8
+         fket = utop*mflux(i,k,1)   + vtop*mflux(i,k,2)    ! top of layer
+         fkeb = ubot*mflux(i,k+1,1) + vbot*mflux(i,k+1,2)  ! bot of layer
+         ! divergence of these fluxes should give a conservative redistribution of KE
+         ketend_cons = (fket-fkeb)/dp(i,k)
+         ! tendency in kinetic energy resulting from the momentum transport
+         ketend = ((windf(i,k,1)**2 + windf(i,k,2)**2) - (wind0(i,k,1)**2 + wind0(i,k,2)**2))*0.5_r8/dt
+         ! the difference should be the dissipation
+         gset2 = ketend_cons - ketend
+         gseten(i,k) = gset2
+      end do
+   end do
 
-          ii = ideep(i)
-
-          ! calculate the KE fluxes at top and bot of layer 
-          ! based on a discrete approximation to b&b eq(35) F_KE = u*F_u + v*F_v at interface
-          utop = (wind0(i,k,1)+wind0(i,km1,1))/2._r8
-          vtop = (wind0(i,k,2)+wind0(i,km1,2))/2._r8
-          ubot = (wind0(i,kp1,1)+wind0(i,k,1))/2._r8
-          vbot = (wind0(i,kp1,2)+wind0(i,k,2))/2._r8
-          fket = utop*mflux(i,k,1)   + vtop*mflux(i,k,2)    ! top of layer
-          fkeb = ubot*mflux(i,k+1,1) + vbot*mflux(i,k+1,2)  ! bot of layer
-
-          ! divergence of these fluxes should give a conservative redistribution of KE
-          ketend_cons = (fket-fkeb)/dp(i,k)
-
-          ! tendency in kinetic energy resulting from the momentum transport
-          ketend = ((windf(i,k,1)**2 + windf(i,k,2)**2) - (wind0(i,k,1)**2 + wind0(i,k,2)**2))*0.5_r8/dt
-
-          ! the difference should be the dissipation
-          gset2 = ketend_cons - ketend
-          gseten(i,k) = gset2
-
-       end do
-
-    end do
-
-    ! Scatter dry static energy to full array
-    do k = 1,pver
-       do i = il1g,il2g
-          ii = ideep(i)
-          seten(ii,k) = gseten(i,k)
-
-       end do
-    end do
+   ! Scatter dry static energy to full array
+   do k = 1,pver
+      do i = il1g,il2g
+         seten(ideep(i),k) = gseten(i,k)
+      end do
+   end do
 
    return
 end subroutine momtran
 
-!=========================================================================================
-
-subroutine buoyan(lchnk   ,ncol    , &
-                  q       ,t       ,p       ,z       ,pf      , &
-                  tp      ,qstp    ,tl      ,rl      ,cape    , &
-                  pblt    ,lcl     ,lel     ,lon     ,mx      , &
-                  rd      ,grav    ,cp      ,msg     , &
-                  tpert   )
-!----------------------------------------------------------------------- 
-! 
-! Purpose: 
-! <Say what the routine does> 
-! 
-! Method: 
-! <Describe the algorithm(s) used in the routine.> 
-! <Also include any applicable external references.> 
-! 
-! Author:
-! This is contributed code not fully standardized by the CCM core group.
-! The documentation has been enhanced to the degree that we are able.
-! Reviewed:          P. Rasch, April 1996
-! 
-!-----------------------------------------------------------------------
-   implicit none
-!-----------------------------------------------------------------------
-!
-! input arguments
-!
-   integer, intent(in) :: lchnk                 ! chunk identifier
-   integer, intent(in) :: ncol                  ! number of atmospheric columns
-
-   real(r8), intent(in) :: q(pcols,pver)        ! spec. humidity
-   real(r8), intent(in) :: t(pcols,pver)        ! temperature
-   real(r8), intent(in) :: p(pcols,pver)        ! pressure
-   real(r8), intent(in) :: z(pcols,pver)        ! height
-   real(r8), intent(in) :: pf(pcols,pver+1)     ! pressure at interfaces
-   real(r8), intent(in) :: pblt(pcols)          ! index of pbl depth
-   real(r8), intent(in) :: tpert(pcols)         ! perturbation temperature by pbl processes
-
-!
-! output arguments
-!
-   real(r8), intent(out) :: tp(pcols,pver)       ! parcel temperature
-   real(r8), intent(out) :: qstp(pcols,pver)     ! saturation mixing ratio of parcel
-   real(r8), intent(out) :: tl(pcols)            ! parcel temperature at lcl
-   real(r8), intent(out) :: cape(pcols)          ! convective aval. pot. energy.
-   integer lcl(pcols)        !
-   integer lel(pcols)        !
-   integer lon(pcols)        ! level of onset of deep convection
-   integer mx(pcols)         ! level of max moist static energy
-!
-!--------------------------Local Variables------------------------------
-!
-   real(r8) capeten(pcols,5)     ! provisional value of cape
-   real(r8) tv(pcols,pver)       !
-   real(r8) tpv(pcols,pver)      !
-   real(r8) buoy(pcols,pver)
-
-   real(r8) a1(pcols)
-   real(r8) a2(pcols)
-   real(r8) estp(pcols)
-   real(r8) pl(pcols)
-   real(r8) plexp(pcols)
-   real(r8) hmax(pcols)
-   real(r8) hmn(pcols)
-   real(r8) y(pcols)
-
-   logical plge600(pcols)
-   integer knt(pcols)
-   integer lelten(pcols,5)
-
-   real(r8) cp
-   real(r8) e
-   real(r8) grav
-
-   integer i
-   integer k
-   integer msg
-   integer n
-
-   real(r8) rd
-   real(r8) rl
-#ifdef PERGRO
-   real(r8) rhd
-#endif
-!
-!-----------------------------------------------------------------------
-!
-   do n = 1,5
-      do i = 1,ncol
-         lelten(i,n) = pver
-         capeten(i,n) = 0._r8
-      end do
-   end do
-!
-   do i = 1,ncol
-      lon(i) = pver
-      knt(i) = 0
-      lel(i) = pver
-      mx(i) = lon(i)
-      cape(i) = 0._r8
-      hmax(i) = 0._r8
-   end do
-
-   tp(:ncol,:) = t(:ncol,:)
-   qstp(:ncol,:) = q(:ncol,:)
-
-!!! RBN - Initialize tv and buoy for output.
-!!! tv=tv : tpv=tpv : qstp=q : buoy=0.
-   tv(:ncol,:) = t(:ncol,:) *(1._r8+1.608_r8*q(:ncol,:))/ (1._r8+q(:ncol,:))
-   tpv(:ncol,:) = tv(:ncol,:)
-   buoy(:ncol,:) = 0._r8
-
-!
-! set "launching" level(mx) to be at maximum moist static energy.
-! search for this level stops at planetary boundary layer top.
-!
-#ifdef PERGRO
-   do k = pver,msg + 1,-1
-      do i = 1,ncol
-         hmn(i) = cp*t(i,k) + grav*z(i,k) + rl*q(i,k)
-!
-! Reset max moist static energy level when relative difference exceeds 1.e-4
-!
-         rhd = (hmn(i) - hmax(i))/(hmn(i) + hmax(i))
-         if (k >= nint(pblt(i)) .and. k <= lon(i) .and. rhd > -1.e-4_r8) then
-            hmax(i) = hmn(i)
-            mx(i) = k
-         end if
-      end do
-   end do
-#else
-   do k = pver,msg + 1,-1
-      do i = 1,ncol
-         hmn(i) = cp*t(i,k) + grav*z(i,k) + rl*q(i,k)
-         if (k >= nint(pblt(i)) .and. k <= lon(i) .and. hmn(i) > hmax(i)) then
-            hmax(i) = hmn(i)
-            mx(i) = k
-         end if
-      end do
-   end do
-#endif
-!
-   do i = 1,ncol
-      lcl(i) = mx(i)
-      e = p(i,mx(i))*q(i,mx(i))/ (eps1+q(i,mx(i)))
-      tl(i) = 2840._r8/ (3.5_r8*log(t(i,mx(i)))-log(e)-4.805_r8) + 55._r8
-      if (tl(i) < t(i,mx(i))) then
-         plexp(i) = (1._r8/ (0.2854_r8* (1._r8-0.28_r8*q(i,mx(i)))))
-         pl(i) = p(i,mx(i))* (tl(i)/t(i,mx(i)))**plexp(i)
-      else
-         tl(i) = t(i,mx(i))
-         pl(i) = p(i,mx(i))
-      end if
-   end do
-
-!
-! calculate lifting condensation level (lcl).
-!
-   do k = pver,msg + 2,-1
-      do i = 1,ncol
-         if (k <= mx(i) .and. (p(i,k) > pl(i) .and. p(i,k-1) <= pl(i))) then
-            lcl(i) = k - 1
-         end if
-      end do
-   end do
-!
-! if lcl is above the nominal level of non-divergence (600 mbs),
-! no deep convection is permitted (ensuing calculations
-! skipped and cape retains initialized value of zero).
-!
-   do i = 1,ncol
-      plge600(i) = pl(i).ge.600._r8
-   end do
-!
-! initialize parcel properties in sub-cloud layer below lcl.
-!
-   do k = pver,msg + 1,-1
-      do i=1,ncol
-         if (k > lcl(i) .and. k <= mx(i) .and. plge600(i)) then
-            tv(i,k) = t(i,k)* (1._r8+1.608_r8*q(i,k))/ (1._r8+q(i,k))
-            qstp(i,k) = q(i,mx(i))
-            tp(i,k) = t(i,mx(i))* (p(i,k)/p(i,mx(i)))**(0.2854_r8* (1._r8-0.28_r8*q(i,mx(i))))
-!
-! buoyancy is increased by 0.5 k as in tiedtke
-!
-!-jjh          tpv (i,k)=tp(i,k)*(1.+1.608*q(i,mx(i)))/
-!-jjh     1                     (1.+q(i,mx(i)))
-            tpv(i,k) = (tp(i,k)+tpert(i))*(1._r8+1.608_r8*q(i,mx(i)))/ (1._r8+q(i,mx(i)))
-            buoy(i,k) = tpv(i,k) - tv(i,k) + tiedke_add
-         end if
-      end do
-   end do
-
-!
-! define parcel properties at lcl (i.e. level immediately above pl).
-!
-   do k = pver,msg + 1,-1
-      do i=1,ncol
-         if (k == lcl(i) .and. plge600(i)) then
-            tv(i,k) = t(i,k)* (1._r8+1.608_r8*q(i,k))/ (1._r8+q(i,k))
-            qstp(i,k) = q(i,mx(i))
-            tp(i,k) = tl(i)* (p(i,k)/pl(i))**(0.2854_r8* (1._r8-0.28_r8*qstp(i,k)))
-!              estp(i)  =exp(21.656_r8 - 5418._r8/tp(i,k))
-! use of different formulas for es has about 1 g/kg difference
-! in qs at t= 300k, and 0.02 g/kg at t=263k, with the formula
-! above giving larger qs.
-            call qsat_hPa(tp(i,k), p(i,k), estp(i), qstp(i,k))
-            a1(i) = cp / rl + qstp(i,k) * (1._r8+ qstp(i,k) / eps1) * rl * eps1 / &
-                    (rd * tp(i,k) ** 2)
-            a2(i) = .5_r8* (qstp(i,k)* (1._r8+2._r8/eps1*qstp(i,k))* &
-                    (1._r8+qstp(i,k)/eps1)*eps1**2*rl*rl/ &
-                    (rd**2*tp(i,k)**4)-qstp(i,k)* &
-                    (1._r8+qstp(i,k)/eps1)*2._r8*eps1*rl/ &
-                    (rd*tp(i,k)**3))
-            a1(i) = 1._r8/a1(i)
-            a2(i) = -a2(i)*a1(i)**3
-            y(i) = q(i,mx(i)) - qstp(i,k)
-            tp(i,k) = tp(i,k) + a1(i)*y(i) + a2(i)*y(i)**2
-            call qsat_hPa(tp(i,k), p(i,k), estp(i), qstp(i,k))
-!
-! buoyancy is increased by 0.5 k in cape calculation.
-! dec. 9, 1994
-!-jjh          tpv(i,k) =tp(i,k)*(1.+1.608*qstp(i,k))/(1.+q(i,mx(i)))
-!
-            tpv(i,k) = (tp(i,k)+tpert(i))* (1._r8+1.608_r8*qstp(i,k)) / (1._r8+q(i,mx(i)))
-            buoy(i,k) = tpv(i,k) - tv(i,k) + tiedke_add
-         end if
-      end do
-   end do
-!
-! main buoyancy calculation.
-!
-   do k = pver - 1,msg + 1,-1
-      do i=1,ncol
-         if (k < lcl(i) .and. plge600(i)) then
-            tv(i,k) = t(i,k)* (1._r8+1.608_r8*q(i,k))/ (1._r8+q(i,k))
-            qstp(i,k) = qstp(i,k+1)
-            tp(i,k) = tp(i,k+1)* (p(i,k)/p(i,k+1))**(0.2854_r8* (1._r8-0.28_r8*qstp(i,k)))
-            call qsat_hPa(tp(i,k), p(i,k), estp(i), qstp(i,k))
-            a1(i) = cp/rl + qstp(i,k)* (1._r8+qstp(i,k)/eps1)*rl*eps1/ (rd*tp(i,k)**2)
-            a2(i) = .5_r8* (qstp(i,k)* (1._r8+2._r8/eps1*qstp(i,k))* &
-                    (1._r8+qstp(i,k)/eps1)*eps1**2*rl*rl/ &
-                    (rd**2*tp(i,k)**4)-qstp(i,k)* &
-                    (1._r8+qstp(i,k)/eps1)*2._r8*eps1*rl/ &
-                    (rd*tp(i,k)**3))
-            a1(i) = 1._r8/a1(i)
-            a2(i) = -a2(i)*a1(i)**3
-            y(i) = qstp(i,k+1) - qstp(i,k)
-            tp(i,k) = tp(i,k) + a1(i)*y(i) + a2(i)*y(i)**2
-            call qsat_hPa(tp(i,k), p(i,k), estp(i), qstp(i,k))
-!-jjh          tpv(i,k) =tp(i,k)*(1.+1.608*qstp(i,k))/
-!jt            (1.+q(i,mx(i)))
-            tpv(i,k) = (tp(i,k)+tpert(i))* (1._r8+1.608_r8*qstp(i,k))/(1._r8+q(i,mx(i)))
-            buoy(i,k) = tpv(i,k) - tv(i,k) + tiedke_add
-         end if
-      end do
-   end do
-
-!
-   do k = msg + 2,pver
-      do i = 1,ncol
-         if (k < lcl(i) .and. plge600(i)) then
-            if (buoy(i,k+1) > 0._r8 .and. buoy(i,k) <= 0._r8) then
-               knt(i) = min(5,knt(i) + 1)
-               lelten(i,knt(i)) = k
-            end if
-         end if
-      end do
-   end do
-!
-! calculate convective available potential energy (cape).
-!
-   do n = 1,5
-      do k = msg + 1,pver
-         do i = 1,ncol
-            if (plge600(i) .and. k <= mx(i) .and. k > lelten(i,n)) then
-               capeten(i,n) = capeten(i,n) + rd*buoy(i,k)*log(pf(i,k+1)/pf(i,k))
-            end if
-         end do
-      end do
-   end do
-!
-! find maximum cape from all possible tentative capes from
-! one sounding,
-! and use it as the final cape, april 26, 1995
-!
-   do n = 1,5
-      do i = 1,ncol
-         if (capeten(i,n) > cape(i)) then
-            cape(i) = capeten(i,n)
-            lel(i) = lelten(i,n)
-         end if
-      end do
-   end do
-!
-! put lower bound on cape for diagnostic purposes.
-!
-   do i = 1,ncol
-      cape(i) = max(cape(i), 0._r8)
-   end do
-!
-   return
-end subroutine buoyan
+!-------------------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 subroutine cldprp(lchnk   , &
                   q       ,t       ,u       ,v       ,p       , &
@@ -2143,86 +1559,57 @@ subroutine cldprp(lchnk   , &
                   rd      ,grav    ,cp      ,msg     , &
                   pflx    ,evp     ,cu      ,rprd    ,limcnv  , &
                   landfrac,  tpertg )
-!----------------------------------------------------------------------- 
-! 
-! Purpose: 
-! <Say what the routine does> 
-! 
-! Method: 
-! may 09/91 - guang jun zhang, m.lazare, n.mcfarlane.
-!             original version cldprop.
-! 
-! Author: See above, modified by P. Rasch
-! This is contributed code not fully standardized by the CCM core group.
-!
-! this code is very much rougher than virtually anything else in the CCM
-! there are debug statements left strewn about and code segments disabled
-! these are to facilitate future development. We expect to release a
-! cleaner code in a future release
-!
-! the documentation has been enhanced to the degree that we are able
-!
-!-----------------------------------------------------------------------
-
+   !----------------------------------------------------------------------------
+   ! Author: may 09/91 guang jun zhang, m.lazare, n.mcfarlane, modified by P. Rasch
+   !----------------------------------------------------------------------------
    implicit none
-
-!------------------------------------------------------------------------------
-!
-! Input arguments
-!
-   integer, intent(in) :: lchnk                  ! chunk identifier
-
-   real(r8), intent(in) :: q(pcols,pver)         ! spec. humidity of env
-   real(r8), intent(in) :: t(pcols,pver)         ! temp of env
-   real(r8), intent(in) :: p(pcols,pver)         ! pressure of env
-   real(r8), intent(in) :: z(pcols,pver)         ! height of env
-   real(r8), intent(in) :: s(pcols,pver)         ! normalized dry static energy of env
-   real(r8), intent(in) :: zf(pcols,pverp)       ! height of interfaces
-   real(r8), intent(in) :: u(pcols,pver)         ! zonal velocity of env
-   real(r8), intent(in) :: v(pcols,pver)         ! merid. velocity of env
-
-   real(r8), intent(in) :: landfrac(pcols) ! RBN Landfrac
-
-   integer, intent(in) :: jb(pcols)              ! updraft base level
-   integer, intent(in) :: lel(pcols)             ! updraft launch level
-   integer, intent(out) :: jt(pcols)              ! updraft plume top
-   integer, intent(out) :: jlcl(pcols)            ! updraft lifting cond level
-   integer, intent(in) :: mx(pcols)              ! updraft base level (same is jb)
-   integer, intent(out) :: j0(pcols)              ! level where updraft begins detraining
-   integer, intent(out) :: jd(pcols)              ! level of downdraft
-   integer, intent(in) :: limcnv                 ! convection limiting level
-   integer, intent(in) :: il2g                   !CORE GROUP REMOVE
-   integer, intent(in) :: msg                    ! missing moisture vals (always 0)
-   real(r8), intent(in) :: rl                    ! latent heat of vap
-   real(r8), intent(in) :: shat(pcols,pver)      ! interface values of dry stat energy
-   real(r8), intent(in) :: tpertg(pcols)
-!
-! output
-!
-   real(r8), intent(out) :: rprd(pcols,pver)     ! rate of production of precip at that layer
-   real(r8), intent(out) :: du(pcols,pver)       ! detrainement rate of updraft
-   real(r8), intent(out) :: ed(pcols,pver)       ! entrainment rate of downdraft
-   real(r8), intent(out) :: eu(pcols,pver)       ! entrainment rate of updraft
-   real(r8), intent(out) :: hmn(pcols,pver)      ! moist stat energy of env
-   real(r8), intent(out) :: hsat(pcols,pver)     ! sat moist stat energy of env
-   real(r8), intent(out) :: mc(pcols,pver)       ! net mass flux
-   real(r8), intent(out) :: md(pcols,pver)       ! downdraft mass flux
-   real(r8), intent(out) :: mu(pcols,pver)       ! updraft mass flux
-   real(r8), intent(out) :: pflx(pcols,pverp)    ! precipitation flux thru layer
-   real(r8), intent(out) :: qd(pcols,pver)       ! spec humidity of downdraft
-   real(r8), intent(out) :: ql(pcols,pver)       ! liq water of updraft
-   real(r8), intent(out) :: qst(pcols,pver)      ! saturation mixing ratio of env.
-   real(r8), intent(out) :: qu(pcols,pver)       ! spec hum of updraft
-   real(r8), intent(out) :: sd(pcols,pver)       ! normalized dry stat energy of downdraft
-   real(r8), intent(out) :: su(pcols,pver)       ! normalized dry stat energy of updraft
-
+   !----------------------------------------------------------------------------
+   ! Interface arguments
+   integer, intent(in ) :: lchnk                ! chunk identifier
+   real(r8),intent(in ) :: q(pcols,pver)        ! spec. humidity of env
+   real(r8),intent(in ) :: t(pcols,pver)        ! temp of env
+   real(r8),intent(in ) :: p(pcols,pver)        ! pressure of env
+   real(r8),intent(in ) :: z(pcols,pver)        ! height of env
+   real(r8),intent(in ) :: s(pcols,pver)        ! normalized dry static energy of env
+   real(r8),intent(in ) :: zf(pcols,pverp)      ! height of interfaces
+   real(r8),intent(in ) :: u(pcols,pver)        ! zonal velocity of env
+   real(r8),intent(in ) :: v(pcols,pver)        ! merid. velocity of env
+   real(r8),intent(in ) :: landfrac(pcols)      ! Land fraction
+   integer, intent(in ) :: jb(pcols)            ! updraft base level
+   integer, intent(in ) :: lel(pcols)           ! updraft launch level
+   integer, intent(out) :: jt(pcols)            ! updraft plume top
+   integer, intent(out) :: jlcl(pcols)          ! updraft lifting cond level
+   integer, intent(in ) :: mx(pcols)            ! updraft base level (same is jb)
+   integer, intent(out) :: j0(pcols)            ! level where updraft begins detraining
+   integer, intent(out) :: jd(pcols)            ! level of downdraft
+   integer, intent(in ) :: limcnv               ! convection limiting level
+   integer, intent(in ) :: il2g                 ! length of gathered array
+   integer, intent(in ) :: msg                  ! missing moisture vals (always 0)
+   real(r8),intent(in ) :: rl                   ! latent heat of vap
+   real(r8),intent(in ) :: shat(pcols,pver)     ! interface values of dry stat energy
+   real(r8),intent(in ) :: tpertg(pcols)
+   real(r8),intent(out) :: rprd(pcols,pver)     ! rate of production of precip at that layer
+   real(r8),intent(out) :: du(pcols,pver)       ! detrainement rate of updraft
+   real(r8),intent(out) :: ed(pcols,pver)       ! entrainment rate of downdraft
+   real(r8),intent(out) :: eu(pcols,pver)       ! entrainment rate of updraft
+   real(r8),intent(out) :: hmn(pcols,pver)      ! moist stat energy of env
+   real(r8),intent(out) :: hsat(pcols,pver)     ! sat moist stat energy of env
+   real(r8),intent(out) :: mc(pcols,pver)       ! net mass flux
+   real(r8),intent(out) :: md(pcols,pver)       ! downdraft mass flux
+   real(r8),intent(out) :: mu(pcols,pver)       ! updraft mass flux
+   real(r8),intent(out) :: pflx(pcols,pverp)    ! precipitation flux thru layer
+   real(r8),intent(out) :: qd(pcols,pver)       ! spec humidity of downdraft
+   real(r8),intent(out) :: ql(pcols,pver)       ! liq water of updraft
+   real(r8),intent(out) :: qst(pcols,pver)      ! saturation mixing ratio of env.
+   real(r8),intent(out) :: qu(pcols,pver)       ! spec hum of updraft
+   real(r8),intent(out) :: sd(pcols,pver)       ! normalized dry stat energy of downdraft
+   real(r8),intent(out) :: su(pcols,pver)       ! normalized dry stat energy of updraft
+   !----------------------------------------------------------------------------
+   ! Local variables
    real(r8) rd                   ! gas constant for dry air
    real(r8) grav                 ! gravity
    real(r8) cp                   ! heat capacity of dry air
 
-!
-! Local workspace
-!
    real(r8) gamma(pcols,pver)
    real(r8) dz(pcols,pver)
    real(r8) iprm(pcols,pver)
@@ -2243,7 +1630,7 @@ subroutine cldprp(lchnk   , &
    real(r8) evp(pcols,pver)
    real(r8) cmeg(pcols,pver)
    real(r8) qds(pcols,pver)
-! RBN For c0mask
+
    real(r8) c0mask(pcols)
 
    real(r8) hmin(pcols)
@@ -2275,27 +1662,23 @@ subroutine cldprp(lchnk   , &
 
    logical doit(pcols)
    logical done(pcols)
-!
-!------------------------------------------------------------------------------
-!
+
+   !----------------------------------------------------------------------------
    do i = 1,il2g
       ftemp(i) = 0._r8
       expnum(i) = 0._r8
       expdif(i) = 0._r8
       c0mask(i)  = c0_ocn * (1._r8-landfrac(i)) +   c0_lnd * landfrac(i) 
    end do
-!
-!jr Change from msg+1 to 1 to prevent blowup
-!
+
+   ! Change from msg+1 to 1 to prevent blowup
    do k = 1,pver
       do i = 1,il2g
          dz(i,k) = zf(i,k) - zf(i,k+1)
       end do
    end do
 
-!
-! initialize many output and work variables to zero
-!
+   ! initialize many output and work variables to zero
    pflx(:il2g,1) = 0
 
    do k = 1,pver
@@ -2322,11 +1705,7 @@ subroutine cldprp(lchnk   , &
          qu(i,k) = q(i,k)
          su(i,k) = s(i,k)
          call qsat_hPa(t(i,k), p(i,k), est(i), qst(i,k))
-!++bee
-         if ( p(i,k)-est(i) <= 0._r8 ) then
-            qst(i,k) = 1.0_r8
-         end if
-!--bee
+         if ( p(i,k)-est(i) <= 0._r8 ) qst(i,k) = 1.0_r8
          gamma(i,k) = qst(i,k)*(1._r8 + qst(i,k)/eps1)*eps1*rl/(rd*t(i,k)**2)*rl/cp
          hmn(i,k) = cp*t(i,k) + grav*z(i,k) + rl*q(i,k)
          hsat(i,k) = cp*t(i,k) + grav*z(i,k) + rl*qst(i,k)
@@ -2335,18 +1714,15 @@ subroutine cldprp(lchnk   , &
          rprd(i,k) = 0._r8
       end do
    end do
-!
-!jr Set to zero things which make this routine blow up
-!
+
+   ! Set to zero things which make this routine blow up
    do k=1,msg
       do i=1,il2g
          rprd(i,k) = 0._r8
       end do
    end do
-!
-! interpolate the layer values of qst, hsat and gamma to
-! layer interfaces
-!
+
+   ! interpolate the layer values of qst, hsat and gamma to layer interfaces
    do k = 1, msg+1
       do i = 1,il2g
          hsthat(i,k) = hsat(i,k)
@@ -2374,10 +1750,8 @@ subroutine cldprp(lchnk   , &
          end if
       end do
    end do
-!
-! initialize cloud top to highest plume top.
-!jr changed hard-wired 4 to limcnv+1 (not to exceed pver)
-!
+
+   ! initialize cloud top to highest plume top.
    jt(:) = pver
    do i = 1,il2g
       jt(i) = max(lel(i),limcnv+1)
@@ -2386,10 +1760,9 @@ subroutine cldprp(lchnk   , &
       jlcl(i) = lel(i)
       hmin(i) = 1.E6_r8
    end do
-!
-! find the level of minimum hsat, where detrainment starts
-!
 
+   !----------------------------------------------------------------------------
+   ! find the level of minimum hsat, where detrainment starts
    do k = msg + 1,pver
       do i = 1,il2g
          if (hsat(i,k) <= hmin(i) .and. k >= jt(i) .and. k <= jb(i)) then
@@ -2401,14 +1774,12 @@ subroutine cldprp(lchnk   , &
    do i = 1,il2g
       j0(i) = min(j0(i),jb(i)-2)
       j0(i) = max(j0(i),jt(i)+2)
-!
-! Fix from Guang Zhang to address out of bounds array reference
-!
+      ! Fix from Guang Zhang to address out of bounds array reference
       j0(i) = min(j0(i),pver)
    end do
-!
-! Initialize certain arrays inside cloud
-!
+
+   !----------------------------------------------------------------------------
+   ! Initialize certain arrays inside cloud
    do k = msg + 1,pver
       do i = 1,il2g
          if (k >= jt(i) .and. k <= jb(i)) then
@@ -2417,11 +1788,9 @@ subroutine cldprp(lchnk   , &
          end if
       end do
    end do
-!
-! *********************************************************
-! compute taylor series for approximate eps(z) below
-! *********************************************************
-!
+
+   !----------------------------------------------------------------------------
+   ! compute taylor series for approximate eps(z) below
    do k = pver - 1,msg + 1,-1
       do i = 1,il2g
          if (k < jb(i) .and. k >= jt(i)) then
@@ -2435,9 +1804,8 @@ subroutine cldprp(lchnk   , &
          end if
       end do
    end do
-!
-! re-initialize hmin array for ensuing calculation.
-!
+
+   ! re-initialize hmin array for ensuing calculation.
    do i = 1,il2g
       hmin(i) = 1.E6_r8
    end do
@@ -2449,11 +1817,9 @@ subroutine cldprp(lchnk   , &
          end if
       end do
    end do
-!
-! *********************************************************
-! compute approximate eps(z) using above taylor series
-! *********************************************************
-!
+
+   !----------------------------------------------------------------------------
+   ! compute approximate eps(z) using above taylor series
    do k = msg + 2,pver
       do i = 1,il2g
          expnum(i) = 0._r8
@@ -2465,8 +1831,7 @@ subroutine cldprp(lchnk   , &
             expnum(i) = hmn(i,mx(i)) - (hsat(i,k-1)*(zf(i,k)-z(i,k)) + &
                         hsat(i,k)* (z(i,k-1)-zf(i,k)))/(z(i,k-1)-z(i,k))
          end if
-         if ((expdif(i) > 100._r8 .and. expnum(i) > 0._r8) .and. &
-	     k1(i,k) > expnum(i)*dz(i,k)) then
+         if ((expdif(i) > 100._r8 .and. expnum(i) > 0._r8) .and. k1(i,k) > expnum(i)*dz(i,k)) then
             ftemp(i) = expnum(i)/k1(i,k)
             f(i,k) = ftemp(i) + i2(i,k)/k1(i,k)*ftemp(i)**2 + &
                      (2._r8*i2(i,k)**2-k1(i,k)*i3(i,k))/k1(i,k)**2* &
@@ -2480,7 +1845,9 @@ subroutine cldprp(lchnk   , &
    end do
    do i = 1,il2g
       if (j0(i) < jb(i)) then
-         if (f(i,j0(i)) < 1.E-6_r8 .and. f(i,j0(i)+1) > f(i,j0(i))) j0(i) = j0(i) + 1
+         if (f(i,j0(i)) < 1.E-6_r8 .and. f(i,j0(i)+1) > f(i,j0(i))) then
+            j0(i) = j0(i) + 1
+         end if
       end if
    end do
    do k = msg + 2,pver
@@ -2494,9 +1861,8 @@ subroutine cldprp(lchnk   , &
       eps0(i) = f(i,j0(i))
       eps(i,jb(i)) = eps0(i)
    end do
-!
-! This is set to match the Rasch and Kristjansson paper
-!
+
+   ! This is set to match the Rasch and Kristjansson paper
    do k = pver,msg + 1,-1
       do i = 1,il2g
          if (k >= j0(i) .and. k <= jb(i)) then
@@ -2509,11 +1875,10 @@ subroutine cldprp(lchnk   , &
          if (k < j0(i) .and. k >= jt(i)) eps(i,k) = f(i,k)
       end do
    end do
-!
-! specify the updraft mass flux mu, entrainment eu, detrainment du
-! and moist static energy hu.
-! here and below mu, eu,du, md and ed are all normalized by mb
-!
+
+   !----------------------------------------------------------------------------
+   ! specify the updraft mass flux mu, entrainment eu, detrainment du and moist static energy hu.
+   ! here and below mu, eu,du, md and ed are all normalized by mb
    do i = 1,il2g
       if (eps0(i) > 0._r8) then
          mu(i,jb(i)) = 1._r8
@@ -2531,7 +1896,7 @@ subroutine cldprp(lchnk   , &
          end if
       end do
    end do
-!
+
    khighest = pverp
    klowest = 1
    do i=1,il2g
@@ -2554,11 +1919,9 @@ subroutine cldprp(lchnk   , &
          end if
       end do
    end do
-!
-!
-! reset cloud top index beginning from two layers above the
-! cloud base (i.e. if cloud is only one layer thick, top is not reset
-!
+
+   ! reset cloud top index beginning from two layers above the
+   ! cloud base (i.e. if cloud is only one layer thick, top is not reset
    do i=1,il2g
       doit(i) = .true.
    end do
@@ -2596,14 +1959,11 @@ subroutine cldprp(lchnk   , &
       end do
    end do
 
-! specify downdraft properties (no downdrafts if jd.ge.jb).
-! scale down downward mass flux profile so that net flux
-! (up-down) at cloud base in not negative.
-!
+   ! specify downdraft properties (no downdrafts if jd.ge.jb).
+   ! scale down downward mass flux profile so that net flux
+   ! (up-down) at cloud base in not negative.
    do i = 1,il2g
-!
-! in normal downdraft strength run alfa=0.2.  In test4 alfa=0.1
-!
+
       alfa(i) = alfa_scalar 
       jt(i) = min(jt(i),jb(i)-1)
       jd(i) = max(j0(i),jt(i)+1)
@@ -2641,9 +2001,8 @@ subroutine cldprp(lchnk   , &
          end if
       end do
    end do
-!
-! calculate updraft and downdraft properties.
-!
+
+   ! calculate updraft and downdraft properties.
    do k = msg + 2,pver
       do i = 1,il2g
          if ((k >= jd(i) .and. k <= jb(i)) .and. eps0(i) > 0._r8 .and. jd(i) < jb(i)) then
@@ -2652,7 +2011,7 @@ subroutine cldprp(lchnk   , &
          end if
       end do
    end do
-!
+
    do i = 1,il2g
       done(i) = .false.
    end do
@@ -2690,7 +2049,7 @@ subroutine cldprp(lchnk   , &
       end do
    end do
 
-! compute condensation in updraft
+   ! compute condensation in updraft
    do k = pver,msg + 2,-1
       do i = 1,il2g
          if (k >= jt(i) .and. k < jb(i) .and. eps0(i) > 0._r8) then
@@ -2702,13 +2061,13 @@ subroutine cldprp(lchnk   , &
       end do
    end do
 
-! compute condensed liquid, rain production rate
-! accumulate total precipitation (condensation - detrainment of liquid)
-! Note ql1 = ql(k) + rprd(k)*dz(k)/mu(k)
-! The differencing is somewhat strange (e.g. du(i,k)*ql(i,k+1)) but is
-! consistently applied.
-!    mu, ql are interface quantities
-!    cu, du, eu, rprd are midpoint quantites
+   ! compute condensed liquid, rain production rate
+   ! accumulate total precipitation (condensation - detrainment of liquid)
+   ! Note ql1 = ql(k) + rprd(k)*dz(k)/mu(k)
+   ! The differencing is somewhat strange (e.g. du(i,k)*ql(i,k+1)) but is
+   ! consistently applied.
+   !    mu, ql are interface quantities
+   !    cu, du, eu, rprd are midpoint quantites
    do k = pver,msg + 2,-1
       do i = 1,il2g
          rprd(i,k) = 0._r8
@@ -2725,12 +2084,12 @@ subroutine cldprp(lchnk   , &
          end if
       end do
    end do
-!
+
    do i = 1,il2g
       qd(i,jd(i)) = qds(i,jd(i))
       sd(i,jd(i)) = (hd(i,jd(i)) - rl*qd(i,jd(i)))/cp
    end do
-!
+
    do k = msg + 2,pver
       do i = 1,il2g
          if (k >= jd(i) .and. k < jb(i) .and. eps0(i) > 0._r8) then
@@ -2744,26 +2103,14 @@ subroutine cldprp(lchnk   , &
       end do
    end do
    do i = 1,il2g
-!*guang         totevp(i) = totevp(i) + md(i,jd(i))*q(i,jd(i)-1) -
       totevp(i) = totevp(i) + md(i,jd(i))*qd(i,jd(i)) - md(i,jb(i))*qd(i,jb(i))
    end do
-!!$   if (.true.) then
-   if (.false.) then
-      do i = 1,il2g
-         k = jb(i)
-         if (eps0(i) > 0._r8) then
-            evp(i,k) = -ed(i,k)*q(i,k) + (md(i,k)*qd(i,k))/dz(i,k)
-            evp(i,k) = max(evp(i,k),0._r8)
-            totevp(i) = totevp(i) - dz(i,k)*ed(i,k)*q(i,k)
-         end if
-      end do
-   endif
 
    do i = 1,il2g
       totpcp(i) = max(totpcp(i),0._r8)
       totevp(i) = max(totevp(i),0._r8)
    end do
-!
+
    do k = msg + 2,pver
       do i = 1,il2g
          if (totevp(i) > 0._r8 .and. totpcp(i) > 0._r8) then
@@ -2775,29 +2122,32 @@ subroutine cldprp(lchnk   , &
             ed(i,k) = 0._r8
             evp(i,k) = 0._r8
          end if
-! cmeg is the cloud water condensed - rain water evaporated
-! rprd is the cloud water converted to rain - (rain evaporated)
+         ! cmeg is the cloud water condensed - rain water evaporated
+         ! rprd is the cloud water converted to rain - (rain evaporated)
          cmeg(i,k) = cu(i,k) - evp(i,k)
          rprd(i,k) = rprd(i,k)-evp(i,k)
       end do
    end do
 
-! compute the net precipitation flux across interfaces
+   ! compute the net precipitation flux across interfaces
    pflx(:il2g,1) = 0._r8
    do k = 2,pverp
       do i = 1,il2g
          pflx(i,k) = pflx(i,k-1) + rprd(i,k-1)*dz(i,k-1)
       end do
    end do
-!
+
    do k = msg + 1,pver
       do i = 1,il2g
          mc(i,k) = mu(i,k) + md(i,k)
       end do
    end do
-!
+
    return
 end subroutine cldprp
+
+!-------------------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 subroutine closure(lchnk   , &
                    q       ,t       ,p       ,z       ,s       , &
@@ -2808,67 +2158,44 @@ subroutine closure(lchnk   , &
                    lcl     ,lel     ,jt      ,mx      ,il1g    , &
                    il2g    ,rd      ,grav    ,cp      ,rl      , &
                    msg     ,capelmt )
-!----------------------------------------------------------------------- 
-! 
-! Purpose: 
-! <Say what the routine does> 
-! 
-! Method: 
-! <Describe the algorithm(s) used in the routine.> 
-! <Also include any applicable external references.> 
-! 
-! Author: G. Zhang and collaborators. CCM contact:P. Rasch
-! This is contributed code not fully standardized by the CCM core group.
-!
-! this code is very much rougher than virtually anything else in the CCM
-! We expect to release cleaner code in a future release
-!
-! the documentation has been enhanced to the degree that we are able
-! 
-!-----------------------------------------------------------------------
-   use dycore,    only: dycore_is, get_resolution
-
+   !---------------------------------------------------------------------------- 
+   ! Author: G. Zhang and collaborators. CCM contact:P. Rasch
+   !----------------------------------------------------------------------------
    implicit none
-
-!
-!-----------------------------Arguments---------------------------------
-!
-   integer, intent(in) :: lchnk                 ! chunk identifier
-
-   real(r8), intent(inout) :: q(pcols,pver)        ! spec humidity
-   real(r8), intent(inout) :: t(pcols,pver)        ! temperature
-   real(r8), intent(inout) :: p(pcols,pver)        ! pressure (mb)
-   real(r8), intent(inout) :: mb(pcols)            ! cloud base mass flux
-   real(r8), intent(in) :: z(pcols,pver)        ! height (m)
-   real(r8), intent(in) :: s(pcols,pver)        ! normalized dry static energy
-   real(r8), intent(in) :: tp(pcols,pver)       ! parcel temp
-   real(r8), intent(in) :: qs(pcols,pver)       ! sat spec humidity
-   real(r8), intent(in) :: qu(pcols,pver)       ! updraft spec. humidity
-   real(r8), intent(in) :: su(pcols,pver)       ! normalized dry stat energy of updraft
-   real(r8), intent(in) :: mc(pcols,pver)       ! net convective mass flux
-   real(r8), intent(in) :: du(pcols,pver)       ! detrainment from updraft
-   real(r8), intent(in) :: mu(pcols,pver)       ! mass flux of updraft
-   real(r8), intent(in) :: md(pcols,pver)       ! mass flux of downdraft
-   real(r8), intent(in) :: qd(pcols,pver)       ! spec. humidity of downdraft
-   real(r8), intent(in) :: sd(pcols,pver)       ! dry static energy of downdraft
-   real(r8), intent(in) :: qhat(pcols,pver)     ! environment spec humidity at interfaces
-   real(r8), intent(in) :: shat(pcols,pver)     ! env. normalized dry static energy at intrfcs
-   real(r8), intent(in) :: dp(pcols,pver)       ! pressure thickness of layers
-   real(r8), intent(in) :: qstp(pcols,pver)     ! spec humidity of parcel
-   real(r8), intent(in) :: zf(pcols,pver+1)     ! height of interface levels
-   real(r8), intent(in) :: ql(pcols,pver)       ! liquid water mixing ratio
-
-   real(r8), intent(in) :: cape(pcols)          ! available pot. energy of column
-   real(r8), intent(in) :: tl(pcols)
-   real(r8), intent(in) :: dsubcld(pcols)       ! thickness of subcloud layer
-
-   integer, intent(in) :: lcl(pcols)        ! index of lcl
-   integer, intent(in) :: lel(pcols)        ! index of launch leve
-   integer, intent(in) :: jt(pcols)         ! top of updraft
-   integer, intent(in) :: mx(pcols)         ! base of updraft
-!
-!--------------------------Local variables------------------------------
-!
+   !----------------------------------------------------------------------------
+   ! Interface arguments
+   integer, intent(in   ) :: lchnk             ! chunk identifier
+   real(r8),intent(inout) :: q(pcols,pver)     ! spec humidity
+   real(r8),intent(inout) :: t(pcols,pver)     ! temperature
+   real(r8),intent(inout) :: p(pcols,pver)     ! pressure (mb)
+   real(r8),intent(inout) :: mb(pcols)         ! cloud base mass flux
+   real(r8),intent(in   ) :: z(pcols,pver)     ! height (m)
+   real(r8),intent(in   ) :: s(pcols,pver)     ! normalized dry static energy
+   real(r8),intent(in   ) :: tp(pcols,pver)    ! parcel temp
+   real(r8),intent(in   ) :: qs(pcols,pver)    ! sat spec humidity
+   real(r8),intent(in   ) :: qu(pcols,pver)    ! updraft spec. humidity
+   real(r8),intent(in   ) :: su(pcols,pver)    ! normalized dry stat energy of updraft
+   real(r8),intent(in   ) :: mc(pcols,pver)    ! net convective mass flux
+   real(r8),intent(in   ) :: du(pcols,pver)    ! detrainment from updraft
+   real(r8),intent(in   ) :: mu(pcols,pver)    ! mass flux of updraft
+   real(r8),intent(in   ) :: md(pcols,pver)    ! mass flux of downdraft
+   real(r8),intent(in   ) :: qd(pcols,pver)    ! spec. humidity of downdraft
+   real(r8),intent(in   ) :: sd(pcols,pver)    ! dry static energy of downdraft
+   real(r8),intent(in   ) :: qhat(pcols,pver)  ! environment spec humidity at interfaces
+   real(r8),intent(in   ) :: shat(pcols,pver)  ! env. normalized dry static energy at intrfcs
+   real(r8),intent(in   ) :: dp(pcols,pver)    ! pressure thickness of layers
+   real(r8),intent(in   ) :: qstp(pcols,pver)  ! spec humidity of parcel
+   real(r8),intent(in   ) :: zf(pcols,pver+1)  ! height of interface levels
+   real(r8),intent(in   ) :: ql(pcols,pver)    ! liquid water mixing ratio
+   real(r8),intent(in   ) :: cape(pcols)       ! available pot. energy of column
+   real(r8),intent(in   ) :: tl(pcols)         !
+   real(r8),intent(in   ) :: dsubcld(pcols)    ! thickness of subcloud layer
+   integer, intent(in   ) :: lcl(pcols)        ! index of lcl
+   integer, intent(in   ) :: lel(pcols)        ! index of launch leve
+   integer, intent(in   ) :: jt(pcols)         ! top of updraft
+   integer, intent(in   ) :: mx(pcols)         ! base of updraft
+   !----------------------------------------------------------------------------
+   ! Local variables
    real(r8) dtpdt(pcols,pver)
    real(r8) dqsdtp(pcols,pver)
    real(r8) dtmdt(pcols,pver)
@@ -2895,14 +2222,15 @@ subroutine closure(lchnk   , &
 
    real(r8) rd
    real(r8) rl
-! change of subcloud layer properties due to convection is
-! related to cumulus updrafts and downdrafts.
-! mc(z)=f(z)*mb, mub=betau*mb, mdb=betad*mb are used
-! to define betau, betad and f(z).
-! note that this implies all time derivatives are in effect
-! time derivatives per unit cloud-base mass flux, i.e. they
-! have units of 1/mb instead of 1/sec.
-!
+   
+   ! change of subcloud layer properties due to convection is
+   ! related to cumulus updrafts and downdrafts.
+   ! mc(z)=f(z)*mb, mub=betau*mb, mdb=betad*mb are used
+   ! to define betau, betad and f(z).
+   ! note that this implies all time derivatives are in effect
+   ! time derivatives per unit cloud-base mass flux, i.e. they
+   ! have units of 1/mb instead of 1/sec.
+
    do i = il1g,il2g
       mb(i) = 0._r8
       eb = p(i,mx(i))*q(i,mx(i))/ (eps1+q(i,mx(i)))
@@ -2914,16 +2242,15 @@ subroutine closure(lchnk   , &
       dtldt(i) = -2840._r8* (3.5_r8/t(i,mx(i))*dtbdt(i)-debdt/eb)/ &
                  (3.5_r8*log(t(i,mx(i)))-log(eb)-4.805_r8)**2
    end do
-!
-!   dtmdt and dqmdt are cumulus heating and drying.
-!
+
+   ! dtmdt and dqmdt are cumulus heating and drying.
    do k = msg + 1,pver
       do i = il1g,il2g
          dtmdt(i,k) = 0._r8
          dqmdt(i,k) = 0._r8
       end do
    end do
-!
+
    do k = msg + 1,pver - 1
       do i = il1g,il2g
          if (k == jt(i)) then
@@ -2934,18 +2261,13 @@ subroutine closure(lchnk   , &
          end if
       end do
    end do
-!
+
    beta = 0._r8
    do k = msg + 1,pver - 1
       do i = il1g,il2g
          if (k > jt(i) .and. k < mx(i)) then
             dtmdt(i,k) = (mc(i,k)* (shat(i,k)-s(i,k))+mc(i,k+1)* (s(i,k)-shat(i,k+1)))/ &
                          dp(i,k) - rl/cp*du(i,k)*(beta*ql(i,k)+ (1-beta)*ql(i,k+1))
-!          dqmdt(i,k)=(mc(i,k)*(qhat(i,k)-q(i,k))
-!     1                +mc(i,k+1)*(q(i,k)-qhat(i,k+1)))/dp(i,k)
-!     2                +du(i,k)*(qs(i,k)-q(i,k))
-!     3                +du(i,k)*(beta*ql(i,k)+(1-beta)*ql(i,k+1))
-
             dqmdt(i,k) = (mu(i,k+1)* (qu(i,k+1)-qhat(i,k+1)+cp/rl* (su(i,k+1)-s(i,k)))- &
                           mu(i,k)* (qu(i,k)-qhat(i,k)+cp/rl*(su(i,k)-s(i,k)))+md(i,k+1)* &
                          (qd(i,k+1)-qhat(i,k+1)+cp/rl*(sd(i,k+1)-s(i,k)))-md(i,k)* &
@@ -2954,38 +2276,32 @@ subroutine closure(lchnk   , &
          end if
       end do
    end do
-!
+
    do k = msg + 1,pver
       do i = il1g,il2g
          if (k >= lel(i) .and. k <= lcl(i)) then
             thetavp(i,k) = tp(i,k)* (1000._r8/p(i,k))** (rd/cp)*(1._r8+1.608_r8*qstp(i,k)-q(i,mx(i)))
             thetavm(i,k) = t(i,k)* (1000._r8/p(i,k))** (rd/cp)*(1._r8+0.608_r8*q(i,k))
             dqsdtp(i,k) = qstp(i,k)* (1._r8+qstp(i,k)/eps1)*eps1*rl/(rd*tp(i,k)**2)
-!
-! dtpdt is the parcel temperature change due to change of
-! subcloud layer properties during convection.
-!
+            ! dtpdt is the parcel temperature change due to change of
+            ! subcloud layer properties during convection.
             dtpdt(i,k) = tp(i,k)/ (1._r8+rl/cp* (dqsdtp(i,k)-qstp(i,k)/tp(i,k)))* &
                         (dtbdt(i)/t(i,mx(i))+rl/cp* (dqbdt(i)/tl(i)-q(i,mx(i))/ &
                          tl(i)**2*dtldt(i)))
-!
-! dboydt is the integrand of cape change.
-!
+            ! dboydt is the integrand of cape change.
             dboydt(i,k) = ((dtpdt(i,k)/tp(i,k)+1._r8/(1._r8+1.608_r8*qstp(i,k)-q(i,mx(i)))* &
                           (1.608_r8 * dqsdtp(i,k) * dtpdt(i,k) -dqbdt(i))) - (dtmdt(i,k)/t(i,k)+0.608_r8/ &
                           (1._r8+0.608_r8*q(i,k))*dqmdt(i,k)))*grav*thetavp(i,k)/thetavm(i,k)
          end if
       end do
    end do
-!
+
    do k = msg + 1,pver
       do i = il1g,il2g
          if (k > lcl(i) .and. k < mx(i)) then
             thetavp(i,k) = tp(i,k)* (1000._r8/p(i,k))** (rd/cp)*(1._r8+0.608_r8*q(i,mx(i)))
             thetavm(i,k) = t(i,k)* (1000._r8/p(i,k))** (rd/cp)*(1._r8+0.608_r8*q(i,k))
-!
-! dboydt is the integrand of cape change.
-!
+            ! dboydt is the integrand of cape change.
             dboydt(i,k) = (dtbdt(i)/t(i,mx(i))+0.608_r8/ (1._r8+0.608_r8*q(i,mx(i)))*dqbdt(i)- &
                           dtmdt(i,k)/t(i,k)-0.608_r8/ (1._r8+0.608_r8*q(i,k))*dqmdt(i,k))* &
                           grav*thetavp(i,k)/thetavm(i,k)
@@ -2993,9 +2309,7 @@ subroutine closure(lchnk   , &
       end do
    end do
 
-!
-! buoyant energy change is set to 2/3*excess cape per 3 hours
-!
+   ! buoyant energy change is set to 2/3*excess cape per 3 hours
    dadt(il1g:il2g)  = 0._r8
    kmin = minval(lel(il1g:il2g))
    kmax = maxval(mx(il1g:il2g)) - 1
@@ -3010,9 +2324,12 @@ subroutine closure(lchnk   , &
       dltaa = -1._r8* (cape(i)-capelmt)
       if (dadt(i) /= 0._r8) mb(i) = max(dltaa/tau/dadt(i),0._r8)
    end do
-!
+
    return
 end subroutine closure
+
+!-------------------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 subroutine q1q2_pjr(lchnk   , &
                     dqdt    ,dsdt    ,q       ,qs      ,qu      , &
@@ -3021,63 +2338,43 @@ subroutine q1q2_pjr(lchnk   , &
                     dsubcld ,jt      ,mx      ,il1g    ,il2g    , &
                     cp      ,rl      ,msg     ,          &
                     dl      ,evp     ,cu      )
-
-
    implicit none
-
-!----------------------------------------------------------------------- 
-! 
-! Purpose: 
-! <Say what the routine does> 
-! 
-! Method: 
-! <Describe the algorithm(s) used in the routine.> 
-! <Also include any applicable external references.> 
-! 
-! Author: phil rasch dec 19 1995
-! 
-!-----------------------------------------------------------------------
-
-
-   real(r8), intent(in) :: cp
-
-   integer, intent(in) :: lchnk             ! chunk identifier
-   integer, intent(in) :: il1g
-   integer, intent(in) :: il2g
-   integer, intent(in) :: msg
-
-   real(r8), intent(in) :: q(pcols,pver)
-   real(r8), intent(in) :: qs(pcols,pver)
-   real(r8), intent(in) :: qu(pcols,pver)
-   real(r8), intent(in) :: su(pcols,pver)
-   real(r8), intent(in) :: du(pcols,pver)
-   real(r8), intent(in) :: qhat(pcols,pver)
-   real(r8), intent(in) :: shat(pcols,pver)
-   real(r8), intent(in) :: dp(pcols,pver)
-   real(r8), intent(in) :: mu(pcols,pver)
-   real(r8), intent(in) :: md(pcols,pver)
-   real(r8), intent(in) :: sd(pcols,pver)
-   real(r8), intent(in) :: qd(pcols,pver)
-   real(r8), intent(in) :: ql(pcols,pver)
-   real(r8), intent(in) :: evp(pcols,pver)
-   real(r8), intent(in) :: cu(pcols,pver)
-   real(r8), intent(in) :: dsubcld(pcols)
-
+   !---------------------------------------------------------------------------- 
+   ! Author: Phil Rasch (Dec 19 1995)
+   !----------------------------------------------------------------------------
+   ! Interface Variables
+   real(r8),intent(in ) :: cp
+   integer, intent(in ) :: lchnk             ! chunk identifier
+   integer, intent(in ) :: il1g
+   integer, intent(in ) :: il2g
+   integer, intent(in ) :: msg
+   real(r8),intent(in ) :: q(pcols,pver)
+   real(r8),intent(in ) :: qs(pcols,pver)
+   real(r8),intent(in ) :: qu(pcols,pver)
+   real(r8),intent(in ) :: su(pcols,pver)
+   real(r8),intent(in ) :: du(pcols,pver)
+   real(r8),intent(in ) :: qhat(pcols,pver)
+   real(r8),intent(in ) :: shat(pcols,pver)
+   real(r8),intent(in ) :: dp(pcols,pver)
+   real(r8),intent(in ) :: mu(pcols,pver)
+   real(r8),intent(in ) :: md(pcols,pver)
+   real(r8),intent(in ) :: sd(pcols,pver)
+   real(r8),intent(in ) :: qd(pcols,pver)
+   real(r8),intent(in ) :: ql(pcols,pver)
+   real(r8),intent(in ) :: evp(pcols,pver)
+   real(r8),intent(in ) :: cu(pcols,pver)
+   real(r8),intent(in ) :: dsubcld(pcols)
    real(r8),intent(out) :: dqdt(pcols,pver),dsdt(pcols,pver)
    real(r8),intent(out) :: dl(pcols,pver)
-   integer kbm
-   integer ktm
+   !----------------------------------------------------------------------------
+   ! Local variables
+   integer kbm,ktm
    integer jt(pcols)
    integer mx(pcols)
-!
-! work fields:
-!
-   integer i
-   integer k
-
+   integer i,k
    real(r8) emc
    real(r8) rl
-!-------------------------------------------------------------------
+   !----------------------------------------------------------------------------
    do k = msg + 1,pver
       do i = il1g,il2g
          dsdt(i,k) = 0._r8
@@ -3085,9 +2382,8 @@ subroutine q1q2_pjr(lchnk   , &
          dl(i,k) = 0._r8
       end do
    end do
-!
-! find the highest level top and bottom levels of convection
-!
+
+   ! find the highest level top and bottom levels of convection
    ktm = pver
    kbm = pver
    do i = il1g, il2g
@@ -3097,8 +2393,8 @@ subroutine q1q2_pjr(lchnk   , &
 
    do k = ktm,pver-1
       do i = il1g,il2g
-         emc = -cu (i,k)               &         ! condensation in updraft
-               +evp(i,k)                         ! evaporating rain in downdraft
+         emc = -cu (i,k) &  ! condensation in updraft
+               +evp(i,k)    ! evaporating rain in downdraft
 
          dsdt(i,k) = -rl/cp*emc &
                      + (+mu(i,k+1)* (su(i,k+1)-shat(i,k+1)) &
@@ -3119,7 +2415,6 @@ subroutine q1q2_pjr(lchnk   , &
       end do
    end do
 
-!
 #ifdef CPRCRAY
 !DIR$ NOINTERCHANGE!
 #endif
@@ -3140,9 +2435,12 @@ subroutine q1q2_pjr(lchnk   , &
          end if
       end do
    end do
-!
+
    return
 end subroutine q1q2_pjr
+
+!-------------------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 subroutine buoyan_dilute(lchnk   ,ncol    , &
                   q       ,t       ,p       ,z       ,pf      , &
@@ -3150,61 +2448,49 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
                   pblt    ,lcl     ,lel     ,lon     ,mx      , &
                   rd      ,grav    ,cp      ,msg     , &
                   tpert   ,iclosure)
-!----------------------------------------------------------------------- 
-! 
-! Purpose: 
-! Calculates CAPE the lifting condensation level and the convective top
-! where buoyancy is first -ve.
-! 
-! Method: Calculates the parcel temperature based on a simple constant
-! entraining plume model. CAPE is integrated from buoyancy.
-! 09/09/04 - Simplest approach using an assumed entrainment rate for 
-!            testing (dmpdp). 
-! 08/04/05 - Swap to convert dmpdz to dmpdp  
-!
-! SCAM Logical Switches - DILUTE:RBN - Now Disabled 
-! ---------------------
-! switch(1) = .T. - Uses the dilute parcel calculation to obtain tendencies.
-! switch(2) = .T. - Includes entropy/q changes due to condensate loss and freezing.
-! switch(3) = .T. - Adds the PBL Tpert for the parcel temperature at all levels.
-! 
-! References:
-! Raymond and Blythe (1992) JAS 
-! 
-! Author:
-! Richard Neale - September 2004
-! 
-!-----------------------------------------------------------------------
+   !---------------------------------------------------------------------------- 
+   ! Purpose: Calculates CAPE the lifting condensation level and the convective top
+   ! where buoyancy is first -ve.
+   ! 
+   ! Method: Calculates the parcel temperature based on a simple constant
+   ! entraining plume model. CAPE is integrated from buoyancy.
+   ! 09/09/04 - Simplest approach using an assumed entrainment rate for 
+   !            testing (dmpdp). 
+   ! 08/04/05 - Swap to convert dmpdz to dmpdp  
+   !
+   ! SCAM Logical Switches - DILUTE:RBN - Now Disabled 
+   ! ---------------------
+   ! switch(1) = .T. - Uses the dilute parcel calculation to obtain tendencies.
+   ! switch(2) = .T. - Includes entropy/q changes due to condensate loss and freezing.
+   ! switch(3) = .T. - Adds the PBL Tpert for the parcel temperature at all levels.
+   ! 
+   ! References: Raymond and Blythe (1992) JAS 
+   ! Author: Richard Neale - September 2004
+   !----------------------------------------------------------------------------
    implicit none
-!-----------------------------------------------------------------------
-!
-! input arguments
-!
-   integer, intent(in) :: lchnk                 ! chunk identifier
-   integer, intent(in) :: ncol                  ! number of atmospheric columns
-
-   real(r8), intent(in) :: q(pcols,pver)        ! spec. humidity
-   real(r8), intent(in) :: t(pcols,pver)        ! temperature
-   real(r8), intent(in) :: p(pcols,pver)        ! pressure
-   real(r8), intent(in) :: z(pcols,pver)        ! height
-   real(r8), intent(in) :: pf(pcols,pver+1)     ! pressure at interfaces
-   real(r8), intent(in) :: pblt(pcols)          ! index of pbl depth
-   real(r8), intent(in) :: tpert(pcols)         ! perturbation temperature by pbl processes
-   logical, intent(in) :: iclosure              ! true for normal procedure, otherwise use dcapemx from 1st call
-!
-! output arguments
-!
-   real(r8), intent(out) :: tp(pcols,pver)       ! parcel temperature
-   real(r8), intent(out) :: qstp(pcols,pver)     ! saturation mixing ratio of parcel (only above lcl, just q below).
-   real(r8), intent(out) :: tl(pcols)            ! parcel temperature at lcl
-   real(r8), intent(out) :: cape(pcols)          ! convective aval. pot. energy.
+   !----------------------------------------------------------------------------
+   ! Interface arguments
+   integer, intent(in ) :: lchnk               ! chunk identifier
+   integer, intent(in ) :: ncol                ! number of atmospheric columns
+   real(r8),intent(in ) :: q(pcols,pver)       ! spec. humidity
+   real(r8),intent(in ) :: t(pcols,pver)       ! temperature
+   real(r8),intent(in ) :: p(pcols,pver)       ! pressure
+   real(r8),intent(in ) :: z(pcols,pver)       ! height
+   real(r8),intent(in ) :: pf(pcols,pver+1)    ! pressure at interfaces
+   real(r8),intent(in ) :: pblt(pcols)         ! index of pbl depth
+   real(r8),intent(in ) :: tpert(pcols)        ! perturbation temperature by pbl processes
+   logical, intent(in ) :: iclosure            ! true for normal procedure, otherwise use dcapemx from 1st call
+   real(r8),intent(out) :: tp(pcols,pver)      ! parcel temperature
+   real(r8),intent(out) :: qstp(pcols,pver)    ! saturation mixing ratio of parcel (only above lcl, just q below).
+   real(r8),intent(out) :: tl(pcols)           ! parcel temperature at lcl
+   real(r8),intent(out) :: cape(pcols)         ! convective aval. pot. energy.
+   !----------------------------------------------------------------------------
+   ! Local variables
    integer lcl(pcols)        !
    integer lel(pcols)        !
    integer lon(pcols)        ! level of onset of deep convection
    integer mx(pcols)         ! level of max moist static energy
-!
-!--------------------------Local Variables------------------------------
-!
+
    real(r8) capeten(pcols,num_cin)     ! provisional value of cape
    real(r8) tv(pcols,pver)       !
    real(r8) tpv(pcols,pver)      !
@@ -3223,7 +2509,7 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
    integer knt(pcols)
    integer lelten(pcols,num_cin)
 
-! DCAPE-ULL
+   ! DCAPE-ULL
    real(r8) pblt600(pcols)
 
    real(r8) cp
@@ -3241,16 +2527,15 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
 #ifdef PERGRO
    real(r8) rhd
 #endif
-!
-!-----------------------------------------------------------------------
-!
+
+   !----------------------------------------------------------------------------
    do n = 1,num_cin
       do i = 1,ncol
          lelten(i,n) = pver
          capeten(i,n) = 0._r8
       end do
    end do
-!
+
    do i = 1,ncol
       lon(i) = pver
       knt(i) = 0
@@ -3263,109 +2548,96 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
    tp(:ncol,:) = t(:ncol,:)
    qstp(:ncol,:) = q(:ncol,:)
 
-!DCAPE-ULL
+   !DCAPE-ULL
    if (trigdcape_ull .or. trig_ull_only) then
       pblt600(:ncol) = 1.0_r8
       do k = pver - 1,msg + 1,-1
-      do i = 1,ncol
-         if ((p(i,k).le.600._r8) .and. (p(i,k+1).gt.600._r8)) pblt600(i) = dble(k)
-      end do
+         do i = 1,ncol
+            if ((p(i,k).le.600._r8) .and. (p(i,k+1).gt.600._r8)) pblt600(i) = dble(k)
+         end do
       end do
    endif
 
-!!! RBN - Initialize tv and buoy for output.
-!!! tv=tv : tpv=tpv : qstp=q : buoy=0.
+   ! Initialize tv and buoy for output.
+   ! tv=tv : tpv=tpv : qstp=q : buoy=0.
    tv(:ncol,:) = t(:ncol,:) *(1._r8+1.608_r8*q(:ncol,:))/ (1._r8+q(:ncol,:))
    tpv(:ncol,:) = tv(:ncol,:)
    buoy(:ncol,:) = 0._r8
 
-!
-! set "launching" level(mx) to be at maximum moist static energy.
-! search for this level stops at planetary boundary layer top.
-!
+   ! set "launching" level(mx) to be at maximum moist static energy.
+   ! search for this level stops at planetary boundary layer top.
    bot_layer = pver - mx_bot_lyr_adj
 
-! DCAPE-ULL
-  if ((trigdcape_ull .or. trig_dcape_only ).and. (.not. iclosure)) then
-     mx(:ncol) = dcapemx(:ncol)
-  else
+   ! DCAPE-ULL
+   if ((trigdcape_ull .or. trig_dcape_only ).and. (.not. iclosure)) then
+      mx(:ncol) = dcapemx(:ncol)
+   else
 #ifdef PERGRO
-   do k = bot_layer,msg + 1,-1
-      do i = 1,ncol
-         hmn(i) = cp*t(i,k) + grav*z(i,k) + rl*q(i,k)
-!
-! Reset max moist static energy level when relative difference exceeds 1.e-4
-!
-         rhd = (hmn(i) - hmax(i))/(hmn(i) + hmax(i))
+      do k = bot_layer,msg + 1,-1
+         do i = 1,ncol
+            hmn(i) = cp*t(i,k) + grav*z(i,k) + rl*q(i,k)
+            ! Reset max moist static energy level when relative difference exceeds 1.e-4
+            rhd = (hmn(i) - hmax(i))/(hmn(i) + hmax(i))
 
-         !DCAPE-ULL
-         if (trigdcape_ull .or. trig_ull_only) then
-           if (k >= nint(pblt600(i)) .and. k <= lon(i) .and. rhd > -1.e-4_r8) then
-              hmax(i) = hmn(i)
-              mx(i) = k
-           end if
-         else
-           if (k >= nint(pblt(i)) .and. k <= lon(i) .and. rhd > -1.e-4_r8) then
-              hmax(i) = hmn(i)
-              mx(i) = k
-           end if
-         end if
-      end do
-   end do
-#else
-   do k = bot_layer,msg + 1,-1
-      do i = 1,ncol
-         hmn(i) = cp*t(i,k) + grav*z(i,k) + rl*q(i,k)
-
-         !DCAPE-ULL
-         if (trigdcape_ull .or. trig_ull_only) then
-            if (k >= nint(pblt600(i)) .and. k <= lon(i) .and. hmn(i) > hmax(i)) then
-               hmax(i) = hmn(i)
-               mx(i) = k
+            !DCAPE-ULL
+            if (trigdcape_ull .or. trig_ull_only) then
+              if (k >= nint(pblt600(i)) .and. k <= lon(i) .and. rhd > -1.e-4_r8) then
+                 hmax(i) = hmn(i)
+                 mx(i) = k
+              end if
+            else
+              if (k >= nint(pblt(i)) .and. k <= lon(i) .and. rhd > -1.e-4_r8) then
+                 hmax(i) = hmn(i)
+                 mx(i) = k
+              end if
             end if
-         else
-           if (k >= nint(pblt(i)) .and. k <= lon(i) .and. hmn(i) > hmax(i)) then
-              hmax(i) = hmn(i)
-              mx(i) = k
-           end if
-         end if
+         end do
       end do
-   end do
+#else
+      do k = bot_layer,msg + 1,-1
+         do i = 1,ncol
+            hmn(i) = cp*t(i,k) + grav*z(i,k) + rl*q(i,k)
+
+            !DCAPE-ULL
+            if (trigdcape_ull .or. trig_ull_only) then
+               if (k >= nint(pblt600(i)) .and. k <= lon(i) .and. hmn(i) > hmax(i)) then
+                  hmax(i) = hmn(i)
+                  mx(i) = k
+               end if
+            else
+              if (k >= nint(pblt(i)) .and. k <= lon(i) .and. hmn(i) > hmax(i)) then
+                 hmax(i) = hmn(i)
+                 mx(i) = k
+              end if
+            end if
+         end do
+      end do
 #endif
 
-  end if
+   end if
 
-! LCL dilute calculation - initialize to mx(i)
-! Determine lcl in parcel_dilute and get pl,tl after parcel_dilute
-! Original code actually sets LCL as level above wher condensate forms.
-! Therefore in parcel_dilute lcl(i) will be at first level where qsmix < qtmix.
-
+   ! LCL dilute calculation - initialize to mx(i)
+   ! Determine lcl in parcel_dilute and get pl,tl after parcel_dilute
+   ! Original code actually sets LCL as level above wher condensate forms.
+   ! Therefore in parcel_dilute lcl(i) will be at first level where qsmix < qtmix.
    do i = 1,ncol ! Initialise LCL variables.
       lcl(i) = mx(i)
       tl(i) = t(i,mx(i))
       pl(i) = p(i,mx(i))
    end do
 
-!
-! main buoyancy calculation.
-!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!!! DILUTE PLUME CALCULATION USING ENTRAINING PLUME !!!
-!!!   RBN 9/9/04   !!!
+   !----------------------------------------------------------------------------
+   ! main buoyancy calculation using dilute entraining plume
 
    call parcel_dilute(lchnk, ncol, msg, mx, p, t, q, tpert, tp, tpv, qstp, pl, tl, lcl)
 
-! If lcl is above the nominal level of non-divergence (600 mbs),
-! no deep convection is permitted (ensuing calculations
-! skipped and cape retains initialized value of zero).
-!
+   ! If lcl is above the nominal level of non-divergence (600 mbs),
+   ! no deep convection is permitted (ensuing calculations
+   ! skipped and cape retains initialized value of zero).
    do i = 1,ncol
       plge600(i) = pl(i).ge.600._r8 ! Just change to always allow buoy calculation.
    end do
 
-!
-! Main buoyancy calculation.
-!
    do k = pver,msg + 1,-1
       do i=1,ncol
          if (k <= mx(i) .and. plge600(i)) then   ! Define buoy from launch level to cloud top.
@@ -3379,15 +2651,7 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
       end do
    end do
 
-
-
-!-------------------------------------------------------------------------------
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-
-
-!
+   !----------------------------------------------------------------------------
    do k = msg + 2,pver
       do i = 1,ncol
          if (k < lcl(i) .and. plge600(i)) then
@@ -3398,9 +2662,8 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
          end if
       end do
    end do
-!
-! calculate convective available potential energy (cape).
-!
+
+   ! calculate convective available potential energy (cape).
    do n = 1,num_cin
       do k = msg + 1,pver
          do i = 1,ncol
@@ -3410,11 +2673,9 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
          end do
       end do
    end do
-!
-! find maximum cape from all possible tentative capes from
-! one sounding,
-! and use it as the final cape, april 26, 1995
-!
+
+   ! find maximum cape from all possible tentative capes from one sounding,
+   ! and use it as the final cape, april 26, 1995
    do n = 1,num_cin
       do i = 1,ncol
          if (capeten(i,n) > cape(i)) then
@@ -3423,467 +2684,416 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
          end if
       end do
    end do
-!
-! put lower bound on cape for diagnostic purposes.
-!
+
+   ! put lower bound on cape for diagnostic purposes.
    do i = 1,ncol
       cape(i) = max(cape(i), 0._r8)
    end do
-!
+
    return
 end subroutine buoyan_dilute
 
+!-------------------------------------------------------------------------------
+!-------------------------------------------------------------------------------
+
 subroutine parcel_dilute (lchnk, ncol, msg, klaunch, p, t, q, tpert, tp, tpv, qstp, pl, tl, lcl)
-! Routine  to determine 
-!   1. Tp   - Parcel temperature
-!   2. qstp - Saturated mixing ratio at the parcel temperature.
-
-!--------------------
-implicit none
-!--------------------
-
-integer, intent(in) :: lchnk
-integer, intent(in) :: ncol
-integer, intent(in) :: msg
-
-integer, intent(in), dimension(pcols) :: klaunch(pcols)
-
-real(r8), intent(in), dimension(pcols,pver) :: p
-real(r8), intent(in), dimension(pcols,pver) :: t
-real(r8), intent(in), dimension(pcols,pver) :: q
-real(r8), intent(in), dimension(pcols) :: tpert ! PBL temperature perturbation.
-
-real(r8), intent(inout), dimension(pcols,pver) :: tp    ! Parcel temp.
-real(r8), intent(inout), dimension(pcols,pver) :: qstp  ! Parcel water vapour (sat value above lcl).
-real(r8), intent(inout), dimension(pcols) :: tl         ! Actual temp of LCL.
-real(r8), intent(inout), dimension(pcols) :: pl          ! Actual pressure of LCL. 
-
-integer, intent(inout), dimension(pcols) :: lcl ! Lifting condesation level (first model level with saturation).
-
-real(r8), intent(out), dimension(pcols,pver) :: tpv   ! Define tpv within this routine.
-
-!--------------------
-
-! Have to be careful as s is also dry static energy.
-
-
-! If we are to retain the fact that CAM loops over grid-points in the internal
-! loop then we need to dimension sp,atp,mp,xsh2o with ncol.
-
-
-real(r8) tmix(pcols,pver)        ! Tempertaure of the entraining parcel.
-real(r8) qtmix(pcols,pver)       ! Total water of the entraining parcel.
-real(r8) qsmix(pcols,pver)       ! Saturated mixing ratio at the tmix.
-real(r8) smix(pcols,pver)        ! Entropy of the entraining parcel.
-real(r8) xsh2o(pcols,pver)       ! Precipitate lost from parcel.
-real(r8) ds_xsh2o(pcols,pver)    ! Entropy change due to loss of condensate.
-real(r8) ds_freeze(pcols,pver)   ! Entropy change sue to freezing of precip.
-
-real(r8) mp(pcols)    ! Parcel mass flux.
-real(r8) qtp(pcols)   ! Parcel total water.
-real(r8) sp(pcols)    ! Parcel entropy.
-
-real(r8) sp0(pcols)    ! Parcel launch entropy.
-real(r8) qtp0(pcols)   ! Parcel launch total water.
-real(r8) mp0(pcols)    ! Parcel launch relative mass flux.
-
-real(r8) lwmax      ! Maximum condesate that can be held in cloud before rainout.
-real(r8) dmpdp      ! Parcel fractional mass entrainment rate (/mb).
-!real(r8) dmpdpc     ! In cloud parcel mass entrainment rate (/mb).
-!real(r8) dmpdz      ! Parcel fractional mass entrainment rate (/m)
-real(r8) dpdz,dzdp  ! Hydrstatic relation and inverse of.
-real(r8) senv       ! Environmental entropy at each grid point.
-real(r8) qtenv      ! Environmental total water "   "   ".
-real(r8) penv       ! Environmental total pressure "   "   ".
-real(r8) tenv       ! Environmental total temperature "   "   ".
-real(r8) new_s      ! Hold value for entropy after condensation/freezing adjustments.
-real(r8) new_q      ! Hold value for total water after condensation/freezing adjustments.
-real(r8) dp         ! Layer thickness (center to center)
-real(r8) tfguess    ! First guess for entropy inversion - crucial for efficiency!
-real(r8) tscool     ! Super cooled temperature offset (in degC) (eg -35).
-
-real(r8) qxsk, qxskp1        ! LCL excess water (k, k+1)
-real(r8) dsdp, dqtdp, dqxsdp ! LCL s, qt, p gradients (k, k+1)
-real(r8) slcl,qtlcl,qslcl    ! LCL s, qt, qs values.
-
-integer rcall       ! Number of ientropy call for errors recording
-integer nit_lheat     ! Number of iterations for condensation/freezing loop.
-integer i,k,ii   ! Loop counters.
-
-!======================================================================
-!    SUMMARY
-!
-!  9/9/04 - Assumes parcel is initiated from level of maxh (klaunch)
-!           and entrains at each level with a specified entrainment rate.
-!
-! 15/9/04 - Calculates lcl(i) based on k where qsmix is first < qtmix.          
-!
-!======================================================================
-!
-! Set some values that may be changed frequently.
-!
-
-nit_lheat = 2 ! iterations for ds,dq changes from condensation freezing.
-
-
-!dmpdpc = 3.e-2_r8   ! In cloud entrainment rate (/mb).
-lwmax = 1.e-3_r8    ! Need to put formula in for this.
-tscool = 0.0_r8   ! Temp at which water loading freezes in the cloud.
-
-qtmix=0._r8
-smix=0._r8
-
-qtenv = 0._r8
-senv = 0._r8
-tenv = 0._r8
-penv = 0._r8
-
-qtp0 = 0._r8
-sp0  = 0._r8
-mp0 = 0._r8
-
-qtp = 0._r8
-sp = 0._r8
-mp = 0._r8
-
-new_q = 0._r8
-new_s = 0._r8
-
-! **** Begin loops ****
-
-do k = pver, msg+1, -1
-   do i=1,ncol 
-
-! Initialize parcel values at launch level.
-
-      if (k == klaunch(i)) then 
-         qtp0(i) = q(i,k)   ! Parcel launch total water (assuming subsaturated) - OK????.
-         sp0(i)  = entropy(t(i,k),p(i,k),qtp0(i))  ! Parcel launch entropy.
-         mp0(i)  = 1._r8       ! Parcel launch relative mass (i.e. 1 parcel stays 1 parcel for dmpdp=0, undilute). 
-         smix(i,k)  = sp0(i)
-         qtmix(i,k) = qtp0(i)
-         tfguess = t(i,k)
-         rcall = 1
-         call ientropy (rcall,i,lchnk,smix(i,k),p(i,k),qtmix(i,k),tmix(i,k),qsmix(i,k),tfguess)
-      end if
-
-! Entraining levels
-      
-      if (k < klaunch(i)) then 
-
-! Set environmental values for this level.                 
-         
-         dp = (p(i,k)-p(i,k+1)) ! In -ve mb as p decreasing with height - difference between center of layers.
-         qtenv = 0.5_r8*(q(i,k)+q(i,k+1))         ! Total water of environment.
-         tenv  = 0.5_r8*(t(i,k)+t(i,k+1)) 
-         penv  = 0.5_r8*(p(i,k)+p(i,k+1))
-
-         senv  = entropy(tenv,penv,qtenv)  ! Entropy of environment.   
-
-! Determine fractional entrainment rate /pa given value /m.
-
-         dpdz = -(penv*grav)/(rgas*tenv) ! in mb/m since  p in mb.
-         dzdp = 1._r8/dpdz                  ! in m/mb
-         dmpdp = dmpdz*dzdp              ! /mb Fractional entrainment
-
-! Sum entrainment to current level
-! entrains q,s out of intervening dp layers, in which linear variation is assumed
-! so really it entrains the mean of the 2 stored values.
-
-         sp(i)  = sp(i)  - dmpdp*dp*senv 
-         qtp(i) = qtp(i) - dmpdp*dp*qtenv 
-         mp(i)  = mp(i)  - dmpdp*dp
-            
-! Entrain s and qt to next level.
-
-         smix(i,k)  = (sp0(i)  +  sp(i)) / (mp0(i) + mp(i))
-         qtmix(i,k) = (qtp0(i) + qtp(i)) / (mp0(i) + mp(i))
-
-! Invert entropy from s and q to determine T and saturation-capped q of mixture.
-! t(i,k) used as a first guess so that it converges faster.
-
-         tfguess = tmix(i,k+1)
-         rcall = 2
-         call ientropy(rcall,i,lchnk,smix(i,k),p(i,k),qtmix(i,k),tmix(i,k),qsmix(i,k),tfguess)   
-
-!
-! Determine if this is lcl of this column if qsmix <= qtmix.
-! FIRST LEVEL where this happens on ascending.
-
-         if (qsmix(i,k) <= qtmix(i,k) .and. qsmix(i,k+1) > qtmix(i,k+1)) then
-            lcl(i) = k
-            qxsk   = qtmix(i,k) - qsmix(i,k)
-            qxskp1 = qtmix(i,k+1) - qsmix(i,k+1)
-            dqxsdp = (qxsk - qxskp1)/dp
-            pl(i)  = p(i,k+1) - qxskp1/dqxsdp    ! pressure level of actual lcl.
-            dsdp   = (smix(i,k)  - smix(i,k+1))/dp
-            dqtdp  = (qtmix(i,k) - qtmix(i,k+1))/dp
-            slcl   = smix(i,k+1)  +  dsdp* (pl(i)-p(i,k+1))  
-            qtlcl  = qtmix(i,k+1) +  dqtdp*(pl(i)-p(i,k+1))
-
-            tfguess = tmix(i,k)
-            rcall = 3
-            call ientropy (rcall,i,lchnk,slcl,pl(i),qtlcl,tl(i),qslcl,tfguess)
-
-!            write(iulog,*)' '
-!            write(iulog,*)' p',p(i,k+1),pl(i),p(i,lcl(i))
-!            write(iulog,*)' t',tmix(i,k+1),tl(i),tmix(i,lcl(i))
-!            write(iulog,*)' s',smix(i,k+1),slcl,smix(i,lcl(i))
-!            write(iulog,*)'qt',qtmix(i,k+1),qtlcl,qtmix(i,lcl(i))
-!            write(iulog,*)'qs',qsmix(i,k+1),qslcl,qsmix(i,lcl(i))
-
-         endif
-!         
-      end if !  k < klaunch
-
- 
-   end do ! Levels loop
-end do ! Columns loop
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!END ENTRAINMENT LOOP!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-!! Could stop now and test with this as it will provide some estimate of buoyancy
-!! without the effects of freezing/condensation taken into account for tmix.
-
-!! So we now have a profile of entropy and total water of the entraining parcel
-!! Varying with height from the launch level klaunch parcel=environment. To the 
-!! top allowed level for the existence of convection.
-
-!! Now we have to adjust these values such that the water held in vaopor is < or 
-!! = to qsmix. Therefore, we assume that the cloud holds a certain amount of
-!! condensate (lwmax) and the rest is rained out (xsh2o). This, obviously 
-!! provides latent heating to the mixed parcel and so this has to be added back 
-!! to it. But does this also increase qsmix as well? Also freezing processes
- 
-
-xsh2o = 0._r8
-ds_xsh2o = 0._r8
-ds_freeze = 0._r8
-
-!!!!!!!!!!!!!!!!!!!!!!!!!PRECIPITATION/FREEZING LOOP!!!!!!!!!!!!!!!!!!!!!!!!!!
-!! Iterate solution twice for accuracy
-
-
-
-do k = pver, msg+1, -1
-   do i=1,ncol    
-      
-! Initialize variables at k=klaunch
-      
-      if (k == klaunch(i)) then
-
-! Set parcel values at launch level assume no liquid water.            
-
-         tp(i,k)    = tmix(i,k)
-         qstp(i,k)  = q(i,k) 
-         tpv(i,k)   =  (tp(i,k) + tp_fac*tpert(i)) * (1._r8+1.608_r8*qstp(i,k)) / (1._r8+qstp(i,k))
-         
-      end if
-
-      if (k < klaunch(i)) then
-            
-! Initiaite loop if switch(2) = .T. - RBN:DILUTE - TAKEN OUT BUT COULD BE RETURNED LATER.
-
-! Iterate nit_lheat times for s,qt changes.
-
-         do ii=0,nit_lheat-1            
-
-! Rain (xsh2o) is excess condensate, bar LWMAX (Accumulated loss from qtmix).
-
-            xsh2o(i,k) = max (0._r8, qtmix(i,k) - qsmix(i,k) - lwmax)
-
-! Contribution to ds from precip loss of condensate (Accumulated change from smix).(-ve)                     
-                     
-            ds_xsh2o(i,k) = ds_xsh2o(i,k+1) - cpliq * log (tmix(i,k)/tfreez) * max(0._r8,(xsh2o(i,k)-xsh2o(i,k+1)))
-!
-! Entropy of freezing: latice times amount of water involved divided by T.
-!
- 
-            if (tmix(i,k) <= tfreez+tscool .and. ds_freeze(i,k+1) == 0._r8) then ! One off freezing of condensate. 
-               ds_freeze(i,k) = (latice/tmix(i,k)) * max(0._r8,qtmix(i,k)-qsmix(i,k)-xsh2o(i,k)) ! Gain of LH
-            end if
-            
-            if (tmix(i,k) <= tfreez+tscool .and. ds_freeze(i,k+1) /= 0._r8) then ! Continual freezing of additional condensate.
-               ds_freeze(i,k) = ds_freeze(i,k+1)+(latice/tmix(i,k)) * max(0._r8,(qsmix(i,k+1)-qsmix(i,k)))
-            end if
-            
-! Adjust entropy and accordingly to sum of ds (be careful of signs).
-
-            new_s = smix(i,k) + ds_xsh2o(i,k) + ds_freeze(i,k) 
-
-! Adjust liquid water and accordingly to xsh2o.
-
-            new_q = qtmix(i,k) - xsh2o(i,k)
-
-! Invert entropy to get updated Tmix and qsmix of parcel.
-
-            tfguess = tmix(i,k)
-            rcall =4
-            call ientropy (rcall,i,lchnk,new_s, p(i,k), new_q, tmix(i,k), qsmix(i,k), tfguess)
-            
-         end do  ! Iteration loop for freezing processes.
-
-! tp  - Parcel temp is temp of mixture.
-! tpv - Parcel v. temp should be density temp with new_q total water. 
-
-         tp(i,k)    = tmix(i,k)
-
-! tpv = tprho in the presence of condensate (i.e. when new_q > qsmix)
-
-         if (new_q > qsmix(i,k)) then  ! Super-saturated so condensate present - reduces buoyancy.
-            qstp(i,k) = qsmix(i,k)
-         else                          ! Just saturated/sub-saturated - no condensate virtual effects.
-            qstp(i,k) = new_q
+   !----------------------------------------------------------------------------
+   ! Routine  to determine 
+   !   1. Tp   - Parcel temperature
+   !   2. qstp - Saturated mixing ratio at the parcel temperature.
+   !----------------------------------------------------------------------------
+   implicit none
+   !----------------------------------------------------------------------------
+   ! Interface variables
+   integer, intent(in   ) :: lchnk
+   integer, intent(in   ) :: ncol
+   integer, intent(in   ) :: msg
+   integer, intent(in   ), dimension(pcols)      :: klaunch
+   real(r8),intent(in   ), dimension(pcols,pver) :: p
+   real(r8),intent(in   ), dimension(pcols,pver) :: t
+   real(r8),intent(in   ), dimension(pcols,pver) :: q
+   real(r8),intent(in   ), dimension(pcols)      :: tpert ! PBL temperature perturbation.
+   real(r8),intent(inout), dimension(pcols,pver) :: tp    ! Parcel temp.
+   real(r8),intent(inout), dimension(pcols,pver) :: qstp  ! Parcel water vapour (sat value above lcl).
+   real(r8),intent(inout), dimension(pcols)      :: tl    ! Actual temp of LCL.
+   real(r8),intent(inout), dimension(pcols)      :: pl    ! Actual pressure of LCL. 
+   integer, intent(inout), dimension(pcols)      :: lcl   ! Lifting condesation level (first model level with saturation).
+   real(r8),intent(  out), dimension(pcols,pver) :: tpv   ! Define tpv within this routine.
+
+   !----------------------------------------------------------------------------
+   ! Local variables
+
+   ! Have to be careful as s is also dry static energy.
+
+   ! If we are to retain the fact that CAM loops over grid-points in the internal
+   ! loop then we need to dimension sp,atp,mp,xsh2o with ncol.
+
+   real(r8) tmix(pcols,pver)        ! Tempertaure of the entraining parcel.
+   real(r8) qtmix(pcols,pver)       ! Total water of the entraining parcel.
+   real(r8) qsmix(pcols,pver)       ! Saturated mixing ratio at the tmix.
+   real(r8) smix(pcols,pver)        ! Entropy of the entraining parcel.
+   real(r8) xsh2o(pcols,pver)       ! Precipitate lost from parcel.
+   real(r8) ds_xsh2o(pcols,pver)    ! Entropy change due to loss of condensate.
+   real(r8) ds_freeze(pcols,pver)   ! Entropy change sue to freezing of precip.
+
+   real(r8) mp(pcols)    ! Parcel mass flux.
+   real(r8) qtp(pcols)   ! Parcel total water.
+   real(r8) sp(pcols)    ! Parcel entropy.
+
+   real(r8) sp0(pcols)    ! Parcel launch entropy.
+   real(r8) qtp0(pcols)   ! Parcel launch total water.
+   real(r8) mp0(pcols)    ! Parcel launch relative mass flux.
+
+   real(r8) lwmax      ! Maximum condesate that can be held in cloud before rainout.
+   real(r8) dmpdp      ! Parcel fractional mass entrainment rate (/mb).
+   real(r8) dpdz,dzdp  ! Hydrstatic relation and inverse of.
+   real(r8) senv       ! Environmental entropy at each grid point.
+   real(r8) qtenv      ! Environmental total water "   "   ".
+   real(r8) penv       ! Environmental total pressure "   "   ".
+   real(r8) tenv       ! Environmental total temperature "   "   ".
+   real(r8) new_s      ! Hold value for entropy after condensation/freezing adjustments.
+   real(r8) new_q      ! Hold value for total water after condensation/freezing adjustments.
+   real(r8) dp         ! Layer thickness (center to center)
+   real(r8) tfguess    ! First guess for entropy inversion - crucial for efficiency!
+   real(r8) tscool     ! Super cooled temperature offset (in degC) (eg -35).
+
+   real(r8) qxsk, qxskp1        ! LCL excess water (k, k+1)
+   real(r8) dsdp, dqtdp, dqxsdp ! LCL s, qt, p gradients (k, k+1)
+   real(r8) slcl,qtlcl,qslcl    ! LCL s, qt, qs values.
+
+   integer rcall       ! Number of ientropy call for errors recording
+   integer nit_lheat     ! Number of iterations for condensation/freezing loop.
+   integer i,k,ii   ! Loop counters.
+
+   !----------------------------------------------------------------------------
+   !    SUMMARY
+   !  9/9/04 - Assumes parcel is initiated from level of maxh (klaunch)
+   !           and entrains at each level with a specified entrainment rate.
+   ! 15/9/04 - Calculates lcl(i) based on k where qsmix is first < qtmix.          
+   !----------------------------------------------------------------------------
+
+   ! Set some values that may be changed frequently.
+
+   nit_lheat = 2 ! iterations for ds,dq changes from condensation freezing.
+
+   lwmax = 1.e-3_r8    ! Need to put formula in for this.
+   tscool = 0.0_r8   ! Temp at which water loading freezes in the cloud.
+
+   qtmix=0._r8
+   smix=0._r8
+
+   qtenv = 0._r8
+   senv = 0._r8
+   tenv = 0._r8
+   penv = 0._r8
+
+   qtp0 = 0._r8
+   sp0  = 0._r8
+   mp0 = 0._r8
+
+   qtp = 0._r8
+   sp = 0._r8
+   mp = 0._r8
+
+   new_q = 0._r8
+   new_s = 0._r8
+
+   !----------------------------------------------------------------------------
+   ! Begin loops
+   do k = pver, msg+1, -1
+      do i=1,ncol 
+
+         ! Initialize parcel values at launch level.
+         if (k == klaunch(i)) then 
+            qtp0(i) = q(i,k)   ! Parcel launch total water (assuming subsaturated) - OK????.
+            sp0(i)  = entropy(t(i,k),p(i,k),qtp0(i))  ! Parcel launch entropy.
+            mp0(i)  = 1._r8       ! Parcel launch relative mass (i.e. 1 parcel stays 1 parcel for dmpdp=0, undilute). 
+            smix(i,k)  = sp0(i)
+            qtmix(i,k) = qtp0(i)
+            tfguess = t(i,k)
+            rcall = 1
+            call ientropy (rcall,i,lchnk,smix(i,k),p(i,k),qtmix(i,k),tmix(i,k),qsmix(i,k),tfguess)
          end if
 
-         tpv(i,k) = (tp(i,k)+tp_fac*tpert(i))* (1._r8+1.608_r8*qstp(i,k)) / (1._r8+ new_q) 
+         ! Entraining levels
+         if (k < klaunch(i)) then 
 
-      end if ! k < klaunch
+            ! Set environmental values for this level.
+            dp = (p(i,k)-p(i,k+1)) ! In -ve mb as p decreasing with height - difference between center of layers.
+            qtenv = 0.5_r8*(q(i,k)+q(i,k+1))         ! Total water of environment.
+            tenv  = 0.5_r8*(t(i,k)+t(i,k+1)) 
+            penv  = 0.5_r8*(p(i,k)+p(i,k+1))
+
+            senv  = entropy(tenv,penv,qtenv)  ! Entropy of environment.   
+
+            ! Determine fractional entrainment rate /pa given value /m.
+            dpdz = -(penv*grav)/(rgas*tenv) ! in mb/m since  p in mb.
+            dzdp = 1._r8/dpdz                  ! in m/mb
+            dmpdp = dmpdz*dzdp              ! /mb Fractional entrainment
+
+            ! Sum entrainment to current level
+            ! entrains q,s out of intervening dp layers, in which linear variation is assumed
+            ! so really it entrains the mean of the 2 stored values.
+            sp(i)  = sp(i)  - dmpdp*dp*senv 
+            qtp(i) = qtp(i) - dmpdp*dp*qtenv 
+            mp(i)  = mp(i)  - dmpdp*dp
+               
+            ! Entrain s and qt to next level.
+            smix(i,k)  = (sp0(i)  +  sp(i)) / (mp0(i) + mp(i))
+            qtmix(i,k) = (qtp0(i) + qtp(i)) / (mp0(i) + mp(i))
+
+            ! Invert entropy from s and q to determine T and saturation-capped q of mixture.
+            ! t(i,k) used as a first guess so that it converges faster.
+            tfguess = tmix(i,k+1)
+            rcall = 2
+            call ientropy(rcall,i,lchnk,smix(i,k),p(i,k),qtmix(i,k),tmix(i,k),qsmix(i,k),tfguess)   
+
+            ! Determine if this is lcl of this column if qsmix <= qtmix.
+            ! FIRST LEVEL where this happens on ascending.
+            if (qsmix(i,k) <= qtmix(i,k) .and. qsmix(i,k+1) > qtmix(i,k+1)) then
+               lcl(i) = k
+               qxsk   = qtmix(i,k) - qsmix(i,k)
+               qxskp1 = qtmix(i,k+1) - qsmix(i,k+1)
+               dqxsdp = (qxsk - qxskp1)/dp
+               pl(i)  = p(i,k+1) - qxskp1/dqxsdp    ! pressure level of actual lcl.
+               dsdp   = (smix(i,k)  - smix(i,k+1))/dp
+               dqtdp  = (qtmix(i,k) - qtmix(i,k+1))/dp
+               slcl   = smix(i,k+1)  +  dsdp* (pl(i)-p(i,k+1))  
+               qtlcl  = qtmix(i,k+1) +  dqtdp*(pl(i)-p(i,k+1))
+
+               tfguess = tmix(i,k)
+               rcall = 3
+               call ientropy (rcall,i,lchnk,slcl,pl(i),qtlcl,tl(i),qslcl,tfguess)
+
+            endif
+
+         end if !  k < klaunch
+
+    
+      end do ! Levels loop
+   end do ! Columns loop
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!END ENTRAINMENT LOOP!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   !! Could stop now and test with this as it will provide some estimate of buoyancy
+   !! without the effects of freezing/condensation taken into account for tmix.
+
+   !! So we now have a profile of entropy and total water of the entraining parcel
+   !! Varying with height from the launch level klaunch parcel=environment. To the 
+   !! top allowed level for the existence of convection.
+
+   !! Now we have to adjust these values such that the water held in vaopor is < or 
+   !! = to qsmix. Therefore, we assume that the cloud holds a certain amount of
+   !! condensate (lwmax) and the rest is rained out (xsh2o). This, obviously 
+   !! provides latent heating to the mixed parcel and so this has to be added back 
+   !! to it. But does this also increase qsmix as well? Also freezing processes
+    
+   xsh2o = 0._r8
+   ds_xsh2o = 0._r8
+   ds_freeze = 0._r8
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!PRECIPITATION/FREEZING LOOP!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! Iterate solution twice for accuracy
+
+   do k = pver, msg+1, -1
+      do i=1,ncol    
+         
+         ! Initialize variables at k=klaunch
+         if (k == klaunch(i)) then
+            ! Set parcel values at launch level assume no liquid water.            
+            tp(i,k)    = tmix(i,k)
+            qstp(i,k)  = q(i,k) 
+            tpv(i,k)   =  (tp(i,k) + tp_fac*tpert(i)) * (1._r8+1.608_r8*qstp(i,k)) / (1._r8+qstp(i,k))
+         end if
+
+         if (k < klaunch(i)) then
+               
+            ! Initiaite loop if switch(2) = .T. - RBN:DILUTE - TAKEN OUT BUT COULD BE RETURNED LATER.
+            ! Iterate nit_lheat times for s,qt changes.
+            do ii=0,nit_lheat-1            
+               ! Rain (xsh2o) is excess condensate, bar LWMAX (Accumulated loss from qtmix).
+               xsh2o(i,k) = max (0._r8, qtmix(i,k) - qsmix(i,k) - lwmax)
+               ! Contribution to ds from precip loss of condensate (Accumulated change from smix).(-ve)                              
+               ds_xsh2o(i,k) = ds_xsh2o(i,k+1) - cpliq * log (tmix(i,k)/tfreez) * max(0._r8,(xsh2o(i,k)-xsh2o(i,k+1)))
+               ! Entropy of freezing: latice times amount of water involved divided by T.
+               if (tmix(i,k) <= tfreez+tscool .and. ds_freeze(i,k+1) == 0._r8) then ! One off freezing of condensate. 
+                  ds_freeze(i,k) = (latice/tmix(i,k)) * max(0._r8,qtmix(i,k)-qsmix(i,k)-xsh2o(i,k)) ! Gain of LH
+               end if
+               if (tmix(i,k) <= tfreez+tscool .and. ds_freeze(i,k+1) /= 0._r8) then ! Continual freezing of additional condensate.
+                  ds_freeze(i,k) = ds_freeze(i,k+1)+(latice/tmix(i,k)) * max(0._r8,(qsmix(i,k+1)-qsmix(i,k)))
+               end if
+               ! Adjust entropy and accordingly to sum of ds (be careful of signs).
+               new_s = smix(i,k) + ds_xsh2o(i,k) + ds_freeze(i,k) 
+               ! Adjust liquid water and accordingly to xsh2o.
+               new_q = qtmix(i,k) - xsh2o(i,k)
+               ! Invert entropy to get updated Tmix and qsmix of parcel.
+               tfguess = tmix(i,k)
+               rcall =4
+               call ientropy (rcall,i,lchnk,new_s, p(i,k), new_q, tmix(i,k), qsmix(i,k), tfguess)
+            end do  ! Iteration loop for freezing processes.
+
+            ! tp  - Parcel temp is temp of mixture.
+            ! tpv - Parcel v. temp should be density temp with new_q total water. 
+            tp(i,k)    = tmix(i,k)
+
+            ! tpv = tprho in the presence of condensate (i.e. when new_q > qsmix)
+            if (new_q > qsmix(i,k)) then  ! Super-saturated so condensate present - reduces buoyancy.
+               qstp(i,k) = qsmix(i,k)
+            else                          ! Just saturated/sub-saturated - no condensate virtual effects.
+               qstp(i,k) = new_q
+            end if
+
+            tpv(i,k) = (tp(i,k)+tp_fac*tpert(i))* (1._r8+1.608_r8*qstp(i,k)) / (1._r8+ new_q) 
+
+         end if ! k < klaunch
+         
+      end do ! Loop for columns
       
-   end do ! Loop for columns
-   
-end do  ! Loop for vertical levels.
+   end do  ! Loop for vertical levels.
 
-
-return
+   return
 end subroutine parcel_dilute
 
-!-----------------------------------------------------------------------------------------
+!-------------------------------------------------------------------------------
+!-------------------------------------------------------------------------------
+
 real(r8) function entropy(TK,p,qtot)
-!-----------------------------------------------------------------------------------------
-!
-! TK(K),p(mb),qtot(kg/kg)
-! from Raymond and Blyth 1992
-!
-     real(r8), intent(in) :: p,qtot,TK
-     real(r8) :: qv,qst,e,est,L
-     real(r8), parameter :: pref = 1000._r8
+   !----------------------------------------------------------------------------
+   ! TK(K),p(mb),qtot(kg/kg)
+   ! from Raymond and Blyth 1992
+   !----------------------------------------------------------------------------
+   real(r8), intent(in) :: p,qtot,TK
+   real(r8) :: qv,qst,e,est,L
+   real(r8), parameter :: pref = 1000._r8
 
-L = rl - (cpliq - cpwv)*(TK-tfreez)         ! T IN CENTIGRADE
+   L = rl - (cpliq - cpwv)*(TK-tfreez)         ! T IN CENTIGRADE
 
-call qsat_hPa(TK, p, est, qst)
+   call qsat_hPa(TK, p, est, qst)
 
-qv = min(qtot,qst)                         ! Partition qtot into vapor part only.
-e = qv*p / (eps1 +qv)
+   qv = min(qtot,qst)                         ! Partition qtot into vapor part only.
+   e = qv*p / (eps1 +qv)
 
-entropy = (cpres + qtot*cpliq)*log( TK/tfreez) - rgas*log( (p-e)/pref ) + &
-        L*qv/TK - qv*rh2o*log(qv/qst)
+   entropy = (cpres + qtot*cpliq)*log( TK/tfreez) - rgas*log( (p-e)/pref ) + &
+           L*qv/TK - qv*rh2o*log(qv/qst)
 
-end FUNCTION entropy
+end function entropy
 
-!
-!-----------------------------------------------------------------------------------------
-SUBROUTINE ientropy (rcall,icol,lchnk,s,p,qt,T,qst,Tfg)
-!-----------------------------------------------------------------------------------------
-!
-! p(mb), Tfg/T(K), qt/qv(kg/kg), s(J/kg). 
-! Inverts entropy, pressure and total water qt 
-! for T and saturated vapor mixing ratio
-! 
+!-------------------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
-  use phys_grid, only: get_rlon_p, get_rlat_p
+subroutine ientropy (rcall,icol,lchnk,s,p,qt,T,qst,Tfg)
+   !----------------------------------------------------------------------------
+   ! p(mb), Tfg/T(K), qt/qv(kg/kg), s(J/kg). 
+   ! Inverts entropy, pressure and total water qt 
+   ! for T and saturated vapor mixing ratio
+   !----------------------------------------------------------------------------
 
-  integer, intent(in) :: icol, lchnk, rcall
-  real(r8), intent(in)  :: s, p, Tfg, qt
-  real(r8), intent(out) :: qst, T
-  real(r8) :: est, this_lat,this_lon
-  real(r8) :: a,b,c,d,ebr,fa,fb,fc,pbr,qbr,rbr,sbr,tol1,xm,tol
-  integer :: i
+   use phys_grid, only: get_rlon_p, get_rlat_p
 
-  logical :: converged
+   integer, intent(in) :: icol, lchnk, rcall
+   real(r8), intent(in)  :: s, p, Tfg, qt
+   real(r8), intent(out) :: qst, T
+   real(r8) :: est, this_lat,this_lon
+   real(r8) :: a,b,c,d,ebr,fa,fb,fc,pbr,qbr,rbr,sbr,tol1,xm,tol
+   integer :: i
 
-  ! Max number of iteration loops.
-  integer, parameter :: LOOPMAX = 100
-  real(r8), parameter :: EPS = 3.e-8_r8
+   logical :: converged
 
-  converged = .false.
+   ! Max number of iteration loops.
+   integer, parameter :: LOOPMAX = 100
+   real(r8), parameter :: EPS = 3.e-8_r8
 
-  ! Invert the entropy equation -- use Brent's method
-  ! Brent, R. P. Ch. 3-4 in Algorithms for Minimization Without Derivatives. Englewood Cliffs, NJ: Prentice-Hall, 1973.
+   converged = .false.
 
-  T = Tfg                  ! Better first guess based on Tprofile from conv.
+   ! Invert the entropy equation -- use Brent's method
+   ! Brent, R. P. Ch. 3-4 in Algorithms for Minimization Without Derivatives. 
+   ! Englewood Cliffs, NJ: Prentice-Hall, 1973.
 
-  a = Tfg-10			!low bracket
-  b = Tfg+10			!high bracket
+   T = Tfg     ! Better first guess based on Tprofile from conv.
+   a = Tfg-10  ! low bracket
+   b = Tfg+10  ! high bracket
 
-  fa = entropy(a, p, qt) - s
-  fb = entropy(b, p, qt) - s
+   fa = entropy(a, p, qt) - s
+   fb = entropy(b, p, qt) - s
 
-  c=b
-  fc=fb
-  tol=0.001_r8
+   c=b
+   fc=fb
+   tol=0.001_r8
 
-  converge: do i=0, LOOPMAX
-     if ((fb > 0.0_r8 .and. fc > 0.0_r8) .or. &
+   converge: do i=0, LOOPMAX
+      if ((fb > 0.0_r8 .and. fc > 0.0_r8) .or. &
           (fb < 0.0_r8 .and. fc < 0.0_r8)) then
-        c=a
-        fc=fa
-        d=b-a
-        ebr=d
-     end if
-     if (abs(fc) < abs(fb)) then
-        a=b
-        b=c
-        c=a
-        fa=fb
-        fb=fc
-        fc=fa
-     end if
+         c=a
+         fc=fa
+         d=b-a
+         ebr=d
+      end if
+      if (abs(fc) < abs(fb)) then
+         a=b
+         b=c
+         c=a
+         fa=fb
+         fb=fc
+         fc=fa
+      end if
 
-     tol1=2.0_r8*EPS*abs(b)+0.5_r8*tol
-     xm=0.5_r8*(c-b)
-     converged = (abs(xm) <= tol1 .or. fb == 0.0_r8)
-     if (converged) exit converge
+      tol1=2.0_r8*EPS*abs(b)+0.5_r8*tol
+      xm=0.5_r8*(c-b)
+      converged = (abs(xm) <= tol1 .or. fb == 0.0_r8)
+      if (converged) exit converge
 
-     if (abs(ebr) >= tol1 .and. abs(fa) > abs(fb)) then
-        sbr=fb/fa
-        if (a == c) then
-           pbr=2.0_r8*xm*sbr
-           qbr=1.0_r8-sbr
-        else
-           qbr=fa/fc
-           rbr=fb/fc
-           pbr=sbr*(2.0_r8*xm*qbr*(qbr-rbr)-(b-a)*(rbr-1.0_r8))
-           qbr=(qbr-1.0_r8)*(rbr-1.0_r8)*(sbr-1.0_r8)
-        end if
-        if (pbr > 0.0_r8) qbr=-qbr
-        pbr=abs(pbr)
-        if (2.0_r8*pbr  <  min(3.0_r8*xm*qbr-abs(tol1*qbr),abs(ebr*qbr))) then
-           ebr=d
-           d=pbr/qbr
-        else
-           d=xm
-           ebr=d
-        end if
-     else
-        d=xm
-        ebr=d
-     end if
-     a=b
-     fa=fb
-     b=b+merge(d,sign(tol1,xm), abs(d) > tol1 )
+      if (abs(ebr) >= tol1 .and. abs(fa) > abs(fb)) then
+         sbr=fb/fa
+         if (a == c) then
+            pbr=2.0_r8*xm*sbr
+            qbr=1.0_r8-sbr
+         else
+            qbr=fa/fc
+            rbr=fb/fc
+            pbr=sbr*(2.0_r8*xm*qbr*(qbr-rbr)-(b-a)*(rbr-1.0_r8))
+            qbr=(qbr-1.0_r8)*(rbr-1.0_r8)*(sbr-1.0_r8)
+         end if
+         if (pbr > 0.0_r8) qbr=-qbr
+         pbr=abs(pbr)
+         if (2.0_r8*pbr  <  min(3.0_r8*xm*qbr-abs(tol1*qbr),abs(ebr*qbr))) then
+            ebr=d
+            d=pbr/qbr
+         else
+            d=xm
+            ebr=d
+         end if
+      else
+         d=xm
+         ebr=d
+      end if
+      a=b
+      fa=fb
+      b=b+merge(d,sign(tol1,xm), abs(d) > tol1 )
 
-     fb = entropy(b, p, qt) - s
+      fb = entropy(b, p, qt) - s
 
   end do converge
 
   T = b
   call qsat_hPa(T, p, est, qst)
 
-  if (.not. converged) then
-     this_lat = get_rlat_p(lchnk, icol)*57.296_r8
-     this_lon = get_rlon_p(lchnk, icol)*57.296_r8
-     write(iulog,*) '*** ZM_CONV: IENTROPY: Failed and about to exit, info follows ****'
-     write(iulog,100) 'ZM_CONV: IENTROPY. Details: call#,lchnk,icol= ',rcall,lchnk,icol, &
-          ' lat: ',this_lat,' lon: ',this_lon, &
-          ' P(mb)= ', p, ' Tfg(K)= ', Tfg, ' qt(g/kg) = ', 1000._r8*qt, &
-          ' qst(g/kg) = ', 1000._r8*qst,', s(J/kg) = ',s
-     call endrun('**** ZM_CONV IENTROPY: Tmix did not converge ****')
-  end if
+   if (.not. converged) then
+      this_lat = get_rlat_p(lchnk, icol)*57.296_r8
+      this_lon = get_rlon_p(lchnk, icol)*57.296_r8
+      write(iulog,*) '*** ZM_CONV: IENTROPY: Failed and about to exit, info follows ****'
+      write(iulog,100) 'ZM_CONV: IENTROPY. Details: call#,lchnk,icol= ',rcall,lchnk,icol, &
+           ' lat: ',this_lat,' lon: ',this_lon, &
+           ' P(mb)= ', p, ' Tfg(K)= ', Tfg, ' qt(g/kg) = ', 1000._r8*qt, &
+           ' qst(g/kg) = ', 1000._r8*qst,', s(J/kg) = ',s
+      call endrun('**** ZM_CONV IENTROPY: Tmix did not converge ****')
+   end if
 
 100 format (A,I1,I4,I4,7(A,F6.2))
 
-end SUBROUTINE ientropy
+end subroutine ientropy
+
+!-------------------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 ! Wrapper for qsat_water that does translation between Pa and hPa
 ! qsat_water uses Pa internally, so get it right, need to pass in Pa.
@@ -3904,5 +3114,8 @@ elemental subroutine qsat_hPa(t, p, es, qm)
   es = es*0.01_r8
 
 end subroutine qsat_hPa
+
+!-------------------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 end module zm_conv

--- a/components/eam/src/physics/cam/zm_conv_intr.F90
+++ b/components/eam/src/physics/cam/zm_conv_intr.F90
@@ -1,16 +1,12 @@
-
-
-
 module zm_conv_intr
-!---------------------------------------------------------------------------------
-! Purpose:
-!
-! CAM interface to the Zhang-McFarlane deep convection scheme
-!
-! Author: D.B. Coleman
-! January 2010 modified by J. Kay to add COSP simulator fields to physics buffer
-! July 2015 B. Singh Added code for unified convective trasport
-!---------------------------------------------------------------------------------
+   !----------------------------------------------------------------------------
+   ! 
+   ! Interface to the Zhang-McFarlane deep convection scheme
+   !
+   ! Author: D.B. Coleman
+   ! January 2010 modified by J. Kay to add COSP simulator fields to pbuf
+   ! July 2015 B. Singh Added code for unified convective trasport
+   !----------------------------------------------------------------------------
    use shr_kind_mod, only: r8=>shr_kind_r8
    use physconst,    only: cpair
    use ppgrid,       only: pver, pcols, pverp, begchunk, endchunk
@@ -24,7 +20,6 @@ module zm_conv_intr
    save
 
    ! Public methods
-
    public ::&
       zm_conv_register,           &! register fields in physics buffer
       zm_conv_init,               &! initialize donner_deep module
@@ -40,11 +35,11 @@ module zm_conv_intr
       prec_dp_idx,   &
       snow_dp_idx
 
-! DCAPE-ULL
+   ! DCAPE-ULL
    integer :: t_star_idx       !t_star index in physics buffer
    integer :: q_star_idx       !q_star index in physics buffer
 
-!  indices for fields in the physics buffer
+   !  indices for fields in the physics buffer
    integer  ::    cld_idx          = 0    
    integer  ::    icwmrdp_idx      = 0     
    integer  ::    rprddp_idx       = 0    
@@ -54,42 +49,38 @@ module zm_conv_intr
    logical  ::    convproc_do_gas 
    logical  ::    clim_modal_aero
 
-!=========================================================================================
 contains
-!=========================================================================================
+
+!-------------------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 subroutine zm_conv_register
+   !----------------------------------------------------------------------------
+   ! Purpose: register fields with the physics buffer
+   !----------------------------------------------------------------------------
+   use physics_buffer, only : pbuf_add_field, dtype_r8
+   implicit none
 
-!----------------------------------------
-! Purpose: register fields with the physics buffer
-!----------------------------------------
+   integer idx
 
-  use physics_buffer, only : pbuf_add_field, dtype_r8
-
-  implicit none
-
-  integer idx
-
-! Flux of precipitation from deep convection (kg/m2/s)
+   ! Flux of precipitation from deep convection (kg/m2/s)
    call pbuf_add_field('DP_FLXPRC','global',dtype_r8,(/pcols,pverp/),dp_flxprc_idx) 
 
-! Flux of snow from deep convection (kg/m2/s) 
+   ! Flux of snow from deep convection (kg/m2/s) 
    call pbuf_add_field('DP_FLXSNW','global',dtype_r8,(/pcols,pverp/),dp_flxsnw_idx) 
 
-! deep gbm cloud liquid water (kg/kg)
+   ! deep gbm cloud liquid water (kg/kg)
    call pbuf_add_field('DP_CLDLIQ','global',dtype_r8,(/pcols,pver/), dp_cldliq_idx)  
 
-! deep gbm cloud liquid water (kg/kg)    
+   ! deep gbm cloud liquid water (kg/kg)    
    call pbuf_add_field('DP_CLDICE','global',dtype_r8,(/pcols,pver/), dp_cldice_idx)  
 
-
-! DCAPE-UPL
-
+   ! DCAPE-UPL
    if (trigdcape_ull .or. trig_dcape_only) then
-    ! temperature from physics in n-1 time step
-    call pbuf_add_field('T_STAR','global',dtype_r8,(/pcols,pver/), t_star_idx)
-    ! moisturetendency from physics in n-1 time step 
-    call pbuf_add_field('Q_STAR','global',dtype_r8,(/pcols,pver/), q_star_idx)
+      ! temperature from physics in n-1 time step
+      call pbuf_add_field('T_STAR','global',dtype_r8,(/pcols,pver/), t_star_idx)
+      ! moisturetendency from physics in n-1 time step 
+      call pbuf_add_field('Q_STAR','global',dtype_r8,(/pcols,pver/), q_star_idx)
    endif
 
 end subroutine zm_conv_register
@@ -97,206 +88,171 @@ end subroutine zm_conv_register
 !=========================================================================================
 
 subroutine zm_conv_init(pref_edge)
+   !----------------------------------------------------------------------------
+   ! Purpose: declare output fields, initialize variables needed by convection
+   !----------------------------------------------------------------------------
+   use cam_history,     only: outfld, addfld, horiz_only, add_default
+   use ppgrid,          only: pcols, pver
+   use zm_conv,         only: zm_convi
+   use pmgrid,          only: plev,plevp
+   use spmd_utils,      only: masterproc
+   use error_messages,  only: alloc_err
+   use phys_control,    only: phys_deepconv_pbl, phys_getopts, cam_physpkg_is
+   use physics_buffer,  only: pbuf_get_index
+   use rad_constituents,only: rad_cnst_get_info 
+   implicit none
+   !----------------------------------------------------------------------------
+   real(r8),intent(in) :: pref_edge(plevp)        ! reference pressures at interfaces
 
-!----------------------------------------
-! Purpose:  declare output fields, initialize variables needed by convection
-!----------------------------------------
+   logical :: no_deep_pbl    ! if true, no deep convection in PBL
+   integer  limcnv           ! top interface level limit for convection
+   integer k, istat
+   logical :: history_budget ! output tendencies and state variables for CAM4
+                             ! temperature, water vapor, cloud ice and cloud
+                             ! liquid budgets.
+   integer :: history_budget_histfile_num ! output history file number for budget fields
+   integer :: nmodes 
+   !----------------------------------------------------------------------------
+   ! Register fields with the output buffer
 
-  use cam_history,    only: outfld, addfld, horiz_only, add_default
-  use ppgrid,         only: pcols, pver
-  use zm_conv,        only: zm_convi
-  use pmgrid,         only: plev,plevp
-  use spmd_utils,     only: masterproc
-  use error_messages, only: alloc_err	
-  use phys_control,   only: phys_deepconv_pbl, phys_getopts, cam_physpkg_is
-  use physics_buffer, only: pbuf_get_index
-  use rad_constituents, only: rad_cnst_get_info 
+   call addfld ('PRECZ',   horiz_only,'A','m/s',     'total precipitation from ZM convection')
+   call addfld ('PRECCDZM',horiz_only,'A','m/s',     'Convective precipitation rate from ZM deep')
+   call addfld ('PCONVB',  horiz_only,'A','Pa',      'convection base pressure')
+   call addfld ('PCONVT',  horiz_only,'A','Pa',      'convection top  pressure')
+   call addfld ('MAXI',    horiz_only,'A','level',   'model level of launching parcel')
+   call addfld ('CAPE',    horiz_only,'A','J/kg',    'Convectively available potential energy')
+   call addfld ('FREQZM',  horiz_only,'A','fraction','Fractional occurance of ZM convection') 
 
-  implicit none
+   call addfld ('ZMDT',    (/'lev'/),'A','K/s',    'T tendency - Zhang-McFarlane moist convection')
+   call addfld ('ZMDQ',    (/'lev'/),'A','kg/kg/s','Q tendency - Zhang-McFarlane moist convection')
+   call addfld ('ZMDICE',  (/'lev'/),'A','kg/kg/s','Cloud ice tendency - Zhang-McFarlane convection')
+   call addfld ('ZMDLIQ',  (/'lev'/),'A','kg/kg/s','Cloud liq tendency - Zhang-McFarlane convection')
+   call addfld ('EVAPTZM', (/'lev'/),'A','K/s',    'T tendency - Evaporation/snow prod from Zhang convection')
+   call addfld ('FZSNTZM', (/'lev'/),'A','K/s',    'T tendency - Rain to snow conversion from Zhang convection')
+   call addfld ('EVSNTZM', (/'lev'/),'A','K/s',    'T tendency - Snow to rain prod from Zhang convection')
+   call addfld ('EVAPQZM', (/'lev'/),'A','kg/kg/s','Q tendency - Evaporation from Zhang-McFarlane moist convection')
+   call addfld ('ZMNTPRPD',(/'lev'/),'A','kg/kg/s','Net precipitation production from ZM convection')
+   call addfld ('ZMNTSNPD',(/'lev'/),'A','kg/kg/s','Net snow production from ZM convection'         )
+   call addfld ('ZMEIHEAT',(/'lev'/),'A','W/kg',   'Heating by ice and evaporation in ZM convection')
+   call addfld ('ZMMTT',   (/'lev'/),'A','K/s',    'T tendency - ZM convective momentum transport')
+   call addfld ('ZMMTU',   (/'lev'/),'A','m/s2',   'U tendency - ZM convective momentum transport')
+   call addfld ('ZMMTV',   (/'lev'/),'A','m/s2',   'V tendency - ZM convective momentum transport')
+   call addfld ('ZMMU',    (/'lev'/),'A','kg/m2/s','ZM convection updraft mass flux')
+   call addfld ('ZMMD',    (/'lev'/),'A','kg/m2/s','ZM convection downdraft mass flux')
+   call addfld ('ZMUPGU',  (/'lev'/),'A','m/s2',   'zonal force from ZM updraft pressure gradient term')
+   call addfld ('ZMUPGD',  (/'lev'/),'A','m/s2',   'zonal force from ZM downdraft pressure gradient term')
+   call addfld ('ZMVPGU',  (/'lev'/),'A','m/s2',   'meridional force from ZM updraft pressure gradient term')
+   call addfld ('ZMVPGD',  (/'lev'/),'A','m/s2',   'merdional force from ZM downdraft pressure gradient term')
+   call addfld ('ZMICUU',  (/'lev'/),'A','m/s',    'ZM in-cloud U updrafts')
+   call addfld ('ZMICUD',  (/'lev'/),'A','m/s',    'ZM in-cloud U downdrafts')
+   call addfld ('ZMICVU',  (/'lev'/),'A','m/s',    'ZM in-cloud V updrafts')
+   call addfld ('ZMICVD',  (/'lev'/),'A','m/s',    'ZM in-cloud V downdrafts')
 
-  real(r8),intent(in) :: pref_edge(plevp)        ! reference pressures at interfaces
+   call addfld ('ZMFLXPRC',(/'ilev'/),'A','kg/m2/s','Flux of precipitation from ZM convection')
+   call addfld ('ZMFLXSNW',(/'ilev'/),'A','kg/m2/s','Flux of snow from ZM convection')
+   call addfld ('CMFMCDZM',(/'ilev'/),'A','kg/m2/s','Convection mass flux from ZM deep ')   
 
+   call phys_getopts( history_budget_out = history_budget, &
+                      history_budget_histfile_num_out = history_budget_histfile_num, &
+                      convproc_do_aer_out = convproc_do_aer, & 
+                      convproc_do_gas_out = convproc_do_gas)   
+   ! Determine whether its a 'modal' aerosol simulation  or not
+   call rad_cnst_get_info(0, nmodes=nmodes)
+   clim_modal_aero = (nmodes > 0)
 
-  logical :: no_deep_pbl    ! if true, no deep convection in PBL
-  integer  limcnv           ! top interface level limit for convection
-  integer k, istat
-  logical :: history_budget ! output tendencies and state variables for CAM4
-                            ! temperature, water vapor, cloud ice and cloud
-                            ! liquid budgets.
-  integer :: history_budget_histfile_num ! output history file number for budget fields
-  integer :: nmodes 
+   if ( history_budget ) then
+      call add_default('EVAPTZM  ', history_budget_histfile_num, ' ')
+      call add_default('EVAPQZM  ', history_budget_histfile_num, ' ')
+      call add_default('ZMDT     ', history_budget_histfile_num, ' ')
+      call add_default('ZMDQ     ', history_budget_histfile_num, ' ')
+      call add_default('ZMDLIQ   ', history_budget_histfile_num, ' ')
+      call add_default('ZMDICE   ', history_budget_histfile_num, ' ')
+      if( cam_physpkg_is('default') ) then
+         call add_default('ZMMTT    ', history_budget_histfile_num, ' ')
+      end if
 
-! 
-! Register fields with the output buffer
-!
+   end if
 
-
-    call addfld ('PRECZ',horiz_only,    'A','m/s','total precipitation from ZM convection')
-    call addfld ('ZMDT',(/ 'lev' /), 'A','K/s','T tendency - Zhang-McFarlane moist convection')
-    call addfld ('ZMDQ',(/ 'lev' /), 'A','kg/kg/s','Q tendency - Zhang-McFarlane moist convection')
-    call addfld ('ZMDICE',(/ 'lev' /), 'A','kg/kg/s','Cloud ice tendency - Zhang-McFarlane convection')
-    call addfld ('ZMDLIQ',(/ 'lev' /), 'A','kg/kg/s','Cloud liq tendency - Zhang-McFarlane convection')
-    call addfld ('EVAPTZM',(/ 'lev' /), 'A','K/s','T tendency - Evaporation/snow prod from Zhang convection')
-    call addfld ('FZSNTZM',(/ 'lev' /), 'A','K/s','T tendency - Rain to snow conversion from Zhang convection')
-    call addfld ('EVSNTZM',(/ 'lev' /), 'A','K/s','T tendency - Snow to rain prod from Zhang convection')
-    call addfld ('EVAPQZM',(/ 'lev' /), 'A','kg/kg/s','Q tendency - Evaporation from Zhang-McFarlane moist convection')
+   ! Limit deep convection to regions below 40 mb
+   ! Note this calculation is repeated in the shallow convection interface
+   limcnv = 0   ! null value to check against below
+   if (pref_edge(1) >= 4.e3_r8) then
+      limcnv = 1
+   else
+      do k=1,plev
+         if (pref_edge(k) < 4.e3_r8 .and. pref_edge(k+1) >= 4.e3_r8) then
+            limcnv = k
+            exit
+         end if
+      end do
+      if ( limcnv == 0 ) limcnv = plevp
+   end if
     
-    call addfld ('ZMFLXPRC',(/ 'ilev' /), 'A','kg/m2/s','Flux of precipitation from ZM convection'       )
-    call addfld ('ZMFLXSNW',(/ 'ilev' /), 'A','kg/m2/s','Flux of snow from ZM convection'                )
-    call addfld ('ZMNTPRPD',(/ 'lev' /) , 'A','kg/kg/s','Net precipitation production from ZM convection')
-    call addfld ('ZMNTSNPD',(/ 'lev' /) , 'A','kg/kg/s','Net snow production from ZM convection'         )
-    call addfld ('ZMEIHEAT',(/ 'lev' /) , 'A','W/kg'    ,'Heating by ice and evaporation in ZM convection')
-    
-    call addfld ('CMFMCDZM',(/ 'ilev' /),'A','kg/m2/s','Convection mass flux from ZM deep ')
-    call addfld ('PRECCDZM',horiz_only,    'A','m/s','Convective precipitation rate from ZM deep')
-
-    call addfld ('PCONVB',horiz_only , 'A','Pa'    ,'convection base pressure')
-    call addfld ('PCONVT',horiz_only , 'A','Pa'    ,'convection top  pressure')
-
-    call addfld ('MAXI',horiz_only , 'A','level'    ,'model level of launching parcel')
-
-    call addfld ('CAPE',       horiz_only, 'A',   'J/kg', 'Convectively available potential energy')
-    call addfld ('FREQZM',horiz_only  ,'A','fraction', 'Fractional occurance of ZM convection') 
-
-    call addfld ('ZMMTT',     (/ 'lev' /), 'A', 'K/s', 'T tendency - ZM convective momentum transport')
-    call addfld ('ZMMTU',    (/ 'lev' /), 'A',  'm/s2', 'U tendency - ZM convective momentum transport')
-    call addfld ('ZMMTV',    (/ 'lev' /), 'A',  'm/s2', 'V tendency - ZM convective momentum transport')
-
-    call addfld ('ZMMU', (/ 'lev' /), 'A',   'kg/m2/s', 'ZM convection updraft mass flux')
-    call addfld ('ZMMD', (/ 'lev' /), 'A',   'kg/m2/s', 'ZM convection downdraft mass flux')
-
-    call addfld ('ZMUPGU',    (/ 'lev' /), 'A', 'm/s2', 'zonal force from ZM updraft pressure gradient term')
-    call addfld ('ZMUPGD',    (/ 'lev' /), 'A', 'm/s2', 'zonal force from ZM downdraft pressure gradient term')
-    call addfld ('ZMVPGU',    (/ 'lev' /), 'A', 'm/s2', 'meridional force from ZM updraft pressure gradient term')
-    call addfld ('ZMVPGD',    (/ 'lev' /), 'A', 'm/s2', 'merdional force from ZM downdraft pressure gradient term')
-
-    call addfld ('ZMICUU',     (/ 'lev' /), 'A', 'm/s', 'ZM in-cloud U updrafts')
-    call addfld ('ZMICUD',     (/ 'lev' /), 'A', 'm/s', 'ZM in-cloud U downdrafts')
-    call addfld ('ZMICVU',     (/ 'lev' /), 'A', 'm/s', 'ZM in-cloud V updrafts')
-    call addfld ('ZMICVD',     (/ 'lev' /), 'A', 'm/s', 'ZM in-cloud V downdrafts')
-    
-    call phys_getopts( history_budget_out = history_budget, &
-                       history_budget_histfile_num_out = history_budget_histfile_num, &
-                       convproc_do_aer_out = convproc_do_aer, & 
-                       convproc_do_gas_out = convproc_do_gas)   
-    ! Determine whether its a 'modal' aerosol simulation  or not
-    call rad_cnst_get_info(0, nmodes=nmodes)
-    clim_modal_aero = (nmodes > 0)
-
-    if ( history_budget ) then
-       call add_default('EVAPTZM  ', history_budget_histfile_num, ' ')
-       call add_default('EVAPQZM  ', history_budget_histfile_num, ' ')
-       call add_default('ZMDT     ', history_budget_histfile_num, ' ')
-       call add_default('ZMDQ     ', history_budget_histfile_num, ' ')
-       call add_default('ZMDLIQ   ', history_budget_histfile_num, ' ')
-       call add_default('ZMDICE   ', history_budget_histfile_num, ' ')
-
-       if( cam_physpkg_is('cam4') .or. cam_physpkg_is('default') ) then
-          call add_default('ZMMTT    ', history_budget_histfile_num, ' ')
-       end if
-
-    end if
-!
-! Limit deep convection to regions below 40 mb
-! Note this calculation is repeated in the shallow convection interface
-!
-    limcnv = 0   ! null value to check against below
-    if (pref_edge(1) >= 4.e3_r8) then
-       limcnv = 1
-    else
-       do k=1,plev
-          if (pref_edge(k) < 4.e3_r8 .and. pref_edge(k+1) >= 4.e3_r8) then
-             limcnv = k
-             exit
-          end if
-       end do
-       if ( limcnv == 0 ) limcnv = plevp
-    end if
-    
-    if (masterproc) then
-       write(iulog,*)'ZM_CONV_INIT: Deep convection will be capped at intfc ',limcnv, &
-            ' which is ',pref_edge(limcnv),' pascals'
-    end if
+   if (masterproc) then
+      write(iulog,*)'ZM_CONV_INIT: Deep convection will be capped at intfc ',limcnv, &
+           ' which is ',pref_edge(limcnv),' pascals'
+   end if
         
-    no_deep_pbl = phys_deepconv_pbl()
-    call zm_convi(limcnv,no_deep_pbl_in = no_deep_pbl)
+   no_deep_pbl = phys_deepconv_pbl()
+   call zm_convi(limcnv,no_deep_pbl_in = no_deep_pbl)
 
-    cld_idx         = pbuf_get_index('CLD')
-    icwmrdp_idx     = pbuf_get_index('ICWMRDP')
-    rprddp_idx      = pbuf_get_index('RPRDDP')
-    fracis_idx      = pbuf_get_index('FRACIS')
-    nevapr_dpcu_idx = pbuf_get_index('NEVAPR_DPCU')
-    prec_dp_idx     = pbuf_get_index('PREC_DP')
-    snow_dp_idx     = pbuf_get_index('SNOW_DP')
+   cld_idx         = pbuf_get_index('CLD')
+   icwmrdp_idx     = pbuf_get_index('ICWMRDP')
+   rprddp_idx      = pbuf_get_index('RPRDDP')
+   fracis_idx      = pbuf_get_index('FRACIS')
+   nevapr_dpcu_idx = pbuf_get_index('NEVAPR_DPCU')
+   prec_dp_idx     = pbuf_get_index('PREC_DP')
+   snow_dp_idx     = pbuf_get_index('SNOW_DP')
 
 end subroutine zm_conv_init
-!=========================================================================================
-!subroutine zm_conv_tend(state, ptend, tdt)
+
+!-------------------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
-     tpert   ,dlf     ,pflx    ,zdu      , &
-     rliq    , &
-     ztodt   , &
-     jctop   ,jcbot , &
-     state   ,ptend_all   ,landfrac,  pbuf, mu, eu, &
-     du, md, ed, dp, dsubcld, jt, maxg, ideep, lengath) 
-
-   use cam_history,   only: outfld
-   use physics_types, only: physics_state, physics_ptend
-   use physics_types, only: physics_ptend_init
-   use physics_update_mod, only: physics_update
-   use physics_types, only: physics_state_copy, physics_state_dealloc
-   use physics_types, only: physics_ptend_sum, physics_ptend_dealloc
-
-   use phys_grid,     only: get_lat_p, get_lon_p
-   use time_manager,  only: get_nstep, is_first_step
-   use physics_buffer, only : pbuf_get_field, physics_buffer_desc, pbuf_old_tim_idx
-   use constituents,  only: pcnst, cnst_get_ind, cnst_is_convtran1
-   use physconst,     only: gravit
-   use phys_control,  only: cam_physpkg_is
-
-   ! Arguments
-
+                        tpert   ,dlf     ,pflx    ,zdu      , &
+                        rliq    , ztodt   , jctop   ,jcbot , &
+                        state   ,ptend_all   ,landfrac,  pbuf, mu, eu, &
+                        du, md, ed, dp, dsubcld, jt, maxg, ideep, lengath) 
+   use cam_history,       only: outfld
+   use physics_types,     only: physics_state, physics_ptend
+   use physics_types,     only: physics_ptend_init
+   use physics_update_mod,only: physics_update
+   use physics_types,     only: physics_state_copy, physics_state_dealloc
+   use physics_types,     only: physics_ptend_sum, physics_ptend_dealloc
+   use phys_grid,         only: get_lat_p, get_lon_p
+   use time_manager,      only: get_nstep, is_first_step
+   use physics_buffer,    only: pbuf_get_field, physics_buffer_desc, pbuf_old_tim_idx
+   use constituents,      only: pcnst, cnst_get_ind, cnst_is_convtran1
+   use physconst,         only: gravit
+   !----------------------------------------------------------------------------
+   ! Interface arguments
    type(physics_state), intent(in )   :: state          ! Physics state variables
    type(physics_ptend), intent(out)   :: ptend_all      ! individual parameterization tendencies
    type(physics_buffer_desc), pointer :: pbuf(:)
-
-   real(r8), intent(in) :: ztodt                       ! 2 delta t (model time increment)
-   real(r8), intent(in) :: pblh(pcols)                 ! Planetary boundary layer height
-   real(r8), intent(in) :: tpert(pcols)                ! Thermal temperature excess
-   real(r8), intent(in) :: landfrac(pcols)             ! RBN - Landfrac 
-
-   real(r8), intent(out) :: mcon(pcols,pverp)  ! Convective mass flux--m sub c
-   real(r8), intent(out) :: dlf(pcols,pver)    ! scattrd version of the detraining cld h2o tend
-   real(r8), intent(out) :: pflx(pcols,pverp)  ! scattered precip flux at each level
-   real(r8), intent(out) :: cme(pcols,pver)    ! cmf condensation - evaporation
-   real(r8), intent(out) :: zdu(pcols,pver)    ! detraining mass flux
-
-   real(r8), intent(out) :: rliq(pcols) ! reserved liquid (not yet in cldliq) for energy integrals
-   real(r8), intent(out):: mu(pcols,pver) 
-   real(r8), intent(out):: eu(pcols,pver) 
-   real(r8), intent(out):: du(pcols,pver) 
-   real(r8), intent(out):: md(pcols,pver) 
-   real(r8), intent(out):: ed(pcols,pver) 
-   real(r8), intent(out):: dp(pcols,pver) 
-   
-   ! wg layer thickness in mbs (between upper/lower interface).
-   real(r8), intent(out):: dsubcld(pcols) 
-   
-   ! wg layer thickness in mbs between lcl and maxi.    
-   integer, intent(out) :: jt(pcols)   
-   
-   ! wg top  level index of deep cumulus convection.
-   integer, intent(out) :: maxg(pcols) 
-   
-   ! wg gathered values of maxi.
-   integer, intent(out) :: ideep(pcols)
-   
-   ! w holds position of gathered points vs longitude index   
-   integer, intent(out)  :: lengath
-
+   real(r8),intent(in ):: ztodt              ! 2 delta t (model time increment)
+   real(r8),intent(in ):: pblh(pcols)        ! Planetary boundary layer height
+   real(r8),intent(in ):: tpert(pcols)       ! Thermal temperature excess
+   real(r8),intent(in ):: landfrac(pcols)    ! Land fraction
+   real(r8),intent(out):: mcon(pcols,pverp)  ! Convective mass flux--m sub c
+   real(r8),intent(out):: dlf(pcols,pver)    ! scattrd version of the detraining cld h2o tend
+   real(r8),intent(out):: pflx(pcols,pverp)  ! scattered precip flux at each level
+   real(r8),intent(out):: cme(pcols,pver)    ! cmf condensation - evaporation
+   real(r8),intent(out):: zdu(pcols,pver)    ! detraining mass flux
+   real(r8),intent(out):: rliq(pcols)        ! reserved liquid (not yet in cldliq) for energy integrals
+   real(r8),intent(out):: mu(pcols,pver) 
+   real(r8),intent(out):: eu(pcols,pver) 
+   real(r8),intent(out):: du(pcols,pver) 
+   real(r8),intent(out):: md(pcols,pver) 
+   real(r8),intent(out):: ed(pcols,pver) 
+   real(r8),intent(out):: dp(pcols,pver) 
+   real(r8),intent(out):: dsubcld(pcols)     ! wg layer thickness in mbs (between upper/lower interface).
+   integer, intent(out):: jt(pcols)          ! wg layer thickness in mbs between lcl and maxi.    
+   integer, intent(out):: maxg(pcols)        ! wg top  level index of deep cumulus convection.
+   integer, intent(out):: ideep(pcols)       ! wg gathered values of maxi.
+   integer, intent(out):: lengath            ! w holds position of gathered points vs longitude index   
+   !----------------------------------------------------------------------------
    ! Local variables
-
    integer :: i,k,m
    integer :: ilon                      ! global longitude index of a column
    integer :: ilat                      ! global latitude index of a column
@@ -318,24 +274,23 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    type(physics_ptend) :: ptend_loc     ! package tendencies
 
    ! physics buffer fields
-   real(r8), pointer, dimension(:)   :: prec         ! total precipitation
-   real(r8), pointer, dimension(:)   :: snow         ! snow from ZM convection 
-   real(r8), pointer, dimension(:,:) :: cld
-   real(r8), pointer, dimension(:,:) :: ql           ! wg grid slice of cloud liquid water.
-   real(r8), pointer, dimension(:,:) :: rprd         ! rain production rate
-   real(r8), pointer, dimension(:,:,:) :: fracis  ! fraction of transported species that are insoluble
-   real(r8), pointer, dimension(:,:) :: evapcdp      ! Evaporation of deep convective precipitation
-   real(r8), pointer, dimension(:,:) :: flxprec      ! Convective-scale flux of precip at interfaces (kg/m2/s)
-   real(r8), pointer, dimension(:,:) :: flxsnow      ! Convective-scale flux of snow   at interfaces (kg/m2/s)
-   real(r8), pointer, dimension(:,:) :: dp_cldliq
-   real(r8), pointer, dimension(:,:) :: dp_cldice
+   real(r8), pointer, dimension(:)    :: prec         ! total precipitation
+   real(r8), pointer, dimension(:)    :: snow         ! snow from ZM convection 
+   real(r8), pointer, dimension(:,:)  :: cld
+   real(r8), pointer, dimension(:,:)  :: ql           ! wg grid slice of cloud liquid water.
+   real(r8), pointer, dimension(:,:)  :: rprd         ! rain production rate
+   real(r8), pointer, dimension(:,:,:):: fracis       ! fraction of transported species that are insoluble
+   real(r8), pointer, dimension(:,:)  :: evapcdp      ! Evaporation of deep convective precipitation
+   real(r8), pointer, dimension(:,:)  :: flxprec      ! Convective-scale flux of precip at interfaces (kg/m2/s)
+   real(r8), pointer, dimension(:,:)  :: flxsnow      ! Convective-scale flux of snow   at interfaces (kg/m2/s)
+   real(r8), pointer, dimension(:,:)  :: dp_cldliq
+   real(r8), pointer, dimension(:,:)  :: dp_cldice
 
    ! DCAPE-ULL
    real(r8), pointer, dimension(:,:) :: t_star ! intermediate T between n and n-1 time step
    real(r8), pointer, dimension(:,:) :: q_star ! intermediate q between n and n-1 time step
    real(r8) :: dcape(pcols)                    ! dynamical cape
    real(r8) :: maxgsav(pcols)                  ! tmp array for recording and outfld to MAXI
-
 
    real(r8) :: jctop(pcols)  ! o row of top-of-deep-convection indices passed out.
    real(r8) :: jcbot(pcols)  ! o row of base of cloud indices passed out.
@@ -361,8 +316,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
 
    logical  :: lq(pcnst)
 
-   !----------------------------------------------------------------------
-
+   !----------------------------------------------------------------------------
    ! initialize
    lchnk = state%lchnk
    ncol  = state%ncol
@@ -373,15 +327,13 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    md_out(:,:) = 0._r8
    wind_tends(:ncol,:pver,:) = 0.0_r8
 
-   call physics_state_copy(state,state1)             ! copy state to local state1.
+   call physics_state_copy(state,state1) ! copy state to local state1.
 
    lq(:) = .FALSE.
    lq(1) = .TRUE.
    call physics_ptend_init(ptend_loc, state%psetcols, 'zm_convr', ls=.true., lq=lq)! initialize local ptend type
 
-!
-! Associate pointers with physics buffer fields
-!
+   ! Associate pointers with physics buffer fields
    itim_old = pbuf_old_tim_idx()
    call pbuf_get_field(pbuf, cld_idx,         cld,    start=(/1,1,itim_old/), kount=(/pcols,pver,1/) )
 
@@ -392,7 +344,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    call pbuf_get_field(pbuf, prec_dp_idx,     prec )
    call pbuf_get_field(pbuf, snow_dp_idx,     snow )
 
-! DCAPE-ULL
+   ! DCAPE-ULL
    if(trigdcape_ull .or. trig_dcape_only)then
      call pbuf_get_field(pbuf, t_star_idx,     t_star)
      call pbuf_get_field(pbuf, q_star_idx,     q_star)
@@ -402,34 +354,30 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
      end if
    end if
 
-!
-! Begin with Zhang-McFarlane (1996) convection parameterization
-!
+   ! Begin with Zhang-McFarlane (1996) convection parameterization
    call t_startf ('zm_convr')
-   call zm_convr(   lchnk   ,ncol    , &
-                    state%t       ,state%q(:,:,1)     ,prec    ,jctop   ,jcbot   , &
-                    pblh    ,state%zm      ,state%phis    ,state%zi      ,ptend_loc%q(:,:,1)    , &
-                    ptend_loc%s    ,state%pmid     ,state%pint    ,state%pdel     , &
-                    .5_r8*ztodt    ,mcon    ,cme     , cape,      &
-                    tpert   ,dlf     ,pflx    ,zdu     ,rprd    , &
-                    mu,md,du,eu,ed      , &
-                    dp ,dsubcld ,jt,maxg,ideep   , &
-                    lengath ,ql      ,rliq  ,landfrac,  &
-                    t_star, q_star, dcape)  
+   call zm_convr(   lchnk        ,ncol    , &
+                    state%t      ,state%q(:,:,1),prec       ,jctop      ,jcbot   , &
+                    pblh         ,state%zm      ,state%phis ,state%zi   ,ptend_loc%q(:,:,1)    , &
+                    ptend_loc%s  ,state%pmid    ,state%pint ,state%pdel , &
+                    .5_r8*ztodt  ,mcon          ,cme        ,cape       , &
+                    tpert        ,dlf           ,pflx       ,zdu        ,rprd    , &
+                    mu           ,md            ,du         ,eu         ,ed      , &
+                    dp           ,dsubcld       ,jt         ,maxg       ,ideep   , &
+                    lengath      ,ql            ,rliq       ,landfrac   , &
+                    t_star       ,q_star        ,dcape)  
    call t_stopf ('zm_convr')
 
-   call outfld('CAPE', cape, pcols, lchnk)        ! RBN - CAPE output
-!
-! Output fractional occurance of ZM convection
-!
+   call outfld('CAPE', cape, pcols, lchnk)
+
+   ! Output fractional occurance of ZM convection
    freqzm(:) = 0._r8
    do i = 1,lengath
       freqzm(ideep(i)) = 1.0_r8
    end do
    call outfld('FREQZM  ',freqzm          ,pcols   ,lchnk   )
-!
-! Convert mass flux from reported mb/s to kg/m^2/s
-!
+
+   ! Convert mass flux from reported mb/s to kg/m^2/s
    mcon(:ncol,:pver) = mcon(:ncol,:pver) * 100._r8/gravit
 
    ! Store upward and downward mass fluxes in un-gathered arrays
@@ -441,7 +389,6 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
          md_out(ii,k) = md(i,k) * 100._r8/gravit
       end do
    end do
-
 
    if(convproc_do_aer .or. convproc_do_gas) then 
       call outfld('ZMMU', mu_out,      pcols, lchnk)
@@ -459,56 +406,51 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    pcont(:ncol) = state%ps(:ncol)
    pconb(:ncol) = state%ps(:ncol)
    do i = 1,lengath
-       if (maxg(i).gt.jt(i)) then
-          pcont(ideep(i)) = state%pmid(ideep(i),jt(i))  ! gathered array (or jctop ungathered)
-          pconb(ideep(i)) = state%pmid(ideep(i),maxg(i))! gathered array
-          maxgsav(ideep(i)) = dble(maxg(i))             ! gathered array for launching level
-       endif
-       !     write(iulog,*) ' pcont, pconb ', pcont(i), pconb(i), cnt(i), cnb(i)
+      if (maxg(i).gt.jt(i)) then
+         pcont(ideep(i)) = state%pmid(ideep(i),jt(i))  ! gathered array (or jctop ungathered)
+         pconb(ideep(i)) = state%pmid(ideep(i),maxg(i))! gathered array
+         maxgsav(ideep(i)) = dble(maxg(i))             ! gathered array for launching level
+      endif
    end do
    call outfld('PCONVT  ',pcont          ,pcols   ,lchnk   )
    call outfld('PCONVB  ',pconb          ,pcols   ,lchnk   )
    call outfld('MAXI  ',maxgsav          ,pcols   ,lchnk   )
 
-  call physics_ptend_init(ptend_all, state%psetcols, 'zm_conv_tend')
+   call physics_ptend_init(ptend_all, state%psetcols, 'zm_conv_tend')
 
-  ! add tendency from this process to tendencies from other processes
-  call physics_ptend_sum(ptend_loc,ptend_all, ncol)
+   ! add tendency from this process to tendencies from other processes
+   call physics_ptend_sum(ptend_loc,ptend_all, ncol)
 
-  ! update physics state type state1 with ptend_loc 
-  call physics_update(state1, ptend_loc, ztodt)
+   ! update physics state type state1 with ptend_loc 
+   call physics_update(state1, ptend_loc, ztodt)
 
-  ! initialize ptend for next process
-  lq(:) = .FALSE.
-  lq(1) = .TRUE.
-  call physics_ptend_init(ptend_loc, state1%psetcols, 'zm_conv_evap', ls=.true., lq=lq)
+   ! initialize ptend for next process
+   lq(:) = .FALSE.
+   lq(1) = .TRUE.
+   call physics_ptend_init(ptend_loc, state1%psetcols, 'zm_conv_evap', ls=.true., lq=lq)
 
-!
-! Determine the phase of the precipitation produced and add latent heat of fusion
-! Evaporate some of the precip directly into the environment (Sundqvist)
-! Allow this to use the updated state1 and the fresh ptend_loc type
-! heating and specific humidity tendencies produced
-!
+   ! Determine the phase of the precipitation produced and add latent heat of fusion
+   ! Evaporate some of the precip directly into the environment (Sundqvist)
+   ! Allow this to use the updated state1 and the fresh ptend_loc type
+   ! heating and specific humidity tendencies produced
+   call pbuf_get_field(pbuf, dp_flxprc_idx, flxprec    )
+   call pbuf_get_field(pbuf, dp_flxsnw_idx, flxsnow    )
+   call pbuf_get_field(pbuf, dp_cldliq_idx, dp_cldliq  )
+   call pbuf_get_field(pbuf, dp_cldice_idx, dp_cldice  )
+   dp_cldliq(:ncol,:) = 0._r8
+   dp_cldice(:ncol,:) = 0._r8
 
-    call pbuf_get_field(pbuf, dp_flxprc_idx, flxprec    )
-    call pbuf_get_field(pbuf, dp_flxsnw_idx, flxsnow    )
-    call pbuf_get_field(pbuf, dp_cldliq_idx, dp_cldliq  )
-    call pbuf_get_field(pbuf, dp_cldice_idx, dp_cldice  )
-    dp_cldliq(:ncol,:) = 0._r8
-    dp_cldice(:ncol,:) = 0._r8
+   call t_startf ('zm_conv_evap')
+   call zm_conv_evap(state1%ncol,state1%lchnk, &
+        state1%t,state1%pmid,state1%pdel,state1%q(:pcols,:pver,1), &
+        ptend_loc%s, tend_s_snwprd, tend_s_snwevmlt, ptend_loc%q(:pcols,:pver,1), &
+        rprd, cld, ztodt, &
+        prec, snow, ntprprd, ntsnprd , flxprec, flxsnow)
+   call t_stopf ('zm_conv_evap')
 
-    call t_startf ('zm_conv_evap')
-    call zm_conv_evap(state1%ncol,state1%lchnk, &
-         state1%t,state1%pmid,state1%pdel,state1%q(:pcols,:pver,1), &
-         ptend_loc%s, tend_s_snwprd, tend_s_snwevmlt, ptend_loc%q(:pcols,:pver,1), &
-         rprd, cld, ztodt, &
-         prec, snow, ntprprd, ntsnprd , flxprec, flxsnow)
-    call t_stopf ('zm_conv_evap')
+   evapcdp(:ncol,:pver) = ptend_loc%q(:ncol,:pver,1)
 
-    evapcdp(:ncol,:pver) = ptend_loc%q(:ncol,:pver,1)
-!
-! Write out variables from zm_conv_evap
-!
+   ! Write out variables from zm_conv_evap
    ftem(:ncol,:pver) = ptend_loc%s(:ncol,:pver)/cpair
    call outfld('EVAPTZM ',ftem           ,pcols   ,lchnk   )
    ftem(:ncol,:pver) = tend_s_snwprd  (:ncol,:pver)/cpair
@@ -524,64 +466,57 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    call outfld('CMFMCDZM   ',mcon ,  pcols   ,lchnk   )
    call outfld('PRECCDZM   ',prec,  pcols   ,lchnk   )
 
-
-
    call outfld('PRECZ   ', prec   , pcols, lchnk)
 
-  ! add tendency from this process to tend from other processes here
-  call physics_ptend_sum(ptend_loc,ptend_all, ncol)
+   ! add tendency from this process to tend from other processes here
+   call physics_ptend_sum(ptend_loc,ptend_all, ncol)
 
-  ! update physics state type state1 with ptend_loc 
-  call physics_update(state1, ptend_loc, ztodt)
+   ! update physics state type state1 with ptend_loc 
+   call physics_update(state1, ptend_loc, ztodt)
 
+   ! Momentum Transport
 
-  ! Momentum Transport (non-cam3 physics)
+   call physics_ptend_init(ptend_loc, state1%psetcols, 'momtran', ls=.true., lu=.true., lv=.true.)
 
-  if ( .not. cam_physpkg_is('cam3')) then
+   winds(:ncol,:pver,1) = state1%u(:ncol,:pver)
+   winds(:ncol,:pver,2) = state1%v(:ncol,:pver)
 
-     call physics_ptend_init(ptend_loc, state1%psetcols, 'momtran', ls=.true., lu=.true., lv=.true.)
+   l_windt(1) = .true.
+   l_windt(2) = .true.
 
-     winds(:ncol,:pver,1) = state1%u(:ncol,:pver)
-     winds(:ncol,:pver,2) = state1%v(:ncol,:pver)
-   
-     l_windt(1) = .true.
-     l_windt(2) = .true.
+   call t_startf ('momtran')
+   call momtran (lchnk, ncol, &
+                 l_windt,winds, 2,  mu(1,1), md(1,1), &
+                 du(1,1), eu(1,1), ed(1,1), dp(1,1), dsubcld(1), &
+                 jt(1),maxg(1), ideep(1), 1, lengath, &
+                 nstep,  wind_tends, pguall, pgdall, icwu, icwd, ztodt, seten )  
+   call t_stopf ('momtran')
 
-     call t_startf ('momtran')
-     call momtran (lchnk, ncol,                                        &
-                   l_windt,winds, 2,  mu(1,1), md(1,1),   &
-                   du(1,1), eu(1,1), ed(1,1), dp(1,1), dsubcld(1),  &
-                   jt(1),maxg(1), ideep(1), 1, lengath,  &
-                   nstep,  wind_tends, pguall, pgdall, icwu, icwd, ztodt, seten )  
-     call t_stopf ('momtran')
+   ptend_loc%u(:ncol,:pver) = wind_tends(:ncol,:pver,1)
+   ptend_loc%v(:ncol,:pver) = wind_tends(:ncol,:pver,2)
+   ptend_loc%s(:ncol,:pver) = seten(:ncol,:pver)  
 
-     ptend_loc%u(:ncol,:pver) = wind_tends(:ncol,:pver,1)
-     ptend_loc%v(:ncol,:pver) = wind_tends(:ncol,:pver,2)
-     ptend_loc%s(:ncol,:pver) = seten(:ncol,:pver)  
+   call physics_ptend_sum(ptend_loc,ptend_all, ncol)
 
-     call physics_ptend_sum(ptend_loc,ptend_all, ncol)
+   ! update physics state type state1 with ptend_loc 
+   call physics_update(state1, ptend_loc, ztodt)
 
-     ! update physics state type state1 with ptend_loc 
-     call physics_update(state1, ptend_loc, ztodt)
+   ftem(:ncol,:pver) = seten(:ncol,:pver)/cpair
+   call outfld('ZMMTT', ftem             , pcols, lchnk)
+   call outfld('ZMMTU', wind_tends(1,1,1), pcols, lchnk)
+   call outfld('ZMMTV', wind_tends(1,1,2), pcols, lchnk)
 
-     ftem(:ncol,:pver) = seten(:ncol,:pver)/cpair
-     call outfld('ZMMTT', ftem             , pcols, lchnk)
-     call outfld('ZMMTU', wind_tends(1,1,1), pcols, lchnk)
-     call outfld('ZMMTV', wind_tends(1,1,2), pcols, lchnk)
-   
-     ! Output apparent force from  pressure gradient
-     call outfld('ZMUPGU', pguall(1,1,1), pcols, lchnk)
-     call outfld('ZMUPGD', pgdall(1,1,1), pcols, lchnk)
-     call outfld('ZMVPGU', pguall(1,1,2), pcols, lchnk)
-     call outfld('ZMVPGD', pgdall(1,1,2), pcols, lchnk)
+   ! Output apparent force from  pressure gradient
+   call outfld('ZMUPGU', pguall(1,1,1), pcols, lchnk)
+   call outfld('ZMUPGD', pgdall(1,1,1), pcols, lchnk)
+   call outfld('ZMVPGU', pguall(1,1,2), pcols, lchnk)
+   call outfld('ZMVPGD', pgdall(1,1,2), pcols, lchnk)
 
-     ! Output in-cloud winds
-     call outfld('ZMICUU', icwu(1,1,1), pcols, lchnk)
-     call outfld('ZMICUD', icwd(1,1,1), pcols, lchnk)
-     call outfld('ZMICVU', icwu(1,1,2), pcols, lchnk)
-     call outfld('ZMICVD', icwd(1,1,2), pcols, lchnk)
-
-   end if
+   ! Output in-cloud winds
+   call outfld('ZMICUU', icwu(1,1,1), pcols, lchnk)
+   call outfld('ZMICUD', icwd(1,1,1), pcols, lchnk)
+   call outfld('ZMICVU', icwu(1,1,2), pcols, lchnk)
+   call outfld('ZMICVD', icwd(1,1,2), pcols, lchnk)
 
    ! Transport cloud water and ice only
    call cnst_get_ind('CLDLIQ', ixcldliq)
@@ -591,9 +526,8 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    lq(2:) = cnst_is_convtran1(2:)
    call physics_ptend_init(ptend_loc, state1%psetcols, 'convtran1', lq=lq)
 
-
-   ! dpdry is not used in this call to convtran since the cloud liquid and ice mixing
-   ! ratios are moist
+   ! dpdry is not used in this call to convtran 
+   ! since the cloud liquid and ice mixing ratios are moist
    fake_dpdry(:,:) = 0._r8
 
    call t_startf ('convtran1')
@@ -614,79 +548,59 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    call physics_ptend_dealloc(ptend_loc)
 
 end subroutine zm_conv_tend
-!=========================================================================================
 
+!-------------------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 subroutine zm_conv_tend_2( state,  ptend,  ztodt, pbuf,mu, eu, &
-     du, md, ed, dp, dsubcld, jt, maxg, ideep, lengath, species_class) 
-
-   use physics_types, only: physics_state, physics_ptend, physics_ptend_init
-   use time_manager,  only: get_nstep
+                           du, md, ed, dp, dsubcld, jt, maxg, &
+                           ideep, lengath, species_class) 
+   use physics_types,  only: physics_state, physics_ptend, physics_ptend_init
+   use time_manager,   only: get_nstep
    use physics_buffer, only: pbuf_get_index, pbuf_get_field, physics_buffer_desc
-   use constituents,  only: pcnst, cnst_get_ind, cnst_is_convtran1
+   use constituents,   only: pcnst, cnst_get_ind, cnst_is_convtran1
    use error_messages, only: alloc_err
    use physconst,      only: spec_class_aerosol, spec_class_gas 
- 
-! Arguments
-   type(physics_state), intent(in )   :: state          ! Physics state variables
-   type(physics_ptend), intent(out)   :: ptend          ! indivdual parameterization tendencies
-   
+   !----------------------------------------------------------------------------
+   ! Interface arguments
+   type(physics_state), intent(in )   :: state   ! Physics state variables
+   type(physics_ptend), intent(out)   :: ptend   ! indivdual parameterization tendencies
    type(physics_buffer_desc), pointer :: pbuf(:)
-
-   real(r8), intent(in) :: ztodt                          ! 2 delta t (model time increment)
-   real(r8), intent(in):: mu(pcols,pver) 
-   real(r8), intent(in):: eu(pcols,pver) 
-   real(r8), intent(in):: du(pcols,pver) 
-   real(r8), intent(in):: md(pcols,pver) 
-   real(r8), intent(in):: ed(pcols,pver) 
-   real(r8), intent(in):: dp(pcols,pver) 
-   
-   ! wg layer thickness in mbs (between upper/lower interface).
-   real(r8), intent(in):: dsubcld(pcols) 
-   
-   ! wg layer thickness in mbs between lcl and maxi.    
-   integer, intent(in) :: jt(pcols)   
-   
-   ! wg top  level index of deep cumulus convection.
-   integer, intent(in) :: maxg(pcols) 
-   
-   ! wg gathered values of maxi.
-   integer, intent(in) :: ideep(pcols)
-   
-   ! w holds position of gathered points vs longitude index 
-   integer, intent(in)  :: lengath
-
-   integer, intent(in) :: species_class(:)
-
-! Local variables
+   real(r8),intent(in):: ztodt            ! 2 delta t (model time increment)
+   real(r8),intent(in):: mu(pcols,pver) 
+   real(r8),intent(in):: eu(pcols,pver) 
+   real(r8),intent(in):: du(pcols,pver) 
+   real(r8),intent(in):: md(pcols,pver) 
+   real(r8),intent(in):: ed(pcols,pver) 
+   real(r8),intent(in):: dp(pcols,pver) 
+   real(r8),intent(in):: dsubcld(pcols)   ! wg layer thickness in mbs (between upper/lower interface).
+   integer, intent(in):: jt(pcols)        ! wg layer thickness in mbs between lcl and maxi.    
+   integer, intent(in):: maxg(pcols)      ! wg top  level index of deep cumulus convection.
+   integer, intent(in):: ideep(pcols)     ! wg gathered values of maxi.
+   integer, intent(in):: lengath          ! w holds position of gathered points
+   integer, intent(in):: species_class(:)
+   !----------------------------------------------------------------------------
+   ! Local variables
    integer :: i, lchnk, istat, m 
    integer :: nstep
    real(r8), dimension(pcols,pver) :: dpdry
 
-! physics buffer fields 
+   ! physics buffer fields 
    integer ifld
    real(r8), pointer, dimension(:,:,:) :: fracis  ! fraction of transported species that are insoluble
    logical   :: lq(pcnst)
+   !----------------------------------------------------------------------------
+   ! Initialize
+   lq(:) = .FALSE.
+   lq(:) = .not. cnst_is_convtran1(:)
+   call physics_ptend_init(ptend, state%psetcols, 'convtran2', lq=lq )
 
-!
-! Initialize
-!
-  lq(:) = .FALSE.
-  lq(:) = .not. cnst_is_convtran1(:)
-  call physics_ptend_init(ptend, state%psetcols, 'convtran2', lq=lq )
-
-!
-! Associate pointers with physics buffer fields
-!
+   ! Associate pointers with physics buffer fields
    ifld = pbuf_get_index('FRACIS')
    call pbuf_get_field(pbuf, fracis_idx, fracis, start=(/1,1,1/), kount=(/pcols, pver, pcnst/) )
 
-!
-! Transport all constituents except cloud water and ice
-!
-
-  lchnk = state%lchnk
-
+   ! Transport all constituents except cloud water and ice
+   lchnk = state%lchnk
    nstep = get_nstep()
    if((convproc_do_aer .or. convproc_do_gas) .and. clim_modal_aero) then
       do m = 1, pcnst
@@ -697,7 +611,6 @@ subroutine zm_conv_tend_2( state,  ptend,  ztodt, pbuf,mu, eu, &
       enddo
    endif
 
-
    if (any(ptend%lq(:))) then
       ! initialize dpdry for call to convtran
       ! it is used for tracers of dry mixing ratio type
@@ -707,7 +620,7 @@ subroutine zm_conv_tend_2( state,  ptend,  ztodt, pbuf,mu, eu, &
       end do
 
       call t_startf ('convtran2')
-      call convtran (lchnk,                                        &
+      call convtran (lchnk, &
                      ptend%lq,state%q, pcnst,  mu, md,   &
                      du, eu, ed, dp, dsubcld,  &
                      jt,maxg,ideep, 1, lengath,  &
@@ -727,8 +640,7 @@ subroutine zm_conv_tend_2( state,  ptend,  ztodt, pbuf,mu, eu, &
 
 end subroutine zm_conv_tend_2
 
-!=========================================================================================
-
-
+!-------------------------------------------------------------------------------
+!-------------------------------------------------------------------------------
 
 end module zm_conv_intr

--- a/components/eam/src/physics/cam/zm_conv_intr.F90
+++ b/components/eam/src/physics/cam/zm_conv_intr.F90
@@ -79,7 +79,7 @@ subroutine zm_conv_register
    if (trigdcape_ull .or. trig_dcape_only) then
       ! temperature from physics in n-1 time step
       call pbuf_add_field('T_STAR','global',dtype_r8,(/pcols,pver/), t_star_idx)
-      ! moisturetendency from physics in n-1 time step 
+      ! specific humidity from physics in n-1 time step 
       call pbuf_add_field('Q_STAR','global',dtype_r8,(/pcols,pver/), q_star_idx)
    endif
 


### PR DESCRIPTION
The Zhang-McFarlane code has suffered a lack of consistency and organization for decades. The current version has many outdated comments and sections that are no longer used. Various authors have modified it over the years and often imposed their own conventions, which has been the source of much confusion and frustration for those wanting to study or modify the code. This PR provides a major cosmetic clean-up of the ZM code, but it is not exhaustive. Some of the quirks of the code have been left intact, such as the lack variable descriptions. Hopefully the enhanced readability will facilitate further refinement. 

[BFB]