### PR TITLE
[MPAS-Framework] Rename `gregorian_noleap` to just `noleap` calendar

### DIFF
--- a/components/mpas-albany-landice/bld/namelist_files/namelist_defaults_mali.xml
+++ b/components/mpas-albany-landice/bld/namelist_files/namelist_defaults_mali.xml
@@ -116,7 +116,7 @@
 <config_start_time>'0000-01-01_00:00:00'</config_start_time>
 <config_stop_time>'0000-01-01_00:00:00'</config_stop_time>
 <config_run_duration>'none'</config_run_duration>
-<config_calendar_type CALENDAR="NO_LEAP">'gregorian_noleap'</config_calendar_type>
+<config_calendar_type CALENDAR="NO_LEAP">'noleap'</config_calendar_type>
 <config_calendar_type>'gregorian'</config_calendar_type>
 
 <!-- io -->

--- a/components/mpas-albany-landice/bld/namelist_files/namelist_definition_mali.xml
+++ b/components/mpas-albany-landice/bld/namelist_files/namelist_definition_mali.xml
@@ -17,7 +17,7 @@
           An abbreviation of the fortran declaration for the variable.
       Valid declarations are:
 
-          char*n  
+          char*n
           integer
           logical
           real
@@ -31,7 +31,7 @@
      input_pathname
           Only include this attribute to indicate that the variable
           contains the pathname of an input dataset that resides in the
-          CESM inputdata directory tree.  
+          CESM inputdata directory tree.
 
       The recognized values are "abs" to indicate that an absolute
           pathname is required, or "rel:var_name" to indicate that the
@@ -840,7 +840,7 @@ Default: Defined in namelist_defaults.xml
 	category="time_management" group="time_management">
 Selection of the type of calendar that should be used in the simulation.
 
-Valid values: 'gregorian', 'gregorian_noleap'
+Valid values: 'gregorian', 'noleap'
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -480,9 +480,9 @@
 		            description="Timestamp describing the length of the simulation. If it is set to 'none' the duration is determined from config_start_time and config_stop_time. config_run_duration overrides inconsistent values of config_stop_time. If a time value is specified for config_run_duration, it must be greater than 0."
 		            possible_values="'YYYY-MM-DD_HH:MM:SS' or 'none' (items in the format string may be dropped from the left if not needed, and the components on either side of the underscore may be replaced with a single integer representing the rightmost unit)"
 		/>
-		<nml_option name="config_calendar_type" type="character" default_value="gregorian_noleap" units="unitless"
+		<nml_option name="config_calendar_type" type="character" default_value="noleap" units="unitless"
 		            description="Selection of the type of calendar that should be used in the simulation."
-		            possible_values="'gregorian', 'gregorian_noleap'"
+		            possible_values="'gregorian', 'noleap'"
 		/>
 	</nml_record>
 
@@ -588,7 +588,7 @@
 
                 <package name="ismip6ShelfMelt" description="This package includes variables required for the ISMIP6 ice-shelf melt parameterization developed for Antarctica."/>
 
-		<package name="ismip6GroundedFaceMelt" description="This package includes variables required for the ISMIP6 grounded glacier front melt parameterization developed for Greenland." />	
+		<package name="ismip6GroundedFaceMelt" description="This package includes variables required for the ISMIP6 grounded glacier front melt parameterization developed for Greenland." />
 
                 <package name="thermal" description="This package includes variables required for the thermal solver."/>
 
@@ -761,7 +761,7 @@
                         <!-- beta, effectivePressure and muFriction are only used for HO solvers -->
 			<var name="beta" packages="higherOrderVelocity"/>
 			<var name="effectivePressure" packages="higherOrderVelocity"/>
-                        <var name="muFriction" packages="higherOrderVelocity"/>      
+                        <var name="muFriction" packages="higherOrderVelocity"/>
                         <!-- dirichletVelocityMask is only used for HO solvers -->
                         <var name="dirichletVelocityMask" packages="higherOrderVelocity"/>
                         <!-- fields only needed by SGH -->
@@ -821,18 +821,18 @@
 			<var name="uReconstructX"/>
 			<var name="uReconstructY"/>
 		</stream>
