### PR TITLE
Reduce nodes used for nbfb test suite on chrysalis

### DIFF
--- a/cime_config/testmods_dirs/config_pes_tests.xml
+++ b/cime_config/testmods_dirs/config_pes_tests.xml
@@ -69,6 +69,31 @@
           <nthrds_wav>2</nthrds_wav>
         </nthrds>
       </pes>
+      <pes compset="any" pesize="S">
+        <comment>tests+chrysalis: any compset on ne4 grid, 1x32x2 NODESxMPIxOMP</comment>
+        <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
+        <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
+        <ntasks>
+          <ntasks_atm>32</ntasks_atm>
+          <ntasks_ice>32</ntasks_ice>
+          <ntasks_cpl>32</ntasks_cpl>
+          <ntasks_lnd>32</ntasks_lnd>
+          <ntasks_rof>32</ntasks_rof>
+          <ntasks_ocn>32</ntasks_ocn>
+          <ntasks_glc>32</ntasks_glc>
+          <ntasks_wav>32</ntasks_wav>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>2</nthrds_atm>
+          <nthrds_ice>2</nthrds_ice>
+          <nthrds_cpl>2</nthrds_cpl>
+          <nthrds_lnd>2</nthrds_lnd>
+          <nthrds_rof>2</nthrds_rof>
+          <nthrds_ocn>2</nthrds_ocn>
+          <nthrds_glc>2</nthrds_glc>
+          <nthrds_wav>2</nthrds_wav>
+        </nthrds>
+      </pes>
     </mach>
     <mach name="anvil">
       <pes compset="any" pesize="any">

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -129,7 +129,7 @@ _TESTS = {
             "ERP_Ln18.ne4_oQU240.F2010.eam-condidiag_rhi",
             )
         },
-    
+
     "e3sm_zm_developer" : {
         "tests"   : (
             "ERP.ne4pg2_oQU480.F2010.eam-zm_enhancements",
@@ -221,7 +221,7 @@ _TESTS = {
     "e3sm_atm_nbfb" : {
         "tests" : (
             "PGN_P1x1.ne4_oQU240.F2010",
-            "TSC.ne4_oQU240.F2010",
+            "TSC_PS.ne4_oQU240.F2010",
             "MVK_PS.ne4_oQU240.F2010",
             )
         },


### PR DESCRIPTION
- Adds a small (S) layout: 1 node per instance for the ne4 grid on chrysalis, to reduce the number of nodes requested for multi-instance tests
- Switches the TSC nightly test in `e3sm_atm_nbfb` to use this layout
- Nightly test node requests are reduced as follows MVK: 90 -> 30; TSC: 36 -> 12
- Wall-clock times are increased by ~1.6x for TSC and ~2.6x for MVK

[bfb]