### PR TITLE
Update module versions for pm-cpu and pm-gpu after machine maintenance

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -237,10 +237,10 @@
         <command name="load">craype-accel-host</command>
         <command name="load">cray-libsci</command>
         <command name="load">craype</command>
-        <command name="load">cray-mpich/8.1.17</command>
-        <command name="load">cray-hdf5-parallel/1.12.1.5</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.8.1.5</command>
-        <command name="load">cray-parallel-netcdf/1.12.2.5</command>
+        <command name="load">cray-mpich/8.1.22</command>
+        <command name="load">cray-hdf5-parallel/1.12.2.1</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.9.0.1</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.1</command>
         <command name="load">cmake/3.22.0</command>
       </modules>
     </module_system>
@@ -359,10 +359,10 @@
       <modules>
         <command name="load">cray-libsci</command>
         <command name="load">craype</command>
-        <command name="load">cray-mpich/8.1.17</command>
-        <command name="load">cray-hdf5-parallel/1.12.1.5</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.8.1.5</command>
-        <command name="load">cray-parallel-netcdf/1.12.2.5</command>
+        <command name="load">cray-mpich/8.1.22</command>
+        <command name="load">cray-hdf5-parallel/1.12.2.1</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.9.0.1</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.1</command>
         <command name="load">cmake/3.22.0</command>
       </modules>
     </module_system>


### PR DESCRIPTION
After maintenance, NERSC not only added new module versions, but also deleted previous versions that E3SM was using. Therefore, this is necessary to use the machine.

I tested e3sm_developer on pm-cpu and one basic test on pm-gpu.

