### PR TITLE
On pm-cpu, Update module version of intel compiler

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -216,7 +216,7 @@
 
       <modules compiler="intel">
         <command name="load">PrgEnv-intel/8.3.3</command>
-        <command name="load">intel/2023.0.0</command>
+        <command name="load">intel/2023.1.0</command>
       </modules>
 
       <modules compiler="nvidia">


### PR DESCRIPTION
After maintenance, the version being used was missing and now trying `intel-oneapi/2023.1.0`

There were a few diffs with baselines, but I'm not sure if they were already there or not, so will say nbfb.
[NBFB]