### PR TITLE
Fix default timestep for high-res MMF

### DIFF
--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -410,6 +410,7 @@
       <!-- a shorter timestep is needed for stability in MMF  -->
       <!-- Use for all "low res" grids (i.e. ne4, ne30, ne45) -->
       <value compset="_EAM%.*MMF">72</value>
+      <value compset="_EAM%.*MMF" grid="a%ne120np4">96</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
Fix default timestep for high-res MMF. This allows running MMF compsets with ne120pg2 atmosphere resolution. Needed for running KPP configuration of MMF.

[BFB]