### PR TITLE
On pm-cpu, update one PE layout that impacts the ne120 test in the hires suite

### DIFF
--- a/components/eam/cime_config/config_pes.xml
+++ b/components/eam/cime_config/config_pes.xml
@@ -1692,7 +1692,7 @@
   <grid name="a%ne120np4">
     <mach name="pm-cpu|alvarez">
       <pes compset=".*EAM.+ELM.+MPASSI.+DOCN.+SGLC.+SWAV.*" pesize="any">
-        <comment>pm-cpu ne120pg2 F-compset with MPASSI on 43 nodes 128x1c8 0.6 sypd</comment>
+        <comment>pm-cpu ne120pg2 F-compset with MPASSI on 43 nodes 128x1c8 1.3 sypd</comment>
         <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
         <ntasks>
           <ntasks_atm>5504</ntasks_atm>

--- a/components/eam/cime_config/config_pes.xml
+++ b/components/eam/cime_config/config_pes.xml
@@ -1698,8 +1698,8 @@
           <ntasks_atm>5504</ntasks_atm>
           <ntasks_lnd>5504</ntasks_lnd>
           <ntasks_rof>5504</ntasks_rof>
-          <ntasks_ice>5200</ntasks_ice>
-          <ntasks_ocn>5200</ntasks_ocn>
+          <ntasks_ice>5400</ntasks_ice>
+          <ntasks_ocn>5504</ntasks_ocn>
           <ntasks_glc>64</ntasks_glc>
           <ntasks_wav>64</ntasks_wav>
           <ntasks_cpl>688</ntasks_cpl>


### PR DESCRIPTION
We've had a failing test in hires suite on pm-cpu since around June21st as there
was a problem with MPAS partition files.
`SMS.ne120pg2_r0125_oRRS18to6v3.F2010`
This PR Increases the partition count for both ocean and ice to use part files that exist. 
[bfb]