### PR TITLE
add outputFieldName to ocean pointwise stats

### DIFF
--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_pointwise_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_pointwise_stats.F
@@ -173,6 +173,7 @@ contains
                            call mpas_duplicate_field(ptr1DReal, ptr1DRealNew)
 
                            ptr1DRealNew % fieldName = trim(ptr1DReal % fieldName) // trim(AMFieldNameSuffix)
+                           ptr1DRealNew % outputFieldName = ptr1DRealNew % fieldName
                            PWAM_DEBUG_WRITE(' -- New Name: ' // trim(ptr1DRealNew % fieldName))
 
                            ! Change constituent names, if it's a var array
@@ -237,6 +238,7 @@ contains
                            call mpas_duplicate_field(ptr2DReal, ptr2DRealNew)
 
                            ptr2DRealNew % fieldName = trim(ptr2DReal % fieldName) // trim(AMFieldNameSuffix)
+                           ptr2DRealNew % outputFieldName = ptr2DRealNew % fieldName
                            PWAM_DEBUG_WRITE(' -- New Name: ' // trim(ptr2DRealNew % fieldName))
 
                            if ( ptr2DRealNew % isVarArray ) then
@@ -301,6 +303,7 @@ contains
                            call mpas_duplicate_field(ptr3DReal, ptr3DRealNew)
 
                            ptr3DRealNew % fieldName = trim(ptr3DReal % fieldName) // trim(AMFieldNameSuffix)
+                           ptr3DRealNew % outputFieldName = ptr3DRealNew % fieldName
                            PWAM_DEBUG_WRITE(' -- New Name: ' // trim(ptr3DRealNew % fieldName))
 
                            if ( ptr3DRealNew % isVarArray ) then
@@ -365,6 +368,7 @@ contains
                            call mpas_duplicate_field(ptr4DReal, ptr4DRealNew)
 
                            ptr4DRealNew % fieldName = trim(ptr4DReal % fieldName) // trim(AMFieldNameSuffix)
+                           ptr4DRealNew % outputFieldName = ptr4DRealNew % fieldName
                            PWAM_DEBUG_WRITE(' -- New Name: ' // trim(ptr4DRealNew % fieldName))
 
                            if ( ptr4DRealNew % isVarArray ) then
@@ -429,6 +433,7 @@ contains
                            call mpas_duplicate_field(ptr5DReal, ptr5DRealNew)
 
                            ptr5DRealNew % fieldName = trim(ptr5DReal % fieldName) // trim(AMFieldNameSuffix)
+                           ptr5DRealNew % outputFieldName = ptr5DRealNew % fieldName
                            PWAM_DEBUG_WRITE(' -- New Name: ' // trim(ptr5DRealNew % fieldName))
 
                            if ( ptr5DRealNew % isVarArray ) then
@@ -498,6 +503,7 @@ contains
                            call mpas_duplicate_field(ptr1DInt, ptr1DIntNew)
 
                            ptr1DIntNew % fieldName = trim(ptr1DInt % fieldName) // trim(AMFieldNameSuffix)
+                           ptr1DIntNew % outputFieldName = ptr1DIntNew % fieldName
                            PWAM_DEBUG_WRITE(' -- New Name: ' // trim(ptr1DIntNew % fieldName))
 
                            if ( ptr1DIntNew % isVarArray ) then
@@ -561,6 +567,7 @@ contains
                            call mpas_duplicate_field(ptr2DInt, ptr2DIntNew)
 
                            ptr2DIntNew % fieldName = trim(ptr2DInt % fieldName) // trim(AMFieldNameSuffix)
+                           ptr2DIntNew % outputFieldName = ptr2DIntNew % fieldName
                            PWAM_DEBUG_WRITE(' -- New Name: ' // trim(ptr2DIntNew % fieldName))
 
                            if ( ptr2DIntNew % isVarArray ) then
@@ -624,6 +631,7 @@ contains
                            call mpas_duplicate_field(ptr3DInt, ptr3DIntNew)
 
                            ptr3DIntNew % fieldName = trim(ptr3DInt % fieldName) // trim(AMFieldNameSuffix)
+                           ptr3DIntNew % outputFieldName = ptr3DIntNew % fieldName
                            PWAM_DEBUG_WRITE(' -- New Name: ' // trim(ptr3DIntNew % fieldName))
 
                            if ( ptr3DIntNew % isVarArray ) then


### PR DESCRIPTION
The ocean pointwise stats analysis member has been broken because the field name is not communicated correctly to PIO for writing. Current use of pointwise stats results in the error
```
PIO: ERROR: Defining variable T+v$`�@�	�v�@%�2fx�@,ƑV�
@�*�^B�@���@�C����@���@!#��@�'�;��@�q|i��@� (ndims = 2) in file pointwiseStats.nc (ncid=24, iotype=PIO_IOTYPE_NETCDF) failed. 
   NetCDF: Name contains illegal characters. NetCDF: Name contains illegal characters (error num=-59), (/global/cscratch1/sd/xylar/temp_spack/spack-stage/spack-stage-scorpio-1.3.2-mm6r5rlzs7w5ueyjfd7jdgkeeelqyome/spack-src/src/clib/pio_nc.c:3091)
```

The problem was that for output streams the variable is named `outputFieldName`, rather than just `fieldName`, and the pointwise stats module never initiated `outputFieldName`. There is an additional field name here because the variable name for `ssh`, for example, becomes `sshPointStats`.

This problem was found a year ago in the sea ice and corrected in https://github.com/E3SM-Project/E3SM/pull/5160, but was not fixed in the ocean.

fixes #5510 
[BFB]