### PR TITLE
Use prescirbed oxidants of corresponding time period  for VBS SOA and MAM5

### DIFF
--- a/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6_chemUCI-Linoz-mam5-vbs-1pctCO2.xml
+++ b/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6_chemUCI-Linoz-mam5-vbs-1pctCO2.xml
@@ -76,10 +76,10 @@
 
 <!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
 <tracer_cnst_type    >CYCLICAL</tracer_cnst_type>
-<tracer_cnst_cycle_yr>1995</tracer_cnst_cycle_yr>
-<tracer_cnst_file    >ch4_oxid_1.9x2.5_L26_1990-1999clim.c090804.nc</tracer_cnst_file>
+<tracer_cnst_cycle_yr>1849</tracer_cnst_cycle_yr>
+<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c20181106.nc</tracer_cnst_file>
 <tracer_cnst_filelist>''</tracer_cnst_filelist>
-<tracer_cnst_datapath>atm/cam/chem/methane</tracer_cnst_datapath>
+<tracer_cnst_datapath>atm/cam/chem/trop_mozart_aero/oxid</tracer_cnst_datapath>
 <tracer_cnst_specifier>'prsd_O3:O3','prsd_NO3:NO3','prsd_OH:OH'</tracer_cnst_specifier>
 
 <!-- prescribed methane  -->

--- a/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6_chemUCI-Linoz-mam5-vbs.xml
+++ b/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6_chemUCI-Linoz-mam5-vbs.xml
@@ -72,10 +72,10 @@
 
 <!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
 <tracer_cnst_type    >CYCLICAL</tracer_cnst_type>
-<tracer_cnst_cycle_yr>1995</tracer_cnst_cycle_yr>
-<tracer_cnst_file    >ch4_oxid_1.9x2.5_L26_1990-1999clim.c090804.nc</tracer_cnst_file>
+<tracer_cnst_cycle_yr>1849</tracer_cnst_cycle_yr>
+<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c20181106.nc</tracer_cnst_file>
 <tracer_cnst_filelist>''</tracer_cnst_filelist>
-<tracer_cnst_datapath>atm/cam/chem/methane</tracer_cnst_datapath>
+<tracer_cnst_datapath>atm/cam/chem/trop_mozart_aero/oxid</tracer_cnst_datapath>
 <tracer_cnst_specifier>'prsd_O3:O3','prsd_NO3:NO3','prsd_OH:OH'</tracer_cnst_specifier>
 
 <!-- prescribed methane  -->

--- a/components/eam/bld/namelist_files/use_cases/2010_eam_CMIP6_chemUCI-Linoz-mam5-vbs.xml
+++ b/components/eam/bld/namelist_files/use_cases/2010_eam_CMIP6_chemUCI-Linoz-mam5-vbs.xml
@@ -69,10 +69,10 @@
 
 <!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
 <tracer_cnst_type    >CYCLICAL</tracer_cnst_type>
-<tracer_cnst_cycle_yr>1995</tracer_cnst_cycle_yr>
-<tracer_cnst_file    >ch4_oxid_1.9x2.5_L26_1990-1999clim.c090804.nc</tracer_cnst_file>
+<tracer_cnst_cycle_yr>2015</tracer_cnst_cycle_yr>
+<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c20181106.nc</tracer_cnst_file>
 <tracer_cnst_filelist>''</tracer_cnst_filelist>
-<tracer_cnst_datapath>atm/cam/chem/methane</tracer_cnst_datapath>
+<tracer_cnst_datapath>atm/cam/chem/trop_mozart_aero/oxid</tracer_cnst_datapath>
 <tracer_cnst_specifier>'prsd_O3:O3','prsd_NO3:NO3','prsd_OH:OH'</tracer_cnst_specifier>
 
 <!-- prescribed methane  -->

--- a/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6_chemUCI-Linoz-mam5-vbs.xml
+++ b/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6_chemUCI-Linoz-mam5-vbs.xml
@@ -58,11 +58,10 @@
 <airpl_emis_file></airpl_emis_file>   <!-- need to be empty, but if specifying empty here, the value would be root of input_data_path -->
 
 <!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
