### PR TITLE
Clean-up ocean bottom drag config options

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -822,7 +822,7 @@ add_default($nl, 'config_remap_limiter');
 
 add_default($nl, 'config_bottom_drag_mode');
 add_default($nl, 'config_implicit_bottom_drag_type');
-add_default($nl, 'config_implicit_bottom_drag_coeff');
+add_default($nl, 'config_implicit_constant_bottom_drag_coeff');
 add_default($nl, 'config_use_implicit_top_drag');
 add_default($nl, 'config_implicit_top_drag_coeff');
 add_default($nl, 'config_explicit_bottom_drag_coeff');

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -607,15 +607,6 @@ add_default($nl, 'config_eddyMLD_reference_depth');
 add_default($nl, 'config_eddyMLD_reference_pressure');
 add_default($nl, 'config_eddyMLD_use_old');
 
-####################################
-# Namelist group: Rayleigh_damping #
-####################################
-
-add_default($nl, 'config_Rayleigh_damping_coeff');
-add_default($nl, 'config_Rayleigh_damping_depth_variable');
-add_default($nl, 'config_Rayleigh_bottom_friction');
-add_default($nl, 'config_Rayleigh_bottom_damping_coeff');
-
 #########################
 # Namelist group: cvmix #
 #########################
@@ -755,13 +746,6 @@ add_default($nl, 'config_use_tidal_potential_forcing_P1');
 add_default($nl, 'config_tidal_potential_ramp');
 add_default($nl, 'config_self_attraction_and_loading_beta');
 
-###################################
-# Namelist group: vegetation_drag #
-###################################
-
-add_default($nl, 'config_use_vegetation_drag');
-add_default($nl, 'config_vegetation_drag_coefficient');
-
 ##############################
 # Namelist group: frazil_ice #
 ##############################
@@ -828,6 +812,22 @@ add_default($nl, 'config_implicit_top_drag_coeff');
 add_default($nl, 'config_explicit_bottom_drag_coeff');
 add_default($nl, 'config_use_topographic_wave_drag');
 add_default($nl, 'config_topographic_wave_drag_coeff');
+
+####################################
+# Namelist group: Rayleigh_damping #
+####################################
+
+add_default($nl, 'config_Rayleigh_damping_coeff');
+add_default($nl, 'config_Rayleigh_damping_depth_variable');
+add_default($nl, 'config_Rayleigh_bottom_friction');
+add_default($nl, 'config_Rayleigh_bottom_damping_coeff');
+
+###################################
+# Namelist group: vegetation_drag #
+###################################
+
+add_default($nl, 'config_use_vegetation_drag');
+add_default($nl, 'config_vegetation_drag_coefficient');
 
 ###################################
 # Namelist group: ocean_constants #
