### PR TITLE
Improve the aerosol wet removal parameterization

### DIFF
--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -1673,14 +1673,14 @@ contains
        if (lphase .eq. 2) then
         fldcw => qqcw_get_field(pbuf, mm,lchnk)
         fldcw(:,:) = fldcw(:,:) + dcondt_resusp3d(mm+pcnst,:,:) !*dt
-!The dcondt_resusp3d is detrained aerosol AMOUNT (i.e., both mass
-!and number for four modals).
-!For dcondt_resusp3d(idx,:,:), idx=16,...,40 -> interstial aerosols
-!                              idx=56,...,80 -> cloud-borne aerosols
-! Currently, we assume that no aerosol resuspension occurrs during convective
-! cloud water detrainment. So, 100% of cloud-borne aerosols will be added to
-! stratiform cloud-borne aerosols and detrained interstial aerosol amount is
-! zero.
+        ! The dcondt_resusp3d is detrained aerosol AMOUNT (i.e., both mass
+        ! and number for four modes).
+        ! For dcondt_resusp3d(idx,:,:), idx=16,...,40 -> interstial aerosols
+        !                               idx=56,...,80 -> cloud-borne aerosols
+        ! Currently, we assume that no aerosol resuspension occurrs during convective
+        ! cloud water detrainment. So, 100% of cloud-borne aerosols will be added to
+        ! stratiform cloud-borne aerosols and detrained interstial aerosol amount is
+        ! zero.
        end if
       end do ! loop over number + chem constituents + water <shanyp the loop is
              ! changed: no aerosol water is considered.

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -68,7 +68,7 @@ module aero_model
   integer :: icwmrsh_idx        = 0
   integer :: sh_frac_idx        = 0
   integer :: dp_frac_idx        = 0
-
+  integer :: wuc_idx            = 0
   integer :: imozart             = -1 
   logical :: history_aero_prevap_resusp = .false. ! controls output of prevap resusp tendencies to history
 
@@ -378,7 +378,7 @@ contains
     icwmrsh_idx      = pbuf_get_index('ICWMRSH')
     sh_frac_idx      = pbuf_get_index('SH_FRAC')
     dp_frac_idx      = pbuf_get_index('DP_FRAC')
-
+    wuc_idx          = pbuf_get_index('WUC')
 
     nwetdep = 0
     ndrydep = 0
@@ -1382,7 +1382,7 @@ contains
        cam_out,                                                                 & !Intent-inout
        pbuf,                                                                    & !Pointer
        ptend,                                                                   & !Intent-out
-       clear_rh, wuc                                                            ) !optional 
+       clear_rh                                                            ) !optional 
 
     use modal_aero_deposition, only: set_srf_wetdep
     use wetdep,                only: wetdepa_v2, wetdep_inputs_set, &
@@ -1427,7 +1427,6 @@ contains
     real(r8), optional,  intent(in)    :: clear_rh(pcols,pver) ! optional clear air relative humidity 
                                                                ! that gets passed to modal_aero_wateruptake_dr
 
-   real(r8),intent(in),optional :: wuc(pcols,pver)
    real(r8) :: dcondt_resusp3d(2*pcnst,pcols, pver)
 
     ! local vars
@@ -1504,6 +1503,7 @@ contains
     real(r8), pointer :: rate1ord_cw2pr_st(:,:)
 
     real(r8), pointer :: fracis(:,:,:)   ! fraction of transported species that are insoluble
+    real(r8), pointer :: wuc(:,:)
 
     integer, parameter:: nsrflx_mzaer2cnvpr = 2  !RCE 2012/01/12 bgn
     real(r8)          :: aerdepwetis(pcols,pcnst) ! aerosol wet deposition (interstitial) 
@@ -1642,6 +1642,7 @@ contains
        call pbuf_get_field(pbuf, icwmrsh_idx,     icwmrsh )
        call pbuf_get_field(pbuf, sh_frac_idx,     sh_frac )
        call pbuf_get_field(pbuf, dp_frac_idx,     dp_frac )
