### PR TITLE
Replace pointers to integer scalars to fix OpenACC issues

### DIFF
--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -140,10 +140,6 @@ module ocn_time_integration_rk4
       logical, pointer :: config_zero_drying_velocity
       character (len=StrKIND), pointer :: config_land_ice_flux_mode
 
-      ! State indices
-      integer, pointer :: indexTemperature
-      integer, pointer :: indexSalinity
-
       ! Diagnostics Indices
 
       ! Mesh array pointers
@@ -1540,7 +1536,7 @@ module ocn_time_integration_rk4
       real (kind=RKIND), intent(in) :: dt
       integer, intent(out) :: err
 
-      integer, pointer :: nCells, nEdges, indexTemperature, indexSalinity
+      integer, pointer :: nCells, nEdges
       integer :: iCell, iEdge, k
 
       type (mpas_pool_type), pointer :: statePool, meshPool, forcingPool
@@ -1587,8 +1583,6 @@ module ocn_time_integration_rk4
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocityNew, 2)
       call mpas_pool_get_array(statePool, 'ssh', sshNew, 2)
 
-      call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
-      call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracersNew, 2)
 
       call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -285,8 +285,9 @@ module ocn_time_integration_si
 
       integer, pointer :: &
          startIndex, endIndex, &! start, end index for tracer groups
-         indexSalinity          ! tracer index for salinity
+         indexSalinityPtr       ! tracer index for salinity
 
+      integer :: indexSalinity
       integer :: iTracer, numTracers, numActiveTracers
 
       type (mpas_pool_iterator_type) :: &
@@ -433,7 +434,8 @@ module ocn_time_integration_si
                                            lowFreqDivergenceNew, 2)
 
       call mpas_pool_get_dimension(tracersPool, 'index_salinity', &
-                                                 indexSalinity)
+                                                 indexSalinityPtr)
+      indexSalinity = indexSalinityPtr
 
       !*** Retrieve tendency variables
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -125,7 +125,8 @@ contains
 
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
 
-      integer, pointer :: indexTemperature, indexSalinity
+      integer, pointer :: indexTemperaturePtr, indexSalinityPtr
+      integer :: indexTemperature, indexSalinity
 
       logical :: full_compute = .true.
 
@@ -149,8 +150,12 @@ contains
          timeLevel = 1
       end if
 
-      call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
-      call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
+      call mpas_pool_get_dimension(tracersPool, 'index_temperature', &
+                                                 indexTemperaturePtr)
+      call mpas_pool_get_dimension(tracersPool, 'index_salinity', &
+                                                 indexSalinityPtr)
+      indexTemperature = indexTemperaturePtr
+      indexSalinity    = indexSalinityPtr
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, timeLevel)
 
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
@@ -3279,11 +3284,6 @@ contains
 
       call mpas_timer_start("land_ice_diagnostic_fields", .false.)
 
-      indexBLTval = indexBLT
-      indexBLSval = indexBLS
-      indexHeatTransval = indexHeatTrans
-      indexSaltTransval = indexSaltTrans
-
       allocate(blTempScratch(nCellsAll), &
                blSaltScratch(nCellsAll))
       !$acc enter data create(blTempScratch, blSaltScratch)
@@ -3373,16 +3373,16 @@ contains
       !$omp do schedule(runtime) private(weightSum, i, cell2)
 #endif
       do iCell = 1, nCellsAll
-         landIceBoundaryLayerTracers(indexBLTval, iCell) = blTempScratch(iCell)
-         landIceBoundaryLayerTracers(indexBLSval, iCell) = blSaltScratch(iCell)
+         landIceBoundaryLayerTracers(indexBLT, iCell) = blTempScratch(iCell)
+         landIceBoundaryLayerTracers(indexBLS, iCell) = blSaltScratch(iCell)
          if(config_land_ice_flux_boundaryLayerNeighborWeight > 0.0_RKIND) then
             weightSum = 1.0_RKIND
             do i = 1, nEdgesOnCell(iCell)
                cell2 = cellsOnCell(i,iCell)
 
