### PR TITLE
MPAS-SeaIce E3SM Version 3 Final BFB Cleanup

### DIFF
--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -943,7 +943,6 @@ if ($iceberg_mode eq 'data') {
     add_default($nl, 'config_use_data_icebergs', 'val'=>"false");
 }
 add_default($nl, 'config_salt_flux_coupling_type');
-add_default($nl, 'config_couple_biogeochemistry_fields');
 add_default($nl, 'config_ice_ocean_drag_coefficient');
 
 ###############################

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -447,7 +447,6 @@ add_default($nl, 'config_min_friction_velocity');
 add_default($nl, 'config_ocean_heat_transfer_type');
 add_default($nl, 'config_sea_freezing_temperature_type');
 add_default($nl, 'config_ocean_surface_type');
-add_default($nl, 'config_couple_biogeochemistry_fields');
 add_default($nl, 'config_use_data_icebergs');
 add_default($nl, 'config_salt_flux_coupling_type');
 add_default($nl, 'config_ice_ocean_drag_coefficient');

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -426,7 +426,6 @@
 <config_ocean_heat_transfer_type>'constant'</config_ocean_heat_transfer_type>
 <config_sea_freezing_temperature_type>'mushy'</config_sea_freezing_temperature_type>
 <config_ocean_surface_type>'free'</config_ocean_surface_type>
-<config_couple_biogeochemistry_fields>false</config_couple_biogeochemistry_fields>
 <config_use_data_icebergs>false</config_use_data_icebergs>
 <config_salt_flux_coupling_type>'constant'</config_salt_flux_coupling_type>
 <config_ice_ocean_drag_coefficient>0.00536</config_ice_ocean_drag_coefficient>

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -2253,7 +2253,7 @@ Default: Defined in namelist_defaults.xml
 	category="snow" group="snow">
 Use a snow redistribution scheme
 
-Valid values: '30percent (30% rule, precip only)','30percentsw (30% rulewith shortwave)','ITDsd (Lecomte PhD, 2014)','ITDrdg (like ITDsd but use level/ridged ice)','default or none (none)'
+Valid values: 'bulk', 'ITDrdg', 'none'
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -2403,7 +2403,7 @@ Default: Defined in namelist_defaults.xml
 	category="thermodynamics" group="thermodynamics">
 Vertical themodynamics type.
 
-Valid values: 'zero layer', 'BL99', or 'mushy'
+Valid values: 'BL99', or 'mushy'
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -2651,14 +2651,6 @@ Default: Defined in namelist_defaults.xml
 Type of coupled ocean surface: (MPAS-O:'free'), (SOM:'non-free')
 
 Valid values: 'free' or 'non-free'
-Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_couple_biogeochemistry_fields" type="logical"
-	category="ocean" group="ocean">
-
-
-Valid values: true or false
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -1603,7 +1603,7 @@
 	<nml_record name="snow" in_defaults="true">
 		<nml_option name="config_snow_redistribution_scheme" type="character" default_value="none" units="none"
 			description="Use a snow redistribution scheme"
-			possible_values="'30percent (30% rule, precip only)','30percentsw (30% rulewith shortwave)','ITDsd (Lecomte PhD, 2014)','ITDrdg (like ITDsd but use level/ridged ice)','default or none (none)'"
+			possible_values="'bulk', 'ITDrdg', 'none'"
 			icepack_name="snwredist"
 		/>
 		<nml_option name="config_fallen_snow_radius" type="real" default_value="54.4" units="um"
@@ -1699,7 +1699,7 @@
 	<nml_record name="thermodynamics" in_defaults="true">
 		<nml_option name="config_thermodynamics_type" type="character" default_value="mushy" units="unitless"
 			description="Vertical themodynamics type."
-			possible_values="'zero layer', 'BL99', or 'mushy'"
+			possible_values="'BL99', or 'mushy'"
 			icepack_name="ktherm"
 		/>
 		<nml_option name="config_heat_conductivity_type" type="character" default_value="bubbly" units="unitless"
@@ -1859,10 +1859,6 @@
 		<nml_option name="config_ocean_surface_type" type="character" default_value="free" units="unitless"
 			description="Type of coupled ocean surface: (MPAS-O:'free'), (SOM:'non-free')"
 			possible_values="'free' or 'non-free'"
-		/>
-		<nml_option name="config_couple_biogeochemistry_fields" type="logical" default_value="false" units="unitless"
-			description=""
-			possible_values="true or false"
 		/>
 		<nml_option name="config_use_data_icebergs" type="logical" default_value="false" units="unitless"
 			description="Use data iceberg meltwater forcing"

--- a/components/mpas-seaice/src/shared/mpas_seaice_constants.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_constants.F
@@ -97,10 +97,10 @@ module seaice_constants
 
   ! fundamental constants
   real (kind=RKIND), parameter, public :: &
