### PR TITLE
Ocean SI code - Update and bug fix

### DIFF
--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -853,6 +853,8 @@ module ocn_forward_mode
 
       if ( config_time_integrator == 'split_explicit') then
          call mpas_dmpar_exch_group_destroy_reusable_buffers(domain, 'subcycleFields')
+      else if ( config_time_integrator == 'split_implicit') then
+         call ocn_time_integrator_si_variable_destroy()
       end if
 
       call ocn_analysis_finalize(domain, ierr)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -71,9 +71,10 @@ module ocn_time_integration_si
    !
    !--------------------------------------------------------------------
 
-   public :: ocn_time_integrator_si, &
-             ocn_time_integration_si_init, &
-             ocn_time_integrator_si_preconditioner
+   public :: ocn_time_integrator_si,                  &
+             ocn_time_integration_si_init,            &
+             ocn_time_integrator_si_preconditioner,   &
+             ocn_time_integrator_si_variable_destroy
 
    !--------------------------------------------------------------------
    !
@@ -3286,6 +3287,13 @@ module ocn_time_integration_si
          call mpas_log_write( &
          '       (Default is sbicg.)')
          si_algorithm = 'scg'
+
+         ! Allocate temporary arrays for reproducible summation
+         allocate( globalReprodSum2fld1(nCellsOwned,2),  &
+                   globalReprodSum2fld2(nCellsOwned,2),  &
+                   globalReprodSum3fld1(nCellsOwned,3),  &
+                   globalReprodSum3fld2(nCellsOwned,3) )
+
       endif
 
       ! Restricted Additive Schwarz preconditioner --------------------!
@@ -4230,6 +4238,33 @@ module ocn_time_integration_si
      !-------------------------------------------------------------!
 
    end subroutine si_solver_sbicg !}}}
+
+!***********************************************************************
+!
+!  routine ocn_time_integrator_si_variable_destroy
+!
+!> \brief   Destroy SI-related variables including CPU & GPU arrays
+!
+!> \author  Hyun-Gyu Kang
+!
+!> \details
+!   This routine deallocates CPU arrays and deletes GPU arrays
+!   allocated in the SI solver.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_time_integrator_si_variable_destroy()
+
+      integer :: info
+
+      if ( config_btr_si_partition_match_mode ) then
+         deallocate( globalReprodSum2fld1,  &
+                     globalReprodSum2fld2,  &
+                     globalReprodSum3fld1,  &
+                     globalReprodSum3fld2 )
+      endif
+
+   end subroutine ocn_time_integrator_si_variable_destroy
 
 !***********************************************************************
 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -4231,8 +4231,6 @@ module ocn_time_integration_si
 
    subroutine ocn_time_integrator_si_variable_destroy()
 
