### PR TITLE
Switch puny use in sea ice velocity solved to seaicePuny constant

### DIFF
--- a/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver.F
@@ -20,7 +20,7 @@ module seaice_velocity_solver
   use mpas_dmpar
   use mpas_timer
   use mpas_log, only: mpas_log_write, mpas_log_info
-  use ice_constants_colpkg, only: puny
+  use seaice_constants, only: seaicePuny
 
   implicit none
 
@@ -62,9 +62,12 @@ module seaice_velocity_solver
   ! velocity solver constants
   real(kind=RKIND), parameter, private :: &
        sinOceanTurningAngle = 0.0_RKIND, & ! northern hemisphere
-       cosOceanTurningAngle = 1.0_RKIND, & ! northern hemisphere
-       seaiceAreaMinimum = puny, &
-       seaiceMassMinimum = 10.0_RKIND*puny
+       cosOceanTurningAngle = 1.0_RKIND    ! northern hemisphere
+
+  ! velocity solver constants initialized in seaice_init_velocity_solver
+  real(kind=RKIND), private :: &
+       seaiceAreaMinimum, &
+       seaiceMassMinimum
 
 contains
 
@@ -133,6 +136,10 @@ contains
 
     integer :: &
          ierr
+
+    ! set up min area and mass for velocity solver
+    seaiceAreaMinimum = seaicePuny
+    seaiceMassMinimum = 10.0_RKIND*seaicePuny
 
     ! set up the dynamically locked cell mask
     call dynamically_locked_cell_mask(domain)


### PR DESCRIPTION
Part 2 of splitting up https://github.com/E3SM-Project/E3SM/pull/6086

Correction of sea ice velocity solver concentration and mass limit to universal constant seaicePuny consistent with changes made with the introduction of Icepack to the code base. The same constant value is used, but it is drawn from a different part of the code, now centralized in one location of constant declarations for Icepack and the MPAS-SeaIce dycore (BFB, authors: @njeffery and @proteanplanet )

Passes e3sm_ice_developer test suite. Additional review/testing in original PR.

[BFB]