### PR TITLE
Aqueous chemistry bug fix

### DIFF
--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -1265,7 +1265,7 @@ contains
     call t_startf('aero_model_gasaerexch')
     call aero_model_gasaerexch( imozart-1, ncol, lchnk, delt, latndx, lonndx, reaction_rates, &
                                 tfld, pmid, pdel, mbar, relhum, &
-                                zm,  qh2o, cwat, cldfr, ncldwtr, &
+                                zm,  qh2o, cwat_liq, cldfr, ncldwtr, &  ! replace cwat with cwat_liq for SO2 aqueous chemsitry bug fix 
                                 invariants(:,:,indexm), invariants, del_h2so4_gasprod,  &
                                 vmr0, vmr, pbuf )
     call t_stopf('aero_model_gasaerexch')

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -1265,7 +1265,7 @@ contains
     call t_startf('aero_model_gasaerexch')
     call aero_model_gasaerexch( imozart-1, ncol, lchnk, delt, latndx, lonndx, reaction_rates, &
                                 tfld, pmid, pdel, mbar, relhum, &
-                                zm,  qh2o, cwat_liq, cldfr, ncldwtr, &  ! replace cwat with cwat_liq for SO2 aqueous chemsitry bug fix 
+                                zm,  qh2o, cwat_liq, cldfr, ncldwtr, &  
                                 invariants(:,:,indexm), invariants, del_h2so4_gasprod,  &
                                 vmr0, vmr, pbuf )
     call t_stopf('aero_model_gasaerexch')


### PR DESCRIPTION
This PR is for fixing the the aqueous chemistry bug where total condensate (liquid +ice) mass mixing ratio was used for the SO2 aqueous chemistry process. The problem is that only liquid water mass mixing ratio should be used here. The bug was found because P3 produces more ice mass which leads to a much larger sulfate production from aqueous chemistry compared to MG2. By working together with Dick Easter, we identified this problem and we also got confirmed from NCAR.  


Fixes #5713 
[CC]

Two files need to be changed for this fix: chemistry.F90 and mo_gas_phase_chemdr.F90.  (really just the latter)

https://github.com/E3SM-Project/E3SM/pull/new/JiwenFan/E3SM/aqueouschemsitry_bugfix. 