### PR TITLE
First D-case column test of sea ice model

### DIFF
--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -437,9 +437,6 @@ if ($prognostic_mode eq 'prescribed') {
     $SSTICE_YEAR_END      = $xmlvars{'SSTICE_YEAR_END'};
     $SSTICE_STREAM        = $xmlvars{'SSTICE_STREAM'};
 }
-if ($column_mode eq 'true') {
-
-}
 
 my $output_r = "./${CASE}.mpassi.r";
 my $output_h = "./${CASE}.mpassi.h";

--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -60,6 +60,8 @@ OPTIONS
                            Options are: none, data, prognostic
      -prognostic_mode      variable for prognostic mode
                            Options are: full, prescribed
+     -column_mode          variable for column-only mode
+                           Options are: true, false
      -ntasks_ice           NTASKS_ICE for this case
      -ninst_ice            NINST_ICE for this case
 

--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -110,6 +110,7 @@ my %opts = ( help            => 0,
              surface_mode    => undef,
              iceberg_mode    => undef,
              prognostic_mode => undef,
+             column_mode => undef,
              cfg_dir         => $cfgdir,
              ntasks_ice      => 0,
              ninst_ice       => 0,
@@ -132,6 +133,7 @@ GetOptions(
     "surface_mode=s"    => \$opts{'surface_mode'},
     "iceberg_mode=s"    => \$opts{'iceberg_mode'},
     "prognostic_mode=s" => \$opts{'prognostic_mode'},
+    "column_mode=s"     => \$opts{'column_mode'},
     "cfg_dir=s"         => \$opts{'cfg_dir'},
     "preview"           => \$opts{'preview'},
     "ntasks_ice=i"      => \$opts{'ntasks_ice'},
@@ -171,6 +173,7 @@ my $ice_bgc         = $opts{'ice_bgc'};
 my $surface_mode    = $opts{'surface_mode'};
 my $iceberg_mode    = $opts{'iceberg_mode'};
 my $prognostic_mode = $opts{'prognostic_mode'};
+my $column_mode     = $opts{'column_mode'};
 my $NINST_ICE       = $opts{'ninst_ice'};
 my $NTASKS_ICE      = $opts{'ntasks_ice'};
 $cfgdir             = $opts{'cfg_dir'};
@@ -193,6 +196,7 @@ print $fh  <<"EOF";
 <config_definition>
 <entry id="ice_grid" value="$ICE_GRID">
 <entry id="prognostic_mode" value="$prognostic_mode">
+<entry id="column_mode" value="$column_mode">
 <entry id="decomp_prefix" value="$decomp_prefix">
 <entry id="date_stamp" value="$date_stamp">
 </config_definition>
@@ -432,6 +436,9 @@ if ($prognostic_mode eq 'prescribed') {
     $SSTICE_YEAR_START    = $xmlvars{'SSTICE_YEAR_START'};
     $SSTICE_YEAR_END      = $xmlvars{'SSTICE_YEAR_END'};
     $SSTICE_STREAM        = $xmlvars{'SSTICE_STREAM'};
+}
+if ($column_mode eq 'true') {
+
 }
 
 my $output_r = "./${CASE}.mpassi.r";

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -91,6 +91,7 @@
 
 <!-- use_sections -->
 <config_use_dynamics>true</config_use_dynamics>
+<config_use_dynamics column_mode="true">false</config_use_dynamics>
 <config_use_dynamics prognostic_mode="prescribed">false</config_use_dynamics>
 <config_use_velocity_solver>true</config_use_velocity_solver>
 <config_use_advection>true</config_use_advection>

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -36,6 +36,7 @@ def buildnml(case, caseroot, compname):
     surface_mode     = case.get_value("MPASSI_SURFACE_MODE")
     iceberg_mode     = case.get_value("MPASSI_ICEBERG_MODE")
     prognostic_mode  = case.get_value("MPASSI_PROGNOSTIC_MODE")
+    column_mode      = case.get_value("MPASSI_COLUMN_MODE")
     ice_pio_typename = case.get_value("ICE_PIO_TYPENAME")
     #ninst_ice       = case.get_value("NINST_ICE")
     ninst_ice        = 1 # Change if you want multiple instances... though this isn't coded yet.
@@ -343,6 +344,7 @@ def buildnml(case, caseroot, compname):
         sysmod += " -surface_mode '{}'".format(surface_mode)
         sysmod += " -iceberg_mode '{}'".format(iceberg_mode)
         sysmod += " -prognostic_mode '{}'".format(prognostic_mode)
+        sysmod += " -column_mode '{}'".format(column_mode)
         sysmod += " -ntasks_ice '{}'".format(ntasks_ice)
         sysmod += " -ninst_ice '{}'".format(ninst_ice_real)
 

--- a/components/mpas-seaice/cime_config/config_component.xml
+++ b/components/mpas-seaice/cime_config/config_component.xml
@@ -66,6 +66,20 @@
         <desc>Option to enable prescribed ice mode in MPASSI</desc>
   </entry>
 
+  <entry id="MPASSI_COLUMN_MODE">
+        <type>char</type>
+        <valid_values>true,false</valid_values>
+        <default_value>full</default_value>
+        <values>
+           <value compset="MPASSI_">false</value>
+           <value compset="_MPASSI%COL">true</value>
+        </values>
+        <group>case_comp</group>
+        <file>env_case.xml</file>
+        <desc>Option to enable MPASSI to be run as a column model</desc>
+  </entry>
+
+
   <description>
     <desc compset="_MPASSI">MPAS seaice:</desc>
   </description>

--- a/components/mpas-seaice/cime_config/config_component.xml
+++ b/components/mpas-seaice/cime_config/config_component.xml
@@ -69,7 +69,7 @@
   <entry id="MPASSI_COLUMN_MODE">
         <type>char</type>
         <valid_values>true,false</valid_values>
-        <default_value>full</default_value>
+        <default_value>true</default_value>
         <values>
            <value compset="MPASSI_">false</value>
            <value compset="_MPASSI%COL">true</value>

--- a/components/mpas-seaice/cime_config/config_compsets.xml
+++ b/components/mpas-seaice/cime_config/config_compsets.xml
@@ -26,8 +26,7 @@
 
   <compset>
     <alias>DTESTM-COL</alias>
-    <! CHANGE TO: 2000_DATM%SHEBA_SLND_MPASSI%COL_SOCN_SROF_SGLC_SWAV_TEST >
-    <lname>2000_DATM%NYF_SLND_MPASSI_DOCN%SOM_DROF%NYF_SGLC_SWAV_TEST</lname>
+    <lname>2000_DATM%NYF_SLND_MPASSI%COL_DOCN%SOM_DROF%NYF_SGLC_SWAV_TEST</lname>
   </compset>
 
 </compsets>

--- a/components/mpas-seaice/cime_config/config_compsets.xml
+++ b/components/mpas-seaice/cime_config/config_compsets.xml
@@ -24,4 +24,9 @@
     <lname>2000_DATM%NYF_SLND_MPASSI%PRES_DOCN%SOM_DROF%NYF_SGLC_SWAV_TEST</lname>
   </compset>
 
+  <compset>
+    <alias>DTESTM-COL</alias>
+    <lname>2000_DATM%SHEBA_SLND_MPASSI%COL_SOCN_SROF_SGLC_SWAV_TEST</lname>
+  </compset>
+
 </compsets>


### PR DESCRIPTION
The first step in creating a D-case column test.  DTESTM-COL switches off dynamics.  Note that only the namelist option `config_use_dynamics = false` needs to be set.  This also switches off advection, so that `config_use_advection = true` can left as is in the namelist, as can `config_use_velocity_solver = true`, due to lines starting at https://github.com/E3SM-Project/E3SM/blob/7443339cfda807f914d6428acf9838b7a8eef1f3/components/mpas-seaice/src/shared/mpas_seaice_time_integration.F#L134.   The compset can be employed with resolution T62_oQU480 for quick execution (see oQU480 grid below), and has been set up in [E3SM-Polar-Developer.sh](https://github.com/E3SM-Project/E3SM/blob/proteanplanet/seaice/testing1/components/mpas-seaice/test/e3sm/E3SM-Polar-Developer.sh) as the E3SM-Polar-Developer.sh -s sandbox -c DC configuration.  I suggest this PR is accepted as a first step, and that we then add SHEBA forcing as a second step, but not part of this PR. 

