### PR TITLE
Fixes initialization of snow ice mass tracer

### DIFF
--- a/components/mpas-seaice/src/column/ice_shortwave.F90
+++ b/components/mpas-seaice/src/column/ice_shortwave.F90
@@ -3665,7 +3665,6 @@
 
       real (kind=dbl_kind), parameter :: &
          ! units for the following are 1.e-6 m (micro-meters)
-         rsnw_fresh    =  100._dbl_kind, & ! freshly-fallen snow grain radius 
          rsnw_nonmelt  =  500._dbl_kind, & ! nonmelt snow grain radius
          rsnw_sig      =  250._dbl_kind    ! assumed sigma for snow grain radius
 
@@ -3696,7 +3695,7 @@
         ! the sign is negative so that if R_snw is 1, then the
         ! snow grain radius is reduced and thus albedo increased.
         rsnw_nm = rsnw_nonmelt - R_snw*rsnw_sig
-        rsnw_nm = max(rsnw_nm, rsnw_fresh)
+        rsnw_nm = max(rsnw_nm, rsnw_fall)
         rsnw_nm = min(rsnw_nm, rsnw_mlt) 
       
         do ks = 1, nslyr
@@ -3704,7 +3703,7 @@
            rhosnw(ks) = rhos
            ! snow grain radius between rsnw_nonmelt and rsnw_mlt
            rsnw(ks) = rsnw_nm + (rsnw_mlt-rsnw_nm)*fT
-           rsnw(ks) = max(rsnw(ks), rsnw_fresh)
+           rsnw(ks) = max(rsnw(ks), rsnw_fall)
            rsnw(ks) = min(rsnw(ks), rsnw_mlt)
         enddo        ! ks
 

--- a/components/mpas-seaice/src/column/ice_snow.F90
+++ b/components/mpas-seaice/src/column/ice_snow.F90
@@ -68,21 +68,21 @@
       rhos_eff = c0
       rhos_cmp = c0
 
-      if (vsno > puny) then
-
       !-----------------------------------------------------------------
       ! Initialize effective snow density (compaction) for new snow
       !-----------------------------------------------------------------
 
-         do n = 1, ncat
-               do k = 1, nslyr
-                  if (rhos_cmpn(k,n) < rhosmin) rhos_cmpn(k,n) = rhosnew
-               enddo
-         enddo
+      do n = 1, ncat
+            do k = 1, nslyr
+               if (rhos_cmpn(k,n) < rhosmin) rhos_cmpn(k,n) = rhosnew
+            enddo
+      enddo
 
       !-----------------------------------------------------------------
       ! Compute average effective density of snow
       !-----------------------------------------------------------------
+
+      if (vsno > puny) then
 
          do n = 1, ncat
             if (vsnon(n) > c0) then
@@ -815,7 +815,7 @@
           zrhos(k) = smice(k) + smliq(k)
 
           ! best-fit table indecies:
-          T_idx    = nint(abs(zTsn(k)+ Tffresh - 223.0_dbl_kind) / 5.0_dbl_kind, kind=int_kind)
+          T_idx    = nint(abs(zTsn(k)+ Tffresh - 223.15_dbl_kind) / 5.0_dbl_kind, kind=int_kind)
           Tgrd_idx = nint(zdTdz(k) / 10.0_dbl_kind, kind=int_kind)
           !rhos_idx = nint(zrhos(k)-50.0_dbl_kind) / 50.0_dbl_kind, kind=int_kind)   ! variable density
           rhos_idx = nint((rhos-50.0_dbl_kind) / 50.0_dbl_kind, kind=int_kind)        ! fixed density

--- a/components/mpas-seaice/src/column/ice_therm_vertical.F90
+++ b/components/mpas-seaice/src/column/ice_therm_vertical.F90
@@ -1228,10 +1228,11 @@
             if (Ts > c0) then
                dhs = cp_ice*Ts*dzs(k) / Lfresh  ! melt
                smice_precs = c0
