### PR TITLE
Adding global water budget tables to ROF log

### DIFF
--- a/components/mosart/bld/build-namelist
+++ b/components/mosart/bld/build-namelist
@@ -314,6 +314,7 @@ else {
     add_default($nl, 'inundflag');
     add_default($nl, 'sediflag');
     add_default($nl, 'heatflag');
+    add_default($nl, 'do_all_budget');
     add_default($nl, 'data_bgc_fluxes_to_ocean_flag');
     add_default($nl, 'rstraflag');
     add_default($nl, 'rinittemp');

--- a/components/mosart/bld/namelist_files/namelist_defaults_mosart.xml
+++ b/components/mosart/bld/namelist_files/namelist_defaults_mosart.xml
@@ -22,6 +22,7 @@ for the CLM data in the CESM distribution
 <inundflag>.false.</inundflag>
 <sediflag>.false.</sediflag>
 <heatflag>.false.</heatflag>
+<do_all_budget>.false.</do_all_budget>
 <data_bgc_fluxes_to_ocean_flag>.false.</data_bgc_fluxes_to_ocean_flag>
 <rstraflag>.false.</rstraflag>
 <rinittemp>283.15</rinittemp>

--- a/components/mosart/bld/namelist_files/namelist_definition_mosart.xml
+++ b/components/mosart/bld/namelist_files/namelist_definition_mosart.xml
@@ -110,6 +110,14 @@ Default: .false.
 If .true., heat model will be turned on.
 </entry>
 
+<entry id="do_all_budget" 
+       type="logical" 
+       category="mosart"
+       group="mosart_inparm">
+Default: .false.
+If .true., write all budget terms at every timestep to the ROF log file.
+</entry>
+
 <entry id="data_bgc_fluxes_to_ocean_flag" 
        type="logical" 
        category="mosart"

--- a/components/mosart/src/riverroute/MOSART_Budgets_mod.F90
+++ b/components/mosart/src/riverroute/MOSART_Budgets_mod.F90
@@ -1,0 +1,487 @@
+module MOSART_Budgets_mod
+! Description: MOSART global water budget disgnostics
+! 
+! Added by Tian Zhou for E3SM v3, 11/06/2023. 
+!-----------------------------------------------------------------------
+  ! USES:
+  use rof_cpl_indices, only : nt_rtm, nt_nliq, nt_nice
+  use RtmVar         , only : iulog, nsrContinue, nsrest
+  use RtmSpmd        , only : masterproc
+  use shr_kind_mod   , only : r8 => shr_kind_r8
+  use shr_sys_mod    , only : shr_sys_abort
+  use shr_const_mod  , only : SHR_CONST_REARTH ! earth radius in m
+  use shr_const_mod  , only : shr_const_pi
+
+  implicit none
+  private
+
+  public MOSART_WaterBudget_Reset
+  public MOSART_WaterBudget_Extraction
+  public MOSART_WaterBudget_Print
+  public MOSART_WaterBudget_Restart_Write
+  public MOSART_WaterBudget_Restart_Read
+  
+    !--- F for flux ---
+
+  integer, parameter :: f_roff = 1
+  integer, parameter :: f_rout = 2
+  integer, parameter :: f_irri = 3
+
+  integer, parameter, public :: f_size = f_irri
+
+  character(len=16),parameter :: fname(f_size) = &
+       (/&
+       '     runoff (in)', &
+       'streamflow (out)', &
+       '           irrig'  &
+       /)
+
+   !--- O for "other" term aggregated from flux to state ---
+
+  integer, parameter :: o_othr = 1
+
+  integer, parameter, public :: o_size = o_othr
+
+  !--- S for state ---
+  integer, parameter :: s_w_beg         = 1
+  integer, parameter :: s_w_end         = 2
+  integer, parameter :: s_wchannel_beg  = 3
+  integer, parameter :: s_wchannel_end  = 4
+  integer, parameter :: s_wdam_beg      = 5
+  integer, parameter :: s_wdam_end      = 6
+  integer, parameter :: s_wflood_beg    = 7
+  integer, parameter :: s_wflood_end    = 8
+  integer, parameter :: s_wother_beg    = 9
+  integer, parameter :: s_wother_end    = 10
+
+  integer, parameter, public :: s_size = s_wother_end
+
+  character(len=13),parameter :: sname(s_size) = &
+       (/&
+       '  total_w_beg', &
+       '  total_w_end', &
+       'channel_w_beg', &
+       'channel_w_end', &
+       '    dam_w_beg', &
+       '    dam_w_end', &
+       '  flood_w_beg', &
+       '  flood_w_end', &
+       '  other_w_beg', &
+       '  other_w_end'  &
+       /)
+
+  !--- P for period ---
+
+  integer, parameter :: p_inst = 1
+  integer, parameter :: p_day  = 2
+  integer, parameter :: p_mon  = 3
+  integer, parameter :: p_ann  = 4
+  integer, parameter :: p_inf  = 5
+
+  integer, parameter, public :: p_size = p_inf
+
+  character(len=8),parameter :: pname(p_size) = &
+       (/'    inst','   daily',' monthly','  annual','all_time' /)
+
+  real(r8), public :: rof_budg_fluxG  (f_size, p_size) ! global flux sum (volume/time)
+  real(r8), public :: rof_budg_other  (o_size, p_size) ! global "other" term (volume)
+  real(r8), public :: rof_budg_stateG (s_size, p_size) ! global state sum (volume)
+  real(r8), public :: rof_budg_fluxN  (f_size, p_size) ! counter, valid only on root pe
+
+  real(r8) :: rof_budg_other_rest (o_size,p_size) = 0.0_r8 ! "other" term from restart file
+
+  real(r8), target, public :: rof_budg_fluxG_1D (f_size*p_size)
+  real(r8), target, public :: rof_budg_other_1D (o_size*p_size)
+  real(r8), target, public :: rof_budg_stateG_1D(s_size*p_size)
+  real(r8), target, public :: rof_budg_fluxN_1D (f_size*p_size)
+
+  !----- formats -----
+  character(*),parameter :: FA0= "('    ',12x,(3x,a10,2x),' | ',(3x,a10,2x))"
+  character(*),parameter :: FF = "('',a16,f15.8,' | ',f18.2)"
+  character(*),parameter :: FS = "('    ',a12,3(f18.2),18x,' | ',(f18.2))"
+  character(*),parameter :: FS0= "('    ',12x,4(a18),' | ',(a18))"
+  character(*),parameter :: FS2= "('    ',a12,27x,f18.2,27x,' | ',f18.2)"
+  character(*),parameter :: FS3= "('    ',a12,4(f18.2),' | ',(f18.2))"
+
+  !----- other variables -----
+  real(r8)               :: unit_conversion
+
+contains
+  subroutine MOSART_WaterBudget_Reset(mode)
+   !
+   use RtmTimeManager, only : get_curr_date, get_prev_date
+   !
+   implicit none
+   !
+   character(len=*), intent(in),optional :: mode
+   !
+   integer :: year, mon, day, sec
+   integer :: ip
+   character(*),parameter :: subName = '(MOSART_WaterBudget_Reset) '
+
+   if (.not.present(mode)) then
+      call get_curr_date(year, mon, day, sec)
+
+      do ip = 1,p_size
+         if (ip == p_inst) then
+            rof_budg_fluxG(:,ip)  = 0.0_r8
+         !   rof_budg_other(:,ip)  = 0.0_r8
+            rof_budg_fluxN(:,ip)  = 0.0_r8
+         endif
+         if (ip==p_day .and. sec==0) then
+            rof_budg_fluxG(:,ip)  = 0.0_r8
+         !   rof_budg_other(:,ip)  = 0.0_r8
+            rof_budg_fluxN(:,ip)  = 0.0_r8
+         endif
+         if (ip==p_mon .and. day==1 .and. sec==0) then
+            rof_budg_fluxG(:,ip)  = 0.0_r8
+         !   rof_budg_other(:,ip)  = 0.0_r8
+            rof_budg_fluxN(:,ip)  = 0.0_r8
+         endif
+         if (ip==p_ann .and. mon==1 .and. day==1 .and. sec==0) then
+            rof_budg_fluxG(:,ip)  = 0.0_r8
+         !   rof_budg_other(:,ip)  = 0.0_r8
+            rof_budg_fluxN(:,ip)  = 0.0_r8
+         endif
+      enddo
+
+   else
+
+      if (trim(mode) == 'inst') then
+         rof_budg_fluxG  (:,p_inst)   = 0.0_r8
+         rof_budg_other  (:,p_inst)   = 0.0_r8
+         rof_budg_stateG (:,p_inst)   = 0.0_r8
+         rof_budg_fluxN  (:,p_inst)   = 0.0_r8
+      elseif (trim(mode) == 'day') then
+         rof_budg_fluxG  (:,p_day)    = 0.0_r8
+         rof_budg_other  (:,p_day)    = 0.0_r8
+         rof_budg_stateG (:,p_day)    = 0.0_r8
+         rof_budg_fluxN  (:,p_day)    = 0.0_r8
+      elseif (trim(mode) == 'mon') then
+         rof_budg_fluxG  (:,p_mon)    = 0.0_r8
+         rof_budg_other  (:,p_mon)    = 0.0_r8
+         rof_budg_stateG (:,p_mon)    = 0.0_r8
+         rof_budg_fluxN  (:,p_mon)    = 0.0_r8
+      elseif (trim(mode) == 'ann') then
+         rof_budg_fluxG  (:,p_ann)    = 0.0_r8
+         rof_budg_other  (:,p_ann)    = 0.0_r8
+         rof_budg_stateG (:,p_ann)    = 0.0_r8
+         rof_budg_fluxN  (:,p_ann)    = 0.0_r8
+      elseif (trim(mode) == 'inf') then
+         rof_budg_fluxG  (:,p_inf)    = 0.0_r8
+         rof_budg_other  (:,p_inf)    = 0.0_r8
+         rof_budg_stateG (:,p_inf)    = 0.0_r8
+         rof_budg_fluxN  (:,p_inf)    = 0.0_r8
+      elseif (trim(mode) == 'all') then
+         rof_budg_fluxG  (:,:)        = 0.0_r8
+         rof_budg_other  (:,:)        = 0.0_r8
+         rof_budg_stateG (:,:)        = 0.0_r8
+         rof_budg_fluxN  (:,:)        = 0.0_r8
+      else
+         call shr_sys_abort(subname//' ERROR in mode '//trim(mode))
+      endif
+   endif
+
+  end subroutine MOSART_WaterBudget_Reset
+!--------------------------------------------------------------------
+  subroutine MOSART_WaterBudget_Extraction(budget_global, budget_terms_total, bv_volt_beg, bv_volt_end, &
+   bv_wt_beg, bv_wt_end, bv_wr_beg, bv_wr_end, bv_wh_beg, bv_wh_end, bv_dstor_beg, bv_dstor_end, bv_fp_beg, bv_fp_end, br_sup, &
+   budget_in, budget_out, budget_oth)
+
+   use RtmTimeManager, only : get_curr_date, get_prev_date, get_nstep, get_step_size
+   implicit none
+   !
+   integer,  intent(in) :: budget_terms_total
+   real(r8), intent(in) :: budget_global(budget_terms_total,nt_rtm)    ! global budget sums
+   integer,  intent(in) :: bv_volt_beg  ! = 1  ! initial total volume
+   integer,  intent(in) :: bv_volt_end  ! = 2  ! final   total volume
+   integer,  intent(in) :: bv_wt_beg    ! = 3  ! initial wt volume
+   integer,  intent(in) :: bv_wt_end    ! = 4  ! final   wt volume
+   integer,  intent(in) :: bv_wr_beg    ! = 5  ! initial wr volume
+   integer,  intent(in) :: bv_wr_end    ! = 6  ! final   wr volume
+   integer,  intent(in) :: bv_wh_beg    ! = 7  ! initial wh volume
+   integer,  intent(in) :: bv_wh_end    ! = 8  ! final   wh volume
+   integer,  intent(in) :: bv_dstor_beg ! = 9  ! initial dam storage
+   integer,  intent(in) :: bv_dstor_end ! = 10 ! final   dam storage
+   integer,  intent(in) :: bv_fp_beg    ! = 11 ! Initial water volume over floodplains.
+   integer,  intent(in) :: bv_fp_end    ! = 12 ! Final water volume over floodplains.
+   integer,  intent(in) :: br_sup       ! = 49 ! supply rate (m3/coupling period)
+
+   real(r8), intent(in) :: budget_in, budget_out, budget_oth
+
+   integer                :: ip, nf
+   integer                :: year_prev, month_prev, day_prev, sec_prev
+   integer                :: year_curr, month_curr, day_curr, sec_curr
+   logical                :: update_state_beg, update_state_end
+
+   character(*),parameter :: subName = '(Extraction) '
+
+   unit_conversion = 1.d0/(4.0_r8*shr_const_pi*SHR_CONST_REARTH**2)*1.0e15_r8
+
+   rof_budg_fluxG(f_roff,p_inst) = budget_in / get_step_size() 
+   rof_budg_fluxG(f_rout,p_inst) = -(budget_out - budget_global(br_sup, nt_nliq)) / get_step_size() !subtract the supply part as it has been aggregated to total out
+   rof_budg_fluxG(f_irri,p_inst) = -budget_global(br_sup, nt_nliq) / get_step_size() 
+   rof_budg_other(o_othr,p_inst) = budget_oth / get_step_size() 
+
+   rof_budg_stateG(s_w_beg, p_inst) =  budget_global(bv_volt_beg,nt_nliq) * unit_conversion ! assign values
+   rof_budg_stateG(s_w_end, p_inst) =  budget_global(bv_volt_end,nt_nliq) * unit_conversion ! 
+   rof_budg_stateG(s_wchannel_beg, p_inst) =  (budget_global(bv_wt_beg,nt_nliq) + budget_global(bv_wr_beg,nt_nliq) + budget_global(bv_wh_beg,nt_nliq)) * unit_conversion 
+   rof_budg_stateG(s_wchannel_end, p_inst) =  (budget_global(bv_wt_end,nt_nliq) + budget_global(bv_wr_end,nt_nliq) + budget_global(bv_wh_end,nt_nliq)) * unit_conversion 
+   rof_budg_stateG(s_wdam_beg, p_inst) =  budget_global(bv_dstor_beg,nt_nliq) * unit_conversion
+   rof_budg_stateG(s_wdam_end, p_inst) =  budget_global(bv_dstor_end,nt_nliq) * unit_conversion
+   rof_budg_stateG(s_wflood_beg, p_inst) =  budget_global(bv_fp_beg,nt_nliq) * unit_conversion
+   rof_budg_stateG(s_wflood_end, p_inst) =  budget_global(bv_fp_end,nt_nliq) * unit_conversion
+
+   call get_prev_date(year_prev, month_prev, day_prev, sec_prev)
+   call get_curr_date(year_curr, month_curr, day_curr, sec_curr)
+
+   do ip = p_inst+1, p_size
+      rof_budg_fluxG(:,ip) = rof_budg_fluxG(:,ip) + rof_budg_fluxG(:,p_inst)
+      rof_budg_other(:,ip) = rof_budg_other(:,ip) + rof_budg_other(:,p_inst)
+
+      update_state_beg = .false.
+      update_state_end = .false.
+
+      select case (ip)
+      case (p_day)
+         if (sec_prev == 0) update_state_beg = .true.
+         if (sec_curr == 0) update_state_end = .true.
+      case (p_mon)
+         if (sec_prev == 0 .and. day_prev == 1) update_state_beg = .true.
+         if (sec_curr == 0 .and. day_curr == 1) update_state_end = .true.
+      case (p_ann)
+         if (sec_prev == 0 .and. day_prev == 1 .and. month_prev == 1) update_state_beg = .true.
+         if (sec_curr == 0 .and. day_curr == 1 .and. month_curr == 1) update_state_end = .true.
+      case (p_inf)
+         if (get_nstep() == 1) update_state_beg = .true.
+         update_state_end = .true.
+      end select
+
+      if (update_state_beg) then
+         nf = s_w_beg        ; rof_budg_stateG(nf,ip) = rof_budg_stateG(nf, p_inst)
+         nf = s_wchannel_beg ; rof_budg_stateG(nf,ip) = rof_budg_stateG(nf, p_inst)
+         nf = s_wdam_beg     ; rof_budg_stateG(nf,ip) = rof_budg_stateG(nf, p_inst)
+         nf = s_wflood_beg   ; rof_budg_stateG(nf,ip) = rof_budg_stateG(nf, p_inst)
+         nf = s_wother_beg   ; rof_budg_stateG(nf,ip) = rof_budg_other_rest(o_othr,ip) + (rof_budg_other(o_othr, ip) - rof_budg_other(o_othr,p_inst)) * unit_conversion * get_step_size()
+      endif
+
+      if (update_state_end) then
+         nf = s_w_end        ; rof_budg_stateG(nf,ip) = rof_budg_stateG(nf, p_inst)
+         nf = s_wchannel_end ; rof_budg_stateG(nf,ip) = rof_budg_stateG(nf, p_inst)
+         nf = s_wdam_end     ; rof_budg_stateG(nf,ip) = rof_budg_stateG(nf, p_inst)
+         nf = s_wflood_end   ; rof_budg_stateG(nf,ip) = rof_budg_stateG(nf, p_inst)
+         nf = s_wother_end   ; rof_budg_stateG(nf,ip) = rof_budg_other_rest(o_othr, ip) + rof_budg_other(o_othr, ip) * unit_conversion * get_step_size() 
+      endif
+
+   end do
+   rof_budg_fluxN(:,:) = rof_budg_fluxN(:,:) + 1._r8
+
+  end subroutine MOSART_WaterBudget_Extraction
+!-----------------------------------------------------------------------
+  subroutine MOSART_WaterBudget_Print()
+   !
+   use RtmTimeManager, only : get_curr_date, get_prev_date, get_nstep, get_step_size
+   !
+   implicit none
+   !
+   integer :: budg_print_inst  = 0
+   integer :: budg_print_daily = 0
+   integer :: budg_print_month = 1
+   integer :: budg_print_ann   = 1
+   integer :: budg_print_ltann = 1
+   integer :: budg_print_ltend = 0
+   !
+   ! !LOCAL VARIABLES:
+   integer :: s,f,ic,nf,ip,is ! data array indicies
+   integer :: plev        ! print level
+   integer :: year, mon, day, sec
+   integer :: cdate
+   logical :: sumdone
+   real(r8) :: budg_fluxGpr (f_size,p_size) ! values to print, scaled and such
+
+   character(*),parameter :: subName = '(MOSART_WaterBudget_Print) '
+
+   sumdone = .false.
+
+   if (get_nstep() <= 1) then
+      call get_prev_date(year, mon, day, sec);
+   else
+      call get_curr_date(year, mon, day, sec);
+   end if
+
+   cdate = year*10000 + mon*100 + day
+
+   do ip = 1,p_size
+      plev = 0
+      if (ip == p_inst) then
+         plev = max(plev,budg_print_inst)
+      endif
+      if (ip==p_day .and. sec==0) then
+         plev = max(plev,budg_print_daily)
+      endif
+      if (ip==p_mon .and. day==1 .and. sec==0) then
+         plev = max(plev,budg_print_month)
+      endif
+      if (ip==p_ann .and. mon==1 .and. day==1 .and. sec==0) then
+         plev = max(plev,budg_print_ann)
+      endif
+      if (ip==p_inf .and. mon==1 .and. day==1 .and. sec==0) then
+         plev = max(plev,budg_print_ltann)
+      endif
+
+      if (plev > 0) then
+            unit_conversion = 1.d0/(4.0_r8*shr_const_pi*SHR_CONST_REARTH**2)*1.0e15_r8
+         if (.not.sumdone) then
+            sumdone = .true.
+            budg_fluxGpr = rof_budg_fluxG
+            budg_fluxGpr = budg_fluxGpr*unit_conversion
+            budg_fluxGpr = budg_fluxGpr/rof_budg_fluxN
+         end if
+
+         if (ip == p_day .and. get_nstep() == 1) cycle
+         if (ip == p_mon .and. get_nstep() == 1) cycle
+         if (ip == p_ann .and. get_nstep() == 1) cycle
+         if (ip == p_inf .and. get_nstep() == 1) cycle
+
+         if (masterproc) then
+            write(iulog,*)''
+            write(iulog,*)'NET WATER FLUXES : period ',trim(pname(ip)),': date = ',cdate,sec
+            write(iulog,FA0)'  Time  ','  Time    '
+            write(iulog,FA0)'averaged','integrated'
+            write(iulog,FA0)'kg/m2s*1e6','kg/m2*1e6'
+            write(iulog,'(32("-"),"|",20("-"))')
+            do f = 1, f_size
+               write(iulog,FF)fname(f),budg_fluxGpr(f,ip),rof_budg_fluxG(f,ip)*unit_conversion*get_step_size()
+            end do
+            write(iulog,'(32("-"),"|",20("-"))')
+            write(iulog,FF)'   *SUM*', &
+                  sum(budg_fluxGpr(:,ip)), sum(rof_budg_fluxG(:,ip))*unit_conversion*get_step_size()
+            write(iulog,'(32("-"),"|",20("-"))')
+            write(iulog,*)''
+            write(iulog,*)'WATER STATES (kg/m2*1e6): period ',trim(pname(ip)),': date = ',cdate,sec
+            write(iulog,FS0) &
+                  '       channel   ', &
+                  '       reservoir ', &
+                  '       floodplain', &
+                  '       other     ', &
+                  '       TOTAL     '
+            write(iulog,'(89("-"),"|",23("-"))')
+            write(iulog,FS3) '         beg', &
+                  rof_budg_stateG(s_wchannel_beg, ip), &
+                  rof_budg_stateG(s_wdam_beg    , ip), &
+                  rof_budg_stateG(s_wflood_beg  , ip), &
+               - rof_budg_stateG(s_wother_beg  , ip), & ! print out negative value in the table for display only, actual calucation uses positive
+                  rof_budg_stateG(s_w_beg       , ip)- &
+                  rof_budg_stateG(s_wother_beg  , ip)
+            write(iulog,FS3) '         end', &
+                  rof_budg_stateG(s_wchannel_end, ip), &
+                  rof_budg_stateG(s_wdam_end    , ip), &
+                  rof_budg_stateG(s_wflood_end  , ip), &
+               - rof_budg_stateG(s_wother_end  , ip), & ! print out negative value in the table for display only, actual calucation uses positive
+                  rof_budg_stateG(s_w_end       , ip)- &
+                  rof_budg_stateG(s_wother_end  , ip)
+            write(iulog,FS3)'*NET CHANGE*', &
+                  (rof_budg_stateG(s_wchannel_end,ip) - rof_budg_stateG(s_wchannel_beg,ip)), &
+                  (rof_budg_stateG(s_wdam_end    ,ip) - rof_budg_stateG(s_wdam_beg    ,ip)), &
+                  (rof_budg_stateG(s_wflood_end  ,ip) - rof_budg_stateG(s_wflood_beg  ,ip)), &
+                - (rof_budg_stateG(s_wother_end  ,ip) - rof_budg_stateG(s_wother_beg  ,ip)), &
+                  (rof_budg_stateG(s_w_end       ,ip) - rof_budg_stateG(s_wother_end  , ip)) - & 
+                  (rof_budg_stateG(s_w_beg       ,ip) - rof_budg_stateG(s_wother_beg  , ip))
+            write(iulog,'(89("-"),"|",23("-"))')
+            write(iulog,FS2)'   *SUM*    ', &
+                  (rof_budg_stateG(s_wchannel_end  ,ip) - rof_budg_stateG(s_wchannel_beg  ,ip)) + &
+                  (rof_budg_stateG(s_wdam_end  ,ip) - rof_budg_stateG(s_wdam_beg  ,ip)) + &
+                  (rof_budg_stateG(s_wflood_end  ,ip) - rof_budg_stateG(s_wflood_beg  ,ip)) - &
+                  (rof_budg_stateG(s_wother_end  ,ip) - rof_budg_stateG(s_wother_beg  ,ip)), &
+                  (rof_budg_stateG(s_wchannel_end  ,ip) - rof_budg_stateG(s_wchannel_beg  ,ip)) + &
+                  (rof_budg_stateG(s_wdam_end  ,ip) - rof_budg_stateG(s_wdam_beg  ,ip)) + &
+                  (rof_budg_stateG(s_wflood_end  ,ip) - rof_budg_stateG(s_wflood_beg  ,ip)) - &
+                  (rof_budg_stateG(s_wother_end  ,ip) - rof_budg_stateG(s_wother_beg  ,ip))
+            write(iulog,'(89("-"),"|",23("-"))')
+         end if
+      end if
+   end do
+  end subroutine MOSART_WaterBudget_Print
+!-----------------------------------------------------------------------
+  subroutine MOSART_WaterBudget_Restart_Write()
+   !
+   implicit none
+   !
+       ! !LOCAL VARIABLES:
+
+   integer  :: f, s, o, p, count
+   character(*),parameter :: subName = '(MOSART_WaterBudget_Restart_Write) '
+
+       ! Copy data from 2D into 1D array
+   count = 0
+   do f = 1, f_size
+      do p = 1, p_size
+         count = count + 1
+         rof_budg_fluxG_1D(count) = rof_budg_fluxG(f,p)
+         rof_budg_fluxN_1D(count) = rof_budg_fluxN(f,p)
+      end do
+   end do
+
+   ! Copy data from 2D into 1D array
+   count = 0
+   do s = 1, s_size
+      do p = 1, p_size
+         count = count + 1
+         rof_budg_stateG_1D(count) = rof_budg_stateG(s,p)
+      end do
+   end do
+
+      ! Copy data from 2D into 1D array
+   count = 0
+   do o = 1, o_size
+      do p = 1, p_size
+         count = count + 1
+         rof_budg_other_1D(count) = rof_budg_other(o,p)
+      end do
+   end do
+
+  end subroutine MOSART_WaterBudget_Restart_Write
+!-----------------------------------------------------------------------
+  subroutine MOSART_WaterBudget_Restart_Read()
+   !
+   implicit none
+   !
+   integer  :: f, s, p, o, count
+   ! Copy data from 1D into 2D array
+   count = 0
+   do f = 1, f_size
+      do p = 1, p_size
+         count = count + 1
+         rof_budg_fluxG(f,p) = rof_budg_fluxG_1D(count)
+         rof_budg_fluxN(f,p) = rof_budg_fluxN_1D(count)
+      end do
+   end do
+
+   ! Copy data from 1D into 2D array
+   if (masterproc) then
+      count = 0
+      do s = 1, s_size
+         do p = 1, p_size
+            count = count + 1
+            rof_budg_stateG(s,p) = rof_budg_stateG_1D(count)
+         end do
+      end do
+   end if
+
+   ! Copy data from 1D into 2D array
+   if (masterproc) then
+      count = 0
+      do o = 1, o_size
+         do p = 1, p_size
+            count = count + 1
+            rof_budg_other(s,p) = rof_budg_other_1D(count)
+         end do
+      end do
+   end if
+   ! save the "other term" from the restart file so that it can
+   ! be used as initial values in the water state budget table
+   rof_budg_other_rest(o_othr,:) = rof_budg_stateG(s_wother_end,:) 
+   ! write(iulog,*) '(TZ)rof_budg_other_rest', rof_budg_other_rest
+  end subroutine MOSART_WaterBudget_Restart_Read
+
+end module MOSART_Budgets_mod

--- a/components/mosart/src/riverroute/RtmMod.F90
+++ b/components/mosart/src/riverroute/RtmMod.F90
@@ -20,7 +20,7 @@ module RtmMod
                                frivinp_rtm, finidat_rtm, nrevsn_rtm,rstraflag,ngeom,nlayers,rinittemp, &
                                nsrContinue, nsrBranch, nsrStartup, nsrest, &
                                inst_index, inst_suffix, inst_name, wrmflag, inundflag, &
-                               smat_option, decomp_option, barrier_timers, heatflag, sediflag, &
+                               smat_option, decomp_option, barrier_timers, heatflag, sediflag, do_all_budget, &
                                isgrid2d, data_bgc_fluxes_to_ocean_flag, use_lnd_rof_two_way, use_ocn_rof_two_way
   use RtmFileUtils    , only : getfil, getavu, relavu
   use RtmTimeManager  , only : timemgr_init, get_nstep, get_curr_date, advance_timestep
@@ -50,6 +50,7 @@ module RtmMod
   use WRM_subw_IO_mod , only : WRM_init, WRM_computeRelease
   use MOSARTinund_PreProcs_MOD, only : calc_chnlMannCoe, preprocess_elevProf
   use MOSARTinund_Core_MOD    , only : MOSARTinund_simulate, ManningEq, ChnlFPexchg
+  use MOSART_Budgets_mod, only: MOSART_WaterBudget_Extraction, MOSART_WaterBudget_Print, MOSART_WaterBudget_Reset
   use RtmIO
   use mct_mod
   use perf_mod
@@ -272,7 +273,7 @@ contains
          rtmhist_fincl1,  rtmhist_fincl2, rtmhist_fincl3, &
          rtmhist_fexcl1,  rtmhist_fexcl2, rtmhist_fexcl3, &
          rtmhist_avgflag_pertape, decomp_option, wrmflag,rstraflag,ngeom,nlayers,rinittemp, &
-         inundflag, smat_option, delt_mosart, barrier_timers,          &
+         inundflag, smat_option, delt_mosart, barrier_timers, do_all_budget, &
          RoutingMethod, DLevelH2R, DLevelR, sediflag, heatflag, data_bgc_fluxes_to_ocean_flag
 
     namelist /inund_inparm / opt_inund, &
@@ -293,6 +294,7 @@ contains
     inundflag   = .false.
     sediflag    = .false.
     heatflag    = .false.
+    do_all_budget = .false.
     barrier_timers = .false.
     finidat_rtm = ' '
     nrevsn_rtm  = ' '
@@ -320,6 +322,8 @@ contains
     OPT_elevProf = 2              
     npt_elevProf = 11             
     threshold_slpRatio = 10.0_r8  
+
+   ! call MOSART_WaterBudget_Reset('all')
 
     nlfilename_rof = "mosart_in" // trim(inst_suffix)
     inquire (file = trim(nlfilename_rof), exist = lexist)
@@ -382,6 +386,7 @@ contains
     call mpi_bcast (wrmflag,        1, MPI_LOGICAL, 0, mpicom_rof, ier)
     call mpi_bcast (sediflag,       1, MPI_LOGICAL, 0, mpicom_rof, ier)
     call mpi_bcast (heatflag,       1, MPI_LOGICAL, 0, mpicom_rof, ier)
+    call mpi_bcast (do_all_budget,  1, MPI_LOGICAL, 0, mpicom_rof, ier)
     call mpi_bcast (rstraflag,      1, MPI_LOGICAL, 0, mpicom_rof, ier)
     call mpi_bcast (rinittemp,      1, MPI_REAL8, 0, mpicom_rof, ier)
     call mpi_bcast (ngeom,          1, MPI_INTEGER, 0, mpicom_rof, ier)
@@ -471,6 +476,7 @@ contains
        write(iulog,*) '   wrmflag               = ',wrmflag
        write(iulog,*) '   inundflag             = ',inundflag
        write(iulog,*) '   sediflag              = ',sediflag
+       write(iulog,*) '   do_all_budget         = ',do_all_budget
        write(iulog,*) '   use_lnd_rof_two_way   = ',use_lnd_rof_two_way
        write(iulog,*) '   heatflag              = ',heatflag
        write(iulog,*) '   barrier_timers        = ',barrier_timers
@@ -511,6 +517,9 @@ contains
        else
           if (masterproc) then
              write(iulog,*) '   MOSART river data       = ',trim(frivinp_rtm)
+             if (wrmflag .and. inundflag) then
+               write(iulog,*) subname,' MOSART wrmflag and inundflag both set to be true'
+             endif
           endif
        end if
     else
@@ -519,10 +528,6 @@ contains
        endif
        RETURN
     end if
-
-    if (wrmflag .and. inundflag) then
-       write(iulog,*) subname,' MOSART wrmflag and inundflag both set to be true'
-    endif
 
     if (coupling_period <= 0) then
        write(iulog,*) subname,' ERROR MOSART coupling_period invalid',coupling_period
@@ -2070,7 +2075,6 @@ contains
 !EOP
     integer  :: i, j, n, nr, ns, nt, n2, nf, idam ! indices
     integer, parameter :: budget_terms_total = 80
-    logical  :: output_all_budget_terms = .false.   ! output flag
     real(r8) :: budget_terms (budget_terms_total,nt_rtm)    ! local budget sums
     real(r8) :: budget_global(budget_terms_total,nt_rtm)    ! global budget sums
 
@@ -2083,6 +2087,7 @@ contains
     real(r8) :: budget_input, budget_output, budget_volume, budget_total, &
                 budget_other
     logical  :: budget_check, budget_write  ! do global budget check
+    integer  :: nt_print ! number of tracers to be printed out
 
     ! BUDGET term ids
     ! budget computed in m3 over each coupling period
@@ -2148,6 +2153,8 @@ contains
     integer,parameter :: bv_chnl2fp       = 46 ! Volume of flows from main channels to floodplains (m^3).
     integer,parameter :: bv_fp2chnl       = 47 ! Volume of flows from floodplains to main channels (m^3).
     integer,parameter :: br_landOutflow   = 48 ! Total streamflow (flow rate) from land to oceans (m^3/s).
+
+    integer,parameter :: br_supply        = 49 ! supply rate
 
     integer,parameter :: bi_landArea      = 50 ! Total land area (m^2).
     integer,parameter :: bi_floodedArea   = 51 ! Total flooded area (including channel area) (m^2).
@@ -2271,7 +2278,10 @@ contains
     end if
     
     if (budget_check) then
+
        call t_startf('mosartr_budget')
+       call MOSART_WaterBudget_Reset()
+
        do nt = 1,nt_rtm
        do nr = rtmCTL%begr,rtmCTL%endr
           budget_terms(bv_volt_i,nt) = budget_terms( bv_volt_i,nt) + rtmCTL%volr(nr,nt)
@@ -2831,6 +2841,7 @@ contains
     !-----------------------------------
 
     budget_write = .false.
+    if (do_all_budget) budget_write = .true.
     if (day == 1 .and. mon == 1) budget_write = .true.
     if (tod == 0) budget_write = .true.
 
@@ -2875,12 +2886,11 @@ contains
        if (wrmflag) then
           nt = 1
           do nr = rtmCTL%begr,rtmCTL%endr
-             budget_terms(bv_dsupp_f,nt) = budget_terms(bv_dsupp_f,nt) + StorWater%supply(nr)
-             ! convert supply from m3 per coupling delta (3hrs)  to mm/s (N. Sun)
-             if (StorWater%supply(nr) > 0) then            
-               StorWater%supply(nr) = StorWater%supply(nr)/delt_coupling               
-             endif
-          end do
+             budget_terms(bv_dsupp_f,nt) = budget_terms(bv_dsupp_f,nt) + StorWater%supply(nr)                      
+               StorWater%supply(nr) = StorWater%supply(nr)/delt_coupling  ! convert supply from m3 per coupling delta (10800 s)  to m3/s 
+          end do          
+          budget_terms(br_supply,nt) = budget_terms(bv_dsupp_f,nt) - budget_terms(bv_dsupp_i,nt) !  delta volume (m3) of supply over 3hrs 
+
           do idam = 1,ctlSubwWRM%LocalNumDam
              budget_terms(bv_dstor_f,nt) = budget_terms(bv_dstor_f,nt) + StorWater%storage(idam)
           enddo
@@ -3036,7 +3046,7 @@ contains
        call t_stopf('mosartr_budget')
     endif  ! budget_check
 
-    if (budget_check .and. budget_write) then
+    if (budget_check) then
        call t_startf('mosartr_budget')
        !--- check budget
 
@@ -3046,10 +3056,18 @@ contains
        ! global sum
        call shr_mpi_sum(budget_terms,budget_global,mpicom_rof,'mosart global budget',all=.false.)
 
+       
        ! write budget
        if (masterproc) then
+         if (budget_write) then
           write(iulog,'(2a,i10,i6)') trim(subname),' MOSART BUDGET diagnostics (million m3) for ',ymd,tod
-          do nt = 1,nt_rtm
+         end if
+          if (sediflag) then
+            nt_print = nt_nsan
+          else
+            nt_print = nt_nice
+          endif
+          do nt = 1,nt_print
             budget_volume = (budget_global(bv_volt_f,nt) - budget_global(bv_volt_i,nt) + &
                              budget_global(bv_dstor_f,nt) - budget_global(bv_dstor_i,nt))   !(Global volume change during a coupling period. --Inund.)
             budget_input  = (budget_global(br_qsur,nt) + budget_global(br_qsub,nt) + &
@@ -3064,26 +3082,28 @@ contains
             budget_other  = budget_global(br_erolpn,nt) - budget_global(br_erolcn,nt) + &   !('previous MOSART sub-step channel outflow volume'-'current MOSART sub-step channel outflow volume'. --Inund.)
                             budget_global(br_erorpn,nt) - budget_global(br_erorcn,nt)       !(When WRM module is on: 'previous MOSART sub-step channel outflow volume'-'current MOSART sub-step channel outflow volume'. --Inund.)
             budget_total  = budget_volume - budget_input + budget_output - budget_other     !('budget_total' is supposed to be zero if water balance is perfect. --Inund.)
+            
+            if (budget_write) then
+             write(iulog,'(2a)') trim(subname),'-----------------------------------------------------------------'
+             write(iulog,'(2a,i4)')        trim(subname),'  tracer = ',nt
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume wh    = ',nt,budget_global(bv_wh_f,nt)-budget_global(bv_wh_i,nt)
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume wt    = ',nt,budget_global(bv_wt_f,nt)-budget_global(bv_wt_i,nt)
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume wr    = ',nt,budget_global(bv_wr_f,nt)-budget_global(bv_wr_i,nt)
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume t_al  = ',nt,budget_global(bv_t_al_f,nt)-budget_global(bv_t_al_i,nt)
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume r_al  = ',nt,budget_global(bv_r_al_f,nt)-budget_global(bv_r_al_i,nt)
 
-            write(iulog,'(2a)') trim(subname),'-----------------------------------------------------------------'
-            write(iulog,'(2a,i4)')        trim(subname),'  tracer = ',nt
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume wh    = ',nt,budget_global(bv_wh_f,nt)-budget_global(bv_wh_i,nt)
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume wt    = ',nt,budget_global(bv_wt_f,nt)-budget_global(bv_wt_i,nt)
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume wr    = ',nt,budget_global(bv_wr_f,nt)-budget_global(bv_wr_i,nt)
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume t_al  = ',nt,budget_global(bv_t_al_f,nt)-budget_global(bv_t_al_i,nt)
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume r_al  = ',nt,budget_global(bv_r_al_f,nt)-budget_global(bv_r_al_i,nt)
+             ! If inundation scheme is turned on :
+             if (inundflag .and. Tctl%OPT_inund .eq. 1 ) then
+               if ( nt .eq. nt_nliq ) then
+                 write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume wf    = ',nt,budget_global(bv_fp_f,nt)-budget_global(bv_fp_i,nt)
+               end if
+             end if
 
-            ! If inundation scheme is turned on :
-            if (inundflag .and. Tctl%OPT_inund .eq. 1 ) then
-              if ( nt .eq. 1 ) then
-                write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume wf    = ',nt,budget_global(bv_fp_f,nt)-budget_global(bv_fp_i,nt)
-              end if
-            end if
-
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume dstor = ',nt,budget_global(bv_dstor_f,nt)-budget_global(bv_dstor_i,nt)
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),' * dvolume total = ',nt,budget_volume   !(Global volume change during a coupling period. --Inund.)
-          if (output_all_budget_terms) then           
-            if (inundflag .and. Tctl%OPT_inund .eq. 1 .and. nt .eq. 1) then                                                                 
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   dvolume dstor = ',nt,budget_global(bv_dstor_f,nt)-budget_global(bv_dstor_i,nt)
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),' * dvolume total = ',nt,budget_volume   !(Global volume change during a coupling period. --Inund.)
+            endif
+            if (do_all_budget) then           
+             if (inundflag .and. Tctl%OPT_inund .eq. 1 .and. nt .eq. 1) then                                                                 
                 write(iulog,'(2a,i4,f22.6,a)') trim(subname),' x dvolume check = ',nt,budget_volume - &
                                                                              (budget_global(bv_wh_f,nt)-budget_global(bv_wh_i,nt) + &
                                                                               budget_global(bv_wt_f,nt)-budget_global(bv_wt_i,nt) + &
@@ -3091,29 +3111,31 @@ contains
                                                                               budget_global(bv_fp_f,nt)-budget_global(bv_fp_i,nt) + &
                                                                               budget_global(bv_dstor_f,nt)-budget_global(bv_dstor_i,nt)),&
                                                                               ' (should be zero)'
-            else
-                write(iulog,'(2a,i4,f22.6,a)') trim(subname),' x dvolume check = ',nt,budget_volume - &
+             else
+                 write(iulog,'(2a,i4,f22.6,a)') trim(subname),' x dvolume check = ',nt,budget_volume - &
                                                                              (budget_global(bv_wh_f,nt)-budget_global(bv_wh_i,nt) + &
                                                                               budget_global(bv_wt_f,nt)-budget_global(bv_wt_i,nt) + &
                                                                               budget_global(bv_wr_f,nt)-budget_global(bv_wr_i,nt) + &
                                                                               budget_global(bv_dstor_f,nt)-budget_global(bv_dstor_i,nt)),&
                                                                               ' (should be zero)'
-            endif
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volume   init = ',nt,budget_global(bv_volt_i,nt)
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volume  final = ',nt,budget_global(bv_volt_f,nt)
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumeh  init = ',nt,budget_global(bv_wh_i,nt)
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumeh final = ',nt,budget_global(bv_wh_f,nt)
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumet  init = ',nt,budget_global(bv_wt_i,nt)
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumet final = ',nt,budget_global(bv_wt_f,nt)
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumer  init = ',nt,budget_global(bv_wr_i,nt)
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumer final = ',nt,budget_global(bv_wr_f,nt)
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumer  init = ',nt,budget_global(bv_t_al_i,nt)
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumer final = ',nt,budget_global(bv_t_al_f,nt)
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumer  init = ',nt,budget_global(bv_r_al_i,nt)
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumer final = ',nt,budget_global(bv_r_al_f,nt)
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),' x storage  init = ',nt,budget_global(bv_dstor_i,nt)
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),' x storage final = ',nt,budget_global(bv_dstor_f,nt)
-          endif
+             endif           
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volume   init = ',nt,budget_global(bv_volt_i,nt)
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volume  final = ',nt,budget_global(bv_volt_f,nt)
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumeh  init = ',nt,budget_global(bv_wh_i,nt)
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumeh final = ',nt,budget_global(bv_wh_f,nt)
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumet  init = ',nt,budget_global(bv_wt_i,nt)
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumet final = ',nt,budget_global(bv_wt_f,nt)
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumer  init = ',nt,budget_global(bv_wr_i,nt)
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumer final = ',nt,budget_global(bv_wr_f,nt)
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumest init = ',nt,budget_global(bv_t_al_i,nt)
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumestfinal = ',nt,budget_global(bv_t_al_f,nt)
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumesr init = ',nt,budget_global(bv_r_al_i,nt)
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),' x volumesrfinal = ',nt,budget_global(bv_r_al_f,nt)
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),' x storage  init = ',nt,budget_global(bv_dstor_i,nt)
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),' x storage final = ',nt,budget_global(bv_dstor_f,nt)
+           endif
+
+           if (budget_write) then
             write(iulog,'(2a)') trim(subname),'----------------'
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   input surface = ',nt,budget_global(br_qsur,nt)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   input subsurf = ',nt,budget_global(br_qsub,nt)
@@ -3124,53 +3146,61 @@ contains
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   input subnetwork channel bank erosion = ',nt,budget_global(br_etexch,nt)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   input main channel bank erosion = ',nt,budget_global(br_erexch,nt)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),' * input total   = ',nt,budget_input
-          if (output_all_budget_terms) then
+           endif
+           if (do_all_budget) then
             write(iulog,'(2a,i4,f22.6,a)') trim(subname),' x input check   = ',nt,budget_input - &
                                                                              (budget_global(br_qsur,nt)+budget_global(br_qsub,nt)+ &
-                                                                              budget_global(br_qgwl,nt)+budget_global(br_qdto,nt)), &
+                                                                              budget_global(br_qgwl,nt)+budget_global(br_qdto,nt)+ &
                                                                               budget_global(br_ehexch,nt)+budget_global(br_etexch,nt)+ &
