### PR TITLE
Change SOwISC12to60E2r4 ocn domain file to masked version

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -2692,7 +2692,7 @@
     <domain name="SOwISC12to60E2r4">
       <nx>569915</nx>
       <ny>1</ny>
-      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.SOwISC12to60E2r4-nomask.210119.nc</file>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.SOwISC12to60E2r4.210119.nc</file>
       <desc>SOwISC12to60E2r4 is a MPAS ice/ocean grid with enhanced resolution of 12km in the Southern Ocean around Antarctica. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid:</desc>
     </domain>
 


### PR DESCRIPTION
This changes the default ocean domain file for the `SOwISC12to60E2r4` mesh to be the masked version, consistent with the `ECwISC30to60E2r1` mesh. With the previous `nomask` version, D-cases with this mesh were failing.

Passes `SMS.TL319_EC30to60E2r2.DTESTM-JRA1p5.pm-cpu_gnu`.

[BFB]

Fixes https://github.com/E3SM-Project/E3SM/issues/5653