### PR TITLE
Fixes for EAM cube_to_target topography tool

### DIFF
--- a/components/eam/tools/topo_tool/bin_to_cube/Makefile
+++ b/components/eam/tools/topo_tool/bin_to_cube/Makefile
@@ -10,12 +10,19 @@ RM = rm
 # setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:/usr/local/netcdf-4.1.3-gcc-4.4.4-13-lf9581/lib
 #
 
+ifeq ($(FC),$(null))
 FC = gfortran
+endif
 #DEBUG=TRUE
 
-FFLAGS := $(shell nf-config --flibs)
-LDFLAGS := $(shell nf-config --flibs)
-
+ifeq ($(FFLAGS),$(null))
+#FFLAGS := $(shell nf-config --flibs)
+FFLAGS := -I$(INC_NETCDF)
+endif
+ifeq ($(LDFLAGS),$(null))
+#LDFLAGS := $(shell nf-config --flibs)
+LDFLAGS := -L$(LIB_NETCDF) -lnetcdf -lnetcdff -lcurl
+endif
 
 # Check for the NetCDF library and include directories 
 ifeq ($(LIB_NETCDF),$(null))

--- a/components/eam/tools/topo_tool/cube_to_target/cube_to_target.F90
+++ b/components/eam/tools/topo_tool/cube_to_target/cube_to_target.F90
@@ -1576,7 +1576,7 @@ SUBROUTINE overlap_weights(weights_lgr_index_all,weights_eul_index_all,weights_a
   REAL(R8), DIMENSION(jall,nreconstruction)  , INTENT(OUT) :: weights_all
   INTEGER, DIMENSION(jall)  , INTENT(OUT) :: weights_lgr_index_all
   
-  REAL(R8), DIMENSION(ncorner,ntarget), INTENT(IN) :: target_corner_lon, target_corner_lat
+  REAL(R8), DIMENSION(ncorner,ntarget), INTENT(INOUT) :: target_corner_lon, target_corner_lat
   
   INTEGER,  DIMENSION(ncorner+1) :: ipanel_array, ipanel_tmp
   REAL(R8), DIMENSION(ncorner)  :: lat, lon

--- a/components/eam/tools/topo_tool/cube_to_target/cube_to_target.F90
+++ b/components/eam/tools/topo_tool/cube_to_target/cube_to_target.F90
@@ -1059,22 +1059,22 @@ subroutine wrtncdf_unstructured(n,terr,landfrac,sgh,sgh30,lon,lat,fout)
   ! Create variable for output
   !
   print *,"Create variable for output"
-  status = nf_def_var (foutid,'PHIS', NF_DOUBLE, 1, nid, terrid)
+  status = nf_def_var (foutid,'PHIS', NF_DOUBLE, 1, (/nid/), terrid)
   if (status .ne. NF_NOERR) call handle_err(status)
   
-  status = nf_def_var (foutid,'LANDFRAC', NF_DOUBLE, 1, nid, landfracid)
+  status = nf_def_var (foutid,'LANDFRAC', NF_DOUBLE, 1, (/nid/), landfracid)
   if (status .ne. NF_NOERR) call handle_err(status)
   
-  status = nf_def_var (foutid,'SGH', NF_DOUBLE, 1, nid, sghid)
+  status = nf_def_var (foutid,'SGH', NF_DOUBLE, 1, (/nid/), sghid)
   if (status .ne. NF_NOERR) call handle_err(status)
   
-  status = nf_def_var (foutid,'SGH30', NF_DOUBLE, 1, nid, sgh30id)
+  status = nf_def_var (foutid,'SGH30', NF_DOUBLE, 1, (/nid/), sgh30id)
   if (status .ne. NF_NOERR) call handle_err(status)
 
-  status = nf_def_var (foutid,'lat', NF_DOUBLE, 1, nid, latvid)
+  status = nf_def_var (foutid,'lat', NF_DOUBLE, 1, (/nid/), latvid)
   if (status .ne. NF_NOERR) call handle_err(status)
   
-  status = nf_def_var (foutid,'lon', NF_DOUBLE, 1, nid, lonvid)
+  status = nf_def_var (foutid,'lon', NF_DOUBLE, 1, (/nid/), lonvid)
   if (status .ne. NF_NOERR) call handle_err(status)
   
   !
@@ -1366,10 +1366,10 @@ subroutine wrtncdf_rll(nlon,nlat,lpole,n,terr_in,landfrac_in,sgh_in,sgh30_in,lon
   status = nf_def_var (foutid,'SGH30', NF_DOUBLE, 2, sgh30dim, sgh30id)
   if (status .ne. NF_NOERR) call handle_err(status)
   
-  status = nf_def_var (foutid,'lat', NF_DOUBLE, 1, latid, latvid)
+  status = nf_def_var (foutid,'lat', NF_DOUBLE, 1, (/latid/), latvid)
   if (status .ne. NF_NOERR) call handle_err(status)
   
-  status = nf_def_var (foutid,'lon', NF_DOUBLE, 1, lonid, lonvid)
+  status = nf_def_var (foutid,'lon', NF_DOUBLE, 1, (/lonid/), lonvid)
   if (status .ne. NF_NOERR) call handle_err(status)
   
   !

--- a/components/eam/tools/topo_tool/cube_to_target/remap.F90
+++ b/components/eam/tools/topo_tool/cube_to_target/remap.F90
@@ -143,7 +143,7 @@ MODULE remap
 
       IF (abs(tmp)>0.01) THEN
         WRITE(*,*) "sum of weights too large",tmp
-        stop
+        !stop
       END IF
       IF (tmp<-1.0E-9) THEN
         WRITE(*,*) "sum of weights is negative - negative area?",tmp,jx,jy


### PR DESCRIPTION
Fixes for EAM cube_to_target topography tool to allow configuring via command line arguments and to prevent aborting when encountering weights outside thresholds with very coarse grids. Allowing configuring via command line arguments enables using a different input USGS raw topo file, which will allow using higher resolution binned topo data for SCREAM, and also allows using lower resolution binned topo data for coarse resolutions to speed up topo generation with very coarse grids (ne2, ne4).

[BFB]