### PR TITLE
Fix split-explicit upwinded advection

### DIFF
--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -1129,7 +1129,7 @@ module ocn_time_integration_split
                ! matches the sum of baroclinic thicknesses at this edge.
                !$omp parallel
                !$omp do schedule(runtime)
-               do iCell = 1, nCells
+               do iCell = 1, nCellsAll
                   deltaSSH(iCell) = sshSubcycleCur(iCell) - sshNew(iCell)
                end do
                !$omp end do
@@ -1384,7 +1384,7 @@ module ocn_time_integration_split
 
                   !$omp parallel
                   !$omp do schedule(runtime)
-                  do iCell = 1, nCells
+                  do iCell = 1, nCellsAll
                      ! SSH is linear combination of SSHold and SSHnew
                      sshTemp(iCell) = (1-config_btr_gam2_SSHWt1)* &
                                       sshSubcycleCur(iCell) + &
@@ -1437,7 +1437,7 @@ module ocn_time_integration_split
 
                   !$omp parallel
                   !$omp do schedule(runtime)
-                  do iCell = 1, nCells
+                  do iCell = 1, nCellsAll
                      ! SSH is linear combination of SSHold and SSHnew
                      sshTemp(iCell) = (1-config_btr_gam2_SSHWt1)* &
                                       sshSubcycleCur(iCell) + &

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -199,8 +199,9 @@ module ocn_time_integration_split
       real (kind=RKIND), dimension(:), allocatable :: &
          btrvel_temp,      &
          sshTemp,          &
+         deltaSSH,         &
          wctEdge,          &! flux water column thickness at edge
-         bottomDepthEdge
+         baroclinicThickness
 
       ! State Array Pointers
       real (kind=RKIND), dimension(:), pointer :: &
@@ -391,7 +392,7 @@ module ocn_time_integration_split
 
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracersNew, 2)
 
-      allocate(bottomDepthEdge(nEdgesAll+1))
+      allocate(baroclinicThickness(nEdgesAll+1))
 
       if (config_transport_tests_flow_id > 0) then
         ! This is a transport test. Write advection velocity from prescribed
@@ -798,20 +799,18 @@ module ocn_time_integration_split
             !$omp end do
             !$omp end parallel
 
-            bottomDepthEdge(:) = 0.0_RKIND
+            baroclinicThickness(:) = 0.0_RKIND
             !$omp parallel
             !$omp do schedule(runtime) &
-            !$omp private(cell1, cell2, k, thicknessSum)
+            !$omp private(cell1, cell2, k)
             do iEdge = 1, nEdgesHalo(config_num_halos+1)
                cell1 = cellsOnEdge(1,iEdge)
                cell2 = cellsOnEdge(2,iEdge)
-               thicknessSum = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
+               baroclinicThickness(iEdge) = layerThickEdgeFlux(minLevelEdgeBot(iEdge),iEdge)
                do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
-                  thicknessSum = thicknessSum + &
+                  baroclinicThickness(iEdge) = baroclinicThickness(iEdge) + &
                                  layerThickEdgeFlux(k,iEdge)
                enddo
-               bottomDepthEdge(iEdge) = thicknessSum &
-                  - 0.5_RKIND*(sshNew(cell1) + sshNew(cell2))
             enddo ! iEdge
             !$omp end do
             !$omp end parallel
@@ -954,6 +953,8 @@ module ocn_time_integration_split
             btrvel_temp(:) = 0.0_RKIND
             allocate(wctEdge(nEdgesAll+1))
             wctEdge(:) = 0.0_RKIND
+            allocate(deltaSSH(nCellsAll))
+            deltaSSH(:) = 0.0_RKIND
 
             cellHaloComputeCounter = 0
             edgeHaloComputeCounter = 0
@@ -1126,8 +1127,15 @@ module ocn_time_integration_split
 
                ! Compute barotropic thickness at the edge. Note this
                ! matches the sum of baroclinic thicknesses at this edge.
