### PR TITLE
Adding SCORPIO build and post processing scripts

### DIFF
--- a/cime_config/config_files.xml
+++ b/cime_config/config_files.xml
@@ -536,7 +536,7 @@
       <value lib="kokkos">$SRCROOT/share/build/buildlib.kokkos</value>
       <value lib="gptl">$SRCROOT/share/build/buildlib.gptl</value>
       <value lib="pio">$CIMEROOT/CIME/build_scripts/buildlib.pio</value>
-      <value lib="spio">$CIMEROOT/CIME/build_scripts/buildlib.spio</value>
+      <value lib="spio">$SRCROOT/share/build/buildlib.spio</value>
       <value lib="mct">$CIMEROOT/CIME/build_scripts/buildlib.mct</value>
       <value lib="csm_share">$SRCROOT/share/build/buildlib.csm_share</value>
       <value lib="mpi-serial">$CIMEROOT/CIME/build_scripts/buildlib.mpi-serial</value>

--- a/cime_config/customize/case_post_run_io.py
+++ b/cime_config/customize/case_post_run_io.py
@@ -1,6 +1,5 @@
 """
 Post run I/O processing
-case_post_run_io is a member of class Case from file case.py
 """
 import os
 from CIME.XML.standard_module_setup import *

--- a/cime_config/customize/case_post_run_io.py
+++ b/cime_config/customize/case_post_run_io.py
@@ -1,0 +1,113 @@
+"""
+Post run I/O processing
+case_post_run_io is a member of class Case from file case.py
+"""
+import os
+from CIME.XML.standard_module_setup import *
+from CIME.utils                     import new_lid, run_and_log_case_status
+
+logger = logging.getLogger(__name__)
+
+###############################################################################
+def _convert_adios_to_nc(case):
+###############################################################################
+    """
+    Converts all ADIOS output files for the case to NetCDF format
+    """
+    env_mach_specific = case.get_env('mach_specific')
+  
+    # Create the ADIOS convertion tool command,
+    # "<EXEROOT>/adios2pio-nm.exe --idir=<RUNDIR>"
+    # The command converts all ADIOS BP files in <RUNDIR> to
+    # NetCDF files
+
+    # The ADIOS conversion tool is installed in EXEROOT
+    exeroot = case.get_value("EXEROOT")
+    adios_conv_tool_name = "adios2pio-nm.exe"
+    adios_conv_tool_exe = os.path.join(exeroot, adios_conv_tool_name)
+
+    # The ADIOS output files should be in RUNDIR
+    rundir = case.get_value("RUNDIR")
+
+    adios_conv_tool_args = "--idir=" + rundir
+    adios_conv_tool_cmd = adios_conv_tool_exe + " " + adios_conv_tool_args
+
+    # Replace logfile name, "e3sm.log.*" with "e3sm_adios_post_io.log.*"
+    # The logfile name is part of the run command suffix
+    adios_conv_tool_cmd_suffix = env_mach_specific.get_value("run_misc_suffix")
+    adios_conv_tool_cmd_suffix = adios_conv_tool_cmd_suffix.replace(
+                                  "e3sm.log", "e3sm_adios_post_io.log")
+
+    is_batch = case.get_value("BATCH_SYSTEM")
+
+    # Set up the LID (used as unique id for log names etc via $LID)
+    lid = new_lid(case=case)
+
+    # For batch jobs the number of nodes/processes for post processing need
+    # to be determined before the post run job is launched
+    # (i.e., via config_workflow.xml)
+    if is_batch == "none":
+      # Reset the total number of tasks to 1/4th for the conversion job
+      CONV_JOB_SCALE_FACTOR = 1.0/4.0
+      CONV_JOB_MIN_TOTAL_TASKS = 1
+      CONV_JOB_MAX_TOTAL_TASKS = 1024
+      env_mach_pes = case.get_env("mach_pes")
+      case.thread_count = 1
+      case.total_tasks = max(min(int(case.total_tasks * CONV_JOB_SCALE_FACTOR), CONV_JOB_MAX_TOTAL_TASKS), CONV_JOB_MIN_TOTAL_TASKS)
+      case.cores_per_task = 1
+      case.tasks_per_node = env_mach_pes.get_tasks_per_node(case.total_tasks, case.thread_count)
+      case.num_nodes, case.spare_nodes = env_mach_pes.get_total_nodes(case.total_tasks, case.thread_count)
+      case.num_nodes += case.spare_nodes
+
+    # Get the current mpirun command (for e3sm.exe)
+    cmd = case.get_mpirun_cmd(allow_unresolved_envvars=False)
+
+    # Create mpirun command for the ADIOS conversion tool
+    # Replace run_exe and run_misc_suffix in mpirun command
+    # with ADIOS convertion tool command and suffix
+    run_exe = env_mach_specific.get_value("run_exe", resolved=True)
+    run_exe = case.get_resolved_value(run_exe);
+    run_misc_suffix = env_mach_specific.get_value("run_misc_suffix")
+    cmd = cmd.replace(run_exe, adios_conv_tool_cmd)
+    cmd = cmd.replace(run_misc_suffix, adios_conv_tool_cmd_suffix)
+    logger.info("Run command for ADIOS post processing is : {}".format(cmd))
+
+    # Load the environment
+    case.load_env(reset=True)
+
+    run_func = lambda: run_cmd(cmd, from_dir=rundir)[0]
+
+    # Run the modified case
+    success = run_and_log_case_status(run_func,
+                "ADIOS to NetCDF conversion",
+                caseroot=case.get_value("CASEROOT"),
+                is_batch=(is_batch != "none"))
+
+    return success
+
+###############################################################################
+def case_post_run_io(self):
+###############################################################################
+    """
+    I/O Post processing :
+    1. Convert ADIOS output files, if any, to NetCDF
+    """
+    success = True
+    has_adios = False
+    self.load_env(job="case.post_run_io")
+    component_classes = self.get_values("COMP_CLASSES")
+    # Check if user chose "adios" as the iotype for any component
+    for compclass in component_classes:
+        key = "PIO_TYPENAME_{}".format(compclass)
+        pio_typename = self.get_value(key)
+        if pio_typename == "adios":
+            has_adios = True
+            break
+    if has_adios:
+        logger.info("I/O post processing for ADIOS starting")
+        success = _convert_adios_to_nc(self)
+        logger.info("I/O post processing for ADIOS completed")
+    else:
+        logger.info("No I/O post processing required")
+
+    return success

