### PR TITLE
EAM: split AODSO4 into tropospheric and stratospheric components

### DIFF
--- a/components/eam/src/physics/cam/modal_aer_opt.F90
+++ b/components/eam/src/physics/cam/modal_aer_opt.F90
@@ -1299,6 +1299,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
          pomaod(idxnite(i))     = fillvalue
          soaaod(idxnite(i))     = fillvalue
          bcaod(idxnite(i))      = fillvalue
+         seasaltaod(idxnite(i)) = fillvalue
 #if ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
          momaod(idxnite(i)) = fillvalue
 #elif ( defined MODAL_AERO_9MODE )


### PR DESCRIPTION
This small PR splits AODSO4 into its stratospheric and tropospheric components following previous (v2) practice.

Note that there is already "stratospheric sulfate AOD" (from v3) that's not modified by this PR. This implementation has two distinct advantages over the current one from v3: 1) it follows the logic of previous implementation of speciated AODs; 2) it follows the naming scheme of the previous implementation and aligns it with the naming of burdens (SAODVIS vs AODSO4_STR, cf ABURDENSO4_STR).

[BFB]

------------------------------------------------------------------------------------------
Follows #5774

Cherry picks 8e7bb6b from #5817 (BFB bugfix)

I don't know if people want this or not, but I definitely would like to have this output in upcoming simulations. Hence, submitting this PR for the record. I would like to also cherry-pick 8e7bb6b to this PR as well before I start my simulations.
