### PR TITLE
Add new SOwISC12to60E3r1 ocean and sea-ice mesh

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -1035,10 +1035,10 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%ne30np4.pg2_l%.+_oi%SOwISC12to60E2r4">
+  <grid name="a%ne30np4.pg2_l%.+_oi%SOwISC12to60E*">
     <mach name="anvil">
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SWAV.+" pesize="L">
-        <comment> -compset WCYCL*/CRYO* -res SOwISC12to60E2r4* on 75 nodes pure-MPI, ~5 sypd </comment>
+        <comment> -compset WCYCL*/CRYO* -res SOwISC12to60E* on 75 nodes pure-MPI, ~5 sypd </comment>
         <ntasks>
           <ntasks_atm>900</ntasks_atm>
           <ntasks_lnd>900</ntasks_lnd>
@@ -1059,7 +1059,7 @@
     </mach>
     <mach name="chrysalis">
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SWAV.+" pesize="L">
-        <comment> -compset WCYCL*/CRYO* -res ne30pg*SOwISC12to60E2r4* on 105 nodes pure-MPI, ~18.5 sypd </comment>
+        <comment> -compset WCYCL*/CRYO* -res ne30pg*SOwISC12to60E* on 105 nodes pure-MPI, ~18.5 sypd </comment>
         <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
         <ntasks>
           <ntasks_atm>2700</ntasks_atm>
@@ -1079,7 +1079,7 @@
         </rootpe>
       </pes>
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SWAV.+" pesize="M">
-        <comment> -compset WCYCL*/CRYO* -res ne30pg*SOwISC12to60E2r4* on 54 nodes pure-MPI, ~11 sypd </comment>
+        <comment> -compset WCYCL*/CRYO* -res ne30pg*SOwISC12to60E* on 54 nodes pure-MPI, ~11 sypd </comment>
         <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
         <ntasks>
           <ntasks_atm>1350</ntasks_atm>

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -1496,6 +1496,16 @@
       <mask>ECwISC30to60E3r2</mask>
     </model_grid>
 
+    <model_grid alias="ne120pg2_r05_SOwISC12to60E3r1">
+      <grid name="atm">ne120np4.pg2</grid>
+      <grid name="lnd">r05</grid>
+      <grid name="ocnice">SOwISC12to60E3r1</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>SOwISC12to60E3r1</mask>
+    </model_grid>
+
     <model_grid alias="ne240_ne240" compset="(DOCN|XOCN|SOCN|AQP1)">
       <grid name="atm">ne240np4</grid>
       <grid name="lnd">ne240np4</grid>
@@ -2074,6 +2084,16 @@
       <mask>WC14to60E2r3</mask>
     </model_grid>
 
+    <model_grid alias="ne30pg2_r05_SOwISC12to60E3r1">
+      <grid name="atm">ne30np4.pg2</grid>
+      <grid name="lnd">r05</grid>
+      <grid name="ocnice">SOwISC12to60E3r1</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>SOwISC12to60E3r1</mask>
+    </model_grid>
+
     <model_grid alias="ne30pg3_r05_oECv3">
       <grid name="atm">ne30np4.pg3</grid>
       <grid name="lnd">r05</grid>
@@ -2603,6 +2623,8 @@
       <file grid="ice|ocn" mask="ICOS10">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120pg2_ICOS10.230120.nc</file>
       <file grid="atm|lnd" mask="ECwISC30to60E3r2">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120pg2_ECwISC30to60E3r2.231018.nc</file>
       <file grid="ice|ocn" mask="ECwISC30to60E3r2">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120pg2_ECwISC30to60E3r2.231018.nc</file>
+      <file grid="atm|lnd" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120pg2_SOwISC12to60E3r1.230918.nc</file>
+      <file grid="ice|ocn" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120pg2_SOwISC12to60E3r1.230918.nc</file>
       <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120pg2_gx1v6.190819.nc</file>
       <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120pg2_gx1v6.190819.nc</file>
       <desc>ne120np4 is Spectral Elem 1/4-deg grid w/ 2x2 FV physics grid</desc>
@@ -2845,6 +2867,8 @@
       <file grid="lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_WC14to60E2r3.200929.nc</file>
       <file grid="atm" mask="ECwISC30to60E3r2">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_ECwISC30to60E3r2.231018.nc</file>
       <file grid="lnd" mask="ECwISC30to60E3r2">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_ECwISC30to60E3r2.231018.nc</file>
+      <file grid="atm" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_SOwISC12to60E3r1.230901.nc</file>
+      <file grid="lnd" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_SOwISC12to60E3r1.230901.nc</file>
       <file grid="lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_gx1v6.191014.nc</file>
       <desc>r05 is 1/2 degree river routing grid:</desc>
     </domain>
@@ -3534,6 +3558,14 @@
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_ECwISC30to60E3r2-nomask_trintbilin.20231018.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/ECwISC30to60E3r2/map_ECwISC30to60E3r2_to_ne120pg2_traave.20231018.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/ECwISC30to60E3r2/map_ECwISC30to60E3r2_to_ne120pg2_traave.20231018.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne120np4.pg2" ocn_grid="SOwISC12to60E3r1">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_SOwISC12to60E3r1_mono.230918.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_SOwISC12to60E3r1_bilin.230918.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_SOwISC12to60E3r1-nomask_bilin.230918.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_ne120pg2_mono.230918.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_ne120pg2_mono.230918.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne120np4.pg2" lnd_grid="r05">

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -2394,7 +2394,7 @@
       <file grid="atm|lnd" mask="SOwISC12to60E2r4">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_SOwISC12to60E2r4.210119.nc</file>
       <file grid="atm|lnd" mask="ECwISC30to60E2r1">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_ECwISC30to60E2r1.201007.nc</file>
       <file grid="atm|lnd" mask="ECwISC30to60E3r2">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_ECwISC30to60E3r2.231018.nc</file>
-      <file grid="atm|lnd" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_SOwISC12to60E3r1.230905.nc</file>
+      <file grid="atm|lnd" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_SOwISC12to60E3r1.231115.nc</file>
       <desc>T62 is Gaussian grid:</desc>
     </domain>
 