--- a/cime_config/machines/config_workflow.xml
+++ b/cime_config/machines/config_workflow.xml
@@ -37,10 +37,27 @@
       <template>template.case.test</template>
       <prereq>$BUILD_COMPLETE and $TEST</prereq>
     </job>
+    <job name="case.post_run_io">
+      <template>template.post_run_io</template>
+      <dependency>case.run</dependency>
+      <prereq>case.get_value("PIO_TYPENAME_ATM") == 'adios' or \
+              case.get_value("PIO_TYPENAME_CPL") == 'adios' or \
+              case.get_value("PIO_TYPENAME_OCN") == 'adios' or \
+              case.get_value("PIO_TYPENAME_WAV") == 'adios' or \
+              case.get_value("PIO_TYPENAME_GLC") == 'adios' or \
+              case.get_value("PIO_TYPENAME_ICE") == 'adios' or \
+              case.get_value("PIO_TYPENAME_ROF") == 'adios' or \
+              case.get_value("PIO_TYPENAME_LND") == 'adios' or \
+              case.get_value("PIO_TYPENAME_ESP") == 'adios' or \
+              case.get_value("PIO_TYPENAME_IAC") == 'adios'</prereq>
+      <runtime_parameters>
+        <walltime>0:30:00</walltime>
+      </runtime_parameters>
+    </job>
     <job name="case.st_archive">
       <template>template.st_archive</template>
       <!-- If DOUT_S is true and case.run (or case.test) exits successfully then run st_archive-->