-      integer :: info
-
       if ( config_btr_si_partition_match_mode ) then
          deallocate( globalReprodSum2fld1,  &
                      globalReprodSum2fld2,  &

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -1933,10 +1933,10 @@ module ocn_time_integration_si
          if (splitImplicitStep < numTSIterations) then
 
             ! Get indices for dynamic tracers (Includes T&S).
-            call mpas_pool_get_dimension(tracersPool,'activeGRP_start',&
-                                                      startIndex)
-            call mpas_pool_get_dimension(tracersPool,'activeGRP_end', &
-                                                      endIndex)
+            call mpas_pool_get_dimension_scalar(tracersPool,'activeGRP_start',&
+                                                             startIndex)
+            call mpas_pool_get_dimension_scalar(tracersPool,'activeGRP_end', &
+                                                             endIndex)
 
             ! Only need T & S for earlier iterations,
             ! then all the tracers needed the last time through.

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -653,20 +653,6 @@ module ocn_time_integration_si
          call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
       endif
 
-      if ( config_btr_si_partition_match_mode ) then
-         if (si_algorithm == 'sbicg' ) then
-            allocate( globalReprodSum2fld1(nCellsOwned,2),  &
-                      globalReprodSum2fld2(nCellsOwned,2),  &
-                      globalReprodSum9fld1(nCellsOwned,9),  &
-                      globalReprodSum9fld2(nCellsOwned,9) )
-         else if ( si_algorithm == 'scg' ) then
-            allocate( globalReprodSum2fld1(nCellsOwned,2),  &
-                      globalReprodSum2fld2(nCellsOwned,2),  &
-                      globalReprodSum3fld1(nCellsOwned,3),  &
-                      globalReprodSum3fld2(nCellsOwned,3) )
-         endif
-      endif
-
 #ifdef MPAS_OPENACC
       !$acc exit data delete(normalVelocityCur, normalBarotropicVelocityCur, &
       !$acc    sshCur, layerThicknessCur)
@@ -2484,16 +2470,6 @@ module ocn_time_integration_si
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       ! END large iteration loop
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-      if ( config_btr_si_partition_match_mode ) then
-         if ( si_algorithm == 'sbicg' ) then
-            deallocate( globalReprodSum2fld1,globalReprodSum2fld2,  &
-                        globalReprodSum9fld1,globalReprodSum9fld2 )
-         else if ( si_algorithm == 'scg' ) then
-            deallocate( globalReprodSum2fld1,globalReprodSum2fld2,  &
-                        globalReprodSum3fld1,globalReprodSum3fld2 )
-         end if
-      endif
 
       call mpas_timer_start("si implicit vert mix")
 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -47,6 +47,8 @@ module ocn_time_integration_si
 
    use ocn_equation_of_state
    use ocn_vmix
+   use ocn_vertical_advection
+   use ocn_vertical_remap
    use ocn_time_average_coupled
 
    use ocn_effective_density_in_land_ice
@@ -245,7 +247,8 @@ module ocn_time_integration_si
          uTemp
 
       real (kind=RKIND), dimension(:), allocatable :: &
-         btrvel_temp
+         btrvel_temp, &
+         bottomDepthEdge
 
       ! State Array Pointers
       real (kind=RKIND), dimension(:), pointer :: &
@@ -283,7 +286,7 @@ module ocn_time_integration_si
          tracersGroupCur,      &! old, new tracer arrays
          tracersGroupNew
 
-      integer, pointer :: &
+      integer :: &
          startIndex, endIndex, &! start, end index for tracer groups
          indexSalinity          ! tracer index for salinity
 
@@ -322,6 +325,10 @@ module ocn_time_integration_si
 
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracersNew
 
+      ! Remap variables
+      real (kind=RKIND), dimension(:,:), pointer :: &
+         layerThicknessLagNew
+
       ! Semi-implicit variables
       real (kind=RKIND) ::  &        !  temp scalars for the SI method
          SIcst_q0y0_global , SIcst_y0y0_global , SIcst_q0q0_global , &
@@ -354,6 +361,7 @@ module ocn_time_integration_si
       ! activeTracerNonLocalTendency
       ! activeTracerHorMixTendency
       ! activeTracerHorizontalAdvectionEdgeFlux
+      ! vertVelocityTop
 
       ! End preamble
       !-----------------------------------------------------------------
@@ -432,8 +440,8 @@ module ocn_time_integration_si
       call mpas_pool_get_array(statePool, 'lowFreqDivergence', &
                                            lowFreqDivergenceNew, 2)
 
-      call mpas_pool_get_dimension(tracersPool, 'index_salinity', &
-                                                 indexSalinity)
+      call mpas_pool_get_dimension_scalar(tracersPool, 'index_salinity', &
+                                                        indexSalinity)
 
       !*** Retrieve tendency variables
 
@@ -453,6 +461,8 @@ module ocn_time_integration_si
                                           lowFreqDivergenceTend)
 
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracersNew, 2)
+
+      allocate(bottomDepthEdge(nEdgesAll+1))
 
       if (config_transport_tests_flow_id > 0) then
         ! This is a transport test. Write advection velocity from prescribed
@@ -816,11 +826,14 @@ module ocn_time_integration_si
 
             allocate(uTemp(nVertLevels,nEdgesOwned))
 
-            !$omp parallel 
-            !$omp do schedule(runtime)
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(k, cell1, cell2, uTemp, &
+            !$omp         normalThicknessFluxSum, thicknessSum)
             do iEdge = 1, nEdgesOwned
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
+               ! could put this after with uTemp(maxleveledgetop+1:nvertlevels)=0
                uTemp(:,iEdge) = 0.0_RKIND
                do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                   ! normalBaroclinicVelocityNew =
@@ -835,16 +848,8 @@ module ocn_time_integration_si
                            + gravity * &
                              (sshNew(cell2) - sshNew(cell1)) &
                              /dcEdge(iEdge) )
-               end do
-            end do
-            !$omp end do
-            !$omp end parallel
+               enddo ! vertical
 
-            !$omp parallel
-            !$omp do schedule(runtime) &
-            !$omp private(k, cell1, cell2, &
-            !$omp         normalThicknessFluxSum, thicknessSum)
-            do iEdge = 1, nEdgesOwned
                ! thicknessSum is initialized outside the loop because
                ! on land boundaries maxLevelEdgeTop=0, but we want to
                ! initialize thicknessSum with a nonzero value to avoid
@@ -876,6 +881,23 @@ module ocn_time_integration_si
                          dt * barotropicForcing(iEdge))
                enddo
 