-               landIceBoundaryLayerTracers(indexBLTval, iCell) = landIceBoundaryLayerTracers(indexBLTval, iCell) &
+               landIceBoundaryLayerTracers(indexBLT, iCell) = landIceBoundaryLayerTracers(indexBLT, iCell) &
                  + cellMask(minLevelCell(cell2),cell2)*config_land_ice_flux_boundaryLayerNeighborWeight*blTempScratch(cell2)
-               landIceBoundaryLayerTracers(indexBLSval, iCell) = landIceBoundaryLayerTracers(indexBLSval, iCell) &
+               landIceBoundaryLayerTracers(indexBLS, iCell) = landIceBoundaryLayerTracers(indexBLS, iCell) &
                  + cellMask(minLevelCell(cell2),cell2)*config_land_ice_flux_boundaryLayerNeighborWeight*blSaltScratch(cell2)
                weightSum = weightSum + cellMask(minLevelCell(cell2),cell2)*config_land_ice_flux_boundaryLayerNeighborWeight
             end do
@@ -3403,9 +3403,9 @@ contains
 #endif
          do iCell = 1, nCellsAll
             ! transfer coefficients from namelist
-            landIceTracerTransferVelocities(indexHeatTransval, iCell) = landIceFrictionVelocity(iCell) &
+            landIceTracerTransferVelocities(indexHeatTrans, iCell) = landIceFrictionVelocity(iCell) &
                                              * config_land_ice_flux_jenkins_heat_transfer_coefficient
-            landIceTracerTransferVelocities(indexSaltTransval, iCell) = landIceFrictionVelocity(iCell) &
+            landIceTracerTransferVelocities(indexSaltTrans, iCell) = landIceFrictionVelocity(iCell) &
                                              * config_land_ice_flux_jenkins_salt_transfer_coefficient
          end do
 #ifndef MPAS_OPENACC
@@ -3432,9 +3432,9 @@ contains
                 *xiN/(abs(fCell(iCell))*h_nu))
             end if
 
-            landIceTracerTransferVelocities(indexHeatTransval, iCell) = 1.0_RKIND/(Gamma_turb + 12.5_RKIND &
+            landIceTracerTransferVelocities(indexHeatTrans, iCell) = 1.0_RKIND/(Gamma_turb + 12.5_RKIND &
                                                                    * Pr**(2.0_RKIND/3.0_RKIND) - 6.0_RKIND)
-            landIceTracerTransferVelocities(indexSaltTransval, iCell) = 1.0_RKIND/(Gamma_turb + 12.5_RKIND &
+            landIceTracerTransferVelocities(indexSaltTrans, iCell) = 1.0_RKIND/(Gamma_turb + 12.5_RKIND &
                                                                    * Sc**(2.0_RKIND/3.0_RKIND) - 6.0_RKIND)
          end do
 #ifndef MPAS_OPENACC

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -88,7 +88,8 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:,:), pointer :: landIceBoundaryLayerTracers
    real (kind=RKIND), dimension(:,:), pointer :: landIceTracerTransferVelocities
 
-   integer, pointer :: indexBLT, indexBLS, indexHeatTrans, indexSaltTrans
+   integer :: indexBLT, indexBLS, &
+              indexHeatTrans, indexSaltTrans
 
    real (kind=RKIND), dimension(:), pointer :: penetrativeTemperatureFluxOBL
    real (kind=RKIND), dimension(:), pointer :: bottomLayerShortwaveTemperatureFlux
@@ -168,7 +169,7 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:), pointer :: boundaryLayerDepth
    real (kind=RKIND), dimension(:), pointer :: boundaryLayerDepthSmooth
    real (kind=RKIND), dimension(:), pointer :: indexBoundaryLayerDepth
