### PR TITLE
Add support for JRA55 v1.5 forcing

### DIFF
--- a/components/data_comps/datm/cime_config/config_component.xml
+++ b/components/data_comps/datm/cime_config/config_component.xml
@@ -10,7 +10,7 @@
        This file may have atm desc entries.
   -->
   <description modifier_mode="1">
-    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%MOSARTTEST][%NLDAS2][%CPLHIST][%1PT][%NYF][%IAF][%JRA][%JRA-1p4-2018][%JRA-RYF8485][%JRA-RYF9091][%JRA-RYF0304][%CFSv2][%CFSR]"> Data driven ATM </desc>
+    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%MOSARTTEST][%NLDAS2][%CPLHIST][%1PT][%NYF][%IAF][%JRA][%JRA-1p5][%JRA-1p4-2018][%JRA-RYF8485][%JRA-RYF9091][%JRA-RYF0304][%CFSv2][%CFSR]"> Data driven ATM </desc>
     <desc option="QIA"> QIAN data set </desc>
     <desc option="WISOQIA">QIAN with water isotopes</desc>
     <desc option="CRU"> CRUNCEP data set </desc>
@@ -23,6 +23,7 @@
     <desc option="NYF">COREv2 normal year forcing</desc>
     <desc option="IAF">COREv2 interannual forcing</desc>
     <desc option="JRA">interannual JRA55 forcing</desc>
+    <desc option="JRA-1p5">interannual JRA55 forcing, v1.5, through 2020</desc>
     <desc option="JRA-1p4-2018">interannual JRA55 forcing, v1.4, through 2018</desc>
     <desc option="JRA-RYF8485"> JRA55 Repeat Year Forcing v1.3 1984-1985</desc>
     <desc option="JRA-RYF9091"> JRA55 Repeat Year Forcing v1.3 1990-1991</desc>
@@ -42,7 +43,7 @@
 
   <entry id="DATM_MODE">
     <type>char</type>
-    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,CLMMOSARTTEST,CLMNLDAS2,CPLHIST,CORE_IAF_JRA,CORE_IAF_JRA_1p4_2018,CORE_RYF8485_JRA,CORE_RYF9091_JRA,CORE_RYF0304_JRA,CFSv2,CFSR</valid_values>
+    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,CLMMOSARTTEST,CLMNLDAS2,CPLHIST,CORE_IAF_JRA,IAF_JRA_1p5,CORE_IAF_JRA_1p4_2018,CORE_RYF8485_JRA,CORE_RYF9091_JRA,CORE_RYF0304_JRA,CFSv2,CFSR</valid_values>
     <default_value>CORE2_NYF</default_value>
     <group>run_component_datm</group>
     <file>env_run.xml</file>
