### PR TITLE
add dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "rljacob"
+    reviewers:
+      - "mahf708"
+      - "bartgol"


### PR DESCRIPTION
With this, dependabot will perform dependency checks on things we use inside GitHub Actions at a configurable frequency (for now, weekly). If there are updates, it will issue a PR requesting reviews from members (for now, Luca and Naser) and assigning the PR to an integrator (for now, Rob).

------

TODO: Naser will monitor how the bot behaves initially; in particular, we likely need to edit the gh-pages workflows with this change:
```diff
    - uses: actions/checkout@v4
      with: 
+       persist-credentials: false

```