### PR TITLE
For gcp only, use 4 nodes to allow cdash test to complete

### DIFF
--- a/components/elm/cime_config/config_pes.xml
+++ b/components/elm/cime_config/config_pes.xml
@@ -313,6 +313,31 @@
         </nthrds>
       </pes>
     </mach>
+    <mach name="gcp">
+      <pes compset="any" pesize="any">
+        <comment>elm: gcp PEs for grid l%360x720cru, 4 nodes, 2 threads</comment>
+        <ntasks>
+          <ntasks_atm>-4</ntasks_atm>
+          <ntasks_lnd>-4</ntasks_lnd>
+          <ntasks_rof>-4</ntasks_rof>
+          <ntasks_ice>-4</ntasks_ice>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_glc>-4</ntasks_glc>
+          <ntasks_wav>-4</ntasks_wav>
+          <ntasks_cpl>-4</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>2</nthrds_atm>
+          <nthrds_lnd>2</nthrds_lnd>
+          <nthrds_rof>2</nthrds_rof>
+          <nthrds_ice>2</nthrds_ice>
+          <nthrds_ocn>2</nthrds_ocn>
+          <nthrds_glc>2</nthrds_glc>
+          <nthrds_wav>2</nthrds_wav>
+          <nthrds_cpl>2</nthrds_cpl>
+        </nthrds>
+      </pes>
+    </mach>
   </grid>
   <grid name="l%0.47x0.63" >
     <mach name="any">


### PR DESCRIPTION
On GCP, the new `ERS.hcru_hcru.I20TRGSWCNPRDCTCBC.gcp_gnu.elm-erosion` test was failing as it was running out of memory with 1 node. Using 4 nodes seems to work.

[bfb]