### PR TITLE
On pm-cpu and pm-gpu, update module version for craype and cray-mpich

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -233,8 +233,8 @@
 
       <modules>
         <command name="load">craype-accel-host</command>
-        <command name="load">craype/2.7.19</command>
-        <command name="load">cray-mpich/8.1.24</command>
+        <command name="load">craype/2.7.20</command>
+        <command name="load">cray-mpich/8.1.25</command>
         <command name="load">cray-hdf5-parallel/1.12.2.3</command>
         <command name="load">cray-netcdf-hdf5parallel/4.9.0.3</command>
         <command name="load">cray-parallel-netcdf/1.12.3.3</command>
@@ -367,8 +367,8 @@
 
       <modules>
         <command name="load">cray-libsci/23.02.1.1</command>
-        <command name="load">craype/2.7.19</command>
-        <command name="load">cray-mpich/8.1.24</command>
+        <command name="load">craype/2.7.20</command>
+        <command name="load">cray-mpich/8.1.25</command>
         <command name="load">cray-hdf5-parallel/1.12.2.3</command>
         <command name="load">cray-netcdf-hdf5parallel/4.9.0.3</command>
         <command name="load">cray-parallel-netcdf/1.12.3.3</command>


### PR DESCRIPTION
On pm-cpu and pm-gpu, update module version for craype and cray-mpich.
craype version 2.7.19 -> 2.7.20
cray-mpich version 8.1.24 -> 8.1.25

Proactive syncing with machine default versions.
Does not fix or cause any issue.
[bfb]