### PR TITLE
Fix EAM config options for CMIP6 family

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -254,6 +254,8 @@ _TESTS = {
         "inherit" : "e3sm_atm_prod",
         "tests"   : (
             "SMS_Ld1.ne30pg2_r05_EC30to60E2r2.WCYCL1850.allactive-wcprod",
+            "SMS_Ld1.ne30pg2_EC30to60E2r2.WCYCL1850-1pctCO2.allactive-wcprod",
+            "SMS_Ld1.ne30pg2_EC30to60E2r2.WCYCL1850-4xCO2.allactive-wcprod",
             "SMS_Ld1.ne30pg2_EC30to60E2r2.WCYCL1850.allactive-wcprod",
             "SMS_Ld1.ne30pg2_EC30to60E2r2.WCYCLSSP370.allactive-wcprodssp",
             "SMS_Ld1.ne30pg2_EC30to60E2r2.WCYCLSSP585.allactive-wcprodssp",

--- a/components/eam/cime_config/config_component.xml
+++ b/components/eam/cime_config/config_component.xml
@@ -47,7 +47,7 @@
     <values modifier='additive'>
       <value compset=""                >-mach $MACH</value>
       <value compset="_EAM"            >-phys default</value>
-      <value compset="_EAM%CMIP6_"     >&eam_phys_defaults; &eam_chem_defaults;</value>
+      <value compset="_EAM%CMIP6"      >&eam_phys_defaults; &eam_chem_defaults;</value>
       <value compset="_EAM%AR5sf"      >&eam_phys_defaults; -chem superfast_mam4_resus_mom_soag -rain_evap_to_coarse_aero</value>
       <value compset="_ELM%[^_]*BC"    >-bc_dep_to_snow_updates</value>
       <value compset="_EAM.*_BGC%*"    >-co2_cycle</value>

--- a/components/eam/cime_config/config_component.xml
+++ b/components/eam/cime_config/config_component.xml
@@ -47,7 +47,9 @@
     <values modifier='additive'>
       <value compset=""                >-mach $MACH</value>
       <value compset="_EAM"            >-phys default</value>
-      <value compset="_EAM%CMIP6"      >&eam_phys_defaults; &eam_chem_defaults;</value>
+      <value compset="_EAM%CMIP6_"      >&eam_phys_defaults; &eam_chem_defaults;</value>
+      <value compset="_EAM%CMIP6-1pctCO2" >&eam_phys_defaults; &eam_chem_defaults;</value>
+      <value compset="_EAM%CMIP6-4xCO2"   >&eam_phys_defaults; &eam_chem_defaults;</value>
       <value compset="_EAM%AR5sf"      >&eam_phys_defaults; -chem superfast_mam4_resus_mom_soag -rain_evap_to_coarse_aero</value>
       <value compset="_ELM%[^_]*BC"    >-bc_dep_to_snow_updates</value>
       <value compset="_EAM.*_BGC%*"    >-co2_cycle</value>


### PR DESCRIPTION
The current repo on setting eam default physics and chemistry fails to recognize compset with physics like EAM%CMIP6-1pctCO2 and EAM%CMIP6-4xCO2.   Add two entries for those compsets.

Fixes #5261
[BFB] except for simulations with WCYCL1850-1pctCO2 and WCYCL1850-4xCO2