### PR TITLE
correct nCells to nEdges

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -1112,7 +1112,7 @@ contains
 
       nCells = nCellsAll
       nVertices = nVerticesAll
-      nEdges = nCellsAll
+      nEdges = nEdgesAll
       apvm_scale_factor = config_apvm_scale_factor;
 
       ! Diagnostics required for the Anticipated Potential Vorticity Method (apvm).


### PR DESCRIPTION
This corrects an obvious error, where the local `nEdges` was mistakenly set to the `nCellsAll` value. Normally this would case a failure in partition tests, but the variables in this section are not used for standard E3SM settings. That also explains why simulations are BFB when compared before/after this fix.

[BFB]
fixes #5141 