+            enddo ! iEdge
+            !$omp end do
+            !$omp end parallel
+
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(cell1, cell2, k, thicknessSum)
+            do iEdge = 1, nEdgesHalo(config_num_halos+1)
+               cell1 = cellsOnEdge(1,iEdge)
+               cell2 = cellsOnEdge(2,iEdge)
+               thicknessSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
+               do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
+                  thicknessSum = thicknessSum + &
+                                 layerThickEdgeFlux(k,iEdge)
+               enddo
+               bottomDepthEdge(iEdge) = thicknessSum &
+                  - 0.5_RKIND*(sshNew(cell1) + sshNew(cell2))
             enddo ! iEdge
             !$omp end do
             !$omp end parallel
@@ -1667,22 +1689,22 @@ module ocn_time_integration_si
          ! {\bf u}_k^{avg} \right)
          ! \left/ \sum_{k=1}^{N^{edge}} h_{k,*}^{edge}   \right.
 
+         !Compute uTemp
+         ! velocity for normalVelocityCorrection is
+         ! normalBarotropicVelocity +
+         ! normalBaroclinicVelocity + uBolus
          nEdges = nEdgesHalo(config_num_halos-1 )
          allocate(uTemp(nVertLevels,nEdges))
 
          !$omp parallel
          !$omp do schedule(runtime)
          do iEdge = 1, nEdges
-            ! velocity for normalVelocityCorrectionection is
-            ! normalBarotropicVelocity +
-            ! normalBaroclinicVelocity + uBolus
             uTemp(:,iEdge) = normalBarotropicVelocityNew(iEdge) &
                          + normalBaroclinicVelocityNew(:,iEdge)
          end do
          !$omp end do
          !$omp end parallel
 
-         !add GM and submesoscale contributions if requested
          call ocn_GM_add_to_transport_vel(uTemp, nEdges, nVertLevels)
          call ocn_MLE_add_to_transport_vel(uTemp, nEdges)
 
@@ -1700,7 +1722,8 @@ module ocn_time_integration_si
          !$omp end parallel
 
          ! add GM and submesoscale contributions if requested
-         call ocn_GM_add_to_transport_vel(normalTransportVelocity, nEdges, nVertLevels)
+         call ocn_GM_add_to_transport_vel(normalTransportVelocity, nEdges, &
+                                          nVertLevels)
          call ocn_MLE_add_to_transport_vel(normalTransportVelocity, nEdges)
 
          !$omp parallel
@@ -1736,13 +1759,10 @@ module ocn_time_integration_si
                ! normalTransportVelocity = normalBarotropicVelocity
                !                         + normalBaroclinicVelocity
                !                         + normalGMBolusVelocity
+               !                         + normalMLEvelocity 
                !                         + normalVelocityCorrection
                ! This is u used in advective terms for layerThickness
                ! and tracers in tendency calls in stage 3.
-               !mrp note: in QC version, there is an if
-               !    (config_use_GM) on adding normalGMBolusVelocity
-               !    I think it is not needed because
-               !    normalGMBolusVelocity=0 when GM not on.
                normalTransportVelocity(k,iEdge) = edgeMask(k,iEdge) &
                         *(normalTransportVelocity(k,iEdge) + & 
                           normalVelocityCorrection )
@@ -1758,10 +1778,9 @@ module ocn_time_integration_si
 
          call mpas_timer_stop("si btr vel")
 
-
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-         !  Stage 3: Tracer, density, pressure, vertical velocity prediction
-         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+         ! Stage 3: Tracer, density, pressure, vert velocity prediction
+         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
          ! only compute tendencies for active tracers on last large iteration
          if (splitImplicitStep < numTSIterations) then
@@ -1826,6 +1845,64 @@ module ocn_time_integration_si
                               meshPool, swForcingPool, &
                               dt, activeTracersOnly, 2)
 
