### PR TITLE
Update maint-2.0 for pm-cpu (including making Intel default compiler)

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -107,7 +107,7 @@
         </nthrds>
       </pes>
     </mach>
-    <mach name="theta|pm-gpu|cori-knl|cori-haswell|jlse">
+    <mach name="theta|pm-cpu|alvarez|pm-gpu|jlse">
       <pes compset="any" pesize="any">
         <comment>allactive: default, 1 node x MAX_MPITASKS_PER_NODE mpi x 1 omp @ root 0</comment>
         <ntasks>
@@ -122,7 +122,7 @@
         </ntasks>
       </pes>
     </mach>
-    <mach name="pm-cpu|alvarez">
+    <mach name="chicoma-cpu">
       <pes compset="any" pesize="any">
         <comment>allactive: default, 1 node x MAX_MPITASKS_PER_NODE mpi x 2 omp @ root 0</comment>
         <ntasks>
@@ -145,9 +145,24 @@
         </nthrds>
       </pes>
     </mach>
-    <mach name="gcp">
+    <mach name="gcp12">
       <pes compset="any" pesize="any">
-        <comment>allactive+gcp: default</comment>
+        <comment>allactive+gcp12: default 1 node 56x1</comment>
+        <ntasks>
+          <ntasks_atm>56</ntasks_atm>
+          <ntasks_lnd>56</ntasks_lnd>
+          <ntasks_rof>56</ntasks_rof>
+          <ntasks_ice>56</ntasks_ice>
+          <ntasks_ocn>56</ntasks_ocn>
+          <ntasks_glc>16</ntasks_glc>
+          <ntasks_wav>16</ntasks_wav>
+          <ntasks_cpl>56</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
+    <mach name="gcp10">
+      <pes compset="any" pesize="any">
+        <comment>allactive+gcp: default 1 node 30x1</comment>
         <ntasks>
           <ntasks_atm>30</ntasks_atm>
           <ntasks_lnd>30</ntasks_lnd>
@@ -191,31 +206,6 @@
       </pes>
     </mach>
     <!-- end machine-specific generic defaults -->
-    <mach name="cori-haswell">
-      <pes compset="any" pesize="T">
-        <comment>allactive+cori-haswell: pesize=threaded</comment>
-        <ntasks>
-          <ntasks_atm>240</ntasks_atm>
-          <ntasks_lnd>240</ntasks_lnd>
-          <ntasks_rof>240</ntasks_rof>
-          <ntasks_ice>240</ntasks_ice>
-          <ntasks_ocn>240</ntasks_ocn>
-          <ntasks_glc>240</ntasks_glc>
-          <ntasks_wav>240</ntasks_wav>
-          <ntasks_cpl>240</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>4</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>4</nthrds_glc>
-          <nthrds_wav>4</nthrds_wav>
-          <nthrds_cpl>4</nthrds_cpl>
-        </nthrds>
-      </pes>
-    </mach>
     <mach name="sandiatoss3">
       <pes compset="any" pesize="T">
         <comment>allactive+sandiatoss3: pesize=T</comment>
@@ -273,9 +263,9 @@
   <!-- 2000_DATM%JRA_ELM%SPBC_MPASSI_MPASO%DATMFORCED_MOSART_SGLC_SWAV_SIAC_SESP -->
   <!-- ATM_GRID is ne30np4.pg2  ICE_GRID is EC30to60E2r2 -->
   <grid name="a%ne30np4">
-    <mach name="pm-cpu">
+    <mach name="pm-cpu|alvarez">
       <pes compset="JRA_ELM.+MPASSI.+MPASO.+MOSART.+SGLC.+SWAV" pesize="any">
-        <comment>"pm-cpu 4 nodes, 256 partition"</comment>
+        <comment>"pm-cpu 4 nodes, 256 partition, 128x1, c8"</comment>
         <ntasks>
           <ntasks_atm>-4</ntasks_atm>
           <ntasks_lnd>-4</ntasks_lnd>
@@ -284,37 +274,25 @@
           <ntasks_ocn>-4</ntasks_ocn>
           <ntasks_glc>-1</ntasks_glc>
           <ntasks_wav>-1</ntasks_wav>
-          <ntasks_cpl>-4</ntasks_cpl>
+          <ntasks_cpl>64</ntasks_cpl>
         </ntasks>
+        <pstrid>
+          <pstrid_cpl>8</pstrid_cpl>
+        </pstrid>
       </pes>
     </mach>
-    <mach name="cori-haswell">
+    <mach name="gcp12">
       <pes compset="JRA_ELM.+MPASSI.+MPASO.+MOSART.+SGLC.+SWAV" pesize="any">
-        <comment>"cori-haswell, 8 nodes, 256 partition"</comment>
+        <comment>"gcp12, 5 nodes, 240 partition, 2 threads 56x2"</comment>
         <ntasks>
-          <ntasks_atm>-8</ntasks_atm>
-          <ntasks_lnd>-8</ntasks_lnd>
-          <ntasks_rof>-8</ntasks_rof>
-          <ntasks_ice>-8</ntasks_ice>
-          <ntasks_ocn>-8</ntasks_ocn>
+          <ntasks_atm>280</ntasks_atm>
+          <ntasks_lnd>280</ntasks_lnd>
+          <ntasks_rof>280</ntasks_rof>
+          <ntasks_ice>256</ntasks_ice>
+          <ntasks_ocn>256</ntasks_ocn>
           <ntasks_glc>-1</ntasks_glc>
           <ntasks_wav>-1</ntasks_wav>
-          <ntasks_cpl>-8</ntasks_cpl>
-        </ntasks>
-      </pes>
-    </mach>
-    <mach name="cori-knl">
-      <pes compset="JRA_ELM.+MPASSI.+MPASO.+MOSART.+SGLC.+SWAV" pesize="any">
-        <comment>"cori-knl, 30 nodes, 1920 partition, 2 threads 64x2"</comment>
-        <ntasks>
-          <ntasks_atm>1920</ntasks_atm>
-          <ntasks_lnd>1920</ntasks_lnd>
-          <ntasks_rof>1920</ntasks_rof>
-          <ntasks_ice>1920</ntasks_ice>
-          <ntasks_ocn>1920</ntasks_ocn>
-          <ntasks_glc>-1</ntasks_glc>
-          <ntasks_wav>-1</ntasks_wav>
-          <ntasks_cpl>1920</ntasks_cpl>
+          <ntasks_cpl>280</ntasks_cpl>
         </ntasks>
         <nthrds>
           <nthrds_atm>2</nthrds_atm>
@@ -326,9 +304,9 @@
         </nthrds>
       </pes>
     </mach>
-    <mach name="gcp">
+    <mach name="gcp10">
       <pes compset="JRA_ELM.+MPASSI.+MPASO.+MOSART.+SGLC.+SWAV" pesize="any">
-        <comment>"gcp, 8 nodes, 240 partition, 2 threads 30x2"</comment>
+        <comment>"gcp10, 8 nodes, 240 partition, 2 threads 30x2"</comment>
         <ntasks>
           <ntasks_atm>-8</ntasks_atm>
           <ntasks_lnd>-8</ntasks_lnd>
@@ -386,198 +364,6 @@
           <ntasks_ocn>-4</ntasks_ocn>
           <ntasks_cpl>-4</ntasks_cpl>
         </ntasks>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%ne30np4_">
-    <mach name="cori-haswell">
-      <pes compset="EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SGLC.+SWAV" pesize="any">
-        <comment>"185 nodes, 32x1, ~5sypd (wmod185)"</comment>
-        <ntasks>
-          <ntasks_atm>5400</ntasks_atm>
-          <ntasks_lnd>608</ntasks_lnd>
-          <ntasks_rof>608</ntasks_rof>
-          <ntasks_ice>3200</ntasks_ice>
-          <ntasks_ocn>512</ntasks_ocn>
-          <ntasks_glc>32</ntasks_glc>
-          <ntasks_wav>32</ntasks_wav>
-          <ntasks_cpl>4800</ntasks_cpl>
-        </ntasks>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>4800</rootpe_lnd>
-          <rootpe_rof>4800</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>5408</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-      <pes compset="EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SGLC.+SWAV" pesize="S">
-        <comment>"15 nodes, 32x1, ~.5sypd (wmod015)"</comment>
-        <ntasks>
-          <ntasks_atm>288</ntasks_atm>
-          <ntasks_lnd>32</ntasks_lnd>
-          <ntasks_rof>32</ntasks_rof>
-          <ntasks_ice>256</ntasks_ice>
-          <ntasks_ocn>192</ntasks_ocn>
-          <ntasks_glc>32</ntasks_glc>
-          <ntasks_wav>32</ntasks_wav>
-          <ntasks_cpl>288</ntasks_cpl>
-        </ntasks>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>256</rootpe_lnd>
-          <rootpe_rof>256</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>288</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-    </mach>
-    <mach name="cori-knl">
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*" pesize="L">
-        <comment>"cori-knl ne30 coupled compest on 105 nodes, 64x1 (2 threads CPL/OCN/ICE), (kmod125) sypd=3.6"</comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>6080</ntasks_atm>
-          <ntasks_lnd>822</ntasks_lnd>
-          <ntasks_rof>128</ntasks_rof>
-          <ntasks_ice>5120</ntasks_ice>
-          <ntasks_ocn>640</ntasks_ocn>
-          <ntasks_glc>64</ntasks_glc>
-          <ntasks_wav>64</ntasks_wav>
-          <ntasks_cpl>5952</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>2</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>5120</rootpe_lnd>
-          <rootpe_rof>5952</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>6080</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*" pesize="any">
-        <comment>"cori-knl ne30 coupled compest on 50 nodes, 67x2, (kmod060b) sypd=2.79"</comment>
-        <MAX_MPITASKS_PER_NODE>67</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>268</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>2700</ntasks_atm>
-          <ntasks_lnd>268</ntasks_lnd>
-          <ntasks_rof>134</ntasks_rof>
-          <ntasks_ice>2560</ntasks_ice>
-          <ntasks_ocn>335</ntasks_ocn>
-          <ntasks_glc>67</ntasks_glc>
-          <ntasks_wav>67</ntasks_wav>
-          <ntasks_cpl>2881</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>2</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>2</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>2613</rootpe_lnd>
-          <rootpe_rof>2881</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>3015</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*" pesize="S">
-        <comment>"cori-knl ne30 coupled compest on 26 nodes, 67x2, (kmod031b) sypd=1.79"</comment>
-        <MAX_MPITASKS_PER_NODE>67</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>134</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>1350</ntasks_atm>
-          <ntasks_lnd>670</ntasks_lnd>
-          <ntasks_rof>64</ntasks_rof>
-          <ntasks_ice>1350</ntasks_ice>
-          <ntasks_ocn>268</ntasks_ocn>
-          <ntasks_glc>67</ntasks_glc>
-          <ntasks_wav>67</ntasks_wav>
-          <ntasks_cpl>1350</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>2</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>2</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>1407</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>1474</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*" pesize="T">
-        <comment>"cori-knl ne30 coupled compest on 17 nodes, 67x4, (kmod017) sypd=1.12"</comment>
-        <MAX_MPITASKS_PER_NODE>67</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>268</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>737</ntasks_atm>
-          <ntasks_lnd>670</ntasks_lnd>
-          <ntasks_rof>64</ntasks_rof>
-          <ntasks_ice>640</ntasks_ice>
-          <ntasks_ocn>384</ntasks_ocn>
-          <ntasks_glc>67</ntasks_glc>
-          <ntasks_wav>67</ntasks_wav>
-          <ntasks_cpl>737</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>2</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>670</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>737</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
       </pes>
     </mach>
   </grid>
@@ -763,26 +549,48 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%ne120np4_l%ne120np4_oi%oRRS15to5_r%r0.+_m%oRRS15to5_g%null_w%null">
-    <mach name="cori-haswell">
-      <pes compset="EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SGLC.+SWAV" pesize="any">
-        <comment>none</comment>
+  <grid name="a%ne120np4">
+    <mach name="pm-cpu|alvarez">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SWAV.*" pesize="any">
+        <comment>ne120-wcycl on 42 nodes 128x1c8 ~0.7 sypd</comment>
+        <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
         <ntasks>
-          <ntasks_atm>9600</ntasks_atm>
-          <ntasks_lnd>9600</ntasks_lnd>
-          <ntasks_rof>9600</ntasks_rof>
-          <ntasks_ice>9600</ntasks_ice>
-          <ntasks_ocn>9600</ntasks_ocn>
-          <ntasks_glc>9600</ntasks_glc>
+          <ntasks_atm>3072</ntasks_atm>
+          <ntasks_cpl>384</ntasks_cpl>
+          <ntasks_ice>3072</ntasks_ice>
+          <ntasks_lnd>2560</ntasks_lnd>
+          <ntasks_rof>512</ntasks_rof>
+          <ntasks_ocn>2304</ntasks_ocn>
+          <ntasks_glc>1</ntasks_glc>
           <ntasks_wav>1</ntasks_wav>
-          <ntasks_cpl>9600</ntasks_cpl>
         </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_cpl>1</nthrds_cpl>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>2560</rootpe_rof>
+          <rootpe_ocn>3072</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>0</rootpe_wav>
+        </rootpe>
+        <pstrid>
+          <pstrid_cpl>8</pstrid_cpl>
+        </pstrid>
       </pes>
     </mach>
-  </grid>
-  <grid name="a%ne120np4">
     <mach name="theta">
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*" pesize="any">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SWAV.*" pesize="any">
         <comment>ne120-wcycl on 145 nodes, MPI-only</comment>
         <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
         <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
@@ -807,7 +615,7 @@
           <rootpe_wav>0</rootpe_wav>
         </rootpe>
       </pes>
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*" pesize="MT">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SWAV.*" pesize="MT">
         <comment>ne120-wcycl on 145 nodes, threaded</comment>
         <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
         <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
@@ -842,7 +650,7 @@
           <rootpe_wav>0</rootpe_wav>
         </rootpe>
       </pes>
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*" pesize="L">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SWAV.*" pesize="L">
         <comment>ne120 coupled-compset on 466 nodes</comment>
         <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
         <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
@@ -867,7 +675,7 @@
           <rootpe_wav>0</rootpe_wav>
         </rootpe>
       </pes>
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*" pesize="XL">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SWAV.*" pesize="XL">
         <comment>ne120-wcycl on 863 nodes, MPI-only</comment>
         <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
         <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
@@ -892,7 +700,7 @@
           <rootpe_wav>0</rootpe_wav>
         </rootpe>
       </pes>
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*" pesize="XLT">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SWAV.*" pesize="XLT">
         <comment>ne120-wcycl on 863 nodes, threaded</comment>
         <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
         <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
@@ -927,7 +735,7 @@
           <rootpe_wav>0</rootpe_wav>
         </rootpe>
       </pes>
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*" pesize="XLT2">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SWAV.*" pesize="XLT2">
         <comment>ne120-wcycl on 825 nodes, threaded, 32 tasks/node</comment>
         <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
         <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
