### PR TITLE
Add CF-compliant Time coordinate

### DIFF
--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -137,6 +137,10 @@
 					description="Selection of the type of calendar that should be used in the simulation."
 					possible_values="'gregorian', 'noleap'"
 		/>
+		<nml_option name="config_output_reference_time" type="character" default_value="0001-01-01_00:00:00"
+					description="Reference time used in the units attribute of Time in output files."
+					possible_values="'YYYY-MM-DD_HH:MM:SS'"
+		/>
 	</nml_record>
 	<nml_record name="io" mode="forward;analysis">
 		<nml_option name="config_write_output_on_startup" type="logical" default_value=".true."
@@ -2529,6 +2533,9 @@
 	<var_struct name="diagnostics" time_levs="1">
 		<var name="xtime" type="text" dimensions="Time"
 			 description="model time, with format 'YYYY-MM-DD_HH:MM:SS'"
+		/>
+		<var name="Time" type="real" dimensions="Time"
+			 description="time"
 		/>
 		<var name="simulationStartTime" type="text" dimensions="" default_value="'no_date_available'"
 			 description="start time of first simulation, with format 'YYYY-MM-DD_HH:MM:SS'"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -26,6 +26,9 @@
 		<dim name="nVerticesP1" definition="nVertices+1"
 			 description="The total number of cells in the dual grid. Also the number of corners in the primary grid."
 		/>
+		<dim name="bnds" definition="2"
+			 description="The number of coordinate bound"
+		/>
 		<dim name="TWO" definition="2"
 			 description="The number two as a dimension."
 		/>
@@ -2534,8 +2537,11 @@
 		<var name="xtime" type="text" dimensions="Time"
 			 description="model time, with format 'YYYY-MM-DD_HH:MM:SS'"
 		/>
-		<var name="Time" type="real" dimensions="Time"
+		<var name="Time" type="real" dimensions="Time" bounds="Time_bnds"
 			 description="time"
+		/>
+		<var name="Time_bnds" type="real" dimensions="Time bnds"
+			 description="time bounds"
 		/>
 		<var name="simulationStartTime" type="text" dimensions="" default_value="'no_date_available'"
 			 description="start time of first simulation, with format 'YYYY-MM-DD_HH:MM:SS'"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -333,7 +333,7 @@
 		/>
 	</nml_record>
 	<nml_record name="submesoscale_eddy_parameterization" mode="forward">
-		<nml_option name="config_submesoscale_enable" type="logical" default_value=".false." 
+		<nml_option name="config_submesoscale_enable" type="logical" default_value=".false."
 					description="flag to enable the FK2011 parameterization for submesoscale eddies"
 					possible_values=".true. or .false."
 					/>
@@ -438,7 +438,7 @@
 		/>
 		<nml_option name="config_eddyMLD_reference_depth" type="real" default_value="10" units="m"
 					description="reference depth for threshold computation"
-					possible_values="any positive real, near 10" 
+					possible_values="any positive real, near 10"
 		/>
 		<nml_option name="config_eddyMLD_reference_pressure" type="real" default_value="1.0e5" units="Pa"
 					description="reference pressure for original mixed layer depth calculation"
@@ -2538,7 +2538,7 @@
 			 description="model time, with format 'YYYY-MM-DD_HH:MM:SS'"
 		/>
 		<var name="Time" type="real" dimensions="Time" bounds="Time_bnds"
-			 description="time"
+			 description="time" standard_name="time"
 		/>
 		<var name="Time_bnds" type="real" dimensions="Time bnds"
 			 description="time bounds"

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_time_series_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_time_series_stats.F
@@ -1007,7 +1007,7 @@ end subroutine start_state
 !> \date    September 1, 2015
 !> \details
 !>  Given a stream name, this will remove the existing variables
-!>  in a stream and replace them with similiarly named ones for
+!>  in a stream and replace them with similarly named ones for
 !>  their accumulation. It will also add xtime and optionally the mesh.
 !-----------------------------------------------------------------------
 subroutine modify_stream(domain, instance, series, valid_input, err)!{{{
@@ -1213,7 +1213,7 @@ end subroutine modify_stream!}}}
 !***********************************************************************
 ! function output_naming
 !
