### PR TITLE
Mask ocean time series stats variables

### DIFF
--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -1058,6 +1058,7 @@ def buildnml(case, caseroot, compname):
         lines.append('        type="output"')
         lines.append('        precision="single"')
         lines.append('        io_type="{}"'.format(ocn_pio_typename))
+        lines.append('        useMissingValMask="true"')
         lines.append('        filename_template="{}.mpaso.hist.am.timeSeriesStatsDaily.$Y-$M-$D.nc"'.format(casename))
         lines.append('        filename_interval="00-01-00_00:00:00"')
         lines.append('        reference_time="01-01-01_00:00:00"')
@@ -1348,6 +1349,7 @@ def buildnml(case, caseroot, compname):
         else:
             lines.append('        io_type="{}"'.format(ocn_pio_typename))
 
+        lines.append('        useMissingValMask="true"')
         lines.append('        filename_template="{}.mpaso.hist.am.timeSeriesStatsMonthlyMax.$Y-$M-$D.nc"'.format(casename))
         lines.append('        filename_interval="00-01-00_00:00:00"')
         lines.append('        reference_time="01-01-01_00:00:00"')
@@ -1409,6 +1411,7 @@ def buildnml(case, caseroot, compname):
         else:
             lines.append('        io_type="{}"'.format(ocn_pio_typename))
 
+        lines.append('        useMissingValMask="true"')
         lines.append('        filename_template="{}.mpaso.hist.am.timeSeriesStatsMonthlyMin.$Y-$M-$D.nc"'.format(casename))
         lines.append('        filename_interval="00-01-00_00:00:00"')
         lines.append('        reference_time="01-01-01_00:00:00"')
@@ -1466,6 +1469,7 @@ def buildnml(case, caseroot, compname):
         lines.append('        type="output"')
         lines.append('        precision="single"')
         lines.append('        io_type="{}"'.format(ocn_pio_typename))
+        lines.append('        useMissingValMask="true"')
         lines.append('        filename_template="{}.mpaso.hist.am.timeSeriesStatsClimatology.$Y-$M-$D.nc"'.format(casename))
         lines.append('        filename_interval="00-01-00_00:00:00"')
         lines.append('        reference_time="01-01-01_00:00:00"')
@@ -1480,6 +1484,7 @@ def buildnml(case, caseroot, compname):
         lines.append('        type="output"')
         lines.append('        precision="single"')
         lines.append('        io_type="{}"'.format(ocn_pio_typename))
+        lines.append('        useMissingValMask="true"')
         lines.append('        filename_template="{}.mpaso.hist.am.timeSeriesStatsCustom.$Y-$M-$D.nc"'.format(casename))
         lines.append('        filename_interval="00-01-00_00:00:00"')
         lines.append('        reference_time="01-01-01_00:00:00"')

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -1112,6 +1112,7 @@ def buildnml(case, caseroot, compname):
         else:
             lines.append('        io_type="{}"'.format(ocn_pio_typename))
 
+        lines.append('        useMissingValMask="true"')
         lines.append('        filename_template="{}.mpaso.hist.am.timeSeriesStatsMonthly.$Y-$M-$D.nc"'.format(casename))
         lines.append('        filename_interval="00-01-00_00:00:00"')
         lines.append('        reference_time="01-01-01_00:00:00"')

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2712,10 +2712,12 @@
 		/>
 		<var name="inSituThermalExpansionCoeff"
 			 type="real" dimensions="nVertLevels nCells Time" units="C^-1"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 description="Thermal expansion coefficient (alpha), defined as $-1/\rho d\rho/dT$ (note negative sign).  This is in situ, i.e. not displaced to another depth."
 		/>
 		<var name="inSituSalineContractionCoeff"
 			 type="real" dimensions="nVertLevels nCells Time" units="1.e3"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 description="Saline contraction coefficient (beta), defined as $1/\rho d\rho/dS$.  This is also called the haline contraction coefficient.  This is in situ, i.e. not displaced to another depth."
 		/>
 

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2788,38 +2788,47 @@
 
 		<var name="kineticEnergyCell" type="real" dimensions="nVertLevels nCells Time" units="m^2 s^-2"
 			 description="kinetic energy of horizontal velocity on cells"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="viscosity" type="real" dimensions="nVertLevels nEdges Time" units="m^2 s^-1"
 			 description="horizontal viscosity"
