### PR TITLE
Add new flag for ChemDyg package to reduce E3SM diagnostic I/O

### DIFF
--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1319,6 +1319,7 @@
 <gaschmbudget_2D_L4_e>         72       </gaschmbudget_2D_L4_e>
 <history_UCIgaschmbudget_2D>      .false.  </history_UCIgaschmbudget_2D>
 <history_UCIgaschmbudget_2D_levels>   .false.  </history_UCIgaschmbudget_2D_levels>
+<history_chemdyg_summary>      .false.  </history_chemdyg_summary>
 
 <!-- BSINGH - ndrop.F90 "repeated g1 equation" bug fix flag -->
 <fix_g1_err_ndrop>             .false.  </fix_g1_err_ndrop>

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -4196,6 +4196,12 @@ Switch for gas chemistry tracers 2D budget diagnostic output
 Default: .false.
 </entry>
 
+<entry id="history_gaschmbudget_num" type="integer"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="1,2,3,4,5,6,7,8,9,10,11,12,13,14,15" >
+History tape number instantaneous gas chemistry budget output is written to.
+Default: 2
+</entry>
+
 <entry id="history_gaschmbudget_2D_levels" type="logical"  category="diagnostics"
        group="phys_ctl_nl" valid_values="" >
 Switch for gas chemistry tracers 2D budget diagnostic output within certain levels
@@ -4259,6 +4265,12 @@ Default: .false.
 <entry id="history_UCIgaschmbudget_2D_levels" type="logical"  category="diagnostics"
        group="phys_ctl_nl" valid_values="" >
 Switch for gas chemistry tracers 2D budget diagnostic output within certain levels
+Default: .false.
+</entry>
+
+<entry id="history_chemdyg_summary" type="logical"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch for gas chemistry tracers in the ChemDyg package
 Default: .false.
 </entry>
 

--- a/components/eam/src/chemistry/mozart/chemistry.F90
+++ b/components/eam/src/chemistry/mozart/chemistry.F90
@@ -1438,6 +1438,7 @@ end function chem_is_active
     logical :: history_gaschmbudget ! output gas chemistry tracer concentrations and tendencies
     logical :: history_gaschmbudget_2D
     logical :: history_gaschmbudget_2D_levels
+    logical :: history_chemdyg_summary
     integer :: gaschmbudget_2D_L1_s
     integer :: gaschmbudget_2D_L1_e
     integer :: gaschmbudget_2D_L2_s
