### PR TITLE
bug fix in crm_physics.F90

### DIFF
--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -1090,8 +1090,8 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf2d, cam_in, cam_out, 
          ! Set surface flux variables
          !------------------------------------------------------------------------------------------
          if (phys_do_flux_avg()) then
-            call pbuf_get_field(pbuf_chunk, pbuf_get_index('LHFLX'), shf_ptr)
-            call pbuf_get_field(pbuf_chunk, pbuf_get_index('SHFLX'), lhf_ptr)
+            call pbuf_get_field(pbuf_chunk, pbuf_get_index('SHFLX'), shf_ptr)
+            call pbuf_get_field(pbuf_chunk, pbuf_get_index('LHFLX'), lhf_ptr)
             call pbuf_get_field(pbuf_chunk, pbuf_get_index('TAUX'),  wsx_ptr)
             call pbuf_get_field(pbuf_chunk, pbuf_get_index('TAUY'),  wsy_ptr)
             shf_tmp = shf_ptr


### PR DESCRIPTION
Fix a bug  in which surface sensible and latent surface fluxes have been unintentionally swapped in the CRM interface. The impact of this fix will generally be small because these fluxes are currently only used to influence the internal CRM friction calculation. The application of suface fluxes in the PBL scheme outside of the CRM (in tphysac) are still correct, so there is no fundamental impact to the water mass or energy budgets. 

[non-BFB] for MMF cases.