### PR TITLE
Add GMPAS-JRA1p5-DIB-ISMF compset

### DIFF
--- a/components/data_comps/drof/cime_config/config_component.xml
+++ b/components/data_comps/drof/cime_config/config_component.xml
@@ -13,7 +13,7 @@
   -->
 
   <description modifier_mode="1">
-    <desc rof="DROF[%NULL][%NYF][%IAF][%IAFAIS00][%IAFAIS45][%IAFAIS55][%CPLHIST][%JRA][%JRA-1p5][%JRA-1p4-2018][%JRA-1p4-2018-AIS0ICE][%JRA-1p4-2018-AIS0LIQ][%JRA-1p4-2018-AIS0ROF[%JRA-RYF8485][%JRA-RYF9091][%JRA-RYF0304]">Data runoff model</desc>
+    <desc rof="DROF[%NULL][%NYF][%IAF][%IAFAIS00][%IAFAIS45][%IAFAIS55][%CPLHIST][%JRA][%JRA-1p5][%JRA-1p5-AIS0ROF][%JRA-1p4-2018][%JRA-1p4-2018-AIS0ICE][%JRA-1p4-2018-AIS0LIQ][%JRA-1p4-2018-AIS0ROF[%JRA-RYF8485][%JRA-RYF9091][%JRA-RYF0304]">Data runoff model</desc>
     <desc option="NULL"     >NULL mode</desc>
     <desc option="NYF"      >COREv2 normal year forcing:</desc>
     <desc option="IAF"      >COREv2 interannual year forcing:</desc>
@@ -22,6 +22,7 @@
     <desc option="IAFAIS55" >COREv2 interannual year forcing:</desc>
     <desc option="CPLHIST"  >CPLHIST mode:</desc>
     <desc option="JRA-1p5">JRA55 interannual forcing, v1.5, through 2020</desc>
+    <desc option="JRA-1p5-AIS0ROF">JRA55 interannual forcing, v1.5, through 2020, no rofi or rofl around AIS</desc>
     <desc option="JRA-1p4-2018">JRA55 interannual forcing, v1.4, through 2018</desc>
     <desc option="JRA-1p4-2018-AIS0ICE">JRA55 interannual forcing, v1.4, through 2018, no rofi around AIS</desc>
     <desc option="JRA-1p4-2018-AIS0LIQ">JRA55 interannual forcing, v1.4, through 2018, no rofl around AIS</desc>
@@ -43,7 +44,7 @@
 
   <entry id="DROF_MODE">
     <type>char</type>
-    <valid_values>CPLHIST,DIATREN_ANN_RX1,DIATREN_IAF_RX1,DIATREN_IAF_AIS00_RX1,DIATREN_IAF_AIS45_RX1,DIATREN_IAF_AIS55_RX1,IAF_JRA,IAF_JRA_1p5,IAF_JRA_1p4_2018,IAF_JRA_1p4_2018_AIS0ICE,IAF_JRA_1p4_2018_AIS0LIQ,IAF_JRA_1p4_2018_AIS0ROF,RYF8485_JRA,RYF9091_JRA,RYF0304_JRA,NULL</valid_values>
+    <valid_values>CPLHIST,DIATREN_ANN_RX1,DIATREN_IAF_RX1,DIATREN_IAF_AIS00_RX1,DIATREN_IAF_AIS45_RX1,DIATREN_IAF_AIS55_RX1,IAF_JRA,IAF_JRA_1p5,IAF_JRA_1p5_AIS0ROF,IAF_JRA_1p4_2018,IAF_JRA_1p4_2018_AIS0ICE,IAF_JRA_1p4_2018_AIS0LIQ,IAF_JRA_1p4_2018_AIS0ROF,RYF8485_JRA,RYF9091_JRA,RYF0304_JRA,NULL</valid_values>
     <default_value>DIATREN_ANN_RX1</default_value>
     <values match="last">
       <value compset="_DROF%NULL">NULL</value>
@@ -58,6 +59,7 @@
       <value compset="_DROF%CPLHIST">CPLHIST</value>
       <value compset="_DROF%JRA" >IAF_JRA</value>
       <value compset="_DROF%JRA-1p5" >IAF_JRA_1p5</value>