-                                                                              budget_global(br_erexch,nt), & !+budget_global(br_qdem,nt)), &
-                                                                             ' (should be zero)'
+                                                                              budget_global(br_erexch,nt)), ' (should be zero)'
                                                                              ! + budget_global(br_qdem,nt)), commented out by Tian 3/13/2018
-
                                                                              
-          endif
+           endif
+
+           if (budget_write) then
             write(iulog,'(2a)') trim(subname),'----------------'
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   output runoff = ',nt,budget_global(br_ocnout,nt)   !(Outflows to oceans. --Inund.)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   output direct = ',nt,budget_global(br_direct,nt)   !(Direct flows to oceans. --Inund.)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   output flood  = ',nt,budget_global(br_flood,nt)    !(Former flood to land. --Inund.)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   output supply = ',nt,budget_global(bv_dsupp_f,nt)-budget_global(bv_dsupp_i,nt)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),' * output total  = ',nt,budget_output
-          if (output_all_budget_terms) then
+           endif
+           if (do_all_budget) then
             write(iulog,'(2a,i4,f22.6,a)') trim(subname),' x output check  = ',nt,budget_output - &
                                                                              (budget_global(br_ocnout,nt) + budget_global(br_direct,nt) + &
                                                                               budget_global(br_flood,nt) + &
                                                                               budget_global(bv_dsupp_f,nt)-budget_global(bv_dsupp_i,nt)), &
                                                                              ' (should be zero)'
