### PR TITLE
Change bilinear map for low-res coupled case to use TempestRemap

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -3149,8 +3149,8 @@
 
     <gridmap atm_grid="ne30np4.pg2" ocn_grid="EC30to60E2r2">
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_EC30to60E2r2_mono.201005.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_EC30to60E2r2_bilin.201005.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_EC30to60E2r2_bilin.201005.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_EC30to60E2r2_bilin.tr.230522.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_EC30to60E2r2_bilin.tr.230522.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/EC30to60E2r2/map_EC30to60E2r2_to_ne30pg2_mono.201005.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/EC30to60E2r2/map_EC30to60E2r2_to_ne30pg2_mono.201005.nc</map>
     </gridmap>


### PR DESCRIPTION
The bilinear map used for the ne30np4.pg2 and EC30to60E2r2 grid combination (and only for mapping atmosphere states to the ocean mesh) is changed to one generated using TempestRemap.  This will allow coupling with offline maps to better match coupling with online maps which use the same algorithm from TempestRemap to calculate the weights.

The answer changes are a little more then roundoff but not climate changing.

[non-BFB] for cases using ne30np4.pg2 and EC30to60E2r2