### PR TITLE
Add a manufactured solution to MPAS-Ocean

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -988,6 +988,15 @@ add_default($nl, 'config_transport_tests_flow_id');
 
 add_default($nl, 'config_vert_levels');
 
+#########################################
+# Namelist group: manufactured_solution #
+#########################################
+
+add_default($nl, 'config_use_manufactured_solution');
+add_default($nl, 'config_manufactured_solution_wavelength_x');
+add_default($nl, 'config_manufactured_solution_wavelength_y');
+add_default($nl, 'config_manufactured_solution_amplitude');
+
 ################################################
 # Namelist group: tracer_forcing_activeTracers #
 ################################################
@@ -1757,6 +1766,7 @@ my @groups = qw(run_modes
                 testing
                 transport_tests
                 init_mode_vert_levels
+                manufactured_solution
                 tracer_forcing_activetracers
                 tracer_forcing_debugtracers
                 tracer_forcing_ecosystracers

--- a/components/mpas-ocean/bld/build-namelist-group-list
+++ b/components/mpas-ocean/bld/build-namelist-group-list
@@ -39,6 +39,7 @@ my @groups = qw(run_modes
                 testing
                 transport_tests
                 init_mode_vert_levels
+                manufactured_solution
                 tracer_forcing_activetracers
                 tracer_forcing_debugtracers
                 tracer_forcing_ecosystracers

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -507,6 +507,15 @@ add_default($nl, 'config_transport_tests_flow_id');
 
 add_default($nl, 'config_vert_levels');
 
+#########################################
+# Namelist group: manufactured_solution #
+#########################################
+
+add_default($nl, 'config_use_manufactured_solution');
+add_default($nl, 'config_manufactured_solution_wavelength_x');
+add_default($nl, 'config_manufactured_solution_wavelength_y');
+add_default($nl, 'config_manufactured_solution_amplitude');
+
 ################################################
 # Namelist group: tracer_forcing_activeTracers #
 ################################################

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -532,6 +532,12 @@
 <!-- init_mode_vert_levels -->
 <config_vert_levels>-1</config_vert_levels>
 
+<!-- manufactured_solution -->
+<config_use_manufactured_solution>.false.</config_use_manufactured_solution>
+<config_manufactured_solution_wavelength_x>2000000.0</config_manufactured_solution_wavelength_x>
+<config_manufactured_solution_wavelength_y>2000000.0</config_manufactured_solution_wavelength_y>
+<config_manufactured_solution_amplitude>1</config_manufactured_solution_amplitude>
+
 <!-- tracer_forcing_activeTracers -->
 <config_use_activeTracers>.true.</config_use_activeTracers>
 <config_use_activeTracers_surface_bulk_forcing>.true.</config_use_activeTracers_surface_bulk_forcing>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -17,7 +17,7 @@
           An abbreviation of the fortran declaration for the variable.
       Valid declarations are:
 
-          char*n  
+          char*n
           integer
           logical
           real
@@ -31,7 +31,7 @@
      input_pathname
           Only include this attribute to indicate that the variable
           contains the pathname of an input dataset that resides in the
-          CESM inputdata directory tree.  
+          CESM inputdata directory tree.
 
       The recognized values are "abs" to indicate that an absolute
           pathname is required, or "rel:var_name" to indicate that the
@@ -1748,6 +1748,14 @@ Valid values: any positive real, typically 5.0e-4
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_thickness_drag_type" type="char*1024"
+	category="bottom_drag" group="bottom_drag">
+The type of layerThickness averaging to use on the drag term. The standard MPAS-O approach is 'centered'.
+
+Valid values: 'harmonic-mean', 'centered'
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- Rayleigh_damping -->
 
@@ -1799,14 +1807,6 @@ Default: Defined in namelist_defaults.xml
 Vegetation drag coefficient
 
 Valid values: O(1)
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_thickness_drag_type" type="char*1024"
-	category="bottom_drag" group="bottom_drag">
-The type of layerThickness averaging to use on the drag term. The standard MPAS-O approach is 'centered'.
-
-Valid values: 'harmonic-mean', 'centered'
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -2553,6 +2553,41 @@ Default: Defined in namelist_defaults.xml
 Number of vertical levels to create within the configuration.
 
 Valid values: Any positive non-zero integer. A value of -1 causes this to be overwritten with the configurations vertical level definition.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+
+<!-- manufactured_solution -->
+
+<entry id="config_use_manufactured_solution" type="logical"
+	category="manufactured_solution" group="manufactured_solution">
+This flag includes additional thickness and velocity tendencies necessary for testing with a manufactured solution.
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_manufactured_solution_wavelength_x" type="real"
+	category="manufactured_solution" group="manufactured_solution">
+Wavelength of manufactured solution in the x direction
+
+Valid values: Any positive real number
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_manufactured_solution_wavelength_y" type="real"
+	category="manufactured_solution" group="manufactured_solution">
+Wavelength of manufactured solution in the y direction
+
+Valid values: Any positive real number
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_manufactured_solution_amplitude" type="real"
+	category="manufactured_solution" group="manufactured_solution">
+Amplitude of the manufactured solution
+
+Valid values: Any positive real number
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1535,15 +1535,15 @@
 	</nml_record>
 	<nml_record name="manufactured_solution">
 		<nml_option name="config_use_manufactured_solution" type="logical" default_value=".false."
-					description="This flag includes additional thickness and velocity tendencies nesseary for testing with a manufactured solution."
+					description="This flag includes additional thickness and velocity tendencies necessary for testing with a manufactured solution."
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_manufactured_solution_wavelength_x" type="real" default_value="2000000.0" units="m"
-					description="Wavelenth of manufactured solution in the x direction"
+					description="Wavelength of manufactured solution in the x direction"
 					possible_values="Any positive real number"
 		/>
 		<nml_option name="config_manufactured_solution_wavelength_y" type="real" default_value="2000000.0" units="m"
-					description="Wavelenth of manufactured solution in the y direction"
+					description="Wavelength of manufactured solution in the y direction"
 					possible_values="Any positive real number"
 		/>
 		<nml_option name="config_manufactured_solution_amplitude" type="real" default_value="1" units="m"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1533,6 +1533,28 @@
 					possible_values="Any positive non-zero integer. A value of -1 causes this to be overwritten with the configurations vertical level definition."
 		/>
 	</nml_record>
+	<nml_record name="manufactured_solution">
+		<nml_option name="config_use_manufactured_solution" type="logical" default_value=".false."
+					description="This flag includes additional thickness and velocity tendencies nesseary for testing with a manufactured solution."
+					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_manufactured_solution_wavelength_x" type="real" default_value="2000000.0" units="m"
+					description="Wavelenth of manufactured solution in the x direction"
+					possible_values="Any positive real number"
+		/>
+		<nml_option name="config_manufactured_solution_wavelength_y" type="real" default_value="2000000.0" units="m"
+					description="Wavelenth of manufactured solution in the y direction"
+					possible_values="Any positive real number"
+		/>
+		<nml_option name="config_manufactured_solution_omega" type="real" default_value="0" units="s^-1"
+					description="Angular frequency of manufactured solution"
+					possible_values="Any positive real number"
+		/>
+		<nml_option name="config_manufactured_solution_amplitude" type="real" default_value="1" units="m"
+					description="Amplitude of the manufactured solution"
+					possible_values="Any positive real number"
+		/>
+	</nml_record>
 	<packages>
 		<package name="timeVaryingAtmosphericForcingPKG" description="This package includes variables required for time varying atmospheric forcing"/>
 		<package name="timeVaryingLandIceForcingPKG" description="This package includes variavles required for time varying land-ice forcing"/>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1546,10 +1546,6 @@
 					description="Wavelenth of manufactured solution in the y direction"
 					possible_values="Any positive real number"
 		/>
-		<nml_option name="config_manufactured_solution_omega" type="real" default_value="0" units="s^-1"
-					description="Angular frequency of manufactured solution"
-					possible_values="Any positive real number"
-		/>
 		<nml_option name="config_manufactured_solution_amplitude" type="real" default_value="1" units="m"
 					description="Amplitude of the manufactured solution"
 					possible_values="Any positive real number"

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -78,6 +78,7 @@ module ocn_forward_mode
    use ocn_gm
    use ocn_submesoscale_eddies
    use ocn_stokes_drift 
+   use ocn_manufactured_solution
 
    use ocn_high_freq_thickness_hmix_del2
 
@@ -498,6 +499,8 @@ module ocn_forward_mode
       if ( configVertAdvMethod == vertAdvRemap ) &
          call ocn_vertical_remap_init(err_tmp)
       call ocn_stokes_drift_init(err_tmp)
+      ierr = ior(ierr,err_tmp)
+      call ocn_manufactured_solution_init(domain, err_tmp)
       ierr = ior(ierr,err_tmp)
 
       if (ierr /= 0) then

--- a/components/mpas-ocean/src/ocean.cmake
+++ b/components/mpas-ocean/src/ocean.cmake
@@ -105,6 +105,7 @@ list(APPEND RAW_SOURCES
   core_ocean/shared/mpas_ocn_wetting_drying.F
   core_ocean/shared/mpas_ocn_vel_tidal_potential.F
   core_ocean/shared/mpas_ocn_stokes_drift.F
+  core_ocean/shared/mpas_ocn_manufactured_solution.F 
 )
 
 set(OCEAN_DRIVER

--- a/components/mpas-ocean/src/shared/Makefile
+++ b/components/mpas-ocean/src/shared/Makefile
@@ -75,13 +75,14 @@ OBJS = mpas_ocn_init_routines.o \
 	   mpas_ocn_transport_tests.o \
 	   mpas_ocn_vel_self_attraction_loading.o \
 	   mpas_ocn_vertical_advection.o \
-           mpas_ocn_stokes_drift.o
+           mpas_ocn_stokes_drift.o \
+           mpas_ocn_manufactured_solution.o
 
 all: $(OBJS)
 
 mpas_ocn_init_routines.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics.o mpas_ocn_diagnostics_variables.o mpas_ocn_gm.o mpas_ocn_submesoscale_eddies.o mpas_ocn_forcing.o mpas_ocn_surface_land_ice_fluxes.o
 
-mpas_ocn_tendency.o: mpas_ocn_high_freq_thickness_hmix_del2.o mpas_ocn_tracer_surface_restoring.o mpas_ocn_thick_surface_flux.o mpas_ocn_tracer_short_wave_absorption.o mpas_ocn_tracer_advection.o mpas_ocn_tracer_hmix.o mpas_ocn_tracer_nonlocalflux.o mpas_ocn_surface_bulk_forcing.o mpas_ocn_surface_land_ice_fluxes.o mpas_ocn_tracer_surface_flux_to_tend.o mpas_ocn_tracer_interior_restoring.o mpas_ocn_tracer_exponential_decay.o mpas_ocn_tracer_ideal_age.o mpas_ocn_tracer_TTD.o mpas_ocn_vmix.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_frazil_forcing.o mpas_ocn_tidal_forcing.o mpas_ocn_tracer_ecosys.o mpas_ocn_tracer_DMS.o mpas_ocn_tracer_MacroMolecules.o mpas_ocn_tracer_CFC.o mpas_ocn_diagnostics.o mpas_ocn_wetting_drying.o mpas_ocn_vel_self_attraction_loading.o  mpas_ocn_vel_tidal_potential.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o mpas_ocn_thick_hadv.o mpas_ocn_thick_vadv.o mpas_ocn_vel_hadv_coriolis.o mpas_ocn_vel_pressure_grad.o mpas_ocn_vel_vadv.o mpas_ocn_vel_hmix.o mpas_ocn_vel_forcing.o
+mpas_ocn_tendency.o: mpas_ocn_high_freq_thickness_hmix_del2.o mpas_ocn_tracer_surface_restoring.o mpas_ocn_thick_surface_flux.o mpas_ocn_tracer_short_wave_absorption.o mpas_ocn_tracer_advection.o mpas_ocn_tracer_hmix.o mpas_ocn_tracer_nonlocalflux.o mpas_ocn_surface_bulk_forcing.o mpas_ocn_surface_land_ice_fluxes.o mpas_ocn_tracer_surface_flux_to_tend.o mpas_ocn_tracer_interior_restoring.o mpas_ocn_tracer_exponential_decay.o mpas_ocn_tracer_ideal_age.o mpas_ocn_tracer_TTD.o mpas_ocn_vmix.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_frazil_forcing.o mpas_ocn_tidal_forcing.o mpas_ocn_tracer_ecosys.o mpas_ocn_tracer_DMS.o mpas_ocn_tracer_MacroMolecules.o mpas_ocn_tracer_CFC.o mpas_ocn_diagnostics.o mpas_ocn_wetting_drying.o mpas_ocn_vel_self_attraction_loading.o  mpas_ocn_vel_tidal_potential.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o mpas_ocn_thick_hadv.o mpas_ocn_thick_vadv.o mpas_ocn_vel_hadv_coriolis.o mpas_ocn_vel_pressure_grad.o mpas_ocn_vel_vadv.o mpas_ocn_vel_hmix.o mpas_ocn_vel_forcing.o mpas_ocn_manufactured_solution.o
 
 mpas_ocn_diagnostics.o: mpas_ocn_thick_ale.o mpas_ocn_equation_of_state.o mpas_ocn_gm.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o mpas_ocn_surface_land_ice_fluxes.o mpas_ocn_vertical_advection.o mpas_ocn_submesoscale_eddies.o
 
@@ -234,6 +235,8 @@ mpas_ocn_vertical_regrid.o: mpas_ocn_config.o mpas_ocn_constants.o mpas_ocn_mesh
 mpas_ocn_vertical_remap.o: mpas_ocn_config.o mpas_ocn_constants.o mpas_ocn_diagnostics_variables.o mpas_ocn_mesh.o mpas_ocn_vertical_regrid.o
 
 mpas_ocn_stokes_drift.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o mpas_ocn_mesh.o
+
+mpas_ocn_manufactured_solution.o:  mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o 
 
 clean:
 	$(RM) *.o *.i *.mod *.f90

--- a/components/mpas-ocean/src/shared/mpas_ocn_manufactured_solution.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_manufactured_solution.F
@@ -220,7 +220,6 @@ contains
       kx = 2.0_RKIND*pii / config_manufactured_solution_wavelength_x
       ky = 2.0_RKIND*pii / config_manufactured_solution_wavelength_y
 
-      omega = config_manufactured_solution_omega
       eta0 = config_manufactured_solution_amplitude
 
       block => domain % blocklist
@@ -230,8 +229,11 @@ contains
          call mpas_pool_get_array(verticalMeshPool, 'restingThickness', restingThickness)
 
          H0 = restingThickness(1,1)
+
          block => block % next
       enddo
+
+      omega = sqrt(H0*gravity * (kx**2+ky**2))
 
       err = 0
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_manufactured_solution.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_manufactured_solution.F
@@ -1,0 +1,245 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.io/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_manufactured_solution
+!
+!> \brief Computes tendency terms for a manufactured solution
+!> \author Steven Brus, Carolyn Begeman
+!> \date   June 2023
+!> \details
+!>  This module contains the routines for computing the thickness and
+!>  normal velocity tendencies for a manufactured solution case. See
+!>  Bishnu et al. 2022 (https://doi.org/10.22541/essoar.167100170.03833124/v1)
+!
+!-----------------------------------------------------------------------
+
+module ocn_manufactured_solution 
+
+   use mpas_constants
+   use mpas_timer
+   use mpas_timekeeping
+   use ocn_constants
+   use ocn_config
+   use ocn_mesh
+   use ocn_diagnostics_variables
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: ocn_manufactured_solution_tend_thick, &
+             ocn_manufactured_solution_tend_vel, &
+             ocn_manufactured_solution_init
+
+   !--------------------------------------------------------------------
+   !
+   ! Private module variables
+   !
+   !--------------------------------------------------------------------
+
+   real (kind=RKIND) :: kx, ky
+   real (kind=RKIND) :: omega
+   real (kind=RKIND) :: eta0
+   real (kind=RKIND) :: H0
+
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+!
+!  routine ocn_manufactured_solution_tend_thick 
+!
+!> \brief  Computes manufactured solution thickness tendency
+!> \author Steven Brus, Carolyn Begeman
+!> \date   June 2023 
+!> \details
+!>  This routine computes the thickness tendency for the manufactured solution
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_manufactured_solution_tend_thick(tend, err)!{{{
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend          !< Input/Output: thickness tendency 
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: iCell, kmin, kmax, k
+      real (kind=RKIND) :: phase, time
+
+      ! End preamble
+      !-------------
+      ! Begin code
+
+      if (.not. config_use_manufactured_solution) return
+
+      time = daysSinceStartOfSim*86400.0_RKIND
+
+      do iCell = 1,nCellsOwned
+
+         kmin = minLevelCell(iCell)
+         kmax = maxLevelCell(iCell)
+
+         phase = kx*xCell(iCell) + ky*yCell(iCell) - omega*time
+         do k = kmin, kmax
+            tend(k,iCell) = tend(k,iCell) + eta0*(-H0*(kx + ky)*sin(phase) &
+                                                  - omega*cos(phase) &
+                                                  + eta0*(kx + ky)*cos(2.0_RKIND*phase))
+         enddo
+
+         err = 0
+
+      enddo
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_manufactured_solution_tend_thick!}}}
+
+!***********************************************************************
+!
+!  routine ocn_manufactured_solution_tend_vel 
+!
+!> \brief  Computes manufactured solution velocity tendency 
+!> \author Steven Brus, Carolyn Begeman
+!> \date   June 2023 
+!> \details
+!>  This routine computes the velocity tendency for the manufactured solution
+!
+!-----------------------------------------------------------------------
+   subroutine ocn_manufactured_solution_tend_vel(tend, err)!{{{
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend          !< Input/Output: velocity tendency 
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: iEdge, kmin, kmax, k
+      real (kind=RKIND) :: phase, u, v, time
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      if (.not. config_use_manufactured_solution) return
+
+      time = daysSinceStartOfSim*86400.0_RKIND
+
+      do iEdge = 1, nEdgesOwned
+
+         kmin = minLevelEdgeBot(iEdge)
+         kmax = maxLevelEdgeTop(iEdge)
+
+         phase = kx*xEdge(iEdge) + ky*yEdge(iEdge) - omega*time
+
+         do k = kmin, kmax
+
+            u = eta0*((-fEdge(iEdge) + gravity*kx)*cos(phase) &
+                       + omega*sin(phase) &
+                       - 0.5_RKIND*eta0*(kx + ky)*sin(2.0_RKIND*(phase)))
+            v = eta0*((fEdge(iEdge) + gravity*ky)*cos(phase) &
+                      + omega*sin(phase) &
+                      - 0.5_RKIND*eta0*(kx + ky)*sin(2.0_RKIND*(phase))) 
+
+            tend(k,iEdge) = tend(k,iEdge) + u*cos(angleEdge(iEdge)) + v*sin(angleEdge(iEdge))
+         enddo
+
+         err = 0
+
+      enddo
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_manufactured_solution_tend_vel!}}}
+
+!***********************************************************************
+!
+!  routine ocn_manufactured_solution_init
+!
+!> \brief  Initialize the manufactured solution tendencies 
+!> \author Steven Brus, Carolyn Begeman
+!> \date   June 2023 
+!> \details
+!>  This routine initializes constants related to the manufactured
+!>  solution tendencies
+!
+!-----------------------------------------------------------------------
+    subroutine ocn_manufactured_solution_init(domain, err)!{{{
+
+      type (domain_type), intent(inout) :: domain      
+      integer, intent(out) :: err !< Output: Error flag
+
+      type (block_type), pointer :: block
+      type (mpas_pool_type), pointer :: verticalMeshPool
+      real (kind=RKIND), dimension(:,:), pointer :: restingThickness
+
+      if (.not. config_use_manufactured_solution) return
+
+      kx = 2.0_RKIND*pii / config_manufactured_solution_wavelength_x
+      ky = 2.0_RKIND*pii / config_manufactured_solution_wavelength_y
+
+      omega = config_manufactured_solution_omega
+      eta0 = config_manufactured_solution_amplitude
+
+      block => domain % blocklist
+      do while (associated(block))
+         call mpas_pool_get_subpool(block % structs, 'verticalMesh', verticalMeshPool)
+
+         call mpas_pool_get_array(verticalMeshPool, 'restingThickness', restingThickness)
+
+         H0 = restingThickness(1,1)
+         block => block % next
+      enddo
+
+      err = 0
+
+    end subroutine ocn_manufactured_solution_init!}}}
+
+!***********************************************************************
+
+end module ocn_manufactured_solution
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+! vim: foldmethod=marker

--- a/components/mpas-ocean/src/shared/mpas_ocn_manufactured_solution.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_manufactured_solution.F
@@ -56,7 +56,7 @@ module ocn_manufactured_solution
    !--------------------------------------------------------------------
 
    real (kind=RKIND) :: kx, ky
-   real (kind=RKIND) :: omega
+   real (kind=RKIND) :: ang_freq
    real (kind=RKIND) :: eta0
    real (kind=RKIND) :: H0
 
@@ -111,10 +111,10 @@ contains
          kmin = minLevelCell(iCell)
          kmax = maxLevelCell(iCell)
 
-         phase = kx*xCell(iCell) + ky*yCell(iCell) - omega*time
+         phase = kx*xCell(iCell) + ky*yCell(iCell) - ang_freq*time
          do k = kmin, kmax
             tend(k,iCell) = tend(k,iCell) + eta0*(-H0*(kx + ky)*sin(phase) &
-                                                  - omega*cos(phase) &
+                                                  - ang_freq*cos(phase) &
                                                   + eta0*(kx + ky)*cos(2.0_RKIND*phase))
          enddo
 
@@ -172,15 +172,15 @@ contains
          kmin = minLevelEdgeBot(iEdge)
          kmax = maxLevelEdgeTop(iEdge)
 
-         phase = kx*xEdge(iEdge) + ky*yEdge(iEdge) - omega*time
+         phase = kx*xEdge(iEdge) + ky*yEdge(iEdge) - ang_freq*time
 
          do k = kmin, kmax
 
             u = eta0*((-fEdge(iEdge) + gravity*kx)*cos(phase) &
-                       + omega*sin(phase) &
+                       + ang_freq*sin(phase) &
                        - 0.5_RKIND*eta0*(kx + ky)*sin(2.0_RKIND*(phase)))
             v = eta0*((fEdge(iEdge) + gravity*ky)*cos(phase) &
-                      + omega*sin(phase) &
+                      + ang_freq*sin(phase) &
                       - 0.5_RKIND*eta0*(kx + ky)*sin(2.0_RKIND*(phase))) 
 
             tend(k,iEdge) = tend(k,iEdge) + u*cos(angleEdge(iEdge)) + v*sin(angleEdge(iEdge))
@@ -233,7 +233,7 @@ contains
          block => block % next
       enddo
 
-      omega = sqrt(H0*gravity * (kx**2+ky**2))
+      ang_freq = sqrt(H0*gravity * (kx**2+ky**2))
 
       err = 0
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_manufactured_solution.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_manufactured_solution.F
@@ -118,9 +118,9 @@ contains
                                                   + eta0*(kx + ky)*cos(2.0_RKIND*phase))
          enddo
 
-         err = 0
-
       enddo
+
+      err = 0
 
    !--------------------------------------------------------------------
 
@@ -186,9 +186,9 @@ contains
             tend(k,iEdge) = tend(k,iEdge) + u*cos(angleEdge(iEdge)) + v*sin(angleEdge(iEdge))
          enddo
 
-         err = 0
-
       enddo
+
+      err = 0
 
    !--------------------------------------------------------------------
 
@@ -222,6 +222,10 @@ contains
 
       eta0 = config_manufactured_solution_amplitude
 
+
+      ! This test case assumes that the restingThickness is horizontally uniform
+      ! and that only one vertical level is used so only one set of indices is
+      ! used here.
       block => domain % blocklist
       do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'verticalMesh', verticalMeshPool)

--- a/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
@@ -67,6 +67,7 @@ module ocn_tendency
    use ocn_wetting_drying
    use ocn_vel_tidal_potential
    use ocn_vel_self_attraction_loading
+   use ocn_manufactured_solution
 
    implicit none
    private
@@ -224,6 +225,9 @@ contains
       ! Compute thickness change due to tidal forcing
       call ocn_tidal_forcing_layer_thickness(forcingPool, &
                                              tendThick, err)
+
+      ! Compute thickness tendency to manufactured solution
+      call ocn_manufactured_solution_tend_thick(tendThick, err)
 
 #ifdef MPAS_OPENACC
       !$acc exit data copyout(tendThick, surfaceThicknessFlux, surfaceThicknessFluxRunoff)
@@ -447,6 +451,9 @@ contains
                                 sfcStress, kineticEnergyCell, &
                                 layerThickEdgeDrag, &
                                 layerThickEdgeMean, tendVel, err)
+ 
+      ! Compute tendency term for manufactured solution
+      call ocn_manufactured_solution_tend_vel(tendVel, err)
 
       ! vertical mixing treated implicitly in a later routine
       ! adjust total velocity tendency based on wetting/drying


### PR DESCRIPTION
This PR adds the tendencies necessary for a manufactured solution test case in MPAS-Ocean. The details of the case can be found in Section 3.7 of a pre-print by Sid Bishnu et al. https://doi.org/10.22541/essoar.167100170.03833124/v1. 

A convergence study that uses this feature has been added to the polaris package https://github.com/E3SM-Project/polaris/pull/72. 

Note that currently this case shows first order convergence due to the issue #5364. However, corrections to the RK4 substep time forcing yields the expected 2nd order convergence. A follow-on PR will be submitted to address this issue.

[BFB]
[NML]