### PR TITLE
Change elm restart file for wcprodssp allactive test

### DIFF
--- a/cime_config/testmods_dirs/allactive/wcprodssp/user_nl_elm
+++ b/cime_config/testmods_dirs/allactive/wcprodssp/user_nl_elm
@@ -1,7 +1,7 @@
 ! fsurdat used is not the same file for the reference historical run (as recorded in elm.r's global attribute)
 
  CHECK_FINIDAT_FSURDAT_CONSISTENCY       = .false.
-
+ finidat = "$DIN_LOC_ROOT/e3sm_init/V2.SSP370_SSP585.ne30pg2_EC30to60E2r2/v2.LR.historical_0101/2015-01-01-00000/v2.LR.historical_0101.elm.r.noNaN.2015-01-01-00000.nc"
  hist_dov2xy = .true.,.true.
  hist_fincl2 = 'H2OSNO', 'FSNO', 'QRUNOFF', 'QSNOMELT', 'FSNO_EFF', 'SNORDSL', 'SNOW', 'FSDS', 'FSR', 'FLDS', 'FIRE', 'FIRA'
  hist_mfilt = 1,365


### PR DESCRIPTION
Replaced the NaN values for TWS_MONTH_BEGIN with a fill value of `1.e+36` in the elm restart file.

Fixes #5665 