### PR TITLE
Removes CLM from module name

### DIFF
--- a/components/elm/src/biogeochem/AllocationMod.F90
+++ b/components/elm/src/biogeochem/AllocationMod.F90
@@ -210,7 +210,7 @@ contains
     !
     ! !USES:
     use elm_varcon      , only: secspday, spval
-    use clm_time_manager, only: get_step_size
+    use elm_time_manager, only: get_step_size
     use elm_varpar      , only: crop_prog
     use elm_varctl      , only: iulog
     use elm_varctl      , only : carbon_only          
@@ -274,7 +274,7 @@ contains
 
   subroutine EvaluateSupplStatus()
 
-    use clm_time_manager, only: get_curr_date
+    use elm_time_manager, only: get_curr_date
 
     ! This module evaluates the current status of N and P
     ! supplementation, and uses that to set flags which indicates

--- a/components/elm/src/biogeochem/CH4Mod.F90
+++ b/components/elm/src/biogeochem/CH4Mod.F90
@@ -16,7 +16,7 @@ module CH4Mod
   use elm_varcon         , only : denh2o, denice, tfrz, grav, spval, rgas, grlnd
   use elm_varcon         , only : catomw, s_con, d_con_w, d_con_g, c_h_inv, kh_theta, kh_tbase
   use landunit_varcon    , only : istdlak
-  use clm_time_manager   , only : get_step_size, get_nstep
+  use elm_time_manager   , only : get_step_size, get_nstep
   use elm_varctl         , only : iulog, use_cn, use_lch4, use_fates
   use abortutils         , only : endrun
   use decompMod          , only : bounds_type

--- a/components/elm/src/biogeochem/CNAllocationBetrMod.F90
+++ b/components/elm/src/biogeochem/CNAllocationBetrMod.F90
@@ -101,7 +101,7 @@ contains
     !
     ! !USES:
     use elm_varcon      , only: secspday
-    use clm_time_manager, only: get_step_size, get_curr_date
+    use elm_time_manager, only: get_step_size, get_curr_date
     use elm_varpar      , only: crop_prog
     use elm_varctl      , only: iulog, cnallocate_carbon_only_set
     use elm_varctl      , only: cnallocate_carbonnitrogen_only_set
@@ -252,7 +252,7 @@ contains
     use elm_varcon       , only: nitrif_n2o_loss_frac, secspday
     use elm_varctl       , only: cnallocate_carbon_only_set
 !    use landunit_varcon  , only: istsoil, istcrop
-    use clm_time_manager , only: get_step_size, get_curr_date
+    use elm_time_manager , only: get_step_size, get_curr_date
     !
     ! !ARGUMENTS:
     type(bounds_type)        , intent(in)    :: bounds
@@ -1112,7 +1112,7 @@ contains
     use elm_varpar       , only:  nlevdecomp !!nlevsoi,
     use elm_varcon       , only: nitrif_n2o_loss_frac, secspday
 !    use landunit_varcon  , only: istsoil, istcrop
-!    use clm_time_manager , only: get_step_size
+!    use elm_time_manager , only: get_step_size
     !
     ! !ARGUMENTS:
     type(bounds_type)        , intent(in)    :: bounds

--- a/components/elm/src/biogeochem/CNCarbonFluxType.F90
+++ b/components/elm/src/biogeochem/CNCarbonFluxType.F90
@@ -1113,7 +1113,7 @@ contains
     !
     ! !USES:
     use shr_infnan_mod   , only : isnan => shr_infnan_isnan, nan => shr_infnan_nan, assignment(=)
-    use clm_time_manager , only : is_restart
+    use elm_time_manager , only : is_restart
     use elm_varcon       , only : c13ratio, c14ratio
     use elm_varctl       , only : use_lch4, use_betr
     use restUtilMod
@@ -1584,7 +1584,7 @@ contains
     !
     ! !USES:
     use elm_varctl       , only : iulog
-    use clm_time_manager , only : get_step_size
+    use elm_time_manager , only : get_step_size
     use elm_varcon       , only : secspday
     use elm_varpar       , only : nlevdecomp, ndecomp_pools, ndecomp_cascade_transitions
     use subgridAveMod    , only : p2c
@@ -2338,7 +2338,7 @@ subroutine CSummary_interface(this, bounds, num_soilc, filter_soilc)
    use shr_sys_mod, only: shr_sys_flush
    use elm_varpar , only: nlevdecomp_full,ndecomp_pools,ndecomp_cascade_transitions
    use elm_varpar , only: i_met_lit, i_cel_lit, i_lig_lit, i_cwd
-   use clm_time_manager    , only : get_step_size
+   use elm_time_manager    , only : get_step_size
 !
 ! !ARGUMENTS:
    implicit none

--- a/components/elm/src/biogeochem/CNCarbonStateType.F90
+++ b/components/elm/src/biogeochem/CNCarbonStateType.F90
@@ -626,7 +626,7 @@ contains
     ! !USES:
     use shr_infnan_mod   , only : isnan => shr_infnan_isnan, nan => shr_infnan_nan, assignment(=)
     use shr_const_mod    , only : SHR_CONST_PDB
-    use clm_time_manager , only : is_restart, get_nstep
+    use elm_time_manager , only : is_restart, get_nstep
     use elm_varcon       , only : c13ratio, c14ratio
     use elm_varctl       , only : spinup_mortality_factor, spinup_state
 
@@ -811,7 +811,7 @@ contains
     !
     ! !USES:
     use elm_varctl       , only: iulog
-    use clm_time_manager , only: get_step_size
+    use elm_time_manager , only: get_step_size
     use elm_varcon       , only: secspday
     use elm_varpar       , only: nlevdecomp, ndecomp_pools, nlevdecomp_full
     !

--- a/components/elm/src/biogeochem/CNEcosystemDynBetrMod.F90
+++ b/components/elm/src/biogeochem/CNEcosystemDynBetrMod.F90
@@ -104,7 +104,7 @@ module CNEcosystemDynBetrMod
     use PhosphorusDynamicsMod              , only : PhosphorusBiochemMin_balance,PhosphorusDeposition,PhosphorusWeathering
     use VerticalProfileMod      , only : decomp_vertprofiles
     use RootDynamicsMod              , only : RootDynamics
-    use clm_time_manager , only : get_step_size 
+    use elm_time_manager , only : get_step_size 
     implicit none
 
 
@@ -570,7 +570,7 @@ module CNEcosystemDynBetrMod
     !
     ! DESCRIPTION
     ! calculate gpp downregulation factor
-    use clm_time_manager         , only : get_step_size
+    use elm_time_manager         , only : get_step_size
     use ColumnType               , only : column_physical_properties
     use VegetationType           , only : vegetation_physical_properties
     use pftvarcon                , only : noveg

--- a/components/elm/src/biogeochem/CNGapMortalityBeTRMod.F90
+++ b/components/elm/src/biogeochem/CNGapMortalityBeTRMod.F90
@@ -89,7 +89,7 @@ contains
     ! Gap-phase mortality routine for coupled carbon-nitrogen code (CN)
     !
     ! !USES:
-    use clm_time_manager , only: get_days_per_year
+    use elm_time_manager , only: get_days_per_year
     use elm_varcon       , only: secspday
     use pftvarcon        , only: npcropmin
     use elm_varctl       , only: spinup_state, spinup_mortality_factor

--- a/components/elm/src/biogeochem/CNNStateUpdate1BeTRMod.F90
+++ b/components/elm/src/biogeochem/CNNStateUpdate1BeTRMod.F90
@@ -5,7 +5,7 @@ module CNNStateUpdate1BeTRMod
   !
   ! !USES:
   use shr_kind_mod           , only: r8 => shr_kind_r8
-  use clm_time_manager       , only : get_step_size
+  use elm_time_manager       , only : get_step_size
   use elm_varpar             , only : nlevdecomp, ndecomp_pools, ndecomp_cascade_transitions
   use elm_varpar             , only : crop_prog, i_met_lit, i_cel_lit, i_lig_lit, i_cwd
   use elm_varctl             , only : iulog

--- a/components/elm/src/biogeochem/CNNStateUpdate2BeTRMod.F90
+++ b/components/elm/src/biogeochem/CNNStateUpdate2BeTRMod.F90
@@ -6,7 +6,7 @@ module CNNStateUpdate2BeTRMod
   !
   ! !USES:
   use shr_kind_mod        , only : r8 => shr_kind_r8
-  use clm_time_manager    , only : get_step_size
+  use elm_time_manager    , only : get_step_size
   use elm_varpar          , only : nlevsoi, nlevdecomp
   use elm_varpar          , only : i_met_lit, i_cel_lit, i_lig_lit, i_cwd
   use elm_varctl          , only : iulog

--- a/components/elm/src/biogeochem/CNNStateUpdate3BeTRMod.F90
+++ b/components/elm/src/biogeochem/CNNStateUpdate3BeTRMod.F90
@@ -8,7 +8,7 @@ module CNNStateUpdate3BeTRMod
   ! !USES:
   use shr_kind_mod        , only: r8 => shr_kind_r8
   use elm_varpar          , only: nlevdecomp, ndecomp_pools
-  use clm_time_manager    , only : get_step_size
+  use elm_time_manager    , only : get_step_size
   use elm_varctl          , only : iulog
   use elm_varpar          , only : i_cwd, i_met_lit, i_cel_lit, i_lig_lit
   use CNNitrogenStateType , only : nitrogenstate_type

--- a/components/elm/src/biogeochem/CNNitrogenFluxType.F90
+++ b/components/elm/src/biogeochem/CNNitrogenFluxType.F90
@@ -1055,7 +1055,7 @@ subroutine NSummary_interface(this,bounds,num_soilc, filter_soilc)
 ! !USES:
    use elm_varpar  , only: nlevdecomp_full, ndecomp_pools
    use elm_varpar  , only: i_met_lit, i_cel_lit, i_lig_lit, i_cwd
-   use clm_time_manager    , only : get_step_size
+   use elm_time_manager    , only : get_step_size
 
 !   use elm_varctl    , only: pf_hmode
 !

--- a/components/elm/src/biogeochem/CNNitrogenStateType.F90
+++ b/components/elm/src/biogeochem/CNNitrogenStateType.F90
@@ -669,7 +669,7 @@ contains
     !
     ! !USES:
     use shr_infnan_mod      , only : isnan => shr_infnan_isnan, nan => shr_infnan_nan, assignment(=)
