### PR TITLE
Hommexx/SL: Implement HOMMEXX_MPI_ON_DEVICE=Off in SL transport.

### DIFF
--- a/components/homme/src/share/compose/CMakeLists.txt
+++ b/components/homme/src/share/compose/CMakeLists.txt
@@ -10,6 +10,10 @@ endif ()
 if (COMPOSE_PORT)
   add_definitions(-DCOMPOSE_PORT)
 endif ()
+if (NOT HOMMEXX_MPI_ON_DEVICE)
+  message("compose> MPI on host")
+  add_definitions(-DCOMPOSE_MPI_ON_HOST)
+endif ()
 add_library (${COMPOSE_LIBRARY}
   compose_test.cpp
   compose_homme.cpp

--- a/components/homme/src/share/compose/compose_slmm_islmpi.cpp
+++ b/components/homme/src/share/compose/compose_slmm_islmpi.cpp
@@ -629,6 +629,7 @@ void set_idx2_maps (IslMpi<MT>& cm, const Rank2Gids& rank2rmtgids,
   cm.x_bulkdata_offset_h = cm.x_bulkdata_offset.mirror();
   cm.sendreq.reset_capacity(i, true);
   cm.recvreq.reset_capacity(i, true);
+  cm.recvreq_ri.reset_capacity(i, true);
 
   const Int nrmtrank = static_cast<Int>(cm.ranks.size()) - 1;
   std::vector<std::map<Int, Int> > lor2idx(nrmtrank);
@@ -737,6 +738,10 @@ void alloc_mpi_buffers (IslMpi<MT>& cm, Real* sendbuf, Real* recvbuf) {
   cm.bla_h = cm.bla.mirror();
   cm.sendbuf.init(nrmtrank, cm.sendsz.data(), sendbuf);
   cm.recvbuf.init(nrmtrank, cm.recvsz.data(), recvbuf);
+#ifdef COMPOSE_MPI_ON_HOST
+  cm.sendbuf_h = cm.sendbuf.mirror();
+  cm.recvbuf_h = cm.recvbuf.mirror();
+#endif
   cm.nlid_per_rank.clear();
   cm.sendsz.clear();
   cm.recvsz.clear();

--- a/components/homme/src/share/compose/compose_slmm_islmpi.hpp
+++ b/components/homme/src/share/compose/compose_slmm_islmpi.hpp
@@ -268,6 +268,7 @@ struct ListOfLists {
     SLMM_KIF T* data () const { return d_; }
     SLMM_KIF T* begin () const { return d_; }
     SLMM_KIF T* end () const { return d_ + n_; }
+    SLMM_KIF Array<T> view () const { return Array<T>(d_, n_); }
 
   private:
     friend class ListOfLists<T, DT>;
@@ -526,7 +527,11 @@ struct IslMpi {
 
   // MPI comm data.
   FixedCapList<mpi::Request, HDT> sendreq, recvreq;
+  FixedCapList<Int, HDT> recvreq_ri;
   ListOfLists<Real, DDT> sendbuf, recvbuf;
+#ifdef COMPOSE_MPI_ON_HOST
+  typename ListOfLists<Real, DDT>::Mirror sendbuf_h, recvbuf_h;
+#endif
   FixedCapList<Int, DDT> sendcount, x_bulkdata_offset;
   ListOfLists<Real, HDT> sendbuf_meta_h, recvbuf_meta_h; // not mirrors
   FixedCapList<Int, DDT> rmt_xs, rmt_qs_extrema;

--- a/components/homme/src/share/compose/compose_slmm_islmpi_comm.cpp
+++ b/components/homme/src/share/compose/compose_slmm_islmpi_comm.cpp
@@ -45,12 +45,17 @@ void setup_irecv (IslMpi<MT>& cm, const bool skip_if_empty) {
   {
     const Int nrmtrank = static_cast<Int>(cm.ranks.size()) - 1;
     cm.recvreq.clear();
-    for (Int ri = 0; ri < nrmtrank; ++ri) {
+    for (Int ri = 0, nri = 0; ri < nrmtrank; ++ri) {
       if (skip_if_empty && cm.nx_in_rank_h(ri) == 0) continue;
-      auto&& recvbuf = cm.recvbuf.get_h(ri);
       // The count is just the number of slots available, which can be larger
       // than what is actually being received.
+      cm.recvreq_ri(nri++) = ri;
       cm.recvreq.inc();
+#ifdef COMPOSE_MPI_ON_HOST
+      auto&& recvbuf = cm.recvbuf_h(ri);
+#else
+      auto&& recvbuf = cm.recvbuf.get_h(ri);
+#endif
       mpi::irecv(*cm.p, recvbuf.data(), recvbuf.n(), cm.ranks(ri), 42,
                  &cm.recvreq.back());
     }
@@ -67,24 +72,19 @@ void isend (IslMpi<MT>& cm, const bool want_req, const bool skip_if_empty) {
     const Int nrmtrank = static_cast<Int>(cm.ranks.size()) - 1;
     for (Int ri = 0; ri < nrmtrank; ++ri) {
       if (skip_if_empty && cm.sendcount_h(ri) == 0) continue;
-      mpi::isend(*cm.p, cm.sendbuf.get_h(ri).data(), cm.sendcount_h(ri),
+#ifdef COMPOSE_MPI_ON_HOST
+      auto&& sendbuf = cm.sendbuf_h(ri);
+      typedef typename IslMpi<MT>::ArrayH<Real*> ArrayH;
+      typedef typename IslMpi<MT>::ArrayD<Real*> ArrayD;
+      Kokkos::deep_copy(ArrayH(sendbuf.data(), cm.sendcount_h(ri)),
+                        ArrayD(cm.sendbuf.get_h(ri).data(), cm.sendcount_h(ri)));
+#else
+      auto&& sendbuf = cm.sendbuf.get_h(ri);
+#endif
+      mpi::isend(*cm.p, sendbuf.data(), cm.sendcount_h(ri),
                  cm.ranks(ri), 42, want_req ? &cm.sendreq(ri) : nullptr);
     }
   }
-}
-
-template <typename MT>
-void recv_and_wait_on_send (IslMpi<MT>& cm) {
-#ifdef COMPOSE_HORIZ_OPENMP
-# pragma omp master
-#endif
-  {
-    mpi::waitall(cm.sendreq.n(), cm.sendreq.data());
-    mpi::waitall(cm.recvreq.n(), cm.recvreq.data());
-  }
-#ifdef COMPOSE_HORIZ_OPENMP
-# pragma omp barrier
-#endif
 }
 
 template <typename MT>
@@ -104,12 +104,47 @@ void wait_on_send (IslMpi<MT>& cm, const bool skip_if_empty) {
 }
 
 template <typename MT>
+void wait_on_recv (IslMpi<MT>& cm) {
+#ifdef COMPOSE_MPI_ON_HOST
+  typedef typename IslMpi<MT>::ArrayH<Real*> ArrayH;
+  typedef typename IslMpi<MT>::ArrayD<Real*> ArrayD;
+  const int nreq = cm.recvreq.n();
+  for (Int i = 0; i < nreq; ++i) {
+    Int reqi;
+    MPI_Status stat;
+    mpi::waitany(nreq, cm.recvreq.data(), &reqi, &stat);
+    const Int ri = cm.recvreq_ri(reqi);
+    int count;
+    MPI_Get_count(&stat, mpi::get_type<Real>(), &count);
+    Kokkos::deep_copy(ArrayD(cm.recvbuf.get_h(ri).data(), count),
+                      ArrayH(cm.recvbuf_h(ri).data(), count));
+  }
+#else
+  mpi::waitall(cm.recvreq.n(), cm.recvreq.data());
+#endif
+}
+
+template <typename MT>
+void recv_and_wait_on_send (IslMpi<MT>& cm) {
+#ifdef COMPOSE_HORIZ_OPENMP
+# pragma omp master
+#endif
+  {
+    mpi::waitall(cm.sendreq.n(), cm.sendreq.data());
+    wait_on_recv(cm);
+  }
+#ifdef COMPOSE_HORIZ_OPENMP
+# pragma omp barrier
+#endif
+}
+
+template <typename MT>
 void recv (IslMpi<MT>& cm, const bool skip_if_empty) {
 #ifdef COMPOSE_HORIZ_OPENMP
 # pragma omp master
 #endif
   {
-    mpi::waitall(cm.recvreq.n(), cm.recvreq.data());
+    wait_on_recv(cm);
   }
 #ifdef COMPOSE_HORIZ_OPENMP
 # pragma omp barrier


### PR DESCRIPTION
Previously, the unstructured SL-internal communication rounds were done using device pointers regardless of the value of HOMMEXX_MPI_ON_DEVICE. Now they are done on host if HOMMEXX_MPI_ON_DEVICE is true.

[BFB]