### PR TITLE
Add script support for ARRM10to60E2r1 ocn/ice grid

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -340,6 +340,16 @@
       <mask>oARRM60to6</mask>
     </model_grid>
 
+    <model_grid alias="T62_ARRM10to60E2r1" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">ARRM10to60E2r1</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>ARRM10to60E2r1</mask>
+    </model_grid>
+
     <model_grid alias="T62_EC30to60E2r2" compset="(DATM|XATM|SATM)">
       <grid name="atm">T62</grid>
       <grid name="lnd">T62</grid>
@@ -438,6 +448,16 @@
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
       <mask>oARRM60to6</mask>
+    </model_grid>
+
+    <model_grid alias="TL319_ARRM10to60E2r1" compset="(DATM|XATM|SATM)">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">TL319</grid>
+      <grid name="ocnice">ARRM10to60E2r1</grid>
+      <grid name="rof">JRA025</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>ARRM10to60E2r1</mask>
     </model_grid>
 
     <model_grid alias="TL319_EC30to60E2r2" compset="(DATM|XATM|SATM)">
@@ -1012,6 +1032,16 @@
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
       <mask>oARRM60to10</mask>
+    </model_grid>
+
+    <model_grid alias="arcticx4v1pg2_ARRM10to60E2r1">
+      <grid name="atm">ne0np4_arcticx4v1.pg2</grid>
+      <grid name="lnd">ne0np4_arcticx4v1.pg2</grid>
+      <grid name="ocnice">ARRM10to60E2r1</grid>
+      <grid name="rof">r0125</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>ARRM10to60E2r1</mask>
     </model_grid>
 
     <model_grid alias="svalbardx8v1_svalbardx8v1" compset="(DOCN|XOCN|SOCN|AQP1)">
@@ -1843,6 +1873,16 @@
       <mask>oARRM60to10</mask>
     </model_grid>
 
+    <model_grid alias="ne30pg2_ARRM10to60E2r1">
+      <grid name="atm">ne30np4.pg2</grid>
+      <grid name="lnd">ne30np4.pg2</grid>
+      <grid name="ocnice">ARRM10to60E2r1</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>ARRM10to60E2r1</mask>
+    </model_grid>
+
     <model_grid alias="ne30pg2_EC30to60E2r2">
       <grid name="atm">ne30np4.pg2</grid>
       <grid name="lnd">ne30np4.pg2</grid>
@@ -2223,6 +2263,7 @@
       <file grid="atm|lnd" mask="oRRS15to5">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oRRS15to5.150722.nc</file>
       <file grid="atm|lnd" mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oARRM60to10.180716.nc</file>
       <file grid="atm|lnd" mask="oARRM60to6">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oARRM60to6.180803.nc</file>
+      <file grid="atm|lnd" mask="ARRM10to60E2r1">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_ARRM10to60E2r1.220802.nc</file>
       <file grid="atm|lnd" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_EC30to60E2r2.201005.nc</file>
       <file grid="atm|lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_WC14to60E2r3.200929.nc</file>
       <file grid="atm|lnd" mask="WCAtl12to45E2r4">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_WCAtl12to45E2r4.210318.nc</file>
@@ -2258,6 +2299,8 @@
       <file grid="ice|ocn" mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oARRM60to10.180905.nc</file>
       <file grid="atm|lnd" mask="oARRM60to6">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_oARRM60to6.180905.nc</file>
       <file grid="ice|ocn" mask="oARRM60to6">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oARRM60to6.180905.nc</file>
+      <file grid="atm|lnd" mask="ARRM10to60E2r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_ARRM10to60E2r1.220802.nc</file>
+      <file grid="ice|ocn" mask="ARRM10to60E2r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_ARRM10to60E2r1.220802.nc</file>
       <file grid="atm|lnd" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_EC30to60E2r2.201005.nc</file>
       <file grid="ice|ocn" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_EC30to60E2r2.201005.nc</file>
       <file grid="atm|lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_WC14to60E2r3.200929.nc</file>
@@ -2359,6 +2402,8 @@
       <file grid="ice|ocn" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_oEC60to30v3.200220.nc</file>
       <file grid="atm|lnd" mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_ARRM60to10.200527.nc</file>
       <file grid="ice|ocn" mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_ARRM60to10.200527.nc</file>
