### PR TITLE
Fix two bugs in timeSeriesStats output in MPAS-Ocean

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -1429,7 +1429,11 @@ add_default($nl, 'config_AM_regionalStatsCustom_vertical_dimension');
 ###########################################
 
 add_default($nl, 'config_AM_timeSeriesStatsDaily_enable');
-add_default($nl, 'config_AM_timeSeriesStatsDaily_compute_on_startup');
+if ($CONTINUE_RUN eq 'TRUE') {
+	add_default($nl, 'config_AM_timeSeriesStatsDaily_compute_on_startup', 'val'=>".false.");
+} else {
+	add_default($nl, 'config_AM_timeSeriesStatsDaily_compute_on_startup', 'val'=>".true.");
+}
 add_default($nl, 'config_AM_timeSeriesStatsDaily_write_on_startup');
 add_default($nl, 'config_AM_timeSeriesStatsDaily_compute_interval');
 add_default($nl, 'config_AM_timeSeriesStatsDaily_output_stream');
@@ -1446,7 +1450,11 @@ add_default($nl, 'config_AM_timeSeriesStatsDaily_backward_output_offset');
 #############################################
 
 add_default($nl, 'config_AM_timeSeriesStatsMonthly_enable');
-add_default($nl, 'config_AM_timeSeriesStatsMonthly_compute_on_startup');
+if ($CONTINUE_RUN eq 'TRUE') {
+	add_default($nl, 'config_AM_timeSeriesStatsMonthly_compute_on_startup', 'val'=>".false.");
+} else {
+	add_default($nl, 'config_AM_timeSeriesStatsMonthly_compute_on_startup', 'val'=>".true.");
+}
 add_default($nl, 'config_AM_timeSeriesStatsMonthly_write_on_startup');
 add_default($nl, 'config_AM_timeSeriesStatsMonthly_compute_interval');
 add_default($nl, 'config_AM_timeSeriesStatsMonthly_output_stream');
@@ -1463,7 +1471,11 @@ add_default($nl, 'config_AM_timeSeriesStatsMonthly_backward_output_offset');
 #################################################
 
 add_default($nl, 'config_AM_timeSeriesStatsClimatology_enable');
-add_default($nl, 'config_AM_timeSeriesStatsClimatology_compute_on_startup');
+if ($CONTINUE_RUN eq 'TRUE') {
+	add_default($nl, 'config_AM_timeSeriesStatsClimatology_compute_on_startup', 'val'=>".false.");
+} else {
+	add_default($nl, 'config_AM_timeSeriesStatsClimatology_compute_on_startup', 'val'=>".true.");
+}
 add_default($nl, 'config_AM_timeSeriesStatsClimatology_write_on_startup');
 add_default($nl, 'config_AM_timeSeriesStatsClimatology_compute_interval');
 add_default($nl, 'config_AM_timeSeriesStatsClimatology_output_stream');
@@ -1480,7 +1492,11 @@ add_default($nl, 'config_AM_timeSeriesStatsClimatology_backward_output_offset');
 ################################################
 
 add_default($nl, 'config_AM_timeSeriesStatsMonthlyMax_enable');
-add_default($nl, 'config_AM_timeSeriesStatsMonthlyMax_compute_on_startup');
+if ($CONTINUE_RUN eq 'TRUE') {
+	add_default($nl, 'config_AM_timeSeriesStatsMonthlyMax_compute_on_startup', 'val'=>".false.");
+} else {
+	add_default($nl, 'config_AM_timeSeriesStatsMonthlyMax_compute_on_startup', 'val'=>".true.");
+}
 add_default($nl, 'config_AM_timeSeriesStatsMonthlyMax_write_on_startup');
 add_default($nl, 'config_AM_timeSeriesStatsMonthlyMax_compute_interval');
 add_default($nl, 'config_AM_timeSeriesStatsMonthlyMax_output_stream');
