### PR TITLE
Update ELM in the definition of multiple V3 compsets

### DIFF
--- a/cime_config/allactive/config_compsets.xml
+++ b/cime_config/allactive/config_compsets.xml
@@ -41,27 +41,27 @@
 
 <compset>
   <alias>WCYCL1850</alias>
-  <lname>1850SOI_EAM%CMIP6_ELM%SPBC_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
+  <lname>1850SOI_EAM%CMIP6_ELM%CNPRDCTCBCTOP_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
 </compset>
 
 <compset>
   <alias>WCYCL1850_chemUCI-Linozv3</alias>
-  <lname>1850SOI_EAM%CHEMUCI-LINOZV3_ELM%SPBC_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
+  <lname>1850SOI_EAM%CHEMUCI-LINOZV3_ELM%CNPRDCTCBCTOP_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
 </compset>
 
 <compset>
   <alias>WCYCL1850_chemUCI-Linozv3-mam5</alias>
-  <lname>1850SOI_EAM%CHEMUCI-LINOZV3-MAM5_ELM%SPBC_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
+  <lname>1850SOI_EAM%CHEMUCI-LINOZV3-MAM5_ELM%CNPRDCTCBCTOP_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
 </compset>
 
 <compset>
   <alias>WCYCL1850-1pctCO2</alias>
-  <lname>1850SOI_EAM%CMIP6-1pctCO2_ELM%SPBC_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
+  <lname>1850SOI_EAM%CMIP6-1pctCO2_ELM%CNPRDCTCBCTOP_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
 </compset>
 
 <compset>
   <alias>WCYCL1850-4xCO2</alias>
-  <lname>1850SOI_EAM%CMIP6-4xCO2_ELM%SPBC_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
+  <lname>1850SOI_EAM%CMIP6-4xCO2_ELM%CNPRDCTCBCTOP_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
 </compset>
 
 <!-- WCYCL1850NS uses no spun-up ICs for mpaso and mpassi. It is only being used for nigthly tests on small grids such as ne11_oQU480-->
@@ -77,7 +77,7 @@
 
 <compset>
   <alias>WCYCL20TR</alias>
-  <lname>20TRSOI_EAM%CMIP6_ELM%SPBC_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
+  <lname>20TRSOI_EAM%CMIP6_ELM%CNPRDCTCBCTOP_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
 </compset>
 
 <!-- ************************************************ -->
@@ -108,7 +108,7 @@
 
 <compset>
   <alias>WCYCL20TR_chemUCI-Linozv3-mam5</alias>
-  <lname>20TRSOI_EAM%CHEMUCI-LINOZV3-MAM5_ELM%SPBC_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
+  <lname>20TRSOI_EAM%CHEMUCI-LINOZV3-MAM5_ELM%CNPRDCTCBCTOP_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
 </compset>
 
 <compset>

--- a/cime_config/allactive/config_compsets.xml
+++ b/cime_config/allactive/config_compsets.xml
@@ -67,7 +67,7 @@
 <!-- WCYCL1850NS uses no spun-up ICs for mpaso and mpassi. It is only being used for nigthly tests on small grids such as ne11_oQU480-->
 <compset>
   <alias>WCYCL1850NS</alias>
-  <lname>1850_EAM%CMIP6_ELM%SPBC_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
+  <lname>1850_EAM%CMIP6_ELM%CNPRDCTCBCTOP_MPASSI_MPASO_MOSART_SGLC_SWAV</lname>
 </compset>
 
 <compset>

