### PR TITLE
MPAS: add dynamic time level allocation from namelist flag

### DIFF
--- a/components/mpas-framework/src/tools/registry/gen_inc.c
+++ b/components/mpas-framework/src/tools/registry/gen_inc.c
@@ -1717,10 +1717,10 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 		varname_in_code = ezxml_attr(var_xml, "name");
 	}
 
-    varname_in_output = ezxml_attr(var_xml, "name_in_output");
-    if(!varname_in_output){
-        varname_in_output = ezxml_attr(var_xml, "name");
-    }
+	varname_in_output = ezxml_attr(var_xml, "name_in_output");
+	if(!varname_in_output){
+		varname_in_output = ezxml_attr(var_xml, "name");
+	}
 
 	if(!vartimelevs){
 		vartimelevs = ezxml_attr(superStruct, "time_levs");
@@ -1761,7 +1761,7 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 	build_dimension_information(registry, var_xml, &ndims, &hasTime, &decomp);
 
 	if (time_levs_from_config || time_levs > 1) {
-	    set_pointer_name(type, ndims, pointer_name, true);
+		set_pointer_name(type, ndims, pointer_name, true);
 		if (time_levs_from_config) {
 			fortprintf(fd, "      allocate(%s(config_flag_time_levs))\n", pointer_name);
 			fortprintf(fd, "      do iTime = 1,config_flag_time_levs\n");
@@ -1771,7 +1771,7 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 		}
 		snprintf(pointer_name_arr, 1024, "%s(iTime)", pointer_name);
 	} else {
-	    set_pointer_name(type, ndims, pointer_name, false);
+		set_pointer_name(type, ndims, pointer_name, false);
 		snprintf(pointer_name_arr, 1024, "%s", pointer_name);
 		fortprintf(fd, "      allocate(%s)\n", pointer_name);
 	}
@@ -1951,10 +1951,10 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 
 			free(tofree);
 
-		        fortprintf(fd, "      %s %% maskName = '%s'\n", pointer_name_arr , temp_str);
+			fortprintf(fd, "      %s %% maskName = '%s'\n", pointer_name_arr , temp_str);
 			fortprintf(fd, "      call mpas_add_att(%s %% attLists(1) %% attList, 'missing_value_mask', '%s')\n", pointer_name_arr, temp_str);
-                } else {
-                        fortprintf(fd, "      %s %% maskName = 'none'\n", pointer_name_arr , temp_str);
+		} else {
+			fortprintf(fd, "      %s %% maskName = 'none'\n", pointer_name_arr , temp_str);
 		}
 
 		if ( varmissingval != NULL ) {
@@ -1966,7 +1966,7 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 
 	if (time_levs_from_config || time_levs > 1) {
 		fortprintf(fd, "      enddo\n");
-		}
+	}
 
 	// Parse packages if they are defined
 	fortprintf(fd, "\n");
@@ -1987,16 +1987,16 @@ int parse_var(FILE *fd, ezxml_t registry, ezxml_t superStruct, ezxml_t currentVa
 	}
 
 	if (time_levs_from_config || time_levs > 1) {
-        if (time_levs_from_config) {
-	        fortprintf(fd, "      do iTime = 1,config_flag_time_levs\n");
-    	} else {
-	        fortprintf(fd, "      do iTime = 1,%d\n",time_levs);
-        }
+		if (time_levs_from_config) {
+			fortprintf(fd, "      do iTime = 1,config_flag_time_levs\n");
+		} else {
+			fortprintf(fd, "      do iTime = 1,%d\n",time_levs);
+		}
 		snprintf(pointer_name_arr, 1024, "%s(iTime)", pointer_name);
 	} else {
 		snprintf(pointer_name_arr, 1024, "%s", pointer_name);
 	}
-		fortprintf(fd, "         %s%s %% isActive = .true.\n", package_spacing, pointer_name_arr);
+	fortprintf(fd, "         %s%s %% isActive = .true.\n", package_spacing, pointer_name_arr);
 	if (time_levs_from_config || time_levs > 1) {
 		fortprintf(fd, "      enddo\n");
 	}

--- a/components/mpas-framework/src/tools/registry/gen_inc.h
+++ b/components/mpas-framework/src/tools/registry/gen_inc.h
@@ -8,10 +8,11 @@
 //
 
 #include "ezxml.h"
+#include <stdbool.h>
 
 void write_model_variables(ezxml_t registry);
 int write_field_pointer_arrays(FILE* fd);
-int set_pointer_name(int type, int ndims, char *pointer_name, int time_levs);
+int set_pointer_name(int type, int ndims, char *pointer_name, bool mult_time_levs);
 int add_package_to_list(const char * package, const char * package_list);
 int build_struct_package_lists(ezxml_t currentPosition, char * out_packages);
 int get_dimension_information(ezxml_t registry, const char *test_dimname, int *has_time, int *decomp);

