### PR TITLE
jenkins_script: Move from CIME to E3SM

### DIFF
--- a/cime_config/scripts/jenkins_script
+++ b/cime_config/scripts/jenkins_script
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+#
+# Wrapper around jenkins_generic_job that will allow output
+# from that script to always be printed to the screen and
+# recoverable if Jenkins is forced to kill the job. This is the
+# script that should be used from Jenkins.
+#
+
+SCRIPT_DIR=$( cd "$( dirname "$0" )" && pwd )
+DATE_STAMP=$(date "+%Y-%m-%d_%H%M%S")
+export JENKINS_START_TIME=$(date "+%s")
+
+umask 002
+
+set -o pipefail
+$SCRIPT_DIR/jenkins_generic_job --submit-to-cdash --update-success "$@" 2>&1 | tee JENKINS_${DATE_STAMP}


### PR DESCRIPTION
Also, tee the output so it appears in both the log and console output.

Also, add a new cime_config/scripts dir for infrastructure-related scripts.

The actual Jenkins python program, `jenkins_generic_job`, is tightly coupled to CIME and its tests live in the CIME regression suite, so that can stay in CIME for now.

[BFB]