--- a/cime_config/testmods_dirs/allactive/wcprod_1850/user_nl_elm
+++ b/cime_config/testmods_dirs/allactive/wcprod_1850/user_nl_elm
@@ -1,4 +1,5 @@
- finidat = '$DIN_LOC_ROOT/lnd/clm2/initdata_map/clmi.WCYCL1850.ne30pg2_EC30to60E2r2.SMS_Ld1.c20230213.nc'
+! Finidat to be updated, The one below not compatible with v3 lnd config (with TOP and BGC mode, new grid)
+! finidat = '$DIN_LOC_ROOT/lnd/clm2/initdata_map/clmi.WCYCL1850.ne30pg2_EC30to60E2r2.SMS_Ld1.c20230213.nc'
  hist_dov2xy = .true.,.true.
  hist_fincl2 = 'H2OSNO', 'FSNO', 'QRUNOFF', 'QSNOMELT', 'FSNO_EFF', 'SNORDSL', 'SNOW', 'FSDS', 'FSR', 'FLDS', 'FIRE', 'FIRA'
  hist_mfilt = 1,365

--- a/cime_config/testmods_dirs/allactive/wcprod_1850_1pctCO2/user_nl_elm
+++ b/cime_config/testmods_dirs/allactive/wcprod_1850_1pctCO2/user_nl_elm
@@ -1,4 +1,5 @@
- finidat = '$DIN_LOC_ROOT/lnd/clm2/initdata_map/clmi.WCYCL1850-1pctCO2.ne30pg2_EC30to60E2r2.SMS_Ld1.c20230213.nc'
+! Finidat to be updated, The one below not compatible with v3 lnd config (with TOP and BGC mode, new grid)
+! finidat = '$DIN_LOC_ROOT/lnd/clm2/initdata_map/clmi.WCYCL1850-1pctCO2.ne30pg2_EC30to60E2r2.SMS_Ld1.c20230213.nc'
  hist_dov2xy = .true.,.true.
  hist_fincl2 = 'H2OSNO', 'FSNO', 'QRUNOFF', 'QSNOMELT', 'FSNO_EFF', 'SNORDSL', 'SNOW', 'FSDS', 'FSR', 'FLDS', 'FIRE', 'FIRA'
  hist_mfilt = 1,365

--- a/cime_config/testmods_dirs/allactive/wcprod_1850_4xCO2/user_nl_elm
+++ b/cime_config/testmods_dirs/allactive/wcprod_1850_4xCO2/user_nl_elm
@@ -1,4 +1,5 @@
- finidat = '$DIN_LOC_ROOT/lnd/clm2/initdata_map/clmi.WCYCL1850-4xCO2.ne30pg2_EC30to60E2r2.SMS_Ld1.c20230213.nc'
+! Finidat to be updated, The one below not compatible with v3 lnd config (with TOP and BGC mode, new grid)
+! finidat = '$DIN_LOC_ROOT/lnd/clm2/initdata_map/clmi.WCYCL1850-4xCO2.ne30pg2_EC30to60E2r2.SMS_Ld1.c20230213.nc'
  hist_dov2xy = .true.,.true.
  hist_fincl2 = 'H2OSNO', 'FSNO', 'QRUNOFF', 'QSNOMELT', 'FSNO_EFF', 'SNORDSL', 'SNOW', 'FSDS', 'FSR', 'FLDS', 'FIRE', 'FIRA'
  hist_mfilt = 1,365

--- a/cime_config/testmods_dirs/allactive/wcprod_1850_r05/user_nl_elm
+++ b/cime_config/testmods_dirs/allactive/wcprod_1850_r05/user_nl_elm
@@ -1,4 +1,5 @@
- finidat = '${DIN_LOC_ROOT}/lnd/clm2/initdata_map/clmi.WCYCL1850.ne30pg2_r05_EC30to60E2r2.SMS_Ld1.c20230213.nc'
+! Finidat to be updated, The one below not compatible with v3 lnd config (with TOP and BGC mode, new grid)
+! finidat = '${DIN_LOC_ROOT}/lnd/clm2/initdata_map/clmi.WCYCL1850.ne30pg2_r05_EC30to60E2r2.SMS_Ld1.c20230213.nc'
  hist_dov2xy = .true.,.true.
  hist_fincl2 = 'H2OSNO', 'FSNO', 'QRUNOFF', 'QSNOMELT', 'FSNO_EFF', 'SNORDSL', 'SNOW', 'FSDS', 'FSR', 'FLDS', 'FIRE', 'FIRA'
  hist_mfilt = 1,365

