### PR TITLE
MPAS: Fix hist file regexes

### DIFF
--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -77,7 +77,7 @@
   <comp_archive_spec compname="mpassi" compclass="ice">
     <rest_file_extension>rst</rest_file_extension>
     <rest_file_extension>rst.am.timeSeriesStatsMonthly</rest_file_extension>
-    <hist_file_extension>hist</hist_file_extension>
+    <hist_file_extension>hist.*[.]nc</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.ice$NINST_STRING</rpointer_file>
@@ -95,7 +95,7 @@
   <comp_archive_spec compname="mpaso" compclass="ocn">
     <rest_file_extension>rst</rest_file_extension>
     <rest_file_extension>rst.am.timeSeriesStatsMonthly</rest_file_extension>
-    <hist_file_extension>hist</hist_file_extension>
+    <hist_file_extension>hist.*[.]nc</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.ocn$NINST_STRING</rpointer_file>
@@ -113,7 +113,7 @@
   <comp_archive_spec compname="mali" compclass="glc">
     <rest_file_extension>rst</rest_file_extension>
     <rest_file_extension>rst.am.timeSeriesStatsMonthly</rest_file_extension>
-    <hist_file_extension>hist</hist_file_extension>
+    <hist_file_extension>hist.*[.]nc</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.glc$NINST_STRING</rpointer_file>


### PR DESCRIPTION
The old setting of hist_file_extension was causing hist files to be missed when suffix!='', like for internal 2-case test comparisons.

Tested with `NCK_P64x2.ne4_oQU240.WCYCL1850NS.mappy_gnu.allactive-mach_mods` and I can now see all the comparisons happening:

```
2022-12-15 12:28:45: Comparing hists for case 'NCK_P64x2.ne4_oQU240.WCYCL1850NS.mappy_gnu.allactive-mach_mods.20221215_121739_ochi9z' dir1='/ascldap/users/jgfouca/acme/scratch/NCK_P64x2.ne4_oQU240.WCYCL1850NS.mappy_gnu.\
allactive-mach_mods.20221215_121739_ochi9z/run', suffix1='base',  dir2='/ascldap/users/jgfouca/acme/scratch/NCK_P64x2.ne4_oQU240.WCYCL1850NS.mappy_gnu.allactive-mach_mods.20221215_121739_ochi9z/run' suffix2='multiinst'
  comparing model 'eam'
    no hist files found for model eam
  comparing model 'elm'
    no hist files found for model elm
  comparing model 'mpassi'
    NCK_P64x2.ne4_oQU240.WCYCL1850NS.mappy_gnu.allactive-mach_mods.20221215_121739_ochi9z.mpassi.hist.am.timeSeriesStatsDaily.0001-01-01.nc.base matched NCK_P64x2.ne4_oQU240.WCYCL1850NS.mappy_gnu.allactive-mach_mods.202\
21215_121739_ochi9z.mpassi_0001.hist.am.timeSeriesStatsDaily.0001-01-01.nc.multiinst
    NCK_P64x2.ne4_oQU240.WCYCL1850NS.mappy_gnu.allactive-mach_mods.20221215_121739_ochi9z.mpassi.hist.am.timeSeriesStatsDaily.0001-01-01.nc.base matched NCK_P64x2.ne4_oQU240.WCYCL1850NS.mappy_gnu.allactive-mach_mods.202\
21215_121739_ochi9z.mpassi_0002.hist.am.timeSeriesStatsDaily.0001-01-01.nc.multiinst
  comparing model 'mpaso'
    no hist files found for model mpaso
  comparing model 'mosart'
    no hist files found for model mosart
  comparing model 'sglc'
    no hist files found for model sglc
  comparing model 'swav'
    no hist files found for model swav
  comparing model 'siac'
    no hist files found for model siac
  comparing model 'sesp'
    no hist files found for model sesp
  comparing model 'cpl'
    NCK_P64x2.ne4_oQU240.WCYCL1850NS.mappy_gnu.allactive-mach_mods.20221215_121739_ochi9z.cpl.hi.0001-01-06-00000.nc.base matched NCK_P64x2.ne4_oQU240.WCYCL1850NS.mappy_gnu.allactive-mach_mods.20221215_121739_ochi9z.cpl\
.hi.0001-01-06-00000.nc.multiinst
```

I will make a PR on the CIME side to try to catch this kind of error.

[BFB]