### PR TITLE
Add chem mech file for decoupling chemUCI and VBS SOA

### DIFF
--- a/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam4_resus_mom_vbs.in
+++ b/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam4_resus_mom_vbs.in
@@ -89,7 +89,7 @@ SPECIES
  End Solution
 
  Fixed
-   M, N2, O2, H2O, H2, CH4, cnst_O3, cnst_NO3, cnst_OH
+   M, N2, O2, H2O, H2, CH4, prsd_O3, prsd_NO3, prsd_OH
  End Fixed
 
  Col-int
@@ -264,21 +264,21 @@ CHEMISTRY
 
 
 * VBS SOAG reactions
-[vsoag0_oh]   SOAG0 + cnst_OH -> 1.15*SOAG15                                  ; 2e-11
-[vsoag15_oh]  SOAG15 + cnst_OH -> 1.15*SOAG24                                 ; 2e-11
-[vsoag24_oh]  SOAG24 + cnst_OH -> 0.46*SOAG33 + 0.5*SOAG35                   ; 2e-11
+[vsoag0_oh]   SOAG0 + prsd_OH -> 1.15*SOAG15                                  ; 2e-11
+[vsoag15_oh]  SOAG15 + prsd_OH -> 1.15*SOAG24                                 ; 2e-11
+[vsoag24_oh]  SOAG24 + prsd_OH -> 0.46*SOAG33 + 0.5*SOAG35                   ; 2e-11
 
-[visop_oh]    ISOP_VBS + cnst_OH -> 0.00272*SOAG32 + 0.00981*SOAG33 + 0.00218*SOAG34     ; 2.54e-11, 410
-[vc10h16_oh]  C10H16 + cnst_OH -> 0.14986*SOAG32 + 0.05450*SOAG33 + 0.09264*SOAG34          ; 1.2e-11, 444
-[visop_o3]    ISOP_VBS + cnst_O3 -> 0.00327*SOAG33                                       ; 1.05e-14, -2000
-[vc10h16_o3]  C10H16 + cnst_O3 -> 0.04360*SOAG31 + 0.01035*SOAG32 + 0.09809*SOAG33 + 0.01635*SOAG34  ; 1.e-15, -732
-[visop_no3]   ISOP_VBS + cnst_NO3 -> 0.00027*SOAG32 + 0.04060*SOAG33 + 0.06458*SOAG34     ; 3.03e-12,-446
-[vc10h16_no3] C10H16 + cnst_NO3 -> 0.17493*SOAG33 + 0.59019*SOAG34                   ; 1.2e-12, 490
+[visop_oh]    ISOP_VBS + prsd_OH -> 0.00272*SOAG32 + 0.00981*SOAG33 + 0.00218*SOAG34     ; 2.54e-11, 410
+[vc10h16_oh]  C10H16 + prsd_OH -> 0.14986*SOAG32 + 0.05450*SOAG33 + 0.09264*SOAG34          ; 1.2e-11, 444
+[visop_o3]    ISOP_VBS + prsd_O3 -> 0.00327*SOAG33                                       ; 1.05e-14, -2000
+[vc10h16_o3]  C10H16 + prsd_O3 -> 0.04360*SOAG31 + 0.01035*SOAG32 + 0.09809*SOAG33 + 0.01635*SOAG34  ; 1.e-15, -732
+[visop_no3]   ISOP_VBS + prsd_NO3 -> 0.00027*SOAG32 + 0.04060*SOAG33 + 0.06458*SOAG34     ; 3.03e-12,-446
+[vc10h16_no3] C10H16 + prsd_NO3 -> 0.17493*SOAG33 + 0.59019*SOAG34                   ; 1.2e-12, 490
 
