### PR TITLE
Fixes for multiple issues in gustiness calculations.

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -3931,9 +3931,6 @@ if ( $linearize_pbl_winds =~ /$TRUE/io ) {
     }
 }
 
-# Export gustiness to surface components.
-add_default($nl, 'export_gustiness');
-
 # Use Convective water in radiation
 add_default($nl, 'conv_water_in_rad');
 

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1140,9 +1140,6 @@
 <!-- Linearization of boundary layer winds -->
 <linearize_pbl_winds>.false.</linearize_pbl_winds>
 
-<!-- Export gustiness value -->
-<export_gustiness>.false.</export_gustiness>
-
 <!-- MMF CRM mean state acceleration -->
 <use_crm_accel    >.false.</use_crm_accel>
 <crm_accel_uv     >.false.</crm_accel_uv>

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -4066,19 +4066,6 @@ If .true., a linearization of the response of the pbl scheme to surface stresses
 is sent to the coupler every time step, using the fields 'wsresp' and 'tau_est'.
 </entry>
 
-<entry id="export_gustiness" type="logical" category="pbl"
-       group="phys_ctl_nl" valid_values="" >
-If .true., a gustiness value will be exported to the coupler, which allows
-surface components to distinguish between the effect of mean wind and gustiness
-when calculating fluxes (and in particular surface drag).
-
-If .false., no extra value is exported, and gustiness is instead applied by the
-atmosphere by scaling up the exported wind fields (ubot and vbot). This is
-simpler and requires slightly less coupling overhead, but produces numerical
-artifacts (oscillations) in surface stresses, particularly when the gustiness is
-large compared with the mean wind.
-</entry>
-
 
 <!-- Flags for implementing code modifications under polar project -->
 

--- a/components/eam/cime_config/buildnml
+++ b/components/eam/cime_config/buildnml
@@ -61,6 +61,11 @@ def buildnml(case, caseroot, compname):
 
     if not os.path.isdir(eamconf_dir): os.mkdir(eamconf_dir)
 
+    # Coupler and surface components now required to accept gustiness when EAM
+    # is used as the atmosphere model, unless SCREAM physics is used.
+    if not (atm_gustiness or "-DSCREAM" in cam_config_opts):
+        sys.exit("\n *** STOP: EAM requires ATM_SUPPLIES_GUSTINESS=TRUE. ***\n")
+
     #--------------------------------------------------------------------
     # Invoke eam configure - output will go in $CASEBUILD/eamconf
     #--------------------------------------------------------------------
@@ -191,7 +196,6 @@ def buildnml(case, caseroot, compname):
         if cam_branch_file: infile_text += " cam_branch_file = {} \n".format(cam_branch_file)
         if debug:           infile_text += " state_debug_checks = .true. \n"
         if linearize_pbl_winds: infile_text += " linearize_pbl_winds = .true. \n"
-        if atm_gustiness: infile_text += " export_gustiness = .true. \n"
 
         create_namelist_infile(case,
                                "{}/user_nl_eam{}".format(caseroot, inst_string),

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/implicit_stress/shell_commands
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/implicit_stress/shell_commands
@@ -1,2 +1,1 @@
-./xmlchange ATM_SUPPLIES_GUSTINESS="TRUE"
 ./xmlchange ATM_FLUX_INTEGRATION_METHOD="implicit_stress"

--- a/components/eam/src/control/camsrfexch.F90
+++ b/components/eam/src/control/camsrfexch.F90
@@ -104,6 +104,7 @@ module camsrfexch
      real(r8), allocatable :: tref(:)       ! ref height surface air temp
      real(r8), allocatable :: qref(:)       ! ref height specific humidity 
      real(r8), allocatable :: u10(:)        ! 10m wind speed
+     real(r8), allocatable :: u10withgusts(:) ! 10m wind speed with gustiness
      real(r8), allocatable :: ts(:)         ! merged surface temp 
      real(r8), allocatable :: sst(:)        ! sea surface temp
      real(r8), allocatable :: snowhland(:)  ! snow depth (liquid water equivalent) over land
@@ -219,6 +220,9 @@ CONTAINS
        allocate (cam_in(c)%u10(pcols), stat=ierror)
        if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error u10')
 
+       allocate (cam_in(c)%u10withgusts(pcols), stat=ierror)
+       if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error u10withgusts')
+
        allocate (cam_in(c)%ts(pcols), stat=ierror)
        if ( ierror /= 0 ) call endrun('HUB2ATM_ALLOC error: allocation error ts')
 
@@ -308,6 +312,7 @@ CONTAINS
        cam_in(c)%tref     (:) = 0._r8
        cam_in(c)%qref     (:) = 0._r8
        cam_in(c)%u10      (:) = 0._r8
+       cam_in(c)%u10withgusts(:) = 0._r8
        cam_in(c)%ts       (:) = 0._r8
        cam_in(c)%sst      (:) = 0._r8
        cam_in(c)%snowhland(:) = 0._r8
@@ -617,6 +622,7 @@ CONTAINS
           deallocate(cam_in(c)%tref)
           deallocate(cam_in(c)%qref)
           deallocate(cam_in(c)%u10)
+          deallocate(cam_in(c)%u10withgusts)
           deallocate(cam_in(c)%ts)
           deallocate(cam_in(c)%sst)
           deallocate(cam_in(c)%snowhland)

--- a/components/eam/src/control/camsrfexch.F90
+++ b/components/eam/src/control/camsrfexch.F90
@@ -713,7 +713,6 @@ subroutine cam_export(state,cam_out,pbuf)
    integer :: vmag_gust_idx, wsresp_idx, tau_est_idx
    real(r8) :: umb(pcols), vmb(pcols),vmag(pcols)
    logical :: linearize_pbl_winds ! Send wsresp and tau_est to coupler.
-   logical :: export_gustiness ! Send vmag_gust to coupler
 
    real(r8), pointer :: prec_dp(:)                 ! total precipitation   from ZM convection
    real(r8), pointer :: snow_dp(:)                 ! snow from ZM   convection
@@ -732,8 +731,7 @@ subroutine cam_export(state,cam_out,pbuf)
    lchnk = state%lchnk
    ncol  = state%ncol
 
-   call phys_getopts(linearize_pbl_winds_out=linearize_pbl_winds, &
-                     export_gustiness_out=export_gustiness)
+   call phys_getopts(linearize_pbl_winds_out=linearize_pbl_winds)
 
    prec_dp_idx = pbuf_get_index('PREC_DP')
    snow_dp_idx = pbuf_get_index('SNOW_DP')
@@ -765,18 +763,9 @@ subroutine cam_export(state,cam_out,pbuf)
 !PMA adds gustiness to surface scheme c20181128
 
    do i=1,ncol
-      if (export_gustiness) then
-         cam_out%ubot(i)  = state%u(i,pver)
-         cam_out%vbot(i)  = state%v(i,pver)
-         cam_out%ugust(i) = vmag_gust(i)
-      else
-         ! If not exporting gustiness as a separate field, we apply it here.
-         umb(i)           = state%u(i,pver)
-         vmb(i)           = state%v(i,pver)
-         vmag(i)          = max(1.e-5_r8,sqrt( umb(i)**2._r8 + vmb(i)**2._r8))
-         cam_out%ubot(i)  = state%u(i,pver) * ((vmag_gust(i)+vmag(i))/vmag(i))
-         cam_out%vbot(i)  = state%v(i,pver) * ((vmag_gust(i)+vmag(i))/vmag(i))
-      end if
+      cam_out%ubot(i)  = state%u(i,pver)
+      cam_out%vbot(i)  = state%v(i,pver)
+      cam_out%ugust(i) = vmag_gust(i)
       cam_out%tbot(i)  = state%t(i,pver)
       cam_out%thbot(i) = state%t(i,pver) * state%exner(i,pver)
       cam_out%zbot(i)  = state%zm(i,pver)

--- a/components/eam/src/cpl/atm_import_export.F90
+++ b/components/eam/src/cpl/atm_import_export.F90
@@ -254,11 +254,10 @@ contains
     integer :: avsize, avnat
     integer :: i,m,c,n,ig       ! indices
     integer :: ncols            ! Number of columns
-    logical :: linearize_pbl_winds, export_gustiness
+    logical :: linearize_pbl_winds
     !-----------------------------------------------------------------------
 
-    call phys_getopts(linearize_pbl_winds_out=linearize_pbl_winds, &
-                      export_gustiness_out=export_gustiness)
+    call phys_getopts(linearize_pbl_winds_out=linearize_pbl_winds)
 
     ! Copy from component arrays into chunk array data structure
     ! Rearrange data from chunk structure into lat-lon buffer and subsequently
@@ -276,7 +275,9 @@ contains
              a2x(index_a2x_Sa_wsresp ,ig) = cam_out(c)%wsresp(i)
              a2x(index_a2x_Sa_tau_est,ig) = cam_out(c)%tau_est(i)
           end if
-          if (export_gustiness) then
+          ! This check is only for SCREAMv0; otherwise gustiness should always
+          ! be exported.
+          if (index_a2x_Sa_ugust /= 0) then
              a2x(index_a2x_Sa_ugust  ,ig) = cam_out(c)%ugust(i)
           end if
           a2x(index_a2x_Sa_tbot   ,ig) = cam_out(c)%tbot(i)   

--- a/components/eam/src/cpl/atm_import_export.F90
+++ b/components/eam/src/cpl/atm_import_export.F90
@@ -98,6 +98,7 @@ contains
           cam_in(c)%tref(i)      =  x2a(index_x2a_Sx_tref,  ig)  
           cam_in(c)%qref(i)      =  x2a(index_x2a_Sx_qref,  ig)
           cam_in(c)%u10(i)       =  x2a(index_x2a_Sx_u10,   ig)
+          cam_in(c)%u10withgusts(i) = x2a(index_x2a_Sx_u10withgusts, ig)
           cam_in(c)%icefrac(i)   =  x2a(index_x2a_Sf_ifrac, ig)  
           cam_in(c)%ocnfrac(i)   =  x2a(index_x2a_Sf_ofrac, ig)
           cam_in(c)%landfrac(i)  =  x2a(index_x2a_Sf_lfrac, ig)

--- a/components/eam/src/cpl/cam_cpl_indices.F90
+++ b/components/eam/src/cpl/cam_cpl_indices.F90
@@ -86,6 +86,7 @@ module cam_cpl_indices
   integer :: index_x2a_So_ssq          ! surface saturation specific humidity in ocean 
   integer :: index_x2a_Sl_ddvel        ! dry deposition velocities from land
   integer :: index_x2a_Sx_u10          ! 10m wind
+  integer :: index_x2a_Sx_u10withgusts ! 10m wind with gusts
 
 contains
 
@@ -122,6 +123,7 @@ contains
     index_x2a_Sf_lfrac      = mct_avect_indexra(x2a,'Sf_lfrac')
 
     index_x2a_Sx_u10        = mct_avect_indexra(x2a,'Sx_u10')
+    index_x2a_Sx_u10withgusts = mct_avect_indexra(x2a,'Sx_u10withgusts')
     index_x2a_Faxx_taux     = mct_avect_indexra(x2a,'Faxx_taux')
     index_x2a_Faxx_tauy     = mct_avect_indexra(x2a,'Faxx_tauy')
     index_x2a_Faxx_lat      = mct_avect_indexra(x2a,'Faxx_lat')

--- a/components/eam/src/physics/cam/cam_diagnostics.F90
+++ b/components/eam/src/physics/cam/cam_diagnostics.F90
@@ -649,6 +649,7 @@ subroutine diag_init()
     standard_name = 'specific_humidity')
    call addfld ('U10',horiz_only,    'A','m/s','10m wind speed', &
      standard_name='wind_speed')
