### PR TITLE
MPAS-SeaIce netcdf output finalization for E3SM V3

### DIFF
--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -461,7 +461,7 @@
 			possible_values="'restart', 'uniform', 'circle', 'square', 'uniform_interior' or 'uniform_1D'"
 		/>
 		<nml_option name="config_initial_ice_area" type="real" default_value="1.0" units="unitless"
-			description="Sea ice concentration at initialization."
+			description="Sea ice fraction at initialization."
 			possible_values="A real number between 0.0 and 1.0 inclusive."
 		/>
 		<nml_option name="config_initial_ice_volume" type="real" default_value="1.0" units="m"
@@ -2661,12 +2661,12 @@
 		<package name="pkgColumnBiogeochemistry" description=""/>
 
 		<!-- column tracer packages -->
-		<package name="pkgColumnTracerIceAge" description=""/>
-		<package name="pkgColumnTracerFirstYearIce" description=""/>
-		<package name="pkgColumnTracerLevelIce" description=""/>
-		<package name="pkgColumnTracerPonds" description=""/>
-		<package name="pkgColumnTracerLidThickness" description=""/>
-		<package name="pkgColumnTracerAerosols" description=""/>
+		<package name="pkgColumnTracerIceAge" description="Chronological age tracer"/>
+		<package name="pkgColumnTracerFirstYearIce" description="Fraction of grid cell area covered by first-year ice"/>
+		<package name="pkgColumnTracerLevelIce" description="Undeformed sea ice area and volume tracers"/>
+		<package name="pkgColumnTracerPonds" description="Pond area and volume tracers"/>
+		<package name="pkgColumnTracerLidThickness" description="Refrozen pond thickness tracer"/>
+		<package name="pkgColumnTracerAerosols" description="Evolves aerosol tracers in ice and snow"/>
 		<package name="pkgColumnTracerEffectiveSnowDensity" description="Computes effective snow density based on snow compaction"/>
 		<package name="pkgColumnTracerSnowGrainRadius" description="Evolves snow grain radius for radiative transfer based on dry and wet metamorphism"/>
 		<package name="pkgTracerBrine" description=""/>
@@ -2729,13 +2729,13 @@
 		     type="real"
 		     dimensions="ONE nCategories nCells Time"
 		     units="m"
-		     description="Ice volume per unit area of sea ice per ice thickness category"
+		     description="Ice volume per unit grid cell area, per ice thickness category"
 		/>
 		<var name="snowVolumeCategory"
 		     type="real"
 		     dimensions="ONE nCategories nCells Time"
 		     units="m"
-		     description="Ice volume per unit area of sea ice per ice thickness category"
+		     description="Snow volume per unit grid cell area, per ice thickness category"
 		/>
 		<var name="surfaceTemperature"
 		     type="real"
@@ -2747,82 +2747,96 @@
 		     type="real"
 		     dimensions="nIceLayers nCategories nCells Time"
 		     units="J m-3"
+		     description="Total heat content per unit volume of ice in layer of ice thickness category"
 		/>
 		<var name="iceSalinity"
 		     type="real"
 		     dimensions="nIceLayers nCategories nCells Time"
 		     units="1e-3"
+		     description="Salt content per unit volume of ice in layer of ice thickness category"
 		/>
 		<var name="snowEnthalpy"
 		     type="real"
 		     dimensions="nSnowLayers nCategories nCells Time"
 		     units="J m-3"
+		     description="Heat content per unit volume of snow in snow layer on ice thickness category"
 		/>
 		<var name="snowIceMass"
 		     type="real"
 		     dimensions="nSnowLayers nCategories nCells Time"
 		     units="kg m-3"
 		     packages="pkgColumnTracerSnowGrainRadius"
+		     description="Mass of crystalline ice per unit snow layer volume, per ice thickness category"
 		/>
 		<var name="snowLiquidMass"
 		     type="real"
 		     dimensions="nSnowLayers nCategories nCells Time"
 		     units="kg m-3"
 		     packages="pkgColumnTracerSnowGrainRadius"
+		     description="Mass of liquid water per unit snow layer volume, per ice thickness category"
 		/>
 		<var name="snowGrainRadius"
 		     type="real"
 		     dimensions="nSnowLayers nCategories nCells Time"
 		     units="um"
 		     packages="pkgColumnTracerSnowGrainRadius"
+		     description="Snow grain radius in snow layer, per ice thickness category"
 		/>
 		<var name="snowDensity"
 		     type="real"
 		     dimensions="nSnowLayers nCategories nCells Time"
 		     units="kg m-3"
 		     packages="pkgColumnTracerEffectiveSnowDensity"
+		     description="Density of snow due to compaction by wind"
 		/>
 		<var name="iceAge"
 		     type="real"
 		     dimensions="ONE nCategories nCells Time"
 		     units="s"
 		     packages="pkgColumnTracerIceAge"
+                     description="Chronological age tracer, per ice thickness category"
 		/>
 		<var name="firstYearIceArea"
 		     type="real"
 		     dimensions="ONE nCategories nCells Time"
 		     units="1"
 		     packages="pkgColumnTracerFirstYearIce"
+                     description="Area tracer for first-year ice, per ice thickness category"
 		/>
 		<var name="levelIceArea"
 		     type="real"
 		     dimensions="ONE nCategories nCells Time"
 		     units="1"
 		     packages="pkgColumnTracerLevelIce"
+                     description="Undeformed fraction of sea ice area, per ice thickness category"
 		/>
 		<var name="levelIceVolume"
 		     type="real"
 		     dimensions="ONE nCategories nCells Time"
-		     units="m"
+		     units="1"
 		     packages="pkgColumnTracerLevelIce"
+                     description="Undeformed fraction of sea ice volume, per ice thickness category"
 		/>
 		<var name="pondArea"
 		     type="real"
 		     dimensions="ONE nCategories nCells Time"
 		     units="1"
 		     packages="pkgColumnTracerPonds"
+                     description="Fraction of sea ice area covered in ponds, per ice thickness category"
 		/>
 		<var name="pondDepth"
 		     type="real"
 		     dimensions="ONE nCategories nCells Time"
 		     units="m"
 		     packages="pkgColumnTracerPonds"
+                     description="Depth of ponds, per ice thickness category"
 		/>
 		<var name="pondLidThickness"
 		     type="real"
 		     dimensions="ONE nCategories nCells Time"
 		     units="m"
 		     packages="pkgColumnTracerLidThickness"
+                     description="Thickness of refrozen pond water, per ice thickness category"
 		/>
 		<var name="snowScatteringAerosol"
 		     type="real"
@@ -3173,62 +3187,65 @@
 		     type="real"
 		     dimensions="nCells Time"
 		     units="m"
-		     description="Ice volume per unit area of sea ice"
+		     description="Ice volume per unit area of grid cell"
 		/>
 		<var name="snowVolumeCell"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="m"