-                <!-- input stream for regions masks files (currently only used by regional stats AM, and 
+                <!-- input stream for regions masks files (currently only used by regional stats AM, and
                      the only field used is the regionCellMasks field -->
                 <stream name="regionsInput" type="input"
                                 mode="forward;analysis"
                                 filename_template="regionMasks.nc"
                                 input_interval="initial_only"
                                 runtime_format="single_file">
-                        <var name="regionCellMasks"/> 
-                        <!--var name="nCellsInRegion"/>  
-                        <var name="regionVertexMasks"/>  
-                        <var name="nVerticesInRegion"/> 
-                        <var name="nRegionsInGroup"/> 
+                        <var name="regionCellMasks"/>
+                        <!--var name="nCellsInRegion"/>
+                        <var name="regionVertexMasks"/>
+                        <var name="nVerticesInRegion"/>
+                        <var name="nRegionsInGroup"/>
                         <var name="regionsInGroup"/>
                         <var name="regionMaskNames"/>
                         <var name="regionGroupNames"/-->
@@ -1196,7 +1196,7 @@ is the value of that variable from the *previous* time level!
                      units="m m^{-1}"  description="surface slope magnitude on edges" packages="SIAvelocity"
                />
                 <!-- Variables only needed by ISMIP6 ice-shelf melt method -->
-                <var name="ismip6shelfMelt_basin" type="integer" dimensions="nCells" units="" default_value="1" 
+                <var name="ismip6shelfMelt_basin" type="integer" dimensions="nCells" units="" default_value="1"
                      packages="ismip6ShelfMelt" description="basin number mask for ISMIP6 melt forcing, input to model"
                 />
                 <var name="ismip6shelfMelt_gamma0" type="real" dimensions="" units="m yr^{-1}" default_value="0.0"
@@ -1210,7 +1210,7 @@ is the value of that variable from the *previous* time level!
                 <var name="ismip6shelfMelt_TFdraft" type="real" dimensions="nCells Time" units="deg. C" packages="ismip6ShelfMelt"
                      description="thermal forcing at ice shelf draft used for ISMIP6 ice-shelf melting method, calculated by param."
                 />
-                <var name="ismip6shelfMelt_3dThermalForcing" type="real" dimensions="nISMIP6OceanLayers nCells Time" units="deg. C" 
+                <var name="ismip6shelfMelt_3dThermalForcing" type="real" dimensions="nISMIP6OceanLayers nCells Time" units="deg. C"
                      default_value="2.0" packages="ismip6ShelfMelt"
                      description="thermal forcing for ISMIP6 ice-shelf melting method, input to model"
                 />
@@ -1221,7 +1221,7 @@ is the value of that variable from the *previous* time level!
                      description="Optional field of offset that should be applied to the melt field calculated by the ISMIP6 melt method.  Can be used to run in anomaly mode, but this is not the anomaly.  See Registry.xml for details."
                 />
                 <!-- Variables needed for ISMIP6 grounded face melt parameterization -->
-                <var name="frontAblationMask" type="integer" dimensions="nCells Time" units="none" time_levs="1" 
+                <var name="frontAblationMask" type="integer" dimensions="nCells Time" units="none" time_levs="1"
                      description="mask of grid cells at which front ablation will be applied. Determined by settings of applyToGrounded, applyToFloating, and applyToGroundingLine in routines that call li_apply_front_ablation_velocity."
                 />
                 />
@@ -1229,7 +1229,7 @@ is the value of that variable from the *previous* time level!
 		     description="linear speed of submarine melting at grounded glacier front"
   		/>
                 <var name="ismip6Runoff" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}" packages="ismip6GroundedFaceMelt" default_value="0.0"
-                     description="Runoff forcing for ISMIP6 grounded ice melting method, input to model" 
+                     description="Runoff forcing for ISMIP6 grounded ice melting method, input to model"
                 />
 		<var name="ismip6_2dThermalForcing" type="real" dimensions="nCells Time" units="deg. C" packages="ismip6GroundedFaceMelt" default_value="2.0"
 	 	     description="thermal forcing for ISMIP6 grounded marine melt method, input to model"

--- a/components/mpas-framework/src/framework/mpas_timekeeping.F
+++ b/components/mpas-framework/src/framework/mpas_timekeeping.F
@@ -18,7 +18,7 @@ module mpas_timekeeping
    private :: mpas_calibrate_alarms
    private :: mpas_in_ringing_envelope
 
-   integer :: TheCalendar 
+   integer :: TheCalendar
    integer :: yearWidth
 
    integer, dimension(12), parameter :: daysInMonth     = (/31,28,31,30,31,30,31,31,30,31,30,31/)
@@ -87,14 +87,16 @@ module mpas_timekeeping
 
       implicit none
 
-      character (len=*), intent(in) :: calendar 
+      character (len=*), intent(in) :: calendar
 
-      if (trim(calendar) == 'gregorian') then
+      if ((trim(calendar) == 'gregorian') .or. (trim(calendar) == 'standard')) then
          TheCalendar = MPAS_GREGORIAN
 #ifndef MPAS_NO_ESMF_INIT
          call ESMF_Initialize(defaultCalendar=ESMF_CALKIND_GREGORIAN)
 #endif
-      else if (trim(calendar) == 'gregorian_noleap') then
+      else if ((trim(calendar) == 'gregorian_noleap') .or. &
+               (trim(calendar) == 'noleap') .or. &
+               (trim(calendar) == '365_day')) then
          TheCalendar = MPAS_GREGORIAN_NOLEAP
 #ifndef MPAS_NO_ESMF_INIT
          call ESMF_Initialize(defaultCalendar=ESMF_CALKIND_NOLEAP)
@@ -177,7 +179,7 @@ module mpas_timekeeping
                   return
                end if
             end if
-         else if (present(stopTime)) then 
+         else if (present(stopTime)) then
             stop_time = stopTime
          else
             if (present(ierr)) ierr = 1   ! neither stopTime nor runDuration are specified
@@ -520,7 +522,7 @@ module mpas_timekeeping
 
          alarmPtr % isSet = .true.
          alarmPtr % ringTime = alarmTime
-         
+
 
          if (present(alarmTimeInterval)) then
             alarmPtr % isRecurring = .true.
@@ -528,7 +530,7 @@ module mpas_timekeeping
             if(clock % direction == MPAS_FORWARD) then
                alarmPtr % prevRingTime = alarmTime - alarmTimeInterval
             else
-               alarmPtr % prevRingTime = alarmTime + alarmTimeInterval         
+               alarmPtr % prevRingTime = alarmTime + alarmTimeInterval
             end if
          else
             alarmPtr % isRecurring = .false.
@@ -613,7 +615,7 @@ module mpas_timekeeping
             mpas_is_alarm_defined = .true.
             return
          end if
-         alarmPtr => alarmPtr % next 
+         alarmPtr => alarmPtr % next
       end do
 
    end function mpas_is_alarm_defined
@@ -652,7 +654,7 @@ module mpas_timekeeping
             end if
             return
          end if
-         alarmPtr => alarmPtr % next 
+         alarmPtr => alarmPtr % next
       end do
 
    end function mpas_alarm_interval
@@ -803,7 +805,7 @@ module mpas_timekeeping
       if (present(ierr)) ierr = 0
 
       mpas_is_alarm_ringing = .false.
-      
+
       alarmPtr => clock % alarmListHead
       do while (associated(alarmPtr))
          if (trim(alarmPtr % alarmID) == trim(alarmID)) then
@@ -854,24 +856,24 @@ module mpas_timekeeping
    logical function mpas_in_ringing_envelope(clock, alarmPtr, interval, ierr)
 
       implicit none
-      
+
       type (MPAS_Clock_type), intent(in) :: clock
       type (MPAS_Alarm_type), pointer :: alarmPtr
       type (MPAS_TimeInterval_type), intent(in), optional :: interval
       integer, intent(out), optional :: ierr
-      
+
       type (MPAS_Time_type) :: alarmNow
       type (MPAS_Time_type) :: alarmThreshold
 
       alarmNow = mpas_get_clock_time(clock, MPAS_NOW, ierr)
-      alarmThreshold = alarmPtr % ringTime 
-      
-      mpas_in_ringing_envelope = .false.      
-               
+      alarmThreshold = alarmPtr % ringTime
+
+      mpas_in_ringing_envelope = .false.
+
       if(clock % direction == MPAS_FORWARD) then
 
          if (present(interval)) then
-            alarmNow = alarmNow + interval; 
+            alarmNow = alarmNow + interval;
          end if
 
          if (alarmPtr % isRecurring) then
@@ -884,13 +886,13 @@ module mpas_timekeeping
       else
 
          if (present(interval)) then
-            alarmNow = alarmNow - interval; 
+            alarmNow = alarmNow - interval;
          end if
 
          if (alarmPtr % isRecurring) then
             alarmThreshold = alarmPtr % prevRingTime - alarmPtr % ringTimeInterval
          end if
-            
+
          if (alarmThreshold >= alarmNow) then
             mpas_in_ringing_envelope = .true.
          end if
@@ -923,13 +925,13 @@ module mpas_timekeeping
       if ( threadNum == 0 ) then
          alarmPtr => clock % alarmListHead
          do while (associated(alarmPtr))
-         
+
             if (trim(alarmPtr % alarmID) == trim(alarmID)) then
 
                if (mpas_in_ringing_envelope(clock, alarmPtr, interval, ierr)) then
 
                   if (.not. alarmPtr % isRecurring) then
-                     alarmPtr % isSet = .false. 
+                     alarmPtr % isSet = .false.
                   else
                      alarmNow = mpas_get_clock_time(clock, MPAS_NOW, ierr)
 
@@ -1051,29 +1053,29 @@ module mpas_timekeeping
       threadNum = mpas_threading_get_thread_num()
 
       now = mpas_get_clock_time(clock, MPAS_NOW, ierr)
-      
+
       if ( threadNum == 0 ) then
          alarmPtr => clock % alarmListHead
          do while (associated(alarmPtr))
-            
+
             if (.not. alarmPtr % isRecurring) then
-               alarmPtr % isSet = .true.            
+               alarmPtr % isSet = .true.
             else
-            
+
                previousRingTime = alarmPtr % prevRingTime
 
                if (previousRingTime <= now) then
-               
+
                   do while(previousRingTime <= now)
                      previousRingTime = previousRingTime + alarmPtr % ringTimeInterval
                   end do
                   positiveNeighborRingTime = previousRingTime
-               
+
                   do while(previousRingTime >= now)
                      previousRingTime = previousRingTime - alarmPtr % ringTimeInterval
                   end do
                   negativeNeighborRingTime = previousRingTime
-               
+
                else
 
                   do while(previousRingTime >= now)
@@ -1085,7 +1087,7 @@ module mpas_timekeeping
                      previousRingTime = previousRingTime + alarmPtr % ringTimeInterval
                   end do
                   positiveNeighborRingTime = previousRingTime
-            
+
                end if
 
                if (clock % direction == MPAS_FORWARD) then
@@ -1095,18 +1097,18 @@ module mpas_timekeeping
                end if
 
             end if
-   
+
             alarmPtr => alarmPtr % next
-            
+
          end do
-   
+
          if (present(ierr)) then
             if (ierr == ESMF_SUCCESS) ierr = 0
          end if
       end if
 
       !$omp barrier
-   
+
    end subroutine mpas_calibrate_alarms
 
 
@@ -1150,7 +1152,7 @@ module mpas_timekeeping
             deallocate(subStrings)
             denominatorPower = len_trim(secDecSubString)
             if(denominatorPower > 0) then
-               read(secDecSubString,*) numerator 
+               read(secDecSubString,*) numerator
                if(numerator > 0) then
                   denominator = 10**denominatorPower
                end if
@@ -1170,13 +1172,13 @@ module mpas_timekeeping
             dateSubString = subStrings(1)
             timeSubString = subStrings(2)
             deallocate(subStrings)
-            
+
             call mpas_split_string(timeSubString, ":", subStrings)
-            
+
             if (size(subStrings) == 3) then
-               read(subStrings(1),*) hour 
-               read(subStrings(2),*) min 
-               read(subStrings(3),*) sec 
+               read(subStrings(1),*) hour
+               read(subStrings(2),*) min
+               read(subStrings(3),*) sec
                deallocate(subStrings)
             else
                deallocate(subStrings)
@@ -1185,14 +1187,14 @@ module mpas_timekeeping
                return
             end if
 
-         else if(size(subStrings) == 1) then   ! contains only a date- assume all time values are 0 
+         else if(size(subStrings) == 1) then   ! contains only a date- assume all time values are 0
             dateSubString = subStrings(1)
             deallocate(subStrings)
-           
+
             hour = 0
             min = 0
             sec = 0
-         
+
          else
             deallocate(subStrings)
             if (present(ierr)) ierr = 1
@@ -1201,9 +1203,9 @@ module mpas_timekeeping
          end if
 
          call mpas_split_string(dateSubString, "-", subStrings)
-            
+
          if (size(subStrings) == 3) then
-            read(subStrings(1),*) year 
+            read(subStrings(1),*) year
             read(subStrings(2),*) month
             read(subStrings(3),*) day
             deallocate(subStrings)
@@ -1217,10 +1219,10 @@ module mpas_timekeeping
          call ESMF_TimeSet(curr_time % t, YY=year, MM=month, DD=day, H=hour, M=min, S=sec, Sn=numerator, Sd=denominator, rc=ierr)
 
       else
-      
+
          if (present(DoY)) then
             call mpas_get_month_day(YYYY, DoY, month, day)
-         
+
             ! consistency check
             if (present(MM)) then
                if (MM /= month) then
@@ -1258,9 +1260,9 @@ module mpas_timekeeping
          end if
 
          call ESMF_TimeSet(curr_time % t, YY=YYYY, MM=month, DD=day, H=H, M=M, S=S, Sn=S_n, Sd=S_d, rc=ierr)
-      
+
       end if
-      
+
       if (present(ierr)) then
          if (ierr == ESMF_SUCCESS) ierr = 0
       end if
@@ -1431,7 +1433,7 @@ module mpas_timekeeping
          denominator = 1
 
          call mpas_split_string(timeString_, ".", subStrings)
-         
+
          if (size(subStrings) == 2) then ! contains second decimals
             timeString_ = subStrings(1)
             secDecSubString = subStrings(2)(:integerMaxDigits)
@@ -1439,7 +1441,7 @@ module mpas_timekeeping
 
             denominatorPower = len_trim(secDecSubString)
             if(denominatorPower > 0) then
-               read(secDecSubString,*) numerator 
+               read(secDecSubString,*) numerator
                if(numerator > 0) then
                   denominator = 10**denominatorPower
                end if
@@ -1496,21 +1498,21 @@ module mpas_timekeeping
          end if
 
          call mpas_split_string(timeSubString, ":", subStrings)
-            
+
          if (size(subStrings) == 3) then
-            read(subStrings(1),*) hour 
-            read(subStrings(2),*) min 
-            read(subStrings(3),*) sec 
+            read(subStrings(1),*) hour
+            read(subStrings(2),*) min
+            read(subStrings(3),*) sec
             deallocate(subStrings)
          else if (size(subStrings) == 2) then
             hour = 0
-            read(subStrings(1),*) min 
-            read(subStrings(2),*) sec 
+            read(subStrings(1),*) min
+            read(subStrings(2),*) sec
             deallocate(subStrings)
          else if (size(subStrings) == 1) then
             hour = 0
             min = 0
-            read(subStrings(1),*) sec 
+            read(subStrings(1),*) sec
             deallocate(subStrings)
          else
             deallocate(subStrings)
@@ -1524,7 +1526,7 @@ module mpas_timekeeping
       else
 
          call ESMF_TimeIntervalSet(interval % ti, YY=YY, MM=MM, D=DD, H=H, M=M, S_i8=S_i8, S=S, Sn=S_n, Sd=S_d, rc=ierr)
-      
+
       end if
 
 !     ! verify that time interval is positive
@@ -1535,10 +1537,10 @@ module mpas_timekeeping
 !     end if
 
 !     if (interval <= zeroInterval) then
-!        if (present(ierr)) ierr = 1   
+!        if (present(ierr)) ierr = 1
 !        call mpas_log_write('TimeInterval must be greater than zero: '// trim(timeString), MPAS_LOG_ERR) !'ERROR: TimeInterval cannot be negative'
 !     end if
-      
+
    end subroutine mpas_set_timeInterval
 
 
@@ -1733,7 +1735,7 @@ module mpas_timekeeping
    !> \brief This routine computes the number intervals that fit into another interval.
    !> \author Michael Duda, Doug Jacobsen, Daniel Henderson
    !> \date   4 October 2016
-   !> \details 
+   !> \details
    !> This routine performs time-interval division on any intervals with cost
    !> that is proportional to the log of the result, n.
    !> It works by first performing a forward search, doubling intervals, until
@@ -1970,8 +1972,8 @@ module mpas_timekeeping
       integer :: D, S, Sn, Sd
 
       call ESMF_TimeIntervalGet(ti % ti, D=D, S=S, Sn=Sn, Sd=Sd, rc=rc)
-      D    = -D 
-      S    = -S 
+      D    = -D
+      S    = -S
       Sn   = -Sn
       call ESMF_TimeIntervalSet(neg_ti % ti, D=D, S=S, Sn=Sn, Sd=Sd, rc=rc)
 
@@ -1992,8 +1994,8 @@ module mpas_timekeeping
 
       if(ti < zeroInterval) then
          call ESMF_TimeIntervalGet(ti % ti, D=D, S=S, Sn=Sn, Sd=Sd, rc=rc)
-         D    = -D 
-         S    = -S 
+         D    = -D
+         S    = -S
          Sn   = -Sn
          call ESMF_TimeIntervalSet(abs_ti % ti, D=D, S=S, Sn=Sn, Sd=Sd, rc=rc)
       else
@@ -2015,14 +2017,14 @@ module mpas_timekeeping
 !   end function mod
 
 
-   subroutine mpas_split_string(string, delimiter, subStrings)   
-      
+   subroutine mpas_split_string(string, delimiter, subStrings)
+
       implicit none
-      
+
       character(len=*), intent(in) :: string
       character, intent(in) :: delimiter
       character(len=*), pointer, dimension(:) :: subStrings
-      
+
       integer :: i, start, index
 
       index = 1
@@ -2038,25 +2040,25 @@ module mpas_timekeeping
       index = 1
       do i = 1, len(string)
          if(string(i:i) == delimiter) then
-               subStrings(index) = string(start:i-1) 
+               subStrings(index) = string(start:i-1)
                index = index + 1
                start = i + 1
          end if
       end do
-      subStrings(index) = string(start:len(string)) 
-      
+      subStrings(index) = string(start:len(string))
+
    end subroutine mpas_split_string
 
 
     subroutine mpas_get_month_day(YYYY, DoY, month, day)
-       
+
        implicit none
 
        integer, intent(in) :: YYYY, DoY
        integer, intent(out) :: month, day
 
        integer, dimension(12) :: dpm
-       
+
        if (isLeapYear(YYYY)) then
           dpm(:) = daysInMonthLeap
        else
@@ -2067,20 +2069,20 @@ module mpas_timekeeping
        day = DoY
        do while (day > dpm(month))
           day = day -  dpm(month)
-          month = month + 1       
+          month = month + 1
        end do
 
     end subroutine mpas_get_month_day
 
 
    logical function isValidDate(YYYY, MM, DD)
-   
+
       integer, intent(in) :: YYYY, MM, DD
       integer :: daysInMM
-      
+
       isValidDate = .true.
 
-      ! TODO: ???? Gregorian calendar has no year zero, but perhaps 0 = 1 BC ??? 
+      ! TODO: ???? Gregorian calendar has no year zero, but perhaps 0 = 1 BC ???
       !if (YYYY == 0) then
       !   isValidDate = .false.
       !   return
@@ -2102,10 +2104,10 @@ module mpas_timekeeping
          if (TheCalendar == MPAS_GREGORIAN .and. isLeapYear(YYYY)) then
             daysInMM = daysInMonthLeap(MM)
          else
-            daysInMM = daysInMonth(MM)        
+            daysInMM = daysInMonth(MM)
          end if
       end if
-     
+
       if (DD > daysInMM) then
          isValidDate = .false.
          return
@@ -2113,7 +2115,7 @@ module mpas_timekeeping
 
    end function
 
-    
+
     logical function isLeapYear(year)
 
        implicit none
@@ -2121,7 +2123,7 @@ module mpas_timekeeping
        integer, intent(in) :: year
 
        isLeapYear = .false.
-       
+
        if (mod(year,4) == 0) then
           if (mod(year,100) == 0) then
              if (mod(year,400) == 0) then
@@ -2261,6 +2263,6 @@ module mpas_timekeeping
         end do
 
     end subroutine mpas_expand_string!}}}
