### PR TITLE
EAM/HOMME: Remove -DNC=4 in bld/configure; NC is an unused symbol.

### DIFF
--- a/components/eam/bld/configure
+++ b/components/eam/bld/configure
@@ -1863,7 +1863,7 @@ if (!$ccsm_seq){
 # on some older compilers used by HOMME standalone.
 if ($dyn_pkg eq 'se') {
     my $csnp = $cfg_ref->get('csnp');
-    $cfg_cppdefs .= " -DNP=$csnp -DNC=4 -DHAVE_F2003_PTR_BND_REMAP";
+    $cfg_cppdefs .= " -DNP=$csnp -DHAVE_F2003_PTR_BND_REMAP";
     if ($smp eq 'ON') {
       $cfg_cppdefs .= " -DHORIZ_OPENMP"
     }


### PR DESCRIPTION
It is believed that NC was used in HOMME long ago. In any case, it is not used any longer. Remove it from bld/configure.

[BFB]