### PR TITLE
Add low nc limit in P3 microphysics

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -3765,6 +3765,7 @@ if ($cfg->get('microphys') =~ /^p3/) {
       add_default($nl, 'p3_embryonic_rain_size');
       add_default($nl, 'do_prescribed_CCN');
       add_default($nl, 'do_Cooper_inP3');  
+      add_default($nl, 'p3_mincdnc');  # shanyp 05042023
    }
 }
 

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -3765,7 +3765,7 @@ if ($cfg->get('microphys') =~ /^p3/) {
       add_default($nl, 'p3_embryonic_rain_size');
       add_default($nl, 'do_prescribed_CCN');
       add_default($nl, 'do_Cooper_inP3');  
-      add_default($nl, 'p3_mincdnc');  # shanyp 05042023
+      add_default($nl, 'p3_mincdnc'); 
    }
 }
 

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -918,7 +918,7 @@
 <micro_nccons         microphys="mg2">  100.D6      </micro_nccons>
 <micro_nicons         microphys="mg2">  0.1D6       </micro_nicons>
 <micro_mincdnc        microphys="mg2">  -999.       </micro_mincdnc>
-<p3_mincdnc           microphys="p3">  -999.        </p3_mincdnc>  <!-- shanyp -->
+<p3_mincdnc           microphys="p3">  -999.        </p3_mincdnc> 
 
 <!-- P3 specific namelist variables -->
 <micro_aerosolactivation            microphys="p3"> .true.  </micro_aerosolactivation>
@@ -949,7 +949,7 @@
 
 <!-- special defaults for MMF, which now sets all other physics scheme options to "off" -->
 <micro_mincdnc        use_MMF="1">  -999.       </micro_mincdnc>
-<p3_mincdnc           use_MMF="1">  -999.       </p3_mincdnc>  <!-- shanyp -->
+<p3_mincdnc           use_MMF="1">  -999.       </p3_mincdnc> 
 
 <rrtmg_temp_fix                      > .false.      </rrtmg_temp_fix>
 
@@ -1848,7 +1848,7 @@ with se_tstep, dt_remap_factor, dt_tracer_factor set to -1
 <dust_emis_fact phys="default"> 1.50D0     </dust_emis_fact>
 <linoz_psc_T               > 197.5      </linoz_psc_T>
 <micro_mincdnc phys="default" microphys="mg2"> 10.D6      </micro_mincdnc>
-<p3_mincdnc phys="default" microphys="p3"> 10.D6      </p3_mincdnc>  <!-- shanyp -->
+<p3_mincdnc phys="default" microphys="p3"> 10.D6      </p3_mincdnc>
 <clubb_C1 phys="default"> 2.4        </clubb_C1>
 <clubb_C11 phys="default"> 0.70       </clubb_C11>
 <clubb_C11b phys="default"> 0.20       </clubb_C11b>

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -918,7 +918,7 @@
 <micro_nccons         microphys="mg2">  100.D6      </micro_nccons>
 <micro_nicons         microphys="mg2">  0.1D6       </micro_nicons>
 <micro_mincdnc        microphys="mg2">  -999.       </micro_mincdnc>
-
+<p3_mincdnc           microphys="p3">  -999.        </p3_mincdnc>  <!-- shanyp -->
 
 <!-- P3 specific namelist variables -->
 <micro_aerosolactivation            microphys="p3"> .true.  </micro_aerosolactivation>
@@ -949,6 +949,7 @@
 
 <!-- special defaults for MMF, which now sets all other physics scheme options to "off" -->
 <micro_mincdnc        use_MMF="1">  -999.       </micro_mincdnc>
+<p3_mincdnc           use_MMF="1">  -999.       </p3_mincdnc>  <!-- shanyp -->
 
 <rrtmg_temp_fix                      > .false.      </rrtmg_temp_fix>
 
@@ -1847,6 +1848,7 @@ with se_tstep, dt_remap_factor, dt_tracer_factor set to -1
 <dust_emis_fact phys="default"> 1.50D0     </dust_emis_fact>
 <linoz_psc_T               > 197.5      </linoz_psc_T>
 <micro_mincdnc phys="default" microphys="mg2"> 10.D6      </micro_mincdnc>
