### PR TITLE
add BTAU variables interpolated to pressure levels

### DIFF
--- a/components/eam/src/physics/cam/gw_drag.F90
+++ b/components/eam/src/physics/cam/gw_drag.F90
@@ -28,7 +28,7 @@ module gw_drag
   use constituents,  only: pcnst
   use physics_types, only: physics_state, physics_ptend, physics_ptend_init
   use spmd_utils,    only: masterproc
-  use cam_history,   only: outfld
+  use cam_history,   only: outfld, hist_fld_active
   use cam_logfile,   only: iulog
   use cam_abortutils,    only: endrun
 
@@ -796,7 +796,7 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
              pint, dpm, u, v, ptend%u, ptend%v, ptend%s, utgw, vtgw, ttgw)
 
         call gw_spec_outflds(beres_pf, lchnk, ncol, pgwv, c, u, v, &
-             xv, yv, gwut, dttdf, dttke, tau(:,:,1:), utgw, vtgw, taucd)
+             xv, yv, gwut, dttdf, dttke, tau(:,:,1:), utgw, vtgw, taucd, state)
 
         ! Note: This is probably redundant, because ZMDT is already being
         ! output...
@@ -859,7 +859,7 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
              pint, dpm, u, v, ptend%u, ptend%v, ptend%s, utgw, vtgw, ttgw)
 
         call gw_spec_outflds(cm_pf, lchnk, ncol, pgwv, c, u, v, &
-             xv, yv, gwut, dttdf, dttke, tau(:,:,1:), utgw, vtgw, taucd)
+             xv, yv, gwut, dttdf, dttke, tau(:,:,1:), utgw, vtgw, taucd, state)
 
         call outfld ('FRONTGF', frontgf, pcols, lchnk)
         call outfld ('FRONTGFA', frontga, pcols, lchnk)
@@ -1051,6 +1051,12 @@ subroutine gw_spec_addflds(prefix, scheme, history_waccm)
      call addfld (trim(dumc1x),(/ 'lev' /), 'A','Pa',dumc2)
      call addfld (trim(dumc1y),(/ 'lev' /), 'A','Pa',dumc2)
 
+     ! add zonal source spectra on specific pressure levels
+     call addfld (trim(dumc1x)//'_100mb',horiz_only, 'A','Pa',dumc2//" at 100 mbar pressure surface")
+     call addfld (trim(dumc1x)//'_50mb' ,horiz_only, 'A','Pa',dumc2//" at 50 mbar pressure surface")
+     call addfld (trim(dumc1x)//'_30mb' ,horiz_only, 'A','Pa',dumc2//" at 30 mbar pressure surface")
+     call addfld (trim(dumc1x)//'_10mb' ,horiz_only, 'A','Pa',dumc2//" at 10 mbar pressure surface")
+
   end do
 
   if (history_waccm) then
@@ -1076,9 +1082,10 @@ end subroutine gw_spec_addflds
 
 ! Outputs for spectral waves.
 subroutine gw_spec_outflds(prefix, lchnk, ncol, ngwv, c, u, v, xv, yv, &
-     gwut, dttdf, dttke, tau, utgw, vtgw, taucd)
+     gwut, dttdf, dttke, tau, utgw, vtgw, taucd, state)
 
   use gw_common, only: west, east, south, north
+  use interpolate_data, only: vertinterp
 
   ! One-character prefix prepended to output fields.
   character(len=1), intent(in) :: prefix
@@ -1107,6 +1114,7 @@ subroutine gw_spec_outflds(prefix, lchnk, ncol, ngwv, c, u, v, xv, yv, &
   real(r8), intent(in) :: vtgw(ncol,pver)
   ! Reynolds stress for waves propagating in each cardinal direction.
   real(r8), intent(in) :: taucd(ncol,0:pver,4)
+  type(physics_state), intent(in) :: state      ! physics state structure
 
   ! Indices
   integer :: i, k, l
@@ -1129,6 +1137,7 @@ subroutine gw_spec_outflds(prefix, lchnk, ncol, ngwv, c, u, v, xv, yv, &
   ! Temporaries for output
   real(r8) :: dummyx(ncol,pver)
   real(r8) :: dummyy(ncol,pver)
+  real(r8) :: dummmy_p_surf(pcols) ! data interpolated to a pressure surface
   ! Variable names
   character(len=10) :: dumc1x, dumc1y
 
@@ -1202,6 +1211,23 @@ subroutine gw_spec_outflds(prefix, lchnk, ncol, ngwv, c, u, v, xv, yv, &
 
      call outfld(dumc1x,dummyx,ncol,lchnk)
      call outfld(dumc1y,dummyy,ncol,lchnk)
+
+     if (hist_fld_active(trim(dumc1x)//'_100mb')) then
+        call vertinterp(ncol, pcols, pver, state%pmid, 10000._r8, dummyx, dummmy_p_surf)
+        call outfld(trim(dumc1x)//'_100mb', dummmy_p_surf, pcols, lchnk)
+     end if
+     if (hist_fld_active(trim(dumc1x)//'_50mb')) then
+        call vertinterp(ncol, pcols, pver, state%pmid, 5000._r8, dummyx, dummmy_p_surf)
+        call outfld(trim(dumc1x)//'_50mb', dummmy_p_surf, pcols, lchnk)
+     end if
+     if (hist_fld_active(trim(dumc1x)//'_30mb')) then
+        call vertinterp(ncol, pcols, pver, state%pmid, 3000._r8, dummyx, dummmy_p_surf)
+        call outfld(trim(dumc1x)//'_30mb', dummmy_p_surf, pcols, lchnk)
+     end if
+     if (hist_fld_active(trim(dumc1x)//'_10mb')) then
+        call vertinterp(ncol, pcols, pver, state%pmid, 1000._r8, dummyx, dummmy_p_surf)
+        call outfld(trim(dumc1x)//'_10mb', dummmy_p_surf, pcols, lchnk)
+     end if
 
   enddo
 


### PR DESCRIPTION
This adds optional versions of variables such as "BTAUXSn28" interpolated to specific pressure levels (100 mb, 50 mb ,30 mb ,10 mb) to assist in diagnosing the QBO. These history variables are the parameterized convective gravity wave drag at each wave phase speed. The new variables will not be output be default so this change will not impact any tests or configurations.

[BFB]