### PR TITLE
Avoid keyword args for non-opt PIO args in ELM

### DIFF
--- a/components/elm/src/main/initInterp.F90
+++ b/components/elm/src/main/initInterp.F90
@@ -309,7 +309,7 @@ contains
        !---------------------------------------------------          
 
        call pio_seterrorhandling(ncidi, PIO_BCAST_ERROR)
-       status = pio_inq_varid(ncidi, name=varname, vardesc=vardesc)
+       status = pio_inq_varid(ncidi, varname, vardesc)
        call pio_seterrorhandling(ncidi, PIO_INTERNAL_ERROR)
        if (status /= PIO_noerr) then
           if (masterproc) then
@@ -438,7 +438,7 @@ contains
           end if
           ! Determine order of level and subgrid dimension in restart file
           status = pio_inq_varid (ncidi, trim(varname), vardesc)
-          status = pio_inquire_variable(ncidi, vardesc=vardesc, dimids=dimidsi)
+          status = pio_inquire_variable(ncidi, vardesc, dimids=dimidsi)
           status = pio_get_att(ncidi, vardesc, 'switchdim_flag', switchdim_flag)
           if (switchdim_flag > 0) then
              levdimi = dimidsi(1)  

--- a/components/elm/src/main/ncdio_pio.F90.in
+++ b/components/elm/src/main/ncdio_pio.F90.in
@@ -1419,7 +1419,7 @@ end subroutine ncd_io_{DIMS}d_{TYPE}_glob
           if ( count(1) > size(tmpString) )then
              write(iulog,*) subname//' ERROR: input string size is too large:'
           end if
-          status = pio_put_var(ncid, varid, start, count, ival=tmpString(1:count(1)))
+          status = pio_put_var(ncid, varid, start, count, tmpString(1:count(1)))
        else
           status = pio_put_var(ncid, varid, data )
        end if


### PR DESCRIPTION
Avoid keyword/named arguments for non-optional arguments
in PIO calls in ELM.

[BFB]