### PR TITLE
Set parameters to wrap up v3alpha03 configuration

### DIFF
--- a/cime_config/testmods_dirs/allactive/wcprodrrm_1850/user_nl_elm
+++ b/cime_config/testmods_dirs/allactive/wcprodrrm_1850/user_nl_elm
@@ -30,4 +30,4 @@
  hist_nhtfrq = 0,-24
  hist_avgflag_pertape = 'A','A'
  check_finidat_year_consistency = .false.
-! finidat = '${DIN_LOC_ROOT}/lnd/clm2/initdata_map/clmi.WCYCL1850.northamericax4v1pg2_WC14to60E2r3.SMS_PS.c20230213.nc'
+ finidat = '${DIN_LOC_ROOT}/lnd/clm2/initdata_map/clmi.WCYCL1850.northamericax4v1pg2_WC14to60E2r3.SMS_PS.c20230213.nc'

--- a/cime_config/testmods_dirs/allactive/wcprodrrm_1850/user_nl_elm
+++ b/cime_config/testmods_dirs/allactive/wcprodrrm_1850/user_nl_elm
@@ -30,4 +30,4 @@
  hist_nhtfrq = 0,-24
  hist_avgflag_pertape = 'A','A'
  check_finidat_year_consistency = .false.
- finidat = '${DIN_LOC_ROOT}/lnd/clm2/initdata_map/clmi.WCYCL1850.northamericax4v1pg2_WC14to60E2r3.SMS_PS.c20230213.nc'
+! finidat = '${DIN_LOC_ROOT}/lnd/clm2/initdata_map/clmi.WCYCL1850.northamericax4v1pg2_WC14to60E2r3.SMS_PS.c20230213.nc'

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -791,6 +791,8 @@ if ( (($chem ne 'none') && ($chem ne 'spa')) or ( $prog_species ) ){
       add_default($nl, 'clim_soilw_file' );
       add_default($nl, 'season_wes_file' );
     }
+
+    add_default($nl, 'lght_no_prd_factor' );
 }
 
 # Initial conditions

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1862,13 +1862,15 @@ with se_tstep, dt_remap_factor, dt_tracer_factor set to -1
 <clubb_C14 phys="default"> 2.5D0      </clubb_C14>
 <clubb_tk1 phys="default"> 268.15D0   </clubb_tk1>
 <dust_emis_fact phys="default"> 12.8D0     </dust_emis_fact>
-<linoz_psc_T               > 198.0      </linoz_psc_T>
+<linoz_psc_T               > 198.0D0    </linoz_psc_T>
+<lght_no_prd_factor        > 5.0D0    </lght_no_prd_factor>
 <micro_mincdnc phys="default" microphys="mg2"> 10.D6      </micro_mincdnc>
 <nucleate_ice_subgrid phys="default" clubb_sgs="1" microphys="p3" >1.35D0</nucleate_ice_subgrid>
 <sscav_tuning phys="default" microphys="p3">.false.</sscav_tuning>
 <p3_mincdnc phys="default" microphys="p3"> 20.D6      </p3_mincdnc>
 <p3_wbf_coeff phys="default" clubb_sgs="1" microphys="p3"> 1.0      </p3_wbf_coeff>
 <p3_nc_autocon_expon  phys="default" clubb_sgs="1" microphys="p3">  -1.20D0   </p3_nc_autocon_expon>
+<n_so4_monolayers_pcage  phys="default" clubb_sgs="1" microphys="p3">  3.0D0   </n_so4_monolayers_pcage>
 <clubb_C1 phys="default"> 2.4        </clubb_C1>
 <clubb_C11 phys="default"> 0.70       </clubb_C11>
 <clubb_C11b phys="default"> 0.20       </clubb_C11b>
