### PR TITLE
[MPAS-Ocean standalone] Allow land-ice topo to come from MPAS variables 

### DIFF
--- a/components/mpas-ocean/src/mode_init/Registry_global_ocean.xml
+++ b/components/mpas-ocean/src/mode_init/Registry_global_ocean.xml
@@ -136,7 +136,7 @@
 			possible_values="Any real positive number."
 		/>
 		<nml_option name="config_global_ocean_topography_source" type="character" default_value="latlon_file" units="unitless"
-			description="If 'latlon_file', reads in topography from file specified in config_global_ocean_topography_file. If 'mpas_variable', reads in topography from mpas variable bed_elevation"
+			description="If 'latlon_file', reads in topography from file specified in config_global_ocean_topography_file. If 'mpas_variable', reads in topography from mpas variable bed_elevation, and optionally oceanFracObserved, landIceDraftObserved, landIceThkObserved, landIceFracObserved, and landIceGroundedFracObserved"
 			possible_values="'latlon_file' or 'mpas_variable'"
 		/>
 		<nml_option name="config_global_ocean_topography_file" type="character" default_value="none" units="unitless"
@@ -168,7 +168,7 @@
 			possible_values="Variable name from input file."
 		/>
 		<nml_option name="config_global_ocean_topography_has_ocean_frac" type="logical" default_value=".false." units="unitless"
-			description="Logical flag that controls if topograhy file contains a field for the fraction of each cell that contains ocean (vs. land or grounded ice)."
+			description="Logical flag that controls if topography file contains a field for the fraction of each cell that contains ocean (vs. land or grounded ice)."
 			possible_values=".true. or .false."
 		/>
 		<nml_option name="config_global_ocean_topography_ocean_frac_varname" type="character" default_value="none" units="unitless"

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
@@ -177,7 +177,7 @@ contains
 
       call mpas_log_write( 'Reading depth levels.')
       call ocn_init_setup_global_ocean_read_depth_levels(domain, iErr)
-      
+
       if (config_global_ocean_topography_source .eq. 'latlon_file') then
         call mpas_log_write( 'Reading topography data from latitude-longitude file.')
         call ocn_init_setup_global_ocean_read_topo(domain, iErr)
@@ -815,40 +815,40 @@ contains
           end do
 
           ! Record depth of the bottom of the ocean, before any alterations for modeling purposes.
-          if (config_global_ocean_topography_source .eq. "latlon_file") then 
+          if (config_global_ocean_topography_source .eq. "latlon_file") then
               if (config_global_ocean_topography_method .eq. "nearest_neighbor") then
-    
+
                  call ocn_init_interpolation_nearest_horiz(topoLon % array, topoLat % array, &
                                                            topoIC % array, nLonTopo, nLatTopo, &
                                                            lonCell, latCell, bottomDepthObserved, nCells, &
                                                            inXPeriod = 2.0_RKIND * pii)
-    
+
                  if (config_global_ocean_topography_has_ocean_frac) then
                     call ocn_init_interpolation_nearest_horiz(topoLon % array, topoLat % array, &
                                                               oceanFracIC % array, nLonTopo, nLatTopo, &
                                                               lonCell, latCell, oceanFracObserved, nCells, &
                                                               inXPeriod = 2.0_RKIND * pii)
                  end if
-    
+
               elseif (config_global_ocean_topography_method .eq. "bilinear_interpolation") then
                  call ocn_init_interpolation_bilinear_horiz(topoLon % array, topoLat % array, &
                                                             topoIC % array, nLonTopo, nLatTopo, &
                                                             lonCell, latCell, bottomDepthObserved, nCells, &
                                                             inXPeriod = 2.0_RKIND * pii)
-    
+
                  if (config_global_ocean_topography_has_ocean_frac) then
                     call ocn_init_interpolation_bilinear_horiz(topoLon % array, topoLat % array, &
                                                                oceanFracIC % array, nLonTopo, nLatTopo, &
                                                                lonCell, latCell, oceanFracObserved, nCells, &
                                                                inXPeriod = 2.0_RKIND * pii)
                  end if
