### PR TITLE
Removes sea surface height gradient filtering as a stealth option in E3SM

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -698,7 +698,6 @@ add_default($nl, 'config_flux_attenuation_coefficient_runoff');
 # Namelist group: coupling #
 ############################
 
-add_default($nl, 'config_ssh_grad_relax_timescale');
 if (($OCN_ICEBERG eq 'true') && ($OCN_FORCING eq 'active_atm')) {
 	add_default($nl, 'config_remove_AIS_coupler_runoff', 'val'=>".true.");
 } else {

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -227,7 +227,6 @@ add_default($nl, 'config_flux_attenuation_coefficient_runoff');
 # Namelist group: coupling #
 ############################
 
-add_default($nl, 'config_ssh_grad_relax_timescale');
 add_default($nl, 'config_remove_AIS_coupler_runoff');
 
 ######################################

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -289,7 +289,6 @@
 <config_flux_attenuation_coefficient_runoff>10.0</config_flux_attenuation_coefficient_runoff>
 
 <!-- coupling -->
-<config_ssh_grad_relax_timescale>0.0</config_ssh_grad_relax_timescale>
 <config_remove_AIS_coupler_runoff>.false.</config_remove_AIS_coupler_runoff>
 
 <!-- shortwaveRadiation -->

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1175,14 +1175,6 @@ Default: Defined in namelist_defaults.xml
 
 <!-- coupling -->
 
-<entry id="config_ssh_grad_relax_timescale" type="real"
-	category="coupling" group="coupling">
-Timescale for relaxation of the ssh gradient for coupling. A value of 0.0 (default) removes any relaxation and gives instantaneous response.
-
-Valid values: Any positive real number.
-Default: Defined in namelist_defaults.xml
-</entry>
-
 <entry id="config_remove_AIS_coupler_runoff" type="logical"
 	category="coupling" group="coupling">
 If true, solid and liquid runoff from the Antarctic Ice Sheet (below 60S latitude) coming from the coupled is zeroed in the coupler import routines.  To be used with data iceberg fluxes coming from the sea ice model.

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -209,7 +209,6 @@ contains
 
     ! ssh coupling interval initialization
     integer, pointer :: index_avgZonalSSHGradient, index_avgMeridionalSSHGradient
-    real (kind=RKIND), dimension(:),   pointer :: avgSSHGradientZonal, avgSSHGradientMeridional
     real (kind=RKIND), dimension(:,:), pointer :: avgSSHGradient
 
     interface
@@ -752,10 +751,6 @@ contains
           call mpas_pool_get_dimension(forcingPool, 'index_avgSSHGradientZonal', index_avgZonalSSHGradient)
           call mpas_pool_get_dimension(forcingPool, 'index_avgSSHGradientMeridional', index_avgMeridionalSSHGradient)
           call mpas_pool_get_array(forcingPool, 'avgSSHGradient', avgSSHGradient)
-          call mpas_pool_get_array(forcingPool, 'avgSSHGradientZonal', avgSSHGradientZonal)
-          call mpas_pool_get_array(forcingPool, 'avgSSHGradientMeridional', avgSSHGradientMeridional)
-          avgSSHGradientZonal      = avgSSHGradient(index_avgZonalSSHGradient,     :)
-          avgSSHGradientMeridional = avgSSHGradient(index_avgMeridionalSSHGradient, :)
           block_ptr => block_ptr % next
        end do
     endif
@@ -889,9 +884,7 @@ contains
 
       ! Added for coupling interval initialization
       integer, pointer :: index_avgZonalSSHGradient, index_avgMeridionalSSHGradient
-      real (kind=RKIND), dimension(:),   pointer :: avgSSHGradientZonal, avgSSHGradientMeridional
       real (kind=RKIND), dimension(:,:), pointer :: avgSSHGradient
-      real (kind=RKIND) :: timeFilterFactor
 
       iam = domain % dminfo % my_proc_id
 
@@ -1110,10 +1103,6 @@ contains
          call mpas_pool_get_dimension(forcingPool, 'index_avgSSHGradientZonal', index_avgZonalSSHGradient)
          call mpas_pool_get_dimension(forcingPool, 'index_avgSSHGradientMeridional', index_avgMeridionalSSHGradient)
          call mpas_pool_get_array(forcingPool, 'avgSSHGradient', avgSSHGradient)
-         call mpas_pool_get_array(forcingPool, 'avgSSHGradientZonal', avgSSHGradientZonal)
-         call mpas_pool_get_array(forcingPool, 'avgSSHGradientMeridional', avgSSHGradientMeridional)
-         avgSSHGradientZonal = avgSSHGradient(index_avgZonalSSHGradient, :)
-         avgSSHGradientMeridional = avgSSHGradient(index_avgMeridionalSSHGradient, :)
          block_ptr => block_ptr % next
       end do
 
@@ -2532,7 +2521,8 @@ contains
 
    integer :: i, n
    integer, pointer :: nCellsSolve, index_temperatureSurfaceValue, index_salinitySurfaceValue, &
-                       index_avgZonalSurfaceVelocity, index_avgMeridionalSurfaceVelocity
+                       index_avgZonalSurfaceVelocity, index_avgMeridionalSurfaceVelocity, &
+                       index_avgZonalSSHGradient, index_avgMeridionalSSHGradient
 
    type (block_type), pointer :: block_ptr
 
@@ -2548,7 +2538,6 @@ contains
    integer, dimension(:), pointer :: landIceMask
 
    real (kind=RKIND), dimension(:), pointer :: seaIceEnergy, accumulatedFrazilIceMass, frazilSurfacePressure, &
-                                               avgSSHGradientZonal, avgSSHGradientMeridional, &
                                                avgTotalFreshWaterTemperatureFlux, &
                                                avgCO2_gas_flux, DMSFlux, surfaceUpwardCO2Flux, &
                                                avgOceanSurfaceDIC, &
@@ -2565,7 +2554,7 @@ contains
                                                ssh
 
    real (kind=RKIND), dimension(:,:), pointer :: avgTracersSurfaceValue, avgSurfaceVelocity, &
-                                                 avgOceanSurfacePhytoC, &
+                                                 avgSSHGradient, avgOceanSurfacePhytoC, &
                                                  avgOceanSurfaceDOC, layerThickness
 
    real (kind=RKIND) :: surfaceFreezingTemp
@@ -2612,6 +2601,8 @@ contains
      call mpas_pool_get_dimension(forcingPool, 'index_avgSalinitySurfaceValue', index_salinitySurfaceValue)
      call mpas_pool_get_dimension(forcingPool, 'index_avgSurfaceVelocityZonal', index_avgZonalSurfaceVelocity)
      call mpas_pool_get_dimension(forcingPool, 'index_avgSurfaceVelocityMeridional', index_avgMeridionalSurfaceVelocity)
+     call mpas_pool_get_dimension(forcingPool, 'index_avgSSHGradientZonal', index_avgZonalSSHGradient)
+     call mpas_pool_get_dimension(forcingPool, 'index_avgSSHGradientMeridional', index_avgMeridionalSSHGradient)
 
      call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
      call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, 1)
