### PR TITLE
Fix bfb fail in elem_ops_ut_test

### DIFF
--- a/components/homme/src/share/cxx/PhysicalConstants.hpp
+++ b/components/homme/src/share/cxx/PhysicalConstants.hpp
@@ -27,6 +27,7 @@ namespace PhysicalConstants
 
   constexpr Real Tref          = 288;
 
+  constexpr Real Tref_lapse_rate = 0.0065;
 };
 
 } // namespace Homme

--- a/components/homme/src/theta-l_kokkos/cxx/ElementOps.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementOps.hpp
@@ -98,9 +98,9 @@ public:
 
 private:
 
-  static constexpr Real TREF = 288.0;
-  static constexpr Real T1 = 0.0065f*TREF*PhysicalConstants::cp/PhysicalConstants::g;
-  static constexpr Real T0 = TREF-T1;
+  static constexpr Real T1 =
+    PhysicalConstants::Tref_lapse_rate*PhysicalConstants::Tref*PhysicalConstants::cp/PhysicalConstants::g;
+  static constexpr Real T0 = PhysicalConstants::Tref-T1;
 
   HybridVCoord    m_hvcoord;
 };


### PR DESCRIPTION
This PR adds `PhysicalConstant` entry for `Tref_lapse_rate` that is `Real` type, and uses this constant (along with `Tref`) in `ElementOps.hpp` instead of hard coding. The bfb fix comes from the fact that the old version of `Tref_lapse_rate` was a `float` type (not matching the new F90 version from https://github.com/E3SM-Project/E3SM/pull/5315 which is `double`).

[bfb]