### PR TITLE
[Standalone MPAS-Ocean] Warn if `debugTracers` enabled with single layer in RK4

### DIFF
--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -1741,7 +1741,7 @@ module ocn_time_integration_rk4
          if (config_use_debugTracers .and. nVertLevels == 1) then
             call mpas_log_write('Debug tracers cannot be used in a ' &
                // 'single layer case. Consider setting ' &
-               // 'config_use_debugTracers to .false.', MPAS_LOG_CRIT)
+               // 'config_use_debugTracers to .false.', MPAS_LOG_WARN)
          endif
          block => block % next
       end do

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -1739,7 +1739,7 @@ module ocn_time_integration_rk4
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
          if (config_use_debugTracers .and. nVertLevels == 1) then
-            call mpas_log_write('Debug tracers cannot be used in a ' &
+            call mpas_log_write('Debug tracers may cause failures in a ' &
                // 'single layer case. Consider setting ' &
                // 'config_use_debugTracers to .false.', MPAS_LOG_WARN)
          endif


### PR DESCRIPTION
Recently, it had been made a critical error when `debugTracers` are used with RK4 in single-layer mode.  This was because this configuration is incompatible with many single-layer test cases. However, we would also shown that the cosine-bell advection test case does work with `debugTracers `and single layer.  To support this case, we switch from a critical error to a warning in this merge.