+       call pbuf_get_field(pbuf, wuc_idx,          wuc )
 
        call t_startf('ma_convproc')
        call ma_convproc_intr( state, ptend, pbuf, dt,                   &
@@ -1673,14 +1674,14 @@ contains
        if (lphase .eq. 2) then
         fldcw => qqcw_get_field(pbuf, mm,lchnk)
         fldcw(:,:) = fldcw(:,:) + dcondt_resusp3d(mm+pcnst,:,:) !*dt
-        ! The dcondt_resusp3d is detrained aerosol AMOUNT (i.e., both mass
-        ! and number for four modes).
-        ! For dcondt_resusp3d(idx,:,:), idx=16,...,40 -> interstial aerosols
-        !                               idx=56,...,80 -> cloud-borne aerosols
-        ! Currently, we assume that no aerosol resuspension occurrs during convective
-        ! cloud water detrainment. So, 100% of cloud-borne aerosols will be added to
-        ! stratiform cloud-borne aerosols and detrained interstial aerosol amount is
-        ! zero.
+!The dcondt_resusp3d is detrained aerosol AMOUNT (i.e., both mass
+!and number for four modes).
+!For dcondt_resusp3d(idx,:,:), idx=16,...,40 -> interstial aerosols
+!                              idx=56,...,80 -> cloud-borne aerosols
+! Currently, we assume that no aerosol resuspension occurrs during convective
+! cloud water detrainment. So, 100% of cloud-borne aerosols will be added to
+! stratiform cloud-borne aerosols and detrained interstial aerosol amount is
+! zero.
        end if
       end do ! loop over number + chem constituents + water <shanyp the loop is
              ! changed: no aerosol water is considered.

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -2007,7 +2007,6 @@ lphase_jnmw_conditional: &
                       sflx(i)=sflx(i)+dqdt_tmp(i,k)*state%pdel(i,k)/gravit
                    enddo
                 enddo
-!                if ( .not. convproc_do_aer ) call outfld( trim(cnst_name(mm))//'SFWET', sflx, pcols, lchnk)
                 aerdepwetis(:ncol,mm) = aerdepwetis(:ncol,mm) + sflx(:ncol)
                 if ( convproc_do_aer ) call outfld(trim(cnst_name(mm))//'SFWET', aerdepwetis(:,mm), pcols, lchnk)
                 sflx(:)=0._r8

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -100,6 +100,7 @@ module aero_model
   real(r8)          :: sol_factb_interstitial  = 0.1_r8
   real(r8)          :: sol_factic_interstitial = 0.4_r8
   real(r8)          :: seasalt_emis_scale
+  real(r8)          :: small = 1.e-36
 
   integer :: ndrydep = 0
   integer,allocatable :: drydep_indices(:)
@@ -1381,7 +1382,7 @@ contains
        cam_out,                                                                 & !Intent-inout
        pbuf,                                                                    & !Pointer
        ptend,                                                                   & !Intent-out
-       clear_rh                                                                 ) !optional 
+       clear_rh, wuc                                                            ) !optional 
 
     use modal_aero_deposition, only: set_srf_wetdep
     use wetdep,                only: wetdepa_v2, wetdep_inputs_set, &
@@ -1426,6 +1427,8 @@ contains
     real(r8), optional,  intent(in)    :: clear_rh(pcols,pver) ! optional clear air relative humidity 
                                                                ! that gets passed to modal_aero_wateruptake_dr
 
+   real(r8),intent(in),optional :: wuc(pcols,pver)
+   real(r8) :: dcondt_resusp3d(2*pcnst,pcols, pver)
 
     ! local vars
 
@@ -1525,6 +1528,8 @@ contains
 
     lchnk = state%lchnk
     ncol  = state%ncol
+
+    dcondt_resusp3d(:,:,:) = 0._r8
 
     call physics_ptend_init(ptend, state%psetcols, 'aero_model_wetdep_ma', lq=wetdep_lq)
 
@@ -1629,6 +1634,59 @@ contains
        rtscavt_sv(:,:,:) = 0.0_r8
        rcscavt_cn_sv(:,:) = 0.0_r8
        rsscavt_cn_sv(:,:) = 0.0_r8
+    endif
+
+    if (convproc_do_aer) then
+
+       call pbuf_get_field(pbuf, icwmrdp_idx,     icwmrdp )
+       call pbuf_get_field(pbuf, icwmrsh_idx,     icwmrsh )
+       call pbuf_get_field(pbuf, sh_frac_idx,     sh_frac )
+       call pbuf_get_field(pbuf, dp_frac_idx,     dp_frac )
+
+       call t_startf('ma_convproc')
+       call ma_convproc_intr( state, ptend, pbuf, dt,                   &
+            dp_frac, icwmrdp, rprddp, evapcdp,                          &
+            sh_frac, icwmrsh, rprdsh, evapcsh,                          &
+            dlf, dlf2, cmfmc2, sh_e_ed_ratio,                           &
+            nsrflx_mzaer2cnvpr, qsrflx_mzaer2cnvpr, aerdepwetis,        &
+            mu, md, du, eu, ed, dp, dsubcld, jt, maxg, ideep, lengath,  &
+            species_class, mam_prevap_resusp_optaa,                     &
+            history_aero_prevap_resusp, &
+            dcondt_resusp3d=dcondt_resusp3d,wuc=wuc)
+    do m = 1, ntot_amode ! main loop over aerosol modes
+     do lphase = strt_loop,end_loop, stride_loop
+      ! loop over interstitial (1) and cloud-borne (2) forms
+      do lspec = 0, nspec_amode(m) !+1 ! loop over number + chem constituents + water
+       if (lspec == 0) then ! number
+        if (lphase == 1) then
+         mm = numptr_amode(m)
+        else
+         mm = numptrcw_amode(m)
+        endif
+       else if (lspec <= nspec_amode(m)) then ! non-water mass
+        if (lphase == 1) then
+         mm = lmassptr_amode(lspec,m)
+        else
+         mm = lmassptrcw_amode(lspec,m)
+        endif
+       endif
+       if (lphase .eq. 2) then
+        fldcw => qqcw_get_field(pbuf, mm,lchnk)
+        fldcw(:,:) = fldcw(:,:) + dcondt_resusp3d(mm+pcnst,:,:) !*dt
+!The dcondt_resusp3d is detrained aerosol AMOUNT (i.e., both mass
+!and number for four modals).
+!For dcondt_resusp3d(idx,:,:), idx=16,...,40 -> interstial aerosols
+!                              idx=56,...,80 -> cloud-borne aerosols
+! Currently, we assume that no aerosol resuspension occurrs during convective
+! cloud water detrainment. So, 100% of cloud-borne aerosols will be added to
+! stratiform cloud-borne aerosols and detrained interstial aerosol amount is
+! zero.
+       end if
+      end do ! loop over number + chem constituents + water <shanyp the loop is
+             ! changed: no aerosol water is considered.
+     end do  ! lphase
+    end do   ! m aerosol modes
+       call t_stopf('ma_convproc')
     endif
 
 mmode_loop_aa: &
@@ -1876,6 +1934,9 @@ lphase_jnmw_conditional: &
                 dqdt_tmp(:,:) = 0.0_r8
                 ! q_tmp reflects changes from modal_aero_calcsize and is the "most current" q
                 q_tmp(1:ncol,:) = state%q(1:ncol,:,mm) + ptend%q(1:ncol,:,mm)*dt
+                where(q_tmp(1:ncol,:).lt.small)
+                 q_tmp(1:ncol,:)=small
+                end where
                 if (convproc_do_aer) then
                    !Feed in the saved cloudborne mixing ratios from phase 2
                    qqcw_in(:,:) = qqcw_sav(:,:,lspec)
@@ -1946,9 +2007,9 @@ lphase_jnmw_conditional: &
                       sflx(i)=sflx(i)+dqdt_tmp(i,k)*state%pdel(i,k)/gravit
                    enddo
                 enddo
-                if ( .not. convproc_do_aer ) call outfld( trim(cnst_name(mm))//'SFWET', sflx, pcols, lchnk)
-                aerdepwetis(:ncol,mm) = sflx(:ncol)
-
+!                if ( .not. convproc_do_aer ) call outfld( trim(cnst_name(mm))//'SFWET', sflx, pcols, lchnk)
+                aerdepwetis(:ncol,mm) = aerdepwetis(:ncol,mm) + sflx(:ncol)
+                if ( convproc_do_aer ) call outfld(trim(cnst_name(mm))//'SFWET', aerdepwetis(:,mm), pcols, lchnk)
                 sflx(:)=0._r8
                 do k=1,pver
                    do i=1,ncol
@@ -2256,25 +2317,26 @@ do_lphase2_conditional: &
        call set_srf_wetdep(aerdepwetis, aerdepwetcw, cam_out)
     endif
 
-    if (convproc_do_aer) then 
-       
-       call pbuf_get_field(pbuf, icwmrdp_idx,     icwmrdp )
-       call pbuf_get_field(pbuf, icwmrsh_idx,     icwmrsh )
-       call pbuf_get_field(pbuf, sh_frac_idx,     sh_frac )
-       call pbuf_get_field(pbuf, dp_frac_idx,     dp_frac )
-
-       call t_startf('ma_convproc')
-       call ma_convproc_intr( state, ptend, pbuf, dt,                   &
-            dp_frac, icwmrdp, rprddp, evapcdp,                          &
-            sh_frac, icwmrsh, rprdsh, evapcsh,                          &
-            dlf, dlf2, cmfmc2, sh_e_ed_ratio,                           &
-            nsrflx_mzaer2cnvpr, qsrflx_mzaer2cnvpr, aerdepwetis,        &
-            mu, md, du, eu, ed, dp, dsubcld, jt, maxg, ideep, lengath,  &
-            species_class, mam_prevap_resusp_optaa,                     &
-            history_aero_prevap_resusp                                  )
-       call t_stopf('ma_convproc')       
-    endif
-
+!Reorder the wet removal schemes, call deep convection wet removal first
+!then the stratiform wet removal.
+!    if (convproc_do_aer) then 
+!       
+!       call pbuf_get_field(pbuf, icwmrdp_idx,     icwmrdp )
+!       call pbuf_get_field(pbuf, icwmrsh_idx,     icwmrsh )
+!       call pbuf_get_field(pbuf, sh_frac_idx,     sh_frac )
+!       call pbuf_get_field(pbuf, dp_frac_idx,     dp_frac )
+!
+!       call t_startf('ma_convproc')
+!       call ma_convproc_intr( state, ptend, pbuf, dt,                   &
+!            dp_frac, icwmrdp, rprddp, evapcdp,                          &
+!            sh_frac, icwmrsh, rprdsh, evapcsh,                          &
+!            dlf, dlf2, cmfmc2, sh_e_ed_ratio,                           &
+!            nsrflx_mzaer2cnvpr, qsrflx_mzaer2cnvpr, aerdepwetis,        &
+!            mu, md, du, eu, ed, dp, dsubcld, jt, maxg, ideep, lengath,  &
+!            species_class, mam_prevap_resusp_optaa,                     &
+!            history_aero_prevap_resusp                                  )
+!       call t_stopf('ma_convproc')       
+!    endif
     call wetdep_inputs_unset(dep_inputs)
 
   end subroutine aero_model_wetdep

--- a/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
@@ -2243,7 +2243,7 @@ k_loop_main_bb: &
             if ((icwmr(icol,k) > clw_cut) .and. (rprd(icol,k) > 0.0)) then 
 !              if (iconvtype == 1) then
                tmpf = fa_u(k) !0.5_r8*cldfrac_i(k)
-                  cdt(k) = (tmpf*dp(i,k)/mu_p_eudp(k)) * rprd(icol,k) / &
+               cdt(k) = (tmpf*dp(i,k)/mu_p_eudp(k)) * rprd(icol,k) / &
                         (tmpf*icwmr(icol,k) + dt*rprd(icol,k))
 !              else if (k < pver) then
 !                 if (eudp(k+1) > 0) cdt(k) =   &
@@ -2455,8 +2455,8 @@ k_loop_main_cc: &
       call ma_resuspend_convproc( dcondt, dcondt_resusp,   &
                                   const, dp_i, ktop, kbot_prevap, pcnst_extd ) ! REASTER 08/05/2015
 
-     dcondt_resusp3d(pcnst+1:pcnst_extd,icol,:) = dcondt_resusp3d(pcnst+1:pcnst_extd,icol,:) &
-                                                + dcondt(pcnst+1:pcnst_extd,:)*dtsub
+      dcondt_resusp3d(pcnst+1:pcnst_extd,icol,:) = dcondt_resusp3d(pcnst+1:pcnst_extd,icol,:) &
+                                                 + dcondt(pcnst+1:pcnst_extd,:)*dtsub
 !     dcondt_resusp(pcnst+1:pcnst_extd,:) = 0._r8
 
       if ( idiag_in(icol)>0 ) then

--- a/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
@@ -13,7 +13,17 @@ module modal_aero_convproc
 !
 ! Author: R. C. Easter
 !
-!---------------------------------------------------------------------------------
+!---------------------------------------------------------------------------------------------------------------------------------
+! Improvements from Yunpeng Shan, Jiwen Fan, and Kai Zhang                                                                       !
+! 1) Use vertical velocity from ZMmp to calculate the (previously prescribed) in-cloud supersaturation, Lagrangian timestep, and !
+! pdraft fraction.                                                                                                               !
+! 2) Consider the cloud-borne aerosol detrainment. This makes cloud-borne aerosol evolution consistent with the convective cloud !
+! condensate.                                                                                                                    !
+! 3) Reorder the deep convection wet removal and stratiform wet removal.                                                         !
+! Shan, Y., X., Liu, L., Lin, Z., Ke, Z., Lu (2021): An improved representation of in-cloud wet removal processes in a global    !
+! climate model and impacts on simulated aerosol vertical profiles, J. Geophys. Res.-Atmos, 126, e2020JD034173.                  !
+! https://doi.org/10.1029/2020JD034173.                                                                                          !
+!________________________________________________________________________________________________________________________________!
 
    use shr_kind_mod, only: r8=>shr_kind_r8
    use physconst,    only: gravit                              
@@ -22,7 +32,8 @@ module modal_aero_convproc
    use cam_logfile,  only: iulog
    use cam_abortutils, only: endrun
    use physconst,    only: spec_class_aerosol, spec_class_gas
-
+   use constituents,  only: pcnst
+   use zm_conv,      only: zm_microp !
    implicit none
 
    save
@@ -194,7 +205,7 @@ subroutine ma_convproc_intr( state, ptend, pbuf, ztodt,             &
                            ed, dp, dsubcld,                         &
                            jt, maxg, ideep, lengath, species_class, &
                            mam_prevap_resusp_optaa,                 &
-                           history_aero_prevap_resusp               )
+                           history_aero_prevap_resusp,dcondt_resusp3d,wuc  )
 !----------------------------------------------------------------------- 
 ! 
 ! Purpose: 
