### PR TITLE
Increase initial soil moisture in fates runs

### DIFF
--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -1616,8 +1616,8 @@ contains
                 if (j > nlevbed) then
                    this%h2osoi_vol(c,j) = 0.0_r8
                 else
-		               if (use_fates_planthydro .or. use_hydrstress) then
-                      this%h2osoi_vol(c,j) = 0.70_r8*watsat_input(c,j) !0.15_r8 to avoid very dry conditions that cause errors in FATES HYDRO
+		               if (use_fates .or. use_hydrstress) then
+                      this%h2osoi_vol(c,j) = 0.70_r8*watsat_input(c,j) !0.15_r8 to avoid very dry conditions that cause errors in FATES
                    else
                       this%h2osoi_vol(c,j) = 0.15_r8
                    endif


### PR DESCRIPTION
This PR changes the condition for a higher initial value of soil moisture so that all FATES runs, not just FATES-Hydro, will be initialized with higher soil moisture. This is to improve the establishment of forest in bare ground simulations. 
See FATES issue here https://github.com/NGEET/fates/issues/994 and discussion here https://github.com/NGEET/fates/discussions/985. 

This change should be B4B in non-FATES runs and non-B4B in FATES runs. 