### PR TITLE
Fixing a bug causing floating-point error in RtmMod.F90

### DIFF
--- a/components/mosart/src/riverroute/RtmMod.F90
+++ b/components/mosart/src/riverroute/RtmMod.F90
@@ -420,7 +420,7 @@ contains
     Tctl%DLevelH2R     = DLevelH2R
     Tctl%DLevelR       = DLevelR
     if(.not.(Tctl%RoutingMethod==KW .or. Tctl%RoutingMethod==DW)) then 
-	   call shr_sys_abort('Error in routing method setup! There are only 2 options available: 1==KW, 2==DW')
+       call shr_sys_abort('Error in routing method setup! There are only 2 options available: 1==KW, 2==DW')
     end if
 
     if (inundflag) then
@@ -2211,23 +2211,23 @@ contains
        if (inundflag .and. Tctl%OPT_inund .eq. 1 ) then
          do nr = rtmCTL%begr, rtmCTL%endr
 
-           !if ( TUnit%mask( nr ) .gt. 0 ) then      ! 0--Ocean; 1--Land; 2--Basin outlet.
            if ( rtmCTL%mask(nr) .eq. 1 .or. rtmCTL%mask(nr) .eq. 3 ) then   ! 1--Land; 3--Basin outlet (downstream is ocean).
              budget_terms(bv_fp_i, 1) = budget_terms(bv_fp_i, 1) + TRunoff%wf_ini( nr )
              !budget_terms(bv_fp_i, 1) = budget_terms(bv_fp_i, 1) + rtmCTL%inundwf(nr)        ! 17-6-7
-           endif
 
-           ! land river two way coupling, update floodplain inundation volume with drainage from lnd
-           if (use_lnd_rof_two_way) then
-             TRunoff%wf_ini(nr) = TRunoff%wf_ini(nr) - rtmCTL%inundinf(nr) * coupling_period
-
-             if ( TRunoff%wf_ini(nr) < 0._r8 ) then
-               TRunoff%wr(nr, 1) = TRunoff%wr(nr, 1) + TRunoff%wf_ini(nr)
-               TRunoff%wf_ini(nr) = 0._r8
-               TRunoff%yr(nr, 1) = TRunoff%wr(nr, 1) / TUnit%rlen(nr) / TUnit%rwidth(nr)
+             ! land river two way coupling, update floodplain inundation volume with drainage from lnd
+             if (use_lnd_rof_two_way) then
+               TRunoff%wf_ini(nr) = TRunoff%wf_ini(nr) - rtmCTL%inundinf(nr) * coupling_period
+           
+               if ( TRunoff%wf_ini(nr) < 0._r8 ) then
+                 TRunoff%wr(nr, 1) = TRunoff%wr(nr, 1) + TRunoff%wf_ini(nr)
+                 TRunoff%wf_ini(nr) = 0._r8
+                 TRunoff%yr(nr, 1) = TRunoff%wr(nr, 1) / TUnit%rlen(nr) / TUnit%rwidth(nr)
+               endif
              endif
-           endif
 
+           endif
+           
          end do
        end if
 


### PR DESCRIPTION
A bug in RtmMod.F90 has been causing a floating-point error, related to Tunit%rlen,
when the land-river two-way coupling is invoked. This PR fixes that bug based on
a branch off the commit, 417920b, where the bug was introduced into the master. 

[BFB]
Fixes #5540 