### PR TITLE
Adds a 1D forcing testcase with BGC (ISPOL)

### DIFF
--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -319,7 +319,7 @@ Default: Defined in namelist_defaults.xml
 	category="initialize" group="initialize">
 Initial condition type for sea ice state.
 
-Valid values: 'restart', 'uniform', 'circle', 'square' or 'uniform_interior'
+Valid values: 'restart', 'uniform', 'circle', 'square', 'uniform_interior' or 'uniform_1D'
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -461,7 +461,7 @@ Default: Defined in namelist_defaults.xml
 	category="forcing" group="forcing">
 Atmospheric forcing type.
 
-Valid values: 'CORE'
+Valid values: 'CORE' or 'ISPOL'
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -501,7 +501,7 @@ Default: Defined in namelist_defaults.xml
 	category="forcing" group="forcing">
 Sea surface temperature ocean forcing type.
 
-Valid values: 'ncar'
+Valid values: 'ncar' or 'ISPOL'
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -450,7 +450,7 @@
 		/>
 		<nml_option name="config_initial_condition_type" type="character" default_value="cice_default" units="unitless"
 			description="Initial condition type for sea ice state."
-			possible_values="'restart', 'uniform', 'circle', 'square' or 'uniform_interior'"
+			possible_values="'restart', 'uniform', 'circle', 'square', 'uniform_interior', or uniform_1D"
 		/>
 		<nml_option name="config_initial_ice_area" type="real" default_value="1.0" units="unitless"
 			description="Sea ice concentration at initialization."
@@ -2110,6 +2110,54 @@
 				immutable="true">
 			<var name="iceCoverage"/>
 		</stream>
+		<stream name="ISPOLSixHourlyForcing"
+				type="input"
+				filename_template="forcing/atmosphere_forcing_six_hourly.ispol.nc"
+				filename_interval="0001-00-00_00:00:00"
+				input_interval="none"
+				reference_time="2004-01-01_00:00:00"
+				immutable="true">
+			<var name="shortwaveDown1D"/>
+			<var name="longwaveDown1D"/>
+		</stream>
+		<stream name="ISPOLDailyForcing"
+				type="input"
+				filename_template="forcing/atmosphere_forcing_daily.ispol.nc"
+				filename_interval="0001-00-00_00:00:00"
+				input_interval="none"
+				reference_time="2004-01-01_00:00:00"
+				immutable="true">
+			<var name="airTemperature1D"/>
+			<var name="airSpecificHumidity1D"/>
+			<var name="uAirVelocity1D"/>
+			<var name="vAirVelocity1D"/>
+			<var name="rainfallRate1D"/>
+		</stream>
+		<stream name="ISPOLMonthlyForcing"
+				type="input"
+				filename_template="forcing/ocean_forcing_monthly.ispol.nc"
+				filename_interval="none"
+				input_interval="none"
+				immutable="true">
+			<var name="seaSurfaceTemperature1D"/>
+			<var name="seaSurfaceSalinity1D"/>
+			<var name="oceanMixedLayerDepth1D"/>
+			<var name="uOceanVelocity1D"/>
+			<var name="vOceanVelocity1D"/>
+			<var name="seaSurfaceTiltU1D"/>
+			<var name="seaSurfaceTiltV1D"/>
+			<var name="oceanHeatFluxConvergence1D"/>
+		</stream>
+		<stream name="ISPOLDailyWOAForcing"
+				type="input"
+				filename_template="forcing/ocean_biogeochemistry_forcing_daily.ispol.nc"
+				filename_interval="0001-00-00_00:00:00"
+				input_interval="none"
+				reference_time="2004-01-01_00:00:00"
+				immutable="true">
+			<var name="oceanNitrateConc1D"/>
+			<var name="oceanSilicateConc1D"/>
+		</stream>
 
 		<!-- Aerosols input -->
 		<stream name="StandardAerosolsInput"
@@ -3737,6 +3785,52 @@
 		/>
 	</var_struct>
 
+	<!--1D atmos forcing -->
+	<var_struct name="1D_atmos_forcing" time_levs="1">
+		<var name="shortwaveDown1D"
+		     type="real"
+		     dimensions="Time"
+		     units="W m-2"
+		     description="Incoming shortwave flux (positive down)"
+		/>
+		<var name="longwaveDown1D"
+		     type="real"
+		     dimensions="Time"
+		     units="W m-2"
+		     description="Incoming longwave flux (positive down)"
+		/>
+		<var name="airTemperature1D"
+		     type="real"
+		     dimensions="Time"
+		     units="K"
+		     description="2-m air temperature"
+		/>
+		<var name="airSpecificHumidity1D"
+		     type="real"
+		     dimensions="Time"
+		     units="1"
+		     description="2-m specific humidity"
+		/>
+		<var name="uAirVelocity1D"
+		     type="real"
+		     dimensions="Time"
+		     units="m s-1"
+		     description="10-m wind velocity in the x direction"
+		/>
+		<var name="vAirVelocity1D"
+		     type="real"
+		     dimensions="Time"
+		     units="m s-1"
+		     description="10-m wind velocity in the y direction"
+		/>
+		<var name="rainfallRate1D"
+		     type="real"
+		     dimensions="Time"
+		     units="kg m-2 s-1"
+		     description="precipitation rate"
+		/>
+	</var_struct>
+
 	<!--ocean coupling -->
 	<var_struct name="ocean_coupling" time_levs="1">
 		<var name="seaSurfaceTemperature"
@@ -3803,6 +3897,73 @@
 		<var name="landIceMaskVertex"
 		     type="integer"
 		     dimensions="nVertices Time"
+		/>
+	</var_struct>
+
+	<!--1D ocean forcing -->
+	<var_struct name="1D_ocean_forcing" time_levs="1">
+		<var name="seaSurfaceTemperature1D"
+		     type="real"
+		     dimensions="Time"
+		     units="K"
+		     description="sea surface temperature"
+		/>
+		<var name="seaSurfaceSalinity1D"
+		     type="real"
+		     dimensions="Time"
+		     units="1e-3"
+		     description="sea surface salinity"
+		/>
+		<var name="uOceanVelocity1D"
+		     type="real"
+		     dimensions="Time"
+		     units="m s-1"
+		     description="ocean surface velocity in the x-direction"
+		/>
+		<var name="vOceanVelocity1D"
+		     type="real"
+		     dimensions="Time"
+		     units="m s-1"
+		     description="ocean surface velocity in the y-direction"
+		/>
+		<var name="seaSurfaceTiltU1D"
+		     type="real"
+		     dimensions="Time"
+		     units="1"
+		     description="sea surface tilt in the  x-direction"
+		/>
+		<var name="seaSurfaceTiltV1D"
+		     type="real"
+		     dimensions="Time"
+		     units="1"
+		     description="sea surface tilt in the y-direction"
+		/>
+		<var name="oceanMixedLayerDepth1D"
+		     type="real"
+		     dimensions="Time"
+		     units="m"
+		     description="ocean mixed layer depth"
+		/>
+		<var name="oceanHeatFluxConvergence1D"
+		     type="real"
+		     dimensions="Time"
+		     units="W m-2"
+		     description="deep ocean heat flux positive up"
+		/>
+	</var_struct>
+
+	<var_struct name="1D_ocean_biogeochemistry_forcing" time_levs="1">
+		<var name="oceanNitrateConc1D"
+		     type="real"
+		     dimensions="Time"
+		     units="mmol N m-3"
+		     description="sea surface nitrate"
+		/>
+		<var name="oceanSilicateConc1D"
+		     type="real"
+		     dimensions="Time"
+		     units="mmol Si m-3"
+		     description="sea surface silicate"
 		/>
 	</var_struct>
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_constants.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_constants.F
@@ -97,5 +97,21 @@ module seaice_constants
         skeletalLayerThickness = sk_l      , &
         gramsCarbonPerMolCarbon = R_gC2molC    ! g carbon per mol carbon
 
