### PR TITLE
Change the name of a test in extra_coverage to be a compset that exists

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -289,7 +289,7 @@ _TESTS = {
     "e3sm_extra_coverage" : {
         "inherit" : ("e3sm_atm_extra_coverage", "e3sm_ocnice_extra_coverage"),
         "tests"   : (
-            "SMS_D_Ln3.TL319_EC30to60E2r2_wQU225EC30to60E2r2.GMPAS-JRA-WW3",
+            "SMS_D_Ln3.TL319_EC30to60E2r2_wQU225EC30to60E2r2.GMPAS-JRA1p5-WW3",
             )
         },
 


### PR DESCRIPTION
Fix typo of testname, use `GMPAS-JRA1p5-WW3` 
[bfb]