-		     description="Snow volume per unit area of sea ice"
+		     description="Snow volume per unit area of grid cell"
 		/>
 		<var name="surfaceTemperatureCell"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="C"
 		     standard_name="sea_ice_surface_temperature"
-		     description="Surface temperature of ice/snow"
+		     description="Average surface temperature over ice/snow"
 		/>
 		<var name="iceEnthalpyCell"
 		     type="real"
 		     dimensions="nIceLayers nCells Time"
 		     units="J m-3"
+		     description="Heat content per unit volume of ice in ice layer"
 		/>
 		<var name="iceSalinityCell"
 		     type="real"
 		     dimensions="nIceLayers nCells Time"
 		     units="1e-3"
+		     description="Salt content per unit volume of ice in ice layer"
 		/>
 		<var name="snowEnthalpyCell"
 		     type="real"
 		     dimensions="nSnowLayers nCells Time"
 		     units="J m-3"
+		     description="Heat content per unit volume of snow in snow layer"
 		/>
 		<var name="snowIceMassCell"
 		     type="real"
 		     dimensions="nSnowLayers nCells Time"
 		     units="kg m-3"
-		     description="Mass of ice in snow layer"
+		     description="Mass of ice per unit snow layer volume"
 		     packages="pkgColumnTracerSnowGrainRadius"
 		/>
 		<var name="snowLiquidMassCell"
 		     type="real"
 		     dimensions="nSnowLayers nCells Time"
 		     units="kg m-3"
-		     description="Mass of liquid in snow layer"
+		     description="Mass of liquid water per unit snow layer volume"
 		     packages="pkgColumnTracerSnowGrainRadius"
 		/>
 		<var name="snowGrainRadiusCell"
 		     type="real"
 		     dimensions="nSnowLayers nCells Time"
 		     units="um"
-		     description="Effective snow grain radius"
+		     description="Average effective snow grain radius over snow layer"
 		     packages="pkgColumnTracerSnowGrainRadius"
 		/>
 		<var name="snowDensityCell"
 		     type="real"
 		     dimensions="nSnowLayers nCells Time"
 		     units="kg m-3"
-		     description="Prognostic snow density"
+		     description="Average prognostic snow density over snow layer"
 		     packages="pkgColumnTracerEffectiveSnowDensity"
 		/>
 		<var name="iceAgeCell"
@@ -3236,42 +3253,49 @@
 		     dimensions="nCells Time"
 		     units="s"
 		     standard_name="age_of_sea_ice"
+                     description="Average chronological age of sea ice"
 		     packages="pkgColumnTracerIceAge"
 		/>
 		<var name="firstYearIceAreaCell"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="1"
+                     description="First-year area fraction of sea ice"
 		     packages="pkgColumnTracerFirstYearIce"
 		/>
 		<var name="levelIceAreaCell"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="1"
+                     description="Undeformed fraction of sea ice area"
 		     packages="pkgColumnTracerLevelIce"
 		/>
 		<var name="levelIceVolumeCell"
 		     type="real"
 		     dimensions="nCells Time"
-		     units="m"
+		     units="1"
+                     description="Undeformed fraction of sea ice volume"
 		     packages="pkgColumnTracerLevelIce"
 		/>
 		<var name="pondAreaCell"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="1"
+                     description="Fraction of sea ice area covered in ponds"
 		     packages="pkgColumnTracerPonds"
 		/>
 		<var name="pondDepthCell"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="m"
+                     description="Average depth of ponds over sea ice"
 		     packages="pkgColumnTracerPonds"
 		/>
 		<var name="pondLidThicknessCell"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="m"
+                     description="Average thickness of refrozen pond water over ponds"
 		     packages="pkgColumnTracerLidThickness"
 		/>
 		<var name="snowScatteringAerosolCell"
@@ -3645,31 +3669,37 @@
 		     type="real"
 		     dimensions="nCells Time"
 		     units="1"
+		     description="Initial fraction of grid cell covered in sea ice"
 		/>
 		<var name="iceAreaCategoryInitial"
 		     type="real"
 		     dimensions="nCategories nCells Time"
 		     units="1"
+		     description="Initial fraction of grid cell covered in sea ice per ice thickness category"
 		/>
 		<var name="iceVolumeCategoryInitial"
 		     type="real"
 		     dimensions="nCategories nCells Time"
 		     units="m"
+		     description="Initial ice volume per unit grid cell area per ice thickness category"
 		/>
 		<var name="iceThicknessCategoryInitial"
 		     type="real"
 		     dimensions="nCategories nCells Time"
 		     units="m"
+		     description="Initial thickness of ice thickness category"
 		/>
 		<var name="snowVolumeCategoryInitial"
 		     type="real"
 		     dimensions="nCategories nCells Time"
 		     units="m"
+		     description="Snow volume per unit grid cell area per ice thickness category"
 		/>
 		<var name="openWaterArea"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="1"
+		     description="Fraction of grid cell without ice"
 		/>
 		<var name="iceAreaVertex"
 		     type="real"
@@ -3680,6 +3710,7 @@
 		     type="real"
 		     dimensions="nCells Time"
 		     units="kg m-2"
+		     description="Mass per unit grid cell area"
 		/>
 		<var name="totalMassVertex"
 		     type="real"
@@ -3757,12 +3788,14 @@
 		     dimensions="nCells Time"
 		     units="K"
 		     default_value="253.0"
+                     description="2m air temperature"
 		/>
 		<var name="airSpecificHumidity"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="1"
 		     default_value="0.0006"
+                     description="2m air humidity"
 		/>
 		<var name="airDensity"
 		     type="real"
@@ -3795,6 +3828,7 @@
 		     dimensions="nCells Time"
 		     units="W m-2"
 		     default_value="180.0"
+                     description="Downwelling longwave radiation"
 		/>
 		<var name="rainfallRate"
 		     type="real"
@@ -3811,12 +3845,14 @@
 		     dimensions="nCells Time"
 		     units="m s-1"
 		     default_value="5.0"
+                     description="Surface u-wind at cell center in native model direction"
 		/>
 		<var name="vAirVelocity"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="m s-1"
 		     default_value="5.0"
+                     description="Surface v-wind at cell center in native model direction"
 		/>
 		<var name="atmosReferenceSpeed10m"
 		     type="real"
@@ -3858,6 +3894,7 @@
 		     type="real"
 		     dimensions="nCells Time"
 		     units="W m-2"
+                     description="Downwelling shortwave radiation"
 		/>
 		<var name="cloudFraction"
 		     type="real"
@@ -3910,12 +3947,14 @@
 		     type="real"
 		     dimensions="nCells Time"
 		     units="C"
+                     description="Sea surface temperature"
 		/>
 		<var name="seaSurfaceSalinity"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="1e-3"
 		     default_value="34.0"