+   call addfld ('U10WITHGUSTS',horiz_only,    'A','m/s','10m wind speed with gustiness effects included')
    call addfld ('RHREFHT',horiz_only,    'A','1','Reference height relative humidity')
 
    call addfld ('LANDFRAC',horiz_only,    'A','1','Fraction of sfc area covered by land')
@@ -2139,6 +2140,7 @@ subroutine diag_surf (cam_in, cam_out, ps, trefmxav, trefmnav )
     call outfld('TREFHTMN', cam_in%tref,      pcols, lchnk)
     call outfld('QREFHT',   cam_in%qref,      pcols, lchnk)
     call outfld('U10',      cam_in%u10,       pcols, lchnk)
+    call outfld('U10WITHGUSTS', cam_in%u10withgusts, pcols, lchnk)
 ! 
 ! Calculate and output reference height RH (RHREFHT)
 

--- a/components/eam/src/physics/cam/clubb_intr.F90
+++ b/components/eam/src/physics/cam/clubb_intr.F90
@@ -1510,7 +1510,6 @@ end subroutine clubb_init_cnst
    real(r8) :: gprec
    real(r8) :: prec_gust(pcols)
    real(r8) :: vmag_gust_dp(pcols),vmag_gust_cl(pcols)
-   real(r8) :: vmag(pcols)
    real(r8) :: gust_fac(pcols)
    real(r8) :: umb(pcols), vmb(pcols),up2b(pcols),vp2b(pcols)
    real(r8),parameter :: gust_facl = 1.2_r8 !gust fac for land
@@ -1527,7 +1526,7 @@ end subroutine clubb_init_cnst
 ! ZM gustiness equation below from Redelsperger et al. (2000)
 ! numbers are coefficients of the empirical equation
 
-   ugust(gprec,gfac) = gfac*log(1._R8+57801.6_R8*gprec-3.55332096e7_R8*(gprec**2.0_R8))
+   ugust(gprec) = log(1._R8+57801.6_R8*gprec-3.55332096e7_R8*(gprec**2.0_R8))
 
 #endif
    det_s(:)   = 0.0_r8
@@ -2967,12 +2966,11 @@ end subroutine clubb_init_cnst
            else
              gust_fac(i)   = gust_faco
            endif
-           vmag(i)         = max(1.e-5_r8,sqrt( umb(i)**2._r8 + vmb(i)**2._r8))
-           vmag_gust_dp(i) = ugust(min(prec_gust(i),6.94444e-4_r8),gust_fac(i)) ! Limit for the ZM gustiness equation set in Redelsperger et al. (2000)
-           vmag_gust_dp(i) = max(0._r8, vmag_gust_dp(i) )!/ vmag(i))
-           vmag_gust_cl(i) = gust_facc*(sqrt(max(0._r8,up2b(i)+vp2b(i))+vmag(i)**2._r8)-vmag(i))
-           vmag_gust_cl(i) = max(0._r8, vmag_gust_cl(i) )!/ vmag(i))
-           vmag_gust(i)    = vmag_gust_cl(i) + vmag_gust_dp(i)
+           vmag_gust_dp(i) = ugust(min(prec_gust(i),6.94444e-4_r8)) ! Limit for the ZM gustiness equation set in Redelsperger et al. (2000)
+           vmag_gust_dp(i) = max(0._r8, vmag_gust_dp(i) )
+           vmag_gust_cl(i) = sqrt(max(0._r8,up2b(i)+vp2b(i)))
+           vmag_gust(i)    = sqrt(gust_facc * vmag_gust_cl(i)**2 &
+                + gust_fac(i) * vmag_gust_dp(i)**2)
           do k=1,pver
              if (state1%zi(i,k)>pblh(i).and.state1%zi(i,k+1)<=pblh(i)) then
                 ktopi(i) = k

--- a/components/eam/src/physics/cam/phys_control.F90
+++ b/components/eam/src/physics/cam/phys_control.F90
@@ -146,7 +146,6 @@ logical           :: micro_do_icesupersat
 logical           :: state_debug_checks   = .false.    ! Extra checks for validity of physics_state objects
                                                        ! in physics_update.
 logical           :: linearize_pbl_winds  = .false.
-logical           :: export_gustiness  = .false.
 logical, public, protected :: use_mass_borrower    = .false.     ! switch on tracer borrower, instead of using the QNEG3 clipping
 logical, public, protected :: use_qqflx_fixer      = .false.     ! switch on water vapor fixer to compensate changes in qflx
 logical, public, protected :: print_fixer_message  = .false.     ! switch on error message printout in log file
@@ -235,7 +234,7 @@ subroutine phys_ctl_readnl(nlfile)
       is_output_interactive_volc, &
       history_eddy, history_budget,  history_budget_histfile_num, history_waccm, &
       conv_water_in_rad, history_clubb, do_clubb_sgs, do_shoc_sgs, do_tms, state_debug_checks, &
-      linearize_pbl_winds, export_gustiness, &
+      linearize_pbl_winds, &
       use_mass_borrower, do_aerocom_ind3, &
       ieflx_opt, &
       history_gaschmbudget, history_gaschmbudget_2D, history_gaschmbudget_2D_levels, &
@@ -363,7 +362,6 @@ subroutine phys_ctl_readnl(nlfile)
    call mpibcast(micro_do_icesupersat,            1 , mpilog,  0, mpicom)
    call mpibcast(state_debug_checks,              1 , mpilog,  0, mpicom)
    call mpibcast(linearize_pbl_winds,             1 , mpilog,  0, mpicom)
-   call mpibcast(export_gustiness,                1 , mpilog,  0, mpicom)
    call mpibcast(use_hetfrz_classnuc,             1 , mpilog,  0, mpicom)
    call mpibcast(use_gw_oro,                      1 , mpilog,  0, mpicom)
    call mpibcast(use_gw_front,                    1 , mpilog,  0, mpicom)
@@ -600,7 +598,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
                         MMF_orientation_angle_out, use_MMF_VT_out, MMF_VT_wn_max_out, use_MMF_ESMT_out, &
                         use_crm_accel_out, crm_accel_factor_out, crm_accel_uv_out, &
                         do_clubb_sgs_out, do_shoc_sgs_out, do_tms_out, state_debug_checks_out, &
-                        linearize_pbl_winds_out, export_gustiness_out, &
+                        linearize_pbl_winds_out, &
                         do_aerocom_ind3_out,  &
                         use_mass_borrower_out, & 
                         use_qqflx_fixer_out, & 
@@ -692,7 +690,6 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
    logical,           intent(out), optional :: print_fixer_message_out
    logical,           intent(out), optional :: state_debug_checks_out
    logical,           intent(out), optional :: linearize_pbl_winds_out
-   logical,           intent(out), optional :: export_gustiness_out
    logical,           intent(out), optional :: fix_g1_err_ndrop_out!BSINGH - bugfix for ndrop.F90
    logical,           intent(out), optional :: ssalt_tuning_out    
    logical,           intent(out), optional :: resus_fix_out       
@@ -799,7 +796,6 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
    if ( present(print_fixer_message_out ) ) print_fixer_message_out  = print_fixer_message
    if ( present(state_debug_checks_out  ) ) state_debug_checks_out   = state_debug_checks
    if ( present(linearize_pbl_winds_out ) ) linearize_pbl_winds_out  = linearize_pbl_winds
-   if ( present(export_gustiness_out    ) ) export_gustiness_out     = export_gustiness
    if ( present(fix_g1_err_ndrop_out    ) ) fix_g1_err_ndrop_out     = fix_g1_err_ndrop
    if ( present(ssalt_tuning_out        ) ) ssalt_tuning_out         = ssalt_tuning   
    if ( present(resus_fix_out           ) ) resus_fix_out            = resus_fix      

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -87,6 +87,8 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <implicit_stress>.false.</implicit_stress>
 <!-- The atmosphere provides gustiness separate from mean wind. -->
 <atm_gustiness>.false.</atm_gustiness>
+<!-- Force the land to add further gustiness to any provided by the atmosphere. -->
+<force_land_gustiness>.false.</force_land_gustiness>
 
 <!-- ========================================================================================  -->
 <!-- VSFM default                                                                              -->

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -594,6 +594,15 @@ If TRUE, use implicit method to calculate stresses output to atmosphere.
 If TRUE, use an extra gustiness supplied by the atmosphere in addition to mean wind.
 </entry>
 
+<entry id="force_land_gustiness" type="logical" category="elm_physics"
+       group="elm_inparm" valid_values="">
+If TRUE, use the land's gustiness parameterization to add gustiness to the mean
+wind regardless of whether the atmosphere supplies its own gustiness (despite
+the risk of "double-counting" some convection in the boundary layer). If FALSE,
+the land's gustiness parameterization will be used only if atm_gustiness is also
+false.
+</entry>
+
 <!-- TOP solar radiation parameterization                        -->
 <entry id="use_top_solar_rad" type="logical" category="elm_physics"
        group="elm_inparm" valid_values="" value=".false.">

--- a/components/elm/src/biogeophys/BareGroundFluxesMod.F90
+++ b/components/elm/src/biogeophys/BareGroundFluxesMod.F90
@@ -82,6 +82,7 @@ contains
     real(r8) :: zeta                             ! dimensionless height used in Monin-Obukhov theory
     real(r8) :: beta                             ! coefficient of convective velocity [-]
     real(r8) :: wc                               ! convective velocity [m/s]
