### PR TITLE
Add normalGMBolusVelocity to the gm package

### DIFF
--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2844,6 +2844,7 @@
 		/>
 		<var name="normalGMBolusVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
 			 description="Bolus velocity in Gent-McWilliams eddy parameterization"
+			 packages="gm"
 		/>
 		<var name="normalMLEvelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
 			description="Velocity from mixed layer eddies (fox kemper 2011 submesoscale parameterization)"

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -1576,16 +1576,13 @@ module ocn_time_integration_split
             !$omp do schedule(runtime)
             do iEdge = 1, nEdges
                uTemp(:,iEdge) = normalBarotropicVelocityNew(iEdge) &
-                            + normalBaroclinicVelocityNew(:,iEdge) &
-                      +       normalGMBolusVelocity(:,iEdge)
+                            + normalBaroclinicVelocityNew(:,iEdge)
             end do
             !$omp end do
             !$omp end parallel
 
-            ! mrp turn off separate GM addition for bfb match.
-            ! normalGMBolusVelocity added in previous loop.
-            !call ocn_GM_add_to_transport_vel(uTemp, nEdges, &
-            !                                 nVertLevels)
+            call ocn_GM_add_to_transport_vel(uTemp, nEdges, &
+                                             nVertLevels)
             call ocn_MLE_add_to_transport_vel(uTemp, nEdges)
 
             !$omp parallel
@@ -1640,11 +1637,9 @@ module ocn_time_integration_split
                   !                         + normalVelocityCorrection
                   ! This is the velocity used in advective terms for layerThickness
                   ! and tracers in tendency calls in stage 3.
-                  normalTransportVelocity(k,iEdge) = edgeMask(k,iEdge) &
-                           *(normalBarotropicVelocityNew(iEdge)   + &
-                             normalBaroclinicVelocityNew(k,iEdge) + &
-                             normalGMBolusVelocity(k,iEdge) + &
-                             normalVelocityCorrection )
+                  normalTransportVelocity(k,iEdge) = edgeMask(k,iEdge)*( &
+                             normalTransportVelocity(k,iEdge) + &
+                             normalVelocityCorrection)
                enddo
 
             end do ! iEdge


### PR DESCRIPTION
This PR is needed to put the `normalGMBolusVelocity` in the gm package, so it is not allocated when GM is off. Otherwise, extra memory is allocated unnecessarily for high-resolution simulations.

This reverts commit 2c6f496a2bbc764434817609c3d8110287fb828c, which was a small change in https://github.com/E3SM-Project/E3SM/pull/5099 to make that PR BFB on intel-19 optimized in MPAS-Ocean standalone. 

This PR is BFB with gcc-9 debug, gcc-9 optimized, and intel-19 debug. For intel-19 optimized there is a mismatch with master of 1e-12 on the first timestep for the MPAS-Ocean standalone compass test `ocean_global_ocean_QU240_PHC_performance_test` on crysalis.  It appears that intel-19 conducts some optimization that changes the order of operations for the lines involved here.

We expect this PR to be bfb for all E3SM tests.

[BFB]