### PR TITLE
Add micro_p3 to list of possible ptend names in physpkg

### DIFF
--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -3101,14 +3101,14 @@ subroutine add_fld_default_calls()
   implicit none
 
   !Add all existing ptend names for the addfld calls
-  character(len=20), parameter :: vlist(27) = (/     'topphysbc           '                       ,&
+  character(len=20), parameter :: vlist(28) = (/     'topphysbc           '                       ,&
        'chkenergyfix        ','dadadj              ','zm_convr            ','zm_conv_evap        ',&
        'momtran             ','zm_conv_tend        ','UWSHCU              ','convect_shallow     ',&
        'pcwdetrain_mac      ','macro_park          ','macrop              ','micro_mg            ',&
        'cldwat_mic          ','aero_model_wetdep_ma','convtran2           ','cam_radheat         ',&
        'chemistry           ','vdiff               ','rayleigh_friction   ','aero_model_drydep_ma',&
        'Grav_wave_drag      ','convect_shallow_off ','clubb_ice1          ','clubb_det           ',&
-       'clubb_ice4          ','clubb_srf           ' /)
+       'clubb_ice4          ','clubb_srf           ','micro_p3            ' /)
 
 
 


### PR DESCRIPTION
Fixes missing field error when running PGN test
`ERROR: GET_MASTERLIST_INDX: attemping to output field s_micro_p3 not on master list`
Fixed by adding `micro_p3` to the list of possible ptend field names.
[bfb]