### PR TITLE
Add control over the years of JRA files required for DROF

### DIFF
--- a/components/data_comps/drof/cime_config/config_component.xml
+++ b/components/data_comps/drof/cime_config/config_component.xml
@@ -154,6 +154,48 @@
     <desc>ending year to loop data over (only used when DROF_MODE is CPLHIST)</desc>
   </entry>
 
+  <entry id="DROF_STRM_YR_ALIGN">
+    <type>integer</type>
+    <valid_values></valid_values>
+    <default_value>1</default_value>
+    <values match="last">
+      <value compset="_DROF%JRA"          >1</value>
+      <value compset="_DROF%JRA-1p4-2018" >1</value>
+      <value compset="_DROF%JRA-1p5"      >1</value>
+    </values>
+    <group>run_component_drof</group>
+    <file>env_run.xml</file>
+    <desc>year align</desc>
+  </entry>
+
+  <entry id="DROF_STRM_YR_START">
+    <type>integer</type>
+    <valid_values></valid_values>
+    <default_value>2004</default_value>
+    <values match="last">
+      <value compset="_DROF%JRA"          >1958</value>
+      <value compset="_DROF%JRA-1p4-2018" >1958</value>
+      <value compset="_DROF%JRA-1p5"      >1958</value>
+    </values>
+    <group>run_component_drof</group>
+    <file>env_run.xml</file>
+    <desc>starting year to loop data over</desc>
+  </entry>
+
+  <entry id="DROF_STRM_YR_END">
+    <type>integer</type>
+    <valid_values></valid_values>
+    <default_value>2004</default_value>
+    <values match="last">
+      <value compset="_DROF%JRA"          >2016</value>
+      <value compset="_DROF%JRA-1p4-2018" >2018</value>
+      <value compset="_DROF%JRA-1p5"      >2020</value>
+    </values>
+    <group>run_component_drof</group>
+    <file>env_run.xml</file>
+    <desc>ending year to loop data over</desc>
+  </entry>
+
   <help>
     =========================================
     DROF naming conventions

--- a/components/data_comps/drof/cime_config/namelist_definition_drof.xml
+++ b/components/data_comps/drof/cime_config/namelist_definition_drof.xml
@@ -201,451 +201,29 @@
       <value stream="rof.diatren_iaf_ais00_rx1">runoff.daitren.iaf-AISx00.20120419.nc</value>
       <value stream="rof.diatren_iaf_ais45_rx1">runoff.daitren.iaf-AISx45.20120419.nc</value>
       <value stream="rof.diatren_iaf_ais55_rx1">runoff.daitren.iaf-AISx55.20120419.nc</value>
-      <value stream="rof.ryf8485_jra">RAF_8485.JRA.v1.3.runoff.180404.nc</value>
-      <value stream="rof.ryf9091_jra">RAF_9091.JRA.v1.3.runoff.180404.nc</value>
-      <value stream="rof.ryf0304_jra">RAF_0304.JRA.v1.3.runoff.180404.nc</value>
+      <value stream="rof.ryf8485_jra"          >RAF_8485.JRA.v1.3.runoff.180404.nc</value>
+      <value stream="rof.ryf9091_jra"          >RAF_9091.JRA.v1.3.runoff.180404.nc</value>
+      <value stream="rof.ryf0304_jra"          >RAF_0304.JRA.v1.3.runoff.180404.nc</value>
       <value stream="rof.iaf_jra_1p5_ais0rof">
-           JRA.v1.5.runoff.1958.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1959.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1960.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1961.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1962.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1963.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1964.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1965.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1966.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1967.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1968.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1969.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1970.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1971.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1972.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1973.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1974.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1975.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1976.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1977.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1978.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1979.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1980.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1981.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1982.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1983.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1984.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1985.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1986.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1987.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1988.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1989.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1990.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1991.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1992.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1993.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1994.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1995.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1996.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1997.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1998.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.1999.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.2000.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.2001.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.2002.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.2003.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.2004.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.2005.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.2006.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.2007.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.2008.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.2009.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.2010.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.2011.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.2012.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.2013.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.2014.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.2015.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.2016.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.2017.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.2018.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.2019.no_rofi_no_rofl.210505.nc
-           JRA.v1.5.runoff.2020.no_rofi_no_rofl.210504.nc
+           JRA.v1.5.runoff.%y.no_rofi_no_rofl.210505.nc
       </value>
       <value stream="rof.iaf_jra_1p5">
