### PR TITLE
Calculation of sedimentation fluxes in P3 is changed.

### DIFF
--- a/components/eam/src/physics/p3/eam/micro_p3.F90
+++ b/components/eam/src/physics/p3/eam/micro_p3.F90
@@ -1604,7 +1604,9 @@ end function bfb_expm1
        call ice_sedimentation(kts,kte,ktop,kbot,kdir,    &
          rho(i,:),inv_rho(i,:),rhofaci(i,:),cld_frac_i(i,:),inv_dz(i,:),dt,inv_dt, &
          qi(i,:),qi_incld(i,:),ni(i,:),qm(i,:),qm_incld(i,:),bm(i,:),bm_incld(i,:),ni_incld(i,:), &
-         precip_ice_surf(i),sflx(i,:),p3_tend_out(i,:,40),p3_tend_out(i,:,41))
+!<shanyp 07192023
+         precip_ice_surf(i),precip_ice_flux(i,:),sflx(i,:),p3_tend_out(i,:,40),p3_tend_out(i,:,41))
+!shanyp 07192023>
 
 
        !*** Add tendencies for the next processes ***  
@@ -3898,6 +3900,9 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
    type(realptr), dimension(num_arrays) :: vs, fluxes, qnr
 
    real(rtype) :: dt_left
+!<shanyp 06252023
+   real(rtype) :: dt_sub
+!shanyp 06252023>
    real(rtype) :: prt_accum
    real(rtype) :: Co_max
    real(rtype) :: nu
@@ -3946,7 +3951,9 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
             Co_max = 0._rtype
             V_qc = 0._rtype
             V_nc = 0._rtype
-
+!<shanyp 06252023
+            dt_sub = 0._rtype
+!shanyp 06252023>
             kloop_sedi_c2: do k = k_qxtop,k_qxbot,-kdir
 
                qc_notsmall_c2: if (qc_incld(k)>qsmall) then
@@ -3969,10 +3976,14 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
             enddo kloop_sedi_c2
 
             call generalized_sedimentation(kts, kte, kdir, k_qxtop, k_qxbot, kbot, Co_max, dt_left, &
-                 prt_accum, inv_dz, inv_rho, rho, num_arrays, vs, fluxes, qnr)
-
+!<shanyp 06252023
+                 prt_accum, inv_dz, inv_rho, rho, num_arrays, vs, fluxes, qnr, dt_sub)
+!shanyp 06252023>
             do k = k_qxbot,k_qxtop,kdir
-                  cflx(k+1) = cflx(k+1) + flux_qx(k)
+!<shanyp 06252023
+!                  cflx(k+1) = cflx(k+1) + flux_qx(k)
+                  cflx(k+1) = cflx(k+1) + flux_qx(k)*dt_sub
+!shanyp 06252023>
             enddo
                  
             !Update _incld values with end-of-step cell-ave values
@@ -4006,10 +4017,14 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
             enddo kloop_sedi_c1
 
             call generalized_sedimentation(kts, kte, kdir, k_qxtop, k_qxbot, kbot, Co_max, dt_left, &
-                 prt_accum, inv_dz, inv_rho, rho, 1, vs, fluxes, qnr)
-
+!<shanyp 06252023
+                 prt_accum, inv_dz, inv_rho, rho, 1, vs, fluxes, qnr, dt_sub)
+!shanyp 06252023>
             do k = k_qxbot,k_qxtop,kdir
-                  cflx(k+1) = cflx(k+1) + flux_qx(k)
+!<shanyp 06252023
+                  cflx(k+1) = cflx(k+1) + flux_qx(k)*dt_sub
+!                  cflx(k+1) = cflx(k+1) + flux_qx(k)
+!shanyp 06252023>
             enddo
 
             !Update _incld values with end-of-step cell-ave values