-          endif
-            write(iulog,'(2a)') trim(subname),'----------------'
+           endif
+           if (budget_write) then
+             write(iulog,'(2a)') trim(subname),'----------------'
             !(--Inund. 'previous MOSART sub-step channel outflow volume'-'current MOSART sub-step channel outflow volume': )
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),'   other dwn lag = ',nt,budget_global(br_erolpn,nt) - budget_global(br_erolcn,nt)
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   other dwn lag = ',nt,budget_global(br_erolpn,nt) - budget_global(br_erolcn,nt)
 
             !(--Inund. When WRM module is on: 'previous MOSART sub-step channel outflow volume'-'current MOSART sub-step channel outflow volume': )
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),'   other reg lnd = ',nt,budget_global(br_erorpn,nt) - budget_global(br_erorcn,nt)
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   other reg lnd = ',nt,budget_global(br_erorpn,nt) - budget_global(br_erorcn,nt)
 
-            write(iulog,'(2a,i4,f22.6  )') trim(subname),' * other total   = ',nt,budget_other
-          if (output_all_budget_terms) then
-            write(iulog,'(2a,i4,f22.6,a)') trim(subname),' x other check   = ',nt,budget_other - &
+             write(iulog,'(2a,i4,f22.6  )') trim(subname),' * other total   = ',nt,budget_other
+           endif
+           if (do_all_budget) then
+             write(iulog,'(2a,i4,f22.6,a)') trim(subname),' x other check   = ',nt,budget_other - &
                                                                             (budget_global(br_erolpn,nt) - budget_global(br_erolcn,nt) + &
                                                                              budget_global(br_erorpn,nt) - budget_global(br_erorcn,nt)), &
                                                                             ' (should be zero)'
