### PR TITLE
Refactor parameter read procedure in elmfates API to avoid FATES calling hlm-side procedures

### DIFF
--- a/components/elm/src/main/elm_initializeMod.F90
+++ b/components/elm/src/main/elm_initializeMod.F90
@@ -21,7 +21,7 @@ module elm_initializeMod
   use readParamsMod    , only : readSharedParameters, readPrivateParameters
   use ncdio_pio        , only : file_desc_t
   use ELMFatesInterfaceMod  , only : ELMFatesGlobals1,ELMFatesGlobals2
-  use CLMFatesParamInterfaceMod, only: FatesReadPFTs
+  use ELMFatesParamInterfaceMod, only: FatesReadPFTs
   use BeTRSimulationELM, only : create_betr_simulation_elm
   !
   !-----------------------------------------

--- a/components/elm/src/main/elmfates_interfaceMod.F90
+++ b/components/elm/src/main/elmfates_interfaceMod.F90
@@ -7,11 +7,9 @@ module ELMFatesInterfaceMod
    !
    ! This is also the only location where CLM code is allowed to see FATES memory
    ! structures.
-   ! The routines here, that call FATES library routines, will not pass any types defined
-   ! by the driving land model (HLM).
-   !
-   ! either native type arrays (int,real,log, etc) or packed into ED boundary condition
-   ! structures.
+   ! The routines here, that call FATES library routines, cannot pass most types defined
+   ! by the driving land model (HLM), only native type arrays (int,real,log, etc), implementations
+   ! of fates abstract classes, and references into fates boundary condition structures.
    !
    ! Note that CLM/ALM does use Shared Memory Parallelism (SMP), where processes such as
    ! the update of state variables are forked.  However, IO is not assumed to be
@@ -176,7 +174,10 @@ module ELMFatesInterfaceMod
    use dynSubgridControlMod, only : get_do_harvest ! this gets the namelist value
 
    use FatesInterfaceTypesMod , only : bc_in_type, bc_out_type
-   use CLMFatesParamInterfaceMod         , only : FatesReadParameters
+
+   use ELMFatesParamInterfaceMod, only : fates_param_reader_ctsm_impl
+   use FatesParametersInterface, only : fates_param_reader_type
+   use FatesParametersInterface, only : fates_parameters_type
    
    use perf_mod          , only : t_startf, t_stopf
 
@@ -292,6 +293,7 @@ contains
     integer                                        :: pass_sp
     integer                                        :: pass_masterproc
     logical                                        :: verbose_output
+    type(fates_param_reader_ctsm_impl)             :: var_reader
 
     if (use_fates) then
 
@@ -346,7 +348,7 @@ contains
     ! want fates to handle crops, so again, it should be ignored.
     ! (RGK 07-2022)
     
-    call SetFatesGlobalElements1(use_fates,natpft_size,0)
+    call SetFatesGlobalElements1(use_fates,natpft_size,0,var_reader)
 
     natpft_size = fates_maxPatchesPerSite
 
@@ -3452,6 +3454,6 @@ end subroutine wrap_update_hifrq_hist
 
  end subroutine GetAndSetTime
 
-
+ !-----------------------------------------------------------------------
 
 end module ELMFatesInterfaceMod


### PR DESCRIPTION
This PR refactors the elm-fates interface to avoid having fates call `elmfates_interfacemod`.  
`FatesReadParameters` has been moved from the aforementioned module into FATES and 
takes in an HLM-provided `fates_param_reader_type` to read the parameters from disk.  
The existing `SetFatesGlobalElements1` method now takes in an optional `fates_param_reader_type`. 

Upcoming PR's will modify the HLM's to construct and pass in instances of fates_param_reader_type 
(which will basically call the HLM-side `ParametersFromNetCDF` method), and then remove the old code path.

This work is ported from https://github.com/ESCOMP/ctsm/pull/2198 and is associated with https://github.com/NGEET/fates/pull/1096

Fixes #6029 

[BFB]