### PR TITLE
EAM: increase mode_defs size from 100 to 1000

### DIFF
--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -4375,7 +4375,7 @@ Approximate value of decay time at model top (days);
 Default: 0.0D0
 </entry>
 
-<entry id="mode_defs" type="char*256(100)"  category="radiation"
+<entry id="mode_defs" type="char*256(1000)"  category="radiation"
        group="rad_cnst_nl" valid_values="" >
 Definitions for the aerosol modes that may be used in the rad_climate and
 rad_diag_* variables.


### PR DESCRIPTION
This small PR increases the mode_defs size from 100 to 1000.

The mode_defs namelist parameter can be used to set up and manipulate aerosol species and their radiative configurations. Currently, the size is restricted to 100 (I guess 1D array of size 100, but I can never be sure with Fortran conventions). This size s relatively small, but covers most use cases used by most developers/staff. However, it hinders more sophsiticated manipulation of the modal aerosol model and its radiative properties. To take fuller advantage, I propose increasing it to 1000.

I will list how mode_defs typically looks in standard configurations and explain _briefly_ how it could be modified.

I am requesting reviews from technical people as well as v3 atmosphere integrators because this is a configuration issue and not a development issue, and so I am not going to request review from domain staff. It shouldn't impact any user except make the lives of ones (like me) attempting to do esoteric things with the model and push it to corner cases. Perhaps there is something I am missing about the dangers of vastly increasing the size of this parameter? I could settle for 300 if needed.

[BFB]