-    use clm_time_manager    , only : is_restart, get_nstep
+    use elm_time_manager    , only : is_restart, get_nstep
     use elm_varctl          , only : spinup_mortality_factor
     use CNStateType         , only : cnstate_type
     use restUtilMod

--- a/components/elm/src/biogeochem/CNPBudgetMod.F90
+++ b/components/elm/src/biogeochem/CNPBudgetMod.F90
@@ -367,7 +367,7 @@ contains
   !-----------------------------------------------------------------------
   subroutine Reset(mode, budg_fluxL, budg_fluxG, budg_fluxN, budg_stateL, budg_stateG)
     !
-    use clm_time_manager, only : get_curr_date, get_prev_date
+    use elm_time_manager, only : get_curr_date, get_prev_date
     !
     implicit none
     !
@@ -514,7 +514,7 @@ contains
 !-----------------------------------------------------------------------
   subroutine Accum(s_size, budg_fluxN, budg_fluxL, budg_stateL, budg_stateG)
     !
-    use clm_time_manager, only : get_curr_date, get_prev_date, get_nstep
+    use elm_time_manager, only : get_curr_date, get_prev_date, get_nstep
     !
     implicit none
     !
@@ -759,7 +759,7 @@ contains
        budg_print_inst,  budg_print_daily,  budg_print_month,  &
        budg_print_ann,  budg_print_ltann,  budg_print_ltend)
     !
-    use clm_time_manager, only : get_curr_date, get_prev_date, get_nstep, get_step_size
+    use elm_time_manager, only : get_curr_date, get_prev_date, get_nstep, get_step_size
     use shr_const_mod   , only : shr_const_pi
     !
     implicit none
@@ -847,7 +847,7 @@ contains
   !-----------------------------------------------------------------------
   subroutine CarbonBudget_Message(ip, cdate, sec, f_size, s_size, budg_stateG, budg_fluxG, budg_fluxGpr, unit_conversion)
     !
-    use clm_time_manager, only : get_curr_date, get_prev_date, get_nstep, get_step_size
+    use elm_time_manager, only : get_curr_date, get_prev_date, get_nstep, get_step_size
     use shr_const_mod   , only : shr_const_pi
     !
     implicit none
@@ -1117,7 +1117,7 @@ contains
     use elm_varcon       , only : spval
     use column_varcon    , only : icol_roof, icol_sunwall, icol_shadewall
     use column_varcon    , only : icol_road_perv, icol_road_imperv
-    use clm_time_manager , only : get_curr_date, get_prev_date, get_nstep
+    use elm_time_manager , only : get_curr_date, get_prev_date, get_nstep
     use GridcellDataType , only : gridcell_carbon_state
     use ColumnDataType   , only : column_carbon_state
     !
@@ -1177,7 +1177,7 @@ contains
     use elm_varcon       , only : spval
     use column_varcon    , only : icol_roof, icol_sunwall, icol_shadewall
     use column_varcon    , only : icol_road_perv, icol_road_imperv
-    use clm_time_manager , only : get_curr_date, get_prev_date, get_nstep
+    use elm_time_manager , only : get_curr_date, get_prev_date, get_nstep
     use GridcellDataType , only : gridcell_carbon_state
     use ColumnDataType   , only : column_carbon_state
     !

--- a/components/elm/src/biogeochem/CNPhenologyBeTRMod.F90
+++ b/components/elm/src/biogeochem/CNPhenologyBeTRMod.F90
@@ -287,7 +287,7 @@ contains
     ! initialized, and after ecophyscon file is read in.
     !
     ! !USES:
-    use clm_time_manager, only: get_step_size
+    use elm_time_manager, only: get_step_size
     use elm_varpar      , only: crop_prog
     use elm_varcon      , only: secspday
     !
@@ -355,8 +355,8 @@ contains
     ! For coupled carbon-nitrogen code (CN).
     !
     ! !USES:
-    use clm_time_manager , only : get_days_per_year
-    use clm_time_manager , only : get_curr_date, is_first_step
+    use elm_time_manager , only : get_days_per_year
+    use elm_time_manager , only : get_curr_date, is_first_step
     !
     ! !ARGUMENTS:
     integer                , intent(in)    :: num_soilp       ! number of soil patches in filter
@@ -445,7 +445,7 @@ contains
     !
     ! !USES:
     use elm_varcon       , only : secspday
-    use clm_time_manager , only : get_days_per_year
+    use elm_time_manager , only : get_days_per_year
     !
     ! !ARGUMENTS:
     integer           , intent(in)    :: num_soilp       ! number of soil patches in filter
@@ -843,7 +843,7 @@ contains
     ! per year.
     !
     ! !USES:
-    use clm_time_manager , only : get_days_per_year
+    use elm_time_manager , only : get_days_per_year
     use elm_varcon       , only : secspday
     use shr_const_mod    , only : SHR_CONST_TKFRZ, SHR_CONST_PI
     !
@@ -1317,7 +1317,7 @@ contains
     ! handle CN fluxes during the phenological onset                       & offset periods.
 
     ! !USES:
-    use clm_time_manager , only : get_curr_date, get_curr_calday, get_days_per_year
+    use elm_time_manager , only : get_curr_date, get_curr_calday, get_days_per_year
     use pftvarcon        , only : ncorn, nscereal, nwcereal, nsoybean, gddmin, hybgdd
     use pftvarcon        , only : nwcerealirrig, nsoybeanirrig, ncornirrig, nscerealirrig
     use pftvarcon        , only : lfemerg, grnfill, mxmat, minplanttemp, planttemp
@@ -1858,7 +1858,7 @@ contains
     use pftvarcon       , only: npcropmin, npcropmax, mnNHplantdate
     use pftvarcon       , only: mnSHplantdate, mxNHplantdate
     use pftvarcon       , only: mxSHplantdate
-    use clm_time_manager, only: get_calday
+    use elm_time_manager, only: get_calday
     !
     ! !ARGUMENTS:
     implicit none
@@ -2067,8 +2067,8 @@ contains
     ! CropPhenologyMod
     !
     ! !USES:
-    use clm_time_manager , only : get_curr_date
-    use clm_time_manager , only : get_step_size
+    use elm_time_manager , only : get_curr_date
+    use elm_time_manager , only : get_step_size
     use elm_varcon       , only : secspday
     use elm_varpar       , only : numpft
     use pftvarcon        , only : planttemp

--- a/components/elm/src/biogeochem/CropType.F90
+++ b/components/elm/src/biogeochem/CropType.F90
@@ -324,7 +324,7 @@ contains
     !
     ! !USES:
     use accumulMod       , only : extract_accum_field
-    use clm_time_manager , only : get_nstep
+    use elm_time_manager , only : get_nstep
     !
     ! !ARGUMENTS:
     class(crop_type),  intent(inout) :: this
@@ -576,7 +576,7 @@ contains
     ! !USES:
     use accumulMod       , only : update_accum_field, extract_accum_field, accumResetVal
     use shr_const_mod    , only : SHR_CONST_CDAY, SHR_CONST_TKFRZ
-    use clm_time_manager , only : get_step_size, get_nstep
+    use elm_time_manager , only : get_step_size, get_nstep
     use pftvarcon        , only : nwcereal, nwcerealirrig, mxtmp, baset
     use TemperatureType  , only : temperature_type
     use VegetationType   , only : veg_pp                
@@ -665,7 +665,7 @@ contains
     ! This routine should be called every time step
     !
     ! !USES:
-    use clm_time_manager , only : get_curr_date, is_first_step
+    use elm_time_manager , only : get_curr_date, is_first_step
     !
     ! !ARGUMENTS:
     class(crop_type) :: this
@@ -711,7 +711,7 @@ contains
     ! messes up these bits of saved information.
     !
     ! !ARGUMENTS:
-    use clm_time_manager, only : get_driver_start_ymd, get_start_date
+    use elm_time_manager, only : get_driver_start_ymd, get_start_date
     use elm_varctl      , only : iulog
     use elm_varctl      , only : nsrest, nsrBranch, nsrStartup
     !

--- a/components/elm/src/biogeochem/DecompCascadeBGCMod.F90
+++ b/components/elm/src/biogeochem/DecompCascadeBGCMod.F90
@@ -280,7 +280,7 @@ contains
     !  written by C. Koven
     !
     ! !USES:
-     use clm_time_manager , only : get_step_size
+     use elm_time_manager , only : get_step_size
     !
     ! !ARGUMENTS:
     type(bounds_type)    , intent(in)    :: bounds

--- a/components/elm/src/biogeochem/DryDepVelocity.F90
+++ b/components/elm/src/biogeochem/DryDepVelocity.F90
@@ -47,7 +47,7 @@ Module DryDepVelocity
   use shr_log_mod          , only : errMsg => shr_log_errMsg
   use shr_kind_mod         , only : r8 => shr_kind_r8
   use abortutils           , only : endrun
-  use clm_time_manager     , only : get_nstep, get_curr_date, get_curr_time
+  use elm_time_manager     , only : get_nstep, get_curr_date, get_curr_time
   use spmdMod              , only : masterproc
   use seq_drydep_mod       , only : n_drydep, drydep_list
   use seq_drydep_mod       , only : drydep_method, DD_XLND

--- a/components/elm/src/biogeochem/EcosystemBalanceCheckMod.F90
+++ b/components/elm/src/biogeochem/EcosystemBalanceCheckMod.F90
@@ -11,7 +11,7 @@ module EcosystemBalanceCheckMod
   use decompMod           , only : bounds_type
   use abortutils          , only : endrun
   use elm_varctl          , only : iulog, use_fates
-  use clm_time_manager    , only : get_step_size,get_nstep
+  use elm_time_manager    , only : get_step_size,get_nstep
   use elm_varpar          , only : crop_prog
   use elm_varpar          , only : nlevdecomp
   use elm_varcon          , only : dzsoi_decomp
@@ -26,7 +26,7 @@ module EcosystemBalanceCheckMod
   ! bgc interface & pflotran:
   use elm_varctl          , only : use_pflotran, pf_cmode, pf_hmode
   ! forest fertilization experiment
-  use clm_time_manager    , only : get_curr_date
+  use elm_time_manager    , only : get_curr_date
   use CNStateType         , only : fert_type , fert_continue, fert_dose, fert_start, fert_end
   use elm_varctl          , only : forest_fert_exp
   use pftvarcon           , only: noveg

