### PR TITLE
Remove ocean unused variable RediKappaData

### DIFF
--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -3783,10 +3783,6 @@
 			 description="Multiplication factors to smooth ssh at coastlines for SAL caculation"
 			 packages="tidalPotentialForcingPKG"
 		/>
-		<var name="RediKappaData" type="real" dimensions="nCells" units="m^2 s^-1"
-			 description="Redi isopycnal mixing Kappa value. This is the data field specified at init."
-			 packages="gm"
-		/>
 	</var_struct>
 	<var_struct name="timeVaryingForcing" time_levs="1">
 		<var name="windSpeedU" type="real" dimensions="nCells Time" units="m s^-1"

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -492,7 +492,7 @@ contains
       type(mpas_pool_type), pointer :: diagnosticsPool
       type(mpas_pool_type), pointer :: forcingPool
 
-      real(kind=RKIND), dimension(:), pointer :: RediKappa, RediKappaData
+      real(kind=RKIND), dimension(:), pointer :: RediKappa
       real(kind=RKIND), dimension(:), pointer :: RediHorizontalTaper
       real(kind=RKIND), dimension(:), pointer :: dcEdge
       real(kind=RKIND) :: coef
@@ -519,7 +519,6 @@ contains
          call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
          call mpas_pool_get_array(diagnosticsPool, 'RediKappa', RediKappa)
          call mpas_pool_get_array(diagnosticsPool, 'RediHorizontalTaper', RediHorizontalTaper)
-         call mpas_pool_get_array(forcingPool, 'RediKappaData', RediKappaData)
          call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
          call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
 


### PR DESCRIPTION
The variable `RediKappaData` exists in the Registry file but is not used in the code. It appears that the gnu compiler removes some underlying information about the array in optimized mode, and then the MPI communication hangs when it tries to communicate the size of the array. When the array is used the simulation no longer hangs on start-up. 

The variable `RediKappaData` was meant for the option of entering a spatially-variable data field from input. Since it has not been used for three years, we should remove it. If this feature is needed in the future, it can be added in properly and tested at that time.

Fixes #5574 
[BFB]