### PR TITLE
Fix MMF heating for convective gravity wave scheme

### DIFF
--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -1587,7 +1587,7 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf2d, cam_in, cam_out, 
          end do
 
 #if defined(MMF_PAM)
-         ! Currently PAM is coupled the CRM to all levels, so only add rad to levels above CRM
+         ! Currently PAM is coupled at all levels, so only add rad to levels above CRM top
          ptend(c)%s(1:ncol, 1:pver-crm_nz) = qrs(1:ncol,1:pver-crm_nz) + qrl(1:ncol,1:pver-crm_nz)
 #else
          ! The radiation tendencies in the GCM levels above the CRM and the top 2 CRM levels are set to
@@ -1606,6 +1606,8 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf2d, cam_in, cam_out, 
          !------------------------------------------------------------------------------------------
          ! set convective heating tendency for gravity wave drag
          !------------------------------------------------------------------------------------------
+         ! Subtract radiation from all levels so only convective heating is used for the
+         ! convective gravityw ave scheme, consistent with standard EAM w/ ZM
          if (ttend_dp_idx > 0) then
             call pbuf_get_field(pbuf_chunk, ttend_dp_idx, ttend_dp)
             ttend_dp(1:ncol,1:pver) = ( ptend(c)%s(1:ncol,:pver) - qrs(1:ncol,:pver) - qrl(1:ncol,:pver) )/cpair

--- a/components/eam/src/physics/crm/crm_physics.F90
+++ b/components/eam/src/physics/crm/crm_physics.F90
@@ -1574,14 +1574,6 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf2d, cam_in, cam_out, 
          end if
 
          !------------------------------------------------------------------------------------------
-         ! set convective heating tendency for gravity wave drag
-         !------------------------------------------------------------------------------------------
-         if (ttend_dp_idx > 0) then
-            call pbuf_get_field(pbuf_chunk, ttend_dp_idx, ttend_dp)
-            ttend_dp(1:ncol,1:pver) = ptend(c)%s(1:ncol,1:pver)/cpair
-         end if
-
-         !------------------------------------------------------------------------------------------
          ! Add radiative heating tendency above CRM
          !------------------------------------------------------------------------------------------
          call pbuf_get_field(pbuf_chunk, pbuf_get_index('QRL'), qrl)
@@ -1610,6 +1602,14 @@ subroutine crm_physics_tend(ztodt, state, tend, ptend, pbuf2d, cam_in, cam_out, 
                mmf_rad_flux(c,i) = mmf_rad_flux(c,i) + ( qrs(i,k) + qrl(i,k) ) * state(c)%pdel(i,k)/gravit
             end do
          end do
+
+         !------------------------------------------------------------------------------------------
+         ! set convective heating tendency for gravity wave drag
+         !------------------------------------------------------------------------------------------
+         if (ttend_dp_idx > 0) then
+            call pbuf_get_field(pbuf_chunk, ttend_dp_idx, ttend_dp)
+            ttend_dp(1:ncol,1:pver) = ( ptend(c)%s(1:ncol,:pver) - qrs(1:ncol,:pver) - qrl(1:ncol,:pver) )/cpair
+         end if
 
          !------------------------------------------------------------------------------------------
          ! CRM cloud/precip output


### PR DESCRIPTION
Previously the MMF heating tendency used for the convective gravity wave parameterization included the effect of radiation. This moves the calculation so that radiative heating can be removed at all levels.

[non-BFB] for all MMF tests