@@ -1892,7 +1894,7 @@ with se_tstep, dt_remap_factor, dt_tracer_factor set to -1
 <seasalt_emis_scale phys="default" chem="linoz_mam4_resus_mom_soag"> 0.6D0      </seasalt_emis_scale>
 <seasalt_emis_scale phys="default" chem="superfast_mam4_resus_mom_soag"> 0.6D0  </seasalt_emis_scale>
 <seasalt_emis_scale phys="default" chem="chemuci_linozv3_mam5_vbs"> 0.55D0 </seasalt_emis_scale>
-<dms_emis_scale phys="default"> 1.0D0 </dms_emis_scale>
+<dms_emis_scale phys="default"> 2.0D0 </dms_emis_scale>
 <zmconv_trigdcape_ull phys="default"> .true.     </zmconv_trigdcape_ull>
 <zmconv_c0_lnd phys="default" clubb_sgs="1" microphys="p3"> 0.0020D0   </zmconv_c0_lnd>
 <zmconv_c0_ocn phys="default" clubb_sgs="1" microphys="p3"> 0.0020D0   </zmconv_c0_ocn>

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/wcprod_F2010/user_nl_elm
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/wcprod_F2010/user_nl_elm
@@ -1,4 +1,5 @@
- finidat = '${DIN_LOC_ROOT}/lnd/clm2/initdata_map/clmi.F2010.ne30pg2_r05_oECv3.SMS_Ln5.c20230213.nc'
+! finidat below not compatitle with new t05 fsurdat with _TOP scheme. This test to be replaced later
+! finidat = '${DIN_LOC_ROOT}/lnd/clm2/initdata_map/clmi.F2010.ne30pg2_r05_oECv3.SMS_Ln5.c20230213.nc'
  hist_dov2xy = .true.,.true.
  hist_fincl2 = 'H2OSNO', 'FSNO', 'QRUNOFF', 'QSNOMELT', 'FSNO_EFF', 'SNORDSL', 'SNOW', 'FSDS', 'FSR', 'FLDS', 'FIRE', 'FIRA'
  hist_mfilt = 1,365

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/wcprod_F20TR/user_nl_elm
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/wcprod_F20TR/user_nl_elm
@@ -1,4 +1,5 @@
- finidat = '${DIN_LOC_ROOT}/lnd/clm2/initdata_map/clmi.F20TR.ne30pg2_r05_oECv3.SMS.c20230213.nc'
+! finidat below not compatitle with new t05 fsurdat with _TOP scheme. This test to be replaced later
+! finidat = '${DIN_LOC_ROOT}/lnd/clm2/initdata_map/clmi.F2010.ne30pg2_r05_oECv3.SMS_Ln5.c20230213.nc'
  hist_dov2xy = .true.,.true.
  hist_fincl2 = 'H2OSNO', 'FSNO', 'QRUNOFF', 'QSNOMELT', 'FSNO_EFF', 'SNORDSL', 'SNOW', 'FSDS', 'FSR', 'FLDS', 'FIRE', 'FIRA'
  hist_mfilt = 1,365