-       pii                                = pi, &    !echmod - replace pii with seaicePi elsewhere
+       pii                                = pi, &    ! replace pii with seaicePi elsewhere (might need to be parameter)
        seaiceDegreesToRadians             = pi / 180.0_RKIND, &
        seaiceRadiansToDegrees             = 180.0_RKIND / pi, &
-       seaiceSecondsPerYear               = 24.0_RKIND * 3600.0_RKIND * 365.0_RKIND, & !echmod - incorrect for leap years
+       seaiceSecondsPerYear               = 24.0_RKIND * 3600.0_RKIND * 365.0_RKIND, & ! incorrect for leap years
        seaiceDaysPerSecond                = 1.0_RKIND/seaiceSecondsPerDay
 
   real (kind=RKIND), public :: &
@@ -143,7 +143,6 @@ module seaice_constants
        iceThicknessMinimum, &
        snowThicknessMinimum
 
-!echmod - declare and define these constants explicitly in case Icepack changes its defaults
   real(kind=RKIND), public :: &
        seaiceBigNumber                   = 1.0e+30_RKIND, & ! a large number
        seaiceSnowMinimumDensity          = 100.0_RKIND  , & ! minimum snow density (kg/m^3)
@@ -169,7 +168,7 @@ module seaice_constants
        seaiceQsatQocnConstant            = 627572.4_RKIND    ,&
        seaiceQsatTocnConstant            = 5107.4_RKIND
 
-!echmod - Are these needed for standalone runs?
+! Are these needed for standalone runs?
 !      ! orbital parameters
 !      integer, public :: iyear_AD  ! Year to calculate orbit for
 !      real(kind=RKIND),public :: eccen  ! Earth's orbital eccentricity

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -2917,9 +2917,6 @@ contains
          config_use_modal_aerosols, &
          config_use_column_biogeochemistry
 
-    character(len=strKIND), pointer :: &
-         config_snow_redistribution_scheme
-
     ! dimensions
     integer, pointer :: &
          nCellsSolve, &
@@ -3050,7 +3047,6 @@ contains
        call MPAS_pool_get_subpool(block % structs, "biogeochemistry", biogeochemistry)
 
        call MPAS_pool_get_config(block % configs, "config_dt", config_dt)
-       call MPAS_pool_get_config(block % configs, "config_snow_redistribution_scheme", config_snow_redistribution_scheme)
 
        call MPAS_pool_get_dimension(mesh, "nCellsSolve", nCellsSolve)
        call MPAS_pool_get_dimension(mesh, "nCategories", nCategories)
@@ -9233,6 +9229,7 @@ contains
          config_use_cesm_meltponds, &  ! deprecated
          config_use_level_meltponds, &
          config_use_topo_meltponds, &
+         config_include_pond_freshwater_feedback, &
          config_use_vertical_zsalinity, &      ! deprecated
          config_use_brine, &
          config_use_vertical_tracers, &
@@ -9294,6 +9291,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_use_cesm_meltponds", config_use_cesm_meltponds) ! deprecated
     call MPAS_pool_get_config(domain % configs, "config_use_level_meltponds", config_use_level_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_topo_meltponds", config_use_topo_meltponds)
+    call MPAS_pool_get_config(domain % configs, "config_include_pond_freshwater_feedback", config_include_pond_freshwater_feedback)
     call MPAS_pool_get_config(domain % configs, "config_ocean_heat_transfer_type", config_ocean_heat_transfer_type)
     call MPAS_pool_get_config(domain % configs, "config_sea_freezing_temperature_type", config_sea_freezing_temperature_type)
     call MPAS_pool_get_config(domain % configs, "config_use_brine", config_use_brine)
@@ -9327,13 +9325,28 @@ contains
     ! Check values
     !-----------------------------------------------------------------------
 
-    ! check config_thermodynamics_type value
-    if (trim(config_thermodynamics_type) == "zero layer") then
+    ! deprecate cesm ponds
+    if (config_use_cesm_meltponds) then
+       call mpas_log_write(&
+            "check_column_package_configs: config_use_cesm_meltponds = .true. but cesm ponds have been deprecated", &
+            messageType=MPAS_LOG_CRIT)
+    endif
+
+    ! deprecate vertical zSalinity
+    if (config_use_vertical_zsalinity) then
+       call mpas_log_write(&
+            "check_column_package_configs: config_use_vertical_zsalinity = .true. but vertical zSalinity has been deprecated", &
+            messageType=MPAS_LOG_CRIT)
+    endif
+
+    ! deprecate 0-layer thermo
+    if (trim(config_thermodynamics_type(1:4)) == "zero") then
        call mpas_log_write(&
             "check_column_package_configs: config_thermodynamics_type) = zero layer but 0-layer thermo has been deprecated", &
             messageType=MPAS_LOG_WARN)
     endif
 
+    ! check config_thermodynamics_type value
     if (.not. (trim(config_thermodynamics_type) == "BL99" .or. &
                trim(config_thermodynamics_type) == "mushy")) then
        call config_error("config_thermodynamics_type", config_thermodynamics_type, "'BL99' or 'mushy'")
@@ -9407,7 +9420,7 @@ contains
     endif
 
     ! check config_salt_flux_coupling_type
-    if (.not. trim(config_salt_flux_coupling_type) == "constant") then
+    if (trim(config_salt_flux_coupling_type) /= "constant") then
        call config_error("config_salt_flux_coupling_type", config_salt_flux_coupling_type, "'constant'")
     endif
 
@@ -9422,13 +9435,6 @@ contains
        call mpas_log_write(&
             'Check for inconsistencies in restart file: config_nIceLayers /= nIceLayers', &
             messageType=MPAS_LOG_CRIT)
-
-    ! deprecate cesm ponds
-    if (config_use_cesm_meltponds) then
-       call mpas_log_write(&
-            "check_column_package_configs: config_use_cesm_meltponds = .true. but cesm ponds have been deprecated", &
-            messageType=MPAS_LOG_CRIT)
-    endif
 
     !-----------------------------------------------------------------------
     ! Check combinations
@@ -9464,6 +9470,13 @@ contains
             messageType=MPAS_LOG_CRIT)
     endif
 