-          endif
-            write(iulog,'(2a)') trim(subname),'----------------'
-          if (output_all_budget_terms) then
+           endif
+           if (budget_write) then
+             write(iulog,'(2a)') trim(subname),'----------------'
+           endif
+           if (do_all_budget) then
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   sum dvolume   = ',nt,budget_volume     !(Global volume change during a coupling period. --Inund.)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   sum input     = ',nt,budget_input
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   sum output    = ',nt,budget_output
             write(iulog,'(2a,i4,f22.6  )') trim(subname),'   sum other     = ',nt,budget_other      !(Channel outflow volume difference between previous and current MOSART sub-step. --Inund.) 
-          endif
+           endif
+           if (budget_write) then
             write(iulog,'(2a,i4,f22.6,a)') trim(subname),' * sum budget ** = ',nt,budget_total,' (should be zero, dv-in+out-oth)'
-          if (output_all_budget_terms) then
+           endif
+           if (do_all_budget) then
             ! accum budget is just dv-i+o and should show that over time, the other terms go to zero (lag yes, reg land no)
             write(iulog,'(2a)') trim(subname),'----------------'
             write(iulog,'(2a,i4,f22.6,a)') trim(subname),' x accum budget  = ',nt,budget_global(bv_naccum,nt),' (should tend to zero over run, dv-in+out)'          ! (Average water balance error of all coupling periods up to now. --Inund.)