-[vsoag35_oh]  SOAG35 + cnst_OH -> 0.46*SOAG34  + 0.5*SOAG35     ; 2e-11
-[vsoag34_oh]  SOAG34 + cnst_OH -> 0.46*SOAG33  + 0.5*SOAG35     ; 2e-11
-[vsoag33_oh]  SOAG33 + cnst_OH -> 0.46*SOAG32  + 0.5*SOAG35     ; 2e-11
-[vsoag32_oh]  SOAG32 + cnst_OH -> 0.46*SOAG31  + 0.5*SOAG35     ; 2e-11
+[vsoag35_oh]  SOAG35 + prsd_OH -> 0.46*SOAG34  + 0.5*SOAG35     ; 2e-11
+[vsoag34_oh]  SOAG34 + prsd_OH -> 0.46*SOAG33  + 0.5*SOAG35     ; 2e-11
+[vsoag33_oh]  SOAG33 + prsd_OH -> 0.46*SOAG32  + 0.5*SOAG35     ; 2e-11
+[vsoag32_oh]  SOAG32 + prsd_OH -> 0.46*SOAG31  + 0.5*SOAG35     ; 2e-11
  End Reactions
 
  Ext Forcing

--- a/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam5_vbs.in
+++ b/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam5_vbs.in
@@ -1,4 +1,5 @@
 Comments
+     "Changed to Chem-UCI-MAM5 by Ziming Ke"
      "last touch 20200326 - QT"
      "Modified by Juno Hsu and Qi Tang - 4/9/2020"
      "chemUCI + MAM4 for E3SM"
@@ -60,6 +61,7 @@ SPECIES
   so4_a1 -> NH4HSO4
   so4_a2 -> NH4HSO4
   so4_a3 -> NH4HSO4
+  so4_a5 -> NH4HSO4
   pom_a1 -> C
 * pom_a2 does not exist
   pom_a3 -> C
@@ -86,6 +88,7 @@ SPECIES
   num_a2 -> H
   num_a3 -> H
   num_a4 -> H
+  num_a5 -> H
  End Solution
 
  Fixed
@@ -106,13 +109,13 @@ Solution Classes
    CO, C2H6, C3H8, CH3COCH3
    E90, N2OLNZ, NOYLNZ, CH4LNZ, H2OLNZ
    DMS, SO2, H2SO4
-   so4_a1,  so4_a2,  so4_a3
+   so4_a1,  so4_a2,  so4_a3,  so4_a5
    pom_a1,           pom_a3,  pom_a4
    bc_a1,            bc_a3,   bc_a4
    dst_a1,           dst_a3
    ncl_a1,  ncl_a2,  ncl_a3
    mom_a1,  mom_a2,  mom_a3,  mom_a4
-   num_a1,  num_a2,  num_a3,  num_a4
+   num_a1,  num_a2,  num_a3,  num_a4, num_a5
  End Explicit
 
  Implicit

--- a/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam5_vbs.in
+++ b/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam5_vbs.in
@@ -92,7 +92,7 @@ SPECIES
  End Solution
 
  Fixed
-   M, N2, O2, H2O, H2, CH4, cnst_O3, cnst_NO3, cnst_OH
+   M, N2, O2, H2O, H2, CH4, prsd_O3, prsd_NO3, prsd_OH
  End Fixed
 
  Col-int
@@ -267,21 +267,21 @@ CHEMISTRY
 
 
 * VBS SOAG reactions
-[vsoag0_oh]   SOAG0 + cnst_OH -> 1.15*SOAG15                                  ; 2e-11
-[vsoag15_oh]  SOAG15 + cnst_OH -> 1.15*SOAG24                                 ; 2e-11
-[vsoag24_oh]  SOAG24 + cnst_OH -> 0.46*SOAG33 + 0.5*SOAG35                   ; 2e-11
+[vsoag0_oh]   SOAG0 + prsd_OH -> 1.15*SOAG15                                  ; 2e-11
+[vsoag15_oh]  SOAG15 + prsd_OH -> 1.15*SOAG24                                 ; 2e-11
+[vsoag24_oh]  SOAG24 + prsd_OH -> 0.46*SOAG33 + 0.5*SOAG35                   ; 2e-11
 