+			 missing_value="FILLVAL" missing_value_mask="edgeMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="divergence" type="real" dimensions="nVertLevels nCells Time" units="s^-1"
 			 description="divergence of horizontal velocity"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="circulation" type="real" dimensions="nVertLevels nVertices Time" units="m^2 s^-1"
 			 description="area-integrated vorticity"
+			 missing_value="FILLVAL" missing_value_mask="vertexMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="relativeVorticity" type="real" dimensions="nVertLevels nVertices Time" units="s^-1"
 			 description="curl of horizontal velocity, defined at vertices"
+			 missing_value="FILLVAL" missing_value_mask="vertexMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="relativeVorticityCell" type="real" dimensions="nVertLevels nCells Time" units="s^-1"
 			 description="curl of horizontal velocity, averaged from vertices to cell centers"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="normalizedRelativeVorticityEdge" type="real" dimensions="nVertLevels nEdges Time" units="s^-1"
 			 description="curl of horizontal velocity divided by layer thickness, averaged from vertices to edges"
+			 missing_value="FILLVAL" missing_value_mask="edgeMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="normalizedPlanetaryVorticityEdge" type="real" dimensions="nVertLevels nEdges Time" units="s^-1"
 			 description="earth's rotational rate (Coriolis parameter, f) divided by layer thickness, averaged from vertices to edges"
+			 missing_value="FILLVAL" missing_value_mask="edgeMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="normalizedRelativeVorticityCell" type="real" dimensions="nVertLevels nCells Time" units="s^-1"
 			 description="curl of horizontal velocity divided by layer thickness, averaged from vertices to cell centers"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="barotropicForcing" type="real" dimensions="nEdges Time" units="m s^-2"
@@ -2833,14 +2842,17 @@
 
 		<var name="velocityX" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			 description="component of horizontal velocity in the x-direction (cartesian)"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="velocityY" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			 description="component of horizontal velocity in the y-direction (cartesian)"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="velocityZ" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			 description="component of horizontal velocity in the z-direction (cartesian)"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="velocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
@@ -2855,14 +2867,17 @@
 		/>
 		<var name="transportVelocityX" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			 description="component of horizontal velocity used to transport mass and tracers in the x-direction (cartesian)"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="transportVelocityY" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			 description="component of horizontal velocity used to transport mass and tracers in the y-direction (cartesian)"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="transportVelocityZ" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			 description="component of horizontal velocity used to transport mass and tracers in the z-direction (cartesian)"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="transportVelocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
@@ -2906,6 +2921,7 @@
 		/>
 		<var name="normalMLEvelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
 			description="Velocity from mixed layer eddies (fox kemper 2011 submesoscale parameterization)"
+			missing_value="FILLVAL" missing_value_mask="edgeMask"
 			packages="submeso"
 		/>
 		<var name="cGMphaseSpeed" type="real" dimensions="nEdges Time" units="m s^-1"
@@ -2937,22 +2953,27 @@
 		/>
 		<var name="mleVelocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			description="Bolus velocity in fox-kemper mle parameterization, zonal-direction"
+			missing_value="FILLVAL" missing_value_mask="cellMask"
 			packages="gm;submeso"
 		/>
 		<var name="mleVelocityMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			description="Bolus velocity in fox-kemper mle parameterization, meridional-direction"
+			missing_value="FILLVAL" missing_value_mask="cellMask"
 			packages="gm;submeso"
 		/>
 		<var name="eddyVelocityX" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			description="Bolus velocity in Gent-McWilliams eddy or submesoscale parameterization, x-direction"
+			missing_value="FILLVAL" missing_value_mask="cellMask"
 			packages="gm;submeso"
 		/>
 		<var name="eddyVelocityY" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			description="Bolus velocity in Gent-McWilliams or submesoscale eddy parameterization, y-direction"
