### PR TITLE
Update linoz data to linozv3 style for all use cases

### DIFF
--- a/components/eam/bld/namelist_files/use_cases/1850S_E3SMv1_superfast_ar5-emis.xml
+++ b/components/eam/bld/namelist_files/use_cases/1850S_E3SMv1_superfast_ar5-emis.xml
@@ -169,7 +169,7 @@
 <chlorine_loading_fixed_ymd >18500101</chlorine_loading_fixed_ymd>
 <chlorine_loading_type      >FIXED</chlorine_loading_type>
 <linoz_data_cycle_yr        >1850</linoz_data_cycle_yr>
-<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_file            >linv3_1849-2015_2010JPL_cmip6_historical_10deg_58km_c20210625.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 

--- a/components/eam/bld/namelist_files/use_cases/1850_E3SMv1_superfast_ar5-emis.xml
+++ b/components/eam/bld/namelist_files/use_cases/1850_E3SMv1_superfast_ar5-emis.xml
@@ -169,7 +169,7 @@
 <chlorine_loading_fixed_ymd >18500101</chlorine_loading_fixed_ymd>
 <chlorine_loading_type      >FIXED</chlorine_loading_type>
 <linoz_data_cycle_yr        >1850</linoz_data_cycle_yr>
-<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_file            >linv3_1849-2015_2010JPL_cmip6_historical_10deg_58km_c20210625.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 

--- a/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6-1pctCO2.xml
+++ b/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6-1pctCO2.xml
@@ -81,7 +81,7 @@
 <chlorine_loading_fixed_ymd >18500101</chlorine_loading_fixed_ymd>
 <chlorine_loading_type      >FIXED</chlorine_loading_type>
 <linoz_data_cycle_yr        >1850</linoz_data_cycle_yr>
-<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_file            >linv3_1849-2015_2010JPL_cmip6_historical_10deg_58km_c20210625.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 

--- a/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6.xml
+++ b/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6.xml
@@ -77,7 +77,7 @@
 <chlorine_loading_fixed_ymd >18500101</chlorine_loading_fixed_ymd>
 <chlorine_loading_type      >FIXED</chlorine_loading_type>
 <linoz_data_cycle_yr        >1850</linoz_data_cycle_yr>
-<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_file            >linv3_1849-2015_2010JPL_cmip6_historical_10deg_58km_c20210625.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 

--- a/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6_bgc.xml
+++ b/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6_bgc.xml
@@ -77,7 +77,7 @@
 <chlorine_loading_fixed_ymd >18500101</chlorine_loading_fixed_ymd>
 <chlorine_loading_type      >FIXED</chlorine_loading_type>
 <linoz_data_cycle_yr        >1850</linoz_data_cycle_yr>
-<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_file            >linv3_1849-2015_2010JPL_cmip6_historical_10deg_58km_c20210625.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 

--- a/components/eam/bld/namelist_files/use_cases/1950_eam_CMIP6.xml
+++ b/components/eam/bld/namelist_files/use_cases/1950_eam_CMIP6.xml
@@ -71,7 +71,7 @@
 <chlorine_loading_fixed_ymd >19500101</chlorine_loading_fixed_ymd>
 <chlorine_loading_type      >FIXED</chlorine_loading_type>
 <linoz_data_cycle_yr        >1950</linoz_data_cycle_yr>
-<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_file            >linv3_1849-2015_2010JPL_cmip6_historical_10deg_58km_c20210625.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 

--- a/components/eam/bld/namelist_files/use_cases/2010S_cam5_CMIP6.xml
+++ b/components/eam/bld/namelist_files/use_cases/2010S_cam5_CMIP6.xml
@@ -178,7 +178,7 @@
 <chlorine_loading_fixed_ymd >20100101</chlorine_loading_fixed_ymd>
 <chlorine_loading_type      >FIXED</chlorine_loading_type>
 <linoz_data_cycle_yr        >2010</linoz_data_cycle_yr>
-<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_file            >linv3_1849-2015_2010JPL_cmip6_historical_10deg_58km_c20210625.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 

--- a/components/eam/bld/namelist_files/use_cases/2010_eam_CMIP6.xml
+++ b/components/eam/bld/namelist_files/use_cases/2010_eam_CMIP6.xml
@@ -80,7 +80,7 @@
 <chlorine_loading_fixed_ymd >20100101</chlorine_loading_fixed_ymd>
 <chlorine_loading_type      >FIXED</chlorine_loading_type>
 <linoz_data_cycle_yr        >2010</linoz_data_cycle_yr>
-<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_file            >linv3_1849-2015_2010JPL_cmip6_historical_10deg_58km_c20210625.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 

--- a/components/eam/bld/namelist_files/use_cases/2010_mmf_2mom.xml
+++ b/components/eam/bld/namelist_files/use_cases/2010_mmf_2mom.xml
@@ -74,7 +74,7 @@
 <chlorine_loading_fixed_ymd >20100101</chlorine_loading_fixed_ymd>
 <chlorine_loading_type      >FIXED</chlorine_loading_type>
 <linoz_data_cycle_yr        >2010</linoz_data_cycle_yr>