--- a/components/elm/src/biogeochem/FATESFireDataMod.F90
+++ b/components/elm/src/biogeochem/FATESFireDataMod.F90
@@ -128,7 +128,7 @@ contains
     !
     ! !USES
     use accumulMod       , only : extract_accum_field
-    use clm_time_manager , only : get_nstep
+    use elm_time_manager , only : get_nstep
     !
     ! !ARGUMENTS:
     class(fates_fire_data_type) :: this
@@ -164,7 +164,7 @@ contains
   subroutine UpdateAccVars (this, bounds)
     !
     ! USES
-    use clm_time_manager, only: get_nstep
+    use elm_time_manager, only: get_nstep
     use accumulMod      , only: update_accum_field, extract_accum_field
     use abortutils      , only: endrun
     !

--- a/components/elm/src/biogeochem/FireDataBaseType.F90
+++ b/components/elm/src/biogeochem/FireDataBaseType.F90
@@ -145,7 +145,7 @@ module FireDataBaseType
       ! Initialize data stream information for population density.
       !
       ! !USES:
-      use clm_time_manager , only : get_calendar
+      use elm_time_manager , only : get_calendar
       use ncdio_pio        , only : pio_subsystem
       use shr_pio_mod      , only : shr_pio_getiotype
       use elm_nlUtilsMod   , only : find_nlgroup_name
@@ -265,7 +265,7 @@ module FireDataBaseType
      ! Interpolate data stream information for population density.
      !
      ! !USES:
-     use clm_time_manager, only : get_curr_date
+     use elm_time_manager, only : get_curr_date
      !
      ! !ARGUMENTS:
      class(fire_base_type)       :: this
@@ -301,7 +301,7 @@ module FireDataBaseType
      ! Initialize data stream information for Lightning.
      !
      ! !USES:
-     use clm_time_manager , only : get_calendar
+     use elm_time_manager , only : get_calendar
      use ncdio_pio        , only : pio_subsystem
      use shr_pio_mod      , only : shr_pio_getiotype
      use elm_nlUtilsMod   , only : find_nlgroup_name
@@ -421,7 +421,7 @@ module FireDataBaseType
      ! Interpolate data stream information for Lightning.
      !
      ! !USES:
-     use clm_time_manager, only : get_curr_date
+     use elm_time_manager, only : get_curr_date
      !
      ! !ARGUMENTS:
      class(fire_base_type)       :: this

--- a/components/elm/src/biogeochem/FireMod.F90
+++ b/components/elm/src/biogeochem/FireMod.F90
@@ -1464,7 +1464,7 @@ contains
    !
    ! !USES:
    use elm_varctl       , only : inst_name
-   use clm_time_manager , only : get_calendar
+   use elm_time_manager , only : get_calendar
    use ncdio_pio        , only : pio_subsystem
    use shr_pio_mod      , only : shr_pio_getiotype
    use elm_nlUtilsMod   , only : find_nlgroup_name
@@ -1581,7 +1581,7 @@ subroutine hdm_interp(bounds)
   ! Interpolate data stream information for population density.
   !
   ! !USES:
-  use clm_time_manager, only : get_curr_date
+  use elm_time_manager, only : get_curr_date
   !
   ! !ARGUMENTS:
   type(bounds_type), intent(in) :: bounds
@@ -1615,7 +1615,7 @@ subroutine lnfm_init( bounds )
   !
   ! !USES:
   use elm_varctl       , only : inst_name
-  use clm_time_manager , only : get_calendar
+  use elm_time_manager , only : get_calendar
   use ncdio_pio        , only : pio_subsystem
   use shr_pio_mod      , only : shr_pio_getiotype
   use elm_nlUtilsMod   , only : find_nlgroup_name
@@ -1731,7 +1731,7 @@ subroutine lnfm_interp(bounds )
   ! Interpolate data stream information for Lightning.
   !
   ! !USES:
-  use clm_time_manager, only : get_curr_date
+  use elm_time_manager, only : get_curr_date
   !
   ! !ARGUMENTS:
   type(bounds_type), intent(in) :: bounds

--- a/components/elm/src/biogeochem/NitrogenStateUpdate1Mod.F90
+++ b/components/elm/src/biogeochem/NitrogenStateUpdate1Mod.F90
@@ -21,7 +21,7 @@ module NitrogenStateUpdate1Mod
   ! bgc interface & pflotran:
   use elm_varctl             , only : use_pflotran, pf_cmode
   ! forest fertilization experiment
-  use clm_time_manager       , only : get_curr_date
+  use elm_time_manager       , only : get_curr_date
   use CNStateType            , only : fert_type , fert_continue, fert_dose, fert_start, fert_end
   use elm_varctl             , only : forest_fert_exp
   use elm_varctl             , only : nu_com

--- a/components/elm/src/biogeochem/PhenologyFluxLimitMod.F90
+++ b/components/elm/src/biogeochem/PhenologyFluxLimitMod.F90
@@ -9,7 +9,7 @@ module PhenologyFLuxLimitMod
   use shr_kind_mod                , only : r8 => shr_kind_r8
   use VegetationType              , only : veg_pp
   use VegetationPropertiesType    , only : veg_vp
-  use clm_time_manager            , only : get_step_size
+  use elm_time_manager            , only : get_step_size
   use pftvarcon                   , only : npcropmin
   use elm_varctl                  , only : iulog
   use abortutils                  , only : endrun

--- a/components/elm/src/biogeochem/PhenologyMod.F90
+++ b/components/elm/src/biogeochem/PhenologyMod.F90
@@ -352,7 +352,7 @@ contains
     ! initialized, and after ecophyscon file is read in.
     !
     ! !USES:
-    use clm_time_manager, only: get_step_size
+    use elm_time_manager, only: get_step_size
     use elm_varpar      , only: crop_prog
     use elm_varcon      , only: secspday
     !
@@ -1939,7 +1939,7 @@ contains
     ! Code based on ORCHIDEE-MICT-BIOENERGY model (Li et al., 2018)
     ! !USES:
     use shr_const_mod    , only : SHR_CONST_TKFRZ
-    use clm_time_manager , only : get_curr_calday, get_days_per_year
+    use elm_time_manager , only : get_curr_calday, get_days_per_year
     use pftvarcon        , only : gddmin, hybgdd
     use pftvarcon        , only : minplanttemp, planttemp, senestemp, min_days_senes
     use elm_varcon       , only : spval, secspday
@@ -2151,7 +2151,7 @@ contains
     use pftvarcon       , only: npcropmin, npcropmax, nppercropmin, nppercropmax, mnNHplantdate
     use pftvarcon       , only: mnSHplantdate, mxNHplantdate
     use pftvarcon       , only: mxSHplantdate
-    use clm_time_manager, only: get_calday
+    use elm_time_manager, only: get_calday
     !
     ! !ARGUMENTS:
     implicit none

--- a/components/elm/src/biogeochem/PhosphorusStateType.F90
+++ b/components/elm/src/biogeochem/PhosphorusStateType.F90
@@ -313,7 +313,7 @@ contains
     !
     ! !USES:
     use shr_infnan_mod      , only : isnan => shr_infnan_isnan, nan => shr_infnan_nan, assignment(=)
-    use clm_time_manager    , only : is_restart, get_nstep
+    use elm_time_manager    , only : is_restart, get_nstep
     use elm_varctl          , only : spinup_mortality_factor
     use CNStateType         , only : cnstate_type
     use restUtilMod

--- a/components/elm/src/biogeochem/PhosphorusStateUpdate1Mod.F90
+++ b/components/elm/src/biogeochem/PhosphorusStateUpdate1Mod.F90
@@ -19,7 +19,7 @@ module PhosphorusStateUpdate1Mod
   use elm_varctl             , only : use_pflotran, pf_cmode
   use elm_varctl             , only : nu_com
   ! forest fertilization experiment
-  use clm_time_manager       , only : get_curr_date
+  use elm_time_manager       , only : get_curr_date
   use CNStateType            , only : fert_type , fert_continue, fert_dose, fert_start, fert_end
   use elm_varctl             , only : forest_fert_exp
   use elm_varctl             , only : NFIX_PTASE_plant

--- a/components/elm/src/biogeochem/SatellitePhenologyMod.F90
+++ b/components/elm/src/biogeochem/SatellitePhenologyMod.F90
@@ -75,7 +75,7 @@ contains
     !
     ! !USES:
     use elm_varctl       , only : inst_name
-    use clm_time_manager , only : get_calendar
+    use elm_time_manager , only : get_calendar
     use ncdio_pio        , only : pio_subsystem
     use shr_pio_mod      , only : shr_pio_getiotype
     use elm_nlUtilsMod   , only : find_nlgroup_name
@@ -201,7 +201,7 @@ contains
     ! Interpolate data stream information for Lai.
     !
     ! !USES:
-    use clm_time_manager, only : get_curr_date
+    use elm_time_manager, only : get_curr_date
     use pftvarcon       , only : noveg
     !
     ! !ARGUMENTS:
@@ -413,7 +413,7 @@ contains
     !
     ! !USES:
     use elm_varctl      , only : fsurdat
-    use clm_time_manager, only : get_curr_date, get_step_size, get_nstep
+    use elm_time_manager, only : get_curr_date, get_step_size, get_nstep
     !
     ! !ARGUMENTS:
     type(bounds_type), intent(in) :: bounds
@@ -574,7 +574,7 @@ contains
     use fileutils        , only : getfil
     use spmdMod          , only : masterproc, mpicom, MPI_REAL8, MPI_INTEGER
     use shr_scam_mod     , only : shr_scam_getCloseLatLon
-    use clm_time_manager , only : get_nstep
+    use elm_time_manager , only : get_nstep
     use netcdf
     !
     ! !ARGUMENTS:

--- a/components/elm/src/biogeochem/VegStructUpdateMod.F90
+++ b/components/elm/src/biogeochem/VegStructUpdateMod.F90
@@ -40,7 +40,7 @@ contains
     use pftvarcon        , only : noveg, nc3crop, nc3irrig, nbrdlf_evr_shrub, nbrdlf_dcd_brl_shrub
     use pftvarcon        , only : ncorn, ncornirrig, npcropmin, ztopmx, laimx
     use pftvarcon        , only : nmiscanthus, nmiscanthusirrig, nswitchgrass, nswitchgrassirrig