--- a/cime_config/testmods_dirs/allactive/wcprodrrm_1850/user_nl_elm
+++ b/cime_config/testmods_dirs/allactive/wcprodrrm_1850/user_nl_elm
@@ -30,4 +30,5 @@
  hist_nhtfrq = 0,-24
  hist_avgflag_pertape = 'A','A'
  check_finidat_year_consistency = .false.
- finidat = '${DIN_LOC_ROOT}/lnd/clm2/initdata_map/clmi.WCYCL1850.northamericax4v1pg2_WC14to60E2r3.SMS_PS.c20230213.nc'
+! Finidat to be updated, The one below not compatible with v3 lnd config (with TOP and BGC mode, new grid)
+! finidat = '${DIN_LOC_ROOT}/lnd/clm2/initdata_map/clmi.WCYCL1850.northamericax4v1pg2_WC14to60E2r3.SMS_PS.c20230213.nc'

--- a/cime_config/testmods_dirs/allactive/wcprodssp/user_nl_elm
+++ b/cime_config/testmods_dirs/allactive/wcprodssp/user_nl_elm
@@ -1,7 +1,8 @@
 ! fsurdat used is not the same file for the reference historical run (as recorded in elm.r's global attribute)
 
  CHECK_FINIDAT_FSURDAT_CONSISTENCY       = .false.
- finidat = "$DIN_LOC_ROOT/e3sm_init/V2.SSP370_SSP585.ne30pg2_EC30to60E2r2/v2.LR.historical_0101/2015-01-01-00000/v2.LR.historical_0101.elm.r.noNaN.2015-01-01-00000.nc"
+! Finidat to be updated, The one below not compatible with v3 lnd config (with TOP and BGC mode, new grid)
+! finidat = "$DIN_LOC_ROOT/e3sm_init/V2.SSP370_SSP585.ne30pg2_EC30to60E2r2/v2.LR.historical_0101/2015-01-01-00000/v2.LR.historical_0101.elm.r.noNaN.2015-01-01-00000.nc"
  hist_dov2xy = .true.,.true.
  hist_fincl2 = 'H2OSNO', 'FSNO', 'QRUNOFF', 'QSNOMELT', 'FSNO_EFF', 'SNORDSL', 'SNOW', 'FSDS', 'FSR', 'FLDS', 'FIRE', 'FIRA'
  hist_mfilt = 1,365

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -213,8 +213,8 @@ _TESTS = {
     #atmopheric tests to mimic low res production runs
     "e3sm_atm_prod" : {
         "tests" : (
-            "SMS_Ln5.ne30pg2_r05_oECv3.F2010.eam-wcprod_F2010",
-            "SMS.ne30pg2_r05_oECv3.F20TR.eam-wcprod_F20TR",
+            "SMS_Ln5.ne30pg2_r05_IcoswISC30E3r5.F2010.eam-wcprod_F2010",
+            "SMS.ne30pg2_r05_IcoswISC30E3r5.F20TR.eam-wcprod_F20TR",
             )
         },
 
@@ -348,10 +348,10 @@ _TESTS = {
     "e3sm_prod" : {
         "inherit" : "e3sm_atm_prod",
         "tests"   : (
-            "SMS_Ld1.ne30pg2_r05_EC30to60E2r2.WCYCL1850.allactive-wcprod_1850_r05",
-            "SMS_Ld1.ne30pg2_EC30to60E2r2.WCYCL1850-1pctCO2.allactive-wcprod_1850_1pctCO2",
-            "SMS_Ld1.ne30pg2_EC30to60E2r2.WCYCL1850-4xCO2.allactive-wcprod_1850_4xCO2",
-            "SMS_Ld1.ne30pg2_EC30to60E2r2.WCYCL1850.allactive-wcprod_1850",
+            "SMS_Ld1.ne30pg2_r05_IcoswISC30E3r5.WCYCL1850.allactive-wcprod_1850_r05",
+            "SMS_Ld1.ne30pg2_r05_IcoswISC30E3r5.WCYCL1850-1pctCO2.allactive-wcprod_1850_1pctCO2",
+            "SMS_Ld1.ne30pg2_r05_IcoswISC30E3r5.WCYCL1850-4xCO2.allactive-wcprod_1850_4xCO2",
+            "SMS_Ld1.ne30pg2_r05_IcoswISC30E3r5.WCYCL1850.allactive-wcprod_1850",
             "SMS_Ld1.ne30pg2_EC30to60E2r2.WCYCLSSP370.allactive-wcprodssp",
             "SMS_Ld1.ne30pg2_EC30to60E2r2.WCYCLSSP585.allactive-wcprodssp",
             "SMS_PS.northamericax4v1pg2_WC14to60E2r3.WCYCL1850.allactive-wcprodrrm_1850",

--- a/components/eam/cime_config/config_compsets.xml
+++ b/components/eam/cime_config/config_compsets.xml
@@ -18,7 +18,7 @@
 
   <compset>
     <alias>F1850</alias>
-    <lname>1850_EAM%CMIP6_ELM%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <lname>1850_EAM%CMIP6_ELM%CNPRDCTCBCTOP_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
@@ -38,7 +38,7 @@
 
   <compset>
     <alias>F20TR</alias>
-    <lname>20TR_EAM%CMIP6_ELM%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <lname>20TR_EAM%CMIP6_ELM%CNPRDCTCBCTOP_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
@@ -48,7 +48,7 @@
 
   <compset>
     <alias>F2010</alias>
-    <lname>2010_EAM%CMIP6_ELM%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <lname>2010_EAM%CMIP6_ELM%CNPRDCTCBCTOP_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>

--- a/components/elm/bld/ELMBuildNamelist.pm
+++ b/components/elm/bld/ELMBuildNamelist.pm
@@ -2309,7 +2309,7 @@ sub setup_logic_create_crop_landunit {
   my ($test_files, $nl_flags, $definition, $defaults, $nl, $physv) = @_;
 
   add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'create_crop_landunit', 
-     'use_crop'=>$nl_flags->{'use_crop'}, 'hgrid'=>$nl_flags->{'res'}, 'use_cn'=>$nl_flags->{'use_cn'});
+     'use_crop'=>$nl_flags->{'use_crop'}, 'hgrid'=>$nl_flags->{'res'}, 'use_cn'=>$nl_flags->{'use_cn'}, 'use_top_solar_rad'=>$nl->get_value('use_top_solar_rad'));
 }
 
 #-------------------------------------------------------------------------------

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -426,6 +426,8 @@ lnd/clm2/surfdata_map/surfdata_ne4pg2_simyr1850_c210722_with_TOP.nc</fsurdat>
 lnd/clm2/surfdata_map/surfdata_ne240np4_simyr1850_c170821.nc</fsurdat>
 <fsurdat hgrid="r05"          sim_year="1850" use_crop=".false." use_cn=".false.">
 lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr1850_c200609_with_TOP.nc</fsurdat>
+<fsurdat hgrid="r05"          sim_year="1850" use_crop=".false." use_cn=".true." use_top_solar_rad=".true.">
+lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr1850_c200609_with_TOP.nc</fsurdat>
 <fsurdat hgrid="r05"          sim_year="1850" use_crop=".false." use_cn=".true.">
 lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr1850_c211019.nc</fsurdat>
 <fsurdat hgrid="r0125"        sim_year="1850" use_crop=".false." >
@@ -862,6 +864,7 @@ this mask will have smb calculated over the entire global land surface
 <!-- Create crop on a separate land-unit -->
 <create_crop_landunit use_crop=".true."                  >.true.</create_crop_landunit>
 <create_crop_landunit use_crop=".false."                 >.false.</create_crop_landunit>
+<create_crop_landunit use_crop=".false." hgrid="r05" use_cn=".true." use_top_solar_rad=".true.">.false.</create_crop_landunit>
 <create_crop_landunit use_crop=".false." hgrid="r05" use_cn=".true." >.true.</create_crop_landunit>
 
 <!-- =========================================  -->

--- a/components/elm/bld/namelist_files/use_cases/20thC_CMIP6_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/20thC_CMIP6_transient.xml
@@ -37,6 +37,8 @@
 <flanduse_timeseries hgrid="ne30np4">lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850_2015_c20171018.nc</flanduse_timeseries>
 <finidat hgrid="ne30np4" mask="oEC60to30v3">lnd/clm2/initdata_map/20180316.DECKv1b_A1.ne30_oEC.edison.clm2.r.1980-01-01-00000.8575c3f_c20190904.nc</finidat>
 
+<flanduse_timeseries hgrid="r05">lnd/clm2/surfdata_map/landuse.timeseries_0.5x0.5_hist_simyr1850-2015_c191004.nc</flanduse_timeseries>
+
 <flanduse_timeseries hgrid="ne120np4">lnd/clm2/surfdata_map/landuse.timeseries_ne120np4_historical_simyr1850-2015_c190904.nc</flanduse_timeseries>
 
 <fsurdat hgrid="r0125">lnd/clm2/surfdata_map/surfdata_0.125x0.125_simyr1850_c190730.nc</fsurdat>

--- a/components/elm/cime_config/config_component.xml
+++ b/components/elm/cime_config/config_component.xml
@@ -127,6 +127,8 @@
       <value compset="_ELM%[^_]*CNPRDCTCBC" >-bgc bgc -nutrient cnp -nutrient_comp_pathway rd  -soil_decomp ctc -methane </value>
       <value compset="_ELM%[^_]*CNECACTCBC" >-bgc bgc -nutrient cn  -nutrient_comp_pathway eca -soil_decomp ctc -methane </value>
       <value compset="_ELM%[^_]*CNPECACTCBC">-bgc bgc -nutrient cnp -nutrient_comp_pathway eca -soil_decomp ctc -methane </value>
+      <value compset="_ELM%[^_]*CNPRDCTCBCTOP">-bgc bgc -nutrient cnp -nutrient_comp_pathway rd  -soil_decomp ctc -methane -solar_rad_scheme top</value>
+
 
       <value compset="_ELM%[^_]*CNECACNTBC" >-bgc bgc -nutrient cn  -nutrient_comp_pathway eca -soil_decomp century -methane </value>
       <value compset="_ELM%[^_]*CNPECACNTBC">-bgc bgc -nutrient cnp -nutrient_comp_pathway eca -soil_decomp century -methane </value>

--- a/components/ww3/cime_config/config_compsets.xml
+++ b/components/ww3/cime_config/config_compsets.xml
@@ -46,7 +46,7 @@
 
   <compset>
     <alias>WCYCL1850-WW3</alias>
-    <lname>1850SOI_EAM%CMIP6_ELM%SPBC_MPASSI_MPASO_MOSART_SGLC_WW3%sp36x36</lname>
+    <lname>1850SOI_EAM%CMIP6_ELM%CNPRDCTCBCTOP_MPASSI_MPASO_MOSART_SGLC_WW3%sp36x36</lname>
   </compset>
 
 </compsets>


### PR DESCRIPTION
The following compsets are updated to change ELM's mode from SP to active BGC mode with TOP solar parameterization:
1. F1850
2. F20TR
3. F2010
4. WCYCL1850_chemUCI-Linozv3
5. WCYCL1850_chemUCI-Linozv3-mam5
6. WCYCL20TR_chemUCI-Linozv3-mam5
7. WCYCL1850-4xCO2
8. WCYCL1850
9. WCYCL1850-1pctCO2
10. WCYCL20TR
11. WCYCL1850NS

[CC]
[non-BFB] but v3 sims already using these by runscript.
[NML]