### PR TITLE
Optionally disable alarm calibration in mpas-framework

### DIFF
--- a/components/mpas-framework/src/framework/mpas_timekeeping.F
+++ b/components/mpas-framework/src/framework/mpas_timekeeping.F
@@ -404,7 +404,7 @@ module mpas_timekeeping
    end subroutine mpas_advance_clock
 
 
-   subroutine mpas_set_clock_time(clock, clock_time, whichTime, ierr)
+   subroutine mpas_set_clock_time(clock, clock_time, whichTime, ierr, calibrate_alarms)
 
       implicit none
 
@@ -412,14 +412,24 @@ module mpas_timekeeping
       type (MPAS_Time_type), intent(in) :: clock_time
       integer, intent(in) :: whichTime
       integer, intent(out), optional :: ierr
+      logical, intent(in), optional :: calibrate_alarms
       integer :: threadNum
+      logical :: local_calibrate_alarms
 
       threadNum = mpas_threading_get_thread_num()
+
+      if (present(calibrate_alarms)) then
+         local_calibrate_alarms = calibrate_alarms
+      else
+         local_calibrate_alarms = .true.
+      end if
 
       if ( threadNum == 0 ) then
          if (whichTime == MPAS_NOW) then
             call ESMF_ClockSet(clock % c, CurrTime=clock_time%t, rc=ierr)
-            call mpas_calibrate_alarms(clock, ierr);
+            if (local_calibrate_alarms) then
+               call mpas_calibrate_alarms(clock, ierr)
+            end if
          else if (whichTime == MPAS_START_TIME) then
             call ESMF_ClockSet(clock % c, StartTime=clock_time%t, rc=ierr)
          else if (whichTime == MPAS_STOP_TIME) then

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -16,7 +16,7 @@ module ocn_comp_mct
    use seq_infodata_mod
    use seq_timemgr_mod
    use seq_comm_mct,      only : seq_comm_suffix, seq_comm_inst, seq_comm_name, info_taskmap_comp
-   use shr_file_mod 
+   use shr_file_mod
    use shr_cal_mod,       only : shr_cal_date2ymd
    use shr_sys_mod
    use shr_taskmap_mod,   only : shr_taskmap_write
@@ -93,8 +93,8 @@ module ocn_comp_mct
 
    character(len=StrKIND) :: runtype, coupleTimeStamp
 
-   type(seq_infodata_type), pointer :: infodata   
-   type (iosystem_desc_t), pointer :: io_system 
+   type(seq_infodata_type), pointer :: infodata
+   type (iosystem_desc_t), pointer :: io_system
    integer :: ocnLogUnit ! unit number for ocn log
 
    !! MPASO Datatypes