-    use clm_time_manager , only : get_rad_step_size
+    use elm_time_manager , only : get_rad_step_size
     use elm_varctl       , only : spinup_state, spinup_mortality_factor
     !
     ! !ARGUMENTS:

--- a/components/elm/src/biogeochem/WoodProductsMod.F90
+++ b/components/elm/src/biogeochem/WoodProductsMod.F90
@@ -8,7 +8,7 @@ module WoodProductsMod
   use decompMod           , only : get_proc_bounds
   use spmdMod             , only : masterproc
   use landunit_varcon     , only : istsoil
-  use clm_time_manager    , only : get_step_size
+  use elm_time_manager    , only : get_step_size
   use elm_varctl          , only : use_c13, use_c14
 
   use ColumnDataType      , only : col_cs, c13_col_cs, c14_col_cs

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -45,7 +45,7 @@ contains
     ! !USES:
     use shr_const_mod    , only : SHR_CONST_TKFRZ
     use elm_varpar       , only : nlevgrnd
-    use clm_time_manager , only : get_curr_date, get_step_size
+    use elm_time_manager , only : get_curr_date, get_step_size
     use elm_varctl       , only : iulog
     use elm_varcon       , only : zsoi
     !

--- a/components/elm/src/biogeophys/AerosolMod.F90
+++ b/components/elm/src/biogeophys/AerosolMod.F90
@@ -6,7 +6,7 @@ module AerosolMod
   use decompMod        , only : bounds_type
   use elm_varpar       , only : nlevsno 
   use elm_varctl       , only : use_extrasnowlayers
-  use clm_time_manager , only : get_step_size
+  use elm_time_manager , only : get_step_size
   use atm2lndType      , only : atm2lnd_type
   use AerosolType      , only : aerosol_type
   use ColumnType       , only : col_pp

--- a/components/elm/src/biogeophys/BareGroundFluxesMod.F90
+++ b/components/elm/src/biogeophys/BareGroundFluxesMod.F90
@@ -51,7 +51,7 @@ contains
     use FrictionVelocityMod  , only : FrictionVelocity, MoninObukIni, implicit_stress
     use QSatMod              , only : QSat
     use SurfaceResistanceMod , only : do_soilevap_beta
-    use clm_time_manager     , only : get_nstep
+    use elm_time_manager     , only : get_nstep
     !
     ! !ARGUMENTS:
     type(bounds_type)      , intent(in)    :: bounds

--- a/components/elm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/elm/src/biogeophys/CanopyHydrologyMod.F90
@@ -122,9 +122,9 @@ contains
      use atm2lndType        , only : atm2lnd_type
      !use domainMod          , only : ldomain
      use TopounitType       , only : top_pp
-     use clm_time_manager   , only : get_step_size
+     use elm_time_manager   , only : get_step_size
      use subgridAveMod      , only : p2c,p2g
-     use clm_time_manager   , only : get_step_size, get_prev_date, get_nstep
+     use elm_time_manager   , only : get_step_size, get_prev_date, get_nstep
      use SnowHydrologyMod   , only : NewSnowBulkDensity
      !
      ! !ARGUMENTS:

--- a/components/elm/src/biogeophys/CanopyStateType.F90
+++ b/components/elm/src/biogeophys/CanopyStateType.F90
@@ -368,7 +368,7 @@ contains
     !
     ! !USES
     use accumulMod       , only : extract_accum_field
-    use clm_time_manager , only : get_nstep
+    use elm_time_manager , only : get_nstep
     !
     ! !ARGUMENTS:
     class(canopystate_type) :: this
@@ -414,7 +414,7 @@ contains
   subroutine UpdateAccVars (this, bounds)
     !
     ! USES
-    use clm_time_manager, only : get_nstep
+    use elm_time_manager, only : get_nstep
     use accumulMod      , only : update_accum_field, extract_accum_field
     use abortutils      , only : endrun
     !

--- a/components/elm/src/biogeophys/LakeFluxesMod.F90
+++ b/components/elm/src/biogeophys/LakeFluxesMod.F90
@@ -58,7 +58,7 @@ contains
     use LakeCon             , only : minz0lake, cur0, cus, curm, fcrit
     use QSatMod             , only : QSat
     use FrictionVelocityMod , only : FrictionVelocity, MoninObukIni, implicit_stress
-    use clm_time_manager    , only : get_nstep
+    use elm_time_manager    , only : get_nstep
     !
     ! !ARGUMENTS:
     type(bounds_type)      , intent(in)    :: bounds

--- a/components/elm/src/biogeophys/LakeHydrologyMod.F90
+++ b/components/elm/src/biogeophys/LakeHydrologyMod.F90
@@ -75,7 +75,7 @@ contains
     use elm_varcon      , only : denh2o, denice, spval, hfus, tfrz, cpliq, cpice
     use elm_varpar      , only : nlevsno, nlevgrnd, nlevsoi
     use elm_varctl      , only : iulog, use_extrasnowlayers, use_lake_wat_storage
-    use clm_time_manager, only : get_step_size
+    use elm_time_manager, only : get_step_size
     use SnowHydrologyMod, only : SnowCompaction, CombineSnowLayers, SnowWater, BuildSnowFilter
     use SnowHydrologyMod, only : DivideSnowLayers, DivideExtraSnowLayers, SnowCapping
     use LakeCon         , only : lsadz

--- a/components/elm/src/biogeophys/SedYieldMod.F90
+++ b/components/elm/src/biogeophys/SedYieldMod.F90
@@ -60,7 +60,7 @@ contains
     ! runoff.
     !
     ! !USES:
-    use clm_time_manager, only : get_step_size
+    use elm_time_manager, only : get_step_size
     use landunit_varcon , only : istcrop, istsoil, istice
     use pftvarcon       , only : gcbc_p, gcbc_q, gcbr_p, gcbr_q 
     use pftvarcon       , only : nc4_grass

--- a/components/elm/src/biogeophys/SnowSnicarMod.F90
+++ b/components/elm/src/biogeophys/SnowSnicarMod.F90
@@ -1804,7 +1804,7 @@ contains
      ! !USES:
       !$acc routine seq
      use elm_varpar       , only : nlevsno, numrad
-     use clm_time_manager , only : get_nstep
+     use elm_time_manager , only : get_nstep
      use shr_const_mod    , only : SHR_CONST_PI
      use elm_varctl       , only : snow_shape, snicar_atm_type, use_dust_snow_internal_mixing
      !

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -265,7 +265,7 @@ contains
      use elm_varcon       , only : pondmx, watmin
      use column_varcon    , only : icol_roof, icol_road_imperv, icol_sunwall, icol_shadewall, icol_road_perv
      use landunit_varcon  , only : istsoil, istcrop
-     use clm_time_manager , only : get_step_size, get_nstep
+     use elm_time_manager , only : get_step_size, get_nstep
      use atm2lndType      , only : atm2lnd_type ! land river two way coupling
      use lnd2atmType      , only : lnd2atm_type
      use subgridAveMod    , only : c2g

--- a/components/elm/src/biogeophys/SoilWaterMovementMod.F90
+++ b/components/elm/src/biogeophys/SoilWaterMovementMod.F90
@@ -275,7 +275,7 @@ contains
     use elm_varcon           , only : wimp,grav,hfus,tfrz
     use elm_varcon           , only : e_ice,denh2o, denice
     use elm_varpar           , only : nlevsoi, max_patch_per_col, nlevgrnd
-    use clm_time_manager     , only : get_step_size
+    use elm_time_manager     , only : get_step_size
     use column_varcon        , only : icol_roof, icol_road_imperv
     use TridiagonalMod       , only : Tridiagonal
     use SoilStateType        , only : soilstate_type
@@ -859,7 +859,7 @@ contains
      use decompMod                 , only : bounds_type
      use elm_varcon                , only : denh2o
      use elm_varpar                , only : nlevsoi, max_patch_per_col, nlevgrnd
-      use clm_time_manager          , only : get_step_size
+      use elm_time_manager          , only : get_step_size
      use SoilStateType             , only : soilstate_type
      use SoilHydrologyType         , only : soilhydrology_type
      use TemperatureType           , only : temperature_type

--- a/components/elm/src/biogeophys/TemperatureType.F90
+++ b/components/elm/src/biogeophys/TemperatureType.F90
@@ -376,7 +376,7 @@ contains
     !
     ! !USES 
     use accumulMod       , only : init_accum_field
-    use clm_time_manager , only : get_step_size
+    use elm_time_manager , only : get_step_size
     use shr_const_mod    , only : SHR_CONST_CDAY, SHR_CONST_TKFRZ
     !
     ! !ARGUMENTS:
@@ -403,7 +403,7 @@ contains
     !
     ! !USES 
     use accumulMod       , only : init_accum_field, extract_accum_field
-    use clm_time_manager , only : get_nstep
+    use elm_time_manager , only : get_nstep
     use elm_varctl       , only : nsrest, nsrStartup
     use abortutils       , only : endrun
     !
@@ -426,7 +426,7 @@ contains
     !
     ! USES
     use shr_const_mod    , only : SHR_CONST_CDAY, SHR_CONST_TKFRZ
-    use clm_time_manager , only : get_step_size, get_nstep, is_end_curr_day, get_curr_date
+    use elm_time_manager , only : get_step_size, get_nstep, is_end_curr_day, get_curr_date
     use accumulMod       , only : update_accum_field, extract_accum_field, accumResetVal
     !
     ! !ARGUMENTS:

--- a/components/elm/src/biogeophys/UrbanFluxesMod.F90
+++ b/components/elm/src/biogeophys/UrbanFluxesMod.F90
@@ -28,7 +28,7 @@ module UrbanFluxesMod
   use ColumnDataType       , only : col_es, col_ef, col_ws
   use VegetationType       , only : veg_pp
   use VegetationDataType   , only : veg_es, veg_ef, veg_ws, veg_wf
-  use clm_time_manager    , only : get_curr_date, get_step_size, get_nstep
+  use elm_time_manager    , only : get_curr_date, get_step_size, get_nstep
 
   use timeinfoMod  , only : nstep_mod, year_curr, mon_curr, day_curr, secs_curr
   use timeinfoMod  , only : dtime_mod

--- a/components/elm/src/biogeophys/WaterBudgetMod.F90
+++ b/components/elm/src/biogeophys/WaterBudgetMod.F90
@@ -120,7 +120,7 @@ contains
   !-----------------------------------------------------------------------
   subroutine WaterBudget_Reset(mode)
     !