+                     description="Sea surface salinity"
 		/>
 		<var name="seaFreezingTemperature"
 		     type="real"
@@ -3931,6 +3970,7 @@
 		     type="real"
 		     dimensions="nCells Time"
 		     units="W m-2"
+                     description="Ocean freezing/melting potential"
 		/>
 		<var name="frazilMassAdjust"
 		     type="real"
@@ -4079,6 +4119,7 @@
 		     type="real"
 		     dimensions="nCells Time"
 		     units="N m-1"
+                     description="Ice pressure"
 		/>
 		<var name="stressDivergenceU"
 		     type="real"
@@ -4174,11 +4215,13 @@
 		     type="real"
 		     dimensions="nCells Time"
 		     units="percent day-1"
+                     description="Ice divergence"
 		/>
 		<var name="shear"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="percent day-1"
+                     description="Ice shear"
 		/>
 		<var name="dynamicallyLockedCellsMask"
 		     type="integer"
@@ -4338,12 +4381,14 @@
 		     dimensions="maxEdges nCells Time"
 		     units="N m-1"
 		     name_in_code="principalStress1"
+                     description="First component of principal stress (variational formulation)"
 		/>
 		<var name="principalStress2Var"
 		     type="real"
 		     dimensions="maxEdges nCells Time"
 		     units="N m-1"
 		     name_in_code="principalStress2"
+                     description="Second component of principal stress (variational formulation)"
 		/>
 		<var name="replacementPressureVar"
 		     type="real"
@@ -4385,74 +4430,89 @@
 		     type="real"
 		     dimensions="nCells Time"
 		     units="s-1"
+		     description="Normalized energy dissipation due to convergence"
 		/>
 		<var name="ridgeShear"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="s-1"
+		     description="Normalized energy dissipation due to shear"
 		/>
 		<var name="areaLossRidge"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="s-1"
+		     description="Rate of fractional area loss by ridging"
 		/>
 		<var name="areaGainRidge"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="s-1"
+		     description="Rate of fractional area gain by new ridges"
 		/>
 		<var name="iceVolumeRidged"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="m s-1"
+		     description="Rate of ice volume ridged per unit ice area"
 		/>
 		<var name="openingRateRidge"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="s-1"
+		     description="Rate of opening due to divergence/shear"
 		/>
 		<var name="ridgeParticipationFunction"
 		     type="real"
 		     dimensions="nCategories nCells Time"
+		     description="Fraction of total area lost by ice thickness category due to ridging/closing"
 		/>
 		<var name="ratioRidgeThicknessToIce"
 		     type="real"
 		     dimensions="nCategories nCells Time"
+		     description="Ratio of mean ridge thickness to thickness of ridging ice in ice thickness category"
 		/>
 		<var name="fractionNewRidgeArea"
 		     type="real"
 		     dimensions="nCategories nCells Time"
 		     units="1"
+		     description="Fraction of new ridged area going to ice thickness category"
 		/>
 		<var name="fractionNewRidgeVolume"
 		     type="real"
 		     dimensions="nCategories nCells Time"
 		     units="1"
+		     description="Fraction of new ridged volume going to ice thickness category"
 		/>
 		<var name="areaLossRidgeCategory"
 		     type="real"
 		     dimensions="nCategories nCells Time"
 		     units="s-1"
+		     description="Rate of area loss by ridging ice, per ice thickness category"
 		/>
 		<var name="areaGainRidgeCategory"
 		     type="real"
 		     dimensions="nCategories nCells Time"
 		     units="s-1"
+		     description="Rate of area gain by new ridges, per ice thickness category"
 		/>
 		<var name="iceVolumeRidgedCategory"
 		     type="real"
 		     dimensions="nCategories nCells Time"
 		     units="m s-1"
+		     description="Rate of ice volume ridged per unit ice area, per ice thickness category"
 		/>
 		<var name="raftingIceArea"
 		     type="real"
 		     dimensions="nCategories nCells Time"
 		     units="1"
+		     description="Rafted ice area fraction, per ice thickness category"
 		/>
 		<var name="raftingIceVolume"
 		     type="real"
 		     dimensions="nCategories nCells Time"
 		     units="m"
+		     description="Rafted ice area volume per unit ice area, per ice thickness category"
 		/>
 	</var_struct>
 
@@ -4477,6 +4537,7 @@
 		     type="real"
 		     dimensions="nCells Time"
 		     units="m s-1"
+                     description="Surface ice melt"
 		/>
 		<var name="surfaceIceMeltCategory"
 		     type="real"
@@ -4487,6 +4548,7 @@
 		     type="real"
 		     dimensions="nCells Time"
 		     units="m s-1"
+                     description="Basal ice melt"
 		/>
 		<var name="basalIceMeltCategory"
 		     type="real"
@@ -4497,11 +4559,13 @@
 		     type="real"
 		     dimensions="nCells Time"
 		     units="m s-1"
+                     description="Lateral ice melt"
 		/>
 		<var name="snowMelt"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="m s-1"
+                     description="Snow melt"
 		/>
 		<var name="snowMeltCategory"
 		     type="real"
@@ -4512,6 +4576,7 @@
 		     type="real"
 		     dimensions="nCells Time"
 		     units="m s-1"
+                     description="Congelation ice growth"
 		/>
 		<var name="congelationCategory"
 		     type="real"
@@ -4522,6 +4587,7 @@
 		     type="real"
 		     dimensions="nCells Time"
 		     units="m s-1"
+                     description="Snow-ice formation"
 		/>
 		<var name="snowiceFormationCategory"
 		     type="real"
@@ -4547,6 +4613,7 @@
 		     type="real"
 		     dimensions="nCells Time"
 		     units="m s-1"
+                     description="Frazil ice formation"
 		/>
 		<var name="frazilGrowthDiagnostic"
 		     type="real"
@@ -4625,41 +4692,49 @@
 		     type="real"
 		     dimensions="nCells Time"
 		     units="kg m-2 s-1"
+                     description="Freshwater flux to ocean from ice column"
 		/>
 		<var name="oceanSaltFlux"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="kg m-2 s-1"
+                     description="Salt flux to ocean from ice column"
 		/>
 		<var name="oceanHeatFlux"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="W m-2"
+                     description="Heat flux to ocean from ice column"
 		/>
 		<var name="oceanShortwaveFlux"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="W m-2"
+                     description="Shortwave flux to ocean from ice column"
 		/>
 		<var name="oceanFreshWaterFluxArea"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="kg m-2 s-1"
+                     description="Freshwater flux to ocean weighted by ice area fraction"
 		/>
 		<var name="oceanSaltFluxArea"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="kg m-2 s-1"
+                     description="Salt flux to ocean weighted by ice area fraction"
 		/>
 		<var name="oceanHeatFluxArea"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="W m-2"
