### PR TITLE
Fix threading issues in submesoscale code

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
@@ -102,7 +102,7 @@ module ocn_submesoscale_eddies
      !$omp parallel
      !$omp do schedule(runtime) &
      !$omp private(cell1,cell2,bvfML,zEdge,streamFunction,gradBuoyML,hML,bvfAv, &
-     !$omp         zMLD,Lf,ds,mu,k)
+     !$omp         zMLD,Lf,ds,mu,k,indMLDedge,hAv)
      do iEdge=1,nEdges
         cell1 = cellsOnEdge(1,iEdge)
         cell2 = cellsOnEdge(2,iEdge)


### PR DESCRIPTION
Adds some missing variables to the omp pragmas in the new submesoscale model code, to fix some issues with a test not being reproducible with threading and debug on.

Fixes #5215 

[non-BFB] only with threading on