-    use clm_time_manager, only : get_curr_date, get_prev_date
+    use elm_time_manager, only : get_curr_date, get_prev_date
     !
     implicit none
     !
@@ -213,7 +213,7 @@ contains
 !-----------------------------------------------------------------------
   subroutine WaterBudget_Accum()
     !
-    use clm_time_manager, only : get_curr_date, get_prev_date, get_nstep
+    use elm_time_manager, only : get_curr_date, get_prev_date, get_nstep
     !
     implicit none
     !
@@ -390,7 +390,7 @@ contains
   subroutine WaterBudget_Print(budg_print_inst,  budg_print_daily,  budg_print_month,  &
        budg_print_ann,  budg_print_ltann,  budg_print_ltend)
     !
-    use clm_time_manager, only : get_curr_date, get_prev_date, get_nstep, get_step_size
+    use elm_time_manager, only : get_curr_date, get_prev_date, get_nstep, get_step_size
     use shr_const_mod   , only : shr_const_pi
     !
     implicit none
@@ -682,7 +682,7 @@ contains
     use elm_varcon       , only : spval
     use column_varcon    , only : icol_roof, icol_sunwall, icol_shadewall
     use column_varcon    , only : icol_road_perv, icol_road_imperv
-    use clm_time_manager , only : get_curr_date, get_prev_date, get_nstep
+    use elm_time_manager , only : get_curr_date, get_prev_date, get_nstep
     !
     ! !ARGUMENTS:
     type(bounds_type)         , intent(in)    :: bounds
@@ -735,7 +735,7 @@ contains
     ! !USES:
     use subgridAveMod    , only : c2g
     use elm_varcon       , only : spval
-    use clm_time_manager , only : get_curr_date, get_nstep 
+    use elm_time_manager , only : get_curr_date, get_nstep 
 
     ! !ARGUMENTS:
     type(bounds_type)         , intent(in)    :: bounds

--- a/components/elm/src/biogeophys/WaterStateType.F90
+++ b/components/elm/src/biogeophys/WaterStateType.F90
@@ -496,7 +496,7 @@ contains
     use elm_varcon       , only : denice, denh2o, pondmx, watmin, spval  
     use landunit_varcon  , only : istcrop, istdlak, istsoil  
     use column_varcon    , only : icol_roof, icol_sunwall, icol_shadewall
-    use clm_time_manager , only : is_first_step
+    use elm_time_manager , only : is_first_step
     use elm_varctl       , only : bound_h2osoi, use_lake_wat_storage
     use ncdio_pio        , only : file_desc_t, ncd_io, ncd_double
     use restUtilMod

--- a/components/elm/src/cpl/lnd_comp_esmf.F90
+++ b/components/elm/src/cpl/lnd_comp_esmf.F90
@@ -76,7 +76,7 @@ contains
     use shr_file_mod     , only : shr_file_setLogUnit, shr_file_setLogLevel
     use shr_file_mod     , only : shr_file_getLogUnit, shr_file_getLogLevel
     use shr_file_mod     , only : shr_file_getUnit, shr_file_setIO
-    use clm_time_manager , only : get_nstep, get_step_size, set_timemgr_init, set_nextsw_cday
+    use elm_time_manager , only : get_nstep, get_step_size, set_timemgr_init, set_nextsw_cday
     use elm_initializeMod, only : initialize1, initialize2, initialize3
     use elm_instMod      , only : lnd2atm_vars, lnd2glc_vars
     use elm_varctl       , only : finidat,single_column, elm_varctl_set, noland
@@ -461,8 +461,8 @@ contains
     use elm_instMod       , only : lnd2atm_vars, atm2lnd_vars, lnd2glc_vars, glc2lnd_vars
     use elm_driver        , only : elm_drv
     use elm_varorb        , only : eccen, obliqr, lambm0, mvelpp
-    use clm_time_manager  , only : get_curr_date, get_nstep, get_curr_calday, get_step_size
-    use clm_time_manager  , only : advance_timestep, set_nextsw_cday,update_rad_dtime
+    use elm_time_manager  , only : get_curr_date, get_nstep, get_curr_calday, get_step_size
+    use elm_time_manager  , only : advance_timestep, set_nextsw_cday,update_rad_dtime
     use seq_timemgr_mod   , only : seq_timemgr_EClockGetData, seq_timemgr_StopAlarmIsOn
     use seq_timemgr_mod   , only : seq_timemgr_RestartAlarmIsOn, seq_timemgr_EClockDateInSync
     use spmdMod           , only : masterproc, mpicom

--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -41,7 +41,7 @@ contains
     ! !USES:
     use abortutils       , only : endrun
     use shr_kind_mod     , only : SHR_KIND_CL
-    use clm_time_manager , only : get_nstep, get_step_size, set_timemgr_init, set_nextsw_cday
+    use elm_time_manager , only : get_nstep, get_step_size, set_timemgr_init, set_nextsw_cday
     use elm_initializeMod, only : initialize1, initialize2, initialize3
     use elm_instMod      , only : lnd2atm_vars, lnd2glc_vars
     use elm_instance     , only : elm_instance_init
@@ -352,8 +352,8 @@ contains
     use shr_kind_mod    ,  only : r8 => shr_kind_r8
     use elm_instMod     , only : lnd2atm_vars, atm2lnd_vars, lnd2glc_vars, glc2lnd_vars
     use elm_driver      ,  only : elm_drv
-    use clm_time_manager,  only : get_curr_date, get_nstep, get_curr_calday, get_step_size
-    use clm_time_manager,  only : advance_timestep, set_nextsw_cday,update_rad_dtime
+    use elm_time_manager,  only : get_curr_date, get_nstep, get_curr_calday, get_step_size
+    use elm_time_manager,  only : advance_timestep, set_nextsw_cday,update_rad_dtime
     use decompMod       ,  only : get_proc_bounds
     use abortutils      ,  only : endrun
     use elm_varctl      ,  only : iulog

--- a/components/elm/src/cpl/lnd_disagg_forc.F90
+++ b/components/elm/src/cpl/lnd_disagg_forc.F90
@@ -56,7 +56,7 @@ contains
     ! Downscaling is done over topounits if the number of topounits > 1.
     !
     ! !USES:
-    use clm_time_manager, only : get_nstep
+    use elm_time_manager, only : get_nstep
     use elm_varcon      , only : rair, cpair, grav, lapse_glcmec
     use elm_varcon      , only : glcmec_rain_snow_threshold, o2_molar_const
     use shr_const_mod   , only : SHR_CONST_TKFRZ
@@ -423,7 +423,7 @@ contains
     ! Downscaling is done over topounits.
     !
     ! !USES:
-    use clm_time_manager, only : get_nstep
+    use elm_time_manager, only : get_nstep
     use elm_varcon      , only : rair, cpair, grav, lapse_glcmec
     use elm_varcon      , only : glcmec_rain_snow_threshold
     use landunit_varcon , only : istice_mec 
@@ -527,7 +527,7 @@ contains
     ! Must be done AFTER temperature downscaling
     
     ! !USES:
-    use clm_time_manager, only : get_nstep
+    use elm_time_manager, only : get_nstep
     use domainMod       , only : ldomain
     use landunit_varcon , only : istice_mec
     use elm_varcon      , only : lapse_glcmec

--- a/components/elm/src/cpl/lnd_downscale_atm_forcing.F90
+++ b/components/elm/src/cpl/lnd_downscale_atm_forcing.F90
@@ -56,7 +56,7 @@ contains
     ! Downscaling is done over topounits if the number of topounits > 1.
     !
     ! !USES:
-    use clm_time_manager, only : get_nstep
+    use elm_time_manager, only : get_nstep
     use elm_varcon      , only : rair, cpair, grav, lapse_glcmec
     use elm_varcon      , only : glcmec_rain_snow_threshold, o2_molar_const
     use shr_const_mod   , only : SHR_CONST_TKFRZ
@@ -423,7 +423,7 @@ contains
     ! Downscaling is done over topounits.
     !
     ! !USES:
-    use clm_time_manager, only : get_nstep
+    use elm_time_manager, only : get_nstep
     use elm_varcon      , only : rair, cpair, grav, lapse_glcmec
     use elm_varcon      , only : glcmec_rain_snow_threshold
     use landunit_varcon , only : istice_mec 
@@ -527,7 +527,7 @@ contains
     ! Must be done AFTER temperature downscaling
     
     ! !USES:
-    use clm_time_manager, only : get_nstep
+    use elm_time_manager, only : get_nstep
     use domainMod       , only : ldomain
     use landunit_varcon , only : istice_mec
     use elm_varcon      , only : lapse_glcmec

--- a/components/elm/src/cpl/lnd_import_export.F90
+++ b/components/elm/src/cpl/lnd_import_export.F90
@@ -31,7 +31,7 @@ contains
     use elm_varctl       , only: const_climate_hist, add_temperature, add_co2, use_cn, use_fates
     use elm_varctl       , only: startdate_add_temperature, startdate_add_co2
     use elm_varcon       , only: rair, o2_molar_const, c13ratio
-    use clm_time_manager , only: get_nstep, get_step_size, get_curr_calday, get_curr_date 
+    use elm_time_manager , only: get_nstep, get_step_size, get_curr_calday, get_curr_date 
     use controlMod       , only: NLFilename
     use shr_const_mod    , only: SHR_CONST_TKFRZ, SHR_CONST_STEBOL
     use domainMod        , only: ldomain
@@ -1353,7 +1353,7 @@ contains
     ! !USES:
     use shr_kind_mod       , only : r8 => shr_kind_r8
     use elm_varctl         , only : iulog, create_glacier_mec_landunit
-    use clm_time_manager   , only : get_nstep, get_step_size  
+    use elm_time_manager   , only : get_nstep, get_step_size  
     use domainMod          , only : ldomain
     use seq_drydep_mod     , only : n_drydep
     use shr_megan_mod      , only : shr_megan_mechcomps_n

--- a/components/elm/src/data_types/CNStateType.F90
+++ b/components/elm/src/data_types/CNStateType.F90
@@ -1529,7 +1529,7 @@ contains
 
     ! !USES
     use accumulMod       , only : init_accum_field, extract_accum_field
-    use clm_time_manager , only : get_nstep
+    use elm_time_manager , only : get_nstep
     use elm_varctl       , only : nsrest
     use abortutils       , only : endrun
     !
