### PR TITLE
Remove interface assignment and copy_par subroutine to simplify

### DIFF
--- a/components/homme/src/share/parallel_mod.F90
+++ b/components/homme/src/share/parallel_mod.F90
@@ -52,9 +52,6 @@ module parallel_mod
     integer :: root                       ! local root
     integer :: nprocs                     ! number of processes in group
     integer :: comm                       ! local communicator
-!    integer :: node_comm                  ! local communicator of all procs per node
-!    integer :: node_rank                  ! local rank in node_comm
-!    integer :: node_nprocs                ! local rank in node_comm
     logical :: masterproc                
     logical :: dynproc                    ! Designation of a dynamics processor - AaronDonahue
   end type
@@ -69,13 +66,6 @@ module parallel_mod
   ! ===================================================
   ! Module Interfaces
   ! ===================================================
-
-  interface assignment ( = )
-    module procedure copy_par
-  end interface
-
-
-
   public :: initmp
   public :: initmp_from_par
   public :: init_par
@@ -86,25 +76,6 @@ module parallel_mod
   public :: pmax_1d,pmin_1d
 
 contains
-
-! ================================================
-!   copy_par: copy constructor for parallel_t type
-!
-!
-!   Overload assignment operator for parallel_t
-! ================================================
-
-  subroutine copy_par(par2,par1)
-    type(parallel_t), intent(out) :: par2
-    type(parallel_t), intent(in)  :: par1
-
-    par2%rank       = par1%rank
-    par2%root       = par1%root
-    par2%nprocs     = par1%nprocs
-    par2%comm       = par1%comm
-    par2%masterproc = par1%masterproc
-
-  end subroutine copy_par
 
 ! ================================================
 !  initmp:
@@ -124,12 +95,14 @@ contains
     integer(kind=int_kind)                              :: ierr
     logical :: running   ! state of MPI at beginning of initmp call
 #ifdef CAM
-    integer :: color = 1
+    integer :: color
     integer :: iam_cam, npes_cam
     integer :: npes_homme
     integer :: max_stride
 #endif
-    integer :: npes_cam_stride = 1
+    integer :: npes_cam_stride
+    color=1
+    npes_cam_stride=1
     !================================================
     !     Basic MPI initialization
     ! ================================================

--- a/components/homme/src/share/parallel_mod.F90
+++ b/components/homme/src/share/parallel_mod.F90
@@ -101,7 +101,9 @@ contains
     integer :: max_stride
 #endif
     integer :: npes_cam_stride
+#ifdef CAM
     color=1
+#endif
     npes_cam_stride=1
     !================================================
     !     Basic MPI initialization


### PR DESCRIPTION
Remove interface assignment and copy_par subroutine as we where not using it anyway.
The nvidia/22.7 compiler was getting confused -- ie, we believe nvidia/22.7 and 22.9 on pm-cpu was doing
something wrong here, but it did point to an issue in the code, which is that because we were not
`include`ing the assignment interface, it was not being used. Which means the default assignment
operation is working fine for this simple data struct and we are confident in removing it.

Note that pm-cpu currently uses nvidia/22.5, which does *not* have this problem. After this PR, I will upgrade to nvidia/22.7.

Unrelated: be more careful about setting initial values for 2 integers in routine.
Example: integer :: ikool=4 is dangerous as we may expect it to be set each entry, but instead, I think it's only set on the first call. Which is fine here as it's only called once, just being more careful.


Fixes https://github.com/E3SM-Project/E3SM/issues/5353
[bfb]