+         call mpas_pool_get_array(tracersPool, 'activeTracers', &
+                                                tracersGroupCur, 1)
+         call mpas_pool_get_array(tracersPool, 'activeTracers', &
+                                                tracersGroupNew, 2)
+         call mpas_pool_get_array(statePool,   'normalVelocity', &
+                                                normalVelocityCur, 1)
+         call mpas_pool_get_array(tracersTendPool,'activeTracersTend', &
+                                                   activeTracersTend)
+
+#ifdef MPAS_OPENACC
+         !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
+         !$acc enter data copyin(normalBarotropicVelocityNew, &
+         !$acc                   normalBaroclinicVelocityNew)
+         !$acc enter data copyin(activeTracersNew)
+         !$acc update device(layerThickEdgeFlux)
+         if (config_use_freq_filtered_thickness) then
+            !$acc enter data copyin(lowFreqDivergenceNew)
+            !$acc enter data copyin(lowFreqDivergenceCur)
+            !$acc enter data copyin(lowFreqDivergenceTend)
+         endif
+         if (splitImplicitStep < numTSIterations) then
+            !$acc update device (normalTransportVelocity)
+            !$acc enter data copyin(atmosphericPressure, seaIcePressure)
+            !$acc enter data copyin(sshNew)
+            !$acc update device(tracersSurfaceValue)
+            if ( associated(normalGMBolusVelocity) ) then
+               !$acc update device (normalGMBolusVelocity)
+            end if
+            if ( associated(normalMLEVelocity) ) then
+               !$acc update device (normalMLEvelocity)
+            end if
+            if ( associated(frazilSurfacePressure) ) then
+               !$acc enter data copyin(frazilSurfacePressure)
+            endif
+            if (landIcePressureOn) then
+               !$acc enter data copyin(landIcePressure)
+               !$acc enter data copyin(landIceDraft)
+            endif
+            if (config_use_freq_filtered_thickness) then
+               !$acc enter data copyin(highFreqThicknessNew)
+               !$acc enter data copyin(highFreqThicknessCur)
+            endif
+         elseif (splitImplicitStep == numTSIterations) then
+            !$acc enter data copyin(layerThicknessCur)
+            !$acc enter data copyin(layerThicknessTend)
+            !$acc enter data copyin(normalBaroclinicVelocityCur)
+            if (config_compute_active_tracer_budgets) then
+               !$acc update device(activeTracerHorizontalAdvectionEdgeFlux)
+               !$acc update device(activeTracerHorizontalAdvectionTendency)
+               !$acc update device(activeTracerVerticalAdvectionTendency)
+               !$acc update device(activeTracerHorMixTendency)
+               !$acc update device(activeTracerSurfaceFluxTendency)
+               !$acc update device(temperatureShortWaveTendency)
+               !$acc update device(activeTracerNonLocalTendency)
+            endif
+         endif
+#endif
+
          call mpas_timer_stop('si tracer tend')
 
          ! update halo for tracer tendencies
@@ -1848,14 +1925,6 @@ module ocn_time_integration_si
          call mpas_timer_stop("si halo tracers")
 
          call mpas_timer_start('si loop fini')
-         call mpas_pool_get_array(tracersPool, 'activeTracers', &
-                                                tracersGroupCur, 1)
-         call mpas_pool_get_array(tracersPool, 'activeTracers', &
-                                                tracersGroupNew, 2)
-         call mpas_pool_get_array(statePool,   'normalVelocity', &
-                                                normalVelocityCur, 1)
-         call mpas_pool_get_array(tracersTendPool,'activeTracersTend', &
-                                                   activeTracersTend)
 
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
          !  If iterating, reset variables for next iteration
@@ -1872,8 +1941,15 @@ module ocn_time_integration_si
             ! Only need T & S for earlier iterations,
             ! then all the tracers needed the last time through.
 
+!! Keeping this calc on the CPU for now
+#ifdef MPAS_OPENACC
+            !$acc update host(layerThicknessNew)
+            !$acc update host(activeTracersNew)
+            !$acc update host(tracersSurfaceValue)
+#else
             !$omp parallel
             !$omp do schedule(runtime) private(i, k, temp_h, temp)
+#endif
             do iCell = 1, nCellsAll
             do k = minLevelCell(iCell), maxLevelCell(iCell)
 
@@ -1897,38 +1973,14 @@ module ocn_time_integration_si
                end do ! tracer index
             end do ! vertical
             end do ! iCell
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
+#endif
 
 #ifdef MPAS_OPENACC
-            !$acc enter data copyin(layerThicknessNew, normalVelocityNew)
-            !$acc update device (normalTransportVelocity)
-            if (config_use_gm) then
-               !$acc update device (normalGMBolusVelocity)
-            end if
-            if (config_submesoscale_enable) then
-               !$acc update device (normalMLEvelocity)
-            end if
-            !$acc enter data copyin(atmosphericPressure, seaIcePressure)
-            !$acc enter data copyin(sshNew)
-            !$acc enter data copyin(activeTracersNew)
-            !$acc update device(tracersSurfaceValue)
-            if ( associated(frazilSurfacePressure) ) then
-               !$acc enter data copyin(frazilSurfacePressure)
-            endif
-            if (landIcePressureOn) then
-               !$acc enter data copyin(landIcePressure)
-               !$acc enter data copyin(landIceDraft)
-            endif
-            !$acc enter data copyin(normalBarotropicVelocityNew, &
-            !$acc                   normalBaroclinicVelocityNew)
-            if (config_use_freq_filtered_thickness) then 
-               !$acc enter data copyin(highFreqThicknessNew)
-               !$acc enter data copyin(highFreqThicknessCur)
-               !$acc enter data copyin(lowFreqDivergenceNew)
-               !$acc enter data copyin(lowFreqDivergenceCur)
-               !$acc enter data copyin(lowFreqDivergenceTend)
-            endif
+            !$acc update device(layerThicknessNew)
+            !$acc update device(activeTracersNew)
 #endif
 
             if (config_use_freq_filtered_thickness) then
