### PR TITLE
MOSART-sediment: suspended sediment module

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -13,6 +13,7 @@ _TESTS = {
     "e3sm_mosart_developer" : {
         "share" : True,
         "time"  : "0:45:00",
+        "inherit" : ("e3sm_mosart_sediment"),
         "tests" : (
             "ERS.r05_r05.RMOSGPCC.mosart-gpcc_1972",
             "ERS.MOS_USRDAT.RMOSGPCC.mosart-mos_usrdat",
@@ -25,6 +26,13 @@ _TESTS = {
         "time"  : "0:45:00",
         "tests" : (
             "ERS.ne30pg2_r05_EC30to60E2r2.GPMPAS-JRA.mosart-rof_ocn_2way",
+            )
+        },
+
+    "e3sm_mosart_sediment" : {
+        "time"  : "0:45:00",
+        "tests" : (
+            "ERS.MOS_USRDAT.RMOSNLDAS.mosart-sediment",
             )
         },
 

--- a/components/data_comps/dlnd/src/dlnd_comp_mod.F90
+++ b/components/data_comps/dlnd/src/dlnd_comp_mod.F90
@@ -53,7 +53,7 @@ module dlnd_comp_mod
   !--------------------------------------------------------------------------
   !--- names of fields ---
   integer(IN),parameter :: fld_len = 12       ! max character length of fields in avofld & avifld
-  integer(IN),parameter :: nflds_nosnow = 28
+  integer(IN),parameter :: nflds_nosnow = 29
 
   ! fields other than snow fields:
   character(fld_len),parameter  :: avofld_nosnow(1:nflds_nosnow) = &
@@ -62,7 +62,7 @@ module dlnd_comp_mod
        "Fall_lat    ","Fall_sen    ","Fall_lwup   ","Fall_evap   ","Fall_swnet  ", &
        "Sl_landfrac ","Sl_fv       ","Sl_ram1     ","Flrl_demand ",                &
         "Flrl_rofsur ","Flrl_rofgwl ","Flrl_rofsub ","Flrl_rofdto ","Flrl_rofi   ", &
-       "Fall_flxdst1","Fall_flxdst2","Fall_flxdst3","Fall_flxdst4"                 /)
+       "Fall_flxdst1","Fall_flxdst2","Fall_flxdst3","Fall_flxdst4", "Flrl_rofmud "/)
 
   character(fld_len),parameter  :: avifld_nosnow(1:nflds_nosnow) = &
        (/ "t           ","tref        ","qref        ","avsdr       ","anidr       ", &
@@ -70,7 +70,7 @@ module dlnd_comp_mod
        "lat         ","sen         ","lwup        ","evap        ","swnet       ", &
        "lfrac       ","fv          ","ram1        ","demand      ",                &
         "rofsur      ","rofgwl      ","rofsub      ","rofdto      ","rofi        ", &
-       "flddst1     ","flxdst2     ","flxdst3     ","flxdst4     "                 /)
+       "flddst1     ","flxdst2     ","flxdst3     ","flxdst4     " ,"rofmud      "/)
 
   integer(IN), parameter :: nflds_snow  = 3   ! number of snow fields in each elevation class
   integer(IN), parameter :: nec_len    = 2   ! length of elevation class index in field names

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -1866,7 +1866,7 @@ Runtime flag to turn on/off lake water storage.
 </entry>
 
 <!-- ========================================================================================  -->
-<!-- Namelist options for downscaling from grid to topounit                                              -->
+<!-- Namelist options for downscaling from grid to topounit                                    -->
 <!-- ========================================================================================  -->
 
 <entry id="use_atm_downscaling_to_topunit" 

--- a/components/elm/src/cpl/elm_cpl_indices.F90
+++ b/components/elm/src/cpl/elm_cpl_indices.F90
@@ -32,6 +32,7 @@ module elm_cpl_indices
   integer, public ::index_l2x_Flrl_Tqsur      ! lnd->rtm input surface runoff temperature
   integer, public ::index_l2x_Flrl_Tqsub      ! lnd->rtm input subsurface runoff temperature
   integer, public ::index_l2x_coszen_str      ! lnd->rtm cosine of zenith  
+  integer, public ::index_l2x_Flrl_rofmud     ! lnd->rtm input sediment yield fluxes
   integer, public ::index_l2x_Flrl_inundinf   ! lnd->rtm infiltration from floodplain inundation
   integer, public ::index_l2x_Sl_t            ! temperature
   integer, public ::index_l2x_Sl_tref         ! 2m reference temperature
@@ -141,7 +142,7 @@ contains
     !
     ! !USES:
     use seq_flds_mod   , only: seq_flds_x2l_fields, seq_flds_l2x_fields,       &
-                               lnd_rof_two_way
+                               lnd_rof_two_way, rof_sed
     use mct_mod        , only: mct_aVect, mct_aVect_init, mct_avect_indexra
     use mct_mod        , only: mct_aVect_clean, mct_avect_nRattr
     use seq_drydep_mod , only: drydep_fields_token, lnd_drydep
@@ -185,6 +186,9 @@ contains
     index_l2x_Flrl_Tqsur    = mct_avect_indexra(l2x,'Flrl_Tqsur')
     index_l2x_Flrl_Tqsub    = mct_avect_indexra(l2x,'Flrl_Tqsub')
     index_l2x_coszen_str    = mct_avect_indexra(l2x,'coszen_str')
+	if(rof_sed) then
+      index_l2x_Flrl_rofmud   = mct_avect_indexra(l2x,'Flrl_rofmud')
+	end if
     if (lnd_rof_two_way) then
       index_l2x_Flrl_inundinf = mct_avect_indexra(l2x,'Flrl_inundinf')
     endif

--- a/components/elm/src/cpl/lnd_import_export.F90
+++ b/components/elm/src/cpl/lnd_import_export.F90
@@ -11,6 +11,7 @@ module lnd_import_export
   use TopounitDataType , only: top_as, top_af  ! atmospheric state and flux variables  
   use elm_cpl_indices
   use mct_mod
+  use seq_flds_mod    , only : rof_sed
   !
   implicit none
   !===============================================================================
@@ -1446,7 +1447,10 @@ contains
        endif
        l2x(index_l2x_Flrl_Tqsur,i)  = lnd2atm_vars%Tqsur_grc(g)
        l2x(index_l2x_Flrl_Tqsub,i)  = lnd2atm_vars%Tqsub_grc(g)
-       l2x(index_l2x_coszen_str,i) = lnd2atm_vars%coszen_str(g)
+       l2x(index_l2x_coszen_str,i)  = lnd2atm_vars%coszen_str(g)
+	   if (rof_sed) then
+           l2x(index_l2x_Flrl_rofmud,i) = lnd2atm_vars%qflx_rofmud_grc(g)
+	   end if
        l2x(index_l2x_Flrl_wslake,i) = lnd2atm_vars%wslake_grc(g)/dtime
 
        if (index_l2x_Flrl_inundinf /= 0) then

--- a/components/elm/src/main/elm_driver.F90
+++ b/components/elm/src/main/elm_driver.F90
@@ -128,6 +128,7 @@ module elm_driver
   use elm_instMod            , only : chemstate_vars
   use elm_instMod            , only : alm_fates
   use elm_instMod            , only : PlantMicKinetics_vars
+  use elm_instMod            , only : sedflux_vars
   use tracer_varcon          , only : is_active_betr_bgc
   use CNEcosystemDynBetrMod  , only : CNEcosystemDynBetr, CNFluxStateBetrSummary
   use UrbanParamsType        , only : urbanparams_vars
@@ -1385,10 +1386,11 @@ contains
     endif
 
     call t_startf('lnd2atm')
-    call lnd2atm(bounds_proc,       &
-         atm2lnd_vars, surfalb_vars, frictionvel_vars,    &
-         energyflux_vars, solarabs_vars, drydepvel_vars,  &
-         vocemis_vars, dust_vars, ch4_vars, soilhydrology_vars, lnd2atm_vars)
+    call lnd2atm(bounds_proc,                                   &
+         atm2lnd_vars, surfalb_vars, frictionvel_vars,          &
+         energyflux_vars, solarabs_vars, drydepvel_vars,        &
+         vocemis_vars, dust_vars, ch4_vars, soilhydrology_vars, &
+         sedflux_vars, lnd2atm_vars)
     call t_stopf('lnd2atm')
 
     ! ============================================================================

--- a/components/elm/src/main/lnd2atmMod.F90
+++ b/components/elm/src/main/lnd2atmMod.F90
@@ -33,6 +33,7 @@ module lnd2atmMod
   use ColumnDataType       , only : col_ws, col_wf, col_cf, col_es
   use VegetationDataType   , only : veg_es, veg_ef, veg_ws, veg_wf
   use SoilHydrologyType    , only : soilhydrology_type 
+  use SedFluxType          , only : sedflux_type
   use spmdmod          , only: masterproc
   use elm_varctl     , only : iulog
   !
@@ -141,7 +142,8 @@ contains
        atm2lnd_vars, surfalb_vars, frictionvel_vars, &
        energyflux_vars, &
        solarabs_vars, drydepvel_vars, &
-       vocemis_vars, dust_vars, ch4_vars, soilhydrology_vars, lnd2atm_vars)
+       vocemis_vars, dust_vars, ch4_vars, soilhydrology_vars, &
+       sedflux_vars, lnd2atm_vars)
     !
     ! !DESCRIPTION:
     ! Compute lnd2atm_vars component of gridcell derived type
@@ -162,6 +164,7 @@ contains
     type(dust_type)        , intent(in)     :: dust_vars
     type(ch4_type)         , intent(in)     :: ch4_vars
     type(soilhydrology_type), intent(in)    :: soilhydrology_vars
+    type(sedflux_type)     , intent(in)     :: sedflux_vars
     type(lnd2atm_type)     , intent(inout)  :: lnd2atm_vars
     !
     ! !LOCAL VARIABLES:
@@ -469,6 +472,11 @@ contains
 
     end do
 
