### PR TITLE
Replace device_resident and other OpenACC fixes for ocean

### DIFF
--- a/cime_config/machines/Depends.pgigpu.cmake
+++ b/cime_config/machines/Depends.pgigpu.cmake
@@ -123,6 +123,7 @@ list(APPEND MPAS_ADD_ACC_FLAGS
   ${CMAKE_BINARY_DIR}/core_ocean/shared/mpas_ocn_surface_land_ice_fluxes.f90
   ${CMAKE_BINARY_DIR}/core_ocean/shared/mpas_ocn_tendency.f90
   ${CMAKE_BINARY_DIR}/core_ocean/shared/mpas_ocn_thick_hadv.f90
+  ${CMAKE_BINARY_DIR}/core_ocean/shared/mpas_ocn_thick_ale.f90
   ${CMAKE_BINARY_DIR}/core_ocean/shared/mpas_ocn_thick_surface_flux.f90
   ${CMAKE_BINARY_DIR}/core_ocean/shared/mpas_ocn_thick_vadv.f90
   ${CMAKE_BINARY_DIR}/core_ocean/shared/mpas_ocn_tidal_forcing.f90

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -734,7 +734,8 @@ module ocn_time_integration_rk4
          call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, scratchPool, tracersPool, 2)
 
          ! Update the effective desnity in land ice if we're coupling to land ice
