### PR TITLE
Make "column_package" the default column_physics_type for BGC

### DIFF
--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -629,7 +629,11 @@ add_default($nl, 'config_recover_tracer_means_check');
 # Namelist group: column_package #
 ##################################
 
-add_default($nl, 'config_column_physics_type');
+if ($ice_bgc eq 'ice_bgc') {
+        add_default($nl, 'config_column_physics_type', 'val'=>"column_package");
+} else {
+        add_default($nl, 'config_column_physics_type');
+}
 add_default($nl, 'config_use_column_shortwave');
 add_default($nl, 'config_use_column_vertical_thermodynamics');
 if ($ice_bgc eq 'ice_bgc') {


### PR DESCRIPTION
With icepack now the default seaice column physics package, we need to make "column_package" the default when seaice BGC is on until it's completely supported in icepack.

[non-BFB] only for BGC configurations with active seaice (which are currently broken)
