### PR TITLE
Add space before bfb_erf macro so as not to confuse preprocessor

### DIFF
--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -2857,7 +2857,7 @@ subroutine shoc_assumed_pdf_compute_s(&
   C=0._rtype
 
   if (std_s .gt. bfb_sqrt(tiny(1._rtype)) * 100) then
-    C=0.5_rtype*(1._rtype+bfb_erf(s/(sqrt2*std_s)))
+    C=0.5_rtype*(1._rtype+ bfb_erf(s/(sqrt2*std_s)))
     if (C .ne. 0._rtype) qn=s*C+(std_s/sqrt2pi)*bfb_exp(-0.5_rtype*bfb_square(s/std_s))
   else
     if (s .gt. 0._rtype) then


### PR DESCRIPTION
For some reason, the preprocessor used for nvidia and AMD builds is having trouble parsing the use of bfb_erf macro in one location. Simply adding a space before the macro (found by @mrnorman) sllows building as a work-around until this is fixed (by compiler vendors?).

```
-    C=0.5_rtype*(1._rtype+bfb_erf(s/(sqrt2*std_s)))
+    C=0.5_rtype*(1._rtype+ bfb_erf(s/(sqrt2*std_s)))
```

Fixes #https://github.com/E3SM-Project/scream/issues/1784
[BFB]

