### PR TITLE
 hommexx: make forcingalg int

### DIFF
--- a/components/homme/src/share/cxx/HommexxEnums.hpp
+++ b/components/homme/src/share/cxx/HommexxEnums.hpp
@@ -40,11 +40,11 @@ enum class ComparisonOp {
 
 // =================== Run parameters enums ====================== //
 
-enum class ForcingAlg {
-  FORCING_OFF,
-  FORCING_0, 
-  FORCING_1, // Unsupported
-  FORCING_2, // TODO: Rename FORCING_1 and FORCING_2 to something more descriptive
+enum class ForcingAlg : int {
+  FORCING_OFF =-1,
+  FORCING_0   = 0, 
+  FORCING_1   = 1, // Unsupported
+  FORCING_2   = 2, // TODO: Rename FORCING_1 and FORCING_2 to something more descriptive
 };
 
 enum class MoistDry {


### PR DESCRIPTION
ForcingAlg type, which is used for ftype, as enum currently is not based on int, which makes the code assign ftype values in xx code not to integers we expect (like ftype0 will not equal to 0 if printed), which makes debugging confusing.

This fixes it. 

[BFB]