### PR TITLE
Change TSC test default to use F2010-CICE

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -140,7 +140,7 @@ _TESTS = {
     "e3sm_atm_nbfb" : {
         "tests" : (
             "PGN_P1x1.ne4_oQU240.F2010",
-            "TSC.ne4_oQU240.F2010",
+            "TSC.ne4_oQU240.F2010-CICE",
             "MVK_PS.ne4_oQU240.F2010",
             )
         },


### PR DESCRIPTION
Use F2010-CICE compset in TSC test

There are problems with short timesteps and MPAS-SI, so we'll revert to this compset until that issue can be fixed.

[non-BFB] only for the TSC test