### PR TITLE
Sync reference profiles between F90 and Cxx

### DIFF
--- a/components/homme/src/theta-l/share/element_ops.F90
+++ b/components/homme/src/theta-l/share/element_ops.F90
@@ -766,8 +766,8 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
    ! compute dp_ref
    ps_ref(:,:) = hvcoord%ps0*exp(-phis(:,:)/(Rgas*TREF))
    do k=1,nlev
-   dp_ref(:,:,k) = (hvcoord%hyai(k+1) - hvcoord%hyai(k))*hvcoord%ps0 + &
-   (hvcoord%hybi(k+1) - hvcoord%hybi(k))*ps_ref(:,:)
+     dp_ref(:,:,k) = (hvcoord%hyai(k+1) - hvcoord%hyai(k))*hvcoord%ps0 + &
+                     (hvcoord%hybi(k+1) - hvcoord%hybi(k))*ps_ref(:,:)
    enddo
 
    ! compute theta_ref
@@ -779,16 +779,12 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
 
    ! keep profiles, based on the value of hv_ref_profiles
    if (hv_ref_profiles == 0) then
-   ! keep PHI profile, but dont use theta and dp:
-   theta_ref = 0
-   dp_ref = 0
+     ! keep phi profile, but dont use theta and dp:
+     theta_ref = 0
+     dp_ref = 0
    endif
    if (hv_ref_profiles == 1) then
-   ! keep all profiles
-   endif
-   if (hv_ref_profiles == 2) then
-   ! keep only dp_ref
-   theta_ref = 0
+     ! keep all profiles
    endif
 
    end subroutine initialize_reference_states

--- a/components/homme/src/theta-l/share/element_ops.F90
+++ b/components/homme/src/theta-l/share/element_ops.F90
@@ -3,16 +3,16 @@
 #endif
 !
 !  getter and setter functions that must be provided by each model
-!  
-!  Note: all routines require dp3d() to be valid, with the exception of 
-!  the initial condition routines which assume reference levels and will initialize dp3d based 
+!
+!  Note: all routines require dp3d() to be valid, with the exception of
+!  the initial condition routines which assume reference levels and will initialize dp3d based
 !  on their 'ps' input argument
-!  
+!
 !
 !
 ! ROUTINES REQUIRED FOR ALL MODELS:
 ! Initial condition routines
-!  set_thermostate()    
+!  set_thermostate()
 !     initial condition interface used by DCMIP 2008 tests, old HOMME tests
 !  set_state(), set_state_i()
 !     initial condition interface used by DCMIP 2012 tests
@@ -22,16 +22,16 @@
 !     initialize geopotential to be in hydrostatic balance
 !     used by DCMIP2012, 2016 tests
 ! Other routines:
-!  get_field() 
+!  get_field()
 !     returns temperature, potential temperature, phi, etc..
-!  get_field_i() 
-!     returns a few quantities on interfaces 
+!  get_field_i()
+!     returns a few quantities on interfaces
 !  copy_state()
-!     copy state variables from one timelevel to another timelevel 
+!     copy state variables from one timelevel to another timelevel
 !  get_state()
 !     return state variables used by some DCMIP forcing functions
 !  save_initial_state()
-!     save t=0 in "state0", used by some DCMIP forcing functions       
+!     save t=0 in "state0", used by some DCMIP forcing functions
 !  set_forcing_rayleigh_friction()
 !     used by dcmip2012 test cases
 !  set_forcing_rayleigh_friction()
@@ -48,7 +48,7 @@
 !  get_cp_star()
 !  get_R_star()
 !  set_theta_ref()
-!  
+!
 !
 module element_ops
 
@@ -60,7 +60,7 @@ module element_ops
   use perf_mod,       only: t_startf, t_stopf, t_barrierf, t_adj_detailf ! _EXTERNAL
   use parallel_mod,   only: abortmp
   use physical_constants, only : p0, Cp, Rgas, Rwater_vapor, Cpwater_vapor, kappa, g, dd_pi, TREF
-  use control_mod,    only: use_moisture, theta_hydrostatic_mode
+  use control_mod,    only: use_moisture, theta_hydrostatic_mode, hv_ref_profiles
   use eos,            only: pnh_and_exner_from_eos, phi_from_eos
   implicit none
   private
@@ -70,7 +70,8 @@ module element_ops
   public get_field, get_field_i, get_state, get_pottemp
   public get_temperature, get_phi, get_R_star, get_hydro_pressure
   public set_thermostate, set_state, set_state_i, set_elem_state