+                     description="Heat flux to ocean weighted by ice area fraction"
 		/>
 		<var name="oceanShortwaveFluxArea"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="W m-2"
+                     description="Shortwave flux to ocean weighted by ice area fraction"
 		/>
 		<var name="oceanHeatFluxIceBottom"
 		     type="real"
@@ -4780,65 +4855,79 @@
 		     type="real"
 		     dimensions="nCategories nCells Time"
 		     units="1"
+                     description="Visible direct albedo over ice thickness category"
 		/>
 		<var name="albedoVisibleDiffuseCategory"
 		     type="real"
 		     dimensions="nCategories nCells Time"
 		     units="1"
+                     description="Visible diffuse albedo over ice thickness category"
 		/>
 		<var name="albedoIRDirectCategory"
 		     type="real"
 		     dimensions="nCategories nCells Time"
 		     units="1"
+                     description="Near IR direct albedo over ice thickness category"
 		/>
 		<var name="albedoIRDiffuseCategory"
 		     type="real"
 		     dimensions="nCategories nCells Time"
 		     units="1"
+                     description="Near IR diffuse albedo over ice thickness category"
 		/>
 		<var name="albedoVisibleDirectCell"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="1"
+                     description="Visible direct albedo weighted by ice area"
 		/>
 		<var name="albedoVisibleDiffuseCell"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="1"
+                     description="Visible diffuse albedo weighted by ice area"
 		/>
 		<var name="albedoIRDirectCell"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="1"
+                     description="Near IR direct albedo weighted by ice area"
 		/>
 		<var name="albedoIRDiffuseCell"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="1"
+                     description="Near IR diffuse albedo weighted by ice area"
 		/>
 		<var name="albedoVisibleDirectArea"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="1"
+                     description="Visible direct albedo weighted by ice area"
 		/>
 		<var name="albedoVisibleDiffuseArea"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="1"
+                     description="Visible diffuse albedo weighted by ice area"
 		/>
 		<var name="albedoIRDirectArea"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="1"
+                     description="Near IR direct albedo weighted by ice area"
 		/>
 		<var name="albedoIRDiffuseArea"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="1"
+                     description="Near IR diffuse albedo weighted by ice area"
 		/>
 		<var name="shortwaveScalingFactor"
 		     type="real"
 		     dimensions="nCells Time"
+                     units="1"
+                     description="Shortwave scaling factor"
 		/>
 		<var name="surfaceShortwaveFlux"
 		     type="real"
@@ -4899,46 +4988,55 @@
 		     type="real"
 		     dimensions="nCategories nCells Time"
 		     units="1"
+                     description="Bare ice albedo per category"
 		/>
 		<var name="snowAlbedoCategory"
 		     type="real"
 		     dimensions="nCategories nCells Time"
 		     units="1"
+                     description="Snow albedo per category"
 		/>
 		<var name="pondAlbedoCategory"
 		     type="real"
 		     dimensions="nCategories nCells Time"
 		     units="1"
+                     description="Pond albedo per category"
 		/>
 		<var name="bareIceAlbedoCell"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="1"
+                     description="Cell-averaged bare ice albedo"
 		/>
 		<var name="snowAlbedoCell"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="1"
+                     description="Cell-averaged snow albedo"
 		/>
 		<var name="pondAlbedoCell"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="1"
+                     description="Cell-averaged pond albedo"
 		/>
 		<var name="effectivePondAreaCategory"
 		     type="real"
 		     dimensions="nCategories nCells Time"
 		     units="1"
+                     description="radiation-effective pond area fraction of ice thickness category"
 		/>
 		<var name="effectivePondAreaCell"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="1"
+                     description="radiation-effective pond area fraction of grid cell"
 		/>
 		<var name="snowFractionCategory"
 		     type="real"
 		     dimensions="nCategories nCells Time"
 		     units="1"
+                     description="snow fraction on each category used for radiation"
 		/>
 	</var_struct>
 
@@ -5055,21 +5153,24 @@
 		     type="real"
 		     dimensions="nCells Time"
 		     units="kg m-3"
+                     description="Snow density based on ice and liquid water content"
 		/>
 		<var name="snowDensityViaCompaction"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="kg m-3"
+                     description="Snow density based on wind compaction"
 		/>
 		<var name="snowLossToLeads"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="kg m-2 s-1"
+                     description="Rate of snow loss to leads per unit grid cell area"
 		/>
 		<var name="snowMeltMassCell"
 		     type="real"
 		     dimensions="nCells Time"
-		     units="kg m-2 dt-1"
+		     units="kg m-2"
 		/>
 		<var name="snowMeltMassCategory"
 		     type="real"
@@ -5616,29 +5717,37 @@
 		     type="real"
 		     dimensions="nCells Time"
 		     units="s-1"
+                     description="Time derivative of ice area due to transport"
 		/>
 		<var name="iceVolumeTendencyTransport"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="m s-1"
+                     description="Time derivative of ice volume due to transport"
 		/>
 		<var name="iceAgeTendencyTransport"
 		     type="real"
 		     dimensions="nCells Time"
+                     units="s s-1"
+                     description="Time derivative of ice age due to transport"
 		/>
 		<var name="iceAreaTendencyThermodynamics"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="s-1"
+                     description="Time derivative of ice area due to thermodynamics"
 		/>
 		<var name="iceVolumeTendencyThermodynamics"
 		     type="real"
 		     dimensions="nCells Time"
 		     units="m s-1"
+                     description="Time derivative of ice volume due to thermodynamics"
 		/>
 		<var name="iceAgeTendencyThermodynamics"
 		     type="real"
 		     dimensions="nCells Time"
+                     units="s s-1"
+                     description="Time derivative of ice age due to thermodynamics"
 		/>
 		<var name="freezingMeltingPotentialInitial"
 		     type="real"

--- a/components/mpas-seaice/src/analysis_members/Registry_seaice_area_variables.xml
+++ b/components/mpas-seaice/src/analysis_members/Registry_seaice_area_variables.xml
@@ -24,43 +24,43 @@
 		<package name="areaVariablesAMPKG" description="This package includes variables required for the areaVariables analysis member."/>
 	</packages>
 	<var_struct name="areaVariablesAM" time_levs="1" packages="areaVariablesAMPKG">
-		<var name="snowfallRateInitialArea" type="real" dimensions="nCells Time" units="UNITS HERE"
-			description="DESCRIPTION HERE"
+		<var name="snowfallRateInitialArea" type="real" dimensions="nCells Time" units="kg m-2 s-1"
+			description="Cell-average snowfall rate over the initial sea ice area"
 		/>
-		<var name="rainfallRateInitialArea" type="real" dimensions="nCells Time" units="UNITS HERE"
-			description="DESCRIPTION HERE"
+		<var name="rainfallRateInitialArea" type="real" dimensions="nCells Time" units="kg m-2 s-1"
+			description="Cell-averaged rainfall rate over the initial sea ice area"
 		/>