- 
+
 
 end module mpas_timekeeping

--- a/components/mpas-framework/src/framework/mpas_timekeeping.F
+++ b/components/mpas-framework/src/framework/mpas_timekeeping.F
@@ -89,14 +89,12 @@ module mpas_timekeeping
 
       character (len=*), intent(in) :: calendar
 
-      if ((trim(calendar) == 'gregorian') .or. (trim(calendar) == 'standard')) then
+      if (trim(calendar) == 'gregorian') then
          TheCalendar = MPAS_GREGORIAN
 #ifndef MPAS_NO_ESMF_INIT
          call ESMF_Initialize(defaultCalendar=ESMF_CALKIND_GREGORIAN)
 #endif
-      else if ((trim(calendar) == 'gregorian_noleap') .or. &
-               (trim(calendar) == 'noleap') .or. &
-               (trim(calendar) == '365_day')) then
+      else if (trim(calendar) == 'noleap') then
          TheCalendar = MPAS_GREGORIAN_NOLEAP
 #ifndef MPAS_NO_ESMF_INIT
          call ESMF_Initialize(defaultCalendar=ESMF_CALKIND_NOLEAP)

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -12,7 +12,7 @@
 <config_start_time>'0001-01-01_00:00:00'</config_start_time>
 <config_stop_time>'none'</config_stop_time>
 <config_run_duration>'0010_00:00:00'</config_run_duration>
