### PR TITLE
Change TSC test default to use F2010

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -221,7 +221,7 @@ _TESTS = {
     "e3sm_atm_nbfb" : {
         "tests" : (
             "PGN_P1x1.ne4_oQU240.F2010",
-            "TSC.ne4_oQU240.F2010-CICE",
+            "TSC.ne4_oQU240.F2010",
             "MVK_PS.ne4_oQU240.F2010",
             )
         },


### PR DESCRIPTION
Revert TSC non-b4b test to use the F2010 compset

With the fix in MPAS-SI: "Corrects thin ice/snow treatment of enthalpy and other tracers" (#5630) the TSC test can now generate a baseline with dtime=1 using MPAS-SI

[non-BFB] only for TSC test