### PR TITLE
ELM: Use intent(inout) to preserve values in early exit.

### DIFF
--- a/components/elm/src/biogeophys/PhotosynthesisMod.F90
+++ b/components/elm/src/biogeophys/PhotosynthesisMod.F90
@@ -1278,7 +1278,7 @@ contains
     real(r8), intent(in) :: oair              ! Atmospheric O2 partial pressure (Pa)
     real(r8), intent(in) :: rh_can            ! inside canopy relative humidity
     integer,  intent(in) :: ip, iv, ic, it    ! pft, c3/c4, column, and topounit index
-    real(r8), intent(out) :: gs_mol           ! leaf stomatal conductance (umol H2O/m**2/s)
+    real(r8), intent(inout) :: gs_mol         ! leaf stomatal conductance (umol H2O/m**2/s)
     type(atm2lnd_type)  , intent(in)    :: atm2lnd_vars
     type(photosyns_type), intent(inout) :: photosyns_vars
     !
@@ -2927,8 +2927,8 @@ contains
     real(r8), intent(in)    :: lmr_z_sun, lmr_z_sha ! canopy layer: leaf maintenance respiration rate (umol CO2/m**2/s)
     real(r8), intent(in)    :: par_z_sun, par_z_sha ! par absorbed per unit lai for canopy layer (w/m**2)
     real(r8), intent(in)    :: rh_can               ! inside canopy relative humidity
-    real(r8), intent(out)   :: gs_mol_sun           ! sunlit leaf stomatal conductance (umol H2O/m**2/s)
-    real(r8), intent(out)   :: gs_mol_sha           ! shaded leaf stomatal conductance (umol H2O/m**2/s)
+    real(r8), intent(inout) :: gs_mol_sun           ! sunlit leaf stomatal conductance (umol H2O/m**2/s)
+    real(r8), intent(inout) :: gs_mol_sha           ! shaded leaf stomatal conductance (umol H2O/m**2/s)
     real(r8), intent(inout) :: bsun                 ! sunlit canopy transpiration wetness factor (0 to 1)
     real(r8), intent(inout) :: bsha                 ! shaded canopy transpiration wetness factor (0 to 1)
     real(r8), intent(in)    :: qsatl                ! leaf specific humidity [kg/kg]


### PR DESCRIPTION
In PhotosynthesisMod.F90, early exits from brent and brent_PHS do not assign gs_mol outputs values. The desired behavior in those cases is for the input values to be retained. Thus, this commit changes intent(out) to intent(inout) for these variables.

The original code usually works because Fortran normally doesn't overwrite these inputs at the start of the routine. But if an option like crayftn's -hzero is provided, intent(out) stack variables are 0-init'ed, causing a bug.

Fixes SCREAM issue 2057. e3sm.log was being filled with messages like this:

7:  Ball-Berry error check - stomatal conductance error:
7:  0.,  52577.053632404488

The 0 in the second line is important: it implies that gs_mol was being set to 0 unintentionally.

[BFB]