### PR TITLE
Accumulate data land-ice mass fluxes

### DIFF
--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -675,7 +675,7 @@ contains
         call ocn_forcing_build_fraction_absorbed_array(meshPool, statePool, forcingPool, ierr, 1)
         call mpas_timer_start("land_ice_build_arrays", .false.)
         call ocn_surface_land_ice_fluxes_build_arrays(meshPool, forcingPool, scratchPool, &
-                                                      statePool, dt=0.0_RKIND, err=ierr)
+                                                      statePool, err=ierr)
         call mpas_timer_stop("land_ice_build_arrays")
 
         call ocn_frazil_forcing_build_arrays(domain, meshPool, forcingPool, statePool, ierr)
@@ -962,8 +962,10 @@ contains
 
             call mpas_timer_start("land_ice_build_arrays", .false.)
             call ocn_surface_land_ice_fluxes_build_arrays(meshPool, &
-                                                          forcingPool, scratchPool, statePool, dt, ierr)
+                                                          forcingPool, scratchPool, statePool, ierr)
             call mpas_timer_stop("land_ice_build_arrays")
+            call ocn_surface_land_ice_fluxes_accumulate_fluxes(meshPool, forcingPool, &
+                                                               statePool, dt, ierr)
 
             call ocn_frazil_forcing_build_arrays(domain, meshPool, forcingPool, statePool, ierr)
 

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2285,11 +2285,11 @@
 		<!-- FIELDS FOR LAND ICE STORAGE -->
 		<var name="accumulatedLandIceMass" type="real" dimensions="nCells Time" units="kg m^-2"
 			description="Mass per unit area of land ice produced at land ice-ocean interface. Only computed in 'standalone' mode where land-ice fluxes are computed in MPAS-O."
-			packages="landIceFluxesPKG"
+			packages="landIceFluxesPKG;dataLandIceFluxesPKG"
 		/>
 		<var name="accumulatedLandIceHeat" type="real" dimensions="nCells Time" units="J m^-2"
 			description="Heat per unit area stored in land ice produced at land ice-ocean interface. Only computed in 'standalone' mode where land-ice fluxes are computed in MPAS-O."
-			packages="landIceFluxesPKG"
+			packages="landIceFluxesPKG;dataLandIceFluxesPKG"
 		/>
 		<var name="accumulatedLandIceFrazilMass" type="real" dimensions="nCells Time" units="kg m^-2"
 			description="Mass per unit area of frazil ice produced under land ice.  Only computed when not coupled to a dynamic land-ice model."

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -77,7 +77,7 @@ module ocn_forward_mode
    use ocn_tracer_surface_restoring
    use ocn_gm
    use ocn_submesoscale_eddies
-   use ocn_stokes_drift 
+   use ocn_stokes_drift
    use ocn_manufactured_solution
 
    use ocn_high_freq_thickness_hmix_del2
@@ -701,8 +701,10 @@ module ocn_forward_mode
            call ocn_forcing_build_fraction_absorbed_array(meshPool, statePool, forcingPool, ierr, 1)
            call mpas_timer_start("land_ice_build_arrays")
            call ocn_surface_land_ice_fluxes_build_arrays(meshPool, &
-                                                         forcingPool, scratchPool, statePool, dt, err)
+                                                         forcingPool, scratchPool, statePool, err)
            call mpas_timer_stop("land_ice_build_arrays")
+           call ocn_surface_land_ice_fluxes_accumulate_fluxes(meshPool, forcingPool, &
+                                                              statePool, dt, err)
 
            call ocn_frazil_forcing_build_arrays(domain, meshPool, forcingPool, statePool, err)
            call ocn_tidal_forcing_build_array(domain, meshPool, forcingPool, statePool, err)

--- a/components/mpas-ocean/src/shared/mpas_ocn_init_routines.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_init_routines.F
@@ -218,7 +218,7 @@ contains
          normalVelocity(maxLevelEdgeTop(iEdge)+1:maxLevelEdgeBot(iEdge), iEdge) = 0.0_RKIND
 
          normalVelocity(maxLevelEdgeBot(iEdge)+1:nVertLevels,iEdge) = -1.0e34_RKIND
-         
+
          normalVelocity(1:minLevelEdgeTop(iEdge)-1,iEdge) = -1.0e34_RKIND
       end do
 
@@ -265,7 +265,10 @@ contains
       call ocn_forcing_build_fraction_absorbed_array(meshPool, statePool, forcingPool, err1, 1)
       err = ior(err, err1)
       call ocn_surface_land_ice_fluxes_build_arrays(meshPool, &
-                                                    forcingPool, scratchPool, statePool, dt, err1)
+                                                    forcingPool, scratchPool, statePool, err1)
+      err = ior(err, err1)
+      call ocn_surface_land_ice_fluxes_accumulate_fluxes(meshPool, forcingPool, &
+                                                         statePool, dt, err1)
       err = ior(err, err1)
 
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_land_ice_fluxes.F
@@ -58,6 +58,7 @@ module ocn_surface_land_ice_fluxes
              ocn_surface_land_ice_fluxes_vel, &
              ocn_surface_land_ice_fluxes_thick, &
              ocn_surface_land_ice_fluxes_build_arrays, &
+             ocn_surface_land_ice_fluxes_accumulate_fluxes, &
              ocn_surface_land_ice_fluxes_init
 
    !--------------------------------------------------------------------