+			missing_value="FILLVAL" missing_value_mask="cellMask"
 			packages="gm;submeso"
 		/>
 		<var name="eddyVelocityZ" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			description="eddy Bolus velocity in Gent-McWilliams or submesoscale eddy parameterization, z-direction"
+			missing_value="FILLVAL" missing_value_mask="cellMask"
 			packages="gm;submeso"
 		/>
 		<var name="GMBolusVelocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
@@ -2987,18 +3008,22 @@
 		/>
 		<var name="bulkRichardsonNumber" type="real" dimensions="nVertLevels nCells Time" units="1"
 			 description="CVMix/KPP: bulk Richardson number"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="forwardMode;analysisMode"
 			 />
 		<var name="bulkRichardsonNumberBuoy" type="real" dimensions="nVertLevels nCells Time" units="1"
 			 description="CVMix/KPP: contribution of buoyancy to bulk Richardson number"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="bulkRichardsonNumberShear" type="real" dimensions="nVertLevels nCells Time" units="1"
 			 description="CVMix/KPP: contribution of shear to bulk Richardson number"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="unresolvedShear" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			 description="CVMix/KPP: contribution of unresolved velocity to vertical shear"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 		/>
 		<var name="boundaryLayerDepth" type="real" dimensions="nCells Time" units="m"
 			 description="CVMix/KPP: diagnosed depth of the ocean surface boundary layer"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2683,6 +2683,7 @@
 			/>
 		</var_array>
 		<var name="zMid" type="real" dimensions="nVertLevels nCells Time" units="m"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 description="z-coordinate of the mid-depth of the layer"
 		/>
 		<var name="zTop" type="real" dimensions="nVertLevels nCells Time" units="m"
@@ -2691,6 +2692,7 @@
 
 		<var name="density" type="real" dimensions="nVertLevels nCells Time" units="kg m^-3"
 			 description="density"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 		/>
 		<var name="displacedDensity" type="real" dimensions="nVertLevels nCells Time" units="kg m^-3"
 			 description="Density displaced adiabatically to the mid-depth one layer deeper.  That is, layer k has been displaced to the depth of layer k+1."
@@ -2698,6 +2700,7 @@
 		/>
 		<var name="potentialDensity" type="real" dimensions="nVertLevels nCells Time" units="kg m^-3"
 			 description="potential density: density displaced adiabatically to the mid-depth of top layer"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="inSituThermalExpansionCoeff"
@@ -2829,10 +2832,12 @@
 		/>
 		<var name="velocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			 description="component of horizontal velocity in the eastward direction"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="velocityMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			 description="component of horizontal velocity in the northward direction"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="transportVelocityX" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2192,10 +2192,12 @@
 		<!-- FIELDS FOR FREQUENCY FILTERED THICKNESS -->
 		<var name="highFreqThickness" type="real" dimensions="nVertLevels nCells Time" units="m"
 			 description="high frequency-filtered layer thickness"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="thicknessFilter"
 		/>
 		<var name="lowFreqDivergence" type="real" dimensions="nVertLevels nCells Time" units="s^-1"
 			 description="low frequency-filtered divergence"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="thicknessFilter"
 		/>
 

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2729,6 +2729,7 @@
 		/>
 		<var name="normalTransportVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
 			 description="horizontal velocity used to transport mass and tracers"
+			 missing_value="FILLVAL" missing_value_mask="edgeMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="wettingVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
@@ -2854,10 +2855,12 @@
 		/>
 		<var name="transportVelocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			 description="component of horizontal velocity used to transport mass and tracers in the eastward direction"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="transportVelocityMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			 description="component of horizontal velocity used to transport mass and tracers in the northward direction"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="gradSSH" type="real" dimensions="nEdges Time" units="1"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2889,6 +2889,7 @@
 		/>
 		<var name="normalGMBolusVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
 			 description="Bolus velocity in Gent-McWilliams eddy parameterization"
+			 missing_value="FILLVAL" missing_value_mask="edgeMask"
 			 packages="gm"
 		/>
 		<var name="normalMLEvelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
