### PR TITLE
Modify ocean z-star ALE coordinate for inactive top cells

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_thick_ale.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_thick_ale.F
@@ -127,11 +127,12 @@ contains
       real (kind=RKIND) :: &
          weightSum,       &! sum of weights in vertical
          columnThickness, &! total thickness from bottomDepth, SSH
-         thicknessSum,    &! total resting thickness
+         restingThicknessDiff,    &! total resting thickness
          remainder,       &! track remainder in mix/max alteration
          newThickness      ! temp used during min/max adjustment
 
       real (kind=RKIND), dimension(:), allocatable :: &
+         restingThicknessSum,    &! total resting thickness
          prelim_ALE_thickness,   & ! ALE thickness at new time
          min_ALE_thickness_down, & ! thickness alteration in min/max adj
          min_ALE_thickness_up      ! thickness alteration in min/max adj
@@ -168,43 +169,47 @@ contains
       ! restingThickness_times_weights
       case (ALEthickProportionThickTimesWgts)
 
+         allocate(restingThicknessSum(nCells))
+
 #ifdef MPAS_OPENACC
          !xacc parallel loop &
          !xacc    present(ALE_thickness, SSH, restingThickness, &
          !xacc            minLevelCell, maxLevelCell, &
          !xacc            vertCoordMovementWeights) &
-         !xacc    private(k, kMin, kMax, thicknessSum)
+         !xacc    private(k, kMin, kMax, restingThicknessDiff)
 #else
          !$omp parallel
          !$omp do schedule(runtime) &
-         !$omp    private(k, kMin, kMax, thicknessSum)
+         !$omp    private(k, kMin, kMax, restingThicknessDiff)
 #endif
          do iCell = 1, nCells
             kMax = maxLevelCell(iCell)
             kMin = minLevelCell(iCell)
    
-            thicknessSum = 1e-14_RKIND
+            restingThicknessSum(iCell) = 0.0_RKIND
             do k = kMin, kMax
-               thicknessSum = thicknessSum &
+               restingThicknessSum(iCell) = restingThicknessSum(iCell) &
                             + vertCoordMovementWeights(k) &
                             * restingThickness(k,iCell)
             end do
-            columnThickness = bottomDepth(iCell) + SSH(iCell)
    
+            restingThicknessDiff = restingThicknessSum(iCell) - bottomDepth(iCell)
+            restingThicknessSum(iCell) = restingThicknessSum(iCell) + 1e-14_RKIND
             ! Note that restingThickness is nonzero, and remaining
             ! terms are perturbations about zero.
             ! This is equation 4 and 6 in Petersen et al 2015,
             ! but with eqn 6
             do k = kMin, kMax
                ALE_thickness(k, iCell) = restingThickness(k, iCell) &
-                  + ( (columnThickness - thicknessSum) * vertCoordMovementWeights(k) * &
-                      restingThickness(k, iCell) ) / thicknessSum
+                  + ( (SSH(iCell) + restingThicknessDiff) * vertCoordMovementWeights(k) * &
+                      restingThickness(k, iCell) ) / restingThicknessSum(iCell)
             end do
          enddo
 #ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
 #endif
+         deallocate(restingThicknessSum)
    
       ! weights_only
       case (ALEthickProportionWgtsOnly)

--- a/components/mpas-ocean/src/shared/mpas_ocn_thick_ale.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_thick_ale.F
@@ -125,10 +125,11 @@ contains
          nCells        ! number of cells
 
       real (kind=RKIND) :: &
-         weightSum,    &! sum of weights in vertical
-         thicknessSum, &! total thickness
-         remainder,    &! track remainder in mix/max alteration
-         newThickness   ! temp used during min/max adjustment
+         weightSum,       &! sum of weights in vertical
+         columnThickness, &! total thickness from bottomDepth, SSH
+         thicknessSum,    &! total resting thickness
+         remainder,       &! track remainder in mix/max alteration
+         newThickness      ! temp used during min/max adjustment
 
       real (kind=RKIND), dimension(:), allocatable :: &
          prelim_ALE_thickness,   & ! ALE thickness at new time