@@ -962,7 +770,7 @@
           <rootpe_wav>0</rootpe_wav>
         </rootpe>
       </pes>
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*" pesize="XLT3">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SWAV.*" pesize="XLT3">
         <comment>ne120-wcycl on 800 nodes, threaded, 32 tasks/node</comment>
         <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
         <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
@@ -993,148 +801,6 @@
           <rootpe_lnd>16800</rootpe_lnd>
           <rootpe_rof>12000</rootpe_rof>
           <rootpe_ocn>21600</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-        </rootpe>
-      </pes>
-    </mach>
-    <mach name="cori-knl">
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*" pesize="L">
-        <comment>cori-knl ne120 coupled compset on 1025 nodes, 33x8, (hmod1025vc) s=1.0</comment>
-        <MAX_MPITASKS_PER_NODE>33</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>264</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>29007</ntasks_atm>
-          <ntasks_cpl>27852</ntasks_cpl>
-          <ntasks_ice>19200</ntasks_ice>
-          <ntasks_lnd>4950</ntasks_lnd>
-          <ntasks_rof>1155</ntasks_rof>
-          <ntasks_ocn>4800</ntasks_ocn>
-          <ntasks_glc>33</ntasks_glc>
-          <ntasks_wav>33</ntasks_wav>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_cpl>4</nthrds_cpl>
-          <nthrds_ice>4</nthrds_ice>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ocn>4</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_cpl>0</rootpe_cpl>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_lnd>19800</rootpe_lnd>
-          <rootpe_rof>27852</rootpe_rof>
-          <rootpe_ocn>29007</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-        </rootpe>
-      </pes>
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*" pesize="any">
-        <comment>cori-knl ne120 coupled-compset on 448 nodes, 33x8, (hmod448b) sypd=0.69 wcosplite s=0.54</comment>
-        <MAX_MPITASKS_PER_NODE>33</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>264</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>12375</ntasks_atm>
-          <ntasks_cpl>11880</ntasks_cpl>
-          <ntasks_ice>9600</ntasks_ice>
-          <ntasks_lnd>2277</ntasks_lnd>
-          <ntasks_rof>495</ntasks_rof>
-          <ntasks_ocn>2400</ntasks_ocn>
-          <ntasks_glc>33</ntasks_glc>
-          <ntasks_wav>33</ntasks_wav>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_cpl>4</nthrds_cpl>
-          <nthrds_ice>4</nthrds_ice>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ocn>4</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_cpl>0</rootpe_cpl>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_lnd>9603</rootpe_lnd>
-          <rootpe_rof>11880</rootpe_rof>
-          <rootpe_ocn>12375</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-        </rootpe>
-      </pes>
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*" pesize="S">
-        <comment>cori-knl ne120 coupled-compset on 207 nodes, 33x8, (hmod207) sypd=0.37</comment>
-        <MAX_MPITASKS_PER_NODE>33</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>264</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>5610</ntasks_atm>
-          <ntasks_cpl>4620</ntasks_cpl>
-          <ntasks_ice>5584</ntasks_ice>
-          <ntasks_lnd>4620</ntasks_lnd>
-          <ntasks_rof>990</ntasks_rof>
-          <ntasks_ocn>1200</ntasks_ocn>
-          <ntasks_glc>33</ntasks_glc>
-          <ntasks_wav>33</ntasks_wav>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>8</nthrds_atm>
-          <nthrds_cpl>8</nthrds_cpl>
-          <nthrds_ice>4</nthrds_ice>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ocn>4</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_cpl>0</rootpe_cpl>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>4620</rootpe_rof>
-          <rootpe_ocn>5610</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-        </rootpe>
-      </pes>
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*" pesize="T">
-        <comment>cori-knl ne120 coupled-compset on 131 nodes, 33x8, (hmod131) sypd=0.25</comment>
-        <MAX_MPITASKS_PER_NODE>33</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>264</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>3333</ntasks_atm>
-          <ntasks_cpl>3333</ntasks_cpl>
-          <ntasks_ice>3200</ntasks_ice>
-          <ntasks_lnd>2871</ntasks_lnd>
-          <ntasks_rof>462</ntasks_rof>
-          <ntasks_ocn>960</ntasks_ocn>
-          <ntasks_glc>33</ntasks_glc>
-          <ntasks_wav>33</ntasks_wav>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>8</nthrds_atm>
-          <nthrds_cpl>8</nthrds_cpl>
-          <nthrds_ice>4</nthrds_ice>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>4</nthrds_rof>
-          <nthrds_ocn>4</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_cpl>0</rootpe_cpl>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>2871</rootpe_rof>
-          <rootpe_ocn>3333</rootpe_ocn>
           <rootpe_glc>0</rootpe_glc>
           <rootpe_wav>0</rootpe_wav>
         </rootpe>
@@ -1491,9 +1157,38 @@
     </mach>
   </grid>
   <grid name="a%ne30.+_oi%.*EC.*to">
-    <mach name="gcp">
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+" pesize="any">
-        <comment> -compset A_WCYCL* -res ne30pg2_oECv3 with MPASO on 11 nodes </comment>
+    <mach name="gcp12">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SWAV.+" pesize="any">
+        <comment> gcp12 -compset A_WCYCL* -res ne30pg2_oECv3 with MPASO on 7 nodes </comment>
+        <ntasks>
+          <ntasks_atm>280</ntasks_atm>
+          <ntasks_lnd>280</ntasks_lnd>
+          <ntasks_rof>280</ntasks_rof>
+          <ntasks_ice>256</ntasks_ice>
+          <ntasks_ocn>112</ntasks_ocn>
+          <ntasks_cpl>280</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>2</nthrds_atm>
+          <nthrds_lnd>2</nthrds_lnd>
+          <nthrds_rof>2</nthrds_rof>
+          <nthrds_ice>2</nthrds_ice>
+          <nthrds_ocn>2</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>280</rootpe_ocn>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
+    <mach name="gcp10">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SWAV.+" pesize="any">
+        <comment> gcp10 -compset A_WCYCL* -res ne30pg2_oECv3 with MPASO on 11 nodes </comment>
         <ntasks>
           <ntasks_atm>240</ntasks_atm>
           <ntasks_lnd>240</ntasks_lnd>
@@ -1522,22 +1217,22 @@
     </mach>
     <mach name="pm-cpu|alvarez">
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+" pesize="any">
-        <comment> -compset A_WCYCL* -res ne30pg2_oECv3 with MPASO on 7 nodes </comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
+        <comment> -compset A_WCYCL* -res ne30pg2_oECv3 with MPASO on 7 nodes, 128x1 c8 </comment>
+        <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
         <ntasks>
-          <ntasks_atm>320</ntasks_atm>
-          <ntasks_lnd>320</ntasks_lnd>
-          <ntasks_rof>320</ntasks_rof>
-          <ntasks_ice>320</ntasks_ice>
-          <ntasks_ocn>128</ntasks_ocn>
-          <ntasks_cpl>320</ntasks_cpl>
+          <ntasks_atm>640</ntasks_atm>
+          <ntasks_lnd>640</ntasks_lnd>
+          <ntasks_rof>640</ntasks_rof>
+          <ntasks_ice>640</ntasks_ice>
+          <ntasks_ocn>256</ntasks_ocn>
+          <ntasks_cpl>80</ntasks_cpl>
         </ntasks>
         <nthrds>
-          <nthrds_atm>2</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
           <nthrds_cpl>1</nthrds_cpl>
         </nthrds>
         <rootpe>
@@ -1545,16 +1240,50 @@
           <rootpe_lnd>0</rootpe_lnd>
           <rootpe_rof>0</rootpe_rof>
           <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>320</rootpe_ocn>
+          <rootpe_ocn>640</rootpe_ocn>
           <rootpe_cpl>0</rootpe_cpl>
         </rootpe>
+        <pstrid>
+          <pstrid_cpl>8</pstrid_cpl>
+        </pstrid>
+      </pes>
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+" pesize="L">
+        <comment> -compset A_WCYCL* -res ne30pg2_oECv3 with MPASO on 58 nodes, ~20 sypd</comment>
+        <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
+        <ntasks>
+          <ntasks_atm>5504</ntasks_atm>
+          <ntasks_lnd>5248</ntasks_lnd>
+          <ntasks_rof>256</ntasks_rof>
+          <ntasks_ice>5248</ntasks_ice>
+          <ntasks_ocn>1920</ntasks_ocn>
+          <ntasks_cpl>688</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>5248</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>5504</rootpe_ocn>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+        <pstrid>
+          <pstrid_cpl>8</pstrid_cpl>
+        </pstrid>
       </pes>
     </mach>
-  </grid>  
-  <grid name="a%ne30np4.pg2">
+  </grid>
+  <grid name="a%ne30np4">
     <mach name="summit|ascent">
       <pes compset="any" pesize="any">
-        <comment>summit|ascent: any compset on ne30np4.pg2 grid</comment>
+        <comment>summit|ascent: any compset on ne30np4 grid</comment>
         <ntasks>
           <ntasks_atm>-2</ntasks_atm>
           <ntasks_lnd>-2</ntasks_lnd>
@@ -1829,174 +1558,6 @@
         </rootpe>
       </pes>
     </mach>
-    <mach name="cori-knl">
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+" pesize="T">
-        <comment> -compset A_WCYCL* -res ne30pg*EC30to60* v2LR 5 nodes n005c64x4 ~0.75 sypd </comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>256</ntasks_atm>
-          <ntasks_lnd>256</ntasks_lnd>
-          <ntasks_rof>256</ntasks_rof>
-          <ntasks_ice>256</ntasks_ice>
-          <ntasks_ocn>64</ntasks_ocn>
-          <ntasks_cpl>256</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>4</nthrds_rof>
-          <nthrds_ice>4</nthrds_ice>
-          <nthrds_ocn>4</nthrds_ocn>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>256</rootpe_ocn>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+" pesize="XS">
-        <comment> -compset A_WCYCL* -res ne30pg*EC30to60* v2LR 16 nodes n016d67x4  ~2.2 sypd </comment>
-        <MAX_MPITASKS_PER_NODE>67</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>272</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>871</ntasks_atm>
-          <ntasks_lnd>512</ntasks_lnd>
-          <ntasks_rof>16</ntasks_rof>
-          <ntasks_ice>864</ntasks_ice>
-          <ntasks_ocn>192</ntasks_ocn>
-          <ntasks_cpl>512</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>4</nthrds_rof>
-          <nthrds_ice>4</nthrds_ice>
-          <nthrds_ocn>4</nthrds_ocn>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>864</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>880</rootpe_ocn>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+" pesize="S">
-        <comment> -compset A_WCYCL* -res ne30pg*EC30to60* v2LR 25 nodes n025b67x4  ~2.8 sypd </comment>
-        <MAX_MPITASKS_PER_NODE>67</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>272</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>1407</ntasks_atm>
-          <ntasks_lnd>1024</ntasks_lnd>
-          <ntasks_rof>256</ntasks_rof>
-          <ntasks_ice>1360</ntasks_ice>
-          <ntasks_ocn>256</ntasks_ocn>
-          <ntasks_cpl>1407</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>4</nthrds_rof>
-          <nthrds_ice>4</nthrds_ice>
-          <nthrds_ocn>4</nthrds_ocn>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>1072</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>1407</rootpe_ocn>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+" pesize="M">
-        <comment> -compset A_WCYCL* -res ne30pg*EC30to60* v2LR 51 nodes n051b64x2.s32c2M ~4.5 sypd </comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>272</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>2752</ntasks_atm>
-          <ntasks_lnd>2048</ntasks_lnd>
-          <ntasks_rof>192</ntasks_rof>
-          <ntasks_ice>2560</ntasks_ice>
-          <ntasks_ocn>512</ntasks_ocn>
-          <ntasks_cpl>2752</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>2</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>2560</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>2752</rootpe_ocn>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+" pesize="L">
-        <comment> -compset A_WCYCL* -res ne30pg*EC30to60* v2LR 101 nodes n101a64x1b  ~6.8 sypd </comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>272</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>5440</ntasks_atm>
-          <ntasks_lnd>192</ntasks_lnd>
-          <ntasks_rof>128</ntasks_rof>
-          <ntasks_ice>5120</ntasks_ice>
-          <ntasks_ocn>1024</ntasks_ocn>
-          <ntasks_cpl>5440</ntasks_cpl>
-        </ntasks>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>5120</rootpe_lnd>
-          <rootpe_rof>5312</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>5440</rootpe_ocn>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+" pesize="XL">
-        <comment> -compset A_WCYCL* -res ne30pg*EC30to60* v2LR 199 nodes n199a32x2  ~9.0 sypd </comment>
-        <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>272</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>5408</ntasks_atm>
-          <ntasks_lnd>4096</ntasks_lnd>
-          <ntasks_rof>256</ntasks_rof>
-          <ntasks_ice>5120</ntasks_ice>
-          <ntasks_ocn>960</ntasks_ocn>
-          <ntasks_cpl>5408</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>2</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>5120</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>5408</rootpe_ocn>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-    </mach>
   </grid>
   <grid name="a%ne30np4.pg.+_oi%WCAtl12to45E2r4">
     <mach name="chrysalis">
@@ -2081,32 +1642,32 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%ne4np4_">
-    <mach name="cori-knl">
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*" pesize="any">
-        <comment>"cori-knl ne4 coupled compest on 6 nodes, sypd=22.9"</comment>
-        <MAX_MPITASKS_PER_NODE>67</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>134</MAX_TASKS_PER_NODE>
+  <grid name="a%ne4np4.*">
+    <mach name="chrysalis">
+      <pes compset="any" pesize="any">
+        <comment>allactive+chrysalis: default, 4 nodes x 32 mpi x 2 omp @ root 0</comment>
+        <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
+        <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
         <ntasks>
-          <ntasks_atm>268</ntasks_atm>
-          <ntasks_lnd>268</ntasks_lnd>
-          <ntasks_rof>96</ntasks_rof>
-          <ntasks_ice>128</ntasks_ice>
-          <ntasks_ocn>128</ntasks_ocn>
-          <ntasks_glc>32</ntasks_glc>
-          <ntasks_wav>32</ntasks_wav>
-          <ntasks_cpl>268</ntasks_cpl>
+          <ntasks_atm>-1</ntasks_atm>
+          <ntasks_lnd>-1</ntasks_lnd>
+          <ntasks_rof>-1</ntasks_rof>
+          <ntasks_ice>-1</ntasks_ice>
+          <ntasks_ocn>-1</ntasks_ocn>
+          <ntasks_glc>-1</ntasks_glc>
+          <ntasks_wav>-1</ntasks_wav>
+          <ntasks_cpl>-1</ntasks_cpl>
         </ntasks>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>268</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
+        <nthrds>
+          <nthrds_atm>2</nthrds_atm>
+          <nthrds_lnd>2</nthrds_lnd>
+          <nthrds_rof>2</nthrds_rof>
+          <nthrds_ice>2</nthrds_ice>
+          <nthrds_ocn>2</nthrds_ocn>
+          <nthrds_glc>2</nthrds_glc>
+          <nthrds_wav>2</nthrds_wav>
+          <nthrds_cpl>2</nthrds_cpl>
+        </nthrds>
       </pes>
     </mach>
   </grid>
