### PR TITLE
Protect SCM array refs with SCM logicals

### DIFF
--- a/components/eam/src/dynamics/se/inidat.F90
+++ b/components/eam/src/dynamics/se/inidat.F90
@@ -68,11 +68,11 @@ contains
 
     real(r8), parameter :: rad2deg = 180.0 / SHR_CONST_PI
     type(element_t), pointer :: elem(:)
-    real(r8), allocatable :: tmp(:,:,:)    ! (npsp,nlev,nelemd)
-    real(r8), allocatable :: tmp_point(:,:)! (npsp,nlev)
-    real(r8), allocatable :: qtmp(:,:)     ! (npsp*nelemd,nlev)
+    real(r8), allocatable :: tmp(:,:,:)    ! (npsq,nlev,nelemd)
+    real(r8), allocatable :: tmp_point(:,:)! (npsq,nlev)
+    real(r8), allocatable :: qtmp(:,:)     ! (npsq*nelemd,nlev)
     real(r8) :: ps(np,np)     
-    logical,  allocatable :: tmpmask(:,:)  ! (npsp,nlev,nelemd) unique grid val
+    logical,  allocatable :: tmpmask(:,:)  ! (npsq,nlev,nelemd) unique grid val
     real(r8), allocatable :: phis_tmp(:,:) ! (nphys_sq,nelemd)
     integer :: nphys_sq                    ! # of fv physics columns per element
     integer :: ie, k, t
@@ -120,8 +120,6 @@ contains
     end if
     allocate(tmp(npsq,nlev,nelemd))
     allocate(tmp_point(1,nlev)) ! To find input at a single location
-    tmp = 0.0_r8
-    tmp_point = 0.0_r8
     allocate(qtmp(npsq*nelemd,nlev))
 
     if (fv_nphys>0) then
@@ -441,9 +439,9 @@ contains
     end if
 
     if (scm_multcols) then
-       if (tmp(1,1,1) < 10000._r8) then
-          call endrun('Problem reading ps field')
-       endif
+      if (tmp(1,1,1) < 10000._r8) then
+        call endrun('Problem reading ps field')
+      endif
     endif
 
     deallocate(tmpmask)
@@ -680,6 +678,11 @@ contains
     end do
 
     deallocate(tmp)
+    deallocate(tmp_point)
+    deallocate(qtmp)
+    if (fv_nphys>0) then
+      deallocate(phis_tmp)
+    end if
 
   end subroutine read_inidat
 


### PR DESCRIPTION
Split an if-conjunction into nested if-stmts to avoid eager
if-condition evaluation, which can lead to illegal array-reference.

[BFB]