### PR TITLE
Fix split-explicit barotropic velocity accumulator

### DIFF
--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -1481,7 +1481,7 @@ module ocn_time_integration_split
 
                !$omp parallel
                !$omp do schedule(runtime)
-               do iEdge = 1, nEdgesAll
+               do iEdge = 1, nEdgesOwned
                   normalBarotropicVelocityNew(iEdge) = &
                   normalBarotropicVelocityNew(iEdge) + &
                   normalBarotropicVelocitySubcycleNew(iEdge)


### PR DESCRIPTION
This PR includes a bugfix for the loop limits on the barotropic velocity (`normalBarotropicVelocityNew`) when its values are accumulated over barotropic subcycles. The loop should be over `nEdgesOwned` for consistency with the loop which divides the barotropic velocity by the number of subcycles.

Fixes https://github.com/E3SM-Project/E3SM/issues/6040

[BFB] for all current E3SM tests, changes to a non-default option