@@ -2439,8 +2439,8 @@
       <file grid="ice|ocn" mask="ECwISC30to60E2r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_ECwISC30to60E2r1.201007.nc</file>
       <file grid="atm|lnd" mask="ECwISC30to60E3r2">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_ECwISC30to60E3r2.231018.nc</file>
       <file grid="ice|ocn" mask="ECwISC30to60E3r2">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_ECwISC30to60E3r2.231018.nc</file>
-      <file grid="atm|lnd" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_SOwISC12to60E3r1.230905.nc</file>
-      <file grid="ice|ocn" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_SOwISC12to60E3r1.230905.nc</file>
+      <file grid="atm|lnd" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_SOwISC12to60E3r1.231115.nc</file>
+      <file grid="ice|ocn" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_SOwISC12to60E3r1.231115.nc</file>
       <file grid="atm|lnd" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_oRRS18to6v3.220124.nc</file>
       <file grid="ice|ocn" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oRRS18to6v3.220124.nc</file>
       <desc>TL319 is JRA lat/lon grid:</desc>
@@ -2550,8 +2550,8 @@
       <file grid="ice|ocn" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_oRRS18to6v3.211101.nc</file>
       <file grid="atm|lnd" mask="ECwISC30to60E3r2">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_ECwISC30to60E3r2.231018.nc</file>
       <file grid="ice|ocn" mask="ECwISC30to60E3r2">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_ECwISC30to60E3r2.231018.nc</file>
-      <file grid="atm|lnd" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_SOwISC12to60E3r1.230905.nc</file>
-      <file grid="ice|ocn" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_SOwISC12to60E3r1.230905.nc</file>
+      <file grid="atm|lnd" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_SOwISC12to60E3r1.231115.nc</file>
+      <file grid="ice|ocn" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_SOwISC12to60E3r1.231115.nc</file>
       <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_gx1v6.190806.nc</file>
       <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_gx1v6.190806.nc</file>
       <desc>ne30np4.pg2 is Spectral Elem 1-deg grid w/ 2x2 FV physics grid per element:</desc>
@@ -2623,8 +2623,8 @@
       <file grid="ice|ocn" mask="ICOS10">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120pg2_ICOS10.230120.nc</file>
       <file grid="atm|lnd" mask="ECwISC30to60E3r2">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120pg2_ECwISC30to60E3r2.231018.nc</file>
       <file grid="ice|ocn" mask="ECwISC30to60E3r2">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120pg2_ECwISC30to60E3r2.231018.nc</file>
-      <file grid="atm|lnd" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120pg2_SOwISC12to60E3r1.230918.nc</file>
-      <file grid="ice|ocn" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120pg2_SOwISC12to60E3r1.230918.nc</file>
+      <file grid="atm|lnd" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120pg2_SOwISC12to60E3r1.231115.nc</file>
+      <file grid="ice|ocn" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120pg2_SOwISC12to60E3r1.231115.nc</file>
       <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120pg2_gx1v6.190819.nc</file>
       <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120pg2_gx1v6.190819.nc</file>
       <desc>ne120np4 is Spectral Elem 1/4-deg grid w/ 2x2 FV physics grid</desc>
@@ -2831,7 +2831,7 @@
     <domain name="SOwISC12to60E3r1">
       <nx>569502</nx>
       <ny>1</ny>
-      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.SOwISC12to60E3r1.230905.nc</file>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.SOwISC12to60E3r1.231115.nc</file>
       <desc>SOwISC12to60E3r1 is a MPAS ocean grid generated with the jigsaw/compass process XXX. Additionally, it has ocean in ice-shelf cavities:</desc>
     </domain>
 
@@ -2867,8 +2867,8 @@
       <file grid="lnd" mask="WC14to60E2r3">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_WC14to60E2r3.200929.nc</file>
       <file grid="atm" mask="ECwISC30to60E3r2">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_ECwISC30to60E3r2.231018.nc</file>
       <file grid="lnd" mask="ECwISC30to60E3r2">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_ECwISC30to60E3r2.231018.nc</file>
-      <file grid="atm" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_SOwISC12to60E3r1.230901.nc</file>
-      <file grid="lnd" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_SOwISC12to60E3r1.230901.nc</file>
+      <file grid="atm" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_SOwISC12to60E3r1.231115.nc</file>
+      <file grid="lnd" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_SOwISC12to60E3r1.231115.nc</file>
       <file grid="lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_gx1v6.191014.nc</file>
       <desc>r05 is 1/2 degree river routing grid:</desc>
     </domain>
@@ -3332,11 +3332,11 @@
     </gridmap>
 
     <gridmap atm_grid="ne30np4.pg2" ocn_grid="SOwISC12to60E3r1">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_SOwISC12to60E3r1_mono.230905.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_SOwISC12to60E3r1_bilin.230905.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_SOwISC12to60E3r1-nomask_bilin.230905.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_ne30pg2_mono.230905.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_ne30pg2_mono.230905.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_SOwISC12to60E3r1_traave.20231115.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_SOwISC12to60E3r1_trbilin.20231115.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_SOwISC12to60E3r1-nomask_trbilin.20231115.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_ne30pg2_traave.20231115.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_ne30pg2_traave.20231115.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4.pg3" ocn_grid="oEC60to30v3">
@@ -3561,11 +3561,11 @@
     </gridmap>
 
     <gridmap atm_grid="ne120np4.pg2" ocn_grid="SOwISC12to60E3r1">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_SOwISC12to60E3r1_mono.230918.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_SOwISC12to60E3r1_bilin.230918.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_SOwISC12to60E3r1-nomask_bilin.230918.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_ne120pg2_mono.230918.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_ne120pg2_mono.230918.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_SOwISC12to60E3r1_traave.20231115.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_SOwISC12to60E3r1_trbilin.20231115.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne120pg2/map_ne120pg2_to_SOwISC12to60E3r1-nomask_trbilin.20231115.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_ne120pg2_traave.20231115.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_ne120pg2_traave.20231115.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne120np4.pg2" lnd_grid="r05">