-           JRA.v1.5.runoff.1958.210505.nc
-           JRA.v1.5.runoff.1959.210505.nc
-           JRA.v1.5.runoff.1960.210505.nc
-           JRA.v1.5.runoff.1961.210505.nc
-           JRA.v1.5.runoff.1962.210505.nc
-           JRA.v1.5.runoff.1963.210505.nc
-           JRA.v1.5.runoff.1964.210505.nc
-           JRA.v1.5.runoff.1965.210505.nc
-           JRA.v1.5.runoff.1966.210505.nc
-           JRA.v1.5.runoff.1967.210505.nc
-           JRA.v1.5.runoff.1968.210505.nc
-           JRA.v1.5.runoff.1969.210505.nc
-           JRA.v1.5.runoff.1970.210505.nc
-           JRA.v1.5.runoff.1971.210505.nc
-           JRA.v1.5.runoff.1972.210505.nc
-           JRA.v1.5.runoff.1973.210505.nc
-           JRA.v1.5.runoff.1974.210505.nc
-           JRA.v1.5.runoff.1975.210505.nc
-           JRA.v1.5.runoff.1976.210505.nc
-           JRA.v1.5.runoff.1977.210505.nc
-           JRA.v1.5.runoff.1978.210505.nc
-           JRA.v1.5.runoff.1979.210505.nc
-           JRA.v1.5.runoff.1980.210505.nc
-           JRA.v1.5.runoff.1981.210505.nc
-           JRA.v1.5.runoff.1982.210505.nc
-           JRA.v1.5.runoff.1983.210505.nc
-           JRA.v1.5.runoff.1984.210505.nc
-           JRA.v1.5.runoff.1985.210505.nc
-           JRA.v1.5.runoff.1986.210505.nc
-           JRA.v1.5.runoff.1987.210505.nc
-           JRA.v1.5.runoff.1988.210505.nc
-           JRA.v1.5.runoff.1989.210505.nc
-           JRA.v1.5.runoff.1990.210505.nc
-           JRA.v1.5.runoff.1991.210505.nc
-           JRA.v1.5.runoff.1992.210505.nc
-           JRA.v1.5.runoff.1993.210505.nc
-           JRA.v1.5.runoff.1994.210505.nc
-           JRA.v1.5.runoff.1995.210505.nc
-           JRA.v1.5.runoff.1996.210505.nc
-           JRA.v1.5.runoff.1997.210505.nc
-           JRA.v1.5.runoff.1998.210505.nc
-           JRA.v1.5.runoff.1999.210505.nc
-           JRA.v1.5.runoff.2000.210505.nc
-           JRA.v1.5.runoff.2001.210505.nc
-           JRA.v1.5.runoff.2002.210505.nc
-           JRA.v1.5.runoff.2003.210505.nc
-           JRA.v1.5.runoff.2004.210505.nc
-           JRA.v1.5.runoff.2005.210505.nc
-           JRA.v1.5.runoff.2006.210505.nc
-           JRA.v1.5.runoff.2007.210505.nc
-           JRA.v1.5.runoff.2008.210505.nc
-           JRA.v1.5.runoff.2009.210505.nc
-           JRA.v1.5.runoff.2010.210505.nc
-           JRA.v1.5.runoff.2011.210505.nc
-           JRA.v1.5.runoff.2012.210505.nc
-           JRA.v1.5.runoff.2013.210505.nc
-           JRA.v1.5.runoff.2014.210505.nc
-           JRA.v1.5.runoff.2015.210505.nc
-           JRA.v1.5.runoff.2016.210505.nc
-           JRA.v1.5.runoff.2017.210505.nc
-           JRA.v1.5.runoff.2018.210505.nc
-           JRA.v1.5.runoff.2019.210505.nc
-           JRA.v1.5.runoff.2020.210504.nc
+           JRA.v1.5.runoff.%y.210505.nc
       </value>
       <value stream="rof.iaf_jra_1p4_2018_ais0ice">