+    ! check level ponds and level ice
+    if (config_use_level_meltponds .and. .not. config_use_level_ice) then
+       call mpas_log_write(&
+            "check_column_package_configs: config_use_level_meltponds = .true. and config_use_level_ice = .false.", &
+            messageType=MPAS_LOG_CRIT)
+    endif
+
     ! check config_snow_to_ice_transition_depth and level ponds
     if (config_use_level_meltponds .and. abs(config_snow_to_ice_transition_depth) > seaicePuny) then
        call mpas_log_write(&
@@ -9471,17 +9484,35 @@ contains
             messageType=MPAS_LOG_CRIT)
     endif
 
-    ! check config_snow_redistribution_scheme
-      if (trim(config_snow_redistribution_scheme) == "ITDrdg".and. .not. config_use_effective_snow_density) then
+    if (config_use_level_meltponds .and. config_include_pond_freshwater_feedback) then
        call mpas_log_write(&
-         "check_column_package_configs: config_snow_redistribution = 'ITDrdg' but config_use_effective_snow_density is false", &
+            "check_column_package_configs: config_include_pond_freshwater_feedback is only available for topo ponds", &
+            messageType=MPAS_LOG_CRIT)
+    endif
+
+    ! check config_snow_redistribution_scheme
+    if (trim(config_snow_redistribution_scheme) == "ITDrdg".and. .not. config_use_effective_snow_density) then
+       call mpas_log_write(&
+            "check_column_package_configs: config_snow_redistribution = 'ITDrdg' but config_use_effective_snow_density is false", &
+            messageType=MPAS_LOG_CRIT)
+    endif
+    if (trim(config_snow_redistribution_scheme) == "ITDrdg".and. .not. config_use_level_ice) then
+       call mpas_log_write(&
+            "check_column_package_configs: config_snow_redistribution = 'ITDrdg' but config_use_level_ice = .false.", &
             messageType=MPAS_LOG_CRIT)
     endif
 
     ! check config_use_snow_liquid_ponds and config_use_snow_grain_radius
     if (config_use_snow_liquid_ponds .and. .not. config_use_snow_grain_radius) then
        call mpas_log_write(&
-         "check_column_package_configs: config_use_snow_liquid_ponds = true but config_use_snow_grain_radius = false", &
+            "check_column_package_configs: config_use_snow_liquid_ponds = true but config_use_snow_grain_radius = false", &
+            messageType=MPAS_LOG_CRIT)
+    endif
+
+    ! check snow grain radius and dEdd shortwave
+    if (config_use_snow_grain_radius .and. .not. (trim(config_shortwave_type(1:4)) == "dEdd")) then
+       call mpas_log_write(&
+            "check_column_package_configs: snow grain radius requires config_shortwave_type(1:4) ==  'dEdd'", &
             messageType=MPAS_LOG_CRIT)
     endif
 
@@ -9510,7 +9541,7 @@ contains
             messageType=MPAS_LOG_CRIT)
     endif
 