@@ -1573,7 +1573,7 @@ contains
   subroutine UpdateAccVars (this, bounds)
     !
     ! USES
-    use clm_time_manager , only : get_step_size, get_nstep, is_end_curr_day, get_curr_date
+    use elm_time_manager , only : get_step_size, get_nstep, is_end_curr_day, get_curr_date
     use accumulMod       , only : update_accum_field, extract_accum_field
     !
     ! !ARGUMENTS:

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -31,8 +31,8 @@ module ColumnDataType
   use ch4varcon       , only : allowlakeprod
   use pftvarcon       , only : VMAX_MINSURF_P_vr, KM_MINSURF_P_vr, pinit_beta1, pinit_beta2
   use soilorder_varcon, only : smax, ks_sorption
-  use clm_time_manager, only : is_restart, get_nstep
-  use clm_time_manager, only : is_first_step, get_step_size
+  use elm_time_manager, only : is_restart, get_nstep
+  use elm_time_manager, only : is_first_step, get_step_size
   use landunit_varcon , only : istice, istwet, istsoil, istdlak, istcrop, istice_mec
   use column_varcon   , only : icol_road_perv, icol_road_imperv, icol_roof, icol_sunwall, icol_shadewall
   use histFileMod     , only : hist_addfld1d, hist_addfld2d, no_snow_normal

--- a/components/elm/src/data_types/TopounitDataType.F90
+++ b/components/elm/src/data_types/TopounitDataType.F90
@@ -249,7 +249,7 @@ module TopounitDataType
     !
     ! !USES
      use accumulMod       , only : extract_accum_field
-     use clm_time_manager , only : get_nstep
+     use elm_time_manager , only : get_nstep
     !
     ! !ARGUMENTS:
     class(topounit_atmospheric_state) :: this
@@ -290,7 +290,7 @@ module TopounitDataType
    subroutine update_acc_vars_top_as (this, bounds)
      !
      ! USES
-      use clm_time_manager, only : get_nstep
+      use elm_time_manager, only : get_nstep
      use accumulMod      , only : update_accum_field, extract_accum_field
      !
      ! !ARGUMENTS:
@@ -472,7 +472,7 @@ module TopounitDataType
     !
     ! !USES
      use accumulMod       , only : extract_accum_field
-     use clm_time_manager , only : get_nstep
+     use elm_time_manager , only : get_nstep
     !
     ! !ARGUMENTS:
     class(topounit_atmospheric_flux) :: this
@@ -530,7 +530,7 @@ module TopounitDataType
   subroutine update_acc_vars_top_af (this, bounds)
     !
     ! USES
-    use clm_time_manager, only : get_nstep
+    use elm_time_manager, only : get_nstep
     use accumulMod      , only : update_accum_field, extract_accum_field
     !
     ! !ARGUMENTS:

--- a/components/elm/src/data_types/VegetationDataType.F90
+++ b/components/elm/src/data_types/VegetationDataType.F90
@@ -11,7 +11,7 @@ module VegetationDataType
   use shr_log_mod     , only : errMsg => shr_log_errMsg
   use spmdMod         , only : masterproc
   use abortutils      , only : endrun
-  use clm_time_manager, only : is_restart, get_nstep
+  use elm_time_manager, only : is_restart, get_nstep
   use elm_varpar      , only : nlevsno, nlevgrnd, nlevlak, nlevurb, nlevcan, crop_prog
   use elm_varpar      , only : nlevdecomp, nlevdecomp_full
   use elm_varcon      , only : spval, ispval, sb
@@ -1400,7 +1400,7 @@ module VegetationDataType
     !
     ! !USES
     use accumulMod       , only : init_accum_field
-    use clm_time_manager , only : get_step_size
+    use elm_time_manager , only : get_step_size
     use shr_const_mod    , only : SHR_CONST_CDAY, SHR_CONST_TKFRZ
     !
     ! !ARGUMENTS:
@@ -1476,7 +1476,7 @@ module VegetationDataType
     !
     ! !USES
     use accumulMod       , only : extract_accum_field
-    use clm_time_manager , only : get_nstep
+    use elm_time_manager , only : get_nstep
     use elm_varctl       , only : nsrest, nsrStartup
     use abortutils       , only : endrun
     !
@@ -1561,7 +1561,7 @@ module VegetationDataType
     !
     ! USES
     use shr_const_mod    , only : SHR_CONST_CDAY, SHR_CONST_TKFRZ
-    use clm_time_manager , only : get_step_size, get_nstep, is_end_curr_day, get_curr_date
+    use elm_time_manager , only : get_step_size, get_nstep, is_end_curr_day, get_curr_date
     use accumulMod       , only : update_accum_field, extract_accum_field, accumResetVal
     !
     ! !ARGUMENTS:

--- a/components/elm/src/dyn_subgrid/dynConsBiogeochemMod.F90
+++ b/components/elm/src/dyn_subgrid/dynConsBiogeochemMod.F90
@@ -71,7 +71,7 @@ contains
     use elm_varpar         , only : nlevdecomp, max_patch_per_col
     use pftvarcon          , only : pconv, pprod10, pprod100
     use elm_varcon         , only : c13ratio, c14ratio
-    use clm_time_manager   , only : get_step_size
+    use elm_time_manager   , only : get_step_size
     use dynPriorWeightsMod , only : prior_weights_type
     !
     ! !ARGUMENTS:

--- a/components/elm/src/dyn_subgrid/dynHarvestMod.F90
+++ b/components/elm/src/dyn_subgrid/dynHarvestMod.F90
@@ -201,7 +201,7 @@ contains
     ! !USES:
     use pftvarcon       , only : noveg, nbrdlf_evr_shrub, pprodharv10
     use elm_varcon      , only : secspday
-    use clm_time_manager, only : get_days_per_year
+    use elm_time_manager, only : get_days_per_year
     use GridcellType   , only : grc_pp
     
     ! !ARGUMENTS:

--- a/components/elm/src/dyn_subgrid/dynSubgridDriverMod.F90
+++ b/components/elm/src/dyn_subgrid/dynSubgridDriverMod.F90
@@ -170,7 +170,7 @@ contains
     use dynPatchStateUpdaterMod   , only : set_old_patch_weights, set_new_patch_weights
     use dynColumnStateUpdaterMod  , only : set_old_column_weights, set_new_column_weights
     use dynPriorWeightsMod        , only : set_prior_weights
-    use clm_time_manager , only : get_step_size
+    use elm_time_manager , only : get_step_size
     !
     ! !ARGUMENTS:
     type(bounds_type)        , intent(in)    :: bounds_proc  ! processor-level bounds

--- a/components/elm/src/dyn_subgrid/dynTimeInfoMod.F90
+++ b/components/elm/src/dyn_subgrid/dynTimeInfoMod.F90
@@ -111,7 +111,7 @@ contains
     ! Should be called every time step
     !
     ! !USES:
-    use clm_time_manager , only : get_curr_date, get_prev_date
+    use elm_time_manager , only : get_curr_date, get_prev_date
     !
     ! !ARGUMENTS:
     class(time_info_type), intent(inout) :: this      ! this object
@@ -154,7 +154,7 @@ contains
     ! This version of set_current_year obtains the current model year for you.
     !
     ! !USES:
-    use clm_time_manager , only : get_curr_date, get_prev_date, get_days_per_year
+    use elm_time_manager , only : get_curr_date, get_prev_date, get_days_per_year
     !
     ! !ARGUMENTS:
     class(time_info_type), intent(inout) :: this      ! this object

--- a/components/elm/src/dyn_subgrid/dynVarTimeInterpMod.F90.in
+++ b/components/elm/src/dyn_subgrid/dynVarTimeInterpMod.F90.in
@@ -125,7 +125,7 @@ contains
     ! underlying dyn_file variable
     
     ! !USES:
-    use clm_time_manager, only : get_curr_yearfrac
+    use elm_time_manager, only : get_curr_yearfrac
     
     ! !ARGUMENTS:
     class(dyn_var_time_interp_type) , intent(inout) :: this             ! this object

--- a/components/elm/src/main/accumulMod.F90
+++ b/components/elm/src/main/accumulMod.F90
@@ -86,7 +86,7 @@ contains
     !
     ! !USES:
     use shr_const_mod, only: SHR_CONST_CDAY
-    use clm_time_manager, only : get_step_size
+    use elm_time_manager, only : get_step_size
     use decompMod, only : get_proc_bounds, get_proc_global
     !
     ! !ARGUMENTS:

--- a/components/elm/src/main/atm2lndType.F90
+++ b/components/elm/src/main/atm2lndType.F90
@@ -564,7 +564,7 @@ contains
     !
     ! !USES 
     use accumulMod       , only : extract_accum_field
-    use clm_time_manager , only : get_nstep
+    use elm_time_manager , only : get_nstep
     !
     ! !ARGUMENTS:
     class(atm2lnd_type) :: this
@@ -629,7 +629,7 @@ contains
   subroutine UpdateAccVars (this, bounds)
     !
     ! USES
-    use clm_time_manager, only : get_nstep
+    use elm_time_manager, only : get_nstep
     use accumulMod      , only : update_accum_field, extract_accum_field
     !
     ! !ARGUMENTS:

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -115,7 +115,7 @@ contains
     ! Initialize CLM run control information
     
     ! !USES:
-    use clm_time_manager          , only : set_timemgr_init, get_timemgr_defaults
+    use elm_time_manager          , only : set_timemgr_init, get_timemgr_defaults
     use fileutils                 , only : getavu, relavu
     use shr_string_mod            , only : shr_string_getParentDir
     use elm_interface_pflotranMod , only : elm_pf_readnl

--- a/components/elm/src/main/elm_driver.F90
+++ b/components/elm/src/main/elm_driver.F90
@@ -16,8 +16,8 @@ module elm_driver
   use elm_varctl             , only : use_cn, use_lch4, use_voc, use_noio, use_c13, use_c14
   use elm_varctl             , only : use_erosion, use_fates_sp
   use elm_varctl             , only : mpi_sync_nstep_freq