@@ -2619,9 +2610,9 @@ contains
      call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
      call mpas_pool_get_array(forcingPool, 'avgTracersSurfaceValue', avgTracersSurfaceValue)
      call mpas_pool_get_array(forcingPool, 'avgSurfaceVelocity', avgSurfaceVelocity)
-     call mpas_pool_get_array(forcingPool, 'avgSSHGradientZonal', avgSSHGradientZonal)
-     call mpas_pool_get_array(forcingPool, 'avgSSHGradientMeridional', avgSSHGradientMeridional)
+     call mpas_pool_get_array(forcingPool, 'avgSSHGradient', avgSSHGradient)
      call mpas_pool_get_array(forcingPool, 'avgTotalFreshWaterTemperatureFlux', avgTotalFreshWaterTemperatureFlux)
+
      if ( frazilIceActive ) then
         call mpas_pool_get_array(forcingPool, 'seaIceEnergy', seaIceEnergy)
         call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
@@ -2674,8 +2665,8 @@ contains
        o2x_o % rAttr(index_o2x_So_v, n) = avgSurfaceVelocity(index_avgMeridionalSurfaceVelocity, i)
 
        o2x_o % rAttr(index_o2x_So_ssh, n)  = ssh(i)
-       o2x_o % rAttr(index_o2x_So_dhdx, n) = avgSSHGradientZonal(i)
-       o2x_o % rAttr(index_o2x_So_dhdy, n) = avgSSHGradientMeridional(i)
+       o2x_o % rAttr(index_o2x_So_dhdx, n) = avgSSHGradient(index_avgZonalSSHGradient, i)
+       o2x_o % rAttr(index_o2x_So_dhdy, n) = avgSSHGradient(index_avgMeridionalSSHGradient, i)
 
        o2x_o % rAttr(index_o2x_Faoo_h2otemp, n) = avgTotalFreshWaterTemperatureFlux(i) * rho_sw * cp_sw
 

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -207,9 +207,9 @@ contains
     logical, pointer :: config_use_surface_salinity_monthly_restoring
     character (len=StrKIND), pointer :: config_land_ice_flux_mode
 
