### PR TITLE
reduce opt on elm files

### DIFF
--- a/cime_config/machines/Depends.chrysalis.intel.cmake
+++ b/cime_config/machines/Depends.chrysalis.intel.cmake
@@ -1,7 +1,9 @@
 # Reduce optimization on files with long compile times
 set(O2MODELSRC
-  eam/src/physics/cam/micro_mg_cam.F90      # ~2027 seconds
-  elm/src/data_types/VegetationDataType.F90 # ~ 930 seconds
+  eam/src/physics/cam/micro_mg_cam.F90                            # ~ 2027 seconds
+  elm/src/data_types/VegetationDataType.F90                       # ~ 930  seconds
+  elm/src/external_models/fates/main/FatesHistoryInterfaceMod.F90 # ~ 1685 seconds
+  elm/src/data_types/ColumnDataType.F90                           # ~ 556  seconds 
 )
 if (NOT DEBUG)
   foreach(ITEM IN LISTS O2MODELSRC)


### PR DESCRIPTION
This PR reduces the optimization on select elm files to reduce overall build time. Build times, in seconds: Before:
- ColumnDataType.F90.o 485.899012
- FatesHistoryInterfaceMod.F90.o 1421.223006

After:
- FatesHistoryInterfaceMod.F90.o 78.462945
- ColumnDataType.F90.o 175.619476

Expected throughput reduction in SMS.ne30pg2_EC30to60E2r2.F2010:
- 1.32% relative to baseline: avg dt 12.09s before and 12.25s after.

[BFB]

=============
The regression (performance in build time) was likely caused by the following PR updating the FATES submodule: https://github.com/E3SM-Project/E3SM/pull/5369. 

On chrysalis with `-O3`:



target | time | 
-- | -- | 
CMakeFiles/lnd.dir/__/__/elm/src/external_models/fates/main/FatesHistoryInterfaceMod.F90.o | 1685.070685
CMakeFiles/lnd.dir/__/__/elm/src/data_types/ColumnDataType.F90.o | 556.200925
CMakeFiles/ice.dir/__/__/core_seaice/shared/mpas_seaice_column.f90.o | 412.729292
CMakeFiles/lnd.dir/__/__/elm/src/data_types/VegetationDataType.F90.o | 237.739976
CMakeFiles/atm.dir/__/__/eam/src/physics/clubb/mt95.f90.o | 128.501878
CMakeFiles/common.dir/__/__/operators/mpas_tensor_operations.f90.o | 100.511387
CMakeFiles/lnd.dir/__/__/elm/src/biogeochem/AllocationMod.F90.o | 90.376389
CMakeFiles/atm.dir/__/__/eam/src/physics/cosp2/local/cosp.F90.o | 88.261630
CMakeFiles/ice.dir/__/__/core_seaice/shared/mpas_seaice_advection_incremental_remap.f90.o | 75.701545
CMakeFiles/ice.dir/__/__/core_seaice/model_forward/mpas_seaice_core_interface.f90.o | 73.779384
CMakeFiles/lnd.dir/__/__/elm/src/biogeochem/CNCarbonFluxType.F90.o | 62.942877




On chrysalis with `-O2`: 



  target | time |
-- | -- | 
CMakeFiles/lnd.dir/__/__/elm/src/data_types/VegetationDataType.F90.o | 242.303669
CMakeFiles/lnd.dir/__/__/elm/src/data_types/ColumnDataType.F90.o | 173.351958
CMakeFiles/atm.dir/__/__/eam/src/physics/cosp2/local/cosp.F90.o | 92.454104
CMakeFiles/lnd.dir/__/__/elm/src/external_models/fates/main/FatesHistoryInterfaceMod.F90.o | 76.084116
CMakeFiles/atm.dir/__/__/eam/src/physics/clubb/mt95.f90.o | 72.881920
CMakeFiles/lnd.dir/__/__/elm/src/biogeochem/CNCarbonFluxType.F90.o | 61.474591
CMakeFiles/ice.dir/__/__/core_seaice/model_forward/mpas_seaice_core_interface.f90.o | 59.358573
CMakeFiles/rof.dir/__/__/mosart/src/riverroute/RtmMod.F90.o | 50.759309
CMakeFiles/ice.dir/__/__/core_seaice/shared/mpas_seaice_column.f90.o | 42.153019
CMakeFiles/ice.dir/__/__/core_seaice/shared/mpas_seaice_advection_incremental_remap.f90.o | 34.135311
CMakeFiles/atm.dir/__/__/eam/src/physics/cam/cospsimulator_intr.F90.o | 32.426493


