### PR TITLE
Fixes st_archive jobs taking more than 1 node

### DIFF
--- a/cime_config/machines/config_workflow.xml
+++ b/cime_config/machines/config_workflow.xml
@@ -43,8 +43,9 @@
       <dependency>case.run or case.test</dependency>
       <prereq>$DOUT_S</prereq>
       <runtime_parameters>
-	<task_count>1</task_count>
-	<walltime>0:20:00</walltime>
+        <task_count>1</task_count>
+        <tasks_per_node>1</tasks_per_node>
+        <walltime>0:20:00</walltime>
       </runtime_parameters>
     </job>
   </workflow_jobs>


### PR DESCRIPTION
Fixes `st_archive` jobs taking more than 1 node.

CIME overrides a jobs number of nodes with `tasks_per_node / task_count`, both must be defined.

[BFB]