-    
+
               else
                  call mpas_log_write( 'Invalid choice of config_global_ocean_topography_method.', MPAS_LOG_CRIT)
                  iErr = 1
                  call mpas_dmpar_finalize(domain % dminfo)
               endif
-          else 
+          else
               ! Get bottomDepthObserved from bed_elevation variable
               bottomDepthObserved = bed_elevation
           endif

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
@@ -819,8 +819,8 @@ contains
           end do
 
           ! Record depth of the bottom of the ocean, before any alterations for modeling purposes.
-          if (config_global_ocean_topography_source .eq. "latlon_file") then
-              if (config_global_ocean_topography_method .eq. "nearest_neighbor") then
+          if (config_global_ocean_topography_source == "latlon_file") then
+              if (config_global_ocean_topography_method == "nearest_neighbor") then
 
                  call ocn_init_interpolation_nearest_horiz(topoLon % array, topoLat % array, &
                                                            topoIC % array, nLonTopo, nLatTopo, &
@@ -834,7 +834,7 @@ contains
                                                               inXPeriod = 2.0_RKIND * pii)
                  end if
 
-              elseif (config_global_ocean_topography_method .eq. "bilinear_interpolation") then
+              elseif (config_global_ocean_topography_method == "bilinear_interpolation") then
                  call ocn_init_interpolation_bilinear_horiz(topoLon % array, topoLat % array, &
                                                             topoIC % array, nLonTopo, nLatTopo, &
                                                             lonCell, latCell, bottomDepthObserved, nCells, &
@@ -852,7 +852,7 @@ contains
                  iErr = 1
                  call mpas_dmpar_finalize(domain % dminfo)
               endif
-          else
+          else if (config_global_ocean_topography_source == "mpas_variable") then
               ! Get bottomDepthObserved from bed_elevation variable
               bottomDepthObserved = bed_elevation
           endif
@@ -2983,6 +2983,14 @@ end subroutine ocn_init_setup_global_ocean_interpolate_swData!}}}
       call MPAS_io_inq_dim(inputFile, config_global_ocean_swData_nlon_dimname, nLonSW, iErr)
 
       call MPAS_io_close(inputFile, iErr)
