### PR TITLE
homme: test with hv_ref_profiles=1

### DIFF
--- a/components/homme/test/reg_test/namelists/theta-fdc12-test21.nl
+++ b/components/homme/test/reg_test/namelists/theta-fdc12-test21.nl
@@ -27,6 +27,7 @@
   dcmip2_x_xi       = 4000.0                    ! mountain wavelength   (m)
   limiter_option    = 9
   vert_remap_q_alg  = 1
+  hv_ref_profiles   = 1
 /
 &vert_nl
   vanalytic         = 1                         ! set vcoords in initialization routine


### PR DESCRIPTION
Needed to test hv profiles code that is in F and cxx.

[bfb] except for homme modified tests (theta-fdc12-test21).