@@ -1461,6 +1462,7 @@ end function chem_is_active
     call phys_getopts(history_gaschmbudget_out = history_gaschmbudget, &
                    history_gaschmbudget_2D_out = history_gaschmbudget_2D, &
             history_gaschmbudget_2D_levels_out = history_gaschmbudget_2D_levels, &
+                   history_chemdyg_summary_out = history_chemdyg_summary, &
                       gaschmbudget_2D_L1_s_out = gaschmbudget_2D_L1_s, &
                       gaschmbudget_2D_L1_e_out = gaschmbudget_2D_L1_e, &
                       gaschmbudget_2D_L2_s_out = gaschmbudget_2D_L2_s, &
@@ -1519,7 +1521,8 @@ end function chem_is_active
 !-----------------------------------------------------------------------
 ! output gas concentration and tendency
 !-----------------------------------------------------------------------
-    if (history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels) then
+    if (history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels &
+            .or. history_chemdyg_summary) then
       do m = 1,pcnst
          n = map2chm(m)
          if (n > 0 .and. (.not. any( aer_species == n ))) then
@@ -1542,13 +1545,14 @@ end function chem_is_active
              call outfld(trim(solsym(n))//'_TDO', Diff, pcols, lchnk )
            end if
            !
-           if (history_gaschmbudget_2D) then
+           if (history_gaschmbudget_2D .or. history_chemdyg_summary) then
              ftem_layers = 0.0_r8
              do k=1,pver
                ftem_layers(:ncol,1) = ftem_layers(:ncol,1) + ftem(:ncol,k)
              end do
+             if (history_gaschmbudget_2D ) then
              call outfld(trim(solsym(n))//'_2DMSB', ftem_layers(:ncol,1), pcols, lchnk )
-
+             endif            
              gas_ac_idx = pbuf_get_index(gas_ac_name_2D(n))
              call pbuf_get_field(pbuf, gas_ac_idx, gas_ac_2D )
              if( nstep == 0 ) then
@@ -1560,10 +1564,12 @@ end function chem_is_active
              else
                 Diff(:ncol,1) = (ftem_layers(:ncol,1) - gas_ac_2D(:ncol))/dt
              end if
+             if (history_gaschmbudget_2D ) then
              call outfld(trim(solsym(n))//'_2DTDO', Diff(:ncol,1), pcols, lchnk )
+             end if
            end if
            ! HHLEE 20210923
-           if (history_gaschmbudget_2D_levels ) then
+           if (history_gaschmbudget_2D_levels .or. history_chemdyg_summary) then
              ftem_layers = 0.0_r8
              gas_ac_layers = 0.0_r8
 
@@ -1591,10 +1597,12 @@ end function chem_is_active
                ftem_layers(:ncol,4) = ftem_layers(:ncol,4) + ftem(:ncol,k)
                gas_ac_layers(:ncol,4) = gas_ac_layers(:ncol,4) + gas_ac(:ncol,k)
              end do
+             if (history_gaschmbudget_2D_levels ) then
              call outfld(trim(solsym(n))//'_2DMSB_L1', ftem_layers(:ncol,1), pcols, lchnk)
              call outfld(trim(solsym(n))//'_2DMSB_L2', ftem_layers(:ncol,2), pcols, lchnk)
              call outfld(trim(solsym(n))//'_2DMSB_L3', ftem_layers(:ncol,3), pcols, lchnk)
              call outfld(trim(solsym(n))//'_2DMSB_L4', ftem_layers(:ncol,4), pcols, lchnk)
+             endif
 
              if( nstep == 0 ) then
                 Diff_layers(:ncol,:) = 0.0_r8
@@ -1605,10 +1613,12 @@ end function chem_is_active
                 Diff_layers(:ncol,3) = (ftem_layers(:ncol,3) - gas_ac_layers(:ncol,3))/dt
                 Diff_layers(:ncol,4) = (ftem_layers(:ncol,4) - gas_ac_layers(:ncol,4))/dt
              end if
+             if (history_gaschmbudget_2D_levels ) then
              call outfld(trim(solsym(n))//'_2DTDO_L1', Diff_layers(:ncol,1), pcols, lchnk)
              call outfld(trim(solsym(n))//'_2DTDO_L2', Diff_layers(:ncol,2), pcols, lchnk)
              call outfld(trim(solsym(n))//'_2DTDO_L3', Diff_layers(:ncol,3), pcols, lchnk)
              call outfld(trim(solsym(n))//'_2DTDO_L4', Diff_layers(:ncol,4), pcols, lchnk)
+             endif
 
              ! for the tropospheric budget diagnostics
              if (trim(solsym(n))=='O3' .or. trim(solsym(n))=='O3LNZ' .or. &
@@ -1619,7 +1629,9 @@ end function chem_is_active
                    ftem_layers(:ncol,1) = ftem_layers(:ncol,1) + ftem(:ncol,k) * tropFlagInt(:ncol,k)
                    gas_ac_layers(:ncol,1) = gas_ac_layers(:ncol,1) + gas_ac(:ncol,k) * tropFlagInt(:ncol,k)
                 end do
+                if (history_gaschmbudget_2D_levels ) then
                 call outfld(trim(solsym(n))//'_2DMSB_trop', ftem_layers(:ncol,1), pcols, lchnk )
+                endif
 
                 if( nstep == 0 ) then
                    Diff_layers(:ncol,:) = 0.0_r8
@@ -1627,7 +1639,14 @@ end function chem_is_active
                    Diff_layers(:ncol,:) = 0.0_r8
                    Diff_layers(:ncol,1) = (ftem_layers(:ncol,1) - gas_ac_layers(:ncol,1))/dt
                 end if
+                        
+                if (history_gaschmbudget_2D_levels ) then
                 call outfld(trim(solsym(n))//'_2DTDO_trop', Diff_layers(:ncol,1), pcols, lchnk)
+                else
+                   if (trim(solsym(n))=='O3' ) then
+                      call outfld(trim(solsym(n))//'_2DTDO_trop', Diff_layers(:ncol,1), pcols, lchnk)
+                   end if
+                end if
              end if
 
            end if ! history_gaschmbudget_2D_levels

--- a/components/eam/src/chemistry/mozart/mo_chm_diags.F90
+++ b/components/eam/src/chemistry/mozart/mo_chm_diags.F90
@@ -1672,14 +1672,6 @@ contains
                        UCIgaschmbudget_2D_L4_s_out = UCIgaschmbudget_2D_L4_s, &
                        UCIgaschmbudget_2D_L4_e_out = UCIgaschmbudget_2D_L4_e )
 
-    if (history_chemdyg_summary) then
-        if (history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels) then    
-            history_chemdyg_summary = .false.  
-            history_gaschmbudget_2D = .true.  
-            history_gaschmbudget_2D_levels = .true.  
-            write(iulog,*) 'gaschmmass_diags: history_chemdyg_summary is in conflict with other flags. Turn history_chemdyg_summary off.'
-        end if
-    end if
 
     if ( .not. history_gaschmbudget .and. .not. history_gaschmbudget_2D .and. .not. history_gaschmbudget_2D_levels &
          .and. .not. history_UCIgaschmbudget_2D .and. .not. history_UCIgaschmbudget_2D_levels &

--- a/components/eam/src/chemistry/mozart/mo_chm_diags.F90
+++ b/components/eam/src/chemistry/mozart/mo_chm_diags.F90
@@ -105,6 +105,7 @@ contains
     integer :: gaschmbudget_2D_L4_e
     logical :: history_UCIgaschmbudget_2D ! output 2D gas chemistry tracer concentrations and tendencies
     logical :: history_UCIgaschmbudget_2D_levels ! output 2D gas chemistry tracer concentrations and tendencies
+    logical :: history_chemdyg_summary 
     integer :: UCIgaschmbudget_2D_L1_s
     integer :: UCIgaschmbudget_2D_L1_e
     integer :: UCIgaschmbudget_2D_L2_s
@@ -113,6 +114,8 @@ contains
     integer :: UCIgaschmbudget_2D_L3_e
     integer :: UCIgaschmbudget_2D_L4_s
     integer :: UCIgaschmbudget_2D_L4_e
+    integer :: history_gaschmbudget_num ! History tape number for instantaneous gas chemistry budget output
+
     integer :: bulkaero_species(20)
     integer :: e90_ndx
 
@@ -136,6 +139,7 @@ contains
                        gaschmbudget_2D_L4_e_out = gaschmbudget_2D_L4_e, &
                     history_UCIgaschmbudget_2D_out = history_UCIgaschmbudget_2D, &
              history_UCIgaschmbudget_2D_levels_out = history_UCIgaschmbudget_2D_levels, &
+                       history_chemdyg_summary_out = history_chemdyg_summary, &
                        UCIgaschmbudget_2D_L1_s_out = UCIgaschmbudget_2D_L1_s, &
                        UCIgaschmbudget_2D_L1_e_out = UCIgaschmbudget_2D_L1_e, &
                        UCIgaschmbudget_2D_L2_s_out = UCIgaschmbudget_2D_L2_s, &
@@ -143,7 +147,8 @@ contains
                        UCIgaschmbudget_2D_L3_s_out = UCIgaschmbudget_2D_L3_s, &
                        UCIgaschmbudget_2D_L3_e_out = UCIgaschmbudget_2D_L3_e, &
                        UCIgaschmbudget_2D_L4_s_out = UCIgaschmbudget_2D_L4_s, &
-                       UCIgaschmbudget_2D_L4_e_out = UCIgaschmbudget_2D_L4_e )
+                       UCIgaschmbudget_2D_L4_e_out = UCIgaschmbudget_2D_L4_e, &
+                      history_gaschmbudget_num_out = history_gaschmbudget_num)
 
     if (masterproc) then
        if (history_gaschmbudget) then
@@ -160,6 +165,9 @@ contains
        endif
        if (history_UCIgaschmbudget_2D_levels) then
           write(iulog,*) 'chm_diags_inti: history_UCIgaschmbudget_2D_levels = ', history_UCIgaschmbudget_2D_levels
+       endif
+       if (history_chemdyg_summary) then
+          write(iulog,*) 'chm_diags_inti: history_chemdyg_summary = ', history_chemdyg_summary
        endif
     endif
 
@@ -435,6 +443,13 @@ contains
              call addfld( trim(spc_name)//'_2DTDD', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency due to dry deposition')
              call addfld( trim(spc_name)//'_2DTDO', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency due to processes outside of chemistry')
           endif
+          if (history_chemdyg_summary) then
+             if (trim(spc_name) == 'O3' .or. trim(spc_name) == 'CO' .or. trim(spc_name) == 'NO' .or. trim(spc_name) == 'NO2' .or. trim(spc_name) == 'CH4') then
+             call addfld( trim(spc_name)//'_2DMSD', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration after dry deposition')
+             call addfld( trim(spc_name)//'_2DTDS', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency due to surface emission')
+             call addfld( trim(spc_name)//'_2DTDD', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency due to dry deposition')
+             endif
+          endif
           if (history_UCIgaschmbudget_2D) then
              if (trim(spc_name) == 'CO') then
              call addfld( trim(spc_name)//'_2DCEP', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated explicit chemistry production rate after reset')
@@ -449,6 +464,16 @@ contains
              call addfld( trim(spc_name)//'_2DTIL', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated implicit chemistry loss rate before reset')
              call addfld( trim(spc_name)//'_2DMPP', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated MP implicit chemistry production rate')
              call addfld( trim(spc_name)//'_2DMPL', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated MP implicit chemistry loss rate')
+             endif
+          endif
+          if (history_chemdyg_summary) then
+             if (trim(spc_name) == 'CO') then
+             call addfld( trim(spc_name)//'_2DCEP', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated explicit chemistry production rate after reset')
+             call addfld( trim(spc_name)//'_2DCEL', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated explicit chemistry loss rate after reset')
+             endif
+             if (trim(spc_name) == 'O3') then
+             call addfld( trim(spc_name)//'_2DCIP', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated implicit chemistry production rate after reset')
+             call addfld( trim(spc_name)//'_2DCIL', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated implicit chemistry loss rate after reset')
              endif
           endif
           if (history_gaschmbudget_2D_levels) then
@@ -537,6 +562,23 @@ contains
              call addfld( trim(spc_name)//'_2DTDD_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to dry deposition')
              call addfld( trim(spc_name)//'_2DTDO_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to processes outside of chemistry')
           endif
+          if (history_chemdyg_summary) then
+             if (trim(spc_name) == 'O3') then
+             call addfld( trim(spc_name)//'_2DMSD_trop', horiz_only, 'I', 'kg/m2', trim(attr)//' vertically integrated concentration in troposphere after dry deposition')
+             call addfld( trim(spc_name)//'_2DTDE_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to explicit solver')
+             call addfld( trim(spc_name)//'_2DTDI_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to implicit solver')
+             call addfld( trim(spc_name)//'_2DTRI_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to reset mixing ratio')
+             call addfld( trim(spc_name)//'_2DTRE_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to reset mixing ratio')
+             call addfld( trim(spc_name)//'_2DTDA_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to aero_model_gasaerexch')
+             call addfld( trim(spc_name)//'_2DTDL_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to Linoz')
+             call addfld( trim(spc_name)//'_2DTDN_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to reset negative values to zero')
+             call addfld( trim(spc_name)//'_2DTDU_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to setting upper boundary values')
+             call addfld( trim(spc_name)//'_2DTDB_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to setting lower boundary values')
+             call addfld( trim(spc_name)//'_2DTDS_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to surface emission')
+             call addfld( trim(spc_name)//'_2DTDD_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to dry deposition')
+             call addfld( trim(spc_name)//'_2DTDO_trop', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated tendency in troposphere due to processes outside of chemistry')
+             endif
+          endif
           if (history_UCIgaschmbudget_2D_levels) then
              if (trim(spc_name) == 'CO') then
              call addfld( trim(spc_name)//'_2DCEP_L1', horiz_only, 'A', 'kg/m2/s', trim(attr)//' vertically integrated explicit chemistry production rate from top-of-model to 100 hPa')
@@ -607,12 +649,15 @@ contains
           if (history_amwg) then
              call add_default( trim(spc_name)//'_SRF', 1, ' ' )
           endif
+          if (history_chemdyg_summary .and. trim(spc_name) == 'CO') then
+             call add_default( trim(spc_name)//'_SRF', 1, ' ' )
+          endif
           if ( .not. any( aer_species == m ) ) then
              if (history_gaschmbudget) then
-                call add_default( trim(spc_name)//'_MSB', 2, ' ' )
-                call add_default( trim(spc_name)//'_MSL', 2, ' ' )
-                call add_default( trim(spc_name)//'_MSS', 2, ' ' )
-                call add_default( trim(spc_name)//'_MSD', 2, ' ' )
+                call add_default( trim(spc_name)//'_MSB', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_MSL', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_MSS', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_MSD', history_gaschmbudget_num, ' ' )
                 call add_default( trim(spc_name)//'_TDE', 1, ' ' )
                 call add_default( trim(spc_name)//'_TDI', 1, ' ' )
                 call add_default( trim(spc_name)//'_TRI', 1, ' ' )
@@ -627,17 +672,17 @@ contains
                 call add_default( trim(spc_name)//'_TDO', 1, ' ' )
              endif
              if (history_gaschmbudget_2D) then
-                call add_default( trim(spc_name)//'_2DMSB', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSL', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSS', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSD', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSI', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSE', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSA', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSN', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSU', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSC', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSW', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSB', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSL', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSS', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSD', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSI', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSE', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSA', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSN', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSU', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSC', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSW', history_gaschmbudget_num, ' ' )
                 call add_default( trim(spc_name)//'_2DTDE', 1, ' ' )
                 call add_default( trim(spc_name)//'_2DTDI', 1, ' ' )
                 call add_default( trim(spc_name)//'_2DTRI', 1, ' ' )
@@ -651,7 +696,14 @@ contains
                 call add_default( trim(spc_name)//'_2DTDD', 1, ' ' )
                 call add_default( trim(spc_name)//'_2DTDO', 1, ' ' )
              endif
-             if (history_UCIgaschmbudget_2D) then
+             if (history_chemdyg_summary) then
+                if (trim(spc_name) == 'O3' .or. trim(spc_name) == 'CO' .or. trim(spc_name) == 'NO' .or. trim(spc_name) == 'NO2' .or. trim(spc_name) == 'CH4') then
+                call add_default( trim(spc_name)//'_2DMSD', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DTDS', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDD', 1, ' ' )
+                endif
+             endif
+             if (history_UCIgaschmbudget_2D ) then
                 if (trim(spc_name) == 'CO') then
                 call add_default( trim(spc_name)//'_2DCEP', 1, ' ' )
                 call add_default( trim(spc_name)//'_2DCEL', 1, ' ' )
@@ -667,11 +719,22 @@ contains
                 call add_default( trim(spc_name)//'_2DMPL', 1, ' ' )
                 endif
              endif
+             if (history_chemdyg_summary) then
+                if (trim(spc_name) == 'CO') then
+                call add_default( trim(spc_name)//'_2DCEP', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DCEL', 1, ' ' )
+                endif
+                if (trim(spc_name) == 'O3') then
+                call add_default( trim(spc_name)//'_2DCIP', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DCIL', 1, ' ' )
+                endif
+             endif
+
              if (history_gaschmbudget_2D_levels) then
-                call add_default( trim(spc_name)//'_2DMSB_L1', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSL_L1', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSS_L1', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSD_L1', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSB_L1', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSL_L1', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSS_L1', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSD_L1', history_gaschmbudget_num, ' ' )
                 call add_default( trim(spc_name)//'_2DTDE_L1', 1, ' ' )
                 call add_default( trim(spc_name)//'_2DTDI_L1', 1, ' ' )
                 call add_default( trim(spc_name)//'_2DTRI_L1', 1, ' ' )
@@ -685,10 +748,10 @@ contains
                 call add_default( trim(spc_name)//'_2DTDD_L1', 1, ' ' )
                 call add_default( trim(spc_name)//'_2DTDO_L1', 1, ' ' )
 
-                call add_default( trim(spc_name)//'_2DMSB_L2', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSL_L2', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSS_L2', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSD_L2', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSB_L2', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSL_L2', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSS_L2', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSD_L2', history_gaschmbudget_num, ' ' )
                 call add_default( trim(spc_name)//'_2DTDE_L2', 1, ' ' )
                 call add_default( trim(spc_name)//'_2DTDI_L2', 1, ' ' )
                 call add_default( trim(spc_name)//'_2DTRI_L2', 1, ' ' )
@@ -702,10 +765,10 @@ contains
                 call add_default( trim(spc_name)//'_2DTDD_L2', 1, ' ' )
                 call add_default( trim(spc_name)//'_2DTDO_L2', 1, ' ' )
 
-                call add_default( trim(spc_name)//'_2DMSB_L3', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSL_L3', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSS_L3', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSD_L3', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSB_L3', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSL_L3', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSS_L3', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSD_L3', history_gaschmbudget_num, ' ' )
                 call add_default( trim(spc_name)//'_2DTDE_L3', 1, ' ' )
                 call add_default( trim(spc_name)//'_2DTDI_L3', 1, ' ' )
                 call add_default( trim(spc_name)//'_2DTRI_L3', 1, ' ' )
@@ -719,10 +782,10 @@ contains
                 call add_default( trim(spc_name)//'_2DTDD_L3', 1, ' ' )
                 call add_default( trim(spc_name)//'_2DTDO_L3', 1, ' ' )
 
-                call add_default( trim(spc_name)//'_2DMSB_L4', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSL_L4', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSS_L4', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSD_L4', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSB_L4', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSL_L4', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSS_L4', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSD_L4', history_gaschmbudget_num, ' ' )
                 call add_default( trim(spc_name)//'_2DTDE_L4', 1, ' ' )
                 call add_default( trim(spc_name)//'_2DTDI_L4', 1, ' ' )
                 call add_default( trim(spc_name)//'_2DTRI_L4', 1, ' ' )
@@ -738,10 +801,10 @@ contains
 
              if (trim(spc_name) == 'O3' .or. trim(spc_name) == 'O3LNZ' .or. &
                  trim(spc_name) == 'N2OLNZ' .or. trim(spc_name) == 'CH4LNZ' ) then
-                call add_default( trim(spc_name)//'_2DMSB_trop', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSL_trop', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSS_trop', 2, ' ' )
-                call add_default( trim(spc_name)//'_2DMSD_trop', 2, ' ' )
+                call add_default( trim(spc_name)//'_2DMSB_trop', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSL_trop', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSS_trop', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DMSD_trop', history_gaschmbudget_num, ' ' )
                 call add_default( trim(spc_name)//'_2DTDE_trop', 1, ' ' )
                 call add_default( trim(spc_name)//'_2DTDI_trop', 1, ' ' )
                 call add_default( trim(spc_name)//'_2DTRI_trop', 1, ' ' )
@@ -755,6 +818,23 @@ contains
                 call add_default( trim(spc_name)//'_2DTDD_trop', 1, ' ' )
                 call add_default( trim(spc_name)//'_2DTDO_trop', 1, ' ' )
              endif
+             endif
+             if (history_chemdyg_summary) then
+                if (trim(spc_name) == 'O3') then
+                call add_default( trim(spc_name)//'_2DMSD_trop', history_gaschmbudget_num, ' ' )
+                call add_default( trim(spc_name)//'_2DTDE_trop', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDI_trop', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTRI_trop', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTRE_trop', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDA_trop', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDL_trop', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDN_trop', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDU_trop', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDB_trop', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDS_trop', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDD_trop', 1, ' ' )
+                call add_default( trim(spc_name)//'_2DTDO_trop', 1, ' ' )
+                endif
              endif
              if (history_UCIgaschmbudget_2D_levels) then
                 if (trim(spc_name) == 'CO') then
@@ -856,7 +936,11 @@ contains
     endif
 
     if (history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels .or.&
-        history_UCIgaschmbudget_2D .or. history_UCIgaschmbudget_2D_levels) then
+        history_UCIgaschmbudget_2D .or. history_UCIgaschmbudget_2D_levels ) then
+       call add_default( 'AREA', 1, ' ' )
+       call add_default( 'MASS', 1, ' ' )
+    endif
+    if (history_chemdyg_summary) then
        call add_default( 'AREA', 1, ' ' )
     endif
 
@@ -1553,6 +1637,7 @@ contains
     integer  :: gaschmbudget_2D_L4_e
     logical  :: history_UCIgaschmbudget_2D ! output 2D gas chemistry tracer concentrations and tendencies
     logical  :: history_UCIgaschmbudget_2D_levels ! output 2D gas chemistry tracer concentrations and tendencies within certain layers
+    logical  :: history_chemdyg_summary 
     integer  :: UCIgaschmbudget_2D_L1_s ! Start layer of L1 for gas chemistry tracer budget 
     integer  :: UCIgaschmbudget_2D_L1_e ! End layer of L1 for gas chemistry trracer budget
     integer  :: UCIgaschmbudget_2D_L2_s
@@ -1577,6 +1662,7 @@ contains
                        gaschmbudget_2D_L4_e_out = gaschmbudget_2D_L4_e, &
                        history_UCIgaschmbudget_2D_out = history_UCIgaschmbudget_2D, &
                        history_UCIgaschmbudget_2D_levels_out = history_UCIgaschmbudget_2D_levels, &
+                       history_chemdyg_summary_out = history_chemdyg_summary, &
                        UCIgaschmbudget_2D_L1_s_out = UCIgaschmbudget_2D_L1_s, &
                        UCIgaschmbudget_2D_L1_e_out = UCIgaschmbudget_2D_L1_e, &
                        UCIgaschmbudget_2D_L2_s_out = UCIgaschmbudget_2D_L2_s, &
@@ -1586,8 +1672,18 @@ contains
                        UCIgaschmbudget_2D_L4_s_out = UCIgaschmbudget_2D_L4_s, &
                        UCIgaschmbudget_2D_L4_e_out = UCIgaschmbudget_2D_L4_e )
 
+    if (history_chemdyg_summary) then
+        if (history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels) then    
+            history_chemdyg_summary = .false.  
+            history_gaschmbudget_2D = .true.  
+            history_gaschmbudget_2D_levels = .true.  
+            write(iulog,*) 'gaschmmass_diags: history_chemdyg_summary is in conflict with other flags. Turn history_chemdyg_summary off.'
+        end if
+    end if
+
     if ( .not. history_gaschmbudget .and. .not. history_gaschmbudget_2D .and. .not. history_gaschmbudget_2D_levels &
-         .and. .not. history_UCIgaschmbudget_2D .and. .not. history_UCIgaschmbudget_2D_levels) return
+         .and. .not. history_UCIgaschmbudget_2D .and. .not. history_UCIgaschmbudget_2D_levels &
+         .and. .not. history_chemdyg_summary) return
     !modification to avoid issues with debug built
     if (len(flag) >= 4) then 
             if (flag(1:4)=='2DCE' .or. flag(1:4)=='2DTE') then
@@ -1600,13 +1696,13 @@ contains
                    start_index = 1
                    end_index = gas_pcnst   
            endif
-   else
+    else
             start_index = 1
             end_index = gas_pcnst 
-   endif
+    endif
 
     do m = start_index,end_index
-       
+        
        if ( .not. any( aer_species == m ) .and. adv_mass(m) /= 0._r8 ) then
           if (flag(1:2) .ne. '2D') then
             if (flag=='MSL' .or. flag=='MSS' .or. flag=='MSD') then
@@ -1668,20 +1764,50 @@ contains
                !this change is to let code not got to flag(6:8) when length is 5
                !to avoid debug built issue
 
-                  wrk_sum(:ncol) = 0.0_r8
-                  if (trim(solsym(m))=='O3' .or. trim(solsym(m))=='O3LNZ' .or. &
-                       trim(solsym(m))=='N2OLNZ' .or. trim(solsym(m))=='CH4LNZ') then
-                     do k = 1, pver
-                           wrk_sum(:ncol) = wrk_sum(:ncol) + wrk(:ncol,k) * tropFlagInt(:ncol,k)
-                     enddo
-                     call outfld( trim(solsym(m))//'_'//flag, wrk_sum(:ncol), ncol ,lchnk )
-                  endif
+                   wrk_sum(:ncol) = 0.0_r8
+               if (history_chemdyg_summary) then
+                   if (trim(solsym(m)) == 'O3') then
+                      do k = 1, pver
+                            wrk_sum(:ncol) = wrk_sum(:ncol) + wrk(:ncol,k) * tropFlagInt(:ncol,k)
+                      enddo
+                      call outfld( trim(solsym(m))//'_'//flag, wrk_sum(:ncol), ncol ,lchnk )
+                   endif
+               else
+                   if (trim(solsym(m))=='O3' .or. trim(solsym(m))=='O3LNZ' .or. &
+                        trim(solsym(m))=='N2OLNZ' .or. trim(solsym(m))=='CH4LNZ') then
+                      do k = 1, pver
+                            wrk_sum(:ncol) = wrk_sum(:ncol) + wrk(:ncol,k) * tropFlagInt(:ncol,k)
+                      enddo
+                      call outfld( trim(solsym(m))//'_'//flag, wrk_sum(:ncol), ncol ,lchnk )
+                   endif
                endif
+               endif
+
             else
                do k=2,pver
                   wrk(:ncol,1) = wrk(:ncol,1) + wrk(:ncol,k)
                enddo
-               call outfld( trim(solsym(m))//'_'//flag, wrk(:ncol,1), ncol ,lchnk )
+               if (history_chemdyg_summary) then
+                   if (trim(solsym(m)) == 'O3') then
+                       if (flag(1:5)=='2DMSD' .or. flag(1:5)=='2DTDS' .or. flag(1:5)=='2DTDD' &
+                               .or.flag(1:4)=='2DCI') then
+                          call outfld( trim(solsym(m))//'_'//flag, wrk(:ncol,1), ncol ,lchnk )
+                       endif
+                   endif 
+                   if (trim(solsym(m)) == 'CO') then
+                       if (flag(1:5)=='2DMSD' .or. flag(1:5)=='2DTDS' .or. flag(1:5)=='2DTDD' &
+                              .or. flag(1:4)=='2DCE') then
+                          call outfld( trim(solsym(m))//'_'//flag, wrk(:ncol,1), ncol ,lchnk )
+                       endif
+                   endif 
+                   if (trim(solsym(m)) == 'NO' .or. trim(solsym(m)) == 'NO2' .or. trim(solsym(m)) == 'CH4') then
+                       if (flag(1:5)=='2DMSD' .or. flag(1:5)=='2DTDS' .or. flag(1:5)=='2DTDD' ) then
+                          call outfld( trim(solsym(m))//'_'//flag, wrk(:ncol,1), ncol ,lchnk )
+                       endif
+                   endif 
+               else  
+                   call outfld( trim(solsym(m))//'_'//flag, wrk(:ncol,1), ncol ,lchnk )
+               endif
             endif
 
           endif

--- a/components/eam/src/chemistry/mozart/mo_extfrc.F90
+++ b/components/eam/src/chemistry/mozart/mo_extfrc.F90
@@ -11,6 +11,7 @@ module mo_extfrc
   use cam_history,  only : addfld, horiz_only, outfld, add_default
   use cam_logfile,  only : iulog
   use tracer_data,  only : trfld,trfile
+  use mo_constants, only : avogadro
 
   implicit none
 
@@ -301,7 +302,7 @@ contains
   end subroutine extfrc_timestep_init
 
   subroutine extfrc_set( lchnk, zint, frcing, ncol )
-
+    use phys_control,  only : phys_getopts
     !--------------------------------------------------------
     !	... form the external forcing
     !--------------------------------------------------------
@@ -321,7 +322,7 @@ contains
     !--------------------------------------------------------
     integer  ::  i, m, n
     character(len=16) :: xfcname
-    real(r8) :: frcing_col(1:ncol)
+    real(r8) :: frcing_col(1:ncol), frcing_tmp(ncol,pver), no2_tdacf(ncol,pver)
     integer  :: k, isec
     real(r8),parameter :: km_to_cm = 1.e5_r8
     !chem diags

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -27,7 +27,7 @@ module mo_gas_phase_chemdr
 
   integer :: o3_ndx, synoz_ndx, so4_ndx, h2o_ndx, o2_ndx, o_ndx, hno3_ndx, dst_ndx, cldice_ndx, e90_ndx
   !integer :: o3lnz_ndx, n2olnz_ndx, noylnz_ndx, ch4lnz_ndx
-  integer :: o3lnz_ndx
+  integer :: o3lnz_ndx, ch4lnz_ndx
   integer :: uci1_ndx
   integer :: het1_ndx
   integer :: ndx_cldfr, ndx_cmfdqr, ndx_nevapr, ndx_cldtop, ndx_prain, ndx_sadsulf
@@ -94,7 +94,7 @@ contains
     o3lnz_ndx =   get_spc_ndx('O3LNZ')
 !    n2olnz_ndx =  get_spc_ndx('N2OLNZ')
 !    noylnz_ndx =  get_spc_ndx('NOYLNZ')
-!    ch4lnz_ndx =  get_spc_ndx('CH4LNZ')
+    ch4lnz_ndx =  get_spc_ndx('CH4LNZ')
     ! for ozone budget 
     jo2_b_ndx      = get_rxt_ndx('jo2_b')
     lch3o2_no_ndx  = get_rxt_ndx('lch3o2_no')

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -496,6 +496,7 @@ contains
     logical :: history_gaschmbudget_2D_levels
     logical :: history_UCIgaschmbudget_2D
     logical :: history_UCIgaschmbudget_2D_levels
+    logical :: history_chemdyg_summary
 
     integer ::  gas_ac_idx
     real(r8), pointer, dimension(:) :: gas_ac_2D
@@ -508,7 +509,8 @@ contains
                     history_gaschmbudget_2D_out = history_gaschmbudget_2D, &
              history_gaschmbudget_2D_levels_out = history_gaschmbudget_2D_levels,&
                  history_UCIgaschmbudget_2D_out = history_UCIgaschmbudget_2D, &
-          history_UCIgaschmbudget_2D_levels_out = history_UCIgaschmbudget_2D_levels)
+          history_UCIgaschmbudget_2D_levels_out = history_UCIgaschmbudget_2D_levels, &
+                    history_chemdyg_summary_out = history_chemdyg_summary)
 
     call t_startf('chemdr_init')
 
@@ -1016,14 +1018,43 @@ contains
 
       end do column0_loop
       end do level0_loop
+    end if
+    
+    if ( history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels &
+            .or. history_chemdyg_summary) then
+       if ( history_gaschmbudget ) then
+          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
+                                 pdeldry(:ncol,:), mbar, delt_inverse, 'TDI' )
+       endif
+       if ( history_gaschmbudget_2D ) then
+          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
+                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DTDI' )
+       endif
+       if ( history_gaschmbudget_2D) then
+          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
+                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DMSI' )
+       endif
+       if ( history_gaschmbudget_2D_levels ) then
+         call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
+                                pdeldry(:ncol,:), mbar, delt_inverse, '2DTDI_LL' )
+         call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
+                                pdeldry(:ncol,:), mbar, delt_inverse, '2DTDI_trop', tropFlagInt )
+       endif
+       if ( history_chemdyg_summary ) then
+         call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old2(:ncol,:,:), &
+                                pdeldry(:ncol,:), mbar, delt_inverse, '2DTDI_trop', tropFlagInt )
+       endif
+       vmr_old(:ncol,:,:) = vmr(:ncol,:,:)
     endif
 
     if ( history_UCIgaschmbudget_2D .or. history_UCIgaschmbudget_2D_levels) then
-       if ( history_UCIgaschmbudget_2D .and. uci1_ndx > 0) then
-          call gaschmmass_diags( lchnk, ncol, chem_prod(:ncol,:,:), vmr_old(ncol,:,:), &
+       if ( history_UCIgaschmbudget_2D) then
+       if ( uci1_ndx > 0) then
+          call gaschmmass_diags( lchnk, ncol, chem_prod(:ncol,:,:), vmr_old2(ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, '2DTIP' )
-          call gaschmmass_diags( lchnk, ncol, chem_loss(:ncol,:,:), vmr_old(:ncol,:,:), &
+          call gaschmmass_diags( lchnk, ncol, chem_loss(:ncol,:,:), vmr_old2(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, '2DTIL' )
+       endif
        endif
        if ( history_UCIgaschmbudget_2D_levels .and. uci1_ndx > 0) then
          call gaschmmass_diags( lchnk, ncol, chem_prod(:ncol,:,:), vmr_old(:ncol,:,:), &
@@ -1058,9 +1089,11 @@ contains
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, 'TRI' )
        endif
-       if ( history_gaschmbudget_2D .and. uci1_ndx > 0) then
+       if ( history_gaschmbudget_2D) then
+       if ( uci1_ndx > 0) then
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, '2DTRI' )
+       endif
        endif
        if ( history_gaschmbudget_2D_levels .and. uci1_ndx > 0) then
          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
@@ -1091,7 +1124,7 @@ contains
  
       chemmp_loss(i,k,o3_ndx) = (diags_reaction_rates(i,k,uci1_ndx) &
          + diags_reaction_rates(i,k,uci2_ndx) &
-         + diags_reaction_rates(i,k,uci3_ndx) &
+         + diags_reaction_rates(i,k,uci3_ndx) * vmr(i,k,ch4lnz_ndx) &
          + diags_reaction_rates(i,k,lc2h4_o3_ndx)*vmr(i,k,c2h4_ndx) &
          + diags_reaction_rates(i,k,lisop_o3_ndx)*vmr(i,k,isop_ndx)  &
          + diags_reaction_rates(i,k,lo3_oh_ndx)*vmr(i,k,oh_ndx)  &
@@ -1106,7 +1139,7 @@ contains
 
       chem_loss(i,k,o3_ndx) = (diags_reaction_rates(i,k,uci1_ndx) &
          + diags_reaction_rates(i,k,uci2_ndx) &
-         + diags_reaction_rates(i,k,uci3_ndx) &
+         + diags_reaction_rates(i,k,uci3_ndx) * vmr(i,k,ch4lnz_ndx) &
          + diags_reaction_rates(i,k,lc2h4_o3_ndx)*vmr(i,k,c2h4_ndx) &
          + diags_reaction_rates(i,k,lisop_o3_ndx)*vmr(i,k,isop_ndx)  &
          + diags_reaction_rates(i,k,lo3_oh_ndx)*vmr(i,k,oh_ndx)  &
@@ -1120,7 +1153,7 @@ contains
       end do level_loop
     endif !uci1_ndx
 
-    if ( history_UCIgaschmbudget_2D .or. history_UCIgaschmbudget_2D_levels) then
+    if ( history_UCIgaschmbudget_2D .or. history_UCIgaschmbudget_2D_levels .or. history_chemdyg_summary) then
        if ( history_UCIgaschmbudget_2D .and. uci1_ndx > 0) then
           call gaschmmass_diags( lchnk, ncol, chem_prod(:ncol,:,:), vmr_old(ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, '2DCIP' )
@@ -1130,6 +1163,12 @@ contains
                                  pdeldry(:ncol,:), mbar, delt_inverse, '2DMPP' )
           call gaschmmass_diags( lchnk, ncol, chemmp_loss(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, '2DMPL' )
+       endif
+       if ( history_chemdyg_summary .and. uci1_ndx > 0) then
+          call gaschmmass_diags( lchnk, ncol, chem_prod(:ncol,:,:), vmr_old(ncol,:,:), &
+                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DCIP' )
+          call gaschmmass_diags( lchnk, ncol, chem_loss(:ncol,:,:), vmr_old(:ncol,:,:), &
+                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DCIL' )
        endif
        if ( history_UCIgaschmbudget_2D_levels .and. uci1_ndx > 0) then
          call gaschmmass_diags( lchnk, ncol, chem_prod(:ncol,:,:), vmr_old(:ncol,:,:), &
@@ -1162,7 +1201,7 @@ contains
     call t_stopf('exp_sol')
 
     if ( history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels .or.&
-         history_UCIgaschmbudget_2D .or. history_UCIgaschmbudget_2D_levels ) then
+         history_UCIgaschmbudget_2D .or. history_UCIgaschmbudget_2D_levels .or. history_chemdyg_summary) then
        if ( history_gaschmbudget ) then
          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                 pdeldry(:ncol,:), mbar, delt_inverse, 'TDE' )
@@ -1170,6 +1209,8 @@ contains
        if ( history_gaschmbudget_2D ) then
          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DTDE' )
+       endif
+       if ( history_gaschmbudget_2D ) then
          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DMSE' )
        endif
@@ -1182,6 +1223,10 @@ contains
        if ( history_gaschmbudget_2D_levels ) then
          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DTDE_LL' )
+         call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
+                                pdeldry(:ncol,:), mbar, delt_inverse, '2DTDE_trop', tropFlagInt )
+       endif
+       if ( history_chemdyg_summary .and. uci1_ndx > 0) then
          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DTDE_trop', tropFlagInt )
        endif
@@ -1211,7 +1256,8 @@ contains
        enddo
     endif
 
-    if ( history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels) then
+    if ( history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels &
+            .or. history_chemdyg_summary) then
        if ( history_gaschmbudget  .and. uci1_ndx > 0) then
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, 'TRE' )
@@ -1220,11 +1266,13 @@ contains
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, '2DTRE' )
        endif
-       if ( history_UCIgaschmbudget_2D .and. uci1_ndx > 0) then
+       if ( history_UCIgaschmbudget_2D .or. history_chemdyg_summary) then
+       if ( uci1_ndx > 0) then
          call gaschmmass_diags( lchnk, ncol, chemmp_prod(:ncol,:,:), vmr_old(ncol,:,:), &
                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DCEP' )
          call gaschmmass_diags( lchnk, ncol, chemmp_loss(:ncol,:,:), vmr_old(:ncol,:,:), &
                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DCEL' )
+       endif
        endif
        if ( history_gaschmbudget_2D_levels .and. uci1_ndx > 0) then
          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
@@ -1343,7 +1391,8 @@ contains
 
     endif
 
-    if ( history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels) then
+    if ( history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels &
+            .or. history_chemdyg_summary) then
        if ( history_gaschmbudget ) then
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, 'TDA' )
@@ -1351,6 +1400,8 @@ contains
        if ( history_gaschmbudget_2D ) then
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, '2DTDA' )
+       endif
+       if ( history_gaschmbudget_2D ) then
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, '2DMSA' )
        endif
@@ -1359,6 +1410,10 @@ contains
                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DTDA_LL' )
          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DTDA_trop', tropFlagInt)
+       endif
+       if ( history_chemdyg_summary ) then
+         call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
+                                pdeldry(:ncol,:), mbar, delt_inverse, '2DTDA_trop', tropFlagInt )
        endif
        vmr_old(:ncol,:,:) = vmr(:ncol,:,:)
     endif
@@ -1397,7 +1452,8 @@ contains
        call lin_strat_sfcsink(ncol, lchnk, vmr, xsfc, delt,   pdel(:ncol,:) )
     end if
 
-    if ( history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels) then
+    if ( history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels &
+            .or. history_chemdyg_summary) then
        if ( history_gaschmbudget ) then
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, 'TDL' )
@@ -1407,6 +1463,8 @@ contains
        if ( history_gaschmbudget_2D ) then
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, '2DTDL' )
+       endif
+       if ( history_gaschmbudget_2D ) then
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, '2DMSL' )
        endif
@@ -1420,6 +1478,10 @@ contains
          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DMSL_trop', tropFlagInt )
        endif
+       if ( history_chemdyg_summary ) then
+         call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
+                                pdeldry(:ncol,:), mbar, delt_inverse, '2DTDL_trop', tropFlagInt )
+       endif
        vmr_old(:ncol,:,:) = vmr(:ncol,:,:)
     endif
 
@@ -1428,7 +1490,8 @@ contains
     !-----------------------------------------------------------------------      
     call negtrc( 'After chemistry ', vmr, ncol )
 
-    if ( history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels) then
+    if ( history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels &
+            .or. history_chemdyg_summary) then
        if ( history_gaschmbudget ) then
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, 'TDN' )
@@ -1436,12 +1499,18 @@ contains
        if ( history_gaschmbudget_2D ) then
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, '2DTDN' )
+       endif
+       if ( history_gaschmbudget_2D ) then
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, '2DMSN' )
        endif
        if ( history_gaschmbudget_2D_levels ) then
          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DTDN_LL' )
+         call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
+                                pdeldry(:ncol,:), mbar, delt_inverse, '2DTDN_trop', tropFlagInt )
+       endif
+       if ( history_chemdyg_summary ) then
          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DTDN_trop', tropFlagInt )
        endif
@@ -1453,7 +1522,8 @@ contains
     !-----------------------------------------------------------------------      
     if(.not. do_lin_strat_chem) call set_fstrat_vals( vmr, pmid, pint, troplev, calday, ncol,lchnk )
 
-    if ( history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels) then
+    if ( history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels &
+            .or. history_chemdyg_summary) then
        if ( history_gaschmbudget ) then
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, 'TDU' )
@@ -1461,12 +1531,18 @@ contains
        if ( history_gaschmbudget_2D ) then
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, '2DTDU' )
+       endif
+       if ( history_gaschmbudget_2D ) then
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, '2DMSU' )
        endif
        if ( history_gaschmbudget_2D_levels ) then
          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DTDU_LL' )
+         call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
+                                pdeldry(:ncol,:), mbar, delt_inverse, '2DTDU_trop', tropFlagInt )
+       endif
+       if ( history_chemdyg_summary ) then
          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DTDU_trop', tropFlagInt )
        endif
@@ -1482,7 +1558,8 @@ contains
        call ghg_chem_set_flbc( vmr, ncol )
     endif
 
-    if ( history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels) then
+    if ( history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels &
+            .or. history_chemdyg_summary) then
        if ( history_gaschmbudget ) then
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, 'TDB' )
@@ -1490,12 +1567,18 @@ contains
        if ( history_gaschmbudget_2D ) then
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, '2DTDB' )
+       endif
+       if ( history_gaschmbudget_2D ) then
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, '2DMSC' )
        endif
        if ( history_gaschmbudget_2D_levels ) then
          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DTDB_LL' )
+         call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
+                                pdeldry(:ncol,:), mbar, delt_inverse, '2DTDB_trop', tropFlagInt )
+       endif
+       if ( history_chemdyg_summary ) then
          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DTDB_trop', tropFlagInt )
        endif
@@ -1528,16 +1611,19 @@ contains
        end do
     endif
 
-    if ( history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels) then
+    if ( history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels &
+            .or. history_chemdyg_summary) then
        if ( history_gaschmbudget ) then
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, 'TDS' )
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, 'MSS' )
        endif
-       if ( history_gaschmbudget_2D ) then
+       if ( history_gaschmbudget_2D .or. history_chemdyg_summary) then
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, '2DTDS' )
+       endif
+       if ( history_gaschmbudget_2D ) then
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, '2DMSS' )
        endif
@@ -1550,6 +1636,10 @@ contains
                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DMSS_LL' )
          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DMSS_trop', tropFlagInt )
+       endif
+       if ( history_chemdyg_summary ) then
+         call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
+                                pdeldry(:ncol,:), mbar, delt_inverse, '2DTDS_trop', tropFlagInt )
        endif
        vmr_old(:ncol,:,:) = vmr(:ncol,:,:)
     endif
@@ -1643,14 +1733,15 @@ contains
     endif
     call t_stopf('drydep')
 
-    if ( history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels) then
+    if ( history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels &
+            .or. history_chemdyg_summary) then
        if ( history_gaschmbudget ) then
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, 'TDD' )
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, 'MSD' )
        endif
-       if ( history_gaschmbudget_2D ) then
+       if ( history_gaschmbudget_2D .or. history_chemdyg_summary) then
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                  pdeldry(:ncol,:), mbar, delt_inverse, '2DTDD' )
           call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
@@ -1666,19 +1757,25 @@ contains
          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DMSD_trop',tropFlagInt )
        endif
+       if ( history_chemdyg_summary ) then
+         call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
+                                pdeldry(:ncol,:), mbar, delt_inverse, '2DTDD_trop', tropFlagInt )
+         call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
+                                pdeldry(:ncol,:), mbar, delt_inverse, '2DMSD_trop',tropFlagInt )
+       endif
        do m = 1,pcnst
           n = map2chm(m)
           if (n > 0 .and. (.not. any( aer_species == n ))) then
             ! store gas chemistry tracer concentration in pbuf for tendency
             ! calculation
-            if (history_gaschmbudget .or. history_gaschmbudget_2D_levels) then
+            if (history_gaschmbudget .or. history_gaschmbudget_2D_levels .or. history_chemdyg_summary) then
                gas_ac_idx = pbuf_get_index(gas_ac_name(n))
                call pbuf_get_field(pbuf, gas_ac_idx, gas_ac )
                ftem(:ncol,:) = adv_mass(n)*vmr(:ncol,:,n)/mbar(:ncol,:) &
                                *pdeldry(:ncol,:)*rga
                gas_ac(:ncol,:) = ftem(:ncol,:)
             endif
-            if (history_gaschmbudget_2D) then
+            if (history_gaschmbudget_2D .or. history_chemdyg_summary) then
                gas_ac_idx = pbuf_get_index(gas_ac_name_2D(n))
                call pbuf_get_field(pbuf, gas_ac_idx, gas_ac_2D )
                ftem(:ncol,:) = adv_mass(n)*vmr(:ncol,:,n)/mbar(:ncol,:) &

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -970,26 +970,6 @@ contains
                   invariants(1,1,indexm), ncol, lchnk, ltrop_sol(:ncol) ) 
     call t_stopf('imp_sol')
 
-    if ( history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels) then
-       if ( history_gaschmbudget ) then
-          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
-                                 pdeldry(:ncol,:), mbar, delt_inverse, 'TDI' )
-       endif
-       if ( history_gaschmbudget_2D ) then
-          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
-                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DTDI' )
-          call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
-                                 pdeldry(:ncol,:), mbar, delt_inverse, '2DMSI' )
-       endif
-       if ( history_gaschmbudget_2D_levels ) then
-         call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
-                                pdeldry(:ncol,:), mbar, delt_inverse, '2DTDI_LL' )
-         call gaschmmass_diags( lchnk, ncol, vmr(:ncol,:,:), vmr_old(:ncol,:,:), &
-                                pdeldry(:ncol,:), mbar, delt_inverse, '2DTDI_trop', tropFlagInt )
-       endif
-       vmr_old(:ncol,:,:) = vmr(:ncol,:,:)
-    endif
-
     ! ozone production 
     if (uci1_ndx > 0) then
       chem_prod(:,:,:) = 0._r8

--- a/components/eam/src/chemistry/mozart/mo_neu_wetdep.F90
+++ b/components/eam/src/chemistry/mozart/mo_neu_wetdep.F90
@@ -41,7 +41,6 @@ module mo_neu_wetdep
   logical :: do_neu_wetdep
 !
   real(r8), parameter  :: TICE=263._r8
-
 contains
 
 !-----------------------------------------------------------------------
@@ -53,8 +52,10 @@ subroutine neu_wetdep_init
   use cam_history,  only : addfld, add_default, horiz_only
   use ppgrid,       only : pver
   use mo_chem_utls, only : get_rxt_ndx
+  use phys_control, only: phys_getopts
 !
   integer :: m,l
+  logical :: history_gaschmbudget_2D_levels
   character*20 :: test_name
 
   do_neu_wetdep = gas_wetdep_method == 'NEU' .and. gas_wetdep_cnt>0
@@ -68,6 +69,7 @@ subroutine neu_wetdep_init
   allocate( ice_uptake(gas_wetdep_cnt) )
   allocate( mol_weight(gas_wetdep_cnt) )
 
+  call phys_getopts( history_gaschmbudget_2D_levels_out = history_gaschmbudget_2D_levels)
 !
 ! find mapping to heff table
 !
@@ -177,17 +179,19 @@ subroutine neu_wetdep_init
   do m=1,gas_wetdep_cnt
     call addfld     ('DTWR_'//trim(gas_wetdep_list(m)),(/ 'lev' /), 'A','kg/kg/s','wet removal Neu scheme tendency')
     call addfld     ('WD_'//trim(gas_wetdep_list(m)),horiz_only, 'A','kg/m2/s','vertical integrated wet deposition flux')
+    call addfld     ('HEFF_'//trim(gas_wetdep_list(m)),(/ 'lev' /), 'A','M/atm','Effective Henrys Law coeff.')
+    call add_default('DTWR_'//trim(gas_wetdep_list(m)), 1, ' ')
+    call add_default('WD_'//trim(gas_wetdep_list(m)), 1, ' ')
+    if (history_gaschmbudget_2D_levels) then
     call addfld     ('WD_L1_'//trim(gas_wetdep_list(m)),horiz_only, 'A','kg/m2/s','vertical integrated wet deposition flux for L1')
     call addfld     ('WD_L2_'//trim(gas_wetdep_list(m)),horiz_only, 'A','kg/m2/s','vertical integrated wet deposition flux for L2')
     call addfld     ('WD_L3_'//trim(gas_wetdep_list(m)),horiz_only, 'A','kg/m2/s','vertical integrated wet deposition flux for L3')
     call addfld     ('WD_L4_'//trim(gas_wetdep_list(m)),horiz_only, 'A','kg/m2/s','vertical integrated wet deposition flux for L4')
-    call addfld     ('HEFF_'//trim(gas_wetdep_list(m)),(/ 'lev' /), 'A','M/atm','Effective Henrys Law coeff.')
-    call add_default('DTWR_'//trim(gas_wetdep_list(m)), 1, ' ')
-    call add_default('WD_'//trim(gas_wetdep_list(m)), 1, ' ')
     call add_default('WD_L1_'//trim(gas_wetdep_list(m)), 1, ' ')
     call add_default('WD_L2_'//trim(gas_wetdep_list(m)), 1, ' ')
     call add_default('WD_L3_'//trim(gas_wetdep_list(m)), 1, ' ')
     call add_default('WD_L4_'//trim(gas_wetdep_list(m)), 1, ' ')
+    end if
   end do
 !
   if ( do_diag ) then

--- a/components/eam/src/chemistry/mozart/mo_setext.F90
+++ b/components/eam/src/chemistry/mozart/mo_setext.F90
@@ -21,8 +21,9 @@ contains
 
     use mo_chem_utls, only : get_extfrc_ndx
     use ppgrid,       only : pver
-    use cam_history,  only : addfld
+    use cam_history,  only : addfld, add_default
     use spmd_utils,   only : masterproc
+    use phys_control, only : phys_getopts
 
     implicit none
 ! chem diags
@@ -106,6 +107,8 @@ contains
     use mo_aurora,      only : aurora
     use mo_solarproton, only : spe_prod 
     use physics_buffer, only : physics_buffer_desc
+    use phys_control, only : phys_getopts
+    use mo_constants, only : avogadro
 
     implicit none
 
@@ -155,6 +158,7 @@ contains
     extfrc(:,:,:) = 0._r8
 
     no_lgt(:,:) = 0._r8
+    no_tdlgt(:,:) = 0._r8
 
     !--------------------------------------------------------
     !     ... set frcing from datasets
@@ -165,7 +169,7 @@ contains
     !     ... set nox production from lighting
     !         note: from ground to cloud top production is c shaped
     !--------------------------------------------------------
-    if ( no_ndx > 0 ) then
+    if ( no_ndx > 0 ) then 
        do i = 1,ncol
           cldind = nint( cldtop(i) )
           if( cldind < pver .and. cldind > 0  ) then

--- a/components/eam/src/physics/cam/phys_control.F90
+++ b/components/eam/src/physics/cam/phys_control.F90
@@ -89,6 +89,7 @@ logical           :: history_budget       = .false.    ! output tendencies and s
 logical           :: history_gaschmbudget = .false.    ! output gas chemistry tracer concentrations and tendencies
 logical           :: history_gaschmbudget_2D = .false. ! output 2D gas chemistry tracer concentrations and tendencies
 logical           :: history_gaschmbudget_2D_levels = .false. ! output 2D gas chemistry tracer concentrations and tendencies within certain layers
+integer           :: history_gaschmbudget_num = 2      ! Tape number for instantaneous gas chemistry budget output
 integer           :: gaschmbudget_2D_L1_s = 1          ! Start layer of L1 for 2D gas chemistry tracer budget 
 integer           :: gaschmbudget_2D_L1_e = 26         ! End layer of L1 for 2D gas chemistry tracer budget 
 integer           :: gaschmbudget_2D_L2_s = 27         ! Start layer of L2 for 2D gas chemistry tracer budget 
@@ -99,6 +100,7 @@ integer           :: gaschmbudget_2D_L4_s = 59         ! Start layer of L4 for 2
 integer           :: gaschmbudget_2D_L4_e = 72         ! End layer of L4 for 2D gas chemistry tracer budget 
 logical           :: history_UCIgaschmbudget_2D = .false. ! output 2D UCI gas chemistry tracer concentrations and tendencies
 logical           :: history_UCIgaschmbudget_2D_levels = .false. ! output 2D UCI gas chemistry tracer concentrations and tendencies within certain layers
+logical           :: history_chemdyg_summary = .false.    ! output necessary variables for ChemDyg 
 integer           :: UCIgaschmbudget_2D_L1_s = 1          ! Start layer of L1 for 2D UCI gas chemistry tracer budget 
 integer           :: UCIgaschmbudget_2D_L1_e = 26         ! End layer of L1 for 2D UCI gas chemistry tracer budget 
 integer           :: UCIgaschmbudget_2D_L2_s = 27         ! Start layer of L2 for 2D UCI gas chemistry tracer budget 
@@ -233,9 +235,10 @@ subroutine phys_ctl_readnl(nlfile)
       history_gaschmbudget, history_gaschmbudget_2D, history_gaschmbudget_2D_levels, &
       gaschmbudget_2D_L1_s, gaschmbudget_2D_L1_e, gaschmbudget_2D_L2_s, gaschmbudget_2D_L2_e, & 
       gaschmbudget_2D_L3_s, gaschmbudget_2D_L3_e, gaschmbudget_2D_L4_s, gaschmbudget_2D_L4_e, & 
-      history_UCIgaschmbudget_2D, history_UCIgaschmbudget_2D_levels, &
+      history_UCIgaschmbudget_2D, history_UCIgaschmbudget_2D_levels, history_chemdyg_summary, &
       UCIgaschmbudget_2D_L1_s, UCIgaschmbudget_2D_L1_e, UCIgaschmbudget_2D_L2_s, UCIgaschmbudget_2D_L2_e, & 
       UCIgaschmbudget_2D_L3_s, UCIgaschmbudget_2D_L3_e, UCIgaschmbudget_2D_L4_s, UCIgaschmbudget_2D_L4_e, & 
+      history_gaschmbudget_num, &
       use_qqflx_fixer, & 
       print_fixer_message, & 
       use_hetfrz_classnuc, use_gw_oro, use_gw_front, use_gw_convect, &
@@ -270,6 +273,14 @@ subroutine phys_ctl_readnl(nlfile)
         history_aerosol = .true.
       endif
 
+   end if
+   if (history_chemdyg_summary) then
+        if (history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels) then
+            history_chemdyg_summary = .false.
+            history_gaschmbudget_2D = .true.
+            history_gaschmbudget_2D_levels = .true.
+            if (masterproc) write(iulog,*) 'phys_ctl_readnl: history_chemdyg_summary is in conflict with history_gaschmbudget_2D and history_gaschmbudget_2D_levels. Turn history_chemdyg_summary off and turn on both history_gaschmbudget_2D and history_gaschmbudget_2D_levels.'
+        end if
    end if
 
 #ifdef SPMD
@@ -318,6 +329,7 @@ subroutine phys_ctl_readnl(nlfile)
    call mpibcast(gaschmbudget_2D_L4_e,            1 , mpiint,  0, mpicom)
    call mpibcast(history_UCIgaschmbudget_2D,         1 , mpilog,  0, mpicom)
    call mpibcast(history_UCIgaschmbudget_2D_levels,  1 , mpilog,  0, mpicom)
+   call mpibcast(history_chemdyg_summary,            1 , mpilog,  0, mpicom)
    call mpibcast(UCIgaschmbudget_2D_L1_s,            1 , mpiint,  0, mpicom)
    call mpibcast(UCIgaschmbudget_2D_L1_e,            1 , mpiint,  0, mpicom)
    call mpibcast(UCIgaschmbudget_2D_L2_s,            1 , mpiint,  0, mpicom)
@@ -326,6 +338,7 @@ subroutine phys_ctl_readnl(nlfile)
    call mpibcast(UCIgaschmbudget_2D_L3_e,            1 , mpiint,  0, mpicom)
    call mpibcast(UCIgaschmbudget_2D_L4_s,            1 , mpiint,  0, mpicom)
    call mpibcast(UCIgaschmbudget_2D_L4_e,            1 , mpiint,  0, mpicom)
+   call mpibcast(history_gaschmbudget_num,           1 , mpiint,  0, mpicom)
    call mpibcast(history_budget_histfile_num,     1 , mpiint,  0, mpicom)
    call mpibcast(history_waccm,                   1 , mpilog,  0, mpicom)
    call mpibcast(history_clubb,                   1 , mpilog,  0, mpicom)
@@ -559,10 +572,11 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
                         history_amwg_out, history_verbose_out, history_vdiag_out, &
                         get_presc_aero_data_out,&
                         history_aerosol_out, history_aero_optics_out, history_eddy_out, &
-                        history_budget_out, history_gaschmbudget_out, history_gaschmbudget_2D_out, history_gaschmbudget_2D_levels_out, &
+                        history_budget_out, history_gaschmbudget_out, history_gaschmbudget_2D_out, &
+                        history_gaschmbudget_num_out, history_gaschmbudget_2D_levels_out, &
                         gaschmbudget_2D_L1_s_out, gaschmbudget_2D_L1_e_out, gaschmbudget_2D_L2_s_out, gaschmbudget_2D_L2_e_out, &
                         gaschmbudget_2D_L3_s_out, gaschmbudget_2D_L3_e_out, gaschmbudget_2D_L4_s_out, gaschmbudget_2D_L4_e_out, &
-                        history_UCIgaschmbudget_2D_out, history_UCIgaschmbudget_2D_levels_out, &
+                        history_UCIgaschmbudget_2D_out, history_UCIgaschmbudget_2D_levels_out, history_chemdyg_summary_out, &
                         UCIgaschmbudget_2D_L1_s_out, UCIgaschmbudget_2D_L1_e_out, UCIgaschmbudget_2D_L2_s_out, UCIgaschmbudget_2D_L2_e_out, &
                         UCIgaschmbudget_2D_L3_s_out, UCIgaschmbudget_2D_L3_e_out, UCIgaschmbudget_2D_L4_s_out, UCIgaschmbudget_2D_L4_e_out, &
                         history_budget_histfile_num_out, history_waccm_out, &
@@ -625,6 +639,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
    logical,           intent(out), optional :: history_budget_out
    logical,           intent(out), optional :: history_gaschmbudget_out
    logical,           intent(out), optional :: history_gaschmbudget_2D_out
+   integer,           intent(out), optional :: history_gaschmbudget_num_out
    logical,           intent(out), optional :: history_gaschmbudget_2D_levels_out
    integer,           intent(out), optional :: gaschmbudget_2D_L1_s_out
    integer,           intent(out), optional :: gaschmbudget_2D_L1_e_out
@@ -636,6 +651,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
    integer,           intent(out), optional :: gaschmbudget_2D_L4_e_out
    logical,           intent(out), optional :: history_UCIgaschmbudget_2D_out
    logical,           intent(out), optional :: history_UCIgaschmbudget_2D_levels_out
+   logical,           intent(out), optional :: history_chemdyg_summary_out
    integer,           intent(out), optional :: UCIgaschmbudget_2D_L1_s_out
    integer,           intent(out), optional :: UCIgaschmbudget_2D_L1_e_out
    integer,           intent(out), optional :: UCIgaschmbudget_2D_L2_s_out
@@ -723,6 +739,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
    if ( present(history_budget_out      ) ) history_budget_out       = history_budget
    if ( present(history_gaschmbudget_out) ) history_gaschmbudget_out = history_gaschmbudget
    if ( present(history_gaschmbudget_2D_out) ) history_gaschmbudget_2D_out = history_gaschmbudget_2D
+   if ( present(history_gaschmbudget_num_out) ) history_gaschmbudget_num_out = history_gaschmbudget_num
    if ( present(history_gaschmbudget_2D_levels_out) ) history_gaschmbudget_2D_levels_out = history_gaschmbudget_2D_levels
    if ( present(gaschmbudget_2D_L1_s_out) ) gaschmbudget_2D_L1_s_out = gaschmbudget_2D_L1_s
    if ( present(gaschmbudget_2D_L1_e_out) ) gaschmbudget_2D_L1_e_out = gaschmbudget_2D_L1_e
@@ -734,6 +751,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
    if ( present(gaschmbudget_2D_L4_e_out) ) gaschmbudget_2D_L4_e_out = gaschmbudget_2D_L4_e
    if ( present(history_UCIgaschmbudget_2D_out) ) history_UCIgaschmbudget_2D_out = history_UCIgaschmbudget_2D
    if ( present(history_UCIgaschmbudget_2D_levels_out) ) history_UCIgaschmbudget_2D_levels_out = history_UCIgaschmbudget_2D_levels
+   if ( present(history_chemdyg_summary_out) ) history_chemdyg_summary_out = history_chemdyg_summary
    if ( present(UCIgaschmbudget_2D_L1_s_out) ) UCIgaschmbudget_2D_L1_s_out = UCIgaschmbudget_2D_L1_s
    if ( present(UCIgaschmbudget_2D_L1_e_out) ) UCIgaschmbudget_2D_L1_e_out = UCIgaschmbudget_2D_L1_e
    if ( present(UCIgaschmbudget_2D_L2_s_out) ) UCIgaschmbudget_2D_L2_s_out = UCIgaschmbudget_2D_L2_s

--- a/components/eam/src/physics/cam/phys_control.F90
+++ b/components/eam/src/physics/cam/phys_control.F90
@@ -278,8 +278,9 @@ subroutine phys_ctl_readnl(nlfile)
         if (history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels) then
             history_chemdyg_summary = .false.
             history_gaschmbudget_2D = .true.
+            history_UCIgaschmbudget_2D = .true.
             history_gaschmbudget_2D_levels = .true.
-            if (masterproc) write(iulog,*) 'phys_ctl_readnl: history_chemdyg_summary is in conflict with history_gaschmbudget_2D and history_gaschmbudget_2D_levels. Turn history_chemdyg_summary off and turn on both history_gaschmbudget_2D and history_gaschmbudget_2D_levels.'
+            if (masterproc) write(iulog,*) 'phys_ctl_readnl: history_chemdyg_summary is in conflict with history_gaschmbudget_2D and history_gaschmbudget_2D_levels. Turn history_chemdyg_summary off and turn on both history_gaschmbudget_2D and history_gaschmbudget_2D_levels, as well as history_UCIgaschmbudget_2D to get full outputs.'
         end if
    end if
 

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -109,6 +109,7 @@ module physpkg
   logical :: history_gaschmbudget ! output gas chemistry tracer concentrations and tendencies
   logical :: history_gaschmbudget_2D ! output 2D gas chemistry tracer concentrations and tendencies
   logical :: history_gaschmbudget_2D_levels ! output 2D gas chemistry tracer concentrations and tendencies within certain layers
+  logical :: history_chemdyg_summary
 
   !======================================================================= 
 contains
@@ -195,7 +196,8 @@ subroutine phys_register
                       pergro_mods_out          = pergro_mods, &
                       history_gaschmbudget_out = history_gaschmbudget, &
                    history_gaschmbudget_2D_out = history_gaschmbudget_2D, &
-            history_gaschmbudget_2D_levels_out = history_gaschmbudget_2D_levels)
+            history_gaschmbudget_2D_levels_out = history_gaschmbudget_2D_levels, &
+                   history_chemdyg_summary_out = history_chemdyg_summary )
 
     ! Initialize dyn_time_lvls
     call pbuf_init_time()
@@ -287,17 +289,18 @@ subroutine phys_register
 
        ! NB: has to be after chem_register to use tracer names
        ! Fields for gas chemistry tracers
-       if (history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels) then
+       if (history_gaschmbudget .or. history_gaschmbudget_2D .or. history_gaschmbudget_2D_levels &
+            .or. history_chemdyg_summary) then
          call chm_diags_inti_ac() ! to get aer_species
          do m = 1,gas_pcnst
             if (.not. any( aer_species == m )) then
               spc_name = trim(solsym(m))
-              if (history_gaschmbudget .or. history_gaschmbudget_2D_levels) then
+              if (history_gaschmbudget .or. history_gaschmbudget_2D_levels .or. history_chemdyg_summary) then
                 gas_ac_name(m) = 'ac_'//spc_name
                 call pbuf_add_field(gas_ac_name(m), 'global', dtype_r8, (/pcols,pver/), gas_ac_idx)
               end if
 
-              if (history_gaschmbudget_2D) then
+              if (history_gaschmbudget_2D .or. history_chemdyg_summary) then
                 gas_ac_name_2D(m) = 'ac_2D_'//spc_name
                 call pbuf_add_field(gas_ac_name_2D(m), 'global', dtype_r8, (/pcols/), gas_ac_idx)
               end if


### PR DESCRIPTION
In order to reduce E3SM outputs for ChemDyg, I created a new flag "history_chemdyg_summary" to write out necessary variables. The run script needs to change to the followings:
```
history_gaschmbudget_num = 2
nhtfrq = 0,0,-1,-24
mfilt = 1,1,240,30
avgflag_pertape = 'A','I','I','A'

fincl1 = 'TROPE_P'
fincl3 = 'O3_SRF'
fincl4 = 'TCO','SCO','T'

tropopause_e90_thrd = 80.0e-9
history_chemdyg_summary = .true.
```
------------------------------------------------
cherry pick and merge 9 commits from v3atm
```
pick e63421ed02 add new flag for chemdyg pkg
pick 6731a94f77 minor changes for if statement
pick a810922ba2 resolve conflicts with v3atm PR#66 commit 3
pick c803de6d17 Force histroy_chemdyg_summary to be false if conflict with other flags
pick a799c22201 correct histroy_chemdyg_summary location to be false if conflict with other flags
pick 4700e03d87 Update components/eam/src/physics/cam/phys_control.F90
pick 45f36af940 Define a new user name list variable history_gaschmbudget_num
pick 33cffea959 Add history_gaschmbudget_num in phys_control.F90
pick dd17529d6d Add history_gaschmbudget_num_out
```