-               if (abs(dzs(k)) > puny) smice_precs = smicetot(k)/dzs(k) * dhs
+               if (dzs(k) > puny) smice_precs = smicetot(k)/dzs(k) * dhs
                smicetot(k) = max(c0,smicetot(k) - smice_precs) ! dhs << dzs
                smliqtot(k) = max(c0,smliqtot(k) + smice_precs)
                dzs (k) = dzs(k) - dhs
+               melts = melts + dhs
                zqsn(k) = -rhos*Lfresh
             endif
          enddo
@@ -1282,7 +1283,7 @@
          dzi(1) = dzi(1) + dhi
          evapn = evapn + dhi*rhoi
          ! enthalpy of melt water
-         emlt_atm = emlt_atm - qmlt(1) * dhi 
+         emlt_atm = emlt_atm - qmlt(1) * dhi
       endif
 
       !--------------------------------------------------------------
@@ -1349,15 +1350,15 @@
       do k = 1, nslyr
 
          !--------------------------------------------------------------
-         ! Remove internal snow melt 
+         ! Remove internal snow melt
          !--------------------------------------------------------------
-         
+
          if (ktherm == 2 .and. zqsn(k) > -rhos * Lfresh) then
 
             dhs = max(-dzs(k), &
-                -((zqsn(k) + rhos*Lfresh) / (rhos*Lfresh)) * dzs(k)) ! dhs < 0 
+                -((zqsn(k) + rhos*Lfresh) / (rhos*Lfresh)) * dzs(k)) ! dhs < 0
             smice_precs = c0
-            if (abs(dzs(k)) > puny) smice_precs = smicetot(k)/dzs(k) * dhs
+            if (dzs(k) > puny) smice_precs = smicetot(k)/dzs(k) * dhs
             smicetot(k) = max(c0,smicetot(k) + smice_precs) ! -dhs <= dzs
             smliqtot(k) = max(c0,smliqtot(k) - smice_precs)
             dzs (k) = dzs(k) + dhs
@@ -1701,6 +1702,11 @@
                                     zs1(:),   zs2(:),   &
                                     hslyr,    hsn,      &
                                     smliq(:))
+
+              do k = 1, nslyr
+                 smicetot(k) = smice(k) * hslyr
+                 smliqtot(k) = smliq(k) * hslyr
+              end do
         endif
 
       endif   ! nslyr > 1
@@ -1717,7 +1723,7 @@
                zqsn(k) = -rhos*Lfresh
                if (tr_snow) then
                  meltsliq = meltsliq + smicetot(k)  ! add to meltponds
-                 smice(k) = c0
+                 smice(k) = rhos
                  smliq(k) = c0
                endif
                hslyr = c0

--- a/components/mpas-seaice/src/shared/mpas_seaice_column.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_column.F
@@ -542,7 +542,7 @@ contains
 
           if (.not. config_do_restart_snow_density) then
 
-             snowIceMass(:,:,:)          = 0.0_RKIND
+             snowIceMass(:,:,:)          = seaiceDensitySnow
              snowLiquidMass(:,:,:)       = 0.0_RKIND
              snowDensity(:,:,:)          = 0.0_RKIND
              snowDensityViaContent(:)    = 0.0_RKIND


### PR DESCRIPTION
non BFB changes:
1. Initialize snow ice mass tracer as the mean snow density
2. Changed to higher precision constant in computing snow aging table index

BFB changes:
3. Removed rsnw_fresh. Freshly fallen snow grain radius is config_fallen_snow_radius (rsnw_fall) BFB in standard configuration,  BFB with snow tracers off but needs config_fallen_snow_radius = 100.0)
4. Correction to diagnostic variable, melts
5. Change effective snow density to new snow density value when there's no snow (diagnostic change)
6. Remove unnecessary absolute value for snow level thicknesses

Fixes #5403 
[non-BFB]