### PR TITLE
[MPAS-Framework] New fill value mask feature

### DIFF
--- a/components/mpas-framework/src/framework/Makefile
+++ b/components/mpas-framework/src/framework/Makefile
@@ -67,7 +67,7 @@ mpas_derived_types.o: mpas_kind_types.o mpas_constants.o $(TYPE_DEPS)
 
 mpas_domain_routines.o: mpas_derived_types.o mpas_pool_routines.o mpas_dmpar.o
 
-mpas_field_routines.o: mpas_derived_types.o duplicate_field_array.inc duplicate_field_scalar.inc mpas_threading.o mpas_attlist.o
+mpas_field_routines.o: mpas_derived_types.o duplicate_field_array.inc duplicate_field_scalar.inc mpas_threading.o mpas_attlist.o mpas_log.o
 
 mpas_pool_routines.o: mpas_derived_types.o mpas_field_routines.o mpas_threading.o mpas_log.o
 

--- a/components/mpas-framework/src/framework/duplicate_field_array.inc
+++ b/components/mpas-framework/src/framework/duplicate_field_array.inc
@@ -48,8 +48,8 @@
                dst_cursor % hasTimeDimension = src_cursor % hasTimeDimension
                dst_cursor % dimNames = src_cursor % dimNames
                dst_cursor % dimSizes = src_cursor % dimSizes
-	       dst_cursor % maskName = src_cursor % maskName
-	       dst_cursor % missingValue = src_cursor % missingValue
+               dst_cursor % maskName = src_cursor % maskName
+               dst_cursor % missingValue = src_cursor % missingValue
                dst_cursor % sendList => src_cursor % sendList
                dst_cursor % recvList => src_cursor % recvList
                dst_cursor % copyList => src_cursor % copyList

--- a/components/mpas-framework/src/framework/duplicate_field_array.inc
+++ b/components/mpas-framework/src/framework/duplicate_field_array.inc
@@ -48,6 +48,8 @@
                dst_cursor % hasTimeDimension = src_cursor % hasTimeDimension
                dst_cursor % dimNames = src_cursor % dimNames
                dst_cursor % dimSizes = src_cursor % dimSizes
+	       dst_cursor % maskName = src_cursor % maskName
+	       dst_cursor % missingValue = src_cursor % missingValue
                dst_cursor % sendList => src_cursor % sendList
                dst_cursor % recvList => src_cursor % recvList
                dst_cursor % copyList => src_cursor % copyList

--- a/components/mpas-framework/src/framework/mpas_bootstrapping.F
+++ b/components/mpas-framework/src/framework/mpas_bootstrapping.F
@@ -656,50 +656,50 @@ module mpas_bootstrapping
                         else
                            call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
                         endif
-                     else if ( fieldInfo % nDims == 4 ) then
-                        call mpas_log_write('looking for mask for 4d field '//TRIM(fieldName))
-                        call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real4DField)
-                        maskName = real4dField % maskName
-                        call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
-                        if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
-                           call mpas_log_write('retrieved mask '//trim(maskName)//' for 4d field '//TRIM(fieldName))
-                           if ( maskInfo % nDims == 3 ) then
-                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int3DMask)
-                              call mpas_mask_assign_pointer(real4DField, int3DMask)
-                           elseif ( maskInfo % nDims == 2 ) then
-                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
-                              call mpas_mask_assign_pointer(real4DField, int2DMask)
-                           elseif ( maskInfo % nDims == 1 ) then
-                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
-                              call mpas_mask_assign_pointer(real4DField, int1DMask)
-                           else
-                              call mpas_log_write(TRIM(fieldName)//' does not have 1d, 2d or 3d mask type '//TRIM(maskName))
-                           endif
-                        else
-                           call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
-                        endif
-                     else if ( fieldInfo % nDims == 5 ) then
-                        call mpas_log_write('looking for mask for 5d field '//TRIM(fieldName))
-                        call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real5DField)
-                        maskName = real5dField % maskName
-                        call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
-                        if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
-                           call mpas_log_write('retrieved mask '//trim(maskName)//' for 5d field '//TRIM(fieldName))
-                           if ( maskInfo % nDims == 3 ) then
-                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int3DMask)
-                              call mpas_mask_assign_pointer(real5DField, int3DMask)
-                           elseif ( maskInfo % nDims == 2 ) then
-                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
-                              call mpas_mask_assign_pointer(real5DField, int2DMask)
-                           elseif ( maskInfo % nDims == 1 ) then
-                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
-                              call mpas_mask_assign_pointer(real5DField, int1DMask)
-                           else
-                              call mpas_log_write(TRIM(fieldName)//' does not have 1d, 2d or 3d mask type '//TRIM(maskName))
-                           endif
-                        else
-                           call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
-                        endif
+                     !else if ( fieldInfo % nDims == 4 ) then
+                     !   call mpas_log_write('looking for mask for 4d field '//TRIM(fieldName))
+                     !   call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real4DField)
+                     !   maskName = real4dField % maskName
+                     !   call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
+                     !   if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
+                     !      call mpas_log_write('retrieved mask '//trim(maskName)//' for 4d field '//TRIM(fieldName))
+                     !      if ( maskInfo % nDims == 3 ) then
+                     !         call mpas_pool_get_field(domain % blocklist % allFields, maskName, int3DMask)
+                     !         call mpas_mask_assign_pointer(real4DField, int3DMask)
+                     !      elseif ( maskInfo % nDims == 2 ) then
+                     !         call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
+                     !         call mpas_mask_assign_pointer(real4DField, int2DMask)
+                     !      elseif ( maskInfo % nDims == 1 ) then
+                     !         call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
+                     !         call mpas_mask_assign_pointer(real4DField, int1DMask)
+                     !      else
+                     !         call mpas_log_write(TRIM(fieldName)//' does not have 1d, 2d or 3d mask type '//TRIM(maskName))
+                     !      endif
+                     !   else
+                     !      call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
+                     !   endif
+                     !else if ( fieldInfo % nDims == 5 ) then
+                     !   call mpas_log_write('looking for mask for 5d field '//TRIM(fieldName))
+                     !   call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real5DField)
+                     !   maskName = real5dField % maskName
+                     !   call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
+                     !   if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
+                     !      call mpas_log_write('retrieved mask '//trim(maskName)//' for 5d field '//TRIM(fieldName))
+                     !      if ( maskInfo % nDims == 3 ) then
+                     !         call mpas_pool_get_field(domain % blocklist % allFields, maskName, int3DMask)
+                     !         call mpas_mask_assign_pointer(real5DField, int3DMask)
+                     !      elseif ( maskInfo % nDims == 2 ) then
+                     !         call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
+                     !         call mpas_mask_assign_pointer(real5DField, int2DMask)
+                     !      elseif ( maskInfo % nDims == 1 ) then
+                     !         call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
+                     !         call mpas_mask_assign_pointer(real5DField, int1DMask)
+                     !      else
+                     !         call mpas_log_write(TRIM(fieldName)//' does not have 1d, 2d or 3d mask type '//TRIM(maskName))
+                     !      endif
+                     !   else
+                     !      call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
+                     !   endif
                      end if
                   endif
                endif

--- a/components/mpas-framework/src/framework/mpas_bootstrapping.F
+++ b/components/mpas-framework/src/framework/mpas_bootstrapping.F
@@ -584,204 +584,253 @@ module mpas_bootstrapping
       call mpas_log_write(' ')
       call mpas_log_write(' ')
 
-      ! TODO Point missingValueMask to the requested field for each field variable
+      ! Point missingValueMask to the requested field for each field variable
       call mpas_stream_mgr_begin_iteration(domain % streamManager)
-      do while ( mpas_stream_mgr_get_next_stream(domain % streamManager, streamID = streamName, directionProperty = streamDirection, &
+      do while ( mpas_stream_mgr_get_next_stream(domain % streamManager, &
+                                                 streamID = streamName, &
+                                                 directionProperty = streamDirection, &
                                                  activeProperty = streamActive) )
 
-         if ( streamActive .and. ( streamDirection == MPAS_STREAM_OUTPUT .or. streamDirection == MPAS_STREAM_INPUT_OUTPUT ) ) then
+         if ( streamActive .and. &
+              ( streamDirection == MPAS_STREAM_OUTPUT .or. &
+                streamDirection == MPAS_STREAM_INPUT_OUTPUT ) ) then
 
-            call mpas_stream_mgr_begin_iteration(domain % streamManager, streamID=streamName)
+            call mpas_stream_mgr_begin_iteration(domain % streamManager, &
+                                                 streamID=streamName)
 
-            do while ( mpas_stream_mgr_get_next_field(domain % streamManager, streamName, fieldName, isActive=fieldActive) )
+            do while ( mpas_stream_mgr_get_next_field(domain % streamManager, &
+                                                      streamName, fieldName, &
+                                                      isActive=fieldActive) )
 
                if (fieldActive) then
-                  call mpas_pool_get_field_info(domain % blocklist % allFields, fieldName, fieldInfo)
+                  call mpas_pool_get_field_info(domain % blocklist % allFields, &
+                                                fieldName, fieldInfo)
                   if ( fieldInfo % fieldType == MPAS_POOL_REAL ) then
 
                      if ( fieldInfo % nDims == 1 ) then
-                        call mpas_log_write('looking for mask for 1d field '//TRIM(fieldName))
-                        call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real1DField)
+                        call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                 fieldName, real1DField)
                         maskName = real1DField % maskName
-                        call mpas_log_write('retrieved mask '//trim(maskName)//' for 1d field '//TRIM(fieldName))
-                        call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
-                        if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
-                           if ( maskInfo % nDims == 1 ) then
-                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
-                              call mpas_mask_assign_pointer(real1DField, int1DMask)
+                        call mpas_pool_get_field_info(domain % blocklist % allFields, &
+                                                      maskName, maskInfo)
+                        if ( maskInfo % isActive ) then
+                           if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
+                              if ( maskInfo % nDims == 1 ) then
+                                 call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                          maskName, int1DMask)
+                                 call mpas_mask_assign_pointer(real1DField, int1DMask)
+                              else
+                                 call mpas_log_write(TRIM(fieldName)//&
+                                    ' does not have 1d mask type '//TRIM(maskName), &
+                                    MPAS_LOG_WARN)
+                              endif
                            else
-                              call mpas_log_write(TRIM(fieldName)//' does not have 1d mask type '//TRIM(maskName))
+                              call mpas_log_write(TRIM(fieldName)//&
+                                 ' does not have an integer mask type '//TRIM(maskName), &
+                                 MPAS_LOG_WARN)
                            endif
-                        else
-                           call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
                         endif
                      elseif ( fieldInfo % nDims == 2 ) then
-                        call mpas_log_write('looking for mask for 2d field '//TRIM(fieldName))
-                        call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real2DField)
+                        call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                 fieldName, real2DField)
                         maskName = real2DField % maskName
-                        call mpas_log_write('retrieved mask '//trim(maskName)//' for 2d field '//TRIM(fieldName))
-                        call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
-                        if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
-                           if ( maskInfo % nDims == 2 ) then
-                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
-                              call mpas_mask_assign_pointer(real2DField, int2DMask)
-                           elseif ( maskInfo % nDims == 1 ) then
-                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
-                              call mpas_mask_assign_pointer(real2DField, int1DMask)
+                        call mpas_pool_get_field_info(domain % blocklist % allFields, &
+                                                      maskName, maskInfo)
+                        if ( maskInfo % isActive ) then
+                           if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
+                              if ( maskInfo % nDims == 2 ) then
+                                 call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                          maskName, int2DMask)
+                                 call mpas_mask_assign_pointer(real2DField, int2DMask)
+                              elseif ( maskInfo % nDims == 1 ) then
+                                 call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                          maskName, int1DMask)
+                                 call mpas_mask_assign_pointer(real2DField, int1DMask)
+                              else
+                                 call mpas_log_write(TRIM(fieldName)//&
+                                    ' does not have 1d or 2d mask type '//TRIM(maskName), &
+                                    MPAS_LOG_WARN)
+                              endif
                            else
-                              call mpas_log_write(TRIM(fieldName)//' does not have 1d or 2d mask type '//TRIM(maskName))
+                              call mpas_log_write(TRIM(fieldName)//&
+                                 ' does not have an integer mask type '//TRIM(maskName), &
+                                    MPAS_LOG_WARN)
                            endif
-                        else
-                           call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
                         endif
                      else if ( fieldInfo % nDims == 3 ) then
-                        call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real3DField)
-                        if (real3DField % isVarArray) then
-                           call mpas_log_write('looking for mask for 3d array '//TRIM(fieldName))
-                           maskName = real3DField % maskName
-                           call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
+                        call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                 fieldName, real3DField)
+                        maskName = real3DField % maskName
+                        call mpas_pool_get_field_info(domain % blocklist % allFields, &
+                                                      maskName, maskInfo)
+                        if ( maskInfo % isActive ) then
                            if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
-                              call mpas_log_write('retrieved mask info'//trim(maskName)//' for 3d array '//TRIM(fieldName))
-                              do j = 1, size(real3DField % constituentNames)
-                                 call mpas_pool_get_field(domain % blocklist % allFields, &
-                                                          real3DField % constituentNames(j), &
-                                                          real2DField)
-                                 call mpas_log_write('retrieved field'//trim(real3DField % constituentNames(j))//' from 3d field '//TRIM(fieldName))
-                                 fieldName = real3DField % constituentNames(j)
-                                 call mpas_pool_get_field_info(domain % blocklist % allFields, fieldName, fieldInfo)
-                                 if ( maskInfo % nDims == 2 ) then
-                                    call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
-                                    call mpas_log_write('retrieved mask'//trim(maskName)//' for 2d field '//TRIM(fieldName))
-                                    call mpas_log_write('call assign_pointer')
+                              if (real3DField % isVarArray) then
+                                 do j = 1, size(real3DField % constituentNames)
+                                    call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                             real3DField % constituentNames(j), &
+                                                             real2DField)
+                                    fieldName = real3DField % constituentNames(j)
+                                    call mpas_pool_get_field_info(domain % blocklist % allFields, &
+                                                                  fieldName, fieldInfo)
+                                    if ( maskInfo % nDims == 2 ) then
+                                       call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                                maskName, int2DMask)
+                                       call mpas_mask_assign_pointer(real3DField, int2DMask)
+                                    elseif ( maskInfo % nDims == 1 ) then
+                                       call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                                maskName, int1DMask)
+                                       call mpas_mask_assign_pointer(real3DField, int1DMask)
+                                    else
+                                       call mpas_log_write(TRIM(fieldName)//&
+                                          ' does not have 1d or 2d mask type '//TRIM(maskName), &
+                                          MPAS_LOG_WARN)
+                                    endif
+                                 enddo
+                              else ! isVar
+                                 if ( maskInfo % nDims == 3 ) then
+                                    call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                             maskName, int3DMask)
+                                    call mpas_mask_assign_pointer(real3DField, int3DMask)
+                                 elseif ( maskInfo % nDims == 2 ) then
+                                    call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                             maskName, int2DMask)
                                     call mpas_mask_assign_pointer(real3DField, int2DMask)
                                  elseif ( maskInfo % nDims == 1 ) then
-                                    call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
+                                    call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                             maskName, int1DMask)
                                     call mpas_mask_assign_pointer(real3DField, int1DMask)
                                  else
-                                    call mpas_log_write(TRIM(fieldName)//' does not have 1d or 2d mask type '//TRIM(maskName))
+                                    call mpas_log_write(TRIM(fieldName)//&
+                                       ' does not have 1d, 2d or 3d mask type '//TRIM(maskName), &
+                                       MPAS_LOG_WARN)
                                  endif
-                              enddo
-                           else
-                              call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
-                           endif
-                        else
-                           call mpas_log_write('looking for mask for 3d field '//TRIM(fieldName))
-                           maskName = real3DField % maskName
-                           call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
-                           if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
-                              call mpas_log_write('retrieved mask '//trim(maskName)//' for 3d field '//TRIM(fieldName))
-                              if ( maskInfo % nDims == 3 ) then
-                                 call mpas_pool_get_field(domain % blocklist % allFields, maskName, int3DMask)
-                                 call mpas_mask_assign_pointer(real3DField, int3DMask)
-                              elseif ( maskInfo % nDims == 2 ) then
-                                 call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
-                                 call mpas_mask_assign_pointer(real3DField, int2DMask)
-                              elseif ( maskInfo % nDims == 1 ) then
-                                 call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
-                                 call mpas_mask_assign_pointer(real3DField, int1DMask)
-                              else
-                                 call mpas_log_write(TRIM(fieldName)//' does not have 1d, 2d or 3d mask type '//TRIM(maskName))
                               endif
                            else
-                              call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
+                              call mpas_log_write(TRIM(fieldName)//&
+                                 ' does not have an integer mask type '//TRIM(maskName), &
+                                 MPAS_LOG_WARN)
                            endif
-                        endif
+                        endif ! mask is active
                      else if ( fieldInfo % nDims == 4 ) then
-                        call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real4DField)
-                        if (real4DField % isVarArray) then
-                           maskName = real4DField % maskName
-                           call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
+                        call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                 fieldName, real4DField)
+                        maskName = real4DField % maskName
+                        call mpas_pool_get_field_info(domain % blocklist % allFields, &
+                                                      maskName, maskInfo)
+                        if ( maskInfo % isActive ) then
                            if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
-                              do j = 1, size(real4DField % constituentNames)
-                                 call mpas_pool_get_field(domain % blocklist % allFields, &
-                                                          real4DField % constituentNames(j), &
-                                                          real3DField)
-                                 fieldName = real4DField % constituentNames(j)
-                                 call mpas_pool_get_field_info(domain % blocklist % allFields, fieldName, fieldInfo)
+                              if (real4DField % isVarArray) then
+                                 do j = 1, size(real4DField % constituentNames)
+                                    call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                             real4DField % constituentNames(j), &
+                                                             real3DField)
+                                    fieldName = real4DField % constituentNames(j)
+                                    call mpas_pool_get_field_info(domain % blocklist % allFields, &
+                                                                  fieldName, fieldInfo)
+                                    if ( maskInfo % nDims == 3 ) then
+                                       call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                                maskName, int3DMask)
+                                       call mpas_mask_assign_pointer(real4DField, int3DMask)
+                                    elseif ( maskInfo % nDims == 2 ) then
+                                       call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                                maskName, int2DMask)
+                                       call mpas_mask_assign_pointer(real4DField, int2DMask)
+                                    elseif ( maskInfo % nDims == 1 ) then
+                                       call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                                maskName, int1DMask)
+                                       call mpas_mask_assign_pointer(real4DField, int1DMask)
+                                    else
+                                       call mpas_log_write(TRIM(fieldName)//&
+                                          ' does not have 1d, 2d or 3d mask type '//TRIM(maskName), &
+                                          MPAS_LOG_WARN)
+                                    endif
+                                 enddo
+                              else ! isVar
                                  if ( maskInfo % nDims == 3 ) then
-                                    call mpas_pool_get_field(domain % blocklist % allFields, maskName, int3DMask)
+                                    call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                             maskName, int3DMask)
                                     call mpas_mask_assign_pointer(real4DField, int3DMask)
-                                 if ( maskInfo % nDims == 2 ) then
-                                    call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
+                                 elseif ( maskInfo % nDims == 2 ) then
+                                    call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                             maskName, int2DMask)
                                     call mpas_mask_assign_pointer(real4DField, int2DMask)
                                  elseif ( maskInfo % nDims == 1 ) then
-                                    call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
+                                    call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                             maskName, int1DMask)
                                     call mpas_mask_assign_pointer(real4DField, int1DMask)
                                  else
-                                    call mpas_log_write(TRIM(fieldName)//' does not have 1d, 2d or 3d mask type '//TRIM(maskName))
+                                    call mpas_log_write(TRIM(fieldName)//&
+                                       ' does not have 1d, 2d or 3d mask type '//TRIM(maskName), &
+                                       MPAS_LOG_WARN)
                                  endif
-                              enddo
-                           else
-                              call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
-                           endif
-                        else
-                           maskName = real4DField % maskName
-                           call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
-                           if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
-                              if ( maskInfo % nDims == 3 ) then
-                                 call mpas_pool_get_field(domain % blocklist % allFields, maskName, int3DMask)
-                                 call mpas_mask_assign_pointer(real4DField, int3DMask)
-                              elseif ( maskInfo % nDims == 2 ) then
-                                 call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
-                                 call mpas_mask_assign_pointer(real4DField, int2DMask)
-                              elseif ( maskInfo % nDims == 1 ) then
-                                 call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
-                                 call mpas_mask_assign_pointer(real4DField, int1DMask)
-                              else
-                                 call mpas_log_write(TRIM(fieldName)//' does not have 1d, 2d or 3d mask type '//TRIM(maskName))
                               endif
                            else
-                              call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
+                              call mpas_log_write(TRIM(fieldName)//&
+                                 ' does not have an integer mask type '//TRIM(maskName), &
+                                 MPAS_LOG_WARN)
                            endif
                         endif
                      else if ( fieldInfo % nDims == 5 ) then
-                        call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real5DField)
-                        if (real5DField % isVarArray) then
-                           maskName = real5DField % maskName
-                           call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
+                        call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                 fieldName, real5DField)
+                        maskName = real5DField % maskName
+                        call mpas_pool_get_field_info(domain % blocklist % allFields, &
+                                                      maskName, maskInfo)
+                        if ( maskInfo % isActive ) then
                            if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
-                              do j = 1, size(real5DField % constituentNames)
-                                 call mpas_pool_get_field(domain % blocklist % allFields, &
-                                                          real5DField % constituentNames(j), &
-                                                          real3DField)
-                                 fieldName = real5DField % constituentNames(j)
-                                 call mpas_pool_get_field_info(domain % blocklist % allFields, fieldName, fieldInfo)
+                              if (real5DField % isVarArray) then
+                                 do j = 1, size(real5DField % constituentNames)
+                                    call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                             real5DField % constituentNames(j), &
+                                                             real3DField)
+                                    fieldName = real5DField % constituentNames(j)
+                                    call mpas_pool_get_field_info(domain % blocklist % allFields, &
+                                                                  fieldName, fieldInfo)
+                                    if ( maskInfo % nDims == 3 ) then
+                                       call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                                maskName, int3DMask)
+                                       call mpas_mask_assign_pointer(real5DField, int3DMask)
+                                    elseif ( maskInfo % nDims == 2 ) then
+                                       call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                                maskName, int2DMask)
+                                       call mpas_mask_assign_pointer(real5DField, int2DMask)
+                                    elseif ( maskInfo % nDims == 1 ) then
+                                       call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                                maskName, int1DMask)
+                                       call mpas_mask_assign_pointer(real5DField, int1DMask)
+                                    else
+                                       call mpas_log_write(TRIM(fieldName)//&
+                                          ' does not have 1d, 2d or 3d mask type '//TRIM(maskName), &
+                                          MPAS_LOG_WARN)
+                                    endif
+                                 enddo
+                              else ! isVar
                                  if ( maskInfo % nDims == 3 ) then
-                                    call mpas_pool_get_field(domain % blocklist % allFields, maskName, int3DMask)
+                                    call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                             maskName, int3DMask)
                                     call mpas_mask_assign_pointer(real5DField, int3DMask)
-                                 if ( maskInfo % nDims == 2 ) then
-                                    call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
+                                 elseif ( maskInfo % nDims == 2 ) then
+                                    call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                             maskName, int2DMask)
                                     call mpas_mask_assign_pointer(real5DField, int2DMask)
                                  elseif ( maskInfo % nDims == 1 ) then
-                                    call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
+                                    call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                             maskName, int1DMask)
                                     call mpas_mask_assign_pointer(real5DField, int1DMask)
                                  else