-		<var name="absorbedShortwaveFluxInitialArea" type="real" dimensions="nCells Time" units="UNITS HERE"
-			description="DESCRIPTION HERE"
+		<var name="absorbedShortwaveFluxInitialArea" type="real" dimensions="nCells Time" units="W m-2"
+			description="Cell-averaged shortwave flux absorbed over the initial sea ice area (downwelling positive)"
 		/>
-		<var name="latentHeatFluxInitialArea" type="real" dimensions="nCells Time" units="UNITS HERE"
-			description="DESCRIPTION HERE"
+		<var name="latentHeatFluxInitialArea" type="real" dimensions="nCells Time" units="W m-2"
+			description="Cell-averaged latent heat flux over the initial sea ice area (downwelling positive)"
 		/>
-		<var name="sensibleHeatFluxInitialArea" type="real" dimensions="nCells Time" units="UNITS HERE"
-			description="DESCRIPTION HERE"
+		<var name="sensibleHeatFluxInitialArea" type="real" dimensions="nCells Time" units="W m-2"
+			description="Cell-averaged sensible heat flux over the initial sea ice area (downwelling positive)"
 		/>
-		<var name="longwaveUpInitialArea" type="real" dimensions="nCells Time" units="UNITS HERE"
-			description="DESCRIPTION HERE"
+		<var name="longwaveUpInitialArea" type="real" dimensions="nCells Time" units="W m-2"
+			description="Cell-averaged longwave flux emitted from the initial sea ice area (upwelling negative)"
 		/>
-		<var name="evaporativeWaterFluxInitialArea" type="real" dimensions="nCells Time" units="UNITS HERE"
-			description="DESCRIPTION HERE"
+		<var name="evaporativeWaterFluxInitialArea" type="real" dimensions="nCells Time" units="kg m-2 s-1"
+			description="Cell-averaged evaporative water flux over the initial sea ice area (condensation positive)"
 		/>
-		<var name="surfaceHeatFluxInitialArea" type="real" dimensions="nCells Time" units="UNITS HERE"
-			description="DESCRIPTION HERE"
+		<var name="surfaceHeatFluxInitialArea" type="real" dimensions="nCells Time" units="W m-2"
+			description="Cell-averaged net heat flux at top surface of initial sea ice area, excluding conductive heat (downwelling positive)"
 		/>
-		<var name="surfaceConductiveFluxInitialArea" type="real" dimensions="nCells Time" units="UNITS HERE"
-			description="DESCRIPTION HERE"
+		<var name="surfaceConductiveFluxInitialArea" type="real" dimensions="nCells Time" units="W m-2"
+			description="Cell-averaged conductive heat flux at top surface of initial sea ice area (downwelling positive)"
 		/>
-		<var name="surfaceHeatFluxCategoryInitialArea" type="real" dimensions="nCategories nCells Time" units="UNITS HERE"
-			description="DESCRIPTION HERE"
+		<var name="surfaceHeatFluxCategoryInitialArea" type="real" dimensions="nCategories nCells Time" units="W m-2"
+			description="surfaceHeatFluxInitialArea for ice thickness categories"
 		/>
-		<var name="surfaceConductiveFluxCategoryInitialArea" type="real" dimensions="nCategories nCells Time" units="UNITS HERE"
-			description="DESCRIPTION HERE"
+		<var name="surfaceConductiveFluxCategoryInitialArea" type="real" dimensions="nCategories nCells Time" units="W m-2"
+			description="surfaceConductiveFluxInitialArea for ice thickness categories"
 		/>
-		<var name="latentHeatFluxCategoryInitialArea" type="real" dimensions="nCategories nCells Time" units="UNITS HERE"
-			description="DESCRIPTION HERE"
+		<var name="latentHeatFluxCategoryInitialArea" type="real" dimensions="nCategories nCells Time" units="W m-2"
+			description="latentHeatFluxInitialArea for ice thickness categories"
 		/>
-		<var name="sensibleHeatFluxCategoryInitialArea" type="real" dimensions="nCategories nCells Time" units="UNITS HERE"
-			description="DESCRIPTION HERE"
+		<var name="sensibleHeatFluxCategoryInitialArea" type="real" dimensions="nCategories nCells Time" units="W m-2"
+			description="sensibleHeatFluxInitialArea for ice thickness categories"
 		/>
 	</var_struct>

--- a/components/mpas-seaice/src/analysis_members/Registry_seaice_conservation_check.xml
+++ b/components/mpas-seaice/src/analysis_members/Registry_seaice_conservation_check.xml
@@ -77,7 +77,7 @@
 		<var name="energyChange" type="real" dimensions="nHemispheres Time" units="J"
 			description="Total energy change of ice and snow during time step"
 		/>
-		<var name="energyChangeFlux" type="real" dimensions="nHemispheres Time" units="W/m2"
+		<var name="energyChangeFlux" type="real" dimensions="nHemispheres Time" units="W m-2"
 			description="Total energy change flux of ice and snow during time step"
 		/>
 		<var name="netEnergyFlux" type="real" dimensions="nHemispheres Time" units="W"
@@ -136,22 +136,22 @@
                 <var name="iceMassChange" type="real" dimensions="nHemispheres Time" units="kg"
 			description="Total mass change of ice and snow during time step"
 		/>
-		<var name="iceMassChangeFlux" type="real" dimensions="nHemispheres Time" units="kg/m2s"
+		<var name="iceMassChangeFlux" type="real" dimensions="nHemispheres Time" units="kg m-2 s-1"
 			description="Total mass change flux of ice and snow during time step"
 		/>
                 <var name="oceanMassChange" type="real" dimensions="nHemispheres Time" units="kg"
 			description="Total mass change of ice and snow during time step"
 		/>
-		<var name="oceanMassChangeFlux" type="real" dimensions="nHemispheres Time" units="kg/m2s"
+		<var name="oceanMassChangeFlux" type="real" dimensions="nHemispheres Time" units="kg m-2 s-1"
 			description="Total mass change flux of ice and snow during time step"
 		/>
                 <var name="massChange" type="real" dimensions="nHemispheres Time" units="kg"
 			description="Total mass change of ice and snow during time step"
 		/>
-		<var name="massChangeFlux" type="real" dimensions="nHemispheres Time" units="kg/m2s"
+		<var name="massChangeFlux" type="real" dimensions="nHemispheres Time" units="kg m-2 s-1"
 			description="Total mass change flux of ice and snow during time step"
 		/>
-		<var name="netMassFlux" type="real" dimensions="nHemispheres Time" units="kg/s"
+		<var name="netMassFlux" type="real" dimensions="nHemispheres Time" units="kg s-1"
 			description="Net mass flux to ice"
 		/>
 		<var name="absoluteMassError" type="real" dimensions="nHemispheres Time" units="kg"
