### PR TITLE
For Perlmutter add env vars to avoid hanging under certain situations

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -258,6 +258,9 @@
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
       <env name="PERL5LIB">/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch</env>
       <env name="FI_CXI_RX_MATCH_MODE">software</env>
+      <env name="FI_CXI_DEFAULT_CQ_SIZE">71680</env>
+      <env name="FI_CXI_REQ_BUF_SIZE">12582912</env>
+      <env name="FI_UNIVERSE_SIZE">4096</env>
     </environment_variables>
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>
@@ -378,6 +381,9 @@
       <env name="OMP_PLACES">threads</env>
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
       <env name="PERL5LIB">/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch</env>
+      <env name="FI_CXI_DEFAULT_CQ_SIZE">71680</env>
+      <env name="FI_CXI_REQ_BUF_SIZE">12582912</env>
+      <env name="FI_UNIVERSE_SIZE">4096</env>
     </environment_variables>
     <environment_variables compiler="gnugpu">
       <env name="MPICH_GPU_SUPPORT_ENABLED">1</env>
@@ -489,6 +495,9 @@
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
       <env name="PERL5LIB">/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch</env>
       <env name="FI_CXI_RX_MATCH_MODE">software</env>
+      <env name="FI_CXI_DEFAULT_CQ_SIZE">71680</env>
+      <env name="FI_CXI_REQ_BUF_SIZE">12582912</env>
+      <env name="FI_UNIVERSE_SIZE">4096</env>
     </environment_variables>
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>


### PR DESCRIPTION
For Perlmutter (pm-cpu, pm-gpu, and test machine alvarez), add some libfabric environment variables that were suggested by NERSC/HPE to address issues such as jobs hanging. Tested with both pm-cpu and pm-gpu.
Appears to be no noticeable difference in performance. Possibly temporary as newer version of libfabric may correct.

```
setenv FI_CXI_DEFAULT_CQ_SIZE 71680
setenv FI_CXI_REQ_BUF_SIZE 12582912
setenv FI_UNIVERSE_SIZE 4096
```

Adding a little more info about the env vars, which I found via `man fi_cxi`:

```
FI_CXI_DEFAULT_CQ_SIZE
  Change the provider default completion queue size.  This may be useful for applications which
  rely on middleware, and middleware defaults the completion queue size to the provider default.

FI_CXI_REQ_BUF_SIZE
  Size of request buffers.  Increasing the request buffer size allows for more unmatched messages
  to be sent into a single request buffer.  The default size is 2MB.

FI_UNIVERSE_SIZE
  Defines the maximum number of processes that will be used by distribute OFI application.

```
Note I think, the `FI_CXI_REQ_BUF_SIZE` variable (and maybe the other?) may only be used when using `FI_CXI_RX_MATCH_MODE=software` which we are already doing for `pm-cpu`, but NOT `pm-gpu`. So it's
possible these are not needed for `pm-gpu` and I will test again there.

Will fix issues in SCREAM repo, so will need upstream merge.
Fixes https://github.com/E3SM-Project/scream/issues/1920
Fixes https://github.com/E3SM-Project/scream/issues/1939

[bfb]