+    call c2g( bounds, &
+         sedflux_vars%sed_yld_col(bounds%begc:bounds%endc), &
+         lnd2atm_vars%qflx_rofmud_grc(bounds%begg:bounds%endg), &
+         c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
+    
     end associate
   end subroutine lnd2atm
 

--- a/components/elm/src/main/lnd2atmType.F90
+++ b/components/elm/src/main/lnd2atmType.F90
@@ -72,6 +72,7 @@ module lnd2atmType
      real(r8), pointer :: Tqsub_grc(:) => null()             ! grc Temperature of subsurface runoff
      real(r8), pointer :: wslake_grc(:) => null()            ! grc lake water storage
 
+     real(r8), pointer :: qflx_rofmud_grc(:)       => null() ! grc sediment yield
      real(r8), pointer :: qflx_h2orof_drain_grc(:) => null() ! grc drainage from floodplain inundation
      
    contains
@@ -163,6 +164,7 @@ contains
        allocate(this%ddvel_grc(begg:endg,1:n_drydep));   this%ddvel_grc(:,:)=ival
     end if
 
+    allocate(this%qflx_rofmud_grc      (begg:endg)); this%qflx_rofmud_grc      (:) =ival
     allocate(this%qflx_h2orof_drain_grc(begg:endg)); this%qflx_h2orof_drain_grc(:) = ival
 
   end subroutine InitAllocate

--- a/components/mosart/cime_config/config_compsets.xml
+++ b/components/mosart/cime_config/config_compsets.xml
@@ -19,4 +19,9 @@
     <lname>2000_DATM%QIA_DLND%GPCC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 
+  <compset>
+    <alias>RMOSNLDAS</alias>
+    <lname>2000_SATM_DLND%LCLMR_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+  </compset>
+  
 </compsets>

--- a/components/mosart/cime_config/testdefs/testmods_dirs/mosart/sediment/shell_commands
+++ b/components/mosart/cime_config/testdefs/testmods_dirs/mosart/sediment/shell_commands
@@ -1,0 +1,51 @@
+input_data_dir=`./xmlquery DIN_LOC_ROOT --value`
+
+./xmlchange LND_DOMAIN_FILE=domain.lnd.nldas2_0224x0464_c110415.nc
+./xmlchange LND_DOMAIN_PATH=${input_data_dir}/share/domains/domain.clm
+
+./xmlchange DLND_MODE=CLMNLDAS
+./xmlchange DLND_CPLHIST_CASE=NLDAS
+
+./xmlchange -file env_run.xml -id DLND_CPLHIST_YR_END -val 1979
+./xmlchange -file env_run.xml -id DLND_CPLHIST_YR_START -val 1979
+./xmlchange -file env_run.xml -id DLND_CPLHIST_YR_ALIGN -val 1
+
+cat >> user_dlnd.streams.txt.clm.nldas << EOF
+<?xml version="1.0"?>
+<file id="stream" version="1.0">
+<dataSource>
+   GENERIC
+</dataSource>
+<domainInfo>
+  <variableNames>
+     time     time
+        lon      lon
+        lat      lat
+        area     area
+        landfrac mask
+  </variableNames>
+  <filePath>
+     $input_data_dir/lnd/dlnd7/NLDAS
+  </filePath>
+  <fileNames>
+     sy_new1_Livneh_NLDAS_1970_2011.nc
+  </fileNames>
+</domainInfo>
+<fieldInfo>
+   <variableNames>
+     sy        rofmud
+        QDRAI     rofsub
+        QOVER     rofsur
+   </variableNames>
+   <filePath>
+     $input_data_dir/lnd/dlnd7/NLDAS
+   </filePath>
+   <fileNames>
+    Sediment_runoff_e3sm_daily_nldas_1979_09.nc
+   </fileNames>
+   <offset>
+      0
+   </offset>
+</fieldInfo>
+</file>
+EOF

--- a/components/mosart/cime_config/testdefs/testmods_dirs/mosart/sediment/user_nl_mosart
+++ b/components/mosart/cime_config/testdefs/testmods_dirs/mosart/sediment/user_nl_mosart
@@ -1,0 +1,5 @@
+frivinp_rtm = '$DIN_LOC_ROOT/rof/mosart/MOSART_NLDAS_8th_20160426_20210609d_rslp.nc'
+sediflag = .true.
+parafile = '$DIN_LOC_ROOT/rof/mosart/US_reservoir_8th_NLDAS3_updated.nc'
+routingmethod = 2
+dlevelh2r = 100

--- a/components/mosart/src/cpl/rof_cpl_indices.F90
+++ b/components/mosart/src/cpl/rof_cpl_indices.F90
@@ -41,6 +41,7 @@ module rof_cpl_indices
   integer, public :: index_x2r_Faxa_swvdf = 0   ! atm->rof shorwave visible diffus flux
   integer, public :: index_x2r_Faxa_swndr = 0   ! atm->rof shorwave near-ir direct flux
   integer, public :: index_x2r_Faxa_swndf = 0   ! atm->rof shorwave near-ir diffus flux
+  integer, public :: index_x2r_Flrl_rofmud = 0  ! lnd->rof input suspended sediment flux from soil erosion
   integer, public :: index_x2r_Flrl_inundinf = 0! lnd->rof infiltration from floodplain inundation
   integer, public :: nflds_x2r = 0
 
@@ -48,10 +49,12 @@ module rof_cpl_indices
   integer, public :: index_x2r_So_ssh = 0        ! ocn->rof ssh from ocean
 
   !TODO - nt_rtm and rtm_tracers need to be removed and set by access to the index array
-  integer, parameter, public :: nt_rtm = 2    ! number of tracers
-  character(len=3), parameter, public :: rtm_tracers(nt_rtm) =  (/'LIQ','ICE'/)
+  integer, parameter, public :: nt_rtm = 4    ! number of tracers
+  character(len=3), parameter, public :: rtm_tracers(nt_rtm) =  (/'LIQ','ICE','MUD','SAN'/)
   integer, parameter, public :: nt_nliq = 1    ! number of tracers
   integer, parameter, public :: nt_nice = 2    ! number of tracers
+  integer, parameter, public :: nt_nmud = 3    ! number of tracers
+  integer, parameter, public :: nt_nsan = 4    ! number of tracers
 
   !Routing methods used for the main-channel
   integer, parameter, public :: KW = 1         ! kinematic wave routing method
@@ -97,7 +100,8 @@ contains
     !
     ! !USES:
     use seq_flds_mod  , only: seq_flds_r2x_fields, seq_flds_x2r_fields, rof_heat, &
-                              rof2ocn_nutrients, lnd_rof_two_way, ocn_rof_two_way
+                              rof2ocn_nutrients, lnd_rof_two_way, ocn_rof_two_way, &
+                              rof_sed
     use mct_mod       , only: mct_aVect, mct_aVect_init, mct_avect_indexra, &
                               mct_aVect_clean, mct_avect_nRattr
     !
@@ -141,7 +145,9 @@ contains
     endif
 
     index_x2r_coszen_str  = mct_avect_indexra(avtmp,'coszen_str')
-
+	if (rof_sed) then
+        index_x2r_Flrl_rofmud = mct_avect_indexra(avtmp,'Flrl_rofmud')
+	end if
     if (lnd_rof_two_way) then
       index_x2r_Flrl_inundinf =  mct_avect_indexra(avtmp,'Flrl_inundinf')
     endif

--- a/components/mosart/src/riverroute/MOSART_BGC_type.F90
+++ b/components/mosart/src/riverroute/MOSART_BGC_type.F90
@@ -1,0 +1,209 @@
+
+module MOSART_BGC_type
+
+!-----------------------------------------------------------------------
+!BOP
+!
+! !MODULE: MOSART_BGC_type
+!
+! !DESCRIPTION:
+! Module containing data structure for riverine biogeochemistry
+!
+!! !REVISION HISTORY:
+! Hongyi Li: Created 03/2015
+!USES:
+  use mct_mod
+  use RunoffMod     , only : Tctl, TUnit, rtmCTL
+  use RtmSpmd       , only : masterproc
+  use RtmVar        , only : iulog
+  use RtmIO         , only : pio_subsystem, ncd_pio_openfile, ncd_pio_closefile
+  use rof_cpl_indices, only : nt_rtm
+  use shr_kind_mod  , only : r8 => shr_kind_r8, SHR_KIND_CL
+  use shr_const_mod , only : denh2o => SHR_CONST_RHOFW, denice => SHR_CONST_RHOICE, grav => SHR_CONST_G, SHR_CONST_REARTH, SHR_CONST_PI
+  use shr_sys_mod   , only : shr_sys_flush, shr_sys_abort
+  use MOSART_RES_type  , only : Tres_ctl, Tres_para, Tres
+  use netcdf
+  use pio
+
+
+! !PUBLIC TYPES:
+  implicit none
+  real(r8), parameter :: TINYVALUE_s = 1.0e-14_r8  ! double precision variable has a significance of about 16 decimal digits
+
+  private
+
+! control information for subbasin-based representation
+
+  ! sediment parameters
+  type Tparameter_sedi
+     character(len=200) :: paraFile             ! the path of the parameter files
+     character(len=100) :: inputPath            ! the path of the input files
+
+     real(r8), pointer :: d50(:)                ! median bed-material sediment particle size [m]
+     real(r8), pointer :: u_f(:)                ! formative shear bed shear velocity [m/s]
+  end type Tparameter_sedi 
+
+    ! sediment storage and flux variables
+    ! note most of the storage/flux items are included in runoff_flow structure in the RunoffMod.F90
+    ! here we just add some unique items for sediment such as shear stress etc.
+    !public :: TstatusFlux_sedi
+    type TstatusFlux_sedi
+
+        ! subnetwork channel
+        real(r8), pointer :: Ssal_t(:)      ! sand-sediment storage in active layer, [kg]
+        real(r8), pointer :: Smal_t(:)      ! mudd-sediment storage in active layer, [kg]
+        real(r8), pointer :: ers_t(:)       ! sand-sediment erosion, [kg/s]
+        real(r8), pointer :: ersal_t(:)     ! sand-sediment erosion @ active layer, [kg/s]
+        real(r8), pointer :: ersb_t(:)      ! sand-sediment erosion @ bank, [kg/s]
+        real(r8), pointer :: ses_t(:)       ! sand-sediment settled to bed zone, [kg/s]
+        real(r8), pointer :: seout_t(:)     ! sand-sediment discharge out of local channel, [kg/s]
+        real(r8), pointer :: erm_t(:)       ! mud-sediment erosion, [kg/s]
+        real(r8), pointer :: ermal_t(:)     ! mud-sediment erosion @ active layer, [kg/s]
+        real(r8), pointer :: ermb_t(:)      ! mud-sediment erosion @ bank, [kg/s]
+        real(r8), pointer :: sem_t(:)       ! mud-sediment settled to bed zone, [kg/s]
+        real(r8), pointer :: meout_t(:)     ! mud-sediment discharge out of local channel, [kg/s]
+        real(r8), pointer :: erb_t(:)       ! total-sediment erosion @ bank, [kg/s]
+
+        ! main channel
+        real(r8), pointer :: Ssal_r(:)      ! sand-sediment storage in active layer, [kg]
+        real(r8), pointer :: Smal_r(:)      ! mudd-sediment storage in active layer, [kg]
+        real(r8), pointer :: ers_r(:)       ! sand-sediment erosion, [kg/s]
+        real(r8), pointer :: ersal_r(:)     ! sand-sediment erosion @ active layer, [kg/s]
+        real(r8), pointer :: ersb_r(:)      ! sand-sediment erosion @ bank, [kg/s]
+        real(r8), pointer :: ses_r(:)       ! sand-sediment settled to bed zone, [kg/s]
+        real(r8), pointer :: seout_r(:)     ! sand-sediment discharge out of local channel, [kg/s]
+        real(r8), pointer :: erm_r(:)       ! mud-sediment erosion, [kg/s]
+        real(r8), pointer :: ermal_r(:)     ! mud-sediment erosion @ active layer, [kg/s]
+        real(r8), pointer :: ermb_r(:)      ! mud-sediment erosion @ bank, [kg/s]
+        real(r8), pointer :: sem_r(:)       ! mud-sediment settled to bed zone, [kg/s]
+        real(r8), pointer :: meout_r(:)     ! mud-sediment discharge out of local channel, [kg/s]
+        real(r8), pointer :: erb_r(:)       ! total-sediment erosion @ bank, [kg/s]
+
+    end type TstatusFlux_sedi
+
+    type (TstatusFlux_sedi)     ,   public :: TSedi
+    type (Tparameter_sedi)      ,   public :: TSedi_para
+
+
+  public :: MOSART_sediment_init
+
+  contains    
+
+  subroutine MOSART_sediment_init(begr, endr, numr)
+
+! !DESCRIPTION:
+! initialize MOSART-sediment variables
+! 
+! !USES:
+! !ARGUMENTS:
+!
+! !REVISION HISTORY:
+! Author: Hongyi Li
+!
+!
+! !OTHER LOCAL VARIABLES:
+!EOP
+    integer :: ier, ios
+    character(len=1000) :: fname
+    type(file_desc_t)  :: ncid       ! pio file desc
+    type(var_desc_t)   :: vardesc    ! pio variable desc 
+    type(io_desc_t)    :: iodesc_dbl ! pio io desc
+    type(io_desc_t)    :: iodesc_int ! pio io desc
+    integer, pointer   :: compdof(:) ! computational degrees of freedom for pio 
+    integer :: dids(2)               ! variable dimension ids 
+    integer :: dsizes(2)             ! variable dimension lengths
+    integer :: begr, endr, numr, iunit, nn, n, cnt, nr, nt
+    integer :: numDT_r, numDT_t
+    integer :: lsize, gsize
+    integer :: igrow, igcol, iwgt
+    integer :: tcnt
+    character(len=16384) :: rList             ! list of fields for SM multiply
+    character(len=*),parameter :: FORMI = '(2A,2i10)'
+    character(len=*),parameter :: FORMR = '(2A,2g15.7)'
+    character(len=*),parameter :: subname='(MOSART_sediment_para)'
+
+    allocate(TSedi%Ssal_t(begr:endr),       &
+             TSedi%Smal_t(begr:endr),       &
+             TSedi%ers_t(begr:endr),       &
+             TSedi%ersal_t(begr:endr),     &
+             TSedi%ersb_t(begr:endr),      &
+             TSedi%ses_t(begr:endr),       &
+             TSedi%erm_t(begr:endr),       &
+             TSedi%ermal_t(begr:endr),     &
+             TSedi%ermb_t(begr:endr),      &
+             TSedi%sem_t(begr:endr),       &
+             TSedi%Ssal_r(begr:endr),       &
+             TSedi%Smal_r(begr:endr),       &
+             TSedi%ers_r(begr:endr),       &
+             TSedi%ersal_r(begr:endr),     &
+             TSedi%ersb_r(begr:endr),      &
+             TSedi%ses_r(begr:endr),       &
+             TSedi%erm_r(begr:endr),       &
+             TSedi%ermal_r(begr:endr),     &
+             TSedi%ermb_r(begr:endr),      &
+             TSedi%sem_r(begr:endr),       &
+             TSedi_para%u_f(begr:endr),    &
+             !TSedi_para%d50(begr:endr),    &
+             stat=ier)
+    if (ier /= 0) then
+       write(iulog,*)'Rtmini ERROR allocation of sediment local flux/status arrays'
+       call shr_sys_abort()
+    end if
+
+    TSedi%Ssal_t = 0._r8
+    TSedi%Smal_t = 0._r8
+    TSedi%ers_t = 0._r8
+    TSedi%ersal_t = 0._r8
+    TSedi%ersb_t = 0._r8
+    TSedi%ses_t = 0._r8
+    TSedi%erm_t = 0._r8
+    TSedi%ermal_t = 0._r8
+    TSedi%ermb_t = 0._r8
+    TSedi%sem_t = 0._r8
+    TSedi%Ssal_r = 0._r8
+    TSedi%Smal_r = 0._r8
+    TSedi%ers_r = 0._r8
+    TSedi%ersal_r = 0._r8
+    TSedi%ersb_r = 0._r8
+    TSedi%ses_r = 0._r8
+    TSedi%erm_r = 0._r8
+    TSedi%ermal_r = 0._r8
+    TSedi%ermb_r = 0._r8
+    TSedi%sem_r = 0._r8
+    !TSedi_para%d50 = 0._r8
+    TSedi_para%u_f = 0._r8
+    do iunit = begr, endr
+        TSedi_para%u_f(iunit) = CRUF(TUnit%rdepth(iunit), TUnit%rslp(iunit))
+    end do
+
+  end subroutine MOSART_sediment_init  
+
+!
+!
+!EOP
+!-----------------------------------------------------------------------
+    function CRUF(h_,slope_) result(uf_)
+      ! !DESCRIPTION: calculate formative shear bed shear velocity following Lamb and Venditti (2016)
+      implicit none
+      real(r8), intent(in) :: h_,slope_   !
+      real(r8)             :: uf_       ! formative shear bed shear velocity, [m/s]
+
+      real(r8) :: vs   !
+      real(r8) :: f_, gamma_ !
+      real(r8) :: D90_to_D50  !
+
+      f_ = 1.5_r8
+      gamma_ = 0.9_r8
+      D90_to_D50 = 3.0_r8
+
+      vs = sqrt(grav*h_*slope_)
+      uf_ = vs*sqrt(f_*D90_to_D50**(1-gamma_))
+
+      if(abs(uf_) < TINYVALUE_s) then
+          uf_ = 0._r8
+      endif
+      return
+    end function CRUF
+
+
+end module MOSART_BGC_type 

--- a/components/mosart/src/riverroute/MOSART_RES_type.F90
+++ b/components/mosart/src/riverroute/MOSART_RES_type.F90
@@ -1,0 +1,229 @@
+
+module MOSART_RES_type
+
+!-----------------------------------------------------------------------
+!BOP
+!
+! !MODULE: MOSART_RES_type
+!
+! !DESCRIPTION:
+! Module containing data structure for reservoir dynamics
+!
+!! !REVISION HISTORY:
+! Hongyi Li: Created 03/2015
+!USES:
+  use RunoffMod     , only : Tctl, TUnit, rtmCTL
+  use RtmSpmd       , only : masterproc
+  use RtmVar        , only : iulog
+  use RtmIO         
+  use rof_cpl_indices, only : nt_rtm
+  use shr_kind_mod  , only : r8 => shr_kind_r8, SHR_KIND_CL
+  use shr_const_mod , only : SHR_CONST_REARTH, SHR_CONST_PI
+  use shr_sys_mod   , only : shr_sys_flush, shr_sys_abort
+  use netcdf
+  use pio
+  use WRM_type_mod  , only : ctlSubwWRM, WRMUnit 
+
+! !PUBLIC TYPES:
+  implicit none
+  private
+
+! control information for reservoirs
+  type Treservoir_control
+     integer :: NDam             ! number of dams
+     integer :: localNumDam      ! number of dams on decomposition
+
+     integer :: month            ! month of the simulation
+     integer :: year             ! year of the simulation
+     integer :: RESFlag          ! Flag for invoking reservoir processes or not
+
+     character(len=350) :: paraFile         ! the path of the parameter files
+     character(len=350) :: paraPath         ! the path of the parameter files
+
+  end type Treservoir_control
+
+! reservoirs information: geometry etc.
+    type Tpara_reservoir
+
+        ! reservoirs or lakes
+        real(r8), pointer :: height(:)       ! reservoir height, [m]
+        real(r8), pointer :: length(:)       ! reservoir length, [m]
+        real(r8), pointer :: area(:)         ! reservoir surface area, [m2]
+        real(r8), pointer :: storage(:,:)    ! reservoir storage, [m3] for water, [kg] for sediment
+        real(r8), pointer :: Tres(:)         ! Change of water residence time due to a reservoir on main channel, [yrs]
+                                             ! here the reservoirs both regulate flow and trap sediment
+        real(r8), pointer :: Tres_t(:)       ! Change of water residence time due to a reservoir on sub-network channel, [yrs]
+        real(r8), pointer :: Tres_r(:)       ! Change of water residence time due to a reservoir on main channel, [yrs]
+                                             ! here the reservoirs only trap sediment 
+        real(r8), pointer :: Eff_trapping(:) ! reservoir trapping efficiency on main channel, [-]
+        real(r8), pointer :: Eff_trapping_t(:) ! reservoir trapping efficiency on sub-network channel, [-]
+        real(r8), pointer :: Eff_trapping_r(:) ! reservoir trapping efficiency on main channel, [-]
+    end type Tpara_reservoir
+
+! reservoirs status and fluxes
+    type TstatusFlux_reservoir
+     ! reservoirs, lakes on the main channel
+     !! states
+     real(r8), pointer :: wres(:,:)    ! MOSART reservoir storage (m3 for water, kg for mud and sand sediment)
+     real(r8), pointer :: dwres(:,:)   ! MOSART reservoir storage change (m3 for water, kg for mud and sand sediment)
+     !! exchange fluxes
+     real(r8), pointer :: eres_in(:,:) ! MOSART reservoir inflow  (m3/s for water, kg/s for mud and sand sediment) 
+     real(r8), pointer :: eres_out(:,:)! MOSART reservoir outflow  (m3/s for water, kg/s for mud and sand sediment) 
+
+     ! reservoirs, lakes on the subnetwork channel
+     !! states
+     real(r8), pointer :: wres_t(:,:)    ! MOSART reservoir storage (m3 for water, kg for mud and sand sediment)
+     real(r8), pointer :: dwres_t(:,:)   ! MOSART reservoir storage change (m3 for water, kg for mud and sand sediment)
+     !! exchange fluxes
+     real(r8), pointer :: eres_in_t(:,:) ! MOSART reservoir inflow  (m3/s for water, kg/s for mud and sand sediment) 
+     real(r8), pointer :: eres_out_t(:,:)! MOSART reservoir outflow  (m3/s for water, kg/s for mud and sand sediment) 
+
+    end type TstatusFlux_reservoir
+
+    type (Treservoir_control)   ,   public :: Tres_ctl
+    type (Tpara_reservoir),   public :: Tres_para
+    type (TstatusFlux_reservoir),   public :: Tres
+
+  public :: MOSART_reservoir_sed_init
+
+!-----------------------------------------------------------------------
+  contains
+!-----------------------------------------------------------------------
+
+  subroutine MOSART_reservoir_sed_init
+! !DESCRIPTION:
+! initialize MOSART-reservoir variables
+! 
+! !USES:
+! !ARGUMENTS:
+!
+! !REVISION HISTORY:
+! Author: Hongyi Li
+!
+
+     ! !DESCRIPTION: initilization of reservoir_sed module
+     implicit none
+
+    integer :: ier                  ! error code
+    integer :: begr, endr, iunit, nn, n, cnt, nr, nt
+    integer  :: damID
+    character(len=*),parameter :: subname = '(MOSART_reservoir_sed_init)'
+    character(len=*),parameter :: FORMI = '(2A,2i10)'
+    character(len=*),parameter :: FORMR = '(2A,2g15.7)'
+    type(file_desc_t):: ncid       ! netcdf file
+    type(var_desc_t) :: vardesc    ! netCDF variable description
+    type(io_desc_t)    :: iodesc_dbl ! pio io desc
+
+    begr = rtmCTL%begr
+    endr = rtmCTL%endr  
+
+    if(endr >= begr) then
+        allocate(Tres_para%Tres(begr:endr))
+        Tres_para%Tres = 0._r8
+        allocate(Tres_para%Eff_trapping(begr:endr))
+        Tres_para%Eff_trapping = 0._r8
+        do iunit=begr,endr
+            damID = WRMUnit%INVicell(iunit) 
+            if (.not.(damID > ctlSubwWRM%LocalNumDam .OR. damID <= 0 .or. WRMUnit%MeanMthFlow(damID,13) <= 0.01_r8)) then
+                Tres_para%Tres(iunit) = CRTres(WRMUnit%StorCap(damID), WRMUnit%MeanMthFlow(damID,13))
+                Tres_para%Eff_trapping(iunit) = CREff_trapping(Tres_para%Tres(iunit))
+                !write(iulog,*) ' Reservoir Trapping ', iunit, WRMUnit%StorCap(damID), WRMUnit%MeanMthFlow(damID,13), Tres_para%Tres(iunit), Tres_para%Eff_trapping(iunit)
+            else
+                Tres_para%Tres(iunit) = 0._r8
+                Tres_para%Eff_trapping(iunit) = 0._r8
+            end if
+        end do    
+
+        allocate (Tres%wres(begr:endr,nt_rtm))
+        Tres%wres = 0._r8
+
+        allocate (Tres%dwres(begr:endr,nt_rtm))
+        Tres%dwres = 0._r8
+
+        allocate (Tres%eres_in(begr:endr,nt_rtm))
+        Tres%eres_in = 0._r8
+
+        allocate (Tres%eres_out(begr:endr,nt_rtm))
+        Tres%eres_out = 0._r8    
+
+        if(0>1) then ! comment out temporily, please do not delete. We may need to use this block in future refinement
+            Tres_para%Eff_trapping_t = 0._r8
+            do iunit=begr,endr
+			    if(Tres_para%Tres_t(iunit)>0._r8) then
+                    Tres_para%Eff_trapping_t(iunit) = CREff_trapping(Tres_para%Tres_t(iunit))
+				else
+                    Tres_para%Eff_trapping_t(iunit) = 0._r8
+				end if
+			end do
+        
+            allocate(Tres_para%Eff_trapping_r(begr:endr))
+            Tres_para%Eff_trapping_r = 0._r8
+            do iunit=begr,endr
+			    if(Tres_para%Tres_r(iunit)>0._r8) then
+                   Tres_para%Eff_trapping_r(iunit) = CREff_trapping(Tres_para%Tres_r(iunit))
+				else
+                    Tres_para%Eff_trapping_r(iunit) = 0._r8
+				end if
+			end do
+        end if
+
+        allocate (Tres%wres_t(begr:endr,nt_rtm))
+        Tres%wres_t = 0._r8
+
+        allocate (Tres%dwres_t(begr:endr,nt_rtm))
+        Tres%dwres_t = 0._r8
+
+        allocate (Tres%eres_in_t(begr:endr,nt_rtm))
+        Tres%eres_in_t = 0._r8
+
+        allocate (Tres%eres_out_t(begr:endr,nt_rtm))
+        Tres%eres_out_t = 0._r8    
+
+    end if  
+
+  end subroutine MOSART_reservoir_sed_init  
+
+    function CRTres(V_, Q_) result(Tres_)
+      ! !DESCRIPTION: calculate large reservoir trapping efficiency based on Eqn (1) and Fig. 2 in Vorosmarty et al. (2003)
+      !! Vorosmarty et al, Anthropogenic sediment retention: Major global impact from registered river impoundments, Glob. Planet. Change, 39, 169-190
+      implicit none
+      real(r8), intent(in) :: V_       ! reservoir maximum reported storage capacity, [m3]; 
+      real(r8), intent(in) :: Q_       ! Mean annual inflow, [m3/s]; 
+      real(r8)             :: Tres_        ! approximated residence time of regulated portion of basin [yrs]
+
+      real(r8) :: V_operational  ! proportion of maximum storage at which reservoirs are assumed to operate routinely [m3]
+      real(r8) :: Eeff  ! Utilization factor [-]
+
+      Eeff = 0.67_r8
+      V_operational = Eeff * V_
+      Tres_ = V_operational / Q_ 
+      Tres_ = Tres_ / (365*24*3600)  !seconds --> yrs
+
+      return
+    end function CRTres
+
+    function CREff_trapping(Tres_) result(Eff_trapping_)
+      ! !DESCRIPTION: calculate large reservoir trapping efficiency based on Eqn (1) and Fig. 2 in Vorosmarty et al. (2003)
+      !! Vorosmarty et al, Anthropogenic sediment retention: Major global impact from registered river impoundments, Glob. Planet. Change, 39, 169-190
+      implicit none
+      real(r8), intent(in) :: Tres_        ! approximated residence time of regulated portion of basin [yrs]
+      real(r8)             :: Eff_trapping_        ! trapping efficiency [-]
+
+
+      Eff_trapping_ = 1 - 0.05/sqrt(Tres_)
+
+      if(Eff_trapping_ < 0._r8) then
+          Eff_trapping_ = 0._r8
+      end if
+
+      return
+    end function CREff_trapping
+
+
+!
+!
+!EOP
+!-----------------------------------------------------------------------
+
+
+end module MOSART_RES_type

--- a/components/mosart/src/riverroute/MOSART_reservoir_mod.F90
+++ b/components/mosart/src/riverroute/MOSART_reservoir_mod.F90
@@ -1,0 +1,81 @@
+!
+MODULE MOSART_reservoir_mod
+! Description: core code of MOSART-reservoir. Can be incoporated within any river model via a interface module
+! 
+! Developed by Hongyi Li, 11/2016.
+! REVISION HISTORY:
+!-----------------------------------------------------------------------
+
+! !USES:
+    use shr_kind_mod  , only : r8 => shr_kind_r8, SHR_KIND_CL
+    use shr_const_mod , only : denh2o => SHR_CONST_RHOFW, denice => SHR_CONST_RHOICE, grav => SHR_CONST_G, SHR_CONST_REARTH, SHR_CONST_PI
+    !use clm_varcon , only : denh2o, grav !!density of liquid water [kg/m3], gravity constant [m/s2]
+    use RunoffMod, only : Tctl, TUnit, TRunoff, TPara
+    use RunoffMod, only : rtmCTL
+    use rof_cpl_indices, only : nt_rtm, rtm_tracers, nt_nliq, nt_nice, nt_nmud, nt_nsan
+    use MOSART_RES_type, only : Tres_para, Tres
+    implicit none
+    real(r8), parameter :: TINYVALUE_r = 1.0e-14_r8  ! double precision variable has a significance of about 16 decimal digits
+
+! !PUBLIC MEMBER FUNCTIONS:
+    contains
+
+
+    subroutine res_trapping(iunit, nt)
+    ! !DESCRIPTION: trapping of particulate fluxes in the reservoirs on the main channels (e.g., sediment)
+    ! !assume the trapping occurs after the channel routing, i.e., won't affect the current channel mass balance, but only change the outflow to the downstream
+        implicit none
+
+        integer, intent(in) :: iunit, nt
+        !real(r8), intent(in) :: theDeltaT
+
+        real(r8) :: trapping_eff  ! trapping efficiency, proportion
+        trapping_eff = Tres_para%Eff_trapping(iunit)
+
+        Tres%eres_in(iunit,nt) = -TRunoff%erout(iunit,nt)  * trapping_eff
+        Tres%eres_out(iunit,nt) = 0._r8  ! currently assuming no sediment release from the dam bottom (this might be OK in U.S., but wrong in other plances such as China)
+        Tres%dwres(iunit,nt) =  Tres%eres_in(iunit,nt) + Tres%eres_out(iunit,nt)
+
+        TRunoff%erout(iunit,nt) = TRunoff%erout(iunit,nt) * (1._r8 - trapping_eff)
+
+    end subroutine res_trapping
+
+    subroutine res_trapping_t(iunit, nt)
+    ! !DESCRIPTION: trapping of particulate fluxes in the reservoirs on the sub-network channels (e.g., sediment)
+    ! !assume the trapping occurs after the channel routing, i.e., won't affect the current channel mass balance, but only change the outflow to the downstream
+        implicit none
+
+        integer, intent(in) :: iunit, nt
+        !real(r8), intent(in) :: theDeltaT
+
+        real(r8) :: trapping_eff_t  ! trapping efficiency, propoation
+        trapping_eff_t = Tres_para%Eff_trapping_t(iunit)
+
+        Tres%eres_in_t(iunit,nt) = -TRunoff%erlateral(iunit,nt)  * trapping_eff_t
+        Tres%eres_out_t(iunit,nt) = 0._r8  ! currently assuming no sediment release from the dam bottom (this might be OK in U.S., but wrong in other plances such as China)
+        Tres%dwres_t(iunit,nt) =  Tres%eres_in_t(iunit,nt) + Tres%eres_out_t(iunit,nt)
+
+        TRunoff%erlateral(iunit,nt) = TRunoff%erlateral(iunit,nt) * (1._r8 - trapping_eff_t)
+
+    end subroutine res_trapping_t
+
+    subroutine res_trapping_r(iunit, nt)
+    ! !DESCRIPTION: trapping of particulate fluxes in the reservoirs on the main channels (e.g., sediment)
+    ! !assume the trapping occurs after the channel routing, i.e., won't affect the current channel mass balance, but only change the outflow to the downstream
+        implicit none
+
+        integer, intent(in) :: iunit, nt
+        !real(r8), intent(in) :: theDeltaT
+
+        real(r8) :: trapping_eff_r  ! trapping efficiency, proportion
+        trapping_eff_r = Tres_para%Eff_trapping_r(iunit)
+
+        Tres%eres_in(iunit,nt) = -TRunoff%erout(iunit,nt)  * trapping_eff_r
+        Tres%eres_out(iunit,nt) = 0._r8  ! currently assuming no sediment release from the dam bottom (this might be OK in U.S., but wrong in other plances such as China)
+        Tres%dwres(iunit,nt) =  Tres%eres_in(iunit,nt) + Tres%eres_out(iunit,nt)
+
+        TRunoff%erout(iunit,nt) = TRunoff%erout(iunit,nt) * (1._r8 - trapping_eff_r)
+
+    end subroutine res_trapping_r
+
+end MODULE MOSART_reservoir_mod 

--- a/components/mosart/src/riverroute/MOSART_sediment_mod.F90
+++ b/components/mosart/src/riverroute/MOSART_sediment_mod.F90
@@ -1,0 +1,530 @@
+!
+MODULE MOSART_sediment_mod
+! Description: core code of MOSART-sediment. Can be incoporated within any land model via a interface module
+! 
+! Developed by Hongyi Li, 03/2015.
+! REVISION HISTORY:
+!-----------------------------------------------------------------------
+
+! !USES:
+    use shr_kind_mod  , only : r8 => shr_kind_r8, SHR_KIND_CL
+    use shr_const_mod , only : denh2o => SHR_CONST_RHOFW, denice => SHR_CONST_RHOICE, grav => SHR_CONST_G, SHR_CONST_REARTH, SHR_CONST_PI
+    use RtmVar        , only : iulog, inst_suffix, smat_option
+    use shr_sys_mod   , only : shr_sys_abort
+    !use clm_varcon , only : denh2o, grav !!density of liquid water [kg/m3], gravity constant [m/s2]
+    use RunoffMod, only : Tctl, TUnit, TRunoff, TPara
+    use RunoffMod, only : rtmCTL
+    use rof_cpl_indices, only : nt_rtm, rtm_tracers, nt_nliq, nt_nice, nt_nmud, nt_nsan, KW, DW
+    use MOSART_BGC_type, only : TSedi, TSedi_para
+    implicit none
+    real(r8), parameter :: TINYVALUE_s = 1.0e-12_r8  ! double precision variable has a significance of about 16 decimal digits
+    real(r8), parameter :: densedi = 2650._r8      ! density of sediment [Kg/m3]
+    !real(r8), parameter :: diam_sand = 0.00035_r8  ! grain size of sand, 0.35mm
+    real(r8), parameter :: KVIS = 1.0036e-6_r8     ! the kinematic viscosity (m2/s)at 20°Ê*/
+    real(r8), parameter :: DVIS = 1.002e-3_r8      ! the dynamatic viscosity (Pa°§s)at 20°Ê*/
+
+! !PUBLIC MEMBER FUNCTIONS:
+    contains
+
+    subroutine hillslopeSediment(iunit, theDeltaT)
+    ! !DESCRIPTION: Hillslope erosion/routing of sediment
+        implicit none
+
+        integer, intent(in) :: iunit
+        real(r8), intent(in) :: theDeltaT
+
+        real(r8) :: Tau_h
+        TRunoff%ehout(iunit, nt_nmud) = -TRunoff%qsur(iunit,nt_nmud) !0._r8
+        TRunoff%qsub(iunit, nt_nmud) = 0._r8
+        !TRunoff%etin(iunit,nt_nmud) = 0._r8
+        !TRunoff%etin(iunit,nt_nmud) = TRunoff%qsur(iunit,nt_nmud) * TUnit%area(iunit)
+
+        !TRunoff%etin(iunit,nt_nmud) = 1.e-6_r8 * TUnit%area(iunit) * TUnit%frac(iunit) ! Ks/s
+        !TRunoff%etin(iunit,nt_nsan) = 1.e-6_r8 * TUnit%area(iunit) * TUnit%frac(iunit) ! Ks/s
+    end subroutine hillslopeSediment
+
+    subroutine subnetworkSediment(iunit, theDeltaT)
+    ! !DESCRIPTION: subnetwork channel processes for mud sediment. Assume no sand sediment in tributary channels
+        implicit none    
+        integer, intent(in) :: iunit !, nt      
+        real(r8), intent(in) :: theDeltaT
+
+        !real(r8) :: ers       ! sand-sediment erosion
+        !real(r8) :: ersal     ! sand-sediment erosion @ active layer
+        !real(r8) :: ersb      ! sand-sediment erosion @ bank
+        !real(r8) :: ses       ! sand-sediment settled to bed zone
+        !real(r8) :: seout     ! sand-sediment discharge out of local channel
+        real(r8) :: erm       ! mud-sediment erosion
+        real(r8) :: ermal     ! mud-sediment erosion @ active layer
+        real(r8) :: ermb      ! mud-sediment erosion @ bank
+        real(r8) :: sem       ! mud-sediment settled to bed zone
+        real(r8) :: meout     ! mud-sediment discharge out of local channel
+        real(r8) :: erb       ! total-sediment erosion @ bank
+        real(r8) :: temp1, temp2, w_temp
+
+
+        real(r8) :: Achannel  ! effective channel area
+
+            ! sand-sediment
+            !ses = CRSES(iunit,TRunoff%yt(iunit,nt_nliq),TUnit%tslp(iunit),TRunoff%conc_t(iunit,nt_nsan))
+            !ers = CRERS(TRunoff%yt(iunit,nt_nliq),TUnit%tslp(iunit))
+            !seout = -TRunoff%etout(iunit,nt_nliq)*TRunoff%conc_t(iunit,nt_nsan)
+            ! mud-sediment
+            sem = 0._r8 !CRSEM(TRunoff%yt(iunit,nt_nliq),TUnit%tslp(iunit),TRunoff%conc_t(iunit,nt_nmud))
+            erm = 0._r8 !CRERM(TRunoff%yt(iunit,nt_nliq),TUnit%tslp(iunit),TRunoff%conc_t(iunit,nt_nmud))
+            meout = -TRunoff%etout(iunit,nt_nliq)*TRunoff%conc_t(iunit,nt_nmud)
+
+            if(TRunoff%wt(iunit,nt_nmud) <= TINYVALUE_s) then
+                meout = 0._r8
+                sem = 0._r8
+            else if ((meout+sem) * theDeltaT > TRunoff%wt(iunit,nt_nmud)+TINYVALUE_s) then
+                w_temp = TRunoff%wt(iunit,nt_nmud) * 0.95_r8
+                temp1 = sem/(sem+meout)
+                temp2 = meout/(sem+meout)
+                sem = temp1*w_temp/theDeltaT
+                meout = temp2*w_temp/theDeltaT
+            end if
+
+            erm = 0._r8
+            ermal = 0._r8
+            ermb = 0._r8
+            sem = 0._r8
+            TSedi%ermal_t(iunit)  =   ermal
+            TSedi%sem_t(iunit)    =   sem
+            TSedi%ermb_t(iunit)   =   ermb            
+
+            TRunoff%etout(iunit,nt_nsan) = 0._r8
+            TRunoff%etout(iunit,nt_nmud) = -meout
+
+            TSedi%Ssal_t(iunit) = 0._r8 ! TSedi%Ssal_t(iunit) + (TSedi%ses_t(iunit) - TSedi%ersal_t(iunit)) * theDeltaT
+            !TSedi%Smal_t(iunit) = 0._r8 ! TSedi%Smal_t(iunit) + (TSedi%sem_t(iunit) - TSedi%ermal_t(iunit)) * theDeltaT
+
+            TRunoff%dwt(iunit,nt_nsan) = 0._r8 !TRunoff%etin(iunit,nt_nsan) + TRunoff%etout(iunit,nt_nsan) + TSedi%ersal_t(iunit) - TSedi%ses_t(iunit) + TSedi%ersb_t(iunit)
+            TRunoff%dwt(iunit,nt_nmud) = TRunoff%etin(iunit,nt_nmud) + TRunoff%etout(iunit,nt_nmud) + TSedi%ermal_t(iunit) - TSedi%sem_t(iunit) + TSedi%ermb_t(iunit)
+
+            !TRunoff%wt(iunit,nt_nsan) = TRunoff%wt(iunit,nt_nsan) + TRunoff%dwt(iunit,nt_nsan)*theDeltaT
+            !TRunoff%wt(iunit,nt_nmud) = TRunoff%wt(iunit,nt_nmud) + TRunoff%dwt(iunit,nt_nmud)*theDeltaT
+
+            !! for budget calculation
+            TRunoff%wt_al(iunit,nt_nsan) = 0._r8 ! TSedi%Ssal_t(iunit)
+            !TRunoff%wt_al(iunit,nt_nmud) = TSedi%Smal_t(iunit)
+            !TRunoff%etexchange(iunit,nt_nsan) = TSedi%ersb_t(iunit)
+            !TRunoff%etexchange(iunit,nt_nmud) = TSedi%ermb_t(iunit)
+
+            if(TRunoff%wt(iunit,nt_nmud) < -1.e-10) then
+               write(iulog,*) 'Negative mud storage in t-zone! ', iunit, TRunoff%wt(iunit, nt_nmud) , TRunoff%etin(iunit,nt_nmud), TRunoff%etout(iunit,nt_nmud), TSedi%ermal_t(iunit), TSedi%sem_t(iunit), TSedi%ermb_t(iunit)
+               call shr_sys_abort('mosart: negative mud t-zone storage')
+            end if
+    end subroutine subnetworkSediment
+
+    subroutine mainchannelSediment(iunit, theDeltaT)
+    ! !DESCRIPTION: subnetwork channel routing
+        implicit none    
+        integer, intent(in) :: iunit !,nt      
+        real(r8), intent(in) :: theDeltaT
+
+        real(r8) :: ers       ! sand-sediment erosion
+        real(r8) :: ersal     ! sand-sediment erosion @ active layer
+        real(r8) :: ersb      ! sand-sediment erosion @ bank
+        real(r8) :: ses       ! sand-sediment settled to bed zone
+        real(r8) :: seout     ! sand-sediment discharge out of local channel
+        real(r8) :: erm       ! mud-sediment erosion
+        real(r8) :: ermal     ! mud-sediment erosion @ active layer
+        real(r8) :: ermb      ! mud-sediment erosion @ bank
+        real(r8) :: sem       ! mud-sediment settled to bed zone
+        real(r8) :: meout     ! mud-sediment discharge out of local channel
+        real(r8) :: erb       ! total-sediment erosion @ bank
+        real(r8) :: ers_net   ! net erosion rate
+        real(r8) :: temp1, temp2, w_temp
+
+        real(r8) :: Achannel  ! effective channel area
+
+        integer :: k, nt, myflag
+        real(r8) :: s_conc_equi! sand-sediment concentration under the equilibirum state (erosion rate = deposition rate)
+        real(r8) :: s_wr_equi! sand-sediment storage under the equilibirum state (erosion rate = deposition rate)
+
+        TRunoff%erin(iunit,nt_nsan) = -TRunoff%eroutUp(iunit,nt_nsan)
+        TRunoff%erin(iunit,nt_nmud) = -TRunoff%eroutUp(iunit,nt_nmud)
+
+        ! bed-material load (sand or coarser)
+        if(TRunoff%vr(iunit,nt_nliq)>TINYVALUE_s) then
+            seout = CRQs_EH(TRunoff%yr(iunit,nt_nliq), abs(TRunoff%vr(iunit,nt_nliq)), TUnit%rwidth(iunit), TUnit%rslp(iunit), TUnit%nr(iunit), TSedi_para%d50(iunit))
+            !seout = CRQs_Wu(TRunoff%yr(iunit,nt_nliq), TRunoff%vr(iunit,nt_nliq), TUnit%rwidth(iunit), TUnit%rslp(iunit), TSedi_para%d50(iunit))
+            !seout = CRQs_Parker(TRunoff%yr(iunit,nt_nliq), TRunoff%vr(iunit,nt_nliq), TUnit%rwidth(iunit), TUnit%rslp(iunit), TSedi_para%d50(iunit))
+         else
+            seout = 0._r8
+        end if        
+
+        ! wash load (mud or finer)
+        if(TRunoff%wr(iunit,nt_nliq)<TINYVALUE_s .and. abs(TRunoff%erout(iunit,nt_nliq))>TINYVALUE_s) then
+            meout = TRunoff%erin(iunit,nt_nmud) + TRunoff%erlateral(iunit,nt_nmud)
+        else
+            meout = -TRunoff%erout(iunit,nt_nliq)*TRunoff%conc_r(iunit,nt_nmud)     
+            if (meout * theDeltaT > TRunoff%wr(iunit,nt_nmud)+TINYVALUE_s) then
+                meout = TRunoff%wr(iunit,nt_nmud)*0.95_r8/theDeltaT
+            end if        
+        end if
+
+        TRunoff%erout(iunit,nt_nsan) = -seout
+        TRunoff%erout(iunit,nt_nmud) = -meout
+        ! in case diffusion wave method is used, account for the mass balance caused by backwater effects
+
+        !== Please don't remove the block
+        !==TODO: in current MOSART, the upstream/downstream relationship and mass balance are too difficult to track
+        !        hence the block below is causing some mass balance issue
+
+        !if(Tctl%RoutingMethod == 4) then
+        !do nt=nt_nmud,nt_nsan
+        !
+        !    if(TRunoff%rslp_energy(iunit) >= TINYVALUE_s) then ! flow is from current channel to downstream
+        !      if(TRunoff%erin(iunit,nt)*theDeltaT + TRunoff%wr(iunit,nt) <= TINYVALUE_s) then! too much negative inflow from upstream, 
+        !         TRunoff%erout(iunit,nt) = 0._r8
+        !      elseif(TRunoff%erout(iunit,nt) <= -TINYVALUE_s .and. TRunoff%wr(iunit,nt) + &
+        !         (TRunoff%erlateral(iunit,nt) + TRunoff%erin(iunit,nt) + TRunoff%erout(iunit,nt)) * theDeltaT < TINYVALUE_s) then
+        !         TRunoff%erout(iunit,nt) = -(TRunoff%erlateral(iunit,nt) + TRunoff%erin(iunit,nt) + TRunoff%wr(iunit,nt)*0.95_r8 / theDeltaT)
+        !      end if
+        !    elseif(TRunoff%rslp_energy(iunit) <= -TINYVALUE_s) then ! flow is from downstream to current channel
+        !       if(rtmCTL%nUp_dstrm(iunit) > 1) then
+        !           if(TRunoff%erin_dstrm(iunit,nt)*theDeltaT + TRunoff%wr_dstrm(iunit,nt)/rtmCTL%nUp_dstrm(iunit) <= TINYVALUE_s) then! much negative inflow from upstream,
+        !               TRunoff%erout(iunit,nt) = 0._r8
+        !          elseif(TRunoff%erout(iunit,nt) >= TINYVALUE_s .and. TRunoff%wr_dstrm(iunit,nt)/rtmCTL%nUp_dstrm(iunit) &
+        !              - TRunoff%erout(iunit,nt) * theDeltaT < TINYVALUE_s) then
+        !              TRunoff%erout(iunit,nt) = TRunoff%wr_dstrm(iunit,nt)*0.95_r8 / theDeltaT / rtmCTL%nUp_dstrm(iunit)
+        !           end if    
+        !       else
+        !           if(TRunoff%erin_dstrm(iunit,nt)*theDeltaT + TRunoff%wr_dstrm(iunit,nt) <= TINYVALUE_s) then! much negative inflow from upstream,
+        !               TRunoff%erout(iunit,nt) = 0._r8
+        !           elseif(TRunoff%erout(iunit,nt) >= TINYVALUE_s .and. TRunoff%wr_dstrm(iunit,nt) &
+        !             - TRunoff%erout(iunit,nt) * theDeltaT < TINYVALUE_s) then
+        !              TRunoff%erout(iunit,nt) = TRunoff%wr_dstrm(iunit,nt)*0.95_r8 / theDeltaT
+        !           end if
+        !       end if                 
+        !       
+        !    else  ! no flow between current channel and downstream
+        !      TRunoff%erout(iunit,nt) = 0._r8
+        !    end if
+        !
+        !end do
+        !end if
+        !== Please don't remove the block
+
+        !==TODO: in current MOSART, the upstream/downstream relationship and mass balance are too difficult to track, hence assuming there is no sediment flux from downstream to upstream channel when backwater occurs
+        if(Tctl%RoutingMethod == DW) then
+        do nt=nt_nmud,nt_nsan
+
+            if(abs(TRunoff%erout(iunit,nt_nliq)) < TINYVALUE_s) then ! no flow between current channel and downstream
+              TRunoff%erout(iunit,nt) = 0._r8
+            elseif(TRunoff%erout(iunit,nt_nliq) >= TINYVALUE_s) then ! flow is from downstream to current channel
+              TRunoff%erout(iunit,nt) = 0._r8            
+            end if
+        end do
+        end if
+
+        seout = - TRunoff%erout(iunit,nt_nsan) 
+        meout = - TRunoff%erout(iunit,nt_nmud) 
+
+        if(abs(TRunoff%erout(iunit,nt_nliq)) > TINYVALUE_s) then
+            s_conc_equi = seout/abs(TRunoff%erout(iunit,nt_nliq))        
+            s_wr_equi = s_conc_equi * TRunoff%wr(iunit,nt_nliq)
+        else 
+            s_wr_equi = 0._r8
+        end if
+
+        ers = 0._r8
+        ses = 0._r8
+        if(s_wr_equi > TRunoff%wr(iunit,nt_nsan) + TINYVALUE_s) then ! too less sand in the water, net erosion occurs
+            ers = (s_wr_equi - TRunoff%wr(iunit,nt_nsan))/theDeltaT
+            ses = 0._r8
+        else
+            if(s_wr_equi < TRunoff%wr(iunit,nt_nsan) - TINYVALUE_s) then ! too much sand in the water, net deposition occurs
+                ers = 0._r8
+                ses = (TRunoff%wr(iunit,nt_nsan) - s_wr_equi)/theDeltaT
+            end if
+        end if
+
+        ! Don't change seout here, only adjust ses and ers for mass balance
+        if ((seout+ses) * theDeltaT > (TRunoff%wr(iunit,nt_nsan) + ers* theDeltaT + TINYVALUE_s)) then
+            if (seout * theDeltaT < (TRunoff%wr(iunit,nt_nsan) + ers* theDeltaT - TINYVALUE_s)) then
+                ses = TRunoff%wr(iunit,nt_nsan)/theDeltaT + ers - seout
+                ers = 0._r8
+            end if
+            if (seout * theDeltaT > (TRunoff%wr(iunit,nt_nsan) + ers* theDeltaT + TINYVALUE_s)) then
+                ses = 0._r8
+                ers = seout - TRunoff%wr(iunit,nt_nsan)/theDeltaT
+            end if
+        end if
+
+        if(TRunoff%wr(iunit,nt_nsan) <= TINYVALUE_s) then
+            ses = 0._r8             
+        end if
+
+        TSedi%Ssal_r(iunit) = TRunoff%wr_al(iunit, nt_nsan)
+        if(TSedi%Ssal_r(iunit) >= ers*theDeltaT + TINYVALUE_s) then ! first erosion from active layer, it no sufficient storage, from channel bed
+            ersal = ers
+        else
+            ersal = TSedi%Ssal_r(iunit)*0.95_r8/theDeltaT          
+        end if
+        ersb = ers - ersal
+
+         ! mud-sediment
+        sem = 0._r8 !CRSEM(TRunoff%yr(iunit,nt_nliq),TUnit%rslp(iunit),TRunoff%conc_r(iunit,nt_nmud))
+        erm = 0._r8 !CRERM(TRunoff%yr(iunit,nt_nliq),TUnit%rslp(iunit),TRunoff%conc_r(iunit,nt_nmud))
+        ermb = 0._r8
+        ermal = 0._r8
+
+        TSedi%ers_r(iunit) = ers
+        TSedi%ersal_r(iunit) = ersal
+        TSedi%ersb_r(iunit) = ersb
+        TSedi%ses_r(iunit) = ses
+        TSedi%erm_r(iunit) = erm
+        TSedi%ermal_r(iunit) = ermal
+        TSedi%ermb_r(iunit) = ermb
+        TSedi%sem_r(iunit) = sem
+
+        TRunoff%dwr_al(iunit,nt_nsan) = TSedi%ses_r(iunit) - TSedi%ersal_r(iunit)
+        TRunoff%dwr_al(iunit,nt_nmud) = 0._r8 !TSedi%sem_r(iunit) - TSedi%ermal_r(iunit)
+
+        !TSedi%Ssal_r(iunit) = TSedi%Ssal_r(iunit) + TRunoff%dwr_al(iunit,nt_nsan) * theDeltaT
+        !TSedi%Smal_r(iunit) = TSedi%Smal_r(iunit) + (TSedi%sem_r(iunit) - TSedi%ermal_r(iunit)) * theDeltaT
+
+        TRunoff%dwr(iunit,nt_nsan) = TRunoff%erlateral(iunit,nt_nsan) + TRunoff%erin(iunit,nt_nsan) + TRunoff%erout(iunit,nt_nsan) + TSedi%ersal_r(iunit) - TSedi%ses_r(iunit) + TSedi%ersb_r(iunit)
+        TRunoff%dwr(iunit,nt_nmud) = TRunoff%erlateral(iunit,nt_nmud) + TRunoff%erin(iunit,nt_nmud) + TRunoff%erout(iunit,nt_nmud) + TSedi%ermal_r(iunit) - TSedi%sem_r(iunit) + TSedi%ermb_r(iunit)
+
+        if(TRunoff%wr(iunit,nt_nmud).gt.TINYVALUE_s .and. (TRunoff%wr(iunit,nt_nmud) + TRunoff%dwr(iunit,nt_nmud)*theDeltaT)/TRunoff%wr(iunit,nt_nmud) < -1.e-8 .and. (TRunoff%wr(iunit,nt_nmud) + TRunoff%dwr(iunit,nt_nmud)*theDeltaT) < -1.e-8) then
+           write(iulog,*) 'Negative mud storage in r-zone - mud ! ', iunit, TRunoff%wr(iunit, nt_nmud), TRunoff%erlateral(iunit,nt_nmud), TRunoff%erin(iunit,nt_nmud), TRunoff%erout(iunit,nt_nmud), TSedi%ermal_r(iunit), - TSedi%sem_r(iunit), TSedi%ermb_r(iunit) 
+           write(iulog,*) 'Negative mud storage in r-zone - water! ', iunit, TRunoff%wr(iunit, nt_nliq), TRunoff%erlateral(iunit,nt_nliq), TRunoff%erin(iunit,nt_nliq), TRunoff%erout(iunit,nt_nliq) 
+            !write(unit=5112,fmt="((i10), 7(e12.3))") iunit, -TRunoff%erout(iunit,nt_nliq), TRunoff%yr(iunit,nt_nliq), abs(TRunoff%vr(iunit,nt_nliq)), TUnit%rwidth(iunit), TUnit%rslp(iunit), TUnit%nr(iunit), TSedi_para%d50(iunit)
+            !write(unit=5113,fmt="((i10), 7(e12.3))") iunit, TRunoff%wr(iunit,nt_nmud), meout, sem, erm, ermal, ermb
+           call shr_sys_abort('mosart: negative mud r-zone storage')
+        end if
+        if(TRunoff%wr(iunit,nt_nsan).gt.TINYVALUE_s .and. (TRunoff%wr(iunit,nt_nsan) + TRunoff%dwr(iunit,nt_nsan)*theDeltaT)/TRunoff%wr(iunit,nt_nsan) < -1.e-8 .and. (TRunoff%wr(iunit,nt_nsan) + TRunoff%dwr(iunit,nt_nsan)*theDeltaT) < -1.e-8) then
+           write(iulog,*) 'Negative sand storage in r-zone! ', iunit, TRunoff%wr(iunit, nt_nsan), TRunoff%erlateral(iunit,nt_nsan), TRunoff%erin(iunit,nt_nsan), TRunoff%erout(iunit,nt_nsan), TSedi%ersal_r(iunit), - TSedi%ses_r(iunit), TSedi%ersb_r(iunit) 
+            !write(unit=1110,fmt="(i10, 6(e12.3))") iunit,TRunoff%erlateral(iunit,nt_nsan), TRunoff%erin(iunit,nt_nsan), TRunoff%erout(iunit,nt_nsan), TSedi%ersal_r(iunit), - TSedi%ses_r(iunit), TSedi%ersb_r(iunit)
+            !write(unit=6112,fmt="((i10), 7(e12.3))") iunit, -TRunoff%erout(iunit,nt_nliq), TRunoff%yr(iunit,nt_nliq), abs(TRunoff%vr(iunit,nt_nliq)), TUnit%rwidth(iunit), TUnit%rslp(iunit), TUnit%nr(iunit), TSedi_para%d50(iunit)
+            !write(unit=6113,fmt="((i10), 7(e12.3))") iunit, TRunoff%wr(iunit,nt_nsan), s_wr_equi, seout, ses, ers, ersal, ersb
+            !write(unit=6114,fmt="((i10), 5(e12.3))") iunit, TRunoff%wr(iunit,nt_nsan) + TRunoff%dwr(iunit,nt_nsan)*theDeltaT, TRunoff%wr(iunit,nt_nsan), s_wr_equi, (TRunoff%wr(iunit,nt_nsan) - s_wr_equi)/theDeltaT, ses
+           call shr_sys_abort('mosart: negative sand r-zone storage')
+        end if
+
+        if(TSedi%Ssal_r(iunit) < -1.e-10) then
+           write(iulog,*) 'Negative storage of sand active layer  in r-zone ! ', iunit, TSedi%Ssal_r(iunit), s_conc_equi, TRunoff%wr(iunit,nt_nliq), TRunoff%wr(iunit,nt_nsan)
+           call shr_sys_abort('mosart: negative sand r-zone active layer storage')
+        end if
+        
+		if((-TRunoff%erout(iunit,nt_nliq)) < -TINYVALUE_s .and. abs(TRunoff%erout(iunit,nt_nmud)) > TINYVALUE_s) then
+		    write(unit=1110,fmt="(i10, 6(e12.3))") iunit, TRunoff%erout(iunit,nt_nliq), TRunoff%erout(iunit,nt_nmud)
+		end if
+		if((-TRunoff%erout(iunit,nt_nliq)) < -TINYVALUE_s .and. abs(TRunoff%erout(iunit,nt_nsan)) > TINYVALUE_s) then
+		    write(unit=1111,fmt="(i10, 6(e12.3))") iunit, TRunoff%erout(iunit,nt_nliq), TRunoff%erout(iunit,nt_nsan)
+		end if
+            !if((TRunoff%yr(iunit,nt_nliq).gt.TINYVALUE_s) .and. (s_wr_equi.gt.TINYVALUE_s)) then
+            !    write(unit=1110,fmt="(i10, 6(e12.3))") iunit, ers, ses, seout, TRunoff%wr(iunit,nt_nsan), TRunoff%vr(iunit,nt_nliq), CRQs(TRunoff%yr(iunit,nt_nliq), TRunoff%vr(iunit,nt_nliq), TUnit%rwidth(iunit), TUnit%rslp(iunit), TUnit%nr(iunit))
+            !end if
+
+            !if((TRunoff%yr(iunit,nt_nliq).gt.TINYVALUE_s) .and. (TRunoff%wr(iunit,nt_nsan).gt.TINYVALUE_s)) then
+            !    write(unit=1111,fmt="(i10, 6(e12.3))") iunit, ers, ses, seout, TRunoff%wr(iunit,nt_nsan), TRunoff%vr(iunit,nt_nliq), CRQs(TRunoff%yr(iunit,nt_nliq), TRunoff%vr(iunit,nt_nliq), TUnit%rwidth(iunit), TUnit%rslp(iunit), TUnit%nr(iunit))
+            !end if
+
+    end subroutine mainchannelSediment
+
+    function CRQs_Wu(h_, U_, rwidth_,slope_, D50_) result(Qs_)
+      ! !DESCRIPTION: calculate equilibrium sand-sediment transport rate using Wu (2000) equation
+      implicit none
+      real(r8), intent(in)  :: h_    !channel water depth [m]
+      real(r8), intent(in)  :: U_    !channel velocity [m/s]
+      real(r8), intent(in)  :: rwidth_!bankfull width [m]
+      real(r8), intent(in)  :: slope_  ! channel slope [-]
+      real(r8), intent(in)  :: D50_  ! median sediment particle size [m]
+
+      real(r8)             :: Qs_       ! equilibrium sediment transporate rate, [kg/s]
+
+      real(r8) :: R_     ! submerged specific gravity of sediment [-]
+      real(r8) :: vsf_    ! sediment settling velocity [m/s]
+      real(r8) :: tah_b  !the bed shear stress
+      real(r8) :: theta ! Shields parameter [-]
+      real(r8) :: theta_c ! critical shear stress [-]
+      real(r8) :: phi_   ! dimensionless shear stress [-]
+      real(r8) :: phi_s ! dimensionless sediment load
+      real(r8) :: q_s    ! the sediment volumetric discharge per unit width, [m2/s] 
+
+      R_ = (densedi-denh2o)/denh2o
+      theta = h_*slope_/((R_ - 1._r8)*D50_)
+      theta_c = 0.0386_r8
+      phi_ = theta/theta_c
+
+      if(phi_ <= 1._r8) then
+          Qs_ = 0._r8
+          return
+      end if      
+      vsf_ = CRVSF(D50_)
+      phi_s = 0.0000262_r8 * ((phi_ - 1._r8)*U_/vsf_)**1.74_r8
+
+      q_s = phi_s * sqrt(grav*R_*D50_)*D50_
+      Qs_ = densedi * rwidth_ * q_s
+
+      if(abs(Qs_) < TINYVALUE_s) then
+          Qs_ = 0._r8
+      endif
+
+      return
+    end function CRQs_Wu    
+
+
+    function CRQs_Parker(h_, U_, rwidth_,slope_, D50_) result(Qs_)
+      ! !DESCRIPTION: calculate equilibrium sand-sediment transport rate using Parker (1990) equation
+      implicit none
+      real(r8), intent(in)  :: h_    !channel water depth [m]
+      real(r8), intent(in)  :: U_    !channel velocity [m/s]
+      real(r8), intent(in)  :: rwidth_!bankfull width [m]
+      real(r8), intent(in)  :: slope_  ! channel slope [-]
+      real(r8), intent(in)  :: D50_  ! median sediment particle size [m]
+      real(r8)             :: Qs_       ! equilibrium sediment transporate rate, [kg/s]
+
+      real(r8) :: R_     ! submerged specific gravity of sediment [-]
+      real(r8) :: tah_b  !the bed shear stress
+      real(r8) :: theta ! Shields parameter [-]
+      real(r8) :: theta_c ! critical shear stress [-]
+      real(r8) :: phi_ ! critical shear stress [-]
+      real(r8) :: q_s    ! the sediment volumetric discharge per unit width, [m2/s] 
+      real(r8) :: susp_ratio   ! ratio of suspended sediment load over the total sediment load [-]
+
+      R_ = (densedi-denh2o)/denh2o
+      theta = h_*slope_/((R_ - 1._r8)*D50_)
+      theta_c = 0.0386_r8
+      phi_ = theta/theta_c
+
+      q_s = CRf_G(phi_) *(grav*h_*slope_)**1.5/(grav*(R_-1._r8))
+      Qs_ = densedi * rwidth_ * q_s
+
+      if(abs(Qs_) < TINYVALUE_s) then
+          Qs_ = 0._r8
+      endif
+      susp_ratio = CRsuspended_ratio(D50_, h_, slope_)
+      Qs_ = Qs_ * susp_ratio
+
+      return
+    end function CRQs_Parker    
+
+    function CRf_G(phi_) result(G_)
+      ! !DESCRIPTION: part of the Parker (1990) equation for total sediment load
+      implicit none
+      real(r8), intent(in) :: phi_  ! [-]
+      real(r8)             :: G_       ! 
+
+      if(phi_ > 1.59_r8) then
+          G_ = 11.933_r8*(1._r8 - 0.853_r8/phi_)**4.5_r8
+      else
+          if(phi_ < 1.0) then
+              G_ = 0.00218_r8*phi_**14.2_r8 
+          else
+              G_ = 0.00218_r8*exp(14.2_r8*(phi_-1._r8) - 9.28_r8*(phi_ - 1._r8)**2._r8)
+          end if
+      end if
+
+      return
+    end function CRf_G
+
+    function CRQs_EH(h_, U_, rwidth_,slope_, roughness_, D50_) result(Qs_)
+      ! !DESCRIPTION: calculate equilibrium sand-sediment transport rate using classic Engelund-Hansen equation
+      implicit none
+      real(r8), intent(in)  :: h_    !channel water depth [m]
+      real(r8), intent(in)  :: U_    !channel velocity [m/s]
+      real(r8), intent(in)  :: rwidth_!bankfull width [m]
+      real(r8), intent(in)  :: slope_  ! channel slope [-]
+      real(r8), intent(in)  :: roughness_  ! Manning's roughness [-]
+      real(r8), intent(in)  :: D50_  ! median sediment particle size [m]
+      real(r8)              :: Qs_       ! equilibrium sediment transporate rate, [kg/s]
+
+      real(r8) :: Cf     ! resistence coefficient
+      real(r8) :: R_     ! submerged specific gravity of sediment [-]
+      real(r8) :: tah_star !the Shields number (dimensionless shear stress)
+      real(r8) :: q_star ! Einstein number (dimensionless sediment flux)    
+      real(r8) :: q_s    ! equilibrium the sediment volumetric discharge per unit width, [m2/s] 
+      real(r8) :: susp_ratio   ! ratio of suspended sediment load over the total sediment load [-]
+
+      R_ = (densedi-denh2o)/denh2o
+      Cf = grav*(roughness_**2)/(h_**(1._r8/3._r8))
+      tah_star = Cf * U_* U_ /(R_*grav*D50_)
+      q_star  = 0.05_r8 * (tah_star**2.5_r8)/Cf      
+      q_s = q_star * sqrt(R_*grav*D50_)*D50_  
+      Qs_ = densedi * rwidth_ * q_s
+
+      if(abs(Qs_) < TINYVALUE_s) then
+          Qs_ = 0._r8
+      endif
+      susp_ratio = CRsuspended_ratio(D50_, h_, slope_)
+      Qs_ = Qs_ * susp_ratio
+            !if(h_>TINYVALUE_s .and. U_>TINYVALUE_s) then
+            !    write(unit=1112,fmt="(5(e20.11))") Cf, tah_star, q_star, q_s, Qs_
+            !end if
+      return
+    end function CRQs_EH 
+
+
+    function CRsuspended_ratio(D_, h_, slope_) result(ratio_)
+      ! !DESCRIPTION: calculate the ratio of suspended portion to the total sediment load
+      implicit none
+      real(r8), intent(in) :: h_,slope_  ! channel water depth [m], channel slope [-]
+      real(r8), intent(in) :: D_   !  particle size [m]
+      real(r8)             :: ratio_       ! ratio of suspended portion to the total sediment load [-]
+
+      real(r8) :: u_t     ! friction shear velocity [m/s]
+      real(r8) :: vsf_    ! sediment settling velocity [m/s]
+      real(r8) :: k_      ! von Kármán constant [-]
+      real(r8) :: Z_      ! [-]
+
+      k_ = 0.41_r8
+      vsf_ = CRVSF(D_)
+      u_t = sqrt(grav*h_*slope_)
+      if(u_t < TINYVALUE_s) then
+          ratio_ = 1._r8
+      else
+          Z_ = vsf_/(k_*u_t)
+          ratio_ = 2.5_r8 * exp(-Z_)
+      end if
+      if(abs(ratio_) < TINYVALUE_s) then
+          ratio_ = 0._r8
+      endif
+      if(abs(ratio_) > 1._r8) then
+          ratio_ = 1._r8
+      endif
+
+      return
+    end function CRsuspended_ratio    
+
+
+    function CRVSF(D_) result(vsf_)
+      ! !DESCRIPTION: calculate particle settling velocity [m/s] using the equation from Cheng N. (1997). Simplified settling velocity formula for sediment particle, J. Hydraul. Eng., 123(2), 149-152. 
+      implicit none
+      real(r8), intent(in) :: D_   ! diameter of particle
+      real(r8)             :: vsf_       ! sand-sediment erosion rate, [kg/m2/s]
+      real(r8) :: R_     ! submerged specific gravity of sediment [-]
+      real(r8) :: d_star ! 
+
+      R_ = (densedi-denh2o)/denh2o
+
+      d_star = D_ *((grav*R_/(KVIS**2))**(1._r8/3._r8))
+      vsf_ = (KVIS/D_) * (sqrt(25._r8 + 1.2_r8 * d_star*d_star)-5._r8)**1.5_r8
+
+      if(abs(vsf_) < TINYVALUE_s) then
+          vsf_ = 0._r8
+      endif
+      return
+    end function CRVSF
+
+  subroutine printTest_sedi(nio)
+      ! !DESCRIPTION: output the simulation results into external files
+      implicit none
+      integer, intent(in) :: nio        ! unit of the file to print
+
+      integer :: IDlist(1:5) = (/1788,2197,1991,3029,1584/)
+      integer :: ios,ii                    ! flag of io status
+
+
+      write(unit=nio,fmt="(25(e20.11))") -TRunoff%etout(IDlist(1),nt_nliq), TRunoff%conc_t(IDlist(1),nt_nsan), TRunoff%wt(IDlist(1),nt_nliq), TRunoff%wt(IDlist(1),nt_nmud), -TRunoff%etout(IDlist(1),nt_nsan), &
+                                         -TRunoff%etout(IDlist(2),nt_nliq), TRunoff%conc_t(IDlist(2),nt_nsan), TRunoff%wt(IDlist(2),nt_nliq), TRunoff%wt(IDlist(2),nt_nmud), -TRunoff%etout(IDlist(2),nt_nsan), &
+                                         -TRunoff%etout(IDlist(3),nt_nliq), TRunoff%conc_t(IDlist(3),nt_nsan), TRunoff%wt(IDlist(3),nt_nliq), TRunoff%wt(IDlist(3),nt_nmud), -TRunoff%etout(IDlist(3),nt_nsan), &
+                                         -TRunoff%etout(IDlist(4),nt_nliq), TRunoff%conc_t(IDlist(4),nt_nsan), TRunoff%wt(IDlist(4),nt_nliq), TRunoff%wt(IDlist(4),nt_nmud), -TRunoff%etout(IDlist(4),nt_nsan), &
+                                         -TRunoff%etout(IDlist(5),nt_nliq), TRunoff%conc_t(IDlist(5),nt_nsan), TRunoff%wt(IDlist(5),nt_nliq), TRunoff%wt(IDlist(5),nt_nmud), -TRunoff%etout(IDlist(5),nt_nsan)
+  end subroutine printTest_sedi
+end MODULE MOSART_sediment_mod

--- a/components/mosart/src/riverroute/RtmFileUtils.F90
+++ b/components/mosart/src/riverroute/RtmFileUtils.F90
@@ -77,7 +77,7 @@ contains
      ! get local file name from full name
      locfn = get_filename( fulpath )
      if (len_trim(locfn) == 0) then
-	if (masterproc) write(iulog,*)'(GETFIL): local filename has zero length'
+	 if (masterproc) write(iulog,*)'(GETFIL): local filename has zero length'
         call shr_sys_abort()
      else
         if (masterproc) write(iulog,*)'(GETFIL): attempting to find local file ',  &

--- a/components/mosart/src/riverroute/RtmHistFile.F90
+++ b/components/mosart/src/riverroute/RtmHistFile.F90
@@ -1113,7 +1113,7 @@ contains
                      trim(locfnh(t)),' at nstep = ', get_nstep()
                 write(iulog,*)
              endif
-	     call ncd_pio_closefile(nfid(t))
+             call ncd_pio_closefile(nfid(t))
              if ((.not.nlend) .and. (tape(t)%ntimes/=tape(t)%mfilt)) then
                 call ncd_pio_openfile (nfid(t), trim(locfnh(t)), ncd_write)
              end if
@@ -1772,7 +1772,7 @@ contains
 
   subroutine strip_null(str)
     character(len=*), intent(inout) :: str
-    integer :: i	
+    integer :: i
     do i=1,len(str)
        if(ichar(str(i:i))==0) str(i:i)=' '
     end do

--- a/components/mosart/src/riverroute/RtmHistFlds.F90
+++ b/components/mosart/src/riverroute/RtmHistFlds.F90
@@ -162,6 +162,36 @@ contains
            avgflag='A', long_name='MOSART main channel water depth:'//trim(rtm_tracers(1)), &
            ptr_rof=rtmCTL%yr_nt1, default='active')
 
