### PR TITLE
For pm-cpu intel builds, add Depends rule to build one file slightly different to avoid internal compiler error

### DIFF
--- a/cime_config/machines/Depends.pm-cpu.intel.cmake
+++ b/cime_config/machines/Depends.pm-cpu.intel.cmake
@@ -9,6 +9,5 @@ if (NOT DEBUG)
   endforeach()
 endif()
 
-
-
-
+# compile mpas_seaice_core_interface.f90 with ifort, not ifx
+e3sm_add_flags("${CMAKE_BINARY_DIR}/core_seaice/model_forward/mpas_seaice_core_interface.f90" "-fc=ifort")


### PR DESCRIPTION
For pm-cpu intel build, which uses new oneapi version,
add Depends rule to build one certain mpas file with ifort instead of ifx as a work-around for internal compiler error

May fix https://github.com/E3SM-Project/E3SM/issues/5672
[bfb]
