### PR TITLE
Fixes issues with weak sea ice spatial operators formulation

### DIFF
--- a/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver_variational_shared.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver_variational_shared.F
@@ -123,7 +123,10 @@ contains
        blockPtr => domain % blocklist
        do while (associated(blockPtr))
 
+          call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
           call MPAS_pool_get_subpool(blockPtr % structs, "velocity_variational", velocityVariationalPool)
+
+          call MPAS_pool_get_dimension(meshPool, "nVertices", nVertices)
 
           call MPAS_pool_get_array(velocityVariationalPool, "tanLatVertexRotatedOverRadius", tanLatVertexRotatedOverRadius)
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver_weak.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver_weak.F
@@ -80,6 +80,10 @@ contains
 
        call MPAS_pool_get_config(domain % configs, "config_rotate_cartesian_grid", config_rotate_cartesian_grid)
 
+       call MPAS_pool_get_subpool(blockPtr % structs, "velocity_weak", velocityWeakPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "mesh", meshPool)
+       call MPAS_pool_get_subpool(blockPtr % structs, "boundary", boundaryPool)
+
        call MPAS_pool_get_array(velocityWeakPool, "normalVectorPolygon", normalVectorPolygon)
        call MPAS_pool_get_array(velocityWeakPool, "normalVectorTriangle", normalVectorTriangle)
        call MPAS_pool_get_array(velocityWeakPool, "latCellRotated", latCellRotated)
@@ -350,9 +354,9 @@ contains
        call MPAS_pool_get_array(velocityWeakPool, "strain11", strain11)
        call MPAS_pool_get_array(velocityWeakPool, "strain22", strain22)
        call MPAS_pool_get_array(velocityWeakPool, "strain12", strain12)
-       call MPAS_pool_get_array(velocityWeakPool, "stress11weak", stress11)
-       call MPAS_pool_get_array(velocityWeakPool, "stress22weak", stress22)
-       call MPAS_pool_get_array(velocityWeakPool, "stress12weak", stress12)
+       call MPAS_pool_get_array(velocityWeakPool, "stress11", stress11)
+       call MPAS_pool_get_array(velocityWeakPool, "stress22", stress22)
+       call MPAS_pool_get_array(velocityWeakPool, "stress12", stress12)
        call MPAS_pool_get_array(velocityWeakPool, "replacementPressure", replacementPressure)
 
        if (constitutiveRelationType == EVP_CONSTITUTIVE_RELATION) then


### PR DESCRIPTION
Recent refactoring to sea ice velocity initialization broke some test cases using the weak formulation. This allows the weak formulation to run successfully.

Fixes https://github.com/E3SM-Project/E3SM/issues/5473

[BFB]