### PR TITLE
Hommexx: Print element state data in various model failure situations.

### DIFF
--- a/components/homme/src/preqx_kokkos/cxx/ElementsState.cpp
+++ b/components/homme/src/preqx_kokkos/cxx/ElementsState.cpp
@@ -170,4 +170,10 @@ void ElementsState::push_to_f90_pointers (F90Ptr& state_v, F90Ptr& state_t, F90P
   sync_to_host(m_v,    state_v_f90);
 }
 
+void check_print_abort_on_bad_elems (const std::string& label, const int time_level,
+                                     const int error_code) {
+  // Not implemented.
+  return;
+}
+
 } // namespace Homme

--- a/components/homme/src/preqx_kokkos/cxx/ElementsState.hpp
+++ b/components/homme/src/preqx_kokkos/cxx/ElementsState.hpp
@@ -53,6 +53,10 @@ private:
   int m_num_elems;
 };
 
+// Not implemented.
+void check_print_abort_on_bad_elems(const std::string& label, const int time_level,
+                                    const int error_code = -1);
+
 } // Homme
 
 #endif // HOMMEXX_ELEMENTS_STATE_HPP

--- a/components/homme/src/share/cxx/ErrorDefs.hpp
+++ b/components/homme/src/share/cxx/ErrorDefs.hpp
@@ -55,6 +55,7 @@ static constexpr int err_unknown_option               = 11;
 static constexpr int err_not_implemented              = 12;
 static constexpr int err_invalid_options_combination  = 13;
 static constexpr int err_negative_layer_thickness     = 101;