@@ -1728,7 +1728,6 @@ my @groups = qw(run_modes
                 submesoscale_eddy_parameterization
                 gm_eddy_parameterization
                 eddy_parameterization
-                rayleigh_damping
                 cvmix
                 wave_coupling
                 gotm
@@ -1741,6 +1740,8 @@ my @groups = qw(run_modes
                 land_ice_fluxes
                 advection
                 bottom_drag
+                rayleigh_damping
+                vegetation_drag
                 ocean_constants
                 pressure_gradient
                 eos

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -611,7 +611,6 @@ add_default($nl, 'config_eddyMLD_use_old');
 # Namelist group: Rayleigh_damping #
 ####################################
 
-add_default($nl, 'config_Rayleigh_friction');
 add_default($nl, 'config_Rayleigh_damping_coeff');
 add_default($nl, 'config_Rayleigh_damping_depth_variable');
 add_default($nl, 'config_Rayleigh_bottom_friction');
@@ -814,14 +813,11 @@ add_default($nl, 'config_remap_limiter');
 # Namelist group: bottom_drag #
 ###############################
 
-add_default($nl, 'config_use_implicit_bottom_drag');
+add_default($nl, 'config_bottom_drag_mode');
+add_default($nl, 'config_implicit_bottom_drag_type');
 add_default($nl, 'config_implicit_bottom_drag_coeff');
 add_default($nl, 'config_use_implicit_top_drag');
 add_default($nl, 'config_implicit_top_drag_coeff');
-add_default($nl, 'config_use_implicit_bottom_roughness');
-add_default($nl, 'config_use_implicit_bottom_drag_variable');
-add_default($nl, 'config_use_implicit_bottom_drag_variable_mannings');
-add_default($nl, 'config_use_explicit_bottom_drag');
 add_default($nl, 'config_explicit_bottom_drag_coeff');
 add_default($nl, 'config_use_topographic_wave_drag');
 add_default($nl, 'config_topographic_wave_drag_coeff');

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -755,6 +755,13 @@ add_default($nl, 'config_use_tidal_potential_forcing_P1');
 add_default($nl, 'config_tidal_potential_ramp');
 add_default($nl, 'config_self_attraction_and_loading_beta');
 
+###################################
+# Namelist group: vegetation_drag #
+###################################
+
+add_default($nl, 'config_use_vegetation_drag');
+add_default($nl, 'config_vegetation_drag_coefficient');
+
 ##############################
 # Namelist group: frazil_ice #
 ##############################

--- a/components/mpas-ocean/bld/build-namelist-group-list
+++ b/components/mpas-ocean/bld/build-namelist-group-list
@@ -11,7 +11,6 @@ my @groups = qw(run_modes
                 submesoscale_eddy_parameterization
                 gm_eddy_parameterization
                 eddy_parameterization
-                rayleigh_damping
                 cvmix
                 wave_coupling
                 gotm
@@ -24,6 +23,8 @@ my @groups = qw(run_modes
                 land_ice_fluxes
                 advection
                 bottom_drag
+                rayleigh_damping
+                vegetation_drag
                 ocean_constants
                 pressure_gradient
                 eos

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -146,15 +146,6 @@ add_default($nl, 'config_eddyMLD_reference_depth');
 add_default($nl, 'config_eddyMLD_reference_pressure');
 add_default($nl, 'config_eddyMLD_use_old');
 
-####################################
-# Namelist group: Rayleigh_damping #
-####################################
-
-add_default($nl, 'config_Rayleigh_damping_coeff');
-add_default($nl, 'config_Rayleigh_damping_depth_variable');
-add_default($nl, 'config_Rayleigh_bottom_friction');
-add_default($nl, 'config_Rayleigh_bottom_damping_coeff');
-
 #########################
 # Namelist group: cvmix #
 #########################
@@ -280,13 +271,6 @@ add_default($nl, 'config_use_tidal_potential_forcing_P1');
 add_default($nl, 'config_tidal_potential_ramp');
 add_default($nl, 'config_self_attraction_and_loading_beta');
 
-###################################
-# Namelist group: vegetation_drag #
-###################################
-
-add_default($nl, 'config_use_vegetation_drag');
-add_default($nl, 'config_vegetation_drag_coefficient');
-
 ##############################
 # Namelist group: frazil_ice #
 ##############################
@@ -347,6 +331,22 @@ add_default($nl, 'config_implicit_top_drag_coeff');
 add_default($nl, 'config_explicit_bottom_drag_coeff');
 add_default($nl, 'config_use_topographic_wave_drag');
 add_default($nl, 'config_topographic_wave_drag_coeff');
+
+####################################
+# Namelist group: Rayleigh_damping #
+####################################
+
+add_default($nl, 'config_Rayleigh_damping_coeff');
+add_default($nl, 'config_Rayleigh_damping_depth_variable');
+add_default($nl, 'config_Rayleigh_bottom_friction');
+add_default($nl, 'config_Rayleigh_bottom_damping_coeff');
+
+###################################
+# Namelist group: vegetation_drag #
+###################################
+
+add_default($nl, 'config_use_vegetation_drag');
+add_default($nl, 'config_vegetation_drag_coefficient');
 
 ###################################
 # Namelist group: ocean_constants #

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -280,6 +280,13 @@ add_default($nl, 'config_use_tidal_potential_forcing_P1');
 add_default($nl, 'config_tidal_potential_ramp');
 add_default($nl, 'config_self_attraction_and_loading_beta');
 
+###################################
+# Namelist group: vegetation_drag #
+###################################
+
+add_default($nl, 'config_use_vegetation_drag');
+add_default($nl, 'config_vegetation_drag_coefficient');
+
 ##############################
 # Namelist group: frazil_ice #
 ##############################

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -150,7 +150,6 @@ add_default($nl, 'config_eddyMLD_use_old');
 # Namelist group: Rayleigh_damping #
 ####################################
 
-add_default($nl, 'config_Rayleigh_friction');
 add_default($nl, 'config_Rayleigh_damping_coeff');
 add_default($nl, 'config_Rayleigh_damping_depth_variable');
 add_default($nl, 'config_Rayleigh_bottom_friction');
@@ -333,14 +332,11 @@ add_default($nl, 'config_remap_limiter');
 # Namelist group: bottom_drag #
 ###############################
 
-add_default($nl, 'config_use_implicit_bottom_drag');
+add_default($nl, 'config_bottom_drag_mode');
+add_default($nl, 'config_implicit_bottom_drag_type');
 add_default($nl, 'config_implicit_bottom_drag_coeff');
 add_default($nl, 'config_use_implicit_top_drag');
 add_default($nl, 'config_implicit_top_drag_coeff');
-add_default($nl, 'config_use_implicit_bottom_roughness');
-add_default($nl, 'config_use_implicit_bottom_drag_variable');
-add_default($nl, 'config_use_implicit_bottom_drag_variable_mannings');
-add_default($nl, 'config_use_explicit_bottom_drag');
 add_default($nl, 'config_explicit_bottom_drag_coeff');
 add_default($nl, 'config_use_topographic_wave_drag');
 add_default($nl, 'config_topographic_wave_drag_coeff');

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -341,7 +341,7 @@ add_default($nl, 'config_remap_limiter');
 
 add_default($nl, 'config_bottom_drag_mode');
 add_default($nl, 'config_implicit_bottom_drag_type');
-add_default($nl, 'config_implicit_bottom_drag_coeff');
+add_default($nl, 'config_implicit_constant_bottom_drag_coeff');
 add_default($nl, 'config_use_implicit_top_drag');
 add_default($nl, 'config_implicit_top_drag_coeff');
 add_default($nl, 'config_explicit_bottom_drag_coeff');

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -380,7 +380,7 @@
 <!-- bottom_drag -->
 <config_bottom_drag_mode>'implicit'</config_bottom_drag_mode>
 <config_implicit_bottom_drag_type>'constant'</config_implicit_bottom_drag_type>
-<config_implicit_bottom_drag_coeff>1.0e-3</config_implicit_bottom_drag_coeff>
+<config_implicit_constant_bottom_drag_coeff>1.0e-3</config_implicit_constant_bottom_drag_coeff>
 <config_use_implicit_top_drag>.false.</config_use_implicit_top_drag>
 <config_implicit_top_drag_coeff>2.5e-3</config_implicit_top_drag_coeff>
 <config_implicit_top_drag_coeff ocn_grid="oEC60to30v3wLI">4.48e-3</config_implicit_top_drag_coeff>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -316,6 +316,10 @@
 <config_tidal_potential_ramp>10.0</config_tidal_potential_ramp>
 <config_self_attraction_and_loading_beta>0.09</config_self_attraction_and_loading_beta>
 
+<!-- vegetation_drag -->
+<config_use_vegetation_drag>.false.</config_use_vegetation_drag>
+<config_vegetation_drag_coefficient>1.09</config_vegetation_drag_coefficient>
+
 <!-- frazil_ice -->
 <config_use_frazil_ice_formation>.true.</config_use_frazil_ice_formation>
 <config_frazil_in_open_ocean>.true.</config_frazil_in_open_ocean>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -210,7 +210,6 @@
 <config_eddyMLD_use_old>.true.</config_eddyMLD_use_old>
 
 <!-- Rayleigh_damping -->
-<config_Rayleigh_friction>.false.</config_Rayleigh_friction>
 <config_Rayleigh_damping_coeff>0.0</config_Rayleigh_damping_coeff>
 <config_Rayleigh_damping_depth_variable>.false.</config_Rayleigh_damping_depth_variable>
 <config_Rayleigh_bottom_friction>.false.</config_Rayleigh_bottom_friction>
@@ -375,7 +374,8 @@
 <config_remap_limiter>'monotonic'</config_remap_limiter>
 
 <!-- bottom_drag -->
-<config_use_implicit_bottom_drag>.true.</config_use_implicit_bottom_drag>
+<config_bottom_drag_mode>'implicit'</config_bottom_drag_mode>
+<config_implicit_bottom_drag_type>'constant'</config_implicit_bottom_drag_type>
 <config_implicit_bottom_drag_coeff>1.0e-3</config_implicit_bottom_drag_coeff>
 <config_use_implicit_top_drag>.false.</config_use_implicit_top_drag>
 <config_implicit_top_drag_coeff>2.5e-3</config_implicit_top_drag_coeff>
@@ -383,10 +383,6 @@
 <config_implicit_top_drag_coeff ocn_grid="ECwISC30to60E1r2">4.48e-3</config_implicit_top_drag_coeff>
 <config_implicit_top_drag_coeff ocn_grid="SOwISC12to60E2r4">4.48e-3</config_implicit_top_drag_coeff>
 <config_implicit_top_drag_coeff ocn_grid="ECwISC30to60E2r1">4.48e-3</config_implicit_top_drag_coeff>
-<config_use_implicit_bottom_roughness>.false.</config_use_implicit_bottom_roughness>
-<config_use_implicit_bottom_drag_variable>.false.</config_use_implicit_bottom_drag_variable>
-<config_use_implicit_bottom_drag_variable_mannings>.false.</config_use_implicit_bottom_drag_variable_mannings>
-<config_use_explicit_bottom_drag>.false.</config_use_explicit_bottom_drag>
 <config_explicit_bottom_drag_coeff>1.0e-3</config_explicit_bottom_drag_coeff>
 <config_use_topographic_wave_drag>.false.</config_use_topographic_wave_drag>
 <config_topographic_wave_drag_coeff>5.0e-4</config_topographic_wave_drag_coeff>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -209,12 +209,6 @@
 <config_eddyMLD_reference_pressure>1.0e5</config_eddyMLD_reference_pressure>
 <config_eddyMLD_use_old>.true.</config_eddyMLD_use_old>
 
-<!-- Rayleigh_damping -->
-<config_Rayleigh_damping_coeff>0.0</config_Rayleigh_damping_coeff>
-<config_Rayleigh_damping_depth_variable>.false.</config_Rayleigh_damping_depth_variable>
-<config_Rayleigh_bottom_friction>.false.</config_Rayleigh_bottom_friction>
-<config_Rayleigh_bottom_damping_coeff>1.0e-4</config_Rayleigh_bottom_damping_coeff>
-
 <!-- cvmix -->
 <config_use_cvmix>.true.</config_use_cvmix>
 <config_cvmix_prandtl_number>1.0</config_cvmix_prandtl_number>
@@ -316,10 +310,6 @@
 <config_tidal_potential_ramp>10.0</config_tidal_potential_ramp>
 <config_self_attraction_and_loading_beta>0.09</config_self_attraction_and_loading_beta>
 
-<!-- vegetation_drag -->
-<config_use_vegetation_drag>.false.</config_use_vegetation_drag>
-<config_vegetation_drag_coefficient>1.09</config_vegetation_drag_coefficient>
-
 <!-- frazil_ice -->
 <config_use_frazil_ice_formation>.true.</config_use_frazil_ice_formation>
 <config_frazil_in_open_ocean>.true.</config_frazil_in_open_ocean>
@@ -390,6 +380,16 @@
 <config_explicit_bottom_drag_coeff>1.0e-3</config_explicit_bottom_drag_coeff>
 <config_use_topographic_wave_drag>.false.</config_use_topographic_wave_drag>
 <config_topographic_wave_drag_coeff>5.0e-4</config_topographic_wave_drag_coeff>
+
+<!-- Rayleigh_damping -->
+<config_Rayleigh_damping_coeff>0.0</config_Rayleigh_damping_coeff>
+<config_Rayleigh_damping_depth_variable>.false.</config_Rayleigh_damping_depth_variable>
+<config_Rayleigh_bottom_friction>.false.</config_Rayleigh_bottom_friction>
+<config_Rayleigh_bottom_damping_coeff>1.0e-4</config_Rayleigh_bottom_damping_coeff>
+
+<!-- vegetation_drag -->
+<config_use_vegetation_drag>.false.</config_use_vegetation_drag>
+<config_vegetation_drag_coefficient>1.09</config_vegetation_drag_coefficient>
 
 <!-- ocean_constants -->
 <config_density0>1026.0</config_density0>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1766,11 +1766,11 @@ Default: Defined in namelist_defaults.xml
 	category="bottom_drag" group="bottom_drag">
 Type of implicit bottom drag used.
 
-Valid values: 'constant','rayleigh','loglaw','spatially-variable','mannings'
+Valid values: 'constant','constant_and_rayleigh','loglaw','spatially-variable','mannings'
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_implicit_bottom_drag_coeff" type="real"
+<entry id="config_implicit_constant_bottom_drag_coeff" type="real"
 	category="bottom_drag" group="bottom_drag">
 Dimensionless bottom drag coefficient, $c_{drag}$.
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -705,41 +705,6 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 
-<!-- Rayleigh_damping -->
-
-<entry id="config_Rayleigh_damping_coeff" type="real"
-	category="Rayleigh_damping" group="Rayleigh_damping">
-Inverse-time coefficient for the Rayleigh damping term, $c_R$, applied at every depth level.
-
-Valid values: Any positive real value.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_Rayleigh_damping_depth_variable" type="logical"
-	category="Rayleigh_damping" group="Rayleigh_damping">
-If true applies r h^-1 instead of just r.
-
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_Rayleigh_bottom_friction" type="logical"
-	category="Rayleigh_damping" group="Rayleigh_damping">
-If true, Rayleigh friction is only applied to the bottom
-
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_Rayleigh_bottom_damping_coeff" type="real"
-	category="Rayleigh_damping" group="Rayleigh_damping">
-Inverse-time coefficient for the Rayleigh damping term, $c_R$, only applied at the bottom.
-
-Valid values: Any positive real value.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-
 <!-- cvmix -->
 
 <entry id="config_use_cvmix" type="logical"
@@ -1444,25 +1409,6 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 
-<!-- vegetation_drag -->
-
-<entry id="config_use_vegetation_drag" type="logical"
-	category="vegetation_drag" group="vegetation_drag">
-Controls if vegetation_drag is used to compute Manning's roughness coefficient.
-
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_vegetation_drag_coefficient" type="real"
-	category="vegetation_drag" group="vegetation_drag">
-Vegetation drag coefficient
-
-Valid values: O(1)
-Default: Defined in namelist_defaults.xml
-</entry>
-
-
 <!-- frazil_ice -->
 
 <entry id="config_use_frazil_ice_formation" type="logical"
@@ -1738,6 +1684,30 @@ Default: Defined in namelist_defaults.xml
 
 <!-- bottom_drag -->
 
+<entry id="config_bottom_drag_mode" type="char*1024"
+	category="bottom_drag" group="bottom_drag">
+Formulation of the bottom drag.
+
+Valid values: 'implicit','explicit'
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_implicit_bottom_drag_type" type="char*1024"
+	category="bottom_drag" group="bottom_drag">
+Type of implicit bottom drag used.
+
+Valid values: 'constant','constant_and_rayleigh','loglaw','spatially-variable','mannings'
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_implicit_constant_bottom_drag_coeff" type="real"
+	category="bottom_drag" group="bottom_drag">
+Dimensionless bottom drag coefficient, $c_{drag}$.
+
+Valid values: any positive real, typically 1.0e-3
+Default: Defined in namelist_defaults.xml
+</entry>
+
 <entry id="config_use_implicit_top_drag" type="logical"
 	category="bottom_drag" group="bottom_drag">
 If true, implicit top drag is used on the momentum equation.
@@ -1754,33 +1724,9 @@ Valid values: any positive real, typically 1.0e-3
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_bottom_drag_mode" type="character"
-	category="bottom_drag" group="bottom_drag">
-Formulation of the bottom drag.
-
-Valid values: 'implicit','explicit'
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_implicit_bottom_drag_type" type="character"
-	category="bottom_drag" group="bottom_drag">
-Type of implicit bottom drag used.
-
-Valid values: 'constant','constant_and_rayleigh','loglaw','spatially-variable','mannings'
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_implicit_constant_bottom_drag_coeff" type="real"
-	category="bottom_drag" group="bottom_drag">
-Dimensionless bottom drag coefficient, $c_{drag}$.
-
-Valid values: any positive real, typically 1.0e-3
-Default: Defined in namelist_defaults.xml
-</entry>
-
 <entry id="config_explicit_bottom_drag_coeff" type="real"
 	category="bottom_drag" group="bottom_drag">
-Dimensionless bottom drag coefficient, $c_{drag}$.
+Dimensionless explicit bottom drag coefficient, $c_{drag}$.
 
 Valid values: any positive real, typically 1.0e-3
 Default: Defined in namelist_defaults.xml
@@ -1799,6 +1745,60 @@ Default: Defined in namelist_defaults.xml
 Dimensionless topographic wave drag coefficient, $c_{topo}$.
 
 Valid values: any positive real, typically 5.0e-4
+Default: Defined in namelist_defaults.xml
+</entry>
+
+
+<!-- Rayleigh_damping -->
+
+<entry id="config_Rayleigh_damping_coeff" type="real"
+	category="Rayleigh_damping" group="Rayleigh_damping">
+Inverse-time coefficient for the Rayleigh damping term, $c_R$, applied at every depth level.
+
+Valid values: Any positive real value.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_Rayleigh_damping_depth_variable" type="logical"
+	category="Rayleigh_damping" group="Rayleigh_damping">
+If true applies r h^-1 instead of just r.
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_Rayleigh_bottom_friction" type="logical"
+	category="Rayleigh_damping" group="Rayleigh_damping">
+If true, Rayleigh friction is only applied to the bottom
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_Rayleigh_bottom_damping_coeff" type="real"
+	category="Rayleigh_damping" group="Rayleigh_damping">
+Inverse-time coefficient for the Rayleigh damping term, $c_R$, only applied at the bottom.
+
+Valid values: Any positive real value.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+
+<!-- vegetation_drag -->
+
+<entry id="config_use_vegetation_drag" type="logical"
+	category="vegetation_drag" group="vegetation_drag">
+Controls if vegetation_drag is used to compute Manning's roughness coefficient.
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_vegetation_drag_coefficient" type="real"
+	category="vegetation_drag" group="vegetation_drag">
+Vegetation drag coefficient
+
+Valid values: O(1)
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1444,6 +1444,25 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 
+<!-- vegetation_drag -->
+
+<entry id="config_use_vegetation_drag" type="logical"
+	category="vegetation_drag" group="vegetation_drag">
+Controls if vegetation_drag is used to compute Manning's roughness coefficient.
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_vegetation_drag_coefficient" type="real"
+	category="vegetation_drag" group="vegetation_drag">
+Vegetation drag coefficient
+
+Valid values: O(1)
+Default: Defined in namelist_defaults.xml
+</entry>
+
+
 <!-- frazil_ice -->
 
 <entry id="config_use_frazil_ice_formation" type="logical"

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -707,14 +707,6 @@ Default: Defined in namelist_defaults.xml
 
 <!-- Rayleigh_damping -->
 
-<entry id="config_Rayleigh_friction" type="logical"
-	category="Rayleigh_damping" group="Rayleigh_damping">
-If true, Rayleigh friction is included in the momentum equation at every depth level.
-
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
 <entry id="config_Rayleigh_damping_coeff" type="real"
 	category="Rayleigh_damping" group="Rayleigh_damping">
 Inverse-time coefficient for the Rayleigh damping term, $c_R$, applied at every depth level.
@@ -1727,22 +1719,6 @@ Default: Defined in namelist_defaults.xml
 
 <!-- bottom_drag -->
 
-<entry id="config_use_implicit_bottom_drag" type="logical"
-	category="bottom_drag" group="bottom_drag">
-If true, implicit bottom drag is used on the momentum equation.
-
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_implicit_bottom_drag_coeff" type="real"
-	category="bottom_drag" group="bottom_drag">
-Dimensionless bottom drag coefficient, $c_{drag}$.
-
-Valid values: any positive real, typically 1.0e-3
-Default: Defined in namelist_defaults.xml
-</entry>
-
 <entry id="config_use_implicit_top_drag" type="logical"
 	category="bottom_drag" group="bottom_drag">
 If true, implicit top drag is used on the momentum equation.
@@ -1759,35 +1735,27 @@ Valid values: any positive real, typically 1.0e-3
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_use_implicit_bottom_roughness" type="logical"
+<entry id="config_bottom_drag_mode" type="character"
 	category="bottom_drag" group="bottom_drag">
-If true, depends on bottom roughness z0
+Formulation of the bottom drag.
 
-Valid values: .true. or .false.
+Valid values: 'implicit','explicit'
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_use_implicit_bottom_drag_variable" type="logical"
+<entry id="config_implicit_bottom_drag_type" type="character"
 	category="bottom_drag" group="bottom_drag">
-If true, spatially-variable implicit bottom drag is used on the momentum equation.
+Type of implicit bottom drag used.
 
-Valid values: .true. or .false.
+Valid values: 'constant','rayleigh','loglaw','spatially-variable','mannings'
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_use_implicit_bottom_drag_variable_mannings" type="logical"
+<entry id="config_implicit_bottom_drag_coeff" type="real"
 	category="bottom_drag" group="bottom_drag">
-If true, uses Mannings' n values for the computation of Cd=g*n^2*h^{-1/3}.
+Dimensionless bottom drag coefficient, $c_{drag}$.
 
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_use_explicit_bottom_drag" type="logical"
-	category="bottom_drag" group="bottom_drag">
-If true, explicit bottom drag is used on the momentum equation.
-
-Valid values: .true. or .false.
+Valid values: any positive real, typically 1.0e-3
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -453,24 +453,6 @@
 					possible_values=".true. or .false."
 		/>
 	</nml_record>
-	<nml_record name="Rayleigh_damping" mode="forward">
-		<nml_option name="config_Rayleigh_damping_coeff" type="real" default_value="1.0e-4" units="s^-1"
-					description="Inverse-time coefficient for the Rayleigh damping term, $c_R$, applied at every depth level."
-					possible_values="Any positive real value."
-		/>
-		<nml_option name="config_Rayleigh_damping_depth_variable" type="logical" default_value=".false."
-					description="If true applies r h^-1 instead of just r."
-					possible_values=".true. or .false."
-		/>
-		<nml_option name="config_Rayleigh_bottom_friction" type="logical" default_value=".false."
-					description="If true, Rayleigh friction is only applied to the bottom"
-					possible_values=".true. or .false."
-		/>
-		<nml_option name="config_Rayleigh_bottom_damping_coeff" type="real" default_value="1.0e-4" units="s^-1"
-					description="Inverse-time coefficient for the Rayleigh damping term, $c_R$, only applied at the bottom."
-					possible_values="Any positive real value."
-		/>
-	</nml_record>
 	<nml_record name="cvmix" mode="forward">
 		<nml_option name="config_use_cvmix" type="logical" default_value=".true."
 					description="If true, use the Community Vertical MIXing routines to compute vertical diffusivity and viscosity"
@@ -923,16 +905,6 @@
 					possible_values="0.0 to turn off, 0.09 is typical value to use for scalar approximation"
 		/>
 	</nml_record>
-	<nml_record name="vegetation_drag" mode="init;forward">
-		<nml_option name="config_use_vegetation_drag" type="logical" default_value=".false."
-					description="Controls if vegetation_drag is used to compute Manning's roughness coefficient."
-					possible_values=".true. or .false."
-		/>
-		<nml_option name="config_vegetation_drag_coefficient" type="real" default_value="1.09"
-					description="Vegetation drag coefficient"
-					possible_values="O(1)"
-		/>
-	</nml_record>
 	<nml_record name="frazil_ice" mode="forward">
 		<nml_option name="config_use_frazil_ice_formation" type="logical" default_value=".false."
 					description="Controls if fluxes related to frazil ice process are computed."
@@ -1079,9 +1051,9 @@
 		/>
 		<nml_option name="config_implicit_bottom_drag_type" type="character" default_value="constant"
 					description="Type of implicit bottom drag used."
-					possible_values="'constant','rayleigh','loglaw','spatially-variable','mannings'"
+					possible_values="'constant','constant_and_rayleigh','loglaw','spatially-variable','mannings'"
 		/>
-		<nml_option name="config_implicit_bottom_drag_coeff" type="real" default_value="1.0e-3"
+		<nml_option name="config_implicit_constant_bottom_drag_coeff" type="real" default_value="1.0e-3"
 					description="Dimensionless bottom drag coefficient, $c_{drag}$."
 					possible_values="any positive real, typically 1.0e-3"
 		/>
@@ -1105,8 +1077,36 @@
 					description="Dimensionless topographic wave drag coefficient, $c_{topo}$."
 					possible_values="any positive real, typically 5.0e-4"
 		/>
-
 	</nml_record>
+	<nml_record name="Rayleigh_damping" mode="forward">
+		<nml_option name="config_Rayleigh_damping_coeff" type="real" default_value="1.0e-4" units="s^-1"
+					description="Inverse-time coefficient for the Rayleigh damping term, $c_R$, applied at every depth level."
+					possible_values="Any positive real value."
+		/>
+		<nml_option name="config_Rayleigh_damping_depth_variable" type="logical" default_value=".false."
+					description="If true applies r h^-1 instead of just r."
+					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_Rayleigh_bottom_friction" type="logical" default_value=".false."
+					description="If true, Rayleigh friction is only applied to the bottom"
+					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_Rayleigh_bottom_damping_coeff" type="real" default_value="1.0e-4" units="s^-1"
+					description="Inverse-time coefficient for the Rayleigh damping term, $c_R$, only applied at the bottom."
+					possible_values="Any positive real value."
+		/>
+	</nml_record>
+	<nml_record name="vegetation_drag" mode="init;forward">
+		<nml_option name="config_use_vegetation_drag" type="logical" default_value=".false."
+					description="Controls if vegetation_drag is used to compute Manning's roughness coefficient."
+					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_vegetation_drag_coefficient" type="real" default_value="1.09"
+					description="Vegetation drag coefficient"
+					possible_values="O(1)"
+		/>
+	</nml_record>
+
 	<nml_record name="wetting_drying" mode="init;forward">
 		<nml_option name="config_use_wetting_drying" type="logical" default_value=".false."
 					description="If true, use wetting and drying algorithm to allow for dry cells to config_min_cell_height."

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -454,10 +454,6 @@
 		/>
 	</nml_record>
 	<nml_record name="Rayleigh_damping" mode="forward">
-		<nml_option name="config_Rayleigh_friction" type="logical" default_value=".false."
-					description="If true, Rayleigh friction is included in the momentum equation at every depth level."
-					possible_values=".true. or .false."
-		/>
 		<nml_option name="config_Rayleigh_damping_coeff" type="real" default_value="1.0e-4" units="s^-1"
 					description="Inverse-time coefficient for the Rayleigh damping term, $c_R$, applied at every depth level."
 					possible_values="Any positive real value."
@@ -1081,9 +1077,13 @@
 		/>
 	</nml_record>
 	<nml_record name="bottom_drag" mode="forward">
-		<nml_option name="config_use_implicit_bottom_drag" type="logical" default_value=".true."
-					description="If true, implicit bottom drag is used on the momentum equation."
-					possible_values=".true. or .false."
+		<nml_option name="config_bottom_drag_mode" type="character" default_value="implicit"
+					description="Formulation of the bottom drag."
+					possible_values="'implicit','explicit'"
+		/>
+		<nml_option name="config_implicit_bottom_drag_type" type="character" default_value="constant"
+					description="Type of implicit bottom drag used."
+					possible_values="'constant','rayleigh','loglaw','spatially-variable','mannings'"
 		/>
 		<nml_option name="config_implicit_bottom_drag_coeff" type="real" default_value="1.0e-3"
 					description="Dimensionless bottom drag coefficient, $c_{drag}$."
@@ -1097,24 +1097,8 @@
 					description="Dimensionless top drag coefficient, $c_{drag}$."
 					possible_values="any positive real, typically 1.0e-3"
 		/>
-		<nml_option name="config_use_implicit_bottom_roughness" type="logical" default_value=".false."
-					description="If true, depends on bottom roughness z0"
-					possible_values=".true. or .false."
-		/>
-		<nml_option name="config_use_implicit_bottom_drag_variable" type="logical" default_value=".false."
-					description="If true, spatially-variable implicit bottom drag is used on the momentum equation."
-					possible_values=".true. or .false."
-		/>
-		<nml_option name="config_use_implicit_bottom_drag_variable_mannings" type="logical" default_value=".false."
-					description="If true, uses Mannings' n values for the computation of Cd=g*n^2*h^{-1/3}."
-					possible_values=".true. or .false."
-		/>
-		<nml_option name="config_use_explicit_bottom_drag" type="logical" default_value=".false."
-					description="If true, explicit bottom drag is used on the momentum equation."
-					possible_values=".true. or .false."
-		/>
 		<nml_option name="config_explicit_bottom_drag_coeff" type="real" default_value="1.0e-3"
-					description="Dimensionless bottom drag coefficient, $c_{drag}$."
+					description="Dimensionless explicit bottom drag coefficient, $c_{drag}$."
 					possible_values="any positive real, typically 1.0e-3"
 		/>
 		<nml_option name="config_use_topographic_wave_drag" type="logical" default_value=".false."

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -925,11 +925,7 @@
 	</nml_record>
 	<nml_record name="vegetation_drag" mode="init;forward">
 		<nml_option name="config_use_vegetation_drag" type="logical" default_value=".false."
-					description="Controls if vegetation_drag is used."
-					possible_values=".true. or .false."
-		/>
-		<nml_option name="config_use_vegetation_manning_equation" type="logical" default_value=".false."
-					description="Compute vegetation drag force using vegetation-induced Manning roughness coefficient."
+					description="Controls if vegetation_drag is used to compute Manning's roughness coefficient."
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_vegetation_drag_coefficient" type="real" default_value="1.09"

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_explicit_bottom_drag.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_explicit_bottom_drag.F
@@ -192,7 +192,7 @@ contains
 
       !*** Reset values based on input model configuration
 
-      if (config_use_explicit_bottom_drag) then
+      if (trim(config_bottom_drag_mode) == 'explicit') then
          explicitBottomDragOff = .false.
          dragCoeff = config_explicit_bottom_drag_coeff
       endif

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -1470,7 +1470,6 @@ contains
       tracerVmixOn = .true.
 
       if (trim(config_bottom_drag_mode) == 'implicit') then
-        implicitBottomDragCoef = config_implicit_bottom_drag_coeff
 
         select case (trim(config_implicit_bottom_drag_type))
 
@@ -1480,10 +1479,12 @@ contains
           endif
           dragType = dragTypeConst
           call mpas_log_write(' Implicit bottom drag type is: constant')
+          implicitBottomDragCoef = config_implicit_constant_bottom_drag_coeff
 
-        case ('rayleigh')
+        case ('constant_and_rayleigh')
           dragType = dragTypeRayleigh
           call mpas_log_write(' Implicit bottom drag type is: Rayleigh')
+          implicitBottomDragCoef = config_implicit_constant_bottom_drag_coeff
           rayleighDampingCoef = config_Rayleigh_damping_coeff
           if (config_Rayleigh_bottom_friction) then
               rayleighBottomDampingCoef = config_Rayleigh_bottom_damping_coeff

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -1499,7 +1499,10 @@ contains
         case ('spatially-variable')
           dragType = dragTypeVariable
           call mpas_log_write(' Implicit bottom drag type is: spatially-variable')
-
+          if (.not. config_use_variable_drag) &
+            call mpas_log_write('bottomDrag may not be available for spatially-variable '// &
+              'implicit bottom drag because config_use_variable_drag is False', &
+              MPAS_LOG_WARN)
         case ('mannings')
           dragType = dragTypeMannings
           call mpas_log_write(' Implicit bottom drag type is: Mannings')

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -66,6 +66,19 @@ module ocn_vmix
 
    logical :: velVmixOn, tracerVmixOn
    real (kind=RKIND) :: implicitBottomDragCoef, implicitTopDragCoef
+
+   integer :: &
+      dragType   ! id for pressure gradient method selected
+
+   integer, parameter ::       &! ids for supported methods
+      dragTypeNone        = 0, &! None selected
+      dragTypeConst       = 0, &! Spatially constant
+      dragTypeRayleigh    = 1, &! Rayleigh
+      dragTypeLogLaw      = 2, &! log law-of-the-wall
+      dragTypeVariable    = 3, &! Spatially variable
+      dragTypeMannings    = 4   ! Manning's coefficient
+
+   real (kind=RKIND) :: implicitBottomDragCoef
    real (kind=RKIND) :: rayleighDampingCoef, rayleighBottomDampingCoef, &
                         rayleighDepthVariable
 
@@ -851,7 +864,7 @@ contains
          cell2 = cellsOnEdge(2,iEdge)
 
          ! average cell-based implicit bottom drag to edges and convert Mannings n to Cd
-         if (config_use_implicit_bottom_roughness) then
+         if (dragType == dragTypeLogLaw) then
            ! NCOM's formula for bottom drag coefficient
            ! The original formula is cb(i,j) = max(cbmin, (vonk/log(0.5*depth(i,j)/z0))**2 ))
            ! where vonk=0.16, z0=0.001, bracketed between [0.0025, 0.1]
@@ -860,7 +873,7 @@ contains
            implicitCd = max(0.0025_RKIND, &
                         min(0.1_RKIND, &
                           0.16_RKIND/(log(250.0_RKIND*(bottomDepth(cell1)+bottomDepth(cell2))))**2 ))
-         elseif (config_use_vegetation_drag .AND. config_use_vegetation_manning_equation) then
+         elseif (dragType == dragTypeMannings .AND. config_use_vegetation_drag .AND. config_use_vegetation_manning_equation) then
            implicitCd = gravity*(0.5_RKIND*(vegetationManning(cell1) + vegetationManning(cell2)))**2 * &
             (0.5_RKIND * (ssh(cell1) + ssh(cell2) + bottomDepth(cell1) + bottomDepth(cell2)))**(-1.0_RKIND/3.0_RKIND)
          else
@@ -1263,26 +1276,39 @@ contains
 #ifdef MPAS_OPENACC
       !$acc enter data copyin(layerThickness, normalVelocity)
 #endif
-      if (config_use_implicit_bottom_drag_variable) then
-        call ocn_vel_vmix_tend_implicit_spatially_variable(bottomDrag, dt, kineticEnergyCell, &
+      select case (dragType)
+
+      case (dragTypeConst)
+
+        call ocn_vel_vmix_tend_implicit(dt, kineticEnergyCell, &
+          vertViscTopOfEdge, layerThickness, layerThickEdgeMean, &
+          landIceEdgeFraction, normalVelocity, err)
+
+      case (dragTypeRayleigh)
+
+        call ocn_vel_vmix_tend_implicit_rayleigh(dt, kineticEnergyCell, &
           vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, err)
-      else if (config_use_implicit_bottom_drag_variable_mannings.or. &
-               config_use_implicit_bottom_roughness) then
-        ! update bottomDrag via Cd=g*n^2*h^(-1/3)
+
+      case (dragTypeLogLaw)
+
         call ocn_vel_vmix_tend_implicit_spatially_variable_mannings(forcingPool, bottomDrag, &
           dt, kineticEnergyCell, &
           vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, &
           ssh, err)
-      else if (config_Rayleigh_friction.or. &
-               config_Rayleigh_bottom_friction.or. &
-               config_Rayleigh_damping_depth_variable) then
-        call ocn_vel_vmix_tend_implicit_rayleigh(dt, kineticEnergyCell, &
+
+      case (dragTypeVariable)
+
+        call ocn_vel_vmix_tend_implicit_spatially_variable(bottomDrag, dt, kineticEnergyCell, &
           vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, err)
-      else
-        call ocn_vel_vmix_tend_implicit(dt, kineticEnergyCell, &
-          vertViscTopOfEdge, layerThickness, layerThickEdgeMean, &
-          landIceEdgeFraction, normalVelocity, err)
-      end if
+
+      case (dragTypeMannings)
+
+        call ocn_vel_vmix_tend_implicit_spatially_variable_mannings(forcingPool, bottomDrag, &
+          dt, kineticEnergyCell, &
+          vertViscTopOfEdge, layerThickness, layerThickEdgeMean, normalVelocity, &
+          ssh, err)
+
+      end select
 #ifdef MPAS_OPENACC
       !$acc exit data copyout(normalVelocity)
 #endif
@@ -1420,28 +1446,7 @@ contains
 
       err = 0
 
-      rayleighDampingCoef = 0.0_RKIND
-
-      if (config_Rayleigh_friction) then
-          rayleighDampingCoef = config_Rayleigh_damping_coeff
-      endif
-
-      rayleighBottomDampingCoef = 0.0_RKIND
-
-      if (config_Rayleigh_bottom_friction) then
-          rayleighBottomDampingCoef = config_Rayleigh_bottom_damping_coeff
-      endif
-
-      rayleighDepthVariable = 0.0_RKIND
-      if (config_Rayleigh_damping_depth_variable) then
-        rayleighDepthVariable = 1.0_RKIND
-      end if
-
-      velVmixOn = .true.
-      tracerVmixOn = .true.
-
-      if(config_disable_vel_vmix.or.config_disable_vel_all_tend) velVmixOn = .false.
-      if(config_disable_tr_vmix.or.config_disable_tr_all_tend) tracerVmixOn = .false.
+      dragType = dragTypeNone
 
       implicitBottomDragCoef = 0.0_RKIND
       implicitTopDragCoef = 0.0_RKIND
@@ -1451,13 +1456,73 @@ contains
          call mpas_log_write('Implicit top drag can only be used with ' //&
               & 'implicit bottom drag', MPAS_LOG_CRIT)
       endif
+      if (config_use_implicit_top_drag .and. &
+          .not. trim(config_implicit_bottom_drag_type)=='constant') then
+         call mpas_log_write('Implicit top drag can only be used with ' //&
+              & 'constant implicit bottom drag type', MPAS_LOG_CRIT)
+      endif
 
-      if (config_use_implicit_bottom_drag) then
-          implicitBottomDragCoef = config_implicit_bottom_drag_coeff
+      rayleighDampingCoef = 0.0_RKIND
+      rayleighBottomDampingCoef = 0.0_RKIND
+      rayleighDepthVariable = 0.0_RKIND
+
+      velVmixOn = .true.
+      tracerVmixOn = .true.
+
+      if (trim(config_bottom_drag_mode) == 'implicit') then
+        implicitBottomDragCoef = config_implicit_bottom_drag_coeff
+
+        select case (trim(config_implicit_bottom_drag_type))
+
+        case ('constant')
+          if (config_use_implicit_top_drag) then
+            implicitTopDragCoef = config_implicit_top_drag_coeff
+          endif
+          dragType = dragTypeConst
+          call mpas_log_write(' Implicit bottom drag type is: constant')
+
+        case ('rayleigh')
+          dragType = dragTypeRayleigh
+          call mpas_log_write(' Implicit bottom drag type is: Rayleigh')
+          rayleighDampingCoef = config_Rayleigh_damping_coeff
+          if (config_Rayleigh_bottom_friction) then
+              rayleighBottomDampingCoef = config_Rayleigh_bottom_damping_coeff
+          endif
+          if (config_Rayleigh_damping_depth_variable) then
+            rayleighDepthVariable = 1.0_RKIND
+          end if
+
+        case ('loglaw')
+          dragType = dragTypeLogLaw
+          call mpas_log_write(' Implicit bottom drag type is: log law-of-the-wall')
+
+        case ('spatially-variable')
+          dragType = dragTypeVariable
+          call mpas_log_write(' Implicit bottom drag type is: spatially-variable')
+
+        case ('mannings')
+          dragType = dragTypeMannings
+          call mpas_log_write(' Implicit bottom drag type is: Mannings')
+
+        case default
+          call mpas_log_write( &
+             ' Incorrect choice of config_implicit_bottom_drag_type.', &
+             MPAS_LOG_CRIT)
+          err = 1
+
+        end select
+      elseif (trim(config_bottom_drag_mode) == 'explicit') then
+        ! We still call the implicit vertical mixing routine but the drag coefficient is 0
+        dragType = dragTypeConst
+      else
+        call mpas_log_write( &
+           ' Incorrect choice of config_bottom_drag_mode.', &
+           MPAS_LOG_CRIT)
+        err = 1
       endif
-      if (config_use_implicit_top_drag) then
-          implicitTopDragCoef = config_implicit_top_drag_coeff
-      endif
+
+      if(config_disable_vel_vmix.or.config_disable_vel_all_tend) velVmixOn = .false.
+      if(config_disable_tr_vmix.or.config_disable_tr_all_tend) tracerVmixOn = .false.
 
       call ocn_vmix_cvmix_init(domain,err_tmp)
       err = ior(err, err_tmp)

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -78,7 +78,6 @@ module ocn_vmix
       dragTypeVariable    = 3, &! Spatially variable
       dragTypeMannings    = 4   ! Manning's coefficient
 
-   real (kind=RKIND) :: implicitBottomDragCoef
    real (kind=RKIND) :: rayleighDampingCoef, rayleighBottomDampingCoef, &
                         rayleighDepthVariable
 
@@ -1452,7 +1451,7 @@ contains
       implicitTopDragCoef = 0.0_RKIND
 
       if (config_use_implicit_top_drag .and. &
-          .not. config_use_implicit_bottom_drag) then
+          .not. trim(config_bottom_drag_mode) == 'implicit') then
          call mpas_log_write('Implicit top drag can only be used with ' //&
               & 'implicit bottom drag', MPAS_LOG_CRIT)
       endif

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -815,7 +815,7 @@ contains
 #endif
 
       ! Compute bottomDrag (Manning roughness) induced by vegetation
-      if (config_use_vegetation_drag .AND. config_use_vegetation_manning_equation) then
+      if (dragType == dragTypeMannings .AND. config_use_vegetation_drag) then
         do iCell = 1, nCellsOwned
           if (vegetationDensity(iCell) * vegetationHeight(iCell) * vegetationDiameter(iCell) .eq. 0.0_RKIND) then
             vegetationMask(iCell) = 0
@@ -873,7 +873,7 @@ contains
            implicitCd = max(0.0025_RKIND, &
                         min(0.1_RKIND, &
                           0.16_RKIND/(log(250.0_RKIND*(bottomDepth(cell1)+bottomDepth(cell2))))**2 ))
-         elseif (dragType == dragTypeMannings .AND. config_use_vegetation_drag .AND. config_use_vegetation_manning_equation) then
+         elseif (dragType == dragTypeMannings .AND. config_use_vegetation_drag) then
            implicitCd = gravity*(0.5_RKIND*(vegetationManning(cell1) + vegetationManning(cell2)))**2 * &
             (0.5_RKIND * (ssh(cell1) + ssh(cell2) + bottomDepth(cell1) + bottomDepth(cell2)))**(-1.0_RKIND/3.0_RKIND)
          else


### PR DESCRIPTION
The main changes in this PR are with respect to the following config options to reduce confusion and configuration user errors:

* `config_bottom_drag_mode = 'implicit' or 'explicit'` replaces the boolean options `config_use_implicit_bottom_drag` and `config_use_explicit_bottom_drag`. The effect of this is that now implicit and explicit drag cannot be used simultaneously.
* the string option `config_implicit_bottom_drag_type` replaces a bunch of boolean config options. Formerly, only one implicit drag option could be used at a time, but multiple implicit drag config options could be set to `.true.` with little transparency about which implicit drag option took precedence.

A minor change is worth noting:

* `config_use_vegetation_manning_equation` is removed. Formerly, there were no situations where `config_use_vegetation_drag` and `config_use_vegetation_manning_equation` had different consequences, so now only `config_use_vegetation_drag` is used. 

[NML]
[BFB]