+<p3_mincdnc phys="default" microphys="p3"> 10.D6      </p3_mincdnc>  <!-- shanyp -->
 <clubb_C1 phys="default"> 2.4        </clubb_C1>
 <clubb_C11 phys="default"> 0.70       </clubb_C11>
 <clubb_C11b phys="default"> 0.20       </clubb_C11b>

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -2502,6 +2502,13 @@ Minimum droplet number conc (#/m3) imposed when micro_mincdnc > 0.
 Default: -999.
 </entry>
 
+<!-- shanyp impose low Nc limit for P3 scheme -->
+<entry id="p3_mincdnc" type="real" category="microphys"
+       group="micro_nl" valid_values="" >
+Minimum droplet number conc (#/m3) imposed when p3_mincdnc > 0.
+Default: -999.
+</entry>
+
 <entry id="micro_mg_version" type="integer" category="microphys"
        group="micro_mg_nl" valid_values="" >
 Version number for MG microphysics

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -2502,7 +2502,6 @@ Minimum droplet number conc (#/m3) imposed when micro_mincdnc > 0.
 Default: -999.
 </entry>
 
-<!-- shanyp impose low Nc limit for P3 scheme -->
 <entry id="p3_mincdnc" type="real" category="microphys"
        group="micro_nl" valid_values="" >
 Minimum droplet number conc (#/m3) imposed when p3_mincdnc > 0.

--- a/components/eam/src/physics/p3/eam/micro_p3.F90
+++ b/components/eam/src/physics/p3/eam/micro_p3.F90
@@ -94,14 +94,6 @@ module micro_p3
   ! lookup table values for rain number- and mass-weighted fallspeeds and ventilation parameters
   real(rtype), protected, dimension(300,10) :: vn_table_vals,vm_table_vals,revap_table_vals
 
-!<shanyp 20221218
-! set lookup tables as threadprivate variables to see if this change can address the threading issue.
-!  !$OMP THREADPRIVATE(ice_table_vals,collect_table_vals,mu_r_table_vals,vn_table_vals,vm_table_vals,revap_table_vals)
-! !$OMP THREADPRIVATE(ice_table_vals) 
- !,vn_table_vals,vm_table_vals)
-!shanyp 20221218>
-
-
   type realptr
      real(rtype), dimension(:), pointer :: p
   end type realptr
@@ -1103,7 +1095,7 @@ end function bfb_expm1
    integer, intent(in) :: kts, kte, kbot, ktop, kdir
 
    real(rtype), intent(in) :: p3_max_mean_rain_size
-   real(rtype), intent(in) :: mincdnc ! Shanyp add imposing Nc
+   real(rtype), intent(in) :: mincdnc 
    real(rtype), intent(in), dimension(kts:kte) :: exner, cld_frac_l, cld_frac_r, cld_frac_i
 
    real(rtype), intent(inout), dimension(kts:kte) :: rho, inv_rho, rhofaci, &
@@ -1141,7 +1133,7 @@ end function bfb_expm1
          nc_incld = nc(k)/cld_frac_l(k)
          call get_cloud_dsd2(qc_incld,nc_incld,mu_c(k),rho(k),nu(k),dnu,lamc(k),  &
               tmp1,tmp2)
-       if (mincdnc.gt.0._rtype) nc_incld = max(nc_incld,mincdnc/rho(k)) ! Shanyp Make sure all nc_incld no less than mincdnc
+       if (mincdnc.gt.0._rtype) nc_incld = max(nc_incld,mincdnc/rho(k)) 
          diag_eff_radius_qc(k) = 0.5_rtype*(mu_c(k)+3._rtype)/lamc(k)
          nc(k) = nc_incld*cld_frac_l(k) !limiters in dsd2 may change nc_incld. Enforcing consistency here.
       else
@@ -1639,7 +1631,7 @@ end function bfb_expm1
            nc(i,knc) = max(nc(i,knc),mincdnc*cld_frac_l(i,knc)/rho(i,knc))
            nc_incld(i,knc) = max(nc_incld(i,knc),mincdnc/rho(i,knc))
           end if
-         end do ! Shanyp: After microphysics updated, make sure all the nc_incld no less than min_ndnc
+         end do 
 
        !...................................................
        ! final checks to ensure consistency of mass/number

--- a/components/eam/src/physics/p3/eam/micro_p3_interface.F90
+++ b/components/eam/src/physics/p3/eam/micro_p3_interface.F90
@@ -129,7 +129,7 @@ module micro_p3_interface
       p3_nc_autocon_expon      = huge(1.0_rtype), &
       p3_qc_accret_expon       = huge(1.0_rtype), &
       p3_wbf_coeff             = huge(1.0_rtype), &
-      p3_mincdnc               = huge(1.0_rtype), & ! Add imposing low Nc limit by Shanyp
+      p3_mincdnc               = huge(1.0_rtype), & 
       p3_max_mean_rain_size    = huge(1.0_rtype), &
       p3_embryonic_rain_size   = huge(1.0_rtype)
    
@@ -165,7 +165,7 @@ subroutine micro_p3_readnl(nlfile)
        micro_p3_tableversion, micro_p3_lookup_dir, micro_aerosolactivation, micro_subgrid_cloud, &
        micro_tend_output, p3_autocon_coeff, p3_qc_autocon_expon, p3_nc_autocon_expon, p3_accret_coeff, &
        p3_qc_accret_expon, p3_wbf_coeff, p3_max_mean_rain_size, p3_embryonic_rain_size, &
-       do_prescribed_CCN, do_Cooper_inP3, p3_mincdnc ! shanyp add p3_mincdnc
+       do_prescribed_CCN, do_Cooper_inP3, p3_mincdnc 
 
   !-----------------------------------------------------------------------------
 
@@ -194,7 +194,7 @@ subroutine micro_p3_readnl(nlfile)
      write(iulog,'(A30,1x,8e12.4)') 'p3_nc_autocon_expon',     p3_nc_autocon_expon
      write(iulog,'(A30,1x,8e12.4)') 'p3_qc_accret_expon',      p3_qc_accret_expon
      write(iulog,'(A30,1x,8e12.4)') 'p3_wbf_coeff',            p3_wbf_coeff
-     write(iulog,'(A30,1x,8e12.4)') 'p3_mincdnc',              p3_mincdnc  ! Shanyp
+     write(iulog,'(A30,1x,8e12.4)') 'p3_mincdnc',              p3_mincdnc 
      write(iulog,'(A30,1x,8e12.4)') 'p3_max_mean_rain_size',   p3_max_mean_rain_size
      write(iulog,'(A30,1x,8e12.4)') 'p3_embryonic_rain_size',  p3_embryonic_rain_size
      write(iulog,'(A30,1x,L)')    'do_prescribed_CCN: ',       do_prescribed_CCN
@@ -215,7 +215,7 @@ subroutine micro_p3_readnl(nlfile)
   call mpibcast(p3_accret_coeff,         1 ,                         mpir8,   0, mpicom)
   call mpibcast(p3_qc_accret_expon,      1 ,                         mpir8,   0, mpicom)
   call mpibcast(p3_wbf_coeff,            1 ,                         mpir8,   0, mpicom)
-  call mpibcast(p3_mincdnc,              1 ,                         mpir8,   0, mpicom) ! Shanyp
+  call mpibcast(p3_mincdnc,              1 ,                         mpir8,   0, mpicom) 
   call mpibcast(p3_max_mean_rain_size,   1 ,                         mpir8,   0, mpicom)
   call mpibcast(p3_embryonic_rain_size,  1 ,                         mpir8,   0, mpicom)
   call mpibcast(do_prescribed_CCN,       1,                          mpilog,  0, mpicom)
@@ -1328,7 +1328,7 @@ end subroutine micro_p3_readnl
          p3_nc_autocon_expon,         & ! IN  autoconversion nc exponent
          p3_qc_accret_expon,          & ! IN  autoconversion coefficient
          p3_wbf_coeff,                & ! IN  WBF process coefficient
-         p3_mincdnc,                  & ! IN  imposing minimal Nc Shanyp
+         p3_mincdnc,                  & ! IN  imposing minimal Nc 
          p3_max_mean_rain_size,       & ! IN  max mean rain size
          p3_embryonic_rain_size,      & ! IN  embryonic rain size for autoconversion
          ! AaronDonahue new stuff

--- a/components/eam/src/physics/p3/eam/micro_p3_interface.F90
+++ b/components/eam/src/physics/p3/eam/micro_p3_interface.F90
@@ -129,6 +129,7 @@ module micro_p3_interface
       p3_nc_autocon_expon      = huge(1.0_rtype), &
       p3_qc_accret_expon       = huge(1.0_rtype), &
       p3_wbf_coeff             = huge(1.0_rtype), &
+      p3_mincdnc               = huge(1.0_rtype), & ! Add imposing low Nc limit by Shanyp
       p3_max_mean_rain_size    = huge(1.0_rtype), &
       p3_embryonic_rain_size   = huge(1.0_rtype)
    
@@ -164,7 +165,7 @@ subroutine micro_p3_readnl(nlfile)
        micro_p3_tableversion, micro_p3_lookup_dir, micro_aerosolactivation, micro_subgrid_cloud, &
        micro_tend_output, p3_autocon_coeff, p3_qc_autocon_expon, p3_nc_autocon_expon, p3_accret_coeff, &
        p3_qc_accret_expon, p3_wbf_coeff, p3_max_mean_rain_size, p3_embryonic_rain_size, &
-       do_prescribed_CCN, do_Cooper_inP3
+       do_prescribed_CCN, do_Cooper_inP3, p3_mincdnc ! shanyp add p3_mincdnc
 
   !-----------------------------------------------------------------------------
 
@@ -193,6 +194,7 @@ subroutine micro_p3_readnl(nlfile)
      write(iulog,'(A30,1x,8e12.4)') 'p3_nc_autocon_expon',     p3_nc_autocon_expon
      write(iulog,'(A30,1x,8e12.4)') 'p3_qc_accret_expon',      p3_qc_accret_expon
      write(iulog,'(A30,1x,8e12.4)') 'p3_wbf_coeff',            p3_wbf_coeff
+     write(iulog,'(A30,1x,8e12.4)') 'p3_mincdnc',              p3_mincdnc  ! Shanyp
      write(iulog,'(A30,1x,8e12.4)') 'p3_max_mean_rain_size',   p3_max_mean_rain_size
      write(iulog,'(A30,1x,8e12.4)') 'p3_embryonic_rain_size',  p3_embryonic_rain_size
      write(iulog,'(A30,1x,L)')    'do_prescribed_CCN: ',       do_prescribed_CCN
@@ -213,6 +215,7 @@ subroutine micro_p3_readnl(nlfile)
   call mpibcast(p3_accret_coeff,         1 ,                         mpir8,   0, mpicom)
   call mpibcast(p3_qc_accret_expon,      1 ,                         mpir8,   0, mpicom)
   call mpibcast(p3_wbf_coeff,            1 ,                         mpir8,   0, mpicom)
+  call mpibcast(p3_mincdnc,              1 ,                         mpir8,   0, mpicom) ! Shanyp
   call mpibcast(p3_max_mean_rain_size,   1 ,                         mpir8,   0, mpicom)
   call mpibcast(p3_embryonic_rain_size,  1 ,                         mpir8,   0, mpicom)
   call mpibcast(do_prescribed_CCN,       1,                          mpilog,  0, mpicom)
@@ -1325,6 +1328,7 @@ end subroutine micro_p3_readnl
          p3_nc_autocon_expon,         & ! IN  autoconversion nc exponent
          p3_qc_accret_expon,          & ! IN  autoconversion coefficient
          p3_wbf_coeff,                & ! IN  WBF process coefficient
+         p3_mincdnc,                  & ! IN  imposing minimal Nc Shanyp
          p3_max_mean_rain_size,       & ! IN  max mean rain size
          p3_embryonic_rain_size,      & ! IN  embryonic rain size for autoconversion
          ! AaronDonahue new stuff


### PR DESCRIPTION
This PR merges in imposing Nc for P3 scheme that was developed as part of 
the v3 atmosphere physics NGD.

It imposes an in-cloud Nc in P3 scheme no less than a threshold
(default value is 10 per CC).

[BFB] No impact for tests that do not use the EAM version of P3.

-----------------------------
Passed the tests:
REP_Ln5.ne4pg2_oQU480.F2010.chrysalis_intel.eam-p3.20230516_223330_8i2avn
SMS_D_Ln5.ne4pg2_oQU480.F2010.chrysalis_intel.eam-p3.20230516_223330_8i2avn
ERS.ne4pg2_oQU480.F2010.chrysalis_intel.eam-p3.20230516_223330_8i2avn
ERP.ne4pg2_oQU480.F2010.chrysalis_intel.eam-p3.20230516_223330_8i2avn
PEM_Ln18.ne4pg2_oQU480.F2010.chrysalis_intel.eam-p3.20230516_223330_8i2avn
PET.ne4pg2_oQU480.F2010.chrysalis_intel.eam-p3.20230516_223330_8i2avn
SMS_Ln5.ne30pg2_EC30to60E2r2.F2010.chrysalis_intel.eam-p3.20230516_223330_8i2avn
SMS_Ln5.ne4pg2_oQU480.F2010.chrysalis_intel.eam-p3.20230516_223330_8i2avn