-  public set_forcing_rayleigh_friction, set_theta_ref
+  public set_forcing_rayleigh_friction
+  public initialize_reference_states, set_theta_ref
   public copy_state, tests_finalize
   public state0
 
@@ -167,7 +168,7 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
       print *,'name = ',trim(name)
       call abortmp('ERROR: get_field_i name not supported in this model')
   end select
- 
+
   end subroutine get_field_i
 
 
@@ -175,24 +176,24 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
   subroutine get_pottemp(elem,pottemp,hvcoord,nt,ntQ)
   !
   implicit none
-    
+
   type (element_t), intent(in)        :: elem
   real (kind=real_kind), intent(out)  :: pottemp(np,np,nlev)
   type (hvcoord_t),     intent(in)    :: hvcoord                      ! hybrid vertical coordinate struct
   integer, intent(in) :: nt
   integer, intent(in) :: ntQ
-  
+
   !   local
   real (kind=real_kind) :: dp(np,np,nlev)
   real (kind=real_kind) :: Rstar(np,np,nlev)
   integer :: k
 
   call get_R_star(Rstar,elem%state%Q(:,:,:,1))
-  
+
   pottemp(:,:,:) = Rgas*elem%state%vtheta_dp(:,:,:,nt)/(Rstar(:,:,:)*elem%state%dp3d(:,:,:,nt))
-  
+
   end subroutine get_pottemp
-  
+
 
   !_____________________________________________________________________
   subroutine get_temperature(elem,temperature,hvcoord,nt)
@@ -200,12 +201,12 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
   ! Should only be called outside timestep loop, state variables on reference levels
   !
   implicit none
-  
+
   type (element_t), intent(in)        :: elem
   real (kind=real_kind), intent(out)  :: temperature(np,np,nlev)
   type (hvcoord_t),     intent(in)    :: hvcoord                      ! hybrid vertical coordinate struct
   integer, intent(in) :: nt
-  
+
   !   local
   real (kind=real_kind) :: dp(np,np,nlev)
   real (kind=real_kind) :: Rstar(np,np,nlev)
@@ -213,8 +214,8 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
   real (kind=real_kind) :: pnh(np,np,nlev)
   real (kind=real_kind) :: dpnh_dp_i(np,np,nlevp)
   integer :: k
-  
-  
+
+
   dp=elem%state%dp3d(:,:,:,nt)
   call get_R_star(Rstar,elem%state%Q(:,:,:,1))
 
@@ -232,20 +233,20 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
   !_____________________________________________________________________
   subroutine get_dpnh_dp(elem,dpnh_dp,hvcoord,nt)
   implicit none
-  
+
   type (element_t), intent(in)        :: elem
   real (kind=real_kind), intent(out)  :: dpnh_dp(np,np,nlev)
   type (hvcoord_t),     intent(in)    :: hvcoord                      ! hybrid vertical coordinate struct
   integer, intent(in) :: nt
-  
+
   !   local
   real (kind=real_kind) :: dp(np,np,nlev)
   real (kind=real_kind) :: exner(np,np,nlev)
   real (kind=real_kind) :: pnh(np,np,nlev)
   real (kind=real_kind) :: dpnh_dp_i(np,np,nlevp)
   integer :: k
-  
-  
+
+
   dp=elem%state%dp3d(:,:,:,nt)
   call pnh_and_exner_from_eos(hvcoord,elem%state%vtheta_dp(:,:,:,nt),&
        dp,elem%state%phinh_i(:,:,:,nt),pnh,exner,dpnh_dp_i)
@@ -253,7 +254,7 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
   do k=1,nlev
      dpnh_dp(:,:,k)=(dpnh_dp_i(:,:,k)+dpnh_dp_i(:,:,k+1))/2
   enddo
-  end subroutine 
+  end subroutine
 
 !this routine returns mu at interfaces, mu_surface = 1, will be fixed later
   !_____________________________________________________________________
@@ -274,18 +275,18 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
   dp=elem%state%dp3d(:,:,:,nt)
   call pnh_and_exner_from_eos(hvcoord,elem%state%vtheta_dp(:,:,:,nt),&
        dp,elem%state%phinh_i(:,:,:,nt),pnh,exner,dpnh_dp_i)
- 
-  end subroutine get_dpnh_dp_i 
+
+  end subroutine get_dpnh_dp_i
 
   !_____________________________________________________________________
   subroutine get_hydro_pressure(p,dp,hvcoord)
   !
   implicit none
-    
+
   real (kind=real_kind), intent(out)  :: p(np,np,nlev)
   real (kind=real_kind), intent(in)   :: dp(np,np,nlev)
   type (hvcoord_t),     intent(in)    :: hvcoord                      ! hybrid vertical coordinate struct