-<config_calendar_type CALENDAR="NO_LEAP">'gregorian_noleap'</config_calendar_type>
+<config_calendar_type CALENDAR="NO_LEAP">'noleap'</config_calendar_type>
 <config_calendar_type>'gregorian'</config_calendar_type>
 
 <!-- io -->

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -17,7 +17,7 @@
           An abbreviation of the fortran declaration for the variable.
       Valid declarations are:
 
-          char*n  
+          char*n
           integer
           logical
           real
@@ -31,7 +31,7 @@
      input_pathname
           Only include this attribute to indicate that the variable
           contains the pathname of an input dataset that resides in the
-          CESM inputdata directory tree.  
+          CESM inputdata directory tree.
 
       The recognized values are "abs" to indicate that an absolute
           pathname is required, or "rel:var_name" to indicate that the
@@ -107,7 +107,7 @@ Default: Defined in namelist_defaults.xml
 	category="time_management" group="time_management">
 Selection of the type of calendar that should be used in the simulation.
 
-Valid values: 'gregorian', 'gregorian_noleap'
+Valid values: 'gregorian', 'noleap'
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -1153,7 +1153,7 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_sw_absorption_type" type="char*1024"
 	category="shortwaveRadiation" group="shortwaveRadiation">
-Name of shortwave absorption type used in simulation. 
+Name of shortwave absorption type used in simulation.
 
 Valid values: 'jerlov' or 'ohlmann00' or 'none'
 Default: Defined in namelist_defaults.xml

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -133,9 +133,9 @@
 					description="Timestamp describing the length of the simulation. If it is set to 'none' the duration is determined from config_start_time and config_stop_time. config_run_duration overrides inconsistent values of config_stop_time."
 					possible_values="'DDDD_HH:MM:SS' or 'none'"
 		/>