-   integer, pointer :: index_vertNonLocalFluxTemp
+   integer :: index_vertNonLocalFluxTemp
 
    real (kind=RKIND), dimension(:), pointer :: salinitySurfaceRestoringTendency
 
@@ -183,8 +184,8 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:), pointer :: barotropicThicknessFlux
 
    real (kind=RKIND), dimension(:, :), pointer :: SSHGradient
-   integer, pointer :: indexSurfaceVelocityZonal, indexSurfaceVelocityMeridional
-   integer, pointer :: indexSSHGradientZonal, indexSSHGradientMeridional
+   integer :: indexSurfaceVelocityZonal, indexSurfaceVelocityMeridional
+   integer :: indexSSHGradientZonal, indexSSHGradientMeridional
 
    type (field1DInteger), pointer :: smoothingMaskField
    type (field2DReal), pointer :: verticalStretchField
@@ -234,6 +235,16 @@ contains
       integer, intent(out) :: err !< Output: Error flag
 
       type (mpas_pool_type), pointer :: diagnosticsPool
+
+      ! Local pointers for pool retrievals
+      integer, pointer :: &
+         indexBLTPtr, indexBLSPtr, &
+         indexHeatTransPtr, indexSaltTransPtr, &
+         index_vertNonLocalFluxTempPtr, &
+         indexSurfaceVelocityZonalPtr, &
+         indexSurfaceVelocityMeridionalPtr, &
+         indexSSHGradientZonalPtr, &
+         indexSSHGradientMeridionalPtr
 
       err = 0
 
@@ -318,13 +329,18 @@ contains
          call mpas_pool_get_array(diagnosticsPool, 'topDrag', topDrag)
          call mpas_pool_get_array(diagnosticsPool, 'topDragMagnitude', topDragMag)
          call mpas_pool_get_dimension(diagnosticsPool, &
-                   'index_landIceBoundaryLayerTemperature', indexBLT)
+                   'index_landIceBoundaryLayerTemperature', indexBLTPtr)
          call mpas_pool_get_dimension(diagnosticsPool, &
-                   'index_landIceBoundaryLayerSalinity', indexBLS)
+                   'index_landIceBoundaryLayerSalinity', indexBLSPtr)
          call mpas_pool_get_dimension(diagnosticsPool, &
-                   'index_landIceHeatTransferVelocity', indexHeatTrans)
+                   'index_landIceHeatTransferVelocity', indexHeatTransPtr)
          call mpas_pool_get_dimension(diagnosticsPool, &
-                   'index_landIceSaltTransferVelocity', indexSaltTrans)
+                   'index_landIceSaltTransferVelocity', indexSaltTransPtr)
+         indexBLT = indexBLTPtr
+         indexBLS = indexBLSPtr
+         indexHeatTrans = indexHeatTransPtr
+         indexSaltTrans = indexSaltTransPtr
+
          call mpas_pool_get_array(diagnosticsPool, &
                    'landIceBoundaryLayerTracers', landIceBoundaryLayerTracers)
          call mpas_pool_get_array(diagnosticsPool, &
@@ -535,16 +551,16 @@ contains
          ! Set pointer for index variables
          call mpas_pool_get_dimension(diagnosticsPool, &
                   'index_surfaceVelocityZonal', &
-                   indexSurfaceVelocityZonal)
+                   indexSurfaceVelocityZonalPtr)
          call mpas_pool_get_dimension(diagnosticsPool, &
                   'index_surfaceVelocityMeridional', &
-                   indexSurfaceVelocityMeridional)
+                   indexSurfaceVelocityMeridionalPtr)
          call mpas_pool_get_dimension(diagnosticsPool, &
                   'index_vertNonLocalFluxTemp', &
-                   index_vertNonLocalFluxTemp)
+                   index_vertNonLocalFluxTempPtr)
          call mpas_pool_get_dimension(diagnosticsPool, &
                   'index_SSHGradientMeridional', &
-                   indexSSHGradientMeridional)
+                   indexSSHGradientMeridionalPtr)
          call mpas_pool_get_array(diagnosticsPool, &
                   'indexSurfaceLayerDepth', &
                    indexSurfaceLayerDepth)
