### PR TITLE
New upwinded advection feature for split-explicit time integrator

### DIFF
--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -177,7 +177,6 @@ module ocn_time_integration_split
          normalThicknessFluxSum, &! sum of thickness flux in column
          thicknessSum,     &! sum of thicknesses in column
          flux,             &! temp for computing flux for barotropic
-         sshEdge,          &! sea surface height at edge
          CoriolisTerm,     &! temp for computing coriolis term (fuperp)
          normalVelocityCorrection, &! velocity correction
          temp,             &! temp for holding vars at new time
@@ -191,7 +190,9 @@ module ocn_time_integration_split
          uTemp
 
       real (kind=RKIND), dimension(:), allocatable :: &
-         btrvel_temp, &
+         btrvel_temp,      &
+         sshTemp,          &
+         sshEdge,          &! sea surface height at edge
          bottomDepthEdge
 
       ! State Array Pointers
@@ -942,11 +943,14 @@ module ocn_time_integration_split
             ! subcycle loop
             allocate(btrvel_temp(nEdgesAll+1))
             btrvel_temp(:) = 0.0_RKIND
+            allocate(sshEdge(nEdgesAll+1))
+            sshEdge(:) = 0.0_RKIND
 
             cellHaloComputeCounter = 0
             edgeHaloComputeCounter = 0
 
             call mpas_timer_start('btr se subcycle loop')
+            call mpas_log_write('start btr se subcycles')
             do j = 1, nBtrSubcycles * config_btr_subcycle_loop_factor
 
                ! Update halos if needed