-		<nml_option name="config_calendar_type" type="character" default_value="gregorian_noleap"
+		<nml_option name="config_calendar_type" type="character" default_value="noleap"
 					description="Selection of the type of calendar that should be used in the simulation."
-					possible_values="'gregorian', 'gregorian_noleap'"
+					possible_values="'gregorian', 'noleap'"
 		/>
 	</nml_record>
 	<nml_record name="io" mode="forward;analysis">

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -23,7 +23,7 @@
 <config_dt ice_grid="WCAtl12to45E2r4">1800.0</config_dt>
 <config_dt ice_grid="SOwISC12to60E2r4">1800.0</config_dt>
 <config_dt ice_grid="ECwISC30to60E2r1">1800.0</config_dt>
-<config_calendar_type>'gregorian_noleap'</config_calendar_type>
+<config_calendar_type>'noleap'</config_calendar_type>
 <config_start_time>'2000-01-01_00:00:00'</config_start_time>
 <config_stop_time>'none'</config_stop_time>
 <config_run_duration>'00-00-01_00:00:00'</config_run_duration>

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -17,7 +17,7 @@
           An abbreviation of the fortran declaration for the variable.
       Valid declarations are:
 
-          char*n  
+          char*n
           integer
           logical
           real
@@ -31,7 +31,7 @@
      input_pathname
           Only include this attribute to indicate that the variable
           contains the pathname of an input dataset that resides in the
-          CESM inputdata directory tree.  
+          CESM inputdata directory tree.
 
       The recognized values are "abs" to indicate that an absolute
           pathname is required, or "rel:var_name" to indicate that the
@@ -64,7 +64,7 @@ Default: Defined in namelist_defaults.xml
 	category="seaice_model" group="seaice_model">
 Selection of the type of calendar that should be used in the simulation.
 
-Valid values: 'gregorian', 'gregorian_noleap'
+Valid values: 'gregorian', 'noleap'
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -1245,7 +1245,7 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_rapid_mobile_to_stationary_time" type="real"
 	category="biogeochemistry" group="biogeochemistry">
-Rapid adsorption timescale  
+Rapid adsorption timescale
 
 Valid values: zero or positive real number
 Default: Defined in namelist_defaults.xml
@@ -1263,7 +1263,7 @@ Default: Defined in namelist_defaults.xml
 	category="biogeochemistry" group="biogeochemistry">
 Maximum speed at which diatoms can move
 
-Valid values: zero or positive real number 
+Valid values: zero or positive real number
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -1717,7 +1717,7 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_fraction_iron_remineralized" type="real"
 	category="biogeochemistry" group="biogeochemistry">
-Fraction of remineralized iron 
+Fraction of remineralized iron
 
 Valid values: zero or positive real less than or equal to 1
 Default: Defined in namelist_defaults.xml
@@ -2106,7 +2106,7 @@ Default: Defined in namelist_defaults.xml
 	category="shortwave" group="shortwave">
 Sea ice tuning parameter; +1 for 1sig increase in albedo.
 
-Valid values: 
+Valid values:
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -2114,7 +2114,7 @@ Default: Defined in namelist_defaults.xml
 	category="shortwave" group="shortwave">
 Ponded ice tuning parameter; +1 for 1sig increase in albedo.
 
-Valid values: 
+Valid values:
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -2122,7 +2122,7 @@ Default: Defined in namelist_defaults.xml
 	category="shortwave" group="shortwave">
 Snow tuning parameter; +1 for ~.01 change in broadband albedo.
 
-Valid values: 
+Valid values:
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -2130,7 +2130,7 @@ Default: Defined in namelist_defaults.xml
 	category="shortwave" group="shortwave">
 Change in temperture for non-melt to melt snow grain radius change.
 
-Valid values: 
+Valid values:
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -2138,7 +2138,7 @@ Default: Defined in namelist_defaults.xml
 	category="shortwave" group="shortwave">
 Maximum melting snow grain radius.
 
-Valid values: 
+Valid values:
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -2146,7 +2146,7 @@ Default: Defined in namelist_defaults.xml
 	category="shortwave" group="shortwave">
 Algae absorption coefficient for 0.5 m thick layer.
 
-Valid values: 
+Valid values:
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -2224,7 +2224,7 @@ Default: Defined in namelist_defaults.xml
 	category="meltponds" group="meltponds">
 Snow depth for transition to bare sea ice.
 
-Valid values: 
+Valid values:
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -2240,7 +2240,7 @@ Default: Defined in namelist_defaults.xml
 	category="meltponds" group="meltponds">
 Alter e-folding time scale for flushing.?????
 
-Valid values: 
+Valid values:
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -2264,7 +2264,7 @@ Default: Defined in namelist_defaults.xml
 	category="meltponds" group="meltponds">
 Ratio of pond depth to pond fraction.
 
-Valid values: 
+Valid values:
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -2272,7 +2272,7 @@ Default: Defined in namelist_defaults.xml
 	category="meltponds" group="meltponds">
 Tapering parameter for snow on pond ice.
 
-Valid values: 
+Valid values:
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -2280,7 +2280,7 @@ Default: Defined in namelist_defaults.xml
 	category="meltponds" group="meltponds">
 Critical parameter for pond ice thickness.
 
-Valid values: 
+Valid values:
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -2401,7 +2401,7 @@ Default: Defined in namelist_defaults.xml
 	category="ridging" group="ridging">
 E-folding scale of ridged ice (krdg_redist = 1)
 
-Valid values: 
+Valid values:
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -2409,7 +2409,7 @@ Default: Defined in namelist_defaults.xml
 	category="ridging" group="ridging">
 Ratio of ridging work to PE change in ridging (kstrength = 1)
 
-Valid values: 
+Valid values:
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -2479,7 +2479,7 @@ Default: Defined in namelist_defaults.xml
 	category="ocean" group="ocean">
 Minimum friction velocity for ice-ocean heat flux.
 
-Valid values: 
+Valid values:
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -17,7 +17,7 @@ module ice_comp_mct
    use seq_infodata_mod
    use seq_timemgr_mod
    use seq_comm_mct,      only : seq_comm_suffix, seq_comm_inst, seq_comm_name, info_taskmap_comp