@@ -2944,10 +2945,12 @@
 		/>
 		<var name="GMBolusVelocityZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			 description="Bolus velocity in Gent-McWilliams eddy parameterization, zonal-direction"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="gm;submeso"
 		/>
 		<var name="GMBolusVelocityMeridional" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			 description="Bolus velocity in Gent-McWilliams eddy parameterization, meridional-direction"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="gm;submeso"
 		/>
 		<var name="RiTopOfCell" type="real" dimensions="nVertLevelsP1 nCells Time" units="1"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2536,10 +2536,12 @@
 	<var_struct name="tend" time_levs="1">
 		<var name="tendNormalVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-2" name_in_code="normalVelocity"
 			 description="time tendency of normal component of velocity"
+			 missing_value="FILLVAL" missing_value_mask="edgeMask"
 			 packages="forwardMode"
 		/>
 		<var name="tendLayerThickness" type="real" dimensions="nVertLevels nCells Time" units="m s^-1" name_in_code="layerThickness"
 			 description="time tendency of layer thickness"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="forwardMode"
 		/>
 		<var name="tendSSH" type="real" dimensions="nCells Time" units="m s^-1" name_in_code="ssh"
@@ -2548,10 +2550,12 @@
 		/>
 		<var name="tendHighFreqThickness" type="real" dimensions="nVertLevels nCells Time" units="m s^-1" name_in_code="highFreqThickness"
 			 description="time tendency of high frequency-filtered layer thickness"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="thicknessFilter"
 		/>
 		<var name="tendLowFreqDivergence" type="real" dimensions="nVertLevels nCells Time" units="m s^-1" name_in_code="lowFreqDivergence"
 			 description="time tendency of low frequency-filtered divergence"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="thicknessFilter"
 		/>
 	</var_struct>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2721,6 +2721,7 @@
 
 		<var name="BruntVaisalaFreqTop" type="real" dimensions="nVertLevels nCells Time" units="s^-2"
 			 description="Brunt Vaisala frequency defined at the center (horizontally) and top (vertically) of cell"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="montgomeryPotential" type="real" dimensions="nVertLevels nCells Time" units="m^2 s^-2"
@@ -2766,18 +2767,22 @@
 		/>
 		<var name="tangentialVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
 			 description="horizontal velocity, tangential to an edge"
+			 missing_value="FILLVAL" missing_value_mask="edgeMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="layerThicknessEdgeMean" type="real" dimensions="nVertLevels nEdges Time" units="m"
 			 description="layer thickness averaged from cell center to edges"
+			 missing_value="FILLVAL" missing_value_mask="edgeMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="layerThicknessEdgeFlux" type="real" dimensions="nVertLevels nEdges Time" units="m"
 			 description="layer thickness used for fluxes through edges. May be centered, upwinded, or a combination of the two."
+			 missing_value="FILLVAL" missing_value_mask="edgeMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="layerThicknessVertex" type="real" dimensions="nVertLevels nVertices Time" units="m"
 			 description="layer thickness averaged from cell center to vertices"
+			 missing_value="FILLVAL" missing_value_mask="vertexMask"
 			 packages="forwardMode;analysisMode"
 		/>
 

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2585,6 +2585,7 @@
 		</var_array>
 		<var name="temperatureShortWaveTendency" dimensions="nVertLevels nCells Time" units="C s^-1" packages="tracerBudget" name_in_code="temperatureShortWaveTendency" type="real"
 				 description="potential temperature tendency due to penetrating shortwave"
+				 missing_value="FILLVAL" missing_value_mask="cellMask"
 		/>
 		<var_array name="activeTracerHorMixTendency" type="real" dimensions="nVertLevels nCells Time" packages="tracerBudget">
 			<var name="temperatureHorMixTendency" array_group="activeTracerHmixTendGroup" units="C s^-1" name_in_code="temperatureHorMixTendency"
@@ -2683,11 +2684,12 @@
 			/>
 		</var_array>
 		<var name="zMid" type="real" dimensions="nVertLevels nCells Time" units="m"