-    ! Added for coupling interval initialization
+    ! ssh coupling interval initialization
     integer, pointer :: index_avgZonalSSHGradient, index_avgMeridionalSSHGradient
-    real (kind=RKIND), dimension(:),   pointer :: SSHGradientZonal, SSHGradientMeridional
+    real (kind=RKIND), dimension(:),   pointer :: avgSSHGradientZonal, avgSSHGradientMeridional
     real (kind=RKIND), dimension(:,:), pointer :: avgSSHGradient
 
     interface
@@ -752,10 +752,10 @@ contains
           call mpas_pool_get_dimension(forcingPool, 'index_avgSSHGradientZonal', index_avgZonalSSHGradient)
           call mpas_pool_get_dimension(forcingPool, 'index_avgSSHGradientMeridional', index_avgMeridionalSSHGradient)
           call mpas_pool_get_array(forcingPool, 'avgSSHGradient', avgSSHGradient)
-          call mpas_pool_get_array(forcingPool, 'SSHGradientZonal', SSHGradientZonal)
-          call mpas_pool_get_array(forcingPool, 'SSHGradientMeridional', SSHGradientMeridional)
-          SSHGradientZonal      = avgSSHGradient(index_avgZonalSSHGradient,     :)
-          SSHGradientMeridional = avgSSHGradient(index_avgMeridionalSSHGradient, :)
+          call mpas_pool_get_array(forcingPool, 'avgSSHGradientZonal', avgSSHGradientZonal)
+          call mpas_pool_get_array(forcingPool, 'avgSSHGradientMeridional', avgSSHGradientMeridional)
+          avgSSHGradientZonal      = avgSSHGradient(index_avgZonalSSHGradient,     :)
+          avgSSHGradientMeridional = avgSSHGradient(index_avgMeridionalSSHGradient, :)
           block_ptr => block_ptr % next
        end do
     endif
@@ -889,7 +889,7 @@ contains
 
       ! Added for coupling interval initialization
       integer, pointer :: index_avgZonalSSHGradient, index_avgMeridionalSSHGradient
-      real (kind=RKIND), dimension(:),   pointer :: SSHGradientZonal, SSHGradientMeridional
+      real (kind=RKIND), dimension(:),   pointer :: avgSSHGradientZonal, avgSSHGradientMeridional
       real (kind=RKIND), dimension(:,:), pointer :: avgSSHGradient
       real (kind=RKIND) :: timeFilterFactor
 
@@ -1110,10 +1110,10 @@ contains
          call mpas_pool_get_dimension(forcingPool, 'index_avgSSHGradientZonal', index_avgZonalSSHGradient)
          call mpas_pool_get_dimension(forcingPool, 'index_avgSSHGradientMeridional', index_avgMeridionalSSHGradient)
          call mpas_pool_get_array(forcingPool, 'avgSSHGradient', avgSSHGradient)