+    real(r8) :: ugust_total(bounds%begp:bounds%endp) ! gustiness including convective velocity [m/s]
     real(r8) :: dth(bounds%begp:bounds%endp)     ! diff of virtual temp. between ref. height and surface
     real(r8) :: dthv                             ! diff of vir. poten. temp. between ref. height and surface
     real(r8) :: dqh(bounds%begp:bounds%endp)     ! diff of humidity between ref. height and surface
@@ -234,6 +235,7 @@ contains
             ur(p)    = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)+ugust(t)*ugust(t)))
          end if
          tau_diff(p) = 1.e100_r8
+         ugust_total(p) = ugust(t)
 
          dth(p)   = thm(p)-t_grnd(c)
          dqh(p)   = forc_q(t) - qg(c)
@@ -269,7 +271,7 @@ contains
 
          call FrictionVelocity(begp, endp, fn, filterp, &
               displa(begp:endp), z0mg_patch(begp:endp), z0hg_patch(begp:endp), z0qg_patch(begp:endp), &
-              obu(begp:endp), iter, ur(begp:endp), um(begp:endp), ustar(begp:endp), &
+              obu(begp:endp), iter, ur(begp:endp), um(begp:endp), ugust_total(begp:endp), ustar(begp:endp), &
               temp1(begp:endp), temp2(begp:endp), temp12m(begp:endp), temp22m(begp:endp), fm(begp:endp), &
               frictionvel_vars)
 
@@ -302,6 +304,7 @@ contains
             else                                      !unstable
                zeta = max(-100._r8,min(zeta,-0.01_r8))
                wc = beta*(-grav*ustar(p)*thvstar*zii(c)/thv(c))**0.333_r8
+               ugust_total(p) = sqrt(ugust(t)**2 + wc**2)
                um(p) = sqrt(ur(p)*ur(p) + wc*wc)
             end if
             obu(p) = zldis(p)/zeta

--- a/components/elm/src/biogeophys/BareGroundFluxesMod.F90
+++ b/components/elm/src/biogeophys/BareGroundFluxesMod.F90
@@ -227,11 +227,11 @@ contains
          if (implicit_stress) then
             wind_speed0(p) = max(0.01_r8, hypot(forc_u(t), forc_v(t)))
             wind_speed_adj(p) = wind_speed0(p)
-            ur(p) = max(1.0_r8, wind_speed_adj(p) + ugust(t))
+            ur(p) = max(1.0_r8, sqrt(wind_speed_adj(p)**2 + ugust(t)**2))
 
             prev_tau(p) = tau_est(t)
          else
-            ur(p)    = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)) + ugust(t))
+            ur(p)    = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)+ugust(t)*ugust(t)))
          end if
          tau_diff(p) = 1.e100_r8
 
@@ -286,7 +286,7 @@ contains
                call shr_flux_update_stress(wind_speed0(p), wsresp(t), tau_est(t), &
                     tau(p), prev_tau(p), tau_diff(p), prev_tau_diff(p), &
                     wind_speed_adj(p))
-               ur(p) = max(1.0_r8, wind_speed_adj(p) + ugust(t))
+               ur(p) = max(1.0_r8, sqrt(wind_speed_adj(p)**2 + ugust(t)**2))
             end if
 
             tstar = temp1(p)*dth(p)

--- a/components/elm/src/biogeophys/BareGroundFluxesMod.F90
+++ b/components/elm/src/biogeophys/BareGroundFluxesMod.F90
@@ -48,7 +48,8 @@ contains
     use elm_varcon           , only : cpair, vkc, grav, denice, denh2o
     use elm_varctl           , only : iulog, use_lch4
     use landunit_varcon      , only : istsoil, istcrop
-    use FrictionVelocityMod  , only : FrictionVelocity, MoninObukIni, implicit_stress
+    use FrictionVelocityMod  , only : FrictionVelocity, MoninObukIni, &
+         implicit_stress, atm_gustiness, force_land_gustiness
     use QSatMod              , only : QSat
     use SurfaceResistanceMod , only : do_soilevap_beta
     use elm_time_manager     , only : get_nstep
@@ -303,9 +304,13 @@ contains
                um(p) = max(ur(p),0.1_r8)
             else                                      !unstable
                zeta = max(-100._r8,min(zeta,-0.01_r8))
-               wc = beta*(-grav*ustar(p)*thvstar*zii(c)/thv(c))**0.333_r8
-               ugust_total(p) = sqrt(ugust(t)**2 + wc**2)
-               um(p) = sqrt(ur(p)*ur(p) + wc*wc)
+               if ((.not. atm_gustiness) .or. force_land_gustiness) then
+                  wc = beta*(-grav*ustar(p)*thvstar*zii(c)/thv(c))**0.333_r8
+                  ugust_total(p) = sqrt(ugust(t)**2 + wc**2)
+                  um(p) = sqrt(ur(p)*ur(p) + wc*wc)
+               else
+                  um(p) = max(ur(p),0.1_r8)
+               end if
             end if
             obu(p) = zldis(p)/zeta
          end do

--- a/components/elm/src/biogeophys/CanopyFluxesMod.F90
+++ b/components/elm/src/biogeophys/CanopyFluxesMod.F90
@@ -169,6 +169,7 @@ contains
     real(r8) :: zldis(bounds%begp:bounds%endp)       ! reference height "minus" zero displacement height [m]
     real(r8) :: zeta                                 ! dimensionless height used in Monin-Obukhov theory
     real(r8) :: wc                                   ! convective velocity [m/s]
+    real(r8) :: ugust_total(bounds%begp:bounds%endp) ! gustiness including convective velocity [m/s]
     real(r8) :: dth(bounds%begp:bounds%endp)         ! diff of virtual temp. between ref. height and surface
     real(r8) :: dthv(bounds%begp:bounds%endp)        ! diff of vir. poten. temp. between ref. height and surface
     real(r8) :: dqh(bounds%begp:bounds%endp)         ! diff of humidity between ref. height and surface
@@ -714,6 +715,7 @@ contains
             ur(p) = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)+ugust(t)*ugust(t)))
          end if
          tau_diff(p) = 1.e100_r8
+         ugust_total(p) = ugust(t)
 
          dth(p) = thm(p)-taf(p)
          dqh(p) = forc_q(t)-qaf(p)
@@ -764,7 +766,7 @@ contains
          ! profiles of the surface boundary layer
          call FrictionVelocity (begp, endp, fn, filterp, &
               displa(begp:endp), z0mv(begp:endp), z0hv(begp:endp), z0qv(begp:endp), &
-              obu(begp:endp), itlef, ur(begp:endp), um(begp:endp), ustar(begp:endp), &
+              obu(begp:endp), itlef, ur(begp:endp), um(begp:endp), ugust_total(begp:endp), ustar(begp:endp), &
               temp1(begp:endp), temp2(begp:endp), temp12m(begp:endp), temp22m(begp:endp), fm(begp:endp), &
               frictionvel_vars)
 
@@ -1124,6 +1126,7 @@ contains
             else                     !unstable
                zeta = max(-100._r8,min(zeta,-0.01_r8))
                wc = beta*(-grav*ustar(p)*thvstar*zii/thv(c))**0.333_r8
+               ugust_total(p) = sqrt(ugust(t)**2 + wc**2)
                um(p) = sqrt(ur(p)*ur(p)+wc*wc)
             end if
             obu(p) = zldis(p)/zeta

--- a/components/elm/src/biogeophys/CanopyFluxesMod.F90
+++ b/components/elm/src/biogeophys/CanopyFluxesMod.F90
@@ -707,11 +707,11 @@ contains
          if (implicit_stress) then
             wind_speed0(p) = max(0.01_r8, hypot(forc_u(t), forc_v(t)))
             wind_speed_adj(p) = wind_speed0(p)
-            ur(p) = max(1.0_r8, wind_speed_adj(p) + ugust(t))
+            ur(p) = max(1.0_r8, sqrt(wind_speed_adj(p)**2 + ugust(t)**2))
 
             prev_tau(p) = tau_est(t)
          else
-            ur(p) = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)) + ugust(t))
+            ur(p) = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)+ugust(t)*ugust(t)))
          end if
          tau_diff(p) = 1.e100_r8
 
@@ -790,7 +790,7 @@ contains
                call shr_flux_update_stress(wind_speed0(p), wsresp(t), tau_est(t), &
                     tau(p), prev_tau(p), tau_diff(p), prev_tau_diff(p), &
                     wind_speed_adj(p))
-               ur(p) = max(1.0_r8, wind_speed_adj(p) + ugust(t))
+               ur(p) = max(1.0_r8, sqrt(wind_speed_adj(p)**2 + ugust(t)**2))
             end if
 
             ! Bulk boundary layer resistance of leaves

--- a/components/elm/src/biogeophys/CanopyFluxesMod.F90
+++ b/components/elm/src/biogeophys/CanopyFluxesMod.F90
@@ -103,7 +103,8 @@ contains
     use elm_varsur         , only : firrig
     use TopounitType       , only : top_pp
     use QSatMod            , only : QSat
-    use FrictionVelocityMod, only : FrictionVelocity, MoninObukIni, implicit_stress
+    use FrictionVelocityMod, only : FrictionVelocity, MoninObukIni, &
+         implicit_stress, atm_gustiness, force_land_gustiness
     use SoilWaterRetentionCurveMod, only : soil_water_retention_curve_type
     use SurfaceResistanceMod, only : getlblcef
     use PhotosynthesisType, only : photosyns_vars_TimeStepInit
@@ -1125,9 +1126,13 @@ contains
                um(p) = max(ur(p),0.1_r8)
             else                     !unstable
                zeta = max(-100._r8,min(zeta,-0.01_r8))
-               wc = beta*(-grav*ustar(p)*thvstar*zii/thv(c))**0.333_r8
-               ugust_total(p) = sqrt(ugust(t)**2 + wc**2)
-               um(p) = sqrt(ur(p)*ur(p)+wc*wc)
+               if ((.not. atm_gustiness) .or. force_land_gustiness) then
+                  wc = beta*(-grav*ustar(p)*thvstar*zii/thv(c))**0.333_r8
+                  ugust_total(p) = sqrt(ugust(t)**2 + wc**2)
+                  um(p) = sqrt(ur(p)*ur(p)+wc*wc)
+               else
+                  um(p) = max(ur(p),0.1_r8)
+               end if
             end if
             obu(p) = zldis(p)/zeta
 

--- a/components/elm/src/biogeophys/FrictionVelocityMod.F90
+++ b/components/elm/src/biogeophys/FrictionVelocityMod.F90
@@ -36,7 +36,7 @@ contains
   !------------------------------------------------------------------------------
   subroutine FrictionVelocity(lbn, ubn, fn, filtern, &
        displa, z0m, z0h, z0q, &
-       obu, iter, ur, um, ustar, &
+       obu, iter, ur, um, ugust, ustar, &
        temp1, temp2, temp12m, temp22m, fm,frictionvel_vars,landunit_index)
     !$acc routine seq
     ! !DESCRIPTION:
