### PR TITLE
Fix high-frequency sea ice coupling to use ice v-vel component in atmospheric boundary layer

### DIFF
--- a/components/mpas-seaice/src/column/ice_colpkg.F90
+++ b/components/mpas-seaice/src/column/ice_colpkg.F90
@@ -3688,9 +3688,8 @@
       if (present(uvel)) then
          worku = uvel
       endif
-      ! should this be for vvel,workv?
-      if (present(uvel)) then
-         worku = uvel
+      if (present(vvel)) then
+         workv = vvel
       endif
 
                if (trim(atmbndy) == 'constant') then


### PR DESCRIPTION
Fixes atmospheric boundary layer calculations when high frequency coupling is switched on by ensuring that both the u- and v-component of sea ice velocity is used in turbulent atmospheric flux calculations.  This change does not affect the current standard configuration of E3SM on ECwISC30to60E2r1 and EC30to60E2r2 meshes, but it is non-BFB on all other meshes, including the NARRM. The change has been tested in a 3-month D-case smoke test using DTESTM-JRA1p5 on a TL319_EC30to60E2r2 grid, and is BFB with master in that configuration.  The bug has been fixed in CESM and RASM long ago, but remained in E3SM, and was detected by @eclare108213 during implementation of the CICE Consortium's Icepack in E3SM.

[non-BFB] with active seaice on all grids except EC30to60E2r2 and ECwISC30to60E2r1