-           JRA.v1.4.runoff.1958.no_rofi.190214.nc
-           JRA.v1.4.runoff.1959.no_rofi.190214.nc
-           JRA.v1.4.runoff.1960.no_rofi.190214.nc
-           JRA.v1.4.runoff.1961.no_rofi.190214.nc
-           JRA.v1.4.runoff.1962.no_rofi.190214.nc
-           JRA.v1.4.runoff.1963.no_rofi.190214.nc
-           JRA.v1.4.runoff.1964.no_rofi.190214.nc
-           JRA.v1.4.runoff.1965.no_rofi.190214.nc
-           JRA.v1.4.runoff.1966.no_rofi.190214.nc
-           JRA.v1.4.runoff.1967.no_rofi.190214.nc
-           JRA.v1.4.runoff.1968.no_rofi.190214.nc
-           JRA.v1.4.runoff.1969.no_rofi.190214.nc
-           JRA.v1.4.runoff.1970.no_rofi.190214.nc
-           JRA.v1.4.runoff.1971.no_rofi.190214.nc
-           JRA.v1.4.runoff.1972.no_rofi.190214.nc
-           JRA.v1.4.runoff.1973.no_rofi.190214.nc
-           JRA.v1.4.runoff.1974.no_rofi.190214.nc
-           JRA.v1.4.runoff.1975.no_rofi.190214.nc
-           JRA.v1.4.runoff.1976.no_rofi.190214.nc
-           JRA.v1.4.runoff.1977.no_rofi.190214.nc
-           JRA.v1.4.runoff.1978.no_rofi.190214.nc
-           JRA.v1.4.runoff.1979.no_rofi.190214.nc
-           JRA.v1.4.runoff.1980.no_rofi.190214.nc
-           JRA.v1.4.runoff.1981.no_rofi.190214.nc
-           JRA.v1.4.runoff.1982.no_rofi.190214.nc
-           JRA.v1.4.runoff.1983.no_rofi.190214.nc
-           JRA.v1.4.runoff.1984.no_rofi.190214.nc
-           JRA.v1.4.runoff.1985.no_rofi.190214.nc
-           JRA.v1.4.runoff.1986.no_rofi.190214.nc
-           JRA.v1.4.runoff.1987.no_rofi.190214.nc
-           JRA.v1.4.runoff.1988.no_rofi.190214.nc
-           JRA.v1.4.runoff.1989.no_rofi.190214.nc
-           JRA.v1.4.runoff.1990.no_rofi.190214.nc
-           JRA.v1.4.runoff.1991.no_rofi.190214.nc
-           JRA.v1.4.runoff.1992.no_rofi.190214.nc
-           JRA.v1.4.runoff.1993.no_rofi.190214.nc
-           JRA.v1.4.runoff.1994.no_rofi.190214.nc
-           JRA.v1.4.runoff.1995.no_rofi.190214.nc
-           JRA.v1.4.runoff.1996.no_rofi.190214.nc
-           JRA.v1.4.runoff.1997.no_rofi.190214.nc
-           JRA.v1.4.runoff.1998.no_rofi.190214.nc
-           JRA.v1.4.runoff.1999.no_rofi.190214.nc
-           JRA.v1.4.runoff.2000.no_rofi.190214.nc
-           JRA.v1.4.runoff.2001.no_rofi.190214.nc
-           JRA.v1.4.runoff.2002.no_rofi.190214.nc
-           JRA.v1.4.runoff.2003.no_rofi.190214.nc
-           JRA.v1.4.runoff.2004.no_rofi.190214.nc
-           JRA.v1.4.runoff.2005.no_rofi.190214.nc
-           JRA.v1.4.runoff.2006.no_rofi.190214.nc
-           JRA.v1.4.runoff.2007.no_rofi.190214.nc
-           JRA.v1.4.runoff.2008.no_rofi.190214.nc
-           JRA.v1.4.runoff.2009.no_rofi.190214.nc
-           JRA.v1.4.runoff.2010.no_rofi.190214.nc
-           JRA.v1.4.runoff.2011.no_rofi.190214.nc
-           JRA.v1.4.runoff.2012.no_rofi.190214.nc
-           JRA.v1.4.runoff.2013.no_rofi.190214.nc
-           JRA.v1.4.runoff.2014.no_rofi.190214.nc
-           JRA.v1.4.runoff.2015.no_rofi.190214.nc
-           JRA.v1.4.runoff.2016.no_rofi.190214.nc
-           JRA.v1.4.runoff.2017.no_rofi.190214.nc
-           JRA.v1.4.runoff.2018.no_rofi.190214.nc
+           JRA.v1.4.runoff.%y.no_rofi.190214.nc
       </value>
       <value stream="rof.iaf_jra_1p4_2018_ais0liq">