@@ -3190,15 +3220,23 @@ contains
             write(iulog,'(2a,i4,f22.6  )') trim(subname),' x eroutup_avg   = ',nt,budget_global(br_eroutup,nt)     !(Total volume of upstream inflow amounts of all land cells. --Inund.)
             write(iulog,'(2a,i4,f22.6  )') trim(subname),' x erlateral     = ',nt,budget_global(br_erlat,nt)       !(Total volume of lateral inflow amounts of all main channels. --Inund.)
             write(iulog,'(2a)') trim(subname),'----------------'
-          endif
-
-            if ((budget_total) > 1.0e-6) then
+           endif
+           if (budget_write) then
+             if ((budget_total) > 1.0e-6) then
                write(iulog,'(2a,i4)') trim(subname),' ***** BUDGET WARNING error gt 1. m3 for nt = ',nt
+             endif
+           endif
+            if (nt .eq. nt_nliq) then
+               call MOSART_WaterBudget_Extraction(budget_global, budget_terms_total, bv_volt_i, bv_volt_f, &
+                 bv_wt_i, bv_wt_f, bv_wr_i, bv_wr_f, bv_wh_i, bv_wh_f, bv_dstor_i, bv_dstor_f, bv_fp_i, bv_fp_f, br_supply,&
+                 budget_input, budget_output, budget_other)
+               call MOSART_WaterBudget_Print()
             endif
