### PR TITLE
add hdepth scaling factor for convective gravity waves

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -827,6 +827,7 @@ add_default($nl,'ieflx_opt');
 add_default($nl,'use_hetfrz_classnuc');
 add_default($nl,'hist_hetfrz_classnuc');
 add_default($nl,'gw_convect_hcf');
+add_default($nl,'hdepth_scaling_factor');
 add_default($nl,'linoz_psc_T');
 if ($cfg->get('microphys') =~ /^mg2/) {
     add_default($nl,'micro_mg_dcs_tdep');

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1863,6 +1863,7 @@ with se_tstep, dt_remap_factor, dt_tracer_factor set to -1
 <cld_sed phys="default" microphys="mg2"> 1.0D0      </cld_sed>
 <effgw_beres phys="default"> 0.35       </effgw_beres>
 <gw_convect_hcf               > 10.0       </gw_convect_hcf>
+<hdepth_scaling_factor        >  1.0       </hdepth_scaling_factor>
 <effgw_oro phys="default"> 0.375      </effgw_oro>
 <use_gw_energy_fix phys="default"> .true.      </use_gw_energy_fix>
 <clubb_C14 phys="default"> 2.5D0      </clubb_C14>

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -1084,6 +1084,12 @@ Heating rate conversion factor associated with convective gravity waves
 Default: 20.0
 </entry>
 
+<entry id="hdepth_scaling_factor" type="real" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+Scaling factor for the heating depth
+Default: 1.0
+</entry>
+
 <entry id="effgw_beres" type="real" category="gw_drag"
        group="gw_drag_nl" valid_values="" >
 Efficiency associated with convective gravity waves from the Beres

--- a/components/eam/src/physics/cam/gw_convect.F90
+++ b/components/eam/src/physics/cam/gw_convect.F90
@@ -92,6 +92,9 @@ subroutine gw_beres_src(ncol, ngwv, lat, u, v, netdt, &
   ! Heating conversion factor
   real(r8), intent(in) :: CF
 
+  ! Scaling factor for the heating depth
+  real(r8), intent(in) :: hdepth_scaling_factor
+
   ! Indices of top gravity wave source level and lowest level where wind
   ! tendencies are allowed.
   integer, intent(out) :: src_level(ncol)
@@ -108,9 +111,6 @@ subroutine gw_beres_src(ncol, ngwv, lat, u, v, netdt, &
 
   ! Heating depth and maximum heating in each column.
   real(r8), intent(out) :: hdepth(ncol), maxq0(ncol)
-
-  ! Scaling factor for the heating depth
-  real(r8), intent(out) :: hdepth_scaling_factor
 
 !---------------------------Local Storage-------------------------------
   ! Column and level indices.

--- a/components/eam/src/physics/cam/gw_convect.F90
+++ b/components/eam/src/physics/cam/gw_convect.F90
@@ -60,7 +60,7 @@ end subroutine gw_convect_init
 
 subroutine gw_beres_src(ncol, ngwv, lat, u, v, netdt, &
      zm, src_level, tend_level, tau, ubm, ubi, xv, yv, c, &
-     hdepth, maxq0, CF)
+     hdepth, maxq0, CF, hdepth_scaling_factor)
 !-----------------------------------------------------------------------
 ! Driver for multiple gravity wave drag parameterization.
 !
@@ -108,6 +108,9 @@ subroutine gw_beres_src(ncol, ngwv, lat, u, v, netdt, &
 
   ! Heating depth and maximum heating in each column.
   real(r8), intent(out) :: hdepth(ncol), maxq0(ncol)
+
+  ! Scaling factor for the heating depth
+  real(r8), intent(out) :: hdepth_scaling_factor
 
 !---------------------------Local Storage-------------------------------
   ! Column and level indices.
@@ -213,6 +216,9 @@ subroutine gw_beres_src(ncol, ngwv, lat, u, v, netdt, &
   hdepth = [ ( (zm(i,maxi(i))-zm(i,mini(i)))/1000._r8, i = 1, ncol ) ]
   ! Confine depth to table range.
   hdepth = min(hdepth, real(maxh, r8))
+
+  ! apply tunable scaling factor for the heating depth
+  hdepth = hdepth * hdepth_scaling_factor
 
   ! Maximum heating rate.
   do k = minval(maxi), maxval(mini)

--- a/components/eam/src/physics/cam/gw_drag.F90
+++ b/components/eam/src/physics/cam/gw_drag.F90
@@ -88,6 +88,9 @@ module gw_drag
   ! Convective heating rate conversion factor, default is 20.0_r8
   real(r8) :: gw_convect_hcf = 20.0_r8
 
+  ! Scaling factor for the heating depth
+  real(r8) :: hdepth_scaling_factor = 1
+
   ! Whether or not to enforce an upper boundary condition of tau = 0.
   ! (Like many variables, this is only here to hold the value between
   ! the readnl phase and the init phase of the CAM physics; only gw_common
@@ -137,7 +140,8 @@ subroutine gw_drag_readnl(nlfile)
   real(r8) :: gw_dc = unset_r8
 
   namelist /gw_drag_nl/ pgwv, gw_dc, tau_0_ubc, effgw_beres, effgw_cm, &
-      effgw_oro, fcrit2, frontgfc, gw_drag_file, taubgnd, gw_convect_hcf
+      effgw_oro, fcrit2, frontgfc, gw_drag_file, taubgnd, gw_convect_hcf, &
+      hdepth_scaling_factor
   !----------------------------------------------------------------------
 
   if (masterproc) then
@@ -167,6 +171,7 @@ subroutine gw_drag_readnl(nlfile)
   call mpibcast(taubgnd,     1, mpir8,  0, mpicom)
   call mpibcast(gw_drag_file, len(gw_drag_file), mpichar, 0, mpicom)
   call mpibcast(gw_convect_hcf, 1, mpir8,  0, mpicom)
+  call mpibcast(hdepth_scaling_factor, 1, mpir8,  0, mpicom)
 #endif
 
   dc = gw_dc
@@ -760,7 +765,7 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
         ! Determine wave sources for Beres04 scheme
         call gw_beres_src(ncol, pgwv, state1%lat(:ncol), u, v, ttend_dp, &
              zm, src_level, tend_level, tau, ubm, ubi, xv, yv, c, &
-             hdepth, maxq0, gw_convect_hcf)
+             hdepth, maxq0, gw_convect_hcf, hdepth_scaling_factor)
 
         do_latitude_taper = .false.
 


### PR DESCRIPTION
Adds a namelist variable "hdepth_scaling_factor" for the convective gravity wave scheme that will be needed for tuning the QBO in v3. The default value of 1 will retain the current behavior.

[BFB]
[NML] new nml variable hdepth_scaling_factor for all tests involving eam.