@@ -2134,9 +1695,27 @@
         </nthrds>
       </pes>
     </mach>
-    <mach name="pm-cpu">
+    <mach name="pm-cpu|alvarez">
       <pes compset="any" pesize="any">
-        <comment>"pm-cpu ne30np4 and ne30np4.pg2 2 nodes 2 threads"</comment>
+        <comment>"pm-cpu ne30np4 and ne30np4.pg2 2 nodes 1 thread, 128x1 c8"</comment>
+        <ntasks>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_glc>-2</ntasks_glc>
+          <ntasks_wav>-2</ntasks_wav>
+          <ntasks_cpl>32</ntasks_cpl>
+        </ntasks>
+        <pstrid>
+          <pstrid_cpl>8</pstrid_cpl>
+        </pstrid>
+      </pes>
+    </mach>
+    <mach name="crusher-scream-gpu">
+      <pes compset="any" pesize="any">
+        <comment>"crusher-gpu-scream ne30np4 and ne30np4.pg2"</comment>
         <ntasks>
           <ntasks_atm>-2</ntasks_atm>
           <ntasks_lnd>-2</ntasks_lnd>
@@ -2148,40 +1727,17 @@
           <ntasks_cpl>-2</ntasks_cpl>
         </ntasks>
         <nthrds>
-          <nthrds_atm>2</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_cpl>2</nthrds_cpl>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>8</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
         </nthrds>
       </pes>
     </mach>
-    <mach name="cori-knl">
-      <pes compset="any" pesize="any">
-        <comment>"cori-knl ne30np4* 8 nodes 2 threads"</comment>
-        <ntasks>
-          <ntasks_atm>-8</ntasks_atm>
-          <ntasks_lnd>-8</ntasks_lnd>
-          <ntasks_rof>-8</ntasks_rof>
-          <ntasks_ice>-8</ntasks_ice>
-          <ntasks_ocn>-8</ntasks_ocn>
-          <ntasks_glc>-8</ntasks_glc>
-          <ntasks_wav>-8</ntasks_wav>
-          <ntasks_cpl>-8</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>2</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_cpl>2</nthrds_cpl>
-        </nthrds>
-      </pes>
-    </mach>
-   </grid>
-   <grid name="a%ne0np4_northamericax4v1.pg2_l%.+_oi%WC14to60E2r3">
+  </grid>
+  <grid name="a%ne0np4_northamericax4v1.pg2_l%.+_oi%WC14to60E2r3">
     <mach name="compy">
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+" pesize="S">
         <comment> rmod025a </comment>
@@ -2347,95 +1903,6 @@
         </rootpe>
       </pes>
     </mach>
-    <mach name="cori-knl">
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+" pesize="S">
-        <comment> mmod039b64x2 s=1.36 </comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>1856</ntasks_atm>
-          <ntasks_lnd>960</ntasks_lnd>
-          <ntasks_rof>896</ntasks_rof>
-          <ntasks_ice>1800</ntasks_ice>
-          <ntasks_ocn>640</ntasks_ocn>
-          <ntasks_cpl>1856</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>2</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>960</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>1856</rootpe_ocn>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>      
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+" pesize="M">
-        <comment> mmod077k64x2 s=2.19 </comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>3648</ntasks_atm>
-          <ntasks_lnd>3648</ntasks_lnd>
-          <ntasks_rof>3648</ntasks_rof>
-          <ntasks_ice>3600</ntasks_ice>
-          <ntasks_ocn>1280</ntasks_ocn>
-          <ntasks_cpl>3648</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>2</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>3648</rootpe_ocn>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>      
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+" pesize="L">
-        <comment> 160 nodes 32x8 s=2.2 - 2.8 </comment>
-        <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>272</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>3680</ntasks_atm>
-          <ntasks_lnd>1024</ntasks_lnd>
-          <ntasks_rof>2656</ntasks_rof>
-          <ntasks_ice>3680</ntasks_ice>
-          <ntasks_ocn>1440</ntasks_ocn>
-          <ntasks_cpl>3680</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>8</nthrds_atm>
-          <nthrds_lnd>8</nthrds_lnd>
-          <nthrds_rof>8</nthrds_rof>
-          <nthrds_ice>8</nthrds_ice>
-          <nthrds_ocn>8</nthrds_ocn>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>1024</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>3680</rootpe_ocn>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>      
-    </mach>
     <mach name="chrysalis">
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+" pesize="T">
         <comment> cmod016b64x1 s=2.4 </comment>
@@ -2545,31 +2012,280 @@
     </mach>
     <mach name="pm-cpu|alvarez">
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+" pesize="any">
-        <comment> 8 nodes, 64x2 </comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
+        <comment> 8 nodes, 128x1 c8</comment>
         <ntasks>
-          <ntasks_atm>320</ntasks_atm>
-          <ntasks_lnd>320</ntasks_lnd>
-          <ntasks_rof>320</ntasks_rof>
-          <ntasks_ice>360</ntasks_ice>
-          <ntasks_ocn>192</ntasks_ocn>
-          <ntasks_cpl>320</ntasks_cpl>
+          <ntasks_atm>640</ntasks_atm>
+          <ntasks_lnd>640</ntasks_lnd>
+          <ntasks_rof>640</ntasks_rof>
+          <ntasks_ice>640</ntasks_ice>
+          <ntasks_ocn>384</ntasks_ocn>
+          <ntasks_cpl>80</ntasks_cpl>
         </ntasks>
         <rootpe>
           <rootpe_atm>0</rootpe_atm>
           <rootpe_lnd>0</rootpe_lnd>
           <rootpe_rof>0</rootpe_rof>
           <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>320</rootpe_ocn>
+          <rootpe_ocn>640</rootpe_ocn>
           <rootpe_cpl>0</rootpe_cpl>
         </rootpe>
         <nthrds>
-          <nthrds_atm>2</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <pstrid>
+          <pstrid_cpl>8</pstrid_cpl>
+        </pstrid>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="a%ne30np4_l%.+oi%oEC60to30.+w%wQU225EC60to30">
+    <mach name="anvil|chrysalis">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SGLC.+WW3" pesize="any">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>1350</ntasks_atm>
+          <ntasks_lnd>72</ntasks_lnd>
+          <ntasks_rof>72</ntasks_rof>
+          <ntasks_ice>1296</ntasks_ice>
+          <ntasks_cpl>1296</ntasks_cpl>
+          <ntasks_ocn>216</ntasks_ocn>
+          <ntasks_wav>612</ntasks_wav>
+        </ntasks>
+        <rootpe>
+          <rootpe_lnd>1296</rootpe_lnd>
+          <rootpe_rof>1296</rootpe_rof>
+          <rootpe_ocn>1368</rootpe_ocn>
+          <rootpe_wav>1584</rootpe_wav>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="a%ne30np4.pg2_l%.+_oi%EC30to60E2r2.+w%wQU225EC30to60E2r2">
+    <mach name="anvil">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+WW3." pesize="M">
+        <comment> --compset WCYCL* --res ne30pg2_EC30to60E2r2_wQU225EC30to60E2r2 on 48 nodes pure-MPI, ~8.8 sypd </comment>
+        <ntasks>
+          <ntasks_atm>1350</ntasks_atm>
+          <ntasks_lnd>288</ntasks_lnd>
+          <ntasks_rof>288</ntasks_rof>
+          <ntasks_ice>1080</ntasks_ice>
+          <ntasks_ocn>360</ntasks_ocn>
+          <ntasks_cpl>1080</ntasks_cpl>
+          <ntasks_wav>612</ntasks_wav>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+          <nthrds_wav>1</nthrds_wav>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>1080</rootpe_lnd>
+          <rootpe_rof>1080</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>1368</rootpe_ocn>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_wav>1728</rootpe_wav>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="a%ne30.+oi%oARRM60to10|a%ne30.+oi%ARRM10to60">
+    <mach name="onyx|warhawk|narwhal">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*" pesize="any">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>924</ntasks_atm>
+          <ntasks_lnd>164</ntasks_lnd>
+          <ntasks_rof>20</ntasks_rof>
+          <ntasks_ice>840</ntasks_ice>
+          <ntasks_ocn>2400</ntasks_ocn>
+          <ntasks_glc>1</ntasks_glc>
+          <ntasks_wav>1</ntasks_wav>
+          <ntasks_cpl>924</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>840</rootpe_lnd>
+          <rootpe_rof>904</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>924</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="a%ne0np4_arcticx4.+oi%oARRM60to10|a%ne0np4_arcticx4.+oi%ARRM10to60">
+    <mach name="onyx|warhawk|narwhal">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.*" pesize="any">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>2768</ntasks_atm>
+          <ntasks_lnd>160</ntasks_lnd>
+          <ntasks_rof>208</ntasks_rof>
+          <ntasks_ice>2400</ntasks_ice>
+          <ntasks_ocn>1200</ntasks_ocn>
+          <ntasks_glc>1</ntasks_glc>
+          <ntasks_wav>1</ntasks_wav>
+          <ntasks_cpl>2768</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>160</rootpe_rof>
+          <rootpe_ice>368</rootpe_ice>
+          <rootpe_ocn>2768</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="a%ne0np4_conus_x4v1_lowcon.pg2_l%r05_oi%oEC60to30v3_r%null_g%null_w%null_z%null_m%oEC60to30v3">
+    <mach name="ascent">
+      <pes compset="any" pesize="any">
+        <MAX_MPITASKS_PER_NODE>6</MAX_MPITASKS_PER_NODE>
+        <MAX_TASKS_PER_NODE>84</MAX_TASKS_PER_NODE>
+        <ntasks>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_glc>-2</ntasks_glc>
+          <ntasks_wav>-2</ntasks_wav>
+          <ntasks_cpl>-2</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>14</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+      </pes>
+    </mach>
+    <mach name="crusher-scream-gpu">
+      <pes compset="any" pesize="any">
+        <MAX_MPITASKS_PER_NODE>8</MAX_MPITASKS_PER_NODE>
+        <MAX_TASKS_PER_NODE>56</MAX_TASKS_PER_NODE>
+        <ntasks>
+          <ntasks_atm>-6</ntasks_atm>
+          <ntasks_lnd>-6</ntasks_lnd>
+          <ntasks_rof>-6</ntasks_rof>
+          <ntasks_ice>-6</ntasks_ice>
+          <ntasks_ocn>-6</ntasks_ocn>
+          <ntasks_glc>-6</ntasks_glc>
+          <ntasks_wav>-6</ntasks_wav>
+          <ntasks_cpl>-6</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>7</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+      </pes>
+    </mach>
+    <mach name="pm-gpu">
+      <pes compset="any" pesize="any">
+        <MAX_MPITASKS_PER_NODE>4</MAX_MPITASKS_PER_NODE>
+        <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
+        <ntasks>
+          <ntasks_atm>-4</ntasks_atm>
+          <ntasks_lnd>-4</ntasks_lnd>
+          <ntasks_rof>-4</ntasks_rof>
+          <ntasks_ice>-4</ntasks_ice>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_glc>-4</ntasks_glc>
+          <ntasks_wav>-4</ntasks_wav>
+          <ntasks_cpl>-4</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>16</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+      </pes>
+    </mach>
+    <mach name="ruby">
+      <pes compset="any" pesize="any">
+        <ntasks>
+          <ntasks_atm>-4</ntasks_atm>
+          <ntasks_lnd>-4</ntasks_lnd>
+          <ntasks_rof>-4</ntasks_rof>
+          <ntasks_ice>-4</ntasks_ice>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_glc>-4</ntasks_glc>
+          <ntasks_wav>-4</ntasks_wav>
+          <ntasks_cpl>-4</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+      </pes>
+    </mach>
+    <mach name="quartz">
+      <pes compset="any" pesize="any">
+        <ntasks>
+          <ntasks_atm>-4</ntasks_atm>
+          <ntasks_lnd>-4</ntasks_lnd>
+          <ntasks_rof>-4</ntasks_rof>
+          <ntasks_ice>-4</ntasks_ice>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_glc>-4</ntasks_glc>
+          <ntasks_wav>-4</ntasks_wav>
+          <ntasks_cpl>-4</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
           <nthrds_cpl>1</nthrds_cpl>
         </nthrds>
       </pes>

--- a/cime_config/machines/Depends.pm-cpu.nvidia.cmake
+++ b/cime_config/machines/Depends.pm-cpu.nvidia.cmake
@@ -3,8 +3,30 @@ list(APPEND REDUCE_OPT_LIST
 )
 
 # Can use this flag to avoid internal compiler error for this file (with nvidia/21.11)
+# Still needed with nvidia/22.5
 if (NOT DEBUG)
   foreach(ITEM IN LISTS REDUCE_OPT_LIST)
     e3sm_add_flags("${ITEM}" " -Mnovect")
+  endforeach()
+endif()
+
+# Use -O2 for a few files already found to benefit from increased optimization in Intel Depends file
+set(PERFOBJS
+  homme/src/share/prim_advection_base.F90
+  homme/src/share/vertremap_base.F90
+  homme/src/share/edge_mod_base.F90
+  homme/src/share/bndry_mod_base.F90
+  homme/src/theta-l/share/prim_advance_mod.F90
+  homme/src/preqx/share/prim_advance_mod.F90
+  homme/src/preqx/share/viscosity_preqx_base.F90
+  homme/src/share/viscosity_base.F90
+  homme/src/theta-l/share/viscosity_theta.F90
+  homme/src/theta-l/share/eos.F90
+  eam/src/physics/cam/uwshcu.F90)
+
+if (NOT DEBUG)
+  foreach(ITEM IN LISTS PERFOBJS)
+    e3sm_remove_flags("${ITEM}" "-O1")
+    e3sm_add_flags("${ITEM}" "-O2")
   endforeach()
 endif()

--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -314,26 +314,6 @@
       </queues>
     </batch_system>
 
-  <batch_system MACH="cori-haswell" type="nersc_slurm">
-     <directives>
-       <directive> --constraint=haswell</directive>
-     </directives>
-     <queues>
-       <queue walltimemax="00:30:00" nodemax="64" strict="true">debug</queue>
-       <queue walltimemax="01:00:00" default="true">regular</queue>
-     </queues>
-  </batch_system>
-
-  <batch_system MACH="cori-knl" type="nersc_slurm">
-    <directives>
-      <directive> --constraint=knl,quad,cache</directive>
-    </directives>
-    <queues>
-      <queue walltimemax="00:30:00" nodemax="512" strict="true">debug</queue>
-      <queue walltimemax="01:15:00" default="true">regular</queue>
-    </queues>
-  </batch_system>
-
   <batch_system MACH="pm-gpu" type="nersc_slurm">
     <directives>
       <directive> --constraint=gpu</directive>
@@ -358,8 +338,9 @@
       <directive> -G 0</directive>
     </directives>
     <queues>