+      <file grid="atm|lnd" mask="ARRM10to60E2r1">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_ARRM10to60E2r1.220802.nc</file>
+      <file grid="ice|ocn" mask="ARRM10to60E2r1">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_ARRM10to60E2r1.220802.nc</file>
       <file grid="atm|lnd" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_EC30to60E2r2.201005.nc</file>
       <file grid="ice|ocn" mask="EC30to60E2r2">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_EC30to60E2r2.201005.nc</file>
       <file grid="atm|lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_WC14to60E2r3.200929.nc</file>
@@ -2567,6 +2612,13 @@
       <ny>1</ny>
       <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oARRM60to6.180803.nc</file>
       <desc>oARRM60to6 is an Arctic-Region-Refined MPAS ocean grid with 30 km gridcells at -90 deg latitude, 60 km gridcells at -40 deg latitude, 30 km gridcells at the equator, and 6 km gridcells at 90 deg latitude; North Atlantic and North Pacific have different resolution between 0 and 60 deg latitudes:</desc>
+    </domain>
+
+    <domain name="ARRM10to60E2r1">
+      <nx>594836</nx>
+      <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.ARRM10to60E2r1.220802.nc</file>
+      <desc>ARRM10to60E2r1 is an Arctic-Region-Refined MPAS ocean grid with 30 km gridcells at -90 deg latitude, 60 km gridcells at -40 deg latitude, 30 km gridcells at the equator, and 10 km gridcells at 90 deg latitude; North Atlantic and North Pacific have different resolution between 0 and 60 deg latitudes:</desc>
     </domain>
 
     <domain name="EC30to60E2r2">
@@ -2785,6 +2837,8 @@
       <ny>1</ny>
       <file grid="atm|lnd" mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.lnd.arcticx4v1pg2_oARRM60to10.210630.nc</file>
       <file grid="ice|ocn" mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.ocn.arcticx4v1pg2_oARRM60to10.210630.nc</file>
+      <file grid="atm|lnd" mask="ARRM10to60E2r1">$DIN_LOC_ROOT/share/domains/domain.lnd.arcticx4v1pg2_ARRM10to60E2r1.220802.nc</file>
+      <file grid="ice|ocn" mask="ARRM10to60E2r1">$DIN_LOC_ROOT/share/domains/domain.ocn.arcticx4v1pg2_ARRM10to60E2r1.220802.nc</file>
       <desc>1-deg with 1/4-deg over Arctic (version 1) pg2:</desc>
     </domain>
 
@@ -3030,6 +3084,14 @@
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_ARRM60to10_bilin.200527.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oARRM60to10/map_ARRM60to10_to_ne30pg2_mono.200527.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oARRM60to10/map_ARRM60to10_to_ne30pg2_mono.200527.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne30np4.pg2" ocn_grid="ARRM10to60E2r1">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_ARRM10to60E2r1_mono.220802.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_ARRM10to60E2r1_bilin.220802.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_ARRM10to60E2r1_bilin.220802.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/ARRM10to60E2r1/map_ARRM10to60E2r1_to_ne30pg2_mono.220802.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/ARRM10to60E2r1/map_ARRM10to60E2r1_to_ne30pg2_mono.220802.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4.pg2" ocn_grid="EC30to60E2r2">
@@ -3529,6 +3591,14 @@
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oARRM60to10/map_oARRM60to10_to_arcticx4v1pg2_mono.20210407.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="ne0np4_arcticx4v1.pg2" ocn_grid="ARRM10to60E2r1">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/arcticx4v1pg2/map_arcticx4v1pg2_to_ARRM10to60E2r1_mono.220802.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/arcticx4v1pg2/map_arcticx4v1pg2_to_ARRM10to60E2r1_bilin.220802.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/arcticx4v1pg2/map_arcticx4v1pg2_to_ARRM10to60E2r1_bilin.220802.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/ARRM10to60E2r1/map_ARRM10to60E2r1_to_arcticx4v1pg2_mono.220802.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/ARRM10to60E2r1/map_ARRM10to60E2r1_to_arcticx4v1pg2_mono.220802.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="ne0np4_arcticx4v1.pg2" lnd_grid="r0125">
       <map name="ATM2LND_FMAPNAME">cpl/gridmaps/arcticx4v1pg2/map_arcticx4v1pg2_to_r0125_mono.20210517.nc</map>
       <map name="ATM2LND_SMAPNAME">cpl/gridmaps/arcticx4v1pg2/map_arcticx4v1pg2_to_r0125_mono.20210517.nc</map>
