### PR TITLE
Drop CICE from MMF compsets

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -272,7 +272,7 @@ _TESTS = {
             "SMS.T62_oQU120_ais20.MPAS_LISIO_TEST",
             "SMS.f09_g16_a.IGELM_MLI",
             "SMS_P12x2.ne4_oQU240.WCYCL1850NS.allactive-mach_mods",
-            "ERS_Ln9.ne4pg2_ne4pg2.F2010-MMF1.eam-mmf_crmout",
+            "ERS_Ln9.ne4pg2_oQU480.F2010-MMF1.eam-mmf_crmout",
             )
         },
 
@@ -337,9 +337,9 @@ _TESTS = {
     "e3sm_mmf_integration" : {
         "tests" : (
             "ERP_Ln9.ne4pg2_oQU480.WCYCL20TRNS-MMF1.allactive-mmf_fixed_subcycle",
-            "ERS_Ln9.ne4pg2_ne4pg2.FRCE-MMF1.eam-cosp_nhtfrq9",
+            "ERS_Ln9.ne4pg2_oQU480.FRCE-MMF1.eam-cosp_nhtfrq9",
             "SMS_Ln5.ne4_ne4.FSCM-ARM97-MMF1",
-            "SMS_Ln3.ne4pg2_ne4pg2.F2010-MMF2",
+            "SMS_Ln3.ne4pg2_oQU480.F2010-MMF2",
             )
         },
 
@@ -648,7 +648,7 @@ _TESTS = {
 
     "e3sm_gpucxx" : {
         "tests"    : (
-                 "SMS_Ln9.ne4pg2_ne4pg2.F2010-MMF1",
+                 "SMS_Ln9.ne4pg2_oQU480.F2010-MMF1",
                  )
     },
 

--- a/components/eam/cime_config/config_compsets.xml
+++ b/components/eam/cime_config/config_compsets.xml
@@ -133,27 +133,27 @@
 
   <compset>
     <alias>FSCM-ARM97-MMF1</alias>
-    <lname>ARM97_EAM%SCM-MMF1_ELM%SP_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+    <lname>ARM97_EAM%SCM-MMF1_ELM%SP_SICE_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>FSCM-ARM97-MMF2</alias>
-    <lname>ARM97_EAM%SCM-MMF2_ELM%SP_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+    <lname>ARM97_EAM%SCM-MMF2_ELM%SP_SICE_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>FSCM-ARM97-MMF2-AWFL</alias>
-    <lname>ARM97_EAM%SCM-MMF2-AWFL_ELM%SP_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+    <lname>ARM97_EAM%SCM-MMF2-AWFL_ELM%SP_SICE_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>FSCM-RICO-MMF1</alias>
-    <lname>RICO_EAM%SCM-MMF1_ELM%SP_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+    <lname>RICO_EAM%SCM-MMF1_ELM%SP_SICE_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>FSCM-RICO-MMF2</alias>
-    <lname>RICO_EAM%SCM-MMF2_ELM%SP_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+    <lname>RICO_EAM%SCM-MMF2_ELM%SP_SICE_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
 
   <!-- ************************************************* -->
@@ -306,17 +306,17 @@
   <!-- F compsets with climatological SST -->
   <compset>
     <alias>F2010-MMF1</alias>
-    <lname>2010_EAM%MMF1_ELM%SP_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+    <lname>2010_EAM%MMF1_ELM%SP_MPASSI%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>F2010-MMF2</alias>
-    <lname>2010_EAM%MMF2_ELM%SP_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+    <lname>2010_EAM%MMF2_ELM%SP_MPASSI%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>F2010-MMF2-AWFL</alias>
-    <lname>2010_EAM%MMF2-AWFL_ELM%SP_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
+    <lname>2010_EAM%MMF2-AWFL_ELM%SP_MPASSI%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
 
   <!-- F compsets with transient SST (AMIP) -->


### PR DESCRIPTION
Remove CICE dependency from MMF compsets to prepare for upcoming CICE deprecation