### PR TITLE
Revert aqueous chemistry bugfix PR

### DIFF
--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -1268,7 +1268,7 @@ contains
     call t_startf('aero_model_gasaerexch')
     call aero_model_gasaerexch( imozart-1, ncol, lchnk, delt, latndx, lonndx, reaction_rates, &
                                 tfld, pmid, pdel, mbar, relhum, &
-                                zm,  qh2o, cwat_liq, cldfr, ncldwtr, &  
+                                zm,  qh2o, cwat, cldfr, ncldwtr, &
                                 invariants(:,:,indexm), invariants, del_h2so4_gasprod,  &
                                 vmr0, vmr, pbuf )
     call t_stopf('aero_model_gasaerexch')


### PR DESCRIPTION
Aqueous chemistry bugfix PR #5723 is climate changing even for v2 compset.

This reverts commit c633ff013b7c6a61d2c25e183897cd7c355013e6 to revert the
climate changing behavior for default master compsets (v2-like) due to #5723.

[CC] 

----------------------------------------------------------------------------------------------------------------------
The reversing changes are made to b9e8b1bb91d9663e1b4bb77fbe23404ae16af365, the head commit of master
before #5723 was merged.

It is CC relative to the blessed baselines following the previous merge of #5723