### PR TITLE
share: Protect bool typedef from stdbool.h inclusion.

### DIFF
--- a/share/timing/private.h
+++ b/share/timing/private.h
@@ -44,7 +44,10 @@
 #define MAX_AUX 9
 
 #ifndef __cplusplus
+// Protect against inclusion of stdbool.h in, e.g., a compiler wrapper.
+# ifndef true
 typedef enum {false = 0, true = 1} bool;  /* mimic C++ */
+# endif
 #endif
 
 typedef struct {


### PR DESCRIPTION
Some compiler wrappers add headers that include stdbool.h. In a C build, including stdbool.h conflicts with the typedef. Guard the typedef with a check for whether 'true' has already been defined.

[BFB]