### PR TITLE
Add MPAS standalone build target for Frontier/Crusher (cray-cray)

### DIFF
--- a/components/mpas-framework/Makefile
+++ b/components/mpas-framework/Makefile
@@ -447,18 +447,18 @@ cray-cray:
 	"CXX_SERIAL = CC" \
 	"FFLAGS_FPIEEE = -h flex_mp=rigorous" \
 	"FFLAGS_PROMOTION = -s real64" \
-	"FFLAGS_OPT = -g -O3 -h byteswapio -ef -f free -h noacc -em -M1077 -hipa0 -hzero " \
+	"FFLAGS_OPT = -g -O3 -h byteswapio -ef -f free -h noacc -em -M1077 -hipa0 -hzero" \
 	"CFLAGS_OPT = -O3 -h noacc" \
 	"CXXFLAGS_OPT = -O3 -h noacc" \
 	"LDFLAGS_OPT = -O3 -h noacc" \
-	"FFLAGS_ACC = -h acc -rm -ri " \
-	"CFLAGS_ACC = -h acc "  \
-	"FFLAGS_GPU = -DUSE_OMPOFFLOAD -homp -fopenmp " \
-	"LDFLAGS_GPU = -homp -fopenmp " \
-	"FFLAGS_DEBUG = -O0 -g -h byteswapio -ef -f free -Ktrap=divz,fp,inv,ovf " \
-	"CFLAGS_DEBUG = -O0 -g "\
-	"CXXFLAGS_DEBUG = -O0 -g " \
-	"LDFLAGS_DEBUG = -O0 -g -Ktrap=divz,fp,inv,ovf " \
+	"FFLAGS_ACC = -h acc -rm -ri" \
+	"CFLAGS_ACC = -h acc"  \
+	"FFLAGS_GPU = -DUSE_OMPOFFLOAD -homp -fopenmp" \
+	"LDFLAGS_GPU = -homp -fopenmp" \
+	"FFLAGS_DEBUG = -O0 -g -h byteswapio -ef -f free -Ktrap=divz,fp,inv,ovf" \
+	"CFLAGS_DEBUG = -O0 -g" \
+	"CXXFLAGS_DEBUG = -O0 -g" \
+	"LDFLAGS_DEBUG = -O0 -g -Ktrap=divz,fp,inv,ovf" \
 	"FFLAGS_OMP = -h omp" \
 	"CFLAGS_OMP = -h omp" \
 	"PICFLAG = -f pic" \

--- a/components/mpas-framework/Makefile
+++ b/components/mpas-framework/Makefile
@@ -437,6 +437,41 @@ intel-cray:
 	"USE_SHTNS = $(USE_SHTNS)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
+cray-cray:
+	( $(MAKE) all \
+	"FC_PARALLEL = ftn" \
+	"CC_PARALLEL = cc" \
+	"CXX_PARALLEL = CC" \
+	"FC_SERIAL = ftn" \
+	"CC_SERIAL = cc" \
+	"CXX_SERIAL = CC" \
+	"FFLAGS_FPIEEE = -h flex_mp=rigorous" \
+	"FFLAGS_PROMOTION = -s real64" \
+	"FFLAGS_OPT = -g -O3 -h byteswapio -ef -f free -h noacc -em -M1077 -hipa0 -hzero " \
+	"CFLAGS_OPT = -O3 -h noacc" \
+	"CXXFLAGS_OPT = -O3 -h noacc" \
+	"LDFLAGS_OPT = -O3 -h noacc" \
+	"FFLAGS_ACC = -h acc -rm -ri " \
+	"CFLAGS_ACC = -h acc "  \
+	"FFLAGS_GPU = -DUSE_OMPOFFLOAD -homp -fopenmp " \
+	"LDFLAGS_GPU = -homp -fopenmp " \
+	"FFLAGS_DEBUG = -O0 -g -h byteswapio -ef -f free -Ktrap=divz,fp,inv,ovf " \
+	"CFLAGS_DEBUG = -O0 -g "\
+	"CXXFLAGS_DEBUG = -O0 -g " \
+	"LDFLAGS_DEBUG = -O0 -g -Ktrap=divz,fp,inv,ovf " \
+	"FFLAGS_OMP = -h omp" \
+	"CFLAGS_OMP = -h omp" \
+	"PICFLAG = -f pic" \
+	"BUILD_TARGET = $(@)" \
+	"CORE = $(CORE)" \
+	"DEBUG = $(DEBUG)" \
+	"USE_PAPI = $(USE_PAPI)" \
+	"OPENMP = $(OPENMP)" \
+	"OPENACC = $(OPENACC)" \
+	"OPENMP_OFFLOAD = $(OPENMP_OFFLOAD)" \
+	"USE_SHTNS = $(USE_SHTNS)" \
+	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
+
 llvm:
 	( $(MAKE) all \
 	"FC_PARALLEL = mpifort" \


### PR DESCRIPTION
Added standalone build target for Cray fortran compiler and Cray wrapper suitable for Frontier/Crusher. With the new target convention, this PR is just cray-cray...

Only affects MPAS standalone builds outside of E3SM

[bfb]