-<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_file            >linv3_1849-2015_2010JPL_cmip6_historical_10deg_58km_c20210625.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 

--- a/components/eam/bld/namelist_files/use_cases/2010_scream_hr.xml
+++ b/components/eam/bld/namelist_files/use_cases/2010_scream_hr.xml
@@ -90,7 +90,7 @@
 <chlorine_loading_fixed_ymd >20100101</chlorine_loading_fixed_ymd>
 <chlorine_loading_type      >FIXED</chlorine_loading_type>
 <linoz_data_cycle_yr        >2010</linoz_data_cycle_yr>
-<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_file            >linv3_1849-2015_2010JPL_cmip6_historical_10deg_58km_c20210625.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 

--- a/components/eam/bld/namelist_files/use_cases/2010_scream_hr_dyamond2.xml
+++ b/components/eam/bld/namelist_files/use_cases/2010_scream_hr_dyamond2.xml
@@ -96,7 +96,7 @@
 <chlorine_loading_fixed_ymd >20100101</chlorine_loading_fixed_ymd>
 <chlorine_loading_type      >FIXED</chlorine_loading_type>
 <linoz_data_cycle_yr        >2010</linoz_data_cycle_yr>
-<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_file            >linv3_1849-2015_2010JPL_cmip6_historical_10deg_58km_c20210625.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 

--- a/components/eam/bld/namelist_files/use_cases/2010_scream_lr.xml
+++ b/components/eam/bld/namelist_files/use_cases/2010_scream_lr.xml
@@ -102,7 +102,7 @@
 <chlorine_loading_fixed_ymd >20100101</chlorine_loading_fixed_ymd>
 <chlorine_loading_type      >FIXED</chlorine_loading_type>
 <linoz_data_cycle_yr        >2010</linoz_data_cycle_yr>
-<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_file            >linv3_1849-2015_2010JPL_cmip6_historical_10deg_58km_c20210625.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 

--- a/components/eam/bld/namelist_files/use_cases/2010_scream_lr_dyamond2.xml
+++ b/components/eam/bld/namelist_files/use_cases/2010_scream_lr_dyamond2.xml
@@ -104,7 +104,7 @@
 <chlorine_loading_fixed_ymd >20100101</chlorine_loading_fixed_ymd>
 <chlorine_loading_type      >FIXED</chlorine_loading_type>
 <linoz_data_cycle_yr        >2010</linoz_data_cycle_yr>
-<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_file            >linv3_1849-2015_2010JPL_cmip6_historical_10deg_58km_c20210625.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 

--- a/components/eam/bld/namelist_files/use_cases/20TRS_E3SMv1_superfast_ar5-emis.xml
+++ b/components/eam/bld/namelist_files/use_cases/20TRS_E3SMv1_superfast_ar5-emis.xml
@@ -161,7 +161,7 @@
 <!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
 <chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_0003-2017_c20171114.nc</chlorine_loading_file>
 <chlorine_loading_type      >SERIAL</chlorine_loading_type>
-<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_file            >linv3_1849-2015_2010JPL_cmip6_historical_10deg_58km_c20210625.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >INTERP_MISSING_MONTHS</linoz_data_type>
 

--- a/components/eam/bld/namelist_files/use_cases/20TR_E3SMv1_superfast_ar5-emis.xml
+++ b/components/eam/bld/namelist_files/use_cases/20TR_E3SMv1_superfast_ar5-emis.xml
@@ -161,7 +161,7 @@
 <!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
 <chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_0003-2017_c20171114.nc</chlorine_loading_file>
 <chlorine_loading_type      >SERIAL</chlorine_loading_type>
-<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_file            >linv3_1849-2015_2010JPL_cmip6_historical_10deg_58km_c20210625.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >INTERP_MISSING_MONTHS</linoz_data_type>
 

--- a/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6.xml
+++ b/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6.xml
@@ -67,7 +67,7 @@
 <!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
 <chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_0003-2017_c20171114.nc</chlorine_loading_file>
 <chlorine_loading_type      >SERIAL</chlorine_loading_type>
-<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_file            >linv3_1849-2015_2010JPL_cmip6_historical_10deg_58km_c20210625.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >INTERP_MISSING_MONTHS</linoz_data_type>
 

--- a/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6_bgc.xml
+++ b/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6_bgc.xml
@@ -67,7 +67,7 @@
 <!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
 <chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_0003-2017_c20171114.nc</chlorine_loading_file>
 <chlorine_loading_type      >SERIAL</chlorine_loading_type>
-<linoz_data_file            >linoz1850-2015_2010JPL_CMIP6_10deg_58km_c20171109.nc</linoz_data_file>
+<linoz_data_file            >linv3_1849-2015_2010JPL_cmip6_historical_10deg_58km_c20210625.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >INTERP_MISSING_MONTHS</linoz_data_type>
 


### PR DESCRIPTION
linoz_data_file for all use cases have to be updated to Linozv3 style
after the merge of UCI-chem to enable Linoz for v2 or v3.

This fixes issue #5613 and should be merged together with #4707.

[NBFB] for all involving full EAM config
[NML]  linoz_data_file changed