@@ -192,10 +192,10 @@
 		<var name="saltChange" type="real" dimensions="nHemispheres Time" units="kg"
 			description="Total salt change of ice and snow during time step"
 		/>
-		<var name="saltChangeFlux" type="real" dimensions="nHemispheres Time" units="kg/m2s"
+		<var name="saltChangeFlux" type="real" dimensions="nHemispheres Time" units="kg m-2 s-1"
 			description="Total salt change flux of ice and snow during time step"
 		/>
-		<var name="netSaltFlux" type="real" dimensions="nHemispheres Time" units="kg/s"
+		<var name="netSaltFlux" type="real" dimensions="nHemispheres Time" units="kg s-1"
 			description="Net salt flux to ice"
 		/>
 		<var name="absoluteSaltError" type="real" dimensions="nHemispheres Time" units="kg"

--- a/components/mpas-seaice/src/analysis_members/Registry_seaice_geographical_vectors.xml
+++ b/components/mpas-seaice/src/analysis_members/Registry_seaice_geographical_vectors.xml
@@ -24,40 +24,40 @@
 		<package name="geographicalVectorsAMPKG" description="This package includes variables required for the geographicalVectors analysis member."/>
 	</packages>
 	<var_struct name="geographicalVectorsAM" time_levs="1" packages="geographicalVectorsAMPKG">
-		<var name="uVelocityGeo" type="real" dimensions="nVertices Time" units="m/s"
+		<var name="uVelocityGeo" type="real" dimensions="nVertices Time" units="m s-1"
 			description="True eastwards ice velocity"
 		/>
-		<var name="vVelocityGeo" type="real" dimensions="nVertices Time" units="m/s"
+		<var name="vVelocityGeo" type="real" dimensions="nVertices Time" units="m s-1"
 			description="True northwards ice velocity"
 		/>
-		<var name="stressDivergenceUGeo" type="real" dimensions="nVertices Time" units="N/m^2"
+		<var name="stressDivergenceUGeo" type="real" dimensions="nVertices Time" units="N m-2"
 			description="True eastwards stress divergence"
 		/>
-		<var name="stressDivergenceVGeo" type="real" dimensions="nVertices Time" units="N/m^2"
+		<var name="stressDivergenceVGeo" type="real" dimensions="nVertices Time" units="N m-2"
 			description="True northwards stress divergence"
 		/>
-		<var name="airStressVertexUGeo" type="real" dimensions="nVertices Time" units="N/m^2"
+		<var name="airStressVertexUGeo" type="real" dimensions="nVertices Time" units="N m-2"
 			description="True eastwards sea ice-air stress"
 		/>
-		<var name="airStressVertexVGeo" type="real" dimensions="nVertices Time" units="N/m^2"
+		<var name="airStressVertexVGeo" type="real" dimensions="nVertices Time" units="N m-2"
 			description="True northwards sea ice-air stress"
 		/>
-		<var name="oceanStressUGeo" type="real" dimensions="nVertices Time" units="N/m^2"
+		<var name="oceanStressUGeo" type="real" dimensions="nVertices Time" units="N m-2"
 			description="True eastwards sea ice-ocean stress"
 		/>
-		<var name="oceanStressVGeo" type="real" dimensions="nVertices Time" units="N/m^2"
+		<var name="oceanStressVGeo" type="real" dimensions="nVertices Time" units="N m-2"
 			description="True northwards sea ice-ocean stress"
 		/>
-		<var name="surfaceTiltForceUGeo" type="real" dimensions="nVertices Time" units="N/m^2"
+		<var name="surfaceTiltForceUGeo" type="real" dimensions="nVertices Time" units="N m-2"
 			description="True eastwards sea surface tilt stress"
 		/>
-		<var name="surfaceTiltForceVGeo" type="real" dimensions="nVertices Time" units="N/m^2"
+		<var name="surfaceTiltForceVGeo" type="real" dimensions="nVertices Time" units="N m-2"
 			description="True northwards sea surface tilt stress"
 		/>
-		<var name="uOceanVelocityVertexGeo" type="real" dimensions="nVertices Time" units="m/s"
+		<var name="uOceanVelocityVertexGeo" type="real" dimensions="nVertices Time" units="m s-1"
 			description="True eastwards ocean velocity"
 		/>
-		<var name="vOceanVelocityVertexGeo" type="real" dimensions="nVertices Time" units="m/s"
+		<var name="vOceanVelocityVertexGeo" type="real" dimensions="nVertices Time" units="m s-1"
 			description="True northwards ocean velocity"
 		/>
 	</var_struct>

--- a/components/mpas-seaice/src/analysis_members/Registry_seaice_high_frequency_output.xml
+++ b/components/mpas-seaice/src/analysis_members/Registry_seaice_high_frequency_output.xml
@@ -24,7 +24,7 @@
 		<package name="highFrequencyOutputAMPKG" description="This package includes variables required for the highFrequencyOutput analysis member."/>
 	</packages>
 	<var_struct name="highFrequencyOutputAM" time_levs="1" packages="highFrequencyOutputAMPKG">
-		<var name="iceAreaCellCategory1" type="real" dimensions="nCells Time" units="m^2 s^{-2}"
+		<var name="iceAreaCellCategory1" type="real" dimensions="nCells Time" units="m2 s-2"
 			description="area of ice in category 1"
 		/>
 	</var_struct>

--- a/components/mpas-seaice/src/analysis_members/Registry_seaice_ice_present.xml
+++ b/components/mpas-seaice/src/analysis_members/Registry_seaice_ice_present.xml
@@ -24,7 +24,7 @@
 		<package name="icePresentAMPKG" description="This package includes variables required for the icePresent analysis member."/>
 	</packages>
 	<var_struct name="icePresentAM" time_levs="1" packages="icePresentAMPKG">
-		<var name="icePresent" type="real" dimensions="nCells Time" units="-"
+		<var name="icePresent" type="real" dimensions="nCells Time"
 			description="1.0 if ice present, 0.0 if ice not present"
 		/>
 	</var_struct>

--- a/components/mpas-seaice/src/analysis_members/Registry_seaice_ice_shelves.xml
+++ b/components/mpas-seaice/src/analysis_members/Registry_seaice_ice_shelves.xml
@@ -24,7 +24,7 @@
 		<package name="iceShelvesAMPKG" description="This package includes variables required for the iceShelves analysis member."/>
 	</packages>
 	<var_struct name="iceShelvesAM" time_levs="1" packages="iceShelvesAMPKG">
-		<var name="iceAreaOverIceShelves" type="real" dimensions="Time" units="-"
+		<var name="iceAreaOverIceShelves" type="real" dimensions="Time" units="1"
 			description="Total ice area present where ice shelves exist"
 		/>
 	</var_struct>

