### PR TITLE
Use double precision for constant

### DIFF
--- a/components/homme/src/theta-l/share/element_ops.F90
+++ b/components/homme/src/theta-l/share/element_ops.F90
@@ -75,7 +75,7 @@ module element_ops
   public state0
 
   ! promote this to _real_kind after V2 code freeze
-  real (kind=real_kind), public :: tref_lapse_rate=0.0065e0
+  real (kind=real_kind), public :: tref_lapse_rate=0.0065D0
 contains
 
 


### PR DESCRIPTION
This is needed for the upcomming pgrad_correction port to theta-l_kokkos. Basically, when adding the constant `tref_lapse_rate`, there were bfb issues since the F90 version was not using double precision.

This would be a non-bfb change, so if that is not ok, I could make the c++ const single precision. Let me know.