-<tracer_cnst_type    >CYCLICAL</tracer_cnst_type>
-<tracer_cnst_cycle_yr>1995</tracer_cnst_cycle_yr>
-<tracer_cnst_file    >ch4_oxid_1.9x2.5_L26_1990-1999clim.c090804.nc</tracer_cnst_file>
+<tracer_cnst_type    >INTERP_MISSING_MONTHS</tracer_cnst_type>
+<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2015_c20181106.nc</tracer_cnst_file>
 <tracer_cnst_filelist>''</tracer_cnst_filelist>
-<tracer_cnst_datapath>atm/cam/chem/methane</tracer_cnst_datapath>
+<tracer_cnst_datapath>atm/cam/chem/trop_mozart_aero/oxid</tracer_cnst_datapath>
 <tracer_cnst_specifier>'prsd_O3:O3','prsd_NO3:NO3','prsd_OH:OH'</tracer_cnst_specifier>
 
 <!-- prescribed methane  -->


### PR DESCRIPTION
Current v3alpha02 uses prescribed oxidants (O3, OH, NO3) of 1995 for VBS SOA and MAM5 for all historical/amip, F2010, and PiControl runs. This PR improves this by using the file of corresponding time period. The file proposed to use is from v1 and v2 default setting. 

[CC]
[NML]

---------------------------------------------------------------------------------------------

30yr amip runs and 10yr F2010 runs were conducted. E3SM_diags ([amip](https://portal.nersc.gov/project/m2136/bin/iice/iice.cgi?url1=https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.mwu/E3SMv2/20230802.v3alpha02.amip.baseline.chrysalis/e3sm_diags/atm_monthly_180x360_aave/model_vs_obs_1985-2014/viewer&label1=baseline&url2=https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.mwu/E3SMv2/20230802.v3alpha02.amip.prsd_oxid01.chrysalis/e3sm_diags/atm_monthly_180x360_aave/model_vs_obs_1985-2014/viewer&label2=prsd_oxid01&category=&plot=&diff=0&dconfig=vsObs&), [F2010](https://portal.nersc.gov/project/m2136/bin/iice/iice.cgi?url1=https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.mwu/E3SMv2/20230713.v3alpha02.F2010.baseline.PD.chrysalis/e3sm_diags/atm_monthly_180x360_aave/model_vs_obs_0001-0011/viewer&label1=baseline&url2=https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.mwu/E3SMv2/20230811.v3alpha02.F2010.prsd_oxid01.PD.chrysalis/e3sm_diags/atm_monthly_180x360_aave/model_vs_obs_0001-0011/viewer&label2=prsd_oxid01&category=&plot=&diff=0&dconfig=vsObs&)) show small differences. 

30yr historical run (1850-1879) was conducted. E3SM_diags ([1850-1879](https://portal.nersc.gov/project/m2136/bin/iice/iice.cgi?url1=https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.mwu/E3SMv2/20230704.v3alpha02.historical_0101.chrysalis/e3sm_diags/atm_monthly_180x360_aave/model_vs_obs_1850-1879/viewer&label1=v3alpha02&url2=https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.mwu/E3SMv2/20230823.v3alpha02.historical.prsd_oxid01.chrysalis/e3sm_diags/atm_monthly_180x360_aave/model_vs_obs_1850-1879/viewer&label2=prsd_oxid01&category=&plot=&diff=0&dconfig=vsObs&)) and MPAS_diags ([1850-1879](https://portal.nersc.gov/project/m2136/bin/iice/mpas-a.cgi?url1=https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.mwu/E3SMv2/20230704.v3alpha02.historical_0101.chrysalis/mpas_analysis/ts_1850-1879_climo_1850-1879&label1=v3alpha02&url2=https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.mwu/E3SMv2/20230823.v3alpha02.historical.prsd_oxid01.chrysalis/mpas_analysis/ts_1850-1879_climo_1850-1879&label2=prsd_oxid01&category=&component=&plot=&diff=0&dconfig=wcycl&)) show small differences.

Aerosol related diagnostics are documented on confluence page (https://acme-climate.atlassian.net/wiki/spaces/ATMOS/pages/3742793945/Aerosol+perturbation+tests+within+the+v3dev+atmosphere)
