### PR TITLE
Move `h2osno` limiter to ensure positive snow depth.

### DIFF
--- a/components/elm/src/biogeophys/LakeHydrologyMod.F90
+++ b/components/elm/src/biogeophys/LakeHydrologyMod.F90
@@ -429,13 +429,12 @@ contains
             else
                h2osno(c) = h2osno(c) + (-qflx_sub_snow(p)+qflx_dew_snow(p))*dtime
             end if
+            h2osno(c) = max(h2osno(c), 0._r8)
             if (h2osno_temp > 0._r8) then
                snow_depth(c) = snow_depth(c) * h2osno(c) / h2osno_temp
             else
                snow_depth(c) = h2osno(c)/snow_bd !Assume a constant snow bulk density = 250.
             end if
-
-            h2osno(c) = max(h2osno(c), 0._r8)
          end if
 
          if (.not. use_extrasnowlayers) then


### PR DESCRIPTION
In `LakeHydrologyMod`, when applying the effects of sublimation and dew to snow, the `snow_depth` variable is set using the `h2osno` variable before that variable is limited to positive values. This commit changes the order of those statements to ensure that `snow_depth` is not accidentally set to a negative value.

It is important to note that in the existing code, only extremely small-magnitude negative values are typically produced, because of another limiter applied earlier in the code. Specifically, `h2osno` variable is set using

```
h2osno(c) = h2osno(c) - qflx_sub_snow(p)*dtime
```

and `qflx_sub_snow` is set using

```
qflx_sub_snow(p) = min(qflx_evap_soi(p), h2osno(c)/dtime)
```

Thus, `h2osno` can only be temporarily negative due to limited floating point precision, i.e. the fact that we can get a slightly negative output from

```
h2osno(c) - (h2osno(c)/dtime)*dtime
```

For this reason, this commit only produces roundoff-level changes in answers under typical conditions.

It is also known that invalid values of `snow_depth` and `snowdp` are implicated in some rare model crashes (see #5798). The causes are unknown, but in at least one case involved exponentially growing negative snow depth. It is possible that this change will prevent such crashes; investigation is ongoing at the time of this commit.

[non-BFB]