-           JRA.v1.4.runoff.1958.no_rofl.190214.nc
-           JRA.v1.4.runoff.1959.no_rofl.190214.nc
-           JRA.v1.4.runoff.1960.no_rofl.190214.nc
-           JRA.v1.4.runoff.1961.no_rofl.190214.nc
-           JRA.v1.4.runoff.1962.no_rofl.190214.nc
-           JRA.v1.4.runoff.1963.no_rofl.190214.nc
-           JRA.v1.4.runoff.1964.no_rofl.190214.nc
-           JRA.v1.4.runoff.1965.no_rofl.190214.nc
-           JRA.v1.4.runoff.1966.no_rofl.190214.nc
-           JRA.v1.4.runoff.1967.no_rofl.190214.nc
-           JRA.v1.4.runoff.1968.no_rofl.190214.nc
-           JRA.v1.4.runoff.1969.no_rofl.190214.nc
-           JRA.v1.4.runoff.1970.no_rofl.190214.nc
-           JRA.v1.4.runoff.1971.no_rofl.190214.nc
-           JRA.v1.4.runoff.1972.no_rofl.190214.nc
-           JRA.v1.4.runoff.1973.no_rofl.190214.nc
-           JRA.v1.4.runoff.1974.no_rofl.190214.nc
-           JRA.v1.4.runoff.1975.no_rofl.190214.nc
-           JRA.v1.4.runoff.1976.no_rofl.190214.nc
-           JRA.v1.4.runoff.1977.no_rofl.190214.nc
-           JRA.v1.4.runoff.1978.no_rofl.190214.nc
-           JRA.v1.4.runoff.1979.no_rofl.190214.nc
-           JRA.v1.4.runoff.1980.no_rofl.190214.nc
-           JRA.v1.4.runoff.1981.no_rofl.190214.nc
-           JRA.v1.4.runoff.1982.no_rofl.190214.nc
-           JRA.v1.4.runoff.1983.no_rofl.190214.nc
-           JRA.v1.4.runoff.1984.no_rofl.190214.nc
-           JRA.v1.4.runoff.1985.no_rofl.190214.nc
-           JRA.v1.4.runoff.1986.no_rofl.190214.nc
-           JRA.v1.4.runoff.1987.no_rofl.190214.nc
-           JRA.v1.4.runoff.1988.no_rofl.190214.nc
-           JRA.v1.4.runoff.1989.no_rofl.190214.nc
-           JRA.v1.4.runoff.1990.no_rofl.190214.nc
-           JRA.v1.4.runoff.1991.no_rofl.190214.nc
-           JRA.v1.4.runoff.1992.no_rofl.190214.nc
-           JRA.v1.4.runoff.1993.no_rofl.190214.nc
-           JRA.v1.4.runoff.1994.no_rofl.190214.nc
-           JRA.v1.4.runoff.1995.no_rofl.190214.nc
-           JRA.v1.4.runoff.1996.no_rofl.190214.nc
-           JRA.v1.4.runoff.1997.no_rofl.190214.nc
-           JRA.v1.4.runoff.1998.no_rofl.190214.nc
-           JRA.v1.4.runoff.1999.no_rofl.190214.nc
-           JRA.v1.4.runoff.2000.no_rofl.190214.nc
-           JRA.v1.4.runoff.2001.no_rofl.190214.nc
-           JRA.v1.4.runoff.2002.no_rofl.190214.nc
-           JRA.v1.4.runoff.2003.no_rofl.190214.nc
-           JRA.v1.4.runoff.2004.no_rofl.190214.nc
-           JRA.v1.4.runoff.2005.no_rofl.190214.nc
-           JRA.v1.4.runoff.2006.no_rofl.190214.nc
-           JRA.v1.4.runoff.2007.no_rofl.190214.nc
-           JRA.v1.4.runoff.2008.no_rofl.190214.nc
-           JRA.v1.4.runoff.2009.no_rofl.190214.nc
-           JRA.v1.4.runoff.2010.no_rofl.190214.nc
-           JRA.v1.4.runoff.2011.no_rofl.190214.nc
-           JRA.v1.4.runoff.2012.no_rofl.190214.nc
-           JRA.v1.4.runoff.2013.no_rofl.190214.nc
-           JRA.v1.4.runoff.2014.no_rofl.190214.nc
-           JRA.v1.4.runoff.2015.no_rofl.190214.nc
-           JRA.v1.4.runoff.2016.no_rofl.190214.nc
-           JRA.v1.4.runoff.2017.no_rofl.190214.nc
-           JRA.v1.4.runoff.2018.no_rofl.190214.nc
+           JRA.v1.4.runoff.%y.no_rofl.190214.nc
       </value>
       <value stream="rof.iaf_jra_1p4_2018_ais0rof">
