### PR TITLE
Changes redi tapering and slopes

### DIFF
--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -3008,10 +3008,6 @@
 			description="spatially and depth varying GM kappa.  The scaling is based on the Brunt Vaisala Frequency relative to a maximum value below the mixed layer, follows from Danabasoglu and Marshall 2007.  If config_GM_closure is not set to N2_dependent the scaling value is set to 1 everywhere."
 			packages="gm"
 		/>
-		<var name="RediKappaScaling" type="real" dimensions="nVertLevelsP1 nCells Time" units="1"
-			description="Scaling coefficient for GM kappa. Varies from 0 to 1.  The scaling is based on the Brunt Vaisala Frequency relative to a maximum value below the mixed layer, follows from Danabasoglu and Marshall 2007.  If config_Redi_N2_based_taper_enable = .false. the scaling is set to 1 everywhere."
-			packages="gm"
-		/>
 		<var name="RediKappaSfcTaper" type="real" dimensions="nVertLevelsP1 nCells Time" units="1"
 			description="Scaling coefficient for Redi kappa. Varies from 0 to 1."
 			packages="gm"
@@ -3148,6 +3144,14 @@
 			 packages="forwardMode;analysisMode"
 		/>
 		<var name="slopeTriadDown" type="real" dimensions="nVertLevels TWO nEdges Time" units="non-dimensional" default_value="0.0"
+			 description="Magnitude of slope of isopycnal surface, using triad through this cell and edge, angled up. Uses expansion of equation of state."
+			 packages="forwardMode;analysisMode"
+		/>
+		<var name="limiterUp" type="real" dimensions="nVertLevels TWO nEdges Time" units="non-dimensional" default_value="0.0"
+			 description="Magnitude of slope of isopycnal surface, using triad through this cell and edge, angled up. Uses expansion of equation of state."
+			 packages="forwardMode;analysisMode"
+		/>
+		<var name="limiterDown" type="real" dimensions="nVertLevels TWO nEdges Time" units="non-dimensional" default_value="0.0"
 			 description="Magnitude of slope of isopycnal surface, using triad through this cell and edge, angled up. Uses expansion of equation of state."
 			 packages="forwardMode;analysisMode"
 		/>

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -127,7 +127,7 @@ module ocn_diagnostics_variables
    real(kind=RKIND), dimension(:,:), pointer :: gradDensityEddy
    real(kind=RKIND), dimension(:), pointer   :: gmBolusKappa
    real(kind=RKIND), dimension(:), pointer   :: cGMphaseSpeed
-   real(kind=RKIND), dimension(:,:,:), pointer :: slopeTriadUp, slopeTriadDown
+   real(kind=RKIND), dimension(:,:,:), pointer :: limiterUp, limiterDown, slopeTriadUp, slopeTriadDown
 
    integer, dimension(:), pointer :: indMLD
    real(kind=RKIND), dimension(:), pointer :: dThreshMLD
@@ -420,6 +420,10 @@ contains
                    slopeTriadUp)
          call mpas_pool_get_array(diagnosticsPool, 'slopeTriadDown', &
                    slopeTriadDown)
