### PR TITLE
disable excessive logging in chem

### DIFF
--- a/components/eam/src/chemistry/mozart/lin_strat_chem.F90
+++ b/components/eam/src/chemistry/mozart/lin_strat_chem.F90
@@ -182,6 +182,7 @@ end subroutine linoz_readnl
    ! write(iulog,*)'in subroutine lin_strat_chem_inti'
    ! write(iulog,*)'O3LNZ=',o3lnz_ndx,'N2OLNZ=',n2olnz_ndx,'NOYLNZ=',noylnz_ndx,'H2OLNZ=',h2olnz_ndx
    ! write(iulog,*)'O3=',o3_ndx,'CH4=',ch4_ndx,'N2O=',n2o_ndx,'NO=',no_ndx,'NO2=',no2_ndx,'HNO3=',hno3_ndx
+   write(iulog,*)'do_lin_strat_chem=',do_lin_strat_chem,'linoz_v2=',linoz_v2,'linoz_v3=',linoz_v3
    !  write(iulog,*)'inside lin_strat_solve for ndx o3, o3lnz, n2o, noylnz, ch4', o3_ndx, o3lnz_ndx, n2o_ndx, noylnz_ndx, ch4_ndx
    end if
     

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -1448,7 +1448,7 @@ contains
 !
     ! LINOZ
     ! col_dens(:,:,1) is for O3; col_dens(:,:,2) is for O2; col_dens(:,:,3) is for O3LNZ
-    if (masterproc)write(iulog,*)'do_lin_strat_chem=',do_lin_strat_chem,'linoz_v2=',linoz_v2,'linoz_v3=',linoz_v3
+    ! if (masterproc)write(iulog,*)'do_lin_strat_chem=',do_lin_strat_chem,'linoz_v2=',linoz_v2,'linoz_v3=',linoz_v3
     
     xsfc(:,:)=0    
     if ( do_lin_strat_chem ) then

--- a/components/eam/src/chemistry/mozart/mo_lightning.F90
+++ b/components/eam/src/chemistry/mozart/mo_lightning.F90
@@ -324,11 +324,11 @@ contains
     glob_flashfreq=wrk2(1)/60._r8
     call shr_reprosum_calc( glob_prod_no_col, wrk2,kk,kk,1, commid=mpicom)
     glob_noprod = wrk2(1)
-    if( masterproc ) then
-       write(iulog,*) ' '
-       write(iulog,'(''Global flash freq (/s), lightning NOx (TgN/y) = '',2f10.4)') &
-            glob_flashfreq, glob_noprod
-    end if
+   !  if( masterproc ) then
+   !     write(iulog,*) ' '
+   !     write(iulog,'(''Global flash freq (/s), lightning NOx (TgN/y) = '',2f10.4)') &
+   !          glob_flashfreq, glob_noprod
+   !  end if
 
     if( glob_noprod > 0._r8 ) then
        !--------------------------------------------------------------------------------


### PR DESCRIPTION
 Disable per step logging of lightning NOx and linoz options.

[BFB]
---------------------------------------------------------------------------------------------------------------
Below is the original draft commit message, which is simplified as above for the merge commit.

This draft PR proposes disabling logging at every time step for two new chem features as part of v3. The logging wasn't enabled previously. For now, I simply commented these lines out. However, a more desirable solution may exist where logging can happen at the first step only or in the preamble. See below for how they appear in the targeted branch (v3) vs current master (v2).

<details><summary>v3</summary>
<p>

```
 nstep, te     3355   0.26237744405846009E+10   0.26237766411979456E+10   0.12167978652049336E-03   0.98536209073071703E+05
  
Global flash freq (/s), lightning NOx (TgN/y) =    31.7797    1.5737
 do_lin_strat_chem= T linoz_v2= F linoz_v3= T
 nstep, te     3356   0.26237397620288749E+10   0.26237414389949470E+10   0.92725490370622340E-04   0.98536171484701117E+05
  
Global flash freq (/s), lightning NOx (TgN/y) =    32.9714    1.6245
 do_lin_strat_chem= T linoz_v2= F linoz_v3= T
 nstep, te     3357   0.26236985440255389E+10   0.26237003970929694E+10   0.10246283025623514E-03   0.98536111961507355E+05
  
```

</p>
</details>  


<details><summary>v2</summary>
<p>

```
 nstep, te   161654   0.26248186663117232E+10   0.26248186801433063E+10   0.15298796601443216E-05   0.98517904983531611E+05
 nstep, te   161655   0.26248016109393911E+10   0.26248038598654752E+10   0.24874861661303263E-03   0.98517880091223531E+05
 nstep, te   161656   0.26247883409141140E+10   0.26247884387260523E+10   0.10818759561378321E-04   0.98517854836411469E+05
 nstep, te   161657   0.26247699333299103E+10   0.26247723163711505E+10   0.26358293082365497E-03   0.98517827478318446E+05
 nstep, te   161658   0.26247557334176493E+10   0.26247558912121325E+10   0.17453304318051123E-04   0.98517799951685549E+05
 nstep, te   161659   0.26247367740292397E+10   0.26247390657590075E+10   0.25348331656305147E-03   0.98517770691385624E+05
```

</p>
</details> 


--

[BFB]