### PR TITLE
Update intel compiler version on pm-cpu for maint-1.0

### DIFF
--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -128,7 +128,7 @@
 
     <modules compiler="intel">
       <command name="load">PrgEnv-intel/8.3.3</command>
-      <command name="load">intel/2023.0.0</command>
+      <command name="load">intel/2023.1.0</command>
     </modules>
 
     <modules compiler="nvidia">


### PR DESCRIPTION
After machine maintenance, module version being used was no longer available. Update to current.

