### PR TITLE
For maint-2.1, add intel compiler to pm-cpu.

### DIFF
--- a/cime_config/machines/cmake_macros/intel_pm-cpu.cmake
+++ b/cime_config/machines/cmake_macros/intel_pm-cpu.cmake
@@ -1,0 +1,44 @@
+string(APPEND CONFIG_ARGS " --host=cray")
+if (COMP_NAME STREQUAL gptl)
+  string(APPEND CPPDEFS " -DHAVE_NANOTIME -DBIT64 -DHAVE_SLASHPROC -DHAVE_GETTIMEOFDAY")
+endif()
+string(APPEND SLIBS " -L$ENV{CRAY_HDF5_PARALLEL_PREFIX}/lib -lhdf5_hl -lhdf5 -L$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}/lib -L$ENV{CRAY_PARALLEL_NETCDF_PREFIX}/lib -lpnetcdf -lnetcdf -lnetcdff")
+string(APPEND SLIBS " -qmkl")
+set(CXX_LINKER "FORTRAN")
+set(NETCDF_PATH "$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}")
+set(NETCDF_C_PATH "$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}")
+set(NETCDF_FORTRAN_PATH "$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}")
+set(HDF5_PATH "$ENV{CRAY_HDF5_PARALLEL_PREFIX}")
+set(PNETCDF_PATH "$ENV{CRAY_PARALLEL_NETCDF_PREFIX}")
+
+set(MPICC "cc")
+set(MPICXX "CC")
+set(MPIFC "ftn")
+set(SCC "icx")
+set(SCXX "icpx")
+set(SFC "ifx")
+
+# Bit of a hack here. For whatever reason, the intel version on pm-cpu (both intel and intel-oneapi, and both icpc/icpx)
+# does not seem to have the -fp-model=source flag (docs still show it).  And I was unable to find a reliable way of testing
+# on the compiler ID or version, so for now, simply manually adjust the CXXFLAG setting for pm-cpu/intel
+# Try to manually remove -fp-model=source (and replace with -fp-model=precise) from CXXFLAGS
+set(CXXFLAGS " ") # hardcode it here to blank, then try to do same things as in intel.cmake
+if (compile_threaded)
+  string(APPEND CXXFLAGS " -qopenmp")
+endif()
+if (DEBUG)
+  string(APPEND CXXFLAGS " -O0 -g")
+endif()
+if (NOT DEBUG)
+  string(APPEND CXXFLAGS " -O2")
+endif()
+string(APPEND CXXFLAGS " -fp-model=precise") # and manually add precise
+
+string(APPEND FFLAGS " -fp-model=consistent -fimf-use-svml")
+if (NOT DEBUG)
+   #  string(APPEND FFLAGS " -qno-opt-dynamic-align")
+   string(APPEND FFLAGS " -g -traceback")
+   string(APPEND CXXFLAGS " -g -traceback")
+endif()
+string(APPEND FFLAGS " -DHAVE_ERF_INTRINSICS")
+string(APPEND CXXFLAGS " -fp-model=consistent")

--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -219,7 +219,7 @@
   </batch_system>
   <!-- for lawrence livermore computing -->
 
-  <!-- for NERSC machines: cori-haswell,cori-knl -->
+  <!-- for NERSC machines: perlmutter etc -->
   <batch_system type="nersc_slurm" >
     <batch_query per_job_arg="-j">squeue</batch_query>
     <batch_submit>sbatch</batch_submit>
@@ -402,8 +402,9 @@
       <directive> --constraint=cpu</directive>
     </directives>
     <queues>
-      <queue walltimemax="00:30:00" nodemax="1500" default="true">regular</queue>
-      <queue walltimemax="00:30:00" nodemax="4" strict="true">debug</queue>
+      <queue walltimemax="00:30:00" nodemax="4096" default="true">regular</queue>
+      <queue walltimemax="00:30:00" nodemax="4096" strict="true">preempt</queue>
+      <queue walltimemax="00:30:00" nodemax="8" strict="true">debug</queue>
     </queues>
   </batch_system>
 

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -163,7 +163,7 @@
     <DESC>Perlmutter CPU-only nodes at NERSC.  Phase2 only: Each node has 2 AMD EPYC 7713 64-Core (Milan) 512GB</DESC>
     <NODENAME_REGEX>$ENV{NERSC_HOST}:perlmutter</NODENAME_REGEX>
     <OS>Linux</OS>
-    <COMPILERS>gnu,nvidia,amdclang</COMPILERS>
+    <COMPILERS>gnu,intel,nvidia,amdclang</COMPILERS>
     <MPILIBS>mpich</MPILIBS>
     <PROJECT>e3sm</PROJECT>
     <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
