### PR TITLE
Update google cloud machine to gnu gcc-12.2

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -4247,24 +4247,24 @@
       </modules>
 
       <modules compiler="gnu">
-	<command name="load">gcc-11.1.0</command>
+	<command name="load">gcc/12.2.0</command>
       </modules>
 
       <modules mpilib="openmpi">
-	<command name="load">openmpi-gcc@11.1.0</command>
+	<command name="load">openmpi-gcc@12.2.0</command>
       </modules>
 
       <modules compiler="gnu">
 	<command name="load">cmake</command>
 	<command name="load">perl</command>
 	<command name="load">perl-xml-libxml</command>
-        <command name="load">netcdf-c-gcc@11.1.0</command>
-        <command name="load">netcdf-cxx-gcc@11.1.0</command>
-        <command name="load">netcdf-fortran-gcc@11.1.0</command>
-        <command name="load">parallel-netcdf-gcc@11.1.0</command>
-        <command name="load">hdf5-gcc@11.1.0</command>
-        <command name="load">netlib-lapack-gcc@11.1.0</command>
-        <command name="load">openblas-gcc@11.1.0</command>
+        <command name="load">netcdf-c-gcc@12.2.0</command>
+        <command name="load">netcdf-cxx-gcc@12.2.0</command>
+        <command name="load">netcdf-fortran-gcc@12.2.0</command>
+        <command name="load">parallel-netcdf-gcc@12.2.0</command>
+        <command name="load">hdf5-gcc@12.2.0</command>
+        <command name="load">netlib-lapack-gcc@12.2.0</command>
+        <command name="load">openblas-gcc@12.2.0</command>
       </modules>
 
     </module_system>
@@ -4275,8 +4275,8 @@
       <env name="NETCDF_C_PATH">$SHELL{dirname $(dirname $(which nc-config))}</env>
       <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf-config))}</env>
-      <env name="OPENBLAS_PATH">/apps/spack/opt/spack/linux-centos7-cascadelake/gcc-11.1.0/openblas-0.3.17-3iblhfhhiatf52ydrj46e6z4luf2dny6</env>
-      <env name="LAPACK_PATH">/apps/spack/opt/spack/linux-centos7-cascadelake/gcc-11.1.0/netlib-lapack-3.9.1-gwvv6izoqvecz37demx42ivbasrobglu</env>
+      <env name="OPENBLAS_PATH">/apps/spack/opt/spack/linux-centos7-cascadelake/gcc-12.2.0/openblas-0.3.20-nxcsxdi56nj2gxyo65iyuaecp3cbd4xd</env>
+      <env name="LAPACK_PATH">/apps/spack/opt/spack/linux-centos7-cascadelake/gcc-12.2.0/netlib-lapack-3.10.1-xjw3q4abrpdihbyvx72em7l4wrzxm3zp</env>
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
     </environment_variables>
 


### PR DESCRIPTION
Update google cloud machine to gnu gcc-12.2

e3sm_integration passes
e3sm_extra_coverage has no new errors:
memory leak/compare base fail:
 ERP_Lm3.ne4_oQU240.F2010.gcp_gnu
setup fails for:
 SMS_D_Ln5.twpx4v1_twpx4v1.F2010-CICE.gcp_gnu
 SMS_D_Ln5.enax4v1_enax4v1.F2010-CICE.gcp_gnu

[BFB]