### PR TITLE
Add mpas-framework support for several other attributes

### DIFF
--- a/components/mpas-framework/src/tools/registry/gen_inc.c
+++ b/components/mpas-framework/src/tools/registry/gen_inc.c
@@ -620,21 +620,12 @@ int parse_namelist_records_from_registry(ezxml_t registry)/*{{{*/
 
 			if(strncmp(nmlopttype, "real", 1024) == 0){
 				fortprintf(fd, "      real (kind=RKIND) :: %s = %lf\n", nmloptname, (double)atof(nmloptval));
-				fortprintf(fcd, "      real (kind=RKIND), pointer :: %s\n", nmloptname);
-				if (strstr(nmloptname, "config_") == nmloptname ) {
-                   fortprintf(fcd, "      real (kind=RKIND) :: varinp_%s\n", nmloptname+7);
-                }
+				fortprintf(fcd, "      real (kind=RKIND) :: %s\n", nmloptname);
 			} else if(strncmp(nmlopttype, "integer", 1024) == 0){
 				fortprintf(fd, "      integer :: %s = %d\n", nmloptname, atoi(nmloptval));
-				fortprintf(fcd, "      integer, pointer :: %s\n", nmloptname);
-				if (strstr(nmloptname, "config_") == nmloptname ) {
-				   fortprintf(fcd, "      integer :: varinp_%s\n", nmloptname+7);
-                }
+				fortprintf(fcd, "      integer :: %s\n", nmloptname);
 			} else if(strncmp(nmlopttype, "logical", 1024) == 0){
-				fortprintf(fcd, "      logical, pointer :: %s\n", nmloptname);
-				if (strstr(nmloptname, "config_") == nmloptname ) {
-				   fortprintf(fcd, "      logical :: varinp_%s\n", nmloptname+7);
-                }
+				fortprintf(fcd, "      logical :: %s\n", nmloptname);
 				if(strncmp(nmloptval, "true", 1024) == 0 || strncmp(nmloptval, ".true.", 1024) == 0){
 					fortprintf(fd, "      logical :: %s = .true.\n", nmloptname);
 				} else {
@@ -642,10 +633,7 @@ int parse_namelist_records_from_registry(ezxml_t registry)/*{{{*/
 				}
 			} else if(strncmp(nmlopttype, "character", 1024) == 0){
 					fortprintf(fd, "      character (len=StrKIND) :: %s = '%s'\n", nmloptname, nmloptval);
-					fortprintf(fcd, "      character (len=StrKIND), pointer :: %s\n", nmloptname);
-				    if (strstr(nmloptname, "config_") == nmloptname ) {
-				    	fortprintf(fcd, "      character (len=StrKIND) :: varinp_%s\n", nmloptname+7);
-                    }
+					fortprintf(fcd, "      character (len=StrKIND) :: %s\n", nmloptname);
 			}
 		}
 		fortprintf(fd, "\n");
@@ -734,10 +722,7 @@ int parse_namelist_records_from_registry(ezxml_t registry)/*{{{*/
 			nmloptname = ezxml_attr(nmlopt_xml, "name");
 
 			fortprintf(fd, "      call mpas_pool_add_config(%s, '%s', %s)\n", pool_name, nmloptname, nmloptname);
-			fortprintf(fcg, "      call mpas_pool_get_config(configPool, '%s', %s)\n", nmloptname, nmloptname);
-		    if (strstr(nmloptname, "config_") == nmloptname ) {
-			   fortprintf(fcg, "      call mpas_pool_get_config_scalar(configPool, '%s', varinp_%s)\n", nmloptname, nmloptname+7);
-            }
+			fortprintf(fcg, "      call mpas_pool_get_config_scalar(configPool, '%s', %s)\n", nmloptname, nmloptname);
 		}
 		fortprintf(fd, "\n");
 		fortprintf(fcg, "\n");