--- a/components/elm/bld/ELMBuildNamelist.pm
+++ b/components/elm/bld/ELMBuildNamelist.pm
@@ -1103,7 +1103,7 @@ sub setup_cmdl_solar_rad_scheme {
   my $val;
 
   # If "-solar_rad_scheme pp" or "-solar_rad_scheme" is unspecified, then
-  # we will set "use_top_solar_rad = .true."
+  # we will set "use_top_solar_rad = .false."
   if ( $opts->{$var} eq "pp" || $opts->{$var} eq "default" ) {
     $val = ".false.";
   } else {

--- a/components/elm/bld/ELMBuildNamelist.pm
+++ b/components/elm/bld/ELMBuildNamelist.pm
@@ -237,6 +237,9 @@ OPTIONS
      -vichydro                Toggle to turn on VIC hydrologic parameterizations (default is off)
                               This turns on the namelist variable: use_vichydro
      -betr_mode               Turn on betr model for tracer transport in soil. [on|off] default is off.
+     -solar_rad_scheme "value"  Type of solar radiation scheme
+                                pp = Plane-Parallel
+                                top = Subgrid topographic parameterization
 
 
 Note: The precedence for setting the values of namelist variables is (highest to lowest):
@@ -305,6 +308,7 @@ sub process_commandline {
                nutrient              => "default",
                nutrient_comp_pathway => "default",
                soil_decomp           => "default",
+               solar_rad_scheme      => "default",
              );
 
   GetOptions(
@@ -356,6 +360,7 @@ sub process_commandline {
              "nutrient=s"                => \$opts{'nutrient'},
              "nutrient_comp_pathway=s"   => \$opts{'nutrient_comp_pathway'},
              "soil_decomp=s"             => \$opts{'soil_decomp'},
+             "solar_rad_scheme=s"        => \$opts{'solar_rad_scheme'},
             )  or usage();
 
   # Give usage message.
@@ -679,6 +684,7 @@ sub process_namelist_commandline_options {
   setup_cmdl_bgc_spinup($opts, $nl_flags, $definition, $defaults, $nl, $cfg, $physv);
   setup_cmdl_vichydro($opts, $nl_flags, $definition, $defaults, $nl, $physv);
   setup_cmdl_betr_mode($opts, $nl_flags, $definition, $defaults, $nl, $physv);
+  setup_cmdl_solar_rad_scheme($opts, $nl_flags, $definition, $defaults, $nl, $cfg, $physv);
 }
 
 #-------------------------------------------------------------------------------
@@ -1085,6 +1091,50 @@ sub setup_cmdl_methane {
         }
     }
   }
+}
+
+#-------------------------------------------------------------------------------
+
+sub setup_cmdl_solar_rad_scheme {
+
+  my ($opts, $nl_flags, $definition, $defaults, $nl, $cfg, $physv) = @_;
+
+  my $var = "solar_rad_scheme";
+  my $val;
+
+  # If "-solar_rad_scheme pp" or "-solar_rad_scheme" is unspecified, then
+  # we will set "use_top_solar_rad = .true."
+  if ( $opts->{$var} eq "pp" || $opts->{$var} eq "default" ) {
+    $val = ".false.";
+  } else {
+    # For "-solar_rad_scheme top", set "use_top_solar_rad = .true."
+    if ( $opts->{$var} eq "top" ) {
+      $val = ".true.";
+    } else {
+      fatal_error("The -solar_rad_scheme $opts->{'solar_rad_scheme'} is unknown");
+    }
+  }
+
+  my $var='use_top_solar_rad';
+  # Check if the value of use_top_solar_rad based on above alogrithm does not match the
+  # value of use_top_solar_rad in user_nl_elm
+  if (defined($nl->get_value($var)) && $nl->get_value($var) ne $val) {
+
+    # If "-solar_rad_scheme <pp|top>" was not specified, then simply use the value
+    # that was specified in the "user_nl_elm".
+    if ($opts->{'solar_rad_scheme'} eq "default") {
+      $val = $nl->get_value($var);
+    } else {
+      # Otherwise report an error
+      my $namelist_value = $nl->get_value('use_top_solar_rad');
+      fatal_error("$var = $namelist_value, which is inconsistent with the commandline setting of -solar_rad_scheme $opts->{'solar_rad_scheme'}");
+    }
+  }
+
+  # Lastly, define the value of use_top_solar_rad
+  my $group = $definition->get_group_name($var);
+  $nl->set_variable_value($group, $var, $val);
+
 }
 
 #-------------------------------------------------------------------------------

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -283,9 +283,9 @@ lnd/clm2/surfdata_map/surfdata_ne30np4_simyr2010_c20181025.nc</fsurdat>
 <fsurdat hgrid="r0125"   sim_year="2010" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_0.125x0.125_simyr2010_c191025.nc</fsurdat>
 <fsurdat hgrid="r05"   sim_year="2010" use_crop=".false." >
-lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr2010_c191025.nc</fsurdat>
+lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr2010_c230922_with_TOP.nc</fsurdat>
 <fsurdat hgrid="ne30np4.pg2"   sim_year="2010" use_crop=".false." >
-lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr2010_c210402.nc</fsurdat>
+lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr2010_c210402_with_TOP.nc</fsurdat>
 <fsurdat hgrid="ne120np4"     sim_year="2010" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_ne120np4_simyr2010_c20181023.nc</fsurdat>
 <fsurdat hgrid="ne120np4.pg2" sim_year="2010" use_crop=".false." >
@@ -405,7 +405,7 @@ lnd/clm2/surfdata_map/surfdata_1x1_brazil_simyr1850_c140610.nc</fsurdat>
 lnd/clm2/surfdata_map/surfdata_ne30np4_simyr1850_c180306.nc</fsurdat>
 
 <fsurdat hgrid="ne30np4.pg2"   sim_year="1850" use_crop=".false." >
-lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr1850_c210402.nc</fsurdat>
+lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr1850_c230417_with_TOP.nc</fsurdat>
 
 <fsurdat hgrid="ne30np4.pg2"   sim_year="1950" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr1950_c210729.nc</fsurdat>
@@ -423,7 +423,7 @@ lnd/clm2/surfdata_map/surfdata_ne4pg2_simyr1850_c210722.nc</fsurdat>
 <fsurdat hgrid="ne240np4"      sim_year="1850" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_ne240np4_simyr1850_c170821.nc</fsurdat>
 <fsurdat hgrid="r05"          sim_year="1850" use_crop=".false." use_cn=".false.">
-lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr1850_c200609.nc</fsurdat>
+lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr1850_c200609_with_TOP.nc</fsurdat>
 <fsurdat hgrid="r05"          sim_year="1850" use_crop=".false." use_cn=".true.">
 lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr1850_c211019.nc</fsurdat>
 <fsurdat hgrid="r0125"        sim_year="1850" use_crop=".false." >

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -149,7 +149,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- HOMME grid ne11 resolution -->
 
 <finidat hgrid="ne11np4"   maxpft="17"  mask="oQU240" use_cn=".false." ic_ymd="18500101" more_vertlayers=".false."
- ic_tod="0" sim_year="1850" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/clmi.I1850CLM45.ne11_oQU240.67a0f98.1850-01-07-00000.nc
+ ic_tod="0" sim_year="1850" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map/clmi.I1850CLM45.ne11_oQU240.daaba0d.1850-01-07-00000.nc
 </finidat>
 
 <finidat hgrid="ne11np4"   maxpft="17"  mask="oQU240" use_cn=".false." ic_ymd="20000101" more_vertlayers=".false."
@@ -225,7 +225,7 @@ ic_tod="0" sim_year="2000" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map
 
 <!-- ne0np4_northamericax4v1.pg2 -->
 <fsurdat hgrid="ne0np4_northamericax4v1.pg2"   sim_year="1850" use_crop=".false." >
-lnd/clm2/surfdata_map/surfdata_ne0np4_northamericax4v1.pg2_simyr1850_c210112.nc</fsurdat>
+lnd/clm2/surfdata_map/surfdata_ne0np4_northamericax4v1.pg2_simyr1850_c210112_with_TOP.nc</fsurdat>
 
 <fsurdat hgrid="ne0np4_northamericax4v1.pg2"   sim_year="2010" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_ne0np4_northamericax4v1.pg2_simyr2010_c210112.nc</fsurdat>
@@ -277,7 +277,7 @@ ic_tod="0" sim_year="2000" glc_nec="0" use_crop=".true." irrigate=".true." nu_co
 
 <!-- for present day simulations - year 2010 -->
 <fsurdat hgrid="ne4np4"   sim_year="2010" use_crop=".false." >
