### PR TITLE
CPL: Add field exclusions list for nonlinear maps.

### DIFF
--- a/driver-mct/cime_config/namelist_definition_drv.xml
+++ b/driver-mct/cime_config/namelist_definition_drv.xml
@@ -1713,11 +1713,27 @@
     <group>seq_infodata_inparm</group>
     <desc>
       Measure and print information about nonlinearly mapped fields. 0 means no
-      analysis is done or printed. >= 1 triggers analysis written to cpl.log.
+      analysis is done or printed. >= 1 triggers analysis written to
+      cpl.log. Modify user_nl_cpl to edit this.
       default: 0
     </desc>
     <values>
       <value>0</value>
+    </values>
+  </entry>
+
+  <entry id="nlmaps_exclude_fields">
+    <type>char(20)</type>
+    <category>nlmaps</category>
+    <group>seq_infodata_inparm</group>
+    <desc>
+      List of fields that are to be excluded from the set that are nonlinearly
+      mapped. For these excluded fields, the low-order linear map is used,
+      instead. Modify user_nl_cpl to edit this.
+      default: 'Faxa_rainc', 'Faxa_rainl', 'Faxa_snowc', 'Faxa_snowl'
+    </desc>
+    <values>
+      <value>'Faxa_rainc', 'Faxa_rainl', 'Faxa_snowc', 'Faxa_snowl'</value>
     </values>
   </entry>
 

--- a/driver-mct/main/cime_comp_mod.F90
+++ b/driver-mct/main/cime_comp_mod.F90
@@ -118,6 +118,7 @@ module cime_comp_mod
   use seq_infodata_mod, only: seq_infodata_init, seq_infodata_exchange
   use seq_infodata_mod, only: seq_infodata_type, seq_infodata_orb_variable_year
   use seq_infodata_mod, only: seq_infodata_print, seq_infodata_init2
+  use seq_infodata_mod, only: nlmaps_exclude_max_number, nlmaps_exclude_nchar
 
   ! domain related routines
   use seq_domain_mct, only : seq_domain_check
@@ -1026,6 +1027,7 @@ contains
     integer(i8) :: end_count          ! end time
     integer(i8) :: irtc_rate          ! factor to convert time to seconds
     integer :: nlmaps_verbosity
+    character(nlmaps_exclude_nchar) :: nlmaps_exclude_fields(nlmaps_exclude_max_number)
 
     !----------------------------------------------------------
     !| Timer initialization (has to be after mpi init)
@@ -1176,7 +1178,8 @@ contains
          reprosum_diffmax=reprosum_diffmax         , &
          reprosum_recompute=reprosum_recompute     , &
          max_cplstep_time=max_cplstep_time         , &
-         nlmaps_verbosity=nlmaps_verbosity)
+         nlmaps_verbosity=nlmaps_verbosity         , &
+         nlmaps_exclude_fields=nlmaps_exclude_fields)
 
     ! above - cpl_decomp is set to pass the cpl_decomp value to seq_mctext_decomp
     ! (via a use statement)
@@ -1189,7 +1192,8 @@ contains
          repro_sum_rel_diff_max_in = reprosum_diffmax, &
          repro_sum_recompute_in    = reprosum_recompute)
 
-    call seq_nlmap_setopts(nlmaps_verbosity_in = nlmaps_verbosity)
+    call seq_nlmap_setopts(nlmaps_verbosity_in = nlmaps_verbosity, &
+         nlmaps_exclude_fields_in = nlmaps_exclude_fields)
 
     ! Check cpl_seq_option
 

--- a/driver-mct/shr/seq_infodata_mod.F90
+++ b/driver-mct/shr/seq_infodata_mod.F90
@@ -60,6 +60,10 @@ MODULE seq_infodata_mod
   character(len=*), public, parameter :: seq_infodata_orb_variable_year    = 'variable_year'
   character(len=*), public, parameter :: seq_infodata_orb_fixed_parameters = 'fixed_parameters'
 