@@ -1497,7 +1513,11 @@ add_default($nl, 'config_AM_timeSeriesStatsMonthlyMax_backward_output_offset');
 ################################################
 
 add_default($nl, 'config_AM_timeSeriesStatsMonthlyMin_enable');
-add_default($nl, 'config_AM_timeSeriesStatsMonthlyMin_compute_on_startup');
+if ($CONTINUE_RUN eq 'TRUE') {
+	add_default($nl, 'config_AM_timeSeriesStatsMonthlyMin_compute_on_startup', 'val'=>".false.");
+} else {
+	add_default($nl, 'config_AM_timeSeriesStatsMonthlyMin_compute_on_startup', 'val'=>".true.");
+}
 add_default($nl, 'config_AM_timeSeriesStatsMonthlyMin_write_on_startup');
 add_default($nl, 'config_AM_timeSeriesStatsMonthlyMin_compute_interval');
 add_default($nl, 'config_AM_timeSeriesStatsMonthlyMin_output_stream');
@@ -1514,7 +1534,11 @@ add_default($nl, 'config_AM_timeSeriesStatsMonthlyMin_backward_output_offset');
 ############################################
 
 add_default($nl, 'config_AM_timeSeriesStatsCustom_enable');
-add_default($nl, 'config_AM_timeSeriesStatsCustom_compute_on_startup');
+if ($CONTINUE_RUN eq 'TRUE') {
+	add_default($nl, 'config_AM_timeSeriesStatsCustom_compute_on_startup', 'val'=>".false.");
+} else {
+	add_default($nl, 'config_AM_timeSeriesStatsCustom_compute_on_startup', 'val'=>".true.");
+}
 add_default($nl, 'config_AM_timeSeriesStatsCustom_write_on_startup');
 add_default($nl, 'config_AM_timeSeriesStatsCustom_compute_interval');
 add_default($nl, 'config_AM_timeSeriesStatsCustom_output_stream');

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -887,7 +887,11 @@ add_default($nl, 'config_AM_regionalStatsCustom_vertical_dimension');
 ###########################################
 
 add_default($nl, 'config_AM_timeSeriesStatsDaily_enable');
-add_default($nl, 'config_AM_timeSeriesStatsDaily_compute_on_startup');
+if ($CONTINUE_RUN eq 'TRUE') {
+	add_default($nl, 'config_AM_timeSeriesStatsDaily_compute_on_startup', 'val'=>".false.");
+} else {
+	add_default($nl, 'config_AM_timeSeriesStatsDaily_compute_on_startup', 'val'=>".true.");
+}
 add_default($nl, 'config_AM_timeSeriesStatsDaily_write_on_startup');
 add_default($nl, 'config_AM_timeSeriesStatsDaily_compute_interval');
 add_default($nl, 'config_AM_timeSeriesStatsDaily_output_stream');
@@ -904,7 +908,11 @@ add_default($nl, 'config_AM_timeSeriesStatsDaily_backward_output_offset');
 #############################################
 
 add_default($nl, 'config_AM_timeSeriesStatsMonthly_enable');
-add_default($nl, 'config_AM_timeSeriesStatsMonthly_compute_on_startup');
+if ($CONTINUE_RUN eq 'TRUE') {
+	add_default($nl, 'config_AM_timeSeriesStatsMonthly_compute_on_startup', 'val'=>".false.");
+} else {
+	add_default($nl, 'config_AM_timeSeriesStatsMonthly_compute_on_startup', 'val'=>".true.");
+}
 add_default($nl, 'config_AM_timeSeriesStatsMonthly_write_on_startup');
 add_default($nl, 'config_AM_timeSeriesStatsMonthly_compute_interval');
 add_default($nl, 'config_AM_timeSeriesStatsMonthly_output_stream');
@@ -921,7 +929,11 @@ add_default($nl, 'config_AM_timeSeriesStatsMonthly_backward_output_offset');
 #################################################
 
 add_default($nl, 'config_AM_timeSeriesStatsClimatology_enable');
