### PR TITLE
Fix gas dry deposition for VBS SOAG gas species

### DIFF
--- a/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6_chemUCI-Linoz-mam5-vbs-1pctCO2.xml
+++ b/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6_chemUCI-Linoz-mam5-vbs-1pctCO2.xml
@@ -123,7 +123,7 @@
 
 <!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
 <drydep_method       >'xactive_lnd'</drydep_method>
-<drydep_list         >'O3','H2O2','CH2O','CH3OOH','NO','NO2','HNO3','HO2NO2','PAN','CO','CH3COCH3','C2H5OOH','CH3CHO','H2SO4','SO2','NO3','N2O5'</drydep_list>
+<drydep_list         >'O3','H2O2','CH2O','CH3OOH','NO','NO2','HNO3','HO2NO2','PAN','CO','CH3COCH3','C2H5OOH','CH3CHO','H2SO4','SO2','NO3','N2O5','SOAG0','SOAG15','SOAG24','SOAG35','SOAG34','SOAG33','SOAG32','SOAG31'</drydep_list>
 <gas_wetdep_method   >'NEU'</gas_wetdep_method>
 <gas_wetdep_list     >'C2H5OOH','CH2O','CH3CHO','CH3OOH','H2O2','H2SO4','HNO3','HO2NO2','SO2','SOAG0','SOAG15','SOAG24','SOAG35','SOAG34','SOAG33','SOAG32','SOAG31'</gas_wetdep_list>
 <fstrat_efold_list>'CH2O', 'CH3O2', 'CH3OOH', 'PAN', 'CO', 'C2H6', 'C3H8', 'C2H4', 'ROHO2', 'CH3COCH3', 'C2H5O2', 'C2H5OOH', 'CH3CHO', 'CH3CO3', 'ISOP', 'ISOPO2', 'MVKMACR', 'MVKO2'</fstrat_efold_list>

--- a/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6_chemUCI-Linoz-mam5-vbs.xml
+++ b/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6_chemUCI-Linoz-mam5-vbs.xml
@@ -119,7 +119,7 @@
 
 <!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
 <drydep_method       >'xactive_lnd'</drydep_method>
-<drydep_list         >'O3','H2O2','CH2O','CH3OOH','NO','NO2','HNO3','HO2NO2','PAN','CO','CH3COCH3','C2H5OOH','CH3CHO','H2SO4','SO2','NO3','N2O5'</drydep_list>
+<drydep_list         >'O3','H2O2','CH2O','CH3OOH','NO','NO2','HNO3','HO2NO2','PAN','CO','CH3COCH3','C2H5OOH','CH3CHO','H2SO4','SO2','NO3','N2O5','SOAG0','SOAG15','SOAG24','SOAG35','SOAG34','SOAG33','SOAG32','SOAG31'</drydep_list>
 <gas_wetdep_method   >'NEU'</gas_wetdep_method>
 <gas_wetdep_list     >'C2H5OOH','CH2O','CH3CHO','CH3OOH','H2O2','H2SO4','HNO3','HO2NO2','SO2','SOAG0','SOAG15','SOAG24','SOAG35','SOAG34','SOAG33','SOAG32','SOAG31'</gas_wetdep_list>
 <fstrat_efold_list>'CH2O', 'CH3O2', 'CH3OOH', 'PAN', 'CO', 'C2H6', 'C3H8', 'C2H4', 'ROHO2', 'CH3COCH3', 'C2H5O2', 'C2H5OOH', 'CH3CHO', 'CH3CO3', 'ISOP', 'ISOPO2', 'MVKMACR', 'MVKO2'</fstrat_efold_list>

--- a/components/eam/bld/namelist_files/use_cases/2010_eam_CMIP6_chemUCI-Linoz-mam5-vbs.xml
+++ b/components/eam/bld/namelist_files/use_cases/2010_eam_CMIP6_chemUCI-Linoz-mam5-vbs.xml
@@ -116,7 +116,7 @@
 
 <!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
 <drydep_method       >'xactive_lnd'</drydep_method>
