### PR TITLE
Fix work array dimension for vmr reaction rate

### DIFF
--- a/components/eam/src/chemistry/mozart/rate_diags.F90
+++ b/components/eam/src/chemistry/mozart/rate_diags.F90
@@ -76,7 +76,7 @@ contains
   subroutine rate_diags_calc( rxt_rates, vmr, m, ncol, lchnk, pver, pdeldry, mbar )
 
     use mo_rxt_rates_conv, only: set_rates
-    use chem_mods,    only : gas_pcnst
+    use chem_mods,    only : gas_pcnst, rxntot
 
     real(r8), intent(inout) :: rxt_rates(:,:,:) ! 'molec/cm3/sec'
     real(r8), intent(in)    :: vmr(:,:,:)
@@ -87,7 +87,7 @@ contains
 
     integer :: i, k
 
-    real(r8)  :: rxt_rates_vmr(ncol,pver,gas_pcnst) ! 'vmr/sec'
+    real(r8)  :: rxt_rates_vmr(ncol,pver,max(1,rxntot)) ! 'vmr/sec'
     real(r8)  :: wrk(ncol,pver)
     real(r8)  :: wrk_sum(ncol)
     real(r8)  :: adv_mass_ch4
@@ -119,7 +119,7 @@ contains
 
     call set_rates( rxt_rates, vmr, ncol )
 
-    rxt_rates_vmr = rxt_rates    
+    rxt_rates_vmr = rxt_rates
 
     do i = 1, rxt_tag_cnt
        ! convert from vmr/sec to molecules/cm3/sec


### PR DESCRIPTION
The work array to save reaction rate in volume mixing ratio is
inconsistent with the one passing in from caller, which cause
debug mode run with gnu and nvidia compiler to fail.

The calculations are for diagnostics. The issue has no impact on
simulation results, nor the reaction rate diagnostics.

Fixes #5624
Fixes #5632 

[BFB]