+         call mpas_pool_get_array(diagnosticsPool, 'limiterUp', &
+                   limiterUp)
+         call mpas_pool_get_array(diagnosticsPool, 'limiterDown', &
+                   limiterDown)
 
          ! GM-related fields
          call mpas_pool_get_array(diagnosticsPool, 'cGMphaseSpeed', &
@@ -719,6 +723,7 @@ contains
          !$acc                   SSHGradient,                     &
          !$acc                   circulation,                     &
          !$acc                   slopeTriadUp,                    &
+         !$acc                   limiterUp,                       &
          !$acc                   gradSSHZonal,                    &
          !$acc                   cGMphaseSpeed,                   &
          !$acc                   velocityZonal,                   &
@@ -729,6 +734,7 @@ contains
          !$acc                   layerThickEdgeFlux,              &
          !$acc                   layerThickEdgeMean,              &
          !$acc                   slopeTriadDown,                  &
+         !$acc                   limiterDown,                     &
          !$acc                   normRelVortEdge,                 &
          !$acc                   surfaceVelocity,                 &
          !$acc                   vertVelocityTop,                 &
@@ -961,6 +967,8 @@ contains
          !$acc                   SSHGradient,                     &
          !$acc                   circulation,                     &
          !$acc                   slopeTriadUp,                    &
+         !$acc                   limiterUp,                       &
+         !$acc                   limiterDown,                     &
          !$acc                   gradSSHZonal,                    &
          !$acc                   cGMphaseSpeed,                   &
          !$acc                   velocityZonal,                   &
@@ -1161,6 +1169,8 @@ contains
                  SSHGradient,                     &
                  circulation,                     &
                  slopeTriadUp,                    &
+                 limiterUp,                       &
+                 limiterDown,                     &
                  gradSSHZonal,                    &
                  cGMphaseSpeed,                   &
                  velocityZonal,                   &

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -62,6 +62,22 @@ module ocn_gm
 
 contains
 
+   function safe_slope(num, den) result(slope)
+
+      real(kind=RKIND), intent(in) :: num, den
+      real(kind=RKIND) :: slope
+
+      ! compute isopycnal slopes safely wrt. finite precision
+      ! small slope assumption, so don't want |s| > 1
+
+      if (abs(den) > abs(num)) then
+         slope = num / den
+      else
+         slope = sign(1.0_RKIND, den * num)
+      end if
+
+   end function
+
 !***********************************************************************
 !
 !  routine ocn_GM_compute_Bolus_velocity
@@ -229,30 +245,6 @@ contains
          allocate(dSdzTop(nVertLevels + 1))
          allocate(k33Norm(nVertLevels + 1))
 
-         if ( config_Redi_N2_based_taper_enable ) then
-
-            !$omp parallel
-            !$omp do schedule(runtime) private(maxLocation, k, BruntVaisalaFreqTopEdge, maxN)
-            do iCell = 1, nCells
-               k = min(maxLevelCell(iCell) - 1, max(minLevelCell(iCell), indMLD(iCell)))
-               maxN = max(BruntVaisalaFreqTop(k, iCell), 0.0_RKIND)
-               do while (BruntVaisalaFreqTop(k + 1, iCell) > maxN .and. k < maxLevelCell(iCell) - 1)
-                 k = k + 1
-                 maxN = max(maxN,max(BruntVaisalaFreqTop(k, iCell), 0.0_RKIND))
-               enddo
-
-               maxLocation = k
-               do k = maxLocation, maxLevelCell(iCell)
-                  BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTop(k, iCell), 0.0_RKIND)
-                  RediKappaScaling(k, iCell) = min(max(config_Redi_N2_based_taper_min,                  &
-                                                       BruntVaisalaFreqTopEdge/(maxN + 1.0E-10_RKIND)), &
-                                                       1.0_RKIND)
-               end do
-            end do
-            !$omp end do
-            !$omp end parallel
-         end if
-
          if (config_Redi_use_surface_taper) then
             !$omp parallel
             !$omp do schedule (runtime) private(zMLD, k)
@@ -271,8 +263,14 @@ contains
          nCells = nCellsArray(3)
          !$omp parallel
          !$omp do schedule(runtime)  &
