### PR TITLE
fixes indexing bug in mpas cvmix interface

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
@@ -471,7 +471,7 @@ contains
               do k=minLevelCell(iCell),maxLevelCell(iCell)
                   Nsqr_iface(k) = BVFSmoothed(k)
               enddo
-              Nsqr_iface(minLevelCell(iCell):minLevelCell(iCell)-1) = Nsqr_iface(minLevelCell(iCell))
+              Nsqr_iface(1:minLevelCell(iCell)-1) = Nsqr_iface(minLevelCell(iCell))
               k=min(maxLevelCell(iCell)+1,nVertLevels)
               Nsqr_iface(k:maxLevelCell(iCell)+1) = Nsqr_iface(k-1)
 


### PR DESCRIPTION
There is a small indexing error in the MPAS ocean interface to CVMix. It has only emerged in GPU configurations, but may emerge in cases where minLevelCell is not equal to 1

Fixes #5840

[BFB] 