### PR TITLE
Fix floating-point exception in MPASSI incremental remap code

### DIFF
--- a/components/mpas-seaice/src/shared/mpas_seaice_advection_incremental_remap.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_advection_incremental_remap.F
@@ -4663,9 +4663,6 @@ contains
        mean1, center1, xGrad1, yGrad1,  &
        mean2, center2, xGrad2, yGrad2)
 
-    use seaice_constants, only: &
-         seaicePuny
-
     type(geometric_avg_cell_type), pointer :: &
          geomAvgCell                       !< Input: derived type holding geometric averages
 
@@ -4692,7 +4689,7 @@ contains
          cxxx,  cxxy,  cxyy,  cyyy,   &
          cxxxx, cxxxy, cxxyy, cxyyy, cyyyy
 
-    real(kind=RKIND) :: reciprocal, massTracerProd
+    real(kind=RKIND) ::  massTracerProd
 
     ! compute the barycenter coordinates, depending on how many tracer types were passed in
     ! Note: These formulas become more complex as the tracer hierarchy deepens.  See the model documentation for details.
@@ -4709,18 +4706,18 @@ contains
        c0 = center0
        cx = xGrad0
        cy = yGrad0
-       if (abs(mean0) > seaicePuny) then
-          reciprocal = 1.0_RKIND / mean0
-       else
-          reciprocal = 0.0_RKIND
+
+       xBarycenter = 0.0_RKIND
+       yBarycenter = 0.0_RKIND
+       if (abs(mean0) > 0.0_RKIND) then
+          xBarycenter = (c0 * geomAvgCell % x (iCell)  &
+                       + cx * geomAvgCell % xx(iCell)  + cy * geomAvgCell % xy(iCell))  &
+                       / mean0
+          yBarycenter = (c0 * geomAvgCell % y (iCell)  &
+                       + cx * geomAvgCell % xy(iCell)  + cy * geomAvgCell % yy(iCell))  &
+                       / mean0
        endif
 
-       xBarycenter = (c0 * geomAvgCell % x (iCell)  &
-                    + cx * geomAvgCell % xx(iCell)  + cy * geomAvgCell % xy(iCell))  &
-                    * reciprocal
-       yBarycenter = (c0 * geomAvgCell % y (iCell)  &
-                    + cx * geomAvgCell % xy(iCell)  + cy * geomAvgCell % yy(iCell))  &
-                    * reciprocal
 
     elseif (.not.present(mean2)) then
 
@@ -4733,21 +4730,19 @@ contains
        cxy = xGrad0  * yGrad1  + yGrad0  * xGrad1
        cyy = yGrad0  * yGrad1
 
+       xBarycenter = 0.0_RKIND
+       yBarycenter = 0.0_RKIND
        massTracerProd = mean0 * mean1
-       if (abs(massTracerProd) > seaicePuny) then
-          reciprocal = 1.0_RKIND / massTracerProd
-       else
-          reciprocal = 0.0_RKIND
+       if (abs(massTracerProd) > 0.0_RKIND) then
+          xBarycenter = (c0  * geomAvgCell % x  (iCell) &
+                       + cx  * geomAvgCell % xx (iCell) + cy  * geomAvgCell % xy (iCell)  &
+                       + cxx * geomAvgCell % xxx(iCell) + cxy * geomAvgCell % xxy(iCell) + cyy * geomAvgCell % xyy(iCell)) &
+                       / massTracerProd
+          yBarycenter = (c0  * geomAvgCell % y  (iCell) &
+                       + cx  * geomAvgCell % xy (iCell) + cy  * geomAvgCell % yy (iCell)  &
+                       + cxx * geomAvgCell % xxy(iCell) + cxy * geomAvgCell % xyy(iCell) + cyy * geomAvgCell % yyy(iCell)) &
+                       / massTracerProd
        endif
-
-       xBarycenter = (c0  * geomAvgCell % x  (iCell) &
-                    + cx  * geomAvgCell % xx (iCell) + cy  * geomAvgCell % xy (iCell)  &
-                    + cxx * geomAvgCell % xxx(iCell) + cxy * geomAvgCell % xxy(iCell) + cyy * geomAvgCell % xyy(iCell)) &
-                    * reciprocal
-       yBarycenter = (c0  * geomAvgCell % y  (iCell) &
-                    + cx  * geomAvgCell % xy (iCell) + cy  * geomAvgCell % yy (iCell)  &
-                    + cxx * geomAvgCell % xxy(iCell) + cxy * geomAvgCell % xyy(iCell) + cyy * geomAvgCell % yyy(iCell)) &
-                    * reciprocal
 
     else  ! mass field, tracer1 and tracer2 are all present
 
@@ -4765,25 +4760,23 @@ contains
        cxyy  = yGrad0  * yGrad1  * xGrad2   + yGrad0  * xGrad1  * yGrad2  + xGrad0  * yGrad1  * yGrad2
        cyyy  = yGrad0  * yGrad1  * yGrad2
 
+       xBarycenter = 0.0_RKIND
+       yBarycenter = 0.0_RKIND
        massTracerProd = mean0 * mean1 * mean2
