### PR TITLE
Fix support for preventing overflow and catastrophic cancellation

### DIFF
--- a/share/util/shr_reprosum_mod.F90
+++ b/share/util/shr_reprosum_mod.F90
@@ -1519,7 +1519,7 @@ module shr_reprosum_mod
 !     1. All other levels are now less than or equal to
 !     (radix(1_i8)**arr_max_shift) in absolute value rather than
 !     strictly less than. 
-           ilevel = 0
+           ilevel = min_level
            do while ((i8_arr_gsum_level(ioffset+ilevel) == 0_i8) &
                      .and. (ilevel < max_levels(ifld)))
              ilevel = ilevel + 1
@@ -1549,7 +1549,7 @@ module shr_reprosum_mod
                         - max_levels(ifld)*arr_max_shift
             curr_exp = 0
             first = .true.
-            do ilevel=max_levels(ifld),0,-1
+            do ilevel=max_levels(ifld),min_level,-1
 
                if (i8_arr_gsum_level(ioffset+ilevel) /= 0_i8) then
                   jlevel = 1
@@ -1614,7 +1614,7 @@ module shr_reprosum_mod
 ! Find first nonzero level and use exponent for this level, then assume all
 ! subsequent levels contribute arr_max_shift digits.
                   sum_digits = 0
-                  do ilevel=0,max_levels(ifld)
+                  do ilevel=min_level,max_levels(ifld)
                      if (sum_digits == 0) then
                         if (i8_arr_gsum_level(ioffset+ilevel) /= 0_i8) then
                            X_8(1) = i8_arr_gsum_level(ioffset+ilevel)


### PR DESCRIPTION
The default shr_reprosum_mod algorithm, the integer vector algorithm,
first converts each floating point summand into an equivalent
representation using a vector of integers, sums the integer vectors,
then converts the resulting sum back to a floating point
representation. 

The algorithm includes logic to preclude the possibility of integer
overflow in the intermediate sums and to eliminate the possibility
of catastrophic cancellation in the final summation. Upon close
inspection it has been determined that this logic is not sufficient
to  achieve these goals in all situations. Though it is very unlikely
for these "edge cases" to occur during E3SM simulations, it
is desirable to correct the problems anyway.

a) Fix logic to make all integers in integer expansion the same sign.

As part of the process of converting the vector of integers
representing the global sum into a floating point value, the
components are first modified to all be the same sign. This eliminates
the possibility of catatrophic cancellation during the next step, when
each integer component is converted to a floating point value and
these floating point values are then summed to generate the global
sum.

The algorithm works as follows. Each integer*8 component IX(i),
i=0,1,... , has an associated implicit exponent LX(i) and represents
the floating point value real(IX(i),r8)**LX(i). The sequence of
exponents all differ by the same amount, LX(i) - LX(i+1) = max_shift,
and are monotonically decreasing in (i). By construction,
 abs(IX(i)) < radix(1_i8)**max_shift
for i = 1,2,... In consequence, if IX(i-1), IX(i), and IX(i+1) are
all nonzero, then the magnitude of the value at index (i)
  (abs(real(IX(i),r8)**LX(i)))
is strictly less than the magnitude of the value at index (i-1)
  (abs(real(IX(i-1),r8)**LX(i-1)))
and strictly greater than the magnitude of the value at index (i+1)
  (abs(real(IX(i+1),r8)**LX(i+1))).
If IX(i) is greater than zero and IX(i+1) is less than zero,
then 1_i8 can be subtracted from IX(i) and radix(1_i8)**max_shift
added to IX(i+1) so that IX(i) is now greater than or equal to zero,
and IX(i+1) is greater than zero. If IX(i) is less than zero and
IX(i+1) is greater than zero, then, after adding 1_i8 to IX(i) and
subtracting radix(1_i8)**max_shift from IX(i+1), IX(i) is less than or
equal to zero and IX(i+1) is less than zero. The algorithm begins by
finding the first nonzero component (i=0,1,...), which determines the
sign of the resulting sum, then uses the above process to change all
components to this sign.

