### PR TITLE
Add initial superBFB tests for EAM and WCYCL

### DIFF
--- a/cime_config/testmods_dirs/pemod/omp1/shell_commands
+++ b/cime_config/testmods_dirs/pemod/omp1/shell_commands
@@ -10,4 +10,5 @@ ppn=`./xmlquery --value MAX_MPITASKS_PER_NODE`
 ./xmlchange NTASKS=$(($ppn * 8))
 ./xmlchange NTHRDS=1
 ./xmlchange ROOTPE=0
+./xmlchange PSTRID=1
 

--- a/cime_config/testmods_dirs/pemod/omp2/shell_commands
+++ b/cime_config/testmods_dirs/pemod/omp2/shell_commands
@@ -11,4 +11,5 @@ ppn=`./xmlquery --value MAX_MPITASKS_PER_NODE`
 ./xmlchange NTASKS=$(($ppn * 4))
 ./xmlchange NTHRDS=2
 ./xmlchange ROOTPE=0
+./xmlchange PSTRID=1
 

--- a/cime_config/testmods_dirs/pemod/ompfull/shell_commands
+++ b/cime_config/testmods_dirs/pemod/ompfull/shell_commands
@@ -11,4 +11,5 @@ ppn=`./xmlquery --value MAX_MPITASKS_PER_NODE`
 ./xmlchange NTASKS=8
 ./xmlchange NTHRDS=$ppn
 ./xmlchange ROOTPE=0
+./xmlchange PSTRID=1
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -800,7 +800,7 @@ _TESTS = {
         "time"    : "02:00:00",
         "tests"   : (
             "PET_Ld3_D.ne30pg2_EC30to60E2r2.WCYCL1850.pemod-omp2",
-            "ERS_Ld3_D.ne30pg2_EC30to60E2r2.WCYCL1850.pemod-ompfull",
+            "ERS_Ld3_D.ne30pg2_EC30to60E2r2.WCYCL1850.pemod-omp2",
         )
     },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -683,7 +683,7 @@ _TESTS = {
             )
     },
 
-    # super-BFB
+    # super-BFB OCN
     "e3sm_superbfb_ocn_opt" : { # opt + pureMPI
         #"share"   : True,
         "time"    : "00:30:00",
@@ -723,6 +723,94 @@ _TESTS = {
     "e3sm_superbfb_ocn" : {
         "inherit" : ("e3sm_superbfb_ocn_dbg", "e3sm_superbfb_ocn_opt",
                      "e3sm_superbfb_ocn_dbg_thrd", "e3sm_superbfb_ocn_opt_thrd"),
+    },
+
+    # super-BFB ATM
+    "e3sm_superbfb_atm_opt" : { # opt + pureMPI
+        #"share"   : True,
+        "time"    : "00:30:00",
+        "tests"   : (
+            "ERS_Lh3.ne30pg2_ne30pg2.FAQP.pemod-omp1",
+            "PEM_Lh3.ne30pg2_ne30pg2.FAQP.pemod-omp1",
+        )
+    },
+
+    "e3sm_superbfb_atm_dbg" : { # dbg + pureMPI
+        #"share"   : True,
+        "time"    : "01:00:00",
+        "tests"   : (
+            "ERS_Lh3_D.ne30pg2_ne30pg2.FAQP.pemod-omp1",
+            "PEM_Lh3_D.ne30pg2_ne30pg2.FAQP.pemod-omp1",
+        )
+    },
+
+    "e3sm_superbfb_atm_opt_thrd" : { # opt + threads
+        #"share"   : True,
+        "time"    : "00:30:00",
+        "tests"   : (
+            "PET_Lh3.ne30pg2_ne30pg2.FAQP.pemod-omp2",
+            "ERS_Lh3.ne30pg2_ne30pg2.FAQP.pemod-ompfull",
+        )
+    },
+
+    "e3sm_superbfb_atm_dbg_thrd" : { # dbg + threads
+        #"share"   : True,
+        "time"    : "01:00:00",
+        "tests"   : (
+            "PET_Lh3_D.ne30pg2_ne30pg2.FAQP.pemod-omp2",
+            "ERS_Lh3_D.ne30pg2_ne30pg2.FAQP.pemod-ompfull",
+        )
+    },
+
+    "e3sm_superbfb_atm" : {
+        "inherit" : ("e3sm_superbfb_atm_dbg", "e3sm_superbfb_atm_opt",
+                     "e3sm_superbfb_atm_dbg_thrd", "e3sm_superbfb_atm_opt_thrd"),
+    },
+
+    # super-BFB all-active
+    "e3sm_superbfb_wcycl_opt" : { # opt + pureMPI
+        #"share"   : True,
+        "time"    : "01:00:00",
+        "tests"   : (
+            "ERS_Ld3.ne30pg2_EC30to60E2r2.WCYCL1850.pemod-omp1",
+            "PEM_Ld3.ne30pg2_EC30to60E2r2.WCYCL1850.pemod-omp1",
+        )
+    },
+
+    "e3sm_superbfb_wcycl_dbg" : { # dbg + pureMPI
+        #"share"   : True,
+        "time"    : "02:00:00",
+        "tests"   : (
+            "ERS_Ld3_D.ne30pg2_EC30to60E2r2.WCYCL1850.pemod-omp1",
+            "PEM_Ld3_D.ne30pg2_EC30to60E2r2.WCYCL1850.pemod-omp1",
+        )
+    },
+
+    "e3sm_superbfb_wcycl_opt_thrd" : { # opt + threads
+        #"share"   : True,
+        "time"    : "01:00:00",
+        "tests"   : (
+            "PET_Ld3.ne30pg2_EC30to60E2r2.WCYCL1850.pemod-omp2",
+            "ERS_Ld3.ne30pg2_EC30to60E2r2.WCYCL1850.pemod-ompfull",
+        )
+    },
+
+    "e3sm_superbfb_wcycl_dbg_thrd" : { # dbg + threads
+        #"share"   : True,
+        "time"    : "02:00:00",
+        "tests"   : (
+            "PET_Ld3_D.ne30pg2_EC30to60E2r2.WCYCL1850.pemod-omp2",
+            "ERS_Ld3_D.ne30pg2_EC30to60E2r2.WCYCL1850.pemod-ompfull",
+        )
+    },
+
+    "e3sm_superbfb_wcycl" : {
+        "inherit" : ("e3sm_superbfb_wcycl_dbg", "e3sm_superbfb_wcycl_opt",
+                     "e3sm_superbfb_wcycl_dbg_thrd", "e3sm_superbfb_wcycl_opt_thrd"),
+    },
+
+    "e3sm_superbfb" : {
+        "inherit" : ("e3sm_superbfb_atm", "e3sm_superbfb_wcycl"),
     },
 }
 


### PR DESCRIPTION
The purpose of this suite is to make sure new code maintains
bit-for-bit properties we demand of the model.  These properties include:
- exact restart:  the model should be able to restart during a run with bit-for-bit 
identical results compared to a model which ran for the same total time without restarting.
- MPI-task count invariance:  The model should give the same answers 
between two runs that only differed by the number of MPI tasks used.
- OpenMP thread count invariance:  The model should give the same answers 
between two runs that only differ by number of OpenMP threads used.

There is a suite for each major component model (`atm`, `ocn`, `ice`, `lnd`, `rof`, and 
fully-coupled `wcycl`). They cover the standard-resolution grids in both 
release/optimized and debug configurations.

[BFB]