### PR TITLE
New MPAS-SI + WW3 compset (D-compset plus ww3)

### DIFF
--- a/components/mpas-seaice/cime_config/config_compsets.xml
+++ b/components/mpas-seaice/cime_config/config_compsets.xml
@@ -10,7 +10,7 @@
   <!-- E3SM D compsets -->
 
   <compset>
-    <alias>DMPAS-JRA1p5</alias>
+    <alias>DTEST-JRA1p5</alias>
     <lname>2000_DATM%JRA-1p5_SLND_MPASSI_DOCN%SOM_DROF%JRA-1p5_SGLC_SWAV_TEST</lname>
   </compset>
 

--- a/components/ww3/cime_config/config_compsets.xml
+++ b/components/ww3/cime_config/config_compsets.xml
@@ -25,7 +25,7 @@
   </compset>
 
   <compset>
-    <alias>DMPAS-JRA1p5-WW3</alias>
+    <alias>DTEST-JRA1p5-WW3</alias>
     <lname>2000_DATM%JRA-1p5_SLND_MPASSI_DOCN%SOM_DROF%JRA-1p5_SGLC_WW3%sp36x36_TEST</lname>
   </compset>
 

--- a/components/ww3/cime_config/config_compsets.xml
+++ b/components/ww3/cime_config/config_compsets.xml
@@ -35,8 +35,8 @@
   </compset>
 
   <compset>
-    <alias>GMPAS-JRA1p4-WW3</alias>
-    <lname>2000_DATM%JRA-1p4-2018_SLND_MPASSI_MPASO%DATMFORCED_DROF%JRA-1p4-2018_SGLC_WW3%sp36x36</lname>
+    <alias>GMPAS-JRA1p5-WW3</alias>
+    <lname>2000_DATM%JRA-1p5_SLND_MPASSI_MPASO%DATMFORCED_DROF%JRA-1p5_SGLC_WW3%sp36x36</lname>
   </compset>
 
   <compset>

--- a/components/ww3/cime_config/config_compsets.xml
+++ b/components/ww3/cime_config/config_compsets.xml
@@ -25,7 +25,7 @@
   </compset>
 
   <compset>
-    <alias>DTEST-JRA-WW3</alias>
+    <alias>DMPAS-JRA1p5-WW3</alias>
     <lname>2000_DATM%JRA-1p5_SLND_MPASSI_DOCN%SOM_DROF%JRA-1p5_SGLC_WW3%sp36x36_TEST</lname>
   </compset>
 

--- a/components/ww3/cime_config/config_compsets.xml
+++ b/components/ww3/cime_config/config_compsets.xml
@@ -25,6 +25,11 @@
   </compset>
 
   <compset>
+    <alias>DMPAS-JRA-WW3</alias>
+    <lname>2000_DATM%JRA-1p5_SLND_MPASSI_DOCN%SOM_DROF%JRA-1p5_SGLC_WW3%sp36x36</lname>
+  </compset>
+
+  <compset>
     <alias>GMPAS-IAF-WW3</alias>
     <lname>2000_DATM%IAF_SLND_MPASSI_MPASO%DATMFORCED_DROF%IAF_SGLC_WW3%sp36x36</lname>
   </compset>

--- a/components/ww3/cime_config/config_compsets.xml
+++ b/components/ww3/cime_config/config_compsets.xml
@@ -25,8 +25,8 @@
   </compset>
 
   <compset>
-    <alias>DMPAS-JRA-WW3</alias>
-    <lname>2000_DATM%JRA-1p5_SLND_MPASSI_DOCN%SOM_DROF%JRA-1p5_SGLC_WW3%sp36x36</lname>
+    <alias>DTEST-JRA-WW3</alias>
+    <lname>2000_DATM%JRA-1p5_SLND_MPASSI_DOCN%SOM_DROF%JRA-1p5_SGLC_WW3%sp36x36_TEST</lname>
   </compset>
 
   <compset>


### PR DESCRIPTION
New WW3 compset option for MPAS-SI plus waves. For testing purposes only. 
Modification to D-JRA compset alias - should include 'TEST' in alias. 

[BFB]