@@ -2000,53 +2052,6 @@ module ocn_time_integration_si
             call ocn_diagnostic_solve(dt, statePool, forcingPool, &
                                       meshPool, scratchPool, &
                                       tracersPool, 2, full=.false.)
-#ifdef MPAS_OPENACC
-            !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
-            !$acc update host(relativeVorticity, circulation)
-            if (config_use_gm) then
-               !$acc update host(vertGMBolusVelocityTop)
-            end if
-            if (config_submesoscale_enable) then
-               !$acc update host(vertMLEBolusVelocityTop)
-            end if
-            !$acc update host(vertTransportVelocityTop, &
-            !$acc             relativeVorticityCell, &
-            !$acc             divergence, &
-            !$acc             kineticEnergyCell, &
-            !$acc             tangentialVelocity, &
-            !$acc             vertVelocityTop)
-            !$acc update host(normRelVortEdge, normPlanetVortEdge, &
-            !$acc             normalizedRelativeVorticityCell)
-            !$acc update host (surfacePressure)
-            !$acc update host(zMid, zTop)
-            !$acc exit data copyout(sshNew)
-            !$acc exit data delete(activeTracersNew)
-            !$acc update host(tracersSurfaceValue)
-            !$acc update host(normalVelocitySurfaceLayer)
-            !$acc exit data delete (atmosphericPressure, seaIcePressure)
-            if ( associated(frazilSurfacePressure) ) then
-               !$acc exit data delete(frazilSurfacePressure)
-            endif
-            if (landIcePressureOn) then
-               !$acc exit data delete(landIcePressure)
-               !$acc exit data delete(landIceDraft)
-            endif
-            !$acc exit data delete(layerThicknessNew)
-            !$acc exit data delete(normalBarotropicVelocityNew, &
-            !$acc                  normalBaroclinicVelocityNew)
-            !$acc exit data copyout(normalVelocityNew)
-            !$acc update host(density, potentialDensity, displacedDensity)
-            !$acc update host(thermExpCoeff,  &
-            !$acc&            salineContractCoeff)
-            !$acc update host(montgomeryPotential, pressure)
-            if (config_use_freq_filtered_thickness) then
-               !$acc exit data copyout(highFreqThicknessNew)
-               !$acc exit data delete(highFreqThicknessCur)
-               !$acc exit data copyout(lowFreqDivergenceNew)
-               !$acc exit data delete(lowFreqDivergenceCur)
-               !$acc exit data delete(lowFreqDivergenceTend)
-            endif
-#endif
 
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
          ! If large iteration complete, compute all variables at
@@ -2055,9 +2060,32 @@ module ocn_time_integration_si
 
          elseif (splitImplicitStep == numTSIterations) then
 
+#ifdef MPAS_OPENACC
+            !$acc parallel present(minLevelCell, maxLevelCell) &
+            !$acc   present(layerThicknessTend) &
+            !$acc   present(layerThicknessCur) &
+            !$acc   present(minLevelEdgeBot, maxLevelEdgeTop) &
+            !$acc   present(layerThickEdgeFlux) &
+            !$acc   present(activeTracerHorizontalAdvectionEdgeFlux) &
+            !$acc   present(layerThicknessNew) &
+            !$acc   present(activeTracerHorizontalAdvectionTendency) &
+            !$acc   present(activeTracerVerticalAdvectionTendency) &
+            !$acc   present(activeTracerHorMixTendency) &
+            !$acc   present(activeTracerSurfaceFluxTendency) &
+            !$acc   present(temperatureShortWaveTendency) &
+            !$acc   present(activeTracerNonLocalTendency)
+#endif
+
+#ifdef MPAS_OPENACC
+            !$acc loop gang
+#else
             !$omp parallel
             !$omp do schedule(runtime) private(k)
+#endif
             do iCell = 1, nCellsAll
+#ifdef MPAS_OPENACC
+            !$acc loop vector
+#endif
             do k = minLevelCell(iCell), maxLevelCell(iCell)
                ! this is h_{n+1}
                layerThicknessNew(k,iCell) = &
@@ -2072,20 +2100,62 @@ module ocn_time_integration_si
 
             if (config_compute_active_tracer_budgets) then
 
+#ifdef MPAS_OPENACC
+               !$acc loop gang
+#else
                !$omp parallel
                !$omp do schedule(runtime) private(k)
+#endif
                do iEdge = 1, nEdgesAll
+#ifdef MPAS_OPENACC
+               !$acc loop seq
+#endif
                do k= minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-                  activeTracerHorizontalAdvectionEdgeFlux(:,k,iEdge) = &