+    if (sediflag) then
+       call RtmHistAddfld (fname='RIVER_DISCHARGE_OVER_LAND'//'_'//trim(rtm_tracers(3)), units='kg/s',  &
+            avgflag='A', long_name='MOSART river basin flow: '//trim(rtm_tracers(3)), &
+            ptr_rof=rtmCTL%runofflnd_nt3, default='active')
+
+       call RtmHistAddfld (fname='RIVER_DISCHARGE_OVER_LAND'//'_'//trim(rtm_tracers(4)), units='kg/s',  &
+            avgflag='A', long_name='MOSART river basin flow: '//trim(rtm_tracers(4)), &
+            ptr_rof=rtmCTL%runofflnd_nt4, default='active')
+
+       call RtmHistAddfld (fname='RIVER_DISCHARGE_TO_OCEAN'//'_'//trim(rtm_tracers(3)), units='kg/s',  &
+            avgflag='A', long_name='MOSART river discharge into ocean: '//trim(rtm_tracers(3)), &
+            ptr_rof=rtmCTL%runoffocn_nt3, default='active')
+
+       call RtmHistAddfld (fname='RIVER_DISCHARGE_TO_OCEAN'//'_'//trim(rtm_tracers(4)), units='kg/s',  &
+            avgflag='A', long_name='MOSART river discharge into ocean: '//trim(rtm_tracers(4)), &
+            ptr_rof=rtmCTL%runoffocn_nt4, default='active')
+
+       call RtmHistAddfld (fname='STORAGE'//'_'//trim(rtm_tracers(3)), units='kg',  &
+            avgflag='A', long_name='MOSART storage: '//trim(rtm_tracers(3)), &
+            ptr_rof=rtmCTL%volr_nt3, default='active')
+
+       call RtmHistAddfld (fname='STORAGE'//'_'//trim(rtm_tracers(4)), units='kg',  &
+            avgflag='A', long_name='MOSART storage: '//trim(rtm_tracers(4)), &
+            ptr_rof=rtmCTL%volr_nt4, default='active')
+
+       call RtmHistAddfld (fname='QSUR'//'_'//trim(rtm_tracers(3)), units='kg/s',  &
+            avgflag='A', long_name='MOSART sediment yield from hillslope: '//trim(rtm_tracers(3)), &
+            ptr_rof=rtmCTL%qsur_nt3, default='active')
+    end if
+
     if (wrmflag) then
 
       call RtmHistAddfld (fname='WRM_IRR_SUPPLY', units='m3/s',  &
@@ -290,6 +320,16 @@ contains
     rtmCTL%qdem_nt2(:)       = rtmCTL%qdem(:,2)
   
     rtmCTL%yr_nt1(:)         = rtmCTL%yr(:,1)  ! water depth
+
+    if(sediflag) then
+        rtmCTL%runofflnd_nt3(:)  = rtmCTL%runofflnd(:,3)
+        rtmCTL%runofflnd_nt4(:)  = rtmCTL%runofflnd(:,4)
+        rtmCTL%runoffocn_nt3(:)  = rtmCTL%runoffocn(:,3)
+        rtmCTL%runoffocn_nt4(:)  = rtmCTL%runoffocn(:,4)
+        rtmCTL%volr_nt3(:)       = rtmCTL%volr(:,3)
+        rtmCTL%volr_nt4(:)       = rtmCTL%volr(:,4)
+        rtmCTL%qsur_nt3(:)       = rtmCTL%qsur(:,3)
+    end if
 
     if (wrmflag) then
        StorWater%storageG = 0._r8

--- a/components/mosart/src/riverroute/RtmMod.F90
+++ b/components/mosart/src/riverroute/RtmMod.F90
@@ -13,6 +13,7 @@ module RtmMod
   use shr_sys_mod     , only : shr_sys_flush
   use shr_const_mod   , only : SHR_CONST_PI, SHR_CONST_CDAY
   use rof_cpl_indices , only : nt_rtm, rtm_tracers, KW, DW
+  use seq_flds_mod    , only : rof_sed
   use RtmSpmd         , only : masterproc, npes, iam, mpicom_rof, ROFID, mastertask, &
                                MPI_REAL8,MPI_INTEGER,MPI_CHARACTER,MPI_LOGICAL,MPI_MAX
   use RtmVar          , only : re, spval, rtmlon, rtmlat, iulog, ice_runoff, &
@@ -23,6 +24,7 @@ module RtmMod
                                isgrid2d, data_bgc_fluxes_to_ocean_flag, use_lnd_rof_two_way, use_ocn_rof_two_way
   use RtmFileUtils    , only : getfil, getavu, relavu
   use RtmTimeManager  , only : timemgr_init, get_nstep, get_curr_date, advance_timestep
+  use RtmTimeManager  , only : get_curr_date, is_end_curr_day, is_end_curr_month, is_first_step, is_first_restart_step, is_last_step
   use RtmHistFlds     , only : RtmHistFldsInit, RtmHistFldsSet 
   use RtmHistFile     , only : RtmHistUpdateHbuf, RtmHistHtapesWrapup, RtmHistHtapesBuild, &
                                rtmhist_ndens, rtmhist_mfilt, rtmhist_nhtfrq,     &
@@ -37,9 +39,13 @@ module RtmMod
                                SMatP_dnstrm, avsrc_dnstrm, avdst_dnstrm, &
                                SMatP_upstrm, avsrc_upstrm, avdst_upstrm, &
                                SMatP_direct, avsrc_direct, avdst_direct
+  use rof_cpl_indices, only : nt_rtm, rtm_tracers, nt_nliq, nt_nice, nt_nmud, nt_nsan
   use MOSART_physics_mod, only : Euler
   use MOSART_physics_mod, only : updatestate_hillslope, updatestate_subnetwork, &
                                  updatestate_mainchannel
+  use MOSART_BGC_type,  only : TSedi, TSedi_para, MOSART_sediment_init
+  use MOSART_RES_type,  only : Tres, MOSART_reservoir_sed_init, Tres_para
+!#ifdef INCLUDE_WRM
   use WRM_type_mod    , only : ctlSubwWRM, WRMUnit, StorWater
   use WRM_subw_IO_mod , only : WRM_init, WRM_computeRelease
   use MOSARTinund_PreProcs_MOD, only : calc_chnlMannCoe, preprocess_elevProf
@@ -77,9 +83,6 @@ module RtmMod
   real(r8) :: river_depth_minimum = 1.e-4 ! gridcell average minimum river depth [m]
 
 !global (glo)
-  integer , pointer :: ID0_global(:)  ! local ID index
-  integer , pointer :: dnID_global(:) ! downstream ID based on ID0
-  real(r8), pointer :: area_global(:) ! area
   real(r8), pointer :: DIN_global(:)  !
   real(r8), pointer :: DIP_global(:)  !
   real(r8), pointer :: DON_global(:)  !
@@ -102,6 +105,9 @@ module RtmMod
   real(r8), save, pointer :: erowm_regf(:,:) ! erout current timestep (m3/s)
   real(r8), save, pointer :: eroutup_avg(:,:)! eroutup average over coupling period (m3/s)
   real(r8), save, pointer :: erlat_avg(:,:)  ! erlateral average over coupling period (m3/s)
+  real(r8), save, pointer :: ehexch_avg(:,:)  ! ehexchange average over coupling period (m3/s, or kg/s)
+  real(r8), save, pointer :: etexch_avg(:,:)  ! etexchange average over coupling period (m3/s, or kg/s)
+  real(r8), save, pointer :: erexch_avg(:,:)  ! erexchange average over coupling period (m3/s, or kg/s)
 
   real(r8), save :: vol_chnl2fp                 ! Total volume of flows from main channels to floodplains (for all local grid cells and all sub-steps of coupling period) (m^3).
   real(r8), save :: vol_fp2chnl                 ! Total volume of flows from floodplains to main channels (for all local grid cells and all sub-steps of coupling period) (m^3).
@@ -350,7 +356,13 @@ contains
        if (.not. inundflag .and. use_lnd_rof_two_way) then
           call shr_sys_abort(trim(subname)//' inundation model must be turned on for land river two way coupling')
        end if
+       if(.not.(rof_sed) .and. sediflag) then
+           write(iulog,*) 'sediflag can only be effective when rof_sed is set as .true.'
+           sediflag = .false.
+       end if
+
     end if
+    
 
     call mpi_bcast (coupling_period,   1, MPI_INTEGER, 0, mpicom_rof, ier)
     call mpi_bcast (delt_mosart    ,   1, MPI_INTEGER, 0, mpicom_rof, ier)
@@ -425,7 +437,7 @@ contains
     Tctl%DLevelH2R     = DLevelH2R
     Tctl%DLevelR       = DLevelR
     if(.not.(Tctl%RoutingMethod==KW .or. Tctl%RoutingMethod==DW)) then 
-	   call shr_sys_abort('Error in routing method setup! There are only 2 options available: 1==KW, 2==DW')
+       call shr_sys_abort('Error in routing method setup! There are only 2 options available: 1==KW, 2==DW')
     end if
 
     if (inundflag) then
@@ -458,6 +470,7 @@ contains
        write(iulog,*) '   smat_option           = ',trim(smat_option)
        write(iulog,*) '   wrmflag               = ',wrmflag
        write(iulog,*) '   inundflag             = ',inundflag
+       write(iulog,*) '   sediflag              = ',sediflag
        write(iulog,*) '   use_lnd_rof_two_way   = ',use_lnd_rof_two_way
        write(iulog,*) '   heatflag              = ',heatflag
        write(iulog,*) '   barrier_timers        = ',barrier_timers
@@ -1310,14 +1323,17 @@ contains
 
     call t_startf('mosarti_vars')
 
-    allocate (evel    (rtmCTL%begr:rtmCTL%endr,nt_rtm), &
-              flow    (rtmCTL%begr:rtmCTL%endr,nt_rtm), &
-              eroup_lagi(rtmCTL%begr:rtmCTL%endr,nt_rtm), &
-              eroup_lagf(rtmCTL%begr:rtmCTL%endr,nt_rtm), &
-              erowm_regi(rtmCTL%begr:rtmCTL%endr,nt_rtm), &
-              erowm_regf(rtmCTL%begr:rtmCTL%endr,nt_rtm), &
+    allocate (evel    (rtmCTL%begr:rtmCTL%endr,nt_rtm),    &
+              flow    (rtmCTL%begr:rtmCTL%endr,nt_rtm),    &
+              eroup_lagi(rtmCTL%begr:rtmCTL%endr,nt_rtm),  &
+              eroup_lagf(rtmCTL%begr:rtmCTL%endr,nt_rtm),  &
+              erowm_regi(rtmCTL%begr:rtmCTL%endr,nt_rtm),  &
+              erowm_regf(rtmCTL%begr:rtmCTL%endr,nt_rtm),  &
               eroutup_avg(rtmCTL%begr:rtmCTL%endr,nt_rtm), &
-              erlat_avg(rtmCTL%begr:rtmCTL%endr,nt_rtm), &
+              erlat_avg(rtmCTL%begr:rtmCTL%endr,nt_rtm),   &
+              ehexch_avg(rtmCTL%begr:rtmCTL%endr,nt_rtm),  &
+              etexch_avg(rtmCTL%begr:rtmCTL%endr,nt_rtm),  &
+              erexch_avg(rtmCTL%begr:rtmCTL%endr,nt_rtm),  &
               stat=ier)
     if (ier /= 0) then
        write(iulog,*) subname,' Allocation ERROR for flow'
@@ -1330,6 +1346,9 @@ contains
     erowm_regf(:,:)  = 0._r8
     eroutup_avg(:,:) = 0._r8
     erlat_avg(:,:)   = 0._r8
+    ehexch_avg(:,:)  = 0._r8 
+    etexch_avg(:,:)  = 0._r8 
+    erexch_avg(:,:)  = 0._r8 
 
     if (inundflag) then
        ! If inundation scheme is turned on :
@@ -1793,19 +1812,33 @@ contains
 !    if (masterproc) call shr_sys_flush(iulog)
     call MOSART_init()
 
-    call t_stopf('mosarti_mosart_init')
+
+    if(sediflag) then
+        call t_startf('mosarti_sediment_init')
+        call MOSART_sediment_init(rtmCTL%begr, rtmCTL%endr, rtmCTL%numr)
+        call t_stopf('mosarti_sediment_init')
+    end if
 
     if (wrmflag) then
        call t_startf('mosarti_wrm_init')
        if (wrmflag) then
           call WRM_init()
        endif
-       call t_startf('mosarti_wrm_init')
+       call t_stopf('mosarti_wrm_init')
+
     end if
     if (wrmflag .and. heatflag .and. rstraflag) then
        call regeom                    
     end if  
 
+    if (sediflag .and. wrmflag) then
+       call t_startf('mosarti_reservoir_sed_init')
+       if (sediflag) then
+          call MOSART_reservoir_sed_init()
+       endif
+       call t_stopf('mosarti_reservoir_sed_init')
+    end if
+    
     !-------------------------------------------------------
     ! Read restart/initial info
     !-------------------------------------------------------
@@ -1920,6 +1953,19 @@ contains
       rtmCTL%wt(:, 2) = 0._r8
       rtmCTL%wr(:, 2) = 0._r8
       rtmCTL%erout(:, 2) = 0._r8
+      
+      if (sediflag) then
+        ! For tracer 3 :
+        rtmCTL%wh(:, 3) = 0._r8
+        rtmCTL%wt(:, 3) = 0._r8
+        rtmCTL%wr(:, 3) = 0._r8
+        rtmCTL%erout(:, 3) = 0._r8
+        ! For tracer 4 :
+        rtmCTL%wh(:, 4) = 0._r8
+        rtmCTL%wt(:, 4) = 0._r8
+        rtmCTL%wr(:, 4) = 0._r8
+        rtmCTL%erout(:, 4) = 0._r8
+      endif
 
       TRunoff%wh   = rtmCTL%wh
       TRunoff%wt   = rtmCTL%wt
@@ -1936,22 +1982,38 @@ contains
     end if
 !#endif
 
-
- do nt = 1,nt_rtm
-      do nr = rtmCTL%begr,rtmCTL%endr
-      
-       call UpdateState_hillslope(nr,nt)
-       call UpdateState_subnetwork(nr,nt)   
-                                          
-        rtmCTL%volr(nr,nt) = (TRunoff%wt(nr,nt) + TRunoff%wr(nr,nt) + TRunoff%wh(nr,nt)*rtmCTL%area(nr)*TUnit%frac(nr))  ! times "TUnit%frac( nr )" or not ?
-        if (inundflag .and. nt == 1) then  
-           rtmCTL%volr(nr,nt) = rtmCTL%volr(nr,nt) + TRunoff%wf_ini( nr )
-        else        
-           call UpdateState_mainchannel(nr,nt)
-        endif
+    do nt = nt_nliq,nt_nice
+        do nr = rtmCTL%begr,rtmCTL%endr
         
-      enddo
- enddo
+           call UpdateState_hillslope(nr,nt)
+           call UpdateState_subnetwork(nr,nt)   
+
+           rtmCTL%volr(nr,nt) = (TRunoff%wt(nr,nt) + TRunoff%wr(nr,nt) + &
+                                     TRunoff%wh(nr,nt)*rtmCTL%area(nr)*TUnit%frac(nr))
+
+           if (inundflag .and. nt == nt_nliq) then  
+              rtmCTL%volr(nr,nt) = rtmCTL%volr(nr,nt) + TRunoff%wf_ini( nr )
+           else
+              call UpdateState_mainchannel(nr,nt)
+           endif
+
+        enddo
+    enddo
+
+    if(sediflag) then
+    do nt=nt_nmud,nt_nsan
+        do nr = rtmCTL%begr,rtmCTL%endr        
+           call UpdateState_hillslope(nr,nt)
+           call UpdateState_subnetwork(nr,nt)   
+           !rtmCTL%volr(nr,nt) = (TRunoff%wt(nr,nt) + TRunoff%wr(nr,nt) + TRunoff%wh(nr,nt)*rtmCTL%area(nr)*TUnit%frac(nr))  ! times "TUnit%frac( nr )" or not ?
+           ! TODO: check if it is consistent when inundflag and sediflag turned on together
+           call UpdateState_mainchannel(nr,nt)
+           rtmCTL%volr(nr,nt) = (TRunoff%wt(nr,nt) + TRunoff%wr(nr,nt) + &
+                                 TRunoff%wh(nr,nt)*rtmCTL%area(nr)*TUnit%frac(nr) + &
+                                 TRunoff%wt_al(nr,nt) + TRunoff%wr_al(nr,nt))
+        enddo
+    enddo
+    end if
 
     call t_stopf('mosarti_restart')
 
@@ -2096,6 +2158,15 @@ contains
     integer,parameter :: bVelo_upward     = 57 ! Sum of all upward flow velocities (is negative) (m/s).
     integer,parameter :: bVelo_upChnlNo   = 58 ! Total number of channels with upward flow velocities (dimensionless).
 
+    ! Sediment TERMS (rates kg/s or storage kg)
+    integer,parameter :: br_ehexch = 70 ! exchanging fluxes between channel and environments
+    integer,parameter :: br_etexch = 71 ! exchanging fluxes between channel and environments
+    integer,parameter :: br_erexch = 72 ! exchanging fluxes between channel and environments
+    integer,parameter :: bv_t_al_i = 73 ! initial sediment storge in the active layer of sub-network channel
+    integer,parameter :: bv_t_al_f = 74 ! final sediment storge in the active layer of sub-network channel
+    integer,parameter :: bv_r_al_i = 75 ! initial sediment storge in the active layer of main channel
+    integer,parameter :: bv_r_al_f = 76 ! final sediment storge in the active layer of main channel
+
     ! Other Diagnostic TERMS (rates, m3/s)
     integer,parameter :: br_erolpo = 60 ! erout lag ocn previous
     integer,parameter :: br_erolco = 61 ! erout lag ocn current
@@ -2112,7 +2183,7 @@ contains
     integer,parameter :: bv_naccum = 80 ! accumulated net budget
 
     !   volume = 2 - 1 + bv_dstor_f - bv_dstor_i
-    !   input  = br_qsur + br_qsub + br_qgwl + br_qdto + br_qdem
+    !   input  = br_qsur + br_qsub + br_qgwl + br_qdto + br_qdem + br_etexch + br_ehexch + br_erexch
     !   output = br_ocnout + br_flood + br_direct + 42
     !   total  = volume - input + output
     !   erlag  = br_erolpn - br_erolcn
@@ -2158,6 +2229,9 @@ contains
     erowm_regf = 0._r8
     eroutup_avg = 0._r8
     erlat_avg = 0._r8
+    ehexch_avg = 0._r8
+    etexch_avg = 0._r8
+    erexch_avg = 0._r8
     rtmCTL%runoff = 0._r8              ! coupler return mosart basin derived flow [m3/s]
     rtmCTL%direct = 0._r8              ! coupler return direct flow [m3/s]
     rtmCTL%flood = 0._r8               ! coupler return flood water sent back to clm [m3/s]
@@ -2203,12 +2277,17 @@ contains
           budget_terms(bv_volt_i,nt) = budget_terms( bv_volt_i,nt) + rtmCTL%volr(nr,nt)
           budget_terms(bv_wt_i,nt) = budget_terms(bv_wt_i,nt) + TRunoff%wt(nr,nt)
           budget_terms(bv_wr_i,nt) = budget_terms(bv_wr_i,nt) + TRunoff%wr(nr,nt)
-          budget_terms(bv_wh_i,nt) = budget_terms(bv_wh_i,nt) + TRunoff%wh(nr,nt)*rtmCTL%area(nr)
+          budget_terms(bv_wh_i,nt) = budget_terms(bv_wh_i,nt) + TRunoff%wh(nr,nt)*rtmCTL%area(nr)          
+          budget_terms(bv_t_al_i,nt) = budget_terms(bv_t_al_i,nt) + TRunoff%wt_al(nr,nt)
+          budget_terms(bv_r_al_i,nt) = budget_terms(bv_r_al_i,nt) + TRunoff%wr_al(nr,nt)
           budget_terms(br_qsur,nt) = budget_terms(br_qsur,nt) + rtmCTL%qsur(nr,nt)*delt_coupling     ! (rtmCTL%qsur 's unit is m^3/s. --Inund.)
           budget_terms(br_qsub,nt) = budget_terms(br_qsub,nt) + rtmCTL%qsub(nr,nt)*delt_coupling
           budget_terms(br_qgwl,nt) = budget_terms(br_qgwl,nt) + rtmCTL%qgwl(nr,nt)*delt_coupling
           budget_terms(br_qdto,nt) = budget_terms(br_qdto,nt) + rtmCTL%qdto(nr,nt)*delt_coupling
           budget_terms(br_qdem,nt) = budget_terms(br_qdem,nt) + rtmCTL%qdem(nr,nt)*delt_coupling
+          budget_terms(br_ehexch,nt) = budget_terms(br_ehexch,nt) + ehexch_avg(nr,nt)*delt_coupling
+          budget_terms(br_etexch,nt) = budget_terms(br_etexch,nt) + etexch_avg(nr,nt)*delt_coupling
+          budget_terms(br_erexch,nt) = budget_terms(br_erexch,nt) + erexch_avg(nr,nt)*delt_coupling
        enddo
        enddo
 
@@ -2245,6 +2324,14 @@ contains
           do idam = 1,ctlSubwWRM%LocalNumDam
              budget_terms(bv_dstor_i,nt) = budget_terms(bv_dstor_i,nt) + StorWater%storage(idam)
           enddo
+          
+          if (sediflag) then
+             do nt = 1,nt_rtm
+             do nr = rtmCTL%begr,rtmCTL%endr
+                budget_terms(bv_dstor_i,nt) = budget_terms(bv_dstor_i,nt) + Tres%wres(nr,nt)
+             enddo
+             enddo
+          end if
        endif
        call t_stopf('mosartr_budget')
     endif ! budget_check
@@ -2450,14 +2537,25 @@ contains
     ! --- convert TRunoff fields from m3/s to m/s before calling Euler
     !-----------------------------------
 
-    do nt = 1,nt_rtm
-    do nr = rtmCTL%begr,rtmCTL%endr
-       TRunoff%qsur(nr,nt) = TRunoff%qsur(nr,nt) / rtmCTL%area(nr)
-       TRunoff%qsub(nr,nt) = TRunoff%qsub(nr,nt) / rtmCTL%area(nr)
-       TRunoff%qgwl(nr,nt) = TRunoff%qgwl(nr,nt) / rtmCTL%area(nr)
-       TRunoff%qdem(nr,nt) = TRunoff%qdem(nr,nt) / rtmCTL%area(nr) !m3 to m
-    enddo
-    enddo
+    if(sediflag) then
+       do nt = 1,nt_rtm
+       do nr = rtmCTL%begr,rtmCTL%endr
+          TRunoff%qsur(nr,nt) = TRunoff%qsur(nr,nt) / rtmCTL%area(nr)
+          TRunoff%qsub(nr,nt) = TRunoff%qsub(nr,nt) / rtmCTL%area(nr)
+          TRunoff%qgwl(nr,nt) = TRunoff%qgwl(nr,nt) / rtmCTL%area(nr)
+          TRunoff%qdem(nr,nt) = TRunoff%qdem(nr,nt) / rtmCTL%area(nr) !m3 to m
+       enddo
+       enddo
+    else
+       do nt = nt_nliq,nt_nice
+       do nr = rtmCTL%begr,rtmCTL%endr
+          TRunoff%qsur(nr,nt) = TRunoff%qsur(nr,nt) / rtmCTL%area(nr)
+          TRunoff%qsub(nr,nt) = TRunoff%qsub(nr,nt) / rtmCTL%area(nr)
+          TRunoff%qgwl(nr,nt) = TRunoff%qgwl(nr,nt) / rtmCTL%area(nr)
+          TRunoff%qdem(nr,nt) = TRunoff%qdem(nr,nt) / rtmCTL%area(nr) !m3 to m
+       enddo
+       enddo
+    end if
 
     do ns = 1,nsub
 
@@ -2529,18 +2627,38 @@ contains
        !-----------------------------------
        ! accumulate local flow field
        !-----------------------------------
-
-       do nt = 1,nt_rtm
-       do nr = rtmCTL%begr,rtmCTL%endr
-          flow(nr,nt) = flow(nr,nt) + TRunoff%flow(nr,nt)
-          eroup_lagi(nr,nt) = eroup_lagi(nr,nt) + TRunoff%eroup_lagi(nr,nt)
-          eroup_lagf(nr,nt) = eroup_lagf(nr,nt) + TRunoff%eroup_lagf(nr,nt)
-          erowm_regi(nr,nt) = erowm_regi(nr,nt) + TRunoff%erowm_regi(nr,nt)
-          erowm_regf(nr,nt) = erowm_regf(nr,nt) + TRunoff%erowm_regf(nr,nt)
-          eroutup_avg(nr,nt) = eroutup_avg(nr,nt) + TRunoff%eroutup_avg(nr,nt)
-          erlat_avg(nr,nt) = erlat_avg(nr,nt) + TRunoff%erlat_avg(nr,nt)
-       enddo
-       enddo
+       
+       if(sediflag) then
+          do nt = 1,nt_rtm
+          do nr = rtmCTL%begr,rtmCTL%endr
+             flow(nr,nt) = flow(nr,nt) + TRunoff%flow(nr,nt)
+             eroup_lagi(nr,nt) = eroup_lagi(nr,nt) + TRunoff%eroup_lagi(nr,nt)
+             eroup_lagf(nr,nt) = eroup_lagf(nr,nt) + TRunoff%eroup_lagf(nr,nt)
+             erowm_regi(nr,nt) = erowm_regi(nr,nt) + TRunoff%erowm_regi(nr,nt)
+             erowm_regf(nr,nt) = erowm_regf(nr,nt) + TRunoff%erowm_regf(nr,nt)
+             eroutup_avg(nr,nt) = eroutup_avg(nr,nt) + TRunoff%eroutup_avg(nr,nt)
+             erlat_avg(nr,nt) = erlat_avg(nr,nt) + TRunoff%erlat_avg(nr,nt)
+             ehexch_avg(nr,nt) = ehexch_avg(nr,nt) + TRunoff%ehexch_avg(nr,nt)
+             etexch_avg(nr,nt) = etexch_avg(nr,nt) + TRunoff%etexch_avg(nr,nt)
+             erexch_avg(nr,nt) = erexch_avg(nr,nt) + TRunoff%erexch_avg(nr,nt)
+          enddo
+          enddo
+       else
+          do nt = nt_nliq,nt_nice
+          do nr = rtmCTL%begr,rtmCTL%endr
+             flow(nr,nt) = flow(nr,nt) + TRunoff%flow(nr,nt)
+             eroup_lagi(nr,nt) = eroup_lagi(nr,nt) + TRunoff%eroup_lagi(nr,nt)
+             eroup_lagf(nr,nt) = eroup_lagf(nr,nt) + TRunoff%eroup_lagf(nr,nt)
+             erowm_regi(nr,nt) = erowm_regi(nr,nt) + TRunoff%erowm_regi(nr,nt)
+             erowm_regf(nr,nt) = erowm_regf(nr,nt) + TRunoff%erowm_regf(nr,nt)
+             eroutup_avg(nr,nt) = eroutup_avg(nr,nt) + TRunoff%eroutup_avg(nr,nt)
+             erlat_avg(nr,nt) = erlat_avg(nr,nt) + TRunoff%erlat_avg(nr,nt)
+             ehexch_avg(nr,nt) = ehexch_avg(nr,nt) + TRunoff%ehexch_avg(nr,nt)
+             etexch_avg(nr,nt) = etexch_avg(nr,nt) + TRunoff%etexch_avg(nr,nt)
+             erexch_avg(nr,nt) = erexch_avg(nr,nt) + TRunoff%erexch_avg(nr,nt)
+          enddo
+          enddo
+       end if
 
 
        if (inundflag) then
@@ -2619,6 +2737,9 @@ contains
     erowm_regf  = erowm_regf  / float(nsub)
     eroutup_avg = eroutup_avg / float(nsub)
     erlat_avg   = erlat_avg   / float(nsub)
+    ehexch_avg  = ehexch_avg  / float(nsub)
+    etexch_avg  = etexch_avg  / float(nsub)
+    erexch_avg  = erexch_avg  / float(nsub)
 
     if (inundflag) then
        ! Mean inundated floodplain area for all sub-steps of coupling period (for each land grid cell):
@@ -2671,11 +2792,20 @@ contains
     do nt = 1,nt_rtm
     do nr = rtmCTL%begr,rtmCTL%endr
        volr_init = rtmCTL%volr(nr,nt)
-       rtmCTL%volr(nr,nt) = (TRunoff%wt(nr,nt) + TRunoff%wr(nr,nt) + &
-                             TRunoff%wh(nr,nt)*rtmCTL%area(nr)) * TUnit%frac(nr)
+
+       if(sediflag) then
+          rtmCTL%volr(nr,nt) = (TRunoff%wt(nr,nt) + TRunoff%wr(nr,nt) + &
+                                TRunoff%wh(nr,nt)*rtmCTL%area(nr) * TUnit%frac(nr) + &
+                                TRunoff%wt_al(nr,nt) + TRunoff%wr_al(nr,nt))
+       else
+          rtmCTL%volr(nr,nt) = (TRunoff%wt(nr,nt) + TRunoff%wr(nr,nt) + &
+                                TRunoff%wh(nr,nt)*rtmCTL%area(nr)) * TUnit%frac(nr)
+       end if  
+
        if (inundflag .and. Tctl%OPT_inund == 1 .and. nt == 1) then
           rtmCTL%volr(nr,nt) = rtmCTL%volr(nr,nt) + TRunoff%wf_ini(nr)
        endif
+
        rtmCTL%dvolrdt(nr,nt) = (rtmCTL%volr(nr,nt) - volr_init) / delt_coupling
        rtmCTL%runoff(nr,nt) = flow(nr,nt)
 
@@ -2712,6 +2842,8 @@ contains
           budget_terms(bv_wt_f,nt) = budget_terms(bv_wt_f,nt) + TRunoff%wt(nr,nt)
           budget_terms(bv_wr_f,nt) = budget_terms(bv_wr_f,nt) + TRunoff%wr(nr,nt)
           budget_terms(bv_wh_f,nt) = budget_terms(bv_wh_f,nt) + TRunoff%wh(nr,nt)*rtmCTL%area(nr)
+          budget_terms(bv_t_al_f,nt) = budget_terms(bv_t_al_f,nt) + TRunoff%wt_al(nr,nt)
+          budget_terms(bv_r_al_f,nt) = budget_terms(bv_r_al_f,nt) + TRunoff%wr_al(nr,nt)
           budget_terms(br_direct,nt) = budget_terms(br_direct,nt) + rtmCTL%direct(nr,nt)*delt_coupling     ! (Volume of direct 'flow' to ocean. --Inund.)
 
           if (rtmCTL%mask(nr) >= 2) then    ! (2 -- Ocean; 3 -- Outlet. --Inund.)
@@ -2731,6 +2863,9 @@ contains
           endif
           budget_terms(br_eroutup,nt) = budget_terms(br_eroutup,nt) - eroutup_avg(nr,nt)*delt_coupling     ! (Sum up upstream inflow volumes of all land cells. --Inund.)
           budget_terms(br_erlat,nt) = budget_terms(br_erlat,nt) - erlat_avg(nr,nt)*delt_coupling           ! (Sum up lateral inflow volumes of all land cells. --Inund.)
+          budget_terms(br_ehexch,nt) = budget_terms(br_ehexch,nt) + ehexch_avg(nr,nt)*delt_coupling
+          budget_terms(br_etexch,nt) = budget_terms(br_etexch,nt) + etexch_avg(nr,nt)*delt_coupling
+          budget_terms(br_erexch,nt) = budget_terms(br_erexch,nt) + erexch_avg(nr,nt)*delt_coupling
        enddo
        enddo
        nt = 1
@@ -2749,6 +2884,14 @@ contains
           do idam = 1,ctlSubwWRM%LocalNumDam
              budget_terms(bv_dstor_f,nt) = budget_terms(bv_dstor_f,nt) + StorWater%storage(idam)
           enddo
+          
+          if(sediflag) then
+             do nt = 1,nt_rtm
+             do nr = rtmCTL%begr,rtmCTL%endr
+                budget_terms(bv_dstor_f,nt) = budget_terms(bv_dstor_f,nt) + Tres%wres(nr,nt)
+             enddo
+             enddo
+          end if
        endif
 
        if (inundflag) then
@@ -2878,7 +3021,10 @@ contains
           budget_volume =  budget_terms(bv_volt_f,nt) - budget_terms(bv_volt_i,nt) + &
                            budget_terms(bv_dstor_f,nt) - budget_terms(bv_dstor_i,nt)             ! (Volume change during a coupling period. --Inund.)
           budget_input  =  budget_terms(br_qsur,nt) + budget_terms(br_qsub,nt) + &
-                           budget_terms(br_qgwl,nt) + budget_terms(br_qdto,nt)
+                           budget_terms(br_qgwl,nt) + budget_terms(br_qdto,nt) + &
+                           budget_terms(br_ehexch,nt) + budget_terms(br_etexch,nt) + &
+                           budget_terms(br_erexch,nt) !+ &
+                           ! budget_terms(br_qdem,nt) commented out by Tian 3/13/2018
           budget_output =  budget_terms(br_ocnout,nt) + budget_terms(br_flood,nt) + &
                            budget_terms(br_direct,nt) + &
                            budget_terms(bv_dsupp_f,nt) - budget_terms(bv_dsupp_i,nt)
@@ -2907,7 +3053,10 @@ contains
             budget_volume = (budget_global(bv_volt_f,nt) - budget_global(bv_volt_i,nt) + &
                              budget_global(bv_dstor_f,nt) - budget_global(bv_dstor_i,nt))   !(Global volume change during a coupling period. --Inund.)
             budget_input  = (budget_global(br_qsur,nt) + budget_global(br_qsub,nt) + &
-                             budget_global(br_qgwl,nt) + budget_global(br_qdto,nt))
+                             budget_global(br_qgwl,nt) + budget_global(br_qdto,nt)) + &
+                             budget_global(br_ehexch,nt) + budget_global(br_etexch,nt) + &
+                             budget_global(br_erexch,nt) !+ &
+                             ! budget_global(br_qdem,nt)) commented out by Tian 3/13/2018
             budget_output = (budget_global(br_ocnout,nt) + budget_global(br_flood,nt) + &
                              budget_global(br_direct,nt) + &
                              budget_global(bv_dsupp_f,nt) - budget_global(bv_dsupp_i,nt))
@@ -2921,6 +3070,8 @@ contains
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume wh    = ',nt,budget_global(bv_wh_f,nt)-budget_global(bv_wh_i,nt)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume wt    = ',nt,budget_global(bv_wt_f,nt)-budget_global(bv_wt_i,nt)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume wr    = ',nt,budget_global(bv_wr_f,nt)-budget_global(bv_wr_i,nt)
+            write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume t_al  = ',nt,budget_global(bv_t_al_f,nt)-budget_global(bv_t_al_i,nt)
+            write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume r_al  = ',nt,budget_global(bv_r_al_f,nt)-budget_global(bv_r_al_i,nt)
 
             ! If inundation scheme is turned on :
             if (inundflag .and. Tctl%OPT_inund .eq. 1 ) then
@@ -2956,6 +3107,10 @@ contains
             write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumet final = ',nt,budget_global(bv_wt_f,nt)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumer  init = ',nt,budget_global(bv_wr_i,nt)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumer final = ',nt,budget_global(bv_wr_f,nt)
+            write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumer  init = ',nt,budget_global(bv_t_al_i,nt)
+            write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumer final = ',nt,budget_global(bv_t_al_f,nt)
+            write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumer  init = ',nt,budget_global(bv_r_al_i,nt)
+            write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumer final = ',nt,budget_global(bv_r_al_f,nt)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),' x storage  init = ',nt,budget_global(bv_dstor_i,nt)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),' x storage final = ',nt,budget_global(bv_dstor_f,nt)
           endif
@@ -2964,12 +3119,20 @@ contains
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   input subsurf = ',nt,budget_global(br_qsub,nt)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   input gwl     = ',nt,budget_global(br_qgwl,nt)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   input dto     = ',nt,budget_global(br_qdto,nt)
+            write(iulog,'(2a,i4,f22.6  )') trim(subname),'   input demand -not included-  = ',nt,budget_global(br_qdem,nt)
+            write(iulog,'(2a,i4,f22.6  )') trim(subname),'   input hillslope erosion = ',nt,budget_global(br_ehexch,nt)
+            write(iulog,'(2a,i4,f22.6  )') trim(subname),'   input subnetwork channel bank erosion = ',nt,budget_global(br_etexch,nt)
+            write(iulog,'(2a,i4,f22.6  )') trim(subname),'   input main channel bank erosion = ',nt,budget_global(br_erexch,nt)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),' * input total   = ',nt,budget_input
           if (output_all_budget_terms) then
             write(iulog,'(2a,i4,f22.6,a)') trim(subname),' x input check   = ',nt,budget_input - &
                                                                              (budget_global(br_qsur,nt)+budget_global(br_qsub,nt)+ &
                                                                               budget_global(br_qgwl,nt)+budget_global(br_qdto,nt)), &
-                     ' (should be zero)'
+                                                                              budget_global(br_ehexch,nt)+budget_global(br_etexch,nt)+ &
+                                                                              budget_global(br_erexch,nt), & !+budget_global(br_qdem,nt)), &
+                                                                             ' (should be zero)'
+                                                                             ! + budget_global(br_qdem,nt)), commented out by Tian 3/13/2018
+
                                                                              
           endif
             write(iulog,'(2a)') trim(subname),'----------------'