+  ! For seq_nlmap_mod.
+  integer, public, parameter :: nlmaps_exclude_max_number = 20
+  integer, public, parameter :: nlmaps_exclude_nchar = SHR_KIND_CS
+
   ! InputInfo derived type
 
   type seq_infodata_type
@@ -171,7 +175,8 @@ MODULE seq_infodata_mod
      real(SHR_KIND_R8)       :: eps_oarea       ! ocn area error tolerance
      logical                 :: mct_usealltoall ! flag for mct alltoall
      logical                 :: mct_usevector   ! flag for mct vector
-     integer                 :: nlmaps_verbosity    ! see seq_nlmap_mod
+     integer                 :: nlmaps_verbosity          ! see seq_nlmap_mod
+     character(nlmaps_exclude_nchar) :: nlmaps_exclude_fields(nlmaps_exclude_max_number) ! see seq_nlmap_mod
 
      logical                 :: reprosum_use_ddpdd  ! use ddpdd algorithm
      logical                 :: reprosum_allow_infnan ! allow INF and NaN summands
@@ -433,6 +438,7 @@ CONTAINS
     real(shr_kind_r8)      :: max_cplstep_time   ! abort if cplstep time exceeds this value
     character(SHR_KIND_CL) :: model_doi_url
     integer(SHR_KIND_IN)   :: nlmaps_verbosity   ! see seq_nlmap_mod
+    character(nlmaps_exclude_nchar) :: nlmaps_exclude_fields(nlmaps_exclude_max_number) ! see seq_nlmap_mod
 
     namelist /seq_infodata_inparm/  &
          cime_model, case_desc, case_name, start_type, tchkpt_dir,     &
@@ -473,7 +479,7 @@ CONTAINS
          reprosum_use_ddpdd, reprosum_allow_infnan,        &
          reprosum_diffmax, reprosum_recompute,             &
          mct_usealltoall, mct_usevector, max_cplstep_time, model_doi_url, &
-         nlmaps_verbosity
+         nlmaps_verbosity, nlmaps_exclude_fields
 
     !-------------------------------------------------------------------------------
 
@@ -595,6 +601,7 @@ CONTAINS
        max_cplstep_time      = 0.0
        model_doi_url        = 'unset'
        nlmaps_verbosity      = 0
+       nlmaps_exclude_fields(:) = ' '
 
        !---------------------------------------------------------------------------
        ! Read in namelist
@@ -730,6 +737,7 @@ CONTAINS
        infodata%mct_usealltoall       = mct_usealltoall
        infodata%mct_usevector         = mct_usevector
        infodata%nlmaps_verbosity      = nlmaps_verbosity
+       infodata%nlmaps_exclude_fields = nlmaps_exclude_fields
 
        infodata%info_debug            = info_debug
        infodata%bfbflag               = bfbflag
@@ -1033,7 +1041,7 @@ CONTAINS
        reprosum_use_ddpdd, reprosum_allow_infnan,                         &
        reprosum_diffmax, reprosum_recompute,                              &
        mct_usealltoall, mct_usevector, max_cplstep_time, model_doi_url,   &
-       glc_valid_input, nlmaps_verbosity)
+       glc_valid_input, nlmaps_verbosity, nlmaps_exclude_fields)
 
 
     implicit none
@@ -1151,6 +1159,7 @@ CONTAINS
     logical,                optional, intent(OUT) :: mct_usealltoall         ! flag for mct alltoall
     logical,                optional, intent(OUT) :: mct_usevector           ! flag for mct vector
     integer(SHR_KIND_IN),   optional, intent(OUT) :: nlmaps_verbosity
+    character(nlmaps_exclude_nchar), optional, intent(OUT) :: nlmaps_exclude_fields(nlmaps_exclude_max_number)
 
     integer(SHR_KIND_IN),   optional, intent(OUT) :: info_debug
     logical,                optional, intent(OUT) :: bfbflag
@@ -1336,6 +1345,7 @@ CONTAINS
     if ( present(mct_usealltoall)) mct_usealltoall = infodata%mct_usealltoall
     if ( present(mct_usevector)  ) mct_usevector  = infodata%mct_usevector
     if ( present(nlmaps_verbosity)) nlmaps_verbosity = infodata%nlmaps_verbosity
