### PR TITLE
Add new land IC files for arcticx4v1 RRM mesh

### DIFF
--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -232,10 +232,13 @@ lnd/clm2/surfdata_map/surfdata_ne0np4_northamericax4v1.pg2_simyr2010_c210112.nc<
 
 <!-- ne0np4_arcticx4v1.pg2 -->
 <finidat hgrid="ne0np4_arcticx4v1.pg2">lnd/clm2/initdata/arcticx4v1pg2_oARRM60to10.ICRUELM.spinup-from-interp.elm.r.0051-01-01-00000.nc</finidat>
+<finidat hgrid="ne0np4_arcticx4v1.pg2"  mask="ARRM10to60E2r1" sim_year="1950">lnd/clm2/initdata/20221017.ICRUELM-1950.arcticx4v1pg2_ARRM10to60E2r1.anvil.elm.r.0051-01-01-00000.nc</finidat>
 <fsurdat hgrid="ne0np4_arcticx4v1.pg2"   sim_year="2010" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr2010_c210805.nc</fsurdat>
 <fsurdat hgrid="ne0np4_arcticx4v1.pg2"   sim_year="2000" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr2000_c210707.nc</fsurdat>
+<fsurdat hgrid="ne0np4_arcticx4v1.pg2"   sim_year="1950" use_crop=".false." >
+lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr1950_c221017.nc</fsurdat>
 <fsurdat hgrid="ne0np4_arcticx4v1.pg2"   sim_year="1850" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr1850_c210707.nc</fsurdat>
 

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -231,7 +231,7 @@ lnd/clm2/surfdata_map/surfdata_ne0np4_northamericax4v1.pg2_simyr1850_c210112.nc<
 lnd/clm2/surfdata_map/surfdata_ne0np4_northamericax4v1.pg2_simyr2010_c210112.nc</fsurdat>
 
 <!-- ne0np4_arcticx4v1.pg2 -->
-<finidat hgrid="ne0np4_arcticx4v1.pg2">lnd/clm2/initdata/arcticx4v1pg2_oARRM60to10.ICRUELM.spinup-from-interp.elm.r.0051-01-01-00000.nc</finidat>
+<finidat hgrid="ne0np4_arcticx4v1.pg2"  mask="oARRM60to10">lnd/clm2/initdata/arcticx4v1pg2_oARRM60to10.ICRUELM.spinup-from-interp.elm.r.0051-01-01-00000.nc</finidat>
 <finidat hgrid="ne0np4_arcticx4v1.pg2"  mask="ARRM10to60E2r1" sim_year="1950">lnd/clm2/initdata/20221017.ICRUELM-1950.arcticx4v1pg2_ARRM10to60E2r1.anvil.elm.r.0051-01-01-00000.nc</finidat>
 <fsurdat hgrid="ne0np4_arcticx4v1.pg2"   sim_year="2010" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_arcticx4v1pg2_simyr2010_c210805.nc</fsurdat>


### PR DESCRIPTION
This adds a default `fsurdat` file for 1950 conditions for the `arcticx4v1` atm/lnd RRM mesh, as well as a default `finidat` file for the `WCYCL1950.arcticx4v1pg2_ARRM10to60E2r1` configuration. The `finidat` file is from a 50 year I-case spinup.

This also specifies the `oARRM60to10` mask for the existing `finidat` file, to avoid that file (with incompatible dimensions) being used in other `arcticx4v1pg2_ARRM10to60E2r1` configurations.

The two new files are staged on the public inputdata server and are world-readable.

[BFB] for all currently tested configurations.