### PR TITLE
On GCP, use 4 nodes for r05 grid to allow test to complete

### DIFF
--- a/components/elm/cime_config/config_pes.xml
+++ b/components/elm/cime_config/config_pes.xml
@@ -506,5 +506,20 @@
         </ntasks>
       </pes>
     </mach>
+    <mach name="gcp">
+      <pes compset="any" pesize="any">
+        <comment>gcp r05 4 nodes</comment>
+        <ntasks>
+          <ntasks_atm>-4</ntasks_atm>
+          <ntasks_lnd>-4</ntasks_lnd>
+          <ntasks_rof>-4</ntasks_rof>
+          <ntasks_ice>-4</ntasks_ice>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_glc>-4</ntasks_glc>
+          <ntasks_wav>-4</ntasks_wav>
+          <ntasks_cpl>-4</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
   </grid>
 </config_pes>


### PR DESCRIPTION
For GCP only, the `ERS.r05_r05.IELM.gcp_gnu.elm-V2_ELM_MOSART_features` test was running out of time on 1 node and using 4 nodes was at least 3x faster.

[bfb]