### PR TITLE
Reduce number of sea ice flux iterations from 10 to 5.

### DIFF
--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -397,7 +397,7 @@
 <config_calc_surface_temperature>true</config_calc_surface_temperature>
 <config_use_form_drag>false</config_use_form_drag>
 <config_use_high_frequency_coupling>true</config_use_high_frequency_coupling>
-<config_boundary_layer_iteration_number>10</config_boundary_layer_iteration_number>
+<config_boundary_layer_iteration_number>5</config_boundary_layer_iteration_number>
 
 <!-- ocean -->
 <config_use_ocean_mixed_layer>false</config_use_ocean_mixed_layer>


### PR DESCRIPTION
The current number of iterations to calculate sea ice fluxes is excessive. Convergence of atm-sea ice fluxes is reached within a few iterations, therefore, the default value for the number of iterations should be reduced from 10 to 5.

[non-BFB]