-add_default($nl, 'config_AM_timeSeriesStatsClimatology_compute_on_startup');
+if ($CONTINUE_RUN eq 'TRUE') {
+	add_default($nl, 'config_AM_timeSeriesStatsClimatology_compute_on_startup', 'val'=>".false.");
+} else {
+	add_default($nl, 'config_AM_timeSeriesStatsClimatology_compute_on_startup', 'val'=>".true.");
+}
 add_default($nl, 'config_AM_timeSeriesStatsClimatology_write_on_startup');
 add_default($nl, 'config_AM_timeSeriesStatsClimatology_compute_interval');
 add_default($nl, 'config_AM_timeSeriesStatsClimatology_output_stream');
@@ -938,7 +950,11 @@ add_default($nl, 'config_AM_timeSeriesStatsClimatology_backward_output_offset');
 ################################################
 
 add_default($nl, 'config_AM_timeSeriesStatsMonthlyMax_enable');
-add_default($nl, 'config_AM_timeSeriesStatsMonthlyMax_compute_on_startup');
+if ($CONTINUE_RUN eq 'TRUE') {
+	add_default($nl, 'config_AM_timeSeriesStatsMonthlyMax_compute_on_startup', 'val'=>".false.");
+} else {
+	add_default($nl, 'config_AM_timeSeriesStatsMonthlyMax_compute_on_startup', 'val'=>".true.");
+}
 add_default($nl, 'config_AM_timeSeriesStatsMonthlyMax_write_on_startup');
 add_default($nl, 'config_AM_timeSeriesStatsMonthlyMax_compute_interval');
 add_default($nl, 'config_AM_timeSeriesStatsMonthlyMax_output_stream');
@@ -955,7 +971,11 @@ add_default($nl, 'config_AM_timeSeriesStatsMonthlyMax_backward_output_offset');
 ################################################
 
 add_default($nl, 'config_AM_timeSeriesStatsMonthlyMin_enable');
-add_default($nl, 'config_AM_timeSeriesStatsMonthlyMin_compute_on_startup');
+if ($CONTINUE_RUN eq 'TRUE') {
+	add_default($nl, 'config_AM_timeSeriesStatsMonthlyMin_compute_on_startup', 'val'=>".false.");
+} else {
+	add_default($nl, 'config_AM_timeSeriesStatsMonthlyMin_compute_on_startup', 'val'=>".true.");
+}
 add_default($nl, 'config_AM_timeSeriesStatsMonthlyMin_write_on_startup');
 add_default($nl, 'config_AM_timeSeriesStatsMonthlyMin_compute_interval');
 add_default($nl, 'config_AM_timeSeriesStatsMonthlyMin_output_stream');
@@ -972,7 +992,11 @@ add_default($nl, 'config_AM_timeSeriesStatsMonthlyMin_backward_output_offset');
 ############################################
 
 add_default($nl, 'config_AM_timeSeriesStatsCustom_enable');
-add_default($nl, 'config_AM_timeSeriesStatsCustom_compute_on_startup');
+if ($CONTINUE_RUN eq 'TRUE') {
+	add_default($nl, 'config_AM_timeSeriesStatsCustom_compute_on_startup', 'val'=>".false.");
+} else {
+	add_default($nl, 'config_AM_timeSeriesStatsCustom_compute_on_startup', 'val'=>".true.");
+}
 add_default($nl, 'config_AM_timeSeriesStatsCustom_write_on_startup');
 add_default($nl, 'config_AM_timeSeriesStatsCustom_compute_interval');
 add_default($nl, 'config_AM_timeSeriesStatsCustom_output_stream');

--- a/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_climatology.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_climatology.xml
@@ -8,7 +8,7 @@
 		<nml_option name="config_AM_timeSeriesStatsClimatology_compute_on_startup"
 			type="logical"
 			default_value=".false."
