### PR TITLE
Verify array is allocated before accessing size attribute

### DIFF
--- a/components/eam/src/physics/cosp2/local/cosp.F90
+++ b/components/eam/src/physics/cosp2/local/cosp.F90
@@ -478,7 +478,9 @@ CONTAINS
        Lrttov_column    = .true.
 
     ! Set flag to deallocate rttov types (only done on final call to simulator)
-    if (size(cospOUT%isccp_meantb) .eq. stop_idx) lrttov_cleanUp = .true.
+    if (associated(cospOUT%isccp_meantb)) then
+       if (size(cospOUT%isccp_meantb) .eq. stop_idx) lrttov_cleanUp = .true.
+    endif
 
     ! ISCCP column
     if (associated(cospOUT%isccp_fq)                                       .or.          &


### PR DESCRIPTION
In EAMxx, COSP is called without allocating `cospOUT%isccp_meantb`. Every instance in EAM's `cosp.F90` we ask `associated(cospOUT%isccp_meantb)` before accessing the array, except here where we ask for it's size, leading to a valgrind error. Solution is just to ask `associated(cospOUT%isccp_meantb)` before asking for the array size.

[BFB]