-!> \brief Given an input name, create a cooresponding output name
+!> \brief Given an input name, create a corresponding output name
 !> \author  Jon Woodring
 !> \date    September 1, 2015
 !> \details

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_time_series_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_time_series_stats.F
@@ -891,6 +891,11 @@ subroutine start_state(domain, instance, series, valid_input, err)
     valid_input(b) = check_real_time(domain % blocklist % allFields, &
       field_name)
 
+    ! We'll make sure that Time and Time_bnds get included in a way separate
+    ! from this list
+    if ((trim(field_name) == 'Time') .or. (trim(field_name) == 'Time_bnds')) &
+       valid_input(b) = .false.
+
     if (valid_input(b)) then
       series % number_of_variables = series % number_of_variables + 1
     end if
@@ -988,11 +993,11 @@ subroutine start_state(domain, instance, series, valid_input, err)
       field_name, series % buffers(b) % reset_alarm_ID)
 
     !
-    ! counter, xtime_start, and xtime_end is not allocated here,
-    ! because it is part of the restart stream and output_stream,
+    ! counter, xtime_start, xtime_end, Time and Time_bnds are not allocated here,
+    ! because they are part of the restart stream and output_stream,
     ! and not just the internal AM state
     !
-    ! it is allocated in modify_stream
+    ! they are allocated in modify_stream
     !
   end do
 end subroutine start_state