-           JRA.v1.4.runoff.1958.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1959.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1960.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1961.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1962.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1963.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1964.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1965.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1966.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1967.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1968.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1969.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1970.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1971.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1972.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1973.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1974.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1975.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1976.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1977.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1978.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1979.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1980.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1981.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1982.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1983.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1984.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1985.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1986.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1987.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1988.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1989.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1990.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1991.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1992.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1993.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1994.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1995.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1996.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1997.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1998.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.1999.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.2000.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.2001.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.2002.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.2003.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.2004.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.2005.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.2006.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.2007.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.2008.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.2009.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.2010.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.2011.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.2012.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.2013.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.2014.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.2015.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.2016.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.2017.no_rofi_no_rofl.190214.nc
-           JRA.v1.4.runoff.2018.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.%y.no_rofi_no_rofl.190214.nc
       </value>
       <value stream="rof.iaf_jra_1p4_2018">
-           JRA.v1.4.runoff.1958.190214.nc
-           JRA.v1.4.runoff.1959.190214.nc
-           JRA.v1.4.runoff.1960.190214.nc
-           JRA.v1.4.runoff.1961.190214.nc
-           JRA.v1.4.runoff.1962.190214.nc
-           JRA.v1.4.runoff.1963.190214.nc
-           JRA.v1.4.runoff.1964.190214.nc
-           JRA.v1.4.runoff.1965.190214.nc
-           JRA.v1.4.runoff.1966.190214.nc
-           JRA.v1.4.runoff.1967.190214.nc
-           JRA.v1.4.runoff.1968.190214.nc
-           JRA.v1.4.runoff.1969.190214.nc
-           JRA.v1.4.runoff.1970.190214.nc
-           JRA.v1.4.runoff.1971.190214.nc
-           JRA.v1.4.runoff.1972.190214.nc
-           JRA.v1.4.runoff.1973.190214.nc
-           JRA.v1.4.runoff.1974.190214.nc
-           JRA.v1.4.runoff.1975.190214.nc
-           JRA.v1.4.runoff.1976.190214.nc
-           JRA.v1.4.runoff.1977.190214.nc
-           JRA.v1.4.runoff.1978.190214.nc
-           JRA.v1.4.runoff.1979.190214.nc
-           JRA.v1.4.runoff.1980.190214.nc
-           JRA.v1.4.runoff.1981.190214.nc
-           JRA.v1.4.runoff.1982.190214.nc
-           JRA.v1.4.runoff.1983.190214.nc
-           JRA.v1.4.runoff.1984.190214.nc
-           JRA.v1.4.runoff.1985.190214.nc
-           JRA.v1.4.runoff.1986.190214.nc
-           JRA.v1.4.runoff.1987.190214.nc
-           JRA.v1.4.runoff.1988.190214.nc
-           JRA.v1.4.runoff.1989.190214.nc
-           JRA.v1.4.runoff.1990.190214.nc
-           JRA.v1.4.runoff.1991.190214.nc
-           JRA.v1.4.runoff.1992.190214.nc
-           JRA.v1.4.runoff.1993.190214.nc
-           JRA.v1.4.runoff.1994.190214.nc
-           JRA.v1.4.runoff.1995.190214.nc
-           JRA.v1.4.runoff.1996.190214.nc
-           JRA.v1.4.runoff.1997.190214.nc
-           JRA.v1.4.runoff.1998.190214.nc
-           JRA.v1.4.runoff.1999.190214.nc
-           JRA.v1.4.runoff.2000.190214.nc
-           JRA.v1.4.runoff.2001.190214.nc
-           JRA.v1.4.runoff.2002.190214.nc
-           JRA.v1.4.runoff.2003.190214.nc
-           JRA.v1.4.runoff.2004.190214.nc
-           JRA.v1.4.runoff.2005.190214.nc
-           JRA.v1.4.runoff.2006.190214.nc
-           JRA.v1.4.runoff.2007.190214.nc
-           JRA.v1.4.runoff.2008.190214.nc
-           JRA.v1.4.runoff.2009.190214.nc
-           JRA.v1.4.runoff.2010.190214.nc
-           JRA.v1.4.runoff.2011.190214.nc
-           JRA.v1.4.runoff.2012.190214.nc
-           JRA.v1.4.runoff.2013.190214.nc
-           JRA.v1.4.runoff.2014.190214.nc
-           JRA.v1.4.runoff.2015.190214.nc
-           JRA.v1.4.runoff.2016.190214.nc
-           JRA.v1.4.runoff.2017.190214.nc
-           JRA.v1.4.runoff.2018.190214.nc
+           JRA.v1.4.runoff.%y.190214.nc
       </value>
       <value stream="rof.iaf_jra">
