### PR TITLE
For perlmutter machines, update module versions

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -225,7 +225,7 @@
 
       <modules compiler="nvidia">
         <command name="load">PrgEnv-nvidia</command>
-        <command name="load">nvidia/21.11</command>
+        <command name="load">nvidia/22.5</command>
       </modules>
 
       <modules compiler="amdclang">
@@ -237,10 +237,10 @@
         <command name="load">craype-accel-host</command>
         <command name="load">cray-libsci</command>
         <command name="load">craype</command>
-        <command name="load">cray-mpich/8.1.15</command>
-        <command name="load">cray-hdf5-parallel/1.12.1.1</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.8.1.1</command>
-        <command name="load">cray-parallel-netcdf/1.12.2.1</command>
+        <command name="load">cray-mpich/8.1.17</command>
+        <command name="load">cray-hdf5-parallel/1.12.1.5</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.8.1.5</command>
+        <command name="load">cray-parallel-netcdf/1.12.2.5</command>
         <command name="load">cmake/3.22.0</command>
       </modules>
     </module_system>
@@ -334,7 +334,7 @@
 
       <modules compiler="nvidia.*">
         <command name="load">PrgEnv-nvidia</command>
-        <command name="load">nvidia/21.11</command>
+        <command name="load">nvidia/22.5</command>
       </modules>
 
       <modules compiler="gnugpu">
@@ -358,10 +358,10 @@
       <modules>
         <command name="load">cray-libsci</command>
         <command name="load">craype</command>
-        <command name="load">cray-mpich/8.1.15</command>
-        <command name="load">cray-hdf5-parallel/1.12.1.1</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.8.1.1</command>
-        <command name="load">cray-parallel-netcdf/1.12.2.1</command>
+        <command name="load">cray-mpich/8.1.17</command>
+        <command name="load">cray-hdf5-parallel/1.12.1.5</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.8.1.5</command>
+        <command name="load">cray-parallel-netcdf/1.12.2.5</command>
         <command name="load">cmake/3.22.0</command>
       </modules>
     </module_system>
@@ -456,7 +456,7 @@
 
       <modules compiler="nvidia">
         <command name="load">PrgEnv-nvidia</command>
-        <command name="load">nvidia/21.11</command>
+        <command name="load">nvidia/22.5</command>
       </modules>
 
       <modules compiler="amdclang">
@@ -468,7 +468,7 @@
         <command name="load">craype-accel-host</command>
         <command name="load">cray-libsci</command>
         <command name="load">craype</command>
-        <command name="load">cray-mpich/8.1.15</command>
+        <command name="load">cray-mpich/8.1.17</command>
         <command name="load">cray-hdf5-parallel/1.12.1.5</command>
         <command name="load">cray-netcdf-hdf5parallel/4.8.1.5</command>
         <command name="load">cray-parallel-netcdf/1.12.2.5</command>


### PR DESCRIPTION
For pm-cpu/pm-gpu and alvarez at NERSC, update a few versions of modules to be the default.  mpich, netcdf-related modules, and nvidia compiler.
These are all minor version updates, and do not "fix" any issues, but wanted to keep the modules updated to the machine defaults.
Tested on pm-cpu and do not see any issues.
Don't have to update pm-gpu at this time, but would prefer to keep them symmetric and I don't expect any issues.

For the change to cray-mpich from version 8.1.15 to 8.1.17: 
```
  Changes in Cray MPICH 8.1.17

      - PE-38123 - Option to instrument ofi receive paths
      - PE-38795 - Improve Reduce_scatter_block performance
      - PE-36493 - Added CXI traffic class features
      - PE-40806 - Improve MPI_Iallgatherv and MPI_Iallgather on SS-11
```

The other module version changes:
```
cray-hdf5-parallel/1.12.1.1       --> cray-hdf5-parallel/1.12.1.5
cray-netcdf-hdf5parallel/4.8.1.1  --> cray-netcdf-hdf5parallel/4.8.1.5
cray-parallel-netcdf/1.12.2.1     --> cray-parallel-netcdf/1.12.2.5

nvidia/21.11 --> nvidia/22.5
```

The tests in e3sm_developer are BFB for GNU