@@ -215,7 +226,8 @@ subroutine ma_convproc_intr( state, ptend, pbuf, ztodt,             &
    use physics_types, only: physics_state, physics_ptend, physics_ptend_init
    use time_manager,  only: get_nstep
    use physics_buffer, only: physics_buffer_desc, pbuf_get_index
-   use constituents,  only: pcnst, cnst_name
+   !use constituents,  only: pcnst, cnst_name
+   use constituents,  only: cnst_name
    use error_messages, only: alloc_err	
 
    use modal_aero_data, only: lmassptr_amode, nspec_amode, ntot_amode, numptr_amode
@@ -260,7 +272,8 @@ subroutine ma_convproc_intr( state, ptend, pbuf, ztodt,             &
    integer,  intent(in)    :: species_class(:)
    integer,  intent(in)    :: mam_prevap_resusp_optaa
    logical,  intent(in)    :: history_aero_prevap_resusp
-
+   real(r8), intent(in),optional :: wuc(pcols,pver)
+   real(r8), intent(inout),optional :: dcondt_resusp3d(2*pcnst,pcols,pver)
 
 ! Local variables
    integer, parameter :: nsrflx = 6        ! last dimension of qsrflx ! REASTER 08/05/2015
@@ -290,6 +303,8 @@ subroutine ma_convproc_intr( state, ptend, pbuf, ztodt,             &
 !
 ! Initialize
 !
+
+   dcondt_resusp3d(:,:,:) = 0._r8
 
 ! apply this minor fix when doing resuspend to coarse mode
    if (mam_prevap_resusp_optaa >= 30) convproc_prevap_resusp_fixaa = .true.
@@ -363,8 +378,7 @@ subroutine ma_convproc_intr( state, ptend, pbuf, ztodt,             &
      ed, dp, dsubcld,                          &
      jt, maxg, ideep, lengath,                 &
      qb, dqdt, dotend, nsrflx, qsrflx,         &
-     species_class, mam_prevap_resusp_optaa    )
-
+     species_class, mam_prevap_resusp_optaa, dcondt_resusp3d=dcondt_resusp3d,wuc=wuc )
 
 ! apply deep conv processing tendency and prepare for shallow conv processing
   do l = 1, pcnst
@@ -472,8 +486,7 @@ subroutine ma_convproc_intr( state, ptend, pbuf, ztodt,             &
         else
            l = lmassptr_amode(ll,n)
         end if
-
-        call outfld( trim(cnst_name(l))//'SFWET', aerdepwetis(:,l), pcols, lchnk )
+!        call outfld( trim(cnst_name(l))//'SFWET', aerdepwetis(:,l), pcols, lchnk )
         call outfld( trim(cnst_name(l))//'SFSIC', sflxic(:,l), pcols, lchnk )
         if ( history_aero_prevap_resusp ) &
         call outfld( trim(cnst_name(l))//'SFSEC', sflxec(:,l), pcols, lchnk )
@@ -500,7 +513,7 @@ subroutine ma_convproc_dp_intr(                &
      ed, dp, dsubcld,                          &
      jt, maxg, ideep, lengath,                 &
      q, dqdt, dotend, nsrflx, qsrflx,          &
-     species_class, mam_prevap_resusp_optaa    )
+     species_class, mam_prevap_resusp_optaa, dcondt_resusp3d, wuc)
 !----------------------------------------------------------------------- 
 ! 
 ! Purpose: 
@@ -563,7 +576,8 @@ subroutine ma_convproc_dp_intr(                &
    integer,  intent(in)    :: lengath           ! Gathered min lon indices over which to operate
    integer,  intent(in)    :: species_class(:)
    integer,  intent(in)    :: mam_prevap_resusp_optaa
-
+   real(r8), intent(in),optional :: wuc(pcols,pver)
+   real(r8), intent(inout),optional :: dcondt_resusp3d(pcnst*2,pcols,pver)
 !  real(r8), intent(in)    :: concld(pcols,pver) ! Convective cloud cover
 
 ! Local variables
@@ -841,7 +855,7 @@ subroutine ma_convproc_dp_intr(                &
                      dqdt,       dotend,     nsrflx,     qsrflx,     &
                      species_class, mam_prevap_resusp_optaa,         & ! REASTER 08/05/2015
                      xx_mfup_max, xx_wcldbase, xx_kcldbase,          &
-                     lun,        itmpveca                            )
+                     lun, itmpveca, dcondt_resusp3d=dcondt_resusp3d, wuc=wuc )
 !                    ed,         dp,         dsubcld,    jt,         &   
 
 
@@ -1470,7 +1484,7 @@ subroutine ma_convproc_tend(                                           &
                      dqdt,       doconvproc, nsrflx,     qsrflx,     &
                      species_class, mam_prevap_resusp_optaa,         & ! REASTER 08/05/2015
                      xx_mfup_max, xx_wcldbase, xx_kcldbase,          &
-                     lun,        idiag_in                            )
+                     lun, idiag_in, dcondt_resusp3d,wuc              )
 
 !----------------------------------------------------------------------- 
 ! 
@@ -1581,7 +1595,8 @@ subroutine ma_convproc_tend(                                           &
    real(r8), intent(out):: xx_kcldbase(pcols)
    integer,  intent(in) :: lun               ! unit number for diagnostic output
    integer,  intent(in) :: idiag_in(pcols)   ! flag for diagnostic output
-
+   real(r8), intent(in), optional :: wuc(pcols,pver)
+   real(r8), intent(inout),optional :: dcondt_resusp3d(pcnst*2,pcols,pver)
 
 !--------------------------Local Variables------------------------------
 
@@ -2056,6 +2071,12 @@ k_loop_main_bb: &
                wup(k) = max( 0.1_r8, min( 4.0_r8, wup(k) ) )
             end if
 
+! update the vertical velocity from convective cloud microphysics scheme
+           if(zm_microp) then
+            wup(k) = wuc(icol,k)
+            wup(k) = max( 0.1_r8, min( 15.0_r8, wup(k) ) )
+           end if
+
 ! compute lagrangian transport time (dt_u) and updraft fractional area (fa_u)
 ! *** these must obey    dt_u(k)*mu_p_eudp(k) = dp_i(k)*fa_u(k)
             dt_u(k) = dz/wup(k)
@@ -2222,7 +2243,10 @@ k_loop_main_bb: &
             cdt(k) = 0.0_r8
             if ((icwmr(icol,k) > clw_cut) .and. (rprd(icol,k) > 0.0)) then 
 !              if (iconvtype == 1) then
-                  tmpf = 0.5_r8*cldfrac_i(k)
+!              tmpf = 0.5_r8*cldfrac_i(k)
+!              fa_u(k) = dt_u(k)*(mu_p_eudp(k)/dp_i(k)) =>
+!              dt_u(k) = tmpf*dp(i,k)/mu_p_eudp(k)
+               tmpf = fa_u(k) !0.5_r8*cldfrac_i(k)
                   cdt(k) = (tmpf*dp(i,k)/mu_p_eudp(k)) * rprd(icol,k) / &
                         (tmpf*icwmr(icol,k) + dt*rprd(icol,k))
 !              else if (k < pver) then
@@ -2434,6 +2458,11 @@ k_loop_main_cc: &
 !    pairs to account any (or total) resuspension of convective-cloudborne aerosol
       call ma_resuspend_convproc( dcondt, dcondt_resusp,   &
                                   const, dp_i, ktop, kbot_prevap, pcnst_extd ) ! REASTER 08/05/2015
+
+     dcondt_resusp3d(pcnst+1:pcnst_extd,icol,:) = dcondt_resusp3d(pcnst+1:pcnst_extd,icol,:) &
+                                                + dcondt(pcnst+1:pcnst_extd,:)*dtsub
+!     dcondt_resusp(pcnst+1:pcnst_extd,:) = 0._r8
+
       if ( idiag_in(icol)>0 ) then
          k = 26
          do m = 16, 23, 7
@@ -3712,7 +3741,7 @@ end subroutine ma_convproc_tend
       call activate_modal(                                                 &
          wbar, sigw, wdiab, wminf, wmaxf, tair, rhoair,                    &
          naerosol, ntot_amode, vaerosol, hygro,                            &
-         fn, fm, fluxn, fluxm, flux_fullact, smax_prescribed               )
+         fn, fm, fluxn, fluxm, flux_fullact              )
    end if
 
 
@@ -3866,11 +3895,20 @@ end subroutine ma_convproc_tend
 !           end if
 
 ! cam5 approach
-            dcondt(la,k) = qdotac
-            dcondt(lc,k) = 0.0
-
-            dcondt_resusp(la,k) = (dcondt(la,k) - qdota)
-            dcondt_resusp(lc,k) = (dcondt(lc,k) - qdotc)
+!            dcondt(la,k) = qdotac
+!            dcondt(lc,k) = 0.0
+!
+!            dcondt_resusp(la,k) = (dcondt(la,k) - qdota)
+!            dcondt_resusp(lc,k) = (dcondt(lc,k) - qdotc)
+            if(qdotc.gt.0._r8) then
+             dcondt(la,k) = qdota
+             dcondt(lc,k) = qdotc
+            else
+             dcondt(la,k) = qdota+qdotc
+             dcondt(lc,k) = 0._r8
+            end if
+            dcondt_resusp(la,k) = 0._r8 !dcondt(la,k)
+            dcondt_resusp(lc,k) = 0._r8 !dcondt(lc,k)
          end do
 
       end do   ! "ll = -1, nspec_amode(n)"

--- a/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
@@ -2243,10 +2243,7 @@ k_loop_main_bb: &
             cdt(k) = 0.0_r8
             if ((icwmr(icol,k) > clw_cut) .and. (rprd(icol,k) > 0.0)) then 
 !              if (iconvtype == 1) then
-!              tmpf = 0.5_r8*cldfrac_i(k)
-!              fa_u(k) = dt_u(k)*(mu_p_eudp(k)/dp_i(k)) =>
-!              dt_u(k) = tmpf*dp(i,k)/mu_p_eudp(k)
-               tmpf = fa_u(k) !0.5_r8*cldfrac_i(k)
+                  tmpf = fa_u(k) !0.5_r8*cldfrac_i(k)
                   cdt(k) = (tmpf*dp(i,k)/mu_p_eudp(k)) * rprd(icol,k) / &
                         (tmpf*icwmr(icol,k) + dt*rprd(icol,k))
 !              else if (k < pver) then
@@ -3895,11 +3892,6 @@ end subroutine ma_convproc_tend
 !           end if
 
 ! cam5 approach
-!            dcondt(la,k) = qdotac
-!            dcondt(lc,k) = 0.0
-!
-!            dcondt_resusp(la,k) = (dcondt(la,k) - qdota)
-!            dcondt_resusp(lc,k) = (dcondt(lc,k) - qdotc)
             if(qdotc.gt.0._r8) then
              dcondt(la,k) = qdota
              dcondt(lc,k) = qdotc

--- a/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_convproc.F90
@@ -15,8 +15,8 @@ module modal_aero_convproc
 !
 !---------------------------------------------------------------------------------------------------------------------------------
 ! Improvements from Yunpeng Shan, Jiwen Fan, and Kai Zhang                                                                       !
-! 1) Use vertical velocity from ZMmp to calculate the (previously prescribed) in-cloud supersaturation, Lagrangian timestep, and !
-! pdraft fraction.                                                                                                               !
+! 1) Use vertical velocity from ZMmp to calculate the in-cloud supersaturation (previously prescribed), Lagrangian timestep, and !
+! updraft fraction.                                                                                                              !
 ! 2) Consider the cloud-borne aerosol detrainment. This makes cloud-borne aerosol evolution consistent with the convective cloud !
 ! condensate.                                                                                                                    !
 ! 3) Reorder the deep convection wet removal and stratiform wet removal.                                                         !
@@ -24,7 +24,6 @@ module modal_aero_convproc
 ! climate model and impacts on simulated aerosol vertical profiles, J. Geophys. Res.-Atmos, 126, e2020JD034173.                  !
 ! https://doi.org/10.1029/2020JD034173.                                                                                          !
 !________________________________________________________________________________________________________________________________!
-
    use shr_kind_mod, only: r8=>shr_kind_r8
    use physconst,    only: gravit                              
    use ppgrid,       only: pver, pcols, pverp, begchunk, endchunk
@@ -2243,7 +2242,7 @@ k_loop_main_bb: &
             cdt(k) = 0.0_r8
             if ((icwmr(icol,k) > clw_cut) .and. (rprd(icol,k) > 0.0)) then 
 !              if (iconvtype == 1) then
-                  tmpf = fa_u(k) !0.5_r8*cldfrac_i(k)
+               tmpf = fa_u(k) !0.5_r8*cldfrac_i(k)
                   cdt(k) = (tmpf*dp(i,k)/mu_p_eudp(k)) * rprd(icol,k) / &
                         (tmpf*icwmr(icol,k) + dt*rprd(icol,k))
 !              else if (k < pver) then

--- a/components/eam/src/physics/cam/convect_deep.F90
+++ b/components/eam/src/physics/cam/convect_deep.F90
@@ -206,7 +206,7 @@ subroutine convect_deep_tend( &
      rliq    ,rice     , &
      ztodt   , &
      state   ,ptend   ,landfrac ,pbuf, mu, eu, &
-     du, md, ed, dp, dsubcld, jt, maxg, ideep,lengath, wuc ) 
+     du, md, ed, dp, dsubcld, jt, maxg, ideep,lengath ) 
 
 
 