@@ -116,7 +116,7 @@ contains
   subroutine ocn_init_mct( EClock, cdata_o, x2o_o, o2x_o, NLFilename )!{{{
 !
 ! !DESCRIPTION:
-! Initialize MPASO 
+! Initialize MPASO
 !
 ! !INPUT/OUTPUT PARAMETERS:
 
@@ -258,7 +258,7 @@ contains
 !   set cdata pointers
 !
 !-----------------------------------------------------------------------
-    errorCode = 0 
+    errorCode = 0
 
     call seq_cdata_setptrs(cdata_o, ID=OCNID, mpicom=mpicom_o, &
          gsMap=gsMap_o, dom=dom_o, infodata=infodata)
@@ -271,7 +271,7 @@ contains
 #if (defined _MEMTRACE)
     if(iam == 0) then
         lbnum=1
-        call memmon_dump_fort('memmon.out','ocn_init_mct:start::',lbnum) 
+        call memmon_dump_fort('memmon.out','ocn_init_mct:start::',lbnum)
     endif
 #endif
 
@@ -280,7 +280,7 @@ contains
 
 !-----------------------------------------------------------------------
 !
-!   initialize the model run 
+!   initialize the model run
 !
 !-----------------------------------------------------------------------
 
@@ -586,7 +586,7 @@ contains
        call mpas_set_clock_time(domain_ptr % clock, currTime, MPAS_START_TIME, ierr)
        call mpas_set_clock_time(domain_ptr % clock, currTime, MPAS_NOW, ierr)
     end if
-    ! Doublecheck that clocks are synced here.  
+    ! Doublecheck that clocks are synced here.
     ! (Note that if this is an initial run, a section below will advance the ocean clock
     ! by one coupling interval, at which point we expect the clocks to be OUT of sync.)
     call check_clocks_sync(domain % clock, Eclock, ierr)
@@ -604,15 +604,15 @@ contains
 
     ! Initialize mct ocn domain (needs ocn initialization info)
     call ocn_domain_mct( lsize, gsMap_o, dom_o )
-    
+
     ! Inialize mct attribute vectors
-    
+
     call mct_aVect_init(x2o_o, rList=seq_flds_x2o_fields, lsize=lsize)
     call mct_aVect_zero(x2o_o)
-    
-    call mct_aVect_init(o2x_o, rList=seq_flds_o2x_fields, lsize=lsize) 
+
+    call mct_aVect_init(o2x_o, rList=seq_flds_o2x_fields, lsize=lsize)
     call mct_aVect_zero(o2x_o)
-    
+
     nsend = mct_avect_nRattr(o2x_o)
     nrecv = mct_avect_nRattr(x2o_o)
 
@@ -769,7 +769,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-    call ocn_export_mct(o2x_o, errorCode)  
+    call ocn_export_mct(o2x_o, errorCode)
     if (errorCode /= 0) then
        call mpas_log_write('ERROR in ocn_export_mct', MPAS_LOG_CRIT)
     endif
@@ -812,7 +812,7 @@ contains
     timeStep = mpas_get_clock_timestep(domain_ptr % clock, ierr=ierr)
     call mpas_get_timeInterval(timeStep, dt=dt)
 
-    call ocn_import_mct(x2o_o, errorCode)  
+    call ocn_import_mct(x2o_o, errorCode)
     if (errorCode /= 0) then
        call mpas_log_write('Error in ocn_import_mct', MPAS_LOG_CRIT)
     endif
@@ -832,7 +832,7 @@ contains
 #if defined (_MEMTRACE)
     if(iam  == 0) then
         lbnum=1
-        call memmon_dump_fort('memmon.out','ocn_init_mct:end::',lbnum) 
+        call memmon_dump_fort('memmon.out','ocn_init_mct:end::',lbnum)
         call memmon_reset_addr()
     endif
 #endif
@@ -906,7 +906,7 @@ contains
 #ifdef MPAS_DEBUG
       debugOn = .true.
 #endif
- 
+
       domain_ptr => domain
 
       ! Set MPAS Log module instance
@@ -1065,12 +1065,12 @@ contains
          end do
 
          if (debugOn) call mpas_log_write('   Computing analysis members')
-         call ocn_analysis_compute(domain_ptr, ierr) 
+         call ocn_analysis_compute(domain_ptr, ierr)
          if (iam==0.and.debugOn) then
             call mpas_log_write( '   Finished computing analysis members')
             call mpas_log_write('   Preparing analysis members for restart')
          endif
-         call ocn_analysis_restart(domain_ptr, ierr) 
+         call ocn_analysis_restart(domain_ptr, ierr)
          if (iam==0.and.debugOn) then
             call mpas_log_write('   Finished preparing analysis members for restart')
             call mpas_log_write('   Writing analysis member output')
@@ -1294,7 +1294,7 @@ contains
 
     integer :: i, n, lsize, gsize, ier
 
-    type (block_type), pointer :: block_ptr 
+    type (block_type), pointer :: block_ptr
     type (mpas_pool_type), pointer :: meshPool
 
     integer, dimension(:), pointer :: indexToCellID
@@ -1362,7 +1362,7 @@ contains
 
     integer        , intent(in)    :: lsize
     type(mct_gsMap), intent(in)    :: gsMap_o
-    type(mct_ggrid), intent(inout) :: dom_o     
+    type(mct_ggrid), intent(inout) :: dom_o
 
 !EOP
 !BOC
@@ -1413,19 +1413,19 @@ contains
 
 !-------------------------------------------------------------------
 !
-! Determine domain 
+! Determine domain
 ! Initialize attribute vector with special value
 !
 !-------------------------------------------------------------------
 
-    data(:) = -9999.0_R8 
-    call mct_gGrid_importRAttr(dom_o,"lat"  ,data,lsize) 
-    call mct_gGrid_importRAttr(dom_o,"lon"  ,data,lsize) 
-    call mct_gGrid_importRAttr(dom_o,"area" ,data,lsize) 
-    call mct_gGrid_importRAttr(dom_o,"aream",data,lsize) 
-    data(:) = 1.0_R8     
-    call mct_gGrid_importRAttr(dom_o,"mask",data,lsize) 
-    call mct_gGrid_importRAttr(dom_o,"frac",data,lsize) 
+    data(:) = -9999.0_R8
+    call mct_gGrid_importRAttr(dom_o,"lat"  ,data,lsize)
+    call mct_gGrid_importRAttr(dom_o,"lon"  ,data,lsize)
+    call mct_gGrid_importRAttr(dom_o,"area" ,data,lsize)
+    call mct_gGrid_importRAttr(dom_o,"aream",data,lsize)
+    data(:) = 1.0_R8
+    call mct_gGrid_importRAttr(dom_o,"mask",data,lsize)
+    call mct_gGrid_importRAttr(dom_o,"frac",data,lsize)
 
 !-------------------------------------------------------------------
 !
@@ -1446,10 +1446,10 @@ contains
           n = n + 1
           data(n) = lonCell(i) * r2d
        end do
-       
+
        block_ptr => block_ptr % next
     end do
-    call mct_gGrid_importRattr(dom_o,"lon",data,lsize) 
+    call mct_gGrid_importRattr(dom_o,"lon",data,lsize)
 
     n = 0
     block_ptr => domain % blocklist
@@ -1466,7 +1466,7 @@ contains
        end do
        block_ptr => block_ptr % next
     end do
-    call mct_gGrid_importRattr(dom_o,"lat",data,lsize) 
+    call mct_gGrid_importRattr(dom_o,"lat",data,lsize)
 
     n = 0
     block_ptr => domain % blocklist
@@ -1484,7 +1484,7 @@ contains
        end do
        block_ptr => block_ptr % next
     end do
-    call mct_gGrid_importRattr(dom_o,"area",data,lsize) 
+    call mct_gGrid_importRattr(dom_o,"area",data,lsize)
 
     ! Build mask and frac based on landIceMask
     block_ptr => domain % blocklist
@@ -1513,8 +1513,8 @@ contains
        block_ptr => block_ptr % next
     end do
 
-    call mct_gGrid_importRattr(dom_o,"mask",data,lsize) 
-    call mct_gGrid_importRattr(dom_o,"frac",data,lsize) 
+    call mct_gGrid_importRattr(dom_o,"mask",data,lsize)
+    call mct_gGrid_importRattr(dom_o,"frac",data,lsize)
 
     deallocate(data)
     deallocate(idata)
@@ -1537,7 +1537,7 @@ contains
 !  This routine receives message from cpl7 driver
 !
 !    The following fields are always received from the coupler:
-! 
+!
 !    o  taux   -- zonal wind stress (taux)                 (W/m2   )
 !    o  tauy   -- meridonal wind stress (tauy)             (W/m2   )
 !    o  snow   -- water flux due to snow                   (kg/m2/s)
@@ -1564,15 +1564,15 @@ contains
 !    o  rofPN  -- PN  runoff flux                          (kg/m2/s)
 !    o  rofDIC -- DIC runoff flux                          (kg/m2/s)
 !    o  rofFe  -- Fe  runoff flux                          (kg/m2/s)
-! 
+!
 !    The following fields are sometimes received from the coupler,
 !      depending on model options:
-! 
+!
 !    o  pbot   -- bottom atm pressure                      (Pa)
 !    o  duu10n -- 10m wind speed squared                   (m^2/s^2)
 !    o  co2prog-- bottom atm level prognostic co2
 !    o  co2diag-- bottom atm level diagnostic co2
-! 
+!
 !-----------------------------------------------------------------------
 !
 ! !REVISION HISTORY:
@@ -1684,7 +1684,7 @@ contains
 
    type (field2DReal), pointer :: stokesDriftZonalWavenumberField, &
                                   stokesDriftMeridionalWavenumberField
- 
+
    real (kind=RKIND), dimension(:), pointer :: windStressZonal, windStressMeridional, &
                                                latentHeatFlux, sensibleHeatFlux, &
                                                longWaveHeatFluxUp, &
@@ -1745,7 +1745,7 @@ contains
 
 !-----------------------------------------------------------------------
 !
-!  zero out padded cells 
+!  zero out padded cells
 !
 !-----------------------------------------------------------------------
 
@@ -2199,7 +2199,7 @@ contains
               iceFluxDMS(i) = x2o_o % rAttr(index_x2o_Fioi_dms, n)
            endif
            if ( iceFluxDMSPField % isActive ) then
-              !JW TODO: dmspp? dmspd? the sum? 
+              !JW TODO: dmspp? dmspd? the sum?
               iceFluxDMSP(i) = x2o_o % rAttr(index_x2o_Fioi_dmspp, n)
            endif
          endif
@@ -2580,13 +2580,13 @@ contains
                                                avgOceanSurfaceFeParticulate, &
                                                avgOceanSurfaceFeDissolved, &
                                                ssh
- 
+
    real (kind=RKIND), dimension(:,:), pointer :: avgTracersSurfaceValue, avgSurfaceVelocity, &
                                                  avgOceanSurfacePhytoC, &
                                                  avgOceanSurfaceDOC, layerThickness
 
    real (kind=RKIND) :: surfaceFreezingTemp
-   
+
    logical, pointer :: frazilIceActive,          &
                        config_use_ecosysTracers, &
                        config_use_DMSTracers,    &
@@ -2695,7 +2695,7 @@ contains
        o2x_o % rAttr(index_o2x_So_dhdy, n) = filteredSSHGradientMeridional(i)
 
        o2x_o % rAttr(index_o2x_Faoo_h2otemp, n) = avgTotalFreshWaterTemperatureFlux(i) * rho_sw * cp_sw
-       
+
        if (ocn_rof_two_way) then
          o2x_o % rAttr(index_o2x_So_ssh, n)       = ssh(i)
        end if
@@ -2714,14 +2714,14 @@ contains
              ! Calculate energy associated with frazil mass transfer to sea ice if frazil has accumulated
              if ( accumulatedFrazilIceMass(i) > 0.0_RKIND ) then
 
-              seaIceEnergy(i) = accumulatedFrazilIceMass(i) * config_frazil_heat_of_fusion 
+              seaIceEnergy(i) = accumulatedFrazilIceMass(i) * config_frazil_heat_of_fusion
 
              ! Otherwise calculate the melt potential where avgTracersSurfaceValue represents only the
              ! top layer of the ocean
              else
 
               surfaceFreezingTemp = ocn_freezing_temperature(salinity=avgTracersSurfaceValue(index_salinitySurfaceValue, i), &
-                 pressure=0.0_RKIND,  inLandIceCavity=.false.) 
+                 pressure=0.0_RKIND,  inLandIceCavity=.false.)
 
               seaIceEnergy(i) = min(rho_sw*cp_sw*layerThickness(1, i)*( surfaceFreezingTemp + T0_Kelvin &
                               - avgTracersSurfaceValue(index_temperatureSurfaceValue, i) ), 0.0_RKIND )
@@ -2783,7 +2783,7 @@ contains
 !JW       o2x_o % rAttr(index_o2x_So_bls, n) = landIceBoundaryLayerSalinity(i)
 !JW       o2x_o % rAttr(index_o2x_So_htv, n) = landIceHeatTransferVelocity(i)
 !JW       o2x_o % rAttr(index_o2x_So_stv, n) = landIceSaltTransferVelocity(i)
- 
+
        if ( trim(config_land_ice_flux_mode) .ne. 'pressure_only' ) then
           o2x_o % rAttr(index_o2x_So_blt, n) = landIceBoundaryLayerTracers(indexBLT,i)
           o2x_o % rAttr(index_o2x_So_bls, n) = landIceBoundaryLayerTracers(indexBLS,i)
@@ -2904,7 +2904,7 @@ contains
       else
           write(histAtt, '(A,I6,A,A,A)') 'mpirun -n ', domain % dminfo % nProcs, ' ./', trim(domain % core % coreName), '_model'
       end if
-     
+
       call seq_infodata_GetData(infodata,case_name=caseid, &
                                 model_version=model_version, &
                                 username=username, &
@@ -2938,7 +2938,7 @@ contains
           &Principal Investigator, L-103, 7000 East Avenue, Livermore, CA 94550, USA')
       call MPAS_stream_mgr_add_att(domain % streamManager, 'contact', &
           'e3sm-data-support@listserv.llnl.gov')
-      
+
 
       call MPAS_stream_mgr_add_att(domain % streamManager, 'on_a_sphere', domain % on_a_sphere)
       call MPAS_stream_mgr_add_att(domain % streamManager, 'sphere_radius', domain % sphere_radius)

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -580,11 +580,11 @@ contains
     if (runtype == 'initial') then
        call seq_timemgr_EClockGetData(EClock, ECurrTime=currTime % t)
        call mpas_set_clock_time(domain_ptr % clock, currTime, MPAS_START_TIME, ierr)
-       call mpas_set_clock_time(domain_ptr % clock, currTime, MPAS_NOW, ierr)
+       call mpas_set_clock_time(domain_ptr % clock, currTime, MPAS_NOW, ierr, calibrate_alarms=.false.)
     else if (runtype == 'continue' .or. runtype == 'branch') then
        call seq_timemgr_EClockGetData(EClock, ECurrTime=currTime % t)
        call mpas_set_clock_time(domain_ptr % clock, currTime, MPAS_START_TIME, ierr)
-       call mpas_set_clock_time(domain_ptr % clock, currTime, MPAS_NOW, ierr)
+       call mpas_set_clock_time(domain_ptr % clock, currTime, MPAS_NOW, ierr, calibrate_alarms=.false.)
     end if
     ! Doublecheck that clocks are synced here.
     ! (Note that if this is an initial run, a section below will advance the ocean clock

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -634,7 +634,7 @@ contains
     if (runtype == 'initial') then
        call seq_timemgr_EClockGetData(EClock, ECurrTime=currTime % t)
        call mpas_set_clock_time(domain % clock, currTime, MPAS_START_TIME, ierr)
-       call mpas_set_clock_time(domain % clock, currTime, MPAS_NOW, ierr)
+       call mpas_set_clock_time(domain % clock, currTime, MPAS_NOW, ierr, calibrate_alarms=.false.)
 
        currTime = mpas_get_clock_time(domain % clock, MPAS_NOW, ierr)
        call mpas_get_time(curr_time=currTime, YYYY=iyear0, MM=imonth0, ierr=ierr)
@@ -650,7 +650,7 @@ contains
     else if (runtype == 'continue' .or. runtype == 'branch') then
        call seq_timemgr_EClockGetData(EClock, ECurrTime=currTime % t)
        call mpas_set_clock_time(domain % clock, currTime, MPAS_START_TIME, ierr)
-       call mpas_set_clock_time(domain % clock, currTime, MPAS_NOW, ierr)
+       call mpas_set_clock_time(domain % clock, currTime, MPAS_NOW, ierr, calibrate_alarms=.false.)
     end if
 
 !-----------------------------------------------------------------------


### PR DESCRIPTION
This merge allows calls to `mpas_set_clock_time` to disable alarm calibration when setting the current time.  This is useful because re-calibrating alarms has a negative impact on `timeSeriesStats` analysis members in MPAS-Ocean and MPAS-Seaice. The timeSeriesStats AMs get initialized with alarms that should ring after one compute interval.  If alarms are re-calibrated, they ring immediately instead.  However, the analysis members typically do not get computed at the start time, so the alarm actually rings after one time step.  If the time interval desired for timeSeriesStats is not a single time step, the compute alarm should not be ringing but it is on the first time step.

Fixes #5217
[non-BFB] for mpas timeSeriesStats diagnostic output only