-                  activeTracerHorizontalAdvectionEdgeFlux(:,k,iEdge) / &
-                       layerThickEdgeFlux(k,iEdge)
+#ifdef MPAS_OPENACC
+               !$acc loop vector
+#endif
+                  do iTracer = 1, size(activeTracerHorizontalAdvectionEdgeFlux,1)
+                     activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = &
+                     activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) / &
+                          layerThickEdgeFlux(k,iEdge)
+                  enddo
                enddo
                enddo
+#ifndef MPAS_OPENACC
                !$omp end do
+#endif
 
+#ifdef MPAS_OPENACC
+               !$acc loop gang
+#else
                !$omp do schedule(runtime) private(k)
+#endif
                do iCell = 1, nCellsAll
                do k= minLevelCell(iCell), maxLevelCell(iCell)
+#ifdef MPAS_OPENACC
+               !$acc loop vector
+                  do iTracer = 1, size(activeTracerHorizontalAdvectionTendency,1)
+                     activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) = &
+                     activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) / &
+                               layerThicknessNew(k,iCell)
+
+                     activeTracerVerticalAdvectionTendency(iTracer,k,iCell) = &
+                     activeTracerVerticalAdvectionTendency(iTracer,k,iCell) / &
+                               layerThicknessNew(k,iCell)
+
+                     activeTracerHorMixTendency(iTracer,k,iCell) = &
+                     activeTracerHorMixTendency(iTracer,k,iCell) / &
+                                layerThicknessNew(k,iCell)
+
+                     activeTracerSurfaceFluxTendency(iTracer,k,iCell) = &
+                     activeTracerSurfaceFluxTendency(iTracer,k,iCell) / &
+                                layerThicknessNew(k,iCell)
+
+                     activeTracerNonLocalTendency(iTracer,k,iCell) = &
+                     activeTracerNonLocalTendency(iTracer,k,iCell) / &
+                                layerThicknessNew(k,iCell)
+                  end do
+#else
                   activeTracerHorizontalAdvectionTendency(:,k,iCell) = &
                   activeTracerHorizontalAdvectionTendency(:,k,iCell) / &
                             layerThicknessNew(k,iCell)
@@ -2102,12 +2172,13 @@ module ocn_time_integration_si
                   activeTracerSurfaceFluxTendency(:,k,iCell) / &
                              layerThicknessNew(k,iCell)
 
-                  temperatureShortWaveTendency(k,iCell) = &
-                  temperatureShortWaveTendency(k,iCell) / &
-                             layerThicknessNew(k,iCell)
-
                   activeTracerNonLocalTendency(:,k,iCell) = &
                   activeTracerNonLocalTendency(:,k,iCell) / &
+                             layerThicknessNew(k,iCell)
+#endif
+
+                  temperatureShortWaveTendency(k,iCell) = &
+                  temperatureShortWaveTendency(k,iCell) / &
                              layerThicknessNew(k,iCell)
                end do
                end do
@@ -2116,6 +2187,18 @@ module ocn_time_integration_si
                !$omp end parallel
 #endif
             endif
