### PR TITLE
Remove extraneous character from openacc directive

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -3458,7 +3458,7 @@ contains
 
       ! compute friction velocity at cell centers
 #ifdef MPAS_OPENACC
-      !$acc parallel loop present(landIceFrictionVelocity, kineticEnergyCell, minLevelCell) &
+      !$acc parallel loop present(landIceFrictionVelocity, kineticEnergyCell, minLevelCell)
 #else
       !$omp parallel
       !$omp do schedule(runtime)


### PR DESCRIPTION
Removes the extra continuation char "&" @amametjanov found while testing the PGI (or nvhpc) compiler when compiling for a GPU run.

Fixes #5764 
[BFB]