### PR TITLE
Add SCREAMv1 test to e3sm_gpucxx suite

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -762,6 +762,7 @@ _TESTS = {
     "e3sm_gpucxx" : {
         "tests"    : (
                  "SMS_Ln9.ne4pg2_ne4pg2.F2010-MMF1",
+                 "ERP_Ln9.ne4pg2_ne4pg2.F2010-SCREAMv1",
                  )
     },
 

--- a/components/eamxx/src/physics/cosp/CMakeLists.txt
+++ b/components/eamxx/src/physics/cosp/CMakeLists.txt
@@ -17,7 +17,7 @@ set(EXTERNAL_SRC
    ${EAM_COSP_DIR}/external/src/cosp_constants.F90
    ${EAM_COSP_DIR}/external/src/simulator/cosp_cloudsat_interface.F90
    ${EAM_COSP_DIR}/external/src/cosp_config.F90
-   ${EAM_COSP_DIR}/local/cosp.F90
+   ${EAM_COSP_DIR}/external/src/cosp.F90
    ${EAM_COSP_DIR}/external/src/cosp_stats.F90
    ${EAM_COSP_DIR}/external/src/simulator/quickbeam/quickbeam.F90
    ${EAM_COSP_DIR}/external/src/simulator/parasol/parasol.F90


### PR DESCRIPTION
Add F2010-SCREAMv1 test to e3sm_gpucxx suite to get test coverage on GPU for
EAMxx codebase in main E3SM repo. 

Fixes #6540.

[BFB]