### PR TITLE
fix for submesoscale parametrization in standalone

### DIFF
--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -711,8 +711,12 @@ module ocn_forward_mode
 
            call ocn_eddy_compute_mixed_layer_depth(statePool, forcingPool)
            if (config_use_GM .or. config_submesoscale_enable) then
-               call mpas_timer_start("submesoscale eddy velocity compute", .false.)
                call ocn_eddy_compute_buoyancy_gradient()
+           end if
+
+           if (config_submesoscale_enable) then
+               call mpas_timer_start("submesoscale eddy velocity compute", .false.)
+               call ocn_submesoscale_compute_velocity()
                call mpas_timer_stop("submesoscale eddy velocity compute")
            end if
 


### PR DESCRIPTION
At the moment, the submesoscale parametrization does not work properly in MPAS-O standalone, that is even if 
`config_submesoscale_enable = .true.`
the parametrization is not active. To solve this issue, the subroutine `ocn_submesoscale_compute_velocity()` has to called in `src/mode_forward/mpas_ocn_forward_mode.F` .

[BFB]