### PR TITLE
Removed confusing warning error messages from forcing

### DIFF
--- a/components/mpas-framework/src/framework/mpas_forcing.F
+++ b/components/mpas-framework/src/framework/mpas_forcing.F
@@ -1807,7 +1807,11 @@ contains
        lInputPoolCreated = .false.
 
        nullify(forcingPoolInput)
-       call MPAS_pool_get_subpool(block % structs, trim(poolnameInput), forcingPoolInput)
+
+       if (MPAS_pool_exists(block % structs, trim(poolnameInput), forcingPoolInput)) then
+          call MPAS_pool_get_subpool(block % structs, trim(poolnameInput), forcingPoolInput)
+       endif
+
        if (.not. associated(forcingPoolInput)) then
           call MPAS_pool_create_pool(forcingPoolInput)
           lInputPoolCreated = .true.

--- a/components/mpas-framework/src/framework/mpas_pool_routines.F
+++ b/components/mpas-framework/src/framework/mpas_pool_routines.F
@@ -5377,6 +5377,40 @@ module mpas_pool_routines
 
 
 !-----------------------------------------------------------------------
+!  subroutine mpas_pool_exists
+!
+!> \brief MPAS Pool check subpool exists function
+!> \author Adrian K. Turner
+!> \date   03/03/2023
+!> \details
+!> This function returns whether a subpool named key exists within
+!> inPool.
+!
+!-----------------------------------------------------------------------
+   function mpas_pool_exists(inPool, key, subPool) result(exists)!{{{
+
+      implicit none
+
+      type (mpas_pool_type), intent(in) :: inPool
+      character (len=*), intent(in) :: key
+      type (mpas_pool_type), pointer :: subPool
+
+      type (mpas_pool_data_type), pointer :: mem
+
+      logical :: exists
+
+      mem => pool_get_member(inPool, key, MPAS_POOL_SUBPOOL)
+
+      if (associated(mem)) then
+         exists = .true.
+      else
+         exists = .false.
+      end if
+
+   end function mpas_pool_exists!}}}
+
+
+!-----------------------------------------------------------------------
 !  subroutine mpas_pool_add_package
 !
 !> \brief MPAS Pool Package insertion subroutine


### PR DESCRIPTION
Added framework function to check if pool exists
In forcing framework check for input pool before accessing to avoid confusing error messages

Fixes https://github.com/E3SM-Project/E3SM/issues/5497

[BFB]