### PR TITLE
Support for HDF5 I/O format in E3SM

### DIFF
--- a/driver-mct/cime_config/config_component.xml
+++ b/driver-mct/cime_config/config_component.xml
@@ -2629,7 +2629,7 @@
 
   <entry id="PIO_TYPENAME">
     <type>char</type>
-    <valid_values>netcdf,pnetcdf,netcdf4p,netcdf4c,adios,default</valid_values>
+    <valid_values>netcdf,pnetcdf,netcdf4p,netcdf4c,adios,hdf5,default</valid_values>
     <group>run_pio</group>
     <file>env_run.xml</file>
     <desc>pio io type</desc>

--- a/driver-moab/cime_config/config_component.xml
+++ b/driver-moab/cime_config/config_component.xml
@@ -2480,7 +2480,7 @@
 
   <entry id="PIO_TYPENAME">
     <type>char</type>
-    <valid_values>netcdf,pnetcdf,netcdf4p,netcdf4c,adios,default</valid_values>
+    <valid_values>netcdf,pnetcdf,netcdf4p,netcdf4c,adios,hdf5,default</valid_values>
     <group>run_pio</group>
     <file>env_run.xml</file>
     <desc>pio io type</desc>

--- a/share/build/buildlib.spio
+++ b/share/build/buildlib.spio
@@ -128,8 +128,10 @@ def buildlib(bldroot, installpath, case):
     # elif which_h5dump is not None:
     #     os.environ["HDF5"] = os.path.dirname(os.path.dirname(which_h5dump))
 
-    if "WITH_HDF5_SCORPIO" in os.environ:
-        cmake_opts += "-DWITH_HDF5:BOOL=ON "
+    # Before E3SM upgrades scorpio submodule to 1.5.0 or higher, keep WITH_HDF5
+    # CMake option OFF by default.
+    # if "HDF5_ROOT" in os.environ:
+    #    cmake_opts += "-DWITH_HDF5:BOOL=ON "
 
     # Same deal with libz and szip
     if "ZLIB_ROOT" in os.environ:

--- a/share/build/buildlib.spio
+++ b/share/build/buildlib.spio
@@ -195,10 +195,12 @@ def buildlib(bldroot, installpath, case):
         netcdf4_string = "NetCDF_C_HAS_PARALLEL:BOOL=TRUE"
 
     adios_string = "WITH_ADIOS2:BOOL=ON"
+    hdf5_string = "WITH_HDF5:BOOL=ON"
     expect_string_found = False
     pnetcdf_found = False
     netcdf4_parallel_found = False
     adios_found = False
+    hdf5_found = False
 
     cache_file = open(os.path.join(pio_bld_dir,"CMakeCache.txt"), "r")
     for line in cache_file:
@@ -210,6 +212,8 @@ def buildlib(bldroot, installpath, case):
             netcdf4_parallel_found = True
         if re.search(adios_string, line):
             adios_found = True
+        if re.search(hdf5_string, line):
+            hdf5_found = True
 
     if pio_version == 1:
         installed_lib = os.path.join(installpath, "lib", "libpio.a")
@@ -266,6 +270,8 @@ def buildlib(bldroot, installpath, case):
         valid_values += ",netcdf4p,netcdf4c"
     if adios_found:
         valid_values += ",adios"
+    if hdf5_found:
+        valid_values += ",hdf5"
 
     _set_pio_valid_values(case, valid_values)
 

--- a/share/util/shr_pio_mod.F90
+++ b/share/util/shr_pio_mod.F90
@@ -671,6 +671,8 @@ contains
        iotype = pio_iotype_netcdf4c
     else if ( typename .eq. 'ADIOS') then
        iotype = pio_iotype_adios
+    else if ( typename .eq. 'HDF5') then
+       iotype = pio_iotype_hdf5
     else if ( typename .eq. 'NOTHING') then
        iotype = defaulttype
     else if ( typename .eq. 'DEFAULT') then


### PR DESCRIPTION
Adding support for the HDF5 I/O format which is already available
in SCORPIO.

Also using HDF5_ROOT in buildlib.spio to turn on HDF5 support.

[BFB]