### PR TITLE
For cori-haswell, increase PE layout for grid l%360x720cru to 6 nodes

### DIFF
--- a/components/elm/cime_config/config_pes.xml
+++ b/components/elm/cime_config/config_pes.xml
@@ -313,6 +313,21 @@
         </nthrds>
       </pes>
     </mach>
+    <mach name="cori-haswell">
+      <pes compset="any" pesize="any">
+        <comment>elm: cori-haswell PEs for grid l%360x720cru, 6 nodes</comment>
+        <ntasks>
+          <ntasks_atm>-6</ntasks_atm>
+          <ntasks_lnd>-6</ntasks_lnd>
+          <ntasks_rof>-6</ntasks_rof>
+          <ntasks_ice>-6</ntasks_ice>
+          <ntasks_ocn>-6</ntasks_ocn>
+          <ntasks_glc>-6</ntasks_glc>
+          <ntasks_wav>-6</ntasks_wav>
+          <ntasks_cpl>-6</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
     <mach name="gcp">
       <pes compset="any" pesize="any">
         <comment>elm: gcp PEs for grid l%360x720cru, 4 nodes, 2 threads</comment>


### PR DESCRIPTION
Similar to https://github.com/E3SM-Project/E3SM/pull/5113, the new test was failing with 4 nodes, but works with 6 nodes
on cori-haswell.

Impacts following test: `ERS.hcru_hcru.I20TRGSWCNPRDCTCBC.cori-haswell_intel.elm-erosion`

[bfb]