-      <dependency>case.run or case.test</dependency>
+      <dependency>(case.run and case.post_run_io) or case.test</dependency>
       <prereq>$DOUT_S</prereq>
       <runtime_parameters>
 	<task_count>1</task_count>

--- a/cime_config/machines/template.post_run_io
+++ b/cime_config/machines/template.post_run_io
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-
-# Batch system directives
 {{ batchdirectives }}
 
 """

--- a/cime_config/machines/template.post_run_io
+++ b/cime_config/machines/template.post_run_io
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+# Batch system directives
+{{ batchdirectives }}
+
+"""
+template to create a case post run script for I/O post processing.
+
+This should only ever be called by case.submit when on batch system. This script only exists as a way of providing batch directives. Use case.submit from the command line to run your case.
+
+DO NOT RUN THIS SCRIPT MANUALLY
+"""
+
+import os, sys
+os.chdir( '{{ caseroot }}')
+
+_LIBDIR = os.path.join("{{ cimeroot }}", "scripts", "Tools")
+sys.path.append(_LIBDIR)
+
+from standard_script_setup          import *
+
+from CIME.case import Case
+
+logger = logging.getLogger(__name__)
+
+import argparse
+
+###############################################################################
+def parse_command_line(args, description):
+###############################################################################
+    parser = argparse.ArgumentParser(
+        usage="""\n{0} [--verbose]
+OR
+{0} --help
+
+\033[1mEXAMPLES:\033[0m
+    \033[1;32m# case.post_run_io SMS\033[0m
+    > {0}
+""".format(os.path.basename(args[0])),
+        description=description,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    CIME.utils.setup_standard_logging_options(parser)
+
+    parser.add_argument("--caseroot",
+                        help="Case directory to build")
+
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
+
+    if args.caseroot is not None:
+        os.chdir(args.caseroot)
+
+    return args.caseroot
+
+###############################################################################
+def _main_func(description):
+###############################################################################
+    sys.argv.extend([] if "ARGS_FOR_SCRIPT" not in os.environ else os.environ["ARGS_FOR_SCRIPT"].split())
+
+    caseroot = parse_command_line(sys.argv, description)
+    with Case(caseroot, read_only=False) as case:
+        success = case.case_post_run_io()
+
+    sys.exit(0 if success else 1)
+
+if __name__ == "__main__":
+    _main_func(__doc__)

--- a/cime_config/machines/template.post_run_io
+++ b/cime_config/machines/template.post_run_io
@@ -6,7 +6,9 @@
 """
 template to create a case post run script for I/O post processing.
 
-This should only ever be called by case.submit when on batch system. This script only exists as a way of providing batch directives. Use case.submit from the command line to run your case.
+This should only ever be called by case.submit when on batch system.
+This script only exists as a way of providing batch directives.
+Use case.submit from the command line to run your case.
 
 DO NOT RUN THIS SCRIPT MANUALLY
 """
@@ -61,6 +63,7 @@ def _main_func(description):
 
     ret = 0
     caseroot = parse_command_line(sys.argv, description)
+    # Load the case_post_run_io.py script and run I/O post processing steps
     with Case(caseroot, read_only=False) as case:
         srcroot = case.get_value("SRCROOT")
 

--- a/cime_config/machines/template.post_run_io
+++ b/cime_config/machines/template.post_run_io
@@ -20,6 +20,7 @@ sys.path.append(_LIBDIR)
 from standard_script_setup          import *
 
 from CIME.case import Case
+from CIME.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -58,11 +59,18 @@ def _main_func(description):
 ###############################################################################
     sys.argv.extend([] if "ARGS_FOR_SCRIPT" not in os.environ else os.environ["ARGS_FOR_SCRIPT"].split())
 
+    ret = 0
     caseroot = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
-        success = case.case_post_run_io()
+        srcroot = case.get_value("SRCROOT")
 
-    sys.exit(0 if success else 1)
+        customize_path = os.path.join(srcroot, "cime_config", "customize")
+
+        config = Config.load(customize_path)
+
+        ret = config.case_post_run_io(case)
+
+    sys.exit(ret)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/share/build/buildlib.spio
+++ b/share/build/buildlib.spio
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+import sys, os, logging, argparse
+
+cimeroot = os.getenv("CIMEROOT")
+sys.path.append(os.path.join(cimeroot, "CIME", "Tools"))
+
+import glob, re
+from standard_script_setup import *
+from CIME import utils
+from CIME.utils import expect, run_bld_cmd_ensure_logging, safe_copy
+from CIME.build import get_standard_makefile_args
+from CIME.case import Case
+
+logger = logging.getLogger(__name__)
+
+
+def parse_command_line(args, description):
+    ###############################################################################
+    parser = argparse.ArgumentParser(
+        usage="""\n{0} [--debug]
+OR
+{0} --verbose
+OR
+{0} --help
+
+\033[1mEXAMPLES:\033[0m
+    \033[1;32m# Run \033[0m
+    > {0}
+""".format(
+            os.path.basename(args[0])
+        ),
+        description=description,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    utils.setup_standard_logging_options(parser)
+
+    parser.add_argument("buildroot", help="build path root")
+
+    parser.add_argument("installpath", help="install path ")
+
+    parser.add_argument(
+        "caseroot", nargs="?", default=os.getcwd(), help="Case directory to build"
+    )
+
+    args = utils.parse_args_and_handle_standard_logging_options(args, parser)
+
+    return args.buildroot, args.installpath, args.caseroot
+
+
+###############################################################################
+def buildlib(bldroot, installpath, case):
+    ###############################################################################
+    cime_model = case.get_value("MODEL")
+    caseroot = case.get_value("CASEROOT")
+    exeroot = case.get_value("EXEROOT")
+    pio_version = case.get_value("PIO_VERSION")
+    srcroot = case.get_value("SRCROOT")
+    scorpio_src_root_dir = None
+    if cime_model == "e3sm":
+        scorpio_src_root_dir = os.path.join(srcroot, "externals")
+        # Scorpio classic is derived from PIO1
+        scorpio_classic_dir = "scorpio_classic"
+        # Scorpio is derived from PIO2
+        scorpio_dir = "scorpio"
+        scorpio_classic_src_dir = os.path.join(
+            scorpio_src_root_dir, scorpio_classic_dir
+        )
+        scorpio_src_dir = os.path.join(scorpio_src_root_dir, scorpio_dir)
+        if (
+            not os.path.isdir(scorpio_src_root_dir)
+            or not os.path.isdir(scorpio_classic_src_dir)
+            or not os.path.isdir(scorpio_src_dir)
+        ):
+            scorpio_src_root_dir = None
+
+    # If variable PIO_VERSION_MAJOR is defined in the environment then
+    # we assume that PIO is installed on the system
+    # and expect to find
+    # PIO_LIBDIR, PIO_INCDIR, PIO_TYPENAME_VALID_VALUES
+    # also defined in the environment.  In this case we
+    # will use the installed pio and not build it here.
+    installed_pio_version = os.environ.get("PIO_VERSION_MAJOR")
+    logger.info(
+        "pio_version_major = {} pio_version = {}".format(
+            installed_pio_version, pio_version
+        )
+    )
+    if installed_pio_version is not None and int(installed_pio_version) == pio_version:
+        logger.info("Using installed PIO library")
+        _set_pio_valid_values(case, os.environ.get("PIO_TYPENAME_VALID_VALUES"))
+        return
+
+    pio_model = "pio{}".format(pio_version)
+    pio_dir = os.path.join(bldroot, pio_model)
+    if not os.path.isdir(pio_dir):
+        os.makedirs(pio_dir)
+    casetools = case.get_value("CASETOOLS")
+    if scorpio_src_root_dir:
+        # Use old genf90 until "short" type is supported
+        cmake_opts = (
+            '"-D GENF90_PATH='
+            + os.path.join(scorpio_src_root_dir, scorpio_dir, "src/genf90")
+            + '" '
+        )
+    elif pio_version == 1:
+        cmake_opts = '"-D GENF90_PATH=$CIMEROOT/CIME/non_py/externals/genf90 "'
+    else:
+        cmake_opts = '"-D GENF90_PATH=' + srcroot + '/libraries/parallelio/scripts/ "'
+
+    stdargs = get_standard_makefile_args(case, shared_lib=True)
+
+    gmake_vars = (
+        "CASEROOT={caseroot} COMP_NAME={pio_model} "
+        "USER_CMAKE_OPTS={cmake_opts} "
+        "PIO_LIBDIR={pio_dir} CASETOOLS={casetools} "
+        "USER_CPPDEFS=-DTIMING".format(
+            caseroot=caseroot,
+            pio_model=pio_model,
+            cmake_opts=cmake_opts,
+            pio_dir=pio_dir,
+            casetools=casetools,
+        )
+    )
+
+    if scorpio_src_root_dir is not None:
+        gmake_vars += (
+            " IO_LIB_SRCROOT={scorpio_src_root_dir} "
+            " IO_LIB_v1_SRCDIR={scorpio_classic_dir} "
+            " IO_LIB_v2_SRCDIR={scorpio_dir} ".format(
+                scorpio_src_root_dir=scorpio_src_root_dir,
+                scorpio_classic_dir=scorpio_classic_dir,
+                scorpio_dir=scorpio_dir,
+            )
+        )
+
+    gmake_opts = (
+        "{pio_dir}/Makefile -C {pio_dir} "
+        " {gmake_vars} {stdargs} -f {casetools}/Makefile".format(
+            pio_dir=pio_dir, gmake_vars=gmake_vars, casetools=casetools, stdargs=stdargs
+        )
+    )
+
+    gmake_cmd = case.get_value("GMAKE")
+
+    # This runs the pio cmake command from the cime case Makefile
+    logger.info("Configuring SCORPIO")
+    cmd = "{} {}".format(gmake_cmd, gmake_opts)
+    run_bld_cmd_ensure_logging(cmd, logger, from_dir=pio_dir)
+
+    # This runs the pio make command from the cmake generated Makefile
+    logger.info("Building SCORPIO")
+    run_bld_cmd_ensure_logging(
+        "{} -j {}".format(gmake_cmd, case.get_value("GMAKE_J")),
+        logger,
+        from_dir=pio_dir,
+    )
+
+    if pio_version == 1:
+        expect_string = "D_NETCDF;"
+        pnetcdf_string = "D_PNETCDF"
+        netcdf4_string = "D_NETCDF4"
+    else:
+        expect_string = "NetCDF_C_LIBRARY-ADVANCED"
+        # pnetcdf_string = "PnetCDF_C_LIBRARY-ADVANCED"
+        pnetcdf_string = "WITH_PNETCDF:BOOL=ON"
+        netcdf4_string = "NetCDF_C_HAS_PARALLEL:BOOL=TRUE"
+
+    adios_string = "WITH_ADIOS2:BOOL=ON"
+    expect_string_found = False
+    pnetcdf_found = False
+    netcdf4_parallel_found = False
+    adios_found = False
+
+    cache_file = open(os.path.join(pio_dir,"CMakeCache.txt"), "r")
+    for line in cache_file:
+        if re.search(expect_string, line):
+            expect_string_found = True
+        if re.search(pnetcdf_string, line):
+            pnetcdf_found = True
+        if re.search(netcdf4_string, line):
+            netcdf4_parallel_found = True
+        if re.search(adios_string, line):
+            adios_found = True
+
+    if pio_version == 1:
+        installed_lib = os.path.join(installpath, "lib", "libpio.a")
+        installed_lib_time = 0
+        if os.path.isfile(installed_lib):
+            installed_lib_time = os.path.getmtime(installed_lib)
+        newlib = os.path.join(pio_dir, "pio", "libpio.a")
+        newlib_time = os.path.getmtime(newlib)
+        if newlib_time > installed_lib_time:
+            logger.info("Installing pio version 1")
+            safe_copy(newlib, installed_lib)
+            for glob_to_copy in ("*.h", "*.mod"):
+                for item in glob.glob(os.path.join(pio_dir, "pio", glob_to_copy)):
+                    safe_copy(item, "{}/include".format(installpath))
+    else:
+        globs_to_copy = [
+            os.path.join("src", "clib", "libpioc.*"),
+            os.path.join("src", "flib", "libpiof.*"),
+            os.path.join("src", "clib", "*.h"),
+            os.path.join("src", "flib", "*.mod"),
+        ]
+        # ADIOS requires an ADIOS to NetCDF conversion library/exe
+        if adios_found:
+            globs_to_copy.append(os.path.join("tools","adios2pio-nm","libadios2pio-nm-lib.*"))
+            globs_to_copy.append(os.path.join("tools","adios2pio-nm","adios2pio-nm.exe"))
+        for glob_to_copy in globs_to_copy:
+            installed_file_time = 0
+            for item in glob.glob(os.path.join(pio_dir, glob_to_copy)):
+                if item.endswith(".a") or item.endswith(".so"):
+                    installdir = "lib"
+                else:
+                    installdir = "include"
+                if item.endswith(".exe"):
+                    # FIXME: Move executables into a bin/util dir
+                    # Currently we are moving the SCORPIO util exes to the same
+                    # dir as e3sm.exe (the EXEROOT) - ignoring installpath
+                    installed_file = os.path.join(exeroot,os.path.basename(item))
+                else:
+                    installed_file = os.path.join(installpath,installdir,os.path.basename(item))
+                item_time = os.path.getmtime(item)
+                if os.path.isfile(installed_file):
+                    installed_file_time = os.path.getmtime(installed_file)
+                if item_time > installed_file_time:
+                    safe_copy(item, installed_file)
+
+    # make sure case pio_typename valid_values is set correctly
+    expect(expect_string_found, "CIME models require NETCDF in PIO build")
+    valid_values = "netcdf"
+    if pnetcdf_found:
+        valid_values += ",pnetcdf"
+    if netcdf4_parallel_found:
+        valid_values += ",netcdf4p,netcdf4c"
+    if adios_found:
+        valid_values += ",adios"
+
+    _set_pio_valid_values(case, valid_values)
+
+
+def _set_pio_valid_values(case, valid_values):
+    # nothing means use the general default
+    valid_values += ",nothing"
+    logger.warning("Updating valid_values for PIO_TYPENAME: {}".format(valid_values))
+    env_run = case.get_env("run")
+    env_run.set_valid_values("PIO_TYPENAME", valid_values)
+
+    for comp in case.get_values("COMP_CLASSES"):
+        comp_pio_typename = "{}_PIO_TYPENAME".format(comp)
+        current_value = case.get_value(comp_pio_typename)
+        if current_value not in valid_values:
+            logger.warning(
+                "Resetting PIO_TYPENAME=netcdf for component {}".format(comp)
+            )
+            env_run.set_value(comp_pio_typename, "netcdf")
+
+
+def _main(argv, documentation):
+    bldroot, installpath, caseroot = parse_command_line(argv, documentation)
+    with Case(caseroot, read_only=False) as case:
+        buildlib(bldroot, installpath, case)
+
+
+if __name__ == "__main__":
+    _main(sys.argv, __doc__)


### PR DESCRIPTION
Adding new build script for SCORPIO, buildlib.spio, to replace the
build script used by PIO, buildlib.pio, in CIME. The new build
script also includes support for ADIOS.

This build script is not enabled in this PR. It will be enabled when
ESMCI/CIME#4372 (CIME PR) will be merged to E3SM.

Also adding I/O post processing logic required to convert ADIOS BP
output files to NetCDF files in a post processing job.

[BFB]