### PR TITLE
Update stomatal resistance to properly account for sunlit or shaded conditions

### DIFF
--- a/components/elm/src/biogeochem/DryDepVelocity.F90
+++ b/components/elm/src/biogeochem/DryDepVelocity.F90
@@ -466,16 +466,17 @@ CONTAINS
 
                   !Following Emmons et al (2020, JAMES), the stomatal resistances for shaded and sunlit
                   !leaves should be added in parallel.  Also need to account for the conditions of
-                  !rssun=0.0 and/or rssha=0.0
+                  !rssun=0.0 and/or rssha=0.0, for which only fsun=0 or fsun=1 is considered, respectively,
+                  !following the suggestion by Sam Silva.
 
                   if (rssun(pi) > 0._r8 .and. rssha(pi) > 0._r8) then
                      rs = 1.0_r8 / ( fsun(pi)/rssun(pi) + (1.0_r8 - fsun(pi))/rssha(pi) )
-                  else if (rssun(pi) > 0._r8 .and. rssha(pi) == 0._r8) then
-                     rs = fsun(pi)*rssun(pi)
-                  else if (rssun(pi) == 0._r8 .and. rssha(pi) > 0._r8) then
-                     rs = rssha(pi)*(1._r8-fsun(pi))
+                  else if (rssun(pi) > 0._r8 .and. fsun(pi) == 1._r8) then
+                    rs = rssun(pi)
+                  else if (rssha(pi) > 0._r8 .and. fsun(pi) == 0._r8) then
+                    rs = rssha(pi)
                   else
-                     rs = 0._r8
+                     rs = 1.e36_r8
                   endif
 
                   if (rs==0._r8) then ! fvitt -- what to do when rs is zero ???

--- a/components/elm/src/biogeochem/DryDepVelocity.F90
+++ b/components/elm/src/biogeochem/DryDepVelocity.F90
@@ -466,8 +466,7 @@ CONTAINS
 
                   !Following Emmons et al (2020, JAMES), the stomatal resistances for shaded and sunlit
                   !leaves should be added in parallel.  Also need to account for the conditions of
-                  !rssun=0.0 and/or rssha=0.0, for which only fsun=0 or fsun=1 is considered, respectively,
-                  !following the suggestion by Sam Silva.
+                  !rssun=0.0 and/or rssha=0.0, for which only fsun=0 or fsun=1 is considered, respectively.
 
                   if (rssun(pi) > 0._r8 .and. rssha(pi) > 0._r8) then
                      rs = 1.0_r8 / ( fsun(pi)/rssun(pi) + (1.0_r8 - fsun(pi))/rssha(pi) )

--- a/components/elm/src/biogeochem/DryDepVelocity.F90
+++ b/components/elm/src/biogeochem/DryDepVelocity.F90
@@ -465,8 +465,19 @@ CONTAINS
                else
 
                   !Following Emmons et al (2020, JAMES), the stomatal resistances for shaded and sunlit
-                  !leaves should be added in parallel
-                  rs = 1.0_r8 / ( fsun(pi)/rssun(pi) + (1.0_r8 - fsun(pi))/rssha(pi) )
+                  !leaves should be added in parallel.  Also need to account for the conditions of
+                  !rssun=0.0 and/or rssha=0.0
+
+                  if (rssun(pi) > 0._r8 .and. rssha(pi) > 0._r8) then
+                     rs = 1.0_r8 / ( fsun(pi)/rssun(pi) + (1.0_r8 - fsun(pi))/rssha(pi) )
+                  else if (rssun(pi) > 0._r8 .and. rssha(pi) == 0._r8) then
+                     rs = fsun(pi)*rssun(pi)
+                  else if (rssun(pi) == 0._r8 .and. rssha(pi) > 0._r8) then
+                     rs = rssha(pi)*(1._r8-fsun(pi))
+                  else
+                     rs = 0._r8
+                  endif
+
                   if (rs==0._r8) then ! fvitt -- what to do when rs is zero ???
                      rsmx(ispec) = 1.e36_r8
                   else


### PR DESCRIPTION
This is to fix issue #5535, which exists in current repo but not exposed 
until testing with pre-merged branch for PR #4707. 

The original formulation of adding sunlit and shaded leaves in parallel 
did not consider the conditions when rssun and/or rssha = 0.0, which can 
not only causing floating invalid -- division by 0, but also leading to 
unrealistic dry deposition fluxes, hence rapid ozone loss. Other gas 
constituents can also be affected.

[non-BFB] expected for all F, I, and B tests. But unclear why current master 
                 hasn't experienced issue.