### PR TITLE
Update partitions for 4 MPAS-Seaice meshes

### DIFF
--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -206,8 +206,8 @@ def buildnml(case, caseroot, compname):
             grid_prefix = 'mpassi.ARRM10to60E2r1.rstFrom1monthG-chrys'
 
     elif ice_grid == 'EC30to60E2r2':
-        decomp_date = '200908'
-        decomp_prefix = 'mpas-seaice.graph.info.'
+        decomp_date = '230313'
+        decomp_prefix = 'partitions/mpas-seaice.graph.info.'
         grid_date = '210210'
         grid_prefix = 'seaice.EC30to60E2r2'
         if ice_ic_mode == 'spunup':
@@ -215,8 +215,8 @@ def buildnml(case, caseroot, compname):
             grid_prefix = 'mpassi.EC30to60E2r2.rstFromG-anvil'
 
     elif ice_grid == 'WC14to60E2r3':
-        decomp_date = '200714'
-        decomp_prefix = 'mpas-seaice.graph.info.'
+        decomp_date = '230313'
+        decomp_prefix = 'partitions/mpas-seaice.graph.info.'
         grid_date = '210210'
         grid_prefix = 'seaice.WC14to60E2r3'
         if ice_ic_mode == 'spunup':
@@ -233,8 +233,8 @@ def buildnml(case, caseroot, compname):
             grid_prefix = 'mpassi.WCAtl12to45E2r4.rstFromG-anvil'
 
     elif ice_grid == 'SOwISC12to60E2r4':
-        decomp_date = '210107'
-        decomp_prefix = 'mpas-seaice.graph.info.'
+        decomp_date = '230314'
+        decomp_prefix = 'partitions/mpas-seaice.graph.info.'
         grid_date = '210107'
         grid_prefix = 'seaice.SOwISC12to60E2r4'
         data_iceberg_file += 'Iceberg_Interannual_Merino_SOwISC12to60E2r4.nc'
@@ -245,8 +245,8 @@ def buildnml(case, caseroot, compname):
     elif ice_grid == 'ECwISC30to60E2r1':
         grid_date = '210413'
         grid_prefix = 'seaice.ECwISC30to60E2r1'
-        decomp_date = '200916'
-        decomp_prefix = 'mpas-seaice.graph.info.'
+        decomp_date = '230314'
+        decomp_prefix = 'partitions/mpas-seaice.graph.info.'
         data_iceberg_file += 'Iceberg_Interannual_Merino_ECwISC30to60E2r1.nc'
         if ice_ic_mode == 'spunup':
             grid_date = '210414'


### PR DESCRIPTION
This merge points to new partition files for each of the following 4 MPAS-Seaice meshes.  Each mesh has about 400 files that are expected to support nearly any conceivable core count.

Meshes with updated partitions:
* EC30to60E2r2
* ECwISC30to60E2r1
* SOwISC12to60E2r4
* WC14to60E2r3

The partition files are better load-balanced, since each core owns cells in both polar and equatorial regions.  They were created with the tools described in:
http://mpas-dev.github.io/MPAS-Tools/stable/seaice/partition.html

See https://github.com/MPAS-Dev/compass/pull/563 for more details on how the core counts were determined.

[NML]
[non-BFB] only for mpassi globalStats files for these meshes -- does not change the seaice state