### PR TITLE
Deal with uninitialized variables in MOSART_heat_mod.F90

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -13,10 +13,18 @@ _TESTS = {
     "e3sm_mosart_developer" : {
         "share" : True,
         "time"  : "0:45:00",
+        "inherit" : ("e3sm_mosart_heat"),
         "tests" : (
             "ERS.r05_r05.RMOSGPCC.mosart-gpcc_1972",
             "ERS.MOS_USRDAT.RMOSGPCC.mosart-mos_usrdat",
             "SMS.MOS_USRDAT.RMOSGPCC.mosart-unstructure",
+            )
+        },
+
+    "e3sm_mosart_heat" : {
+        "time"  : "0:45:00",
+        "tests" : (
+            "ERS.r05_r05.RMOSGPCC.mosart-heat", 
             )
         },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -13,18 +13,11 @@ _TESTS = {
     "e3sm_mosart_developer" : {
         "share" : True,
         "time"  : "0:45:00",
-        "inherit" : ("e3sm_mosart_heat"),
         "tests" : (
             "ERS.r05_r05.RMOSGPCC.mosart-gpcc_1972",
             "ERS.MOS_USRDAT.RMOSGPCC.mosart-mos_usrdat",
             "SMS.MOS_USRDAT.RMOSGPCC.mosart-unstructure",
-            )
-        },
-
-    "e3sm_mosart_heat" : {
-        "time"  : "0:45:00",
-        "tests" : (
-            "ERS.r05_r05.RMOSGPCC.mosart-heat", 
+            "ERS.r05_r05.RMOSGPCC.mosart-heat",
             )
         },
 

--- a/components/mosart/cime_config/testdefs/testmods_dirs/mosart/heat/shell_commands
+++ b/components/mosart/cime_config/testdefs/testmods_dirs/mosart/heat/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange DATM_CLMNCEP_YR_END=1972

--- a/components/mosart/cime_config/testdefs/testmods_dirs/mosart/heat/user_nl_mosart
+++ b/components/mosart/cime_config/testdefs/testmods_dirs/mosart/heat/user_nl_mosart
@@ -1,0 +1,2 @@
+frivinp_rtm = '$DIN_LOC_ROOT/rof/mosart/MOSART_global_half_20180721a.nc'
+heatflag = .true.

--- a/components/mosart/src/riverroute/MOSART_heat_mod.F90
+++ b/components/mosart/src/riverroute/MOSART_heat_mod.F90
@@ -75,21 +75,22 @@ MODULE MOSART_heat_mod
         integer, intent(in) :: iunit
         real(r8), intent(in) :: theDeltaT    
         
-        real(r8) :: Qsur, Qsub ! flow rate of surface and subsurface runoff separately
-        !if(TUnit%fdir(iunit) >= 0 .and. TUnit%areaTotal(iunit) > TINYVALUE1) then
-                THeat%Hs_t(iunit) = 0._r8
-                THeat%Hl_t(iunit) = 0._r8
-                THeat%He_t(iunit) = 0._r8
-                THeat%Hh_t(iunit) = 0._r8
-                THeat%Hc_t(iunit) = 0._r8
+        !real(r8) :: Qsur, Qsub ! flow rate of surface and subsurface runoff separately
+        
+        !!if(TUnit%fdir(iunit) >= 0 .and. TUnit%areaTotal(iunit) > TINYVALUE1) then
+        THeat%Hs_t(iunit) = 0._r8
+        THeat%Hl_t(iunit) = 0._r8
+        THeat%He_t(iunit) = 0._r8
+        THeat%Hh_t(iunit) = 0._r8
+        THeat%Hc_t(iunit) = 0._r8
 
-                THeat%Ha_h2t(iunit) = 0._r8
-                THeat%Ha_t2r(iunit) = -cr_advectheat(abs(TRunoff%etout(iunit,nt_nliq)+TRunoff%etout(iunit,nt_nice)), THeat%Tt(iunit))
-            ! change of energy due to heat exchange with the environment
-            THeat%deltaH_t(iunit) = theDeltaT * (THeat%Hs_t(iunit) + THeat%Hl_t(iunit) + THeat%He_t(iunit) + THeat%Hc_t(iunit) + THeat%Hh_t(iunit))
-            ! change of energy due to advective heat flux
-            THeat%deltaM_t(iunit) = theDeltaT * (THeat%Ha_h2t(iunit)-cr_advectheat(Qsur + Qsub, THeat%Tt(iunit)))
-        !end if
+        THeat%Ha_h2t(iunit) = 0._r8
+        THeat%Ha_t2r(iunit) = -cr_advectheat(abs(TRunoff%etout(iunit,nt_nliq)+TRunoff%etout(iunit,nt_nice)), THeat%Tt(iunit))
+        ! change of energy due to heat exchange with the environment
+        THeat%deltaH_t(iunit) = 0._r8 !theDeltaT * (THeat%Hs_t(iunit) + THeat%Hl_t(iunit) + THeat%He_t(iunit) + THeat%Hc_t(iunit) + THeat%Hh_t(iunit))
+        ! change of energy due to advective heat flux
+        THeat%deltaM_t(iunit) = 0._r8 !theDeltaT * (THeat%Ha_h2t(iunit)-cr_advectheat(Qsur + Qsub, THeat%Tt(iunit)))
+        !!end if
     end subroutine subnetworkHeat_simple
 
     

--- a/components/mosart/src/riverroute/MOSART_heat_mod.F90
+++ b/components/mosart/src/riverroute/MOSART_heat_mod.F90
@@ -75,9 +75,6 @@ MODULE MOSART_heat_mod
         integer, intent(in) :: iunit
         real(r8), intent(in) :: theDeltaT    
         
-        !real(r8) :: Qsur, Qsub ! flow rate of surface and subsurface runoff separately
-        
-        !!if(TUnit%fdir(iunit) >= 0 .and. TUnit%areaTotal(iunit) > TINYVALUE1) then
         THeat%Hs_t(iunit) = 0._r8
         THeat%Hl_t(iunit) = 0._r8
         THeat%He_t(iunit) = 0._r8
@@ -87,10 +84,10 @@ MODULE MOSART_heat_mod
         THeat%Ha_h2t(iunit) = 0._r8
         THeat%Ha_t2r(iunit) = -cr_advectheat(abs(TRunoff%etout(iunit,nt_nliq)+TRunoff%etout(iunit,nt_nice)), THeat%Tt(iunit))
         ! change of energy due to heat exchange with the environment
-        THeat%deltaH_t(iunit) = 0._r8 !theDeltaT * (THeat%Hs_t(iunit) + THeat%Hl_t(iunit) + THeat%He_t(iunit) + THeat%Hc_t(iunit) + THeat%Hh_t(iunit))
+        THeat%deltaH_t(iunit) = 0._r8 
         ! change of energy due to advective heat flux
-        THeat%deltaM_t(iunit) = 0._r8 !theDeltaT * (THeat%Ha_h2t(iunit)-cr_advectheat(Qsur + Qsub, THeat%Tt(iunit)))
-        !!end if
+        THeat%deltaM_t(iunit) = 0._r8 
+
     end subroutine subnetworkHeat_simple
 
     


### PR DESCRIPTION
The use of uninitialized variables (i.e., `Qsur` and `Qsub`) in the computation of the change of energy 
due to heat exchange with the environment and advection is fixed. Currently, it is assumed that those
changes in energy are zero.

Fixes #5332
[BFB]