### PR TITLE
move ocean namelist transport_tests to testing section

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -1691,7 +1691,6 @@ my @groups = qw(run_modes
                 time_management
                 io
                 decomposition
-                transport_tests
                 time_integration
                 hmix
                 hmix_del2
@@ -1725,6 +1724,7 @@ my @groups = qw(run_modes
                 ale_frequency_filtered_thickness
                 debug
                 testing
+                transport_tests
                 init_mode_vert_levels
                 tracer_forcing_activetracers
                 tracer_forcing_debugtracers

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -496,15 +496,6 @@ add_default($nl, 'config_number_of_blocks');
 add_default($nl, 'config_explicit_proc_decomp');
 add_default($nl, 'config_proc_decomp_file_prefix');
 
-###################################
-# Namelist group: transport_tests #
-###################################
-
-add_default($nl, 'config_transport_tests_vert_levels');
-add_default($nl, 'config_transport_tests_temperature');
-add_default($nl, 'config_transport_tests_salinity');
-add_default($nl, 'config_transport_tests_flow_id');
-
 ####################################
 # Namelist group: time_integration #
 ####################################
@@ -952,6 +943,15 @@ add_default($nl, 'config_read_nearest_restart');
 add_default($nl, 'config_conduct_tests');
 add_default($nl, 'config_test_tensors');
 add_default($nl, 'config_tensor_test_function');
+
+###################################
+# Namelist group: transport_tests #
+###################################
+
+add_default($nl, 'config_transport_tests_vert_levels');
+add_default($nl, 'config_transport_tests_temperature');
+add_default($nl, 'config_transport_tests_salinity');
+add_default($nl, 'config_transport_tests_flow_id');
 
 #########################################
 # Namelist group: init_mode_vert_levels #

--- a/components/mpas-ocean/bld/build-namelist-group-list
+++ b/components/mpas-ocean/bld/build-namelist-group-list
@@ -2,7 +2,6 @@ my @groups = qw(run_modes
                 time_management
                 io
                 decomposition
-                transport_tests
                 time_integration
                 hmix
                 hmix_del2
@@ -36,6 +35,7 @@ my @groups = qw(run_modes
                 ale_frequency_filtered_thickness
                 debug
                 testing
+                transport_tests
                 init_mode_vert_levels
                 tracer_forcing_activetracers
                 tracer_forcing_debugtracers

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -39,15 +39,6 @@ add_default($nl, 'config_number_of_blocks');
 add_default($nl, 'config_explicit_proc_decomp');
 add_default($nl, 'config_proc_decomp_file_prefix');
 
-###################################
-# Namelist group: transport_tests #
-###################################
-
-add_default($nl, 'config_transport_tests_vert_levels');
-add_default($nl, 'config_transport_tests_temperature');
-add_default($nl, 'config_transport_tests_salinity');
-add_default($nl, 'config_transport_tests_flow_id');
-
 ####################################
 # Namelist group: time_integration #
 ####################################
@@ -485,6 +476,15 @@ add_default($nl, 'config_read_nearest_restart');
 add_default($nl, 'config_conduct_tests');
 add_default($nl, 'config_test_tensors');
 add_default($nl, 'config_tensor_test_function');
+
+###################################
+# Namelist group: transport_tests #
+###################################
+
+add_default($nl, 'config_transport_tests_vert_levels');
+add_default($nl, 'config_transport_tests_temperature');
+add_default($nl, 'config_transport_tests_salinity');
+add_default($nl, 'config_transport_tests_flow_id');
 
 #########################################
 # Namelist group: init_mode_vert_levels #

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -27,12 +27,6 @@
 <config_explicit_proc_decomp>.false.</config_explicit_proc_decomp>
 <config_proc_decomp_file_prefix>'graph.info.part.'</config_proc_decomp_file_prefix>
 
-<!-- transport_tests -->
-<config_transport_tests_vert_levels>3</config_transport_tests_vert_levels>
-<config_transport_tests_temperature>15</config_transport_tests_temperature>
-<config_transport_tests_salinity>35</config_transport_tests_salinity>
-<config_transport_tests_flow_id>0</config_transport_tests_flow_id>
-
 <!-- time_integration -->
 <config_dt ocn_grid="oQU480">'02:00:00'</config_dt>
 <config_dt ocn_grid="oQU240">'01:00:00'</config_dt>
@@ -504,6 +498,12 @@
 <config_conduct_tests>.false.</config_conduct_tests>
 <config_test_tensors>.false.</config_test_tensors>
 <config_tensor_test_function>'sph_uCosCos'</config_tensor_test_function>
+
+<!-- transport_tests -->
+<config_transport_tests_vert_levels>3</config_transport_tests_vert_levels>
+<config_transport_tests_temperature>15.0</config_transport_tests_temperature>
+<config_transport_tests_salinity>35.0</config_transport_tests_salinity>
+<config_transport_tests_flow_id>0</config_transport_tests_flow_id>
 
 <!-- init_mode_vert_levels -->
 <config_vert_levels>-1</config_vert_levels>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -182,41 +182,6 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 
-<!-- transport_tests -->
-
-<entry id="config_transport_tests_vert_levels" type="integer"
-	category="transport_tests" group="transport_tests">
-Number of vertical levels in transport_tests. Typical value is 3 for 2D tests.
-
-Valid values: Any positive integer number greater than 0.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_transport_tests_temperature" type="real"
-	category="transport_tests" group="transport_tests">
-Temperature of the ocean.
-
-Valid values: Any real number
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_transport_tests_salinity" type="real"
-	category="transport_tests" group="transport_tests">
-Salinity of the ocean.
-
-Valid values: Any real number
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_transport_tests_flow_id" type="integer"
-	category="transport_tests" group="transport_tests">
-integer id of transport test.
-
-Valid values: 1 = rotation, 2 = nondivergent2D, 3 = divergent2D, 4 = correlatedTracers2D
-Default: Defined in namelist_defaults.xml
-</entry>
-
-
 <!-- time_integration -->
 
 <entry id="config_dt" type="char*1024"
@@ -2496,6 +2461,41 @@ Default: Defined in namelist_defaults.xml
 Character string to choose tensor test fuction
 
 Valid values: 'linear_x', 'linear_y', 'linear_arb_rot', 'power_x', 'power_y', 'power_arb_rot', 'sin_arb_rot', 'sph_solid_body', 'sph_Williamson', 'sph_uCosCos', 'sph_vCosCos', 'sph_ELonLon_CosCos', 'sph_ELatLat_CosCos', 'sph_ELonLat_CosCos'
+Default: Defined in namelist_defaults.xml
+</entry>
+
+
+<!-- transport_tests -->
+
+<entry id="config_transport_tests_vert_levels" type="integer"
+	category="transport_tests" group="transport_tests">
+Number of vertical levels in transport_tests. Typical value is 3 for 2D tests.
+
+Valid values: Any positive integer number greater than 0.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_transport_tests_temperature" type="real"
+	category="transport_tests" group="transport_tests">
+Temperature of the ocean.
+
+Valid values: Any real number
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_transport_tests_salinity" type="real"
+	category="transport_tests" group="transport_tests">
+Salinity of the ocean.
+
+Valid values: Any real number
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_transport_tests_flow_id" type="integer"
+	category="transport_tests" group="transport_tests">
+integer id of transport test.
+
+Valid values: 1 = rotation, 2 = nondivergent2D, 3 = divergent2D, 4 = correlatedTracers2D
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -17,7 +17,7 @@
           An abbreviation of the fortran declaration for the variable.
       Valid declarations are:
 
-          char*n
+          char*n  
           integer
           logical
           real
@@ -31,7 +31,7 @@
      input_pathname
           Only include this attribute to indicate that the variable
           contains the pathname of an input dataset that resides in the
-          CESM inputdata directory tree.
+          CESM inputdata directory tree.  
 
       The recognized values are "abs" to indicate that an absolute
           pathname is required, or "rel:var_name" to indicate that the
@@ -1196,7 +1196,7 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_sw_absorption_type" type="char*1024"
 	category="shortwaveRadiation" group="shortwaveRadiation">
-Name of shortwave absorption type used in simulation.
+Name of shortwave absorption type used in simulation. 
 
 Valid values: 'jerlov' or 'ohlmann00' or 'none'
 Default: Defined in namelist_defaults.xml
@@ -2595,7 +2595,7 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_salinity_restoring_max_difference" type="real"
 	category="tracer_forcing_activeTracers" group="tracer_forcing_activeTracers">
-Maximum allowable difference between surface salinity and climatology.
+Maximum allowable difference between surface salinity and climatology, in grams salt per kilogram seawater.
 
 Valid values: any non-negative number
 Default: Defined in namelist_defaults.xml

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -176,24 +176,6 @@
 					possible_values="Any path/prefix to a processor decomposition file."
 		/>
 	</nml_record>
-  <nml_record name="transport_tests" mode="init;forward" configuration="transport_tests">
-    <nml_option name="config_transport_tests_vert_levels" type="integer" default_value="3"
-      description="Number of vertical levels in transport_tests. Typical value is 3 for 2D tests."
-      possible_values="Any positive integer number greater than 0."
-    />
-    <nml_option name="config_transport_tests_temperature" type="real" default_value="15.0" units="deg C"
-      description="Temperature of the ocean."
-      possible_values="Any real number"
-    />
-    <nml_option name="config_transport_tests_salinity" type="real" default_value="35.0" units="1.e-3"
-      description="Salinity of the ocean."
-      possible_values="Any real number"
-    />
-    <nml_option name="config_transport_tests_flow_id" type="integer" default_value="0"
-     description="integer id of transport test."
-     possible_values="1 = rotation, 2 = nondivergent2D, 3 = divergent2D, 4 = correlatedTracers2D"
-    />
-  </nml_record>
 
 
 	<!--*************************************-->
@@ -1496,6 +1478,24 @@
 		<nml_option name="config_tensor_test_function" type="character" default_value="sph_uCosCos"
 					description="Character string to choose tensor test fuction"
 					possible_values="'linear_x', 'linear_y', 'linear_arb_rot', 'power_x', 'power_y', 'power_arb_rot', 'sin_arb_rot', 'sph_solid_body', 'sph_Williamson', 'sph_uCosCos', 'sph_vCosCos', 'sph_ELonLon_CosCos', 'sph_ELatLat_CosCos', 'sph_ELonLat_CosCos'"
+		/>
+	</nml_record>
+	<nml_record name="transport_tests" mode="init;forward" configuration="transport_tests">
+		<nml_option name="config_transport_tests_vert_levels" type="integer" default_value="3"
+					description="Number of vertical levels in transport_tests. Typical value is 3 for 2D tests."
+					possible_values="Any positive integer number greater than 0."
+		/>
+		<nml_option name="config_transport_tests_temperature" type="real" default_value="15.0" units="deg C"
+					description="Temperature of the ocean."
+					possible_values="Any real number"
+		/>
+		<nml_option name="config_transport_tests_salinity" type="real" default_value="35.0" units="1.e-3"
+					description="Salinity of the ocean."
+					possible_values="Any real number"
+		/>
+		<nml_option name="config_transport_tests_flow_id" type="integer" default_value="0"
+					description="integer id of transport test."
+					possible_values="1 = rotation, 2 = nondivergent2D, 3 = divergent2D, 4 = correlatedTracers2D"
 		/>
 	</nml_record>
 	<nml_record name="init_mode_vert_levels">


### PR DESCRIPTION
The namelist is generally ordered by importance, and the transport_tests was inadvertently added at the top, rather than with the testing section near the bottom. This also cleans up white space for that namelist in the Registry file.

[NML]
[BFB]