-[visop_oh]    ISOP_VBS + cnst_OH -> 0.00272*SOAG32 + 0.00981*SOAG33 + 0.00218*SOAG34     ; 2.54e-11, 410
-[vc10h16_oh]  C10H16 + cnst_OH -> 0.14986*SOAG32 + 0.05450*SOAG33 + 0.09264*SOAG34          ; 1.2e-11, 444
-[visop_o3]    ISOP_VBS + cnst_O3 -> 0.00327*SOAG33                                       ; 1.05e-14, -2000
-[vc10h16_o3]  C10H16 + cnst_O3 -> 0.04360*SOAG31 + 0.01035*SOAG32 + 0.09809*SOAG33 + 0.01635*SOAG34  ; 1.e-15, -732
-[visop_no3]   ISOP_VBS + cnst_NO3 -> 0.00027*SOAG32 + 0.04060*SOAG33 + 0.06458*SOAG34     ; 3.03e-12,-446
-[vc10h16_no3] C10H16 + cnst_NO3 -> 0.17493*SOAG33 + 0.59019*SOAG34                   ; 1.2e-12, 490
+[visop_oh]    ISOP_VBS + prsd_OH -> 0.00272*SOAG32 + 0.00981*SOAG33 + 0.00218*SOAG34     ; 2.54e-11, 410
+[vc10h16_oh]  C10H16 + prsd_OH -> 0.14986*SOAG32 + 0.05450*SOAG33 + 0.09264*SOAG34          ; 1.2e-11, 444
+[visop_o3]    ISOP_VBS + prsd_O3 -> 0.00327*SOAG33                                       ; 1.05e-14, -2000
+[vc10h16_o3]  C10H16 + prsd_O3 -> 0.04360*SOAG31 + 0.01035*SOAG32 + 0.09809*SOAG33 + 0.01635*SOAG34  ; 1.e-15, -732
+[visop_no3]   ISOP_VBS + prsd_NO3 -> 0.00027*SOAG32 + 0.04060*SOAG33 + 0.06458*SOAG34     ; 3.03e-12,-446
+[vc10h16_no3] C10H16 + prsd_NO3 -> 0.17493*SOAG33 + 0.59019*SOAG34                   ; 1.2e-12, 490
 
-[vsoag35_oh]  SOAG35 + cnst_OH -> 0.46*SOAG34  + 0.5*SOAG35     ; 2e-11
-[vsoag34_oh]  SOAG34 + cnst_OH -> 0.46*SOAG33  + 0.5*SOAG35     ; 2e-11
-[vsoag33_oh]  SOAG33 + cnst_OH -> 0.46*SOAG32  + 0.5*SOAG35     ; 2e-11
-[vsoag32_oh]  SOAG32 + cnst_OH -> 0.46*SOAG31  + 0.5*SOAG35     ; 2e-11
+[vsoag35_oh]  SOAG35 + prsd_OH -> 0.46*SOAG34  + 0.5*SOAG35     ; 2e-11
+[vsoag34_oh]  SOAG34 + prsd_OH -> 0.46*SOAG33  + 0.5*SOAG35     ; 2e-11
+[vsoag33_oh]  SOAG33 + prsd_OH -> 0.46*SOAG32  + 0.5*SOAG35     ; 2e-11
+[vsoag32_oh]  SOAG32 + prsd_OH -> 0.46*SOAG31  + 0.5*SOAG35     ; 2e-11
  End Reactions
 
  Ext Forcing

--- a/components/eam/src/chemistry/mozart/mo_chm_diags.F90
+++ b/components/eam/src/chemistry/mozart/mo_chm_diags.F90
@@ -815,7 +815,7 @@ contains
     enddo
 
     ! Add sum of mass mixing ratios for each aerosol class
-    if (history_aerosol .and. .not. history_verbose) then
+    if (history_aerosol) then
        call addfld( 'Mass_bc',   (/ 'lev' /), 'A', 'kg/kg ', &
             'sum of bc mass concentration bc_a1+bc_c1+bc_a3+bc_c3+bc_a4+bc_c4')
        call add_default( 'Mass_bc', 1, ' ' )
@@ -1041,8 +1041,8 @@ contains
     ! Mass_soa = soa_a1 + soa_c1 + soa_a2 + soa_c2 + soa_a3 + soa_c3
 
     !initialize the mass arrays
