### PR TITLE
Fix linoz data file for 1pctCO2 use_case

### DIFF
--- a/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6_chemUCI-Linoz-mam5-vbs-1pctCO2.xml
+++ b/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6_chemUCI-Linoz-mam5-vbs-1pctCO2.xml
@@ -117,7 +117,7 @@
 <chlorine_loading_fixed_ymd >18500101</chlorine_loading_fixed_ymd>
 <chlorine_loading_type      >FIXED</chlorine_loading_type>
 <linoz_data_cycle_yr        >1850</linoz_data_cycle_yr>
-<linoz_data_file            >linv3_1849-2015_2010JPL_cmip6_historical_10deg_58km_c20210625.nc</linoz_data_file>
+<linoz_data_file            >linv3_1849-2017_CMIP6_Hist_10deg_58km_c20230705.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 


### PR DESCRIPTION
PR #5860 updated linoz data files for use cases. But the PR did not involve the use_case file for WCYCL1850-1pctCO2 
as it was introduced at a later time.

This fixes WCYCL1850-1pctCO2 tests, though some machines were able to run with the old file.

[non-BFB] only for compy and anvil prod tests that were able to run with the old file