@@ -1734,8 +1719,8 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 		if ( varbounds != NULL ) {
 			string = strdup(varbounds);
 			tofree = string;
-
 			token = strsep(&string, "'");
+
 			sprintf(temp_str, "%s", token);
 
 			while ( ( token = strsep(&string, "'") ) != NULL ) {
@@ -1744,14 +1729,14 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 
 			free(tofree);
 
-			fortprintf(fd, "         call mpas_add_att(%s %% attLists(const_index) %% attList, 'bounds', '%s')\n", pointer_name_arr, temp_str);
+			fortprintf(fd, "      call mpas_add_att(%s %% attLists(1) %% attList, 'bounds', '%s')\n", pointer_name_arr, temp_str);
 		}
 
 		if ( varcellmeasures != NULL ) {
 			string = strdup(varcellmeasures);
 			tofree = string;
-
 			token = strsep(&string, "'");
+
 			sprintf(temp_str, "%s", token);
 
 			while ( ( token = strsep(&string, "'") ) != NULL ) {
@@ -1760,14 +1745,14 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 
 			free(tofree);
 
-			fortprintf(fd, "         call mpas_add_att(%s %% attLists(const_index) %% attList, 'cell_measures', '%s')\n", pointer_name_arr, temp_str);
+			fortprintf(fd, "      call mpas_add_att(%s %% attLists(1) %% attList, 'cell_measures', '%s')\n", pointer_name_arr, temp_str);
 		}
 
 		if ( varcellmethod != NULL ) {
 			string = strdup(varcellmethod);
 			tofree = string;
-
 			token = strsep(&string, "'");
+
 			sprintf(temp_str, "%s", token);
 
 			while ( ( token = strsep(&string, "'") ) != NULL ) {
@@ -1776,14 +1761,14 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 
 			free(tofree);
 
-			fortprintf(fd, "         call mpas_add_att(%s %% attLists(const_index) %% attList, 'cell_method', '%s')\n", pointer_name_arr, temp_str);
+			fortprintf(fd, "      call mpas_add_att(%s %% attLists(1) %% attList, 'cell_method', '%s')\n", pointer_name_arr, temp_str);
 		}
 
 		if ( varcoords != NULL ) {
 			string = strdup(varcoords);
 			tofree = string;
-
 			token = strsep(&string, "'");
+
 			sprintf(temp_str, "%s", token);
 
 			while ( ( token = strsep(&string, "'") ) != NULL ) {
@@ -1792,7 +1777,7 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 
 			free(tofree);
 
-			fortprintf(fd, "         call mpas_add_att(%s %% attLists(const_index) %% attList, 'coordinates', '%s')\n", pointer_name_arr, temp_str);
+			fortprintf(fd, "      call mpas_add_att(%s %% attLists(1) %% attList, 'coordinates', '%s')\n", pointer_name_arr, temp_str);
 		}
 
 		if ( varstdname != NULL ) {

--- a/components/mpas-framework/src/tools/registry/gen_inc.c
+++ b/components/mpas-framework/src/tools/registry/gen_inc.c
@@ -1020,6 +1020,7 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 	const char *structname, *structlevs, *structpackages;
 	const char *substructname;
 	const char *vararrname, *vararrtype, *vararrdims, *vararrpersistence, *vararrdefaultval, *vararrpackages, *vararrmissingval;
+	const char *vararrbounds, *vararrcellmeasures, *vararrcellmethod, *vararrcoords, *vararrstdname;
 	const char *varname, *varpersistence, *vartype, *vardims, *varunits, *vardesc, *vararrgroup, *varstreams, *vardefaultval, *varpackages;
 	const char *varbounds, *varcellmeasures, *varcellmethod, *varcoords, *varstdname;
 	const char *varname2, *vararrgroup2, *vararrname_in_code;
@@ -1061,6 +1062,11 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 	vararrpackages = ezxml_attr(var_arr_xml, "packages");
 	vararrtimelevs = ezxml_attr(var_arr_xml, "time_levs");
 	vararrname_in_code = ezxml_attr(var_arr_xml, "name_in_code");
+	vararrbounds = ezxml_attr(var_arr_xml, "bounds");
+	vararrcellmeasures = ezxml_attr(var_arr_xml, "cell_measures");
+	vararrcellmethod = ezxml_attr(var_arr_xml, "cell_method");
+	vararrcoords = ezxml_attr(var_arr_xml, "coordinates");
+	vararrstdname = ezxml_attr(var_arr_xml, "standard_name");
 
 	package_list[0] = '\0';
 	no_packages = build_struct_package_lists(varArray, package_list);
@@ -1433,10 +1439,38 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 				free(tofree);
 
 				fortprintf(fd, "         call mpas_add_att(%s %% attLists(const_index) %% attList, 'bounds', '%s')\n", pointer_name_arr, temp_str);
+			} else if ( vararrbounds != NULL ) {
+				string = strdup(vararrbounds);
+				tofree = string;
+
+				token = strsep(&string, "'");
+				sprintf(temp_str, "%s", token);
+
+				while ( ( token = strsep(&string, "'") ) != NULL ) {
+					sprintf(temp_str, "%s''%s", temp_str, token);
+				}
+
+				free(tofree);
+
+				fortprintf(fd, "         call mpas_add_att(%s %% attLists(const_index) %% attList, 'bounds', '%s')\n", pointer_name_arr, temp_str);
 			}
 
 			if ( varcellmeasures != NULL ) {
 				string = strdup(varcellmeasures);
+				tofree = string;
+
+				token = strsep(&string, "'");
+				sprintf(temp_str, "%s", token);
+
+				while ( ( token = strsep(&string, "'") ) != NULL ) {
+					sprintf(temp_str, "%s''%s", temp_str, token);
+				}
+
+				free(tofree);
+
+				fortprintf(fd, "         call mpas_add_att(%s %% attLists(const_index) %% attList, 'cell_measures', '%s')\n", pointer_name_arr, temp_str);
+			} else if ( vararrcellmeasures != NULL ) {
+				string = strdup(vararrcellmeasures);
 				tofree = string;
 
 				token = strsep(&string, "'");
@@ -1465,6 +1499,20 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 				free(tofree);
 
 				fortprintf(fd, "         call mpas_add_att(%s %% attLists(const_index) %% attList, 'cell_method', '%s')\n", pointer_name_arr, temp_str);
+			} else if ( vararrcellmethod != NULL ) {
+				string = strdup(vararrcellmethod);
+				tofree = string;
+
+				token = strsep(&string, "'");
+				sprintf(temp_str, "%s", token);
+
+				while ( ( token = strsep(&string, "'") ) != NULL ) {
+					sprintf(temp_str, "%s''%s", temp_str, token);
+				}
+
+				free(tofree);
+
+				fortprintf(fd, "         call mpas_add_att(%s %% attLists(const_index) %% attList, 'cell_method', '%s')\n", pointer_name_arr, temp_str);
 			}
 
 			if ( varcoords != NULL ) {
@@ -1481,10 +1529,38 @@ int parse_var_array(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t var
 				free(tofree);
 
 				fortprintf(fd, "         call mpas_add_att(%s %% attLists(const_index) %% attList, 'coordinates', '%s')\n", pointer_name_arr, temp_str);
+			} else if ( vararrcoords != NULL ) {
+				string = strdup(vararrcoords);
+				tofree = string;
+
+				token = strsep(&string, "'");
+				sprintf(temp_str, "%s", token);
+
+				while ( ( token = strsep(&string, "'") ) != NULL ) {
+					sprintf(temp_str, "%s''%s", temp_str, token);
+				}
+
+				free(tofree);
+
+				fortprintf(fd, "         call mpas_add_att(%s %% attLists(const_index) %% attList, 'coordinates', '%s')\n", pointer_name_arr, temp_str);
 			}
 
 			if ( varstdname != NULL ) {
 				string = strdup(varstdname);
+				tofree = string;
+
+				token = strsep(&string, "'");
+				sprintf(temp_str, "%s", token);
+
+				while ( ( token = strsep(&string, "'") ) != NULL ) {
+					sprintf(temp_str, "%s''%s", temp_str, token);
+				}
+
+				free(tofree);
+
+				fortprintf(fd, "         call mpas_add_att(%s %% attLists(const_index) %% attList, 'standard_name', '%s')\n", pointer_name_arr, temp_str);
+			} else if ( vararrstdname != NULL ) {
+				string = strdup(vararrstdname);
 				tofree = string;
 
 				token = strsep(&string, "'");

--- a/components/mpas-framework/src/tools/registry/parse.c
+++ b/components/mpas-framework/src/tools/registry/parse.c
@@ -83,6 +83,7 @@ int validate_reg_xml(ezxml_t registry)/*{{{*/
 	const char *nmloptbounds, *nmloptcellmeasures, *nmloptcellmethod, *nmloptcoords, *nmloptstdname;
 	const char *structname, *structpackages, *structstreams;
 	const char *vararrname, *vararrtype, *vararrdims, *vararrpersistence, *vararrpackages, *vararrstreams;
+	const char *vararrbounds, *vararrcellmeasures, *vararrcellmethod, *vararrcoords, *vararrstdname;
 	const char *varname, *varpersistence, *vartype, *vardims, *varunits, *vardesc, *vararrgroup, *varstreams, *varpackages;
 	const char *varbounds, *varcellmeasures, *varcellmethod, *varcoords, *varstdname;
 	const char *varname_in_code, *varname_in_stream;
@@ -257,6 +258,11 @@ int validate_reg_xml(ezxml_t registry)/*{{{*/
 			vararrtype = ezxml_attr(var_arr_xml, "type");
 			vararrdims = ezxml_attr(var_arr_xml, "dimensions");
 			vararrpersistence = ezxml_attr(var_arr_xml, "persistence");
+                        vararrbounds = ezxml_attr(var_arr_xml, "bounds");
+                        vararrcellmeasures = ezxml_attr(var_arr_xml, "cell_measures");
+                        vararrcellmethod = ezxml_attr(var_arr_xml, "cell_method");
+                        vararrcoords = ezxml_attr(var_arr_xml, "coordinates");
+                        vararrstdname = ezxml_attr(var_arr_xml, "standard_name");
 			vararrpackages = ezxml_attr(var_arr_xml, "packages");
 			vararrstreams = ezxml_attr(var_arr_xml, "streams");
 			time_levs = ezxml_attr(var_arr_xml, "time_levs");

--- a/components/mpas-framework/src/tools/registry/parse.c
+++ b/components/mpas-framework/src/tools/registry/parse.c
@@ -80,9 +80,11 @@ int validate_reg_xml(ezxml_t registry)/*{{{*/
 	const char *dimname, *dimunits, *dimdesc, *dimdef, *dimdecomp;
 	const char *nmlrecname, *nmlrecindef;
 	const char *nmloptname, *nmlopttype, *nmloptval, *nmloptunits, *nmloptdesc, *nmloptposvals, *nmloptindef;
+	const char *nmloptbounds, *nmloptcellmeasures, *nmloptcellmethod, *nmloptcoords, *nmloptstdname;
 	const char *structname, *structpackages, *structstreams;
 	const char *vararrname, *vararrtype, *vararrdims, *vararrpersistence, *vararrpackages, *vararrstreams;
 	const char *varname, *varpersistence, *vartype, *vardims, *varunits, *vardesc, *vararrgroup, *varstreams, *varpackages;
+	const char *varbounds, *varcellmeasures, *varcellmethod, *varcoords, *varstdname;
 	const char *varname_in_code, *varname_in_stream;
 	const char *const_model, *const_core, *const_version;
 	const char *streamname, *streamtype, *streamfilename, *streamrecords, *streaminterval_in, *streaminterval_out, *streampackages, *streamvarpackages;
@@ -125,6 +127,11 @@ int validate_reg_xml(ezxml_t registry)/*{{{*/
 			nmlopttype = ezxml_attr(nmlopt_xml, "type");
 			nmloptval = ezxml_attr(nmlopt_xml, "default_value");
 			nmloptunits = ezxml_attr(nmlopt_xml, "units");
+			nmloptbounds = ezxml_attr(nmlopt_xml, "bounds");
+			nmloptcellmeasures = ezxml_attr(nmlopt_xml, "cell_measures");
+			nmloptcellmethod = ezxml_attr(nmlopt_xml, "cell_method");
+			nmloptcoords = ezxml_attr(nmlopt_xml, "coordinates");
+			nmloptstdname = ezxml_attr(nmlopt_xml, "standard_name");
 			nmloptdesc = ezxml_attr(nmlopt_xml, "description");
 			nmloptposvals = ezxml_attr(nmlopt_xml, "possible_values");
 
@@ -342,6 +349,11 @@ int validate_reg_xml(ezxml_t registry)/*{{{*/
 			for(var_xml = ezxml_child(var_arr_xml, "var"); var_xml; var_xml = var_xml->next){
 				varname = ezxml_attr(var_xml, "name");
 				varunits = ezxml_attr(var_xml, "units");
+				varbounds = ezxml_attr(var_xml, "bounds");
+				varcellmeasures = ezxml_attr(var_xml, "cell_measures");
+				varcellmethod = ezxml_attr(var_xml, "cell_method");
+				varcoords = ezxml_attr(var_xml, "coordinates");
+				varstdname = ezxml_attr(var_xml, "standard_name");
 				vardesc = ezxml_attr(var_xml, "description");
 				vararrgroup = ezxml_attr(var_xml, "array_group");
 				varname_in_code = ezxml_attr(var_xml, "name_in_code");
@@ -399,6 +411,11 @@ int validate_reg_xml(ezxml_t registry)/*{{{*/
 			vartype = ezxml_attr(var_xml, "type");
 			vardims = ezxml_attr(var_xml, "dimensions");
 			varunits = ezxml_attr(var_xml, "units");
+			varbounds = ezxml_attr(var_xml, "bounds");
+			varcellmeasures = ezxml_attr(var_xml, "cell_measures");
+			varcellmethod = ezxml_attr(var_xml, "cell_method");
+			varcoords = ezxml_attr(var_xml, "coordinates");
+			varstdname = ezxml_attr(var_xml, "standard_name");
 			vardesc = ezxml_attr(var_xml, "description");
 			varname_in_code = ezxml_attr(var_xml, "name_in_code");
 			varpackages = ezxml_attr(var_xml, "packages");


### PR DESCRIPTION
Adds parsing support to the mpas-framework for the following attributes:
* bounds
* cell_measures
* cell_method
* coordinates
* standard_name
See discussion in [E3SM-Ocean-Discussion PR #28](https://github.com/E3SM-Ocean-Discussion/E3SM/pull/28)

[BFB]