+   ! ocean biogeochemistry ISPOL values
+   real(kind=RKIND), parameter, public :: &
+         oceanAmmoniumISPOL        = 1.0_RKIND, & ! mmol N m-3
+         oceanDMSISPOL             = 0.1_RKIND, & ! mmol S m-3
+         oceanDMSPISPOL            = 0.1_RKIND, & ! mmol S m-3
+         oceanDiatomsISPOL         = 1.0_RKIND, & ! mmol N m-3
+         oceanSmallAlgaeISPOL      = 0.0057_RKIND, & ! mmol N m-3
+         oceanPhaeocystisISPOL     = 0.0027_RKIND, & ! mmol N m-3
+         oceanPolysaccharidsISPOL  = 16.2_RKIND, & ! mmol C m-3
+         oceanLipidsISPOL          = 9.0_RKIND, & ! mmol C m-3
+         oceanProteinsCarbonISPOL  = 9.0_RKIND, & ! mmol C m-3
+         oceanDICISPOL             = 1.0_RKIND, & ! mmol C m-3
+         oceanProteinsISPOL        = 12.9_RKIND, & ! mmol N m-3
+         oceanDissolvedIronISPOL   = 0.4_RKIND, & ! mmol Fe m-3
+         oceanParticulateIronISPOL = 2.0_RKIND,& ! mmol Fe m-3
+         oceanHumicsISPOL          = 1.0_RKIND ! mmol C m-3
 
 end module seaice_constants

--- a/components/mpas-seaice/src/shared/mpas_seaice_forcing.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_forcing.F
@@ -120,6 +120,8 @@ contains
     select case (trim(config_atmospheric_forcing_type))
     case ("CORE")
        call init_atmospheric_forcing_CORE(domain)
+    case ("ISPOL")
+       call init_atmospheric_forcing_ISPOL(domain)
     case ("hourly_velocities")
        call init_atmospheric_forcing_hourly_velocities(domain)
     case default
@@ -287,6 +289,183 @@ contains
          .false.)
 
   end subroutine init_atmospheric_forcing_CORE
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  init_atmospheric_forcing_ISPOL
+!
+!> \brief Initialize the forcing objects
+!> \author Nicole Jeffery, LANL
+!> \date Nov, 2022
+!> \details
+!> This routine calls the MPAS_forcing module subroutines that initializes
+!> a 1D forcing dataset. The data corresponds to the Weddell Sea (67.9S, 54W)
+!> from June 16, 2004 to December 31, 2004, and is from the 2004
+!> Ice Station Polarstern (ISPOL) field experiment.
+!
+!-----------------------------------------------------------------------
+
+  subroutine init_atmospheric_forcing_ISPOL(domain)
+
+    type(domain_type) :: domain
+
+    real(kind=RKIND), pointer :: &
+         config_dt
+
+    character(len=strKIND), pointer :: &
+         config_forcing_start_time, &
+         config_forcing_cycle_start, &
+         config_forcing_cycle_duration
+
+    logical, pointer :: &
+         config_do_restart
+
+    character(len=strKIND) :: &
+         forcingIntervalSixHourly, &
+         forcingReferenceTimeSixHourly, &
+         forcingIntervalDaily, &
+         forcingReferenceTimeDaily
+
+    ! get atmospheric forcing configuration options
+    call MPAS_pool_get_config(domain % configs, "config_forcing_start_time", config_forcing_start_time)
+    call MPAS_pool_get_config(domain % configs, "config_dt", config_dt)
+    call MPAS_pool_get_config(domain % configs, "config_forcing_cycle_start", config_forcing_cycle_start)
+    call MPAS_pool_get_config(domain % configs, "config_forcing_cycle_duration", config_forcing_cycle_duration)
+    call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
+
+    ! create the six hourly forcing group
+    call MPAS_forcing_init_group(&
+         seaiceForcingGroups, &
+         "seaice_atmospheric_forcing_sixhrly", &
+         domain, &
+         config_forcing_start_time, &
+         config_forcing_cycle_start, &
+         config_forcing_cycle_duration, &
+         config_do_restart, &
+         .false.)
+
+    forcingIntervalSixHourly = "06:00:00"
+    forcingReferenceTimeSixHourly = "2004-01-01_00:00:00"
+
+    call MPAS_forcing_init_field(&
+         domain % streamManager, &
+         seaiceForcingGroups, &
+         "seaice_atmospheric_forcing_sixhrly", &
+         "shortwaveDown1D", &
+         "ISPOLSixHourlyForcing", &
+         "1D_atmos_forcing", &
+         "shortwaveDown1D", &
+         "linear", &
+         forcingReferenceTimeSixHourly, &
+         forcingIntervalSixHourly, &
+         "next")
+
+    call MPAS_forcing_init_field(&
+         domain % streamManager, &
+         seaiceForcingGroups, &
+         "seaice_atmospheric_forcing_sixhrly", &
+         "longwaveDown1D", &
+         "ISPOLSixHourlyForcing", &
+         "1D_atmos_forcing", &
+         "longwaveDown1D", &
+         "linear", &
+         forcingReferenceTimeSixHourly, &
+         forcingIntervalSixHourly, &
+         "next")
+
+    call MPAS_forcing_init_field_data(&
+         seaiceForcingGroups, &
+         "seaice_atmospheric_forcing_sixhrly", &
+         domain % streamManager, &
+         config_do_restart, &
+         .false.)
+
+    ! create the daily forcing group
+    call MPAS_forcing_init_group(&
+         seaiceForcingGroups, &
+         "seaice_atmospheric_forcing_daily", &
+         domain, &
+         config_forcing_start_time, &
+         config_forcing_cycle_start, &
+         config_forcing_cycle_duration, &
+         config_do_restart)
+
+    forcingIntervalDaily = "00-00-01_00:00:00"
+    forcingReferenceTimeDaily = "2004-01-01_00:00:00"
+
+    call MPAS_forcing_init_field(&
+         domain % streamManager, &
+         seaiceForcingGroups, &
+         "seaice_atmospheric_forcing_daily", &
+         "airTemperature1D", &
+         "ISPOLDailyForcing", &
+         "1D_atmos_forcing", &
+         "airTemperature1D", &
+         "linear", &
+         forcingReferenceTimeDaily, &
+         forcingIntervalDaily, &
+         "next")
+
+    call MPAS_forcing_init_field(&
+         domain % streamManager, &
+         seaiceForcingGroups, &
+         "seaice_atmospheric_forcing_daily", &
+         "airSpecificHumidity1D", &
+         "ISPOLDailyForcing", &
+         "1D_atmos_forcing", &
+         "airSpecificHumidity1D", &
+         "linear", &
+         forcingReferenceTimeDaily, &
+         forcingIntervalDaily, &
+         "next")
+
+    call MPAS_forcing_init_field(&
+         domain % streamManager, &
+         seaiceForcingGroups, &
+         "seaice_atmospheric_forcing_daily", &
+         "uAirVelocity1D", &
+         "ISPOLDailyForcing", &
+         "1D_atmos_forcing", &
+         "uAirVelocity1D", &
+         "linear", &
+         forcingReferenceTimeDaily, &
+         forcingIntervalDaily, &
+         "next")
+
+    call MPAS_forcing_init_field(&
+         domain % streamManager, &
+         seaiceForcingGroups, &
+         "seaice_atmospheric_forcing_daily", &
+         "vAirVelocity1D", &
+         "ISPOLDailyForcing", &
+         "1D_atmos_forcing", &
+         "vAirVelocity1D", &
+         "linear", &
+         forcingReferenceTimeDaily, &
+         forcingIntervalDaily, &
+         "next")
+
+    call MPAS_forcing_init_field(&
+         domain % streamManager, &
+         seaiceForcingGroups, &
+         "seaice_atmospheric_forcing_daily", &
+         "rainfallRate1D", &
+         "ISPOLDailyForcing", &
+         "1D_atmos_forcing", &
+         "rainfallRate1D", &
+         "linear", &
+         forcingReferenceTimeDaily, &
+         forcingIntervalDaily, &
+         "next")
+
+    call MPAS_forcing_init_field_data(&
+         seaiceForcingGroups, &
+         "seaice_atmospheric_forcing_daily", &
+         domain % streamManager, &
+         config_do_restart, &
+         .false.)
+
+  end subroutine init_atmospheric_forcing_ISPOL
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
@@ -501,6 +680,20 @@ contains
             streamManager, &
             config_dt)
 