@@ -57,6 +58,7 @@ data (see cime issue #3653 -- https://github.com/ESMCI/cime/issues/3653).
       <value compset="%NYF">CORE2_NYF</value>
       <value compset="%IAF">CORE2_IAF</value>
       <value compset="%JRA">CORE_IAF_JRA</value>
+      <value compset="%JRA-1p5">IAF_JRA_1p5</value>
       <value compset="%JRA-1p4-2018">CORE_IAF_JRA_1p4_2018</value>
       <value compset="%JRA-RYF8485">CORE_RYF8485_JRA</value>
       <value compset="%JRA-RYF9091">CORE_RYF9091_JRA</value>

--- a/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+++ b/components/data_comps/datm/cime_config/namelist_definition_datm.xml
@@ -42,6 +42,7 @@
     CORE2_NYF		= CORE2 normal year forcing (for forcing POP and CICE)
     CORE2_IAF		= CORE2 intra-annual year forcing (for forcing POP and CICE)
     CORE_IAF_JRA	= JRA55 intra-annual year forcing (for forcing POP and CICE)
+    IAF_JRA_1p5         = JRA55 intra-annual year forcing, v1.5, through 2020 (for forcing MPAS-Ocean and MPAS-Seaice)
     CORE_IAF_JRA_1p4_2018 = JRA55 intra-annual year forcing, v1.4, through 2018 (for forcing POP and CICE)
     CORE_RYF8485_JRA = JRA55 repeat year forcing, v1.3, 1984-1985 (for forcing POP and CICE)
     CORE_RYF9091_JRA = JRA55 repeat year forcing, v1.3, 1990-1991 (for forcing POP and CICE)
@@ -205,6 +206,7 @@
       <value datm_mode="CLMNLDAS2">CLMNLDAS2.Solar,CLMNLDAS2.Precip,CLMNLDAS2.TPQW</value>
       <value datm_mode="CORE2_NYF" >CORE2_NYF.GISS,CORE2_NYF.GXGXS,CORE2_NYF.NCEP</value>
       <value datm_mode="CORE2_IAF" >CORE2_IAF.GCGCS.PREC,CORE2_IAF.GISS.LWDN,CORE2_IAF.GISS.SWDN,CORE2_IAF.GISS.SWUP,CORE2_IAF.NCEP.DN10,CORE2_IAF.NCEP.Q_10,CORE2_IAF.NCEP.SLP_,CORE2_IAF.NCEP.T_10,CORE2_IAF.NCEP.U_10,CORE2_IAF.NCEP.V_10,CORE2_IAF.CORE2.ArcFactor</value>
+      <value datm_mode="IAF_JRA_1p5" >IAF_JRA_1p5.GCGCS.PREC,IAF_JRA_1p5.GISS.LWDN,IAF_JRA_1p5.GISS.SWDN,IAF_JRA_1p5.NCEP.Q_10,IAF_JRA_1p5.NCEP.SLP_,IAF_JRA_1p5.NCEP.T_10,IAF_JRA_1p5.NCEP.U_10,IAF_JRA_1p5.NCEP.V_10</value>
       <value datm_mode="CORE_IAF_JRA_1p4_2018" >CORE_IAF_JRA_1p4_2018.GCGCS.PREC,CORE_IAF_JRA_1p4_2018.GISS.LWDN,CORE_IAF_JRA_1p4_2018.GISS.SWDN,CORE_IAF_JRA_1p4_2018.NCEP.Q_10,CORE_IAF_JRA_1p4_2018.NCEP.SLP_,CORE_IAF_JRA_1p4_2018.NCEP.T_10,CORE_IAF_JRA_1p4_2018.NCEP.U_10,CORE_IAF_JRA_1p4_2018.NCEP.V_10</value>
       <value datm_mode="CORE_IAF_JRA" >CORE_IAF_JRA.GCGCS.PREC,CORE_IAF_JRA.GISS.LWDN,CORE_IAF_JRA.GISS.SWDN,CORE_IAF_JRA.NCEP.Q_10,CORE_IAF_JRA.NCEP.SLP_,CORE_IAF_JRA.NCEP.T_10,CORE_IAF_JRA.NCEP.U_10,CORE_IAF_JRA.NCEP.V_10</value>
       <value datm_mode="CORE_RYF8485_JRA" >CORE_RYF8485_JRA.GISS.LWDN,CORE_RYF8485_JRA.GISS.SWDN,CORE_RYF8485_JRA.GCGCS,CORE_RYF8485_JRA.NCEP</value>
@@ -260,6 +262,7 @@
       <value stream="CORE2_IAF.NCEP.U_10">$DIN_LOC_ROOT/atm/datm7</value>
       <value stream="CORE2_IAF.NCEP.V_10">$DIN_LOC_ROOT/atm/datm7</value>
       <value stream="CORE_IAF_JRA.*">$DIN_LOC_ROOT/atm/datm7/JRA55</value>
+      <value stream="IAF_JRA_1p5.*">$DIN_LOC_ROOT/atm/datm7/JRA55</value>
       <value stream="CORE_RYF*">$DIN_LOC_ROOT/atm/datm7/JRA55</value>
       <value stream="co2tseries">$DIN_LOC_ROOT/atm/datm7/CO2 </value>
       <value stream="BC.QIAN.Precip">$DIN_LOC_ROOT/atm/datm7/bias_correction/precip/gpcp/qian</value>
@@ -326,6 +329,7 @@
       <value stream="CORE2_IAF.NCEP.V_10">domain.T62.050609.nc</value>
       <value stream="CORE2_IAF.CORE2.ArcFactor">CORE2.t_10.ArcFactor.T62.1997-2004.nc</value>
       <value stream="CORE_IAF_JRA.*">domain.atm.TL319.151007.nc</value>
+      <value stream="IAF_JRA_1p5.*">domain.atm.TL319.151007.nc</value>
       <value stream="CORE_RYF*">domain.atm.TL319.151007.nc</value>
       <value stream="co2tseries.20tr" cime_model="e3sm">fco2_datm_1765-2007_c100614.nc</value>
       <value stream="co2tseries.20tr" cime_model="cesm">fco2_datm_global_simyr_1750-2014_CMIP6_c180929.nc</value>
@@ -482,6 +486,7 @@
       <value stream="CORE2_IAF.CORE2.ArcFactor">$DIN_LOC_ROOT/atm/datm7/CORE2</value>
       <value stream="CORE2_IAF">$DIN_LOC_ROOT/ocn/iaf</value>
       <value stream="CORE_IAF_JRA.*">$DIN_LOC_ROOT/ocn/jra55/v1.3_noleap</value>
+      <value stream="IAF_JRA_1p5.*">$DIN_LOC_ROOT/ocn/jra55/v1.5_noleap</value>
       <value stream="CORE_RYF*">$DIN_LOC_ROOT/ocn/jra55/v1.3_ryf</value>
       <value stream="co2tseries">$DIN_LOC_ROOT/atm/datm7/CO2</value>
       <value stream="BC.QIAN.Precip">$DIN_LOC_ROOT/atm/datm7/bias_correction/precip/gpcp/qian</value>
@@ -1211,11 +1216,17 @@
       <value  stream="CORE_IAF_JRA.GCGCS.PREC">
         JRA.v1.3.prec.TL319.%y.171019.nc
       </value>
+      <value  stream="IAF_JRA_1p5.GCGCS.PREC">
+        JRA.v1.5.prec.TL319.%y.210504.nc
+      </value>
       <value  stream="CORE_IAF_JRA_1p4_2018.GCGCS.PREC">
         JRA.v1.3.prec.TL319.%y.190528.nc
       </value>
       <value  stream="CORE_IAF_JRA.GISS.LWDN">
         JRA.v1.3.lwdn.TL319.%y.171019.nc
+      </value>
+      <value  stream="IAF_JRA_1p5.GISS.LWDN">
+        JRA.v1.5.lwdn.TL319.%y.210504.nc
       </value>
       <value  stream="CORE_IAF_JRA_1p4_2018.GISS.LWDN">
         JRA.v1.3.lwdn.TL319.%y.190528.nc
@@ -1223,35 +1234,53 @@
       <value  stream="CORE_IAF_JRA.GISS.SWDN">
         JRA.v1.3.swdn.TL319.%y.171019.nc
       </value>
+      <value  stream="IAF_JRA_1p5.GISS.SWDN">
+        JRA.v1.5.swdn.TL319.%y.210504.nc
+      </value>
       <value  stream="CORE_IAF_JRA_1p4_2018.GISS.SWDN">
         JRA.v1.3.swdn.TL319.%y.190528.nc
       </value>
       <value  stream="CORE_IAF_JRA.NCEP.Q_10">
         JRA.v1.3.q_10.TL319.%y.171019.nc
       </value>
+      <value  stream="IAF_JRA_1p5.NCEP.Q_10">
+        JRA.v1.5.q_10.TL319.%y.210504.nc
+      </value>
       <value  stream="CORE_IAF_JRA_1p4_2018.NCEP.Q_10">
         JRA.v1.3.q_10.TL319.%y.190528.nc
-      </value> 
+      </value>
       <value  stream="CORE_IAF_JRA.NCEP.SLP_">
         JRA.v1.3.slp.TL319.%y.171019.nc
-      </value> 
+      </value>
+      <value  stream="IAF_JRA_1p5.NCEP.SLP_">
+        JRA.v1.5.slp.TL319.%y.210504.nc
+      </value>
       <value  stream="CORE_IAF_JRA_1p4_2018.NCEP.SLP_">
         JRA.v1.3.slp.TL319.%y.190528.nc
       </value> 
       <value  stream="CORE_IAF_JRA.NCEP.T_10">
         JRA.v1.3.t_10.TL319.%y.171019.nc
-      </value> 
+      </value>
+      <value  stream="IAF_JRA_1p5.NCEP.T_10">
+        JRA.v1.5.t_10.TL319.%y.210504.nc
+      </value>
       <value  stream="CORE_IAF_JRA_1p4_2018.NCEP.T_10">
         JRA.v1.3.t_10.TL319.%y.190528.nc
       </value> 
       <value  stream="CORE_IAF_JRA.NCEP.U_10">
         JRA.v1.3.u_10.TL319.%y.171019.nc
-      </value> 
+      </value>
+      <value  stream="IAF_JRA_1p5.NCEP.U_10">
+        JRA.v1.5.u_10.TL319.%y.210504.nc
+      </value>
       <value  stream="CORE_IAF_JRA_1p4_2018.NCEP.U_10">
         JRA.v1.3.u_10.TL319.%y.190528.nc
       </value> 
       <value  stream="CORE_IAF_JRA.NCEP.V_10">
         JRA.v1.3.v_10.TL319.%y.171019.nc
+      </value>
+      <value  stream="IAF_JRA_1p5.NCEP.V_10">
+        JRA.v1.5.v_10.TL319.%y.210504.nc
       </value>
       <value  stream="CORE_IAF_JRA_1p4_2018.NCEP.V_10">
         JRA.v1.3.v_10.TL319.%y.190528.nc
@@ -1619,6 +1648,30 @@
       <value  stream="CORE_IAF_JRA.*.NCEP.V_10">
         v_10  v
       </value>
+      <value  stream="IAF_JRA_1p5*.GCGCS.PREC">
+        prec  prec
+      </value>
+      <value  stream="IAF_JRA_1p5*.GISS.LWDN">
+        lwdn  lwdn
+      </value>
+      <value  stream="IAF_JRA_1p5*.GISS.SWDN">
+        swdn  swdn
+      </value>
+      <value  stream="IAF_JRA_1p5*.NCEP.Q_10">
+        q_10  shum
+      </value>
+      <value  stream="IAF_JRA_1p5*.NCEP.SLP_">
+        slp  pslv
+      </value>
+      <value  stream="IAF_JRA_1p5*.NCEP.T_10">
+        t_10  tbot
+      </value>
+      <value  stream="IAF_JRA_1p5*.NCEP.U_10">
+        u_10  u
+      </value>
+      <value  stream="IAF_JRA_1p5*.NCEP.V_10">
+        v_10  v
+      </value>
       <value stream="CORE_RYF.*.GISS.LWDN">
         lwdn  lwdn
       </value>
@@ -1746,6 +1799,7 @@
       <value stream="CORE2_IAF.CORE2.ArcFactor">1</value>
       <value stream="CORE2_IAF">1</value>
       <value stream="CORE_IAF_JRA.*">1</value>
+      <value stream="IAF_JRA_1p5.*">1</value>
       <value stream="CORE_RYF*">1</value>
       <value stream="co2tseries.20tr">1850</value>
       <!-- ncycles*(year_end-year_start+1)-(year_end-co2_year_start) -->
@@ -1814,6 +1868,7 @@
       <value stream="CORE2_IAF.NCEP.V_10">1948</value>
       <value stream="CORE2_IAF.CORE2.ArcFactor">1948</value>
       <value stream="CORE_IAF_JRA.*">$DATM_CLMNCEP_YR_START</value>
+      <value stream="IAF_JRA_1p5.*">1958</value>
       <value stream="CORE_RYF8485_JRA">1984</value>
       <value stream="CORE_RYF9091_JRA">1990</value>
       <value stream="CORE_RYF0304_JRA">2003</value>
@@ -1887,6 +1942,7 @@
       <value stream="co2tseries.20tr" cime_model="cesm">2014</value>
       <value stream="CORE_IAF_JRA.*2018">2018</value>
       <value stream="CORE_IAF_JRA.*">$DATM_CLMNCEP_YR_END</value>
+      <value stream="IAF_JRA_1p5.*">2020</value>
       <value stream="CORE_RYF8485_JRA">1984</value>
       <value stream="CORE_RYF9091_JRA">1990</value>
       <value stream="CORE_RYF0304_JRA">2003</value>
@@ -1924,6 +1980,7 @@
     <values>
       <value>0</value>
       <value stream="CORE_IAF_JRA.*.GISS.SWDN">-5400</value>
+      <value stream="IAF_JRA_1p5.*.GISS.SWDN">-5400</value>
       <value stream="CORE_RYF.*.GISS.SWDN">-5400</value>
       <value stream="CPLHISTForcing.Solar">2700</value>
       <value stream="CPLHISTForcing.nonSolarFlux">900</value>
@@ -1946,7 +2003,7 @@
     <type>char</type>
     <category>streams</category>
     <group>shr_strdata_nml</group>
-    <valid_values>CLMNCEP,COPYALL,CORE2_NYF,CORE2_IAF,CORE_IAF_JRA,CORE_RYF_JRA,NULL</valid_values>
+    <valid_values>CLMNCEP,COPYALL,CORE2_NYF,CORE2_IAF,CORE_IAF_JRA,IAF_JRA_1p5,CORE_RYF_JRA,NULL</valid_values>
     <desc>
       general method that operates on the data.  this is generally
       implemented in the data models but is set in the strdata method for
@@ -1984,6 +2041,8 @@
       Clm Dyn doi 10.1007/s00382-008-0441-3.
       datamode = "CORE_IAF_JRA*"
       JRA55 intra-annual year forcing
+      datamode = "IAF_JRA_1p5*"
+      JRA55 intra-annual year forcing v1.5
       datamode = "CLMNCEP"
       In conjunction with NCEP climatological atmosphere data, provides the
       atmosphere forcing favored by the Land Model Working Group when
@@ -1998,6 +2057,7 @@
       <value datm_mode="CORE2_NYF">CORE2_NYF</value>
       <value datm_mode="CORE2_IAF">CORE2_IAF</value>
       <value datm_mode="CORE_IAF_JRA.*">CORE_IAF_JRA</value>
+      <value datm_mode="IAF_JRA_1p5">IAF_JRA_1p5</value>
       <value datm_mode="CORE_RYF*">CORE_RYF_JRA</value>
       <value datm_mode="CPLHIST">COPYALL</value>
       <value datm_mode="CFSv2">COPYALL</value>
@@ -2207,6 +2267,7 @@
       <value stream="topo.observed">lower</value>
       <value stream="CORE2_IAF.GISS.SWDN">coszen</value>
       <value stream="CORE_IAF_JRA.*.GISS.SWDN">coszen</value>
+      <value stream="IAF_JRA_1p5.*.GISS.SWDN">coszen</value>
       <value stream="CORE_RYF.*.GISS.SWDN">coszen</value>
     </values>
   </entry>
@@ -2300,6 +2361,7 @@
       <value datm_mode="CORE2_NYF">u:v</value>
       <value datm_mode="CORE2_IAF">u:v</value>
       <value datm_mode="CORE_IAF_JRA.*">u:v</value>
+      <value datm_mode="IAF_JRA_1p5.*">u:v</value>
       <value datm_mode="CORE_RYF*">u:v</value>
       <value datm_mode="CFSv2">u:v</value>
       <value datm_mode="CFSR">u:v</value>

--- a/components/data_comps/datm/src/datm_comp_mod.F90
+++ b/components/data_comps/datm/src/datm_comp_mod.F90
@@ -824,7 +824,7 @@ CONTAINS
 
        enddo   ! lsize
 
-    case('CORE_IAF_JRA', 'CORE_RYF_JRA')
+    case('CORE_IAF_JRA', 'CORE_RYF_JRA', 'IAF_JRA_1p5')
        if (firstcall) then
           if (sprec < 1 .or. sswdn < 1) then
              write(logunit,F00) 'ERROR: prec and swdn must be in streams for IAF/RYF JRA'

--- a/components/data_comps/datm/src/datm_shr_mod.F90
+++ b/components/data_comps/datm/src/datm_shr_mod.F90
@@ -154,6 +154,7 @@ CONTAINS
          trim(datamode) == 'CORE2_NYF' .or. &
          trim(datamode) == 'CORE2_IAF' .or. &
          trim(datamode) == 'CORE_IAF_JRA' .or. &
+         trim(datamode) == 'IAF_JRA_1p5' .or. &
          trim(datamode) == 'CORE_RYF_JRA' .or. &
          trim(datamode) == 'CLMNCEP'   .or. &
          trim(datamode) == 'COPYALL'   ) then