-      <queue walltimemax="00:45:00" nodemax="1500" default="true">regular</queue>
-      <queue walltimemax="00:30:00" nodemax="4" strict="true">debug</queue>
+      <queue walltimemax="00:45:00" nodemax="1600" default="true">regular</queue>
+      <queue walltimemax="00:45:00" nodemax="1600" strict="true">preempt</queue>
+      <queue walltimemax="00:15:00" nodemax="4" strict="true">debug</queue>
     </queues>
   </batch_system>
 
@@ -368,8 +349,9 @@
       <directive> --constraint=cpu</directive>
     </directives>
     <queues>
-      <queue walltimemax="00:30:00" nodemax="4096" default="true">regular</queue>
-      <queue walltimemax="00:30:00" nodemax="4096" strict="true">preempt</queue>
+      <!-- Note: walltime is not the max walltime, but the default - see NERSC docs for Q limits, https://docs.nersc.gov/jobs/policy/ -->
+      <queue walltimemax="12:00:00" nodemax="4096" default="true">regular</queue>
+      <queue walltimemax="12:00:00" nodemax="4096" strict="true">preempt</queue>
       <queue walltimemax="00:30:00" nodemax="8" strict="true">debug</queue>
     </queues>
   </batch_system>
@@ -379,7 +361,7 @@
       <directive> --constraint=cpu</directive>
     </directives>
     <queues>
-      <queue walltimemax="00:45:00" nodemax="256" default="true">regular</queue>
+      <queue walltimemax="00:30:00" nodemax="256" default="true">regular</queue>
       <queue walltimemax="00:30:00" nodemax="4" strict="true">debug</queue>
     </queues>
   </batch_system>
@@ -602,11 +584,21 @@
     </queues>
    </batch_system>
 
-   <batch_system MACH="gcp" type="slurm" >
+   <batch_system MACH="gcp10" type="slurm" >
      <queues>
-       <queue walltimemax="01:30:00" default="true">compute-30</queue>
-       <queue walltimemax="01:30:00" default="true">computep</queue>	 <!--enable_placement-->
-       <queue walltimemax="01:30:00" default="true">compute</queue>
+       <queue walltimemax="01:30:00" default="true">compute-30</queue> <!--                 0.14214 -->
+       <queue walltimemax="01:30:00" default="true">computep</queue>   <!--enable_placement 0.28428 -->
+       <queue walltimemax="01:30:00" default="true">compute</queue>    <!--                 0.28428 -->
+     </queues>
+   </batch_system>
+
+   <batch_system MACH="gcp12" type="slurm" >
+     <queues>
+       <queue walltimemax="01:30:00" default="true">c2dh112</queue>   <!-- c2d-highcpu-112     1.88984 -->
+       <queue walltimemax="01:30:00" default="true">c2d32</queue>     <!-- c2d-standard-32     0.30794 -->
+       <queue walltimemax="01:30:00" default="true">c2d56</queue>     <!-- c2d-standard-56     0.53889 -->
+       <queue walltimemax="01:30:00" default="true">c2o60</queue>     <!-- "old" c2-compute-60 0.28428 -->
+       <queue walltimemax="01:30:00" default="true">compute</queue>   <!-- c2d-standard-112    1.07776 -->
      </queues>
    </batch_system>
    

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -59,7 +59,7 @@
     <DESC>Perlmutter CPU-only nodes at NERSC.  Phase2 only: Each node has 2 AMD EPYC 7713 64-Core (Milan) 512GB</DESC>
     <NODENAME_REGEX>$ENV{NERSC_HOST}:perlmutter</NODENAME_REGEX>
     <OS>Linux</OS>
-    <COMPILERS>gnu,intel,nvidia,amdclang</COMPILERS>
+    <COMPILERS>intel,gnu,nvidia,amdclang</COMPILERS>
     <MPILIBS>mpich</MPILIBS>
     <PROJECT>e3sm</PROJECT>
     <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
@@ -71,7 +71,7 @@
     <DIN_LOC_ROOT_CLMFORC>/global/cfs/cdirs/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>/global/cfs/cdirs/e3sm/baselines/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/global/cfs/cdirs/e3sm/tools/cprnc.cori/cprnc</CCSM_CPRNC>
+    <CCSM_CPRNC>/global/cfs/cdirs/e3sm/tools/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>10</GMAKE_J>
     <TESTS>e3sm_developer</TESTS>
     <NTEST_PARALLEL_JOBS>4</NTEST_PARALLEL_JOBS>
@@ -144,8 +144,8 @@
 
       <modules>
         <command name="load">craype-accel-host</command>
-        <command name="load">craype/2.7.19</command>
-        <command name="load">cray-mpich/8.1.24</command>
+        <command name="load">craype/2.7.20</command>
+        <command name="load">cray-mpich/8.1.25</command>
         <command name="load">cray-hdf5-parallel/1.12.2.3</command>
         <command name="load">cray-netcdf-hdf5parallel/4.9.0.3</command>
         <command name="load">cray-parallel-netcdf/1.12.3.3</command>
@@ -190,7 +190,7 @@
     <DIN_LOC_ROOT_CLMFORC>/global/cfs/cdirs/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>/global/cfs/cdirs/e3sm/baselines/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/global/cfs/cdirs/e3sm/tools/cprnc.cori/cprnc</CCSM_CPRNC>
+    <CCSM_CPRNC>/global/cfs/cdirs/e3sm/tools/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>10</GMAKE_J>
     <TESTS>e3sm_developer</TESTS>
     <NTEST_PARALLEL_JOBS>4</NTEST_PARALLEL_JOBS>
@@ -269,8 +269,8 @@
 
       <modules>
         <command name="load">cray-libsci/23.02.1.1</command>
-        <command name="load">craype/2.7.19</command>
-        <command name="load">cray-mpich/8.1.24</command>
+        <command name="load">craype/2.7.20</command>
+        <command name="load">cray-mpich/8.1.25</command>
         <command name="load">cray-hdf5-parallel/1.12.2.3</command>
         <command name="load">cray-netcdf-hdf5parallel/4.9.0.3</command>
         <command name="load">cray-parallel-netcdf/1.12.3.3</command>
@@ -319,7 +319,7 @@
     <DIN_LOC_ROOT_CLMFORC>/global/cfs/cdirs/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>/global/cfs/cdirs/e3sm/baselines/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/global/cfs/cdirs/e3sm/tools/cprnc.cori/cprnc</CCSM_CPRNC>
+    <CCSM_CPRNC>/global/cfs/cdirs/e3sm/tools/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>10</GMAKE_J>
     <TESTS>e3sm_developer</TESTS>
     <NTEST_PARALLEL_JOBS>4</NTEST_PARALLEL_JOBS>
@@ -490,310 +490,6 @@
     </environment_variables>
   </machine>
 
-  <machine MACH="cori-haswell">
-    <DESC>Cori. XC40 Cray system at NERSC. Haswell partition. os is CNL, 32 pes/node, batch system is SLURM</DESC>
-    <NODENAME_REGEX>cori-knl-is-default</NODENAME_REGEX>
-    <OS>CNL</OS>
-    <COMPILERS>intel,gnu</COMPILERS>
-    <MPILIBS>mpt</MPILIBS>
-    <PROJECT>e3sm</PROJECT>
-    <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
-    <SAVE_TIMING_DIR_PROJECTS>e3sm,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
-    <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/e3sm_scratch/cori-haswell</CIME_OUTPUT_ROOT>
-    <CIME_HTML_ROOT>/global/cfs/cdirs/e3sm/www/$ENV{USER}</CIME_HTML_ROOT>
-    <CIME_URL_ROOT>http://portal.nersc.gov/project/e3sm/$ENV{USER}</CIME_URL_ROOT>
-    <DIN_LOC_ROOT>/global/cfs/cdirs/e3sm/inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/global/cfs/cdirs/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
-    <BASELINE_ROOT>/global/cfs/cdirs/e3sm/baselines/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/global/cfs/cdirs/e3sm/tools/cprnc.cori/cprnc</CCSM_CPRNC>
-    <GMAKE_J>8</GMAKE_J>
-    <TESTS>e3sm_developer</TESTS>
-    <NTEST_PARALLEL_JOBS>4</NTEST_PARALLEL_JOBS>
-    <BATCH_SYSTEM>nersc_slurm</BATCH_SYSTEM>
-    <SUPPORTED_BY>e3sm</SUPPORTED_BY>
-    <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
-    <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
-    <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
-    <mpirun mpilib="default">
-      <executable>srun</executable>
-      <arguments>
-        <arg name="label"> --label</arg>
-        <arg name="num_tasks"> -n {{ total_tasks }} -N {{ num_nodes }}</arg>
-        <arg name="thread_count">-c $SHELL{echo 64/`./xmlquery --value MAX_MPITASKS_PER_NODE`|bc}</arg>
-        <arg name="binding"> $SHELL{if [ 32 -ge `./xmlquery --value MAX_MPITASKS_PER_NODE` ]; then echo "--cpu_bind=cores"; else echo "--cpu_bind=threads";fi;} </arg>
-        <arg name="placement"> -m plane=$SHELL{echo `./xmlquery --value MAX_MPITASKS_PER_NODE`}</arg>
-    </arguments>
-    </mpirun>
-    <module_system type="module">
-      <init_path lang="perl">/opt/modules/default/init/perl</init_path>
-      <init_path lang="python">/opt/modules/default/init/python</init_path>
-      <init_path lang="sh">/opt/modules/default/init/sh</init_path>
-      <init_path lang="csh">/opt/modules/default/init/csh</init_path>
-      <cmd_path lang="perl">/opt/modules/default/bin/modulecmd perl</cmd_path>
-      <cmd_path lang="python">/opt/modules/default/bin/modulecmd python</cmd_path>
-      <cmd_path lang="sh">module</cmd_path>
-      <cmd_path lang="csh">module</cmd_path>
-
-      <modules>
-        <command name="rm">PrgEnv-intel</command>
-        <command name="rm">PrgEnv-cray</command>
-        <command name="rm">PrgEnv-gnu</command>
-        <command name="rm">intel</command>
-        <command name="rm">cce</command>
-        <command name="rm">gcc</command>
-        <command name="rm">cray-parallel-netcdf</command>
-        <command name="rm">cray-hdf5-parallel</command>
-        <command name="rm">pmi</command>
-        <command name="rm">cray-libsci</command>
-        <command name="rm">cray-mpich2</command>
-        <command name="rm">cray-mpich</command>
-        <command name="rm">cray-netcdf</command>
-        <command name="rm">cray-hdf5</command>
-        <command name="rm">cray-netcdf-hdf5parallel</command>
-        <command name="rm">craype-sandybridge</command>
-        <command name="rm">craype-ivybridge</command>
-        <command name="rm">craype</command>
-        <command name="rm">papi</command>
-        <command name="rm">cmake</command>
-        <command name="rm">cray-petsc</command>
-        <command name="rm">esmf</command>
-        <command name="rm">zlib</command>
-        <command name="rm">craype-hugepages2M</command>
-        <command name="rm">darshan</command>
-        
-        <!-- first load basic defaults, then remove/swap/load as necessary -->
-        <command name="load">craype</command>
-        <command name="load">PrgEnv-intel</command>
-        <command name="load">cray-mpich</command>
-        <command name="rm">craype-mic-knl</command>
-        <command name="load">craype-haswell</command>
-      </modules>
-
-      <modules mpilib="mpt">
-        <command name="swap">cray-mpich cray-mpich/7.7.10</command>
-      </modules>
-
-      <modules compiler="intel">
-        <command name="load">PrgEnv-intel/6.0.10</command>
-        <command name="rm">intel</command>
-        <command name="load">intel/19.0.3.199</command>
-      </modules>
-
-      <modules compiler="gnu">
-        <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.10</command>
-        <command name="rm">gcc</command>
-        <command name="load">gcc/10.3.0</command>
-        <command name="rm">cray-libsci</command>
-        <command name="load">cray-libsci/20.09.1</command>
-      </modules>
-
-      <modules>
-        <command name="swap">craype craype/2.6.2</command>
-        <command name="rm">pmi</command>
-        <command name="load">pmi/5.0.14</command>
-        <command name="rm">craype-mic-knl</command>
-        <command name="load">craype-haswell</command>
-      </modules>
-
-      <modules mpilib="mpi-serial">
-        <command name="rm">cray-netcdf-hdf5parallel</command>
-        <command name="rm">cray-hdf5-parallel</command>
-        <command name="rm">cray-parallel-netcdf</command>
-        <command name="load">cray-netcdf/4.6.3.2</command>
-        <command name="load">cray-hdf5/1.10.5.2</command>
-      </modules>
-      <modules mpilib="!mpi-serial">
-        <command name="rm">cray-netcdf-hdf5parallel</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
-        <command name="load">cray-hdf5-parallel/1.10.5.2</command>
-        <command name="load">cray-parallel-netcdf/1.11.1.1</command>
-      </modules>
-
-      <modules>
-        <command name="rm">cmake</command>
-        <command name="load">cmake</command>
-        <command name="load">perl5-extras</command>
-      </modules>
-    </module_system>
-
-    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
-    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
-    <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
-    <environment_variables>
-
-      <env name="MPICH_ENV_DISPLAY">1</env>
-      <env name="MPICH_VERSION_DISPLAY">1</env>
-      <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
-
-      <env name="OMP_STACKSIZE">128M</env>
-      <env name="OMP_PROC_BIND">spread</env>
-      <env name="OMP_PLACES">threads</env>
-      <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
-      <env name="CRAYPE_LINK_TYPE">static</env>
-    </environment_variables>
-    <environment_variables compiler="intel">
-      <env name="FORT_BUFFERED">yes</env>
-    </environment_variables>
-  </machine>
-
-  <!-- KNL nodes of Cori -->
-  <machine MACH="cori-knl">
-    <DESC>Cori. XC40 Cray system at NERSC. KNL partition. os is CNL, 68 pes/node (for now only use 64), batch system is SLURM</DESC>
-    <NODENAME_REGEX>cori</NODENAME_REGEX>
-    <OS>CNL</OS>
-    <COMPILERS>intel,gnu</COMPILERS>
-    <MPILIBS>mpt,impi</MPILIBS>
-    <PROJECT>e3sm</PROJECT>
-    <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
-    <SAVE_TIMING_DIR_PROJECTS>e3sm,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
-    <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/e3sm_scratch/cori-knl</CIME_OUTPUT_ROOT>
-    <CIME_HTML_ROOT>/global/cfs/cdirs/e3sm/www/$ENV{USER}</CIME_HTML_ROOT>
-    <CIME_URL_ROOT>http://portal.nersc.gov/project/e3sm/$ENV{USER}</CIME_URL_ROOT>
-    <DIN_LOC_ROOT>/global/cfs/cdirs/e3sm/inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/global/cfs/cdirs/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
-    <BASELINE_ROOT>/global/cfs/cdirs/e3sm/baselines/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/global/cfs/cdirs/e3sm/tools/cprnc.cori/cprnc</CCSM_CPRNC>
-    <GMAKE_J>8</GMAKE_J>
-    <TESTS>e3sm_developer</TESTS>
-    <NTEST_PARALLEL_JOBS>4</NTEST_PARALLEL_JOBS>
-    <BATCH_SYSTEM>nersc_slurm</BATCH_SYSTEM>
-    <SUPPORTED_BY>e3sm</SUPPORTED_BY>
-    <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
-    <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-    <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
-    <mpirun mpilib="default">
-      <executable>srun</executable>
-      <arguments>
-        <arg name="label"> --label</arg>
-        <arg name="num_tasks"> -n {{ total_tasks }} -N {{ num_nodes }}</arg>
-        <arg name="thread_count">-c $SHELL{mpn=`./xmlquery --value MAX_MPITASKS_PER_NODE`; if [ 68 -ge $mpn ]; then c0=`expr 272 / $mpn`; c1=`expr $c0 / 4`; cflag=`expr $c1 \* 4`; echo $cflag|bc ; else echo 272/$mpn|bc;fi;} </arg>
-        <arg name="binding"> $SHELL{if [ 68 -ge `./xmlquery --value MAX_MPITASKS_PER_NODE` ]; then echo "--cpu_bind=cores"; else echo "--cpu_bind=threads";fi;} </arg>
-        <arg name="placement"> -m plane=$SHELL{echo `./xmlquery --value MAX_MPITASKS_PER_NODE`}</arg>
-    </arguments>
-    </mpirun>
-    <module_system type="module">
-      <init_path lang="perl">/opt/modules/default/init/perl</init_path>
-      <init_path lang="python">/opt/modules/default/init/python</init_path>
-      <init_path lang="sh">/opt/modules/default/init/sh</init_path>
-      <init_path lang="csh">/opt/modules/default/init/csh</init_path>
-      <cmd_path lang="perl">/opt/modules/default/bin/modulecmd perl</cmd_path>
-      <cmd_path lang="python">/opt/modules/default/bin/modulecmd python</cmd_path>
-      <cmd_path lang="sh">module</cmd_path>
-      <cmd_path lang="csh">module</cmd_path>
-      <modules>
-        <command name="rm">craype</command>
-        <command name="rm">craype-mic-knl</command>
-        <command name="rm">craype-haswell</command>
-        <command name="rm">PrgEnv-intel</command>
-        <command name="rm">PrgEnv-cray</command>
-        <command name="rm">PrgEnv-gnu</command>
-        <command name="rm">intel</command>
-        <command name="rm">cce</command>
-        <command name="rm">gcc</command>
-        <command name="rm">cray-parallel-netcdf</command>
-        <command name="rm">cray-hdf5-parallel</command>
-        <command name="rm">pmi</command>
-        <command name="rm">cray-mpich2</command>
-        <command name="rm">cray-mpich</command>
-        <command name="rm">cray-netcdf</command>
-        <command name="rm">cray-hdf5</command>
-        <command name="rm">cray-netcdf-hdf5parallel</command>
-        <command name="rm">cray-libsci</command>
-        <command name="rm">papi</command>
-        <command name="rm">cmake</command>
-        <command name="rm">cray-petsc</command>
-        <command name="rm">esmf</command>
-        <command name="rm">zlib</command>
-        <command name="rm">craype-hugepages2M</command>
-        <command name="rm">darshan</command>
-        
-        <!-- first load basic defaults, then remove/swap/load as necessary -->
-        <command name="load">craype</command>
-        <command name="load">PrgEnv-intel</command>
-        <command name="load">cray-mpich</command>
-        <command name="rm">craype-haswell</command>
-        <command name="load">craype-mic-knl</command>
-      </modules>
-
-      <modules mpilib="mpt">
-        <command name="swap">cray-mpich cray-mpich/7.7.10</command>
-      </modules>
-
-      <modules mpilib="impi">
-        <command name="swap">cray-mpich impi/2020.up4</command>
-      </modules>
-
-      <modules compiler="intel">
-        <command name="load">PrgEnv-intel/6.0.10</command>
-        <command name="rm">intel</command>
-        <command name="load">intel/19.0.3.199</command>
-      </modules>
-
-      <modules compiler="gnu">
-        <command name="swap">PrgEnv-intel PrgEnv-gnu/6.0.10</command>
-        <command name="rm">gcc</command>
-        <command name="load">gcc/10.3.0</command>
-        <command name="rm">cray-libsci</command>
-        <command name="load">cray-libsci/20.09.1</command>
-      </modules>
-
-      <modules>
-        <command name="swap">craype craype/2.6.2</command>
-        <command name="rm">pmi</command>
-        <command name="load">pmi/5.0.14</command>
-        <command name="rm">craype-haswell</command>
-        <command name="load">craype-mic-knl</command>
-      </modules>
-
-      <modules mpilib="mpi-serial">
-        <command name="rm">cray-netcdf-hdf5parallel</command>
-        <command name="rm">cray-hdf5-parallel</command>
-        <command name="rm">cray-parallel-netcdf</command>
-        <command name="load">cray-netcdf/4.6.3.2</command>
-        <command name="load">cray-hdf5/1.10.5.2</command>
-      </modules>
-      <modules mpilib="!mpi-serial">
-        <command name="rm">cray-netcdf-hdf5parallel</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
-        <command name="load">cray-hdf5-parallel/1.10.5.2</command>
-        <command name="load">cray-parallel-netcdf/1.11.1.1</command>
-      </modules>
-
-      <modules>
-        <command name="rm">cmake</command>
-        <command name="load">cmake</command>
-        <command name="load">perl5-extras</command>
-      </modules>
-
-      <!--command name="list">&gt;&amp; ml.txt</command-->
-
-    </module_system>
-
-    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
-    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
-    <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
-    <environment_variables>
-      <env name="MPICH_ENV_DISPLAY">1</env>
-      <env name="MPICH_VERSION_DISPLAY">1</env>
-      <!--env name="MPICH_CPUMASK_DISPLAY">1</env-->
-
-      <env name="OMP_STACKSIZE">128M</env>
-      <env name="OMP_PROC_BIND">spread</env>
-      <env name="OMP_PLACES">threads</env>
-      <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
-      <env name="CRAYPE_LINK_TYPE">static</env>
-    </environment_variables>
-
-    <environment_variables mpilib="mpt">
-      <env name="MPICH_GNI_DYNAMIC_CONN">disabled</env>
-    </environment_variables>
-    <environment_variables compiler="intel">
-      <env name="MPICH_MEMORY_REPORT">1</env>
-    </environment_variables>
-  </machine>
-
   <!-- Skylake nodes of Stampede2 at TACC -->
   <machine MACH="stampede2">
     <DESC>Stampede2. Intel skylake nodes at TACC. 48 cores per node, batch system is SLURM</DESC>
