### PR TITLE
Remove tests of old RRM configurations

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -217,8 +217,6 @@ _TESTS = {
     "e3sm_extra_coverage" : {
         "inherit" : ("e3sm_atm_extra_coverage", "e3sm_ocnice_extra_coverage"),
         "tests"   : (
-            "SMS_D_Ln5.enax4v1_enax4v1.F2010-CICE",
-            "SMS_D_Ln5.twpx4v1_twpx4v1.F2010-CICE",
             "SMS_D_Ln3.TL319_EC30to60E2r2_wQU225EC30to60E2r2.GMPAS-JRA-WW3",
             )
         },
@@ -236,8 +234,6 @@ _TESTS = {
     "e3sm_rrm" : {
         "tests" : (
             "SMS_D_Ln5.conusx4v1_r05_oECv3.F2010",
-            "SMS_D_Ln5.enax4v1_enax4v1.F2010-CICE",
-            "SMS_D_Ln5.twpx4v1_twpx4v1.F2010-CICE",
             )
         },
 


### PR DESCRIPTION
Remove F-case tests that use out-dated RRM grids which no longer have land conditions needed to run:
ne0np4_enax4v1: 1-deg with 1/4-deg over Eastern North Atlantic (version 1)
ne0np4_twpx4v1: 1-deg with 1/4-deg over Tropical West Pacific (version 1)

We are still testing the fully coupled RRM case in the production suite:
ne0np4_northamericax4v1.pg2
1-deg with 1/4-deg over North America (version 1) pg2
WC14to60E2r3
MPAS with enhanced resolution of 14km along the coast of North America, the Northern Atlantic subpolar gyre, and the Arctic Ocean.

[BFB]
