### PR TITLE
EAM: ensure seasaltaod gets fillvalue at nighttime

### DIFF
--- a/components/eam/src/physics/cam/modal_aer_opt.F90
+++ b/components/eam/src/physics/cam/modal_aer_opt.F90
@@ -1167,6 +1167,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
          pomaod(idxnite(i))     = fillvalue
          soaaod(idxnite(i))     = fillvalue
          bcaod(idxnite(i))      = fillvalue
+         seasaltaod(idxnite(i)) = fillvalue
 #if ( defined MODAL_AERO_4MODE_MOM )
          momaod(idxnite(i)) = fillvalue
 #elif ( defined MODAL_AERO_9MODE )


### PR DESCRIPTION
Make sure AODSS has a fillvalue at night like other OD variables.

Technically, it is a bug fix PR, but it is BFB as the bug is in a diagnostic output, and not in anything used internally in the model.

[BFB]

Fixes #5822 

Xref #4800 and #5816 (discussions that prompted this discovery)