@@ -808,7 +504,7 @@
     <DIN_LOC_ROOT_CLMFORC>$ENV{SCRATCH}/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>$ENV{SCRATCH}/baselines/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>$ENV{SCRATCH}/tools/cprnc.cori/cprnc</CCSM_CPRNC>
+    <CCSM_CPRNC>$ENV{SCRATCH}/tools/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>8</GMAKE_J>
     <TESTS>e3sm_developer</TESTS>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>

--- a/components/eam/cime_config/config_pes.xml
+++ b/components/eam/cime_config/config_pes.xml
@@ -97,31 +97,6 @@
         </nthrds>
       </pes>
     </mach>
-    <mach name="cori-haswell">
-      <pes compset="any" pesize="T">
-        <comment>none</comment>
-        <ntasks>
-          <ntasks_atm>240</ntasks_atm>
-          <ntasks_lnd>240</ntasks_lnd>
-          <ntasks_rof>240</ntasks_rof>
-          <ntasks_ice>240</ntasks_ice>
-          <ntasks_ocn>240</ntasks_ocn>
-          <ntasks_glc>240</ntasks_glc>
-          <ntasks_wav>240</ntasks_wav>
-          <ntasks_cpl>240</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>4</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>4</nthrds_glc>
-          <nthrds_wav>4</nthrds_wav>
-          <nthrds_cpl>4</nthrds_cpl>
-        </nthrds>
-      </pes>
-    </mach>
     <!-- machine-specific generic defaults -->
     <mach name="anvil|compy">
       <pes compset="any" pesize="any">
@@ -165,7 +140,7 @@
         </nthrds>
       </pes>
     </mach>
-    <mach name="theta|pm-gpu|cori-knl|cori-haswell|jlse">
+    <mach name="theta|pm-cpu|alvarez|pm-gpu|jlse">
       <pes compset="any" pesize="any">
         <comment>eam: default, 1 node x MAX_MPITASKS_PER_NODE mpi x 1 omp @ root 0</comment>
         <ntasks>
@@ -180,9 +155,9 @@
         </ntasks>
       </pes>
     </mach>
-    <mach name="pm-cpu|alvarez">
+    <mach name="gcp12">
       <pes compset="any" pesize="any">
-        <comment>allactive: default, 1 node x MAX_MPITASKS_PER_NODE mpi x 2 omp @ root 0</comment>
+        <comment>eam+gcp: default 1 node</comment>
         <ntasks>
           <ntasks_atm>-1</ntasks_atm>
           <ntasks_lnd>-1</ntasks_lnd>
@@ -193,17 +168,9 @@
           <ntasks_wav>-1</ntasks_wav>
           <ntasks_cpl>-1</ntasks_cpl>
         </ntasks>
-        <nthrds>
-          <nthrds_atm>2</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_cpl>2</nthrds_cpl>
-        </nthrds>
       </pes>
     </mach>
-    <mach name="gcp">
+    <mach name="gcp10">
       <pes compset="any" pesize="any">
         <comment>eam+gcp: default</comment>
         <ntasks>
@@ -249,91 +216,6 @@
       </pes>
     </mach>
     <!-- end machine-specific generic defaults -->
-  </grid>
-  <!-- ne4 PEs -->
-  <grid name="a%ne4np4_">
-    <mach name="cori-haswell">
-      <pes compset="any" pesize="any">
-        <comment>3 nodes, any compset on ne4 grid</comment>
-        <ntasks>
-          <ntasks_atm>96</ntasks_atm>
-          <ntasks_lnd>96</ntasks_lnd>
-          <ntasks_rof>96</ntasks_rof>
-          <ntasks_ice>96</ntasks_ice>
-          <ntasks_ocn>96</ntasks_ocn>
-          <ntasks_glc>96</ntasks_glc>
-          <ntasks_wav>96</ntasks_wav>
-          <ntasks_cpl>96</ntasks_cpl>
-        </ntasks>
-      </pes>
-    </mach>
-    <mach name="cori-knl">
-      <pes compset="any" pesize="any">
-        <comment>cori-knl, 3 nodes, 32x4 any compset on ne4 grid, sypd=32</comment>
-        <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>96</ntasks_atm>
-          <ntasks_lnd>96</ntasks_lnd>
-          <ntasks_rof>96</ntasks_rof>
-          <ntasks_ice>96</ntasks_ice>
-          <ntasks_ocn>96</ntasks_ocn>
-          <ntasks_glc>96</ntasks_glc>
-          <ntasks_wav>96</ntasks_wav>
-          <ntasks_cpl>96</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>4</nthrds_rof>
-          <nthrds_ice>4</nthrds_ice>
-          <nthrds_ocn>4</nthrds_ocn>
-          <nthrds_glc>4</nthrds_glc>
-          <nthrds_wav>4</nthrds_wav>
-          <nthrds_cpl>4</nthrds_cpl>
-        </nthrds>
-      </pes>
-      <pes compset="any" pesize="S">
-        <comment>cori-knl, 1 node, 32x4 any compset on ne4 grid, sypd=18</comment>
-        <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>32</ntasks_atm>
-          <ntasks_lnd>32</ntasks_lnd>
-          <ntasks_rof>32</ntasks_rof>
-          <ntasks_ice>32</ntasks_ice>
-          <ntasks_ocn>32</ntasks_ocn>
-          <ntasks_glc>32</ntasks_glc>
-          <ntasks_wav>32</ntasks_wav>
-          <ntasks_cpl>32</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>4</nthrds_rof>
-          <nthrds_ice>4</nthrds_ice>
-          <nthrds_ocn>4</nthrds_ocn>
-          <nthrds_glc>4</nthrds_glc>
-          <nthrds_wav>4</nthrds_wav>
-          <nthrds_cpl>4</nthrds_cpl>
-        </nthrds>
-      </pes>
-      <pes compset="any" pesize="L">
-        <comment>cori-knl, 13 nodes, 67x1 any compset on ne4 grid, one MPI per column. sypd=52</comment>
-        <MAX_MPITASKS_PER_NODE>67</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>67</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>866</ntasks_atm>
-          <ntasks_lnd>128</ntasks_lnd>
-          <ntasks_rof>128</ntasks_rof>
-          <ntasks_ice>256</ntasks_ice>
-          <ntasks_ocn>256</ntasks_ocn>
-          <ntasks_glc>32</ntasks_glc>
-          <ntasks_wav>32</ntasks_wav>
-          <ntasks_cpl>866</ntasks_cpl>
-        </ntasks>
-      </pes>
-    </mach>
   </grid>
   <grid name="a%ne4np4.pg2">
     <mach name="any">
@@ -393,6 +275,21 @@
           <ntasks_cpl>-1</ntasks_cpl>
           <ntasks_glc>-1</ntasks_glc>
           <ntasks_wav>-1</ntasks_wav>
+        </ntasks>
+      </pes>
+    </mach>
+    <mach name="gcp12">
+      <pes compset="any" pesize="any">
+        <comment>gcp12: any compset on ne4np4.pg2 grid, 56x1 except 36 for ice/ocn</comment>
+        <ntasks>
+          <ntasks_atm>56</ntasks_atm>
+          <ntasks_lnd>56</ntasks_lnd>
+          <ntasks_rof>56</ntasks_rof>
+          <ntasks_ice>36</ntasks_ice>
+          <ntasks_ocn>36</ntasks_ocn>
+          <ntasks_cpl>56</ntasks_cpl>
+          <ntasks_glc>56</ntasks_glc>
+          <ntasks_wav>56</ntasks_wav>
         </ntasks>
       </pes>
     </mach>
@@ -594,36 +491,6 @@
       </pes>
     </mach>
   </grid>
-  <!-- ne11 PEs -->
-  <grid name="a%ne11np4_">
-    <mach name="cori-knl">
-      <pes compset="any" pesize="any">
-        <comment>6 nodes, 64x2, sypd=11.1 (for F-compset)</comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>363</ntasks_atm>
-          <ntasks_lnd>363</ntasks_lnd>
-          <ntasks_rof>363</ntasks_rof>
-          <ntasks_ice>128</ntasks_ice>
-          <ntasks_ocn>128</ntasks_ocn>
-          <ntasks_glc>64</ntasks_glc>
-          <ntasks_wav>64</ntasks_wav>
-          <ntasks_cpl>363</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>2</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>2</nthrds_cpl>
-        </nthrds>
-      </pes>
-    </mach>
-  </grid>
   <grid name="a%ne16np4_|a%360x720cru">
     <mach name="any">
       <pes compset="any" pesize="any">
@@ -653,48 +520,6 @@
           <ntasks_wav>48</ntasks_wav>
           <ntasks_cpl>48</ntasks_cpl>
         </ntasks>
