### PR TITLE
Add an init-to-zero for kbfs and remove unecessary where statement

### DIFF
--- a/components/eam/src/physics/cam/clubb_intr.F90
+++ b/components/eam/src/physics/cam/clubb_intr.F90
@@ -2906,6 +2906,7 @@ end subroutine clubb_init_cnst
    enddo
 
    ! diagnose surface friction and obukhov length (inputs to diagnose PBL depth)
+   kbfs = 0._r8
    do i=1,ncol
       rrho = invrs_gravit*(state1%pdel(i,pver)/dz_g(pver))
       call calc_ustar( state1%t(i,pver), state1%pmid(i,pver), cam_in%wsx(i), cam_in%wsy(i), &
@@ -2916,8 +2917,6 @@ end subroutine clubb_init_cnst
 
    dummy2(:) = 0._r8
    dummy3(:) = 0._r8
-
-   where (kbfs .eq. -0.0_r8) kbfs = 0.0_r8
 
    !  Compute PBL depth according to Holtslag-Boville Scheme
    call pblintd(ncol, thv, state1%zm, state1%u, state1%v, &


### PR DESCRIPTION
Add `kbfs=0` to init array to zero before use.
Remove a where statement that was looking for negative zeros (`-0`) and does
not look necessary.

After this change (and other recent PR's), should be able to add the compiler
check for floating invalids in DEBUG builds.

Fixes https://github.com/E3SM-Project/E3SM/issues/5295
[bfb]