-          enddo   ! (do nt = 1,nt_rtm   --Inund.)
-          write(iulog,'(a)') '----------------------------------- '
 
-          if (inundflag) then
+           enddo   ! (do nt = 1,nt_rtm   --Inund.)
+
+         if (budget_write) then
+           if (inundflag) then
              write(iulog,'(a)') ' '
              write(iulog,'(a)') '=================================================== '
              write(iulog,'(a)') ' '
@@ -3357,12 +3395,12 @@ contains
                 write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume in main channel active layer (1e9kg)=', budget_glb_inund(bv_r_al_f, nt)
 
                 ! If inundation scheme is on & the 1st tracer (liquid water) :
-                if ( inundflag .and. Tctl%OPT_inund .eq. 1 .and. nt .eq. 1 ) then
+                if ( inundflag .and. Tctl%OPT_inund .eq. 1 .and. nt .eq. nt_nliq ) then
                    write(iulog,'(a, f22.6)') trim(tracerID)//'   Volume over floodplains (km^3)             =', budget_glb_inund(bv_fp_f, nt)
                 end if
 
                 ! If inundation scheme is on & the 1st tracer (liquid water) :
-                if ( inundflag .and. Tctl%OPT_inund .eq. 1 .and. nt .eq. 1 ) then
+                if ( inundflag .and. Tctl%OPT_inund .eq. 1 .and. nt .eq. nt_nliq ) then
 
                    write(iulog,'(a)') ' '
                    write(iulog,'(a)') trim(tracerID)//'---------------------------------'