@@ -3056,10 +3219,17 @@ contains
              budget_glb_inund(bv_wr_f, 1) = budget_global(bv_wr_f, 1) / 1000._r8       ! Final water volume in main channels.
              budget_glb_inund(bv_wh_i, 1) = budget_global(bv_wh_i, 1) / 1000._r8       ! Inital water volume over hillslopes.
              budget_glb_inund(bv_wh_f, 1) = budget_global(bv_wh_f, 1) / 1000._r8       ! Final water volume over hillslopes.
+             budget_glb_inund(bv_t_al_i, 1) = budget_global(bv_t_al_i, 1) / 1000._r8   ! Initial storage in the active layer of subnetwork channels.
+             budget_glb_inund(bv_t_al_i, 1) = budget_global(bv_t_al_f, 1) / 1000._r8   ! Final storage in the active layer of subnetwork channels.
+             budget_glb_inund(bv_r_al_i, 1) = budget_global(bv_r_al_i, 1) / 1000._r8   ! Initial storage in the active layer of main channels.
+             budget_glb_inund(bv_r_al_i, 1) = budget_global(bv_r_al_f, 1) / 1000._r8   ! Final storage in the active layer of main channels.
              budget_glb_inund(br_qsur, 1) = budget_global(br_qsur, 1) / 1000._r8       ! Input surface runoff.
              budget_glb_inund(br_qsub, 1) = budget_global(br_qsub, 1) / 1000._r8       ! Input sub-surface runoff.
              budget_glb_inund(br_qgwl, 1) = budget_global(br_qgwl, 1) / 1000._r8       ! Input from glacier, wetland or lake.
              budget_glb_inund(br_qdto, 1) = budget_global(br_qdto, 1) / 1000._r8       ! Input direct-to-ocean runoff.
