### PR TITLE
New ocean variables for floating land ice

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -782,7 +782,7 @@ if ($OCN_ISMF eq 'coupled') {
 } elsif ($OCN_ISMF eq 'internal') {
 	add_default($nl, 'config_land_ice_flux_mode', 'val'=>"standalone");
 } else {
-	add_default($nl, 'config_land_ice_flux_mode', 'val'=>"pressure_only");
+	add_default($nl, 'config_land_ice_flux_mode');
 }
 add_default($nl, 'config_land_ice_flux_formulation');
 add_default($nl, 'config_land_ice_flux_useHollandJenkinsAdvDiff');

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -333,12 +333,12 @@
 
 <!-- land_ice_fluxes -->
 <config_land_ice_flux_mode>'off'</config_land_ice_flux_mode>
-<config_land_ice_flux_mode ocn_grid="oQU240wLI">'standalone'</config_land_ice_flux_mode>
-<config_land_ice_flux_mode ocn_grid="oEC60to30v3wLI">'standalone'</config_land_ice_flux_mode>
-<config_land_ice_flux_mode ocn_grid="ECwISC30to60E1r2">'standalone'</config_land_ice_flux_mode>
-<config_land_ice_flux_mode ocn_grid="oRRS30to10v3wLI">'standalone'</config_land_ice_flux_mode>
-<config_land_ice_flux_mode ocn_grid="SOwISC12to60E2r4">'standalone'</config_land_ice_flux_mode>
-<config_land_ice_flux_mode ocn_grid="ECwISC30to60E2r1">'standalone'</config_land_ice_flux_mode>
+<config_land_ice_flux_mode ocn_grid="oQU240wLI">'pressure_only'</config_land_ice_flux_mode>
+<config_land_ice_flux_mode ocn_grid="oEC60to30v3wLI">'pressure_only'</config_land_ice_flux_mode>
+<config_land_ice_flux_mode ocn_grid="ECwISC30to60E1r2">'pressure_only'</config_land_ice_flux_mode>
+<config_land_ice_flux_mode ocn_grid="oRRS30to10v3wLI">'pressure_only'</config_land_ice_flux_mode>
+<config_land_ice_flux_mode ocn_grid="SOwISC12to60E2r4">'pressure_only'</config_land_ice_flux_mode>
+<config_land_ice_flux_mode ocn_grid="ECwISC30to60E2r1">'pressure_only'</config_land_ice_flux_mode>
 <config_land_ice_flux_formulation>'Jenkins'</config_land_ice_flux_formulation>
 <config_land_ice_flux_useHollandJenkinsAdvDiff>.false.</config_land_ice_flux_useHollandJenkinsAdvDiff>
 <config_land_ice_flux_attenuation_coefficient>10.0</config_land_ice_flux_attenuation_coefficient>

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -90,10 +90,10 @@ def buildnml(case, caseroot, compname):
         decomp_prefix = 'mpas-o.graph.info.'
         restoring_file = 'sss.monthlyClimatology.PHC2_salx_040803.oEC60to30v3wLI.nc'
         analysis_mask_file = 'masks_SingleRegionAtlanticWTransportTransects_EC60to30v3wLI_171116.nc'
-        ic_date = '171031'
+        ic_date = '230220'
         ic_prefix = 'oEC60to30v3wLI60lev'
         if ocn_ic_mode == 'spunup':
-            ic_date = '171116'
+            ic_date = '230220'
             ic_prefix = 'oEC60to30v3wLI60lev.restart_theta_year26'
 
     elif ocn_grid == 'ECwISC30to60E1r2':
@@ -101,7 +101,7 @@ def buildnml(case, caseroot, compname):
         decomp_prefix = 'mpas-o.graph.info.'
         restoring_file = 'sss.PHC2_monthlyClimatology.ECwISC30to60E1r02.200408.nc'
         analysis_mask_file = 'ECwISC30to60E1r02_transportTransects.nc'
-        ic_date = '200408'
+        ic_date = '230220'
         ic_prefix = 'ocean.ECwISC30to60E1r2'
         if ocn_ic_mode == 'spunup':
             logger.warning("WARNING: The specified compset is requesting ocean ICs spunup from a G-case")
@@ -128,7 +128,7 @@ def buildnml(case, caseroot, compname):
     elif ocn_grid == 'oQU240wLI':
         decomp_date = '160929'
         decomp_prefix = 'mpas-o.graph.info.'
-        ic_date = '160929'
+        ic_date = '230220'
         ic_prefix = 'ocean.QU.240wLI'
         if ocn_ic_mode == 'spunup':
             logger.warning("WARNING: The specified compset is requesting ocean ICs spunup from a G-case")
@@ -159,7 +159,7 @@ def buildnml(case, caseroot, compname):
         decomp_prefix = 'mpas-o.graph.info.'
         restoring_file = 'sss.monthlyClimatology.PHC2_salx.2004_08_03.180503.nc'
         analysis_mask_file = 'masks_SingleRegionAtlanticWTransportTransects_RRS30to10v3wLI.nc'
-        ic_date = '171109'
+        ic_date = '230220'
         ic_prefix = 'oRRS30to10v3wLI'
         if ocn_ic_mode == 'spunup':
             logger.warning("WARNING: The specified compset is requesting ocean ICs spunup from a G-case")
@@ -261,10 +261,10 @@ def buildnml(case, caseroot, compname):
         decomp_prefix = 'mpas-o.graph.info.'
         restoring_file = 'sss.PHC2_monthlyClimatology.SOwISC12to60E2r4_nomask.210120.nc'
         analysis_mask_file = 'SOwISC12to60E2r4_mocBasinsAndTransects20210623.nc'
