### PR TITLE
Bugfix: rework P3_input_dim and P3_output_dim for hist_coord

### DIFF
--- a/components/eam/src/physics/p3/eam/micro_p3_interface.F90
+++ b/components/eam/src/physics/p3/eam/micro_p3_interface.F90
@@ -257,12 +257,11 @@ end subroutine micro_p3_readnl
 
   logical :: prog_modal_aero ! prognostic aerosols
 
+  integer :: idim
   integer,parameter :: P3_in_dimsize = 16
   integer,parameter :: P3_out_dimsize = 32
-  integer,parameter,dimension(P3_in_dimsize) :: &
-          P3_input_dim = (/ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16/)
-  integer,parameter,dimension(P3_out_dimsize) :: &
-          P3_output_dim = (/ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32 /)
+  integer,parameter :: P3_input_dim(P3_in_dimsize)   = [ (idim, idim = 1, P3_in_dimsize) ]
+  integer,parameter :: P3_output_dim(P3_out_dimsize) = [ (idim, idim = 1, P3_out_dimsize) ]
 
   if (masterproc) write(iulog,'(A20)') ' P3 register start ...'
 

--- a/components/eam/src/physics/p3/eam/micro_p3_interface.F90
+++ b/components/eam/src/physics/p3/eam/micro_p3_interface.F90
@@ -260,8 +260,10 @@ end subroutine micro_p3_readnl
   integer :: idim
   integer,parameter :: P3_in_dimsize = 16
   integer,parameter :: P3_out_dimsize = 32
-  integer,parameter :: P3_input_dim(P3_in_dimsize)   = [ (idim, idim = 1, P3_in_dimsize) ]
-  integer,parameter :: P3_output_dim(P3_out_dimsize) = [ (idim, idim = 1, P3_out_dimsize) ]
+  integer,parameter,dimension(P3_in_dimsize) :: &
+          P3_input_dim = (/ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16/)
+  integer,parameter,dimension(P3_out_dimsize) :: &
+          P3_output_dim = (/ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32 /)
 
   if (masterproc) write(iulog,'(A20)') ' P3 register start ...'
 

--- a/components/eam/src/physics/p3/eam/micro_p3_interface.F90
+++ b/components/eam/src/physics/p3/eam/micro_p3_interface.F90
@@ -257,6 +257,13 @@ end subroutine micro_p3_readnl
 
   logical :: prog_modal_aero ! prognostic aerosols
 
+  integer,parameter :: P3_in_dimsize = 16
+  integer,parameter :: P3_out_dimsize = 32
+  integer,parameter,dimension(P3_in_dimsize) :: &
+          P3_input_dim = (/ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16/)
+  integer,parameter,dimension(P3_out_dimsize) :: &
+          P3_output_dim = (/ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32 /)
+
   if (masterproc) write(iulog,'(A20)') ' P3 register start ...'
 
   call phys_getopts( prog_modal_aero_out   = prog_modal_aero )
@@ -341,8 +348,8 @@ end subroutine micro_p3_readnl
    call pbuf_add_field('MON_CCN_1',  'global', dtype_r8,(/pcols,pver/),mon_ccn_1_idx)
    call pbuf_add_field('MON_CCN_2',  'global', dtype_r8,(/pcols,pver/),mon_ccn_2_idx)
 
-   call add_hist_coord('P3_input_dim',  16, 'Input field dimension for p3_main subroutine',  'N/A', (/ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16 /))
-   call add_hist_coord('P3_output_dim',    32, 'Output field dimension for p3_main subroutine', 'N/A', (/ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32 /))
+   call add_hist_coord('P3_input_dim',  P3_in_dimsize, 'Input field dimension for p3_main subroutine',  'N/A', P3_input_dim)
+   call add_hist_coord('P3_output_dim', P3_out_dimsize, 'Output field dimension for p3_main subroutine', 'N/A', P3_output_dim)
 
    if (masterproc) write(iulog,'(A20)') '    P3 register finished'
   end subroutine micro_p3_register


### PR DESCRIPTION
The constant integer scalar and array in calling add_hist_coord to define 
P3_input_dim and P3_output_dim can cause type mismatch for some compilers,
leading to invalid values of these two coordinate arrays in eam history output, along
with randomness from one run to another. This behavior causes tests to be labelled diff
although they are otherwise BFB.

Fixes #5863 

[BFB] for all actual test results. Some baselines (that compare eam.h#) may contain invalid
         values for P3_input_dim and/or P3_output_dim, and the tests would report diff.

------------------------------------------------
Note: The size of P3_input_dim size may be more appropriate to be 17 instead of 16,  as seen at line 1052 and lines  1266-1282 of the updated micro_p3_interface.F90. However, these two coordinate arrays are never used in the model. Rather, they are just for reference in output file. Changing from 16 to 17 would cause more tests to diff that do not experience this issue. 