-   use shr_file_mod 
+   use shr_file_mod
    use shr_cal_mod,       only : shr_cal_date2ymd
    use shr_sys_mod
    use shr_taskmap_mod,   only : shr_taskmap_write
@@ -91,8 +91,8 @@ module ice_comp_mct
 
    character(len=StrKIND) :: runtype, coupleTimeStamp
 
-   type(seq_infodata_type), pointer :: infodata   
-   type (iosystem_desc_t), pointer :: io_system 
+   type(seq_infodata_type), pointer :: infodata
+   type (iosystem_desc_t), pointer :: io_system
 
    integer :: iceLogUnit ! unit number for ice log
 
@@ -103,7 +103,7 @@ module ice_comp_mct
 
    ! prescribed ice mode
    type(shr_strdata_type) :: &
-        sdat ! prescribed data stream   
+        sdat ! prescribed data stream
 
 !=======================================================================
 
@@ -256,7 +256,7 @@ contains
 !   set cdata pointers
 !
 !-----------------------------------------------------------------------
-    errorCode = 0 
+    errorCode = 0
 
     call seq_cdata_setptrs(cdata_i, ID=ICEID, mpicom=mpicom_i, &
          gsMap=gsMap_i, dom=dom_i, infodata=infodata)
@@ -269,7 +269,7 @@ contains
 #if (defined _MEMTRACE)
     if(iam == 0) then
         lbnum=1
-        call memmon_dump_fort('memmon.out','ice_init_mct:start::',lbnum) 
+        call memmon_dump_fort('memmon.out','ice_init_mct:start::',lbnum)
     endif
 #endif
 
@@ -668,15 +668,15 @@ contains
 
     ! Initialize mct ice domain (needs ice initialization info)
     call ice_domain_mct( lsize, gsMap_i, dom_i )
-    
+
     ! Inialize mct attribute vectors
-    
+
     call mct_aVect_init(x2i_i, rList=seq_flds_x2i_fields, lsize=lsize)
     call mct_aVect_zero(x2i_i)
-    
-    call mct_aVect_init(i2x_i, rList=seq_flds_i2x_fields, lsize=lsize) 
+
+    call mct_aVect_init(i2x_i, rList=seq_flds_i2x_fields, lsize=lsize)
     call mct_aVect_zero(i2x_i)
-    
+
     nsend = mct_avect_nRattr(i2x_i)
     nrecv = mct_avect_nRattr(x2i_i)
 
@@ -745,7 +745,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-    call ice_export_mct(i2x_i, errorCode)  
+    call ice_export_mct(i2x_i, errorCode)
     if (errorCode /= 0) then
        call mpas_log_write('Error in ice_export_mct', MPAS_LOG_CRIT)
     endif
@@ -760,7 +760,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-    call ice_import_mct(x2i_i, errorCode)  
+    call ice_import_mct(x2i_i, errorCode)
     if (errorCode /= 0) then
        call mpas_log_write('Error in ice_import_mct', MPAS_LOG_CRIT)
     endif
@@ -771,7 +771,7 @@ contains
 
     itimestep = 0
 
-    call seaice_analysis_compute_startup(domain, ierr) 
+    call seaice_analysis_compute_startup(domain, ierr)
 
     ! Reset all output alarms, to prevent intial time step from writing any output, unless it's ringing.
     call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_OUTPUT, ierr=ierr)
@@ -797,7 +797,7 @@ contains
 #if defined (_MEMTRACE)
     if(iam  == 0) then
         lbnum=1
-        call memmon_dump_fort('memmon.out','ice_init_mct:end::',lbnum) 
+        call memmon_dump_fort('memmon.out','ice_init_mct:end::',lbnum)
         call memmon_reset_addr()
     endif
 #endif
@@ -955,12 +955,12 @@ contains
 
        call MPAS_pool_get_dimension(domain % blocklist % dimensions, "nCellsSolve", nCellsSolve)
        call MPI_Allreduce(nCellsSolve, nCells, 1, MPI_Integer, MPI_SUM, domain % dminfo % comm, ierr)
-       
+
 
        call MPAS_pool_get_config(domain % configs, "config_calendar_type", config_calendar_type)
        if (trim(config_calendar_type) == "gregorian") then
           calendar_type = shr_cal_gregorian
