### PR TITLE
Improvements to Diagnostics computation

### DIFF
--- a/components/homme/src/theta-l_kokkos/cxx/Diagnostics.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/Diagnostics.cpp
@@ -15,40 +15,46 @@ namespace Homme
 {
 
 void Diagnostics::init (const ElementsState& state, const ElementsGeometry& geometry,
-                        const HybridVCoord& hvcoord, F90Ptr& elem_state_q_ptr,
-                        F90Ptr& elem_accum_qvar_ptr,  F90Ptr& elem_accum_qmass_ptr,
-                        F90Ptr& elem_accum_q1mass_ptr,F90Ptr& elem_accum_iener_ptr,
-                        F90Ptr& elem_accum_kener_ptr, F90Ptr& elem_accum_pener_ptr)
-{
+                        const HybridVCoord& hvcoord,  const Tracers& tracers,
+                        F90Ptr& elem_state_q_ptr, F90Ptr& elem_accum_qvar_ptr,
+                        F90Ptr& elem_accum_qmass_ptr, F90Ptr& elem_accum_q1mass_ptr,
+                        F90Ptr& elem_accum_iener_ptr, F90Ptr& elem_accum_kener_ptr,
+                        F90Ptr& elem_accum_pener_ptr) {
   // Check state/geometry/hvcoord were inited
   assert (state.num_elems()>0);
   assert (geometry.num_elems()>0);
   assert (hvcoord.m_inited);
+  assert (tracers.inited());
 
   // Check initialization was done right
   assert (m_num_elems==state.num_elems());
+  assert (m_num_tracers==tracers.num_tracers());
 
   m_state    = state;
   m_geometry = geometry;
   m_hvcoord  = hvcoord;
+  m_tracers  = tracers;
 
   m_eos.init(m_theta_hydrostatic_mode,m_hvcoord);
   m_elem_ops.init(m_hvcoord);
 
   // F90 ptr to array (n1,n2,...,nK,nelemd) can be stuffed directly in an unmanaged view
   // with scalar type Real*[nK]...[n2][n1] (with runtime dimension nelemd)
-  h_Q      = decltype(h_Q)(elem_state_q_ptr, m_num_elems);
-  h_Qvar   = decltype(h_Qvar)(elem_accum_qvar_ptr, m_num_elems);
-  h_Qmass  = decltype(h_Qmass)(elem_accum_qmass_ptr, m_num_elems);
+  h_Qvar   = decltype(h_Qvar)  (elem_accum_qvar_ptr,   m_num_elems);
+  h_Qmass  = decltype(h_Qmass) (elem_accum_qmass_ptr,  m_num_elems);
   h_Q1mass = decltype(h_Q1mass)(elem_accum_q1mass_ptr, m_num_elems);
 
-  h_IEner  = decltype(h_IEner)(elem_accum_iener_ptr, m_num_elems);
-  h_KEner  = decltype(h_KEner)(elem_accum_kener_ptr, m_num_elems);
-  h_PEner  = decltype(h_PEner)(elem_accum_pener_ptr, m_num_elems);
+  d_Qvar   = decltype(d_Qvar)  ("Qvar",   m_num_elems);
+  d_Qmass  = decltype(d_Qmass) ("Qmass",  m_num_elems);
+  d_Q1mass = decltype(d_Q1mass)("Q1mass", m_num_elems);
 
-  m_IEner  = decltype(m_IEner)("Internal  Energy", m_num_elems);
-  m_KEner  = decltype(m_KEner)("Kinetic   Energy", m_num_elems);
-  m_PEner  = decltype(m_PEner)("Potential Energy", m_num_elems);
+  h_IEner  = decltype(h_IEner) (elem_accum_iener_ptr, m_num_elems);
+  h_KEner  = decltype(h_KEner) (elem_accum_kener_ptr, m_num_elems);
+  h_PEner  = decltype(h_PEner) (elem_accum_pener_ptr, m_num_elems);
+
+  d_IEner  = decltype(d_IEner) ("Internal  Energy", m_num_elems);
+  d_KEner  = decltype(d_KEner) ("Kinetic   Energy", m_num_elems);
+  d_PEner  = decltype(d_PEner) ("Potential Energy", m_num_elems);
 }
 
 int Diagnostics::requested_buffer_size () const {
@@ -90,10 +96,13 @@ void Diagnostics::init_buffers (const FunctorsBuffersManager& fbm) {
   }
 }
 
-void Diagnostics::sync_diags_to_host () {
-  Kokkos::deep_copy(h_IEner,m_IEner);
-  Kokkos::deep_copy(h_PEner,m_PEner);
-  Kokkos::deep_copy(h_KEner,m_KEner);
+void Diagnostics::sync_diagnostics_to_host () {
+  Kokkos::deep_copy(h_IEner,  d_IEner);
+  Kokkos::deep_copy(h_PEner,  d_PEner);
+  Kokkos::deep_copy(h_KEner,  d_KEner);
+  Kokkos::deep_copy(h_Qvar,   d_Qvar);
+  Kokkos::deep_copy(h_Qmass,  d_Qmass);
+  Kokkos::deep_copy(h_Q1mass, d_Q1mass);
 }
 
 void Diagnostics::run_diagnostics (const bool before_advance, const int ivar)
@@ -104,6 +113,8 @@ void Diagnostics::run_diagnostics (const bool before_advance, const int ivar)
 
 void Diagnostics::prim_diag_scalars (const bool before_advance, const int ivar)
 {
+  m_ivar = ivar;
+
   // Get simulation params
   SimulationParams& params = Context::singleton().get<SimulationParams>();
   assert(params.params_set);
@@ -115,40 +126,13 @@ void Diagnostics::prim_diag_scalars (const bool before_advance, const int ivar)
   tl.update_tracers_levels(params.dt_tracer_factor);
 
   // Pick tracers time-level, depending on when this routine was called
-  int t2_qdp;
   if (before_advance) {
     t2_qdp = tl.n0_qdp;
   } else {
     t2_qdp = tl.np1_qdp;
   }
 
-  const Tracers& tracers = Context::singleton().get<Tracers>();
-
-  sync_to_host(tracers.Q,h_Q);
-
-  // Copy back tracers concentration and mass
-  auto qdp_h = Kokkos::create_mirror_view(tracers.qdp);
-  Kokkos::deep_copy(qdp_h,tracers.qdp);
-  for (int ie=0; ie<m_num_elems; ++ie) {
-    for (int iq=0; iq<params.qsize; ++iq) {
-      for (int igp=0; igp<NP; ++igp) {
-        for (int jgp=0; jgp<NP; ++jgp) {
-          Real accum_qdp_q = 0;
-          Real accum_qdp = 0;
-
-          HostViewUnmanaged<Real[NUM_PHYSICAL_LEV]> qdp(&qdp_h(ie, t2_qdp, iq, igp, jgp, 0)[0]);
-          for (int level=0; level<NUM_PHYSICAL_LEV; ++level) {
-            accum_qdp_q += qdp(level)*h_Q(ie, iq, level, igp, jgp);
-            accum_qdp   += qdp(level);
-          }
-          h_Qvar(ie, ivar, iq, igp, jgp) = accum_qdp_q;
-
-          h_Qmass(ie, ivar, iq, igp, jgp) = accum_qdp;
-          h_Q1mass(ie, iq, igp, jgp) = accum_qdp;
-        }
-      }
-    }
-  }
+  Kokkos::parallel_for(m_policy_diag_scalars, *this);
 }
 
 void Diagnostics::prim_energy_halftimes (const bool before_advance, const int ivar)
@@ -174,9 +158,7 @@ void Diagnostics::prim_energy_halftimes (const bool before_advance, const int iv
     t1_qdp = tl.np1_qdp;
   }
 
-  Kokkos::parallel_for(m_policy, *this);
-
-  Kokkos::deep_copy(h_KEner, m_KEner);
+  Kokkos::parallel_for(m_policy_energy_halftimes, *this);
 }
 
 } // namespace Homme