-           JRA.v1.1.runoff.1958.170807.nc
-           JRA.v1.1.runoff.1959.170807.nc
-           JRA.v1.1.runoff.1960.170807.nc
-           JRA.v1.1.runoff.1961.170807.nc
-           JRA.v1.1.runoff.1962.170807.nc
-           JRA.v1.1.runoff.1963.170807.nc
-           JRA.v1.1.runoff.1964.170807.nc
-           JRA.v1.1.runoff.1965.170807.nc
-           JRA.v1.1.runoff.1966.170807.nc
-           JRA.v1.1.runoff.1967.170807.nc
-           JRA.v1.1.runoff.1968.170807.nc
-           JRA.v1.1.runoff.1969.170807.nc
-           JRA.v1.1.runoff.1970.170807.nc
-           JRA.v1.1.runoff.1971.170807.nc
-           JRA.v1.1.runoff.1972.170807.nc
-           JRA.v1.1.runoff.1973.170807.nc
-           JRA.v1.1.runoff.1974.170807.nc
-           JRA.v1.1.runoff.1975.170807.nc
-           JRA.v1.1.runoff.1976.170807.nc
-           JRA.v1.1.runoff.1977.170807.nc
-           JRA.v1.1.runoff.1978.170807.nc
-           JRA.v1.1.runoff.1979.170807.nc
-           JRA.v1.1.runoff.1980.170807.nc
-           JRA.v1.1.runoff.1981.170807.nc
-           JRA.v1.1.runoff.1982.170807.nc
-           JRA.v1.1.runoff.1983.170807.nc
-           JRA.v1.1.runoff.1984.170807.nc
-           JRA.v1.1.runoff.1985.170807.nc
-           JRA.v1.1.runoff.1986.170807.nc
-           JRA.v1.1.runoff.1987.170807.nc
-           JRA.v1.1.runoff.1988.170807.nc
-           JRA.v1.1.runoff.1989.170807.nc
-           JRA.v1.1.runoff.1990.170807.nc
-           JRA.v1.1.runoff.1991.170807.nc
-           JRA.v1.1.runoff.1992.170807.nc
-           JRA.v1.1.runoff.1993.170807.nc
-           JRA.v1.1.runoff.1994.170807.nc
-           JRA.v1.1.runoff.1995.170807.nc
-           JRA.v1.1.runoff.1996.170807.nc
-           JRA.v1.1.runoff.1997.170807.nc
-           JRA.v1.1.runoff.1998.170807.nc
-           JRA.v1.1.runoff.1999.170807.nc
-           JRA.v1.1.runoff.2000.170807.nc
-           JRA.v1.1.runoff.2001.170807.nc
-           JRA.v1.1.runoff.2002.170807.nc
-           JRA.v1.1.runoff.2003.170807.nc
-           JRA.v1.1.runoff.2004.170807.nc
-           JRA.v1.1.runoff.2005.170807.nc
-           JRA.v1.1.runoff.2006.170807.nc
-           JRA.v1.1.runoff.2007.170807.nc
-           JRA.v1.1.runoff.2008.170807.nc
-           JRA.v1.1.runoff.2009.170807.nc
-           JRA.v1.1.runoff.2010.170807.nc
-           JRA.v1.1.runoff.2011.170807.nc
-           JRA.v1.1.runoff.2012.170807.nc
-           JRA.v1.1.runoff.2013.170807.nc
-           JRA.v1.1.runoff.2014.170807.nc
-           JRA.v1.1.runoff.2015.170807.nc
-           JRA.v1.1.runoff.2016.170807.nc
+           JRA.v1.1.runoff.%y.170807.nc
       </value>
       <value stream="rof.cplhist">$DROF_CPLHIST_CASE.cpl.hr2x.%ym.nc</value>
     </values>
