### PR TITLE
Fix an array allocation bug in the ocean SI solver

### DIFF
--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -853,6 +853,8 @@ module ocn_forward_mode
 
       if ( config_time_integrator == 'split_explicit') then
          call mpas_dmpar_exch_group_destroy_reusable_buffers(domain, 'subcycleFields')
+      else if ( config_time_integrator == 'split_implicit') then
+         call ocn_time_integrator_si_variable_destroy()
       end if
 
       call ocn_analysis_finalize(domain, ierr)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -4230,7 +4230,7 @@ module ocn_time_integration_si
 !
 !  routine ocn_time_integrator_si_variable_destroy
 !
-!> \brief   Destroy SI-related variables including CPU & GPU arrays
+!> \brief   Destroy SI solver-related variables
 !
 !> \author  Hyun-Gyu Kang
 !

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -72,8 +72,9 @@ module ocn_time_integration_si
    !--------------------------------------------------------------------
 
    public :: ocn_time_integrator_si, &
-             ocn_time_integration_si_init, &
-             ocn_time_integrator_si_preconditioner
+             ocn_time_integration_si_init,            &
+             ocn_time_integrator_si_preconditioner,   &
+             ocn_time_integrator_si_variable_destroy
 
    !--------------------------------------------------------------------
    !
@@ -653,20 +654,6 @@ module ocn_time_integration_si
          call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
       endif
 
-      if ( config_btr_si_partition_match_mode ) then
-         if (si_algorithm == 'sbicg' ) then
-            allocate( globalReprodSum2fld1(nCellsOwned,2),  &
-                      globalReprodSum2fld2(nCellsOwned,2),  &
-                      globalReprodSum9fld1(nCellsOwned,9),  &
-                      globalReprodSum9fld2(nCellsOwned,9) )
-         else if ( si_algorithm == 'scg' ) then
-            allocate( globalReprodSum2fld1(nCellsOwned,2),  &
-                      globalReprodSum2fld2(nCellsOwned,2),  &
-                      globalReprodSum3fld1(nCellsOwned,3),  &
-                      globalReprodSum3fld2(nCellsOwned,3) )
-         endif
-      endif
-
 #ifdef MPAS_OPENACC
       !$acc exit data delete(normalVelocityCur, normalBarotropicVelocityCur, &
       !$acc    sshCur, layerThicknessCur)
@@ -917,21 +904,6 @@ module ocn_time_integration_si
          call mpas_timer_start('si halo barotropicForcing')
          call mpas_dmpar_field_halo_exch(domain, 'barotropicForcing')
          call mpas_timer_stop('si halo barotropicForcing')
-
-
-!        call mpas_timer_start("si halo btr vel")
-!        call mpas_dmpar_exch_group_create(domain, iterGroupName)
-!        call mpas_dmpar_exch_group_add_field(domain, &
-!                  iterGroupName, 'barotropicForcing')
-!        call mpas_dmpar_exch_group_add_field(domain,             &
-!                  iterGroupName,                             &
-!                             'bottomDepthEdge')
-!        call mpas_dmpar_exch_group_full_halo_exch(domain, &
-!                  iterGroupName)
-!        call mpas_dmpar_exch_group_destroy(domain, iterGroupName)
-!        call mpas_timer_stop("si halo btr vel")
-
-
 
          call mpas_timer_stop("si bcl vel")
 
@@ -2501,16 +2473,6 @@ module ocn_time_integration_si
       ! END large iteration loop
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-      if ( config_btr_si_partition_match_mode ) then
-         if ( si_algorithm == 'sbicg' ) then
-            deallocate( globalReprodSum2fld1,globalReprodSum2fld2,  &
-                        globalReprodSum9fld1,globalReprodSum9fld2 )
-         else if ( si_algorithm == 'scg' ) then
-            deallocate( globalReprodSum2fld1,globalReprodSum2fld2,  &
-                        globalReprodSum3fld1,globalReprodSum3fld2 )
-         end if
-      endif
-
       call mpas_timer_start("si implicit vert mix")
 
       ! Call ocean diagnostic solve in preparation for vertical mixing.
@@ -3303,6 +3265,13 @@ module ocn_time_integration_si
          call mpas_log_write( &
          '       (Default is sbicg.)')
          si_algorithm = 'scg'
+
+         ! Allocate temporary arrays for reproducible summation
+         allocate( globalReprodSum2fld1(nCellsOwned,2),  &
+                   globalReprodSum2fld2(nCellsOwned,2),  &
+                   globalReprodSum3fld1(nCellsOwned,3),  &
+                   globalReprodSum3fld2(nCellsOwned,3) )
+
       endif
 
       ! Restricted Additive Schwarz preconditioner --------------------!
@@ -4256,6 +4225,30 @@ module ocn_time_integration_si
      !-------------------------------------------------------------!
 
    end subroutine si_solver_sbicg !}}}
+
+!***********************************************************************
+!
+!  routine ocn_time_integrator_si_variable_destroy
+!
+!> \brief   Destroy SI-related variables including CPU & GPU arrays
+!
+!> \author  Hyun-Gyu Kang
+!
+!> \details
+!   This routine deallocates CPU arrays allocated in the SI solver.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_time_integrator_si_variable_destroy() !{{{
+
+      if ( config_btr_si_partition_match_mode ) then
+         deallocate( globalReprodSum2fld1,  &
+                     globalReprodSum2fld2,  &
+                     globalReprodSum3fld1,  &
+                     globalReprodSum3fld2 )
+      endif
+
+   end subroutine ocn_time_integrator_si_variable_destroy !}}}
 
 !***********************************************************************
 


### PR DESCRIPTION
This PR fixes an array allocation bug  in the ocean SI solver.

This PR passes `PEM_Ln9.T62_oQU240.GMPAS-IAF.cori-knl_intel` and `SMS_D.T62_oQU120_ais20.MPAS_LISIO_TEST.cori-knl_gnu` tests with `config_time_integrator='split_implicit'` `config_btr_si_partition_match_mode=.true.` options. 

These changes are only in the semi-implicit time stepping, which is not used in the E3SM tests (stealth). So this can be classified as BFB for E3SM testing.

Fixes #5361 

[BFB]