### PR TITLE
add  linear reference profile for theta 

### DIFF
--- a/components/homme/test/reg_test/namelists/theta-fdc12-test21.nl
+++ b/components/homme/test/reg_test/namelists/theta-fdc12-test21.nl
@@ -27,7 +27,7 @@
   dcmip2_x_xi       = 4000.0                    ! mountain wavelength   (m)
   limiter_option    = 9
   vert_remap_q_alg  = 1
-  hv_ref_profiles   = 1
+  hv_ref_profiles   = 6
 /
 &vert_nl
   vanalytic         = 1                         ! set vcoords in initialization routine


### PR DESCRIPTION
Minor modification for the HV reference profile for theta: use linear version near the surface

This option is to enable rougher topography, to be used in SCREAM (not used in EAM)

F case evaluation:  https://acme-climate.atlassian.net/wiki/spaces/NGDNA/pages/3530719247/F2010+NH+evaluation

[BFB] except for one standalone HOMME test ([theta-fdc12-test21.nl]) which is switched to this profile and will need a new baseline