### PR TITLE
Add DMPAS-JRA1p5 compset

### DIFF
--- a/components/mpas-seaice/cime_config/config_compsets.xml
+++ b/components/mpas-seaice/cime_config/config_compsets.xml
@@ -10,6 +10,11 @@
   <!-- E3SM D compsets -->
 
   <compset>
+    <alias>DMPAS-JRA1p5</alias>
+    <lname>2000_DATM%JRA-1p5_SLND_MPASSI_DOCN%SOM_DROF%JRA-1p5_SGLC_SWAV_TEST</lname>
+  </compset>
+
+  <compset>
     <alias>DTESTM</alias>
     <lname>2000_DATM%NYF_SLND_MPASSI_DOCN%SOM_DROF%NYF_SGLC_SWAV_TEST</lname>
   </compset>

--- a/components/mpas-seaice/cime_config/config_pes.xml
+++ b/components/mpas-seaice/cime_config/config_pes.xml
@@ -32,6 +32,21 @@
         </ntasks>
       </pes>
     </mach>
+    <mach name="anvil">
+      <pes compset="any" pesize="S">
+        <comment>seaice: 20 nodes pure mpi, ~23 SYPD</comment>
+        <ntasks>
+          <ntasks_atm>720</ntasks_atm>
+          <ntasks_lnd>720</ntasks_lnd>
+          <ntasks_rof>720</ntasks_rof>
+          <ntasks_ice>720</ntasks_ice>
+          <ntasks_ocn>720</ntasks_ocn>
+          <ntasks_glc>720</ntasks_glc>
+          <ntasks_wav>720</ntasks_wav>
+          <ntasks_cpl>720</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
     <mach name="chrysalis">
       <pes compset="any" pesize="any">
         <comment>seaice+chrysalis: default, 4 nodes x 32 mpi x 2 omp @ root 0</comment>
@@ -56,6 +71,33 @@
           <nthrds_glc>2</nthrds_glc>
           <nthrds_wav>2</nthrds_wav>
           <nthrds_cpl>2</nthrds_cpl>
+        </nthrds>
+      </pes>
+    </mach>
+    <mach name="chrysalis">
+      <pes compset="any" pesize="S">
+        <comment>seaice+chrysalis: 20 nodes pure mpi, ~47 SYPD</comment>
+        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
+        <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
+        <ntasks>
+          <ntasks_atm>1280</ntasks_atm>
+          <ntasks_lnd>1280</ntasks_lnd>
+          <ntasks_rof>1280</ntasks_rof>
+          <ntasks_ice>1280</ntasks_ice>
+          <ntasks_ocn>1280</ntasks_ocn>
+          <ntasks_glc>1280</ntasks_glc>
+          <ntasks_wav>1280</ntasks_wav>
+          <ntasks_cpl>1280</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
         </nthrds>
       </pes>
     </mach>


### PR DESCRIPTION
Adds `DMPAS-JRA1p5` compset; D-case with active sea ice only.

Also adds PE layouts for any D-case on Chrysalis and Anvil, `S` layouts on 20 nodes, with ~47 and 23 SYPD, respectively.

[BFB] for all currently tested configurations.