-               call ocn_diagnostic_solve_wctEdge(btrvel_temp, sshSubcycleCur, &
-                         bottomDepthEdge, wctEdge)
+               !$omp parallel
+               !$omp do schedule(runtime)
+               do iCell = 1, nCells
+                  deltaSSH(iCell) = sshSubcycleCur(iCell) - sshNew(iCell)
+               end do
+               !$omp end do
+               !$omp end parallel
+               call ocn_diagnostic_solve_wctEdge(btrvel_temp, deltaSSH, &
+                         baroclinicThickness, wctEdge)
 
                !$omp parallel
                !$omp do schedule(runtime) &
@@ -1382,6 +1390,7 @@ module ocn_time_integration_split
                                       sshSubcycleCur(iCell) + &
                                       config_btr_gam2_SSHWt1 * &
                                       sshSubcycleNew(iCell)
+                     deltaSSH(iCell) = sshTemp(iCell) - sshNew(iCell)
                   end do ! cell loop for ssh
                   !$omp end do
                   !$omp end parallel
@@ -1397,8 +1406,8 @@ module ocn_time_integration_split
                   !$omp end do
                   !$omp end parallel
 
-                  call ocn_diagnostic_solve_wctEdge(btrvel_temp, sshTemp, &
-                         bottomDepthEdge, wctEdge)
+                  call ocn_diagnostic_solve_wctEdge(btrvel_temp, deltaSSH, &
+                         baroclinicThickness, wctEdge)
 
                   !$omp parallel
                   !$omp do schedule(runtime) &
@@ -1434,12 +1443,13 @@ module ocn_time_integration_split
                                       sshSubcycleCur(iCell) + &
                                       config_btr_gam2_SSHWt1 * &
                                       sshSubcycleNew(iCell)
+                     deltaSSH(iCell) = sshTemp(iCell) - sshNew(iCell)
                   end do ! cell loop for ssh
                   !$omp end do
                   !$omp end parallel
 
-                  call ocn_diagnostic_solve_wctEdge(btrvel_temp, sshTemp, &
-                         bottomDepthEdge, wctEdge)
+                  call ocn_diagnostic_solve_wctEdge(btrvel_temp, deltaSSH, &
+                         baroclinicThickness, wctEdge)
 
                   ! compute barotropic thickness flux on edges
                   !$omp parallel
@@ -1498,6 +1508,7 @@ module ocn_time_integration_split
 
             deallocate(btrvel_temp)
             deallocate(wctEdge)
+            deallocate(deltaSSH)
 
             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             ! END Barotropic subcycle loop
@@ -2704,7 +2715,7 @@ module ocn_time_integration_split
          call mpas_dmpar_exch_halo_field(effectiveDensityField)
          call mpas_timer_stop("se effective density halo")
       end if
