### PR TITLE
Limits the definition of `cohort` dim in ELM restart file

### DIFF
--- a/components/elm/src/main/restFileMod.F90
+++ b/components/elm/src/main/restFileMod.F90
@@ -944,7 +944,9 @@ contains
     call ncd_defdim(ncid , namel      , numl           ,  dimid)
     call ncd_defdim(ncid , namec      , numc           ,  dimid)
     call ncd_defdim(ncid , namep      , nump           ,  dimid)
-    call ncd_defdim(ncid , nameCohort , numCohort      ,  dimid)
+    if ( use_fates ) then
+       call ncd_defdim(ncid , nameCohort , numCohort      ,  dimid)
+    endif
 
     call ncd_defdim(ncid , 'levgrnd' , nlevgrnd       ,  dimid)
     call ncd_defdim(ncid , 'levurb'  , nlevurb        ,  dimid)


### PR DESCRIPTION
In ELM restart file, the `cohort` dimension is only defined when FATES is turned on.
This code modification allows ELM to write `elm.rh0` when `hist_empty_htapes=.true.`
is set in `user_nl_elm`.

Fixes #5694
[BFB]