--- a/components/data_comps/drof/cime_config/config_component.xml
+++ b/components/data_comps/drof/cime_config/config_component.xml
@@ -13,7 +13,7 @@
   -->
 
   <description modifier_mode="1">
-    <desc rof="DROF[%NULL][%NYF][%IAF][%IAFAIS00][%IAFAIS45][%IAFAIS55][%CPLHIST][%JRA][%JRA-1p4-2018][%JRA-1p4-2018-AIS0ICE][%JRA-1p4-2018-AIS0LIQ][%JRA-1p4-2018-AIS0ROF[%JRA-RYF8485][%JRA-RYF9091][%JRA-RYF0304]">Data runoff model</desc>
+    <desc rof="DROF[%NULL][%NYF][%IAF][%IAFAIS00][%IAFAIS45][%IAFAIS55][%CPLHIST][%JRA][%JRA-1p5][%JRA-1p4-2018][%JRA-1p4-2018-AIS0ICE][%JRA-1p4-2018-AIS0LIQ][%JRA-1p4-2018-AIS0ROF[%JRA-RYF8485][%JRA-RYF9091][%JRA-RYF0304]">Data runoff model</desc>
     <desc option="NULL"     >NULL mode</desc>
     <desc option="NYF"      >COREv2 normal year forcing:</desc>
     <desc option="IAF"      >COREv2 interannual year forcing:</desc>