--- a/components/mpas-seaice/src/analysis_members/Registry_seaice_load_balance.xml
+++ b/components/mpas-seaice/src/analysis_members/Registry_seaice_load_balance.xml
@@ -31,10 +31,10 @@
 		<package name="loadBalanceAMPKG" description="This package includes variables required for the loadBalance analysis member."/>
 	</packages>
 	<var_struct name="loadBalanceAM" time_levs="1" packages="loadBalanceAMPKG">
-		<var name="nCellsProcWithSeaIce" type="integer" dimensions="nProcs Time" units="-"
+		<var name="nCellsProcWithSeaIce" type="integer" dimensions="nProcs Time" units="1"
 			description="Number of cells with sea ice present per processor"
 		/>
-		<var name="nCellsProc" type="integer" dimensions="nProcs" units="-"
+		<var name="nCellsProc" type="integer" dimensions="nProcs" units="1"
 			description="Number of cells per processor"
 		/>
 	</var_struct>

--- a/components/mpas-seaice/src/analysis_members/Registry_seaice_miscellaneous.xml
+++ b/components/mpas-seaice/src/analysis_members/Registry_seaice_miscellaneous.xml
@@ -24,16 +24,16 @@
 		<package name="miscellaneousAMPKG" description="This package includes variables required for the miscellaneous analysis member."/>
 	</packages>
 	<var_struct name="miscellaneousAM" time_levs="1" packages="miscellaneousAMPKG">
-		<var name="bulkSalinity" type="real" dimensions="nCells Time" units="ppt"
+		<var name="bulkSalinity" type="real" dimensions="nCells Time" units="1e-3"
 			description="Bulk salinity of ice in a cell"
 		/>
-		<var name="broadbandAlbedo" type="real" dimensions="nCells Time" units="-"
+		<var name="broadbandAlbedo" type="real" dimensions="nCells Time" units="1"
 			description="snow/sea ice broadband albedo"
 		/>
-		<var name="coriolisStressVertexU" type="real" dimensions="nVertices Time" units=""
+		<var name="coriolisStressVertexU" type="real" dimensions="nVertices Time" units="kg m-1 s-2"
 			description="Coriolis stress in U direction"
 		/>
-		<var name="coriolisStressVertexV" type="real" dimensions="nVertices Time" units=""
+		<var name="coriolisStressVertexV" type="real" dimensions="nVertices Time" units="kg m-1 s-2"
 			description="Coriolis stress in V direction"
 		/>
 	</var_struct>

--- a/components/mpas-seaice/src/analysis_members/Registry_seaice_pond_diagnostics.xml
+++ b/components/mpas-seaice/src/analysis_members/Registry_seaice_pond_diagnostics.xml
@@ -24,25 +24,25 @@
 		<package name="pondDiagnosticsAMPKG" description="This package includes variables required for the pondDiagnostics analysis member."/>
 	</packages>
 	<var_struct name="pondDiagnosticsAM" time_levs="1" packages="pondDiagnosticsAMPKG">
-		<var name="meltPondArea" type="real" dimensions="nCells Time" units="UNITS HERE"
-			description="DESCRIPTION HERE"
+		<var name="meltPondArea" type="real" dimensions="nCells Time" units="1"
+                        description="Fraction of sea ice area covered in ponds"
 		/>
-		<var name="meltPondAreaFinalArea" type="real" dimensions="nCells Time" units="UNITS HERE"
-			description="DESCRIPTION HERE"
+		<var name="meltPondAreaFinalArea" type="real" dimensions="nCells Time" units="1"
+			description="Fraction of grid cell covered in ponds at end of timestep"
 		/>
-		<var name="meltPondDepth" type="real" dimensions="nCells Time" units="UNITS HERE"
-			description="DESCRIPTION HERE"
+		<var name="meltPondDepth" type="real" dimensions="nCells Time" units="m"
+			description="Average depth of ponds over sea ice"
 		/>
-		<var name="meltPondDepthFinalArea" type="real" dimensions="nCells Time" units="UNITS HERE"
-			description="DESCRIPTION HERE"
+		<var name="meltPondDepthFinalArea" type="real" dimensions="nCells Time" units="m"
+			description="Cell-average depth of ponds at end of timestep"
 		/>
-		<var name="meltPondLidThickness" type="real" dimensions="nCells Time" units="UNITS HERE"
-			description="DESCRIPTION HERE"
+		<var name="meltPondLidThickness" type="real" dimensions="nCells Time" units="m"
+			description="Average pond refrozen lid thickness over sea ice"
 		/>
-		<var name="meltPondLidThicknessFinalArea" type="real" dimensions="nCells Time" units="UNITS HERE"
-			description="DESCRIPTION HERE"
+		<var name="meltPondLidThicknessFinalArea" type="real" dimensions="nCells Time" units="m"
+			description="Cell-average pond refrozen lid thickness at end of timestep"
 		/>
-		<var name="meltPondDepthCategory" type="real" dimensions="nCategories nCells Time" units="UNITS HERE"
-			description="DESCRIPTION HERE"
+		<var name="meltPondDepthCategory" type="real" dimensions="nCategories nCells Time" units="m"
+			description="Pond depth for each thickness category of sea ice"
 		/>
 	</var_struct>

--- a/components/mpas-seaice/src/analysis_members/Registry_seaice_regional_statistics.xml
+++ b/components/mpas-seaice/src/analysis_members/Registry_seaice_regional_statistics.xml
@@ -28,40 +28,40 @@
 		<package name="regionalStatisticsAMPKG" description="This package includes variables required for the regionalStatistics analysis member."/>
 	</packages>
 	<var_struct name="regionalStatisticsAM" time_levs="1" packages="regionalStatisticsAMPKG">
-		<var name="totalIceArea" type="real" dimensions="nRegions Time" units="km^2"
+		<var name="totalIceArea" type="real" dimensions="nRegions Time" units="km2"
 			description="Total sea-ice area by region"
 		/>
-		<var name="totalIceExtent" type="real" dimensions="nRegions Time" units="km^2"
+		<var name="totalIceExtent" type="real" dimensions="nRegions Time" units="km2"
 			description="Total sea-ice extent by region"
 		/>
-		<var name="totalIceVolume" type="real" dimensions="nRegions Time" units="km^3"
+		<var name="totalIceVolume" type="real" dimensions="nRegions Time" units="km3"
 			description="Total sea-ice volume by region"
 		/>
-		<var name="totalSnowVolume" type="real" dimensions="nRegions Time" units="km^3"
+		<var name="totalSnowVolume" type="real" dimensions="nRegions Time" units="km3"
 			description="Total snow volume by region"
 		/>
 		<var name="totalKineticEnergy" type="real" dimensions="nRegions Time" units="J"
 			description="Total kinetic energy by region"
 		/>
