### PR TITLE
Reduce the number of files required for JRA_1p5 D-tests

### DIFF
--- a/cime_config/config_files.xml
+++ b/cime_config/config_files.xml
@@ -346,6 +346,7 @@
       <value component="mosart"   >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testmods_dirs</value>
       <value component="scream"   >$COMP_ROOT_DIR_ATM/cime_config/testdefs/testmods_dirs</value>
       <value component="mpaso"    >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testmods_dirs</value>
+      <value component="mpassi"   >$COMP_ROOT_DIR_ICE/cime_config/testdefs/testmods_dirs</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -106,7 +106,7 @@ _TESTS = {
 
     "e3sm_ice_developer" : {
         "tests"   : (
-            "SMS_D_Ld1.TL319_EC30to60E2r2.DTESTM-JRA1p5",
+            "SMS_D_Ld1.TL319_EC30to60E2r2.DTESTM-JRA1p5.mpassi-jra_1958",
             "ERS_Ld5.T62_oQU240.DTESTM",
             "PEM_Ln5.T62_oQU240wLI.DTESTM",
             "PET_Ln5.T62_oQU240.DTESTM",

--- a/components/data_comps/datm/cime_config/config_component.xml
+++ b/components/data_comps/datm/cime_config/config_component.xml
@@ -329,6 +329,7 @@ data (see cime issue #3653 -- https://github.com/ESMCI/cime/issues/3653).
       <value   compset="2010.*_DATM%NLDAS2">2014</value>
       <value   compset="2003.*_DATM%NLDAS2">2003</value>
       <value   compset="2000_DATM%JRA">2016</value>
+      <value   compset="2000_DATM%JRA-1p5">2020</value>
     </values>
     <group>run_component_datm</group>
     <file>env_run.xml</file>

--- a/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+++ b/components/data_comps/datm/cime_config/namelist_definition_datm.xml
@@ -1868,7 +1868,7 @@
       <value stream="CORE2_IAF.NCEP.V_10">1948</value>
       <value stream="CORE2_IAF.CORE2.ArcFactor">1948</value>
       <value stream="CORE_IAF_JRA.*">$DATM_CLMNCEP_YR_START</value>
-      <value stream="IAF_JRA_1p5.*">1958</value>
+      <value stream="IAF_JRA_1p5.*">$DATM_CLMNCEP_YR_START</value>
       <value stream="CORE_RYF8485_JRA">1984</value>
       <value stream="CORE_RYF9091_JRA">1990</value>
       <value stream="CORE_RYF0304_JRA">2003</value>
@@ -1940,9 +1940,9 @@
       <value stream="CORE2_IAF.CORE2.ArcFactor">2009</value>
       <value stream="co2tseries.20tr" cime_model="e3sm">2007</value>
       <value stream="co2tseries.20tr" cime_model="cesm">2014</value>
-      <value stream="CORE_IAF_JRA.*2018">2018</value>
+      <value stream="CORE_IAF_JRA.*2018">$DATM_CLMNCEP_YR_END</value>
       <value stream="CORE_IAF_JRA.*">$DATM_CLMNCEP_YR_END</value>
-      <value stream="IAF_JRA_1p5.*">2020</value>
+      <value stream="IAF_JRA_1p5.*">$DATM_CLMNCEP_YR_END</value>
       <value stream="CORE_RYF8485_JRA">1984</value>
       <value stream="CORE_RYF9091_JRA">1990</value>
       <value stream="CORE_RYF0304_JRA">2003</value>

--- a/components/mpas-seaice/cime_config/testdefs/testmods_dirs/mpassi/jra_1958/shell_commands
+++ b/components/mpas-seaice/cime_config/testdefs/testmods_dirs/mpassi/jra_1958/shell_commands
@@ -1,0 +1,2 @@
+./xmlchange DATM_CLMNCEP_YR_START=1958
+./xmlchange DATM_CLMNCEP_YR_END=1958


### PR DESCRIPTION
Several testing platforms fail the new SMS_D_Ld1.TL319_EC30to60E2r2.DTESTM-JRA1p5 test because the JRA1p5 dataset currently needs to download all its data to run. This fixes that problem in much the same way that [PR #5150](https://github.com/E3SM-Project/E3SM/pull/5150) did with the previous version of JRA, by removing the hard-coded start and end year from 1958/2020 to be the start/end values specified by DATM_CLMNCEP_YR_START/DATM_CLMNCEP_YR_END. It also adds a new mpas-seaice testdef to specify year 1958 for a simple test, and replaces the old test with this new one, SMS_D_Ld1.TL319_EC30to60E2r2.DTESTM-JRA1p5.mpassi-jra_1958.

[BFB] 
