### PR TITLE
Sets sea ice high-frequency turbulent boundary layer as the E3SM default

### DIFF
--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -395,11 +395,7 @@
 <config_calc_surface_temperature>true</config_calc_surface_temperature>
 <config_use_form_drag>false</config_use_form_drag>
 <config_use_high_frequency_coupling>true</config_use_high_frequency_coupling>
-<config_use_high_frequency_coupling ice_grid="ECwISC30to60E2r1">false</config_use_high_frequency_coupling>
-<config_use_high_frequency_coupling ice_grid="EC30to60E2r2">false</config_use_high_frequency_coupling>
 <config_boundary_layer_iteration_number>10</config_boundary_layer_iteration_number>
-<config_boundary_layer_iteration_number ice_grid="ECwISC30to60E2r1">5</config_boundary_layer_iteration_number>
-<config_boundary_layer_iteration_number ice_grid="EC30to60E2r2">5</config_boundary_layer_iteration_number>
 
 <!-- ocean -->
 <config_use_ocean_mixed_layer>false</config_use_ocean_mixed_layer>

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -1751,7 +1751,7 @@
 			possible_values="true or false"
 			icepack_name="formdrag"
 		/>
-		<nml_option name="config_use_high_frequency_coupling" type="logical" default_value="false" units="unitless"
+		<nml_option name="config_use_high_frequency_coupling" type="logical" default_value="true" units="unitless"
 			description="If true use high frequency coupling."
 			possible_values="true or false"
 			icepack_name="highfreq"

--- a/components/mpas-seaice/src/column/ice_colpkg.F90
+++ b/components/mpas-seaice/src/column/ice_colpkg.F90
@@ -3688,9 +3688,8 @@
       if (present(uvel)) then
          worku = uvel
       endif
-      ! should this be for vvel,workv?
-      if (present(uvel)) then
-         worku = uvel
+      if (present(vvel)) then
+         workv = vvel
       endif
 
                if (trim(atmbndy) == 'constant') then


### PR DESCRIPTION
Switches on high-frequency boundary layer coupling between the atmosphere and sea ice for all configurations of E3SM, where previously it was switched off for standard resolution without (EC30to60E2r2) and with (ECwISC30to60E2r1) ice shelves. The change includes a bug fix submitted in a separate PR https://github.com/E3SM-Project/E3SM/pull/5619.  This is a significant change, including the bug fix, to E3SM, and has therefore undergone the following tests:

1) 3-month D-case smoke test using DTESTM-JRA1p5 on a TL319_EC30to60E2r2 grid (non-BFB with master)
2) 20-year B-case smoke test using WCYCL1850 on ne30pg2_EC30to60E2r2 grid _(test underway now)_

[NML] for configurations with EC30to60E2r2 or ECwISC30to60E2r1
[non-BFB] for configurations with EC30to60E2r2 or ECwISC30to60E2r1