### PR TITLE
For pm-cpu and pm-gpu, add environment variable MPICH_COLL_SYNC=MPI_Bcast

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -258,6 +258,7 @@
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
       <env name="PERL5LIB">/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch</env>
       <env name="FI_CXI_RX_MATCH_MODE">software</env>
+      <env name="MPICH_COLL_SYNC">MPI_Bcast</env>
     </environment_variables>
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>
@@ -378,6 +379,7 @@
       <env name="OMP_PLACES">threads</env>
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
       <env name="PERL5LIB">/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch</env>
+      <env name="MPICH_COLL_SYNC">MPI_Bcast</env>
     </environment_variables>
     <environment_variables compiler="gnugpu">
       <env name="MPICH_GPU_SUPPORT_ENABLED">1</env>


### PR DESCRIPTION
For pm-cpu and pm-gpu, add env variable MPICH_COLL_SYNC=MPI_Bcast
to avoid hanging during writing of certain files (esp ELM restarts). Thanks to @whannah1 and @dqwu for
testing, understanding the issue better, and finding this solution.

There appears to be some issues with the slingshot network as we don't see this 
problem on other machines.

Setting this will perform a MPI_Barrier before each MPI_Bcast and we've
found this resolves hanging and does not noticeably degrade performance.

Once updates are made to the network on PM, we can re-evaluate if this is still needed.

We already had a PR started with one solution to this problem here https://github.com/E3SM-Project/E3SM/pull/5275
but this solution is favored.

Fixes issues that were created in the SCREAM repo
Fixes https://github.com/E3SM-Project/scream/issues/1920
Fixes https://github.com/E3SM-Project/scream/issues/1939
Was also hanging with MMF case on 128 pm-gpu nodes.

Also noting https://github.com/E3SM-Project/scorpio/pull/493 which further explains the problem.

[BFB]