@@ -21,6 +21,7 @@
     <desc option="IAFAIS45" >COREv2 interannual year forcing:</desc>
     <desc option="IAFAIS55" >COREv2 interannual year forcing:</desc>
     <desc option="CPLHIST"  >CPLHIST mode:</desc>
+    <desc option="JRA-1p5">JRA55 interannual forcing, v1.5, through 2020</desc>
     <desc option="JRA-1p4-2018">JRA55 interannual forcing, v1.4, through 2018</desc>
     <desc option="JRA-1p4-2018-AIS0ICE">JRA55 interannual forcing, v1.4, through 2018, no rofi around AIS</desc>
     <desc option="JRA-1p4-2018-AIS0LIQ">JRA55 interannual forcing, v1.4, through 2018, no rofl around AIS</desc>
@@ -42,7 +43,7 @@
 
   <entry id="DROF_MODE">
     <type>char</type>
-    <valid_values>CPLHIST,DIATREN_ANN_RX1,DIATREN_IAF_RX1,DIATREN_IAF_AIS00_RX1,DIATREN_IAF_AIS45_RX1,DIATREN_IAF_AIS55_RX1,IAF_JRA,IAF_JRA_1p4_2018,IAF_JRA_1p4_2018_AIS0ICE,IAF_JRA_1p4_2018_AIS0LIQ,IAF_JRA_1p4_2018_AIS0ROF,RYF8485_JRA,RYF9091_JRA,RYF0304_JRA,NULL</valid_values>
+    <valid_values>CPLHIST,DIATREN_ANN_RX1,DIATREN_IAF_RX1,DIATREN_IAF_AIS00_RX1,DIATREN_IAF_AIS45_RX1,DIATREN_IAF_AIS55_RX1,IAF_JRA,IAF_JRA_1p5,IAF_JRA_1p4_2018,IAF_JRA_1p4_2018_AIS0ICE,IAF_JRA_1p4_2018_AIS0LIQ,IAF_JRA_1p4_2018_AIS0ROF,RYF8485_JRA,RYF9091_JRA,RYF0304_JRA,NULL</valid_values>
     <default_value>DIATREN_ANN_RX1</default_value>
     <values match="last">
       <value compset="_DROF%NULL">NULL</value>
