### PR TITLE
Allocates memory for rof-2-ocn variables

### DIFF
--- a/driver-mct/main/prep_rof_mod.F90
+++ b/driver-mct/main/prep_rof_mod.F90
@@ -305,6 +305,11 @@ contains
 
        call shr_sys_flush(logunit)
 
+    else
+
+       allocate(o2r_rx(num_inst_rof))
+       allocate(o2racc_ox(num_inst_ocn))
+
     end if
 
   end subroutine prep_rof_init


### PR DESCRIPTION
Memory is allocated for rof-2-ocn coupling variables even in the case of two-way 
river-ocean coupling is not turned on.

Fixes #5221

[BFB]