### PR TITLE
Fix out-of-bounds error by only looking at array when scm_multcols enabled

### DIFF
--- a/components/eam/src/dynamics/se/inidat.F90
+++ b/components/eam/src/dynamics/se/inidat.F90
@@ -440,8 +440,10 @@ contains
        call endrun('Problem reading ps field')
     end if
 
-    if (scm_multcols .and. tmp(1,1,1) < 10000._r8) then
-      call endrun('Problem reading ps field')
+    if (scm_multcols) then
+       if (tmp(1,1,1) < 10000._r8) then
+          call endrun('Problem reading ps field')
+       endif
     endif
 
     deallocate(tmpmask)


### PR DESCRIPTION
Compiler found out-of-bounds with tmp() array. If instead, we only check that array when scm_multcols is true, it seems OK:
```
    if (scm_multcols) then
       if (tmp(1,1,1) < 10000._r8) then
          call endrun('Problem reading ps field')
       endif
    endif
```
Fixes https://github.com/E3SM-Project/E3SM/issues/5657

[bfb]