-         call mpas_pool_get_array(forcingPool, 'SSHGradientZonal', SSHGradientZonal)
-         call mpas_pool_get_array(forcingPool, 'SSHGradientMeridional', SSHGradientMeridional)
-         SSHGradientZonal = avgSSHGradient(index_avgZonalSSHGradient, :)
-         SSHGradientMeridional = avgSSHGradient(index_avgMeridionalSSHGradient, :)
+         call mpas_pool_get_array(forcingPool, 'avgSSHGradientZonal', avgSSHGradientZonal)
+         call mpas_pool_get_array(forcingPool, 'avgSSHGradientMeridional', avgSSHGradientMeridional)
+         avgSSHGradientZonal = avgSSHGradient(index_avgZonalSSHGradient, :)
+         avgSSHGradientMeridional = avgSSHGradient(index_avgMeridionalSSHGradient, :)
          block_ptr => block_ptr % next
       end do
 
@@ -2548,7 +2548,7 @@ contains
    integer, dimension(:), pointer :: landIceMask
 
    real (kind=RKIND), dimension(:), pointer :: seaIceEnergy, accumulatedFrazilIceMass, frazilSurfacePressure, &
-                                               SSHGradientZonal, SSHGradientMeridional, &
+                                               avgSSHGradientZonal, avgSSHGradientMeridional, &
                                                avgTotalFreshWaterTemperatureFlux, &
                                                avgCO2_gas_flux, DMSFlux, surfaceUpwardCO2Flux, &
                                                avgOceanSurfaceDIC, &
@@ -2619,8 +2619,8 @@ contains
      call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
      call mpas_pool_get_array(forcingPool, 'avgTracersSurfaceValue', avgTracersSurfaceValue)
      call mpas_pool_get_array(forcingPool, 'avgSurfaceVelocity', avgSurfaceVelocity)
-     call mpas_pool_get_array(forcingPool, 'SSHGradientZonal', SSHGradientZonal)
-     call mpas_pool_get_array(forcingPool, 'SSHGradientMeridional', SSHGradientMeridional)
+     call mpas_pool_get_array(forcingPool, 'avgSSHGradientZonal', avgSSHGradientZonal)
+     call mpas_pool_get_array(forcingPool, 'avgSSHGradientMeridional', avgSSHGradientMeridional)
      call mpas_pool_get_array(forcingPool, 'avgTotalFreshWaterTemperatureFlux', avgTotalFreshWaterTemperatureFlux)
      if ( frazilIceActive ) then
         call mpas_pool_get_array(forcingPool, 'seaIceEnergy', seaIceEnergy)
@@ -2674,14 +2674,10 @@ contains
        o2x_o % rAttr(index_o2x_So_v, n) = avgSurfaceVelocity(index_avgMeridionalSurfaceVelocity, i)
 
        o2x_o % rAttr(index_o2x_So_ssh, n)  = ssh(i)
-       o2x_o % rAttr(index_o2x_So_dhdx, n) = SSHGradientZonal(i)
-       o2x_o % rAttr(index_o2x_So_dhdy, n) = SSHGradientMeridional(i)
+       o2x_o % rAttr(index_o2x_So_dhdx, n) = avgSSHGradientZonal(i)
+       o2x_o % rAttr(index_o2x_So_dhdy, n) = avgSSHGradientMeridional(i)
 
        o2x_o % rAttr(index_o2x_Faoo_h2otemp, n) = avgTotalFreshWaterTemperatureFlux(i) * rho_sw * cp_sw
-
-       if (ocn_rof_two_way) then
-         o2x_o % rAttr(index_o2x_So_ssh, n)       = ssh(i)
-       end if
 
        if ( frazilIceActive ) then
           ! negative when frazil ice can be melted

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -209,7 +209,7 @@ contains
 
     ! Added for coupling interval initialization
     integer, pointer :: index_avgZonalSSHGradient, index_avgMeridionalSSHGradient
-    real (kind=RKIND), dimension(:),   pointer :: filteredSSHGradientZonal, filteredSSHGradientMeridional
+    real (kind=RKIND), dimension(:),   pointer :: SSHGradientZonal, SSHGradientMeridional
     real (kind=RKIND), dimension(:,:), pointer :: avgSSHGradient
 
     interface
@@ -752,10 +752,10 @@ contains
           call mpas_pool_get_dimension(forcingPool, 'index_avgSSHGradientZonal', index_avgZonalSSHGradient)
           call mpas_pool_get_dimension(forcingPool, 'index_avgSSHGradientMeridional', index_avgMeridionalSSHGradient)
           call mpas_pool_get_array(forcingPool, 'avgSSHGradient', avgSSHGradient)