-lnd/clm2/surfdata_map/surfdata_ne4np4_simyr2010_c210908.nc</fsurdat>
+lnd/clm2/surfdata_map/surfdata_ne4np4_simyr2010_c210908_with_TOP.nc</fsurdat>
 <fsurdat hgrid="ne30np4"   sim_year="2010" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_ne30np4_simyr2010_c20181025.nc</fsurdat>
 <fsurdat hgrid="r0125"   sim_year="2010" use_crop=".false." >
@@ -333,9 +333,9 @@ lnd/clm2/surfdata_map/surfdata_ne11np4_simyr2000_c160614.nc</fsurdat>
 <fsurdat hgrid="ne4np4"      sim_year="2000" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_ne4np4_simyr2000_c160614.nc</fsurdat>
 <fsurdat hgrid="ne4np4.pg2" sim_year="2000" >
-lnd/clm2/surfdata_map/surfdata_ne4pg2_simyr2000_c190620.nc</fsurdat>
+lnd/clm2/surfdata_map/surfdata_ne4pg2_simyr2000_c190620_with_TOP.nc</fsurdat>
 <fsurdat hgrid="ne4np4.pg2" sim_year="2010" >
-lnd/clm2/surfdata_map/surfdata_ne4pg2_simyr2000_c190620.nc</fsurdat>
+lnd/clm2/surfdata_map/surfdata_ne4pg2_simyr2000_c190620_with_TOP.nc</fsurdat>
 <fsurdat hgrid="ne240np4"      sim_year="2000" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_ne240np4_simyr2000_c170821.nc</fsurdat>
 <fsurdat hgrid="ne256np4"      sim_year="2000" use_crop=".false." >
@@ -415,7 +415,7 @@ lnd/clm2/surfdata_map/surfdata_ne16np4_simyr1850_c160108.nc</fsurdat>
 <fsurdat hgrid="ne120np4"     sim_year="1850" >
 lnd/clm2/surfdata_map/surfdata_ne120np4_simyr1850_c160211.nc</fsurdat>
 <fsurdat hgrid="ne11np4"      sim_year="1850" use_crop=".false." >
-lnd/clm2/surfdata_map/surfdata_ne11np4_simyr1850_c160614.nc</fsurdat>
+lnd/clm2/surfdata_map/surfdata_ne11np4_simyr1850_c160614_with_TOP.nc</fsurdat>
 <fsurdat hgrid="ne4np4"      sim_year="1850" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_ne4np4_simyr1850_c160614.nc</fsurdat>
 <fsurdat hgrid="ne4np4.pg2"  sim_year="1850" >

--- a/components/elm/bld/namelist_files/use_cases/2015-2100_SSP370_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/2015-2100_SSP370_transient.xml
@@ -32,7 +32,7 @@
 
 <!-- CMIP6 DECK compsets -->
 
-<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_SSP3_RCP70_simyr2015_c220420.nc </fsurdat>
+<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_SSP3_RCP70_simyr2015_c220420_with_TOP.nc </fsurdat>
 <flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30pg2_SSP3_RCP70_simyr2015-2100_c211015.nc</flanduse_timeseries>
 
 <!-- Add following for hybrid run of SSP370 continuing from a historical simulation -->

--- a/components/elm/bld/namelist_files/use_cases/2015-2100_SSP585_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/2015-2100_SSP585_transient.xml
@@ -32,7 +32,7 @@
 
 <!-- CMIP6 DECK compsets -->
 
-<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_SSP5_RCP85_simyr2015_c220420.nc </fsurdat>
+<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_SSP5_RCP85_simyr2015_c220420_TOP.nc </fsurdat>
 <flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30pg2_SSP5_RCP85_simyr2015-2100_c220310.nc</flanduse_timeseries>
 
 <!-- Add following for hybrid run of SSP370 continuing from a historical simulation -->

