### PR TITLE
Move from mpas-cice to mpas-seaice in inputdata

### DIFF
--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -13,7 +13,7 @@
 #
 # The simplest use of build-namelist is to execute it from the build directory where configure
 # was run.  By default it will use the config_cache.xml file that was written by configure to
-# determine the build time properties of the executable, and will write the files that contain 
+# determine the build time properties of the executable, and will write the files that contain
 # the output namelists in that same directory.
 #
 #
@@ -35,14 +35,14 @@ SYNOPSIS
      build-namelist [options]
 OPTIONS
      -infile "filepath"    Specify a file containing namelists to read values from.
-     -namelist "namelist"  Specify namelist settings directly on the commandline by supplying 
+     -namelist "namelist"  Specify namelist settings directly on the commandline by supplying
                            a string containing FORTRAN namelist syntax, e.g.,
                               -namelist "&mpas-seaice_nml dt=1800 /"
      -help [or -h]         Print usage to STDOUT.
      -test                 Enable checking that input datasets exist on local filesystem.
      -verbose              Turn on verbose echoing of informational messages.
      -caseroot             CASEROOT directory variable
-     -casebuild            CASEBUILD directory variable          
+     -casebuild            CASEBUILD directory variable
      -cimeroot             CIMEROOT directory variable
      -ice_grid             ICE_GRID variable
      -decomp_prefix        decomp_prefix variable
@@ -67,7 +67,7 @@ NOTE: The precedence for setting the values of namelist variables is (highest to
       1. namelist values set by specific command-line options, i.e. (none right now)
       2. values set on the command-line using the -namelist option,
       3. values read from the file specified by -infile,
-      4. values from the namelist defaults file - or values specifically set in build-namelist 
+      4. values from the namelist defaults file - or values specifically set in build-namelist
 EOF
 }
 
@@ -82,7 +82,7 @@ my $ProgDir = $1;                      # name of directory containing this scrip
                                        # the user's PATH
 my $cwd = getcwd();                    # current working directory
 my $cfgdir;                            # absolute pathname of directory that contains this script