@@ -553,7 +569,12 @@ contains
                    indexBoundaryLayerDepth)
          call mpas_pool_get_dimension(diagnosticsPool, &
                   'index_SSHGradientZonal', &
-                   indexSSHGradientZonal)
+                   indexSSHGradientZonalPtr)
+         indexSurfaceVelocityZonal = indexSurfaceVelocityZonalPtr
+         indexSurfaceVelocityMeridional = indexSurfaceVelocityMeridionalPtr
+         index_vertNonLocalFluxTemp = index_vertNonLocalFluxTempPtr
+         indexSSHGradientMeridional = indexSSHGradientMeridionalPtr
+         indexSSHGradientZonal = indexSSHGradientZonalPtr
       end if
 
       call mpas_pool_get_array(diagnosticsPool, &
@@ -650,10 +671,6 @@ contains
          !$acc enter data create(                                 &
          !$acc                   topDrag,                         &
          !$acc                   topDragMag,                      &
-         !$acc                   indexBLT,                        &
-         !$acc                   indexBLS,                        &
-         !$acc                   indexHeatTrans,                  &
-         !$acc                   indexSaltTrans,                  &
          !$acc                   landIceBoundaryLayerTracers,     &
          !$acc                   landIceTracerTransferVelocities, &
          !$acc                   landIceFrictionVelocity)
@@ -736,7 +753,6 @@ contains
          !$acc                   mleVelocityZonal,                &
          !$acc                   bulkRichardsonNumber,            &
          !$acc                   gmStreamFuncTopOfEdge,           &
-         !$acc                   indexSSHGradientZonal,           &
          !$acc                   relativeVorticityCell,           &
          !$acc                   normalGMBolusVelocity,           &
          !$acc                   normalMLEvelocity,               &
@@ -756,13 +772,9 @@ contains
          !$acc                   GMBolusVelocityMeridional,       &
          !$acc                   mleVelocityMeridional,           &
          !$acc                   bulkRichardsonNumberShear,       &
-         !$acc                   indexSurfaceVelocityZonal,       &
          !$acc                   normalVelocitySurfaceLayer,      &
-         !$acc                   index_vertNonLocalFluxTemp,      &
-         !$acc                   indexSSHGradientMeridional,      &
          !$acc                   transportVelocityMeridional,     &
          !$acc                   penetrativeTemperatureFluxOBL,   &
-         !$acc                   indexSurfaceVelocityMeridional,  &
          !$acc                   normalizedRelativeVorticityCell  &
          !$acc                   )
       end if
@@ -899,11 +911,7 @@ contains
       if ( trim(config_land_ice_flux_mode) /= 'off' ) then
          !$acc exit data delete(                                  &
          !$acc                   topDrag,                         &
-         !$acc                   indexBLT,                        &
-         !$acc                   indexBLS,                        &
          !$acc                   topDragMag,                      &
-         !$acc                   indexHeatTrans,                  &
-         !$acc                   indexSaltTrans,                  &
          !$acc                   landIceBoundaryLayerTracers,     &
          !$acc                   landIceTracerTransferVelocities, &
          !$acc                   landIceFrictionVelocity)
@@ -986,7 +994,6 @@ contains
          !$acc                   mleVelocityZonal,                &
          !$acc                   bulkRichardsonNumber,            &
          !$acc                   gmStreamFuncTopOfEdge,           &
-         !$acc                   indexSSHGradientZonal,           &
          !$acc                   relativeVorticityCell,           &
          !$acc                   normalGMBolusVelocity,           &
          !$acc                   normalMLEvelocity,               &
@@ -1006,13 +1013,9 @@ contains
          !$acc                   mleVelocityMeridional,           &
          !$acc                   GMBolusVelocityMeridional,       &
          !$acc                   bulkRichardsonNumberShear,       &