@@ -259,7 +259,6 @@ subroutine convect_deep_tend( &
    
    ! w holds position of gathered points vs longitude index   
    integer, intent(out) :: lengath
-   real(r8),intent(inout),optional :: wuc(pcols,pver)
 
    real(r8), pointer :: prec(:)   ! total precipitation
    real(r8), pointer :: snow(:)   ! snow from ZM convection 
@@ -346,7 +345,7 @@ subroutine convect_deep_tend( &
           ztodt   , &
           jctop, jcbot , &
           state   ,ptend   ,landfrac, pbuf, mu, eu, &
-          du, md, ed, dp, dsubcld, jt, maxg, ideep, lengath, wuc)
+          du, md, ed, dp, dsubcld, jt, maxg, ideep, lengath)
      call t_stopf('zm_conv_tend')
 
 

--- a/components/eam/src/physics/cam/convect_deep.F90
+++ b/components/eam/src/physics/cam/convect_deep.F90
@@ -206,7 +206,7 @@ subroutine convect_deep_tend( &
      rliq    ,rice     , &
      ztodt   , &
      state   ,ptend   ,landfrac ,pbuf, mu, eu, &
-     du, md, ed, dp, dsubcld, jt, maxg, ideep,lengath ) 
+     du, md, ed, dp, dsubcld, jt, maxg, ideep,lengath, wuc ) 
 
 
 