@@ -1064,6 +1068,7 @@ module ocn_time_integration_split
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                ! Barotropic subcycle: SSH PREDICTOR STEP
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+               call mpas_log_write('start ssh predictor')
 
                call mpas_pool_get_array(statePool, 'sshSubcycle', &
                                                     sshSubcycleCur, &
@@ -1102,30 +1107,32 @@ module ocn_time_integration_split
                !    flux = normalBarotropicVelocityOld*H
 
                !$omp parallel
+               !$omp do schedule(runtime)
+               do iEdge = 1, nEdges
+                  btrvel_temp(iEdge) = (1.0-config_btr_gam1_velWt1) * &
+                               normalBarotropicVelocitySubcycleCur(iEdge) &
+                             +       config_btr_gam1_velWt1 *             &
+                               normalBarotropicVelocitySubcycleNew(iEdge)
+               end do
+               !$omp end do
+               !$omp end parallel
+
+               call ocn_diagnostic_solve_sshEdge(btrvel_temp, sshSubcycleCur, sshEdge)
+
+               !$omp parallel
                !$omp do schedule(runtime) &
-               !$omp private(i, iEdge, cell1, cell2, sshEdge, &
-               !$omp         thicknessSum, flux)
+               !$omp private(i, iEdge, thicknessSum, flux)
                do iCell = 1, nCells
                   sshTend(iCell) = 0.0_RKIND
                   do i = 1, nEdgesOnCell(iCell)
                      iEdge = edgesOnCell(i, iCell)
                      if (maxLevelEdgeTop(iEdge).eq.0) cycle
 
-                     cell1 = cellsOnEdge(1, iEdge)
-                     cell2 = cellsOnEdge(2, iEdge)
-
-                     sshEdge = 0.5_RKIND*(sshSubcycleCur(cell1) + &
-                                          sshSubcycleCur(cell2))
-
                      ! Compute barotropic thickness at the edge. Note this
                      ! matches the sum of baroclinic thicknesses at this edge.
-                     thicknessSum = sshEdge + bottomDepthEdge(iEdge)
+                     thicknessSum = sshEdge(iEdge) + bottomDepthEdge(iEdge)
 
-                     flux = ((1.0-config_btr_gam1_velWt1)* &
-                            normalBarotropicVelocitySubcycleCur(iEdge) &
-                          +       config_btr_gam1_velWt1 * &
-                            normalBarotropicVelocitySubcycleNew(iEdge))&
-                           *thicknessSum
+                     flux = btrvel_temp(iEdge)*thicknessSum
 
                      sshTend(iCell) = sshTend(iCell) + &
                                       edgeSignOncell(i, iCell)*flux* &
@@ -1157,16 +1164,13 @@ module ocn_time_integration_split
 
                   !$omp parallel
                   !$omp do schedule(runtime) &
-                  !$omp private(cell1, cell2, sshEdge,thicknessSum,flux)
+                  !$omp private(thicknessSum, flux)
                   do iEdge = 1, nEdges
                      if (maxLevelEdgeTop(iEdge).eq.0) cycle
                      cell1 = cellsOnEdge(1,iEdge)
                      cell2 = cellsOnEdge(2,iEdge)
 
-                     sshEdge = 0.5_RKIND*(sshSubcycleCur(cell1) + &
-                                          sshSubcycleCur(cell2))
-
-                     thicknessSum = sshEdge + bottomDepthEdge(iEdge)
+                     thicknessSum = sshEdge(iEdge) + bottomDepthEdge(iEdge)
 
                      flux = ((1.0-config_btr_gam1_velWt1)* &
                             normalBarotropicVelocitySubcycleCur(iEdge) &
@@ -1188,6 +1192,7 @@ module ocn_time_integration_split
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                ! Barotropic subcycle: VELOCITY CORRECTOR STEP
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+               call mpas_log_write('start velocity corrector')
 
                do BtrCorIter = 1, config_n_btr_cor_iter
                   uPerpTime = newBtrSubcycleTime
@@ -1331,7 +1336,10 @@ module ocn_time_integration_split
                ! Barotropic subcycle: SSH CORRECTOR STEP
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+               call mpas_log_write('start ssh corrector')
                if (config_btr_solve_SSH2) then
+
+                  allocate(sshTemp(nCellsAll))
 
                   call mpas_pool_get_array(statePool, 'sshSubcycle', &
                                                        sshSubcycleCur,&
@@ -1371,38 +1379,45 @@ module ocn_time_integration_split
                   !    flux = normalBarotropicVelocityOld*H
 
                   !$omp parallel
+                  !$omp do schedule(runtime)
+                  do iCell = 1, nCells
+                     ! SSH is linear combination of SSHold and SSHnew
+                     sshTemp(iCell) = (1-config_btr_gam2_SSHWt1)* &
+                                            sshSubcycleCur(iCell) &
+                                    +    config_btr_gam2_SSHWt1 * &
+                                            sshSubcycleNew(iCell)
+                  end do ! cell loop for ssh
+                  !$omp end do
+                  !$omp end parallel
+
+                  !$omp parallel
+                  !$omp do schedule(runtime)
+                  do iEdge = 1, nEdges
+                     btrvel_temp(iEdge) = (1.0-config_btr_gam3_velWt2) * &
+                                  normalBarotropicVelocitySubcycleCur(iEdge) &
+                                +       config_btr_gam3_velWt2 *             &
+                                  normalBarotropicVelocitySubcycleNew(iEdge)
+                  end do
+                  !$omp end do
+                  !$omp end parallel
+
+                  call ocn_diagnostic_solve_sshEdge( &
+                                  btrvel_temp, sshTemp, sshEdge)
+
+                  !$omp parallel
                   !$omp do schedule(runtime) &
-                  !$omp private(i, iEdge, cell1, cell2, thicknessSum, &
-                  !$omp         sshCell1, sshCell2, sshEdge, flux)
+                  !$omp private(i, iEdge, thicknessSum, flux)
                   do iCell = 1, nCells
                      sshTend(iCell) = 0.0_RKIND
                      do i = 1, nEdgesOnCell(iCell)
                         iEdge = edgesOnCell(i, iCell)
                         if (maxLevelEdgeTop(iEdge).eq.0) cycle
 
-                        cell1 = cellsOnEdge(1,iEdge)
-                        cell2 = cellsOnEdge(2,iEdge)
-
                         ! SSH is a linear combination of SSHold
                         ! and SSHnew.
-                        sshCell1 = (1-config_btr_gam2_SSHWt1)* &
-                                         sshSubcycleCur(cell1) &
-                                 +    config_btr_gam2_SSHWt1 * &
-                                         sshSubcycleNew(cell1)
-                        sshCell2 = (1-config_btr_gam2_SSHWt1)* &
-                                         sshSubcycleCur(cell2) &
-                                 +    config_btr_gam2_SSHWt1 * &
-                                         sshSubcycleNew(cell2)
+                        thicknessSum = sshEdge(iEdge) + bottomDepthEdge(iEdge)
 
-                        sshEdge = 0.5_RKIND*(sshCell1 + sshCell2)
-
-                        thicknessSum = sshEdge + bottomDepthEdge(iEdge)
-
-                        flux = ((1.0-config_btr_gam3_velWt2)* &
-                           normalBarotropicVelocitySubcycleCur(iEdge) &
-                             +       config_btr_gam3_velWt2 * &
-                           normalBarotropicVelocitySubcycleNew(iEdge))&
-                             *thicknessSum
+                        flux = btrvel_temp(iEdge) * thicknessSum
 
                         sshTend(iCell) = sshTend(iCell) + &
                                          edgeSignOnCell(i, iCell)* &
@@ -1416,27 +1431,30 @@ module ocn_time_integration_split
                                           sshTend(iCell)/areaCell(iCell)
                   end do ! cell loop for ssh
                   !$omp end do
+                  !$omp end parallel
+
+                  !$omp parallel
+                  !$omp do schedule(runtime)
+                  do iCell = 1, nCells
+                     ! SSH is linear combination of SSHold and SSHnew
+                     sshTemp(iCell) = (1-config_btr_gam2_SSHWt1)* &
+                                            sshSubcycleCur(iCell) &
+                                    +    config_btr_gam2_SSHWt1 * &
+                                            sshSubcycleNew(iCell)
+                  end do ! cell loop for ssh
+                  !$omp end do
+                  !$omp end parallel
+
+                  call ocn_diagnostic_solve_sshEdge( &
+                                  btrvel_temp, sshTemp, sshEdge)
 
                   ! compute barotropic thickness flux on edges
+                  !$omp parallel
                   !$omp do schedule(runtime) &
-                  !$omp private(cell1, cell2, thicknessSum, &
-                  !$omp         sshCell1, sshCell2, sshEdge, flux)
+                  !$omp private(thicknessSum, flux)
                   do iEdge = 1, nEdges
-                     cell1 = cellsOnEdge(1,iEdge)
-                     cell2 = cellsOnEdge(2,iEdge)
 
-                     ! SSH is linear combination of SSHold and SSHnew
-                     sshCell1 = (1-config_btr_gam2_SSHWt1)* &
-                                      sshSubcycleCur(cell1) &
-                              +    config_btr_gam2_SSHWt1 * &
-                                      sshSubcycleNew(cell1)
-                     sshCell2 = (1-config_btr_gam2_SSHWt1)* &
-                                      sshSubcycleCur(cell2) &
-                              +    config_btr_gam2_SSHWt1 * &
-                                      sshSubcycleNew(cell2)
-                     sshEdge = 0.5_RKIND * (sshCell1 + sshCell2)
-
-                     thicknessSum = sshEdge + bottomDepthEdge(iEdge)
+                     thicknessSum = sshEdge(iEdge) + bottomDepthEdge(iEdge)
 
                      flux = ((1.0-config_btr_gam3_velWt2) * &
                          normalBarotropicVelocitySubcycleCur(iEdge) &
@@ -1452,6 +1470,9 @@ module ocn_time_integration_split
                   !$omp end parallel
 
                   edgeHaloComputeCounter = config_num_halos + 1
+
+                  deallocate(sshTemp)
+
                endif ! config_btr_solve_SSH2
 
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -1487,8 +1508,10 @@ module ocn_time_integration_split
 
             end do ! j=1,nBtrSubcycles
             call mpas_timer_stop('btr se subcycle loop')
+            call mpas_log_write('end btr se subcycles')
 
             deallocate(btrvel_temp)
+            deallocate(sshEdge)
 
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             ! END Barotropic subcycle loop
@@ -1638,6 +1661,7 @@ module ocn_time_integration_split
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
          ! Stage 3: Tracer, density, pressure, vert velocity prediction
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+         call mpas_log_write('start stage 3')
 
          ! only compute tendencies for active tracers on last large iteration
          if (splitExplicitStep < numTSIterations) then
@@ -1914,6 +1938,7 @@ module ocn_time_integration_split
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
          elseif (splitExplicitStep == numTSIterations) then
+            call mpas_log_write('end large iteration')
 
 #ifdef MPAS_OPENACC
             !$acc parallel present(minLevelCell, maxLevelCell) &
@@ -2341,6 +2366,7 @@ module ocn_time_integration_split
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
       call mpas_timer_start("se implicit vert mix")
+      call mpas_log_write('start vmix')
 
       ! Call ocean diagnostic solve in preparation for vertical mixing.
       ! Note it is called again after vertical mixing, because u and
@@ -2680,6 +2706,7 @@ module ocn_time_integration_split
 
       call mpas_timer_stop('se fini')
       call mpas_timer_stop("se timestep")
+      call mpas_log_write('end se')
 
    end subroutine ocn_time_integrator_split!}}}
 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -192,7 +192,8 @@ module ocn_time_integration_split
       real (kind=RKIND), dimension(:), allocatable :: &
          btrvel_temp,      &
          sshTemp,          &
-         sshEdge,          &! sea surface height at edge
+         wctTemp,          &
+         wctEdge,          &! flux thickness at edge
          bottomDepthEdge
 
       ! State Array Pointers
@@ -943,14 +944,13 @@ module ocn_time_integration_split
             ! subcycle loop
             allocate(btrvel_temp(nEdgesAll+1))
             btrvel_temp(:) = 0.0_RKIND
-            allocate(sshEdge(nEdgesAll+1))
-            sshEdge(:) = 0.0_RKIND
+            allocate(wctEdge(nEdgesAll+1))
+            wctEdge(:) = 0.0_RKIND
 
             cellHaloComputeCounter = 0
             edgeHaloComputeCounter = 0
 
             call mpas_timer_start('btr se subcycle loop')
-            call mpas_log_write('start btr se subcycles')
             do j = 1, nBtrSubcycles * config_btr_subcycle_loop_factor
 
                ! Update halos if needed
@@ -1068,7 +1068,7 @@ module ocn_time_integration_split
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                ! Barotropic subcycle: SSH PREDICTOR STEP
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-               call mpas_log_write('start ssh predictor')
+               call mpas_timer_start('ssh predictor')
 
                call mpas_pool_get_array(statePool, 'sshSubcycle', &
                                                     sshSubcycleCur, &
@@ -1096,6 +1096,7 @@ module ocn_time_integration_split
                   nEdges = nEdgesHalo(edgeHaloComputeCounter-1)
                endif
 
+
                ! config_btr_gam1_velWt1 sets the forward weighting of
                !    velocity in the SSH computation
                ! config_btr_gam1_velWt1=  1
@@ -1117,22 +1118,19 @@ module ocn_time_integration_split
                !$omp end do
                !$omp end parallel
 
-               call ocn_diagnostic_solve_sshEdge(btrvel_temp, sshSubcycleCur, sshEdge)
+               call ocn_diagnostic_solve_wctEdge(btrvel_temp, sshSubcycleCur, &
+                         bottomDepthEdge, wctEdge)
 
                !$omp parallel
                !$omp do schedule(runtime) &
-               !$omp private(i, iEdge, thicknessSum, flux)
+               !$omp private(i, iEdge, flux)
                do iCell = 1, nCells
                   sshTend(iCell) = 0.0_RKIND
                   do i = 1, nEdgesOnCell(iCell)
                      iEdge = edgesOnCell(i, iCell)
                      if (maxLevelEdgeTop(iEdge).eq.0) cycle
 
-                     ! Compute barotropic thickness at the edge. Note this
-                     ! matches the sum of baroclinic thicknesses at this edge.
-                     thicknessSum = sshEdge(iEdge) + bottomDepthEdge(iEdge)
-
-                     flux = btrvel_temp(iEdge)*thicknessSum
+                     flux = btrvel_temp(iEdge)*wctEdge(iEdge)
 
                      sshTend(iCell) = sshTend(iCell) + &
                                       edgeSignOncell(i, iCell)*flux* &
@@ -1170,13 +1168,11 @@ module ocn_time_integration_split
                      cell1 = cellsOnEdge(1,iEdge)
                      cell2 = cellsOnEdge(2,iEdge)
 
-                     thicknessSum = sshEdge(iEdge) + bottomDepthEdge(iEdge)
-
                      flux = ((1.0-config_btr_gam1_velWt1)* &
                             normalBarotropicVelocitySubcycleCur(iEdge) &
                             +     config_btr_gam1_velWt1 * &
                             normalBarotropicVelocitySubcycleNew(iEdge))&
-                            *thicknessSum
+                            *wctEdge(iEdge)
 
                      barotropicThicknessFlux(iEdge) = &
                      barotropicThicknessFlux(iEdge) + flux
@@ -1188,11 +1184,12 @@ module ocn_time_integration_split
 
                ! a cell halo layer is now corrupted - decrement counter
                cellHaloComputeCounter = cellHaloComputeCounter - 1
+               call mpas_timer_stop('ssh predictor')
 
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                ! Barotropic subcycle: VELOCITY CORRECTOR STEP
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-               call mpas_log_write('start velocity corrector')
+               call mpas_timer_start('velocity corrector')
 
                do BtrCorIter = 1, config_n_btr_cor_iter
                   uPerpTime = newBtrSubcycleTime
@@ -1331,15 +1328,17 @@ module ocn_time_integration_split
                      cellHaloComputeCounter = cellHaloComputeCounter-1
 
                end do !do BtrCorIter=1,config_n_btr_cor_iter
+               call mpas_timer_stop('velocity corrector')
 
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                ! Barotropic subcycle: SSH CORRECTOR STEP
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-               call mpas_log_write('start ssh corrector')
+               call mpas_timer_start('ssh corrector')
                if (config_btr_solve_SSH2) then
 
                   allocate(sshTemp(nCellsAll))
+                  allocate(wctTemp(nCellsAll))
 
                   call mpas_pool_get_array(statePool, 'sshSubcycle', &
                                                        sshSubcycleCur,&
@@ -1401,12 +1400,12 @@ module ocn_time_integration_split
                   !$omp end do
                   !$omp end parallel
 
-                  call ocn_diagnostic_solve_sshEdge( &
-                                  btrvel_temp, sshTemp, sshEdge)
+                  call ocn_diagnostic_solve_wctEdge(btrvel_temp, sshTemp, &
+                         bottomDepthEdge, wctEdge)
 
                   !$omp parallel
                   !$omp do schedule(runtime) &
-                  !$omp private(i, iEdge, thicknessSum, flux)
+                  !$omp private(i, iEdge, flux)
                   do iCell = 1, nCells
                      sshTend(iCell) = 0.0_RKIND
                      do i = 1, nEdgesOnCell(iCell)
@@ -1415,9 +1414,7 @@ module ocn_time_integration_split
 
                         ! SSH is a linear combination of SSHold
                         ! and SSHnew.
-                        thicknessSum = sshEdge(iEdge) + bottomDepthEdge(iEdge)
-
-                        flux = btrvel_temp(iEdge) * thicknessSum
+                        flux = btrvel_temp(iEdge) * wctEdge(iEdge)
 
                         sshTend(iCell) = sshTend(iCell) + &
                                          edgeSignOnCell(i, iCell)* &
@@ -1445,22 +1442,20 @@ module ocn_time_integration_split
                   !$omp end do
                   !$omp end parallel
 
-                  call ocn_diagnostic_solve_sshEdge( &
-                                  btrvel_temp, sshTemp, sshEdge)
+                  call ocn_diagnostic_solve_wctEdge(btrvel_temp, sshTemp, &
+                         bottomDepthEdge, wctEdge)
 
                   ! compute barotropic thickness flux on edges
                   !$omp parallel
                   !$omp do schedule(runtime) &
-                  !$omp private(thicknessSum, flux)
+                  !$omp private(flux)
                   do iEdge = 1, nEdges
-
-                     thicknessSum = sshEdge(iEdge) + bottomDepthEdge(iEdge)
 
                      flux = ((1.0-config_btr_gam3_velWt2) * &
                          normalBarotropicVelocitySubcycleCur(iEdge) &
                           +       config_btr_gam3_velWt2  * &
                          normalBarotropicVelocitySubcycleNew(iEdge)) &
-                            * thicknessSum
+                            * wctEdge(iEdge)
 
                      barotropicThicknessFlux(iEdge) = &
                      barotropicThicknessFlux(iEdge) + flux
@@ -1472,8 +1467,10 @@ module ocn_time_integration_split
                   edgeHaloComputeCounter = config_num_halos + 1
 
                   deallocate(sshTemp)
+                  deallocate(wctTemp)
 
                endif ! config_btr_solve_SSH2
+               call mpas_timer_stop('ssh corrector')
 
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                ! Barotropic subcycle: Accumulate running sums, advance
@@ -1508,10 +1505,9 @@ module ocn_time_integration_split
 
             end do ! j=1,nBtrSubcycles
             call mpas_timer_stop('btr se subcycle loop')
-            call mpas_log_write('end btr se subcycles')
 
             deallocate(btrvel_temp)
-            deallocate(sshEdge)
+            deallocate(wctEdge)
 
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             ! END Barotropic subcycle loop
@@ -1605,6 +1601,8 @@ module ocn_time_integration_split
                                              nVertLevels)
             call ocn_MLE_add_to_transport_vel(normalTransportVelocity, nEdges)
 
+            call ocn_edge_var_from_cell_var_upwind( &
+                     uTemp, layerThicknessCur, layerThickEdgeFlux)
 
             !$omp parallel
             !$omp do schedule(runtime) &
@@ -1661,7 +1659,6 @@ module ocn_time_integration_split
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
          ! Stage 3: Tracer, density, pressure, vert velocity prediction
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-         call mpas_log_write('start stage 3')
 
          ! only compute tendencies for active tracers on last large iteration
          if (splitExplicitStep < numTSIterations) then
@@ -1938,7 +1935,6 @@ module ocn_time_integration_split
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
          elseif (splitExplicitStep == numTSIterations) then
-            call mpas_log_write('end large iteration')
 
 #ifdef MPAS_OPENACC
             !$acc parallel present(minLevelCell, maxLevelCell) &
@@ -2366,7 +2362,6 @@ module ocn_time_integration_split
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
       call mpas_timer_start("se implicit vert mix")
-      call mpas_log_write('start vmix')
 
       ! Call ocean diagnostic solve in preparation for vertical mixing.
       ! Note it is called again after vertical mixing, because u and
@@ -2706,7 +2701,6 @@ module ocn_time_integration_split
 
       call mpas_timer_stop('se fini')
       call mpas_timer_stop("se timestep")
-      call mpas_log_write('end se')
 
    end subroutine ocn_time_integrator_split!}}}
 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -177,6 +177,7 @@ module ocn_time_integration_split
          normalThicknessFluxSum, &! sum of thickness flux in column
          thicknessSum,     &! sum of thicknesses in column
          flux,             &! temp for computing flux for barotropic