+    else if (trim(config_atmospheric_forcing_type) == "ISPOL") then
+
+       call MPAS_forcing_get_forcing(&
+            seaiceForcingGroups, &
+            "seaice_atmospheric_forcing_sixhrly", &
+            streamManager, &
+            config_dt)
+
+       call MPAS_forcing_get_forcing(&
+            seaiceForcingGroups, &
+            "seaice_atmospheric_forcing_daily", &
+            streamManager, &
+            config_dt)
+
     endif
 
     block => domain % blocklist
@@ -510,6 +703,8 @@ contains
        select case (trim(config_atmospheric_forcing_type))
        case ("CORE")
           call prepare_atmospheric_coupling_variables_CORE(block)
+       case ("ISPOL")
+          call prepare_atmospheric_coupling_variables_ISPOL(block)
        end select
 
        ! perform post coupling operations
@@ -689,6 +884,188 @@ contains
     enddo ! iCell
 
   end subroutine prepare_atmospheric_coupling_variables_CORE
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  prepare_atmospheric_coupling_variables_ISPOL
+!
+!> \brief
+!> \author Nicole Jeffery, LANL
+!> \date
+!> \details
+!> Defines the cell fields corresponding to the 1D forcing fields.
+!
+!-----------------------------------------------------------------------
+
+  subroutine prepare_atmospheric_coupling_variables_ISPOL(block)
+
+    use seaice_constants, only: &
+         seaiceFreshWaterFreezingPoint, &
+         pii
+
+    type (block_type), pointer :: block
+
+    type (mpas_pool_type), pointer :: &
+         mesh, &
+         atmosCoupling, &
+         atmosForcing, &
+         atmos1DForcing, &
+         oceanCoupling, &
+         tracers_aggregate
+
+    real(kind=RKIND), dimension(:), pointer :: &
+         airLevelHeight, &
+         airPotentialTemperature, &
+         airTemperature, &
+         airSpecificHumidity, &
+         airDensity, &
+         shortwaveDown, &
+         shortwaveVisibleDirectDown, &
+         shortwaveVisibleDiffuseDown, &
+         shortwaveIRDirectDown, &
+         shortwaveIRDiffuseDown, &
+         longwaveDown, &
+         rainfallRate, &
+         snowfallRate, &
+         cloudFraction, &
+         uAirVelocity, &
+         vAirVelocity, &
+         lonCell, &
+         latCell, &
+         iceAreaCell
+
+    real(kind=RKIND), pointer :: &
+         seaSurfaceTemperature1D, &
+         airTemperature1D, &
+         airSpecificHumidity1D, &
+         shortwaveDown1D, &
+         longwaveDown1D, &
+         rainfallRate1D, &
+         uAirVelocity1D, &
+         vAirVelocity1D
+
+    type (MPAS_time_type) :: &
+         currentForcingTime
+
+    real(kind=RKIND) :: &
+         secondsToday
+
+    integer, pointer :: &
+         nCellsSolve
+
+    integer :: &
+         dayOfYear, &
+         iCell
+
+    call MPAS_pool_get_subpool(block % structs, "mesh", mesh)
+    call MPAS_pool_get_subpool(block % structs, "atmos_coupling", atmosCoupling)
+    call MPAS_pool_get_subpool(block % structs, "1D_atmos_forcing", atmos1DForcing)
+    call MPAS_pool_get_subpool(block % structs, "ocean_coupling", oceanCoupling)
+    call MPAS_pool_get_subpool(block % structs, "tracers_aggregate", tracers_aggregate)
+    call MPAS_pool_get_subpool(block % structs, "atmos_forcing", atmosForcing)
+
+    call MPAS_pool_get_dimension(mesh, "nCellsSolve", nCellsSolve)
+
+    call MPAS_pool_get_array(mesh, "lonCell", lonCell)
+    call MPAS_pool_get_array(mesh, "latCell", latCell)
+
+    call MPAS_pool_get_array(atmosCoupling, "airLevelHeight", airLevelHeight)
+    call MPAS_pool_get_array(atmosCoupling, "airPotentialTemperature", airPotentialTemperature)
+    call MPAS_pool_get_array(atmosCoupling, "airTemperature", airTemperature)
+    call MPAS_pool_get_array(atmosCoupling, "airSpecificHumidity", airSpecificHumidity)
+    call MPAS_pool_get_array(atmosCoupling, "airDensity", airDensity)
+    call MPAS_pool_get_array(atmosCoupling, "shortwaveVisibleDirectDown", shortwaveVisibleDirectDown)
+    call MPAS_pool_get_array(atmosCoupling, "shortwaveVisibleDiffuseDown", shortwaveVisibleDiffuseDown)
+    call MPAS_pool_get_array(atmosCoupling, "shortwaveIRDirectDown", shortwaveIRDirectDown)
+    call MPAS_pool_get_array(atmosCoupling, "shortwaveIRDiffuseDown", shortwaveIRDiffuseDown)
+    call MPAS_pool_get_array(atmosCoupling, "longwaveDown", longwaveDown)
+    call MPAS_pool_get_array(atmosCoupling, "rainfallRate", rainfallRate)
+    call MPAS_pool_get_array(atmosCoupling, "snowfallRate", snowfallRate)
+    call MPAS_pool_get_array(atmosCoupling, "uAirVelocity", uAirVelocity)
+    call MPAS_pool_get_array(atmosCoupling, "vAirVelocity", vAirVelocity)
+    call MPAS_pool_get_array(atmos1DForcing, "airTemperature1D", airTemperature1D)
+    call MPAS_pool_get_array(atmos1DForcing, "airSpecificHumidity1D", airSpecificHumidity1D)
+    call MPAS_pool_get_array(atmos1DForcing, "shortwaveDown1D", shortwaveDown1D)
+    call MPAS_pool_get_array(atmos1DForcing, "longwaveDown1D", longwaveDown1D)
+    call MPAS_pool_get_array(atmos1DForcing, "rainfallRate1D", rainfallRate1D)
+    call MPAS_pool_get_array(atmos1DForcing, "uAirVelocity1D", uAirVelocity1D)
+    call MPAS_pool_get_array(atmos1DForcing, "vAirVelocity1D", vAirVelocity1D)
+
+    call MPAS_pool_get_array(atmosForcing, "cloudFraction", cloudFraction)
+    call MPAS_pool_get_array(atmosForcing, "shortwaveDown", shortwaveDown)
+
+    call MPAS_pool_get_array(tracers_aggregate, "iceAreaCell", iceAreaCell)
+
+    ! get the current time
+    call MPAS_forcing_get_forcing_time(&
+         seaiceForcingGroups, &
+         "seaice_atmospheric_forcing_sixhrly", &
+         currentForcingTime)
+
+    ! get the number of seconds so far today
+    call get_seconds_today(&
+         currentForcingTime, &
+         secondsToday, &
+         dayOfYear)
+
+    do iCell = 1, nCellsSolve
+
+       ! not sure if we need this
+       cloudFraction(iCell)       = 0.5_RKIND
+
+       ! define cell quantities
+       airTemperature(iCell)      = airTemperature1D
+       shortwaveDown(iCell)       = shortwaveDown1D
+       longwaveDown(iCell)        = longwaveDown1D
+       airSpecificHumidity(iCell) = airSpecificHumidity1D
+       uAirVelocity(iCell)        = uAirVelocity1D
+       vAirVelocity(iCell)        = vAirVelocity1D
+       rainfallRate(iCell)        = rainfallRate1D
+
+       ! limit air temperature values where ice is present
+       if (iceAreaCell(iCell) > 0.1_RKIND) then
+          airTemperature(iCell) = min(airTemperature(iCell), seaiceFreshWaterFreezingPoint + 0.1_RKIND)
+       endif
+
+       ! prevent supersaturated humidity
+       call limit_specific_humidity(&
+            airTemperature(iCell), &
+            airSpecificHumidity(iCell))
+
+       shortwaveVisibleDirectDown(iCell)  = shortwaveDown(iCell) * fracShortwaveVisibleDirect
+       shortwaveVisibleDiffuseDown(iCell) = shortwaveDown(iCell) * fracShortwaveVisibleDiffuse
+       shortwaveIRDirectDown(iCell)       = shortwaveDown(iCell) * fracShortwaveIRDirectDown
+       shortwaveIRDiffuseDown(iCell)      = shortwaveDown(iCell) * fracShortwaveIRDiffuseDown
+
+       ! ensure physically realistic values
+       shortwaveDown(iCell)       = max(shortwaveDown(iCell),0.0_RKIND)
+       rainfallRate(iCell)        = max(rainfallRate(iCell),0.0_RKIND)
+       airSpecificHumidity(iCell) = max(airSpecificHumidity(iCell),0.0_RKIND)
+
+       ! atmospheric level height
+       airLevelHeight(iCell) = 10.0_RKIND ! for velocities, 2-m for air T and specific humidity
+
+       ! air potential temperature
+       airPotentialTemperature(iCell) = airTemperature(iCell)
+
+       ! air density
+       airDensity(iCell) = 1.3_RKIND
+
+       ! precipitation
+
+       ! divide total precipitation between rain and snow
+       snowfallRate(iCell) = 0.0_RKIND
+
+       if (airTemperature(iCell) < seaiceFreshWaterFreezingPoint) then
+
+          snowfallRate(iCell) = rainfallRate(iCell)
+          rainfallRate(iCell) = 0.0_RKIND
+
+       endif
+
+    enddo ! iCell
+
+  end subroutine prepare_atmospheric_coupling_variables_ISPOL
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
@@ -1281,6 +1658,8 @@ contains
     select case (trim(config_forcing_sst_type))
     case ("ncar")
        call init_oceanic_forcing_ncar(domain)