@@ -259,6 +259,7 @@ subroutine convect_deep_tend( &
    
    ! w holds position of gathered points vs longitude index   
    integer, intent(out) :: lengath
+   real(r8),intent(inout),optional :: wuc(pcols,pver)
 
    real(r8), pointer :: prec(:)   ! total precipitation
    real(r8), pointer :: snow(:)   ! snow from ZM convection 
@@ -345,7 +346,7 @@ subroutine convect_deep_tend( &
           ztodt   , &
           jctop, jcbot , &
           state   ,ptend   ,landfrac, pbuf, mu, eu, &
-          du, md, ed, dp, dsubcld, jt, maxg, ideep, lengath)
+          du, md, ed, dp, dsubcld, jt, maxg, ideep, lengath, wuc)
      call t_stopf('zm_conv_tend')
 
 

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -2256,8 +2256,6 @@ subroutine tphysbc (ztodt,               &
                              ! after tphysac:clubb_surface and before aerosol dry removal.
                              ! For chemical gases, different versions of EAM 
                              ! might use different process ordering.
-    real(r8) :: wuc(pcols,pver)
-    wuc(:,:) = 0.0_r8 
     !-----------------------------------------------------------------------
     call cnd_diag_checkpoint( diag, 'DYNEND', state, pbuf, cam_in, cam_out )
     !-----------------------------------------------------------------------
@@ -2525,7 +2523,7 @@ end if
          rliq,       rice, &
          ztodt,   &
          state,   ptend, cam_in%landfrac, pbuf, mu, eu, du, md, ed, dp,   &
-         dsubcld, jt, maxg, ideep, lengath, wuc) 
+         dsubcld, jt, maxg, ideep, lengath) 
     call t_stopf('convect_deep_tend')
 
     call physics_update(state, ptend, ztodt, tend)
