### PR TITLE
Removed ice pressure as a daily average output for V3

### DIFF
--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -719,7 +719,6 @@ def buildnml(case, caseroot, compname):
             lines.append('    <var name="snowVolumeCell"/>')
             lines.append('    <var name="uVelocityGeo"/>')
             lines.append('    <var name="vVelocityGeo"/>')
-            lines.append('    <var name="icePressure"/>')
             lines.append('</stream>')
             lines.append('')
             lines.append('<stream name="timeSeriesStatsDailyRestart"')


### PR DESCRIPTION
Removes the field of icePressure from daily output fields for V3, which is still included in monthly averages in the sea ice model history. No one appears to have analyzed this daily field for V2, it can still be switched on for particular simulations, and removing it from the default output will roughly reduce sea ice history output by 12%. The change has been tested in a D-case, which compiles and runs successfully.

[BFB]