-      deallocate(bottomDepthEdge)
+      deallocate(baroclinicThickness)
 
       call mpas_timer_stop('se fini')
       call mpas_timer_stop("se timestep")

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -681,20 +681,19 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_diagnostic_solve_wctEdge(btrVelocity, sshCell, &
-                         bottomDepthEdge, wctEdge)!{{{
+   subroutine ocn_diagnostic_solve_wctEdge(btrVelocity, deltaSSH, &
+                         baroclinicThickness, wctEdge)!{{{
 
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:), intent(in) :: &
-         btrVelocity,   &!< barotropic velocity
-         sshCell,       &!< ssh at cells, used for centered water column
-                         !< thickness
-         bottomDepthEdge !< bottom depth centered at edges, used for
-                         !< centered water column thickness
-      ! bottomDepth is already present
+         btrVelocity,       &!< barotropic velocity
+         deltaSSH,          &!< ssh change from baroclinic step to barotropic
+                             !< substep
+         baroclinicThickness !< water column thickness on edges at the last
+                             !< baroclinic step (centered or upwinded)
 
       !-----------------------------------------------------------------
       ! output variables
@@ -725,9 +724,9 @@ contains
 
          ! Compute mean layer thickness at edge
 #ifdef MPAS_OPENACC
-         !$acc enter data copyin(bottomDepthEdge, sshCell, wctEdge)
+         !$acc enter data copyin(baroclinicThickness, deltaSSH, wctEdge)
          !$acc parallel loop &
-         !$acc    present(bottomDepthEdge, sshCell, wctEdge, cellsOnEdge) &
+         !$acc    present(baroclinicThickness, deltaSSH, wctEdge, cellsOnEdge) &
          !$acc    private(iEdge, cell1, cell2)
 #else
          !$omp parallel
@@ -737,8 +736,8 @@ contains
             if ( maxLevelEdgeTop(iEdge) == 0 ) cycle
             cell1 = cellsOnEdge(1,iEdge)
             cell2 = cellsOnEdge(2,iEdge)
-            wctEdge(iEdge) = 0.5_RKIND*(sshCell(cell1) + sshCell(cell2)) &
-                             + bottomDepthEdge(iEdge)
+            wctEdge(iEdge) = 0.5_RKIND*(deltaSSH(cell1) + deltaSSH(cell2)) &
+                             + baroclinicThickness(iEdge)
          end do
 #ifndef MPAS_OPENACC
          !$omp end do
@@ -746,16 +745,16 @@ contains
 #endif
 
 #ifdef MPAS_OPENACC
-         !$acc exit data copyout(wctEdge) delete(bottomDepthEdge, sshCell)
+         !$acc exit data copyout(wctEdge) delete(baroclinicThickness, deltaSSH)
 #endif
 
       case (thickEdgeFluxUpwind)
 
          ! Use upwind thickness as the edge flux value
 #ifdef MPAS_OPENACC
-         !$acc enter data copyin(bottomDepthEdge, sshCell, btrVelocity, wctEdge)
+         !$acc enter data copyin(baroclinicThickness, deltaSSH, btrVelocity, wctEdge)
          !$acc parallel loop &
-         !$acc    present(bottomDepthEdge, btrVelocity, sshCell, cellsOnEdge, maxLevelEdgeTop, wctEdge) &
+         !$acc    present(baroclinicThickness, btrVelocity, deltaSSH, cellsOnEdge, maxLevelEdgeTop, wctEdge) &
          !$acc    private(cell1, cell2, iEdge)
 #else
          !$omp parallel
@@ -766,12 +765,12 @@ contains
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
             if (btrVelocity(iEdge) > 0.0_RKIND) then
-               wctEdge(iEdge) = sshCell(cell1) + bottomDepthEdge(iEdge)
+               wctEdge(iEdge) = deltaSSH(cell1) + baroclinicThickness(iEdge)
             elseif (btrVelocity(iEdge) < 0.0_RKIND) then
-               wctEdge(iEdge) = sshCell(cell2) + bottomDepthEdge(iEdge)
+               wctEdge(iEdge) = deltaSSH(cell2) + baroclinicThickness(iEdge)
             else
-               wctEdge(iEdge) = max(sshCell(cell1), sshCell(cell2)) &
-                                + bottomDepthEdge(iEdge)
+               wctEdge(iEdge) = max(deltaSSH(cell1), deltaSSH(cell2)) &
+                                + baroclinicThickness(iEdge)
             end if
          end do
 #ifndef MPAS_OPENACC
@@ -780,7 +779,7 @@ contains
 #endif
 
 #ifdef MPAS_OPENACC
-         !$acc exit data copyout(wctEdge) delete(bottomDepthEdge, sshCell, btrVelocity)
+         !$acc exit data copyout(wctEdge) delete(baroclinicThickness, deltaSSH, btrVelocity)
 #endif
 
       case default


### PR DESCRIPTION
This PR introduces a new variable to track the baroclinic water column thickness for the barotropic subcycles. The method of storing the baroclinic water column thickness in a `bottomDepthEdge` variable was problematic for upwinding because the upwinded cell can change between the baroclinic cycle and the barotropic subcycle. We now store the baroclinic (upwinded or centered) water column thickness at edges and then apply it along with the barotropic  (upwinded or centered) ssh on edges to determine the barotropic water column thickness at edges.

Fixes https://github.com/E3SM-Project/E3SM/issues/6048
[BFB]