### PR TITLE
Update alias names for MPAS-SI testing D-compsets

### DIFF
--- a/components/mpas-seaice/cime_config/config_compsets.xml
+++ b/components/mpas-seaice/cime_config/config_compsets.xml
@@ -10,7 +10,7 @@
   <!-- E3SM D compsets -->
 
   <compset>
-    <alias>DTEST-JRA1p5</alias>
+    <alias>DTESTM-JRA1p5</alias>
     <lname>2000_DATM%JRA-1p5_SLND_MPASSI_DOCN%SOM_DROF%JRA-1p5_SGLC_SWAV_TEST</lname>
   </compset>
 

--- a/components/ww3/cime_config/config_compsets.xml
+++ b/components/ww3/cime_config/config_compsets.xml
@@ -25,7 +25,7 @@
   </compset>
 
   <compset>
-    <alias>DTEST-JRA1p5-WW3</alias>
+    <alias>DTESTM-JRA1p5-WW3</alias>
     <lname>2000_DATM%JRA-1p5_SLND_MPASSI_DOCN%SOM_DROF%JRA-1p5_SGLC_WW3%sp36x36_TEST</lname>
   </compset>
 


### PR DESCRIPTION
update D compset alias names. These compsets are for MPAS-SI testing purposes only.
Modification to D-JRA compset aliases - should be 'DTEST**M**' in alias (to differentiate from D compsets that use CICE) 
[BFB]
