### PR TITLE
Add missing time level index to 'ssh' coupling field

### DIFF
--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -2630,7 +2630,7 @@ contains
      call mpas_pool_get_dimension(forcingPool, 'index_avgSurfaceVelocityZonal', index_avgZonalSurfaceVelocity)
      call mpas_pool_get_dimension(forcingPool, 'index_avgSurfaceVelocityMeridional', index_avgMeridionalSurfaceVelocity)
 
-     call mpas_pool_get_array(statePool, 'ssh', ssh)
+     call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
      call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
 
      call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)


### PR DESCRIPTION
This adds a time level index that was missing from an 'ssh' call. The missing index results in the following warnings being printed to `ocn.log.*` every timestep in certain configurations (`GMPAS-*.*wISC*`):

```
WARNING: Error: Field ssh has more than one time level, but no timeLevel argument given.
```

With this fix (h/t @xylar), those warning messages no longer appear.

[BFB] for all currently tested configurations.

Closes https://github.com/E3SM-Project/E3SM/issues/5287.