+         sshEdge,          &! sea surface height at edge
          CoriolisTerm,     &! temp for computing coriolis term (fuperp)
          normalVelocityCorrection, &! velocity correction
          temp,             &! temp for holding vars at new time
@@ -249,6 +250,7 @@ module ocn_time_integration_split
          sshTend                ! sea-surface height tendency
 
       real (kind=RKIND), dimension(:,:), pointer :: &
+         restingThickness,      &
          normalVelocityTend,    &! normal velocity tendency
          highFreqThicknessTend, &! thickness tendency for high-freq iter
          lowFreqDivergenceTend, &! thickness tendency for low freq
@@ -384,6 +386,7 @@ module ocn_time_integration_split
                                           lowFreqDivergenceTend)
 
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracersNew, 2)
+      call mpas_pool_get_array(verticalMeshPool, 'restingThickness', restingThickness)
 
       allocate(bottomDepthEdge(nEdgesAll+1))
 
@@ -1096,7 +1099,6 @@ module ocn_time_integration_split
                   nEdges = nEdgesHalo(edgeHaloComputeCounter-1)
                endif
 
-
                ! config_btr_gam1_velWt1 sets the forward weighting of
                !    velocity in the SSH computation
                ! config_btr_gam1_velWt1=  1
@@ -1118,6 +1120,8 @@ module ocn_time_integration_split
                !$omp end do
                !$omp end parallel
 
+               ! Compute barotropic thickness at the edge. Note this
+               ! matches the sum of baroclinic thicknesses at this edge.
                call ocn_diagnostic_solve_wctEdge(btrvel_temp, sshSubcycleCur, &
                          bottomDepthEdge, wctEdge)
 
@@ -1130,7 +1134,13 @@ module ocn_time_integration_split
                      iEdge = edgesOnCell(i, iCell)
                      if (maxLevelEdgeTop(iEdge).eq.0) cycle
 
-                     flux = btrvel_temp(iEdge)*wctEdge(iEdge)
+                     ! There is a redundant computation here of btrvel_temp
+                     ! but is needed to preserve decomp
+                     flux = ((1.0-config_btr_gam1_velWt1)* &
+                            normalBarotropicVelocitySubcycleCur(iEdge) &
+                          +       config_btr_gam1_velWt1 * &
+                            normalBarotropicVelocitySubcycleNew(iEdge))&
+                           *wctEdge(iEdge)
 
                      sshTend(iCell) = sshTend(iCell) + &
                                       edgeSignOncell(i, iCell)*flux* &
@@ -1162,11 +1172,9 @@ module ocn_time_integration_split
 
                   !$omp parallel
                   !$omp do schedule(runtime) &
-                  !$omp private(thicknessSum, flux)
+                  !$omp private(flux)
                   do iEdge = 1, nEdges
                      if (maxLevelEdgeTop(iEdge).eq.0) cycle
-                     cell1 = cellsOnEdge(1,iEdge)
-                     cell2 = cellsOnEdge(2,iEdge)
 
                      flux = ((1.0-config_btr_gam1_velWt1)* &
                             normalBarotropicVelocitySubcycleCur(iEdge) &
@@ -1377,6 +1385,7 @@ module ocn_time_integration_split
                   ! config_btr_gam3_velWt2=  0
                   !    flux = normalBarotropicVelocityOld*H
 
+                  call mpas_log_write('begin sshTemp')
                   !$omp parallel
                   !$omp do schedule(runtime)
                   do iCell = 1, nCells
@@ -1400,9 +1409,11 @@ module ocn_time_integration_split
                   !$omp end do
                   !$omp end parallel
 
+                  call mpas_log_write('call wctWdge on L1396')
                   call ocn_diagnostic_solve_wctEdge(btrvel_temp, sshTemp, &
                          bottomDepthEdge, wctEdge)
 
+                  call mpas_log_write('begin main loop')
                   !$omp parallel
                   !$omp do schedule(runtime) &
                   !$omp private(i, iEdge, flux)
@@ -1410,11 +1421,14 @@ module ocn_time_integration_split
                      sshTend(iCell) = 0.0_RKIND
                      do i = 1, nEdgesOnCell(iCell)
                         iEdge = edgesOnCell(i, iCell)
+
                         if (maxLevelEdgeTop(iEdge).eq.0) cycle
 
-                        ! SSH is a linear combination of SSHold
-                        ! and SSHnew.
-                        flux = btrvel_temp(iEdge) * wctEdge(iEdge)
+                        flux = ((1.0-config_btr_gam3_velWt2)* &
+                           normalBarotropicVelocitySubcycleCur(iEdge) &
+                             +       config_btr_gam3_velWt2 * &
+                           normalBarotropicVelocitySubcycleNew(iEdge))&
+                             *wctEdge(iEdge)
 
                         sshTend(iCell) = sshTend(iCell) + &
                                          edgeSignOnCell(i, iCell)* &
@@ -1455,7 +1469,7 @@ module ocn_time_integration_split
                          normalBarotropicVelocitySubcycleCur(iEdge) &
                           +       config_btr_gam3_velWt2  * &
                          normalBarotropicVelocitySubcycleNew(iEdge)) &
-                            * wctEdge(iEdge)
+                          * wctEdge(iEdge)
 
                      barotropicThicknessFlux(iEdge) = &
                      barotropicThicknessFlux(iEdge) + flux
@@ -1601,8 +1615,10 @@ module ocn_time_integration_split
                                              nVertLevels)
             call ocn_MLE_add_to_transport_vel(normalTransportVelocity, nEdges)
 
-            call ocn_edge_var_from_cell_var_upwind( &
-                     uTemp, layerThicknessCur, layerThickEdgeFlux)
+            call mpas_log_write('update layerThicknessEdge')
+            call ocn_diagnostic_solve_layerThicknessEdge( &
+                     uTemp, layerThicknessCur, restingThickness)
+            call mpas_log_write('update layerThicknessEdge: end')
 
             !$omp parallel
             !$omp do schedule(runtime) &

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -193,7 +193,6 @@ module ocn_time_integration_split
       real (kind=RKIND), dimension(:), allocatable :: &
          btrvel_temp,      &
          sshTemp,          &
-         wctTemp,          &
          wctEdge,          &! flux thickness at edge
          bottomDepthEdge
 
@@ -1346,7 +1345,6 @@ module ocn_time_integration_split
                if (config_btr_solve_SSH2) then
 
                   allocate(sshTemp(nCellsAll))
-                  allocate(wctTemp(nCellsAll))
 
                   call mpas_pool_get_array(statePool, 'sshSubcycle', &
                                                        sshSubcycleCur,&
@@ -1385,7 +1383,6 @@ module ocn_time_integration_split
                   ! config_btr_gam3_velWt2=  0
                   !    flux = normalBarotropicVelocityOld*H
 
-                  call mpas_log_write('begin sshTemp')
                   !$omp parallel
                   !$omp do schedule(runtime)
                   do iCell = 1, nCells
@@ -1409,11 +1406,9 @@ module ocn_time_integration_split
                   !$omp end do
                   !$omp end parallel
 
-                  call mpas_log_write('call wctWdge on L1396')
                   call ocn_diagnostic_solve_wctEdge(btrvel_temp, sshTemp, &
                          bottomDepthEdge, wctEdge)
 
-                  call mpas_log_write('begin main loop')
                   !$omp parallel
                   !$omp do schedule(runtime) &
                   !$omp private(i, iEdge, flux)
@@ -1428,7 +1423,7 @@ module ocn_time_integration_split
                            normalBarotropicVelocitySubcycleCur(iEdge) &
                              +       config_btr_gam3_velWt2 * &
                            normalBarotropicVelocitySubcycleNew(iEdge))&
-                             *wctEdge(iEdge)
+                             * wctEdge(iEdge)
 
                         sshTend(iCell) = sshTend(iCell) + &
                                          edgeSignOnCell(i, iCell)* &
@@ -1481,7 +1476,6 @@ module ocn_time_integration_split
                   edgeHaloComputeCounter = config_num_halos + 1
 
                   deallocate(sshTemp)
-                  deallocate(wctTemp)
 
                endif ! config_btr_solve_SSH2
                call mpas_timer_stop('ssh corrector')
@@ -1615,57 +1609,119 @@ module ocn_time_integration_split
                                              nVertLevels)
             call ocn_MLE_add_to_transport_vel(normalTransportVelocity, nEdges)
 
-            call mpas_log_write('update layerThicknessEdge')
-            call ocn_diagnostic_solve_layerThicknessEdge( &
-                     uTemp, layerThicknessCur, restingThickness)
-            call mpas_log_write('update layerThicknessEdge: end')
+            !call mpas_log_write('update layerThicknessEdge')
+            !call ocn_diagnostic_solve_layerThicknessEdge( &
+            !         uTemp, layerThicknessCur, restingThickness)
+            !call mpas_log_write('update layerThicknessEdge: end')
 
-            !$omp parallel
-            !$omp do schedule(runtime) &
-            !$omp private(k, normalThicknessFluxSum, &
-            !$omp         thicknessSum, normalVelocityCorrection)
-            do iEdge = 1, nEdges
+            if (trim(config_thickness_flux_type) == 'upwind') then
+               !$omp parallel
+               !$omp do schedule(runtime) &
+               !$omp private(cell1, cell2, k, normalThicknessFluxSum, &
+               !$omp         thicknessSum, normalVelocityCorrection)
+               do iEdge = 1, nEdges
+                  call mpas_log_write('Compute velocity correction for iEdge $i of nEdges $i', &
+                       intArgs=(/ iEdge, nEdges /))
+                  ! thicknessSum is initialized outside the loop because
+                  ! on land boundaries maxLevelEdgeTop=0, but I want to
+                  ! initialize thicknessSum with a nonzero value to avoid
+                  ! a NaN.
+                  cell1 = cellsOnEdge(1,iEdge)
+                  cell2 = cellsOnEdge(2,iEdge)
+                  do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+                     layerThickEdgeFlux(:,iEdge) = -1.0e34_RKIND
+                     if (uTemp(k,iEdge) > 0.0_RKIND) then
+                        layerThickEdgeFlux(k,iEdge) = layerThicknessCur(k,cell1)
+                     elseif (uTemp(k,iEdge) < 0.0_RKIND) then
+                        layerThickEdgeFlux(k,iEdge) = layerThicknessCur(k,cell2)
+                     else
+                        layerThickEdgeFlux(k,iEdge) = max(layerThicknessCur(k,cell1), &
+                                                          layerThicknessCur(k,cell2))
+                     end if
+                  enddo 
+                  normalThicknessFluxSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)* &
+                                           uTemp(minLevelEdgeBot(iEdge),iEdge)
+                  thicknessSum  = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
 