+             budget_glb_inund(br_ehexch, 1) = budget_global(br_ehexch, 1) / 1000._r8   ! Input hillslope erosion.
+             budget_glb_inund(br_etexch, 1) = budget_global(br_etexch, 1) / 1000._r8   ! Input subntework channel bank erosion.
+             budget_glb_inund(br_erexch, 1) = budget_global(br_erexch, 1) / 1000._r8   ! Input main channel bank erosion.
              budget_glb_inund(br_ocnout, 1) = budget_global(br_ocnout, 1) / 1000._r8   ! Output flows to oceans.
              budget_glb_inund(br_direct, 1) = budget_global(br_direct, 1) / 1000._r8   ! Output direct to oceans.
              budget_glb_inund(br_erolpn, 1) = budget_global(br_erolpn, 1) / 1000._r8   ! Output from previous sub-step
@@ -3133,7 +3303,8 @@ contains
                 write(iulog,'(a)') trim(tracerID)//'   Surface-water balance check:'
                 write(iulog,'(a)') trim(tracerID)//'---------------------------------'
 
-                budget_input = budget_glb_inund(br_qsur, nt) + budget_glb_inund(br_qsub, nt) + budget_glb_inund(br_qgwl, nt) + budget_glb_inund(br_qdto, nt)
+                budget_input = budget_glb_inund(br_qsur, nt) + budget_glb_inund(br_qsub, nt) + budget_glb_inund(br_qgwl, nt) + budget_glb_inund(br_qdto, nt) + &
+                     budget_glb_inund(br_ehexch, nt) + budget_glb_inund(br_etexch, nt) + budget_glb_inund(br_erexch, nt)
                 budget_output = budget_glb_inund(br_ocnout, nt) + budget_glb_inund(br_direct, nt)
                 budget_other = budget_glb_inund(br_erolpn,nt) - budget_glb_inund(br_erolcn,nt)   !('previous MOSART sub-step channel outflow volume'-'current MOSART sub-step channel outflow volume'. --Inund.)                                                                                                                                                                                                
 
