### PR TITLE
Update raw data for soil erosion to match code changes in fsurdat

### DIFF
--- a/components/elm/bld/namelist_files/namelist_defaults_tools.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults_tools.xml
@@ -306,7 +306,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/rawdata/mksrf_slope_10p_0.5x0.5.c190603.nc</mksrf_fslp10>
 
 <mksrf_fero hgrid="0.5x0.5" lmask="AVHRR"
->lnd/clm2/rawdata/mksrf_soilero_0.5x0.5.c190603.nc</mksrf_fero>
+>lnd/clm2/rawdata/mksrf_soilero_0.5x0.5.c220523.nc</mksrf_fero>
 
 <!-- mksrf_fvegtyp -->
 


### PR DESCRIPTION
PR #5085 added handling of "Tillage" and "Litho" variables from the soil erosion raw data file to 
`mksurfdata_map`, but it looks like the namelist defaults for the tool were never updated to point
to the revised data file that contains these fields. This updates `namelist_defaults_tools.xml` to 
use the correct data file so that `mksurfdata_map` does not look for non-existent fields in the old file.

[BFB]