+
+#ifdef MPAS_OPENACC
+            !$acc end parallel
+#endif
+
+! This tracer block is still computed on the CPU
+#ifdef MPAS_OPENACC
+            !$acc update host(layerThicknessNew)
+            !$acc update host(layerThicknessCur, layerThicknessTend)
+            !$acc update host(activeTracersNew)
+            !$acc update host(tracersSurfaceValue)
+#endif
 
             call mpas_pool_begin_iteration(tracersPool)
             do while (mpas_pool_get_next_member(tracersPool, &
@@ -2231,10 +2314,29 @@ module ocn_time_integration_si
                end if ! tracer
             end do ! tracer group
 
+#ifdef MPAS_OPENACC
+            !$acc update device(layerThicknessNew)
+            !$acc update device(activeTracersNew)
+#endif
+
             if (config_use_freq_filtered_thickness) then
+#ifdef MPAS_OPENACC
+               !$acc parallel present(minLevelCell, maxLevelCell) &
+               !$acc   present(lowFreqDivergenceNew) &
+               !$acc   present(lowFreqDivergenceCur) &
+               !$acc   present(lowFreqDivergenceTend)
+#endif
+
+#ifdef MPAS_OPENACC
+               !$acc loop gang
+#else
                !$omp parallel
                !$omp do schedule(runtime) private(k)
+#endif
                do iCell = 1, nCellsAll
+#ifdef MPAS_OPENACC
+               !$acc loop vector
+#endif
                do k = minLevelCell(iCell), maxLevelCell(iCell)
 
                   ! h^{hf}_{n+1} was computed in Stage 1
@@ -2249,6 +2351,11 @@ module ocn_time_integration_si
                !$omp end do
                !$omp end parallel
 #endif
+
+#ifdef MPAS_OPENACC
+               !$acc end parallel
+#endif
+
             end if
 
             ! Recompute final u to go on to next step.
@@ -2267,9 +2374,24 @@ module ocn_time_integration_si
             ! so normalBaroclinicVelocity does not have to be
             ! recomputed here.
 
+#ifdef MPAS_OPENACC
+            !$acc parallel present(minLevelEdgeBot, maxLevelEdgeTop) &
+            !$acc   present(normalVelocityNew) &
+            !$acc   present(normalBarotropicVelocityNew) &
+            !$acc   present(normalBaroclinicVelocityNew) &
+            !$acc   present(normalBaroclinicVelocityCur)
+#endif
+
+#ifdef MPAS_OPENACC
+            !$acc loop gang
+#else
             !$omp parallel
             !$omp do schedule(runtime) private(k)
+#endif
             do iEdge = 1, nEdgesAll
+#ifdef MPAS_OPENACC
+            !$acc loop vector
+#endif
             do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                normalVelocityNew(k,iEdge) = &
                                normalBarotropicVelocityNew(iEdge) + &
@@ -2282,12 +2404,82 @@ module ocn_time_integration_si
             !$omp end parallel
 #endif
 
-            endif ! splitImplicitStep
+#ifdef MPAS_OPENACC
+            !$acc end parallel
+#endif
+
+         endif ! splitImplicitStep
+
+#ifdef MPAS_OPENACC
+         !$acc exit data copyout(layerThicknessNew)
+         !$acc exit data copyout(normalVelocityNew)
+         !$acc exit data delete(normalBarotropicVelocityNew, &
+         !$acc                  normalBaroclinicVelocityNew)
+         !$acc exit data copyout(activeTracersNew)
+         !$acc update host(layerThickEdgeFlux)
+         if (config_use_freq_filtered_thickness) then
+            !$acc exit data copyout(lowFreqDivergenceNew)
+            !$acc exit data delete(lowFreqDivergenceCur)
+            !$acc exit data delete(lowFreqDivergenceTend)
+         endif
+         if (splitImplicitStep < numTSIterations) then
+            if (config_use_gm) then
+               !$acc update host(vertGMBolusVelocityTop)
+            end if
+            if (config_submesoscale_enable) then
+               !$acc update host(vertMLEBolusVelocityTop)
+            end if
+            !$acc exit data delete (atmosphericPressure, seaIcePressure)
+            !$acc exit data copyout(sshNew)
+            !$acc update host(layerThickEdgeMean)
+            !$acc update host(relativeVorticity, circulation)
+            !$acc update host(vertTransportVelocityTop, &
+            !$acc             relativeVorticityCell, &
+            !$acc             divergence, &
+            !$acc             kineticEnergyCell, &
+            !$acc             tangentialVelocity, &
+            !$acc             vertVelocityTop)
+            !$acc update host(normRelVortEdge, normPlanetVortEdge, &
+            !$acc             normalizedRelativeVorticityCell)
+            !$acc update host (surfacePressure)
+            !$acc update host(zMid, zTop)
+            !$acc update host(tracersSurfaceValue)
+            !$acc update host(normalVelocitySurfaceLayer)
+            !$acc update host(density, potentialDensity, displacedDensity)
+            !$acc update host(thermExpCoeff,  &
+            !$acc&            salineContractCoeff)
+            !$acc update host(montgomeryPotential, pressure)
+            if (landIcePressureOn) then
+               !$acc exit data delete(landIcePressure)
+               !$acc exit data delete(landIceDraft)
+            endif
+            if (config_use_freq_filtered_thickness) then
+               !$acc exit data copyout(highFreqThicknessNew)
+               !$acc exit data delete(highFreqThicknessCur)
+            endif
+            if ( associated(frazilSurfacePressure) ) then
+               !$acc exit data delete(frazilSurfacePressure)
+            endif
+         elseif (splitImplicitStep == numTSIterations) then
+            !$acc exit data delete(layerThicknessCur, layerThicknessTend)
+            !$acc exit data delete(normalBaroclinicVelocityCur)
+            if (config_compute_active_tracer_budgets) then
+               !$acc update host(activeTracerHorizontalAdvectionEdgeFlux)
+               !$acc update host(activeTracerHorizontalAdvectionTendency)
+               !$acc update host(activeTracerVerticalAdvectionTendency)
+               !$acc update host(activeTracerHorMixTendency)
+               !$acc update host(activeTracerSurfaceFluxTendency)
+               !$acc update host(temperatureShortWaveTendency)
+               !$acc update host(activeTracerNonLocalTendency)
+            endif
+         endif
+#endif
 
          call mpas_timer_stop('si loop fini')
          call mpas_timer_stop('si loop')
 
-      end do  ! splitImplicitStep = 1, config_n_ts_iter
+      end do  ! outer timestep loop (splitImplicitStep)
+
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       ! END large iteration loop
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -2334,6 +2526,9 @@ module ocn_time_integration_si
 #endif
       call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, &
                                 scratchPool, tracersPool, 2)
+
+      call mpas_dmpar_field_halo_exch(domain, 'surfaceFrictionVelocity')
+
 #ifdef MPAS_OPENACC
       !$acc update host(layerThickEdgeFlux, layerThickEdgeMean)
       !$acc update host(relativeVorticity, circulation)
@@ -2378,8 +2573,6 @@ module ocn_time_integration_si
       endif
       !$acc exit data delete(layerThicknessNew, normalVelocityNew)
 #endif
-
-      call mpas_dmpar_field_halo_exch(domain, 'surfaceFrictionVelocity')
 
       call ocn_vmix_implicit(dt, meshPool, statePool, forcingPool, &
                              scratchPool, err, 2)
@@ -2433,6 +2626,23 @@ module ocn_time_integration_si
 
       call mpas_timer_stop("si implicit vert mix")
 
+      if ( configVertAdvMethod == vertAdvRemap ) then
+
+         call mpas_timer_start("vertical remap")
+
+         call mpas_pool_get_array(statePool, 'layerThicknessLag', layerThicknessLagNew, 2)
+
+         ! Store the current, Lagrangian location for computation of the
+         ! Eulerian vertical velocity induced by remapping
+         layerThicknessLagNew = layerThicknessNew
+
+         ! Perform the remapping
+         call ocn_remap_vert_state(block, err)
+
+         call mpas_timer_stop("vertical remap")
+
+      end if
+
       call mpas_timer_start('si fini')
 
 #ifdef MPAS_OPENACC
@@ -2452,7 +2662,7 @@ module ocn_time_integration_si
       end if
       !$acc enter data copyin(atmosphericPressure, seaIcePressure)
       !$acc enter data copyin(sshNew)
-      !$acc enter data copyin(tracersGroupNew)
+      !$acc enter data copyin(activeTracersNew)
       !$acc update device(tracersSurfaceValue)
       if ( associated(frazilSurfacePressure) ) then
          !$acc enter data copyin(frazilSurfacePressure)
@@ -2572,7 +2782,7 @@ module ocn_time_integration_si
       !$acc update host (surfacePressure)
       !$acc update host(zMid, zTop)
       !$acc exit data copyout(sshNew)
-      !$acc exit data delete(tracersGroupNew)
+      !$acc exit data delete(activeTracersNew)
       !$acc update host(tracersSurfaceValue)
       !$acc update host(normalVelocitySurfaceLayer)
       !$acc exit data delete (atmosphericPressure, seaIcePressure)
@@ -2583,7 +2793,7 @@ module ocn_time_integration_si
          !$acc exit data delete(landIcePressure)
          !$acc exit data delete(landIceDraft)
       endif
-      !$acc exit data delete(layerThicknessNew, normalVelocityNew)
+      !$acc exit data copyout(layerThicknessNew, normalVelocityNew)
       !$acc update host(density, potentialDensity, displacedDensity)
       !$acc update host(thermExpCoeff,  &
       !$acc&            salineContractCoeff)
@@ -2596,7 +2806,7 @@ module ocn_time_integration_si
       !$acc             sfcFlxAttCoeff, &
       !$acc             surfaceFluxAttenuationCoefficientRunoff)
       if (config_prescribe_velocity) then
-         !$acc exit data delete(normalVelocityCur) 
+         !$acc exit data delete(normalVelocityCur)
       endif
       if (config_prescribe_thickness) then
          !$acc exit data delete(layerThicknessCur)
@@ -2621,6 +2831,7 @@ module ocn_time_integration_si
          call mpas_dmpar_exch_halo_field(effectiveDensityField)
          call mpas_timer_stop("si effective density halo")
       end if
+      deallocate(bottomDepthEdge)
 
       call mpas_timer_stop('si fini')
       call mpas_timer_stop("si timestep")


### PR DESCRIPTION
This PR updates Ocean SI solver code (baroclinic parts) and fix a bug issued in #5361 when using `config_btr_si_partition_match_mode = .true.`

So far, the branch passed `PEM_Ln9_D.T62_oQU240.GMPAS-IAF.cori-knl_gnu` and `SMS.T62_oQU120_ais20.MPAS_LISIO_TEST.cori-knl_gnu` using configurations `config_time_integrator = 'split_implicit'` and `config_btr_si_partition_match_mode = .true.`