### PR TITLE
Add PIO_ROOT=1 mod to FIDEAL test

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -111,7 +111,7 @@ _TESTS = {
             "ERS_Ld5.ne4_oQU240.F2010.eam-rrtmgpxx",
             "REP_Ln5.ne4_oQU240.F2010",
             "SMS_Ld9.ne4pg2_oQU480.F2010.eam-thetahy_sl_pg2_mass",
-            "ERP_Ld9.ne4_ne4.FIDEAL",
+            "ERP_Ld9.ne4_ne4.FIDEAL.allactive-pioroot1",
             )
         },
 


### PR DESCRIPTION
To avoid false-positive memleak fail on ROOTPE 0 in ERP tests.

Fixes E3SM-Project/E3SM#5076

[NML] - due to the test name change