### PR TITLE
Add missing variable to the overloaded copy assignment operator for parallel_t

### DIFF
--- a/components/homme/src/share/parallel_mod.F90
+++ b/components/homme/src/share/parallel_mod.F90
@@ -103,6 +103,7 @@ contains
     par2%nprocs     = par1%nprocs
     par2%comm       = par1%comm
     par2%masterproc = par1%masterproc
+    par2%dynproc    = par1%dynproc
 
   end subroutine copy_par
 
@@ -124,12 +125,15 @@ contains
     integer(kind=int_kind)                              :: ierr
     logical :: running   ! state of MPI at beginning of initmp call
 #ifdef CAM
-    integer :: color = 1
+    integer :: color
     integer :: iam_cam, npes_cam
     integer :: npes_homme
     integer :: max_stride
 #endif
-    integer :: npes_cam_stride = 1
+    integer :: npes_cam_stride
+
+    color = 1
+    npes_cam_stride = 1
     !================================================
     !     Basic MPI initialization
     ! ================================================

--- a/components/homme/src/share/parallel_mod.F90
+++ b/components/homme/src/share/parallel_mod.F90
@@ -52,11 +52,10 @@ module parallel_mod
     integer :: root                       ! local root
     integer :: nprocs                     ! number of processes in group
     integer :: comm                       ! local communicator
-!    integer :: node_comm                  ! local communicator of all procs per node
-!    integer :: node_rank                  ! local rank in node_comm
-!    integer :: node_nprocs                ! local rank in node_comm
     logical :: masterproc                
     logical :: dynproc                    ! Designation of a dynamics processor - AaronDonahue
+    ! note: HOMME redefines the parallel_t assignment operator to be a deep copy,
+    ! so with any change to this struct, check the user defined assignment operator below (copy_par)
   end type
 
 #ifdef CAM


### PR DESCRIPTION
Add missing variable to the overloaded copy assignment operator for parallel_data structure.
Recently added variable to `parallel_t` was missing from the `copy_par` routine.
`par2%dynproc    = par1%dynproc`
Which, for whatever reason, was only a problem with `nvidia/22.7` (and higher).

Be more careful about setting initial values for 2 integers in routine. 
Example: `integer :: ikool=4` is dangerous as we may expect it to be set each entry, but instead, I think it's only set on the first call. Which is fine here as it's only called once, just being more careful.

Fixes https://github.com/E3SM-Project/E3SM/issues/5353
BFB