@@ -56,6 +57,7 @@
       <value compset="_DROF%IAFAIS55" >DIATREN_IAF_AIS55_RX1</value>
       <value compset="_DROF%CPLHIST">CPLHIST</value>
       <value compset="_DROF%JRA" >IAF_JRA</value>
+      <value compset="_DROF%JRA-1p5" >IAF_JRA_1p5</value>
       <value compset="_DROF%JRA-1p4-2018" >IAF_JRA_1p4_2018</value>
       <value compset="_DROF%JRA-1p4-2018-AIS0ICE" >IAF_JRA_1p4_2018_AIS0ICE</value>
       <value compset="_DROF%JRA-1p4-2018-AIS0LIQ" >IAF_JRA_1p4_2018_AIS0LIQ</value>

--- a/components/data_comps/drof/cime_config/namelist_definition_drof.xml
+++ b/components/data_comps/drof/cime_config/namelist_definition_drof.xml
@@ -63,6 +63,7 @@
       <value drof_mode="IAF_JRA_1p4_2018_AIS0LIQ">rof.iaf_jra_1p4_2018_ais0liq</value>
       <value drof_mode="IAF_JRA_1p4_2018_AIS0ROF">rof.iaf_jra_1p4_2018_ais0rof</value>
       <value drof_mode="IAF_JRA_1p4_2018"     >rof.iaf_jra_1p4_2018</value>
