### PR TITLE
remove unused variables in ocean

### DIFF
--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -3756,10 +3756,6 @@
 			description="Equilibrium tidal potential"
 			packages="forwardMode"
 		/>
-		<var name="nTidalPotentialConstituents" type="integer" dimensions="Time"
-			description="Number of tidal constituents"
-			packages="tidalPotentialForcingPKG"
-		/>
 		<var name="tidalPotentialConstituentFrequency" type="real" dimensions="maxTidalConstituents Time" units="s^-1"
 			description="Frequency of tidal constituents"
 			packages="tidalPotentialForcingPKG"
@@ -3790,10 +3786,6 @@
 		/>
 		<var name="tidalPotentialLatitudeFunction" type="real" dimensions="nCells R3 Time" units="1"
 			description="Latitude function for tidal constituents: long-period = 3\sin^2(\phi)-1, diurnal = \sin(2\phi), semi-diurnal = \cos^2(\phi)"
-			packages="tidalPotentialForcingPKG"
-		/>
-		<var name="tidalPotentialZMid" type="real" dimensions="nVertLevels nCells Time" units="m"
-			description="zMid - Equilibrium tidal potential in RK4"
 			packages="tidalPotentialForcingPKG"
 		/>
 		<var name="sshSubcycleCurWithTides" type="real" dimensions="nCells Time" units="m"

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_tidal_potential.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_tidal_potential.F
@@ -313,7 +313,6 @@ contains
       type (mpas_pool_type), pointer :: forcingPool
       type (mpas_pool_type), pointer :: meshPool
       integer, pointer :: nCells
-      integer, pointer :: nTidalPotentialConstituents
       real (kind=RKIND), dimension(:), pointer :: latCell
 
       ! End preamble
@@ -358,9 +357,6 @@ contains
          call mpas_pool_get_array(forcingPool, 'tidalPotentialEta', &
                                                 tidalPotEta)
 
-         call mpas_pool_get_array(forcingPool, &
-                            'nTidalPotentialConstituents', &
-                             nTidalPotentialConstituents)
          call mpas_pool_get_array(forcingPool, &
                             'tidalPotentialConstituentAmplitude', & 
                              tidalConstituentAmplitude)
@@ -433,9 +429,6 @@ contains
             nTidalConstituents = nTidalConstituents + 1
             constituentList(nTidalConstituents)%constituent = 'P1'
          end if 
-
-         ! set point value in forcing pool just in case
-         nTidalPotentialConstituents = nTidalConstituents
 
          call tidal_constituent_factors(constituentList, &
                                        nTidalConstituents, refTime, &


### PR DESCRIPTION
The variables `tidalPotentialZMid` and `nTidalPotentialConstituents` are defined in the Registry but not used for any computations. This tricks the gnu compiler in optimized mode, which removes them internally. The simulation then dies when the i/o references these variables on initialization. See earlier description at https://github.com/MPAS-Dev/compass/issues/497.

With this fix, the standalone MPAS-Ocean tests pass
```
ocean_global_ocean_EC30to60_PHC_performance_test
ocean_global_ocean_ECwISC30to60_PHC_performance_test
```

fixes #5609
[BFB]