-         !$acc                   indexSurfaceVelocityZonal,       &
          !$acc                   normalVelocitySurfaceLayer,      &
-         !$acc                   index_vertNonLocalFluxTemp,      &
-         !$acc                   indexSSHGradientMeridional,      &
          !$acc                   transportVelocityMeridional,     &
          !$acc                   penetrativeTemperatureFluxOBL,   &
-         !$acc                   indexSurfaceVelocityMeridional,  &
          !$acc                   normalizedRelativeVorticityCell  &
          !$acc                   )
       end if
@@ -1118,10 +1121,6 @@ contains
       if ( trim(config_land_ice_flux_mode) /= 'off' ) then
          nullify(topDrag,                         &
                  topDragMag,                      &
-                 indexBLT,                        &
-                 indexBLS,                        &
-                 indexHeatTrans,                  &
-                 indexSaltTrans,                  &
                  landIceBoundaryLayerTracers,     &
                  landIceTracerTransferVelocities, &
                  landIceFrictionVelocity)
@@ -1194,7 +1193,6 @@ contains
                  mleVelocityZonal,                &
                  bulkRichardsonNumber,            &
                  gmStreamFuncTopOfEdge,           &
-                 indexSSHGradientZonal,           &
                  relativeVorticityCell,           &
                  normalGMBolusVelocity,           &
                  normalMLEvelocity,               &
@@ -1214,13 +1212,9 @@ contains
                  mleVelocityMeridional,           &
                  GMBolusVelocityMeridional,       &
                  bulkRichardsonNumberShear,       &
-                 indexSurfaceVelocityZonal,       &
                  normalVelocitySurfaceLayer,      &
-                 index_vertNonLocalFluxTemp,      &
-                 indexSSHGradientMeridional,      &
                  transportVelocityMeridional,     &
                  penetrativeTemperatureFluxOBL,   &
-                 indexSurfaceVelocityMeridional,  &
                  normalizedRelativeVorticityCell)
       end if
       if ( trim(config_ocean_run_mode) == 'forward' ) then

--- a/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
@@ -255,8 +255,10 @@ contains
       !-----------------------------------------------------------------
 
       integer :: iCell, k, nCells
-      integer, pointer :: indexTemperature
-      integer, pointer :: indexSalinity
+      integer, pointer :: indexTemperaturePtr
+      integer, pointer :: indexSalinityPtr
+      integer :: indexTemperature
+      integer :: indexSalinity
       integer, pointer, dimension(:) :: nCellsArray
       integer, pointer, dimension(:) :: minLevelCell, maxLevelCell
 
@@ -268,8 +270,12 @@ contains
       if ( .not. frazilFormationOn ) return
 
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
-      call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
-      call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
+      call mpas_pool_get_dimension(tracersPool, 'index_temperature', &
+                                                 indexTemperaturePtr)
+      call mpas_pool_get_dimension(tracersPool, 'index_salinity', &
+                                                 indexSalinityPtr)
+      indexTemperature = indexTemperaturePtr
+      indexSalinity    = indexSalinityPtr
 
       call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
       call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
@@ -379,8 +385,10 @@ contains
       real (kind=RKIND), pointer, dimension(:,:,:) :: activeTracers
 
       integer, dimension(:), pointer :: minLevelCell, maxLevelCell
-      integer, pointer :: indexTemperature !< index in tracers array for temperature
-      integer, pointer :: indexSalinity !< index in tracers array for salinity
+      integer, pointer :: indexTemperaturePtr !< index in tracers array for temperature
+      integer, pointer :: indexSalinityPtr !< index in tracers array for salinity
+      integer :: indexTemperature !< index in tracers array for temperature
+      integer :: indexSalinity !< index in tracers array for salinity
       integer :: kBottomFrazil  ! k index where testing for frazil begins
 
       logical :: underLandIce ! indicates if we are under land ice