@@ -3697,6 +3767,14 @@
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oARRM60to6/map_oARRM60to6_to_T62_aave.180803.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="T62" ocn_grid="ARRM10to60E2r1">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_ARRM10to60E2r1_aave.220802.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_ARRM10to60E2r1_bilin.220802.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_ARRM10to60E2r1_patch.220802.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/ARRM10to60E2r1/map_ARRM10to60E2r1_to_T62_aave.220802.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/ARRM10to60E2r1/map_ARRM10to60E2r1_to_T62_aave.220802.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="T62" ocn_grid="EC30to60E2r2">
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_EC30to60E2r2_aave.201005.nc</map>
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_EC30to60E2r2_bilin.201005.nc</map>
@@ -3775,6 +3853,14 @@
       <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oARRM60to6_patch.180904.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oARRM60to6/map_oARRM60to6_to_TL319_aave.180904.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oARRM60to6/map_oARRM60to6_to_TL319_aave.180904.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="TL319" ocn_grid="ARRM10to60E2r1">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_ARRM10to60E2r1_aave.220802.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_ARRM10to60E2r1_bilin.220802.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_ARRM10to60E2r1_patch.220802.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/ARRM10to60E2r1/map_ARRM10to60E2r1_to_TL319_aave.220802.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/ARRM10to60E2r1/map_ARRM10to60E2r1_to_TL319_aave.220802.nc</map>
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="EC30to60E2r2">
@@ -4220,6 +4306,11 @@
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_oARRM60to6_smoothed.r150e300.180816.nc</map>
     </gridmap>
 
+    <gridmap ocn_grid="ARRM10to60E2r1" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_ARRM10to60E2r1_smoothed.r150e300.220802.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_ARRM10to60E2r1_smoothed.r150e300.220802.nc</map>
+    </gridmap>
+
     <gridmap ocn_grid="EC30to60E2r2" rof_grid="rx1">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_EC30to60E2r2_smoothed.r150e300.201005.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_EC30to60E2r2_smoothed.r150e300.201005.nc</map>
@@ -4268,6 +4359,11 @@
     <gridmap ocn_grid="oARRM60to6" rof_grid="JRA025">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_oARRM60to6_smoothed.r150e300.181220.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_oARRM60to6_smoothed.r150e300.181220.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="ARRM10to60E2r1" rof_grid="JRA025">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_ARRM10to60E2r1_smoothed.r150e300.220802.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_ARRM10to60E2r1_smoothed.r150e300.220802.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="EC30to60E2r2" rof_grid="JRA025">
@@ -4335,9 +4431,19 @@
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_ARRM60to10_smoothed.r150e300.200413.nc</map>
     </gridmap>
 
+    <gridmap ocn_grid="ARRM10to60E2r1" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_ARRM10to60E2r1_smoothed.r150e300.220802.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_ARRM10to60E2r1_smoothed.r150e300.220802.nc</map>
+    </gridmap>
+
     <gridmap ocn_grid="oARRM60to10" rof_grid="r0125">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r0125_to_ARRM60to10_smoothed.r50e100.220214.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r0125_to_ARRM60to10_smoothed.r50e100.220214.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="ARRM10to60E2r1" rof_grid="r0125">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r0125_to_ARRM10to60E2r1_smoothed.r50e100.220802.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r0125_to_ARRM10to60E2r1_smoothed.r50e100.220802.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="EC30to60E2r2" rof_grid="r05">

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -183,6 +183,10 @@ sim_year="1950" glc_nec="0" use_crop=".false.">lnd/clm2/initdata/20210802.ICRUEL
 sim_year="1950" glc_nec="0" use_crop=".false.">lnd/clm2/initdata/20210817.ICRUELM-1950.ne30pg2_SOwISC12to60E2r4.elm.r.0051-01-01-00000.nc
 </finidat>
 