@@ -2874,7 +2872,7 @@ end if
          call aero_model_wetdep( ztodt, dlf, dlf2, cmfmc2, state,  & ! inputs
                 sh_e_ed_ratio, mu, md, du, eu, ed, dp, dsubcld,    &
                 jt, maxg, ideep, lengath, species_class,           &
-                cam_out, pbuf, ptend, wuc=wuc )                      ! outputs
+                cam_out, pbuf, ptend)                      ! outputs
          call physics_update(state, ptend, ztodt, tend)
 
          ! deep convective aerosol transport

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -2256,7 +2256,8 @@ subroutine tphysbc (ztodt,               &
                              ! after tphysac:clubb_surface and before aerosol dry removal.
                              ! For chemical gases, different versions of EAM 
                              ! might use different process ordering.
-
+    real(r8) :: wuc(pcols,pver)
+    wuc(:,:) = 0.0_r8 
     !-----------------------------------------------------------------------
     call cnd_diag_checkpoint( diag, 'DYNEND', state, pbuf, cam_in, cam_out )
     !-----------------------------------------------------------------------
@@ -2524,7 +2525,7 @@ end if
          rliq,       rice, &
          ztodt,   &
          state,   ptend, cam_in%landfrac, pbuf, mu, eu, du, md, ed, dp,   &
-         dsubcld, jt, maxg, ideep, lengath) 
+         dsubcld, jt, maxg, ideep, lengath, wuc) 
     call t_stopf('convect_deep_tend')
 
     call physics_update(state, ptend, ztodt, tend)