-if ($ProgDir) { 
+if ($ProgDir) {
     $cfgdir = absolute_path($ProgDir);
 } else {
     $cfgdir = $cwd;
@@ -173,7 +173,7 @@ my $NINST_ICE       = $opts{'ninst_ice'};
 my $NTASKS_ICE      = $opts{'ntasks_ice'};
 $cfgdir             = $opts{'cfg_dir'};
 
-my $CIMEROOT;     
+my $CIMEROOT;
 if ( defined $opts{'cimeroot'} ) {
     $CIMEROOT = $opts{'cimeroot'};
 }
@@ -246,7 +246,7 @@ EOF
 # The namelist definition file contains entries for all namelist variables that
 # can be output by build-namelist.  The version of the file that is associate with a
 # fixed MPASSI tag is $cfgdir/namelist_files/namelist_definition.xml.  To aid developers
-# who make use of the SourceMods/src.mpassi directory - we allow the definition file 
+# who make use of the SourceMods/src.mpassi directory - we allow the definition file
 # to come from that directory
 my $nl_definition_file;
 if (-f "${CASEROOT}/SourceMods/src.mpassi/namelist_definition_mpassi.xml") {
@@ -285,7 +285,7 @@ require Build::Namelist;
 require Config::SetupTools;
 
 #-----------------------------------------------------------------------------------------------
-# Create a configuration object from the MPASSI config_cache.xml file-  created by 
+# Create a configuration object from the MPASSI config_cache.xml file-  created by
 # mpassi.cpl7.template in $CASEBUILD/mpassiconf
 my $cfg = Build::Config->new('config_cache.xml');
 
@@ -439,13 +439,13 @@ if ($inst_string) {
     $output_r = "./${CASE}.mpassi${inst_string}.r";
     $output_h = "./${CASE}.mpassi${inst_string}.h";
     $output_d = "./${CASE}.mpassi${inst_string}.d";
-} 
+}
 
 # Environment variables set in mpassi.buildnml.csh that are not xml variables
-my $RESTART_INPUT_TS_FMT = "$ENV{'RESTART_INPUT_TS_FMT'}"; 
+my $RESTART_INPUT_TS_FMT = "$ENV{'RESTART_INPUT_TS_FMT'}";
 my $LID = $ENV{'LID'};
 
-my $ntasks = $NTASKS_ICE / $NINST_ICE; 
+my $ntasks = $NTASKS_ICE / $NINST_ICE;
 
 print "MPASSI build-namelist: ice_grid is $ICE_GRID \n";
 
@@ -1379,7 +1379,7 @@ sub add_default {
     # The default values for input pathnames are relative.  If the namelist
     # variable is defined to be an absolute pathname, then prepend
     # the CCSM inputdata root directory.
-    # TODO: unless ignore_abs is passed as argument 
+    # TODO: unless ignore_abs is passed as argument
     if ($is_input_pathname eq 'abs') {
       unless ($opts{'noprepend'}){
         $val = set_abs_filepath($val, $DIN_LOC_ROOT);
@@ -1587,8 +1587,8 @@ sub expand_env_xml {
 	my $subst = $xmlvars{$1};
 	$value =~ s/\$${1}/$subst/g;
     }
-    return $value; 
-}	 
+    return $value;
+}
 
 #-------------------------------------------------------------------------------
 
@@ -1617,7 +1617,7 @@ sub print_nl_to_screen {
 sub valid_date {
 # return 1 if given date ($$month/$$day/$$year) exists in calendar $cal
 # otherwise subtract number of days in $$month from $$day, and increment
-# $$month by 1 (also incrementing $$year if going from Dec to Jan) and 
+# $$month by 1 (also incrementing $$year if going from Dec to Jan) and
 # then return 0.
 
   my $day = shift;

--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -487,7 +487,7 @@ add_default($nl, 'config_full_abort_write');
 # Namelist group: decomposition #
 #################################
 
-add_default($nl, 'config_block_decomp_file_prefix', 'val'=>"'${DIN_LOC_ROOT}/ice/mpas-cice/${ICE_GRID}/${decomp_prefix}${date_stamp}.part.'");
+add_default($nl, 'config_block_decomp_file_prefix', 'val'=>"'${DIN_LOC_ROOT}/ice/mpas-seaice/${ICE_GRID}/${decomp_prefix}${date_stamp}.part.'");
 add_default($nl, 'config_number_of_blocks');
 add_default($nl, 'config_explicit_proc_decomp');
 add_default($nl, 'config_proc_decomp_file_prefix');

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -28,7 +28,7 @@ add_default($nl, 'config_full_abort_write');
 # Namelist group: decomposition #
 #################################
 
-add_default($nl, 'config_block_decomp_file_prefix', 'val'=>"'${DIN_LOC_ROOT}/ice/mpas-cice/${ICE_GRID}/mpas-cice.graph.info.${date_stamp}.part.'");
+add_default($nl, 'config_block_decomp_file_prefix', 'val'=>"'${DIN_LOC_ROOT}/ice/mpas-seaice/${ICE_GRID}/mpas-seaice.graph.info.${date_stamp}.part.'");
 add_default($nl, 'config_number_of_blocks');
 add_default($nl, 'config_explicit_proc_decomp');
 add_default($nl, 'config_proc_decomp_file_prefix');

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -267,7 +267,7 @@ def buildnml(case, caseroot, compname):
     # Set the initial file
     #--------------------------------------------------------------------
 
-    input_file = "{}/ice/mpas-cice/{}/{}.{}.nc".format(din_loc_root, ice_mask, grid_prefix, grid_date)
+    input_file = "{}/ice/mpas-seaice/{}/{}.{}.nc".format(din_loc_root, ice_mask, grid_prefix, grid_date)
 
     #--------------------------------------------------------------------
     # Generate input data file with stream-specified files
@@ -275,12 +275,12 @@ def buildnml(case, caseroot, compname):
 
     with open(os.path.join(casebuild, "mpassi.input_data_list"), "w") as input_list:
         input_list.write("mesh = {}\n".format(input_file))
-        input_list.write("snow_data = {}/ice/mpas-cice/general/snicar_drdt_bst_fit_60_c04262019.nc\n".format(din_loc_root))
-        input_list.write("snicar_data = {}/ice/mpas-cice/general/snicar_optics_5bnd_snow_and_aerosols.nc\n".format(din_loc_root))
+        input_list.write("snow_data = {}/ice/mpas-seaice/general/snicar_drdt_bst_fit_60_c04262019.nc\n".format(din_loc_root))
+        input_list.write("snicar_data = {}/ice/mpas-seaice/general/snicar_optics_5bnd_snow_and_aerosols.nc\n".format(din_loc_root))
         if points_file != '':
-            input_list.write("points = {}/ice/mpas-cice/{}/{}\n".format(din_loc_root, ice_mask, points_file))
+            input_list.write("points = {}/ice/mpas-seaice/{}/{}\n".format(din_loc_root, ice_mask, points_file))
         if iceberg_mode == 'data':
-            input_list.write("data_iceberg = {}/ice/mpas-cice/{}/{}\n".format(din_loc_root, ice_mask, data_iceberg_file))
+            input_list.write("data_iceberg = {}/ice/mpas-seaice/{}/{}\n".format(din_loc_root, ice_mask, data_iceberg_file))
 
     #--------------------------------------------------------------------
     # Invoke mpas build-namelist - output will go in $CASEBUILD/mpassiconf
@@ -507,14 +507,14 @@ def buildnml(case, caseroot, compname):
             lines.append('<immutable_stream name="SnowAgingPropertiesInput"')
             lines.append('                  type="input"')
             lines.append('                  io_type="{}"'.format(ice_pio_typename))
-            lines.append('                  filename_template="{}/ice/mpas-cice/general/snicar_drdt_bst_fit_60_c04262019.nc"'.format(din_loc_root))
+            lines.append('                  filename_template="{}/ice/mpas-seaice/general/snicar_drdt_bst_fit_60_c04262019.nc"'.format(din_loc_root))
             lines.append('                  filename_interval="none"')
             lines.append('                  input_interval="initial_only" />')
             lines.append('')
             lines.append('<immutable_stream name="SnicarInput"')
             lines.append('                  type="input"')
             lines.append('                  io_type="{}"'.format(ice_pio_typename))
-            lines.append('                  filename_template="{}/ice/mpas-cice/general/snicar_optics_5bnd_snow_and_aerosols.nc"'.format(din_loc_root))
+            lines.append('                  filename_template="{}/ice/mpas-seaice/general/snicar_optics_5bnd_snow_and_aerosols.nc"'.format(din_loc_root))
             lines.append('                  filename_interval="none"')
             lines.append('                  input_interval="initial_only" />')
             lines.append('')
@@ -551,7 +551,7 @@ def buildnml(case, caseroot, compname):
             if iceberg_mode == 'data':
                 lines.append('<stream name="dataIcebergForcing"')
                 lines.append('                  type="input"')
-                lines.append('                  filename_template="{}/ice/mpas-cice/{}/{}"'.format(din_loc_root, ice_mask, data_iceberg_file))
+                lines.append('                  filename_template="{}/ice/mpas-seaice/{}/{}"'.format(din_loc_root, ice_mask, data_iceberg_file))
                 lines.append('                  filename_interval="none"')
                 lines.append('                  input_interval="none" >')
                 lines.append('')
@@ -851,7 +851,7 @@ def buildnml(case, caseroot, compname):
                 if points_file != '':
                     lines.append('<immutable_stream name="pointLocationsInput"')
                     lines.append('                  type="input"')
-                    lines.append('                  filename_template="{}/ice/mpas-cice/{}/{}"'.format(din_loc_root, ice_mask, points_file))
+                    lines.append('                  filename_template="{}/ice/mpas-seaice/{}/{}"'.format(din_loc_root, ice_mask, points_file))
                     lines.append('                  input_interval="initial_only"')
                     lines.append('                  runtime_format="single_file" />')
 
@@ -971,7 +971,7 @@ def buildnml(case, caseroot, compname):
             lines.append('        type="input"')
             lines.append('        io_type="{}"'.format(ice_pio_typename))
             lines.append('        input_interval="initial_only"')
-            lines.append('        filename_template="{}/ice/mpas-cice/{}/{}.{}.nc">'.format(din_loc_root, ice_mask, grid_prefix, grid_date))
+            lines.append('        filename_template="{}/ice/mpas-seaice/{}/{}.{}.nc">'.format(din_loc_root, ice_mask, grid_prefix, grid_date))
             lines.append('')
             lines.append('       <var name="landIceMask"/>')
             lines.append('</stream>')


### PR DESCRIPTION
This merge points all instances of `inputdata/ice/mpas-cice` instead to `inputdata/ice/mpas-seaice`.

I have rsynced all files in `inputdata/ice/mpas-cice` that were not already in `inputdata/ice/mpas-seaice` into that directory this morning.

I propose to move `mpas-cice` to `deprecated-mpas-cice` and make `mpas-cice` a symlink to `mpas-seaice` instead.  This solution will be fully backwards compatible.  However, we will retain the `deprecated-mpas-cice` for a few months just in case.

[BFB]