+
+      if (config_global_ocean_topography_source /= 'latlon_file' .and. &
+          config_global_ocean_topography_source /= 'mpas_variable') then
+         call mpas_log_write( 'Unexpected value for config_global_ocean_topography_source: ' &
+             // trim(config_global_ocean_topography_source), MPAS_LOG_CRIT)
+         iErr = 1
+         return
+      end if
 
       if (config_global_ocean_topography_file == 'none' .and. &
           config_global_ocean_topography_source == 'latlon_file') then

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
@@ -106,9 +106,9 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_init_setup_global_ocean(domain, iErr)!{{{
+    subroutine ocn_init_setup_global_ocean(domain, iErr)!{{{
 
-   !--------------------------------------------------------------------
+    !--------------------------------------------------------------------
 
       type (domain_type), intent(inout) :: domain
       type (mpas_pool_type), pointer :: meshPool, forcingPool, statePool, tracersPool, scratchPool
@@ -178,13 +178,13 @@ contains
       call mpas_log_write( 'Reading depth levels.')
       call ocn_init_setup_global_ocean_read_depth_levels(domain, iErr)
 
-      if (config_global_ocean_topography_source .eq. 'latlon_file') then
+      if (config_global_ocean_topography_source == 'latlon_file') then
         call mpas_log_write( 'Reading topography data from latitude-longitude file.')
         call ocn_init_setup_global_ocean_read_topo(domain, iErr)
       endif
       call mpas_log_write( 'Creating model topography data.')
       call ocn_init_setup_global_ocean_create_model_topo(domain, iErr)
-      if (config_global_ocean_topography_source .eq. 'latlon_file') then
+      if (config_global_ocean_topography_source == 'latlon_file') then
         call mpas_log_write( 'Cleaning up topography IC fields')
         call ocn_init_global_ocean_destroy_topo_fields()
       endif
@@ -196,8 +196,10 @@ contains
       !***********************************************************************
 
       if (config_global_ocean_depress_by_land_ice) then
-         call mpas_log_write( 'Reading land ice topography data.')
-         call ocn_init_setup_global_ocean_read_land_ice_topography(domain, iErr)
+         if (config_global_ocean_topography_source == "latlon_file") then
+            call mpas_log_write( 'Reading land ice topography data.')
+            call ocn_init_setup_global_ocean_read_land_ice_topography(domain, iErr)
+         end if
          call mpas_log_write( 'Interpolating land ice topography data.')
          call ocn_init_setup_global_ocean_interpolate_land_ice_topography(domain, iErr)
       end if
@@ -505,8 +507,10 @@ contains
             call mpas_dmpar_finalize(domain % dminfo)
          end if
 
-         call mpas_log_write( 'Cleaning up land ice topography IC fields')
-         call ocn_init_global_ocean_destroy_land_ice_topography_fields()
+         if (config_global_ocean_topography_source == "latlon_file") then
+            call mpas_log_write( 'Cleaning up land ice topography IC fields')
+            call ocn_init_global_ocean_destroy_land_ice_topography_fields()
+         end if
       end if
 
       call mpas_log_write( 'Copying restoring fields')
@@ -1081,71 +1085,73 @@ contains
 
        iErr = 0
 
-       block_ptr => domain % blocklist
-       do while(associated(block_ptr))
+       if (config_global_ocean_topography_source == "latlon_file") then
+          block_ptr => domain % blocklist
+          do while(associated(block_ptr))
 
-          call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
-          call mpas_pool_get_subpool(block_ptr % structs, 'landIceInit', landIceInitPool)
-          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+             call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+             call mpas_pool_get_subpool(block_ptr % structs, 'landIceInit', landIceInitPool)
+             call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
-          call mpas_pool_get_array(meshPool, 'latCell', latCell)
-          call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
-          call mpas_pool_get_array(landIceInitPool, 'landIceDraftObserved', landIceDraftObserved)
-          call mpas_pool_get_array(landIceInitPool, 'landIceThkObserved', landIceThkObserved)
-          call mpas_pool_get_array(landIceInitPool, 'landIceFracObserved', landIceFracObserved)
-          call mpas_pool_get_array(landIceInitPool, 'landIceGroundedFracObserved', landIceGroundedFracObserved)
+             call mpas_pool_get_array(meshPool, 'latCell', latCell)
+             call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
+             call mpas_pool_get_array(landIceInitPool, 'landIceDraftObserved', landIceDraftObserved)
+             call mpas_pool_get_array(landIceInitPool, 'landIceThkObserved', landIceThkObserved)
+             call mpas_pool_get_array(landIceInitPool, 'landIceFracObserved', landIceFracObserved)
+             call mpas_pool_get_array(landIceInitPool, 'landIceGroundedFracObserved', landIceGroundedFracObserved)
 
-          if (config_global_ocean_topography_method .eq. "nearest_neighbor") then
+             if (config_global_ocean_topography_method .eq. "nearest_neighbor") then
 
-             call ocn_init_interpolation_nearest_horiz(landIceThkLon % array, landIceThkLat % array, &
-                                                       landIceThkIC % array, nLonLandIceThk, nLatLandIceThk, &
-                                                       lonCell, latCell, landIceThkObserved, nCells, &
-                                                       inXPeriod = 2.0_RKIND * pii)
+                call ocn_init_interpolation_nearest_horiz(landIceThkLon % array, landIceThkLat % array, &
+                                                          landIceThkIC % array, nLonLandIceThk, nLatLandIceThk, &
+                                                          lonCell, latCell, landIceThkObserved, nCells, &
+                                                          inXPeriod = 2.0_RKIND * pii)
 
-             call ocn_init_interpolation_nearest_horiz(landIceThkLon % array, landIceThkLat % array, &
-                                                       landIceDraftIC % array, nLonLandIceThk, nLatLandIceThk, &
-                                                       lonCell, latCell, landIceDraftObserved, nCells, &
-                                                       inXPeriod = 2.0_RKIND * pii)
+                call ocn_init_interpolation_nearest_horiz(landIceThkLon % array, landIceThkLat % array, &
+                                                          landIceDraftIC % array, nLonLandIceThk, nLatLandIceThk, &
+                                                          lonCell, latCell, landIceDraftObserved, nCells, &
+                                                          inXPeriod = 2.0_RKIND * pii)
 
-             call ocn_init_interpolation_nearest_horiz(landIceThkLon % array, landIceThkLat % array, &
-                                                       landIceFracIC % array, nLonLandIceThk, nLatLandIceThk, &
-                                                       lonCell, latCell, landIceFracObserved, nCells, &
-                                                       inXPeriod = 2.0_RKIND * pii)
+                call ocn_init_interpolation_nearest_horiz(landIceThkLon % array, landIceThkLat % array, &
+                                                          landIceFracIC % array, nLonLandIceThk, nLatLandIceThk, &
+                                                          lonCell, latCell, landIceFracObserved, nCells, &
+                                                          inXPeriod = 2.0_RKIND * pii)
 
-             call ocn_init_interpolation_nearest_horiz(landIceThkLon % array, landIceThkLat % array, &
-                                                       groundedFracIC % array, nLonLandIceThk, nLatLandIceThk, &
-                                                       lonCell, latCell, landIceGroundedFracObserved, nCells, &
-                                                       inXPeriod = 2.0_RKIND * pii)
+                call ocn_init_interpolation_nearest_horiz(landIceThkLon % array, landIceThkLat % array, &
+                                                          groundedFracIC % array, nLonLandIceThk, nLatLandIceThk, &
+                                                          lonCell, latCell, landIceGroundedFracObserved, nCells, &
+                                                          inXPeriod = 2.0_RKIND * pii)
 
-          elseif (config_global_ocean_topography_method .eq. "bilinear_interpolation") then
-             call ocn_init_interpolation_bilinear_horiz(landIceThkLon % array, landIceThkLat % array, &
-                                                        landIceThkIC % array, nLonLandIceThk, nLatLandIceThk, &
-                                                        lonCell, latCell, landIceThkObserved, nCells, &
-                                                        inXPeriod = 2.0_RKIND * pii)
+             elseif (config_global_ocean_topography_method .eq. "bilinear_interpolation") then
+                call ocn_init_interpolation_bilinear_horiz(landIceThkLon % array, landIceThkLat % array, &
+                                                           landIceThkIC % array, nLonLandIceThk, nLatLandIceThk, &
+                                                           lonCell, latCell, landIceThkObserved, nCells, &
+                                                           inXPeriod = 2.0_RKIND * pii)
 
-             call ocn_init_interpolation_bilinear_horiz(landIceThkLon % array, landIceThkLat % array, &
-                                                        landIceDraftIC % array, nLonLandIceThk, nLatLandIceThk, &
-                                                        lonCell, latCell, landIceDraftObserved, nCells, &
-                                                        inXPeriod = 2.0_RKIND * pii)
+                call ocn_init_interpolation_bilinear_horiz(landIceThkLon % array, landIceThkLat % array, &
+                                                           landIceDraftIC % array, nLonLandIceThk, nLatLandIceThk, &
+                                                           lonCell, latCell, landIceDraftObserved, nCells, &
+                                                           inXPeriod = 2.0_RKIND * pii)
 
-             call ocn_init_interpolation_bilinear_horiz(landIceThkLon % array, landIceThkLat % array, &
-                                                        landIceFracIC % array, nLonLandIceThk, nLatLandIceThk, &
-                                                        lonCell, latCell, landIceFracObserved, nCells, &
-                                                        inXPeriod = 2.0_RKIND * pii)
+                call ocn_init_interpolation_bilinear_horiz(landIceThkLon % array, landIceThkLat % array, &
+                                                           landIceFracIC % array, nLonLandIceThk, nLatLandIceThk, &
+                                                           lonCell, latCell, landIceFracObserved, nCells, &
+                                                           inXPeriod = 2.0_RKIND * pii)
 
-             call ocn_init_interpolation_bilinear_horiz(landIceThkLon % array, landIceThkLat % array, &
-                                                        groundedFracIC % array, nLonLandIceThk, nLatLandIceThk, &
-                                                        lonCell, latCell, landIceGroundedFracObserved, nCells, &
-                                                        inXPeriod = 2.0_RKIND * pii)
+                call ocn_init_interpolation_bilinear_horiz(landIceThkLon % array, landIceThkLat % array, &
+                                                           groundedFracIC % array, nLonLandIceThk, nLatLandIceThk, &
+                                                           lonCell, latCell, landIceGroundedFracObserved, nCells, &
+                                                           inXPeriod = 2.0_RKIND * pii)
 
-          else
-             call mpas_log_write( 'Invalid choice of config_global_ocean_topography_method.', MPAS_LOG_CRIT)
-             iErr = 1
-             call mpas_dmpar_finalize(domain % dminfo)
-          endif
+             else
+                call mpas_log_write( 'Invalid choice of config_global_ocean_topography_method.', MPAS_LOG_CRIT)
+                iErr = 1
+                call mpas_dmpar_finalize(domain % dminfo)
+             endif
 
-          block_ptr => block_ptr % next
-       end do
+             block_ptr => block_ptr % next
+          end do
+       end if
 
 
        ! Iteratively smooth landIceDraftObserved, landIceThkObserved, landIceFracObserved,
@@ -2803,6 +2809,7 @@ end subroutine ocn_init_setup_global_ocean_interpolate_swData!}}}
       type (mpas_io_context_type), pointer :: iocontext_ptr
       type (MPAS_IO_Handle_type) :: inputFile
       character (len=StrKIND), pointer :: config_init_configuration, &
+                                          config_global_ocean_topography_source, &
                                           config_global_ocean_depth_file, &
                                           config_global_ocean_depth_dimname, &
                                           config_global_ocean_temperature_file, &
@@ -2842,6 +2849,8 @@ end subroutine ocn_init_setup_global_ocean_interpolate_swData!}}}
 
       call mpas_pool_get_config(configPool, 'config_vert_levels', config_vert_levels)
 
+      call mpas_pool_get_config(configPool, 'config_global_ocean_topography_source', &
+                                config_global_ocean_topography_source)
       call mpas_pool_get_config(configPool, 'config_global_ocean_depth_file', &
                                 config_global_ocean_depth_file)
       call mpas_pool_get_config(configPool, 'config_global_ocean_depth_dimname', &
@@ -2975,23 +2984,26 @@ end subroutine ocn_init_setup_global_ocean_interpolate_swData!}}}
 
       call MPAS_io_close(inputFile, iErr)
 