-  use clm_time_manager       , only : get_step_size, get_curr_date, get_ref_date, get_nstep, is_beg_curr_day, get_curr_time_string
-  use clm_time_manager       , only : get_curr_calday, get_days_per_year
+  use elm_time_manager       , only : get_step_size, get_curr_date, get_ref_date, get_nstep, is_beg_curr_day, get_curr_time_string
+  use elm_time_manager       , only : get_curr_calday, get_days_per_year
   use elm_varpar             , only : nlevsno, nlevgrnd, crop_prog
   use spmdMod                , only : masterproc, mpicom
   use decompMod              , only : get_proc_clumps, get_clump_bounds, get_proc_bounds, bounds_type
@@ -162,7 +162,7 @@ module elm_driver
   use elm_varctl             , only : use_elm_bgc
   use elm_interface_funcsMod , only : elm_bgc_run, update_bgc_data_elm2elm
   ! (2) pflotran
-  use clm_time_manager            , only : nsstep, nestep
+  use elm_time_manager            , only : nsstep, nestep
   use elm_varctl                  , only : use_pflotran, pf_cmode, pf_hmode, pf_tmode
   use elm_interface_funcsMod      , only : update_bgc_data_pf2elm, update_th_data_pf2elm
   use elm_interface_pflotranMod   , only : elm_pf_run, elm_pf_write_restart

--- a/components/elm/src/main/elm_initializeMod.F90
+++ b/components/elm/src/main/elm_initializeMod.F90
@@ -463,9 +463,9 @@ contains
     use elm_varctl            , only : finidat, finidat_interp_source, finidat_interp_dest, fsurdat
     use elm_varctl            , only : use_century_decomp, single_column, scmlat, scmlon, use_cn
     use elm_varorb            , only : eccen, mvelpp, lambm0, obliqr
-    use clm_time_manager      , only : get_step_size, get_curr_calday
-    use clm_time_manager      , only : get_curr_date, get_nstep, advance_timestep
-    use clm_time_manager      , only : timemgr_init, timemgr_restart_io, timemgr_restart
+    use elm_time_manager      , only : get_step_size, get_curr_calday
+    use elm_time_manager      , only : get_curr_date, get_nstep, advance_timestep
+    use elm_time_manager      , only : timemgr_init, timemgr_restart_io, timemgr_restart
     use controlMod            , only : nlfilename
     use decompMod             , only : get_proc_clumps, get_proc_bounds, get_clump_bounds, bounds_type
     use domainMod             , only : ldomain
@@ -502,7 +502,7 @@ contains
     use elm_varctl                          , only : fates_spitfire_mode
     use elm_interface_pflotranMod           , only : elm_pf_interface_init !, elm_pf_set_restart_stamp
     use tracer_varcon         , only : is_active_betr_bgc
-    use clm_time_manager      , only : is_restart
+    use elm_time_manager      , only : is_restart
     use ELMbetrNLMod          , only : betr_namelist_buffer
     use ELMFatesInterfaceMod  , only: ELMFatesTimesteps
     use FATESFireFactoryMod   , only : scalar_lightning

--- a/components/elm/src/main/elm_interface_funcsMod.F90
+++ b/components/elm/src/main/elm_interface_funcsMod.F90
@@ -338,7 +338,7 @@ contains
   !  get soil temperature/saturation from CLM to soil BGC module
   !
   ! !USES:
-    use clm_time_manager    , only : get_nstep
+    use elm_time_manager    , only : get_nstep
     use shr_const_mod       , only : SHR_CONST_G
 
 
@@ -418,7 +418,7 @@ contains
   !  get soil temperature/saturation from CLM to soil BGC module
   !
   ! !USES:
-    use clm_time_manager    , only : get_nstep
+    use elm_time_manager    , only : get_nstep
     use shr_const_mod       , only : SHR_CONST_G
 
 
@@ -602,7 +602,7 @@ contains
   ! get clm bgc flux variables: external inputs to bgc state variables (pools)
   !
   ! !USES:
-    use clm_time_manager      , only : get_curr_date
+    use elm_time_manager      , only : get_curr_date
     use elm_varctl            , only : spinup_state
     use CNDecompCascadeConType, only : decomp_cascade_con
 
@@ -925,7 +925,7 @@ contains
            nitrogenstate_vars, phosphorusstate_vars)
 
     use CNDecompCascadeConType, only : decomp_cascade_con
-    use clm_time_manager, only : get_step_size
+    use elm_time_manager, only : get_step_size
 
     implicit none
 
@@ -1360,7 +1360,7 @@ contains
 
     ! USES:
     use SoilLittDecompMod          , only: SoilLittDecompAlloc
-    use clm_time_manager           , only: get_step_size
+    use elm_time_manager           , only: get_step_size
 
     ! ARGUMENTS:
     type(bounds_type)                   , intent(in)    :: bounds

--- a/components/elm/src/main/elm_interface_pflotranMod.F90
+++ b/components/elm/src/main/elm_interface_pflotranMod.F90
@@ -276,7 +276,7 @@ contains
   !--------------------------------------------------------------------------------------------
 
     subroutine elm_pf_run(elm_interface_data, bounds, filters, ifilter)
-    use clm_time_manager, only : get_nstep
+    use elm_time_manager, only : get_nstep
 
     implicit none
 
@@ -380,7 +380,7 @@ contains
     use spmdMod         , only : mpicom, masterproc, iam, npes
     use domainMod       , only : ldomain, lon1d, lat1d
 
-    use clm_time_manager, only : get_nstep
+    use elm_time_manager, only : get_nstep
     use elm_varcon      , only : dzsoi, zisoi
     use elm_varpar      , only : nlevsoi, nlevgrnd, nlevdecomp_full, ndecomp_pools
     use elm_varctl      , only : pf_hmode, pf_tmode, pf_cmode, pf_frzmode,  &
@@ -1075,7 +1075,7 @@ contains
   !
   ! !USES:
     use spmdMod           , only : mpicom, masterproc, iam, npes
-    use clm_time_manager  , only : get_step_size, get_nstep, nsstep, nestep,         &
+    use elm_time_manager  , only : get_step_size, get_nstep, nsstep, nestep,         &
                                    is_first_step, is_first_restart_step, calc_nestep
     use elm_varctl        , only : pf_tmode, pf_hmode, pf_cmode,                     &
                                    pf_frzmode, pf_elmnstep0, initth_pf2elm
@@ -1971,7 +1971,7 @@ contains
   !  if either NOT available inside PFLOTRAN
   !
   ! !USES:
-    use clm_time_manager    , only : get_nstep, is_first_step, is_first_restart_step
+    use elm_time_manager    , only : get_nstep, is_first_step, is_first_restart_step
     use shr_const_mod       , only : SHR_CONST_G
     use ColumnType          , only : col_pp
     use elm_varctl          , only : iulog
@@ -2289,7 +2289,7 @@ contains
     use ColumnType      , only : col_pp
     use elm_varcon      , only : tfrz, denh2o
     use elm_varpar      , only : nlevsoi, nlevgrnd
-    use clm_time_manager, only : get_step_size, get_nstep
+    use elm_time_manager, only : get_step_size, get_nstep
     use shr_infnan_mod  , only : shr_infnan_isnan
     use shr_const_mod   , only : SHR_CONST_G
 
@@ -2671,7 +2671,7 @@ contains
   !
   ! !USES:
     use ColumnType      , only : col_pp
-    use clm_time_manager, only : get_step_size, get_nstep
+    use elm_time_manager, only : get_step_size, get_nstep
     use elm_varcon      , only : tfrz
     use elm_varpar      , only : nlevgrnd
     use shr_infnan_mod  , only : shr_infnan_isnan
@@ -3033,7 +3033,7 @@ contains
   !
   ! !USES:
     use ColumnType          , only : col_pp
-    use clm_time_manager    , only : get_step_size, get_nstep,  is_first_step, is_first_restart_step
+    use elm_time_manager    , only : get_step_size, get_nstep,  is_first_step, is_first_restart_step
     use elm_varpar          , only : ndecomp_pools, nlevdecomp_full
     use elm_varctl          , only : iulog, pf_hmode
 
@@ -3520,7 +3520,7 @@ contains
     use elm_varpar          , only : nlevgrnd
     use elm_varcon          , only : tfrz, denh2o
     use landunit_varcon     , only : istsoil, istcrop
-    use clm_time_manager    , only : get_step_size, get_nstep
+    use elm_time_manager    , only : get_step_size, get_nstep
 
     !
     type(bounds_type), intent(in) :: bounds         ! bounds of current process
@@ -3648,7 +3648,7 @@ contains
     use CNDecompCascadeConType  , only : decomp_cascade_con
     use elm_varpar              , only : ndecomp_pools, nlevdecomp_full
     use elm_varctl              , only : pf_hmode
-    use clm_time_manager        , only : get_step_size,get_nstep
+    use elm_time_manager        , only : get_step_size,get_nstep
 
     use elm_varcon              , only : dzsoi_decomp
 
@@ -3953,7 +3953,7 @@ contains
   subroutine update_bgc_gaslosses_pf2elm(elm_interface_data, bounds, filters, ifilter)
 
      use ColumnType         , only : col_pp
-     use clm_time_manager   , only : get_step_size, get_nstep
+     use elm_time_manager   , only : get_step_size, get_nstep
      use elm_varpar         , only : nlevdecomp_full
      use elm_varcon         , only : tfrz
 
@@ -4312,7 +4312,7 @@ contains
   subroutine update_bgc_bcflux_pf2elm(elm_interface_data, bounds, filters, ifilter)
 
      use ColumnType         , only : col_pp
-     use clm_time_manager   , only : get_step_size
+     use elm_time_manager   , only : get_step_size
      use elm_varpar         , only : nlevdecomp_full
 
      !
@@ -4562,7 +4562,7 @@ contains
     ! On the radiation time step, perform carbon mass conservation check for column and pft
     !
     ! !USES:
-    use clm_time_manager, only : get_step_size, get_nstep
+    use elm_time_manager, only : get_step_size, get_nstep
     use elm_varctl      , only : iulog, use_fates
     use elm_varpar      , only : ndecomp_pools, nlevdecomp, nlevdecomp_full
     use elm_varcon      , only : dzsoi_decomp
@@ -4647,7 +4647,7 @@ contains
     ! On the radiation time step, perform carbon mass conservation check for column and pft
     !
     ! !USES:
-    use clm_time_manager, only : get_step_size,get_nstep
+    use elm_time_manager, only : get_step_size,get_nstep
     use elm_varctl      , only : iulog, use_fates
     use elm_varpar      , only : ndecomp_pools, nlevdecomp, nlevdecomp_full
     use elm_varcon      , only : dzsoi_decomp

