### PR TITLE
Double PEs to prevent walltime timeouts on Ascent

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -366,12 +366,12 @@
       <pes compset="JRA_ELM.+MPASSI.+MPASO.+MOSART" pesize="any">
         <comment>"crusher, GPMPAS-JRA compset, 2 nodes"</comment>
         <ntasks>
-          <ntasks_atm>-2</ntasks_atm>
-          <ntasks_lnd>-2</ntasks_lnd>
-          <ntasks_rof>-2</ntasks_rof>
-          <ntasks_ice>-2</ntasks_ice>
-          <ntasks_ocn>-2</ntasks_ocn>
-          <ntasks_cpl>-2</ntasks_cpl>
+          <ntasks_atm>-4</ntasks_atm>
+          <ntasks_lnd>-4</ntasks_lnd>
+          <ntasks_rof>-4</ntasks_rof>
+          <ntasks_ice>-4</ntasks_ice>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_cpl>-4</ntasks_cpl>
         </ntasks>
       </pes>
     </mach>

--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -1558,14 +1558,14 @@
       <pes compset="any" pesize="any">
         <comment>summit|ascent: any compset on ne30np4 grid</comment>
         <ntasks>
-          <ntasks_atm>-2</ntasks_atm>
-          <ntasks_lnd>-2</ntasks_lnd>
-          <ntasks_rof>-2</ntasks_rof>
-          <ntasks_ice>-2</ntasks_ice>
-          <ntasks_ocn>-2</ntasks_ocn>
-          <ntasks_cpl>-2</ntasks_cpl>
-          <ntasks_glc>-2</ntasks_glc>
-          <ntasks_wav>-2</ntasks_wav>
+          <ntasks_atm>-4</ntasks_atm>
+          <ntasks_lnd>-4</ntasks_lnd>
+          <ntasks_rof>-4</ntasks_rof>
+          <ntasks_ice>-4</ntasks_ice>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_cpl>-4</ntasks_cpl>
+          <ntasks_glc>-4</ntasks_glc>
+          <ntasks_wav>-4</ntasks_wav>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>

--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -375,6 +375,19 @@
         </ntasks>
       </pes>
     </mach>
+    <mach name="summit|ascent">
+      <pes compset="JRA_ELM.+MPASSI.+MPASO.+MOSART" pesize="any">
+        <comment>summit|ascent: GPMPAS-JRA compset on ne30np4 grid</comment>
+        <ntasks>
+          <ntasks_atm>-4</ntasks_atm>
+          <ntasks_lnd>-4</ntasks_lnd>
+          <ntasks_rof>-4</ntasks_rof>
+          <ntasks_ice>-4</ntasks_ice>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_cpl>-4</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
   </grid>
   <grid name="a%ne30np4_">
     <mach name="cori-haswell">
@@ -1558,14 +1571,14 @@
       <pes compset="any" pesize="any">
         <comment>summit|ascent: any compset on ne30np4 grid</comment>
         <ntasks>
-          <ntasks_atm>-4</ntasks_atm>
-          <ntasks_lnd>-4</ntasks_lnd>
-          <ntasks_rof>-4</ntasks_rof>
-          <ntasks_ice>-4</ntasks_ice>
-          <ntasks_ocn>-4</ntasks_ocn>
-          <ntasks_cpl>-4</ntasks_cpl>
-          <ntasks_glc>-4</ntasks_glc>
-          <ntasks_wav>-4</ntasks_wav>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_cpl>-2</ntasks_cpl>
+          <ntasks_glc>-2</ntasks_glc>
+          <ntasks_wav>-2</ntasks_wav>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>

--- a/components/elm/cime_config/config_pes.xml
+++ b/components/elm/cime_config/config_pes.xml
@@ -279,12 +279,12 @@
       <pes compset=".*ELM%CN.*" pesize="any">
         <comment>elm: ascent|summit PEs for grid l%360x720cru</comment>
         <ntasks>
-          <ntasks_atm>-1</ntasks_atm>
-          <ntasks_lnd>-1</ntasks_lnd>
-          <ntasks_rof>-1</ntasks_rof>
-          <ntasks_ice>-1</ntasks_ice>
-          <ntasks_ocn>-1</ntasks_ocn>
-          <ntasks_cpl>-1</ntasks_cpl>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_cpl>-2</ntasks_cpl>
         </ntasks>
       </pes>
     </mach>
@@ -531,6 +531,19 @@
           <ntasks_glc>-4</ntasks_glc>
           <ntasks_wav>-4</ntasks_wav>
           <ntasks_cpl>-4</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
+    <mach name="ascent|summit">
+      <pes compset="any" pesize="any">
+        <comment>elm: ascent|summit PEs for grid l%r05_*r%r05</comment>
+        <ntasks>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_cpl>-2</ntasks_cpl>
         </ntasks>
       </pes>
     </mach>


### PR DESCRIPTION
Double PEs to prevent walltime timeouts on Ascent for
- ERS.hcru_hcru.I20TRGSWCNPRDCTCBC.elm-erosion
- ERS.ne30pg2_r05_EC30to60E2r2.GPMPAS-JRA.mosart-rof_ocn_2way (on Crusher too)
- ERS.r05_r05.IELM.elm-V2_ELM_MOSART_features

[BFB]