### PR TITLE
Using the correct PIO module in MPAS

### DIFF
--- a/components/mpas-framework/src/framework/mpas_io.F
+++ b/components/mpas-framework/src/framework/mpas_io.F
@@ -13,8 +13,7 @@ module mpas_io
    use mpas_log
 
    use pio
-   use piolib_mod
-   use pionfatt_mod
+   use pio_kinds
    use pio_types
 
 #ifdef SINGLE_PRECISION


### PR DESCRIPTION
Removing unused modules and adding the required/correct PIO module

[BFB]