-<drydep_list         >'O3','H2O2','CH2O','CH3OOH','NO','NO2','HNO3','HO2NO2','PAN','CO','CH3COCH3','C2H5OOH','CH3CHO','H2SO4','SO2','NO3','N2O5'</drydep_list>
+<drydep_list         >'O3','H2O2','CH2O','CH3OOH','NO','NO2','HNO3','HO2NO2','PAN','CO','CH3COCH3','C2H5OOH','CH3CHO','H2SO4','SO2','NO3','N2O5','SOAG0','SOAG15','SOAG24','SOAG35','SOAG34','SOAG33','SOAG32','SOAG31'</drydep_list>
 <gas_wetdep_method   >'NEU'</gas_wetdep_method>
 <gas_wetdep_list     >'C2H5OOH','CH2O','CH3CHO','CH3OOH','H2O2','H2SO4','HNO3','HO2NO2','SO2','SOAG0','SOAG15','SOAG24','SOAG35','SOAG34','SOAG33','SOAG32','SOAG31'</gas_wetdep_list>
 <fstrat_efold_list>'CH2O', 'CH3O2', 'CH3OOH', 'PAN', 'CO', 'C2H6', 'C3H8', 'C2H4', 'ROHO2', 'CH3COCH3', 'C2H5O2', 'C2H5OOH', 'CH3CHO', 'CH3CO3', 'ISOP', 'ISOPO2', 'MVKMACR', 'MVKO2'</fstrat_efold_list>

--- a/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6_chemUCI-Linoz-mam5-vbs.xml
+++ b/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6_chemUCI-Linoz-mam5-vbs.xml
@@ -106,7 +106,7 @@
 
 <!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
 <drydep_method       >'xactive_lnd'</drydep_method>
-<drydep_list         >'O3','H2O2','CH2O','CH3OOH','NO','NO2','HNO3','HO2NO2','PAN','CO','CH3COCH3','C2H5OOH','CH3CHO','H2SO4','SO2','NO3','N2O5'</drydep_list>
+<drydep_list         >'O3','H2O2','CH2O','CH3OOH','NO','NO2','HNO3','HO2NO2','PAN','CO','CH3COCH3','C2H5OOH','CH3CHO','H2SO4','SO2','NO3','N2O5','SOAG0','SOAG15','SOAG24','SOAG35','SOAG34','SOAG33','SOAG32','SOAG31'</drydep_list>
 <gas_wetdep_method   >'NEU'</gas_wetdep_method>
 <gas_wetdep_list     >'C2H5OOH','CH2O','CH3CHO','CH3OOH','H2O2','H2SO4','HNO3','HO2NO2','SO2','SOAG0','SOAG15','SOAG24','SOAG35','SOAG34','SOAG33','SOAG32','SOAG31'</gas_wetdep_list>
 <fstrat_efold_list>'CH2O', 'CH3O2', 'CH3OOH', 'PAN', 'CO', 'C2H6', 'C3H8', 'C2H4', 'ROHO2', 'CH3COCH3', 'C2H5O2', 'C2H5OOH', 'CH3CHO', 'CH3CO3', 'ISOP', 'ISOPO2', 'MVKMACR', 'MVKO2'</fstrat_efold_list>

--- a/driver-mct/shr/seq_drydep_mod.F90
+++ b/driver-mct/shr/seq_drydep_mod.F90
@@ -36,7 +36,7 @@ module seq_drydep_mod
   ! !PRIVATE ARRAY SIZES
 
   integer, private, parameter :: maxspc = 210              ! Maximum number of species
-  integer, public,  parameter :: n_species_table = 192      ! Number of species to work with
+  integer, public,  parameter :: n_species_table = 200      ! Number of species to work with
   integer, private, parameter :: NSeas = 5                 ! Number of seasons
   integer, private, parameter :: NLUse = 11                ! Number of land-use types
 
@@ -280,6 +280,14 @@ module seq_drydep_mod
        ,1.e-36_r8 & ! HCN
        ,1.e-36_r8 & ! CH3CN
        ,1.e-36_r8 & ! SO2
+       ,0.1_r8    & ! SOAG0
+       ,0.1_r8    & ! SOAG15
+       ,0.1_r8    & ! SOAG24
+       ,0.1_r8    & ! SOAG35
+       ,0.1_r8    & ! SOAG34
+       ,0.1_r8    & ! SOAG33
+       ,0.1_r8    & ! SOAG32
+       ,0.1_r8    & ! SOAG31
        ,0.1_r8    & ! SOAGff0
        ,0.1_r8    & ! SOAGff1
        ,0.1_r8    & ! SOAGff2