-      </pes>
-    </mach>
-    <mach name="cori-haswell">
-      <pes compset="any" pesize="any">
-        <comment>none</comment>
-        <ntasks>
-          <ntasks_atm>96</ntasks_atm>
-          <ntasks_lnd>96</ntasks_lnd>
-          <ntasks_rof>96</ntasks_rof>
-          <ntasks_ice>96</ntasks_ice>
-          <ntasks_ocn>96</ntasks_ocn>
-          <ntasks_glc>96</ntasks_glc>
-          <ntasks_wav>96</ntasks_wav>
-          <ntasks_cpl>96</ntasks_cpl>
-        </ntasks>
-      </pes>
-    </mach>
-    <mach name="cori-knl">
-      <pes compset="any" pesize="any">
-        <comment>cori-knl, 6 nodes, 64x4, sypd=2.93 (for F-compset)</comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>384</ntasks_atm>
-          <ntasks_lnd>384</ntasks_lnd>
-          <ntasks_rof>384</ntasks_rof>
-          <ntasks_ice>256</ntasks_ice>
-          <ntasks_ocn>256</ntasks_ocn>
-          <ntasks_glc>64</ntasks_glc>
-          <ntasks_wav>64</ntasks_wav>
-          <ntasks_cpl>384</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>4</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>4</nthrds_cpl>
-        </nthrds>
       </pes>
     </mach>
   </grid>
@@ -756,229 +581,6 @@
           <ntasks_wav>5400</ntasks_wav>
           <ntasks_cpl>5400</ntasks_cpl>
         </ntasks>
-      </pes>
-    </mach>
-    <mach name="cori-haswell">
-      <pes compset="any" pesize="L">
-        <comment>169 nodes, 19 sypd</comment>
-        <ntasks>
-          <ntasks_atm>5400</ntasks_atm>
-          <ntasks_lnd>5400</ntasks_lnd>
-          <ntasks_rof>5400</ntasks_rof>
-          <ntasks_ice>5400</ntasks_ice>
-          <ntasks_ocn>5400</ntasks_ocn>
-          <ntasks_glc>5400</ntasks_glc>
-          <ntasks_wav>5400</ntasks_wav>
-          <ntasks_cpl>5400</ntasks_cpl>
-        </ntasks>
-      </pes>
-      <pes compset="any" pesize="any">
-        <comment>85 nodes</comment>
-        <ntasks>
-          <ntasks_atm>2700</ntasks_atm>
-          <ntasks_lnd>2700</ntasks_lnd>
-          <ntasks_rof>2700</ntasks_rof>
-          <ntasks_ice>2700</ntasks_ice>
-          <ntasks_ocn>2700</ntasks_ocn>
-          <ntasks_glc>2700</ntasks_glc>
-          <ntasks_wav>2700</ntasks_wav>
-          <ntasks_cpl>2700</ntasks_cpl>
-        </ntasks>
-      </pes>
-      <pes compset="any" pesize="S">
-        <comment>9 nodes</comment>
-        <ntasks>
-          <ntasks_atm>270</ntasks_atm>
-          <ntasks_lnd>270</ntasks_lnd>
-          <ntasks_rof>270</ntasks_rof>
-          <ntasks_ice>270</ntasks_ice>
-          <ntasks_ocn>270</ntasks_ocn>
-          <ntasks_glc>270</ntasks_glc>
-          <ntasks_wav>270</ntasks_wav>
-          <ntasks_cpl>270</ntasks_cpl>
-        </ntasks>
-      </pes>
-    </mach>
-    <mach name="cori-knl">
-      <pes compset="any" pesize="L">
-        <comment>cori-knl, generic ne30, 85 nodes, 64x1</comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>5440</ntasks_atm>
-          <ntasks_lnd>5440</ntasks_lnd>
-          <ntasks_rof>5440</ntasks_rof>
-          <ntasks_ice>4800</ntasks_ice>
-          <ntasks_ocn>4800</ntasks_ocn>
-          <ntasks_glc>64</ntasks_glc>
-          <ntasks_wav>64</ntasks_wav>
-          <ntasks_cpl>5440</ntasks_cpl>
-        </ntasks>
-      </pes>
-      <pes compset="any" pesize="any">
-        <comment>cori-knl, generic ne30, 43 nodes, 32x4</comment>
-        <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>1350</ntasks_atm>
-          <ntasks_lnd>1350</ntasks_lnd>
-          <ntasks_rof>1350</ntasks_rof>
-          <ntasks_ice>1200</ntasks_ice>
-          <ntasks_ocn>1200</ntasks_ocn>
-          <ntasks_glc>32</ntasks_glc>
-          <ntasks_wav>32</ntasks_wav>
-          <ntasks_cpl>1350</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>4</nthrds_cpl>
-        </nthrds>
-      </pes>
-      <pes compset="any" pesize="S">
-        <comment>cori-knl, generic ne30, 22 nodes, 32x4</comment>
-        <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>704</ntasks_atm>
-          <ntasks_lnd>704</ntasks_lnd>
-          <ntasks_rof>704</ntasks_rof>
-          <ntasks_ice>480</ntasks_ice>
-          <ntasks_ocn>480</ntasks_ocn>
-          <ntasks_glc>32</ntasks_glc>
-          <ntasks_wav>32</ntasks_wav>
-          <ntasks_cpl>704</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>4</nthrds_cpl>
-        </nthrds>
-      </pes>
-      <pes compset="any" pesize="T">
-        <comment>cori-knl, generic ne30, 4 nodes, 34x8</comment>
-        <MAX_MPITASKS_PER_NODE>34</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>268</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>136</ntasks_atm>
-          <ntasks_lnd>136</ntasks_lnd>
-          <ntasks_rof>136</ntasks_rof>
-          <ntasks_ice>128</ntasks_ice>
-          <ntasks_ocn>128</ntasks_ocn>
-          <ntasks_glc>33</ntasks_glc>
-          <ntasks_wav>33</ntasks_wav>
-          <ntasks_cpl>136</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>8</nthrds_atm>
-          <nthrds_lnd>8</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>8</nthrds_cpl>
-        </nthrds>
-      </pes>
-      <pes compset=".*EAM.+ELM.+CICE.+DOCN.+SROF.+SGLC.+SWAV.*" pesize="L">
-        <comment>cori-knl ne30 F-compset on 81 nodes, 67x1, sypd=6.1</comment>
-        <MAX_MPITASKS_PER_NODE>67</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>134</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>5427</ntasks_atm>
-          <ntasks_lnd>5427</ntasks_lnd>
-          <ntasks_rof>5427</ntasks_rof>
-          <ntasks_ice>5427</ntasks_ice>
-          <ntasks_ocn>5427</ntasks_ocn>
-          <ntasks_glc>33</ntasks_glc>
-          <ntasks_wav>33</ntasks_wav>
-          <ntasks_cpl>5427</ntasks_cpl>
-        </ntasks>
-      </pes>
-      <pes compset=".*EAM.+ELM.+CICE.+DOCN.+SROF.+SGLC.+SWAV.*" pesize="any">
-        <comment>cori-knl ne30 F-compset on 41 nodes, 33x4, sypd=4.4</comment>
-        <MAX_MPITASKS_PER_NODE>33</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>132</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>1350</ntasks_atm>
-          <ntasks_lnd>1350</ntasks_lnd>
-          <ntasks_rof>1350</ntasks_rof>
-          <ntasks_ice>1200</ntasks_ice>
-          <ntasks_ocn>1200</ntasks_ocn>
-          <ntasks_glc>33</ntasks_glc>
-          <ntasks_wav>33</ntasks_wav>
-          <ntasks_cpl>1350</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>4</nthrds_cpl>
-        </nthrds>
-      </pes>
-      <pes compset=".*EAM.+ELM.+CICE.+DOCN.+SROF.+SGLC.+SWAV.*" pesize="S">
-        <comment>cori-knl ne30 F-compset on 21 nodes, 33x4, sypd=2.35</comment>
-        <MAX_MPITASKS_PER_NODE>33</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>132</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>693</ntasks_atm>
-          <ntasks_lnd>693</ntasks_lnd>
-          <ntasks_rof>693</ntasks_rof>
-          <ntasks_ice>693</ntasks_ice>
-          <ntasks_ocn>693</ntasks_ocn>
-          <ntasks_glc>33</ntasks_glc>
-          <ntasks_wav>33</ntasks_wav>
-          <ntasks_cpl>693</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>4</nthrds_cpl>
-        </nthrds>
-      </pes>
-      <pes compset=".*EAM.+ELM.+CICE.+DOCN.+SROF.+SGLC.+SWAV.*" pesize="T">
-        <comment>cori-knl ne30 F-compset on 4 nodes, 34x8, sypd=0.61</comment>
-        <MAX_MPITASKS_PER_NODE>34</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>268</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>136</ntasks_atm>
-          <ntasks_lnd>136</ntasks_lnd>
-          <ntasks_rof>136</ntasks_rof>
-          <ntasks_ice>136</ntasks_ice>
-          <ntasks_ocn>136</ntasks_ocn>
-          <ntasks_glc>33</ntasks_glc>
-          <ntasks_wav>33</ntasks_wav>
-          <ntasks_cpl>136</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>8</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>4</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>4</nthrds_cpl>
-        </nthrds>
       </pes>
     </mach>
   </grid>
@@ -1091,33 +693,6 @@
     </mach>
   </grid>
   <grid name="a%ne30np4.pg2">
-    <mach name="cori-knl">
-      <pes compset="any" pesize="any">
-        <comment>cori-knl, generic ne30pg2, 43 nodes, 32x4</comment>
-        <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>1350</ntasks_atm>
-          <ntasks_lnd>1350</ntasks_lnd>
-          <ntasks_rof>1350</ntasks_rof>
-          <ntasks_ice>1200</ntasks_ice>
-          <ntasks_ocn>1200</ntasks_ocn>
-          <ntasks_glc>32</ntasks_glc>
-          <ntasks_wav>32</ntasks_wav>
-          <ntasks_cpl>1350</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>4</nthrds_cpl>
-        </nthrds>
-      </pes>
-    </mach>
     <mach name="summit|ascent">
       <pes compset="any" pesize="any">
         <comment>summit|ascent: any compset on ne30np4.pg2 grid</comment>
@@ -1159,12 +734,39 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%ne30.+_oi%oEC60to30v3">
-    <mach name="gcp">
+  <grid name="a%ne30.+_oi%.*EC.*to">
+    <mach name="gcp12">
       <!--Pes setting: grid          is a%ne30np4_l%ne30np4_oi%oEC60to30v3_r%r05_g%null_w%null_z%null_m%oEC60to30v3 
-          Pes setting: compset       is 2010_EAM%CMIP6_ELM%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV_SIAC_SESP -->
+          Pes setting: compset       is 2010_EAM%CMIP6_ELM%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV_SIAC_SESP
+                               or       a%ne30np4.pg2_l%r05_oi%EC30to60E2r2_r%null_g%null_w%null_z%null_m%EC30to60E2r2
+                                        1850_EAM%CMIP6_ELM%CNPRDCTCBC_MPASSI%PRES_DOCN%DOM_SROF_SGLC_SWAV_SIAC_SESP_BGC%LNDATM  -->
       <pes compset=".*EAM.+ELM.+DOCN" pesize="any">
-        <comment> -compset A_WCYCL* -res ne30pg2_oECv3 without MPASO on 8 nodes </comment>
+        <comment> gcp12 -compset A_WCYCL* -res ne30pg2_oECv3 or ne30pg2_r05_EC30to60E2r2 without MPASO on 5 nodes, 56x2 </comment>
+        <ntasks>
+          <ntasks_atm>280</ntasks_atm>
+          <ntasks_lnd>280</ntasks_lnd>
+          <ntasks_rof>280</ntasks_rof>
+          <ntasks_ice>256</ntasks_ice>
+          <ntasks_ocn>256</ntasks_ocn>
+          <ntasks_cpl>280</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>2</nthrds_atm>
+          <nthrds_lnd>2</nthrds_lnd>
+          <nthrds_rof>2</nthrds_rof>
+          <nthrds_ice>2</nthrds_ice>
+          <nthrds_ocn>2</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+      </pes>
+    </mach>
+    <mach name="gcp10">
+      <!--Pes setting: grid          is a%ne30np4_l%ne30np4_oi%oEC60to30v3_r%r05_g%null_w%null_z%null_m%oEC60to30v3 
+          Pes setting: compset       is 2010_EAM%CMIP6_ELM%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV_SIAC_SESP
+                               or       a%ne30np4.pg2_l%r05_oi%EC30to60E2r2_r%null_g%null_w%null_z%null_m%EC30to60E2r2
+                                        1850_EAM%CMIP6_ELM%CNPRDCTCBC_MPASSI%PRES_DOCN%DOM_SROF_SGLC_SWAV_SIAC_SESP_BGC%LNDATM  -->
+      <pes compset=".*EAM.+ELM.+DOCN" pesize="any">
+        <comment> gcp10 -compset A_WCYCL* -res ne30pg2_oECv3 or ne30pg2_r05_EC30to60E2r2 without MPASO on 8 nodes </comment>
         <ntasks>
           <ntasks_atm>240</ntasks_atm>
           <ntasks_lnd>240</ntasks_lnd>
@@ -1187,24 +789,19 @@
       <!--Pes setting: grid          is a%ne30np4_l%ne30np4_oi%oEC60to30v3_r%r05_g%null_w%null_z%null_m%oEC60to30v3
           Pes setting: compset       is 2010_EAM%CMIP6_ELM%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV_SIAC_SESP -->
       <pes compset=".*EAM.+ELM.+DOCN" pesize="any">
-        <comment> -compset A_WCYCL* -res ne30pg2_oECv3 without MPASO on 4 nodes </comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
+        <comment> -compset A_WCYCL* -res ne30pg2_oECv3 without MPASO on 4 nodes, 128x1 c8 </comment>
+        <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
         <ntasks>
-          <ntasks_atm>256</ntasks_atm>
-          <ntasks_lnd>256</ntasks_lnd>
-          <ntasks_rof>256</ntasks_rof>
-          <ntasks_ice>256</ntasks_ice>
-          <ntasks_ocn>256</ntasks_ocn>
-          <ntasks_cpl>256</ntasks_cpl>
+          <ntasks_atm>512</ntasks_atm>
+          <ntasks_lnd>512</ntasks_lnd>
+          <ntasks_rof>512</ntasks_rof>
+          <ntasks_ice>512</ntasks_ice>
+          <ntasks_ocn>512</ntasks_ocn>
+          <ntasks_cpl>64</ntasks_cpl>
         </ntasks>
-        <nthrds>
-          <nthrds_atm>2</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
+        <pstrid>
+          <pstrid_cpl>8</pstrid_cpl>
+        </pstrid>
       </pes>
     </mach>
   </grid>
@@ -1474,51 +1071,6 @@
       </pes>
     </mach>
   </grid>