The above description does not treat the situation when IX(i) is zero,
which is where an error arises in the current algorithm. The current
algorithm always treats 0_i8 as positive (as it uses the fortran 'sign'
intrinsic to compare signs between components). This can cause
problems if IX(i-1) is greater than zero, IX(i) is zero, and IX(i+1)
is less than zero. In this case IX(i-1) and IX(i) have the
same sign and neither are modified after their comparison. However,
IX(i) and IX(i+1) have different signs, so 1_i8 will be subtracted
from IX(i), changing it to negative, while radix(1_i8)**max_shift will
be added to IX(i+1), changing it to positive, and the same sign
property will not be achieved. The solution is to always treat a zero
IX(i) as having a different sign from IX(i-1) so that IX(i) always
becomes nonzero. As we always start the process with a nonzero IX(i),
we end up with all components either greater than or equal to zero or
all components less than or equal to zero.

Note that while this error can prevent the resulting sequence of
floating point values from being all the same sign or zero, the
situation in which this error occurs does not lead to additional
rounding error in the final summation and so does not decrease the
accuracy. Also, the fix has been BFB with the buggy version in
practice, though it probably is not guaranteed to be.

Despite the innocuousness of the error, it is important to fix it as
part of the resolution to issue #5276 ("Improving accuracy of
shr_reprosum_calc").

Claiming that this is BFB, for the purposes of testing (as it
likely is BFB for E3SM testing and production simulations) so that any
non-BFB behavior in the testing will be examined before the PR is
merged into master.

b) Fix logic to prevent overflow in intermediate sums

To reiterate, each integer*8 component IX(i), i=1,... , has an
associated implicit exponent LX(i) and represents the floating point
value real(IX(i),r8)**LX(i). The sequence of exponents all differ by
the same amount, LX(i) - LX(i+1) = max_shift, and are monotonically
decreasing in (i), and each component for a given summand is strictly
less than radix(1_i8)**max_shift in absolute value.

To allow for a larger max_shift (and shorter integer vector), the
components of the integer vector are manipulated after the local
single threaded sums and before the sum over OpenMP threads and MPI
tasks so that
 abs(IX(i)) < radix(1_i8)**max_shift
for all i > 0, as follows. If abs(IX(i)) is larger than or equal to
(radix(1_i8)**arr_max_shift), subtract this 'overlap' from the current
value and add it (appropriately shifted) to IX(i-1). By starting from
the largest index (smallest implicit exponent), this removes any
overlap from each component. Note that the integer vector has an IX(0)
that is initially zero to capture the overlap from IX(1).

The current logic stops the process at index 0. However, this can be
greater than the target radix(1_i8)**max_shift, and the subsequent
summation over MPI tasks and OpenMP threads can potentially overflow
for the distributed sum of IX(0) if the number of OpenMP threads times
the number of MPI tasks is large. By extending the length of the
integer vector from 0:max_levels to -(extra_levels-1):max_levels and
continuing the above process to index -(extra_levels-1), can guarantee
that the integer value for all indices satisfies abs(IX(i)) <
radix(1_i8)**max_shift if choose extra_levels appropriately, thus
eliminating the possibility of overflow.

Another weakness in the original algorithm arises from using

 RX_8 = real(IX(i),r8)
 Overlap = int(scale(RX_8,-max_shift),i8)

to identify the overlap in IX(i), which may miss some of the overlap
if IX(i) has too many significant digits to be represented by a
floating point value. However, simply calculating the overlap using
integer division

 Overlap = IX(i) / (i8_radix**max_shift)

eliminates this (slight) possibility, and also simplifies the code.

This commit implements both fixes. It also augments the comments to
better document why this approach is sufficient to avoid overlap
during the sum over threads and MPI tasks.

Note that, while these changes are not guaranteed to be BFB, the
calculated value for extra_levels for all E3SM simulations in the test
suites (and likely all production simulations) is almost certainly
'1', and so will be identical to the existing algorithm. The change
in the overlap calculation is also likely to be BFB with the current
algorithm in practice for this code fragment and, even if not, is
still unlikely to change the value of the final sum. Again, claiming
that it is BFB for the purposes of this PR so that any non-BFB
behavior in the testing will be examined before the PR is accepted.

Fixes E3SM-Project/E3SM#5537

[BFB]