@@ -3423,11 +3461,12 @@ contains
              write(iulog,'(a)') ' '
              write(iulog,'(a)') '=================================================== '
              write(iulog,'(a)') ' '
-          endif
-       endif   ! (End of if (masterproc). --Inund.)
+           endif
+         endif
+        endif   ! (End of if (masterproc). --Inund.)
 
-       call t_stopf('mosartr_budget')
-    endif  ! budget_write   (end of if (budget_check .and. budget_write). --Inund.)
+        call t_stopf('mosartr_budget')
+    endif  ! budget_check   (end of if (budget_check). --Inund.)
 
     !-----------------------------------
     ! Write out MOSART history file
@@ -4760,7 +4799,7 @@ contains
  use shr_sys_mod   , only : shr_sys_flush
  use WRM_type_mod  , only : WRMUnit
  use RunoffMod     , only : rtmCTL
- use RtmVar         , only : iulog, ngeom, nlayers
+ use RtmVar        , only : iulog, ngeom, nlayers
     
  implicit none
  real(r8) :: M_W,M_L,gm_j,d_res,dd_in,C_a,C_v

--- a/components/mosart/src/riverroute/RtmRestFile.F90
+++ b/components/mosart/src/riverroute/RtmRestFile.F90
@@ -9,24 +9,26 @@ module RtmRestFile
 ! Reads from or writes to/ the RTM restart file.
 !
 ! !USES:
-  use shr_kind_mod  , only : r8 => shr_kind_r8
-  use shr_sys_mod   , only : shr_sys_abort
-  use RtmSpmd       , only : masterproc 
-  use RtmVar        , only : rtmlon, rtmlat, iulog, inst_suffix, rpntfil, &
+  use shr_kind_mod      , only : r8 => shr_kind_r8
+  use shr_sys_mod       , only : shr_sys_abort
+  use RtmSpmd           , only : masterproc 
+  use RtmVar            , only : rtmlon, rtmlat, iulog, inst_suffix, rpntfil, &
                              caseid, nsrest, brnch_retain_casename, &
                              finidat_rtm, nrevsn_rtm, wrmflag, inundflag, &
                              nsrContinue, nsrBranch, nsrStartup, &
                              ctitle, version, username, hostname, conventions, source
-  use RtmHistFile   , only : RtmHistRestart
-  use RtmFileUtils  , only : relavu, getavu, opnfil, getfil
-  use RtmTimeManager, only : timemgr_restart, get_nstep, get_curr_date, is_last_step
-  use RunoffMod     , only : rtmCTL
+  use RtmHistFile       , only : RtmHistRestart
+  use RtmFileUtils      , only : relavu, getavu, opnfil, getfil
+  use RtmTimeManager    , only : timemgr_restart, get_nstep, get_curr_date, is_last_step
+  use RunoffMod         , only : rtmCTL
+  use MOSART_Budgets_mod, only : rof_budg_stateG_1D, rof_budg_fluxG_1D, rof_budg_other_1D, rof_budg_fluxN_1D, &
+                                 MOSART_WaterBudget_Restart_Write, MOSART_WaterBudget_Restart_Read, &
+                                 f_size, p_size, s_size, o_size
   use RtmIO       
   use RtmDateTime
-  use WRM_type_mod  , only : ctlSubwWRM, WRMUnit, StorWater
-  use WRM_subw_io_mod, only : WRM_computeRelease
-
-  use rof_cpl_indices , only : nt_rtm, rtm_tracers 
+  use WRM_type_mod      , only : ctlSubwWRM, WRMUnit, StorWater
+  use WRM_subw_io_mod   , only : WRM_computeRelease
+  use rof_cpl_indices   , only : nt_rtm, rtm_tracers 
 
 ! !PUBLIC TYPES:
   implicit none