@@ -3150,6 +3321,9 @@ contains
                 write(iulog,'(a, f22.6)') trim(tracerID)//'   Input sub-surface runoff (km^3)            =', budget_glb_inund(br_qsub, nt)
                 write(iulog,'(a, f22.6)') trim(tracerID)//'   Input from glacier, wetland or lake (km^3) =', budget_glb_inund(br_qgwl, nt)
                 write(iulog,'(a, f22.6)') trim(tracerID)//'   Input direct-to-ocean runoff (km^3)        =', budget_glb_inund(br_qdto, nt)
+                write(iulog,'(a, f22.6)') trim(tracerID)//'   Input hillslope erosion (1e9kg)            =', budget_glb_inund(br_ehexch, nt)
+                write(iulog,'(a, f22.6)') trim(tracerID)//'   Input subnetwork channel bank erosion (1e9kg)  =', budget_glb_inund(br_etexch, nt)
+                write(iulog,'(a, f22.6)') trim(tracerID)//'   Input main channel bank erosion (1e9kg)        =', budget_glb_inund(br_erexch, nt)
                 write(iulog,'(a, f22.6)') trim(tracerID)//'   Output flows to oceans (km^3)              =', budget_glb_inund(br_ocnout, nt)
                 write(iulog,'(a, f22.6)') trim(tracerID)//'   Output direct to oceans (km^3)             =', budget_glb_inund(br_direct, nt)
 
