### PR TITLE
Update weights for ocean barotropic subcycling in split-explicit solver

### DIFF
--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -460,9 +460,9 @@
 <config_btr_dt ocn_grid="oQU240">'0000_00:03:00'</config_btr_dt>
 <config_btr_dt ocn_grid="oQU240wLI">'0000_00:03:00'</config_btr_dt>
 <config_btr_dt ocn_grid="oQU120">'0000_00:01:30'</config_btr_dt>
-<config_btr_dt ocn_grid="oEC60to30v3">'0000_00:01:00'</config_btr_dt>
-<config_btr_dt ocn_grid="oEC60to30v3wLI">'0000_00:01:00'</config_btr_dt>
-<config_btr_dt ocn_grid="ECwISC30to60E1r2">'0000_00:01:00'</config_btr_dt>
+<config_btr_dt ocn_grid="oEC60to30v3">'0000_00:00:75'</config_btr_dt>
+<config_btr_dt ocn_grid="oEC60to30v3wLI">'0000_00:00:75'</config_btr_dt>
+<config_btr_dt ocn_grid="ECwISC30to60E1r2">'0000_00:00:75'</config_btr_dt>
 <config_btr_dt ocn_grid="oRRS30to10v3">'0000_00:00:24'</config_btr_dt>
 <config_btr_dt ocn_grid="oRRS30to10v3wLI">'0000_00:00:18'</config_btr_dt>
 <config_btr_dt ocn_grid="oRRS18to6v3">'0000_00:00:12'</config_btr_dt>
@@ -470,17 +470,17 @@
 <config_btr_dt ocn_grid="oARRM60to10">'0000_00:00:24'</config_btr_dt>
 <config_btr_dt ocn_grid="oARRM60to6">'0000_00:00:10'</config_btr_dt>
 <config_btr_dt ocn_grid="ARRM10to60E2r1">'0000_00:00:24'</config_btr_dt>
-<config_btr_dt ocn_grid="EC30to60E2r2">'0000_00:01:00'</config_btr_dt>
+<config_btr_dt ocn_grid="EC30to60E2r2">'0000_00:00:75'</config_btr_dt>
 <config_btr_dt ocn_grid="WC14to60E2r3">'0000_00:00:15'</config_btr_dt>
 <config_btr_dt ocn_grid="WCAtl12to45E2r4">'0000_00:00:15'</config_btr_dt>
 <config_btr_dt ocn_grid="SOwISC12to60E2r4">'0000_00:00:15'</config_btr_dt>
-<config_btr_dt ocn_grid="ECwISC30to60E2r1">'0000_00:01:00'</config_btr_dt>
-<config_btr_dt ocn_grid="ECwISC30to60E3r2">'0000_00:01:00'</config_btr_dt>
+<config_btr_dt ocn_grid="ECwISC30to60E2r1">'0000_00:00:75'</config_btr_dt>
+<config_btr_dt ocn_grid="ECwISC30to60E3r2">'0000_00:00:75'</config_btr_dt>
 <config_n_btr_cor_iter>2</config_n_btr_cor_iter>
 <config_vel_correction>.true.</config_vel_correction>
 <config_btr_subcycle_loop_factor>2</config_btr_subcycle_loop_factor>
-<config_btr_gam1_velWt1>0.5</config_btr_gam1_velWt1>
-<config_btr_gam2_SSHWt1>1.0</config_btr_gam2_SSHWt1>
+<config_btr_gam1_velWt1>0.5333</config_btr_gam1_velWt1>
+<config_btr_gam2_SSHWt1>0.5333</config_btr_gam2_SSHWt1>
 <config_btr_gam3_velWt2>1.0</config_btr_gam3_velWt2>
 <config_btr_solve_SSH2>.false.</config_btr_solve_SSH2>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -460,9 +460,9 @@
 <config_btr_dt ocn_grid="oQU240">'0000_00:03:00'</config_btr_dt>
 <config_btr_dt ocn_grid="oQU240wLI">'0000_00:03:00'</config_btr_dt>
 <config_btr_dt ocn_grid="oQU120">'0000_00:01:30'</config_btr_dt>
