### PR TITLE
Update ocean and sea-ice partitions for 6 E3SM v1 meshes used in testing

### DIFF
--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -108,8 +108,8 @@ def buildnml(case, caseroot, compname):
             logger.warning("         But no file available for this grid.")
 
     elif ocn_grid == 'oQU480':
-        decomp_date = '151209'
-        decomp_prefix = 'mpas-o.graph.info.'
+        decomp_date = '230422'
+        decomp_prefix = 'partitions/mpas-o.graph.info.'
         ic_date = '151209'
         ic_prefix = 'ocean.QU.480km'
         if ocn_ic_mode == 'spunup':
@@ -117,8 +117,8 @@ def buildnml(case, caseroot, compname):
             logger.warning("         But no file available for this grid.")
 
     elif ocn_grid == 'oQU240':
-        decomp_date = '151209'
-        decomp_prefix = 'mpas-o.graph.info.'
+        decomp_date = '230422'
+        decomp_prefix = 'partitions/mpas-o.graph.info.'
         ic_date = '151209'
         ic_prefix = 'ocean.QU.240km'
         if ocn_ic_mode == 'spunup':
@@ -126,8 +126,8 @@ def buildnml(case, caseroot, compname):
             logger.warning("         But no file available for this grid.")
 
     elif ocn_grid == 'oQU240wLI':
-        decomp_date = '160929'
-        decomp_prefix = 'mpas-o.graph.info.'
+        decomp_date = '230422'
+        decomp_prefix = 'partitions/mpas-o.graph.info.'
         ic_date = '230220'
         ic_prefix = 'ocean.QU.240wLI'
         if ocn_ic_mode == 'spunup':

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -75,8 +75,8 @@ def buildnml(case, caseroot, compname):
     eco_forcing_file = ''
 
     if ocn_grid == 'oEC60to30v3':
-        decomp_date = '161222'
-        decomp_prefix = 'mpas-o.graph.info.'
+        decomp_date = '230424'
+        decomp_prefix = 'partitions/mpas-o.graph.info.'
         restoring_file = 'sss.monthlyClimatology.PHC2_salx_040803.oEC60to30v3.nc'
         analysis_mask_file = 'oEC60to30v3_Atlantic_region_and_southern_transect.nc'
         ic_date = '170905'
@@ -135,8 +135,8 @@ def buildnml(case, caseroot, compname):
             logger.warning("         But no file available for this grid.")
 
     elif ocn_grid == 'oQU120':
-        decomp_date = '160318'
-        decomp_prefix = 'mpas-o.graph.info.'
+        decomp_date = '230424'
+        decomp_prefix = 'partitions/mpas-o.graph.info.'
         ic_date = '160318'
         ic_prefix = 'ocean.QU.120km'
         if ocn_ic_mode == 'spunup':
@@ -166,8 +166,8 @@ def buildnml(case, caseroot, compname):
             logger.warning("         But no file available for this grid.")
 
     elif ocn_grid == 'oRRS18to6v3':
-        decomp_date = '170111'
-        decomp_prefix = 'mpas-o.graph.info.'
+        decomp_date = '230424'
+        decomp_prefix = 'partitions/mpas-o.graph.info.'
         restoring_file = 'sss.monthlyClimatology.PHC2_salx_040803.oRRS18to6v3.nc'
         analysis_mask_file = 'oRRS18to6v3_mocBasinsAndTransects20210623.nc'
         ic_date = '171116'

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -73,8 +73,8 @@ def buildnml(case, caseroot, compname):
     points_file = ''
 
     if ice_grid == 'oEC60to30v3':
-        decomp_date = '161222'
-        decomp_prefix = 'mpas-cice.graph.info.'
+        decomp_date = '230424'
+        decomp_prefix = 'partitions/mpas-seaice.graph.info.'
         grid_date = '161222'
         grid_prefix = 'seaice.EC60to30v3'
         if ice_ic_mode == 'spunup':
@@ -106,8 +106,8 @@ def buildnml(case, caseroot, compname):
             logger.warning("         But no file available for this grid.")
 
     elif ice_grid == 'oQU120':
-        decomp_date = '151209'
-        decomp_prefix = 'mpas-cice.graph.info.'
+        decomp_date = '230424'
+        decomp_prefix = 'partitions/mpas-seaice.graph.info.'
         grid_date = '151209'
         grid_prefix = 'seaice.oQU120km'
         if ice_ic_mode == 'spunup':
@@ -161,8 +161,8 @@ def buildnml(case, caseroot, compname):
             logger.warning("         But no file available for this grid.")
 
     elif ice_grid == 'oRRS18to6v3':
-        decomp_date = '180214'
-        decomp_prefix = 'mpas-seaice.v2.'
+        decomp_date = '230424'
+        decomp_prefix = 'partitions/mpas-seaice.graph.info.'
         grid_date = '170111'
         grid_prefix = 'seaice.RRS18to6v3'
         if ice_ic_mode == 'spunup':

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -115,8 +115,8 @@ def buildnml(case, caseroot, compname):
             logger.warning("         But no file available for this grid.")
 
     elif ice_grid == 'oQU240':
-        decomp_date = '151209'
-        decomp_prefix = 'mpas-cice.graph.info.'
+        decomp_date = '230422'
+        decomp_prefix = 'partitions/mpas-seaice.graph.info.'
         grid_date = '151209'
         grid_prefix = 'seaice.oQU240km'
         if ice_ic_mode == 'spunup':
@@ -124,8 +124,8 @@ def buildnml(case, caseroot, compname):
             logger.warning("         But no file available for this grid.")
 
     elif ice_grid == 'oQU240wLI':
-        decomp_date = '160929'
-        decomp_prefix = 'mpas-cice.graph.info.'
+        decomp_date = '230422'
+        decomp_prefix = 'partitions/mpas-seaice.graph.info.'
         grid_date = '160929'
         grid_prefix = 'cice.QU240wLI'
         if ice_ic_mode == 'spunup':
@@ -133,8 +133,8 @@ def buildnml(case, caseroot, compname):
             logger.warning("         But no file available for this grid.")
 
     elif ice_grid == 'oQU480':
-        decomp_date = '180705'
-        decomp_prefix = 'mpas-seaice.graph.legacy.'
+        decomp_date = '230422'
+        decomp_prefix = 'partitions/mpas-seaice.graph.info.'
         grid_date = '180705'
         grid_prefix = 'seaice.oQU480'
         if ice_ic_mode == 'spunup':


### PR DESCRIPTION
New partition files are created for:
* oQU480
* oQU240
* oQU240wLI
* oQU120
* oEC60to30v3
* oRRS18to6v3

The new `partitions` subdirectory contains many more partition files that should hopefully avoid missing partition issues plaguing some developers.

The new sea-ice partition files are load-balanced so that each core gets a fraction of both polar and equatorial regions.  This is not a concern for the first 4 meshes because they are very small but it is not a bad idea for the last 2 meshes.