@@ -422,7 +423,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_surface_land_ice_fluxes_build_arrays(meshPool, &
-      forcingPool, scratchPool, statePool, dt, err) !{{{
+      forcingPool, scratchPool, statePool, err) !{{{
 
       !-----------------------------------------------------------------
       !
@@ -432,7 +433,6 @@ contains
 
       type (mpas_pool_type), intent(in) :: &
          meshPool        !< Input: mesh information
-      real(kind=RKIND), intent(in) :: dt ! the time step over which to accumulate fluxes
 
       !-----------------------------------------------------------------
       !
@@ -467,10 +467,6 @@ contains
                                                   landIceSurfaceTemperature, &
                                                   landIceFreshwaterFlux, &
                                                   landIceHeatFlux, heatFluxToLandIce
-      real (kind=RKIND), dimension(:), pointer :: accumulatedLandIceMassOld, &
-                                                  accumulatedLandIceMassNew, &
-                                                  accumulatedLandIceHeatOld, &
-                                                  accumulatedLandIceHeatNew
 
       integer, dimension(:), pointer :: landIceFloatingMask
 
@@ -518,10 +514,6 @@ contains
                                  indexISPtr)
       indexIT = indexITPtr
       indexIS = indexISPtr
-      call mpas_pool_get_array(statePool, 'accumulatedLandIceMass', accumulatedLandIceMassNew, 2)
-      call mpas_pool_get_array(statePool, 'accumulatedLandIceMass', accumulatedLandIceMassOld, 1)
-      call mpas_pool_get_array(statePool, 'accumulatedLandIceHeat', accumulatedLandIceHeatNew, 2)
-      call mpas_pool_get_array(statePool, 'accumulatedLandIceHeat', accumulatedLandIceHeatOld, 1)
 
       if (useHollandJenkinsAdvDiff) then
          call mpas_pool_get_array(forcingPool, 'landIceSurfaceTemperature', landIceSurfaceTemperature)
@@ -666,17 +658,99 @@ contains
                     freezeIceHeatFlux)
       end if
 
-      ! accumulate land-ice mass and heat
-      do iCell = 1, nCells
-        accumulatedLandIceMassNew(iCell) = accumulatedLandIceMassOld(iCell) - dt*landIceFreshwaterFlux(iCell)
-        accumulatedLandIceHeatNew(iCell) = accumulatedLandIceHeatOld(iCell) + dt*heatFluxToLandIce(iCell)
-      end do
-
       call mpas_timer_stop("land_ice_build_arrays")
 
    !--------------------------------------------------------------------
 
    end subroutine ocn_surface_land_ice_fluxes_build_arrays!}}}
+
+
+!***********************************************************************
+!
+!  routine ocn_surface_land_ice_fluxes_accumulate_fluxes
+!
+!> \brief Accumulate total land-ice mass and heat fluxes
+!> \author Xylar Asay-Davis
+!> \date   09/02/2023
+!> \details
+!>  This routine accumulates land-ice mass and heat fluxes into variables
+!>  used to keep track of the total mass and energy budgets.
+!-----------------------------------------------------------------------
+
+   subroutine ocn_surface_land_ice_fluxes_accumulate_fluxes(meshPool, &
+      forcingPool, statePool, dt, err) !{{{
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: &
+         meshPool        !< Input: mesh information
+      real(kind=RKIND), intent(in) :: dt ! the time step over which to accumulate fluxes
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(inout) :: &
+         forcingPool, & !< Input: Forcing information
+         statePool      !< Input: state field information
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: Error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, nCells
+      integer, dimension(:), pointer :: nCellsArray
+
+      real (kind=RKIND), dimension(:), pointer :: landIceFreshwaterFlux, &
+                                                  heatFluxToLandIce
+      real (kind=RKIND), dimension(:), pointer :: accumulatedLandIceMassOld, &
+                                                  accumulatedLandIceMassNew, &
+                                                  accumulatedLandIceHeatOld, &
+                                                  accumulatedLandIceHeatNew
+
+      err = 0
+
+      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
+      nCells = nCellsArray( size(nCellsArray) )
+
+      if (landIceStandaloneOn .or. landIceDataOn) then
+        call mpas_pool_get_array(statePool, 'accumulatedLandIceMass', accumulatedLandIceMassNew, 2)
+        call mpas_pool_get_array(statePool, 'accumulatedLandIceMass', accumulatedLandIceMassOld, 1)
+        call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
+        ! accumulate land-ice mass
+        do iCell = 1, nCells
+          accumulatedLandIceMassNew(iCell) = accumulatedLandIceMassOld(iCell) - dt*landIceFreshwaterFlux(iCell)
+        end do
+      end if
+
+      if (landIceStandaloneOn) then
+        call mpas_pool_get_array(forcingPool, 'heatFluxToLandIce', heatFluxToLandIce)
+        call mpas_pool_get_array(statePool, 'accumulatedLandIceHeat', accumulatedLandIceHeatNew, 2)
+        call mpas_pool_get_array(statePool, 'accumulatedLandIceHeat', accumulatedLandIceHeatOld, 1)
+        ! accumulate land-ice heat
+        do iCell = 1, nCells
+          accumulatedLandIceHeatNew(iCell) = accumulatedLandIceHeatOld(iCell) + dt*heatFluxToLandIce(iCell)
+        end do
+      end if
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_surface_land_ice_fluxes_accumulate_fluxes!}}}
 
 !***********************************************************************
 !


### PR DESCRIPTION
Before this merge, we were only accumulating this flux in prognostic flux mode.  With this merge, we accumulate the mass flux in data mode as well, as this term is needed in the total mass budget of the model.

To facilitate this and reduce issues related to initialization vs. forward time stepping, this accumulation step has been broken into its own subroutine, `ocn_surface_land_ice_fluxes_accumulate_fluxes()`. This subroutine is called when time-stepping the model but not at initialization (since we do not want to accumulate any fluxes at that time).

Fixes #5911 