--- a/components/homme/src/theta-l_kokkos/cxx/Diagnostics.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/Diagnostics.cpp
@@ -11,6 +11,8 @@
 #include "utilities/SyncUtils.hpp"
 #include "utilities/SubviewUtils.hpp"
 
+#include "profiling.hpp"
+
 namespace Homme
 {
 
@@ -107,8 +109,10 @@ void Diagnostics::sync_diagnostics_to_host () {
 
 void Diagnostics::run_diagnostics (const bool before_advance, const int ivar)
 {
+  GPTLstart("prim_diag");
   prim_diag_scalars(before_advance, ivar);
   prim_energy_halftimes(before_advance, ivar);
+  GPTLstop("prim_diag");
 }
 
 void Diagnostics::prim_diag_scalars (const bool before_advance, const int ivar)

--- a/components/homme/src/theta-l_kokkos/cxx/Diagnostics.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/Diagnostics.hpp
@@ -119,21 +119,21 @@ public:
       // Compute Qvar
       Qvar = 0.0;
       Dispatch<>::parallel_reduce(kv.team, Kokkos::ThreadVectorRange(kv.team, NUM_PHYSICAL_LEV),
-                                  [=](const int ilev, Real& accumulator){
+                                  [&](const int ilev, Real& accumulator){
         accumulator += qdp(ilev)*Q(ilev);
       }, Qvar);
 
       // Compute Qmass
       Qmass = 0.0;
       Dispatch<>::parallel_reduce(kv.team, Kokkos::ThreadVectorRange(kv.team, NUM_PHYSICAL_LEV),
-                                  [=](const int ilev, Real& accumulator){
+                                  [&](const int ilev, Real& accumulator){
         accumulator += qdp(ilev);
       }, Qmass);
 
       // Compute Q1mass
       Q1mass = 0.0;
       Dispatch<>::parallel_reduce(kv.team, Kokkos::ThreadVectorRange(kv.team, NUM_PHYSICAL_LEV),
-                                  [=](const int ilev, Real& accumulator){
+                                  [&](const int ilev, Real& accumulator){
         accumulator += qdp(ilev);
       }, Q1mass);
     });
@@ -209,7 +209,7 @@ public:
       // Compute KEner
       KEner = 0.0;
       Dispatch<>::parallel_reduce(kv.team, Kokkos::ThreadVectorRange(kv.team, NUM_PHYSICAL_LEV),
-                                  [=](const int ilev, Real& accumulator){
+                                  [&](const int ilev, Real& accumulator){
         accumulator += ((u(ilev)*u(ilev) + v(ilev)*v(ilev))/2.0) * dpt1_real(ilev);
       }, KEner);
 
@@ -217,7 +217,7 @@ public:
         Real sum = 0.0;
         auto w_i = viewAsReal(Homme::subview(m_state.m_w_i,kv.ie,t1,igp,jgp));
         Dispatch<>::parallel_reduce(kv.team,Kokkos::ThreadVectorRange(kv.team,NUM_PHYSICAL_LEV),
-                                    [=](const int ilev, Real& accumulator){
+                                    [&](const int ilev, Real& accumulator){
           accumulator += (w_i(ilev)*w_i(ilev) + w_i(ilev+1)*w_i(ilev+1))/4.0 *dpt1_real(ilev);
         },sum);
 
@@ -230,7 +230,7 @@ public:
       // Compute PEner
       PEner = 0.0;
       Dispatch<>::parallel_reduce(kv.team,Kokkos::ThreadVectorRange(kv.team, NUM_PHYSICAL_LEV),
-                                  [=](const int ilev, Real& accumulator){
+                                [&](const int ilev, Real& accumulator){
         accumulator += phi_real(ilev)*dpt1_real(ilev);
       },PEner);
 
@@ -238,7 +238,7 @@ public:
       IEner = 0.0;
       Kokkos::Real2 sum;
       Dispatch<>::parallel_reduce(kv.team,Kokkos::ThreadVectorRange(kv.team, NUM_PHYSICAL_LEV),
-                                  [=](const int ilev, Kokkos::Real2& accumulator){
+                                  [&](const int ilev, Kokkos::Real2& accumulator){
         accumulator.v[0] += PhysicalConstants::cp*vtheta_dp_real(ilev)*exner_real(ilev);
         accumulator.v[1] += (phi_i_real(ilev+1)-phi_i_real(ilev))*pnh_real(ilev);
       },sum);

--- a/components/homme/src/theta-l_kokkos/cxx/Diagnostics.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/Diagnostics.hpp
@@ -9,6 +9,7 @@
 #include "EquationOfState.hpp"
 #include "ElementOps.hpp"
 #include "HybridVCoord.hpp"
+#include "Tracers.hpp"
 #include "KernelVariables.hpp"
 #include "utilities/SubviewUtils.hpp"
 #include "utilities/ViewUtils.hpp"
@@ -65,36 +66,78 @@ private:
 public:
 
 
-  Diagnostics (const int num_elems, const bool theta_hydrostatic_mode) :
+  Diagnostics (const int num_elems, const int num_tracers, const bool theta_hydrostatic_mode) :
 #if ! defined(RESOLVE_ISSUE_WITH_ASSERTS)
-    m_policy(Homme::get_default_team_policy<ExecSpace,EnergyHalfTimesTag>(num_elems)),
+    m_policy_diag_scalars(Homme::get_default_team_policy<ExecSpace,DiagScalarsTag>(num_elems*num_tracers)),
+    m_policy_energy_halftimes(Homme::get_default_team_policy<ExecSpace,EnergyHalfTimesTag>(num_elems)),
 #else
-    m_policy(d_team_policy<EnergyHalfTimesTag>(num_elems)),
+    m_policy_diag_scalars(d_team_policy<DiagScalarsTag>(num_elems*num_tracers)),
+    m_policy_energy_halftimes(d_team_policy<EnergyHalfTimesTag>(num_elems)),
 #endif
-    m_tu(m_policy),
+    m_tu(m_policy_energy_halftimes),
     m_num_elems(num_elems),
+    m_num_tracers(num_tracers),
     m_theta_hydrostatic_mode(theta_hydrostatic_mode)
   {}
 
   void init (const ElementsState& state, const ElementsGeometry& geometry,
-             const HybridVCoord& hvcoord,  F90Ptr& elem_state_q_ptr,
-             F90Ptr& elem_accum_qvar_ptr,  F90Ptr& elem_accum_qmass_ptr,
-             F90Ptr& elem_accum_q1mass_ptr,F90Ptr& elem_accum_iener_ptr,
-             F90Ptr& elem_accum_kener_ptr, F90Ptr& elem_accum_pener_ptr);
+             const HybridVCoord& hvcoord,  const Tracers& tracers,
+             F90Ptr& elem_state_q_ptr, F90Ptr& elem_accum_qvar_ptr,
+             F90Ptr& elem_accum_qmass_ptr, F90Ptr& elem_accum_q1mass_ptr,
+             F90Ptr& elem_accum_iener_ptr, F90Ptr& elem_accum_kener_ptr,
+             F90Ptr& elem_accum_pener_ptr);
 
   int requested_buffer_size () const;
   void init_buffers (const FunctorsBuffersManager& fbm);
 
-  void sync_diags_to_host ();
+  void sync_diagnostics_to_host ();
 
   void run_diagnostics (const bool before_advance, const int ivar);
 
   void prim_diag_scalars (const bool before_advance, const int ivar);
   void prim_energy_halftimes (const bool before_advance, const int ivar);
 
-  HostViewUnmanaged<Real*[QSIZE_D][NUM_PHYSICAL_LEV][NP][NP]> h_Q;
-
+  struct DiagScalarsTag {};
   struct EnergyHalfTimesTag {};
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (const DiagScalarsTag&, const TeamMember& team) const {
+    KernelVariables kv(team, m_num_tracers);
+
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(kv.team, NP * NP),
+                         [&](const int &point_idx) {
+      const int igp = point_idx / NP;
+      const int jgp = point_idx % NP;
+
+      const auto Q   = viewAsReal(Homme::subview(m_tracers.Q,   kv.ie,         kv.iq, igp, jgp));
+      const auto qdp = viewAsReal(Homme::subview(m_tracers.qdp, kv.ie, t2_qdp, kv.iq, igp, jgp));
+
+      auto& Qvar =   d_Qvar  (kv.ie,m_ivar,kv.iq,igp,jgp);
+      auto& Qmass =  d_Qmass (kv.ie,m_ivar,kv.iq,igp,jgp);
+      auto& Q1mass = d_Q1mass(kv.ie,       kv.iq,igp,jgp);
+
+      // Compute Qvar
+      Qvar = 0.0;
+      Dispatch<>::parallel_reduce(kv.team, Kokkos::ThreadVectorRange(kv.team, NUM_PHYSICAL_LEV),
+                                  [=](const int ilev, Real& accumulator){
+        accumulator += qdp(ilev)*Q(ilev);
+      }, Qvar);
+
+      // Compute Qmass
+      Qmass = 0.0;
+      Dispatch<>::parallel_reduce(kv.team, Kokkos::ThreadVectorRange(kv.team, NUM_PHYSICAL_LEV),
+                                  [=](const int ilev, Real& accumulator){
+        accumulator += qdp(ilev);
+      }, Qmass);
+
+      // Compute Q1mass
+      Q1mass = 0.0;
+      Dispatch<>::parallel_reduce(kv.team, Kokkos::ThreadVectorRange(kv.team, NUM_PHYSICAL_LEV),
+                                  [=](const int ilev, Real& accumulator){
+        accumulator += qdp(ilev);
+      }, Q1mass);
+    });
+  }
 
   KOKKOS_INLINE_FUNCTION
   void operator() (const EnergyHalfTimesTag&, const TeamMember& team) const {
@@ -159,9 +202,9 @@ public:
       ColumnOps::compute_midpoint_values(kv,Homme::subview(phi_i,igp,jgp),
                                             Homme::subview(phi,  igp,jgp));
 
-      auto& KEner = m_KEner(kv.ie,m_ivar,igp,jgp);
-      auto& PEner = m_PEner(kv.ie,m_ivar,igp,jgp);
-      auto& IEner = m_IEner(kv.ie,m_ivar,igp,jgp);
+      auto& KEner = d_KEner(kv.ie,m_ivar,igp,jgp);
+      auto& PEner = d_PEner(kv.ie,m_ivar,igp,jgp);
+      auto& IEner = d_IEner(kv.ie,m_ivar,igp,jgp);
 
       // Compute KEner
       KEner = 0.0;
@@ -212,29 +255,35 @@ private:
   HostViewUnmanaged<Real*[NUM_DIAG_TIMES][NP][NP]> h_KEner;
   HostViewUnmanaged<Real*[NUM_DIAG_TIMES][NP][NP]> h_PEner;
 
-  HostViewUnmanaged<Real*[NUM_DIAG_TIMES][QSIZE_D][NP][NP]>     h_Qvar;
-  HostViewUnmanaged<Real*[NUM_DIAG_TIMES][QSIZE_D][NP][NP]>     h_Qmass;
-  HostViewUnmanaged<Real*                [QSIZE_D][NP][NP]>     h_Q1mass;
+  ExecViewManaged<Real*[NUM_DIAG_TIMES][NP][NP]> d_IEner;
+  ExecViewManaged<Real*[NUM_DIAG_TIMES][NP][NP]> d_KEner;
+  ExecViewManaged<Real*[NUM_DIAG_TIMES][NP][NP]> d_PEner;
 
+  HostViewUnmanaged<Real*[NUM_DIAG_TIMES][QSIZE_D][NP][NP]> h_Qvar;
+  HostViewUnmanaged<Real*[NUM_DIAG_TIMES][QSIZE_D][NP][NP]> h_Qmass;
+  HostViewUnmanaged<Real*                [QSIZE_D][NP][NP]> h_Q1mass;
 
-  ExecViewManaged<Real*[NUM_DIAG_TIMES][NP][NP]>   m_IEner;
-  ExecViewManaged<Real*[NUM_DIAG_TIMES][NP][NP]>   m_KEner;
-  ExecViewManaged<Real*[NUM_DIAG_TIMES][NP][NP]>   m_PEner;
+  ExecViewManaged<Real*[NUM_DIAG_TIMES][QSIZE_D][NP][NP]> d_Qvar;
+  ExecViewManaged<Real*[NUM_DIAG_TIMES][QSIZE_D][NP][NP]> d_Qmass;
+  ExecViewManaged<Real*                [QSIZE_D][NP][NP]> d_Q1mass;
 
   HybridVCoord      m_hvcoord;
   EquationOfState   m_eos;
   ElementOps        m_elem_ops;
   ElementsState     m_state;
   ElementsGeometry  m_geometry;
+  Tracers           m_tracers;
   Buffers           m_buffers;
 
-  Kokkos::TeamPolicy<ExecSpace, EnergyHalfTimesTag> m_policy;
+  Kokkos::TeamPolicy<ExecSpace, DiagScalarsTag>     m_policy_diag_scalars;
+  Kokkos::TeamPolicy<ExecSpace, EnergyHalfTimesTag> m_policy_energy_halftimes;
   TeamUtils<ExecSpace> m_tu;
 
-  int t1,t1_qdp;
+  int t1,t1_qdp,t2_qdp;
 
   int m_ivar;
   int m_num_elems;
+  int m_num_tracers;
 
   bool m_theta_hydrostatic_mode;
 };

--- a/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
@@ -41,7 +41,7 @@ extern "C"
 void init_simulation_params_c (const int& remap_alg, const int& limiter_option, const int& rsplit, const int& qsplit,
                                const int& time_step_type, const int& qsize, const int& state_frequency,
                                const Real& nu, const Real& nu_p, const Real& nu_q, const Real& nu_s, const Real& nu_div, const Real& nu_top,
-                               const int& hypervis_order, const int& hypervis_subcycle, const int& hypervis_subcycle_tom, 
+                               const int& hypervis_order, const int& hypervis_subcycle, const int& hypervis_subcycle_tom,
                                const double& hypervis_scaling, const double& dcmip16_mu,
                                const int& ftype, const int& theta_adv_form, const bool& prescribed_wind, const bool& moisture, const bool& disable_diagnostics,
                                const bool& use_cpstar, const int& transport_alg, const bool& theta_hydrostatic_mode, const char** test_case,
@@ -136,7 +136,7 @@ void init_simulation_params_c (const int& remap_alg, const int& limiter_option, 
     //2nd order implicit table
     params.time_step_type = TimeStepType::ttype10_imex;
   } else if ( ! params.prescribed_wind) {
-    Errors::runtime_abort("Invalid time_step_type" 
+    Errors::runtime_abort("Invalid time_step_type"
                           + std::to_string(time_step_type), Errors::err_not_implemented);
   }
 
@@ -353,7 +353,8 @@ void init_functors_c (const bool& allocate_buffer)
 #endif
   auto& hvf     = c.create_if_not_there<HyperviscosityFunctor>();
   auto& ff      = c.create_if_not_there<ForcingFunctor>();
-  auto& diag    = c.create_if_not_there<Diagnostics> (elems.num_elems(),params.theta_hydrostatic_mode);
+  auto& diag    = c.create_if_not_there<Diagnostics> (elems.num_elems(),tracers.num_tracers(),
+                                                      params.theta_hydrostatic_mode);
   auto& vrm     = c.create_if_not_there<VerticalRemapManager>(elems.num_elems());
 
   auto& fbm     = c.create_if_not_there<FunctorsBuffersManager>();
@@ -370,10 +371,10 @@ void init_functors_c (const bool& allocate_buffer)
     auto& esf = c.get<EulerStepFunctor>();
     if (esf.setup_needed()) esf.setup();
   } else {
-#ifdef HOMME_ENABLE_COMPOSE	  
+#ifdef HOMME_ENABLE_COMPOSE
     auto& ct = c.get<ComposeTransport>();
     if (ct.setup_needed()) ct.setup();
-#endif    
+#endif
   }
   if (hvf.setup_needed()) {
     hvf.setup(geometry, state, derived);
@@ -385,7 +386,7 @@ void init_functors_c (const bool& allocate_buffer)
     vrm.setup();
   }
 
-  const bool need_dirk = (params.time_step_type==TimeStepType::ttype7_imex ||   
+  const bool need_dirk = (params.time_step_type==TimeStepType::ttype7_imex ||
                           params.time_step_type==TimeStepType::ttype9_imex ||
                           params.time_step_type==TimeStepType::ttype10_imex  );
 
@@ -402,7 +403,7 @@ void init_functors_c (const bool& allocate_buffer)
     if (params.transport_alg == 0)
       fbm.request_size(c.get<EulerStepFunctor>().requested_buffer_size());
 #ifdef HOMME_ENABLE_COMPOSE
-    else	    
+    else
       fbm.request_size(c.get<ComposeTransport>().requested_buffer_size());
 #endif
     fbm.request_size(hvf.requested_buffer_size());
@@ -523,7 +524,7 @@ void init_elements_states_c (CF90Ptr& elem_state_v_ptr,       CF90Ptr& elem_stat
   });
 }
 
-void init_reference_states_c (CF90Ptr& elem_theta_ref_ptr, 
+void init_reference_states_c (CF90Ptr& elem_theta_ref_ptr,
                               CF90Ptr& elem_dp_ref_ptr,
                               CF90Ptr& elem_phi_ref_ptr)
 {
@@ -551,8 +552,9 @@ void init_diagnostics_c (F90Ptr& elem_state_q_ptr, F90Ptr& elem_accum_qvar_ptr, 
   Diagnostics&      diags    = Context::singleton().get<Diagnostics> ();
 
   auto& hvcoord = Context::singleton().get<HybridVCoord>();
-  
-  diags.init(state, geometry, hvcoord,
+  const auto& tracers = Context::singleton().get<Tracers>();
+
+  diags.init(state, geometry, hvcoord, tracers,
              elem_state_q_ptr, elem_accum_qvar_ptr, elem_accum_qmass_ptr, elem_accum_q1mass_ptr,
              elem_accum_iener_ptr, elem_accum_kener_ptr, elem_accum_pener_ptr);
 }
@@ -580,11 +582,11 @@ void init_boundary_exchanges_c ()
     esf.reset(params);
     esf.init_boundary_exchanges();
   } else {
-#ifdef HOMME_ENABLE_COMPOSE	  
+#ifdef HOMME_ENABLE_COMPOSE
     auto& ct = c.get<ComposeTransport>();
     ct.reset(params);
     ct.init_boundary_exchanges();
-#endif    
+#endif
   }
 
   // RK stages BE's
@@ -616,6 +618,11 @@ void push_test_state_to_c (
     vn0_h(vn0_ptr, derived.num_elems());
   sync_to_device(eta_dot_dpdn_h, derived.m_eta_dot_dpdn);
   sync_to_device(vn0_h, derived.m_vn0);
+}
+
+void sync_diagnostics_to_host_c ()
+{
+  Context::singleton().get<Diagnostics>().sync_diagnostics_to_host();
 }
 
 } // extern "C"

--- a/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
+++ b/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
@@ -475,7 +475,9 @@ contains
     ! Print some diagnostic information
 
     if (compute_diagnostics) then
+       call t_startf('sync_diag_to_host')
        call sync_diagnostics_to_host_c()
+       call t_stopf('sync_diag_to_host')
        call prim_printstate(elem, tl, hybrid,hvcoord,nets,nete)
     end if
 

--- a/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
+++ b/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
@@ -372,7 +372,7 @@ contains
     use perf_mod,       only : t_startf, t_stopf
     use prim_state_mod, only : prim_printstate
     use theta_f2c_mod,  only : prim_run_subcycle_c, cxx_push_results_to_f90
-    use theta_f2c_mod,  only : push_forcing_to_c
+    use theta_f2c_mod,  only : push_forcing_to_c, sync_diagnostics_to_host_c
     !
     ! Inputs
     !
@@ -441,7 +441,7 @@ contains
     if (prescribed_wind == 1) then ! standalone Homme
       call set_prescribed_wind_f(elem,deriv1,hybrid,hvcoord,dt,tl,nets,nete)
     end if
-   
+
     call prim_run_subcycle_c(dt,nstep_c,nm1_c,n0_c,np1_c,nextOutputStep,nsplit_iteration)
 
     ! Set final timelevels from C into Fortran structure
@@ -475,6 +475,7 @@ contains
     ! Print some diagnostic information
 
     if (compute_diagnostics) then
+       call sync_diagnostics_to_host_c()
        call prim_printstate(elem, tl, hybrid,hvcoord,nets,nete)
     end if
 
@@ -495,9 +496,9 @@ contains
 ! (always forcing and push to c) -> (subcycle) -> (always push to f)
 
   function is_push_to_c_required(nsplit_iter) result(compute_forcing_and_push_to_c)
-    
+
     use control_mod, only: test_with_forcing
-    
+
     integer,              intent(in) :: nsplit_iter
 
     logical :: compute_forcing_and_push_to_c
@@ -506,7 +507,7 @@ contains
 
     ! Scream already computes all forcing using the same pointers
     ! stored in Hommexx, so the forcing is already up to date
-#if defined(HOMMEXX_BENCHMARK_NOFORCING) 
+#if defined(HOMMEXX_BENCHMARK_NOFORCING)
 
 #elif defined(SCREAM)
 
@@ -531,7 +532,7 @@ contains
     type (TimeLevel_t),   intent(in) :: tl
     integer,              intent(in) :: statefreq, nextOutputStep, nsplit_iter
     logical,              intent(in) :: compute_diagnostics
- 
+
     logical                          :: push_to_f, time_for_homme_output
 
     push_to_f = .false.
@@ -545,7 +546,7 @@ contains
 #elif defined(SCREAM)
 !SCREAM run, only compute_diagnostics
     push_to_f = compute_diagnostics
-    
+
 #elif defined(CAM)
 !CAM run, push at the end of nsplit loop
     if (nsplit_iter == nsplit) then
@@ -558,11 +559,11 @@ contains
        push_to_f = .true.
     endif
 
-#else     
+#else
 !standalone homme, not benchmarks
 !output
-    !if (MODULO(tl%nstep,statefreq)==0 .or. tl%nstep >= nextOutputStep .or. compute_diagnostics) then 
-    if ( time_for_homme_output ) then 
+    !if (MODULO(tl%nstep,statefreq)==0 .or. tl%nstep >= nextOutputStep .or. compute_diagnostics) then
+    if ( time_for_homme_output ) then
        push_to_f = .true.
     endif
 
@@ -607,7 +608,7 @@ contains
     dt = 0        ! value unused in initialization
     eta_ave_w = 0 ! same
     call set_prescribed_wind(elem,deriv,hybrid,hvcoord,dt,tl,nets,nete,eta_ave_w)
-#endif        
+#endif
   end subroutine init_standalone_test
 
   subroutine compute_test_forcing_f(elem,hybrid,hvcoord,nt,ntQ,dt,nets,nete,tl)
@@ -647,7 +648,7 @@ contains
                                  elem_state_phinh_i, elem_state_dp3d, elem_state_ps_v,   &
                                  elem_derived_eta_dot_dpdn, elem_derived_vn0
 #endif
-    
+
     type (element_t),      intent(inout), target  :: elem(:)
     type (derivative_t),   intent(in)             :: deriv
     type (hvcoord_t),      intent(in)             :: hvcoord
@@ -662,7 +663,7 @@ contains
     type (c_ptr) :: elem_state_v_ptr, elem_state_w_i_ptr, elem_state_vtheta_dp_ptr, elem_state_phinh_i_ptr
     type (c_ptr) :: elem_state_dp3d_ptr, elem_state_Qdp_ptr, elem_state_Q_ptr, elem_state_ps_v_ptr
     type (c_ptr) :: elem_derived_eta_dot_dpdn_ptr, elem_derived_vn0_ptr
-    
+
     real(kind=real_kind) :: eta_ave_w
 
     ! We need to set up an hvcoord_t that can be passed as intent(inout), even
@@ -678,7 +679,7 @@ contains
 
     eta_ave_w = 1d0/qsplit
     call set_prescribed_wind(elem,deriv,hybrid,hv,dt,tl,nets,nete,eta_ave_w)
-    
+
     call t_startf('push_to_cxx')
     elem_state_v_ptr         = c_loc(elem_state_v)
     elem_state_w_i_ptr       = c_loc(elem_state_w_i)
@@ -692,7 +693,7 @@ contains
          elem_state_vtheta_dp_ptr, elem_state_phinh_i_ptr, elem_state_v_ptr, &
          elem_state_w_i_ptr, elem_derived_eta_dot_dpdn_ptr, elem_derived_vn0_ptr)
     call t_stopf('push_to_cxx')
-#endif    
+#endif
   end subroutine set_prescribed_wind_f
 
 end module

--- a/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
+++ b/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
@@ -198,9 +198,13 @@ interface
        ! derived
        eta_dot_dpdn, vn0) bind(c)
     use iso_c_binding, only: c_ptr
-    
+
     type (c_ptr), intent(in) :: ps_v, dp3d, vtheta_dp, phinh_i, v, w_i, eta_dot_dpdn, vn0
   end subroutine push_test_state_to_c
+
+  ! Sync diagnostics computed on device to host
+  subroutine sync_diagnostics_to_host_c() bind(c)
+  end subroutine sync_diagnostics_to_host_c
 end interface
 
 end module theta_f2c_mod


### PR DESCRIPTION
Previously, `prim_diag_scalars()` computation was done on host. 

Additionally, while `prim_energy_halftimes()` was already ported to GPU, it contained a `deep_copy()` to host at every single call, and `Diagnostics::sync_diagnostics_to_host()` defined but never used. A new F90->Cxx function created and deep copies to host only happen right before diagnostic info is printed.

For testing I added changes to `components/homme/cmake/CxxVsF90.cmake.in` from https://github.com/E3SM-Project/E3SM/pull/5386 which compare diagnostic output. Diagnostics related to `Q`,`Qvar`,`Qmass` match between F90 and Cxx runs for all `theta-f*ne2*` tests.

[bfb]