### PR TITLE
Fix domain file name for oQU240wLI

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -2936,7 +2936,7 @@
     <domain name="oQU240wLI">
       <nx>7268</nx>
       <ny>1</ny>
-      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oQU240wLI.160929.nc</file>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oQU240wLI_mask.160929.nc</file>
       <desc>oQU240wLI is an MPAS ocean mesh with quasi-uniform 240 km grid cells, nominally 2 degree resolution. Additionally, it has ocean under landice cavities.:</desc>
     </domain>
 


### PR DESCRIPTION
The domain for ocn/ice grid oQU240wLI was pointing to a non-existent file. This replaces it with the correct file.

Fixes #5579

[BFB] for all currently tested configurations