### PR TITLE
Fix usage of o2r_rx without rof-ocn two way enabled

### DIFF
--- a/driver-mct/main/prep_rof_mod.F90
+++ b/driver-mct/main/prep_rof_mod.F90
@@ -261,11 +261,11 @@ contains
                'seq_maps.rc','atm2rof_smapname:','atm2rof_smaptype:',samegrid_ar, &
                string='mapper_Sa2r initialization', esmf_map=esmf_map_flag)
        endif
-      
+	   
        call shr_sys_flush(logunit)
 
     end if
-    
+
     if (rof_present .and. ocn_present) then
 
        call seq_comm_getData(CPLID, &
@@ -282,7 +282,7 @@ contains
           call mct_aVect_zero(o2racc_ox(eoi))
        end do
        o2racc_ox_cnt = 0
-      
+
        allocate(o2r_rx(num_inst_rof))
        do eri = 1,num_inst_rof
           call mct_avect_init(o2r_rx(eri), rList=seq_flds_o2x_fields_to_rof, lsize=lsize_r)
@@ -469,6 +469,7 @@ contains
     type(mct_aVect), pointer :: x2r_rx
     character(*), parameter  :: subname = '(prep_rof_mrg)'
     !---------------------------------------------------------------
+
     call t_drvstartf (trim(timer_mrg), barrier=mpicom_CPLID)
     do eri = 1,num_inst_rof
        efi = mod((eri-1),num_inst_frc) + 1
@@ -575,7 +576,7 @@ contains
     character(*), parameter   :: subname = '(prep_rof_merge) '
 
     !-----------------------------------------------------------------------
-    
+
     call seq_comm_getdata(CPLID, iamroot=iamroot)
     lsize = mct_aVect_lsize(x2r_r)
 


### PR DESCRIPTION
When ocn_rof_two_way = .false. o2r_rx is not allocated nor associated but elements were still passed to function call.  
Changed to optional argument for subroutine prep_rof_merge.

Fixes #5221
Fixes #5192 
[BFB] 
