### PR TITLE
For pm-gpu, add module gcc-mixed/11.2.0 for nvidiagpu builds.

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -384,6 +384,7 @@
       <modules compiler="nvidiagpu">
         <command name="load">cudatoolkit/11.7</command>
         <command name="load">craype-accel-nvidia80</command>
+        <command name="load">gcc-mixed/11.2.0</command>
       </modules>
 
       <modules compiler="gnu">


### PR DESCRIPTION
For pm-gpu, add module gcc-mixed/11.2.0 for nvidiagpu builds.
After the NERSC maintenance, the underlying GNU version is now too high for the cudatoolkit we are using.
But this is only an issue with nvidia compilers as the GNU builds set the version to 11.
All we do here is add a module `gcc-mixed/11.2.0` for nvidiagpu builds.

Fixes https://github.com/E3SM-Project/E3SM/issues/6156

[bfb]