@@ -702,12 +280,12 @@
     <desc>Simulation year to align stream to.</desc>
     <values>
       <value>1</value>
-      <value stream="rof.diatren_ann_rx1">1</value>
-      <value stream="rof.diatren_iaf_rx1">1</value>
+      <value stream="rof.diatren_ann_rx1"      >1</value>
+      <value stream="rof.diatren_iaf_rx1"      >1</value>
       <value stream="rof.diatren_iaf_ais45_rx1">1</value>
-      <value stream="rof.iaf_jra.*">1</value>
-      <value stream="rof.ryf*">1</value>
-      <value stream="rof.cplhist">$DROF_CPLHIST_YR_ALIGN</value>
+      <value stream="rof.iaf_jra.*"            >$DROF_STRM_YR_ALIGN</value>
+      <value stream="rof.ryf*"                 >$DROF_STRM_YR_ALIGN</value>
+      <value stream="rof.cplhist"              >$DROF_CPLHIST_YR_ALIGN</value>
     </values>
   </entry>
 
@@ -725,7 +303,7 @@
       <value stream="rof.diatren_iaf_ais00_rx1">1948</value>
       <value stream="rof.diatren_iaf_ais45_rx1">1948</value>
       <value stream="rof.diatren_iaf_ais55_rx1">1948</value>
-      <value stream="rof.iaf_jra.*"            >1958</value>
+      <value stream="rof.iaf_jra.*"            >$DROF_STRM_YR_START</value>
       <value stream="rof.ryf8485_jra"          >1984</value>
       <value stream="rof.ryf9091_jra"          >1990</value>
       <value stream="rof.ryf0304_jra"          >2003</value>