-               ! thicknessSum is initialized outside the loop because
-               ! on land boundaries maxLevelEdgeTop=0, but I want to
-               ! initialize thicknessSum with a nonzero value to avoid
-               ! a NaN.
-               normalThicknessFluxSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)* &
-                                        uTemp(minLevelEdgeBot(iEdge),iEdge)
-               thicknessSum  = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
+                  do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
+                     normalThicknessFluxSum = normalThicknessFluxSum + &
+                                              layerThickEdgeFlux(k,iEdge)*&
+                                              uTemp(k,iEdge)
+                     thicknessSum = thicknessSum + &
+                                    layerThickEdgeFlux(k,iEdge)
+                  enddo
 
-               do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
-                  normalThicknessFluxSum = normalThicknessFluxSum + &
-                                           layerThickEdgeFlux(k,iEdge)*&
-                                           uTemp(k,iEdge)
-                  thicknessSum = thicknessSum + &
-                                 layerThickEdgeFlux(k,iEdge)
-               enddo
+                  normalVelocityCorrection = useVelocityCorrection* &
+                                ((barotropicThicknessFlux(iEdge) - &
+                                  normalThicknessFluxSum)/thicknessSum)
+                  call mpas_log_write('Velocity correction for iEdge $i = $r', &
+                       intArgs=(/ iEdge /), realArgs=(/ normalVelocityCorrection /))
 
-               normalVelocityCorrection = useVelocityCorrection* &
-                             ((barotropicThicknessFlux(iEdge) - &
-                               normalThicknessFluxSum)/thicknessSum)
+                  do k = 1, nVertLevels
 
-               do k = 1, nVertLevels
+                     ! normalTransportVelocity = normalBarotropicVelocity
+                     !                         + normalBaroclinicVelocity
+                     !                         + normalGMBolusVelocity
+                     !                         + normalMLEvelocity 
+                     !                         + normalVelocityCorrection
+                     ! This is the velocity used in advective terms for layerThickness
+                     ! and tracers in tendency calls in stage 3.
+                     normalTransportVelocity(k,iEdge) = edgeMask(k,iEdge)*( &
+                                normalTransportVelocity(k,iEdge) + &
+                                normalVelocityCorrection)
+                  enddo
 
-                  ! normalTransportVelocity = normalBarotropicVelocity
-                  !                         + normalBaroclinicVelocity
-                  !                         + normalGMBolusVelocity
-                  !                         + normalMLEvelocity 
-                  !                         + normalVelocityCorrection
-                  ! This is the velocity used in advective terms for layerThickness
-                  ! and tracers in tendency calls in stage 3.
-                  normalTransportVelocity(k,iEdge) = edgeMask(k,iEdge)*( &
-                             normalTransportVelocity(k,iEdge) + &
-                             normalVelocityCorrection)
-               enddo
+               end do ! iEdge
+               !$omp end do
+               !$omp end parallel
+            else
+               !$omp parallel
+               !$omp do schedule(runtime) &
+               !$omp private(k, normalThicknessFluxSum, &
+               !$omp         thicknessSum, normalVelocityCorrection)
+               do iEdge = 1, nEdges
 
-            end do ! iEdge
-            !$omp end do
-            !$omp end parallel
+                  ! thicknessSum is initialized outside the loop because
+                  ! on land boundaries maxLevelEdgeTop=0, but I want to
+                  ! initialize thicknessSum with a nonzero value to avoid
+                  ! a NaN.
+                  normalThicknessFluxSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)* &
+                                           uTemp(minLevelEdgeBot(iEdge),iEdge)
+                  thicknessSum  = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
 
+                  do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
+                     normalThicknessFluxSum = normalThicknessFluxSum + &
+                                              layerThickEdgeFlux(k,iEdge)*&
+                                              uTemp(k,iEdge)
+                     thicknessSum = thicknessSum + &
+                                    layerThickEdgeFlux(k,iEdge)
+                  enddo
+
+                  normalVelocityCorrection = useVelocityCorrection* &
+                                ((barotropicThicknessFlux(iEdge) - &
+                                  normalThicknessFluxSum)/thicknessSum)
+
+                  do k = 1, nVertLevels
+
+                     ! normalTransportVelocity = normalBarotropicVelocity
+                     !                         + normalBaroclinicVelocity
+                     !                         + normalGMBolusVelocity
+                     !                         + normalMLEvelocity 
+                     !                         + normalVelocityCorrection
+                     ! This is the velocity used in advective terms for layerThickness
+                     ! and tracers in tendency calls in stage 3.
+                     normalTransportVelocity(k,iEdge) = edgeMask(k,iEdge)*( &
+                                normalTransportVelocity(k,iEdge) + &
+                                normalVelocityCorrection)
+                  enddo
+
+               end do ! iEdge
+               !$omp end do
+               !$omp end parallel
+            endif
             deallocate(uTemp)
 
+            call mpas_log_write('Applied velocity correction, end stage 2')
             call mpas_timer_stop('btr se ssh verif')
 
          endif ! split_explicit

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -1075,7 +1075,6 @@ module ocn_time_integration_split
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                ! Barotropic subcycle: SSH PREDICTOR STEP
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-               call mpas_timer_start('ssh predictor')
 
                call mpas_pool_get_array(statePool, 'sshSubcycle', &
                                                     sshSubcycleCur, &
@@ -1186,12 +1185,10 @@ module ocn_time_integration_split
 
                ! a cell halo layer is now corrupted - decrement counter
                cellHaloComputeCounter = cellHaloComputeCounter - 1
-               call mpas_timer_stop('ssh predictor')
 
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                ! Barotropic subcycle: VELOCITY CORRECTOR STEP
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-               call mpas_timer_start('velocity corrector')
 
                do BtrCorIter = 1, config_n_btr_cor_iter
                   uPerpTime = newBtrSubcycleTime
@@ -1330,13 +1327,11 @@ module ocn_time_integration_split
                      cellHaloComputeCounter = cellHaloComputeCounter-1
 
                end do !do BtrCorIter=1,config_n_btr_cor_iter
-               call mpas_timer_stop('velocity corrector')
 
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                ! Barotropic subcycle: SSH CORRECTOR STEP
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-               call mpas_timer_start('ssh corrector')
                if (config_btr_solve_SSH2) then
 
                   allocate(sshTemp(nCellsAll))
@@ -1465,7 +1460,6 @@ module ocn_time_integration_split
                   deallocate(sshTemp)
 
                endif ! config_btr_solve_SSH2
-               call mpas_timer_stop('ssh corrector')
 
                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                ! Barotropic subcycle: Accumulate running sums, advance

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -198,7 +198,7 @@ module ocn_time_integration_split
       real (kind=RKIND), dimension(:), allocatable :: &
          btrvel_temp,      &
          sshTemp,          &
-         wctEdge,          &! flux thickness at edge
+         wctEdge,          &! flux water column thickness at edge
          bottomDepthEdge
 
       ! State Array Pointers
@@ -254,7 +254,6 @@ module ocn_time_integration_split
          sshTend                ! sea-surface height tendency
 
       real (kind=RKIND), dimension(:,:), pointer :: &
-         restingThickness,      &
          normalVelocityTend,    &! normal velocity tendency
          highFreqThicknessTend, &! thickness tendency for high-freq iter
          lowFreqDivergenceTend, &! thickness tendency for low freq
@@ -390,7 +389,6 @@ module ocn_time_integration_split
                                           lowFreqDivergenceTend)
 
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracersNew, 2)
-      call mpas_pool_get_array(verticalMeshPool, 'restingThickness', restingThickness)
 
       allocate(bottomDepthEdge(nEdgesAll+1))
 
@@ -1115,10 +1113,10 @@ module ocn_time_integration_split
                !$omp parallel
                !$omp do schedule(runtime)
                do iEdge = 1, nEdgesAll
-                  btrvel_temp(iEdge) = (1.0-config_btr_gam1_velWt1) * &
-                               normalBarotropicVelocitySubcycleCur(iEdge) &
-                             +       config_btr_gam1_velWt1 *             &
-                               normalBarotropicVelocitySubcycleNew(iEdge)
+                  btrvel_temp(iEdge) = (1.0_RKIND - config_btr_gam1_velWt1) * &
+                                       normalBarotropicVelocitySubcycleCur(iEdge) + &
+                                       config_btr_gam1_velWt1 * &
+                                       normalBarotropicVelocitySubcycleNew(iEdge)
                end do
                !$omp end do
                !$omp end parallel
@@ -1378,9 +1376,9 @@ module ocn_time_integration_split
                   do iCell = 1, nCells
                      ! SSH is linear combination of SSHold and SSHnew
                      sshTemp(iCell) = (1-config_btr_gam2_SSHWt1)* &
-                                            sshSubcycleCur(iCell) &
-                                    +    config_btr_gam2_SSHWt1 * &
-                                            sshSubcycleNew(iCell)
+                                      sshSubcycleCur(iCell) + &
+                                      config_btr_gam2_SSHWt1 * &
+                                      sshSubcycleNew(iCell)
                   end do ! cell loop for ssh
                   !$omp end do
                   !$omp end parallel
@@ -1389,9 +1387,9 @@ module ocn_time_integration_split
                   !$omp do schedule(runtime)
                   do iEdge = 1, nEdgesAll
                      btrvel_temp(iEdge) = (1.0-config_btr_gam3_velWt2) * &
-                                  normalBarotropicVelocitySubcycleCur(iEdge) &
-                                +       config_btr_gam3_velWt2 *             &
-                                  normalBarotropicVelocitySubcycleNew(iEdge)
+                                          normalBarotropicVelocitySubcycleCur(iEdge) + &
+                                          config_btr_gam3_velWt2 * &
+                                          normalBarotropicVelocitySubcycleNew(iEdge)
                   end do
                   !$omp end do
                   !$omp end parallel
@@ -1430,9 +1428,9 @@ module ocn_time_integration_split
                   do iCell = 1, nCells
                      ! SSH is linear combination of SSHold and SSHnew
                      sshTemp(iCell) = (1-config_btr_gam2_SSHWt1)* &
-                                            sshSubcycleCur(iCell) &
-                                    +    config_btr_gam2_SSHWt1 * &
-                                            sshSubcycleNew(iCell)
+                                      sshSubcycleCur(iCell) + &
+                                      config_btr_gam2_SSHWt1 * &
+                                      sshSubcycleNew(iCell)
                   end do ! cell loop for ssh
                   !$omp end do
                   !$omp end parallel
@@ -1608,7 +1606,7 @@ module ocn_time_integration_split
                   cell1 = cellsOnEdge(1,iEdge)
                   cell2 = cellsOnEdge(2,iEdge)
                   do k=1,nVertLevels
-                     ! initialize layerThicknessEdgeFlux to avoid divide by
+                     ! initialize layerThickEdgeFlux to avoid divide by
                      ! zero and NaN problems.
                      layerThickEdgeFlux(k,iEdge) = -1.0e34_RKIND
                   end do

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -92,6 +92,11 @@ module ocn_time_integration_split
       nBtrSubcycles     ! number of barotropic subcycles
 
    integer :: ssh_sal_on