@@ -65,6 +65,7 @@ contains
     integer  , intent(in)    :: iter                     ! iteration number
     real(r8) , intent(in)    :: ur      ( lbn: )         ! wind speed at reference height [m/s] [lbn:ubn]
     real(r8) , intent(in)    :: um      ( lbn: )         ! wind speed including the stablity effect [m/s] [lbn:ubn]
+    real(r8) , intent(in)    :: ugust   ( lbn: )         ! Gustiness wind speed [m/s] [lbn:ubn]
     real(r8) , intent(out)   :: ustar   ( lbn: )         ! friction velocity [m/s] [lbn:ubn]
     real(r8) , intent(out)   :: temp1   ( lbn: )         ! relation for potential temperature profile [lbn:ubn]
     real(r8) , intent(out)   :: temp12m ( lbn: )         ! relation for potential temperature profile applied at 2-m [lbn:ubn]
@@ -97,6 +98,7 @@ contains
          vds              => frictionvel_vars%vds_patch        , & ! Output: [real(r8) (:) ] dry deposition velocity term (m/s) (for SO4 NH4NO3)
          u10              => frictionvel_vars%u10_patch        , & ! Output: [real(r8) (:) ] 10-m wind (m/s) (for dust model)
          u10_elm          => frictionvel_vars%u10_elm_patch    , & ! Output: [real(r8) (:) ] 10-m wind (m/s)
+         u10_with_gusts_elm=>frictionvel_vars%u10_with_gusts_elm_patch, & ! Output: [real(r8) (:) ] 10-m wind with gusts(m/s)
          va               => frictionvel_vars%va_patch         , & ! Output: [real(r8) (:) ] atmospheric wind speed plus convective velocity (m/s)
          fv               => frictionvel_vars%fv_patch           & ! Output: [real(r8) (:) ] friction velocity (m/s) (for dust model)
          )
@@ -166,52 +168,56 @@ contains
           if (present(landunit_index)) then
              do pp = pfti,pftf
                 if (zldis-z0m(n) <= 10._r8) then
-                   u10_elm(pp) = um(n)
+                   u10_with_gusts_elm(pp) = um(n)
                 else
                    if (zeta < -zetam) then