-          call mpas_pool_get_array(forcingPool, 'filteredSSHGradientZonal', filteredSSHGradientZonal)
-          call mpas_pool_get_array(forcingPool, 'filteredSSHGradientMeridional', filteredSSHGradientMeridional)
-          filteredSSHGradientZonal      = avgSSHGradient(index_avgZonalSSHGradient,     :)
-          filteredSSHGradientMeridional = avgSSHGradient(index_avgMeridionalSSHGradient, :)
+          call mpas_pool_get_array(forcingPool, 'SSHGradientZonal', SSHGradientZonal)
+          call mpas_pool_get_array(forcingPool, 'SSHGradientMeridional', SSHGradientMeridional)
+          SSHGradientZonal      = avgSSHGradient(index_avgZonalSSHGradient,     :)
+          SSHGradientMeridional = avgSSHGradient(index_avgMeridionalSSHGradient, :)
           block_ptr => block_ptr % next
        end do
     endif
@@ -889,9 +889,8 @@ contains
 
       ! Added for coupling interval initialization
       integer, pointer :: index_avgZonalSSHGradient, index_avgMeridionalSSHGradient
-      real (kind=RKIND), dimension(:),   pointer :: filteredSSHGradientZonal, filteredSSHGradientMeridional
+      real (kind=RKIND), dimension(:),   pointer :: SSHGradientZonal, SSHGradientMeridional
       real (kind=RKIND), dimension(:,:), pointer :: avgSSHGradient
-      real (kind=RKIND), pointer :: config_ssh_grad_relax_timescale
       real (kind=RKIND) :: timeFilterFactor
 
       iam = domain % dminfo % my_proc_id
