### PR TITLE
Set CO2 PPMV value for generic 2010 and 1950 compsets

### DIFF
--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -724,7 +724,9 @@
       <value compset="^2000.+AV1C-H01C"				>368.865</value>
       <value compset="^1850.+CMIP6"                             >284.317</value>
       <value compset="^1850.+CMIP6.+4xCO2"			>1137.268</value>
+      <value compset="^1950"                                    >312.821</value>
       <value compset="^1950.+CMIP6"                             >312.821</value>
+      <value compset="^2010"                                    >388.717</value>
       <value compset="^2010.+CMIP6"                             >388.717</value>
       <value compset="^SSP585.+CMIP6"				>0.000001</value>
       <value compset="^SSP370.+CMIP6"                           >0.000001</value>


### PR DESCRIPTION
The values currently set 2010 and 1950 depend on physics/chemistry modifiers in the compset longnames. A variant of 2010 or 1950 compsets, if not setting a value correspondingly, would pick up the default 379.0 PPMV, which is for an older present-day condition (around 2005).

[non-BFB] for F2010_chemUCI.* compsets.

----- Until this PR taking effect -----
v3alpha.F2010 cases can do `./xmlchange CCSM_CO2_PPMV="388.717"`  to achieve the equivalent.