### PR TITLE
Updates for pm-cpu machine files for maint-1.0

### DIFF
--- a/cime/config/e3sm/machines/config_batch.xml
+++ b/cime/config/e3sm/machines/config_batch.xml
@@ -306,10 +306,11 @@
      <directives>
        <directive> --constraint=cpu</directive>
      </directives>
+     <!-- Note: walltime is not the max walltime, but the default - see NERSC docs for Q limits, https://docs.nersc.gov/jobs/policy/ -->
      <queues>
        <queue walltimemax="00:30:00" nodemin="1" nodemax="8" strict="true">debug</queue>
-       <queue walltimemax="00:35:00" nodemin="1" nodemax="4096" strict="true">preempt</queue>
-       <queue walltimemax="01:00:00" nodemin="1" nodemax="4096" default="true">regular</queue>
+       <queue walltimemax="00:35:00" nodemin="1" nodemax="3072" strict="true">preempt</queue>
+       <queue walltimemax="01:00:00" nodemin="1" nodemax="3072" default="true">regular</queue>
      </queues>
    </batch_system>
 

--- a/cime/config/e3sm/machines/config_machines.xml
+++ b/cime/config/e3sm/machines/config_machines.xml
@@ -55,12 +55,12 @@
    This allows using a different mpirun command to launch unit tests
 
 -->
-<machine MACH="pm-cpu">
+ <machine MACH="pm-cpu">
   <DESC>Perlmutter CPU-only nodes at NERSC.  Phase2 only: Each node has 2 AMD EPYC 7713 64-Core (Milan) 512GB</DESC>
   <!--NODENAME_REGEX>$ENV{NERSC_HOST}:perlmutter</NODENAME_REGEX-->
   <NODENAME_REGEX>login</NODENAME_REGEX>
   <OS>Linux</OS>
-  <COMPILERS>gnu,intel</COMPILERS>
+  <COMPILERS>intel,gnu</COMPILERS>
   <MPILIBS>mpich</MPILIBS>
   <PROJECT>e3sm</PROJECT>
   <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
@@ -72,7 +72,7 @@
   <DIN_LOC_ROOT_CLMFORC>/global/cfs/cdirs/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
   <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
   <BASELINE_ROOT>/global/cfs/cdirs/e3sm/baselines/$COMPILER</BASELINE_ROOT>
-  <CCSM_CPRNC>/global/cfs/cdirs/e3sm/tools/cprnc.cori/cprnc</CCSM_CPRNC>
+  <CCSM_CPRNC>/global/cfs/cdirs/e3sm/tools/cprnc/cprnc</CCSM_CPRNC>
   <GMAKE_J>10</GMAKE_J>
   <TESTS>e3sm_developer</TESTS>
   <NTEST_PARALLEL_JOBS>4</NTEST_PARALLEL_JOBS>
@@ -105,6 +105,8 @@
       <command name="unload">cray-hdf5-parallel</command>
       <command name="unload">cray-netcdf-hdf5parallel</command>
       <command name="unload">cray-parallel-netcdf</command>
+      <command name="unload">cray-netcdf</command>
+      <command name="unload">cray-hdf5</command>
       <command name="unload">PrgEnv-gnu</command>
       <command name="unload">PrgEnv-intel</command>
       <command name="unload">PrgEnv-nvidia</command>
@@ -112,7 +114,10 @@
       <command name="unload">PrgEnv-aocc</command>
       <command name="unload">intel</command>
       <command name="unload">intel-oneapi</command>
+      <command name="unload">nvidia</command>
+      <command name="unload">aocc</command>
       <command name="unload">cudatoolkit</command>
+      <command name="unload">climate-utils</command>
       <command name="unload">craype-accel-nvidia80</command>
       <command name="unload">craype-accel-host</command>
       <command name="unload">perftools-base</command>
@@ -139,7 +144,7 @@
 
     <modules compiler="amdclang">
       <command name="load">PrgEnv-aocc</command>
-      <command name="load">aocc/3.2.0</command>
+      <command name="load">aocc/4.0.0</command>
       <command name="load">cray-libsci/23.02.1.1</command>
     </modules>
 


### PR DESCRIPTION
Change the default compiler to intel (from GNU).
Update the cprnc location to be the new one for perlmutter.
Mild module cleanup, but only really changing AMD compiler version.

[bfb]