@@ -4067,11 +4067,11 @@
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="SOwISC12to60E3r1">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_SOwISC12to60E3r1_mono.230905.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_SOwISC12to60E3r1-nomask_bilin.230905.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_SOwISC12to60E3r1_patch.230905.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_T62_mono.230905.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_T62_mono.230905.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_SOwISC12to60E3r1_traave.20231115.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_SOwISC12to60E3r1-nomask_trbilin.20231115.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_SOwISC12to60E3r1_patch.20231115.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_T62_traave.20231115.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_T62_traave.20231115.nc</map>
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="oEC60to30v3">
@@ -4171,11 +4171,11 @@
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="SOwISC12to60E3r1">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_SOwISC12to60E3r1_mono.230905.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_SOwISC12to60E3r1-nomask_bilin.230905.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_SOwISC12to60E3r1_patch.230905.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_TL319_mono.230905.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_TL319_mono.230905.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_SOwISC12to60E3r1_traave.20231115.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_SOwISC12to60E3r1-nomask_trbilin.20231115.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_SOwISC12to60E3r1_patch.20231115.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_TL319_traave.20231115.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_TL319_traave.20231115.nc</map>
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="oRRS18to6v3">

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -409,6 +409,16 @@
       <mask>ECwISC30to60E3r2</mask>
     </model_grid>
 
+    <model_grid alias="T62_SOwISC12to60E3r1" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">SOwISC12to60E3r1</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>SOwISC12to60E3r1</mask>
+    </model_grid>
+
     <model_grid alias="TL319_oEC60to30v3" compset="(DATM|XATM|SATM)">
       <grid name="atm">TL319</grid>
       <grid name="lnd">TL319</grid>
@@ -527,6 +537,16 @@
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
       <mask>ECwISC30to60E3r2</mask>
+    </model_grid>
+
+    <model_grid alias="TL319_SOwISC12to60E3r1" compset="(DATM|XATM|SATM)">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">TL319</grid>
+      <grid name="ocnice">SOwISC12to60E3r1</grid>
+      <grid name="rof">JRA025</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>SOwISC12to60E3r1</mask>
     </model_grid>
 
     <model_grid alias="TL319_oRRS18to6v3" compset="(DATM|XATM|SATM)">
@@ -1211,6 +1231,16 @@
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
       <mask>ECwISC30to60E3r2</mask>
+    </model_grid>
+
+    <model_grid alias="ne30pg2_SOwISC12to60E3r1">
+      <grid name="atm">ne30np4.pg2</grid>
+      <grid name="lnd">ne30np4.pg2</grid>
+      <grid name="ocnice">SOwISC12to60E3r1</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>SOwISC12to60E3r1</mask>
     </model_grid>
 
     <model_grid alias="northamericax4v1_r0125_northamericax4v1" compset="(DOCN|XOCN|SOCN|AQP1)">
@@ -2344,6 +2374,7 @@
       <file grid="atm|lnd" mask="SOwISC12to60E2r4">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_SOwISC12to60E2r4.210119.nc</file>
       <file grid="atm|lnd" mask="ECwISC30to60E2r1">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_ECwISC30to60E2r1.201007.nc</file>
       <file grid="atm|lnd" mask="ECwISC30to60E3r2">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_ECwISC30to60E3r2.231018.nc</file>
+      <file grid="atm|lnd" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_SOwISC12to60E3r1.230905.nc</file>
       <desc>T62 is Gaussian grid:</desc>
     </domain>
 
@@ -2388,6 +2419,8 @@
       <file grid="ice|ocn" mask="ECwISC30to60E2r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_ECwISC30to60E2r1.201007.nc</file>
       <file grid="atm|lnd" mask="ECwISC30to60E3r2">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_ECwISC30to60E3r2.231018.nc</file>
       <file grid="ice|ocn" mask="ECwISC30to60E3r2">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_ECwISC30to60E3r2.231018.nc</file>
+      <file grid="atm|lnd" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_SOwISC12to60E3r1.230905.nc</file>
+      <file grid="ice|ocn" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_SOwISC12to60E3r1.230905.nc</file>
       <file grid="atm|lnd" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_oRRS18to6v3.220124.nc</file>
       <file grid="ice|ocn" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oRRS18to6v3.220124.nc</file>
       <desc>TL319 is JRA lat/lon grid:</desc>
@@ -2497,6 +2530,8 @@
       <file grid="ice|ocn" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_oRRS18to6v3.211101.nc</file>
       <file grid="atm|lnd" mask="ECwISC30to60E3r2">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_ECwISC30to60E3r2.231018.nc</file>
       <file grid="ice|ocn" mask="ECwISC30to60E3r2">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_ECwISC30to60E3r2.231018.nc</file>
+      <file grid="atm|lnd" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_SOwISC12to60E3r1.230905.nc</file>
+      <file grid="ice|ocn" mask="SOwISC12to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_SOwISC12to60E3r1.230905.nc</file>
       <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30pg2_gx1v6.190806.nc</file>
       <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30pg2_gx1v6.190806.nc</file>
       <desc>ne30np4.pg2 is Spectral Elem 1-deg grid w/ 2x2 FV physics grid per element:</desc>
@@ -2769,6 +2804,13 @@
       <ny>1</ny>
       <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.ECwISC30to60E3r2.231018.nc</file>
       <desc>ECwISC30to60E3r2 is a MPAS ocean grid generated with the jigsaw/compass process using the eddy closure density function that has 30 km gridcells at the equator, 60 km at mid-latitudes, and 35 km at high latitudes. Additionally, it has ocean in ice-shelf cavities:</desc>
+    </domain>
+
+    <domain name="SOwISC12to60E3r1">
+      <nx>569502</nx>
+      <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.SOwISC12to60E3r1.230905.nc</file>
+      <desc>SOwISC12to60E3r1 is a MPAS ocean grid generated with the jigsaw/compass process XXX. Additionally, it has ocean in ice-shelf cavities:</desc>
     </domain>
 
     <!-- ROF (river) grids-->