-			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 description="z-coordinate of the mid-depth of the layer"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 		/>
 		<var name="zTop" type="real" dimensions="nVertLevels nCells Time" units="m"
 			 description="z-coordinate of the top of the layer"
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 		/>
 
 		<var name="density" type="real" dimensions="nVertLevels nCells Time" units="kg m^-3"
@@ -2696,6 +2698,7 @@
 		/>
 		<var name="displacedDensity" type="real" dimensions="nVertLevels nCells Time" units="kg m^-3"
 			 description="Density displaced adiabatically to the mid-depth one layer deeper.  That is, layer k has been displaced to the depth of layer k+1."
+			 missing_value="FILLVAL" missing_value_mask="cellMask"
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="potentialDensity" type="real" dimensions="nVertLevels nCells Time" units="kg m^-3"

--- a/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_climatology.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_climatology.xml
@@ -80,6 +80,7 @@
 				type="output"
 				mode="forward;analysis"
 				io_type="pnetcdf"
+				useMissingValMask="true"
 				precision="single"
 				filename_template="analysis_members/mpaso.hist.am.timeSeriesStatsClimatology.$Y-$M-$D.nc"
 				reference_time="01-01-01_00:00:00"

--- a/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_custom.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_custom.xml
@@ -80,6 +80,7 @@
 				type="output"
 				mode="forward;analysis"
 				io_type="pnetcdf"
+				useMissingValMask="true"
 				precision="single"
 				filename_template="analysis_members/mpaso.hist.am.timeSeriesStatsCustom.$Y-$M-$D.nc"
 				reference_time="01-01-01_00:00:00"

--- a/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_daily.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_daily.xml
@@ -93,6 +93,7 @@
 				type="output"
 				mode="forward;analysis"
 				io_type="pnetcdf"
+				useMissingValMask="true"
 				precision="single"
 				filename_template="analysis_members/mpaso.hist.am.timeSeriesStatsDaily.$Y-$M-$D.nc"
 				reference_time="01-01-01_00:00:00"

--- a/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_monthly_max.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_monthly_max.xml
@@ -93,6 +93,7 @@
 				type="output"
 				mode="forward;analysis"
 				io_type="pnetcdf"
+				useMissingValMask="true"
 				precision="single"
 				filename_template="analysis_members/mpaso.hist.am.timeSeriesStatsMonthlyMax.$Y-$M-$D.nc"
 				filename_interval="00-01-00_00:00:00"

--- a/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_monthly_mean.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_monthly_mean.xml
@@ -93,6 +93,7 @@
 				type="output"
 				mode="forward;analysis"
 				io_type="pnetcdf"
+				useMissingValMask="true"
 				filename_template="analysis_members/mpaso.hist.am.timeSeriesStatsMonthly.$Y-$M-$D.nc"
 				filename_interval="00-01-00_00:00:00"
 				reference_time="01-01-01_00:00:00"

--- a/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_monthly_min.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_time_series_stats_monthly_min.xml
@@ -93,6 +93,7 @@
 				type="output"
 				mode="forward;analysis"
 				io_type="pnetcdf"
+				useMissingValMask="true"
 				precision="single"
 				filename_template="analysis_members/mpaso.hist.am.timeSeriesStatsMonthlyMin.$Y-$M-$D.nc"
 				filename_interval="00-01-00_00:00:00"

--- a/components/mpas-ocean/src/tracer_groups/Registry_CFC.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_CFC.xml
@@ -49,7 +49,7 @@
 
 	<var_struct name="state" time_levs="2">
 		<var_struct name="tracers" time_levs="2">
-			<var_array name="CFCTracers" dimensions="nVertLevels nCells Time" type="real" packages="CFCTracersPKG"  default_value="0.0">
+			<var_array name="CFCTracers" dimensions="nVertLevels nCells Time" type="real" packages="CFCTracersPKG"  default_value="0.0" missing_value="FILLVAL" missing_value_mask="cellMask">
 				<!-- Add constituents of tracer group -->
 				<var name="CFC11" array_group="CFCGRP" units="mol m^{-3}"
 			description="CFC11"
