### PR TITLE
Fixes the hyperlink for local pages

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -39,3 +39,5 @@ extra_javascript:
   # - javascript/mathjax.js
   - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+
+use_directory_urls: false


### PR DESCRIPTION
The fix for hyperlink is based on the following webpage 
https://stackoverflow.com/questions/48063231/mkdocs-hyperlink-not-working-in-static-pages.

Fixes #5960