### PR TITLE
Update CIME submodule

### DIFF
--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -92,10 +92,12 @@
       <arg flag="--cwd" name="CASEROOT"/>
       <arg flag="-A" name="CHARGE_ACCOUNT"/>
       <arg flag="-t" name="JOB_WALLCLOCK_TIME"/>
-      <arg flag="-n" name=" $TOTALPES/$MAX_MPITASKS_PER_NODE"/>
       <arg flag="-q" name="JOB_QUEUE"/>
       <arg flag="--mode script"/>
     </submit_args>
+    <directives>
+      <directive> -n {{ num_nodes }} </directive>
+    </directives>
   </batch_system>
 
   <batch_system type="cobalt_theta" >
@@ -113,10 +115,12 @@
     <submit_args>
       <arg flag="-A" name="CHARGE_ACCOUNT"/>
       <arg flag="-t" name="JOB_WALLCLOCK_TIME"/>
-      <arg flag="-n" name=" $TOTALPES/$MAX_MPITASKS_PER_NODE"/>
       <arg flag="-q" name="JOB_QUEUE"/>
       <arg flag="--mode script"/>
     </submit_args>
+    <directives>
+      <directive> -n {{ num_nodes }} </directive>
+    </directives>
   </batch_system>
 
 <!-- This is the new version on Summit, released as IBM 10.1.0.0 build 476197, Nov 21 2017.  -->


### PR DESCRIPTION
Features:
1) Move e3sm_compiler_wrap to E3SM
2) Use the jobid_pattern xml variable in determining jobid
3) Check number of hist file comparisons in system_test_common, issue
   warning if number is not expected
4) jenkins_generic_job: Add a bit more archiving output
5) bless_test_results: improve error checking of bless_tests args
6) Improve cmake build system for sharedlibs! Can now check compsets
   when building sharedlibs, allows for things like:
```
    if ("eamxx" IN_LIST COMP_NAMES)
      string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_OPENMP=ON")
    endif()
```

Fixes:
1) when $PROJECT isn't defined the project flag should not be used for batch submit.
2) create_newcase: Fix bug in fallback thrd setting
3) improve float detection in argument resolution of the batch environment
4) Fixes aprun submissions in CIME
5) Fix Python > 3.10 import bug
6) Fix exception chain in import_and_run_sub_or_cmd

[BFB]