@@ -63,7 +63,7 @@
 
 	<var_struct name="tend" time_levs="1">
 		<var_struct name="tracersTend" time_levs="1">
-			<var_array name="CFCTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="CFCTracersPKG">
+			<var_array name="CFCTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="CFCTracersPKG" missing_value="FILLVAL" missing_value_mask="cellMask">
 				<!-- Add constituents of tracer group -->
 				<var name="CFC11Tend" array_group="CFCGRP" units="mol m^{-3} s^{-1}"
 			description="CFC11 Tendency"

--- a/components/mpas-ocean/src/tracer_groups/Registry_DMS.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_DMS.xml
@@ -49,7 +49,7 @@
 
 	<var_struct name="state" time_levs="2">
 		<var_struct name="tracers" time_levs="2">
-			<var_array name="DMSTracers" dimensions="nVertLevels nCells Time" type="real" packages="DMSTracersPKG" >
+			<var_array name="DMSTracers" dimensions="nVertLevels nCells Time" type="real" packages="DMSTracersPKG" missing_value="FILLVAL" missing_value_mask="cellMask">
 				<!-- Add constituents of tracer group -->
 				<var name="DMS" array_group="DMSGRP" units="mmol m^{-3}"
 			description="Dimethyl Sulfide"
@@ -63,7 +63,7 @@
 
 	<var_struct name="tend" time_levs="1">
 		<var_struct name="tracersTend" time_levs="1">
-			<var_array name="DMSTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="DMSTracersPKG">
+			<var_array name="DMSTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="DMSTracersPKG" missing_value="FILLVAL" missing_value_mask="cellMask">
 				<!-- Add constituents of tracer group -->
 				<var name="DMSTend" array_group="DMSGRP" units="mmol m^{-3} s^{-1}"
 			description="Dimethyl Sulfide Tendency"

--- a/components/mpas-ocean/src/tracer_groups/Registry_MacroMolecules.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_MacroMolecules.xml
@@ -49,7 +49,7 @@
 
 	<var_struct name="state" time_levs="2">
 		<var_struct name="tracers" time_levs="2">
-			<var_array name="MacroMoleculesTracers" dimensions="nVertLevels nCells Time" type="real" packages="MacroMoleculesTracersPKG" >
+			<var_array name="MacroMoleculesTracers" dimensions="nVertLevels nCells Time" type="real" packages="MacroMoleculesTracersPKG" missing_value="FILLVAL" missing_value_mask="cellMask">
 				<!-- Add constituents of tracer group -->
 			<var name="PROT" array_group="MacroMoleculesGRP" units="mmol m^{-3}"
 				description="Proteins"
@@ -66,7 +66,7 @@
 
 	<var_struct name="tend" time_levs="1">
 		<var_struct name="tracersTend" time_levs="1">
-			<var_array name="MacroMoleculesTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="MacroMoleculesTracersPKG">
+			<var_array name="MacroMoleculesTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="MacroMoleculesTracersPKG" missing_value="FILLVAL" missing_value_mask="cellMask">
 				<!-- Add constituents of tracer group -->
 			<var name="PROTTend" array_group="MacroMoleculesGRP" units="mmol m^{-3} s^{-1}"
 				description="Proteins Tendency"

--- a/components/mpas-ocean/src/tracer_groups/Registry_activeTracers.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_activeTracers.xml
@@ -74,7 +74,7 @@
 
 	<var_struct name="tend" time_levs="1">
 		<var_struct name="tracersTend" time_levs="1">
-			<var_array name="activeTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="activeTracersPKG">
+			<var_array name="activeTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="activeTracersPKG" missing_value="FILLVAL" missing_value_mask="cellMask">
 				<var name="temperatureTend" array_group="activeGRP" units="C s^-1"
 			 description="time tendency of potential temperature"
 				/>

--- a/components/mpas-ocean/src/tracer_groups/Registry_debugTracers.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_debugTracers.xml
@@ -49,7 +49,7 @@
 
 	<var_struct name="state" time_levs="2">
 		<var_struct name="tracers" time_levs="2">