+      <value drof_mode="IAF_JRA_1p5"          >rof.iaf_jra_1p5</value>
       <value drof_mode="IAF_JRA"              >rof.iaf_jra</value>
       <value drof_mode="RYF8485_JRA"          >rof.ryf8485_jra</value>
       <value drof_mode="RYF9091_JRA"          >rof.ryf9091_jra</value>
@@ -85,6 +86,7 @@
       <value stream="rof.diatren_iaf_ais00_rx1">$DIN_LOC_ROOT/lnd/dlnd7/RX1</value>
       <value stream="rof.diatren_iaf_ais45_rx1">$DIN_LOC_ROOT/lnd/dlnd7/RX1</value>
       <value stream="rof.diatren_iaf_ais55_rx1">$DIN_LOC_ROOT/lnd/dlnd7/RX1</value>
+      <value stream="rof.iaf_jra_1p5"          >$DIN_LOC_ROOT/lnd/dlnd7/JRA55</value>
       <value stream="rof.iaf_jra.*"            >$DIN_LOC_ROOT/lnd/dlnd7/JRA55</value>
       <value stream="rof.ryf*"                 >$DIN_LOC_ROOT/lnd/dlnd7/JRA55</value>
       <value stream="rof.cplhist"              >null</value>
@@ -177,6 +179,7 @@
       <value stream="rof.diatren_iaf_ais00_rx1">$DIN_LOC_ROOT/lnd/dlnd7/RX1</value>
       <value stream="rof.diatren_iaf_ais45_rx1">$DIN_LOC_ROOT/lnd/dlnd7/RX1</value>
       <value stream="rof.diatren_iaf_ais55_rx1">$DIN_LOC_ROOT/lnd/dlnd7/RX1</value>
