### PR TITLE
Fix array shapes in where assignment statements in micro_p3_interface.F90

### DIFF
--- a/components/eam/src/physics/p3/eam/micro_p3_interface.F90
+++ b/components/eam/src/physics/p3/eam/micro_p3_interface.F90
@@ -1565,9 +1565,9 @@ end subroutine micro_p3_readnl
            numrain(:ncol,top_lev:) * rho(:ncol,top_lev:), &
            rho(:ncol,top_lev:), rho_h2o)
 
-      aqrain = rain * cld_frac_r
-      anrain = numrain * cld_frac_r
-      freqr = cld_frac_r
+      aqrain(:ncol,top_lev:) = rain(:ncol,top_lev:) * cld_frac_r(:ncol,top_lev:)
+      anrain(:ncol,top_lev:) = numrain(:ncol,top_lev:) * cld_frac_r(:ncol,top_lev:)
+      freqr(:ncol,top_lev:) = cld_frac_r(:ncol,top_lev:)
       reff_rain(:ncol,top_lev:) = drout2(:ncol,top_lev:) * &
            1.5_rtype * 1.e6_rtype
    end where


### PR DESCRIPTION
Mismatch of array shapes in where assignment statements and where mask expression causing three diagostic variables, AQRAIN, ANRAIN, FREQR, to differ from one run to another when using gnu compiler. The declared shapes of the three arrays are the same as the array rain. While the scope could be narrowed with rain(:ncol,top_lev:) in the mask expression, the assignment statments for the three affected variables still use the full scope. Although test with other compilers, e.g., intel, does not report diff, the diagnostic output for these three variables are assumed to have also be affected.

Fixes #5864

[NBFB] for tests that compare eam.h0 with diff in AQRAIN, ANRAIN and FREQR.
       The test results are otherwise not affected.