### PR TITLE
New ocean implicit top drag feature

### DIFF
--- a/cime_config/config_files.xml
+++ b/cime_config/config_files.xml
@@ -345,6 +345,7 @@
       <value component="cice"     >$COMP_ROOT_DIR_ICE/cime_config/testdefs/testmods_dirs</value>
       <value component="mosart"   >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testmods_dirs</value>
       <value component="scream"   >$COMP_ROOT_DIR_ATM/cime_config/testdefs/testmods_dirs</value>
+      <value component="mpaso"    >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testmods_dirs</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -197,7 +197,7 @@ _TESTS = {
 
 
     "e3sm_integration" : {
-        "inherit" : ("e3sm_developer", "e3sm_atm_integration", "e3sm_mmf_integration"),
+        "inherit" : ("e3sm_developer", "e3sm_atm_integration", "e3sm_mmf_integration", "e3sm_ocn_integration"),
         "time"    : "03:00:00",
         "tests"   : (
             "ERS.ne11_oQU240.WCYCL1850NS",

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -154,7 +154,14 @@ _TESTS = {
             )
         },
 
+    "e3sm_ocnice_stealth_features" : {
+        "tests" : (
+            "SMS_D_Ld1.T62_oQU240wLI.GMPAS-IAF-ISMF.mpaso-impl_top_drag",
+            )
+        },
+
     "e3sm_ocnice_extra_coverage" : {
+        "inherit" : ("e3sm_ocnice_stealth_features"),
         "tests" : (
             "ERS_P480_Ld5.T62_ECwISC30to60E2r1.GMPAS-DIB-IAF-ISMF",
             "PEM_P480_Ld5.T62_ECwISC30to60E2r1.GMPAS-DIB-IAF-ISMF",
@@ -188,13 +195,6 @@ _TESTS = {
             "HOMMEBFB_P24.f19_g16_rx1.A",
             )
         },
-
-    "e3sm_ocn_integration" : {
-        "tests" : (
-            "SMS_D_Ld1.T62_oQU240wLI.GMPAS-IAF-ISMF.mpaso-impl_top_drag",
-            )
-        },
-
 
     "e3sm_integration" : {
         "inherit" : ("e3sm_developer", "e3sm_atm_integration", "e3sm_mmf_integration", "e3sm_ocn_integration"),

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -197,7 +197,7 @@ _TESTS = {
         },
 
     "e3sm_integration" : {
-        "inherit" : ("e3sm_developer", "e3sm_atm_integration", "e3sm_mmf_integration", "e3sm_ocn_integration"),
+        "inherit" : ("e3sm_developer", "e3sm_atm_integration", "e3sm_mmf_integration"),
         "time"    : "03:00:00",
         "tests"   : (
             "ERS.ne11_oQU240.WCYCL1850NS",

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -189,6 +189,13 @@ _TESTS = {
             )
         },
 
+    "e3sm_ocn_integration" : {
+        "tests" : (
+            "SMS_D_Ld1.T62_oQU240wLI.GMPAS-IAF-ISMF.mpaso-impl_top_drag",
+            )
+        },
+
+
     "e3sm_integration" : {
         "inherit" : ("e3sm_developer", "e3sm_atm_integration", "e3sm_mmf_integration"),
         "time"    : "03:00:00",

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -672,7 +672,7 @@ if ($ocn_wave eq 'true' ) {
 }
 
 #################################
-# Namelist group: wave coupling #
+# Namelist group: wave_coupling #
 #################################
 
 if ($ocn_wave eq 'true' ) {
@@ -790,7 +790,7 @@ add_default($nl, 'config_land_ice_flux_boundaryLayerThickness');
 add_default($nl, 'config_land_ice_flux_boundaryLayerNeighborWeight');
 add_default($nl, 'config_land_ice_flux_cp_ice');
 add_default($nl, 'config_land_ice_flux_rho_ice');
-add_default($nl, 'config_land_ice_flux_topDragCoeff');
+add_default($nl, 'config_land_ice_flux_explicit_topDragCoeff');
 add_default($nl, 'config_land_ice_flux_ISOMIP_gammaT');
 add_default($nl, 'config_land_ice_flux_rms_tidal_velocity');
 add_default($nl, 'config_land_ice_flux_jenkins_heat_transfer_coefficient');
@@ -815,6 +815,8 @@ add_default($nl, 'config_remap_limiter');
 
 add_default($nl, 'config_use_implicit_bottom_drag');
 add_default($nl, 'config_implicit_bottom_drag_coeff');
+add_default($nl, 'config_use_implicit_top_drag');
+add_default($nl, 'config_implicit_top_drag_coeff');
 add_default($nl, 'config_use_implicit_bottom_roughness');
 add_default($nl, 'config_use_implicit_bottom_drag_variable');
 add_default($nl, 'config_use_implicit_bottom_drag_variable_mannings');

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -208,8 +208,8 @@ add_default($nl, 'config_cvmix_kpp_use_active_wave');
 # Namelist group: wave_coupling #
 #################################
 
-add_default($nl, 'config_n_stokes_drift_wavenumber_partitions');
 add_default($nl, 'config_use_active_wave');
+add_default($nl, 'config_n_stokes_drift_wavenumber_partitions');
 
 ########################
 # Namelist group: gotm #
@@ -309,7 +309,7 @@ add_default($nl, 'config_land_ice_flux_boundaryLayerThickness');
 add_default($nl, 'config_land_ice_flux_boundaryLayerNeighborWeight');
 add_default($nl, 'config_land_ice_flux_cp_ice');
 add_default($nl, 'config_land_ice_flux_rho_ice');
-add_default($nl, 'config_land_ice_flux_topDragCoeff');
+add_default($nl, 'config_land_ice_flux_explicit_topDragCoeff');
 add_default($nl, 'config_land_ice_flux_ISOMIP_gammaT');
 add_default($nl, 'config_land_ice_flux_rms_tidal_velocity');
 add_default($nl, 'config_land_ice_flux_jenkins_heat_transfer_coefficient');
@@ -334,6 +334,8 @@ add_default($nl, 'config_remap_limiter');
 
 add_default($nl, 'config_use_implicit_bottom_drag');
 add_default($nl, 'config_implicit_bottom_drag_coeff');
+add_default($nl, 'config_use_implicit_top_drag');
+add_default($nl, 'config_implicit_top_drag_coeff');
 add_default($nl, 'config_use_implicit_bottom_roughness');
 add_default($nl, 'config_use_implicit_bottom_drag_variable');
 add_default($nl, 'config_use_implicit_bottom_drag_variable_mannings');

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -378,7 +378,11 @@
 <config_use_implicit_bottom_drag>.true.</config_use_implicit_bottom_drag>
 <config_implicit_bottom_drag_coeff>1.0e-3</config_implicit_bottom_drag_coeff>
 <config_use_implicit_top_drag>.false.</config_use_implicit_top_drag>
-<config_implicit_top_drag_coeff>1.0e-3</config_implicit_top_drag_coeff>
+<config_implicit_top_drag_coeff>2.5e-3</config_implicit_top_drag_coeff>
+<config_implicit_top_drag_coeff ocn_grid="oEC60to30v3wLI">4.48e-3</config_implicit_top_drag_coeff>
+<config_implicit_top_drag_coeff ocn_grid="ECwISC30to60E1r2">4.48e-3</config_implicit_top_drag_coeff>
+<config_implicit_top_drag_coeff ocn_grid="SOwISC12to60E2r4">4.48e-3</config_implicit_top_drag_coeff>
+<config_implicit_top_drag_coeff ocn_grid="ECwISC30to60E2r1">4.48e-3</config_implicit_top_drag_coeff>
 <config_use_implicit_bottom_roughness>.false.</config_use_implicit_bottom_roughness>
 <config_use_implicit_bottom_drag_variable>.false.</config_use_implicit_bottom_drag_variable>
 <config_use_implicit_bottom_drag_variable_mannings>.false.</config_use_implicit_bottom_drag_variable_mannings>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -347,6 +347,10 @@
 <config_land_ice_flux_cp_ice>2.009e3</config_land_ice_flux_cp_ice>
 <config_land_ice_flux_rho_ice>918</config_land_ice_flux_rho_ice>
 <config_land_ice_flux_explicit_topDragCoeff>2.5e-3</config_land_ice_flux_explicit_topDragCoeff>
+<config_land_ice_flux_explicit_topDragCoeff ocn_grid="oEC60to30v3wLI">4.48e-3</config_land_ice_flux_explicit_topDragCoeff>
+<config_land_ice_flux_explicit_topDragCoeff ocn_grid="ECwISC30to60E1r2">4.48e-3</config_land_ice_flux_explicit_topDragCoeff>
+<config_land_ice_flux_explicit_topDragCoeff ocn_grid="SOwISC12to60E2r4">4.48e-3</config_land_ice_flux_explicit_topDragCoeff>
+<config_land_ice_flux_explicit_topDragCoeff ocn_grid="ECwISC30to60E2r1">4.48e-3</config_land_ice_flux_explicit_topDragCoeff>
 <config_land_ice_flux_ISOMIP_gammaT>1e-4</config_land_ice_flux_ISOMIP_gammaT>
 <config_land_ice_flux_rms_tidal_velocity>5e-2</config_land_ice_flux_rms_tidal_velocity>
 <config_land_ice_flux_jenkins_heat_transfer_coefficient>0.011</config_land_ice_flux_jenkins_heat_transfer_coefficient>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -14,6 +14,7 @@
 <config_run_duration>'0010_00:00:00'</config_run_duration>
 <config_calendar_type CALENDAR="NO_LEAP">'noleap'</config_calendar_type>
 <config_calendar_type>'gregorian'</config_calendar_type>
+<config_output_reference_time>'0001-01-01_00:00:00'</config_output_reference_time>
 
 <!-- io -->
 <config_write_output_on_startup>.false.</config_write_output_on_startup>
@@ -257,12 +258,11 @@
 <config_cvmix_kpp_use_enhanced_diff>.true.</config_cvmix_kpp_use_enhanced_diff>
 <config_cvmix_kpp_nonlocal_with_implicit_mix>.false.</config_cvmix_kpp_nonlocal_with_implicit_mix>
 <config_cvmix_kpp_use_theory_wave>.false.</config_cvmix_kpp_use_theory_wave>
-<config_cvmix_kpp_use_active_wave>.false.</config_cvmix_kpp_use_active_wave>
 <config_cvmix_kpp_langmuir_mixing_opt>'NONE'</config_cvmix_kpp_langmuir_mixing_opt>
 <config_cvmix_kpp_langmuir_entrainment_opt>'NONE'</config_cvmix_kpp_langmuir_entrainment_opt>
+<config_cvmix_kpp_use_active_wave>.false.</config_cvmix_kpp_use_active_wave>
 
-
-<!-- wave coupling-->
+<!-- wave_coupling -->
 <config_use_active_wave>.false.</config_use_active_wave>
 <config_n_stokes_drift_wavenumber_partitions>6</config_n_stokes_drift_wavenumber_partitions>
 
@@ -346,11 +346,7 @@
 <config_land_ice_flux_boundaryLayerNeighborWeight>0.0</config_land_ice_flux_boundaryLayerNeighborWeight>
 <config_land_ice_flux_cp_ice>2.009e3</config_land_ice_flux_cp_ice>
 <config_land_ice_flux_rho_ice>918</config_land_ice_flux_rho_ice>
-<config_land_ice_flux_topDragCoeff>2.5e-3</config_land_ice_flux_topDragCoeff>
-<config_land_ice_flux_topDragCoeff ocn_grid="oEC60to30v3wLI">4.48e-3</config_land_ice_flux_topDragCoeff>
-<config_land_ice_flux_topDragCoeff ocn_grid="ECwISC30to60E1r2">4.48e-3</config_land_ice_flux_topDragCoeff>
-<config_land_ice_flux_topDragCoeff ocn_grid="SOwISC12to60E2r4">4.48e-3</config_land_ice_flux_topDragCoeff>
-<config_land_ice_flux_topDragCoeff ocn_grid="ECwISC30to60E2r1">4.48e-3</config_land_ice_flux_topDragCoeff>
+<config_land_ice_flux_explicit_topDragCoeff>2.5e-3</config_land_ice_flux_explicit_topDragCoeff>
 <config_land_ice_flux_ISOMIP_gammaT>1e-4</config_land_ice_flux_ISOMIP_gammaT>
 <config_land_ice_flux_rms_tidal_velocity>5e-2</config_land_ice_flux_rms_tidal_velocity>
 <config_land_ice_flux_jenkins_heat_transfer_coefficient>0.011</config_land_ice_flux_jenkins_heat_transfer_coefficient>
@@ -377,6 +373,8 @@
 <!-- bottom_drag -->
 <config_use_implicit_bottom_drag>.true.</config_use_implicit_bottom_drag>
 <config_implicit_bottom_drag_coeff>1.0e-3</config_implicit_bottom_drag_coeff>
+<config_use_implicit_top_drag>.false.</config_use_implicit_top_drag>
+<config_implicit_top_drag_coeff>1.0e-3</config_implicit_top_drag_coeff>
 <config_use_implicit_bottom_roughness>.false.</config_use_implicit_bottom_roughness>
 <config_use_implicit_bottom_drag_variable>.false.</config_use_implicit_bottom_drag_variable>
 <config_use_implicit_bottom_drag_variable_mannings>.false.</config_use_implicit_bottom_drag_variable_mannings>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -111,6 +111,14 @@ Valid values: 'gregorian', 'noleap'
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_output_reference_time" type="char*1024"
+	category="time_management" group="time_management">
+Reference time used in the units attribute of Time in output files.
+
+Valid values: 'YYYY-MM-DD_HH:MM:SS'
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- io -->
 
@@ -1070,14 +1078,6 @@ Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_cvmix_kpp_use_active_wave" type="logical"
-	category="cvmix" group="cvmix">
-Flag for use of active WAVEWATCH III coupling to calculate the Langmuir number and enhancement factor
-
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
 <entry id="config_cvmix_kpp_langmuir_mixing_opt" type="char*1024"
 	category="cvmix" group="cvmix">
 Option of Langmuir enhanced mixing parameterization
@@ -1094,22 +1094,30 @@ Valid values: NONE, LWF16, LF17, RWHGK16
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_cvmix_kpp_use_active_wave" type="logical"
+	category="cvmix" group="cvmix">
+Flag for Langmuir enchancement factor using prognostic waves. Requires config_use_active_wave = .true.
 
-<!-- wave coupling -->
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+
+<!-- wave_coupling -->
 
 <entry id="config_use_active_wave" type="logical"
 	category="wave_coupling" group="wave_coupling">
-Flag for using prognostic waves
+Flag for using prognostic waves. Controls the allocation of wave arrays and computation of Stokes drift profiles.
 
-Valid values: 
+Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_n_stokes_drift_wavenumber_partitions" type="integer"
 	category="wave_coupling" group="wave_coupling">
-Number of wavenumbers used to reconstruct Stokes drift profile
+Number of wavenumber partitions to be used in reconstructing wave-induced Stokes drift profile
 
-Valid values: 3, 4, and 6
+Valid values: 3,4,6
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -1609,9 +1617,9 @@ Valid values: Any positive real number
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_land_ice_flux_topDragCoeff" type="real"
+<entry id="config_land_ice_flux_explicit_topDragCoeff" type="real"
 	category="land_ice_fluxes" group="land_ice_fluxes">
-The top drag coefficient.
+The top drag coefficient if config_use_implicit_top_drag_coeff is false.
 
 Valid values: Any positive real number
 Default: Defined in namelist_defaults.xml
@@ -1730,6 +1738,22 @@ Default: Defined in namelist_defaults.xml
 <entry id="config_implicit_bottom_drag_coeff" type="real"
 	category="bottom_drag" group="bottom_drag">
 Dimensionless bottom drag coefficient, $c_{drag}$.
+
+Valid values: any positive real, typically 1.0e-3
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_use_implicit_top_drag" type="logical"
+	category="bottom_drag" group="bottom_drag">
+If true, implicit top drag is used on the momentum equation.
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_implicit_top_drag_coeff" type="real"
+	category="bottom_drag" group="bottom_drag">
+Dimensionless top drag coefficient, $c_{drag}$.
 
 Valid values: any positive real, typically 1.0e-3
 Default: Defined in namelist_defaults.xml

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/impl_top_drag/README
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/impl_top_drag/README
@@ -1,0 +1,5 @@
+This testdef is used to test a stealth feature in mpaso introduced by
+PR #5447. It simplies changes one mpaso namelist variable, 
+    config_use_implicit_top_drag
+from its default value of false to true. It will only have an impact 
+on meshes with ice shelf cavities.

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/impl_top_drag/user_nl_mpaso
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/impl_top_drag/user_nl_mpaso
@@ -1,0 +1,1 @@
+ config_use_implicit_top_drag = .true.

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1024,8 +1024,8 @@
 					description="The density of land ice."
 					possible_values="Any positive real number"
 		/>
-		<nml_option name="config_land_ice_flux_topDragCoeff" type="real" default_value="2.5e-3"
-					description="The top drag coefficient."
+		<nml_option name="config_land_ice_flux_explicit_topDragCoeff" type="real" default_value="2.5e-3"
+					description="The top drag coefficient if config_use_implicit_top_drag_coeff is false."
 					possible_values="Any positive real number"
 		/>
 		<nml_option name="config_land_ice_flux_ISOMIP_gammaT" type="real" default_value="1e-4" units="m s^-1"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1089,6 +1089,14 @@
 					description="Dimensionless bottom drag coefficient, $c_{drag}$."
 					possible_values="any positive real, typically 1.0e-3"
 		/>
+		<nml_option name="config_use_implicit_top_drag" type="logical" default_value=".false."
+					description="If true, implicit top drag is used on the momentum equation."
+					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_implicit_top_drag_coeff" type="real" default_value="1.0e-3"
+					description="Dimensionless top drag coefficient, $c_{drag}$."
+					possible_values="any positive real, typically 1.0e-3"
+		/>
 		<nml_option name="config_use_implicit_bottom_roughness" type="logical" default_value=".false."
 					description="If true, depends on bottom roughness z0"
 					possible_values=".true. or .false."

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -75,6 +75,7 @@ module ocn_diagnostics
 
    integer :: ke_cell_flag, ke_vertex_flag
    real (kind=RKIND) ::  fCoef
+   real (kind=RKIND) ::  landIceTopDragCoeff
    real (kind=RKIND), pointer ::  coef_3rd_order
 
    ! Methods for computing thickness at edges for flux calculations
@@ -3306,7 +3307,7 @@ contains
          velocityMagnitude = sqrt(kineticEnergyCell(minLevelCell(cell1),cell1) + kineticEnergyCell(minLevelCell(cell2),cell2))
          landIceEdgeFraction = 0.5_RKIND*(landIceFraction(cell1)+landIceFraction(cell2))
 
-         topDrag(iEdge) = - rho_sw * landIceEdgeFraction * config_land_ice_flux_topDragCoeff &
+         topDrag(iEdge) = - rho_sw * landIceEdgeFraction * landIceTopDragCoeff &
                           * velocityMagnitude * normalVelocity(minLevelEdgeBot(iEdge),iEdge)
 
       end do
@@ -3324,11 +3325,11 @@ contains
       do iCell = 1, nCellsAll
          ! the magnitude of the top drag is CD*u**2 = CD*(2*KE)
          topDragMag(iCell) = rho_sw * landIceFraction(iCell) &
-                           * 2.0_RKIND * config_land_ice_flux_topDragCoeff *  kineticEnergyCell(minLevelCell(iCell),iCell)
+                           * 2.0_RKIND * landIceTopDragCoeff *  kineticEnergyCell(minLevelCell(iCell),iCell)
 
          ! the friction velocity is the square root of the top drag + variance of tidal velocity
          ! (computed regardless of land-ice coverage)
-         landIceFrictionVelocity(iCell) = sqrt(config_land_ice_flux_topDragCoeff * &
+         landIceFrictionVelocity(iCell) = sqrt(landIceTopDragCoeff * &
                                    (2.0_RKIND * kineticEnergyCell(minLevelCell(iCell),iCell) &
                                    + config_land_ice_flux_rms_tidal_velocity**2))
       end do
@@ -4228,6 +4229,13 @@ contains
                  & 'is not known', MPAS_LOG_CRIT)
          end if
       end if
+
+      ! Initialize coefficient choice for computing land ice drag
+      if (config_use_implicit_top_drag) then
+         landIceTopDragCoeff = config_implicit_top_drag_coeff
+      else
+         landIceTopDragCoeff = config_land_ice_flux_explicit_topDragCoeff
+      endif
 
       call ocn_diagnostics_variables_init(domain, jenkinsOn, &
                                           hollandJenkinsOn, err)

--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -188,6 +188,7 @@ contains
 
       err = 0
       if (.not.landIceFluxesOn) return
+      if (config_use_implicit_top_drag) return
 
       call mpas_timer_start("top_drag", .false.)
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -34,6 +34,7 @@ module ocn_vmix
    use ocn_vmix_gotm
    use ocn_vmix_coefs_redi
    use ocn_diagnostics_variables
+   use ocn_surface_land_ice_fluxes
 
    implicit none
    private
@@ -64,7 +65,7 @@ module ocn_vmix
    !--------------------------------------------------------------------
 
    logical :: velVmixOn, tracerVmixOn
-   real (kind=RKIND) :: implicitBottomDragCoef
+   real (kind=RKIND) :: implicitBottomDragCoef, implicitTopDragCoef
    real (kind=RKIND) :: rayleighDampingCoef, rayleighBottomDampingCoef, &
                         rayleighDepthVariable
 
@@ -384,7 +385,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_vel_vmix_tend_implicit(dt, kineticEnergyCell, vertViscTopOfEdge, layerThickness, & !{{{
-                                         layerThickEdgeMean, normalVelocity, err)
+                                         layerThickEdgeMean, landIceEdgeFraction, normalVelocity, err)
 
       !-----------------------------------------------------------------
       !
@@ -406,6 +407,9 @@ contains
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          layerThickEdgeMean !< Input: mean thickness at edge
+
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         landIceEdgeFraction !< Input: land ice fraction
 
       !-----------------------------------------------------------------
       !
@@ -446,7 +450,7 @@ contains
 
       !$acc parallel loop present(maxLevelEdgeTop, minLevelEdgeBot, cellsOnEdge, &
       !$acc    layerThickEdgeMean, layerThickness, vertViscTopOfEdge, normalVelocity, &
-      !$acc    kineticEnergyCell) &
+      !$acc    landIceEdgeFraction, kineticEnergyCell) &
       !$acc    private(Nsurf, N, cell1, cell2, A, bTemp, C, m, rTemp, k)
 #else
       !$omp parallel
@@ -463,7 +467,7 @@ contains
          ! one active layer
          if (N .eq. Nsurf) then
             normalVelocity(N,iEdge) = normalVelocity(N,iEdge)  &
-                / (1.0_RKIND + dt*implicitBottomDragCoef &
+                / (1.0_RKIND + dt*(implicitTopDragCoef * landIceEdgeFraction(iEdge) + implicitBottomDragCoef) &
                    * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / layerThickEdgeMean(N,iEdge) )
          else
 
@@ -471,7 +475,10 @@ contains
            C(Nsurf)     = -2.0_RKIND*dt*vertViscTopOfEdge(Nsurf+1,iEdge) &
                       / (layerThickEdgeMean(Nsurf,iEdge) + layerThickEdgeMean(Nsurf+1,iEdge)) &
                       / layerThickEdgeMean(Nsurf,iEdge)
-           bTemp(Nsurf) = 1.0_RKIND - C(Nsurf)
+           bTemp(Nsurf) = 1.0_RKIND - C(Nsurf) &
+              + dt * implicitTopDragCoef * landIceEdgeFraction(iEdge) &
+                * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / &
+                layerThickEdgeMean(N,iEdge)
            rTemp(Nsurf) = normalVelocity(Nsurf,iEdge)
 
            ! first pass: set the coefficients
@@ -1122,7 +1129,8 @@ contains
       type (mpas_pool_type), pointer :: tracersPool, tracersSurfaceFluxPool
 
       integer :: iCell, timeLevel, k, cell1, cell2, iEdge, iTracer, num_tracers, nCells, nEdges, N, Nsurf
-      real (kind=RKIND), dimension(:), pointer :: bottomDrag, ssh
+      real (kind=RKIND), dimension(:), pointer :: bottomDrag, ssh, landIceFraction
+      real (kind=RKIND), dimension(:), allocatable :: landIceEdgeFraction
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocity, layerThickness
       real (kind=RKIND), dimension(:,:), pointer :: tracerGroupSurfaceFlux
       real (kind=RKIND), dimension(:,:,:), pointer :: tracersGroup
@@ -1144,6 +1152,33 @@ contains
       end if
 
       call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceFlux', tracersSurfaceFluxPool)
+
+      allocate(landIceEdgeFraction(nEdgesOwned))
+      landIceEdgeFraction(:) = 0.0_RKIND
+      if (landIcePressureOn) then
+         call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
+#ifdef MPAS_OPENACC
+         !$acc enter data copyin(landIceFraction)
+
+         !$acc parallel loop present(landIceEdgeFraction) &
+         !$acc    private(cell1, cell2, k)
+#else
+         !$omp parallel
+         !$omp do schedule(runtime) private(cell1, cell2, k)
+#endif
+         do iEdge = 1, nEdgesOwned
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            landIceEdgeFraction(iEdge) = 0.5_RKIND*(landIceFraction(cell1)+landIceFraction(cell2))
+         end do
+#ifdef MPAS_OPENACC
+         !$acc exit data copyout(landIceFraction)
+#else
+         !$omp end do
+         !$omp end parallel
+#endif
+      end if
+
       call mpas_pool_get_array(statePool, 'normalVelocity', normalVelocity, timeLevel)
       call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
       call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
@@ -1245,7 +1280,8 @@ contains
           vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, err)
       else
         call ocn_vel_vmix_tend_implicit(dt, kineticEnergyCell, &
-          vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, err)
+          vertViscTopOfEdge, layerThickness, layerThickEdgeMean, &
+          landIceEdgeFraction, normalVelocity, err)
       end if
 #ifdef MPAS_OPENACC
       !$acc exit data copyout(normalVelocity)
@@ -1405,9 +1441,13 @@ contains
       if(config_disable_tr_vmix.or.config_disable_tr_all_tend) tracerVmixOn = .false.
 
       implicitBottomDragCoef = 0.0_RKIND
+      implicitTopDragCoef = 0.0_RKIND
 
       if (config_use_implicit_bottom_drag) then
           implicitBottomDragCoef = config_implicit_bottom_drag_coeff
+      endif
+      if (config_use_implicit_top_drag) then
+          implicitTopDragCoef = config_implicit_top_drag_coeff
       endif
 
       call ocn_vmix_cvmix_init(domain,err_tmp)

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -477,8 +477,8 @@ contains
                       / layerThickEdgeMean(Nsurf,iEdge)
            bTemp(Nsurf) = 1.0_RKIND - C(Nsurf) &
               + dt * implicitTopDragCoef * landIceEdgeFraction(iEdge) &
-                * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) / &
-                layerThickEdgeMean(N,iEdge)
+                * sqrt(kineticEnergyCell(Nsurf,cell1) + kineticEnergyCell(Nsurf,cell2)) / &
+                layerThickEdgeMean(Nsurf,iEdge)
            rTemp(Nsurf) = normalVelocity(Nsurf,iEdge)
 
            ! first pass: set the coefficients

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -1443,6 +1443,12 @@ contains
       implicitBottomDragCoef = 0.0_RKIND
       implicitTopDragCoef = 0.0_RKIND
 
+      if (config_use_implicit_top_drag .and. &
+          .not. config_use_implicit_bottom_drag) then
+         call mpas_log_write('Implicit top drag can only be used with ' //&
+              & 'implicit bottom drag', MPAS_LOG_CRIT)
+      endif
+
       if (config_use_implicit_bottom_drag) then
           implicitBottomDragCoef = config_implicit_bottom_drag_coeff
       endif


### PR DESCRIPTION
This PR creates a new option to use implicit top drag in the same manner as implicit bottom drag. It assumes that the only setting in which top drag will be used is in land-ice-covered regions. 

This feature is off by default (stealth). Implicit top drag is activated by setting `config_use_implicit_top_drag = .true.` and `config_implicit_top_drag_coeff` > 0 and `config_land_ice_flux_mode = 'standalone'` (while also ensuring that at least part of the domain has `landIceFraction` > 0).

[NML]
[BFB] - Stealth