### PR TITLE
On cori-knl, add better PE layout for grid l%360x720cru, 16 nodes, 64x2

### DIFF
--- a/components/elm/cime_config/config_pes.xml
+++ b/components/elm/cime_config/config_pes.xml
@@ -288,6 +288,31 @@
         </ntasks>
       </pes>
     </mach>
+    <mach name="cori-knl">
+      <pes compset="any" pesize="any">
+        <comment>elm: cori-knl PEs for grid l%360x720cru, 16 nodes, 64x2</comment>
+        <ntasks>
+          <ntasks_atm>-16</ntasks_atm>
+          <ntasks_lnd>-16</ntasks_lnd>
+          <ntasks_rof>-16</ntasks_rof>
+          <ntasks_ice>-16</ntasks_ice>
+          <ntasks_ocn>-16</ntasks_ocn>
+          <ntasks_glc>-16</ntasks_glc>
+          <ntasks_wav>-16</ntasks_wav>
+          <ntasks_cpl>-16</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>2</nthrds_atm>
+          <nthrds_lnd>2</nthrds_lnd>
+          <nthrds_rof>2</nthrds_rof>
+          <nthrds_ice>2</nthrds_ice>
+          <nthrds_ocn>2</nthrds_ocn>
+          <nthrds_glc>2</nthrds_glc>
+          <nthrds_wav>2</nthrds_wav>
+          <nthrds_cpl>2</nthrds_cpl>
+        </nthrds>
+      </pes>
+    </mach>
   </grid>
   <grid name="l%0.47x0.63" >
     <mach name="any">


### PR DESCRIPTION
Only on cori-knl, add better PE layout for grid l%360x720cru, 16 nodes, 64x2

Fixes https://github.com/E3SM-Project/E3SM/issues/5111

[bfb]