+    case ("ISPOL")
+       call init_oceanic_forcing_ISPOL(domain)
     case ("hourly_velocities")
        call init_oceanic_forcing_hourly_velocities(domain)
     case default
@@ -1460,6 +1839,225 @@ contains
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
+!  init_oceanic_forcing_ISPOL
+!
+!> \brief
+!> \author Nicole Jeffery, LANL
+!> \date October 2022
+!> \details
+!> The physical data corresponds to the Weddell Sea (67.9S, 54W) location from a
+!> POP 1-degree (gx1v3) field derived from an ocean-ice simulation
+!> forced with Ice Station Polarstern (ISPOL) 2004 atmospheric data.
+!> Biogeochemical data is World Ocean Atlas (NCEP 2013) surface nutrient data.
+!
+!-----------------------------------------------------------------------
+
+  subroutine init_oceanic_forcing_ISPOL(domain)
+
+    type (domain_type) :: domain
+
+    logical, pointer :: &
+         config_do_restart, &
+         config_use_column_biogeochemistry
+
+    character(len=strKIND), pointer :: &
+         config_forcing_start_time, &
+         config_forcing_cycle_start, &
+         config_forcing_cycle_duration
+
+    character(len=strKIND) :: &
+         forcingIntervalMonthly, &
+         forcingReferenceTimeMonthly, &
+         forcingIntervaldaily, &
+         forcingReferenceTimedaily
+
+    ! get oceanic forcing configuration options
+    call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
+    call MPAS_pool_get_config(domain % configs, "config_use_column_biogeochemistry", config_use_column_biogeochemistry)
+
+    ! get ispol forcing configuration options
+    call MPAS_pool_get_config(domain % configs, "config_forcing_start_time", config_forcing_start_time)
+    call MPAS_pool_get_config(domain % configs, "config_forcing_cycle_start", config_forcing_cycle_start)
+    call MPAS_pool_get_config(domain % configs, "config_forcing_cycle_duration", config_forcing_cycle_duration)
+
+    ! create the sea surface temperature forcing group
+    call MPAS_forcing_init_group(&
+         seaiceForcingGroups, &
+         "seaice_oceanic_forcing_monthly", &
+         domain, &
+         config_forcing_start_time, &
+         config_forcing_cycle_start, &
+         config_forcing_cycle_duration, &
+         config_do_restart)
+
+    forcingIntervalMonthly = "00-01-00_00:00:00"
+    forcingReferenceTimeMonthly = "0001-01-15_00:00:00"
+
+    ! sea surface temperature
+    call MPAS_forcing_init_field(&
+         domain % streamManager, &
+         seaiceForcingGroups, &
+         "seaice_oceanic_forcing_monthly", &
+         "seaSurfaceTemperature1D", &
+         "ISPOLMonthlyForcing", &
+         "1D_ocean_forcing", &
+         "seaSurfaceTemperature1D", &
+         "linear", &
+         forcingReferenceTimeMonthly, &
+         forcingIntervalMonthly)
+
+    ! sea surface salinity
+    call MPAS_forcing_init_field(&
+         domain % streamManager, &
+         seaiceForcingGroups, &
+         "seaice_oceanic_forcing_monthly", &
+         "seaSurfaceSalinity1D", &
+         "ISPOLMonthlyForcing", &
+         "1D_ocean_forcing", &
+         "seaSurfaceSalinity1D", &
+         "linear", &
+         forcingReferenceTimeMonthly, &
+         forcingIntervalMonthly)
+
+    ! u ocean velocity
+    call MPAS_forcing_init_field(&
+         domain % streamManager, &
+         seaiceForcingGroups, &
+         "seaice_oceanic_forcing_monthly", &
+         "uOceanVelocity1D", &
+         "ISPOLMonthlyForcing", &
+         "1D_ocean_forcing", &
+         "uOceanVelocity1D", &
+         "linear", &
+         forcingReferenceTimeMonthly, &
+         forcingIntervalMonthly)
+
+    ! v ocean velocity
+    call MPAS_forcing_init_field(&
+         domain % streamManager, &
+         seaiceForcingGroups, &
+         "seaice_oceanic_forcing_monthly", &
+         "vOceanVelocity1D", &
+         "ISPOLMonthlyForcing", &
+         "1D_ocean_forcing", &
+         "vOceanVelocity1D", &
+         "linear", &
+         forcingReferenceTimeMonthly, &
+         forcingIntervalMonthly)
+
+    ! ocean mixed layer depth
+    call MPAS_forcing_init_field(&
+         domain % streamManager, &
+         seaiceForcingGroups, &
+         "seaice_oceanic_forcing_monthly", &
+         "oceanMixedLayerDepth1D", &
+         "ISPOLMonthlyForcing", &
+         "1D_ocean_forcing", &
+         "oceanMixedLayerDepth1D", &
+         "linear", &
+         forcingReferenceTimeMonthly, &
+         forcingIntervalMonthly)
+
+    ! ocean sea surface tilt
+    call MPAS_forcing_init_field(&
+         domain % streamManager, &
+         seaiceForcingGroups, &
+         "seaice_oceanic_forcing_monthly", &
+         "seaSurfaceTiltU1D", &
+         "ISPOLMonthlyForcing", &
+         "1D_ocean_forcing", &
+         "seaSurfaceTiltU1D", &
+         "linear", &
+         forcingReferenceTimeMonthly, &
+         forcingIntervalMonthly)
+
+    call MPAS_forcing_init_field(&
+         domain % streamManager, &
+         seaiceForcingGroups, &
+         "seaice_oceanic_forcing_monthly", &
+         "seaSurfaceTiltV1D", &
+         "ISPOLMonthlyForcing", &
+         "1D_ocean_forcing", &
+         "seaSurfaceTiltV1D", &
+         "linear", &
+         forcingReferenceTimeMonthly, &
+         forcingIntervalMonthly)
+
+    ! deep ocean heat flux convergence
+    call MPAS_forcing_init_field(&
+         domain % streamManager, &
+         seaiceForcingGroups, &
+         "seaice_oceanic_forcing_monthly", &
+         "oceanHeatFluxConvergence1D", &
+         "ISPOLMonthlyForcing", &
+         "1D_ocean_forcing", &
+         "oceanHeatFluxConvergence1D", &
+         "linear", &
+         forcingReferenceTimeMonthly, &
+         forcingIntervalMonthly)
+
+    call MPAS_forcing_init_field_data(&
+         seaiceForcingGroups, &
+         "seaice_oceanic_forcing_monthly", &
+         domain % streamManager, &
+         config_do_restart, &
+         .false.)
+
+    ! ocean surface biogeochemistry fields
+    if (config_use_column_biogeochemistry) then
+
+       ! create the sea surface biogeochemistry forcing group
+       call MPAS_forcing_init_group(&
+            seaiceForcingGroups, &
+            "seaice_oceanic_biogeochemistry_forcing_daily", &
+            domain, &
+            config_forcing_start_time, &
+            config_forcing_cycle_start, &
+            config_forcing_cycle_duration, &
+            config_do_restart)
+
+       forcingIntervalDaily = "00-00-01_00:00:00"
+       forcingReferenceTimeDaily = "2004-01-01_00:00:00"
+
+       ! sea surface nitrate
+       call MPAS_forcing_init_field(&
+            domain % streamManager, &
+            seaiceForcingGroups, &
+            "seaice_oceanic_biogeochemistry_forcing_daily", &
+            "oceanNitrateConc1D", &
+            "ISPOLDailyWOAForcing", &
+            "1D_ocean_biogeochemistry_forcing", &
+            "oceanNitrateConc1D", &
+            "linear", &
+            forcingReferenceTimeDaily, &
+            forcingIntervalDaily)
+
+       ! sea surface silicate
+       call MPAS_forcing_init_field(&
+            domain % streamManager, &
+            seaiceForcingGroups, &
+            "seaice_oceanic_biogeochemistry_forcing_daily", &
+            "oceanSilicateConc1D", &
+            "ISPOLDailyWOAForcing", &
+            "1D_ocean_biogeochemistry_forcing", &
+            "oceanSilicateConc1D", &
+            "linear", &
+            forcingReferenceTimeDaily, &
+            forcingIntervalDaily)
+
+       call MPAS_forcing_init_field_data(&
+            seaiceForcingGroups, &
+            "seaice_oceanic_biogeochemistry_forcing_daily", &
+            domain % streamManager, &
+            config_do_restart, &
+            .false.)
+
+    end if
+
+  end subroutine init_oceanic_forcing_ISPOL
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
 !  init_oceanic_forcing_hourly_velocities
 !
 !> \brief Initialize the forcing objects