-       else if (trim(config_calendar_type) == "gregorian_noleap") then
+       else if (trim(config_calendar_type) == "noleap") then
           calendar_type = shr_cal_noleap
        else
           call MPAS_log_write("ice_prescribed_init: Unknown calendar type: "//trim(config_calendar_type))
@@ -1054,7 +1054,7 @@ contains
 #ifdef MPAS_DEBUG
       debugOn = .true.
 #endif
- 
+
       ! Set MPAS Log module instance
       mpas_log_info => domain % logInfo
       if (debugOn) call mpas_log_write("=== Beginning ice_run_mct ===")
@@ -1108,7 +1108,7 @@ contains
         itimestep = itimestep + 1
         call mpas_advance_clock(domain % clock)
 
-        ! final initialization after clock advance 
+        ! final initialization after clock advance
         if (first) then
            call seaice_forcing_get(domain % streamManager, domain, domain % clock, .true.)
 
@@ -1285,7 +1285,7 @@ contains
 
     type (field1DReal), pointer :: &
          iceCoverageField
-    
+
     call MPAS_pool_get_config(domain % configs, "config_use_prescribed_ice", config_use_prescribed_ice)
     if (config_use_prescribed_ice) then
 
@@ -1431,7 +1431,7 @@ contains
 
     integer :: i, n, lsize, gsize, ier
 
-    type (block_type), pointer :: block_ptr 
+    type (block_type), pointer :: block_ptr
     type (mpas_pool_type), pointer :: meshPool
 
     integer, dimension(:), pointer :: indexToCellID
@@ -1499,7 +1499,7 @@ contains
 
     integer        , intent(in)    :: lsize
     type(mct_gsMap), intent(in)    :: gsMap_i
-    type(mct_ggrid), intent(inout) :: dom_i     
+    type(mct_ggrid), intent(inout) :: dom_i
 
 !EOP
 !BOC
@@ -1550,19 +1550,19 @@ contains
 
 !-------------------------------------------------------------------
 !
-! Determine domain 
+! Determine domain
 ! Initialize attribute vector with special value
 !
 !-------------------------------------------------------------------
 
-    data(:) = -9999.0_R8 
-    call mct_gGrid_importRAttr(dom_i,"lat"  ,data,lsize) 
-    call mct_gGrid_importRAttr(dom_i,"lon"  ,data,lsize) 
-    call mct_gGrid_importRAttr(dom_i,"area" ,data,lsize) 
-    call mct_gGrid_importRAttr(dom_i,"aream",data,lsize) 
-    data(:) = 1.0_R8     
-    call mct_gGrid_importRAttr(dom_i,"mask",data,lsize) 
-    call mct_gGrid_importRAttr(dom_i,"frac",data,lsize) 
+    data(:) = -9999.0_R8
+    call mct_gGrid_importRAttr(dom_i,"lat"  ,data,lsize)
+    call mct_gGrid_importRAttr(dom_i,"lon"  ,data,lsize)
+    call mct_gGrid_importRAttr(dom_i,"area" ,data,lsize)
+    call mct_gGrid_importRAttr(dom_i,"aream",data,lsize)
+    data(:) = 1.0_R8
+    call mct_gGrid_importRAttr(dom_i,"mask",data,lsize)
+    call mct_gGrid_importRAttr(dom_i,"frac",data,lsize)
 
 !-------------------------------------------------------------------
 !
@@ -1583,10 +1583,10 @@ contains
           n = n + 1
           data(n) = lonCell(i) * r2d
        end do
-       
+
        block_ptr => block_ptr % next
     end do
-    call mct_gGrid_importRattr(dom_i,"lon",data,lsize) 
+    call mct_gGrid_importRattr(dom_i,"lon",data,lsize)
 
     n = 0
     block_ptr => domain % blocklist
@@ -1603,7 +1603,7 @@ contains
        end do
        block_ptr => block_ptr % next
     end do
-    call mct_gGrid_importRattr(dom_i,"lat",data,lsize) 
+    call mct_gGrid_importRattr(dom_i,"lat",data,lsize)
 
     n = 0
     block_ptr => domain % blocklist
@@ -1621,7 +1621,7 @@ contains
        end do
        block_ptr => block_ptr % next
     end do
-    call mct_gGrid_importRattr(dom_i,"area",data,lsize) 
+    call mct_gGrid_importRattr(dom_i,"area",data,lsize)
 
     ! Build mask and frac based on landIceMask
     block_ptr => domain % blocklist
@@ -1650,8 +1650,8 @@ contains
        block_ptr => block_ptr % next
     end do
 
-    call mct_gGrid_importRattr(dom_i,"mask",data,lsize) 
-    call mct_gGrid_importRattr(dom_i,"frac",data,lsize) 
+    call mct_gGrid_importRattr(dom_i,"mask",data,lsize)
+    call mct_gGrid_importRattr(dom_i,"frac",data,lsize)
 
     deallocate(data)
     deallocate(idata)
@@ -1674,7 +1674,7 @@ contains
 !  This routine receives message from cpl7 driver
 !
 !    The following fields are always received from the coupler:
-! 
+!
 !    o  t        -- ocn layer temperature
 !    o  s        -- ocn salinity
 !    o  u        -- ocn u velocity
@@ -1690,15 +1690,15 @@ contains
 !    o  dhdx     -- ocn surface slope, zonal
 !    o  dhdy     -- ocn surface slope, meridional
 !    o  lwdn     -- downward lw heat flux
-!    o  rain     -- prec: liquid 
-!    o  snow     -- prec: frozen 
+!    o  rain     -- prec: liquid
+!    o  snow     -- prec: frozen
 !    o  swndr    -- sw: nir direct  downward
 !    o  swvdr    -- sw: vis direct  downward
 !    o  swndf    -- sw: nir diffuse downward
 !    o  swvdf    -- sw: vis diffuse downward
 !    o  swnet    -- sw: net
 !    o  q        -- ocn frazil heat flux(+) / melt potential(-)
-!    o  frazil   -- ocn frazil mass flux 
+!    o  frazil   -- ocn frazil mass flux
 !    o  bcphidry -- Black Carbon hydrophilic dry deposition flux
 !    o  bcphodry -- Black Carbon hydrophobic dry deposition flux
 !    o  bcphiwet -- Black Carbon hydrophilic wet deposition flux
@@ -1713,10 +1713,10 @@ contains
 !    o  dstdry2  -- Size 2 dust -- dry deposition flux
 !    o  dstdry3  -- Size 3 dust -- dry deposition flux
 !    o  dstdry4  -- Size 4 dust -- dry deposition flux
-! 
+!
 !    The following fields are sometimes received from the coupler,
 !      depending on model options:
-! 
+!
 !    o  algae1   --
 !    o  algae2   --
 !    o  algae3   --
@@ -1741,7 +1741,7 @@ contains
 !    o  zaer4    --
 !    o  zaer5    --
 !    o  zaer6    --
-! 
+!
 !-----------------------------------------------------------------------
 !
 ! !REVISION HISTORY:
@@ -1767,7 +1767,7 @@ contains
    character (len=StrKIND) :: &
       label,                  &
       message
- 
+
    integer ::  &
       i,n
 
@@ -1886,9 +1886,9 @@ contains
       atmosBlackCarbonFlux,        &
       atmosDustFlux
 
-!----------------------------------------------------------------------- 
+!-----------------------------------------------------------------------
 !
-!  zero out padded cells 
+!  zero out padded cells
 !
 !-----------------------------------------------------------------------
 
@@ -1987,8 +1987,8 @@ contains
         seaSurfaceTiltV(i)             = x2i_i % rAttr(index_x2i_So_dhdy, n)
 
         if (trim(config_ocean_surface_type) == "free") then ! free surface (MPAS-O)
-        
-           ! freezingMeltingPotential(i) is the ocean energy associated with frazil formation 
+
+           ! freezingMeltingPotential(i) is the ocean energy associated with frazil formation
            ! when it is positive and frazilMassFlux is positive. Conversely, freezingMeltingPotential(i)
            ! is negative when there is the melting potential in which case frazilMassFlux is zero.
 
@@ -1997,7 +1997,7 @@ contains
            frazilMassFlux              = x2i_i % rAttr(index_x2i_Fioo_frazil, n)
 
            ! Now determine the sea ice mass associated with the frazil heat flux given when
-           ! freezingMeltingPotential(i) is positive. This produces a revised mass flux, given 
+           ! freezingMeltingPotential(i) is positive. This produces a revised mass flux, given
            ! in frazilMassFluxRev for the given sea surface salinity. The resulting difference
            ! is assigned to frazilMassAdjust(i) which is exported to the ocean in the subsequent
            ! coupling step as a freshwater and salt flux. This step is required to balance mass
@@ -2006,7 +2006,7 @@ contains
            call frazil_mass(freezingMeltingPotential(i), frazilMassFluxRev, seaSurfaceSalinity(i), &
                                    config_thermodynamics_type)
 
-           frazilMassAdjust(i) = frazilMassFlux-frazilMassFluxRev 
+           frazilMassAdjust(i) = frazilMassFlux-frazilMassFluxRev
 
         else ! non-free surface (SOM)
 
@@ -2120,7 +2120,7 @@ contains
         endif
       end do
 
-!----------------------------------------------------------------------- 
+!-----------------------------------------------------------------------
 !
 !  unit conversions and any manipulation of coupled fields
 !
@@ -2382,7 +2382,7 @@ contains
       oceanParticulateIronFlux,    &
       oceanDissolvedIronFlux
 
-!----------------------------------------------------------------------- 
+!-----------------------------------------------------------------------
 
    errorCode = 0
    n = 0
@@ -2527,7 +2527,7 @@ contains
               sphere_radius,        &
               config_rotate_cartesian_grid)
 
