### PR TITLE
Remove special hypervis defaults for v2 ne30

### DIFF
--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1278,13 +1278,6 @@
 <hypervis_order >     2 </hypervis_order>
 <hypervis_scaling> 3.0 </hypervis_scaling>
 
-<!-- special defaults for V2 NE30 -->
-<nu hgrid="ne30np4">  1.0e15 </nu>
-<hypervis_scaling hgrid="ne30np4" > 0 </hypervis_scaling>
-
-
-
-
 <!-- -1.0 indicates use the value for nu -->
 <nu_q> -1.0 </nu_q>
 <nu_p> -1.0 </nu_p>


### PR DESCRIPTION
Remove special hyperviscosity override for v2 ne30 configurations. This will be non-BFB only for ne30 tests. Note that answers with v2 will still be preserved with the maint-2.0 branch.

[non-BFB] (only for ne30)