@@ -4021,7 +4036,9 @@ subroutine cloud_sedimentation(kts,kte,ktop,kbot,kdir,   &
          enddo substep_sedi_c1
 
       endif two_moment
-
+!<shanyp 06252023
+      cflx(:) = cflx(:)*inv_dt
+!shanyp 06252023>
       precip_liq_surf = precip_liq_surf + prt_accum*inv_rho_h2o*inv_dt
 
    endif qc_present
@@ -4067,6 +4084,9 @@ subroutine rain_sedimentation(kts,kte,ktop,kbot,kdir,                           
    type(realptr), dimension(num_arrays) :: vs, fluxes, qnr
 
    real(rtype) :: dt_left
+!<shanyp 06252023
+   real(rtype) :: dt_sub
+!shanyp 06252023>
    real(rtype) :: prt_accum
    real(rtype) :: Co_max
    real(rtype), dimension(kts:kte), target :: V_qr
@@ -4111,7 +4131,9 @@ subroutine rain_sedimentation(kts,kte,ktop,kbot,kdir,                           
          Co_max = 0._rtype
          V_qr = 0._rtype
          V_nr = 0._rtype
-
+!<shanyp 06252023
+         dt_sub = 0._rtype
+!shanyp 06252023>
          kloop_sedi_r1: do k = k_qxtop,k_qxbot,-kdir
 
             qr_notsmall_r1: if (qr_incld(k)>qsmall) then
@@ -4132,12 +4154,18 @@ subroutine rain_sedimentation(kts,kte,ktop,kbot,kdir,                           
          enddo kloop_sedi_r1
 
          call generalized_sedimentation(kts, kte, kdir, k_qxtop, k_qxbot, kbot, Co_max, dt_left, &
-              prt_accum, inv_dz, inv_rho, rho, num_arrays, vs, fluxes, qnr)
+!<shanyp 06252023
+              prt_accum, inv_dz, inv_rho, rho, num_arrays, vs, fluxes, qnr, dt_sub)
+!shanyp 06252023>
 
          !-- AaronDonahue, precip_liq_flux output
          do k = k_qxbot,k_qxtop,kdir
-            precip_liq_flux(k+1) = precip_liq_flux(k+1) + flux_qx(k) ! AaronDonahue
-            rflx(k+1) = rflx(k+1) + flux_qx(k)
+!<shanyp 06252023
+!            precip_liq_flux(k+1) = precip_liq_flux(k+1) + flux_qx(k) ! AaronDonahue
+!            rflx(k+1) = rflx(k+1) + flux_qx(k)
+            precip_liq_flux(k+1) = precip_liq_flux(k+1) + flux_qx(k)*dt_sub ! AaronDonahue
+            rflx(k+1) = rflx(k+1) + flux_qx(k)*dt_sub
+!shanyp 06252023>
          enddo
 
          !Update _incld values with end-of-step cell-ave values
@@ -4147,7 +4175,10 @@ subroutine rain_sedimentation(kts,kte,ktop,kbot,kdir,                           
          nr_incld(:) = nr(:)/cld_frac_r(:)
 
       enddo substep_sedi_r
-
+!<shanyp 06252023
+            precip_liq_flux(:) = precip_liq_flux(:)*inv_dt
+            rflx(:) = rflx(:)*inv_dt
+!shanyp 06252023>
       precip_liq_surf = precip_liq_surf + prt_accum*inv_rho_h2o*inv_dt
 
    endif qr_present
@@ -4199,7 +4230,10 @@ end subroutine compute_rain_fall_velocity
 
 subroutine ice_sedimentation(kts,kte,ktop,kbot,kdir,    &
    rho,inv_rho,rhofaci,cld_frac_i,inv_dz,dt,inv_dt,  &
-   qi,qi_incld,ni,qm,qm_incld,bm,bm_incld,ni_incld,precip_ice_surf,sflx,qi_tend,ni_tend)
+!<shanyp 04242023
+!   qi,qi_incld,ni,qm,qm_incld,bm,bm_incld,ni_incld,precip_ice_surf,sflx,qi_tend,ni_tend)
+   qi,qi_incld,ni,qm,qm_incld,bm,bm_incld,ni_incld,precip_ice_surf,precip_ice_flux,sflx,qi_tend,ni_tend)
+!shanyp 04242023>
 
    implicit none
    integer, intent(in) :: kts, kte
@@ -4223,10 +4257,16 @@ subroutine ice_sedimentation(kts,kte,ktop,kbot,kdir,    &
    real(rtype), intent(inout), dimension(kts:kte) :: bm_incld
 
    real(rtype), intent(inout) :: precip_ice_surf
+!<shanyp 04242023
+   real(rtype), intent(inout), dimension(kts:kte+1) :: precip_ice_flux
+!shanyp 04242023>
    real(rtype), intent(inout), dimension(kts:kte+1) :: sflx
    real(rtype), intent(inout), dimension(kts:kte) :: qi_tend
    real(rtype), intent(inout), dimension(kts:kte) :: ni_tend
 
+!<shanyp 06252023
+   real(rtype) :: dt_sub
+!shanyp 06252023>
    logical(btype) :: log_qxpresent
    integer :: k
    integer :: k_qxtop, k_qxbot
@@ -4294,7 +4334,9 @@ subroutine ice_sedimentation(kts,kte,ktop,kbot,kdir,    &
          Co_max = 0._rtype
          V_qit = 0._rtype
          V_nit = 0._rtype
-
+!<shanyp 06252023
+         dt_sub = 0._rtype
+!shanyp 06252023>
          kloop_sedi_i1: do k = k_qxtop,k_qxbot,-kdir
 
             !-- compute Vq, Vn (get values from lookup table)
@@ -4333,11 +4375,15 @@ subroutine ice_sedimentation(kts,kte,ktop,kbot,kdir,    &
          enddo kloop_sedi_i1
 
          call generalized_sedimentation(kts, kte, kdir, k_qxtop, k_qxbot, kbot, Co_max, &
-              dt_left, prt_accum, inv_dz, inv_rho, rho, num_arrays, vs, fluxes, qnr)
-
+!<shanyp 06252023
+              dt_left, prt_accum, inv_dz, inv_rho, rho, num_arrays, vs, fluxes, qnr, dt_sub)
+!shanyp 06252023>
 
          do k = k_qxbot,k_qxtop,kdir
-               sflx(k+1) = sflx(k+1) + flux_qit(k)
+!<shanyp 06252023
+            precip_ice_flux(k+1) = precip_ice_flux(k+1) + flux_qit(k)*dt_sub ! shanyp
+            sflx(k+1) = sflx(k+1) + flux_qit(k)*dt_sub
+!shanyp 06252023>
          enddo     
 
          !update _incld variables
@@ -4349,7 +4395,10 @@ subroutine ice_sedimentation(kts,kte,ktop,kbot,kdir,    &
          bm_incld(:) = bm(:)/cld_frac_i(:)
 
       enddo substep_sedi_i
-
+!<shanyp 06252023
+      precip_ice_flux(:)=precip_ice_flux(:)*inv_dt
+      sflx(:)=sflx(:)*inv_dt
+!shanyp 06252023>
       precip_ice_surf = precip_ice_surf + prt_accum*inv_rho_h2o*inv_dt
 
    endif qi_present
@@ -4360,8 +4409,9 @@ subroutine ice_sedimentation(kts,kte,ktop,kbot,kdir,    &
 end subroutine ice_sedimentation
 
 subroutine generalized_sedimentation(kts, kte, kdir, k_qxtop, k_qxbot, kbot, Co_max, dt_left, &
-     prt_accum, inv_dz, inv_rho, rho, num_arrays, vs, fluxes, qnx)
-
+!<shanyp 06252023
+     prt_accum, inv_dz, inv_rho, rho, num_arrays, vs, fluxes, qnx, dt_sub)
+!shanyp 06252023>
    implicit none
 
    integer, intent(in) :: kts, kte, kdir, k_qxtop, kbot, num_arrays
@@ -4375,7 +4425,9 @@ subroutine generalized_sedimentation(kts, kte, kdir, k_qxtop, k_qxbot, kbot, Co_
    type(realptr), intent(in), dimension(num_arrays), target :: vs, fluxes, qnx
 
    integer :: tmpint1, k_temp, i
-   real(rtype) :: dt_sub
+!<shanyp 06252023
+   real(rtype),intent(inout) :: dt_sub
+!shanyp 06252023>
 
    !-- compute dt_sub
    tmpint1 = int(Co_max+1._rtype)    !number of substeps remaining if dt_sub were constant


### PR DESCRIPTION
**Original calculation in the P3 code**: the precipitation (rain and snow) flux (sflx for snow ) is summed over the flux at each sub-timestep during one microphysics timestep: sflx=flux_qit_1+ flux_qit_2+ flux_qit_3+… flux_qit_n, where the flux_qit_i (i=1,2,3,…n) represents the snow flux at each sub-timestep for sedimentation. This should not be correct. The correct flux should be the mean value for each microphysics timestep. 

**Changed calculation in the current version**: In E3SM-P3, since the  sub-timestep is not a fixed value, the mean flux  over the microphysics timestep should be calculated with: sflx=(flux_qit_1*dt1+ flux_qit_2*dt2+ flux_qit_3*dt3+… flux_qit_n*dtn)/( dt1+ dt2+ dt3+… dtn), where dti represents sub-timestep length. This is similar to the equation used to calculate the surface precipitation rate.

This PR does not effect the model simulation results, but only change the diagnostic precipitation flux output. 