### PR TITLE
Fix inconsistent string length in a cosp character array

### DIFF
--- a/components/eam/src/physics/cam/cospsimulator_intr.F90
+++ b/components/eam/src/physics/cam/cospsimulator_intr.F90
@@ -1391,7 +1391,7 @@ CONTAINS
     ! MODIS outputs
     character(len=max_fieldname_len),dimension(nf_modis) :: &
          fname_modis=(/'CLTMODIS    ','CLWMODIS    ','CLIMODIS    ','CLHMODIS    ','CLMMODIS    ',&
-                       'CLTMODISIC  ','CLWMODISIC  ','CLIMODISIC ',&
+                       'CLTMODISIC  ','CLWMODISIC  ','CLIMODISIC  ',&
                        'CLLMODIS    ','TAUTMODIS   ','TAUWMODIS   ','TAUIMODIS   ','TAUTLOGMODIS',&
                        'TAUWLOGMODIS','TAUILOGMODIS','REFFCLWMODIS','REFFCLIMODIS',&
                        'PCTMODIS    ','LWPMODIS    ','IWPMODIS    ','CLMODIS     ','CLRIMODIS   ',&


### PR DESCRIPTION
An initialized character array does not have the same length for some
elements (newly introduced cosp variables via #5147), causing gnu compiler to abort.

[BFB]