### PR TITLE
Reduce Anvil WCYCL1850 config from 20 to 18 nodes

### DIFF
--- a/cime_config/testmods_dirs/config_pes_tests.xml
+++ b/cime_config/testmods_dirs/config_pes_tests.xml
@@ -183,17 +183,17 @@
     </mach>
     <mach name="anvil">
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SWAV.+" pesize="any">
-        <comment>tests+anvil: --compset WCYCL1850 --res northamericax4v1pg2_WC14to60E2r3 on 20 nodes pure-MPI, ~0.8 sypd </comment>
+        <comment>tests+anvil: --compset WCYCL1850 --res northamericax4v1pg2_WC14to60E2r3 on 18 nodes pure-MPI, ~0.8 sypd </comment>
         <ntasks>
-          <ntasks_atm>468</ntasks_atm>
-          <ntasks_lnd>468</ntasks_lnd>
-          <ntasks_rof>468</ntasks_rof>
-          <ntasks_ice>468</ntasks_ice>
-          <ntasks_ocn>252</ntasks_ocn>
-          <ntasks_cpl>468</ntasks_cpl>
+          <ntasks_atm>432</ntasks_atm>
+          <ntasks_lnd>432</ntasks_lnd>
+          <ntasks_rof>432</ntasks_rof>
+          <ntasks_ice>432</ntasks_ice>
+          <ntasks_ocn>216</ntasks_ocn>
+          <ntasks_cpl>432</ntasks_cpl>
         </ntasks>
         <rootpe>
-          <rootpe_ocn>468</rootpe_ocn>
+          <rootpe_ocn>432</rootpe_ocn>
         </rootpe>
       </pes>
     </mach>


### PR DESCRIPTION
This is 12 atm, lnd, ice, etc. and 6 ocn instead of 13 and 7 (there are not currently ice partition files for 13 Anvil nodes).

[NML] - in cime_pes namelists
[non-BFB] - in mpaso.hist.am.globalStats outputs