@@ -400,8 +408,12 @@ contains
       ! get dimensions
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
-      call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
-      call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
+      call mpas_pool_get_dimension(tracersPool, 'index_temperature', &
+                                                 indexTemperaturePtr)
+      call mpas_pool_get_dimension(tracersPool, 'index_salinity', &
+                                                 indexSalinityPtr)
+      indexTemperature = indexTemperaturePtr
+      indexSalinity    = indexSalinityPtr
 
       ! get mesh information
       call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -150,7 +150,8 @@ contains
 
       type(mpas_pool_type), pointer :: tracersPool
       real(kind=RKIND), dimension(:, :, :), pointer :: activeTracers
-      integer, pointer :: indexTemperature, indexSalinity
+      integer, pointer :: indexTemperaturePtr, indexSalinityPtr
+      integer :: indexTemperature, indexSalinity
       integer :: timeLevel
 
       if (present(timeLevelIn)) then
@@ -166,8 +167,10 @@ contains
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
       call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, timeLevel)
-      call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperature)
-      call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
+      call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperaturePtr)
+      call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinityPtr)
+      indexTemperature = indexTemperaturePtr
+      indexSalinity    = indexSalinityPtr
 
       call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
       call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)

--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
@@ -456,7 +456,8 @@ contains
       !-----------------------------------------------------------------
 
       integer :: iCell, nCells
-      integer, pointer :: index_temperature_flux, index_salinity_flux
+      integer, pointer :: index_temperature_fluxPtr, index_salinity_fluxPtr
+      integer :: index_temperature_flux, index_salinity_flux
       integer, dimension(:), pointer :: nCellsArray
 
       type(mpas_pool_type),pointer :: tracersSurfaceFluxPool
@@ -477,8 +478,14 @@ contains
 
       call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceFlux',tracersSurfaceFluxPool)
 
-      call mpas_pool_get_dimension(tracersSurfaceFluxPool, 'index_temperatureSurfaceFlux', index_temperature_flux)
-      call mpas_pool_get_dimension(tracersSurfaceFluxPool, 'index_salinitySurfaceFlux', index_salinity_flux)
+      call mpas_pool_get_dimension(tracersSurfaceFluxPool, &
+                                  'index_temperatureSurfaceFlux', &
+                                   index_temperature_fluxPtr)
+      call mpas_pool_get_dimension(tracersSurfaceFluxPool, &
+                                  'index_salinitySurfaceFlux', &
+                                   index_salinity_fluxPtr)
+      index_temperature_flux = index_temperature_fluxPtr
+      index_salinity_flux    = index_salinity_fluxPtr
 
       call mpas_pool_get_array(forcingPool, 'latentHeatFlux', latentHeatFlux)
       call mpas_pool_get_array(forcingPool, 'sensibleHeatFlux', sensibleHeatFlux)

--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -443,7 +443,8 @@ contains
       real (kind=RKIND), dimension(:,:), pointer :: &
                                                     landIceInterfaceTracers
 
-      integer, pointer :: indexIT, indexIS
+      integer, pointer :: indexITPtr, indexISPtr
+      integer :: indexIT, indexIS
 
       ! Scratch Arrays
       !---
@@ -475,8 +476,14 @@ contains
       call mpas_pool_get_array(forcingPool, 'heatFluxToLandIce', heatFluxToLandIce)
 
       call mpas_pool_get_array(forcingPool, 'landIceInterfaceTracers', landIceInterfaceTracers)