+   integer :: &
+      thickEdgeFluxChoice ! choice of thickness flux type
+   integer, parameter :: &
+      thickEdgeFluxCenter   = 1, &! use mean thickness of cell neighbors
+      thickEdgeFluxUpwind   = 2   ! use upwind cell thickness at edge
 
    real (kind=RKIND) :: &
       useVelocityCorrection,&! mask for velocity correction
@@ -1110,7 +1115,7 @@ module ocn_time_integration_split
 
                !$omp parallel
                !$omp do schedule(runtime)
-               do iEdge = 1, nEdges
+               do iEdge = 1, nEdgesAll
                   btrvel_temp(iEdge) = (1.0-config_btr_gam1_velWt1) * &
                                normalBarotropicVelocitySubcycleCur(iEdge) &
                              +       config_btr_gam1_velWt1 *             &
@@ -1133,13 +1138,7 @@ module ocn_time_integration_split
                      iEdge = edgesOnCell(i, iCell)
                      if (maxLevelEdgeTop(iEdge).eq.0) cycle
 
-                     ! There is a redundant computation here of btrvel_temp
-                     ! but is needed to preserve decomp
-                     flux = ((1.0-config_btr_gam1_velWt1)* &
-                            normalBarotropicVelocitySubcycleCur(iEdge) &
-                          +       config_btr_gam1_velWt1 * &
-                            normalBarotropicVelocitySubcycleNew(iEdge))&
-                           *wctEdge(iEdge)
+                     flux = btrvel_temp(iEdge) * wctEdge(iEdge)
 
                      sshTend(iCell) = sshTend(iCell) + &
                                       edgeSignOncell(i, iCell)*flux* &
@@ -1175,11 +1174,7 @@ module ocn_time_integration_split
                   do iEdge = 1, nEdges
                      if (maxLevelEdgeTop(iEdge).eq.0) cycle
 
-                     flux = ((1.0-config_btr_gam1_velWt1)* &
-                            normalBarotropicVelocitySubcycleCur(iEdge) &
-                            +     config_btr_gam1_velWt1 * &
-                            normalBarotropicVelocitySubcycleNew(iEdge))&
-                            *wctEdge(iEdge)
+                     flux = btrvel_temp(iEdge) * wctEdge(iEdge)
 
                      barotropicThicknessFlux(iEdge) = &
                      barotropicThicknessFlux(iEdge) + flux
@@ -1397,7 +1392,7 @@ module ocn_time_integration_split
 
                   !$omp parallel
                   !$omp do schedule(runtime)
-                  do iEdge = 1, nEdges
+                  do iEdge = 1, nEdgesAll
                      btrvel_temp(iEdge) = (1.0-config_btr_gam3_velWt2) * &
                                   normalBarotropicVelocitySubcycleCur(iEdge) &
                                 +       config_btr_gam3_velWt2 *             &
@@ -1419,11 +1414,7 @@ module ocn_time_integration_split
 
                         if (maxLevelEdgeTop(iEdge).eq.0) cycle
 
-                        flux = ((1.0-config_btr_gam3_velWt2)* &
-                           normalBarotropicVelocitySubcycleCur(iEdge) &
-                             +       config_btr_gam3_velWt2 * &
-                           normalBarotropicVelocitySubcycleNew(iEdge))&
-                             * wctEdge(iEdge)
+                        flux = btrvel_temp(iEdge) * wctEdge(iEdge)
 
                         sshTend(iCell) = sshTend(iCell) + &
                                          edgeSignOnCell(i, iCell)* &
@@ -1460,11 +1451,7 @@ module ocn_time_integration_split
                   !$omp private(flux)
                   do iEdge = 1, nEdges
 
-                     flux = ((1.0-config_btr_gam3_velWt2) * &
-                         normalBarotropicVelocitySubcycleCur(iEdge) &
-                          +       config_btr_gam3_velWt2  * &
-                         normalBarotropicVelocitySubcycleNew(iEdge)) &
-                          * wctEdge(iEdge)
+                     flux = btrvel_temp(iEdge) * wctEdge(iEdge)
 
                      barotropicThicknessFlux(iEdge) = &
                      barotropicThicknessFlux(iEdge) + flux
@@ -1609,119 +1596,79 @@ module ocn_time_integration_split
                                              nVertLevels)
             call ocn_MLE_add_to_transport_vel(normalTransportVelocity, nEdges)
 
-            !call mpas_log_write('update layerThicknessEdge')
-            !call ocn_diagnostic_solve_layerThicknessEdge( &
-            !         uTemp, layerThicknessCur, restingThickness)
-            !call mpas_log_write('update layerThicknessEdge: end')
+#ifdef MPAS_OPENACC
+            !$acc parallel loop &
+            !$acc    present(normalVelocity, layerThickness, &
+            !$acc            minLevelEdgeBot, maxLevelEdgeTop, &
+            !$acc            layerThickEdgeFlux, cellsOnEdge) &
+            !$acc    private(k, kmin, kmax, cell1, cell2)
+#else
+            !$omp parallel
+            !$omp do schedule(runtime) &
+            !$omp private(cell1, cell2, k, normalThicknessFluxSum, &
+            !$omp         thicknessSum, normalVelocityCorrection)
+            do iEdge = 1, nEdges
 
-            if (trim(config_thickness_flux_type) == 'upwind') then
-               !$omp parallel
-               !$omp do schedule(runtime) &
-               !$omp private(cell1, cell2, k, normalThicknessFluxSum, &
-               !$omp         thicknessSum, normalVelocityCorrection)
-               do iEdge = 1, nEdges
-                  call mpas_log_write('Compute velocity correction for iEdge $i of nEdges $i', &
-                       intArgs=(/ iEdge, nEdges /))
-                  ! thicknessSum is initialized outside the loop because
-                  ! on land boundaries maxLevelEdgeTop=0, but I want to
-                  ! initialize thicknessSum with a nonzero value to avoid
-                  ! a NaN.
+#endif
+               if (thickEdgeFluxChoice == thickEdgeFluxUpwind) then
                   cell1 = cellsOnEdge(1,iEdge)
                   cell2 = cellsOnEdge(2,iEdge)
+                  do k=1,nVertLevels
+                     ! initialize layerThicknessEdgeFlux to avoid divide by
+                     ! zero and NaN problems.
+                     layerThickEdgeFlux(k,iEdge) = -1.0e34_RKIND
+                  end do
                   do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-                     layerThickEdgeFlux(:,iEdge) = -1.0e34_RKIND
                      if (uTemp(k,iEdge) > 0.0_RKIND) then
                         layerThickEdgeFlux(k,iEdge) = layerThicknessCur(k,cell1)
                      elseif (uTemp(k,iEdge) < 0.0_RKIND) then
                         layerThickEdgeFlux(k,iEdge) = layerThicknessCur(k,cell2)
                      else
-                        layerThickEdgeFlux(k,iEdge) = max(layerThicknessCur(k,cell1), &
-                                                          layerThicknessCur(k,cell2))
+                        layerThickEdgeFlux(k,iEdge) = &
+                                            max(layerThicknessCur(k,cell1), &
+                                                layerThicknessCur(k,cell2))
                      end if
-                  enddo 
-                  normalThicknessFluxSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)* &
-                                           uTemp(minLevelEdgeBot(iEdge),iEdge)
-                  thicknessSum  = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
+                  end do
+               endif
+               ! thicknessSum is initialized outside the loop because
+               ! on land boundaries maxLevelEdgeTop=0, but I want to
+               ! initialize thicknessSum with a nonzero value to avoid
+               ! a NaN.
+               normalThicknessFluxSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)* &
+                                        uTemp(minLevelEdgeBot(iEdge),iEdge)
+               thicknessSum  = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
 
-                  do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
-                     normalThicknessFluxSum = normalThicknessFluxSum + &
-                                              layerThickEdgeFlux(k,iEdge)*&
-                                              uTemp(k,iEdge)
-                     thicknessSum = thicknessSum + &
-                                    layerThickEdgeFlux(k,iEdge)
-                  enddo
+               do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
+                  normalThicknessFluxSum = normalThicknessFluxSum + &
+                                           layerThickEdgeFlux(k,iEdge)*&
+                                           uTemp(k,iEdge)
+                  thicknessSum = thicknessSum + &
+                                 layerThickEdgeFlux(k,iEdge)
+               enddo
 
-                  normalVelocityCorrection = useVelocityCorrection* &
-                                ((barotropicThicknessFlux(iEdge) - &
-                                  normalThicknessFluxSum)/thicknessSum)
-                  call mpas_log_write('Velocity correction for iEdge $i = $r', &
-                       intArgs=(/ iEdge /), realArgs=(/ normalVelocityCorrection /))
+               normalVelocityCorrection = useVelocityCorrection* &
+                             ((barotropicThicknessFlux(iEdge) - &
+                               normalThicknessFluxSum)/thicknessSum)
 
-                  do k = 1, nVertLevels
+               do k = 1, nVertLevels
 
-                     ! normalTransportVelocity = normalBarotropicVelocity
-                     !                         + normalBaroclinicVelocity
-                     !                         + normalGMBolusVelocity
-                     !                         + normalMLEvelocity 
-                     !                         + normalVelocityCorrection
-                     ! This is the velocity used in advective terms for layerThickness
-                     ! and tracers in tendency calls in stage 3.
-                     normalTransportVelocity(k,iEdge) = edgeMask(k,iEdge)*( &
-                                normalTransportVelocity(k,iEdge) + &
-                                normalVelocityCorrection)
-                  enddo
+                  ! normalTransportVelocity = normalBarotropicVelocity
+                  !                         + normalBaroclinicVelocity
+                  !                         + normalGMBolusVelocity
+                  !                         + normalMLEvelocity 
+                  !                         + normalVelocityCorrection
+                  ! This is the velocity used in advective terms for layerThickness
+                  ! and tracers in tendency calls in stage 3.
+                  normalTransportVelocity(k,iEdge) = edgeMask(k,iEdge)*( &
+                             normalTransportVelocity(k,iEdge) + &
+                             normalVelocityCorrection)
+               enddo
 
-               end do ! iEdge
-               !$omp end do
-               !$omp end parallel
-            else
-               !$omp parallel
-               !$omp do schedule(runtime) &
-               !$omp private(k, normalThicknessFluxSum, &
-               !$omp         thicknessSum, normalVelocityCorrection)
-               do iEdge = 1, nEdges
+            end do ! iEdge
+            !$omp end do
+            !$omp end parallel
 
-                  ! thicknessSum is initialized outside the loop because
-                  ! on land boundaries maxLevelEdgeTop=0, but I want to
-                  ! initialize thicknessSum with a nonzero value to avoid
-                  ! a NaN.
-                  normalThicknessFluxSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)* &
-                                           uTemp(minLevelEdgeBot(iEdge),iEdge)
-                  thicknessSum  = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
-
-                  do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
-                     normalThicknessFluxSum = normalThicknessFluxSum + &
-                                              layerThickEdgeFlux(k,iEdge)*&
-                                              uTemp(k,iEdge)
-                     thicknessSum = thicknessSum + &
-                                    layerThickEdgeFlux(k,iEdge)
-                  enddo
-
-                  normalVelocityCorrection = useVelocityCorrection* &
-                                ((barotropicThicknessFlux(iEdge) - &
-                                  normalThicknessFluxSum)/thicknessSum)
-
-                  do k = 1, nVertLevels
-
-                     ! normalTransportVelocity = normalBarotropicVelocity
-                     !                         + normalBaroclinicVelocity
-                     !                         + normalGMBolusVelocity
-                     !                         + normalMLEvelocity 
-                     !                         + normalVelocityCorrection
-                     ! This is the velocity used in advective terms for layerThickness
-                     ! and tracers in tendency calls in stage 3.
-                     normalTransportVelocity(k,iEdge) = edgeMask(k,iEdge)*( &
-                                normalTransportVelocity(k,iEdge) + &
-                                normalVelocityCorrection)
-                  enddo
-
-               end do ! iEdge
-               !$omp end do
-               !$omp end parallel
-            endif
             deallocate(uTemp)