-      if (trim(config_global_ocean_topography_file) == 'none') then
+      if (config_global_ocean_topography_file == 'none' .and. &
+          config_global_ocean_topography_source == 'latlon_file') then
          call mpas_log_write( 'Validation failed for global ocean. ' &
              // 'Invalid filename for config_global_ocean_topography_file', MPAS_LOG_CRIT)
          iErr = 1
          return
       end if
 
-      inputFile = MPAS_io_open(config_global_ocean_topography_file, MPAS_IO_READ, MPAS_IO_NETCDF, iocontext_ptr, ierr=iErr)
-      if (iErr .ne. 0) then
-         call mpas_log_write( 'could not open file '// trim(config_global_ocean_topography_file), MPAS_LOG_CRIT)
-         return
+      if (config_global_ocean_topography_source == 'latlon_file') then
+         inputFile = MPAS_io_open(config_global_ocean_topography_file, MPAS_IO_READ, MPAS_IO_NETCDF, iocontext_ptr, ierr=iErr)
+         if (iErr /= 0) then
+            call mpas_log_write( 'could not open file '// trim(config_global_ocean_topography_file), MPAS_LOG_CRIT)
+            return
+         end if
+
+         call MPAS_io_inq_dim(inputFile, config_global_ocean_topography_nlat_dimname, nLatTopo, iErr)
+         call MPAS_io_inq_dim(inputFile, config_global_ocean_topography_nlon_dimname, nLonTopo, iErr)
+
+         call MPAS_io_close(inputFile, iErr)
       end if
-
-      call MPAS_io_inq_dim(inputFile, config_global_ocean_topography_nlat_dimname, nLatTopo, iErr)
-      call MPAS_io_inq_dim(inputFile, config_global_ocean_topography_nlon_dimname, nLonTopo, iErr)
-
-      call MPAS_io_close(inputFile, iErr)
 
       inputFile = MPAS_io_open(config_global_ocean_windstress_file, MPAS_IO_READ, MPAS_IO_NETCDF, iocontext_ptr, ierr=iErr)
       if (iErr .ne. 0) then
@@ -3039,23 +3051,26 @@ end subroutine ocn_init_setup_global_ocean_interpolate_swData!}}}
       end if
 
       if (config_global_ocean_depress_by_land_ice) then