-  
+
   integer :: k
   real(kind=real_kind), dimension(np,np,nlevp) :: p_i
 
@@ -302,21 +303,21 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
      p(:,:,k)=p_i(:,:,k) + dp(:,:,k)/2
   enddo
 #endif
-  
-  
+
+
   end subroutine get_hydro_pressure
-  
+
 
   !_____________________________________________________________________
   subroutine get_nonhydro_pressure(elem,pnh,exner,hvcoord,nt)
     implicit none
-    
+
     type (element_t),       intent(in)  :: elem
     real (kind=real_kind),  intent(out) :: pnh(np,np,nlev)
     real (kind=real_kind),  intent(out) :: exner(np,np,nlev)
     type (hvcoord_t),       intent(in)  :: hvcoord
     integer,                intent(in)  :: nt
-    
+
     real (kind=real_kind), dimension(np,np,nlevp) :: dpnh_dp_i
 
     call pnh_and_exner_from_eos(hvcoord,elem%state%vtheta_dp(:,:,:,nt),&
@@ -328,12 +329,12 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
 
   subroutine get_nonhydro_pressure_i(elem,pnh_i,hvcoord,nt)
     implicit none
-    
+
     type (element_t),       intent(in)  :: elem
     real (kind=real_kind),  intent(out) :: pnh_i(np,np,nlevp)
     type (hvcoord_t),       intent(in)  :: hvcoord
     integer,                intent(in)  :: nt
-    
+
     real (kind=real_kind), dimension(np,np,nlevp) :: dpnh_dp_i
     real (kind=real_kind), dimension(np,np,nlev) :: pnh,exner
 
@@ -346,13 +347,13 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
 
   subroutine get_phi(elem,phi,phi_i,hvcoord,nt)
     implicit none
-    
+
     type (element_t),       intent(in)  :: elem
     type (hvcoord_t),       intent(in)  :: hvcoord
     real (kind=real_kind),  intent(out) :: phi(np,np,nlev)
     real (kind=real_kind),  intent(out) :: phi_i(np,np,nlevp)
     integer,                intent(in)  :: nt
-    
+
     real (kind=real_kind), dimension(np,np,nlev) :: dp
     real (kind=real_kind) :: pnh(np,np,nlev)
     real (kind=real_kind) :: exner(np,np,nlev)
@@ -371,7 +372,7 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
     do k=1,nlev
        phi(:,:,k) = (phi_i(:,:,k)+phi_i(:,:,k+1))/2
     end do
-    
+
   end subroutine
 
 
@@ -415,7 +416,7 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
   !_____________________________________________________________________
   subroutine copy_state(elem,nin,nout)
   implicit none
-  
+
   type (element_t), intent(inout)   :: elem
   integer :: nin,nout
 
@@ -432,19 +433,19 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
   subroutine set_thermostate(elem,ps,temperature,hvcoord,qv)
   !
   ! Assuming a hydrostatic intital state and given surface pressure,
-  ! and no moisture, compute theta and phi 
+  ! and no moisture, compute theta and phi
   !
   ! input:  ps_v, temperature
   ! ouput:  state variables:   vtheta_dp, phi
   !
   implicit none
-  
+
   type (element_t), intent(inout)   :: elem
   real (kind=real_kind), intent(in) :: temperature(np,np,nlev)
   type (hvcoord_t),     intent(in)  :: hvcoord                      ! hybrid vertical coordinate struct
   real (kind=real_kind), intent(in) :: ps(np,np)
   real (kind=real_kind), intent(in), optional :: qv(np,np,nlev)  ! water vapor mixing ratio
-  
+
   !   local
   real (kind=real_kind) :: p(np,np,nlev)
   real (kind=real_kind) :: pi_i(np,np,nlevp)
@@ -508,7 +509,7 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
   !
   ! set state variables at node(i,j,k) at layer midpoints
   ! used by idealized tests for dry initial conditions
-  ! so we use constants cp, kappa  
+  ! so we use constants cp, kappa
   !
   real(real_kind),  intent(in)    :: u,v,w,T,ps,phis,p,dp,zm,g
   integer,          intent(in)    :: i,j,k,n0,n1
@@ -529,7 +530,7 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
   !
   ! set state variables at node(i,j,k) at layer interfaces
   ! used by idealized tests for dry initial conditions
-  ! so we use constants cp, kappa  
+  ! so we use constants cp, kappa
   !
   real(real_kind),  intent(in)    :: u,v,w,T,ps,phis,p,zm,g
   integer,          intent(in)    :: i,j,k,n0,n1
@@ -620,7 +621,7 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
     if(theta_hydrostatic_mode) then
        ! overwrite w and phi_i computed above
        w = -(elem%derived%omega_p)/(rho*g)
-       
+
        do k=nlev,1,-1
           temp(:,:,k) = Rgas*elem%state%vtheta_dp(:,:,k,nt)*exner(:,:,k)/pnh(:,:,k)
           phi_i(:,:,k)=phi_i(:,:,k+1)+temp(:,:,k)
@@ -644,11 +645,11 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
     type(elem_state_t), intent(inout):: state
     integer,            intent(in)   :: ie     ! element index
 
-!$OMP BARRIER    
+!$OMP BARRIER
 !$OMP MASTER
     if(.not. allocated(state0)) allocate( state0(nelemd) )
 !$OMP END MASTER
-!$OMP BARRIER    
+!$OMP BARRIER
     state0(ie) = state
 
   end subroutine
@@ -690,7 +691,7 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
   where(zi(:,:,1:nlev) .ge. ztop); f_d = 1.0d0; end where
   f_d = -f_d/tau
   elem%derived%FM(:,:,3,:) = f_d * ( elem%state%w_i(:,:,1:nlev,n)  )
-  end subroutine 
+  end subroutine
 
   !_____________________________________________________________________
   subroutine tests_finalize(elem,hvcoord,ie)
@@ -729,7 +730,7 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
      endif
   enddo
 #endif
-  
+
   do tl = 2,timelevels
     call copy_state(elem,1,tl)
   enddo
@@ -739,6 +740,58 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
 
   end subroutine tests_finalize
 
+  !_____________________________________________________________________
+  subroutine initialize_reference_states(hvcoord, phis, &
+                                         dp_ref, theta_ref, phi_ref)
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !
+   ! Compute and sets reference profiles
+   !
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   implicit none
+
+   ! input variables
+   type (hvcoord_t),      intent(in) :: hvcoord     ! hybrid vertical coordinate struct
+   real (kind=real_kind), intent(in) :: phis(np,np) ! surface geopotential
+
+   ! output variables
+   real (kind=real_kind), intent(out) :: dp_ref(np,np,nlev)
+   real (kind=real_kind), intent(out) :: theta_ref(np,np,nlev)
+   real (kind=real_kind), intent(out) :: phi_ref(np,np,nlevp)
+
+   ! local variables
+   integer :: k
+   real (kind=real_kind) :: ps_ref(np,np), temp(np,np,nlev)
+
+   ! compute dp_ref
+   ps_ref(:,:) = hvcoord%ps0*exp(-phis(:,:)/(Rgas*TREF))
+   do k=1,nlev
+   dp_ref(:,:,k) = (hvcoord%hyai(k+1) - hvcoord%hyai(k))*hvcoord%ps0 + &
+   (hvcoord%hybi(k+1) - hvcoord%hybi(k))*ps_ref(:,:)
+   enddo
+
+   ! compute theta_ref
+   call set_theta_ref(hvcoord, dp_ref, theta_ref)
+
+   ! compute phi_ref
+   temp = theta_ref*dp_ref
+   call phi_from_eos(hvcoord, phis, temp, dp_ref, phi_ref)
+
+   ! keep profiles, based on the value of hv_ref_profiles
+   if (hv_ref_profiles == 0) then
+   ! keep PHI profile, but dont use theta and dp:
+   theta_ref = 0
+   dp_ref = 0
+   endif
+   if (hv_ref_profiles == 1) then
+   ! keep all profiles
+   endif
+   if (hv_ref_profiles == 2) then
+   ! keep only dp_ref
+   theta_ref = 0
+   endif
+
+   end subroutine initialize_reference_states
 
 
   !_____________________________________________________________________
@@ -752,11 +805,11 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
   !
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   implicit none
-  
+
   type (hvcoord_t),     intent(in)  :: hvcoord                      ! hybrid vertical coordinate struct
   real (kind=real_kind), intent(in) :: dp(np,np,nlev)
   real (kind=real_kind), intent(out) :: theta_ref(np,np,nlev)
-  
+
   !   local
   real (kind=real_kind) :: p_i(np,np,nlevp)
   real (kind=real_kind) :: exner(np,np,nlev)
@@ -769,7 +822,7 @@ recursive subroutine get_field(elem,name,field,hvcoord,nt,ntQ)
   T1 = tref_lapse_rate*TREF*Cp/g ! = 191
   T0 = TREF-T1           ! = 97
 
-  p_i(:,:,1) =  hvcoord%hyai(1)*hvcoord%ps0   
+  p_i(:,:,1) =  hvcoord%hyai(1)*hvcoord%ps0
   do k=1,nlev
      p_i(:,:,k+1) = p_i(:,:,k) + dp(:,:,k)
   enddo

--- a/components/homme/src/theta-l_kokkos/cxx/ElementOps.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementOps.hpp
@@ -53,32 +53,6 @@ public:
     ColumnOps::compute_midpoint_values(kv,p_i,pi);
   }
 
