### PR TITLE
Change tref_lapse_rate to double precision

### DIFF
--- a/components/homme/src/theta-l/share/element_ops.F90
+++ b/components/homme/src/theta-l/share/element_ops.F90
@@ -75,7 +75,7 @@ module element_ops
   public state0
 
   ! promote this to _real_kind after V2 code freeze
-  real (kind=real_kind), public :: tref_lapse_rate=0.0065e0
+  real (kind=real_kind), public :: tref_lapse_rate=0.0065D0
 contains
 
 


### PR DESCRIPTION
Use double precision for tref_lapse_rate. Originally a part of https://github.com/E3SM-Project/E3SM/pull/5299. This is smaller PR to ensure fails there are not from other places.

[BFB] except for HOMME(BFB) standalone tests