@@ -1585,12 +2183,14 @@ contains
          config_forcing_sst_type
 
     logical, pointer :: &
-         config_do_restart
+         config_do_restart, &
+         config_use_column_biogeochemistry
 
     ! configurations
     call mpas_pool_get_config(domain % configs, 'config_dt', config_dt)
     call mpas_pool_get_config(domain % configs, 'config_forcing_sst_type', config_forcing_sst_type)
     call mpas_pool_get_config(domain % configs, 'config_do_restart', config_do_restart)
+    call mpas_pool_get_config(domain % configs, 'config_use_column_biogeochemistry', config_use_column_biogeochemistry)
 
     ! use the forcing layer to get data
     if (trim(config_forcing_sst_type) == 'ncar') then
@@ -1620,6 +2220,21 @@ contains
             streamManager, &
             config_dt)
 
+    else if (trim(config_forcing_sst_type) == 'ISPOL') then
+
+       call MPAS_forcing_get_forcing(&
+            seaiceForcingGroups, &
+            "seaice_oceanic_forcing_monthly", &
+            streamManager, &
+            config_dt)
+       if (config_use_column_biogeochemistry) &
+
+          call MPAS_forcing_get_forcing(&
+               seaiceForcingGroups, &
+               "seaice_oceanic_biogeochemistry_forcing_daily", &
+               streamManager, &
+               config_dt)
+
     endif
 
     block => domain % blocklist
@@ -1629,6 +2244,8 @@ contains
        select case (trim(config_forcing_sst_type))
        case ("ncar")
           call prepare_oceanic_coupling_variables_ncar(block, firstTimeStep)
+       case ("ISPOL")
+          call prepare_oceanic_coupling_variables_ISPOL(block, firstTimeStep)
        end select
 
        call post_oceanic_coupling(block)
