### PR TITLE
Convert thread private variables to allocatable

### DIFF
--- a/components/eam/src/physics/crm/rrtmgp/radiation.F90
+++ b/components/eam/src/physics/crm/rrtmgp/radiation.F90
@@ -1828,6 +1828,9 @@ contains
                ! Extract LW and SW bands we need
                cosp_lwband = get_band_index_lw(10.5_r8, 'micron')
                cosp_swband = get_band_index_sw(0.67_r8, 'micron')
+               ! Initialize packed variables
+               dems_packed = 0._r8
+               dtau_packed = 0._r8
                do ilay = 1,pver
                   do j = 1,ncol_tot
                      dems_packed(j,ilay) = 1._r8 - exp(-cld_tau_bnd_lw(j,ilay+1,cosp_lwband))


### PR DESCRIPTION
Thread private variables in certain aerosol related code was causing problems for coupled MMF runs, but this is a more general problem that limits the flexibility of the PE layout because these variables become unintentionally unallocated other model components like the ocean are using a different number of hardware threads. So this converts those problematic variables to allocatables within each routine that are allocated and deallocated every time they are needed. Performance does not appear to be impacted.

[BFB]