@@ -489,6 +497,14 @@ module seq_drydep_mod
          ,'HCN      ' &
          ,'CH3CN    ' &
          ,'SO2      ' &
+         ,'SOAG0    ' &
+         ,'SOAG15   ' &
+         ,'SOAG24   ' &
+         ,'SOAG35   ' &
+         ,'SOAG34   ' &
+         ,'SOAG33   ' &
+         ,'SOAG32   ' &
+         ,'SOAG31   ' &
          ,'SOAGff0  ' &
          ,'SOAGff1  ' &
          ,'SOAGff2  ' &
@@ -685,6 +701,14 @@ module seq_drydep_mod
        ,9.02e+00_r8, 8258._r8,0._r8     ,    0._r8,0._r8     ,    0._r8  & ! HCN
        ,5.28e+01_r8, 3970._r8,0._r8     ,    0._r8,0._r8     ,    0._r8  & ! CH3CN
        ,1.36e+00_r8, 3100._r8,1.30e-02_r8,1960._r8,6.6e-08_r8, 1500._r8  & ! SO2
+       ,7.59e+03_r8, 6013.95_r8,0._r8   ,    0._r8,0._r8     ,    0._r8  & ! SOAG0
+       ,7.94e+04_r8, 6013.95_r8,0._r8   ,    0._r8,0._r8     ,    0._r8  & ! SOAG15
+       ,2.57e+05_r8, 6013.95_r8,0._r8   ,    0._r8,0._r8     ,    0._r8  & ! SOAG24
+       ,7.94e+04_r8, 6013.95_r8,0._r8   ,    0._r8,0._r8     ,    0._r8  & ! SOAG35
+       ,2.57e+05_r8, 6013.95_r8,0._r8   ,    0._r8,0._r8     ,    0._r8  & ! SOAG34
+       ,8.32e+05_r8, 6013.95_r8,0._r8   ,    0._r8,0._r8     ,    0._r8  & ! SOAG33
+       ,2.69e+06_r8, 6013.95_r8,0._r8   ,    0._r8,0._r8     ,    0._r8  & ! SOAG32
+       ,8.71e+06_r8, 6013.95_r8,0._r8   ,    0._r8,0._r8     ,    0._r8  & ! SOAG31
        ,1.3e+07_r8,     0._r8,0._r8     ,    0._r8,0._r8     ,    0._r8  & ! SOAGff0
        ,3.2e+05_r8,     0._r8,0._r8     ,    0._r8,0._r8     ,    0._r8  & ! SOAGff1
        ,4.0e+05_r8,     0._r8,0._r8     ,    0._r8,0._r8     ,    0._r8  & ! SOAGff2 
@@ -836,7 +860,9 @@ module seq_drydep_mod
        58.0768013_r8, 76.0910034_r8, 89.070126_r8,  90.078067_r8,  222.000000_r8, &
        68.1141968_r8, 70.0877991_r8, 70.0877991_r8, 46.0657997_r8, 147.125946_r8, &
        119.074341_r8, 162.117935_r8, 100.112999_r8, 27.0256_r8   , 41.0524_r8   , &
-       64.064800_r8,  250._r8,       250._r8,       250._r8,       250._r8,       &
+       64.064800_r8,  250.445_r8,    250.445_r8,    250.445_r8,    250.445_r8,    &
+       250.445_r8,    250.445_r8,    250.445_r8,    250.445_r8, &
+       250._r8,       250._r8,       250._r8,       250._r8,       &
        250._r8,       250._r8,       250._r8,       250._r8,       250._r8,       &
        250._r8,       250._r8,       250._r8,       250._r8,       250._r8,       &
        250._r8,       170.3_r8,      170.3_r8,      170.3_r8,       170.3_r8,     &


### PR DESCRIPTION
This PR fixes the issue #5963  on dry deposition of VBS SOAG gases. Dry deposition for VBS SOAG gas species, namely SOAG0, SOAG15, SOAG24, SOAG35, SOAG34, SOAG33, SOAG32, SOAG31, is now included in shared seq_drydep_mod.F90 and namelist drydep_list.

[CC]
[NML]