### PR TITLE
Remove unneeded mesh declaration

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
@@ -627,7 +627,6 @@ contains
 
         ! MPI variables
         integer :: curProc
-        integer, dimension(:), pointer :: indexToCellID
         integer :: iProc, l, ilm, nProcs
 
         ! Alarm variables


### PR DESCRIPTION
Mesh variables are declared in `mpas_ocn_mesh.F` rather than individual routines.

Fixes #5200
[BFB]