-			description="Logical flag determining if an analysis member computation occurs on start-up. You likely want this off for this (time series) analysis member because it will accumulate any state prior to time stepping (double counting the last time step)."
+			description="Logical flag determining if an analysis member computation occurs on start-up. This should be set to .false. for better efficiency in most cases because the results of this first call will simply be thrown away.  The exception is at the beginning of new E3SM simulations (CONTINUE_RUN = FALSE), where the first time step will be missing if this is not set to .true."
 			possible_values=".true. or .false."
 		/>
 		<nml_option name="config_AM_timeSeriesStatsClimatology_write_on_startup"

--- a/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_custom.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_custom.xml
@@ -8,7 +8,7 @@
 		<nml_option name="config_AM_timeSeriesStatsCustom_compute_on_startup"
 			type="logical"
 			default_value=".false."
-			description="Logical flag determining if an analysis member computation occurs on start-up. You likely want this off for this (time series) analysis member because it will accumulate any state prior to time stepping (double counting the last time step)."
+			description="Logical flag determining if an analysis member computation occurs on start-up. This should be set to .false. for better efficiency in most cases because the results of this first call will simply be thrown away.  The exception is at the beginning of new E3SM simulations (CONTINUE_RUN = FALSE), where the first time step will be missing if this is not set to .true."
 			possible_values=".true. or .false."
 		/>
 		<nml_option name="config_AM_timeSeriesStatsCustom_write_on_startup"

--- a/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_daily.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_daily.xml
@@ -8,7 +8,7 @@
 		<nml_option name="config_AM_timeSeriesStatsDaily_compute_on_startup"
 			type="logical"
 			default_value=".false."
-			description="Logical flag determining if an analysis member computation occurs on start-up. You likely want this off for this (time series) analysis member because it will accumulate any state prior to time stepping (double counting the last time step)."
+			description="Logical flag determining if an analysis member computation occurs on start-up. This should be set to .false. for better efficiency in most cases because the results of this first call will simply be thrown away.  The exception is at the beginning of new E3SM simulations (CONTINUE_RUN = FALSE), where the first time step will be missing if this is not set to .true."
 			possible_values=".true. or .false."
 		/>
 		<nml_option name="config_AM_timeSeriesStatsDaily_write_on_startup"

--- a/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_monthly_max.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_monthly_max.xml
@@ -8,7 +8,7 @@
 		<nml_option name="config_AM_timeSeriesStatsMonthlyMax_compute_on_startup"
 			type="logical"
 			default_value=".false."
-			description="Logical flag determining if an analysis member computation occurs on start-up. You likely want this off for this (time series) analysis member because it will accumulate any state prior to time stepping (double counting the last time step)."
+			description="Logical flag determining if an analysis member computation occurs on start-up. This should be set to .false. for better efficiency in most cases because the results of this first call will simply be thrown away.  The exception is at the beginning of new E3SM simulations (CONTINUE_RUN = FALSE), where the first time step will be missing if this is not set to .true."
 			possible_values=".true. or .false."
 		/>
 		<nml_option name="config_AM_timeSeriesStatsMonthlyMax_write_on_startup"

--- a/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_monthly_mean.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_monthly_mean.xml
@@ -8,7 +8,7 @@
 		<nml_option name="config_AM_timeSeriesStatsMonthly_compute_on_startup"
 			type="logical"
 			default_value=".false."
-			description="Logical flag determining if an analysis member computation occurs on start-up. You likely want this off for this (time series) analysis member because it will accumulate any state prior to time stepping (double counting the last time step)."
+			description="Logical flag determining if an analysis member computation occurs on start-up. This should be set to .false. for better efficiency in most cases because the results of this first call will simply be thrown away.  The exception is at the beginning of new E3SM simulations (CONTINUE_RUN = FALSE), where the first time step will be missing if this is not set to .true."
 			possible_values=".true. or .false."
 		/>
 		<nml_option name="config_AM_timeSeriesStatsMonthly_write_on_startup"

--- a/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_monthly_min.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_monthly_min.xml
@@ -8,7 +8,7 @@
 		<nml_option name="config_AM_timeSeriesStatsMonthlyMin_compute_on_startup"
 			type="logical"
 			default_value=".false."