-		<var name="rmsIceSpeed" type="real" dimensions="nRegions Time" units="m/s"
+		<var name="rmsIceSpeed" type="real" dimensions="nRegions Time" units="m s-1"
 			description="RMS ice speed by region"
 		/>
-		<var name="averageAlbedo" type="real" dimensions="nRegions Time" units="-"
+		<var name="averageAlbedo" type="real" dimensions="nRegions Time" units="1"
 			description="Average albedo by region"
 		/>
-		<var name="maximumIceVolume" type="real" dimensions="nRegions Time" units="km^2"
+		<var name="maximumIceVolume" type="real" dimensions="nRegions Time" units="km2"
 			description="Maximum sea-ice volume by region"
 		/>
-		<var name="maximumIceVolumeLocked" type="real" dimensions="nRegions Time" units="km^2"
+		<var name="maximumIceVolumeLocked" type="real" dimensions="nRegions Time" units="km2"
 			description="Maximum sea-ice volume by region for dynamically locked cells"
 		/>
-		<var name="maximumIceVolumeNotLocked" type="real" dimensions="nRegions Time" units="km^2"
+		<var name="maximumIceVolumeNotLocked" type="real" dimensions="nRegions Time" units="km2"
 			description="Maximum sea-ice volume by region for non-dynamically locked cells"
 		/>
-		<var name="maximumIcePressure" type="real" dimensions="nRegions Time" units="kN/m"
+		<var name="maximumIcePressure" type="real" dimensions="nRegions Time" units="kN m-1"
 			description="Maximum sea-ice pressure by region"
 		/>
-		<var name="maximumIceSpeed" type="real" dimensions="nRegions Time" units="m/s"
+		<var name="maximumIceSpeed" type="real" dimensions="nRegions Time" units="m s-1"
 			description="Maximum sea-ice speed by region"
 		/>
 	</var_struct>

--- a/components/mpas-seaice/src/analysis_members/Registry_seaice_ridging_diagnostics.xml
+++ b/components/mpas-seaice/src/analysis_members/Registry_seaice_ridging_diagnostics.xml
@@ -24,16 +24,16 @@
 		<package name="ridgingDiagnosticsAMPKG" description="This package includes variables required for the ridgingDiagnostics analysis member."/>
 	</packages>
 	<var_struct name="ridgingDiagnosticsAM" time_levs="1" packages="ridgingDiagnosticsAMPKG">
-		<var name="levelIceAreaAverage" type="real" dimensions="nCells Time" units="-"
-			description="level ice cell fraction"
+		<var name="levelIceAreaAverage" type="real" dimensions="nCells Time" units="1"
+			description="Fraction of grid cell covered in undeformed ice"
 		/>
-		<var name="ridgedIceAreaAverage" type="real" dimensions="nCells Time" units="-"
-			description="ridged ice cell fraction"
+		<var name="ridgedIceAreaAverage" type="real" dimensions="nCells Time" units="1"
+			description="Fraction of grid cell covered in deformed ice"
 		/>
-		<var name="levelIceVolumeAverage" type="real" dimensions="nCells Time" units="-"
-			description="level ice cell volume"
+		<var name="levelIceVolumeAverage" type="real" dimensions="nCells Time" units="m"
+			description="Volume of undeformed ice per unit grid cell area"
 		/>
-		<var name="ridgedIceVolumeAverage" type="real" dimensions="nCells Time" units="-"
-			description="ridged ice cell volume"
+		<var name="ridgedIceVolumeAverage" type="real" dimensions="nCells Time" units="m"
+			description="Volume of deformed ice per unit grid cell area"
 		/>
 	</var_struct>

--- a/components/mpas-seaice/src/analysis_members/Registry_seaice_temperatures.xml
+++ b/components/mpas-seaice/src/analysis_members/Registry_seaice_temperatures.xml
@@ -24,10 +24,10 @@
 		<package name="temperaturesAMPKG" description="This package includes variables required for the temperatures analysis member."/>
 	</packages>
 	<var_struct name="temperaturesAM" time_levs="1" packages="temperaturesAMPKG">
-		<var name="iceTemperature" type="real" dimensions="nIceLayers nCategories nCells Time" units="degrees C"
+		<var name="iceTemperature" type="real" dimensions="nIceLayers nCategories nCells Time" units="C"
 			description="Ice layer temperature"
 		/>
-		<var name="snowTemperature" type="real" dimensions="nSnowLayers nCategories nCells Time" units="degrees C"
+		<var name="snowTemperature" type="real" dimensions="nSnowLayers nCategories nCells Time" units="C"
 			description="snow layer temperature"
 		/>
 	</var_struct>

--- a/components/mpas-seaice/src/analysis_members/Registry_seaice_thicknesses.xml
+++ b/components/mpas-seaice/src/analysis_members/Registry_seaice_thicknesses.xml
@@ -25,15 +25,15 @@
 	</packages>
 	<var_struct name="thicknessesAM" time_levs="1" packages="thicknessesAMPKG">
 		<var name="iceThicknessCell" type="real" dimensions="nCells Time" units="m"
-			description="Ice aggregate thickness"
+			description="Average thickness of sea ice"
 		/>
 		<var name="snowThicknessCell" type="real" dimensions="nCells Time" units="m"
-			description="Snow aggregate thickness"
+			description="Average depth of snow over sea ice"
 		/>
 		<var name="iceThicknessCategory" type="real" dimensions="nCategories nCells Time" units="m"
-			description="Ice category thickness"
+			description="Sea ice thickness per category"
 		/>
 		<var name="snowThicknessCategory" type="real" dimensions="nCategories nCells Time" units="m"
-			description="Snow category thickness"
+			description="Snow depth over ice thickness category"
 		/>
 	</var_struct>

--- a/components/mpas-seaice/src/analysis_members/Registry_seaice_time_series_stats.xml
+++ b/components/mpas-seaice/src/analysis_members/Registry_seaice_time_series_stats.xml
@@ -11,16 +11,13 @@
 		<var name="timeSeriesStatsOneString"
 			 type="text"
 			 dimensions="Time"
-			 units="unitless"
 		/>
 		<var name="timeSeriesStatsOneInteger"
 			 type="integer"
 			 dimensions="Time"
-			 units="unitless"
 		/>
 		<var name="timeSeriesStatsOneReal"
 			 type="real"
 			 dimensions="Time"
-			 units="unitless"
 		/>
 	</var_struct>


### PR DESCRIPTION
This PR corrects and improves netcdf metadata in MPAS-SeaIce output for E3SM V3. The following changes have been made: Correction of existing long names and units to match the CF convention and addition of missing units and long names consistent with CF conventions. These correct netcdf monthly, daily and regional netcdf history output as illustrated in comments below. This PR has been tested in a 1-month D-case simulation on Anvil, and is BFB. 