-    ! check not mushy physics and dont calculate surface temperature
+    ! check mushy physics and surface temperature calculation
     if (trim(config_thermodynamics_type) == "mushy" .and. .not. config_calc_surface_temperature) then
        call mpas_log_write(&
             "check_column_package_configs: config_thermodynamics_type = 'mushy' and config_calc_surface_temperature = .false.", &
@@ -9560,7 +9591,6 @@ contains
     endif
 
     ! check biogeochemistry flags:
-!    if (.not. config_use_column_biogeochemistry .and. (config_use_brine .or. config_use_vertical_zsalinity .or. &
     if (.not. config_use_column_biogeochemistry .and. (config_use_brine .or. &
         config_use_vertical_biochemistry .or. config_use_shortwave_bioabsorption .or. config_use_vertical_tracers .or. &
         config_use_skeletal_biochemistry .or. config_use_nitrate .or. config_use_carbon .or. config_use_chlorophyll .or. &
@@ -9569,13 +9599,6 @@ contains
        call mpas_log_write(&
             "check_column_package_configs: config_use_column_biogeochemistry = false. "//&
             "All biogeochemistry namelist flags must also be false", &
-            messageType=MPAS_LOG_CRIT)
-    endif
-
-    ! deprecate vertical zSalinity
-    if (config_use_vertical_zsalinity) then
-       call mpas_log_write(&
-            "check_column_package_configs: config_use_vertical_zsalinity = .true. but vertical zSalinity has been deprecated", &
             messageType=MPAS_LOG_CRIT)
     endif
 
@@ -12715,6 +12738,7 @@ contains
     !kitd = config_cice_int("config_itd_conversion_type", config_itd_conversion_type)
 
     ! kcatbound:
+    !  -1 = single category
     !   0 = old category boundary formula
     !   1 = new formula giving round numbers
     !   2 = WMO standard
@@ -15647,7 +15671,7 @@ contains
           surfaceTiltForceU   = 0.0_RKIND
           surfaceTiltForceV   = 0.0_RKIND
 
-          if (config_use_velocity_solver .and. trim(config_stress_divergence_scheme) == "weak") then !echmod BUG? - why is this here and wrapped in a config_use_column_physics conditional?
+          if (config_use_velocity_solver .and. trim(config_stress_divergence_scheme) == "weak") then
 
              call MPAS_pool_get_subpool(block % structs, "velocity_weak", velocityWeakPool)
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -11761,7 +11761,9 @@ contains
          config_minimum_wind_compaction, &
          config_wind_compaction_factor, &
          config_snow_redistribution_factor, &
-         config_max_dry_snow_radius
+         config_max_dry_snow_radius, &
+         config_floediam, &
+         config_floeshape
 
     real(kind=RKIND), dimension(:,:,:), pointer :: &
          snowEmpiricalGrowthParameterTau, &
@@ -12001,9 +12003,13 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_snow_redistribution_factor", config_snow_redistribution_factor)
     call MPAS_pool_get_config(domain % configs, "config_max_dry_snow_radius", config_max_dry_snow_radius)
     call MPAS_pool_get_config(domain % configs, "config_use_snow_grain_radius", config_use_snow_grain_radius)
+    call MPAS_pool_get_config(domain % configs, "config_floediam", config_floediam)
+    call MPAS_pool_get_config(domain % configs, "config_floeshape", config_floeshape)
+
     call MPAS_pool_get_dimension(domain % blocklist % dimensions, "nGrainAgingTemperature", nGrainAgingTemperature)
     call MPAS_pool_get_dimension(domain % blocklist % dimensions, "nGrainAgingTempGradient", nGrainAgingTempGradient)
     call MPAS_pool_get_dimension(domain % blocklist % dimensions, "nGrainAgingSnowDensity", nGrainAgingSnowDensity)
+
     call MPAS_pool_get_subpool(domain % blocklist % structs, "snow", snow)
     call MPAS_pool_get_array(snow, "snowEmpiricalGrowthParameterTau", snowEmpiricalGrowthParameterTau)
     call MPAS_pool_get_array(snow, "snowEmpiricalGrowthParameterKappa", snowEmpiricalGrowthParameterKappa)
@@ -12172,7 +12178,7 @@ contains
          cp_ice_in               = seaiceFreshIceSpecificHeat, & !
          cp_ocn_in               = seaiceSeaWaterSpecificHeat, &
          hfrazilmin_in           = seaiceFrazilMinimumThickness, &
-         !floediam_in             = , &
+         floediam_in             = config_floediam, &
          depressT_in             = seaiceMeltingTemperatureDepression, &
          dragio_in               = config_ice_ocean_drag_coefficient, & ! calc_dragio not implemented
          !thickness_ocn_layer1_in = , &        ! not yet implemented in MPAS-SI (stealth feature)
@@ -12265,7 +12271,7 @@ contains
          hs0_in                  = config_snow_to_ice_transition_depth, &
          frzpnd_in               = config_pond_refreezing_type, &
          saltflux_option_in      = config_salt_flux_coupling_type, &
-         !floeshape_in            = , &
+         floeshape_in            = config_floeshape, &
          !wave_spec_in            = , &        ! not yet implemented in MPAS-SI (stealth feature)
          !wave_spec_type_in       = , &        ! not yet implemented in MPAS-SI (stealth feature)
          !nfreq_in                = , &        ! not yet implemented in MPAS-SI (stealth feature)
@@ -12744,6 +12750,22 @@ contains
     !   2 = WMO standard
     !   3 = asymptotic formula
     !kcatbound = config_cice_int("config_category_bounds_type", config_category_bounds_type)
+
+    !-----------------------------------------------------------------------
+    ! Parameters for floe sizes
+    !-----------------------------------------------------------------------
+
+    ! floediam:
+    ! effective floe diameter for lateral melt (m)
+    ! default value is 300m from Steele (1992; doi:10.1029/92JC01755)
+    !floediam = config_floediam
+
+
+    ! floeshape:
+    ! bulk floe shape constant for lateral melt (unitless coefficient)
+    ! default value is 0.66 from Rothrock and Thorndike (1984; doi:10.1029/JC089iC04p06477)
+    !floeshape = config_floeshape
+
 
     !-----------------------------------------------------------------------
     ! Parameters for melt ponds

--- a/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
@@ -89,6 +89,9 @@ contains
 
     call mpas_log_write("seaice_init: Initialize sea-ice model")
 
+    ! check configs
+    call seaice_check_configs_coupled(domain)
+
     call mpas_pool_get_config(domain % configs, "config_column_physics_type", config_column_physics_type)
 
     ! set column constants
@@ -172,7 +175,7 @@ contains
     call seaice_set_special_boundaries_tracers(domain)
 
     ! check constants
-    call seaice_check_constants
+    call seaice_check_constants_coupled
 
   end subroutine seaice_init!}}}
 
@@ -2878,11 +2881,9 @@ contains
 
   end subroutine init_test_ice_shelf_mask
 
-!-----------------------------------------------------------------------
-
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  seaice_check_constants
+!  seaice_check_constants_coupled
 !
 !> \brief
 !> \author Elizabeth Hunke, LANL
@@ -2892,7 +2893,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_check_constants
+  subroutine seaice_check_constants_coupled
 
     use seaice_constants, only: &
          seaiceIceSnowEmissivity
@@ -2900,11 +2901,333 @@ contains
 #ifdef CCSMCOUPLED
     if (seaiceIceSnowEmissivity /= 1._RKIND) then
       call mpas_log_write(&
-           'seaice_check_constants: seaiceIceSnowEmissivity out of bounds', &
+           'seaice_check_constants_coupled: seaiceIceSnowEmissivity out of bounds', &
            messageType=MPAS_LOG_CRIT)
     endif
 #endif
 
-  end subroutine seaice_check_constants
+  end subroutine seaice_check_constants_coupled
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  seaice_check_configs_coupled
+!
+!> \brief
+!> \author Elizabeth Hunke, LANL
+!> \date 3 November 2023
+!> \details
+!> Checks critical configuration settings for coupled simulations.
+!> Aborts if they would cause conservation or other errors.
+!> Warns for some non-critical, non-default settings.
+!> Config consistency checks are in subroutine check_column_package_configs
+!
+!-----------------------------------------------------------------------
+
+  subroutine seaice_check_configs_coupled(domain)
+
+    type(domain_type), intent(inout) :: &
+         domain
+
+    ! abort
+    character(len=strKIND), pointer :: &
+         config_frazil_coupling_type, &
+         config_thermodynamics_type, &
+         config_sea_freezing_temperature_type, &
+         config_itd_conversion_type
+
+    logical, pointer :: &
+         config_use_column_shortwave, &
+         config_use_column_vertical_thermodynamics, &
+         config_use_column_ridging, &
+         config_use_form_drag, &
+         config_use_ocean_mixed_layer, &
+         config_calc_surface_stresses, &
+         config_calc_surface_temperature, &
+         config_include_pond_freshwater_feedback, &
+         config_update_ocean_fluxes
+
+    ! write warnings
+    character(len=strKIND), pointer :: &
+         config_column_physics_type, &
+         config_shortwave_type, &
+         config_snow_redistribution_scheme, &
+         config_category_bounds_type, &
+         config_ridging_participation_function, &
+         config_ridging_redistribution_function, &
+         config_ocean_heat_transfer_type, &
+         config_salt_flux_coupling_type, &       ! only available in icepack
+         config_ocean_surface_type               ! only used in ice_comp_mct.F
+
+    logical, pointer :: &
+         config_use_column_physics, &
+         config_use_column_itd_thermodynamics, & ! must be false for F case
+         config_use_prescribed_ice, &
+         config_use_snicar_ad, &
+         config_use_shortwave_redistribution, &  ! only available in icepack
+         config_use_column_snow_tracers, &
+         config_use_snow_liquid_ponds, &
+         config_use_high_frequency_coupling, &
+         config_limit_air_temperatures, &        ! only used for CORE forcing
+         config_use_congelation_basal_melt, &    ! deprecate with colpkg
+         config_use_lateral_melt, &              ! deprecate with colpkg
+         config_use_latent_processes             ! deprecate with colpkg
+
+#ifdef CCSMCOUPLED
+    ! abort
+    call MPAS_pool_get_config(domain % configs, "config_category_bounds_type", config_category_bounds_type)
+    call MPAS_pool_get_config(domain % configs, "config_frazil_coupling_type", config_frazil_coupling_type)
+    call MPAS_pool_get_config(domain % configs, "config_thermodynamics_type", config_thermodynamics_type)
+    call MPAS_pool_get_config(domain % configs, "config_sea_freezing_temperature_type", config_sea_freezing_temperature_type)
+    call MPAS_pool_get_config(domain % configs, "config_itd_conversion_type", config_itd_conversion_type)
+    call MPAS_pool_get_config(domain % configs, "config_use_column_shortwave", config_use_column_shortwave)
+    call MPAS_pool_get_config(domain % configs, "config_use_column_vertical_thermodynamics", &
+                                                 config_use_column_vertical_thermodynamics)
+    call MPAS_pool_get_config(domain % configs, "config_use_column_ridging", config_use_column_ridging)
+    call MPAS_pool_get_config(domain % configs, "config_use_form_drag", config_use_form_drag)
+    call MPAS_pool_get_config(domain % configs, "config_use_ocean_mixed_layer", config_use_ocean_mixed_layer)
+    call MPAS_pool_get_config(domain % configs, "config_calc_surface_stresses", config_calc_surface_stresses)
+    call MPAS_pool_get_config(domain % configs, "config_calc_surface_temperature", config_calc_surface_temperature)
+    call MPAS_pool_get_config(domain % configs, "config_include_pond_freshwater_feedback", config_include_pond_freshwater_feedback)
+    call MPAS_pool_get_config(domain % configs, "config_update_ocean_fluxes", config_update_ocean_fluxes)
+
+    if (trim(config_category_bounds_type) == "single category") then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_category_bounds_type must not be single category', &
+           messageType=MPAS_LOG_CRIT)
+    endif
+
+    if (trim(config_frazil_coupling_type) /= "external") then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_frazil_coupling_type must be external', &
+           messageType=MPAS_LOG_CRIT)
+    endif
+
+    if (trim(config_thermodynamics_type) /= "mushy") then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_thermodynamics_type must be mushy', &
+           messageType=MPAS_LOG_CRIT)
+    endif
+
+    if (trim(config_sea_freezing_temperature_type) /= "mushy") then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_sea_freezing_temperature_type must be mushy', &
+           messageType=MPAS_LOG_CRIT)
+    endif
+
+    if (trim(config_itd_conversion_type) /= "linear remap") then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_itd_conversion_type must be linear remap', &
+           messageType=MPAS_LOG_CRIT)
+    endif
+
+    if (.not. config_use_column_shortwave) then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_use_column_shortwave must be true', &
+           messageType=MPAS_LOG_CRIT)
+    endif
+
+    if (.not. config_use_column_vertical_thermodynamics) then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_use_column_vertical_thermodynamics must be true', &
+           messageType=MPAS_LOG_CRIT)
+    endif
+
+    if (.not. config_use_column_ridging) then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_use_column_ridging must be true', &
+           messageType=MPAS_LOG_CRIT)
+    endif
+
+    if (config_use_form_drag) then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_use_form_drag = true is not supported', &
+           messageType=MPAS_LOG_CRIT)
+    endif
+
+    if (config_use_ocean_mixed_layer) then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_use_ocean_mixed_layer must be false in coupled runs', &
+           messageType=MPAS_LOG_CRIT)
+    endif
+
+    if (.not. config_calc_surface_stresses) then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_calc_surface_stresses must be true', &
+           messageType=MPAS_LOG_CRIT)
+    endif
+
+    if (.not. config_calc_surface_temperature) then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_calc_surface_temperature must be true', &
+           messageType=MPAS_LOG_CRIT)
+    endif
+
+    if (config_include_pond_freshwater_feedback) then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_include_pond_freshwater_feedback must be false', &
+           messageType=MPAS_LOG_CRIT)
+    endif
+
+    if (.not. config_update_ocean_fluxes) then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_update_ocean_fluxes must be true', &
+           messageType=MPAS_LOG_CRIT)
+    endif
+
+    ! write warnings
+    call MPAS_pool_get_config(domain % configs, "config_column_physics_type", config_column_physics_type)
+    call MPAS_pool_get_config(domain % configs, "config_shortwave_type", config_shortwave_type)
+    call MPAS_pool_get_config(domain % configs, "config_snow_redistribution_scheme", config_snow_redistribution_scheme)
+    call MPAS_pool_get_config(domain % configs, "config_category_bounds_type", config_category_bounds_type)
+    call MPAS_pool_get_config(domain % configs, "config_ridging_participation_function", config_ridging_participation_function)
+    call MPAS_pool_get_config(domain % configs, "config_ridging_redistribution_function", config_ridging_redistribution_function)
+    call MPAS_pool_get_config(domain % configs, "config_ocean_heat_transfer_type", config_ocean_heat_transfer_type)
+    call MPAS_pool_get_config(domain % configs, "config_salt_flux_coupling_type", config_salt_flux_coupling_type)
+    call MPAS_pool_get_config(domain % configs, "config_ocean_surface_type", config_ocean_surface_type)
+
+    call MPAS_pool_get_config(domain % configs, "config_use_column_physics", config_use_column_physics)
+    call MPAS_pool_get_config(domain % configs, "config_use_column_itd_thermodynamics", config_use_column_itd_thermodynamics)
+    call MPAS_pool_get_config(domain % configs, "config_use_prescribed_ice", config_use_prescribed_ice)
+    call MPAS_pool_get_config(domain % configs, "config_use_column_snow_tracers", config_use_column_snow_tracers)
+    call MPAS_pool_get_config(domain % configs, "config_use_snow_liquid_ponds", config_use_snow_liquid_ponds)
+    call MPAS_pool_get_config(domain % configs, "config_use_snicar_ad", config_use_snicar_ad)
+    call MPAS_pool_get_config(domain % configs, "config_use_shortwave_redistribution", config_use_shortwave_redistribution)
+    call MPAS_pool_get_config(domain % configs, "config_use_high_frequency_coupling", config_use_high_frequency_coupling)
+    call MPAS_pool_get_config(domain % configs, "config_limit_air_temperatures", config_limit_air_temperatures)
+    call MPAS_pool_get_config(domain % configs, "config_use_latent_processes", config_use_latent_processes)             ! colpkg
+    call MPAS_pool_get_config(domain % configs, "config_use_lateral_melt", config_use_lateral_melt)                     ! colpkg
+    call MPAS_pool_get_config(domain % configs, "config_use_congelation_basal_melt", config_use_congelation_basal_melt) ! colpkg
+
+    if (trim(config_column_physics_type) /= "icepack") then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_column_physics_type /= icepack', &
+           messageType=MPAS_LOG_WARN)
+    endif
+
+    if (trim(config_shortwave_type) /= "dEdd") then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_shortwave_type /= dEdd', &
+           messageType=MPAS_LOG_WARN)
+    endif
+
+    if (trim(config_snow_redistribution_scheme) /= "ITDrdg") then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_snow_redistribution_scheme /= ITDrdg', &
+           messageType=MPAS_LOG_WARN)
+    endif
+
+    if (trim(config_category_bounds_type) /= "original") then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_category_bounds_type /= original', &
+           messageType=MPAS_LOG_WARN)
+    endif
+
+    if (trim(config_ridging_participation_function) /= "exponential") then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_ridging_participation_function /= exponential', &
+           messageType=MPAS_LOG_WARN)
+    endif
+
+    if (trim(config_ridging_redistribution_function) /= "exponential") then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_ridging_redistribution_function /= exponential', &
+           messageType=MPAS_LOG_WARN)
+    endif
+
+    if (trim(config_ocean_heat_transfer_type) /= "constant") then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_ocean_heat_transfer_type /= constant', &
+           messageType=MPAS_LOG_WARN)
+    endif
+
+    if (trim(config_salt_flux_coupling_type) /= "constant") then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_salt_flux_coupling_type /= constant', &
+           messageType=MPAS_LOG_WARN)
+    endif
+
+    if (trim(config_ocean_surface_type) /= "free") then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_ocean_surface_type /= free', &
+           messageType=MPAS_LOG_WARN)
+    endif
+
+    if (.not. config_use_column_physics) then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_use_column_physics = false', &
+           messageType=MPAS_LOG_WARN)
+    endif
+
+    if (.not. config_use_column_itd_thermodynamics) then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_use_column_itd_thermodynamics = false', &
+           messageType=MPAS_LOG_WARN)
+    endif
+
+    if (config_use_prescribed_ice) then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_use_prescribed_ice = true', &
+           messageType=MPAS_LOG_WARN)
+    endif
+
+    if (.not. config_use_column_snow_tracers) then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_use_column_snow_tracers = false', &
+           messageType=MPAS_LOG_WARN)
+    endif
+
+    if (.not. config_use_snow_liquid_ponds) then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_use_snow_liquid_ponds = false', &
+           messageType=MPAS_LOG_WARN)
+    endif
+
+    if (.not. config_use_snicar_ad) then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_use_snicar_ad = false', &
+           messageType=MPAS_LOG_WARN)
+    endif
+
+    if (config_use_shortwave_redistribution) then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_use_shortwave_redistribution = true', &
+           messageType=MPAS_LOG_WARN)
+    endif
+
+    if (.not. config_use_high_frequency_coupling) then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_use_high_frequency_coupling = false', &
+           messageType=MPAS_LOG_WARN)
+    endif
+
+    if (config_limit_air_temperatures) then
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_limit_air_temperatures = true', &
+           messageType=MPAS_LOG_WARN)
+    endif
+
+    if (trim(config_column_physics_type) == 'icepack' .and. .not. config_use_latent_processes) then ! colpkg
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_use_latent_processes is not available in icepack', &
+           messageType=MPAS_LOG_WARN)
+    endif
+
+    if (trim(config_column_physics_type) == 'icepack' .and. .not. config_use_lateral_melt) then ! colpkg
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_use_lateral_melt is not available in icepack', &
+           messageType=MPAS_LOG_WARN)
+    endif
+
+    if (trim(config_column_physics_type) == 'icepack' .and. .not. config_use_congelation_basal_melt) then ! colpkg
+      call mpas_log_write(&
+           'seaice_check_configs_coupled: config_use_congelation_basal_melt is not available in icepack', &
+           messageType=MPAS_LOG_WARN)
+    endif
+
+#endif
+
+  end subroutine seaice_check_configs_coupled
+
+!-----------------------------------------------------------------------
 
 end module seaice_initialize