@@ -3162,6 +3336,8 @@ contains
                 write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume over hillslopes (km^3)              =', budget_glb_inund(bv_wh_i, nt)
                 write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume in subnetworks (km^3)               =', budget_glb_inund(bv_wt_i, nt)
                 write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume in main channels (km^3)             =', budget_glb_inund(bv_wr_i, nt)
+                write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume in subnetworks active layer (1e9kg) =', budget_glb_inund(bv_t_al_i, nt)
+                write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume in main channel active layer (1e9kg)=', budget_glb_inund(bv_r_al_i, nt)
 
                 ! If inundation scheme is on & the 1st tracer (liquid water) :
                 if ( inundflag .and. Tctl%OPT_inund .eq. 1 .and. nt .eq. 1 ) then
@@ -3177,6 +3353,8 @@ contains
                 write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume over hillslopes (km^3)              =', budget_glb_inund(bv_wh_f, nt)
                 write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume in subnetworks (km^3)               =', budget_glb_inund(bv_wt_f, nt)
                 write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume in main channels (km^3)             =', budget_glb_inund(bv_wr_f, nt)
+                write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume in subnetworks active layer (1e9kg) =', budget_glb_inund(bv_t_al_f, nt)
+                write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume in main channel active layer (1e9kg)=', budget_glb_inund(bv_r_al_f, nt)
 
                 ! If inundation scheme is on & the 1st tracer (liquid water) :
                 if ( inundflag .and. Tctl%OPT_inund .eq. 1 .and. nt .eq. 1 ) then
@@ -3375,27 +3553,28 @@ contains
 !
 ! !INTERFACE:
   subroutine MOSART_init
-!
-! !REVISION HISTORY:
-! Author: Hongyi Li
+  !
+  ! !REVISION HISTORY:
+  ! Author: Hongyi Li
 
-! !DESCRIPTION:
-! initialize MOSART variables
-! 
-! !USES:
-! !ARGUMENTS:
-  implicit none
-!
-! !REVISION HISTORY:
-! Author: Hongyi Li
-!
-!
-! !OTHER LOCAL VARIABLES:
-!EOP
+  ! !DESCRIPTION:
+  ! initialize MOSART variables
+  ! 
+  ! !USES:
+  ! !ARGUMENTS:
+    implicit none
+  !
+  ! !REVISION HISTORY:
+  ! Author: Hongyi Li
+  !
+  !
+  ! !OTHER LOCAL VARIABLES:
+  !EOP
   type(file_desc_t)  :: ncid       ! pio file desc
   type(var_desc_t)   :: vardesc    ! pio variable desc 
   type(io_desc_t)    :: iodesc_dbl ! pio io desc
   type(io_desc_t)    :: iodesc_int ! pio io desc
