### PR TITLE
Improve robustness of Kokkos build script

### DIFF
--- a/share/build/buildlib.kokkos
+++ b/share/build/buildlib.kokkos
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import os, sys, argparse, logging
+import os, sys, argparse, logging, shutil
 
 from standard_script_setup import *
 from CIME import utils
@@ -94,7 +94,13 @@ def buildlib(bldroot, installpath, case):
                 .split(":=")[-1]
                 .strip()
             )
-        cxx = "-DCMAKE_CXX_COMPILER={}".format(cxx)
+
+        if "/" in cxx:
+            cxx = "-DCMAKE_CXX_COMPILER={}".format(cxx)
+        else:
+            cxx_path = shutil.which(cxx)
+            expect(cxx_path is not None, "{} is not in PATH?".format(cxx))
+            cxx = "-DCMAKE_CXX_COMPILER={}".format(cxx_path)
 
     gmake_cmd = case.get_value("GMAKE")
     gmake_j = case.get_value("GMAKE_J")


### PR DESCRIPTION
It seems that, sometimes, the kokkos CMake will change the CMAKE_CXX_COMPILER to an absolute path before storing it in the cache. Subsequent calls to cmake that do not have -DCMAKE_CXX_COMPILER=$absolute_path_to_cxx will be interpreted as a changed compiler, which results in the CMakeCache being flushed and then results in CMAKE_INSTALL_PREFIX being lost.

I'm not sure if this is a bug in CMake or Kokkos' cmake files, but this PR will work around the problem.

Fixes #5422 

[BFB]