### PR TITLE
Move batching directives to the top of batching templates

### DIFF
--- a/cime_config/machines/template.case.run
+++ b/cime_config/machines/template.case.run
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-
-# Batch system directives
 {{ batchdirectives }}
 
 """

--- a/cime_config/machines/template.case.run.sh
+++ b/cime_config/machines/template.case.run.sh
@@ -1,6 +1,4 @@
 #!/bin/bash -e
-
-# Batch system directives
 {{ batchdirectives }}
 
 # template to create a case run shell script. This should only ever be called

--- a/cime_config/machines/template.ocn_diagnostics
+++ b/cime_config/machines/template.ocn_diagnostics
@@ -1,4 +1,6 @@
 #! /usr/bin/env bash
+{{ batchdirectives }}
+
 #
 # template.diags_generate used to create the $CASEROOT/$CASE.ocn_diagnostics
 #
@@ -6,9 +8,6 @@
 # for the specified machine
 # <ocn_diags_pes>##</ocn_diags_pes>
 #
-
-{{ batchdirectives }}
-
 mpirun={{ mpirun }}
 
 # xmlquery to get POSTPROCESS_VIRTUALENV, BATCHSUBMIT variable settings

--- a/cime_config/machines/template.st_archive
+++ b/cime_config/machines/template.st_archive
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# Batch system directives
 {{ batchdirectives }}
 
 """

--- a/cime_config/machines/template.timeseries
+++ b/cime_config/machines/template.timeseries
@@ -1,4 +1,6 @@
 #! /usr/bin/env bash
+{_batchdirectives_}
+
 #
 # template.tseries_generate used to create the $CASEROOT/$CASE.timeseries
 #
@@ -6,9 +8,6 @@
 # for the specified machine
 # <timeseries_pes>##</timeseries_pes>
 #
-
-{_batchdirectives_}
-
 mpirun={_mpirun_}
 
 # xmlquery to get POSTPROCESS_VIRTUALENV, BATCHSUBMIT variable settings


### PR DESCRIPTION
This is needed for machines with Cobalt job scheduler, which needs `#COBALT -n {{ num_nodes }}` right after the first line of the batch script.