--- a/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver.F
@@ -20,7 +20,7 @@ module seaice_velocity_solver
   use mpas_dmpar
   use mpas_timer
   use mpas_log, only: mpas_log_write, mpas_log_info
-  use ice_constants_colpkg, only: puny
+  use seaice_constants, only: seaicePuny
 
   implicit none
 
@@ -62,9 +62,12 @@ module seaice_velocity_solver
   ! velocity solver constants
   real(kind=RKIND), parameter, private :: &
        sinOceanTurningAngle = 0.0_RKIND, & ! northern hemisphere
-       cosOceanTurningAngle = 1.0_RKIND, & ! northern hemisphere
-       seaiceAreaMinimum = puny, &
-       seaiceMassMinimum = 10.0_RKIND*puny
+       cosOceanTurningAngle = 1.0_RKIND    ! northern hemisphere
+
+  ! velocity solver constants initialized in seaice_init_velocity_solver
+  real(kind=RKIND), private :: &
+       seaiceAreaMinimum, &
+       seaiceMassMinimum
 
 contains
 
@@ -133,6 +136,10 @@ contains
 
     integer :: &
          ierr
+
+    ! set up min area and mass for velocity solver
+    seaiceAreaMinimum = seaicePuny
+    seaiceMassMinimum = 10.0_RKIND*seaicePuny
 
     ! set up the dynamically locked cell mask
     call dynamically_locked_cell_mask(domain)


