### PR TITLE
Fix parabolic bowl registry for MPAS-Ocean init mode

### DIFF
--- a/components/mpas-ocean/src/mode_init/Registry_parabolic_bowl.xml
+++ b/components/mpas-ocean/src/mode_init/Registry_parabolic_bowl.xml
@@ -1,6 +1,6 @@
-	<nml_record name="parabolic_bowl" mode="init" configuration=="parabolic_bowl">
+	<nml_record name="parabolic_bowl" mode="init" configuration="parabolic_bowl">
 		<nml_option name="config_parabolic_bowl_vert_levels" type="integer" default_value="3" units="unitless"
-			description="Number of vertical levels in para_bowl."
+			description="Number of vertical levels in parabolic bowl."
 			possible_values="Any positive integer number greater than 2."
 	        />
 	        <nml_option name="config_parabolic_bowl_Coriolis_parameter" type="real" default_value="1.031e-4" units="1/s"
@@ -25,8 +25,7 @@
 		/>
 	        <nml_option name="config_parabolic_bowl_adjust_domain_center" type="logical" default_value="true" units="unitless"
 			description="Flag to adjust mesh coordinates"
-			possible_values='.true. or .false'
-
+			possible_values=".true. or .false."
 		/>
 	</nml_record>
 

--- a/components/mpas-ocean/src/mode_init/Registry_parabolic_bowl.xml
+++ b/components/mpas-ocean/src/mode_init/Registry_parabolic_bowl.xml
@@ -1,7 +1,7 @@
 	<nml_record name="parabolic_bowl" mode="init" configuration="parabolic_bowl">
 		<nml_option name="config_parabolic_bowl_vert_levels" type="integer" default_value="3" units="unitless"
 			description="Number of vertical levels in parabolic bowl."
-			possible_values="Any positive integer number greater than 2."
+			possible_values="Any positive integer"
 	        />
 	        <nml_option name="config_parabolic_bowl_Coriolis_parameter" type="real" default_value="1.031e-4" units="1/s"
 			description="Coriolis paramter"


### PR DESCRIPTION
There were a few syntax issues with the MPAS-Ocean registry for the parabolic bowl test case that prevent it from being parsed correctly in Polaris.  They are fixed here.