### PR TITLE
Added wcprod tests in maint-2.0 for WCYCL1850-1pctCO2 and -4xCO2

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -245,6 +245,8 @@ _TESTS = {
         "tests"   : (
             "SMS_Ld1.ne30pg2_r05_EC30to60E2r2.WCYCL1850.allactive-wcprod",
             "SMS_Ld1.ne30pg2_EC30to60E2r2.WCYCL1850.allactive-wcprod",
+            "SMS_Ld1.ne30pg2_EC30to60E2r2.WCYCL1850-1pctCO2.allactive-wcprod",
+            "SMS_Ld1.ne30pg2_EC30to60E2r2.WCYCL1850-4xCO2.allactive-wcprod",
             "SMS_Ld1.ne30pg2_EC30to60E2r2.WCYCLSSP370.allactive-wcprodssp",
             "SMS_Ld1.ne30pg2_EC30to60E2r2.WCYCLSSP585.allactive-wcprodssp",
             "SMS_PS.northamericax4v1pg2_WC14to60E2r3.WCYCL1850.allactive-wcprodrrm",


### PR DESCRIPTION
This PR added wcprod tests for compsets WCYCL1850-1pctCO2 and WCYCL1850-4xCO2.

[BFB] except baselines need to be created for the two new tests.