### PR TITLE
Edit anvil machine regular expression so it doesn't also match bebop

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2076,7 +2076,7 @@
 
   <machine MACH="anvil">
     <DESC>ANL/LCRC Linux Cluster</DESC>
-    <NODENAME_REGEX>b.*.lcrc.anl.gov</NODENAME_REGEX>
+    <NODENAME_REGEX>(b\d+|blues.*).lcrc.anl.gov</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>intel,gnu</COMPILERS>
     <MPILIBS>impi,openmpi,mvapich</MPILIBS>


### PR DESCRIPTION
The regular expression in the machine file for anvil was also matching bebop. This PR narrows the regular expression so it doesn't conflict with bebop.

Fixes #5485 

[BFB] 