### PR TITLE
Add CondiDiag1.1 to EAM

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -127,6 +127,7 @@ _TESTS = {
 
     #atmopheric tests for extra coverage
     "e3sm_atm_extra_coverage" : {
+        "inherit" : ("eam_condidiag"),
         "tests" : (
             "SMS_Lm1.ne4_oQU240.F2010",
             "ERS_Ld31.ne4_oQU240.F2010",

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -97,6 +97,7 @@ _TESTS = {
 
     "eam_condidiag" : {
         "tests"   : (
+            "SMS_D_Ln5.ne4_oQU240.F2010",
             "SMS_D_Ln5.ne4_oQU240.F2010.eam-condidiag_dcape",
             "ERP_Ld3.ne4_oQU240.F2010.eam-condidiag_dcape",
             "ERP_Ld3.ne4_oQU240.F2010.eam-condidiag_rhi",

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -97,8 +97,8 @@ _TESTS = {
 
     "eam_condidiag" : {
         "tests"   : (
-            "SMS_D_Ln5.ne4_oQU240.F2010",
-            "SMS_D_Ln5.ne4_oQU240.F2010.eam-condidiag_dcape",
+            "SMS_D_Ln5.ne4pg2_oQU480.F2010",
+            "SMS_D_Ln5.ne4pg2_oQU480.F2010.eam-condidiag_dcape",
             "ERP_Ln18.ne4_oQU240.F2010.eam-condidiag_dcape",
             "ERP_Ln18.ne4_oQU240.F2010.eam-condidiag_rhi",
             )
@@ -127,7 +127,6 @@ _TESTS = {
 
     #atmopheric tests for extra coverage
     "e3sm_atm_extra_coverage" : {
-        "inherit" : ("eam_condidiag"),
         "tests" : (
             "SMS_Lm1.ne4_oQU240.F2010",
             "ERS_Ld31.ne4_oQU240.F2010",
@@ -138,6 +137,8 @@ _TESTS = {
 	    "SMS_D_Ln5.ne45pg2_ne45pg2.FAQP",
             "SMS_D_Ln5.ne4_oQU240.F2010.eam-implicit_stress",
             "ERS_Ld5.ne30_oECv3.F2010.eam-implicit_stress",
+            "ERP_Ln18.ne4_oQU240.F2010.eam-condidiag_dcape",
+            "ERP_Ln18.ne4_oQU240.F2010.eam-condidiag_rhi",
             )
         },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -95,6 +95,14 @@ _TESTS = {
             )
         },
 
+    "eam_condidiag" : {
+        "tests"   : (
+            "SMS_D_Ln5.ne4_oQU240.F2010.eam-condidiag_dcape",
+            "ERP_Ld3.ne4_oQU240.F2010.eam-condidiag_dcape",
+            "ERP_Ld3.ne4_oQU240.F2010.eam-condidiag_rhi",
+            )
+        },
+
     "e3sm_atm_integration" : {
         "inherit" : ("eam_preqx", "eam_theta"),
         "tests" : (

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -99,8 +99,8 @@ _TESTS = {
         "tests"   : (
             "SMS_D_Ln5.ne4_oQU240.F2010",
             "SMS_D_Ln5.ne4_oQU240.F2010.eam-condidiag_dcape",
-            "ERP_Ld3.ne4_oQU240.F2010.eam-condidiag_dcape",
-            "ERP_Ld3.ne4_oQU240.F2010.eam-condidiag_rhi",
+            "ERP_Ln18.ne4_oQU240.F2010.eam-condidiag_dcape",
+            "ERP_Ln18.ne4_oQU240.F2010.eam-condidiag_rhi",
             )
         },
 

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -1332,6 +1332,116 @@ error tolerance for CO2 conservation
 Default: 5.e-13
 </entry>
 
+<!-- CondiDiag-->
+
+<entry id="metric_name" type="char*8(10)"  category="history"
+       group="conditional_diag_nl" valid_values="" >
+List of fields to use as metrics in conditional sampling.
+Default: none
+</entry>
+
+<entry id="metric_nver" type="integer(10)"  category="history"
+       group="conditional_diag_nl" valid_values="" >
+Numbers of vertical levels of the metrics used in conditional sampling
+Different metrics can have different vertical dimension sizes.
+Default: none
+</entry>
+
+<entry id="metric_cmpr_type" type="integer(10)"  category="history"
+       group="conditional_diag_nl" valid_values="-2,-1,0,1,2" >
+Types of comparison (.le., .lt., .eq. within tolerance, .gt., .ge.)
+to be used in conditional sampling.
+Different metrics can have different comparison types.
+Default: none
+</entry>
+
+<entry id="metric_threshold" type="real(10)"  category="history"
+       group="conditional_diag_nl" valid_values="" >
+Thresholds to be used in conditional sampling.
+Different metrics can have different thresholds.
+Default: none
+</entry>
+
+<entry id="metric_tolerance" type="real(10)"  category="history"
+       group="conditional_diag_nl" valid_values="" >
+Tolerances for the "equal to" comparison type if the type is
+specified using metric_cmpr_type. The values are ignored
+if other comparison types are specified.
+Default: none
+</entry>
+
+<entry id="cnd_eval_chkpt" type="char*10(10)"  category="history"
+       group="conditional_diag_nl" valid_values="" >
+A list. Each element specifies the checkpoint at which the
+corresponding conditional sampling criterion
+will be evaluated. The number of checkpoints specified here
+should match the number of non-empty elements in metric_name;
+Default: none
+</entry>
+
+<entry id="cnd_end_chkpt" type="char*10(10)"  category="history"
+       group="conditional_diag_nl" valid_values="" >
+A list. Each element specifies the checkpoint that marks the end
+of validity of the corresponding sampling condition.
+At this checkpoint, the masking of QoIs will be done
+and the masked values will be sent to history buffer.
+Default: none
+</entry>
+
+<entry id="qoi_name" type="char*8(20)"  category="history"
+       group="conditional_diag_nl" valid_values="" >
+List of fields (Quantities of Interest, QoIs) to be
+monitored or conditionally sampled.
+Default: none
+</entry>
+
+<entry id="qoi_nver" type="integer(20)"  category="history"
+       group="conditional_diag_nl" valid_values="" >
+Dimension sizes of the QoIs.
+Default: none
+</entry>
+
+<entry id="qoi_x_dp" type="integer(20)"  category="history"
+       group="conditional_diag_nl" valid_values="" >
+Whether a QoI should be multiplied by dp for output;
+if so, wet or dry.
+Default: none
+</entry>
+
+
+<entry id="qoi_chkpt" type="char*10(250)"  category="history"
+       group="conditional_diag_nl" valid_values="" >
+Checkpoints at which QoIs will be monitored or conditionally sampled.
+Default: none
+</entry>
+
+<entry id="chkpt_x_dp" type="integer(250)"  category="history"
+       group="conditional_diag_nl" valid_values="" >
+Whether QoIs at a checkpoint should be multiplied by dp
+for output if applicable; if so, wet or dry.
+Default: none
+</entry>
+
+<entry id="l_output_state" type="logical"  category="history"
+       group="conditional_diag_nl" valid_values=".true.,.false." >
+Whether the state of the above-specified fields will be written
+to history file(s).
+Default: none
+</entry>
+
+<entry id="l_output_incrm" type="logical"  category="history"
+       group="conditional_diag_nl" valid_values=".true.,.false." >
+Whether the increments of the above-specified fields will be written
+to history file(s).
+Default: none
+</entry>
+
+<entry id="hist_tape_with_all_output" type="integer(10)"  category="history"
+       group="conditional_diag_nl" valid_values="" >
+Indices of history tapes that will each contain a whole suite of CondiDiag output.
+Default: none
+</entry>
+
 <!-- History and Initial Conditions Output -->
 
 <entry id="avgflag_pertape" type="char*1(15)"  category="history"

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -1349,8 +1349,12 @@ Default: none
 
 <entry id="metric_cmpr_type" type="integer(10)"  category="history"
        group="conditional_diag_nl" valid_values="-2,-1,0,1,2" >
-Types of comparison (.le., .lt., .eq. within tolerance, .gt., .ge.)
-to be used in conditional sampling.
+Types of comparison to be used in conditional sampling:
+-2 means .le.,
+-1 means .lt.,
+ 0 means .eq. within tolerance,
+ 1 means .gt.,
+ 2 means .ge..
 Different metrics can have different comparison types.
 Default: none
 </entry>

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/condidiag_dcape/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/condidiag_dcape/user_nl_eam
@@ -1,0 +1,20 @@
+ metric_name = 'ALL',
+
+ qoi_chkpt = 'RAD', 'PACEND','DYNEND','DEEPCU', 'STCLD',
+
+ qoi_name = 'CAPE','dCAPE'
+ qoi_nver =  1,     72,
+
+ l_output_state = .true.
+ l_output_incrm = .false.
+
+ hist_tape_with_all_output = 1,2
+
+ nhtfrq          =  -24,   -6 
+ mfilt           =   30,  120 
+ avgflag_pertape =   'A', 'I'
+
+ history_amwg        = .false.
+ history_aero_optics = .false.
+ history_aerosol     = .false.
+

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/condidiag_rhi/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/condidiag_rhi/user_nl_eam
@@ -1,0 +1,36 @@
+! RHI budget analyses
+!  - condition 1: only sample grid cells and time steps where RHI after the first mac-mic sub-cycle exceeds 125%.
+!  - condition 2: all grid columns and time steps
+
+ metric_name       = 'RHI',      'RHI',
+ metric_nver       =  72,         72
+ metric_cmpr_type  =  1,          1
+ metric_threshold  =  125,        -1
+ cnd_eval_chkpt    =  'CLDMAC01', 'CLDMAC01'
+ cnd_end_chkpt     =  'PBCDIAG',  'PBCDIAG'
+
+ qoi_chkpt   = 'PBCDIAG', 'RAD', 'PACEND','DYNEND','DEEPCU',
+               'CLDMAC01','CLDMIC01'
+               'CLDMAC02','CLDMIC02'
+               'CLDMAC03','CLDMIC03'
+               'CLDMAC04','CLDMIC04'
+               'CLDMAC05','CLDMIC05'
+               'CLDMAC06','CLDMIC06'
+
+ qoi_name = 'RHI', 'Q', 'QSATI'
+ qoi_nver =  72,    72,  72
+
+ l_output_state = .true.
+ l_output_incrm = .true.
+
+! Write out both averaged and instantaneous output for testing
+
+ hist_tape_with_all_output = 1, 2
+
+ nhtfrq = -24,  -6
+ mfilt  =  30, 120
+ avgflag_pertape = 'A','I'
+
+ history_amwg        = .false.
+ history_aero_optics = .false.
+ history_aerosol     = .false.

--- a/components/eam/src/control/cam_comp.F90
+++ b/components/eam/src/control/cam_comp.F90
@@ -16,7 +16,8 @@ module cam_comp
    use physics_types,     only: physics_state, physics_tend
    use cam_control_mod,   only: nsrest, print_step_cost, obliqr, lambm0, mvelpp, eccen
    use dyn_comp,          only: dyn_import_t, dyn_export_t
-   use ppgrid,            only: begchunk, endchunk
+   use ppgrid,            only: begchunk, endchunk, pcols
+   use conditional_diag,  only: cnd_diag_t
    use perf_mod
    use cam_logfile,       only: iulog
    use physics_buffer,            only: physics_buffer_desc
@@ -56,6 +57,7 @@ module cam_comp
   type(physics_state), pointer :: phys_state(:) => null()
   type(physics_tend ), pointer :: phys_tend(:) => null()
   type(physics_buffer_desc), pointer :: pbuf2d(:,:) => null()
+  type(cnd_diag_t),          pointer :: phys_diag(:) => null()
 
   real(r8) :: wcstart, wcend     ! wallclock timestamp at start, end of timestep
   real(r8) :: usrstart, usrend   ! user timestamp at start, end of timestep
@@ -97,6 +99,7 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
    use scamMod,          only: single_column
    use cam_pio_utils,    only: init_pio_subsystem
    use cam_instance,     only: inst_suffix
+   use conditional_diag, only: cnd_diag_info, cnd_diag_alloc
 
 #if ( defined SPMD )   
    real(r8) :: mpi_wtime  ! External
@@ -163,10 +166,14 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
       call atm2hub_alloc(cam_out)
       call hub2atm_alloc(cam_in)
 
+      ! Allocate memory for CondiDiag
+      ! (When rest /= 0, the subroutine is called from inside cam_read_restart)
+      call cnd_diag_alloc(phys_diag, begchunk, endchunk, pcols, cnd_diag_info)
+
    else
 
       call t_startf('cam_read_restart')
-      call cam_read_restart ( cam_in, cam_out, dyn_in, dyn_out, pbuf2d, stop_ymd, stop_tod, NLFileName=filein )
+      call cam_read_restart ( cam_in, cam_out, dyn_in, dyn_out, pbuf2d, phys_diag, stop_ymd, stop_tod, NLFileName=filein )
       call t_stopf('cam_read_restart')
 
      ! Commented out the hub2atm_alloc call as it overwrite cam_in, which is undesirable. The fields in cam_in are necessary for getting BFB restarts
@@ -255,7 +262,7 @@ subroutine cam_run1(cam_in, cam_out)
    !
    call t_barrierf ('sync_phys_run1', mpicom)
    call t_startf ('phys_run1')
-   call phys_run1(phys_state, dtime, phys_tend, pbuf2d,  cam_in, cam_out)
+   call phys_run1(phys_state, dtime, phys_tend, pbuf2d,  cam_in, cam_out, phys_diag)
    call t_stopf  ('phys_run1')
 
 end subroutine cam_run1
@@ -290,7 +297,7 @@ subroutine cam_run2( cam_out, cam_in )
    !
    call t_barrierf ('sync_phys_run2', mpicom)
    call t_startf ('phys_run2')
-   call phys_run2(phys_state, dtime, phys_tend, pbuf2d,  cam_out, cam_in )
+   call phys_run2(phys_state, dtime, phys_tend, pbuf2d,  cam_out, cam_in, phys_diag )
    call t_stopf  ('phys_run2')
 
    !
@@ -399,10 +406,10 @@ subroutine cam_run4( cam_out, cam_in, rstwr, nlend, &
    if (rstwr) then
       call t_startf ('cam_write_restart')
       if (present(yr_spec).and.present(mon_spec).and.present(day_spec).and.present(sec_spec)) then
-         call cam_write_restart( cam_in, cam_out, dyn_out, pbuf2d, &
+         call cam_write_restart( cam_in, cam_out, dyn_out, pbuf2d, phys_diag, &
               yr_spec=yr_spec, mon_spec=mon_spec, day_spec=day_spec, sec_spec= sec_spec )
       else
-         call cam_write_restart( cam_in, cam_out, dyn_out, pbuf2d )
+         call cam_write_restart( cam_in, cam_out, dyn_out, pbuf2d, phys_diag )
       end if
       call t_stopf  ('cam_write_restart')
    end if
@@ -469,7 +476,7 @@ subroutine cam_final( cam_out, cam_in )
 #endif
 
    call t_startf ('phys_final')
-   call phys_final( phys_state, phys_tend , pbuf2d)
+   call phys_final( phys_state, phys_tend , pbuf2d, phys_diag )
    call t_stopf ('phys_final')
 
    call t_startf ('stepon_final')

--- a/components/eam/src/control/cam_comp.F90
+++ b/components/eam/src/control/cam_comp.F90
@@ -262,7 +262,11 @@ subroutine cam_run1(cam_in, cam_out)
    !
    call t_barrierf ('sync_phys_run1', mpicom)
    call t_startf ('phys_run1')
+#if defined(MMF_SAMXX)
+   call phys_run1(phys_state, dtime, phys_tend, pbuf2d,  cam_in, cam_out)
+#else
    call phys_run1(phys_state, dtime, phys_tend, pbuf2d,  cam_in, cam_out, phys_diag)
+#endif
    call t_stopf  ('phys_run1')
 
 end subroutine cam_run1
@@ -297,7 +301,11 @@ subroutine cam_run2( cam_out, cam_in )
    !
    call t_barrierf ('sync_phys_run2', mpicom)
    call t_startf ('phys_run2')
-   call phys_run2(phys_state, dtime, phys_tend, pbuf2d,  cam_out, cam_in, phys_diag )
+#if defined(MMF_SAMXX)
+   call phys_run2(phys_state, dtime, phys_tend, pbuf2d,  cam_out, cam_in)
+#else
+   call phys_run2(phys_state, dtime, phys_tend, pbuf2d,  cam_out, cam_in, phys_diag)
+#endif
    call t_stopf  ('phys_run2')
 
    !
@@ -476,7 +484,11 @@ subroutine cam_final( cam_out, cam_in )
 #endif
 
    call t_startf ('phys_final')
+#if defined(MMF_SAMXX)
+   call phys_final( phys_state, phys_tend , pbuf2d, )
+#else
    call phys_final( phys_state, phys_tend , pbuf2d, phys_diag )
+#endif
    call t_stopf ('phys_final')
 
    call t_startf ('stepon_final')

--- a/components/eam/src/control/cam_history_support.F90
+++ b/components/eam/src/control/cam_history_support.F90
@@ -25,7 +25,7 @@ module cam_history_support
 
   integer, parameter, public :: max_string_len = 256   ! Length of strings
   integer, parameter, public :: max_chars = shr_kind_cl         ! max chars for char variables
-  integer, parameter, public :: fieldname_len = 24   ! max chars for field name
+  integer, parameter, public :: fieldname_len = 34   ! max chars for field name
   integer, parameter, public :: fieldname_suffix_len =  3 ! length of field name suffix ("&IC")
   integer, parameter, public :: fieldname_lenp2      = fieldname_len + 2 ! allow for extra characters
   ! max_fieldname_len = max chars for field name (including suffix)

--- a/components/eam/src/control/runtime_opts.F90
+++ b/components/eam/src/control/runtime_opts.F90
@@ -270,6 +270,7 @@ contains
    use metdata,             only: metdata_readnl
 #endif
    use radiation,           only: radiation_readnl
+   use conditional_diag,    only: cnd_diag_readnl
 
 !---------------------------Arguments-----------------------------------
 
@@ -514,6 +515,7 @@ contains
 #if ( defined OFFLINE_DYN )
    call metdata_readnl(nlfilename)
 #endif
+   call cnd_diag_readnl(nlfilename)
 
    ! Read radiation namelist
    call radiation_readnl(nlfilename, dtime_in=dtime)

--- a/components/eam/src/physics/cam/clubb_intr.F90
+++ b/components/eam/src/physics/cam/clubb_intr.F90
@@ -1061,8 +1061,8 @@ end subroutine clubb_init_cnst
   ! =============================================================================== !
 
    subroutine clubb_tend_cam( &
-                              state,   ptend_all,   pbuf,     hdtime, &
-                              cmfmc,   cam_in,   sgh30, &
+                              state,   ptend_all,   pbuf,  diag,   hdtime, &
+                              cmfmc,   cam_in,   cam_out,  sgh30,          &
                               macmic_it, cld_macmic_num_steps,dlf, det_s, det_ice, alst_o)
 
 !-------------------------------------------------------------------------------
@@ -1088,12 +1088,15 @@ end subroutine clubb_init_cnst
    use ppgrid,         only: pver, pverp, pcols
    use constituents,   only: cnst_get_ind, cnst_type
    use co2_cycle,      only: co2_cycle_set_cnst_type
-   use camsrfexch,     only: cam_in_t
+   use camsrfexch,     only: cam_in_t, cam_out_t
    use ref_pres,       only: top_lev => trop_cloud_top_lev
    use time_manager,   only: is_first_step, is_first_restart_step, get_nstep
    use cam_abortutils, only: endrun
    use wv_saturation,  only: qsat
    use micro_mg_cam,   only: micro_mg_version
+
+   use conditional_diag,      only: cnd_diag_t
+   use conditional_diag_main, only: cnd_diag_checkpoint
 
 #ifdef CLUBB_SGS
    use hb_diff,                   only: pblintd
@@ -1147,12 +1150,14 @@ end subroutine clubb_init_cnst
    real(r8),            intent(in)    :: sgh30(pcols)             ! std deviation of orography              [m]
    integer,             intent(in)    :: cld_macmic_num_steps     ! number of mac-mic iterations
    integer,             intent(in)    :: macmic_it                ! number of mac-mic iterations
+   type(cam_out_t),     intent(in)    :: cam_out
 
    ! ---------------------- !
    ! Input-Output Auguments !
    ! ---------------------- !
 
    type(physics_buffer_desc), pointer :: pbuf(:)
+   type(cnd_diag_t),    intent(inout) :: diag                     !  conditionally sampled fields
 
    ! ---------------------- !
    ! Output Auguments !
@@ -1459,6 +1464,8 @@ end subroutine clubb_init_cnst
 
    integer :: ixorg
 
+   character(len=2) :: char_macmic_it
+
    intrinsic :: selected_real_kind, max
 
 !PMA adds gustiness and tpert
@@ -1492,6 +1499,12 @@ end subroutine clubb_init_cnst
 #endif
    det_s(:)   = 0.0_r8
    det_ice(:) = 0.0_r8
+
+   if (macmic_it > 99) then
+      call endrun('clubb_tend_cam: macmic_it > 99. Revise checkpoint name for cnd_diag_checkpoint.')
+   end if
+   write(char_macmic_it,'(i2.2)') macmic_it
+
 #ifdef CLUBB_SGS
 
    !-----------------------------------------------------------------------------------------------!
@@ -1725,6 +1738,8 @@ end subroutine clubb_init_cnst
      call outfld( 'NITENDICE', initend, pcols, lchnk )
 
    endif
+
+   call cnd_diag_checkpoint(diag, 'ICEMAC'//char_macmic_it, state1, pbuf, cam_in, cam_out)
 
    !  Determine CLUBB time step and make it sub-step friendly
    !  For now we want CLUBB time step to be 5 min since that is
@@ -2584,6 +2599,8 @@ end subroutine clubb_init_cnst
    call physics_ptend_sum(ptend_loc,ptend_all,ncol)
    call physics_update(state1,ptend_loc,hdtime)
 
+   call cnd_diag_checkpoint(diag, 'CLUBB'//char_macmic_it, state1, pbuf, cam_in, cam_out)
+
    ! ------------------------------------------------------------ !
    ! ------------------------------------------------------------ !
    ! ------------------------------------------------------------ !
@@ -2653,6 +2670,7 @@ end subroutine clubb_init_cnst
 
    call physics_ptend_sum(ptend_loc,ptend_all,ncol)
    call physics_update(state1,ptend_loc,hdtime)
+   call cnd_diag_checkpoint(diag, 'CUDET'//char_macmic_it, state1, pbuf, cam_in, cam_out)
 
    ! ptend_all now has all accumulated tendencies.  Convert the tendencies for the
    ! dry constituents to dry air basis.
@@ -3046,6 +3064,8 @@ end subroutine clubb_init_cnst
       enddo
 
    endif
+
+   call cnd_diag_checkpoint(diag, 'MACDIAG'//char_macmic_it, state1, pbuf, cam_in, cam_out)
 
    return
 #endif

--- a/components/eam/src/physics/cam/clubb_intr.F90
+++ b/components/eam/src/physics/cam/clubb_intr.F90
@@ -1503,7 +1503,6 @@ end subroutine clubb_init_cnst
    if (macmic_it > 99) then
       call endrun('clubb_tend_cam: macmic_it > 99. Revise checkpoint name for cnd_diag_checkpoint.')
    end if
-   write(char_macmic_it,'(i2.2)') macmic_it
 
 #ifdef CLUBB_SGS
 
@@ -1514,6 +1513,8 @@ end subroutine clubb_init_cnst
    !-----------------------------------------------------------------------------------------------!
    !-----------------------------------------------------------------------------------------------!
    !-----------------------------------------------------------------------------------------------!
+
+   write(char_macmic_it,'(i2.2)') macmic_it
 
    call t_startf('clubb_tend_cam_init')
    invrs_hdtime = 1._r8 / hdtime

--- a/components/eam/src/physics/cam/conditional_diag.F90
+++ b/components/eam/src/physics/cam/conditional_diag.F90
@@ -1,0 +1,813 @@
+module conditional_diag
+!--------------------------------------------------------
+! This is one of the modules that support conditional
+! sampling and budget analysis in EAM.
+!
+! This module contains 
+!  - derived types definitions
+!  - subroutine for namelist handling
+!  - subroutine for memory allocation
+!
+! History:
+!  First version by Hui Wan, PNNL, March - May 2021
+!--------------------------------------------------------
+  use shr_kind_mod,   only: r8 => shr_kind_r8
+  use spmd_utils,     only: masterproc
+  use cam_logfile,    only: iulog
+  use cam_abortutils, only: endrun
+
+  implicit none
+
+  private
+
+  ! Derived types
+
+  public cnd_diag_info_t   ! for metadata
+  public cnd_diag_t        ! for physical quantities
+
+  ! Variable(s) of derived type
+
+  public cnd_diag_info  ! metadata
+
+  ! Subroutines
+
+  public cnd_diag_readnl
+  public cnd_diag_alloc
+
+  ! module parameters
+
+  integer, parameter :: ncnd_max         = 10 ! max # of conditions allowed in a single simulation
+  integer, parameter :: mname_maxlen     = 8  ! string length for metric name
+
+  integer, parameter :: nqoi_max         = 20 ! max # of conditionally sampled QoIs in a single simulation
+  integer, parameter :: qoiname_maxlen   = 8  ! string length for QoI name
+
+  integer, parameter :: nchkpt_max       = 250 ! max # of active checkpoints in a single simulation
+  integer, parameter :: chkptname_maxlen = 10  ! string length for checkpoint name
+
+  ! what kind of dp (pressure layer thickness) to multiply QoI by
+
+  integer, parameter         :: UNSET   = -1
+  integer, parameter, public :: NODP    = 0
+  integer, parameter, public :: PDEL    = 1
+  integer, parameter, public :: PDELDRY = 2
+
+  ! fillvalue for cells that are masked out 
+
+  real(r8),parameter, public :: FILLVALUE = 0._r8
+
+  !-------------------------------------------------------------------------------
+  ! Derived type for metadata
+  !-------------------------------------------------------------------------------
+  type cnd_diag_info_t
+
+    ! Do we want to write out the QoIs to history tapes?
+    logical :: l_output_state = .false.
+
+    ! Do we want to write out increments of the QoIs to history tapes? 
+    logical :: l_output_incrm = .false.
+
+    ! Which history tapes should contain a complete set of the conditionally sampled diagnostics?
+    ! Note: we allow the user to specify multiple history tapes that will contain all output variables 
+    ! associated with the conditional diagnostics. It is envisioned that these multiple history 
+    ! tapes might have different output frequencies and/or averaging flags. Apart from that,
+    ! like with all other output variables on the master list, the user can manually add or 
+    ! remove individual variables using fincl or fexcl. 
+
+    integer             :: ntape                         ! number of tapes
+    integer,allocatable :: hist_tape_with_all_output(:)  ! tape indices
+
+    ! Sampling conditions. 
+    ! The current implementation allows the user to define multiple conditions,
+    ! each of which will have its own metric, QoIs, and output.
+    ! But to keep it simple (at least as a start), we assume that
+    ! the QoIs and checkpoints to monitor are the same for different sampling conditions
+
+    integer                      :: ncnd = 0             ! total # of sampling conditions used in this simulation
+    character(len=mname_maxlen),&
+                     allocatable :: metric_name(:)       ! shape = (ncnd); metric names
+    integer,allocatable          :: metric_nver(:)       ! shape = (ncnd); # of vertical levels of the metrics
+    integer,allocatable          :: metric_cmpr_type(:)  ! shape = (ncnd); see module parameters in conditional_diag_main.F90
+    real(r8),allocatable         :: metric_threshold(:)  ! shape = (ncnd); threshold values for conditional sampling 
+    real(r8),allocatable         :: metric_tolerance(:)  ! shape = (ncnd); tolerance for the "equal to" comparison type
+    character(len=chkptname_maxlen),&
+                     allocatable :: cnd_eval_chkpt(:)    ! shape = (ncnd); checkpoints at which the evaluation of 
+                                                         ! the corresponding sampling condition will happen
+    character(len=chkptname_maxlen),&
+                     allocatable :: cnd_end_chkpt(:)     ! shape = (ncnd); checkpoints marking end-of-time-step
+                                                         ! of the corresponding sampling conditions. 
+                                                         ! At this checkpoint, the masking of QoIs will be done
+                                                         ! and the masked values will be send to history buffer.
+
+    ! QoIs to be monitored. Each QoI can have 1, pver, or pver+1 vertical levels
+    integer                                   :: nqoi = 0
+    character(len=qoiname_maxlen),allocatable :: qoi_name(:)       ! shape = (nqoi)
+    integer,allocatable                       :: qoi_nver(:)       ! shape = (nqoi); # of vertical levels of the QoI
+    integer,allocatable                       :: qoi_nver_save(:)  ! shape = (nqoi); # of vertical levels of the QoI
+                                                                   ! if no vertical integral is requested; 1 otherwise.
+
+    ! Active checkpoints at which the QoI will be monitored 
+    integer                                      :: nchkpt = 0     ! total # of active checkpoints
+    character(len=chkptname_maxlen), allocatable :: qoi_chkpt(:)   ! checkpoints at which QoIs will be monitored
+
+    ! "Multiply by dp" options
+    integer,allocatable :: x_dp(:,:)  ! shape = (nqoi,nchkpt); whether QoIs at each checkpoint and checkpoint 
+                                      ! should be multiplied by dp, and if so, wet or dry.
+
+
+  end type cnd_diag_info_t
+
+  !-------------------------------------------------------------------------------
+  ! Derived types for the sampling conditions and monitored QoIs
+  !-------------------------------------------------------------------------------
+  ! Values of a single QoI at different checkpoints and the 
+  ! inrements relative to the previous active checkpoint
+
+  type snapshots_and_increments_t
+
+    real(r8), allocatable :: val(:,:,:) ! shape = (pcols,info%qoi_nver_save(iqoi),info%nchkpt) QoI (or vert. integral) values at active checkpoints
+    real(r8), allocatable :: inc(:,:,:) ! shape = (pcols,info%qoi_nver_save(iqoi),info%nchkpt) QoI (or vert. integral) increments between adjacent active checkpoints
+    real(r8), allocatable :: old(:,:)   ! shape = (pcols,info%qoi_nver_save(iqoi)) QoI (or vert. integral) values at the previous active checkpoint
+
+  end type snapshots_and_increments_t
+
+  !----------------------------------------------------------------------
+  ! The collection of all QoIs monitored under the same condition, and
+  ! the values of the metric and flag used for sampling
+
+  type metric_and_qois_t
+
+    real(r8),                        allocatable :: metric (:,:)     ! shape = (pcols, info%metric_nver(icnd))
+    real(r8),                        allocatable :: flag   (:,:)     ! shape = (pcols, info%metric_nver(icnd))
+    type(snapshots_and_increments_t),allocatable :: qoi    (:)       ! shape = (info%nqoi)
+
+  end type metric_and_qois_t
+
+  !----------------------------------------------------------------------
+  ! A collection of multiple conditions (including the corresponding
+  ! metrics and monitored QoIs)
+
+  type cnd_diag_t
+
+    type(metric_and_qois_t), allocatable :: cnd(:) ! shape = (info%ncnd)
+
+  end type cnd_diag_t
+
+!===============================================================================
+! Module variables
+!===============================================================================
+  type(cnd_diag_info_t) :: cnd_diag_info
+
+contains
+!===============================================================================
+! Procedures
+!===============================================================================
+subroutine cnd_diag_readnl(nlfile)
+
+   use cam_history_support,only: ptapes
+   use ppgrid,             only: pver
+   use infnan,             only: nan, assignment(=), isnan
+   use namelist_utils,     only: find_group_name
+   use units,              only: getunit, freeunit
+   use mpishorthand
+
+   character(len=*), intent(in) :: nlfile  ! filepath for file containing namelist input
+
+   ! Local variables
+   character(len=*), parameter :: subname = 'cnd_diag_readnl'
+
+   integer :: ncnd, nchkpt, nqoi, ntape, ii, icnd, ichkpt
+
+   ! Local variables for reading namelist
+
+   integer :: unitn, ierr
+
+   character(len=mname_maxlen)     :: metric_name     (ncnd_max)
+   integer                         :: metric_nver     (ncnd_max)
+   integer                         :: metric_cmpr_type(ncnd_max)
+   real(r8)                        :: metric_threshold(ncnd_max)
+   real(r8)                        :: metric_tolerance(ncnd_max)
+
+   character(len=chkptname_maxlen) :: cnd_eval_chkpt  (ncnd_max)
+   character(len=chkptname_maxlen) :: cnd_end_chkpt   (ncnd_max)
+
+   character(len=chkptname_maxlen) :: qoi_chkpt(nchkpt_max)
+
+   character(len=qoiname_maxlen)   :: qoi_name (nqoi_max)
+   integer                         :: qoi_nver (nqoi_max)
+
+   integer ::   qoi_x_dp(nqoi_max)
+   integer :: chkpt_x_dp(nchkpt_max)
+
+   logical :: l_output_state, l_output_incrm
+   integer :: hist_tape_with_all_output(ptapes)  ! tape indices
+
+   !-------
+   namelist /conditional_diag_nl/     &
+            metric_name, metric_nver, &
+            metric_cmpr_type, metric_threshold, metric_tolerance, &
+            cnd_eval_chkpt, cnd_end_chkpt,  & 
+            qoi_chkpt, qoi_name, qoi_nver,  &
+            qoi_x_dp, chkpt_x_dp, &
+            l_output_state, l_output_incrm, &
+            hist_tape_with_all_output
+
+   !----------------------------------------
+   !  Default values
+   !----------------------------------------
+   metric_name(:)      = ' '
+   metric_nver(:)      = 0
+   metric_cmpr_type(:) = -99
+   metric_threshold(:) = nan
+   metric_tolerance(:) = 0._r8
+
+   cnd_eval_chkpt(:) = ' '
+    cnd_end_chkpt(:) = ' '
+
+   qoi_name (:) = ' '
+   qoi_nver (:) = 0 
+   qoi_chkpt(:) = ' '
+
+     qoi_x_dp(:) = NODP
+   chkpt_x_dp(:) = UNSET
+
+   l_output_state = .false.
+   l_output_incrm = .false.
+
+   hist_tape_with_all_output(:) = -1
+
+   !----------------------------------------
+   ! Read namelist and check validity
+   !----------------------------------------
+   if (masterproc) then
+
+      ! Read namelist
+
+      unitn = getunit()
+      open( unitn, file=trim(nlfile), status='old' )
+      call find_group_name(unitn, 'conditional_diag_nl', status=ierr)
+      if (ierr == 0) then
+         read(unitn, conditional_diag_nl, iostat=ierr)
+         if (ierr /= 0) then
+            write(iulog,*) 'read error ',ierr
+            call endrun(subname // ':: ERROR reading namelist')
+         end if
+      end if
+      close(unitn)
+
+      ! Count user-specified sampling conditions
+
+      ii = 0
+      do while ( (ii+1) <= ncnd_max .and. metric_name(ii+1) /= ' ')
+         ii = ii + 1
+      end do
+      ncnd = ii
+
+      !----------------------------------------------------------------------
+      ! If no condition has been specified, set the other counts to zero, too
+      !----------------------------------------------------------------------
+      if (ncnd==0) then
+
+         nqoi   = 0
+         nchkpt = 0
+         ntape  = 0
+
+      !----------------------------------------------------------------------
+      ! If at least one condition has been sepecified, do some sanity check, 
+      ! then parse additional namelist settings
+      !----------------------------------------------------------------------
+      else
+
+         do ii = 1,ncnd
+            if (trim(adjustl(metric_name(ii)))=='ALL') then
+
+            ! Metric name 'ALL' is interpreted as selecting all grid cells.
+            ! In this case, the metric will be set to a constant field of 1 and
+            ! the flags will be set to ON.
+
+            ! - set metric_nver(ii) to 1 to save memory
+
+                metric_nver(ii) = 1
+
+            ! - metric_cmpr_type and metric_threshold will no longer
+            !   be needed; set them to some values to avoid program abort.
+
+                metric_cmpr_type(ii) = 0
+                metric_threshold(ii) = 1._r8
+                metric_tolerance(ii) = 1._r8
+
+            ! - if user did not specify cnd_end_chkpt(ii), set it to the non-empty cnd_eval_chkpt(ii).
+            ! - if neither cnd_end_chkpt(ii) or cnd_eval_chkpt(ii) is specified, set 
+            !   cnd_end_chkpt(ii) to 'PBCDIAG' as this is the checkpoint at which 
+            !   where most of the standard model output variables are sent to history buffer.
+
+                if ( cnd_end_chkpt(ii) == ' ' ) then 
+                   if ( cnd_eval_chkpt(ii) /= ' ' ) then 
+                      cnd_end_chkpt(ii) = cnd_eval_chkpt(ii) 
+                   else
+                      cnd_end_chkpt(ii) = 'PBCDIAG'
+                   end if
+                end if
+
+            ! - cnd_eval_chkpt is not needed as we will sample all time steps; 
+            !   set to cnd_end_chkpt so that it has a value, but the value really doesn't matter.
+
+                cnd_eval_chkpt(ii) = cnd_end_chkpt(ii)
+
+            end if
+         end do
+
+         if (any( metric_nver     (1:ncnd) <= 0   )) call endrun(subname//' error: need positive metric_nver for each metric_name')
+         if (any( metric_cmpr_type(1:ncnd) == -99 )) call endrun(subname//' error: need valid metric_cmpr_type for each metric_name')
+         if (any( isnan(metric_threshold(1:ncnd)) )) call endrun(subname//' error: need valid metric_threshold for each metric_name')
+         if (any( cnd_eval_chkpt  (1:ncnd) == ' ' )) call endrun(subname//' error: be sure to specify cnd_eval_chkpt for each metric_name')
+         
+         do ii = 1,ncnd
+            if (cnd_end_chkpt(ii)==' ')  cnd_end_chkpt(ii) = cnd_eval_chkpt(ii)
+         end do
+
+         !-------------------------------------------------------
+         ! Count QoIs to be monitored, then do some sanity check
+
+         ii = 0
+         do while ( (ii+1) <= nqoi_max .and. qoi_name(ii+1) /= ' ')
+            ii = ii + 1
+         end do
+         nqoi = ii
+
+         if (any(qoi_nver(1:nqoi)<=0)) call endrun(subname//'error: need positive qoi_nver for each qoi_name')
+
+         !---------------------------------------------
+         ! Count active checkpoints for QoI monitoring
+
+         ii = 0
+         do while ( (ii+1) <= nchkpt_max .and. qoi_chkpt(ii+1) /= ' ')
+            ii = ii + 1
+         end do
+         nchkpt = ii
+
+         !---------------------
+         ! Enforce consistency
+
+         if (nqoi==0) nchkpt = 0 ! If user did not specify any QoI, set nchkpt to 0 for consistency
+         if (nchkpt==0) nqoi = 0 ! If user did not specify any checkpoint for QoI monitoring, set nqoi to 0 for consistency
+
+         !--------------------------
+         ! "multiply by dp" options
+
+         ! ... for QoIs
+
+         do ii = 1,nqoi
+
+            ! Set user-provided unexpected values to NODP
+
+            if ( qoi_x_dp(ii)/=PDEL     .and. &
+                 qoi_x_dp(ii)/=PDEL+100 .and. &
+                 qoi_x_dp(ii)/=PDELDRY  .and. &
+                 qoi_x_dp(ii)/=PDELDRY+100    ) then
+
+               qoi_x_dp(ii) = NODP
+            end if
+
+            ! Multiplication by dp can only be applied to QoIs defined at layer midpoints
+            ! or as layer averages. Force selection to be NODP for other types of QoIs.
+
+            if (qoi_nver(ii)/=pver) qoi_x_dp(ii) = NODP
+
+         end do
+
+         ! ... for checkpoints
+
+         do ii = 1,nchkpt
+            if (chkpt_x_dp(ii)/=PDEL .and. chkpt_x_dp(ii)/=PDELDRY) chkpt_x_dp(ii) = UNSET
+         end do
+
+         !---------------------------------------------------------------------------------
+         ! Count history tapes that will each contain a full suite of the output variables
+
+         ii = 0
+         do while ( (ii+1) <= ptapes .and. hist_tape_with_all_output(ii+1) >= 0)
+            ii = ii + 1
+         end do
+         ntape = ii
+
+         ! If the user did not specify any tape, then at least add the output variables to h0
+
+         if (ntape==0) then
+            ntape = 1
+            hist_tape_with_all_output(ntape) = 1
+         end if
+
+      end if ! ncnd = 0 or > 0
+
+   end if ! masterproc
+   !--------------------------------------
+
+#ifdef SPMD
+   call mpibcast(ncnd,   1, mpiint, 0, mpicom)
+   call mpibcast(nqoi,   1, mpiint, 0, mpicom)
+   call mpibcast(nchkpt, 1, mpiint, 0, mpicom)
+   call mpibcast(ntape,  1, mpiint, 0, mpicom)
+#endif
+
+   cnd_diag_info% ncnd   = ncnd
+   cnd_diag_info% nqoi   = nqoi
+   cnd_diag_info% nchkpt = nchkpt
+   cnd_diag_info% ntape  = ntape
+
+   if (ncnd==0) then
+
+      if (masterproc) then
+         write(iulog,*)'==========================================================='
+         write(iulog,*)'       *** Conditional diagnostics NOT requested ***'
+         write(iulog,*)'==========================================================='
+      end if
+
+      return
+   end if
+
+#ifdef SPMD
+   !--------------------------------------
+   ! Broadcast namelist variables
+   !--------------------------------------
+   call mpibcast(metric_name,      ncnd_max*len(metric_name(1)), mpichar, 0, mpicom)
+   call mpibcast(metric_nver,      ncnd_max,                     mpiint,  0, mpicom)
+   call mpibcast(metric_cmpr_type, ncnd_max,                     mpiint,  0, mpicom)
+   call mpibcast(metric_threshold, ncnd_max,                     mpir8,   0, mpicom)
+   call mpibcast(metric_tolerance, ncnd_max,                     mpir8,   0, mpicom)
+
+   call mpibcast(cnd_eval_chkpt,   ncnd_max*len(cnd_eval_chkpt(1)), mpichar, 0, mpicom)
+   call mpibcast(cnd_end_chkpt,    ncnd_max*len(cnd_end_chkpt(1)),  mpichar, 0, mpicom)
+   call mpibcast(qoi_chkpt,      nchkpt_max*len(qoi_chkpt(1)),      mpichar, 0, mpicom)
+
+   call mpibcast(qoi_name,  nqoi_max*len(qoi_name(1)),  mpichar, 0, mpicom)
+   call mpibcast(qoi_nver,  nqoi_max,                   mpiint,  0, mpicom)
+
+   call mpibcast(  qoi_x_dp,   nqoi_max, mpiint,  0, mpicom)
+   call mpibcast(chkpt_x_dp, nchkpt_max, mpiint,  0, mpicom)
+
+   call mpibcast(l_output_state, 1, mpilog, 0, mpicom)
+   call mpibcast(l_output_incrm, 1, mpilog, 0, mpicom)
+
+   call mpibcast(hist_tape_with_all_output, ptapes, mpiint, 0, mpicom)
+#endif
+
+   !-------------------------------------------
+   ! Pack information into to cnd_diag_info
+   !-------------------------------------------
+   ! Conditions for conditional sampling
+
+   allocate( cnd_diag_info% metric_name(ncnd), stat=ierr)
+   if ( ierr /= 0 ) call endrun(subname//': allocation of cnd_diag_info% metric_name')
+   do ii = 1,ncnd
+      cnd_diag_info% metric_name(ii) = trim(adjustl(metric_name(ii)))
+   end do
+
+   allocate( cnd_diag_info% metric_nver(ncnd), stat=ierr)
+   if ( ierr /= 0 ) call endrun(subname//': allocation of cnd_diag_info% metric_nver')
+   cnd_diag_info% metric_nver(1:ncnd) = metric_nver(1:ncnd)
+
+   allocate( cnd_diag_info% metric_cmpr_type(ncnd), stat=ierr)
+   if ( ierr /= 0 ) call endrun(subname//': allocation of cnd_diag_info% metric_cmpr_type')
+   cnd_diag_info% metric_cmpr_type(1:ncnd) = metric_cmpr_type(1:ncnd)
+
+   allocate( cnd_diag_info% metric_threshold(ncnd), stat=ierr)
+   if ( ierr /= 0 ) call endrun(subname//': allocation of cnd_diag_info% metric_threshold')
+   cnd_diag_info% metric_threshold(1:ncnd) = metric_threshold(1:ncnd)
+
+   allocate( cnd_diag_info% metric_tolerance(ncnd), stat=ierr)
+   if ( ierr /= 0 ) call endrun(subname//': allocation of cnd_diag_info% metric_tolerance')
+   cnd_diag_info% metric_tolerance(1:ncnd) = metric_tolerance(1:ncnd)
+
+   allocate( cnd_diag_info% cnd_eval_chkpt(ncnd), stat=ierr)
+   if ( ierr /= 0 ) call endrun(subname//': allocation of cnd_diag_info% cnd_eval_chkpt')
+   cnd_diag_info% cnd_eval_chkpt(1:ncnd) = cnd_eval_chkpt(1:ncnd)
+
+   allocate( cnd_diag_info% cnd_end_chkpt(ncnd), stat=ierr)
+   if ( ierr /= 0 ) call endrun(subname//': allocation of cnd_diag_info% cnd_end_chkpt')
+   cnd_diag_info% cnd_end_chkpt(1:ncnd) = cnd_end_chkpt(1:ncnd)
+
+   ! QoIs 
+
+   allocate( cnd_diag_info% qoi_name(nqoi), stat=ierr)
+   if ( ierr /= 0 ) call endrun(subname//': allocation of cnd_diag_info% qoi_name')
+   do ii = 1,nqoi
+      cnd_diag_info% qoi_name(ii) = trim(adjustl(qoi_name(ii)))
+   end do
+
+   allocate( cnd_diag_info% qoi_nver(nqoi), stat=ierr)
+   if ( ierr /= 0 ) call endrun(subname//': allocation of cnd_diag_info% qoi_nver')
+   cnd_diag_info% qoi_nver(1:nqoi) = qoi_nver(1:nqoi)
+
+   ! Active checkpoints at which the QoIs will be monitored
+
+   allocate( cnd_diag_info% qoi_chkpt(nchkpt), stat=ierr)
+   if ( ierr /= 0 ) call endrun(subname//': allocation of cnd_diag_info% qoi_chkpt')
+   do ii = 1,nchkpt
+      cnd_diag_info% qoi_chkpt(ii) = trim(adjustl(qoi_chkpt(ii)))
+   end do
+
+   ! "multiply by dp" selections
+   
+   allocate( cnd_diag_info% x_dp(nqoi,nchkpt), stat=ierr)
+   if ( ierr /= 0 ) call endrun(subname//': allocation of cnd_diag_info% x_dp')
+
+   call set_x_dp( nqoi, qoi_x_dp, nchkpt, chkpt_x_dp, cnd_diag_info%x_dp )! in, ..., in, out
+
+   ! qoi_nver_save(ii) is the # of vertical levels on which the ii-th QoI and/or its increment
+   ! will be saved in the data structure for output. qoi_nver_save(ii) will be 1 if 
+   ! vertical integral is requested by the user by choosing an appropriate value for qoi_x_dp(ii).
+   ! Otherwise  qoi_nver_save(ii) ==  qoi_nver(ii).
+
+   allocate( cnd_diag_info% qoi_nver_save(nqoi), stat=ierr)
+   if ( ierr /= 0 ) call endrun(subname//': allocation of cnd_diag_info% qoi_nver_save')
+
+   where (qoi_x_dp(1:nqoi)==NODP)
+      cnd_diag_info%qoi_nver_save = cnd_diag_info%qoi_nver
+   elsewhere
+      cnd_diag_info%qoi_nver_save = 1
+   end where
+
+   ! output to history tape(s)
+
+   cnd_diag_info%l_output_state = l_output_state
+   cnd_diag_info%l_output_incrm = l_output_incrm
+
+   allocate( cnd_diag_info% hist_tape_with_all_output(ntape), stat=ierr)
+   if ( ierr /= 0 ) call endrun(subname//': allocation of cnd_diag_info% hist_tape_with_all_output')
+   cnd_diag_info% hist_tape_with_all_output(1:ntape) = hist_tape_with_all_output(1:ntape)
+
+   !-----------------------------------------------
+   ! Send information to log file
+   !-----------------------------------------------
+   if (masterproc) then
+
+      write(iulog,*)
+      write(iulog,*)'==============================================================================='
+      write(iulog,*)'               *** Conditional diagnostics requested ***'
+      write(iulog,*)'==============================================================================='
+
+      write(iulog,*)
+      write(iulog,'(4x,a12,a6,a12,2a12,2a17)') 'metric','nlev','cmpr_type','threshold','tolerance', &
+                                               'cnd_eval_chkpt','cnd_end_chkpt' 
+      do ii = 1,cnd_diag_info%ncnd
+       if (trim(cnd_diag_info% metric_name(ii))=='ALL') then
+
+         write(iulog,'(i4.3,a12,a6,a12,2a12,  2a17)') ii,                                 &
+                                             adjustr(cnd_diag_info% metric_name(ii)),     &
+                                                     '-','-','-','-','-',                 &
+                                             adjustr(cnd_diag_info% cnd_end_chkpt(ii))
+       else
+         write(iulog,'(i4.3,a12,i6,i12,2e12.2,2a17)') ii,                                 &
+                                             adjustr(cnd_diag_info% metric_name(ii)),     &
+                                                     cnd_diag_info% metric_nver(ii),      &
+                                                     cnd_diag_info% metric_cmpr_type(ii), &
+                                                     cnd_diag_info% metric_threshold(ii), &
+                                                     cnd_diag_info% metric_tolerance(ii), &
+                                             adjustr(cnd_diag_info% cnd_eval_chkpt(ii)),  &
+                                             adjustr(cnd_diag_info% cnd_end_chkpt(ii))
+       end if
+      end do
+
+      write(iulog,*)
+      write(iulog,*)'--------------------------------------------------'
+      write(iulog,'(4x,a12,a15)') 'qoi_chkpt','mult_by_dp'
+      do ii = 1,cnd_diag_info%nchkpt
+         write(iulog,'(i4.3,a12,i15)') ii, adjustr(cnd_diag_info%qoi_chkpt(ii)), chkpt_x_dp(ii)
+      end do
+
+      write(iulog,*)
+      write(iulog,*)'--------------------------------------------------'
+      write(iulog,'(4x,a12,a8,a15,a12)')'QoI_name','nlev', 'mult_by_dp', 'nlev_save'
+      do ii = 1,cnd_diag_info%nqoi
+         write(iulog,'(i4.3,a12,i8,i15,i12)') ii, adjustr(cnd_diag_info%qoi_name(ii)),  &
+                                              cnd_diag_info%qoi_nver(ii), qoi_x_dp(ii), &
+                                              cnd_diag_info%qoi_nver_save(ii)
+      end do
+      write(iulog,*)
+
+      write(iulog,*)'--------------------------------------------------'
+      write(iulog,*)' l_output_state = ',l_output_state
+      write(iulog,*)' l_output_incrm = ',l_output_incrm
+      write(iulog,*)
+      write(iulog,'(a,12i5)')' hist_tape_with_all_output = ',hist_tape_with_all_output(1:ntape)
+      write(iulog,*)'--------------------------------------------------'
+      write(iulog,*)
+      write(iulog,*)'      "multiply by dp" selections, final'
+      write(iulog,*)
+      write(iulog,'(10x,20a10)') ( adjustr(cnd_diag_info%qoi_name(ii)), ii=1,nqoi )
+      do ichkpt = 1,nchkpt
+         write(iulog,'(a10,20i10)') adjustr(cnd_diag_info%qoi_chkpt(ichkpt)), ( cnd_diag_info%x_dp(ii,ichkpt), ii=1,nqoi )
+      end do
+      write(iulog,*)'==============================================================================='
+      write(iulog,*)
+
+  end if  ! masterproc
+
+end subroutine cnd_diag_readnl
+
+!===============================================================
+subroutine set_x_dp( nqoi, qoi_x_dp, nchkpt, chkpt_x_dp, x_dp_out )
+
+   integer,intent(in) :: nqoi, nchkpt
+   integer,intent(in) ::   qoi_x_dp(:)
+   integer,intent(in) :: chkpt_x_dp(:)
+   integer,intent(out) ::  x_dp_out(:,:)
+
+   integer :: icnd, iqoi, ichkpt
+
+   character(len=256) :: msg
+
+        do iqoi = 1,nqoi
+
+           !---------------------------------------------------------------------------
+           ! If user chose NODP, PDEL, or PDELDRY for this QoI, then take that value
+           !---------------------------------------------------------------------------
+           select case ( qoi_x_dp(iqoi) )
+           case (NODP,PDEL,PDELDRY)
+
+              x_dp_out(iqoi,:) = qoi_x_dp(iqoi) 
+
+           !---------------------------------------------------------------------------------
+           ! If user set qoi_x_dp(iqoi) to PDEL+100 or PDELDRY+100, then use PDEL or PDELDRY
+           ! but give precedence to chkpt_x_dp.
+           !---------------------------------------------------------------------------------
+           case ( PDEL+100, PDELDRY+100 )
+
+              !--------------------------------------------------------------
+              ! Loop through all checkpoints. If chkpt_x_dp(ichkpt) has been 
+              ! set, then take that value; otherwise, use qoi_x_dp(iqoi)
+              !--------------------------------------------------------------
+              do ichkpt = 1,nchkpt
+                 if (chkpt_x_dp(ichkpt)/=(-1)) then
+                    x_dp_out(iqoi,ichkpt) = chkpt_x_dp(ichkpt)
+                 else
+                    x_dp_out(iqoi,ichkpt) = qoi_x_dp(iqoi) - 100
+                 end if
+              end do ! ichkpt
+
+           case default 
+           !-----------------------------------------------------------------------
+           ! Subroutine cnd_diag_readnl is supposed to have set the default value
+           ! of qoi_x_dp to NODP, so we do not expect values other than
+           ! NODP, PDEL(+100), or PDELDRY(+100).
+           !-----------------------------------------------------------------------
+              write(msg,'(a,i2,a,i2,a)') "qoi_x_dp(",iqoi,") =",qoi_x_dp(iqoi),' is unexpected'
+              call endrun(trim(msg))
+
+           end select ! qoi_x_dp(iqoi)
+        end do    ! iqoi
+
+end subroutine set_x_dp
+
+!===============================================================================
+subroutine cnd_diag_alloc( phys_diag, begchunk, endchunk, pcols, cnd_diag_info )
+
+  type(cnd_diag_t), pointer :: phys_diag(:)
+
+  integer, intent(in) :: begchunk, endchunk
+  integer, intent(in) :: pcols
+  type(cnd_diag_info_t),intent(in) :: cnd_diag_info
+
+  integer :: ierr, lchnk
+
+  character(len=*), parameter :: subname = 'cnd_diag_alloc'
+  !-----------------------------------------------------------------
+
+  allocate(phys_diag(begchunk:endchunk), stat=ierr)
+  if( ierr /= 0 ) then
+     write(iulog,*) subname//': phys_diag allocation error = ',ierr
+     call endrun(subname//': failed to allocate phys_diag array')
+  end if
+
+  if (cnd_diag_info%ncnd <= 0) return
+
+  do lchnk=begchunk,endchunk
+     call single_chunk_cnd_diag_alloc( phys_diag(lchnk), lchnk, pcols, cnd_diag_info )
+  end do
+
+  if (masterproc) then
+     write(iulog,*)
+     write(iulog,*) "====================================================================="
+     write(iulog,*) " Finished memory allocation for conditional diagnostics including:"
+     write(iulog,*) cnd_diag_info%ncnd,   " conditions"
+     write(iulog,*) cnd_diag_info%nqoi,   " quantities of interest (QoIs)"
+     write(iulog,*) cnd_diag_info%nchkpt, " active checkpoints to monitor QoIs"
+     write(iulog,*) "====================================================================="
+     write(iulog,*)
+  end if
+
+end subroutine cnd_diag_alloc
+
+
+!-----------------------------------------------------------------------------
+! Allocate memory for conditional diagnostics in a single grid chunk
+!-----------------------------------------------------------------------------
+subroutine single_chunk_cnd_diag_alloc( diag, lchnk, psetcols, cnd_diag_info )
+
+  type(cnd_diag_t), intent(inout)   :: diag
+  integer,intent(in)                :: lchnk
+
+  integer, intent(in)               :: psetcols
+  type(cnd_diag_info_t), intent(in) :: cnd_diag_info
+
+  integer :: ierr = 0
+  integer :: ncnd, icnd
+
+  character(len=*), parameter :: subname = 'single_chunk_cnd_diag_alloc'
+
+  !----------------------------------------------
+  ! Allocate an array for all sampling conditions
+  !----------------------------------------------
+  ncnd = cnd_diag_info%ncnd
+
+  allocate( diag%cnd(ncnd), stat=ierr)
+  if ( ierr /= 0 ) call endrun(subname//': allocation of diag%cnd')
+
+  !----------------------------------------------------------------
+  ! Allocate memory for metrics and QoIs of each condition
+  !----------------------------------------------------------------
+  do icnd = 1,ncnd
+
+     call metrics_and_qois_alloc( diag%cnd(icnd),                  &
+                                  cnd_diag_info%metric_nver(icnd), &
+                                  cnd_diag_info%nchkpt,            &
+                                  cnd_diag_info%nqoi,              &
+                                  cnd_diag_info%qoi_nver_save,     &
+                                  cnd_diag_info%l_output_state,    &
+                                  cnd_diag_info%l_output_incrm,    &
+                                  psetcols                         )
+  end do
+
+end subroutine single_chunk_cnd_diag_alloc
+
+
+!-----------------------------------------------------------------------------
+! Allocate memory for metrics and diagnostics for a single sampling condition
+!-----------------------------------------------------------------------------
+subroutine metrics_and_qois_alloc( cnd, metric_nver, nchkpt, nqoi, qoi_nver_save, &
+                                   l_output_state, l_output_incrm, psetcols )
+
+  type(metric_and_qois_t), intent(inout) :: cnd
+
+  integer, intent(in) :: metric_nver, nchkpt
+  integer, intent(in) :: nqoi
+  integer, intent(in) :: qoi_nver_save(nqoi)
+  logical, intent(in) :: l_output_state
+  logical, intent(in) :: l_output_incrm
+  integer, intent(in) :: psetcols
+
+  integer :: iqoi
+  integer :: ierr
+
+  character(len=*), parameter :: subname = 'metrics_and_qois_alloc'
+
+  ! metric and flag, which might have 1, pver, or pver+1 vertical levels
+
+  allocate( cnd% metric(psetcols,metric_nver), stat=ierr)
+  if ( ierr /= 0 ) call endrun(subname//': allocation of cnd% metric')
+
+  allocate( cnd% flag  (psetcols,metric_nver), stat=ierr)
+  if ( ierr /= 0 ) call endrun(subname//': allocation of cnd% flag')
+
+  ! QoIs 
+
+  if (nqoi > 0) then
+
+     allocate( cnd% qoi( nqoi ), stat=ierr)
+     if ( ierr /= 0 ) call endrun(subname//': allocation of cnd% qoi')
+
+     ! snapshots of each QoI 
+     if (l_output_state) then
+      do iqoi = 1, nqoi
+
+        allocate( cnd%qoi(iqoi)% val(psetcols,qoi_nver_save(iqoi),nchkpt), stat=ierr)
+        if ( ierr /= 0 ) call endrun(subname//': allocation of cnd%qoi% val')
+
+        cnd%qoi(iqoi)% val(:,:,:) = 0._r8
+
+      end do !iqoi
+     end if
+
+     ! increments of each QoI
+     if (l_output_incrm) then
+      do iqoi = 1, nqoi
+
+        allocate( cnd%qoi(iqoi)% old(psetcols,qoi_nver_save(iqoi)), stat=ierr)
+        if ( ierr /= 0 ) call endrun(subname//': allocation of cnd%qoi% old')
+
+        allocate( cnd%qoi(iqoi)% inc(psetcols,qoi_nver_save(iqoi),nchkpt), stat=ierr)
+        if ( ierr /= 0 ) call endrun(subname//': allocation of cnd%qoi% inc')
+
+        cnd%qoi(iqoi)% old(:,:)   = 0._r8
+        cnd%qoi(iqoi)% inc(:,:,:) = 0._r8
+
+      end do !iqoi
+     end if
+
+   end if
+
+end subroutine metrics_and_qois_alloc
+
+end module conditional_diag
+

--- a/components/eam/src/physics/cam/conditional_diag_main.F90
+++ b/components/eam/src/physics/cam/conditional_diag_main.F90
@@ -1,0 +1,720 @@
+module conditional_diag_main
+
+  use shr_kind_mod,   only: r8 => shr_kind_r8
+  use cam_abortutils, only: endrun
+
+  use conditional_diag, only: cnd_diag_info, cnd_diag_info_t
+
+  implicit none
+
+  private
+
+  public cnd_diag_checkpoint
+
+  ! types of comparison used in defining sampling condition
+
+  integer, parameter :: GE  =  2
+  integer, parameter :: GT  =  1
+  integer, parameter :: EQ  =  0
+  integer, parameter :: LT  = -1
+  integer, parameter :: LE  = -2
+
+  ! flags for grid cell/column masking
+
+  real(r8),parameter :: ON  = 1._r8
+  real(r8),parameter :: OFF = 0._r8
+
+  ! start time step for increment calculation
+
+  integer,parameter :: NS0INC = 3 ! start time step for increment calculation
+  integer,parameter :: NS0SMP = 4 ! start time step for conditional sampling
+contains
+
+!======================================================
+subroutine cnd_diag_checkpoint( diag, this_chkpt, state, pbuf, cam_in, cam_out )
+
+  use perf_mod,            only: t_startf, t_stopf
+  use time_manager,        only: get_nstep
+  use ppgrid,              only: pcols, pver
+  use cam_history_support, only: max_fieldname_len
+  use cam_history,         only: outfld
+
+  use physics_types,    only: physics_state
+  use camsrfexch,       only: cam_in_t, cam_out_t
+  use physics_buffer,   only: physics_buffer_desc
+
+  use conditional_diag,    only: cnd_diag_t, FILLVALUE, NODP
+  use conditional_diag_output_utils, only: get_metric_and_flag_names_for_output, &
+                                           get_fld_name_for_output
+
+  type(cnd_diag_t),    intent(inout), target :: diag
+  character(len=*),    intent(in)            :: this_chkpt
+
+  type(physics_state),     intent(in) :: state
+  type(physics_buffer_desc),pointer   :: pbuf(:)
+  type(cam_in_t),          intent(in) :: cam_in
+  type(cam_out_t),optional,intent(in) :: cam_out
+
+  integer :: ncnd, nchkpt, nqoi
+  integer :: icnd, ichkpt, ii, iqoi
+  integer :: ncol, lchnk
+  integer :: nstep
+  integer :: x_dp
+  character(len=20) :: qoi_name
+
+  real(r8) :: new3d(pcols,pver)
+
+  real(r8),pointer     :: metric(:,:), flag(:,:), inc(:,:), old(:,:)
+  real(r8),allocatable :: new(:,:)
+
+  character(len=max_fieldname_len) :: outfldname, flag_name_out, metric_name_out
+
+  !---------------------------------------------------------------------------
+  call t_startf('cnd_diag_checkpoint')
+  if (cnd_diag_info%ncnd == 0) then ! no conditional diagnostics requested 
+
+     call t_stopf('cnd_diag_checkpoint')
+     return
+
+  else
+  !---------------------------------------------------------------------------
+
+  ncnd   = cnd_diag_info%ncnd
+  nchkpt = cnd_diag_info%nchkpt
+  nqoi   = cnd_diag_info%nqoi
+
+  lchnk  = state%lchnk
+  ncol   = state%ncol
+
+  nstep  = get_nstep()  ! current time step. Later in this routine, we
+                        ! - save QoI values starting from the first step.
+                        ! - do increment calculation when nstep >= NS0INC.
+                        ! - evaluate sampling metrics starting from the first step.
+                        ! - do conditional sampling and outfld calls only when 
+                        !   nstep >= NS0SMP, because the sampling time window might 
+                        !   involve some checkpints from the previous nstep,
+                        !   and valid increments are available only from nstep >= NS0INC.
+
+  !=======================================
+  ! Obtain QoI values and/or increments
+  !=======================================
+  ! First determine if this checkpoint is active for QoI monitoring
+
+  ichkpt = 0  ! 0 = checkpoint inactive; this is the default
+
+  do ii = 1,nchkpt
+     if ( trim(cnd_diag_info%qoi_chkpt(ii)) == trim(this_chkpt) ) then 
+        ichkpt = ii
+        exit
+     end if
+  end do
+
+  if (ichkpt>0) then 
+  !---------------------------------------------------------------------------
+  ! This checkpoint is active for QoI monitoring. Obtain the QoI values 
+  ! and/or their increments if needed, and save to the "diag" data structure. 
+  ! Note that here we only obtain and save the QoIs and/or increments.
+  ! Conditional sampling won't be applied until the "cnd_end_chkpt" checkpoint
+  !---------------------------------------------------------------------------
+     do iqoi = 1,nqoi
+
+        qoi_name = cnd_diag_info% qoi_name(iqoi)
+        x_dp     = cnd_diag_info% x_dp(iqoi,ichkpt)
+
+        ! Allocate memory for tmp array. This has to be done inside the iqoi
+        ! loop as different QoIs might have different numbers of vertical levels
+
+        allocate( new( pcols,cnd_diag_info%qoi_nver_save(iqoi) ))
+
+        !------------------------------------------------------------------------
+        ! Obtain the most up-to-date values of the QoI or its vertical integral
+        !------------------------------------------------------------------------
+        if (x_dp==NODP) then ! get the new QoI values
+
+           call get_values( new, trim(qoi_name), state, pbuf, cam_in, cam_out ) !out, in, ... ,in
+
+        else ! get the vertical integral of the new QoI values
+
+           call get_values( new3d, trim(qoi_name), state, pbuf, cam_in, cam_out ) !out, in, ... ,in
+           call mass_wtd_vert_intg( new, new3d, state, x_dp ) !out, in, in, in
+
+        end if
+        !-----------------------------------------------------------------------------------------
+        ! Save the QoI and its increment to corresponding components of the "diag" data structure
+        !-----------------------------------------------------------------------------------------
+        ! The current implementation is such that the same set of checkpoints and QoIs are 
+        ! monitored for all different sampling conditions. Below, the same QoI values 
+        ! and/or increments are copied to all conditions. When conditional sampling is applied 
+        ! later, the different copies will likely be sampled differently. In the future, if we 
+        ! decide to allow for different QoIs and/or checkpoints under different sampling 
+        ! conditions, then the loops in this subroutine will need to be reworked.
+        !--------------------------------------------------------------------------
+        ! Save the QoI 
+
+        if (cnd_diag_info%l_output_state) then
+           do icnd = 1,ncnd
+              diag%cnd(icnd)%qoi(iqoi)% val(1:ncol,:,ichkpt) = new(1:ncol,:) 
+           end do
+        end if
+
+        !-------------------------------
+        ! Calculate and save inrements
+
+        if (cnd_diag_info%l_output_incrm) then
+
+           icnd = 1
+           old => diag%cnd(icnd)%qoi(iqoi)% old
+
+           if (nstep >= NS0INC) then 
+              inc => diag%cnd(icnd)%qoi(iqoi)% inc(:,:,ichkpt)
+              inc(1:ncol,:) = new(1:ncol,:) - old(1:ncol,:)
+           end if
+
+           ! Save the current value of QoI as "old" for next checkpoint
+
+           old(1:ncol,:) = new(1:ncol,:)
+
+           ! Save increments for other sampling conditions; update "old" value
+
+           do icnd = 2,ncnd
+
+              diag%cnd(icnd)%qoi(iqoi)% old(1:ncol,:) = new(1:ncol,:)
+              if (nstep >= NS0INC) &
+              diag%cnd(icnd)%qoi(iqoi)% inc(1:ncol,:,ichkpt) = inc(1:ncol,:)
+
+           end do
+
+        end if !l_output_incrm
+        !----------------------
+
+        ! Calculations done for this QoI. Clean up.
+        deallocate(new)
+
+     end do ! iqoi = 1,nqoi
+  end if    ! ichkpt > 0
+
+  !=======================================================
+  ! Evaluate sampling condition if this is cnd_eval_chkpt 
+  !=======================================================
+  do icnd = 1,ncnd
+
+     ! Check if sampling condition needs to be evaluated at this checkpoint.
+     ! The answer could be .t. for multiple icnd values
+
+     if (trim(cnd_diag_info% cnd_eval_chkpt(icnd)) .eq. trim(this_chkpt)) then 
+
+        !---------------------------------
+        ! Get metric values and set flags 
+        !---------------------------------
+        metric => diag%cnd(icnd)%metric
+        flag   => diag%cnd(icnd)%flag
+
+        !----------------------------------------------------------------
+        ! The special metric name "ALL" is used to select all grid cells.
+
+        if (trim(cnd_diag_info%metric_name(icnd)).eq.'ALL') then
+
+           metric = 1._r8
+           flag   = ON
+
+        !------------------------------------------
+        else ! If NOT selecting all grid cells...
+
+           call get_values( metric,                                &! out
+                            trim(cnd_diag_info%metric_name(icnd)), &! in
+                            state, pbuf, cam_in, cam_out )          ! in
+
+           call get_flags( metric, icnd, ncol, cnd_diag_info, flag )
+
+           ! Apply conditional sampling to metric
+
+           where(flag.eq.OFF)  metric = FILLVALUE
+
+        end if
+
+        !----------------------------------------------------
+        ! Send both metric and flag values to history buffer
+        !----------------------------------------------------
+        call get_metric_and_flag_names_for_output( icnd, cnd_diag_info, metric_name_out, flag_name_out )
+
+        call outfld( trim(metric_name_out), metric, pcols, lchnk )
+        call outfld( trim(flag_name_out),     flag, pcols, lchnk )
+
+     end if !right chkpt
+  end do    !icnd
+
+  !=======================================================================
+  ! Apply conditional sampling, then send QoIs to history buffer.
+  ! (Do this only when nstep >= NS0SMP, because the sampling time window might 
+  ! involve some checkpints from the previous nstep,
+  ! and valid increments are available only from nstep = NS0INC onwards)
+  !=======================================================================
+  if (nstep >= NS0SMP) then
+  do icnd = 1,ncnd
+
+     ! Check if conditional sampling needs to be completed at this checkpoint.
+     ! The answer could be .t. for multiple icnd values
+
+     if (trim(cnd_diag_info% cnd_end_chkpt(icnd)).eq.trim(this_chkpt)) then 
+
+        ! Each sampling condition has its own flags that will be applied
+        ! to all QoIs and checkpoints
+
+        flag => diag%cnd(icnd)%flag
+
+        !----------------------------------------------------------------
+        ! Apply conditional sampling to QoIs and/or their increments,
+        ! then do the outfld calls to send the values to history buffer. 
+        ! In subroutine apply_masking,
+        ! different actions are taken depending on the vertical 
+        ! dimension sizes of the metric and the QoIs.
+        !----------------------------------------------------------------
+        if (cnd_diag_info%l_output_state) then        
+
+           ! Apply conditional sampling to QoI values
+
+           if (trim(cnd_diag_info%metric_name(icnd)).ne.'ALL') then
+             do iqoi = 1,nqoi
+                call apply_masking( flag, diag%cnd(icnd)%qoi(iqoi)%val, FILLVALUE )
+             end do
+           end if
+
+           ! Send QoI values to history buffer
+
+           do iqoi = 1,nqoi
+             do ichkpt = 1,nchkpt
+                call get_fld_name_for_output( '', cnd_diag_info, icnd, iqoi, ichkpt, outfldname)
+                call outfld( trim(outfldname), diag%cnd(icnd)%qoi(iqoi)%val(:,:,ichkpt), pcols, lchnk )
+             end do
+           end do
+
+        end if
+
+        !------------
+        if (cnd_diag_info%l_output_incrm) then
+
+           ! Apply conditional sampling to QoI increments
+
+           if (trim(cnd_diag_info%metric_name(icnd)).ne.'ALL') then
+             do iqoi = 1,nqoi
+                call apply_masking( flag, diag%cnd(icnd)%qoi(iqoi)%inc, FILLVALUE )
+             end do
+           end if
+
+           ! Send QoI increments to history buffer
+
+           do iqoi = 1,nqoi
+             do ichkpt = 1,nchkpt
+                call get_fld_name_for_output( '_inc', cnd_diag_info, icnd, iqoi, ichkpt, outfldname)
+                call outfld( trim(outfldname), diag%cnd(icnd)%qoi(iqoi)%inc(:,:,ichkpt), pcols, lchnk )
+             end do
+           end do
+
+        end if
+
+     end if  !trim(this_chkpt).eq.trim(cnd_diag_info% cnd_end_chkpt(icnd))
+  end do ! icnd = 1,ncnd
+  end if ! nstep >= NS0SMP
+
+  call t_stopf('cnd_diag_checkpoint')
+
+  end if ! cnd_diag_info%ncnd == 0
+
+end subroutine cnd_diag_checkpoint
+
+!==================================================================
+subroutine apply_masking( flag, array, fillvalue )
+
+    real(r8),intent(in)    ::  flag(:,:)
+    real(r8),intent(inout) :: array(:,:,:)
+    real(r8),intent(in)    :: fillvalue
+
+    integer :: kk             ! vertical level index for a loop
+    integer :: flag_nver      ! # of vertical levels the flag array has
+    integer :: array_nver     ! # of vertical levels the output array has
+    integer :: nchkpt, ichkpt ! # of checkpoints to process, and the loop index
+    integer :: pcols, icol    ! # of columns in grid chunk, and the loop index
+
+         pcols = size(flag, 1)
+     flag_nver = size(flag, 2) 
+    array_nver = size(array,2) 
+        nchkpt = size(array,3)
+
+    if (flag_nver == array_nver) then 
+    ! same vertical dimension size; simply apply masking - and do this 
+    ! for all checkpoints
+
+       do ichkpt = 1,nchkpt
+          where(flag(:,:).eq.OFF) array(:,:,ichkpt) = fillvalue 
+       end do
+
+    elseif (flag_nver == 1 .and. array_nver > 1) then 
+    ! apply the same masking to all vertical levels and checkpoints
+
+       do icol = 1,pcols
+          if (flag(icol,1).eq.OFF) array(icol,:,:) = fillvalue
+       end do
+
+    elseif (flag_nver > 1 .and. array_nver == 1) then
+    ! if any level in a grid column is selected, select that column;
+    ! In other words, mask out a column in the output array 
+    ! only if cells on all levels in that column are masked out.
+
+       do icol = 1,pcols
+          if (all( flag(icol,:).eq.OFF )) then
+             array(icol,1,:) = fillvalue
+          end if
+       end do
+
+    else
+    ! QoI and flag both have multiple levels but the number of 
+    ! vertical levels are different. Do not apply masking.
+
+       continue
+
+    end if
+
+end subroutine apply_masking 
+
+
+!========================================================
+subroutine get_values( arrayout, varname, state, pbuf, cam_in, cam_out )
+
+  use ppgrid,         only: pcols,pver
+  use physics_types,  only: physics_state
+  use camsrfexch,     only: cam_in_t, cam_out_t
+  use physics_buffer, only: physics_buffer_desc, pbuf_get_index, pbuf_get_field
+  use time_manager,   only: get_nstep
+  use constituents,   only: cnst_get_ind, pcnst, sflxnam
+  use misc_diagnostics
+  use wv_saturation, only: qsat_water
+
+  real(r8),           intent(out)   :: arrayout(:,:)
+  character(len=*),   intent(in)    :: varname
+  type(physics_state),intent(in)    :: state
+  type(physics_buffer_desc), pointer:: pbuf(:)
+  type(cam_in_t),     intent(in)    :: cam_in
+  type(cam_out_t),    intent(in)    :: cam_out
+
+  real(r8),pointer :: ptr2d(:,:)
+  real(r8),pointer :: ptr1d(:)
+
+  real(r8) :: tmp(pcols,pver)
+
+  character(len=*),parameter :: subname = 'conditional_diag_main:get_values'
+
+  integer :: ncol, idx, m
+
+  ncol = state%ncol
+
+  !--------------------------------------------------------------------------------
+  ! If the requested variable is one of the advected tracers, get it from state%q
+  !--------------------------------------------------------------------------------
+  ! cnst_get_ind returns the index of a tracer in the host  model's advected 
+  ! tracer array. If variable is not found on the tracer list, and index value 
+  ! of -1 will be returned
+
+  call cnst_get_ind(trim(adjustl(varname)),idx, abrtf=.false.)  !in, out, in
+
+  if (idx /= -1) then ! This variable is a tracer field
+     arrayout(1:ncol,:) = state%q(1:ncol,:,idx)
+
+  else
+  !--------------------------------------------------------------------------------
+  ! If the requested variable is the surface flux of an advected tracer, get it
+  ! from cam_in%cflx
+  !--------------------------------------------------------------------------------
+     do m = 1,pcnst
+        if (trim(adjustl(varname)).eq.trim(sflxnam(m))) then
+           idx = m ; exit
+        end if
+     end do
+
+     if (idx /= -1) then ! This variable is the surface flux of an advected tracer
+        arrayout(1:ncol,1) = cam_in%cflx(1:ncol,idx)
+
+     else
+     !============================================================================
+     ! Non-tracer and non-sfc-flux variables
+     !============================================================================
+
+        select case (trim(adjustl(varname)))
+        case('T')
+           arrayout(1:ncol,:) = state%t(1:ncol,:)
+
+        case('U')
+           arrayout(1:ncol,:) = state%u(1:ncol,:)
+
+        case('V')
+           arrayout(1:ncol,:) = state%v(1:ncol,:)
+
+        case('OMEGA')
+           arrayout(1:ncol,:) = state%omega(1:ncol,:)
+
+        case('PMID')
+           arrayout(1:ncol,:) = state%pmid(1:ncol,:)
+
+        case('PINT')
+           arrayout(1:ncol,:) = state%pint(1:ncol,:)
+
+        case('ZM')
+           arrayout(1:ncol,:) = state%zm(1:ncol,:)
+
+        case('ZI')
+           arrayout(1:ncol,:) = state%zi(1:ncol,:)
+
+        case('PS')
+           arrayout(1:ncol,1) = state%ps(1:ncol)
+
+        !---------
+        ! cam_in 
+        !---------
+
+        case('LWUP')
+           arrayout(1:ncol,1) = cam_in%lwup(1:ncol)
+
+        case('LHF')
+           arrayout(1:ncol,1) = cam_in%lhf(1:ncol)
+
+        case('SHF')
+           arrayout(1:ncol,1) = cam_in%shf(1:ncol)
+
+        case('WSX')
+           arrayout(1:ncol,1) = cam_in%wsx(1:ncol)
+
+        case('WSY')
+           arrayout(1:ncol,1) = cam_in%wsy(1:ncol)
+
+        case('TREF')
+           arrayout(1:ncol,1) = cam_in%tref(1:ncol)
+
+        case('QREF')
+           arrayout(1:ncol,1) = cam_in%qref(1:ncol)
+
+        case('U10')
+           arrayout(1:ncol,1) = cam_in%u10(1:ncol)
+
+        case('TS')
+           arrayout(1:ncol,1) = cam_in%ts(1:ncol)
+
+        case('SST')
+           arrayout(1:ncol,1) = cam_in%sst(1:ncol)
+
+        !----------
+        ! cam_out
+        !----------
+
+        case('FLWDS')
+           arrayout(1:ncol,1) = cam_out%flwds(1:ncol)
+
+        case('NETSW')
+           arrayout(1:ncol,1) = cam_out%netsw(1:ncol)
+
+        !----------
+        ! pbuf
+        !----------
+        ! PBL/turbulence
+
+        case('PBLH')
+            idx = pbuf_get_index('pblh') ; call pbuf_get_field( pbuf, idx, ptr1d )
+            arrayout(:,1) = ptr1d
+
+        case('TKE')
+            idx = pbuf_get_index('tke')  ; call pbuf_get_field( pbuf, idx, ptr2d )
+            arrayout(:,:) = ptr2d
+
+        case('UPWP')
+            idx = pbuf_get_index('UPWP')  ; call pbuf_get_field( pbuf, idx, ptr2d )
+            arrayout(:,:) = ptr2d
+
+        case('VPWP')
+            idx = pbuf_get_index('VPWP')  ; call pbuf_get_field( pbuf, idx, ptr2d )
+            arrayout(:,:) = ptr2d
+
+        ! cloud frations
+
+        case('CLD')
+            idx = pbuf_get_index('CLD')  ; call pbuf_get_field( pbuf, idx, ptr2d )
+            arrayout(:,:) = ptr2d
+
+        case('AST')
+            idx = pbuf_get_index('AST')  ; call pbuf_get_field( pbuf, idx, ptr2d )
+            arrayout(:,:) = ptr2d
+
+        ! cloud microphysic
+
+        case('DEI')
+            idx = pbuf_get_index('DEI')  ; call pbuf_get_field( pbuf, idx, ptr2d )
+            arrayout(:,:) = ptr2d
+
+        case('DES')
+            idx = pbuf_get_index('DES')  ; call pbuf_get_field( pbuf, idx, ptr2d )
+            arrayout(:,:) = ptr2d
+
+        case('MU')
+            idx = pbuf_get_index('MU')  ; call pbuf_get_field( pbuf, idx, ptr2d )
+            arrayout(:,:) = ptr2d
+
+        case('LAMBDAC')
+            idx = pbuf_get_index('LAMBDAC')  ; call pbuf_get_field( pbuf, idx, ptr2d )
+            arrayout(:,:) = ptr2d
+
+        !-----------------------------------------------------------
+        ! physical quantities that need to be calculated on the fly 
+        !-----------------------------------------------------------
+
+        case ('QSATW')
+          call qsat_water( state%t(:ncol,:), state%pmid(:ncol,:), &! in
+                               tmp(:ncol,:),   arrayout(:ncol,:)  )! out
+
+        case ('QSATI')
+          call qsat_ice( ncol, pver, state%t(:ncol,:), state%pmid(:ncol,:), &! in
+                         arrayout(:ncol,:)                                  )! out
+
+        case ('QSSATW')  ! supersaturation w.r.t. water in terms of mixing ratio
+
+          call supersat_q_water( ncol, pver, state%t(:ncol,:),            &! in
+                                 state%pmid(:ncol,:), state%q(:ncol,:,1), &! in
+                                 arrayout(:ncol,:)  )                      ! out
+
+        case ('QSSATI')  ! supersaturation w.r.t. ice in terms of mixing ratio
+
+          call supersat_q_ice(   ncol, pver, state%t(:ncol,:),            &! in
+                                 state%pmid(:ncol,:), state%q(:ncol,:,1), &! in
+                                 arrayout(:ncol,:)  )                      ! out
+
+        case ('RHW')
+          call relhum_water_percent( ncol, pver, state%t(:ncol,:),            &! in
+                                     state%pmid(:ncol,:), state%q(:ncol,:,1), &! in
+                                     arrayout(:ncol,:)  )                      ! out
+        case ('RHI')
+          call relhum_ice_percent( ncol, pver, state%t(:ncol,:),            &! in
+                                   state%pmid(:ncol,:), state%q(:ncol,:,1), &! in
+                                   arrayout(:ncol,:)  )                      ! out
+
+        case ('CAPE')
+          call compute_cape( state, pbuf, pcols, pver, arrayout(:,1) ) ! in, in, in, out
+
+        !-----------------------------------------------------------------------------------
+        ! The following were added mostly for testing of the conditional diag functionality
+        !-----------------------------------------------------------------------------------
+        case('NSTEP')
+           arrayout(1:ncol,:) = get_nstep()
+
+        !case('LAT')
+        !   arrayout(1:ncol,1) = state%lat(1:ncol)
+
+        !case('LON')
+        !   arrayout(1:ncol,1) = state%lon(1:ncol)
+
+        case default
+           call endrun(subname//': unknow varname - '//trim(varname))
+        end select
+
+     end if !whether the requested variable is the surface flux of a tracer
+  end if    !whether the requested variable is a tracer field
+
+end subroutine get_values
+
+!==============================================================
+subroutine mass_wtd_vert_intg( arrayout, arrayin, state, x_dp )
+
+  use physics_types,   only: physics_state
+  use conditional_diag,only: PDEL,PDELDRY,NODP
+  use physconst,       only: gravit
+  use ppgrid,          only: pcols, pver
+
+  real(r8),           intent(out) :: arrayout(:,:)
+  real(r8),           intent(in)  :: arrayin (:,:)
+  type(physics_state),intent(in)  :: state
+  integer,            intent(in)  :: x_dp 
+
+  real(r8) :: tmp(pcols,pver)
+
+  integer :: ncol
+  character(len=*),parameter :: subname = 'conditional_diag_main: mass_wtd_vert_intg'
+
+  ncol = state%ncol
+
+  ! Multiply by the appropriate dp (dry or wet)
+
+  select case (x_dp)
+  case (PDEL)
+     tmp(1:ncol,:) = arrayin(1:ncol,:) * state%pdel(1:ncol,:)
+
+  case (PDELDRY)
+     tmp(1:ncol,:) = arrayin(1:ncol,:) * state%pdeldry(1:ncol,:)
+
+  case default
+     call endrun(subname//': unexpected value of x_dp')
+  end select
+
+  ! Vertical sum divided by gravit
+
+  arrayout(1:ncol,1) = sum( tmp(1:ncol,:), 2 )/gravit
+
+end subroutine mass_wtd_vert_intg 
+
+!==============================================================
+subroutine get_flags( metric, icnd, ncol, cnd_diag_info, flag )
+
+  real(r8),              intent(in) :: metric(:,:)
+  integer,               intent(in) :: icnd
+  integer,               intent(in) :: ncol
+  type(cnd_diag_info_t), intent(in) :: cnd_diag_info
+
+  real(r8), intent(inout) :: flag(:,:)
+
+  character(len=*),parameter :: subname = 'get_flags'
+
+  flag(:,:) = OFF
+
+  select case (cnd_diag_info%metric_cmpr_type(icnd))
+  case (GT)
+
+    where (metric(1:ncol,:).gt.cnd_diag_info%metric_threshold(icnd))
+      flag(1:ncol,:) = ON
+    elsewhere
+      flag(1:ncol,:) = OFF
+    end where
+
+  case (GE)
+
+    where (metric(1:ncol,:).ge.cnd_diag_info%metric_threshold(icnd))
+      flag(1:ncol,:) = ON
+    elsewhere
+      flag(1:ncol,:) = OFF
+    end where
+
+  case (LT)
+
+    where (metric(1:ncol,:).lt.cnd_diag_info%metric_threshold(icnd))
+      flag(1:ncol,:) = ON
+    elsewhere
+      flag(1:ncol,:) = OFF
+    end where
+
+  case (LE)
+
+    where (metric(1:ncol,:).le.cnd_diag_info%metric_threshold(icnd))
+      flag(1:ncol,:) = ON
+    elsewhere
+      flag(1:ncol,:) = OFF
+    end where
+
+  case (EQ)
+
+    where ( abs(metric(1:ncol,:)-cnd_diag_info%metric_threshold(icnd)) &
+            .le. cnd_diag_info%metric_tolerance(icnd)                  )
+      flag(1:ncol,:) = ON
+    elsewhere
+      flag(1:ncol,:) = OFF
+    end where
+
+  case default
+    call endrun(subname//': unknown cnd_diag_info%metric_cmpr_type')
+  end select
+
+end subroutine get_flags
+
+end module conditional_diag_main

--- a/components/eam/src/physics/cam/conditional_diag_main.F90
+++ b/components/eam/src/physics/cam/conditional_diag_main.F90
@@ -399,7 +399,9 @@ subroutine get_values( arrayout, varname, state, pbuf, cam_in, cam_out )
   real(r8),pointer :: ptr2d(:,:)
   real(r8),pointer :: ptr1d(:)
 
-  real(r8) :: tmp(pcols,pver)
+  real(r8) ::   tmp(pcols,pver)
+  real(r8) ::  cape(pcols)
+  real(r8) :: dcape(pcols,3)
 
   character(len=*),parameter :: subname = 'conditional_diag_main:get_values'
 
@@ -593,7 +595,16 @@ subroutine get_values( arrayout, varname, state, pbuf, cam_in, cam_out )
                                    arrayout(:ncol,:)  )                      ! out
 
         case ('CAPE')
-          call compute_cape( state, pbuf, pcols, pver, arrayout(:,1) ) ! in, in, in, out
+          call compute_cape_diags( state, pbuf, pcols, pver, cape ) ! 4xin, 1xout
+          arrayout(:,1) = cape(:)
+
+        case ('dCAPE')
+
+          arrayout(:,:) = 0._r8
+
+          call compute_cape_diags( state, pbuf, pcols, pver, cape, dcape ) ! 4xin, 2xout
+
+          arrayout(:,1:3) = dcape(:,1:3)   ! 1=dCAPE, 2=dCAPEp, 3=dCAPEe
 
         !-----------------------------------------------------------------------------------
         ! The following were added mostly for testing of the conditional diag functionality

--- a/components/eam/src/physics/cam/conditional_diag_output_utils.F90
+++ b/components/eam/src/physics/cam/conditional_diag_output_utils.F90
@@ -1,0 +1,264 @@
+module conditional_diag_output_utils
+!----------------------------------------------------------------------
+! Utility subroutines used for handling model output 
+! for the conditional sampling and budget analysis tool. 
+! Currently included are a few small subroutines that construct output
+! variable names, and a subroutine that makes addfld and add_default 
+! calls to register output variables during model initialization.
+! The outfld calls are in module conditional_diag_main.
+!
+! History:
+!  First version by Hui Wan, PNNL, March-May 2021
+!----------------------------------------------------------------------
+  use cam_abortutils, only: endrun
+  use conditional_diag, only: cnd_diag_info_t
+
+  implicit none
+  public
+
+contains
+
+subroutine cnd_diag_output_init(pver, cnd_diag_info)
+!----------------------------------------------------------------------------------- 
+! 
+! Purpose: Register variables related to conditional sampling and budget analysis
+!          for history output
+!
+! Method: (1) Add variables to the master field list by doing addfld calls
+!         (2) Add the whole suite of supported output variables to 
+!             user-specified history tapes by doing add_default calls.
+!         These two things are done for each sampling condition. 
+!         Registered output variables include, for each condition,
+!          - the metric used for evaluating the user-specified sampling condition,
+!          - the flag field resulting from evaluating the sampling condition,
+!          - the various QoIs (and their increments if requested) to which 
+!            conditional sampling is applied. Per user's choice, 
+!            these QoIs and increments might be monitored at various checkpoints
+!            in each time step and might be multiplied with the pressure layer
+!            thickness.
+!-----------------------------------------------------------------------------------
+  use cam_history_support, only: max_fieldname_len, horiz_only
+  use cam_history,         only: addfld, add_default
+  use conditional_diag,    only: FILLVALUE
+
+  integer,intent(in) :: pver
+  type(cnd_diag_info_t), intent(in) :: cnd_diag_info
+
+  integer          :: ntape,itape
+  integer          :: icnd, iqoi, ichkpt, ii
+  character(len=4) :: val_inc_suff(2), suff
+  logical          :: l_output(2)
+
+  character(len=max_fieldname_len) :: output_fld_name
+  character(len=max_fieldname_len) :: output_fld_name2
+
+  character(len=256) :: fld_long_name
+
+  character(len=*),parameter :: subname = 'cnd_diag_output_init'
+
+  if (cnd_diag_info%ncnd==0) return
+
+  ntape = cnd_diag_info%ntape
+
+  ! Loop through all sampling conditions. Each of them will have
+  ! its own set of output variables distinguished by the prefix cndxx_
+  ! where xx is a two-digit integer.
+
+  do icnd = 1,cnd_diag_info%ncnd
+
+     !------------------------------------------------------------------------------
+     ! Register the metric of the sampling condition and the associated flag field
+     !------------------------------------------------------------------------------
+     call get_metric_and_flag_names_for_output( icnd, cnd_diag_info, &!in
+                                                output_fld_name,     &!out
+                                                output_fld_name2    ) !out
+
+     ! Add the 2 variables to the master list of possible output variables.
+     ! The arguments of an addfld call are: (1) variable name, 
+     ! (2) vertical dimension name, (3) avg. flag, (4) unit, (5) long_name.
+     ! Units are set to blank right now; we could add a namelist variable
+     ! to let the user provide the info. 
+
+     if (cnd_diag_info%metric_nver(icnd)==1) then
+
+       call addfld(trim(output_fld_name ), horiz_only, 'A',' ','Metric used in conditional sampling')
+       call addfld(trim(output_fld_name2), horiz_only, 'A',' ','Flags  used in conditional sampling')
+
+     elseif(cnd_diag_info%metric_nver(icnd)==pver) then
+
+       call addfld(trim(output_fld_name ), (/'lev'/),  'A',' ','Metric used in conditional sampling')
+       call addfld(trim(output_fld_name2), (/'lev'/),  'A',' ','Flags  used in conditional sampling')
+
+     elseif(cnd_diag_info%metric_nver(icnd)==pver+1) then
+
+       call addfld(trim(output_fld_name ), (/'ilev'/), 'A',' ','Metric used in conditional sampling')
+       call addfld(trim(output_fld_name2), (/'ilev'/), 'A',' ','Flags  used in conditional sampling')
+
+     else 
+       call endrun(subname//': invalid number of vertical levels for metric '//trim(cnd_diag_info%metric_name(icnd)))
+     end if 
+
+     ! Add the variable to user-specified history tapes.
+     ! The 3 arguments of an add_default call are (1) variable name, (2) hist. tape index,
+     ! and (3) hist. averaging flag
+
+     do itape = 1,ntape
+        call add_default(trim(output_fld_name ), cnd_diag_info%hist_tape_with_all_output(itape), ' ')  
+        call add_default(trim(output_fld_name2), cnd_diag_info%hist_tape_with_all_output(itape), ' ')
+     end do
+
+     !-------------------------------------------------------------------
+     ! Register the diagnostics fields and their increments 
+     !-------------------------------------------------------------------
+     ! Put the on/off switches for value and increment output into one
+     ! array so that we can deal with both using the ii-loop below
+
+     l_output = (/cnd_diag_info%l_output_state, cnd_diag_info%l_output_incrm/)
+
+     ! In terms of variable names in the output files, the values and 
+     ! increments of a field are distinguished by different suffixes
+
+     val_inc_suff = (/"","_inc"/)
+
+     do ii = 1,2 ! field value (state) or increment
+
+        if (.not.l_output(ii)) cycle
+        suff = val_inc_suff(ii)
+
+        do iqoi  = 1,cnd_diag_info%nqoi
+        do ichkpt = 1,cnd_diag_info%nchkpt
+
+           call get_fld_name_for_output( suff, cnd_diag_info, &! in
+                                         icnd, iqoi, ichkpt,  &! in
+                                         output_fld_name      )! out
+
+           call get_fld_longname_for_output( suff, cnd_diag_info, &! in
+                                             icnd, iqoi, ichkpt,  &! in
+                                             fld_long_name        )! out
+
+           ! Add the variable to the master list of possible output variables.
+           ! The arguments of an addfld call are: (1) variable name, 
+           ! (2) vertical dimension name, (3) avg. flag, (4) unit, (5) long_name.
+           ! Units are set to blank right now; we could add a namelist variable
+           ! to let the user provide the info. 
+
+           if (cnd_diag_info%qoi_nver_save(iqoi)==1) then
+              call addfld(trim(output_fld_name), horiz_only, 'A',' ',trim(fld_long_name)) 
+
+           elseif (cnd_diag_info%qoi_nver_save(iqoi)==pver) then
+              call addfld(trim(output_fld_name), (/'lev'/),  'A',' ',trim(fld_long_name)) 
+
+           elseif (cnd_diag_info%qoi_nver_save(iqoi)==pver+1) then
+              call addfld(trim(output_fld_name), (/'ilev'/), 'A',' ',trim(fld_long_name)) 
+           else
+              call endrun(subname//': invalid number of vertical levels for '//cnd_diag_info%qoi_name(iqoi))
+           end if
+
+           ! Add the variable to user-specified history tapes.
+           ! The 3 arguments of an add_default call are (1) variable name, (2) hist. tape index,
+           ! and (3) hist. averaging flag
+
+           do itape = 1,ntape
+              call add_default(trim(output_fld_name ), cnd_diag_info%hist_tape_with_all_output(itape), ' ')  
+           end do
+
+        end do ! ichkpt
+        end do ! iqoi
+
+     end do ! ii = 1,2, field value (state) or tendency
+
+  end do ! icnd = 1,ncnd
+
+end subroutine cnd_diag_output_init
+
+!======================================================
+subroutine get_metric_and_flag_names_for_output( icnd, cnd_diag_info,   &! in
+                                               metric_name_in_output, &! out
+                                               flag_name_in_output    )! out
+
+   use cam_history_support, only: max_fieldname_len
+
+   integer,               intent(in)  :: icnd
+   type(cnd_diag_info_t), intent(in)  :: cnd_diag_info
+
+   character(len=max_fieldname_len) :: metric_name_in_output
+   character(len=max_fieldname_len) :: flag_name_in_output
+
+   character(len=2) :: icnd_str ! condition index as a string
+
+   write(icnd_str,'(i2.2)') icnd
+   metric_name_in_output = 'cnd'//icnd_str//'_'//trim(cnd_diag_info%metric_name(icnd))
+     flag_name_in_output = 'cnd'//icnd_str//'_'//trim(cnd_diag_info%metric_name(icnd))//'_flag'
+
+end subroutine get_metric_and_flag_names_for_output
+
+!======================================================
+subroutine get_fld_name_for_output( suff, cnd_diag_info,    &!in
+                                    icnd, iqoi, ichkpt,     &!in
+                                    fld_name_in_output      )!out
+
+   use cam_history_support, only: max_fieldname_len
+   use conditional_diag,    only: NODP
+
+   character(len=*),      intent(in)  :: suff
+   type(cnd_diag_info_t), intent(in)  :: cnd_diag_info
+   integer,               intent(in)  :: icnd, iqoi, ichkpt
+
+   character(len=max_fieldname_len),intent(out) :: fld_name_in_output 
+
+   character(len=2) :: icnd_str   ! condition index as a string
+   character(len=2) :: vint       ! suffix
+
+   ! If the field will be vertically integrated, append "_v" to the QoI name
+
+   if (cnd_diag_info%x_dp(iqoi,ichkpt)/=NODP) then
+      vint = '_v'
+   else
+      vint = ''
+   end if
+
+   ! Now construct the full name of the variable in output file
+
+   write(icnd_str,'(i2.2)') icnd
+
+   fld_name_in_output = 'cnd'//icnd_str//'_'// &
+                        trim(cnd_diag_info%qoi_name(iqoi))//trim(vint)//'_'// &
+                        trim(cnd_diag_info%qoi_chkpt(ichkpt))//suff
+
+end subroutine get_fld_name_for_output 
+
+!======================================================
+subroutine get_fld_longname_for_output( suff, cnd_diag_info,    &!in
+                                        icnd, iqoi, ichkpt,      &!in
+                                        fld_long_name_in_output )!out
+
+   use cam_history_support, only: max_fieldname_len
+   use conditional_diag,    only: NODP
+
+   character(len=*),      intent(in)  :: suff
+   type(cnd_diag_info_t), intent(in)  :: cnd_diag_info
+   integer,               intent(in)  :: icnd, iqoi, ichkpt
+
+   character(len=256),intent(out)     :: fld_long_name_in_output 
+
+   character(len=2) :: icnd_str ! condition index as a string
+   character(len=2) :: vint       ! suffix
+
+   ! If the field will be vertically integrated, append "_v" to the QoI name
+
+   if (cnd_diag_info%x_dp(iqoi,ichkpt)/=NODP) then
+      vint = '_v'
+   else
+      vint = ''
+   end if
+
+   write(icnd_str,'(i2.2)') icnd
+
+   fld_long_name_in_output = trim(cnd_diag_info%qoi_name(iqoi))//trim(vint)//trim(suff)// &
+                             ' at '//trim(cnd_diag_info%qoi_chkpt(ichkpt))// &
+                             ' sampled under condition '//icnd_str// &
+                             ' ('//trim(cnd_diag_info%metric_name(icnd))//')' 
+
+end subroutine get_fld_longname_for_output 
+
+end module conditional_diag_output_utils

--- a/components/eam/src/physics/cam/conditional_diag_output_utils.F90
+++ b/components/eam/src/physics/cam/conditional_diag_output_utils.F90
@@ -118,12 +118,12 @@ subroutine cnd_diag_output_init(pver, cnd_diag_info)
      ! In terms of variable names in the output files, the values and 
      ! increments of a field are distinguished by different suffixes
 
-     val_inc_suff = (/"","_inc"/)
+     val_inc_suff = (/"    ","_inc"/)
 
      do ii = 1,2 ! field value (state) or increment
 
         if (.not.l_output(ii)) cycle
-        suff = val_inc_suff(ii)
+        suff = trim(val_inc_suff(ii))
 
         do iqoi  = 1,cnd_diag_info%nqoi
         do ichkpt = 1,cnd_diag_info%nchkpt

--- a/components/eam/src/physics/cam/conditional_diag_restart.F90
+++ b/components/eam/src/physics/cam/conditional_diag_restart.F90
@@ -1,0 +1,782 @@
+module conditional_diag_restart
+
+  implicit none
+  private
+
+  public :: cnd_diag_init_restart
+  public :: cnd_diag_write_restart
+  public :: cnd_diag_read_restart
+
+contains
+  !==================================================================================================
+  subroutine cnd_diag_init_restart( dimids, hdimcnt, pver, pver_id, pverp_id,            &! in
+                                    file, cnd_metric_desc,  cnd_flag_desc,               &! inout
+                                    cnd_qoi_val_desc, cnd_qoi_old_desc, cnd_qoi_inc_desc )! inout
+  !------------------------------------------------------------------------------------------------
+  ! Purpose: add variables to the restart file for conditional sampling and diagnostics.
+  ! History: First version by Hui Wan, PNNL, 2021-04
+  !------------------------------------------------------------------------------------------------
+
+  use cam_abortutils,   only: endrun
+  use conditional_diag, only: cnd_diag_info
+  use pio,              only: file_desc_t, var_desc_t, pio_def_var, pio_double
+
+  integer, intent(in) :: dimids(4)
+  integer, intent(in) :: hdimcnt
+  integer, intent(in) :: pver
+  integer, intent(in) :: pver_id
+  integer, intent(in) :: pverp_id
+
+  type(file_desc_t), intent(inout) :: file
+
+  type(var_desc_t),allocatable,intent(inout) :: cnd_metric_desc(:)
+  type(var_desc_t),allocatable,intent(inout) :: cnd_flag_desc(:)
+  type(var_desc_t),allocatable,intent(inout) :: cnd_qoi_val_desc(:,:,:)
+  type(var_desc_t),allocatable,intent(inout) :: cnd_qoi_inc_desc(:,:,:)
+  type(var_desc_t),allocatable,intent(inout) :: cnd_qoi_old_desc(:,:)
+
+  ! Local variables
+
+  integer :: ierr, ndims
+  integer :: dimids_local(4)
+  character(len=256) :: pname  !variable name in restart file
+
+  integer :: ncnd, nchkpt, nqoi, icnd, ichkpt, iqoi, nver
+  character(len=*),parameter :: subname = 'cnd_diag_init_restart'
+
+  if (cnd_diag_info%ncnd <= 0 ) return
+
+  !-------------------------------------------------------------------------------
+  ! Copy dimension IDs to a local array.
+  !-------------------------------------------------------------------------------
+  ! Because the various metrics, flags and QoIs in the conditional diagnostics 
+  ! data structre can have different sizes in the vertical dimension,
+  ! the last element of the local variable dimids_local might get different values
+  ! during this subroutine. The use of a local variable here ensures that 
+  ! the array dimids in the calling subroutine remains intact.
+  !-------------------------------------------------------------------------------
+  dimids_local(:) = dimids(:)
+
+  !-------------------------------------------------------------------------------
+  ! Allocate memeory for the variable description arrays
+  !-------------------------------------------------------------------------------
+  ! (Question: would it be better to allocate and deallocate at the beginning
+  ! and end of each run instead of each time step?)
+
+  ncnd   = cnd_diag_info%ncnd
+  nchkpt = cnd_diag_info%nchkpt
+  nqoi   = cnd_diag_info%nqoi
+
+  allocate( cnd_metric_desc(ncnd) )
+  allocate( cnd_flag_desc(ncnd) )
+
+  if (nqoi>0) then
+     allocate( cnd_qoi_old_desc(       ncnd,nqoi) )
+     allocate( cnd_qoi_val_desc(nchkpt,ncnd,nqoi) )
+     allocate( cnd_qoi_inc_desc(nchkpt,ncnd,nqoi) )
+  end if
+
+  !-----------------------------------------------------------
+  ! Add the metrics and corresponding flags to restart file
+  !-----------------------------------------------------------
+  do icnd = 1,ncnd
+
+     nver = cnd_diag_info%metric_nver(icnd)
+
+     ! Dimension information
+
+     if ( nver == 1) then
+        ndims = hdimcnt
+
+     else if ( nver == pver ) then
+        ndims = hdimcnt+1
+        dimids_local(ndims) = pver_id
+
+     else if ( nver == pver+1 ) then
+        ndims = hdimcnt+1
+        dimids_local(ndims) = pverp_id
+
+     else
+        call endrun(subname//': check cnd_diag_info%metric_nver')
+     end if
+
+     ! Add the metric variable
+
+     write(pname,'(a,i2.2,a)') 'cnd',icnd,'_metric'
+     ierr = pio_def_var(File, trim(pname), pio_double, dimids_local(1:ndims), cnd_metric_desc(icnd))
+
+     ! Add the flag variable
+
+     write(pname,'(a,i2.2,a)') 'cnd',icnd,'_flag'
+     ierr = pio_def_var(File, trim(pname), pio_double, dimids_local(1:ndims),   cnd_flag_desc(icnd))
+
+  end do
+
+  !--------------------------------
+  ! Add the QoIs to restart file
+  !--------------------------------
+  do iqoi = 1,nqoi
+
+     ! Dimension information
+
+     nver = cnd_diag_info%qoi_nver_save(iqoi)
+
+     if ( nver == 1) then
+        ndims = hdimcnt
+
+     else if ( nver == pver ) then
+        ndims = hdimcnt+1
+        dimids_local(ndims) = pver_id
+
+     else if ( nver == pver+1 ) then
+        ndims = hdimcnt+1
+        dimids_local(ndims) = pverp_id
+
+     else
+        call endrun(subname//': check cnd_diag_info%qoi_nver_save')
+     end if
+
+     ! Add to restart file the variables containing QoIs at various checkpoints 
+
+     if (cnd_diag_info%l_output_state) then
+        do icnd = 1,ncnd
+         do ichkpt = 1,nchkpt
+            write(pname,'(3(a,i2.2))') 'cnd',icnd, '_qoi',iqoi, '_',ichkpt
+            ierr = pio_def_var(File, trim(pname), pio_double, dimids_local(1:ndims), cnd_qoi_val_desc(ichkpt,icnd,iqoi))
+         end do
+        end do
+     end if
+
+     ! Add to restart file the variables containing increments at various checkpoints 
+
+     if (cnd_diag_info%l_output_incrm) then
+
+        do icnd = 1,ncnd
+         do ichkpt = 1,nchkpt
+            write(pname,'(3(a,i2.2))') 'cnd',icnd, '_qoi',iqoi, '_inc',ichkpt
+            ierr = pio_def_var(File, trim(pname), pio_double, dimids_local(1:ndims), cnd_qoi_inc_desc(ichkpt,icnd,iqoi))
+         end do
+        end do
+
+        ! Add to restart file the variable containing the "old" value of the field 
+
+        do icnd = 1,ncnd
+           write(pname,'(2(a,i2.2),a)') 'cnd',icnd, '_qoi',iqoi, '_old'
+           ierr = pio_def_var(File, trim(pname), pio_double, dimids_local(1:ndims), cnd_qoi_old_desc(icnd,iqoi))
+        end do
+
+     end if
+
+  end do !iqoi
+
+  end subroutine cnd_diag_init_restart
+  !=========================================================
+
+  subroutine cnd_diag_write_restart( phys_diag, begchunk, endchunk,         &! in
+                                     physgrid, file_hdimsizes, file_nhdims, &! in
+                                     pcols, chunk_ncols, fillvalue,         &! in
+                                     file, cnd_metric_desc,  cnd_flag_desc, &! inout
+                                     cnd_qoi_val_desc, cnd_qoi_inc_desc,    &! inout
+                                     cnd_qoi_old_desc                       )! inout
+  !------------------------------------------------------------------------------------------------
+  ! Purpose: add variables to the restart file for conditional sampling and diagnostics.
+  ! History: First version by Hui Wan, PNNL, 2021-04
+  !------------------------------------------------------------------------------------------------
+
+  use cam_abortutils,   only: endrun
+  use conditional_diag, only: cnd_diag_info, cnd_diag_t
+  use pio,              only: file_desc_t, io_desc_t, var_desc_t, pio_double, pio_write_darray
+  use cam_grid_support, only: cam_grid_get_decomp, cam_grid_write_dist_array
+  use shr_kind_mod,     only: r8 => shr_kind_r8
+
+  integer, intent(in) :: begchunk, endchunk
+  type(cnd_diag_t),intent(in) :: phys_diag(begchunk:endchunk)
+
+  integer, intent(in) :: physgrid
+  integer, intent(in) :: file_nhdims                  ! number of horizontal dimensions in restart file 
+  integer, intent(in) :: file_hdimsizes(file_nhdims)  ! horizontal dimension sizes in restart file
+
+  integer, intent(in) :: pcols
+  integer, intent(in) :: chunk_ncols(begchunk:endchunk)
+  real(r8),intent(in) :: fillvalue
+
+  type(file_desc_t), intent(inout) :: file
+
+  type(var_desc_t),allocatable,intent(inout) :: cnd_metric_desc(:)
+  type(var_desc_t),allocatable,intent(inout) :: cnd_flag_desc(:)
+  type(var_desc_t),allocatable,intent(inout) :: cnd_qoi_val_desc(:,:,:)
+  type(var_desc_t),allocatable,intent(inout) :: cnd_qoi_inc_desc(:,:,:)
+  type(var_desc_t),allocatable,intent(inout) :: cnd_qoi_old_desc(:,:)
+
+  ! Local variables
+
+  integer :: file_dims(3)   ! dimension sizes in restart file, local variable
+  integer :: arry_dims(3)   ! dimension sizes of array holding values to be written out, local variable
+
+  type(io_desc_t), pointer :: iodesc
+
+  integer :: ierr
+  integer :: lchnk,ncol
+  integer :: ncnd, nchkpt, nqoi, icnd, ichkpt, iqoi, nver
+  character(len=*),parameter :: subname = 'cnd_write_init_restart'
+
+  real(r8):: tmpfield_2d_1(pcols, begchunk:endchunk)
+  real(r8):: tmpfield_2d_2(pcols, begchunk:endchunk)
+
+  real(r8), allocatable :: tmpfield_3d_1(:,:,:)
+  real(r8), allocatable :: tmpfield_3d_2(:,:,:)
+
+
+  if (cnd_diag_info%ncnd <= 0 ) return
+
+  !---------------------------------------------------------------
+  ! Gather dimension info and save in local variables
+  !---------------------------------------------------------------
+  ncnd   = cnd_diag_info%ncnd
+  nchkpt = cnd_diag_info%nchkpt
+  nqoi   = cnd_diag_info%nqoi
+
+  file_dims(1:file_nhdims) = file_hdimsizes(1:file_nhdims)
+
+  !-------------------
+  ! metrics and flags
+  !-------------------
+  do icnd = 1,ncnd
+
+     nver = cnd_diag_info%metric_nver(icnd)
+
+     if (nver==1) then
+
+        !--------------------------------------------
+        ! get iodesc needed by pio_write_darray calls
+
+        arry_dims(1) = pcols
+        arry_dims(2) = endchunk - begchunk + 1
+
+        call cam_grid_get_decomp(physgrid, arry_dims(1:2), file_dims(1:file_nhdims), pio_double, iodesc) ! 4xin, out
+
+        !----------------------------------------------------------------
+        ! pack metric and flag values into tmp arrays and write them out
+
+        tmpfield_2d_1 = fillvalue
+        tmpfield_2d_2 = fillvalue
+
+        do lchnk = begchunk, endchunk
+           ncol = chunk_ncols(lchnk) 
+           tmpfield_2d_1(:ncol,lchnk) = phys_diag(lchnk)%cnd(icnd)% metric(:ncol,1)
+           tmpfield_2d_2(:ncol,lchnk) = phys_diag(lchnk)%cnd(icnd)%   flag(:ncol,1)
+        end do
+
+        call pio_write_darray(File, cnd_metric_desc(icnd), iodesc, tmpfield_2d_1, ierr)
+        call pio_write_darray(File,   cnd_flag_desc(icnd), iodesc, tmpfield_2d_2, ierr)
+
+     else ! nver > 1
+
+        !----------------------------------------------------
+        ! prepare input for cam_grid_write_dist_array calls
+
+        arry_dims(1) = pcols
+        arry_dims(2) = nver
+        arry_dims(3) = endchunk - begchunk + 1
+
+        file_dims(file_nhdims+1) = nver
+
+        allocate( tmpfield_3d_1(pcols,nver,begchunk:endchunk) )
+        allocate( tmpfield_3d_2(pcols,nver,begchunk:endchunk) )
+
+        tmpfield_3d_1 = fillvalue
+        tmpfield_3d_2 = fillvalue
+        
+        !----------------------------------------------------------------
+        ! pack metric and flag values into tmp arrays and write them out
+
+        do lchnk = begchunk, endchunk
+           ncol = chunk_ncols(lchnk)
+           tmpfield_3d_1(:ncol,:,lchnk) = phys_diag(lchnk)%cnd(icnd)% metric(:ncol,:)
+           tmpfield_3d_2(:ncol,:,lchnk) = phys_diag(lchnk)%cnd(icnd)%   flag(:ncol,:)
+        end do
+
+        call cam_grid_write_dist_array(File, physgrid, arry_dims(1:3), file_dims(1:file_nhdims+1), tmpfield_3d_1, cnd_metric_desc(icnd))
+        call cam_grid_write_dist_array(File, physgrid, arry_dims(1:3), file_dims(1:file_nhdims+1), tmpfield_3d_2,   cnd_flag_desc(icnd))
+
+        deallocate(tmpfield_3d_1)
+        deallocate(tmpfield_3d_2)
+
+     end if 
+  end do
+
+  !----------------------------------------------------------
+  ! Conditionally sampled QoIs: "old", snapshots, and "inc"
+  !----------------------------------------------------------
+  do iqoi = 1,nqoi
+
+     nver = cnd_diag_info%qoi_nver_save(iqoi)
+
+     if (nver==1) then
+
+        tmpfield_2d_1 = fillvalue
+
+        !--------------------------------------------
+        ! get iodesc needed by pio_write_darray calls
+        !--------------------------------------------
+        arry_dims(1) = pcols
+        arry_dims(2) = endchunk - begchunk + 1
+ 
+        call cam_grid_get_decomp(physgrid, arry_dims(1:2), file_dims(1:file_nhdims), pio_double, iodesc) ! 4xin, out
+
+        !-------------------------------------------------------
+        ! pack field values into tmp arrays and write them out
+        !-------------------------------------------------------
+        if (cnd_diag_info%l_output_state) then
+
+           do icnd = 1,ncnd
+           do ichkpt = 1,nchkpt
+
+              do lchnk = begchunk, endchunk
+                 ncol = chunk_ncols(lchnk)
+                 tmpfield_2d_1(:ncol,lchnk) = phys_diag(lchnk)%cnd(icnd)%qoi(iqoi)% val(:ncol,1,ichkpt)
+              end do
+
+              call pio_write_darray(File, cnd_qoi_val_desc(ichkpt,icnd,iqoi), iodesc, tmpfield_2d_1, ierr)
+
+           end do
+           end do
+
+        end if !cnd_diag_info%l_output_state
+
+        !-------------------------------------------------------------------
+        ! pack increment and old values into tmp arrays and write them out
+        !-------------------------------------------------------------------
+        if (cnd_diag_info%l_output_incrm) then
+
+           do icnd = 1,ncnd
+
+              ! increments corresponding to various checkpoints 
+
+              do ichkpt = 1,nchkpt
+
+                 do lchnk = begchunk, endchunk
+                    ncol = chunk_ncols(lchnk)
+                    tmpfield_2d_1(:ncol,lchnk) = phys_diag(lchnk)%cnd(icnd)%qoi(iqoi)% inc(:ncol,1,ichkpt)
+                 end do
+
+                 call pio_write_darray(File, cnd_qoi_inc_desc(ichkpt,icnd,iqoi), iodesc, tmpfield_2d_1, ierr)
+
+              end do !ichkpt
+
+              ! the "old" values
+ 
+              do lchnk = begchunk, endchunk
+                 ncol = chunk_ncols(lchnk)
+                 tmpfield_2d_1(:ncol,lchnk) = phys_diag(lchnk)%cnd(icnd)%qoi(iqoi)%old(:ncol,1)
+              end do
+
+              call pio_write_darray(File, cnd_qoi_old_desc(icnd,iqoi), iodesc, tmpfield_2d_1, ierr)
+
+           end do !icnd
+
+        end if !cnd_diag_info%l_output_incrm
+
+
+    else ! nver > 1
+
+        !----------------------------------------------------
+        ! prepare input for cam_grid_write_dist_array calls
+        !----------------------------------------------------
+        arry_dims(1) = pcols
+        arry_dims(2) = nver
+        arry_dims(3) = endchunk - begchunk + 1
+
+        file_dims(file_nhdims+1) = nver
+
+        allocate( tmpfield_3d_1(pcols,nver,begchunk:endchunk) )
+        tmpfield_3d_1 = fillvalue
+        
+        !-------------------------------------------------------
+        ! pack field values into tmp arrays and write them out
+        !-------------------------------------------------------
+        if (cnd_diag_info%l_output_state) then
+
+           do icnd = 1,ncnd
+           do ichkpt = 1,nchkpt
+
+              do lchnk = begchunk, endchunk
+                 ncol = chunk_ncols(lchnk)
+                 tmpfield_3d_1(:ncol,:,lchnk) = phys_diag(lchnk)%cnd(icnd)%qoi(iqoi)% val(:ncol,:,ichkpt)
+              end do
+
+              call cam_grid_write_dist_array( File, physgrid, arry_dims(1:3), file_dims(1:file_nhdims+1), &
+                                              tmpfield_3d_1, cnd_qoi_val_desc(ichkpt,icnd,iqoi)            )
+
+           end do
+           end do
+
+        end if !cnd_diag_info%l_output_state
+
+        !-------------------------------------------------------------------
+        ! pack increment and old values into tmp arrays and write them out
+        !-------------------------------------------------------------------
+        if (cnd_diag_info%l_output_incrm) then
+
+           ! increments associated with various checkpoints 
+
+           do icnd = 1,ncnd
+           do ichkpt = 1,nchkpt
+
+              do lchnk = begchunk, endchunk
+                 ncol = chunk_ncols(lchnk)
+                 tmpfield_3d_1(:ncol,:,lchnk) = phys_diag(lchnk)%cnd(icnd)%qoi(iqoi)% inc(:ncol,:,ichkpt)
+              end do
+
+              call cam_grid_write_dist_array( File, physgrid, arry_dims(1:3), file_dims(1:file_nhdims+1), &
+                                              tmpfield_3d_1, cnd_qoi_inc_desc(ichkpt,icnd,iqoi)            )
+
+           end do
+           end do
+
+           ! the "old" values
+
+           do icnd = 1,ncnd
+
+              do lchnk = begchunk, endchunk
+                 ncol = chunk_ncols(lchnk)
+                 tmpfield_3d_1(:ncol,:,lchnk) = phys_diag(lchnk)%cnd(icnd)%qoi(iqoi)% old(:ncol,:)
+              end do
+
+              call cam_grid_write_dist_array( File, physgrid, arry_dims(1:3), file_dims(1:file_nhdims+1), &
+                                              tmpfield_3d_1, cnd_qoi_old_desc(icnd,iqoi)             )
+
+           end do
+
+        end if !cnd_diag_info%l_output_incrm
+
+        !----------
+        ! Clean up
+        !----------
+        deallocate(tmpfield_3d_1)
+
+    end if 
+  end do
+
+  !-------------------------------------------------------------------------
+  ! Done writing variables for restart. Dealocate description info arrays.
+  ! (Question: would it be better to allocate and deallocate at the beginning
+  ! and end of each run instead of each time step?)
+  !-------------------------------------------------------------------------
+  deallocate( cnd_metric_desc )
+  deallocate( cnd_flag_desc )
+
+  if (nqoi>0) then
+     deallocate( cnd_qoi_old_desc )
+     deallocate( cnd_qoi_val_desc )
+     deallocate( cnd_qoi_inc_desc )
+  end if
+ 
+  end subroutine cnd_diag_write_restart
+
+  !======================================================================
+  subroutine cnd_diag_read_restart( phys_diag, begchunk, endchunk,         &! in
+                                    physgrid, file_hdimsizes, file_nhdims, &! in
+                                    pcols, fillvalue, file                 )! in, in, inout 
+  !------------------------------------------------------------------------------------------------
+  ! Purpose: read variables for conditional sampling and budget analysis from restart file
+  ! History: First version by Hui Wan, PNNL, 2021-04
+  !------------------------------------------------------------------------------------------------
+
+  use cam_abortutils,   only: endrun
+  use conditional_diag, only: cnd_diag_info, cnd_diag_t
+  use pio,              only: file_desc_t, io_desc_t, var_desc_t, pio_double, pio_read_darray, pio_inq_varid
+  use cam_grid_support, only: cam_grid_get_decomp, cam_grid_read_dist_array
+  use shr_kind_mod,     only: r8 => shr_kind_r8
+
+  integer, intent(in) :: begchunk, endchunk
+  type(cnd_diag_t),intent(inout) :: phys_diag(begchunk:endchunk)
+
+  integer, intent(in) :: physgrid
+  integer, intent(in) :: file_nhdims                  ! number of horizontal dimensions in restart file 
+  integer, intent(in) :: file_hdimsizes(file_nhdims)  ! horizontal dimension sizes in restart file
+
+  integer, intent(in) :: pcols
+  real(r8),intent(in) :: fillvalue
+
+  type(file_desc_t), intent(inout) :: file
+
+  ! Local variables
+
+  integer :: file_dims(3)   ! dimension sizes in restart file, local variable
+  integer :: arry_dims(3)   ! dimension sizes of array holding values to be read in, local variable
+
+  type(io_desc_t), pointer :: iodesc
+  type(var_desc_t) :: vardesc
+
+  integer :: ierr
+  integer :: lchnk
+  integer :: ncnd, nchkpt, nqoi, icnd, ichkpt, iqoi, nver
+
+  real(r8) :: tmpfield_2d(pcols, begchunk:endchunk)
+  real(r8), allocatable :: tmpfield_3d(:,:,:)
+
+  character(len=256) :: varname  !variable name in restart file
+
+  character(len=*),parameter :: subname = 'cnd_read_init_restart'
+
+  !----------------------------------------
+
+  if (cnd_diag_info%ncnd <= 0 ) return
+
+  !---------------------------------------------------------------
+  ! Gather dimension info and save in local variables
+  !---------------------------------------------------------------
+  ncnd   = cnd_diag_info%ncnd
+  nchkpt = cnd_diag_info%nchkpt
+  nqoi   = cnd_diag_info%nqoi
+
+  file_dims(1:file_nhdims) = file_hdimsizes(1:file_nhdims)
+
+  !-----------------
+  ! metric and flag
+  !-----------------
+  do icnd = 1,ncnd
+
+     nver = cnd_diag_info%metric_nver(icnd)
+
+     if (nver==1) then
+
+        tmpfield_2d = fillvalue
+        !--------------------------------------------
+        ! get iodesc needed by pio_read_darray calls
+        !--------------------------------------------
+        arry_dims(1) = pcols
+        arry_dims(2) = endchunk - begchunk + 1
+
+        call cam_grid_get_decomp(physgrid, arry_dims(1:2), file_hdimsizes(1:file_nhdims), pio_double, iodesc)
+
+        !----------------------------
+        ! read and unpack the metric 
+        !----------------------------
+        write(varname,'(a,i2.2,a)') 'cnd',icnd,'_metric'
+        ierr = pio_inq_varid(File, trim(varname), vardesc)
+        call pio_read_darray(File, vardesc, iodesc, tmpfield_2d, ierr)
+
+        do lchnk = begchunk,endchunk
+           phys_diag(lchnk)%cnd(icnd)% metric(:,1) = tmpfield_2d(:,lchnk)
+        end do
+
+        !----------------------------
+        ! read and unpack the flags
+        !----------------------------
+        write(varname,'(a,i2.2,a)') 'cnd',icnd,'_flag'
+        ierr = pio_inq_varid(File, trim(varname), vardesc)
+        call pio_read_darray(File, vardesc, iodesc, tmpfield_2d, ierr)
+
+        do lchnk = begchunk,endchunk
+           phys_diag(lchnk)%cnd(icnd)% flag(:,1) = tmpfield_2d(:,lchnk)
+        end do
+
+     else ! nver > 1
+
+        !----------------------------------------------------
+        ! prepare input for cam_grid_read_dist_array calls
+        !----------------------------------------------------
+        arry_dims(1) = pcols
+        arry_dims(2) = nver
+        arry_dims(3) = endchunk - begchunk + 1
+
+        file_dims(file_nhdims+1) = nver
+
+        allocate( tmpfield_3d(pcols,nver,begchunk:endchunk) )
+        tmpfield_3d = fillvalue
+        
+        !-------------------------------
+        ! read and unpack metric values 
+        !-------------------------------
+        write(varname,'(a,i2.2,a)') 'cnd',icnd,'_metric'
+        ierr = pio_inq_varid(File, trim(varname), vardesc)
+
+        call cam_grid_read_dist_array(File, physgrid, arry_dims(1:3), file_dims(1:file_nhdims+1), tmpfield_3d, vardesc)
+
+        do lchnk = begchunk, endchunk
+           phys_diag(lchnk)%cnd(icnd)% metric(:,:) = tmpfield_3d(:,:,lchnk)
+        end do
+
+        !-------------------------------
+        ! read and unpack flag values 
+        !-------------------------------
+        write(varname,'(a,i2.2,a)') 'cnd',icnd,'_flag'
+        ierr = pio_inq_varid(File, trim(varname), vardesc)
+
+        call cam_grid_read_dist_array(File, physgrid, arry_dims(1:3), file_dims(1:file_nhdims+1), tmpfield_3d, vardesc)
+
+        do lchnk = begchunk, endchunk
+           phys_diag(lchnk)%cnd(icnd)% flag(:,:) = tmpfield_3d(:,:,lchnk)
+        end do
+
+        !----------
+        ! clean up
+        !----------
+        deallocate(tmpfield_3d)
+
+     end if 
+  end do
+
+  !---------------------------------------------------------
+  ! Conditionally sampled QoIs: "old", snapsots, and "inc"
+  !---------------------------------------------------------
+  do iqoi = 1,nqoi
+
+     nver = cnd_diag_info%qoi_nver_save(iqoi)
+
+     if (nver==1) then
+
+        tmpfield_2d = fillvalue
+
+        !--------------------------------------------
+        ! get iodesc needed by pio_read_darray calls
+        !--------------------------------------------
+        arry_dims(1) = pcols
+        arry_dims(2) = endchunk - begchunk + 1
+ 
+        call cam_grid_get_decomp(physgrid, arry_dims(1:2), file_dims(1:file_nhdims), pio_double, iodesc) ! 4xin, out
+
+        !----------------------------------------------
+        ! read and unpack QoIs at various checkpoints 
+        !----------------------------------------------
+        if (cnd_diag_info%l_output_state) then
+
+           do icnd = 1,ncnd
+           do ichkpt = 1,nchkpt
+
+              write(varname,'(3(a,i2.2))') 'cnd',icnd, '_qoi',iqoi, '_',ichkpt
+              ierr = pio_inq_varid(File, trim(varname), vardesc)
+              call pio_read_darray(File, vardesc, iodesc, tmpfield_2d, ierr)
+
+              do lchnk = begchunk,endchunk
+                 phys_diag(lchnk)%cnd(icnd)%qoi(iqoi)% val(:,1,ichkpt) = tmpfield_2d(:,lchnk)
+              end do
+
+           end do
+           end do
+
+        end if !cnd_diag_info%l_output_state
+
+        !-------------------------------------------
+        ! read and unpack increments and old values 
+        !-------------------------------------------
+        if (cnd_diag_info%l_output_incrm) then
+
+           do icnd = 1,ncnd
+
+              ! increments corresponding to various checkpoints
+
+              do ichkpt = 1,nchkpt
+
+                 write(varname,'(3(a,i2.2))') 'cnd',icnd, '_qoi',iqoi, '_inc',ichkpt
+                 ierr = pio_inq_varid(File, trim(varname), vardesc)
+                 call pio_read_darray(File, vardesc, iodesc, tmpfield_2d, ierr)
+
+                 do lchnk = begchunk,endchunk
+                    phys_diag(lchnk)%cnd(icnd)%qoi(iqoi)% inc(:,1,ichkpt) = tmpfield_2d(:,lchnk)
+                 end do
+
+              end do !ichkpt
+
+              ! the "old" values
+ 
+              write(varname, '(2(a,i2.2),a)') 'cnd',icnd, '_qoi',iqoi, '_old'
+              ierr = pio_inq_varid(File, trim(varname), vardesc)
+              call pio_read_darray(File, vardesc, iodesc, tmpfield_2d, ierr)
+
+              do lchnk = begchunk,endchunk
+                 phys_diag(lchnk)%cnd(icnd)%qoi(iqoi)% old(:,1) = tmpfield_2d(:,lchnk)
+              end do
+
+           end do !icnd
+
+        end if !cnd_diag_info%l_output_incrm
+
+    else ! nver > 1
+
+        !----------------------------------------------------
+        ! prepare input for cam_grid_read_dist_array calls
+        !----------------------------------------------------
+        arry_dims(1) = pcols
+        arry_dims(2) = nver
+        arry_dims(3) = endchunk - begchunk + 1
+
+        file_dims(file_nhdims+1) = nver
+
+        allocate( tmpfield_3d(pcols,nver,begchunk:endchunk) )
+        tmpfield_3d = fillvalue
+        
+        !------------------------------
+        ! read and unpack field values 
+        !------------------------------
+        if (cnd_diag_info%l_output_state) then
+
+           do icnd = 1,ncnd
+           do ichkpt = 1,nchkpt
+
+              write(varname,'(3(a,i2.2))') 'cnd',icnd, '_qoi',iqoi, '_',ichkpt
+              ierr = pio_inq_varid(File, trim(varname), vardesc)
+
+              call cam_grid_read_dist_array(File, physgrid, arry_dims(1:3), file_dims(1:file_nhdims+1), tmpfield_3d, vardesc)
+
+              do lchnk = begchunk,endchunk
+                 phys_diag(lchnk)%cnd(icnd)%qoi(iqoi)% val(:,:,ichkpt) = tmpfield_3d(:,:,lchnk)
+              end do
+
+           end do
+           end do
+
+        end if !cnd_diag_info%l_output_state
+
+        !-------------------------------------------
+        ! read and unpack increments and old values 
+        !-------------------------------------------
+        if (cnd_diag_info%l_output_incrm) then
+
+           ! increments associated with various checkpoints 
+
+           do icnd = 1,ncnd
+           do ichkpt = 1,nchkpt
+
+              write(varname,'(3(a,i2.2))') 'cnd',icnd, '_qoi',iqoi, '_inc',ichkpt
+              ierr = pio_inq_varid(File, trim(varname), vardesc)
+
+              call cam_grid_read_dist_array(File, physgrid, arry_dims(1:3), file_dims(1:file_nhdims+1), tmpfield_3d, vardesc)
+
+              do lchnk = begchunk,endchunk
+                 phys_diag(lchnk)%cnd(icnd)%qoi(iqoi)% inc(:,:,ichkpt) = tmpfield_3d(:,:,lchnk)
+              end do
+
+           end do
+           end do
+
+           ! the "old" values
+
+           do icnd = 1,ncnd
+
+              write(varname, '(2(a,i2.2),a)') 'cnd',icnd, '_qoi',iqoi, '_old'
+              ierr = pio_inq_varid(File, trim(varname), vardesc)
+
+              call cam_grid_read_dist_array(File, physgrid, arry_dims(1:3), file_dims(1:file_nhdims+1), tmpfield_3d, vardesc)
+
+              do lchnk = begchunk,endchunk
+                 phys_diag(lchnk)%cnd(icnd)%qoi(iqoi)% old(:,:) = tmpfield_3d(:,:,lchnk)
+              end do
+
+           end do
+
+        end if !cnd_diag_info%l_output_incrm
+
+        !----------
+        ! Clean up
+        !----------
+        deallocate(tmpfield_3d)
+
+    end if 
+  end do
+ 
+  end subroutine cnd_diag_read_restart
+
+end module conditional_diag_restart

--- a/components/eam/src/physics/cam/misc_diagnostics.F90
+++ b/components/eam/src/physics/cam/misc_diagnostics.F90
@@ -391,7 +391,7 @@ subroutine compute_cape_diags( state, pbuf, pcols, pver, cape_out, dcape_out )
    integer,  pointer :: iptr1d(:)
 
    call pbuf_get_field( pbuf, pbuf_get_index('CAPE_old_dCAPEd'), ptr1d ); ptr1d = 0._r8 
-   call pbuf_get_field( pbuf, pbuf_get_index('Q_mx_old_dCAPEd'), ptr1d ); ptr1d = 5.e-3
+   call pbuf_get_field( pbuf, pbuf_get_index('Q_mx_old_dCAPEd'), ptr1d ); ptr1d = 5.e-3_r8
    call pbuf_get_field( pbuf, pbuf_get_index('T_mx_old_dCAPEd'), ptr1d ); ptr1d = 273._r8
    call pbuf_get_field( pbuf, pbuf_get_index(  'mx_old_dCAPEd'), iptr1d); iptr1d= pver
 

--- a/components/eam/src/physics/cam/misc_diagnostics.F90
+++ b/components/eam/src/physics/cam/misc_diagnostics.F90
@@ -7,7 +7,6 @@ public
 
 contains
 
-
 !------------------------------------------------
 ! saturation specific humidity wrt ice.
 ! The calculation in this subroutine follows 
@@ -156,13 +155,18 @@ subroutine relhum_ice_percent( ncol, pver, tair, pair, qv,  rhi_percent )
 
 end subroutine relhum_ice_percent
 
-subroutine compute_cape( state, pbuf, pcols, pver, cape )
-!----------------------------------------------------------------------
-! Purpose: compute CAPE (convecitve available potential energy)
-!          using subroutine buoyan_dilute from the ZM deep convection
-!          parameterization (module file zm_conv.F90)
-! History: first version by Hui Wan, 2021-05
-!----------------------------------------------------------------------
+subroutine compute_cape_diags( state, pbuf, pcols, pver, cape_out, dcape_out )
+!-------------------------------------------------------------------------------------------
+! Purpose: 
+! - CAPE, the convecitve available potential energy
+! - dCAPE, change in CAPE 
+! - dCAPEe, dCAPE caused by environment change
+! - dCAPEp, dCAPE caused by parcel property change 
+!
+! History: 
+! First version (2021): algorithm by Xiaoliang Song and Guang Zhang; code by Hui Wan.
+! Update to EAMv2 (2022).
+!-------------------------------------------------------------------------------------------
 
   use physics_types,  only: physics_state
   use physics_buffer, only: physics_buffer_desc, pbuf_get_index, pbuf_get_field
@@ -173,15 +177,14 @@ subroutine compute_cape( state, pbuf, pcols, pver, cape )
   type(physics_buffer_desc),pointer    :: pbuf(:)
   integer,                  intent(in) :: pver
   integer,                  intent(in) :: pcols
-  real(r8),                intent(out) :: cape(pcols)
 
-  ! local variables used for providing input to subroutine buoyan_dilute
+  real(r8),                 intent(out) ::  cape_out(pcols)
+  real(r8),optional,        intent(out) :: dcape_out(pcols,3)
+
+  ! local variables used for providing the same input to different calls of subroutine buoyan_dilute
 
   real(r8) :: pmid_in_hPa(pcols,pver)
   real(r8) :: pint_in_hPa(pcols,pver+1)
-
-  real(r8),pointer ::    qv(:,:)
-  real(r8),pointer ::  temp(:,:)
 
   real(r8) ::   zs(pcols)
   real(r8) :: pblt(pcols)
@@ -191,6 +194,23 @@ subroutine compute_cape( state, pbuf, pcols, pver, cape )
 
   integer :: idx, kk, lchnk, ncol, msg
 
+  logical :: iclosure = .true.  ! set to .true. to avoid interference with trig_dcape
+
+  ! variables that distinguish different calls of buoyan_dilute 
+
+  real(r8),pointer ::    qv_new(:,:)  ! new qv   from current state
+  real(r8),pointer ::  temp_new(:,:)  ! new temp from current state
+
+  logical :: use_old_parcel_tq    ! whether or not to use old launching level and parcel T, q when calculating CAPE
+
+  integer  ::    mx_new(pcols)  ! index of launching level in new environment,  calculated by buoyan_dilute
+  real(r8) ::  q_mx_new(pcols)  ! new specific humidity at new launching level, calculated by buoyan_dilute
+  real(r8) ::  t_mx_new(pcols)  ! new temperature       at new launching level, calculated by buoyan_dilute
+
+  integer, pointer ::   mx_old(:)  ! old launching level from pbuf
+  real(r8),pointer :: q_mx_old(:)  ! old qv   at launching level from pbuf
+  real(r8),pointer :: t_mx_old(:)  ! old temp at launching level from pbuf
+
   ! variables returned by buoyan_dilute but not needed here
 
   real(r8) ::   ztp(pcols,pver) ! parcel temperatures.
@@ -199,21 +219,38 @@ subroutine compute_cape( state, pbuf, pcols, pver, cape )
   integer  ::  zlcl(pcols)      ! base level index of deep cumulus convection.
   integer  ::  zlel(pcols)      ! index of highest theoretical convective plume.
   integer  ::  zlon(pcols)      ! index of onset level for deep convection.
-  integer  :: zmaxi(pcols)      ! index of level with largest moist static energy.
+  integer  ::   zmx(pcols)      ! launching level index 
+
+  ! CAPE calculated using different combinations of environmental profiles and parcel properties
+
+  real(r8)         :: cape_new_pcl_new_env(pcols) ! cape in new environment (assuming new launching level and parcel properties) 
+  real(r8)         :: cape_old_pcl_new_env(pcols) ! cape in new environment (assuming old launching level and parcel properties) 
+
+  real(r8),pointer :: cape_old_pcl_old_env(:)     ! cape in old environment (assuming old launching level and parcel proper.
+                                                  ! This variable is a pointer because the values are saved in pbuf
 
   !----------------------------------------------------------------------- 
   ncol  = state%ncol
   lchnk = state%lchnk
 
+  !-----------------------------------------------------------------------------------------
+  ! If diagnosing dCAPE and its decomposition, retrieve old CAPE and old parcel properties 
+  !-----------------------------------------------------------------------------------------
+  if (PRESENT(dcape_out)) then 
+
+    idx = pbuf_get_index('CAPE_old_dCAPEd')  ; call pbuf_get_field( pbuf, idx, cape_old_pcl_old_env )
+    idx = pbuf_get_index('Q_mx_old_dCAPEd')  ; call pbuf_get_field( pbuf, idx, q_mx_old )
+    idx = pbuf_get_index('T_mx_old_dCAPEd')  ; call pbuf_get_field( pbuf, idx, t_mx_old )
+    idx = pbuf_get_index(  'mx_old_dCAPEd')  ; call pbuf_get_field( pbuf, idx,   mx_old )
+
+  end if 
+
+  !-----------------------------------
+  ! Time-independent quantities 
+  !-----------------------------------
   msg = limcnv - 1  ! limcnv is the top interface level limit for convection
 
   idx = pbuf_get_index('tpert') ; call pbuf_get_field( pbuf, idx, tpert )
-
-  pmid_in_hPa(1:ncol,:) = state%pmid(1:ncol,:) * 0.01_r8
-  pint_in_hPa(1:ncol,:) = state%pint(1:ncol,:) * 0.01_r8
-
-  qv   => state%q(:,:,1)
-  temp => state%t
 
   ! Surface elevation (m) is needed to calculate height above sea level (m) 
   ! Note that zm (and zi) stored in state are height above surface. 
@@ -240,19 +277,127 @@ subroutine compute_cape( state, pbuf, pcols, pver, cape )
      pblt(:ncol) = kk
   end do
 
-  !----------------
-  ! Calculate CAPE
-  !----------------
-  call buoyan_dilute(lchnk ,ncol, qv, temp,            &! in
+  !-------------------------------------------------------------------
+  ! Temperature, specific humidity, and pressure in new environment
+  !-------------------------------------------------------------------
+  qv_new   => state%q(:,:,1)
+  temp_new => state%t
+
+  pmid_in_hPa(1:ncol,:) = state%pmid(1:ncol,:) * 0.01_r8
+  pint_in_hPa(1:ncol,:) = state%pint(1:ncol,:) * 0.01_r8
+
+  !------------------------------------------------------------------------
+  ! Calculate CAPE using the new state; also return launching level index
+  ! and T, qv values at (new) launching level
+  !------------------------------------------------------------------------
+  iclosure = .true.
+  call buoyan_dilute(lchnk ,ncol,                      &! in
+                     qv_new, temp_new,                 &! in  !!
                      pmid_in_hPa, zmid_above_sealevel, &! in
                      pint_in_hPa,                      &! in
                      ztp, zqstp, ztl,                  &! out
-                     latvap, cape, pblt,               &! in, out, in
-                     zlcl, zlel, zlon, zmaxi,          &! out
+                     latvap,                           &! in
+                     cape_new_pcl_new_env,             &! out !!
+                     pblt,                             &! in
+                     zlcl, zlel, zlon,                 &! out
+                     mx_new,                           &! out !!
                      rair, gravit, cpair, msg, tpert,  &! in
-                     .true.                            )! in (.t. = std CAPE calculation)
+                     iclosure,                         &! in
+                     use_input_parcel_tq_in = .false., &! in  !!
+                     q_mx = q_mx_new,                  &! out !!
+                     t_mx = t_mx_new                   )! out !!
 
- end subroutine compute_cape
+  cape_out(:ncol) = cape_new_pcl_new_env(:ncol)
+ 
+  !---------------------------------------------------------------------
+  ! If requested output is CAPE only, then we are done. Otherwise,
+  ! diagnose dCAPE and its decomposition (dCAPEe and dCAPEp) 
+  !---------------------------------------------------------------------
+  if (PRESENT(dcape_out)) then 
+
+    !-----------------------------------------------------------------
+    ! dCAPE is the difference between the new CAPE calculated above 
+    ! and the old CAPE retrieved from pbuf
+
+     dcape_out(:ncol,1) = cape_new_pcl_new_env(:ncol) - cape_old_pcl_old_env(:ncol)
+
+    !-----------------------------------------------------------------
+    ! Calculate cape_old_pcl_new_env using
+    !  - new state (T, qv profiles)
+    !  - old launching level and parcel T, qv
+
+    iclosure = .true.
+    call buoyan_dilute(lchnk ,ncol,                      &! in
+                       qv_new, temp_new,                 &! in  !!!
+                       pmid_in_hPa, zmid_above_sealevel, &! in
+                       pint_in_hPa,                      &! in
+                       ztp, zqstp, ztl,                  &! out
+                       latvap,                           &! in
+                       cape_old_pcl_new_env,             &! out !!!
+                       pblt,                             &! in
+                       zlcl, zlel, zlon,                 &! out
+                       zmx,                              &! out 
+                       rair, gravit, cpair, msg, tpert,  &! in
+                       iclosure,                         &! in
+                       dcapemx = mx_old,                 &! in  !!!
+                       use_input_parcel_tq_in = .true.,  &! in  !!!
+                       q_mx = q_mx_old,                  &! in  !!!
+                       t_mx = t_mx_old                   )! in  !!!
+
+    ! dCAPEp = CAPE(new parcel, new env) - CAPE( old parcel, new env)
+    dcape_out(:ncol,2) = cape_new_pcl_new_env(:ncol) - cape_old_pcl_new_env(:ncol)
+
+    ! dCAPEe = CAPE(old parcel, new env) - CAPE( old parcel, old env)
+    dcape_out(:ncol,3) = cape_old_pcl_new_env(:ncol) - cape_old_pcl_old_env(:ncol)
+
+    !-----------------------------------------------------------------
+    ! Update "old" CAPE and parcel properties in pbuf for next call
+
+    cape_old_pcl_old_env(:ncol) = cape_new_pcl_new_env(:ncol)
+
+    t_mx_old(:ncol) = t_mx_new(:ncol)
+    q_mx_old(:ncol) = q_mx_new(:ncol)
+      mx_old(:ncol) =   mx_new(:ncol)
+
+  end if 
+
+ end subroutine compute_cape_diags
+
+ subroutine dcape_diags_register( pcols )
+
+   use physics_buffer, only : pbuf_add_field, dtype_r8, dtype_i4
+
+   integer,intent(in) :: pcols
+   integer :: idx
+
+   call pbuf_add_field('CAPE_old_dCAPEd', 'global', dtype_r8,(/pcols/), idx)
+   call pbuf_add_field(  'mx_old_dCAPEd', 'global', dtype_i4,(/pcols/), idx)
+   call pbuf_add_field('Q_mx_old_dCAPEd', 'global', dtype_r8,(/pcols/), idx)
+   call pbuf_add_field('T_mx_old_dCAPEd', 'global', dtype_r8,(/pcols/), idx)
+
+ end subroutine dcape_diags_register
+
+ subroutine dcape_diags_init( pbuf, state, pver )
+
+   use physics_buffer, only: physics_buffer_desc, pbuf_get_index, pbuf_get_field
+   use physics_types,  only: physics_state
+
+   implicit none
+
+   type(physics_buffer_desc), pointer :: pbuf(:)
+   type(physics_state), intent(in) :: state
+   integer, intent(in) :: pver
+
+   real(r8), pointer ::  ptr2d(:,:)
+   real(r8), pointer ::  ptr1d(:)
+   integer,  pointer :: iptr1d(:)
+
+   call pbuf_get_field( pbuf, pbuf_get_index('CAPE_old_dCAPEd'), ptr1d ); ptr1d = 0._r8 
+   call pbuf_get_field( pbuf, pbuf_get_index('Q_mx_old_dCAPEd'), ptr1d ); ptr1d = state%q(:,pver,1)
+   call pbuf_get_field( pbuf, pbuf_get_index('T_mx_old_dCAPEd'), ptr1d ); ptr1d = state%T(:,pver)
+   call pbuf_get_field( pbuf, pbuf_get_index(  'mx_old_dCAPEd'), iptr1d); iptr1d= pver
+
+ end subroutine dcape_diags_init
 !---------------------------
 
 end module misc_diagnostics

--- a/components/eam/src/physics/cam/misc_diagnostics.F90
+++ b/components/eam/src/physics/cam/misc_diagnostics.F90
@@ -377,15 +377,13 @@ subroutine compute_cape_diags( state, pbuf, pcols, pver, cape_out, dcape_out )
 
  end subroutine dcape_diags_register
 
- subroutine dcape_diags_init( pbuf, state, pver )
+ subroutine dcape_diags_init( pbuf, pver )
 
    use physics_buffer, only: physics_buffer_desc, pbuf_get_index, pbuf_get_field
-   use physics_types,  only: physics_state
 
    implicit none
 
    type(physics_buffer_desc), pointer :: pbuf(:)
-   type(physics_state), intent(in) :: state
    integer, intent(in) :: pver
 
    real(r8), pointer ::  ptr2d(:,:)
@@ -393,8 +391,8 @@ subroutine compute_cape_diags( state, pbuf, pcols, pver, cape_out, dcape_out )
    integer,  pointer :: iptr1d(:)
 
    call pbuf_get_field( pbuf, pbuf_get_index('CAPE_old_dCAPEd'), ptr1d ); ptr1d = 0._r8 
-   call pbuf_get_field( pbuf, pbuf_get_index('Q_mx_old_dCAPEd'), ptr1d ); ptr1d = state%q(:,pver,1)
-   call pbuf_get_field( pbuf, pbuf_get_index('T_mx_old_dCAPEd'), ptr1d ); ptr1d = state%T(:,pver)
+   call pbuf_get_field( pbuf, pbuf_get_index('Q_mx_old_dCAPEd'), ptr1d ); ptr1d = 5.e-3
+   call pbuf_get_field( pbuf, pbuf_get_index('T_mx_old_dCAPEd'), ptr1d ); ptr1d = 273._r8
    call pbuf_get_field( pbuf, pbuf_get_index(  'mx_old_dCAPEd'), iptr1d); iptr1d= pver
 
  end subroutine dcape_diags_init

--- a/components/eam/src/physics/cam/misc_diagnostics.F90
+++ b/components/eam/src/physics/cam/misc_diagnostics.F90
@@ -1,0 +1,258 @@
+module misc_diagnostics
+
+use shr_kind_mod,   only: r8 => shr_kind_r8
+
+implicit none
+public
+
+contains
+
+
+!------------------------------------------------
+! saturation specific humidity wrt ice.
+! The calculation in this subroutine follows 
+! what is used in the model for 
+!  - history output
+!  - ice nucleation parameterization
+! 
+subroutine qsat_ice( ncol, pver, tair, pair, qsati )
+
+  use wv_saturation, only: qsat_water, svp_ice
+
+  integer, intent(in)  :: ncol, pver
+
+  real(r8),intent(in)  :: tair(ncol,pver)
+  real(r8),intent(in)  :: pair(ncol,pver)
+
+  real(r8),intent(out) :: qsati(ncol,pver)
+
+  real(r8) :: qsatw(ncol,pver)
+  real(r8) ::   esl(ncol,pver)
+  real(r8) ::   esi(ncol,pver)
+
+  integer :: i,k
+
+  call qsat_water( tair, pair, esl, qsatw )
+
+  do i=1,ncol
+  do k=1,pver
+     esi(i,k)=svp_ice(tair(i,k))
+  end do
+  end do
+
+  qsati = qsatw*esi/esl
+
+end subroutine qsat_ice
+!----------------------------------
+
+!-----------------------------------------------------------
+! supersaturation wrt water (liquid) given as mixing ratio
+!
+subroutine supersat_q_water( ncol, pver, tair, pair, qv, qssatw )
+
+  use wv_saturation, only: qsat_water
+
+  integer, intent(in)  :: ncol, pver
+
+  real(r8),intent(in)  :: tair(ncol,pver)
+  real(r8),intent(in)  :: pair(ncol,pver)
+  real(r8),intent(in)  ::   qv(ncol,pver)
+
+  real(r8),intent(out) :: qssatw(ncol,pver)
+
+  real(r8) :: qsatw(ncol,pver)
+  real(r8) ::   esl(ncol,pver) !not used
+
+  call qsat_water( tair, pair, esl, qsatw )
+  qssatw = qv-qsatw
+
+end subroutine supersat_q_water
+!----------------------------------
+
+!-----------------------------------------------------------
+! supersaturation wrt ice given as mixing ratio
+!
+subroutine supersat_q_ice( ncol, pver, tair, pair, qv, qssati )
+
+  use wv_saturation, only: qsat_water, svp_ice
+
+  integer, intent(in)  :: ncol, pver
+
+  real(r8),intent(in)  :: tair(ncol,pver)
+  real(r8),intent(in)  :: pair(ncol,pver)
+  real(r8),intent(in)  ::   qv(ncol,pver)
+
+  real(r8),intent(out) :: qssati(ncol,pver)
+
+  real(r8) :: qsatw(ncol,pver)
+  real(r8) ::   esl(ncol,pver)
+  real(r8) ::   esi(ncol,pver)
+
+  integer :: i,k
+
+  call qsat_water( tair, pair, esl, qsatw )
+
+  do i=1,ncol
+  do k=1,pver
+     esi(i,k)=svp_ice(tair(i,k))
+  end do
+  end do
+
+  qssati = qv - qsatw*esi/esl
+
+
+end subroutine supersat_q_ice
+!----------------------------------
+
+subroutine relhum_water_percent( ncol, pver, tair, pair, qv,  rhw_percent )
+
+  use wv_saturation, only: qsat_water
+
+  integer, intent(in)  :: ncol, pver
+
+  real(r8),intent(in)  :: tair(ncol,pver)
+  real(r8),intent(in)  :: pair(ncol,pver)
+  real(r8),intent(in)  ::   qv(ncol,pver)
+
+  real(r8),intent(out) :: rhw_percent(ncol,pver)
+
+  real(r8) :: qsatw(ncol,pver)
+  real(r8) ::   esl(ncol,pver) !not used
+
+  call qsat_water( tair, pair, esl, qsatw )
+  rhw_percent = qv/qsatw*100._r8
+
+end subroutine relhum_water_percent
+
+
+!----------------------------------
+subroutine relhum_ice_percent( ncol, pver, tair, pair, qv,  rhi_percent )
+
+  use wv_saturation, only: qsat_water, svp_ice
+
+  integer, intent(in)  :: ncol, pver
+
+  real(r8),intent(in)  :: tair(ncol,pver)
+  real(r8),intent(in)  :: pair(ncol,pver)
+  real(r8),intent(in)  ::   qv(ncol,pver)
+
+  real(r8),intent(out) :: rhi_percent(ncol,pver)
+
+  real(r8) :: qsatw(ncol,pver)
+  real(r8) ::   esl(ncol,pver)
+  real(r8) ::   esi(ncol,pver)
+
+  integer :: i,k
+
+  call qsat_water( tair, pair, esl, qsatw )
+
+  do i=1,ncol
+  do k=1,pver
+     esi(i,k)=svp_ice(tair(i,k))
+  end do
+  end do
+
+  rhi_percent = 100._r8* qv/qsatw* esl/esi
+
+end subroutine relhum_ice_percent
+
+subroutine compute_cape( state, pbuf, pcols, pver, cape )
+!----------------------------------------------------------------------
+! Purpose: compute CAPE (convecitve available potential energy)
+!          using subroutine buoyan_dilute from the ZM deep convection
+!          parameterization (module file zm_conv.F90)
+! History: first version by Hui Wan, 2021-05
+!----------------------------------------------------------------------
+
+  use physics_types,  only: physics_state
+  use physics_buffer, only: physics_buffer_desc, pbuf_get_index, pbuf_get_field
+  use physconst,      only: cpair, gravit, rair, latvap
+  use zm_conv,        only: buoyan_dilute, limcnv
+
+  type(physics_state),intent(in),target:: state
+  type(physics_buffer_desc),pointer    :: pbuf(:)
+  integer,                  intent(in) :: pver
+  integer,                  intent(in) :: pcols
+  real(r8),                intent(out) :: cape(pcols)
+
+  ! local variables used for providing input to subroutine buoyan_dilute
+
+  real(r8) :: pmid_in_hPa(pcols,pver)
+  real(r8) :: pint_in_hPa(pcols,pver+1)
+
+  real(r8),pointer ::    qv(:,:)
+  real(r8),pointer ::  temp(:,:)
+
+  real(r8) ::   zs(pcols)
+  real(r8) :: pblt(pcols)
+  real(r8) :: zmid_above_sealevel(pcols,pver)
+
+  real(r8),pointer :: tpert(:), pblh(:)
+
+  integer :: idx, kk, lchnk, ncol, msg
+
+  ! variables returned by buoyan_dilute but not needed here
+
+  real(r8) ::   ztp(pcols,pver) ! parcel temperatures.
+  real(r8) :: zqstp(pcols,pver) ! grid slice of parcel temp. saturation mixing ratio.
+  real(r8) ::   ztl(pcols)      ! parcel temperature at lcl.
+  integer  ::  zlcl(pcols)      ! base level index of deep cumulus convection.
+  integer  ::  zlel(pcols)      ! index of highest theoretical convective plume.
+  integer  ::  zlon(pcols)      ! index of onset level for deep convection.
+  integer  :: zmaxi(pcols)      ! index of level with largest moist static energy.
+
+  !----------------------------------------------------------------------- 
+  ncol  = state%ncol
+  lchnk = state%lchnk
+
+  msg = limcnv - 1  ! limcnv is the top interface level limit for convection
+
+  idx = pbuf_get_index('tpert') ; call pbuf_get_field( pbuf, idx, tpert )
+
+  pmid_in_hPa(1:ncol,:) = state%pmid(1:ncol,:) * 0.01_r8
+  pint_in_hPa(1:ncol,:) = state%pint(1:ncol,:) * 0.01_r8
+
+  qv   => state%q(:,:,1)
+  temp => state%t
+
+  ! Surface elevation (m) is needed to calculate height above sea level (m) 
+  ! Note that zm (and zi) stored in state are height above surface. 
+  ! The layer midpoint height provided to buoyan_dilute is height above sea level. 
+
+  zs(1:ncol) = state%phis(1:ncol)/gravit
+
+  !------------------------------------------
+  ! Height above sea level at layer midpoints
+  !------------------------------------------
+  do kk = 1,pver
+     zmid_above_sealevel(1:ncol,kk) = state%zm(1:ncol,kk)+zs(1:ncol)
+  end do
+
+  !--------------------------
+  ! layer index for PBL top
+  !--------------------------
+  idx = pbuf_get_index('pblh')  ; call pbuf_get_field( pbuf, idx, pblh )
+
+  pblt(:) = pver
+  do kk = pver-1, msg+1, -1
+     where( abs(zmid_above_sealevel(:ncol,kk)-zs(:ncol)-pblh(:ncol))   &
+            < (state%zi(:ncol,kk)-state%zi(:ncol,kk+1))*0.5_r8       ) & 
+     pblt(:ncol) = kk
+  end do
+
+  !----------------
+  ! Calculate CAPE
+  !----------------
+  call buoyan_dilute(lchnk ,ncol, qv, temp,            &! in
+                     pmid_in_hPa, zmid_above_sealevel, &! in
+                     pint_in_hPa,                      &! in
+                     ztp, zqstp, ztl,                  &! out
+                     latvap, cape, pblt,               &! in, out, in
+                     zlcl, zlel, zlon, zmaxi,          &! out
+                     rair, gravit, cpair, msg, tpert,  &! in
+                     .true.                            )! in (.t. = std CAPE calculation)
+
+ end subroutine compute_cape
+!---------------------------
+
+end module misc_diagnostics

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -2157,8 +2157,9 @@ subroutine tphysbc (ztodt,               &
     !HuiWan (2014/15): added for a short-term time step convergence test ==
 
     !-----------------------------------------------------------------------
-    call cnd_diag_checkpoint( diag, 'DYNEND', state, pbuf, cam_in, cam_out )
     if (is_first_step()) call dcape_diags_init( pbuf, state, pver )
+
+    call cnd_diag_checkpoint( diag, 'DYNEND', state, pbuf, cam_in, cam_out )
     !-----------------------------------------------------------------------
 
     call phys_getopts( microp_scheme_out      = microp_scheme, &

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -2000,6 +2000,7 @@ subroutine tphysbc (ztodt,               &
     use phys_control,    only: use_qqflx_fixer, use_mass_borrower
     use nudging,         only: Nudge_Model,Nudge_Loc_PhysOut,nudging_calc_tend
     use lnd_infodata,    only: precip_downscaling_method
+    use misc_diagnostics,only: dcape_diags_init
 
     implicit none
 
@@ -2155,6 +2156,10 @@ subroutine tphysbc (ztodt,               &
     logical :: l_rad
     !HuiWan (2014/15): added for a short-term time step convergence test ==
 
+    !-----------------------------------------------------------------------
+    call cnd_diag_checkpoint( diag, 'DYNEND', state, pbuf, cam_in, cam_out )
+    if (is_first_step()) call dcape_diags_init( pbuf, state, pver )
+    !-----------------------------------------------------------------------
 
     call phys_getopts( microp_scheme_out      = microp_scheme, &
                        macrop_scheme_out      = macrop_scheme, &
@@ -2169,8 +2174,6 @@ subroutine tphysbc (ztodt,               &
                       ,l_rad_out              = l_rad              &
                       )
     
-    call cnd_diag_checkpoint( diag, 'DYNEND', state, pbuf, cam_in, cam_out )
-
     !-----------------------------------------------------------------------
     call t_startf('bc_init')
 

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -748,6 +748,7 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
     ! local variables
     integer :: lchnk
     real(r8) :: dp1 = huge(1.0_r8) !set in namelist, assigned in cloud_fraction.F90
+    character(len=16)  :: deep_scheme      ! Default set in phys_control.F90
 
     !-----------------------------------------------------------------------
 
@@ -894,7 +895,9 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
     ! In restart/branch/hybrid runs, these values are read from
     ! the restart file.
 
-    if (is_first_step()) then
+    call phys_getopts( deep_scheme_out   = deep_scheme )
+
+    if (is_first_step() .and. deep_scheme .eq. 'ZM') then
        do lchnk = begchunk, endchunk
           pbuf1d => pbuf_get_chunk(pbuf2d, lchnk)
           call dcape_diags_init( pbuf1d, pver )

--- a/components/eam/src/physics/cam/restart_physics.F90
+++ b/components/eam/src/physics/cam/restart_physics.F90
@@ -51,6 +51,12 @@ module restart_physics
 
     type(var_desc_t) :: cospcnt_desc, rad_randn_seedrst_desc
 
+    type(var_desc_t),allocatable :: cnd_metric_desc(:)
+    type(var_desc_t),allocatable :: cnd_flag_desc(:)
+    type(var_desc_t),allocatable :: cnd_fld_val_desc(:,:,:)
+    type(var_desc_t),allocatable :: cnd_fld_inc_desc(:,:,:)
+    type(var_desc_t),allocatable :: cnd_fld_old_desc(:,:)
+
   CONTAINS
     subroutine init_restart_physics ( File, pbuf2d)
       
@@ -68,6 +74,7 @@ module restart_physics
     use subcol_utils,        only: is_subcol_on
     use subcol,              only: subcol_init_restart
     use phys_control,        only: phys_getopts
+    use conditional_diag_restart, only: cnd_diag_init_restart
 
     type(file_desc_t), intent(inout) :: file
     type(physics_buffer_desc), pointer :: pbuf2d(:,:)
@@ -104,6 +111,12 @@ module restart_physics
 
     call pbuf_init_restart(File, pbuf2d)
 
+    ! CondiDiag
+    call cnd_diag_init_restart( dimids, hdimcnt, pver, pver_id, pverp_id,            &! in
+                                File, cnd_metric_desc,  cnd_flag_desc,               &! inout
+                                cnd_fld_val_desc, cnd_fld_old_desc, cnd_fld_inc_desc )! inout
+
+    !-----
     if ( .not. adiabatic .and. .not. ideal_phys )then
        
        call chem_init_restart(File)
@@ -173,7 +186,7 @@ module restart_physics
       
   end subroutine init_restart_physics
 
-  subroutine write_restart_physics (File, cam_in, cam_out, pbuf2d)
+  subroutine write_restart_physics (File, cam_in, cam_out, pbuf2d, phys_diag)
 
       !-----------------------------------------------------------------------
       use physics_buffer,      only: physics_buffer_desc, pbuf_write_restart
@@ -194,6 +207,8 @@ module restart_physics
       use pio,                 only: pio_write_darray
       use subcol_utils,        only: is_subcol_on
       use subcol,              only: subcol_write_restart
+      use conditional_diag,    only: cnd_diag_t
+      use conditional_diag_restart, only: cnd_diag_write_restart
       !
       ! Input arguments
       !
@@ -201,6 +216,7 @@ module restart_physics
       type(cam_in_t),    intent(in)    :: cam_in(begchunk:endchunk)
       type(cam_out_t),   intent(in)    :: cam_out(begchunk:endchunk)
       type(physics_buffer_desc), pointer        :: pbuf2d(:,:)
+      type(cnd_diag_t),          intent(in)     :: phys_diag(begchunk:endchunk)
       !
       ! Local workspace
       !
@@ -213,6 +229,8 @@ module restart_physics
       integer :: physgrid
       integer :: dims(3), gdims(3)
       integer :: nhdims
+      integer :: lchnk
+      integer :: chunk_ncols(begchunk:endchunk)
       !-----------------------------------------------------------------------
 
       ! Write grid vars
@@ -231,6 +249,21 @@ module restart_physics
 
       physgrid = cam_grid_id('physgrid')
       call cam_grid_dimensions(physgrid, gdims(1:2), nhdims)
+
+      !---------------------------------------
+      ! CondiDiag
+
+      do lchnk = begchunk,endchunk
+         chunk_ncols(lchnk) = cam_out(lchnk)%ncol
+      end do
+
+      call cnd_diag_write_restart( phys_diag, begchunk, endchunk,        &! in
+                                   physgrid, gdims(1:nhdims), nhdims,    &! in
+                                   pcols, chunk_ncols, fillvalue,        &! in
+                                   File, cnd_metric_desc, cnd_flag_desc, &!  inout
+                                   cnd_fld_val_desc, cnd_fld_inc_desc,   &!  inout
+                                   cnd_fld_old_desc                      )
+      !------
 
       if ( .not. adiabatic .and. .not. ideal_phys )then
 
@@ -420,7 +453,7 @@ module restart_physics
 
 !#######################################################################
 
-    subroutine read_restart_physics(File, cam_in, cam_out, pbuf2d)
+    subroutine read_restart_physics(File, cam_in, cam_out, pbuf2d, phys_diag)
 
      !-----------------------------------------------------------------------
      use physics_buffer,      only: physics_buffer_desc, pbuf_read_restart
@@ -438,6 +471,8 @@ module restart_physics
      use subcol_utils,        only: is_subcol_on
      use subcol,              only: subcol_read_restart
      use pio,                 only: pio_read_darray
+     use conditional_diag,    only: cnd_diag_t
+     use conditional_diag_restart, only: cnd_diag_read_restart
      !
      ! Arguments
      !
@@ -445,6 +480,7 @@ module restart_physics
      type(cam_in_t),            pointer :: cam_in(:)
      type(cam_out_t),           pointer :: cam_out(:)
      type(physics_buffer_desc), pointer :: pbuf2d(:,:)
+     type(cnd_diag_t),          pointer :: phys_diag(:)
      !
      ! Local workspace
      !
@@ -475,6 +511,9 @@ module restart_physics
      call pbuf_read_restart(File, pbuf2d)
      call t_stopf("pbuf_read_restart")
 
+     !-------------------------------
+     ! grid and dimension sizes
+     !-------------------------------
      csize=endchunk-begchunk+1
      dims(1) = pcols
      dims(2) = csize
@@ -491,6 +530,17 @@ module restart_physics
      
      call cam_grid_get_decomp(physgrid, dims(1:2), gdims(1:nhdims), pio_double, &
           iodesc)
+
+     !-----------------------------------------------------------------------
+     ! CondiDiag
+     !-----------------------------------------------------------------------
+     call cnd_diag_read_restart( phys_diag, begchunk, endchunk,     &! in
+                                 physgrid, gdims(1:nhdims), nhdims, &! in
+                                 pcols, fillvalue, File             )! inout
+
+     !-----------------------------------------------------------------------
+     ! Miscellaneous fields
+     !-----------------------------------------------------------------------
      if ( .not. adiabatic .and. .not. ideal_phys )then
 
         ! data for chemistry

--- a/components/eam/src/physics/cam/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm_conv.F90
@@ -72,12 +72,6 @@ module zm_conv
    logical :: trig_dcape_only  = .false. !true to use DCAPE trigger, ULL not used
    logical :: trig_ull_only    = .false. !true to use ULL along with default CAPE-based trigger
 
-!!!---
-!!!   integer, allocatable :: dcapemx(:) ! save maxi from 1st call for CAPE calculation and used in 2nd call when DCAPE-ULL active
-!!!!  May need to change to use local variable !  as passed via dummy argument. For now, making it threadprivate as follows,
-!!!!$omp threadprivate (dcapemx)
-!!!---
-
    real(r8) :: ke           ! Tunable evaporation efficiency set from namelist input zmconv_ke
    real(r8) :: c0_lnd       ! set from namelist input zmconv_c0_lnd
    real(r8) :: c0_ocn       ! set from namelist input zmconv_c0_ocn
@@ -104,7 +98,7 @@ module zm_conv
    real(r8) :: grav        ! = gravit
    real(r8) :: cp          ! = cpres = cpair
    
-   integer  limcnv       ! top interface level limit for convection
+   integer,protected ::  limcnv   ! top interface level limit for convection
 
    real(r8) :: tp_fac = unset_r8  ! PMA tunes tpert 
 
@@ -655,10 +649,6 @@ subroutine zm_convr(lchnk   ,ncol    , &
                   tpert   ,iclosure                            )  ! in
          
       if (trigdcape_ull .or. trig_dcape_only) then
-!!!         if (.not. allocated(dcapemx)) then
-!!!            allocate (dcapemx(pcols), stat=ierror)
-!!!            if ( ierror /= 0 ) call endrun('ZM_CONVR error: allocation error dcapemx')
-!!!         endif
          dcapemx(:ncol) = maxi(:ncol)
       endif
 

--- a/components/eam/src/physics/cam/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm_conv.F90
@@ -38,7 +38,11 @@ module zm_conv
   public trigdcape_ull            ! true if to use dcape-ULL trigger
   public trig_dcape_only          ! true if to use dcape only trigger
   public trig_ull_only            ! true if to ULL along with default CAPE-based trigger
-
+  public buoyan_dilute            ! subroutine that calculates CAPE
+!
+! PUBLIC: data
+!
+  public limcnv                   ! top interface level limit for convection
 !
 ! Private data
 !

--- a/components/eam/src/physics/cam/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm_conv.F90
@@ -3243,7 +3243,7 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
 
 ! DCAPE-ULL
    real(r8) pblt600(pcols)
-
+   integer top_k(pcols)
 
    real(r8) e
    integer i
@@ -3300,9 +3300,22 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
 
 ! DCAPE-ULL
   if ((trigdcape_ull .or. trig_dcape_only ).and. (.not. iclosure)) then
+  !------------------------------------------------------
+  ! Use max moist static energy level that is passed in
+  !------------------------------------------------------
      if (.not.PRESENT(dcapemx)) call endrun('** ZM CONV buoyan_dilute: dcapemx not present **')
      mx(:ncol) = dcapemx(:ncol)
+
   else
+  !----------------------------------------------
+  ! Search for max moist static energy level
+  !----------------------------------------------
+   if (trigdcape_ull .or. trig_ull_only) then !DCAPE-ULL
+      top_k(:ncol) = nint(pblt600(:ncol))
+   else
+      top_k(:ncol) = nint(pblt(:ncol))
+   end if
+
 #ifdef PERGRO
    do k = bot_layer,msg + 1,-1
       do i = 1,ncol
@@ -3312,18 +3325,11 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
 !
          rhd = (hmn(i) - hmax(i))/(hmn(i) + hmax(i))
 
-         !DCAPE-ULL
-         if (trigdcape_ull .or. trig_ull_only) then
-           if (k >= nint(pblt600(i)) .and. k <= lon(i) .and. rhd > -1.e-4_r8) then
+           if (k >= top_k(i) .and. k <= lon(i) .and. rhd > -1.e-4_r8) then
               hmax(i) = hmn(i)
               mx(i) = k
            end if
-         else
-           if (k >= nint(pblt(i)) .and. k <= lon(i) .and. rhd > -1.e-4_r8) then
-              hmax(i) = hmn(i)
-              mx(i) = k
-           end if
-         end if
+
       end do
    end do
 #else
@@ -3331,18 +3337,11 @@ subroutine buoyan_dilute(lchnk   ,ncol    , &
       do i = 1,ncol
          hmn(i) = cp*t(i,k) + grav*z(i,k) + rl*q(i,k)
 
-         !DCAPE-ULL
-         if (trigdcape_ull .or. trig_ull_only) then
-            if (k >= nint(pblt600(i)) .and. k <= lon(i) .and. hmn(i) > hmax(i)) then
+            if (k >= top_k(i) .and. k <= lon(i) .and. hmn(i) > hmax(i)) then
                hmax(i) = hmn(i)
                mx(i) = k
             end if
-         else
-           if (k >= nint(pblt(i)) .and. k <= lon(i) .and. hmn(i) > hmax(i)) then
-              hmax(i) = hmn(i)
-              mx(i) = k
-           end if
-         end if
+
       end do
    end do
 #endif

--- a/components/eam/src/physics/cam/zm_conv_intr.F90
+++ b/components/eam/src/physics/cam/zm_conv_intr.F90
@@ -65,6 +65,7 @@ subroutine zm_conv_register
 !----------------------------------------
 
   use physics_buffer, only : pbuf_add_field, dtype_r8
+  use misc_diagnostics,only: dcape_diags_register
 
   implicit none
 
@@ -91,6 +92,10 @@ subroutine zm_conv_register
     ! moisturetendency from physics in n-1 time step 
     call pbuf_add_field('Q_STAR','global',dtype_r8,(/pcols,pver/), q_star_idx)
    endif
+
+! Variables for dCAPE diagnosis and decomposition
+
+   call dcape_diags_register( pcols )
 
 end subroutine zm_conv_register
 


### PR DESCRIPTION
CondiDiag is an online diagnostics capability in EAM. It is turned off by default and turned on via namelist variables. Either way, the simulation results remain BFB.

Summary of "superBFB" tests conducted so far:
- the `e3sm_atm_developer` test suite including comparison with baseline, with CondiDiag turned off by default,
- a new `eam_condidiag` test suite with CondiDiag turned on, including 
   - two `ERP` tests,
   - a comparison between `SMS_D` tests with CondiDiag on or off.

All tests passed on Compy, Cori, and Perlmutter.

Please see [this Confluence page](https://acme-climate.atlassian.net/wiki/spaces/NGDAP/pages/3691741185/CondiDiag1.1+integration) for
- more detailed notes on the "superBFB" tests,
- links to PACE results, and
- feature overview.