-        ic_date = '210107'
+        ic_date = '230220'
         ic_prefix = 'ocean.SOwISC12to60E2r4'
         if ocn_ic_mode == 'spunup':
-            ic_date = '210203'
+            ic_date = '230220'
             ic_prefix = 'mpaso.SOwISC12to60E2r4.rstFromG-anvil'
 
     elif ocn_grid == 'ECwISC30to60E2r1':
@@ -272,10 +272,10 @@ def buildnml(case, caseroot, compname):
         decomp_prefix = 'mpas-o.graph.info.'
         restoring_file = 'sss.PHC2_monthlyClimatology.ECwISC30to60E2r1_nomask.201221.nc'
         analysis_mask_file = 'ECwISC30to60E2r1_mocBasinsAndTransects20210623.nc'
-        ic_date = '210413'
+        ic_date = '230220'
         ic_prefix = 'ocean.ECwISC30to60E2r1'
         if ocn_ic_mode == 'spunup':
-            ic_date = '210414'
+            ic_date = '230220'
             ic_prefix = 'mpaso.ECwISC30to60E2r1.rstFromG-anvil'
 
 

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -790,10 +790,9 @@ contains
     call t_stopf ('mpaso_mct_init')
 
     call mpas_pool_get_config(domain % configs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
-    if ( trim(config_land_ice_flux_mode) .eq. 'pressure_only' ) then
-       call seq_infodata_PutData( infodata, ocn_prognostic=.true., ocnrof_prognostic=.true., &
-                                            ocn_c2_glcshelf=.false.)
-    else if ( trim(config_land_ice_flux_mode) .eq. 'standalone' ) then
+    if ( trim(config_land_ice_flux_mode) == 'off' .or. &
+         trim(config_land_ice_flux_mode) == 'pressure_only' .or. &
+         trim(config_land_ice_flux_mode) == 'standalone' ) then
        call seq_infodata_PutData( infodata, ocn_prognostic=.true., ocnrof_prognostic=.true., &
                                             ocn_c2_glcshelf=.false.)
     else if ( trim(config_land_ice_flux_mode) .eq. 'coupled' ) then
@@ -2784,7 +2783,8 @@ contains
 !JW       o2x_o % rAttr(index_o2x_So_htv, n) = landIceHeatTransferVelocity(i)
 !JW       o2x_o % rAttr(index_o2x_So_stv, n) = landIceSaltTransferVelocity(i)
  
-       if ( trim(config_land_ice_flux_mode) .ne. 'pressure_only' ) then
+       if ( trim(config_land_ice_flux_mode) .eq. 'standalone' .or. &
+            trim(config_land_ice_flux_mode) .eq. 'coupled'  ) then
           o2x_o % rAttr(index_o2x_So_blt, n) = landIceBoundaryLayerTracers(indexBLT,i)
           o2x_o % rAttr(index_o2x_So_bls, n) = landIceBoundaryLayerTracers(indexBLS,i)
           o2x_o % rAttr(index_o2x_So_htv, n) = landIceTracerTransferVelocities(indexHeatTrans,i)

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1996,6 +1996,7 @@
 				immutable="true">
 			<var name="landIcePressureForcing"/>
 			<var name="landIceFractionForcing"/>
+			<var name="landIceFloatingFractionForcing"/>
 			<var name="landIceDraftForcing"/>
 		</stream>
 
@@ -3822,6 +3823,10 @@
 			packages="timeVaryingAtmosphericForcingPKG"
 		/>
 		<var name="landIceFractionForcing" type="real" dimensions="nCells Time" units="1"
+			description="The fraction of each cell covered by land ice"
+			packages="timeVaryingLandIceForcingPKG"
+		/>
+		<var name="landIceFloatingFractionForcing" type="real" dimensions="nCells Time" units="1"
 			description="The fraction of each cell covered by land ice"
 			packages="timeVaryingLandIceForcingPKG"
 		/>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -3625,7 +3625,7 @@
 			description="The fraction of each cell covered by an ice shelf"
 			packages="landIcePressurePKG"
 		/>
-		<var name="landIceFloatingMask" type="integer" dimensions="nCells Time"
+		<var name="landIceFloatingMask" type="integer" dimensions="nCells Time" default_value="-1"
 			description="Mask indicating where an ice shelf is present (1) or absent (0)"
 			packages="landIcePressurePKG"
 		/>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1640,6 +1640,8 @@
 			<var name="landIcePressure"/>
 			<var name="landIceFraction"/>
 			<var name="landIceDraft"/>
+			<var name="landIceFloatingMask"/>
+			<var name="landIceFloatingFraction"/>
 		</stream>
 
 		<stream name="forcing_data_init"
@@ -1749,6 +1751,8 @@
 			<var name="landIcePressure"/>
 			<var name="landIceFraction"/>
 			<var name="landIceDraft"/>
+			<var name="landIceFloatingMask"/>
+			<var name="landIceFloatingFraction"/>
 		</stream>
 		<stream name="block_debug_output"
 				type="output"
@@ -1848,6 +1852,8 @@
 			<var name="landIceDraft"/>
 			<var name="landIceFraction"/>
 			<var name="landIceMask"/>
+			<var name="landIceFloatingMask"/>
+			<var name="landIceFloatingFraction"/>
 			<var name="seaIcePressure"/>
 			<var name="atmosphericPressure"/>
 			<var_array name="tracersSurfaceValue"/>
@@ -2106,6 +2112,8 @@
 			<var name="nAccumulatedCoupled"/>
 			<var name="landIceFraction"/>
 			<var name="landIceMask"/>
+			<var name="landIceFloatingMask"/>
+			<var name="landIceFloatingFraction"/>
 			<var_array name="landIceInterfaceTracers"/>
 			<var_array name="landIceBoundaryLayerTracers"/>
 			<var name="landIceFrictionVelocity"/>
@@ -3610,6 +3618,14 @@
 		/>
 		<var name="landIceMask" type="integer" dimensions="nCells Time"
 			description="Mask indicating where land-ice is present (1) or absent (0)"
+			packages="landIcePressurePKG"
+		/>
+		<var name="landIceFloatingFraction" type="real" dimensions="nCells Time" units="1"
+			description="The fraction of each cell covered by an ice shelf"
+			packages="landIcePressurePKG"
+		/>
+		<var name="landIceFloatingMask" type="integer" dimensions="nCells Time"
+			description="Mask indicating where an ice shelf is present (1) or absent (0)"
 			packages="landIcePressurePKG"
 		/>
 		<var name="landIcePressure" type="real" dimensions="nCells Time" units="Pa"

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_global_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_global_stats.F
@@ -234,7 +234,7 @@ contains
 
       integer, parameter :: kMaxVariables = 1024 ! this must be a little more than double the number of variables to be reduced
       integer, dimension(:), pointer :: minLevelCell, minLevelEdgeBot, minLevelVertexTop, maxLevelCell, &
-          maxLevelEdgeTop, maxLevelVertexBot, landiceMask
+          maxLevelEdgeTop, maxLevelVertexBot, landIceFloatingMask
 
       type (MPAS_Time_type) :: xtime_timeType, simulationStartTime_timeType
       type (MPAS_TimeInterval_type) :: timeStep
@@ -364,7 +364,7 @@ contains
          call mpas_pool_get_array(forcingPool, 'rainFlux', rainFlux)
          call mpas_pool_get_array(forcingPool, 'frazilLayerThicknessTendency', frazilLayerThicknessTendency)
          call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
-         call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+         call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
 
          call mpas_pool_get_array(tracersSurfaceFluxPool, 'activeTracersSurfaceFlux', activeTracersSurfaceFlux)
          call mpas_pool_get_array(tracersSurfaceRestoringFieldsPool, 'activeTracersPistonVelocity', &
@@ -381,8 +381,8 @@ contains
          areaEdge = dcEdge(1:nEdgesSolve)*dvEdge(1:nEdgesSolve)
 
          allocate(landIceFloatingArea(1:nCellsSolve))
-         if ( associated(landIceMask) ) then
-            landIceFloatingArea = landIceMask(1:nCellsSolve)*areaCell(1:nCellsSolve)
+         if ( associated(landIceFloatingMask) ) then
+            landIceFloatingArea = landIceFloatingMask(1:nCellsSolve)*areaCell(1:nCellsSolve)
          else
             landIceFloatingArea = 0.
          end if

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -176,7 +176,7 @@ contains
 
       real (kind=RKIND), dimension(:), pointer :: tThreshMLD, tGradientMLD, landIceDraft
       real (kind=RKIND), dimension(:), pointer :: dGradientMLD, landIcePressure
-      integer, dimension(:), pointer :: landIceMask
+      integer, dimension(:), pointer :: landIceFloatingMask
       real (kind=RKIND), dimension(:,:,:), pointer :: tracers
       integer :: interp_local
       real (kind=RKIND), allocatable, dimension(:,:) :: densityGradient, temperatureGradient
@@ -214,7 +214,7 @@ contains
          call mpas_pool_get_array(tracersPool, 'activeTracers', tracers, timeLevel)
          call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
          call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
-         call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+         call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
          call mpas_pool_get_array(meshPool, 'latCell', latCell)
          call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
 
@@ -286,11 +286,11 @@ contains
                !$omp end do
                !$omp end parallel
 
-               if (associated(landIceMask) ) then
+               if (associated(landIceFloatingMask) ) then
                   !$omp parallel
                   !$omp do schedule(runtime)
                   do iCell = 1, nCells
-                     tThreshMLD(iCell) = tThreshMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
+                     tThreshMLD(iCell) = tThreshMLD(iCell) - abs(landIceDraft(iCell))*landIceFloatingMask(iCell)
                   end do
                   !$omp end do
                   !$omp end parallel
@@ -352,11 +352,11 @@ contains
          !$omp end parallel
 
          !normalize MLD to top of ice cavity
-         if (associated(landIceMask) ) then
+         if (associated(landIceFloatingMask) ) then
            !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
-             tGradientMLD(iCell) = tGradientMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
+             tGradientMLD(iCell) = tGradientMLD(iCell) - abs(landIceDraft(iCell))*landIceFloatingMask(iCell)
            end do
            !$omp end do
            !$omp end parallel
@@ -417,11 +417,11 @@ contains
          !$omp end do
          !$omp end parallel
 
-         if (associated(landIceMask) ) then
+         if (associated(landIceFloatingMask) ) then
            !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
-             dGradientMLD(iCell) = dGradientMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
+             dGradientMLD(iCell) = dGradientMLD(iCell) - abs(landIceDraft(iCell))*landIceFloatingMask(iCell)
            end do
            !$omp end do
            !$omp end parallel

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -176,7 +176,6 @@ contains
 
       real (kind=RKIND), dimension(:), pointer :: tThreshMLD, tGradientMLD, landIceDraft
       real (kind=RKIND), dimension(:), pointer :: dGradientMLD, landIcePressure
-      integer, dimension(:), pointer :: landIceFloatingMask
       real (kind=RKIND), dimension(:,:,:), pointer :: tracers
       integer :: interp_local
       real (kind=RKIND), allocatable, dimension(:,:) :: densityGradient, temperatureGradient
@@ -214,7 +213,6 @@ contains
          call mpas_pool_get_array(tracersPool, 'activeTracers', tracers, timeLevel)
          call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
          call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
-         call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
          call mpas_pool_get_array(meshPool, 'latCell', latCell)
          call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
 
@@ -286,11 +284,11 @@ contains
                !$omp end do
                !$omp end parallel
 
-               if (associated(landIceFloatingMask) ) then
+               if (associated(landIceDraft) ) then
                   !$omp parallel
                   !$omp do schedule(runtime)
                   do iCell = 1, nCells
-                     tThreshMLD(iCell) = tThreshMLD(iCell) - abs(landIceDraft(iCell))*landIceFloatingMask(iCell)
+                     tThreshMLD(iCell) = tThreshMLD(iCell) - abs(landIceDraft(iCell))
                   end do
                   !$omp end do
                   !$omp end parallel
@@ -352,11 +350,11 @@ contains
          !$omp end parallel
 
          !normalize MLD to top of ice cavity
-         if (associated(landIceFloatingMask) ) then
+         if (associated(landIceDraft) ) then
            !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
-             tGradientMLD(iCell) = tGradientMLD(iCell) - abs(landIceDraft(iCell))*landIceFloatingMask(iCell)
+             tGradientMLD(iCell) = tGradientMLD(iCell) - abs(landIceDraft(iCell))
            end do
            !$omp end do
            !$omp end parallel
@@ -417,11 +415,11 @@ contains
          !$omp end do
          !$omp end parallel
 
-         if (associated(landIceFloatingMask) ) then
+         if (associated(landIceDraft) ) then
            !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
-             dGradientMLD(iCell) = dGradientMLD(iCell) - abs(landIceDraft(iCell))*landIceFloatingMask(iCell)
+             dGradientMLD(iCell) = dGradientMLD(iCell) - abs(landIceDraft(iCell))
            end do
            !$omp end do
            !$omp end parallel

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
@@ -1199,6 +1199,11 @@ contains
           call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
           call mpas_pool_get_array(forcingPool, 'landIceFloatingFraction', landIceFloatingFraction)
 
+          if (landIceFloatingMask(1) == -1) then
+             call mpas_log_write('landIceFloatingMask contains the default value which likely ' // &
+               'indicates that this field is missing in the initial condition file (e.g. ' // &
+               'because it is meant for an older E3SM version).', MPAS_LOG_CRIT)
+          endif
           ssh(:) = 0.0_RKIND
           landIceFraction(:) = 0.0_RKIND
           modifyLandIcePressureMask(:) = 0

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
@@ -1073,13 +1073,16 @@ contains
 
        real (kind=RKIND), dimension(:), pointer :: latCell, lonCell
        real (kind=RKIND), dimension(:), pointer :: landIceThkObserved, landIceDraftObserved, &
-                                                   landIceFracObserved, landIceGroundedFracObserved
+                                                   landIceFracObserved, &
+                                                   landIceFloatingFracObserved, &
+                                                   landIceGroundedFracObserved
 
-       real (kind=RKIND), dimension(:), pointer :: landIcePressure, landIceFraction, ssh, &
+       real (kind=RKIND), dimension(:), pointer :: landIcePressure, landIceFraction, &
+                                                   landIceFloatingFraction, ssh, &
                                                    bottomDepth
 
        integer, pointer :: nCells
-       integer, dimension(:), pointer :: maxLevelCell, landIceMask
+       integer, dimension(:), pointer :: maxLevelCell, landIceMask, landIceFloatingMask
 
        integer :: iCell
 
@@ -1123,6 +1126,7 @@ contains
                                                           inXPeriod = 2.0_RKIND * pii)
 
              elseif (config_global_ocean_topography_method .eq. "bilinear_interpolation") then
+
                 call ocn_init_interpolation_bilinear_horiz(landIceThkLon % array, landIceThkLat % array, &
                                                            landIceThkIC % array, nLonLandIceThk, nLatLandIceThk, &
                                                            lonCell, latCell, landIceThkObserved, nCells, &
@@ -1186,11 +1190,14 @@ contains
           call mpas_pool_get_array(landIceInitPool, 'landIceDraftObserved', landIceDraftObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIceThkObserved', landIceThkObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIceFracObserved', landIceFracObserved)
+          call mpas_pool_get_array(landIceInitPool, 'landIceFracObserved', landIceFloatingFracObserved)
           call mpas_pool_get_array(landIceInitPool, 'landIceGroundedFracObserved', landIceGroundedFracObserved)
           call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
           call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+          call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
           call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
           call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
+          call mpas_pool_get_array(forcingPool, 'landIceFloatingFraction', landIceFloatingFraction)
 
           ssh(:) = 0.0_RKIND
           landIceFraction(:) = 0.0_RKIND
@@ -1198,8 +1205,14 @@ contains
           landIcePressure(:) = 0.0_RKIND
           do iCell = 1, nCells
 
-             if(landIceMask(iCell) == 1) then
+             if (landIceMask(iCell) == 1) then
                 landIceFraction(iCell) = landIceFracObserved(iCell)
+             end if
+
+             ! this implicitly assumes that when a cell is considered floating, the
+             ! full landIceFracObserved is floating
+             if (landIceFloatingMask(iCell) == 1) then
+                landIceFloatingFraction(iCell) = landIceFloatingFracObserved(iCell)
              end if
 
              ! nothing to do here if the cell is land
@@ -1207,7 +1220,7 @@ contains
 
              ! we compute the SSH first and find out the land-ice pressure
              ssh(iCell) = min(0.0_RKIND, landIceDraftObserved(iCell))
-             if(ssh(iCell) < 0.0_RKIND) then
+             if (ssh(iCell) < 0.0_RKIND) then
                 modifyLandIcePressureMask(iCell) = 1
              end if
           end do
@@ -2056,7 +2069,6 @@ contains
                  inXPeriod = 2.0_RKIND * pii)
 
          elseif (config_global_ocean_tracer_method .eq. "bilinear_interpolation") then
-
             call ocn_init_interpolation_bilinear_horiz(tracerLon % array, tracerLat % array, &
                  tracerIC % array, nLonTracer, nLatTracer, &
                  lonCell, latCell, interpTracer, nCells, &

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -171,6 +171,10 @@ contains
          call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
          call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
          call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
+         if (landIceFloatingMask(1) == -1) then
+            call mpas_log_write('landIceFloatingMask contains the default value which likely indicates that this field is missing in the initial condition file (e.g. because it is meant for an older E3SM version).', &
+                                MPAS_LOG_CRIT)
+         endif
       end if
 
       nEdges = nEdgesAll

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -134,7 +134,7 @@ contains
         frazilSurfacePressure, landIcePressure, landIceDraft, landIceFraction
 
       integer, dimension(:), pointer :: &
-        landIceMask
+        landIceFloatingMask
 
       call mpas_timer_start('diagnostic solve')
 
@@ -169,7 +169,7 @@ contains
       if (landIcePressureOn) then
          call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
          call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
-         call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+         call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
          call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
       end if
 
@@ -445,11 +445,11 @@ contains
       !
       !  compute fields needed to compute land-ice fluxes, either in the ocean model or in the coupler
       !
-      ! inputs: layerThickness, normalVelocity, landIceFraction, landIceMask
+      ! inputs: layerThickness, normalVelocity, landIceFraction, landIceFloatingMask
       ! outputs: 
       if (landIcePressureOn) then
          call ocn_compute_land_ice_flux_input_fields(layerThickness, normalVelocity, activeTracers, &
-                landIceFraction, landIceMask, timeLevel, indexTemperature, indexSalinity)
+                landIceFraction, landIceFloatingMask, timeLevel, indexTemperature, indexSalinity)
       end if
 
       if ( full_compute ) then
@@ -3229,7 +3229,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_compute_land_ice_flux_input_fields(layerThickness, normalVelocity, &
-      activeTracers, landIceFraction, landIceMask, &
+      activeTracers, landIceFraction, landIceFloatingMask, &
       timeLevel, indexTval, indexSval)!{{{
 
       !-----------------------------------------------------------------
@@ -3250,7 +3250,7 @@ contains
          activeTracers
 
       integer, dimension(:), intent(in) :: &
-         landIceMask
+         landIceFloatingMask
 
       !-----------------------------------------------------------------
       !
@@ -3288,7 +3288,7 @@ contains
                blSaltScratch(nCellsAll))
       !$acc enter data create(blTempScratch, blSaltScratch)
 
-      ! Compute top drag
+      ! Compute top drag everywhere there is grounded or floating land ice
 #ifdef MPAS_OPENACC
       !$acc enter data copyin(landIceFraction)
 
@@ -3449,15 +3449,15 @@ contains
 
       ! modify the spatially-varying attenuation coefficient where there is land ice
 #ifdef MPAS_OPENACC
-      !$acc enter data copyin(landIceMask)
+      !$acc enter data copyin(landIceFloatingMask)
 
-      !$acc parallel loop present(landIceMask, sfcFlxAttCoeff)
+      !$acc parallel loop present(landIceFloatingMask, sfcFlxAttCoeff)
 #else
       !$omp parallel
       !$omp do schedule(runtime)
 #endif
       do iCell = 1, nCellsAll
-         if(landIceMask(iCell) == 1) then
+         if(landIceFloatingMask(iCell) == 1) then
             sfcFlxAttCoeff(iCell) = config_land_ice_flux_attenuation_coefficient
          end if
       end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
@@ -197,7 +197,6 @@ module ocn_eddy_parameterization_helpers
      integer :: iEdge, nEdges, refIndex, cell1, cell2, nCells, k, iCell
      real(kind=RKIND) :: dDenThres, den_ref_lev
      real(kind=RKIND),dimension(:), allocatable :: depth
-     integer, dimension(:), pointer :: landIceFloatingMask
      real (kind=RKIND), dimension(:,:), pointer :: layerThickness
      real (kind=RKIND), dimension(:), pointer :: landIceDraft, landIcePressure
      logical :: found_den_mld
@@ -209,7 +208,6 @@ module ocn_eddy_parameterization_helpers
      if ( config_eddyMLD_use_old ) then
        call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
        call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
-       call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
 
        allocate(pressureAdjustedForLandIce(nVertLevels, size(pressure,2)))
 
@@ -281,11 +279,11 @@ module ocn_eddy_parameterization_helpers
         !$omp end do
         !$omp end parallel
 
-        if (associated(landIceFloatingMask) ) then
+        if (associated(landIceDraft) ) then
           !$omp parallel
           !$omp do schedule(runtime)
           do iCell = 1, nCells
-             dThreshMLD(iCell) = dThreshMLD(iCell) - abs(landIceDraft(iCell))*landIceFloatingMask(iCell)
+             dThreshMLD(iCell) = dThreshMLD(iCell) - abs(landIceDraft(iCell))
           end do
           !$omp end do
           !$omp end parallel

--- a/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
@@ -197,7 +197,7 @@ module ocn_eddy_parameterization_helpers
      integer :: iEdge, nEdges, refIndex, cell1, cell2, nCells, k, iCell
      real(kind=RKIND) :: dDenThres, den_ref_lev
      real(kind=RKIND),dimension(:), allocatable :: depth
-     integer, dimension(:), pointer :: landIceMask
+     integer, dimension(:), pointer :: landIceFloatingMask
      real (kind=RKIND), dimension(:,:), pointer :: layerThickness
      real (kind=RKIND), dimension(:), pointer :: landIceDraft, landIcePressure
      logical :: found_den_mld
@@ -209,7 +209,7 @@ module ocn_eddy_parameterization_helpers
      if ( config_eddyMLD_use_old ) then
        call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
        call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
-       call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+       call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
 
        allocate(pressureAdjustedForLandIce(nVertLevels, size(pressure,2)))
 
@@ -281,11 +281,11 @@ module ocn_eddy_parameterization_helpers
         !$omp end do
         !$omp end parallel
 
-        if (associated(landIceMask) ) then
+        if (associated(landIceFloatingMask) ) then
           !$omp parallel
           !$omp do schedule(runtime)
           do iCell = 1, nCells
-             dThreshMLD(iCell) = dThreshMLD(iCell) - abs(landIceDraft(iCell))*landIceMask(iCell)
+             dThreshMLD(iCell) = dThreshMLD(iCell) - abs(landIceDraft(iCell))*landIceFloatingMask(iCell)
           end do
           !$omp end do
           !$omp end parallel

--- a/components/mpas-ocean/src/shared/mpas_ocn_effective_density_in_land_ice.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_effective_density_in_land_ice.F
@@ -113,7 +113,7 @@ contains
          effectiveDensityNew   ! effective density at new time level
                                                   
       integer, dimension(:), pointer :: &
-         landIceMask           ! mask for land ice presence on cell
+         landIceFloatingMask   ! mask for land ice presence on cell
 
       ! Scratch Arrays
       ! effectiveDensityScratch: effective seawater density in land
@@ -130,8 +130,8 @@ contains
       if ( (trim(config_land_ice_flux_mode) /= 'coupled') ) return
 
       ! Retrieve forcing and state variables
-      call mpas_pool_get_array(forcingPool, 'landIceMask', &
-                                             landIceMask)
+      call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', &
+                                             landIceFloatingMask)
       call mpas_pool_get_array(forcingPool, 'landIcePressure', &
                                              landIcePressure)
       call mpas_pool_get_array(statePool, 'ssh', ssh, 2)
@@ -139,7 +139,7 @@ contains
                                            effectiveDensityCur, 1)
       call mpas_pool_get_array(statePool, 'effectiveDensityInLandIce', &
                                            effectiveDensityNew, 2)
-      !$acc enter data copyin(landIceMask, landIcePressure, ssh, &
+      !$acc enter data copyin(landIceFloatingMask, landIcePressure, ssh, &
       !$acc                   effectiveDensityCur, effectiveDensityNew)
 
       allocate(effectiveDensityScratch(nCellsAll))
@@ -151,13 +151,13 @@ contains
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
       !$acc    present(effectiveDensityScratch, effectiveDensityCur, &
-      !$acc            landIcePressure, landIceMask, ssh)
+      !$acc            landIcePressure, landIceFloatingMask, ssh)
 #else
       !$omp parallel
       !$omp do schedule(runtime)
 #endif
       do iCell = 1, nCellsAll
-         if (landIceMask(iCell) == 1) then
+         if (landIceFloatingMask(iCell) == 1) then
             ! land ice is present to update the effective density
             effectiveDensityScratch(iCell) = -landIcePressure(iCell)/ &
                                               (ssh(iCell)*gravity)
@@ -198,7 +198,7 @@ contains
 #endif
 
       !$acc exit data delete(effectiveDensityScratch)
-      !$acc exit data delete(landIceMask, landIcePressure, ssh, &
+      !$acc exit data delete(landIceFloatingMask, landIcePressure, ssh, &
       !$acc                  effectiveDensityCur, effectiveDensityNew)
       deallocate(effectiveDensityScratch)
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
@@ -360,7 +360,7 @@ contains
       real (kind=RKIND), dimension(:,:), pointer :: frazilTemperatureTendency
       real (kind=RKIND), dimension(:,:), pointer :: frazilSalinityTendency
       real (kind=RKIND), dimension(:), pointer :: frazilSurfacePressure
-      integer, dimension(:), pointer :: landIceMask
+      integer, dimension(:), pointer :: landIceMask, landIceFloatingMask
 
       integer :: iCell, k, nCells
       integer, dimension(:), pointer :: nCellsArray
@@ -391,7 +391,7 @@ contains
       integer :: indexSalinity !< index in tracers array for salinity
       integer :: kBottomFrazil  ! k index where testing for frazil begins
 
-      logical :: underLandIce ! indicates if we are under land ice
+      logical :: underFloatingLandIce, underLandIce ! indicates if we are under land ice
 
       real (kind=RKIND) :: potential  ! scalar holding freezing/melt potential
       real (kind=RKIND) :: freezingEnergy  ! energy available for freezing, positive definite
@@ -435,6 +435,7 @@ contains
       call mpas_pool_get_array(forcingPool, 'frazilLayerThicknessTendency', frazilLayerThicknessTendency)
       call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
       call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+      call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
 
       ! get time step in units of seconds
       timeStep = mpas_get_clock_timestep(domain % clock, ierr=err)
@@ -451,7 +452,7 @@ contains
       ! loop over all columns
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp private(underLandIce, kBottomFrazil, columnTemperatureMin, k, sumNewFrazilIceThickness, &
+      !$omp private(underFloatingLandIce, underLandIce, kBottomFrazil, columnTemperatureMin, k, sumNewFrazilIceThickness, &
       !$omp         sumNewThicknessWeightedSaltContent, oceanFreezingTemperature, potential, &
       !$omp         freezingEnergy, meltingEnergy, frazilSalinity, newFrazilIceThickness, &
       !$omp         newThicknessWeightedSaltContent, meltedFrazilIceThickness, &
@@ -463,13 +464,23 @@ contains
            underLandIce = (landIceMask(iCell) == 1)
         end if
 
-        if (underLandIce .and. .not. config_frazil_under_land_ice) then
-          ! skip this cell because we're not doing frazil under land ice
+        underFloatingLandIce = .false.
+        if ( associated(landIceFloatingMask) ) then
+           underFloatingLandIce = (landIceFloatingMask(iCell) == 1)
+        end if
+
+        if (underFloatingLandIce .and. .not. config_frazil_under_land_ice) then
+          ! skip this cell because we're not doing frazil under floating land ice
           cycle
         end if
 
         if (.not. underLandIce .and. .not. config_frazil_in_open_ocean) then
           ! skip this cell because we're not doing frazil in the open ocean
+          cycle
+        end if
+
+        if (underLandIce .and. .not. underFloatingLandIce) then
+          ! skip this cell because we're not doing frazil under grounded land ice
           cycle
         end if
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -429,7 +429,7 @@ contains
 
       real (kind=RKIND) :: freshwaterFlux, heatFlux
 
-      real (kind=RKIND), dimension(:), pointer :: landIcePressure, landIceFraction, &
+      real (kind=RKIND), dimension(:), pointer :: landIcePressure, landIceFloatingFraction, &
                                                   landIceSurfaceTemperature, &
                                                   landIceFreshwaterFlux, &
                                                   landIceHeatFlux, heatFluxToLandIce
@@ -438,7 +438,7 @@ contains
                                                   accumulatedLandIceHeatOld, &
                                                   accumulatedLandIceHeatNew
 
-      integer, dimension(:), pointer :: landIceMask
+      integer, dimension(:), pointer :: landIceFloatingMask
 
       real (kind=RKIND), dimension(:,:), pointer :: &
                                                     landIceInterfaceTracers
@@ -468,8 +468,8 @@ contains
 
       call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
 
-      call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
-      call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+      call mpas_pool_get_array(forcingPool, 'landIceFloatingFraction', landIceFloatingFraction)
+      call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
 
       call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
       call mpas_pool_get_array(forcingPool, 'landIceHeatFlux', landIceHeatFlux)
@@ -506,7 +506,7 @@ contains
          !$omp parallel
          !$omp do schedule(runtime) private(freshwaterFlux, heatFlux)
          do iCell = 1, nCells
-            if (landIceMask(iCell) == 0) cycle
+            if (landIceFloatingMask(iCell) == 0) cycle
 
             ! linearized equaiton for the S and p dependent potential freezing temperature
             landIceInterfaceTracers(indexIT,iCell) = ocn_freezing_temperature( &
@@ -521,14 +521,14 @@ contains
             freshwaterFlux = -rho_sw * ISOMIPgammaT * (cp_sw/latent_heat_fusion_mks) &
                        * (landIceInterfaceTracers(indexIT,iCell)-landIceBoundaryLayerTracers(indexBLT,iCell))
 
-            landIceFreshwaterFlux(iCell) = landIceFraction(iCell)*freshwaterFlux
+            landIceFreshwaterFlux(iCell) = landIceFloatingFraction(iCell)*freshwaterFlux
 
             ! Using (13) from Jenkins et al. (2001)
             ! heat flux is in W/s
             heatFlux = cp_sw*(freshwaterFlux*landIceInterfaceTracers(indexIT,iCell) &
                               + rho_sw*ISOMIPgammaT &
                                 * (landIceInterfaceTracers(indexIT,iCell)-landIceBoundaryLayerTracers(indexBLT,iCell)))
-            landIceHeatFlux(iCell) = landIceFraction(iCell)*heatFlux
+            landIceHeatFlux(iCell) = landIceFloatingFraction(iCell)*heatFlux
 
             heatFluxToLandIce(iCell) = 0.0_RKIND
 
@@ -541,7 +541,7 @@ contains
          if(useHollandJenkinsAdvDiff) then
             ! melting solution
             call compute_HJ99_melt_fluxes( &
-               landIceMask, &
+               landIceFloatingMask, &
                landIceBoundaryLayerTracers(indexBLT,:), &
                landIceBoundaryLayerTracers(indexBLS,:), &
                landIceTracerTransferVelocities(indexHeatTrans,:), &
@@ -563,7 +563,7 @@ contains
 
             ! freezing solution
             call compute_melt_fluxes( &
-               landIceMask, &
+               landIceFloatingMask, &
                landIceBoundaryLayerTracers(indexBLT,:), &
                landIceBoundaryLayerTracers(indexBLS,:), &
                landIceTracerTransferVelocities(indexHeatTrans,:), &
@@ -583,7 +583,7 @@ contains
             end if
 
             do iCell = 1, nCells
-               if ((landIceMask(iCell) == 0) .or. (landIceFreshwaterFlux(iCell) >= 0.0_RKIND)) cycle
+               if ((landIceFloatingMask(iCell) == 0) .or. (landIceFreshwaterFlux(iCell) >= 0.0_RKIND)) cycle
 
                landIceInterfaceTracers(indexIS,iCell) = freezeInterfaceSalinity(iCell)
                landIceInterfaceTracers(indexIT,iCell) = freezeInterfaceTemperature(iCell)
@@ -593,7 +593,7 @@ contains
             end do
          else ! not using Holland and Jenkins advection/diffusion
             call compute_melt_fluxes( &
-               landIceMask, &
+               landIceFloatingMask, &
                landIceBoundaryLayerTracers(indexBLT,:), &
                landIceBoundaryLayerTracers(indexBLS,:), &
                landIceTracerTransferVelocities(indexHeatTrans,:), &
@@ -613,13 +613,13 @@ contains
             end if
          end if
 
-         ! modulate the fluxes by the landIceFraction
+         ! modulate the fluxes by the landIceFloatingFraction
          do iCell = 1, nCells
-            if (landIceMask(iCell) == 0) cycle
+            if (landIceFloatingMask(iCell) == 0) cycle
 
-            landIceFreshwaterFlux(iCell) = landIceFraction(iCell)*landIceFreshwaterFlux(iCell)
-            landIceHeatFlux(iCell) = landIceFraction(iCell)*landIceHeatFlux(iCell)
-            heatFluxToLandIce(iCell) = landIceFraction(iCell)*heatFluxToLandIce(iCell)
+            landIceFreshwaterFlux(iCell) = landIceFloatingFraction(iCell)*landIceFreshwaterFlux(iCell)
+            landIceHeatFlux(iCell) = landIceFloatingFraction(iCell)*landIceHeatFlux(iCell)
+            heatFluxToLandIce(iCell) = landIceFloatingFraction(iCell)*heatFluxToLandIce(iCell)
          end do
 
       endif ! jenkinsOn or hollandJenkinsOn

--- a/components/mpas-ocean/src/shared/mpas_ocn_time_varying_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_time_varying_forcing.F
@@ -443,6 +443,10 @@ contains
          config_time_varying_land_ice_forcing_reference_time, config_time_varying_land_ice_forcing_interval)
 
     call mpas_forcing_init_field(domain % streamManager, forcingGroupHead, "ocn_land_ice_forcing", &
+         "landIceFloatingFraction", "land_ice_forcing", "timeVaryingForcing", "landIceFloatingFractionForcing", "linear", &
+         config_time_varying_land_ice_forcing_reference_time, config_time_varying_land_ice_forcing_interval)
+
+    call mpas_forcing_init_field(domain % streamManager, forcingGroupHead, "ocn_land_ice_forcing", &
          "landIceDraft", "land_ice_forcing", "timeVaryingForcing", "landIceDraftForcing", "linear", &
          config_time_varying_land_ice_forcing_reference_time, config_time_varying_land_ice_forcing_interval)
 
@@ -495,6 +499,8 @@ contains
     real(kind=RKIND), dimension(:), pointer :: &
          landIceFractionForcing, &
          landIceFraction, &
+         landIceFloatingFractionForcing, &
+         landIceFloatingFraction, &
          landIcePressureForcing, &
          landIcePressure, &
          landIceDraftForcing, &
@@ -525,15 +531,18 @@ contains
        call MPAS_pool_get_dimension(mesh, "nCells", nCells)
    
        call MPAS_pool_get_array(timeVaryingForcingPool, "landIceFractionForcing", landIceFractionForcing)
+       call MPAS_pool_get_array(timeVaryingForcingPool, "landIceFloatingFractionForcing", landIceFloatingFractionForcing)
        call MPAS_pool_get_array(timeVaryingForcingPool, "landIcePressureForcing", landIcePressureForcing)
        call MPAS_pool_get_array(timeVaryingForcingPool, "landIceDraftForcing", landIceDraftForcing)
        call MPAS_pool_get_array(forcingPool, "landIceFraction", landIceFraction)
+       call MPAS_pool_get_array(forcingPool, "landIceFloatingFraction", landIceFloatingFraction)
        call MPAS_pool_get_array(forcingPool, "landIcePressure", landIcePressure)
        call MPAS_pool_get_array(forcingPool, "landIceDraft", landIceDraft)
    
        do iCell = 1, nCells
    
           landIceFraction(iCell) = landIceFractionForcing(iCell)
+          landIceFloatingFraction(iCell) = landIceFloatingFractionForcing(iCell)
           landIcePressure(iCell) = landIcePressureForcing(iCell)
           landIceDraft(iCell) = landIceDraftForcing(iCell)
    

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_ideal_age.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_ideal_age.F
@@ -189,7 +189,7 @@ contains
 
       if (config_use_idealAgeTracers_idealAge_forcing) then
          ! set mask = 0 for open ocean
-         ! set mask = 1 under ice shelves
+         ! set mask = 1 under land ice
          idealAgeMask = 0.0_RKIND
          if (associated(landIceMask)) then
             where (landIceMask /= 0) idealAgeMask(1,:) = 1.0_RKIND


### PR DESCRIPTION
This PR adds new variables to represent floating land ice. This is a necessary step toward coupling with an ice sheet model component (MALI).

- `landIceMask` and `landIceFraction` (existing variables) now represent both grounded and floating land ice.
- `landIceFloatingMask` and `landIceFloatingFraction (new variables)` represent only floating land ice.

The `landIceFloating*` variables are used to modulate land ice fluxes, whereas the `landIce*` variables are used to mask out certain fields, as before. `landIce*` variables also modulate top drag, as we want to include the effect of top drag on thin film regions to slow flow.

[NML]
[non-BFB]