-       if (abs(massTracerProd) > seaicePuny) then
-          reciprocal = 1.0_RKIND / massTracerProd
-       else
-          reciprocal = 0.0_RKIND
+       if (abs(massTracerProd) > 0.0_RKIND) then
+          xBarycenter = (c0   * geomAvgCell % x   (iCell) &
+                       + cx   * geomAvgCell % xx  (iCell) + cy   * geomAvgCell % xy  (iCell) &
+                       + cxx  * geomAvgCell % xxx (iCell) + cxy  * geomAvgCell % xxy (iCell) + cyy  * geomAvgCell % xyy (iCell) &
+                       + cxxx * geomAvgCell % xxxx(iCell) + cxxy * geomAvgCell % xxxy(iCell) + cxyy * geomAvgCell % xxyy(iCell) &
+                                                                                             + cyyy * geomAvgCell % xyyy(iCell)) &
+                       / massTracerProd
+          yBarycenter = (c0   * geomAvgCell % y   (iCell) &
+                       + cx   * geomAvgCell % xy  (iCell) + cy   * geomAvgCell % yy  (iCell) &
+                       + cxx  * geomAvgCell % xxy (iCell) + cxy  * geomAvgCell % xyy (iCell) + cyy  * geomAvgCell % yyy (iCell) &
+                       + cxxx * geomAvgCell % xxxy(iCell) + cxxy * geomAvgCell % xxyy(iCell) + cxyy * geomAvgCell % xyyy(iCell) &
+                                                                                             + cyyy * geomAvgCell % yyyy(iCell)) &
+                       / massTracerProd
        endif
-
-       xBarycenter = (c0   * geomAvgCell % x   (iCell) &
-                    + cx   * geomAvgCell % xx  (iCell) + cy   * geomAvgCell % xy  (iCell) &
-                    + cxx  * geomAvgCell % xxx (iCell) + cxy  * geomAvgCell % xxy (iCell) + cyy  * geomAvgCell % xyy (iCell) &
-                    + cxxx * geomAvgCell % xxxx(iCell) + cxxy * geomAvgCell % xxxy(iCell) + cxyy * geomAvgCell % xxyy(iCell) &
-                                                                                          + cyyy * geomAvgCell % xyyy(iCell)) &
-                    * reciprocal
-       yBarycenter = (c0   * geomAvgCell % y   (iCell) &
-                    + cx   * geomAvgCell % xy  (iCell) + cy   * geomAvgCell % yy  (iCell) &
-                    + cxx  * geomAvgCell % xxy (iCell) + cxy  * geomAvgCell % xyy (iCell) + cyy  * geomAvgCell % yyy (iCell) &
-                    + cxxx * geomAvgCell % xxxy(iCell) + cxxy * geomAvgCell % xxyy(iCell) + cxyy * geomAvgCell % xyyy(iCell) &
-                                                                                          + cyyy * geomAvgCell % yyyy(iCell)) &
-                    * reciprocal
 
     endif
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_advection_incremental_remap.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_advection_incremental_remap.F
@@ -4663,6 +4663,9 @@ contains
        mean1, center1, xGrad1, yGrad1,  &
        mean2, center2, xGrad2, yGrad2)
 
+    use seaice_constants, only: &
+         seaicePuny
+
     type(geometric_avg_cell_type), pointer :: &
          geomAvgCell                       !< Input: derived type holding geometric averages
 
@@ -4706,7 +4709,7 @@ contains
        c0 = center0
        cx = xGrad0
        cy = yGrad0
-       if (abs(mean0) > 0.0_RKIND) then
+       if (abs(mean0) > seaicePuny) then
           reciprocal = 1.0_RKIND / mean0
        else
           reciprocal = 0.0_RKIND
@@ -4731,7 +4734,7 @@ contains
        cyy = yGrad0  * yGrad1
 
        massTracerProd = mean0 * mean1
-       if (abs(massTracerProd) > 0.0_RKIND) then
+       if (abs(massTracerProd) > seaicePuny) then
           reciprocal = 1.0_RKIND / massTracerProd
        else
           reciprocal = 0.0_RKIND
@@ -4763,7 +4766,7 @@ contains
        cyyy  = yGrad0  * yGrad1  * yGrad2
 
        massTracerProd = mean0 * mean1 * mean2
-       if (abs(massTracerProd) > 0.0_RKIND) then
+       if (abs(massTracerProd) > seaicePuny) then
           reciprocal = 1.0_RKIND / massTracerProd
        else
           reciprocal = 0.0_RKIND


### PR DESCRIPTION
High-res (ne120pg2_r0125_oRRS18to6v3.WCYCL1950) B-case tests on summit using gnu have been failing with a floating-point exception that points to a line in the seaice incremental remap code:
````
       if (abs(massTracerProd) > 0.0_RKIND) then
````
line 4769 of mpas_seaice_advection_incremental_remap.F. @whannah1 reported the issue and has found that the error occurs when massTracerProd is extremely small, so its inverse ends up being extremely large. He also found that it can be avoided by replacing the 0.0 with a tiny number. However, after discussion this PR fixes the issue by removing the reciprocal calculation and dividing by the mean0 (and massTracerProd) quantities instead -- @ambrad thank you for the suggestion.

Fixes #5463

[non-BFB]