-
-            call mpas_log_write('Applied velocity correction, end stage 2')
             call mpas_timer_stop('btr se ssh verif')
 
          endif ! split_explicit
@@ -2903,6 +2850,11 @@ module ocn_time_integration_split
 
       end select
 
+      if (trim(config_thickness_flux_type) == 'upwind') then
+         thickEdgeFluxChoice = thickEdgeFluxUpwind
+      else
+         thickEdgeFluxChoice = thickEdgeFluxCenter
+      end if
       !*** set number of baroclinic iterations on each outer
       !*** time step iteration (number can be different on the
       !*** first and last time step iteration)

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -673,13 +673,11 @@ contains
 !  routine ocn_diagnostic_solve_wctEdge
 !
 !> \brief   Computes layer thickness at edge
-!> \author  Matt Turner
-!> \date    October 2020
+!> \author  Carolyn Begeman
+!> \date    July 2023
 !> \details
-!>  This routine computes the diagnostic variables layerThickEdgeFlux
-!>  and layerThickEdgeMean. The Mean is a simple mean across the edge
-!>  but the Flux value can either be the mean or an upwind value,
-!>  depending on user input.
+!>  This routine computes the water column thickness on edges, wctEdge, which 
+!>  can either be the mean or an upwind value, depending on user input.
 !
 !-----------------------------------------------------------------------
 
@@ -704,7 +702,7 @@ contains
 
       ! Outputs are the shared variables from diagnostic_variables:
       real (kind=RKIND), dimension(:), intent(inout) :: &
-         wctEdge !< [out] wct on edge
+         wctEdge !< [out] water column thickness on edge
 
       !-----------------------------------------------------------------
       ! local variables
@@ -729,7 +727,9 @@ contains
 
          ! Compute mean layer thickness at edge
 #ifdef MPAS_OPENACC
-         !$acc parallel loop collapse(2) &
+         !$acc parallel loop &
+         !$acc    present(bottomDepthEdge, sshCell, sshEdge, cellsOnEdge, wctEdge) &
+         !$acc    private(cell1, cell2)
 #else
          !$omp parallel
          !$omp do schedule(runtime) private (cell1, cell2)
@@ -759,14 +759,14 @@ contains
          ! Use upwind thickness as the edge flux value
 #ifdef MPAS_OPENACC
          !$acc parallel loop &
-         !$acc    present(btrVelocity, sshCell, sshEdge, cellsOnEdge) &
+         !$acc    present(btrVelocity, sshCell, sshEdge, cellsOnEdge, maxLevelEdgeTop, wctCell, wctEdge) &
          !$acc    private(cell1, cell2)
 #else
          !$omp parallel
          !$omp do schedule(runtime) private(cell1, cell2)
 #endif
          do iEdge = 1, nEdgesAll
-            if ( maxLevelEdgeTop(iEdge).eq.0 ) cycle
+            if ( maxLevelEdgeTop(iEdge) == 0 ) cycle
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
             if (btrVelocity(iEdge) > 0.0_RKIND) then

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -1056,6 +1056,7 @@ contains
       !$omp do schedule(runtime) private(k, kmin, kmax, cell1, cell2)
 #endif
       do iEdge = 1, nEdgesAll
+         if ( maxLevelEdgeTop(iEdge).eq.0 ) cycle
          kmin = minLevelEdgeBot(iEdge)
          kmax = maxLevelEdgeTop(iEdge)
          cell1 = cellsOnEdge(1,iEdge)
@@ -1135,9 +1136,9 @@ contains
       !$omp do schedule(runtime) private(cell1, cell2)
 #endif
       do iEdge = 1, nEdgesAll
-         if ( maxLevelEdgeTop(iEdge) < 1 ) cycle
-         cell1 = cellsOnEdge(1,iEdge)
-         cell2 = cellsOnEdge(2,iEdge)
+         if ( maxLevelEdgeTop(iEdge).eq.0 ) cycle
+         cell1 = cellsOnEdge(1, iEdge)
+         cell2 = cellsOnEdge(2, iEdge)
          if (btrVelocity(iEdge) > 0.0_RKIND) then
             edgeVar(iEdge) = cellVar(cell1)
          elseif (btrVelocity(iEdge) < 0.0_RKIND) then

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -725,7 +725,6 @@ contains
       !-----------------------------------------------------------------
       ! Begin code
 
-      call mpas_timer_start("wctEdge")
       wctEdge(:) = -1.0e34_RKIND
       ! Compute edge flux based on option set on init
       select case (thickEdgeFluxChoice)
@@ -776,7 +775,6 @@ contains
                              MPAS_LOG_CRIT)
 
       end select
-      call mpas_timer_stop("wctEdge")
 
    !--------------------------------------------------------------------
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -675,7 +675,7 @@ contains
 
 !***********************************************************************
 !
-!  routine ocn_diagnostic_solve_sshEdge
+!  routine ocn_diagnostic_solve_wctEdge
 !
 !> \brief   Computes layer thickness at edge
 !> \author  Matt Turner
@@ -756,6 +756,7 @@ contains
 
       case (thickEdgeFluxUpwind)
          allocate(wctCell(nCellsAll))
+
          !$omp parallel
          !$omp do schedule(runtime)
          do iCell = 1, nCellsAll

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -4471,17 +4471,14 @@ contains
                  & 'Set config_disable_vel_hadv to true for a linear test case. ', &
                  MPAS_LOG_CRIT)
          end if
+      elseif (trim(config_thickness_flux_type) == 'upwind') then
+         thickEdgeFluxChoice = thickEdgeFluxUpwind
+         call mpas_log_write('Thickness flux option set to ' //&
+              & trim(config_thickness_flux_type))
       else
-         if (config_use_wetting_drying .and. &
-             (trim(config_thickness_flux_type) /= 'centered')) then
-            if ( trim(config_thickness_flux_type) == 'upwind') then
-               thickEdgeFluxChoice = thickEdgeFluxUpwind
-            end if
-         else
-            call mpas_log_write('Thickness flux option of ' //&
-                 & trim(config_thickness_flux_type) // &
-                 & ' is not known', MPAS_LOG_CRIT)
-         end if
+         call mpas_log_write('Thickness flux option of ' //&
+              & trim(config_thickness_flux_type) // &
+              & 'is not known', MPAS_LOG_CRIT)
       end if
 
       ! Initialize coefficient choice for computing land ice drag

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -57,6 +57,7 @@ module ocn_diagnostics
 
    public :: ocn_diagnostic_solve, &
              ocn_diagnostic_solve_layerThicknessEdge, &
+             ocn_diagnostic_solve_sshEdge, &
              ocn_relativeVorticity_circulation, &
              ocn_vert_transport_velocity_top, &
              ocn_fuperp, &
@@ -667,6 +668,114 @@ contains
 
    end subroutine ocn_relativeVorticity_circulation!}}}
 
+!***********************************************************************
+!
+!  routine ocn_diagnostic_solve_sshEdge
+!
+!> \brief   Computes layer thickness at edge
+!> \author  Matt Turner
+!> \date    October 2020
+!> \details
+!>  This routine computes the diagnostic variables layerThickEdgeFlux
+!>  and layerThickEdgeMean. The Mean is a simple mean across the edge
+!>  but the Flux value can either be the mean or an upwind value,
+!>  depending on user input.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_diagnostic_solve_sshEdge(btrVelocity, sshCell, sshEdge)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         btrVelocity,  &!< [in] barotropic velocity
+         sshCell           !< [in] ssh at cells
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      ! Outputs are the shared variables from diagnostic_variables:
+      real (kind=RKIND), dimension(:), intent(inout) :: &
+         sshEdge !< [out] ssh on edge
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         iEdge,       &! edge and vertical loop indices
+         cell1, cell2  ! neighbor cell indices across an edge
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      sshEdge(:) = 0.0_RKIND
+      call mpas_log_write('begin sshEdge routine')
+      ! Compute edge flux based on option set on init
+      select case (thickEdgeFluxChoice)
+
+      case (thickEdgeFluxCenter)
+         ! Use centered (mean) thickness as flux value
+
+         ! Compute mean layer thickness at edge
+#ifdef MPAS_OPENACC
+         !$acc parallel loop collapse(2) &
+#else
+         !$omp parallel
+         !$omp do schedule(runtime)
+#endif
+         do iEdge = 1, nEdgesAll
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            sshEdge(iEdge) = 0.5_RKIND*(sshCell(cell1) + sshCell(cell2))
+         end do
+#ifndef MPAS_OPENACC
+         !$omp end do
+         !$omp end parallel
+#endif
+
+      case (thickEdgeFluxUpwind)
+         ! Use upwind thickness as the edge flux value
+
+#ifdef MPAS_OPENACC
+         !$acc parallel loop &
+         !$acc    present(btrVelocity, sshCell, sshEdge, cellsOnEdge) &
+         !$acc    private(cell1, cell2)
+#else
+         !$omp parallel
+         !$omp do schedule(runtime) private(cell1, cell2)
+#endif
+         do iEdge = 1, nEdgesAll
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            if (btrVelocity(iEdge) > 0.0_RKIND) then
+               sshEdge(iEdge) = sshCell(cell1)
+            elseif (btrVelocity(iEdge) < 0.0_RKIND) then
+               sshEdge(iEdge) = sshCell(cell2)
+            else
+               sshEdge(iEdge) = max(sshCell(cell1), sshCell(cell2)) 
+            end if
+         end do
+#ifndef MPAS_OPENACC
+         !$omp end do
+         !$omp end parallel
+#endif
+
+      case default
+         ! Should have been caught on init
+         call mpas_log_write('Thickness flux option unknown', &
+                             MPAS_LOG_CRIT)
+
+      end select
+      call mpas_log_write('end sshEdge routine')
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_diagnostic_solve_sshEdge!}}}
 !***********************************************************************
 !
 !  routine ocn_diagnostic_solve_layerThicknessEdge

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -39,11 +39,7 @@ module ocn_diagnostics
    use ocn_surface_land_ice_fluxes
    use ocn_vertical_advection
 
-   interface ocn_edge_var_from_cell_var_upwind
-      module procedure ocn_edge_var_from_cell_var_upwind_1d
-      module procedure ocn_edge_var_from_cell_var_upwind_2d
-   end interface
-
+   implicit none
    private
    save
 
@@ -62,7 +58,6 @@ module ocn_diagnostics
    public :: ocn_diagnostic_solve, &
              ocn_diagnostic_solve_layerThicknessEdge, &
              ocn_diagnostic_solve_wctEdge, &