+static constexpr int err_bad_column_value             = 102;
 
 template<typename T>
 void option_error(const std::string& location,

--- a/components/homme/src/share/cxx/RemapFunctor.hpp
+++ b/components/homme/src/share/cxx/RemapFunctor.hpp
@@ -320,11 +320,25 @@ struct RemapFunctor : public Remapper {
 
   void input_valid_assert() {
     Kokkos::deep_copy(host_valid_input, valid_layer_thickness);
+    bool ok = true;
     for (int ie = 0; ie < m_state.num_elems(); ++ie) {
-      if (host_valid_input(ie) == false) {
-        Errors::runtime_abort("Negative (or nan) layer thickness detected, aborting!",
-                              Errors::err_negative_layer_thickness);
+      if ( ! host_valid_input(ie)) {
+        ok = false;
+        break;
       }
+    }
+    if ( ! ok) {
+      check_print_abort_on_bad_elems(
+        "Vertical remap: Negative (or nan) layer thickness detected, aborting!",
+        m_data.np1, Errors::err_negative_layer_thickness);
+      // If check_print_abort_on_bad_elems can't see the issue -- e.g., if the
+      // source grid is bad but the state itself is fine, or the routine has no
+      // implementation (as is true for preqx) -- it won't call
+      // runtime_abort. Thus, for safety, call runtime_abort here if we're still
+      // running.
+      Errors::runtime_abort(
+        "Negative (or nan) layer thickness detected, aborting!",
+        Errors::err_negative_layer_thickness);
     }
   }
 

--- a/components/homme/src/theta-l_kokkos/cxx/CaarFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/CaarFunctorImpl.hpp
@@ -334,9 +334,12 @@ struct CaarFunctorImpl {
     profiling_resume();
 
     GPTLstart("caar compute");
-    Kokkos::parallel_for("caar loop pre-boundary exchange", m_policy_pre, *this);
+    int nerr;
+    Kokkos::parallel_reduce("caar loop pre-boundary exchange", m_policy_pre, *this, nerr);
     ExecSpace::impl_static_fence();
     GPTLstop("caar compute");
+    if (nerr > 0)
+      check_print_abort_on_bad_elems("CaarFunctorImpl::run TagPreExchange", data.n0);
 
     GPTLstart("caar_bexchV");
     m_bes[data.np1]->exchange(m_geometry.m_rspheremp);
@@ -359,7 +362,7 @@ struct CaarFunctorImpl {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const TagPreExchange&, const TeamMember &team) const {
+  void operator()(const TagPreExchange&, const TeamMember &team, int& nerr) const {
     // In this body, we use '====' to separate sync epochs (delimited by barriers)
     // Note: make sure the same temp is not used within each epoch!
 
@@ -372,7 +375,8 @@ struct CaarFunctorImpl {
     kv.team_barrier();
 
     // Computes pi, omega, and phi.
-    compute_scan_quantities(kv);
+    const bool ok = compute_scan_quantities(kv);
+    if ( ! ok) nerr = 1;
 
     if (m_rsplit==0 || !m_theta_hydrostatic_mode) {
       // ============ EPOCH 2.1 =========== //
@@ -598,7 +602,9 @@ struct CaarFunctorImpl {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void compute_scan_quantities (KernelVariables &kv) const {
+  bool compute_scan_quantities (KernelVariables &kv) const {
+    bool ok = true;
+    
     kv.team_barrier();
     Kokkos::parallel_for(Kokkos::TeamThreadRange(kv.team,NP*NP),
                          [&](const int idx) {
@@ -676,11 +682,13 @@ struct CaarFunctorImpl {
                             Homme::subview(m_buffers.pnh,kv.team_idx,igp,jgp),
                             Homme::subview(m_state.m_phinh_i,kv.ie,m_data.n0,igp,jgp));
       } else {
+        const bool ok1 =
         m_eos.compute_pnh_and_exner(kv,
                                     Homme::subview(m_state.m_vtheta_dp,kv.ie,m_data.n0,igp,jgp),
                                     Homme::subview(m_state.m_phinh_i,kv.ie,m_data.n0,igp,jgp),
                                     Homme::subview(m_buffers.pnh,kv.team_idx,igp,jgp),
                                     Homme::subview(m_buffers.exner,kv.team_idx,igp,jgp));
+        if ( ! ok1) ok = false;
       }
 
       // Compute phi at midpoints
@@ -688,6 +696,7 @@ struct CaarFunctorImpl {
                                             Homme::subview(m_buffers.phi,kv.team_idx,igp,jgp));
     });
     kv.team_barrier();
+    return ok;
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/components/homme/src/theta-l_kokkos/cxx/DirkFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/DirkFunctorImpl.hpp
@@ -232,7 +232,7 @@ struct DirkFunctorImpl {
     const auto hybi = hvcoord.hybrid_bi;
     const auto tu   = m_tu;
 
-    const auto toplevel = KOKKOS_LAMBDA (const MT& team) {
+    const auto toplevel = KOKKOS_LAMBDA (const MT& team, int& nerr) {
       KernelVariables kv(team, tu);
       const auto ie = kv.ie;
       const int nlev = num_phys_lev;
@@ -283,7 +283,9 @@ struct DirkFunctorImpl {
           dphi(k,i) = phi_np1(k+1,i) - phi_np1(k,i);
         });
         kv.team_barrier();
-        pnh_and_exner_from_eos(kv, hvcoord, vtheta_dp, dp3d, dphi, pnh, wrk, dpnh_dp_i);
+        const bool ok = pnh_and_exner_from_eos(kv, hvcoord, vtheta_dp, dp3d,
+                                               dphi, pnh, wrk, dpnh_dp_i);
+        if ( ! ok) nerr = 1;
         kv.team_barrier();
         loop_ki(kv, nlev, nvec, [&] (const int k, const int i) {
           w_n0(k,i) += dt3*grav*(dpnh_dp_i(k,i) - 1);
@@ -345,7 +347,9 @@ struct DirkFunctorImpl {
       int it = 0;
       Real deltaerr;
       for (; it < maxiter; ++it) { // Newton iteration
-        pnh_and_exner_from_eos(kv, hvcoord, vtheta_dp, dp3d, dphi, pnh, wrk, dpnh_dp_i);
+        const bool ok = pnh_and_exner_from_eos(kv, hvcoord, vtheta_dp, dp3d,
+                                               dphi, pnh, wrk, dpnh_dp_i);
+        if ( ! ok) nerr = 1;
         kv.team_barrier();
         loop_ki(kv, nlev, nvec, [&] (const int k, const int i) {
           x(k,i) = -(w_np1(k,i) - (w_n0(k,i) + grav*dt2*(dpnh_dp_i(k,i) - 1))); // -residual
@@ -382,9 +386,10 @@ struct DirkFunctorImpl {
       } // Newton iteration
       kv.team_barrier();
 
-      if (it>=maxiter) {
-        printf ("[DIRK] WARNING! Newton reached max iteration count,"
-                " with deltaerr = %3.17f\n", deltaerr);
+      if (it >= maxiter) {
+        printf("[DIRK] WARNING! Newton reached max iteration count,"
+               " with deltaerr = %3.17f\n", deltaerr);
+        nerr = 1;
       }
 
       // Update phi_np1.
@@ -395,7 +400,14 @@ struct DirkFunctorImpl {
       transpose(kv, nlev+1, w_np1,   subview(e_w_i    ,ie,np1,a,a,a));
     };
 
-    Kokkos::parallel_for(m_policy, toplevel);
+    int nerr;
+    Kokkos::parallel_reduce(m_policy, toplevel, nerr);
+    if (nerr > 0) {
+      const int nt[] = {nm1, n0, np1};
+      const char* ntname[] = {"nm1", "n0", "np1"};
+      for (int i = 0; i < 3; ++i)
+        check_print_abort_on_bad_elems(std::string("DIRK Newton loop ") + ntname[i], nt[i]);
+    }
   }
 
   template <typename Fn>
@@ -548,7 +560,7 @@ struct DirkFunctorImpl {
 
   template <typename R, typename W, typename Wi>
   KOKKOS_INLINE_FUNCTION
-  static void pnh_and_exner_from_eos (
+  static bool pnh_and_exner_from_eos (
     const KernelVariables& kv, const HybridVCoord& hvcoord,
     // All arrays are in DIRK format.
     const R& vtheta_dp, const R& dp3d, const R& dphi,
@@ -558,12 +570,15 @@ struct DirkFunctorImpl {
   {
     using Kokkos::parallel_for;
 
-    const int n = npack;
+    const int n = npack, ns = packn;
     const auto pv = Kokkos::ThreadVectorRange(kv.team, n);
+    bool ok = true;
 
     // Compute pnh(1:nlev,:). pnh(nlevp,:) is not needed.
     const auto f1 = [&] (const int k) {
       const auto g = [&] (const int i) {
+        for (int s = 0; s < ns; ++s)
+          if (vtheta_dp(k,i)[s] < 0 || dphi(k,i)[s] > 0) ok = false;
         EquationOfState::compute_pnh_and_exner(
           vtheta_dp(k,i), dphi(k,i), pnh(k,i), exner(k,i));
       };
@@ -593,6 +608,8 @@ struct DirkFunctorImpl {
       parallel_for(pv, kr);
     };
     parallel_for(Kokkos::TeamThreadRange(kv.team, nlev-1), f3);
+
+    return ok;
   }
 
   // Suboptimal impl of the initial guess that uses the policy native to the

--- a/components/homme/src/theta-l_kokkos/cxx/ElementsState.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementsState.hpp
@@ -86,6 +86,16 @@ private:
   TeamUtils<ExecSpace> m_tu;
 };
 
+// Check ElementsState for NaN or incorrectly signed values. The initial check
+// is fast and on device. If everything is fine, the routine returns
+// immediately. If there is a bad value, a subsequent check is run on the host,
+// and this check prints detailed information to a file called
+// hommexx.errlog.${rank}. Then runtime_abort is called with a message pointing
+// to this file.
+void check_print_abort_on_bad_elems(const std::string& label,    // string to ID call site
+                                    const int time_level,        // time level index in state arrays
+                                    const int error_code = -1);
+
 } // Homme
 
 #endif // HOMMEXX_ELEMENTS_STATE_HPP

--- a/components/homme/test_execs/thetal_kokkos_ut/dirk_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/dirk_ut.cpp
@@ -87,6 +87,8 @@ struct Session {
 
     nelemd = c.get<Connectivity>().get_num_local_elements();
     e = c.create<Elements>();
+    e.m_state = c.create<ElementsState>();
+    e.m_geometry = c.create<ElementsGeometry>();
   }
 
   void cleanup () {


### PR DESCRIPTION
In the log file, one will see, e.g.,

 46: Bad dphi, dp3d, or vtheta_dp; label: 'Vertical remap: Negative (or nan) layer thickness detected, aborting!'; see hommexx.errlog.320.46

Then, for example,

$ cat hommexx.errlog.320.46
label: Vertical remap: Negative (or nan) layer thickness detected, aborting! time-level 1
lat  5.182512623200946e-01 lon  1.413716694115407e+00 ie 3 igll 3 jgll 3 lev 122: bad vtheta_dp bad dp3d bad dphi
level                   dphi                   dp3d              vtheta_dp
    0 -1.894494653842581e+04  6.511250007060127e+01  9.449394802849884e+04
...
  122  1.061523656197460e+02 -3.435052907124674e+01 -8.703189416949290e+03
...

This feature is for the theta-l_kokkos dycore. preqx_kokkos has an empty implementation of the check routine, so its behavior on failure is unchanged.

[BFB]