### PR TITLE
change pbuf variables for CRM state total water to water vapor

### DIFF
--- a/components/eam/src/physics/crm/crm_history.F90
+++ b/components/eam/src/physics/crm/crm_history.F90
@@ -459,9 +459,7 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
    call outfld('CRM_T   ',crm_state%temperature(icol_beg:icol_end,:,:,:), ncol, lchnk )
 
    if (MMF_microphysics_scheme .eq. 'sam1mom') then
-      call outfld('CRM_QV  ',(crm_state%qt(icol_beg:icol_end,:,:,:)    &
-                              -crm_output%qcl(icol_beg:icol_end,:,:,:) &
-                              -crm_output%qci(icol_beg:icol_end,:,:,:)), ncol, lchnk )
+      call outfld('CRM_QV  ',crm_state%qv(icol_beg:icol_end,:,:,:) , ncol, lchnk )
    else if (MMF_microphysics_scheme .eq. 'm2005') then 
       call outfld('CRM_QV  ', crm_state%qt(icol_beg:icol_end,:,:,:)    &
                               -crm_output%qcl(icol_beg:icol_end,:,:,:), ncol, lchnk )

--- a/components/eam/src/physics/crm/crm_history.F90
+++ b/components/eam/src/physics/crm/crm_history.F90
@@ -461,8 +461,7 @@ subroutine crm_history_out(state, ptend, crm_state, crm_rad, crm_output, &
    if (MMF_microphysics_scheme .eq. 'sam1mom') then
       call outfld('CRM_QV  ',crm_state%qv(icol_beg:icol_end,:,:,:) , ncol, lchnk )
    else if (MMF_microphysics_scheme .eq. 'm2005') then 
-      call outfld('CRM_QV  ', crm_state%qt(icol_beg:icol_end,:,:,:)    &
-                              -crm_output%qcl(icol_beg:icol_end,:,:,:), ncol, lchnk )
+      call outfld('CRM_QV  ',crm_state%qv(icol_beg:icol_end,:,:,:), ncol, lchnk )
    endif
 
    !----------------------------------------------------------------------------

--- a/components/eam/src/physics/crm/crm_state_module.F90
+++ b/components/eam/src/physics/crm/crm_state_module.F90
@@ -24,8 +24,8 @@ module crm_state_module
       real(crm_rknd), allocatable :: u_wind(:,:,:,:)       ! CRM u-wind component
       real(crm_rknd), allocatable :: v_wind(:,:,:,:)       ! CRM v-wind component
       real(crm_rknd), allocatable :: w_wind(:,:,:,:)       ! CRM w-wind component
-      real(crm_rknd), allocatable :: temperature(:,:,:,:)  ! CRM temperuture
-      real(crm_rknd), allocatable :: qt(:,:,:,:)           ! CRM total water
+      real(crm_rknd), allocatable :: temperature(:,:,:,:)  ! CRM temperature
+      real(crm_rknd), allocatable :: qv(:,:,:,:)           ! CRM water vapor
 
       ! 2-moment microphsics variables
       real(crm_rknd), allocatable :: qc(:,:,:,:)   ! mass mixing ratio of cloud water
@@ -59,13 +59,13 @@ contains
       if (.not. allocated(state%v_wind))      allocate(state%v_wind(ncrms,crm_nx,crm_ny,crm_nz))
       if (.not. allocated(state%w_wind))      allocate(state%w_wind(ncrms,crm_nx,crm_ny,crm_nz))
       if (.not. allocated(state%temperature)) allocate(state%temperature(ncrms,crm_nx,crm_ny,crm_nz))
-      if (.not. allocated(state%qt))          allocate(state%qt(ncrms,crm_nx,crm_ny,crm_nz))
+      if (.not. allocated(state%qv))          allocate(state%qv(ncrms,crm_nx,crm_ny,crm_nz))
 
       call prefetch(state%u_wind)
       call prefetch(state%v_wind)
       call prefetch(state%w_wind)
       call prefetch(state%temperature)
-      call prefetch(state%qt)
+      call prefetch(state%qv)
 
       if (trim(MMF_microphysics_scheme) .eq. 'm2005') then
          if (.not. allocated(state%qc))          allocate(state%qc(ncrms,crm_nx,crm_ny,crm_nz))
@@ -107,7 +107,7 @@ contains
       if (allocated(state%v_wind))      deallocate(state%v_wind)
       if (allocated(state%w_wind))      deallocate(state%w_wind)
       if (allocated(state%temperature)) deallocate(state%temperature)
-      if (allocated(state%qt))          deallocate(state%qt)
+      if (allocated(state%qv))          deallocate(state%qv)
 
       if (trim(MMF_microphysics_scheme) .eq. 'm2005') then
          if (allocated(state%qc)) deallocate(state%qc)

--- a/components/eam/src/physics/crm/samxx/cpp_interface_mod.F90
+++ b/components/eam/src/physics/crm/samxx/cpp_interface_mod.F90
@@ -15,7 +15,7 @@ module cpp_interface_mod
                    crm_input_ul_esmt, crm_input_vl_esmt, &
                    crm_input_t_vt, crm_input_q_vt, crm_input_u_vt, &
                    crm_state_u_wind, crm_state_v_wind, crm_state_w_wind, crm_state_temperature, &
-                   crm_state_qt, crm_state_qp, crm_state_qn, crm_rad_qrad, crm_rad_temperature, &
+                   crm_state_qv, crm_state_qp, crm_state_qn, crm_rad_qrad, crm_rad_temperature, &
                    crm_rad_qv, crm_rad_qc, crm_rad_qi, crm_rad_cld, crm_output_subcycle_factor, &
                    crm_output_prectend, crm_output_precstend, crm_output_cld, crm_output_cldtop, &
                    crm_output_gicewp, crm_output_gliqwp, crm_output_mctot, crm_output_mcup, crm_output_mcdn, &
@@ -53,7 +53,7 @@ module cpp_interface_mod
                                       crm_input_ul_esmt, crm_input_vl_esmt, &
                                       crm_input_t_vt, crm_input_q_vt, &
                                       crm_state_u_wind, crm_state_v_wind, crm_state_w_wind, crm_state_temperature, &
-                                      crm_state_qt, crm_state_qp, crm_state_qn, crm_rad_qrad, crm_rad_temperature, &
+                                      crm_state_qv, crm_state_qp, crm_state_qn, crm_rad_qrad, crm_rad_temperature, &
                                       crm_rad_qv, crm_rad_qc, crm_rad_qi, crm_rad_cld, crm_output_subcycle_factor, &
                                       crm_output_prectend, crm_output_precstend, crm_output_cld, crm_output_cldtop, &
                                       crm_output_gicewp, crm_output_gliqwp, crm_output_mctot, crm_output_mcup, crm_output_mcdn, &

--- a/components/eam/src/physics/crm/samxx/crm.cpp
+++ b/components/eam/src/physics/crm/samxx/crm.cpp
@@ -15,7 +15,7 @@ extern "C" void crm(int ncrms_in, int pcols_in, real dt_gl, int plev, real *crm_
                     real *crm_input_t_vt_p, real *crm_input_q_vt_p, real *crm_input_u_vt_p,
                     real *crm_state_u_wind_p, real *crm_state_v_wind_p, real *crm_state_w_wind_p, 
                     real *crm_state_temperature_p, 
-                    real *crm_state_qt_p, real *crm_state_qp_p, real *crm_state_qn_p, real *crm_rad_qrad_p, 
+                    real *crm_state_qv_p, real *crm_state_qp_p, real *crm_state_qn_p, real *crm_rad_qrad_p, 
                     real *crm_rad_temperature_p, 
                     real *crm_rad_qv_p, real *crm_rad_qc_p, real *crm_rad_qi_p, real *crm_rad_cld_p, 
                     real *crm_output_subcycle_factor_p, 
@@ -67,12 +67,12 @@ extern "C" void crm(int ncrms_in, int pcols_in, real dt_gl, int plev, real *crm_
                          crm_input_ul_esmt_p, crm_input_vl_esmt_p,
                          crm_input_t_vt_p, crm_input_q_vt_p, crm_input_u_vt_p,
                          crm_state_u_wind_p, crm_state_v_wind_p, crm_state_w_wind_p, crm_state_temperature_p, 
-                         crm_state_qt_p, crm_state_qp_p, crm_state_qn_p, crm_rad_qrad_p, crm_output_subcycle_factor_p, 
+                         crm_state_qv_p, crm_state_qp_p, crm_state_qn_p, crm_rad_qrad_p, crm_output_subcycle_factor_p, 
                          lat0_p, long0_p, gcolp_p, crm_output_cltot_p, crm_output_clhgh_p, crm_output_clmed_p, 
                          crm_output_cllow_p);
 
   copy_outputs(crm_state_u_wind_p, crm_state_v_wind_p, crm_state_w_wind_p, crm_state_temperature_p, 
-               crm_state_qt_p, crm_state_qp_p, crm_state_qn_p, crm_rad_temperature_p, 
+               crm_state_qv_p, crm_state_qp_p, crm_state_qn_p, crm_rad_temperature_p, 
                crm_rad_qv_p, crm_rad_qc_p, crm_rad_qi_p, crm_rad_cld_p, crm_output_subcycle_factor_p, 
                crm_output_prectend_p, crm_output_precstend_p, crm_output_cld_p, crm_output_cldtop_p, 
                crm_output_gicewp_p, crm_output_gliqwp_p, 
@@ -110,7 +110,7 @@ extern "C" void crm(int ncrms_in, int pcols_in, real dt_gl, int plev, real *crm_
   post_timeloop();
 
   copy_outputs_and_destroy(crm_state_u_wind_p, crm_state_v_wind_p, crm_state_w_wind_p, crm_state_temperature_p, 
-                           crm_state_qt_p, crm_state_qp_p, crm_state_qn_p, crm_rad_temperature_p, 
+                           crm_state_qv_p, crm_state_qp_p, crm_state_qn_p, crm_rad_temperature_p, 
                            crm_rad_qv_p, crm_rad_qc_p, crm_rad_qi_p, crm_rad_cld_p, crm_output_subcycle_factor_p, 
                            crm_output_prectend_p, crm_output_precstend_p, crm_output_cld_p, crm_output_cldtop_p, 
                            crm_output_gicewp_p, crm_output_gliqwp_p, 

--- a/components/eam/src/physics/crm/samxx/post_timeloop.cpp
+++ b/components/eam/src/physics/crm/samxx/post_timeloop.cpp
@@ -53,7 +53,7 @@ void post_timeloop() {
   YAKL_SCOPE( crm_state_v_wind        , :: crm_state_v_wind );
   YAKL_SCOPE( crm_state_w_wind        , :: crm_state_w_wind );
   YAKL_SCOPE( crm_state_temperature   , :: crm_state_temperature );
-  YAKL_SCOPE( crm_state_qt            , :: crm_state_qt );
+  YAKL_SCOPE( crm_state_qv            , :: crm_state_qv );
   YAKL_SCOPE( crm_state_qp            , :: crm_state_qp );
   YAKL_SCOPE( crm_state_qn            , :: crm_state_qn );
   YAKL_SCOPE( micro_field             , :: micro_field );
@@ -359,7 +359,7 @@ void post_timeloop() {
     crm_state_v_wind(k,j,i,icrm) = v(k,j+offy_v,i+offx_v,icrm);
     crm_state_w_wind(k,j,i,icrm) = w(k,j+offy_w,i+offx_w,icrm);
     crm_state_temperature(k,j,i,icrm) = tabs(k,j,i,icrm);
-    crm_state_qt(k,j,i,icrm) = micro_field(0,k,j+offy_s,i+offx_s,icrm);
+    crm_state_qv(k,j,i,icrm) = micro_field(0,k,j+offy_s,i+offx_s,icrm) - qn(k,j,i,icrm);
     crm_state_qp(k,j,i,icrm) = micro_field(1,k,j+offy_s,i+offx_s,icrm);
     crm_state_qn(k,j,i,icrm) = qn(k,j,i,icrm);
     crm_output_tk(k,j,i,icrm) = sgs_field_diag(0,k,j+offy_d,i+offx_d,icrm);

--- a/components/eam/src/physics/crm/samxx/pre_timeloop.cpp
+++ b/components/eam/src/physics/crm/samxx/pre_timeloop.cpp
@@ -50,7 +50,7 @@ void pre_timeloop() {
   YAKL_SCOPE( crm_state_w_wind         , :: crm_state_w_wind );
   YAKL_SCOPE( crm_state_temperature    , :: crm_state_temperature ); 
   YAKL_SCOPE( micro_field              , :: micro_field );
-  YAKL_SCOPE( crm_state_qt             , :: crm_state_qt );
+  YAKL_SCOPE( crm_state_qv             , :: crm_state_qv );
   YAKL_SCOPE( crm_state_qp             , :: crm_state_qp );
   YAKL_SCOPE( crm_state_qn             , :: crm_state_qn );
   YAKL_SCOPE( qn                       , :: qn );
@@ -316,7 +316,7 @@ void pre_timeloop() {
   //     for (int i=0; i<nx; i++) {
   //       for (int icrm=0; icrm<ncrms; icrm++) {
   parallel_for( SimpleBounds<4>(nzm,ny,nx,ncrms) , YAKL_LAMBDA (int k, int j, int i, int icrm) {
-    micro_field(0,k,j+offy_s,i+offx_s,icrm) = crm_state_qt(k,j,i,icrm);
+    micro_field(0,k,j+offy_s,i+offx_s,icrm) = crm_state_qv(k,j,i,icrm)+crm_state_qn(k,j,i,icrm);
     micro_field(1,k,j+offy_s,i+offx_s,icrm) = crm_state_qp(k,j,i,icrm);
     qn(k,j,i,icrm) = crm_state_qn(k,j,i,icrm);
   });

--- a/components/eam/src/physics/crm/samxx/vars.cpp
+++ b/components/eam/src/physics/crm/samxx/vars.cpp
@@ -678,7 +678,7 @@ void create_and_copy_inputs(real *crm_input_bflxls_p, real *crm_input_wndls_p, r
                             real *crm_input_ul_esmt_p, real *crm_input_vl_esmt_p,
                             real *crm_input_t_vt_p, real *crm_input_q_vt_p, real *crm_input_u_vt_p,
                             real *crm_state_u_wind_p, real *crm_state_v_wind_p, real *crm_state_w_wind_p, real *crm_state_temperature_p, 
-                            real *crm_state_qt_p, real *crm_state_qp_p, real *crm_state_qn_p, real *crm_rad_qrad_p, real *crm_output_subcycle_factor_p, 
+                            real *crm_state_qv_p, real *crm_state_qp_p, real *crm_state_qn_p, real *crm_rad_qrad_p, real *crm_output_subcycle_factor_p, 
                             real *lat0_p, real *long0_p, int *gcolp_p, real *crm_output_cltot_p, real *crm_output_clhgh_p, real *crm_output_clmed_p,
                             real *crm_output_cllow_p) {
 
@@ -706,7 +706,7 @@ void create_and_copy_inputs(real *crm_input_bflxls_p, real *crm_input_wndls_p, r
   realHost4d crm_state_v_wind          = realHost4d( "crm_state_v_wind        ",crm_state_v_wind_p         , crm_nz, crm_ny    , crm_nx    , pcols);
   realHost4d crm_state_w_wind          = realHost4d( "crm_state_w_wind        ",crm_state_w_wind_p         , crm_nz, crm_ny    , crm_nx    , pcols);
   realHost4d crm_state_temperature     = realHost4d( "crm_state_temperature   ",crm_state_temperature_p    , crm_nz, crm_ny    , crm_nx    , pcols);
-  realHost4d crm_state_qt              = realHost4d( "crm_state_qt            ",crm_state_qt_p             , crm_nz, crm_ny    , crm_nx    , pcols);
+  realHost4d crm_state_qv              = realHost4d( "crm_state_qv            ",crm_state_qv_p             , crm_nz, crm_ny    , crm_nx    , pcols);
   realHost4d crm_state_qp              = realHost4d( "crm_state_qp            ",crm_state_qp_p             , crm_nz, crm_ny    , crm_nx    , pcols);
   realHost4d crm_state_qn              = realHost4d( "crm_state_qn            ",crm_state_qn_p             , crm_nz, crm_ny    , crm_nx    , pcols);
   realHost4d crm_rad_qrad              = realHost4d( "crm_rad_qrad            ",crm_rad_qrad_p             , crm_nz, crm_ny_rad, crm_nx_rad, pcols);
@@ -743,7 +743,7 @@ void create_and_copy_inputs(real *crm_input_bflxls_p, real *crm_input_wndls_p, r
   ::crm_state_v_wind          = real4d( "crm_state_v_wind        ", crm_nz, crm_ny    , crm_nx    , pcols);
   ::crm_state_w_wind          = real4d( "crm_state_w_wind        ", crm_nz, crm_ny    , crm_nx    , pcols);
   ::crm_state_temperature     = real4d( "crm_state_temperature   ", crm_nz, crm_ny    , crm_nx    , pcols);
-  ::crm_state_qt              = real4d( "crm_state_qt            ", crm_nz, crm_ny    , crm_nx    , pcols);
+  ::crm_state_qv              = real4d( "crm_state_qv            ", crm_nz, crm_ny    , crm_nx    , pcols);
   ::crm_state_qp              = real4d( "crm_state_qp            ", crm_nz, crm_ny    , crm_nx    , pcols);
   ::crm_state_qn              = real4d( "crm_state_qn            ", crm_nz, crm_ny    , crm_nx    , pcols);
   ::crm_rad_qrad              = real4d( "crm_rad_qrad            ", crm_nz, crm_ny_rad, crm_nx_rad, pcols);
@@ -854,7 +854,7 @@ void create_and_copy_inputs(real *crm_input_bflxls_p, real *crm_input_wndls_p, r
   crm_state_v_wind        .deep_copy_to(::crm_state_v_wind        );
   crm_state_w_wind        .deep_copy_to(::crm_state_w_wind        );
   crm_state_temperature   .deep_copy_to(::crm_state_temperature   );
-  crm_state_qt            .deep_copy_to(::crm_state_qt            );
+  crm_state_qv            .deep_copy_to(::crm_state_qv            );
   crm_state_qp            .deep_copy_to(::crm_state_qp            );
   crm_state_qn            .deep_copy_to(::crm_state_qn            );
   crm_rad_qrad            .deep_copy_to(::crm_rad_qrad            );
@@ -871,7 +871,7 @@ void create_and_copy_inputs(real *crm_input_bflxls_p, real *crm_input_wndls_p, r
 
 
 void copy_outputs(real *crm_state_u_wind_p, real *crm_state_v_wind_p, real *crm_state_w_wind_p, real *crm_state_temperature_p, 
-                  real *crm_state_qt_p, real *crm_state_qp_p, real *crm_state_qn_p, real *crm_rad_temperature_p, 
+                  real *crm_state_qv_p, real *crm_state_qp_p, real *crm_state_qn_p, real *crm_rad_temperature_p, 
                   real *crm_rad_qv_p, real *crm_rad_qc_p, real *crm_rad_qi_p, real *crm_rad_cld_p, real *crm_output_subcycle_factor_p, 
                   real *crm_output_prectend_p, real *crm_output_precstend_p, real *crm_output_cld_p, real *crm_output_cldtop_p, 
                   real *crm_output_gicewp_p, real *crm_output_gliqwp_p, real *crm_output_mctot_p, real *crm_output_mcup_p, real *crm_output_mcdn_p, 
@@ -895,7 +895,7 @@ void copy_outputs(real *crm_state_u_wind_p, real *crm_state_v_wind_p, real *crm_
   realHost4d crm_state_v_wind          = realHost4d( "crm_state_v_wind        ",crm_state_v_wind_p         , crm_nz, crm_ny    , crm_nx    , pcols);
   realHost4d crm_state_w_wind          = realHost4d( "crm_state_w_wind        ",crm_state_w_wind_p         , crm_nz, crm_ny    , crm_nx    , pcols);
   realHost4d crm_state_temperature     = realHost4d( "crm_state_temperature   ",crm_state_temperature_p    , crm_nz, crm_ny    , crm_nx    , pcols);
-  realHost4d crm_state_qt              = realHost4d( "crm_state_qt            ",crm_state_qt_p             , crm_nz, crm_ny    , crm_nx    , pcols);
+  realHost4d crm_state_qv              = realHost4d( "crm_state_qv            ",crm_state_qv_p             , crm_nz, crm_ny    , crm_nx    , pcols);
   realHost4d crm_state_qp              = realHost4d( "crm_state_qp            ",crm_state_qp_p             , crm_nz, crm_ny    , crm_nx    , pcols);
   realHost4d crm_state_qn              = realHost4d( "crm_state_qn            ",crm_state_qn_p             , crm_nz, crm_ny    , crm_nx    , pcols);
   realHost4d crm_rad_temperature       = realHost4d( "crm_rad_temperature     ",crm_rad_temperature_p      , crm_nz, crm_ny_rad, crm_nx_rad, pcols);
@@ -980,7 +980,7 @@ void copy_outputs(real *crm_state_u_wind_p, real *crm_state_v_wind_p, real *crm_
   crm_state_v_wind          .deep_copy_to( ::crm_state_v_wind           );
   crm_state_w_wind          .deep_copy_to( ::crm_state_w_wind           );
   crm_state_temperature     .deep_copy_to( ::crm_state_temperature      );
-  crm_state_qt              .deep_copy_to( ::crm_state_qt               );
+  crm_state_qv              .deep_copy_to( ::crm_state_qv               );
   crm_state_qp              .deep_copy_to( ::crm_state_qp               );
   crm_state_qn              .deep_copy_to( ::crm_state_qn               );
   crm_rad_temperature       .deep_copy_to( ::crm_rad_temperature        );
@@ -1065,7 +1065,7 @@ void copy_outputs(real *crm_state_u_wind_p, real *crm_state_v_wind_p, real *crm_
 
 
 void copy_outputs_and_destroy(real *crm_state_u_wind_p, real *crm_state_v_wind_p, real *crm_state_w_wind_p, real *crm_state_temperature_p, 
-                              real *crm_state_qt_p, real *crm_state_qp_p, real *crm_state_qn_p, real *crm_rad_temperature_p, 
+                              real *crm_state_qv_p, real *crm_state_qp_p, real *crm_state_qn_p, real *crm_rad_temperature_p, 
                               real *crm_rad_qv_p, real *crm_rad_qc_p, real *crm_rad_qi_p, real *crm_rad_cld_p, real *crm_output_subcycle_factor_p, 
                               real *crm_output_prectend_p, real *crm_output_precstend_p, real *crm_output_cld_p, real *crm_output_cldtop_p, 
                               real *crm_output_gicewp_p, real *crm_output_gliqwp_p, real *crm_output_mctot_p, real *crm_output_mcup_p, real *crm_output_mcdn_p, 
@@ -1090,7 +1090,7 @@ void copy_outputs_and_destroy(real *crm_state_u_wind_p, real *crm_state_v_wind_p
   realHost4d crm_state_v_wind          = realHost4d( "crm_state_v_wind        ",crm_state_v_wind_p         , crm_nz, crm_ny    , crm_nx    , pcols);
   realHost4d crm_state_w_wind          = realHost4d( "crm_state_w_wind        ",crm_state_w_wind_p         , crm_nz, crm_ny    , crm_nx    , pcols);
   realHost4d crm_state_temperature     = realHost4d( "crm_state_temperature   ",crm_state_temperature_p    , crm_nz, crm_ny    , crm_nx    , pcols);
-  realHost4d crm_state_qt              = realHost4d( "crm_state_qt            ",crm_state_qt_p             , crm_nz, crm_ny    , crm_nx    , pcols);
+  realHost4d crm_state_qv              = realHost4d( "crm_state_qv            ",crm_state_qv_p             , crm_nz, crm_ny    , crm_nx    , pcols);
   realHost4d crm_state_qp              = realHost4d( "crm_state_qp            ",crm_state_qp_p             , crm_nz, crm_ny    , crm_nx    , pcols);
   realHost4d crm_state_qn              = realHost4d( "crm_state_qn            ",crm_state_qn_p             , crm_nz, crm_ny    , crm_nx    , pcols);
   realHost4d crm_rad_temperature       = realHost4d( "crm_rad_temperature     ",crm_rad_temperature_p      , crm_nz, crm_ny_rad, crm_nx_rad, pcols);
@@ -1176,7 +1176,7 @@ void copy_outputs_and_destroy(real *crm_state_u_wind_p, real *crm_state_v_wind_p
   ::crm_state_v_wind        .deep_copy_to(crm_state_v_wind        );
   ::crm_state_w_wind        .deep_copy_to(crm_state_w_wind        );
   ::crm_state_temperature   .deep_copy_to(crm_state_temperature   );
-  ::crm_state_qt            .deep_copy_to(crm_state_qt            );
+  ::crm_state_qv            .deep_copy_to(crm_state_qv            );
   ::crm_state_qp            .deep_copy_to(crm_state_qp            );
   ::crm_state_qn            .deep_copy_to(crm_state_qn            );
   ::crm_rad_temperature     .deep_copy_to(crm_rad_temperature     );
@@ -1281,7 +1281,7 @@ void copy_outputs_and_destroy(real *crm_state_u_wind_p, real *crm_state_v_wind_p
   ::crm_state_v_wind          = real4d();
   ::crm_state_w_wind          = real4d();
   ::crm_state_temperature     = real4d();
-  ::crm_state_qt              = real4d();
+  ::crm_state_qv              = real4d();
   ::crm_state_qp              = real4d();
   ::crm_state_qn              = real4d();
   ::crm_rad_qrad              = real4d();
@@ -1735,7 +1735,7 @@ real4d crm_state_u_wind;
 real4d crm_state_v_wind;
 real4d crm_state_w_wind; 
 real4d crm_state_temperature;
-real4d crm_state_qt;
+real4d crm_state_qv;
 real4d crm_state_qp;
 real4d crm_state_qn;
 real4d crm_rad_qrad;

--- a/components/eam/src/physics/crm/samxx/vars.h
+++ b/components/eam/src/physics/crm/samxx/vars.h
@@ -59,14 +59,14 @@ void create_and_copy_inputs(real *crm_input_bflxls_p, real *crm_input_wndls_p, r
                             real *crm_input_ul_esmt_p, real *crm_input_vl_esmt_p,
                             real *crm_input_t_vt_p, real *crm_input_q_vt_p, real *crm_input_u_vt_p,
                             real *crm_state_u_wind_p, real *crm_state_v_wind_p, real *crm_state_w_wind_p, real *crm_state_temperature_p, 
-                            real *crm_state_qt_p, real *crm_state_qp_p, real *crm_state_qn_p, real *crm_rad_qrad_p, real *crm_output_subcycle_factor_p, 
+                            real *crm_state_qv_p, real *crm_state_qp_p, real *crm_state_qn_p, real *crm_rad_qrad_p, real *crm_output_subcycle_factor_p, 
                             real *lat0_p, real *long0_p, int *gcolp_p, real *crm_output_cltot_p, real *crm_output_clhgh_p, real *crm_output_clmed_p,
                             real *crm_output_cllow_p);
                             
 
 
 void copy_outputs(real *crm_state_u_wind_p, real *crm_state_v_wind_p, real *crm_state_w_wind_p, real *crm_state_temperature_p, 
-                  real *crm_state_qt_p, real *crm_state_qp_p, real *crm_state_qn_p, real *crm_rad_temperature_p, 
+                  real *crm_state_qv_p, real *crm_state_qp_p, real *crm_state_qn_p, real *crm_rad_temperature_p, 
                   real *crm_rad_qv_p, real *crm_rad_qc_p, real *crm_rad_qi_p, real *crm_rad_cld_p, real *crm_output_subcycle_factor_p, 
                   real *crm_output_prectend_p, real *crm_output_precstend_p, real *crm_output_cld_p, real *crm_output_cldtop_p, 
                   real *crm_output_gicewp_p, real *crm_output_gliqwp_p, real *crm_output_mctot_p, real *crm_output_mcup_p, real *crm_output_mcdn_p, 
@@ -89,7 +89,7 @@ void copy_outputs(real *crm_state_u_wind_p, real *crm_state_v_wind_p, real *crm_
 
 
 void copy_outputs_and_destroy(real *crm_state_u_wind_p, real *crm_state_v_wind_p, real *crm_state_w_wind_p, real *crm_state_temperature_p, 
-                              real *crm_state_qt_p, real *crm_state_qp_p, real *crm_state_qn_p, real *crm_rad_temperature_p, 
+                              real *crm_state_qv_p, real *crm_state_qp_p, real *crm_state_qn_p, real *crm_rad_temperature_p, 
                               real *crm_rad_qv_p, real *crm_rad_qc_p, real *crm_rad_qi_p, real *crm_rad_cld_p, real *crm_output_subcycle_factor_p, 
                               real *crm_output_prectend_p, real *crm_output_precstend_p, real *crm_output_cld_p, real *crm_output_cldtop_p, 
                               real *crm_output_gicewp_p, real *crm_output_gliqwp_p, real *crm_output_mctot_p, real *crm_output_mcup_p, real *crm_output_mcdn_p, 
@@ -448,7 +448,7 @@ extern real4d crm_state_u_wind;
 extern real4d crm_state_v_wind;
 extern real4d crm_state_w_wind; 
 extern real4d crm_state_temperature;
-extern real4d crm_state_qt;
+extern real4d crm_state_qv;
 extern real4d crm_state_qp;
 extern real4d crm_state_qn;
 extern real4d crm_rad_qrad;


### PR DESCRIPTION
This change for SAM++ is needed for the future upgrade to PAM, and also needed if we eventually put P3/SHOC into SAM++ (which seems unlikely now).  This is non-BFB due to the fact floating point arithmetic is non-communitive, but the qualititive solution will not change. 

[non-BFB] MMF only