### PR TITLE
Add Polar historical/SSP compsets

### DIFF
--- a/cime_config/allactive/config_compsets.xml
+++ b/cime_config/allactive/config_compsets.xml
@@ -303,6 +303,21 @@
 </compset>
 
 <compset>
+  <alias>CRYO20TR</alias>
+  <lname>20TRSOI_EAM%CMIP6_ELM%SPBC_MPASSI%DIB_MPASO%IBISMF_MOSART_SGLC_SWAV</lname>
+</compset>
+
+<compset>
+  <alias>CRYOSSP585</alias>
+  <lname>SSP585SOI_EAM%CMIP6_ELM%SPBC_MPASSI%DIB_MPASO%IBISMF_MOSART_SGLC_SWAV</lname>
+</compset>
+
+<compset>
+  <alias>CRYOSSP370</alias>
+  <lname>SSP370SOI_EAM%CMIP6_ELM%SPBC_MPASSI%DIB_MPASO%IBISMF_MOSART_SGLC_SWAV</lname>
+</compset>
+
+<compset>
   <alias>BGCEXP_BDRD_CNPECACNT_SSP585_CMIP6</alias>
   <lname>SSP585_EAM%CMIP6_ELM%CNPECACNTBC_MPASSI%BGC_MPASO%OIECO_MOSART_SGLC_SWAV_BGC%BDRD</lname>
 </compset>


### PR DESCRIPTION
Adds new Polar compsets that are similar to `WCYCL20TR`, `WCYCLSSP585`, `WCYCLSSP370`, except uses Polar settings for Antarctic runoff (disables Antarctic runoff from the coupler to the ocn, includes ice-shelf melt fluxes and data icebergs).

[BFB] for all currently tested configurations.