--- a/components/elm/bld/namelist_files/use_cases/2015-2100_SSP585_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/2015-2100_SSP585_transient.xml
@@ -32,7 +32,7 @@
 
 <!-- CMIP6 DECK compsets -->
 
-<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_SSP5_RCP85_simyr2015_c220420_TOP.nc </fsurdat>
+<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_SSP5_RCP85_simyr2015_c220420_with_TOP.nc </fsurdat>
 <flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30pg2_SSP5_RCP85_simyr2015-2100_c220310.nc</flanduse_timeseries>
 
 <!-- Add following for hybrid run of SSP370 continuing from a historical simulation -->

--- a/components/elm/bld/namelist_files/use_cases/20thC_CMIP6_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/20thC_CMIP6_transient.xml
@@ -41,7 +41,7 @@
 
 <fsurdat hgrid="r0125">lnd/clm2/surfdata_map/surfdata_0.125x0.125_simyr1850_c190730.nc</fsurdat>
 
-<fsurdat hgrid="r05">lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr1850_c190418.nc</fsurdat>
+<fsurdat hgrid="r05">lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr1850_c200609_with_TOP.nc</fsurdat>
 
 <check_finidat_year_consistency>.false.</check_finidat_year_consistency>
 <check_dynpft_consistency>.false.</check_dynpft_consistency>

--- a/components/elm/cime_config/config_component.xml
+++ b/components/elm/cime_config/config_component.xml
@@ -112,6 +112,7 @@
       <value compset="_ELM%[^_]*SP"        >-bgc sp</value>
       <value compset="_ELM%[^_]*TOP"       >-solar_rad_scheme top</value>
       <value compset="_ELM%[^_]*SPBC"      >-bgc sp</value>
+      <value compset="_EAM%CMIP6_ELM%[^_]*SPBC" >-bgc sp -solar_rad_scheme top</value>
       <value compset="_ELM%[^_]*CN"        >-bgc cn</value>
       <value compset="_ELM%[^_]*BGC"       >-bgc bgc</value>
       <value compset="_ELM%[^_]*CN-CROP"   >-bgc cn -crop</value>

--- a/components/elm/cime_config/config_component.xml
+++ b/components/elm/cime_config/config_component.xml
@@ -110,6 +110,7 @@
     <values>
       <value compset="%CNCR"                 >-ignore_ic_year</value>  <!-- ERROR: Never matched, see bug 2025 -->
       <value compset="_ELM%[^_]*SP"        >-bgc sp</value>
+      <value compset="_ELM%[^_]*TOP"       >-solar_rad_scheme top</value>
       <value compset="_ELM%[^_]*SPBC"      >-bgc sp</value>
       <value compset="_ELM%[^_]*CN"        >-bgc cn</value>
       <value compset="_ELM%[^_]*BGC"       >-bgc bgc</value>

--- a/components/mpas-seaice/src/shared/mpas_seaice_advection_incremental_remap.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_advection_incremental_remap.F
@@ -4689,7 +4689,7 @@ contains
          cxxx,  cxxy,  cxyy,  cyyy,   &
          cxxxx, cxxxy, cxxyy, cxyyy, cyyyy
 
-    real(kind=RKIND) ::  massTracerProd
+    real(kind=RKIND) :: reciprocal, massTracerProd
 
     ! compute the barycenter coordinates, depending on how many tracer types were passed in
     ! Note: These formulas become more complex as the tracer hierarchy deepens.  See the model documentation for details.
@@ -4706,18 +4706,18 @@ contains
        c0 = center0
        cx = xGrad0
        cy = yGrad0
-
-       xBarycenter = 0.0_RKIND
-       yBarycenter = 0.0_RKIND
        if (abs(mean0) > 0.0_RKIND) then