@@ -188,15 +189,16 @@ contains
                             + vertCoordMovementWeights(k) &
                             * restingThickness(k,iCell)
             end do
+            columnThickness = bottomDepth(iCell) + SSH(iCell)
    
             ! Note that restingThickness is nonzero, and remaining
             ! terms are perturbations about zero.
             ! This is equation 4 and 6 in Petersen et al 2015,
             ! but with eqn 6
             do k = kMin, kMax
-               ALE_thickness(k,iCell) = restingThickness(k,iCell) &
-                  + (SSH(iCell)*vertCoordMovementWeights(k)* &
-                     restingThickness(k,iCell) )/thicknessSum
+               ALE_thickness(k, iCell) = restingThickness(k, iCell) &
+                  + ( (columnThickness - thicknessSum) * vertCoordMovementWeights(k) * &
+                      restingThickness(k, iCell) ) / thicknessSum
             end do
          enddo
 #ifndef MPAS_OPENACC

--- a/components/mpas-ocean/src/shared/mpas_ocn_thick_ale.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_thick_ale.F
@@ -126,13 +126,12 @@ contains
 
       real (kind=RKIND) :: &
          weightSum,       &! sum of weights in vertical
-         columnThickness, &! total thickness from bottomDepth, SSH
+         restingThicknessSum,    &! total resting thickness
          restingThicknessDiff,    &! total resting thickness
          remainder,       &! track remainder in mix/max alteration
          newThickness      ! temp used during min/max adjustment
 
       real (kind=RKIND), dimension(:), allocatable :: &
-         restingThicknessSum,    &! total resting thickness
          prelim_ALE_thickness,   & ! ALE thickness at new time
          min_ALE_thickness_down, & ! thickness alteration in min/max adj
          min_ALE_thickness_up      ! thickness alteration in min/max adj
@@ -169,32 +168,30 @@ contains
       ! restingThickness_times_weights
       case (ALEthickProportionThickTimesWgts)
 
-         allocate(restingThicknessSum(nCells))
-
 #ifdef MPAS_OPENACC
          !xacc parallel loop &
          !xacc    present(ALE_thickness, SSH, restingThickness, &
          !xacc            minLevelCell, maxLevelCell, &
          !xacc            vertCoordMovementWeights) &
-         !xacc    private(k, kMin, kMax, restingThicknessDiff)
+         !xacc    private(k, kMin, kMax, restingThicknessDiff, restingThicknessSum)
 #else
          !$omp parallel
          !$omp do schedule(runtime) &
-         !$omp    private(k, kMin, kMax, restingThicknessDiff)
+         !$omp    private(k, kMin, kMax, restingThicknessDiff, restingThicknessSum)
 #endif
          do iCell = 1, nCells
             kMax = maxLevelCell(iCell)
             kMin = minLevelCell(iCell)
    
-            restingThicknessSum(iCell) = 0.0_RKIND
+            restingThicknessSum = 0.0_RKIND
             do k = kMin, kMax
-               restingThicknessSum(iCell) = restingThicknessSum(iCell) &
+               restingThicknessSum = restingThicknessSum &
                             + vertCoordMovementWeights(k) &
                             * restingThickness(k,iCell)
             end do
    
-            restingThicknessDiff = restingThicknessSum(iCell) - bottomDepth(iCell)
-            restingThicknessSum(iCell) = restingThicknessSum(iCell) + 1e-14_RKIND
+            restingThicknessDiff = restingThicknessSum - bottomDepth(iCell)
+            restingThicknessSum = restingThicknessSum + 1e-14_RKIND
             ! Note that restingThickness is nonzero, and remaining
             ! terms are perturbations about zero.
             ! This is equation 4 and 6 in Petersen et al 2015,
@@ -202,15 +199,14 @@ contains
             do k = kMin, kMax
                ALE_thickness(k, iCell) = restingThickness(k, iCell) &
                   + ( (SSH(iCell) + restingThicknessDiff) * vertCoordMovementWeights(k) * &
-                      restingThickness(k, iCell) ) / restingThicknessSum(iCell)
+                      restingThickness(k, iCell) ) / restingThicknessSum
             end do
          enddo
 #ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
 #endif
