### PR TITLE
Enable rough topograph and add remaining atm and lnd settings for v3b02

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -879,6 +879,12 @@ if ($sim_year =~ /(\d+)-(\d+)/) {
 
 # Topography
 add_default($nl, 'bnd_topo', 'nofail'=>1);
+if (defined($defaults->get_value('pgrad_correction'))) {
+   add_default($nl, 'pgrad_correction', 'val' =>$nl->get_value('pgrad_correction'));
+}
+if (defined($defaults->get_value('hv_ref_profiles'))) {
+   add_default($nl, 'hv_ref_profiles', 'val' =>$nl->get_value('hv_ref_profiles'));
+}
 
 # Tropopause climatology
 add_default($nl, 'tropopause_climo_file');

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1943,7 +1943,7 @@ with se_tstep, dt_remap_factor, dt_tracer_factor set to -1
 <tropopause_E90_thrd phys="default"> 80.0e-9 </tropopause_E90_thrd>
 
 <!-- set following parameters to go with rough topography -->
-<pgrad_correction phys="default"> 2 </pgrad_correction>
+<pgrad_correction phys="default"> 1 </pgrad_correction>
 <hv_ref_profiles phys="default"> 6 </hv_ref_profiles>
 
 </namelist_defaults>

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -133,13 +133,13 @@
 <bnd_topo hgrid="ne16np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne16np4_16xconsistentSGH.c20160612.nc</bnd_topo>
 <bnd_topo hgrid="ne16np4"  npg="2">atm/cam/topo/USGS-gtopo30_ne16np4pg2_16xdel2_20200527.nc</bnd_topo>
 <bnd_topo hgrid="ne30np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne30np4_16xdel2-PFC-consistentSGH.nc</bnd_topo>
-<bnd_topo hgrid="ne30np4"  npg="2">atm/cam/topo/USGS-gtopo30_ne30np4pg2_16xdel2.c20200108.nc</bnd_topo>
+<bnd_topo hgrid="ne30np4"  npg="2">atm/cam/topo/USGS-gtopo30_ne30np4pg2_x6t-SGH.c20210614.nc</bnd_topo>
 <bnd_topo hgrid="ne30np4"  npg="3">atm/cam/topo/USGS-gtopo30_ne30np4pg3_16xdel2.c20200504.nc</bnd_topo>
 <bnd_topo hgrid="ne30np4"  npg="4">atm/cam/topo/USGS-gtopo30_ne30np4pg4_16xdel2.c20200504.nc</bnd_topo>
 <bnd_topo hgrid="ne45np4"  npg="2">atm/cam/topo/USGS-gtopo30_ne45np4pg2_16xdel2.c20200615.nc</bnd_topo>
 <bnd_topo hgrid="ne60np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne60np4_16xconsistentSGH.c20140517.nc</bnd_topo>
 <bnd_topo hgrid="ne120np4" npg="0">atm/cam/topo/USGS-gtopo30_ne120np4_16xdel2-PFC-consistentSGH.nc</bnd_topo>
-<bnd_topo hgrid="ne120np4" npg="2">atm/cam/topo/USGS-gtopo30_ne120np4pg2_16xdel2.nc</bnd_topo>
+<bnd_topo hgrid="ne120np4" npg="2">atm/cam/topo/USGS-gtopo30_ne120np4pg2_x6t_20230404.nc</bnd_topo>
 <bnd_topo hgrid="ne240np4" npg="0">atm/cam/topo/USGS-gtopo30_ne240np4_16xconsistentSGH.c20130724.nc</bnd_topo>
 <bnd_topo hgrid="ne512np4"  npg="0">atm/cam/topo/USGS-gtopo30_ne512np4_16xconsistentSGH_20190212.nc</bnd_topo>
 <bnd_topo hgrid="ne1024np4" npg="0">atm/cam/topo/USGS-gtopo30_ne1024np4_16xconsistentSGH_20190528.nc</bnd_topo>
@@ -1887,7 +1887,7 @@ with se_tstep, dt_remap_factor, dt_tracer_factor set to -1
 <use_gw_energy_fix phys="default"> .true.      </use_gw_energy_fix>
 <clubb_C14 phys="default"> 2.5D0      </clubb_C14>
 <clubb_tk1 phys="default"> 268.15D0   </clubb_tk1>
-<dust_emis_fact phys="default"> 12.8D0     </dust_emis_fact>
+<dust_emis_fact phys="default"> 13.8D0     </dust_emis_fact>
 <linoz_psc_T               > 198.0D0    </linoz_psc_T>
 <lght_no_prd_factor        > 5.0D0    </lght_no_prd_factor>
 <micro_mincdnc phys="default" microphys="mg2"> 10.D6      </micro_mincdnc>
@@ -1941,5 +1941,9 @@ with se_tstep, dt_remap_factor, dt_tracer_factor set to -1
 <cosp_ncolumns phys="default"> 10 </cosp_ncolumns>
 <cflx_cpl_opt phys="default"> 2 </cflx_cpl_opt>
 <tropopause_E90_thrd phys="default"> 80.0e-9 </tropopause_E90_thrd>
+
+<!-- set following parameters to go with rough topography -->
+<pgrad_correction phys="default"> 2 </pgrad_correction>
+<hv_ref_profiles phys="default"> 6 </hv_ref_profiles>
 
 </namelist_defaults>

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -670,8 +670,12 @@ this mask will have smb calculated over the entire global land surface
 
 
 <!-- Phosphorus deposition streams namelist defaults -->
+<stream_year_first_pdep use_cn=".true."   sim_year="2010" >2000</stream_year_first_pdep>
+<stream_year_last_pdep  use_cn=".true."   sim_year="2010" >2000</stream_year_last_pdep>
 <stream_year_first_pdep use_cn=".true."   sim_year="2000" >2000</stream_year_first_pdep>
 <stream_year_last_pdep  use_cn=".true."   sim_year="2000" >2000</stream_year_last_pdep>
+<stream_year_first_pdep use_cn=".true."   sim_year="1950" >2000</stream_year_first_pdep>
+<stream_year_last_pdep  use_cn=".true."   sim_year="1950" >2000</stream_year_last_pdep>
 <stream_year_first_pdep use_cn=".true."   sim_year="1850" >2000</stream_year_first_pdep>
 <stream_year_last_pdep  use_cn=".true."   sim_year="1850" >2000</stream_year_last_pdep>
 <stream_year_first_pdep use_cn=".true."   sim_year="1000" >2000</stream_year_first_pdep>

--- a/components/elm/bld/namelist_files/use_cases/1950_CMIP6_control.xml
+++ b/components/elm/bld/namelist_files/use_cases/1950_CMIP6_control.xml
@@ -11,8 +11,8 @@
 <stream_year_first_ndep phys="elm" use_cn=".true." ndepsrc="stream" >1950</stream_year_first_ndep>
 <stream_year_last_ndep  phys="elm" use_cn=".true." ndepsrc="stream" >1950</stream_year_last_ndep>
 
-<stream_year_first_pdep phys="elm" use_cn=".true." ndepsrc="stream" >1950</stream_year_first_pdep>
-<stream_year_last_pdep  phys="elm" use_cn=".true." ndepsrc="stream" >1950</stream_year_last_pdep>
+<stream_year_first_pdep phys="elm" use_cn=".true." ndepsrc="stream" >2000</stream_year_first_pdep>
+<stream_year_last_pdep  phys="elm" use_cn=".true." ndepsrc="stream" >2000</stream_year_last_pdep>
 
 <stream_year_first_popdens phys="elm" use_cn=".true." ndepsrc="stream" >1950</stream_year_first_popdens>
 <stream_year_last_popdens  phys="elm" use_cn=".true." ndepsrc="stream" >1950</stream_year_last_popdens>

--- a/components/elm/bld/namelist_files/use_cases/2010_CMIP6_control.xml
+++ b/components/elm/bld/namelist_files/use_cases/2010_CMIP6_control.xml
@@ -11,8 +11,8 @@
 <stream_year_first_ndep phys="elm" use_cn=".true." ndepsrc="stream" >2010</stream_year_first_ndep>
 <stream_year_last_ndep  phys="elm" use_cn=".true." ndepsrc="stream" >2010</stream_year_last_ndep>
 
-<stream_year_first_pdep phys="elm" use_cn=".true." ndepsrc="stream" >2010</stream_year_first_pdep>
-<stream_year_last_pdep  phys="elm" use_cn=".true." ndepsrc="stream" >2010</stream_year_last_pdep>
+<stream_year_first_pdep phys="elm" use_cn=".true." ndepsrc="stream" >2000</stream_year_first_pdep>
+<stream_year_last_pdep  phys="elm" use_cn=".true." ndepsrc="stream" >2000</stream_year_last_pdep>
 
 <stream_year_first_popdens phys="elm" use_cn=".true." ndepsrc="stream" >2010</stream_year_first_popdens>
 <stream_year_last_popdens  phys="elm" use_cn=".true." ndepsrc="stream" >2010</stream_year_last_popdens>


### PR DESCRIPTION
Rough topography for atm is enabled by replacing 16x topography with x6t ones. This PR replaces the default topo file for ne30pg2 and ne120pg2. x6t topo for other production grids are pending. Companion settings to go with rough topo are set with pgrad_correction = 1 and hv_ref_profiles = 6. These options can also be beneficial when using smoother topography.

The PR also reset dust_emis_fact and first and last year of pdepdyn stream files for 2010 and 1950 compsets to match the stream file used.

[Non-BFB] All tests with EAM, or ELM for simyr 2010 and 1950
[NML]