@@ -182,7 +182,7 @@
     <BATCH_SYSTEM>nersc_slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>e3sm</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
-    <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
       <executable>srun</executable>
@@ -209,7 +209,12 @@
         <command name="unload">cray-netcdf-hdf5parallel</command>
         <command name="unload">cray-parallel-netcdf</command>
         <command name="unload">PrgEnv-gnu</command>
+        <command name="unload">PrgEnv-intel</command>
         <command name="unload">PrgEnv-nvidia</command>
+        <command name="unload">PrgEnv-cray</command>
+        <command name="unload">PrgEnv-aocc</command>
+        <command name="unload">intel</command>
+        <command name="unload">intel-oneapi</command>
         <command name="unload">cudatoolkit</command>
         <command name="unload">craype-accel-nvidia80</command>
         <command name="unload">craype-accel-host</command>
@@ -221,33 +226,41 @@
       <modules compiler="gnu">
         <command name="load">PrgEnv-gnu/8.3.3</command>
         <command name="load">gcc/11.2.0</command>
+        <command name="load">cray-libsci/23.02.1.1</command>
+      </modules>
+
+      <modules compiler="intel">
+        <command name="load">PrgEnv-intel/8.3.3</command>
+        <command name="load">intel/2023.1.0</command>
       </modules>
 
       <modules compiler="nvidia">
         <command name="load">PrgEnv-nvidia</command>
-        <command name="load">nvidia/22.5</command>
+        <command name="load">nvidia/22.7</command>
+        <command name="load">cray-libsci/23.02.1.1</command>
       </modules>
 
       <modules compiler="amdclang">
         <command name="load">PrgEnv-aocc</command>
         <command name="load">aocc/3.2.0</command>
+        <command name="load">cray-libsci/23.02.1.1</command>
       </modules>
 
       <modules>
         <command name="load">craype-accel-host</command>
-        <command name="load">cray-libsci</command>
-        <command name="load">craype</command>
-        <command name="load">cray-mpich/8.1.22</command>
-        <command name="load">cray-hdf5-parallel/1.12.2.1</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.9.0.1</command>
-        <command name="load">cray-parallel-netcdf/1.12.3.1</command>
-        <command name="load">cmake/3.22.0</command>
+        <command name="load">craype/2.7.19</command>
+        <command name="load">cray-mpich/8.1.24</command>
+        <command name="load">cray-hdf5-parallel/1.12.2.3</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.9.0.3</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.3</command>
+        <command name="load">cmake/3.24.3</command>
       </modules>
     </module_system>
 
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
     <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
+    <TEST_MEMLEAK_TOLERANCE>0.20</TEST_MEMLEAK_TOLERANCE>
 
     <environment_variables>
       <env name="MPICH_ENV_DISPLAY">1</env>
@@ -320,6 +333,8 @@
         <command name="unload">cray-parallel-netcdf</command>
         <command name="unload">PrgEnv-gnu</command>
         <command name="unload">PrgEnv-nvidia</command>
+        <command name="unload">PrgEnv-cray</command>
+        <command name="unload">PrgEnv-aocc</command>
         <command name="unload">cudatoolkit</command>
         <command name="unload">craype-accel-nvidia80</command>
         <command name="unload">craype-accel-host</command>
@@ -335,7 +350,7 @@
 
       <modules compiler="nvidia.*">
         <command name="load">PrgEnv-nvidia</command>
-        <command name="load">nvidia/22.5</command>
+        <command name="load">nvidia/22.7</command>
       </modules>
 
       <modules compiler="gnugpu">
@@ -357,13 +372,13 @@
       </modules>
 
       <modules>
-        <command name="load">cray-libsci</command>
-        <command name="load">craype</command>
-        <command name="load">cray-mpich/8.1.22</command>
-        <command name="load">cray-hdf5-parallel/1.12.2.1</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.9.0.1</command>
-        <command name="load">cray-parallel-netcdf/1.12.3.1</command>
-        <command name="load">cmake/3.22.0</command>
+        <command name="load">cray-libsci/23.02.1.1</command>
+        <command name="load">craype/2.7.19</command>
+        <command name="load">cray-mpich/8.1.24</command>
+        <command name="load">cray-hdf5-parallel/1.12.2.3</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.9.0.3</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.3</command>
+        <command name="load">cmake/3.24.3</command>
       </modules>
     </module_system>
 


### PR DESCRIPTION
Also update module versions to match those on master for pm-cpu/pm-gpu.

--

Cherry-picks https://github.com/E3SM-Project/E3SM/pull/5815 with a minor conflict resolution.