-         !-------states-------------------- 
+         !-------states--------------------
          i2x_i % rAttr(index_i2x_Si_ifrac ,n)    = ailohi
 
          if (config_use_data_icebergs) then
@@ -2537,7 +2537,7 @@ contains
 
          if ( ailohi > 0.0_RKIND ) then
 
-            !-------states-------------------- 
+            !-------states--------------------
             i2x_i % rAttr(index_i2x_Si_t     ,n)  = Tsrf
             i2x_i % rAttr(index_i2x_Si_bpress,n)  = basalPressure
             i2x_i % rAttr(index_i2x_Si_u10   ,n)  = atmosReferenceSpeed10m(i)
@@ -2564,7 +2564,7 @@ contains
                i2x_i % rAttr(index_i2x_Faii_swnet,n) = absorbedShortwaveFlux(i)
             endif
 
-            ! i/o fluxes computed by ice, as well as additional freshwater and salt calculated at the last 
+            ! i/o fluxes computed by ice, as well as additional freshwater and salt calculated at the last
             ! coupling import and needed to grow sea ice from frazil passed from the ocean model in the
             ! field frazilMassAdjust.
             i2x_i % rAttr(index_i2x_Fioi_melth,n) = oceanHeatFlux(i)
@@ -2637,7 +2637,7 @@ contains
       else
           write(histAtt, '(A,I6,A,A,A)') 'mpirun -n ', domain % dminfo % nProcs, ' ./', trim(domain % core % coreName), '_model'
       end if
-     
+
 
       call MPAS_stream_mgr_add_att(domain % streamManager, 'on_a_sphere', domain % on_a_sphere)
       call MPAS_stream_mgr_add_att(domain % streamManager, 'sphere_radius', domain % sphere_radius)
@@ -2748,8 +2748,8 @@ contains
                                  config_thermodynamics_type)
 !
 ! !DESCRIPTION:
-! Calculate frazil mass based on on the sea surface salinity, and frazil heat flux 
-! from the ocean, otherwise referred to as to as the freeze-melt potential. When 
+! Calculate frazil mass based on on the sea surface salinity, and frazil heat flux
+! from the ocean, otherwise referred to as to as the freeze-melt potential. When
 ! freezingPotential is positive, it gives the heat flux, according to the ocean model
 ! associated with the frazil mass passed from the ocean.  This function calculates
 ! the frazil mass based on the freezingPotential according to sea ice model thermodynamics,
@@ -2823,7 +2823,7 @@ contains
    subroutine datetime(cdate, ctime)
 !
 ! !DESCRIPTION:
-! Calculate current date and time for metadata history 
+! Calculate current date and time for metadata history
 !
 ! !USES:
 

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -318,9 +318,9 @@
 			description="Length of model time-step."
 			possible_values="Any positive real number."
 		/>
-		<nml_option name="config_calendar_type" type="character" default_value="gregorian_noleap" units="unitless"
+		<nml_option name="config_calendar_type" type="character" default_value="noleap" units="unitless"
 			description="Selection of the type of calendar that should be used in the simulation."
-			possible_values="'gregorian', 'gregorian_noleap'"
+			possible_values="'gregorian', 'noleap'"
 		/>
 		<nml_option name="config_start_time" type="character" default_value="2000-01-01_00:00:00" units="unitless"
 			description="Timestamp describing the initial time of the simulation. If it is set to 'file', the initial time is read from restart_timestamp."

--- a/components/mpas-seaice/src/shared/mpas_seaice_column.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_column.F
@@ -2606,8 +2606,8 @@ contains
 !> \details
 !>
 !> Snow physics improvements include:
-!> 1) Snow redistribution by wind (multiple options available).  
-!> Includes parametrizations for snow compaction, redistribution among categories/level ice 
+!> 1) Snow redistribution by wind (multiple options available).
+!> Includes parametrizations for snow compaction, redistribution among categories/level ice
 !> and loss to leads.
 !> 2) Tracking of snow liquid and ice content.  Liquid is stored in snow before passing to ponds.
 !> Effective snow density is also tracked.
@@ -3130,7 +3130,7 @@ contains
        if (trim(config_calendar_type) == "gregorian") then
           calendarType = "GREGORIAN"
        else
-          calendarType = "GREGORIAN_NOLEAP"
+          calendarType = "NOLEAP"
        endif
 
        ! aerosols array
@@ -4275,7 +4275,7 @@ contains
        else
           daysInYear = sum(daysInMonth)
        endif
-    case ("gregorian_noleap")
+    case ("noleap")
        daysInYear = sum(daysInMonth)
     end select
 
@@ -6083,7 +6083,7 @@ contains
        tracerObject % index_snowGrainRadius = nTracers + 1
        nTracers = nTracers + nSnowLayers
     endif
-    
+
     ! aerosols
     tracerObject % index_aerosols = indexMissingValue
     if (config_use_aerosols) then
@@ -9677,7 +9677,7 @@ contains
     !     nt_hpnd, &       ! melt pond depth
     !     nt_ipnd, &       ! melt pond refrozen lid thickness
     !     nt_aero, &       ! starting index for aerosols in ice
-    !     nt_smice, &      ! snow ice mass 
+    !     nt_smice, &      ! snow ice mass
     !     nt_smliq, &      ! snow liquid mass
     !     nt_rsnw, &       ! snow grain radius
     !     nt_rhos, &       ! snow density tracer
@@ -10058,7 +10058,7 @@ contains
     !     F_abs_chl_diatoms  , &
     !     F_abs_chl_sp       , &
     !     F_abs_chl_phaeo    , &
-    !     ratio_C2N_proteins 
+    !     ratio_C2N_proteins
 
     use ice_colpkg, only: &
          colpkg_init_parameters
@@ -11442,7 +11442,7 @@ contains
 
     ! windmin:
     ! minimum wind speed to compact snow (m/s)
-    ! windmin = config_minimum_wind_compaction 
+    ! windmin = config_minimum_wind_compaction
 
     ! drhosdwind:
     ! wind compaction factor (kg s/m^4)


### PR DESCRIPTION
The `noleap` is the CF-compliant name for what MPAS currently calls the `gregorian_noleap` calendar. See https://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/ch04s04.html.

This merge changes `gregorian_noleap` to `noleap` in the MPAS framework and in all 3 MPAS components.

The context of this change is that the `config_calendar_type` namelist option is being used for the `calendar` attribute of the `Time` coordinate in https://github.com/E3SM-Ocean-Discussion/E3SM/pull/19.  However, the result is not making post-processing tools (notably `xarray`) happy because the `gregorian_noleap` calendar is not CF-compliant.

```
ValueError: calendar must be one of ['standard', 'gregorian', 'proleptic_gregorian', 'noleap', 'julian', 'all_leap', '365_day', '366_day', '360_day'], got 'gregorian_noleap'
```


[NML]
[BFB]