--- a/components/mpas-framework/src/tools/registry/parse.c
+++ b/components/mpas-framework/src/tools/registry/parse.c
@@ -222,7 +222,34 @@ int validate_reg_xml(ezxml_t registry)/*{{{*/
 			fprintf(stderr,"ERROR: time_levs attribute missing for var_struct %s.\n", structname);
 			return 1;
 		} else {
-			if (atoi(time_levs) == 0){
+			if (strncmp(time_levs, "namelist:", 9) == 0){
+				fprintf(stderr,"Namelist string detected in time_levs for %s.\n", structname);
+				found = 0;
+				snprintf(name_holder, 1024, "%s",time_levs);
+				snprintf(name_holder, 1024, "%s",(name_holder)+9);
+				for (nmlrecs_xml = ezxml_child(registry, "nml_record"); nmlrecs_xml; nmlrecs_xml = nmlrecs_xml->next){
+
+					for (nmlopt_xml = ezxml_child(nmlrecs_xml, "nml_option"); nmlopt_xml; nmlopt_xml = nmlopt_xml->next){
+						nmloptname = ezxml_attr(nmlopt_xml, "name");
+						nmlopttype = ezxml_attr(nmlopt_xml, "type");
+
+						if (strncmp(name_holder, nmloptname, 1024) == 0){
+							if (strcasecmp("integer", nmlopttype) != 0){
+								fprintf(stderr, "ERROR: Namelist variable %s must be an integer for namelist-derived time_levs.\n", nmloptname);
+								return 1;
+							}
+
+							found = 1;
+							fprintf(stderr,"Namelist string match in time_levs for %s: %s \n", structname, nmloptname);
+						}
+					}
+				}
+
+				if (!found){
+					fprintf(stderr, "ERROR: Namelist variable %s not found for namelist-derived time_levs\n", name_holder);
+					return 1;
+				}
+			} else if (atoi(time_levs) == 0){
 				fprintf(stderr, "WARNING: time_levs attribute on var_struct %s is 0. It will be replaced with 1.\n", structname);
 			} else if (atoi(time_levs) < 1){
 				fprintf(stderr, "ERROR: time_levs attribute on var_struct %s is negative.\n", structname);

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -507,6 +507,7 @@ add_default($nl, 'config_proc_decomp_file_prefix');
 
 add_default($nl, 'config_dt');
 add_default($nl, 'config_time_integrator');
+add_default($nl, 'config_number_of_time_levels');
 
 ########################
 # Namelist group: hmix #

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -46,6 +46,7 @@ add_default($nl, 'config_proc_decomp_file_prefix');
 
 add_default($nl, 'config_dt');
 add_default($nl, 'config_time_integrator');
+add_default($nl, 'config_number_of_time_levels');
 
 ########################
 # Namelist group: hmix #

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -49,6 +49,7 @@
 <config_dt ocn_grid="SOwISC12to60E2r4">'00:10:00'</config_dt>
 <config_dt ocn_grid="ECwISC30to60E2r1">'00:30:00'</config_dt>
 <config_time_integrator>'split_explicit'</config_time_integrator>
+<config_number_of_time_levels>2</config_number_of_time_levels>
 
 <!-- hmix -->
 <config_hmix_scaleWithMesh ocn_grid="oQU480">.false.</config_hmix_scaleWithMesh>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -208,6 +208,14 @@ Valid values: 'split_explicit', 'RK4', 'unsplit_explicit', 'split_implicit'
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_number_of_time_levels" type="integer"
+	category="time_integration" group="time_integration">
+The number of time levels in the time-stepping scheme. This is used for array allocation.
+
+Valid values: Any integer greater than or equal to 2.
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- hmix -->
 

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -201,6 +201,10 @@
 					description="Time integration method."
 					possible_values="'split_explicit', 'RK4', 'unsplit_explicit', 'split_implicit'"
 		/>
+		<nml_option name="config_number_of_time_levels" type="integer" default_value="2"
+					description="The number of time levels in the time-stepping scheme. This is used for array allocation."
+					possible_values="Any integer greater than or equal to 2."
+		/>
 	</nml_record>
 	<nml_record name="hmix" mode="forward">
 		<nml_option name="config_hmix_scaleWithMesh" type="logical" default_value=".false."
@@ -2194,7 +2198,7 @@
 
 	</streams>
 
-	<var_struct name="state" time_levs="2">
+	<var_struct name="state" time_levs="namelist:config_number_of_time_levels">
 		<var name="normalVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
 			 description="horizontal velocity, normal component to an edge"
 			 missing_value="FILLVAL" missing_value_mask="edgeMask"


### PR DESCRIPTION
Currently, the number of time levels in all mpas cores must be set in the `Registry.xml` file for each structure as follows:
```
<var_struct name="state" time_levs="2">
```
This PR allows dynamic time level specifications, so that each `var_struct` may be controlled with a namelist flag:
```
<var_struct name="state" time_levs="namelist:config_number_of_time_levels">
```
and the number of time levels may be changed from the namelist at run time.

This option is now available to all MPAS cores, but is optional, so if no changes are made to the Registry file, the behavior remains identical to before. The PR includes a check in `parse.c` to ensure that the config flag name is valid and is an integer.

I have included the addition of a flag here for the ocean core in order to show how it works. The default value for this new flag is 2, so the behavior remains unchanged.

[BFB]
[NML]