-  template<typename InputProvider>
-  KOKKOS_INLINE_FUNCTION
-  void compute_theta_ref (const KernelVariables& kv,
-                          const InputProvider& p,
-                          const ExecViewUnmanaged<Scalar[NUM_LEV]>& theta_ref) const {
-    assert (m_hvcoord.m_inited);
-    // theta_ref = T0/exner + T1, with T0,T1 fixed
-    // exner = (p/p0)^k
-    Kokkos::parallel_for(Kokkos::ThreadVectorRange(kv.team,NUM_LEV),
-                         [&](const int ilev) {
-      using namespace PhysicalConstants;
-      // Compute exner, store in theta_ref
-      // TODO: F90 does p(k) = (p_i(k)+p_i(k+1)) / (2*p0).
-      //       If this is a non BFB source, incorporate p0 scaling
-      //       in the calculation of p
-#ifdef HOMMEXX_BFB_TESTING
-      theta_ref(ilev) = bfb_pow(p(ilev)/p0,kappa);
-#else
-      theta_ref(ilev) = pow(p(ilev)/p0,kappa);
-#endif
-
-      // Compute theta_ref
-      theta_ref(ilev) = T0/theta_ref(ilev) + T1;
-    });
-  }
-
   KOKKOS_FUNCTION
   void get_temperature (const KernelVariables& kv,
                         const EquationOfState& eos,
@@ -97,10 +71,6 @@ public:
   }
 
 private:
-
-  static constexpr Real T1 =
-    PhysicalConstants::Tref_lapse_rate*PhysicalConstants::Tref*PhysicalConstants::cp/PhysicalConstants::g;
-  static constexpr Real T0 = PhysicalConstants::Tref-T1;
 
   HybridVCoord    m_hvcoord;
 };

--- a/components/homme/src/theta-l_kokkos/cxx/ElementsState.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementsState.cpp
@@ -33,68 +33,6 @@ void RefStates::init(const int num_elems) {
   m_tu     = TeamUtils<ExecSpace>(m_policy);
 }
 
-void RefStates::compute(const HybridVCoord& hvcoord,
-                        const ExecViewUnmanaged<Real *[NP][NP]>& phis) {
-  EquationOfState eos;
-  eos.init(true,hvcoord); // hydrostatic boolean is not relevant for these computations
-
-  ElementOps elem_ops;
-  elem_ops.init(hvcoord);
-
-  assert(dp_ref.extent_int(0)==m_num_elems);
-
-  // Local copies, to avoid cuda issues with *this
-  auto l_dp_ref = dp_ref;
-  auto l_phi_i_ref = phi_i_ref;
-  auto l_theta_ref = theta_ref;
-
-  constexpr Real Rgas = PhysicalConstants::Rgas;
-  constexpr Real Tref = PhysicalConstants::Tref;
-
-  const int num_slots = m_tu.get_num_ws_slots();
-  const auto tu = m_tu;
-
-  ExecViewManaged<Scalar*[NP][NP][NUM_LEV]> buf_p("",num_slots);
-  ExecViewManaged<Scalar*[NP][NP][NUM_LEV_P]> buf_p_i("",num_slots);
-  Kokkos::parallel_for(m_policy,KOKKOS_LAMBDA(const TeamMember& team){
-    KernelVariables kv(team, tu);
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team,NP*NP),
-                         [&](const int idx){
-      const int igp = idx / NP;
-      const int jgp = idx % NP;
-
-      auto dpRef    = Homme::subview(l_dp_ref,kv.ie,igp,jgp);
-      auto phiRef   = Homme::subview(l_phi_i_ref,kv.ie,igp,jgp);
-      auto thetaRef = Homme::subview(l_theta_ref,kv.ie,igp,jgp);
-      auto p        = Homme::subview(buf_p,kv.team_idx,igp,jgp);
-      auto p_i      = Homme::subview(buf_p_i,kv.team_idx,igp,jgp);
-
-      // Step 0: compute ps_ref
-      const Real ps_ref = hvcoord.ps0 * exp(-phis(kv.ie,igp,jgp)/(Rgas*Tref));
-
-      // Step 1: compute dp_ref = delta_hyai(k)*ps0 + delta_hybi(k)*ps_ref
-      hvcoord.compute_dp_ref(kv,ps_ref,dpRef);
-
-      // Step 2: compute p_ref = p(p_i(dp))
-      elem_ops.compute_hydrostatic_p(kv,dpRef,p_i,p);
-
-      // Step 3: compute theta_ref = theta(exner(p_ref))
-      elem_ops.compute_theta_ref(kv,p,thetaRef);
-
-      // Step 3: compute phi_i_ref = phi(theta_ref,dp_ref,p_ref)
-      // TODO: you could exploit exner computed in compute_theta_ref, to replace (p/p0)^(k-1) with exner*p0/p.
-      auto theta_dp = [&thetaRef,&dpRef](const int ilev)->Scalar {
-        return thetaRef(ilev)*dpRef(ilev);
-      };
-      eos.compute_phi_i(kv,phis(kv.ie,igp,jgp),
-                           theta_dp,p,phiRef);
-    });
-  });
-  Kokkos::fence();
-  Kokkos::deep_copy(theta_ref,0.0);
-  Kokkos::deep_copy(dp_ref,0.0);
-}
-
 void ElementsState::init(const int num_elems) {
   m_num_elems = num_elems;
 

--- a/components/homme/src/theta-l_kokkos/cxx/ElementsState.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementsState.hpp
@@ -27,8 +27,6 @@ struct RefStates {
   {}
 
   void init (const int num_elems);
-  void compute (const HybridVCoord& hvcoord,
-                const ExecViewUnmanaged<Real *[NP][NP]>& phis);
 
   int num_elems () const { return m_num_elems; }
 private:

--- a/components/homme/src/theta-l_kokkos/cxx/ElementsState.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementsState.hpp
@@ -27,7 +27,7 @@ struct RefStates {
   {}
 
   void init (const int num_elems);
-  void compute (const bool hydrostatic,const HybridVCoord& hvcoord,
+  void compute (const HybridVCoord& hvcoord,
                 const ExecViewUnmanaged<Real *[NP][NP]>& phis);
 
   int num_elems () const { return m_num_elems; }

--- a/components/homme/test_execs/thetal_kokkos_ut/elem_ops_interface.F90
+++ b/components/homme/test_execs/thetal_kokkos_ut/elem_ops_interface.F90
@@ -2,16 +2,14 @@ module elem_ops_interface
 
   use iso_c_binding,  only: c_int, c_bool, c_ptr, c_f_pointer
   use dimensions_mod, only: nlev, nlevp, np
-  use kinds,          only: real_kind 
-  use hybvcoord_mod,  only: hvcoord_t 
+  use kinds,          only: real_kind
+  use hybvcoord_mod,  only: hvcoord_t
   use parallel_mod,   only: abortmp
 
   implicit none
 
   type(hvcoord_t) :: hvcoord
-
   public :: init_f90
-  public :: set_theta_ref_f90
   public :: compute_r_star_f90
 contains
 
@@ -26,30 +24,6 @@ contains
     hvcoord%ps0 = ps0
 
   end subroutine init_f90
-
-  subroutine set_theta_ref_f90(num_elems, dp_ptr, theta_ref_ptr) bind(c)
-    use element_ops, only: set_theta_ref
-    !
-    ! Inputs
-    !
-    integer (kind=c_int), intent(in) :: num_elems
-    type (c_ptr), intent(in) :: dp_ptr, theta_ref_ptr
-
-    !
-    ! Locals
-    !
-    real (kind=real_kind), dimension(:,:,:,:),  pointer :: dp, theta_ref
-    integer :: ie
-
-    call c_f_pointer(dp_ptr,        dp,        [np,np,nlev,num_elems])
-    call c_f_pointer(theta_ref_ptr, theta_ref, [np,np,nlev,num_elems])
-
-    do ie=1,num_elems
-      call set_theta_ref(hvcoord,             &
-                         dp(:,:,:,ie),        &
-                         theta_ref(:,:,:,ie))
-    enddo
-  end subroutine set_theta_ref_f90
 
   subroutine compute_r_star_f90(num_elems, moist, Q_ptr, R_ptr) bind(c)
     use element_ops, only: get_R_star

--- a/components/homme/test_execs/thetal_kokkos_ut/elem_ops_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/elem_ops_ut.cpp
@@ -90,7 +90,7 @@ TEST_CASE("elem_ops", "elem_ops") {
       const Real* Q_ptr = Q_f90.data();
       Real* R_ptr = R_f90.data();
       compute_r_star_f90(num_elems,moist,Q_ptr,R_ptr);
-    
+
       // Compare answers
       auto R_cxx = Kokkos::create_mirror_view(dp_cxx);
       Kokkos::deep_copy(R_cxx,dp_cxx);
@@ -133,10 +133,7 @@ TEST_CASE("elem_ops", "elem_ops") {
         auto dp  = Homme::subview(dp_cxx,kv.ie,igp,jgp);
         auto p   = Homme::subview(p_cxx,kv.ie,igp,jgp);
         auto p_i = Homme::subview(p_i_cxx,kv.ie,igp,jgp);
-        p_i(0)[0] = hvcoord.hybrid_ai0*hvcoord.ps0;
-
-        ColumnOps::column_scan_mid_to_int<true>(kv,dp,p_i);
-        ColumnOps::compute_midpoint_values(kv,p_i,p);
+        elem_ops.compute_hydrostatic_p(kv,dp,p_i,p);
 
         auto theta = Homme::subview(theta_ref_cxx,kv.ie,igp,jgp);
         elem_ops.compute_theta_ref(kv,p,theta);

--- a/components/homme/test_execs/thetal_kokkos_ut/elem_ops_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/elem_ops_ut.cpp
@@ -14,10 +14,6 @@ using namespace Homme;
 
 extern "C" {
 void init_f90 (const Real* hyai_ptr, const Real& ps0);
-void set_theta_ref_f90(const int& num_elems,
-                       const Real*& dp,
-                       Real*& theta_ref);
-
 void compute_r_star_f90(const int& num_elems,
                         const bool& moist,
                         const Real*& Q,
@@ -109,49 +105,4 @@ TEST_CASE("elem_ops", "elem_ops") {
     }
   }
 
-  SECTION("theta_ref") {
-    // Create random inputs
-    genRandArray(theta_ref_cxx,engine,pdf);
-    genRandArray(dp_cxx,engine,pdf);
-
-    sync_to_host(theta_ref_cxx,theta_ref_f90);
-    sync_to_host(dp_cxx,dp_f90);
-
-    // Run fortran version
-    const Real* dp_f90_ptr = dp_f90.data();
-    Real* theta_ref_f90_ptr = theta_ref_f90.data();
-    set_theta_ref_f90(num_elems,dp_f90_ptr,theta_ref_f90_ptr);
-
-    // Run cxx version
-    Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const TeamMember& team) {
-      KernelVariables kv(team);
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(kv.team,NP*NP),
-                           [&](const int idx) {
-        const int igp = idx / NP;
-        const int jgp = idx % NP;
-
-        auto dp  = Homme::subview(dp_cxx,kv.ie,igp,jgp);
-        auto p   = Homme::subview(p_cxx,kv.ie,igp,jgp);
-        auto p_i = Homme::subview(p_i_cxx,kv.ie,igp,jgp);
-        elem_ops.compute_hydrostatic_p(kv,dp,p_i,p);
-
-        auto theta = Homme::subview(theta_ref_cxx,kv.ie,igp,jgp);
-        elem_ops.compute_theta_ref(kv,p,theta);
-      });
-    });
-
-    // Compare answers
-    Kokkos::deep_copy(h_theta_ref,theta_ref_cxx);
-    for (int ie=0; ie<num_elems; ++ie) {
-      for (int igp=0; igp<NP; ++igp) {
-        for (int jgp=0; jgp<NP; ++jgp) {
-          for (int k=0; k<NUM_PHYSICAL_LEV; ++k) {
-            const int ilev = k / VECTOR_SIZE;
-            const int ivec = k % VECTOR_SIZE;
-            REQUIRE (h_theta_ref(ie,igp,jgp,ilev)[ivec] == theta_ref_f90(ie,k,igp,jgp));
-          }
-        }
-      }
-    }
-  }
 }

--- a/components/homme/test_execs/thetal_kokkos_ut/thetal_test_interface.F90
+++ b/components/homme/test_execs/thetal_kokkos_ut/thetal_test_interface.F90
@@ -3,8 +3,8 @@ module thetal_test_interface
   use iso_c_binding,  only: c_int, c_bool, c_double, c_ptr, c_f_pointer
   use derivative_mod, only: derivative_t
   use element_mod,    only: element_t
-  use kinds,          only: real_kind 
-  use hybvcoord_mod,  only: hvcoord_t 
+  use kinds,          only: real_kind
+  use hybvcoord_mod,  only: hvcoord_t
   use parallel_mod,   only: abortmp
   use geometry_mod,   only: set_area_correction_map0
 
@@ -16,6 +16,7 @@ module thetal_test_interface
   public :: init_f90
   public :: cleanup_f90
   public :: init_geo_views_f90
+  public :: initialize_reference_states_f90
 
 contains
 
@@ -48,7 +49,7 @@ contains
     scale_factor = rearth
     scale_factor_inv = rrearth
     laplacian_rigid_factor = rrearth
-    
+
     call derivinit(deriv)
 
     call initmp_f90()
@@ -114,8 +115,8 @@ contains
     call c_f_pointer(d_ptr,    tensor2d, [np,np,2,2,nelemd])
     call c_f_pointer(mdet_ptr, scalar2d, [np,np,    nelemd])
     do ie=1,nelemd
-      tensor2d(:,:,:,:,ie) = elem(ie)%d      
-      scalar2d(:,:,ie)     = elem(ie)%metdet 
+      tensor2d(:,:,:,:,ie) = elem(ie)%d
+      scalar2d(:,:,ie)     = elem(ie)%metdet
     enddo
 
     call c_f_pointer(dinv_ptr, tensor2d, [np,np,2,2,nelemd])
@@ -173,5 +174,40 @@ contains
     call deallocate_element_arrays()
 
   end subroutine cleanup_f90
+
+
+  subroutine initialize_reference_states_f90(phis_ptr, dp_ref_ptr, theta_ref_ptr, phi_ref_ptr) bind(c)
+    use element_ops,    only: initialize_reference_states
+    use dimensions_mod, only: nelemd, nlev, nlevp, np
+    use theta_f2c_mod,  only : init_reference_states_c
+    !
+    ! Inputs
+    !
+    type (c_ptr), intent(in) :: phis_ptr, dp_ref_ptr, theta_ref_ptr, phi_ref_ptr
+    !
+    ! Locals
+    !
+    real (kind=real_kind), dimension(:,:,:),  pointer :: phis
+    real (kind=real_kind), dimension(:,:,:,:),  pointer :: dp_ref, theta_ref, phi_ref
+    integer :: ie
+
+    call c_f_pointer(phis_ptr,      phis,      [np,np,      nelemd])
+    call c_f_pointer(dp_ref_ptr,    dp_ref,    [np,np,nlev, nelemd])
+    call c_f_pointer(theta_ref_ptr, theta_ref, [np,np,nlev, nelemd])
+    call c_f_pointer(phi_ref_ptr,   phi_ref,   [np,np,nlevp,nelemd])
+
+    ! Compute reference states
+    do ie=1,nelemd
+      call initialize_reference_states(hvcoord,             &
+                                       phis(:,:,ie),        &
+                                       dp_ref(:,:,:,ie),    &
+                                       theta_ref(:,:,:,ie), &
+                                       phi_ref(:,:,:,ie))
+    end do
+
+    ! Initialize reference states in C++
+    call init_reference_states_c(dp_ref_ptr,theta_ref_ptr,phi_ref_ptr)
+
+  end subroutine initialize_reference_states_f90
 
 end module thetal_test_interface


### PR DESCRIPTION
Previously, some unit tests (`hv_ut.cpp:hypervis` and `elem_ops_ut.cpp:set_theta_ref`) were computing reference profiles via `RefStates::compute()` and `ElementOps::compute_theta_ref()`, however this C++ code for reference profiles is never used in the main code, F90 code in `src/theta-l/` is used.

My editor removes trailing whitespaces from all changed files, recommend using the "Hide whitespaces" option.

Details of changes:

- Updates to current code
  - In `src/theta-l/share/model_init_mod.F90`, separate the ref states computation into it's own function.
  - In `hv_ut.cpp:hypervis` test, ref states were being computed unnecessarily. Optimize test by removing unneeded computation.
  -  A couple of places in C++ code contained a copy of `compute_hydrostatic_p()` computation instead of using the function. (unrelated to this PR)
- Add linking functions from C++ to F90 for computing ref states in `hv_ut` instead of calling C++ versions
- Delete C++ version of ref states computation
  - Remove `RefStates::compute()` and `ElementOps::compute_theta_ref()`
  - Remove `elem_ops_ut.cpp:theta_ref test`
  - Update initial "random" guess in `hv_ut.cpp:hypervis` test to mimic computation of `theta_ref`. Does not need to be BFB to F90 version and not used anywhere else, so no need to be in it's own `ElementOps` function, IMO.

Addresses #5327 .