--- a/components/elm/src/main/elmfates_interfaceMod.F90
+++ b/components/elm/src/main/elmfates_interfaceMod.F90
@@ -81,10 +81,10 @@ module ELMFatesInterfaceMod
    use SurfaceAlbedoType , only : surfalb_type
    use SolarAbsorbedType , only : solarabs_type
    use FrictionVelocityType , only : frictionvel_type
-   use clm_time_manager  , only : is_restart
+   use elm_time_manager  , only : is_restart
    use ncdio_pio         , only : file_desc_t, ncd_int, ncd_double
    use restUtilMod,        only : restartvar
-   use clm_time_manager  , only : get_days_per_year, &
+   use elm_time_manager  , only : get_days_per_year, &
                                   get_curr_date,     &
                                   get_ref_date,      &
                                   timemgr_datediff,  &
@@ -3204,7 +3204,7 @@ end subroutine wrap_update_hifrq_hist
  subroutine GetAndSetTime()
 
    ! CLM MODULES
-   use clm_time_manager  , only : get_days_per_year, &
+   use elm_time_manager  , only : get_days_per_year, &
                                   get_curr_date,     &
                                   get_ref_date,      &
                                   timemgr_datediff

--- a/components/elm/src/main/histFileMod.F90
+++ b/components/elm/src/main/histFileMod.F90
@@ -441,7 +441,7 @@ contains
     ! appropriate variables and calling appropriate routines
     !
     ! !USES:
-    use clm_time_manager, only: get_prev_time
+    use elm_time_manager, only: get_prev_time
     use elm_varcon      , only: secspday
     !
     ! !ARGUMENTS:
@@ -2343,8 +2343,8 @@ contains
     use elm_varcon      , only : zsoi, zlak, secspday
     use elm_varpar      , only : nlevsoi
     use domainMod       , only : ldomain, lon1d, lat1d
-    use clm_time_manager, only : get_nstep, get_curr_date, get_curr_time
-    use clm_time_manager, only : get_ref_date, get_calendar, NO_LEAP_C, GREGORIAN_C
+    use elm_time_manager, only : get_nstep, get_curr_date, get_curr_time
+    use elm_time_manager, only : get_ref_date, get_calendar, NO_LEAP_C, GREGORIAN_C
     use FatesInterfaceTypesMod, only : fates_hdim_levsclass
     use FatesInterfaceTypesMod, only : fates_hdim_pfmap_levscpf
     use FatesInterfaceTypesMod, only : fates_hdim_scmap_levscpf
@@ -3331,7 +3331,7 @@ contains
     !   date = yyyy/mm+1/01 with mscur = 0.
     !
     ! !USES:
-    use clm_time_manager, only : get_nstep, get_curr_date, get_curr_time, get_prev_date
+    use elm_time_manager, only : get_nstep, get_curr_date, get_curr_time, get_prev_date
     use elm_varcon      , only : secspday
     use perf_mod        , only : t_startf, t_stopf
     use elm_varpar      , only : nlevgrnd
@@ -3539,7 +3539,7 @@ contains
     use fileutils       , only : getfil
     use domainMod       , only : ldomain
     use elm_varpar      , only : nlevgrnd, nlevlak, numrad, nlevdecomp_full, nmonth
-    use clm_time_manager, only : is_restart
+    use elm_time_manager, only : is_restart
     use restUtilMod     , only : iflag_skip
     use pio
     !
@@ -4398,7 +4398,7 @@ contains
      !
      ! !USES:
      use elm_varctl, only : caseid, inst_suffix
-     use clm_time_manager, only : get_curr_date, get_prev_date
+     use elm_time_manager, only : get_curr_date, get_prev_date
      !
      ! !ARGUMENTS:
      integer, intent(in)  :: hist_freq   !history file frequency
@@ -5185,7 +5185,7 @@ contains
     ! history file is not full.
     !
     ! !USES:
-    use clm_time_manager, only : is_last_step
+    use elm_time_manager, only : is_last_step
     !
     ! !ARGUMENTS:
     integer, intent(in)  :: ntapes              !actual number of history tapes

--- a/components/elm/src/main/ndepStreamMod.F90
+++ b/components/elm/src/main/ndepStreamMod.F90
@@ -48,7 +48,7 @@ contains
    !
    ! Uses:
    use elm_varctl       , only : inst_name
-   use clm_time_manager , only : get_calendar
+   use elm_time_manager , only : get_calendar
    use ncdio_pio        , only : pio_subsystem
    use shr_pio_mod      , only : shr_pio_getiotype
    use shr_nl_mod       , only : shr_nl_find_group_name
@@ -151,7 +151,7 @@ contains
  subroutine ndep_interp(bounds, atm2lnd_vars)
 
    !-----------------------------------------------------------------------
-   use clm_time_manager, only : get_curr_date, get_days_per_year
+   use elm_time_manager, only : get_curr_date, get_days_per_year
    use elm_varcon      , only : secspday
    use atm2lndType     , only : atm2lnd_type
    !

--- a/components/elm/src/main/pdepStreamMod.F90
+++ b/components/elm/src/main/pdepStreamMod.F90
@@ -49,7 +49,7 @@ contains
    !
    ! Uses:
    use elm_varctl       , only : inst_name
-   use clm_time_manager , only : get_calendar
+   use elm_time_manager , only : get_calendar
    use ncdio_pio        , only : pio_subsystem
    use shr_pio_mod      , only : shr_pio_getiotype
    use shr_nl_mod       , only : shr_nl_find_group_name
@@ -151,7 +151,7 @@ contains
  subroutine pdep_interp(bounds, atm2lnd_vars)
 
    !-----------------------------------------------------------------------
-   use clm_time_manager, only : get_curr_date, get_days_per_year
+   use elm_time_manager, only : get_curr_date, get_days_per_year
    use elm_varcon      , only : secspday
    use atm2lndType     , only : atm2lnd_type
    !

--- a/components/elm/src/main/restFileMod.F90
+++ b/components/elm/src/main/restFileMod.F90
@@ -10,7 +10,7 @@ module restFileMod
   use spmdMod              , only : masterproc, mpicom
   use abortutils           , only : endrun
   use shr_log_mod          , only : errMsg => shr_log_errMsg
-  use clm_time_manager     , only : timemgr_restart_io, get_nstep
+  use elm_time_manager     , only : timemgr_restart_io, get_nstep
   use subgridRestMod       , only : SubgridRest
   use accumulMod           , only : accumulRest
   use histFileMod          , only : hist_restart_ncd
@@ -783,7 +783,7 @@ contains
     ! in write mode, otherwise just close restart file if in read mode
     !
     ! !USES:
-    use clm_time_manager, only : is_last_step
+    use elm_time_manager, only : is_last_step
     !
     ! !ARGUMENTS:
     character(len=*) , intent(in) :: file  ! local output filename
@@ -843,7 +843,7 @@ contains
   !-----------------------------------------------------------------------
   subroutine restFile_open( flag, file, ncid )
 
-    use clm_time_manager, only : get_nstep
+    use elm_time_manager, only : get_nstep
 
     character(len=*),  intent(in) :: flag ! flag to specify read or write
     character(len=*),  intent(in) :: file ! filename
@@ -905,7 +905,7 @@ contains
     ! Read/Write initial data from/to netCDF instantaneous initial data file
     !
     ! !USES:
-    use clm_time_manager     , only : get_nstep
+    use elm_time_manager     , only : get_nstep
     use elm_varctl           , only : caseid, ctitle, version, username, hostname, fsurdat
     use elm_varctl           , only : conventions, source, use_hydrstress
     use elm_varpar           , only : numrad, nlevlak, nlevsno, nlevgrnd, nlevurb, nlevcan, nlevtrc_full, nmonth, nvegwcs
@@ -1348,7 +1348,7 @@ contains
     ! Make sure year on the restart file is consistent with the current model year
     !
     ! !USES:
-    use clm_time_manager     , only : get_curr_date, get_rest_date
+    use elm_time_manager     , only : get_curr_date, get_rest_date
     use elm_varctl           , only : fname_len
     use dynSubgridControlMod , only : get_flanduse_timeseries
     !

--- a/components/elm/src/main/subgridRestMod.F90
+++ b/components/elm/src/main/subgridRestMod.F90
@@ -9,7 +9,7 @@ module subgridRestMod
   use abortutils         , only : endrun
   use decompMod          , only : bounds_type, BOUNDS_LEVEL_PROC, ldecomp
   use domainMod          , only : ldomain
-  use clm_time_manager   , only : get_curr_date
+  use elm_time_manager   , only : get_curr_date
   use elm_varcon         , only : nameg, namet, namel, namec, namep
   use elm_varpar         , only : nlevsno
   use pio                , only : file_desc_t

--- a/components/elm/src/utils/AnnualFluxDribbler.F90
+++ b/components/elm/src/utils/AnnualFluxDribbler.F90
@@ -64,9 +64,9 @@ module AnnualFluxDribbler
   use decompMod        , only : bounds_type, get_beg, get_end
   use decompMod        , only : BOUNDS_SUBGRID_GRIDCELL, BOUNDS_SUBGRID_PATCH
   use elm_varcon       , only : secspday, nameg, namep
-  use clm_time_manager , only : get_days_per_year, get_step_size_real, is_beg_curr_year
-  use clm_time_manager , only : get_curr_yearfrac, get_prev_yearfrac, get_prev_date
-  use clm_time_manager , only : is_first_step
+  use elm_time_manager , only : get_days_per_year, get_step_size_real, is_beg_curr_year
+  use elm_time_manager , only : get_curr_yearfrac, get_prev_yearfrac, get_prev_date
+  use elm_time_manager , only : is_first_step
   !
   implicit none
   private

--- a/components/elm/src/utils/elm_time_manager.F90
+++ b/components/elm/src/utils/elm_time_manager.F90
@@ -1,4 +1,4 @@
-module clm_time_manager
+module elm_time_manager
 
    use shr_kind_mod, only: r8 => shr_kind_r8
    use shr_sys_mod , only: shr_sys_abort
@@ -1883,4 +1883,4 @@ contains
 
   end subroutine for_test_set_curr_date
 
-end module clm_time_manager
+end module elm_time_manager


### PR DESCRIPTION
Renames `clm_time_manager` module as `elm_time_manager`.

[BFB]