### PR TITLE
Update to github.io in mpas license website

### DIFF
--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_TEMPLATE.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_TEMPLATE.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_analysis_driver.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_analysis_driver.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_regional_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_regional_stats.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-albany-landice/src/mode_forward/Interface_velocity_solver.cpp
+++ b/components/mpas-albany-landice/src/mode_forward/Interface_velocity_solver.cpp
@@ -4,7 +4,7 @@ and the University Corporation for Atmospheric Research (UCAR).
 
 Unless noted otherwise source code is licensed under the BSD license.
 Additional copyright and license information can be found in the LICENSE file
-distributed with this code, or at http://mpas-dev.github.com/license.html
+distributed with this code, or at http://mpas-dev.github.io/license.html
 */
 
 // ===================================================

--- a/components/mpas-albany-landice/src/mode_forward/Interface_velocity_solver.hpp
+++ b/components/mpas-albany-landice/src/mode_forward/Interface_velocity_solver.hpp
@@ -4,7 +4,7 @@ and the University Corporation for Atmospheric Research (UCAR).
 
 Unless noted otherwise source code is licensed under the BSD license.
 Additional copyright and license information can be found in the LICENSE file
-distributed with this code, or at http://mpas-dev.github.com/license.html
+distributed with this code, or at http://mpas-dev.github.io/license.html
 */
 
 // ===================================================

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -2,7 +2,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 module li_core
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core_interface.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core_interface.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 module li_core_interface
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_diagnostic_vars.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_diagnostic_vars.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_sia.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_sia.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_statistics.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_statistics.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_thermal.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_thermal.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity_external.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity_external.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity_simple.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity_simple.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-albany-landice/src/shared/mpas_li_constants.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_constants.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-albany-landice/src/shared/mpas_li_mask.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mask.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-albany-landice/src/shared/mpas_li_setup.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_setup.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-framework/src/core_sw/mpas_sw_advection.F
+++ b/components/mpas-framework/src/core_sw/mpas_sw_advection.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 module sw_advection
 

--- a/components/mpas-framework/src/core_sw/mpas_sw_constants.F
+++ b/components/mpas-framework/src/core_sw/mpas_sw_constants.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 module sw_constants
 

--- a/components/mpas-framework/src/core_sw/mpas_sw_core.F
+++ b/components/mpas-framework/src/core_sw/mpas_sw_core.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 module sw_core
 

--- a/components/mpas-framework/src/core_sw/mpas_sw_core_interface.F
+++ b/components/mpas-framework/src/core_sw/mpas_sw_core_interface.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 module sw_core_interface
 

--- a/components/mpas-framework/src/core_sw/mpas_sw_global_diagnostics.F
+++ b/components/mpas-framework/src/core_sw/mpas_sw_global_diagnostics.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 module sw_global_diagnostics
 

--- a/components/mpas-framework/src/core_sw/mpas_sw_test_cases.F
+++ b/components/mpas-framework/src/core_sw/mpas_sw_test_cases.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 module sw_test_cases
 

--- a/components/mpas-framework/src/core_sw/mpas_sw_time_integration.F
+++ b/components/mpas-framework/src/core_sw/mpas_sw_time_integration.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 module sw_time_integration
 

--- a/components/mpas-framework/src/core_test/mpas_test_core.F
+++ b/components/mpas-framework/src/core_test/mpas_test_core.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 module test_core
 

--- a/components/mpas-framework/src/core_test/mpas_test_core_field_tests.F
+++ b/components/mpas-framework/src/core_test/mpas_test_core_field_tests.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 !#define HALO_EXCH_DEBUG

--- a/components/mpas-framework/src/core_test/mpas_test_core_halo_exch.F
+++ b/components/mpas-framework/src/core_test/mpas_test_core_halo_exch.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 !#define HALO_EXCH_DEBUG

--- a/components/mpas-framework/src/core_test/mpas_test_core_interface.F
+++ b/components/mpas-framework/src/core_test/mpas_test_core_interface.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 module test_core_interface
 

--- a/components/mpas-framework/src/core_test/mpas_test_core_sorting.F
+++ b/components/mpas-framework/src/core_test/mpas_test_core_sorting.F
@@ -4,7 +4,7 @@
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the
 ! LICENSE file distributed with this code, or at
-! http://mpas-dev.github.com/license.html .
+! http://mpas-dev.github.io/license.html .
 !
 module test_core_sorting
 

