### PR TITLE
Bugfix for ocean submesoscale feature

### DIFF
--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2923,7 +2923,6 @@
 		/>
 		<var name="normalMLEvelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
 			description="Velocity from mixed layer eddies (fox kemper 2011 submesoscale parameterization)"
-			missing_value="FILLVAL" missing_value_mask="edgeMask"
 			packages="submeso"
 		/>
 		<var name="cGMphaseSpeed" type="real" dimensions="nEdges Time" units="m s^-1"


### PR DESCRIPTION
Fill value masking of the submesoscale variable `normalMLEVelocity` resulted in bad values in `vertMLEBolusVelocityTop` that affected `timeMonthly_avg_mocStreamvalLatAndDepth`. This bugfix removes masking of `normalMLEVelocity`. 

Fixes #5459 on maint-2.1

[BFB]