@@ -89,6 +91,7 @@ contains
     call ncd_enddef(ncid)
 
     ! Write restart file variables
+    call MOSART_WaterBudget_Restart_Write()
     call RtmRestart( ncid, flag='write' )
     call RtmHistRestart ( ncid, flag='write' )
     call timemgr_restart( ncid, flag='write' )
@@ -134,6 +137,7 @@ contains
     call RtmRestart( ncid, flag='read' )
     call RtmHistRestart(ncid, flag='read')
     call ncd_pio_closefile(ncid)
+    call MOSART_WaterBudget_Restart_Read()
 
     ! Write out diagnostic info
     if (masterproc) then
@@ -344,6 +348,9 @@ contains
     call ncd_defdim(ncid, 'rtmlon'  , rtmlon         , dimid)
     call ncd_defdim(ncid, 'rtmlat'  , rtmlat         , dimid)
     call ncd_defdim(ncid, 'string_length', 64        , dimid)
+    call ncd_defdim(ncid, 'budg_flux' , f_size*p_size, dimid)
+    call ncd_defdim(ncid, 'budg_state', s_size*p_size, dimid)
+    call ncd_defdim(ncid, 'budg_other', o_size*p_size, dimid)
        
     ! Define global attributes
     
@@ -398,12 +405,10 @@ contains
     stormth_read = .true.
 
 if (wrmflag) then
-    nvmax = 19
+    nvmax = 23
 else
-
-    nvmax = 15
+    nvmax = 19
 endif
-
 
     do nv = 1,nvmax
     do nt = 1,nt_rtm
@@ -486,8 +491,30 @@ endif
           uname = 'no unit'
           dfld  => rtmCTL%rr(:,nt)
 
-          
+      ! budget terms
        elseif (nv == 16 .and. trim(rtm_tracers(nt)) == 'LIQ') then
+          vname = 'WATER_BUDGET_STATE_'//trim(rtm_tracers(nt))
+          lname = 'Water budget global state'
+          uname = 'mm'
+          dfld  => rof_budg_stateG_1D
+       elseif (nv == 17 .and. trim(rtm_tracers(nt)) == 'LIQ') then
+          vname = 'WATER_BUDGET_FLUX_'//trim(rtm_tracers(nt))
+          lname = 'water budget global flux'
+          uname = 'mm/s'
+          dfld  => rof_budg_fluxG_1D
+       elseif (nv == 18 .and. trim(rtm_tracers(nt)) == 'LIQ') then
+          vname = 'WATER_BUDGET_COUNTER_'//trim(rtm_tracers(nt))
+          lname = 'water budget global step counter'
+          uname = 'no unit'
+          dfld  => rof_budg_fluxN_1D
+       elseif (nv == 19 .and. trim(rtm_tracers(nt)) == 'LIQ') then
+          vname = 'WATER_BUDGET_OTHER_'//trim(rtm_tracers(nt))
+          lname = 'water budget global other term'
+          uname = 'mm'
+          dfld  => rof_budg_other_1D   
+
+       ! WRM terms   
+       elseif (nv == 20 .and. trim(rtm_tracers(nt)) == 'LIQ') then
           varok = .false.
           if (wrmflag) then
              varok = .true.
@@ -503,7 +530,7 @@ endif
              uname = 'm3'
              dfld  => StorWater%storageG(:)
           endif
-       elseif (nv == 17 .and. trim(rtm_tracers(nt)) == 'LIQ') then
+       elseif (nv == 21 .and. trim(rtm_tracers(nt)) == 'LIQ') then
           varok = .false.
           if (wrmflag) then
              varok = .true.
@@ -519,7 +546,7 @@ endif
              uname = 'm3'
              dfld  => StorWater%releaseG(:)
           endif
-       elseif (nv == 18 .and. trim(rtm_tracers(nt)) == 'LIQ') then
+       elseif (nv == 22 .and. trim(rtm_tracers(nt)) == 'LIQ') then
           varok = .false.
           if (wrmflag) then
              varok = .true.
@@ -535,7 +562,7 @@ endif
              uname = 'm3'
              dfld  => WRMUnit%StorMthStOpG(:)
           endif        
-       elseif (nv == 19 .and. trim(rtm_tracers(nt)) == 'LIQ') then
+       elseif (nv == 23 .and. trim(rtm_tracers(nt)) == 'LIQ') then
           varok = .false.
           if (wrmflag) then
              varok = .true.
@@ -550,15 +577,26 @@ endif
              lname = 'dam active stage'
              uname = 'no unit'
              dfld_int  => StorWater%active_stageG(:)
-          endif
-          
+          endif       
        else
           varok = .false.
        endif
 
        if (varok) then
        if (flag == 'define') then
-         if (nv == 19) then
+         if (nv == 16) then
+          call ncd_defvar(ncid=ncid, varname=trim(vname), &
+            xtype=ncd_double,  dim1name='budg_state', &
+            long_name=trim(lname), units=trim(uname))  
+         elseif (nv == 17 .or. nv == 18) then
+          call ncd_defvar(ncid=ncid, varname=trim(vname), &
+            xtype=ncd_double,  dim1name='budg_flux', &
+            long_name=trim(lname), units=trim(uname))
+         elseif (nv == 19) then
+          call ncd_defvar(ncid=ncid, varname=trim(vname), &
+            xtype=ncd_double,  dim1name='budg_other', &
+            long_name=trim(lname), units=trim(uname))
+         elseif (nv == 23) then
           call ncd_defvar(ncid=ncid, varname=trim(vname), &
                xtype=ncd_int,  dim1name='rtmlon', dim2name='rtmlat', &
                long_name=trim(lname), units=trim(uname))
@@ -567,11 +605,15 @@ endif
                xtype=ncd_double,  dim1name='rtmlon', dim2name='rtmlat', &
                long_name=trim(lname), units=trim(uname))
          endif
+
        else if (flag == 'read' .or. flag == 'write') then
-         if (nv==19) then
+         if (nv==23) then
           call ncd_io(varname=trim(vname), data=dfld_int, dim1name='allrof', &
                ncid=ncid, flag=flag, readvar=readvar)
-         else
+         elseif (nv >= 16 .and. nv <=19) then
+          call ncd_io(varname=trim(vname), data=dfld,  &
+               ncid=ncid, flag=flag, readvar=readvar)
+         else  
           call ncd_io(varname=trim(vname), data=dfld, dim1name='allrof', &
                ncid=ncid, flag=flag, readvar=readvar)
          endif
@@ -633,7 +675,6 @@ endif
           endif
        enddo  ! n
 
-
        if (wrmflag) then
           do idam = 1, ctlSubwWRM%localNumDam
              ig = WRMUnit%icell(idam)
@@ -652,6 +693,3 @@ endif
   end subroutine RtmRestart
 
 end module RtmRestFile
-
-
-

--- a/components/mosart/src/riverroute/RtmVar.F90
+++ b/components/mosart/src/riverroute/RtmVar.F90
@@ -32,6 +32,7 @@ module RtmVar
   logical, public :: use_lnd_rof_two_way = .false.     ! land river two way coupling flag
   logical, public :: sediflag = .false.                ! sediment model flag
   logical, public :: heatflag = .false.                ! heat model flag
+  logical, public :: do_all_budget = .false.           ! write all budget terms at every timestep
   logical, public :: use_ocn_rof_two_way = .false.     ! ocean river two way coupling flag
   logical, public :: rstraflag = .false.               ! reservoir stratification module flag
   real,    public :: rinittemp = 283.15_r8             ! initial reservoir temperature


### PR DESCRIPTION
Adding global water budget tables to rof log file. The budget tables include a net water fluxes table and a water states table at the end of each month, year, as well as at the end of the simulation.
An example file: [rof.log](https://github.com/E3SM-Project/E3SM/files/13525870/rof.log)

Resolves https://github.com/E3SM-Project/E3SM/issues/6024
