### PR TITLE
Add zeroing of velocity to ocean init mode

### DIFF
--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_mode.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_mode.F
@@ -267,8 +267,14 @@ module ocn_init_mode
       type (mpas_pool_type), pointer :: forcingPool
 
       type (MPAS_timeInterval_type) :: timeStep
+      real (kind=RKIND), dimension(:,:), pointer :: normalVelocity
 
       ierr = 0
+
+      ! Initialize normalVelocity to zero for cases that do not specify it.
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'state', statePool)
+      call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, 1)
+      normalVelocity(:,:) = 0.0_RKIND
 
       ! Eventually, dt should be domain specific
       timeStep = mpas_get_clock_timestep(domain % clock, ierr=ierr)


### PR DESCRIPTION
Explicitly sets normal velocity to zero at the beginning of init mode. Each test case can then overwrite the zeros with initial velocities, but most do not. In the past the unassigned arrays wrote out zeros, but this is not true now, as described in #5230.

This code is used to create MPAS-Ocean initial conditions. It is not compiled in the E3SM code base for simulations.

Fixes #5230
[BFB]