@@ -1721,6 +2338,203 @@ contains
     endif
 
   end subroutine prepare_oceanic_coupling_variables_ncar
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  prepare_oceanic_coupling_variables_ISPOL
+!
+!> \brief
+!> \author Nicole Jeffery, LANL
+!> \date  October, 2022
+!> \details
+!> Defines the ocean cell fields corresponding to the 1D forcing fields.
+!
+!-----------------------------------------------------------------------
+
+  subroutine prepare_oceanic_coupling_variables_ISPOL(block, firstTimeStep)
+
+    use ice_colpkg, only: &
+         colpkg_sea_freezing_temperature
+
+    use seaice_constants, only: &
+         oceanAmmoniumISPOL, oceanDMSISPOL, oceanDMSPISPOL, oceanDiatomsISPOL, &
+         oceanSmallAlgaeISPOL, oceanPhaeocystisISPOL, oceanPolysaccharidsISPOL, &
+         oceanLipidsISPOL, oceanDICISPOL, oceanProteinsISPOL, oceanDissolvedIronISPOL, &
+         oceanParticulateIronISPOL, oceanHumicsISPOL, oceanProteinsCarbonISPOL
+
+    type (block_type), pointer :: block
+
+    logical, intent(in) :: &
+         firstTimeStep
+
+    type (mpas_pool_type), pointer :: &
+         mesh, &
+         ocean_coupling, &
+         ocean1DForcing, &
+         oceanBGCForcing, &
+         biogeochemistry
+
+    real(kind=RKIND), dimension(:,:), pointer :: &
+         oceanDONConc, &
+         oceanDICConc, &
+         oceanDOCConc, &
+         oceanAlgaeConc, &
+         oceanParticulateIronConc, &
+         oceanDissolvedIronConc
+
+    real(kind=RKIND), dimension(:), pointer :: &
+         seaSurfaceTemperature, &
+         seaSurfaceSalinity, &
+         oceanMixedLayerDepth, &
+         seaFreezingTemperature, &
+         seaSurfaceTiltU, &
+         seaSurfaceTiltV, &
+         uOceanVelocity, &
+         vOceanVelocity, &
+         oceanHeatFluxConvergence, &
+         oceanNitrateConc, &
+         oceanSilicateConc, &
+         oceanAmmoniumConc, &
+         oceanDMSConc, &
+         oceanDMSPConc, &
+         oceanHumicsConc
+
+    real(kind=RKIND), pointer :: &
+         seaSurfaceTemperature1D, &
+         seaSurfaceSalinity1D, &
+         oceanMixedLayerDepth1D, &
+         uOceanVelocity1D, &
+         vOceanVelocity1D, &
+         seaSurfaceTiltU1D, &
+         seaSurfaceTiltV1D, &
+         oceanHeatFluxConvergence1D, &
+         oceanNitrateConc1D, &
+         oceanSilicateConc1D
+
+    character(len=strKIND), pointer :: &
+         config_sea_freezing_temperature_type
+
+    logical, pointer :: &
+         config_do_restart, &
+         config_use_column_biogeochemistry
+
+    integer, pointer :: &
+         nCellsSolve, &
+         nCells
+
+    integer :: &
+         iCell
+
+    call MPAS_pool_get_config(block % configs, "config_do_restart", config_do_restart)
+    call MPAS_pool_get_config(block % configs, "config_use_column_biogeochemistry", config_use_column_biogeochemistry)
+    call MPAS_pool_get_config(block % configs, "config_sea_freezing_temperature_type", config_sea_freezing_temperature_type)
+
+    call MPAS_pool_get_subpool(block % structs, "mesh", mesh)
+    call MPAS_pool_get_subpool(block % structs, "ocean_coupling", ocean_coupling)
+    call MPAS_pool_get_subpool(block % structs, "1D_ocean_forcing", ocean1DForcing)
+
+    call MPAS_pool_get_dimension(mesh, "nCellsSolve", nCellsSolve)
+    call MPAS_pool_get_dimension(mesh, "nCells", nCells)
+
+    call MPAS_pool_get_array(ocean_coupling, "seaSurfaceTemperature", seaSurfaceTemperature)
+    call MPAS_pool_get_array(ocean_coupling, "seaSurfaceSalinity", seaSurfaceSalinity)
+    call MPAS_pool_get_array(ocean_coupling, "oceanMixedLayerDepth", oceanMixedLayerDepth)
+    call MPAS_pool_get_array(ocean_coupling, "seaFreezingTemperature", seaFreezingTemperature)
+    call MPAS_pool_get_array(ocean_coupling, "seaSurfaceTiltU", seaSurfaceTiltU)
+    call MPAS_pool_get_array(ocean_coupling, "seaSurfaceTiltV", seaSurfaceTiltV)
+    call MPAS_pool_get_array(ocean_coupling, "uOceanVelocity", uOceanVelocity)
+    call MPAS_pool_get_array(ocean_coupling, "vOceanVelocity", vOceanVelocity)
+    call MPAS_pool_get_array(ocean_coupling, "oceanHeatFluxConvergence", oceanHeatFluxConvergence)
+
+    call MPAS_pool_get_array(ocean1DForcing, "seaSurfaceTemperature1D", seaSurfaceTemperature1D)
+    call MPAS_pool_get_array(ocean1DForcing, "seaSurfaceSalinity1D", seaSurfaceSalinity1D)
+    call MPAS_pool_get_array(ocean1DForcing, "oceanMixedLayerDepth1D", oceanMixedLayerDepth1D)
+    call MPAS_pool_get_array(ocean1DForcing, "uOceanVelocity1D", uOceanVelocity1D)
+    call MPAS_pool_get_array(ocean1DForcing, "vOceanVelocity1D", vOceanVelocity1D)
+    call MPAS_pool_get_array(ocean1DForcing, "seaSurfaceTiltU1D", seaSurfaceTiltU1D)
+    call MPAS_pool_get_array(ocean1DForcing, "seaSurfaceTiltV1D", seaSurfaceTiltV1D)
+    call MPAS_pool_get_array(ocean1DForcing, "oceanHeatFluxConvergence1D", oceanHeatFluxConvergence1D)
+
+    do iCell = 1, nCellsSolve
+
+       ! define cell quantities
+       seaSurfaceTemperature(iCell) = seaSurfaceTemperature1D
+       seaSurfaceSalinity(iCell) = seaSurfaceSalinity1D
+       oceanMixedLayerDepth(iCell) = oceanMixedLayerDepth1D
+       uOceanVelocity(iCell) = uOceanVelocity1D
+       vOceanVelocity(iCell) = vOceanVelocity1D
+       oceanHeatFluxConvergence(iCell) = oceanHeatFluxConvergence1D
+       seaSurfaceTiltU(iCell) = seaSurfaceTiltU1D
+       seaSurfaceTiltV(iCell) = seaSurfaceTiltV1D
+
+       ! ensure physical realism
+       seaSurfaceSalinity(iCell)   = max(seaSurfaceSalinity(iCell), 0.0_RKIND)
+       oceanMixedLayerDepth(iCell) = max(oceanMixedLayerDepth(iCell), 0.0_RKIND)
+
+       ! sea freezing temperature
+       seaFreezingTemperature(iCell) = colpkg_sea_freezing_temperature(seaSurfaceSalinity(iCell))
+
+    enddo ! iCell
+
+    ! only update sea surface temperature on first non-restart timestep
+    if (firstTimeStep .and. .not. config_do_restart) then
+
+       do iCell = 1, nCellsSolve
+
+          ! sea surface temperature
+          seaSurfaceTemperature(iCell) = max(seaSurfaceTemperature(iCell), seaFreezingTemperature(iCell))
+
+       enddo ! iCell
+
+    endif
+
+    if (config_use_column_biogeochemistry) then
+       call MPAS_pool_get_subpool(block % structs, "biogeochemistry",biogeochemistry)
+       call MPAS_pool_get_subpool(block % structs, "1D_ocean_biogeochemistry_forcing", &
+            oceanBGCForcing)
+
+       call MPAS_pool_get_array(oceanBGCForcing, "oceanNitrateConc1D", oceanNitrateConc1D)
+       call MPAS_pool_get_array(oceanBGCForcing, "oceanSilicateConc1D", oceanSilicateConc1D)
+       call MPAS_pool_get_array(biogeochemistry, "oceanSilicateConc", oceanSilicateConc)
+       call MPAS_pool_get_array(biogeochemistry, "oceanNitrateConc", oceanNitrateConc)
+       call MPAS_pool_get_array(biogeochemistry, "oceanAlgaeConc", oceanAlgaeConc)
+       call MPAS_pool_get_array(biogeochemistry, "oceanAmmoniumConc", oceanAmmoniumConc)
+       call MPAS_pool_get_array(biogeochemistry, "oceanDMSConc", oceanDMSConc)
+       call MPAS_pool_get_array(biogeochemistry, "oceanDMSPConc", oceanDMSPConc)
+       call MPAS_pool_get_array(biogeochemistry, "oceanHumicsConc", oceanHumicsConc)
+       call MPAS_pool_get_array(biogeochemistry, "oceanDONConc", oceanDONConc)
+       call MPAS_pool_get_array(biogeochemistry, "oceanDICConc", oceanDICConc)
+       call MPAS_pool_get_array(biogeochemistry, "oceanDOCConc", oceanDOCConc)
+       call MPAS_pool_get_array(biogeochemistry, "oceanParticulateIronConc", oceanParticulateIronConc)
+       call MPAS_pool_get_array(biogeochemistry, "oceanDissolvedIronConc", oceanDissolvedIronConc)
+
+       do iCell = 1, nCellsSolve
+          ! define cell quantities
+          oceanNitrateConc(iCell) = oceanNitrateConc1D
+          oceanSilicateConc(iCell) = oceanSilicateConc1D
+       end do
+
+       if (firstTimeStep) then
+          do iCell = 1, nCellsSolve
+             oceanAmmoniumConc(iCell) = oceanAmmoniumISPOL
+             oceanDMSConc(iCell) = oceanDMSISPOL
+             oceanDMSPConc(iCell) = oceanDMSPISPOL
+             oceanAlgaeConc(:,iCell) = oceanDiatomsISPOL
+             oceanAlgaeConc(2,iCell) = oceanSmallAlgaeISPOL
+             oceanAlgaeConc(3,iCell) = oceanPhaeocystisISPOL
+             oceanDOCConc(:,iCell) = oceanPolysaccharidsISPOL
+             oceanDOCConc(2,iCell) = oceanLipidsISPOL
+             oceanDOCConc(3,iCell) = oceanProteinsCarbonISPOL
+             oceanDONConc(:,iCell) = oceanProteinsISPOL
+             oceanDICConc(:,iCell) = oceanDICISPOL
+             oceanHumicsConc(iCell) = oceanHumicsISPOL
+             oceanParticulateIronConc(:,iCell) = oceanParticulateIronISPOL
+             oceanDissolvedIronConc(:,iCell) = oceanDissolvedIronISPOL
+          enddo ! iCell
+       endif
+    end if
+
+  end subroutine prepare_oceanic_coupling_variables_ISPOL
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
@@ -317,6 +317,12 @@ contains
                   block, &
                   domain % configs)
 
