### PR TITLE
fix openacc data directive on non-existent ssh_sal array

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
@@ -434,7 +434,6 @@ contains
           call ocn_compute_self_attraction_loading(domain, forcingPool, dminfo, ssh, err)
           call mpas_reset_clock_alarm(domain % clock, 'salComputeAlarm', ierr=err)
       endif
-      !$acc update device(ssh_sal)
 
       ! Add tidal potential (if needed) 
       call ocn_compute_tidal_potential_forcing(err)

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
@@ -184,6 +184,9 @@ contains
 
         endif
 
+        ! ssh_sal currently computed on host but must be transferred
+        ! to device for later tendency calculations
+        !$acc update device(ssh_sal)
 
         call mpas_timer_stop('SAL Calculation')
 


### PR DESCRIPTION
An openacc data transfer on the self-attraction ssh change was outside any conditional for SAL so was operating on a non-existent array if SAL is turned off. This mod changes the location of the data directive so it is within the compute SAL routine and only executed of SAL is turned on

bfb
fixes #5866 

