### PR TITLE
For pm-cpu only, use the regular intel module instead of intel-oneapi

### DIFF
--- a/cime_config/machines/Depends.pm-cpu.intel.cmake
+++ b/cime_config/machines/Depends.pm-cpu.intel.cmake
@@ -1,13 +1,14 @@
-# For this file, see internal compiler error on pm-cpu with -O2
-set(NOOPT
-  eam/src/physics/cam/debug_info.F90)
+# For this file, we see internal compiler error with ifx (via intel-oneapi module) on pm-cpu with -O2
+# Commenting for now as we are using intel module which is not seeing build issue
+#set(NOOPT
+#  eam/src/physics/cam/debug_info.F90)
 
-if (NOT DEBUG)
-  foreach(ITEM IN LISTS NOOPT)
-    e3sm_remove_flags("${ITEM}" "-O2")
-    e3sm_add_flags("${ITEM}" "-O0")
-  endforeach()
-endif()
+#if (NOT DEBUG)
+#  foreach(ITEM IN LISTS NOOPT)
+#    e3sm_remove_flags("${ITEM}" "-O2")
+#    e3sm_add_flags("${ITEM}" "-O0")
+#  endforeach()
+#endif()
 
 
 

--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -431,7 +431,8 @@
       <directive> -G 0</directive>
     </directives>
     <queues>
-      <queue walltimemax="00:45:00" nodemax="1500" default="true">regular</queue>
+      <queue walltimemax="00:45:00" nodemax="1600" default="true">regular</queue>
+      <queue walltimemax="00:45:00" nodemax="1600" strict="true">preempt</queue>
       <queue walltimemax="00:15:00" nodemax="4" strict="true">debug</queue>
     </queues>
   </batch_system>
@@ -441,8 +442,8 @@
       <directive> --constraint=cpu</directive>
     </directives>
     <queues>
-      <queue walltimemax="00:30:00" nodemax="1500" default="true">regular</queue>
-      <queue walltimemax="00:30:00" nodemax="1500" strict="true">preempt</queue>
+      <queue walltimemax="00:30:00" nodemax="4096" default="true">regular</queue>
+      <queue walltimemax="00:30:00" nodemax="4096" strict="true">preempt</queue>
       <queue walltimemax="00:30:00" nodemax="8" strict="true">debug</queue>
     </queues>
   </batch_system>

--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -442,7 +442,8 @@
     </directives>
     <queues>
       <queue walltimemax="00:30:00" nodemax="1500" default="true">regular</queue>
-      <queue walltimemax="00:30:00" nodemax="4" strict="true">debug</queue>
+      <queue walltimemax="00:30:00" nodemax="1500" strict="true">preempt</queue>
+      <queue walltimemax="00:30:00" nodemax="8" strict="true">debug</queue>
     </queues>
   </batch_system>
 

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -216,7 +216,7 @@
 
       <modules compiler="intel">
         <command name="load">PrgEnv-intel/8.3.3</command>
-        <command name="load">intel-oneapi/2023.0.0</command>
+        <command name="load">intel/2023.0.0</command>
       </modules>
 
       <modules compiler="nvidia">


### PR DESCRIPTION
Using `intel` instead of `intel-oneapi` avoids several issues (so from ifx 2023.0.0  to ifort 2021.8.0)

```
module load intel-oneapi
login15% ftn --version
ifx (IFORT) 2023.0.0 20221201

module load intel
login15% ftn --version
ifort (IFORT) 2021.8.0 20221119
```

Remove a work-around that was needed for intel-oneapi. 
Add option to use preempt queue (for both pm-cpu and pm-gpu).
Not BFB with Intel compiler as it changes the version used.

Fixes https://github.com/E3SM-Project/E3SM/issues/5672
Fixes https://github.com/E3SM-Project/E3SM/issues/5664
Fixes https://github.com/E3SM-Project/E3SM/issues/5605
Fixes https://github.com/E3SM-Project/E3SM/issues/5680

[NBFB]