-         !$omp private(invAreaCell, k33Norm, k, dzTop, dTdzTop, dSdzTop, i, iEdge, cell1, cell2, &
-         !$omp         iCellSelf, dcEdgeInv, areaEdge, drhoDT, drhoDS, dTdx, dSdx, drhoDx, &
+!         !$omp private(invAreaCell, k33Norm, k, dzTop, dTdzTop, dSdzTop, i, iEdge, cell1, cell2, &
+!         !$omp         iCellSelf, dcEdgeInv, areaEdge, drhoDT, drhoDS, dTdx, dSdx, drhoDx, &
+!         !$omp         slopeTaperUp, slopeTaperDown, sfcTaperUp, sfcTaperDown, sfcTaper)
+         !$omp private(invAreaCell, dzTop, dTdzTop, dSdzTop, &
+         !$omp         k, i, iEdge, cell1, cell2, &
+         !$omp         iCellSelf, dcEdgeInv, drhoDTTop, drhoDTBot, &
+         !$omp         drhoDSTop, drhoDSBot, dTdxTop, dTdxBot, dSdxTop, dSdxBot, &
+         !$omp         drhoDxTop, drhoDxBot, &
          !$omp         slopeTaperUp, slopeTaperDown, sfcTaperUp, sfcTaperDown, sfcTaper)
          do iCell = 1, nCells
             invAreaCell = 1.0_RKIND/areaCell(iCell)
@@ -318,17 +316,17 @@ contains
                          *dcEdgeInv
                   drhoDx = drhoDT*dTdx + drhoDS*dSdx
 
+
+                  sfcTaperUp = drhoDT*dTdzTop(k) + drhoDS*dSdzTop(k)
+                  sfcTaperDown = drhoDT*dTdzTop(k+1) + drhoDS*dSdzTop(k+1)
+
                   ! Always compute *Up on the top cell and *Down on the bottom
                   ! cell, even though they are never used. This avoids an if
                   ! statement or separate computation for top and bottom.
                   slopeTriadUp(k, iCellSelf, iEdge) = &
-                     -drhoDx/ &
-                     (drhoDT*dTdzTop(k) &
-                      + drhoDS*dSdzTop(k) + 1E-15_RKIND)
+                     safe_slope( -drhoDx, sfcTaperUp )
                   slopeTriadDown(k, iCellSelf, iEdge) = &
-                     -drhoDx/ &
-                     (drhoDT*dTdzTop(k + 1) &
-                      + drhoDS*dSdzTop(k + 1) + 1E-15_RKIND)
+                      safe_slope( -drhoDx, sfcTaperDown )
 
                   ! set taper of slope ('F' function from Danabasoglu and McWilliams 95)
                   if (abs(slopeTriadDown(k, iCellSelf, iEdge)) > 0.6_RKIND*config_redi_maximum_slope) then
@@ -363,30 +361,34 @@ contains
                   sfcTaperUp = 1.0_RKIND + sfcTaperFactor*(sfcTaper - 1.0_RKIND)
                   sfcTaperDown = 1.0_RKIND + sfcTaperFactor*(sfcTaper - 1.0_RKIND)
 
+!                  ! Griffies 1998 eqn 34
+                  if (k > minLevelCell(iCell)) then
+                     k33(k, iCell) = k33(k, iCell) +  &
+                                     slopeTaperUp*sfcTaperUp*areaEdge*dzTop(k)*slopeTriadUp(k, iCellSelf, iEdge)**2
+                     k33Norm(k) = k33Norm(k) + areaEdge*dzTop(k)
+                  end if
+
+!                  !Taper Redi by tapering the slopes
+                  k33(k + 1, iCell) = k33(k + 1, iCell) +  &
+                                      slopeTaperDown*sfcTaperDown*areaEdge*dzTop(k + 1)*slopeTriadDown(k, iCellSelf, iEdge)**2
+                  k33Norm(k + 1) = k33Norm(k + 1) + areaEdge*dzTop(k + 1)
+
+                  limiterUp(k,iCellSelf,iEdge) = slopeTaperUp*sfcTaperUp
+                  limiterDown(k,iCellSelf,iEdge) = slopeTaperDown*sfcTaperDown
+
                   slopeTriadUp(k, iCellSelf, iEdge) = &
                      slopeTaperUp*sfcTaperUp*slopeTriadUp(k, iCellSelf, iEdge)
                   slopeTriadDown(k, iCellSelf, iEdge) = &
                      slopeTaperDown*sfcTaperDown*slopeTriadDown(k, iCellSelf, iEdge)
 
-                  ! Griffies 1998 eqn 34
-                  if (k > minLevelCell(iCell)) then
-                     k33(k, iCell) = k33(k, iCell) +  &
-                                     areaEdge*dzTop(k)*slopeTriadUp(k, iCellSelf, iEdge)**2
-                     k33Norm(k) = k33Norm(k) + areaEdge*dzTop(k)
-                  end if
-
-                  !Taper Redi by tapering the slopes
-                  k33(k + 1, iCell) = k33(k + 1, iCell) +  &
-                                      areaEdge*dzTop(k + 1)*slopeTriadDown(k, iCellSelf, iEdge)**2
-                  k33Norm(k + 1) = k33Norm(k + 1) + areaEdge*dzTop(k + 1)
-
-
                end do ! maxLevelEdgeTop(iEdge)
             end do ! nEdgesOnCell(iCell)
 
-            ! Normalize k33
+!            ! Normalize k33
+            RediKappaScaling(1:minLevelCell(iCell),iCell) = 0.0_RKIND
+            RediKappaScaling(maxLevelCell(iCell):nVertLevels,iCell) = 0.0_RKIND
             do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
-               k33(k, iCell) = k33(k, iCell)/k33Norm(k)*RediKappaScaling(k, iCell)
+               k33(k, iCell) = k33(k, iCell)/k33Norm(k)
             end do
             k33(1:minLevelCell(iCell), iCell) = 0.0_RKIND
             k33(maxLevelCell(iCell) + 1, iCell) = 0.0_RKIND
@@ -904,7 +906,7 @@ contains
       real(kind=RKIND), dimension(:), pointer :: dcEdge
 
       integer :: iEdge
-      integer, pointer :: nEdges
+      integer, pointer :: nCells, nEdges
       integer, pointer :: nVertLevels
       real(kind=RKIND), pointer :: sphere_radius
       real(kind=RKIND), dimension(:), pointer   :: latEdge, fEdge
@@ -918,10 +920,12 @@ contains
       do while (associated(block))
          call mpas_pool_get_subpool(block%structs, 'mesh', meshPool)
          call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
          call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
          call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
          call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
          call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
+
          if (config_Redi_use_slope_taper) then
             slopeTaperFactor = 1.0_RKIND
          else

--- a/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
@@ -1141,8 +1141,9 @@ contains
          call ocn_tracer_hmix_tend(meshPool, layerThickEdgeMean, &
                                    layerThickness, zMid, tracerGroup, &
                                    RediKappa, slopeTriadUp, &
-                                   slopeTriadDown, dt, isActiveTracer, &
-                                   RediKappaScaling, rediLimiterCount, &
+                                   slopeTriadDown, limiterUp, &
+                                   limiterDown, dt, isActiveTracer, &
+                                   rediLimiterCount, &
                                    tracerGroupTend, err)
 
          if (computeBudgets) then

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix.F
@@ -80,8 +80,8 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_tracer_hmix_tend(meshPool, layerThickEdgeMean, layerThickness, zMid, tracers, &
-                                   RediKappa, slopeTriadUp, slopeTriadDown, dt, isActiveTracer,          &
-                                   RediKappaScaling, rediLimiterCount, tend, err)!{{{
+                                   RediKappa, slopeTriadUp, slopeTriadDown, limiterUp, limiterDown, &
+                                   dt, isActiveTracer, rediLimiterCount, tend, err)!{{{
 
 
       !-----------------------------------------------------------------
@@ -98,8 +98,6 @@ contains
          layerThickEdgeMean, &!< Input: mean thickness at edge
          layerThickness,     &!< Input: thickness at centers
          zMid                 !< Input: Z coordinate at the center of a cell
-      real (kind=RKIND), dimension(:,:), intent(in), optional :: &
-         RediKappaScaling        !< Input: vertical structure of GM/Redi limiter
 
       real (kind=RKIND), dimension(:,:,:), intent(in) :: &
         slopeTriadUp, slopeTriadDown, &
@@ -154,7 +152,8 @@ contains
         call ocn_tracer_hmix_Redi_tend(meshPool, layerThickness, layerThickEdgeMean, zMid, tracers, &
                                      RediKappa, dt, isActiveTracer,        &
                                      slopeTriadUp, slopeTriadDown, &
-                                     RediKappaScaling, rediLimiterCount, tend, err1)
+                                     limiterUp, limiterDown, rediLimiterCount, &
+                                     tend, err1)
       endif
       err = ior(err1, err2)
       call mpas_timer_stop("tracer hmix")

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -75,7 +75,7 @@ contains
 
    subroutine ocn_tracer_hmix_Redi_tend(meshPool, layerThickness, layerThickEdgeMean, zMid, tracers, &
                                         RediKappa, dt, isActiveTracer, slopeTriadUp, slopeTriadDown, &
-                                        RediKappaScaling, rediLimiterCount, tend, err)!{{{
+                                        limiterUp, limiterDown, rediLimiterCount, tend, err)!{{{
 
       !-----------------------------------------------------------------
       !
@@ -91,11 +91,10 @@ contains
       real(kind=RKIND), dimension(:, :), intent(in) :: &
          layerThickEdgeMean, &!< Input: mean thickness at edge
          zMid, &!< Input: Z coordinate at the center of a cell
-         RediKappaScaling, &
          layerThickness
 
       real(kind=RKIND), dimension(:, :, :), intent(in) :: &
-         slopeTriadUp, slopeTriadDown, &
+         slopeTriadUp, slopeTriadDown, limiterUp, limiterDown, &
          tracers !< Input: tracer quantities
 
       real(kind=RKIND), intent(in) :: dt
@@ -237,10 +236,12 @@ contains
 
             k = 1
             if (minLevelEdgeBot(iEdge) .ne. 1) k = minLevelEdgeBot(iEdge)
-            kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
-                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))
+
+            kappaRediEdgeVal = 0.25_RKIND*(limiterUp(k,1,iEdge) + limiterUp(k,2,iEdge) + &
+                                           limiterDown(k,1,iEdge) + limiterDown(k,2,iEdge)) 
 
             do iTr = 1, nTracers
+               ! term 1: div( h grad psi )
                tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)
                flux = layerThickEdgeMean(k, iEdge)*tracer_turb_flux*r_tmp*RediKappa(iEdge)
                redi_term1(iTr, k, iCell) = redi_term1(iTr, k, iCell) - (1.0_RKIND + term1TaperFactor* &
@@ -248,8 +249,8 @@ contains
 
                if (.not.use_Redi_diag_terms) cycle
 
-               ! Term 2: div( h S dphi/dz)
-               flux_term2 = coef*kappaRediEdgeVal*RediKappa(iEdge)*layerThickEdgeMean(k, iEdge)* &
+               ! term 2: div( h S d/dz psi )
+               flux_term2 = coef*RediKappa(iEdge)*layerThickEdgeMean(k, iEdge)* &
                             0.25_RKIND* &
                             (slopeTriadDown(k, 1, iEdge)*(tracers(iTr, k, cell1) - tracers(iTr, k + 1, cell1)) &
                              /(zMid(k, cell1) - zMid(k + 1, cell1)) &
@@ -257,37 +258,37 @@ contains
                              /(zMid(k, cell2) - zMid(k + 1, cell2)))
                if (minLevelCell(cell1) < minLevelEdgeBot(iEdge)) then
                   flux_term2 = flux_term2 + coef*RediKappa(iEdge)* &
-                               layerThickEdgeMean(k, iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadUp(k, 1, iEdge)* &
+                               layerThickEdgeMean(k, iEdge)*0.25_RKIND*slopeTriadUp(k, 1, iEdge)* &
                                (tracers(iTr, k - 1, cell1) - tracers(iTr, k, cell1))/(zMid(k - 1, cell1) - zMid(k, cell1))
                endif
                if (minLevelCell(cell2) < minLevelEdgeBot(iEdge)) then
                   flux_term2 = flux_term2 + coef*RediKappa(iEdge)* &
-                               layerThickEdgeMean(k, iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadUp(k, 2, iEdge)* &
+                               layerThickEdgeMean(k, iEdge)*0.25_RKIND*slopeTriadUp(k, 2, iEdge)* &
                                (tracers(iTr, k - 1, cell2) - tracers(iTr, k, cell2))/(zMid(k - 1, cell2) - zMid(k, cell2))
                endif
 
                redi_term2(iTr, k, iCell) = redi_term2(iTr, k, iCell) - edgeSignOnCell(i, iCell)*flux_term2*invAreaCell
                redi_term2_edge(iTr, k, iEdge) = -flux_term2
+
+               ! term 3: zero at surface
             end do
 
             do k = minLevelEdgeBot(iEdge) + 1, maxLevelEdgeTop(iEdge) - 1
 
-               kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
-                                              RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))
+               kappaRediEdgeVal = 0.25_RKIND*(limiterUp(k,1,iEdge) + limiterUp(k,2,iEdge) + &
+                                              limiterDown(k,1,iEdge) + limiterDown(k,2,iEdge)) 
 
                do iTr = 1, nTracers
-                  ! \kappa_2 \nabla \phi on edge
+                  ! term 1: div( h grad psi )
                   tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)
-
-                  ! div(h \kappa_2 \nabla \phi) at cell center
                   flux = layerThickEdgeMean(k, iEdge)*tracer_turb_flux*r_tmp*RediKappa(iEdge)
-
                   redi_term1(iTr, k, iCell) = redi_term1(iTr, k, iCell) - (1.0_RKIND + term1TaperFactor* &
                                               (kappaRediEdgeVal - 1.0_RKIND))*edgeSignOnCell(i, iCell)*flux*invAreaCell
 
                   if (.not.use_Redi_diag_terms) cycle
 
-                  flux_term2 = coef*RediKappa(iEdge)*kappaRediEdgeVal*layerThickEdgeMean(k, iEdge)* &
+                  ! term 2: div( h S d/dz psi )
+                  flux_term2 = coef*RediKappa(iEdge)*layerThickEdgeMean(k, iEdge)* &
                                0.25_RKIND* &
                                (slopeTriadUp(k, 1, iEdge)*(tracers(iTr, k - 1, cell1) - tracers(iTr, k, cell1)) &
                                 /(zMid(k - 1, cell1) - zMid(k, cell1)) &
@@ -309,10 +310,11 @@ contains
             end do
 
             k = maxLevelEdgeTop(iEdge)
-            kappaRediEdgeVal = 0.25_RKIND*(RediKappaScaling(k, cell1) + RediKappaScaling(k, cell2) + &
-                                           RediKappaScaling(k + 1, cell1) + RediKappaScaling(k + 1, cell2))
+            kappaRediEdgeVal = 0.25_RKIND*(limiterUp(k,1,iEdge) + limiterUp(k,2,iEdge) + &
+                                           limiterDown(k,1,iEdge) + limiterDown(k,2,iEdge)) 
 
             do iTr = 1, nTracers
+               ! term 1: div( h grad psi )
                tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)
                flux = layerThickEdgeMean(k, iEdge)*tracer_turb_flux*r_tmp*RediKappa(iEdge)
                redi_term1(iTr, k, iCell) = redi_term1(iTr, k, iCell) - (1.0_RKIND + term1TaperFactor* &
@@ -321,7 +323,7 @@ contains
                if (.not.use_Redi_diag_terms) cycle
 
                ! For bottom layer, only use triads pointing up:
-               flux_term2 = coef*kappaRediEdgeVal*RediKappa(iEdge)*layerThickEdgeMean(k, iEdge)* &
+               flux_term2 = coef*RediKappa(iEdge)*layerThickEdgeMean(k, iEdge)* &
                             0.25_RKIND* &
                             (slopeTriadUp(k, 1, iEdge)*(tracers(iTr, k - 1, cell1) - tracers(iTr, k, cell1)) &
                              /(zMid(k - 1, cell1) - zMid(k, cell1)) &
@@ -330,12 +332,12 @@ contains
 
                if (maxLevelCell(cell1) > maxLevelEdgeTop(iEdge)) then
                   flux_term2 = flux_term2 + coef*RediKappa(iEdge)* &
-                               layerThickEdgeMean(k, iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadDown(k, 1, iEdge)* &
+                               layerThickEdgeMean(k, iEdge)*0.25_RKIND*slopeTriadDown(k, 1, iEdge)* &
                                (tracers(iTr, k, cell1) - tracers(iTr, k + 1, cell1))/(zMid(k, cell1) - zMid(k + 1, cell1))
                endif
                if (maxLevelCell(cell2) > maxLevelEdgeTop(iEdge)) then
                   flux_term2 = flux_term2 + coef*RediKappa(iEdge)* &
-                               layerThickEdgeMean(k, iEdge)*0.25_RKIND*kappaRediEdgeVal*slopeTriadDown(k, 2, iEdge)* &
+                               layerThickEdgeMean(k, iEdge)*0.25_RKIND*slopeTriadDown(k, 2, iEdge)* &
                                (tracers(iTr, k, cell2) - tracers(iTr, k + 1, cell2))/(zMid(k, cell2) - zMid(k + 1, cell2))
                endif
                redi_term2(iTr, k, iCell) = redi_term2(iTr, k, iCell) - edgeSignOnCell(i, iCell)*flux_term2 &
@@ -365,8 +367,8 @@ contains
                   ! 2.0 in next line is because a dot product on a C-grid
                   ! requires a factor of 1/2 to average to the cell center.
                   flux_term3 = rediKappaCell(iCell)*2.0_RKIND* &
-                               (RediKappaScaling(k, iCell)*fluxRediZTop(iTr, k)  &
-                               * invAreaCell - RediKappaScaling(k + 1, iCell) &
+                               (fluxRediZTop(iTr, k)  &
+                               * invAreaCell -  &
                                *fluxRediZTop(iTr, k + 1) * invAreaCell)
 
                   redi_term3(iTr, k, iCell) = redi_term3(iTr, k, iCell) + flux_term3
@@ -435,9 +437,8 @@ contains
             do k = minLevelCell(iCell), maxLevelCell(iCell)
                do iTr = 1, ntracers
                   tend(iTr, k, iCell) = tend(iTr, k, iCell) + rediKappaCell(iCell)*2.0_RKIND* &
-                                        (RediKappaScaling(k, iCell)* &
-                                         redi_term3_topOfCell(iTr, k, iCell) - &
-                                         RediKappaScaling(k + 1, iCell)*redi_term3_topOfCell(iTr, k + 1, iCell))
+                                        (redi_term3_topOfCell(iTr, k, iCell) - &
+                                         redi_term3_topOfCell(iTr, k + 1, iCell))
                end do
             end do
 


### PR DESCRIPTION
In current MPAS slopes are altered directly, e.g. when S > Scrit it is set to zero.  Griffies et al 1998 (Appendix C) equates this to slope clipping.  The appropriate setup is to taper the redi kappa coefficient for each individual flux instead.  The cross terms ("term2" and "term 3") end up being identical as they are d/dz(kappa S grad phi) so  tapering kappa or S are identical.  However for the vertical it is d/dz(kappa |S|^2 d phi / dz) so tapering S is different from tapering kappa.  Also term 1 (laplacian diffusion) was not being tapered with slopes creating a cross isopycnal flux in steeply sloping regions.  These issues are fixed here.

In addition a new slope calculation is introduced to prevent the slopes from getting very large when grad phi or d/dz(phi) get small.  This function limits the slope to be between -1 and 1.