-         if (trim(config_global_ocean_land_ice_topo_file) == 'none') then
+         if (config_global_ocean_land_ice_topo_file == 'none' .and. &
+             config_global_ocean_topography_source == 'latlon_file') then
             call mpas_log_write( 'Validation failed for global ocean. '// &
                'Invalid filename for config_global_ocean_land_ice_topo_file', MPAS_LOG_CRIT)
             iErr = 1
             return
          end if
 
-         inputFile = MPAS_io_open(config_global_ocean_land_ice_topo_file, MPAS_IO_READ, MPAS_IO_NETCDF, iocontext_ptr, ierr=iErr)
-         if (iErr .ne. 0) then
-            call mpas_log_write( 'could not open file '// trim(config_global_ocean_land_ice_topo_file), MPAS_LOG_CRIT)
-            return
+         if(config_global_ocean_topography_source == 'latlon_file') then
+            inputFile = MPAS_io_open(config_global_ocean_land_ice_topo_file, MPAS_IO_READ, MPAS_IO_NETCDF, iocontext_ptr, ierr=iErr)
+            if (iErr /= 0) then
+               call mpas_log_write( 'could not open file '// trim(config_global_ocean_land_ice_topo_file), MPAS_LOG_CRIT)
+               return
+            end if
+
+            call MPAS_io_inq_dim(inputFile, config_global_ocean_land_ice_topo_nlat_dimname, nLatLandIceThk, iErr)
+            call MPAS_io_inq_dim(inputFile, config_global_ocean_land_ice_topo_nlon_dimname, nLonLandIceThk, iErr)
+
+            call MPAS_io_close(inputFile, iErr)
          end if
-
-         call MPAS_io_inq_dim(inputFile, config_global_ocean_land_ice_topo_nlat_dimname, nLatLandIceThk, iErr)
-         call MPAS_io_inq_dim(inputFile, config_global_ocean_land_ice_topo_nlon_dimname, nLonLandIceThk, iErr)
-
-         call MPAS_io_close(inputFile, iErr)
       end if
 
    !--------------------------------------------------------------------


### PR DESCRIPTION
This applies only to the `global_ocean` test case in `init` mode for standalone MPAS-Ocean.  E3SM simulations are unaffected.

In the same way that we could previously bypass the interpolation from a lat-lon file for bathymetry, this merge allows us to bypass the interpolation of variables related to land-ice topography and instead read them in from a stream.

[BFB] 