### PR TITLE
Allows config_use_snow_liquid_ponds = false with snow tracers

### DIFF
--- a/components/mpas-seaice/src/column/ice_colpkg.F90
+++ b/components/mpas-seaice/src/column/ice_colpkg.F90
@@ -2284,16 +2284,15 @@
          endif   ! aicen_init
 
       !-----------------------------------------------------------------
-      ! Transport liquid water in snow between layers and 
+      ! Transport liquid water in snow between layers and
       ! compute the meltpond contribution
       !-----------------------------------------------------------------
 
-       if (use_smliq_pnd) then
-         call drain_snow (dt,            nslyr,        &
-                          vsnon   (n) ,  aicen    (n), &
-                          smice  (:,n),  smliq  (:,n), &
-                          meltsliqn(n))
-       endif
+      call drain_snow (dt,            nslyr,        &
+                       vsnon   (n) ,  aicen    (n), &
+                       smice  (:,n),  smliq  (:,n), &
+                       meltsliqn(n),  use_smliq_pnd)
+
 
       !-----------------------------------------------------------------
       ! Melt ponds

--- a/components/mpas-seaice/src/column/ice_snow.F90
+++ b/components/mpas-seaice/src/column/ice_snow.F90
@@ -883,7 +883,7 @@
 !  Conversions between ice mass, liquid water mass in snow
 
       subroutine drain_snow (dt, nslyr, vsnon,  aicen, &
-                             smice, smliq, meltsliq)
+                             smice, smliq, meltsliq, use_smliq_pnd)
 
       integer (kind=int_kind), intent(in) :: &
          nslyr    ! number of snow layers
@@ -904,13 +904,17 @@
          intent(inout) :: &
          smliq    ! mass of liquid in snow (kg/m^2)
 
+      logical (kind=log_kind), intent(in) :: &
+         use_smliq_pnd   ! if true, use snow liquid tracer for ponds
+
       ! local temporary variables
 
       integer (kind=int_kind) ::  k
 
       real (kind=dbl_kind) :: &
         hslyr,  & ! snow layer thickness (m)
-        hsn       ! snow thickness (m)
+        hsn,    & ! snow thickness (m)
+        meltsliq_tmp  ! temperary snow liquid content
 
       real (kind=dbl_kind), dimension(nslyr) :: &
          dlin    , & ! liquid into the layer from above (kg/m^2)
@@ -920,12 +924,12 @@
          w_drain    ! flow between layers
 
       hsn = c0
+      meltsliq_tmp = c0
       if (aicen > c0) hsn = vsnon/aicen
       if (hsn > puny) then
         dlin(:) = c0
         dlout(:) = c0
         hslyr    = hsn / real(nslyr,kind=dbl_kind)
-        meltsliq = c0
         do k = 1,nslyr
             smliq(k)   = smliq(k)  + dlin(k) / hslyr   ! liquid in from above layer
             phi_ice(k) = min(c1, smice(k) / rhoi)
@@ -936,12 +940,15 @@
             if (k < nslyr) then
                 dlin(k+1) = dlout(k)
             else
-                meltsliq = dlout(nslyr)
+                meltsliq_tmp = dlout(nslyr)
             endif
         enddo
       else
-        meltsliq = meltsliq  ! computed in thickness_changes
+        meltsliq_tmp = meltsliq  ! computed in thickness_changes
       endif
+
+      meltsliq = meltsliq
+      if (use_smliq_pnd) meltsliq = meltsliq_tmp
 
       end subroutine drain_snow
 


### PR DESCRIPTION
With the flag false, the routine to drain snow liquid was omitted. However, this routine is needed to properly keep track of snow liquid. The flag now only controls whether the drained snow-melt contributes to pond formation or not.

[BFB]