### PR TITLE
Adds a ELM namelist option to add a MPI_Barrier

### DIFF
--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -2026,7 +2026,7 @@ Toggle to turn on the internal mixing of dust-snow.
 
 <entry id="mpi_sync_nstep_freq" type="integer(6)" category="history"
        group="elm_inparm" value="0">
-The number of steps after which a MPI_Barrier is called. By default (-1), a MPI_Barrier will
+The number of steps after which a MPI_Barrier is called. By default, a MPI_Barrier will
 not be called.
 <default>Default: 0</default>
 </entry>

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -2020,5 +2020,15 @@ explain the SZA dependence of direct irradiance.
 Toggle to turn on the internal mixing of dust-snow. 
 </entry>
 
+<!-- ========================================================================================  -->
+<!-- Namelist option for MPI syncing                                                           -->
+<!-- ========================================================================================  -->
+
+<entry id="mpi_sync_nstep_freq" type="integer(6)" category="history"
+       group="elm_inparm" value="0">
+The number of steps after which a MPI_Barrier is called. By default (-1), a MPI_Barrier will
+not be called.
+<default>Default: 0</default>
+</entry>
 
 </namelist_definition>

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -225,7 +225,8 @@ contains
     namelist /elm_inparm/  &
          clump_pproc, wrtdia, &
          create_crop_landunit, nsegspc, co2_ppmv, override_nsrest, &
-         albice, more_vertlayers, subgridflag, irrigate, tw_irr, extra_gw_irr, firrig_data, all_active
+         albice, more_vertlayers, subgridflag, irrigate, tw_irr, extra_gw_irr, firrig_data, all_active, &
+         mpi_sync_nstep_freq
     ! Urban options
 
     namelist /elm_inparm/  &
@@ -318,7 +319,7 @@ contains
 		 
     namelist /elm_inparm/ &
          snow_shape, snicar_atm_type, use_dust_snow_internal_mixing 
-    
+
     ! ----------------------------------------------------------------------
     ! Default values
     ! ----------------------------------------------------------------------
@@ -938,6 +939,8 @@ contains
     call mpi_bcast (snicar_atm_type, len(snicar_atm_type), MPI_CHARACTER, 0, mpicom, ier)
     call mpi_bcast (use_dust_snow_internal_mixing, 1, MPI_LOGICAL, 0, mpicom, ier)
 	
+    call mpi_bcast (mpi_sync_nstep_freq, 1, MPI_INTEGER, 0, mpicom, ier)
+
   end subroutine control_spmd
 
   !------------------------------------------------------------------------
@@ -1195,6 +1198,7 @@ contains
     ! land river two way coupling
     write(iulog,*) '    use_lnd_rof_two_way    = ', use_lnd_rof_two_way
     write(iulog,*) '    lnd_rof_coupling_nstep = ', lnd_rof_coupling_nstep
+    write(iulog,*) '    mpi_sync_nstep_freq    = ', mpi_sync_nstep_freq
 
   end subroutine control_print
 

--- a/components/elm/src/main/elm_varctl.F90
+++ b/components/elm/src/main/elm_varctl.F90
@@ -522,6 +522,10 @@ module elm_varctl
    character(len=256), public :: snicar_atm_type = 'default'
    logical, public :: use_dust_snow_internal_mixing = .false.
 
+   !----------------------------------------------------------
+   ! MPI syncing
+   !----------------------------------------------------------
+   integer, public :: mpi_sync_nstep_freq = 0
 
 contains
 


### PR DESCRIPTION
A namelist option (`mpi_sync_nstep_freq`) is added to allow ELM to call an MPI_Barrier. 
By default, the MPI_Barrier is not called.

[BFB]