### PR TITLE
[Standalone MPAS-Ocean] Add tracers to dam break initialization

### DIFF
--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_dam_break.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_dam_break.F
@@ -190,6 +190,8 @@ contains
        call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
 
        call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+       call mpas_pool_get_dimension(tracersPool, 'index_temperature', index_temperature)
+       call mpas_pool_get_dimension(tracersPool, 'index_salinity', index_salinity)
        call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
        call mpas_pool_get_array(meshPool, 'xCell', xCell)
        call mpas_pool_get_array(meshPool, 'yCell', yCell)
@@ -200,6 +202,7 @@ contains
        call mpas_pool_get_array(meshPool,'cullCell',cullCell)
 
        call mpas_pool_get_array(statePool,'layerThickness',layerThickness,1)
+       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, 1)
        call mpas_pool_get_array(statePool,'ssh',ssh,1)
        call mpas_pool_get_array(verticalMeshPool,'restingThickness',restingThickness)
        call mpas_pool_get_array(verticalMeshPool,'refZMid',refZMid)
@@ -252,6 +255,19 @@ contains
            restingThickness(k,iCell) = layerThickness(k,iCell)
          enddo
        enddo
+       ! Set salinity
+       if ( associated(activeTracers) ) then
+         do iCell = 1, nCellsSolve
+           activeTracers(index_salinity, :, iCell) = 30.0_RKIND
+         end do
+       end if
+
+       ! Set temperature
+       if ( associated(activeTracers) ) then
+         do iCell = 1, nCellsSolve
+           activeTracers(index_temperature, :, iCell) = 10.0_RKIND
+         end do
+       end if
 
        ! Determine global min and max values.
        call mpas_dmpar_min_real(domain % dminfo, yMin, yMinGlobal)


### PR DESCRIPTION
This PR adds temperature and salinity initialization to the initialization steps for the dam break test case. This is necessary to avoid run time crashes since the fill value feature was merged https://github.com/E3SM-Project/E3SM/pull/5154.