### PR TITLE
Updates a MOSART test

### DIFF
--- a/components/mosart/cime_config/testdefs/testmods_dirs/mosart/rof_ocn_2way/shell_commands
+++ b/components/mosart/cime_config/testdefs/testmods_dirs/mosart/rof_ocn_2way/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange DATM_CLMNCEP_YR_END=1972


### PR DESCRIPTION
The DATM_CLMNCEP_YR_END of the two-way river-ocean test is updated to avoid downloading
large number of netcdf files that are not needed for the test.

[BFB]