### PR TITLE
Fix determination of flds_c_oi logical variable

### DIFF
--- a/driver-mct/main/seq_diagBGC_mct.F90
+++ b/driver-mct/main/seq_diagBGC_mct.F90
@@ -875,9 +875,9 @@ contains
           index_x2o_Faxa_ocphidry = mct_aVect_indexRA(x2o_o,'Faxa_ocphidry')
           index_x2o_Faxa_ocphodry = mct_aVect_indexRA(x2o_o,'Faxa_ocphodry')
           index_x2o_Faxa_ocphiwet = mct_aVect_indexRA(x2o_o,'Faxa_ocphiwet')
+          index_x2o_Fioi_algae1   = mct_aVect_indexRA(x2o_o,'Fioi_algae1',perrWith='quiet')
           if ( index_x2o_Fioi_algae1 /= 0 ) flds_c_oi = .true.
           if ( flds_c_oi ) then
-             index_x2o_Fioi_algae1   = mct_aVect_indexRA(x2o_o,'Fioi_algae1')
              index_x2o_Fioi_algae2   = mct_aVect_indexRA(x2o_o,'Fioi_algae2')
              index_x2o_Fioi_algae3   = mct_aVect_indexRA(x2o_o,'Fioi_algae3')
              index_x2o_Fioi_dic1     = mct_aVect_indexRA(x2o_o,'Fioi_dic1')
@@ -982,9 +982,9 @@ contains
 
     if (present(do_i2x)) then
        if (first_time) then
+          index_i2x_Fioi_algae1   = mct_aVect_indexRA(i2x_i,'Fioi_algae1',perrWith='quiet')
           if ( index_i2x_Fioi_algae1 /= 0 ) flds_c_oi = .true.
           if ( flds_c_oi ) then
-             index_i2x_Fioi_algae1   = mct_aVect_indexRA(i2x_i,'Fioi_algae1')
              index_i2x_Fioi_algae2   = mct_aVect_indexRA(i2x_i,'Fioi_algae2')
              index_i2x_Fioi_algae3   = mct_aVect_indexRA(i2x_i,'Fioi_algae3')
              index_i2x_Fioi_dic1     = mct_aVect_indexRA(i2x_i,'Fioi_dic1')


### PR DESCRIPTION
Fixes the determination of the flds_c_oi logical variable in the coupler carbon budget code, used to load carbon exchange fields between the ice and ocn. This only impacts the carbon coupler budget output.

[BFB]