### PR TITLE
Fix MPAS standalone compile issues

### DIFF
--- a/components/mpas-framework/Makefile
+++ b/components/mpas-framework/Makefile
@@ -628,6 +628,7 @@ endif
 
 ifeq "$(USE_SHTNS)" "true"
 	override CPPFLAGS += -DUSE_SHTNS
+endif
 
 ifneq "$(MOAB_PATH)" ""
        CPPINCLUDES +=  -DHAVE_MOAB -I$(MOAB_PATH)/include

--- a/components/mpas-framework/src/driver/mpas.F
+++ b/components/mpas-framework/src/driver/mpas.F
@@ -12,7 +12,6 @@ program mpas
 
    implicit none
 
-   type (core_type), pointer :: corelist => null()
    type (domain_type), pointer :: domain => null()
 
    call mpas_init(corelist, domain)


### PR DESCRIPTION
These two small changes allow MPAS components to compile in stand-alone mode. It should not affect E3SM compile or simulations.  The fixes are:

1. A missing `endif` was added to the Makefile
2. A redundant corelist declaration was removed from `mpas.F` because it was added to `mpas_subdriver.F` in PR #5979, and the subdriver is `used` by `mpas.F`.

These fixes should work for ocean, sea ice, and MALI cores.

Fixes #6133
Fixes #6138
[BFB]