### PR TITLE
Move bottomDepthEdge calculation to single loop over all edges

### DIFF
--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -173,8 +173,6 @@ module ocn_time_integration_split
          edgeHaloComputeCounter, &! halo counters to reduce
          cellHaloComputeCounter   ! halo updates during cycling
 
-      integer, dimension(:), pointer :: nEdgesArray
-
       real (kind=RKIND) :: &
          normalThicknessFluxSum, &! sum of thickness flux in column
          thicknessSum,     &! sum of thicknesses in column
@@ -384,8 +382,6 @@ module ocn_time_integration_split
                                           lowFreqDivergenceTend)
 
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracersNew, 2)
-
-      call mpas_pool_get_dimension(meshPool,'nEdgesArray', nEdgesArray)
 
       allocate(bottomDepthEdge(nEdgesAll+1))
 
@@ -796,7 +792,7 @@ module ocn_time_integration_split
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(cell1, cell2, k, thicknessSum)
-            do iEdge = 1, nEdgesArray(size(nEdgesArray)-1)
+            do iEdge = 1, nEdgesHalo(config_num_halos+1)
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
                thicknessSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -775,8 +775,6 @@ module ocn_time_integration_split
                enddo
                barotropicForcing(iEdge) = splitFact* &
                               normalThicknessFluxSum/thicknessSum/dt
-               bottomDepthEdge(iEdge) = thicknessSum &
-                  - 0.5_RKIND*(sshNew(cell1) + sshNew(cell2))
 
                do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                   ! These two steps are together here:
@@ -798,7 +796,7 @@ module ocn_time_integration_split
             !$omp parallel
             !$omp do schedule(runtime) &
             !$omp private(cell1, cell2, k, thicknessSum)
-            do iEdge = nEdgesOwned+1, nEdgesArray(4)
+            do iEdge = 1, nEdgesArray(size(nEdgesArray)-1)
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
                thicknessSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)


### PR DESCRIPTION
After #5195 was merged, the MPAS-Ocean standalone test `ocean/baroclinic_channel/10km/decomp_test` failed to match between 4 and 8 partitions, but only for intel optimized. All compass nightly suite tests passed for gnu debug, gnu optimized, intel debug. 

This PR solves the problem by merging the computation of `bottomDepthEdge` into a single edge loop. Previously it was split into two loops, `1:nEdgesOwned` (with many other calculations) and another from `nEdgesOwned+1:nEdgesArray(4)`. The intel optimized compiler must have changed order-of-operations in these two loops for different partitions.

Fixes #5219
[BFB]