### PR TITLE
Added missing am_thicknesses to mpas-seaice build file

### DIFF
--- a/components/mpas-seaice/bld/build-namelist-group-list
+++ b/components/mpas-seaice/bld/build-namelist-group-list
@@ -24,6 +24,7 @@ my @groups = qw(seaice_model
                 prescribed_ice
                 am_highfrequencyoutput
                 am_temperatures
+                am_thicknesses
                 am_regionalstatistics
                 am_ridgingdiagnostics
                 am_conservationcheck


### PR DESCRIPTION
Reference to am_thicknesses was missing from build-namelist-group-list

Fixes https://github.com/E3SM-Project/E3SM/issues/5482

[BFB]