+      <value stream="rof.iaf_jra_1p5"          >$DIN_LOC_ROOT/ocn/jra55/v1.5_noleap</value>
       <value stream="rof.iaf_jra.*"            >$DIN_LOC_ROOT/lnd/dlnd7/JRA55</value>
       <value stream="rof.ryf*"                 >$DIN_LOC_ROOT/lnd/dlnd7/JRA55</value>
       <value stream="rof.cplhist"              >$DROF_CPLHIST_DIR</value>
@@ -200,6 +203,71 @@
       <value stream="rof.ryf8485_jra">RAF_8485.JRA.v1.3.runoff.180404.nc</value>
       <value stream="rof.ryf9091_jra">RAF_9091.JRA.v1.3.runoff.180404.nc</value>
       <value stream="rof.ryf0304_jra">RAF_0304.JRA.v1.3.runoff.180404.nc</value>
+      <value stream="rof.iaf_jra_1p5">
+           JRA.v1.5.runoff.1958.210505.nc
+           JRA.v1.5.runoff.1959.210505.nc
+           JRA.v1.5.runoff.1960.210505.nc
+           JRA.v1.5.runoff.1961.210505.nc
+           JRA.v1.5.runoff.1962.210505.nc
+           JRA.v1.5.runoff.1963.210505.nc
+           JRA.v1.5.runoff.1964.210505.nc
+           JRA.v1.5.runoff.1965.210505.nc
+           JRA.v1.5.runoff.1966.210505.nc
+           JRA.v1.5.runoff.1967.210505.nc
+           JRA.v1.5.runoff.1968.210505.nc
+           JRA.v1.5.runoff.1969.210505.nc
+           JRA.v1.5.runoff.1970.210505.nc
+           JRA.v1.5.runoff.1971.210505.nc
+           JRA.v1.5.runoff.1972.210505.nc
+           JRA.v1.5.runoff.1973.210505.nc
+           JRA.v1.5.runoff.1974.210505.nc
+           JRA.v1.5.runoff.1975.210505.nc
+           JRA.v1.5.runoff.1976.210505.nc
+           JRA.v1.5.runoff.1977.210505.nc
+           JRA.v1.5.runoff.1978.210505.nc
+           JRA.v1.5.runoff.1979.210505.nc
+           JRA.v1.5.runoff.1980.210505.nc
+           JRA.v1.5.runoff.1981.210505.nc
+           JRA.v1.5.runoff.1982.210505.nc
+           JRA.v1.5.runoff.1983.210505.nc
+           JRA.v1.5.runoff.1984.210505.nc
+           JRA.v1.5.runoff.1985.210505.nc
+           JRA.v1.5.runoff.1986.210505.nc
+           JRA.v1.5.runoff.1987.210505.nc
+           JRA.v1.5.runoff.1988.210505.nc
+           JRA.v1.5.runoff.1989.210505.nc
+           JRA.v1.5.runoff.1990.210505.nc
+           JRA.v1.5.runoff.1991.210505.nc
+           JRA.v1.5.runoff.1992.210505.nc
+           JRA.v1.5.runoff.1993.210505.nc
+           JRA.v1.5.runoff.1994.210505.nc
+           JRA.v1.5.runoff.1995.210505.nc
+           JRA.v1.5.runoff.1996.210505.nc
+           JRA.v1.5.runoff.1997.210505.nc
+           JRA.v1.5.runoff.1998.210505.nc
+           JRA.v1.5.runoff.1999.210505.nc
+           JRA.v1.5.runoff.2000.210505.nc
+           JRA.v1.5.runoff.2001.210505.nc
+           JRA.v1.5.runoff.2002.210505.nc
+           JRA.v1.5.runoff.2003.210505.nc
+           JRA.v1.5.runoff.2004.210505.nc
+           JRA.v1.5.runoff.2005.210505.nc
+           JRA.v1.5.runoff.2006.210505.nc
+           JRA.v1.5.runoff.2007.210505.nc
+           JRA.v1.5.runoff.2008.210505.nc
+           JRA.v1.5.runoff.2009.210505.nc
+           JRA.v1.5.runoff.2010.210505.nc
+           JRA.v1.5.runoff.2011.210505.nc
+           JRA.v1.5.runoff.2012.210505.nc
+           JRA.v1.5.runoff.2013.210505.nc
+           JRA.v1.5.runoff.2014.210505.nc
+           JRA.v1.5.runoff.2015.210505.nc
+           JRA.v1.5.runoff.2016.210505.nc
+           JRA.v1.5.runoff.2017.210505.nc
+           JRA.v1.5.runoff.2018.210505.nc
+           JRA.v1.5.runoff.2019.210505.nc
+           JRA.v1.5.runoff.2020.210504.nc
+      </value>
       <value stream="rof.iaf_jra_1p4_2018_ais0ice">
            JRA.v1.4.runoff.1958.no_rofi.190214.nc
            JRA.v1.4.runoff.1959.no_rofi.190214.nc