+          else if (trim(config_initial_condition_type) == "uniform_1D") then
+
+             call init_ice_state_uniform_1D(&
+                  block, &
+                  domain % configs)
+
           else if (trim(config_initial_condition_type) == "special") then
 
              call init_ice_state_special(&
@@ -557,6 +563,124 @@ contains
     enddo ! iCell
 
   end subroutine init_ice_state_uniform_ice!}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  init_ice_state_uniform_1D
+!
+!> \brief
+!> \author Nicole Jeffery, LANL
+!> \date November, 2022
+!> \details
+!> Initializes sea ice in the first category only with constant
+!> values and latitude bounds defined in the namelist.
+!
+!-----------------------------------------------------------------------
+
+  subroutine init_ice_state_uniform_1D(&
+       block, &
+       configs)!{{{
+
+    use seaice_constants, only: &
+         seaiceDegreesToRadians
+
+    type(block_type), intent(inout) :: &
+         block !< Input/Output:
+
+    type (MPAS_pool_type), pointer, intent(in) :: &
+         configs !< Input:
+
+    type (MPAS_pool_type), pointer :: &
+         mesh, &
+         tracers, &
+         tracers_aggregate
+
+    integer, pointer :: &
+         nCellsSolve
+
+    real(kind=RKIND), dimension(:), pointer :: &
+         latCell
+
+    real(kind=RKIND), dimension(:,:,:), pointer :: &
+         iceAreaCategory, &
+         iceVolumeCategory, &
+         snowVolumeCategory, &
+         surfaceTemperature
+
+    real(kind=RKIND), dimension(:), pointer :: &
+         iceAreaCell, &
+         surfaceTemperatureCell
+
+    real(kind=RKIND), pointer :: &
+         config_initial_ice_area, &
+         config_initial_ice_volume, &
+         config_initial_snow_volume, &
+         config_initial_latitude_north, &
+         config_initial_latitude_south
+
+    integer :: &
+         iCell
+
+    call MPAS_pool_get_config(configs, "config_initial_ice_area", config_initial_ice_area)
+    call MPAS_pool_get_config(configs, "config_initial_ice_volume", config_initial_ice_volume)
+    call MPAS_pool_get_config(configs, "config_initial_snow_volume", config_initial_snow_volume)
+    call MPAS_pool_get_config(configs, "config_initial_latitude_north", config_initial_latitude_north)
+    call MPAS_pool_get_config(configs, "config_initial_latitude_south", config_initial_latitude_south)
+
+    call MPAS_pool_get_subpool(block % structs, "mesh", mesh)
+    call MPAS_pool_get_subpool(block % structs, "tracers", tracers)
+    call MPAS_pool_get_subpool(block % structs, "tracers_aggregate", tracers_aggregate)
+
+    call MPAS_pool_get_dimension(mesh, "nCells", nCellsSolve)
+
+    call MPAS_pool_get_array(mesh, "latCell", latCell)
+
+    call MPAS_pool_get_array(tracers, "iceAreaCategory", iceAreaCategory, 1)
+    call MPAS_pool_get_array(tracers, "iceVolumeCategory", iceVolumeCategory, 1)
+    call MPAS_pool_get_array(tracers, "snowVolumeCategory", snowVolumeCategory, 1)
+    call MPAS_pool_get_array(tracers, "surfaceTemperature", surfaceTemperature, 1)
+
+    call MPAS_pool_get_array(tracers_aggregate, "iceAreaCell", iceAreaCell)
+    call MPAS_pool_get_array(tracers_aggregate, "surfaceTemperatureCell", surfaceTemperatureCell)
+
+    do iCell = 1, nCellsSolve
+
+       if (latCell(iCell) > config_initial_latitude_north * seaiceDegreesToRadians .or. &
+           latCell(iCell) < config_initial_latitude_south * seaiceDegreesToRadians) then
+
+
+          iceAreaCategory(1,:,iCell)    = 0.0_RKIND
+          iceVolumeCategory(1,:,iCell)  = 0.0_RKIND
+          snowVolumeCategory(1,:,iCell) = 0.0_RKIND
+          surfaceTemperature(1,:,iCell) = 0.0_RKIND
+
+          ! has ice
+          iceAreaCategory(1,1,iCell)    = config_initial_ice_area
+          iceVolumeCategory(1,1,iCell)  = config_initial_ice_volume
+          snowVolumeCategory(1,1,iCell) = config_initial_snow_volume
+          surfaceTemperature(1,1,iCell) = -1.0_RKIND
+
+       else
+
+          ! no ice
+          iceAreaCategory(1,:,iCell)    = 0.0_RKIND
+          iceVolumeCategory(1,:,iCell)  = 0.0_RKIND
+          snowVolumeCategory(1,:,iCell) = 0.0_RKIND
+          surfaceTemperature(1,:,iCell) = 0.0_RKIND
+
+       endif
+
+    enddo ! iCell
+
+    ! integrated quantities
+    do iCell = 1, nCellsSolve
+
+       iceAreaCell(iCell) = sum(iceAreaCategory(1,:,iCell))
+       surfaceTemperatureCell(iCell) = -20.15_RKIND
+
+    enddo ! iCell
+
+  end subroutine init_ice_state_uniform_1D!}}}
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
@@ -584,6 +584,10 @@ contains
     use seaice_constants, only: &
          seaiceDegreesToRadians
 
+    use ice_colpkg, only: &
+         colpkg_init_trcr, &
+         colpkg_enthalpy_snow
+
     type(block_type), intent(inout) :: &
          block !< Input/Output:
 
@@ -593,19 +597,35 @@ contains
     type (MPAS_pool_type), pointer :: &
          mesh, &
          tracers, &
-         tracers_aggregate
+         tracers_aggregate, &
+         atmos_coupling, &
+         ocean_coupling, &
+         initial
 
     integer, pointer :: &