+      <value compset="_DROF%JRA-1p5-AIS0ROF" >IAF_JRA_1p5_AIS0ROF</value>
       <value compset="_DROF%JRA-1p4-2018" >IAF_JRA_1p4_2018</value>
       <value compset="_DROF%JRA-1p4-2018-AIS0ICE" >IAF_JRA_1p4_2018_AIS0ICE</value>
       <value compset="_DROF%JRA-1p4-2018-AIS0LIQ" >IAF_JRA_1p4_2018_AIS0LIQ</value>

--- a/components/data_comps/drof/cime_config/namelist_definition_drof.xml
+++ b/components/data_comps/drof/cime_config/namelist_definition_drof.xml
@@ -63,6 +63,7 @@
       <value drof_mode="IAF_JRA_1p4_2018_AIS0LIQ">rof.iaf_jra_1p4_2018_ais0liq</value>
       <value drof_mode="IAF_JRA_1p4_2018_AIS0ROF">rof.iaf_jra_1p4_2018_ais0rof</value>
       <value drof_mode="IAF_JRA_1p4_2018"     >rof.iaf_jra_1p4_2018</value>
+      <value drof_mode="IAF_JRA_1p5_AIS0ROF"  >rof.iaf_jra_1p5_ais0rof</value>
       <value drof_mode="IAF_JRA_1p5"          >rof.iaf_jra_1p5</value>
       <value drof_mode="IAF_JRA"              >rof.iaf_jra</value>
       <value drof_mode="RYF8485_JRA"          >rof.ryf8485_jra</value>
@@ -203,6 +204,71 @@
       <value stream="rof.ryf8485_jra">RAF_8485.JRA.v1.3.runoff.180404.nc</value>
       <value stream="rof.ryf9091_jra">RAF_9091.JRA.v1.3.runoff.180404.nc</value>
       <value stream="rof.ryf0304_jra">RAF_0304.JRA.v1.3.runoff.180404.nc</value>
+      <value stream="rof.iaf_jra_1p5_ais0rof">
+           JRA.v1.5.runoff.1958.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1959.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1960.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1961.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1962.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1963.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1964.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1965.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1966.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1967.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1968.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1969.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1970.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1971.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1972.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1973.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1974.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1975.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1976.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1977.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1978.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1979.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1980.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1981.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1982.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1983.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1984.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1985.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1986.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1987.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1988.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1989.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1990.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1991.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1992.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1993.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1994.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1995.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1996.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1997.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1998.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.1999.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.2000.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.2001.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.2002.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.2003.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.2004.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.2005.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.2006.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.2007.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.2008.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.2009.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.2010.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.2011.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.2012.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.2013.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.2014.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.2015.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.2016.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.2017.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.2018.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.2019.no_rofi_no_rofl.210505.nc
+           JRA.v1.5.runoff.2020.no_rofi_no_rofl.210504.nc
+      </value>
       <value stream="rof.iaf_jra_1p5">
            JRA.v1.5.runoff.1958.210505.nc
            JRA.v1.5.runoff.1959.210505.nc

--- a/components/mpas-ocean/cime_config/config_compsets.xml
+++ b/components/mpas-ocean/cime_config/config_compsets.xml
@@ -58,6 +58,11 @@
   </compset>
 
   <compset>
+    <alias>GMPAS-JRA1p5-DIB-ISMF</alias>
+    <lname>2000_DATM%JRA-1p5_SLND_MPASSI%DIB_MPASO%IBISMFDATMFORCED_DROF%JRA-1p5-AIS0ROF_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>GMPAS-JRA1p4</alias>
     <lname>2000_DATM%JRA-1p4-2018_SLND_MPASSI_MPASO%DATMFORCED_DROF%JRA-1p4-2018_SGLC_SWAV</lname>
   </compset>


### PR DESCRIPTION
Adds a new `GMPAS-JRA1p5-DIB-ISMF` compset, an updated version of the existing `GMPAS-JRA1p4-DIB-ISMF` compset that uses JRA v1.5.

This compset is for use with ocean meshes with ice-shelf cavities, and uses prognostic ice-shelf basal melting, and prescribed iceberg forcing. To compensate for this Antarctic runoff, the `rofi` and `rofl` fields have been zeroed out below 60S in the modified runoff forcing files pointed to.

New modified runoff files (with the `no_rofi_no_rofl` tag are on the public inputdata server and world readable.

[BFB] for all currently tested configurations.