@@ -3263,6 +3305,14 @@
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_ECwISC30to60E3r2-nomask_trintbilin.20231018.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/ECwISC30to60E3r2/map_ECwISC30to60E3r2_to_ne30pg2_traave.20231018.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/ECwISC30to60E3r2/map_ECwISC30to60E3r2_to_ne30pg2_traave.20231018.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne30np4.pg2" ocn_grid="SOwISC12to60E3r1">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_SOwISC12to60E3r1_mono.230905.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_SOwISC12to60E3r1_bilin.230905.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_SOwISC12to60E3r1-nomask_bilin.230905.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_ne30pg2_mono.230905.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_ne30pg2_mono.230905.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4.pg3" ocn_grid="oEC60to30v3">
@@ -3984,6 +4034,14 @@
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/ECwISC30to60E3r2/map_ECwISC30to60E3r2_to_T62_traave.20231018.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="T62" ocn_grid="SOwISC12to60E3r1">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_SOwISC12to60E3r1_mono.230905.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_SOwISC12to60E3r1-nomask_bilin.230905.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_SOwISC12to60E3r1_patch.230905.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_T62_mono.230905.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_T62_mono.230905.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="TL319" ocn_grid="oEC60to30v3">
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oEC60to30v3_aave.181203.nc</map>
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oEC60to30v3_bilin.181203.nc</map>
@@ -4078,6 +4136,14 @@
       <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_ECwISC30to60E3r2_patch.20231018.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/ECwISC30to60E3r2/map_ECwISC30to60E3r2_to_TL319_traave.20231018.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/ECwISC30to60E3r2/map_ECwISC30to60E3r2_to_TL319_traave.20231018.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="TL319" ocn_grid="SOwISC12to60E3r1">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_SOwISC12to60E3r1_mono.230905.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_SOwISC12to60E3r1-nomask_bilin.230905.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_SOwISC12to60E3r1_patch.230905.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_TL319_mono.230905.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/SOwISC12to60E3r1/map_SOwISC12to60E3r1_to_TL319_mono.230905.nc</map>
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="oRRS18to6v3">
@@ -4540,6 +4606,11 @@
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_ECwISC30to60E3r2_smoothed.r150e300.230901.nc</map>
     </gridmap>
 
+    <gridmap ocn_grid="SOwISC12to60E3r1" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_SOwISC12to60E3r1_smoothed.r150e300.230905.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_SOwISC12to60E3r1_smoothed.r150e300.230905.nc</map>
+    </gridmap>
+
     <gridmap ocn_grid="oEC60to30v3" rof_grid="JRA025">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_oEC60to30v3_smoothed.r150e300.181204.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_oEC60to30v3_smoothed.r150e300.181204.nc</map>
@@ -4598,6 +4669,11 @@
     <gridmap ocn_grid="ECwISC30to60E3r2" rof_grid="JRA025">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_ECwISC30to60E3r2_smoothed.r150e300.230901.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_ECwISC30to60E3r2_smoothed.r150e300.230901.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="SOwISC12to60E3r1" rof_grid="JRA025">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_SOwISC12to60E3r1_smoothed.r150e300.230905.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_SOwISC12to60E3r1_smoothed.r150e300.230905.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="oRRS18to6v3" rof_grid="JRA025">
