### PR TITLE
Add tidal boundary conditions to split-explicit time integrator

### DIFF
--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -3858,11 +3858,11 @@
 		/>
 		<var name="sshSubcycleCurWithTides" type="real" dimensions="nCells Time" units="m"
 			description="SSH - tidal potential in split explicit "
-			packages="tidalPotentialForcingPKG"
+			packages="tidalPotentialForcingPKG;tidalForcing"
 		/>
 		<var name="sshSubcycleNewWithTides" type="real" dimensions="nCells Time" units="m"
 			description="SSH - tidal potential in split explicit "
-			packages="tidalPotentialForcingPKG"
+			packages="tidalPotentialForcingPKG;tidalForcing"
 		/>
 		<var name="coastalSmoothingFactor" type="real" dimensions="nCells" units="1"
 			 description="Multiplication factors to smooth ssh at coastlines for SAL caculation"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -797,7 +797,7 @@
 		/>
 		<nml_option name="config_tidal_forcing_model" type="character" default_value="off"
 					description="Selects the mode in which tidal forcing is computed."
-					possible_values="'off','monochromatic'"
+					possible_values="'off','monochromatic','linear'"
 		/>
 		<nml_option name="config_tidal_forcing_monochromatic_amp" type="real" default_value="2.0" units="m"
 					description="Value of amplitude of monochromatic tide."
@@ -814,6 +814,18 @@
 		<nml_option name="config_tidal_forcing_monochromatic_baseline" type="real" default_value="0.0" units="days"
 					description="Value of baseline monochromatic tide, e.g., sea level rise."
 					possible_values="Any positive real number."
+		/>
+		<nml_option name="config_tidal_forcing_linear_baseline" type="real" default_value="0.0" units="days"
+					description="Value of baseline linear tide, e.g., sea level rise."
+					possible_values="Any positive real number."
+		/>
+		<nml_option name="config_tidal_forcing_linear_min" type="real" default_value="-1.0" units="days"
+					description="Value of minimum tide."
+					possible_values="Any real number."
+		/>
+		<nml_option name="config_tidal_forcing_linear_rate" type="real" default_value="-8.0" units="days"
+					description="Value of tide rate of change in m per day."
+					possible_values="Any real number."
 		/>
 	</nml_record>
 	<nml_record name="self_attraction_loading" mode="init;forward">

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -267,6 +267,10 @@ module ocn_time_integration_split
       ! Forcing pool
       real (kind=RKIND), dimension(:), pointer :: tidalPotentialEta
 
+      real (kind=RKIND) :: totalDepth
+      real (kind=RKIND), dimension(:), pointer :: tidalInputMask, tidalBCValue
+      real (kind=RKIND), dimension(:,:), pointer :: restingThickness
+
       real (kind=RKIND), dimension(:), pointer :: &
         seaIcePressure, atmosphericPressure
 
@@ -2580,6 +2584,29 @@ module ocn_time_integration_split
          !$omp end do
          !$omp end parallel
 #endif
+      end if
+
+      ! direct application of tidal boundary condition
+      if (config_use_tidal_forcing .and. trim(config_tidal_forcing_type) == 'direct') then
+        call mpas_pool_get_array(verticalMeshPool, 'restingThickness', restingThickness)
+        call mpas_pool_get_array(forcingPool, 'tidalInputMask', tidalInputMask)
+        call mpas_pool_get_array(forcingPool, 'tidalBCValue', tidalBCValue)
+        do iCell=1, nCells
+          ! artificially assumes boolean mask for now, could generalize to tappered sponge layer
+          if (tidalInputMask(iCell) == 1.0_RKIND) then
+            ! compute total depth for relative thickness contribution
+            totalDepth = 0.0_RKIND
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
+              totalDepth = totalDepth + restingThickness(k,iCell)
+            end do
+
+            ! only modify layer thicknesses on tidal boundary
+            do k = minLevelCell(iCell), maxLevelCell(iCell)
+              layerThicknessNew(k, iCell) = tidalInputMask(iCell)*(tidalBCValue(iCell) + bottomDepth(iCell))*(restingThickness(k,iCell)/totalDepth)
+              !(1.0_RKIND - tidalInputMask(iCell))*layerThicknessNew(k, iCell)  ! generalized tappered assumption code
+            end do
+          end if
+        end do
       end if
 
       call ocn_diagnostic_solve(dt, statePool, forcingPool, meshPool, verticalMeshPool, &

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -1032,6 +1032,29 @@ module ocn_time_integration_split
 
                   end if ! tidal potential forcing
 
+                  ! direct application of tidal boundary condition
+                  if (config_use_tidal_forcing .and. trim(config_tidal_forcing_type) == 'direct') then
+                     call mpas_pool_get_array(forcingPool, &
+                                           'sshSubcycleCurWithTides', &
+                                            sshSubcycleCurWithTides)
+                     call mpas_pool_get_array(forcingPool, 'tidalInputMask', tidalInputMask)
+                     call mpas_pool_get_array(forcingPool, 'tidalBCValue', tidalBCValue)
+                     !$omp parallel
+                     !$omp do schedule(runtime)
+                     do iCell=1, nCellsAll
+                        ! boolean mask for now, could generalize to tappered sponge layer
+                        ! only modify layer thicknesses on tidal boundary
+                        do k = minLevelCell(iCell), maxLevelCell(iCell)
+                           sshSubcycleCurWithTides(iCell) = sshSubcycleCur(iCell) + &
+                               (tidalInputMask(iCell)*(tidalBCValue(iCell) - sshSubcycleCur(iCell)))
+                        end do
+                     end do
+                     !$omp end do
+                     !$omp end parallel
+                     call mpas_pool_get_array(forcingPool, &
+                                          'sshSubcycleCurWithTides', &
+                                           sshSubcycleCur)
+                  end if
                   if (edgeHaloComputeCounter <= 1) then
                      nEdges = nEdgesOwned
                   else
@@ -1258,6 +1281,37 @@ module ocn_time_integration_split
                                     'sshSubcycleNewWithTides',  &
                                      sshSubcycleNew)
                   end if ! tidal potential forcing