-      call mpas_pool_get_dimension(forcingPool, 'index_landIceInterfaceTemperature', indexIT)
-      call mpas_pool_get_dimension(forcingPool, 'index_landIceInterfaceSalinity', indexIS)
+      call mpas_pool_get_dimension(forcingPool, &
+                                'index_landIceInterfaceTemperature', &
+                                 indexITPtr)
+      call mpas_pool_get_dimension(forcingPool, &
+                                'index_landIceInterfaceSalinity', &
+                                 indexISPtr)
+      indexIT = indexITPtr
+      indexIS = indexISPtr
       call mpas_pool_get_array(statePool, 'accumulatedLandIceMass', accumulatedLandIceMassNew, 2)
       call mpas_pool_get_array(statePool, 'accumulatedLandIceMass', accumulatedLandIceMassOld, 1)
       call mpas_pool_get_array(statePool, 'accumulatedLandIceHeat', accumulatedLandIceHeatNew, 2)

--- a/components/mpas-ocean/src/shared/mpas_ocn_time_average_coupled.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_time_average_coupled.F
@@ -209,7 +209,9 @@ module ocn_time_average_coupled
         real (kind=RKIND), dimension(:,:), pointer :: avgTracersSurfaceValue
         real (kind=RKIND), dimension(:,:), pointer :: avgSSHGradient
         integer :: iCell
-        integer, pointer :: index_temperature, index_SSHzonal, index_SSHmeridional, nAccumulatedCoupled, nCells
+        integer, pointer :: index_temperaturePtr, index_SSHzonalPtr, &
+                 index_SSHmeridionalPtr, nAccumulatedCoupled, nCells
+        integer :: index_temperature, index_SSHzonal, index_SSHmeridional
         real (kind=RKIND), dimension(:,:), pointer :: &
                                                       avgLandIceBoundaryLayerTracers, avgLandIceTracerTransferVelocities
         real (kind=RKIND), dimension(:), pointer :: effectiveDensityInLandIce, avgEffectiveDensityInLandIce, &
@@ -252,9 +254,18 @@ module ocn_time_average_coupled
         call mpas_pool_get_array(forcingPool, 'avgTotalFreshWaterTemperatureFlux', avgTotalFreshWaterTemperatureFlux)
 
         call mpas_pool_get_dimension(forcingPool, 'nCells', nCells)
-        call mpas_pool_get_dimension(forcingPool, 'index_avgTemperatureSurfaceValue', index_temperature)
-        call mpas_pool_get_dimension(forcingPool, 'index_avgSSHGradientZonal', index_SSHzonal)
-        call mpas_pool_get_dimension(forcingPool, 'index_avgSSHGradientMeridional', index_SSHmeridional)
+        call mpas_pool_get_dimension(forcingPool, &
+                                     'index_avgTemperatureSurfaceValue', &
+                                      index_temperaturePtr)
+        call mpas_pool_get_dimension(forcingPool, &
+                                     'index_avgSSHGradientZonal', &
+                                      index_SSHzonalPtr)
+        call mpas_pool_get_dimension(forcingPool, &
+                                     'index_avgSSHGradientMeridional', &
+                                      index_SSHmeridionalPtr)
+        index_temperature   = index_temperaturePtr
+        index_SSHzonal      = index_SSHzonalPtr
+        index_SSHmeridional = index_SSHmeridionalPtr
 
         call mpas_pool_get_array(forcingPool, 'nAccumulatedCoupled', nAccumulatedCoupled)
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_surface_restoring.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_surface_restoring.F
@@ -237,7 +237,9 @@ contains
 
         real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
 
-        integer, pointer :: nCells, nCellsSolve, indexSalinity, indexSalinitySurfaceRestoringValue
+        integer, pointer :: nCells, nCellsSolve
+        integer, pointer :: indexSalinityPtr, indexSalinitySurfaceRestoringValuePtr
+        integer :: indexSalinity, indexSalinitySurfaceRestoringValue
         integer :: iCell, timeLevel
         integer, dimension(:), pointer :: landIceMask
 
@@ -317,9 +319,14 @@ contains
 
         call mpas_pool_get_dimension(block % dimensions, 'nCells', nCells)
         call mpas_pool_get_dimension(block % dimensions, 'nCellsSolve', nCellsSolve)
