### PR TITLE
tentative ssp testmod and control for E90 related calculations/output

### DIFF
--- a/cime_config/testmods_dirs/allactive/wcprodssp/user_nl_eam
+++ b/cime_config/testmods_dirs/allactive/wcprodssp/user_nl_eam
@@ -1,7 +1,9 @@
  nhtfrq =   -24,-24,-6,-6,-3,-24,-24
  mfilt  = 1,30,120,120,240,30,1
  avgflag_pertape = 'A','A','I','A','A','A','I'
- fexcl1 = 'CFAD_SR532_CAL', 'LINOZ_DO3', 'LINOZ_DO3_PSC', 'LINOZ_O3CLIM', 'LINOZ_O3COL', 'LINOZ_SSO3', 'hstobie_linoz'
+!temporarily remove LINOZ O3 related fields from the list until updated linoz v3 style inputdata is ready
+!fexcl1 = 'CFAD_SR532_CAL', 'LINOZ_DO3', 'LINOZ_DO3_PSC', 'LINOZ_O3CLIM', 'LINOZ_O3COL', 'LINOZ_SSO3', 'hstobie_linoz'
+ fexcl1 = 'CFAD_SR532_CAL', 'hstobie_linoz'
  fincl1 = 'extinct_sw_inp','extinct_lw_bnd7','extinct_lw_inp','CLD_CAL', 'TREFMNAV', 'TREFMXAV'
  fincl2 = 'FLUT','PRECT','U200','V200','U850','V850','Z500','OMEGA500','UBOT','VBOT','TREFHT','TREFHTMN:M','TREFHTMX:X','QREFHT','TS','PS','TMQ','TUQ','TVQ','TOZ', 'FLDS', 'FLNS', 'FSDS', 'FSNS', 'SHFLX', 'LHFLX', 'TGCLDCWP', 'TGCLDIWP', 'TGCLDLWP', 'CLDTOT', 'T250', 'T200', 'T150', 'T100', 'T050', 'T025', 'T010', 'T005', 'T002', 'T001', 'TTOP', 'U250', 'U150', 'U100', 'U050', 'U025', 'U010', 'U005', 'U002', 'U001', 'UTOP', 'FSNT', 'FLNT'
  fincl3 = 'PSL','T200','T500','U850','V850','UBOT','VBOT','TREFHT', 'Z700', 'TBOT:M'

--- a/components/eam/src/chemistry/mozart/chemistry.F90
+++ b/components/eam/src/chemistry/mozart/chemistry.F90
@@ -1496,6 +1496,11 @@ end function chem_is_active
 !-----------------------------------------------------------------------
 ! get tropopause level
 !-----------------------------------------------------------------------
+
+! initialize tropospheric level flags
+    tropFlag = .false.
+    tropFlagInt = 0._r8
+
     e90_ndx = get_spc_ndx('E90')
     if (e90_ndx <= 0) then
       call tropopause_find(state, tropLev, primary=TROP_ALG_HYBSTOB, backup=TROP_ALG_CLIMATE)


### PR DESCRIPTION
New format linoz data for SSP compset pending, tentative fix is
introduced to allow wcprodssp test to proceed.

PR #4707 (UCI-chem) introduced E90 for determining 3D tropopause.
However, compsets not using UCI-chem do not use E90 species, lead to
variables related to 3D tropopause effectively uninitialized but could 
still be involved in calculations and sent to outfld. It causes randomness in
output fields, hence NBFB in tests when re-run, or invalid values that are
rejected by IO API.

Fixes #5613 (tentative), #5637, #5643

[NBFB] for tests comparing eam.h0 (e.g., wcprod,  cosplite_nhtfrq5)