-         deallocate(restingThicknessSum)
-   
+
       ! weights_only
       case (ALEthickProportionWgtsOnly)
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_thick_ale.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_thick_ale.F
@@ -191,7 +191,6 @@ contains
             end do
    
             restingThicknessDiff = restingThicknessSum - bottomDepth(iCell)
-            restingThicknessSum = restingThicknessSum + 1e-14_RKIND
             ! Note that restingThickness is nonzero, and remaining
             ! terms are perturbations about zero.
             ! This is equation 4 and 6 in Petersen et al 2015,
@@ -199,7 +198,7 @@ contains
             do k = kMin, kMax
                ALE_thickness(k, iCell) = restingThickness(k, iCell) &
                   + ( (SSH(iCell) + restingThicknessDiff) * vertCoordMovementWeights(k) * &
-                      restingThickness(k, iCell) ) / restingThicknessSum
+                      restingThickness(k, iCell) ) / max(1e-14_RKIND, restingThicknessSum)
             end do
          enddo
 #ifndef MPAS_OPENACC

--- a/components/mpas-ocean/src/shared/mpas_ocn_thick_ale.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_thick_ale.F
@@ -126,8 +126,9 @@ contains
 
       real (kind=RKIND) :: &
          weightSum,       &! sum of weights in vertical
-         restingThicknessSum,    &! total resting thickness
-         restingThicknessDiff,    &! total resting thickness
+         restingThicknessSum,  &! total resting thickness
+         restingThicknessDiff, &! difference from total resting thickness
+         weightedThicknessSum, &! total resting thickness, weighted
          remainder,       &! track remainder in mix/max alteration
          newThickness      ! temp used during min/max adjustment
 
@@ -173,19 +174,24 @@ contains
          !xacc    present(ALE_thickness, SSH, restingThickness, &
          !xacc            minLevelCell, maxLevelCell, &
          !xacc            vertCoordMovementWeights) &
-         !xacc    private(k, kMin, kMax, restingThicknessDiff, restingThicknessSum)
+         !xacc    private(k, kMin, kMax, restingThicknessDiff, &
+         !xacc            restingThicknessSum, weightedThicknessSum)
 #else
          !$omp parallel
          !$omp do schedule(runtime) &
-         !$omp    private(k, kMin, kMax, restingThicknessDiff, restingThicknessSum)
+         !$omp    private(k, kMin, kMax, restingThicknessDiff, &
+         !$omp            restingThicknessSum, weightedThicknessSum)
 #endif
          do iCell = 1, nCells
             kMax = maxLevelCell(iCell)
             kMin = minLevelCell(iCell)
    
             restingThicknessSum = 0.0_RKIND
+            weightedThicknessSum = 0.0_RKIND
             do k = kMin, kMax
                restingThicknessSum = restingThicknessSum &
+                            + restingThickness(k,iCell)
+               weightedThicknessSum = weightedThicknessSum &
                             + vertCoordMovementWeights(k) &
                             * restingThickness(k,iCell)
             end do
@@ -198,7 +204,7 @@ contains
             do k = kMin, kMax
                ALE_thickness(k, iCell) = restingThickness(k, iCell) &
                   + ( (SSH(iCell) + restingThicknessDiff) * vertCoordMovementWeights(k) * &
-                      restingThickness(k, iCell) ) / max(1e-14_RKIND, restingThicknessSum)
+                      restingThickness(k, iCell) ) / max(1e-14_RKIND, weightedThicknessSum)
             end do
          enddo
 #ifndef MPAS_OPENACC


### PR DESCRIPTION
This PR increases the generalizability of vertical coordinates by relaxing the assumption that `restingThickness` spans `ssh=0` to `bottomDepth`. As such, it is tangentially related to inactive top cells. The change affects cases where `config_ALE_thickness_proportionality='restingThickness_times_weights'`, which is the default.

[non-BFB]