@@ -4683,6 +4759,11 @@
     <gridmap ocn_grid="ECwISC30to60E3r2" rof_grid="r05">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_ECwISC30to60E3r2_smoothed.r150e300.230901.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_ECwISC30to60E3r2_smoothed.r150e300.230901.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="SOwISC12to60E3r1" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_SOwISC12to60E3r1_smoothed.r150e300.230905.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_SOwISC12to60E3r1_smoothed.r150e300.230905.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="WC14to60E2r3" rof_grid="r0125">

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -1310,7 +1310,7 @@ Representative concentration pathway for future scenarios [radiative forcing at 
 
 <entry id="mask" type="char*20" category="default_settings"
        group="default_settings"
-       valid_values="USGS,gx3v7,gx1v6,navy,test,tx0.1v2,tx1v1,T62,TL319,cruncep,oEC60to30v3,oEC60to30v3wLI,ECwISC30to60E1r2,EC30to60E2r2,WC14to60E2r3,WCAtl12to45E2r4,SOwISC12to60E2r4,ECwISC30to60E2r1,oRRS18to6,oRRS18to6v3,oRRS15to5,oARRM60to10,oARRM60to6,ARRM10to60E2r1,oQU480,oQU240,oQU240wLI,oQU120,oRRS30to10v3,oRRS30to10v3wLI,360x720cru,NLDASww3a,NLDAS,tx0.1v2,ICOS10,ECwISC30to60E3r2">
+       valid_values="USGS,gx3v7,gx1v6,navy,test,tx0.1v2,tx1v1,T62,TL319,cruncep,oEC60to30v3,oEC60to30v3wLI,ECwISC30to60E1r2,EC30to60E2r2,WC14to60E2r3,WCAtl12to45E2r4,SOwISC12to60E2r4,ECwISC30to60E2r1,oRRS18to6,oRRS18to6v3,oRRS15to5,oARRM60to10,oARRM60to6,ARRM10to60E2r1,oQU480,oQU240,oQU240wLI,oQU120,oRRS30to10v3,oRRS30to10v3wLI,360x720cru,NLDASww3a,NLDAS,tx0.1v2,ICOS10,ECwISC30to60E3r2,SOwISC12to60E3r1">
 Land mask description
 </entry>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -49,6 +49,7 @@
 <config_dt ocn_grid="SOwISC12to60E2r4">'00:10:00'</config_dt>
 <config_dt ocn_grid="ECwISC30to60E2r1">'00:30:00'</config_dt>
 <config_dt ocn_grid="ECwISC30to60E3r2">'00:30:00'</config_dt>
+<config_dt ocn_grid="SOwISC12to60E3r1">'00:10:00'</config_dt>
 <config_time_integrator>'split_explicit'</config_time_integrator>
 <config_number_of_time_levels>2</config_number_of_time_levels>
 
@@ -73,6 +74,7 @@
 <config_hmix_scaleWithMesh ocn_grid="SOwISC12to60E2r4">.true.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="ECwISC30to60E2r1">.true.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="ECwISC30to60E3r2">.true.</config_hmix_scaleWithMesh>
+<config_hmix_scaleWithMesh ocn_grid="SOwISC12to60E3r1">.true.</config_hmix_scaleWithMesh>
 <config_maxMeshDensity>-1.0</config_maxMeshDensity>
 <config_hmix_use_ref_cell_width>.false.</config_hmix_use_ref_cell_width>
 <config_hmix_ref_cell_width>30.0e3</config_hmix_ref_cell_width>
@@ -89,6 +91,7 @@
 <config_use_mom_del2 ocn_grid="SOwISC12to60E2r4">.true.</config_use_mom_del2>
 <config_use_mom_del2 ocn_grid="ECwISC30to60E2r1">.true.</config_use_mom_del2>
 <config_use_mom_del2 ocn_grid="ECwISC30to60E3r2">.true.</config_use_mom_del2>
+<config_use_mom_del2 ocn_grid="SOwISC12to60E3r1">.true.</config_use_mom_del2>
 <config_mom_del2>10.0</config_mom_del2>
 <config_mom_del2 ocn_grid="oEC60to30v3">1000.0</config_mom_del2>
 <config_mom_del2 ocn_grid="oEC60to30v3wLI">1000.0</config_mom_del2>
@@ -99,6 +102,7 @@
 <config_mom_del2 ocn_grid="SOwISC12to60E2r4">462.0</config_mom_del2>
 <config_mom_del2 ocn_grid="ECwISC30to60E2r1">1000.0</config_mom_del2>
 <config_mom_del2 ocn_grid="ECwISC30to60E3r2">1000.0</config_mom_del2>
+<config_mom_del2 ocn_grid="SOwISC12to60E3r1">462.0</config_mom_del2>
 <config_use_tracer_del2>.false.</config_use_tracer_del2>
 <config_tracer_del2>10.0</config_tracer_del2>
 
@@ -124,6 +128,7 @@
 <config_mom_del4 ocn_grid="SOwISC12to60E2r4">1.18e10</config_mom_del4>
 <config_mom_del4 ocn_grid="ECwISC30to60E2r1">1.2e11</config_mom_del4>
 <config_mom_del4 ocn_grid="ECwISC30to60E3r2">1.2e11</config_mom_del4>
+<config_mom_del4 ocn_grid="SOwISC12to60E3r1">1.18e10</config_mom_del4>
 <config_mom_del4_div_factor>1.0</config_mom_del4_div_factor>
 <config_use_tracer_del4>.false.</config_use_tracer_del4>
 <config_tracer_del4>0.0</config_tracer_del4>
@@ -156,6 +161,7 @@
 <config_Redi_horizontal_taper ocn_grid="ECwISC30to60E2r1">'RossbyRadius'</config_Redi_horizontal_taper>
 <!-- To do: ramp for WC but RossbyRadius for Cryo -->
 <config_Redi_horizontal_taper ocn_grid="ECwISC30to60E3r2">'ramp'</config_Redi_horizontal_taper>
+<config_Redi_horizontal_taper ocn_grid="SOwISC12to60E3r1">'RossbyRadius'</config_Redi_horizontal_taper>
 <config_Redi_horizontal_ramp_min>20e3</config_Redi_horizontal_ramp_min>
 <config_Redi_horizontal_ramp_min ocn_grid="WCAtl12to45E2r4">30e3</config_Redi_horizontal_ramp_min>
 <config_Redi_horizontal_ramp_max>30e3</config_Redi_horizontal_ramp_max>
@@ -182,6 +188,7 @@
 <config_GM_closure ocn_grid="ECwISC30to60E2r1">'N2_dependent'</config_GM_closure>
 <!-- To do: constant for WC but N2_dependent for Cryo -->
 <config_GM_closure ocn_grid="ECwISC30to60E3r2">'constant'</config_GM_closure>
+<config_GM_closure ocn_grid="SOwISC12to60E3r1">'N2_dependent'</config_GM_closure>
 <config_GM_constant_kappa>900.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="oEC60to30v3wLI">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="ECwISC30to60E1r2">600.0</config_GM_constant_kappa>
@@ -191,6 +198,7 @@
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="SOwISC12to60E2r4">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="ECwISC30to60E2r1">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="ECwISC30to60E3r2">600.0</config_GM_constant_kappa>
+<config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="SOwISC12to60E3r1">600.0</config_GM_constant_kappa>
 <config_GM_constant_bclModeSpeed>0.3</config_GM_constant_bclModeSpeed>
 <config_GM_minBclModeSpeed_method>'constant'</config_GM_minBclModeSpeed_method>
 <config_GM_spatially_variable_min_kappa>300.0</config_GM_spatially_variable_min_kappa>
@@ -200,6 +208,7 @@
 <config_GM_spatially_variable_baroclinic_mode ocn_grid="ECwISC30to60E2r1">1.0</config_GM_spatially_variable_baroclinic_mode>
 <!-- To do: 3.0 for WC but 1.0 for Cryo? -->
 <config_GM_spatially_variable_baroclinic_mode ocn_grid="ECwISC30to60E3r2">3.0</config_GM_spatially_variable_baroclinic_mode>
+<config_GM_spatially_variable_baroclinic_mode ocn_grid="SOwISC12to60E3r1">1.0</config_GM_spatially_variable_baroclinic_mode>
 <config_GM_Visbeck_alpha>0.13</config_GM_Visbeck_alpha>
 <config_GM_Visbeck_max_depth>1000.0</config_GM_Visbeck_max_depth>
 <config_GM_EG_riMin>200.0</config_GM_EG_riMin>
@@ -211,6 +220,7 @@
 <config_GM_horizontal_taper ocn_grid="ECwISC30to60E2r1">'RossbyRadius'</config_GM_horizontal_taper>
 <!-- To do: ramp for WC but RossbyRadius for Cryo -->
 <config_GM_horizontal_taper ocn_grid="ECwISC30to60E3r2">'ramp'</config_GM_horizontal_taper>
+<config_GM_horizontal_taper ocn_grid="SOwISC12to60E3r1">'RossbyRadius'</config_GM_horizontal_taper>
 <config_GM_horizontal_ramp_min>20e3</config_GM_horizontal_ramp_min>
 <config_GM_horizontal_ramp_min ocn_grid="WCAtl12to45E2r4">30e3</config_GM_horizontal_ramp_min>
 <config_GM_horizontal_ramp_max>30e3</config_GM_horizontal_ramp_max>
@@ -348,6 +358,7 @@
 <config_land_ice_flux_mode ocn_grid="SOwISC12to60E2r4">'pressure_only'</config_land_ice_flux_mode>
 <config_land_ice_flux_mode ocn_grid="ECwISC30to60E2r1">'pressure_only'</config_land_ice_flux_mode>
 <config_land_ice_flux_mode ocn_grid="ECwISC30to60E3r2">'pressure_only'</config_land_ice_flux_mode>
+<config_land_ice_flux_mode ocn_grid="SOwISC12to60E3r1">'pressure_only'</config_land_ice_flux_mode>
 <config_land_ice_flux_formulation>'Jenkins'</config_land_ice_flux_formulation>
 <config_land_ice_flux_useHollandJenkinsAdvDiff>.false.</config_land_ice_flux_useHollandJenkinsAdvDiff>
 <config_land_ice_flux_attenuation_coefficient>10.0</config_land_ice_flux_attenuation_coefficient>
@@ -361,6 +372,7 @@
 <config_land_ice_flux_explicit_topDragCoeff ocn_grid="SOwISC12to60E2r4">4.48e-3</config_land_ice_flux_explicit_topDragCoeff>
 <config_land_ice_flux_explicit_topDragCoeff ocn_grid="ECwISC30to60E2r1">4.48e-3</config_land_ice_flux_explicit_topDragCoeff>
 <config_land_ice_flux_explicit_topDragCoeff ocn_grid="ECwISC30to60E3r2">4.48e-3</config_land_ice_flux_explicit_topDragCoeff>
+<config_land_ice_flux_explicit_topDragCoeff ocn_grid="SOwISC12to60E3r1">4.48e-3</config_land_ice_flux_explicit_topDragCoeff>
 <config_land_ice_flux_ISOMIP_gammaT>1e-4</config_land_ice_flux_ISOMIP_gammaT>
 <config_land_ice_flux_rms_tidal_velocity>5e-2</config_land_ice_flux_rms_tidal_velocity>
 <config_land_ice_flux_jenkins_heat_transfer_coefficient>0.011</config_land_ice_flux_jenkins_heat_transfer_coefficient>
@@ -369,12 +381,14 @@
 <config_land_ice_flux_jenkins_heat_transfer_coefficient ocn_grid="SOwISC12to60E2r4">0.00295</config_land_ice_flux_jenkins_heat_transfer_coefficient>
 <config_land_ice_flux_jenkins_heat_transfer_coefficient ocn_grid="ECwISC30to60E2r1">0.00295</config_land_ice_flux_jenkins_heat_transfer_coefficient>
 <config_land_ice_flux_jenkins_heat_transfer_coefficient ocn_grid="ECwISC30to60E3r2">0.00295</config_land_ice_flux_jenkins_heat_transfer_coefficient>
+<config_land_ice_flux_jenkins_heat_transfer_coefficient ocn_grid="SOwISC12to60E3r1">0.00295</config_land_ice_flux_jenkins_heat_transfer_coefficient>
 <config_land_ice_flux_jenkins_salt_transfer_coefficient>3.1e-4</config_land_ice_flux_jenkins_salt_transfer_coefficient>
 <config_land_ice_flux_jenkins_salt_transfer_coefficient ocn_grid="oEC60to30v3wLI">8.42e-5</config_land_ice_flux_jenkins_salt_transfer_coefficient>
 <config_land_ice_flux_jenkins_salt_transfer_coefficient ocn_grid="ECwISC30to60E1r2">8.42e-5</config_land_ice_flux_jenkins_salt_transfer_coefficient>
 <config_land_ice_flux_jenkins_salt_transfer_coefficient ocn_grid="SOwISC12to60E2r4">8.42e-5</config_land_ice_flux_jenkins_salt_transfer_coefficient>
 <config_land_ice_flux_jenkins_salt_transfer_coefficient ocn_grid="ECwISC30to60E2r1">8.42e-5</config_land_ice_flux_jenkins_salt_transfer_coefficient>
 <config_land_ice_flux_jenkins_salt_transfer_coefficient ocn_grid="ECwISC30to60E3r2">8.42e-5</config_land_ice_flux_jenkins_salt_transfer_coefficient>
+<config_land_ice_flux_jenkins_salt_transfer_coefficient ocn_grid="SOwISC12to60E3r1">8.42e-5</config_land_ice_flux_jenkins_salt_transfer_coefficient>
 
 <!-- advection -->
 <config_vert_advection_method>'flux-form'</config_vert_advection_method>
@@ -398,6 +412,7 @@
 <config_implicit_top_drag_coeff ocn_grid="SOwISC12to60E2r4">4.48e-3</config_implicit_top_drag_coeff>
 <config_implicit_top_drag_coeff ocn_grid="ECwISC30to60E2r1">4.48e-3</config_implicit_top_drag_coeff>
 <config_implicit_top_drag_coeff ocn_grid="ECwISC30to60E3r2">4.48e-3</config_implicit_top_drag_coeff>
+<config_implicit_top_drag_coeff ocn_grid="SOwISC12to60E3r1">4.48e-3</config_implicit_top_drag_coeff>
 <config_loglaw_bottom_roughness>1.0e-3</config_loglaw_bottom_roughness>
 <config_loglaw_layer_depth_max>10.0</config_loglaw_layer_depth_max>
 <config_loglaw_bottom_drag_min>2.5e-3</config_loglaw_bottom_drag_min>
@@ -476,6 +491,7 @@
 <config_btr_dt ocn_grid="SOwISC12to60E2r4">'0000_00:00:15'</config_btr_dt>
 <config_btr_dt ocn_grid="ECwISC30to60E2r1">'0000_00:01:00'</config_btr_dt>
 <config_btr_dt ocn_grid="ECwISC30to60E3r2">'0000_00:01:00'</config_btr_dt>
+<config_btr_dt ocn_grid="SOwISC12to60E3r1">'0000_00:00:15'</config_btr_dt>
 <config_n_btr_cor_iter>2</config_n_btr_cor_iter>
 <config_vel_correction>.true.</config_vel_correction>
 <config_btr_subcycle_loop_factor>2</config_btr_subcycle_loop_factor>
@@ -517,6 +533,7 @@
 <config_check_ssh_consistency ocn_grid="SOwISC12to60E2r4">.false.</config_check_ssh_consistency>
 <config_check_ssh_consistency ocn_grid="ECwISC30to60E2r1">.false.</config_check_ssh_consistency>
 <config_check_ssh_consistency ocn_grid="ECwISC30to60E3r2">.false.</config_check_ssh_consistency>
+<config_check_ssh_consistency ocn_grid="SOwISC12to60E3r1">.false.</config_check_ssh_consistency>
 <config_filter_btr_mode>.false.</config_filter_btr_mode>
 <config_prescribe_velocity>.false.</config_prescribe_velocity>
 <config_prescribe_thickness>.false.</config_prescribe_thickness>
@@ -1034,6 +1051,7 @@
 <config_AM_mocStreamfunction_enable ocn_grid="SOwISC12to60E2r4">.true.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="ECwISC30to60E2r1">.true.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="ECwISC30to60E3r2">.true.</config_AM_mocStreamfunction_enable>
+<config_AM_mocStreamfunction_enable ocn_grid="SOwISC12to60E3r1">.true.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_compute_interval>'0000-00-00_01:00:00'</config_AM_mocStreamfunction_compute_interval>
 <config_AM_mocStreamfunction_output_stream>'mocStreamfunctionOutput'</config_AM_mocStreamfunction_output_stream>
 <config_AM_mocStreamfunction_compute_on_startup>.true.</config_AM_mocStreamfunction_compute_on_startup>
@@ -1116,16 +1134,19 @@
 <config_AM_conservationCheck_enable ocn_grid="SOwISC12to60E2r4">.true.</config_AM_conservationCheck_enable>
 <config_AM_conservationCheck_enable ocn_grid="ECwISC30to60E2r1">.true.</config_AM_conservationCheck_enable>
 <config_AM_conservationCheck_enable ocn_grid="ECwISC30to60E3r2">.true.</config_AM_conservationCheck_enable>
+<config_AM_conservationCheck_enable ocn_grid="SOwISC12to60E3r1">.true.</config_AM_conservationCheck_enable>
 <config_AM_conservationCheck_compute_interval>'dt'</config_AM_conservationCheck_compute_interval>
 <config_AM_conservationCheck_output_stream>'conservationCheckOutput'</config_AM_conservationCheck_output_stream>
 <config_AM_conservationCheck_compute_on_startup>.false.</config_AM_conservationCheck_compute_on_startup>
 <config_AM_conservationCheck_compute_on_startup ocn_grid="SOwISC12to60E2r4">.true.</config_AM_conservationCheck_compute_on_startup>
 <config_AM_conservationCheck_compute_on_startup ocn_grid="ECwISC30to60E2r1">.true.</config_AM_conservationCheck_compute_on_startup>
 <config_AM_conservationCheck_compute_on_startup ocn_grid="ECwISC30to60E3r2">.true.</config_AM_conservationCheck_compute_on_startup>
+<config_AM_conservationCheck_compute_on_startup ocn_grid="SOwISC12to60E3r1">.true.</config_AM_conservationCheck_compute_on_startup>
 <config_AM_conservationCheck_write_on_startup>.false.</config_AM_conservationCheck_write_on_startup>
 <config_AM_conservationCheck_write_on_startup ocn_grid="SOwISC12to60E2r4">.true.</config_AM_conservationCheck_write_on_startup>
 <config_AM_conservationCheck_write_on_startup ocn_grid="ECwISC30to60E2r1">.true.</config_AM_conservationCheck_write_on_startup>
 <config_AM_conservationCheck_write_on_startup ocn_grid="ECwISC30to60E3r2">.true.</config_AM_conservationCheck_write_on_startup>
+<config_AM_conservationCheck_write_on_startup ocn_grid="SOwISC12to60E3r1">.true.</config_AM_conservationCheck_write_on_startup>
 <config_AM_conservationCheck_write_to_logfile>.true.</config_AM_conservationCheck_write_to_logfile>
 <config_AM_conservationCheck_restart_stream>'conservationCheckRestart'</config_AM_conservationCheck_restart_stream>
 

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -304,8 +304,8 @@ def buildnml(case, caseroot, compname):
         ic_date = '20230901'
         ic_prefix = 'mpaso.SOwISC12to60E3r1'
         if ocn_ic_mode == 'spunup':
-            logger.warning("WARNING: The specified compset is requesting ocean ICs spunup from a G-case")
-            logger.warning("         But no file available for this grid.")
+            ic_date = '230914'
+            ic_prefix = 'mpaso.SOwISC12to60E3r1.rstFromG-chrysalis'
         if ocn_ismf == 'data':
             data_ismf_file = 'prescribed_ismf_adusumilli2020.SOwISC12to60E3r1.20230901.nc'
 

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -296,6 +296,19 @@ def buildnml(case, caseroot, compname):
         if ocn_ismf == 'data':
             data_ismf_file = 'prescribed_ismf_adusumilli2020.ECwISC30to60E3r2.20230901.nc'
 
+    elif ocn_grid == 'SOwISC12to60E3r1':
+        decomp_date = '20230901'
+        decomp_prefix = 'partitions/mpas-o.graph.info.'
+        restoring_file = 'sss.PHC2_monthlyClimatology.SOwISC12to60E3r1.20230901.nc'
+        analysis_mask_file = 'SOwISC12to60E3r1_mocBasinsAndTransects20210623.nc'
+        ic_date = '20230901'
+        ic_prefix = 'mpaso.SOwISC12to60E3r1'
+        if ocn_ic_mode == 'spunup':
+            logger.warning("WARNING: The specified compset is requesting ocean ICs spunup from a G-case")
+            logger.warning("         But no file available for this grid.")
+        if ocn_ismf == 'data':
+            data_ismf_file = 'prescribed_ismf_adusumilli2020.SOwISC12to60E3r1.20230901.nc'
+
     #--------------------------------------------------------------------
     # Set OCN_FORCING = datm_forced_restoring if restoring file is available
     #--------------------------------------------------------------------

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -25,6 +25,7 @@
 <config_dt ice_grid="SOwISC12to60E2r4">1800.0</config_dt>
 <config_dt ice_grid="ECwISC30to60E2r1">1800.0</config_dt>
 <config_dt ice_grid="ECwISC30to60E3r2">1800.0</config_dt>
+<config_dt ice_grid="SOwISC12to60E3r1">1800.0</config_dt>
 <config_calendar_type>'noleap'</config_calendar_type>
 <config_start_time>'2000-01-01_00:00:00'</config_start_time>
 <config_stop_time>'none'</config_stop_time>
@@ -77,6 +78,7 @@
 <config_initial_latitude_north ice_grid="ECwISC30to60E2r1">75.0</config_initial_latitude_north>
 <!-- To do: 70.0 for WC but 75.0 for Cryo -->
 <config_initial_latitude_north ice_grid="ECwISC30to60E3r2">70.0</config_initial_latitude_north>
+<config_initial_latitude_north ice_grid="SOwISC12to60E3r1">85.0</config_initial_latitude_north>
 <config_initial_latitude_north ice_grid="ARRM10to60E2r1">75.0</config_initial_latitude_north>
 <config_initial_latitude_north ice_grid="oRRS30to10v3wLI">85.0</config_initial_latitude_north>
 <config_initial_latitude_north ice_grid="oRRS18to6v3">85.0</config_initial_latitude_north>
@@ -87,6 +89,7 @@
 <config_initial_latitude_south ice_grid="ECwISC30to60E2r1">-75.0</config_initial_latitude_south>
 <!-- To do: -60.0 for WC but -75.0 for Cryo -->
 <config_initial_latitude_south ice_grid="ECwISC30to60E3r2">-60.0</config_initial_latitude_south>
+<config_initial_latitude_south ice_grid="SOwISC12to60E3r1">-85.0</config_initial_latitude_south>
 <config_initial_latitude_south ice_grid="ARRM10to60E2r1">-85.0</config_initial_latitude_south>
 <config_initial_latitude_south ice_grid="oRRS30to10v3wLI">-85.0</config_initial_latitude_south>
 <config_initial_latitude_south ice_grid="oRRS18to6v3">-85.0</config_initial_latitude_south>
@@ -148,6 +151,7 @@
 <config_dynamics_subcycle_number ice_grid="SOwISC12to60E2r4">1</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="ECwISC30to60E2r1">1</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="ECwISC30to60E3r2">1</config_dynamics_subcycle_number>
+<config_dynamics_subcycle_number ice_grid="SOwISC12to60E3r1">1</config_dynamics_subcycle_number>
 <config_rotate_cartesian_grid>true</config_rotate_cartesian_grid>
 <config_include_metric_terms>true</config_include_metric_terms>
 <config_elastic_subcycle_number>120</config_elastic_subcycle_number>

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -263,6 +263,16 @@ def buildnml(case, caseroot, compname):
             grid_date = '230914'
             grid_prefix = 'mpassi.ECwISC30to60E3r2.rstFromG-chrysalis'
 
+    elif ice_grid == 'SOwISC12to60E3r1':
+        grid_date = '20230901'
+        grid_prefix = 'mpassi.SOwISC12to60E3r1'
+        decomp_date = '20230901'
+        decomp_prefix = 'partitions/mpas-seaice.graph.info.'
+        data_iceberg_file = 'Iceberg_Climatology_Merino.SOwISC12to60E3r1.20230901.nc'
+        if ice_ic_mode == 'spunup':
+            logger.warning("WARNING: The specified compset is requesting seaice ICs spunup from a G-case")
+            logger.warning("         But no file available for this grid.")
+
     elif ice_grid == 'ICOS10':
         grid_date = '211015'
         grid_prefix = 'seaice.ICOS10'

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -270,8 +270,8 @@ def buildnml(case, caseroot, compname):
         decomp_prefix = 'partitions/mpas-seaice.graph.info.'
         data_iceberg_file = 'Iceberg_Climatology_Merino.SOwISC12to60E3r1.20230901.nc'
         if ice_ic_mode == 'spunup':
-            logger.warning("WARNING: The specified compset is requesting seaice ICs spunup from a G-case")
-            logger.warning("         But no file available for this grid.")
+            grid_date = '230914'
+            grid_prefix = 'mpassi.SOwISC12to60E3r1.rstFromG-chrysalis'
 
     elif ice_grid == 'ICOS10':
         grid_date = '211015'


### PR DESCRIPTION
Long name: SOwISC12to60kmL64E3SMv3r1

This version of the Southern Ocean Regionally Refined Mesh (SORRM) has the same distribution of resolution as in the E3SM v2 version of the mesh https://github.com/MPAS-Dev/compass/pull/37, including:

- 12 km resolution around Antarctica
- 45 km resolution at southern mid-latitudes
- 30 km resolution at the equator and the north Atlantic
- 60 km resolution in the north Pacific
- 35 km resolution in the Arctic

It matches the EC30to60 (#5927) mesh except in the Southern Ocean and north Atlantic.

This is a proposed E3SM v3 (E3) mesh for polar (formerly cryosphere) simulations. It is also being considered for flagship coupled simulations because of its strong AMOC. This is revision 1 (r1) of the mesh, since we caught and fixed the issues with Greenland topography (seen in earlier revisions of EC and Icos meshes) before any substantial testing was performed.

The mesh was created using [compass](https://github.com/MPAS-Dev/compass), specifically this tag: https://github.com/MPAS-Dev/compass/releases/tag/mesh_SOwISC12to60E3r1

A G-case with data iceberg melt fluxes (DIB) and data ice-shelf melt fluxes (DISMF) has been run for 30 years, with MPAS-Analysis output available here:
https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.jwolfe/20230905.G-test.SOwISC12to60E3r1.anvil/html/

The mesh and the G-case results are being reviewed here:
https://acme-climate.atlassian.net/wiki/spaces/OO/pages/3894181889/Review+SOwISC12to60E3r1

A B-case will begin shortly and analysis will be posted here and on the review page as soon as it is available.