### PR TITLE
Temporary vertical grid override for RRM cases

### DIFF
--- a/components/eam/cime_config/config_component.xml
+++ b/components/eam/cime_config/config_component.xml
@@ -58,6 +58,9 @@
       <value compset="_ELM%[^_]*BC"            >-bc_dep_to_snow_updates</value>
       <value compset="_EAM.*_BGC%*"            >-co2_cycle</value>
 
+      <!-- Temporarily override the default v3 vertical grid (L80) and use L72 to maintain RRM test coverage -->
+      <value grid="a%ne0]">-nlev 72</value>
+
       <!-- Single column model (SCM) -->
       <value compset="_EAM%SCM_"       >&eamv3_phys_defaults; &eamv3_chem_defaults; -scam</value>
 

--- a/components/eam/cime_config/config_component.xml
+++ b/components/eam/cime_config/config_component.xml
@@ -59,7 +59,7 @@
       <value compset="_EAM.*_BGC%*"            >-co2_cycle</value>
 
       <!-- Temporarily override the default v3 vertical grid (L80) and use L72 to maintain RRM test coverage -->
-      <value grid="a%ne0]">-nlev 72</value>
+      <value grid="a%ne0">-nlev 72</value>
 
       <!-- Single column model (SCM) -->
       <value compset="_EAM%SCM_"       >&eamv3_phys_defaults; &eamv3_chem_defaults; -scam</value>


### PR DESCRIPTION
Due to difficulties in the generation of new initial condition files with L80 for RRM tests, it was decided that we can safely revert these tests to use L72 to ensure we maintain test coverage of the RRM capability. This needs to be undone when the new ncdata files are provided for RRM.

[non-BFB]