@@ -1163,6 +1168,59 @@ subroutine modify_stream(domain, instance, series, valid_input, err)!{{{
       call mpas_stream_mgr_add_field(domain % streamManager, &
         restart_stream_name, out_field_name, ierr=err)
     end if
+
+    ! Time
+    in_field_name = 'Time'
+    ! get the info of the field
+    call mpas_pool_get_field_info(domain % blocklist % allFields, &
+      in_field_name, info)
+
+    if (series % number_of_buffers > 1) then
+      out_field_name = output_naming(storage_prefix, op_name, in_field_name, buf_identifier)
+    else
+      out_field_name = output_naming(storage_prefix, op_name, in_field_name)
+    end if
+
+    ! create the field and add to pool
+    call add_new_field(info, in_field_name, out_field_name, &
+      domain % blocklist % allFields, amPool)
+
+    ! add the field to the output stream
+    call mpas_stream_mgr_add_field(domain % streamManager, &
+      output_stream_name, out_field_name, ierr=err)
+
+    ! put it in the restart stream
+    if (restartStreamEnabled) then
+       call mpas_stream_mgr_add_field(domain % streamManager, &
+         restart_stream_name, out_field_name, ierr=err)
+    end if
+
+    ! Time_bnds
+    in_field_name = 'Time_bnds'
+    ! get the info of the field
+    call mpas_pool_get_field_info(domain % blocklist % allFields, &
+      in_field_name, info)
+
+    if (series % number_of_buffers > 1) then
+      out_field_name = output_naming(storage_prefix, op_name, in_field_name, buf_identifier)
+    else
+      out_field_name = output_naming(storage_prefix, op_name, in_field_name)
+    end if
+
+    ! create the field and add to pool
+    call add_new_field(info, in_field_name, out_field_name, &
+      domain % blocklist % allFields, amPool)
+
+    ! add the field to the output stream
+    call mpas_stream_mgr_add_field(domain % streamManager, &
+      output_stream_name, out_field_name, ierr=err)
+
+    ! put it in the restart stream
+    if (restartStreamEnabled) then
+       call mpas_stream_mgr_add_field(domain % streamManager, &
+         restart_stream_name, out_field_name, ierr=err)
+    end if
+
   end do
 
   ! set up the variables

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_time_series_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_time_series_stats.F
@@ -67,6 +67,8 @@ module ocn_time_series_stats
     integer, pointer :: counter
     character (len=StrKIND), pointer :: xtime_start
     character (len=StrKIND), pointer :: xtime_end
+    real (kind=RKIND), pointer :: Time
+    real (kind=RKIND), dimension(:), pointer :: Time_bnds
   end type time_series_buffer_type
 
   type time_series_type
@@ -236,8 +238,12 @@ subroutine ocn_init_time_series_stats(domain, instance, err)!{{{
   integer :: v, b
   type (time_series_type) :: series
   type (time_series_alarms_type), allocatable, dimension(:) :: alarms
-  type (MPAS_Time_type) :: start_intv
+  type (MPAS_Time_type) :: start_intv, start_time, reference_time
   character (len=StrKIND) :: start_xtime
+  real (kind=RKIND) :: Time
+  character (len=StrKIND), pointer :: config_output_reference_time
+
+  integer :: err_tmp    ! local error codes from subroutine calls
 
   ! start procedure
   err = 0
@@ -259,9 +265,23 @@ subroutine ocn_init_time_series_stats(domain, instance, err)!{{{
   start_intv = mpas_get_clock_time(domain % clock, MPAS_NOW, err)
   call mpas_get_time(start_intv, dateTimeString=start_xtime, ierr=err)
 
+  start_time = mpas_get_clock_time(domain%clock, MPAS_START_TIME, err_tmp)
+  if (err_tmp /= 0) then
+     call mpas_log_write('Error getting start time in init', &
+          MPAS_LOG_ERR, masterOnly=.true., flushNow=.true.)
+     err = ior(err, err_tmp)
+  endif
+
+  call mpas_pool_get_config(domain % configs, 'config_output_reference_time', &
+    config_output_reference_time)
+  call mpas_set_time(reference_time, dateTimeString=config_output_reference_time)
+  call mpas_get_timeInterval(start_time - reference_time, dt=Time)
+  Time = Time*days_per_second
+
   do b = 1, series % number_of_buffers
     if (trim(series % buffers(b) % xtime_start) == '') then
       series % buffers(b) % xtime_start = start_xtime
+      series % buffers(b) % Time_bnds(1) = Time
     end if
   end do
 
@@ -299,15 +319,20 @@ subroutine ocn_compute_time_series_stats(domain, timeLevel, instance, err)!{{{
   integer :: v, b
   type (time_series_type) :: series
   type (MPAS_TimeInterval_type) :: dt
-  type (MPAS_Time_type) :: start_intv, end_intv
+  type (MPAS_Time_type) :: start_intv, end_intv, reference_time
   character (len=StrKIND) :: start_xtime, end_xtime
+  real (kind=RKIND), dimension(2) :: Time_bnds
   logical :: unset_xtime
+  character (len=StrKIND), pointer :: config_output_reference_time
 
   ! start procedure
   err = 0
 
   ! get all of the state for this instance to be able to compute
   call get_state(domain, instance, series)
+
+  call mpas_pool_get_config(domain % configs, 'config_output_reference_time', &
+    config_output_reference_time)
 
   ! get the strings for the date
   unset_xtime = .true.
@@ -320,16 +345,25 @@ subroutine ocn_compute_time_series_stats(domain, timeLevel, instance, err)!{{{
         call mpas_get_time(end_intv, dateTimeString=end_xtime, ierr=err)
         start_intv = end_intv - mpas_get_clock_timestep(domain % clock, err)
         call mpas_get_time(start_intv, dateTimeString=start_xtime, ierr=err)
+        call mpas_set_time(reference_time, dateTimeString=config_output_reference_time)
+        call mpas_get_timeInterval(start_intv - reference_time, dt=Time_bnds(1))
+        call mpas_get_timeInterval(end_intv - reference_time, dt=Time_bnds(2))
+        Time_bnds = Time_bnds*days_per_second
         unset_xtime = .false.
       end if
 
       if (series % buffers(b) % reset_flag == 1) then
         series % buffers(b) % xtime_start = start_xtime
+        series % buffers(b) % Time_bnds(1) = Time_bnds(1)
         series % buffers(b) % counter = 1
       else
         series % buffers(b) % xtime_end = end_xtime
         series % buffers(b) % counter = series % buffers(b) % counter + 1
       end if
+      series % buffers(b) % Time_bnds(2) = Time_bnds(2)
+      series % buffers(b) % Time = 0.5_RKIND * &
+        (series % buffers(b) % Time_bnds(1) + series % buffers(b) % Time_bnds(2))
+
     end if
   end do
 
@@ -796,6 +830,26 @@ subroutine get_state(domain, instance, series)
     call mpas_pool_get_array(amPool, &
       field_name, series % buffers(b) % xtime_end, 1)
 
+    ! Time
+    field_name = 'Time'
+    if (series % number_of_buffers > 1) then
+      field_name = output_naming(storage_prefix, op_name, field_name, buf_identifier)
+    else
+      field_name = output_naming(storage_prefix, op_name, field_name)
+    end if
+    call mpas_pool_get_array(amPool, &
+      field_name, series % buffers(b) % Time, 1)
+
+    ! Time_bnds
+    field_name = 'Time_bnds'
+    if (series % number_of_buffers > 1) then
+      field_name = output_naming(storage_prefix, op_name, field_name, buf_identifier)
+    else
+      field_name = output_naming(storage_prefix, op_name, field_name)
+    end if
+    call mpas_pool_get_array(amPool, &
+      field_name, series % buffers(b) % Time_bnds, 1)
+
   end do
 
 end subroutine get_state
@@ -1036,6 +1090,11 @@ subroutine modify_stream(domain, instance, series, valid_input, err)!{{{
     storage_prefix, buf_identifier, buf_prefix
   type (mpas_pool_field_info_type) :: info
   type (mpas_pool_type), pointer :: amPool
+  type (field0DReal), pointer :: TimeField
+  type (field1DReal), pointer :: TimeBndsField
+  character (len=StrKIND), pointer :: config_output_reference_time, &
+    config_calendar_type
+  character (len=StrKIND) :: units
 
   ! start procedure
   err = 0
@@ -1189,6 +1248,21 @@ subroutine modify_stream(domain, instance, series, valid_input, err)!{{{
     call mpas_stream_mgr_add_field(domain % streamManager, &
       output_stream_name, out_field_name, ierr=err)
 
+    ! add units of "days since <ref_date>" to Time
+    call mpas_pool_get_config(domain % configs, 'config_output_reference_time', &
+      config_output_reference_time)
+    write(units, '(a10,a20)') 'days since', &
+      config_output_reference_time(1:10)//" "//config_output_reference_time(12:19)
+    call mpas_pool_get_Field(domain % blocklist % allFields, out_field_name, TimeField)
+    call mpas_add_att(TimeField % attLists(1) % attList, 'units', units)
+
+    ! Add calendar attribute to Time
+    call mpas_pool_get_config(domain % configs, 'config_calendar_type', config_calendar_type)
+    call mpas_add_att(TimeField % attLists(1) % attList, 'calendar', config_calendar_type)
+
+    ! For CF compliance, output field name is the original field name, not the mangled one
+    TimeField % outputFieldName = in_field_name
+
     ! put it in the restart stream
     if (restartStreamEnabled) then
        call mpas_stream_mgr_add_field(domain % streamManager, &
@@ -1220,6 +1294,10 @@ subroutine modify_stream(domain, instance, series, valid_input, err)!{{{
        call mpas_stream_mgr_add_field(domain % streamManager, &
          restart_stream_name, out_field_name, ierr=err)
     end if
+
+    ! For CF compliance, output field name is the original field name, not the mangled one
+    call mpas_pool_get_Field(domain % blocklist % allFields, out_field_name, TimeBndsField)
+    TimeBndsField % outputFieldName = in_field_name
 
   end do
 

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_time_series_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_time_series_stats.F
@@ -1026,8 +1026,7 @@ subroutine modify_stream(domain, instance, series, valid_input, err)!{{{
   integer :: v, b
   logical :: emptyRestartStream, restartStreamEnabled
   character (len=StrKIND), pointer :: output_stream_name, restart_stream_name
-  character (len=StrKIND) :: fieldName
-  character (len=StrKIND) :: field_name, config, op_name
+  character (len=StrKIND) :: in_field_name, out_field_name, config, op_name
   character (len=StrKIND) :: namelist_prefix, &
     storage_prefix, buf_identifier, buf_prefix
   type (mpas_pool_field_info_type) :: info
@@ -1062,15 +1061,15 @@ subroutine modify_stream(domain, instance, series, valid_input, err)!{{{
   b = 1
   v = 1
   do while (mpas_stream_mgr_get_next_field(domain % streamManager, &
-    output_stream_name, field_name))
+    output_stream_name, in_field_name))
 
     ! check if we can handle it
     if (valid_input(b)) then
-      series % variables(v) % input_name = field_name
+      series % variables(v) % input_name = in_field_name
 
       ! remove the old one
       call mpas_stream_mgr_remove_field(domain % streamManager, &
-        output_stream_name, series % variables(v) % input_name)
+        output_stream_name, in_field_name)
 
       v = v + 1
     end if
@@ -1091,7 +1090,7 @@ subroutine modify_stream(domain, instance, series, valid_input, err)!{{{
      call mpas_stream_mgr_begin_iteration(domain % streamManager, &
        streamID=restart_stream_name, ierr=err)
      do while (mpas_stream_mgr_get_next_field(domain % streamManager, &
-       streamID=restart_stream_name, fieldName=fieldName) .and. emptyRestartStream)
+       streamID=restart_stream_name, fieldName=in_field_name) .and. emptyRestartStream)
        emptyRestartStream = .false.
      end do
 
@@ -1114,55 +1113,55 @@ subroutine modify_stream(domain, instance, series, valid_input, err)!{{{
 
     ! allocate counter memory
     if (series % number_of_buffers > 1) then
-      field_name = counter_naming(storage_prefix, buf_identifier)
+      out_field_name = counter_naming(storage_prefix, buf_identifier)
     else
-      field_name = counter_naming(storage_prefix)
+      out_field_name = counter_naming(storage_prefix)
     end if
     call add_new_integer(domain % blocklist % allFields, amPool, amPool, &
-      field_name, series % buffers(b) % counter)
+      out_field_name, series % buffers(b) % counter)
 
     ! put it in the output and restart
     call mpas_stream_mgr_add_field(domain % streamManager, &
-      output_stream_name, field_name, ierr=err)
+      output_stream_name, out_field_name, ierr=err)
     if (restartStreamEnabled) then
       call mpas_stream_mgr_add_field(domain % streamManager, &
-        restart_stream_name, field_name, ierr=err)
+        restart_stream_name, out_field_name, ierr=err)
     end if
 
     ! xtime start
     if (series % number_of_buffers > 1) then
-      field_name = trim(TIME_START_PREFIX) // trim(instance) // &
+      out_field_name = trim(TIME_START_PREFIX) // trim(instance) // &
         '_' // buf_identifier
     else
-      field_name = trim(TIME_START_PREFIX) // trim(instance)
+      out_field_name = trim(TIME_START_PREFIX) // trim(instance)
     end if
     call add_new_string(domain % blocklist % allFields, amPool, amPool, &
-      field_name, series % buffers(b) % xtime_start)
+      out_field_name, series % buffers(b) % xtime_start)
 
     ! put it in the output and restart
     call mpas_stream_mgr_add_field(domain % streamManager, &
-      output_stream_name, field_name, ierr=err)
+      output_stream_name, out_field_name, ierr=err)
     if (restartStreamEnabled) then
       call mpas_stream_mgr_add_field(domain % streamManager, &
-       restart_stream_name, field_name, ierr=err)
+       restart_stream_name, out_field_name, ierr=err)
     end if
 
     ! xtime end
     if (series % number_of_buffers > 1) then
-      field_name = trim(TIME_END_PREFIX) // trim(instance) // &
+      out_field_name = trim(TIME_END_PREFIX) // trim(instance) // &
         '_' // buf_identifier
     else
-      field_name = trim(TIME_END_PREFIX) // trim(instance)
+      out_field_name = trim(TIME_END_PREFIX) // trim(instance)
     end if
     call add_new_string(domain % blocklist % allFields, amPool, amPool, &
-      field_name, series % buffers(b) % xtime_end)
+      out_field_name, series % buffers(b) % xtime_end)
 
     ! put it in the output and restart
     call mpas_stream_mgr_add_field(domain % streamManager, &
-      output_stream_name, field_name, ierr=err)
+      output_stream_name, out_field_name, ierr=err)
     if (restartStreamEnabled) then
       call mpas_stream_mgr_add_field(domain % streamManager, &
-        restart_stream_name, field_name, ierr=err)
+        restart_stream_name, out_field_name, ierr=err)
     end if
   end do
 
@@ -1170,39 +1169,40 @@ subroutine modify_stream(domain, instance, series, valid_input, err)!{{{
   call mpas_stream_mgr_begin_iteration(domain % streamManager, &
     output_stream_name, err)
   do v = 1, series % number_of_variables
+    in_field_name = series % variables(v) % input_name
     ! get the info of the field
     call mpas_pool_get_field_info(domain % blocklist % allFields, &
-      series % variables(v) % input_name, info)
+      in_field_name, info)
 
     ! allocate a number of fields and add field
     do b = 1, series % number_of_buffers
       write(buf_identifier, '(I0)') b
 
       if (series % number_of_buffers > 1) then
-        field_name = output_naming(storage_prefix, op_name, &
-          series % variables(v) % input_name, buf_identifier)
+        out_field_name = output_naming(storage_prefix, op_name, &
+          in_field_name, buf_identifier)
       else
-        field_name = output_naming(storage_prefix, op_name, &
-          series % variables(v) % input_name)
+        out_field_name = output_naming(storage_prefix, op_name, &
+          in_field_name)
       end if
 
       ! create the name of the output var
-      series % variables(v) % output_names(b) = field_name
+      series % variables(v) % output_names(b) = out_field_name
 
       ! create the field and add to pool
       call add_new_field(info, &
-        series % variables(v) % input_name, &
-        series % variables(v) % output_names(b), &
+        in_field_name, &
+        out_field_name, &
         domain % blocklist % allFields, amPool)
 
       ! add the field to the output stream
       call mpas_stream_mgr_add_field(domain % streamManager, &
-        output_stream_name, series % variables(v) % output_names(b), ierr=err)
+        output_stream_name, out_field_name, ierr=err)
 
       ! put it in the restart stream
       if (restartStreamEnabled) then
          call mpas_stream_mgr_add_field(domain % streamManager, &
-           restart_stream_name, series % variables(v) % output_names(b), ierr=err)
+           restart_stream_name, out_field_name, ierr=err)
       end if
     end do
   end do ! number_of_variables

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -343,6 +343,9 @@ module ocn_forward_mode
       call mpas_set_time(referenceTime_timeType, dateTimeString=config_output_reference_time)
       call mpas_get_timeInterval(xtime_timeType - referenceTime_timeType, dt=Time)
       Time = Time*days_per_second
+      ! bounds on instantaneous time are just the time itself
+      Time_bnds(1) = Time
+      Time_bnds(2) = Time
 
       ! Update any mesh fields that may have been modified during init
       call ocn_meshUpdateFields(domain)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -155,17 +155,22 @@ module ocn_forward_mode
          block              ! structure with all data for a given block
 
       type (mpas_pool_type), pointer :: &
-         meshPool           ! structure containing mesh data
+         diagnosticsPool    ! structure containing diagnostics data
 
       type (MPAS_Time_type) :: &
          xtime_timeType,               &! current time
          simulationStartTime_timeType, &! start time whole simulation
+         referenceTime_timeType,       &! reference time for Time coordinate
          startTime,                    &! start time this run
          alarmTime                      ! alarm for salinity restoring
+
+      type (field0DReal), pointer :: TimeField    ! to add units
 
       type (MPAS_TimeInterval_type) :: &
          timeStep,      &! time step in time manager form
          alarmTimeStep   ! alarm interval in time manager form
+
+      character (len=StrKIND) :: units
 
       ! End preamble
       !-------------
@@ -320,8 +325,24 @@ module ocn_forward_mode
       ! compute time since start of simulation, in days
       call mpas_set_time(xtime_timeType, dateTimeString=xtime)
       call mpas_set_time(simulationStartTime_timeType, dateTimeString=simulationStartTime)
-      call mpas_get_timeInterval(xtime_timeType - simulationStartTime_timeType,dt=daysSinceStartOfSim)
+      call mpas_get_timeInterval(xtime_timeType - simulationStartTime_timeType, dt=daysSinceStartOfSim)
       daysSinceStartOfSim = daysSinceStartOfSim*days_per_second
+
+      call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
+
+      ! add units of "days since <ref_date>" to Time
+      write(units, '(a10,a20)') 'days since', &
+           config_output_reference_time(1:10)//" "//config_output_reference_time(12:19)
+      call mpas_pool_get_Field(diagnosticsPool, 'Time', TimeField)
+      call mpas_add_att(TimeField % attLists(1) % attList, 'units', units)
+
+      ! Add calendar attribute to Time
+      call mpas_add_att(TimeField % attLists(1) % attList, 'calendar', config_calendar_type)
+
+      ! compute Time as days since config_output_reference_time
+      call mpas_set_time(referenceTime_timeType, dateTimeString=config_output_reference_time)
+      call mpas_get_timeInterval(xtime_timeType - referenceTime_timeType, dt=Time)
+      Time = Time*days_per_second
 
       ! Update any mesh fields that may have been modified during init
       call ocn_meshUpdateFields(domain)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration.F
@@ -111,8 +111,9 @@ module ocn_time_integration
       !-----------------------------------------------------------------
 
       type (MPAS_Time_type) :: &
-         xtime_timeType,              &! current time in time type
-         simulationStartTime_timeType  ! start time in time type
+         xtime_timeType,               &! current time in time type
+         simulationStartTime_timeType, &! start time in time type
+         referenceTime_timeType         ! reference time for Time coordinate
 
       ! End preamble
       !-------------
@@ -142,6 +143,14 @@ module ocn_time_integration
            dt=daysSinceStartOfSim)
 
       daysSinceStartOfSim = daysSinceStartOfSim*days_per_second
+
+      call mpas_set_time(referenceTime_timeType, &
+                         dateTimeString=config_output_reference_time)
+      call mpas_get_timeInterval( &
+           xtime_timeType - referenceTime_timeType, &
+           dt=Time)
+
+      Time = Time*days_per_second
 
    !--------------------------------------------------------------------
 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration.F
@@ -151,6 +151,9 @@ module ocn_time_integration
            dt=Time)
 
       Time = Time*days_per_second
+      ! bounds on instantaneous time are just the time itself
+      Time_bnds(1) = Time
+      Time_bnds(2) = Time
 
    !--------------------------------------------------------------------
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -158,6 +158,7 @@ module ocn_diagnostics_variables
 
    real (kind=RKIND), pointer :: daysSinceStartOfSim
    real (kind=RKIND), pointer :: Time
+   real (kind=RKIND), dimension(:), pointer :: Time_bnds
    character (len=StrKIND), pointer :: xtime, simulationStartTime
 
    real (kind=RKIND), dimension(:,:), pointer :: bulkRichardsonNumber
@@ -559,6 +560,7 @@ contains
                "daysSinceStartOfSim", &
                 daysSinceStartOfSim)
       call mpas_pool_get_array(diagnosticsPool, 'Time', Time)
+      call mpas_pool_get_array(diagnosticsPool, 'Time_bnds', Time_bnds)
       call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
       call mpas_pool_get_array(diagnosticsPool, 'simulationStartTime', &
                 simulationStartTime)
@@ -856,6 +858,7 @@ contains
       !$acc                   tracersSurfaceValue,                     &
       !$acc                   daysSinceStartOfSim,                     &
       !$acc                   Time,                                    &
+      !$acc                   Time_bnds,                               &
       !$acc                   simulationStartTime,                     &
       !$acc                   boundaryLayerDepthSmooth,                &
       !$acc                   surfaceFluxAttenuationCoefficientRunoff  &
@@ -1105,6 +1108,7 @@ contains
       !$acc                   tracersSurfaceValue,                     &
       !$acc                   daysSinceStartOfSim,                     &
       !$acc                   Time,                                    &
+      !$acc                   Time_bnds,                               &
       !$acc                   simulationStartTime,                     &
       !$acc                   boundaryLayerDepthSmooth,                &
       !$acc                   surfaceFluxAttenuationCoefficientRunoff  &
@@ -1303,6 +1307,7 @@ contains
               tracersSurfaceValue,                     &
               daysSinceStartOfSim,                     &
               Time,                                    &
+              Time_bnds,                               &
               simulationStartTime,                     &
               boundaryLayerDepthSmooth,                &
               surfaceFluxAttenuationCoefficientRunoff)

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -157,6 +157,7 @@ module ocn_diagnostics_variables
       activeTracerVertMixTendency
 
    real (kind=RKIND), pointer :: daysSinceStartOfSim
+   real (kind=RKIND), pointer :: Time
    character (len=StrKIND), pointer :: xtime, simulationStartTime
 
    real (kind=RKIND), dimension(:,:), pointer :: bulkRichardsonNumber
@@ -557,6 +558,7 @@ contains
       call mpas_pool_get_array(diagnosticsPool, &
                "daysSinceStartOfSim", &
                 daysSinceStartOfSim)
+      call mpas_pool_get_array(diagnosticsPool, 'Time', Time)
       call mpas_pool_get_array(diagnosticsPool, 'xtime', xtime)
       call mpas_pool_get_array(diagnosticsPool, 'simulationStartTime', &
                 simulationStartTime)
@@ -853,6 +855,7 @@ contains
       !$acc                   pressureAdjustedSSH,                     &
       !$acc                   tracersSurfaceValue,                     &
       !$acc                   daysSinceStartOfSim,                     &
+      !$acc                   Time,                                    &
       !$acc                   simulationStartTime,                     &
       !$acc                   boundaryLayerDepthSmooth,                &
       !$acc                   surfaceFluxAttenuationCoefficientRunoff  &
@@ -1101,6 +1104,7 @@ contains
       !$acc                   pressureAdjustedSSH,                     &
       !$acc                   tracersSurfaceValue,                     &
       !$acc                   daysSinceStartOfSim,                     &
+      !$acc                   Time,                                    &
       !$acc                   simulationStartTime,                     &
       !$acc                   boundaryLayerDepthSmooth,                &
       !$acc                   surfaceFluxAttenuationCoefficientRunoff  &
@@ -1298,6 +1302,7 @@ contains
               pressureAdjustedSSH,                     &
               tracersSurfaceValue,                     &
               daysSinceStartOfSim,                     &
+              Time,                                    &
               simulationStartTime,                     &
               boundaryLayerDepthSmooth,                &
               surfaceFluxAttenuationCoefficientRunoff)


### PR DESCRIPTION
This variable has CF-compliant units and calendar. To accommodate the CF-compliant units, a new config option has been added to supply the reference time, 0001-01-01 by default.

This merge also adds a `Time_bnds` variable.  For output from a single point in time, the values in `Time_bnds` are the same as `Time`.  For time-averaged (or min or max) output, `Time_bnds` contains the start and end times of the interval covered by the output.

See https://github.com/E3SM-Ocean-Discussion/E3SM/pull/19 for more discussion

[BFB]