### PR TITLE
Add missing variables to omp pragmas from PR #5195

### DIFF
--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -797,7 +797,7 @@ module ocn_time_integration_split
 
             !$omp parallel
             !$omp do schedule(runtime) &
-            !$omp private(k, thicknessSum)
+            !$omp private(cell1, cell2, k, thicknessSum)
             do iEdge = nEdgesOwned+1, nEdgesArray(4)
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)


### PR DESCRIPTION
PR #5195 added new code, but had some variables missing from omp pragmas that cause SMS_D_Ld3.T62_oQU120.CMPASO-IAF.chrysalis_intel failures. This fixes that issue.

[non-BFB] for threaded tests