### PR TITLE
Replace dt with 0.0 in ocn_surface_land_ice_fluxes_build_arrays call

### DIFF
--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -667,6 +667,9 @@ contains
     call mpas_add_clock_alarm(domain % clock, coupleAlarmID, alarmStartTime, alarmTimeStep, ierr=ierr)
     call mpas_reset_clock_alarm(domain_ptr % clock, coupleAlarmID, ierr=ierr)
 
+    timeStep = mpas_get_clock_timestep(domain_ptr % clock, ierr=ierr)
+    call mpas_get_timeInterval(timeStep, dt=dt)
+
     ! Build forcing arrays.
     block_ptr => domain % blocklist
     do while(associated(block_ptr))
@@ -808,9 +811,6 @@ contains
 !   get initial state from driver
 !
 !-----------------------------------------------------------------------
-
-    timeStep = mpas_get_clock_timestep(domain_ptr % clock, ierr=ierr)
-    call mpas_get_timeInterval(timeStep, dt=dt)
 
     call ocn_import_mct(x2o_o, errorCode)
     if (errorCode /= 0) then

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -207,9 +207,6 @@ contains
     logical, pointer :: config_use_surface_salinity_monthly_restoring
     character (len=StrKIND), pointer :: config_land_ice_flux_mode
 
-    real (kind=RKIND) :: dt
-    type (MPAS_timeInterval_type) :: timeStep
-
     ! Added for coupling interval initialization
     integer, pointer :: index_avgZonalSSHGradient, index_avgMeridionalSSHGradient
     real (kind=RKIND), dimension(:),   pointer :: filteredSSHGradientZonal, filteredSSHGradientMeridional
@@ -667,9 +664,6 @@ contains
     call mpas_add_clock_alarm(domain % clock, coupleAlarmID, alarmStartTime, alarmTimeStep, ierr=ierr)
     call mpas_reset_clock_alarm(domain_ptr % clock, coupleAlarmID, ierr=ierr)
 
-    timeStep = mpas_get_clock_timestep(domain_ptr % clock, ierr=ierr)
-    call mpas_get_timeInterval(timeStep, dt=dt)
-
     ! Build forcing arrays.
     block_ptr => domain % blocklist
     do while(associated(block_ptr))
@@ -680,8 +674,8 @@ contains
 
         call ocn_forcing_build_fraction_absorbed_array(meshPool, statePool, forcingPool, ierr, 1)
         call mpas_timer_start("land_ice_build_arrays", .false.)
-        call ocn_surface_land_ice_fluxes_build_arrays(meshPool, &
-                                                      forcingPool, scratchPool, statePool, dt, ierr)
+        call ocn_surface_land_ice_fluxes_build_arrays(meshPool, forcingPool, scratchPool, &
+                                                      statePool, dt=0.0_RKIND, err=ierr)
         call mpas_timer_stop("land_ice_build_arrays")
 
         call ocn_frazil_forcing_build_arrays(domain, meshPool, forcingPool, statePool, ierr)


### PR DESCRIPTION
Currently the variable "dt" is used in subroutine ocn_init_mct in a call to ocn_surface_land_ice_fluxes_build_arrays before it has been set. This can cause errors in debug mode with some compilers. This replaces the variable with 0.0 in the argument list and removes dt from the routine, since it is not otherwise needed.

Fixes #5772 
[BFB]