--- a/components/mpas-framework/src/core_test/mpas_test_core_streams.F
+++ b/components/mpas-framework/src/core_test/mpas_test_core_streams.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 module test_core_streams
 

--- a/components/mpas-framework/src/core_test/mpas_test_core_timekeeping_tests.F
+++ b/components/mpas-framework/src/core_test/mpas_test_core_timekeeping_tests.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 module test_core_timekeeping_tests
 

--- a/components/mpas-framework/src/driver/mpas.F
+++ b/components/mpas-framework/src/driver/mpas.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 program mpas
 

--- a/components/mpas-framework/src/driver/mpas_subdriver.F
+++ b/components/mpas-framework/src/driver/mpas_subdriver.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 module mpas_subdriver
 

--- a/components/mpas-framework/src/external/ezxml/ezxml.c
+++ b/components/mpas-framework/src/external/ezxml/ezxml.c
@@ -3,7 +3,7 @@
 //
 // Unless noted otherwise source code is licensed under the BSD license.
 // Additional copyright and license information can be found in the LICENSE file
-// distributed with this code, or at http://mpas-dev.github.com/license.html
+// distributed with this code, or at http://mpas-dev.github.io/license.html
 //
 /* ezxml.c
  *

--- a/components/mpas-framework/src/external/ezxml/ezxml.h
+++ b/components/mpas-framework/src/external/ezxml/ezxml.h
@@ -3,7 +3,7 @@
 //
 // Unless noted otherwise source code is licensed under the BSD license.
 // Additional copyright and license information can be found in the LICENSE file
-// distributed with this code, or at http://mpas-dev.github.com/license.html
+// distributed with this code, or at http://mpas-dev.github.io/license.html
 //
 /* ezxml.h
  *

--- a/components/mpas-framework/src/framework/mpas_abort.F
+++ b/components/mpas-framework/src/framework/mpas_abort.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 module mpas_abort
 

--- a/components/mpas-framework/src/framework/mpas_attlist.F
+++ b/components/mpas-framework/src/framework/mpas_attlist.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !***********************************************************************
 !

--- a/components/mpas-framework/src/framework/mpas_block_creator.F
+++ b/components/mpas-framework/src/framework/mpas_block_creator.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !***********************************************************************
 !

--- a/components/mpas-framework/src/framework/mpas_block_decomp.F
+++ b/components/mpas-framework/src/framework/mpas_block_decomp.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !***********************************************************************
 !

--- a/components/mpas-framework/src/framework/mpas_bootstrapping.F
+++ b/components/mpas-framework/src/framework/mpas_bootstrapping.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 module mpas_bootstrapping
 

--- a/components/mpas-framework/src/framework/mpas_constants.F
+++ b/components/mpas-framework/src/framework/mpas_constants.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !***********************************************************************
 !

--- a/components/mpas-framework/src/framework/mpas_decomp.F
+++ b/components/mpas-framework/src/framework/mpas_decomp.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !-----------------------------------------------------------------------
 !  mpas_decomp

--- a/components/mpas-framework/src/framework/mpas_derived_types.F
+++ b/components/mpas-framework/src/framework/mpas_derived_types.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !***********************************************************************
 !

--- a/components/mpas-framework/src/framework/mpas_dmpar.F
+++ b/components/mpas-framework/src/framework/mpas_dmpar.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !-----------------------------------------------------------------------
 !  mpas_dmpar

--- a/components/mpas-framework/src/framework/mpas_domain_routines.F
+++ b/components/mpas-framework/src/framework/mpas_domain_routines.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !***********************************************************************
 !

--- a/components/mpas-framework/src/framework/mpas_field_accessor.F
+++ b/components/mpas-framework/src/framework/mpas_field_accessor.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 #define COMMA ,

--- a/components/mpas-framework/src/framework/mpas_field_routines.F
+++ b/components/mpas-framework/src/framework/mpas_field_routines.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !***********************************************************************
 !

--- a/components/mpas-framework/src/framework/mpas_framework.F
+++ b/components/mpas-framework/src/framework/mpas_framework.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !-----------------------------------------------------------------------
 !  mpas_framework

--- a/components/mpas-framework/src/framework/mpas_hash.F
+++ b/components/mpas-framework/src/framework/mpas_hash.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !***********************************************************************
 !

--- a/components/mpas-framework/src/framework/mpas_io.F
+++ b/components/mpas-framework/src/framework/mpas_io.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 module mpas_io
 

--- a/components/mpas-framework/src/framework/mpas_io_streams.F
+++ b/components/mpas-framework/src/framework/mpas_io_streams.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 module mpas_io_streams
 

--- a/components/mpas-framework/src/framework/mpas_io_units.F
+++ b/components/mpas-framework/src/framework/mpas_io_units.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !***********************************************************************
 !

--- a/components/mpas-framework/src/framework/mpas_kind_types.F
+++ b/components/mpas-framework/src/framework/mpas_kind_types.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !***********************************************************************
 !

--- a/components/mpas-framework/src/framework/mpas_log.F
+++ b/components/mpas-framework/src/framework/mpas_log.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-framework/src/framework/mpas_pool_routines.F
+++ b/components/mpas-framework/src/framework/mpas_pool_routines.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !***********************************************************************
 !

--- a/components/mpas-framework/src/framework/mpas_sort.F
+++ b/components/mpas-framework/src/framework/mpas_sort.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !***********************************************************************
 !

--- a/components/mpas-framework/src/framework/mpas_threading.F
+++ b/components/mpas-framework/src/framework/mpas_threading.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !-----------------------------------------------------------------------
 !  mpas_threading

--- a/components/mpas-framework/src/framework/mpas_timekeeping.F
+++ b/components/mpas-framework/src/framework/mpas_timekeeping.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 module mpas_timekeeping
 

--- a/components/mpas-framework/src/framework/mpas_timer.F
+++ b/components/mpas-framework/src/framework/mpas_timer.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !***********************************************************************
 !

--- a/components/mpas-framework/src/framework/random_id.c
+++ b/components/mpas-framework/src/framework/random_id.c
@@ -3,7 +3,7 @@
 //
 // Unless noted otherwise source code is licensed under the BSD license.
 // Additional copyright and license information can be found in the LICENSE file
-// distributed with this code, or at http://mpas-dev.github.com/license.html
+// distributed with this code, or at http://mpas-dev.github.io/license.html
 //
 
 #include <stdlib.h>

--- a/components/mpas-framework/src/framework/xml_stream_parser.c
+++ b/components/mpas-framework/src/framework/xml_stream_parser.c
@@ -3,7 +3,7 @@
 //
 // Unless noted otherwise source code is licensed under the BSD license.
 // Additional copyright and license information can be found in the LICENSE file
-// distributed with this code, or at http://mpas-dev.github.com/license.html
+// distributed with this code, or at http://mpas-dev.github.io/license.html
 //
 
 #include <stdio.h>

--- a/components/mpas-framework/src/operators/mpas_geometry_utils.F
+++ b/components/mpas-framework/src/operators/mpas_geometry_utils.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 module mpas_geometry_utils
 

--- a/components/mpas-framework/src/operators/mpas_matrix_operations.F
+++ b/components/mpas-framework/src/operators/mpas_matrix_operations.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-framework/src/operators/mpas_rbf_interpolation.F
+++ b/components/mpas-framework/src/operators/mpas_rbf_interpolation.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !***********************************************************************
 !

--- a/components/mpas-framework/src/operators/mpas_spline_interpolation.F
+++ b/components/mpas-framework/src/operators/mpas_spline_interpolation.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !***********************************************************************
 !

--- a/components/mpas-framework/src/operators/mpas_tensor_operations.F
+++ b/components/mpas-framework/src/operators/mpas_tensor_operations.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-framework/src/operators/mpas_tracer_advection_helpers.F
+++ b/components/mpas-framework/src/operators/mpas_tracer_advection_helpers.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-framework/src/operators/mpas_tracer_advection_mono.F
+++ b/components/mpas-framework/src/operators/mpas_tracer_advection_mono.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-framework/src/operators/mpas_tracer_advection_std.F
+++ b/components/mpas-framework/src/operators/mpas_tracer_advection_std.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-framework/src/operators/mpas_vector_operations.F
+++ b/components/mpas-framework/src/operators/mpas_vector_operations.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-framework/src/operators/mpas_vector_reconstruction.F
+++ b/components/mpas-framework/src/operators/mpas_vector_reconstruction.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !***********************************************************************
 !

--- a/components/mpas-framework/src/tools/input_gen/namelist_gen.c
+++ b/components/mpas-framework/src/tools/input_gen/namelist_gen.c
@@ -3,7 +3,7 @@
 //
 // Unless noted otherwise source code is licensed under the BSD license.
 // Additional copyright and license information can be found in the LICENSE file
-// distributed with this code, or at http://mpas-dev.github.com/license.html
+// distributed with this code, or at http://mpas-dev.github.io/license.html
 //
 #include <stdio.h>
 #include <stdlib.h>

--- a/components/mpas-framework/src/tools/input_gen/streams_gen.c
+++ b/components/mpas-framework/src/tools/input_gen/streams_gen.c
@@ -3,7 +3,7 @@
 //
 // Unless noted otherwise source code is licensed under the BSD license.
 // Additional copyright and license information can be found in the LICENSE file
-// distributed with this code, or at http://mpas-dev.github.com/license.html
+// distributed with this code, or at http://mpas-dev.github.io/license.html
 //
 #include <stdio.h>
 #include <stdlib.h>

--- a/components/mpas-framework/src/tools/input_gen/test_functions.c
+++ b/components/mpas-framework/src/tools/input_gen/test_functions.c
@@ -3,7 +3,7 @@
 //
 // Unless noted otherwise source code is licensed under the BSD license.
 // Additional copyright and license information can be found in the LICENSE file
-// distributed with this code, or at http://mpas-dev.github.com/license.html
+// distributed with this code, or at http://mpas-dev.github.io/license.html
 //
 
 #include <string.h>

--- a/components/mpas-framework/src/tools/input_gen/test_functions.h
+++ b/components/mpas-framework/src/tools/input_gen/test_functions.h
@@ -3,7 +3,7 @@
 //
 // Unless noted otherwise source code is licensed under the BSD license.
 // Additional copyright and license information can be found in the LICENSE file
-// distributed with this code, or at http://mpas-dev.github.com/license.html
+// distributed with this code, or at http://mpas-dev.github.io/license.html
 //
 
 #include "ezxml.h"

--- a/components/mpas-framework/src/tools/registry/dictionary.c
+++ b/components/mpas-framework/src/tools/registry/dictionary.c
@@ -3,7 +3,7 @@
 //
 // Unless noted otherwise source code is licensed under the BSD license.
 // Additional copyright and license information can be found in the LICENSE file
-// distributed with this code, or at http://mpas-dev.github.com/license.html
+// distributed with this code, or at http://mpas-dev.github.io/license.html
 //
 #include <stdlib.h>
 #include <string.h>

--- a/components/mpas-framework/src/tools/registry/dictionary.h
+++ b/components/mpas-framework/src/tools/registry/dictionary.h
@@ -3,7 +3,7 @@
 //
 // Unless noted otherwise source code is licensed under the BSD license.
 // Additional copyright and license information can be found in the LICENSE file
-// distributed with this code, or at http://mpas-dev.github.com/license.html
+// distributed with this code, or at http://mpas-dev.github.io/license.html
 //
 
 #define TABLESIZE 271

--- a/components/mpas-framework/src/tools/registry/fortprintf.c
+++ b/components/mpas-framework/src/tools/registry/fortprintf.c
@@ -3,7 +3,7 @@
 //
 // Unless noted otherwise source code is licensed under the BSD license.
 // Additional copyright and license information can be found in the LICENSE file
-// distributed with this code, or at http://mpas-dev.github.com/license.html
+// distributed with this code, or at http://mpas-dev.github.io/license.html
 //
 #include <stdio.h>
 #include <stdarg.h>

--- a/components/mpas-framework/src/tools/registry/fortprintf.h
+++ b/components/mpas-framework/src/tools/registry/fortprintf.h
@@ -3,7 +3,7 @@
 //
 // Unless noted otherwise source code is licensed under the BSD license.
 // Additional copyright and license information can be found in the LICENSE file
-// distributed with this code, or at http://mpas-dev.github.com/license.html
+// distributed with this code, or at http://mpas-dev.github.io/license.html
 //
 void fortprintf(FILE *, char *, ...);
 void fortprint_flush(FILE *);

--- a/components/mpas-framework/src/tools/registry/gen_inc.c
+++ b/components/mpas-framework/src/tools/registry/gen_inc.c
@@ -3,7 +3,7 @@
 //
 // Unless noted otherwise source code is licensed under the BSD license.
 // Additional copyright and license information can be found in the LICENSE file
-// distributed with this code, or at http://mpas-dev.github.com/license.html
+// distributed with this code, or at http://mpas-dev.github.io/license.html
 //
 #include <stdio.h>
 #include <stdlib.h>

--- a/components/mpas-framework/src/tools/registry/gen_inc.h
+++ b/components/mpas-framework/src/tools/registry/gen_inc.h
@@ -3,7 +3,7 @@
 //
 // Unless noted otherwise source code is licensed under the BSD license.
 // Additional copyright and license information can be found in the LICENSE file
-// distributed with this code, or at http://mpas-dev.github.com/license.html
+// distributed with this code, or at http://mpas-dev.github.io/license.html
 //
 //
 

--- a/components/mpas-framework/src/tools/registry/parse.c
+++ b/components/mpas-framework/src/tools/registry/parse.c
@@ -3,7 +3,7 @@
 //
 // Unless noted otherwise source code is licensed under the BSD license.
 // Additional copyright and license information can be found in the LICENSE file
-// distributed with this code, or at http://mpas-dev.github.com/license.html
+// distributed with this code, or at http://mpas-dev.github.io/license.html
 //
 #include <stdio.h>
 #include <stdlib.h>

--- a/components/mpas-framework/src/tools/registry/registry_types.h
+++ b/components/mpas-framework/src/tools/registry/registry_types.h
@@ -3,7 +3,7 @@
 //
 // Unless noted otherwise source code is licensed under the BSD license.
 // Additional copyright and license information can be found in the LICENSE file
-// distributed with this code, or at http://mpas-dev.github.com/license.html
+// distributed with this code, or at http://mpas-dev.github.io/license.html
 //
 #define INTEGER 0
 #define REAL 1

--- a/components/mpas-framework/src/tools/registry/utility.c
+++ b/components/mpas-framework/src/tools/registry/utility.c
@@ -3,7 +3,7 @@
 //
 // Unless noted otherwise source code is licensed under the BSD license.
 // Additional copyright and license information can be found in the LICENSE file
-// distributed with this code, or at http://mpas-dev.github.com/license.html
+// distributed with this code, or at http://mpas-dev.github.io/license.html
 //
 
 #include <stdio.h>

--- a/components/mpas-framework/src/tools/registry/utility.h
+++ b/components/mpas-framework/src/tools/registry/utility.h
@@ -3,7 +3,7 @@
 //
 // Unless noted otherwise source code is licensed under the BSD license.
 // Additional copyright and license information can be found in the LICENSE file
-// distributed with this code, or at http://mpas-dev.github.com/license.html
+// distributed with this code, or at http://mpas-dev.github.io/license.html
 //
 
 

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_TEMPLATE.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_TEMPLATE.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_analysis_driver.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_analysis_driver.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_conservation_check.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_conservation_check.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_debug_diagnostics.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_debug_diagnostics.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_eddy_product_variables.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_eddy_product_variables.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_eliassen_palm.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_eliassen_palm.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_global_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_global_stats.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_harmonic_analysis.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_harmonic_analysis.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_high_frequency_output.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_high_frequency_output.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_lagrangian_particle_tracking.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_lagrangian_particle_tracking.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_lagrangian_particle_tracking_interpolations.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_lagrangian_particle_tracking_interpolations.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !***********************************************************************
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_lagrangian_particle_tracking_reset.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_lagrangian_particle_tracking_reset.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !***********************************************************************
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_layer_volume_weighted_averages.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_layer_volume_weighted_averages.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_meridional_heat_transport.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_meridional_heat_transport.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_heat_budget.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_heat_budget.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_moc_streamfunction.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_moc_streamfunction.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_ocean_heat_content.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_ocean_heat_content.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_okubo_weiss.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_okubo_weiss.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_okubo_weiss_eigenvalues.c
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_okubo_weiss_eigenvalues.c
@@ -4,7 +4,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_particle_list.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_particle_list.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_pointwise_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_pointwise_stats.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_regional_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_regional_stats.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_rpn_calculator.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_rpn_calculator.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_sediment_flux_index.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_sediment_flux_index.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_sediment_transport.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_sediment_transport.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_surface_area_weighted_averages.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_surface_area_weighted_averages.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_test_compute_interval.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_test_compute_interval.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_time_filters.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_time_filters.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_time_series_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_time_series_stats.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_transect_transport.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_transect_transport.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_water_mass_census.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_water_mass_census.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_zonal_mean.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_zonal_mean.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/driver/mpas_ocn_core.F
+++ b/components/mpas-ocean/src/driver/mpas_ocn_core.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/driver/mpas_ocn_core_interface.F
+++ b/components/mpas-ocean/src/driver/mpas_ocn_core_interface.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 module ocn_core_interface
 

--- a/components/mpas-ocean/src/mode_analysis/mpas_ocn_analysis_mode.F
+++ b/components/mpas-ocean/src/mode_analysis/mpas_ocn_analysis_mode.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_TEMPLATE.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_TEMPLATE.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_baroclinic_channel.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_baroclinic_channel.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_cell_markers.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_cell_markers.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_cosine_bell.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_cosine_bell.F
@@ -5,7 +5,7 @@
 ! Additional copyright and license information can be found in the
 ! LICENSE file
 ! distributed with this code, or at
-! http://mpas-dev.github.com/license.html
+! http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_cvmix_WSwSBF.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_cvmix_WSwSBF.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_dam_break.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_dam_break.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_ecosys_column.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_ecosys_column.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_hurricane.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_hurricane.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_internal_waves.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_internal_waves.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_interpolation.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_interpolation.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_iso.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_iso.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_isomip.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_isomip.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_isomip_plus.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_isomip_plus.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_lock_exchange.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_lock_exchange.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_mixed_layer_eddy.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_mixed_layer_eddy.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_mode.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_mode.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_overflow.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_overflow.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_periodic_planar.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_periodic_planar.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_sea_mount.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_sea_mount.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_smoothing.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_smoothing.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_soma.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_soma.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_spherical_utils.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_spherical_utils.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_ssh_and_landIcePressure.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_ssh_and_landIcePressure.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_sub_ice_shelf_2D.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_sub_ice_shelf_2D.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_test_sht.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_test_sht.F
@@ -5,7 +5,7 @@
 ! Additional copyright and license information can be found in the
 ! LICENSE file
 ! distributed with this code, or at
-! http://mpas-dev.github.com/license.html
+! http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_tidal_boundary.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_tidal_boundary.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_transport_tests.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_transport_tests.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_vertical_grids.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_vertical_grids.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_ziso.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_ziso.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_config.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_config.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_constants.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_constants.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 module ocn_eddy_parameterization_helpers

--- a/components/mpas-ocean/src/shared/mpas_ocn_effective_density_in_land_ice.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_effective_density_in_land_ice.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_equation_of_state.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_equation_of_state.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_equation_of_state_jm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_equation_of_state_jm.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_equation_of_state_linear.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_equation_of_state_linear.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_equation_of_state_wright.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_equation_of_state_wright.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_forcing.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_framework_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_framework_forcing.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 module ocn_gm
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_high_freq_thickness_hmix_del2.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_high_freq_thickness_hmix_del2.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_init_routines.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_init_routines.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_mesh.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_mesh.F
@@ -6,7 +6,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 
 module ocn_submesoscale_eddies

--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_test.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_test.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_thick_ale.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_thick_ale.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_thick_hadv.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_thick_hadv.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_thick_surface_flux.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_thick_surface_flux.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_thick_vadv.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_thick_vadv.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tidal_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tidal_forcing.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_time_average_coupled.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_time_average_coupled.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_CFC.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_CFC.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_DMS.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_DMS.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_MacroMolecules.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_MacroMolecules.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_TTD.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_TTD.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_mono.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_mono.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_shared.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_shared.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_std.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_std.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_vert.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_advection_vert.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_ecosys.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_ecosys.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_exponential_decay.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_exponential_decay.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del2.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del2.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del4.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_del4.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_ideal_age.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_ideal_age.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_interior_restoring.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_interior_restoring.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_nonlocalflux.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_nonlocalflux.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_surface_flux_to_tend.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_surface_flux_to_tend.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_surface_restoring.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_surface_restoring.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_explicit_bottom_drag.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_explicit_bottom_drag.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_surface_stress.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_surface_stress.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_hadv_coriolis.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_hadv_coriolis.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix_del2.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix_del2.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix_del4.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix_del4.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix_leith.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix_leith.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_pressure_grad.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_pressure_grad.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_tidal_potential.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_tidal_potential.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_vadv.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_vadv.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_vertical_advection.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vertical_advection.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_vertical_regrid.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vertical_regrid.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_vertical_remap.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vertical_remap.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_wetting_drying.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_wetting_drying.F
@@ -3,7 +3,7 @@
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.com/license.html
+! distributed with this code, or at http://mpas-dev.github.io/license.html
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !


### PR DESCRIPTION
Until 2021 github supported the alternate web address `github.com`. In 2021 it changed exclusively to `github.io`. This PR updates the link to the MPAS license on all MPAS headers. It only changes code comments, not working code.

[BFB]