### PR TITLE
Ocean bugfix to allow users to disable tracer tendencies with RK4 time integrator

### DIFF
--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -1004,6 +1004,8 @@ module ocn_time_integration_rk4
       integer, pointer :: nEdges, nVertLevels
       err = 0
 
+      if (config_disable_tr_all_tend) return
+
       call mpas_pool_get_config(block % configs, 'config_filter_btr_mode', config_filter_btr_mode)
 
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -92,7 +92,7 @@ module ocn_time_integration_rk4
       type (domain_type), intent(inout) :: domain !< Input/Output: domain information
       real (kind=RKIND), intent(in) :: dt !< Input: timestep
 
-      integer :: iCell, iEdge, k, i, err
+      integer :: iCell, iEdge, iTracer, k, i, err, num_tracers
       type (block_type), pointer :: block
 
       type (mpas_pool_type), pointer :: tendPool
@@ -121,7 +121,7 @@ module ocn_time_integration_rk4
         vertViscTopOfEdge, vertDiffTopOfCell
 
       ! Dimensions
-      integer, pointer :: nCells, nEdges, nVertLevels, num_tracers
+      integer, pointer :: nCells, nEdges, nVertLevels
 
       ! Config options
       logical, pointer :: config_prescribe_velocity, config_prescribe_thickness
@@ -192,7 +192,7 @@ module ocn_time_integration_rk4
       real (kind=RKIND), dimension(:), pointer :: &
         frazilSurfacePressure, landIcePressure, landIceDraft
 
-      real (kind=RKIND), dimension(:,:,:), pointer :: activeTracersNew
+      real (kind=RKIND), dimension(:,:,:), pointer :: activeTracersCur, activeTracersNew
 
       ! Get config options
       call mpas_pool_get_config(domain % configs, 'config_mom_del4', config_mom_del4)
@@ -655,6 +655,7 @@ module ocn_time_integration_rk4
          call mpas_pool_get_array(forcingPool, 'tidalInputMask', tidalInputMask)
          call mpas_pool_get_array(forcingPool, 'tidalBCValue', tidalBCValue)
 
+         call mpas_pool_get_array(tracersPool, 'activeTracers',activeTracersCur, 1)
          call mpas_pool_get_array(tracersPool, 'activeTracers',activeTracersNew, 2)
 
          if (config_prescribe_velocity) then
@@ -665,6 +666,19 @@ module ocn_time_integration_rk4
             end do
             !$omp end do
             !$omp end parallel
+         end if
+
+         if (config_disable_tr_all_tend) then
+            num_tracers = size(activeTracersNew, dim=2)
+            do iTracer = 1, num_tracers
+               !$omp parallel
+               !$omp do schedule(runtime)
+               do iCell = 1, nCells
+                  activeTracersNew(iTracer, :, iCell) = activeTracersCur(iTracer, :, iCell)
+               end do
+               !$omp end do
+               !$omp end parallel
+            end do
          end if
 
          if (config_prescribe_thickness) then


### PR DESCRIPTION
This PR provides a fix to https://github.com/E3SM-Project/E3SM/issues/5518. In the case where `config_disable_tr_all_tend = .true.` and `config_time_integrator = 'RK4'`:

1. We enforce no time updates to active tracers (https://github.com/E3SM-Project/E3SM/commit/b4e9ec1096a9f33a931ae48be6b7afb7e3b4b306). 
2. We also completely bypass the RK4 tracer tendency update (as opposed to just the update within `ocn_tend_tracer`), which saves a little time (https://github.com/E3SM-Project/E3SM/commit/b4e9ec1096a9f33a931ae48be6b7afb7e3b4b306). 

In principle, only (2) would be needed, but we find that there is contamination of the tracer fields without (1) that leads to model crashes.

We find that after these changes, model runtimes are still ~30% faster when tracers are disabled.

[BFB]