-          xBarycenter = (c0 * geomAvgCell % x (iCell)  &
-                       + cx * geomAvgCell % xx(iCell)  + cy * geomAvgCell % xy(iCell))  &
-                       / mean0
-          yBarycenter = (c0 * geomAvgCell % y (iCell)  &
-                       + cx * geomAvgCell % xy(iCell)  + cy * geomAvgCell % yy(iCell))  &
-                       / mean0
+          reciprocal = 1.0_RKIND / mean0
+       else
+          reciprocal = 0.0_RKIND
        endif
 
+       xBarycenter = (c0 * geomAvgCell % x (iCell)  &
+                    + cx * geomAvgCell % xx(iCell)  + cy * geomAvgCell % xy(iCell))  &
+                    * reciprocal
+       yBarycenter = (c0 * geomAvgCell % y (iCell)  &
+                    + cx * geomAvgCell % xy(iCell)  + cy * geomAvgCell % yy(iCell))  &
+                    * reciprocal
 
     elseif (.not.present(mean2)) then
 
@@ -4730,19 +4730,21 @@ contains
        cxy = xGrad0  * yGrad1  + yGrad0  * xGrad1
        cyy = yGrad0  * yGrad1
 
-       xBarycenter = 0.0_RKIND
-       yBarycenter = 0.0_RKIND
        massTracerProd = mean0 * mean1
        if (abs(massTracerProd) > 0.0_RKIND) then
-          xBarycenter = (c0  * geomAvgCell % x  (iCell) &
-                       + cx  * geomAvgCell % xx (iCell) + cy  * geomAvgCell % xy (iCell)  &
-                       + cxx * geomAvgCell % xxx(iCell) + cxy * geomAvgCell % xxy(iCell) + cyy * geomAvgCell % xyy(iCell)) &
-                       / massTracerProd
-          yBarycenter = (c0  * geomAvgCell % y  (iCell) &
-                       + cx  * geomAvgCell % xy (iCell) + cy  * geomAvgCell % yy (iCell)  &
-                       + cxx * geomAvgCell % xxy(iCell) + cxy * geomAvgCell % xyy(iCell) + cyy * geomAvgCell % yyy(iCell)) &
-                       / massTracerProd
+          reciprocal = 1.0_RKIND / massTracerProd
+       else
+          reciprocal = 0.0_RKIND
        endif
+
+       xBarycenter = (c0  * geomAvgCell % x  (iCell) &
+                    + cx  * geomAvgCell % xx (iCell) + cy  * geomAvgCell % xy (iCell)  &
+                    + cxx * geomAvgCell % xxx(iCell) + cxy * geomAvgCell % xxy(iCell) + cyy * geomAvgCell % xyy(iCell)) &
+                    * reciprocal
+       yBarycenter = (c0  * geomAvgCell % y  (iCell) &
+                    + cx  * geomAvgCell % xy (iCell) + cy  * geomAvgCell % yy (iCell)  &
+                    + cxx * geomAvgCell % xxy(iCell) + cxy * geomAvgCell % xyy(iCell) + cyy * geomAvgCell % yyy(iCell)) &
+                    * reciprocal
 
     else  ! mass field, tracer1 and tracer2 are all present
 
@@ -4760,23 +4762,25 @@ contains
        cxyy  = yGrad0  * yGrad1  * xGrad2   + yGrad0  * xGrad1  * yGrad2  + xGrad0  * yGrad1  * yGrad2
        cyyy  = yGrad0  * yGrad1  * yGrad2
 
-       xBarycenter = 0.0_RKIND
-       yBarycenter = 0.0_RKIND
        massTracerProd = mean0 * mean1 * mean2
        if (abs(massTracerProd) > 0.0_RKIND) then