@@ -739,24 +317,24 @@
     <group>streams_file</group>
     <desc>Last year of stream.</desc>
     <values>
-      <value stream="rof.diatren_ann_rx1"      >1</value>
-      <value stream="rof.diatren_ann_ais00_rx1">1</value>
-      <value stream="rof.diatren_ann_ais45_rx1">1</value>
-      <value stream="rof.diatren_ann_ais55_rx1">1</value>
-      <value stream="rof.diatren_iaf_rx1"      >2009</value>
-      <value stream="rof.diatren_iaf_ais00_rx1">2009</value>
-      <value stream="rof.diatren_iaf_ais45_rx1">2009</value>
-      <value stream="rof.diatren_iaf_ais55_rx1">2009</value>
-      <value stream="rof.iaf_jra_1p5"     >2020</value>
-      <value stream="rof.iaf_jra_1p4_2018"     >2018</value>
-      <value stream="rof.iaf_jra_1p4_2018_ais0ice">2018</value>
-      <value stream="rof.iaf_jra_1p4_2018_ais0liq">2018</value>
-      <value stream="rof.iaf_jra_1p4_2018_ais0rof">2018</value>
-      <value stream="rof.iaf_jra"              >2016</value>
-      <value stream="rof.ryf8485_jra"          >1984</value>
-      <value stream="rof.ryf9091_jra"          >1990</value>
-      <value stream="rof.ryf0304_jra"          >2003</value>
-      <value stream="rof.cplhist"              >$DROF_CPLHIST_YR_END</value>
+      <value stream="rof.diatren_ann_rx1"         >1</value>
+      <value stream="rof.diatren_ann_ais00_rx1"   >1</value>
+      <value stream="rof.diatren_ann_ais45_rx1"   >1</value>
+      <value stream="rof.diatren_ann_ais55_rx1"   >1</value>
+      <value stream="rof.diatren_iaf_rx1"         >2009</value>
+      <value stream="rof.diatren_iaf_ais00_rx1"   >2009</value>
+      <value stream="rof.diatren_iaf_ais45_rx1"   >2009</value>
+      <value stream="rof.diatren_iaf_ais55_rx1"   >2009</value>
+      <value stream="rof.iaf_jra_1p5"             >$DROF_STRM_YR_END</value>
+      <value stream="rof.iaf_jra_1p4_2018"        >$DROF_STRM_YR_END</value>
+      <value stream="rof.iaf_jra_1p4_2018_ais0ice">$DROF_STRM_YR_END</value>
+      <value stream="rof.iaf_jra_1p4_2018_ais0liq">$DROF_STRM_YR_END</value>
+      <value stream="rof.iaf_jra_1p4_2018_ais0rof">$DROF_STRM_YR_END</value>
+      <value stream="rof.iaf_jra"                 >$DROF_STRM_YR_END</value>
+      <value stream="rof.ryf8485_jra"             >1984</value>
+      <value stream="rof.ryf9091_jra"             >1990</value>
+      <value stream="rof.ryf0304_jra"             >2003</value>
+      <value stream="rof.cplhist"                 >$DROF_CPLHIST_YR_END</value>
     </values>
   </entry>
 

--- a/components/mpas-seaice/cime_config/testdefs/testmods_dirs/mpassi/jra_1958/shell_commands
+++ b/components/mpas-seaice/cime_config/testdefs/testmods_dirs/mpassi/jra_1958/shell_commands
@@ -1,2 +1,4 @@
 ./xmlchange DATM_CLMNCEP_YR_START=1958
 ./xmlchange DATM_CLMNCEP_YR_END=1958
+./xmlchange DROF_STRM_YR_START=1958
+./xmlchange DROF_STRM_YR_END=1958


### PR DESCRIPTION
Builds on the approach in datm, but adds new drof variables for DROF_STRM_ALIGN, DROF_STRM_YR_START and DROF_STRM_YR_END to allow control over the number of JRA files needed for testing. Also adds these new settings to a current jra_1958 testdef

[BFB]