-    if (history_aerosol .and. .not. history_verbose) then
-       mass_bc(:ncol,:) = 0._r8
+    if (history_aerosol) then
+       mass_bc(:ncol,:)  = 0._r8
        mass_dst(:ncol,:) = 0._r8
        mass_mom(:ncol,:) = 0._r8
        mass_ncl(:ncol,:) = 0._r8
@@ -1233,7 +1233,7 @@ contains
           call outfld( solsym(m), mmr(:ncol,:,m), ncol ,lchnk )
           call outfld( trim(solsym(m))//'_SRF', mmr(:ncol,pver,m), ncol ,lchnk )
 #ifdef MODAL_AERO
-          if (history_aerosol .and. .not. history_verbose) then
+          if (history_aerosol) then
              select case (trim(solsym(m)))
              case ('bc_a1','bc_a3','bc_a4')
                   mass_bc(:ncol,:) = mass_bc(:ncol,:) + mmr(:ncol,:,m)
@@ -1245,7 +1245,11 @@ contains
                   mass_ncl(:ncol,:) = mass_ncl(:ncol,:) + mmr(:ncol,:,m)
              case ('pom_a1','pom_a3','pom_a4')
                   mass_pom(:ncol,:) = mass_pom(:ncol,:) + mmr(:ncol,:,m)
+#if (defined MODAL_AERO_5MODE)
+             case ('so4_a1','so4_a2','so4_a3','so4_a5')
+#else
              case ('so4_a1','so4_a2','so4_a3')
+#endif
                   mass_so4(:ncol,:) = mass_so4(:ncol,:) + mmr(:ncol,:,m)
              case ('soa_a1','soa_a2','soa_a3')
                   mass_soa(:ncol,:) = mass_soa(:ncol,:) + mmr(:ncol,:,m)
@@ -1299,7 +1303,7 @@ contains
 
 #ifdef MODAL_AERO
     ! diagnostics for cloud-borne aerosols, then add to corresponding mass accumulators
-    if (history_aerosol .and. .not. history_verbose) then
+    if (history_aerosol) then
 
 
        do n = 1,pcnst
@@ -1316,7 +1320,11 @@ contains
                      mass_ncl(:ncol,:) = mass_ncl(:ncol,:) + fldcw(:ncol,:)
                 case ('pom_c1','pom_c3','pom_c4')
                      mass_pom(:ncol,:) = mass_pom(:ncol,:) + fldcw(:ncol,:)
+#if (defined MODAL_AERO_5MODE)
+                case ('so4_c1','so4_c2','so4_c3','so4_c5')
+#else
                 case ('so4_c1','so4_c2','so4_c3')
+#endif
                      mass_so4(:ncol,:) = mass_so4(:ncol,:) + fldcw(:ncol,:)
                 case ('soa_c1','soa_c2','soa_c3')
                      mass_soa(:ncol,:) = mass_soa(:ncol,:) + fldcw(:ncol,:)


### PR DESCRIPTION
This small PR aims to

1. decouple chemUCI and VBS SOA. Two files are added.
    - pp_chemUCI_linozv3_mam5_vbs.in is for final chemistry-aerosol chem mech in, 
       which has chemUCI+MAM5+VBS SOA

    - pp_chemUCI_linozv3_mam4_resus_mom_vbs.in is for chemUCI+MAM4+VBS SOA

     Note that it also needs to change user_nl_eam for decoupling chemUCI and VBS SOA, 
     which can be done in runscript for now.

2.  Change if statement so that adding history_verbose won't remove Mass_xx output, and correct Mass_so4 for MAM5 strat sulfate (including so4_a5 and so4_c5). 
3. 
[BFB] For tests with present v2-like compsets and for v3-like tests with chemUCI-Linozv3 alone 

----------------------------------------------------------------------------
The 1) It has already been tested in NGD_v3atm branch, see /lcrc/group/e3sm/ac.mwu/archive/20230512.F2010.NGD_v3atm.SOAtest09.PD.chrysalis/

The '2)' above is for including [PR#42](https://github.com/E3SM-Project/v3atm/pull/42/files) in NGD_v3atm. As we discussed in last Friday's meeting (05/19/2023), we decided to also include this small PR