-                      u10_elm(pp) = um(n) - ( ustar(n)/vkc*(log(-zetam*obu(n)/(10._r8+z0m(n)))      &
+                      u10_with_gusts_elm(pp) = um(n) - ( ustar(n)/vkc*(log(-zetam*obu(n)/(10._r8+z0m(n))) &
                            - StabilityFunc1(-zetam)                              &
                            + StabilityFunc1((10._r8+z0m(n))/obu(n))              &
                            + 1.14_r8*((-zeta)**0.333_r8-(zetam)**0.333_r8)) )
                    else if (zeta < 0._r8) then
-                      u10_elm(pp) = um(n) - ( ustar(n)/vkc*(log(zldis/(10._r8+z0m(n)))           &
+                      u10_with_gusts_elm(pp) = um(n) - ( ustar(n)/vkc*(log(zldis/(10._r8+z0m(n))) &
                            - StabilityFunc1(zeta)                             &
                            + StabilityFunc1((10._r8+z0m(n))/obu(n))) )
                    else if (zeta <=  1._r8) then
-                      u10_elm(pp) = um(n) - ( ustar(n)/vkc*(log(zldis/(10._r8+z0m(n)))           &
+                      u10_with_gusts_elm(pp) = um(n) - ( ustar(n)/vkc*(log(zldis/(10._r8+z0m(n))) &
                            + 5._r8*zeta - 5._r8*(10._r8+z0m(n))/obu(n)) )
                    else
-                      u10_elm(pp) = um(n) - ( ustar(n)/vkc*(log(obu(n)/(10._r8+z0m(n)))             &
+                      u10_with_gusts_elm(pp) = um(n) - ( ustar(n)/vkc*(log(obu(n)/(10._r8+z0m(n))) &
                            + 5._r8 - 5._r8*(10._r8+z0m(n))/obu(n)                &
                            + (5._r8*log(zeta)+zeta-1._r8)) )
 
                    end if
                 end if
                 va(pp) = um(n)
+                ! Estimate u10 with effects of gustiness removed.
+                u10_elm(pp) = u10_with_gusts_elm(pp) * sqrt(max(0., um(n)**2 - ugust(n)**2)) / um(n)
              end do
           else
              if (zldis-z0m(n) <= 10._r8) then
-                u10_elm(n) = um(n)
+                u10_with_gusts_elm(n) = um(n)
              else
                 if (zeta < -zetam) then
-                   u10_elm(n) = um(n) - ( ustar(n)/vkc*(log(-zetam*obu(n)/(10._r8+z0m(n)))         &
+                   u10_with_gusts_elm(n) = um(n) - ( ustar(n)/vkc*(log(-zetam*obu(n)/(10._r8+z0m(n))) &
                         - StabilityFunc1(-zetam)                                 &
                         + StabilityFunc1((10._r8+z0m(n))/obu(n))                 &
                         + 1.14_r8*((-zeta)**0.333_r8-(zetam)**0.333_r8)) )
                 else if (zeta < 0._r8) then
-                   u10_elm(n) = um(n) - ( ustar(n)/vkc*(log(zldis/(10._r8+z0m(n)))              &
+                   u10_with_gusts_elm(n) = um(n) - ( ustar(n)/vkc*(log(zldis/(10._r8+z0m(n))) &
                         - StabilityFunc1(zeta)                                &
                         + StabilityFunc1((10._r8+z0m(n))/obu(n))) )
                 else if (zeta <=  1._r8) then
-                   u10_elm(n) = um(n) - ( ustar(n)/vkc*(log(zldis/(10._r8+z0m(n)))              &
+                   u10_with_gusts_elm(n) = um(n) - ( ustar(n)/vkc*(log(zldis/(10._r8+z0m(n))) &
                         + 5._r8*zeta - 5._r8*(10._r8+z0m(n))/obu(n)) )
                 else
-                   u10_elm(n) = um(n) - ( ustar(n)/vkc*(log(obu(n)/(10._r8+z0m(n)))    &
+                   u10_with_gusts_elm(n) = um(n) - ( ustar(n)/vkc*(log(obu(n)/(10._r8+z0m(n))) &
                         + 5._r8 - 5._r8*(10._r8+z0m(n))/obu(n)                   &
                         + (5._r8*log(zeta)+zeta-1._r8)) )
                 end if
              end if
              va(n) = um(n)
+             ! Estimate u10 with effects of gustiness removed.
+             u10_elm(n) = u10_with_gusts_elm(n) * sqrt(max(0., um(n)**2 - ugust(n)**2)) / um(n)
           end if
 
           !===================!

--- a/components/elm/src/biogeophys/FrictionVelocityMod.F90
+++ b/components/elm/src/biogeophys/FrictionVelocityMod.F90
@@ -20,6 +20,7 @@ module FrictionVelocityMod
 
   logical, public :: implicit_stress = .false.
   logical, public :: atm_gustiness = .false.
+  logical, public :: force_land_gustiness = .false.
   !
   ! !PUBLIC MEMBER FUNCTIONS:
   public :: FrictionVelocity       ! Calculate friction velocity

--- a/components/elm/src/biogeophys/FrictionVelocityType.F90
+++ b/components/elm/src/biogeophys/FrictionVelocityType.F90
@@ -28,6 +28,7 @@ module FrictionVelocityType
      real(r8), pointer :: forc_hgt_q_patch (:)   ! patch specific humidity forcing height (10m+z0m+d) (m)
      real(r8), pointer :: u10_patch        (:)   ! patch 10-m wind (m/s) (for dust model)
      real(r8), pointer :: u10_elm_patch    (:)   ! patch 10-m wind (m/s) (for elm_map2gcell)
+     real(r8), pointer :: u10_with_gusts_elm_patch(:)! patch 10-m wind with gusts (m/s) (for elm_map2gcell)
      real(r8), pointer :: va_patch         (:)   ! patch atmospheric wind speed plus convective velocity (m/s)
      real(r8), pointer :: vds_patch        (:)   ! patch deposition velocity term (m/s) (for dry dep SO4, NH4NO3)
      real(r8), pointer :: fv_patch         (:)   ! patch friction velocity (m/s) (for dust model)
@@ -91,6 +92,7 @@ contains
     allocate(this%forc_hgt_q_patch (begp:endp)) ; this%forc_hgt_q_patch (:)   = spval
     allocate(this%u10_patch        (begp:endp)) ; this%u10_patch        (:)   = spval
     allocate(this%u10_elm_patch    (begp:endp)) ; this%u10_elm_patch    (:)   = spval
+    allocate(this%u10_with_gusts_elm_patch(begp:endp));this%u10_with_gusts_elm_patch(:)=spval
     allocate(this%va_patch         (begp:endp)) ; this%va_patch         (:)   = spval
     allocate(this%vds_patch        (begp:endp)) ; this%vds_patch        (:)   = spval
     allocate(this%fv_patch         (begp:endp)) ; this%fv_patch         (:)   = spval
@@ -152,6 +154,11 @@ contains
     call hist_addfld1d (fname='U10', units='m/s', &
          avgflag='A', long_name='10-m wind', &
          ptr_patch=this%u10_elm_patch)
+
+    this%u10_with_gusts_elm_patch(begp:endp) = spval
+    call hist_addfld1d (fname='U10WITHGUSTS', units='m/s', &
+         avgflag='A', long_name='10-m wind with gustiness enhancement included', &
+         ptr_patch=this%u10_with_gusts_elm_patch)
 
     if (use_cn) then
        this%u10_patch(begp:endp) = spval

--- a/components/elm/src/biogeophys/LakeFluxesMod.F90
+++ b/components/elm/src/biogeophys/LakeFluxesMod.F90
@@ -57,7 +57,8 @@ contains
     use LakeCon             , only : lake_use_old_fcrit_minz0
     use LakeCon             , only : minz0lake, cur0, cus, curm, fcrit
     use QSatMod             , only : QSat
-    use FrictionVelocityMod , only : FrictionVelocity, MoninObukIni, implicit_stress
+    use FrictionVelocityMod , only : FrictionVelocity, MoninObukIni, &
+         implicit_stress, atm_gustiness, force_land_gustiness
     use elm_time_manager    , only : get_nstep
     !
     ! !ARGUMENTS:
@@ -495,9 +496,13 @@ contains
                um(p) = max(ur(p),0.1_r8)
             else                     !unstable
                zeta = max(-100._r8,min(zeta,-0.01_r8))
-               wc = beta1*(-grav*ustar(p)*thvstar*zii/thv(c))**0.333_r8
-               ugust_total(p) = sqrt(ugust(t)**2 + wc**2)
-               um(p) = sqrt(ur(p)*ur(p)+wc*wc)
+               if ((.not. atm_gustiness) .or. force_land_gustiness) then
+                  wc = beta1*(-grav*ustar(p)*thvstar*zii/thv(c))**0.333_r8
+                  ugust_total(p) = sqrt(ugust(t)**2 + wc**2)
+                  um(p) = sqrt(ur(p)*ur(p)+wc*wc)
+               else
+                  um(p) = max(ur(p),0.1_r8)
+               end if
             end if
             obu(p) = zldis(p)/zeta
 

--- a/components/elm/src/biogeophys/LakeFluxesMod.F90
+++ b/components/elm/src/biogeophys/LakeFluxesMod.F90
@@ -354,11 +354,11 @@ contains
          if (implicit_stress) then
             wind_speed0(p) = max(0.01_r8, hypot(forc_u(t), forc_v(t)))
             wind_speed_adj(p) = wind_speed0(p)
-            ur(p) = max(1.0_r8, wind_speed_adj(p) + ugust(t))
+            ur(p) = max(1.0_r8, sqrt(wind_speed_adj(p)**2 + ugust(t)**2))
 
             prev_tau(p) = tau_est(t)
          else
-            ur(p) = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)) + ugust(t))
+            ur(p) = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)+ugust(t)*ugust(t)))
          end if
          tau_diff(p) = 1.e100_r8
 
@@ -435,7 +435,7 @@ contains
                call shr_flux_update_stress(wind_speed0(p), wsresp(t), tau_est(t), &
                     tau(p), prev_tau(p), tau_diff(p), prev_tau_diff(p), &
                     wind_speed_adj(p))
-               ur(p) = max(1.0_r8, wind_speed_adj(p) + ugust(t))
+               ur(p) = max(1.0_r8, sqrt(wind_speed_adj(p)**2 + ugust(t)**2))
             end if
 
             ! Get derivative of fluxes with respect to ground temperature

--- a/components/elm/src/biogeophys/LakeFluxesMod.F90
+++ b/components/elm/src/biogeophys/LakeFluxesMod.F90
@@ -123,6 +123,7 @@ contains
     real(r8) :: ur(bounds%begp:bounds%endp)        ! wind speed at reference height [m/s]
     real(r8) :: ustar(bounds%begp:bounds%endp)     ! friction velocity [m/s]
     real(r8) :: wc                                 ! convective velocity [m/s]
+    real(r8) :: ugust_total(bounds%begp:bounds%endp) ! gustiness including convective velocity [m/s]
     real(r8) :: zeta                               ! dimensionless height used in Monin-Obukhov theory
     real(r8) :: zldis(bounds%begp:bounds%endp)     ! reference height "minus" zero displacement height [m]
     real(r8) :: displa(bounds%begp:bounds%endp)    ! displacement (always zero) [m]
@@ -361,6 +362,7 @@ contains
             ur(p) = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)+ugust(t)*ugust(t)))
          end if
          tau_diff(p) = 1.e100_r8
+         ugust_total(p) = ugust(t)
 
          dth(p)   = thm(p)-t_grnd(c)
          dqh(p)   = forc_q(t)-qsatg(c)
@@ -390,7 +392,8 @@ contains
 
          call FrictionVelocity(begp, endp, fncopy, fpcopy, &
               displa(begp:endp), z0mg(begp:endp), z0hg(begp:endp), z0qg(begp:endp), &
-              obu(begp:endp), iter, ur(begp:endp), um(begp:endp), ustar(begp:endp), &
+              obu(begp:endp), iter, ur(begp:endp), um(begp:endp), ugust_total(begp:endp), &
+              ustar(begp:endp), &
               temp1(begp:endp), temp2(begp:endp), temp12m(begp:endp), temp22m(begp:endp), &
               fm(begp:endp), frictionvel_vars)
 
@@ -493,6 +496,7 @@ contains
             else                     !unstable
                zeta = max(-100._r8,min(zeta,-0.01_r8))
                wc = beta1*(-grav*ustar(p)*thvstar*zii/thv(c))**0.333_r8
+               ugust_total(p) = sqrt(ugust(t)**2 + wc**2)
                um(p) = sqrt(ur(p)*ur(p)+wc*wc)
             end if
             obu(p) = zldis(p)/zeta

--- a/components/elm/src/biogeophys/UrbanFluxesMod.F90
+++ b/components/elm/src/biogeophys/UrbanFluxesMod.F90
@@ -64,7 +64,8 @@ contains
     use column_varcon       , only : icol_shadewall, icol_road_perv, icol_road_imperv
     use column_varcon       , only : icol_roof, icol_sunwall
     use filterMod           , only : filter
-    use FrictionVelocityMod , only : FrictionVelocity, MoninObukIni, implicit_stress
+    use FrictionVelocityMod , only : FrictionVelocity, MoninObukIni, &
+         implicit_stress, atm_gustiness, force_land_gustiness
     use QSatMod             , only : QSat
     use elm_varpar          , only : maxpatch_urb, nlevurb, nlevgrnd
     use elm_varctl          , only : use_vsfm
@@ -713,9 +714,13 @@ contains
                um(l) = max(ur(l),0.1_r8)
             else                                      !unstable
                zeta = max(-100._r8,min(zeta,-0.01_r8))
-               wc = beta(l)*(-grav*ustar(l)*thvstar*zii(l)/thv_g(l))**0.333_r8
-               ugust_total(l) = sqrt(ugust(t)**2 + wc**2)
-               um(l) = sqrt(ur(l)*ur(l) + wc*wc)
+               if ((.not. atm_gustiness) .or. force_land_gustiness) then
+                  wc = beta(l)*(-grav*ustar(l)*thvstar*zii(l)/thv_g(l))**0.333_r8
+                  ugust_total(l) = sqrt(ugust(t)**2 + wc**2)
+                  um(l) = sqrt(ur(l)*ur(l) + wc*wc)
+               else
+                  um(l) = max(ur(l),0.1_r8)
+               end if
             end if
 
             obu(l) = zldis(l)/zeta

--- a/components/elm/src/biogeophys/UrbanFluxesMod.F90
+++ b/components/elm/src/biogeophys/UrbanFluxesMod.F90
@@ -162,6 +162,7 @@ contains
     real(r8) :: t_roof_innerl(bounds%begl:bounds%endl)               ! temperature of inner layer of roof (K)
     real(r8) :: lngth_roof                                           ! length of roof (m)
     real(r8) :: wc                                                   ! convective velocity (m/s)
+    real(r8) :: ugust_total(bounds%begl:bounds%endl)                 ! gustiness including convective velocity [m/s]
     real(r8) :: zeta                                                 ! dimensionless height used in Monin-Obukhov theory
     real(r8) :: eflx_sh_grnd_scale(bounds%begp:bounds%endp)          ! scaled sensible heat flux from ground (W/m**2) [+ to atm]
     real(r8) :: qflx_evap_soi_scale(bounds%begp:bounds%endp)         ! scaled soil evaporation (mm H2O/s) (+ = to atm)
@@ -345,6 +346,7 @@ contains
             ur(l) = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)+ugust(t)*ugust(t)))
          end if
          tau_diff(l) = 1.e100_r8
+         ugust_total(l) = ugust(t)
 
       end do
 
@@ -411,7 +413,7 @@ contains
             call FrictionVelocity(begl, endl, &
                  num_urbanl, filter_urbanl, &
                  z_d_town(begl:endl), z_0_town(begl:endl), z_0_town(begl:endl), z_0_town(begl:endl), &
-                 obu(begl:endl), iter, ur(begl:endl), um(begl:endl), ustar(begl:endl), &
+                 obu(begl:endl), iter, ur(begl:endl), um(begl:endl), ugust_total(begl:endl), ustar(begl:endl), &
                  temp1(begl:endl), temp2(begl:endl), temp12m(begl:endl), temp22m(begl:endl), fm(begl:endl), &
                  frictionvel_vars, landunit_index=.true.)
          end if
@@ -712,6 +714,7 @@ contains
             else                                      !unstable
                zeta = max(-100._r8,min(zeta,-0.01_r8))
                wc = beta(l)*(-grav*ustar(l)*thvstar*zii(l)/thv_g(l))**0.333_r8
+               ugust_total(l) = sqrt(ugust(t)**2 + wc**2)
                um(l) = sqrt(ur(l)*ur(l) + wc*wc)
             end if
 

--- a/components/elm/src/biogeophys/UrbanFluxesMod.F90
+++ b/components/elm/src/biogeophys/UrbanFluxesMod.F90
@@ -338,11 +338,11 @@ contains
          if (implicit_stress) then
             wind_speed0(l) = max(0.01_r8, hypot(forc_u(t), forc_v(t)))
             wind_speed_adj(l) = wind_speed0(l)
-            ur(l) = max(1.0_r8, wind_speed_adj(l) + ugust(t))
+            ur(l) = max(1.0_r8, sqrt(wind_speed_adj(l)**2 + ugust(t)**2))
 
             prev_tau(l) = tau_est(t)
          else
-            ur(l) = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)) + ugust(t))
+            ur(l) = max(1.0_r8,sqrt(forc_u(t)*forc_u(t)+forc_v(t)*forc_v(t)+ugust(t)*ugust(t)))
          end if
          tau_diff(l) = 1.e100_r8
 
@@ -433,7 +433,7 @@ contains
                call shr_flux_update_stress(wind_speed0(l), wsresp(t), tau_est(t), &
                     tau(l), prev_tau(l), tau_diff(l), prev_tau_diff(l), &
                     wind_speed_adj(l))
-               ur(l) = max(1.0_r8, wind_speed_adj(l) + ugust(t))
+               ur(l) = max(1.0_r8, sqrt(wind_speed_adj(l)**2 + ugust(t)**2))
             end if
 
             ! Canyon top wind

--- a/components/elm/src/cpl/elm_cpl_indices.F90
+++ b/components/elm/src/cpl/elm_cpl_indices.F90
@@ -43,6 +43,7 @@ module elm_cpl_indices
   integer, public ::index_l2x_Sl_anidf        ! albedo: diffuse, near-ir
   integer, public ::index_l2x_Sl_snowh        ! snow height
   integer, public ::index_l2x_Sl_u10          ! 10m wind
+  integer, public ::index_l2x_Sl_u10withgusts ! 10m wind with gustiness included
   integer, public ::index_l2x_Sl_ddvel        ! dry deposition velocities (optional)
   integer, public ::index_l2x_Sl_fv           ! friction velocity  
   integer, public ::index_l2x_Sl_ram1         ! aerodynamical resistance
@@ -201,6 +202,7 @@ contains
     index_l2x_Sl_tref       = mct_avect_indexra(l2x,'Sl_tref')
     index_l2x_Sl_qref       = mct_avect_indexra(l2x,'Sl_qref')
     index_l2x_Sl_u10        = mct_avect_indexra(l2x,'Sl_u10')
+    index_l2x_Sl_u10withgusts = mct_avect_indexra(l2x,'Sl_u10withgusts')
     index_l2x_Sl_ram1       = mct_avect_indexra(l2x,'Sl_ram1')
     index_l2x_Sl_fv         = mct_avect_indexra(l2x,'Sl_fv')
     index_l2x_Sl_soilw      = mct_avect_indexra(l2x,'Sl_soilw',perrwith='quiet')

--- a/components/elm/src/cpl/lnd_downscale_atm_forcing.F90
+++ b/components/elm/src/cpl/lnd_downscale_atm_forcing.F90
@@ -64,6 +64,7 @@ contains
     use elm_varctl      , only : glcmec_downscale_rain_snow_convert
     use domainMod       , only : ldomain
     use QsatMod         , only : Qsat
+    use FrictionVelocityMod, only: atm_gustiness
     !
     ! !ARGUMENTS:
     integer                    , intent(in)    :: g  
@@ -225,10 +226,16 @@ contains
              top_as%ubot(t)    = x2l(index_x2l_Sa_u,i)         ! forc_uxy  Atm state m/s
              top_as%vbot(t)    = x2l(index_x2l_Sa_v,i)         ! forc_vxy  Atm state m/s
              top_as%zbot(t)    = x2l(index_x2l_Sa_z,i)         ! zgcmxy    Atm state m
+             if (atm_gustiness) then
+                top_as%ugust(t)  = x2l(index_x2l_Sa_ugust,i)   ! ugust     Atm state m/s
+             end if
 		 
              ! assign the state forcing fields derived from other inputs
              ! Horizontal windspeed (m/s)
              top_as%windbot(t) = sqrt(top_as%ubot(t)**2 + top_as%vbot(t)**2)
+             if (atm_gustiness) then
+                top_as%windbot(t) = sqrt(top_as%windbot(t)**2 + top_as%ugust(t)**2)
+             end if
              ! Relative humidity (percent)
              if (top_as%tbot(t) > SHR_CONST_TKFRZ) then
                 e = esatw(tdc(top_as%tbot(t)))
@@ -257,6 +264,9 @@ contains
              top_as%ubot(t)    = x2l(index_x2l_Sa_u,i)         ! forc_uxy  Atm state m/s
              top_as%vbot(t)    = x2l(index_x2l_Sa_v,i)         ! forc_vxy  Atm state m/s
              top_as%zbot(t)    = x2l(index_x2l_Sa_z,i)         ! zgcmxy    Atm state m
+             if (atm_gustiness) then
+                top_as%ugust(t)  = x2l(index_x2l_Sa_ugust,i)   ! ugust     Atm state m/s
+             end if
           
              sum_qbot_g = sum_qbot_g + top_pp%wtgcell(t)*top_as%qbot(t)
              sum_wtsq_g = sum_wtsq_g + top_pp%wtgcell(t)
@@ -264,6 +274,9 @@ contains
              ! assign the state forcing fields derived from other inputs
              ! Horizontal windspeed (m/s)
              top_as%windbot(t) = sqrt(top_as%ubot(t)**2 + top_as%vbot(t)**2)
+             if (atm_gustiness) then
+                top_as%windbot(t) = sqrt(top_as%windbot(t)**2 + top_as%ugust(t)**2)
+             end if
              ! partial pressure of oxygen (Pa)
              top_as%po2bot(t) = o2_molar_const * top_as%pbot(t)
              ! air density (kg/m**3) - uses a temporary calculation
@@ -342,10 +355,16 @@ contains
        top_as%ubot(t)    = x2l(index_x2l_Sa_u,i)         ! forc_uxy  Atm state m/s
        top_as%vbot(t)    = x2l(index_x2l_Sa_v,i)         ! forc_vxy  Atm state m/s
        top_as%zbot(t)    = x2l(index_x2l_Sa_z,i)         ! zgcmxy    Atm state m
+       if (atm_gustiness) then
+          top_as%ugust(t)  = x2l(index_x2l_Sa_ugust,i)   ! ugust     Atm state m/s
+       end if
 		 
        ! assign the state forcing fields derived from other inputs
        ! Horizontal windspeed (m/s)
        top_as%windbot(t) = sqrt(top_as%ubot(t)**2 + top_as%vbot(t)**2)
+       if (atm_gustiness) then
+          top_as%windbot(t) = sqrt(top_as%windbot(t)**2 + top_as%ugust(t)**2)
+       end if
        ! Relative humidity (percent)
        if (top_as%tbot(t) > SHR_CONST_TKFRZ) then
           e = esatw(tdc(top_as%tbot(t)))

--- a/components/elm/src/cpl/lnd_import_export.F90
+++ b/components/elm/src/cpl/lnd_import_export.F90
@@ -1049,7 +1049,7 @@ contains
          ! Horizontal windspeed (m/s)
          top_as%windbot(topo) = sqrt(top_as%ubot(topo)**2 + top_as%vbot(topo)**2)
          if (atm_gustiness) then
-            top_as%windbot(topo) = top_as%windbot(topo) + top_as%ugust(topo)
+            top_as%windbot(topo) = sqrt(top_as%windbot(topo)**2 + top_as%ugust(topo)**2)
          end if
          ! Relative humidity (percent)
          if (top_as%tbot(topo) > SHR_CONST_TKFRZ) then
@@ -1148,9 +1148,9 @@ contains
            ! assign the state forcing fields derived from other inputs
            ! Horizontal windspeed (m/s)
            top_as%windbot(topo) = sqrt(top_as%ubot(topo)**2 + top_as%vbot(topo)**2)
-         if (atm_gustiness) then
-            top_as%windbot(topo) = top_as%windbot(topo) + top_as%ugust(topo)
-         end if
+           if (atm_gustiness) then
+              top_as%windbot(topo) = sqrt(top_as%windbot(topo)**2 + top_as%ugust(topo)**2)
+           end if
            ! Relative humidity (percent)
            if (top_as%tbot(topo) > SHR_CONST_TKFRZ) then
             e = esatw(tdc(top_as%tbot(topo)))

--- a/components/elm/src/cpl/lnd_import_export.F90
+++ b/components/elm/src/cpl/lnd_import_export.F90
@@ -1391,6 +1391,7 @@ contains
        l2x(index_l2x_Sl_tref,i)     =  lnd2atm_vars%t_ref2m_grc(g)
        l2x(index_l2x_Sl_qref,i)     =  lnd2atm_vars%q_ref2m_grc(g)
        l2x(index_l2x_Sl_u10,i)      =  lnd2atm_vars%u_ref10m_grc(g)
+       l2x(index_l2x_Sl_u10withgusts,i)=lnd2atm_vars%u_ref10m_with_gusts_grc(g)
        l2x(index_l2x_Fall_taux,i)   = -lnd2atm_vars%taux_grc(g)
        l2x(index_l2x_Fall_tauy,i)   = -lnd2atm_vars%tauy_grc(g)
        l2x(index_l2x_Fall_lat,i)    = -lnd2atm_vars%eflx_lh_tot_grc(g)

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -38,7 +38,7 @@ module controlMod
   use CanopyHydrologyMod      , only: CanopyHydrology_readnl
   use SurfaceAlbedoType        , only: albice, lake_melt_icealb
   use UrbanParamsType         , only: urban_hac, urban_traffic
-  use FrictionVelocityMod     , only: implicit_stress, atm_gustiness
+  use FrictionVelocityMod     , only: implicit_stress, atm_gustiness, force_land_gustiness
   use elm_varcon              , only: h2osno_max
   use elm_varctl              , only: use_dynroot
   use AllocationMod         , only: nu_com_phosphatase,nu_com_nfix
@@ -234,7 +234,7 @@ contains
 
     ! Stress options
     namelist /elm_inparm/ &
-         implicit_stress, atm_gustiness
+         implicit_stress, atm_gustiness, force_land_gustiness
 
     ! vertical soil mixing variables
     namelist /elm_inparm/  &
@@ -827,6 +827,7 @@ contains
     call mpi_bcast (urban_traffic , 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (implicit_stress, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (atm_gustiness, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (force_land_gustiness, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (nsegspc, 1, MPI_INTEGER, 0, mpicom, ier)
     call mpi_bcast (subgridflag , 1, MPI_INTEGER, 0, mpicom, ier)
     call mpi_bcast (wrtdia, 1, MPI_LOGICAL, 0, mpicom, ier)
@@ -1135,6 +1136,7 @@ contains
     write(iulog,*) '   urban traffic flux   = ', urban_traffic
     write(iulog,*) '   implicit_stress   = ', implicit_stress
     write(iulog,*) '   atm_gustiness   = ', atm_gustiness
+    write(iulog,*) '   force_land_gustiness   = ', force_land_gustiness
     write(iulog,*) '   more vertical layers = ', more_vertlayers
     
     write(iulog,*) '   Sub-grid topographic effects on solar radiation   = ', use_top_solar_rad  ! TOP solar radiation parameterization

--- a/components/elm/src/main/lnd2atmMod.F90
+++ b/components/elm/src/main/lnd2atmMod.F90
@@ -181,7 +181,9 @@ contains
       q_ref2m     => veg_ws%q_ref2m , &
       q_ref2m_grc => lnd2atm_vars%q_ref2m_grc      , &
       u10_elm_patch => frictionvel_vars%u10_elm_patch , &
+      u10_with_gusts_elm_patch => frictionvel_vars%u10_with_gusts_elm_patch, &
       u_ref10m_grc => lnd2atm_vars%u_ref10m_grc      , &
+      u_ref10m_with_gusts_grc => lnd2atm_vars%u_ref10m_with_gusts_grc      , &
       taux     => veg_ef%taux , &
       taux_grc => lnd2atm_vars%taux_grc      , &
       tauy     => veg_ef%tauy , &
@@ -256,6 +258,11 @@ contains
     call p2g(bounds, &
          u10_elm_patch(bounds%begp:bounds%endp) , &
          u_ref10m_grc (bounds%begg:bounds%endg)     , &
+         p2c_scale_type=unity, c2l_scale_type= unity, l2g_scale_type=unity)
+
+    call p2g(bounds, &
+         u10_with_gusts_elm_patch(bounds%begp:bounds%endp) , &
+         u_ref10m_with_gusts_grc (bounds%begg:bounds%endg)     , &
          p2c_scale_type=unity, c2l_scale_type= unity, l2g_scale_type=unity)
 
     call p2g(bounds, &

--- a/components/elm/src/main/lnd2atmType.F90
+++ b/components/elm/src/main/lnd2atmType.F90
@@ -30,6 +30,7 @@ module lnd2atmType
      real(r8), pointer :: t_ref2m_grc        (:)   => null() ! 2m surface air temperature (Kelvin)
      real(r8), pointer :: q_ref2m_grc        (:)   => null() ! 2m surface specific humidity (kg/kg)
      real(r8), pointer :: u_ref10m_grc       (:)   => null() ! 10m surface wind speed (m/sec)
+     real(r8), pointer :: u_ref10m_with_gusts_grc(:)=> null()! 10m surface wind speed with gusts included (m/sec)
      real(r8), pointer :: h2osno_grc         (:)   => null() ! snow water (mm H2O)
      real(r8), pointer :: h2osoi_vol_grc     (:,:) => null() ! volumetric soil water (0~watsat, m3/m3, nlevgrnd) (for dust model)
      real(r8), pointer :: albd_grc           (:,:) => null() ! (numrad) surface albedo (direct)
@@ -118,6 +119,7 @@ contains
     allocate(this%t_ref2m_grc          (begg:endg))            ; this%t_ref2m_grc          (:) =ival
     allocate(this%q_ref2m_grc          (begg:endg))            ; this%q_ref2m_grc          (:) =ival
     allocate(this%u_ref10m_grc         (begg:endg))            ; this%u_ref10m_grc         (:) =ival
+    allocate(this%u_ref10m_with_gusts_grc(begg:endg))          ; this%u_ref10m_with_gusts_grc(:)=ival
     allocate(this%h2osno_grc           (begg:endg))            ; this%h2osno_grc           (:) =ival
     allocate(this%h2osoi_vol_grc       (begg:endg,1:nlevgrnd)) ; this%h2osoi_vol_grc     (:,:) =ival
     allocate(this%albd_grc             (begg:endg,1:numrad))   ; this%albd_grc           (:,:) =ival

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -2541,6 +2541,7 @@ contains
             i2x_i % rAttr(index_i2x_Si_t     ,n)  = Tsrf
             i2x_i % rAttr(index_i2x_Si_bpress,n)  = basalPressure
             i2x_i % rAttr(index_i2x_Si_u10   ,n)  = atmosReferenceSpeed10m(i)
+            i2x_i % rAttr(index_i2x_Si_u10withgusts,n) = atmosReferenceSpeed10m(i)
             i2x_i % rAttr(index_i2x_Si_tref  ,n)  = atmosReferenceTemperature2m(i)
             i2x_i % rAttr(index_i2x_Si_qref  ,n)  = atmosReferenceHumidity2m(i)
             i2x_i % rAttr(index_i2x_Si_snowh ,n)  = snowVolumeCell(i) / ailohi

--- a/components/mpas-seaice/driver/mpassi_cpl_indices.F
+++ b/components/mpas-seaice/driver/mpassi_cpl_indices.F
@@ -22,6 +22,7 @@ module mpassi_cpl_indices
   integer :: index_i2x_Si_anidr        ! albedo: visible, diffuse        
   integer :: index_i2x_Si_anidf        ! albedo: near ir, diffuse        
   integer :: index_i2x_Si_u10          ! 10m wind
+  integer :: index_i2x_Si_u10withgusts ! 10m wind root-mean-square magnitude with gustiness
   integer :: index_i2x_Faii_lwup       ! upward longwave heat flux  
   integer :: index_i2x_Faii_lat        ! latent          heat flux  
   integer :: index_i2x_Faii_sen        ! sensible        heat flux      
@@ -154,6 +155,7 @@ contains
     index_i2x_Si_anidf      = mct_avect_indexra(i2x,'Si_anidf')
     index_i2x_Si_snowh      = mct_avect_indexra(i2x,'Si_snowh')
     index_i2x_Si_u10        = mct_avect_indexra(i2x,'Si_u10')
+    index_i2x_Si_u10withgusts = mct_avect_indexra(i2x,'Si_u10withgusts')
     index_i2x_Faii_taux     = mct_avect_indexra(i2x,'Faii_taux')
     index_i2x_Faii_tauy     = mct_avect_indexra(i2x,'Faii_tauy')
     index_i2x_Faii_lat      = mct_avect_indexra(i2x,'Faii_lat')

--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -204,6 +204,10 @@
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
+    <values match="last">
+      <value compset="_EAM">TRUE</value>
+      <value compset="SCREAM">FALSE</value>
+    </values>
     <group>run_flags</group>
     <file>env_run.xml</file>
     <desc>

--- a/driver-mct/main/seq_flux_mct.F90
+++ b/driver-mct/main/seq_flux_mct.F90
@@ -71,6 +71,7 @@ module seq_flux_mct
   real(r8), allocatable ::  tref (:)  ! diagnostic:  2m ref T
   real(r8), allocatable ::  qref (:)  ! diagnostic:  2m ref Q
   real(r8), allocatable :: duu10n(:)  ! diagnostic: 10m wind speed squared
+  real(r8), allocatable :: u10res(:)  ! diagnostic: 10m "resolved" (no gustiness) wind speed (m/s)^2
 
   real(r8), allocatable :: fswpen (:) ! fraction of sw penetrating ocn surface layer
   real(r8), allocatable :: ocnsal (:) ! ocean salinity
@@ -171,6 +172,7 @@ module seq_flux_mct
   integer :: index_xao_So_ssq
   integer :: index_xao_So_duu10n
   integer :: index_xao_So_u10
+  integer :: index_xao_So_u10withgusts
   integer :: index_xao_So_fswpen
   integer :: index_xao_So_warm_diurn
   integer :: index_xao_So_salt_diurn
@@ -343,6 +345,9 @@ contains
     allocate(duu10n(nloc),stat=ier)
     if(ier/=0) call mct_die(subName,'allocate duu10n',ier)
     duu10n = 0.0_r8
+    allocate(u10res(nloc),stat=ier)
+    if(ier/=0) call mct_die(subName,'allocate u10res',ier)
+    u10res = 0.0_r8
 
     !--- flux_diurnal cycle flux fields ---
     allocate(uGust(nloc),stat=ier)
@@ -744,6 +749,8 @@ contains
     if(ier/=0) call mct_die(subName,'allocate qref',ier)
     allocate(duu10n(nloc_a2o),stat=ier)
     if(ier/=0) call mct_die(subName,'allocate duu10n',ier)
+    allocate(u10res(nloc_a2o),stat=ier)
+    if(ier/=0) call mct_die(subName,'allocate u10res',ier)
 
     ! set emask
 
@@ -986,6 +993,7 @@ contains
     integer(in) :: index_tref
     integer(in) :: index_qref
     integer(in) :: index_duu10n
+    integer(in) :: index_u10withgusts
     integer(in) :: index_ustar
     integer(in) :: index_ssq
     integer(in) :: index_re
@@ -1138,8 +1146,9 @@ contains
             warmMaxInc, windMaxInc, qSolInc, windInc, nInc, &
             tbulk, tskin, tskin_day, tskin_night, &
             cskin, cskin_night, tod, dt,          &
-            duu10n,ustar, re  , ssq , missval = 0.0_r8, &
+            duu10n, ustar, re  , ssq , missval = 0.0_r8, &
             cold_start=cold_start, wsresp=wsresp, tau_est=tau_est)
+       u10res = sqrt(duu10n) ! atm-supplied gustiness not implemented for flux_diurnal
     else if (ocn_surface_flux_scheme.eq.2) then
        call shr_flux_atmOcn_UA(nloc_a2o , zbot , ubot, vbot, thbot, &
             shum , shum_16O , shum_HDO, shum_18O, dens , tbot, pslv, &
@@ -1148,6 +1157,7 @@ contains
             evap , evap_16O, evap_HDO, evap_18O, taux, tauy, tref, qref , &
             duu10n,ustar, re  , ssq , missval = 0.0_r8, &
             wsresp=wsresp, tau_est=tau_est)
+       u10res = sqrt(duu10n) ! atm-supplied gustiness not implemented for UA
     else
 
        call shr_flux_atmocn (nloc_a2o , zbot , ubot, vbot, thbot, &
@@ -1157,7 +1167,7 @@ contains
             roce_16O, roce_HDO, roce_18O,    &
             evap , evap_16O, evap_HDO, evap_18O, taux, tauy, tref, qref , &
             ocn_surface_flux_scheme, &
-            duu10n,ustar, re  , ssq , missval = 0.0_r8, &
+            duu10n, u10res, ustar, re  , ssq , missval = 0.0_r8, &
             wsresp=wsresp, tau_est=tau_est, ugust=ugust)
     endif
 
@@ -1176,6 +1186,7 @@ contains
     index_tref   = mct_aVect_indexRA(xaop_ae,"So_tref")
     index_qref   = mct_aVect_indexRA(xaop_ae,"So_qref")
     index_duu10n = mct_aVect_indexRA(xaop_ae,"So_duu10n")
+    index_u10withgusts = mct_aVect_indexRA(xaop_ae,"So_u10withgusts")
     index_ustar  = mct_aVect_indexRA(xaop_ae,"So_ustar")
     index_ssq    = mct_aVect_indexRA(xaop_ae,"So_ssq")
     index_re     = mct_aVect_indexRA(xaop_ae,"So_re")
@@ -1216,7 +1227,8 @@ contains
        xaop_oe%rAttr(index_ssq   ,io) = xaop_oe%rAttr(index_ssq   ,io) + ssq(n) * wt   ! s.hum. saturation at Ts
        xaop_oe%rAttr(index_lwup  ,io) = xaop_oe%rAttr(index_lwup  ,io) + lwup(n)* wt
        xaop_oe%rAttr(index_duu10n,io) = xaop_oe%rAttr(index_duu10n,io) + duu10n(n)*wt
-       xaop_oe%rAttr(index_u10   ,io) = xaop_oe%rAttr(index_u10   ,io) + sqrt(duu10n(n))*wt
+       xaop_oe%rAttr(index_u10   ,io) = xaop_oe%rAttr(index_u10   ,io) + u10res(n)*wt
+       xaop_oe%rAttr(index_u10withgusts,io) = xaop_oe%rAttr(index_u10withgusts,io) + sqrt(duu10n(n))*wt
        xaop_oe%rAttr(index_sumwt ,io) = xaop_oe%rAttr(index_sumwt ,io) + wt
     enddo
 
@@ -1250,7 +1262,8 @@ contains
        xaop_ae%rAttr(index_ssq   ,ia) = xaop_ae%rAttr(index_ssq   ,ia) + ssq(n) * wt   ! s.hum. saturation at Ts
        xaop_ae%rAttr(index_lwup  ,ia) = xaop_ae%rAttr(index_lwup  ,ia) + lwup(n)* wt
        xaop_ae%rAttr(index_duu10n,ia) = xaop_ae%rAttr(index_duu10n,ia) + duu10n(n)*wt
-       xaop_ae%rAttr(index_u10   ,ia) = xaop_ae%rAttr(index_u10   ,ia) + sqrt(duu10n(n))*wt
+       xaop_ae%rAttr(index_u10   ,ia) = xaop_ae%rAttr(index_u10   ,ia) + u10res(n)*wt
+       xaop_ae%rAttr(index_u10withgusts,ia) = xaop_ae%rAttr(index_u10withgusts,ia) + sqrt(duu10n(n))*wt
        xaop_ae%rAttr(index_sumwt ,ia) = xaop_ae%rAttr(index_sumwt ,ia) + wt
     enddo
 
@@ -1366,6 +1379,7 @@ contains
        index_xao_So_re     = mct_aVect_indexRA(xao,'So_re')
        index_xao_So_ssq    = mct_aVect_indexRA(xao,'So_ssq')
        index_xao_So_u10    = mct_aVect_indexRA(xao,'So_u10')
+       index_xao_So_u10withgusts = mct_aVect_indexRA(xao,'So_u10withgusts')
        index_xao_So_duu10n = mct_aVect_indexRA(xao,'So_duu10n')
        index_xao_Faox_taux = mct_aVect_indexRA(xao,'Faox_taux')
        index_xao_Faox_tauy = mct_aVect_indexRA(xao,'Faox_tauy')
@@ -1602,6 +1616,7 @@ contains
                                 !consistent with mrgx2a fraction
                                 !duu10n,ustar, re  , ssq, missval = 0.0_r8 )
             cold_start=cold_start, wsresp=wsresp, tau_est=tau_est)
+       u10res = sqrt(duu10n) ! atm-supplied gustiness not implemented for flux_diurnal
     else if (ocn_surface_flux_scheme.eq.2) then
        call shr_flux_atmOcn_UA(nloc , zbot , ubot, vbot, thbot, &
             shum , shum_16O , shum_HDO, shum_18O, dens , tbot, pslv, &
@@ -1609,6 +1624,7 @@ contains
             roce_16O, roce_HDO, roce_18O,    &
             evap , evap_16O, evap_HDO, evap_18O, taux , tauy, tref, qref , &
             duu10n,ustar, re  , ssq, wsresp=wsresp, tau_est=tau_est)
+       u10res = sqrt(duu10n) ! atm-supplied gustiness not implemented for UA
     else
        call shr_flux_atmocn (nloc , zbot , ubot, vbot, thbot, &
             shum , shum_16O , shum_HDO, shum_18O, dens , tbot, uocn, vocn , &
@@ -1617,7 +1633,7 @@ contains
             roce_16O, roce_HDO, roce_18O,    &
             evap , evap_16O, evap_HDO, evap_18O, taux , tauy, tref, qref , &
             ocn_surface_flux_scheme, &
-            duu10n,ustar, re  , ssq, &
+            duu10n, u10res, ustar, re  , ssq, &
             wsresp=wsresp, tau_est=tau_est, ugust=ugust_atm)
        !missval should not be needed if flux calc
        !consistent with mrgx2a fraction
@@ -1641,7 +1657,8 @@ contains
           xao%rAttr(index_xao_So_ssq   ,n) = ssq(n)    ! s.hum. saturation at Ts
           xao%rAttr(index_xao_Faox_lwup,n) = lwup(n)
           xao%rAttr(index_xao_So_duu10n,n) = duu10n(n)
-          xao%rAttr(index_xao_So_u10   ,n) = sqrt(duu10n(n))
+          xao%rAttr(index_xao_So_u10   ,n) = u10res(n)
+          xao%rAttr(index_xao_So_u10withgusts,n) = sqrt(duu10n(n))
           xao%rAttr(index_xao_So_warm_diurn       ,n) = warm(n)
           xao%rAttr(index_xao_So_salt_diurn       ,n) = salt(n)
           xao%rAttr(index_xao_So_speed_diurn      ,n) = speed(n)

--- a/driver-mct/shr/seq_flds_mod.F90
+++ b/driver-mct/shr/seq_flds_mod.F90
@@ -1278,8 +1278,19 @@ contains
     call seq_flds_add(x2a_states,"Sx_u10")
     longname = '10m wind'
     stdname  = '10m_wind'
-    units    = 'm'
+    units    = 'm s-1'
     attname  = 'u10'
+    call metadata_set(attname, longname, stdname, units)
+
+    ! 10 meter wind with gustiness
+    call seq_flds_add(i2x_states,"Si_u10withgusts")
+    call seq_flds_add(xao_states,"So_u10withgusts")
+    call seq_flds_add(l2x_states,"Sl_u10withgusts")
+    call seq_flds_add(x2a_states,"Sx_u10withgusts")
+    longname = '10m wind with gustiness'
+    stdname  = ''
+    units    = 'm s-1'
+    attname  = 'u10withgusts'
     call metadata_set(attname, longname, stdname, units)
 
     ! Zonal surface stress"

--- a/share/util/shr_flux_mod.F90
+++ b/share/util/shr_flux_mod.F90
@@ -149,7 +149,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
            &               evap  ,evap_16O, evap_HDO, evap_18O, &
            &               taux  ,tauy  ,tref  ,qref  ,   &
            &               ocn_surface_flux_scheme, &
-           &               duu10n,  ustar_sv   ,re_sv ,ssq_sv,   &
+           &               duu10n, u10res, ustar_sv   ,re_sv ,ssq_sv,   &
            &               missval, wsresp, tau_est, ugust)
 
 ! !USES:
@@ -194,6 +194,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
    real(R8),intent(out)  ::  tref (nMax) ! diag:  2m ref height T     (K)
    real(R8),intent(out)  ::  qref (nMax) ! diag:  2m ref humidity (kg/kg)
    real(R8),intent(out)  :: duu10n(nMax) ! diag: 10m wind speed squared (m/s)^2
+   real(R8),intent(out)  :: u10res(nMax) ! diag: 10m "resolved" (no gustiness) wind speed (m/s)^2
 
    real(R8),intent(out),optional :: ustar_sv(nMax) ! diag: ustar
    real(R8),intent(out),optional :: re_sv   (nMax) ! diag: sqrt of exchange coefficient (water)
@@ -481,6 +482,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
         qref(n) =  qbot(n) - delq*fac
 
         duu10n(n) = u10n*u10n ! 10m wind speed squared
+        u10res(n) = u10n*wind_adj/vmag
 
         !------------------------------------------------------------
         ! optional diagnostics, needed for water tracer fluxes (dcn)
@@ -505,6 +507,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
         tref  (n) = spval  !  2m reference height temperature (K)
         qref  (n) = spval  !  2m reference height humidity (kg/kg)
         duu10n(n) = spval  ! 10m wind speed squared (m/s)^2
+        u10res(n) = spval  ! 10m "resolved" (no gustiness) wind speed (m/s)^2
 
         if (present(ustar_sv)) ustar_sv(n) = spval
         if (present(re_sv   )) re_sv   (n) = spval
@@ -585,6 +588,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
         tref(n) = trf
         qref(n) = qrf
         duu10n(n) = urf**2+vrf**2
+        u10res(n) = sqrt(duu10n(n)) ! atm-supplied gustiness not implemented for COARE
 
         !------------------------------------------------------------
         ! optional diagnostics, needed for water tracer fluxes (dcn)
@@ -609,6 +613,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
         tref     (n) = spval  !  2m reference height temperature (K)
         qref     (n) = spval  !  2m reference height humidity (kg/kg)
         duu10n   (n) = spval  ! 10m wind speed squared (m/s)^2
+        u10res   (n) = spval  ! 10m "resolved" (no gustiness) wind speed (m/s)^2
 
         if (present(ustar_sv)) ustar_sv(n) = spval
         if (present(re_sv   )) re_sv   (n) = spval

--- a/share/util/shr_flux_mod.F90
+++ b/share/util/shr_flux_mod.F90
@@ -337,7 +337,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
         wind0 = max(sqrt((ubot(n) - us(n))**2 + (vbot(n) - vs(n))**2), 0.01_r8)
         vmag = wind0
         if (present(ugust)) then
-           vmag = vmag + ugust(n)
+           vmag = sqrt(vmag**2 + ugust(n)**2)
         end if
         vmag = max(seq_flux_atmocn_minwind, vmag)
         if (use_coldair_outbreak_mod) then
@@ -382,7 +382,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
                 tau, prev_tau, tau_diff, prev_tau_diff, wind_adj)
            vmag = wind_adj
            if (present(ugust)) then
-              vmag = vmag + ugust(n)
+              vmag = sqrt(vmag**2 + ugust(n)**2)
            end if
            vmag = max(seq_flux_atmocn_minwind, vmag)
         else
@@ -431,7 +431,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
                    tau, prev_tau, tau_diff, prev_tau_diff, wind_adj)
               vmag = wind_adj
               if (present(ugust)) then
-                 vmag = vmag + ugust(n)
+                 vmag = sqrt(vmag**2 + ugust(n)**2)
               end if
               vmag = max(seq_flux_atmocn_minwind, vmag)
            end if


### PR DESCRIPTION
This is designed to fix the following issues:

 * #5834
 * #5835
 * #5836
 * #5837

The first of these was fixed by forcing ATM_SUPPLIES_GUSTINESS=TRUE
for all EAM cases, and the second was fixed purely by rewriting the
Fortran formulas. These two changes are climate changing, and will
generally tend to reduce the impact of gustiness on the mean winds,
i.e. mean wind speed will increase.

The third fix is to the U10 diagnostic only, and will decrease the
output U10. A value that has not been "fixed" in this way can be
obtained by outputting the new history variable 'U10WITHGUSTS' from
EAM.

The final fix is to remove some double-counting between gustiness
parameterizations in EAM and ELM. The fix can be "undone" by setting
`force_land_gustiness = .true.` in the ELM namelist.

Note that these fixes are only applied over land and ocean. At the
request of sea ice developers, this tag also disables gustiness over
sea ice completely.

Fixes #5834
Fixes #5835
Fixes #5836 
Fixes #5837 

[CC]
[NML]