### PR TITLE
remove seq_flds dependency for mpas_moabmesh

### DIFF
--- a/components/mpas-framework/Makefile
+++ b/components/mpas-framework/Makefile
@@ -1113,7 +1113,7 @@ ifeq "$(USE_GPUAWARE)" "true"
    @echo $(GPUAWARE_MESSAGE)
 endif
 ifeq "$(USE_MOAB)" "true"
-   @echo $(MOAB_MESSAGE)
+	@echo $(MOAB_MESSAGE)
 endif
 	@echo "*******************************************************************************"
 clean:

--- a/components/mpas-framework/src/driver/mpas_subdriver.F
+++ b/components/mpas-framework/src/driver/mpas_subdriver.F
@@ -53,6 +53,9 @@ module mpas_subdriver
       use mpas_timekeeping, only : mpas_get_clock_time, mpas_get_time
       use mpas_bootstrapping, only : mpas_bootstrap_framework_phase1, mpas_bootstrap_framework_phase2
       use mpas_log
+#ifdef HAVE_MOAB
+      use iMOAB, only: iMOAB_Initialize
+#endif
  
       implicit none
 
@@ -89,9 +92,6 @@ module mpas_subdriver
       logical :: streamsExists
       integer :: mesh_iotype
       integer, save :: domainID = 0
-#ifdef HAVE_MOAB
-      integer, external :: iMOAB_InitializeFortran
-#endif
       interface
          subroutine xml_stream_parser(xmlname, mgr_p, comm, ierr) bind(c)
             use iso_c_binding, only : c_char, c_ptr, c_int
@@ -303,7 +303,7 @@ module mpas_subdriver
           call mpas_build_stream_filename(ref_time, start_time, filename_interval, mesh_filename_temp, blockID, mesh_filename, ierr)
       end if
 #ifdef HAVE_MOAB
-      ierr = iMOAB_InitializeFortran()
+      ierr = iMOAB_Initialize()
       if ( ierr /= 0 ) then
          call mpas_log_write('cannot initialize MOAB', messageType=MPAS_LOG_CRIT)
       else

--- a/components/mpas-framework/src/framework/mpas_moabmesh.F
+++ b/components/mpas-framework/src/framework/mpas_moabmesh.F
@@ -187,6 +187,11 @@ module mpas_moabmesh
        enddo
 
        tagname='area'//C_NULL_CHAR
+       tagtype = 1  ! dense, real
+       numco = 1
+       ierr = iMOAB_DefineTagStorage(pid, tagname, tagtype, numco,  tagindex )
+       call errorout(ierr, 'fail to define area tag')
+
        ierr = iMOAB_SetDoubleTagStorage ( pid, tagname, nCellsSolve , ent_type, data)
        if (ierr > 0 )  &
           call errorout(ierr,'Error: fail to set area tag ')

--- a/components/mpas-framework/src/framework/mpas_moabmesh.F
+++ b/components/mpas-framework/src/framework/mpas_moabmesh.F
@@ -30,7 +30,6 @@ module mpas_moabmesh
      iMOAB_ResolveSharedEntities, iMOAB_DetermineGhostEntities, &
      iMOAB_DefineTagStorage,  iMOAB_SetIntTagStorage , &
      iMOAB_UpdateMeshInfo, iMOAB_SetDoubleTagStorage
-    use seq_flds_mod, only: seq_flds_dom_fields
 
     type (domain_type), intent(inout) :: domain
     integer , intent(in) :: ext_comp_id
@@ -186,13 +185,6 @@ module mpas_moabmesh
          n= n+1
          data(n)=areaCell(ic) / (sphere_radius * sphere_radius)
        enddo
-
-       ! add domain tags
-       tagname=trim(seq_flds_dom_fields)//C_NULL_CHAR
-       tagtype = 1
-       ierr = iMOAB_DefineTagStorage(pid, tagname, tagtype, numco,  tagindex )
-       if (ierr > 0 )  &
-          call errorout(ierr, 'Error: fail to define domain tags ')
 
        tagname='area'//C_NULL_CHAR
        ierr = iMOAB_SetDoubleTagStorage ( pid, tagname, nCellsSolve , ent_type, data)

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -682,7 +682,13 @@ contains
       write(ocnLogUnit,*) 'Fail to set MOAB fields '
    endif
    
-   
+   ! add domain tags
+   tagname=trim(seq_flds_dom_fields)//C_NULL_CHAR
+   tagtype = 1
+   ierr = iMOAB_DefineTagStorage(MPOID, tagname, tagtype, numco,  tagindex )
+   if ( ierr /= 0 ) then
+      write(ocnLogUnit,*) 'Fail to set define dom fields '
+   endif
    ent_type = 1 ! cells
       
 

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -753,6 +753,15 @@ contains
     if ( ierrmb /= 0 ) then
        call mpas_log_write('cannot set tags for MOAB x2i fields to zero' // trim(seq_flds_x2i_fields), MPAS_LOG_ERR)
     endif
+
+    ! add domain tags
+    tagname=trim(seq_flds_dom_fields)//C_NULL_CHAR
+    tagtype = 1
+    ierrmb = iMOAB_DefineTagStorage(MPSIID, tagname, tagtype, numco,  tagindex )
+    if ( ierrmb /= 0 ) then
+       call mpas_log_write('Fail to set define dom fields ',  MPAS_LOG_ERR)
+    endif
+
 #endif
     
 


### PR DESCRIPTION
mpas framework should not depend on driver-moab/shr
mpas ocean cannot be built in standalone mode with MOAB, because of this

[BFB]