### PR DESCRIPTION
This PR cleans up MPAS-SeaIce with final BFB changes for Version 3, including:

1) Added or updated checks on configuration settings. Checks on values necessary for coupled runs are done in mpas_seaice_initialize.F, and consistency checks for icepack are done in mpas_seaice_icepack.F. Consistency checks for colpkg were not updated (BFB, author: @eclare108213): a) remove config_couple_biogeochemistry_fields (not used); b) correct listed namelist values for config_snow_redistribution_scheme; c) update config consistency checks for icepack; d) rename seaice_check_constants to seaice_check_constants_coupled; e) add subroutine seaice_check_configs_coupled; f) update comment statements

2) Correction of sea ice velocity solver concentration and mass limit to universal constant seaicePuny consistent with changes made with the introduction of Icepack to the code base. The same constant value is used, but it is drawn from a different part of the code, now centralized in one location of constant declarations for Icepack and the MPAS-SeaIce dycore (BFB, authors: @njeffery and @proteanplanet )

3) Completed wiring of floe diameter and floe shape constants from the namelist into Icepack (BFB, author: @proteanplanet )

Testing for this PR was conducted on each individual listed item above, as well as on the PR as a whole.  For the first item, testing of warnings and aborts was done in D, F, and B cases as detailed in a comment below.  For every item D-cases testing was conducted against master at the time of checkout to ensure each item alone was BFB with master.  In addition, the E3SM_ice_developer test suite, comprising D-case SMS, ERS, PEM, and PET tests, was run on each listed item individually as well as on the PR as a whole, and in all cases passed. The PR as a whole was tested in a D-case against master and confirmed to be BFB.   