@@ -2873,7 +2874,7 @@ end if
          call aero_model_wetdep( ztodt, dlf, dlf2, cmfmc2, state,  & ! inputs
                 sh_e_ed_ratio, mu, md, du, eu, ed, dp, dsubcld,    &
                 jt, maxg, ideep, lengath, species_class,           &
-                cam_out, pbuf, ptend )                               ! outputs
+                cam_out, pbuf, ptend, wuc=wuc )                      ! outputs
          call physics_update(state, ptend, ztodt, tend)
 
          ! deep convective aerosol transport

--- a/components/eam/src/physics/cam/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm_conv.F90
@@ -330,7 +330,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
                     t_star  ,q_star, dcape,   &
                     aero    ,qi      ,dif     ,dnlf    ,dnif    , & 
                     dsf     ,dnsf    ,sprd    ,rice    ,frz     , &
-                    mudpcu  ,lambdadpcu, microp_st)
+                    mudpcu  ,lambdadpcu, microp_st, wuc)
 !----------------------------------------------------------------------- 
 ! 
 ! Purpose: 
@@ -497,7 +497,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
    real(r8), intent(out) :: frz(pcols,pver)        ! freezing heating
    real(r8), intent(out) :: rice(pcols)            ! reserved ice (not yet in cldce) for energy integrals
    real(r8), intent(out) :: qi(pcols,pver)         ! cloud ice mixing ratio. 
-
+   real(r8), intent(inout),optional :: wuc(pcols,pver) ! vertical velocity from ZMmp
 ! move these vars from local storage to output so that convective
 ! transports can be done in outside of conv_cam.
    real(r8), intent(out) :: mu(pcols,pver)
@@ -1346,6 +1346,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
             microp_st%qns (i,k) = 0.5_r8*(microp_st%qns(i,k)+microp_st%qns(i,k+1))
             microp_st%qng (i,k) = 0.5_r8*(microp_st%qng(i,k)+microp_st%qng(i,k+1))
             microp_st%wu(i,k)   = 0.5_r8*(microp_st%wu(i,k)+microp_st%wu(i,k+1))
+            wuc(i,k) = microp_st%wu(i,k)
          end if
 
          if (t(i,k).gt.tmelt .and. t(i,k-1).le.tmelt) then

--- a/components/eam/src/physics/cam/zm_conv_intr.F90
+++ b/components/eam/src/physics/cam/zm_conv_intr.F90
@@ -57,7 +57,8 @@ module zm_conv_intr
       dnifzm_idx,    &     ! detrained convective cloud ice num concen.
       dnsfzm_idx,    &     ! detrained convective snow num concen.
       prec_dp_idx,   &
-      snow_dp_idx
+      snow_dp_idx,   &
+      wuc_idx
 
 ! DCAPE-ULL
    integer :: t_star_idx       !t_star index in physics buffer
@@ -115,6 +116,9 @@ subroutine zm_conv_register
 
 ! deep gbm cloud liquid water (kg/kg)    
    call pbuf_add_field('DP_CLDICE','global',dtype_r8,(/pcols,pver/), dp_cldice_idx)  
+
+! vertical velocity (m/s)
+   call pbuf_add_field('WUC','global',dtype_r8,(/pcols,pver/), wuc_idx)
 
 ! DCAPE-UPL
 
@@ -440,6 +444,7 @@ subroutine zm_conv_init(pref_edge)
     nevapr_dpcu_idx = pbuf_get_index('NEVAPR_DPCU')
     prec_dp_idx     = pbuf_get_index('PREC_DP')
     snow_dp_idx     = pbuf_get_index('SNOW_DP')
