### PR TITLE
Fix lunit restart error

### DIFF
--- a/components/elm/src/main/subgridRestMod.F90
+++ b/components/elm/src/main/subgridRestMod.F90
@@ -476,6 +476,11 @@ contains
          dim1name='landunit',                                                      &
          long_name='landunit weight relative to corresponding gridcell',           &
          interpinic_flag='skip', readvar=readvar, data=lun_pp%wtgcell)
+    
+    call restartvar(ncid=ncid, flag=flag, varname='land1d_wttopounit', xtype=ncd_double, &
+         dim1name='landunit',                                                            &
+         long_name='landunit weight relative to corresponding topounit', units='',         &
+         interpinic_flag='skip', readvar=readvar, data=lun_pp%wttopounit)
 
     call restartvar(ncid=ncid, flag=flag, varname='cols1d_wtxy', xtype=ncd_double,  &
          dim1name='column',                                                         &
@@ -491,6 +496,11 @@ contains
          dim1name='column',                                                             &
          long_name='mean elevation on glacier elevation classes', units='m',            &
          interpinic_flag='skip', readvar=readvar, data=col_pp%glc_topo)
+    
+    call restartvar(ncid=ncid, flag=flag, varname='cols1d_wttopounit', xtype=ncd_double, &
+         dim1name='column',                                                            &
+         long_name='column weight relative to corresponding topounit', units='',         &
+         interpinic_flag='skip', readvar=readvar, data=col_pp%wttopounit)
 
     call restartvar(ncid=ncid, flag=flag, varname='pfts1d_wtxy', xtype=ncd_double,  &
          dim1name='pft',                                                            &

--- a/components/elm/src/main/subgridWeightsMod.F90
+++ b/components/elm/src/main/subgridWeightsMod.F90
@@ -217,7 +217,7 @@ contains
   subroutine compute_higher_order_weights(bounds)
     !
     ! !DESCRIPTION:
-    ! Assuming veg_pp%wtcol, col_pp%wtlunit and lun_pp%wttopounit have already been computed, compute
+    ! Assuming veg_pp%wtcol, col_pp%wtlunit, lun_pp%wttopounit and top_pp%wtgcell have already been computed, compute
     ! the "higher-order" weights: 
     ! veg_pp%wtlunit, veg_pp%wttopounit, veg_pp%wtgcell,
     ! col_pp%wttopounit, col_pp%wtgcell, and


### PR DESCRIPTION
The changes in this branch have fixed an error related to the land unit fraction coming from the model restart file. 

[BFB]
would be non-BFB for transient runs with topo units but there are none of those.
