### PR TITLE
Alters MOC calculation in ocean component

### DIFF
--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_moc_streamfunction.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_moc_streamfunction.F
@@ -508,10 +508,15 @@ contains
                      * 0.5_RKIND*(layerThickness(k,c1) + layerThickness(k,c2))
                end do
             end do
-            do k = 2, nVertLevels
+            !Integrate transport from bottom to top, which switches the sign of sumTransport
+            !there is also an implicit moc(nVertLevels+1,iTransect) = 0
+            k = nVertLevels
+            mocStreamValLatAndDepthRegionLocal(1, k, iTransect) = &
+               - sumTransport(k, iTransect)
+            do k = nVertLevels-1, 1, -1
                mocStreamValLatAndDepthRegionLocal(1, k, iTransect) = &
-                  mocStreamValLatAndDepthRegionLocal(1, k - 1, iTransect) &
-                  + sumTransport(k - 1, iTransect)
+                  mocStreamValLatAndDepthRegionLocal(1, k + 1, iTransect) &
+                  - sumTransport(k - 1, iTransect)
             end do
          end do
 
@@ -606,10 +611,15 @@ contains
                        * 0.5_RKIND*(layerThickness(k,c1) + layerThickness(k,c2))
                  end do
               end do
-              do k = 2, nVertLevels
+              !Integrate transport from bottom to top, which switches the sign of sumTransport
+              !there is also an implicit moc(nVertLevels+1,iTransect) = 0
+              k = nVertLevels
+              mocStreamValLatAndDepthRegionLocal(1, k, iTransect) = &
+                 - sumTransport(k, iTransect)
+              do k = nVertLevels - 1, 1, -1
                  mocStreamValLatAndDepthRegionLocal(1, k, iTransect) = &
-                    mocStreamValLatAndDepthRegionLocal(1, k - 1, iTransect) &
-                    + sumTransport(k - 1, iTransect)
+                    mocStreamValLatAndDepthRegionLocal(1, k + 1, iTransect) &
+                    - sumTransport(k + 1, iTransect)
               end do
            end do
 
@@ -712,10 +722,15 @@ contains
                        * 0.5_RKIND*(layerThickness(k,c1) + layerThickness(k,c2))
                  end do
               end do
-              do k = 2, nVertLevels
+              !Integrate transport from bottom to top, which switches the sign of sumTransport
+              !there is also an implicit moc(nVertLevels+1,iTransect) = 0
+              k = nVertLevels
+              mocStreamValLatAndDepthRegionLocal(1, k, iTransect) = &
+                 - sumTransport(k, iTransect)
+              do k = nVertLevels - 1, 1, -1
                  mocStreamValLatAndDepthRegionLocal(1, k, iTransect) = &
-                    mocStreamValLatAndDepthRegionLocal(1, k - 1, iTransect) &
-                    + sumTransport(k - 1, iTransect)
+                    mocStreamValLatAndDepthRegionLocal(1, k + 1, iTransect) &
+                    - sumTransport(k - 1, iTransect)
               end do
            end do
 


### PR DESCRIPTION
Currently the southern boundary is integrated from top to bottom, this is changed to be from bottom to top to take advantage of the natural boundary condition that the streamfunction at the bottom is zero.  In the calculation we implicitly assume that there is a mocStreamValLatAndDepthLocal(nVertLevels+1) that is always zero.

The calculation is also consistent with that used by the POP model for the same diagnostic -- https://github.com/ESCOMP/POP2-CESM/blob/master/source/diags_on_lat_aux_grid.F90#L1155-L1158