-  <!-- ne45 PEs -->
-  <grid name="a%ne45np4.pg2">
-    <mach name="cori-knl">
-      <pes compset="any" pesize="L">
-        <comment>cori-knl, generic ne45pg2, 85 nodes, 64x1</comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>5440</ntasks_atm>
-          <ntasks_lnd>5440</ntasks_lnd>
-          <ntasks_rof>5440</ntasks_rof>
-          <ntasks_ice>4800</ntasks_ice>
-          <ntasks_ocn>4800</ntasks_ocn>
-          <ntasks_glc>64</ntasks_glc>
-          <ntasks_wav>64</ntasks_wav>
-          <ntasks_cpl>5440</ntasks_cpl>
-        </ntasks>
-      </pes>
-      <pes compset="any" pesize="any">
-        <comment>cori-knl, generic ne45, 43 nodes, 32x4</comment>
-        <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>1350</ntasks_atm>
-          <ntasks_lnd>1350</ntasks_lnd>
-          <ntasks_rof>1350</ntasks_rof>
-          <ntasks_ice>1200</ntasks_ice>
-          <ntasks_ocn>1200</ntasks_ocn>
-          <ntasks_glc>32</ntasks_glc>
-          <ntasks_wav>32</ntasks_wav>
-          <ntasks_cpl>1350</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>4</nthrds_cpl>
-        </nthrds>
-      </pes>
-    </mach>
-  </grid>
   <!-- ne120 PEs -->
   <grid name="a%ne120np4_">
     <mach name="any">
@@ -1536,110 +1088,37 @@
         </ntasks>
       </pes>
     </mach>
-    <mach name="cori-haswell">
-      <pes compset="EAM.+ELM.+DOCN." pesize="any">
-        <comment>none</comment>
-        <ntasks>
-          <ntasks_atm>4800</ntasks_atm>
-          <ntasks_lnd>4800</ntasks_lnd>
-          <ntasks_rof>4800</ntasks_rof>
-          <ntasks_ice>4800</ntasks_ice>
-          <ntasks_ocn>4800</ntasks_ocn>
-          <ntasks_glc>4800</ntasks_glc>
-          <ntasks_wav>4800</ntasks_wav>
-          <ntasks_cpl>4800</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>4</nthrds_rof>
-          <nthrds_ice>4</nthrds_ice>
-          <nthrds_ocn>4</nthrds_ocn>
-          <nthrds_glc>4</nthrds_glc>
-          <nthrds_wav>4</nthrds_wav>
-          <nthrds_cpl>4</nthrds_cpl>
-        </nthrds>
-      </pes>
-    </mach>
-    <mach name="cori-knl">
-      <pes compset="any" pesize="L">
-        <comment>cori-knl, generic ne120, 338 nodes, 64x4 </comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>21600</ntasks_atm>
-          <ntasks_lnd>21600</ntasks_lnd>
-          <ntasks_rof>21600</ntasks_rof>
-          <ntasks_ice>19200</ntasks_ice>
-          <ntasks_ocn>19200</ntasks_ocn>
-          <ntasks_glc>64</ntasks_glc>
-          <ntasks_wav>64</ntasks_wav>
-          <ntasks_cpl>21600</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>4</nthrds_cpl>
-        </nthrds>
-      </pes>
-      <pes compset="any" pesize="any">
-        <comment>cori-knl, generic ne120, 169 nodes, 64x4 </comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>10800</ntasks_atm>
-          <ntasks_lnd>10800</ntasks_lnd>
-          <ntasks_rof>10800</ntasks_rof>
-          <ntasks_ice>9600</ntasks_ice>
-          <ntasks_ocn>9600</ntasks_ocn>
-          <ntasks_glc>64</ntasks_glc>
-          <ntasks_wav>64</ntasks_wav>
-          <ntasks_cpl>10800</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>4</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>4</nthrds_cpl>
-        </nthrds>
-      </pes>
-      <pes compset="any" pesize="S">
-        <comment>cori-knl, generic ne120, 85 nodes, 64x4 </comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>5400</ntasks_atm>
-          <ntasks_lnd>5400</ntasks_lnd>
-          <ntasks_rof>5400</ntasks_rof>
-          <ntasks_ice>4800</ntasks_ice>
-          <ntasks_ocn>4800</ntasks_ocn>
-          <ntasks_glc>64</ntasks_glc>
-          <ntasks_wav>64</ntasks_wav>
-          <ntasks_cpl>5400</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>4</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>4</nthrds_cpl>
-        </nthrds>
-      </pes>
-    </mach>
   </grid>
   <grid name="a%ne120np4">
+    <mach name="pm-cpu|alvarez">
+      <pes compset=".*EAM.+ELM.+MPASSI.+DOCN.+SGLC.+SWAV.*" pesize="any">
+        <comment>pm-cpu ne120pg2 F-compset with MPASSI on 43 nodes 128x1c8 1.3 sypd</comment>
+        <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
+        <ntasks>
+          <ntasks_atm>5504</ntasks_atm>
+          <ntasks_lnd>5504</ntasks_lnd>
+          <ntasks_rof>5504</ntasks_rof>
+          <ntasks_ice>5400</ntasks_ice>
+          <ntasks_ocn>5504</ntasks_ocn>
+          <ntasks_glc>64</ntasks_glc>
+          <ntasks_wav>64</ntasks_wav>
+          <ntasks_cpl>688</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <pstrid>
+          <pstrid_cpl>8</pstrid_cpl>
+        </pstrid>
+      </pes>
+    </mach>
     <mach name="theta">
       <pes compset=".*EAM.+ELM.+DOCN.+SGLC.+SWAV.*" pesize="any">
         <comment>ne120 F-compset on 128 nodes 0.524sypd</comment>
@@ -1700,258 +1179,6 @@
           <rootpe_glc>0</rootpe_glc>
           <rootpe_wav>0</rootpe_wav>
         </rootpe>
-      </pes>
-    </mach>
-    <mach name="cori-knl">
-      <pes compset=".*EAM.+ELM.+MPASSI.+DOCN.+SGLC.+SWAV.*" pesize="X">
-        <comment>cori-knl ne120pg2 F-compset with MPASSI on 1024 nodes, 16x4, sypd=2.2</comment>
-        <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>16384</ntasks_atm>
-          <ntasks_lnd>16384</ntasks_lnd>
-          <ntasks_rof>16384</ntasks_rof>
-          <ntasks_ice>16384</ntasks_ice>
-          <ntasks_ocn>16384</ntasks_ocn>
-          <ntasks_glc>64</ntasks_glc>
-          <ntasks_wav>64</ntasks_wav>
-          <ntasks_cpl>16384</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>4</nthrds_rof>
-          <nthrds_ice>4</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-      </pes>
-      <pes compset=".*EAM.+ELM.+MPASSI.+DOCN.+SGLC.+SWAV.*" pesize="L">
-        <comment>cori-knl ne120pg2 F-compset with MPASSI on 338 nodes, 32x8, sypd=1.4</comment>
-        <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>10816</ntasks_atm>
-          <ntasks_lnd>10816</ntasks_lnd>
-          <ntasks_rof>10816</ntasks_rof>
-          <ntasks_ice>9600</ntasks_ice>
-          <ntasks_ocn>9600</ntasks_ocn>
-          <ntasks_glc>64</ntasks_glc>
-          <ntasks_wav>64</ntasks_wav>
-          <ntasks_cpl>10816</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>8</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-      </pes>
-      <pes compset=".*EAM.+ELM.+MPASSI.+DOCN.+SGLC.+SWAV.*" pesize="any">
-        <comment>cori-knl ne120pg2 F-compset with MPASSI on 169 nodes, 32x8, sypd=0.84</comment>
-        <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>5408</ntasks_atm>
-          <ntasks_lnd>5408</ntasks_lnd>
-          <ntasks_rof>5408</ntasks_rof>
-          <ntasks_ice>5200</ntasks_ice>
-          <ntasks_ocn>5200</ntasks_ocn>
-          <ntasks_glc>64</ntasks_glc>
-          <ntasks_wav>64</ntasks_wav>
-          <ntasks_cpl>4096</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>8</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>4</nthrds_rof>
-          <nthrds_ice>4</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-      </pes>
-      <pes compset=".*EAM.+ELM.+MPASSI.+DOCN.+SGLC.+SWAV.*" pesize="S">
-        <comment>cori-knl ne120pg2 F-compset with MPASSI on 85 nodes, 32x8, sypd=0.52 </comment>
-        <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>2720</ntasks_atm>
-          <ntasks_lnd>2720</ntasks_lnd>
-          <ntasks_rof>2720</ntasks_rof>
-          <ntasks_ice>2560</ntasks_ice>
-          <ntasks_ocn>2560</ntasks_ocn>
-          <ntasks_glc>32</ntasks_glc>
-          <ntasks_wav>32</ntasks_wav>
-          <ntasks_cpl>2048</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>8</nthrds_atm>
-          <nthrds_lnd>4</nthrds_lnd>
-          <nthrds_rof>4</nthrds_rof>
-          <nthrds_ice>4</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-      </pes>
-      <pes compset=".*EAM.+ELM.+MPASSI.+DOCN.+SGLC.+SWAV.*" pesize="T">
-        <comment>cori-knl ne120pg2 F-compset with MPASSI on 43 nodes, 16x8, sypd=0.29 </comment>
-        <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>688</ntasks_atm>
-          <ntasks_lnd>688</ntasks_lnd>
-          <ntasks_rof>688</ntasks_rof>
-          <ntasks_ice>640</ntasks_ice>
-          <ntasks_ocn>640</ntasks_ocn>
-          <ntasks_glc>16</ntasks_glc>
-          <ntasks_wav>16</ntasks_wav>
-          <ntasks_cpl>688</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>16</nthrds_atm>
-          <nthrds_lnd>16</nthrds_lnd>
-          <nthrds_rof>16</nthrds_rof>
-          <nthrds_ice>16</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-      </pes>
-      <pes compset=".*EAM.+ELM.+CICE.+DOCN.+SROF.+SGLC.+SWAV.*" pesize="X">
-        <comment>cori-knl ne120pg2 F-compset with CICE on 1024 nodes, 16x4, sypd=2.4</comment>
-        <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>16384</ntasks_atm>
-          <ntasks_lnd>16384</ntasks_lnd>
-          <ntasks_rof>16384</ntasks_rof>
-          <ntasks_ice>16384</ntasks_ice>
-          <ntasks_ocn>16384</ntasks_ocn>
-          <ntasks_glc>64</ntasks_glc>
-          <ntasks_wav>64</ntasks_wav>
-          <ntasks_cpl>16384</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-      </pes>
-      <pes compset=".*EAM.+ELM.+CICE.+DOCN.+SROF.+SGLC.+SWAV.*" pesize="L">
-        <comment>cori-knl ne120pg2 F-compset with CICE on 338 nodes, 64x4, sypd=1.6</comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>21632</ntasks_atm>
-          <ntasks_lnd>21632</ntasks_lnd>
-          <ntasks_rof>21632</ntasks_rof>
-          <ntasks_ice>21632</ntasks_ice>
-          <ntasks_ocn>21632</ntasks_ocn>
-          <ntasks_glc>64</ntasks_glc>
-          <ntasks_wav>64</ntasks_wav>
-          <ntasks_cpl>21632</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-      </pes>
-      <pes compset=".*EAM.+ELM.+CICE.+DOCN.+SROF.+SGLC.+SWAV.*" pesize="any">
-        <comment>cori-knl ne120pg2 F-compset with CICE on 169 nodes, 64x4, sypd=1.0</comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>10816</ntasks_atm>
-          <ntasks_lnd>10816</ntasks_lnd>
-          <ntasks_rof>10816</ntasks_rof>
-          <ntasks_ice>10816</ntasks_ice>
-          <ntasks_ocn>10816</ntasks_ocn>
-          <ntasks_glc>64</ntasks_glc>
-          <ntasks_wav>64</ntasks_wav>
-          <ntasks_cpl>10816</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-      </pes>
-      <pes compset=".*EAM.+ELM.+CICE.+DOCN.+SROF.+SGLC.+SWAV.*" pesize="S">
-        <comment>cori-knl ne120pg2 F-compset with CICE on 85 nodes, 64x4, sypd=0.55 </comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>5440</ntasks_atm>
-          <ntasks_lnd>5440</ntasks_lnd>
-          <ntasks_rof>5440</ntasks_rof>
-          <ntasks_ice>5440</ntasks_ice>
-          <ntasks_ocn>5440</ntasks_ocn>
-          <ntasks_glc>64</ntasks_glc>
-          <ntasks_wav>64</ntasks_wav>
-          <ntasks_cpl>5440</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-      </pes>
-      <pes compset=".*EAM.+ELM.+CICE.+DOCN.+SROF.+SGLC.+SWAV.*" pesize="T">
-        <comment>cori-knl ne120pg2 F-compset with CICE on 43 nodes, 64x4, sypd=0.31 </comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>268</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>2752</ntasks_atm>
-          <ntasks_lnd>2752</ntasks_lnd>
-          <ntasks_rof>2752</ntasks_rof>
-          <ntasks_ice>2752</ntasks_ice>
-          <ntasks_ocn>2752</ntasks_ocn>
-          <ntasks_glc>64</ntasks_glc>
-          <ntasks_wav>64</ntasks_wav>
-          <ntasks_cpl>2752</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>4</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
       </pes>
     </mach>
   </grid>
@@ -2123,48 +1350,6 @@
           <ntasks_wav>48</ntasks_wav>
           <ntasks_cpl>48</ntasks_cpl>
         </ntasks>
-      </pes>
-    </mach>
-    <mach name="cori-haswell">
-      <pes compset="any" pesize="any">
-        <comment>none</comment>
-        <ntasks>
-          <ntasks_atm>96</ntasks_atm>
-          <ntasks_lnd>96</ntasks_lnd>
-          <ntasks_rof>96</ntasks_rof>
-          <ntasks_ice>96</ntasks_ice>
-          <ntasks_ocn>96</ntasks_ocn>
-          <ntasks_glc>96</ntasks_glc>
-          <ntasks_wav>96</ntasks_wav>
-          <ntasks_cpl>96</ntasks_cpl>
-        </ntasks>
-      </pes>
-    </mach>
-    <mach name="cori-knl">
-      <pes compset="any" pesize="any">
-        <comment>4 nodes, 64x2</comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>256</ntasks_atm>
-          <ntasks_lnd>256</ntasks_lnd>
-          <ntasks_rof>256</ntasks_rof>
-          <ntasks_ice>256</ntasks_ice>
-          <ntasks_ocn>256</ntasks_ocn>
-          <ntasks_glc>256</ntasks_glc>
-          <ntasks_wav>256</ntasks_wav>
-          <ntasks_cpl>256</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>2</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_glc>2</nthrds_glc>
-          <nthrds_wav>2</nthrds_wav>
-          <nthrds_cpl>2</nthrds_cpl>
-        </nthrds>
       </pes>
     </mach>
   </grid>

--- a/components/elm/cime_config/config_pes.xml
+++ b/components/elm/cime_config/config_pes.xml
@@ -59,7 +59,7 @@
         </nthrds>
       </pes>
     </mach>
