### PR TITLE
Fixes the definition of 20TR GSWP BGC compset

### DIFF
--- a/components/elm/cime_config/config_compsets.xml
+++ b/components/elm/cime_config/config_compsets.xml
@@ -508,7 +508,7 @@
   </compset>
 
   <compset>
-    <alias>I20TRCRUELMBGC</alias>
+    <alias>I20TRGSWELMBGC</alias>
     <lname>20TR_DATM%GSWP3v1_ELM%BGC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 


### PR DESCRIPTION
The alias for the 20TR BGC compset for BGC is corrected.

[BFB]