@@ -613,6 +681,7 @@
       <value stream="rof.diatren_iaf_ais00_rx1">2009</value>
       <value stream="rof.diatren_iaf_ais45_rx1">2009</value>
       <value stream="rof.diatren_iaf_ais55_rx1">2009</value>
+      <value stream="rof.iaf_jra_1p5"     >2020</value>
       <value stream="rof.iaf_jra_1p4_2018"     >2018</value>
       <value stream="rof.iaf_jra_1p4_2018_ais0ice">2018</value>
       <value stream="rof.iaf_jra_1p4_2018_ais0liq">2018</value>

--- a/components/mpas-ocean/cime_config/config_compsets.xml
+++ b/components/mpas-ocean/cime_config/config_compsets.xml
@@ -53,6 +53,11 @@
   </compset>
 
   <compset>
+    <alias>GMPAS-JRA1p5</alias>
+    <lname>2000_DATM%JRA-1p5_SLND_MPASSI_MPASO%DATMFORCED_DROF%JRA-1p5_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>GMPAS-JRA1p4</alias>
     <lname>2000_DATM%JRA-1p4-2018_SLND_MPASSI_MPASO%DATMFORCED_DROF%JRA-1p4-2018_SGLC_SWAV</lname>
   </compset>


### PR DESCRIPTION
Adds support for [JRA55-do v1.5](https://climate.mri-jma.go.jp/pub/ocean/JRA55-do/) datm/drof forcing through years 1958 - 2020 with a new compset `GMPAS-JRA1p5`.

Forcing files have been downloaded from the [ccsm-inputdata server](https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata/ocn/jra55/v1.5_noleap) to the E3SM public inputdata server [here](https://web.lcrc.anl.gov/public/e3sm/inputdata/ocn/jra55/v1.5_noleap/).

A pair of runs, `GMPAS-JRA1p4.TL319_ECwISC30to60E2r1` and `GMPAS-JRA1p5.TL319_ECwISC30to60E2r1`, were run for 60 years for comparison. Comparison analysis of years 41-60: https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.dcomeau/JRA1p5-testing/JRA1p4_vs_1p5/yrs41-60/

[BFB] for all currently tested configurations. 

