### PR TITLE
Fix format for nlmaps_exclude_fields in seq_infodata_print

### DIFF
--- a/driver-mct/shr/seq_infodata_mod.F90
+++ b/driver-mct/shr/seq_infodata_mod.F90
@@ -2921,7 +2921,8 @@ CONTAINS
     write(logunit,F0L) subname,'mct_usevector            = ', infodata%mct_usevector
 
     write(logunit,F0I) subname,'nlmaps_verbosity         = ', infodata%nlmaps_verbosity
-    write(logunit,F0I) subname,'nlmaps_exclude_fields    = ', infodata%nlmaps_exclude_fields
+
+    write(logunit,F0A) subname,'nlmaps_exclude_fields    = ', infodata%nlmaps_exclude_fields
 
     write(logunit,F0S) subname,'info_debug               = ', infodata%info_debug
     write(logunit,F0L) subname,'bfbflag                  = ', infodata%bfbflag

--- a/driver-mct/shr/seq_infodata_mod.F90
+++ b/driver-mct/shr/seq_infodata_mod.F90
@@ -2777,7 +2777,7 @@ CONTAINS
     !EOP
 
     !----- local -----
-    integer                     :: ind
+    integer                     :: ind, i
     character(len=*), parameter :: subname = '(seq_infodata_print) '
     character(len=*), parameter ::  F0A = "(2A,A)"
     character(len=*), parameter ::  F0L = "(2A,L3)"
@@ -2922,7 +2922,12 @@ CONTAINS
 
     write(logunit,F0I) subname,'nlmaps_verbosity         = ', infodata%nlmaps_verbosity
 
-    write(logunit,F0A) subname,'nlmaps_exclude_fields    = ', infodata%nlmaps_exclude_fields
+    write(logunit,'(2A)',advance='no') subname,'nlmaps_exclude_fields    = '
+    do i = 1, size(infodata%nlmaps_exclude_fields)
+       if (len(trim(infodata%nlmaps_exclude_fields(i))) == 0) cycle
+       write(logunit,'(3A)',advance='no') ' ', trim(infodata%nlmaps_exclude_fields(i))
+    end do
+    write(logunit,'(A)') ''
 
     write(logunit,F0S) subname,'info_debug               = ', infodata%info_debug
     write(logunit,F0L) subname,'bfbflag                  = ', infodata%bfbflag


### PR DESCRIPTION
The format for printing out nlmaps_exclude_fields in seq_infodata_print is currently F0I (for an integer value) but the variable is a character array. This type mismatch causes a failure when the seq_infodata_print subroutine is called, from cime_comp_mod.F90 when info_debug > 1. This PR uses a formatting suggested by Andrew Bradley to more elegantly print out this array.

Fixes #6165
[BFB]