-             ocn_edge_var_from_cell_var_upwind, &
              ocn_relativeVorticity_circulation, &
              ocn_vert_transport_velocity_top, &
              ocn_fuperp, &
@@ -716,7 +711,7 @@ contains
       !-----------------------------------------------------------------
 
       integer :: &
-         iEdge,       &! edge and vertical loop indices
+         iCell, iEdge, &! edge and cell loop indices
          cell1, cell2  ! neighbor cell indices across an edge
 
       real (kind=RKIND), dimension(:), allocatable :: wctCell, sshEdge
@@ -762,8 +757,30 @@ contains
          !$omp end parallel
 
          ! Use upwind thickness as the edge flux value
-         call ocn_edge_var_from_cell_var_upwind( &
-                            btrVelocity, wctCell, wctEdge)
+#ifdef MPAS_OPENACC
+         !$acc parallel loop &
+         !$acc    present(btrVelocity, sshCell, sshEdge, cellsOnEdge) &
+         !$acc    private(cell1, cell2)
+#else
+         !$omp parallel
+         !$omp do schedule(runtime) private(cell1, cell2)
+#endif
+         do iEdge = 1, nEdgesAll
+            if ( maxLevelEdgeTop(iEdge).eq.0 ) cycle
+            cell1 = cellsOnEdge(1, iEdge)
+            cell2 = cellsOnEdge(2, iEdge)
+            if (btrVelocity(iEdge) > 0.0_RKIND) then
+               wctEdge(iEdge) = wctCell(cell1)
+            elseif (btrVelocity(iEdge) < 0.0_RKIND) then
+               wctEdge(iEdge) = wctCell(cell2)
+            else
+               wctEdge(iEdge) = max(wctCell(cell1), wctCell(cell2))
+            end if
+         end do
+#ifndef MPAS_OPENACC
+         !$omp end do
+         !$omp end parallel
+#endif
          deallocate(wctCell)
 
       case default
@@ -885,8 +902,43 @@ contains
 
       case (thickEdgeFluxUpwind)
          ! Use upwind thickness as the edge flux value
-         call ocn_edge_var_from_cell_var_upwind( &
-            normalVelocity, layerThickness, layerThickEdgeFlux)
+
+#ifdef MPAS_OPENACC
+         !$acc parallel loop &
+         !$acc    present(normalVelocity, layerThickness, &
+         !$acc            minLevelEdgeBot, maxLevelEdgeTop, &
+         !$acc            layerThickEdgeFlux, cellsOnEdge) &
+         !$acc    private(k, kmin, kmax, cell1, cell2)
+#else
+         !$omp parallel
+         !$omp do schedule(runtime) private(k, kmin, kmax, cell1, cell2)
+#endif
+         do iEdge = 1, nEdgesAll
+            kmin = minLevelEdgeBot(iEdge)
+            kmax = maxLevelEdgeTop(iEdge)
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+            do k=1,nVertLevels
+               ! initialize layerThicknessEdgeFlux to avoid divide by
+               ! zero and NaN problems.
+               layerThickEdgeFlux(k,iEdge) = -1.0e34_RKIND
+            end do
+            do k = kmin,kmax
+               if (normalVelocity(k,iEdge) > 0.0_RKIND) then
+                  layerThickEdgeFlux(k,iEdge) = layerThickness(k,cell1)
+               elseif (normalVelocity(k,iEdge) < 0.0_RKIND) then
+                  layerThickEdgeFlux(k,iEdge) = layerThickness(k,cell2)
+               else
+                  layerThickEdgeFlux(k,iEdge) = &
+                                      max(layerThickness(k,cell1), &
+                                          layerThickness(k,cell2))
+               end if
+            end do
+         end do
+#ifndef MPAS_OPENACC
+         !$omp end do
+         !$omp end parallel
+#endif
 
       case (thickEdgeFluxConstant)
          ! Use linearized version H*u where H is constant in time
@@ -995,161 +1047,6 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_diagnostic_solve_layerThicknessEdge!}}}
-
-!***********************************************************************
-!
-!  routine ocn_edge_var_from_cell_var_upwind_2d
-!
-!> \brief   Computes edge variable from upwind cell variable
-!> \author  Matt Turner
-!> \date    October 2020
-!> \details
-!
-!-----------------------------------------------------------------------
-
-   subroutine ocn_edge_var_from_cell_var_upwind_2d(&
-                   normalVelocity, cellVar, edgeVar)!{{{
-
-      !-----------------------------------------------------------------
-      ! input variables
-      !-----------------------------------------------------------------
-
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         normalVelocity,  &!< [in] transport
-         cellVar           !< [in] layer thickness at cell center
-
-      !-----------------------------------------------------------------
-      ! output variables
-      !-----------------------------------------------------------------
-
-      real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         edgeVar
-
-      !-----------------------------------------------------------------
-      ! local variables
-      !-----------------------------------------------------------------
-
-      integer :: &
-         iEdge, k,     &! edge and vertical loop indices
-         cell1, cell2, &! neighbor cell indices across an edge
-         kmin, kmax     ! min,max active vertical levels
-
-      ! End preamble
-      !-----------------------------------------------------------------
-      ! Begin code
-
-      ! Use upwind thickness as the edge flux value
-
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(normalVelocity, layerThickness, &
-      !$acc            minLevelEdgeBot, maxLevelEdgeTop, &
-      !$acc            layerThickEdgeFlux, cellsOnEdge) &
-      !$acc    private(k, kmin, kmax, cell1, cell2)
-#else
-      !$omp parallel
-      !$omp do schedule(runtime) private(k, kmin, kmax, cell1, cell2)
-#endif
-      do iEdge = 1, nEdgesAll
-         if ( maxLevelEdgeTop(iEdge).eq.0 ) cycle
-         kmin = minLevelEdgeBot(iEdge)
-         kmax = maxLevelEdgeTop(iEdge)
-         cell1 = cellsOnEdge(1,iEdge)
-         cell2 = cellsOnEdge(2,iEdge)
-         ! initialize layerThicknessEdgeFlux to avoid divide by
-         ! zero and NaN problems.
-         edgeVar(:,iEdge) = -1.0e34_RKIND
-         do k = kmin,kmax
-            if (normalVelocity(k,iEdge) > 0.0_RKIND) then
-               edgeVar(k,iEdge) = cellVar(k,cell1)
-            elseif (normalVelocity(k,iEdge) < 0.0_RKIND) then
-               edgeVar(k,iEdge) = cellVar(k,cell2)
-            else
-               edgeVar(k,iEdge) = max(cellVar(k,cell1), &
-                                      cellVar(k,cell2))
-            end if
-         end do
-      end do
-#ifndef MPAS_OPENACC
-      !$omp end do
-      !$omp end parallel
-#endif
-
-   !--------------------------------------------------------------------
-
-   end subroutine ocn_edge_var_from_cell_var_upwind_2d!}}}
-
-!***********************************************************************
-!
-!  routine ocn_edge_var_from_cell_var_upwind_1d
-!
-!> \brief   Computes edge variable from upwind cell variable
-!> \author  Matt Turner
-!> \date    October 2020
-!> \details
-!
-!-----------------------------------------------------------------------
-
-   subroutine ocn_edge_var_from_cell_var_upwind_1d(&
-                   btrVelocity, cellVar, edgeVar)!{{{
-
-      !-----------------------------------------------------------------
-      ! input variables
-      !-----------------------------------------------------------------
-
-      real (kind=RKIND), dimension(:), intent(in) :: &
-         btrVelocity,  &!< [in] transport
-         cellVar           !< [in] layer thickness at cell center
-
-      !-----------------------------------------------------------------
-      ! output variables
-      !-----------------------------------------------------------------
-
-      real (kind=RKIND), dimension(:), intent(inout) :: &
-         edgeVar
-
-      !-----------------------------------------------------------------
-      ! local variables
-      !-----------------------------------------------------------------
-
-      integer :: &
-         iEdge, k,     &! edge and vertical loop indices
-         cell1, cell2   ! neighbor cell indices across an edge
-
-      ! End preamble
-      !-----------------------------------------------------------------
-      ! Begin code
-
-      ! Use upwind thickness as the edge flux value
-
-#ifdef MPAS_OPENACC
-      !$acc parallel loop &
-      !$acc    present(btrVelocity, sshCell, sshEdge, cellsOnEdge) &
-      !$acc    private(cell1, cell2)
-#else
-      !$omp parallel
-      !$omp do schedule(runtime) private(cell1, cell2)
-#endif
-      do iEdge = 1, nEdgesAll
-         if ( maxLevelEdgeTop(iEdge).eq.0 ) cycle
-         cell1 = cellsOnEdge(1, iEdge)
-         cell2 = cellsOnEdge(2, iEdge)
-         if (btrVelocity(iEdge) > 0.0_RKIND) then
-            edgeVar(iEdge) = cellVar(cell1)
-         elseif (btrVelocity(iEdge) < 0.0_RKIND) then
-            edgeVar(iEdge) = cellVar(cell2)
-         else
-            edgeVar(iEdge) = max(cellVar(cell1), cellVar(cell2))
-         end if
-      end do
-#ifndef MPAS_OPENACC
-      !$omp end do
-      !$omp end parallel
-#endif
-
-   !--------------------------------------------------------------------
-
-   end subroutine ocn_edge_var_from_cell_var_upwind_1d!}}}
 
 !***********************************************************************
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -730,8 +730,6 @@ contains
       select case (thickEdgeFluxChoice)
 
       case (thickEdgeFluxCenter)
-         allocate(sshEdge(nEdgesAll))
-         sshEdge(:) = -1.0e34_RKIND
          ! Use centered (mean) thickness as flux value
 
          ! Compute mean layer thickness at edge
@@ -739,19 +737,18 @@ contains
          !$acc parallel loop collapse(2) &
 #else
          !$omp parallel
-         !$omp do schedule(runtime)
+         !$omp do schedule(runtime) private (cell1, cell2)
 #endif
          do iEdge = 1, nEdgesAll
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
-            sshEdge(iEdge) = 0.5_RKIND*(sshCell(cell1) + sshCell(cell2))
-            wctEdge(iEdge) = sshEdge(iEdge) + bottomDepthEdge(iEdge)
+            wctEdge(iEdge) = 0.5_RKIND*(sshCell(cell1) + sshCell(cell2)) &
+                             + bottomDepthEdge(iEdge)
          end do
 #ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
 #endif
-         deallocate(sshEdge)
 
       case (thickEdgeFluxUpwind)
          allocate(wctCell(nCellsAll))

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -39,7 +39,11 @@ module ocn_diagnostics
    use ocn_surface_land_ice_fluxes
    use ocn_vertical_advection
 
-   implicit none
+   interface ocn_edge_var_from_cell_var_upwind
+      module procedure ocn_edge_var_from_cell_var_upwind_1d
+      module procedure ocn_edge_var_from_cell_var_upwind_2d
+   end interface
+
    private
    save
 
@@ -57,7 +61,8 @@ module ocn_diagnostics
 
    public :: ocn_diagnostic_solve, &
              ocn_diagnostic_solve_layerThicknessEdge, &
