### PR TITLE
Remove NERSC inputdata server

### DIFF
--- a/cime_config/config_inputdata.xml
+++ b/cime_config/config_inputdata.xml
@@ -7,10 +7,6 @@
     <address>https://web.lcrc.anl.gov/public/e3sm/inputdata/</address>
   </server>
   <server>
-    <protocol>wget</protocol>
-    <address>https://portal.nersc.gov/project/e3sm/inputdata</address>
-  </server>
-  <server>
     <protocol>svn</protocol>
     <address>https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata</address>
   </server>


### PR DESCRIPTION
We were using NERSC as inputdata server while LCRC was down.
However, running into issues with 0-sized files written.
No need to have NERSC server as backup now.

Fixes https://github.com/E3SM-Project/E3SM/issues/5899
[bfb]