### PR TITLE
Fix lightning NOx emission bug

### DIFF
--- a/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam4_resus_mom_vbs.in
+++ b/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam4_resus_mom_vbs.in
@@ -282,6 +282,7 @@ CHEMISTRY
  End Reactions
 
  Ext Forcing
+      NO
       NO2 <- dataset
       SO2 <- dataset
       so4_a1 <- dataset

--- a/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam5_vbs.in
+++ b/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam5_vbs.in
@@ -285,6 +285,7 @@ CHEMISTRY
  End Reactions
 
  Ext Forcing
+      NO
       NO2 <- dataset
       SO2 <- dataset
       so4_a1 <- dataset


### PR DESCRIPTION
During v3atm aerosol-chemistry integration, "NO" was removed from the external foring list of chemistry mechanism files ending in _vbs.in. This means that the lightning NOx emissions won't be used by the simulations using these mechanisms. This PR corrects this bug.

[non-BFB]

-------------------------------------
The test simulation was discussed at the [v3atm integration meeting](https://acme-climate.atlassian.net/wiki/spaces/ATMOS/pages/3854434386/2023-07-12+Meeting+notes+-+v3+Integration) and documented at this confluence [page](https://acme-climate.atlassian.net/wiki/spaces/ATMOS/pages/3849715713/20230707.NO-lght-fix.5x.v3alpha02.F2010.chrysalis).