-			<var_array name="debugTracers" dimensions="nVertLevels nCells Time" type="real" packages="debugTracersPKG" default_value="1.0">
+			<var_array name="debugTracers" dimensions="nVertLevels nCells Time" type="real" packages="debugTracersPKG" default_value="1.0" missing_value="FILLVAL" missing_value_mask="cellMask">
 				<var name="tracer1" array_group="debugGRP"
 			 description="tracer for debugging purposes"
 				/>
@@ -65,7 +65,7 @@
 
 	<var_struct name="tend" time_levs="1">
 		<var_struct name="tracersTend" time_levs="1">
-			<var_array name="debugTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="debugTracersPKG">
+			<var_array name="debugTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="debugTracersPKG" missing_value="FILLVAL" missing_value_mask="cellMask">
 				<var name="tracer1Tend" array_group="debugGRP"
 			 description="Tendency for tracer1"
 				/>

--- a/components/mpas-ocean/src/tracer_groups/Registry_ecosys.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_ecosys.xml
@@ -89,7 +89,7 @@
 
 	<var_struct name="state" time_levs="2">
 		<var_struct name="tracers" time_levs="2">
-			<var_array name="ecosysTracers" dimensions="nVertLevels nCells Time" type="real" packages="ecosysTracersPKG" >
+			<var_array name="ecosysTracers" dimensions="nVertLevels nCells Time" type="real" packages="ecosysTracersPKG" missing_value="FILLVAL" missing_value_mask="cellMask">
 				<!-- Add constituents of tracer group -->
 				<var name="PO4" array_group="ecosysGRP" units="mmol P m^{-3}"
 					description="Dissolved Inorganic Phosphate"
@@ -193,7 +193,7 @@
 
 	<var_struct name="tend" time_levs="1">
 		<var_struct name="tracersTend" time_levs="1">
-			<var_array name="ecosysTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="ecosysTracersPKG">
+			<var_array name="ecosysTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="ecosysTracersPKG" missing_value="FILLVAL" missing_value_mask="cellMask">
 				<!-- Add constituents of tracer group -->
 				<var name="PO4Tend" array_group="ecosysGRP" units="mmol P m^{-3} s^{-1}"
 					description="Dissolved Inorganic Phosphate Tendency"

--- a/components/mpas-ocean/src/tracer_groups/Registry_idealAge.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_idealAge.xml
@@ -41,7 +41,7 @@
 
 	<var_struct name="state" time_levs="2">
 		<var_struct name="tracers" time_levs="2">
-			<var_array name="idealAgeTracers" dimensions="nVertLevels nCells Time" type="real" packages="idealAgeTracersPKG"  default_value="0.0">
+			<var_array name="idealAgeTracers" dimensions="nVertLevels nCells Time" type="real" packages="idealAgeTracersPKG"  default_value="0.0" missing_value="FILLVAL" missing_value_mask="cellMask">
 				<var name="iAge" array_group="iAgeGRP" units="seconds" description="tracer for ideal age"
 				/>
 			</var_array>
@@ -50,7 +50,7 @@
 
 	<var_struct name="tend" time_levs="1">
 		<var_struct name="tracersTend" time_levs="1">
-			<var_array name="idealAgeTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="idealAgeTracersPKG">
+			<var_array name="idealAgeTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="idealAgeTracersPKG" missing_value="FILLVAL" missing_value_mask="cellMask">
 				<var name="iAgeTend" array_group="iAgeGRP" units="seconds/second" description="Tendency for iAge"
 				/>
 			</var_array>


### PR DESCRIPTION
This PR applies fill value masking to non-restart time series stats streams in the ocean component. It also specifies the masking array for a subset of variables in the Registry.

It builds on the PRs that add the masking option to the framework, https://github.com/E3SM-Project/E3SM/pull/5154 and https://github.com/E3SM-Project/E3SM/pull/5251. Discussion can be found at https://github.com/E3SM-Ocean-Discussion/E3SM/pull/32.

Fixes #5253

[BFB]