### PR TITLE
Adding support for SCORPIO legacy fortran interface

### DIFF
--- a/share/build/buildlib.spio
+++ b/share/build/buildlib.spio
@@ -200,8 +200,10 @@ def buildlib(bldroot, installpath, case):
         globs_to_copy = [
             os.path.join("src", "clib", "libpioc.*"),
             os.path.join("src", "flib", "libpiof.*"),
+            os.path.join("src", "flib_legacy", "libpiof.*"),
             os.path.join("src", "clib", "*.h"),
             os.path.join("src", "flib", "*.mod"),
+            os.path.join("src", "flib_legacy", "*.mod"),
         ]
         # ADIOS requires an ADIOS to NetCDF conversion library/exe
         if adios_found:


### PR DESCRIPTION
The Fortran interface implementation in SCORPIO was recently refactored but
users still have the option to use the legacy/old Fortran interface implementation.

Adding support in CIME for the SCORPIO legacy Fortran interface

[BFB]