### PR TITLE
Add settings to re-tune QBO, kPOM, and additional hyperviscosity modifier

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -828,8 +828,8 @@ add_default($nl,'ieflx_opt');
 # Add other variables that are previously set in use_case but not previously set
 add_default($nl,'use_hetfrz_classnuc');
 add_default($nl,'hist_hetfrz_classnuc');
-add_default($nl,'gw_convect_hcf');
-add_default($nl,'hdepth_scaling_factor');
+add_default($nl,'gw_convect_hcf') if (get_default_value('gw_convect_hcf'));
+add_default($nl,'hdepth_scaling_factor') if (get_default_value('hdepth_scaling_factor'));
 add_default($nl,'linoz_psc_T');
 if ($cfg->get('microphys') =~ /^mg2/) {
     add_default($nl,'micro_mg_dcs_tdep');

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1863,9 +1863,10 @@ with se_tstep, dt_remap_factor, dt_tracer_factor set to -1
 
 <clubb_ipdf_call_placement phys="default"> 2         </clubb_ipdf_call_placement>
 <cld_sed phys="default" microphys="mg2"> 1.0D0      </cld_sed>
-<effgw_beres phys="default"> 0.35       </effgw_beres>
-<gw_convect_hcf               > 10.0       </gw_convect_hcf>
-<hdepth_scaling_factor        >  0.50D0    </hdepth_scaling_factor>
+<effgw_beres           phys="default" > 0.35  </effgw_beres>
+<gw_convect_hcf        phys="default" > 10.0  </gw_convect_hcf>
+<hdepth_scaling_factor phys="default" > 0.50  </hdepth_scaling_factor>
+<hdepth_scaling_factor phys="default" use_MMF="1" >  1.0  </hdepth_scaling_factor>
 <effgw_oro phys="default"> 0.375      </effgw_oro>
 <use_gw_energy_fix phys="default"> .true.      </use_gw_energy_fix>
 <clubb_C14 phys="default"> 2.5D0      </clubb_C14>

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -243,6 +243,7 @@
 <mam_so4  rad="rrtmg">atm/cam/physprops/sulfate_rrtmg_c080918.nc</mam_so4>
 <mam_pom  rad="rrtmg" mam="3mode">atm/cam/physprops/ocpho_rrtmg_c101112.nc</mam_pom>
 <mam_pom  rad="rrtmg">atm/cam/physprops/ocpho_rrtmg_c130709.nc</mam_pom>
+<mam_pom  rad="rrtmg" clubb_sgs="1" microphys="p3">atm/cam/physprops/ocpho_rrtmg_c130709_kPOM0.04.nc</mam_pom>
 <mam_soa  rad="rrtmg">atm/cam/physprops/ocphi_rrtmg_c100508.nc</mam_soa>
 <mam_bc   rad="rrtmg">atm/cam/physprops/bcpho_rrtmg_c100508.nc</mam_bc>
 <mam_dst  rad="rrtmg">atm/cam/physprops/dust_aeronet_rrtmg_c141106.nc</mam_dst>
@@ -253,6 +254,7 @@
 <mam_so4  rad="rrtmgp">atm/cam/physprops/sulfate_rrtmg_c080918.nc</mam_so4>
 <mam_pom  rad="rrtmgp" mam="3mode">atm/cam/physprops/ocpho_rrtmg_c101112.nc</mam_pom>
 <mam_pom  rad="rrtmgp">atm/cam/physprops/ocpho_rrtmg_c130709.nc</mam_pom>
+<mam_pom  rad="rrtmgp" clubb_sgs="1" microphys="p3">atm/cam/physprops/ocpho_rrtmg_c130709_kPOM0.04.nc</mam_pom>
 <mam_soa  rad="rrtmgp">atm/cam/physprops/ocphi_rrtmg_c100508.nc</mam_soa>
 <mam_bc   rad="rrtmgp">atm/cam/physprops/bcpho_rrtmg_c100508.nc</mam_bc>
 <mam_dst  rad="rrtmgp">atm/cam/physprops/dust_aeronet_rrtmg_c141106.nc</mam_dst>
@@ -1863,7 +1865,7 @@ with se_tstep, dt_remap_factor, dt_tracer_factor set to -1
 <cld_sed phys="default" microphys="mg2"> 1.0D0      </cld_sed>
 <effgw_beres phys="default"> 0.35       </effgw_beres>
 <gw_convect_hcf               > 10.0       </gw_convect_hcf>
-<hdepth_scaling_factor        >  1.0       </hdepth_scaling_factor>
+<hdepth_scaling_factor        >  0.50D0    </hdepth_scaling_factor>
 <effgw_oro phys="default"> 0.375      </effgw_oro>
 <use_gw_energy_fix phys="default"> .true.      </use_gw_energy_fix>
 <clubb_C14 phys="default"> 2.5D0      </clubb_C14>

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -6434,7 +6434,7 @@ pressure gradient discretization error.
 Default: 0
 </entry>
 <entry id="hv_ref_profiles" type="integer" category="se"
-       group="ctl_nl" valid_values="0,1,2" >
+       group="ctl_nl" valid_values="0,1,2,6" >
 Modifications to hyperviscosity to minimize dissipation of
 background reference states.
 Default: 0


### PR DESCRIPTION
The following settings are changed or added

- hdepth_scaling_factor is halved to improve QBO
- New mam_pom file with modified hygroscopicity to reflect the tuning of kPOM = 0.04, for v3 configurations 
- Additional optional hv_ref_profiles value for use with rough topography (which is not used by default)

[NBFB] All tests involving EAM except for FIDEAL, FDPSCREAM, and MMF
[NML] a modified parameter value and an updated input file

-----------------------------
Changes in #6038 incorporated.
e3sm_atm_developer tests return expected diffs, including FAQP. 
FIDEAL and FDPSCREAM are not affected.