-    <mach name="theta|jlse|pm-gpu">
+    <mach name="theta|jlse|pm-gpu|pm-cpu|alvarez">
       <pes compset="any" pesize="any">
         <comment>elm: default, 1 node x MAX_MPITASKS_PER_NODE mpi x 1 omp @ root 0</comment>
         <ntasks>
@@ -74,49 +74,24 @@
         </ntasks>
       </pes>
     </mach>
-    <mach name="pm-cpu|alvarez">
+    <mach name="gcp12">
       <pes compset="any" pesize="any">
-        <comment>elm: default, 1 node x MAX_MPITASKS_PER_NODE mpi x 2 omp @ root 0</comment>
+        <comment>elm+gcp12: default 1 node, 56x1</comment>
         <ntasks>
-          <ntasks_atm>-1</ntasks_atm>
-          <ntasks_lnd>-1</ntasks_lnd>
-          <ntasks_rof>-1</ntasks_rof>
-          <ntasks_ice>-1</ntasks_ice>
-          <ntasks_ocn>-1</ntasks_ocn>
-          <ntasks_glc>-1</ntasks_glc>
-          <ntasks_wav>-1</ntasks_wav>
-          <ntasks_cpl>-1</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>2</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_glc>2</nthrds_glc>
-          <nthrds_wav>2</nthrds_wav>
-          <nthrds_cpl>2</nthrds_cpl>
-        </nthrds>
-      </pes>
-    </mach>
-    <mach name="cori-knl|cori-haswell">
-      <pes compset="any" pesize="any">
-        <comment>elm: default, 1 node x MAX_MPITASKS_PER_NODE mpi x 1 omp @ root 0</comment>
-        <ntasks>
-          <ntasks_atm>-4</ntasks_atm>
-          <ntasks_lnd>-4</ntasks_lnd>
-          <ntasks_rof>-4</ntasks_rof>
-          <ntasks_ice>-4</ntasks_ice>
-          <ntasks_ocn>-4</ntasks_ocn>
-          <ntasks_glc>-4</ntasks_glc>
-          <ntasks_wav>-4</ntasks_wav>
-          <ntasks_cpl>-4</ntasks_cpl>
+          <ntasks_atm>56</ntasks_atm>
+          <ntasks_lnd>56</ntasks_lnd>
+          <ntasks_rof>56</ntasks_rof>
+          <ntasks_ice>56</ntasks_ice>
+          <ntasks_ocn>56</ntasks_ocn>
+          <ntasks_glc>16</ntasks_glc>
+          <ntasks_wav>16</ntasks_wav>
+          <ntasks_cpl>56</ntasks_cpl>
         </ntasks>
       </pes>
     </mach>
-    <mach name="gcp">
+    <mach name="gcp10">
       <pes compset="any" pesize="any">
-        <comment>elm+gcp: default</comment>
+        <comment>elm+gcp10: default 1 node</comment>
         <ntasks>
           <ntasks_atm>30</ntasks_atm>
           <ntasks_lnd>30</ntasks_lnd>
@@ -381,7 +356,7 @@
     </mach>
   </grid>
   <grid name="a%r05_l%r05_oi%null_r%r05_g%null_w%null_z%null_m%oEC60to30v3">
-    <mach name="sandiatoss3|cori-knl|cori-haswell|theta|anvil|bebop">
+    <mach name="sandiatoss3|theta|anvil|bebop">
       <pes compset="any" pesize="any">
         <comment>none</comment>
         <ntasks>
@@ -393,6 +368,49 @@
           <ntasks_glc>256</ntasks_glc>
           <ntasks_wav>256</ntasks_wav>
           <ntasks_cpl>256</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
+    <mach name="gcp12">
+      <pes compset="any" pesize="any">
+        <comment>gcp12 r05 2 nodes</comment>
+        <ntasks>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_glc>-2</ntasks_glc>
+          <ntasks_wav>-2</ntasks_wav>
+          <ntasks_cpl>-2</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
+    <mach name="gcp10">
+      <pes compset="any" pesize="any">
+        <comment>gcp10 r05 4 nodes</comment>
+        <ntasks>
+          <ntasks_atm>-4</ntasks_atm>
+          <ntasks_lnd>-4</ntasks_lnd>
+          <ntasks_rof>-4</ntasks_rof>
+          <ntasks_ice>-4</ntasks_ice>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_glc>-4</ntasks_glc>
+          <ntasks_wav>-4</ntasks_wav>
+          <ntasks_cpl>-4</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
+    <mach name="ascent|summit">
+      <pes compset="any" pesize="any">
+        <comment>elm: ascent|summit PEs for grid l%r05_*r%r05</comment>
+        <ntasks>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_cpl>-2</ntasks_cpl>
         </ntasks>
       </pes>
     </mach>

--- a/components/mpas-albany-landice/cime_config/config_pes.xml
+++ b/components/mpas-albany-landice/cime_config/config_pes.xml
@@ -87,7 +87,7 @@
         </nthrds>
       </pes>
     </mach>
-    <mach name="theta|pm-gpu|pm-cpu|cori-knl|cori-haswell|jlse">
+    <mach name="theta|pm-gpu|pm-cpu|jlse">
       <pes compset="any" pesize="any">
         <comment>mali: default, 1 node x MAX_MPITASKS_PER_NODE mpi x 1 omp @ root 0</comment>
         <ntasks>
@@ -102,9 +102,24 @@
         </ntasks>
       </pes>
     </mach>
-    <mach name="gcp">
+    <mach name="gcp12">
       <pes compset="any" pesize="any">
-        <comment>mali+gcp: default</comment>
+        <comment>mali+gcp12: default 1 node</comment>
+        <ntasks>
+          <ntasks_atm>56</ntasks_atm>
+          <ntasks_lnd>56</ntasks_lnd>
+          <ntasks_rof>56</ntasks_rof>
+          <ntasks_ice>36</ntasks_ice>
+          <ntasks_ocn>36</ntasks_ocn>
+          <ntasks_glc>16</ntasks_glc>
+          <ntasks_wav>16</ntasks_wav>
+          <ntasks_cpl>56</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
+    <mach name="gcp10">
+      <pes compset="any" pesize="any">
+        <comment>mali+gcp10: default</comment>
         <ntasks>
           <ntasks_atm>30</ntasks_atm>
           <ntasks_lnd>30</ntasks_lnd>

--- a/components/mpas-ocean/cime_config/config_pes.xml
+++ b/components/mpas-ocean/cime_config/config_pes.xml
@@ -72,7 +72,7 @@
         </nthrds>
       </pes>
     </mach>
-    <mach name="theta|pm-gpu|cori-knl|cori-haswell|jlse">
+    <mach name="theta|pm-cpu|alvarez|pm-gpu|jlse">
       <pes compset="any" pesize="any">
         <comment>mpas-ocean: default, 1 node x MAX_MPITASKS_PER_NODE mpi x 1 omp @ root 0</comment>
         <ntasks>
@@ -87,34 +87,24 @@
         </ntasks>
       </pes>
     </mach>
-    <mach name="pm-cpu|alvarez">
+    <mach name="gcp12">
       <pes compset="any" pesize="any">
-        <comment>mpas-ocean: default, 1 node x MAX_MPITASKS_PER_NODE mpi x 2 omp @ root 0</comment>
+        <comment>mpas-ocean+gcp12: default 1 node</comment>
         <ntasks>
-          <ntasks_atm>-1</ntasks_atm>
-          <ntasks_lnd>-1</ntasks_lnd>
-          <ntasks_rof>-1</ntasks_rof>
-          <ntasks_ice>-1</ntasks_ice>
-          <ntasks_ocn>-1</ntasks_ocn>
-          <ntasks_glc>-1</ntasks_glc>
-          <ntasks_wav>-1</ntasks_wav>
-          <ntasks_cpl>-1</ntasks_cpl>
+          <ntasks_atm>56</ntasks_atm>
+          <ntasks_lnd>56</ntasks_lnd>
+          <ntasks_rof>56</ntasks_rof>
+          <ntasks_ice>56</ntasks_ice>
+          <ntasks_ocn>56</ntasks_ocn>
+          <ntasks_glc>16</ntasks_glc>
+          <ntasks_wav>16</ntasks_wav>
+          <ntasks_cpl>56</ntasks_cpl>
         </ntasks>
-        <nthrds>
-          <nthrds_atm>2</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_glc>2</nthrds_glc>
-          <nthrds_wav>2</nthrds_wav>
-          <nthrds_cpl>2</nthrds_cpl>
-        </nthrds>
       </pes>
     </mach>
-    <mach name="gcp">
+    <mach name="gcp10">
       <pes compset="any" pesize="any">
-        <comment>mpas-ocean+gcp: default</comment>
+        <comment>mpas-ocean+gcp10: default</comment>
         <ntasks>
           <ntasks_atm>30</ntasks_atm>
           <ntasks_lnd>30</ntasks_lnd>
@@ -269,33 +259,6 @@
         </rootpe>
       </pes>
     </mach>
-    <mach name="cori-knl">
-      <pes compset=".*MPASSI.+MPASO.+" pesize="any">
-        <comment>cori-knl, lowres (60to30) G case on 16 nodes, 64x2, sypd=2.42</comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>1024</ntasks_atm>
-          <ntasks_lnd>1024</ntasks_lnd>
-          <ntasks_rof>1024</ntasks_rof>
-          <ntasks_ice>1024</ntasks_ice>
-          <ntasks_ocn>1024</ntasks_ocn>
-          <ntasks_cpl>1024</ntasks_cpl>
-          <ntasks_glc>1</ntasks_glc>
-          <ntasks_wav>1</ntasks_wav>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-      </pes>
-    </mach>
     <mach name="compy">
       <pes compset="DATM.+MPASO" pesize="S">
         <comment>compy, lowres (60to30v3) G case on 12 nodes 40 ppn pure-MPI, sypd=10</comment>
@@ -372,97 +335,6 @@
           <ntasks_glc>1</ntasks_glc>
           <ntasks_wav>1</ntasks_wav>
         </ntasks>
-      </pes>
-    </mach>
-    <mach name="cori-knl">
-      <pes compset=".*MPASSI.+MPASO.+" pesize="any">
-        <comment>cori-knl G 30to10 on 52 nodes, 64x2</comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>1280</ntasks_atm>
-          <ntasks_lnd>1280</ntasks_lnd>
-          <ntasks_rof>1280</ntasks_rof>
-          <ntasks_ice>1280</ntasks_ice>
-          <ntasks_ocn>2048</ntasks_ocn>
-          <ntasks_cpl>1280</ntasks_cpl>
-          <ntasks_glc>1</ntasks_glc>
-          <ntasks_wav>1</ntasks_wav>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>2</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>1280</rootpe_ocn>
-          <rootpe_cpl>0</rootpe_cpl>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-        </rootpe>
-      </pes>
-    </mach>
-    <mach name="cori-haswell">
-      <pes compset=".*MPASSI.+MPASO.+" pesize="any">
-        <comment>cori-haswell G 30to10 on 48 nodes</comment>
-        <ntasks>
-          <ntasks_atm>512</ntasks_atm>
-          <ntasks_lnd>512</ntasks_lnd>
-          <ntasks_rof>512</ntasks_rof>
-          <ntasks_ice>512</ntasks_ice>
-          <ntasks_ocn>1024</ntasks_ocn>
-          <ntasks_cpl>512</ntasks_cpl>
-          <ntasks_glc>1</ntasks_glc>
-          <ntasks_wav>1</ntasks_wav>
-        </ntasks>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>512</rootpe_ocn>
-          <rootpe_cpl>0</rootpe_cpl>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-        </rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name=".*oi%oRRS18to6v3*">
-    <mach name="cori-knl">
-      <pes compset=".*MPASSI.+MPASO.+" pesize="any">
-        <comment>cori-knl, hires (18to6) G case on 150 nodes, 64x2, sypd=0.5</comment>
-        <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>9600</ntasks_atm>
-          <ntasks_lnd>9600</ntasks_lnd>
-          <ntasks_rof>9600</ntasks_rof>
-          <ntasks_ice>9600</ntasks_ice>
-          <ntasks_ocn>9600</ntasks_ocn>
-          <ntasks_cpl>9600</ntasks_cpl>
-          <ntasks_glc>1</ntasks_glc>
-          <ntasks_wav>1</ntasks_wav>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
       </pes>
     </mach>
   </grid>

--- a/components/mpas-seaice/cime_config/config_pes.xml
+++ b/components/mpas-seaice/cime_config/config_pes.xml
@@ -59,7 +59,7 @@
         </nthrds>
       </pes>
     </mach>
-    <mach name="theta|pm-gpu|cori-knl|cori-haswell|jlse">
+    <mach name="theta|pm-gpu|jlse">
       <pes compset="any" pesize="any">
         <comment>seaice: default, 1 node x MAX_MPITASKS_PER_NODE mpi x 1 omp @ root 0</comment>
         <ntasks>
@@ -74,34 +74,24 @@
         </ntasks>
       </pes>
     </mach>
-    <mach name="pm-cpu|alvarez">
+    <mach name="gcp12">
       <pes compset="any" pesize="any">
-        <comment>seaice: default, 1 node x MAX_MPITASKS_PER_NODE mpi x 2 omp @ root 0</comment>
+        <comment>seaice+gcp12: default 1 node</comment>
         <ntasks>
-          <ntasks_atm>-1</ntasks_atm>
-          <ntasks_lnd>-1</ntasks_lnd>
-          <ntasks_rof>-1</ntasks_rof>
-          <ntasks_ice>-1</ntasks_ice>
-          <ntasks_ocn>-1</ntasks_ocn>
-          <ntasks_glc>-1</ntasks_glc>
-          <ntasks_wav>-1</ntasks_wav>
-          <ntasks_cpl>-1</ntasks_cpl>
+          <ntasks_atm>56</ntasks_atm>
+          <ntasks_lnd>56</ntasks_lnd>
+          <ntasks_rof>56</ntasks_rof>
+          <ntasks_ice>56</ntasks_ice>
+          <ntasks_ocn>56</ntasks_ocn>
+          <ntasks_glc>16</ntasks_glc>
+          <ntasks_wav>16</ntasks_wav>
+          <ntasks_cpl>56</ntasks_cpl>
         </ntasks>
-        <nthrds>
-          <nthrds_atm>2</nthrds_atm>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_glc>2</nthrds_glc>
-          <nthrds_wav>2</nthrds_wav>
-          <nthrds_cpl>2</nthrds_cpl>
-        </nthrds>
       </pes>
     </mach>
-    <mach name="gcp">
+    <mach name="gcp10">
       <pes compset="any" pesize="any">
-        <comment>seaice+gcp: default</comment>
+        <comment>seaice+gcp10: default</comment>
         <ntasks>
           <ntasks_atm>30</ntasks_atm>
           <ntasks_lnd>30</ntasks_lnd>


### PR DESCRIPTION
For pm-cpu:
Use Intel compiler as default
Update modules to match version on master.
Remove references to cori in XML files.
Adjust pelayouts for pm-cpu/gcp.
Use new cprnc
Update NERSC batch settings