### PR TITLE
For pm-cpu,pm-gpu,alvarez, update to the default nvidia 22.7 compiler

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -210,7 +210,7 @@
 
       <modules compiler="nvidia">
         <command name="load">PrgEnv-nvidia</command>
-        <command name="load">nvidia/22.5</command>
+        <command name="load">nvidia/22.7</command>
       </modules>
 
       <modules compiler="amdclang">
@@ -330,7 +330,7 @@
 
       <modules compiler="nvidia.*">
         <command name="load">PrgEnv-nvidia</command>
-        <command name="load">nvidia/22.5</command>
+        <command name="load">nvidia/22.7</command>
       </modules>
 
       <modules compiler="gnugpu">
@@ -459,7 +459,7 @@
 
       <modules compiler="nvidia">
         <command name="load">PrgEnv-nvidia</command>
-        <command name="load">nvidia/22.5</command>
+        <command name="load">nvidia/22.7</command>
       </modules>
 
       <modules compiler="amdclang">


### PR DESCRIPTION
For pm-cpu,pm-gpu,alvarez, update to the default nvidia 22.7 compiler version from 22.5.

Fixes https://github.com/E3SM-Project/E3SM/issues/5351

Will not be bfb.