-         call ocn_effective_density_in_land_ice_update(meshPool, forcingPool, statePool, err)
+         call ocn_effective_density_in_land_ice_update(forcingPool, &
+                                                       statePool, err)
 
 #ifdef MPAS_OPENACC
          !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -898,12 +898,12 @@ module ocn_time_integration_rk4
 
       ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
       if (associated(highFreqThicknessProvis)) then
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
+         call ocn_vert_transport_velocity_top(verticalMeshPool, &
             layerThicknessCur,layerThickEdgeFlux, normalVelocityProvis, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
+         call ocn_vert_transport_velocity_top(verticalMeshPool, &
             layerThicknessCur,layerThickEdgeFlux, normalVelocityProvis, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err)
@@ -971,12 +971,12 @@ module ocn_time_integration_rk4
 
       ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
       if (associated(highFreqThicknessProvis)) then
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
+         call ocn_vert_transport_velocity_top(verticalMeshPool, &
             layerThicknessCur, layerThickEdgeFlux, normalTransportVelocity, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
+         call ocn_vert_transport_velocity_top(verticalMeshPool, &
             layerThicknessCur, layerThickEdgeFlux, normalTransportVelocity, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err)
@@ -1045,12 +1045,12 @@ module ocn_time_integration_rk4
 
       ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
       if (associated(highFreqThicknessProvis)) then
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
+         call ocn_vert_transport_velocity_top(verticalMeshPool, &
             layerThicknessCur, layerThickEdgeFlux, normalTransportVelocity, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
+         call ocn_vert_transport_velocity_top(verticalMeshPool, &
             layerThicknessCur, layerThickEdgeFlux, normalTransportVelocity, &
             sshCur, rkSubstepWeight, &
             vertAleTransportTop, err)
@@ -1108,12 +1108,12 @@ module ocn_time_integration_rk4
 
       ! advection of u uses u, while advection of layerThickness and tracers use normalTransportVelocity.
       if (associated(highFreqThicknessProvis)) then
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
+         call ocn_vert_transport_velocity_top(verticalMeshPool, &
             layerThicknessCur,layerThickEdgeFlux, normalVelocityProvis, &
             sshCur, rkWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
+         call ocn_vert_transport_velocity_top(verticalMeshPool, &
             layerThicknessCur,layerThickEdgeFlux, normalVelocityProvis, &
             sshCur, rkWeight, &
             vertAleTransportTop, err)
@@ -1122,12 +1122,12 @@ module ocn_time_integration_rk4
       call ocn_tend_vel(domain, tendPool, provisStatePool, forcingPool, 1, dminfo, dt)
 
       if (associated(highFreqThicknessProvis)) then
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
+         call ocn_vert_transport_velocity_top(verticalMeshPool, &
             layerThicknessCur, layerThickEdgeFlux, normalTransportVelocity, &
             sshCur, rkWeight, &
             vertAleTransportTop, err, highFreqThicknessProvis)
       else
-         call ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, &
+         call ocn_vert_transport_velocity_top(verticalMeshPool, &
             layerThicknessCur, layerThickEdgeFlux, normalTransportVelocity, &
             sshCur, rkWeight, &
             vertAleTransportTop, err)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -773,12 +773,12 @@ module ocn_time_integration_si
          ! Use the most recent time level available.
 
          if (associated(highFreqThicknessNew)) then
-            call ocn_vert_transport_velocity_top(meshPool, &
+            call ocn_vert_transport_velocity_top( &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdgeFlux, normalVelocityCur, sshCur, dt, &
                  vertAleTransportTop, err, highFreqThicknessNew)
          else
-            call ocn_vert_transport_velocity_top(meshPool, &
+            call ocn_vert_transport_velocity_top( &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdgeFlux, normalVelocityCur, sshCur, dt, &
                  vertAleTransportTop, err)
@@ -1790,7 +1790,7 @@ module ocn_time_integration_si
 #ifdef MPAS_OPENACC
             !$acc enter data copyin(highFreqThicknessNew)
 #endif
-            call ocn_vert_transport_velocity_top(meshPool, &
+            call ocn_vert_transport_velocity_top( &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdgeFlux, normalTransportVelocity, sshCur, &
                  dt, vertAleTransportTop, err, highFreqThicknessNew)
@@ -1798,7 +1798,7 @@ module ocn_time_integration_si
             !$acc exit data delete(highFreqThicknessNew)
 #endif
          else
-            call ocn_vert_transport_velocity_top(meshPool, &
+            call ocn_vert_transport_velocity_top( &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdgeFlux, normalTransportVelocity, sshCur, &
                  dt, vertAleTransportTop, err)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -2504,8 +2504,8 @@ module ocn_time_integration_si
 
       ! Update the effective desnity in land ice if we're coupling to
       ! land ice
-      call ocn_effective_density_in_land_ice_update(meshPool, &
-                                       forcingPool, statePool, err)
+      call ocn_effective_density_in_land_ice_update(forcingPool, &
+                                                    statePool, err)
 
       call mpas_timer_start('si final mpas reconstruct', .false.)
 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -684,12 +684,12 @@ module ocn_time_integration_split
          ! Use the most recent time level available.
 
          if (associated(highFreqThicknessNew)) then
-            call ocn_vert_transport_velocity_top(meshPool, &
+            call ocn_vert_transport_velocity_top( &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdgeFlux, normalVelocityCur, sshCur, dt, &
                  vertAleTransportTop, err, highFreqThicknessNew)
          else
-            call ocn_vert_transport_velocity_top(meshPool, &
+            call ocn_vert_transport_velocity_top( &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdgeFlux, normalVelocityCur, sshCur, dt, &
                  vertAleTransportTop, err)
@@ -1685,7 +1685,7 @@ module ocn_time_integration_split
 #ifdef MPAS_OPENACC
             !$acc enter data copyin(highFreqThicknessNew)
 #endif
-            call ocn_vert_transport_velocity_top(meshPool, &
+            call ocn_vert_transport_velocity_top( &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdgeFlux, normalTransportVelocity, sshCur, &
                  dt, vertAleTransportTop, err, highFreqThicknessNew)
@@ -1693,7 +1693,7 @@ module ocn_time_integration_split
             !$acc exit data delete(highFreqThicknessNew)
 #endif
          else
-            call ocn_vert_transport_velocity_top(meshPool, &
+            call ocn_vert_transport_velocity_top( &
                  verticalMeshPool, layerThicknessCur, &
                  layerThickEdgeFlux, normalTransportVelocity, sshCur, &
                  dt, vertAleTransportTop, err)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -2578,8 +2578,8 @@ module ocn_time_integration_split
 
       ! Update the effective desnity in land ice if we're coupling to
       ! land ice
-      call ocn_effective_density_in_land_ice_update(meshPool, &
-                                       forcingPool, statePool, err)
+      call ocn_effective_density_in_land_ice_update(forcingPool, &
+                                                    statePool, err)
 
       call mpas_timer_start('se final mpas reconstruct', .false.)
 

--- a/components/mpas-ocean/src/shared/Makefile
+++ b/components/mpas-ocean/src/shared/Makefile
@@ -88,7 +88,7 @@ mpas_ocn_diagnostics_variables.o: mpas_ocn_config.o
 
 mpas_ocn_mesh.o: mpas_ocn_config.o
 
-mpas_ocn_thick_ale.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_thick_ale.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o
 
 mpas_ocn_time_average_coupled.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_tracer_ecosys.o mpas_ocn_tracer_DMS.o mpas_ocn_tracer_MacroMolecules.o mpas_ocn_diagnostics_variables.o
 

--- a/components/mpas-ocean/src/shared/Makefile
+++ b/components/mpas-ocean/src/shared/Makefile
@@ -186,7 +186,7 @@ mpas_ocn_tidal_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_equati
 
 mpas_ocn_transport_tests.o: mpas_ocn_config.o
 
-mpas_ocn_effective_density_in_land_ice.o: mpas_ocn_constants.o mpas_ocn_config.o
+mpas_ocn_effective_density_in_land_ice.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o
 
 mpas_ocn_forcing_restoring.o: mpas_ocn_constants.o mpas_ocn_config.o
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -2606,91 +2606,81 @@ contains
 !>  cell.
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_vert_transport_velocity_top(meshPool, verticalMeshPool, oldLayerThickness, layerThicknessEdgeFlux, &
-     normalVelocity, oldSSH, dt, vertAleTransportTop, err, newHighFreqThickness)!{{{
+
+   subroutine ocn_vert_transport_velocity_top(verticalMeshPool, &
+                     oldLayerThickness, layerThicknessEdgeFlux, &
+                     normalVelocity, oldSSH, dt, vertAleTransportTop, &
+                     err, newHighFreqThickness)!{{{
 
       !-----------------------------------------------------------------
-      !
       ! input variables
-      !
       !-----------------------------------------------------------------
 
       type (mpas_pool_type), intent(in) :: &
-         meshPool           !< Input: horizonal mesh information
-
-      type (mpas_pool_type), intent(in) :: &
-         verticalMeshPool   !< Input: vertical mesh information
-
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         oldLayerThickness    !< Input: layer thickness at old time
-
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdgeFlux     !< Input: layerThickness interpolated to an edge
-
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         normalVelocity     !< Input: transport
+         verticalMeshPool         !< [in] vertical mesh information
 
       real (kind=RKIND), dimension(:), intent(in) :: &
-         oldSSH     !< Input: sea surface height at old time
+         oldSSH                   !< [in] sea surface height at old time
 
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         oldLayerThickness,      &!< [in] layer thickness at old time
+         layerThicknessEdgeFlux, &!< [in] layerThickness at edge
+         normalVelocity           !< [in] transport
+
+      !  alters ALE thickness when freq-filtering
       real (kind=RKIND), dimension(:,:), intent(in), optional :: &
-         newHighFreqThickness   !< Input: high frequency thickness.  Alters ALE thickness.
+         newHighFreqThickness     !< [in] high frequency thickness
 
       real (kind=RKIND), intent(in) :: &
          dt     !< Input: time step
 
       !-----------------------------------------------------------------
-      !
       ! output variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(out) :: &
-         vertAleTransportTop     !< Output: vertical transport at top of cell
+         vertAleTransportTop     !< [out] vertical transport top of cell
 
-      integer, intent(out) :: err !< Output: error flag
+      integer, intent(out) :: err !< [out] error flag
 
       !-----------------------------------------------------------------
-      !
       ! local variables
-      !
       !-----------------------------------------------------------------
 
-      integer :: iEdge, iCell, k, i, nCells, kmin, kmax
+      integer :: &
+         iEdge, iCell, k, i, &! edge, cell, vert, nbr indices
+         nCells,             &! number of cells
+         kmin, kmax           ! min/max layer indices for active layers
 
-      real (kind=RKIND) :: flux, invAreaCell1, div_hu_btr
-      integer, dimension(:,:), pointer :: edgeSignOnCell
+      real (kind=RKIND) :: &
+         flux,         &!
+         invAreaCell1, &! 1/cell area
+         div_hu_btr     ! divergence of h*u for barotropic u
 
-      ! Scratch Arrays
-      ! projectedSSH: projected SSH at a new time
-      !        units: none
-      real (kind=RKIND), dimension(:), allocatable ::  projectedSSH
-      ! div_hu: divergence of (thickness*velocity)
-      !  units: none
-      real (kind=RKIND), dimension(:,:), allocatable :: div_hu
-      ! ALE_Thickness: ALE thickness at new time
-      !         units: none
-      real (kind=RKIND), dimension(:,:), allocatable :: ALE_Thickness
-#ifdef MPAS_OPENACC
-      !$acc declare device_resident(div_hu)
-#endif
+      real (kind=RKIND), dimension(:), allocatable :: &
+         projectedSSH ! projectedSSH: projected SSH at a new time
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         div_hu,       &! divergence of (thickness*velocity)
+         ALE_Thickness  ! ALE thickness at new time
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
 
       err = 0
 
       if (config_vert_coord_movement == 'impermeable_interfaces' .or. &
           configVertAdvMethod == vertAdvRemap) then
-        vertAleTransportTop=0.0_RKIND
-        !$acc update device(vertAleTransportTop)
-        return
+         vertAleTransportTop = 0.0_RKIND
+         !$acc update device(vertAleTransportTop)
+         return
       end if
 
-      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
-
-      ncells = nCellsAll
-
-      allocate(div_hu(nVertLevels, nCells), &
-               projectedSSH(nCells), &
-               ALE_Thickness(nVertLevels, nCells))
+      allocate(div_hu(nVertLevels, nCellsAll), &
+               projectedSSH(nCellsAll), &
+               ALE_Thickness(nVertLevels, nCellsAll))
+      !$acc enter data create(projectedSSH, ALE_Thickness, div_hu)
 
       ! Only need to compute over 0 and 1 halos
       nCells = nCellsHalo( 1 )
@@ -2700,21 +2690,22 @@ contains
       !
       ! See Ringler et al. (2010) jcp paper, eqn 19, 21, and fig. 3.
 #ifdef MPAS_OPENACC
-      !$acc enter data create(projectedSSH, ALE_Thickness) &
-      !$acc            copyin(edgeSignOnCell)
-
       !$acc parallel loop &
-      !$acc          present(invAreaCell, nEdgesOnCell, edgesOnCell, maxLevelEdgeTop, &
-      !$acc                  layerThicknessEdgeFlux, normalVelocity, dvEdge, edgeSignOnCell, &
-      !$acc                  oldSSH, projectedSSH, minLevelEdgeBot) &
-      !$acc          private(div_hu_btr, invAreaCell1, i, iEdge, flux, k, kmin, kmax)
+      !$acc    present(projectedSSH, oldSSH, normalVelocity, div_hu, &
+      !$acc            layerThicknessEdgeFlux, dvEdge, invAreaCell, &
+      !$acc            nEdgesOnCell, edgesOnCell, edgeSignOnCell, &
+      !$acc            minLevelEdgeBot, maxLevelEdgeTop) &
+      !$acc    private(i, iEdge, k, kmin, kmax, div_hu_btr, &
+      !$acc            invAreaCell1, flux)
 #else
       !$omp parallel
-      !$omp do schedule(runtime) private(invAreaCell1, i, iEdge, k, flux, div_hu_btr, kmin, kmax)
+      !$omp do schedule(runtime) &
+      !$omp    private(i, iEdge, k, kmin, kmax, div_hu_btr, &
+      !$omp            invAreaCell1, flux)
 #endif
       do iCell = 1, nCells
          div_hu(:,iCell) = 0.0_RKIND
-         div_hu_btr = 0.0_RKIND
+         div_hu_btr      = 0.0_RKIND
          invAreaCell1 = invAreaCell(iCell)
          do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
@@ -2722,18 +2713,16 @@ contains
             kmax = maxLevelEdgeTop(iEdge)
 
             do k = kmin, kmax
-               flux = layerThicknessEdgeFlux(k, iEdge) * normalVelocity(k, iEdge) * dvEdge(iEdge) * edgeSignOnCell(i, iCell) &
-                    * invAreaCell1
+               flux = layerThicknessEdgeFlux(k,iEdge)* &
+                      normalVelocity(k,iEdge)*dvEdge(iEdge)* &
+                      edgeSignOnCell(i,iCell) * invAreaCell1
                div_hu(k,iCell) = div_hu(k,iCell) - flux
                div_hu_btr = div_hu_btr - flux
             end do
          end do
          projectedSSH(iCell) = oldSSH(iCell) - dt*div_hu_btr
       end do
-#ifdef MPAS_OPENACC
-      !$acc update host(projectedSSH)
-      !$acc exit data delete(edgeSignOnCell)
-#else
+#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
 #endif
@@ -2742,21 +2731,22 @@ contains
       ! Compute desired thickness at new time
       !
       if (present(newHighFreqThickness)) then
-        call ocn_ALE_thickness(meshPool, verticalMeshPool, projectedSSH, ALE_thickness, err, newHighFreqThickness)
+        call ocn_ALE_thickness(verticalMeshPool, projectedSSH, &
+                               ALE_thickness, err, newHighFreqThickness)
       else
-        call ocn_ALE_thickness(meshPool, verticalMeshPool, projectedSSH, ALE_thickness, err)
+        call ocn_ALE_thickness(verticalMeshPool, projectedSSH, &
+                               ALE_thickness, err)
       endif
 
       !
       ! Vertical transport through layer interfaces
       !
-      ! Vertical transport through layer interface at top and bottom is zero.
-      ! Here we are using solving the continuity equation for vertAleTransportTop ($w^t$),
-      ! and using ALE_Thickness for thickness at the new time.
+      ! Vertical transport through layer interface at top and
+      ! bottom is zero. Here we are using solving the continuity
+      ! equation for vertAleTransportTop ($w^t$), and using
+      ! ALE_Thickness for thickness at the new time.
 
 #ifdef MPAS_OPENACC
-      !$acc update device(ALE_Thickness)
-
       !$acc parallel loop gang vector &
       !$acc          present(vertAleTransportTop, maxLevelCell, ALE_Thickness, &
       !$acc                  oldLayerThickness, minLevelCell) &
@@ -2766,23 +2756,28 @@ contains
       !$omp do schedule(runtime) private(k)
 #endif
       do iCell = 1,nCells
+         kmin = minLevelCell(iCell)
+         kmax = maxLevelCell(iCell)
          vertAleTransportTop(1,iCell) = 0.0_RKIND
-         vertAleTransportTop(maxLevelCell(iCell)+1,iCell) = 0.0_RKIND
-         do k = maxLevelCell(iCell), minLevelCell(iCell)+1, -1
-            vertAleTransportTop(k,iCell) = vertAleTransportTop(k+1,iCell) - div_hu(k,iCell) &
-              - (ALE_Thickness(k,iCell) - oldLayerThickness(k,iCell))/dt
+         vertAleTransportTop(kmax+1,iCell) = 0.0_RKIND
+         do k = kmax, kmin+1, -1
+            vertAleTransportTop(k,iCell) = &
+                vertAleTransportTop(k+1,iCell) - div_hu(k,iCell) &
+                     - (ALE_Thickness(k,iCell) - &
+                        oldLayerThickness(k,iCell))/dt
          end do
       end do
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(projectedSSH, ALE_Thickness)
-#else
+#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
 #endif
 
+      !$acc exit data delete(projectedSSH, ALE_Thickness, div_hu)
       deallocate(div_hu, &
                  projectedSSH, &
                  ALE_Thickness)
+
+   !--------------------------------------------------------------------
 
    end subroutine ocn_vert_transport_velocity_top!}}}
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -1213,7 +1213,7 @@ contains
          ! Modify PV edge with upstream bias.
          !
 #ifdef MPAS_OPENACC
-         !$acc parallel loop, &
+         !$acc parallel loop &
          !$acc    present(normalizedRelativeVorticityEdge,      &
          !$acc            vorticityGradientNormalComponent,     &
          !$acc            vorticityGradientTangentialComponent, &
@@ -2748,19 +2748,17 @@ contains
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector &
-      !$acc          present(vertAleTransportTop, maxLevelCell, ALE_Thickness, &
-      !$acc                  oldLayerThickness, minLevelCell) &
-      !$acc          private(k)
+      !$acc          present(vertAleTransportTop, ALE_Thickness, &
+      !$acc                  oldLayerThickness, div_hu, &
+      !$acc                  minLevelCell, maxLevelCell)
 #else
       !$omp parallel
       !$omp do schedule(runtime) private(k)
 #endif
       do iCell = 1,nCells
-         kmin = minLevelCell(iCell)
-         kmax = maxLevelCell(iCell)
          vertAleTransportTop(1,iCell) = 0.0_RKIND
-         vertAleTransportTop(kmax+1,iCell) = 0.0_RKIND
-         do k = kmax, kmin+1, -1
+         vertAleTransportTop(maxLevelCell(iCell)+1,iCell) = 0.0_RKIND
+         do k = maxLevelCell(iCell), minLevelCell(iCell)+1, -1
             vertAleTransportTop(k,iCell) = &
                 vertAleTransportTop(k+1,iCell) - div_hu(k,iCell) &
                      - (ALE_Thickness(k,iCell) - &
@@ -2959,8 +2957,6 @@ contains
          kmin,            &! topmost active cell index
          nCells,          &! number of cells
          err,             &! local error code
-         indexTempFlux,   &! index of temperature in tracer array
-         indexSaltFlux,   &! index of salinity    in tracer array
          timeLevel         ! time level for state variables (default 1)
 
       real (kind=RKIND) :: &
@@ -2969,6 +2965,10 @@ contains
          sumSurfaceStressSquared ! sum of sfc stress squared
 
       ! pointers for variable/pool retrievals
+      integer, pointer :: &
+         indexTempFlux,   &! index of temperature in tracer array
+         indexSaltFlux     ! index of salinity    in tracer array
+
       type (mpas_pool_type), pointer :: &
          tracersSurfaceFluxPool, &! pool of tracer surface fluxes
          tracersPool              ! pool of tracers
@@ -2993,9 +2993,6 @@ contains
 
       real (kind=RKIND), dimension(:,:,:), pointer :: &
          activeTracers  ! array of active tracers
-
-      integer, pointer :: &
-         indexTempFluxPtr, indexSaltFluxPtr
 
       ! Scratch Arrays
       ! densitySurfaceDisplaced: Density computed by displacing SST
@@ -3030,14 +3027,21 @@ contains
                                                tracersSurfaceFluxPool)
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
+      !TODO: should be hard-wired?
+      call mpas_pool_get_array(tracersPool, 'activeTracers', &
+                                             activeTracers, 1)
+
       call mpas_pool_get_dimension(tracersSurfaceFluxPool, &
                                   'index_temperatureSurfaceFlux', &
-                                   indexTempFluxPtr)
+                                   indexTempFlux)
       call mpas_pool_get_dimension(tracersSurfaceFluxPool, &
                                   'index_salinitySurfaceFlux', &
-                                   indexSaltFluxPtr)
-      indexTempFlux = indexTempFluxPtr
-      indexSaltFlux = indexSaltFluxPtr
+                                   indexSaltFlux)
+
+      call mpas_pool_get_array(statePool, 'normalVelocity', &
+                                           normalVelocity, timeLevel)
+      call mpas_pool_get_array(statePool, 'layerThickness', &
+                                           layerThickness, timeLevel)
 
       call mpas_pool_get_array(tracersSurfaceFluxPool, &
                               'nonLocalSurfaceTracerFlux', &
@@ -3048,13 +3052,6 @@ contains
       call mpas_pool_get_array(tracersSurfaceFluxPool, &
                               'activeTracersSurfaceFluxRunoff', &
                                activeTracersSurfaceFluxRunoff)
-
-      call mpas_pool_get_array(tracersPool, 'activeTracers', &
-                                             activeTracers, timeLevel)
-      call mpas_pool_get_array(statePool, 'normalVelocity', &
-                                           normalVelocity, timeLevel)
-      call mpas_pool_get_array(statePool, 'layerThickness', &
-                                           layerThickness, timeLevel)
 
       call mpas_pool_get_array(forcingPool, 'surfaceThicknessFlux', &
                                              surfaceThicknessFlux)
@@ -3211,7 +3208,6 @@ contains
     !-------------------------------------------------------------------
 
     end subroutine ocn_compute_KPP_input_fields!}}}
-
 
 !***********************************************************************
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -2009,6 +2009,7 @@ contains
       end do
 #ifndef MPAS_OPENACC
       !$omp end do
+      !$omp end parallel
 #endif
 
       !$acc exit data delete(div_hu, div_huTransport)
@@ -2025,6 +2026,7 @@ contains
       !$acc            minLevelEdgeBot, maxLevelEdgeTop) &
       !$acc    private(i, k, kmin, kmax, eoe, weightsOnEdge_temp)
 #else
+      !$omp parallel
       !$omp do schedule(runtime) &
       !$omp    private(i, k, kmin, kmax, eoe, weightsOnEdge_temp)
 #endif

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -805,130 +805,143 @@ contains
 !
 !  routine ocn_diagnostic_solve_kineticEnergy
 !
-!> \brief   Computes diagnostic variable kineticEnergyCell
+!> \brief   Computes kinetic energy at cell center
 !> \author  Matt Turner
 !> \date    October 2020
 !> \details
-!>  This routine computes the diagnostic variable kineticEnergyCell
+!>  This routine computes the kinetic energy (m^2/s^2) at cell center
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_diagnostic_solve_kineticEnergy(normalVelocity, &
-                kineticEnergyCell)!{{{
 
-      implicit none
+   subroutine ocn_diagnostic_solve_kineticEnergy(normalVelocity, &
+                                                 kineticEnergyCell)!{{{
 
       !-----------------------------------------------------------------
-      !
       ! input variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         normalVelocity     !< Input: transport
+         normalVelocity     !< [in] velocity normal to edge
 
       !-----------------------------------------------------------------
-      !
       ! output variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(out) :: &
-         kineticEnergyCell
+         kineticEnergyCell  !< [out] kinetic energy at cell center
 
       !-----------------------------------------------------------------
-      !
       ! local variables
-      !
       !-----------------------------------------------------------------
 
-      integer :: iVertex, i, iEdge, k, j, nCells, nVertices, iCell
-      real (kind=RKIND) :: r_tmp, invAreaCell1
+      integer :: &
+         i, j, k,               &! generic loop indices
+         iCell, iEdge, iVertex, &! indices for cell, edge, vertex
+         nCells                  ! number of cells and vertices
+
+      real (kind=RKIND) :: &
+         rTmp,        &! local tmp for common factors
+         invAreaCell1  ! 1/cell area
 
       ! Scratch Arrays
-      ! kineticEnergyVertex: kinetic energy of horizontal velocity defined at vertices
-      !               units: m^2 s^{-2}
-      real (kind=RKIND), dimension(:,:), allocatable :: kineticEnergyVertex
-      ! kineticEnergyVertexOnCells: kinetic energy of horizontal velocity defined at vertices
-      !                      units: m^2 s^{-2}
-      real (kind=RKIND), dimension(:,:), allocatable :: kineticEnergyVertexOnCells
-#ifdef MPAS_OPENACC
-      !$acc declare device_resident(kineticEnergyVertex, kineticEnergyVertexOnCells)
-#endif
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         kineticEnergyVertex, &! horiz kinetic energy at vertices
+         kineticEnergyVertexOnCells
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
 
       nCells = nCellsHalo( 2 )
-      nVertices = nVerticesAll
 
-      allocate(kineticEnergyVertex(nVertLevels, nVertices), &
+      allocate(kineticEnergyVertex(nVertLevels, nVerticesAll), &
                kineticEnergyVertexOnCells(nVertLevels, nCells))
+      !$acc enter data create(kineticEnergyVertex, &
+      !$acc                   kineticEnergyVertexOnCells)
 
 #ifdef MPAS_OPENACC
-      !$acc parallel loop present(areaTriangle, dcEdge, dvEdge, normalVelocity, edgesOnVertex)
+      !$acc parallel loop &
+      !$acc    present(kineticEnergyVertex, normalVelocity, &
+      !$acc            areaTriangle, dcEdge, dvEdge, edgesOnVertex)
 #else
       !$omp parallel
-      !$omp do schedule(runtime) private(i, iEdge, r_tmp, k)
+      !$omp do schedule(runtime) private(i, k, iEdge, rTmp)
 #endif
-      do iVertex = 1, nVertices
-        kineticEnergyVertex(:, iVertex) = 0.0_RKIND
-        do i = 1, vertexDegree
-          iEdge = edgesOnVertex(i, iVertex)
-          r_tmp = dcEdge(iEdge) * dvEdge(iEdge) * 0.25_RKIND / areaTriangle(iVertex)
-#ifdef MPAS_OPENACC
-          !$acc loop seq
-#endif
-          do k = 1, nVertLevels
-            kineticEnergyVertex(k, iVertex) = kineticEnergyVertex(k, iVertex) + r_tmp * normalVelocity(k, iEdge)**2
-          end do
-        end do
+      do iVertex = 1, nVerticesAll
+         kineticEnergyVertex(:, iVertex) = 0.0_RKIND
+         do i = 1, vertexDegree
+            iEdge = edgesOnVertex(i, iVertex)
+            rTmp  = dcEdge(iEdge)*dvEdge(iEdge)*0.25_RKIND/ &
+                    areaTriangle(iVertex)
+            !$acc loop seq
+            do k = 1, nVertLevels
+               kineticEnergyVertex(k,iVertex) = &
+               kineticEnergyVertex(k,iVertex) + rTmp* &
+                            normalVelocity(k,iEdge)**2
+            end do
+         end do
       end do
 #ifndef MPAS_OPENACC
       !$omp end do
 #endif
 
 #ifdef MPAS_OPENACC
-      !$acc parallel loop present(kiteIndexOnCell, kiteAreasOnVertex, invAreaCell, verticesOnCell, nEdgesOnCell)
+      !$acc parallel loop &
+      !$acc    present(kineticEnergyVertexOnCells, kineticEnergyVertex,& 
+      !$acc            kiteIndexOnCell, kiteAreasOnVertex, invAreaCell,&
+      !$acc            verticesOnCell, nEdgesOnCell)
 #else
-      !$omp do schedule(runtime) private(invAreaCell1, i, j, iVertex, k)
+      !$omp do schedule(runtime) &
+      !$omp    private(i, j, k, iVertex, invAreaCell1)
 #endif
       do iCell = 1, nCells
-        kineticEnergyVertexOnCells(:, iCell) = 0.0_RKIND
-        invAreaCell1 = invAreaCell(iCell)
-        do i = 1, nEdgesOnCell(iCell)
-          j = kiteIndexOnCell(i, iCell)
-          iVertex = verticesOnCell(i, iCell)
-#ifdef MPAS_OPENACC
-          !$acc loop seq
-#endif
-          do k = 1, nVertLevels
-            kineticEnergyVertexOnCells(k, iCell) = kineticEnergyVertexOnCells(k, iCell) + kiteAreasOnVertex(j, iVertex) &
-                                                 * kineticEnergyVertex(k, iVertex) * invAreaCell1
-          end do
-        end do
+         kineticEnergyVertexOnCells(:, iCell) = 0.0_RKIND
+         invAreaCell1 = invAreaCell(iCell)
+         do i = 1, nEdgesOnCell(iCell)
+            j = kiteIndexOnCell(i, iCell)
+            iVertex = verticesOnCell(i, iCell)
+            !$acc loop seq
+            do k = 1, nVertLevels
+               kineticEnergyVertexOnCells(k,iCell) = &
+               kineticEnergyVertexOnCells(k,iCell) + &
+                        kiteAreasOnVertex(j,iVertex)* &
+                        kineticEnergyVertex(k,iVertex)*invAreaCell1
+            end do
+         end do
       end do
 #ifndef MPAS_OPENACC
       !$omp end do
 #endif
 
       !
-      ! Compute kinetic energy in each cell by blending kineticEnergyCell and kineticEnergyVertexOnCells
+      ! Compute kinetic energy in each cell by blending
+      ! kineticEnergyCell and kineticEnergyVertexOnCells
       !
 #ifdef MPAS_OPENACC
-      !$acc parallel loop collapse(2) present(kineticEnergyCell)
+      !$acc parallel loop collapse(2) &
+      !$acc    present(kineticEnergyCell, kineticEnergyVertexOnCells)
 #else
       !$omp do schedule(runtime) private(k)
 #endif
       do iCell = 1, nCells
-         do k = 1, nVertLevels
-            kineticEnergyCell(k,iCell) = 5.0_RKIND / 8.0_RKIND * kineticEnergyCell(k,iCell) + 3.0_RKIND / 8.0_RKIND &
-                                       * kineticEnergyVertexOnCells(k,iCell)
-         end do
+      do k = 1, nVertLevels
+         kineticEnergyCell(k,iCell) = 5.0_RKIND/8.0_RKIND* &
+                                      kineticEnergyCell(k,iCell) & 
+                                    + 3.0_RKIND/8.0_RKIND* &
+                                      kineticEnergyVertexOnCells(k,iCell)
+      end do
       end do
 #ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
 #endif
 
+      !$acc exit data delete(kineticEnergyVertex, &
+      !$acc                  kineticEnergyVertexOnCells)
       deallocate(kineticEnergyVertex, &
                  kineticEnergyVertexOnCells)
+
+   !--------------------------------------------------------------------
 
    end subroutine ocn_diagnostic_solve_kineticEnergy!}}}
 
@@ -936,116 +949,125 @@ contains
 !
 !  routine ocn_diagnostic_solve_vorticity
 !
-!> \brief   Computes diagnostic variables for vorticity
+!> \brief   Computes normalized vorticity at various locations
 !> \author  Matt Turner
 !> \date    October 2020
 !> \details
-!>  This routine computes the diagnostic variables for vorticity
+!>  This routine computes a normalized vorticity at centers, edges
+!>  based on relative vorticity at cell centers
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_diagnostic_solve_vorticity(dt, normalVelocity, tangentialVelocity, &
-                layerThickness, relativeVorticity, &
-                normalizedRelativeVorticityEdge, normalizedPlanetaryVorticityEdge, &
-                normalizedRelativeVorticityCell)!{{{
 
-      implicit none
+   subroutine ocn_diagnostic_solve_vorticity(dt, &
+                         normalVelocity, tangentialVelocity, &
+                         layerThickness, relativeVorticity, &
+                         normalizedRelativeVorticityEdge, &
+                         normalizedPlanetaryVorticityEdge, &
+                         normalizedRelativeVorticityCell)!{{{
 
       !-----------------------------------------------------------------
-      !
       ! input variables
-      !
       !-----------------------------------------------------------------
 
-      real (kind=RKIND), intent(in) :: dt !< Input: Time step
+      real (kind=RKIND), intent(in) :: dt !< [in] Time step
+
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         normalVelocity     !< Input: transport
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         tangentialVelocity !< Input: transport
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-        layerThickness      !< Input: layer thickness
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-        relativeVorticity
+         normalVelocity,     &!< [in] velocity normal to edge
+         tangentialVelocity, &!< [in] velocity tangent to edge
+         layerThickness,     &!< [in] layer thickness
+         relativeVorticity    !< [in] relative vorticity at cell center
 
       !-----------------------------------------------------------------
-      !
       ! output variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(out) :: &
-        normalizedRelativeVorticityEdge
-      real (kind=RKIND), dimension(:,:), intent(out) :: &
-        normalizedPlanetaryVorticityEdge
-      real (kind=RKIND), dimension(:,:), intent(out) :: &
-        normalizedRelativeVorticityCell
+         normalizedRelativeVorticityEdge,  &!< [out] rel vort at edge
+         normalizedPlanetaryVorticityEdge, &!< [out] planet vort edge
+         normalizedRelativeVorticityCell    !< [out] rel vort in cell
 
       !-----------------------------------------------------------------
-      !
       ! local variables
-      !
       !-----------------------------------------------------------------
 
-      integer :: nVertices, nEdges, nCells
-      integer :: iVertex, k, i, iEdge, iCell, j
-      integer :: vertex1, vertex2, cell1, cell2
-      real(kind=RKIND) :: invAreaTri1, invAreaCell1, invLength
-      real(kind=RKIND) :: layerThicknessVertex
-      real(kind=RKIND) :: apvm_scale_factor
+      integer :: &
+         i, j, k,                   &! loop indices
+         iCell, iEdge, iVertex,     &! indices for cell, edge, vertex
+         nCells, nEdges, nVertices, &! number of cells, edges, vertices
+         vertex1, vertex2,          &! neighbor vertex addresses
+         cell1, cell2                ! neighbor cell   addresses
 
-      ! normalizedPlanetaryVorticityVertex: earth's rotational rate (Coriolis parameter, f)
-      !                                     divided by layer thickness, defined at vertices
-      !                              units: s^{-1}
-      real (kind=RKIND), dimension(:,:), allocatable :: normalizedPlanetaryVorticityVertex
-      ! normalizedRelativeVorticityVertex: curl of horizontal velocity divided by layer thickness,
-      !                                    defined at vertices
-      !                             units: s^{-1}
-      real (kind=RKIND), dimension(:,:), allocatable :: normalizedRelativeVorticityVertex
-      ! vorticityGradientNormalComponent: gradient of vorticity in the normal direction
-      !                                   (positive points from cell1 to cell2)
-      !                            units: s^{-1} m^{-1}
-      real (kind=RKIND), dimension(:,:), allocatable :: vorticityGradientNormalComponent
-      ! vorticityGradientTangentialComponent: gradient of vorticity in the tangent direction
-      !                                       (positive points from vertex1 to vertex2)
-      !                                units: s^{-1} m^{-1}
-      real (kind=RKIND), dimension(:,:), allocatable :: vorticityGradientTangentialComponent
-#ifdef MPAS_OPENACC
-      !$acc declare device_resident(normalizedPlanetaryVorticityVertex, &
-      !$acc                         normalizedRelativeVorticityVertex, &
-      !$acc                         vorticityGradientNormalComponent, &
-      !$acc                         vorticityGradientTangentialComponent)
-#endif
+      real(kind=RKIND) :: &
+         invAreaTri1,          &! 1/triangle area
+         invAreaCell1,         &! 1/cell area
+         invLength,            &! 1/length
+         layerThicknessVertex, &! layer thickness at vertex
+         apvm_scale_factor      ! scale factor for APVM form
+
+      ! Local arrays
+      ! normalizedPlanetaryVorticityVertex: earth's rotational rate
+      !   (Coriolis parameter, f) divided by layer thickness,
+      !   defined at vertices units: s^{-1}
+      ! normalizedRelativeVorticityVertex: curl of horizontal velocity
+      !   divided by layer thickness, defined at vertices units: s^{-1}
+      ! vorticityGradientNormalComponent: gradient of vorticity in the
+      !   normal direction (positive points from cell1 to cell2)
+      !   units: s^{-1} m^{-1}
+      ! vorticityGradientTangentialComponent: gradient of vorticity in
+      !   the tangent direction (positive points from vertex1 to vertex2)
+      !   units: s^{-1} m^{-1}
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         normalizedPlanetaryVorticityVertex,  &
+         normalizedRelativeVorticityVertex,   &
+         vorticityGradientNormalComponent,    &
+         vorticityGradientTangentialComponent
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
 
       !
       ! Compute normalized relative and planetary vorticity
       !
       allocate(normalizedPlanetaryVorticityVertex(nVertLevels, nVerticesAll), &
                normalizedRelativeVorticityVertex(nVertLevels, nVerticesAll))
+      !$acc enter data create(normalizedPlanetaryVorticityVertex, &
+      !$acc                   normalizedRelativeVorticityVertex)
 
-      nVertices = nVerticesHalo( 2 )
+      nVertices = nVerticesHalo(2)
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector &
-      !$acc          present(areaTriangle, maxLevelVertexBot, &
-      !$acc                  layerThickness, kiteAreasOnVertex, &
-      !$acc                  relativeVorticity, fVertex, cellsOnVertex) &
-      !$acc          private(invAreaTri1, layerThicknessVertex, k, i)
+      !$acc    present(normalizedRelativeVorticityVertex, &
+      !$acc            normalizedPlanetaryVorticityVertex, &
+      !$acc            relativeVorticity, fVertex, layerThickness, &
+      !$acc            areaTriangle, kiteAreasOnVertex, cellsOnVertex, &
+      !$acc            maxLevelVertexBot) &
+      !$acc    private(i, k, iCell, invAreaTri1, layerThicknessVertex)
 #else
       !$omp parallel
-      !$omp do schedule(runtime) private(invAreaTri1, k, layerThicknessVertex, i)
+      !$omp do schedule(runtime) &
+      !$omp    private(i, k, iCell, invAreaTri1, layerThicknessVertex)
 #endif
       do iVertex = 1, nVertices
          invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
          do k = 1, maxLevelVertexBot(iVertex)
             layerThicknessVertex = 0.0_RKIND
             do i = 1, vertexDegree
-               layerThicknessVertex = layerThicknessVertex + layerThickness(k,cellsOnVertex(i,iVertex)) &
+               iCell = cellsOnVertex(i,iVertex)
+               layerThicknessVertex = layerThicknessVertex &
+                                    + layerThickness(k,iCell) &
                                     * kiteAreasOnVertex(i,iVertex)
             end do
-            layerThicknessVertex = layerThicknessVertex * invAreaTri1
+            layerThicknessVertex = layerThicknessVertex*invAreaTri1
             if (layerThicknessVertex == 0) cycle
 
-            normalizedRelativeVorticityVertex(k,iVertex) = relativeVorticity(k,iVertex) / layerThicknessVertex
-            normalizedPlanetaryVorticityVertex(k,iVertex) = fVertex(iVertex) / layerThicknessVertex
+            normalizedRelativeVorticityVertex(k,iVertex) = &
+                            relativeVorticity(k,iVertex) / &
+                            layerThicknessVertex
+            normalizedPlanetaryVorticityVertex(k,iVertex) = &
+                            fVertex(iVertex)/layerThicknessVertex
          end do
       end do
 #ifndef MPAS_OPENACC
@@ -1053,32 +1075,34 @@ contains
       !$omp end parallel
 #endif
 
-      nEdges = nEdgesHalo( 2 )
+      nEdges = nEdgesHalo(2)
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector &
-      !$acc          present(normalizedRelativeVorticityEdge, &
-      !$acc                  normalizedPlanetaryVorticityEdge, &
-      !$acc                  verticesOnEdge, maxLevelEdgeBot, &
-      !$acc                  minLevelEdgeTop) &
-      !$acc          private(vertex1, vertex2, k)
+      !$acc    present(normalizedRelativeVorticityEdge, &
+      !$acc            normalizedPlanetaryVorticityEdge, &
+      !$acc            normalizedRelativeVorticityVertex, &
+      !$acc            normalizedPlanetaryVorticityVertex, &
+      !&acc            minLevelEdgeTop, maxLevelEdgeBot, &
+      !$acc            verticesOnEdge) &
+      !$acc    private(k, vertex1, vertex2)
 #else
       !$omp parallel
-      !$omp do schedule(runtime) private(vertex1, vertex2, k)
+      !$omp do schedule(runtime) private(k, vertex1, vertex2)
 #endif
       do iEdge = 1, nEdges
-        normalizedRelativeVorticityEdge(:, iEdge) = 0.0_RKIND
-        normalizedPlanetaryVorticityEdge(:, iEdge) = 0.0_RKIND
-        vertex1 = verticesOnEdge(1, iEdge)
-        vertex2 = verticesOnEdge(2, iEdge)
-#ifdef MPAS_OPENACC
-        !$acc loop seq
-#endif
-        do k = minLevelEdgeTop(iEdge), maxLevelEdgeBot(iEdge)
-              normalizedRelativeVorticityEdge(k, iEdge) = 0.5_RKIND * (normalizedRelativeVorticityVertex(k, vertex1) &
-                                                    + normalizedRelativeVorticityVertex(k, vertex2))
-              normalizedPlanetaryVorticityEdge(k, iEdge) = 0.5_RKIND * (normalizedPlanetaryVorticityVertex(k, vertex1) &
-                                                    + normalizedPlanetaryVorticityVertex(k, vertex2))
+         normalizedRelativeVorticityEdge (:,iEdge) = 0.0_RKIND
+         normalizedPlanetaryVorticityEdge(:,iEdge) = 0.0_RKIND
+         vertex1 = verticesOnEdge(1, iEdge)
+         vertex2 = verticesOnEdge(2, iEdge)
+         !$acc loop seq
+         do k = minLevelEdgeTop(iEdge), maxLevelEdgeBot(iEdge)
+            normalizedRelativeVorticityEdge(k,iEdge) = 0.5_RKIND* &
+                   (normalizedRelativeVorticityVertex(k,vertex1) &
+                  + normalizedRelativeVorticityVertex(k,vertex2))
+            normalizedPlanetaryVorticityEdge(k,iEdge) = 0.5_RKIND* &
+                   (normalizedPlanetaryVorticityVertex(k,vertex1) &
+                  + normalizedPlanetaryVorticityVertex(k,vertex2))
         end do
       end do
 #ifndef MPAS_OPENACC
@@ -1086,33 +1110,37 @@ contains
       !$omp end parallel
 #endif
 
-      nCells = nCellsHalo ( 1 )
+      nCells = nCellsHalo(1)
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector &
-      !$acc          present(normalizedRelativeVorticityCell, maxLevelCell, nEdgesOnCell, &
-      !$acc                  areaCell, kiteIndexOnCell, verticesOnCell, kiteAreasOnVertex, &
-      !$acc                  invAreaCell, minLevelCell) &
-      !$acc          private(invAreaCell1, i, j, iVertex, k)
+      !$acc    present(normalizedRelativeVorticityCell, &
+      !$acc            normalizedRelativeVorticityVertex, &
+      !$acc            invAreaCell, kiteAreasOnVertex, &
+      !$acc            nEdgesOnCell, kiteIndexOnCell, &
+      !$acc            minLevelCell, maxLevelCell, verticesOnCell) &
+      !$acc    private(i, j, k, iVertex, invAreaCell1)
 #else
       !$omp parallel
-      !$omp do schedule(runtime) private(invAreaCell1, i, j, iVertex, k)
+      !$omp do schedule(runtime) &
+      !$omp    private(i, j, k, iVertex, invAreaCell1)
 #endif
       do iCell = 1, nCells
-        normalizedRelativeVorticityCell(:, iCell) = 0.0_RKIND
-        invAreaCell1 = invAreaCell(iCell)
+         normalizedRelativeVorticityCell(:,iCell) = 0.0_RKIND
+         invAreaCell1 = invAreaCell(iCell)
 
-        do i = 1, nEdgesOnCell(iCell)
-          j = kiteIndexOnCell(i, iCell)
-          iVertex = verticesOnCell(i, iCell)
-#ifdef MPAS_OPENACC
-        !$acc loop seq
-#endif
-          do k = minLevelCell(iCell), maxLevelCell(iCell)
-            normalizedRelativeVorticityCell(k, iCell) = normalizedRelativeVorticityCell(k, iCell) &
-              + kiteAreasOnVertex(j, iVertex) * normalizedRelativeVorticityVertex(k, iVertex) * invAreaCell1
-          end do
-        end do
+         do i = 1, nEdgesOnCell(iCell)
+            j = kiteIndexOnCell(i, iCell)
+            iVertex = verticesOnCell(i, iCell)
+            !$acc loop seq
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
+               normalizedRelativeVorticityCell(k,iCell) = &
+               normalizedRelativeVorticityCell(k,iCell) + &
+                                  kiteAreasOnVertex(j,iVertex)* &
+                  normalizedRelativeVorticityVertex(k,iVertex)* &
+                  invAreaCell1
+            end do
+         end do
       end do
 #ifndef MPAS_OPENACC
       !$omp end do
@@ -1122,51 +1150,58 @@ contains
       nCells = nCellsAll
       nVertices = nVerticesAll
       nEdges = nEdgesAll
-      apvm_scale_factor = config_apvm_scale_factor;
+      apvm_scale_factor = config_apvm_scale_factor
 
       ! Diagnostics required for the Anticipated Potential Vorticity Method (apvm).
       if (config_apvm_scale_factor>1e-10) then
 
-         allocate(vorticityGradientNormalComponent(nVertLevels, nEdges), &
-                  vorticityGradientTangentialComponent(nVertLevels, nEdges))
+         allocate( &
+            vorticityGradientNormalComponent    (nVertLevels,nEdges), &
+            vorticityGradientTangentialComponent(nVertLevels,nEdges))
+         !$acc enter data create(vorticityGradientNormalComponent, &
+         !$acc                   vorticityGradientTangentialComponent)
 
          nEdges = nEdgesHalo( 1 )
 
 #ifdef MPAS_OPENACC
          !$acc parallel loop &
-         !$acc    present(minLevelEdgeBot, maxLevelEdgeTop, cellsOnEdge, &
-         !$acc            minLevelEdgeTop, maxLevelEdgeBot, dcEdge, dvEdge, &
-         !$acc            verticesOnedge, normalizedRelativeVorticityCell)
+         !$acc    present(vorticityGradientNormalComponent, &
+         !$acc            vorticityGradientTangentialComponent, &
+         !$acc            normalizedRelativeVorticityCell, &
+         !$acc            normalizedRelativeVorticityVertex, &
+         !$acc            dcEdge, dvEdge, cellsOnEdge, verticesOnedge, &
+         !$acc            minLevelEdgeBot, maxLevelEdgeTop, &
+         !$acc            minLevelEdgeTop, maxLevelEdgeBot) &
+         !$acc    private(k, cell1, cell2, vertex1, vertex2, invLength)
 #else
          !$omp parallel
-         !$omp do schedule(runtime) private(cell1, cell2, vertex1, vertex2, invLength, k)
+         !$omp do schedule(runtime) &
+         !$omp    private(k, cell1, cell2, vertex1, vertex2, invLength)
 #endif
          do iEdge = 1,nEdges
-            cell1 = cellsOnEdge(1, iEdge)
-            cell2 = cellsOnEdge(2, iEdge)
-            vertex1 = verticesOnedge(1, iEdge)
-            vertex2 = verticesOnedge(2, iEdge)
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            vertex1 = verticesOnedge(1,iEdge)
+            vertex2 = verticesOnedge(2,iEdge)
 
-            invLength = 1.0_RKIND / dcEdge(iEdge)
             ! Compute gradient of PV in normal direction
-            !   ( this computes the gradient for all edges bounding real cells )
-#ifdef MPAS_OPENACC
-        !$acc loop seq
-#endif
+
+            invLength = 1.0_RKIND/dcEdge(iEdge)
+            !$acc loop seq
             do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                vorticityGradientNormalComponent(k,iEdge) = &
-                  (normalizedRelativeVorticityCell(k,cell2) - normalizedRelativeVorticityCell(k,cell1)) * invLength
+                  (normalizedRelativeVorticityCell(k,cell2) - &
+                   normalizedRelativeVorticityCell(k,cell1))*invLength
             enddo
 
-            invLength = 1.0_RKIND / dvEdge(iEdge)
             ! Compute gradient of PV in the tangent direction
-            !   ( this computes the gradient at all edges bounding real cells and distance-1 ghost cells )
-#ifdef MPAS_OPENACC
-        !$acc loop seq
-#endif
+
+            invLength = 1.0_RKIND / dvEdge(iEdge)
+            !$acc loop seq
             do k = minLevelEdgeTop(iEdge), maxLevelEdgeBot(iEdge)
               vorticityGradientTangentialComponent(k,iEdge) = &
-                 (normalizedRelativeVorticityVertex(k,vertex2) - normalizedRelativeVorticityVertex(k,vertex1)) * invLength
+                 (normalizedRelativeVorticityVertex(k,vertex2) - &
+                  normalizedRelativeVorticityVertex(k,vertex1))*invLength
             enddo
 
          enddo
@@ -1179,20 +1214,24 @@ contains
          !
 #ifdef MPAS_OPENACC
          !$acc parallel loop, &
-         !$acc    present(minLevelEdgeTop, maxLevelEdgeBot, tangentialVelocity, &
-         !$acc            normalVelocity, normalizedRelativeVorticityEdge)
+         !$acc    present(normalizedRelativeVorticityEdge,      &
+         !$acc            vorticityGradientNormalComponent,     &
+         !$acc            vorticityGradientTangentialComponent, &
+         !$acc            normalVelocity, tangentialVelocity,   &
+         !$acc            minLevelEdgeTop, maxLevelEdgeBot)
 #else
          !$omp do schedule(runtime) private(k)
 #endif
          do iEdge = 1,nEdges
-#ifdef MPAS_OPENACC
-        !$acc loop seq
-#endif
+            !$acc loop seq
             do k = minLevelEdgeTop(iEdge), maxLevelEdgeBot(iEdge)
-              normalizedRelativeVorticityEdge(k,iEdge) = normalizedRelativeVorticityEdge(k,iEdge) &
-                - apvm_scale_factor * dt * &
-                    (  normalVelocity(k,iEdge)     * vorticityGradientNormalComponent(k,iEdge)      &
-                     + tangentialVelocity(k,iEdge) * vorticityGradientTangentialComponent(k,iEdge) )
+               normalizedRelativeVorticityEdge(k,iEdge) = &
+               normalizedRelativeVorticityEdge(k,iEdge) - &
+                    apvm_scale_factor*dt* &
+                    (normalVelocity(k,iEdge)* &
+                     vorticityGradientNormalComponent(k,iEdge)      &
+                   + tangentialVelocity(k,iEdge)* &
+                     vorticityGradientTangentialComponent(k,iEdge) )
             end do
          enddo
 #ifndef MPAS_OPENACC
@@ -1200,14 +1239,19 @@ contains
          !$omp end parallel
 #endif
 
+         !$acc exit data delete(vorticityGradientNormalComponent, &
+         !$acc                  vorticityGradientTangentialComponent)
          deallocate(vorticityGradientNormalComponent, &
                     vorticityGradientTangentialComponent)
 
       endif
 
+      !$acc exit data delete(normalizedPlanetaryVorticityVertex, &
+      !$acc                  normalizedRelativeVorticityVertex)
       deallocate(normalizedPlanetaryVorticityVertex, &
                  normalizedRelativeVorticityVertex)
 
+   !--------------------------------------------------------------------
 
    end subroutine ocn_diagnostic_solve_vorticity!}}}
 
@@ -1570,92 +1614,107 @@ contains
 !>    the normal velocity due to GM bolus velocity
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_diagnostic_solve_GMvel(layerThickEdgeFlux, normalGMBolusVelocity, &
+
+   subroutine ocn_diagnostic_solve_GMvel(layerThickEdgeFlux, &
+                                         normalGMBolusVelocity, &
                                          vertGMBolusVelocityTop)!{{{
+
       !-----------------------------------------------------------------
-      !
       ! input variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThickEdgeFlux,     &
-         normalGMBolusVelocity
+         layerThickEdgeFlux,     &!< [in] thickness flux at edge
+         normalGMBolusVelocity    !< [in] Bolus velocity normal to edge
 
       !-----------------------------------------------------------------
-      !
       ! output variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(out) :: &
-         vertGMBolusVelocityTop
+         vertGMBolusVelocityTop !< [out] Bolus vertical velocity at top
 
       !-----------------------------------------------------------------
-      !
       ! local variables
-      !
       !-----------------------------------------------------------------
 
-      integer :: nCells, nEdges
-      integer :: iCell, iVertex, iEdge
-      integer :: i, j, k
-      integer :: edgeSignOnCell_temp, eoe
-      real(kind=RKIND) :: invAreaCell1
-      real(kind=RKIND) :: dcEdge_temp, dvEdge_temp, r_tmp, weightsOnEdge_temp
+      integer :: &
+         i, k,         &! loop indices for neighbors, vertical levels
+         iCell, iEdge, &! addresses for cells, edges
+         eoe,          &! address for edges on edge
+         kmin, kmax,   &! min, max indices of active vert layers
+         edgeSignOnCell_temp ! directional sign across edge
 
-      real (kind=RKIND), dimension(:), allocatable:: div_huGMBolus
+      real(kind=RKIND) :: &
+         invAreaCell1, &! 1/cell area
+         dvEdge_temp    ! local value of dvEdge
 
-#ifdef MPAS_OPENACC
-      !$acc declare device_resident(div_huGMBolus)
-#endif
+      real (kind=RKIND), dimension(:), allocatable :: &
+         div_huGMBolus ! divergence of thick-weighted Bolus velocity
 
-      ! Need owned cells for relativeVorticityCell
-      nCells = nCellsOwned
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
 
+      ! Return immediately if not needed
       if (.not. config_use_gm) return
 
       allocate(div_huGMBolus(nVertLevels))
+      !$acc enter data create(div_huGMBolus)
+
+      ! Compute vertical velocity from the divergence of horizontal GM
+      ! Bolus velocity
+
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector &
-      !$acc          present(nEdgesOnCell, edgesOnCell, edgeSignonCell, dcEdge, dvEdge, &
-      !$acc                  normalGMBolusVelocity, &
-      !$acc                  vertGMBolusVelocityTop, invAreaCell, minLevelCell) &
-      !$acc          private(invAreaCell1, i, iEdge, edgeSignOnCell_temp, dcEdge_temp, &
-      !$acc                  dvEdge_temp, k)
+      !$acc    present(vertGMBolusVelocityTop, &
+      !$acc            normalGMBolusVelocity, layerThickEdgeFlux, &
+      !$acc            dvEdge, invAreaCell, edgeSignOnCell, &
+      !$acc            nEdgesOnCell, edgesOnCell, &
+      !$acc            minLevelCell, maxLevelCell) &
+      !$acc    private(div_huGMBolus, i, k, kmin, kmax, iEdge, &
+      !$acc            invAreaCell1, edgeSignOnCell_temp, dvEdge_temp)
 #else
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(i, iEdge, invAreaCell1, edgeSignOnCell_temp, dcEdge_temp, dvEdge_temp, &
-      !$omp         k, div_huGMBolus)
+      !$omp    private(div_huGMBolus, i, k, kmin, kmax, iEdge, &
+      !$omp            invAreaCell1, edgeSignOnCell_temp, dvEdge_temp)
 #endif
-      do iCell = 1, nCells
+      do iCell = 1, nCellsOwned
          div_huGMBolus(:) = 0.0_RKIND
          invAreaCell1 = invAreaCell(iCell)
+         kmin = minLevelCell(iCell)
+         kmax = maxLevelCell(iCell)
          do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
             edgeSignOnCell_temp = edgeSignOnCell(i, iCell)
-            dcEdge_temp = dcEdge(iEdge)
             dvEdge_temp = dvEdge(iEdge)
-            do k = minLevelCell(iCell), maxLevelCell(iCell)
+            do k = kmin, kmax
                ! Compute vertical velocity from the horizontal GM Bolus velocity
                div_huGMBolus(k) = div_huGMBolus(k) &
-                                  - layerThickEdgeFlux(k, iEdge) * edgeSignOnCell_temp * dvEdge_temp &
-                                  * normalGMBolusVelocity(k, iEdge) * invAreaCell1
+                                - layerThickEdgeFlux(k,iEdge)* &
+                                  edgeSignOnCell_temp*dvEdge_temp* &
+                                  normalGMBolusVelocity(k,iEdge)* &
+                                  invAreaCell1
             end do
          end do
-         ! Vertical velocity at bottom (maxLevelCell(iCell)+1) is zero, initialized above.
-         vertGMBolusVelocityTop(1:minLevelCell(iCell)-1, iCell) = 0.0_RKIND
-         vertGMBolusVelocityTop(maxLevelCell(iCell)+1, iCell) = 0.0_RKIND
-         do k = maxLevelCell(iCell), 1, -1
-            vertGMBolusVelocityTop(k,iCell) = vertGMBolusVelocityTop(k+1,iCell) - div_huGMBolus(k)
+         ! Vertical velocity at bottom is zero, initialized above.
+         vertGMBolusVelocityTop(1:kmin-1,iCell) = 0.0_RKIND
+         vertGMBolusVelocityTop(kmax+1  ,iCell) = 0.0_RKIND
+         do k = kmax, 1, -1
+            vertGMBolusVelocityTop(k,iCell) = &
+            vertGMBolusVelocityTop(k+1,iCell) - div_huGMBolus(k)
          end do
       end do
 #ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
 #endif
+
+      !$acc exit data delete(div_huGMBolus)
       deallocate(div_huGMBolus)
+
+   !--------------------------------------------------------------------
 
    end subroutine ocn_diagnostic_solve_GMvel!}}}
 
@@ -1671,90 +1730,104 @@ contains
 !>    the normal velocity due to MLE (submesoscale eddy) bolus velocity
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_diagnostic_solve_MLEvel(layerThickEdgeFlux, normalMLEVelocity, &
-                                         vertMLEBolusVelocityTop)!{{{
+
+   subroutine ocn_diagnostic_solve_MLEvel(layerThickEdgeFlux, &
+                                          normalMLEVelocity, &
+                                          vertMLEBolusVelocityTop)!{{{
+
       !-----------------------------------------------------------------
-      !
       ! input variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThickEdgeFlux,     &
-         normalMLEVelocity
+         layerThickEdgeFlux,  &!< [in] thickness flux at edge
+         normalMLEVelocity     !< [in] MLE velocity normal to edge
 
       !-----------------------------------------------------------------
-      !
       ! output variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(out) :: &
-         vertMLEBolusVelocityTop
+         vertMLEBolusVelocityTop !< [out] MLE velocity at top
 
       !-----------------------------------------------------------------
-      !
       ! local variables
-      !
       !-----------------------------------------------------------------
 
-      integer :: nCells, nEdges
-      integer :: iCell, iVertex, iEdge
-      integer :: i, j, k
-      integer :: edgeSignOnCell_temp, eoe
-      real(kind=RKIND) :: invAreaCell1
-      real(kind=RKIND) :: dcEdge_temp, dvEdge_temp, r_tmp, weightsOnEdge_temp
+      integer :: &
+         i, k,         &! loop indices for neighbors, vertical levels
+         iCell, iEdge, &! addresses for cells, edges
+         eoe,          &! address for edges on edge
+         kmin, kmax,   &! min, max indices of active vert layers
+         edgeSignOnCell_temp ! directional sign across edge
 
-      real (kind=RKIND), dimension(:), allocatable:: div_huMLEBolus
+      real(kind=RKIND) :: &
+         invAreaCell1, &! 1/cell area
+         dvEdge_temp    ! local value of dvEdge
 
-#ifdef MPAS_OPENACC
-      !$acc declare device_resident(div_huMLEBolus)
-#endif
+      real (kind=RKIND), dimension(:), allocatable :: &
+         div_huMLEBolus ! divergence of thick-weighted MLE velocity
 
-      nCells = nCellsOwned
+      !-----------------------------------------------------------------
+
+      ! Return if not needed
       if (.not. config_submesoscale_enable) return
 
       allocate(div_huMLEBolus(nVertLevels))
+      !$acc enter data create(div_huMLEBolus)
+
+      ! Compute vertical velocity from the divergence of horizontal MLE
+      ! (submesoscale eddy)  Bolus velocity
+
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector &
-      !$acc          present(nEdgesOnCell, edgesOnCell, edgeSignonCell, dcEdge, dvEdge, &
-      !$acc                  areaCell, normalMLEVelocity, &
-      !$acc                  vertMLEBolusVelocityTop, invAreaCell, minLevelCell) &
-      !$acc          private(invAreaCell1, i, iEdge, edgeSignOnCell_temp, dcEdge_temp, &
-      !$acc                  dvEdge_temp, k)
+      !$acc    present(vertMLEBolusVelocityTop, &
+      !$acc            normalMLEVelocity, layerThickEdgeFlux, &
+      !$acc            dvEdge, invAreaCell, edgeSignOnCell, &
+      !$acc            nEdgesOnCell, edgesOnCell, &
+      !$acc            minLevelCell, maxLevelCell) &
+      !$acc    private(div_huMLEBolus, i, k, kmin, kmax, iEdge, &
+      !$acc            invAreaCell1, edgeSignOnCell_temp, dvEdge_temp)
 #else
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(i, iEdge, invAreaCell1, edgeSignOnCell_temp, dcEdge_temp, dvEdge_temp, &
-      !$omp         k, div_huMLEBolus)
+      !$omp    private(div_huMLEBolus, i, k, kmin, kmax, iEdge, &
+      !$omp            invAreaCell1, edgeSignOnCell_temp, dvEdge_temp)
 #endif
-      do iCell = 1, nCells
+      do iCell = 1, nCellsOwned
          div_huMLEBolus(:) = 0.0_RKIND
          invAreaCell1 = invAreaCell(iCell)
+         kmin = minLevelCell(iCell)
+         kmax = maxLevelCell(iCell)
          do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
             edgeSignOnCell_temp = edgeSignOnCell(i, iCell)
-            dcEdge_temp = dcEdge(iEdge)
             dvEdge_temp = dvEdge(iEdge)
-            do k = minLevelCell(iCell), maxLevelCell(iCell)
-               ! Compute vertical velocity from the horizontal MLE (submesoscale eddy)  Bolus velocity
+            do k = kmin,kmax
                div_huMLEBolus(k) = div_huMLEBolus(k) &
-                                   - layerThickEdgeFlux(k, iEdge) * edgeSignOnCell_temp * dvEdge_temp &
-                                   * normalMLEVelocity(k, iEdge) * invAreaCell1
+                                 - layerThickEdgeFlux(k,iEdge)* &
+                                   edgeSignOnCell_temp*dvEdge_temp* &
+                                   normalMLEVelocity(k,iEdge)* &
+                                   invAreaCell1
             end do
          end do
-         ! Vertical velocity at bottom (maxLevelCell(iCell)+1) is zero, initialized above.
-         vertMLEBolusVelocityTop(1:minLevelCell(iCell)-1, iCell) = 0.0_RKIND
-         vertMLEBolusVelocityTop(maxLevelCell(iCell)+1, iCell) = 0.0_RKIND
-         do k = maxLevelCell(iCell), 1, -1
-            vertMLEBolusVelocityTop(k,iCell) = vertMLEBolusVelocityTop(k+1,iCell) - div_huMLEBolus(k)
+         ! Vertical velocity at bottom is zero, initialized above.
+         vertMLEBolusVelocityTop(1:kmin-1, iCell) = 0.0_RKIND
+         vertMLEBolusVelocityTop(kmax+1,   iCell) = 0.0_RKIND
+         do k = kmax, 1, -1
+            vertMLEBolusVelocityTop(k,iCell) = &
+            vertMLEBolusVelocityTop(k+1,iCell) - div_huMLEBolus(k)
          end do
       end do
 #ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
 #endif
+
+      !$acc exit data delete(div_huMLEBolus)
       deallocate(div_huMLEBolus)
+
+   !--------------------------------------------------------------------
 
    end subroutine ocn_diagnostic_solve_MLEvel!}}}
 
@@ -1762,100 +1835,102 @@ contains
 !
 !  routine ocn_diagnostic_solve_vortVel
 !
-!> \brief   Computes diagnostic variables for vorticity and velocity
+!> \brief   Computes several velocity-related fields
 !> \author  Matt Turner
 !> \date    October 2020
 !> \details
-!>  This routine computes the diagnostic variables for vorticity and vertical
-!>    velocities
+!>  This routine a number of fields related to horizontal velocity,
+!>  namely kinetic energy, divergence, vorticity, vertical velocity
+!>  and tangential velocity
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_diagnostic_solve_vortVel(relativeVorticity, &
-                layerThicknessEdgeFlux, normalVelocity, normalTransportVelocity, &
-                vertVelocityTop, vertTransportVelocityTop, relativeVorticityCell, &
-                divergence, kineticEnergyCell, tangentialVelocity)!{{{
 
-      implicit none
+   subroutine ocn_diagnostic_solve_vortVel( &
+                           relativeVorticity, layerThicknessEdgeFlux, &
+                           normalVelocity, normalTransportVelocity, &
+                           vertVelocityTop, vertTransportVelocityTop, &
+                           relativeVorticityCell, divergence, &
+                           kineticEnergyCell, tangentialVelocity)!{{{
 
       !-----------------------------------------------------------------
-      !
       ! input variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         relativeVorticity
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThicknessEdgeFlux
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         normalVelocity
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         normalTransportVelocity
+         relativeVorticity,      &!< [in] relative vorticity in cells
+         layerThicknessEdgeFlux, &!< [in] thickness flux at edge
+         normalVelocity,         &!< [in] velocity normal to edge
+         normalTransportVelocity  !< [in] transport vel normal to edge
 
       !-----------------------------------------------------------------
-      !
       ! output variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         vertVelocityTop
-      real (kind=RKIND), dimension(:,:), intent(out) :: &
-         vertTransportVelocityTop
-      real (kind=RKIND), dimension(:,:), intent(out) :: &
-         relativeVorticityCell
-      real (kind=RKIND), dimension(:,:), intent(out) :: &
-         divergence
-      real (kind=RKIND), dimension(:,:), intent(out) :: &
-         kineticEnergyCell
-      real (kind=RKIND), dimension(:,:), intent(out) :: &
-         tangentialVelocity
+         vertVelocityTop,       &!< [out] vertical velocity top of cell
+         vertTransportVelocityTop, &!< [out] vert transport vel at top
+         relativeVorticityCell, &!< [out] relative vorticity in cell
+         divergence,            &!< [out] divergence
+         kineticEnergyCell,     &!< [out] kinetic energy in cell
+         tangentialVelocity      !< [out] tangential velocity at edge
 
       !-----------------------------------------------------------------
-      !
       ! local variables
-      !
       !-----------------------------------------------------------------
 
-      integer :: nCells, nEdges
-      integer :: iCell, iVertex, iEdge
-      integer :: i, j, k
-      integer :: edgeSignOnCell_temp, eoe
-      real(kind=RKIND) :: invAreaCell1
-      real(kind=RKIND) :: dcEdge_temp, dvEdge_temp, r_tmp, weightsOnEdge_temp
+      integer :: &
+         i, j, k,               &! loop indices
+         iCell, iVertex, iEdge, &! indices for cells, vertices, edges
+         nCells, nEdges,        &! number of cells, edges
+         kmin, kmax,            &! min, max active vert level index
+         eoe,                   &! index for edge on edge
+         edgeSignOnCell_temp     ! local tmp for sign across edge
 
-      real (kind=RKIND), dimension(:), allocatable:: div_hu,div_huTransport
+      real(kind=RKIND) :: &
+         invAreaCell1,      &! 1/cell area
+         dcEdge_temp,       &! local val of dcEdge
+         dvEdge_temp,       &! local val of dvEdge
+         r_tmp,             &! tmp for common factors
+         weightsOnEdge_temp  ! local tmp for weights on edge
 
-#ifdef MPAS_OPENACC
-      !$acc declare device_resident(div_hu, div_huTransport)
-#endif
+      real (kind=RKIND), dimension(:), allocatable :: &
+         div_hu,         &! local divergence of thick-weighted velocity
+         div_huTransport  ! local div of thick-weighted transport vel
 
-      ! Need owned cells for relativeVorticityCell
-      nCells = nCellsOwned
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      ! Compute relative vorticity in cells
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector &
-      !$acc          present(relativeVorticityCell, areaCell, nEdgesOnCell, &
-      !$acc                  kiteIndexOnCell, verticesOnCell, maxLevelCell, &
-      !$acc                  relativeVorticity, kiteAreasOnVertex, invAreaCell, &
-      !$acc                  minLevelCell) &
-      !$acc          private(invAreaCell1, i, j, iVertex, k)
+      !$acc    present(relativeVorticityCell, relativeVorticity, &
+      !$acc            invAreaCell, kiteAreasOnVertex, &
+      !$acc            nEdgesOnCell, kiteIndexOnCell, verticesOnCell, &
+      !$acc            minLevelCell, maxLevelCell) &
+      !$acc    private(i, iVertex, j, k, kmin, kmax, invAreaCell1) 
 #else
       !$omp parallel
-      !$omp do schedule(runtime) private(invAreaCell1, i, j, k, iVertex)
+      !$omp do schedule(runtime) &
+      !$omp    private(i, iVertex, j, k, kmin, kmax, invAreaCell1) 
 #endif
-      do iCell = 1, nCells
-        relativeVorticityCell(:,iCell) = 0.0_RKIND
-        invAreaCell1 = invAreaCell(iCell)
+      do iCell = 1, nCellsOwned
+         relativeVorticityCell(:,iCell) = 0.0_RKIND
+         invAreaCell1 = invAreaCell(iCell)
+         kmin = minLevelCell(iCell)
+         kmax = maxLevelCell(iCell)
 
-        do i = 1, nEdgesOnCell(iCell)
-          j = kiteIndexOnCell(i, iCell)
-          iVertex = verticesOnCell(i, iCell)
-          do k = minLevelCell(iCell), maxLevelCell(iCell)
-            relativeVorticityCell(k, iCell) = relativeVorticityCell(k, iCell) + kiteAreasOnVertex(j, iVertex) &
-                                            * relativeVorticity(k, iVertex) * invAreaCell1
-          end do
-        end do
+         do i = 1, nEdgesOnCell(iCell)
+            j = kiteIndexOnCell(i, iCell)
+            iVertex = verticesOnCell(i, iCell)
+            do k = kmin,kmax
+               relativeVorticityCell(k,iCell) = &
+               relativeVorticityCell(k,iCell) + &
+                        kiteAreasOnVertex(j,iVertex)* &
+                        relativeVorticity(k,iVertex)*invAreaCell1
+            end do
+         end do
       end do
 #ifndef MPAS_OPENACC
       !$omp end do
@@ -1863,86 +1938,107 @@ contains
 #endif
 
       ! Need 0,1,2 halo cells
-      nCells = nCellsHalo( 2 )
+      nCells = nCellsHalo(2)
 
       !
       ! Compute divergence, kinetic energy, and vertical velocity
       !
       allocate(div_hu(nVertLevels),div_huTransport(nVertLevels))
+      !$acc enter data create(div_hu, div_huTransport)
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector &
-      !$acc          present(divergence, kineticEnergyCell, &
-      !$acc                  areaCell, nEdgesOnCell, edgesOnCell, edgeSignOnCell, dcEdge, dvEdge, &
-      !$acc                  maxLevelCell, normalVelocity, divergence, layerThicknessEdgeFlux, &
-      !$acc                  normalTransportVelocity, vertVelocityTop, vertTransportVelocityTop, &
-      !$acc                  invAreaCell, minLevelCell) &
-      !$acc          private(invAreaCell1, i, iEdge, edgeSignOnCell_temp, dcEdge_temp, &
-      !$acc                  dvEdge_temp, k, r_tmp)
+      !$acc    present(divergence, kineticEnergyCell, &
+      !$acc            vertVelocityTop, vertTransportVelocityTop, &
+      !$acc            normalVelocity, normalTransportVelocity, &
+      !$acc            layerThicknessEdgeFlux, dcEdge, dvEdge, &
+      !$acc            invAreaCell, nEdgesOnCell, edgesOnCell, &
+      !$acc            edgeSignOnCell, minLevelCell, maxLevelCell) &
+      !$acc    private(div_hu, div_huTransport, i, k, kmin, kmax, & 
+      !$acc            iEdge, invAreaCell1, r_tmp, dcEdge_temp, & 
+      !$acc            dvEdge_temp, edgeSignOnCell_temp)  
 #else
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(i, iEdge, invAreaCell1, edgeSignOnCell_temp, dcEdge_temp, dvEdge_temp, &
-      !$omp         k, r_tmp, div_hu, div_huTransport)
+      !$omp    private(div_hu, div_huTransport, i, k, kmin, kmax, & 
+      !$omp            iEdge, invAreaCell1, r_tmp, dcEdge_temp, & 
+      !$omp            dvEdge_temp, edgeSignOnCell_temp)  
 #endif
       do iCell = 1, nCells
-         divergence(:, iCell) = 0.0_RKIND
-         kineticEnergyCell(:, iCell) = 0.0_RKIND
+         divergence(:,iCell) = 0.0_RKIND
+         kineticEnergyCell(:,iCell) = 0.0_RKIND
          div_hu(:) = 0.0_RKIND
          div_huTransport(:) = 0.0_RKIND
          invAreaCell1 = invAreaCell(iCell)
+         kmin = minLevelCell(iCell)
+         kmax = maxLevelCell(iCell)
          do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
             edgeSignOnCell_temp = edgeSignOnCell(i, iCell)
             dcEdge_temp = dcEdge(iEdge)
             dvEdge_temp = dvEdge(iEdge)
-            do k = minLevelCell(iCell), maxLevelCell(iCell)
-               r_tmp = dvEdge_temp * normalVelocity(k, iEdge) * invAreaCell1
+            do k = kmin,kmax
+               r_tmp = dvEdge_temp*normalVelocity(k,iEdge)*invAreaCell1
 
-               divergence(k, iCell) = divergence(k, iCell) - edgeSignOnCell_temp * r_tmp
-               div_hu(k) = div_hu(k) - layerThicknessEdgeFlux(k, iEdge) * edgeSignOnCell_temp * r_tmp
-               kineticEnergyCell(k, iCell) = kineticEnergyCell(k, iCell) &
-                                              + 0.25 * r_tmp * dcEdge_temp * normalVelocity(k,iEdge)
-               ! Compute vertical velocity from the horizontal total transport
+               divergence(k,iCell) = divergence(k,iCell) &
+                                   - edgeSignOnCell_temp*r_tmp
+               div_hu(k) = div_hu(k) &
+                         - layerThicknessEdgeFlux(k,iEdge)* &
+                           edgeSignOnCell_temp*r_tmp
                div_huTransport(k) = div_huTransport(k) &
-                                    - layerThicknessEdgeFlux(k, iEdge) * edgeSignOnCell_temp &
-                                    * dvEdge_temp * normalTransportVelocity(k, iEdge) * invAreaCell1
+                                  - layerThicknessEdgeFlux(k,iEdge)* &
+                                    edgeSignOnCell_temp*dvEdge_temp* &
+                                    normalTransportVelocity(k,iEdge)* &
+                                    invAreaCell1
+               kineticEnergyCell(k,iCell) = kineticEnergyCell(k,iCell) &
+                                          + 0.25*r_tmp*dcEdge_temp* &
+                                            normalVelocity(k,iEdge)
             end do
          end do
-         ! Vertical velocity at bottom (maxLevelCell(iCell)+1) is zero, initialized above.
-         vertVelocityTop(1:minLevelCell(iCell)-1, iCell) = 0.0_RKIND
-         vertVelocityTop(maxLevelCell(iCell)+1, iCell) = 0.0_RKIND
-         do k = maxLevelCell(iCell), 1, -1
-            vertVelocityTop(k,iCell) = vertVelocityTop(k+1,iCell) - div_hu(k)
-            vertTransportVelocityTop(k,iCell) = vertTransportVelocityTop(k+1,iCell) - div_huTransport(k)
+         ! Vertical velocity at bottom is zero, initialized above.
+         vertVelocityTop(1:kmin-1,iCell) = 0.0_RKIND
+         vertVelocityTop(kmax+1  ,iCell) = 0.0_RKIND
+         vertTransportVelocityTop(1:kmin-1,iCell) = 0.0_RKIND
+         vertTransportVelocityTop(kmax+1  ,iCell) = 0.0_RKIND
+         do k = kmax, 1, -1
+            vertVelocityTop(k,iCell) = &
+            vertVelocityTop(k+1,iCell) - div_hu(k)
+            vertTransportVelocityTop(k,iCell) = &
+            vertTransportVelocityTop(k+1,iCell) - div_huTransport(k)
          end do
       end do
 #ifndef MPAS_OPENACC
       !$omp end do
-      !$omp end parallel
 #endif
 
+      !$acc exit data delete(div_hu, div_huTransport)
       deallocate(div_hu,div_huTransport)
 
-      nEdges = nEdgesHalo( 2 )
+      ! Compute tangential velocity
+
+      nEdges = nEdgesHalo(2)
+
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector &
-      !$acc          present(tangentialVelocity, nEdgesOnEdge, edgesOnEdge, weightsOnEdge, &
-      !$acc                  maxLevelEdgeTop, normalVelocity, minLevelEdgeBot) &
-      !$acc          private(i, eoe, weightsOnEdge_temp, k)
+      !$acc    present(tangentialVelocity, normalVelocity, &
+      !$acc            weightsOnEdge, nEdgesOnEdge, edgesOnEdge, &
+      !$acc            minLevelEdgeBot, maxLevelEdgeTop) &
+      !$acc    private(i, k, kmin, kmax, eoe, weightsOnEdge_temp)
 #else
-      !$omp parallel
-      !$omp do schedule(runtime) private(i, eoe, weightsOnEdge_temp, k)
+      !$omp do schedule(runtime) &
+      !$omp    private(i, k, kmin, kmax, eoe, weightsOnEdge_temp)
 #endif
       do iEdge = 1, nEdges
-         tangentialVelocity(:, iEdge) = 0.0_RKIND
-         ! Compute v (tangential) velocities
+         tangentialVelocity(:,iEdge) = 0.0_RKIND
+         kmin = minLevelEdgeBot(iEdge)
+         kmax = maxLevelEdgeTop(iEdge)
          do i = 1, nEdgesOnEdge(iEdge)
             eoe = edgesOnEdge(i,iEdge)
             weightsOnEdge_temp = weightsOnEdge(i, iEdge)
-            do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-               tangentialVelocity(k,iEdge) = tangentialVelocity(k,iEdge) &
-                                              + weightsOnEdge_temp * normalVelocity(k, eoe)
+            do k = kmin,kmax
+               tangentialVelocity(k,iEdge) = &
+               tangentialVelocity(k,iEdge) + weightsOnEdge_temp* &
+                                             normalVelocity(k, eoe)
             end do
          end do
       end do
@@ -1950,6 +2046,8 @@ contains
       !$omp end do
       !$omp end parallel
 #endif
+
+   !--------------------------------------------------------------------
 
    end subroutine ocn_diagnostic_solve_vortVel!}}}
 
@@ -2249,131 +2347,141 @@ contains
 !
 !  routine ocn_diagnostic_solve_pressure
 !
-!> \brief   Computes diagnostic variables for pressure or montgomery potential
+!> \brief   Computes pressure or Montgomery potential at all levels
 !> \author  Matt Turner, Xylar Asay-Davis
 !> \date    Jan. 2021
 !> \details
-!>  This routine computes the diagnostic variables for pressure or montgomery potential
+!>  This routine computes the pressure or Montgomery potential
 !
 !-----------------------------------------------------------------------
+
    subroutine ocn_diagnostic_solve_pressure(layerThickness, density, &
                 surfacePressure, montgomeryPotential, pressure)!{{{
 
-      implicit none
-
       !-----------------------------------------------------------------
-      !
       ! input variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThickness
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         density
+         layerThickness, &!< [in] layer thickness
+         density          !< [in] density
+
       real (kind=RKIND), dimension(:), intent(in) :: &
-         surfacePressure
+         surfacePressure  !< [in] pressure at surface
 
       !-----------------------------------------------------------------
-      !
       ! output variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(out) :: &
-         montgomeryPotential
-      real (kind=RKIND), dimension(:,:), intent(out) :: &
-         pressure
-
+         montgomeryPotential, &!< [out] Montgomery potential at all lvls
+         pressure              !< [out] pressure at all levels
 
       !-----------------------------------------------------------------
-      !
       ! local variables
-      !
       !-----------------------------------------------------------------
 
-      integer :: nCells
-      integer :: iCell
-      integer :: k
+      integer :: &
+         nCells,    &! number of cells
+         iCell, k,  &! cell, vertical loop indices
+         kmin, kmax  ! min, max active vertical levels
 
-      real (kind=RKIND), dimension(:), allocatable:: pTop
-#ifdef MPAS_OPENACC
-      !$acc declare device_resident(pTop)
-#endif
+      real (kind=RKIND), dimension(:), allocatable :: &
+         pTop      ! local pressure at top of layer
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
 
       !
-      ! Pressure
-      ! This section must be placed in the code after computing the density.
+      ! If needed, compute Montgomery potential
+      !   This is the preferred option when layers are isopycnal though
+      !     pressure_and_zmid option can be used for isopycnal as well
       !
 
       nCells = nCellsAll
-      if (config_pressure_gradient_type.eq.'MontgomeryPotential') then
+      if (config_pressure_gradient_type == 'MontgomeryPotential') then
 
-        ! use Montgomery Potential when layers are isopycnal.
-        ! However, one may use 'pressure_and_zmid' when layers are isopycnal as well.
-        ! Compute pressure at top of each layer, and then Montgomery Potential.
-
-        allocate(pTop(nVertLevels))
+         allocate(pTop(nVertLevels))
+         !$acc enter data create(pTop)
 
 #ifdef MPAS_OPENACC
-        !$acc parallel loop present(minLevelCell, bottomdepth, montgomeryPotential, &
-        !$acc                       density, layerThickness)
+         !$acc parallel loop &
+         !$acc    present(montgomeryPotential, density, bottomDepth, & 
+         !$acc            layerThickness, minLevelCell) &
+         !$acc    private(pTop, k, kmin)
 #else
-        !$omp parallel
-        !$omp do schedule(runtime) private(pTop, k)
+         !$omp parallel
+         !$omp do schedule(runtime) private(pTop, k, kmin)
 #endif
-        do iCell = 1, nCells
+         do iCell = 1, nCells
 
-           ! assume atmospheric pressure at the surface is zero for now.
-           pTop(1) = 0.0_RKIND
-           ! At top layer it is g*SSH, where SSH may be off by a
-           ! constant (ie, bottomDepth can be relative to top or bottom)
-           montgomeryPotential(minLevelCell(iCell),iCell) = gravity &
-              * (bottomDepth(iCell) + sum(layerThickness(1:nVertLevels,iCell)))
+            ! assume atmospheric pressure at surface is zero for now
+            pTop(1) = 0.0_RKIND
+            ! At top layer it is g*SSH, where SSH may be off by a
+            ! constant (ie, bottomDepth can be relative to top or bottom)
+            kmin = minLevelCell(iCell)
+            montgomeryPotential(kmin,iCell) = gravity &
+                   * (bottomDepth(iCell) + &
+                      sum(layerThickness(1:nVertLevels,iCell)))
 
-           do k = 2, nVertLevels
-              pTop(k) = pTop(k-1) + density(k-1,iCell)*gravity* layerThickness(k-1,iCell)
+            do k = 2, nVertLevels
+               pTop(k) = pTop(k-1) + density(k-1,iCell)*gravity* &
+                              layerThickness(k-1,iCell)
 
-              ! from delta M = p delta / density
-              montgomeryPotential(k,iCell) = montgomeryPotential(k-1,iCell) &
-                 + pTop(k)*(1.0_RKIND/density(k,iCell) - 1.0_RKIND/density(k-1,iCell))
-           end do
+               ! from delta M = p delta / density
+               montgomeryPotential(k  ,iCell) = &
+               montgomeryPotential(k-1,iCell) + pTop(k)* &
+                             (1.0_RKIND/density(k  ,iCell) -  &
+                              1.0_RKIND/density(k-1,iCell))
+            end do
 
-        end do
+         end do
 #ifndef MPAS_OPENACC
-        !$omp end do
-        !$omp end parallel
+         !$omp end do
+         !$omp end parallel
 #endif
 
-        deallocate(pTop)
+         !$acc exit data delete(pTop)
+         deallocate(pTop)
+
+      !
+      ! Otherwise, compute pressure for generalized coordinates.
+      !
 
       else
 
 #ifdef MPAS_OPENACC
-        !$acc parallel loop present(layerThickness, pressure, surfacePressure, density, &
-        !$acc                       minLevelCell, maxLevelCell)
+         !$acc parallel loop &
+         !$acc    present(pressure, surfacePressure, density, &
+         !$acc            layerThickness, minLevelCell, maxLevelCell) &
+         !$acc    private(k, kmin, kmax)
 #else
-        !$omp parallel
-        !$omp do schedule(runtime) private(k)
+         !$omp parallel
+         !$omp do schedule(runtime) private(k, kmin, kmax)
 #endif
-        do iCell = 1, nCells
-           ! Pressure for generalized coordinates.
-           pressure(minLevelCell(iCell),iCell) = surfacePressure(iCell) &
-             + density(minLevelCell(iCell),iCell)*gravity*0.5_RKIND*layerThickness(minLevelCell(iCell),iCell)
+         do iCell = 1, nCells
+            kmin = minLevelCell(iCell)
+            kmax = maxLevelCell(iCell)
+            pressure(kmin,iCell) = surfacePressure(iCell) &
+                                 + density(kmin,iCell)*gravity* &
+                                   0.5_RKIND*layerThickness(kmin,iCell)
 
-           do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
-              pressure(k,iCell) = pressure(k-1,iCell)  &
-                + 0.5_RKIND*gravity*(  density(k-1,iCell)*layerThickness(k-1,iCell) &
-                                     + density(k  ,iCell)*layerThickness(k  ,iCell))
-           end do
-
-        end do
+            do k = kmin+1, kmax
+               pressure(k,iCell) = pressure(k-1,iCell) &
+                                 + 0.5_RKIND*gravity* &
+                    (  density(k-1,iCell)*layerThickness(k-1,iCell) &
+                     + density(k  ,iCell)*layerThickness(k  ,iCell))
+            end do
+         end do
 #ifndef MPAS_OPENACC
-        !$omp end do
-        !$omp end parallel
+         !$omp end do
+         !$omp end parallel
 #endif
 
       endif
+
+   !--------------------------------------------------------------------
 
    end subroutine ocn_diagnostic_solve_pressure!}}}
 
@@ -3073,10 +3181,8 @@ contains
       real (kind=RKIND) :: blThickness, dz, weightSum, h_nu, Gamma_turb, landIceEdgeFraction, velocityMagnitude
 
       ! Scratch Arrays
-      real (kind=RKIND), dimension(:), allocatable ::  blTempScratch, blSaltScratch
-#ifdef MPAS_OPENACC
-      !$acc declare device_resident(blTempScratch, blSaltScratch)
-#endif
+      real (kind=RKIND), dimension(:), allocatable ::  &
+         blTempScratch, blSaltScratch
 
       ! constants for Holland and Jenkins 1999 parameterization of the boundary layer
       real (kind=RKIND), parameter :: &
@@ -3087,6 +3193,8 @@ contains
          xiN = 0.052_RKIND              ! dimensionless planetary boundary layer constant
 
       integer :: indexBLTval, indexBLSval, indexHeatTransval, indexSaltTransval
+
+      !-----------------------------------------------------------------
 
       if ( trim(config_land_ice_flux_mode) .ne. 'standalone' .and. trim(config_land_ice_flux_mode) .ne. 'coupled' ) then
          return
@@ -3101,6 +3209,7 @@ contains
 
       allocate(blTempScratch(nCellsAll), &
                blSaltScratch(nCellsAll))
+      !$acc enter data create(blTempScratch, blSaltScratch)
 
       ! Compute top drag
 #ifdef MPAS_OPENACC
@@ -3152,7 +3261,9 @@ contains
 
       ! average temperature and salinity over horizontal neighbors and the sub-ice-shelf boundary layer
 #ifdef MPAS_OPENACC
-      !$acc parallel loop present(minLevelCell, maxLevelCell, layerThickness, activeTracers)
+      !$acc parallel loop &
+      !$acc    present(blTempScratch, blSaltScratch, activeTracers, &
+      !$acc            minLevelCell, maxLevelCell, layerThickness)
 #else
       !$omp do schedule(runtime) private(blThickness, iLevel, dz)
 #endif
@@ -3177,8 +3288,10 @@ contains
 #endif
 
 #ifdef MPAS_OPENACC
-      !$acc parallel loop present(cellsOnCell, nEdgesOnCell, minLevelCell) &
-      !$acc    present(landIceBoundaryLayerTracers, cellMask)
+      !$acc parallel loop &
+      !$acc    present(landIceBoundaryLayerTracers, &
+      !$acc            blTempScratch, blSaltScratch, cellMask, &
+      !$acc            nEdgesOnCell, cellsOnCell, minLevelCell)
 #else
       !$omp do schedule(runtime) private(weightSum, i, cell2)
 #endif
@@ -3224,7 +3337,9 @@ contains
 #endif
       else if(hollandJenkinsOn) then
 #ifdef MPAS_OPENACC
-         !$acc parallel loop present(fCell, landIceTracerTransferVelocities, landIceFrictionVelocity)
+         !$acc parallel loop &
+         !$acc    present(fCell, landIceTracerTransferVelocities, &
+         !$acc            landIceFrictionVelocity)
 #else
          !$omp parallel
          !$omp do schedule(runtime) private(h_nu, Gamma_turb)
@@ -3251,6 +3366,7 @@ contains
 #endif
       end if
 
+      !$acc exit data delete(blTempScratch, blSaltScratch)
       deallocate(blTempScratch, &
                  blSaltScratch)
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -2940,56 +2940,87 @@ contains
 !
 !-----------------------------------------------------------------------
 
-    subroutine ocn_compute_KPP_input_fields(statePool, forcingPool, meshPool, timeLevelIn)!{{{
+    subroutine ocn_compute_KPP_input_fields(statePool, forcingPool, &
+                                            meshPool, timeLevelIn)!{{{
 
-      type (mpas_pool_type), intent(in) :: statePool !< Input/Output: State information
-      type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
-      type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
-      integer, intent(in), optional :: timeLevelIn
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
 
-      ! pool pointers
-      type (mpas_pool_type), pointer :: tracersSurfaceFluxPool
-      type (mpas_pool_type), pointer :: tracersPool
+      type (mpas_pool_type), intent(in) :: &
+         statePool,  &!< [in] State information
+         meshPool,   &!< [in] Mesh information (for pass to eq state)
+         forcingPool  !< [in] Forcing information
 
-      ! scalars
-      integer :: nCells
+      integer, intent(in), optional :: &
+         timeLevelIn  !< [in] optional time level for state variables
 
-      ! real pointers
-      real (kind=RKIND), dimension(:), pointer :: penetrativeTemperatureFlux, surfaceThicknessFlux, &
-           surfaceThicknessFluxRunoff, rainTemperatureFlux, evapTemperatureFlux, &
-           icebergTemperatureFlux, seaIceTemperatureFlux
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
 
-      real (kind=RKIND), dimension(:), pointer :: surfaceStress, surfaceStressMagnitude
+      integer :: &
+         iCell, iEdge, i, &! loop indices for cell, edge, neighbors
+         kmin,            &! topmost active cell index
+         nCells,          &! number of cells
+         err,             &! local error code
+         indexTempFlux,   &! index of temperature in tracer array
+         indexSaltFlux,   &! index of salinity    in tracer array
+         timeLevel         ! time level for state variables (default 1)
+
+      real (kind=RKIND) :: &
+         fracAbsorbed,       &! fraction of sfc flux absorbed
+         fracAbsorbedRunoff, &! same for runoff
+         sumSurfaceStressSquared ! sum of sfc stress squared
+
+      ! pointers for variable/pool retrievals
+      type (mpas_pool_type), pointer :: &
+         tracersSurfaceFluxPool, &! pool of tracer surface fluxes
+         tracersPool              ! pool of tracers
+
+      real (kind=RKIND), dimension(:), pointer :: &
+         penetrativeTemperatureFlux, &! various sfc flux components
+         surfaceThicknessFlux, &
+         surfaceThicknessFluxRunoff, &
+         rainTemperatureFlux, &
+         evapTemperatureFlux, &
+         icebergTemperatureFlux, &
+         seaIceTemperatureFlux, &
+         surfaceStress, &
+         surfaceStressMagnitude
+
       real (kind=RKIND), dimension(:,:), pointer ::  &
-           layerThickness, &
-           normalVelocity, activeTracersSurfaceFlux, &
-           activeTracersSurfaceFluxRunoff, nonLocalSurfaceTracerFlux
+         layerThickness,           &! layer thickness
+         normalVelocity,           &! normal velocity
+         activeTracersSurfaceFlux, &! sfc flux of active tracers (T,S)
+         activeTracersSurfaceFluxRunoff, &! flx of tracers in runoff
+         nonLocalSurfaceTracerFlux  ! non-local flux of tracers
 
       real (kind=RKIND), dimension(:,:,:), pointer :: &
-           activeTracers
+         activeTracers  ! array of active tracers
 
-      ! local
-      integer :: iCell, iEdge, i, err, timeLevel
-      integer, pointer :: indexTempFlux, indexSaltFlux
-      real (kind=RKIND) :: turbulentVelocitySquared, fracAbsorbed, fracAbsorbedRunoff
-      real (kind=RKIND) :: sumSurfaceStressSquared
+      integer, pointer :: &
+         indexTempFluxPtr, indexSaltFluxPtr
 
       ! Scratch Arrays
-      ! densitySurfaceDisplaced: Density computed by displacing SST and SSS to every vertical
-      !                          layer within the column
-      !                   units: kg m^{-3}
-      real (kind=RKIND), dimension(:,:), allocatable :: densitySurfaceDisplaced
-#ifdef MPAS_OPENACC
-      !$acc declare device_resident(densitySurfaceDisplaced)
-#endif
-      ! thermalExpansionCoeff: Thermal expansion coefficient (alpha), defined as $-1/\rho
-      !                        d\rho/dT$ (note negative sign)
-      !                 units: C^{-1}
-      real (kind=RKIND), dimension(:,:), allocatable :: thermalExpansionCoeff
-      ! salineContractionCoeff: Saline contraction coefficient (beta), defined as $1/\rho
-      !                         d\rho/dS$.  This is also called the haline contraction coefficient.
-      !                  units: PSU^{-1}
-      real (kind=RKIND), dimension(:,:), allocatable :: salineContractionCoeff
+      ! densitySurfaceDisplaced: Density computed by displacing SST
+      !    and SSS to every vertical layer within the column
+      !    units: kg m^{-3}
+      ! thermalExpansionCoeff: Thermal expansion coefficient (alpha),
+      !    defined as $-1/\rho d\rho/dT$ (note negative sign)
+      !    units: C^{-1}
+      ! salineContractionCoeff: Saline contraction coefficient (beta),
+      !    defined as $1/\rho d\rho/dS$.  This is also called the
+      !    haline contraction coefficient.  units: PSU^{-1}
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         densitySurfaceDisplaced, &
+         thermalExpansionCoeff,   &
+         salineContractionCoeff
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
 
       call mpas_timer_start('KPP input fields')
 
@@ -2999,34 +3030,55 @@ contains
          timeLevel = 1
       end if
 
-      call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceFlux', tracersSurfaceFluxPool)
+      ! Retrieve variables from pool
+      call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceFlux', &
+                                               tracersSurfaceFluxPool)
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-      call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, timeLevel)
-      ! set the parameter turbulentVelocitySquared
-      turbulentVelocitySquared = 0.001_RKIND
 
-      ! set scalar values
-      call mpas_pool_get_dimension(tracersSurfaceFluxPool, 'index_temperatureSurfaceFlux', indexTempFlux)
-      call mpas_pool_get_dimension(tracersSurfaceFluxPool, 'index_salinitySurfaceFlux', indexSaltFlux)
+      call mpas_pool_get_dimension(tracersSurfaceFluxPool, &
+                                  'index_temperatureSurfaceFlux', &
+                                   indexTempFluxPtr)
+      call mpas_pool_get_dimension(tracersSurfaceFluxPool, &
+                                  'index_salinitySurfaceFlux', &
+                                   indexSaltFluxPtr)
+      indexTempFlux = indexTempFluxPtr
+      indexSaltFlux = indexSaltFluxPtr
 
-      ! set pointers into state, mesh, diagnostics and scratch
-      call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
-      call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
+      call mpas_pool_get_array(tracersSurfaceFluxPool, &
+                              'nonLocalSurfaceTracerFlux', &
+                               nonLocalSurfaceTracerFlux)
+      call mpas_pool_get_array(tracersSurfaceFluxPool, &
+                              'activeTracersSurfaceFlux', &
+                               activeTracersSurfaceFlux)
+      call mpas_pool_get_array(tracersSurfaceFluxPool, &
+                              'activeTracersSurfaceFluxRunoff', &
+                               activeTracersSurfaceFluxRunoff)
 
-      call mpas_pool_get_array(tracersSurfaceFluxPool, 'nonLocalSurfaceTracerFlux', nonLocalSurfaceTracerFlux)
+      call mpas_pool_get_array(tracersPool, 'activeTracers', &
+                                             activeTracers, timeLevel)
+      call mpas_pool_get_array(statePool, 'normalVelocity', &
+                                           normalVelocity, timeLevel)
+      call mpas_pool_get_array(statePool, 'layerThickness', &
+                                           layerThickness, timeLevel)
 
-      call mpas_pool_get_array(forcingPool, 'surfaceThicknessFlux', surfaceThicknessFlux)
-      call mpas_pool_get_array(forcingPool, 'surfaceThicknessFluxRunoff', surfaceThicknessFluxRunoff)
-      call mpas_pool_get_array(forcingPool, 'penetrativeTemperatureFlux', penetrativeTemperatureFlux)
-      call mpas_pool_get_array(forcingPool, 'surfaceStress', surfaceStress)
-      call mpas_pool_get_array(forcingPool, 'surfaceStressMagnitude', surfaceStressMagnitude)
-      call mpas_pool_get_array(forcingPool, 'rainTemperatureFlux', rainTemperatureFlux)
-      call mpas_pool_get_array(forcingPool, 'evapTemperatureFlux', evapTemperatureFlux)
-      call mpas_pool_get_array(forcingPool, 'seaIceTemperatureFlux', seaIceTemperatureFlux)
-      call mpas_pool_get_array(forcingPool, 'icebergTemperatureFlux', icebergTemperatureFlux)
-      call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
-      call mpas_pool_get_array(tracersSurfaceFluxPool, 'activeTracersSurfaceFlux', activeTracersSurfaceFlux)
-      call mpas_pool_get_array(tracersSurfaceFluxPool, 'activeTracersSurfaceFluxRunoff', activeTracersSurfaceFluxRunoff)
+      call mpas_pool_get_array(forcingPool, 'surfaceThicknessFlux', &
+                                             surfaceThicknessFlux)
+      call mpas_pool_get_array(forcingPool, 'surfaceThicknessFluxRunoff', &
+                                             surfaceThicknessFluxRunoff)
+      call mpas_pool_get_array(forcingPool, 'penetrativeTemperatureFlux', &
+                                             penetrativeTemperatureFlux)
+      call mpas_pool_get_array(forcingPool, 'surfaceStress', &
+                                             surfaceStress)
+      call mpas_pool_get_array(forcingPool, 'surfaceStressMagnitude', &
+                                             surfaceStressMagnitude)
+      call mpas_pool_get_array(forcingPool, 'rainTemperatureFlux', &
+                                             rainTemperatureFlux)
+      call mpas_pool_get_array(forcingPool, 'evapTemperatureFlux', &
+                                             evapTemperatureFlux)
+      call mpas_pool_get_array(forcingPool, 'seaIceTemperatureFlux', &
+                                             seaIceTemperatureFlux)
+      call mpas_pool_get_array(forcingPool, 'icebergTemperatureFlux', &
+                                             icebergTemperatureFlux)
 
       ! allocate scratch space displaced density computation
       ncells = nCellsAll
@@ -3034,95 +3086,125 @@ contains
       allocate(densitySurfaceDisplaced(nVertLevels, nCells), &
                thermalExpansionCoeff(nVertLevels, nCells), &
                salineContractionCoeff(nVertLevels, nCells))
+      !$acc enter data create(thermalExpansionCoeff,  &
+      !$acc                   salineContractionCoeff, &
+      !$acc                   densitySurfaceDisplaced)
 
       ! Only need to compute over the 0 and 1 halos
       nCells = nCellsHalo( 2 )
 
-#ifdef MPAS_OPENACC
-      !$acc enter data create(thermalExpansionCoeff,   &
-      !$acc                   salineContractionCoeff)
-#endif
+      ! compute displaced density defined as density computed
+      ! from T, S that have been displaced (adiabatically) from surface
 
-      ! compute EOS by displacing SST/SSS to every vertical layer in column
+      call ocn_equation_of_state_density(statePool, meshPool, &
+                          activeTracers, tracersSurfaceValue, &
+                          nCells, 0, 'surfaceDisplaced', &
+                          densitySurfaceDisplaced, err, &
+                          thermalExpansionCoeff, &
+                          salineContractionCoeff, timeLevel)
 
-      ! inputs: activeTracers, tracersSurfaceValue,maxLevelCell,refBottomDepth 
-      ! outputs: densitySurfaceDisplayed, thermalExpansionCoeff, salineContractionCoeff
-      call ocn_equation_of_state_density(statePool, meshPool, activeTracers, tracersSurfaceValue, &
-                                         nCells, 0, 'surfaceDisplaced', densitySurfaceDisplaced, &
-                                         err, thermalExpansionCoeff, salineContractionCoeff, &
-                                         timeLevel)
+      !$acc exit data copyout(thermalExpansionCoeff,  &
+      !$acc                   salineContractionCoeff, &
+      !$acc                   densitySurfaceDisplaced)
 
-#ifdef MPAS_OPENACC
-      !$acc exit data copyout(thermalExpansionCoeff,   &
-      !$acc                   salineContractionCoeff)
-#endif
+      ! compute surface buoyancy forcing based on surface fluxes of
+      ! mass, temperature, salinity and frazil (frazil to be added later)
+      ! since this computation is confusing, variables, units and sign
+      ! convention is repeated here
+      ! everything below should be consistent with that specified in
+      !   Registry and with the CVMix/KPP documentation:
+      !    https://www.dropbox.com/s/6hqgc0rsoa828nf/cvmix_20aug2013.pdf
+      !
+      ! surfaceThicknessFlux: surface mass flux, m/s, positive into ocean
+      ! activeTracersSurfaceFlux(indexTempFlux): non-penetrative
+      !    temperature flux, C m/s, positive into ocean
+      ! penetrativeTemperatureFlux: penetrative surface temperature
+      !    flux at ocean surface, positive into ocean
+      ! activeTracersSurfaceFlux(indexSaltFlux): salinity flux, PSU m/s,
+      !    positive into ocean
+      ! penetrativeTemperatureFluxOBL: penetrative temperature flux
+      !    computed at z=OBL, positive down
+      !
+      ! note: the following fields used the CVMix/KPP computation of
+      !    buoyancy forcing are not included here
+      !    1. Tm: temperature associated with surfaceThicknessFlux,
+      !           C  (here we assume Tm == temperatureSurfaceValue)
+      !    2. Sm: salinity associated with surfaceThicknessFlux, PSU 
+      !           (here we assume Sm == salinitySurfaceValue and
+      !            account for salinity flux in
+      !            activeTracersSurfaceFlux array)
+      !
 
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(fracAbsorbed, fracAbsorbedRunoff, sumSurfaceStressSquared, i, iEdge)
+      !$omp private(kmin, fracAbsorbed, fracAbsorbedRunoff, &
+      !$omp         sumSurfaceStressSquared, i, iEdge)
       do iCell = 1, nCells
-         ! compute surface buoyancy forcing based on surface fluxes of mass, temperature, salinity and frazil
-         !                                (frazil to be added later)
-         ! since this computation is confusing, variables, units and sign convention is repeated here
-         ! everything below should be consistent with that specified in Registry
-         ! everything below should be consistent with the CVMix/KPP documentation:
-         !           https://www.dropbox.com/s/6hqgc0rsoa828nf/cvmix_20aug2013.pdf
-         !
-         !    surfaceThicknessFlux: surface mass flux, m/s, positive into ocean
-         !    activeTracersSurfaceFlux(indexTempFlux): non-penetrative temperature flux, C m/s, positive into ocean
-         !    penetrativeTemperatureFlux: penetrative surface temperature flux at ocean surface, positive into ocean
-         !    activeTracersSurfaceFlux(indexSaltFlux): salinity flux, PSU m/s, positive into ocean
-         !    penetrativeTemperatureFluxOBL: penetrative temperature flux computed at z=OBL, positive down
-         !
-         ! note: the following fields used the CVMix/KPP computation of buoyancy forcing are not included here
-         !    1. Tm: temperature associated with surfaceThicknessFlux, C  (here we assume Tm == temperatureSurfaceValue)
-         !    2. Sm: salinity associated with surfaceThicknessFlux, PSU (here we assume Sm == salinitySurfaceValue and account for
-         !           salinity flux in activeTracersSurfaceFlux array)
-         !
 
+         kmin = minLevelCell(iCell)
          ! Compute fraction of thickness flux that is in the top model layer
-         fracAbsorbed = 1.0_RKIND - exp( max(-layerThickness(minLevelCell(iCell), iCell) / config_flux_attenuation_coefficient, -100.0_RKIND) )
-         fracAbsorbedRunoff = 1.0_RKIND - exp( max(-layerThickness(minLevelCell(iCell), iCell) / config_flux_attenuation_coefficient_runoff, &
-                              -100.0_RKIND) )
-         ! Store the total tracer flux below in nonLocalSurfaceTemperatureFlux for use in the CVMix nonlocal
-         ! transport code.  This includes tracer forcing due to thickness
+         fracAbsorbed = 1.0_RKIND &
+                      - exp( max(-100.0_RKIND, &
+                                 -layerThickness(kmin, iCell)/ &
+                           config_flux_attenuation_coefficient))
+         fracAbsorbedRunoff = 1.0_RKIND &
+                      - exp( max(-100.0_RKIND, &
+                                 -layerThickness(kmin, iCell)/ &
+                           config_flux_attenuation_coefficient_runoff))
 
-         nonLocalSurfaceTracerFlux(indexTempFlux, iCell) = activeTracersSurfaceFlux(indexTempFlux,iCell) &
-                 + penetrativeTemperatureFlux(iCell) - penetrativeTemperatureFluxOBL(iCell)  &
-                 - fracAbsorbed * (rainTemperatureFlux(iCell) + evapTemperatureFlux(iCell) + &
-                                   seaIceTemperatureFlux(iCell) + icebergTemperatureFlux(iCell)) &
-                 - fracAbsorbedRunoff * activeTracersSurfaceFluxRunoff(indexTempFlux, iCell)
+         ! Store the total tracer flux below in
+         ! nonLocalSurfaceTemperatureFlux for use in the CVMix nonlocal
+         ! transport code. This includes tracer forcing due to thickness
 
-         nonLocalSurfaceTracerFlux(indexSaltFlux,iCell) = activeTracersSurfaceFlux(indexSaltFlux,iCell) &
-                 - fracAbsorbed * surfaceThicknessFlux(iCell) * activeTracers(indexSaltFlux,minLevelCell(iCell),iCell) &
-                 - fracAbsorbedRunoff * surfaceThicknessFluxRunoff(iCell) * activeTracers(indexSaltFlux,minLevelCell(iCell),iCell)
+         nonLocalSurfaceTracerFlux(indexTempFlux, iCell) = &
+                   activeTracersSurfaceFlux(indexTempFlux,iCell) &
+                 + penetrativeTemperatureFlux(iCell) &
+                 - penetrativeTemperatureFluxOBL(iCell)  &
+                 - fracAbsorbed* (rainTemperatureFlux(iCell) + &
+                                  evapTemperatureFlux(iCell) + &
+                                  seaIceTemperatureFlux(iCell) + &
+                                  icebergTemperatureFlux(iCell)) &
+                 - fracAbsorbedRunoff* &
+                   activeTracersSurfaceFluxRunoff(indexTempFlux,iCell)
 
-         surfaceBuoyancyForcing(iCell) =  thermalExpansionCoeff (minLevelCell(iCell),iCell) &
-                * nonLocalSurfaceTracerFlux(indexTempFlux,iCell) &
-                - salineContractionCoeff(minLevelCell(iCell),iCell) * nonLocalSurfaceTracerFlux(indexSaltFlux,iCell)
+         nonLocalSurfaceTracerFlux(indexSaltFlux,iCell) = &
+                   activeTracersSurfaceFlux(indexSaltFlux,iCell) &
+                 - fracAbsorbed*surfaceThicknessFlux(iCell)* &
+                   activeTracers(indexSaltFlux,kmin,iCell) &
+                 - fracAbsorbedRunoff*surfaceThicknessFluxRunoff(iCell)* &
+                   activeTracers(indexSaltFlux,kmin,iCell)
+
+         surfaceBuoyancyForcing(iCell) = &
+                  thermalExpansionCoeff(kmin,iCell)* &
+                  nonLocalSurfaceTracerFlux(indexTempFlux,iCell) &
+                - salineContractionCoeff(kmin,iCell)* &
+                  nonLocalSurfaceTracerFlux(indexSaltFlux,iCell)
 
          ! at this point, surfaceBuoyancyForcing has units of m/s
-         ! change into units of m^2/s^3 (which can be thought of as the flux of buoyancy, units of buoyancy * velocity )
-         surfaceBuoyancyForcing(iCell) = surfaceBuoyancyForcing(iCell) * gravity
+         ! change into units of m^2/s^3 (which can be thought of as
+         ! the flux of buoyancy, units of buoyancy * velocity )
+         surfaceBuoyancyForcing(iCell) = surfaceBuoyancyForcing(iCell)* &
+                                         gravity
 
          ! compute magnitude of surface stress
          sumSurfaceStressSquared = 0.0_RKIND
          do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
-            sumSurfaceStressSquared = sumSurfaceStressSquared + edgeAreaFractionOfCell(i,iCell) * surfaceStress(iEdge)**2
+            sumSurfaceStressSquared = sumSurfaceStressSquared &
+                                    + edgeAreaFractionOfCell(i,iCell)* &
+                                      surfaceStress(iEdge)**2
          enddo
-         ! NOTE that the factor of 2 is from averaging dot products to cell centers on a C-grid
-         surfaceStressMagnitude(iCell) = sqrt(2.0_RKIND * sumSurfaceStressSquared)
-         surfaceFrictionVelocity(iCell) = sqrt(surfaceStressMagnitude(iCell) / rho_sw)
+
+         ! NOTE that the factor of 2 is from averaging dot products
+         ! to cell centers on a C-grid
+         surfaceStressMagnitude(iCell) = &
+                           sqrt(2.0_RKIND * sumSurfaceStressSquared)
+         surfaceFrictionVelocity(iCell) = &
+                           sqrt(surfaceStressMagnitude(iCell) / rho_sw)
 
       enddo
       !$omp end do
       !$omp end parallel
-
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(thermalExpansionCoeff,   &
-      !$acc                  salineContractionCoeff)
-#endif
 
       ! deallocate scratch space
       deallocate(thermalExpansionCoeff, &
@@ -3130,6 +3212,8 @@ contains
                  densitySurfaceDisplaced)
 
       call mpas_timer_stop('KPP input fields')
+
+    !-------------------------------------------------------------------
 
     end subroutine ocn_compute_KPP_input_fields!}}}
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_effective_density_in_land_ice.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_effective_density_in_land_ice.F
@@ -27,6 +27,7 @@ module ocn_effective_density_in_land_ice
 
    use ocn_constants
    use ocn_config
+   use ocn_mesh
 
    implicit none
    private
@@ -65,102 +66,101 @@ contains
 !> \date   10/03/2015
 !> \details
 !>  This routine updates the value of the effective seawater density
-!>  displaced by land ice, based on Archimedes' principle.  The effective
-!>  density is smoothed and extrapolated by averaging with nearest neighbors
-!>  (cellsOnCell).
+!>  displaced by land ice, based on Archimedes' principle.  The
+!>  effective density is smoothed and extrapolated by averaging with
+!>  nearest neighbors (cellsOnCell).
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_effective_density_in_land_ice_update(meshPool, forcingPool, statePool, ierr)!{{{
+   subroutine ocn_effective_density_in_land_ice_update(forcingPool, &
+                                                    statePool, ierr)!{{{
 
       !-----------------------------------------------------------------
-      !
       ! input variables
-      !
       !-----------------------------------------------------------------
-      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
-      type (mpas_pool_type), intent(in) :: forcingPool !< Input: Forcing information
+
+      type (mpas_pool_type), intent(in) :: &
+         forcingPool !< [in] Forcing information
 
       !-----------------------------------------------------------------
-      !
       ! input/output variables
-      !
       !-----------------------------------------------------------------
-      type (mpas_pool_type), intent(inout) :: statePool !< Input/Output: state information
+
+      type (mpas_pool_type), intent(inout) :: &
+         statePool !< [inout] state information
 
       !-----------------------------------------------------------------
-      !
       ! output variables
-      !
       !-----------------------------------------------------------------
 
-      integer, intent(out) :: ierr !< Output: Error flag
+      integer, intent(out) :: ierr !< [out] Error flag
 
       !-----------------------------------------------------------------
-      !
       ! local variables
-      !
       !-----------------------------------------------------------------
 
-      real (kind=RKIND), dimension(:), pointer :: landIcePressure, &
-                                                  ssh, &
-                                                  effectiveDensityCur, &
-                                                  effectiveDensityNew
+      integer :: &
+         i, iCell,  &! loop indices for neighbor loop and cell loop
+         cell2       ! neighbor cell address
+
+      real (kind=RKIND) :: &
+         weightSum   ! local sum of weights for masked points
+
+      real (kind=RKIND), dimension(:), pointer :: &
+         ssh,                 &! sea surface height
+         landIcePressure,     &! land ice pressure
+         effectiveDensityCur, &! effective density at current time
+         effectiveDensityNew   ! effective density at new time level
                                                   
-      integer, dimension(:), pointer :: landIceMask
-
-      real (kind=RKIND) :: weightSum
-
-      integer :: iCell, cell2, i
-      integer :: nCells
-
-      integer, dimension(:,:), pointer :: cellsOnCell, cellMask
-
-      integer, dimension(:), pointer :: nEdgesOnCell
+      integer, dimension(:), pointer :: &
+         landIceMask           ! mask for land ice presence on cell
 
       ! Scratch Arrays
-      ! effectiveDensityScratch: effective seawater density in land ice before horizontal averaging
-      !                   units: kg m^{-3}
-      real (kind=RKIND), dimension(:), allocatable :: effectiveDensityScratch
-#ifdef MPAS_OPENACC
-      !$acc declare device_resident(effectiveDensityScratch)
-#endif
+      ! effectiveDensityScratch: effective seawater density in land
+      ! ice before horizontal averaging units: kg m^{-3}
+      real (kind=RKIND), dimension(:), allocatable :: &
+         effectiveDensityScratch
 
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      ! Set default return code and exit if not needed
       ierr = 0
+      if ( (trim(config_land_ice_flux_mode) /= 'coupled') ) return
 
-      if ( (trim(config_land_ice_flux_mode) .ne. 'coupled') ) then
-         return
-      end if
-
-      call mpas_pool_get_dimension_scalar(meshPool, 'nCells', nCells)
-
-      call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'cellMask', cellMask)
-
-      call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
-      call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
+      ! Retrieve forcing and state variables
+      call mpas_pool_get_array(forcingPool, 'landIceMask', &
+                                             landIceMask)
+      call mpas_pool_get_array(forcingPool, 'landIcePressure', &
+                                             landIcePressure)
       call mpas_pool_get_array(statePool, 'ssh', ssh, 2)
-      call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', effectiveDensityCur, 1)
-      call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', effectiveDensityNew, 2)
+      call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', &
+                                           effectiveDensityCur, 1)
+      call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', &
+                                           effectiveDensityNew, 2)
+      !$acc enter data copyin(landIceMask, landIcePressure, ssh, &
+      !$acc                   effectiveDensityCur, effectiveDensityNew)
 
-      allocate(effectiveDensityScratch(nCells))
+      allocate(effectiveDensityScratch(nCellsAll))
+      !$acc enter data create(effectiveDensityScratch)
 
+      ! Compute effective density in each cell
+      ! TODO: should only apply to floating land ice,
+      !       once wetting/drying is supported
 #ifdef MPAS_OPENACC
-      !$acc parallel present(ssh, landIcePressure, landIceMask, nEdgesOnCell, cellsOnCell, cellMask)
-#endif
-
-#ifdef MPAS_OPENACC
-      !$acc loop
+      !$acc parallel loop &
+      !$acc    present(effectiveDensityScratch, effectiveDensityCur, &
+      !$acc            landIcePressure, landIceMask, ssh)
 #else
       !$omp parallel
       !$omp do schedule(runtime)
 #endif
-      do iCell = 1, nCells
-         ! TODO: should only apply to floating land ice, once wetting/drying is supported
-         if(landIceMask(iCell) == 1) then
+      do iCell = 1, nCellsAll
+         if (landIceMask(iCell) == 1) then
             ! land ice is present to update the effective density
-            effectiveDensityScratch(iCell) = -landIcePressure(iCell)/(ssh(iCell)*gravity)
+            effectiveDensityScratch(iCell) = -landIcePressure(iCell)/ &
+                                              (ssh(iCell)*gravity)
          else
             ! we copy the previous effective density
             effectiveDensityScratch(iCell) = effectiveDensityCur(iCell)
@@ -170,30 +170,36 @@ contains
       !$omp end do
 #endif
 
+      ! smooth/extrapolate density by averaging with nearest neighbors
 #ifdef MPAS_OPENACC
-      !$acc loop private(weightSum)
+      !$acc parallel loop &
+      !$acc    present(effectiveDensityNew, effectiveDensityScratch, &
+      !$acc            nEdgesOnCell, cellsOnCell, cellMask) &
+      !$acc    private(weightSum)
 #else
       !$omp do schedule(runtime) private(weightSum, i, cell2)
 #endif
-      do iCell = 1, nCells
-         ! smooth/extrapolate by averaging with nearest neighbors
+      do iCell = 1, nCellsAll
          weightSum = 1.0_RKIND
          effectiveDensityNew(iCell) = effectiveDensityScratch(iCell)
          do i = 1, nEdgesOnCell(iCell)
             cell2 = cellsOnCell(i,iCell)
             effectiveDensityNew(iCell) = effectiveDensityNew(iCell) &
-               + cellMask(1,cell2)*effectiveDensityScratch(cell2)
+                                       + cellMask(1,cell2)* &
+                                         effectiveDensityScratch(cell2)
             weightSum = weightSum + cellMask(1,cell2)
          end do
-         effectiveDensityNew(iCell) = effectiveDensityNew(iCell)/weightSum
+         effectiveDensityNew(iCell) = effectiveDensityNew(iCell)/ &
+                                      weightSum
       end do
-#ifdef MPAS_OPENACC
-      !$acc end parallel
-#else
+#ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
 #endif
 
+      !$acc exit data delete(effectiveDensityScratch)
+      !$acc exit data delete(landIceMask, landIcePressure, ssh, &
+      !$acc                  effectiveDensityCur, effectiveDensityNew)
       deallocate(effectiveDensityScratch)
 
    !--------------------------------------------------------------------

--- a/components/mpas-ocean/src/shared/mpas_ocn_equation_of_state_jm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_equation_of_state_jm.F
@@ -221,9 +221,6 @@ contains
       real (kind=RKIND), dimension(:,:), allocatable :: &
          tracerTemp,          &! modified temperature
          tracerSalt            ! modified salinity
-#ifdef MPAS_OPENACC
-      !$acc declare device_resident(tracerTemp, tracerSalt)
-#endif
 
       real (kind=RKIND) :: &
          work1, work2,     &! temporary scalars for calc
@@ -309,12 +306,14 @@ contains
       ! For OpenACC, these are device resident only
       allocate(tracerTemp(nVertLevels,nCells), &
                tracerSalt(nVertLevels,nCells))
+      !$acc enter data create(tracerTemp, tracerSalt)
 
       if (displacementType == 'surfaceDisplaced') then
 
 #ifdef MPAS_OPENACC
          !$acc parallel loop gang vector collapse(2) &
-         !$acc&  present(tracerssurfacelayervalue)
+         !$acc    present(tracerssurfacelayervalue, &
+         !$acc            tracerTemp, tracerSalt)
 #else
          !$omp parallel
          !$omp do schedule(runtime) private(k, tq, sq)
@@ -338,7 +337,7 @@ contains
 
 #ifdef MPAS_OPENACC
          !$acc parallel loop gang vector collapse(2) &
-         !$acc&  present(tracers)
+         !$acc    present(tracers, tracerTemp, tracerSalt)
 #else
          !$omp parallel
          !$omp do schedule(runtime) private(k, tq, sq)
@@ -360,7 +359,7 @@ contains
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector collapse(2) &
-      !$acc&   present(density, p, p2)
+      !$acc&   present(density, tracerTemp, tracerSalt, p, p2)
 #else
       !$omp parallel
       !$omp do schedule(runtime) &
@@ -417,9 +416,7 @@ contains
       !$omp end parallel
 #endif
 
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(p, p2)
-#endif
+      !$acc exit data delete(p, p2, tracerTemp, tracerSalt)
       deallocate(p,p2)
       deallocate(tracerTemp, tracerSalt)
 
@@ -531,9 +528,6 @@ contains
       real (kind=RKIND), dimension(:,:), allocatable :: &
          tracerTemp,          &! modified temperature
          tracerSalt            ! modified salinity
-#ifdef MPAS_OPENACC
-      !$acc declare device_resident(tracerTemp, tracerSalt)
-#endif
 
       !-----------------------------------------------------------------
 
@@ -611,12 +605,14 @@ contains
       ! For OpenACC, these are device resident only
       allocate(tracerTemp(nVertLevels,nCells), &
                tracerSalt(nVertLevels,nCells))
+      !$acc enter data create(tracerTemp, tracerSalt)
 
       if (displacementType == 'surfaceDisplaced') then
 
 #ifdef MPAS_OPENACC
          !$acc parallel loop gang vector collapse(2) &
-         !$acc&  present(tracerssurfacelayervalue)
+         !$acc    present(tracerssurfacelayervalue, &
+         !$acc            tracerTemp, tracerSalt)
 #else
          !$omp parallel
          !$omp do schedule(runtime) private(k, tq, sq)
@@ -640,7 +636,7 @@ contains
 
 #ifdef MPAS_OPENACC
          !$acc parallel loop gang vector collapse(2) &
-         !$acc&  present(tracers)
+         !$acc    present(tracers, tracerTemp, tracerSalt)
 #else
          !$omp parallel
          !$omp do schedule(runtime) private(k, tq, sq)
@@ -662,14 +658,15 @@ contains
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector collapse(2)     &
-      !$acc&   present(density, p, p2,                &
-      !$acc&           thermalExpansionCoeff,         &
-      !$acc&           salineContractionCoeff)
+      !$acc    present(density, tracerTemp, tracerSalt, p, p2, &
+      !$acc            thermalExpansionCoeff,         &
+      !$acc            salineContractionCoeff)
 #else
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(k, sq, tq, sqr, t2, work1, work2, rhosfc, work3, work4, bulkMod, &
-      !$omp         denomk, drdt0, dkdt, drhodt, drds0, dkds, drhods)
+      !$omp private(k, sq, tq, sqr, t2, rhosfc, bulkMod, &
+      !$omp         work1, work2, work3, work4, denomk, &
+      !$omp         drdt0, dkdt, drhodt, drds0, dkds, drhods)
 #endif
       do iCell=1,nCells
       do k=1,nVertLevels
@@ -767,9 +764,7 @@ contains
       !$omp end parallel
 #endif
 
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(p, p2)
-#endif
+      !$acc exit data delete(p, p2, tracerTemp, tracerSalt)
       deallocate(p,p2)
       deallocate(tracerTemp, tracerSalt)
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_equation_of_state_wright.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_equation_of_state_wright.F
@@ -61,16 +61,6 @@ module ocn_equation_of_state_wright
    !
    !--------------------------------------------------------------------
 
-   !*** temporary array to hold modified T, S, p for EOS calculation
-   !*** declared here to make it thread-shared - could be replaced
-   !***   by a local subroutine temporary in a different thread model
-
-   real (kind=RKIND), dimension(:,:), allocatable :: &
-      tracerTemp, tracerSalt, boussinesqPres
-#ifdef MPAS_OPENACC
-   !$acc declare device_resident(tracerTemp, tracerSalt, boussinesqPres)
-#endif
-
    !*** valid range of T,S for Wright (1997) EOS
    !***   allowing T to become more negative because of sub-ice-shelf cavities
 
@@ -193,15 +183,21 @@ contains
          alpha0, lambda0,  &! functions of theta and S defined by Wright (1997)
          p0
 
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         tracerTemp,    &! local bounded temperature for use in EOS
+         tracerSalt,    &! local bounded salinity    for use in EOS
+         boussinesqPres  ! boussinesq pressure
+
       !-----------------------------------------------------------------
 
       !*** initialize error flag
 
       err = 0
 
-      allocate(tracerTemp(nVertLevels, nCells))
-      allocate(tracerSalt(nVertLevels, nCells))
-      allocate(boussinesqPres(nVertLevels, nCells))
+      allocate(tracerTemp(nVertLevels, nCells), &
+               tracerSalt(nVertLevels, nCells), &
+               boussinesqPres(nVertLevels, nCells))
+      !$acc enter data create(tracerTemp, tracerSalt, boussinesqPres)
 
       if (displacementType == 'surfaceDisplaced') then
          call compute_surface_displaced_T_S(nVertLevels, nCells, indexT,      &
@@ -218,7 +214,8 @@ contains
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector collapse(2) &
-      !$acc&   present(density)
+      !$acc    present(density, tracerTemp, tracerSalt, &
+      !$acc            boussinesqPres)
 #else
       !$omp parallel
       !$omp do schedule(runtime) &
@@ -249,9 +246,8 @@ contains
       !$omp end parallel
 #endif
 
-      deallocate(tracerTemp)
-      deallocate(tracerSalt)
-      deallocate(boussinesqPres)
+      !$acc exit data delete(tracerTemp, tracerSalt, boussinesqPres)
+      deallocate(tracerTemp, tracerSalt, boussinesqPres)
 
    !--------------------------------------------------------------------
 
@@ -355,6 +351,11 @@ contains
          drhodT,           &! derivative of density with respect to temperature
          drhodS             ! derivative of density with respect to salinity
 
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         tracerTemp,    &! local bounded temperature for use in EOS
+         tracerSalt,    &! local bounded salinity    for use in EOS
+         boussinesqPres  ! boussinesq pressure
+
       !-----------------------------------------------------------------
 
       !*** initialize error flag
@@ -362,9 +363,10 @@ contains
       err = 0
 
 
-      allocate(tracerTemp(nVertLevels, nCells))
-      allocate(tracerSalt(nVertLevels, nCells))
-      allocate(boussinesqPres(nVertLevels, nCells))
+      allocate(tracerTemp(nVertLevels, nCells), &
+               tracerSalt(nVertLevels, nCells), &
+               boussinesqPres(nVertLevels, nCells))
+      !$acc enter data create(tracerTemp, tracerSalt, boussinesqPres)
 
       if (displacementType == 'surfaceDisplaced') then
          call compute_surface_displaced_T_S(nVertLevels, nCells, indexT,      &
@@ -381,16 +383,15 @@ contains
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector collapse(2)     &
-      !$acc&   present(density, &
-      !$acc&           thermalExpansionCoeff,         &
-      !$acc&           salineContractionCoeff)
+      !$acc    present(density, tracerTemp, tracerSalt, boussinesqPres,& 
+      !$acc            thermalExpansionCoeff, salineContractionCoeff)
 #else
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(k, S, T, p, T2, T3, p0, dp0dT, dp0dS, lambda0, dlambda0dT, dlambda0dS, &
-      !$omp         alpha0, dalpha0dT, dalpha0dS, denom, denom2, drhodT, drhodS)
+      !$omp private(k, S, T, p, T2, T3, p0, dp0dT, dp0dS, lambda0, &
+      !$omp         dlambda0dT, dlambda0dS, alpha0, dalpha0dT, &
+      !$omp         dalpha0dS, denom, denom2, drhodT, drhodS)
 #endif
-
 
       do iCell=1,nCells
          do k=1,nVertLevels
@@ -417,8 +418,10 @@ contains
             denom = 1.0_RKIND/(lambda0 + alpha0*(p + p0))
             denom2 = denom*denom
 
-            drhodT = (lambda0*dp0dT - (p + p0)*(dlambda0dT + (p + p0)*dalpha0dT))*denom2
-            drhodS = (lambda0*dp0dS - (p + p0)*(dlambda0dS + (p + p0)*dalpha0dS))*denom2
+            drhodT = (lambda0*dp0dT - &
+                      (p + p0)*(dlambda0dT + (p + p0)*dalpha0dT))*denom2
+            drhodS = (lambda0*dp0dS - &
+                      (p + p0)*(dlambda0dS + (p + p0)*dalpha0dS))*denom2
 
             density(k, iCell) = (p + p0)*denom
             thermalExpansionCoeff(k, iCell) = -drhodT/density(k, iCell)
@@ -432,9 +435,8 @@ contains
       !$omp end parallel
 #endif
 
-      deallocate(tracerTemp)
-      deallocate(tracerSalt)
-      deallocate(boussinesqPres)
+      !$acc exit data delete(tracerTemp, tracerSalt, boussinesqPres)
+      deallocate(tracerTemp, tracerSalt, boussinesqPres)
 
    !--------------------------------------------------------------------
 
@@ -601,7 +603,7 @@ contains
 #ifdef MPAS_OPENACC
       !$acc parallel loop gang vector collapse(2), &
       !$acc    present(tracersSurfaceLayerValue, &
-      !$acc&           tracerTemp, tracerSalt)
+      !$acc            tracerTemp, tracerSalt)
 #else
       !$omp parallel
       !$omp do schedule(runtime) private(k, T, S)
@@ -695,7 +697,8 @@ contains
             do k = 1, nVertLevels
                kPressure = min(k + kDisplaced, maxLevelCell(iCell))
                kPressure = max(kPressure, 1)
-               boussinesqPres(k, iCell) = -rho_sw*gravity*zMid(kPressure, iCell)
+               boussinesqPres(k, iCell) = -rho_sw*gravity* &
+                                           zMid(kPressure, iCell)
             end do
          end do
 #ifndef MPAS_OPENACC

--- a/components/mpas-ocean/src/shared/mpas_ocn_thick_ale.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_thick_ale.F
@@ -26,6 +26,7 @@ module ocn_thick_ale
 
    use ocn_constants
    use ocn_config
+   use ocn_mesh
 
    implicit none
    private
@@ -52,7 +53,23 @@ module ocn_thick_ale
    !
    !--------------------------------------------------------------------
 
-   integer :: configALEthicknessProportionality
+   ! Choices for ALE thickness proportionality
+
+   integer :: &
+      ALEthickProportionality
+
+   integer, parameter :: &
+      ALEthickProportionThickTimesWgts = 1, &
+      ALEthickProportionWgtsOnly       = 2
+
+   ! Variables for adjusting thickness based on min, max parameters
+
+   logical :: &
+      useMinMaxThick ! flag for using min/max adjustment
+
+   real (kind=RKIND) :: &
+      minThick,     &! minimum thickness
+      maxThickFact   ! factor for limiting max thickness
 
 !***********************************************************************
 
@@ -72,109 +89,135 @@ contains
 !>  (z-tilde), and imposes a minimum layer thickness.
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_ALE_thickness(meshPool, verticalMeshPool, SSH, ALE_thickness, err, newHighFreqThickness)!{{{
+
+   subroutine ocn_ALE_thickness(verticalMeshPool, SSH, ALE_thickness, &
+                                err, newHighFreqThickness)!{{{
 
       !-----------------------------------------------------------------
-      !
       ! input variables
-      !
       !-----------------------------------------------------------------
 
       type (mpas_pool_type), intent(in) :: &
-         meshPool           !< Input: horizonal mesh information
-
-      type (mpas_pool_type), intent(in) :: &
-         verticalMeshPool   !< Input: vertical mesh information
+         verticalMeshPool     !< [in] vertical mesh information
 
       real (kind=RKIND), dimension(:), intent(in) :: &
-         SSH     !< Input: sea surface height
+         SSH                  !< [in] sea surface height
 
       real (kind=RKIND), dimension(:,:), intent(in), optional :: &
-         newHighFreqThickness   !< Input: high frequency thickness.  Alters ALE thickness.
+         newHighFreqThickness !< [in] high freq thickness alters ALE thickness.
 
       !-----------------------------------------------------------------
-      !
       ! output variables
-      !
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:), intent(out) :: &
-         ALE_thickness     !< Output: desired thickness at new time
+         ALE_thickness            !< [out] desired thickness at new time
 
-      integer, intent(out) :: err !< Output: error flag
+      integer, intent(out) :: err !< [out] error flag
 
       !-----------------------------------------------------------------
-      !
       ! local variables
-      !
       !-----------------------------------------------------------------
 
-      integer :: iCell, k, kMax, kMin
-      integer, pointer :: nVertLevels
-      integer :: nCells
-      integer, dimension(:), pointer :: maxLevelCell
-      integer, dimension(:), pointer :: minLevelCell
-      integer, dimension(:), pointer :: nCellsArray
+      integer :: &
+         iCell, k,    &! loop indices for cells, depth
+         kMax, kMin,  &! indices for min, max active levels
+         nCells        ! number of cells
 
-      real (kind=RKIND) :: weightSum, thicknessSum, remainder, newThickness
-      real (kind=RKIND), dimension(:), pointer :: vertCoordMovementWeights
+      real (kind=RKIND) :: &
+         weightSum,    &! sum of weights in vertical
+         thicknessSum, &! total thickness
+         remainder,    &! track remainder in mix/max alteration
+         newThickness   ! temp used during min/max adjustment
+
       real (kind=RKIND), dimension(:), allocatable :: &
-         prelim_ALE_thickness,   & !> ALE thickness at new time
-         min_ALE_thickness_down, & !> ALE thickness alteration due to min/max thickness
-         min_ALE_thickness_up      !> ALE thickness alteration due to min/max thickness
-      real (kind=RKIND), dimension(:,:), pointer :: &
-         restingThickness   !>  Layer thickness when the ocean is at rest, i.e. without SSH or internal perturbations.
+         prelim_ALE_thickness,   & ! ALE thickness at new time
+         min_ALE_thickness_down, & ! thickness alteration in min/max adj
+         min_ALE_thickness_up      ! thickness alteration in min/max adj
 
-      logical, pointer :: thicknessFilterActive
+      real (kind=RKIND), dimension(:,:), pointer :: &
+         restingThickness   ! Layer thickness when the ocean is at rest
+                            ! i.e. without SSH or internal perturbations.
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
 
       err = 0
 
-      call mpas_pool_get_package(ocnPackages, 'thicknessFilterActive', thicknessFilterActive)
+      !TEMP: acc directives temporarily disabled here for bit-for-bit
+      !      validation - will enable these on subsequent PR
+      !      must also update host since ssh data on device - this
+      !      will also be removed
+      !$acc update host (ssh)
 
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
-      call mpas_pool_get_array(meshPool, 'vertCoordMovementWeights', vertCoordMovementWeights)
+      ! Retrieve or allocate needed variables
 
-      call mpas_pool_get_array(verticalMeshPool, 'restingThickness', restingThickness)
+      call mpas_pool_get_array(verticalMeshPool, 'restingThickness', &
+                                                  restingThickness)
+      !xacc enter data copyin(restingThickness) 
 
-      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
-
-      allocate(prelim_ALE_thickness(nVertLevels), &
-         min_ALE_thickness_down(nVertLevels), min_ALE_thickness_up(nVertLevels))
-
-      nCells = nCellsArray( 2 )
+      nCells = nCellsHalo(1)
 
       !
       ! ALE thickness alteration due to SSH (z-star)
       !
-      if (configALEthicknessProportionality==1) then ! restingThickness_times_weights
+      select case(ALEthickProportionality)
 
+      ! restingThickness_times_weights
+      case (ALEthickProportionThickTimesWgts)
+
+#ifdef MPAS_OPENACC
+         !xacc parallel loop &
+         !xacc    present(ALE_thickness, SSH, restingThickness, &
+         !xacc            minLevelCell, maxLevelCell, &
+         !xacc            vertCoordMovementWeights) &
+         !xacc    private(k, kMin, kMax, thicknessSum)
+#else
          !$omp parallel
-         !$omp do schedule(runtime) private(kMax, thicknessSum, k)
+         !$omp do schedule(runtime) &
+         !$omp    private(k, kMin, kMax, thicknessSum)
+#endif
          do iCell = 1, nCells
             kMax = maxLevelCell(iCell)
             kMin = minLevelCell(iCell)
    
             thicknessSum = 1e-14_RKIND
             do k = kMin, kMax
-               thicknessSum = thicknessSum + vertCoordMovementWeights(k) * restingThickness(k, iCell)
+               thicknessSum = thicknessSum &
+                            + vertCoordMovementWeights(k) &
+                            * restingThickness(k,iCell)
             end do
    
-            ! Note that restingThickness is nonzero, and remaining terms are perturbations about zero.
-            ! This is equation 4 and 6 in Petersen et al 2015, but with eqn 6
+            ! Note that restingThickness is nonzero, and remaining
+            ! terms are perturbations about zero.
+            ! This is equation 4 and 6 in Petersen et al 2015,
+            ! but with eqn 6
             do k = kMin, kMax
-               ALE_thickness(k, iCell) = restingThickness(k, iCell) &
-                  + ( SSH(iCell) * vertCoordMovementWeights(k) * restingThickness(k, iCell) ) &
-                    / thicknessSum
+               ALE_thickness(k,iCell) = restingThickness(k,iCell) &
+                  + (SSH(iCell)*vertCoordMovementWeights(k)* &
+                     restingThickness(k,iCell) )/thicknessSum
             end do
          enddo
+#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
+#endif
    
-         elseif (configALEthicknessProportionality==2) then ! weights_only
+      ! weights_only
+      case (ALEthickProportionWgtsOnly)
+
+#ifdef MPAS_OPENACC
+         !xacc parallel loop &
+         !xacc    present(ALE_thickness, restingThickness, ssh, &
+         !xacc            vertCoordMovementWeights, &
+         !xacc            minLevelCell, maxLevelCell) &
+         !xacc    private(k, kMin, kMax, weightSum)
+#else
          !$omp parallel
-         !$omp do schedule(runtime) private(kMax, weightSum, k)
+         !$omp do schedule(runtime) &
+         !$omp    private(k, kMin, kMax, weightSum)
+#endif
          do iCell = 1, nCells
             kMax = maxLevelCell(iCell)
             kMin = minLevelCell(iCell)
@@ -185,80 +228,145 @@ contains
             end do
    
             do k = kMin, kMax
-               ! Using this, we must require that sum(restingThickness(k, iCell))
+               ! Using this, we must require that the
+               ! sum(restingThickness(k, iCell))
                ! summed over k is equal to bottomDepth.
-               ! This is equation 4 and 6 in Petersen et al 2015, but with eqn 6
-               ! altered so only the W_k weights are used. The resting
-               ! thickness shown in eqn 6 is not included here.
-               ALE_thickness(k, iCell) = restingThickness(k, iCell) + ssh(iCell) * vertCoordMovementWeights(k) / weightSum
-   
+               ! This is equation 4 and 6 in Petersen et al 2015,
+               ! but with eqn 6 altered so only the W_k weights
+               ! are used. The resting thickness shown in eqn 6 is
+               ! not included here.
+               ALE_thickness(k,iCell) = restingThickness(k,iCell) &
+                                      + ssh(iCell)* &
+                            vertCoordMovementWeights(k)/weightSum
             end do
          enddo
+#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-      endif
+#endif
 
-      if (thicknessFilterActive) then
+      case default
+         ! Checked on init
+      end select ! ALE thickness proportionality
+
+      ! thickness filtering active
+      if (present(newHighFreqThickness)) then
+
+#ifdef MPAS_OPENACC
+         !xacc parallel loop &
+         !xacc    present(ALE_thickness, newHighFreqThickness, &
+         !xacc            minLevelCell, maxLevelCell) &
+         !xacc    private(k, kMin, kMax)
+#else
          !$omp parallel
-         !$omp do schedule(runtime) private(kMax)
+         !$omp do schedule(runtime) private(k, kMin, kMax)
+#endif
          do iCell = 1, nCells
             kMax = maxLevelCell(iCell)
             kMin = minLevelCell(iCell)
 
-            ALE_thickness(kMin:kMax, iCell) = &
-                ALE_thickness(kMin:kMax, iCell) &
-              + newHighFreqThickness(kMin:kMax,iCell)
+            do k=kMin,kMax
+               ALE_thickness(k,iCell) = ALE_thickness(k,iCell) &
+                                      + newHighFreqThickness(k,iCell)
+            enddo
          enddo
+#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
-      end if
+#endif
+
+      endif
 
       !
       ! ALE thickness alteration due to minimum and maximum thickness
       !
-      if (config_use_min_max_thickness) then
+      if (useMinMaxThick) then
 
+         allocate(prelim_ALE_thickness  (nVertLevels), &
+                  min_ALE_thickness_down(nVertLevels), &
+                  min_ALE_thickness_up  (nVertLevels))
+         !xacc enter data create(prelim_ALE_thickness, &
+         !xacc                   min_ALE_thickness_down, &
+         !xacc                   min_ALE_thickness_up)
+
+#ifdef MPAS_OPENACC
+         !xacc parallel loop &
+         !xacc    present(ALE_thickness, restingThickness, &
+         !xacc            minLevelCell, maxLevelCell) &
+         !xacc    private(k, kMin, kMax, remainder, newThickness, &
+         !xacc            prelim_ALE_thickness, &
+         !xacc            min_ALE_thickness_down, min_ALE_thickness_up)
+#else
          !$omp parallel
          !$omp do schedule(runtime) &
-         !$omp private(kMax, prelim_ALE_Thickness, remainder, k, newThickness, &
-         !$omp         min_ALE_thickness_down, min_ALE_thickness_up)
+         !$omp    private(k, kMin, kMax, remainder, newThickness, &
+         !$omp            prelim_ALE_thickness, &
+         !$omp            min_ALE_thickness_down, min_ALE_thickness_up)
+#endif
          do iCell = 1, nCells
             kMax = maxLevelCell(iCell)
             kMin = minLevelCell(iCell)
 
             ! go down the column:
-            prelim_ALE_thickness(kMin:kMax) = ALE_thickness(kMin:kMax, iCell)
+            do k = kMin, kMax
+               prelim_ALE_thickness(k) = ALE_thickness(k,iCell)
+            end do
+
             remainder = 0.0_RKIND
             do k = kMin, kMax
-               newThickness = max( min(prelim_ALE_thickness(k) + remainder, &
-                                      config_max_thickness_factor * restingThickness(k,iCell) ), &
-                                  config_min_thickness)
-               min_ALE_thickness_down(k) = newThickness - prelim_ALE_thickness(k)
+               newThickness = max(minThick, &
+                            min(prelim_ALE_thickness(k) + remainder, &
+                                maxThickFact*restingThickness(k,iCell)))
+               min_ALE_thickness_down(k) = newThickness &
+                                         - prelim_ALE_thickness(k)
                remainder = remainder - min_ALE_thickness_down(k)
             end do
 
             ! go back up the column:
             min_ALE_thickness_up(kMax) = 0.0_RKIND
-            prelim_ALE_thickness(kMin:kMax) = prelim_ALE_thickness(kMin:kMax) + min_ALE_thickness_down(kMin:kMax)
+            do k=kMin,kMax
+               prelim_ALE_thickness(k) = prelim_ALE_thickness(k) &
+                                       + min_ALE_thickness_down(k)
+            end do
             do k = kMax-1, kMin, -1
-               newThickness = max( min(prelim_ALE_thickness(k) + remainder, &
-                                      config_max_thickness_factor * restingThickness(k,iCell) ), &
-                                  config_min_thickness)
-               min_ALE_thickness_up(k) = newThickness - prelim_ALE_thickness(k)
+               newThickness = max(minThick, &
+                         min(prelim_ALE_thickness(k) + remainder, &
+                             maxThickFact * restingThickness(k,iCell)))
+               min_ALE_thickness_up(k) = newThickness &
+                                       - prelim_ALE_thickness(k)
                remainder = remainder - min_ALE_thickness_up(k)
             end do
-            min_ALE_thickness_up(kMin) = min_ALE_thickness_up(kMin) + remainder
+            min_ALE_thickness_up(kMin) = min_ALE_thickness_up(kMin) &
+                                       + remainder
 
-            ALE_thickness(kMin:kMax, iCell) = ALE_thickness(kMin:kMax, iCell) + min_ALE_thickness_down(kMin:kMax) &
-                                         + min_ALE_thickness_up(kMin:kMax)
+            do k=kMin,kMax
+               ALE_thickness(k,iCell) = ALE_thickness(k,iCell) &
+                                      + min_ALE_thickness_down(k) &
+                                      + min_ALE_thickness_up(k)
 
+            enddo
          enddo
+#ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
+#endif
 
-      endif ! config_use_min_max_thickness
+         !xacc exit data delete(prelim_ALE_thickness, &
+         !xacc                  min_ALE_thickness_down, &
+         !xacc                  min_ALE_thickness_up)
+         deallocate(prelim_ALE_thickness, &
+                    min_ALE_thickness_down, &
+                    min_ALE_thickness_up)
 
-      deallocate(prelim_ALE_thickness, min_ALE_thickness_down, min_ALE_thickness_up)
+      endif ! useMinMaxThick
+
+      !xacc exit data delete(restingThickness) 
+
+      !TEMP: move result to device - this will be unnecessary once
+      !      acc directives enabled
+      !$acc update device(ALE_thickness)
+
+   !--------------------------------------------------------------------
 
    end subroutine ocn_ALE_thickness!}}}
 
@@ -266,30 +374,55 @@ contains
 !
 !  routine ocn_thick_ale_init
 !
-!> \brief   Initializes flags used within diagnostics routines.
+!> \brief   Initializes flags used within ALE thickness computation.
 !> \author  Mark Petersen
 !> \date    August 2013
 !> \details
-!>  This routine initializes flags related to quantities computed within
-!>  other diagnostics routines.
+!>  This routine initializes flags related to thickness computation in
+!>  the Arbitrary Lagrangian-Eulerian (ALE) formulation.
 !
 !-----------------------------------------------------------------------
+
    subroutine ocn_thick_ale_init(err)!{{{
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
       integer, intent(out) :: err !< Output: Error flag
 
-      if (config_ALE_thickness_proportionality=='restingThickness_times_weights') then
-          configALEthicknessProportionality = 1
-      elseif (config_ALE_thickness_proportionality=='weights_only') then
-          configALEthicknessProportionality = 2
-      else
+      !-----------------------------------------------------------------
+
+      err = 0 ! default error flag
+
+      ! Determine ALE thickness proportionality type from user config
+      select case (trim(config_ALE_thickness_proportionality))
+      case ('restingThickness_times_weights')
+          ALEthickProportionality = ALEthickProportionThickTimesWgts
+      case ('weights_only')
+          ALEthickProportionality = ALEthickProportionWgtsOnly
+      case default
           call mpas_log_write( &
-             ' Warning: config_ALE_thickness_proportionality is not valid', &
+             ' Error: Invalid config_ALE_thickness_proportionality', &
              MPAS_LOG_CRIT)
+      end select
+
+      ! Determine whether to adjust thickness based on user input
+      if (config_use_min_max_thickness) then
+         useMinMaxThick = .true.
+         minThick     = config_min_thickness
+         maxThickFact = config_max_thickness_factor
+      else
+         useMinMaxThick = .false.
+         minThick     = 0.0_RKIND
+         maxThickFact = 0.0_RKIND
       endif
 
-      err = 0
+   !--------------------------------------------------------------------
 
-    end subroutine ocn_thick_ale_init!}}}
+   end subroutine ocn_thick_ale_init!}}}
+
+!***********************************************************************
 
 end module ocn_thick_ale
 


### PR DESCRIPTION
The OpenACC declare device resident was not universally supported so replaced these with the more standard create/delete pairs. Also fixed some other missing private declarations that were possibly resulting in race conditions and bad results. Cleaned up some long lines, removed meshPool and other things along the way.

This was bit-for-bit on a QU240 test on Summit for both CPU and GPU. Also passes the compass pr tests with Intel on Chrysalis.

[bfb]
Fixes #5006 
Fixes #5176 