### PR TITLE
Refactor of MPAS-Seaice velocity solver

### DIFF
--- a/components/mpas-seaice/src/seaice.cmake
+++ b/components/mpas-seaice/src/seaice.cmake
@@ -60,6 +60,8 @@ list(APPEND RAW_SOURCES
   core_seaice/shared/mpas_seaice_velocity_solver_pwl.F
   core_seaice/shared/mpas_seaice_velocity_solver_variational_shared.F
   core_seaice/shared/mpas_seaice_velocity_solver_constitutive_relation.F
+  core_seaice/shared/mpas_seaice_triangle_quadrature.F
+  core_seaice/shared/mpas_seaice_wachspress_basis.F
   core_seaice/shared/mpas_seaice_forcing.F
   core_seaice/shared/mpas_seaice_initialize.F
   core_seaice/shared/mpas_seaice_testing.F

--- a/components/mpas-seaice/src/shared/Makefile
+++ b/components/mpas-seaice/src/shared/Makefile
@@ -12,6 +12,8 @@ OBJS = 	mpas_seaice_time_integration.o \
 	mpas_seaice_velocity_solver_pwl.o \
 	mpas_seaice_velocity_solver_variational_shared.o \
 	mpas_seaice_velocity_solver_constitutive_relation.o \
+	mpas_seaice_wachspress_basis.o \
+	mpas_seaice_triangle_quadrature.o \
 	mpas_seaice_forcing.o \
 	mpas_seaice_initialize.o \
 	mpas_seaice_testing.o \
@@ -48,15 +50,19 @@ mpas_seaice_velocity_solver_constitutive_relation.o: mpas_seaice_constants.o mpa
 
 mpas_seaice_forcing.o: mpas_seaice_constants.o mpas_seaice_mesh.o
 
+mpas_seaice_wachspress_basis.o: mpas_seaice_mesh.o
+
+mpas_seaice_triangle_quadrature.o:
+
 mpas_seaice_velocity_solver_weak.o: mpas_seaice_constants.o mpas_seaice_testing.o mpas_seaice_velocity_solver_constitutive_relation.o mpas_seaice_mesh_pool.o
 
 mpas_seaice_velocity_solver_variational_shared.o: mpas_seaice_constants.o
 
-mpas_seaice_velocity_solver_wachspress.o: mpas_seaice_constants.o mpas_seaice_numerics.o mpas_seaice_mesh.o mpas_seaice_testing.o mpas_seaice_velocity_solver_variational_shared.o
+mpas_seaice_velocity_solver_wachspress.o: mpas_seaice_constants.o mpas_seaice_numerics.o mpas_seaice_mesh.o mpas_seaice_testing.o mpas_seaice_velocity_solver_variational_shared.o mpas_seaice_wachspress_basis.o mpas_seaice_triangle_quadrature.o
 
 mpas_seaice_velocity_solver_pwl.o: mpas_seaice_constants.o mpas_seaice_numerics.o mpas_seaice_mesh.o mpas_seaice_testing.o mpas_seaice_velocity_solver_variational_shared.o
 
-mpas_seaice_velocity_solver_variational.o: mpas_seaice_constants.o mpas_seaice_velocity_solver_constitutive_relation.o mpas_seaice_velocity_solver_wachspress.o mpas_seaice_velocity_solver_pwl.o mpas_seaice_mesh_pool.o
+mpas_seaice_velocity_solver_variational.o: mpas_seaice_constants.o mpas_seaice_velocity_solver_constitutive_relation.o mpas_seaice_velocity_solver_wachspress.o mpas_seaice_velocity_solver_pwl.o mpas_seaice_mesh_pool.o mpas_seaice_mesh.o
 
 mpas_seaice_velocity_solver.o: mpas_seaice_constants.o mpas_seaice_mesh.o mpas_seaice_testing.o mpas_seaice_velocity_solver_weak.o mpas_seaice_velocity_solver_constitutive_relation.o mpas_seaice_velocity_solver_variational.o mpas_seaice_diagnostics.o mpas_seaice_mesh_pool.o mpas_seaice_special_boundaries.o
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_mesh.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_mesh.F
@@ -24,7 +24,8 @@ module seaice_mesh
 
   public :: &
        seaice_init_mesh, &
-       seaice_cell_vertices_at_vertex, &
+       seaice_wrapped_index, &
+       seaice_calc_local_coords, &
        seaice_normal_vectors, &
        seaice_normal_vectors_polygon, &
        seaice_dot_product_3space, &
@@ -614,12 +615,12 @@ contains
   end subroutine interior_edges
 
 !-----------------------------------------------------------------------
-! mesh searches
+! misc
 !-----------------------------------------------------------------------
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  seaice_cell_vertices_at_vertex
+!  seaice_wrapped_index
 !
 !> \brief
 !> \author Adrian K. Turner, LANL
@@ -629,60 +630,266 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_cell_vertices_at_vertex(&
-       cellVerticesAtVertex, &
-       nVertices, &
-       vertexDegree, &
-       nEdgesOnCell, &
-       verticesOnCell, &
-       cellsOnVertex)!{{{
-
-    integer, dimension(:,:), intent(out) :: &
-         cellVerticesAtVertex !< Output:
+  function seaice_wrapped_index(&
+       input, &
+       nelements) &
+       result(output)!{{{
 
     integer, intent(in) :: &
-         nVertices, & !< Input:
-         vertexDegree !< Input:
+         input, &  !< Input:
+         nelements !< Input:
+
+    integer :: output
+
+    output = modulo(input - 1, nelements) + 1
+
+  end function seaice_wrapped_index!}}}
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  seaice_calc_local_coords
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 22 October 2014
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine seaice_calc_local_coords(&
+       xLocal, &
+       yLocal, &
+       nCells, &
+       nEdgesOnCell, &
+       verticesOnCell, &
+       xVertex, &
+       yVertex, &
+       zVertex, &
+       xCell, &
+       yCell, &
+       zCell, &
+       rotateCartesianGrid, &
+       onASphere)!{{{
+
+    real(kind=RKIND), dimension(:,:), intent(out) :: &
+         xLocal, & !< Output:
+         yLocal    !< Output:
+
+    integer, intent(in) :: &
+         nCells !< Input:
 
     integer, dimension(:), intent(in) :: &
          nEdgesOnCell !< Input:
 
     integer, dimension(:,:), intent(in) :: &
-         cellsOnVertex, & !< Input:
-         verticesOnCell   !< Input:
+         verticesOnCell !< Input:
+
+    real(kind=RKIND), dimension(:), intent(in) :: &
+         xVertex, & !< Input:
+         yVertex, & !< Input:
+         zVertex, & !< Input:
+         xCell, &   !< Input:
+         yCell, &   !< Input:
+         zCell      !< Input:
+
+    logical, intent(in) :: &
+         rotateCartesianGrid, & !< Input:
+         onASphere              !< Input:
+
+    if (onASphere) then
+       call calc_local_coords_spherical(&
+            xLocal, &
+            yLocal, &
+            nCells, &
+            nEdgesOnCell, &
+            verticesOnCell, &
+            xVertex, &
+            yVertex, &
+            zVertex, &
+            xCell, &
+            yCell, &
+            zCell, &
+            rotateCartesianGrid)
+    else
+       call calc_local_coords_planar(&
+            xLocal, &
+            yLocal, &
+            nCells, &
+            nEdgesOnCell, &
+            verticesOnCell, &
+            xVertex, &
+            yVertex, &
+            zVertex, &
+            xCell, &
+            yCell, &
+            zCell)
+    endif
+
+  end subroutine seaice_calc_local_coords!}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  calc_local_coords_planar
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 2013-2014
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine calc_local_coords_planar(&
+       xLocal, &
+       yLocal, &
+       nCells, &
+       nEdgesOnCell, &
+       verticesOnCell, &
+       xVertex, &
+       yVertex, &
+       zVertex, &
+       xCell, &
+       yCell, &
+       zCell)!{{{
+
+    real(kind=RKIND), dimension(:,:), intent(out) :: &
+         xLocal, & !< Output:
+         yLocal    !< Output:
+
+    integer, intent(in) :: &
+         nCells !< Input:
+
+    integer, dimension(:), intent(in) :: &
+         nEdgesOnCell !< Input:
+
+    integer, dimension(:,:), intent(in) :: &
+         verticesOnCell !< Input:
+
+    real(kind=RKIND), dimension(:), intent(in) :: &
+         xVertex, & !< Input:
+         yVertex, & !< Input:
+         zVertex, & !< Input:
+         xCell, &   !< Input:
+         yCell, &   !< Input:
+         zCell      !< Input:
 
     integer :: &
-         iVertex, &
-         iVertexDegree, &
          iCell, &
-         iVertexOnCell, &
-         jVertex
+         iVertex, &
+         iVertexOnCell
 
-    do iVertex = 1, nVertices
+    do iCell = 1, nCells
 
-       do iVertexDegree = 1, vertexDegree
+       do iVertexOnCell = 1, nEdgesOnCell(iCell)
 
-          cellVerticesAtVertex(iVertexDegree,iVertex) = 0
+          iVertex = verticesOnCell(iVertexOnCell, iCell)
 
-          iCell = cellsOnVertex(iVertexDegree, iVertex)
+          xLocal(iVertexOnCell,iCell) = xVertex(iVertex) - xCell(iCell)
+          yLocal(iVertexOnCell,iCell) = yVertex(iVertex) - yCell(iCell)
 
-          do iVertexOnCell = 1, nEdgesOnCell(iCell)
+       enddo ! iVertexOnCell
 
-             jVertex = verticesOnCell(iVertexOnCell,iCell)
+    enddo ! iCell
 
-             if (iVertex == jVertex) then
+  end subroutine calc_local_coords_planar!}}}
 
-                cellVerticesAtVertex(iVertexDegree,iVertex) = iVertexOnCell
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  calc_local_coords_spherical
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 22 October 2014
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
 
-             endif
+  subroutine calc_local_coords_spherical(&
+       xLocal, &
+       yLocal, &
+       nCells, &
+       nEdgesOnCell, &
+       verticesOnCell, &
+       xVertex, &
+       yVertex, &
+       zVertex, &
+       xCell, &
+       yCell, &
+       zCell, &
+       rotateCartesianGrid)!{{{
 
-          enddo ! iVertexOnCell
+    real(kind=RKIND), dimension(:,:), intent(out) :: &
+         xLocal, & !< Output:
+         yLocal    !< Output:
 
-       enddo ! iVertexDegree
+    integer, intent(in) :: &
+         nCells !< Input:
 
-    enddo ! iVertex
+    integer, dimension(:), intent(in) :: &
+         nEdgesOnCell !< Input:
 
-  end subroutine seaice_cell_vertices_at_vertex!}}}
+    integer, dimension(:,:), intent(in) :: &
+         verticesOnCell !< Input:
+
+    real(kind=RKIND), dimension(:), intent(in) :: &
+         xVertex, & !< Input:
+         yVertex, & !< Input:
+         zVertex, & !< Input:
+         xCell, &   !< Input:
+         yCell, &   !< Input:
+         zCell      !< Input:
+
+    logical, intent(in) :: &
+         rotateCartesianGrid !< Input:
+
+    real(kind=RKIND), dimension(3) :: &
+         normalVector3D
+
+    real(kind=RKIND), dimension(2) :: &
+         normalVector2D
+
+    integer :: &
+         iCell, &
+         iVertex, &
+         iVertexOnCell
+
+    real(kind=RKIND) :: &
+         xCellRotated, &
+         yCellRotated, &
+         zCellRotated
+
+    do iCell = 1, nCells
+
+       call seaice_grid_rotation_forward(&
+            xCellRotated, yCellRotated, zCellRotated, &
+            xCell(iCell), yCell(iCell), zCell(iCell), &
+            rotateCartesianGrid)
+
+       do iVertexOnCell = 1, nEdgesOnCell(iCell)
+
+          iVertex = verticesOnCell(iVertexOnCell, iCell)
+
+          call seaice_grid_rotation_forward(&
+               normalVector3D(1), normalVector3D(2), normalVector3D(3), &
+               xVertex(iVertex),  yVertex(iVertex),  zVertex(iVertex), &
+               rotateCartesianGrid)
+
+          call seaice_project_3D_vector_onto_local_2D(&
+               normalVector2D, &
+               normalVector3D, &
+               xCellRotated, &
+               yCellRotated, &
+               zCellRotated)
+
+          xLocal(iVertexOnCell,iCell) = normalVector2D(1)
+          yLocal(iVertexOnCell,iCell) = normalVector2D(2)
+
+       enddo ! iVertexOnCell
+
+    enddo ! iCell
+
+  end subroutine calc_local_coords_spherical!}}}
 
 !-----------------------------------------------------------------------
 ! normal vectors

--- a/components/mpas-seaice/src/shared/mpas_seaice_triangle_quadrature.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_triangle_quadrature.F
@@ -1,0 +1,761 @@
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  seaice_triangle_quadrature
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 4th November 2022
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+module seaice_triangle_quadrature
+
+  use mpas_derived_types
+  use mpas_log, only: mpas_log_write
+
+  implicit none
+
+  private
+  save
+
+  public :: &
+       seaice_triangle_quadrature_rules
+
+contains
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  seaice_triangle_quadrature_rules
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 18th October 2016
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine seaice_triangle_quadrature_rules(&
+       integrationType, &
+       integrationOrder, &
+       nIntegrationPoints, &
+       u, &
+       v, &
+       weights, &
+       normalizationFactor)
+
+    character(len=strKIND), intent(in) :: &
+         integrationType
+
+    integer, intent(in) :: &
+         integrationOrder
+
+    integer, intent(out) :: &
+         nIntegrationPoints
+
+    real(kind=RKIND), dimension(:), allocatable, intent(out) :: &
+         u, &
+         v, &
+         weights
+
+    real(kind=RKIND), intent(out) :: &
+         normalizationFactor
+
+    if (trim(integrationType) == "trapezoidal") then
+
+       call triangle_quadrature_rules_trapezoidal(&
+            integrationOrder, &
+            nIntegrationPoints, &
+            u, &
+            v, &
+            weights, &
+            normalizationFactor)
+
+    else if (trim(integrationType) == "dunavant") then
+
+       call triangle_quadrature_rules_dunavant(&
+            integrationOrder, &
+            nIntegrationPoints, &
+            u, &
+            v, &
+            weights, &
+            normalizationFactor)
+
+    else if (trim(integrationType) == "fekete") then
+
+       call triangle_quadrature_rules_fekete(&
+            integrationOrder, &
+            nIntegrationPoints, &
+            u, &
+            v, &
+            weights, &
+            normalizationFactor)
+
+    else
+
+       ! unknown integration type
+       call mpas_log_write("seaice_triangle_quadrature_rules: Unknown triangle quadrature type: "//trim(integrationType), MPAS_LOG_CRIT)
+
+    endif
+
+  end subroutine seaice_triangle_quadrature_rules
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  triangle_quadrature_rules_trapezoidal
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 18th October 2016
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine triangle_quadrature_rules_trapezoidal(&
+       integrationOrder, &
+       nIntegrationPoints, &
+       u, &
+       v, &
+       weights, &
+       normalizationFactor)
+
+    integer, intent(in) :: &
+         integrationOrder
+
+    integer, intent(out) :: &
+         nIntegrationPoints
+
+    real(kind=RKIND), dimension(:), allocatable, intent(out) :: &
+         u, &
+         v, &
+         weights
+
+    real(kind=RKIND), intent(out) :: &
+         normalizationFactor
+
+    integer :: &
+         nIntegrationTriangles
+
+    integer :: &
+         i, j, ij
+
+    nIntegrationTriangles = integrationOrder
+
+    ! total number of integration points in sub triangle
+    nIntegrationPoints = ((nIntegrationTriangles+1)**2 + (nIntegrationTriangles+1)) / 2
+
+    ! allocate integration factors
+    allocate(u(nIntegrationPoints))
+    allocate(v(nIntegrationPoints))
+    allocate(weights(nIntegrationPoints))
+
+    ! get integration point canonical location
+    ij = 1
+    do i = 0, nIntegrationTriangles
+       do j = 0, nIntegrationTriangles-i
+
+          u(ij) = real(i,RKIND) / real(nIntegrationTriangles,RKIND)
+          v(ij) = real(j,RKIND) / real(nIntegrationTriangles,RKIND)
+
+          ij = ij + 1
+
+       enddo ! j
+    enddo ! i
+
+    ! get the weights
+    ij = 1
+    do i = 0, nIntegrationTriangles
+       do j = 0, nIntegrationTriangles-i
+
+          weights(ij) = 0.0_RKIND
+
+          if (i<=nIntegrationTriangles-j) then
+
+             if (i==nIntegrationTriangles .or. j==nIntegrationTriangles .or. (i==0 .and. j==0)) then
+
+                weights(ij) = 1.0_RKIND
+
+             else if ((j==0 .and. i/=0 .and. i/=nIntegrationTriangles) .or. &
+                      (i==0 .and. j/=0 .and. j/=nIntegrationTriangles) .or. &
+                      (i==nIntegrationTriangles-j .and. i/=0 .and. j/=0)) then
+
+                weights(ij) = 3.0_RKIND
+
+             else
+
+                weights(ij) = 6.0_RKIND
+
+             endif
+
+          endif
+
+          ij = ij + 1
+
+       enddo ! j
+    enddo ! i
+
+    ! normalization factor
+    normalizationFactor = 6.0_RKIND * real(nIntegrationTriangles,RKIND)**2
+
+  end subroutine triangle_quadrature_rules_trapezoidal
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  triangle_quadrature_rules_dunavant
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 18th October 2016
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine triangle_quadrature_rules_dunavant(&
+       integrationOrder, &
+       nIntegrationPoints, &
+       u, &
+       v, &
+       weights, &
+       normalizationFactor)
+
+    integer, intent(in) :: &
+         integrationOrder
+
+    integer, intent(out) :: &
+         nIntegrationPoints
+
+    real(kind=RKIND), dimension(:), allocatable, intent(out) :: &
+         u, &
+         v, &
+         weights
+
+    real(kind=RKIND), intent(out) :: &
+         normalizationFactor
+
+    ! D. A. Dunavant, High degree efficient symmetrical Gaussian quadrature rules for the triangle,
+    ! Int. J. Num. Meth. Engng, 21(1985):1129-1148.
+
+    normalizationFactor = 2.0_RKIND
+
+    if (modulo(integrationOrder,2) /= 0) then
+       call mpas_log_write("get_integration_factors_dunavant: odd orders of integration not recommended", MPAS_LOG_WARN)
+    endif
+
+    select case (integrationOrder)
+    case(1)
+
+       nIntegrationPoints = 1
+
+       allocate(u(nIntegrationPoints))
+       allocate(v(nIntegrationPoints))
+       allocate(weights(nIntegrationPoints))
+
+       u = (/ &
+            0.33333333333333_RKIND /)
+
+       v = (/ &
+            0.33333333333333_RKIND /)
+
+       weights = (/ &
+            1.00000000000000_RKIND /)
+
+    case (2)
+
+       nIntegrationPoints = 3
+
+       allocate(u(nIntegrationPoints))
+       allocate(v(nIntegrationPoints))
+       allocate(weights(nIntegrationPoints))
+
+       u = (/ &
+            0.16666666666667_RKIND, 0.16666666666667_RKIND, 0.66666666666667_RKIND /)
+
+       v = (/ &
+            0.16666666666667_RKIND, 0.66666666666667_RKIND, 0.16666666666667_RKIND /)
+
+       weights = (/ &
+            0.33333333333333_RKIND, 0.33333333333333_RKIND, 0.33333333333333_RKIND /)
+
+    case (3)
+
+       nIntegrationPoints = 4
+
+       allocate(u(nIntegrationPoints))
+       allocate(v(nIntegrationPoints))
+       allocate(weights(nIntegrationPoints))
+
+       u = (/ &
+            0.33333333333333_RKIND, 0.20000000000000_RKIND, 0.20000000000000_RKIND, 0.60000000000000_RKIND /)
+
+       v = (/ &
+            0.33333333333333_RKIND, 0.20000000000000_RKIND, 0.60000000000000_RKIND, 0.20000000000000_RKIND /)
+
+       weights = (/ &
+           -0.56250000000000_RKIND, 0.52083333333333_RKIND, 0.52083333333333_RKIND, 0.52083333333333_RKIND /)
+
+    case (4)
+
+       nIntegrationPoints = 6
+
+       allocate(u(nIntegrationPoints))
+       allocate(v(nIntegrationPoints))
+       allocate(weights(nIntegrationPoints))
+
+       u = (/ &
+            0.44594849091597_RKIND, 0.44594849091597_RKIND, 0.10810301816807_RKIND, 0.09157621350977_RKIND, &
+            0.09157621350977_RKIND, 0.81684757298046_RKIND /)
+
+       v = (/ &
+            0.44594849091597_RKIND, 0.10810301816807_RKIND, 0.44594849091597_RKIND, 0.09157621350977_RKIND, &
+            0.81684757298046_RKIND, 0.09157621350977_RKIND /)
+
+       weights = (/ &
+            0.22338158967801_RKIND, 0.22338158967801_RKIND, 0.22338158967801_RKIND, 0.10995174365532_RKIND, &
+            0.10995174365532_RKIND, 0.10995174365532_RKIND /)
+
+    case (5)
+
+       nIntegrationPoints = 7
+
+       allocate(u(nIntegrationPoints))
+       allocate(v(nIntegrationPoints))
+       allocate(weights(nIntegrationPoints))
+
+       u = (/ &
+            0.33333333333333_RKIND, 0.47014206410511_RKIND, 0.47014206410511_RKIND, 0.05971587178977_RKIND, &
+            0.10128650732346_RKIND, 0.10128650732346_RKIND, 0.79742698535309_RKIND /)
+
+       v = (/ &
+            0.33333333333333_RKIND, 0.47014206410511_RKIND, 0.05971587178977_RKIND, 0.47014206410511_RKIND, &
+            0.10128650732346_RKIND, 0.79742698535309_RKIND, 0.10128650732346_RKIND /)
+
+       weights = (/ &
+            0.22500000000000_RKIND, 0.13239415278851_RKIND, 0.13239415278851_RKIND, 0.13239415278851_RKIND, &
+            0.12593918054483_RKIND, 0.12593918054483_RKIND, 0.12593918054483_RKIND /)
+
+    case (6)
+
+       nIntegrationPoints = 12
+
+       allocate(u(nIntegrationPoints))
+       allocate(v(nIntegrationPoints))
+       allocate(weights(nIntegrationPoints))
+
+       u = (/ &
+            0.24928674517091_RKIND, 0.24928674517091_RKIND, 0.50142650965818_RKIND, 0.06308901449150_RKIND, &
+            0.06308901449150_RKIND, 0.87382197101700_RKIND, 0.31035245103378_RKIND, 0.63650249912140_RKIND, &
+            0.05314504984482_RKIND, 0.63650249912140_RKIND, 0.31035245103378_RKIND, 0.05314504984482_RKIND /)
+
+       v = (/ &
+            0.24928674517091_RKIND, 0.50142650965818_RKIND, 0.24928674517091_RKIND, 0.06308901449150_RKIND, &
+            0.87382197101700_RKIND, 0.06308901449150_RKIND, 0.63650249912140_RKIND, 0.05314504984482_RKIND, &
+            0.31035245103378_RKIND, 0.31035245103378_RKIND, 0.05314504984482_RKIND, 0.63650249912140_RKIND /)
+
+       weights = (/ &
+            0.11678627572638_RKIND, 0.11678627572638_RKIND, 0.11678627572638_RKIND, 0.05084490637021_RKIND, &
+            0.05084490637021_RKIND, 0.05084490637021_RKIND, 0.08285107561837_RKIND, 0.08285107561837_RKIND, &
+            0.08285107561837_RKIND, 0.08285107561837_RKIND, 0.08285107561837_RKIND, 0.08285107561837_RKIND /)
+
+    case (7)
+
+       nIntegrationPoints = 13
+
+       allocate(u(nIntegrationPoints))
+       allocate(v(nIntegrationPoints))
+       allocate(weights(nIntegrationPoints))
+
+       u = (/ &
+            0.33333333333333_RKIND, 0.26034596607904_RKIND, 0.26034596607904_RKIND, 0.47930806784192_RKIND, &
+            0.06513010290222_RKIND, 0.06513010290222_RKIND, 0.86973979419557_RKIND, 0.31286549600487_RKIND, &
+            0.63844418856981_RKIND, 0.04869031542532_RKIND, 0.63844418856981_RKIND, 0.31286549600487_RKIND, &
+            0.04869031542532_RKIND /)
+
+       v = (/ &
+            0.33333333333333_RKIND, 0.26034596607904_RKIND, 0.47930806784192_RKIND, 0.26034596607904_RKIND, &
+            0.06513010290222_RKIND, 0.86973979419557_RKIND, 0.06513010290222_RKIND, 0.63844418856981_RKIND, &
+            0.04869031542532_RKIND, 0.31286549600487_RKIND, 0.31286549600487_RKIND, 0.04869031542532_RKIND, &
+            0.63844418856981_RKIND /)
+
+       weights = (/ &
+           -0.14957004446768_RKIND, 0.17561525743321_RKIND, 0.17561525743321_RKIND, 0.17561525743321_RKIND, &
+            0.05334723560884_RKIND, 0.05334723560884_RKIND, 0.05334723560884_RKIND, 0.07711376089026_RKIND, &
+            0.07711376089026_RKIND, 0.07711376089026_RKIND, 0.07711376089026_RKIND, 0.07711376089026_RKIND, &
+            0.07711376089026_RKIND /)
+
+    case (8)
+
+       nIntegrationPoints = 16
+
+       allocate(u(nIntegrationPoints))
+       allocate(v(nIntegrationPoints))
+       allocate(weights(nIntegrationPoints))
+
+       u = (/ &
+            0.33333333333333_RKIND, 0.45929258829272_RKIND, 0.45929258829272_RKIND, 0.08141482341455_RKIND, &
+            0.17056930775176_RKIND, 0.17056930775176_RKIND, 0.65886138449648_RKIND, 0.05054722831703_RKIND, &
+            0.05054722831703_RKIND, 0.89890554336594_RKIND, 0.26311282963464_RKIND, 0.72849239295540_RKIND, &
+            0.00839477740996_RKIND, 0.72849239295540_RKIND, 0.26311282963464_RKIND, 0.00839477740996_RKIND /)
+
+       v = (/ &
+            0.33333333333333_RKIND, 0.45929258829272_RKIND, 0.08141482341455_RKIND, 0.45929258829272_RKIND, &
+            0.17056930775176_RKIND, 0.65886138449648_RKIND, 0.17056930775176_RKIND, 0.05054722831703_RKIND, &
+            0.89890554336594_RKIND, 0.05054722831703_RKIND, 0.72849239295540_RKIND, 0.00839477740996_RKIND, &
+            0.26311282963464_RKIND, 0.26311282963464_RKIND, 0.00839477740996_RKIND, 0.72849239295540_RKIND /)
+
+       weights = (/ &
+            0.14431560767779_RKIND, 0.09509163426728_RKIND, 0.09509163426728_RKIND, 0.09509163426728_RKIND, &
+            0.10321737053472_RKIND, 0.10321737053472_RKIND, 0.10321737053472_RKIND, 0.03245849762320_RKIND, &
+            0.03245849762320_RKIND, 0.03245849762320_RKIND, 0.02723031417443_RKIND, 0.02723031417443_RKIND, &
+            0.02723031417443_RKIND, 0.02723031417443_RKIND, 0.02723031417443_RKIND, 0.02723031417443_RKIND /)
+
+    case (9)
+
+       nIntegrationPoints = 19
+
+       allocate(u(nIntegrationPoints))
+       allocate(v(nIntegrationPoints))
+       allocate(weights(nIntegrationPoints))
+
+       u = (/ &
+            0.333333333333333_RKIND, 0.020634961602525_RKIND, 0.489682519198738_RKIND, 0.489682519198738_RKIND, &
+            0.125820817014127_RKIND, 0.437089591492937_RKIND, 0.437089591492937_RKIND, 0.623592928761935_RKIND, &
+            0.188203535619033_RKIND, 0.188203535619033_RKIND, 0.910540973211095_RKIND, 0.044729513394453_RKIND, &
+            0.044729513394453_RKIND, 0.036838412054736_RKIND, 0.221962989160766_RKIND, 0.036838412054736_RKIND, &
+            0.741198598784498_RKIND, 0.221962989160766_RKIND, 0.741198598784498_RKIND /)
+
+       v = (/ &
+            0.333333333333333_RKIND, 0.489682519198738_RKIND, 0.020634961602525_RKIND, 0.489682519198738_RKIND, &
+            0.437089591492937_RKIND, 0.125820817014127_RKIND, 0.437089591492937_RKIND, 0.188203535619033_RKIND, &
+            0.623592928761935_RKIND, 0.188203535619033_RKIND, 0.044729513394453_RKIND, 0.910540973211095_RKIND, &
+            0.044729513394453_RKIND, 0.221962989160766_RKIND, 0.036838412054736_RKIND, 0.741198598784498_RKIND, &
+            0.036838412054736_RKIND, 0.741198598784498_RKIND, 0.221962989160766_RKIND /)
+
+       weights = (/ &
+            0.097135796282799_RKIND, 0.031334700227139_RKIND, 0.031334700227139_RKIND, 0.031334700227139_RKIND, &
+            0.077827541004774_RKIND, 0.077827541004774_RKIND, 0.077827541004774_RKIND, 0.079647738927210_RKIND, &
+            0.079647738927210_RKIND, 0.079647738927210_RKIND, 0.025577675658698_RKIND, 0.025577675658698_RKIND, &
+            0.025577675658698_RKIND, 0.043283539377289_RKIND, 0.043283539377289_RKIND, 0.043283539377289_RKIND, &
+            0.043283539377289_RKIND, 0.043283539377289_RKIND, 0.043283539377289_RKIND /)
+
+    case (10)
+
+       nIntegrationPoints = 25
+
+       allocate(u(nIntegrationPoints))
+       allocate(v(nIntegrationPoints))
+       allocate(weights(nIntegrationPoints))
+
+       u = (/ &
+            0.333333333333333_RKIND, 0.028844733232685_RKIND, 0.485577633383657_RKIND, 0.485577633383657_RKIND, &
+            0.781036849029926_RKIND, 0.109481575485037_RKIND, 0.109481575485037_RKIND, 0.141707219414880_RKIND, &
+            0.307939838764121_RKIND, 0.141707219414880_RKIND, 0.550352941820999_RKIND, 0.307939838764121_RKIND, &
+            0.550352941820999_RKIND, 0.025003534762686_RKIND, 0.246672560639903_RKIND, 0.025003534762686_RKIND, &
+            0.728323904597411_RKIND, 0.246672560639903_RKIND, 0.728323904597411_RKIND, 0.009540815400299_RKIND, &
+            0.066803251012200_RKIND, 0.009540815400299_RKIND, 0.923655933587500_RKIND, 0.066803251012200_RKIND, &
+            0.923655933587500_RKIND /)
+
+       v = (/ &
+            0.333333333333333_RKIND, 0.485577633383657_RKIND, 0.028844733232685_RKIND, 0.485577633383657_RKIND, &
+            0.109481575485037_RKIND, 0.781036849029926_RKIND, 0.109481575485037_RKIND, 0.307939838764121_RKIND, &
+            0.141707219414880_RKIND, 0.550352941820999_RKIND, 0.141707219414880_RKIND, 0.550352941820999_RKIND, &
+            0.307939838764121_RKIND, 0.246672560639903_RKIND, 0.025003534762686_RKIND, 0.728323904597411_RKIND, &
+            0.025003534762686_RKIND, 0.728323904597411_RKIND, 0.246672560639903_RKIND, 0.066803251012200_RKIND, &
+            0.009540815400299_RKIND, 0.923655933587500_RKIND, 0.009540815400299_RKIND, 0.923655933587500_RKIND, &
+            0.066803251012200_RKIND /)
+
+       weights = (/ &
+            0.090817990382754_RKIND, 0.036725957756467_RKIND, 0.036725957756467_RKIND, 0.036725957756467_RKIND, &
+            0.045321059435528_RKIND, 0.045321059435528_RKIND, 0.045321059435528_RKIND, 0.072757916845420_RKIND, &
+            0.072757916845420_RKIND, 0.072757916845420_RKIND, 0.072757916845420_RKIND, 0.072757916845420_RKIND, &
+            0.072757916845420_RKIND, 0.028327242531057_RKIND, 0.028327242531057_RKIND, 0.028327242531057_RKIND, &
+            0.028327242531057_RKIND, 0.028327242531057_RKIND, 0.028327242531057_RKIND, 0.009421666963733_RKIND, &
+            0.009421666963733_RKIND, 0.009421666963733_RKIND, 0.009421666963733_RKIND, 0.009421666963733_RKIND, &
+            0.009421666963733_RKIND /)
+
+    case (12)
+
+       nIntegrationPoints = 33
+
+       allocate(u(nIntegrationPoints))
+       allocate(v(nIntegrationPoints))
+       allocate(weights(nIntegrationPoints))
+
+       u = (/ &
+            0.023565220452390_RKIND, 0.488217389773805_RKIND, 0.488217389773805_RKIND, 0.120551215411079_RKIND, &
+            0.439724392294460_RKIND, 0.439724392294460_RKIND, 0.457579229975768_RKIND, 0.271210385012116_RKIND, &
+            0.271210385012116_RKIND, 0.744847708916828_RKIND, 0.127576145541586_RKIND, 0.127576145541586_RKIND, &
+            0.957365299093579_RKIND, 0.021317350453210_RKIND, 0.021317350453210_RKIND, 0.115343494534698_RKIND, &
+            0.275713269685514_RKIND, 0.115343494534698_RKIND, 0.608943235779788_RKIND, 0.275713269685514_RKIND, &
+            0.608943235779788_RKIND, 0.022838332222257_RKIND, 0.281325580989940_RKIND, 0.022838332222257_RKIND, &
+            0.695836086787803_RKIND, 0.281325580989940_RKIND, 0.695836086787803_RKIND, 0.025734050548330_RKIND, &
+            0.116251915907597_RKIND, 0.025734050548330_RKIND, 0.858014033544073_RKIND, 0.116251915907597_RKIND, &
+            0.858014033544073_RKIND /)
+
+       v = (/ &
+            0.488217389773805_RKIND, 0.023565220452390_RKIND, 0.488217389773805_RKIND, 0.439724392294460_RKIND, &
+            0.120551215411079_RKIND, 0.439724392294460_RKIND, 0.271210385012116_RKIND, 0.457579229975768_RKIND, &
+            0.271210385012116_RKIND, 0.127576145541586_RKIND, 0.744847708916828_RKIND, 0.127576145541586_RKIND, &
+            0.021317350453210_RKIND, 0.957365299093579_RKIND, 0.021317350453210_RKIND, 0.275713269685514_RKIND, &
+            0.115343494534698_RKIND, 0.608943235779788_RKIND, 0.115343494534698_RKIND, 0.608943235779788_RKIND, &
+            0.275713269685514_RKIND, 0.281325580989940_RKIND, 0.022838332222257_RKIND, 0.695836086787803_RKIND, &
+            0.022838332222257_RKIND, 0.695836086787803_RKIND, 0.281325580989940_RKIND, 0.116251915907597_RKIND, &
+            0.025734050548330_RKIND, 0.858014033544073_RKIND, 0.025734050548330_RKIND, 0.858014033544073_RKIND, &
+            0.116251915907597_RKIND /)
+
+       weights = (/ &
+            0.025731066440455_RKIND, 0.025731066440455_RKIND, 0.025731066440455_RKIND, 0.043692544538038_RKIND, &
+            0.043692544538038_RKIND, 0.043692544538038_RKIND, 0.062858224217885_RKIND, 0.062858224217885_RKIND, &
+            0.062858224217885_RKIND, 0.034796112930709_RKIND, 0.034796112930709_RKIND, 0.034796112930709_RKIND, &
+            0.006166261051559_RKIND, 0.006166261051559_RKIND, 0.006166261051559_RKIND, 0.040371557766381_RKIND, &
+            0.040371557766381_RKIND, 0.040371557766381_RKIND, 0.040371557766381_RKIND, 0.040371557766381_RKIND, &
+            0.040371557766381_RKIND, 0.022356773202303_RKIND, 0.022356773202303_RKIND, 0.022356773202303_RKIND, &
+            0.022356773202303_RKIND, 0.022356773202303_RKIND, 0.022356773202303_RKIND, 0.017316231108659_RKIND, &
+            0.017316231108659_RKIND, 0.017316231108659_RKIND, 0.017316231108659_RKIND, 0.017316231108659_RKIND, &
+            0.017316231108659_RKIND /)
+
+    case default
+
+       call mpas_log_write(&
+            "get_integration_factors_dunavant: Unimplemented integration order for Dunavant wachspress integration", &
+            MPAS_LOG_CRIT)
+
+    end select
+
+  end subroutine triangle_quadrature_rules_dunavant
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  triangle_quadrature_rules_fekete
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 18th October 2016
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine triangle_quadrature_rules_fekete(&
+       integrationOrder, &
+       nIntegrationPoints, &
+       u, &
+       v, &
+       weights, &
+       normalizationFactor)
+
+    integer, intent(in) :: &
+         integrationOrder
+
+    integer, intent(out) :: &
+         nIntegrationPoints
+
+    real(kind=RKIND), dimension(:), allocatable, intent(out) :: &
+         u, &
+         v, &
+         weights
+
+    real(kind=RKIND), intent(out) :: &
+         normalizationFactor
+
+    ! M. A. TAYLOR, B. A. WINGATE, AND R. E. VINCENT, (200), "AN ALGORITHM FOR COMPUTING FEKETE POINTS IN THE TRIANGLE",
+    ! SIAM J. NUMER. ANAL., Vol. 38, No. 5, pp. 1707–1720
+
+    normalizationFactor = 2.0_RKIND
+
+    select case (integrationOrder)
+    case (1)
+
+       nIntegrationPoints = 1
+
+       allocate(u(nIntegrationPoints))
+       allocate(v(nIntegrationPoints))
+       allocate(weights(nIntegrationPoints))
+
+       u = (/ &
+            3.33333333333333333e-01_RKIND /)
+
+       v = (/ &
+            3.33333333333333333e-01_RKIND /)
+
+       weights = (/ &
+            1.0_RKIND /)
+
+    case (2)
+
+       nIntegrationPoints = 3
+
+       allocate(u(nIntegrationPoints))
+       allocate(v(nIntegrationPoints))
+       allocate(weights(nIntegrationPoints))
+
+       u = (/ &
+            1.66666666666666666e-01_RKIND, 6.66666666666666666e-01_RKIND, 1.66666666666666666e-01_RKIND /)
+
+       v = (/ &
+            6.66666666666666666e-01_RKIND, 1.66666666666666666e-01_RKIND, 1.66666666666666666e-01_RKIND /)
+
+       weights = (/ &
+            3.33333333333333333e-01_RKIND, 3.33333333333333333e-01_RKIND, 3.33333333333333333e-01_RKIND /)
+
+    case (3:4)
+
+       nIntegrationPoints = 6
+
+       allocate(u(nIntegrationPoints))
+       allocate(v(nIntegrationPoints))
+       allocate(weights(nIntegrationPoints))
+
+       u = (/ &
+            9.15762135097704655e-02_RKIND, 8.16847572980458514e-01_RKIND, &
+            9.15762135097710761e-02_RKIND, 1.08103018168070275e-01_RKIND, &
+            4.45948490915965612e-01_RKIND, 4.45948490915964113e-01_RKIND /)
+
+       v = (/ &
+            8.16847572980458514e-01_RKIND, 9.15762135097710761e-02_RKIND, &
+            9.15762135097704655e-02_RKIND, 4.45948490915964113e-01_RKIND, &
+            1.08103018168070275e-01_RKIND, 4.45948490915965612e-01_RKIND /)
+
+       weights = (/ &
+            1.09951743655321843e-01_RKIND, 1.09951743655321857e-01_RKIND, &
+            1.09951743655321885e-01_RKIND, 2.23381589678011389e-01_RKIND, &
+            2.23381589678011527e-01_RKIND, 2.23381589678011527e-01_RKIND /)
+
+    case (5)
+
+       nIntegrationPoints = 10
+
+       allocate(u(nIntegrationPoints))
+       allocate(v(nIntegrationPoints))
+       allocate(weights(nIntegrationPoints))
+
+       u = (/ &
+            0.00000000000000000e+00_RKIND, 1.00000000000000000e+00_RKIND, &
+            0.00000000000000000e+00_RKIND, 2.67327353118498978e-01_RKIND, &
+            6.72817552946136210e-01_RKIND, 6.49236350054349654e-02_RKIND, &
+            6.71649853904175198e-01_RKIND, 6.54032456800035522e-02_RKIND, &
+            2.69376706913982855e-01_RKIND, 3.38673850389605513e-01_RKIND /)
+
+       v = (/ &
+            1.00000000000000000e+00_RKIND, 0.00000000000000000e+00_RKIND, &
+            0.00000000000000000e+00_RKIND, 6.72819921871012694e-01_RKIND, &
+            2.67328859948191944e-01_RKIND, 6.71653011149382917e-01_RKIND, &
+            6.49251690028951334e-02_RKIND, 2.69378936645285116e-01_RKIND, &
+            6.54054874919145490e-02_RKIND, 3.38679989302702156e-01_RKIND /)
+
+       weights = (/ &
+            1.31356049751916795e-02_RKIND, 1.31358306034076201e-02_RKIND, &
+            1.37081973800151392e-02_RKIND, 1.17419193291163376e-01_RKIND, &
+            1.17420611913379477e-01_RKIND, 1.24012589655715613e-01_RKIND, &
+            1.24015246126072495e-01_RKIND, 1.25930230276426303e-01_RKIND, &
+            1.25933026682913923e-01_RKIND, 2.25289469095714456e-01_RKIND /)
+
+    case (6)
+
+       nIntegrationPoints = 11
+
+       allocate(u(nIntegrationPoints))
+       allocate(v(nIntegrationPoints))
+       allocate(weights(nIntegrationPoints))
+
+       u = (/ &
+            5.72549866774768601e-02_RKIND, 8.95362640024579104e-01_RKIND, 6.84475748456514044e-01_RKIND, &
+            6.87462559150295305e-02_RKIND, 6.15676205575839575e-01_RKIND, 6.27946141197789465e-01_RKIND, &
+            6.29091383418635686e-02_RKIND, 6.83782119205099126e-02_RKIND, 2.87529458374392255e-01_RKIND, &
+            3.28783556413134614e-01_RKIND, 3.12290405013644801e-01_RKIND /)
+
+       v = (/ &
+            8.95498146789879490e-01_RKIND, 6.18282212503219533e-02_RKIND, 2.33437384976827311e-02_RKIND, &
+            6.00302757472630025e-02_RKIND, 3.33461808341377175e-01_RKIND, 1.59189185992151483e-01_RKIND, &
+            6.55295093705452469e-01_RKIND, 3.09117685428267230e-01_RKIND, 6.36426509179620181e-01_RKIND, &
+            7.70240056424634223e-02_RKIND, 3.52344786445899505e-01_RKIND /)
+
+       weights = (/ &
+            3.80680718529555623e-02_RKIND, 3.83793553077528410e-02_RKIND, 4.62004567445618367e-02_RKIND, &
+            5.34675894441989999e-02_RKIND, 8.37558269657456833e-02_RKIND, 1.01644833025517037e-01_RKIND, &
+            1.01861524461366940e-01_RKIND, 1.11421831660001677e-01_RKIND, 1.12009450262946106e-01_RKIND, &
+            1.24787571437558295e-01_RKIND, 1.88403488837394911e-01_RKIND /)
+
+    case (8)
+
+       nIntegrationPoints = 16
+
+       allocate(u(nIntegrationPoints))
+       allocate(v(nIntegrationPoints))
+       allocate(weights(nIntegrationPoints))
+
+       u = (/ &
+            7.28492392955404355e-01_RKIND, 8.39477740995753056e-03_RKIND, 2.63112829634638112e-01_RKIND, &
+            8.39477740995753056e-03_RKIND, 7.28492392955404355e-01_RKIND, 2.63112829634638112e-01_RKIND, &
+            5.05472283170310122e-02_RKIND, 5.05472283170309566e-02_RKIND, 8.98905543365938087e-01_RKIND, &
+            4.59292588292723236e-01_RKIND, 8.14148234145536387e-02_RKIND, 4.59292588292723125e-01_RKIND, &
+            1.70569307751760324e-01_RKIND, 1.70569307751760046e-01_RKIND, 6.58861384496479685e-01_RKIND, &
+            3.33333333333333370e-01_RKIND /)
+
+       v = (/ &
+            8.39477740995753056e-03_RKIND, 2.63112829634638112e-01_RKIND, 7.28492392955404355e-01_RKIND, &
+            7.28492392955404355e-01_RKIND, 2.63112829634638112e-01_RKIND, 8.39477740995753056e-03_RKIND, &
+            5.05472283170309566e-02_RKIND, 8.98905543365938087e-01_RKIND, 5.05472283170310122e-02_RKIND, &
+            8.14148234145536387e-02_RKIND, 4.59292588292723125e-01_RKIND, 4.59292588292723236e-01_RKIND, &
+            6.58861384496479685e-01_RKIND, 1.70569307751760324e-01_RKIND, 1.70569307751760046e-01_RKIND, &
+            3.33333333333333370e-01_RKIND /)
+
+       weights = (/ &
+            2.72303141744348991e-02_RKIND, 2.72303141744349199e-02_RKIND, 2.72303141744349199e-02_RKIND, &
+            2.72303141744349789e-02_RKIND, 2.72303141744349789e-02_RKIND, 2.72303141744349997e-02_RKIND, &
+            3.24584976231980793e-02_RKIND, 3.24584976231980793e-02_RKIND, 3.24584976231981001e-02_RKIND, &
+            9.50916342672845638e-02_RKIND, 9.50916342672846193e-02_RKIND, 9.50916342672846193e-02_RKIND, &
+            1.03217370534718286e-01_RKIND, 1.03217370534718314e-01_RKIND, 1.03217370534718314e-01_RKIND, &
+            1.44315607677787283e-01_RKIND /)
+
+    case (9)
+
+       nIntegrationPoints = 19
+
+       allocate(u(nIntegrationPoints))
+       allocate(v(nIntegrationPoints))
+       allocate(weights(nIntegrationPoints))
+
+       u = (/ &
+            2.26739052759332704e-01_RKIND, 4.77345862087794129e-02_RKIND, 2.26577168977105115e-02_RKIND, &
+            9.10074385862343016e-01_RKIND, 4.41452661673673585e-02_RKIND, 4.79944340675050984e-01_RKIND, &
+            7.42657808541620557e-01_RKIND, 7.43369623518591927e-01_RKIND, 2.79454959355581213e-02_RKIND, &
+            3.71861932583309532e-02_RKIND, 2.22639561442096401e-01_RKIND, 1.16082059855864395e-01_RKIND, &
+            4.73822270420208358e-01_RKIND, 4.77758170054016440e-01_RKIND, 6.46387881792721997e-01_RKIND, &
+            2.85357695207302253e-01_RKIND, 2.04236860041029755e-01_RKIND, 1.59370884213907937e-01_RKIND, &
+            3.95698265017060125e-01_RKIND /)
+
+       v = (/ &
+            0.00000000000000000e+00_RKIND, 9.16183156802148568e-01_RKIND, 7.97193825386026345e-01_RKIND, &
+            4.44666861644595901e-02_RKIND, 4.81588383854628099e-02_RKIND, 5.01294615157430568e-01_RKIND, &
+            3.03405081749971196e-02_RKIND, 2.22245578824042445e-01_RKIND, 5.25527023486726308e-01_RKIND, &
+            2.39263537482135413e-01_RKIND, 7.29063709376736702e-01_RKIND, 6.62507673462198188e-01_RKIND, &
+            4.60334709656892230e-02_RKIND, 4.01038691325781238e-01_RKIND, 1.65342747538830548e-01_RKIND, &
+            4.92973630851354261e-01_RKIND, 1.19056565447230756e-01_RKIND, 3.66261159763432431e-01_RKIND, &
+            2.27511600022304139e-01_RKIND /)
+
+       weights = (/ &
+            1.58676858667487208e-02_RKIND, 2.19524732703951786e-02_RKIND, 2.40354401213296598e-02_RKIND, &
+            2.58522468388647786e-02_RKIND, 2.71951393759608216e-02_RKIND, 3.02097786027936584e-02_RKIND, &
+            3.70093240446550606e-02_RKIND, 4.11482921825866571e-02_RKIND, 4.26331605467379776e-02_RKIND, &
+            4.71413336863812371e-02_RKIND, 5.45129844125978591e-02_RKIND, 6.26632599630084636e-02_RKIND, &
+            6.31379657675310846e-02_RKIND, 7.14623133641135444e-02_RKIND, 7.51048615652924606e-02_RKIND, &
+            7.98259878444318866e-02_RKIND, 8.16607475819435963e-02_RKIND, 9.37481686311500140e-02_RKIND, &
+            1.04838836333477403e-01_RKIND /)
+
+    case default
+
+       call mpas_log_write(&
+            "get_integration_factors_fekete: Unimplemented integration order for Fekete wachspress integration", &
+            MPAS_LOG_CRIT)
+
+    end select
+
+  end subroutine triangle_quadrature_rules_fekete
+
+!-----------------------------------------------------------------------
+
+end module seaice_triangle_quadrature

--- a/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver.F
@@ -99,7 +99,7 @@ contains
          domain !< Input/Output:
 
     type(block_type), pointer :: &
-         block
+         blockPtr
 
     character(len=strKIND), pointer :: &
          config_strain_scheme, &
@@ -118,12 +118,7 @@ contains
          config_reuse_halo_exch
 
     type (MPAS_pool_type), pointer :: &
-         mesh, &
-         boundary, &
-         velocitySolver, &
-         velocity_weak, &
-         velocity_variational, &
-         velocity_pwl
+         velocitySolverPool
 
     real(kind=RKIND), pointer :: &
          dynamicsTimeStep, &
@@ -142,22 +137,22 @@ contains
     call dynamically_locked_cell_mask(domain)
 
     ! set timesteps even with velocity turned off
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_config(block % configs, "config_dt", config_dt)
-       call MPAS_pool_get_config(block % configs, "config_dynamics_subcycle_number", config_dynamics_subcycle_number)
-       call MPAS_pool_get_config(block % configs, "config_elastic_subcycle_number", config_elastic_subcycle_number)
+       call MPAS_pool_get_config(blockPtr % configs, "config_dt", config_dt)
+       call MPAS_pool_get_config(blockPtr % configs, "config_dynamics_subcycle_number", config_dynamics_subcycle_number)
+       call MPAS_pool_get_config(blockPtr % configs, "config_elastic_subcycle_number", config_elastic_subcycle_number)
 
-       call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolver)
-       call MPAS_pool_get_array(velocitySolver, "dynamicsTimeStep", dynamicsTimeStep)
-       call MPAS_pool_get_array(velocitySolver, "elasticTimeStep", elasticTimeStep)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
+       call MPAS_pool_get_array(velocitySolverPool, "dynamicsTimeStep", dynamicsTimeStep)
+       call MPAS_pool_get_array(velocitySolverPool, "elasticTimeStep", elasticTimeStep)
 
        dynamicsTimeStep = config_dt / real(config_dynamics_subcycle_number,RKIND)
 
        elasticTimeStep = dynamicsTimeStep / real(config_elastic_subcycle_number,RKIND)
 
-       block => block % next
+       blockPtr => blockPtr % next
     enddo
 
     ! check if we initialize velocity solver
@@ -206,51 +201,20 @@ contains
        ! initialize the evp solver
        call seaice_init_evp(domain)
 
-       block => domain % blocklist
-       do while (associated(block))
+       ! init solvers
+       if (strainSchemeType           == WEAK_STRAIN_SCHEME .or. &
+           stressDivergenceSchemeType == WEAK_STRESS_DIVERGENCE_SCHEME) then
 
-          call MPAS_pool_get_subpool(block % structs, "mesh", mesh)
-          call MPAS_pool_get_subpool(block % structs, "boundary", boundary)
-          call MPAS_pool_get_subpool(block % structs, "velocity_weak", velocity_weak)
-          call MPAS_pool_get_subpool(block % structs, "velocity_variational", velocity_variational)
+          call seaice_init_velocity_solver_weak(domain)
 
-          call MPAS_pool_get_config(block % configs, "config_variational_basis", config_variational_basis)
-          call MPAS_pool_get_config(block % configs, "config_variational_denominator_type", config_variational_denominator_type)
-          call MPAS_pool_get_config(block % configs, "config_rotate_cartesian_grid", config_rotate_cartesian_grid)
-          call MPAS_pool_get_config(block % configs, "config_include_metric_terms", config_include_metric_terms)
-          call MPAS_pool_get_config(block % configs, "config_wachspress_integration_type", config_wachspress_integration_type)
-          call MPAS_pool_get_config(block % configs, "config_wachspress_integration_order", config_wachspress_integration_order)
+       endif
 
-          ! init solvers
-          if (strainSchemeType           == WEAK_STRAIN_SCHEME .or. &
-              stressDivergenceSchemeType == WEAK_STRESS_DIVERGENCE_SCHEME) then
+       if (strainSchemeType           == VARIATIONAL_STRAIN_SCHEME .or. &
+           stressDivergenceSchemeType == VARIATIONAL_STRESS_DIVERGENCE_SCHEME) then
 
-             call seaice_init_velocity_solver_weak(&
-                  mesh, &
-                  boundary, &
-                  velocity_weak, &
-                  config_rotate_cartesian_grid)
+          call seaice_init_velocity_solver_variational(domain)
 
-          endif
-
-          if (strainSchemeType           == VARIATIONAL_STRAIN_SCHEME .or. &
-              stressDivergenceSchemeType == VARIATIONAL_STRESS_DIVERGENCE_SCHEME) then
-
-             call seaice_init_velocity_solver_variational(&
-                  mesh, &
-                  velocity_variational, &
-                  boundary, &
-                  config_rotate_cartesian_grid, &
-                  config_include_metric_terms, &
-                  config_variational_basis, &
-                  config_variational_denominator_type, &
-                  config_wachspress_integration_type, &
-                  config_wachspress_integration_order)
-
-          endif
-
-          block => block % next
-       enddo
+       endif
 
     endif
 
@@ -408,7 +372,7 @@ contains
          domain !< Input/Output:
 
     type(block_type), pointer :: &
-         block
+         blockPtr
 
     type(MPAS_pool_type), pointer :: &
          velocitySolverPool, &
@@ -431,12 +395,12 @@ contains
          iVertexOnCell, &
          iVertex
 
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
-       call MPAS_pool_get_subpool(block % structs, "mesh", meshPool)
-       call MPAS_pool_get_subpool(block % structs, "boundary", boundaryPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "boundary", boundaryPool)
 
        call MPAS_pool_get_array(velocitySolverPool, "dynamicallyLockedCellsMask", dynamicallyLockedCellsMask)
 
@@ -445,7 +409,7 @@ contains
        call MPAS_pool_get_array(meshPool, "nEdgesOnCell", nEdgesOnCell)
        call MPAS_pool_get_array(meshPool, "verticesOnCell", verticesOnCell)
 
-       call MPAS_pool_get_dimension(block % dimensions, "nCells", nCells)
+       call MPAS_pool_get_dimension(blockPtr % dimensions, "nCells", nCells)
 
        do iCell = 1, nCells
 
@@ -464,7 +428,7 @@ contains
 
        enddo ! iCell
 
-       block => block % next
+       blockPtr => blockPtr % next
     enddo
 
   end subroutine dynamically_locked_cell_mask
@@ -487,7 +451,7 @@ contains
          domain !< Input/Output:
 
     type(block_type), pointer :: &
-         block
+         blockPtr
 
     type(MPAS_pool_type), pointer :: &
          oceanCouplingPool, &
@@ -509,19 +473,19 @@ contains
          iVertex, &
          iCellOnVertex
 
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_subpool(block % structs, "ocean_coupling", oceanCouplingPool)
-       call MPAS_pool_get_subpool(block % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "ocean_coupling", oceanCouplingPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
 
        call MPAS_pool_get_array(oceanCouplingPool, "landIceMask", landIceMask)
        call MPAS_pool_get_array(oceanCouplingPool, "landIceMaskVertex", landIceMaskVertex)
 
        call MPAS_pool_get_array(meshPool, "cellsOnVertex", cellsOnVertex)
 
-       call MPAS_pool_get_dimension(block % dimensions, "vertexDegree", vertexDegree)
-       call MPAS_pool_get_dimension(block % dimensions, "nVerticesSolve", nVerticesSolve)
+       call MPAS_pool_get_dimension(blockPtr % dimensions, "vertexDegree", vertexDegree)
+       call MPAS_pool_get_dimension(blockPtr % dimensions, "nVerticesSolve", nVerticesSolve)
 
        landIceMaskVertex(:) = 0
 
@@ -541,7 +505,7 @@ contains
 
        enddo ! iVertex
 
-       block => block % next
+       blockPtr => blockPtr % next
     enddo
 
   end subroutine init_ice_shelve_vertex_mask
@@ -695,7 +659,7 @@ contains
          domain
 
     type(block_type), pointer :: &
-         block
+         blockPtr
 
     type(MPAS_pool_type), pointer :: &
          tracersPool, &
@@ -719,14 +683,14 @@ contains
     integer :: &
          iCell
 
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_dimension(block % dimensions, "nCells", nCellsSolve)
+       call MPAS_pool_get_dimension(blockPtr % dimensions, "nCells", nCellsSolve)
 
-       call MPAS_pool_get_subpool(block % structs, "tracers", tracersPool)
-       call MPAS_pool_get_subpool(block % structs, "tracers_aggregate", tracersAggregatePool)
-       call MPAS_pool_get_subpool(block % structs, "icestate", icestatePool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "tracers", tracersPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "tracers_aggregate", tracersAggregatePool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "icestate", icestatePool)
 
        call MPAS_pool_get_array(tracersPool, "iceAreaCategory", iceAreaCategory, 1)
        call MPAS_pool_get_array(tracersPool, "iceVolumeCategory", iceVolumeCategory, 1)
@@ -749,7 +713,7 @@ contains
 
        enddo ! iCell
 
-       block => block % next
+       blockPtr => blockPtr % next
     enddo
 
   end subroutine aggregate_mass_and_area!}}}
@@ -778,7 +742,7 @@ contains
          domain
 
     type(block_type), pointer :: &
-         block
+         blockPtr
 
     type(MPAS_pool_type), pointer :: &
          icestatePool, &
@@ -811,17 +775,17 @@ contains
     if (.not. config_use_column_package .or. &
          (config_use_column_package .and. .not. config_use_column_vertical_thermodynamics)) then
 
-       block => domain % blocklist
-       do while (associated(block))
+       blockPtr => domain % blocklist
+       do while (associated(blockPtr))
 
-          call MPAS_pool_get_subpool(block % structs, "tracers_aggregate", tracersAggregatePool)
-          call MPAS_pool_get_subpool(block % structs, "icestate", icestatePool)
+          call MPAS_pool_get_subpool(blockPtr % structs, "tracers_aggregate", tracersAggregatePool)
+          call MPAS_pool_get_subpool(blockPtr % structs, "icestate", icestatePool)
           call MPAS_pool_get_array(tracersAggregatePool, "iceAreaCell", iceAreaCell)
           call MPAS_pool_get_array(icestatePool, "iceAreaCellInitial", iceAreaCellInitial)
 
           iceAreaCellInitial = iceAreaCell
 
-          block => block % next
+          blockPtr => blockPtr % next
        end do
 
     endif
@@ -872,11 +836,11 @@ contains
     call seaice_load_balance_timers(domain, "vel prep after")
 
     ! interpolate area and mass from cells to vertices
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_subpool(block % structs, "mesh", meshPool)
-       call MPAS_pool_get_subpool(block % structs, "icestate", icestatePool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "icestate", icestatePool)
 
        call MPAS_pool_get_array(icestatePool, "iceAreaVertex", iceAreaVertex)
        call MPAS_pool_get_array(icestatePool, "totalMassCell", totalMassCell)
@@ -893,7 +857,7 @@ contains
             totalMassVertex, &
             totalMassCell)
 
-       block => block % next
+       blockPtr => blockPtr % next
     end do
 
     ! calculate computational masks
@@ -967,7 +931,7 @@ contains
          domain
 
     type(block_type), pointer :: &
-         block
+         blockPtr
 
     type(MPAS_pool_type), pointer :: &
          meshPool, &
@@ -997,15 +961,15 @@ contains
     integer, dimension(:,:), pointer :: &
          cellsOnCell
 
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_dimension(block % dimensions, "nCells", nCells)
+       call MPAS_pool_get_dimension(blockPtr % dimensions, "nCells", nCells)
 
-       call MPAS_pool_get_subpool(block % structs, "mesh", meshPool)
-       call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
-       call MPAS_pool_get_subpool(block % structs, "icestate", icestatePool)
-       call MPAS_pool_get_subpool(block % structs, "ocean_coupling", oceanCouplingPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "icestate", icestatePool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "ocean_coupling", oceanCouplingPool)
 
        call MPAS_pool_get_array(meshPool, "nEdgesOnCell", nEdgesOnCell)
        call MPAS_pool_get_array(meshPool, "cellsOnCell", cellsOnCell)
@@ -1056,7 +1020,7 @@ contains
 
        enddo ! iCell
 
-       block => block % next
+       blockPtr => blockPtr % next
     enddo
 
   end subroutine stress_calculation_mask!}}}
@@ -1079,7 +1043,7 @@ contains
          domain
 
     type(block_type), pointer :: &
-         block
+         blockPtr
 
     type(MPAS_pool_type), pointer :: &
          velocitySolverPool, &
@@ -1105,16 +1069,16 @@ contains
          nVerticesSolve, &
          nVertices
 
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_dimension(block % dimensions, "nVerticesSolve", nVerticesSolve)
-       call MPAS_pool_get_dimension(block % dimensions, "nVertices", nVertices)
+       call MPAS_pool_get_dimension(blockPtr % dimensions, "nVerticesSolve", nVerticesSolve)
+       call MPAS_pool_get_dimension(blockPtr % dimensions, "nVertices", nVertices)
 
-       call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
-       call MPAS_pool_get_subpool(block % structs, "icestate", icestatePool)
-       call MPAS_pool_get_subpool(block % structs, "boundary", boundaryPool)
-       call MPAS_pool_get_subpool(block % structs, "ocean_coupling", oceanCouplingPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "icestate", icestatePool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "boundary", boundaryPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "ocean_coupling", oceanCouplingPool)
 
        call MPAS_pool_get_array(velocitySolverPool, "solveVelocity", solveVelocity)
 
@@ -1147,7 +1111,7 @@ contains
 
        enddo ! iVertex
 
-       block => block % next
+       blockPtr => blockPtr % next
     enddo
 
   end subroutine velocity_calculation_mask!}}}
@@ -1176,7 +1140,7 @@ contains
          domain
 
     type(block_type), pointer :: &
-         block
+         blockPtr
 
     type(MPAS_pool_type), pointer :: &
          velocitySolverPool, &
@@ -1213,14 +1177,14 @@ contains
          config_aggregate_halo_exch, &
          config_reuse_halo_exch
 
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_dimension(block % dimensions, "nVerticesSolve", nVerticesSolve)
+       call MPAS_pool_get_dimension(blockPtr % dimensions, "nVerticesSolve", nVerticesSolve)
 
-       call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
-       call MPAS_pool_get_subpool(block % structs, "mesh", meshPool)
-       call MPAS_pool_get_subpool(block % structs, "ocean_coupling", oceanCouplingPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "ocean_coupling", oceanCouplingPool)
 
        call MPAS_pool_get_array(velocitySolverPool, "uVelocity", uVelocity)
        call MPAS_pool_get_array(velocitySolverPool, "vVelocity", vVelocity)
@@ -1279,7 +1243,7 @@ contains
        uVelocityInitial = uVelocity
        vVelocityInitial = vVelocity
 
-       block => block % next
+       blockPtr => blockPtr % next
     enddo
 
     ! halo exchange velocities
@@ -1357,7 +1321,7 @@ contains
          domain
 
     type(block_type), pointer :: &
-         block
+         blockPtr
 
     type(MPAS_pool_type), pointer :: &
          velocitySolverPool, &
@@ -1393,20 +1357,20 @@ contains
          iCell, &
          ierr
 
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_config(block % configs, "config_use_column_package", config_use_column_package)
-       call MPAS_pool_get_config(block % configs, "config_use_column_vertical_thermodynamics", &
+       call MPAS_pool_get_config(blockPtr % configs, "config_use_column_package", config_use_column_package)
+       call MPAS_pool_get_config(blockPtr % configs, "config_use_column_vertical_thermodynamics", &
                                                    config_use_column_vertical_thermodynamics)
 
-       call MPAS_pool_get_dimension(block % dimensions, "nCellsSolve", nCellsSolve)
-       call MPAS_pool_get_dimension(block % dimensions, "nCategories", nCategories)
+       call MPAS_pool_get_dimension(blockPtr % dimensions, "nCellsSolve", nCellsSolve)
+       call MPAS_pool_get_dimension(blockPtr % dimensions, "nCategories", nCategories)
 
-       call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
-       call MPAS_pool_get_subpool(block % structs, "tracers_aggregate", tracersAggregatePool)
-       call MPAS_pool_get_subpool(block % structs, "icestate", icestatePool)
-       call MPAS_pool_get_subpool(block % structs, "tracers", tracersPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "tracers_aggregate", tracersAggregatePool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "icestate", icestatePool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "tracers", tracersPool)
 
        call MPAS_pool_get_array(velocitySolverPool, "icePressure", icePressure)
        call MPAS_pool_get_array(velocitySolverPool, "solveStress", solveStress)
@@ -1461,7 +1425,7 @@ contains
 
        endif
 
-       block => block % next
+       blockPtr => blockPtr % next
     enddo
 
     ! halo exchange ice strength
@@ -1534,7 +1498,7 @@ contains
          domain
 
     type(block_type), pointer :: &
-         block
+         blockPtr
 
     logical, pointer :: &
          config_use_column_package, &
@@ -1570,14 +1534,14 @@ contains
     ! check for no air stress
     call MPAS_pool_get_config(domain % blocklist % configs, "config_use_air_stress", config_use_air_stress)
     if (.not. config_use_air_stress) then
-       block => domain % blocklist
-       do while (associated(block))
-          call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
+       blockPtr => domain % blocklist
+       do while (associated(blockPtr))
+          call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
           call MPAS_pool_get_array(velocitySolverPool, "airStressCellU", airStressCellU)
           call MPAS_pool_get_array(velocitySolverPool, "airStressCellV", airStressCellV)
           airStressCellU = 0.0_RKIND
           airStressCellV = 0.0_RKIND
-          block => block % next
+          blockPtr => blockPtr % next
        end do
     endif ! .not. config_use_air_stress
 
@@ -1627,11 +1591,11 @@ contains
     call seaice_load_balance_timers(domain, "vel prep after")
 
     ! interpolate air stress
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_subpool(block % structs, "mesh", meshPool)
-       call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
 
        call MPAS_pool_get_array(velocitySolverPool, "airStressCellU", airStressCellU)
        call MPAS_pool_get_array(velocitySolverPool, "airStressCellV", airStressCellV)
@@ -1648,7 +1612,7 @@ contains
             airStressVertexV, &
             airStressCellV)
 
-       block => block % next
+       blockPtr => blockPtr % next
     end do
 
   end subroutine air_stress
@@ -1671,7 +1635,7 @@ contains
          domain
 
     type(block_type), pointer :: &
-         block
+         blockPtr
 
     type(MPAS_pool_type), pointer :: &
          velocitySolverPool, &
@@ -1698,14 +1662,14 @@ contains
     real(kind=RKIND), parameter :: &
          airStressCoeff = 0.0012_RKIND
 
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_dimension(block % dimensions, "nCellsSolve", nCellsSolve)
+       call MPAS_pool_get_dimension(blockPtr % dimensions, "nCellsSolve", nCellsSolve)
 
-       call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
-       call MPAS_pool_get_subpool(block % structs, "atmos_coupling", atmosCouplingPool)
-       call MPAS_pool_get_subpool(block % structs, "tracers_aggregate", tracersAggregatePool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "atmos_coupling", atmosCouplingPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "tracers_aggregate", tracersAggregatePool)
 
        call MPAS_pool_get_array(velocitySolverPool, "airStressCellU", airStressCellU)
        call MPAS_pool_get_array(velocitySolverPool, "airStressCellV", airStressCellV)
@@ -1725,7 +1689,7 @@ contains
 
        enddo ! iCell
 
-       block => block % next
+       blockPtr => blockPtr % next
     end do
 
   end subroutine constant_air_stress
@@ -1748,7 +1712,7 @@ contains
          domain
 
     type(block_type), pointer :: &
-         block
+         blockPtr
 
     type(MPAS_pool_type), pointer :: &
          icestatePool, &
@@ -1766,14 +1730,14 @@ contains
     integer :: &
          iVertex
 
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_dimension(block % dimensions, "nVerticesSolve", nVerticesSolve)
+       call MPAS_pool_get_dimension(blockPtr % dimensions, "nVerticesSolve", nVerticesSolve)
 
-       call MPAS_pool_get_subpool(block % structs, "icestate", icestatePool)
-       call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
-       call MPAS_pool_get_subpool(block % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "icestate", icestatePool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
 
        call MPAS_pool_get_array(icestatePool, "totalMassVertex", totalMassVertex)
        call MPAS_pool_get_array(velocitySolverPool, "totalMassVertexfVertex", totalMassVertexfVertex)
@@ -1785,7 +1749,7 @@ contains
 
        enddo ! iVertex
 
-       block => block % next
+       blockPtr => blockPtr % next
     end do
 
   end subroutine coriolis_force_coefficient
@@ -1808,7 +1772,7 @@ contains
          domain
 
     type(block_type), pointer :: &
-         block
+         blockPtr
 
     type(MPAS_pool_type), pointer :: &
          velocitySolverPool, &
@@ -1833,15 +1797,15 @@ contains
     integer :: &
          iVertex
 
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_config(block % configs, "config_use_ocean_stress", configUseOceanStress)
+       call MPAS_pool_get_config(blockPtr % configs, "config_use_ocean_stress", configUseOceanStress)
 
-       call MPAS_pool_get_dimension(block % dimensions, "nVerticesSolve", nVerticesSolve)
+       call MPAS_pool_get_dimension(blockPtr % dimensions, "nVerticesSolve", nVerticesSolve)
 
-       call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
-       call MPAS_pool_get_subpool(block % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
 
        call MPAS_pool_get_array(velocitySolverPool, "oceanStressU", oceanStressU)
        call MPAS_pool_get_array(velocitySolverPool, "oceanStressV", oceanStressV)
@@ -1880,7 +1844,7 @@ contains
 
        endif
 
-       block => block % next
+       blockPtr => blockPtr % next
     end do
 
   end subroutine ocean_stress
@@ -1947,7 +1911,7 @@ contains
          domain
 
     type(block_type), pointer :: &
-         block
+         blockPtr
 
     type(MPAS_pool_type), pointer :: &
          icestatePool, &
@@ -1971,14 +1935,14 @@ contains
     integer :: &
          iVertex
 
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_dimension(block % dimensions, "nVerticesSolve", nVerticesSolve)
+       call MPAS_pool_get_dimension(blockPtr % dimensions, "nVerticesSolve", nVerticesSolve)
 
-       call MPAS_pool_get_subpool(block % structs, "icestate", icestatePool)
-       call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
-       call MPAS_pool_get_subpool(block % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "icestate", icestatePool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
 
        call MPAS_pool_get_array(velocitySolverPool, "surfaceTiltForceU", surfaceTiltForceU)
        call MPAS_pool_get_array(velocitySolverPool, "surfaceTiltForceV", surfaceTiltForceV)
@@ -2007,7 +1971,7 @@ contains
 
        enddo ! iVertex
 
-       block => block % next
+       blockPtr => blockPtr % next
     end do
 
   end subroutine surface_tilt_geostrophic
@@ -2039,7 +2003,7 @@ contains
          domain
 
     type(block_type), pointer :: &
-         block
+         blockPtr
 
     type(MPAS_pool_type), pointer :: &
          icestatePool, &
@@ -2116,15 +2080,15 @@ contains
 
     call seaice_load_balance_timers(domain, "vel prep after")
 
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_dimension(block % dimensions, "nVerticesSolve", nVerticesSolve)
+       call MPAS_pool_get_dimension(blockPtr % dimensions, "nVerticesSolve", nVerticesSolve)
 
-       call MPAS_pool_get_subpool(block % structs, "icestate", icestatePool)
-       call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
-       call MPAS_pool_get_subpool(block % structs, "ocean_coupling", oceanCouplingPool)
-       call MPAS_pool_get_subpool(block % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "icestate", icestatePool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "ocean_coupling", oceanCouplingPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
 
        call MPAS_pool_get_array(velocitySolverPool, "surfaceTiltForceU", surfaceTiltForceU)
        call MPAS_pool_get_array(velocitySolverPool, "surfaceTiltForceV", surfaceTiltForceV)
@@ -2166,7 +2130,7 @@ contains
 
        enddo ! iVertex
 
-       block => block % next
+       blockPtr => blockPtr % next
     end do
 
   end subroutine surface_tilt_ssh_gradient
@@ -2189,7 +2153,7 @@ contains
          domain
 
     type(block_type), pointer :: &
-         block
+         blockPtr
 
     type(MPAS_pool_type), pointer :: &
          velocitySolverPool
@@ -2198,10 +2162,10 @@ contains
          surfaceTiltForceU, &
          surfaceTiltForceV
 
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
 
        call MPAS_pool_get_array(velocitySolverPool, "surfaceTiltForceU", surfaceTiltForceU)
        call MPAS_pool_get_array(velocitySolverPool, "surfaceTiltForceV", surfaceTiltForceV)
@@ -2210,7 +2174,7 @@ contains
        surfaceTiltForceU = 0.0_RKIND
        surfaceTiltForceV = 0.0_RKIND
 
-       block => block % next
+       blockPtr => blockPtr % next
     end do
 
   end subroutine no_surface_tilt
@@ -2231,7 +2195,7 @@ contains
 
     type(domain_type) :: domain
 
-    type(block_type), pointer :: block
+    type(block_type), pointer :: blockPtr
 
     type(MPAS_pool_type), pointer :: &
          velocitySolverPool, &
@@ -2278,10 +2242,10 @@ contains
 
     call MPAS_pool_get_config(domain % configs, "config_stress_divergence_scheme", config_stress_divergence_scheme)
 
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
 
        ! divergence of stress
        call MPAS_pool_get_array(velocitySolverPool, "stressDivergenceU", stressDivergenceU)
@@ -2297,7 +2261,7 @@ contains
        call MPAS_pool_get_array(velocitySolverPool, "vVelocity", vVelocity)
        call MPAS_pool_get_array(velocitySolverPool, "oceanStressCoeff", oceanStressCoeff)
 
-       call MPAS_pool_get_dimension(block % dimensions, "nVerticesSolve", nVerticesSolve)
+       call MPAS_pool_get_dimension(blockPtr % dimensions, "nVerticesSolve", nVerticesSolve)
 
        do iVertex = 1, nVerticesSolve
 
@@ -2315,7 +2279,7 @@ contains
        if (trim(config_stress_divergence_scheme) == "variational") then
           ! variational
 
-          call MPAS_pool_get_subpool(block % structs, "velocity_variational", velocityVariationalPool)
+          call MPAS_pool_get_subpool(blockPtr % structs, "velocity_variational", velocityVariationalPool)
 
           ! strains
           call MPAS_pool_get_array(velocityVariationalPool, "strain11", strain11Var)
@@ -2333,7 +2297,7 @@ contains
           call MPAS_pool_get_array(velocityVariationalPool, "stress22", stress22Var)
           call MPAS_pool_get_array(velocityVariationalPool, "stress12", stress12Var)
 
-          call MPAS_pool_get_dimension(block % dimensions, "nCells", nCells)
+          call MPAS_pool_get_dimension(blockPtr % dimensions, "nCells", nCells)
 
           do iCell = 1, nCells
 
@@ -2349,7 +2313,7 @@ contains
 
        else if (trim(config_stress_divergence_scheme) == "weak") then
 
-          call MPAS_pool_get_subpool(block % structs, "velocity_weak", velocityWeakPool)
+          call MPAS_pool_get_subpool(blockPtr % structs, "velocity_weak", velocityWeakPool)
 
           ! strains
           call MPAS_pool_get_array(velocityWeakPool, "strain11", strain11Weak)
@@ -2367,7 +2331,7 @@ contains
           call MPAS_pool_get_array(velocityWeakPool, "stress22", stress22Weak)
           call MPAS_pool_get_array(velocityWeakPool, "stress12", stress12Weak)
 
-          call MPAS_pool_get_dimension(block % dimensions, "nCells", nCells)
+          call MPAS_pool_get_dimension(blockPtr % dimensions, "nCells", nCells)
 
           do iCell = 1, nCells
 
@@ -2383,7 +2347,7 @@ contains
 
        endif ! config_stress_divergence_scheme
 
-       block => block % next
+       blockPtr => blockPtr % next
     enddo
 
   end subroutine init_subcycle_variables
@@ -2608,23 +2572,6 @@ contains
 
   subroutine seaice_internal_stress(domain)
 
-    use seaice_mesh_pool, only: &
-         basisGradientU, &
-         basisGradientV, &
-         basisIntegralsMetric, &
-         basisIntegralsU, &
-         basisIntegralsV, &
-         cellVerticesAtVertex, &
-         icePressure, &
-         solveStress, &
-         solveVelocity, &
-         stress11var => stress11, &
-         stress22var => stress22, &
-         stress12var => stress12, &
-         tanLatVertexRotatedOverRadius, &
-         uVelocity, &
-         vVelocity
-
     use seaice_velocity_solver_weak, only: &
          seaice_strain_tensor_weak, &
          seaice_stress_tensor_weak, &
@@ -2639,229 +2586,66 @@ contains
     type(domain_type), intent(inout) :: &
          domain
 
-    type(block_type), pointer :: &
-         blockPtr
+    ! strain
+    if (strainSchemeType == WEAK_STRAIN_SCHEME) then
 
-    type (MPAS_pool_type), pointer :: &
-         meshPool, &
-         velocityWeakPool, &
-         velocityVariationalPool, &
-         velocityWeakVariationalPool, &
-         velocitySolverPool
+       call mpas_timer_start("Velocity solver strain tensor")
+       call seaice_strain_tensor_weak(domain)
+       call mpas_timer_stop("Velocity solver strain tensor")
 
-    real(kind=RKIND), pointer :: &
-         elasticTimeStep
+    else if (strainSchemeType == VARIATIONAL_STRAIN_SCHEME) then
 
-    real(kind=RKIND), dimension(:), pointer :: &
-         stressDivergenceU, &
-         stressDivergenceV
+       call mpas_timer_start("Velocity solver strain tensor")
+       call seaice_strain_tensor_variational(domain)
+       call mpas_timer_stop("Velocity solver strain tensor")
 
-    real(kind=RKIND), dimension(:), pointer :: &
-         replacementPressureWeak, &
-         strain11weak, &
-         strain22weak, &
-         strain12weak, &
-         stress11weak, &
-         stress22weak, &
-         stress12weak, &
-         latCellRotated, &
-         latVertexRotated, &
-         areaCell
+    endif
 
-    real(kind=RKIND), dimension(:,:,:), pointer :: &
-         normalVectorPolygon, &
-         normalVectorTriangle
+    ! average variational strains around vertex
+    if (strainSchemeType == VARIATIONAL_STRAIN_SCHEME .and. &
+         averageVariationalStrains) then
+       call seaice_average_strains_on_vertex(domain)
+    endif
 
-    real(kind=RKIND), dimension(:,:), pointer :: &
-         replacementPressureVar, &
-         strain11var, &
-         strain22var, &
-         strain12var
+    ! weak strain / variational stress divergence
+    if (strainSchemeType           == WEAK_STRAIN_SCHEME .and. &
+         stressDivergenceSchemeType == VARIATIONAL_STRESS_DIVERGENCE_SCHEME) then
 
-    real(kind=RKIND), dimension(:), pointer :: &
-         variationalDenominator
+       call mpas_timer_start("Velocity solver interpolate strain")
+       call interpolate_strains_weak_to_variational(domain)
+       call mpas_timer_stop("Velocity solver interpolate strain")
 
-    blockPtr => domain % blocklist
-    do while (associated(blockPtr))
+    endif
 
-       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
-       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_weak", velocityWeakPool)
-       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_variational", velocityVariationalPool)
-       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_weak_variational", velocityWeakVariationalPool)
-       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
+    ! consitutive relation
+    if (stressDivergenceSchemeType == WEAK_STRESS_DIVERGENCE_SCHEME) then
 
-       call MPAS_pool_get_array(velocitySolverPool, "elasticTimeStep", elasticTimeStep)
-       call MPAS_pool_get_array(velocitySolverPool, "stressDivergenceU", stressDivergenceU)
-       call MPAS_pool_get_array(velocitySolverPool, "stressDivergenceV", stressDivergenceV)
+       call mpas_timer_start("Velocity solver stress tensor")
+       call seaice_stress_tensor_weak(domain)
+       call mpas_timer_stop("Velocity solver stress tensor")
 
-       if (strainSchemeType           == WEAK_STRAIN_SCHEME .or. &
-           stressDivergenceSchemeType == WEAK_STRESS_DIVERGENCE_SCHEME) then
+    else if (stressDivergenceSchemeType == VARIATIONAL_STRESS_DIVERGENCE_SCHEME) then
 
-          call MPAS_pool_get_array(velocityWeakPool, "normalVectorPolygon", normalVectorPolygon)
-          call MPAS_pool_get_array(velocityWeakPool, "normalVectorTriangle", normalVectorTriangle)
-          call MPAS_pool_get_array(velocityWeakPool, "latCellRotated", latCellRotated)
-          call MPAS_pool_get_array(velocityWeakPool, "latVertexRotated", latVertexRotated)
-          call MPAS_pool_get_array(velocityWeakPool, "strain11", strain11weak)
-          call MPAS_pool_get_array(velocityWeakPool, "strain22", strain22weak)
-          call MPAS_pool_get_array(velocityWeakPool, "strain12", strain12weak)
-          call MPAS_pool_get_array(velocityWeakPool, "stress11", stress11weak)
-          call MPAS_pool_get_array(velocityWeakPool, "stress22", stress22weak)
-          call MPAS_pool_get_array(velocityWeakPool, "stress12", stress12weak)
-          call MPAS_pool_get_array(velocityWeakPool, "replacementPressure", replacementPressureWeak)
+       call mpas_timer_start("Velocity solver stress tensor")
+       call seaice_stress_tensor_variational(domain)
+       call mpas_timer_stop("Velocity solver stress tensor")
 
-       endif
+    endif
 
-       if (strainSchemeType           == VARIATIONAL_STRAIN_SCHEME .or. &
-           stressDivergenceSchemeType == VARIATIONAL_STRESS_DIVERGENCE_SCHEME) then
+    ! stress divergence
+    if (stressDivergenceSchemeType == WEAK_STRESS_DIVERGENCE_SCHEME) then
 
-          call MPAS_pool_get_array(velocityVariationalPool, "strain11", strain11var)
-          call MPAS_pool_get_array(velocityVariationalPool, "strain22", strain22var)
-          call MPAS_pool_get_array(velocityVariationalPool, "strain12", strain12var)
-          call MPAS_pool_get_array(velocityVariationalPool, "replacementPressure", replacementPressureVar)
-          call MPAS_pool_get_array(velocityVariationalPool, "variationalDenominator", variationalDenominator)
+       call mpas_timer_start("Velocity solver stress divergence")
+       call seaice_stress_divergence_weak(domain)
+       call mpas_timer_stop("Velocity solver stress divergence")
 
-       endif
+    else if (stressDivergenceSchemeType == VARIATIONAL_STRESS_DIVERGENCE_SCHEME) then
 
-       ! strain
-       if (strainSchemeType == WEAK_STRAIN_SCHEME) then
+       call mpas_timer_start("Velocity solver stress divergence")
+       call seaice_stress_divergence_variational(domain)
+       call mpas_timer_stop("Velocity solver stress divergence")
 
-          call mpas_timer_start("Velocity solver strain tensor")
-          call seaice_strain_tensor_weak(&
-               meshPool, &
-               strain11weak, &
-               strain22weak, &
-               strain12weak, &
-               uVelocity, &
-               vVelocity, &
-               normalVectorPolygon, &
-               latCellRotated, &
-               solveStress)
-          call mpas_timer_stop("Velocity solver strain tensor")
-
-       else if (strainSchemeType == VARIATIONAL_STRAIN_SCHEME) then
-
-          call mpas_timer_start("Velocity solver strain tensor")
-          call seaice_strain_tensor_variational(&
-               meshPool, &
-               strain11var, &
-               strain22var, &
-               strain12var, &
-               uVelocity, &
-               vVelocity, &
-               basisGradientU, &
-               basisGradientV, &
-               tanLatVertexRotatedOverRadius, &
-               solveStress)
-          call mpas_timer_stop("Velocity solver strain tensor")
-
-       endif
-
-       ! average variational strains around vertex
-       if (strainSchemeType == VARIATIONAL_STRAIN_SCHEME .and. &
-           averageVariationalStrains) then
-
-          call MPAS_pool_get_array(meshPool, "areaCell", areaCell)
-          call seaice_average_strains_on_vertex(&
-                areaCell, &
-                strain11var, &
-                strain22var, &
-                strain12var)
-       endif
-
-       ! weak strain / variational stress divergence
-       if (strainSchemeType           == WEAK_STRAIN_SCHEME .and. &
-           stressDivergenceSchemeType == VARIATIONAL_STRESS_DIVERGENCE_SCHEME) then
-
-          call mpas_timer_start("Velocity solver interpolate strain")
-          call interpolate_strains_weak_to_variational(&
-               meshPool, &
-               velocityWeakVariationalPool, &
-               strain11weak, &
-               strain22weak, &
-               strain12weak, &
-               strain11var, &
-               strain22var, &
-               strain12var)
-          call mpas_timer_stop("Velocity solver interpolate strain")
-
-       endif
-
-       ! consitutive relation
-       if (stressDivergenceSchemeType == WEAK_STRESS_DIVERGENCE_SCHEME) then
-
-          call mpas_timer_start("Velocity solver stress tensor")
-          call seaice_stress_tensor_weak(&
-               meshPool, &
-               stress11weak, &
-               stress22weak, &
-               stress12weak, &
-               strain11weak, &
-               strain22weak, &
-               strain12weak, &
-               icePressure, &
-               replacementPressureWeak, &
-               solveStress, &
-               elasticTimeStep)
-          call mpas_timer_stop("Velocity solver stress tensor")
-
-       else if (stressDivergenceSchemeType == VARIATIONAL_STRESS_DIVERGENCE_SCHEME) then
-
-          call mpas_timer_start("Velocity solver stress tensor")
-          call seaice_stress_tensor_variational(&
-               meshPool, &
-               stress11var, &
-               stress22var, &
-               stress12var, &
-               strain11var, &
-               strain22var, &
-               strain12var, &
-               icePressure, &
-               replacementPressureVar, &
-               solveStress, &
-               elasticTimeStep)
-          call mpas_timer_stop("Velocity solver stress tensor")
-
-       endif
-
-       ! stress divergence
-       if (stressDivergenceSchemeType == WEAK_STRESS_DIVERGENCE_SCHEME) then
-
-          call mpas_timer_start("Velocity solver stress divergence")
-          call seaice_stress_divergence_weak(&
-               meshPool, &
-               stressDivergenceU, &
-               stressDivergenceV, &
-               stress11weak, &
-               stress22weak, &
-               stress12weak, &
-               normalVectorTriangle, &
-               latVertexRotated, &
-               solveVelocity)
-          call mpas_timer_stop("Velocity solver stress divergence")
-
-       else if (stressDivergenceSchemeType == VARIATIONAL_STRESS_DIVERGENCE_SCHEME) then
-
-          call mpas_timer_start("Velocity solver stress divergence")
-          call seaice_stress_divergence_variational(&
-               meshPool, &
-               stressDivergenceU, &
-               stressDivergenceV, &
-               stress11var, &
-               stress22var, &
-               stress12var, &
-               basisIntegralsU, &
-               basisIntegralsV, &
-               basisIntegralsMetric, &
-               variationalDenominator, &
-               tanLatVertexRotatedOverRadius, &
-               cellVerticesAtVertex, &
-               solveVelocity)
-          call mpas_timer_stop("Velocity solver stress divergence")
-
-       endif
-
-       blockPtr => blockPtr % next
-    end do
+    endif
 
   end subroutine seaice_internal_stress
 
@@ -2877,15 +2661,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine interpolate_strains_weak_to_variational(&
-       meshPool, &
-       velocityWeakVariationalPool, &
-       strain11weak, &
-       strain22weak, &
-       strain12weak, &
-       strain11var, &
-       strain22var, &
-       strain12var)
+  subroutine interpolate_strains_weak_to_variational(domain)
 
     use seaice_mesh_pool, only: &
          nCells, &
@@ -2895,19 +2671,27 @@ contains
          nEdgesOnCell, &
          verticesOnCell
 
+    type(domain_type), intent(inout) :: &
+         domain
+
+    type(block_type), pointer :: &
+         blockPtr
+
     type (MPAS_pool_type), pointer :: &
          meshPool, &
+         velocityWeakPool, &
+         velocityVariationalPool, &
          velocityWeakVariationalPool
 
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         strain11weak, & !< Input/Output:
-         strain22weak, & !< Input/Output:
-         strain12weak    !< Input/Output:
+    real(kind=RKIND), dimension(:), pointer :: &
+         strain11weak, &
+         strain22weak, &
+         strain12weak
 
-    real(kind=RKIND), dimension(:,:), intent(out) :: &
-         strain11var, & !< Input/Output:
-         strain22var, & !< Input/Output:
-         strain12var    !< Input/Output:
+    real(kind=RKIND), dimension(:,:), pointer :: &
+         strain11var, &
+         strain22var, &
+         strain12var
 
     real(kind=RKIND), dimension(:), pointer :: &
          strain11Vertex, &
@@ -2926,51 +2710,70 @@ contains
          iCell, &
          iVertexOnCell
 
-    call MPAS_pool_get_array(meshPool, "areaCell", areaCell)
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-    call MPAS_pool_get_array(velocityWeakVariationalPool, "strain11Vertex", strain11Vertex)
-    call MPAS_pool_get_array(velocityWeakVariationalPool, "strain22Vertex", strain22Vertex)
-    call MPAS_pool_get_array(velocityWeakVariationalPool, "strain12Vertex", strain12Vertex)
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_weak", velocityWeakPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_variational", velocityVariationalPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_weak_variational", velocityWeakVariationalPool)
 
-    do iVertex = 1, nVerticesSolve
+       call MPAS_pool_get_array(meshPool, "areaCell", areaCell)
 
-       strain11Vertex(iVertex) = 0.0_RKIND
-       strain22Vertex(iVertex) = 0.0_RKIND
-       strain12Vertex(iVertex) = 0.0_RKIND
-       denom = 0.0_RKIND
+       call MPAS_pool_get_array(velocityVariationalPool, "strain11", strain11var)
+       call MPAS_pool_get_array(velocityVariationalPool, "strain22", strain22var)
+       call MPAS_pool_get_array(velocityVariationalPool, "strain12", strain12var)
 
-       do iCellOnVertex = 1, vertexDegree
+       call MPAS_pool_get_array(velocityWeakPool, "strain11", strain11weak)
+       call MPAS_pool_get_array(velocityWeakPool, "strain22", strain22weak)
+       call MPAS_pool_get_array(velocityWeakPool, "strain12", strain12weak)
 
-          iCell = cellsOnVertex(iCellOnVertex,iVertex)
+       call MPAS_pool_get_array(velocityWeakVariationalPool, "strain11Vertex", strain11Vertex)
+       call MPAS_pool_get_array(velocityWeakVariationalPool, "strain22Vertex", strain22Vertex)
+       call MPAS_pool_get_array(velocityWeakVariationalPool, "strain12Vertex", strain12Vertex)
 
-          if (iCell >= 1 .and. iCell <= nCells) then
-             strain11Vertex(iVertex) = strain11Vertex(iVertex) + areaCell(iCell) * strain11weak(iCell)
-             strain22Vertex(iVertex) = strain22Vertex(iVertex) + areaCell(iCell) * strain22weak(iCell)
-             strain12Vertex(iVertex) = strain12Vertex(iVertex) + areaCell(iCell) * strain12weak(iCell)
-             denom = denom + areaCell(iCell)
-          endif
+       do iVertex = 1, nVerticesSolve
 
-       enddo ! iCellOnVertex
+          strain11Vertex(iVertex) = 0.0_RKIND
+          strain22Vertex(iVertex) = 0.0_RKIND
+          strain12Vertex(iVertex) = 0.0_RKIND
+          denom = 0.0_RKIND
 
-       strain11Vertex(iVertex) = strain11Vertex(iVertex) / denom
-       strain22Vertex(iVertex) = strain22Vertex(iVertex) / denom
-       strain12Vertex(iVertex) = strain12Vertex(iVertex) / denom
+          do iCellOnVertex = 1, vertexDegree
 
-    enddo ! iVertex
+             iCell = cellsOnVertex(iCellOnVertex,iVertex)
 
-    do iCell = 1, nCells
+             if (iCell >= 1 .and. iCell <= nCells) then
+                strain11Vertex(iVertex) = strain11Vertex(iVertex) + areaCell(iCell) * strain11weak(iCell)
+                strain22Vertex(iVertex) = strain22Vertex(iVertex) + areaCell(iCell) * strain22weak(iCell)
+                strain12Vertex(iVertex) = strain12Vertex(iVertex) + areaCell(iCell) * strain12weak(iCell)
+                denom = denom + areaCell(iCell)
+             endif
 
-       do iVertexOnCell = 1, nEdgesOnCell(iCell)
+          enddo ! iCellOnVertex
 
-          iVertex = verticesOnCell(iVertexOnCell,iCell)
+          strain11Vertex(iVertex) = strain11Vertex(iVertex) / denom
+          strain22Vertex(iVertex) = strain22Vertex(iVertex) / denom
+          strain12Vertex(iVertex) = strain12Vertex(iVertex) / denom
 
-          strain11var(iVertexOnCell,iCell) = strain11Vertex(iVertex)
-          strain22var(iVertexOnCell,iCell) = strain22Vertex(iVertex)
-          strain12var(iVertexOnCell,iCell) = strain12Vertex(iVertex)
+       enddo ! iVertex
 
-       enddo ! iVertexOnCell
+       do iCell = 1, nCells
 
-    enddo ! iCell
+          do iVertexOnCell = 1, nEdgesOnCell(iCell)
+
+             iVertex = verticesOnCell(iVertexOnCell,iCell)
+
+             strain11var(iVertexOnCell,iCell) = strain11Vertex(iVertex)
+             strain22var(iVertexOnCell,iCell) = strain22Vertex(iVertex)
+             strain12var(iVertexOnCell,iCell) = strain12Vertex(iVertex)
+
+          enddo ! iVertexOnCell
+
+       enddo ! iCell
+
+       blockPtr => blockPtr % next
+    end do
 
   end subroutine interpolate_strains_weak_to_variational
 
@@ -2996,7 +2799,7 @@ contains
          domain
 
     type(block_type), pointer :: &
-         block
+         blockPtr
 
     type(MPAS_pool_type), pointer :: &
          velocitySolverPool, &
@@ -3022,15 +2825,15 @@ contains
     integer :: &
          iVertex
 
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_config(block % configs, "config_use_ocean_stress", configUseOceanStress)
+       call MPAS_pool_get_config(blockPtr % configs, "config_use_ocean_stress", configUseOceanStress)
 
-       call MPAS_pool_get_dimension(block % dimensions, "nVerticesSolve", nVerticesSolve)
+       call MPAS_pool_get_dimension(blockPtr % dimensions, "nVerticesSolve", nVerticesSolve)
 
-       call MPAS_pool_get_subpool(block % structs, "icestate", icestatePool)
-       call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "icestate", icestatePool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
 
        call MPAS_pool_get_array(velocitySolverPool, "oceanStressCoeff", oceanStressCoeff)
 
@@ -3079,7 +2882,7 @@ contains
 
        endif ! configUseOceanStress
 
-       block => block % next
+       blockPtr => blockPtr % next
     end do
 
   end subroutine ocean_stress_coefficient
@@ -3102,7 +2905,7 @@ contains
          domain
 
     type(block_type), pointer :: &
-         block
+         blockPtr
 
     type(MPAS_pool_type), pointer :: &
          velocitySolverPool, &
@@ -3144,13 +2947,13 @@ contains
     integer :: &
          iVertex
 
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_dimension(block % dimensions, "nVerticesSolve", nVerticesSolve)
+       call MPAS_pool_get_dimension(blockPtr % dimensions, "nVerticesSolve", nVerticesSolve)
 
-       call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
-       call MPAS_pool_get_subpool(block % structs, "icestate", icestatePool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "icestate", icestatePool)
 
        call MPAS_pool_get_array(icestatePool, "totalMassVertex", totalMassVertex)
 
@@ -3205,7 +3008,7 @@ contains
 
        enddo ! iVertex
 
-       block => block % next
+       blockPtr => blockPtr % next
     end do
 
   end subroutine solve_velocity
@@ -3231,7 +3034,7 @@ contains
          domain
 
     type(block_type), pointer :: &
-         block
+         blockPtr
 
     type(MPAS_pool_type), pointer :: &
          velocitySolverPool, &
@@ -3275,13 +3078,13 @@ contains
     integer :: &
          iVertex
 
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_dimension(block % dimensions, "nVerticesSolve", nVerticesSolve)
+       call MPAS_pool_get_dimension(blockPtr % dimensions, "nVerticesSolve", nVerticesSolve)
 
-       call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
-       call MPAS_pool_get_subpool(block % structs, "icestate", icestatePool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "icestate", icestatePool)
 
        call MPAS_pool_get_array(icestatePool, "totalMassVertex", totalMassVertex)
 
@@ -3339,7 +3142,7 @@ contains
 
        enddo ! iVertex
 
-       block => block % next
+       blockPtr => blockPtr % next
     end do
 
   end subroutine solve_velocity_revised
@@ -3405,29 +3208,20 @@ contains
     type(domain_type), intent(inout) :: &
          domain
 
-    type(block_type), pointer :: &
-         block
-
     character(len=strKIND), pointer :: &
          config_stress_divergence_scheme
 
-    block => domain % blocklist
-    do while (associated(block))
+    call MPAS_pool_get_config(domain % configs, "config_stress_divergence_scheme", config_stress_divergence_scheme)
 
-       call MPAS_pool_get_config(block % configs, "config_stress_divergence_scheme", config_stress_divergence_scheme)
+    if (trim(config_stress_divergence_scheme) == "weak") then
 
-       if (trim(config_stress_divergence_scheme) == "weak") then
+       call seaice_final_divergence_shear_weak(domain)
 
-          call seaice_final_divergence_shear_weak(block)
+    else if (trim(config_stress_divergence_scheme) == "variational") then
 
-       else if (trim(config_stress_divergence_scheme) == "variational") then
+       call seaice_final_divergence_shear_variational(domain)
 
-          call seaice_final_divergence_shear_variational(block)
-
-       endif
-
-       block => block % next
-    enddo
+    endif
 
   end subroutine final_divergence_shear
 
@@ -3449,7 +3243,7 @@ contains
          domain
 
     type(block_type), pointer :: &
-         block
+         blockPtr
 
     type(MPAS_pool_type), pointer :: &
          velocityWeakPool, &
@@ -3489,17 +3283,17 @@ contains
     character(len=strKIND), pointer :: &
          config_stress_divergence_scheme
 
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_config(block % configs, "config_stress_divergence_scheme", config_stress_divergence_scheme)
+       call MPAS_pool_get_config(blockPtr % configs, "config_stress_divergence_scheme", config_stress_divergence_scheme)
 
-       call MPAS_pool_get_dimension(block % dimensions, "nCellsSolve", nCellsSolve)
+       call MPAS_pool_get_dimension(blockPtr % dimensions, "nCellsSolve", nCellsSolve)
 
        ! calculate the principal stresses
        if (trim(config_stress_divergence_scheme) == "weak") then
 
-          call MPAS_pool_get_subpool(block % structs, "velocity_weak", velocityWeakPool)
+          call MPAS_pool_get_subpool(blockPtr % structs, "velocity_weak", velocityWeakPool)
 
           call MPAS_pool_get_array(velocityWeakPool, "stress11", stress11Weak)
           call MPAS_pool_get_array(velocityWeakPool, "stress22", stress22Weak)
@@ -3522,8 +3316,8 @@ contains
 
        else if (trim(config_stress_divergence_scheme) == "variational") then
 
-          call MPAS_pool_get_subpool(block % structs, "velocity_variational", velocityVariationalPool)
-          call MPAS_pool_get_subpool(block % structs, "mesh", meshPool)
+          call MPAS_pool_get_subpool(blockPtr % structs, "velocity_variational", velocityVariationalPool)
+          call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
 
           call MPAS_pool_get_array(meshPool, "nEdgesOnCell", nEdgesOnCell)
 
@@ -3550,7 +3344,7 @@ contains
 
        endif
 
-       block => block % next
+       blockPtr => blockPtr % next
     enddo
 
   end subroutine principal_stresses_driver!}}}
@@ -3636,7 +3430,7 @@ contains
          domain
 
     type(block_type), pointer :: &
-         block
+         blockPtr
 
     type(MPAS_pool_type), pointer :: &
          meshPool, &
@@ -3680,14 +3474,14 @@ contains
     call MPAS_pool_get_config(domain % blocklist % configs, "config_use_ocean_stress", configUseOceanStress)
 
     ! get ocean stress on vertices
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_dimension(block % dimensions, "nVerticesSolve", nVerticesSolve)
+       call MPAS_pool_get_dimension(blockPtr % dimensions, "nVerticesSolve", nVerticesSolve)
 
-       call MPAS_pool_get_subpool(block % structs, "mesh", meshPool)
-       call MPAS_pool_get_subpool(block % structs, "icestate", icestatePool)
-       call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "icestate", icestatePool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
 
        call MPAS_pool_get_array(velocitySolverPool, "oceanStressU", oceanStressU)
        call MPAS_pool_get_array(velocitySolverPool, "oceanStressV", oceanStressV)
@@ -3742,7 +3536,7 @@ contains
 
        endif
 
-       block => block % next
+       blockPtr => blockPtr % next
     end do
 
     ! get ocean stress on cells
@@ -3793,15 +3587,15 @@ contains
 
        call seaice_load_balance_timers(domain, "vel prep after")
 
-       block => domain % blocklist
-       do while (associated(block))
+       blockPtr => domain % blocklist
+       do while (associated(blockPtr))
 
-          call MPAS_pool_get_dimension(block % dimensions, "nVerticesSolve", nVerticesSolve)
+          call MPAS_pool_get_dimension(blockPtr % dimensions, "nVerticesSolve", nVerticesSolve)
 
-          call MPAS_pool_get_subpool(block % structs, "mesh", meshPool)
-          call MPAS_pool_get_subpool(block % structs, "boundary", boundaryPool)
-          call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
-          call MPAS_pool_get_subpool(block % structs, "icestate", icestatePool)
+          call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+          call MPAS_pool_get_subpool(blockPtr % structs, "boundary", boundaryPool)
+          call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
+          call MPAS_pool_get_subpool(blockPtr % structs, "icestate", icestatePool)
 
           call MPAS_pool_get_array(icestatePool, "iceAreaVertex", iceAreaVertex)
 
@@ -3827,15 +3621,15 @@ contains
 
           enddo ! iVertex
 
-          block => block % next
+          blockPtr => blockPtr % next
        end do
 
     else
 
-       block => domain % blocklist
-       do while (associated(block))
+       blockPtr => domain % blocklist
+       do while (associated(blockPtr))
 
-          call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
+          call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
 
           call MPAS_pool_get_array(velocitySolverPool, "oceanStressCellU", oceanStressCellU)
           call MPAS_pool_get_array(velocitySolverPool, "oceanStressCellV", oceanStressCellV)
@@ -3843,7 +3637,7 @@ contains
           oceanStressCellU = 0.0_RKIND
           oceanStressCellV = 0.0_RKIND
 
-          block => block % next
+          blockPtr => blockPtr % next
        end do
 
     endif ! configUseOceanStress

--- a/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver_constitutive_relation.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver_constitutive_relation.F
@@ -76,14 +76,14 @@ contains
 
     type(domain_type) :: domain
 
-    type(block_type), pointer :: block
+    type(block_type), pointer :: blockPtr
 
     character(len=strKIND), pointer :: &
          config_constitutive_relation_type
 
     type(MPAS_pool_type), pointer :: &
-         velocitySolver, &
-         mesh
+         velocitySolverPool, &
+         meshPool
 
     real(kind=RKIND), pointer :: &
          dynamicsTimeStep, &
@@ -115,50 +115,47 @@ contains
     endif
 
     ! general EVP
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolver)
-       call MPAS_pool_get_array(velocitySolver, "dynamicsTimeStep", dynamicsTimeStep)
-       call MPAS_pool_get_array(velocitySolver, "elasticTimeStep", elasticTimeStep)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
+       call MPAS_pool_get_array(velocitySolverPool, "dynamicsTimeStep", dynamicsTimeStep)
+       call MPAS_pool_get_array(velocitySolverPool, "elasticTimeStep", elasticTimeStep)
 
        dampingTimescale = dampingTimescaleParameter * dynamicsTimeStep
 
        evpDampingCriterion = (1230.0_RKIND * dampingTimescale) / elasticTimeStep**2
 
-       block => block % next
+       blockPtr => blockPtr % next
     enddo
 
     ! find the minimum edge length in the grid
     dvEdgeMin = 1.0e30_RKIND
 
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       call MPAS_pool_get_subpool(block % structs, "mesh", mesh)
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
 
-       call MPAS_pool_get_dimension(mesh, "nEdgesSolve", nEdgesSolve)
+       call MPAS_pool_get_dimension(meshPool, "nEdgesSolve", nEdgesSolve)
 
-       call MPAS_pool_get_array(mesh, "dvEdge", dvEdge)
+       call MPAS_pool_get_array(meshPool, "dvEdge", dvEdge)
 
        dvEdgeMin = min(dvEdgeMin, minval(dvEdge(1:nEdgesSolve)))
 
-       block => block % next
+       blockPtr => blockPtr % next
     enddo
 
     call mpas_dmpar_min_real(domain % dminfo, dvEdgeMin, dvEdgeMinGlobal)
 
-    !!!! Testing!
-    !dvEdgeMinGlobal = 8558.2317072059941_RKIND
-
     ! Bouillon et al. 2013
-    block => domain % blocklist
-    do while (associated(block))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
        gamma = 0.25_RKIND * 1.0e11_RKIND * dynamicsTimeStep
        numericalInertiaCoefficient = (2.0_RKIND * dampingRatioDenominator * dampingRatio * gamma) / dvEdgeMinGlobal**2
 
-       block => block % next
+       blockPtr => blockPtr % next
     enddo
 
   end subroutine seaice_init_evp

--- a/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver_pwl.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver_pwl.F
@@ -14,6 +14,7 @@ module seaice_velocity_solver_pwl
 
   use mpas_derived_types
   use mpas_pool_routines
+  use mpas_timer
 
   implicit none
 
@@ -41,53 +42,60 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_init_velocity_solver_pwl(&
-       nCells, &
-       maxEdges, &
-       nEdgesOnCell, &
-       verticesOnCell, &
-       edgesOnCell, &
-       dvEdge, &
-       areaCell, &
-       xLocal, &
-       yLocal, &
-       basisGradientU, &
-       basisGradientV, &
-       basisIntegralsMetric, &
-       basisIntegralsU, &
-       basisIntegralsV)!{{{
+  subroutine seaice_init_velocity_solver_pwl(domain)!{{{
 
     use seaice_numerics, only: &
          seaice_solve_linear_basis_system
 
-    use seaice_velocity_solver_variational_shared, only: &
-         seaice_wrapped_index
+    use seaice_mesh, only: &
+         seaice_wrapped_index, &
+         seaice_calc_local_coords
 
-    real(kind=RKIND), dimension(:,:), intent(in) :: &
-         xLocal, & !< Input:
-         yLocal    !< Input:
+    type (domain_type), intent(inout) :: &
+         domain !< Input/Output:
 
-    integer, intent(in) :: &
-         nCells, & !< Input:
-         maxEdges  !< Input:
+    type(block_type), pointer :: &
+         blockPtr
 
-    integer, dimension(:), intent(in) :: &
-         nEdgesOnCell !< Input:
+    logical, pointer :: &
+         on_a_sphere, &
+         config_rotate_cartesian_grid
 
-    integer, dimension(:,:), intent(in) :: &
-         verticesOnCell, & !< Input:
-         edgesOnCell       !< Input:
+    real(kind=RKIND), pointer :: &
+         sphere_radius
 
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         dvEdge, & !< Input:
-         areaCell  !< Input:
+    type(MPAS_pool_type), pointer :: &
+         meshPool, &
+         velocityVariationalPool
 
-    real(kind=RKIND), dimension(:,:,:), intent(out) :: &
-         basisGradientU, &       !< Output:
-         basisGradientV, &       !< Output:
-         basisIntegralsMetric, & !< Output:
-         basisIntegralsU, &      !< Output:
-         basisIntegralsV         !< Output:
+    integer, pointer :: &
+         nCells, &
+         maxEdges
+
+    integer, dimension(:), pointer :: &
+         nEdgesOnCell
+
+    integer, dimension(:,:), pointer :: &
+         verticesOnCell, &
+         cellsOnVertex, &
+         edgesOnCell
+
+    real(kind=RKIND), dimension(:), pointer :: &
+         xVertex, &
+         yVertex, &
+         zVertex, &
+         xCell, &
+         yCell, &
+         zCell, &
+         areaCell, &
+         dvEdge
+
+    real(kind=RKIND), dimension(:,:,:), pointer :: &
+         basisGradientU, &
+         basisGradientV, &
+         basisIntegralsMetric, &
+         basisIntegralsU, &
+         basisIntegralsV
 
     real(kind=RKIND) :: &
          xPWLCentre, &
@@ -123,6 +131,8 @@ contains
          solutionVector
 
     real(kind=RKIND), dimension(:,:), allocatable :: &
+         xLocal, &
+         yLocal, &
          subBasisGradientU, &
          subBasisGradientV, &
          subBasisConstant, &
@@ -131,244 +141,298 @@ contains
 
     real(kind=RKIND), dimension(:), allocatable :: &
          basisSubArea
+call MPAS_pool_get_config(domain % configs, "config_rotate_cartesian_grid", config_rotate_cartesian_grid)
 
-    allocate(subBasisGradientU(maxEdges,3))
-    allocate(subBasisGradientV(maxEdges,3))
-    allocate(subBasisConstant(maxEdges,3))
-    allocate(subCellgradientU(maxEdges,maxEdges))
-    allocate(subCellgradientV(maxEdges,maxEdges))
-    allocate(basisSubArea(maxEdges))
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-    ! loop over cells
-    do iCell = 1, nCells
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_variational", velocityVariationalPool)
 
-       alphaPWL = 1.0_RKIND / real(nEdgesOnCell(iCell),RKIND)
+       call MPAS_pool_get_config(meshPool, "on_a_sphere", on_a_sphere)
+       call MPAS_pool_get_config(meshPool, "sphere_radius", sphere_radius)
 
-       ! determine cell centre for piecewise linear basis
-       xPWLCentre = 0.0_RKIND
-       yPWLCentre = 0.0_RKIND
+       call MPAS_pool_get_dimension(meshPool, "nCells", nCells)
+       call MPAS_pool_get_dimension(meshPool, "maxEdges", maxEdges)
 
-       do iVertexOnCell = 1, nEdgesOnCell(iCell)
+       call MPAS_pool_get_array(meshPool, "nEdgesOnCell", nEdgesOnCell)
+       call MPAS_pool_get_array(meshPool, "verticesOnCell", verticesOnCell)
+       call MPAS_pool_get_array(meshPool, "edgesOnCell", edgesOnCell)
+       call MPAS_pool_get_array(meshPool, "xVertex", xVertex)
+       call MPAS_pool_get_array(meshPool, "yVertex", yVertex)
+       call MPAS_pool_get_array(meshPool, "zVertex", zVertex)
+       call MPAS_pool_get_array(meshPool, "xCell", xCell)
+       call MPAS_pool_get_array(meshPool, "yCell", yCell)
+       call MPAS_pool_get_array(meshPool, "zCell", zCell)
+       call MPAS_pool_get_array(meshPool, "areaCell", areaCell)
+       call MPAS_pool_get_array(meshPool, "dvEdge", dvEdge)
 
-          xPWLCentre = xPWLCentre + alphaPWL * xLocal(iVertexOnCell,iCell)
-          yPWLCentre = yPWLCentre + alphaPWL * yLocal(iVertexOnCell,iCell)
+       call MPAS_pool_get_array(velocityVariationalPool, "basisGradientU", basisGradientU)
+       call MPAS_pool_get_array(velocityVariationalPool, "basisGradientV", basisGradientV)
+       call MPAS_pool_get_array(velocityVariationalPool, "basisIntegralsU", basisIntegralsU)
+       call MPAS_pool_get_array(velocityVariationalPool, "basisIntegralsV", basisIntegralsV)
+       call MPAS_pool_get_array(velocityVariationalPool, "basisIntegralsMetric", basisIntegralsMetric)
 
-       enddo ! iVertexOnCell
+       call mpas_timer_start("variational calc_local_coords")
+       allocate(xLocal(maxEdges,nCells))
+       allocate(yLocal(maxEdges,nCells))
 
-       ! calculate the area of the subcells
-       basisSubAreaSum = 0.0_RKIND
+       call seaice_calc_local_coords(&
+            xLocal, &
+            yLocal, &
+            nCells, &
+            nEdgesOnCell, &
+            verticesOnCell, &
+            xVertex, &
+            yVertex, &
+            zVertex, &
+            xCell, &
+            yCell, &
+            zCell, &
+            config_rotate_cartesian_grid, &
+            on_a_sphere)
+       call mpas_timer_stop("variational calc_local_coords")
 
-       do iSubCell = 1, nEdgesOnCell(iCell)
+       allocate(subBasisGradientU(maxEdges,3))
+       allocate(subBasisGradientV(maxEdges,3))
+       allocate(subBasisConstant(maxEdges,3))
+       allocate(subCellgradientU(maxEdges,maxEdges))
+       allocate(subCellgradientV(maxEdges,maxEdges))
+       allocate(basisSubArea(maxEdges))
 
-          iEdge = edgesOnCell(iSubCell,iCell)
-          iVertexOnCell1 = seaice_wrapped_index(iSubCell - 1, nEdgesOnCell(iCell))
-          iVertexOnCell2 = iSubCell
+       ! loop over cells
+       do iCell = 1, nCells
 
-          c = dvEdge(iEdge)
-          a = sqrt((xLocal(iVertexOnCell1,iCell) - xPWLCentre)**2 + &
-                   (yLocal(iVertexOnCell1,iCell) - yPWLCentre)**2)
-          b = sqrt((xLocal(iVertexOnCell2,iCell) - xPWLCentre)**2 + &
-                   (yLocal(iVertexOnCell2,iCell) - yPWLCentre)**2)
+          alphaPWL = 1.0_RKIND / real(nEdgesOnCell(iCell),RKIND)
 
-          s = (a + b + c) * 0.5_RKIND
+          ! determine cell centre for piecewise linear basis
+          xPWLCentre = 0.0_RKIND
+          yPWLCentre = 0.0_RKIND
 
-          ! Heron's formula
-          basisSubArea(iSubCell) = sqrt(s * (s-a) * (s-b) * (s-c))
+          do iVertexOnCell = 1, nEdgesOnCell(iCell)
 
-          basisSubAreaSum = basisSubAreaSum + basisSubArea(iSubCell)
+             xPWLCentre = xPWLCentre + alphaPWL * xLocal(iVertexOnCell,iCell)
+             yPWLCentre = yPWLCentre + alphaPWL * yLocal(iVertexOnCell,iCell)
 
-       enddo ! iSubCell
+          enddo ! iVertexOnCell
 
-       ! ensure sum of subareas equals the area of the cell
-       basisSubArea(:) = basisSubArea(:) * (areaCell(iCell) / basisSubAreaSum)
+          ! calculate the area of the subcells
+          basisSubAreaSum = 0.0_RKIND
 
-       ! calculate the linear basis on the sub triangle
-       do iSubCell = 1, nEdgesOnCell(iCell)
-
-          iVertexOnCell1 = seaice_wrapped_index(iSubCell - 1, nEdgesOnCell(iCell))
-          iVertexOnCell2 = iSubCell
-
-          ! set up left hand matrix
-          leftMatrix(1,1) = xLocal(iVertexOnCell1,iCell) - xPWLCentre
-          leftMatrix(1,2) = yLocal(iVertexOnCell1,iCell) - yPWLCentre
-          leftMatrix(1,3) = 1.0_RKIND
-
-          leftMatrix(2,1) = xLocal(iVertexOnCell2,iCell) - xPWLCentre
-          leftMatrix(2,2) = yLocal(iVertexOnCell2,iCell) - yPWLCentre
-          leftMatrix(2,3) = 1.0_RKIND
-
-          leftMatrix(3,1) = 0.0_RKIND
-          leftMatrix(3,2) = 0.0_RKIND
-          leftMatrix(3,3) = 1.0_RKIND
-
-          ! first basis
-          rightHandSide(1) = 1.0_RKIND
-          rightHandSide(2) = 0.0_RKIND
-          rightHandSide(3) = 0.0_RKIND
-
-          call seaice_solve_linear_basis_system(leftMatrix, rightHandSide, solutionVector)
-
-          subBasisGradientU(iSubCell,1) = solutionVector(1)
-          subBasisGradientV(iSubCell,1) = solutionVector(2)
-          subBasisConstant(iSubCell,1)  = solutionVector(3)
-
-          ! second basis
-          rightHandSide(1) = 0.0_RKIND
-          rightHandSide(2) = 1.0_RKIND
-          rightHandSide(3) = 0.0_RKIND
-
-          call seaice_solve_linear_basis_system(leftMatrix, rightHandSide, solutionVector)
-
-          subBasisGradientU(iSubCell,2) = solutionVector(1)
-          subBasisGradientV(iSubCell,2) = solutionVector(2)
-          subBasisConstant(iSubCell,2)  = solutionVector(3)
-
-          ! third basis
-          subBasisGradientU(iSubCell,3) = -subBasisGradientU(iSubCell,1) - subBasisGradientU(iSubCell,2)
-          subBasisGradientV(iSubCell,3) = -subBasisGradientV(iSubCell,1) - subBasisGradientV(iSubCell,2)
-          subBasisConstant(iSubCell,3)  = 1.0_RKIND - subBasisConstant(iSubCell,1) - subBasisConstant(iSubCell,2)
-
-       enddo ! iSubCell
-
-       ! use the linear sub area basis to calculate the PWL basis
-       do iBasisVertex = 1, nEdgesOnCell(iCell)
-
-          ! loop over subcells
           do iSubCell = 1, nEdgesOnCell(iCell)
 
-             ! array (index of the basis vertex, subarea value)
-             subCellGradientU(iBasisVertex,iSubCell) = subBasisGradientU(iSubCell,3) * alphaPWL
-             subCellGradientV(iBasisVertex,iSubCell) = subBasisGradientV(iSubCell,3) * alphaPWL
+             iEdge = edgesOnCell(iSubCell,iCell)
+             iVertexOnCell1 = seaice_wrapped_index(iSubCell - 1, nEdgesOnCell(iCell))
+             iVertexOnCell2 = iSubCell
 
-             if (iSubCell == seaice_wrapped_index(iBasisVertex + 1, nEdgesOnCell(iCell))) then
+             c = dvEdge(iEdge)
+             a = sqrt((xLocal(iVertexOnCell1,iCell) - xPWLCentre)**2 + &
+                  (yLocal(iVertexOnCell1,iCell) - yPWLCentre)**2)
+             b = sqrt((xLocal(iVertexOnCell2,iCell) - xPWLCentre)**2 + &
+                  (yLocal(iVertexOnCell2,iCell) - yPWLCentre)**2)
 
-                subCellGradientU(iBasisVertex,iSubCell) = subCellGradientU(iBasisVertex,iSubCell) + subBasisGradientU(iSubCell,1)
-                subCellGradientV(iBasisVertex,iSubCell) = subCellGradientV(iBasisVertex,iSubCell) + subBasisGradientV(iSubCell,1)
+             s = (a + b + c) * 0.5_RKIND
 
-             else if (iSubCell == iBasisVertex) then
+             ! Heron's formula
+             basisSubArea(iSubCell) = sqrt(s * (s-a) * (s-b) * (s-c))
 
-                subCellGradientU(iBasisVertex,iSubCell) = subCellGradientU(iBasisVertex,iSubCell) + subBasisGradientU(iSubCell,2)
-                subCellGradientV(iBasisVertex,iSubCell) = subCellGradientV(iBasisVertex,iSubCell) + subBasisGradientV(iSubCell,2)
-
-             endif
+             basisSubAreaSum = basisSubAreaSum + basisSubArea(iSubCell)
 
           enddo ! iSubCell
 
-       enddo ! iEdgeOnCell
+          ! ensure sum of subareas equals the area of the cell
+          basisSubArea(:) = basisSubArea(:) * (areaCell(iCell) / basisSubAreaSum)
 
-       ! calculate the gradients at the cell corners
-       do iBasisVertex = 1, nEdgesOnCell(iCell)
+          ! calculate the linear basis on the sub triangle
+          do iSubCell = 1, nEdgesOnCell(iCell)
 
-          do iGradientVertex = 1, nEdgesOnCell(iCell)
+             iVertexOnCell1 = seaice_wrapped_index(iSubCell - 1, nEdgesOnCell(iCell))
+             iVertexOnCell2 = iSubCell
 
-             iSubCell1 = iGradientVertex
-             iSubCell2 = seaice_wrapped_index(iGradientVertex + 1, nEdgesOnCell(iCell))
+             ! set up left hand matrix
+             leftMatrix(1,1) = xLocal(iVertexOnCell1,iCell) - xPWLCentre
+             leftMatrix(1,2) = yLocal(iVertexOnCell1,iCell) - yPWLCentre
+             leftMatrix(1,3) = 1.0_RKIND
 
-             basisGradientU(iBasisVertex,iGradientVertex,iCell) = &
-                  0.5_RKIND * (subCellGradientU(iBasisVertex,iSubCell1) + subCellGradientU(iBasisVertex,iSubCell2))
-             basisGradientV(iBasisVertex,iGradientVertex,iCell) = &
-                  0.5_RKIND * (subCellGradientV(iBasisVertex,iSubCell1) + subCellGradientV(iBasisVertex,iSubCell2))
+             leftMatrix(2,1) = xLocal(iVertexOnCell2,iCell) - xPWLCentre
+             leftMatrix(2,2) = yLocal(iVertexOnCell2,iCell) - yPWLCentre
+             leftMatrix(2,3) = 1.0_RKIND
 
-          enddo ! iGradientVertex
+             leftMatrix(3,1) = 0.0_RKIND
+             leftMatrix(3,2) = 0.0_RKIND
+             leftMatrix(3,3) = 1.0_RKIND
 
-       enddo ! iBasisVertex
+             ! first basis
+             rightHandSide(1) = 1.0_RKIND
+             rightHandSide(2) = 0.0_RKIND
+             rightHandSide(3) = 0.0_RKIND
 
-       ! calculate the basis integrals
-       do iStressVertex = 1, nEdgesOnCell(iCell)
-          do iVelocityVertex = 1, nEdgesOnCell(iCell)
+             call seaice_solve_linear_basis_system(leftMatrix, rightHandSide, solutionVector)
 
-             basisIntegralsU(iStressVertex,iVelocityVertex,iCell) = 0.0_RKIND
-             basisIntegralsV(iStressVertex,iVelocityVertex,iCell) = 0.0_RKIND
+             subBasisGradientU(iSubCell,1) = solutionVector(1)
+             subBasisGradientV(iSubCell,1) = solutionVector(2)
+             subBasisConstant(iSubCell,1)  = solutionVector(3)
 
+             ! second basis
+             rightHandSide(1) = 0.0_RKIND
+             rightHandSide(2) = 1.0_RKIND
+             rightHandSide(3) = 0.0_RKIND
+
+             call seaice_solve_linear_basis_system(leftMatrix, rightHandSide, solutionVector)
+
+             subBasisGradientU(iSubCell,2) = solutionVector(1)
+             subBasisGradientV(iSubCell,2) = solutionVector(2)
+             subBasisConstant(iSubCell,2)  = solutionVector(3)
+
+             ! third basis
+             subBasisGradientU(iSubCell,3) = -subBasisGradientU(iSubCell,1) - subBasisGradientU(iSubCell,2)
+             subBasisGradientV(iSubCell,3) = -subBasisGradientV(iSubCell,1) - subBasisGradientV(iSubCell,2)
+             subBasisConstant(iSubCell,3)  = 1.0_RKIND - subBasisConstant(iSubCell,1) - subBasisConstant(iSubCell,2)
+
+          enddo ! iSubCell
+
+          ! use the linear sub area basis to calculate the PWL basis
+          do iBasisVertex = 1, nEdgesOnCell(iCell)
+
+             ! loop over subcells
              do iSubCell = 1, nEdgesOnCell(iCell)
 
-                if (iSubCell == iStressVertex .or. iSubCell == seaice_wrapped_index(iStressVertex + 1, nEdgesOnCell(iCell))) then
-                   basisIntegral = ((alphaPWL + 1) * basisSubArea(iSubCell)) / 3.0_RKIND
-                else
-                   basisIntegral = ( alphaPWL      * basisSubArea(iSubCell)) / 3.0_RKIND
+                ! array (index of the basis vertex, subarea value)
+                subCellGradientU(iBasisVertex,iSubCell) = subBasisGradientU(iSubCell,3) * alphaPWL
+                subCellGradientV(iBasisVertex,iSubCell) = subBasisGradientV(iSubCell,3) * alphaPWL
+
+                if (iSubCell == seaice_wrapped_index(iBasisVertex + 1, nEdgesOnCell(iCell))) then
+
+                   subCellGradientU(iBasisVertex,iSubCell) = subCellGradientU(iBasisVertex,iSubCell) + subBasisGradientU(iSubCell,1)
+                   subCellGradientV(iBasisVertex,iSubCell) = subCellGradientV(iBasisVertex,iSubCell) + subBasisGradientV(iSubCell,1)
+
+                else if (iSubCell == iBasisVertex) then
+
+                   subCellGradientU(iBasisVertex,iSubCell) = subCellGradientU(iBasisVertex,iSubCell) + subBasisGradientU(iSubCell,2)
+                   subCellGradientV(iBasisVertex,iSubCell) = subCellGradientV(iBasisVertex,iSubCell) + subBasisGradientV(iSubCell,2)
+
                 endif
-
-                basisIntegralsU(iStressVertex,iVelocityVertex,iCell) = basisIntegralsU(iStressVertex,iVelocityVertex,iCell) + &
-                     subCellGradientU(iVelocityVertex,iSubCell) * basisIntegral
-
-                basisIntegralsV(iStressVertex,iVelocityVertex,iCell) = basisIntegralsV(iStressVertex,iVelocityVertex,iCell) + &
-                     subCellGradientV(iVelocityVertex,iSubCell) * basisIntegral
 
              enddo ! iSubCell
 
-          enddo ! iVelocityVertex
-       enddo ! iStressVertex
+          enddo ! iEdgeOnCell
 
-       ! basis integrals for the metric terms
-       do iStressVertex = 1, nEdgesOnCell(iCell)
-          do iVelocityVertex = 1, nEdgesOnCell(iCell)
+          ! calculate the gradients at the cell corners
+          do iBasisVertex = 1, nEdgesOnCell(iCell)
 
-             basisIntegralsMetric(iStressVertex,iVelocityVertex,iCell) = 0.0_RKIND
+             do iGradientVertex = 1, nEdgesOnCell(iCell)
 
-             do iSubCell = 1, nEdgesOnCell(iCell)
+                iSubCell1 = iGradientVertex
+                iSubCell2 = seaice_wrapped_index(iGradientVertex + 1, nEdgesOnCell(iCell))
 
-                ! determine stress subcell type
-                if (iSubCell == seaice_wrapped_index(iStressVertex + 1, nEdgesOnCell(iCell))) then
-                   subCellTypeStress = 1
-                else if (iSubCell == iStressVertex) then
-                   subCellTypeStress = 2
-                else
-                   subCellTypeStress = 3
-                endif
+                basisGradientU(iBasisVertex,iGradientVertex,iCell) = &
+                     0.5_RKIND * (subCellGradientU(iBasisVertex,iSubCell1) + subCellGradientU(iBasisVertex,iSubCell2))
+                basisGradientV(iBasisVertex,iGradientVertex,iCell) = &
+                     0.5_RKIND * (subCellGradientV(iBasisVertex,iSubCell1) + subCellGradientV(iBasisVertex,iSubCell2))
 
-                ! determine velocity subcell type
-                if (iSubCell == seaice_wrapped_index(iVelocityVertex + 1, nEdgesOnCell(iCell))) then
-                   subCellTypeVelocity = 1
-                else if (iSubCell == iVelocityVertex) then
-                   subCellTypeVelocity = 2
-                else
-                   subCellTypeVelocity = 3
-                endif
+             enddo ! iGradientVertex
 
-                ! set the subcell integral value
-                if      ((subCellTypeStress == 1 .and. subCellTypeVelocity == 1) .or. &
-                         (subCellTypeStress == 2 .and. subCellTypeVelocity == 2)) then
+          enddo ! iBasisVertex
 
-                   basisIntegralsMetricSubCell = 2.0_RKIND * alphaPWL**2 + 2.0_RKIND * alphaPWL + 2.0_RKIND
+          ! calculate the basis integrals
+          do iStressVertex = 1, nEdgesOnCell(iCell)
+             do iVelocityVertex = 1, nEdgesOnCell(iCell)
 
-                else if ((subCellTypeStress == 1 .and. subCellTypeVelocity == 2) .or. &
-                         (subCellTypeStress == 2 .and. subCellTypeVelocity == 1)) then
+                basisIntegralsU(iStressVertex,iVelocityVertex,iCell) = 0.0_RKIND
+                basisIntegralsV(iStressVertex,iVelocityVertex,iCell) = 0.0_RKIND
 
-                   basisIntegralsMetricSubCell = 2.0_RKIND * alphaPWL**2 + 2.0_RKIND * alphaPWL + 1.0_RKIND
+                do iSubCell = 1, nEdgesOnCell(iCell)
 
-                else if ((subCellTypeStress == 1 .and. subCellTypeVelocity == 3) .or. &
-                         (subCellTypeStress == 3 .and. subCellTypeVelocity == 1) .or. &
-                         (subCellTypeStress == 2 .and. subCellTypeVelocity == 3) .or. &
-                         (subCellTypeStress == 3 .and. subCellTypeVelocity == 2)) then
+                   if (iSubCell == iStressVertex .or. iSubCell == seaice_wrapped_index(iStressVertex + 1, nEdgesOnCell(iCell))) then
+                      basisIntegral = ((alphaPWL + 1) * basisSubArea(iSubCell)) / 3.0_RKIND
+                   else
+                      basisIntegral = ( alphaPWL      * basisSubArea(iSubCell)) / 3.0_RKIND
+                   endif
 
-                   basisIntegralsMetricSubCell = 2.0_RKIND * alphaPWL**2 + alphaPWL
+                   basisIntegralsU(iStressVertex,iVelocityVertex,iCell) = basisIntegralsU(iStressVertex,iVelocityVertex,iCell) + &
+                        subCellGradientU(iVelocityVertex,iSubCell) * basisIntegral
 
-                else if  (subCellTypeStress == 3 .and. subCellTypeVelocity == 3) then
+                   basisIntegralsV(iStressVertex,iVelocityVertex,iCell) = basisIntegralsV(iStressVertex,iVelocityVertex,iCell) + &
+                        subCellGradientV(iVelocityVertex,iSubCell) * basisIntegral
 
-                   basisIntegralsMetricSubCell = 2.0_RKIND * alphaPWL**2
+                enddo ! iSubCell
 
-                end if
+             enddo ! iVelocityVertex
+          enddo ! iStressVertex
 
-                basisIntegralsMetricSubCell = basisIntegralsMetricSubCell * &
-                     basisSubArea(iSubCell) / 12.0_RKIND
+          ! basis integrals for the metric terms
+          do iStressVertex = 1, nEdgesOnCell(iCell)
+             do iVelocityVertex = 1, nEdgesOnCell(iCell)
 
-                basisIntegralsMetric(iStressVertex,iVelocityVertex,iCell) = &
-                     basisIntegralsMetric(iStressVertex,iVelocityVertex,iCell) + &
-                     basisIntegralsMetricSubCell
+                basisIntegralsMetric(iStressVertex,iVelocityVertex,iCell) = 0.0_RKIND
 
-             enddo ! iSubCell
+                do iSubCell = 1, nEdgesOnCell(iCell)
 
-          enddo ! iVelocityVertex
-       enddo ! iStressVertex
+                   ! determine stress subcell type
+                   if (iSubCell == seaice_wrapped_index(iStressVertex + 1, nEdgesOnCell(iCell))) then
+                      subCellTypeStress = 1
+                   else if (iSubCell == iStressVertex) then
+                      subCellTypeStress = 2
+                   else
+                      subCellTypeStress = 3
+                   endif
 
-    enddo ! iCell
+                   ! determine velocity subcell type
+                   if (iSubCell == seaice_wrapped_index(iVelocityVertex + 1, nEdgesOnCell(iCell))) then
+                      subCellTypeVelocity = 1
+                   else if (iSubCell == iVelocityVertex) then
+                      subCellTypeVelocity = 2
+                   else
+                      subCellTypeVelocity = 3
+                   endif
 
-    deallocate(subBasisGradientU)
-    deallocate(subBasisGradientV)
-    deallocate(subBasisConstant)
-    deallocate(subCellgradientU)
-    deallocate(subCellgradientV)
-    deallocate(basisSubArea)
+                   ! set the subcell integral value
+                   if      ((subCellTypeStress == 1 .and. subCellTypeVelocity == 1) .or. &
+                        (subCellTypeStress == 2 .and. subCellTypeVelocity == 2)) then
+
+                      basisIntegralsMetricSubCell = 2.0_RKIND * alphaPWL**2 + 2.0_RKIND * alphaPWL + 2.0_RKIND
+
+                   else if ((subCellTypeStress == 1 .and. subCellTypeVelocity == 2) .or. &
+                        (subCellTypeStress == 2 .and. subCellTypeVelocity == 1)) then
+
+                      basisIntegralsMetricSubCell = 2.0_RKIND * alphaPWL**2 + 2.0_RKIND * alphaPWL + 1.0_RKIND
+
+                   else if ((subCellTypeStress == 1 .and. subCellTypeVelocity == 3) .or. &
+                        (subCellTypeStress == 3 .and. subCellTypeVelocity == 1) .or. &
+                        (subCellTypeStress == 2 .and. subCellTypeVelocity == 3) .or. &
+                        (subCellTypeStress == 3 .and. subCellTypeVelocity == 2)) then
+
+                      basisIntegralsMetricSubCell = 2.0_RKIND * alphaPWL**2 + alphaPWL
+
+                   else if  (subCellTypeStress == 3 .and. subCellTypeVelocity == 3) then
+
+                      basisIntegralsMetricSubCell = 2.0_RKIND * alphaPWL**2
+
+                   end if
+
+                   basisIntegralsMetricSubCell = basisIntegralsMetricSubCell * &
+                        basisSubArea(iSubCell) / 12.0_RKIND
+
+                   basisIntegralsMetric(iStressVertex,iVelocityVertex,iCell) = &
+                        basisIntegralsMetric(iStressVertex,iVelocityVertex,iCell) + &
+                        basisIntegralsMetricSubCell
+
+                enddo ! iSubCell
+
+             enddo ! iVelocityVertex
+          enddo ! iStressVertex
+
+       enddo ! iCell
+
+       deallocate(subBasisGradientU)
+       deallocate(subBasisGradientV)
+       deallocate(subBasisConstant)
+       deallocate(subCellgradientU)
+       deallocate(subCellgradientV)
+       deallocate(basisSubArea)
+
+       blockPtr => blockPtr % next
+    enddo
 
   end subroutine seaice_init_velocity_solver_pwl!}}}
 
@@ -392,7 +456,7 @@ contains
        iSubCell) &
        result(grad)!{{{
 
-    use seaice_velocity_solver_variational_shared, only: &
+    use seaice_mesh, only: &
          seaice_wrapped_index
 
     integer, intent(in) :: &

--- a/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver_variational.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver_variational.F
@@ -50,78 +50,14 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_init_velocity_solver_variational(&
-       mesh, &
-       velocity_variational, &
-       boundary, &
-       rotateCartesianGrid, &
-       includeMetricTerms, &
-       variationalBasisType, &
-       variationalDenominatorType, &
-       integrationType, &
-       integrationOrder)!{{{
-
-    type(MPAS_pool_type), pointer, intent(in) :: &
-         mesh !< Input:
-
-    type(MPAS_pool_type), pointer :: &
-         velocity_variational, & !< Input/Output:
-         boundary                !< Input/Output:
-
-    logical, intent(in) :: &
-         rotateCartesianGrid, & !< Input:
-         includeMetricTerms     !< Input:
-
-    character(len=*), intent(in) :: &
-         variationalBasisType, &       !< Input:
-         variationalDenominatorType, & !< Input:
-         integrationType               !< Input:
-
-    integer, intent(in) :: &
-         integrationOrder !< Input:
-
-    call init_velocity_solver_variational_primary_mesh(&
-         mesh, &
-         velocity_variational, &
-         boundary, &
-         rotateCartesianGrid, &
-         includeMetricTerms, &
-         variationalBasisType, &
-         variationalDenominatorType, &
-         integrationType, &
-         integrationOrder)
-
-  end subroutine seaice_init_velocity_solver_variational
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  init_velocity_solver_variational_primary_mesh
-!
-!> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 24 October 2014
-!> \details
-!>
-!
-!-----------------------------------------------------------------------
-
-  subroutine init_velocity_solver_variational_primary_mesh(&
-       mesh, &
-       velocity_variational, &
-       boundary, &
-       rotateCartesianGrid, &
-       includeMetricTerms, &
-       variationalBasisType, &
-       variationalDenominatorType, &
-       integrationType, &
-       integrationOrder)!{{{
+  subroutine seaice_init_velocity_solver_variational(domain)!{{{
 
     use seaice_mesh, only: &
-         seaice_cell_vertices_at_vertex
+         seaice_calc_local_coords
 
     use seaice_velocity_solver_variational_shared, only: &
-         seaice_calc_local_coords, &
-         seaice_calc_variational_metric_terms
+         seaice_calc_variational_metric_terms, &
+         seaice_cell_vertices_at_vertex
 
     use seaice_velocity_solver_wachspress, only: &
          seaice_init_velocity_solver_wachspress
@@ -129,219 +65,47 @@ contains
     use seaice_velocity_solver_pwl, only: &
          seaice_init_velocity_solver_pwl
 
-    type(MPAS_pool_type), pointer, intent(in) :: &
-         mesh !< Input:
+    type (domain_type), intent(inout) :: &
+         domain !< Input/Output:
 
-    type(MPAS_pool_type), pointer :: &
-         velocity_variational, & !< Input/Output:
-         boundary                !< Input/Output:
-
-    logical, intent(in) :: &
-         rotateCartesianGrid, & !< Input:
-         includeMetricTerms     !< Input:
-
-    character(len=*), intent(in) :: &
-         variationalBasisType, &       !< Input:
-         variationalDenominatorType, & !< Input:
-         integrationType               !< Input:
-
-    integer, intent(in) :: &
-         integrationOrder !< Input:
-
-    integer, dimension(:,:), pointer :: &
-         cellVerticesAtVertex
-
-    real(kind=RKIND), dimension(:), pointer :: &
-         tanLatVertexRotatedOverRadius, &
-         variationalDenominator
-
-    real(kind=RKIND), dimension(:,:,:), pointer :: &
-         basisGradientU, &
-         basisGradientV, &
-         basisIntegralsMetric, &
-         basisIntegralsU, &
-         basisIntegralsV
-
-    integer, pointer :: &
-         nCells, &
-         nVertices, &
-         vertexDegree, &
-         maxEdges
-
-    integer, dimension(:), pointer :: &
-         nEdgesOnCell, &
-         interiorVertex
-
-    integer, dimension(:,:), pointer :: &
-         verticesOnCell, &
-         cellsOnVertex, &
-         edgesOnCell
-
-    real(kind=RKIND), dimension(:), pointer :: &
-         xVertex, &
-         yVertex, &
-         zVertex, &
-         xCell, &
-         yCell, &
-         zCell, &
-         areaCell, &
-         areaTriangle, &
-         dvEdge
-
-    logical, pointer :: &
-         on_a_sphere
-
-    real(kind=RKIND), pointer :: &
-         sphere_radius
-
-    real(kind=RKIND), dimension(:,:), allocatable :: &
-         xLocal, &
-         yLocal
-
-    call MPAS_pool_get_config(mesh, "on_a_sphere", on_a_sphere)
-    call MPAS_pool_get_config(mesh, "sphere_radius", sphere_radius)
-
-    call MPAS_pool_get_dimension(mesh, "nCells", nCells)
-    call MPAS_pool_get_dimension(mesh, "nVertices", nVertices)
-    call MPAS_pool_get_dimension(mesh, "vertexDegree", vertexDegree)
-    call MPAS_pool_get_dimension(mesh, "maxEdges", maxEdges)
-
-    call MPAS_pool_get_array(mesh, "nEdgesOnCell", nEdgesOnCell)
-    call MPAS_pool_get_array(mesh, "verticesOnCell", verticesOnCell)
-    call MPAS_pool_get_array(mesh, "cellsOnVertex", cellsOnVertex)
-    call MPAS_pool_get_array(mesh, "edgesOnCell", edgesOnCell)
-    call MPAS_pool_get_array(mesh, "xVertex", xVertex)
-    call MPAS_pool_get_array(mesh, "yVertex", yVertex)
-    call MPAS_pool_get_array(mesh, "zVertex", zVertex)
-    call MPAS_pool_get_array(mesh, "xCell", xCell)
-    call MPAS_pool_get_array(mesh, "yCell", yCell)
-    call MPAS_pool_get_array(mesh, "zCell", zCell)
-    call MPAS_pool_get_array(mesh, "areaCell", areaCell)
-    call MPAS_pool_get_array(mesh, "areaTriangle", areaTriangle)
-    call MPAS_pool_get_array(mesh, "dvEdge", dvEdge)
-
-    call MPAS_pool_get_array(boundary, "interiorVertex", interiorVertex)
-
-    call MPAS_pool_get_array(velocity_variational, "cellVerticesAtVertex", cellVerticesAtVertex)
-    call MPAS_pool_get_array(velocity_variational, "tanLatVertexRotatedOverRadius", tanLatVertexRotatedOverRadius)
-    call MPAS_pool_get_array(velocity_variational, "basisGradientU", basisGradientU)
-    call MPAS_pool_get_array(velocity_variational, "basisGradientV", basisGradientV)
-    call MPAS_pool_get_array(velocity_variational, "basisIntegralsU", basisIntegralsU)
-    call MPAS_pool_get_array(velocity_variational, "basisIntegralsV", basisIntegralsV)
-    call MPAS_pool_get_array(velocity_variational, "basisIntegralsMetric", basisIntegralsMetric)
-    call MPAS_pool_get_array(velocity_variational, "variationalDenominator", variationalDenominator)
+    character(len=strKIND), pointer :: &
+         config_variational_basis
 
     call mpas_timer_start("variational calc_metric_terms")
-    call seaice_calc_variational_metric_terms(&
-         tanLatVertexRotatedOverRadius, &
-         nVertices, &
-         xVertex, &
-         yVertex, &
-         zVertex, &
-         sphere_radius, &
-         rotateCartesianGrid, &
-         includeMetricTerms)
+    call seaice_calc_variational_metric_terms(domain)
     call mpas_timer_stop("variational calc_metric_terms")
 
     call mpas_timer_start("variational vertices_at_vertex")
-    call seaice_cell_vertices_at_vertex(&
-         cellVerticesAtVertex, &
-         nVertices, &
-         vertexDegree, &
-         nEdgesOnCell, &
-         verticesOnCell, &
-         cellsOnVertex)
+    call seaice_cell_vertices_at_vertex(domain)
     call mpas_timer_stop("variational vertices_at_vertex")
 
-    call mpas_timer_start("variational calc_local_coords")
-    allocate(xLocal(maxEdges,nCells))
-    allocate(yLocal(maxEdges,nCells))
+    call MPAS_pool_get_config(domain % configs, "config_variational_basis", config_variational_basis)
 
-    call seaice_calc_local_coords(&
-         xLocal, &
-         yLocal, &
-         nCells, &
-         nEdgesOnCell, &
-         verticesOnCell, &
-         xVertex, &
-         yVertex, &
-         zVertex, &
-         xCell, &
-         yCell, &
-         zCell, &
-         rotateCartesianGrid, &
-         on_a_sphere)
-    call mpas_timer_stop("variational calc_local_coords")
+    if (trim(config_variational_basis) == "wachspress") then
 
-    if (trim(variationalBasisType) == "wachspress") then
+       call seaice_init_velocity_solver_wachspress(domain)
 
-       call seaice_init_velocity_solver_wachspress(&
-            nCells, &
-            maxEdges, &
-            nEdgesOnCell, &
-            xLocal, &
-            yLocal, &
-            rotateCartesianGrid, &
-            includeMetricTerms, &
-            on_a_sphere, &
-            integrationType, &
-            integrationOrder, &
-            sphere_radius, &
-            basisGradientU, &
-            basisGradientV, &
-            basisIntegralsU, &
-            basisIntegralsV, &
-            basisIntegralsMetric)
+    else if (trim(config_variational_basis) == "pwl") then
 
-    else if (trim(variationalBasisType) == "pwl") then
+       call seaice_init_velocity_solver_pwl(domain)
 
-       call seaice_init_velocity_solver_pwl(&
-            nCells, &
-            maxEdges, &
-            nEdgesOnCell, &
-            verticesOnCell, &
-            edgesOnCell, &
-            dvEdge, &
-            areaCell, &
-            xLocal, &
-            yLocal, &
-            basisGradientU, &
-            basisGradientV, &
-            basisIntegralsMetric, &
-            basisIntegralsU, &
-            basisIntegralsV)
-
-    else if (trim(variationalBasisType) == "none") then
+    else if (trim(config_variational_basis) == "none") then
 
        continue
 
     else
 
-       call MPAS_log_write("Unknown variational basis type: "//trim(variationalBasisType), MPAS_LOG_CRIT)
+       call MPAS_log_write("Unknown variational basis type: "//trim(config_variational_basis), MPAS_LOG_CRIT)
 
     endif
 
     call mpas_timer_start("variational denominator")
-    call variational_denominator(&
-         nVertices, &
-         vertexDegree, &
-         nEdgesOnCell, &
-         interiorVertex, &
-         areaTriangle, &
-         cellsOnVertex, &
-         cellVerticesAtVertex, &
-         basisIntegralsMetric, &
-         variationalDenominatorType, &
-         variationalDenominator)
+    call variational_denominator(domain)
     call mpas_timer_stop("variational denominator")
-
-    ! clean up
-    deallocate(xLocal)
-    deallocate(yLocal)
 
     !call homogenize_variational_basis_field()
 
-  end subroutine init_velocity_solver_variational_primary_mesh
+  end subroutine seaice_init_velocity_solver_variational
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
@@ -355,42 +119,43 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine variational_denominator(&
-       nVertices, &
-       vertexDegree, &
-       nEdgesOnCell, &
-       interiorVertex, &
-       areaTriangle, &
-       cellsOnVertex, &
-       cellVerticesAtVertex, &
-       basisIntegralsMetric, &
-       variationalDenominatorType, &
-       variationalDenominator)
+  subroutine variational_denominator(domain)
 
-    integer, intent(in) :: &
-         nVertices, & !< Input:
-         vertexDegree !< Input:
+    type (domain_type), intent(inout) :: &
+         domain !< Input/Output:
 
-    integer, dimension(:), intent(in) :: &
-         nEdgesOnCell, & !< Input:
-         interiorVertex  !< Input:
+    type(block_type), pointer :: &
+         blockPtr
 
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         areaTriangle !< Input:
+    type(MPAS_pool_type), pointer :: &
+         meshPool, &
+         boundaryPool, &
+         velocityVariationalPool
 
-    integer, dimension(:,:), intent(in) :: &
-         cellsOnVertex !< Input:
+    character(len=strKIND), pointer :: &
+         config_variational_denominator_type
 
-    integer, dimension(:,:), intent(in) :: &
-         cellVerticesAtVertex !< Input:
+    integer, pointer :: &
+         nVertices, &
+         vertexDegree
 
-    real(kind=RKIND), dimension(:,:,:), intent(in) :: &
-         basisIntegralsMetric !< Input:
+    integer, dimension(:), pointer :: &
+         nEdgesOnCell, &
+         interiorVertex
 
-    character(len=*), intent(in) :: &
-         variationalDenominatorType !< Input:
+    real(kind=RKIND), dimension(:), pointer :: &
+         areaTriangle
 
-    real(kind=RKIND), dimension(:), intent(out) :: &
+    integer, dimension(:,:), pointer :: &
+         cellsOnVertex
+
+    integer, dimension(:,:), pointer :: &
+         cellVerticesAtVertex
+
+    real(kind=RKIND), dimension(:,:,:), pointer :: &
+         basisIntegralsMetric
+
+    real(kind=RKIND), dimension(:), pointer :: &
          variationalDenominator
 
     integer :: &
@@ -400,45 +165,84 @@ contains
          iCell, &
          iVelocityVertex
 
-    if (trim(variationalDenominatorType) == "alternate") then
+    call MPAS_pool_get_config(domain % configs, "config_variational_denominator_type", config_variational_denominator_type)
+    if (trim(config_variational_denominator_type) == "alternate") then
 
-       do iVertex = 1, nVertices
+       blockPtr => domain % blocklist
+       do while (associated(blockPtr))
 
-          variationalDenominator(iVertex) = 0.0_RKIND
+          call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+          call MPAS_pool_get_subpool(blockPtr % structs, "boundary", boundaryPool)
+          call MPAS_pool_get_subpool(blockPtr % structs, "velocity_variational", velocityVariationalPool)
 
-          ! loop over surrounding cells
-          do iSurroundingCell = 1, vertexDegree
+          call MPAS_pool_get_dimension(meshPool, "nVertices", nVertices)
+          call MPAS_pool_get_dimension(meshPool, "vertexDegree", vertexDegree)
 
-             ! get the cell number of this cell
-             iCell = cellsOnVertex(iSurroundingCell, iVertex)
+          call MPAS_pool_get_array(meshPool, "nEdgesOnCell", nEdgesOnCell)
+          call MPAS_pool_get_array(meshPool, "areaTriangle", areaTriangle)
+          call MPAS_pool_get_array(meshPool, "cellsOnVertex", cellsOnVertex)
 
-             ! get the vertexOnCell number of the iVertex velocity point from cell iCell
-             iVelocityVertex = cellVerticesAtVertex(iSurroundingCell,iVertex)
+          call MPAS_pool_get_array(boundaryPool, "interiorVertex", interiorVertex)
 
-             ! loop over the vertices of the surrounding cell
-             do iStressVertex = 1, nEdgesOnCell(iCell)
+          call MPAS_pool_get_array(velocityVariationalPool, "cellVerticesAtVertex", cellVerticesAtVertex)
+          call MPAS_pool_get_array(velocityVariationalPool, "basisIntegralsMetric", basisIntegralsMetric)
+          call MPAS_pool_get_array(velocityVariationalPool, "variationalDenominator", variationalDenominator)
 
-                variationalDenominator(iVertex) = variationalDenominator(iVertex) + &
-                     basisIntegralsMetric(iStressVertex,iVelocityVertex,iCell)
+          do iVertex = 1, nVertices
 
-             enddo ! iStressVertex
+             variationalDenominator(iVertex) = 0.0_RKIND
 
-          enddo ! iSurroundingCell
+             ! loop over surrounding cells
+             do iSurroundingCell = 1, vertexDegree
 
-          ! inverse
-          variationalDenominator(iVertex) = variationalDenominator(iVertex)
+                ! get the cell number of this cell
+                iCell = cellsOnVertex(iSurroundingCell, iVertex)
 
-       enddo ! iVertex
+                ! get the vertexOnCell number of the iVertex velocity point from cell iCell
+                iVelocityVertex = cellVerticesAtVertex(iSurroundingCell,iVertex)
 
-    else if (trim(variationalDenominatorType) == "original") then
+                ! loop over the vertices of the surrounding cell
+                do iStressVertex = 1, nEdgesOnCell(iCell)
 
-       do iVertex = 1, nVertices
-          variationalDenominator(iVertex) = areaTriangle(iVertex)
-       enddo ! iVertex
+                   variationalDenominator(iVertex) = variationalDenominator(iVertex) + &
+                        basisIntegralsMetric(iStressVertex,iVelocityVertex,iCell)
+
+                enddo ! iStressVertex
+
+             enddo ! iSurroundingCell
+
+             ! inverse
+             variationalDenominator(iVertex) = variationalDenominator(iVertex)
+
+          enddo ! iVertex
+
+          blockPtr => blockPtr % next
+       enddo
+
+    else if (trim(config_variational_denominator_type) == "original") then
+
+       blockPtr => domain % blocklist
+       do while (associated(blockPtr))
+
+          call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+          call MPAS_pool_get_subpool(blockPtr % structs, "velocity_variational", velocityVariationalPool)
+
+          call MPAS_pool_get_dimension(meshPool, "nVertices", nVertices)
+
+          call MPAS_pool_get_array(meshPool, "areaTriangle", areaTriangle)
+
+          call MPAS_pool_get_array(velocityVariationalPool, "variationalDenominator", variationalDenominator)
+
+          do iVertex = 1, nVertices
+             variationalDenominator(iVertex) = areaTriangle(iVertex)
+          enddo ! iVertex
+
+          blockPtr => blockPtr % next
+       enddo
 
     else
 
-       call MPAS_log_write("Unknown variational denominator type: "//trim(variationalDenominatorType), MPAS_LOG_CRIT)
+       call MPAS_log_write("Unknown variational denominator type: "//trim(config_variational_denominator_type), MPAS_LOG_CRIT)
 
     endif
 
@@ -572,42 +376,32 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_strain_tensor_variational(&
-       mesh, &
-       strain11, &
-       strain22, &
-       strain12, &
-       uVelocity, &
-       vVelocity, &
-       basisGradientU, &
-       basisGradientV, &
-       tanLatVertexRotatedOverRadius, &
-       solveStress)!{{{
+  subroutine seaice_strain_tensor_variational(domain)!{{{
 
     use seaice_mesh_pool, only: &
          nCells, &
          verticesOnCell, &
-         nEdgesOnCell
+         nEdgesOnCell, &
+         basisGradientU, &
+         basisGradientV, &
+         solveStress, &
+         tanLatVertexRotatedOverRadius, &
+         uVelocity, &
+         vVelocity
 
-    type(MPAS_pool_type), pointer, intent(in) :: &
-         mesh !< Input:
+    type(domain_type), intent(inout) :: &
+         domain
 
-    real(kind=RKIND), dimension(:,:), intent(out) :: &
-         strain11, & !< Output:
-         strain22, & !< Output:
-         strain12    !< Output:
+    type(block_type), pointer :: &
+         blockPtr
 
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         uVelocity, & !< Input:
-         vVelocity, & !< Input:
-         tanLatVertexRotatedOverRadius !< Input:
+    type(MPAS_pool_type), pointer :: &
+         velocityVariationalPool
 
-    real(kind=RKIND), dimension(:,:,:), contiguous, intent(in) :: &
-         basisGradientU, & !< Input:
-         basisGradientV    !< Input:
-
-    integer, dimension(:), intent(in) :: &
-         solveStress !< Input:
+    real(kind=RKIND), dimension(:,:), pointer :: &
+         strain11, &
+         strain22, &
+         strain12
 
     integer :: &
          iCell, &
@@ -621,7 +415,16 @@ contains
          strain22Tmp, &
          strain12Tmp
 
-    ! loop over cells
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
+
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_variational", velocityVariationalPool)
+
+       call MPAS_pool_get_array(velocityVariationalPool, "strain11", strain11)
+       call MPAS_pool_get_array(velocityVariationalPool, "strain22", strain22)
+       call MPAS_pool_get_array(velocityVariationalPool, "strain12", strain12)
+
+       ! loop over cells
 #ifdef MPAS_OPENMP_OFFLOAD
 !$omp target teams distribute parallel do
 #elif MPAS_OPENACC
@@ -630,42 +433,45 @@ contains
 !$omp parallel do default(shared) private(iGradientVertex, iBasisVertex, iVertex, jVertex, &
 !$omp&                                    strain11Tmp, strain22Tmp, strain12Tmp)
 #endif
-    do iCell = 1, nCells
+       do iCell = 1, nCells
 
-       if (solveStress(iCell) == 1) then
+          if (solveStress(iCell) == 1) then
 
-          ! loop over velocity points surrounding cell - location of stress and derivative
-          do iGradientVertex = 1, nEdgesOnCell(iCell)
+             ! loop over velocity points surrounding cell - location of stress and derivative
+             do iGradientVertex = 1, nEdgesOnCell(iCell)
 
-             strain11Tmp = 0.0_RKIND
-             strain22Tmp = 0.0_RKIND
-             strain12Tmp = 0.0_RKIND
+                strain11Tmp = 0.0_RKIND
+                strain22Tmp = 0.0_RKIND
+                strain12Tmp = 0.0_RKIND
 
-             ! loop over basis functions
-             do iBasisVertex = 1, nEdgesOnCell(iCell)
+                ! loop over basis functions
+                do iBasisVertex = 1, nEdgesOnCell(iCell)
 
-                iVertex = verticesOnCell(iBasisVertex,iCell)
+                   iVertex = verticesOnCell(iBasisVertex,iCell)
 
-                strain11Tmp = strain11Tmp + uVelocity(iVertex) * basisGradientU(iBasisVertex,iGradientVertex,iCell)
-                strain22Tmp = strain22Tmp + vVelocity(iVertex) * basisGradientV(iBasisVertex,iGradientVertex,iCell)
-                strain12Tmp = strain12Tmp + 0.5_RKIND * (&
-                            uVelocity(iVertex) * basisGradientV(iBasisVertex,iGradientVertex,iCell) + &
-                            vVelocity(iVertex) * basisGradientU(iBasisVertex,iGradientVertex,iCell))
+                   strain11Tmp = strain11Tmp + uVelocity(iVertex) * basisGradientU(iBasisVertex,iGradientVertex,iCell)
+                   strain22Tmp = strain22Tmp + vVelocity(iVertex) * basisGradientV(iBasisVertex,iGradientVertex,iCell)
+                   strain12Tmp = strain12Tmp + 0.5_RKIND * (&
+                        uVelocity(iVertex) * basisGradientV(iBasisVertex,iGradientVertex,iCell) + &
+                        vVelocity(iVertex) * basisGradientU(iBasisVertex,iGradientVertex,iCell))
 
-             enddo ! iVertexOnCell
+                enddo ! iVertexOnCell
 
-             ! metric terms
-             jVertex = verticesOnCell(iGradientVertex,iCell)
+                ! metric terms
+                jVertex = verticesOnCell(iGradientVertex,iCell)
 
-             strain11(iGradientVertex,iCell) = strain11Tmp - vVelocity(jVertex) * tanLatVertexRotatedOverRadius(jVertex)
-             strain12(iGradientVertex,iCell) = strain12Tmp + uVelocity(jVertex) * tanLatVertexRotatedOverRadius(jVertex) * 0.5_RKIND
-             strain22(iGradientVertex,iCell) = strain22Tmp
+                strain11(iGradientVertex,iCell) = strain11Tmp - vVelocity(jVertex) * tanLatVertexRotatedOverRadius(jVertex)
+                strain12(iGradientVertex,iCell) = strain12Tmp + uVelocity(jVertex) * tanLatVertexRotatedOverRadius(jVertex) * 0.5_RKIND
+                strain22(iGradientVertex,iCell) = strain22Tmp
 
-          enddo ! jVertexOnCell
+             enddo ! jVertexOnCell
 
-       endif ! solveStress
+          endif ! solveStress
 
-    enddo ! iCell
+       enddo ! iCell
+
+       blockPtr => blockPtr % next
+    end do
 
   end subroutine seaice_strain_tensor_variational!}}}
 
@@ -681,11 +487,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_average_strains_on_vertex(&
-       areaCell, &
-       strain11, &
-       strain22, &
-       strain12)
+  subroutine seaice_average_strains_on_vertex(domain)
 
     use seaice_mesh_pool, only: &
          nCells, &
@@ -694,13 +496,23 @@ contains
          cellsOnVertex, &
          vertexDegree
 
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         areaCell !< Input
+    type(domain_type), intent(inout) :: &
+         domain
 
-    real(kind=RKIND), dimension(:,:), intent(inout) :: &
-         strain11, & !< Input/Output:
-         strain22, & !< Input/Output:
-         strain12    !< Input/Output:
+    type(block_type), pointer :: &
+         blockPtr
+
+    type(MPAS_pool_type), pointer :: &
+         meshPool, &
+         velocityVariationalPool
+
+    real(kind=RKIND), dimension(:), pointer :: &
+         areaCell
+
+    real(kind=RKIND), dimension(:,:), pointer :: &
+         strain11, &
+         strain22, &
+         strain12
 
     real(kind=RKIND) :: &
          strain11avg, &
@@ -714,51 +526,66 @@ contains
          iCell, &
          iVertexOnCell
 
-    do iVertex = 1, nVerticesSolve
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-       strain11avg = 0.0_RKIND
-       strain22avg = 0.0_RKIND
-       strain12avg = 0.0_RKIND
-       denominator = 0.0_RKIND
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_variational", velocityVariationalPool)
 
-       do iVertexDegree = 1, vertexDegree
+       call MPAS_pool_get_array(meshPool, "areaCell", areaCell)
 
-          iCell = cellsOnVertex(iVertexDegree,iVertex)
+       call MPAS_pool_get_array(velocityVariationalPool, "strain11", strain11)
+       call MPAS_pool_get_array(velocityVariationalPool, "strain22", strain22)
+       call MPAS_pool_get_array(velocityVariationalPool, "strain12", strain12)
 
-          if (iCell <= nCells) then
+       do iVertex = 1, nVerticesSolve
 
-             iVertexOnCell = cellVerticesAtVertex(iVertexDegree,iVertex)
+          strain11avg = 0.0_RKIND
+          strain22avg = 0.0_RKIND
+          strain12avg = 0.0_RKIND
+          denominator = 0.0_RKIND
 
-             strain11avg = strain11avg + strain11(iVertexOnCell,iCell) * areaCell(iCell)
-             strain22avg = strain22avg + strain22(iVertexOnCell,iCell) * areaCell(iCell)
-             strain12avg = strain12avg + strain12(iVertexOnCell,iCell) * areaCell(iCell)
-             denominator = denominator + areaCell(iCell)
+          do iVertexDegree = 1, vertexDegree
 
-          endif
+             iCell = cellsOnVertex(iVertexDegree,iVertex)
 
-       enddo ! iVertexDegree
+             if (iCell <= nCells) then
 
-       strain11avg = strain11avg / denominator
-       strain22avg = strain22avg / denominator
-       strain12avg = strain12avg / denominator
+                iVertexOnCell = cellVerticesAtVertex(iVertexDegree,iVertex)
 
-       do iVertexDegree = 1, vertexDegree
+                strain11avg = strain11avg + strain11(iVertexOnCell,iCell) * areaCell(iCell)
+                strain22avg = strain22avg + strain22(iVertexOnCell,iCell) * areaCell(iCell)
+                strain12avg = strain12avg + strain12(iVertexOnCell,iCell) * areaCell(iCell)
+                denominator = denominator + areaCell(iCell)
 
-          iCell = cellsOnVertex(iVertexDegree,iVertex)
+             endif
 
-          if (iCell <= nCells) then
+          enddo ! iVertexDegree
 
-             iVertexOnCell = cellVerticesAtVertex(iVertexDegree,iVertex)
+          strain11avg = strain11avg / denominator
+          strain22avg = strain22avg / denominator
+          strain12avg = strain12avg / denominator
 
-             strain11(iVertexOnCell,iCell) = strain11avg
-             strain22(iVertexOnCell,iCell) = strain22avg
-             strain12(iVertexOnCell,iCell) = strain12avg
+          do iVertexDegree = 1, vertexDegree
 
-          endif
+             iCell = cellsOnVertex(iVertexDegree,iVertex)
 
-       enddo ! iCellOnVertex
+             if (iCell <= nCells) then
 
-    enddo ! iVertex
+                iVertexOnCell = cellVerticesAtVertex(iVertexDegree,iVertex)
+
+                strain11(iVertexOnCell,iCell) = strain11avg
+                strain22(iVertexOnCell,iCell) = strain22avg
+                strain12(iVertexOnCell,iCell) = strain12avg
+
+             endif
+
+          enddo ! iCellOnVertex
+
+       enddo ! iVertex
+
+       blockPtr => blockPtr % next
+    end do
 
   end subroutine seaice_average_strains_on_vertex
 
@@ -774,18 +601,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_stress_tensor_variational(&
-       mesh, &
-       stress11, &
-       stress22, &
-       stress12, &
-       strain11, &
-       strain22, &
-       strain12, &
-       icePressure, &
-       replacementPressure, &
-       solveStress, &
-       dtElastic)!{{{
+  subroutine seaice_stress_tensor_variational(domain)!{{{
 
     use seaice_velocity_solver_constitutive_relation, only: &
          constitutiveRelationType, &
@@ -799,32 +615,34 @@ contains
 
     use seaice_mesh_pool, only: &
          nCells, &
-         nEdgesOnCell
+         nEdgesOnCell, &
+         stress11, &
+         stress22, &
+         stress12, &
+         icePressure, &
+         solveStress
 
-    type(MPAS_pool_type), pointer, intent(in) :: &
-         mesh !< Input:
+    type(domain_type), intent(inout) :: &
+         domain
 
-    real(kind=RKIND), dimension(:,:), contiguous, intent(inout) :: &
-         stress11, & !< Input/Output:
-         stress22, & !< Input/Output:
-         stress12    !< Input/Output:
+    type(block_type), pointer :: &
+         blockPtr
 
-    real(kind=RKIND), dimension(:,:), contiguous, intent(out) :: &
-         replacementPressure !< Output:
+    type(MPAS_pool_type), pointer :: &
+         meshPool, &
+         velocitySolverPool, &
+         velocityVariationalPool
 
-    real(kind=RKIND), dimension(:,:), contiguous, intent(in) :: &
-         strain11, & !< Input:
-         strain22, & !< Input:
-         strain12    !< Input:
+    real(kind=RKIND), dimension(:,:), pointer :: &
+         replacementPressure
 
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         icePressure !< Input:
+    real(kind=RKIND), dimension(:,:), pointer :: &
+         strain11, &
+         strain22, &
+         strain12
 
-    integer, dimension(:), intent(in) :: &
-         solveStress !< Input:
-
-    real(kind=RKIND), intent(in) :: &
-         dtElastic !< Input:
+    real(kind=RKIND), pointer :: &
+         elasticTimeStep
 
     integer :: &
          iCell, &
@@ -843,12 +661,25 @@ contains
          pressureCoefficient, &
          denominator
 
-    ! init variables
-    call MPAS_pool_get_array(mesh, "areaCell", areaCell)
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-    if (constitutiveRelationType == EVP_CONSTITUTIVE_RELATION) then
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_variational", velocityVariationalPool)
 
-       denominator = 1.0_RKIND + (0.5_RKIND * dtElastic) / dampingTimescale
+       call MPAS_pool_get_array(velocitySolverPool, "elasticTimeStep", elasticTimeStep)
+
+       call MPAS_pool_get_array(velocityVariationalPool, "strain11", strain11)
+       call MPAS_pool_get_array(velocityVariationalPool, "strain22", strain22)
+       call MPAS_pool_get_array(velocityVariationalPool, "strain12", strain12)
+       call MPAS_pool_get_array(velocityVariationalPool, "replacementPressure", replacementPressure)
+
+       call MPAS_pool_get_array(meshPool, "areaCell", areaCell)
+
+       if (constitutiveRelationType == EVP_CONSTITUTIVE_RELATION) then
+
+          denominator = 1.0_RKIND + (0.5_RKIND * elasticTimeStep) / dampingTimescale
 
 #ifdef MPAS_OPENMP_OFFLOAD
 !$omp target teams distribute parallel do
@@ -857,94 +688,177 @@ contains
 #else
 !$omp parallel do default(shared) private(iVertexOnCell)
 #endif
-       do iCell = 1, nCells
+          do iCell = 1, nCells
 
-          replacementPressure(:,iCell) = 0.0_RKIND
+             replacementPressure(:,iCell) = 0.0_RKIND
 
-          if (solveStress(iCell) == 1) then
+             if (solveStress(iCell) == 1) then
 
 #if defined(MPAS_OPENMP_OFFLOAD) || defined(MPAS_OPENACC)
-             ! inline call to seaice_evp_constitutive_relation for GPUs
-             do iVertexOnCell = 1, nEdgesOnCell(iCell)
+                ! inline call to seaice_evp_constitutive_relation for GPUs
+                do iVertexOnCell = 1, nEdgesOnCell(iCell)
 
-                ! convert from stress11 to stress1 etc
-                strainDivergence = strain11(iVertexOnCell,iCell) + strain22(iVertexOnCell,iCell)
-                strainTension    = strain11(iVertexOnCell,iCell) - strain22(iVertexOnCell,iCell)
-                strainShearing   = strain12(iVertexOnCell,iCell) * 2.0_RKIND
+                   ! convert from stress11 to stress1 etc
+                   strainDivergence = strain11(iVertexOnCell,iCell) + strain22(iVertexOnCell,iCell)
+                   strainTension    = strain11(iVertexOnCell,iCell) - strain22(iVertexOnCell,iCell)
+                   strainShearing   = strain12(iVertexOnCell,iCell) * 2.0_RKIND
 
-                stress1 = stress11(iVertexOnCell,iCell) + stress22(iVertexOnCell,iCell)
-                stress2 = stress11(iVertexOnCell,iCell) - stress22(iVertexOnCell,iCell)
+                   stress1 = stress11(iVertexOnCell,iCell) + stress22(iVertexOnCell,iCell)
+                   stress2 = stress11(iVertexOnCell,iCell) - stress22(iVertexOnCell,iCell)
 
-                ! perform the constituitive relation
-                Delta = sqrt(strainDivergence*strainDivergence + &
-                             (strainTension*strainTension + strainShearing*strainShearing) / eccentricitySquared)
+                   ! perform the constituitive relation
+                   Delta = sqrt(strainDivergence*strainDivergence + &
+                               (strainTension*strainTension + strainShearing*strainShearing) / eccentricitySquared)
 
-                pressureCoefficient                      = icePressure(iCell) / max(Delta,puny)
-                replacementPressure(iVertexOnCell,iCell) = pressureCoefficient * Delta
+                   pressureCoefficient                      = icePressure(iCell) / max(Delta,puny)
+                   replacementPressure(iVertexOnCell,iCell) = pressureCoefficient * Delta
 
-                pressureCoefficient = (pressureCoefficient * dtElastic) / (2.0_RKIND * dampingTimescale)
+                   pressureCoefficient = (pressureCoefficient * elasticTimeStep) / (2.0_RKIND * dampingTimescale)
 
-                stress1  = (stress1  +  pressureCoefficient                        * (strainDivergence - Delta)) / denominator
-                stress2  = (stress2  + (pressureCoefficient / eccentricitySquared) *  strainTension            ) / denominator
-                stress12(iVertexOnCell,iCell) = (stress12(iVertexOnCell,iCell) &
-                                     + (pressureCoefficient / eccentricitysquared) * strainShearing * 0.5_RKIND) / denominator
+                   stress1  = (stress1  +  pressureCoefficient                        * (strainDivergence - Delta)) / denominator
+                   stress2  = (stress2  + (pressureCoefficient / eccentricitySquared) *  strainTension            ) / denominator
+                   stress12(iVertexOnCell,iCell) = (stress12(iVertexOnCell,iCell) &
+                        + (pressureCoefficient / eccentricitysquared) * strainShearing * 0.5_RKIND) / denominator
 
-                ! convert back
-                stress11(iVertexOnCell,iCell) = 0.5_RKIND * (stress1 + stress2)
-                stress22(iVertexOnCell,iCell) = 0.5_RKIND * (stress1 - stress2)
+                   ! convert back
+                   stress11(iVertexOnCell,iCell) = 0.5_RKIND * (stress1 + stress2)
+                   stress22(iVertexOnCell,iCell) = 0.5_RKIND * (stress1 - stress2)
 
 #else
-             !$omp simd
-             do iVertexOnCell = 1, nEdgesOnCell(iCell)
+                   !$omp simd
+                do iVertexOnCell = 1, nEdgesOnCell(iCell)
 
-                call seaice_evp_constitutive_relation(&
-                     stress11(iVertexOnCell,iCell), &
-                     stress22(iVertexOnCell,iCell), &
-                     stress12(iVertexOnCell,iCell), &
-                     strain11(iVertexOnCell,iCell), &
-                     strain22(iVertexOnCell,iCell), &
-                     strain12(iVertexOnCell,iCell), &
-                     icePressure(iCell), &
-                     replacementPressure(iVertexOnCell,iCell), &
-                     areaCell(iCell), &
-                     dtElastic)
+                   call seaice_evp_constitutive_relation(&
+                        stress11(iVertexOnCell,iCell), &
+                        stress22(iVertexOnCell,iCell), &
+                        stress12(iVertexOnCell,iCell), &
+                        strain11(iVertexOnCell,iCell), &
+                        strain22(iVertexOnCell,iCell), &
+                        strain12(iVertexOnCell,iCell), &
+                        icePressure(iCell), &
+                        replacementPressure(iVertexOnCell,iCell), &
+                        areaCell(iCell), &
+                        elasticTimeStep)
 #endif
-             enddo ! iVertexOnCell
+                enddo ! iVertexOnCell
 
-          endif ! solveStress
+             endif ! solveStress
 
-       enddo ! iCell
+          enddo ! iCell
 
-    else if (constitutiveRelationType == REVISED_EVP_CONSTITUTIVE_RELATION) then
+       else if (constitutiveRelationType == REVISED_EVP_CONSTITUTIVE_RELATION) then
 
 #ifdef MPAS_OPENMP
 !$omp parallel do default(shared) private(iVertexOnCell)
 #endif
-       do iCell = 1, nCells
+          do iCell = 1, nCells
 
-          if (solveStress(iCell) == 1) then
+             if (solveStress(iCell) == 1) then
 
-             !$omp simd
-             do iVertexOnCell = 1, nEdgesOnCell(iCell)
+                !$omp simd
+                do iVertexOnCell = 1, nEdgesOnCell(iCell)
 
-                call seaice_evp_constitutive_relation_revised(&
-                     stress11(iVertexOnCell,iCell), &
-                     stress22(iVertexOnCell,iCell), &
-                     stress12(iVertexOnCell,iCell), &
-                     strain11(iVertexOnCell,iCell), &
-                     strain22(iVertexOnCell,iCell), &
-                     strain12(iVertexOnCell,iCell), &
-                     icePressure(iCell), &
-                     replacementPressure(iVertexOnCell,iCell), &
-                     areaCell(iCell))
+                   call seaice_evp_constitutive_relation_revised(&
+                        stress11(iVertexOnCell,iCell), &
+                        stress22(iVertexOnCell,iCell), &
+                        stress12(iVertexOnCell,iCell), &
+                        strain11(iVertexOnCell,iCell), &
+                        strain22(iVertexOnCell,iCell), &
+                        strain12(iVertexOnCell,iCell), &
+                        icePressure(iCell), &
+                        replacementPressure(iVertexOnCell,iCell), &
+                        areaCell(iCell))
 
-             enddo ! iVertexOnCell
+                enddo ! iVertexOnCell
 
-          endif ! solveStress
+             endif ! solveStress
 
-       enddo ! iCell
+          enddo ! iCell
 
-    else if (constitutiveRelationType == LINEAR_CONSTITUTIVE_RELATION) then
+       else if (constitutiveRelationType == LINEAR_CONSTITUTIVE_RELATION) then
+
+#ifdef MPAS_OPENMP
+!$omp parallel do default(shared) private(iCell, iVertexOnCell)
+#endif
+          do iCell = 1, nCells
+
+             if (solveStress(iCell) == 1) then
+
+                !$omp simd
+                do iVertexOnCell = 1, nEdgesOnCell(iCell)
+
+                   call seaice_linear_constitutive_relation(&
+                        stress11(iVertexOnCell,iCell), &
+                        stress22(iVertexOnCell,iCell), &
+                        stress12(iVertexOnCell,iCell), &
+                        strain11(iVertexOnCell,iCell), &
+                        strain22(iVertexOnCell,iCell), &
+                        strain12(iVertexOnCell,iCell))
+
+                enddo ! iVertexOnCell
+
+             endif ! solveStress
+
+          enddo ! iCell
+
+       endif ! constitutiveRelationType
+
+       blockPtr => blockPtr % next
+    end do
+
+  end subroutine seaice_stress_tensor_variational!}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  seaice_stress_tensor_variational_linear
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 3rd October 2019
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine seaice_stress_tensor_variational_linear(domain)!{{{
+
+    use seaice_velocity_solver_constitutive_relation, only: &
+         seaice_linear_constitutive_relation
+
+    use seaice_mesh_pool, only: &
+         nCells, &
+         nEdgesOnCell, &
+         stress11, &
+         stress22, &
+         stress12, &
+         solveStress
+
+    type(domain_type), intent(inout) :: &
+         domain
+
+    type(block_type), pointer :: &
+         blockPtr
+
+    type(MPAS_pool_type), pointer :: &
+         velocityVariationalPool
+
+    real(kind=RKIND), dimension(:,:), pointer :: &
+         strain11, &
+         strain22, &
+         strain12
+
+    integer :: &
+         iCell, &
+         iVertexOnCell
+
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
+
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_variational", velocityVariationalPool)
+
+       call MPAS_pool_get_array(velocityVariationalPool, "strain11", strain11)
+       call MPAS_pool_get_array(velocityVariationalPool, "strain22", strain22)
+       call MPAS_pool_get_array(velocityVariationalPool, "strain12", strain12)
 
 #ifdef MPAS_OPENMP
 !$omp parallel do default(shared) private(iCell, iVertexOnCell)
@@ -970,82 +884,8 @@ contains
 
        enddo ! iCell
 
-    endif ! constitutiveRelationType
-
-  end subroutine seaice_stress_tensor_variational!}}}
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  seaice_stress_tensor_variational_linear
-!
-!> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 3rd October 2019
-!> \details
-!>
-!
-!-----------------------------------------------------------------------
-
-  subroutine seaice_stress_tensor_variational_linear(&
-       mesh, &
-       stress11, &
-       stress22, &
-       stress12, &
-       strain11, &
-       strain22, &
-       strain12, &
-       solveStress)!{{{
-
-    use seaice_velocity_solver_constitutive_relation, only: &
-         seaice_linear_constitutive_relation
-
-    use seaice_mesh_pool, only: &
-         nCells, &
-         nEdgesOnCell
-
-    type(MPAS_pool_type), pointer, intent(in) :: &
-         mesh !< Input:
-
-    real(kind=RKIND), dimension(:,:), contiguous, intent(out) :: &
-         stress11, & !< Input/Output:
-         stress22, & !< Input/Output:
-         stress12    !< Input/Output:
-
-    real(kind=RKIND), dimension(:,:), contiguous, intent(in) :: &
-         strain11, & !< Input:
-         strain22, & !< Input:
-         strain12    !< Input:
-
-    integer, dimension(:), intent(in) :: &
-         solveStress !< Input:
-
-    integer :: &
-         iCell, &
-         iVertexOnCell
-
-#ifdef MPAS_OPENMP
-!$omp parallel do default(shared) private(iCell, iVertexOnCell)
-#endif
-    do iCell = 1, nCells
-
-       if (solveStress(iCell) == 1) then
-
-          !$omp simd
-          do iVertexOnCell = 1, nEdgesOnCell(iCell)
-
-             call seaice_linear_constitutive_relation(&
-                  stress11(iVertexOnCell,iCell), &
-                  stress22(iVertexOnCell,iCell), &
-                  stress12(iVertexOnCell,iCell), &
-                  strain11(iVertexOnCell,iCell), &
-                  strain22(iVertexOnCell,iCell), &
-                  strain12(iVertexOnCell,iCell))
-
-          enddo ! iVertexOnCell
-
-       endif ! solveStress
-
-    enddo ! iCell
+       blockPtr => blockPtr % next
+    end do
 
   end subroutine seaice_stress_tensor_variational_linear!}}}
 
@@ -1061,54 +901,40 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_stress_divergence_variational(&
-       mesh, &
-       stressDivergenceU, &
-       stressDivergenceV, &
-       stress11, &
-       stress22, &
-       stress12, &
-       basisIntegralsU, &
-       basisIntegralsV, &
-       basisIntegralsMetric, &
-       variationalDenominator, &
-       tanLatVertexRotatedOverRadius, &
-       cellVerticesAtVertex, &
-       solveVelocity)!{{{
+  subroutine seaice_stress_divergence_variational(domain)!{{{
 
     use seaice_mesh_pool, only: &
          nVerticesSolve, &
          cellsOnVertex, &
          nEdgesOnCell, &
          areaTriangle, &
-         vertexDegree
+         vertexDegree, &
+         basisIntegralsMetric, &
+         basisIntegralsU, &
+         basisIntegralsV, &
+         cellVerticesAtVertex, &
+         solveVelocity, &
+         stress11, &
+         stress22, &
+         stress12, &
+         tanLatVertexRotatedOverRadius
 
-    type(MPAS_pool_type), pointer, intent(in) :: &
-         mesh !< Input:
+    type(domain_type), intent(inout) :: &
+         domain
 
-    real(kind=RKIND), dimension(:), intent(out) :: &
-         stressDivergenceU, & !< Output:
-         stressDivergenceV    !< Output:
+    type(block_type), pointer :: &
+         blockPtr
 
-    real(kind=RKIND), dimension(:,:), contiguous, intent(in) :: &
-         stress11, & !< Input:
-         stress22, & !< Input:
-         stress12    !< Input:
+    type(MPAS_pool_type), pointer :: &
+         velocitySolverPool, &
+         velocityVariationalPool
 
-    real(kind=RKIND), dimension(:,:,:), contiguous, intent(in) :: &
-         basisIntegralsU, &   !< Input:
-         basisIntegralsV, &   !< Input:
-         basisIntegralsMetric !< Input:
+    real(kind=RKIND), dimension(:), pointer :: &
+         stressDivergenceU, &
+         stressDivergenceV
 
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         tanLatVertexRotatedOverRadius, & !< Input:
-         variationalDenominator           !< Input:
-
-    integer, dimension(:,:), intent(in) :: &
-         cellVerticesAtVertex !< Input:
-
-    integer, dimension(:), intent(in) :: &
-         solveVelocity !< Input:
+    real(kind=RKIND), dimension(:), pointer :: &
+         variationalDenominator
 
     real(kind=RKIND) :: &
          stressDivergenceUVertex, &
@@ -1123,7 +949,18 @@ contains
          iStressVertex, &
          iVelocityVertex
 
-    ! loop over velocity positions
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
+
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_variational", velocityVariationalPool)
+
+       call MPAS_pool_get_array(velocitySolverPool, "stressDivergenceU", stressDivergenceU)
+       call MPAS_pool_get_array(velocitySolverPool, "stressDivergenceV", stressDivergenceV)
+
+       call MPAS_pool_get_array(velocityVariationalPool, "variationalDenominator", variationalDenominator)
+
+       ! loop over velocity positions
 #ifdef MPAS_OPENMP_OFFLOAD
 !$omp target teams distribute parallel do
 #elif MPAS_OPENACC
@@ -1132,54 +969,57 @@ contains
 !$omp parallel do default(shared) private(stressDivergenceUVertex, stressDivergenceVVertex, &
 !$omp&   iSurroundingCell, iCell, iVelocityVertex, stressDivergenceUCell, stressDivergenceVCell, iStressVertex)
 #endif
-    do iVertex = 1, nVerticesSolve
+       do iVertex = 1, nVerticesSolve
 
-       if (solveVelocity(iVertex) == 1) then
+          if (solveVelocity(iVertex) == 1) then
 
-          stressDivergenceUVertex = 0.0_RKIND
-          stressDivergenceVVertex = 0.0_RKIND
+             stressDivergenceUVertex = 0.0_RKIND
+             stressDivergenceVVertex = 0.0_RKIND
 
-          ! loop over surrounding cells
-          do iSurroundingCell = 1, vertexDegree
+             ! loop over surrounding cells
+             do iSurroundingCell = 1, vertexDegree
 
-             ! get the cell number of this cell
-             iCell = cellsOnVertex(iSurroundingCell, iVertex)
+                ! get the cell number of this cell
+                iCell = cellsOnVertex(iSurroundingCell, iVertex)
 
-             ! get the vertexOnCell number of the iVertex velocity point from cell iCell
-             iVelocityVertex = cellVerticesAtVertex(iSurroundingCell,iVertex)
+                ! get the vertexOnCell number of the iVertex velocity point from cell iCell
+                iVelocityVertex = cellVerticesAtVertex(iSurroundingCell,iVertex)
 
-             stressDivergenceUCell = 0.0_RKIND
-             stressDivergenceVCell = 0.0_RKIND
+                stressDivergenceUCell = 0.0_RKIND
+                stressDivergenceVCell = 0.0_RKIND
 
-             ! loop over the vertices of the surrounding cell
-             do iStressVertex = 1, nEdgesOnCell(iCell)
+                ! loop over the vertices of the surrounding cell
+                do iStressVertex = 1, nEdgesOnCell(iCell)
 
-                ! normal & metric terms
-                stressDivergenceUCell = stressDivergenceUCell - &
-                     stress11(iStressVertex,iCell) * basisIntegralsU(iStressVertex,iVelocityVertex,iCell) - &
-                     stress12(iStressVertex,iCell) * basisIntegralsV(iStressVertex,iVelocityVertex,iCell) - &
-                     stress12(iStressVertex,iCell) * basisIntegralsMetric(iStressVertex,iVelocityVertex,iCell) * &
-                     tanLatVertexRotatedOverRadius(iVertex)
+                   ! normal & metric terms
+                   stressDivergenceUCell = stressDivergenceUCell - &
+                        stress11(iStressVertex,iCell) * basisIntegralsU(iStressVertex,iVelocityVertex,iCell) - &
+                        stress12(iStressVertex,iCell) * basisIntegralsV(iStressVertex,iVelocityVertex,iCell) - &
+                        stress12(iStressVertex,iCell) * basisIntegralsMetric(iStressVertex,iVelocityVertex,iCell) * &
+                        tanLatVertexRotatedOverRadius(iVertex)
 
-                stressDivergenceVCell = stressDivergenceVCell - &
-                     stress22(iStressVertex,iCell) * basisIntegralsV(iStressVertex,iVelocityVertex,iCell) - &
-                     stress12(iStressVertex,iCell) * basisIntegralsU(iStressVertex,iVelocityVertex,iCell) + &
-                     stress11(iStressVertex,iCell) * basisIntegralsMetric(iStressVertex,iVelocityVertex,iCell) * &
-                     tanLatVertexRotatedOverRadius(iVertex)
+                   stressDivergenceVCell = stressDivergenceVCell - &
+                        stress22(iStressVertex,iCell) * basisIntegralsV(iStressVertex,iVelocityVertex,iCell) - &
+                        stress12(iStressVertex,iCell) * basisIntegralsU(iStressVertex,iVelocityVertex,iCell) + &
+                        stress11(iStressVertex,iCell) * basisIntegralsMetric(iStressVertex,iVelocityVertex,iCell) * &
+                        tanLatVertexRotatedOverRadius(iVertex)
 
-             enddo ! iStressVertex
+                enddo ! iStressVertex
 
-             stressDivergenceUVertex = stressDivergenceUVertex + stressDivergenceUCell
-             stressDivergenceVVertex = stressDivergenceVVertex + stressDivergenceVCell
+                stressDivergenceUVertex = stressDivergenceUVertex + stressDivergenceUCell
+                stressDivergenceVVertex = stressDivergenceVVertex + stressDivergenceVCell
 
-          enddo ! iSurroundingCell
+             enddo ! iSurroundingCell
 
-          stressDivergenceU(iVertex) = stressDivergenceUVertex / variationalDenominator(iVertex)
-          stressDivergenceV(iVertex) = stressDivergenceVVertex / variationalDenominator(iVertex)
+             stressDivergenceU(iVertex) = stressDivergenceUVertex / variationalDenominator(iVertex)
+             stressDivergenceV(iVertex) = stressDivergenceVVertex / variationalDenominator(iVertex)
 
-       endif ! solveVelocity
+          endif ! solveVelocity
 
-    enddo ! iVertex
+       enddo ! iVertex
+
+       blockPtr => blockPtr % next
+    end do
 
   end subroutine seaice_stress_divergence_variational!}}}
 
@@ -1195,7 +1035,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_final_divergence_shear_variational(block)
+  subroutine seaice_final_divergence_shear_variational(domain)
 
     use seaice_velocity_solver_constitutive_relation, only: &
          eccentricitySquared
@@ -1205,8 +1045,11 @@ contains
          solveStress, &
          nEdgesOnCell
 
-    type(block_type), intent(inout) :: &
-         block
+    type(domain_type), intent(inout) :: &
+         domain
+
+    type(block_type), pointer :: &
+         blockPtr
 
     type(MPAS_pool_type), pointer :: &
          velocityVariationalPool, &
@@ -1243,89 +1086,95 @@ contains
          iCell, &
          iVertexOnCell
 
-    call MPAS_pool_get_subpool(block % structs, "velocity_variational", velocityVariationalPool)
-    call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-    call MPAS_pool_get_array(velocityVariationalPool, "strain11", strain11)
-    call MPAS_pool_get_array(velocityVariationalPool, "strain22", strain22)
-    call MPAS_pool_get_array(velocityVariationalPool, "strain12", strain12)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_variational", velocityVariationalPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
 
-    call MPAS_pool_get_array(velocitySolverPool, "divergence", divergence)
-    call MPAS_pool_get_array(velocitySolverPool, "shear", shear)
+       call MPAS_pool_get_array(velocityVariationalPool, "strain11", strain11)
+       call MPAS_pool_get_array(velocityVariationalPool, "strain22", strain22)
+       call MPAS_pool_get_array(velocityVariationalPool, "strain12", strain12)
 
-    allocate(DeltaAverage(nCells))
+       call MPAS_pool_get_array(velocitySolverPool, "divergence", divergence)
+       call MPAS_pool_get_array(velocitySolverPool, "shear", shear)
 
-    do iCell = 1, nCells
-
-       if (solveStress(iCell) == 1) then
-
-          strainDivergenceSum = 0.0_RKIND
-          strainTensionSum    = 0.0_RKIND
-          strainShearingSum   = 0.0_RKIND
-          DeltaAverage(iCell) = 0.0_RKIND
-
-          do iVertexOnCell = 1, nEdgesOnCell(iCell)
-
-             strainDivergence = strain11(iVertexOnCell,iCell) + strain22(iVertexOnCell,iCell)
-             strainTension    = strain11(iVertexOnCell,iCell) - strain22(iVertexOnCell,iCell)
-             strainShearing   = strain12(iVertexOnCell,iCell) * 2.0_RKIND
-
-             Delta = sqrt(strainDivergence**2 + (strainTension**2 + strainShearing**2) / eccentricitySquared)
-
-             strainDivergenceSum = strainDivergenceSum + strainDivergence
-             strainTensionSum    = strainTensionSum    + strainTension
-             strainShearingSum   = strainShearingSum   + strainShearing
-             DeltaAverage(iCell) = DeltaAverage(iCell) + Delta
-
-          enddo ! iVertexOnCell
-
-          divergence(iCell)   = strainDivergenceSum                              / real(nEdgesOnCell(iCell),RKIND)
-          shear(iCell)        = sqrt(strainTensionSum**2 + strainShearingSum**2) / real(nEdgesOnCell(iCell),RKIND)
-          DeltaAverage(iCell) = DeltaAverage(iCell)                              / real(nEdgesOnCell(iCell),RKIND)
-
-       else
-
-          divergence(iCell)   = 0.0_RKIND
-          shear(iCell)        = 0.0_RKIND
-
-       endif
-
-    enddo ! iCell
-
-    ! ridging parameters
-    call MPAS_pool_get_config(block % configs, "config_use_column_package", config_use_column_package)
-
-    if (config_use_column_package) then
-
-       call MPAS_pool_get_subpool(block % structs, "ridging", ridgingPool)
-
-       call MPAS_pool_get_array(ridgingPool, "ridgeConvergence", ridgeConvergence)
-       call MPAS_pool_get_array(ridgingPool, "ridgeShear", ridgeShear)
+       allocate(DeltaAverage(nCells))
 
        do iCell = 1, nCells
 
           if (solveStress(iCell) == 1) then
 
-             ridgeConvergence(iCell) = -min(divergence(iCell),0.0_RKIND)
-             ridgeShear(iCell)       = 0.5_RKIND * (DeltaAverage(iCell) - abs(divergence(iCell)))
+             strainDivergenceSum = 0.0_RKIND
+             strainTensionSum    = 0.0_RKIND
+             strainShearingSum   = 0.0_RKIND
+             DeltaAverage(iCell) = 0.0_RKIND
+
+             do iVertexOnCell = 1, nEdgesOnCell(iCell)
+
+                strainDivergence = strain11(iVertexOnCell,iCell) + strain22(iVertexOnCell,iCell)
+                strainTension    = strain11(iVertexOnCell,iCell) - strain22(iVertexOnCell,iCell)
+                strainShearing   = strain12(iVertexOnCell,iCell) * 2.0_RKIND
+
+                Delta = sqrt(strainDivergence**2 + (strainTension**2 + strainShearing**2) / eccentricitySquared)
+
+                strainDivergenceSum = strainDivergenceSum + strainDivergence
+                strainTensionSum    = strainTensionSum    + strainTension
+                strainShearingSum   = strainShearingSum   + strainShearing
+                DeltaAverage(iCell) = DeltaAverage(iCell) + Delta
+
+             enddo ! iVertexOnCell
+
+             divergence(iCell)   = strainDivergenceSum                              / real(nEdgesOnCell(iCell),RKIND)
+             shear(iCell)        = sqrt(strainTensionSum**2 + strainShearingSum**2) / real(nEdgesOnCell(iCell),RKIND)
+             DeltaAverage(iCell) = DeltaAverage(iCell)                              / real(nEdgesOnCell(iCell),RKIND)
 
           else
 
-             ridgeConvergence(iCell) = 0.0_RKIND
-             ridgeShear(iCell)       = 0.0_RKIND
+             divergence(iCell)   = 0.0_RKIND
+             shear(iCell)        = 0.0_RKIND
 
           endif
 
        enddo ! iCell
 
-    endif ! config_use_column_package
+       ! ridging parameters
+       call MPAS_pool_get_config(blockPtr % configs, "config_use_column_package", config_use_column_package)
 
-    ! units - for comparison to CICE
-    divergence = divergence * 100.0_RKIND * 86400.0_RKIND
-    shear      = shear      * 100.0_RKIND * 86400.0_RKIND
+       if (config_use_column_package) then
 
-    ! cleanup
-    deallocate(DeltaAverage)
+          call MPAS_pool_get_subpool(blockPtr % structs, "ridging", ridgingPool)
+
+          call MPAS_pool_get_array(ridgingPool, "ridgeConvergence", ridgeConvergence)
+          call MPAS_pool_get_array(ridgingPool, "ridgeShear", ridgeShear)
+
+          do iCell = 1, nCells
+
+             if (solveStress(iCell) == 1) then
+
+                ridgeConvergence(iCell) = -min(divergence(iCell),0.0_RKIND)
+                ridgeShear(iCell)       = 0.5_RKIND * (DeltaAverage(iCell) - abs(divergence(iCell)))
+
+             else
+
+                ridgeConvergence(iCell) = 0.0_RKIND
+                ridgeShear(iCell)       = 0.0_RKIND
+
+             endif
+
+          enddo ! iCell
+
+       endif ! config_use_column_package
+
+       ! units - for comparison to CICE
+       divergence = divergence * 100.0_RKIND * 86400.0_RKIND
+       shear      = shear      * 100.0_RKIND * 86400.0_RKIND
+
+       ! cleanup
+       deallocate(DeltaAverage)
+
+       blockPtr => blockPtr % next
+    enddo
 
   end subroutine seaice_final_divergence_shear_variational
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver_variational_shared.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver_variational_shared.F
@@ -21,262 +21,10 @@ module seaice_velocity_solver_variational_shared
   save
 
   public :: &
-       seaice_calc_local_coords, &
        seaice_calc_variational_metric_terms, &
-       seaice_wrapped_index
+       seaice_cell_vertices_at_vertex
 
 contains
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  seaice_calc_local_coords
-!
-!> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 22 October 2014
-!> \details
-!>
-!
-!-----------------------------------------------------------------------
-
-  subroutine seaice_calc_local_coords(&
-       xLocal, &
-       yLocal, &
-       nCells, &
-       nEdgesOnCell, &
-       verticesOnCell, &
-       xVertex, &
-       yVertex, &
-       zVertex, &
-       xCell, &
-       yCell, &
-       zCell, &
-       rotateCartesianGrid, &
-       onASphere)!{{{
-
-    real(kind=RKIND), dimension(:,:), intent(out) :: &
-         xLocal, & !< Output:
-         yLocal    !< Output:
-
-    integer, intent(in) :: &
-         nCells !< Input:
-
-    integer, dimension(:), intent(in) :: &
-         nEdgesOnCell !< Input:
-
-    integer, dimension(:,:), intent(in) :: &
-         verticesOnCell !< Input:
-
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         xVertex, & !< Input:
-         yVertex, & !< Input:
-         zVertex, & !< Input:
-         xCell, &   !< Input:
-         yCell, &   !< Input:
-         zCell      !< Input:
-
-    logical, intent(in) :: &
-         rotateCartesianGrid, & !< Input:
-         onASphere              !< Input:
-
-    if (onASphere) then
-       call calc_local_coords_spherical(&
-            xLocal, &
-            yLocal, &
-            nCells, &
-            nEdgesOnCell, &
-            verticesOnCell, &
-            xVertex, &
-            yVertex, &
-            zVertex, &
-            xCell, &
-            yCell, &
-            zCell, &
-            rotateCartesianGrid)
-    else
-       call calc_local_coords_planar(&
-            xLocal, &
-            yLocal, &
-            nCells, &
-            nEdgesOnCell, &
-            verticesOnCell, &
-            xVertex, &
-            yVertex, &
-            zVertex, &
-            xCell, &
-            yCell, &
-            zCell)
-    endif
-
-  end subroutine seaice_calc_local_coords!}}}
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  calc_local_coords_planar
-!
-!> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 2013-2014
-!> \details
-!>
-!
-!-----------------------------------------------------------------------
-
-  subroutine calc_local_coords_planar(&
-       xLocal, &
-       yLocal, &
-       nCells, &
-       nEdgesOnCell, &
-       verticesOnCell, &
-       xVertex, &
-       yVertex, &
-       zVertex, &
-       xCell, &
-       yCell, &
-       zCell)!{{{
-
-    real(kind=RKIND), dimension(:,:), intent(out) :: &
-         xLocal, & !< Output:
-         yLocal    !< Output:
-
-    integer, intent(in) :: &
-         nCells !< Input:
-
-    integer, dimension(:), intent(in) :: &
-         nEdgesOnCell !< Input:
-
-    integer, dimension(:,:), intent(in) :: &
-         verticesOnCell !< Input:
-
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         xVertex, & !< Input:
-         yVertex, & !< Input:
-         zVertex, & !< Input:
-         xCell, &   !< Input:
-         yCell, &   !< Input:
-         zCell      !< Input:
-
-    integer :: &
-         iCell, &
-         iVertex, &
-         iVertexOnCell
-
-    do iCell = 1, nCells
-
-       do iVertexOnCell = 1, nEdgesOnCell(iCell)
-
-          iVertex = verticesOnCell(iVertexOnCell, iCell)
-
-          xLocal(iVertexOnCell,iCell) = xVertex(iVertex) - xCell(iCell)
-          yLocal(iVertexOnCell,iCell) = yVertex(iVertex) - yCell(iCell)
-
-       enddo ! iVertexOnCell
-
-    enddo ! iCell
-
-  end subroutine calc_local_coords_planar!}}}
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  calc_local_coords_spherical
-!
-!> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 22 October 2014
-!> \details
-!>
-!
-!-----------------------------------------------------------------------
-
-  subroutine calc_local_coords_spherical(&
-       xLocal, &
-       yLocal, &
-       nCells, &
-       nEdgesOnCell, &
-       verticesOnCell, &
-       xVertex, &
-       yVertex, &
-       zVertex, &
-       xCell, &
-       yCell, &
-       zCell, &
-       rotateCartesianGrid)!{{{
-
-    use seaice_mesh, only: &
-         seaice_project_3D_vector_onto_local_2D, &
-         seaice_grid_rotation_forward
-
-    real(kind=RKIND), dimension(:,:), intent(out) :: &
-         xLocal, & !< Output:
-         yLocal    !< Output:
-
-    integer, intent(in) :: &
-         nCells !< Input:
-
-    integer, dimension(:), intent(in) :: &
-         nEdgesOnCell !< Input:
-
-    integer, dimension(:,:), intent(in) :: &
-         verticesOnCell !< Input:
-
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         xVertex, & !< Input:
-         yVertex, & !< Input:
-         zVertex, & !< Input:
-         xCell, &   !< Input:
-         yCell, &   !< Input:
-         zCell      !< Input:
-
-    logical, intent(in) :: &
-         rotateCartesianGrid !< Input:
-
-    real(kind=RKIND), dimension(3) :: &
-         normalVector3D
-
-    real(kind=RKIND), dimension(2) :: &
-         normalVector2D
-
-    integer :: &
-         iCell, &
-         iVertex, &
-         iVertexOnCell
-
-    real(kind=RKIND) :: &
-         xCellRotated, &
-         yCellRotated, &
-         zCellRotated
-
-    do iCell = 1, nCells
-
-       call seaice_grid_rotation_forward(&
-            xCellRotated, yCellRotated, zCellRotated, &
-            xCell(iCell), yCell(iCell), zCell(iCell), &
-            rotateCartesianGrid)
-
-       do iVertexOnCell = 1, nEdgesOnCell(iCell)
-
-          iVertex = verticesOnCell(iVertexOnCell, iCell)
-
-          call seaice_grid_rotation_forward(&
-               normalVector3D(1), normalVector3D(2), normalVector3D(3), &
-               xVertex(iVertex),  yVertex(iVertex),  zVertex(iVertex), &
-               rotateCartesianGrid)
-
-          call seaice_project_3D_vector_onto_local_2D(&
-               normalVector2D, &
-               normalVector3D, &
-               xCellRotated, &
-               yCellRotated, &
-               zCellRotated)
-
-          xLocal(iVertexOnCell,iCell) = normalVector2D(1)
-          yLocal(iVertexOnCell,iCell) = normalVector2D(2)
-
-       enddo ! iVertexOnCell
-
-    enddo ! iCell
-
-  end subroutine calc_local_coords_spherical!}}}
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
@@ -290,36 +38,38 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_calc_variational_metric_terms(&
-       tanLatVertexRotatedOverRadius, &
-       nVertices, &
-       xVertex, &
-       yVertex, &
-       zVertex, &
-       sphereRadius, &
-       rotateCartesianGrid, &
-       includeMetricTerms)
+  subroutine seaice_calc_variational_metric_terms(domain)
 
     use seaice_mesh, only: &
          seaice_grid_rotation_forward
 
-    real(kind=RKIND), dimension(:), intent(out) :: &
-         tanLatVertexRotatedOverRadius !< Output:
+    type (domain_type), intent(inout) :: &
+         domain !< Input/Output:
 
-    integer, intent(in) :: &
-         nVertices !< Input:
+    type(block_type), pointer :: &
+         blockPtr
+
+    type(MPAS_pool_type), pointer :: &
+         meshPool, &
+         velocityVariationalPool
 
     real(kind=RKIND), dimension(:), pointer :: &
-         xVertex, & !< Input:
-         yVertex, & !< Input:
-         zVertex    !< Input:
+         tanLatVertexRotatedOverRadius
+
+    integer, pointer :: &
+         nVertices
+
+    real(kind=RKIND), dimension(:), pointer :: &
+         xVertex, &
+         yVertex, &
+         zVertex
 
     real(kind=RKIND), pointer :: &
-         sphereRadius !< Input:
+         sphereRadius
 
-    logical, intent(in) :: &
-         rotateCartesianGrid, & !< Input:
-         includeMetricTerms     !< Input:
+    logical, pointer :: &
+         config_rotate_cartesian_grid, &
+         config_include_metric_terms
 
     integer :: &
          iVertex
@@ -330,28 +80,61 @@ contains
          zVertexRotated, &
          latVertexRotated
 
-    if (includeMetricTerms) then
+    call MPAS_pool_get_config(domain % configs, "config_include_metric_terms", config_include_metric_terms)
 
-       do iVertex = 1, nVertices
+    if (config_include_metric_terms) then
 
-          call seaice_grid_rotation_forward(&
-               xVertexRotated,   yVertexRotated,   zVertexRotated, &
-               xVertex(iVertex), yVertex(iVertex), zVertex(iVertex), &
-               rotateCartesianGrid)
+       call MPAS_pool_get_config(domain % configs, "config_rotate_cartesian_grid", config_rotate_cartesian_grid)
 
-          latVertexRotated = asin(zVertexRotated / sphereRadius)
+       blockPtr => domain % blocklist
+       do while (associated(blockPtr))
 
-          tanLatVertexRotatedOverRadius(iVertex) = tan(latVertexRotated) / sphereRadius
+          call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+          call MPAS_pool_get_subpool(blockPtr % structs, "velocity_variational", velocityVariationalPool)
 
-       enddo ! iVertex
+          call MPAS_pool_get_dimension(meshPool, "nVertices", nVertices)
+
+          call MPAS_pool_get_config(meshPool, "sphere_radius", sphereRadius)
+
+          call MPAS_pool_get_array(meshPool, "xVertex", xVertex)
+          call MPAS_pool_get_array(meshPool, "yVertex", yVertex)
+          call MPAS_pool_get_array(meshPool, "zVertex", zVertex)
+
+          call MPAS_pool_get_array(velocityVariationalPool, "tanLatVertexRotatedOverRadius", tanLatVertexRotatedOverRadius)
+
+          do iVertex = 1, nVertices
+
+             call seaice_grid_rotation_forward(&
+                  xVertexRotated,   yVertexRotated,   zVertexRotated, &
+                  xVertex(iVertex), yVertex(iVertex), zVertex(iVertex), &
+                  config_rotate_cartesian_grid)
+
+             latVertexRotated = asin(zVertexRotated / sphereRadius)
+
+             tanLatVertexRotatedOverRadius(iVertex) = tan(latVertexRotated) / sphereRadius
+
+          enddo ! iVertex
+
+          blockPtr => blockPtr % next
+       enddo
 
     else
 
-       do iVertex = 1, nVertices
+       blockPtr => domain % blocklist
+       do while (associated(blockPtr))
 
-          tanLatVertexRotatedOverRadius(iVertex) = 0.0_RKIND
+          call MPAS_pool_get_subpool(blockPtr % structs, "velocity_variational", velocityVariationalPool)
 
-       enddo ! iVertex
+          call MPAS_pool_get_array(velocityVariationalPool, "tanLatVertexRotatedOverRadius", tanLatVertexRotatedOverRadius)
+
+          do iVertex = 1, nVertices
+
+             tanLatVertexRotatedOverRadius(iVertex) = 0.0_RKIND
+
+          enddo ! iVertex
+
+          blockPtr => blockPtr % next
+       enddo
 
     endif
 
@@ -359,7 +142,7 @@ contains
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  seaice_wrapped_index
+!  seaice_cell_vertices_at_vertex
 !
 !> \brief
 !> \author Adrian K. Turner, LANL
@@ -369,20 +152,82 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  function seaice_wrapped_index(&
-       input, &
-       nelements) &
-       result(output)!{{{
+  subroutine seaice_cell_vertices_at_vertex(domain)!{{{
 
-    integer, intent(in) :: &
-         input, &  !< Input:
-         nelements !< Input:
+    type (domain_type), intent(inout) :: &
+         domain !< Input/Output:
 
-    integer :: output
+    type(block_type), pointer :: &
+         blockPtr
 
-    output = modulo(input - 1, nelements) + 1
+    type(MPAS_pool_type), pointer :: &
+         meshPool, &
+         velocityVariationalPool
 
-  end function seaice_wrapped_index!}}}
+    integer, dimension(:,:), pointer :: &
+         cellVerticesAtVertex
+
+    integer, pointer :: &
+         nVertices, &
+         vertexDegree
+
+    integer, dimension(:), pointer :: &
+         nEdgesOnCell
+
+    integer, dimension(:,:), pointer :: &
+         cellsOnVertex, &
+         verticesOnCell
+
+    integer :: &
+         iVertex, &
+         iVertexDegree, &
+         iCell, &
+         iVertexOnCell, &
+         jVertex
+
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
+
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_variational", velocityVariationalPool)
+
+       call MPAS_pool_get_dimension(meshPool, "nVertices", nVertices)
+       call MPAS_pool_get_dimension(meshPool, "vertexDegree", vertexDegree)
+
+       call MPAS_pool_get_array(meshPool, "nEdgesOnCell", nEdgesOnCell)
+       call MPAS_pool_get_array(meshPool, "verticesOnCell", verticesOnCell)
+       call MPAS_pool_get_array(meshPool, "cellsOnVertex", cellsOnVertex)
+
+       call MPAS_pool_get_array(velocityVariationalPool, "cellVerticesAtVertex", cellVerticesAtVertex)
+
+       do iVertex = 1, nVertices
+
+          do iVertexDegree = 1, vertexDegree
+
+             cellVerticesAtVertex(iVertexDegree,iVertex) = 0
+
+             iCell = cellsOnVertex(iVertexDegree, iVertex)
+
+             do iVertexOnCell = 1, nEdgesOnCell(iCell)
+
+                jVertex = verticesOnCell(iVertexOnCell,iCell)
+
+                if (iVertex == jVertex) then
+
+                   cellVerticesAtVertex(iVertexDegree,iVertex) = iVertexOnCell
+
+                endif
+
+             enddo ! iVertexOnCell
+
+          enddo ! iVertexDegree
+
+       enddo ! iVertex
+
+       blockPtr => blockPtr % next
+    enddo
+
+  end subroutine seaice_cell_vertices_at_vertex!}}}
 
 !-----------------------------------------------------------------------
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver_wachspress.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver_wachspress.F
@@ -43,60 +43,68 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_init_velocity_solver_wachspress(&
-       nCells, &
-       maxEdges, &
-       nEdgesOnCell, &
-       xLocal, &
-       yLocal, &
-       rotateCartesianGrid, &
-       includeMetricTerms, &
-       onASphere, &
-       integrationType, &
-       integrationOrder, &
-       sphereRadius, &
-       basisGradientU, &
-       basisGradientV, &
-       basisIntegralsU, &
-       basisIntegralsV, &
-       basisIntegralsMetric)!{{{
+  subroutine seaice_init_velocity_solver_wachspress(domain)!{{{
 
     use mpas_timer
 
-    use seaice_velocity_solver_variational_shared, only: &
+    use seaice_mesh, only: &
          seaice_calc_local_coords
 
-    integer, intent(in) :: &
-         nCells, & !< Input:
-         maxEdges  !< Input:
+    use seaice_wachspress_basis, only: &
+         seaice_calc_wachspress_coefficients
 
-    integer, dimension(:), intent(in) :: &
-         nEdgesOnCell !< Input:
+    type (domain_type), intent(inout) :: &
+         domain !< Input/Output:
 
-    real(kind=RKIND), dimension(:,:), intent(in) :: &
-         xLocal, & !< Input:
-         yLocal    !< Input:
+    type(block_type), pointer :: &
+         blockPtr
 
-    logical, intent(in) :: &
-         rotateCartesianGrid, & !< Input:
-         includeMetricTerms, &  !< Input:
-         onASphere              !< Input:
+    type(MPAS_pool_type), pointer :: &
+         meshPool, &
+         velocityVariationalPool
 
-    character(len=strKIND), intent(in) :: &
-         integrationType !< Input:
+    integer, pointer :: &
+         nCells, &
+         maxEdges
 
-    integer, intent(in) :: &
-         integrationOrder !< Input:
+    integer, dimension(:), pointer :: &
+         nEdgesOnCell
 
-    real(kind=RKIND), intent(in) :: &
-         sphereRadius !< Input:
+    integer, dimension(:,:), pointer :: &
+         verticesOnCell
 
-    real(kind=RKIND), dimension(:,:,:), intent(out) :: &
-         basisGradientU, &    !< Output:
-         basisGradientV, &    !< Output:
-         basisIntegralsU, &   !< Output:
-         basisIntegralsV, &   !< Output:
-         basisIntegralsMetric !< Output:
+    real(kind=RKIND), dimension(:), pointer :: &
+         xVertex, &
+         yVertex, &
+         zVertex, &
+         xCell, &
+         yCell, &
+         zCell
+
+    real(kind=RKIND), dimension(:,:), allocatable :: &
+         xLocal, &
+         yLocal
+
+    logical, pointer :: &
+         config_rotate_cartesian_grid, &
+         config_include_metric_terms, &
+         on_a_sphere
+
+    character(len=strKIND), pointer :: &
+         config_wachspress_integration_type
+
+    integer, pointer :: &
+         config_wachspress_integration_order
+
+    real(kind=RKIND), pointer :: &
+         sphere_radius
+
+    real(kind=RKIND), dimension(:,:,:), pointer :: &
+         basisGradientU, &
+         basisGradientV, &
+         basisIntegralsU, &
+         basisIntegralsV, &
+         basisIntegralsMetric
 
     real(kind=RKIND), dimension(:,:), allocatable :: &
          wachspressA, &
@@ -105,56 +113,120 @@ contains
     real(kind=RKIND), dimension(:,:,:), allocatable :: &
          wachspressKappa
 
+    integer :: &
+         iCell, &
+         iStressVertex, &
+         iVelocityVertex, &
+         iSubCell, &
+         iVertex
+
     call mpas_timer_start("Velocity solver Wachpress init")
 
-    allocate(wachspressKappa(maxEdges,maxEdges,nCells))
-    allocate(wachspressA(maxEdges,nCells))
-    allocate(wachspressB(maxEdges,nCells))
+    call MPAS_pool_get_config(domain % configs, "config_rotate_cartesian_grid", config_rotate_cartesian_grid)
+    call MPAS_pool_get_config(domain % configs, "config_include_metric_terms", config_include_metric_terms)
+    call MPAS_pool_get_config(domain % configs, "config_wachspress_integration_type", config_wachspress_integration_type)
+    call MPAS_pool_get_config(domain % configs, "config_wachspress_integration_order", config_wachspress_integration_order)
 
-    call mpas_timer_start("wachpress calc_coefficients")
-    call calc_wachspress_coefficients(&
-         wachspressKappa, &
-         wachspressA, &
-         wachspressB, &
-         nCells, &
-         nEdgesOnCell, &
-         xLocal, &
-         yLocal)
-    call mpas_timer_stop("wachpress calc_coefficients")
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-    call mpas_timer_start("wachpress calc_derivatives")
-    call calculate_wachspress_derivatives(&
-         basisGradientU, &
-         basisGradientV, &
-         nCells, &
-         maxEdges, &
-         nEdgesOnCell, &
-         xLocal, &
-         yLocal, &
-         wachspressA, &
-         wachspressB, &
-         wachspressKappa)
-    call mpas_timer_stop("wachpress calc_derivatives")
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_variational", velocityVariationalPool)
 
-    call mpas_timer_start("wachpress integrate")
-    call integrate_wachspress(&
-         basisIntegralsU, &
-         basisIntegralsV, &
-         basisIntegralsMetric, &
-         nCells, &
-         nEdgesOnCell, &
-         xLocal, &
-         yLocal, &
-         wachspressA, &
-         wachspressB, &
-         wachspressKappa, &
-         integrationType, &
-         integrationOrder)
-    call mpas_timer_stop("wachpress integrate")
+       call MPAS_pool_get_config(meshPool, "on_a_sphere", on_a_sphere)
+       call MPAS_pool_get_config(meshPool, "sphere_radius", sphere_radius)
 
-    deallocate(wachspressKappa)
-    deallocate(wachspressA)
-    deallocate(wachspressB)
+       call MPAS_pool_get_dimension(meshPool, "nCells", nCells)
+       call MPAS_pool_get_dimension(meshPool, "maxEdges", maxEdges)
+
+       call MPAS_pool_get_array(meshPool, "nEdgesOnCell", nEdgesOnCell)
+       call MPAS_pool_get_array(meshPool, "verticesOnCell", verticesOnCell)
+       call MPAS_pool_get_array(meshPool, "xVertex", xVertex)
+       call MPAS_pool_get_array(meshPool, "yVertex", yVertex)
+       call MPAS_pool_get_array(meshPool, "zVertex", zVertex)
+       call MPAS_pool_get_array(meshPool, "xCell", xCell)
+       call MPAS_pool_get_array(meshPool, "yCell", yCell)
+       call MPAS_pool_get_array(meshPool, "zCell", zCell)
+
+       call MPAS_pool_get_array(velocityVariationalPool, "basisGradientU", basisGradientU)
+       call MPAS_pool_get_array(velocityVariationalPool, "basisGradientV", basisGradientV)
+       call MPAS_pool_get_array(velocityVariationalPool, "basisIntegralsU", basisIntegralsU)
+       call MPAS_pool_get_array(velocityVariationalPool, "basisIntegralsV", basisIntegralsV)
+       call MPAS_pool_get_array(velocityVariationalPool, "basisIntegralsMetric", basisIntegralsMetric)
+
+       call mpas_timer_start("variational calc_local_coords")
+       allocate(xLocal(maxEdges,nCells))
+       allocate(yLocal(maxEdges,nCells))
+
+       call seaice_calc_local_coords(&
+            xLocal, &
+            yLocal, &
+            nCells, &
+            nEdgesOnCell, &
+            verticesOnCell, &
+            xVertex, &
+            yVertex, &
+            zVertex, &
+            xCell, &
+            yCell, &
+            zCell, &
+            config_rotate_cartesian_grid, &
+            on_a_sphere)
+       call mpas_timer_stop("variational calc_local_coords")
+
+       allocate(wachspressKappa(maxEdges,maxEdges,nCells))
+       allocate(wachspressA(maxEdges,nCells))
+       allocate(wachspressB(maxEdges,nCells))
+
+       call mpas_timer_start("wachpress calc_coefficients")
+       call seaice_calc_wachspress_coefficients(&
+            wachspressKappa, &
+            wachspressA, &
+            wachspressB, &
+            nCells, &
+            nEdgesOnCell, &
+            xLocal, &
+            yLocal)
+       call mpas_timer_stop("wachpress calc_coefficients")
+
+       call mpas_timer_start("wachpress calc_derivatives")
+       call calculate_wachspress_derivatives(&
+            basisGradientU, &
+            basisGradientV, &
+            nCells, &
+            maxEdges, &
+            nEdgesOnCell, &
+            xLocal, &
+            yLocal, &
+            wachspressA, &
+            wachspressB, &
+            wachspressKappa)
+       call mpas_timer_stop("wachpress calc_derivatives")
+
+       call mpas_timer_start("wachpress integrate")
+       call integrate_wachspress(&
+            basisIntegralsU, &
+            basisIntegralsV, &
+            basisIntegralsMetric, &
+            nCells, &
+            nEdgesOnCell, &
+            xLocal, &
+            yLocal, &
+            wachspressA, &
+            wachspressB, &
+            wachspressKappa, &
+            config_wachspress_integration_type, &
+            config_wachspress_integration_order)
+       call mpas_timer_stop("wachpress integrate")
+
+       deallocate(wachspressKappa)
+       deallocate(wachspressA)
+       deallocate(wachspressB)
+       deallocate(xLocal)
+       deallocate(yLocal)
+
+       blockPtr => blockPtr % next
+    enddo
 
     call mpas_timer_stop("Velocity solver Wachpress init")
 
@@ -189,6 +261,9 @@ contains
        wachspressKappa, &
        integrationType, &
        integrationOrder)!{{{
+
+    use seaice_triangle_quadrature, only: &
+         seaice_triangle_quadrature_rules
 
     ! basisIntegralsUV (iStressVertex,iVelocityVertex,iCell)
     ! iCell         : cell integrals are performed on
@@ -239,7 +314,7 @@ contains
          normalizationFactor
 
     ! Quadrature rules
-    call get_integration_factors(&
+    call seaice_triangle_quadrature_rules(&
          integrationType, &
          integrationOrder, &
          nIntegrationPoints, &
@@ -319,8 +394,13 @@ contains
        integrationWeights, &
        normalizationFactor)!{{{
 
-    use seaice_velocity_solver_variational_shared, only: &
+    use seaice_mesh, only: &
          seaice_wrapped_index
+
+    use seaice_wachspress_basis, only: &
+         seaice_wachspress_indexes, &
+         seaice_wachspress_basis_function, &
+         seaice_wachspress_basis_derivative
 
     real(kind=RKIND), intent(inout) :: &
          basisIntegralsU, &   !< Input/Output:
@@ -386,7 +466,7 @@ contains
          i1, &
          i2
 
-    call wachspress_indexes(&
+    call seaice_wachspress_indexes(&
          nEdgesOnCell, &
          nEdgesOnCellSubset, &
          vertexIndexSubset)
@@ -414,19 +494,19 @@ contains
 
        enddo ! iIntegrationPoint
 
-       call wachspress_basis_function(&
+       call seaice_wachspress_basis_function(&
             nEdgesOnCell, iStressVertex, x, y, &
             wachspressKappa, wachspressA, wachspressB, &
             nEdgesOnCellSubset, vertexIndexSubset, &
             stressBasisFunction)
 
-       call wachspress_basis_function(&
+       call seaice_wachspress_basis_function(&
             nEdgesOnCell, iVelocityVertex, x, y, &
             wachspressKappa, wachspressA, wachspressB, &
             nEdgesOnCellSubset, vertexIndexSubset, &
             velocityBasisFunction)
 
-       call wachspress_basis_derivative(&
+       call seaice_wachspress_basis_derivative(&
             nEdgesOnCell, iVelocityVertex, x, y, &
             wachspressKappa, wachspressA, wachspressB, &
             nEdgesOnCellSubset, vertexIndexSubset, &
@@ -517,556 +597,8 @@ contains
   end subroutine get_triangle_mapping!}}}
 
 !-----------------------------------------------------------------------
-! Wachspress function
+! Wachspress derivatives
 !-----------------------------------------------------------------------
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  calc_wachspress_coefficients
-!
-!> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 2013-2014
-!> \details
-!>
-!
-!-----------------------------------------------------------------------
-
-  subroutine calc_wachspress_coefficients(&
-       wachspressKappa, &
-       wachspressA, &
-       wachspressB, &
-       nCells, &
-       nEdgesOnCell, &
-       xLocal, &
-       yLocal)!{{{
-
-    real(kind=RKIND), dimension(:,:,:), intent(out) :: &
-         wachspressKappa !< Output:
-
-    real(kind=RKIND), dimension(:,:), intent(out) :: &
-         wachspressA, & !< Output:
-         wachspressB    !< Output:
-
-    integer, intent(in) :: &
-         nCells !< Input:
-
-    integer, dimension(:), intent(in) :: &
-         nEdgesOnCell !< Input:
-
-    real(kind=RKIND), dimension(:,:), intent(in) :: &
-         xLocal, & !< Input:
-         yLocal    !< Input:
-
-    integer :: &
-         iCell, &
-         iVertex, &
-         i0, &
-         i1, &
-         i2, &
-         jVertex
-
-    ! loop over cells
-    do iCell = 1, nCells
-
-       ! loop over vertices
-       do iVertex = 1, nEdgesOnCell(iCell)
-
-          ! end points of line segment
-          i1 = iVertex - 1
-          i2 = iVertex
-          if (i1 < 1) i1 = i1 + nEdgesOnCell(iCell)
-
-          ! solve for the line segment equation
-          wachspressA(iVertex, iCell) = &
-               (yLocal(i2,iCell) - yLocal(i1,iCell)) / (xLocal(i1,iCell) * yLocal(i2,iCell) - xLocal(i2,iCell) * yLocal(i1,iCell))
-          wachspressB(iVertex, iCell) = &
-               (xLocal(i1,iCell) - xLocal(i2,iCell)) / (xLocal(i1,iCell) * yLocal(i2,iCell) - xLocal(i2,iCell) * yLocal(i1,iCell))
-
-       enddo ! iVertex
-
-       ! loop over vertices
-       do iVertex = 1, nEdgesOnCell(iCell)
-
-          ! determine kappa
-          wachspressKappa(1,iVertex,iCell) = 1.0_RKIND
-
-          do jVertex = 2, nEdgesOnCell(iCell)
-
-             ! previous, this and next vertex
-             i0 = jVertex - 1
-             i1 = jVertex
-             i2 = jVertex + 1
-             if (i2 > nEdgesOnCell(iCell)) i2 = i2 - nEdgesOnCell(iCell)
-
-             wachspressKappa(jVertex,iVertex,iCell) = wachspressKappa(jVertex-1,iVertex,iCell) * &
-                  (wachspressA(i2,iCell) * (xLocal(i0,iCell) - xLocal(i1,iCell)) + &
-                   wachspressB(i2,iCell) * (yLocal(i0,iCell) - yLocal(i1,iCell))) / &
-                  (wachspressA(i0,iCell) * (xLocal(i1,iCell) - xLocal(i0,iCell)) + &
-                   wachspressB(i0,iCell) * (yLocal(i1,iCell) - yLocal(i0,iCell)))
-
-          enddo ! jVertex
-
-       enddo ! iVertex
-
-    enddo ! iCell
-
-  end subroutine calc_wachspress_coefficients!}}}
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  wachspress_indexes
-!
-!> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 2013-2014
-!> \details
-!>
-!
-!-----------------------------------------------------------------------
-
-  subroutine wachspress_indexes(&
-       nEdgesOnCell, &
-       nEdgesOnCellSubset, &
-       vertexIndexSubset)
-
-    use seaice_velocity_solver_variational_shared, only: &
-         seaice_wrapped_index
-
-    integer, intent(in) :: &
-         nEdgesOnCell !< Input:
-
-    integer, dimension(:), intent(out) :: &
-         nEdgesOnCellSubset !< Output:
-
-    integer, dimension(:,:), intent(out) :: &
-         vertexIndexSubset !< Output:
-
-    integer :: &
-         jVertex, &
-         kVertex, &
-         i1, i2
-
-    do jVertex = 1, nEdgesOnCell
-
-       i1 = jVertex
-       i2 = seaice_wrapped_index(jVertex + 1, nEdgesOnCell)
-
-       nEdgesOnCellSubset(jVertex) = 0
-
-       do kVertex = 1, nEdgesOnCell
-
-          if (kVertex /= i1 .and. kVertex /= i2) then
-             nEdgesOnCellSubset(jVertex) = nEdgesOnCellSubset(jVertex) + 1
-             vertexIndexSubset(jVertex,nEdgesOnCellSubset(jVertex)) = kVertex
-          endif
-
-       enddo ! kVertex
-
-    enddo ! jVertex
-
-  end subroutine wachspress_indexes
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  wachspress_basis_function
-!
-!> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 2013-2014
-!> \details
-!>
-!
-!-----------------------------------------------------------------------
-
-  subroutine wachspress_basis_function(&
-       nEdgesOnCell, &
-       iVertex, &
-       x, &
-       y, &
-       wachspressKappa, &
-       wachspressA, &
-       wachspressB, &
-       nEdgesOnCellSubset, &
-       vertexIndexSubset, &
-       wachpress)!{{{
-
-    use seaice_velocity_solver_variational_shared, only: &
-         seaice_wrapped_index
-
-    integer, intent(in) :: &
-         nEdgesOnCell, & !< Input:
-         iVertex         !< Input:
-
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         x, & !< Input:
-         y    !< Input:
-
-    real(kind=RKIND), dimension(:,:), intent(in) :: &
-         wachspressKappa !< Input:
-
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         wachspressA, & !< Input:
-         wachspressB    !< Input:
-
-    integer, dimension(:), intent(in) :: &
-         nEdgesOnCellSubset !< Input:
-
-    integer, dimension(:,:), intent(in) :: &
-         vertexIndexSubset !< Input:
-
-    real(kind=RKIND), dimension(:), intent(out) :: &
-         wachpress !< Output:
-
-    real(kind=RKIND), dimension(size(x),nEdgesOnCell) :: &
-         numerator
-
-    real(kind=RKIND), dimension(size(x)) :: &
-         denominator, &
-         edgeEquation
-
-    integer :: &
-         jVertex
-
-    ! sum over numerators to get denominator
-    denominator(:) = 0.0_RKIND
-
-    do jVertex = 1, nEdgesOnCell
-
-      call wachspress_numerator(&
-           nEdgesOnCell, jVertex, iVertex, x(:), y(:), &
-           wachspressKappa, wachspressA, wachspressB, &
-           nEdgesOnCellSubset, vertexIndexSubset, &
-           edgeEquation(:), &
-           numerator(:,jVertex))
-
-       denominator(:) = denominator(:) + numerator(:,jVertex)
-
-    enddo ! jVertex
-
-    wachpress(:) = numerator(:,iVertex) / denominator(:)
-
-  end subroutine wachspress_basis_function!}}}
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  wachspress_basis_derivative
-!
-!> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 2013-2014
-!> \details
-!>
-!
-!-----------------------------------------------------------------------
-
-  subroutine wachspress_basis_derivative(&
-       nEdgesOnCell, &
-       iVertex, &
-       x, &
-       y, &
-       wachspressKappa, &
-       wachspressA, &
-       wachspressB, &
-       nEdgesOnCellSubset, &
-       vertexIndexSubset, &
-       wachspressU, &
-       wachspressV)!{{{
-
-    integer, intent(in) :: &
-         nEdgesOnCell, & !< Input:
-         iVertex         !< Input:
-
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         x, & !< Input:
-         y    !< Input:
-
-    real(kind=RKIND), dimension(:,:), intent(in) :: &
-         wachspressKappa !< Input:
-
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         wachspressA, & !< Input:
-         wachspressB    !< Input:
-
-    integer, dimension(:), intent(in) :: &
-         nEdgesOnCellSubset !< Input:
-
-    integer, dimension(:,:), intent(in) :: &
-         vertexIndexSubset !< Input:
-
-    real(kind=RKIND), dimension(:), intent(out) :: &
-         wachspressU, & !< Output:
-         wachspressV !< Output:
-
-    real(kind=RKIND), dimension(size(x),2,nEdgesOnCell) :: &
-         derivative
-
-    real(kind=RKIND), dimension(size(x),nEdgesOnCell) :: &
-         numerator
-
-    real(kind=RKIND), dimension(size(x),2) :: &
-         sum_of_derivatives, &
-         sum_of_products, &
-         product
-
-    real(kind=RKIND), dimension(size(x)) :: &
-         denominator, &
-         edgeEquation
-
-    integer :: &
-         jVertex
-
-    ! sum over numerators to get denominator
-    denominator(:) = 0.0_RKIND
-    sum_of_derivatives(:,:) = 0.0_RKIND
-
-    do jVertex = 1, nEdgesOnCell
-
-       call wachspress_numerator(&
-            nEdgesOnCell, jVertex, iVertex, x(:), y(:), &
-            wachspressKappa, wachspressA, wachspressB, &
-            nEdgesOnCellSubset, vertexIndexSubset, &
-            edgeEquation, &
-            numerator(:,jVertex))
-
-       denominator(:) = denominator(:) + numerator(:,jVertex)
-
-       call wachspress_numerator_derivative(&
-            nEdgesOnCell, jVertex, iVertex, x(:), y(:), &
-            wachspressKappa, wachspressA, wachspressB, &
-            nEdgesOnCellSubset, vertexIndexSubset, &
-            sum_of_products, product, edgeEquation, &
-            derivative(:,:,jVertex))
-
-       sum_of_derivatives(:,:) = sum_of_derivatives(:,:) + derivative(:,:,jVertex)
-
-    enddo ! jVertex
-
-    wachspressU(:) = derivative(:,1,iVertex) / denominator(:) - &
-         (numerator(:,iVertex) / denominator(:)**2) * sum_of_derivatives(:,1)
-    wachspressV(:) = derivative(:,2,iVertex) / denominator(:) - &
-         (numerator(:,iVertex) / denominator(:)**2) * sum_of_derivatives(:,2)
-
-  end subroutine wachspress_basis_derivative!}}}
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  wachspress_numerator
-!
-!> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 2013-2014
-!> \details
-!>
-!
-!-----------------------------------------------------------------------
-
-  subroutine wachspress_numerator(&
-       nEdgesOnCell, &
-       jVertex, &
-       iVertex, &
-       x, &
-       y, &
-       wachspressKappa, &
-       wachspressA, &
-       wachspressB, &
-       nEdgesOnCellSubset, &
-       vertexIndexSubset, &
-       edgeEquation, &
-       numerator)!{{{
-
-    integer, intent(in) :: &
-         nEdgesOnCell, & !< Input:
-         jVertex, &      !< Input:
-         iVertex         !< Input:
-
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         x, & !< Input:
-         y    !< Input:
-
-    real(kind=RKIND), dimension(:,:), intent(in) :: &
-         wachspressKappa !< Input:
-
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         wachspressA, & !< Input:
-         wachspressB    !< Input:
-
-    integer, dimension(:), intent(in) :: &
-         nEdgesOnCellSubset !< Input:
-
-    integer, dimension(:,:), intent(in) :: &
-         vertexIndexSubset !< Input:
-
-    real(kind=RKIND), dimension(:), intent(inout) :: &
-         edgeEquation
-
-    real(kind=RKIND), dimension(:), intent(out) :: &
-         numerator !< Output:
-
-    integer :: &
-         kVertex
-
-    numerator(:) = 1.0_RKIND
-
-    do kVertex = 1, nEdgesOnCellSubset(jVertex)
-
-       call wachspress_edge_equation(&
-            x(:), y(:), &
-            wachspressA(vertexIndexSubset(jVertex,kVertex)), &
-            wachspressB(vertexIndexSubset(jVertex,kVertex)), &
-            edgeEquation(:))
-
-       numerator(:) = numerator(:) * edgeEquation(:)
-
-    enddo ! jVertex
-
-    numerator(:) = numerator(:) * wachspressKappa(jVertex,iVertex)
-
-  end subroutine wachspress_numerator!}}}
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  wachspress_numerator_derivative
-!
-!> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 2013-2014
-!> \details
-!>
-!
-!-----------------------------------------------------------------------
-
-  subroutine wachspress_numerator_derivative(&
-       nEdgesOnCell, &
-       jVertex, &
-       iVertex, &
-       x, &
-       y, &
-       wachspressKappa, &
-       wachspressA, &
-       wachspressB, &
-       nEdgesOnCellSubset, &
-       vertexIndexSubset, &
-       sum_of_products, &
-       product, &
-       edgeEquation, &
-       derivative)!{{{
-
-    integer, intent(in) :: &
-         nEdgesOnCell, & !< Input:
-         jVertex, &      !< Input:
-         iVertex         !< Input:
-
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         x, & !< Input:
-         y    !< Input:
-
-    real(kind=RKIND), dimension(:,:), intent(in) :: &
-         wachspressKappa !< Input:
-
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         wachspressA, & !< Input:
-         wachspressB    !< Input:
-
-    integer, dimension(:), intent(in) :: &
-         nEdgesOnCellSubset !< Input:
-
-    integer, dimension(:,:), intent(in) :: &
-         vertexIndexSubset !< Input:
-
-    real(kind=RKIND), dimension(:,:), intent(out) :: &
-         derivative !< Output:
-
-    real(kind=RKIND), dimension(:,:), intent(inout) :: &
-         sum_of_products, & !< Input/Output:
-         product            !< Input/Output:
-
-    real(kind=RKIND), dimension(:), intent(inout) :: &
-         edgeEquation !< Input/Output:
-
-    integer :: &
-         kVertex, &
-         lVertex
-
-    sum_of_products(:,:) = 0.0_RKIND
-
-    do kVertex = 1, nEdgesOnCellSubset(jVertex)
-
-       product(:,:) = 1.0_RKIND
-
-       ! lVertex < kVertex
-       do lVertex = 1, kVertex - 1
-
-          call wachspress_edge_equation(&
-               x(:), y(:), &
-               wachspressA(vertexIndexSubset(jVertex,lVertex)), &
-               wachspressB(vertexIndexSubset(jVertex,lVertex)), &
-               edgeEquation(:))
-
-          product(:,1) = product(:,1) * edgeEquation(:)
-          product(:,2) = product(:,2) * edgeEquation(:)
-
-       enddo ! lVertex
-
-       ! lVertex == kVertex
-       product(:,1) = product(:,1) * (-wachspressA(vertexIndexSubset(jVertex,kVertex)))
-       product(:,2) = product(:,2) * (-wachspressB(vertexIndexSubset(jVertex,kVertex)))
-
-       ! lVertex > kVertex
-       do lVertex = kVertex + 1, nEdgesOnCellSubset(jVertex)
-
-          call wachspress_edge_equation(&
-               x(:), y(:), &
-               wachspressA(vertexIndexSubset(jVertex,lVertex)), &
-               wachspressB(vertexIndexSubset(jVertex,lVertex)), &
-               edgeEquation(:))
-
-          product(:,1) = product(:,1) * edgeEquation(:)
-          product(:,2) = product(:,2) * edgeEquation(:)
-
-       enddo ! lVertex
-
-       sum_of_products(:,:) = sum_of_products(:,:) + product(:,:)
-
-    enddo ! jVertex
-
-    derivative(:,:) = sum_of_products(:,:) * wachspressKappa(jVertex,iVertex)
-
-  end subroutine wachspress_numerator_derivative!}}}
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  wachspress_edge_equation
-!
-!> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 2013-2014
-!> \details
-!>
-!
-!-----------------------------------------------------------------------
-
-  subroutine wachspress_edge_equation(&
-       x, &
-       y, &
-       wachspressA, &
-       wachspressB, &
-       edgeEquation)
-
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         x, & !< Input:
-         y    !< Input:
-
-    real(kind=RKIND), intent(in) :: &
-         wachspressA, & !< Input:
-         wachspressB    !< Input:
-
-    real(kind=RKIND), dimension(:), intent(out) :: &
-         edgeEquation !< Output:
-
-    edgeEquation(:) = 1.0_RKIND - wachspressA * x(:) - wachspressB * y(:)
-
-  end subroutine wachspress_edge_equation!}}}
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
@@ -1092,8 +624,12 @@ contains
        wachspressB, &
        wachspressKappa)!{{{
 
-    use seaice_velocity_solver_variational_shared, only: &
+    use seaice_mesh, only: &
          seaice_wrapped_index
+
+    use seaice_wachspress_basis, only: &
+         seaice_wachspress_indexes, &
+         seaice_wachspress_basis_derivative
 
     ! basisGradientUV(jVertexOnCell,iVertexOnCell,iCell)
     ! iCell         : The cell the gradients are based in
@@ -1146,7 +682,7 @@ contains
     ! loop over cells
     do iCell = 1, nCells
 
-       call wachspress_indexes(&
+       call seaice_wachspress_indexes(&
             nEdgesOnCell(iCell), &
             nEdgesOnCellSubset(1:nEdgesOnCell(iCell)), &
             vertexIndexSubset(1:nEdgesOnCell(iCell),1:nEdgesOnCell(iCell)))
@@ -1162,7 +698,7 @@ contains
        ! loop over vertices - basis function
        do iBasisVertex = 1, nEdgesOnCell(iCell)
 
-          call wachspress_basis_derivative(&
+          call seaice_wachspress_basis_derivative(&
                nEdgesOnCell(iCell), &
                iBasisVertex, &
                x(1:nEdgesOnCell(iCell)), &
@@ -1204,741 +740,6 @@ contains
     deallocate(derivativeV)
 
   end subroutine calculate_wachspress_derivatives!}}}
-
-!-----------------------------------------------------------------------
-! Integration factors
-!-----------------------------------------------------------------------
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  get_integration_factors
-!
-!> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 18th October 2016
-!> \details
-!>
-!
-!-----------------------------------------------------------------------
-
-  subroutine get_integration_factors(&
-       integrationType, &
-       integrationOrder, &
-       nIntegrationPoints, &
-       u, &
-       v, &
-       weights, &
-       normalizationFactor)
-
-    character(len=strKIND), intent(in) :: &
-         integrationType
-
-    integer, intent(in) :: &
-         integrationOrder
-
-    integer, intent(out) :: &
-         nIntegrationPoints
-
-    real(kind=RKIND), dimension(:), allocatable, intent(out) :: &
-         u, &
-         v, &
-         weights
-
-    real(kind=RKIND), intent(out) :: &
-         normalizationFactor
-
-    if (trim(integrationType) == "trapezoidal") then
-
-       call get_integration_factors_trapezoidal(&
-            integrationOrder, &
-            nIntegrationPoints, &
-            u, &
-            v, &
-            weights, &
-            normalizationFactor)
-
-    else if (trim(integrationType) == "dunavant") then
-
-       call get_integration_factors_dunavant(&
-            integrationOrder, &
-            nIntegrationPoints, &
-            u, &
-            v, &
-            weights, &
-            normalizationFactor)
-
-    else if (trim(integrationType) == "fekete") then
-
-       call get_integration_factors_fekete(&
-            integrationOrder, &
-            nIntegrationPoints, &
-            u, &
-            v, &
-            weights, &
-            normalizationFactor)
-
-    else
-
-       ! unknown integration type
-       call mpas_log_write("get_integration_factors: Unknown wachspress integration type: "//trim(integrationType), MPAS_LOG_CRIT)
-
-    endif
-
-  end subroutine get_integration_factors
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  get_integration_factors_trapezoidal
-!
-!> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 18th October 2016
-!> \details
-!>
-!
-!-----------------------------------------------------------------------
-
-  subroutine get_integration_factors_trapezoidal(&
-       integrationOrder, &
-       nIntegrationPoints, &
-       u, &
-       v, &
-       weights, &
-       normalizationFactor)
-
-    integer, intent(in) :: &
-         integrationOrder
-
-    integer, intent(out) :: &
-         nIntegrationPoints
-
-    real(kind=RKIND), dimension(:), allocatable, intent(out) :: &
-         u, &
-         v, &
-         weights
-
-    real(kind=RKIND), intent(out) :: &
-         normalizationFactor
-
-    integer :: &
-         nIntegrationTriangles
-
-    integer :: &
-         i, j, ij
-
-    nIntegrationTriangles = integrationOrder
-
-    ! total number of integration points in sub triangle
-    nIntegrationPoints = ((nIntegrationTriangles+1)**2 + (nIntegrationTriangles+1)) / 2
-
-    ! allocate integration factors
-    allocate(u(nIntegrationPoints))
-    allocate(v(nIntegrationPoints))
-    allocate(weights(nIntegrationPoints))
-
-    ! get integration point canonical location
-    ij = 1
-    do i = 0, nIntegrationTriangles
-       do j = 0, nIntegrationTriangles-i
-
-          u(ij) = real(i,RKIND) / real(nIntegrationTriangles,RKIND)
-          v(ij) = real(j,RKIND) / real(nIntegrationTriangles,RKIND)
-
-          ij = ij + 1
-
-       enddo ! j
-    enddo ! i
-
-    ! get the weights
-    ij = 1
-    do i = 0, nIntegrationTriangles
-       do j = 0, nIntegrationTriangles-i
-
-          weights(ij) = 0.0_RKIND
-
-          if (i<=nIntegrationTriangles-j) then
-
-             if (i==nIntegrationTriangles .or. j==nIntegrationTriangles .or. (i==0 .and. j==0)) then
-
-                weights(ij) = 1.0_RKIND
-
-             else if ((j==0 .and. i/=0 .and. i/=nIntegrationTriangles) .or. &
-                      (i==0 .and. j/=0 .and. j/=nIntegrationTriangles) .or. &
-                      (i==nIntegrationTriangles-j .and. i/=0 .and. j/=0)) then
-
-                weights(ij) = 3.0_RKIND
-
-             else
-
-                weights(ij) = 6.0_RKIND
-
-             endif
-
-          endif
-
-          ij = ij + 1
-
-       enddo ! j
-    enddo ! i
-
-    ! normalization factor
-    normalizationFactor = 6.0_RKIND * real(nIntegrationTriangles,RKIND)**2
-
-  end subroutine get_integration_factors_trapezoidal
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  get_integration_factors
-!
-!> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 18th October 2016
-!> \details
-!>
-!
-!-----------------------------------------------------------------------
-
-  subroutine get_integration_factors_dunavant(&
-       integrationOrder, &
-       nIntegrationPoints, &
-       u, &
-       v, &
-       weights, &
-       normalizationFactor)
-
-    integer, intent(in) :: &
-         integrationOrder
-
-    integer, intent(out) :: &
-         nIntegrationPoints
-
-    real(kind=RKIND), dimension(:), allocatable, intent(out) :: &
-         u, &
-         v, &
-         weights
-
-    real(kind=RKIND), intent(out) :: &
-         normalizationFactor
-
-    ! D. A. Dunavant, High degree efficient symmetrical Gaussian quadrature rules for the triangle,
-    ! Int. J. Num. Meth. Engng, 21(1985):1129-1148.
-
-    normalizationFactor = 2.0_RKIND
-
-    if (modulo(integrationOrder,2) /= 0) then
-       call mpas_log_write("get_integration_factors_dunavant: odd orders of integration not recommended", MPAS_LOG_WARN)
-    endif
-
-    select case (integrationOrder)
-    case(1)
-
-       nIntegrationPoints = 1
-
-       allocate(u(nIntegrationPoints))
-       allocate(v(nIntegrationPoints))
-       allocate(weights(nIntegrationPoints))
-
-       u = (/ &
-            0.33333333333333_RKIND /)
-
-       v = (/ &
-            0.33333333333333_RKIND /)
-
-       weights = (/ &
-            1.00000000000000_RKIND /)
-
-    case (2)
-
-       nIntegrationPoints = 3
-
-       allocate(u(nIntegrationPoints))
-       allocate(v(nIntegrationPoints))
-       allocate(weights(nIntegrationPoints))
-
-       u = (/ &
-            0.16666666666667_RKIND, 0.16666666666667_RKIND, 0.66666666666667_RKIND /)
-
-       v = (/ &
-            0.16666666666667_RKIND, 0.66666666666667_RKIND, 0.16666666666667_RKIND /)
-
-       weights = (/ &
-            0.33333333333333_RKIND, 0.33333333333333_RKIND, 0.33333333333333_RKIND /)
-
-    case (3)
-
-       nIntegrationPoints = 4
-
-       allocate(u(nIntegrationPoints))
-       allocate(v(nIntegrationPoints))
-       allocate(weights(nIntegrationPoints))
-
-       u = (/ &
-            0.33333333333333_RKIND, 0.20000000000000_RKIND, 0.20000000000000_RKIND, 0.60000000000000_RKIND /)
-
-       v = (/ &
-            0.33333333333333_RKIND, 0.20000000000000_RKIND, 0.60000000000000_RKIND, 0.20000000000000_RKIND /)
-
-       weights = (/ &
-           -0.56250000000000_RKIND, 0.52083333333333_RKIND, 0.52083333333333_RKIND, 0.52083333333333_RKIND /)
-
-    case (4)
-
-       nIntegrationPoints = 6
-
-       allocate(u(nIntegrationPoints))
-       allocate(v(nIntegrationPoints))
-       allocate(weights(nIntegrationPoints))
-
-       u = (/ &
-            0.44594849091597_RKIND, 0.44594849091597_RKIND, 0.10810301816807_RKIND, 0.09157621350977_RKIND, &
-            0.09157621350977_RKIND, 0.81684757298046_RKIND /)
-
-       v = (/ &
-            0.44594849091597_RKIND, 0.10810301816807_RKIND, 0.44594849091597_RKIND, 0.09157621350977_RKIND, &
-            0.81684757298046_RKIND, 0.09157621350977_RKIND /)
-
-       weights = (/ &
-            0.22338158967801_RKIND, 0.22338158967801_RKIND, 0.22338158967801_RKIND, 0.10995174365532_RKIND, &
-            0.10995174365532_RKIND, 0.10995174365532_RKIND /)
-
-    case (5)
-
-       nIntegrationPoints = 7
-
-       allocate(u(nIntegrationPoints))
-       allocate(v(nIntegrationPoints))
-       allocate(weights(nIntegrationPoints))
-
-       u = (/ &
-            0.33333333333333_RKIND, 0.47014206410511_RKIND, 0.47014206410511_RKIND, 0.05971587178977_RKIND, &
-            0.10128650732346_RKIND, 0.10128650732346_RKIND, 0.79742698535309_RKIND /)
-
-       v = (/ &
-            0.33333333333333_RKIND, 0.47014206410511_RKIND, 0.05971587178977_RKIND, 0.47014206410511_RKIND, &
-            0.10128650732346_RKIND, 0.79742698535309_RKIND, 0.10128650732346_RKIND /)
-
-       weights = (/ &
-            0.22500000000000_RKIND, 0.13239415278851_RKIND, 0.13239415278851_RKIND, 0.13239415278851_RKIND, &
-            0.12593918054483_RKIND, 0.12593918054483_RKIND, 0.12593918054483_RKIND /)
-
-    case (6)
-
-       nIntegrationPoints = 12
-
-       allocate(u(nIntegrationPoints))
-       allocate(v(nIntegrationPoints))
-       allocate(weights(nIntegrationPoints))
-
-       u = (/ &
-            0.24928674517091_RKIND, 0.24928674517091_RKIND, 0.50142650965818_RKIND, 0.06308901449150_RKIND, &
-            0.06308901449150_RKIND, 0.87382197101700_RKIND, 0.31035245103378_RKIND, 0.63650249912140_RKIND, &
-            0.05314504984482_RKIND, 0.63650249912140_RKIND, 0.31035245103378_RKIND, 0.05314504984482_RKIND /)
-
-       v = (/ &
-            0.24928674517091_RKIND, 0.50142650965818_RKIND, 0.24928674517091_RKIND, 0.06308901449150_RKIND, &
-            0.87382197101700_RKIND, 0.06308901449150_RKIND, 0.63650249912140_RKIND, 0.05314504984482_RKIND, &
-            0.31035245103378_RKIND, 0.31035245103378_RKIND, 0.05314504984482_RKIND, 0.63650249912140_RKIND /)
-
-       weights = (/ &
-            0.11678627572638_RKIND, 0.11678627572638_RKIND, 0.11678627572638_RKIND, 0.05084490637021_RKIND, &
-            0.05084490637021_RKIND, 0.05084490637021_RKIND, 0.08285107561837_RKIND, 0.08285107561837_RKIND, &
-            0.08285107561837_RKIND, 0.08285107561837_RKIND, 0.08285107561837_RKIND, 0.08285107561837_RKIND /)
-
-    case (7)
-
-       nIntegrationPoints = 13
-
-       allocate(u(nIntegrationPoints))
-       allocate(v(nIntegrationPoints))
-       allocate(weights(nIntegrationPoints))
-
-       u = (/ &
-            0.33333333333333_RKIND, 0.26034596607904_RKIND, 0.26034596607904_RKIND, 0.47930806784192_RKIND, &
-            0.06513010290222_RKIND, 0.06513010290222_RKIND, 0.86973979419557_RKIND, 0.31286549600487_RKIND, &
-            0.63844418856981_RKIND, 0.04869031542532_RKIND, 0.63844418856981_RKIND, 0.31286549600487_RKIND, &
-            0.04869031542532_RKIND /)
-
-       v = (/ &
-            0.33333333333333_RKIND, 0.26034596607904_RKIND, 0.47930806784192_RKIND, 0.26034596607904_RKIND, &
-            0.06513010290222_RKIND, 0.86973979419557_RKIND, 0.06513010290222_RKIND, 0.63844418856981_RKIND, &
-            0.04869031542532_RKIND, 0.31286549600487_RKIND, 0.31286549600487_RKIND, 0.04869031542532_RKIND, &
-            0.63844418856981_RKIND /)
-
-       weights = (/ &
-           -0.14957004446768_RKIND, 0.17561525743321_RKIND, 0.17561525743321_RKIND, 0.17561525743321_RKIND, &
-            0.05334723560884_RKIND, 0.05334723560884_RKIND, 0.05334723560884_RKIND, 0.07711376089026_RKIND, &
-            0.07711376089026_RKIND, 0.07711376089026_RKIND, 0.07711376089026_RKIND, 0.07711376089026_RKIND, &
-            0.07711376089026_RKIND /)
-
-    case (8)
-
-       nIntegrationPoints = 16
-
-       allocate(u(nIntegrationPoints))
-       allocate(v(nIntegrationPoints))
-       allocate(weights(nIntegrationPoints))
-
-       u = (/ &
-            0.33333333333333_RKIND, 0.45929258829272_RKIND, 0.45929258829272_RKIND, 0.08141482341455_RKIND, &
-            0.17056930775176_RKIND, 0.17056930775176_RKIND, 0.65886138449648_RKIND, 0.05054722831703_RKIND, &
-            0.05054722831703_RKIND, 0.89890554336594_RKIND, 0.26311282963464_RKIND, 0.72849239295540_RKIND, &
-            0.00839477740996_RKIND, 0.72849239295540_RKIND, 0.26311282963464_RKIND, 0.00839477740996_RKIND /)
-
-       v = (/ &
-            0.33333333333333_RKIND, 0.45929258829272_RKIND, 0.08141482341455_RKIND, 0.45929258829272_RKIND, &
-            0.17056930775176_RKIND, 0.65886138449648_RKIND, 0.17056930775176_RKIND, 0.05054722831703_RKIND, &
-            0.89890554336594_RKIND, 0.05054722831703_RKIND, 0.72849239295540_RKIND, 0.00839477740996_RKIND, &
-            0.26311282963464_RKIND, 0.26311282963464_RKIND, 0.00839477740996_RKIND, 0.72849239295540_RKIND /)
-
-       weights = (/ &
-            0.14431560767779_RKIND, 0.09509163426728_RKIND, 0.09509163426728_RKIND, 0.09509163426728_RKIND, &
-            0.10321737053472_RKIND, 0.10321737053472_RKIND, 0.10321737053472_RKIND, 0.03245849762320_RKIND, &
-            0.03245849762320_RKIND, 0.03245849762320_RKIND, 0.02723031417443_RKIND, 0.02723031417443_RKIND, &
-            0.02723031417443_RKIND, 0.02723031417443_RKIND, 0.02723031417443_RKIND, 0.02723031417443_RKIND /)
-
-    case (9)
-
-       nIntegrationPoints = 19
-
-       allocate(u(nIntegrationPoints))
-       allocate(v(nIntegrationPoints))
-       allocate(weights(nIntegrationPoints))
-
-       u = (/ &
-            0.333333333333333_RKIND, 0.020634961602525_RKIND, 0.489682519198738_RKIND, 0.489682519198738_RKIND, &
-            0.125820817014127_RKIND, 0.437089591492937_RKIND, 0.437089591492937_RKIND, 0.623592928761935_RKIND, &
-            0.188203535619033_RKIND, 0.188203535619033_RKIND, 0.910540973211095_RKIND, 0.044729513394453_RKIND, &
-            0.044729513394453_RKIND, 0.036838412054736_RKIND, 0.221962989160766_RKIND, 0.036838412054736_RKIND, &
-            0.741198598784498_RKIND, 0.221962989160766_RKIND, 0.741198598784498_RKIND /)
-
-       v = (/ &
-            0.333333333333333_RKIND, 0.489682519198738_RKIND, 0.020634961602525_RKIND, 0.489682519198738_RKIND, &
-            0.437089591492937_RKIND, 0.125820817014127_RKIND, 0.437089591492937_RKIND, 0.188203535619033_RKIND, &
-            0.623592928761935_RKIND, 0.188203535619033_RKIND, 0.044729513394453_RKIND, 0.910540973211095_RKIND, &
-            0.044729513394453_RKIND, 0.221962989160766_RKIND, 0.036838412054736_RKIND, 0.741198598784498_RKIND, &
-            0.036838412054736_RKIND, 0.741198598784498_RKIND, 0.221962989160766_RKIND /)
-
-       weights = (/ &
-            0.097135796282799_RKIND, 0.031334700227139_RKIND, 0.031334700227139_RKIND, 0.031334700227139_RKIND, &
-            0.077827541004774_RKIND, 0.077827541004774_RKIND, 0.077827541004774_RKIND, 0.079647738927210_RKIND, &
-            0.079647738927210_RKIND, 0.079647738927210_RKIND, 0.025577675658698_RKIND, 0.025577675658698_RKIND, &
-            0.025577675658698_RKIND, 0.043283539377289_RKIND, 0.043283539377289_RKIND, 0.043283539377289_RKIND, &
-            0.043283539377289_RKIND, 0.043283539377289_RKIND, 0.043283539377289_RKIND /)
-
-    case (10)
-
-       nIntegrationPoints = 25
-
-       allocate(u(nIntegrationPoints))
-       allocate(v(nIntegrationPoints))
-       allocate(weights(nIntegrationPoints))
-
-       u = (/ &
-            0.333333333333333_RKIND, 0.028844733232685_RKIND, 0.485577633383657_RKIND, 0.485577633383657_RKIND, &
-            0.781036849029926_RKIND, 0.109481575485037_RKIND, 0.109481575485037_RKIND, 0.141707219414880_RKIND, &
-            0.307939838764121_RKIND, 0.141707219414880_RKIND, 0.550352941820999_RKIND, 0.307939838764121_RKIND, &
-            0.550352941820999_RKIND, 0.025003534762686_RKIND, 0.246672560639903_RKIND, 0.025003534762686_RKIND, &
-            0.728323904597411_RKIND, 0.246672560639903_RKIND, 0.728323904597411_RKIND, 0.009540815400299_RKIND, &
-            0.066803251012200_RKIND, 0.009540815400299_RKIND, 0.923655933587500_RKIND, 0.066803251012200_RKIND, &
-            0.923655933587500_RKIND /)
-
-       v = (/ &
-            0.333333333333333_RKIND, 0.485577633383657_RKIND, 0.028844733232685_RKIND, 0.485577633383657_RKIND, &
-            0.109481575485037_RKIND, 0.781036849029926_RKIND, 0.109481575485037_RKIND, 0.307939838764121_RKIND, &
-            0.141707219414880_RKIND, 0.550352941820999_RKIND, 0.141707219414880_RKIND, 0.550352941820999_RKIND, &
-            0.307939838764121_RKIND, 0.246672560639903_RKIND, 0.025003534762686_RKIND, 0.728323904597411_RKIND, &
-            0.025003534762686_RKIND, 0.728323904597411_RKIND, 0.246672560639903_RKIND, 0.066803251012200_RKIND, &
-            0.009540815400299_RKIND, 0.923655933587500_RKIND, 0.009540815400299_RKIND, 0.923655933587500_RKIND, &
-            0.066803251012200_RKIND /)
-
-       weights = (/ &
-            0.090817990382754_RKIND, 0.036725957756467_RKIND, 0.036725957756467_RKIND, 0.036725957756467_RKIND, &
-            0.045321059435528_RKIND, 0.045321059435528_RKIND, 0.045321059435528_RKIND, 0.072757916845420_RKIND, &
-            0.072757916845420_RKIND, 0.072757916845420_RKIND, 0.072757916845420_RKIND, 0.072757916845420_RKIND, &
-            0.072757916845420_RKIND, 0.028327242531057_RKIND, 0.028327242531057_RKIND, 0.028327242531057_RKIND, &
-            0.028327242531057_RKIND, 0.028327242531057_RKIND, 0.028327242531057_RKIND, 0.009421666963733_RKIND, &
-            0.009421666963733_RKIND, 0.009421666963733_RKIND, 0.009421666963733_RKIND, 0.009421666963733_RKIND, &
-            0.009421666963733_RKIND /)
-
-    case (12)
-
-       nIntegrationPoints = 33
-
-       allocate(u(nIntegrationPoints))
-       allocate(v(nIntegrationPoints))
-       allocate(weights(nIntegrationPoints))
-
-       u = (/ &
-            0.023565220452390_RKIND, 0.488217389773805_RKIND, 0.488217389773805_RKIND, 0.120551215411079_RKIND, &
-            0.439724392294460_RKIND, 0.439724392294460_RKIND, 0.457579229975768_RKIND, 0.271210385012116_RKIND, &
-            0.271210385012116_RKIND, 0.744847708916828_RKIND, 0.127576145541586_RKIND, 0.127576145541586_RKIND, &
-            0.957365299093579_RKIND, 0.021317350453210_RKIND, 0.021317350453210_RKIND, 0.115343494534698_RKIND, &
-            0.275713269685514_RKIND, 0.115343494534698_RKIND, 0.608943235779788_RKIND, 0.275713269685514_RKIND, &
-            0.608943235779788_RKIND, 0.022838332222257_RKIND, 0.281325580989940_RKIND, 0.022838332222257_RKIND, &
-            0.695836086787803_RKIND, 0.281325580989940_RKIND, 0.695836086787803_RKIND, 0.025734050548330_RKIND, &
-            0.116251915907597_RKIND, 0.025734050548330_RKIND, 0.858014033544073_RKIND, 0.116251915907597_RKIND, &
-            0.858014033544073_RKIND /)
-
-       v = (/ &
-            0.488217389773805_RKIND, 0.023565220452390_RKIND, 0.488217389773805_RKIND, 0.439724392294460_RKIND, &
-            0.120551215411079_RKIND, 0.439724392294460_RKIND, 0.271210385012116_RKIND, 0.457579229975768_RKIND, &
-            0.271210385012116_RKIND, 0.127576145541586_RKIND, 0.744847708916828_RKIND, 0.127576145541586_RKIND, &
-            0.021317350453210_RKIND, 0.957365299093579_RKIND, 0.021317350453210_RKIND, 0.275713269685514_RKIND, &
-            0.115343494534698_RKIND, 0.608943235779788_RKIND, 0.115343494534698_RKIND, 0.608943235779788_RKIND, &
-            0.275713269685514_RKIND, 0.281325580989940_RKIND, 0.022838332222257_RKIND, 0.695836086787803_RKIND, &
-            0.022838332222257_RKIND, 0.695836086787803_RKIND, 0.281325580989940_RKIND, 0.116251915907597_RKIND, &
-            0.025734050548330_RKIND, 0.858014033544073_RKIND, 0.025734050548330_RKIND, 0.858014033544073_RKIND, &
-            0.116251915907597_RKIND /)
-
-       weights = (/ &
-            0.025731066440455_RKIND, 0.025731066440455_RKIND, 0.025731066440455_RKIND, 0.043692544538038_RKIND, &
-            0.043692544538038_RKIND, 0.043692544538038_RKIND, 0.062858224217885_RKIND, 0.062858224217885_RKIND, &
-            0.062858224217885_RKIND, 0.034796112930709_RKIND, 0.034796112930709_RKIND, 0.034796112930709_RKIND, &
-            0.006166261051559_RKIND, 0.006166261051559_RKIND, 0.006166261051559_RKIND, 0.040371557766381_RKIND, &
-            0.040371557766381_RKIND, 0.040371557766381_RKIND, 0.040371557766381_RKIND, 0.040371557766381_RKIND, &
-            0.040371557766381_RKIND, 0.022356773202303_RKIND, 0.022356773202303_RKIND, 0.022356773202303_RKIND, &
-            0.022356773202303_RKIND, 0.022356773202303_RKIND, 0.022356773202303_RKIND, 0.017316231108659_RKIND, &
-            0.017316231108659_RKIND, 0.017316231108659_RKIND, 0.017316231108659_RKIND, 0.017316231108659_RKIND, &
-            0.017316231108659_RKIND /)
-
-    case default
-
-       call mpas_log_write(&
-            "get_integration_factors_dunavant: Unimplemented integration order for Dunavant wachspress integration", &
-            MPAS_LOG_CRIT)
-
-    end select
-
-  end subroutine get_integration_factors_dunavant
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  get_integration_factors
-!
-!> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 18th October 2016
-!> \details
-!>
-!
-!-----------------------------------------------------------------------
-
-  subroutine get_integration_factors_fekete(&
-       integrationOrder, &
-       nIntegrationPoints, &
-       u, &
-       v, &
-       weights, &
-       normalizationFactor)
-
-    integer, intent(in) :: &
-         integrationOrder
-
-    integer, intent(out) :: &
-         nIntegrationPoints
-
-    real(kind=RKIND), dimension(:), allocatable, intent(out) :: &
-         u, &
-         v, &
-         weights
-
-    real(kind=RKIND), intent(out) :: &
-         normalizationFactor
-
-    ! M. A. TAYLOR, B. A. WINGATE, AND R. E. VINCENT, (200), "AN ALGORITHM FOR COMPUTING FEKETE POINTS IN THE TRIANGLE",
-    ! SIAM J. NUMER. ANAL., Vol. 38, No. 5, pp. 1707–1720
-
-    normalizationFactor = 2.0_RKIND
-
-    select case (integrationOrder)
-    case (1)
-
-       nIntegrationPoints = 1
-
-       allocate(u(nIntegrationPoints))
-       allocate(v(nIntegrationPoints))
-       allocate(weights(nIntegrationPoints))
-
-       u = (/ &
-            3.33333333333333333e-01_RKIND /)
-
-       v = (/ &
-            3.33333333333333333e-01_RKIND /)
-
-       weights = (/ &
-            1.0_RKIND /)
-
-    case (2)
-
-       nIntegrationPoints = 3
-
-       allocate(u(nIntegrationPoints))
-       allocate(v(nIntegrationPoints))
-       allocate(weights(nIntegrationPoints))
-
-       u = (/ &
-            1.66666666666666666e-01_RKIND, 6.66666666666666666e-01_RKIND, 1.66666666666666666e-01_RKIND /)
-
-       v = (/ &
-            6.66666666666666666e-01_RKIND, 1.66666666666666666e-01_RKIND, 1.66666666666666666e-01_RKIND /)
-
-       weights = (/ &
-            3.33333333333333333e-01_RKIND, 3.33333333333333333e-01_RKIND, 3.33333333333333333e-01_RKIND /)
-
-    case (3:4)
-
-       nIntegrationPoints = 6
-
-       allocate(u(nIntegrationPoints))
-       allocate(v(nIntegrationPoints))
-       allocate(weights(nIntegrationPoints))
-
-       u = (/ &
-            9.15762135097704655e-02_RKIND, 8.16847572980458514e-01_RKIND, &
-            9.15762135097710761e-02_RKIND, 1.08103018168070275e-01_RKIND, &
-            4.45948490915965612e-01_RKIND, 4.45948490915964113e-01_RKIND /)
-
-       v = (/ &
-            8.16847572980458514e-01_RKIND, 9.15762135097710761e-02_RKIND, &
-            9.15762135097704655e-02_RKIND, 4.45948490915964113e-01_RKIND, &
-            1.08103018168070275e-01_RKIND, 4.45948490915965612e-01_RKIND /)
-
-       weights = (/ &
-            1.09951743655321843e-01_RKIND, 1.09951743655321857e-01_RKIND, &
-            1.09951743655321885e-01_RKIND, 2.23381589678011389e-01_RKIND, &
-            2.23381589678011527e-01_RKIND, 2.23381589678011527e-01_RKIND /)
-
-    case (5)
-
-       nIntegrationPoints = 10
-
-       allocate(u(nIntegrationPoints))
-       allocate(v(nIntegrationPoints))
-       allocate(weights(nIntegrationPoints))
-
-       u = (/ &
-            0.00000000000000000e+00_RKIND, 1.00000000000000000e+00_RKIND, &
-            0.00000000000000000e+00_RKIND, 2.67327353118498978e-01_RKIND, &
-            6.72817552946136210e-01_RKIND, 6.49236350054349654e-02_RKIND, &
-            6.71649853904175198e-01_RKIND, 6.54032456800035522e-02_RKIND, &
-            2.69376706913982855e-01_RKIND, 3.38673850389605513e-01_RKIND /)
-
-       v = (/ &
-            1.00000000000000000e+00_RKIND, 0.00000000000000000e+00_RKIND, &
-            0.00000000000000000e+00_RKIND, 6.72819921871012694e-01_RKIND, &
-            2.67328859948191944e-01_RKIND, 6.71653011149382917e-01_RKIND, &
-            6.49251690028951334e-02_RKIND, 2.69378936645285116e-01_RKIND, &
-            6.54054874919145490e-02_RKIND, 3.38679989302702156e-01_RKIND /)
-
-       weights = (/ &
-            1.31356049751916795e-02_RKIND, 1.31358306034076201e-02_RKIND, &
-            1.37081973800151392e-02_RKIND, 1.17419193291163376e-01_RKIND, &
-            1.17420611913379477e-01_RKIND, 1.24012589655715613e-01_RKIND, &
-            1.24015246126072495e-01_RKIND, 1.25930230276426303e-01_RKIND, &
-            1.25933026682913923e-01_RKIND, 2.25289469095714456e-01_RKIND /)
-
-    case (6)
-
-       nIntegrationPoints = 11
-
-       allocate(u(nIntegrationPoints))
-       allocate(v(nIntegrationPoints))
-       allocate(weights(nIntegrationPoints))
-
-       u = (/ &
-            5.72549866774768601e-02_RKIND, 8.95362640024579104e-01_RKIND, 6.84475748456514044e-01_RKIND, &
-            6.87462559150295305e-02_RKIND, 6.15676205575839575e-01_RKIND, 6.27946141197789465e-01_RKIND, &
-            6.29091383418635686e-02_RKIND, 6.83782119205099126e-02_RKIND, 2.87529458374392255e-01_RKIND, &
-            3.28783556413134614e-01_RKIND, 3.12290405013644801e-01_RKIND /)
-
-       v = (/ &
-            8.95498146789879490e-01_RKIND, 6.18282212503219533e-02_RKIND, 2.33437384976827311e-02_RKIND, &
-            6.00302757472630025e-02_RKIND, 3.33461808341377175e-01_RKIND, 1.59189185992151483e-01_RKIND, &
-            6.55295093705452469e-01_RKIND, 3.09117685428267230e-01_RKIND, 6.36426509179620181e-01_RKIND, &
-            7.70240056424634223e-02_RKIND, 3.52344786445899505e-01_RKIND /)
-
-       weights = (/ &
-            3.80680718529555623e-02_RKIND, 3.83793553077528410e-02_RKIND, 4.62004567445618367e-02_RKIND, &
-            5.34675894441989999e-02_RKIND, 8.37558269657456833e-02_RKIND, 1.01644833025517037e-01_RKIND, &
-            1.01861524461366940e-01_RKIND, 1.11421831660001677e-01_RKIND, 1.12009450262946106e-01_RKIND, &
-            1.24787571437558295e-01_RKIND, 1.88403488837394911e-01_RKIND /)
-
-    case (8)
-
-       nIntegrationPoints = 16
-
-       allocate(u(nIntegrationPoints))
-       allocate(v(nIntegrationPoints))
-       allocate(weights(nIntegrationPoints))
-
-       u = (/ &
-            7.28492392955404355e-01_RKIND, 8.39477740995753056e-03_RKIND, 2.63112829634638112e-01_RKIND, &
-            8.39477740995753056e-03_RKIND, 7.28492392955404355e-01_RKIND, 2.63112829634638112e-01_RKIND, &
-            5.05472283170310122e-02_RKIND, 5.05472283170309566e-02_RKIND, 8.98905543365938087e-01_RKIND, &
-            4.59292588292723236e-01_RKIND, 8.14148234145536387e-02_RKIND, 4.59292588292723125e-01_RKIND, &
-            1.70569307751760324e-01_RKIND, 1.70569307751760046e-01_RKIND, 6.58861384496479685e-01_RKIND, &
-            3.33333333333333370e-01_RKIND /)
-
-       v = (/ &
-            8.39477740995753056e-03_RKIND, 2.63112829634638112e-01_RKIND, 7.28492392955404355e-01_RKIND, &
-            7.28492392955404355e-01_RKIND, 2.63112829634638112e-01_RKIND, 8.39477740995753056e-03_RKIND, &
-            5.05472283170309566e-02_RKIND, 8.98905543365938087e-01_RKIND, 5.05472283170310122e-02_RKIND, &
-            8.14148234145536387e-02_RKIND, 4.59292588292723125e-01_RKIND, 4.59292588292723236e-01_RKIND, &
-            6.58861384496479685e-01_RKIND, 1.70569307751760324e-01_RKIND, 1.70569307751760046e-01_RKIND, &
-            3.33333333333333370e-01_RKIND /)
-
-       weights = (/ &
-            2.72303141744348991e-02_RKIND, 2.72303141744349199e-02_RKIND, 2.72303141744349199e-02_RKIND, &
-            2.72303141744349789e-02_RKIND, 2.72303141744349789e-02_RKIND, 2.72303141744349997e-02_RKIND, &
-            3.24584976231980793e-02_RKIND, 3.24584976231980793e-02_RKIND, 3.24584976231981001e-02_RKIND, &
-            9.50916342672845638e-02_RKIND, 9.50916342672846193e-02_RKIND, 9.50916342672846193e-02_RKIND, &
-            1.03217370534718286e-01_RKIND, 1.03217370534718314e-01_RKIND, 1.03217370534718314e-01_RKIND, &
-            1.44315607677787283e-01_RKIND /)
-
-    case (9)
-
-       nIntegrationPoints = 19
-
-       allocate(u(nIntegrationPoints))
-       allocate(v(nIntegrationPoints))
-       allocate(weights(nIntegrationPoints))
-
-       u = (/ &
-            2.26739052759332704e-01_RKIND, 4.77345862087794129e-02_RKIND, 2.26577168977105115e-02_RKIND, &
-            9.10074385862343016e-01_RKIND, 4.41452661673673585e-02_RKIND, 4.79944340675050984e-01_RKIND, &
-            7.42657808541620557e-01_RKIND, 7.43369623518591927e-01_RKIND, 2.79454959355581213e-02_RKIND, &
-            3.71861932583309532e-02_RKIND, 2.22639561442096401e-01_RKIND, 1.16082059855864395e-01_RKIND, &
-            4.73822270420208358e-01_RKIND, 4.77758170054016440e-01_RKIND, 6.46387881792721997e-01_RKIND, &
-            2.85357695207302253e-01_RKIND, 2.04236860041029755e-01_RKIND, 1.59370884213907937e-01_RKIND, &
-            3.95698265017060125e-01_RKIND /)
-
-       v = (/ &
-            0.00000000000000000e+00_RKIND, 9.16183156802148568e-01_RKIND, 7.97193825386026345e-01_RKIND, &
-            4.44666861644595901e-02_RKIND, 4.81588383854628099e-02_RKIND, 5.01294615157430568e-01_RKIND, &
-            3.03405081749971196e-02_RKIND, 2.22245578824042445e-01_RKIND, 5.25527023486726308e-01_RKIND, &
-            2.39263537482135413e-01_RKIND, 7.29063709376736702e-01_RKIND, 6.62507673462198188e-01_RKIND, &
-            4.60334709656892230e-02_RKIND, 4.01038691325781238e-01_RKIND, 1.65342747538830548e-01_RKIND, &
-            4.92973630851354261e-01_RKIND, 1.19056565447230756e-01_RKIND, 3.66261159763432431e-01_RKIND, &
-            2.27511600022304139e-01_RKIND /)
-
-       weights = (/ &
-            1.58676858667487208e-02_RKIND, 2.19524732703951786e-02_RKIND, 2.40354401213296598e-02_RKIND, &
-            2.58522468388647786e-02_RKIND, 2.71951393759608216e-02_RKIND, 3.02097786027936584e-02_RKIND, &
-            3.70093240446550606e-02_RKIND, 4.11482921825866571e-02_RKIND, 4.26331605467379776e-02_RKIND, &
-            4.71413336863812371e-02_RKIND, 5.45129844125978591e-02_RKIND, 6.26632599630084636e-02_RKIND, &
-            6.31379657675310846e-02_RKIND, 7.14623133641135444e-02_RKIND, 7.51048615652924606e-02_RKIND, &
-            7.98259878444318866e-02_RKIND, 8.16607475819435963e-02_RKIND, 9.37481686311500140e-02_RKIND, &
-            1.04838836333477403e-01_RKIND /)
-
-    case default
-
-       call mpas_log_write(&
-            "get_integration_factors_fekete: Unimplemented integration order for Fekete wachspress integration", &
-            MPAS_LOG_CRIT)
-
-    end select
-
-  end subroutine get_integration_factors_fekete
 
 !-----------------------------------------------------------------------
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver_weak.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver_weak.F
@@ -45,24 +45,24 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_init_velocity_solver_weak(&
-       mesh, &
-       boundary, &
-       velocity_weak, &
-       rotateCartesianGrid)!{{{
+  subroutine seaice_init_velocity_solver_weak(domain)!{{{
 
     use seaice_mesh, only: &
          seaice_normal_vectors
 
-    type(MPAS_pool_type), pointer, intent(inout) :: &
-         mesh !< Input/Output:
+    type (domain_type), intent(inout) :: &
+         domain !< Input/Output:
+
+    type(block_type), pointer :: &
+         blockPtr
 
     type(MPAS_pool_type), pointer :: &
-         velocity_weak, & !< Input/Output:
-         boundary   !< Input/Output:
+         meshPool, &
+         velocityWeakPool, &
+         boundaryPool
 
-    logical, intent(in) :: &
-         rotateCartesianGrid !< Input:
+    logical, pointer :: &
+         config_rotate_cartesian_grid
 
     real(kind=RKIND), dimension(:,:,:), pointer :: &
          normalVectorPolygon, &
@@ -75,21 +75,29 @@ contains
     integer, dimension(:), pointer :: &
          interiorVertex
 
-    call MPAS_pool_get_array(velocity_weak, "normalVectorPolygon", normalVectorPolygon)
-    call MPAS_pool_get_array(velocity_weak, "normalVectorTriangle", normalVectorTriangle)
-    call MPAS_pool_get_array(velocity_weak, "latCellRotated", latCellRotated)
-    call MPAS_pool_get_array(velocity_weak, "latVertexRotated", latVertexRotated)
-    call MPAS_pool_get_array(boundary, "interiorVertex", interiorVertex)
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-    call seaice_normal_vectors(&
-         mesh, &
-         normalVectorPolygon, &
-         normalVectorTriangle, &
-         interiorVertex, &
-         rotateCartesianGrid, &
-         .true., &
-         latCellRotated, &
-         latVertexRotated)
+       call MPAS_pool_get_config(domain % configs, "config_rotate_cartesian_grid", config_rotate_cartesian_grid)
+
+       call MPAS_pool_get_array(velocityWeakPool, "normalVectorPolygon", normalVectorPolygon)
+       call MPAS_pool_get_array(velocityWeakPool, "normalVectorTriangle", normalVectorTriangle)
+       call MPAS_pool_get_array(velocityWeakPool, "latCellRotated", latCellRotated)
+       call MPAS_pool_get_array(velocityWeakPool, "latVertexRotated", latVertexRotated)
+       call MPAS_pool_get_array(boundaryPool, "interiorVertex", interiorVertex)
+
+       call seaice_normal_vectors(&
+            meshPool, &
+            normalVectorPolygon, &
+            normalVectorTriangle, &
+            interiorVertex, &
+            config_rotate_cartesian_grid, &
+            .true., &
+            latCellRotated, &
+            latVertexRotated)
+
+       blockPtr => blockPtr % next
+    enddo
 
   end subroutine seaice_init_velocity_solver_weak!}}}
 
@@ -109,35 +117,33 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_strain_tensor_weak(&
-       mesh, &
-       strain11, &
-       strain22, &
-       strain12, &
-       uVelocity, &
-       vVelocity, &
-       normalVectorPolygon, &
-       latCellRotated, &
-       solveStress)!{{{
+  subroutine seaice_strain_tensor_weak(domain)!{{{
 
-    type(MPAS_pool_type), pointer, intent(in) :: &
-         mesh !< Input:
+    use seaice_mesh_pool, only: &
+         solveStress, &
+         uVelocity, &
+         vVelocity
 
-    real(kind=RKIND), dimension(:), intent(out) :: &
-         strain11, & !< Output:
-         strain22, & !< Output:
-         strain12    !< Output:
+    type(domain_type), intent(inout) :: &
+         domain
 
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         uVelocity, &   !< Input:
-         vVelocity, &   !< Input:
-         latCellRotated !< Input:
+    type(block_type), pointer :: &
+         blockPtr
 
-    real(kind=RKIND), dimension(:,:,:), intent(in) :: &
-         normalVectorPolygon !< Input:
+    type(MPAS_pool_type), pointer :: &
+         meshPool, &
+         velocityWeakPool
 
-    integer, dimension(:), intent(in) :: &
-         solveStress !< Input:
+    real(kind=RKIND), dimension(:), pointer :: &
+         strain11, &
+         strain22, &
+         strain12
+
+    real(kind=RKIND), dimension(:), pointer :: &
+         latCellRotated
+
+    real(kind=RKIND), dimension(:,:,:), pointer :: &
+         normalVectorPolygon
 
     integer :: &
          iCell, &
@@ -173,82 +179,97 @@ contains
          dvEdge, &
          areaCell
 
-    call MPAS_pool_get_dimension(mesh, "nCells", nCells)
-    call MPAS_pool_get_config(mesh, "sphere_radius", sphere_radius)
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-    call MPAS_pool_get_array(mesh, "nEdgesOnCell", nEdgesOnCell)
-    call MPAS_pool_get_array(mesh, "verticesOnCell", verticesOnCell)
-    call MPAS_pool_get_array(mesh, "edgesOnCell", edgesOnCell)
-    call MPAS_pool_get_array(mesh, "verticesOnEdge", verticesOnEdge)
-    call MPAS_pool_get_array(mesh, "dvEdge", dvEdge)
-    call MPAS_pool_get_array(mesh, "areaCell", areaCell)
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_weak", velocityWeakPool)
 
-    ! planar cases with zero sphere radius
-    sphereRadius = sphere_radius
-    if (sphereRadius == 0.0_RKIND) sphereRadius = 1.0_RKIND
+       call MPAS_pool_get_dimension(meshPool, "nCells", nCells)
+       call MPAS_pool_get_config(meshPool, "sphere_radius", sphere_radius)
 
-    do iCell = 1, nCells
+       call MPAS_pool_get_array(meshPool, "nEdgesOnCell", nEdgesOnCell)
+       call MPAS_pool_get_array(meshPool, "verticesOnCell", verticesOnCell)
+       call MPAS_pool_get_array(meshPool, "edgesOnCell", edgesOnCell)
+       call MPAS_pool_get_array(meshPool, "verticesOnEdge", verticesOnEdge)
+       call MPAS_pool_get_array(meshPool, "dvEdge", dvEdge)
+       call MPAS_pool_get_array(meshPool, "areaCell", areaCell)
 
-       strain11(iCell) = 0.0_RKIND
-       strain22(iCell) = 0.0_RKIND
-       strain12(iCell) = 0.0_RKIND
+       call MPAS_pool_get_array(velocityWeakPool, "normalVectorPolygon", normalVectorPolygon)
+       call MPAS_pool_get_array(velocityWeakPool, "latCellRotated", latCellRotated)
+       call MPAS_pool_get_array(velocityWeakPool, "strain11", strain11)
+       call MPAS_pool_get_array(velocityWeakPool, "strain22", strain22)
+       call MPAS_pool_get_array(velocityWeakPool, "strain12", strain12)
 
-       if (solveStress(iCell) == 1) then
+       ! planar cases with zero sphere radius
+       sphereRadius = sphere_radius
+       if (sphereRadius == 0.0_RKIND) sphereRadius = 1.0_RKIND
 
-          uCellCentre = 0.0_RKIND
-          vCellCentre = 0.0_RKIND
+       do iCell = 1, nCells
 
-          do iEdgeOnCell = 1, nEdgesOnCell(iCell)
+          strain11(iCell) = 0.0_RKIND
+          strain22(iCell) = 0.0_RKIND
+          strain12(iCell) = 0.0_RKIND
 
-             ! cell centre velocities
-             iVertex = verticesOnCell(iEdgeOnCell,iCell)
+          if (solveStress(iCell) == 1) then
 
-             uCellCentre = uCellCentre + uVelocity(iVertex)
-             vCellCentre = vCellCentre + vVelocity(iVertex)
+             uCellCentre = 0.0_RKIND
+             vCellCentre = 0.0_RKIND
 
-             ! interpolated edge velocity
-             iEdge = edgesOnCell(iEdgeOnCell,iCell)
+             do iEdgeOnCell = 1, nEdgesOnCell(iCell)
 
-             uVelocityEdge = 0.0_RKIND
-             vVelocityEdge = 0.0_RKIND
+                ! cell centre velocities
+                iVertex = verticesOnCell(iEdgeOnCell,iCell)
 
-             do iVertexOnEdge = 1, 2
+                uCellCentre = uCellCentre + uVelocity(iVertex)
+                vCellCentre = vCellCentre + vVelocity(iVertex)
 
-                iVertex = verticesOnEdge(iVertexOnEdge,iEdge)
+                ! interpolated edge velocity
+                iEdge = edgesOnCell(iEdgeOnCell,iCell)
 
-                uVelocityEdge = uVelocityEdge + uVelocity(iVertex)
-                vVelocityEdge = vVelocityEdge + vVelocity(iVertex)
+                uVelocityEdge = 0.0_RKIND
+                vVelocityEdge = 0.0_RKIND
 
-             enddo ! iVertexOnEdge
+                do iVertexOnEdge = 1, 2
 
-             uVelocityEdge = uVelocityEdge / 2.0_RKIND
-             vVelocityEdge = vVelocityEdge / 2.0_RKIND
+                   iVertex = verticesOnEdge(iVertexOnEdge,iEdge)
 
-             ! summation over edges
-             strain11(iCell) = strain11(iCell) + uVelocityEdge * normalVectorPolygon(1,iEdgeOnCell,iCell) * dvEdge(iEdge)
-             strain22(iCell) = strain22(iCell) + vVelocityEdge * normalVectorPolygon(2,iEdgeOnCell,iCell) * dvEdge(iEdge)
-             strain12(iCell) = strain12(iCell) + 0.5_RKIND * ( &
-                  uVelocityEdge * normalVectorPolygon(2,iEdgeOnCell,iCell) + &
-                  vVelocityEdge * normalVectorPolygon(1,iEdgeOnCell,iCell) ) * dvEdge(iEdge)
+                   uVelocityEdge = uVelocityEdge + uVelocity(iVertex)
+                   vVelocityEdge = vVelocityEdge + vVelocity(iVertex)
 
-          enddo ! iEdgeOnCell
+                enddo ! iVertexOnEdge
 
-          uCellCentre = uCellCentre / real(nEdgesOnCell(iCell), RKIND)
-          vCellCentre = vCellCentre / real(nEdgesOnCell(iCell), RKIND)
+                uVelocityEdge = uVelocityEdge / 2.0_RKIND
+                vVelocityEdge = vVelocityEdge / 2.0_RKIND
 
-          strain11(iCell) = strain11(iCell) / areaCell(iCell)
-          strain22(iCell) = strain22(iCell) / areaCell(iCell)
-          strain12(iCell) = strain12(iCell) / areaCell(iCell)
+                ! summation over edges
+                strain11(iCell) = strain11(iCell) + uVelocityEdge * normalVectorPolygon(1,iEdgeOnCell,iCell) * dvEdge(iEdge)
+                strain22(iCell) = strain22(iCell) + vVelocityEdge * normalVectorPolygon(2,iEdgeOnCell,iCell) * dvEdge(iEdge)
+                strain12(iCell) = strain12(iCell) + 0.5_RKIND * ( &
+                     uVelocityEdge * normalVectorPolygon(2,iEdgeOnCell,iCell) + &
+                     vVelocityEdge * normalVectorPolygon(1,iEdgeOnCell,iCell) ) * dvEdge(iEdge)
 
-          ! metric terms
-          strain11(iCell) = strain11(iCell) - (vCellCentre * tan(latCellRotated(iCell))) / sphereRadius
-          strain12(iCell) = strain12(iCell) + (uCellCentre * tan(latCellRotated(iCell)) * 0.5_RKIND) / sphereRadius
+             enddo ! iEdgeOnCell
 
-          !if (abs(strain11(iCell)) < 1e-10_RKIND) strain11(iCell) = 0.0_RKIND
+             uCellCentre = uCellCentre / real(nEdgesOnCell(iCell), RKIND)
+             vCellCentre = vCellCentre / real(nEdgesOnCell(iCell), RKIND)
 
-       endif ! solveStress
+             strain11(iCell) = strain11(iCell) / areaCell(iCell)
+             strain22(iCell) = strain22(iCell) / areaCell(iCell)
+             strain12(iCell) = strain12(iCell) / areaCell(iCell)
 
-    enddo ! iCell
+             ! metric terms
+             strain11(iCell) = strain11(iCell) - (vCellCentre * tan(latCellRotated(iCell))) / sphereRadius
+             strain12(iCell) = strain12(iCell) + (uCellCentre * tan(latCellRotated(iCell)) * 0.5_RKIND) / sphereRadius
+
+             !if (abs(strain11(iCell)) < 1e-10_RKIND) strain11(iCell) = 0.0_RKIND
+
+          endif ! solveStress
+
+       enddo ! iCell
+
+       blockPtr => blockPtr % next
+    end do
 
   end subroutine seaice_strain_tensor_weak!}}}
 
@@ -264,18 +285,11 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_stress_tensor_weak(&
-       mesh, &
-       stress11, &
-       stress22, &
-       stress12, &
-       strain11, &
-       strain22, &
-       strain12, &
-       icePressure, &
-       replacementPressure, &
-       solveStress, &
-       dtElastic)!{{{
+  subroutine seaice_stress_tensor_weak(domain)!{{{
+
+    use seaice_mesh_pool, only: &
+         icePressure, &
+         solveStress
 
     use seaice_velocity_solver_constitutive_relation, only: &
          constitutiveRelationType, &
@@ -286,26 +300,30 @@ contains
          seaice_evp_constitutive_relation_revised, &
          seaice_linear_constitutive_relation
 
-    type(MPAS_pool_type), pointer, intent(in) :: &
-         mesh !< Input:
+    type(domain_type), intent(inout) :: &
+         domain
 
-    real(kind=RKIND), dimension(:), intent(inout) :: &
-         stress11, &         !< Input/Output:
-         stress22, &         !< Input/Output:
-         stress12, &         !< Input/Output:
-         replacementPressure !< Input/Output:
+    type(block_type), pointer :: &
+         blockPtr
 
-    real(kind=RKIND), dimension(:), intent(inout) :: &
-         strain11, & !< Input/Output:
-         strain22, & !< Input/Output:
-         strain12, & !< Input/Output:
-         icePressure !< Input/Output:
+    type(MPAS_pool_type), pointer :: &
+         meshPool, &
+         velocitySolverPool, &
+         velocityWeakPool
 
-    integer, dimension(:), intent(in) :: &
-         solveStress !< Input:
+    real(kind=RKIND), dimension(:), pointer :: &
+         replacementPressure
 
-    real(kind=RKIND), intent(in) :: &
-         dtElastic !< Input:
+    real(kind=RKIND), dimension(:), pointer :: &
+         strain11, &
+         strain22, &
+         strain12, &
+         stress11, &
+         stress22, &
+         stress12
+
+    real(kind=RKIND), pointer :: &
+         elasticTimeStep
 
     integer :: &
          iCell
@@ -316,67 +334,169 @@ contains
     real(kind=RKIND), dimension(:), pointer :: &
          areaCell
 
-    ! init variables
-    call MPAS_pool_get_dimension(mesh, "nCells", nCells)
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-    call MPAS_pool_get_array(mesh, "areaCell", areaCell)
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_weak", velocityWeakPool)
 
-    if (constitutiveRelationType == EVP_CONSTITUTIVE_RELATION) then
+       call MPAS_pool_get_dimension(meshPool, "nCells", nCells)
 
-       do iCell = 1, nCells
+       call MPAS_pool_get_array(meshPool, "areaCell", areaCell)
 
-          if (solveStress(iCell) == 1) then
+       call MPAS_pool_get_array(velocitySolverPool, "elasticTimeStep", elasticTimeStep)
 
-             call seaice_evp_constitutive_relation(&
-                  stress11(iCell), &
-                  stress22(iCell), &
-                  stress12(iCell), &
-                  strain11(iCell), &
-                  strain22(iCell), &
-                  strain12(iCell), &
-                  icePressure(iCell), &
-                  replacementPressure(iCell), &
-                  areaCell(iCell), &
-                  dtElastic)
+       call MPAS_pool_get_array(velocityWeakPool, "strain11", strain11)
+       call MPAS_pool_get_array(velocityWeakPool, "strain22", strain22)
+       call MPAS_pool_get_array(velocityWeakPool, "strain12", strain12)
+       call MPAS_pool_get_array(velocityWeakPool, "stress11weak", stress11)
+       call MPAS_pool_get_array(velocityWeakPool, "stress22weak", stress22)
+       call MPAS_pool_get_array(velocityWeakPool, "stress12weak", stress12)
+       call MPAS_pool_get_array(velocityWeakPool, "replacementPressure", replacementPressure)
 
-          else
+       if (constitutiveRelationType == EVP_CONSTITUTIVE_RELATION) then
 
-             stress11(iCell) = 0.0_RKIND
-             stress22(iCell) = 0.0_RKIND
-             stress12(iCell) = 0.0_RKIND
+          do iCell = 1, nCells
 
-          endif ! solveStress
+             if (solveStress(iCell) == 1) then
 
-       end do ! iCell
+                call seaice_evp_constitutive_relation(&
+                     stress11(iCell), &
+                     stress22(iCell), &
+                     stress12(iCell), &
+                     strain11(iCell), &
+                     strain22(iCell), &
+                     strain12(iCell), &
+                     icePressure(iCell), &
+                     replacementPressure(iCell), &
+                     areaCell(iCell), &
+                     elasticTimeStep)
 
-    else if (constitutiveRelationType == REVISED_EVP_CONSTITUTIVE_RELATION) then
+             else
 
-       do iCell = 1, nCells
+                stress11(iCell) = 0.0_RKIND
+                stress22(iCell) = 0.0_RKIND
+                stress12(iCell) = 0.0_RKIND
 
-          if (solveStress(iCell) == 1) then
+             endif ! solveStress
 
-             call seaice_evp_constitutive_relation_revised(&
-                  stress11(iCell), &
-                  stress22(iCell), &
-                  stress12(iCell), &
-                  strain11(iCell), &
-                  strain22(iCell), &
-                  strain12(iCell), &
-                  icePressure(iCell), &
-                  replacementPressure(iCell), &
-                  areaCell(iCell))
+          end do ! iCell
 
-          else
+       else if (constitutiveRelationType == REVISED_EVP_CONSTITUTIVE_RELATION) then
 
-             stress11(iCell) = 0.0_RKIND
-             stress22(iCell) = 0.0_RKIND
-             stress12(iCell) = 0.0_RKIND
+          do iCell = 1, nCells
 
-          endif ! solveStress
+             if (solveStress(iCell) == 1) then
 
-       end do ! iCell
+                call seaice_evp_constitutive_relation_revised(&
+                     stress11(iCell), &
+                     stress22(iCell), &
+                     stress12(iCell), &
+                     strain11(iCell), &
+                     strain22(iCell), &
+                     strain12(iCell), &
+                     icePressure(iCell), &
+                     replacementPressure(iCell), &
+                     areaCell(iCell))
 
-    else if (constitutiveRelationType == LINEAR_CONSTITUTIVE_RELATION) then
+             else
+
+                stress11(iCell) = 0.0_RKIND
+                stress22(iCell) = 0.0_RKIND
+                stress12(iCell) = 0.0_RKIND
+
+             endif ! solveStress
+
+          end do ! iCell
+
+       else if (constitutiveRelationType == LINEAR_CONSTITUTIVE_RELATION) then
+
+          do iCell = 1, nCells
+
+             if (solveStress(iCell) == 1) then
+
+                call seaice_linear_constitutive_relation(&
+                     stress11(iCell), &
+                     stress22(iCell), &
+                     stress12(iCell), &
+                     strain11(iCell), &
+                     strain22(iCell), &
+                     strain12(iCell))
+
+             else
+
+                stress11(iCell) = 0.0_RKIND
+                stress22(iCell) = 0.0_RKIND
+                stress12(iCell) = 0.0_RKIND
+
+             endif ! solveStress
+
+          enddo ! iCell
+
+       endif ! constitutiveRelationType
+
+       blockPtr => blockPtr % next
+    end do
+
+  end subroutine seaice_stress_tensor_weak!}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  seaice_stress_tensor_weak_linear
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 2013-2014
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine seaice_stress_tensor_weak_linear(domain)!{{{
+
+    use seaice_velocity_solver_constitutive_relation, only: &
+         seaice_linear_constitutive_relation
+
+    use seaice_mesh_pool, only: &
+         nCells, &
+         solveStress
+
+    type(domain_type), intent(inout) :: &
+         domain
+
+    type(block_type), pointer :: &
+         blockPtr
+
+    type(MPAS_pool_type), pointer :: &
+         meshPool, &
+         velocityWeakPool
+
+    real(kind=RKIND), dimension(:), pointer :: &
+         stress11, & !< Output:
+         stress22, & !< Output:
+         stress12    !< Output:
+
+    real(kind=RKIND), dimension(:), pointer :: &
+         strain11, & !< Input:
+         strain22, & !< Input:
+         strain12    !< Input:
+
+    integer :: &
+         iCell
+
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
+
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_weak", velocityWeakPool)
+
+       call MPAS_pool_get_array(velocityWeakPool, "strain11", strain11)
+       call MPAS_pool_get_array(velocityWeakPool, "strain22", strain22)
+       call MPAS_pool_get_array(velocityWeakPool, "strain12", strain12)
+       call MPAS_pool_get_array(velocityWeakPool, "stress11", stress11)
+       call MPAS_pool_get_array(velocityWeakPool, "stress22", stress22)
+       call MPAS_pool_get_array(velocityWeakPool, "stress12", stress12)
 
        do iCell = 1, nCells
 
@@ -400,81 +520,8 @@ contains
 
        enddo ! iCell
 
-    endif ! constitutiveRelationType
-
-  end subroutine seaice_stress_tensor_weak!}}}
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  seaice_stress_tensor_weak_linear
-!
-!> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 2013-2014
-!> \details
-!>
-!
-!-----------------------------------------------------------------------
-
-  subroutine seaice_stress_tensor_weak_linear(&
-       mesh, &
-       stress11, &
-       stress22, &
-       stress12, &
-       strain11, &
-       strain22, &
-       strain12, &
-       solveStress)!{{{
-
-    use seaice_velocity_solver_constitutive_relation, only: &
-         seaice_linear_constitutive_relation
-
-    type(MPAS_pool_type), pointer, intent(in) :: &
-         mesh !< Input:
-
-    real(kind=RKIND), dimension(:), intent(out) :: &
-         stress11, & !< Output:
-         stress22, & !< Output:
-         stress12    !< Output:
-
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         strain11, & !< Input:
-         strain22, & !< Input:
-         strain12    !< Input:
-
-    integer, dimension(:), intent(in) :: &
-         solveStress !< Input:
-
-    integer :: &
-         iCell
-
-    integer, pointer :: &
-         nCells
-
-    ! init variables
-    call MPAS_pool_get_dimension(mesh, "nCells", nCells)
-
-    do iCell = 1, nCells
-
-       if (solveStress(iCell) == 1) then
-
-          call seaice_linear_constitutive_relation(&
-               stress11(iCell), &
-               stress22(iCell), &
-               stress12(iCell), &
-               strain11(iCell), &
-               strain22(iCell), &
-               strain12(iCell))
-
-       else
-
-          stress11(iCell) = 0.0_RKIND
-          stress22(iCell) = 0.0_RKIND
-          stress12(iCell) = 0.0_RKIND
-
-       endif ! solveStress
-
-    enddo ! iCell
+       blockPtr => blockPtr % next
+    end do
 
   end subroutine seaice_stress_tensor_weak_linear!}}}
 
@@ -490,35 +537,34 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_stress_divergence_weak(&
-       mesh, &
-       stressDivergenceU, &
-       stressDivergenceV, &
-       stress11, &
-       stress22, &
-       stress12, &
-       normalVectorTriangle, &
-       latVertexRotated,  &
-       solveVelocity)!{{{
+  subroutine seaice_stress_divergence_weak(domain)!{{{
 
-    type(MPAS_pool_type), pointer, intent(in) :: &
-         mesh !< Input:
+    use seaice_mesh_pool, only: &
+         solveVelocity
 
-    real(kind=RKIND), dimension(:), intent(out) :: &
-         stressDivergenceU, & !< Output:
-         stressDivergenceV    !< Output:
+    type(domain_type), intent(inout) :: &
+         domain
 
-    real(kind=RKIND), dimension(:), intent(in) :: &
-         stress11, &      !< Input:
-         stress22, &      !< Input:
-         stress12, &      !< Input:
-         latVertexRotated !< Input:
+    type(block_type), pointer :: &
+         blockPtr
 
-    real(kind=RKIND), dimension(:,:,:), intent(in) :: &
-         normalVectorTriangle !< Input:
+    type(MPAS_pool_type), pointer :: &
+         meshPool, &
+         velocitySolverPool, &
+         velocityWeakPool
 
-    integer, dimension(:), intent(in) :: &
-         solveVelocity !< Input:
+    real(kind=RKIND), dimension(:), pointer :: &
+         stressDivergenceU, &
+         stressDivergenceV
+
+    real(kind=RKIND), dimension(:), pointer :: &
+         stress11, &
+         stress22, &
+         stress12, &
+         latVertexRotated
+
+    real(kind=RKIND), dimension(:,:,:), pointer :: &
+         normalVectorTriangle
 
     real(kind=RKIND) :: &
          stress11Edge, &
@@ -554,88 +600,106 @@ contains
          areaTriangle, &
          dcEdge
 
-    ! init variables
-    call MPAS_pool_get_dimension(mesh, "nVertices", nVerticesSolve)
-    call MPAS_pool_get_dimension(mesh, "vertexDegree", vertexDegree)
-    call MPAS_pool_get_config(mesh, "sphere_radius", sphere_radius)
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-    call MPAS_pool_get_array(mesh, "cellsOnVertex", cellsOnVertex)
-    call MPAS_pool_get_array(mesh, "edgesOnVertex", edgesOnVertex)
-    call MPAS_pool_get_array(mesh, "cellsOnEdge", cellsOnEdge)
-    call MPAS_pool_get_array(mesh, "areaTriangle", areaTriangle)
-    call MPAS_pool_get_array(mesh, "dcEdge", dcEdge)
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_weak", velocityWeakPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
 
-    ! planar cases with zero sphere radius
-    sphereRadius = sphere_radius
-    if (sphereRadius == 0.0_RKIND) sphereRadius = 1.0_RKIND
+       call MPAS_pool_get_dimension(meshPool, "nVertices", nVerticesSolve)
+       call MPAS_pool_get_dimension(meshPool, "vertexDegree", vertexDegree)
+       call MPAS_pool_get_config(meshPool, "sphere_radius", sphere_radius)
 
-    do iVertex = 1, nVerticesSolve
+       call MPAS_pool_get_array(meshPool, "cellsOnVertex", cellsOnVertex)
+       call MPAS_pool_get_array(meshPool, "edgesOnVertex", edgesOnVertex)
+       call MPAS_pool_get_array(meshPool, "cellsOnEdge", cellsOnEdge)
+       call MPAS_pool_get_array(meshPool, "areaTriangle", areaTriangle)
+       call MPAS_pool_get_array(meshPool, "dcEdge", dcEdge)
 
-       stressDivergenceU(iVertex) = 0.0_RKIND
-       stressDivergenceV(iVertex) = 0.0_RKIND
+       call MPAS_pool_get_array(velocitySolverPool, "stressDivergenceU", stressDivergenceU)
+       call MPAS_pool_get_array(velocitySolverPool, "stressDivergenceV", stressDivergenceV)
 
-       if (solveVelocity(iVertex) == 1) then
+       call MPAS_pool_get_array(velocityWeakPool, "normalVectorTriangle", normalVectorTriangle)
+       call MPAS_pool_get_array(velocityWeakPool, "latVertexRotated", latVertexRotated)
+       call MPAS_pool_get_array(velocityWeakPool, "stress11", stress11)
+       call MPAS_pool_get_array(velocityWeakPool, "stress22", stress22)
+       call MPAS_pool_get_array(velocityWeakPool, "stress12", stress12)
 
-          stress11Vertex = 0.0_RKIND
-          stress22Vertex = 0.0_RKIND
-          stress12Vertex = 0.0_RKIND
+       ! planar cases with zero sphere radius
+       sphereRadius = sphere_radius
+       if (sphereRadius == 0.0_RKIND) sphereRadius = 1.0_RKIND
 
-          do iVertexDegree = 1, vertexDegree
+       do iVertex = 1, nVerticesSolve
 
-             ! vertex stresses
-             iCell = cellsOnVertex(iVertexDegree,iVertex)
+          stressDivergenceU(iVertex) = 0.0_RKIND
+          stressDivergenceV(iVertex) = 0.0_RKIND
 
-             stress11Vertex = stress11Vertex + stress11(iCell)
-             stress22Vertex = stress22Vertex + stress22(iCell)
-             stress12Vertex = stress12Vertex + stress12(iCell)
+          if (solveVelocity(iVertex) == 1) then
 
-             ! interpolated edge velocity
-             iEdge = edgesOnVertex(iVertexDegree,iVertex)
+             stress11Vertex = 0.0_RKIND
+             stress22Vertex = 0.0_RKIND
+             stress12Vertex = 0.0_RKIND
 
-             stress11Edge = 0.0_RKIND
-             stress22Edge = 0.0_RKIND
-             stress12Edge = 0.0_RKIND
+             do iVertexDegree = 1, vertexDegree
 
-             do iCellOnEdge = 1, 2
+                ! vertex stresses
+                iCell = cellsOnVertex(iVertexDegree,iVertex)
 
-                iCell = cellsOnEdge(iCellOnEdge,iEdge)
+                stress11Vertex = stress11Vertex + stress11(iCell)
+                stress22Vertex = stress22Vertex + stress22(iCell)
+                stress12Vertex = stress12Vertex + stress12(iCell)
 
-                stress11Edge = stress11Edge + stress11(iCell)
-                stress22Edge = stress22Edge + stress22(iCell)
-                stress12Edge = stress12Edge + stress12(iCell)
+                ! interpolated edge velocity
+                iEdge = edgesOnVertex(iVertexDegree,iVertex)
 
-             enddo ! iCellOnEdge
+                stress11Edge = 0.0_RKIND
+                stress22Edge = 0.0_RKIND
+                stress12Edge = 0.0_RKIND
 
-             stress11Edge = stress11Edge / 2.0_RKIND
-             stress22Edge = stress22Edge / 2.0_RKIND
-             stress12Edge = stress12Edge / 2.0_RKIND
+                do iCellOnEdge = 1, 2
 
-             stressDivergenceU(iVertex) = stressDivergenceU(iVertex) + &
-                  (stress11Edge * normalVectorTriangle(1,iVertexDegree,iVertex) + &
-                   stress12Edge * normalVectorTriangle(2,iVertexDegree,iVertex)) * dcEdge(iEdge)
+                   iCell = cellsOnEdge(iCellOnEdge,iEdge)
 
+                   stress11Edge = stress11Edge + stress11(iCell)
+                   stress22Edge = stress22Edge + stress22(iCell)
+                   stress12Edge = stress12Edge + stress12(iCell)
+
+                enddo ! iCellOnEdge
+
+                stress11Edge = stress11Edge / 2.0_RKIND
+                stress22Edge = stress22Edge / 2.0_RKIND
+                stress12Edge = stress12Edge / 2.0_RKIND
+
+                stressDivergenceU(iVertex) = stressDivergenceU(iVertex) + &
+                     (stress11Edge * normalVectorTriangle(1,iVertexDegree,iVertex) + &
+                     stress12Edge * normalVectorTriangle(2,iVertexDegree,iVertex)) * dcEdge(iEdge)
+
+                stressDivergenceV(iVertex) = stressDivergenceV(iVertex) + &
+                     (stress22Edge * normalVectorTriangle(2,iVertexDegree,iVertex) + &
+                     stress12Edge * normalVectorTriangle(1,iVertexDegree,iVertex)) * dcEdge(iEdge)
+
+             enddo ! iVertexDegree
+
+             stress11Vertex = stress11Vertex / real(vertexDegree, RKIND)
+             stress22Vertex = stress22Vertex / real(vertexDegree, RKIND)
+             stress12Vertex = stress12Vertex / real(vertexDegree, RKIND)
+
+             stressDivergenceU(iVertex) = stressDivergenceU(iVertex) / areaTriangle(iVertex)
+             stressDivergenceV(iVertex) = stressDivergenceV(iVertex) / areaTriangle(iVertex)
+
+             ! metric terms
+             stressDivergenceU(iVertex) = stressDivergenceU(iVertex) - &
+                  (tan(latVertexRotated(iVertex)) * stress12Vertex) / sphereRadius
              stressDivergenceV(iVertex) = stressDivergenceV(iVertex) + &
-                  (stress22Edge * normalVectorTriangle(2,iVertexDegree,iVertex) + &
-                   stress12Edge * normalVectorTriangle(1,iVertexDegree,iVertex)) * dcEdge(iEdge)
+                  (tan(latVertexRotated(iVertex)) * stress11Vertex) / sphereRadius
 
-          enddo ! iVertexDegree
+          endif ! solveVelocity
 
-          stress11Vertex = stress11Vertex / real(vertexDegree, RKIND)
-          stress22Vertex = stress22Vertex / real(vertexDegree, RKIND)
-          stress12Vertex = stress12Vertex / real(vertexDegree, RKIND)
+       enddo ! iVertex
 
-          stressDivergenceU(iVertex) = stressDivergenceU(iVertex) / areaTriangle(iVertex)
-          stressDivergenceV(iVertex) = stressDivergenceV(iVertex) / areaTriangle(iVertex)
-
-          ! metric terms
-          stressDivergenceU(iVertex) = stressDivergenceU(iVertex) - &
-               (tan(latVertexRotated(iVertex)) * stress12Vertex) / sphereRadius
-          stressDivergenceV(iVertex) = stressDivergenceV(iVertex) + &
-               (tan(latVertexRotated(iVertex)) * stress11Vertex) / sphereRadius
-
-       endif ! solveVelocity
-
-    enddo ! iVertex
+       blockPtr => blockPtr % next
+    end do
 
   end subroutine seaice_stress_divergence_weak!}}}
 
@@ -651,7 +715,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_final_divergence_shear_weak(block)
+  subroutine seaice_final_divergence_shear_weak(domain)
 
     use seaice_velocity_solver_constitutive_relation, only: &
          eccentricitySquared
@@ -661,8 +725,11 @@ contains
          solveStress, &
          nEdgesOnCell
 
-    type(block_type), intent(inout) :: &
-         block
+    type(domain_type), intent(inout) :: &
+         domain
+
+    type(block_type), pointer :: &
+         blockPtr
 
     type(MPAS_pool_type), pointer :: &
          meshPool, &
@@ -693,71 +760,77 @@ contains
     integer :: &
          iCell
 
-    call MPAS_pool_get_subpool(block % structs, "mesh", meshPool)
-    call MPAS_pool_get_subpool(block % structs, "velocity_weak", velocityWeakPool)
-    call MPAS_pool_get_subpool(block % structs, "velocity_solver", velocitySolverPool)
+    blockPtr => domain % blocklist
+    do while (associated(blockPtr))
 
-    call MPAS_pool_get_array(velocityWeakPool, "strain11", strain11)
-    call MPAS_pool_get_array(velocityWeakPool, "strain22", strain22)
-    call MPAS_pool_get_array(velocityWeakPool, "strain12", strain12)
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_weak", velocityWeakPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_solver", velocitySolverPool)
 
-    call MPAS_pool_get_array(velocitySolverPool, "divergence", divergence)
-    call MPAS_pool_get_array(velocitySolverPool, "shear", shear)
+       call MPAS_pool_get_array(velocityWeakPool, "strain11", strain11)
+       call MPAS_pool_get_array(velocityWeakPool, "strain22", strain22)
+       call MPAS_pool_get_array(velocityWeakPool, "strain12", strain12)
 
-    allocate(Delta(nCells))
+       call MPAS_pool_get_array(velocitySolverPool, "divergence", divergence)
+       call MPAS_pool_get_array(velocitySolverPool, "shear", shear)
 
-    do iCell = 1, nCells
-
-       if (solveStress(iCell) == 1) then
-
-          strainDivergence = strain11(iCell) + strain22(iCell)
-          strainTension    = strain11(iCell) - strain22(iCell)
-          strainShearing   = strain12(iCell) * 2.0_RKIND
-
-          Delta(iCell) = sqrt(strainDivergence**2 + (strainTension**2 + strainShearing**2) / eccentricitySquared)
-
-          divergence(iCell) = strainDivergence
-          shear(iCell)      = sqrt(strainTension**2 + strainShearing**2)
-
-       else
-
-          divergence(iCell)   = 0.0_RKIND
-          shear(iCell)        = 0.0_RKIND
-
-       endif
-
-    enddo ! iCell
-
-    ! ridging parameters
-    call MPAS_pool_get_config(block % configs, "config_use_column_package", config_use_column_package)
-
-    if (config_use_column_package) then
-
-       call MPAS_pool_get_subpool(block % structs, "ridging", ridgingPool)
-
-       call MPAS_pool_get_array(ridgingPool, "ridgeConvergence", ridgeConvergence)
-       call MPAS_pool_get_array(ridgingPool, "ridgeShear", ridgeShear)
+       allocate(Delta(nCells))
 
        do iCell = 1, nCells
 
           if (solveStress(iCell) == 1) then
 
-             ridgeConvergence(iCell) = -min(divergence(iCell),0.0_RKIND)
-             ridgeShear(iCell)       = 0.5_RKIND * (Delta(iCell) - abs(divergence(iCell)))
+             strainDivergence = strain11(iCell) + strain22(iCell)
+             strainTension    = strain11(iCell) - strain22(iCell)
+             strainShearing   = strain12(iCell) * 2.0_RKIND
+
+             Delta(iCell) = sqrt(strainDivergence**2 + (strainTension**2 + strainShearing**2) / eccentricitySquared)
+
+             divergence(iCell) = strainDivergence
+             shear(iCell)      = sqrt(strainTension**2 + strainShearing**2)
 
           else
 
-             ridgeConvergence(iCell) = 0.0_RKIND
-             ridgeShear(iCell)       = 0.0_RKIND
+             divergence(iCell)   = 0.0_RKIND
+             shear(iCell)        = 0.0_RKIND
 
           endif
 
        enddo ! iCell
 
-    endif ! config_use_column_package
+       ! ridging parameters
+       call MPAS_pool_get_config(blockPtr % configs, "config_use_column_package", config_use_column_package)
 
-    ! cleanup
-    deallocate(Delta)
+       if (config_use_column_package) then
+
+          call MPAS_pool_get_subpool(blockPtr % structs, "ridging", ridgingPool)
+
+          call MPAS_pool_get_array(ridgingPool, "ridgeConvergence", ridgeConvergence)
+          call MPAS_pool_get_array(ridgingPool, "ridgeShear", ridgeShear)
+
+          do iCell = 1, nCells
+
+             if (solveStress(iCell) == 1) then
+
+                ridgeConvergence(iCell) = -min(divergence(iCell),0.0_RKIND)
+                ridgeShear(iCell)       = 0.5_RKIND * (Delta(iCell) - abs(divergence(iCell)))
+
+             else
+
+                ridgeConvergence(iCell) = 0.0_RKIND
+                ridgeShear(iCell)       = 0.0_RKIND
+
+             endif
+
+          enddo ! iCell
+
+       endif ! config_use_column_package
+
+       ! cleanup
+       deallocate(Delta)
+
+       blockPtr => blockPtr % next
+    enddo
 
   end subroutine seaice_final_divergence_shear_weak
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_wachspress_basis.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_wachspress_basis.F
@@ -1,0 +1,580 @@
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  seaice_wachspress_basis
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 4th November 2022
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+module seaice_wachspress_basis
+
+  use mpas_derived_types
+
+  implicit none
+
+  private
+  save
+
+  public :: &
+       seaice_calc_wachspress_coefficients, &
+       seaice_wachspress_indexes, &
+       seaice_wachspress_basis_function, &
+       seaice_wachspress_basis_derivative
+
+contains
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  seaice_calc_wachspress_coefficients
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 2013-2014
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine seaice_calc_wachspress_coefficients(&
+       wachspressKappa, &
+       wachspressA, &
+       wachspressB, &
+       nCells, &
+       nEdgesOnCell, &
+       xLocal, &
+       yLocal)!{{{
+
+    real(kind=RKIND), dimension(:,:,:), intent(out) :: &
+         wachspressKappa !< Output:
+
+    real(kind=RKIND), dimension(:,:), intent(out) :: &
+         wachspressA, & !< Output:
+         wachspressB    !< Output:
+
+    integer, intent(in) :: &
+         nCells !< Input:
+
+    integer, dimension(:), intent(in) :: &
+         nEdgesOnCell !< Input:
+
+    real(kind=RKIND), dimension(:,:), intent(in) :: &
+         xLocal, & !< Input:
+         yLocal    !< Input:
+
+    integer :: &
+         iCell, &
+         iVertex, &
+         i0, &
+         i1, &
+         i2, &
+         jVertex
+
+    ! loop over cells
+    do iCell = 1, nCells
+
+       ! loop over vertices
+       do iVertex = 1, nEdgesOnCell(iCell)
+
+          ! end points of line segment
+          i1 = iVertex - 1
+          i2 = iVertex
+          if (i1 < 1) i1 = i1 + nEdgesOnCell(iCell)
+
+          ! solve for the line segment equation
+          wachspressA(iVertex, iCell) = &
+               (yLocal(i2,iCell) - yLocal(i1,iCell)) / (xLocal(i1,iCell) * yLocal(i2,iCell) - xLocal(i2,iCell) * yLocal(i1,iCell))
+          wachspressB(iVertex, iCell) = &
+               (xLocal(i1,iCell) - xLocal(i2,iCell)) / (xLocal(i1,iCell) * yLocal(i2,iCell) - xLocal(i2,iCell) * yLocal(i1,iCell))
+
+       enddo ! iVertex
+
+       ! loop over vertices
+       do iVertex = 1, nEdgesOnCell(iCell)
+
+          ! determine kappa
+          wachspressKappa(1,iVertex,iCell) = 1.0_RKIND
+
+          do jVertex = 2, nEdgesOnCell(iCell)
+
+             ! previous, this and next vertex
+             i0 = jVertex - 1
+             i1 = jVertex
+             i2 = jVertex + 1
+             if (i2 > nEdgesOnCell(iCell)) i2 = i2 - nEdgesOnCell(iCell)
+
+             wachspressKappa(jVertex,iVertex,iCell) = wachspressKappa(jVertex-1,iVertex,iCell) * &
+                  (wachspressA(i2,iCell) * (xLocal(i0,iCell) - xLocal(i1,iCell)) + &
+                   wachspressB(i2,iCell) * (yLocal(i0,iCell) - yLocal(i1,iCell))) / &
+                  (wachspressA(i0,iCell) * (xLocal(i1,iCell) - xLocal(i0,iCell)) + &
+                   wachspressB(i0,iCell) * (yLocal(i1,iCell) - yLocal(i0,iCell)))
+
+          enddo ! jVertex
+
+       enddo ! iVertex
+
+    enddo ! iCell
+
+  end subroutine seaice_calc_wachspress_coefficients!}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  seaice_wachspress_indexes
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 2013-2014
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine seaice_wachspress_indexes(&
+       nEdgesOnCell, &
+       nEdgesOnCellSubset, &
+       vertexIndexSubset)
+
+    use seaice_mesh, only: &
+         seaice_wrapped_index
+
+    integer, intent(in) :: &
+         nEdgesOnCell !< Input:
+
+    integer, dimension(:), intent(out) :: &
+         nEdgesOnCellSubset !< Output:
+
+    integer, dimension(:,:), intent(out) :: &
+         vertexIndexSubset !< Output:
+
+    integer :: &
+         jVertex, &
+         kVertex, &
+         i1, i2
+
+    do jVertex = 1, nEdgesOnCell
+
+       i1 = jVertex
+       i2 = seaice_wrapped_index(jVertex + 1, nEdgesOnCell)
+
+       nEdgesOnCellSubset(jVertex) = 0
+
+       do kVertex = 1, nEdgesOnCell
+
+          if (kVertex /= i1 .and. kVertex /= i2) then
+             nEdgesOnCellSubset(jVertex) = nEdgesOnCellSubset(jVertex) + 1
+             vertexIndexSubset(jVertex,nEdgesOnCellSubset(jVertex)) = kVertex
+          endif
+
+       enddo ! kVertex
+
+    enddo ! jVertex
+
+  end subroutine seaice_wachspress_indexes
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  seaice_wachspress_basis_function
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 2013-2014
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine seaice_wachspress_basis_function(&
+       nEdgesOnCell, &
+       iVertex, &
+       x, &
+       y, &
+       wachspressKappa, &
+       wachspressA, &
+       wachspressB, &
+       nEdgesOnCellSubset, &
+       vertexIndexSubset, &
+       wachpress)!{{{
+
+    use seaice_mesh, only: &
+         seaice_wrapped_index
+
+    integer, intent(in) :: &
+         nEdgesOnCell, & !< Input:
+         iVertex         !< Input:
+
+    real(kind=RKIND), dimension(:), intent(in) :: &
+         x, & !< Input:
+         y    !< Input:
+
+    real(kind=RKIND), dimension(:,:), intent(in) :: &
+         wachspressKappa !< Input:
+
+    real(kind=RKIND), dimension(:), intent(in) :: &
+         wachspressA, & !< Input:
+         wachspressB    !< Input:
+
+    integer, dimension(:), intent(in) :: &
+         nEdgesOnCellSubset !< Input:
+
+    integer, dimension(:,:), intent(in) :: &
+         vertexIndexSubset !< Input:
+
+    real(kind=RKIND), dimension(:), intent(out) :: &
+         wachpress !< Output:
+
+    real(kind=RKIND), dimension(size(x),nEdgesOnCell) :: &
+         numerator
+
+    real(kind=RKIND), dimension(size(x)) :: &
+         denominator, &
+         edgeEquation
+
+    integer :: &
+         jVertex
+
+    ! sum over numerators to get denominator
+    denominator(:) = 0.0_RKIND
+
+    do jVertex = 1, nEdgesOnCell
+
+      call wachspress_numerator(&
+           nEdgesOnCell, jVertex, iVertex, x(:), y(:), &
+           wachspressKappa, wachspressA, wachspressB, &
+           nEdgesOnCellSubset, vertexIndexSubset, &
+           edgeEquation(:), &
+           numerator(:,jVertex))
+
+       denominator(:) = denominator(:) + numerator(:,jVertex)
+
+    enddo ! jVertex
+
+    wachpress(:) = numerator(:,iVertex) / denominator(:)
+
+  end subroutine seaice_wachspress_basis_function!}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  seaice_wachspress_basis_derivative
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 2013-2014
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine seaice_wachspress_basis_derivative(&
+       nEdgesOnCell, &
+       iVertex, &
+       x, &
+       y, &
+       wachspressKappa, &
+       wachspressA, &
+       wachspressB, &
+       nEdgesOnCellSubset, &
+       vertexIndexSubset, &
+       wachspressU, &
+       wachspressV)!{{{
+
+    integer, intent(in) :: &
+         nEdgesOnCell, & !< Input:
+         iVertex         !< Input:
+
+    real(kind=RKIND), dimension(:), intent(in) :: &
+         x, & !< Input:
+         y    !< Input:
+
+    real(kind=RKIND), dimension(:,:), intent(in) :: &
+         wachspressKappa !< Input:
+
+    real(kind=RKIND), dimension(:), intent(in) :: &
+         wachspressA, & !< Input:
+         wachspressB    !< Input:
+
+    integer, dimension(:), intent(in) :: &
+         nEdgesOnCellSubset !< Input:
+
+    integer, dimension(:,:), intent(in) :: &
+         vertexIndexSubset !< Input:
+
+    real(kind=RKIND), dimension(:), intent(out) :: &
+         wachspressU, & !< Output:
+         wachspressV !< Output:
+
+    real(kind=RKIND), dimension(size(x),2,nEdgesOnCell) :: &
+         derivative
+
+    real(kind=RKIND), dimension(size(x),nEdgesOnCell) :: &
+         numerator
+
+    real(kind=RKIND), dimension(size(x),2) :: &
+         sum_of_derivatives, &
+         sum_of_products, &
+         product
+
+    real(kind=RKIND), dimension(size(x)) :: &
+         denominator, &
+         edgeEquation
+
+    integer :: &
+         jVertex
+
+    ! sum over numerators to get denominator
+    denominator(:) = 0.0_RKIND
+    sum_of_derivatives(:,:) = 0.0_RKIND
+
+    do jVertex = 1, nEdgesOnCell
+
+       call wachspress_numerator(&
+            nEdgesOnCell, jVertex, iVertex, x(:), y(:), &
+            wachspressKappa, wachspressA, wachspressB, &
+            nEdgesOnCellSubset, vertexIndexSubset, &
+            edgeEquation, &
+            numerator(:,jVertex))
+
+       denominator(:) = denominator(:) + numerator(:,jVertex)
+
+       call wachspress_numerator_derivative(&
+            nEdgesOnCell, jVertex, iVertex, x(:), y(:), &
+            wachspressKappa, wachspressA, wachspressB, &
+            nEdgesOnCellSubset, vertexIndexSubset, &
+            sum_of_products, product, edgeEquation, &
+            derivative(:,:,jVertex))
+
+       sum_of_derivatives(:,:) = sum_of_derivatives(:,:) + derivative(:,:,jVertex)
+
+    enddo ! jVertex
+
+    wachspressU(:) = derivative(:,1,iVertex) / denominator(:) - &
+         (numerator(:,iVertex) / denominator(:)**2) * sum_of_derivatives(:,1)
+    wachspressV(:) = derivative(:,2,iVertex) / denominator(:) - &
+         (numerator(:,iVertex) / denominator(:)**2) * sum_of_derivatives(:,2)
+
+  end subroutine seaice_wachspress_basis_derivative!}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  wachspress_numerator
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 2013-2014
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine wachspress_numerator(&
+       nEdgesOnCell, &
+       jVertex, &
+       iVertex, &
+       x, &
+       y, &
+       wachspressKappa, &
+       wachspressA, &
+       wachspressB, &
+       nEdgesOnCellSubset, &
+       vertexIndexSubset, &
+       edgeEquation, &
+       numerator)!{{{
+
+    integer, intent(in) :: &
+         nEdgesOnCell, & !< Input:
+         jVertex, &      !< Input:
+         iVertex         !< Input:
+
+    real(kind=RKIND), dimension(:), intent(in) :: &
+         x, & !< Input:
+         y    !< Input:
+
+    real(kind=RKIND), dimension(:,:), intent(in) :: &
+         wachspressKappa !< Input:
+
+    real(kind=RKIND), dimension(:), intent(in) :: &
+         wachspressA, & !< Input:
+         wachspressB    !< Input:
+
+    integer, dimension(:), intent(in) :: &
+         nEdgesOnCellSubset !< Input:
+
+    integer, dimension(:,:), intent(in) :: &
+         vertexIndexSubset !< Input:
+
+    real(kind=RKIND), dimension(:), intent(inout) :: &
+         edgeEquation
+
+    real(kind=RKIND), dimension(:), intent(out) :: &
+         numerator !< Output:
+
+    integer :: &
+         kVertex
+
+    numerator(:) = 1.0_RKIND
+
+    do kVertex = 1, nEdgesOnCellSubset(jVertex)
+
+       call wachspress_edge_equation(&
+            x(:), y(:), &
+            wachspressA(vertexIndexSubset(jVertex,kVertex)), &
+            wachspressB(vertexIndexSubset(jVertex,kVertex)), &
+            edgeEquation(:))
+
+       numerator(:) = numerator(:) * edgeEquation(:)
+
+    enddo ! jVertex
+
+    numerator(:) = numerator(:) * wachspressKappa(jVertex,iVertex)
+
+  end subroutine wachspress_numerator!}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  wachspress_numerator_derivative
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 2013-2014
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine wachspress_numerator_derivative(&
+       nEdgesOnCell, &
+       jVertex, &
+       iVertex, &
+       x, &
+       y, &
+       wachspressKappa, &
+       wachspressA, &
+       wachspressB, &
+       nEdgesOnCellSubset, &
+       vertexIndexSubset, &
+       sum_of_products, &
+       product, &
+       edgeEquation, &
+       derivative)!{{{
+
+    integer, intent(in) :: &
+         nEdgesOnCell, & !< Input:
+         jVertex, &      !< Input:
+         iVertex         !< Input:
+
+    real(kind=RKIND), dimension(:), intent(in) :: &
+         x, & !< Input:
+         y    !< Input:
+
+    real(kind=RKIND), dimension(:,:), intent(in) :: &
+         wachspressKappa !< Input:
+
+    real(kind=RKIND), dimension(:), intent(in) :: &
+         wachspressA, & !< Input:
+         wachspressB    !< Input:
+
+    integer, dimension(:), intent(in) :: &
+         nEdgesOnCellSubset !< Input:
+
+    integer, dimension(:,:), intent(in) :: &
+         vertexIndexSubset !< Input:
+
+    real(kind=RKIND), dimension(:,:), intent(out) :: &
+         derivative !< Output:
+
+    real(kind=RKIND), dimension(:,:), intent(inout) :: &
+         sum_of_products, & !< Input/Output:
+         product            !< Input/Output:
+
+    real(kind=RKIND), dimension(:), intent(inout) :: &
+         edgeEquation !< Input/Output:
+
+    integer :: &
+         kVertex, &
+         lVertex
+
+    sum_of_products(:,:) = 0.0_RKIND
+
+    do kVertex = 1, nEdgesOnCellSubset(jVertex)
+
+       product(:,:) = 1.0_RKIND
+
+       ! lVertex < kVertex
+       do lVertex = 1, kVertex - 1
+
+          call wachspress_edge_equation(&
+               x(:), y(:), &
+               wachspressA(vertexIndexSubset(jVertex,lVertex)), &
+               wachspressB(vertexIndexSubset(jVertex,lVertex)), &
+               edgeEquation(:))
+
+          product(:,1) = product(:,1) * edgeEquation(:)
+          product(:,2) = product(:,2) * edgeEquation(:)
+
+       enddo ! lVertex
+
+       ! lVertex == kVertex
+       product(:,1) = product(:,1) * (-wachspressA(vertexIndexSubset(jVertex,kVertex)))
+       product(:,2) = product(:,2) * (-wachspressB(vertexIndexSubset(jVertex,kVertex)))
+
+       ! lVertex > kVertex
+       do lVertex = kVertex + 1, nEdgesOnCellSubset(jVertex)
+
+          call wachspress_edge_equation(&
+               x(:), y(:), &
+               wachspressA(vertexIndexSubset(jVertex,lVertex)), &
+               wachspressB(vertexIndexSubset(jVertex,lVertex)), &
+               edgeEquation(:))
+
+          product(:,1) = product(:,1) * edgeEquation(:)
+          product(:,2) = product(:,2) * edgeEquation(:)
+
+       enddo ! lVertex
+
+       sum_of_products(:,:) = sum_of_products(:,:) + product(:,:)
+
+    enddo ! jVertex
+
+    derivative(:,:) = sum_of_products(:,:) * wachspressKappa(jVertex,iVertex)
+
+  end subroutine wachspress_numerator_derivative!}}}
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  wachspress_edge_equation
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 2013-2014
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine wachspress_edge_equation(&
+       x, &
+       y, &
+       wachspressA, &
+       wachspressB, &
+       edgeEquation)
+
+    real(kind=RKIND), dimension(:), intent(in) :: &
+         x, & !< Input:
+         y    !< Input:
+
+    real(kind=RKIND), intent(in) :: &
+         wachspressA, & !< Input:
+         wachspressB    !< Input:
+
+    real(kind=RKIND), dimension(:), intent(out) :: &
+         edgeEquation !< Output:
+
+    edgeEquation(:) = 1.0_RKIND - wachspressA * x(:) - wachspressB * y(:)
+
+  end subroutine wachspress_edge_equation!}}}
+
+!-----------------------------------------------------------------------
+
+end module seaice_wachspress_basis


### PR DESCRIPTION
Refactor of MPAS sea ice velocity solver to allow easier testing of new options and methods
Move domain reference to within subroutines avoiding messy passing of variables 
Move wachspress basis routines to separate module
Move triangular quadrature rules to new module
Move some mesh related routines to the mesh module 
Rename block variable to blockPtr
Rename all pool types to end in Pool

Fixes https://github.com/E3SM-Project/E3SM/issues/5289

[BFB]