+    wuc_idx         = pbuf_get_index('WUC')
 
     lambdadpcu_idx  = pbuf_get_index('LAMBDADPCU')
     mudpcu_idx      = pbuf_get_index('MUDPCU')
@@ -626,7 +631,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
      ztodt   , &
      jctop   ,jcbot , &
      state   ,ptend_all   ,landfrac,  pbuf, mu, eu, &
-     du, md, ed, dp, dsubcld, jt, maxg, ideep, lengath, wuc) 
+     du, md, ed, dp, dsubcld, jt, maxg, ideep, lengath) 
 
    use cam_history,   only: outfld
    use physics_types, only: physics_state, physics_ptend
@@ -684,7 +689,6 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    
    ! w holds position of gathered points vs longitude index   
    integer, intent(out)  :: lengath
-   real(r8), intent(inout),optional :: wuc(pcols,pver)
    ! Local variables
 
     type(zm_microp_st)        :: microp_st 
@@ -720,6 +724,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    real(r8), pointer, dimension(:,:) :: flxsnow      ! Convective-scale flux of snow   at interfaces (kg/m2/s)
    real(r8), pointer, dimension(:,:) :: dp_cldliq
    real(r8), pointer, dimension(:,:) :: dp_cldice
+   real(r8), pointer, dimension(:,:) :: wuc
 
    ! DCAPE-ULL
    real(r8), pointer, dimension(:,:) :: t_star ! intermediate T between n and n-1 time step
@@ -747,6 +752,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    real(r8) :: cape(pcols)        ! w  convective available potential energy.
    real(r8) :: mu_out(pcols,pver)
    real(r8) :: md_out(pcols,pver)
+
 
    ! used in momentum transport calculation
    real(r8) :: winds(pcols, pver, 2)
@@ -950,9 +956,12 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
       call pbuf_get_field(pbuf, dnifzm_idx, dnif)
       call pbuf_get_field(pbuf, dsfzm_idx,  dsf)
       call pbuf_get_field(pbuf, dnsfzm_idx, dnsf)
+      call pbuf_get_field(pbuf, wuc_idx, wuc  )
    else
       allocate(dnlf(pcols,pver), dnif(pcols,pver),dsf(pcols,pver), dnsf(pcols,pver))
+      allocate(wuc(pcols,pver))
    end if
+   wuc(:,:) = 0._r8
 
    call pbuf_get_field(pbuf, lambdadpcu_idx, lambdadpcu)
    call pbuf_get_field(pbuf, mudpcu_idx,     mudpcu)

--- a/components/eam/src/physics/cam/zm_conv_intr.F90
+++ b/components/eam/src/physics/cam/zm_conv_intr.F90
@@ -626,7 +626,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
      ztodt   , &
      jctop   ,jcbot , &
      state   ,ptend_all   ,landfrac,  pbuf, mu, eu, &
-     du, md, ed, dp, dsubcld, jt, maxg, ideep, lengath) 
+     du, md, ed, dp, dsubcld, jt, maxg, ideep, lengath, wuc) 
 
    use cam_history,   only: outfld
    use physics_types, only: physics_state, physics_ptend
@@ -684,7 +684,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    
    ! w holds position of gathered points vs longitude index   
    integer, intent(out)  :: lengath
-
+   real(r8), intent(inout),optional :: wuc(pcols,pver)
    ! Local variables
 
     type(zm_microp_st)        :: microp_st 
@@ -1000,7 +1000,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
                     lengath ,ql      ,rliq  ,landfrac,  &
                     t_star, q_star, dcape, &  
                     aero(lchnk), qi, dif, dnlf, dnif, dsf, dnsf, sprd, rice, frz, mudpcu, &
-                    lambdadpcu,  microp_st)
+                    lambdadpcu,  microp_st, wuc)
 
    if (zm_microp) then
      dlftot(:,:) = dlf(:,:) + dif(:,:) + dsf(:,:)


### PR DESCRIPTION
Scheme improvements include:
1) Use vertical velocity from ZMmp to calculate the (previously prescribed) in-cloud supersaturation, Lagrangian timestep, and pdraft fraction.
2) Consider the cloud-borne aerosol detrainment. This makes cloud-borne aerosol evolution consistent with the convective cloud condensate.
3) Reorder the deep convection wet removal and stratiform wet removal.
Shan, Y., X., Liu, L., Lin, Z., Ke, Z., Lu (2021): An improved representation of in-cloud wet removal processes in a global climate model and impacts on simulated aerosol vertical profiles, J. Geophys. Res.-Atmos, 126, e2020JD034173. https://doi.org/10.1029/2020JD034173.   
These changes significantly reduce the aerosol loading overestimation and help decrease the overly strong aerosol radiative forcing.

[CC] for both v2 and v3 compsets
---------------------------------------

https://acme-climate.atlassian.net/wiki/spaces/NGDAP/pages/3797549135/Improve+the+aerosol+wet+removal+parameterization

Passed these tests:
SMS_D_Ln5.ne4pg2_oQU480.F2010.chrysalis_intel.eam-p3
PEM_Ln18.ne4pg2_oQU480.F2010.chrysalis_intel.eam-p3
ERP.ne4pg2_oQU480.F2010.chrysalis_intel.eam-p3
REP_Ln5.ne4pg2_oQU480.F2010.chrysalis_intel.eam-p3
ERS.ne4pg2_oQU480.F2010.chrysalis_intel.eam-p3
SMS_Ln5.ne30pg2_EC30to60E2r2.F2010.chrysalis_intel.eam-p3
PET.ne4pg2_oQU480.F2010.chrysalis_intel.eam-p3
SMS_Ln5.ne4pg2_oQU480.F2010.chrysalis_intel.eam-p3