-                                    call mpas_log_write(TRIM(fieldName)//' does not have 1d, 2d or 3d mask type '//TRIM(maskName))
+                                    call mpas_log_write(TRIM(fieldName)//&
+                                       ' does not have 1d, 2d or 3d mask type '//TRIM(maskName), &
+                                       MPAS_LOG_WARN)
                                  endif
-                              enddo
-                           else
-                              call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
-                           endif
-                        else
-                           maskName = real5DField % maskName
-                           call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
-                           if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
-                              if ( maskInfo % nDims == 3 ) then
-                                 call mpas_pool_get_field(domain % blocklist % allFields, maskName, int3DMask)
-                                 call mpas_mask_assign_pointer(real5DField, int3DMask)
-                              elseif ( maskInfo % nDims == 2 ) then
-                                 call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
-                                 call mpas_mask_assign_pointer(real5DField, int2DMask)
-                              elseif ( maskInfo % nDims == 1 ) then
-                                 call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
-                                 call mpas_mask_assign_pointer(real5DField, int1DMask)
-                              else
-                                 call mpas_log_write(TRIM(fieldName)//' does not have 1d, 2d or 3d mask type '//TRIM(maskName))
                               endif
                            else
-                              call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
+                              call mpas_log_write(TRIM(fieldName)//&
+                                 ' does not have an integer mask type '//TRIM(maskName), &
+                                 MPAS_LOG_WARN)
                            endif
-                     end if
+                        endif
+                     endif
                   endif
                endif
             enddo

--- a/components/mpas-framework/src/framework/mpas_bootstrapping.F
+++ b/components/mpas-framework/src/framework/mpas_bootstrapping.F
@@ -649,19 +649,14 @@ module mpas_bootstrapping
                                  call mpas_log_write('retrieved field'//trim(real3DField % constituentNames(j))//' from 3d field '//TRIM(fieldName))
                                  fieldName = real3DField % constituentNames(j)
                                  call mpas_pool_get_field_info(domain % blocklist % allFields, fieldName, fieldInfo)
-                                 !call mpas_log_write('real2DField nDims'//trim(fieldInfo%nDims))
                                  if ( maskInfo % nDims == 2 ) then
                                     call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
                                     call mpas_log_write('retrieved mask'//trim(maskName)//' for 2d field '//TRIM(fieldName))
-                                    !call mpas_log_write('retrieved mask'//trim(int2DMask%fieldName))
-                                    !call mpas_log_write('        for 2d field'//TRIM(real2DField%fieldName))
                                     call mpas_log_write('call assign_pointer')
                                     call mpas_mask_assign_pointer(real3DField, int2DMask)
-                                    !call mpas_mask_assign_pointer(real2DField, int2DMask)
                                  elseif ( maskInfo % nDims == 1 ) then
                                     call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
                                     call mpas_mask_assign_pointer(real3DField, int1DMask)
-                                    !call mpas_mask_assign_pointer(real2DField, int1DMask)
                                  else
                                     call mpas_log_write(TRIM(fieldName)//' does not have 1d or 2d mask type '//TRIM(maskName))
                                  endif
@@ -691,50 +686,101 @@ module mpas_bootstrapping
                               call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
                            endif
                         endif
-                     !else if ( fieldInfo % nDims == 4 ) then
-                     !   call mpas_log_write('looking for mask for 4d field '//TRIM(fieldName))
-                     !   call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real4DField)
-                     !   maskName = real4DField % maskName
-                     !   call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
-                     !   if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
-                     !      call mpas_log_write('retrieved mask '//trim(maskName)//' for 4d field '//TRIM(fieldName))
-                     !      if ( maskInfo % nDims == 3 ) then
-                     !         call mpas_pool_get_field(domain % blocklist % allFields, maskName, int3DMask)
-                     !         call mpas_mask_assign_pointer(real4DField, int3DMask)
-                     !      elseif ( maskInfo % nDims == 2 ) then
-                     !         call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
-                     !         call mpas_mask_assign_pointer(real4DField, int2DMask)
-                     !      elseif ( maskInfo % nDims == 1 ) then
-                     !         call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
-                     !         call mpas_mask_assign_pointer(real4DField, int1DMask)
-                     !      else
-                     !         call mpas_log_write(TRIM(fieldName)//' does not have 1d, 2d or 3d mask type '//TRIM(maskName))
-                     !      endif
-                     !   else
-                     !      call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
-                     !   endif
-                     !else if ( fieldInfo % nDims == 5 ) then
-                     !   call mpas_log_write('looking for mask for 5d field '//TRIM(fieldName))
-                     !   call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real5DField)
-                     !   maskName = real5DField % maskName
-                     !   call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
-                     !   if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
-                     !      call mpas_log_write('retrieved mask '//trim(maskName)//' for 5d field '//TRIM(fieldName))
-                     !      if ( maskInfo % nDims == 3 ) then
-                     !         call mpas_pool_get_field(domain % blocklist % allFields, maskName, int3DMask)
-                     !         call mpas_mask_assign_pointer(real5DField, int3DMask)
-                     !      elseif ( maskInfo % nDims == 2 ) then
-                     !         call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
-                     !         call mpas_mask_assign_pointer(real5DField, int2DMask)
-                     !      elseif ( maskInfo % nDims == 1 ) then
-                     !         call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
-                     !         call mpas_mask_assign_pointer(real5DField, int1DMask)
-                     !      else
-                     !         call mpas_log_write(TRIM(fieldName)//' does not have 1d, 2d or 3d mask type '//TRIM(maskName))
-                     !      endif
-                     !   else
-                     !      call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
-                     !   endif
+                     else if ( fieldInfo % nDims == 4 ) then
+                        call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real4DField)
+                        if (real4DField % isVarArray) then
+                           maskName = real4DField % maskName
+                           call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
+                           if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
+                              do j = 1, size(real4DField % constituentNames)
+                                 call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                          real4DField % constituentNames(j), &
+                                                          real3DField)
+                                 fieldName = real4DField % constituentNames(j)
+                                 call mpas_pool_get_field_info(domain % blocklist % allFields, fieldName, fieldInfo)
+                                 if ( maskInfo % nDims == 3 ) then
+                                    call mpas_pool_get_field(domain % blocklist % allFields, maskName, int3DMask)
+                                    call mpas_mask_assign_pointer(real4DField, int3DMask)
+                                 if ( maskInfo % nDims == 2 ) then
+                                    call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
+                                    call mpas_mask_assign_pointer(real4DField, int2DMask)
+                                 elseif ( maskInfo % nDims == 1 ) then
+                                    call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
+                                    call mpas_mask_assign_pointer(real4DField, int1DMask)
+                                 else
+                                    call mpas_log_write(TRIM(fieldName)//' does not have 1d, 2d or 3d mask type '//TRIM(maskName))
+                                 endif
+                              enddo
+                           else
+                              call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
+                           endif
+                        else
+                           maskName = real4DField % maskName
+                           call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
+                           if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
+                              if ( maskInfo % nDims == 3 ) then
+                                 call mpas_pool_get_field(domain % blocklist % allFields, maskName, int3DMask)
+                                 call mpas_mask_assign_pointer(real4DField, int3DMask)
+                              elseif ( maskInfo % nDims == 2 ) then
+                                 call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
+                                 call mpas_mask_assign_pointer(real4DField, int2DMask)
+                              elseif ( maskInfo % nDims == 1 ) then
+                                 call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
+                                 call mpas_mask_assign_pointer(real4DField, int1DMask)
+                              else
+                                 call mpas_log_write(TRIM(fieldName)//' does not have 1d, 2d or 3d mask type '//TRIM(maskName))
+                              endif
+                           else
+                              call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
+                           endif
+                        endif
+                     else if ( fieldInfo % nDims == 5 ) then
+                        call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real5DField)
+                        if (real5DField % isVarArray) then
+                           maskName = real5DField % maskName
+                           call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
+                           if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
+                              do j = 1, size(real5DField % constituentNames)
+                                 call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                          real5DField % constituentNames(j), &
+                                                          real3DField)
+                                 fieldName = real5DField % constituentNames(j)
+                                 call mpas_pool_get_field_info(domain % blocklist % allFields, fieldName, fieldInfo)
+                                 if ( maskInfo % nDims == 3 ) then
+                                    call mpas_pool_get_field(domain % blocklist % allFields, maskName, int3DMask)
+                                    call mpas_mask_assign_pointer(real5DField, int3DMask)
+                                 if ( maskInfo % nDims == 2 ) then
+                                    call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
+                                    call mpas_mask_assign_pointer(real5DField, int2DMask)
+                                 elseif ( maskInfo % nDims == 1 ) then
+                                    call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
+                                    call mpas_mask_assign_pointer(real5DField, int1DMask)
+                                 else
+                                    call mpas_log_write(TRIM(fieldName)//' does not have 1d, 2d or 3d mask type '//TRIM(maskName))
+                                 endif
+                              enddo
+                           else
+                              call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
+                           endif
+                        else
+                           maskName = real5DField % maskName
+                           call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
+                           if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
+                              if ( maskInfo % nDims == 3 ) then
+                                 call mpas_pool_get_field(domain % blocklist % allFields, maskName, int3DMask)
+                                 call mpas_mask_assign_pointer(real5DField, int3DMask)
+                              elseif ( maskInfo % nDims == 2 ) then
+                                 call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
+                                 call mpas_mask_assign_pointer(real5DField, int2DMask)
+                              elseif ( maskInfo % nDims == 1 ) then
+                                 call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
+                                 call mpas_mask_assign_pointer(real5DField, int1DMask)
+                              else
+                                 call mpas_log_write(TRIM(fieldName)//' does not have 1d, 2d or 3d mask type '//TRIM(maskName))
+                              endif
+                           else
+                              call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
+                           endif
                      end if
                   endif
                endif

--- a/components/mpas-framework/src/framework/mpas_bootstrapping.F
+++ b/components/mpas-framework/src/framework/mpas_bootstrapping.F
@@ -450,11 +450,19 @@ module mpas_bootstrapping
       type (mpas_pool_type), pointer :: streamDimensions
 
       character (len=StrKIND) :: streamName, streamFilenameTemplate, streamFilenameInterval, streamReferenceTime, streamFilename
-      character (len=StrKIND) :: fieldName
+      character (len=StrKIND) :: fieldName, maskName
       integer :: streamDirection
       logical :: streamActive
       logical :: fieldActive
       integer :: ioType
+
+      type (mpas_pool_field_info_type) :: fieldInfo, maskInfo
+      type (field2DInteger), pointer :: int2DMask
+      type (field1DReal), pointer :: real1DField
+      type (field2DReal), pointer :: real2DField
+      type (field3DReal), pointer :: real3DField
+      type (field4DReal), pointer :: real4DField
+      type (field5DReal), pointer :: real5DField
 
       type (mpas_pool_iterator_type) :: poolItr
 
@@ -574,6 +582,53 @@ module mpas_bootstrapping
       call mpas_log_write(' ')
       call mpas_log_write(' ')
 
+      ! TODO Point missingValueMask to the requested field for each field variable
+      call mpas_stream_mgr_begin_iteration(domain % streamManager)
+      do while ( mpas_stream_mgr_get_next_stream(domain % streamManager, streamID = streamName, directionProperty = streamDirection, &
+                                                 activeProperty = streamActive) )
+
+         if ( streamActive .and. ( streamDirection == MPAS_STREAM_OUTPUT .or. streamDirection == MPAS_STREAM_INPUT_OUTPUT ) ) then
+
+            call mpas_stream_mgr_begin_iteration(domain % streamManager, streamID=streamName)
+
+            do while ( mpas_stream_mgr_get_next_field(domain % streamManager, streamName, fieldName, isActive=fieldActive) )
+
+               if (fieldActive) then
+                  call mpas_pool_get_field_info(domain % blocklist % allFields, fieldName, fieldInfo)
+                  if ( fieldInfo % fieldType == MPAS_POOL_REAL ) then
+
+                     !if ( fieldInfo % nDims == 1 ) then
+                     !   call mpas_pool_get_field(allFields, fieldName, real1DField)
+                     if ( fieldInfo % nDims == 2 ) then
+                        call mpas_log_write('looking for mask for 2d field '//TRIM(fieldName))
+                        call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real2DField)
+                        !call MPAS_io_get_att(handle, trim(att_cursor % attName), field % attLists(1) % attList % attValueInt, fieldName)
+                        maskName = real2dField % maskName
+                        call mpas_log_write('retrieved mask '//trim(maskName)//' for 2d field '//TRIM(fieldName))
+                        call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
+                        if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
+                           if ( maskInfo % nDims == 2 ) then
+                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
+                              ! get mask field from pool
+                              call mpas_mask_assign_pointer(real2DField, int2DMask)
+                           else
+                              call mpas_log_write(TRIM(fieldName)//' does not have 2d mask type '//TRIM(maskName))
+                           endif
+                        else
+                           call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
+                        endif
+                     !else if ( fieldInfo % nDims == 3 ) then
+                     !   call mpas_pool_get_field(allFields, fieldName, real3DField)
+                     !else if ( fieldInfo % nDims == 4 ) then
+                     !   call mpas_pool_get_field(allFields, fieldName, real4DField)
+                     !else if ( fieldInfo % nDims == 5 ) then
+                     !   call mpas_pool_get_field(allFields, fieldName, real5DField)
+                     end if
+                  endif
+               endif
+            enddo
+         endif
+      enddo
       call mpas_pool_set_error_level(err_level)
 
       ! Allocate blocks, and copy indexTo arrays into blocks

--- a/components/mpas-framework/src/framework/mpas_bootstrapping.F
+++ b/components/mpas-framework/src/framework/mpas_bootstrapping.F
@@ -457,7 +457,9 @@ module mpas_bootstrapping
       integer :: ioType
 
       type (mpas_pool_field_info_type) :: fieldInfo, maskInfo
+      type (field1DInteger), pointer :: int1DMask
       type (field2DInteger), pointer :: int2DMask
+      type (field3DInteger), pointer :: int3DMask
       type (field1DReal), pointer :: real1DField
       type (field2DReal), pointer :: real2DField
       type (field3DReal), pointer :: real3DField
@@ -597,32 +599,107 @@ module mpas_bootstrapping
                   call mpas_pool_get_field_info(domain % blocklist % allFields, fieldName, fieldInfo)
                   if ( fieldInfo % fieldType == MPAS_POOL_REAL ) then
 
-                     !if ( fieldInfo % nDims == 1 ) then
-                     !   call mpas_pool_get_field(allFields, fieldName, real1DField)
-                     if ( fieldInfo % nDims == 2 ) then
+                     if ( fieldInfo % nDims == 1 ) then
+                        call mpas_log_write('looking for mask for 1d field '//TRIM(fieldName))
+                        call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real1DField)
+                        maskName = real1dField % maskName
+                        call mpas_log_write('retrieved mask '//trim(maskName)//' for 1d field '//TRIM(fieldName))
+                        call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
+                        if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
+                           if ( maskInfo % nDims == 1 ) then
+                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
+                              call mpas_mask_assign_pointer(real1DField, int1DMask)
+                           else
+                              call mpas_log_write(TRIM(fieldName)//' does not have 1d mask type '//TRIM(maskName))
+                           endif
+                        else
+                           call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
+                        endif
+                     elseif ( fieldInfo % nDims == 2 ) then
                         call mpas_log_write('looking for mask for 2d field '//TRIM(fieldName))
                         call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real2DField)
-                        !call MPAS_io_get_att(handle, trim(att_cursor % attName), field % attLists(1) % attList % attValueInt, fieldName)
                         maskName = real2dField % maskName
                         call mpas_log_write('retrieved mask '//trim(maskName)//' for 2d field '//TRIM(fieldName))
                         call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
                         if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
                            if ( maskInfo % nDims == 2 ) then
                               call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
-                              ! get mask field from pool
                               call mpas_mask_assign_pointer(real2DField, int2DMask)
+                           elseif ( maskInfo % nDims == 1 ) then
+                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
+                              call mpas_mask_assign_pointer(real2DField, int1DMask)
                            else
-                              call mpas_log_write(TRIM(fieldName)//' does not have 2d mask type '//TRIM(maskName))
+                              call mpas_log_write(TRIM(fieldName)//' does not have 1d or 2d mask type '//TRIM(maskName))
                            endif
                         else
                            call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
                         endif
-                     !else if ( fieldInfo % nDims == 3 ) then
-                     !   call mpas_pool_get_field(allFields, fieldName, real3DField)
-                     !else if ( fieldInfo % nDims == 4 ) then
-                     !   call mpas_pool_get_field(allFields, fieldName, real4DField)
-                     !else if ( fieldInfo % nDims == 5 ) then
-                     !   call mpas_pool_get_field(allFields, fieldName, real5DField)
+                     else if ( fieldInfo % nDims == 3 ) then
+                        call mpas_log_write('looking for mask for 3d field '//TRIM(fieldName))
+                        call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real3DField)
+                        maskName = real3dField % maskName
+                        call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
+                        if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
+                           call mpas_log_write('retrieved mask '//trim(maskName)//' for 3d field '//TRIM(fieldName))
+                           if ( maskInfo % nDims == 3 ) then
+                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int3DMask)
+                              call mpas_mask_assign_pointer(real3DField, int3DMask)
+                           elseif ( maskInfo % nDims == 2 ) then
+                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
+                              call mpas_mask_assign_pointer(real3DField, int2DMask)
+                           elseif ( maskInfo % nDims == 1 ) then
+                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
+                              call mpas_mask_assign_pointer(real3DField, int1DMask)
+                           else
+                              call mpas_log_write(TRIM(fieldName)//' does not have 1d, 2d or 3d mask type '//TRIM(maskName))
+                           endif
+                        else
+                           call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
+                        endif
+                     else if ( fieldInfo % nDims == 4 ) then
+                        call mpas_log_write('looking for mask for 4d field '//TRIM(fieldName))
+                        call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real4DField)
+                        maskName = real4dField % maskName
+                        call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
+                        if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
+                           call mpas_log_write('retrieved mask '//trim(maskName)//' for 4d field '//TRIM(fieldName))
+                           if ( maskInfo % nDims == 3 ) then
+                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int3DMask)
+                              call mpas_mask_assign_pointer(real4DField, int3DMask)
+                           elseif ( maskInfo % nDims == 2 ) then
+                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
+                              call mpas_mask_assign_pointer(real4DField, int2DMask)
+                           elseif ( maskInfo % nDims == 1 ) then
+                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
+                              call mpas_mask_assign_pointer(real4DField, int1DMask)
+                           else
+                              call mpas_log_write(TRIM(fieldName)//' does not have 1d, 2d or 3d mask type '//TRIM(maskName))
+                           endif
+                        else
+                           call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
+                        endif
+                     else if ( fieldInfo % nDims == 5 ) then
+                        call mpas_log_write('looking for mask for 5d field '//TRIM(fieldName))
+                        call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real5DField)
+                        maskName = real5dField % maskName
+                        call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
+                        if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
+                           call mpas_log_write('retrieved mask '//trim(maskName)//' for 5d field '//TRIM(fieldName))
+                           if ( maskInfo % nDims == 3 ) then
+                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int3DMask)
+                              call mpas_mask_assign_pointer(real5DField, int3DMask)
+                           elseif ( maskInfo % nDims == 2 ) then
+                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
+                              call mpas_mask_assign_pointer(real5DField, int2DMask)
+                           elseif ( maskInfo % nDims == 1 ) then
+                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
+                              call mpas_mask_assign_pointer(real5DField, int1DMask)
+                           else
+                              call mpas_log_write(TRIM(fieldName)//' does not have 1d, 2d or 3d mask type '//TRIM(maskName))
+                           endif
+                        else
+                           call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
+                        endif
                      end if
                   endif
                endif

--- a/components/mpas-framework/src/framework/mpas_bootstrapping.F
+++ b/components/mpas-framework/src/framework/mpas_bootstrapping.F
@@ -473,7 +473,7 @@ module mpas_bootstrapping
       character (len=StrKIND), dimension(:), pointer :: dimNames
       integer, pointer :: dimValue
       integer :: tempDim
-      integer :: i, err_level, err_local
+      integer :: i, j, err_level, err_local
 
 
       call mpas_pool_create_pool(readableDimensions)
@@ -602,7 +602,7 @@ module mpas_bootstrapping
                      if ( fieldInfo % nDims == 1 ) then
                         call mpas_log_write('looking for mask for 1d field '//TRIM(fieldName))
                         call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real1DField)
-                        maskName = real1dField % maskName
+                        maskName = real1DField % maskName
                         call mpas_log_write('retrieved mask '//trim(maskName)//' for 1d field '//TRIM(fieldName))
                         call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
                         if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
@@ -618,7 +618,7 @@ module mpas_bootstrapping
                      elseif ( fieldInfo % nDims == 2 ) then
                         call mpas_log_write('looking for mask for 2d field '//TRIM(fieldName))
                         call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real2DField)
-                        maskName = real2dField % maskName
+                        maskName = real2DField % maskName
                         call mpas_log_write('retrieved mask '//trim(maskName)//' for 2d field '//TRIM(fieldName))
                         call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
                         if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
@@ -635,31 +635,66 @@ module mpas_bootstrapping
                            call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
                         endif
                      else if ( fieldInfo % nDims == 3 ) then
-                        call mpas_log_write('looking for mask for 3d field '//TRIM(fieldName))
                         call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real3DField)
-                        maskName = real3dField % maskName
-                        call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
-                        if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
-                           call mpas_log_write('retrieved mask '//trim(maskName)//' for 3d field '//TRIM(fieldName))
-                           if ( maskInfo % nDims == 3 ) then
-                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int3DMask)
-                              call mpas_mask_assign_pointer(real3DField, int3DMask)
-                           elseif ( maskInfo % nDims == 2 ) then
-                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
-                              call mpas_mask_assign_pointer(real3DField, int2DMask)
-                           elseif ( maskInfo % nDims == 1 ) then
-                              call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
-                              call mpas_mask_assign_pointer(real3DField, int1DMask)
+                        if (real3DField % isVarArray) then
+                           call mpas_log_write('looking for mask for 3d array '//TRIM(fieldName))
+                           maskName = real3DField % maskName
+                           call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
+                           if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
+                              call mpas_log_write('retrieved mask info'//trim(maskName)//' for 3d array '//TRIM(fieldName))
+                              do j = 1, size(real3DField % constituentNames)
+                                 call mpas_pool_get_field(domain % blocklist % allFields, &
+                                                          real3DField % constituentNames(j), &
+                                                          real2DField)
+                                 call mpas_log_write('retrieved field'//trim(real3DField % constituentNames(j))//' from 3d field '//TRIM(fieldName))
+                                 fieldName = real3DField % constituentNames(j)
+                                 call mpas_pool_get_field_info(domain % blocklist % allFields, fieldName, fieldInfo)
+                                 !call mpas_log_write('real2DField nDims'//trim(fieldInfo%nDims))
+                                 if ( maskInfo % nDims == 2 ) then
+                                    call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
+                                    call mpas_log_write('retrieved mask'//trim(maskName)//' for 2d field '//TRIM(fieldName))
+                                    !call mpas_log_write('retrieved mask'//trim(int2DMask%fieldName))
+                                    !call mpas_log_write('        for 2d field'//TRIM(real2DField%fieldName))
+                                    call mpas_log_write('call assign_pointer')
+                                    call mpas_mask_assign_pointer(real3DField, int2DMask)
+                                    !call mpas_mask_assign_pointer(real2DField, int2DMask)
+                                 elseif ( maskInfo % nDims == 1 ) then
+                                    call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
+                                    call mpas_mask_assign_pointer(real3DField, int1DMask)
+                                    !call mpas_mask_assign_pointer(real2DField, int1DMask)
+                                 else
+                                    call mpas_log_write(TRIM(fieldName)//' does not have 1d or 2d mask type '//TRIM(maskName))
+                                 endif
+                              enddo
                            else
-                              call mpas_log_write(TRIM(fieldName)//' does not have 1d, 2d or 3d mask type '//TRIM(maskName))
+                              call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
                            endif
                         else
-                           call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
+                           call mpas_log_write('looking for mask for 3d field '//TRIM(fieldName))
+                           maskName = real3DField % maskName
+                           call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
+                           if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
+                              call mpas_log_write('retrieved mask '//trim(maskName)//' for 3d field '//TRIM(fieldName))
+                              if ( maskInfo % nDims == 3 ) then
+                                 call mpas_pool_get_field(domain % blocklist % allFields, maskName, int3DMask)
+                                 call mpas_mask_assign_pointer(real3DField, int3DMask)
+                              elseif ( maskInfo % nDims == 2 ) then
+                                 call mpas_pool_get_field(domain % blocklist % allFields, maskName, int2DMask)
+                                 call mpas_mask_assign_pointer(real3DField, int2DMask)
+                              elseif ( maskInfo % nDims == 1 ) then
+                                 call mpas_pool_get_field(domain % blocklist % allFields, maskName, int1DMask)
+                                 call mpas_mask_assign_pointer(real3DField, int1DMask)
+                              else
+                                 call mpas_log_write(TRIM(fieldName)//' does not have 1d, 2d or 3d mask type '//TRIM(maskName))
+                              endif
+                           else
+                              call mpas_log_write(TRIM(fieldName)//' does not have an integer mask type '//TRIM(maskName))
+                           endif
                         endif
                      !else if ( fieldInfo % nDims == 4 ) then
                      !   call mpas_log_write('looking for mask for 4d field '//TRIM(fieldName))
                      !   call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real4DField)
-                     !   maskName = real4dField % maskName
+                     !   maskName = real4DField % maskName
                      !   call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
                      !   if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
                      !      call mpas_log_write('retrieved mask '//trim(maskName)//' for 4d field '//TRIM(fieldName))
@@ -681,7 +716,7 @@ module mpas_bootstrapping
                      !else if ( fieldInfo % nDims == 5 ) then
                      !   call mpas_log_write('looking for mask for 5d field '//TRIM(fieldName))
                      !   call mpas_pool_get_field(domain % blocklist % allFields, fieldName, real5DField)
-                     !   maskName = real5dField % maskName
+                     !   maskName = real5DField % maskName
                      !   call mpas_pool_get_field_info(domain % blocklist % allFields, maskName, maskInfo)
                      !   if ( maskInfo % fieldType == MPAS_POOL_INTEGER ) then
                      !      call mpas_log_write('retrieved mask '//trim(maskName)//' for 5d field '//TRIM(fieldName))

--- a/components/mpas-framework/src/framework/mpas_field_routines.F
+++ b/components/mpas-framework/src/framework/mpas_field_routines.F
@@ -39,7 +39,7 @@ module mpas_field_routines
 
    interface mpas_mask_assign_pointer
       module procedure mpas_mask_assign_pointer_field2d_mask2d_real
-      ! TODO module procedure mpas_mask_assign_pointer_field3d_mask2d_real
+      module procedure mpas_mask_assign_pointer_field3d_mask2d_real
       !module procedure mpas_mask_assign_pointer_field3d_mask3d_real
    end interface
    interface mpas_mask_field
@@ -2914,6 +2914,42 @@ module mpas_field_routines
       field % missingValueMask2d => mask
 
    end subroutine mpas_mask_assign_pointer_field2d_mask2d_real
+
+!***********************************************************************
+!
+!  routine mpas_mask_assign_pointer_field3d_mask2d_real
+!
+!> \brief   MPAS 3D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> 
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_mask_assign_pointer_field3d_mask2d_real(field, mask) !{{{
+
+      implicit none
+
+      type (field3DReal), intent(inout), pointer :: field
+      type (field2DInteger), intent(in), pointer :: mask
+
+      integer :: i
+      integer, dimension(3) :: fieldDims
+      integer, dimension(2) :: maskDims
+
+      character (len=StrKIND), dimension(3) :: fieldDimNames
+      character (len=StrKIND), dimension(2) :: maskDimNames
+
+      fieldDims = field % dimSizes
+      fieldDimNames = field % dimNames
+      maskDims = mask % dimSizes
+      maskDimNames = mask % dimNames
+
+      call mpas_log_write('Assign pointer from '//trim(field % fieldName)//' to '//trim(mask % fieldName))
+      field % missingValueMask2d => mask
+
+   end subroutine mpas_mask_assign_pointer_field3d_mask2d_real
+
 
 !***********************************************************************
 !

--- a/components/mpas-framework/src/framework/mpas_field_routines.F
+++ b/components/mpas-framework/src/framework/mpas_field_routines.F
@@ -23,6 +23,7 @@ module mpas_field_routines
    use mpas_derived_types
    use mpas_threading
    use mpas_attlist
+   use mpas_log
 
    interface mpas_allocate_mold
       module procedure mpas_allocate_mold_1dreal
@@ -35,6 +36,16 @@ module mpas_field_routines
       module procedure mpas_allocate_mold_3dinteger
       module procedure mpas_allocate_mold_1dchar
    end interface
+
+   interface mpas_mask_assign_pointer
+      module procedure mpas_mask_assign_pointer_field2d_mask2d_real
+      ! TODO module procedure mpas_mask_assign_pointer_field3d_mask2d_real
+      !module procedure mpas_mask_assign_pointer_field3d_mask3d_real
+   end interface
+   !interface mpas_mask_field
+   !   ! TODO module procedure mpas_mask_field3d_mask2d_real
+   !   module procedure mpas_mask_field3d_mask3d_real
+   !end interface
 
    interface mpas_duplicate_field
       module procedure mpas_duplicate_field0d_real
@@ -2857,6 +2868,183 @@ module mpas_field_routines
       end if
 
    end subroutine mpas_allocate_mold_1dchar!}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_mask_assign_pointer_field2d_mask2d_real
+!
+!> \brief   MPAS 3D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> Masks the source field using a masking array.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_mask_assign_pointer_field2d_mask2d_real(field, mask) !{{{
+
+      implicit none
+
+      type (field2DReal), intent(inout), pointer :: field
+      type (field2DInteger), intent(in), pointer :: mask
+
+      integer :: i
+      integer, dimension(2) :: fieldDims
+      integer, dimension(2) :: maskDims
+
+      character (len=StrKIND), dimension(2) :: fieldDimNames
+      character (len=StrKIND), dimension(2) :: maskDimNames
+
+      fieldDims = field % dimSizes
+      fieldDimNames = field % dimNames
+      maskDims = mask % dimSizes
+      maskDimNames = mask % dimNames
+      ! TODO check that dimNames and dimSizes match
+      do i = 1,2 
+         if ( maskDimNames(i) .ne. fieldDimNames(i) ) then
+            call mpas_log_write('Warning: dimension names do not match between masking and output arrays')
+            call mpas_log_write(trim(field % fieldName)//', '//trim(fieldDimNames(i)))
+            call mpas_log_write(trim(mask % fieldName)//', '//trim(maskDimNames(i)))
+            return
+         endif
+      enddo
+
+      call mpas_log_write('Assign pointer from '//trim(field % fieldName)//' to '//trim(mask % fieldName))
+      field % missingValueMask2d => mask
+
+   end subroutine mpas_mask_assign_pointer_field2d_mask2d_real
+
+!***********************************************************************
+!
+!  routine mpas_mask_field3d_mask3d_real
+!
+!> \brief   MPAS 3D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> Masks the source field using a masking array.
+!
+!-----------------------------------------------------------------------
+!   subroutine mpas_mask_assign_pointer_field3d_mask3d_real(field, mask) !{{{
+!
+!      implicit none
+!
+!      type (field3DReal), intent(inout), pointer :: field
+!      type (field3DInteger), intent(in), pointer :: mask
+!
+!      integer :: i
+!      integer, dimension(3) :: fieldDims
+!      integer, dimension(3) :: maskDims
+!
+!      character (len=StrKIND), dimension(3) :: fieldDimNames
+!      character (len=StrKIND), dimension(3) :: maskDimNames
+!
+!      !if ( field % missingValue == null() ) then
+!      !   call mpas_log_write('Warning: no missingValue was provided for fieldName') ! TODO Replace field name iwth field name
+!      !   return
+!      !endif
+!      maskDims = mask % dimSizes
+!      maskDimNames = mask % dimNames
+!      ! TODO check that dimNames and dimSizes match
+!      do i = 1, 3
+!         if ( maskDimNames(i) .ne. fieldDimNames(i) ) then
+!            call mpas_log_write('Warning: dimension names do not match between masking and output arrays')
+!         endif
+!      enddo
+!
+!      field % missingValueMask3d => mask
+!
+!   end subroutine mpas_mask_assign_pointer_field3d_mask3d_real
+
+!***********************************************************************
+!
+!  routine mpas_mask_field2d_mask2d_real
+!
+!> \brief   MPAS 3D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> Masks the source field using a masking array.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_mask_field2d_mask2d_real(field, mask, maskedField) !{{{
+
+      implicit none
+
+      type (field2DReal), intent(in), pointer :: field !< Input/Output: Field to be masked
+
+      type (field2DInteger), intent(in), pointer :: mask
+
+      real (kind=RKIND), dimension(:,:), intent(out) :: maskedField !< Input/Output: Field to be masked
+      ! TODO consider whether this should be of field type or 3d real array
+      !type (field3DReal), intent(out) :: maskedField !< Input/Output: Field to be masked
+
+      real (kind=RKIND), dimension(:,:), pointer :: fieldArray
+      character (len=100) :: log_string
+      integer, dimension(:,:), pointer :: maskArray
+
+      call mpas_log_write('Masking array '//trim(field % fieldName))
+      fieldArray = field % array
+      write(log_string,*) 'fieldArray shape=', SHAPE(fieldArray)
+      call mpas_log_write(log_string)
+      maskArray = mask % array
+      write(log_string,*) 'maskedField shape=', SHAPE(maskedField)
+      call mpas_log_write(log_string)
+      ! real3d_temp is already allocated in mpas_io_streams
+      !allocate(maskedField(fieldDims(1),fieldDims(2),fieldDims(3)))
+
+      maskedField = fieldArray ! consider putting in elsewhere
+      !where (maskArray == 0)
+      !   maskedField = field % missingValue
+      !endwhere
+
+   end subroutine mpas_mask_field2d_mask2d_real !}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_mask_field3d_mask3d_real
+!
+!> \brief   MPAS 3D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> Masks the source field using a masking array.
+!
+!-----------------------------------------------------------------------
+!   subroutine mpas_mask_field3d_mask3d_real(field, mask, maskedField) !{{{
+!
+!      implicit none
+!
+!      type (field3DReal), intent(in), pointer :: field !< Input/Output: Field to be masked
+!
+!      type (field3DInteger), intent(in), pointer :: mask
+!
+!      real (kind=RKIND), dimension(:,:,:), intent(out) :: maskedField !< Input/Output: Field to be masked
+!      ! TODO consider whether this should be of field type or 3d real array
+!      !type (field3DReal), intent(out) :: maskedField !< Input/Output: Field to be masked
+!
+!      real (kind=RKIND), dimension(:,:,:), pointer :: fieldArray
+!
+!      integer :: i
+!      integer, dimension(3) :: fieldDims
+!      integer, dimension(3) :: maskDims
+!      integer, dimension(:,:,:), pointer :: maskArray
+!
+!      character (len=StrKIND), dimension(3) :: fieldDimNames
+!      character (len=StrKIND), dimension(3) :: maskDimNames
+!
+!      fieldDims = field % dimSizes
+!      fieldDimNames = field % dimNames
+!      maskDims = mask % dimSizes
+!      maskDimNames = mask % dimNames
+!      ! real3d_temp is already allocated in mpas_io_streams
+!      !allocate(maskedField(fieldDims(1),fieldDims(2),fieldDims(3)))
+!
+!      ! TODO use fieldDimNames to know how to transform the mask
+!
+!   end subroutine mpas_mask_field3d_mask3d_real !}}}
+
 
 !***********************************************************************
 !

--- a/components/mpas-framework/src/framework/mpas_field_routines.F
+++ b/components/mpas-framework/src/framework/mpas_field_routines.F
@@ -38,14 +38,26 @@ module mpas_field_routines
    end interface
 
    interface mpas_mask_assign_pointer
+      module procedure mpas_mask_assign_pointer_field1d_mask1d_real
       module procedure mpas_mask_assign_pointer_field2d_mask2d_real
+      module procedure mpas_mask_assign_pointer_field2d_mask1d_real
+      module procedure mpas_mask_assign_pointer_field3d_mask3d_real
       module procedure mpas_mask_assign_pointer_field3d_mask2d_real
-      !module procedure mpas_mask_assign_pointer_field3d_mask3d_real
+      module procedure mpas_mask_assign_pointer_field3d_mask1d_real
+      module procedure mpas_mask_assign_pointer_field4d_mask3d_real
+      module procedure mpas_mask_assign_pointer_field4d_mask2d_real
+      module procedure mpas_mask_assign_pointer_field4d_mask1d_real
    end interface
    interface mpas_mask_field
+      module procedure mpas_mask_field1d_mask1d_real
       module procedure mpas_mask_field2d_mask2d_real
-      !module procedure mpas_mask_field3d_mask3d_real
-      ! TODO module procedure mpas_mask_field3d_mask2d_real
+      module procedure mpas_mask_field2d_mask1d_real
+      module procedure mpas_mask_field3d_mask3d_real
+      module procedure mpas_mask_field3d_mask2d_real
+      module procedure mpas_mask_field3d_mask1d_real
+      module procedure mpas_mask_field4d_mask3d_real
+      module procedure mpas_mask_field4d_mask2d_real
+      module procedure mpas_mask_field4d_mask1d_real
    end interface
 
    interface mpas_duplicate_field
@@ -2873,9 +2885,32 @@ module mpas_field_routines
 
 !***********************************************************************
 !
+!  routine mpas_mask_assign_pointer_field1d_mask1d_real
+!
+!> \brief   MPAS 1D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> Masks the source field using a masking array.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_mask_assign_pointer_field1d_mask1d_real(field, mask) !{{{
+
+      implicit none
+
+      type (field1DReal), intent(inout), pointer :: field
+      type (field1DInteger), intent(in), pointer :: mask
+
+      call mpas_log_write('Assign pointer from '//trim(field % fieldName)//' to '//trim(mask % fieldName))
+      field % missingValueMask1d => mask
+
+   end subroutine mpas_mask_assign_pointer_field1d_mask1d_real
+
+!***********************************************************************
+!
 !  routine mpas_mask_assign_pointer_field2d_mask2d_real
 !
-!> \brief   MPAS 3D real field mask routine.
+!> \brief   MPAS 2D real field mask routine.
 !> \author  Carolyn Begeman, Adrian Turner
 !> \date    05/17/22
 !> \details 
@@ -2889,31 +2924,56 @@ module mpas_field_routines
       type (field2DReal), intent(inout), pointer :: field
       type (field2DInteger), intent(in), pointer :: mask
 
-      integer :: i
-      integer, dimension(2) :: fieldDims
-      integer, dimension(2) :: maskDims
-
-      character (len=StrKIND), dimension(2) :: fieldDimNames
-      character (len=StrKIND), dimension(2) :: maskDimNames
-
-      fieldDims = field % dimSizes
-      fieldDimNames = field % dimNames
-      maskDims = mask % dimSizes
-      maskDimNames = mask % dimNames
-      ! TODO check that dimNames and dimSizes match
-      do i = 1,2 
-         if ( maskDimNames(i) .ne. fieldDimNames(i) ) then
-            call mpas_log_write('Warning: dimension names do not match between masking and output arrays')
-            call mpas_log_write(trim(field % fieldName)//', '//trim(fieldDimNames(i)))
-            call mpas_log_write(trim(mask % fieldName)//', '//trim(maskDimNames(i)))
-            return
-         endif
-      enddo
-
       call mpas_log_write('Assign pointer from '//trim(field % fieldName)//' to '//trim(mask % fieldName))
       field % missingValueMask2d => mask
 
    end subroutine mpas_mask_assign_pointer_field2d_mask2d_real
+
+!***********************************************************************
+!
+!  routine mpas_mask_assign_pointer_field2d_mask1d_real
+!
+!> \brief   MPAS 2D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> Masks the source field using a masking array.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_mask_assign_pointer_field2d_mask1d_real(field, mask) !{{{
+
+      implicit none
+
+      type (field2DReal), intent(inout), pointer :: field
+      type (field1DInteger), intent(in), pointer :: mask
+
+      call mpas_log_write('Assign pointer from '//trim(field % fieldName)//' to '//trim(mask % fieldName))
+      field % missingValueMask1d => mask
+
+   end subroutine mpas_mask_assign_pointer_field2d_mask1d_real
+
+!***********************************************************************
+!
+!  routine mpas_mask_field3d_mask3d_real
+!
+!> \brief   MPAS 3D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> Masks the source field using a masking array.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_mask_assign_pointer_field3d_mask3d_real(field, mask) !{{{
+
+      implicit none
+
+      type (field3DReal), intent(inout), pointer :: field
+      type (field3DInteger), intent(in), pointer :: mask
+
+      call mpas_log_write('Assign pointer from '//trim(field % fieldName)//' to '//trim(mask % fieldName))
+      field % missingValueMask3d => mask
+
+   end subroutine mpas_mask_assign_pointer_field3d_mask3d_real
 
 !***********************************************************************
 !
@@ -2933,18 +2993,6 @@ module mpas_field_routines
       type (field3DReal), intent(inout), pointer :: field
       type (field2DInteger), intent(in), pointer :: mask
 
-      integer :: i
-      integer, dimension(3) :: fieldDims
-      integer, dimension(2) :: maskDims
-
-      character (len=StrKIND), dimension(3) :: fieldDimNames
-      character (len=StrKIND), dimension(2) :: maskDimNames
-
-      fieldDims = field % dimSizes
-      fieldDimNames = field % dimNames
-      maskDims = mask % dimSizes
-      maskDimNames = mask % dimNames
-
       call mpas_log_write('Assign pointer from '//trim(field % fieldName)//' to '//trim(mask % fieldName))
       field % missingValueMask2d => mask
 
@@ -2953,51 +3001,78 @@ module mpas_field_routines
 
 !***********************************************************************
 !
-!  routine mpas_mask_field3d_mask3d_real
+!  routine mpas_mask_assign_pointer_field3d_mask1d_real
 !
 !> \brief   MPAS 3D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> 
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_mask_assign_pointer_field3d_mask1d_real(field, mask) !{{{
+
+      implicit none
+
+      type (field3DReal), intent(inout), pointer :: field
+      type (field1DInteger), intent(in), pointer :: mask
+
+      call mpas_log_write('Assign pointer from '//trim(field % fieldName)//' to '//trim(mask % fieldName))
+      field % missingValueMask1d => mask
+
+   end subroutine mpas_mask_assign_pointer_field3d_mask1d_real
+
+
+!***********************************************************************
+!
+!  routine mpas_mask_field1d_mask1d_real
+!
+!> \brief   MPAS 1D real field mask routine.
 !> \author  Carolyn Begeman, Adrian Turner
 !> \date    05/17/22
 !> \details 
 !> Masks the source field using a masking array.
 !
 !-----------------------------------------------------------------------
-!   subroutine mpas_mask_assign_pointer_field3d_mask3d_real(field, mask) !{{{
-!
-!      implicit none
-!
-!      type (field3DReal), intent(inout), pointer :: field
-!      type (field3DInteger), intent(in), pointer :: mask
-!
-!      integer :: i
-!      integer, dimension(3) :: fieldDims
-!      integer, dimension(3) :: maskDims
-!
-!      character (len=StrKIND), dimension(3) :: fieldDimNames
-!      character (len=StrKIND), dimension(3) :: maskDimNames
-!
-!      !if ( field % missingValue == null() ) then
-!      !   call mpas_log_write('Warning: no missingValue was provided for fieldName') ! TODO Replace field name iwth field name
-!      !   return
-!      !endif
-!      maskDims = mask % dimSizes
-!      maskDimNames = mask % dimNames
-!      ! TODO check that dimNames and dimSizes match
-!      do i = 1, 3
-!         if ( maskDimNames(i) .ne. fieldDimNames(i) ) then
-!            call mpas_log_write('Warning: dimension names do not match between masking and output arrays')
-!         endif
-!      enddo
-!
-!      field % missingValueMask3d => mask
-!
-!   end subroutine mpas_mask_assign_pointer_field3d_mask3d_real
+   subroutine mpas_mask_field1d_mask1d_real(field, mask, maskedField) !{{{
+
+      implicit none
+
+      type (field1DReal), intent(in), pointer :: field
+      type (field1DInteger), intent(in), pointer :: mask
+      real (kind=RKIND), dimension(:), intent(inout), pointer :: maskedField
+
+      real (kind=RKIND), dimension(:), pointer :: fieldArray
+      integer, dimension(:), pointer :: maskArray
+
+      integer, dimension(1) :: fieldDims
+      integer, dimension(1) :: maskDims
+
+      fieldDims = field % dimSizes
+      maskDims = mask % dimSizes
+
+      !TODO determine whether mask would ever be smaller than field
+      !fieldArray => field % array(1:maskDims(1))
+      !maskArray => mask   % array(1:maskDims(1))
+
+      if (fieldDims(1) == maskDims(1) ) then
+         call mpas_log_write('Masking array '//trim(field % fieldName))
+         maskedField = fieldArray ! consider putting in elsewhere
+         where (maskArray == 0)
+            maskedField = field % missingValue
+         endwhere
+      else
+         call mpas_log_write('masking array and field array do not have the same dimensions')
+      endif
+
+   end subroutine mpas_mask_field1d_mask1d_real !}}}
+
 
 !***********************************************************************
 !
 !  routine mpas_mask_field2d_mask2d_real
 !
-!> \brief   MPAS 3D real field mask routine.
+!> \brief   MPAS 2D real field mask routine.
 !> \author  Carolyn Begeman, Adrian Turner
 !> \date    05/17/22
 !> \details 
@@ -3008,33 +3083,83 @@ module mpas_field_routines
 
       implicit none
 
-      type (field2DReal), intent(in), pointer :: field !< Input/Output: Field to be masked
-
+      type (field2DReal), intent(in), pointer :: field
       type (field2DInteger), intent(in), pointer :: mask
-
-      real (kind=RKIND), dimension(:,:), intent(inout), pointer :: maskedField !< Input/Output: Field to be masked
+      real (kind=RKIND), dimension(:,:), intent(inout), pointer :: maskedField
 
       real (kind=RKIND), dimension(:,:), pointer :: fieldArray
-      integer :: dim2Length
-      character (len=100) :: log_string
       integer, dimension(:,:), pointer :: maskArray
 
-      dim2Length = SIZE(maskedField, dim=2)
-      fieldArray => field % array(:,1:dim2Length)
-      maskArray => mask % array(:,1:dim2Length)
+      integer, dimension(2) :: fieldDims
+      integer, dimension(2) :: maskDims
 
-      call mpas_log_write('Masking array '//trim(field % fieldName))
-      write(log_string,*) 'fieldArray shape=', SHAPE(fieldArray)
-      call mpas_log_write(log_string)
-      write(log_string,*) 'maskedField shape=', SHAPE(maskedField)
-      call mpas_log_write(log_string)
+      fieldDims = field % dimSizes
+      maskDims = mask % dimSizes
 
-      maskedField = fieldArray ! consider putting in elsewhere
-      where (maskArray == 0)
-         maskedField = field % missingValue
-      endwhere
+      if (fieldDims(1) == maskDims(1) .and. (fieldDims(2) == maskDims(2)) then
+         call mpas_log_write('Masking array '//trim(field % fieldName))
+         maskedField = fieldArray ! consider putting in elsewhere
+         where (maskArray == 0)
+            maskedField = field % missingValue
+         endwhere
+      else
+         call mpas_log_write('masking array and field array do not share dimensions')
+         return
+      endif
 
    end subroutine mpas_mask_field2d_mask2d_real !}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_mask_field2d_mask1d_real
+!
+!> \brief   MPAS 2D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> Masks the source field using a masking array.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_mask_field2d_mask1d_real(field, mask, maskedField) !{{{
+
+      implicit none
+
+      type (field2DReal), intent(in), pointer :: field
+      type (field1DInteger), intent(in), pointer :: mask
+      real (kind=RKIND), dimension(:,:), intent(inout), pointer :: maskedField
+
+      real (kind=RKIND), dimension(:,:), pointer :: fieldArray
+      integer, dimension(:), pointer :: maskArray
+
+      integer, dimension(2) :: fieldDims
+      integer, dimension(1) :: maskDims
+
+      fieldDims = field % dimSizes
+      maskDims = mask % dimSizes
+
+      if (fieldDims(1) == maskDims(1)) then
+         call mpas_log_write('Masking array '//trim(field % fieldName))
+         maskedField = fieldArray ! consider putting in elsewhere
+         do j = 1, fieldDims(2)
+            where (maskArray == 0)
+               maskedField(:, j) = field % missingValue
+            endwhere
+         enddo
+      elseif (fieldDims(2) == maskDims(1)) then
+         call mpas_log_write('Masking array '//trim(field % fieldName))
+         maskedField = fieldArray ! consider putting in elsewhere
+         do i = 1, fieldDims(1)
+            where (maskArray == 0)
+               maskedField(i, :) = field % missingValue
+            endwhere
+         enddo
+      else
+         call mpas_log_write('masking array and field array do not share a dimension')
+         return
+      endif
+
+   end subroutine mpas_mask_field2d_mask1d_real !}}}
 
 
 !***********************************************************************
@@ -3048,38 +3173,166 @@ module mpas_field_routines
 !> Masks the source field using a masking array.
 !
 !-----------------------------------------------------------------------
-!   subroutine mpas_mask_field3d_mask3d_real(field, mask, maskedField) !{{{
+   subroutine mpas_mask_field3d_mask3d_real(field, mask, maskedField) !{{{
+
+      implicit none
+
+      type (field3DReal), intent(in), pointer :: field
+      type (field3DInteger), intent(in), pointer :: mask
+      real (kind=RKIND), dimension(:,:,:), intent(inout), pointer :: maskedField
+
+      real (kind=RKIND), dimension(:,:,:), pointer :: fieldArray
+      integer, dimension(:,:,:), pointer :: maskArray
+
+      integer, dimension(3) :: fieldDims
+      integer, dimension(3) :: maskDims
+
+      fieldDims = field % dimSizes
+      maskDims = mask % dimSizes
+
+      if (fieldDims(1) == maskDims(1) .and. &
+          fieldDims(2) == maskDims(2) .and. &
+          fieldDims(3) == maskDims(3) ) then
+         call mpas_log_write('Masking array '//trim(field % fieldName))
+         maskedField = fieldArray ! consider putting in elsewhere
+         where (maskArray == 0)
+            maskedField = field % missingValue
+         endwhere
+      else
+         call mpas_log_write('masking array and field array do not have the same dimensions')
+      endif
+
+   end subroutine mpas_mask_field3d_mask3d_real !}}}
+
+
+!***********************************************************************
 !
-!      implicit none
+!  routine mpas_mask_field3d_mask2d_real
 !
-!      type (field3DReal), intent(in), pointer :: field !< Input/Output: Field to be masked
+!> \brief   MPAS 3D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> Masks the source field using a masking array.
 !
-!      type (field3DInteger), intent(in), pointer :: mask
+!-----------------------------------------------------------------------
+   subroutine mpas_mask_field3d_mask2d_real(field, mask, maskedField) !{{{
+
+      implicit none
+
+      type (field3DReal), intent(in), pointer :: field
+      type (field2DInteger), intent(in), pointer :: mask
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: maskedField
+
+      real (kind=RKIND), dimension(:,:,:), pointer :: fieldArray
+      integer, dimension(:,:), pointer :: maskArray
+      integer :: i, j, k
+
+      integer, dimension(3) :: fieldDims
+      integer, dimension(2) :: maskDims
+
+      fieldDims = field % dimSizes
+      maskDims = mask % dimSizes
+
+      ! Here we require that the dimension order in mask match the dimension
+      ! order in field
+      if (fieldDims(3) == maskDims(2) .and. fieldDims(2) == maskDims(1)) then
+         call mpas_log_write('Masking array '//trim(field % fieldName))
+         maskedField = fieldArray ! consider putting in elsewhere
+         do i = 1, fieldDims(1)
+            where (maskArray == 0)
+               maskedField(i, :, :) = field % missingValue
+            endwhere
+         enddo
+      elseif (fieldDims(2) == maskDims(2) .and. fieldDims(1) == maskDims(1)) then
+         call mpas_log_write('Masking array '//trim(field % fieldName))
+         maskedField = fieldArray ! consider putting in elsewhere
+         do k = 1, fieldDims(3)
+            where (maskArray == 0)
+               maskedField(:, :, k) = field % missingValue
+            endwhere
+         enddo
+      else
+         !TODO change these to warnings
+         call mpas_log_write('masking array and field array share dimensions')
+         return
+      endif
+
+   end subroutine mpas_mask_field3d_mask2d_real !}}}
+
+
+!***********************************************************************
 !
-!      real (kind=RKIND), dimension(:,:,:), intent(out) :: maskedField !< Input/Output: Field to be masked
-!      ! TODO consider whether this should be of field type or 3d real array
-!      !type (field3DReal), intent(out) :: maskedField !< Input/Output: Field to be masked
+!  routine mpas_mask_field3d_mask1d_real
 !
-!      real (kind=RKIND), dimension(:,:,:), pointer :: fieldArray
+!> \brief   MPAS 3D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> Masks the source field using a masking array.
 !
-!      integer :: i
-!      integer, dimension(3) :: fieldDims
-!      integer, dimension(3) :: maskDims
-!      integer, dimension(:,:,:), pointer :: maskArray
-!
-!      character (len=StrKIND), dimension(3) :: fieldDimNames
-!      character (len=StrKIND), dimension(3) :: maskDimNames
-!
-!      fieldDims = field % dimSizes
-!      fieldDimNames = field % dimNames
-!      maskDims = mask % dimSizes
-!      maskDimNames = mask % dimNames
-!      ! real3d_temp is already allocated in mpas_io_streams
-!      !allocate(maskedField(fieldDims(1),fieldDims(2),fieldDims(3)))
-!
-!      ! TODO use fieldDimNames to know how to transform the mask
-!
-!   end subroutine mpas_mask_field3d_mask3d_real !}}}
+!-----------------------------------------------------------------------
+   subroutine mpas_mask_field3d_mask1d_real(field, mask, maskedField) !{{{
+
+      implicit none
+
+      type (field3DReal), intent(in), pointer :: field
+      type (field1DInteger), intent(in), pointer :: mask
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: maskedField
+
+      real (kind=RKIND), dimension(:,:,:), pointer :: fieldArray
+      integer, dimension(:), pointer :: maskArray
+      integer :: i, j, k
+
+      integer, dimension(3) :: fieldDims
+      integer, dimension(1) :: maskDims
+
+      fieldDims = field % dimSizes
+      maskDims = mask % dimSizes
+
+      ! TODO use fieldDimNames to know how to transform the mask
+      !character (len=StrKIND), dimension(3) :: fieldDimNames
+      !character (len=StrKIND), dimension(2) :: maskDimNames
+
+      !fieldDimNames = field % dimNames
+      !maskDimNames = mask % dimNames
+
+      if (fieldDims(1) == maskDims(1)) then
+         call mpas_log_write('Masking array '//trim(field % fieldName))
+         maskedField = fieldArray ! consider putting in elsewhere
+         do j = 1, fieldDims(2)
+            do k = 1, fieldDims(3) 
+               where (maskArray == 0)
+                  maskedField(:, j, k) = field % missingValue
+               endwhere
+            enddo
+         enddo
+      elseif (fieldDims(2) == maskDims(1)) then
+         call mpas_log_write('Masking array '//trim(field % fieldName))
+         maskedField = fieldArray ! consider putting in elsewhere
+         do i = 1, fieldDims(1)
+            do k = 1, fieldDims(3)
+               where (maskArray == 0)
+                  maskedField(i, :, k) = field % missingValue
+               endwhere
+            enddo
+         enddo
+      elseif (fieldDims(3) == maskDims(1)) then
+         call mpas_log_write('Masking array '//trim(field % fieldName))
+         maskedField = fieldArray ! consider putting in elsewhere
+         do i = 1, fieldDims(1)
+            do j = 1, fieldDims(2) 
+               where (maskArray == 0)
+                  maskedField(i, j, :) = field % missingValue
+               endwhere
+            enddo
+         enddo
+      else
+         call mpas_log_write('masking array and field array share a dimension')
+         return
+      endif
+
+   end subroutine mpas_mask_field3d_mask1d_real !}}}
 
 
 !***********************************************************************

--- a/components/mpas-framework/src/framework/mpas_field_routines.F
+++ b/components/mpas-framework/src/framework/mpas_field_routines.F
@@ -44,9 +44,12 @@ module mpas_field_routines
       module procedure mpas_mask_assign_pointer_field3d_mask3d_real
       module procedure mpas_mask_assign_pointer_field3d_mask2d_real
       module procedure mpas_mask_assign_pointer_field3d_mask1d_real
-      module procedure mpas_mask_assign_pointer_field4d_mask3d_real
-      module procedure mpas_mask_assign_pointer_field4d_mask2d_real
-      module procedure mpas_mask_assign_pointer_field4d_mask1d_real
+      !module procedure mpas_mask_assign_pointer_field4d_mask3d_real
+      !module procedure mpas_mask_assign_pointer_field4d_mask2d_real
+      !module procedure mpas_mask_assign_pointer_field4d_mask1d_real
+      !module procedure mpas_mask_assign_pointer_field5d_mask3d_real
+      !module procedure mpas_mask_assign_pointer_field5d_mask2d_real
+      !module procedure mpas_mask_assign_pointer_field5d_mask1d_real
    end interface
    interface mpas_mask_field
       module procedure mpas_mask_field1d_mask1d_real
@@ -55,9 +58,12 @@ module mpas_field_routines
       module procedure mpas_mask_field3d_mask3d_real
       module procedure mpas_mask_field3d_mask2d_real
       module procedure mpas_mask_field3d_mask1d_real
-      module procedure mpas_mask_field4d_mask3d_real
-      module procedure mpas_mask_field4d_mask2d_real
-      module procedure mpas_mask_field4d_mask1d_real
+      !module procedure mpas_mask_field4d_mask3d_real
+      !module procedure mpas_mask_field4d_mask2d_real
+      !module procedure mpas_mask_field4d_mask1d_real
+      !module procedure mpas_mask_field5d_mask3d_real
+      !module procedure mpas_mask_field5d_mask2d_real
+      !module procedure mpas_mask_field5d_mask1d_real
    end interface
 
    interface mpas_duplicate_field
@@ -2924,7 +2930,8 @@ module mpas_field_routines
       type (field2DReal), intent(inout), pointer :: field
       type (field2DInteger), intent(in), pointer :: mask
 
-      call mpas_log_write('Assign pointer from '//trim(field % fieldName)//' to '//trim(mask % fieldName))
+      !call mpas_log_write('Assign pointer from '//trim(field % fieldName))
+      !call mpas_log_write('Assign pointer to '//trim(mask % fieldName))
       field % missingValueMask2d => mask
 
    end subroutine mpas_mask_assign_pointer_field2d_mask2d_real
@@ -2954,7 +2961,7 @@ module mpas_field_routines
 
 !***********************************************************************
 !
-!  routine mpas_mask_field3d_mask3d_real
+!  routine mpas_mask_assign_pointer_field3d_mask3d_real
 !
 !> \brief   MPAS 3D real field mask routine.
 !> \author  Carolyn Begeman, Adrian Turner
@@ -3047,13 +3054,14 @@ module mpas_field_routines
 
       integer, dimension(1) :: fieldDims
       integer, dimension(1) :: maskDims
+      integer :: blockLength
+
+      blockLength = SIZE(maskedField, dim=1)
+      fieldArray => field % array(1:blockLength)
+      maskArray  => mask  % array(1:blockLength)
 
       fieldDims = field % dimSizes
       maskDims = mask % dimSizes
-
-      !TODO determine whether mask would ever be smaller than field
-      !fieldArray => field % array(1:maskDims(1))
-      !maskArray => mask   % array(1:maskDims(1))
 
       if (fieldDims(1) == maskDims(1) ) then
          call mpas_log_write('Masking array '//trim(field % fieldName))
@@ -3092,16 +3100,28 @@ module mpas_field_routines
 
       integer, dimension(2) :: fieldDims
       integer, dimension(2) :: maskDims
+      integer :: blockLength
+      character(len=100) :: log_string
+
+      blockLength = SIZE(maskedField, dim=2)
+      fieldArray => field % array(:, 1:blockLength)
+      maskArray  => mask  % array(:, 1:blockLength)
 
       fieldDims = field % dimSizes
       maskDims = mask % dimSizes
+      maskedField = fieldArray
 
-      if (fieldDims(1) == maskDims(1) .and. (fieldDims(2) == maskDims(2)) then
-         call mpas_log_write('Masking array '//trim(field % fieldName))
-         maskedField = fieldArray ! consider putting in elsewhere
-         where (maskArray == 0)
-            maskedField = field % missingValue
-         endwhere
+      if (fieldDims(1) == maskDims(1) .and. fieldDims(2) == maskDims(2)) then
+         if (any(maskArray == 1)) then
+            call mpas_log_write('Masking 2d array '//trim(field % fieldName)//&
+                                'with 2d mask '//trim(field % maskName))
+            where (maskArray == 0)
+               maskedField = field % missingValue
+            endwhere
+         else
+            call mpas_log_write('Mask '//trim(field % maskName)//' is zeros, may not be initialized')
+            return
+         endif
       else
          call mpas_log_write('masking array and field array do not share dimensions')
          return
@@ -3131,15 +3151,21 @@ module mpas_field_routines
 
       real (kind=RKIND), dimension(:,:), pointer :: fieldArray
       integer, dimension(:), pointer :: maskArray
+      integer :: i, j
 
       integer, dimension(2) :: fieldDims
       integer, dimension(1) :: maskDims
+      integer :: blockLength
+
+      blockLength = SIZE(maskedField, dim=2)
+      fieldArray => field % array(:, 1:blockLength)
 
       fieldDims = field % dimSizes
       maskDims = mask % dimSizes
 
       if (fieldDims(1) == maskDims(1)) then
          call mpas_log_write('Masking array '//trim(field % fieldName))
+         maskArray  => mask % array
          maskedField = fieldArray ! consider putting in elsewhere
          do j = 1, fieldDims(2)
             where (maskArray == 0)
@@ -3148,6 +3174,7 @@ module mpas_field_routines
          enddo
       elseif (fieldDims(2) == maskDims(1)) then
          call mpas_log_write('Masking array '//trim(field % fieldName))
+         maskArray  => mask % array(1:blockLength)
          maskedField = fieldArray ! consider putting in elsewhere
          do i = 1, fieldDims(1)
             where (maskArray == 0)
@@ -3186,6 +3213,11 @@ module mpas_field_routines
 
       integer, dimension(3) :: fieldDims
       integer, dimension(3) :: maskDims
+      integer :: blockLength
+
+      blockLength = SIZE(maskedField, dim=3)
+      fieldArray => field % array(:, :, 1:blockLength)
+      maskArray  => mask  % array(:, :, 1:blockLength)
 
       fieldDims = field % dimSizes
       maskDims = mask % dimSizes
@@ -3226,38 +3258,49 @@ module mpas_field_routines
 
       real (kind=RKIND), dimension(:,:,:), pointer :: fieldArray
       integer, dimension(:,:), pointer :: maskArray
-      integer :: i, j, k
+      integer :: i, k
 
       integer, dimension(3) :: fieldDims
       integer, dimension(2) :: maskDims
+      integer :: blockLength
+      character(len=100) :: log_string
+
+      blockLength = SIZE(maskedField, dim=3)
+      fieldArray => field % array(:, :, 1:blockLength)
 
       fieldDims = field % dimSizes
       maskDims = mask % dimSizes
 
-      ! Here we require that the dimension order in mask match the dimension
-      ! order in field
-      if (fieldDims(3) == maskDims(2) .and. fieldDims(2) == maskDims(1)) then
-         call mpas_log_write('Masking array '//trim(field % fieldName))
-         maskedField = fieldArray ! consider putting in elsewhere
-         do i = 1, fieldDims(1)
-            where (maskArray == 0)
-               maskedField(i, :, :) = field % missingValue
-            endwhere
-         enddo
-      elseif (fieldDims(2) == maskDims(2) .and. fieldDims(1) == maskDims(1)) then
-         call mpas_log_write('Masking array '//trim(field % fieldName))
-         maskedField = fieldArray ! consider putting in elsewhere
-         do k = 1, fieldDims(3)
-            where (maskArray == 0)
-               maskedField(:, :, k) = field % missingValue
-            endwhere
-         enddo
+      if (any(mask % array == 1)) then
+         call mpas_log_write('Masking 2d array '//trim(field % fieldName)//&
+                             'with 2d mask '//trim(field % maskName))
+         ! Here we require that the dimension order in mask match the dimension
+         ! order in field
+         if (fieldDims(3) == maskDims(2) .and. fieldDims(2) == maskDims(1)) then
+            maskArray  => mask  % array(:, 1:blockLength)
+            maskedField = fieldArray ! consider putting in elsewhere
+            do i = 1, fieldDims(1)
+               where (maskArray == 0)
+                  maskedField(i, :, :) = field % missingValue
+               endwhere
+            enddo
+         elseif (fieldDims(2) == maskDims(2) .and. fieldDims(1) == maskDims(1)) then
+            maskArray  => mask  % array
+            maskedField = fieldArray ! consider putting in elsewhere
+            do k = 1, fieldDims(3)
+               where (maskArray == 0)
+                  maskedField(:, :, k) = field % missingValue
+               endwhere
+            enddo
+         else
+            !TODO change these to warnings
+            call mpas_log_write('masking array and field array do not share dimensions')
+            return
+         endif
       else
-         !TODO change these to warnings
-         call mpas_log_write('masking array and field array share dimensions')
+         call mpas_log_write('Mask '//trim(field % maskName)//' is zeros, may not be initialized')
          return
       endif
-
    end subroutine mpas_mask_field3d_mask2d_real !}}}
 
 
@@ -3286,6 +3329,10 @@ module mpas_field_routines
 
       integer, dimension(3) :: fieldDims
       integer, dimension(1) :: maskDims
+      integer :: blockLength
+
+      blockLength = SIZE(maskedField, dim=3)
+      fieldArray => field % array(:, :, 1:blockLength)
 
       fieldDims = field % dimSizes
       maskDims = mask % dimSizes
@@ -3299,6 +3346,7 @@ module mpas_field_routines
 
       if (fieldDims(1) == maskDims(1)) then
          call mpas_log_write('Masking array '//trim(field % fieldName))
+         maskArray  => mask % array
          maskedField = fieldArray ! consider putting in elsewhere
          do j = 1, fieldDims(2)
             do k = 1, fieldDims(3) 
@@ -3309,6 +3357,7 @@ module mpas_field_routines
          enddo
       elseif (fieldDims(2) == maskDims(1)) then
          call mpas_log_write('Masking array '//trim(field % fieldName))
+         maskArray  => mask % array
          maskedField = fieldArray ! consider putting in elsewhere
          do i = 1, fieldDims(1)
             do k = 1, fieldDims(3)
@@ -3319,6 +3368,7 @@ module mpas_field_routines
          enddo
       elseif (fieldDims(3) == maskDims(1)) then
          call mpas_log_write('Masking array '//trim(field % fieldName))
+         maskArray  => mask % array(1:blockLength)
          maskedField = fieldArray ! consider putting in elsewhere
          do i = 1, fieldDims(1)
             do j = 1, fieldDims(2) 

--- a/components/mpas-framework/src/framework/mpas_field_routines.F
+++ b/components/mpas-framework/src/framework/mpas_field_routines.F
@@ -42,10 +42,11 @@ module mpas_field_routines
       ! TODO module procedure mpas_mask_assign_pointer_field3d_mask2d_real
       !module procedure mpas_mask_assign_pointer_field3d_mask3d_real
    end interface
-   !interface mpas_mask_field
-   !   ! TODO module procedure mpas_mask_field3d_mask2d_real
-   !   module procedure mpas_mask_field3d_mask3d_real
-   !end interface
+   interface mpas_mask_field
+      module procedure mpas_mask_field2d_mask2d_real
+      !module procedure mpas_mask_field3d_mask3d_real
+      ! TODO module procedure mpas_mask_field3d_mask2d_real
+   end interface
 
    interface mpas_duplicate_field
       module procedure mpas_duplicate_field0d_real
@@ -2975,28 +2976,27 @@ module mpas_field_routines
 
       type (field2DInteger), intent(in), pointer :: mask
 
-      real (kind=RKIND), dimension(:,:), intent(out) :: maskedField !< Input/Output: Field to be masked
-      ! TODO consider whether this should be of field type or 3d real array
-      !type (field3DReal), intent(out) :: maskedField !< Input/Output: Field to be masked
+      real (kind=RKIND), dimension(:,:), intent(inout), pointer :: maskedField !< Input/Output: Field to be masked
 
       real (kind=RKIND), dimension(:,:), pointer :: fieldArray
+      integer :: dim2Length
       character (len=100) :: log_string
       integer, dimension(:,:), pointer :: maskArray
 
+      dim2Length = SIZE(maskedField, dim=2)
+      fieldArray => field % array(:,1:dim2Length)
+      maskArray => mask % array(:,1:dim2Length)
+
       call mpas_log_write('Masking array '//trim(field % fieldName))
-      fieldArray = field % array
       write(log_string,*) 'fieldArray shape=', SHAPE(fieldArray)
       call mpas_log_write(log_string)
-      maskArray = mask % array
       write(log_string,*) 'maskedField shape=', SHAPE(maskedField)
       call mpas_log_write(log_string)
-      ! real3d_temp is already allocated in mpas_io_streams
-      !allocate(maskedField(fieldDims(1),fieldDims(2),fieldDims(3)))
 
       maskedField = fieldArray ! consider putting in elsewhere
-      !where (maskArray == 0)
-      !   maskedField = field % missingValue
-      !endwhere
+      where (maskArray == 0)
+         maskedField = field % missingValue
+      endwhere
 
    end subroutine mpas_mask_field2d_mask2d_real !}}}
 

--- a/components/mpas-framework/src/framework/mpas_field_routines.F
+++ b/components/mpas-framework/src/framework/mpas_field_routines.F
@@ -3303,14 +3303,14 @@ module mpas_field_routines
       if (any(maskArray == 1)) then
          if (fieldDims(1) == maskDims(1)) then
             maskArray  => mask % array
-            do j = 1, fieldDims(2)
+            do j = 1, SIZE(maskedField, dim=2)
                where (maskArray == 0)
                   maskedField(:, j) = field % missingValue
                endwhere
             enddo
          elseif (fieldDims(2) == maskDims(1)) then
             maskArray  => mask % array(1:blockLength)
-            do i = 1, fieldDims(1)
+            do i = 1, SIZE(maskedField, dim=1)
                where (maskArray == 0)
                   maskedField(i, :) = field % missingValue
                endwhere
@@ -3421,14 +3421,14 @@ module mpas_field_routines
          ! order in field
          if (fieldDims(3) == maskDims(2) .and. fieldDims(2) == maskDims(1)) then
             maskArray  => mask % array(:, 1:blockLength)
-            do i = 1, fieldDims(1)
+            do i = 1, SIZE(maskedField, dim=1)
                where (maskArray == 0)
                   maskedField(i, :, :) = field % missingValue
                endwhere
             enddo
          elseif (fieldDims(2) == maskDims(2) .and. fieldDims(1) == maskDims(1)) then
             maskArray  => mask % array
-            do k = 1, fieldDims(3)
+            do k = 1, SIZE(maskedField, dim=3)
                where (maskArray == 0)
                   maskedField(:, :, k) = field % missingValue
                endwhere
@@ -3483,8 +3483,8 @@ module mpas_field_routines
       if (any(mask % array == 1)) then
          if (fieldDims(1) == maskDims(1)) then
             maskArray  => mask % array
-            do j = 1, fieldDims(2)
-               do k = 1, fieldDims(3) 
+            do j = 1, SIZE(maskedField, dim=2)
+               do k = 1, SIZE(maskedField, dim=3)
                   where (maskArray == 0)
                      maskedField(:, j, k) = field % missingValue
                   endwhere
@@ -3492,8 +3492,8 @@ module mpas_field_routines
             enddo
          elseif (fieldDims(2) == maskDims(1)) then
             maskArray  => mask % array
-            do i = 1, fieldDims(1)
-               do k = 1, fieldDims(3)
+            do i = 1, SIZE(maskedField, dim=1)
+               do k = 1, SIZE(maskedField, dim=3)
                   where (maskArray == 0)
                      maskedField(i, :, k) = field % missingValue
                   endwhere
@@ -3501,8 +3501,8 @@ module mpas_field_routines
             enddo
          elseif (fieldDims(3) == maskDims(1)) then
             maskArray  => mask % array(1:blockLength)
-            do i = 1, fieldDims(1)
-               do j = 1, fieldDims(2) 
+            do i = 1, SIZE(maskedField, dim=1)
+               do j = 1, SIZE(maskedField, dim=2)
                   where (maskArray == 0)
                      maskedField(i, j, :) = field % missingValue
                   endwhere
@@ -3562,7 +3562,7 @@ module mpas_field_routines
              fieldDims(3) == maskDims(2) .and. &
              fieldDims(4) == maskDims(3) ) then
             maskArray => mask % array(:,:,1:blockLength)
-            do i = 1, fieldDims(1)
+            do i = 1, SIZE(maskedField, dim=1)
                where (maskArray == 0)
                   maskedField(i,:,:,:) = field % missingValue
                endwhere
@@ -3571,7 +3571,7 @@ module mpas_field_routines
                  fieldDims(2) == maskDims(2) .and. &
                  fieldDims(3) == maskDims(3) ) then
             maskArray => mask % array
-            do k = 1, fieldDims(4)
+            do k = 1, SIZE(maskedField, dim=4)
                where (maskArray == 0)
                   maskedField(:,:,:,k) = field % missingValue
                endwhere
@@ -3629,8 +3629,8 @@ module mpas_field_routines
          ! order in field
          if (fieldDims(2) == maskDims(2) .and. fieldDims(1) == maskDims(1)) then
             maskArray => mask % array
-            do j = 1, fieldDims(3)
-            do k = 1, fieldDims(4)
+            do j = 1, SIZE(maskedField, dim=3)
+            do k = 1, SIZE(maskedField, dim=4)
                where (maskArray == 0)
                   maskedField(:, :, j, k) = field % missingValue
                endwhere
@@ -3638,8 +3638,8 @@ module mpas_field_routines
             enddo
          elseif (fieldDims(3) == maskDims(2) .and. fieldDims(2) == maskDims(1)) then
             maskArray  => mask % array
-            do i = 1, fieldDims(1)
-            do k = 1, fieldDims(4)
+            do i = 1, SIZE(maskedField, dim=1)
+            do k = 1, SIZE(maskedField, dim=4)
                where (maskArray == 0)
                   maskedField(i, :, :, k) = field % missingValue
                endwhere
@@ -3647,8 +3647,8 @@ module mpas_field_routines
             enddo
          elseif (fieldDims(3) == maskDims(2) .and. fieldDims(4) == maskDims(1)) then
             maskArray => mask % array(:, 1:blockLength)
-            do i = 1, fieldDims(1)
-            do j = 1, fieldDims(2)
+            do i = 1, SIZE(maskedField, dim=1)
+            do j = 1, SIZE(maskedField, dim=2)
                where (maskArray == 0)
                   maskedField(i, j, :, :) = field % missingValue
                endwhere
@@ -3706,9 +3706,9 @@ module mpas_field_routines
          ! order in field
          if (fieldDims(1) == maskDims(1)) then
             maskArray => mask % array
-            do i = 1, fieldDims(2)
-            do j = 1, fieldDims(3)
-            do k = 1, fieldDims(4) 
+            do i = 1, SIZE(maskedField, dim=2)
+            do j = 1, SIZE(maskedField, dim=3)
+            do k = 1, SIZE(maskedField, dim=4)
                where (maskArray == 0)
                   maskedField(:, i, j, k) = field % missingValue
                endwhere
@@ -3717,9 +3717,9 @@ module mpas_field_routines
             enddo
          elseif (fieldDims(2) == maskDims(1)) then
             maskArray => mask % array
-            do i = 1, fieldDims(1)
-            do j = 1, fieldDims(3)
-            do k = 1, fieldDims(4)
+            do i = 1, SIZE(maskedField, dim=1)
+            do j = 1, SIZE(maskedField, dim=3)
+            do k = 1, SIZE(maskedField, dim=4)
                where (maskArray == 0)
                   maskedField(i, :, j, k) = field % missingValue
                endwhere
@@ -3728,9 +3728,9 @@ module mpas_field_routines
             enddo
          elseif (fieldDims(3) == maskDims(1)) then
             maskArray => mask % array
-            do i = 1, fieldDims(1)
-            do j = 1, fieldDims(2) 
-            do k = 1, fieldDims(4) 
+            do i = 1, SIZE(maskedField, dim=1)
+            do j = 1, SIZE(maskedField, dim=2)
+            do k = 1, SIZE(maskedField, dim=4)
                where (maskArray == 0)
                   maskedField(i, j, :, k) = field % missingValue
                endwhere
@@ -3739,9 +3739,9 @@ module mpas_field_routines
             enddo
          elseif (fieldDims(4) == maskDims(1)) then
             maskArray => mask % array(1:blockLength)
-            do i = 1, fieldDims(1)
-            do j = 1, fieldDims(2) 
-            do k = 1, fieldDims(3) 
+            do i = 1, SIZE(maskedField, dim=1)
+            do j = 1, SIZE(maskedField, dim=2)
+            do k = 1, SIZE(maskedField, dim=3)
                where (maskArray == 0)
                   maskedField(i, j, k, :) = field % missingValue
                endwhere
@@ -3802,8 +3802,8 @@ module mpas_field_routines
              fieldDims(2) == maskDims(2) .and. &
              fieldDims(3) == maskDims(3) ) then
             maskArray => mask % array
-            do i = 1, fieldDims(4)
-            do k = 1, fieldDims(5)
+            do i = 1, SIZE(maskedField, dim=4)
+            do k = 1, SIZE(maskedField, dim=5)
                where (maskArray == 0)
                   maskedField(:,:,:,i,k) = field % missingValue
                endwhere
@@ -3813,8 +3813,8 @@ module mpas_field_routines
                  fieldDims(3) == maskDims(2) .and. &
                  fieldDims(4) == maskDims(3) ) then
             maskArray => mask % array
-            do i = 1, fieldDims(1)
-            do k = 1, fieldDims(5)
+            do i = 1, SIZE(maskedField, dim=1)
+            do k = 1, SIZE(maskedField, dim=5)
                where (maskArray == 0)
                   maskedField(i,:,:,:,k) = field % missingValue
                endwhere
@@ -3824,8 +3824,8 @@ module mpas_field_routines
                  fieldDims(4) == maskDims(2) .and. &
                  fieldDims(5) == maskDims(3) ) then
             maskArray => mask % array(:,:,1:blockLength)
-            do i = 1, fieldDims(1)
-            do k = 1, fieldDims(2)
+            do i = 1, SIZE(maskedField, dim=1)
+            do k = 1, SIZE(maskedField, dim=2)
                where (maskArray == 0)
                   maskedField(i,k,:,:,:) = field % missingValue
                endwhere
@@ -3883,9 +3883,9 @@ module mpas_field_routines
          ! order in field
          if (fieldDims(2) == maskDims(2) .and. fieldDims(1) == maskDims(1)) then
             maskArray => mask % array
-            do i = 1, fieldDims(3)
-            do j = 1, fieldDims(4)
-            do k = 1, fieldDims(5)
+            do i = 1, SIZE(maskedField, dim=3)
+            do j = 1, SIZE(maskedField, dim=4)
+            do k = 1, SIZE(maskedField, dim=5)
                where (maskArray == 0)
                   maskedField(:,:,i,j,k) = field % missingValue
                endwhere
@@ -3894,9 +3894,9 @@ module mpas_field_routines
             enddo
          elseif (fieldDims(3) == maskDims(2) .and. fieldDims(2) == maskDims(1)) then
             maskArray => mask % array
-            do i = 1, fieldDims(1)
-            do j = 1, fieldDims(4)
-            do k = 1, fieldDims(5)
+            do i = 1, SIZE(maskedField, dim=1)
+            do j = 1, SIZE(maskedField, dim=4)
+            do k = 1, SIZE(maskedField, dim=5)
                where (maskArray == 0)
                   maskedField(i,:,:,j,k) = field % missingValue
                endwhere
@@ -3905,9 +3905,9 @@ module mpas_field_routines
             enddo
          elseif (fieldDims(4) == maskDims(2) .and. fieldDims(3) == maskDims(1)) then
             maskArray => mask % array
-            do i = 1, fieldDims(1)
-            do j = 1, fieldDims(2)
-            do k = 1, fieldDims(5)
+            do i = 1, SIZE(maskedField, dim=1)
+            do j = 1, SIZE(maskedField, dim=2)
+            do k = 1, SIZE(maskedField, dim=5)
                where (maskArray == 0)
                   maskedField(i,j,:,:,k) = field % missingValue
                endwhere
@@ -3916,9 +3916,9 @@ module mpas_field_routines
             enddo
          elseif (fieldDims(5) == maskDims(2) .and. fieldDims(4) == maskDims(1)) then
             maskArray => mask % array(:, 1:blockLength)
-            do i = 1, fieldDims(1)
-            do j = 1, fieldDims(2)
-            do k = 1, fieldDims(3)
+            do i = 1, SIZE(maskedField, dim=1)
+            do j = 1, SIZE(maskedField, dim=2)
+            do k = 1, SIZE(maskedField, dim=3)
                where (maskArray == 0)
                   maskedField(i,j,k,:,:) = field % missingValue
                endwhere
@@ -3977,10 +3977,10 @@ module mpas_field_routines
          ! order in field
          if (fieldDims(1) == maskDims(1)) then
             maskArray => mask % array
-            do i = 1, fieldDims(2)
-            do j = 1, fieldDims(3)
-            do k = 1, fieldDims(4) 
-            do p = 1, fieldDims(5) 
+            do i = 1, SIZE(maskedField, dim=2)
+            do j = 1, SIZE(maskedField, dim=3)
+            do k = 1, SIZE(maskedField, dim=4)
+            do p = 1, SIZE(maskedField, dim=5)
                where (maskArray == 0)
                   maskedField(:,i,j,k,p) = field % missingValue
                endwhere
@@ -3990,10 +3990,10 @@ module mpas_field_routines
             enddo
          elseif (fieldDims(2) == maskDims(1)) then
             maskArray => mask % array
-            do i = 1, fieldDims(1)
-            do j = 1, fieldDims(3)
-            do k = 1, fieldDims(4)
-            do p = 1, fieldDims(5) 
+            do i = 1, SIZE(maskedField, dim=1)
+            do j = 1, SIZE(maskedField, dim=3)
+            do k = 1, SIZE(maskedField, dim=4)
+            do p = 1, SIZE(maskedField, dim=5)
                where (maskArray == 0)
                   maskedField(i,:,j,k,p) = field % missingValue
                endwhere
@@ -4003,10 +4003,10 @@ module mpas_field_routines
             enddo
          elseif (fieldDims(3) == maskDims(1)) then
             maskArray => mask % array
-            do i = 1, fieldDims(1)
-            do j = 1, fieldDims(2) 
-            do k = 1, fieldDims(4) 
-            do p = 1, fieldDims(5) 
+            do i = 1, SIZE(maskedField, dim=1)
+            do j = 1, SIZE(maskedField, dim=2)
+            do k = 1, SIZE(maskedField, dim=4)
+            do p = 1, SIZE(maskedField, dim=5)
                where (maskArray == 0)
                   maskedField(i,j,:,k,p) = field % missingValue
                endwhere
@@ -4016,10 +4016,10 @@ module mpas_field_routines
             enddo
          elseif (fieldDims(4) == maskDims(1)) then
             maskArray => mask % array
-            do i = 1, fieldDims(1)
-            do j = 1, fieldDims(2) 
-            do k = 1, fieldDims(3) 
-            do p = 1, fieldDims(5) 
+            do i = 1, SIZE(maskedField, dim=1)
+            do j = 1, SIZE(maskedField, dim=2)
+            do k = 1, SIZE(maskedField, dim=3)
+            do p = 1, SIZE(maskedField, dim=5)
                where (maskArray == 0)
                   maskedField(i,j,k,:,p) = field % missingValue
                endwhere
@@ -4029,10 +4029,10 @@ module mpas_field_routines
             enddo
          elseif (fieldDims(5) == maskDims(1)) then
             maskArray => mask % array(1:blockLength)
-            do i = 1, fieldDims(1)
-            do j = 1, fieldDims(2) 
-            do k = 1, fieldDims(3) 
-            do p = 1, fieldDims(4) 
+            do i = 1, SIZE(maskedField, dim=1)
+            do j = 1, SIZE(maskedField, dim=2)
+            do k = 1, SIZE(maskedField, dim=3)
+            do p = 1, SIZE(maskedField, dim=4)
                where (maskArray == 0)
                   maskedField(i,j,k,p,:) = field % missingValue
                endwhere

--- a/components/mpas-framework/src/framework/mpas_field_routines.F
+++ b/components/mpas-framework/src/framework/mpas_field_routines.F
@@ -3172,32 +3172,32 @@ module mpas_field_routines
 !> Masks the source field using a masking array.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_mask_field1d_mask1d_real(field, mask, maskedField) !{{{
+   subroutine mpas_mask_field1d_mask1d_real(field, mask, maskedArray) !{{{
 
       implicit none
 
       type (field1DReal), intent(in), pointer :: field
       type (field1DInteger), intent(in), pointer :: mask
-      real (kind=RKIND), dimension(:), intent(inout), pointer :: maskedField
+      real (kind=RKIND), dimension(:), intent(inout), pointer :: maskedArray
 
       real (kind=RKIND), dimension(:), pointer :: fieldArray
-      integer, dimension(:), pointer :: maskArray
+      integer, dimension(:), pointer :: maskingArray
 
       integer, dimension(1) :: fieldDims
       integer, dimension(1) :: maskDims
       integer :: blockLength
 
-      blockLength = SIZE(maskedField, dim=1)
+      blockLength = SIZE(maskedArray, dim=1)
       fieldArray => field % array(1:blockLength)
-      maskArray  => mask  % array(1:blockLength)
+      maskingArray  => mask  % array(1:blockLength)
 
       fieldDims = field % dimSizes
       maskDims = mask % dimSizes
 
-      if (any(maskArray == 1)) then
+      if (any(maskingArray == 1)) then
          if (fieldDims(1) == maskDims(1) ) then
-            where (maskArray == 0)
-               maskedField = field % missingValue
+            where (maskingArray == 0)
+               maskedArray = field % missingValue
             endwhere
          else
             call mpas_log_write('Masking array and field array do not have'// &
@@ -3223,34 +3223,34 @@ module mpas_field_routines
 !> Masks the source field using a masking array.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_mask_field2d_mask2d_real(field, mask, maskedField) !{{{
+   subroutine mpas_mask_field2d_mask2d_real(field, mask, maskedArray) !{{{
 
       implicit none
 
       type (field2DReal), intent(in), pointer :: field
       type (field2DInteger), intent(in), pointer :: mask
-      real (kind=RKIND), dimension(:,:), intent(inout), pointer :: maskedField
+      real (kind=RKIND), dimension(:,:), intent(inout), pointer :: maskedArray
 
       real (kind=RKIND), dimension(:,:), pointer :: fieldArray
-      integer, dimension(:,:), pointer :: maskArray
+      integer, dimension(:,:), pointer :: maskingArray
 
       integer, dimension(2) :: fieldDims
       integer, dimension(2) :: maskDims
       integer :: blockLength
       character(len=100) :: log_string
 
-      blockLength = SIZE(maskedField, dim=2)
+      blockLength = SIZE(maskedArray, dim=2)
       fieldArray => field % array(:, 1:blockLength)
-      maskArray  => mask  % array(:, 1:blockLength)
+      maskingArray  => mask  % array(:, 1:blockLength)
 
       fieldDims = field % dimSizes
       maskDims = mask % dimSizes
-      maskedField = fieldArray
+      maskedArray = fieldArray
 
-      if (any(maskArray == 1)) then
+      if (any(maskingArray == 1)) then
          if (fieldDims(1) == maskDims(1) .and. fieldDims(2) == maskDims(2)) then
-            where (maskArray == 0)
-               maskedField = field % missingValue
+            where (maskingArray == 0)
+               maskedArray = field % missingValue
             endwhere
          else
             call mpas_log_write('Masking array and field array do not share dimensions', &
@@ -3277,42 +3277,42 @@ module mpas_field_routines
 !> Masks the source field using a masking array.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_mask_field2d_mask1d_real(field, mask, maskedField) !{{{
+   subroutine mpas_mask_field2d_mask1d_real(field, mask, maskedArray) !{{{
 
       implicit none
 
       type (field2DReal), intent(in), pointer :: field
       type (field1DInteger), intent(in), pointer :: mask
-      real (kind=RKIND), dimension(:,:), intent(inout), pointer :: maskedField
+      real (kind=RKIND), dimension(:,:), intent(inout), pointer :: maskedArray
 
       real (kind=RKIND), dimension(:,:), pointer :: fieldArray
-      integer, dimension(:), pointer :: maskArray
+      integer, dimension(:), pointer :: maskingArray
       integer :: i, j
 
       integer, dimension(2) :: fieldDims
       integer, dimension(1) :: maskDims
       integer :: blockLength
 
-      blockLength = SIZE(maskedField, dim=2)
+      blockLength = SIZE(maskedArray, dim=2)
       fieldArray => field % array(:, 1:blockLength)
 
       fieldDims = field % dimSizes
       maskDims = mask % dimSizes
-      maskArray  => mask % array
+      maskingArray  => mask % array
 
-      if (any(maskArray == 1)) then
+      if (any(maskingArray == 1)) then
          if (fieldDims(1) == maskDims(1)) then
-            maskArray  => mask % array
-            do j = 1, SIZE(maskedField, dim=2)
-               where (maskArray == 0)
-                  maskedField(:, j) = field % missingValue
+            maskingArray  => mask % array
+            do j = 1, SIZE(maskedArray, dim=2)
+               where (maskingArray == 0)
+                  maskedArray(:, j) = field % missingValue
                endwhere
             enddo
          elseif (fieldDims(2) == maskDims(1)) then
-            maskArray  => mask % array(1:blockLength)
-            do i = 1, SIZE(maskedField, dim=1)
-               where (maskArray == 0)
-                  maskedField(i, :) = field % missingValue
+            maskingArray  => mask % array(1:blockLength)
+            do i = 1, SIZE(maskedArray, dim=1)
+               where (maskingArray == 0)
+                  maskedArray(i, :) = field % missingValue
                endwhere
             enddo
          else
@@ -3340,34 +3340,34 @@ module mpas_field_routines
 !> Masks the source field using a masking array.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_mask_field3d_mask3d_real(field, mask, maskedField) !{{{
+   subroutine mpas_mask_field3d_mask3d_real(field, mask, maskedArray) !{{{
 
       implicit none
 
       type (field3DReal), intent(in), pointer :: field
       type (field3DInteger), intent(in), pointer :: mask
-      real (kind=RKIND), dimension(:,:,:), intent(inout), pointer :: maskedField
+      real (kind=RKIND), dimension(:,:,:), intent(inout), pointer :: maskedArray
 
       real (kind=RKIND), dimension(:,:,:), pointer :: fieldArray
-      integer, dimension(:,:,:), pointer :: maskArray
+      integer, dimension(:,:,:), pointer :: maskingArray
 
       integer, dimension(3) :: fieldDims
       integer, dimension(3) :: maskDims
       integer :: blockLength
 
-      blockLength = SIZE(maskedField, dim=3)
+      blockLength = SIZE(maskedArray, dim=3)
       fieldArray => field % array(:, :, 1:blockLength)
-      maskArray  => mask  % array(:, :, 1:blockLength)
+      maskingArray  => mask  % array(:, :, 1:blockLength)
 
       fieldDims = field % dimSizes
       maskDims = mask % dimSizes
 
-      if (any(maskArray == 1)) then
+      if (any(maskingArray == 1)) then
          if (fieldDims(1) == maskDims(1) .and. &
              fieldDims(2) == maskDims(2) .and. &
              fieldDims(3) == maskDims(3) ) then
-            where (maskArray == 0)
-               maskedField = field % missingValue
+            where (maskingArray == 0)
+               maskedArray = field % missingValue
             endwhere
          else
             call mpas_log_write('Masking array and field array do not have the'// &
@@ -3393,16 +3393,16 @@ module mpas_field_routines
 !> Masks the source field using a masking array.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_mask_field3d_mask2d_real(field, mask, maskedField) !{{{
+   subroutine mpas_mask_field3d_mask2d_real(field, mask, maskedArray) !{{{
 
       implicit none
 
       type (field3DReal), intent(in), pointer :: field
       type (field2DInteger), intent(in), pointer :: mask
-      real (kind=RKIND), dimension(:,:,:), intent(inout) :: maskedField
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: maskedArray
 
       real (kind=RKIND), dimension(:,:,:), pointer :: fieldArray
-      integer, dimension(:,:), pointer :: maskArray
+      integer, dimension(:,:), pointer :: maskingArray
       integer :: i, k
 
       integer, dimension(3) :: fieldDims
@@ -3410,7 +3410,7 @@ module mpas_field_routines
       integer :: blockLength
       character(len=100) :: log_string
 
-      blockLength = SIZE(maskedField, dim=3)
+      blockLength = SIZE(maskedArray, dim=3)
       fieldArray => field % array(:, :, 1:blockLength)
 
       fieldDims = field % dimSizes
@@ -3420,17 +3420,17 @@ module mpas_field_routines
          ! Here we require that the dimension order in mask match the dimension
          ! order in field
          if (fieldDims(3) == maskDims(2) .and. fieldDims(2) == maskDims(1)) then
-            maskArray  => mask % array(:, 1:blockLength)
-            do i = 1, SIZE(maskedField, dim=1)
-               where (maskArray == 0)
-                  maskedField(i, :, :) = field % missingValue
+            maskingArray  => mask % array(:, 1:blockLength)
+            do i = 1, SIZE(maskedArray, dim=1)
+               where (maskingArray == 0)
+                  maskedArray(i, :, :) = field % missingValue
                endwhere
             enddo
          elseif (fieldDims(2) == maskDims(2) .and. fieldDims(1) == maskDims(1)) then
-            maskArray  => mask % array
-            do k = 1, SIZE(maskedField, dim=3)
-               where (maskArray == 0)
-                  maskedField(:, :, k) = field % missingValue
+            maskingArray  => mask % array
+            do k = 1, SIZE(maskedArray, dim=3)
+               where (maskingArray == 0)
+                  maskedArray(:, :, k) = field % missingValue
                endwhere
             enddo
          else
@@ -3458,23 +3458,23 @@ module mpas_field_routines
 !> Masks the source field using a masking array.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_mask_field3d_mask1d_real(field, mask, maskedField) !{{{
+   subroutine mpas_mask_field3d_mask1d_real(field, mask, maskedArray) !{{{
 
       implicit none
 
       type (field3DReal), intent(in), pointer :: field
       type (field1DInteger), intent(in), pointer :: mask
-      real (kind=RKIND), dimension(:,:,:), intent(inout) :: maskedField
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: maskedArray
 
       real (kind=RKIND), dimension(:,:,:), pointer :: fieldArray
-      integer, dimension(:), pointer :: maskArray
+      integer, dimension(:), pointer :: maskingArray
       integer :: i, j, k
 
       integer, dimension(3) :: fieldDims
       integer, dimension(1) :: maskDims
       integer :: blockLength
 
-      blockLength = SIZE(maskedField, dim=3)
+      blockLength = SIZE(maskedArray, dim=3)
       fieldArray => field % array(:, :, 1:blockLength)
 
       fieldDims = field % dimSizes
@@ -3482,29 +3482,29 @@ module mpas_field_routines
 
       if (any(mask % array == 1)) then
          if (fieldDims(1) == maskDims(1)) then
-            maskArray  => mask % array
-            do j = 1, SIZE(maskedField, dim=2)
-               do k = 1, SIZE(maskedField, dim=3)
-                  where (maskArray == 0)
-                     maskedField(:, j, k) = field % missingValue
+            maskingArray  => mask % array
+            do j = 1, SIZE(maskedArray, dim=2)
+               do k = 1, SIZE(maskedArray, dim=3)
+                  where (maskingArray == 0)
+                     maskedArray(:, j, k) = field % missingValue
                   endwhere
                enddo
             enddo
          elseif (fieldDims(2) == maskDims(1)) then
-            maskArray  => mask % array
-            do i = 1, SIZE(maskedField, dim=1)
-               do k = 1, SIZE(maskedField, dim=3)
-                  where (maskArray == 0)
-                     maskedField(i, :, k) = field % missingValue
+            maskingArray  => mask % array
+            do i = 1, SIZE(maskedArray, dim=1)
+               do k = 1, SIZE(maskedArray, dim=3)
+                  where (maskingArray == 0)
+                     maskedArray(i, :, k) = field % missingValue
                   endwhere
                enddo
             enddo
          elseif (fieldDims(3) == maskDims(1)) then
-            maskArray  => mask % array(1:blockLength)
-            do i = 1, SIZE(maskedField, dim=1)
-               do j = 1, SIZE(maskedField, dim=2)
-                  where (maskArray == 0)
-                     maskedField(i, j, :) = field % missingValue
+            maskingArray  => mask % array(1:blockLength)
+            do i = 1, SIZE(maskedArray, dim=1)
+               do j = 1, SIZE(maskedArray, dim=2)
+                  where (maskingArray == 0)
+                     maskedArray(i, j, :) = field % missingValue
                   endwhere
                enddo
             enddo
@@ -3533,23 +3533,23 @@ module mpas_field_routines
 !> Masks the source field using a masking array.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_mask_field4d_mask3d_real(field, mask, maskedField) !{{{
+   subroutine mpas_mask_field4d_mask3d_real(field, mask, maskedArray) !{{{
 
       implicit none
 
       type (field4DReal), intent(in), pointer :: field
       type (field3DInteger), intent(in), pointer :: mask
-      real (kind=RKIND), dimension(:,:,:,:), intent(inout), pointer :: maskedField
+      real (kind=RKIND), dimension(:,:,:,:), intent(inout), pointer :: maskedArray
 
       real (kind=RKIND), dimension(:,:,:,:), pointer :: fieldArray
-      integer, dimension(:,:,:), pointer :: maskArray
+      integer, dimension(:,:,:), pointer :: maskingArray
 
       integer, dimension(4) :: fieldDims
       integer, dimension(3) :: maskDims
       integer :: blockLength
       integer :: i, k
 
-      blockLength = SIZE(maskedField, dim=4)
+      blockLength = SIZE(maskedArray, dim=4)
       fieldArray => field % array(:,:,:,1:blockLength)
 
       fieldDims = field % dimSizes
@@ -3561,19 +3561,19 @@ module mpas_field_routines
          if (fieldDims(2) == maskDims(1) .and. &
              fieldDims(3) == maskDims(2) .and. &
              fieldDims(4) == maskDims(3) ) then
-            maskArray => mask % array(:,:,1:blockLength)
-            do i = 1, SIZE(maskedField, dim=1)
-               where (maskArray == 0)
-                  maskedField(i,:,:,:) = field % missingValue
+            maskingArray => mask % array(:,:,1:blockLength)
+            do i = 1, SIZE(maskedArray, dim=1)
+               where (maskingArray == 0)
+                  maskedArray(i,:,:,:) = field % missingValue
                endwhere
             enddo
          elseif (fieldDims(1) == maskDims(1) .and. &
                  fieldDims(2) == maskDims(2) .and. &
                  fieldDims(3) == maskDims(3) ) then
-            maskArray => mask % array
-            do k = 1, SIZE(maskedField, dim=4)
-               where (maskArray == 0)
-                  maskedField(:,:,:,k) = field % missingValue
+            maskingArray => mask % array
+            do k = 1, SIZE(maskedArray, dim=4)
+               where (maskingArray == 0)
+                  maskedArray(:,:,:,k) = field % missingValue
                endwhere
             enddo
          else
@@ -3601,16 +3601,16 @@ module mpas_field_routines
 !> Masks the source field using a masking array.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_mask_field4d_mask2d_real(field, mask, maskedField) !{{{
+   subroutine mpas_mask_field4d_mask2d_real(field, mask, maskedArray) !{{{
 
       implicit none
 
       type (field4DReal), intent(in), pointer :: field
       type (field2DInteger), intent(in), pointer :: mask
-      real (kind=RKIND), dimension(:,:,:,:), intent(inout) :: maskedField
+      real (kind=RKIND), dimension(:,:,:,:), intent(inout) :: maskedArray
 
       real (kind=RKIND), dimension(:,:,:,:), pointer :: fieldArray
-      integer, dimension(:,:), pointer :: maskArray
+      integer, dimension(:,:), pointer :: maskingArray
       integer :: i, j, k
 
       integer, dimension(4) :: fieldDims
@@ -3618,7 +3618,7 @@ module mpas_field_routines
       integer :: blockLength
       character(len=100) :: log_string
 
-      blockLength = SIZE(maskedField, dim=4)
+      blockLength = SIZE(maskedArray, dim=4)
       fieldArray => field % array(:, :, :, 1:blockLength)
 
       fieldDims = field % dimSizes
@@ -3628,29 +3628,29 @@ module mpas_field_routines
          ! Here we require that the dimension order in mask match the dimension
          ! order in field
          if (fieldDims(2) == maskDims(2) .and. fieldDims(1) == maskDims(1)) then
-            maskArray => mask % array
-            do j = 1, SIZE(maskedField, dim=3)
-            do k = 1, SIZE(maskedField, dim=4)
-               where (maskArray == 0)
-                  maskedField(:, :, j, k) = field % missingValue
+            maskingArray => mask % array
+            do j = 1, SIZE(maskedArray, dim=3)
+            do k = 1, SIZE(maskedArray, dim=4)
+               where (maskingArray == 0)
+                  maskedArray(:, :, j, k) = field % missingValue
                endwhere
             enddo
             enddo
          elseif (fieldDims(3) == maskDims(2) .and. fieldDims(2) == maskDims(1)) then
-            maskArray  => mask % array
-            do i = 1, SIZE(maskedField, dim=1)
-            do k = 1, SIZE(maskedField, dim=4)
-               where (maskArray == 0)
-                  maskedField(i, :, :, k) = field % missingValue
+            maskingArray  => mask % array
+            do i = 1, SIZE(maskedArray, dim=1)
+            do k = 1, SIZE(maskedArray, dim=4)
+               where (maskingArray == 0)
+                  maskedArray(i, :, :, k) = field % missingValue
                endwhere
             enddo
             enddo
          elseif (fieldDims(3) == maskDims(2) .and. fieldDims(4) == maskDims(1)) then
-            maskArray => mask % array(:, 1:blockLength)
-            do i = 1, SIZE(maskedField, dim=1)
-            do j = 1, SIZE(maskedField, dim=2)
-               where (maskArray == 0)
-                  maskedField(i, j, :, :) = field % missingValue
+            maskingArray => mask % array(:, 1:blockLength)
+            do i = 1, SIZE(maskedArray, dim=1)
+            do j = 1, SIZE(maskedArray, dim=2)
+               where (maskingArray == 0)
+                  maskedArray(i, j, :, :) = field % missingValue
                endwhere
             enddo
             enddo
@@ -3679,23 +3679,23 @@ module mpas_field_routines
 !> Masks the source field using a masking array.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_mask_field4d_mask1d_real(field, mask, maskedField) !{{{
+   subroutine mpas_mask_field4d_mask1d_real(field, mask, maskedArray) !{{{
 
       implicit none
 
       type (field4DReal), intent(in), pointer :: field
       type (field1DInteger), intent(in), pointer :: mask
-      real (kind=RKIND), dimension(:,:,:,:), intent(inout) :: maskedField
+      real (kind=RKIND), dimension(:,:,:,:), intent(inout) :: maskedArray
 
       real (kind=RKIND), dimension(:,:,:,:), pointer :: fieldArray
-      integer, dimension(:), pointer :: maskArray
+      integer, dimension(:), pointer :: maskingArray
       integer :: i, j, k
 
       integer, dimension(4) :: fieldDims
       integer, dimension(1) :: maskDims
       integer :: blockLength
 
-      blockLength = SIZE(maskedField, dim=4)
+      blockLength = SIZE(maskedArray, dim=4)
       fieldArray => field % array(:, :, :, 1:blockLength)
 
       fieldDims = field % dimSizes
@@ -3705,45 +3705,45 @@ module mpas_field_routines
          ! Here we require that the dimension order in mask match the dimension
          ! order in field
          if (fieldDims(1) == maskDims(1)) then
-            maskArray => mask % array
-            do i = 1, SIZE(maskedField, dim=2)
-            do j = 1, SIZE(maskedField, dim=3)
-            do k = 1, SIZE(maskedField, dim=4)
-               where (maskArray == 0)
-                  maskedField(:, i, j, k) = field % missingValue
+            maskingArray => mask % array
+            do i = 1, SIZE(maskedArray, dim=2)
+            do j = 1, SIZE(maskedArray, dim=3)
+            do k = 1, SIZE(maskedArray, dim=4)
+               where (maskingArray == 0)
+                  maskedArray(:, i, j, k) = field % missingValue
                endwhere
             enddo
             enddo
             enddo
          elseif (fieldDims(2) == maskDims(1)) then
-            maskArray => mask % array
-            do i = 1, SIZE(maskedField, dim=1)
-            do j = 1, SIZE(maskedField, dim=3)
-            do k = 1, SIZE(maskedField, dim=4)
-               where (maskArray == 0)
-                  maskedField(i, :, j, k) = field % missingValue
+            maskingArray => mask % array
+            do i = 1, SIZE(maskedArray, dim=1)
+            do j = 1, SIZE(maskedArray, dim=3)
+            do k = 1, SIZE(maskedArray, dim=4)
+               where (maskingArray == 0)
+                  maskedArray(i, :, j, k) = field % missingValue
                endwhere
             enddo
             enddo
             enddo
          elseif (fieldDims(3) == maskDims(1)) then
-            maskArray => mask % array
-            do i = 1, SIZE(maskedField, dim=1)
-            do j = 1, SIZE(maskedField, dim=2)
-            do k = 1, SIZE(maskedField, dim=4)
-               where (maskArray == 0)
-                  maskedField(i, j, :, k) = field % missingValue
+            maskingArray => mask % array
+            do i = 1, SIZE(maskedArray, dim=1)
+            do j = 1, SIZE(maskedArray, dim=2)
+            do k = 1, SIZE(maskedArray, dim=4)
+               where (maskingArray == 0)
+                  maskedArray(i, j, :, k) = field % missingValue
                endwhere
             enddo
             enddo
             enddo
          elseif (fieldDims(4) == maskDims(1)) then
-            maskArray => mask % array(1:blockLength)
-            do i = 1, SIZE(maskedField, dim=1)
-            do j = 1, SIZE(maskedField, dim=2)
-            do k = 1, SIZE(maskedField, dim=3)
-               where (maskArray == 0)
-                  maskedField(i, j, k, :) = field % missingValue
+            maskingArray => mask % array(1:blockLength)
+            do i = 1, SIZE(maskedArray, dim=1)
+            do j = 1, SIZE(maskedArray, dim=2)
+            do k = 1, SIZE(maskedArray, dim=3)
+               where (maskingArray == 0)
+                  maskedArray(i, j, k, :) = field % missingValue
                endwhere
             enddo
             enddo
@@ -3773,23 +3773,23 @@ module mpas_field_routines
 !> Masks the source field using a masking array.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_mask_field5d_mask3d_real(field, mask, maskedField) !{{{
+   subroutine mpas_mask_field5d_mask3d_real(field, mask, maskedArray) !{{{
 
       implicit none
 
       type (field5DReal), intent(in), pointer :: field
       type (field3DInteger), intent(in), pointer :: mask
-      real (kind=RKIND), dimension(:,:,:,:,:), intent(inout), pointer :: maskedField
+      real (kind=RKIND), dimension(:,:,:,:,:), intent(inout), pointer :: maskedArray
 
       real (kind=RKIND), dimension(:,:,:,:,:), pointer :: fieldArray
-      integer, dimension(:,:,:), pointer :: maskArray
+      integer, dimension(:,:,:), pointer :: maskingArray
 
       integer, dimension(5) :: fieldDims
       integer, dimension(3) :: maskDims
       integer :: blockLength
       integer :: i, k
 
-      blockLength = SIZE(maskedField, dim=5)
+      blockLength = SIZE(maskedArray, dim=5)
       fieldArray => field % array(:,:,:,:,1:blockLength)
 
       fieldDims = field % dimSizes
@@ -3801,33 +3801,33 @@ module mpas_field_routines
          if (fieldDims(1) == maskDims(1) .and. &
              fieldDims(2) == maskDims(2) .and. &
              fieldDims(3) == maskDims(3) ) then
-            maskArray => mask % array
-            do i = 1, SIZE(maskedField, dim=4)
-            do k = 1, SIZE(maskedField, dim=5)
-               where (maskArray == 0)
-                  maskedField(:,:,:,i,k) = field % missingValue
+            maskingArray => mask % array
+            do i = 1, SIZE(maskedArray, dim=4)
+            do k = 1, SIZE(maskedArray, dim=5)
+               where (maskingArray == 0)
+                  maskedArray(:,:,:,i,k) = field % missingValue
                endwhere
             enddo
             enddo
          elseif (fieldDims(2) == maskDims(1) .and. &
                  fieldDims(3) == maskDims(2) .and. &
                  fieldDims(4) == maskDims(3) ) then
-            maskArray => mask % array
-            do i = 1, SIZE(maskedField, dim=1)
-            do k = 1, SIZE(maskedField, dim=5)
-               where (maskArray == 0)
-                  maskedField(i,:,:,:,k) = field % missingValue
+            maskingArray => mask % array
+            do i = 1, SIZE(maskedArray, dim=1)
+            do k = 1, SIZE(maskedArray, dim=5)
+               where (maskingArray == 0)
+                  maskedArray(i,:,:,:,k) = field % missingValue
                endwhere
             enddo
             enddo
          elseif (fieldDims(3) == maskDims(1) .and. &
                  fieldDims(4) == maskDims(2) .and. &
                  fieldDims(5) == maskDims(3) ) then
-            maskArray => mask % array(:,:,1:blockLength)
-            do i = 1, SIZE(maskedField, dim=1)
-            do k = 1, SIZE(maskedField, dim=2)
-               where (maskArray == 0)
-                  maskedField(i,k,:,:,:) = field % missingValue
+            maskingArray => mask % array(:,:,1:blockLength)
+            do i = 1, SIZE(maskedArray, dim=1)
+            do k = 1, SIZE(maskedArray, dim=2)
+               where (maskingArray == 0)
+                  maskedArray(i,k,:,:,:) = field % missingValue
                endwhere
             enddo
             enddo
@@ -3856,23 +3856,23 @@ module mpas_field_routines
 !> Masks the source field using a masking array.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_mask_field5d_mask2d_real(field, mask, maskedField) !{{{
+   subroutine mpas_mask_field5d_mask2d_real(field, mask, maskedArray) !{{{
 
       implicit none
 
       type (field5DReal), intent(in), pointer :: field
       type (field2DInteger), intent(in), pointer :: mask
-      real (kind=RKIND), dimension(:,:,:,:,:), intent(inout) :: maskedField
+      real (kind=RKIND), dimension(:,:,:,:,:), intent(inout) :: maskedArray
 
       real (kind=RKIND), dimension(:,:,:,:,:), pointer :: fieldArray
-      integer, dimension(:,:), pointer :: maskArray
+      integer, dimension(:,:), pointer :: maskingArray
 
       integer, dimension(5) :: fieldDims
       integer, dimension(2) :: maskDims
       integer :: blockLength
       integer :: i, j, k
 
-      blockLength = SIZE(maskedField, dim=5)
+      blockLength = SIZE(maskedArray, dim=5)
       fieldArray => field % array(:,:,:,:,1:blockLength)
 
       fieldDims = field % dimSizes
@@ -3882,45 +3882,45 @@ module mpas_field_routines
          ! Here we require that the dimension order in mask match the dimension
          ! order in field
          if (fieldDims(2) == maskDims(2) .and. fieldDims(1) == maskDims(1)) then
-            maskArray => mask % array
-            do i = 1, SIZE(maskedField, dim=3)
-            do j = 1, SIZE(maskedField, dim=4)
-            do k = 1, SIZE(maskedField, dim=5)
-               where (maskArray == 0)
-                  maskedField(:,:,i,j,k) = field % missingValue
+            maskingArray => mask % array
+            do i = 1, SIZE(maskedArray, dim=3)
+            do j = 1, SIZE(maskedArray, dim=4)
+            do k = 1, SIZE(maskedArray, dim=5)
+               where (maskingArray == 0)
+                  maskedArray(:,:,i,j,k) = field % missingValue
                endwhere
             enddo
             enddo
             enddo
          elseif (fieldDims(3) == maskDims(2) .and. fieldDims(2) == maskDims(1)) then
-            maskArray => mask % array
-            do i = 1, SIZE(maskedField, dim=1)
-            do j = 1, SIZE(maskedField, dim=4)
-            do k = 1, SIZE(maskedField, dim=5)
-               where (maskArray == 0)
-                  maskedField(i,:,:,j,k) = field % missingValue
+            maskingArray => mask % array
+            do i = 1, SIZE(maskedArray, dim=1)
+            do j = 1, SIZE(maskedArray, dim=4)
+            do k = 1, SIZE(maskedArray, dim=5)
+               where (maskingArray == 0)
+                  maskedArray(i,:,:,j,k) = field % missingValue
                endwhere
             enddo
             enddo
             enddo
          elseif (fieldDims(4) == maskDims(2) .and. fieldDims(3) == maskDims(1)) then
-            maskArray => mask % array
-            do i = 1, SIZE(maskedField, dim=1)
-            do j = 1, SIZE(maskedField, dim=2)
-            do k = 1, SIZE(maskedField, dim=5)
-               where (maskArray == 0)
-                  maskedField(i,j,:,:,k) = field % missingValue
+            maskingArray => mask % array
+            do i = 1, SIZE(maskedArray, dim=1)
+            do j = 1, SIZE(maskedArray, dim=2)
+            do k = 1, SIZE(maskedArray, dim=5)
+               where (maskingArray == 0)
+                  maskedArray(i,j,:,:,k) = field % missingValue
                endwhere
             enddo
             enddo
             enddo
          elseif (fieldDims(5) == maskDims(2) .and. fieldDims(4) == maskDims(1)) then
-            maskArray => mask % array(:, 1:blockLength)
-            do i = 1, SIZE(maskedField, dim=1)
-            do j = 1, SIZE(maskedField, dim=2)
-            do k = 1, SIZE(maskedField, dim=3)
-               where (maskArray == 0)
-                  maskedField(i,j,k,:,:) = field % missingValue
+            maskingArray => mask % array(:, 1:blockLength)
+            do i = 1, SIZE(maskedArray, dim=1)
+            do j = 1, SIZE(maskedArray, dim=2)
+            do k = 1, SIZE(maskedArray, dim=3)
+               where (maskingArray == 0)
+                  maskedArray(i,j,k,:,:) = field % missingValue
                endwhere
             enddo
             enddo
@@ -3950,23 +3950,23 @@ module mpas_field_routines
 !> Masks the source field using a masking array.
 !
 !-----------------------------------------------------------------------
-   subroutine mpas_mask_field5d_mask1d_real(field, mask, maskedField) !{{{
+   subroutine mpas_mask_field5d_mask1d_real(field, mask, maskedArray) !{{{
 
       implicit none
 
       type (field5DReal), intent(in), pointer :: field
       type (field1DInteger), intent(in), pointer :: mask
-      real (kind=RKIND), dimension(:,:,:,:,:), intent(inout) :: maskedField
+      real (kind=RKIND), dimension(:,:,:,:,:), intent(inout) :: maskedArray
 
       real (kind=RKIND), dimension(:,:,:,:,:), pointer :: fieldArray
-      integer, dimension(:), pointer :: maskArray
+      integer, dimension(:), pointer :: maskingArray
       integer :: i, j, k, p
 
       integer, dimension(5) :: fieldDims
       integer, dimension(1) :: maskDims
       integer :: blockLength
 
-      blockLength = SIZE(maskedField, dim=5)
+      blockLength = SIZE(maskedArray, dim=5)
       fieldArray => field % array(:,:,:,:,1:blockLength)
 
       fieldDims = field % dimSizes
@@ -3976,65 +3976,65 @@ module mpas_field_routines
          ! Here we require that the dimension order in mask match the dimension
          ! order in field
          if (fieldDims(1) == maskDims(1)) then
-            maskArray => mask % array
-            do i = 1, SIZE(maskedField, dim=2)
-            do j = 1, SIZE(maskedField, dim=3)
-            do k = 1, SIZE(maskedField, dim=4)
-            do p = 1, SIZE(maskedField, dim=5)
-               where (maskArray == 0)
-                  maskedField(:,i,j,k,p) = field % missingValue
+            maskingArray => mask % array
+            do i = 1, SIZE(maskedArray, dim=2)
+            do j = 1, SIZE(maskedArray, dim=3)
+            do k = 1, SIZE(maskedArray, dim=4)
+            do p = 1, SIZE(maskedArray, dim=5)
+               where (maskingArray == 0)
+                  maskedArray(:,i,j,k,p) = field % missingValue
                endwhere
             enddo
             enddo
             enddo
             enddo
          elseif (fieldDims(2) == maskDims(1)) then
-            maskArray => mask % array
-            do i = 1, SIZE(maskedField, dim=1)
-            do j = 1, SIZE(maskedField, dim=3)
-            do k = 1, SIZE(maskedField, dim=4)
-            do p = 1, SIZE(maskedField, dim=5)
-               where (maskArray == 0)
-                  maskedField(i,:,j,k,p) = field % missingValue
+            maskingArray => mask % array
+            do i = 1, SIZE(maskedArray, dim=1)
+            do j = 1, SIZE(maskedArray, dim=3)
+            do k = 1, SIZE(maskedArray, dim=4)
+            do p = 1, SIZE(maskedArray, dim=5)
+               where (maskingArray == 0)
+                  maskedArray(i,:,j,k,p) = field % missingValue
                endwhere
             enddo
             enddo
             enddo
             enddo
          elseif (fieldDims(3) == maskDims(1)) then
-            maskArray => mask % array
-            do i = 1, SIZE(maskedField, dim=1)
-            do j = 1, SIZE(maskedField, dim=2)
-            do k = 1, SIZE(maskedField, dim=4)
-            do p = 1, SIZE(maskedField, dim=5)
-               where (maskArray == 0)
-                  maskedField(i,j,:,k,p) = field % missingValue
+            maskingArray => mask % array
+            do i = 1, SIZE(maskedArray, dim=1)
+            do j = 1, SIZE(maskedArray, dim=2)
+            do k = 1, SIZE(maskedArray, dim=4)
+            do p = 1, SIZE(maskedArray, dim=5)
+               where (maskingArray == 0)
+                  maskedArray(i,j,:,k,p) = field % missingValue
                endwhere
             enddo
             enddo
             enddo
             enddo
          elseif (fieldDims(4) == maskDims(1)) then
-            maskArray => mask % array
-            do i = 1, SIZE(maskedField, dim=1)
-            do j = 1, SIZE(maskedField, dim=2)
-            do k = 1, SIZE(maskedField, dim=3)
-            do p = 1, SIZE(maskedField, dim=5)
-               where (maskArray == 0)
-                  maskedField(i,j,k,:,p) = field % missingValue
+            maskingArray => mask % array
+            do i = 1, SIZE(maskedArray, dim=1)
+            do j = 1, SIZE(maskedArray, dim=2)
+            do k = 1, SIZE(maskedArray, dim=3)
+            do p = 1, SIZE(maskedArray, dim=5)
+               where (maskingArray == 0)
+                  maskedArray(i,j,k,:,p) = field % missingValue
                endwhere
             enddo
             enddo
             enddo
             enddo
          elseif (fieldDims(5) == maskDims(1)) then
-            maskArray => mask % array(1:blockLength)
-            do i = 1, SIZE(maskedField, dim=1)
-            do j = 1, SIZE(maskedField, dim=2)
-            do k = 1, SIZE(maskedField, dim=3)
-            do p = 1, SIZE(maskedField, dim=4)
-               where (maskArray == 0)
-                  maskedField(i,j,k,p,:) = field % missingValue
+            maskingArray => mask % array(1:blockLength)
+            do i = 1, SIZE(maskedArray, dim=1)
+            do j = 1, SIZE(maskedArray, dim=2)
+            do k = 1, SIZE(maskedArray, dim=3)
+            do p = 1, SIZE(maskedArray, dim=4)
+               where (maskingArray == 0)
+                  maskedArray(i,j,k,p,:) = field % missingValue
                endwhere
             enddo
             enddo

--- a/components/mpas-framework/src/framework/mpas_field_routines.F
+++ b/components/mpas-framework/src/framework/mpas_field_routines.F
@@ -44,12 +44,12 @@ module mpas_field_routines
       module procedure mpas_mask_assign_pointer_field3d_mask3d_real
       module procedure mpas_mask_assign_pointer_field3d_mask2d_real
       module procedure mpas_mask_assign_pointer_field3d_mask1d_real
-      !module procedure mpas_mask_assign_pointer_field4d_mask3d_real
-      !module procedure mpas_mask_assign_pointer_field4d_mask2d_real
-      !module procedure mpas_mask_assign_pointer_field4d_mask1d_real
-      !module procedure mpas_mask_assign_pointer_field5d_mask3d_real
-      !module procedure mpas_mask_assign_pointer_field5d_mask2d_real
-      !module procedure mpas_mask_assign_pointer_field5d_mask1d_real
+      module procedure mpas_mask_assign_pointer_field4d_mask3d_real
+      module procedure mpas_mask_assign_pointer_field4d_mask2d_real
+      module procedure mpas_mask_assign_pointer_field4d_mask1d_real
+      module procedure mpas_mask_assign_pointer_field5d_mask3d_real
+      module procedure mpas_mask_assign_pointer_field5d_mask2d_real
+      module procedure mpas_mask_assign_pointer_field5d_mask1d_real
    end interface
    interface mpas_mask_field
       module procedure mpas_mask_field1d_mask1d_real
@@ -58,12 +58,12 @@ module mpas_field_routines
       module procedure mpas_mask_field3d_mask3d_real
       module procedure mpas_mask_field3d_mask2d_real
       module procedure mpas_mask_field3d_mask1d_real
-      !module procedure mpas_mask_field4d_mask3d_real
-      !module procedure mpas_mask_field4d_mask2d_real
-      !module procedure mpas_mask_field4d_mask1d_real
-      !module procedure mpas_mask_field5d_mask3d_real
-      !module procedure mpas_mask_field5d_mask2d_real
-      !module procedure mpas_mask_field5d_mask1d_real
+      module procedure mpas_mask_field4d_mask3d_real
+      module procedure mpas_mask_field4d_mask2d_real
+      module procedure mpas_mask_field4d_mask1d_real
+      module procedure mpas_mask_field5d_mask3d_real
+      module procedure mpas_mask_field5d_mask2d_real
+      module procedure mpas_mask_field5d_mask1d_real
    end interface
 
    interface mpas_duplicate_field
@@ -2907,7 +2907,6 @@ module mpas_field_routines
       type (field1DReal), intent(inout), pointer :: field
       type (field1DInteger), intent(in), pointer :: mask
 
-      call mpas_log_write('Assign pointer from '//trim(field % fieldName)//' to '//trim(mask % fieldName))
       field % missingValueMask1d => mask
 
    end subroutine mpas_mask_assign_pointer_field1d_mask1d_real
@@ -2930,8 +2929,6 @@ module mpas_field_routines
       type (field2DReal), intent(inout), pointer :: field
       type (field2DInteger), intent(in), pointer :: mask
 
-      !call mpas_log_write('Assign pointer from '//trim(field % fieldName))
-      !call mpas_log_write('Assign pointer to '//trim(mask % fieldName))
       field % missingValueMask2d => mask
 
    end subroutine mpas_mask_assign_pointer_field2d_mask2d_real
@@ -2954,7 +2951,6 @@ module mpas_field_routines
       type (field2DReal), intent(inout), pointer :: field
       type (field1DInteger), intent(in), pointer :: mask
 
-      call mpas_log_write('Assign pointer from '//trim(field % fieldName)//' to '//trim(mask % fieldName))
       field % missingValueMask1d => mask
 
    end subroutine mpas_mask_assign_pointer_field2d_mask1d_real
@@ -2977,7 +2973,6 @@ module mpas_field_routines
       type (field3DReal), intent(inout), pointer :: field
       type (field3DInteger), intent(in), pointer :: mask
 
-      call mpas_log_write('Assign pointer from '//trim(field % fieldName)//' to '//trim(mask % fieldName))
       field % missingValueMask3d => mask
 
    end subroutine mpas_mask_assign_pointer_field3d_mask3d_real
@@ -3000,7 +2995,6 @@ module mpas_field_routines
       type (field3DReal), intent(inout), pointer :: field
       type (field2DInteger), intent(in), pointer :: mask
 
-      call mpas_log_write('Assign pointer from '//trim(field % fieldName)//' to '//trim(mask % fieldName))
       field % missingValueMask2d => mask
 
    end subroutine mpas_mask_assign_pointer_field3d_mask2d_real
@@ -3024,10 +3018,147 @@ module mpas_field_routines
       type (field3DReal), intent(inout), pointer :: field
       type (field1DInteger), intent(in), pointer :: mask
 
-      call mpas_log_write('Assign pointer from '//trim(field % fieldName)//' to '//trim(mask % fieldName))
       field % missingValueMask1d => mask
 
    end subroutine mpas_mask_assign_pointer_field3d_mask1d_real
+
+
+!***********************************************************************
+!
+!  routine mpas_mask_assign_pointer_field4d_mask3d_real
+!
+!> \brief   MPAS 4D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> 
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_mask_assign_pointer_field4d_mask3d_real(field, mask) !{{{
+
+      implicit none
+
+      type (field4DReal), intent(inout), pointer :: field
+      type (field3DInteger), intent(in), pointer :: mask
+
+      field % missingValueMask3d => mask
+
+   end subroutine mpas_mask_assign_pointer_field4d_mask3d_real
+
+
+!***********************************************************************
+!
+!  routine mpas_mask_assign_pointer_field4d_mask2d_real
+!
+!> \brief   MPAS 4D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> 
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_mask_assign_pointer_field4d_mask2d_real(field, mask) !{{{
+
+      implicit none
+
+      type (field4DReal), intent(inout), pointer :: field
+      type (field2DInteger), intent(in), pointer :: mask
+
+      field % missingValueMask2d => mask
+
+   end subroutine mpas_mask_assign_pointer_field4d_mask2d_real
+
+
+!***********************************************************************
+!
+!  routine mpas_mask_assign_pointer_field4d_mask1d_real
+!
+!> \brief   MPAS 4D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> 
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_mask_assign_pointer_field4d_mask1d_real(field, mask) !{{{
+
+      implicit none
+
+      type (field4DReal), intent(inout), pointer :: field
+      type (field1DInteger), intent(in), pointer :: mask
+
+      field % missingValueMask1d => mask
+
+   end subroutine mpas_mask_assign_pointer_field4d_mask1d_real
+
+
+!***********************************************************************
+!
+!  routine mpas_mask_assign_pointer_field5d_mask3d_real
+!
+!> \brief   MPAS 4D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> 
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_mask_assign_pointer_field5d_mask3d_real(field, mask) !{{{
+
+      implicit none
+
+      type (field5DReal), intent(inout), pointer :: field
+      type (field3DInteger), intent(in), pointer :: mask
+
+      field % missingValueMask3d => mask
+
+   end subroutine mpas_mask_assign_pointer_field5d_mask3d_real
+
+
+!***********************************************************************
+!
+!  routine mpas_mask_assign_pointer_field5d_mask2d_real
+!
+!> \brief   MPAS 4D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> 
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_mask_assign_pointer_field5d_mask2d_real(field, mask) !{{{
+
+      implicit none
+
+      type (field5DReal), intent(inout), pointer :: field
+      type (field2DInteger), intent(in), pointer :: mask
+
+      field % missingValueMask2d => mask
+
+   end subroutine mpas_mask_assign_pointer_field5d_mask2d_real
+
+
+!***********************************************************************
+!
+!  routine mpas_mask_assign_pointer_field5d_mask1d_real
+!
+!> \brief   MPAS 4D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> 
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_mask_assign_pointer_field5d_mask1d_real(field, mask) !{{{
+
+      implicit none
+
+      type (field5DReal), intent(inout), pointer :: field
+      type (field1DInteger), intent(in), pointer :: mask
+
+      field % missingValueMask1d => mask
+
+   end subroutine mpas_mask_assign_pointer_field5d_mask1d_real
 
 
 !***********************************************************************
@@ -3063,14 +3194,19 @@ module mpas_field_routines
       fieldDims = field % dimSizes
       maskDims = mask % dimSizes
 
-      if (fieldDims(1) == maskDims(1) ) then
-         call mpas_log_write('Masking array '//trim(field % fieldName))
-         maskedField = fieldArray ! consider putting in elsewhere
-         where (maskArray == 0)
-            maskedField = field % missingValue
-         endwhere
+      if (any(maskArray == 1)) then
+         if (fieldDims(1) == maskDims(1) ) then
+            where (maskArray == 0)
+               maskedField = field % missingValue
+            endwhere
+         else
+            call mpas_log_write('Masking array and field array do not have'// &
+                                ' the same dimensions', MPAS_LOG_WARN)
+         endif
       else
-         call mpas_log_write('masking array and field array do not have the same dimensions')
+         call mpas_log_write('Mask '//trim(field % maskName)//&
+                             ' is zeros, may not be initialized', MPAS_LOG_WARN)
+         return
       endif
 
    end subroutine mpas_mask_field1d_mask1d_real !}}}
@@ -3111,19 +3247,19 @@ module mpas_field_routines
       maskDims = mask % dimSizes
       maskedField = fieldArray
 
-      if (fieldDims(1) == maskDims(1) .and. fieldDims(2) == maskDims(2)) then
-         if (any(maskArray == 1)) then
-            call mpas_log_write('Masking 2d array '//trim(field % fieldName)//&
-                                'with 2d mask '//trim(field % maskName))
+      if (any(maskArray == 1)) then
+         if (fieldDims(1) == maskDims(1) .and. fieldDims(2) == maskDims(2)) then
             where (maskArray == 0)
                maskedField = field % missingValue
             endwhere
          else
-            call mpas_log_write('Mask '//trim(field % maskName)//' is zeros, may not be initialized')
+            call mpas_log_write('Masking array and field array do not share dimensions', &
+                                MPAS_LOG_WARN)
             return
          endif
       else
-         call mpas_log_write('masking array and field array do not share dimensions')
+         call mpas_log_write('Mask '//trim(field % maskName)//&
+                             ' is zeros, may not be initialized', MPAS_LOG_WARN)
          return
       endif
 
@@ -3162,27 +3298,31 @@ module mpas_field_routines
 
       fieldDims = field % dimSizes
       maskDims = mask % dimSizes
+      maskArray  => mask % array
 
-      if (fieldDims(1) == maskDims(1)) then
-         call mpas_log_write('Masking array '//trim(field % fieldName))
-         maskArray  => mask % array
-         maskedField = fieldArray ! consider putting in elsewhere
-         do j = 1, fieldDims(2)
-            where (maskArray == 0)
-               maskedField(:, j) = field % missingValue
-            endwhere
-         enddo
-      elseif (fieldDims(2) == maskDims(1)) then
-         call mpas_log_write('Masking array '//trim(field % fieldName))
-         maskArray  => mask % array(1:blockLength)
-         maskedField = fieldArray ! consider putting in elsewhere
-         do i = 1, fieldDims(1)
-            where (maskArray == 0)
-               maskedField(i, :) = field % missingValue
-            endwhere
-         enddo
+      if (any(maskArray == 1)) then
+         if (fieldDims(1) == maskDims(1)) then
+            maskArray  => mask % array
+            do j = 1, fieldDims(2)
+               where (maskArray == 0)
+                  maskedField(:, j) = field % missingValue
+               endwhere
+            enddo
+         elseif (fieldDims(2) == maskDims(1)) then
+            maskArray  => mask % array(1:blockLength)
+            do i = 1, fieldDims(1)
+               where (maskArray == 0)
+                  maskedField(i, :) = field % missingValue
+               endwhere
+            enddo
+         else
+            call mpas_log_write('Masking array and field array do not share dimensions', &
+                                MPAS_LOG_WARN)
+            return
+         endif
       else
-         call mpas_log_write('masking array and field array do not share a dimension')
+         call mpas_log_write('Mask '//trim(field % maskName)//&
+                             ' is zeros, may not be initialized', MPAS_LOG_WARN)
          return
       endif
 
@@ -3222,16 +3362,21 @@ module mpas_field_routines
       fieldDims = field % dimSizes
       maskDims = mask % dimSizes
 
-      if (fieldDims(1) == maskDims(1) .and. &
-          fieldDims(2) == maskDims(2) .and. &
-          fieldDims(3) == maskDims(3) ) then
-         call mpas_log_write('Masking array '//trim(field % fieldName))
-         maskedField = fieldArray ! consider putting in elsewhere
-         where (maskArray == 0)
-            maskedField = field % missingValue
-         endwhere
+      if (any(maskArray == 1)) then
+         if (fieldDims(1) == maskDims(1) .and. &
+             fieldDims(2) == maskDims(2) .and. &
+             fieldDims(3) == maskDims(3) ) then
+            where (maskArray == 0)
+               maskedField = field % missingValue
+            endwhere
+         else
+            call mpas_log_write('Masking array and field array do not have the'// &
+                                ' same dimensions', MPAS_LOG_WARN)
+         endif
       else
-         call mpas_log_write('masking array and field array do not have the same dimensions')
+         call mpas_log_write('Mask '//trim(field % maskName)//&
+                             ' is zeros, may not be initialized', MPAS_LOG_WARN)
+         return
       endif
 
    end subroutine mpas_mask_field3d_mask3d_real !}}}
@@ -3272,35 +3417,33 @@ module mpas_field_routines
       maskDims = mask % dimSizes
 
       if (any(mask % array == 1)) then
-         call mpas_log_write('Masking 2d array '//trim(field % fieldName)//&
-                             'with 2d mask '//trim(field % maskName))
          ! Here we require that the dimension order in mask match the dimension
          ! order in field
          if (fieldDims(3) == maskDims(2) .and. fieldDims(2) == maskDims(1)) then
-            maskArray  => mask  % array(:, 1:blockLength)
-            maskedField = fieldArray ! consider putting in elsewhere
+            maskArray  => mask % array(:, 1:blockLength)
             do i = 1, fieldDims(1)
                where (maskArray == 0)
                   maskedField(i, :, :) = field % missingValue
                endwhere
             enddo
          elseif (fieldDims(2) == maskDims(2) .and. fieldDims(1) == maskDims(1)) then
-            maskArray  => mask  % array
-            maskedField = fieldArray ! consider putting in elsewhere
+            maskArray  => mask % array
             do k = 1, fieldDims(3)
                where (maskArray == 0)
                   maskedField(:, :, k) = field % missingValue
                endwhere
             enddo
          else
-            !TODO change these to warnings
-            call mpas_log_write('masking array and field array do not share dimensions')
+            call mpas_log_write('Masking array and field array do not share dimensions', &
+                                MPAS_LOG_WARN)
             return
          endif
       else
-         call mpas_log_write('Mask '//trim(field % maskName)//' is zeros, may not be initialized')
+         call mpas_log_write('Mask '//trim(field % maskName)//&
+                             ' is zeros, may not be initialized', MPAS_LOG_WARN)
          return
       endif
+
    end subroutine mpas_mask_field3d_mask2d_real !}}}
 
 
@@ -3337,52 +3480,578 @@ module mpas_field_routines
       fieldDims = field % dimSizes
       maskDims = mask % dimSizes
 
-      ! TODO use fieldDimNames to know how to transform the mask
-      !character (len=StrKIND), dimension(3) :: fieldDimNames
-      !character (len=StrKIND), dimension(2) :: maskDimNames
-
-      !fieldDimNames = field % dimNames
-      !maskDimNames = mask % dimNames
-
-      if (fieldDims(1) == maskDims(1)) then
-         call mpas_log_write('Masking array '//trim(field % fieldName))
-         maskArray  => mask % array
-         maskedField = fieldArray ! consider putting in elsewhere
-         do j = 1, fieldDims(2)
-            do k = 1, fieldDims(3) 
-               where (maskArray == 0)
-                  maskedField(:, j, k) = field % missingValue
-               endwhere
+      if (any(mask % array == 1)) then
+         if (fieldDims(1) == maskDims(1)) then
+            maskArray  => mask % array
+            do j = 1, fieldDims(2)
+               do k = 1, fieldDims(3) 
+                  where (maskArray == 0)
+                     maskedField(:, j, k) = field % missingValue
+                  endwhere
+               enddo
             enddo
-         enddo
-      elseif (fieldDims(2) == maskDims(1)) then
-         call mpas_log_write('Masking array '//trim(field % fieldName))
-         maskArray  => mask % array
-         maskedField = fieldArray ! consider putting in elsewhere
-         do i = 1, fieldDims(1)
-            do k = 1, fieldDims(3)
-               where (maskArray == 0)
-                  maskedField(i, :, k) = field % missingValue
-               endwhere
+         elseif (fieldDims(2) == maskDims(1)) then
+            maskArray  => mask % array
+            do i = 1, fieldDims(1)
+               do k = 1, fieldDims(3)
+                  where (maskArray == 0)
+                     maskedField(i, :, k) = field % missingValue
+                  endwhere
+               enddo
             enddo
-         enddo
-      elseif (fieldDims(3) == maskDims(1)) then
-         call mpas_log_write('Masking array '//trim(field % fieldName))
-         maskArray  => mask % array(1:blockLength)
-         maskedField = fieldArray ! consider putting in elsewhere
-         do i = 1, fieldDims(1)
-            do j = 1, fieldDims(2) 
-               where (maskArray == 0)
-                  maskedField(i, j, :) = field % missingValue
-               endwhere
+         elseif (fieldDims(3) == maskDims(1)) then
+            maskArray  => mask % array(1:blockLength)
+            do i = 1, fieldDims(1)
+               do j = 1, fieldDims(2) 
+                  where (maskArray == 0)
+                     maskedField(i, j, :) = field % missingValue
+                  endwhere
+               enddo
             enddo
-         enddo
+         else
+            call mpas_log_write('Masking array and field array do not share'// &
+                                ' a dimension', MPAS_LOG_WARN)
+            return
+         endif
       else
-         call mpas_log_write('masking array and field array share a dimension')
+         call mpas_log_write('Mask '//trim(field % maskName)//&
+                             ' is zeros, may not be initialized', MPAS_LOG_WARN)
          return
       endif
 
    end subroutine mpas_mask_field3d_mask1d_real !}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_mask_field4d_mask3d_real
+!
+!> \brief   MPAS 4D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> Masks the source field using a masking array.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_mask_field4d_mask3d_real(field, mask, maskedField) !{{{
+
+      implicit none
+
+      type (field4DReal), intent(in), pointer :: field
+      type (field3DInteger), intent(in), pointer :: mask
+      real (kind=RKIND), dimension(:,:,:,:), intent(inout), pointer :: maskedField
+
+      real (kind=RKIND), dimension(:,:,:,:), pointer :: fieldArray
+      integer, dimension(:,:,:), pointer :: maskArray
+
+      integer, dimension(4) :: fieldDims
+      integer, dimension(3) :: maskDims
+      integer :: blockLength
+      integer :: i, k
+
+      blockLength = SIZE(maskedField, dim=4)
+      fieldArray => field % array(:,:,:,1:blockLength)
+
+      fieldDims = field % dimSizes
+      maskDims = mask % dimSizes
+
+      if (any(mask % array == 1)) then
+         ! Here we require that the dimension order in mask match the dimension
+         ! order in field
+         if (fieldDims(2) == maskDims(1) .and. &
+             fieldDims(3) == maskDims(2) .and. &
+             fieldDims(4) == maskDims(3) ) then
+            maskArray => mask % array(:,:,1:blockLength)
+            do i = 1, fieldDims(1)
+               where (maskArray == 0)
+                  maskedField(i,:,:,:) = field % missingValue
+               endwhere
+            enddo
+         elseif (fieldDims(1) == maskDims(1) .and. &
+                 fieldDims(2) == maskDims(2) .and. &
+                 fieldDims(3) == maskDims(3) ) then
+            maskArray => mask % array
+            do k = 1, fieldDims(4)
+               where (maskArray == 0)
+                  maskedField(:,:,:,k) = field % missingValue
+               endwhere
+            enddo
+         else
+            call mpas_log_write('Masking array and field array do not share'// &
+                                ' dimensions', MPAS_LOG_WARN)
+            return
+         endif
+      else
+         call mpas_log_write('Mask '//trim(field % maskName)//&
+                             ' is zeros, may not be initialized', MPAS_LOG_WARN)
+         return
+      endif
+
+   end subroutine mpas_mask_field4d_mask3d_real !}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_mask_field4d_mask2d_real
+!
+!> \brief   MPAS 3D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> Masks the source field using a masking array.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_mask_field4d_mask2d_real(field, mask, maskedField) !{{{
+
+      implicit none
+
+      type (field4DReal), intent(in), pointer :: field
+      type (field2DInteger), intent(in), pointer :: mask
+      real (kind=RKIND), dimension(:,:,:,:), intent(inout) :: maskedField
+
+      real (kind=RKIND), dimension(:,:,:,:), pointer :: fieldArray
+      integer, dimension(:,:), pointer :: maskArray
+      integer :: i, j, k
+
+      integer, dimension(4) :: fieldDims
+      integer, dimension(2) :: maskDims
+      integer :: blockLength
+      character(len=100) :: log_string
+
+      blockLength = SIZE(maskedField, dim=4)
+      fieldArray => field % array(:, :, :, 1:blockLength)
+
+      fieldDims = field % dimSizes
+      maskDims = mask % dimSizes
+
+      if (any(mask % array == 1)) then
+         ! Here we require that the dimension order in mask match the dimension
+         ! order in field
+         if (fieldDims(2) == maskDims(2) .and. fieldDims(1) == maskDims(1)) then
+            maskArray => mask % array
+            do j = 1, fieldDims(3)
+            do k = 1, fieldDims(4)
+               where (maskArray == 0)
+                  maskedField(:, :, j, k) = field % missingValue
+               endwhere
+            enddo
+            enddo
+         elseif (fieldDims(3) == maskDims(2) .and. fieldDims(2) == maskDims(1)) then
+            maskArray  => mask % array
+            do i = 1, fieldDims(1)
+            do k = 1, fieldDims(4)
+               where (maskArray == 0)
+                  maskedField(i, :, :, k) = field % missingValue
+               endwhere
+            enddo
+            enddo
+         elseif (fieldDims(3) == maskDims(2) .and. fieldDims(4) == maskDims(1)) then
+            maskArray => mask % array(:, 1:blockLength)
+            do i = 1, fieldDims(1)
+            do j = 1, fieldDims(2)
+               where (maskArray == 0)
+                  maskedField(i, j, :, :) = field % missingValue
+               endwhere
+            enddo
+            enddo
+         else
+            call mpas_log_write('Masking array and field array do not share'// &
+                                ' dimensions', MPAS_LOG_WARN)
+            return
+         endif
+      else
+         call mpas_log_write('Mask '//trim(field % maskName)//&
+                             ' is zeros, may not be initialized', MPAS_LOG_WARN)
+         return
+      endif
+
+   end subroutine mpas_mask_field4d_mask2d_real !}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_mask_field4d_mask1d_real
+!
+!> \brief   MPAS 3D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> Masks the source field using a masking array.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_mask_field4d_mask1d_real(field, mask, maskedField) !{{{
+
+      implicit none
+
+      type (field4DReal), intent(in), pointer :: field
+      type (field1DInteger), intent(in), pointer :: mask
+      real (kind=RKIND), dimension(:,:,:,:), intent(inout) :: maskedField
+
+      real (kind=RKIND), dimension(:,:,:,:), pointer :: fieldArray
+      integer, dimension(:), pointer :: maskArray
+      integer :: i, j, k
+
+      integer, dimension(4) :: fieldDims
+      integer, dimension(1) :: maskDims
+      integer :: blockLength
+
+      blockLength = SIZE(maskedField, dim=4)
+      fieldArray => field % array(:, :, :, 1:blockLength)
+
+      fieldDims = field % dimSizes
+      maskDims = mask % dimSizes
+
+      if (any(mask % array == 1)) then
+         ! Here we require that the dimension order in mask match the dimension
+         ! order in field
+         if (fieldDims(1) == maskDims(1)) then
+            maskArray => mask % array
+            do i = 1, fieldDims(2)
+            do j = 1, fieldDims(3)
+            do k = 1, fieldDims(4) 
+               where (maskArray == 0)
+                  maskedField(:, i, j, k) = field % missingValue
+               endwhere
+            enddo
+            enddo
+            enddo
+         elseif (fieldDims(2) == maskDims(1)) then
+            maskArray => mask % array
+            do i = 1, fieldDims(1)
+            do j = 1, fieldDims(3)
+            do k = 1, fieldDims(4)
+               where (maskArray == 0)
+                  maskedField(i, :, j, k) = field % missingValue
+               endwhere
+            enddo
+            enddo
+            enddo
+         elseif (fieldDims(3) == maskDims(1)) then
+            maskArray => mask % array
+            do i = 1, fieldDims(1)
+            do j = 1, fieldDims(2) 
+            do k = 1, fieldDims(4) 
+               where (maskArray == 0)
+                  maskedField(i, j, :, k) = field % missingValue
+               endwhere
+            enddo
+            enddo
+            enddo
+         elseif (fieldDims(4) == maskDims(1)) then
+            maskArray => mask % array(1:blockLength)
+            do i = 1, fieldDims(1)
+            do j = 1, fieldDims(2) 
+            do k = 1, fieldDims(3) 
+               where (maskArray == 0)
+                  maskedField(i, j, k, :) = field % missingValue
+               endwhere
+            enddo
+            enddo
+            enddo
+         else
+            call mpas_log_write('Masking array and field array do not share'// &
+                                ' a dimension', MPAS_LOG_WARN)
+            return
+         endif
+      else
+         call mpas_log_write('Mask '//trim(field % maskName)//&
+                             ' is zeros, may not be initialized', MPAS_LOG_WARN)
+         return
+      endif
+
+   end subroutine mpas_mask_field4d_mask1d_real !}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_mask_field5d_mask3d_real
+!
+!> \brief   MPAS 4D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> Masks the source field using a masking array.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_mask_field5d_mask3d_real(field, mask, maskedField) !{{{
+
+      implicit none
+
+      type (field5DReal), intent(in), pointer :: field
+      type (field3DInteger), intent(in), pointer :: mask
+      real (kind=RKIND), dimension(:,:,:,:,:), intent(inout), pointer :: maskedField
+
+      real (kind=RKIND), dimension(:,:,:,:,:), pointer :: fieldArray
+      integer, dimension(:,:,:), pointer :: maskArray
+
+      integer, dimension(5) :: fieldDims
+      integer, dimension(3) :: maskDims
+      integer :: blockLength
+      integer :: i, k
+
+      blockLength = SIZE(maskedField, dim=5)
+      fieldArray => field % array(:,:,:,:,1:blockLength)
+
+      fieldDims = field % dimSizes
+      maskDims = mask % dimSizes
+
+      if (any(mask % array == 1)) then
+         ! Here we require that the dimension order in mask match the dimension
+         ! order in field
+         if (fieldDims(1) == maskDims(1) .and. &
+             fieldDims(2) == maskDims(2) .and. &
+             fieldDims(3) == maskDims(3) ) then
+            maskArray => mask % array
+            do i = 1, fieldDims(4)
+            do k = 1, fieldDims(5)
+               where (maskArray == 0)
+                  maskedField(:,:,:,i,k) = field % missingValue
+               endwhere
+            enddo
+            enddo
+         elseif (fieldDims(2) == maskDims(1) .and. &
+                 fieldDims(3) == maskDims(2) .and. &
+                 fieldDims(4) == maskDims(3) ) then
+            maskArray => mask % array
+            do i = 1, fieldDims(1)
+            do k = 1, fieldDims(5)
+               where (maskArray == 0)
+                  maskedField(i,:,:,:,k) = field % missingValue
+               endwhere
+            enddo
+            enddo
+         elseif (fieldDims(3) == maskDims(1) .and. &
+                 fieldDims(4) == maskDims(2) .and. &
+                 fieldDims(5) == maskDims(3) ) then
+            maskArray => mask % array(:,:,1:blockLength)
+            do i = 1, fieldDims(1)
+            do k = 1, fieldDims(2)
+               where (maskArray == 0)
+                  maskedField(i,k,:,:,:) = field % missingValue
+               endwhere
+            enddo
+            enddo
+         else
+            call mpas_log_write('Masking array and field array do not share'// &
+                                ' a dimension', MPAS_LOG_WARN)
+            return
+         endif
+      else
+         call mpas_log_write('Mask '//trim(field % maskName)//&
+                             ' is zeros, may not be initialized', MPAS_LOG_WARN)
+         return
+      endif
+
+   end subroutine mpas_mask_field5d_mask3d_real !}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_mask_field5d_mask2d_real
+!
+!> \brief   MPAS 3D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> Masks the source field using a masking array.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_mask_field5d_mask2d_real(field, mask, maskedField) !{{{
+
+      implicit none
+
+      type (field5DReal), intent(in), pointer :: field
+      type (field2DInteger), intent(in), pointer :: mask
+      real (kind=RKIND), dimension(:,:,:,:,:), intent(inout) :: maskedField
+
+      real (kind=RKIND), dimension(:,:,:,:,:), pointer :: fieldArray
+      integer, dimension(:,:), pointer :: maskArray
+
+      integer, dimension(5) :: fieldDims
+      integer, dimension(2) :: maskDims
+      integer :: blockLength
+      integer :: i, j, k
+
+      blockLength = SIZE(maskedField, dim=5)
+      fieldArray => field % array(:,:,:,:,1:blockLength)
+
+      fieldDims = field % dimSizes
+      maskDims = mask % dimSizes
+
+      if (any(mask % array == 1)) then
+         ! Here we require that the dimension order in mask match the dimension
+         ! order in field
+         if (fieldDims(2) == maskDims(2) .and. fieldDims(1) == maskDims(1)) then
+            maskArray => mask % array
+            do i = 1, fieldDims(3)
+            do j = 1, fieldDims(4)
+            do k = 1, fieldDims(5)
+               where (maskArray == 0)
+                  maskedField(:,:,i,j,k) = field % missingValue
+               endwhere
+            enddo
+            enddo
+            enddo
+         elseif (fieldDims(3) == maskDims(2) .and. fieldDims(2) == maskDims(1)) then
+            maskArray => mask % array
+            do i = 1, fieldDims(1)
+            do j = 1, fieldDims(4)
+            do k = 1, fieldDims(5)
+               where (maskArray == 0)
+                  maskedField(i,:,:,j,k) = field % missingValue
+               endwhere
+            enddo
+            enddo
+            enddo
+         elseif (fieldDims(4) == maskDims(2) .and. fieldDims(3) == maskDims(1)) then
+            maskArray => mask % array
+            do i = 1, fieldDims(1)
+            do j = 1, fieldDims(2)
+            do k = 1, fieldDims(5)
+               where (maskArray == 0)
+                  maskedField(i,j,:,:,k) = field % missingValue
+               endwhere
+            enddo
+            enddo
+            enddo
+         elseif (fieldDims(5) == maskDims(2) .and. fieldDims(4) == maskDims(1)) then
+            maskArray => mask % array(:, 1:blockLength)
+            do i = 1, fieldDims(1)
+            do j = 1, fieldDims(2)
+            do k = 1, fieldDims(3)
+               where (maskArray == 0)
+                  maskedField(i,j,k,:,:) = field % missingValue
+               endwhere
+            enddo
+            enddo
+            enddo
+         else
+            call mpas_log_write('Masking array and field array do not share'// &
+                                ' a dimension', MPAS_LOG_WARN)
+            return
+         endif
+      else
+         call mpas_log_write('Mask '//trim(field % maskName)//&
+                             ' is zeros, may not be initialized', MPAS_LOG_WARN)
+         return
+      endif
+
+   end subroutine mpas_mask_field5d_mask2d_real !}}}
+
+
+!***********************************************************************
+!
+!  routine mpas_mask_field5d_mask1d_real
+!
+!> \brief   MPAS 3D real field mask routine.
+!> \author  Carolyn Begeman, Adrian Turner
+!> \date    05/17/22
+!> \details 
+!> Masks the source field using a masking array.
+!
+!-----------------------------------------------------------------------
+   subroutine mpas_mask_field5d_mask1d_real(field, mask, maskedField) !{{{
+
+      implicit none
+
+      type (field5DReal), intent(in), pointer :: field
+      type (field1DInteger), intent(in), pointer :: mask
+      real (kind=RKIND), dimension(:,:,:,:,:), intent(inout) :: maskedField
+
+      real (kind=RKIND), dimension(:,:,:,:,:), pointer :: fieldArray
+      integer, dimension(:), pointer :: maskArray
+      integer :: i, j, k, p
+
+      integer, dimension(5) :: fieldDims
+      integer, dimension(1) :: maskDims
+      integer :: blockLength
+
+      blockLength = SIZE(maskedField, dim=5)
+      fieldArray => field % array(:,:,:,:,1:blockLength)
+
+      fieldDims = field % dimSizes
+      maskDims = mask % dimSizes
+
+      if (any(mask % array == 1)) then
+         ! Here we require that the dimension order in mask match the dimension
+         ! order in field
+         if (fieldDims(1) == maskDims(1)) then
+            maskArray => mask % array
+            do i = 1, fieldDims(2)
+            do j = 1, fieldDims(3)
+            do k = 1, fieldDims(4) 
+            do p = 1, fieldDims(5) 
+               where (maskArray == 0)
+                  maskedField(:,i,j,k,p) = field % missingValue
+               endwhere
+            enddo
+            enddo
+            enddo
+            enddo
+         elseif (fieldDims(2) == maskDims(1)) then
+            maskArray => mask % array
+            do i = 1, fieldDims(1)
+            do j = 1, fieldDims(3)
+            do k = 1, fieldDims(4)
+            do p = 1, fieldDims(5) 
+               where (maskArray == 0)
+                  maskedField(i,:,j,k,p) = field % missingValue
+               endwhere
+            enddo
+            enddo
+            enddo
+            enddo
+         elseif (fieldDims(3) == maskDims(1)) then
+            maskArray => mask % array
+            do i = 1, fieldDims(1)
+            do j = 1, fieldDims(2) 
+            do k = 1, fieldDims(4) 
+            do p = 1, fieldDims(5) 
+               where (maskArray == 0)
+                  maskedField(i,j,:,k,p) = field % missingValue
+               endwhere
+            enddo
+            enddo
+            enddo
+            enddo
+         elseif (fieldDims(4) == maskDims(1)) then
+            maskArray => mask % array
+            do i = 1, fieldDims(1)
+            do j = 1, fieldDims(2) 
+            do k = 1, fieldDims(3) 
+            do p = 1, fieldDims(5) 
+               where (maskArray == 0)
+                  maskedField(i,j,k,:,p) = field % missingValue
+               endwhere
+            enddo
+            enddo
+            enddo
+            enddo
+         elseif (fieldDims(5) == maskDims(1)) then
+            maskArray => mask % array(1:blockLength)
+            do i = 1, fieldDims(1)
+            do j = 1, fieldDims(2) 
+            do k = 1, fieldDims(3) 
+            do p = 1, fieldDims(4) 
+               where (maskArray == 0)
+                  maskedField(i,j,k,p,:) = field % missingValue
+               endwhere
+            enddo
+            enddo
+            enddo
+            enddo
+         else
+            call mpas_log_write('Masking array and field array do not share'// &
+                                ' a dimension', MPAS_LOG_WARN)
+            return
+         endif
+      else
+         call mpas_log_write('Mask '//trim(field % maskName)//&
+                             ' is zeros, may not be initialized', MPAS_LOG_WARN)
+         return
+      endif
+
+   end subroutine mpas_mask_field5d_mask1d_real !}}}
 
 
 !***********************************************************************

--- a/components/mpas-framework/src/framework/mpas_field_types.inc
+++ b/components/mpas-framework/src/framework/mpas_field_types.inc
@@ -134,6 +134,7 @@
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       character (len=StrKIND), dimension(2) :: dimNames
       integer, dimension(2) :: dimSizes
+      character (len=StrKIND) :: maskName
       type (field1DInteger), pointer :: missingValueMask1D => null()
       type (field2DInteger), pointer :: missingValueMask2D => null()
       real (kind=RKIND) :: defaultValue

--- a/components/mpas-framework/src/framework/mpas_field_types.inc
+++ b/components/mpas-framework/src/framework/mpas_field_types.inc
@@ -20,10 +20,10 @@
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       character (len=StrKIND), dimension(5) :: dimNames
       integer, dimension(5) :: dimSizes
-      !type (field1DInteger), pointer :: missingValueMask1D => null()
-      !type (field2DInteger), pointer :: missingValueMask2D => null()
-      !type (field3DInteger), pointer :: missingValueMask3D => null()
-      !type (field4DInteger), pointer :: missingValueMask4D => null()
+      character (len=StrKIND) :: maskName
+      type (field1DInteger), pointer :: missingValueMask1D => null()
+      type (field2DInteger), pointer :: missingValueMask2D => null()
+      type (field3DInteger), pointer :: missingValueMask3D => null()
       real (kind=RKIND) :: defaultValue
       real (kind=RKIND) :: missingValue
       logical :: isDecomposed
@@ -58,10 +58,10 @@
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       character (len=StrKIND), dimension(4) :: dimNames
       integer, dimension(4) :: dimSizes
-      !type (field1DInteger), pointer :: missingValueMask1D => null()
-      !type (field2DInteger), pointer :: missingValueMask2D => null()
-      !type (field3DInteger), pointer :: missingValueMask3D => null()
-      !type (field4DInteger), pointer :: missingValueMask4D => null()
+      character (len=StrKIND) :: maskName
+      type (field1DInteger), pointer :: missingValueMask1D => null()
+      type (field2DInteger), pointer :: missingValueMask2D => null()
+      type (field3DInteger), pointer :: missingValueMask3D => null()
       real (kind=RKIND) :: defaultValue
       real (kind=RKIND) :: missingValue
       logical :: isDecomposed
@@ -94,12 +94,13 @@
 
       ! Information used by the I/O layer
       character (len=StrKIND) :: fieldName
+      character (len=StrKIND) :: maskName
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       character (len=StrKIND), dimension(3) :: dimNames
       integer, dimension(3) :: dimSizes
-      !type (field1DInteger), pointer :: missingValueMask1D => null()
-      !type (field2DInteger), pointer :: missingValueMask2D => null()
-      !type (field3DInteger), pointer :: missingValueMask3D => null()
+      type (field1DInteger), pointer :: missingValueMask1D => null()
+      type (field2DInteger), pointer :: missingValueMask2D => null()
+      type (field3DInteger), pointer :: missingValueMask3D => null()
       real (kind=RKIND) :: defaultValue
       real (kind=RKIND) :: missingValue
       logical :: isDecomposed
@@ -171,7 +172,8 @@
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       character (len=StrKIND), dimension(1) :: dimNames
       integer, dimension(1) :: dimSizes
-      !type (field1DInteger), pointer :: missingValueMask1D => null()
+      character (len=StrKIND) :: maskName
+      type (field1DInteger), pointer :: missingValueMask1D => null()
       real (kind=RKIND) :: defaultValue
       real (kind=RKIND) :: missingValue
       logical :: isDecomposed
@@ -206,6 +208,7 @@
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       real (kind=RKIND) :: defaultValue
       real (kind=RKIND) :: missingValue
+      character (len=StrKIND) :: maskName
       logical :: isDecomposed
       logical :: hasTimeDimension
       logical :: isActive
@@ -224,40 +227,6 @@
 
 
    ! Derived type for storing fields
-   !type field4DInteger
-
-   !   ! Back-pointer to the containing block
-   !   type (block_type), pointer :: block => null()
-
-   !   ! Raw array holding field data on this block
-   !   integer, dimension(:,:,:,:), pointer :: array => null()
-
-   !   ! Information used by the I/O layer
-   !   character (len=StrKIND) :: fieldName
-   !   character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
-   !   character (len=StrKIND), dimension(4) :: dimNames
-   !   integer :: defaultValue
-   !   integer :: missingValue
-   !   integer, dimension(4) :: dimSizes
-   !   logical :: isDecomposed
-   !   logical :: hasTimeDimension
-   !   logical :: isActive
-   !   logical :: isVarArray
-   !   logical :: isPersistent
-   !   type (att_lists_type), dimension(:), pointer :: attLists => null()
-
-   !   ! Pointers to the prev and next blocks for this field on this task
-   !   type (field4DInteger), pointer :: prev => null()
-   !   type (field4DInteger), pointer :: next => null()
-
-   !   ! Halo communication lists
-   !   type (mpas_multihalo_exchange_list), pointer :: sendList => null()
-   !   type (mpas_multihalo_exchange_list), pointer :: recvList => null()
-   !   type (mpas_multihalo_exchange_list), pointer :: copyList => null()
-   !end type field4DInteger
-
-
-   ! Derived type for storing fields
    type field3DInteger
   
       ! Back-pointer to the containing block
@@ -273,6 +242,7 @@
       integer :: defaultValue
       integer :: missingValue
       integer, dimension(3) :: dimSizes
+      character (len=StrKIND) :: maskName
       logical :: isDecomposed
       logical :: hasTimeDimension
       logical :: isActive
@@ -307,6 +277,7 @@
       integer :: defaultValue
       integer :: missingValue
       integer, dimension(2) :: dimSizes
+      character (len=StrKIND) :: maskName
       logical :: isDecomposed
       logical :: hasTimeDimension
       logical :: isActive
@@ -341,6 +312,7 @@
       integer :: defaultValue
       integer :: missingValue
       integer, dimension(1) :: dimSizes
+      character (len=StrKIND) :: maskName
       logical :: isDecomposed
       logical :: hasTimeDimension
       logical :: isActive
@@ -373,6 +345,7 @@
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       integer :: defaultValue
       integer :: missingValue
+      character (len=StrKIND) :: maskName
       logical :: isDecomposed
       logical :: hasTimeDimension
       logical :: isActive
@@ -406,6 +379,7 @@
       integer, dimension(1) :: dimSizes
       character (len=StrKIND) :: defaultValue
       character (len=StrKIND) :: missingValue
+      character (len=StrKIND) :: maskName
       logical :: isDecomposed
       logical :: hasTimeDimension
       logical :: isActive
@@ -438,6 +412,7 @@
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       character (len=StrKIND) :: defaultValue
       character (len=StrKIND) :: missingValue
+      character (len=StrKIND) :: maskName
       logical :: isDecomposed
       logical :: hasTimeDimension
       logical :: isActive
@@ -469,6 +444,7 @@
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       logical :: defaultValue
       logical :: missingValue
+      character (len=StrKIND) :: maskName
       logical :: isDecomposed
       logical :: hasTimeDimension
       logical :: isActive

--- a/components/mpas-framework/src/framework/mpas_field_types.inc
+++ b/components/mpas-framework/src/framework/mpas_field_types.inc
@@ -20,6 +20,10 @@
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       character (len=StrKIND), dimension(5) :: dimNames
       integer, dimension(5) :: dimSizes
+      !type (field1DInteger), pointer :: missingValueMask1D => null()
+      !type (field2DInteger), pointer :: missingValueMask2D => null()
+      !type (field3DInteger), pointer :: missingValueMask3D => null()
+      !type (field4DInteger), pointer :: missingValueMask4D => null()
       real (kind=RKIND) :: defaultValue
       real (kind=RKIND) :: missingValue
       logical :: isDecomposed
@@ -54,6 +58,10 @@
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       character (len=StrKIND), dimension(4) :: dimNames
       integer, dimension(4) :: dimSizes
+      !type (field1DInteger), pointer :: missingValueMask1D => null()
+      !type (field2DInteger), pointer :: missingValueMask2D => null()
+      !type (field3DInteger), pointer :: missingValueMask3D => null()
+      !type (field4DInteger), pointer :: missingValueMask4D => null()
       real (kind=RKIND) :: defaultValue
       real (kind=RKIND) :: missingValue
       logical :: isDecomposed
@@ -89,6 +97,9 @@
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       character (len=StrKIND), dimension(3) :: dimNames
       integer, dimension(3) :: dimSizes
+      !type (field1DInteger), pointer :: missingValueMask1D => null()
+      !type (field2DInteger), pointer :: missingValueMask2D => null()
+      !type (field3DInteger), pointer :: missingValueMask3D => null()
       real (kind=RKIND) :: defaultValue
       real (kind=RKIND) :: missingValue
       logical :: isDecomposed
@@ -123,6 +134,8 @@
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       character (len=StrKIND), dimension(2) :: dimNames
       integer, dimension(2) :: dimSizes
+      type (field1DInteger), pointer :: missingValueMask1D => null()
+      type (field2DInteger), pointer :: missingValueMask2D => null()
       real (kind=RKIND) :: defaultValue
       real (kind=RKIND) :: missingValue
       logical :: isDecomposed
@@ -157,6 +170,7 @@
       character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
       character (len=StrKIND), dimension(1) :: dimNames
       integer, dimension(1) :: dimSizes
+      !type (field1DInteger), pointer :: missingValueMask1D => null()
       real (kind=RKIND) :: defaultValue
       real (kind=RKIND) :: missingValue
       logical :: isDecomposed
@@ -206,6 +220,40 @@
       type (mpas_multihalo_exchange_list), pointer :: recvList => null()
       type (mpas_multihalo_exchange_list), pointer :: copyList => null()
    end type field0DReal
+
+
+   ! Derived type for storing fields
+   !type field4DInteger
+
+   !   ! Back-pointer to the containing block
+   !   type (block_type), pointer :: block => null()
+
+   !   ! Raw array holding field data on this block
+   !   integer, dimension(:,:,:,:), pointer :: array => null()
+
+   !   ! Information used by the I/O layer
+   !   character (len=StrKIND) :: fieldName
+   !   character (len=StrKIND), dimension(:), pointer :: constituentNames => null()
+   !   character (len=StrKIND), dimension(4) :: dimNames
+   !   integer :: defaultValue
+   !   integer :: missingValue
+   !   integer, dimension(4) :: dimSizes
+   !   logical :: isDecomposed
+   !   logical :: hasTimeDimension
+   !   logical :: isActive
+   !   logical :: isVarArray
+   !   logical :: isPersistent
+   !   type (att_lists_type), dimension(:), pointer :: attLists => null()
+
+   !   ! Pointers to the prev and next blocks for this field on this task
+   !   type (field4DInteger), pointer :: prev => null()
+   !   type (field4DInteger), pointer :: next => null()
+
+   !   ! Halo communication lists
+   !   type (mpas_multihalo_exchange_list), pointer :: sendList => null()
+   !   type (mpas_multihalo_exchange_list), pointer :: recvList => null()
+   !   type (mpas_multihalo_exchange_list), pointer :: copyList => null()
+   !end type field4DInteger
 
 
    ! Derived type for storing fields

--- a/components/mpas-framework/src/framework/mpas_io_streams.F
+++ b/components/mpas-framework/src/framework/mpas_io_streams.F
@@ -3246,15 +3246,17 @@ module mpas_io_streams
    end subroutine MPAS_readStream
 
 
-   subroutine MPAS_writeStream(stream, frame, ierr)
+   subroutine MPAS_writeStream(stream, frame, useMissingValMask, ierr)
 
       implicit none
 
       type (MPAS_Stream_type), intent(inout) :: stream
       integer, intent(in) :: frame
+      logical, intent(in), optional :: useMissingValMask
       integer, intent(out), optional :: ierr
 
       character (len=StrKIND) :: dimensionSuffix
+      logical :: local_useMissingValMask
       integer :: io_err
       integer :: i, j
       integer :: ncons
@@ -3283,6 +3285,12 @@ module mpas_io_streams
       real (kind=RKIND), dimension(:,:,:),     pointer :: real3d_temp, real3d_temp_small
       real (kind=RKIND), dimension(:,:,:,:),   pointer :: real4d_temp, real4d_temp_small
       real (kind=RKIND), dimension(:,:,:,:,:), pointer :: real5d_temp, real5d_temp_small
+
+      if (present(useMissingValMask)) then
+         local_useMissingValMask = useMissingValMask
+      else
+         local_useMissingValMask = .false.
+      end if
 
       if (present(ierr)) ierr = MPAS_STREAM_NOERR
 
@@ -3587,7 +3595,8 @@ module mpas_io_streams
                         ! I suspect we will never hit this code, as it doesn't make sense, really
                         real0d_temp = field_1dreal_ptr % array(j)
                      else
-                        if (ASSOCIATED( field_1dreal_ptr % missingValueMask1D )) then
+                        if (local_useMissingValMask .and. &
+                            ASSOCIATED( field_1dreal_ptr % missingValueMask1D )) then
                            allocate(real1d_temp_small(ownedSize))
                            real1d_temp_small = field_1dreal_ptr % array(1:ownedSize)
                            call mpas_mask_field(field_1dreal_ptr, &
@@ -3657,7 +3666,8 @@ module mpas_io_streams
                      end if
 
                      if (field_cursor % real2dField % isVarArray) then
-                        if (ASSOCIATED( field_2dreal_ptr % missingValueMask1D )) then
+                        if (local_useMissingValMask .and. &
+                            ASSOCIATED( field_2dreal_ptr % missingValueMask1D )) then
                            allocate(real2d_temp_small(1,ownedSize))
                            real2d_temp_small(1,:) = field_2dreal_ptr % array(j,1:ownedSize)
                            call mpas_mask_field(field_2dreal_ptr, &
@@ -3668,22 +3678,26 @@ module mpas_io_streams
                            real1d_temp(i:i+ownedSize-1) = field_2dreal_ptr % array(j,1:ownedSize)
                         end if
                      else
-                        if (ASSOCIATED( field_2dreal_ptr % missingValueMask2D )) then
-                           allocate(real2d_temp_small(field_cursor % real2dField % dimSizes(1), &
-                                                      ownedSize))
-                           real2d_temp_small = field_2dreal_ptr % array(:,1:ownedSize)
-                           call mpas_mask_field(field_2dreal_ptr, &
-                              field_2dreal_ptr % missingValueMask2D, real2d_temp_small)
-                           real2d_temp(:,i:i+ownedSize-1) = real2d_temp_small
-                           deallocate(real2d_temp_small)
-                        elseif (ASSOCIATED( field_2dreal_ptr % missingValueMask1D )) then
-                           allocate(real2d_temp_small(field_cursor % real2dField % dimSizes(1), &
-                                                      ownedSize))
-                           real2d_temp_small = field_2dreal_ptr % array(:,1:ownedSize)
-                           call mpas_mask_field(field_2dreal_ptr, &
-                              field_2dreal_ptr % missingValueMask1D, real2d_temp_small)
-                           real2d_temp(:,i:i+ownedSize-1) = real2d_temp_small
-                           deallocate(real2d_temp_small)
+                        if (local_useMissingValMask) then
+                           if (ASSOCIATED( field_2dreal_ptr % missingValueMask2D )) then
+                              allocate(real2d_temp_small(field_cursor % real2dField % dimSizes(1), &
+                                                         ownedSize))
+                              real2d_temp_small = field_2dreal_ptr % array(:,1:ownedSize)
+                              call mpas_mask_field(field_2dreal_ptr, &
+                                 field_2dreal_ptr % missingValueMask2D, real2d_temp_small)
+                              real2d_temp(:,i:i+ownedSize-1) = real2d_temp_small
+                              deallocate(real2d_temp_small)
+                           elseif (ASSOCIATED( field_2dreal_ptr % missingValueMask1D )) then
+                              allocate(real2d_temp_small(field_cursor % real2dField % dimSizes(1), &
+                                                         ownedSize))
+                              real2d_temp_small = field_2dreal_ptr % array(:,1:ownedSize)
+                              call mpas_mask_field(field_2dreal_ptr, &
+                                 field_2dreal_ptr % missingValueMask1D, real2d_temp_small)
+                              real2d_temp(:,i:i+ownedSize-1) = real2d_temp_small
+                              deallocate(real2d_temp_small)
+                           else
+                              real2d_temp(:,i:i+ownedSize-1) = field_2dreal_ptr % array(:,1:ownedSize)
+                           end if
                         else
                            real2d_temp(:,i:i+ownedSize-1) = field_2dreal_ptr % array(:,1:ownedSize)
                         end if
@@ -3753,55 +3767,64 @@ module mpas_io_streams
                      end if
 
                      if (field_cursor % real3dField % isVarArray) then
-                        if (ASSOCIATED( field_3dreal_ptr % missingValueMask2D )) then
-                           allocate(real3d_temp_small(1, &
-                                                      field_cursor % real3dField % dimSizes(2), &
-                                                      ownedSize))
-                           real3d_temp_small(1,:,:) = field_3dreal_ptr % array(j,:,1:ownedSize)
-                           call mpas_mask_field(field_3dreal_ptr, &
-                              field_3dreal_ptr % missingValueMask2D, real3d_temp_small)
-                           real2d_temp(:,i:i+ownedSize-1) = real3d_temp_small(1,:,:)
-                           deallocate(real3d_temp_small)
-                       elseif (ASSOCIATED( field_3dreal_ptr % missingValueMask1D )) then
-                           allocate(real3d_temp_small(1, &
-                                                      field_cursor % real3dField % dimSizes(2), &
-                                                      ownedSize))
-                           real3d_temp_small(1,:,:) = field_3dreal_ptr % array(j,:,1:ownedSize)
-                           call mpas_mask_field(field_3dreal_ptr, &
-                              field_3dreal_ptr % missingValueMask1D, real3d_temp_small)
-                           real2d_temp(:,i:i+ownedSize-1) = real3d_temp_small(1,:,:)
-                           deallocate(real3d_temp_small)
+                        if (local_useMissingValMask) then
+                           if (ASSOCIATED( field_3dreal_ptr % missingValueMask2D )) then
+                              allocate(real3d_temp_small(1, &
+                                                         field_cursor % real3dField % dimSizes(2), &
+                                                         ownedSize))
+                              real3d_temp_small(1,:,:) = field_3dreal_ptr % array(j,:,1:ownedSize)
+                              call mpas_mask_field(field_3dreal_ptr, &
+                                 field_3dreal_ptr % missingValueMask2D, real3d_temp_small)
+                              real2d_temp(:,i:i+ownedSize-1) = real3d_temp_small(1,:,:)
+                              deallocate(real3d_temp_small)
+                           elseif (ASSOCIATED( field_3dreal_ptr % missingValueMask1D )) then
+                              allocate(real3d_temp_small(1, &
+                                                         field_cursor % real3dField % dimSizes(2), &
+                                                         ownedSize))
+                              real3d_temp_small(1,:,:) = field_3dreal_ptr % array(j,:,1:ownedSize)
+                              call mpas_mask_field(field_3dreal_ptr, &
+                                 field_3dreal_ptr % missingValueMask1D, real3d_temp_small)
+                              real2d_temp(:,i:i+ownedSize-1) = real3d_temp_small(1,:,:)
+                              deallocate(real3d_temp_small)
+                           else
+                              real2d_temp(:,i:i+ownedSize-1) = field_3dreal_ptr % array(j,:,1:ownedSize)
+                           endif
                         else
                            real2d_temp(:,i:i+ownedSize-1) = field_3dreal_ptr % array(j,:,1:ownedSize)
                         endif
                      else
-                        if (ASSOCIATED( field_3dreal_ptr % missingValueMask3D )) then
-                           allocate(real3d_temp_small(field_cursor % real3dField % dimSizes(1), &
-                                                      field_cursor % real3dField % dimSizes(2), &
-                                                      ownedSize))
-                           real3d_temp_small = field_3dreal_ptr % array(:,:,1:ownedSize)
-                           call mpas_mask_field(field_3dreal_ptr, &
-                              field_3dreal_ptr % missingValueMask3D, real3d_temp_small)
-                           real3d_temp(:,:,i:i+ownedSize-1) = real3d_temp_small
-                           deallocate(real3d_temp_small)
-                        elseif (ASSOCIATED( field_3dreal_ptr % missingValueMask2D )) then
-                           allocate(real3d_temp_small(field_cursor % real3dField % dimSizes(1), &
-                                                      field_cursor % real3dField % dimSizes(2), &
-                                                      ownedSize))
-                           real3d_temp_small = field_3dreal_ptr % array(:,:,1:ownedSize)
-                           call mpas_mask_field(field_3dreal_ptr, &
-                              field_3dreal_ptr % missingValueMask2D, real3d_temp_small)
-                           real3d_temp(:,:,i:i+ownedSize-1) = real3d_temp_small
-                           deallocate(real3d_temp_small)
-                        elseif (ASSOCIATED( field_3dreal_ptr % missingValueMask1D )) then
-                           allocate(real3d_temp_small(field_cursor % real3dField % dimSizes(1), &
-                                                      field_cursor % real3dField % dimSizes(2), &
-                                                      ownedSize))
-                           real3d_temp_small = field_3dreal_ptr % array(:,:,1:ownedSize)
-                           call mpas_mask_field(field_3dreal_ptr, &
-                              field_3dreal_ptr % missingValueMask1D, real3d_temp_small)
-                           real3d_temp(:,:,i:i+ownedSize-1) = real3d_temp_small
-                           deallocate(real3d_temp_small)
+                        if (local_useMissingValMask) then
+                           if (ASSOCIATED( field_3dreal_ptr % missingValueMask3D )) then
+                              allocate(real3d_temp_small(field_cursor % real3dField % dimSizes(1), &
+                                                         field_cursor % real3dField % dimSizes(2), &
+                                                         ownedSize))
+                              real3d_temp_small = field_3dreal_ptr % array(:,:,1:ownedSize)
+                              call mpas_mask_field(field_3dreal_ptr, &
+                                 field_3dreal_ptr % missingValueMask3D, real3d_temp_small)
+                              real3d_temp(:,:,i:i+ownedSize-1) = real3d_temp_small
+                              deallocate(real3d_temp_small)
+                           elseif (ASSOCIATED( field_3dreal_ptr % missingValueMask2D )) then
+                              deallocate(real3d_temp_small)
+                              allocate(real3d_temp_small(field_cursor % real3dField % dimSizes(1), &
+                                                         field_cursor % real3dField % dimSizes(2), &
+                                                         ownedSize))
+                              real3d_temp_small = field_3dreal_ptr % array(:,:,1:ownedSize)
+                              call mpas_mask_field(field_3dreal_ptr, &
+                                 field_3dreal_ptr % missingValueMask2D, real3d_temp_small)
+                              real3d_temp(:,:,i:i+ownedSize-1) = real3d_temp_small
+                              deallocate(real3d_temp_small)
+                           elseif (ASSOCIATED( field_3dreal_ptr % missingValueMask1D )) then
+                              allocate(real3d_temp_small(field_cursor % real3dField % dimSizes(1), &
+                                                         field_cursor % real3dField % dimSizes(2), &
+                                                         ownedSize))
+                              real3d_temp_small = field_3dreal_ptr % array(:,:,1:ownedSize)
+                              call mpas_mask_field(field_3dreal_ptr, &
+                                 field_3dreal_ptr % missingValueMask1D, real3d_temp_small)
+                              real3d_temp(:,:,i:i+ownedSize-1) = real3d_temp_small
+                              deallocate(real3d_temp_small)
+                           else
+                              real3d_temp(:,:,i:i+ownedSize-1) = field_3dreal_ptr % array(:,:,1:ownedSize)
+                           end if
                         else
                            real3d_temp(:,:,i:i+ownedSize-1) = field_3dreal_ptr % array(:,:,1:ownedSize)
                         end if
@@ -3871,70 +3894,78 @@ module mpas_io_streams
                      end if
 
                      if (field_cursor % real4dField % isVarArray) then
-                        if (ASSOCIATED( field_4dreal_ptr % missingValueMask3D )) then
-                           allocate(real4d_temp_small(1, &
-                                                      field_cursor % real4dField % dimSizes(2), &
-                                                      field_cursor % real4dField % dimSizes(3), &
-                                                      ownedSize))
-                           real4d_temp_small(1,:,:,:) = field_4dreal_ptr % array(j,:,:,1:ownedSize)
-                           call mpas_mask_field(field_4dreal_ptr, &
-                              field_4dreal_ptr % missingValueMask3D, real4d_temp_small)
-                           real3d_temp(:,:,i:i+ownedSize-1) = real4d_temp_small(1,:,:,:)
-                           deallocate(real4d_temp_small)
-                        elseif (ASSOCIATED( field_4dreal_ptr % missingValueMask2D )) then
-                           allocate(real4d_temp_small(1, &
-                                                      field_cursor % real4dField % dimSizes(2), &
-                                                      field_cursor % real4dField % dimSizes(3), &
-                                                      ownedSize))
-                           real4d_temp_small(1,:,:,:) = field_4dreal_ptr % array(j,:,:,1:ownedSize)
-                           call mpas_mask_field(field_4dreal_ptr, &
-                              field_4dreal_ptr % missingValueMask2D, real4d_temp_small)
-                           real3d_temp(:,:,i:i+ownedSize-1) = real4d_temp_small(1,:,:,:)
-                           deallocate(real4d_temp_small)
-                        elseif (ASSOCIATED( field_4dreal_ptr % missingValueMask1D )) then
-                           allocate(real4d_temp_small(1, &
-                                                      field_cursor % real4dField % dimSizes(2), &
-                                                      field_cursor % real4dField % dimSizes(3), &
-                                                      ownedSize))
-                           real4d_temp_small(1,:,:,:) = field_4dreal_ptr % array(j,:,:,1:ownedSize)
-                           call mpas_mask_field(field_4dreal_ptr, &
-                              field_4dreal_ptr % missingValueMask1D, real4d_temp_small)
-                           real3d_temp(:,:,i:i+ownedSize-1) = real4d_temp_small(1,:,:,:)
-                           deallocate(real4d_temp_small)
+                        if (local_useMissingValMask) then
+                           if (ASSOCIATED( field_4dreal_ptr % missingValueMask3D )) then
+                              allocate(real4d_temp_small(1, &
+                                                         field_cursor % real4dField % dimSizes(2), &
+                                                         field_cursor % real4dField % dimSizes(3), &
+                                                         ownedSize))
+                              real4d_temp_small(1,:,:,:) = field_4dreal_ptr % array(j,:,:,1:ownedSize)
+                              call mpas_mask_field(field_4dreal_ptr, &
+                                 field_4dreal_ptr % missingValueMask3D, real4d_temp_small)
+                              real3d_temp(:,:,i:i+ownedSize-1) = real4d_temp_small(1,:,:,:)
+                              deallocate(real4d_temp_small)
+                           elseif (ASSOCIATED( field_4dreal_ptr % missingValueMask2D )) then
+                              allocate(real4d_temp_small(1, &
+                                                         field_cursor % real4dField % dimSizes(2), &
+                                                         field_cursor % real4dField % dimSizes(3), &
+                                                         ownedSize))
+                              real4d_temp_small(1,:,:,:) = field_4dreal_ptr % array(j,:,:,1:ownedSize)
+                              call mpas_mask_field(field_4dreal_ptr, &
+                                 field_4dreal_ptr % missingValueMask2D, real4d_temp_small)
+                              real3d_temp(:,:,i:i+ownedSize-1) = real4d_temp_small(1,:,:,:)
+                              deallocate(real4d_temp_small)
+                           elseif (ASSOCIATED( field_4dreal_ptr % missingValueMask1D )) then
+                              allocate(real4d_temp_small(1, &
+                                                         field_cursor % real4dField % dimSizes(2), &
+                                                         field_cursor % real4dField % dimSizes(3), &
+                                                         ownedSize))
+                              real4d_temp_small(1,:,:,:) = field_4dreal_ptr % array(j,:,:,1:ownedSize)
+                              call mpas_mask_field(field_4dreal_ptr, &
+                                 field_4dreal_ptr % missingValueMask1D, real4d_temp_small)
+                              real3d_temp(:,:,i:i+ownedSize-1) = real4d_temp_small(1,:,:,:)
+                              deallocate(real4d_temp_small)
+                           else
+                              real3d_temp(:,:,i:i+ownedSize-1) = field_4dreal_ptr % array(j,:,:,1:ownedSize)
+                           endif
                         else
                            real3d_temp(:,:,i:i+ownedSize-1) = field_4dreal_ptr % array(j,:,:,1:ownedSize)
                         endif
                      else
-                        if (ASSOCIATED( field_4dreal_ptr % missingValueMask3D )) then
-                           allocate(real4d_temp_small(field_cursor % real4dField % dimSizes(1), &
-                                                      field_cursor % real4dField % dimSizes(2), &
-                                                      field_cursor % real4dField % dimSizes(3), &
-                                                      ownedSize))
-                           real4d_temp_small = field_4dreal_ptr % array(:,:,:,1:ownedSize)
-                           call mpas_mask_field(field_4dreal_ptr, &
-                              field_4dreal_ptr % missingValueMask3D, real4d_temp_small)
-                           real4d_temp(:,:,:,i:i+ownedSize-1) = real4d_temp_small
-                           deallocate(real4d_temp_small)
-                        elseif (ASSOCIATED( field_4dreal_ptr % missingValueMask2D )) then
-                           allocate(real4d_temp_small(field_cursor % real4dField % dimSizes(1), &
-                                                      field_cursor % real4dField % dimSizes(2), &
-                                                      field_cursor % real4dField % dimSizes(3), &
-                                                      ownedSize))
-                           real4d_temp_small = field_4dreal_ptr % array(:,:,:,1:ownedSize)
-                           call mpas_mask_field(field_4dreal_ptr, &
-                              field_4dreal_ptr % missingValueMask2D, real4d_temp_small)
-                           real4d_temp(:,:,:,i:i+ownedSize-1) = real4d_temp_small
-                           deallocate(real4d_temp_small)
-                        elseif (ASSOCIATED( field_4dreal_ptr % missingValueMask1D )) then
-                           allocate(real4d_temp_small(field_cursor % real4dField % dimSizes(1), &
-                                                      field_cursor % real4dField % dimSizes(2), &
-                                                      field_cursor % real4dField % dimSizes(3), &
-                                                      ownedSize))
-                           real4d_temp_small = field_4dreal_ptr % array(:,:,:,1:ownedSize)
-                           call mpas_mask_field(field_4dreal_ptr, &
-                              field_4dreal_ptr % missingValueMask1D, real4d_temp_small)
-                           real4d_temp(:,:,:,i:i+ownedSize-1) = real4d_temp_small
-                           deallocate(real4d_temp_small)
+                        if (local_useMissingValMask) then
+                           if (ASSOCIATED( field_4dreal_ptr % missingValueMask3D )) then
+                              allocate(real4d_temp_small(field_cursor % real4dField % dimSizes(1), &
+                                                         field_cursor % real4dField % dimSizes(2), &
+                                                         field_cursor % real4dField % dimSizes(3), &
+                                                         ownedSize))
+                              real4d_temp_small = field_4dreal_ptr % array(:,:,:,1:ownedSize)
+                              call mpas_mask_field(field_4dreal_ptr, &
+                                 field_4dreal_ptr % missingValueMask3D, real4d_temp_small)
+                              real4d_temp(:,:,:,i:i+ownedSize-1) = real4d_temp_small
+                              deallocate(real4d_temp_small)
+                           elseif (ASSOCIATED( field_4dreal_ptr % missingValueMask2D )) then
+                              allocate(real4d_temp_small(field_cursor % real4dField % dimSizes(1), &
+                                                         field_cursor % real4dField % dimSizes(2), &
+                                                         field_cursor % real4dField % dimSizes(3), &
+                                                         ownedSize))
+                              real4d_temp_small = field_4dreal_ptr % array(:,:,:,1:ownedSize)
+                              call mpas_mask_field(field_4dreal_ptr, &
+                                 field_4dreal_ptr % missingValueMask2D, real4d_temp_small)
+                              real4d_temp(:,:,:,i:i+ownedSize-1) = real4d_temp_small
+                              deallocate(real4d_temp_small)
+                           elseif (ASSOCIATED( field_4dreal_ptr % missingValueMask1D )) then
+                              allocate(real4d_temp_small(field_cursor % real4dField % dimSizes(1), &
+                                                         field_cursor % real4dField % dimSizes(2), &
+                                                         field_cursor % real4dField % dimSizes(3), &
+                                                         ownedSize))
+                              real4d_temp_small = field_4dreal_ptr % array(:,:,:,1:ownedSize)
+                              call mpas_mask_field(field_4dreal_ptr, &
+                                 field_4dreal_ptr % missingValueMask1D, real4d_temp_small)
+                              real4d_temp(:,:,:,i:i+ownedSize-1) = real4d_temp_small
+                              deallocate(real4d_temp_small)
+                           else
+                              real4d_temp(:,:,:,i:i+ownedSize-1) = field_4dreal_ptr % array(:,:,:,1:ownedSize)
+                           end if
                         else
                            real4d_temp(:,:,:,i:i+ownedSize-1) = field_4dreal_ptr % array(:,:,:,1:ownedSize)
                         end if
@@ -4006,76 +4037,84 @@ module mpas_io_streams
                      end if
 
                      if (field_cursor % real5dField % isVarArray) then
-                        if (ASSOCIATED( field_5dreal_ptr % missingValueMask3D )) then
-                           allocate(real5d_temp_small(1, &
-                                                      field_cursor % real5dField % dimSizes(2), &
-                                                      field_cursor % real5dField % dimSizes(3), &
-                                                      field_cursor % real5dField % dimSizes(4), &
-                                                      ownedSize))
-                           real5d_temp_small(1,:,:,:,:) = field_5dreal_ptr % array(j,:,:,:,1:ownedSize)
-                           call mpas_mask_field(field_5dreal_ptr, &
-                              field_5dreal_ptr % missingValueMask3D, real5d_temp_small)
-                           real4d_temp(:,:,:,i:i+ownedSize-1) = real5d_temp_small(1,:,:,:,:)
-                           deallocate(real5d_temp_small)
-                        elseif (ASSOCIATED( field_5dreal_ptr % missingValueMask2D )) then
-                           allocate(real5d_temp_small(1, &
-                                                      field_cursor % real5dField % dimSizes(2), &
-                                                      field_cursor % real5dField % dimSizes(3), &
-                                                      field_cursor % real5dField % dimSizes(4), &
-                                                      ownedSize))
-                           real5d_temp_small(1,:,:,:,:) = field_5dreal_ptr % array(j,:,:,:,1:ownedSize)
-                           call mpas_mask_field(field_5dreal_ptr, &
-                              field_5dreal_ptr % missingValueMask2D, real5d_temp_small)
-                           real4d_temp(:,:,:,i:i+ownedSize-1) = real5d_temp_small(1,:,:,:,:)
-                           deallocate(real5d_temp_small)
-                        elseif (ASSOCIATED( field_5dreal_ptr % missingValueMask1D )) then
-                           allocate(real5d_temp_small(1, &
-                                                      field_cursor % real5dField % dimSizes(2), &
-                                                      field_cursor % real5dField % dimSizes(3), &
-                                                      field_cursor % real5dField % dimSizes(4), &
-                                                      ownedSize))
-                           real5d_temp_small(1,:,:,:,:) = field_5dreal_ptr % array(j,:,:,:,1:ownedSize)
-                           call mpas_mask_field(field_5dreal_ptr, &
-                              field_5dreal_ptr % missingValueMask1D, real5d_temp_small)
-                           real4d_temp(:,:,:,i:i+ownedSize-1) = real5d_temp_small(1,:,:,:,:)
-                           deallocate(real5d_temp_small)
+                        if (local_useMissingValMask) then
+                           if (ASSOCIATED( field_5dreal_ptr % missingValueMask3D )) then
+                              allocate(real5d_temp_small(1, &
+                                                         field_cursor % real5dField % dimSizes(2), &
+                                                         field_cursor % real5dField % dimSizes(3), &
+                                                         field_cursor % real5dField % dimSizes(4), &
+                                                         ownedSize))
+                              real5d_temp_small(1,:,:,:,:) = field_5dreal_ptr % array(j,:,:,:,1:ownedSize)
+                              call mpas_mask_field(field_5dreal_ptr, &
+                                 field_5dreal_ptr % missingValueMask3D, real5d_temp_small)
+                              real4d_temp(:,:,:,i:i+ownedSize-1) = real5d_temp_small(1,:,:,:,:)
+                              deallocate(real5d_temp_small)
+                           elseif (ASSOCIATED( field_5dreal_ptr % missingValueMask2D )) then
+                              allocate(real5d_temp_small(1, &
+                                                         field_cursor % real5dField % dimSizes(2), &
+                                                         field_cursor % real5dField % dimSizes(3), &
+                                                         field_cursor % real5dField % dimSizes(4), &
+                                                         ownedSize))
+                              real5d_temp_small(1,:,:,:,:) = field_5dreal_ptr % array(j,:,:,:,1:ownedSize)
+                              call mpas_mask_field(field_5dreal_ptr, &
+                                 field_5dreal_ptr % missingValueMask2D, real5d_temp_small)
+                              real4d_temp(:,:,:,i:i+ownedSize-1) = real5d_temp_small(1,:,:,:,:)
+                              deallocate(real5d_temp_small)
+                           elseif (ASSOCIATED( field_5dreal_ptr % missingValueMask1D )) then
+                              allocate(real5d_temp_small(1, &
+                                                         field_cursor % real5dField % dimSizes(2), &
+                                                         field_cursor % real5dField % dimSizes(3), &
+                                                         field_cursor % real5dField % dimSizes(4), &
+                                                         ownedSize))
+                              real5d_temp_small(1,:,:,:,:) = field_5dreal_ptr % array(j,:,:,:,1:ownedSize)
+                              call mpas_mask_field(field_5dreal_ptr, &
+                                 field_5dreal_ptr % missingValueMask1D, real5d_temp_small)
+                              real4d_temp(:,:,:,i:i+ownedSize-1) = real5d_temp_small(1,:,:,:,:)
+                              deallocate(real5d_temp_small)
+                           else
+                              real4d_temp(:,:,:,i:i+ownedSize-1) = field_5dreal_ptr % array(j,:,:,:,1:ownedSize)
+                           endif
                         else
                            real4d_temp(:,:,:,i:i+ownedSize-1) = field_5dreal_ptr % array(j,:,:,:,1:ownedSize)
                         endif
                      else
-                        if (ASSOCIATED( field_5dreal_ptr % missingValueMask3D )) then
-                           allocate(real5d_temp_small(field_cursor % real5dField % dimSizes(1), &
-                                                      field_cursor % real5dField % dimSizes(2), &
-                                                      field_cursor % real5dField % dimSizes(3), &
-                                                      field_cursor % real5dField % dimSizes(4), &
-                                                      ownedSize))
-                           real5d_temp_small = field_5dreal_ptr % array(:,:,:,:,1:ownedSize)
-                           call mpas_mask_field(field_5dreal_ptr, &
-                              field_5dreal_ptr % missingValueMask3D, real5d_temp_small)
-                           real5d_temp(:,:,:,:,i:i+ownedSize-1) = real5d_temp_small
-                           deallocate(real5d_temp_small)
-                        elseif (ASSOCIATED( field_5dreal_ptr % missingValueMask2D )) then
-                           allocate(real5d_temp_small(field_cursor % real5dField % dimSizes(1), &
-                                                      field_cursor % real5dField % dimSizes(2), &
-                                                      field_cursor % real5dField % dimSizes(3), &
-                                                      field_cursor % real5dField % dimSizes(4), &
-                                                      ownedSize))
-                           real5d_temp_small = field_5dreal_ptr % array(:,:,:,:,1:ownedSize)
-                           call mpas_mask_field(field_5dreal_ptr, &
-                              field_5dreal_ptr % missingValueMask2D, real5d_temp_small)
-                           real5d_temp(:,:,:,:,i:i+ownedSize-1) = real5d_temp_small
-                           deallocate(real5d_temp_small)
-                        elseif (ASSOCIATED( field_5dreal_ptr % missingValueMask1D )) then
-                           allocate(real5d_temp_small(field_cursor % real5dField % dimSizes(1), &
-                                                      field_cursor % real5dField % dimSizes(2), &
-                                                      field_cursor % real5dField % dimSizes(3), &
-                                                      field_cursor % real5dField % dimSizes(4), &
-                                                      ownedSize))
-                           real5d_temp_small = field_5dreal_ptr % array(:,:,:,:,1:ownedSize)
-                           call mpas_mask_field(field_5dreal_ptr, &
-                              field_5dreal_ptr % missingValueMask1D, real5d_temp_small)
-                           real5d_temp(:,:,:,:,i:i+ownedSize-1) = real5d_temp_small
-                           deallocate(real5d_temp_small)
+                        if (local_useMissingValMask) then
+                           if (ASSOCIATED( field_5dreal_ptr % missingValueMask3D )) then
+                              allocate(real5d_temp_small(field_cursor % real5dField % dimSizes(1), &
+                                                         field_cursor % real5dField % dimSizes(2), &
+                                                         field_cursor % real5dField % dimSizes(3), &
+                                                         field_cursor % real5dField % dimSizes(4), &
+                                                         ownedSize))
+                              real5d_temp_small = field_5dreal_ptr % array(:,:,:,:,1:ownedSize)
+                              call mpas_mask_field(field_5dreal_ptr, &
+                                 field_5dreal_ptr % missingValueMask3D, real5d_temp_small)
+                              real5d_temp(:,:,:,:,i:i+ownedSize-1) = real5d_temp_small
+                              deallocate(real5d_temp_small)
+                           elseif (ASSOCIATED( field_5dreal_ptr % missingValueMask2D )) then
+                              allocate(real5d_temp_small(field_cursor % real5dField % dimSizes(1), &
+                                                         field_cursor % real5dField % dimSizes(2), &
+                                                         field_cursor % real5dField % dimSizes(3), &
+                                                         field_cursor % real5dField % dimSizes(4), &
+                                                         ownedSize))
+                              real5d_temp_small = field_5dreal_ptr % array(:,:,:,:,1:ownedSize)
+                              call mpas_mask_field(field_5dreal_ptr, &
+                                 field_5dreal_ptr % missingValueMask2D, real5d_temp_small)
+                              real5d_temp(:,:,:,:,i:i+ownedSize-1) = real5d_temp_small
+                              deallocate(real5d_temp_small)
+                           elseif (ASSOCIATED( field_5dreal_ptr % missingValueMask1D )) then
+                              allocate(real5d_temp_small(field_cursor % real5dField % dimSizes(1), &
+                                                         field_cursor % real5dField % dimSizes(2), &
+                                                         field_cursor % real5dField % dimSizes(3), &
+                                                         field_cursor % real5dField % dimSizes(4), &
+                                                         ownedSize))
+                              real5d_temp_small = field_5dreal_ptr % array(:,:,:,:,1:ownedSize)
+                              call mpas_mask_field(field_5dreal_ptr, &
+                                 field_5dreal_ptr % missingValueMask1D, real5d_temp_small)
+                              real5d_temp(:,:,:,:,i:i+ownedSize-1) = real5d_temp_small
+                              deallocate(real5d_temp_small)
+                           else
+                              real5d_temp(:,:,:,:,i:i+ownedSize-1) = field_5dreal_ptr % array(:,:,:,:,1:ownedSize)
+                           end if
                         else
                            real5d_temp(:,:,:,:,i:i+ownedSize-1) = field_5dreal_ptr % array(:,:,:,:,1:ownedSize)
                         end if

--- a/components/mpas-framework/src/framework/mpas_io_streams.F
+++ b/components/mpas-framework/src/framework/mpas_io_streams.F
@@ -3278,13 +3278,11 @@ module mpas_io_streams
       integer, dimension(:,:),   pointer :: maskArray
       integer, dimension(:,:,:), pointer :: int3d_temp
       real (kind=RKIND)                                :: real0d_temp
-      real (kind=RKIND), dimension(:),         pointer :: real1d_temp
-      real (kind=RKIND), dimension(:,:),       pointer :: real2d_temp
-      real (kind=RKIND), dimension(:,:),       pointer :: real2d_temp_small
-      real (kind=RKIND), dimension(:,:,:),     pointer :: real3d_temp
-      real (kind=RKIND), dimension(:,:,:),     pointer :: real3d_temp_small
-      real (kind=RKIND), dimension(:,:,:,:),   pointer :: real4d_temp
-      real (kind=RKIND), dimension(:,:,:,:,:), pointer :: real5d_temp
+      real (kind=RKIND), dimension(:),         pointer :: real1d_temp, real1d_temp_small
+      real (kind=RKIND), dimension(:,:),       pointer :: real2d_temp, real2d_temp_small
+      real (kind=RKIND), dimension(:,:,:),     pointer :: real3d_temp, real3d_temp_small
+      real (kind=RKIND), dimension(:,:,:,:),   pointer :: real4d_temp, real4d_temp_small
+      real (kind=RKIND), dimension(:,:,:,:,:), pointer :: real5d_temp, real5d_temp_small
 
       if (present(ierr)) ierr = MPAS_STREAM_NOERR
 
@@ -3327,6 +3325,10 @@ module mpas_io_streams
 
       !
       ! Loop over fields in the stream
+      !
+      ! -- Masking is supported for real fields with dimensions 1-5 and
+      ! -- real arrays with dimensions 3-5 with integer mask fields with
+      ! -- dimensions less than or equal to the field dimension, up to 3.
       !
       field_cursor => stream % fieldList
       do while (associated(field_cursor))
@@ -3582,10 +3584,19 @@ module mpas_io_streams
                      end if
 
                      if (field_cursor % real1dField % isVarArray) then
-! I suspect we will never hit this code, as it doesn't make sense, really
+                        ! I suspect we will never hit this code, as it doesn't make sense, really
                         real0d_temp = field_1dreal_ptr % array(j)
                      else
-                        real1d_temp(i:i+ownedSize-1) = field_1dreal_ptr % array(1:ownedSize)
+                        if (ASSOCIATED( field_1dreal_ptr % missingValueMask1D )) then
+                           allocate(real1d_temp_small(ownedSize))
+                           real1d_temp_small = field_1dreal_ptr % array(1:ownedSize)
+                           call mpas_mask_field(field_1dreal_ptr, &
+                              field_1dreal_ptr % missingValueMask1D, real1d_temp_small)
+                           real1d_temp(i:i+ownedSize-1) = real1d_temp_small
+                           deallocate(real1d_temp_small)
+                        else
+                           real1d_temp(i:i+ownedSize-1) = field_1dreal_ptr % array(1:ownedSize)
+                        end if
                      end if
                      i = i + ownedSize
                      if ( .not. stream % blockWrite ) then
@@ -3632,7 +3643,6 @@ module mpas_io_streams
                   field_2dreal_ptr => field_cursor % real2dField
                   i = 1
                   do while (associated(field_2dreal_ptr))
-                     call mpas_log_write('field_2dreal_ptr is '//TRIM(field_2dreal_ptr % fieldName))
                      if (trim(field_2dreal_ptr % dimNames(2)) == 'nCells') then
                         call mpas_pool_get_dimension(field_2dreal_ptr % block % dimensions, trim(field_2dreal_ptr % dimNames(2)) &
                                                      // trim(dimensionSuffix), ownedSize)
@@ -3647,14 +3657,31 @@ module mpas_io_streams
                      end if
 
                      if (field_cursor % real2dField % isVarArray) then
-                        real1d_temp(i:i+ownedSize-1) = field_2dreal_ptr % array(j,1:ownedSize)
+                        if (ASSOCIATED( field_2dreal_ptr % missingValueMask1D )) then
+                           allocate(real2d_temp_small(1,ownedSize))
+                           real2d_temp_small(1,:) = field_2dreal_ptr % array(j,1:ownedSize)
+                           call mpas_mask_field(field_2dreal_ptr, &
+                              field_2dreal_ptr % missingValueMask1D, real2d_temp_small)
+                           real2d_temp(:,i:i+ownedSize-1) = real2d_temp_small
+                           deallocate(real2d_temp_small)
+                        else
+                           real1d_temp(i:i+ownedSize-1) = field_2dreal_ptr % array(j,1:ownedSize)
+                        end if
                      else
                         if (ASSOCIATED( field_2dreal_ptr % missingValueMask2D )) then
                            allocate(real2d_temp_small(field_cursor % real2dField % dimSizes(1), &
-                                                ownedSize))
+                                                      ownedSize))
                            real2d_temp_small = field_2dreal_ptr % array(:,1:ownedSize)
                            call mpas_mask_field(field_2dreal_ptr, &
-                               field_2dreal_ptr % missingValueMask2D, real2d_temp_small)
+                              field_2dreal_ptr % missingValueMask2D, real2d_temp_small)
+                           real2d_temp(:,i:i+ownedSize-1) = real2d_temp_small
+                           deallocate(real2d_temp_small)
+                        elseif (ASSOCIATED( field_2dreal_ptr % missingValueMask1D )) then
+                           allocate(real2d_temp_small(field_cursor % real2dField % dimSizes(1), &
+                                                      ownedSize))
+                           real2d_temp_small = field_2dreal_ptr % array(:,1:ownedSize)
+                           call mpas_mask_field(field_2dreal_ptr, &
+                              field_2dreal_ptr % missingValueMask1D, real2d_temp_small)
                            real2d_temp(:,i:i+ownedSize-1) = real2d_temp_small
                            deallocate(real2d_temp_small)
                         else
@@ -3706,7 +3733,6 @@ module mpas_io_streams
             end if
 
             do j=1,ncons
-               call mpas_log_write('j')
                if (field_cursor % isDecomposed) then
                   ! Gather field from across multiple blocks
                   field_3dreal_ptr => field_cursor % real3dField
@@ -3733,14 +3759,52 @@ module mpas_io_streams
                                                       ownedSize))
                            real3d_temp_small(1,:,:) = field_3dreal_ptr % array(j,:,1:ownedSize)
                            call mpas_mask_field(field_3dreal_ptr, &
-                               field_3dreal_ptr % missingValueMask2D, real3d_temp_small)
+                              field_3dreal_ptr % missingValueMask2D, real3d_temp_small)
+                           real2d_temp(:,i:i+ownedSize-1) = real3d_temp_small(1,:,:)
+                           deallocate(real3d_temp_small)
+                       elseif (ASSOCIATED( field_3dreal_ptr % missingValueMask1D )) then
+                           allocate(real3d_temp_small(1, &
+                                                      field_cursor % real3dField % dimSizes(2), &
+                                                      ownedSize))
+                           real3d_temp_small(1,:,:) = field_3dreal_ptr % array(j,:,1:ownedSize)
+                           call mpas_mask_field(field_3dreal_ptr, &
+                              field_3dreal_ptr % missingValueMask1D, real3d_temp_small)
                            real2d_temp(:,i:i+ownedSize-1) = real3d_temp_small(1,:,:)
                            deallocate(real3d_temp_small)
                         else
                            real2d_temp(:,i:i+ownedSize-1) = field_3dreal_ptr % array(j,:,1:ownedSize)
                         endif
                      else
-                        real3d_temp(:,:,i:i+ownedSize-1) = field_3dreal_ptr % array(:,:,1:ownedSize)
+                        if (ASSOCIATED( field_3dreal_ptr % missingValueMask3D )) then
+                           allocate(real3d_temp_small(field_cursor % real3dField % dimSizes(1), &
+                                                      field_cursor % real3dField % dimSizes(2), &
+                                                      ownedSize))
+                           real3d_temp_small = field_3dreal_ptr % array(:,:,1:ownedSize)
+                           call mpas_mask_field(field_3dreal_ptr, &
+                              field_3dreal_ptr % missingValueMask3D, real3d_temp_small)
+                           real3d_temp(:,:,i:i+ownedSize-1) = real3d_temp_small
+                           deallocate(real3d_temp_small)
+                        elseif (ASSOCIATED( field_3dreal_ptr % missingValueMask2D )) then
+                           allocate(real3d_temp_small(field_cursor % real3dField % dimSizes(1), &
+                                                      field_cursor % real3dField % dimSizes(2), &
+                                                      ownedSize))
+                           real3d_temp_small = field_3dreal_ptr % array(:,:,1:ownedSize)
+                           call mpas_mask_field(field_3dreal_ptr, &
+                              field_3dreal_ptr % missingValueMask2D, real3d_temp_small)
+                           real3d_temp(:,:,i:i+ownedSize-1) = real3d_temp_small
+                           deallocate(real3d_temp_small)
+                        elseif (ASSOCIATED( field_3dreal_ptr % missingValueMask1D )) then
+                           allocate(real3d_temp_small(field_cursor % real3dField % dimSizes(1), &
+                                                      field_cursor % real3dField % dimSizes(2), &
+                                                      ownedSize))
+                           real3d_temp_small = field_3dreal_ptr % array(:,:,1:ownedSize)
+                           call mpas_mask_field(field_3dreal_ptr, &
+                              field_3dreal_ptr % missingValueMask1D, real3d_temp_small)
+                           real3d_temp(:,:,i:i+ownedSize-1) = real3d_temp_small
+                           deallocate(real3d_temp_small)
+                        else
+                           real3d_temp(:,:,i:i+ownedSize-1) = field_3dreal_ptr % array(:,:,1:ownedSize)
+                        end if
                      end if
                      i = i + ownedSize
                      if ( .not. stream % blockWrite ) then
@@ -3758,9 +3822,7 @@ module mpas_io_streams
                end if
 
                if (field_cursor % real3dField % isVarArray) then
-                  call mpas_log_write('Put 3d varArray ...')
                   call MPAS_io_put_var(stream % fileHandle, field_cursor % real3dField % constituentNames(j), real2d_temp, io_err)
-                  call mpas_log_write('... Completed')
                else
                   call MPAS_io_put_var(stream % fileHandle, field_cursor % real3dField % fieldName, real3d_temp, io_err)
                end if
@@ -3809,9 +3871,73 @@ module mpas_io_streams
                      end if
 
                      if (field_cursor % real4dField % isVarArray) then
-                        real3d_temp(:,:,i:i+ownedSize-1) = field_4dreal_ptr % array(j,:,:,1:ownedSize)
+                        if (ASSOCIATED( field_4dreal_ptr % missingValueMask3D )) then
+                           allocate(real4d_temp_small(1, &
+                                                      field_cursor % real4dField % dimSizes(2), &
+                                                      field_cursor % real4dField % dimSizes(3), &
+                                                      ownedSize))
+                           real4d_temp_small(1,:,:,:) = field_4dreal_ptr % array(j,:,:,1:ownedSize)
+                           call mpas_mask_field(field_4dreal_ptr, &
+                              field_4dreal_ptr % missingValueMask3D, real4d_temp_small)
+                           real3d_temp(:,:,i:i+ownedSize-1) = real4d_temp_small(1,:,:,:)
+                           deallocate(real4d_temp_small)
+                        elseif (ASSOCIATED( field_4dreal_ptr % missingValueMask2D )) then
+                           allocate(real4d_temp_small(1, &
+                                                      field_cursor % real4dField % dimSizes(2), &
+                                                      field_cursor % real4dField % dimSizes(3), &
+                                                      ownedSize))
+                           real4d_temp_small(1,:,:,:) = field_4dreal_ptr % array(j,:,:,1:ownedSize)
+                           call mpas_mask_field(field_4dreal_ptr, &
+                              field_4dreal_ptr % missingValueMask2D, real4d_temp_small)
+                           real3d_temp(:,:,i:i+ownedSize-1) = real4d_temp_small(1,:,:,:)
+                           deallocate(real4d_temp_small)
+                        elseif (ASSOCIATED( field_4dreal_ptr % missingValueMask1D )) then
+                           allocate(real4d_temp_small(1, &
+                                                      field_cursor % real4dField % dimSizes(2), &
+                                                      field_cursor % real4dField % dimSizes(3), &
+                                                      ownedSize))
+                           real4d_temp_small(1,:,:,:) = field_4dreal_ptr % array(j,:,:,1:ownedSize)
+                           call mpas_mask_field(field_4dreal_ptr, &
+                              field_4dreal_ptr % missingValueMask1D, real4d_temp_small)
+                           real3d_temp(:,:,i:i+ownedSize-1) = real4d_temp_small(1,:,:,:)
+                           deallocate(real4d_temp_small)
+                        else
+                           real3d_temp(:,:,i:i+ownedSize-1) = field_4dreal_ptr % array(j,:,:,1:ownedSize)
+                        endif
                      else
-                        real4d_temp(:,:,:,i:i+ownedSize-1) = field_4dreal_ptr % array(:,:,:,1:ownedSize)
+                        if (ASSOCIATED( field_4dreal_ptr % missingValueMask3D )) then
+                           allocate(real4d_temp_small(field_cursor % real4dField % dimSizes(1), &
+                                                      field_cursor % real4dField % dimSizes(2), &
+                                                      field_cursor % real4dField % dimSizes(3), &
+                                                      ownedSize))
+                           real4d_temp_small = field_4dreal_ptr % array(:,:,:,1:ownedSize)
+                           call mpas_mask_field(field_4dreal_ptr, &
+                              field_4dreal_ptr % missingValueMask3D, real4d_temp_small)
+                           real4d_temp(:,:,:,i:i+ownedSize-1) = real4d_temp_small
+                           deallocate(real4d_temp_small)
+                        elseif (ASSOCIATED( field_4dreal_ptr % missingValueMask2D )) then
+                           allocate(real4d_temp_small(field_cursor % real4dField % dimSizes(1), &
+                                                      field_cursor % real4dField % dimSizes(2), &
+                                                      field_cursor % real4dField % dimSizes(3), &
+                                                      ownedSize))
+                           real4d_temp_small = field_4dreal_ptr % array(:,:,:,1:ownedSize)
+                           call mpas_mask_field(field_4dreal_ptr, &
+                              field_4dreal_ptr % missingValueMask2D, real4d_temp_small)
+                           real4d_temp(:,:,:,i:i+ownedSize-1) = real4d_temp_small
+                           deallocate(real4d_temp_small)
+                        elseif (ASSOCIATED( field_4dreal_ptr % missingValueMask1D )) then
+                           allocate(real4d_temp_small(field_cursor % real4dField % dimSizes(1), &
+                                                      field_cursor % real4dField % dimSizes(2), &
+                                                      field_cursor % real4dField % dimSizes(3), &
+                                                      ownedSize))
+                           real4d_temp_small = field_4dreal_ptr % array(:,:,:,1:ownedSize)
+                           call mpas_mask_field(field_4dreal_ptr, &
+                              field_4dreal_ptr % missingValueMask1D, real4d_temp_small)
+                           real4d_temp(:,:,:,i:i+ownedSize-1) = real4d_temp_small
+                           deallocate(real4d_temp_small)
+                        else
+                           real4d_temp(:,:,:,i:i+ownedSize-1) = field_4dreal_ptr % array(:,:,:,1:ownedSize)
+                        end if
                      end if
                      i = i + ownedSize
                      if ( .not. stream % blockWrite ) then
@@ -3880,9 +4006,79 @@ module mpas_io_streams
                      end if
 
                      if (field_cursor % real5dField % isVarArray) then
-                        real4d_temp(:,:,:,i:i+ownedSize-1) = field_5dreal_ptr % array(j,:,:,:,1:ownedSize)
+                        if (ASSOCIATED( field_5dreal_ptr % missingValueMask3D )) then
+                           allocate(real5d_temp_small(1, &
+                                                      field_cursor % real5dField % dimSizes(2), &
+                                                      field_cursor % real5dField % dimSizes(3), &
+                                                      field_cursor % real5dField % dimSizes(4), &
+                                                      ownedSize))
+                           real5d_temp_small(1,:,:,:,:) = field_5dreal_ptr % array(j,:,:,:,1:ownedSize)
+                           call mpas_mask_field(field_5dreal_ptr, &
+                              field_5dreal_ptr % missingValueMask3D, real5d_temp_small)
+                           real4d_temp(:,:,:,i:i+ownedSize-1) = real5d_temp_small(1,:,:,:,:)
+                           deallocate(real5d_temp_small)
+                        elseif (ASSOCIATED( field_5dreal_ptr % missingValueMask2D )) then
+                           allocate(real5d_temp_small(1, &
+                                                      field_cursor % real5dField % dimSizes(2), &
+                                                      field_cursor % real5dField % dimSizes(3), &
+                                                      field_cursor % real5dField % dimSizes(4), &
+                                                      ownedSize))
+                           real5d_temp_small(1,:,:,:,:) = field_5dreal_ptr % array(j,:,:,:,1:ownedSize)
+                           call mpas_mask_field(field_5dreal_ptr, &
+                              field_5dreal_ptr % missingValueMask2D, real5d_temp_small)
+                           real4d_temp(:,:,:,i:i+ownedSize-1) = real5d_temp_small(1,:,:,:,:)
+                           deallocate(real5d_temp_small)
+                        elseif (ASSOCIATED( field_5dreal_ptr % missingValueMask1D )) then
+                           allocate(real5d_temp_small(1, &
+                                                      field_cursor % real5dField % dimSizes(2), &
+                                                      field_cursor % real5dField % dimSizes(3), &
+                                                      field_cursor % real5dField % dimSizes(4), &
+                                                      ownedSize))
+                           real5d_temp_small(1,:,:,:,:) = field_5dreal_ptr % array(j,:,:,:,1:ownedSize)
+                           call mpas_mask_field(field_5dreal_ptr, &
+                              field_5dreal_ptr % missingValueMask1D, real5d_temp_small)
+                           real4d_temp(:,:,:,i:i+ownedSize-1) = real5d_temp_small(1,:,:,:,:)
+                           deallocate(real5d_temp_small)
+                        else
+                           real4d_temp(:,:,:,i:i+ownedSize-1) = field_5dreal_ptr % array(j,:,:,:,1:ownedSize)
+                        endif
                      else
-                        real5d_temp(:,:,:,:,i:i+ownedSize-1) = field_5dreal_ptr % array(:,:,:,:,1:ownedSize)
+                        if (ASSOCIATED( field_5dreal_ptr % missingValueMask3D )) then
+                           allocate(real5d_temp_small(field_cursor % real5dField % dimSizes(1), &
+                                                      field_cursor % real5dField % dimSizes(2), &
+                                                      field_cursor % real5dField % dimSizes(3), &
+                                                      field_cursor % real5dField % dimSizes(4), &
+                                                      ownedSize))
+                           real5d_temp_small = field_5dreal_ptr % array(:,:,:,:,1:ownedSize)
+                           call mpas_mask_field(field_5dreal_ptr, &
+                              field_5dreal_ptr % missingValueMask3D, real5d_temp_small)
+                           real5d_temp(:,:,:,:,i:i+ownedSize-1) = real5d_temp_small
+                           deallocate(real5d_temp_small)
+                        elseif (ASSOCIATED( field_5dreal_ptr % missingValueMask2D )) then
+                           allocate(real5d_temp_small(field_cursor % real5dField % dimSizes(1), &
+                                                      field_cursor % real5dField % dimSizes(2), &
+                                                      field_cursor % real5dField % dimSizes(3), &
+                                                      field_cursor % real5dField % dimSizes(4), &
+                                                      ownedSize))
+                           real5d_temp_small = field_5dreal_ptr % array(:,:,:,:,1:ownedSize)
+                           call mpas_mask_field(field_5dreal_ptr, &
+                              field_5dreal_ptr % missingValueMask2D, real5d_temp_small)
+                           real5d_temp(:,:,:,:,i:i+ownedSize-1) = real5d_temp_small
+                           deallocate(real5d_temp_small)
+                        elseif (ASSOCIATED( field_5dreal_ptr % missingValueMask1D )) then
+                           allocate(real5d_temp_small(field_cursor % real5dField % dimSizes(1), &
+                                                      field_cursor % real5dField % dimSizes(2), &
+                                                      field_cursor % real5dField % dimSizes(3), &
+                                                      field_cursor % real5dField % dimSizes(4), &
+                                                      ownedSize))
+                           real5d_temp_small = field_5dreal_ptr % array(:,:,:,:,1:ownedSize)
+                           call mpas_mask_field(field_5dreal_ptr, &
+                              field_5dreal_ptr % missingValueMask1D, real5d_temp_small)
+                           real5d_temp(:,:,:,:,i:i+ownedSize-1) = real5d_temp_small
+                           deallocate(real5d_temp_small)
+                        else
+                           real5d_temp(:,:,:,:,i:i+ownedSize-1) = field_5dreal_ptr % array(:,:,:,:,1:ownedSize)
+                        end if
                      end if
                      i = i + ownedSize
                      if ( .not. stream % blockWrite ) then

--- a/components/mpas-framework/src/framework/mpas_io_streams.F
+++ b/components/mpas-framework/src/framework/mpas_io_streams.F
@@ -3255,7 +3255,6 @@ module mpas_io_streams
       integer, intent(out), optional :: ierr
 
       character (len=StrKIND) :: dimensionSuffix
-      character (len=100) :: log_string
       integer :: io_err
       integer :: i, j
       integer :: ncons
@@ -3283,6 +3282,7 @@ module mpas_io_streams
       real (kind=RKIND), dimension(:,:),       pointer :: real2d_temp
       real (kind=RKIND), dimension(:,:),       pointer :: real2d_temp_small
       real (kind=RKIND), dimension(:,:,:),     pointer :: real3d_temp
+      real (kind=RKIND), dimension(:,:,:),     pointer :: real3d_temp_small
       real (kind=RKIND), dimension(:,:,:,:),   pointer :: real4d_temp
       real (kind=RKIND), dimension(:,:,:,:,:), pointer :: real5d_temp
 
@@ -3645,8 +3645,6 @@ module mpas_io_streams
                      else
                         call mpas_pool_get_dimension(field_2dreal_ptr % block % dimensions, field_2dreal_ptr % dimNames(2), ownedSize)
                      end if
-                     write(log_string,*) 'i,OwnedSize,dimName = ',i, ownedSize, trim(field_2dreal_ptr % dimNames(2))
-                     call mpas_log_write(log_string)
 
                      if (field_cursor % real2dField % isVarArray) then
                         real1d_temp(i:i+ownedSize-1) = field_2dreal_ptr % array(j,1:ownedSize)
@@ -3654,7 +3652,8 @@ module mpas_io_streams
                         if (ASSOCIATED( field_2dreal_ptr % missingValueMask2D )) then
                            allocate(real2d_temp_small(field_cursor % real2dField % dimSizes(1), &
                                                 ownedSize))
-                           call mpas_mask_field2d_mask2d_real(field_2dreal_ptr, &
+                           real2d_temp_small = field_2dreal_ptr % array(:,1:ownedSize)
+                           call mpas_mask_field(field_2dreal_ptr, &
                                field_2dreal_ptr % missingValueMask2D, real2d_temp_small)
                            real2d_temp(:,i:i+ownedSize-1) = real2d_temp_small
                            deallocate(real2d_temp_small)
@@ -3665,10 +3664,8 @@ module mpas_io_streams
                      end if
                      i = i + ownedSize
                      if ( .not. stream % blockWrite ) then
-                        call mpas_log_write('Go to next')
                         field_2dreal_ptr => field_2dreal_ptr % next
                      else
-                        call mpas_log_write('Nullify ptr')
                         nullify(field_2dreal_ptr)
                      end if
                   end do
@@ -3709,6 +3706,7 @@ module mpas_io_streams
             end if
 
             do j=1,ncons
+               call mpas_log_write('j')
                if (field_cursor % isDecomposed) then
                   ! Gather field from across multiple blocks
                   field_3dreal_ptr => field_cursor % real3dField
@@ -3724,11 +3722,23 @@ module mpas_io_streams
                         call mpas_pool_get_dimension(field_3dreal_ptr % block % dimensions, trim(field_3dreal_ptr % dimNames(3)) &
                                                      // trim(dimensionSuffix), ownedSize)
                      else
-                        call mpas_pool_get_dimension(field_3dreal_ptr % block % dimensions, field_3dreal_ptr % dimNames(3), ownedSize)
+                        call mpas_pool_get_dimension(field_3dreal_ptr % block % dimensions, &
+                                                     field_3dreal_ptr % dimNames(3), ownedSize)
                      end if
 
                      if (field_cursor % real3dField % isVarArray) then
-                        real2d_temp(:,i:i+ownedSize-1) = field_3dreal_ptr % array(j,:,1:ownedSize)
+                        if (ASSOCIATED( field_3dreal_ptr % missingValueMask2D )) then
+                           allocate(real3d_temp_small(1, &
+                                                      field_cursor % real3dField % dimSizes(2), &
+                                                      ownedSize))
+                           real3d_temp_small(1,:,:) = field_3dreal_ptr % array(j,:,1:ownedSize)
+                           call mpas_mask_field(field_3dreal_ptr, &
+                               field_3dreal_ptr % missingValueMask2D, real3d_temp_small)
+                           real2d_temp(:,i:i+ownedSize-1) = real3d_temp_small(1,:,:)
+                           deallocate(real3d_temp_small)
+                        else
+                           real2d_temp(:,i:i+ownedSize-1) = field_3dreal_ptr % array(j,:,1:ownedSize)
+                        endif
                      else
                         real3d_temp(:,:,i:i+ownedSize-1) = field_3dreal_ptr % array(:,:,1:ownedSize)
                      end if
@@ -3748,7 +3758,9 @@ module mpas_io_streams
                end if
 
                if (field_cursor % real3dField % isVarArray) then
+                  call mpas_log_write('Put 3d varArray ...')
                   call MPAS_io_put_var(stream % fileHandle, field_cursor % real3dField % constituentNames(j), real2d_temp, io_err)
+                  call mpas_log_write('... Completed')
                else
                   call MPAS_io_put_var(stream % fileHandle, field_cursor % real3dField % fieldName, real3d_temp, io_err)
                end if

--- a/components/mpas-framework/src/framework/mpas_io_streams.F
+++ b/components/mpas-framework/src/framework/mpas_io_streams.F
@@ -3597,7 +3597,12 @@ module mpas_io_streams
                      else
                         if (local_useMissingValMask .and. &
                             ASSOCIATED( field_1dreal_ptr % missingValueMask1D )) then
-                           allocate(real1d_temp_small(ownedSize))
+                           allocate(real1d_temp_small(ownedSize),stat=io_err)
+                           if (io_err /= 0) then
+                              call mpas_log_write('real1d_temp_small: $i', intArgs=(/ownedSize/) )
+                              if (present(ierr)) ierr = MPAS_IO_ERR
+                              return
+                           end if
                            real1d_temp_small = field_1dreal_ptr % array(1:ownedSize)
                            call mpas_mask_field(field_1dreal_ptr, &
                               field_1dreal_ptr % missingValueMask1D, real1d_temp_small)
@@ -3668,7 +3673,13 @@ module mpas_io_streams
                      if (field_cursor % real2dField % isVarArray) then
                         if (local_useMissingValMask .and. &
                             ASSOCIATED( field_2dreal_ptr % missingValueMask1D )) then
-                           allocate(real2d_temp_small(1,ownedSize))
+                           allocate(real2d_temp_small(1,ownedSize),stat=io_err)
+                           if (io_err /= 0) then
+                              call mpas_log_write('real2d_temp_small: $i', intArgs=(/ownedSize/) )
+                              if (present(ierr)) ierr = MPAS_IO_ERR
+                              return
+                           end if
+
                            real2d_temp_small(1,:) = field_2dreal_ptr % array(j,1:ownedSize)
                            call mpas_mask_field(field_2dreal_ptr, &
                               field_2dreal_ptr % missingValueMask1D, real2d_temp_small)
@@ -3681,7 +3692,12 @@ module mpas_io_streams
                         if (local_useMissingValMask) then
                            if (ASSOCIATED( field_2dreal_ptr % missingValueMask2D )) then
                               allocate(real2d_temp_small(field_cursor % real2dField % dimSizes(1), &
-                                                         ownedSize))
+                                                         ownedSize),stat=io_err)
+                              if (io_err /= 0) then
+                                 call mpas_log_write('real2d_temp_small: $i', intArgs=(/field_cursor % real2dField % dimSizes(1)*ownedSize/) )
+                                 if (present(ierr)) ierr = MPAS_IO_ERR
+                                 return
+                              end if
                               real2d_temp_small = field_2dreal_ptr % array(:,1:ownedSize)
                               call mpas_mask_field(field_2dreal_ptr, &
                                  field_2dreal_ptr % missingValueMask2D, real2d_temp_small)
@@ -3689,7 +3705,12 @@ module mpas_io_streams
                               deallocate(real2d_temp_small)
                            elseif (ASSOCIATED( field_2dreal_ptr % missingValueMask1D )) then
                               allocate(real2d_temp_small(field_cursor % real2dField % dimSizes(1), &
-                                                         ownedSize))
+                                                         ownedSize),stat=io_err)
+                              if (io_err /= 0) then
+                                 call mpas_log_write('real2d_temp_small: $i', intArgs=(/field_cursor % real2dField % dimSizes(1)*ownedSize/) )
+                                 if (present(ierr)) ierr = MPAS_IO_ERR
+                                 return
+                              end if
                               real2d_temp_small = field_2dreal_ptr % array(:,1:ownedSize)
                               call mpas_mask_field(field_2dreal_ptr, &
                                  field_2dreal_ptr % missingValueMask1D, real2d_temp_small)
@@ -3771,7 +3792,13 @@ module mpas_io_streams
                            if (ASSOCIATED( field_3dreal_ptr % missingValueMask2D )) then
                               allocate(real3d_temp_small(1, &
                                                          field_cursor % real3dField % dimSizes(2), &
-                                                         ownedSize))
+                                                         ownedSize),stat=io_err)
+                              if (io_err /= 0) then
+                                 call mpas_log_write('real3d_temp_small: $i', intArgs=(/field_cursor % real3dField % dimSizes(2)*ownedSize/) )
+                                 if (present(ierr)) ierr = MPAS_IO_ERR
+                                 return
+                              end if
+
                               real3d_temp_small(1,:,:) = field_3dreal_ptr % array(j,:,1:ownedSize)
                               call mpas_mask_field(field_3dreal_ptr, &
                                  field_3dreal_ptr % missingValueMask2D, real3d_temp_small)
@@ -3780,7 +3807,13 @@ module mpas_io_streams
                            elseif (ASSOCIATED( field_3dreal_ptr % missingValueMask1D )) then
                               allocate(real3d_temp_small(1, &
                                                          field_cursor % real3dField % dimSizes(2), &
-                                                         ownedSize))
+                                                         ownedSize),stat=io_err)
+                              if (io_err /= 0) then
+                                 call mpas_log_write('real3d_temp_small: $i', intArgs=(/field_cursor % real3dField % dimSizes(2)*ownedSize/) )
+                                 if (present(ierr)) ierr = MPAS_IO_ERR
+                                 return
+                              end if
+
                               real3d_temp_small(1,:,:) = field_3dreal_ptr % array(j,:,1:ownedSize)
                               call mpas_mask_field(field_3dreal_ptr, &
                                  field_3dreal_ptr % missingValueMask1D, real3d_temp_small)
@@ -3797,7 +3830,14 @@ module mpas_io_streams
                            if (ASSOCIATED( field_3dreal_ptr % missingValueMask3D )) then
                               allocate(real3d_temp_small(field_cursor % real3dField % dimSizes(1), &
                                                          field_cursor % real3dField % dimSizes(2), &
-                                                         ownedSize))
+                                                         ownedSize),stat=io_err)
+                              if (io_err /= 0) then
+                                 call mpas_log_write('real3d_temp_small: $i', intArgs=(/field_cursor % real3dField % dimSizes(1)* &
+                                                                                        field_cursor % real3dField % dimSizes(2)*ownedSize/) )
+                                 if (present(ierr)) ierr = MPAS_IO_ERR
+                                 return
+                              end if
+
                               real3d_temp_small = field_3dreal_ptr % array(:,:,1:ownedSize)
                               call mpas_mask_field(field_3dreal_ptr, &
                                  field_3dreal_ptr % missingValueMask3D, real3d_temp_small)
@@ -3807,7 +3847,14 @@ module mpas_io_streams
                               deallocate(real3d_temp_small)
                               allocate(real3d_temp_small(field_cursor % real3dField % dimSizes(1), &
                                                          field_cursor % real3dField % dimSizes(2), &
-                                                         ownedSize))
+                                                         ownedSize),stat=io_err)
+                              if (io_err /= 0) then
+                                 call mpas_log_write('real3d_temp_small: $i', intArgs=(/field_cursor % real3dField % dimSizes(1)* &
+                                                                                        field_cursor % real3dField % dimSizes(2)*ownedSize/) )
+                                 if (present(ierr)) ierr = MPAS_IO_ERR
+                                 return
+                              end if
+
                               real3d_temp_small = field_3dreal_ptr % array(:,:,1:ownedSize)
                               call mpas_mask_field(field_3dreal_ptr, &
                                  field_3dreal_ptr % missingValueMask2D, real3d_temp_small)
@@ -3816,7 +3863,14 @@ module mpas_io_streams
                            elseif (ASSOCIATED( field_3dreal_ptr % missingValueMask1D )) then
                               allocate(real3d_temp_small(field_cursor % real3dField % dimSizes(1), &
                                                          field_cursor % real3dField % dimSizes(2), &
-                                                         ownedSize))
+                                                         ownedSize),stat=io_err)
+                              if (io_err /= 0) then
+                                 call mpas_log_write('real3d_temp_small: $i', intArgs=(/field_cursor % real3dField % dimSizes(1)* &
+                                                                                        field_cursor % real3dField % dimSizes(2)*ownedSize/) )
+                                 if (present(ierr)) ierr = MPAS_IO_ERR
+                                 return
+                              end if
+
                               real3d_temp_small = field_3dreal_ptr % array(:,:,1:ownedSize)
                               call mpas_mask_field(field_3dreal_ptr, &
                                  field_3dreal_ptr % missingValueMask1D, real3d_temp_small)
@@ -3899,7 +3953,14 @@ module mpas_io_streams
                               allocate(real4d_temp_small(1, &
                                                          field_cursor % real4dField % dimSizes(2), &
                                                          field_cursor % real4dField % dimSizes(3), &
-                                                         ownedSize))
+                                                         ownedSize), stat=io_err)
+                              if (io_err /= 0) then
+                                 call mpas_log_write('real4d_temp_small: $i', intArgs=(/field_cursor % real4dField % dimSizes(2)* &
+                                                                                        field_cursor % real4dField % dimSizes(3)*ownedSize/) )
+                                 if (present(ierr)) ierr = MPAS_IO_ERR
+                                 return
+                              end if
+
                               real4d_temp_small(1,:,:,:) = field_4dreal_ptr % array(j,:,:,1:ownedSize)
                               call mpas_mask_field(field_4dreal_ptr, &
                                  field_4dreal_ptr % missingValueMask3D, real4d_temp_small)
@@ -3909,7 +3970,14 @@ module mpas_io_streams
                               allocate(real4d_temp_small(1, &
                                                          field_cursor % real4dField % dimSizes(2), &
                                                          field_cursor % real4dField % dimSizes(3), &
-                                                         ownedSize))
+                                                         ownedSize), stat=io_err)
+                              if (io_err /= 0) then
+                                 call mpas_log_write('real4d_temp_small: $i', intArgs=(/field_cursor % real4dField % dimSizes(2)* &
+                                                                                        field_cursor % real4dField % dimSizes(3)*ownedSize/) )
+                                 if (present(ierr)) ierr = MPAS_IO_ERR
+                                 return
+                              end if
+
                               real4d_temp_small(1,:,:,:) = field_4dreal_ptr % array(j,:,:,1:ownedSize)
                               call mpas_mask_field(field_4dreal_ptr, &
                                  field_4dreal_ptr % missingValueMask2D, real4d_temp_small)
@@ -3919,7 +3987,14 @@ module mpas_io_streams
                               allocate(real4d_temp_small(1, &
                                                          field_cursor % real4dField % dimSizes(2), &
                                                          field_cursor % real4dField % dimSizes(3), &
-                                                         ownedSize))
+                                                         ownedSize), stat=io_err)
+                              if (io_err /= 0) then
+                                 call mpas_log_write('(real4d_temp_small: $i', intArgs=(/field_cursor % real4dField % dimSizes(2)* &
+                                                                                         field_cursor % real4dField % dimSizes(3)*ownedSize/) )
+                                 if (present(ierr)) ierr = MPAS_IO_ERR
+                                 return
+                              end if
+
                               real4d_temp_small(1,:,:,:) = field_4dreal_ptr % array(j,:,:,1:ownedSize)
                               call mpas_mask_field(field_4dreal_ptr, &
                                  field_4dreal_ptr % missingValueMask1D, real4d_temp_small)
@@ -3937,7 +4012,15 @@ module mpas_io_streams
                               allocate(real4d_temp_small(field_cursor % real4dField % dimSizes(1), &
                                                          field_cursor % real4dField % dimSizes(2), &
                                                          field_cursor % real4dField % dimSizes(3), &
-                                                         ownedSize))
+                                                         ownedSize), stat=io_err)
+                              if (io_err /= 0) then
+                                 call mpas_log_write('(real4d_temp_small: $i', intArgs=(/field_cursor % real4dField % dimSizes(1)* &
+                                                                                         field_cursor % real4dField % dimSizes(2)* &
+                                                                                         field_cursor % real4dField % dimSizes(3)*ownedSize/) )
+                                 if (present(ierr)) ierr = MPAS_IO_ERR
+                                 return
+                              end if
+
                               real4d_temp_small = field_4dreal_ptr % array(:,:,:,1:ownedSize)
                               call mpas_mask_field(field_4dreal_ptr, &
                                  field_4dreal_ptr % missingValueMask3D, real4d_temp_small)
@@ -3947,7 +4030,15 @@ module mpas_io_streams
                               allocate(real4d_temp_small(field_cursor % real4dField % dimSizes(1), &
                                                          field_cursor % real4dField % dimSizes(2), &
                                                          field_cursor % real4dField % dimSizes(3), &
-                                                         ownedSize))
+                                                         ownedSize), stat=io_err)
+                              if (io_err /= 0) then
+                                 call mpas_log_write('(real4d_temp_small: $i', intArgs=(/field_cursor % real4dField % dimSizes(1)* &
+                                                                                         field_cursor % real4dField % dimSizes(2)* &
+                                                                                         field_cursor % real4dField % dimSizes(3)*ownedSize/) )
+                                 if (present(ierr)) ierr = MPAS_IO_ERR
+                                 return
+                              end if
+
                               real4d_temp_small = field_4dreal_ptr % array(:,:,:,1:ownedSize)
                               call mpas_mask_field(field_4dreal_ptr, &
                                  field_4dreal_ptr % missingValueMask2D, real4d_temp_small)
@@ -3957,7 +4048,15 @@ module mpas_io_streams
                               allocate(real4d_temp_small(field_cursor % real4dField % dimSizes(1), &
                                                          field_cursor % real4dField % dimSizes(2), &
                                                          field_cursor % real4dField % dimSizes(3), &
-                                                         ownedSize))
+                                                         ownedSize), stat=io_err)
+                              if (io_err /= 0) then
+                                 call mpas_log_write('(real4d_temp_small: $i', intArgs=(/field_cursor % real4dField % dimSizes(1)* &
+                                                                                         field_cursor % real4dField % dimSizes(2)* &
+                                                                                         field_cursor % real4dField % dimSizes(3)*ownedSize/) )
+                                 if (present(ierr)) ierr = MPAS_IO_ERR
+                                 return
+                              end if
+
                               real4d_temp_small = field_4dreal_ptr % array(:,:,:,1:ownedSize)
                               call mpas_mask_field(field_4dreal_ptr, &
                                  field_4dreal_ptr % missingValueMask1D, real4d_temp_small)
@@ -4043,7 +4142,15 @@ module mpas_io_streams
                                                          field_cursor % real5dField % dimSizes(2), &
                                                          field_cursor % real5dField % dimSizes(3), &
                                                          field_cursor % real5dField % dimSizes(4), &
-                                                         ownedSize))
+                                                         ownedSize), stat=io_err)
+                              if (io_err /= 0) then
+                                 call mpas_log_write('real5d_temp_small: $i', intArgs=(/field_cursor % real5dField % dimSizes(2)* &
+                                                                                        field_cursor % real5dField % dimSizes(3)* &
+                                                                                        field_cursor % real5dField % dimSizes(4)*ownedSize/) )
+                                 if (present(ierr)) ierr = MPAS_IO_ERR
+                                 return
+                              end if
+
                               real5d_temp_small(1,:,:,:,:) = field_5dreal_ptr % array(j,:,:,:,1:ownedSize)
                               call mpas_mask_field(field_5dreal_ptr, &
                                  field_5dreal_ptr % missingValueMask3D, real5d_temp_small)
@@ -4054,7 +4161,15 @@ module mpas_io_streams
                                                          field_cursor % real5dField % dimSizes(2), &
                                                          field_cursor % real5dField % dimSizes(3), &
                                                          field_cursor % real5dField % dimSizes(4), &
-                                                         ownedSize))
+                                                         ownedSize), stat=io_err)
+                              if (io_err /= 0) then
+                                 call mpas_log_write('real5d_temp_small: $i', intArgs=(/field_cursor % real5dField % dimSizes(2)* &
+                                                                                        field_cursor % real5dField % dimSizes(3)* &
+                                                                                        field_cursor % real5dField % dimSizes(4)*ownedSize/) )
+                                 if (present(ierr)) ierr = MPAS_IO_ERR
+                                 return
+                              end if
+
                               real5d_temp_small(1,:,:,:,:) = field_5dreal_ptr % array(j,:,:,:,1:ownedSize)
                               call mpas_mask_field(field_5dreal_ptr, &
                                  field_5dreal_ptr % missingValueMask2D, real5d_temp_small)
@@ -4065,7 +4180,15 @@ module mpas_io_streams
                                                          field_cursor % real5dField % dimSizes(2), &
                                                          field_cursor % real5dField % dimSizes(3), &
                                                          field_cursor % real5dField % dimSizes(4), &
-                                                         ownedSize))
+                                                         ownedSize), stat=io_err)
+                              if (io_err /= 0) then
+                                 call mpas_log_write('real5d_temp_small: $i', intArgs=(/field_cursor % real5dField % dimSizes(2)* &
+                                                                                        field_cursor % real5dField % dimSizes(3)* &
+                                                                                        field_cursor % real5dField % dimSizes(4)*ownedSize/) )
+                                 if (present(ierr)) ierr = MPAS_IO_ERR
+                                 return
+                              end if
+
                               real5d_temp_small(1,:,:,:,:) = field_5dreal_ptr % array(j,:,:,:,1:ownedSize)
                               call mpas_mask_field(field_5dreal_ptr, &
                                  field_5dreal_ptr % missingValueMask1D, real5d_temp_small)
@@ -4084,7 +4207,16 @@ module mpas_io_streams
                                                          field_cursor % real5dField % dimSizes(2), &
                                                          field_cursor % real5dField % dimSizes(3), &
                                                          field_cursor % real5dField % dimSizes(4), &
-                                                         ownedSize))
+                                                         ownedSize), stat=io_err)
+                              if (io_err /= 0) then
+                                 call mpas_log_write('real5d_temp_small: $i', intArgs=(/field_cursor % real5dField % dimSizes(1)* &
+                                                                                        field_cursor % real5dField % dimSizes(2)* &
+                                                                                        field_cursor % real5dField % dimSizes(3)* &
+                                                                                        field_cursor % real5dField % dimSizes(4)*ownedSize/) )
+                                 if (present(ierr)) ierr = MPAS_IO_ERR
+                                 return
+                              end if
+
                               real5d_temp_small = field_5dreal_ptr % array(:,:,:,:,1:ownedSize)
                               call mpas_mask_field(field_5dreal_ptr, &
                                  field_5dreal_ptr % missingValueMask3D, real5d_temp_small)
@@ -4095,7 +4227,16 @@ module mpas_io_streams
                                                          field_cursor % real5dField % dimSizes(2), &
                                                          field_cursor % real5dField % dimSizes(3), &
                                                          field_cursor % real5dField % dimSizes(4), &
-                                                         ownedSize))
+                                                         ownedSize), stat=io_err)
+                              if (io_err /= 0) then
+                                 call mpas_log_write('real5d_temp_small: $i', intArgs=(/field_cursor % real5dField % dimSizes(1)* &
+                                                                                        field_cursor % real5dField % dimSizes(2)* &
+                                                                                        field_cursor % real5dField % dimSizes(3)* &
+                                                                                        field_cursor % real5dField % dimSizes(4)*ownedSize/) )
+                                 if (present(ierr)) ierr = MPAS_IO_ERR
+                                 return
+                              end if
+
                               real5d_temp_small = field_5dreal_ptr % array(:,:,:,:,1:ownedSize)
                               call mpas_mask_field(field_5dreal_ptr, &
                                  field_5dreal_ptr % missingValueMask2D, real5d_temp_small)
@@ -4106,7 +4247,16 @@ module mpas_io_streams
                                                          field_cursor % real5dField % dimSizes(2), &
                                                          field_cursor % real5dField % dimSizes(3), &
                                                          field_cursor % real5dField % dimSizes(4), &
-                                                         ownedSize))
+                                                         ownedSize), stat=io_err)
+                              if (io_err /= 0) then
+                                 call mpas_log_write('real5d_temp_small: $i', intArgs=(/field_cursor % real5dField % dimSizes(1)* &
+                                                                                        field_cursor % real5dField % dimSizes(2)* &
+                                                                                        field_cursor % real5dField % dimSizes(3)* &
+                                                                                        field_cursor % real5dField % dimSizes(4)*ownedSize/) )
+                                 if (present(ierr)) ierr = MPAS_IO_ERR
+                                 return
+                              end if
+
                               real5d_temp_small = field_5dreal_ptr % array(:,:,:,:,1:ownedSize)
                               call mpas_mask_field(field_5dreal_ptr, &
                                  field_5dreal_ptr % missingValueMask1D, real5d_temp_small)

--- a/components/mpas-framework/src/framework/mpas_io_streams.F
+++ b/components/mpas-framework/src/framework/mpas_io_streams.F
@@ -3255,6 +3255,7 @@ module mpas_io_streams
       integer, intent(out), optional :: ierr
 
       character (len=StrKIND) :: dimensionSuffix
+      character (len=100) :: log_string
       integer :: io_err
       integer :: i, j
       integer :: ncons
@@ -3275,10 +3276,12 @@ module mpas_io_streams
       integer                            :: int0d_temp
       integer, dimension(:),     pointer :: int1d_temp
       integer, dimension(:,:),   pointer :: int2d_temp
+      integer, dimension(:,:),   pointer :: maskArray
       integer, dimension(:,:,:), pointer :: int3d_temp
       real (kind=RKIND)                                :: real0d_temp
       real (kind=RKIND), dimension(:),         pointer :: real1d_temp
       real (kind=RKIND), dimension(:,:),       pointer :: real2d_temp
+      real (kind=RKIND), dimension(:,:),       pointer :: real2d_temp_small
       real (kind=RKIND), dimension(:,:,:),     pointer :: real3d_temp
       real (kind=RKIND), dimension(:,:,:,:),   pointer :: real4d_temp
       real (kind=RKIND), dimension(:,:,:,:,:), pointer :: real5d_temp
@@ -3629,6 +3632,7 @@ module mpas_io_streams
                   field_2dreal_ptr => field_cursor % real2dField
                   i = 1
                   do while (associated(field_2dreal_ptr))
+                     call mpas_log_write('field_2dreal_ptr is '//TRIM(field_2dreal_ptr % fieldName))
                      if (trim(field_2dreal_ptr % dimNames(2)) == 'nCells') then
                         call mpas_pool_get_dimension(field_2dreal_ptr % block % dimensions, trim(field_2dreal_ptr % dimNames(2)) &
                                                      // trim(dimensionSuffix), ownedSize)
@@ -3641,16 +3645,30 @@ module mpas_io_streams
                      else
                         call mpas_pool_get_dimension(field_2dreal_ptr % block % dimensions, field_2dreal_ptr % dimNames(2), ownedSize)
                      end if
+                     write(log_string,*) 'i,OwnedSize,dimName = ',i, ownedSize, trim(field_2dreal_ptr % dimNames(2))
+                     call mpas_log_write(log_string)
 
                      if (field_cursor % real2dField % isVarArray) then
                         real1d_temp(i:i+ownedSize-1) = field_2dreal_ptr % array(j,1:ownedSize)
                      else
-                        real2d_temp(:,i:i+ownedSize-1) = field_2dreal_ptr % array(:,1:ownedSize)
+                        if (ASSOCIATED( field_2dreal_ptr % missingValueMask2D )) then
+                           allocate(real2d_temp_small(field_cursor % real2dField % dimSizes(1), &
+                                                ownedSize))
+                           call mpas_mask_field2d_mask2d_real(field_2dreal_ptr, &
+                               field_2dreal_ptr % missingValueMask2D, real2d_temp_small)
+                           real2d_temp(:,i:i+ownedSize-1) = real2d_temp_small
+                           deallocate(real2d_temp_small)
+                        else
+                           real2d_temp(:,i:i+ownedSize-1) = field_2dreal_ptr % array(:,1:ownedSize)
+                        end if
+
                      end if
                      i = i + ownedSize
                      if ( .not. stream % blockWrite ) then
+                        call mpas_log_write('Go to next')
                         field_2dreal_ptr => field_2dreal_ptr % next
                      else
+                        call mpas_log_write('Nullify ptr')
                         nullify(field_2dreal_ptr)
                      end if
                   end do

--- a/components/mpas-framework/src/framework/mpas_io_streams_types.inc
+++ b/components/mpas-framework/src/framework/mpas_io_streams_types.inc
@@ -55,6 +55,7 @@
       ! When blockWrite is true, a stream only writes a single block.
       ! This option is really only useful for writing debugging streams out.
       logical :: blockWrite = .false.
+      logical :: useMissingValueMask = .false.
       character(len=StrKIND) :: filename
       type (MPAS_IO_Handle_type) :: fileHandle
       type (att_list_type), pointer :: attList => null()

--- a/components/mpas-framework/src/framework/mpas_stream_list_types.inc
+++ b/components/mpas-framework/src/framework/mpas_stream_list_types.inc
@@ -14,6 +14,7 @@
         logical :: immutable = .false.
         logical :: active_stream = .true.
         logical :: blockWrite = .false.
+        logical :: useMissingValMask = .false.
         character(len=StrKIND) :: filename
         character(len=StrKIND) :: filename_template
         character(len=StrKIND) :: filename_interval

--- a/components/mpas-framework/src/framework/mpas_stream_manager.F
+++ b/components/mpas-framework/src/framework/mpas_stream_manager.F
@@ -298,7 +298,8 @@ module mpas_stream_manager
     !-----------------------------------------------------------------------
     subroutine MPAS_stream_mgr_create_stream(manager, streamID, direction, filename, &
                                              filenameInterval, referenceTime, recordInterval, &
-                                             realPrecision, clobberMode, ioType, ierr) !{{{
+                                             realPrecision, clobberMode, useMissingValMask, &
+                                             ioType, ierr) !{{{
 
         use mpas_io, only : MPAS_IO_PNETCDF
 
@@ -315,6 +316,7 @@ module mpas_stream_manager
         type (MPAS_TimeInterval_type), intent(in), optional :: recordInterval
         integer, intent(in), optional :: realPrecision
         integer, intent(in), optional :: clobberMode
+        logical , intent(in), optional :: useMissingValMask
         integer, intent(in), optional :: ioType
         integer, intent(out), optional :: ierr
 
@@ -362,6 +364,11 @@ module mpas_stream_manager
                new_stream % clobber_mode = clobberMode
            else
                new_stream % clobber_mode = MPAS_STREAM_CLOBBER_NEVER
+           end if
+           if (present(useMissingValMask)) then
+               new_stream % useMissingValMask = useMissingValMask
+           else
+               new_stream % useMissingValMask = .false.
            end if
            if (present(ioType)) then
                new_stream % io_type = ioType
@@ -1916,6 +1923,9 @@ module mpas_stream_manager
                !
                select case (propertyName)
 
+                   case (MPAS_STREAM_PROPERTY_MASK)
+                       stream_cursor % useMissingValMask = propertyValue
+
                    case (MPAS_STREAM_PROPERTY_ACTIVE)
                        stream_cursor % active_stream = propertyValue
 
@@ -2161,6 +2171,9 @@ module mpas_stream_manager
         ! Set property
         !
         select case (propertyName)
+
+            case (MPAS_STREAM_PROPERTY_MASK)
+                propertyValue = stream_cursor % useMissingValMask
 
             case (MPAS_STREAM_PROPERTY_ACTIVE)
                 propertyValue = stream_cursor % active_stream
@@ -3078,6 +3091,7 @@ module mpas_stream_manager
         character (len=StrKIND) :: temp_filename, actualWhen
         character (len=StrKIND) :: err_string
         logical :: ringing_alarm, recordSeek, swapRecords
+        logical :: useMissingValMask
         logical :: clobberRecords, clobberFiles, truncateFiles
         integer :: maxRecords, tempRecord
         integer :: local_ierr, threadNum
@@ -3144,6 +3158,8 @@ module mpas_stream_manager
            else
                truncateFiles = .false.
            end if
+
+           useMissingValMask = stream % useMissingValMask
 
            !
            ! If the stream is not valid, assume that we have not yet written this
@@ -3363,7 +3379,8 @@ module mpas_stream_manager
            ! Write the stream
            ! 
            STREAM_DEBUG_WRITE(' -- Writing stream ' // trim(stream % name))
-           call MPAS_writeStream(stream % stream, stream % nRecords, ierr=local_ierr)
+           call MPAS_writeStream(stream % stream, stream % nRecords, &
+                                 useMissingValMask, ierr=local_ierr)
 
            !
            ! Regardless of the error code from MPAS_writeStream, we need to reset global indices in the stream back to local indices
@@ -5860,7 +5877,7 @@ end module mpas_stream_manager
 
 
 subroutine stream_mgr_create_stream_c(manager_c, streamID_c, direction_c, filename_c, filename_intv_c, ref_time_c, rec_intv_c, &
-                                      immutable_c, precision_c, clobber_c, iotype_c, ierr_c) bind(c) !{{{
+                                      immutable_c, precision_c, clobber_c, mask_c, iotype_c, ierr_c) bind(c) !{{{
 
     use mpas_c_interfacing, only : mpas_c_to_f_string
     use iso_c_binding, only : c_char, c_int, c_ptr, c_f_pointer
@@ -5869,7 +5886,8 @@ subroutine stream_mgr_create_stream_c(manager_c, streamID_c, direction_c, filena
                                         MPAS_STREAM_PROPERTY_FILENAME_INTV, MPAS_STREAM_PROPERTY_REF_TIME, &
                                         MPAS_STREAM_PROPERTY_RECORD_INTV, MPAS_STREAM_PROPERTY_PRECISION, &
                                         MPAS_STREAM_PROPERTY_CLOBBER, MPAS_STREAM_CLOBBER_NEVER, MPAS_STREAM_CLOBBER_APPEND, &
-                                        MPAS_STREAM_CLOBBER_TRUNCATE, MPAS_STREAM_CLOBBER_OVERWRITE, MPAS_STREAM_PROPERTY_IOTYPE
+                                        MPAS_STREAM_CLOBBER_TRUNCATE, MPAS_STREAM_CLOBBER_OVERWRITE, &
+                                        MPAS_STREAM_PROPERTY_MASK, MPAS_STREAM_PROPERTY_IOTYPE
     use mpas_stream_manager, only : MPAS_stream_mgr_create_stream, MPAS_stream_mgr_set_property
     use mpas_kind_types, only : StrKIND
     use mpas_derived_types, only : MPAS_LOG_ERR
@@ -5889,6 +5907,7 @@ subroutine stream_mgr_create_stream_c(manager_c, streamID_c, direction_c, filena
     integer(kind=c_int) :: immutable_c
     integer(kind=c_int) :: precision_c
     integer(kind=c_int) :: clobber_c
+    integer(kind=c_int) :: mask_c
     integer(kind=c_int) :: iotype_c
     integer(kind=c_int) :: ierr_c
 
@@ -5896,6 +5915,7 @@ subroutine stream_mgr_create_stream_c(manager_c, streamID_c, direction_c, filena
     character(len=StrKIND) :: streamID, filename, filename_interval, reference_time, record_interval
     integer :: direction, immutable, prec, ierr
     integer :: clobber_mode, iotype
+    logical :: useMissingValMask
 
     call c_f_pointer(manager_c, manager)
     call mpas_c_to_f_string(streamID_c, streamID)
@@ -5924,6 +5944,12 @@ subroutine stream_mgr_create_stream_c(manager_c, streamID_c, direction_c, filena
        clobber_mode = MPAS_STREAM_CLOBBER_OVERWRITE
     else
        clobber_mode = MPAS_STREAM_CLOBBER_NEVER
+    end if
+
+    if (mask_c == 1) then
+       useMissingValMask = .true.
+    else
+       useMissingValMask = .false.
     end if
 
     if (iotype_c == 0) then
@@ -5961,10 +5987,12 @@ subroutine stream_mgr_create_stream_c(manager_c, streamID_c, direction_c, filena
         end if
         call MPAS_stream_mgr_set_property(manager, streamID, MPAS_STREAM_PROPERTY_PRECISION, prec, ierr=ierr)
         call MPAS_stream_mgr_set_property(manager, streamID, MPAS_STREAM_PROPERTY_CLOBBER, clobber_mode, ierr=ierr)
+        call MPAS_stream_mgr_set_property(manager, streamID, MPAS_STREAM_PROPERTY_MASK, useMissingValMask, ierr=ierr)
         call MPAS_stream_mgr_set_property(manager, streamID, MPAS_STREAM_PROPERTY_IOTYPE, iotype, ierr=ierr)
     else
         call MPAS_stream_mgr_create_stream(manager, streamID, direction, filename, realPrecision=prec, &
-                                           clobberMode=clobber_mode, ioType=iotype, ierr=ierr)
+                                           clobberMode=clobber_mode, useMissingValMask=useMissingValMask, &
+                                           ioType=iotype, ierr=ierr)
     end if
 
     if (reference_time /= 'initial_time') then

--- a/components/mpas-framework/src/framework/mpas_stream_manager_types.inc
+++ b/components/mpas-framework/src/framework/mpas_stream_manager_types.inc
@@ -20,7 +20,8 @@
                                   MPAS_STREAM_PROPERTY_PRECISION     = 10, &
                                   MPAS_STREAM_PROPERTY_FILENAME_INTV = 11, &
                                   MPAS_STREAM_PROPERTY_CLOBBER       = 12, &
-                                  MPAS_STREAM_PROPERTY_IOTYPE        = 13
+                                  MPAS_STREAM_PROPERTY_IOTYPE        = 13, &
+                                  MPAS_STREAM_PROPERTY_MASK          = 14
 
     integer, public, parameter :: MPAS_STREAM_CLOBBER_NEVER     = 100, &
                                   MPAS_STREAM_CLOBBER_APPEND    = 101, &

--- a/components/mpas-framework/src/framework/xml_stream_parser.c
+++ b/components/mpas-framework/src/framework/xml_stream_parser.c
@@ -25,7 +25,7 @@
 /*
  *  Interface routines for building streams at run-time; defined in mpas_stream_manager.F
  */
-void stream_mgr_create_stream_c(void *, const char *, int *, const char *, const char *, const char *, const char *, int *, int *, int *, int *, int *);
+void stream_mgr_create_stream_c(void *, const char *, int *, const char *, const char *, const char *, const char *, int *, int *, int *, int *, int *, int *);
 void stream_mgr_add_field_c(void *, const char *, const char *, const char *, int *);
 void stream_mgr_add_immutable_stream_fields_c(void *, const char *, const char *, const char *, int *);
 void stream_mgr_add_pool_c(void *, const char *, const char *, const char *, int *);
@@ -1053,6 +1053,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 	const char *streamID, *filename_template, *filename_interval, *direction, *varfile, *fieldname_const, *reference_time, *record_interval, *streamname_const, *precision;
 	const char *interval_in, *interval_out, *packagelist;
 	const char *clobber;
+	const char *useMissingValMask;
 	const char *iotype;
 	const char *streamID2, *interval_in2, *interval_out2;
 	char interval_name[256];
@@ -1068,6 +1069,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 	char msgbuf[MSGSIZE];
 	int itype;
 	int iclobber;
+	int imask;
 	int i_iotype;
 	int iprec;
 	int immutable;
@@ -1114,6 +1116,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 		precision = ezxml_attr(stream_xml, "precision");
 		packagelist = ezxml_attr(stream_xml, "packages");
 		clobber = ezxml_attr(stream_xml, "clobber_mode");
+		useMissingValMask = ezxml_attr(stream_xml, "useMissingValMask");
 		iotype = ezxml_attr(stream_xml, "io_type");
 
 		/* Extract the input interval, if it refer to other streams */
@@ -1236,6 +1239,25 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 			}
 		}
 
+		imask = 0;
+		if (useMissingValMask != NULL) {
+			if (strstr(useMissingValMask, "false") != NULL) {
+				imask = 0;
+				snprintf(msgbuf, MSGSIZE, "        %-20s%s", "useMissingValMask:", "false");
+				mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
+			}
+			else if (strstr(useMissingValMask, "true") != NULL) {
+				imask = 1;
+				snprintf(msgbuf, MSGSIZE, "        %-20s%s", "useMissingValMask:", "true");
+				mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
+			}
+			else {
+				imask = 0;
+				snprintf(msgbuf, MSGSIZE, "        *** unrecognized useMissingValMask specification; set to false by default");
+				mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
+			}
+		}
+
 		/* NB: These io_type constants must match those in the mpas_stream_manager module! */
 		i_iotype = 0;
 		if (iotype != NULL) {
@@ -1337,7 +1359,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 		}
 
 		stream_mgr_create_stream_c(manager, streamID, &itype, filename_template, filename_interval_string, ref_time_local, rec_intv_local,
-					&immutable, &iprec, &iclobber, &i_iotype, &err);
+					&immutable, &iprec, &iclobber, &imask, &i_iotype, &err);
 		if (err != 0) {
 			*status = 1;
 			return;
@@ -1423,6 +1445,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 		precision = ezxml_attr(stream_xml, "precision");
 		packagelist = ezxml_attr(stream_xml, "packages");
 		clobber = ezxml_attr(stream_xml, "clobber_mode");
+		useMissingValMask = ezxml_attr(stream_xml, "useMissingValMask");
 		iotype = ezxml_attr(stream_xml, "io_type");
 
 		/* Extract the input interval, if it refer to other streams */
@@ -1545,6 +1568,26 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 			}
 		}
 
+		/* NB: These mask constants must match those in the mpas_stream_manager module! */
+		imask = 0;
+		if (useMissingValMask != NULL) {
+			if (strstr(useMissingValMask, "false") != NULL) {
+				imask = 0;
+				snprintf(msgbuf, MSGSIZE, "        %-20s%s", "useMissingValMask:", "false");
+				mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
+			}
+			else if (strstr(useMissingValMask, "true") != NULL) {
+				imask = 1;
+				snprintf(msgbuf, MSGSIZE, "        %-20s%s", "useMissingValMask:", "true");
+				mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
+			}
+			else {
+				imask = 0;
+				snprintf(msgbuf, MSGSIZE, "        *** unrecognized useMissingValMask specification; set to false by default");
+				mpas_log_write_c(msgbuf, "MPAS_LOG_OUT");
+			}
+		}
+
 		/* NB: These io_type constants must match those in the mpas_stream_manager module! */
 		i_iotype = 0;
 		if (iotype != NULL) {
@@ -1646,7 +1689,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 		}
 
 		stream_mgr_create_stream_c(manager, streamID, &itype, filename_template, filename_interval_string, ref_time_local, rec_intv_local,
-					&immutable, &iprec, &iclobber, &i_iotype, &err);
+					&immutable, &iprec, &iclobber, &imask, &i_iotype, &err);
 		if (err != 0) {
 			*status = 1;
 			return;

--- a/components/mpas-framework/src/tools/input_gen/streams_gen.c
+++ b/components/mpas-framework/src/tools/input_gen/streams_gen.c
@@ -105,7 +105,7 @@ int generate_streams(ezxml_t registry, FILE* fd, char *stream_file_prefix, int o
 
 	const char *name, *type, *immutable, *filename_template, *filename_interval, *packages, *record_interval;
 	const char *varpackages;
-	const char *reference_time, *clobber_mode, *precision, *input_interval, *output_interval;
+	const char *reference_time, *clobber_mode, *useMissingValMask, *precision, *input_interval, *output_interval;
 
 	const char *runtime, *subname;
 
@@ -319,7 +319,7 @@ int generate_streams(ezxml_t registry, FILE* fd, char *stream_file_prefix, int o
 
 void write_stream_header(ezxml_t stream_xml, FILE *fd){/*{{{*/
 	const char *name, *type, *immutable, *filename_template, *filename_interval, *packages, *record_interval;
-	const char *reference_time, *clobber_mode, *precision, *input_interval, *output_interval, *io_type;
+	const char *reference_time, *clobber_mode, *useMissingValMask, *precision, *input_interval, *output_interval, *io_type;
 
 	char spacing[1024];
 
@@ -329,6 +329,7 @@ void write_stream_header(ezxml_t stream_xml, FILE *fd){/*{{{*/
 	filename_interval = ezxml_attr(stream_xml, "filename_interval");
 	reference_time = ezxml_attr(stream_xml, "reference_time");
 	clobber_mode = ezxml_attr(stream_xml, "clobber_mode");
+	useMissingValMask = ezxml_attr(stream_xml, "useMissingValMask");
 	input_interval = ezxml_attr(stream_xml, "input_interval");
 	output_interval = ezxml_attr(stream_xml, "output_interval");
 	record_interval = ezxml_attr(stream_xml, "record_interval");
@@ -359,6 +360,9 @@ void write_stream_header(ezxml_t stream_xml, FILE *fd){/*{{{*/
 	}
 	if ( clobber_mode != NULL ){
 		fprintf(fd, "\n%sclobber_mode=\"%s\"", spacing, clobber_mode);
+	}
+	if ( useMissingValMask != NULL ){
+		fprintf(fd, "\n%suseMissingValMask=\"%s\"", spacing, useMissingValMask);
 	}
 	if ( precision != NULL ){
 		fprintf(fd, "\n%sprecision=\"%s\"", spacing, precision);

--- a/components/mpas-framework/src/tools/registry/Registry.xsd
+++ b/components/mpas-framework/src/tools/registry/Registry.xsd
@@ -133,6 +133,7 @@
 												<xs:attribute name="description"  type="xs:string" use="optional"/>
 												<!-- The packages attribute defines the packages the particular variable belongs to -->
 												<xs:attribute name="packages"  type="xs:string" use="optional"/>
+												<xs:attribute name="mask"  type="xs:string" use="optional"/>
 											</xs:complexType>
 										</xs:element>
 									</xs:sequence>
@@ -148,6 +149,7 @@
 									<xs:attribute name="default_value"  type="xs:string" use="optional"/>
 									<!-- The packages attribute defines the packages that control allocation of this variable -->
 									<xs:attribute name="packages"  type="xs:string" use="optional"/>
+									<xs:attribute name="mask"  type="xs:string" use="optional"/>
 								</xs:complexType>
 							</xs:element>
 							<!-- This var element defines a variable that does not live within a var_array group. -->
@@ -171,6 +173,7 @@
 									<xs:attribute name="persistence"  type="xs:string" use="optional"/>
 									<!-- The packages attribute defines the packages that control allocation of this variable -->
 									<xs:attribute name="packages"  type="xs:string" use="optional"/>
+									<xs:attribute name="mask"  type="xs:string" use="optional"/>
 								</xs:complexType>
 							</xs:element>
 						</xs:sequence>

--- a/components/mpas-framework/src/tools/registry/gen_inc.c
+++ b/components/mpas-framework/src/tools/registry/gen_inc.c
@@ -1423,6 +1423,8 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 
 		                fortprintf(fd, "         %s %% maskName = '%s'\n", pointer_name_arr , temp_str);
 				fortprintf(fd, "         call mpas_add_att(%s %% attLists(const_index) %% attList, 'missing_value_mask', '%s')\n", pointer_name_arr, temp_str);
+                        } else {
+                                fortprintf(fd, "         %s %% maskName = 'none'\n", pointer_name_arr , temp_str);
 		        }
 
 			if ( vararrmissingval ) {
@@ -1668,6 +1670,8 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 
 		        fortprintf(fd, "      %s %% maskName = '%s'\n", pointer_name_arr , temp_str);
 			fortprintf(fd, "      call mpas_add_att(%s %% attLists(1) %% attList, 'missing_value_mask', '%s')\n", pointer_name_arr, temp_str);
+                } else {
+                        fortprintf(fd, "      %s %% maskName = 'none'\n", pointer_name_arr , temp_str);
 		}
 
 		if ( varmissingval != NULL ) {

--- a/components/mpas-framework/src/tools/registry/gen_inc.c
+++ b/components/mpas-framework/src/tools/registry/gen_inc.c
@@ -1666,6 +1666,7 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 
 			free(tofree);
 
+		        fortprintf(fd, "      %s %% maskName = '%s'\n", pointer_name_arr , temp_str);
 			fortprintf(fd, "      call mpas_add_att(%s %% attLists(1) %% attList, 'missing_value_mask', '%s')\n", pointer_name_arr, temp_str);
 		}
 

--- a/components/mpas-framework/src/tools/registry/gen_inc.c
+++ b/components/mpas-framework/src/tools/registry/gen_inc.c
@@ -1013,7 +1013,7 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 
 	const char *structname, *structlevs, *structpackages;
 	const char *substructname;
-	const char *vararrname, *vararrtype, *vararrdims, *vararrpersistence, *vararrdefaultval, *vararrpackages, *vararrmissingval;
+	const char *vararrname, *vararrtype, *vararrdims, *vararrpersistence, *vararrdefaultval, *vararrpackages, *vararrmissingval, *vararrmissing_value_mask;
 	const char *varname, *varpersistence, *vartype, *vardims, *varunits, *vardesc, *vararrgroup, *varstreams, *vardefaultval, *varpackages;
 	const char *varname2, *vararrgroup2, *vararrname_in_code;
 	const char *varname_in_code;
@@ -1054,6 +1054,7 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 	vararrpackages = ezxml_attr(var_arr_xml, "packages");
 	vararrtimelevs = ezxml_attr(var_arr_xml, "time_levs");
 	vararrname_in_code = ezxml_attr(var_arr_xml, "name_in_code");
+	vararrmissing_value_mask= ezxml_attr(var_arr_xml, "missing_value_mask");
 
 	package_list[0] = '\0';
 	no_packages = build_struct_package_lists(varArray, package_list);
@@ -1078,6 +1079,7 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 	persistence = check_persistence(vararrpersistence);
 
 	fortprintf(fd, "! Define var array %s\n", vararrname);
+
 	snprintf(spacing, 1024, "      ");
 
 	// Determine field type and default value.
@@ -1406,6 +1408,22 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 
 				fortprintf(fd, "         call mpas_add_att(%s %% attLists(const_index) %% attList, 'units', '%s')\n", pointer_name_arr, temp_str);
 			}
+		        if ( vararrmissing_value_mask != NULL && vararrmissingval != NULL ) {
+				string = strdup(vararrmissing_value_mask);
+				tofree = string;
+
+				token = strsep(&string, "'");
+				sprintf(temp_str, "%s", token);
+
+				while ( ( token = strsep(&string, "'") ) != NULL ) {
+					sprintf(temp_str, "%s''%s", temp_str, token);
+				}
+
+				free(tofree);
+
+		                fortprintf(fd, "         %s %% maskName = '%s'\n", pointer_name_arr , temp_str);
+				fortprintf(fd, "         call mpas_add_att(%s %% attLists(const_index) %% attList, 'missing_value_mask', '%s')\n", pointer_name_arr, temp_str);
+		        }
 
 			if ( vararrmissingval ) {
 				fortprintf(fd, "         call mpas_add_att(%s %% attLists(const_index) %% attList, '_FillValue', %s)\n", pointer_name_arr, missing_value);
@@ -1465,7 +1483,7 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 	const char *structtimelevs, *vartimelevs;
 	const char *structname, *structlevs, *structpackages;
 	const char *substructname;
-	const char *varname, *varpersistence, *vartype, *vardims, *varunits, *vardesc, *vararrgroup, *varstreams, *vardefaultval, *varpackages, *varmissingval;
+	const char *varname, *varpersistence, *vartype, *vardims, *varunits, *vardesc, *vararrgroup, *varstreams, *vardefaultval, *varpackages, *varmissingval, *varmissing_value_mask;
 	const char *varname2, *vararrgroup2;
 	const char *varname_in_code;
 	const char *streamname, *streamname2;
@@ -1503,6 +1521,7 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 	varunits = ezxml_attr(var_xml, "units");
 	vardesc = ezxml_attr(var_xml, "description");
 	varmissingval = ezxml_attr(var_xml, "missing_value");
+	varmissing_value_mask = ezxml_attr(var_xml, "missing_value_mask");
 
 	if(!varname_in_code){
 		varname_in_code = ezxml_attr(var_xml, "name");
@@ -1632,6 +1651,22 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 			free(tofree);
 
 			fortprintf(fd, "      call mpas_add_att(%s %% attLists(1) %% attList, 'long_name', '%s')\n", pointer_name_arr, temp_str);
+		}
+
+		if ( varmissing_value_mask != NULL && varmissingval != NULL ) {
+			string = strdup(varmissing_value_mask);
+			tofree = string;
+
+			token = strsep(&string, "'");
+			sprintf(temp_str, "%s", token);
+
+			while ( ( token = strsep(&string, "'") ) != NULL ) {
+				sprintf(temp_str, "%s''%s", temp_str, token);
+			}
+
+			free(tofree);
+
+			fortprintf(fd, "      call mpas_add_att(%s %% attLists(1) %% attList, 'missing_value_mask', '%s')\n", pointer_name_arr, temp_str);
 		}
 
 		if ( varmissingval != NULL ) {

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2111,9 +2111,11 @@
 	<var_struct name="state" time_levs="2">
 		<var name="normalVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
 			 description="horizontal velocity, normal component to an edge"
+			 missing_value="FILLVAL" missing_value_mask="edgeMask"
 		/>
 		<var name="layerThickness" type="real" dimensions="nVertLevels nCells Time" units="m"
 			 description="layer thickness"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 		/>
 		<var name="ssh" type="real" dimensions="nCells Time" units="m"
 			 description="sea surface height"

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_time_series_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_time_series_stats.F
@@ -2004,30 +2004,42 @@ subroutine copy_field_1r(inname, all_fields, amPool, outname)!{{{
 #include "time_series_inc/copy_field_1.inc"
   type (field1DReal), pointer :: src, dst
 #include "time_series_inc/copy_field_2.inc"
+  dst % missingValueMask1D => src % missingValueMask1D
 end subroutine copy_field_1r!}}}
 
 subroutine copy_field_2r(inname, all_fields, amPool, outname)!{{{
 #include "time_series_inc/copy_field_1.inc"
   type (field2DReal), pointer :: src, dst
 #include "time_series_inc/copy_field_2.inc"
+  dst % missingValueMask1D => src % missingValueMask1D
+  dst % missingValueMask2D => src % missingValueMask2D
 end subroutine copy_field_2r!}}}
 
 subroutine copy_field_3r(inname, all_fields, amPool, outname)!{{{
 #include "time_series_inc/copy_field_1.inc"
   type (field3DReal), pointer :: src, dst
 #include "time_series_inc/copy_field_2.inc"
+  dst % missingValueMask1D => src % missingValueMask1D
+  dst % missingValueMask2D => src % missingValueMask2D
+  dst % missingValueMask3D => src % missingValueMask3D
 end subroutine copy_field_3r!}}}
 
 subroutine copy_field_4r(inname, all_fields, amPool, outname)!{{{
 #include "time_series_inc/copy_field_1.inc"
   type (field4DReal), pointer :: src, dst
 #include "time_series_inc/copy_field_2.inc"
+  dst % missingValueMask1D => src % missingValueMask1D
+  dst % missingValueMask2D => src % missingValueMask2D
+  dst % missingValueMask3D => src % missingValueMask3D
 end subroutine copy_field_4r!}}}
 
 subroutine copy_field_5r(inname, all_fields, amPool, outname)!{{{
 #include "time_series_inc/copy_field_1.inc"
   type (field5DReal), pointer :: src, dst
 #include "time_series_inc/copy_field_2.inc"
+  dst % missingValueMask1D => src % missingValueMask1D
+  dst % missingValueMask2D => src % missingValueMask2D
+  dst % missingValueMask3D => src % missingValueMask3D
 end subroutine copy_field_5r!}}}
 
 

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
@@ -128,6 +128,7 @@ contains
 
       integer, dimension(:), pointer :: maxLevelCell
 
+      real (kind=RKIND), dimension(:, :), pointer :: normalVelocity
       real (kind=RKIND), dimension(:, :, :), pointer :: ecosysTracers, activeTracers, debugTracers, &
            DMSTracers, MacroMoleculesTracers
       integer, pointer :: nVertLevels, nCellsSolve, tracerIndex
@@ -150,6 +151,7 @@ contains
       call mpas_pool_get_subpool(domain % blocklist % structs, 'forcing', forcingPool)
       call mpas_pool_get_subpool(domain % blocklist % structs, 'scratch', scratchPool)
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
+      call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, 1)
 
       call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
@@ -166,6 +168,7 @@ contains
       if ( .not. on_a_sphere ) call mpas_log_write('The global ocean configuration can ' &
            // 'only be applied to a spherical mesh. Exiting...', MPAS_LOG_CRIT)
 
+      normalVelocity(:,:) = 0.0_RKIND
       !***********************************************************************
       !
       !  Topography

--- a/components/mpas-ocean/src/tracer_groups/Registry_activeTracers.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_activeTracers.xml
@@ -64,9 +64,11 @@
 			<var_array name="activeTracers" dimensions="nVertLevels nCells Time" type="real" packages="activeTracersPKG" >
 				<var name="temperature" array_group="activeGRP" units="C"
 			 description="potential temperature"
-				/>
-				<var name="salinity" array_group="activeGRP" units="1.e-3"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
+			 	/>
+			 	<var name="salinity" array_group="activeGRP" units="1.e-3"
 			 description="salinity in grams salt per kilogram seawater"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 				/>
 			</var_array>
 		</var_struct>

--- a/components/mpas-ocean/src/tracer_groups/Registry_activeTracers.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_activeTracers.xml
@@ -61,14 +61,12 @@
 
 	<var_struct name="state" time_levs="2">
 		<var_struct name="tracers" time_levs="2">
-			<var_array name="activeTracers" dimensions="nVertLevels nCells Time" type="real" packages="activeTracersPKG" >
+			<var_array name="activeTracers" dimensions="nVertLevels nCells Time" type="real" packages="activeTracersPKG" missing_value="FILLVAL" missing_value_mask="cellMask">
 				<var name="temperature" array_group="activeGRP" units="C"
 			 description="potential temperature"
-			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 	/>
 			 	<var name="salinity" array_group="activeGRP" units="1.e-3"
 			 description="salinity in grams salt per kilogram seawater"
-			 missing_value="FILLVAL" missing_value_mask="cellMask"
 				/>
 			</var_array>
 		</var_struct>

--- a/components/mpas-seaice/src/analysis_members/mpas_seaice_time_series_stats.F
+++ b/components/mpas-seaice/src/analysis_members/mpas_seaice_time_series_stats.F
@@ -1999,30 +1999,42 @@ subroutine copy_field_1r(inname, all_fields, amPool, outname)!{{{
 #include "time_series_inc/copy_field_1.inc"
   type (field1DReal), pointer :: src, dst
 #include "time_series_inc/copy_field_2.inc"
+  dst % missingValueMask1D => src % missingValueMask1D
 end subroutine copy_field_1r!}}}
 
 subroutine copy_field_2r(inname, all_fields, amPool, outname)!{{{
 #include "time_series_inc/copy_field_1.inc"
   type (field2DReal), pointer :: src, dst
 #include "time_series_inc/copy_field_2.inc"
+  dst % missingValueMask1D => src % missingValueMask1D
+  dst % missingValueMask2D => src % missingValueMask2D
 end subroutine copy_field_2r!}}}
 
 subroutine copy_field_3r(inname, all_fields, amPool, outname)!{{{
 #include "time_series_inc/copy_field_1.inc"
   type (field3DReal), pointer :: src, dst
 #include "time_series_inc/copy_field_2.inc"
+  dst % missingValueMask1D => src % missingValueMask1D
+  dst % missingValueMask2D => src % missingValueMask2D
+  dst % missingValueMask3D => src % missingValueMask3D
 end subroutine copy_field_3r!}}}
 
 subroutine copy_field_4r(inname, all_fields, amPool, outname)!{{{
 #include "time_series_inc/copy_field_1.inc"
   type (field4DReal), pointer :: src, dst
 #include "time_series_inc/copy_field_2.inc"
+  dst % missingValueMask1D => src % missingValueMask1D
+  dst % missingValueMask2D => src % missingValueMask2D
+  dst % missingValueMask3D => src % missingValueMask3D
 end subroutine copy_field_4r!}}}
 
 subroutine copy_field_5r(inname, all_fields, amPool, outname)!{{{
 #include "time_series_inc/copy_field_1.inc"
   type (field5DReal), pointer :: src, dst
 #include "time_series_inc/copy_field_2.inc"
+  dst % missingValueMask1D => src % missingValueMask1D
+  dst % missingValueMask2D => src % missingValueMask2D
+  dst % missingValueMask3D => src % missingValueMask3D
 end subroutine copy_field_5r!}}}
 
 


### PR DESCRIPTION
This PR is in support of CF-compliant output from MPAS components. It adds a new optional feature to fill variables in output streams with the `missing_value` defined in the Registry everywhere a masking array, designated with its registry name by a new registry attribute `missing_value_mask`, is equal to zero. These attributes can be added either to `var`s or to `vararray`s; when added to a `vararray`, masking is applied to each `var` in the `vararray`.

The masking is only applied to variables who (a) have a `missing_value` and `missing_value_mask` attribute and (b) are members of a stream that has the attribute `useMissingValMask='true'`. `useMissingValMask='false'` by default. Thus, changes can be made to Registry attributes without affecting the default behavior of streams.

Masking is supported for Real fields with dimensions 1-5 when the masking array is an integer array with dimensions 1-3 _and_ the shape of the masking array matches up to 3 contiguous dimensions of the Real field. 

The structure of code changes is as follows:

1. `gen_inc.c` adds `missing_value_mask` as specified in the Registry as an attribute of `var`s and `vararray`s and stores the value of `missing_value_mask` in the real field type structure as `maskName`. 
2. `mpas_bootstrap_framework_phase2` calls `mpas_mask_assign_pointer`, which assigns a pointer from the real field structure to the masking array. The name of the pointer is `missingValueMaskXD` where X is the dimension of the masking array. 
3. `xml_stream_parser.c` ensures that `useMissingValMask` is added as an attribute of the stream. `stream_mgr_create_stream_c` converts the string value of `useMissingValMask` given in the streams xml file to the logical value of `useMissingValMask` in the stream type structure.
4. `MPAS_writeStream` applies the masking if the command line argument `useMissingValMask` (which derives from the stream attribute) is `.true.` and the array dimensions are appropriate. It applies the masking through a call  to `mpas_mask_field`.
5. `mpas_field_routines.F` contains `mpas_mask_assign_pointer` and `mpas_mask_field` for multiple mask and field dimension combinations.
6. Support was added for the `time_series_stats` analysis member through changes to `duplicate_field_array.inc` and assigning pointer to `missingValueMaskXd` in subroutines of `mpas_ocn_time_series_stats.F`. The latter needed to be located in dimension-specific routines so that the appropriate X values were used.
7. The `global_ocean` test cases had an implicit assumption that `normalVelocity` would be initialized to 0 that needed to be made explicit in `mpas_ocn_init_global_ocean.F` in order for the PR test suite to pass.

**To use this feature:**

1. If the variable you want to mask does not have `missing_value_mask="maskingArray"` in its entry in the Registry, add this line.
2. Add `useMissingValMask="true"` to the stream entry to which you would like to apply the masking.

[BFB]