### PR TITLE
Change defunct Fortran line labels to end do

### DIFF
--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_harmonic_analysis.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_harmonic_analysis.F
@@ -806,14 +806,12 @@ contains
 
 !     solve for x by back-substituting for l(tr)*x=c
 
-      ir=mm
- 140  continue
-      hax(ir)=c(ir)
-      do jr=ir+1,mm
-         hax(ir)=hax(ir)-ha(ir,jr)*hax(jr)
+      do ir = mm,1,-1
+         hax(ir)=c(ir)
+         do jr=ir+1,mm
+            hax(ir)=hax(ir)-ha(ir,jr)*hax(jr)
+         end do
       end do
-      ir=ir-1
-      if(ir.ge.1) goto 140
 
       end subroutine least_squares_solve!}}}
 

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_harmonic_analysis.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_harmonic_analysis.F
@@ -748,7 +748,7 @@ contains
          do j=ire,mm
             ha(ir,j)=ha(ir,j)/ha(ir,ir)
          end do
-         if (ire.gt.mm) cycle
+         if (ire.gt.mm) exit
          do j=ire,mm
            do k=ire,mm
               ha(k,j)=ha(k,j)-ha(k,ir)*ha(ir,j)

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_harmonic_analysis.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_harmonic_analysis.F
@@ -743,18 +743,21 @@ contains
 
 !     Decomposition of matrix 
 
-      do 100 ir=1,mm
+      do ir=1,mm
          ire=ir+1
-         do 20 j=ire,mm
- 20         ha(ir,j)=ha(ir,j)/ha(ir,ir)
-         if (ire.gt.mm) goto 100
-         do 40 j=ire,mm
-           do 40 k=ire,mm
- 40           ha(k,j)=ha(k,j)-ha(k,ir)*ha(ir,j)
-         do 50 j=ire,mm
- 50        ha(j,ir)=0.0_RKIND
- 100  continue
-
+         do j=ire,mm
+            ha(ir,j)=ha(ir,j)/ha(ir,ir)
+         end do
+         if (ire.gt.mm) cycle
+         do j=ire,mm
+           do k=ire,mm
+              ha(k,j)=ha(k,j)-ha(k,ir)*ha(ir,j)
+           end do
+         end do
+         do j=ire,mm
+           ha(j,ir)=0.0_RKIND
+         end do
+      end do
 
       end subroutine least_squares_decompose !}}}
 
@@ -788,24 +791,27 @@ contains
 
 !     solve for y by forward substitution for l*y=p
 
-      do 120 ir=1,mm
+      do ir=1,mm
          y(ir)=hap(ir)
-         do 110 jr=1,ir-1
- 110        y(ir)=y(ir)-ha(jr,ir)*y(jr)
- 120  continue
+         do jr=1,ir-1
+            y(ir)=y(ir)-ha(jr,ir)*y(jr)
+         end do
+      end do
 
 !     calculate c=d**(-1)*y
 
-      do 130 ir=1,mm
- 130     c(ir)=y(ir)/ha(ir,ir)
+      do ir=1,mm
+         c(ir)=y(ir)/ha(ir,ir)
+      end do
 
 !     solve for x by back-substituting for l(tr)*x=c
 
       ir=mm
  140  continue
       hax(ir)=c(ir)
-      do 150 jr=ir+1,mm
- 150     hax(ir)=hax(ir)-ha(ir,jr)*hax(jr)
+      do jr=ir+1,mm
+         hax(ir)=hax(ir)-ha(ir,jr)*hax(jr)
+      end do
       ir=ir-1
       if(ir.ge.1) goto 140
 


### PR DESCRIPTION
Update from numerical line labels to closing `end do`. 

Fixes #5188
[BFB]