### PR TITLE
Correct the units of active tracer tendencies

### DIFF
--- a/components/mpas-ocean/src/tracer_groups/Registry_activeTracers.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_activeTracers.xml
@@ -75,11 +75,11 @@
 	<var_struct name="tend" time_levs="1">
 		<var_struct name="tracersTend" time_levs="1">
 			<var_array name="activeTracersTend" type="real" dimensions="nVertLevels nCells Time" packages="activeTracersPKG" missing_value="FILLVAL" missing_value_mask="cellMask">
-				<var name="temperatureTend" array_group="activeGRP" units="C s^-1"
-			 description="time tendency of potential temperature"
+				<var name="temperatureTend" array_group="activeGRP" units="C m s^-1"
+			 description="time tendency of potential temperature measured as change in degrees times layerThickness per second"
 				/>
-				<var name="salinityTend" array_group="activeGRP" units="1.e-3 s^-1"
-			 description="time tendency of salinity measured as change in practical salinity units per second"
+				<var name="salinityTend" array_group="activeGRP" units="m 1.e-3 s^-1"
+			 description="time tendency of salinity measured as change in practical salinity units times layerThickness per second"
 				/>
 			</var_array>
 		</var_struct>


### PR DESCRIPTION
The units of active tracer tendencies in the Registry should have an additional factor of `m`. 

The `activeTracerTend`'s are divided by a factor of `layerThickness` when they are used in the code to update active tracers. This operation is also needed to evaluate tracer conservation from `activeTracerTend` output.

[BFB]