+                  ! direct application of tidal boundary condition
+                  if (config_use_tidal_forcing .and. trim(config_tidal_forcing_type) == 'direct') then
+                     call mpas_pool_get_array(forcingPool, &
+                                           'sshSubcycleCurWithTides',  &
+                                            sshSubcycleCurWithTides)
+                     call mpas_pool_get_array(forcingPool, &
+                                           'sshSubcycleNewWithTides',  &
+                                            sshSubcycleNewWithTides)
+                     call mpas_pool_get_array(forcingPool, 'tidalInputMask', tidalInputMask)
+                     call mpas_pool_get_array(forcingPool, 'tidalBCValue', tidalBCValue)
+                     !$omp parallel
+                     !$omp do schedule(runtime)
+                     do iCell=1, nCellsAll
+                        ! boolean mask for now, could generalize to tappered sponge layer
+                        ! only modify layer thicknesses on tidal boundary
+                        do k = minLevelCell(iCell), maxLevelCell(iCell)
+                           sshSubcycleCurWithTides(iCell) = sshSubcycleCur(iCell) + &
+                               (tidalInputMask(iCell)*(tidalBCValue(iCell) - sshSubcycleCur(iCell)))
+                           sshSubcycleNewWithTides(iCell) = sshSubcycleNew(iCell) + &
+                               (tidalInputMask(iCell)*(tidalBCValue(iCell) - sshSubcycleNew(iCell)))
+                        end do
+                     end do
+                     !$omp end do
+                     !$omp end parallel
+                     call mpas_pool_get_array(forcingPool, &
+                                    'sshSubcycleCurWithTides',  &
+                                     sshSubcycleCur)
+                     call mpas_pool_get_array(forcingPool, &
+                                    'sshSubcycleNewWithTides',  &
+                                     sshSubcycleNew)
+                  end if
 
                   ! Need to initialize btr_vel_temp over one more halo
                   ! than we are computing over
@@ -2602,7 +2656,9 @@ module ocn_time_integration_split
 
             ! only modify layer thicknesses on tidal boundary
             do k = minLevelCell(iCell), maxLevelCell(iCell)
-              layerThicknessNew(k, iCell) = tidalInputMask(iCell)*(tidalBCValue(iCell) + bottomDepth(iCell))*(restingThickness(k,iCell)/totalDepth)
+              layerThicknessNew(k, iCell) = tidalInputMask(iCell)* &
+                                            (tidalBCValue(iCell) + bottomDepth(iCell))* &
+                                            (restingThickness(k,iCell)/totalDepth)
               !(1.0_RKIND - tidalInputMask(iCell))*layerThicknessNew(k, iCell)  ! generalized tappered assumption code
             end do
           end if

--- a/components/mpas-ocean/src/shared/mpas_ocn_tidal_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tidal_forcing.F
@@ -245,6 +245,10 @@ contains
             SIN(2.0_RKIND*pii/config_tidal_forcing_monochromatic_period * daysSinceStartOfSim - &
             pii*config_tidal_forcing_monochromatic_phaseLag/180.0_RKIND) - &
             config_tidal_forcing_monochromatic_baseline
+        elseif (trim(config_tidal_forcing_model) == 'linear') then
+           tidalHeight = max(config_tidal_forcing_linear_min, &
+                             config_tidal_forcing_linear_baseline + &
+                             config_tidal_forcing_linear_rate * daysSinceStartOfSim)
         !else if (trim(config_tidal_forcing_type) == 'data') then
         !  ! data option
         !  ! pass


### PR DESCRIPTION
This PR adds the option to have a tidal boundary condition with the split-explicit time integrator. Formerly, only tidal boundary conditions were supported with RK4. The changes to the ssh and layerThickness terms are described in https://www.overleaf.com/read/htysppyxksyh#6b2d8f. 

This PR also includes options for a linearly-varying tidal boundary condition to match a test case from O'Dea et al. 2021 used for validation.

This work depends on https://github.com/E3SM-Project/E3SM/pull/6047 in that the test cases used for verification of the forcing will fail without the use of upwinded advection and that fix.

[BFB] when feature is turned off

This feature is only available in MPAS-Ocean standalone configurations.