-         nCellsSolve
+         nCellsSolve, &
+         nSnowLayers, &
+         nIceLayers, &
+         nCategories
 
     real(kind=RKIND), dimension(:), pointer :: &
-         latCell
+         latCell, &
+         airTemperature, &
+         seaSurfaceTemperature, &
+         seaFreezingTemperature
+
+    real(kind=RKIND), dimension(:,:), pointer :: &
+         initialSalinityProfile, &
+         initialMeltingTemperatureProfile
 
     real(kind=RKIND), dimension(:,:,:), pointer :: &
          iceAreaCategory, &
          iceVolumeCategory, &
          snowVolumeCategory, &
-         surfaceTemperature
+         surfaceTemperature, &
+         snowEnthalpy, &
+         iceEnthalpy, &
+         iceSalinity
 
     real(kind=RKIND), dimension(:), pointer :: &
          iceAreaCell, &
@@ -619,7 +639,10 @@ contains
          config_initial_latitude_south
 
     integer :: &
-         iCell
+         iCell, &
+         iSnowLayer, &
+         iIceLayer, &
+         iCategory
 
     call MPAS_pool_get_config(configs, "config_initial_ice_area", config_initial_ice_area)
     call MPAS_pool_get_config(configs, "config_initial_ice_volume", config_initial_ice_volume)
@@ -630,8 +653,14 @@ contains
     call MPAS_pool_get_subpool(block % structs, "mesh", mesh)
     call MPAS_pool_get_subpool(block % structs, "tracers", tracers)
     call MPAS_pool_get_subpool(block % structs, "tracers_aggregate", tracers_aggregate)
+    call MPAS_pool_get_subpool(block % structs, "ocean_coupling", ocean_coupling)
+    call MPAS_pool_get_subpool(block % structs, "atmos_coupling", atmos_coupling)
+    call MPAS_pool_get_subpool(block % structs, "initial", initial)
 
     call MPAS_pool_get_dimension(mesh, "nCells", nCellsSolve)
+    call MPAS_pool_get_dimension(mesh, "nSnowLayers", nSnowLayers)
+    call MPAS_pool_get_dimension(mesh, "nIceLayers", nIceLayers)
+    call MPAS_pool_get_dimension(mesh, "nCategories", nCategories)
 
     call MPAS_pool_get_array(mesh, "latCell", latCell)
 
@@ -640,19 +669,34 @@ contains
     call MPAS_pool_get_array(tracers, "snowVolumeCategory", snowVolumeCategory, 1)
     call MPAS_pool_get_array(tracers, "surfaceTemperature", surfaceTemperature, 1)
 
+    call MPAS_pool_get_array(atmos_coupling, "airTemperature", airTemperature)
+
+    call MPAS_pool_get_array(ocean_coupling, "seaSurfaceTemperature", seaSurfaceTemperature)
+    call MPAS_pool_get_array(ocean_coupling, "seaFreezingTemperature", seaFreezingTemperature)
+
     call MPAS_pool_get_array(tracers_aggregate, "iceAreaCell", iceAreaCell)
     call MPAS_pool_get_array(tracers_aggregate, "surfaceTemperatureCell", surfaceTemperatureCell)
+    call MPAS_pool_get_array(tracers, "snowEnthalpy", snowEnthalpy, 1)
+    call MPAS_pool_get_array(tracers, "iceEnthalpy", iceEnthalpy, 1)
+    call MPAS_pool_get_array(tracers, "iceSalinity", iceSalinity, 1)
+
+    call MPAS_pool_get_array(initial, "initialSalinityProfile", initialSalinityProfile)
+    call MPAS_pool_get_array(initial, "initialMeltingTemperatureProfile", initialMeltingTemperatureProfile)
 
     do iCell = 1, nCellsSolve
 
+       iceAreaCategory(1,:,iCell)    = 0.0_RKIND
+       iceVolumeCategory(1,:,iCell)  = 0.0_RKIND
+       snowVolumeCategory(1,:,iCell) = 0.0_RKIND
+       surfaceTemperature(1,:,iCell) = seaFreezingTemperature(iCell)
+       iceEnthalpy(:,:,iCell)        = 0.0_RKIND
+
+       do iSnowLayer = 1, nSnowLayers
+          snowEnthalpy(iSnowLayer,:,iCell) = colpkg_enthalpy_snow(0.0_RKIND)
+       end do
+
        if (latCell(iCell) > config_initial_latitude_north * seaiceDegreesToRadians .or. &
            latCell(iCell) < config_initial_latitude_south * seaiceDegreesToRadians) then
-
-
-          iceAreaCategory(1,:,iCell)    = 0.0_RKIND
-          iceVolumeCategory(1,:,iCell)  = 0.0_RKIND
-          snowVolumeCategory(1,:,iCell) = 0.0_RKIND
-          surfaceTemperature(1,:,iCell) = 0.0_RKIND
 
           ! has ice
           iceAreaCategory(1,1,iCell)    = config_initial_ice_area
@@ -660,24 +704,30 @@ contains
           snowVolumeCategory(1,1,iCell) = config_initial_snow_volume
           surfaceTemperature(1,1,iCell) = -1.0_RKIND
 
-       else
-
-          ! no ice
-          iceAreaCategory(1,:,iCell)    = 0.0_RKIND
-          iceVolumeCategory(1,:,iCell)  = 0.0_RKIND
-          snowVolumeCategory(1,:,iCell) = 0.0_RKIND
-          surfaceTemperature(1,:,iCell) = 0.0_RKIND
-
+          call colpkg_init_trcr(&
+               airTemperature(iCell), &
+               seaFreezingTemperature(iCell), &
+               initialSalinityProfile(:,iCell), &
+               initialMeltingTemperatureProfile(:,iCell), &
+               surfaceTemperature(1,1,iCell), &
+               nIceLayers, &
+               nSnowLayers, &
+               iceEnthalpy(:,1,iCell), &
+               snowEnthalpy(:,1,iCell))
        endif
-
-    enddo ! iCell
+    !enddo ! iCell
 
     ! integrated quantities
-    do iCell = 1, nCellsSolve
+    !do iCell = 1, nCellsSolve
 
        iceAreaCell(iCell) = sum(iceAreaCategory(1,:,iCell))
        surfaceTemperatureCell(iCell) = -20.15_RKIND
 
+       do iCategory = 1, nCategories
+          do iIceLayer = 1, nIceLayers
+             iceSalinity(iIceLayer,iCategory,iCell) = initialSalinityProfile(iIceLayer,iCell)
+          enddo ! iIceLayer
+       enddo ! iCategory
     enddo ! iCell
 
   end subroutine init_ice_state_uniform_1D!}}}

--- a/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
@@ -715,10 +715,6 @@ contains
                iceEnthalpy(:,1,iCell), &
                snowEnthalpy(:,1,iCell))
        endif
-    !enddo ! iCell
-
-    ! integrated quantities
-    !do iCell = 1, nCellsSolve
 
        iceAreaCell(iCell) = sum(iceAreaCategory(1,:,iCell))
        surfaceTemperatureCell(iCell) = -20.15_RKIND


### PR DESCRIPTION
Atmospheric, ocean and biogeochemical data from the 2004 Ice Station Polarstern (ISPOL) Weddell Sea (67.9S, 54W) experiment from June 16, 2004 to December 31, 2004. Core 2 from the ISPOL location fills out the remainder of the year.

A uniform_1D initial condition was added for flexible initialization. A new testcase - single_cell_ispol - was added to
MPAS-Dev/MPAS-Seaice_standalone_framework to verify this forcing and initializtion. https://github.com/MPAS-Dev/MPAS-Seaice_standalone_framework/pull/15

BFB