+  logical            :: readvar    ! If variable exists or not
   integer, pointer   :: compdof(:) ! computational degrees of freedom for pio 
   integer :: ndims                 ! number of dimensions in the input
   integer :: dids(2)               ! variable dimension ids 
@@ -3460,8 +3639,14 @@ contains
      
      if (wrmflag) then
        allocate(TUnit%domainfrac(begr:endr))
-       ier = pio_inq_varid(ncid, 'domainfrac', vardesc)
-       call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%domainfrac, ier)
+       call check_var(ncid, 'domainfrac', vardesc, readvar)
+       if (readvar) then
+         ier = pio_inq_varid(ncid, name='domainfrac', vardesc=vardesc)
+         write(iulog,*) subname,' ier =',ier
+         call pio_read_darray(ncid, vardesc, iodesc_dbl, TUnit%domainfrac, ier)
+       else
+         TUnit%domainfrac = 1.0_r8
+       endif
        if (masterproc) write(iulog,FORMR) trim(subname),' read domainfrac ',minval(Tunit%domainfrac),maxval(Tunit%domainfrac)
        call shr_sys_flush(iulog)
      endif
@@ -3665,8 +3850,41 @@ contains
         call shr_sys_flush(iulog)
      end if
 
+     if (sediflag) then
+        allocate(TSedi_para%d50(begr:endr))
+        ier = pio_inq_varid(ncid, name='D50', vardesc=vardesc)
+        call pio_read_darray(ncid, vardesc, iodesc_dbl, TSedi_para%d50, ier)
+        if (masterproc) write(iulog,FORMR) trim(subname),' read D50 ',minval(TSedi_para%d50),maxval(TSedi_para%d50)
+        call shr_sys_flush(iulog)
+     end if
+
+     !! TODO: inputs for the reservoir trapping only but not for regulation
+     !  if(sediflag .and. wrmflag) then
+     !    allocate(Tres_para%Tres_t(begr:endr))  
+     !    ier = pio_inq_varid(ncid, name='deltaT_local', vardesc=vardesc)
+     !    call pio_read_darray(ncid, vardesc, iodesc_dbl, Tres_para%Tres_t, ier)
+     !    if (masterproc) write(iulog,FORMR) trim(subname),' read Tres_t ',minval(Tres_para%Tres_t),maxval(Tres_para%Tres_t)
+     !    call shr_sys_flush(iulog)
+     !    do iunit=begr,endr
+     !    if(Tres_para%Tres_t(iunit)<0._r8) then
+     !            Tres_para%Tres_t(iunit) = 0._r8
+     !        end if
+     !    end do
+     !
+     !    allocate(Tres_para%Tres_r(begr:endr))  
+     !    ier = pio_inq_varid(ncid, name='deltaT_main', vardesc=vardesc)
+     !    call pio_read_darray(ncid, vardesc, iodesc_dbl, Tres_para%Tres_r, ier)
+     !    if (masterproc) write(iulog,FORMR) trim(subname),' read Tres_r ',minval(Tres_para%Tres_r),maxval(Tres_para%Tres_r)
+     !    call shr_sys_flush(iulog)
+     !    do iunit=begr,endr
+     !        if(Tres_para%Tres_r(iunit)<0._r8) then
+     !            Tres_para%Tres_r(iunit) = 0._r8
+     !        end if        
+     !    end do
+     !  end if
+
      allocate(TUnit%nr(begr:endr))
-  
+
      if (inundflag) then
         ! Calculate channel Manning roughness coefficients :
         call calc_chnlMannCoe ( )
@@ -3690,13 +3908,12 @@ contains
 
             if ( TUnit%area(n) .le. 0._r8 ) then
               write( iulog, * ) trim( subname ) // ' ERROR: TUnit%area(n) <= 0 for n=', n
-              call shr_sys_abort( trim( subname ) // ' ERROR: TUnit%area(n) <= 0 ')
+            !  call shr_sys_abort( trim( subname ) // ' ERROR: TUnit%area(n) <= 0 ')
             end if
 
             if ( TUnit%areaTotal(n) .le. 0._r8 ) then
               write( iulog, * ) trim( subname ) // ' ERROR: TUnit%areaTotal(n) <= 0 for n=', n
-
-              call shr_sys_abort( trim( subname ) // ' ERROR: TUnit%areaTotal(n) <= 0 ')
+            !  call shr_sys_abort( trim( subname ) // ' ERROR: TUnit%areaTotal(n) <= 0 ')
             end if
 
             if ( TUnit%nh(n) .le. 0._r8 ) then
@@ -3706,7 +3923,6 @@ contains
 
             if ( TUnit%hslp(n) .LT. 0._r8 ) then
               write( iulog, * ) trim( subname ) // ' ERROR: TUnit%hslp(n) < 0 for n=', n
-
               call shr_sys_abort( trim( subname ) // ' ERROR: TUnit%hslp(n) < 0 ')
             end if
 
@@ -3717,7 +3933,6 @@ contains
 
             if ( TUnit%tslp(n) .LT. 0._r8 ) then
               write( iulog, * ) trim( subname ) // ' ERROR: TUnit%tslp(n) < 0 for n=', n
-
               call shr_sys_abort( trim( subname ) // ' ERROR: TUnit%tslp(n) < 0 ')
             end if
 
@@ -3800,9 +4015,9 @@ contains
           call shr_sys_flush(iulog)
        end if
 
-       if (Tctl%OPT_inund == 1) then
+       if (Tctl%OPT_inund == 1) then 
           allocate (TUnit%wr_bf(begr:endr))
-          TUnit%wr_bf = 0.0_r8   
+          TUnit%wr_bf = 0.0_r8 
 
           allocate( TUnit%e_eprof_in2( Tctl%npt_elevProf, begr:endr ) )    
 
@@ -3855,7 +4070,16 @@ contains
        endif
 
      end if  ! inundflag
-  
+
+     allocate(TUnit%nUp(begr:endr))
+     TUnit%nUp = 0
+
+     allocate(TUnit%iUp(begr:endr,8))
+     TUnit%iUp = 0
+
+     allocate(TUnit%indexDown(begr:endr))
+     TUnit%indexDown = 0
+
      ! initialize water states and fluxes
      allocate (TRunoff%wh(begr:endr,nt_rtm))
      TRunoff%wh = 0._r8
@@ -3881,6 +4105,12 @@ contains
      allocate (TRunoff%ehout(begr:endr,nt_rtm))
      TRunoff%ehout = 0._r8
 
+     allocate (TRunoff%ehexchange(begr:endr,nt_rtm))
+     TRunoff%ehexchange = 0._r8
+
+     allocate (TRunoff%ehexch_avg(begr:endr,nt_rtm))
+     TRunoff%ehexch_avg = 0._r8
+
      allocate (TRunoff%tarea(begr:endr,nt_rtm))
      TRunoff%tarea = 0._r8
 
@@ -3889,6 +4119,12 @@ contains
 
      allocate (TRunoff%dwt(begr:endr,nt_rtm))
      TRunoff%dwt = 0._r8
+
+     allocate (TRunoff%wt_al(begr:endr,nt_rtm))
+     TRunoff%wt_al = 0._r8
+
+     allocate (TRunoff%dwt_al(begr:endr,nt_rtm))
+     TRunoff%dwt_al = 0._r8
 
      allocate (TRunoff%yt(begr:endr,nt_rtm))
      TRunoff%yt = 0._r8
@@ -3908,11 +4144,20 @@ contains
      allocate (TRunoff%tt(begr:endr,nt_rtm))
      TRunoff%tt = 0._r8
 
+     allocate (TRunoff%conc_t(begr:endr,nt_rtm))
+     TRunoff%conc_t = 0._r8
+
      allocate (TRunoff%etin(begr:endr,nt_rtm))
      TRunoff%etin = 0._r8
 
      allocate (TRunoff%etout(begr:endr,nt_rtm))
      TRunoff%etout = 0._r8
+
+     allocate (TRunoff%etexchange(begr:endr,nt_rtm))
+     TRunoff%etexchange = 0._r8
+
+     allocate (TRunoff%etexch_avg(begr:endr,nt_rtm))
+     TRunoff%etexch_avg = 0._r8
 
      allocate (TRunoff%rarea(begr:endr,nt_rtm))
      TRunoff%rarea = 0._r8
@@ -3922,6 +4167,15 @@ contains
 
      allocate (TRunoff%dwr(begr:endr,nt_rtm))
      TRunoff%dwr = 0._r8
+
+     allocate (TRunoff%wr_al(begr:endr,nt_rtm))
+     TRunoff%wr_al = 0._r8
+
+     allocate (TRunoff%dwr_al(begr:endr,nt_rtm))
+     TRunoff%dwr_al = 0._r8
+
+     allocate (TRunoff%rslp_energy(begr:endr))
+     TRunoff%rslp_energy = 0._r8
 
      allocate (TRunoff%yr(begr:endr,nt_rtm))
      TRunoff%yr = 0._r8
@@ -3940,6 +4194,9 @@ contains
 
      allocate (TRunoff%tr(begr:endr,nt_rtm))
      TRunoff%tr = 0._r8
+
+     allocate (TRunoff%conc_r(begr:endr,nt_rtm))
+     TRunoff%conc_r = 0._r8
 
      allocate (TRunoff%erlg(begr:endr,nt_rtm))
      TRunoff%erlg = 0._r8
@@ -3979,7 +4236,13 @@ contains
 
      allocate (TRunoff%flow(begr:endr,nt_rtm))
      TRunoff%flow = 0._r8
-    
+
+     allocate (TRunoff%erexchange(begr:endr,nt_rtm))
+     TRunoff%erexchange = 0._r8
+
+     allocate (TRunoff%erexch_avg(begr:endr,nt_rtm))
+     TRunoff%erexch_avg = 0._r8
+
      allocate (TPara%c_twid(begr:endr))
      TPara%c_twid = 1.0_r8
 
@@ -3991,10 +4254,13 @@ contains
         TRunoff%wr_dstrm = 0.0_r8
 
         allocate (TRunoff%yr_dstrm(begr:endr))
-        TRunoff%yr_dstrm = 0.0_r8    
+        TRunoff%yr_dstrm = 0.0_r8
+
+        allocate (TRunoff%conc_r_dstrm(begr:endr,nt_rtm))
+        TRunoff%conc_r_dstrm = 0.0_r8
 
         allocate (TRunoff%erin_dstrm(begr:endr,nt_rtm))
-        TRunoff%erin_dstrm = 0.0_r8 
+        TRunoff%erin_dstrm = 0.0_r8
 
         do nr = rtmCTL%begr,rtmCTL%endr
             do i=1, rtmCTL%nUp(nr)
@@ -4163,14 +4429,14 @@ contains
         THeat%coszen = 0._r8
         
      end if
-    
+
      call pio_freedecomp(ncid, iodesc_dbl)
      call pio_freedecomp(ncid, iodesc_int)
      call pio_closefile(ncid)
 
-   ! control parameters and some other derived parameters
-   ! estimate derived input variables
-
+     ! control parameters and some other derived parameters
+     ! estimate derived input variables
+     ! TODO: Main channel storage capacity should be moved after rlen is modified
      if (inundflag .and. Tctl%OPT_inund == 1) then
         do iunit = rtmCTL%begr, rtmCTL%endr
           if ( rtmCTL%mask(iunit) .eq. 1 .or. rtmCTL%mask(iunit) .eq. 3 ) then   ! 1--Land; 3--Basin outlet (downstream is ocean).
@@ -4178,7 +4444,7 @@ contains
             ! Main channel storage capacity :
             TUnit%wr_bf( iunit ) = TUnit%rwidth( iunit ) * TUnit%rlen( iunit ) * TUnit%rdepth( iunit )
 
-          end if 
+          end if
         end do
      end if
 
@@ -4203,6 +4469,18 @@ contains
               TUnit%hlen(iunit) = hlen_max   ! allievate the outlier in drainage density estimation. TO DO
            end if
            rlen_min = sqrt(TUnit%area(iunit))
+           ! TODO: refine min channel length for numerical stability
+           !if(TUnit%rlen(iunit) < rlen_min .and. TUnit%mask(iunit)==1) then
+           !   TUnit%rlen(iunit) = rlen_min  ! the channel length should not be small if its has downstream grids
+           !else
+           !   if(TUnit%rlen(iunit) < rlen_min) then
+           !       TUnit%rlen(iunit) = 0.5_r8*rlen_min
+           !   end if
+           !end if
+           !if(TUnit%rlen(iunit) < rlen_min .and. TUnit%mask(iunit)==1) then
+           !   TUnit%rlen(iunit) = rlen_min  ! the channel length should not be small if its has downstream grids
+           !end if
+
            if(TUnit%rlen(iunit) < rlen_min) then
               TUnit%tlen(iunit) = TUnit%area(iunit) / rlen_min / 2._r8 - TUnit%hlen(iunit)
            else
@@ -4230,11 +4508,11 @@ contains
         
         if(TUnit%rslp(iunit) <= 0._r8) then
 
-        if (inundflag) then
-           TUnit%rslp(iunit) = Tctl%rslp_assume
-        else
-           TUnit%rslp(iunit) = 0.0001_r8
-        endif
+          if (inundflag) then
+             TUnit%rslp(iunit) = Tctl%rslp_assume
+          else
+             TUnit%rslp(iunit) = 0.0001_r8
+          endif
 
         end if
         if(TUnit%tslp(iunit) <= 0._r8) then
@@ -4246,7 +4524,7 @@ contains
         TUnit%rslpsqrt(iunit) = sqrt(Tunit%rslp(iunit))
         TUnit%tslpsqrt(iunit) = sqrt(Tunit%tslp(iunit))
         TUnit%hslpsqrt(iunit) = sqrt(Tunit%hslp(iunit))
-     end do
+     end do 
   end if  ! endr >= begr
 
   ! retrieve the downstream channel attributes after some post-processing above

--- a/components/mosart/src/riverroute/RtmRestFile.F90
+++ b/components/mosart/src/riverroute/RtmRestFile.F90
@@ -76,7 +76,7 @@ contains
 
     ! Define dimensions and variables
 
-    if (masterproc) then	
+    if (masterproc) then
        write(iulog,*)
        write(iulog,*)'restFile_open: writing RTM restart dataset '
        write(iulog,*)

--- a/driver-mct/cime_config/namelist_definition_drv.xml
+++ b/driver-mct/cime_config/namelist_definition_drv.xml
@@ -268,6 +268,18 @@
     </values>
   </entry>
 
+  <entry id="rof_sed">
+    <type>logical</type>
+    <category>seq_flds</category>
+    <group>seq_cplflds_inparm</group>
+    <desc>
+      If set to .true., adds fields needed to calculate sediment in the river model
+    </desc>
+    <values>
+      <value>.false.</value>
+    </values>
+  </entry>
+
   <!-- =========================== -->
   <!-- -group seq_cplflds_custom   -->
   <!-- =========================== -->

--- a/driver-mct/shr/seq_flds_mod.F90
+++ b/driver-mct/shr/seq_flds_mod.F90
@@ -157,6 +157,7 @@ module seq_flds_mod
   logical            :: rof2ocn_nutrients   ! .true. if the runoff model passes nutrient fields to the ocn
   logical            :: lnd_rof_two_way     ! .true. if land-river two-way coupling turned on
   logical            :: ocn_rof_two_way     ! .true. if river-ocean two-way coupling turned on
+  logical            :: rof_sed             ! .true. if river model includes sediment
 
   !----------------------------------------------------------------------------
   ! metadata
@@ -381,7 +382,7 @@ contains
          flds_co2a, flds_co2b, flds_co2c, flds_co2_dmsa, flds_wiso, glc_nec, &
          ice_ncat, seq_flds_i2o_per_cat, flds_bgc_oi, &
          nan_check_component_fields, rof_heat, atm_flux_method, atm_gustiness, &
-         rof2ocn_nutrients, lnd_rof_two_way, ocn_rof_two_way
+         rof2ocn_nutrients, lnd_rof_two_way, ocn_rof_two_way, rof_sed
 
     ! user specified new fields
     integer,  parameter :: nfldmax = 200
@@ -422,6 +423,7 @@ contains
        rof2ocn_nutrients = .false.
        lnd_rof_two_way   = .false.
        ocn_rof_two_way   = .false.
+       rof_sed   = .false.
 
        unitn = shr_file_getUnit()
        write(logunit,"(A)") subname//': read seq_cplflds_inparm namelist from: '&
@@ -454,6 +456,7 @@ contains
     call shr_mpi_bcast(rof2ocn_nutrients, mpicom)
     call shr_mpi_bcast(lnd_rof_two_way,   mpicom)
     call shr_mpi_bcast(ocn_rof_two_way,   mpicom)
+    call shr_mpi_bcast(rof_sed,   mpicom)
 
     call glc_elevclass_init(glc_nec)
 
@@ -2184,8 +2187,21 @@ contains
        units    = ' '
        attname  = 'coszen_str'
        call metadata_set(attname, longname, stdname, units)
+       
+	   if (rof_sed) then
+          call seq_flds_add(l2x_fluxes,'Flrl_rofmud')
+          call seq_flds_add(l2x_fluxes_to_rof,'Flrl_rofmud')
+          call seq_flds_add(x2r_fluxes,'Flrl_rofmud')
+          longname = 'Sediment flux from land (mud)'
+          stdname  = 'mud_flux_into_runoff_surface'
+          units    = 'kg m-2 s-1'
+          attname  = 'Flrl_rofmud'
+          call metadata_set(attname, longname, stdname, units)
+	   end if
+
     endif
 
+	
     !-----------------------------
     ! rof->ocn (runoff) and rof->lnd (flooding)
     !-----------------------------


### PR DESCRIPTION
MOSART-sediment, the suspended sediment module, takes lateral sediment yield fluxes from a 
land model (such as the soil erosion module in ELM) as the inputs and includes the description 
of riverine transport, erosion, and deposition processes. It also accounts for two major damming
 effects on suspended sediment load, direct sediment trapping effect and indirect flow regulating
 effect (via reservoir regulation of streamflow and hydraulic conditions). The scientific validation 
was conducted over the NLDAS2 domain (against observations from multiple USGS gages. The 
current parameter files are for the NLDAS2 domain only, although the process description is 
general and largely transferrable.

[NML]