+<finidat hgrid="ne30np4.pg2" maxpft="17" mask="ARRM10to60E2r1" use_cn=".false." ic_ymd="19500101" more_vertlayers=".false."
+sim_year="1950" glc_nec="0" use_crop=".false.">lnd/clm2/initdata/20220908.ICRUELM-1950.ne30pg2_ARRM10to60E2r1.anvil.elm.r.0051-01-01-00000.nc
+</finidat>
+
 <!-- HOMME grid ne120 resolution -->
 
 <finidat hgrid="ne120np4"   maxpft="17"  mask="gx1v6" use_cn=".false." ic_ymd="18500101" more_vertlayers=".false."

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -1297,7 +1297,7 @@ Representative concentration pathway for future scenarios [radiative forcing at 
 
 <entry id="mask" type="char*20" category="default_settings"
        group="default_settings"  
-       valid_values="USGS,gx3v7,gx1v6,navy,test,tx0.1v2,tx1v1,T62,TL319,cruncep,oEC60to30v3,oEC60to30v3wLI,ECwISC30to60E1r2,EC30to60E2r2,WC14to60E2r3,WCAtl12to45E2r4,SOwISC12to60E2r4,ECwISC30to60E2r1,oRRS18to6,oRRS18to6v3,oRRS15to5,oARRM60to10,oARRM60to6,oQU480,oQU240,oQU240wLI,oQU120,oRRS30to10v3,oRRS30to10v3wLI,360x720cru,NLDASww3a,NLDAS,tx0.1v2">
+       valid_values="USGS,gx3v7,gx1v6,navy,test,tx0.1v2,tx1v1,T62,TL319,cruncep,oEC60to30v3,oEC60to30v3wLI,ECwISC30to60E1r2,EC30to60E2r2,WC14to60E2r3,WCAtl12to45E2r4,SOwISC12to60E2r4,ECwISC30to60E2r1,oRRS18to6,oRRS18to6v3,oRRS15to5,oARRM60to10,oARRM60to6,ARRM10to60E2r1,oQU480,oQU240,oQU240wLI,oQU120,oRRS30to10v3,oRRS30to10v3wLI,360x720cru,NLDASww3a,NLDAS,tx0.1v2">
 Land mask description
 </entry>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -148,7 +148,7 @@
 <config_Redi_N2_based_taper_enable>.true.</config_Redi_N2_based_taper_enable>
 <config_Redi_N2_based_taper_min>0.1</config_Redi_N2_based_taper_min>
 <config_Redi_N2_based_taper_limit_term1>.true.</config_Redi_N2_based_taper_limit_term1>
-<config_Redi_min_layers_diag_terms>6</config_Redi_min_layers_diag_terms>
+<config_Redi_min_layers_diag_terms>15</config_Redi_min_layers_diag_terms>
 <config_Redi_horizontal_taper>'ramp'</config_Redi_horizontal_taper>
 <config_Redi_horizontal_ramp_min>20e3</config_Redi_horizontal_ramp_min>
 <config_Redi_horizontal_ramp_min ocn_grid="WCAtl12to45E2r4">30e3</config_Redi_horizontal_ramp_min>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -148,7 +148,8 @@
 <config_Redi_N2_based_taper_enable>.true.</config_Redi_N2_based_taper_enable>
 <config_Redi_N2_based_taper_min>0.1</config_Redi_N2_based_taper_min>
 <config_Redi_N2_based_taper_limit_term1>.true.</config_Redi_N2_based_taper_limit_term1>
-<config_Redi_min_layers_diag_terms>15</config_Redi_min_layers_diag_terms>
+<config_Redi_min_layers_diag_terms>6</config_Redi_min_layers_diag_terms>
+<config_Redi_min_layers_diag_terms ocn_grid="ARRM10to60E2r1">15</config_Redi_min_layers_diag_terms>
 <config_Redi_horizontal_taper>'ramp'</config_Redi_horizontal_taper>
 <config_Redi_horizontal_ramp_min>20e3</config_Redi_horizontal_ramp_min>
 <config_Redi_horizontal_ramp_min ocn_grid="WCAtl12to45E2r4">30e3</config_Redi_horizontal_ramp_min>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -47,6 +47,7 @@
 <config_dt ocn_grid="oRRS15to5">'00:03:45'</config_dt>
 <config_dt ocn_grid="oARRM60to10">'00:10:00'</config_dt>
 <config_dt ocn_grid="oARRM60to6">'00:05:00'</config_dt>
+<config_dt ocn_grid="ARRM10to60E2r1">'00:10:00'</config_dt>
 <config_dt ocn_grid="EC30to60E2r2">'00:30:00'</config_dt>
 <config_dt ocn_grid="WC14to60E2r3">'00:10:00'</config_dt>
 <config_dt ocn_grid="WCAtl12to45E2r4">'00:10:00'</config_dt>
@@ -68,6 +69,7 @@
 <config_hmix_scaleWithMesh ocn_grid="oRRS15to5">.true.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="oARRM60to10">.true.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="oARRM60to6">.true.</config_hmix_scaleWithMesh>
+<config_hmix_scaleWithMesh ocn_grid="ARRM10to60E2r1">.true.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="EC30to60E2r2">.true.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="WC14to60E2r3">.true.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="WCAtl12to45E2r4">.true.</config_hmix_scaleWithMesh>
@@ -115,6 +117,7 @@
 <config_mom_del4 ocn_grid="oRRS15to5">1.9e09</config_mom_del4>
 <config_mom_del4 ocn_grid="oARRM60to10">1.5e10</config_mom_del4>
 <config_mom_del4 ocn_grid="oARRM60to6">3.2e09</config_mom_del4>
+<config_mom_del4 ocn_grid="ARRM10to60E2r1">1.5e10</config_mom_del4>
 <config_mom_del4 ocn_grid="EC30to60E2r2">1.2e11</config_mom_del4>
 <config_mom_del4 ocn_grid="WC14to60E2r3">1.18e10</config_mom_del4>
 <config_mom_del4 ocn_grid="WCAtl12to45E2r4">1.18e10</config_mom_del4>
@@ -414,6 +417,7 @@
 <config_btr_dt ocn_grid="oRRS15to5">'0000_00:00:11.25'</config_btr_dt>
 <config_btr_dt ocn_grid="oARRM60to10">'0000_00:00:24'</config_btr_dt>
 <config_btr_dt ocn_grid="oARRM60to6">'0000_00:00:10'</config_btr_dt>
+<config_btr_dt ocn_grid="ARRM10to60E2r1">'0000_00:00:24'</config_btr_dt>
 <config_btr_dt ocn_grid="EC30to60E2r2">'0000_00:01:00'</config_btr_dt>
 <config_btr_dt ocn_grid="WC14to60E2r3">'0000_00:00:15'</config_btr_dt>
 <config_btr_dt ocn_grid="WCAtl12to45E2r4">'0000_00:00:15'</config_btr_dt>
@@ -958,6 +962,7 @@
 <config_AM_mocStreamfunction_enable ocn_grid="oRRS15to5">.false.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="oARRM60to10">.false.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="oARRM60to6">.false.</config_AM_mocStreamfunction_enable>
+<config_AM_mocStreamfunction_enable ocn_grid="ARRM10to60E2r1">.true.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="EC30to60E2r2">.true.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="WC14to60E2r3">.true.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="WCAtl12to45E2r4">.true.</config_AM_mocStreamfunction_enable>

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -215,8 +215,8 @@ def buildnml(case, caseroot, compname):
         ic_date = '220730'
         ic_prefix = 'mpaso.ARRM10to60E2r1'
         if ocn_ic_mode == 'spunup':
-            logger.warning("WARNING: The specified compset is requesting ocean ICs spunup from a G-case")
-            logger.warning("         But no file available for this grid.")
+            ic_date = '220802'
+            ic_prefix = 'mpaso.ARRM10to60E2r1.rstFrom1monthG-chrys'
 
     elif ocn_grid == 'EC30to60E2r2':
         decomp_date = '200904'

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -211,7 +211,7 @@ def buildnml(case, caseroot, compname):
         decomp_date = '220730'
         decomp_prefix = 'mpas-o.graph.info.'
         restoring_file = 'sss.PHC3.0_monthlyClimatology.ARRM10to60E2r1.220802.nc'
-        analysis_mask_file = 'ARRM10to60E2r1_mocBasinsAndTransects220730.nc'
+        analysis_mask_file = 'ARRM10to60E2r1_mocBasinsAndTransects20210623.nc'
         ic_date = '220730'
         ic_prefix = 'mpaso.ARRM10to60E2r1'
         if ocn_ic_mode == 'spunup':

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -207,6 +207,17 @@ def buildnml(case, caseroot, compname):
             logger.warning("WARNING: The specified compset is requesting ocean ICs spunup from a G-case")
             logger.warning("         But no file available for this grid.")
 
+    elif ocn_grid == 'ARRM10to60E2r1':
+        decomp_date = '220730'
+        decomp_prefix = 'mpas-o.graph.info.'
+        restoring_file = 'sss.PHC3.0_monthlyClimatology.ARRM10to60E2r1.220802.nc'
+        analysis_mask_file = 'ARRM10to60E2r1_mocBasinsAndTransects220730.nc'
+        ic_date = '220730'
+        ic_prefix = 'mpaso.ARRM10to60E2r1'
+        if ocn_ic_mode == 'spunup':
+            logger.warning("WARNING: The specified compset is requesting ocean ICs spunup from a G-case")
+            logger.warning("         But no file available for this grid.")
+
     elif ocn_grid == 'EC30to60E2r2':
         decomp_date = '200904'
         decomp_prefix = 'mpas-o.graph.info.'

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -18,6 +18,7 @@
 <config_dt ice_grid="oRRS15to5">900.0</config_dt>
 <config_dt ice_grid="oARRM60to10">900.0</config_dt>
 <config_dt ice_grid="oARRM60to6">900.0</config_dt>
+<config_dt ice_grid="ARRM10to60E2r1">900.0</config_dt>
 <config_dt ice_grid="EC30to60E2r2">1800.0</config_dt>
 <config_dt ice_grid="WC14to60E2r3">1800.0</config_dt>
 <config_dt ice_grid="WCAtl12to45E2r4">1800.0</config_dt>
@@ -72,6 +73,7 @@
 <config_initial_latitude_north ice_grid="ECwISC30to60E1r2">75.0</config_initial_latitude_north>
 <config_initial_latitude_north ice_grid="SOwISC12to60E2r4">85.0</config_initial_latitude_north>
 <config_initial_latitude_north ice_grid="ECwISC30to60E2r1">75.0</config_initial_latitude_north>
+<config_initial_latitude_north ice_grid="ARRM10to60E2r1">75.0</config_initial_latitude_north>
 <config_initial_latitude_north ice_grid="oRRS30to10v3wLI">85.0</config_initial_latitude_north>
 <config_initial_latitude_north ice_grid="oRRS18to6v3">85.0</config_initial_latitude_north>
 <config_initial_latitude_south>-60.0</config_initial_latitude_south>
@@ -79,6 +81,7 @@
 <config_initial_latitude_south ice_grid="ECwISC30to60E1r2">-75.0</config_initial_latitude_south>
 <config_initial_latitude_south ice_grid="SOwISC12to60E2r4">-85.0</config_initial_latitude_south>
 <config_initial_latitude_south ice_grid="ECwISC30to60E2r1">-75.0</config_initial_latitude_south>
+<config_initial_latitude_south ice_grid="ARRM10to60E2r1">-85.0</config_initial_latitude_south>
 <config_initial_latitude_south ice_grid="oRRS30to10v3wLI">-85.0</config_initial_latitude_south>
 <config_initial_latitude_south ice_grid="oRRS18to6v3">-85.0</config_initial_latitude_south>
 <config_initial_velocity_type>'uniform'</config_initial_velocity_type>
@@ -125,6 +128,7 @@
 <config_dynamics_subcycle_number ice_grid="oRRS15to5">2</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="oARRM60to10">1</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="oARRM60to6">2</config_dynamics_subcycle_number>
+<config_dynamics_subcycle_number ice_grid="ARRM10to60E2r1">1</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="EC30to60E2r2">1</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="WC14to60E2r3">1</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="WCAtl12to45E2r4">1</config_dynamics_subcycle_number>

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -204,8 +204,8 @@ def buildnml(case, caseroot, compname):
         grid_date = '220730'
         grid_prefix = 'mpassi.ARRM10to60E2r1'
         if ice_ic_mode == 'spunup':
-            logger.warning("WARNING: The specified compset is requesting seaice ICs spunup from a G-case")
-            logger.warning("         But no file available for this grid.")
+            grid_date = '220802'
+            grid_prefix = 'mpassi.ARRM10to60E2r1.rstFrom1monthG-chrys'
 
     elif ice_grid == 'EC30to60E2r2':
         decomp_date = '200908'

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -198,6 +198,15 @@ def buildnml(case, caseroot, compname):
             logger.warning("WARNING: The specified compset is requesting seaice ICs spunup from a G-case")
             logger.warning("         But no file available for this grid.")
 
+    elif ice_grid == 'ARRM10to60E2r1':
+        decomp_date = '220730'
+        decomp_prefix = 'mpas-o.graph.info.'
+        grid_date = '220730'
+        grid_prefix = 'mpassi.ARRM10to60E2r1'
+        if ice_ic_mode == 'spunup':
+            logger.warning("WARNING: The specified compset is requesting seaice ICs spunup from a G-case")
+            logger.warning("         But no file available for this grid.")
+
     elif ice_grid == 'EC30to60E2r2':
         decomp_date = '200908'
         decomp_prefix = 'mpas-seaice.graph.info.'

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -199,8 +199,8 @@ def buildnml(case, caseroot, compname):
             logger.warning("         But no file available for this grid.")
 
     elif ice_grid == 'ARRM10to60E2r1':
-        decomp_date = '220730'
-        decomp_prefix = 'mpas-o.graph.info.'
+        decomp_date = '220802'
+        decomp_prefix = 'mpas-seaice.v2.'
         grid_date = '220730'
         grid_prefix = 'mpassi.ARRM10to60E2r1'
         if ice_ic_mode == 'spunup':

--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -372,6 +372,7 @@
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oRRS15to5">96</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oARRM60to10">96</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oARRM60to6">96</value>
+      <value compset="_DATM.*_SLND.*MPAS" grid="oi%ARRM10to60">96</value>
       <value compset="_EAM.*_ELM.*MPASO">48</value>
       <value compset="_EAM.*_ELM.*MPASO" grid="a%ne11np4">12</value>
       <value compset="_EAM.*_ELM.*MPASO" grid="a%ne120np4">96</value>
@@ -484,6 +485,7 @@
       <value compset="_MPASO" grid="oi%oRRS15to5">96</value>
       <value compset="_MPASO" grid="oi%oARRM60to10">48</value>
       <value compset="_MPASO" grid="oi%oARRM60to6">48</value>
+      <value compset="_MPASO" grid="oi%ARRM10to60">48</value>
 
     </values>
     <group>run_coupling</group>

--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -372,7 +372,6 @@
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oRRS15to5">96</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oARRM60to10">96</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oARRM60to6">96</value>
-      <value compset="_DATM.*_SLND.*MPAS" grid="oi%ARRM10to60">96</value>
       <value compset="_EAM.*_ELM.*MPASO">48</value>
       <value compset="_EAM.*_ELM.*MPASO" grid="a%ne11np4">12</value>
       <value compset="_EAM.*_ELM.*MPASO" grid="a%ne120np4">96</value>
@@ -485,7 +484,6 @@
       <value compset="_MPASO" grid="oi%oRRS15to5">96</value>
       <value compset="_MPASO" grid="oi%oARRM60to10">48</value>
       <value compset="_MPASO" grid="oi%oARRM60to6">48</value>
-      <value compset="_MPASO" grid="oi%ARRM10to60">48</value>
 
     </values>
     <group>run_coupling</group>


### PR DESCRIPTION
Brings in support for the `ARRM10to60E2r1` ocn/ice mesh. https://github.com/MPAS-Dev/compass/pull/414 has details on the mesh generation, which is an updated version of the `oARRM60to10` mesh. This PR includes all necessary mapping, runoff, and domain files for the following configurations:

`ne30pg2_ARRM10to60E2r1`
`arcticx4v1pg2_ARRM10to60E2r1`
`TL319_ARRM10to60E2r1` (JRA-forced)
`T62_ARRM10to60E2r1` (CORE-forced)

*Testing*

The following 5 day smoke tests have been run on Chrysalis:
`WCYCL1950.ne30pg2_ARRM10to60E2r1`
`WCYCL1850.arcticx4v1pg2_ARRM10to60E2r1`
`GMPAS-JRA1p4.TL319_ARRM10to60E2r1`
`GMPAS-IAF.T62_ARRM10to60E2r1`

A `WCYCL1950.ne30pg2_ARRM10to60E2r1` B-case is currently running on Cori as the final check for this mesh, and is in year 26. [Here is the MPAS-Analysis for years 11-20](https://portal.nersc.gov/project/m1199/dcomeau/E3SMv2-Arctic/20220803.WCYCL1950.ne30pg2_ARRM10to60E2r1.baseline.cori-knl/mpas_analysis/ts_0011-0020_climo_0011-0020/ocean/index.html)

[BFB] for all currently tested configurations.