-          xBarycenter = (c0   * geomAvgCell % x   (iCell) &
-                       + cx   * geomAvgCell % xx  (iCell) + cy   * geomAvgCell % xy  (iCell) &
-                       + cxx  * geomAvgCell % xxx (iCell) + cxy  * geomAvgCell % xxy (iCell) + cyy  * geomAvgCell % xyy (iCell) &
-                       + cxxx * geomAvgCell % xxxx(iCell) + cxxy * geomAvgCell % xxxy(iCell) + cxyy * geomAvgCell % xxyy(iCell) &
-                                                                                             + cyyy * geomAvgCell % xyyy(iCell)) &
-                       / massTracerProd
-          yBarycenter = (c0   * geomAvgCell % y   (iCell) &
-                       + cx   * geomAvgCell % xy  (iCell) + cy   * geomAvgCell % yy  (iCell) &
-                       + cxx  * geomAvgCell % xxy (iCell) + cxy  * geomAvgCell % xyy (iCell) + cyy  * geomAvgCell % yyy (iCell) &
-                       + cxxx * geomAvgCell % xxxy(iCell) + cxxy * geomAvgCell % xxyy(iCell) + cxyy * geomAvgCell % xyyy(iCell) &
-                                                                                             + cyyy * geomAvgCell % yyyy(iCell)) &
-                       / massTracerProd
+          reciprocal = 1.0_RKIND / massTracerProd
+       else
+          reciprocal = 0.0_RKIND
        endif
+
+       xBarycenter = (c0   * geomAvgCell % x   (iCell) &
+                    + cx   * geomAvgCell % xx  (iCell) + cy   * geomAvgCell % xy  (iCell) &
+                    + cxx  * geomAvgCell % xxx (iCell) + cxy  * geomAvgCell % xxy (iCell) + cyy  * geomAvgCell % xyy (iCell) &
+                    + cxxx * geomAvgCell % xxxx(iCell) + cxxy * geomAvgCell % xxxy(iCell) + cxyy * geomAvgCell % xxyy(iCell) &
+                                                                                          + cyyy * geomAvgCell % xyyy(iCell)) &
+                    * reciprocal
+       yBarycenter = (c0   * geomAvgCell % y   (iCell) &
+                    + cx   * geomAvgCell % xy  (iCell) + cy   * geomAvgCell % yy  (iCell) &
+                    + cxx  * geomAvgCell % xxy (iCell) + cxy  * geomAvgCell % xyy (iCell) + cyy  * geomAvgCell % yyy (iCell) &
+                    + cxxx * geomAvgCell % xxxy(iCell) + cxxy * geomAvgCell % xxyy(iCell) + cxyy * geomAvgCell % xyyy(iCell) &
+                                                                                          + cyyy * geomAvgCell % yyyy(iCell)) &
+                    * reciprocal
 
     endif
 


### PR DESCRIPTION
To set default the extra parameters for atm and lnd used by v3alpha03 configuration.
The merge of this PR should create a state ready for tagging v3alpha03.

Land surface data for WCYCL config are updated to enable subgrid topographic
radiative parameterization (TOP). The surfdata files for simyr 1850 and 2010 are fully
ready for ne30pg2 and r05 grids. Workaround are applied for F2010 ne4, ne4pg2, ne11
grids, 1850 NARRM, and SSP370 and SSP585 ne30pg2 grid, with placeholder for 
TOP-related variables. The TOP developers will update these files. 

Land initial files for several wcprod F2010 and F20R tests with older trigrid are disabled.
The trigrid for the tests will be updated at a later time along with new initial files.

[non-BFB] for all F and B-cases.
[NML] extra default namelist variables in atm_in and lnd_in along with some update on input files

------------------
The change on elm to enable use_top_solar_rad for water cycle production config to be added.

#5252 is temporarily reverted in order for the target v3alpha03 tag to reproduce coupled v3alpha03 simulation. It will be restored after  this and a similar PR for wrapping up v3alpha04 config are merged. With proper reproducibility tests done, all these PRs (including revert the revert of #5252) should happen on the same day, to avoid repeated diffs for the same cime tests.