@@ -1104,29 +1103,17 @@ contains
          if (debugOn) call mpas_log_write('Completed timestep '//trim(timeStamp))
       end do
 
-      ! update coupled variables that get calculated on coupling intervals
-      ! NOTE: could be moved to subroutine
-      ! time filter ssh gradient
+      ! update coupled variables that are calculated on coupling intervals
       block_ptr => domain_ptr % blocklist
       do while(associated(block_ptr))
          call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
          call mpas_pool_get_dimension(forcingPool, 'index_avgSSHGradientZonal', index_avgZonalSSHGradient)
          call mpas_pool_get_dimension(forcingPool, 'index_avgSSHGradientMeridional', index_avgMeridionalSSHGradient)
          call mpas_pool_get_array(forcingPool, 'avgSSHGradient', avgSSHGradient)
-         call mpas_pool_get_array(forcingPool, 'filteredSSHGradientZonal', filteredSSHGradientZonal)
-         call mpas_pool_get_array(forcingPool, 'filteredSSHGradientMeridional', filteredSSHGradientMeridional)
-         call mpas_pool_get_config(domain % configs, 'config_ssh_grad_relax_timescale', &
-                                                      config_ssh_grad_relax_timescale)
-         if (config_ssh_grad_relax_timescale < real(ocn_cpl_dt,RKIND)) then
-            filteredSSHGradientZonal = avgSSHGradient(index_avgZonalSSHGradient, :)
-            filteredSSHGradientMeridional = avgSSHGradient(index_avgMeridionalSSHGradient, :)
-         else
-            timeFilterFactor = real(ocn_cpl_dt,RKIND) / config_ssh_grad_relax_timescale
-            filteredSSHGradientZonal = filteredSSHGradientZonal * (1.0_RKIND - timeFilterFactor) + &
-                 avgSSHGradient(index_avgZonalSSHGradient, :) * timeFilterFactor
-            filteredSSHGradientMeridional = filteredSSHGradientMeridional * (1.0_RKIND - timeFilterFactor) + &
-                 avgSSHGradient(index_avgMeridionalSSHGradient, :) * timeFilterFactor
-         endif
+         call mpas_pool_get_array(forcingPool, 'SSHGradientZonal', SSHGradientZonal)
+         call mpas_pool_get_array(forcingPool, 'SSHGradientMeridional', SSHGradientMeridional)
+         SSHGradientZonal = avgSSHGradient(index_avgZonalSSHGradient, :)
+         SSHGradientMeridional = avgSSHGradient(index_avgMeridionalSSHGradient, :)
          block_ptr => block_ptr % next
       end do
 
@@ -2561,7 +2548,7 @@ contains
    integer, dimension(:), pointer :: landIceMask
 
    real (kind=RKIND), dimension(:), pointer :: seaIceEnergy, accumulatedFrazilIceMass, frazilSurfacePressure, &
-                                               filteredSSHGradientZonal, filteredSSHGradientMeridional, &
+                                               SSHGradientZonal, SSHGradientMeridional, &
                                                avgTotalFreshWaterTemperatureFlux, &
                                                avgCO2_gas_flux, DMSFlux, surfaceUpwardCO2Flux, &
                                                avgOceanSurfaceDIC, &
@@ -2632,8 +2619,8 @@ contains
      call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
      call mpas_pool_get_array(forcingPool, 'avgTracersSurfaceValue', avgTracersSurfaceValue)
      call mpas_pool_get_array(forcingPool, 'avgSurfaceVelocity', avgSurfaceVelocity)
-     call mpas_pool_get_array(forcingPool, 'filteredSSHGradientZonal', filteredSSHGradientZonal)
-     call mpas_pool_get_array(forcingPool, 'filteredSSHGradientMeridional', filteredSSHGradientMeridional)
+     call mpas_pool_get_array(forcingPool, 'SSHGradientZonal', SSHGradientZonal)
+     call mpas_pool_get_array(forcingPool, 'SSHGradientMeridional', SSHGradientMeridional)
      call mpas_pool_get_array(forcingPool, 'avgTotalFreshWaterTemperatureFlux', avgTotalFreshWaterTemperatureFlux)
      if ( frazilIceActive ) then
         call mpas_pool_get_array(forcingPool, 'seaIceEnergy', seaIceEnergy)
@@ -2687,8 +2674,8 @@ contains
        o2x_o % rAttr(index_o2x_So_v, n) = avgSurfaceVelocity(index_avgMeridionalSurfaceVelocity, i)
 
        o2x_o % rAttr(index_o2x_So_ssh, n)  = ssh(i)
-       o2x_o % rAttr(index_o2x_So_dhdx, n) = filteredSSHGradientZonal(i)
-       o2x_o % rAttr(index_o2x_So_dhdy, n) = filteredSSHGradientMeridional(i)
+       o2x_o % rAttr(index_o2x_So_dhdx, n) = SSHGradientZonal(i)
+       o2x_o % rAttr(index_o2x_So_dhdy, n) = SSHGradientMeridional(i)
 
        o2x_o % rAttr(index_o2x_Faoo_h2otemp, n) = avgTotalFreshWaterTemperatureFlux(i) * rho_sw * cp_sw
 

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1923,8 +1923,7 @@
 			<var name="accumulatedLandIceHeat"/>
 			<var name="accumulatedLandIceFrazilMass"/>
 			<var name="frazilSurfacePressure"/>
-			<var name="avgSSHGradientZonal"/>
-			<var name="avgSSHGradientMeridional"/>
+			<var_array name="avgSSHGradient"/>
 			<var name="forcingGroupNames"/>
 			<var name="forcingGroupRestartTimes"/>
             <var name="gotmVertViscTopOfCell"/>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1923,8 +1923,8 @@
 			<var name="accumulatedLandIceHeat"/>
 			<var name="accumulatedLandIceFrazilMass"/>
 			<var name="frazilSurfacePressure"/>
-			<var name="filteredSSHGradientZonal"/>
-			<var name="filteredSSHGradientMeridional"/>
+			<var name="SSHGradientZonal"/>
+			<var name="SSHGradientMeridional"/>
 			<var name="forcingGroupNames"/>
 			<var name="forcingGroupRestartTimes"/>
             <var name="gotmVertViscTopOfCell"/>
@@ -3663,12 +3663,12 @@
 				 description="Time averaged meridional gradient of SSH"
 			/>
 		</var_array>
-		<var name="filteredSSHGradientZonal" type="real" dimensions="nCells Time" units="1"
-			description="Time filtered zonal gradient of SSH"
+		<var name="SSHGradientZonal" type="real" dimensions="nCells Time" units="1"
+			description="Zonal gradient of SSH"
 			packages="forwardMode;analysisMode"
 		/>
-		<var name="filteredSSHGradientMeridional" type="real" dimensions="nCells Time" units="1"
-			description="Time filtered meridional gradient of SSH"
+		<var name="SSHGradientMeridional" type="real" dimensions="nCells Time" units="1"
+			description="Meridional gradient of SSH"
 			packages="forwardMode;analysisMode"
 		/>
 		<var name="avgTotalFreshWaterTemperatureFlux" type="real" dimensions="nCells Time" units="C m s^-1"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -755,10 +755,6 @@
 		/>
 	</nml_record>
 	<nml_record name="coupling" mode="init;forward">
-		<nml_option name="config_ssh_grad_relax_timescale" type="real" default_value="0.0" units="seconds"
-					description="Timescale for relaxation of the ssh gradient for coupling. A value of 0.0 (default) removes any relaxation and gives instantaneous response."
-					possible_values="Any positive real number."
-		/>
 		<nml_option name="config_remove_AIS_coupler_runoff" type="logical" default_value=".false."
 					description="If true, solid and liquid runoff from the Antarctic Ice Sheet (below 60S latitude) coming from the coupled is zeroed in the coupler import routines.  To be used with data iceberg fluxes coming from the sea ice model."
 					possible_values=".true. or .false."

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1923,8 +1923,8 @@
 			<var name="accumulatedLandIceHeat"/>
 			<var name="accumulatedLandIceFrazilMass"/>
 			<var name="frazilSurfacePressure"/>
-			<var name="SSHGradientZonal"/>
-			<var name="SSHGradientMeridional"/>
+			<var name="avgSSHGradientZonal"/>
+			<var name="avgSSHGradientMeridional"/>
 			<var name="forcingGroupNames"/>
 			<var name="forcingGroupRestartTimes"/>
             <var name="gotmVertViscTopOfCell"/>
@@ -3663,14 +3663,6 @@
 				 description="Time averaged meridional gradient of SSH"
 			/>
 		</var_array>
-		<var name="SSHGradientZonal" type="real" dimensions="nCells Time" units="1"
-			description="Zonal gradient of SSH"
-			packages="forwardMode;analysisMode"
-		/>
-		<var name="SSHGradientMeridional" type="real" dimensions="nCells Time" units="1"
-			description="Meridional gradient of SSH"
-			packages="forwardMode;analysisMode"
-		/>
 		<var name="avgTotalFreshWaterTemperatureFlux" type="real" dimensions="nCells Time" units="C m s^-1"
 			 description="Sum of heat fluxes associated with water fluxes cell centers sent to coupler. Positive into the ocean."
 		/>


### PR DESCRIPTION
This removes sea surface height gradient filtering from MPAS-Ocean coupling with MPAS-SeaIce, which is a stealth option in E3SM.  This option was used in E3SM Version 1 to provide a temporary solution to "tiger stripes" in sea ice concentration associated with non-linear feedbacks between multiple bugs in the sea ice and ocean codes.  The "tiger stripes" were reduced by time filtering sea surface height gradient passed from the ocean to the sea ice model through the coupler.   The time filtering option was switched off in Version 2 of E3SM, but the code remained as a stealth option.   This PR completely removes this stealth option for Version 3.  The option should not be used in future. 

Changes introduced in this PR have been tested on chrysalis in a 1-month standard -resolution G-case (GMPAS-JRA1p5 TL319_EC30to60E2r2) from initial conditions. That test was BFB with the control for this code change at the end of the respective month simulations.  The code change also passes exact restart (ERS.TL319_EC30to60E2r2.GMPAS-JRA.chrysalis_intel) and processor count (PEM.T62_oQU240.GMPAS-IAF.chrysalis_intel) tests in E3SM.  The changes do not affect energy and mass conservation. Redundant ssh coupler communication code has also been removed as part of this PR.  

This change is BFB and should be included as part of the E3SM Version 3 release.

[NML]