-             ocn_diagnostic_solve_sshEdge, &
+             ocn_diagnostic_solve_wctEdge, &
+             ocn_edge_var_from_cell_var_upwind, &
              ocn_relativeVorticity_circulation, &
              ocn_vert_transport_velocity_top, &
              ocn_fuperp, &
@@ -683,15 +688,20 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_diagnostic_solve_sshEdge(btrVelocity, sshCell, sshEdge)!{{{
+   subroutine ocn_diagnostic_solve_wctEdge(btrVelocity, sshCell, &
+                         bottomDepthEdge, wctEdge)!{{{
 
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:), intent(in) :: &
-         btrVelocity,  &!< [in] barotropic velocity
-         sshCell           !< [in] ssh at cells
+         btrVelocity,   &!< [in] barotropic velocity
+         sshCell,       &!< ssh at cells, used for centered water column
+                         !< thickness
+         bottomDepthEdge !< bottom depth centered at edges, used for
+                         !< centered water column thickness
+      ! bottomDepth is already present
 
       !-----------------------------------------------------------------
       ! output variables
@@ -699,7 +709,7 @@ contains
 
       ! Outputs are the shared variables from diagnostic_variables:
       real (kind=RKIND), dimension(:), intent(inout) :: &
-         sshEdge !< [out] ssh on edge
+         wctEdge !< [out] wct on edge
 
       !-----------------------------------------------------------------
       ! local variables
@@ -709,16 +719,20 @@ contains
          iEdge,       &! edge and vertical loop indices
          cell1, cell2  ! neighbor cell indices across an edge
 
+      real (kind=RKIND), dimension(:), allocatable :: wctCell, sshEdge
+
       ! End preamble
       !-----------------------------------------------------------------
       ! Begin code
 
-      sshEdge(:) = 0.0_RKIND
-      call mpas_log_write('begin sshEdge routine')
+      call mpas_timer_start("wctEdge")
+      wctEdge(:) = -1.0e34_RKIND
       ! Compute edge flux based on option set on init
       select case (thickEdgeFluxChoice)
 
       case (thickEdgeFluxCenter)
+         allocate(sshEdge(nEdgesAll))
+         sshEdge(:) = -1.0e34_RKIND
          ! Use centered (mean) thickness as flux value
 
          ! Compute mean layer thickness at edge
@@ -732,38 +746,28 @@ contains
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
             sshEdge(iEdge) = 0.5_RKIND*(sshCell(cell1) + sshCell(cell2))
+            wctEdge(iEdge) = sshEdge(iEdge) + bottomDepthEdge(iEdge)
          end do
 #ifndef MPAS_OPENACC
          !$omp end do
          !$omp end parallel
 #endif
+         deallocate(sshEdge)
 
       case (thickEdgeFluxUpwind)
-         ! Use upwind thickness as the edge flux value
-
-#ifdef MPAS_OPENACC
-         !$acc parallel loop &
-         !$acc    present(btrVelocity, sshCell, sshEdge, cellsOnEdge) &
-         !$acc    private(cell1, cell2)
-#else
+         allocate(wctCell(nCellsAll))
          !$omp parallel
-         !$omp do schedule(runtime) private(cell1, cell2)
-#endif
-         do iEdge = 1, nEdgesAll
-            cell1 = cellsOnEdge(1,iEdge)
-            cell2 = cellsOnEdge(2,iEdge)
-            if (btrVelocity(iEdge) > 0.0_RKIND) then
-               sshEdge(iEdge) = sshCell(cell1)
-            elseif (btrVelocity(iEdge) < 0.0_RKIND) then
-               sshEdge(iEdge) = sshCell(cell2)
-            else
-               sshEdge(iEdge) = max(sshCell(cell1), sshCell(cell2)) 
-            end if
-         end do
-#ifndef MPAS_OPENACC
+         !$omp do schedule(runtime)
+         do iCell = 1, nCellsAll
+            wctCell(iCell) = sshCell(iCell) + bottomDepth(iCell)
+         end do ! cell loop for ssh
          !$omp end do
          !$omp end parallel
-#endif
+
+         ! Use upwind thickness as the edge flux value
+         call ocn_edge_var_from_cell_var_upwind( &
+                            btrVelocity, wctCell, wctEdge)
+         deallocate(wctCell)
 
       case default
          ! Should have been caught on init
@@ -771,11 +775,12 @@ contains
                              MPAS_LOG_CRIT)
 
       end select
-      call mpas_log_write('end sshEdge routine')
+      call mpas_timer_stop("wctEdge")
 
    !--------------------------------------------------------------------
 
-   end subroutine ocn_diagnostic_solve_sshEdge!}}}
+   end subroutine ocn_diagnostic_solve_wctEdge!}}}
+
 !***********************************************************************
 !
 !  routine ocn_diagnostic_solve_layerThicknessEdge
@@ -884,43 +889,8 @@ contains
 
       case (thickEdgeFluxUpwind)
          ! Use upwind thickness as the edge flux value
-
-#ifdef MPAS_OPENACC
-         !$acc parallel loop &
-         !$acc    present(normalVelocity, layerThickness, &
-         !$acc            minLevelEdgeBot, maxLevelEdgeTop, &
-         !$acc            layerThickEdgeFlux, cellsOnEdge) &
-         !$acc    private(k, kmin, kmax, cell1, cell2)
-#else
-         !$omp parallel
-         !$omp do schedule(runtime) private(k, kmin, kmax, cell1, cell2)
-#endif
-         do iEdge = 1, nEdgesAll
-            kmin = minLevelEdgeBot(iEdge)
-            kmax = maxLevelEdgeTop(iEdge)
-            cell1 = cellsOnEdge(1,iEdge)
-            cell2 = cellsOnEdge(2,iEdge)
-            do k=1,nVertLevels
-               ! initialize layerThicknessEdgeFlux to avoid divide by
-               ! zero and NaN problems.
-               layerThickEdgeFlux(k,iEdge) = -1.0e34_RKIND
-            end do
-            do k = kmin,kmax
-               if (normalVelocity(k,iEdge) > 0.0_RKIND) then
-                  layerThickEdgeFlux(k,iEdge) = layerThickness(k,cell1)
-               elseif (normalVelocity(k,iEdge) < 0.0_RKIND) then
-                  layerThickEdgeFlux(k,iEdge) = layerThickness(k,cell2)
-               else
-                  layerThickEdgeFlux(k,iEdge) = &
-                                      max(layerThickness(k,cell1), &
-                                          layerThickness(k,cell2))
-               end if
-            end do
-         end do
-#ifndef MPAS_OPENACC
-         !$omp end do
-         !$omp end parallel
-#endif
+         call ocn_edge_var_from_cell_var_upwind( &
+            normalVelocity, layerThickness, layerThickEdgeFlux)
 
       case (thickEdgeFluxConstant)
          ! Use linearized version H*u where H is constant in time
@@ -1029,6 +999,160 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_diagnostic_solve_layerThicknessEdge!}}}
+
+!***********************************************************************
+!
+!  routine ocn_edge_var_from_cell_var_upwind_2d
+!
+!> \brief   Computes edge variable from upwind cell variable
+!> \author  Matt Turner
+!> \date    October 2020
+!> \details
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_edge_var_from_cell_var_upwind_2d(&
+                   normalVelocity, cellVar, edgeVar)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalVelocity,  &!< [in] transport
+         cellVar           !< [in] layer thickness at cell center
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         edgeVar
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         iEdge, k,     &! edge and vertical loop indices
+         cell1, cell2, &! neighbor cell indices across an edge
+         kmin, kmax     ! min,max active vertical levels
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      ! Use upwind thickness as the edge flux value
+
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(normalVelocity, layerThickness, &
+      !$acc            minLevelEdgeBot, maxLevelEdgeTop, &
+      !$acc            layerThickEdgeFlux, cellsOnEdge) &
+      !$acc    private(k, kmin, kmax, cell1, cell2)
+#else
+      !$omp parallel
+      !$omp do schedule(runtime) private(k, kmin, kmax, cell1, cell2)
+#endif
+      do iEdge = 1, nEdgesAll
+         kmin = minLevelEdgeBot(iEdge)
+         kmax = maxLevelEdgeTop(iEdge)
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+         ! initialize layerThicknessEdgeFlux to avoid divide by
+         ! zero and NaN problems.
+         edgeVar(:,iEdge) = -1.0e34_RKIND
+         do k = kmin,kmax
+            if (normalVelocity(k,iEdge) > 0.0_RKIND) then
+               edgeVar(k,iEdge) = cellVar(k,cell1)
+            elseif (normalVelocity(k,iEdge) < 0.0_RKIND) then
+               edgeVar(k,iEdge) = cellVar(k,cell2)
+            else
+               edgeVar(k,iEdge) = max(cellVar(k,cell1), &
+                                      cellVar(k,cell2))
+            end if
+         end do
+      end do
+#ifndef MPAS_OPENACC
+      !$omp end do
+      !$omp end parallel
+#endif
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_edge_var_from_cell_var_upwind_2d!}}}
+
+!***********************************************************************
+!
+!  routine ocn_edge_var_from_cell_var_upwind_1d
+!
+!> \brief   Computes edge variable from upwind cell variable
+!> \author  Matt Turner
+!> \date    October 2020
+!> \details
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_edge_var_from_cell_var_upwind_1d(&
+                   btrVelocity, cellVar, edgeVar)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         btrVelocity,  &!< [in] transport
+         cellVar           !< [in] layer thickness at cell center
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:), intent(inout) :: &
+         edgeVar
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         iEdge, k,     &! edge and vertical loop indices
+         cell1, cell2   ! neighbor cell indices across an edge
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      ! Use upwind thickness as the edge flux value
+
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(btrVelocity, sshCell, sshEdge, cellsOnEdge) &
+      !$acc    private(cell1, cell2)
+#else
+      !$omp parallel
+      !$omp do schedule(runtime) private(cell1, cell2)
+#endif
+      do iEdge = 1, nEdgesAll
+         if ( maxLevelEdgeTop(iEdge) < 1 ) cycle
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+         if (btrVelocity(iEdge) > 0.0_RKIND) then
+            edgeVar(iEdge) = cellVar(cell1)
+         elseif (btrVelocity(iEdge) < 0.0_RKIND) then
+            edgeVar(iEdge) = cellVar(cell2)
+         else
+            edgeVar(iEdge) = max(cellVar(cell1), cellVar(cell2))
+         end if
+      end do
+#ifndef MPAS_OPENACC
+      !$omp end do
+      !$omp end parallel
+#endif
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_edge_var_from_cell_var_upwind_1d!}}}
 
 !***********************************************************************
 !


### PR DESCRIPTION
This PR adds the option to use upwinded advection with the split-explicit time integrator. Formerly, upwinded advection was only available with the RK4 time integrator.

For the barotropic subcycle's SSH predictor and corrector steps, the barotropic velocity is first computed on edges, then used to determine the water column thickness on edges (either centered or upwinded), then both barotropic velocity and water column thickness on edges is used to compute the SSH tendency on cells.

We also compute the normal velocity correction factor using `layerThickEdgeFlux`, which is updated if upwinded advection is used.

Upwinding of the water column thickness is done with a new diagnostic subroutine, `ocn_diagnostic_solve_wctEdge`, which is modeled after `ocn_diagnostic_solve_layerThicknessEdge`.

[non-BFB] (machine-precision diffs on some compiler, machine combinations, BFB on others)