-			description="Logical flag determining if an analysis member computation occurs on start-up. You likely want this off for this (time series) analysis member because it will accumulate any state prior to time stepping (double counting the last time step)."
+			description="Logical flag determining if an analysis member computation occurs on start-up. This should be set to .false. for better efficiency in most cases because the results of this first call will simply be thrown away.  The exception is at the beginning of new E3SM simulations (CONTINUE_RUN = FALSE), where the first time step will be missing if this is not set to .true."
 			possible_values=".true. or .false."
 		/>
 		<nml_option name="config_AM_timeSeriesStatsMonthlyMin_write_on_startup"

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_analysis_driver.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_analysis_driver.F
@@ -576,11 +576,12 @@ contains
 
       integer :: timeLevel, err_tmp
 
-      character (len=StrKIND) :: configName, timerName
-      character (len=StrKIND), pointer :: config_AM_output_stream
+      character (len=StrKIND) :: configName, alarmName, timerName
+      character (len=StrKIND), pointer :: config_AM_output_stream, config_AM_compute_interval
       logical, pointer :: config_AM_enable, config_AM_write_on_startup, config_AM_compute_on_startup
       type (mpas_pool_iterator_type) :: poolItr
       integer :: nameLength
+      type (MPAS_TimeInterval_type) :: computeInterval
 
       err = 0
 
@@ -600,20 +601,31 @@ contains
             configName = 'config_AM_' // poolItr % memberName(1:nameLength) // '_write_on_startup'
             call mpas_pool_get_config(domain % configs, configName, config_AM_write_on_startup)
 
