### PR TITLE
Change explicit solver equation for SO2 and H2SO4

### DIFF
--- a/components/eam/src/chemistry/mozart/mo_exp_sol.F90
+++ b/components/eam/src/chemistry/mozart/mo_exp_sol.F90
@@ -136,6 +136,9 @@ contains
        
     end do
 !----------- for UCIchem diagnostics ------------
+    ! Note: base_sol_rest and diags_reaction_rates are passed to indprd and exp_prod_loss
+    !       so the reset tendency for tropopause folds (i.e., stratospheric boxes below the tropopause)
+    !       and the explicit solver tendency are included in chemmp_prod and chemmp_loss below.
     call indprd( 1, ind_prd, clscnt1, base_sol_reset, extfrc, &
          diags_reaction_rates, ncol )
     call exp_prod_loss( prod, loss, base_sol_reset, diags_reaction_rates, het_rates )

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -1044,6 +1044,9 @@ contains
           do k = 1,pver
              if ( .not. tropFlag(i,k) ) then
                 vmr(i,k,:) = vmr_old2(i,k,:)
+                ! Zero out the reaction rates (only for diagnostic purpose) in the stratosphere
+                ! Only need to do this one time and diags_reaction_rates will be used below
+                ! in the exp_sol to diagnose the chemistry prod/loss rates.
                 diags_reaction_rates(i,k,:) = 0._r8
              endif
           enddo


### PR DESCRIPTION
SO2 and H2SO4 can be dead zeros due to aerosol processes, which fails the debug test (https://github.com/E3SM-Project/E3SM/issues/5646). This PR implements a different equation in the explicit solver for these two tracers to avoid the issue without a limiter.

Since SO2 and H2SO4 are handled by the implicit solver, instead of the explicit solver, in v2 compsets, this PR is BFB for v2 tests.

Fixes #5646, #5648

[BFB] Tests not using chemUCI are not affected. Tests using chemUCI will be NBFB.