-<config_btr_dt ocn_grid="oEC60to30v3">'0000_00:00:75'</config_btr_dt>
-<config_btr_dt ocn_grid="oEC60to30v3wLI">'0000_00:00:75'</config_btr_dt>
-<config_btr_dt ocn_grid="ECwISC30to60E1r2">'0000_00:00:75'</config_btr_dt>
+<config_btr_dt ocn_grid="oEC60to30v3">'0000_00:01:15'</config_btr_dt>
+<config_btr_dt ocn_grid="oEC60to30v3wLI">'0000_00:01:15'</config_btr_dt>
+<config_btr_dt ocn_grid="ECwISC30to60E1r2">'0000_00:01:15'</config_btr_dt>
 <config_btr_dt ocn_grid="oRRS30to10v3">'0000_00:00:24'</config_btr_dt>
 <config_btr_dt ocn_grid="oRRS30to10v3wLI">'0000_00:00:18'</config_btr_dt>
 <config_btr_dt ocn_grid="oRRS18to6v3">'0000_00:00:12'</config_btr_dt>
@@ -470,12 +470,12 @@
 <config_btr_dt ocn_grid="oARRM60to10">'0000_00:00:24'</config_btr_dt>
 <config_btr_dt ocn_grid="oARRM60to6">'0000_00:00:10'</config_btr_dt>
 <config_btr_dt ocn_grid="ARRM10to60E2r1">'0000_00:00:24'</config_btr_dt>
-<config_btr_dt ocn_grid="EC30to60E2r2">'0000_00:00:75'</config_btr_dt>
+<config_btr_dt ocn_grid="EC30to60E2r2">'0000_00:01:15'</config_btr_dt>
 <config_btr_dt ocn_grid="WC14to60E2r3">'0000_00:00:15'</config_btr_dt>
 <config_btr_dt ocn_grid="WCAtl12to45E2r4">'0000_00:00:15'</config_btr_dt>
 <config_btr_dt ocn_grid="SOwISC12to60E2r4">'0000_00:00:15'</config_btr_dt>
-<config_btr_dt ocn_grid="ECwISC30to60E2r1">'0000_00:00:75'</config_btr_dt>
-<config_btr_dt ocn_grid="ECwISC30to60E3r2">'0000_00:00:75'</config_btr_dt>
+<config_btr_dt ocn_grid="ECwISC30to60E2r1">'0000_00:01:15'</config_btr_dt>
+<config_btr_dt ocn_grid="ECwISC30to60E3r2">'0000_00:01:15'</config_btr_dt>
 <config_n_btr_cor_iter>2</config_n_btr_cor_iter>
 <config_vel_correction>.true.</config_vel_correction>
 <config_btr_subcycle_loop_factor>2</config_btr_subcycle_loop_factor>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1311,11 +1311,11 @@
 					description="Barotropic subcycles proceed from $t$ to $t+n\Delta t$, where $n$ is this configuration option."
 					possible_values="Any positive integer, but typically 1 or 2"
 		/>
-		<nml_option name="config_btr_gam1_velWt1" type="real" default_value="0.5"
+		<nml_option name="config_btr_gam1_velWt1" type="real" default_value="0.5333"
 					description="Weighting of velocity in the SSH predictor step in stage 2. When zero, previous subcycle time is used; when one, new subcycle time is used."
 					possible_values="between 0 and 1"
 		/>
-		<nml_option name="config_btr_gam2_SSHWt1" type="real" default_value="1.0"
+		<nml_option name="config_btr_gam2_SSHWt1" type="real" default_value="0.5333"
 					description="Weighting of SSH in the velocity corrector step in stage 2. When zero, previous subcycle time is used; when one, new subcycle time is used."
 					possible_values="between 0 and 1"
 		/>


### PR DESCRIPTION
These improvements were originally written by @dengwirda, as described in https://github.com/E3SM-Ocean-Discussion/E3SM/pull/48. Please refer to that PR for additional test results and discussion. Also see test results run in combination with AB2 at https://github.com/E3SM-Project/E3SM/pull/5989#issuecomment-1786133429.

This PR updates the weights `config_btr_gam1_velWt1`, `config_btr_gam2_SSHWt1` in the MPAS-Ocean barotropic solver based on recent analysis of this scheme. This update applies to "split explicit" time stepping schemes, i.e. `config_time_integrator = 'split_explicit'` and the new `config_time_integrator = 'split_explicit_ab2'` in https://github.com/E3SM-Project/E3SM/pull/5989. The new weights allow for a barotropic time step `config_btr_dt` to be 25% longer in the tests of EC30to60, thus speeding up the barotropic subcycling. We expect that values of `config_btr_dt` can be increased by 25% for all meshes.

[NML]
[non-BFB]