### PR TITLE
Ascent needs to use static hdf5 libs

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -4384,6 +4384,7 @@
       <env name="BLA_VENDOR">Generic</env>
       <env name="ESSL_PATH">$ENV{OLCF_ESSL_ROOT}</env>
       <env name="HDF5_ROOT">$ENV{OLCF_HDF5_ROOT}</env>
+      <env name="HDF5_USE_STATIC_LIBRARIES">True</env>
       <env name="PGI_ACC_POOL_ALLOC">0</env>
       <env name="SMPIARGS"> </env>
     </environment_variables>

--- a/components/cmake/modules/FindPIO.cmake
+++ b/components/cmake/modules/FindPIO.cmake
@@ -29,6 +29,9 @@ list(APPEND PIOLIBS "${INSTALL_SHAREDPATH}/lib/libgptl.a")
 find_package(NETCDF REQUIRED)
 # Check if scorpio has hdf5 enabled
 if (DEFINED ENV{HDF5_ROOT})
+  if (DEFINED ENV{HDF5_USE_STATIC_LIBRARIES})
+    set(HDF5_USE_STATIC_LIBRARIES On)
+  endif()
   find_package(HDF5 REQUIRED COMPONENTS C HL)
 endif()
 


### PR DESCRIPTION
The ibm linker chokes on the .so's due to the non-standard suffix. FindHDF5 for some reason does not use the symlinks which have a normal suffix.

[BFB]