### PR TITLE
Align minimum concentration and mass limits in MPAS-SeaIce (Single Commit Version)

### DIFF
--- a/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver.F
@@ -20,6 +20,7 @@ module seaice_velocity_solver
   use mpas_dmpar
   use mpas_timer
   use mpas_log, only: mpas_log_write, mpas_log_info
+  use ice_constants_colpkg, only: puny
 
   implicit none
 
@@ -62,8 +63,8 @@ module seaice_velocity_solver
   real(kind=RKIND), parameter, private :: &
        sinOceanTurningAngle = 0.0_RKIND, & ! northern hemisphere
        cosOceanTurningAngle = 1.0_RKIND, & ! northern hemisphere
-       seaiceAreaMinimum = 0.001_RKIND, &
-       seaiceMassMinimum = 0.01_RKIND
+       seaiceAreaMinimum = puny, &
+       seaiceMassMinimum = 10.0_RKIND*puny
 
 contains
 


### PR DESCRIPTION
This is a single-commit version of the closed and reviewed PR: https://github.com/E3SM-Project/E3SM/pull/6033

This changes the minimum sea ice concentration and mass per unit area used to solve the sea ice momentum equation to 10^-11 and 10^-10, respectively, aligning the concentration cutoff with the value used in sea ice column physics. The values have been reduced from 10^-3 and 10^-2, respectively.

Testing has been completed in two categories: The branch passes the e3sm_ice_developer D-case test-suite. However, the most important test is that this change does not cause numerical exceptions in a B-case simulation of E3SM. Results from that simulation are provided in the comments below, successfully completed to 160+ years for the v3alpha04_trigrid configuration. This simulation deliberately includes the https://github.com/E3SM-Project/E3SM/pull/5999, because it is important to see the results of this PR on top of that change.

The impact of this change is the removal of numerical diffusion in coupling to the ocean, thus sharpening the sea ice edge, and removing "shadow" fields in low-concentration sea ice mass, heat and salt fluxes with the ocean. This PR does not impact flux conservation between models, nor within MPAS-SeaIce

CC