+    if ( present(nlmaps_exclude_fields)) nlmaps_exclude_fields = infodata%nlmaps_exclude_fields
 
     if ( present(info_debug)     ) info_debug     = infodata%info_debug
     if ( present(bfbflag)        ) bfbflag        = infodata%bfbflag
@@ -1584,7 +1594,8 @@ CONTAINS
        eps_agrid, eps_aarea, eps_omask, eps_ogrid, eps_oarea,             &
        reprosum_use_ddpdd, reprosum_allow_infnan,                         &
        reprosum_diffmax, reprosum_recompute,                              &
-       mct_usealltoall, mct_usevector, glc_valid_input, nlmaps_verbosity)
+       mct_usealltoall, mct_usevector, glc_valid_input,                   &
+       nlmaps_verbosity, nlmaps_exclude_fields)
 
 
     implicit none
@@ -1701,6 +1712,7 @@ CONTAINS
     logical,                optional, intent(IN)    :: mct_usealltoall    ! flag for mct alltoall
     logical,                optional, intent(IN)    :: mct_usevector      ! flag for mct vector
     integer(SHR_KIND_IN),   optional, intent(IN)    :: nlmaps_verbosity
+    character(nlmaps_exclude_nchar), optional, intent(IN) :: nlmaps_exclude_fields(nlmaps_exclude_max_number)
 
     integer(SHR_KIND_IN),   optional, intent(IN)    :: info_debug
     logical,                optional, intent(IN)    :: bfbflag
@@ -1885,6 +1897,7 @@ CONTAINS
     if ( present(mct_usealltoall)) infodata%mct_usealltoall = mct_usealltoall
     if ( present(mct_usevector)  ) infodata%mct_usevector  = mct_usevector
     if ( present(nlmaps_verbosity)) infodata%nlmaps_verbosity = nlmaps_verbosity
+    if ( present(nlmaps_exclude_fields)) infodata%nlmaps_exclude_fields = nlmaps_exclude_fields
 
     if ( present(info_debug)     ) infodata%info_debug     = info_debug
     if ( present(bfbflag)        ) infodata%bfbflag        = bfbflag
@@ -2081,6 +2094,8 @@ CONTAINS
 
     !----- local -----
 
+    integer :: i
+
     !-------------------------------------------------------------------------------
     ! Notes:
     !-------------------------------------------------------------------------------
@@ -2192,6 +2207,9 @@ CONTAINS
     call shr_mpi_bcast(infodata%mct_usealltoall,         mpicom)
     call shr_mpi_bcast(infodata%mct_usevector,           mpicom)
     call shr_mpi_bcast(infodata%nlmaps_verbosity,        mpicom)
+    do i = 1, nlmaps_exclude_max_number
+       call shr_mpi_bcast(infodata%nlmaps_exclude_fields(i), mpicom)
+    end do
 
     call shr_mpi_bcast(infodata%info_debug,              mpicom)
     call shr_mpi_bcast(infodata%bfbflag,                 mpicom)
@@ -2903,6 +2921,7 @@ CONTAINS
     write(logunit,F0L) subname,'mct_usevector            = ', infodata%mct_usevector
 
     write(logunit,F0I) subname,'nlmaps_verbosity         = ', infodata%nlmaps_verbosity
+    write(logunit,F0I) subname,'nlmaps_exclude_fields    = ', infodata%nlmaps_exclude_fields
 
     write(logunit,F0S) subname,'info_debug               = ', infodata%info_debug
     write(logunit,F0L) subname,'bfbflag                  = ', infodata%bfbflag


### PR DESCRIPTION
Add the user_nl_cpl namelist option nlmaps_exclude_fields. This is a list of fields that are to be excluded from the set that are nonlinearly mapped. For these excluded fields, the low-order linear map is used instead. The default is

nlmaps_exclude_fields = 'Faxa_rainc', 'Faxa_rainl', 'Faxa_snowc', 'Faxa_snowl'

[non-BFB] for cases using nlmaps
[NML] for all tests due to extra variable nlmaps_exclude_fields