### PR TITLE
Allow to build E3SM against a pre-built kokkos installation

### DIFF
--- a/share/build/buildlib.kokkos
+++ b/share/build/buildlib.kokkos
@@ -106,6 +106,17 @@ def buildlib(bldroot, installpath, case):
         installpath=installpath,
     )
 
+    # When later we use find_package to get kokkos in CMake, the folder
+    # install_sharedpath/kokkos (which is bldroot here) gets picked over
+    # the actual install folders. Since a KokkosConfig.cmake file *is* present
+    # there, but the other cmake config files aren't, this causes config errors.
+    # To prevent find_package from picking up that folder, we actually use
+    # ${bldroot}/build as a binary dir, so that CMake won't consider it when
+    # executing find_package.
+    bldroot = f"{bldroot}/build"
+    if not os.path.isdir(bldroot):
+        os.makedirs(bldroot)
+
     run_bld_cmd_ensure_logging(gen_makefile_cmd, logger, from_dir=bldroot)
     run_bld_cmd_ensure_logging(
         "{} VERBOSE=1 -j {}".format(gmake_cmd, gmake_j), logger, from_dir=bldroot

--- a/share/build/buildlib.kokkos
+++ b/share/build/buildlib.kokkos
@@ -47,7 +47,26 @@ OR
 
 ###############################################################################
 def buildlib(bldroot, installpath, case):
-    ###############################################################################
+###############################################################################
+    installed_kokkos_dir = os.environ.get("KOKKOS_PATH")
+    if installed_kokkos_dir is not None:
+        # We are trying to use a pre-installed kokkos. Look for the relevant folders/libs,
+        # and if all looks good, return. Otherwise, crap out
+        kokkos_root = os.path.abspath(installed_kokkos_dir)
+        include_dir = os.path.join(kokkos_root,'include')
+
+        expect (os.path.isdir(kokkos_root),f"Non-existent kokkos install dir '{kokkos_root}'")
+        expect (os.path.isdir(include_dir),f"Missing include subfolder in kokkos install dir '{kokkos_root}'")
+        expect (os.path.isfile(os.path.join(include_dir,'Kokkos_Core.hpp')),f"Missing kokkos headers in '{include_dir}'")
+
+        # TODO: should I check for libs too? The problem is that the lib subfolder is
+        # often arch dependent (e.g., $prefix/lib or $prefix/lib64)... The best thing
+        # would be to run a small cmake script, that calls find_package. But E3SM's
+        # cmake build system will do that soon enough, so any error will be caught there.
+        return
+    else:
+        print ("no value foudn in env for KOKKOS_PATH. building from scratch")
+
     srcroot = case.get_value("SRCROOT")
     kokkos_dir = os.path.join(srcroot, "externals", "kokkos")
     expect(os.path.isdir(kokkos_dir), "Missing kokkos submodule")


### PR DESCRIPTION
Allows to build compsets that require kokkos without building our internal submodule, and use an existing kokkos installation instead.

The behavior is triggered by the presense of the `KOKKOS_PATH` env variable. If present, we _assume_ that it points to a valid kokkos installation; we check that the folder exists and contains at least the `Kokkos_Core.hpp` header, crapping out if that's not true (portably checking for the libs is harder, since the lib install folder is likely to be arch-dependent).

This helps with MALI compsets, which link against trilinos, which already contains a kokkos installation. If the `KOKKOS_PATH` env var is not present, the behavior is identical to what it was before.

@stephenprice  this is the branch that @mperego and I worked on to get MALI working on Cori.

@rljacob to trigger the behavior I use the env var approach, as that is already done with PIO (in a slighlty different way). I am not super fond of this approach, and would prefer being able to trigger this via some XML change, but I'm not really sure how to do it or where to start. However, if this is the preferred way for CIME/E3SM to handle this kind of scenario, I'm fine with it.