-        call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
-        call mpas_pool_get_dimension(tracersSurfaceRestoringFieldsPool, 'index_salinitySurfaceRestoringValue',  &
-                                                                         indexSalinitySurfaceRestoringValue)
+        call mpas_pool_get_dimension(tracersPool, 'index_salinity', &
+                                                   indexSalinityPtr)
+        call mpas_pool_get_dimension(tracersSurfaceRestoringFieldsPool, &
+                                'index_salinitySurfaceRestoringValue',  &
+                                 indexSalinitySurfaceRestoringValuePtr)
+        indexSalinity = indexSalinityPtr
+        indexSalinitySurfaceRestoringValue = &
+                                 indexSalinitySurfaceRestoringValuePtr
         call mpas_pool_get_subpool(block % structs, 'surfaceSalinityMonthlyForcing',  &
                                                                   surfaceSalinityMonthlyForcing)
         call mpas_pool_get_array(surfaceSalinityMonthlyForcing, 'surfaceSalinityMonthlyClimatologyValue',   &
@@ -440,8 +447,11 @@ contains
         call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceRestoringFields',tracersSurfaceRestoringFieldsPool)
         call mpas_pool_get_array(tracersSurfaceRestoringFieldsPool, 'activeTracersSurfaceRestoringValue', &
            activeTracersSurfaceRestoringValue)
-        call mpas_pool_get_dimension(tracersSurfaceRestoringFieldsPool, 'index_salinitySurfaceRestoringValue',  &
-                                                                         indexSalinitySurfaceRestoringValue)
+        call mpas_pool_get_dimension(tracersSurfaceRestoringFieldsPool, &
+                                'index_salinitySurfaceRestoringValue',  &
+                                 indexSalinitySurfaceRestoringValuePtr)
+        indexSalinitySurfaceRestoringValue = &
+                                 indexSalinitySurfaceRestoringValuePtr
 
         do iCell = 1, nCells
           deltaS = activeTracersSurfaceRestoringValue(indexSalinitySurfaceRestoringValue,iCell)

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
@@ -612,7 +612,6 @@ contains
         integer :: fromNcId, fromNsDimId, fromRowId, fromColId, fromSId
         integer:: nMpasDimId, nGridDimId, toNsLen, fromNsLen
         character (len = NF90_MAX_NAME) :: toNsName, fromNsName, nMpasName, nGridName
-        integer, pointer :: n_s
         character(len=StrKIND) :: mpasToGridFile, gridToMpasFile
 
         ! SHTns routine variables

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -1299,12 +1299,15 @@ contains
                           tracerGroupSurfaceFlux)
                endif
 #ifdef MPAS_OPENACC
-            !$acc enter data copyin(tracerGroupSurfaceFlux)
+               !$acc enter data copyin(tracerGroupSurfaceFlux)
 #endif
 
                call ocn_tracer_vmix_tend_implicit(dt, vertDiffTopOfCell, layerThickness, tracersGroup, &
                         vertNonLocalFlux, tracerGroupSurfaceFlux,  &
                         config_cvmix_kpp_nonlocal_with_implicit_mix, err)
+#ifdef MPAS_OPENACC
+               !$acc exit data delete(tracerGroupSurfaceFlux)
+#endif
             end if
 
             ! difference tracers to compute influence of vertical mixing and divide by dt
@@ -1336,7 +1339,7 @@ contains
             endif
 
 #ifdef MPAS_OPENACC
-      !$acc exit data copyout(tracersGroup) delete(tracerGroupSurfaceFlux)
+      !$acc exit data copyout(tracersGroup)
 #endif
          end if
       end do


### PR DESCRIPTION
Pointers to integer scalars in MPAS retrievals were not being treated correctly in OpenACC for Frontier/Crusher and have often caused problems in the past with other compilers. These are now replaced in most cases by integer scalar variables, especially for tracer indices.

This has been tested on Summit, Crusher and passes the compass pr test suite with Intel on Chrysalis.

[bfb]
Fixes #5366 