+            configName = 'config_AM_' // poolItr % memberName(1:nameLength) // '_output_stream'
+            call mpas_pool_get_config(domain % configs, configName, config_AM_output_stream)
+
             if ( config_AM_compute_on_startup ) then
                timerName = trim(computeStartupTimerPrefix) // poolItr % memberName(1:nameLength)
 #ifdef MPAS_DEBUG
                call mpas_log_write( '      Computing AM ' // poolItr % memberName(1:nameLength))
 #endif
+               configName = 'config_AM_' // poolItr % memberName(1:nameLength) // '_compute_interval'
+               call mpas_pool_get_config(domain % configs, configName, config_AM_compute_interval)
+               if ( config_AM_compute_interval == 'output_interval') then
+                  computeInterval = MPAS_stream_mgr_get_stream_interval(domain % streamManager, &
+                     streamID=config_AM_output_stream, direction=MPAS_STREAM_OUTPUT, ierr=err_tmp)
+               else
+                  alarmName = poolItr % memberName(1:nameLength) // computeAlarmSuffix
+                  computeInterval = mpas_alarm_interval(domain % clock, alarmName, ierr=err_tmp)
+               end if
+
                call mpas_timer_start(timerName)
-               call ocn_compute_analysis_members(domain, timeLevel, poolItr % memberName, err_tmp)
+               call ocn_compute_analysis_members(domain, timeLevel, poolItr % memberName, computeInterval, err_tmp)
                call mpas_timer_stop(timerName)
                err = ior(err, err_tmp)
             end if
 
             if ( config_AM_write_on_startup ) then
-               configName = 'config_AM_' // poolItr % memberName(1:nameLength) // '_output_stream'
-               call mpas_pool_get_config(domain % configs, configName, config_AM_output_stream)
                if ( config_AM_output_stream /= 'none' ) then
 #ifdef MPAS_DEBUG
                   call mpas_log_write( '      Writing AM ' // poolItr % memberName(1:nameLength))
@@ -789,6 +801,7 @@ contains
       logical, pointer :: config_AM_enable
       type (mpas_pool_iterator_type) :: poolItr
       integer :: nameLength
+      type (MPAS_TimeInterval_type) :: computeInterval
 
       err = 0
 
@@ -819,8 +832,10 @@ contains
 #ifdef MPAS_DEBUG
                   call mpas_log_write( '      Computing AM ' // poolItr % memberName(1:nameLength))
 #endif
+                  computeInterval = MPAS_stream_mgr_get_stream_interval(domain % streamManager, streamID=config_AM_output_stream, &
+                     direction=MPAS_STREAM_OUTPUT, ierr=err_tmp)
                   call mpas_timer_start(timerName)
-                  call ocn_compute_analysis_members(domain, timeLevel, poolItr % memberName, err_tmp)
+                  call ocn_compute_analysis_members(domain, timeLevel, poolItr % memberName, computeInterval, err_tmp)
                   call mpas_timer_stop(timerName)
                end if
             else if ( mpas_is_alarm_ringing(domain % clock, alarmName, ierr=err_tmp) ) then
@@ -828,8 +843,9 @@ contains
 #ifdef MPAS_DEBUG
                call mpas_log_write( '      Computing AM ' // poolItr % memberName(1:nameLength))
 #endif
+               computeInterval = mpas_alarm_interval(domain % clock, alarmName, ierr=err_tmp)
                call mpas_timer_start(timerName)
-               call ocn_compute_analysis_members(domain, timeLevel, poolItr % memberName, err_tmp)
+               call ocn_compute_analysis_members(domain, timeLevel, poolItr % memberName, computeInterval, err_tmp)
                call mpas_timer_stop(timerName)
             end if
          end if
@@ -1319,11 +1335,12 @@ contains
 !>  This private routine calls the correct compute routine for each analysis member.
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_compute_analysis_members(domain, timeLevel, analysisMemberName, iErr)!{{{
+   subroutine ocn_compute_analysis_members(domain, timeLevel, analysisMemberName, computeInterval, iErr)!{{{
       type (domain_type), intent(inout) :: domain !< Input: Domain information
       integer, intent(in) :: timeLevel !< Input: Time level to compute with in analysis member
       character (len=*), intent(in) :: analysisMemberName !< Input: Name of analysis member
       integer, intent(out) :: iErr !< Output: Error code
+      type (MPAS_TimeInterval_type), intent(in) :: computeInterval
 
       integer :: nameLength, err_tmp
 
@@ -1396,22 +1413,22 @@ contains
       ! time is last
       else if ( analysisMemberName(1:nameLength) == 'timeSeriesStatsDaily' ) then
          call ocn_compute_time_series_stats(domain, timeLevel, &
-           timeSeriesDailyTAG, err_tmp)
+           timeSeriesDailyTAG, computeInterval, err_tmp)
       else if ( analysisMemberName(1:nameLength) == 'timeSeriesStatsMonthly' ) then
          call ocn_compute_time_series_stats(domain, timeLevel, &
-           timeSeriesMonthlyTAG, err_tmp)
+           timeSeriesMonthlyTAG, computeInterval, err_tmp)
       else if ( analysisMemberName(1:nameLength) == 'timeSeriesStatsClimatology' ) then
          call ocn_compute_time_series_stats(domain, timeLevel, &
-           timeSeriesClimatologyTAG, err_tmp)
+           timeSeriesClimatologyTAG, computeInterval, err_tmp)
       else if ( analysisMemberName(1:nameLength) == 'timeSeriesStatsCustom' ) then
          call ocn_compute_time_series_stats(domain, timeLevel, &
-           timeSeriesCustomTAG, err_tmp)
+           timeSeriesCustomTAG, computeInterval, err_tmp)
       else if ( analysisMemberName(1:nameLength) == 'timeSeriesStatsMonthlyMin' ) then
          call ocn_compute_time_series_stats(domain, timeLevel, &
-           timeSeriesMonthlyMinTAG, err_tmp)
+           timeSeriesMonthlyMinTAG, computeInterval, err_tmp)
       else if ( analysisMemberName(1:nameLength) == 'timeSeriesStatsMonthlyMax' ) then
          call ocn_compute_time_series_stats(domain, timeLevel, &
-           timeSeriesMonthlyMaxTAG, err_tmp)
+           timeSeriesMonthlyMaxTAG, computeInterval, err_tmp)
       end if
 
       iErr = ior(iErr, err_tmp)

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_time_series_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_time_series_stats.F
@@ -304,10 +304,11 @@ end subroutine ocn_init_time_series_stats!}}}
 !>  This routine conducts all computation required for this
 !>  MPAS-Ocean analysis member.
 !-----------------------------------------------------------------------
-subroutine ocn_compute_time_series_stats(domain, timeLevel, instance, err)!{{{
+subroutine ocn_compute_time_series_stats(domain, timeLevel, instance, computeInterval, err)!{{{
   ! input variables
   character (len=StrKIND), intent(in) :: instance
   integer, intent(in) :: timeLevel
+  type (MPAS_TimeInterval_type), intent(in) :: computeInterval
 
   ! input/output variables
   type (domain_type), intent(inout) :: domain
@@ -343,7 +344,7 @@ subroutine ocn_compute_time_series_stats(domain, timeLevel, instance, err)!{{{
       if (unset_xtime) then
         end_intv = mpas_get_clock_time(domain % clock, MPAS_NOW, err)
         call mpas_get_time(end_intv, dateTimeString=end_xtime, ierr=err)
-        start_intv = end_intv - mpas_get_clock_timestep(domain % clock, err)
+        start_intv = end_intv - computeInterval
         call mpas_get_time(start_intv, dateTimeString=start_xtime, ierr=err)
         call mpas_set_time(reference_time, dateTimeString=config_output_reference_time)
         call mpas_get_timeInterval(start_intv - reference_time, dt=Time_bnds(1))

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_time_series_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_time_series_stats.F
@@ -238,7 +238,7 @@ subroutine ocn_init_time_series_stats(domain, instance, err)!{{{
   integer :: v, b
   type (time_series_type) :: series
   type (time_series_alarms_type), allocatable, dimension(:) :: alarms
-  type (MPAS_Time_type) :: start_intv, start_time, reference_time
+  type (MPAS_Time_type) :: start_time, reference_time
   character (len=StrKIND) :: start_xtime
   real (kind=RKIND) :: Time
   character (len=StrKIND), pointer :: config_output_reference_time
@@ -262,10 +262,8 @@ subroutine ocn_init_time_series_stats(domain, instance, err)!{{{
 
   ! set xtime start if it is still unset, for very first time step
   ! (i.e., no restarts)
-  start_intv = mpas_get_clock_time(domain % clock, MPAS_NOW, err)
-  call mpas_get_time(start_intv, dateTimeString=start_xtime, ierr=err)
-
   start_time = mpas_get_clock_time(domain%clock, MPAS_START_TIME, err_tmp)
+  call mpas_get_time(start_time, dateTimeString=start_xtime, ierr=err_tmp)
   if (err_tmp /= 0) then
      call mpas_log_write('Error getting start time in init', &
           MPAS_LOG_ERR, masterOnly=.true., flushNow=.true.)
@@ -275,14 +273,15 @@ subroutine ocn_init_time_series_stats(domain, instance, err)!{{{
   call mpas_pool_get_config(domain % configs, 'config_output_reference_time', &
     config_output_reference_time)
   call mpas_set_time(reference_time, dateTimeString=config_output_reference_time)
-  call mpas_get_timeInterval(start_time - reference_time, dt=Time)
-  Time = Time*days_per_second
 
   do b = 1, series % number_of_buffers
     if (trim(series % buffers(b) % xtime_start) == '') then
       series % buffers(b) % xtime_start = start_xtime
-      series % buffers(b) % Time_bnds(1) = Time
     end if
+    call mpas_set_time(start_time, dateTimeString=series % buffers(b) % xtime_start)
+    call mpas_get_timeInterval(start_time - reference_time, dt=Time)
+    Time = Time*days_per_second
+    series % buffers(b) % Time_bnds(1) = Time
   end do
 
   ! clean up the instance memory
@@ -1264,11 +1263,8 @@ subroutine modify_stream(domain, instance, series, valid_input, err)!{{{
     ! For CF compliance, output field name is the original field name, not the mangled one
     TimeField % outputFieldName = in_field_name
 
-    ! put it in the restart stream
-    if (restartStreamEnabled) then
-       call mpas_stream_mgr_add_field(domain % streamManager, &
-         restart_stream_name, out_field_name, ierr=err)
-    end if
+    ! do not put Time in the restart stream because it has a generic output name and will
+    ! interfere with Time from a normal restart file
 
     ! Time_bnds
     in_field_name = 'Time_bnds'
@@ -1290,11 +1286,8 @@ subroutine modify_stream(domain, instance, series, valid_input, err)!{{{
     call mpas_stream_mgr_add_field(domain % streamManager, &
       output_stream_name, out_field_name, ierr=err)
 
-    ! put it in the restart stream
-    if (restartStreamEnabled) then
-       call mpas_stream_mgr_add_field(domain % streamManager, &
-         restart_stream_name, out_field_name, ierr=err)
-    end if
+    ! do not put Time_bnds in the restart stream because it has a generic output name and will
+    ! interfere with Time_bnds from a normal restart file
 
     ! For CF compliance, output field name is the original field name, not the mangled one
     call mpas_pool_get_Field(domain % blocklist % allFields, out_field_name, TimeBndsField)

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_time_series_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_time_series_stats.F
@@ -23,6 +23,7 @@ module ocn_time_series_stats
   use mpas_stream_manager
 
   use ocn_constants
+  use ocn_diagnostics_variables
 
   implicit none
   private
@@ -269,7 +270,6 @@ subroutine ocn_init_time_series_stats(domain, instance, err)!{{{
           MPAS_LOG_ERR, masterOnly=.true., flushNow=.true.)
      err = ior(err, err_tmp)
   endif
-
   call mpas_pool_get_config(domain % configs, 'config_output_reference_time', &
     config_output_reference_time)
   call mpas_set_time(reference_time, dateTimeString=config_output_reference_time)
@@ -1813,8 +1813,8 @@ subroutine set_times(series, alarms, clock, which, config, ok, err)
     ! set the time
     if (which == START_TIMES) then
       if (time == INITIAL_TIME_TOKEN) then
-        alarms(b) % start_time = &
-          mpas_get_clock_time(clock, MPAS_START_TIME, err)
+        call mpas_set_time(alarms(b) % start_time, &
+          dateTimeString=simulationStartTime)
       else
         call mpas_set_time(alarms(b) % start_time, &
           dateTimeString=time, ierr=err)


### PR DESCRIPTION
This merge fixes two issues in `timeSeriesStatsDaily` and `timeSeriesStatsMonthly` in MPAS-Ocean.

The first is that the value `xtimeMonthly_start` was inaccurate at the start of a simulation and after model restart.  This occurred because of a combination of problems.  
1. When E3SM reset the MPAS clock, MPAS alarms are recalibrated so they ring immediately (rather than at the end of the desired time-averaging interval), a behavior different from MPAS standalone runs. 
2. As a result, it turns out to be desirable to immediately check (and reset) alarms when MPAS) starts for the first time or restarts, allowing the time interval to begin afresh and time averaging to start over if appropriate.
3. Because MPAS-O is a step behind when starting a new E3SM simulation, it is desirable to compute time-series stats on startup (but not on restart) so the first day or month is complete (rather than short one time step).
4. `xtimeMonthly_start` was being computed by subtracting a time step from the current time, rather than a compute interval of `timeSeriesStats` after a restart.

This issue was present in E3SM output.
closes #5217

The second issue does not affect E3SM output because E3SM doesn't use restart files for `timeSeriesStats`.  However, standalone runs that do use restart files for this analysis were experiencing a problem in which time averaging was not getting reset after a restart, leading to time averages over the whole simulation rather than the expected (daily or monthly) interval.  This issue has been fixed by referencing the reset alarm to the `simulationStartTime` rather than the beginning of the current (possibly restart) run.

closes https://github.com/MPAS-Dev/MPAS-Model/issues/121