### PR TITLE
Update resolutions and maps in test suites and v3 low res mesh

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -1544,6 +1544,19 @@
 	</ntasks>
       </pes>
     </mach>
+    <mach name="pm-cpu|muller-cpu">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SWAV.+" pesize="any">
+	<comment> pm-cpu --compset WCYCL* --res ne30pg2_r05_IcoswISC30E3r5 on 4 nodes</comment>
+	<ntasks>
+	  <ntasks_atm>-4</ntasks_atm>
+	  <ntasks_cpl>-4</ntasks_cpl>
+	  <ntasks_ocn>-4</ntasks_ocn>
+	  <ntasks_ice>-4</ntasks_ice>
+	  <ntasks_rof>-4</ntasks_rof>
+	  <ntasks_lnd>-4</ntasks_lnd>
+	</ntasks>
+      </pes>
+    </mach>
   </grid>
   <grid name="a%ne30np4.pg.+_oi%EC30to60E2r2">
     <mach name="chrysalis">
@@ -2453,6 +2466,27 @@
           <ntasks_glc>-4</ntasks_glc>
           <ntasks_wav>-4</ntasks_wav>
           <ntasks_cpl>-4</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+      </pes>
+    </mach>
+    <mach name="pm-cpu|muller-cpu">
+      <pes compset="any" pesize="any">
+        <comment>pm-cpu, conus 2 nodes</comment>
+        <ntasks>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_cpl>-2</ntasks_cpl>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>

--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -1531,6 +1531,19 @@
         </rootpe>
       </pes>
     </mach>
+    <mach name="gcp12">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SWAV.+" pesize="any">
+	<comment> gcp12 --compset WCYCL* --res ne30pg2_r05_IcoswISC30E3r5 on 4 nodes </comment>
+	<ntasks>
+	  <ntasks_atm>-4</ntasks_atm>
+	  <ntasks_cpl>-4</ntasks_cpl>
+	  <ntasks_ocn>-4</ntasks_ocn>
+	  <ntasks_ice>-4</ntasks_ice>
+	  <ntasks_rof>-4</ntasks_rof>
+	  <ntasks_lnd>-4</ntasks_lnd>
+	</ntasks>
+      </pes>
+    </mach>
   </grid>
   <grid name="a%ne30np4.pg.+_oi%EC30to60E2r2">
     <mach name="chrysalis">

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -4477,6 +4477,10 @@
     </gridmap>
 
     <!--- ocean to river mapping files -->
+    <gridmap rof_grid="r05" ocn_grid="IcoswISC30E3r5">
+      <map name="OCN2ROF_SMAPNAME">cpl/gridmaps/IcoswISC30E3r5/map_IcoswISC30E3r5_to_r05_traave.20231121.nc</map>
+    </gridmap>
+
     <gridmap rof_grid="r05" ocn_grid="EC30to60E2r2">
       <map name="OCN2ROF_SMAPNAME">cpl/cpl6/map_EC30to60E2r2_to_r05_neareststod.220728.nc</map>
     </gridmap>

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -3295,6 +3295,8 @@
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_IcoswISC30E3r5-nomask_trbilin.20231121.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/IcoswISC30E3r5/map_IcoswISC30E3r5_to_ne30pg2_traave.20231121.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/IcoswISC30E3r5/map_IcoswISC30E3r5_to_ne30pg2_traave.20231121.nc</map>
+      <map name="ATM2ICE_FMAPNAME_NONLINEAR">cpl/gridmaps/ne30pg2/map_ne30pg2_to_IcoswISC30E3r5_trfvnp2.20231121.nc</map>
+      <map name="ATM2OCN_FMAPNAME_NONLINEAR">cpl/gridmaps/ne30pg2/map_ne30pg2_to_IcoswISC30E3r5_trfvnp2.20231121.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4.pg3" ocn_grid="oEC60to30v3">
@@ -3352,6 +3354,7 @@
 
     <gridmap atm_grid="ne30np4.pg2" lnd_grid="r05">
       <map name="ATM2LND_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_r05_traave.20231130.nc</map>
+      <map name="ATM2LND_FMAPNAME_NONLINEAR">cpl/gridmaps/ne30pg2/map_ne30pg2_to_r05_trfvnp2.230516.nc</map>
       <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_r05_trbilin.20231130.nc</map>
       <map name="LND2ATM_FMAPNAME">cpl/gridmaps/ne30pg2/map_r05_to_ne30pg2_traave.20231130.nc</map>
       <map name="LND2ATM_SMAPNAME">cpl/gridmaps/ne30pg2/map_r05_to_ne30pg2_traave.20231130.nc</map>
@@ -4203,7 +4206,8 @@
 
     <gridmap atm_grid="ne30np4.pg2" rof_grid="r05">
       <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_r05_traave.20231130.nc</map>
-      <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_r05_traave.20231130.nc</map>
+      <map name="ATM2ROF_FMAPNAME_NONLINEAR">cpl/gridmaps/ne30pg2/map_ne30pg2_to_r05_trfvnp2.230516.nc</map>
+      <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_r05_trbilin.20231130.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4.pg3" rof_grid="r05">

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -153,7 +153,7 @@
     <PROJECT>e3sm</PROJECT>
     <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>e3sm,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
-    <CIME_OUTPUT_ROOT>$ENV{PSCRATCH}/e3sm_scratch/pm-cpu/rtest</CIME_OUTPUT_ROOT>
+    <CIME_OUTPUT_ROOT>$ENV{PSCRATCH}/e3sm_scratch/pm-cpu</CIME_OUTPUT_ROOT>
     <CIME_HTML_ROOT>/global/cfs/cdirs/e3sm/www/$ENV{USER}</CIME_HTML_ROOT>
     <CIME_URL_ROOT>http://portal.nersc.gov/project/e3sm/$ENV{USER}</CIME_URL_ROOT>
     <DIN_LOC_ROOT>/global/cfs/cdirs/e3sm/inputdata</DIN_LOC_ROOT>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -153,7 +153,7 @@
     <PROJECT>e3sm</PROJECT>
     <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>e3sm,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
-    <CIME_OUTPUT_ROOT>$ENV{PSCRATCH}/e3sm_scratch/pm-cpu</CIME_OUTPUT_ROOT>
+    <CIME_OUTPUT_ROOT>$ENV{PSCRATCH}/e3sm_scratch/pm-cpu/rtest</CIME_OUTPUT_ROOT>
     <CIME_HTML_ROOT>/global/cfs/cdirs/e3sm/www/$ENV{USER}</CIME_HTML_ROOT>
     <CIME_URL_ROOT>http://portal.nersc.gov/project/e3sm/$ENV{USER}</CIME_URL_ROOT>
     <DIN_LOC_ROOT>/global/cfs/cdirs/e3sm/inputdata</DIN_LOC_ROOT>

--- a/cime_config/testmods_dirs/allactive/nlmaps/shell_commands
+++ b/cime_config/testmods_dirs/allactive/nlmaps/shell_commands
@@ -1,19 +1,16 @@
 alg=trfvnp2
 
-# This line is separate from the nonlinear maps. It corrects an oversight in the
-# existing default trigrid grid configuration.
-./xmlchange ATM2ROF_SMAPNAME=cpl/gridmaps/ne30pg2/map_ne30pg2_to_r05_bilin.200220.nc
-
 # We want these in v3.
 a2l=cpl/gridmaps/ne30pg2/map_ne30pg2_to_r05_trfvnp2.230516.nc
-a2o=cpl/gridmaps/ne30pg2/map_ne30pg2_to_EC30to60E2r2_trfvnp2.230516.nc
+a2o=cpl/gridmaps/ne30pg2/map_ne30pg2_to_IcoswISC30E3r5_trfvnp2.20231121.nc
 ./xmlchange ATM2LND_FMAPNAME_NONLINEAR=$a2l
 ./xmlchange ATM2ROF_FMAPNAME_NONLINEAR=$a2l
 ./xmlchange ATM2OCN_FMAPNAME_NONLINEAR=$a2o
+./xmlchange ATM2ICE_FMAPNAME_NONLINEAR=$a2o
 
-# These surface->atm maps are not needed, but we want to test the capability.
+# These surface->atm maps are not needed in v3, but we want to test the capability.
 l2a=cpl/gridmaps/ne30pg2/map_r05_to_ne30pg2_${alg}.230516.nc
-o2a=cpl/gridmaps/EC30to60E2r2/map_EC30to60E2r2_to_ne30pg2_trfvnp2.230516.nc
+o2a=cpl/gridmaps/IcoswISC30E3r5/map_IcoswISC30E3r5_to_ne30pg2_trfv2.20240222.nc
 ./xmlchange LND2ATM_FMAPNAME_NONLINEAR=$l2a
 ./xmlchange LND2ATM_SMAPNAME_NONLINEAR=$l2a
 ./xmlchange OCN2ATM_FMAPNAME_NONLINEAR=$o2a

--- a/cime_config/testmods_dirs/allactive/nlmaps/shell_commands
+++ b/cime_config/testmods_dirs/allactive/nlmaps/shell_commands
@@ -6,7 +6,6 @@ a2o=cpl/gridmaps/ne30pg2/map_ne30pg2_to_IcoswISC30E3r5_trfvnp2.20231121.nc
 ./xmlchange ATM2LND_FMAPNAME_NONLINEAR=$a2l
 ./xmlchange ATM2ROF_FMAPNAME_NONLINEAR=$a2l
 ./xmlchange ATM2OCN_FMAPNAME_NONLINEAR=$a2o
-./xmlchange ATM2ICE_FMAPNAME_NONLINEAR=$a2o
 
 # These surface->atm maps are not needed in v3, but we want to test the capability.
 l2a=cpl/gridmaps/ne30pg2/map_r05_to_ne30pg2_${alg}.230516.nc

--- a/cime_config/testmods_dirs/allactive/wcprodssp/shell_commands
+++ b/cime_config/testmods_dirs/allactive/wcprodssp/shell_commands
@@ -6,9 +6,9 @@
  
  ./xmlchange RUN_TYPE="hybrid"
  ./xmlchange GET_REFCASE="TRUE"
- ./xmlchange RUN_REFCASE="v2.LR.historical_0101"
- ./xmlchange RUN_REFDATE="2015-01-01"
- ./xmlchange RUN_REFDIR=${INPUTDATA_ROOT}"/e3sm_init/V2.SSP370_SSP585.ne30pg2_EC30to60E2r2/v2.LR.historical_0101/2015-01-01-00000"
+ ./xmlchange RUN_REFCASE="20231209.v3.LR.piControl-spinup.chrysalis"
+ ./xmlchange RUN_REFDATE="1801-01-01"
+ ./xmlchange RUN_REFDIR=${INPUTDATA_ROOT}"/e3sm_init/V3.SSP370_SSP585.ne30pg2_r05_IcoswISC30E3r5/v3.LR.piControl-spinup/1801-01-01-00000"
 
  exit
 

--- a/cime_config/testmods_dirs/allactive/wcprodssp/user_nl_elm
+++ b/cime_config/testmods_dirs/allactive/wcprodssp/user_nl_elm
@@ -1,8 +1,11 @@
-! fsurdat used is not the same file for the reference historical run (as recorded in elm.r's global attribute)
+! fsurdat might be set to be not the same file for the reference historical run (as recorded in elm.r's global attribute)
 
  CHECK_FINIDAT_FSURDAT_CONSISTENCY       = .false.
-! Finidat to be updated, The one below not compatible with v3 lnd config (with TOP and BGC mode, new grid)
-! finidat = "$DIN_LOC_ROOT/e3sm_init/V2.SSP370_SSP585.ne30pg2_EC30to60E2r2/v2.LR.historical_0101/2015-01-01-00000/v2.LR.historical_0101.elm.r.noNaN.2015-01-01-00000.nc"
+
+! flanduse_timeseries not ready for v3.LR.SSP production grid, set not to do transient_pft tentatively until SSP compset fully ready
+
+ do_transient_pfts = .false.
+
  hist_dov2xy = .true.,.true.
  hist_fincl2 = 'H2OSNO', 'FSNO', 'QRUNOFF', 'QSNOMELT', 'FSNO_EFF', 'SNORDSL', 'SNOW', 'FSDS', 'FSR', 'FLDS', 'FIRE', 'FIRA'
  hist_mfilt = 1,365

--- a/cime_config/testmods_dirs/config_pes_tests.xml
+++ b/cime_config/testmods_dirs/config_pes_tests.xml
@@ -115,10 +115,10 @@
     </mach>
   </grid>
   <!-- allactive -->
-  <grid name="a%ne30np4.pg.+_oi%EC30to60E2r2">
+  <grid name="a%ne30np4.pg.+_oi%IcoswISC30E3r5">
     <mach name="chrysalis">
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+_SESP$" pesize="any">
-        <comment>tests+chrysalis: -compset WCYCL* -res ne30pg*EC30to60E2r2 on 4 nodes pure-MPI, ~2.38 sypd </comment>
+        <comment>tests+chrysalis: -compset WCYCL* -res ne30pg*IcoswISC30E3r5 on 4 nodes pure-MPI </comment>
         <ntasks>
           <ntasks_atm>192</ntasks_atm>
           <ntasks_lnd>192</ntasks_lnd>
@@ -132,7 +132,7 @@
         </rootpe>
       </pes>
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+SGLC_SWAV_SIAC_SESP_BGC.*" pesize="any">
-        <comment>tests+chrysalis: --compset BGC* --res ne30pg2_r05_EC30to60E2r2 on 5 nodes pure-MPI, ~0.9 sypd </comment>
+        <comment>tests+chrysalis: --compset BGC* --res ne30pg2_r05_IcoswISC30E3r5 on 5 nodes pure-MPI </comment>
         <ntasks>
           <ntasks_atm>256</ntasks_atm>
           <ntasks_lnd>256</ntasks_lnd>
@@ -159,7 +159,7 @@
         </ntasks>
       </pes>
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SWAV.+_SESP$" pesize="any">
-        <comment>tests+anvil: --compset WCYCL* --res ne30pg2_EC30to60E2r2 on 16 nodes pure-MPI, ~2.7 sypd </comment>
+        <comment>tests+anvil: --compset WCYCL* --res ne30pg2_IcoswISC30E3r5 on 16 nodes pure-MPI </comment>
         <ntasks>
           <ntasks_atm>396</ntasks_atm>
           <ntasks_lnd>396</ntasks_lnd>
@@ -173,7 +173,7 @@
         </rootpe>
       </pes>
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+SGLC_SWAV_SIAC_SESP_BGC.*" pesize="any">
-        <comment>tests+anvil: --compset BGC* --res ne30pg2_r05_EC30to60E2r2 on 30 nodes pure-MPI, ~3 sypd </comment>
+        <comment>tests+anvil: --compset BGC* --res ne30pg2_r05_IcoswISC30E3r5 on 30 nodes pure-MPI </comment>
         <ntasks>
           <ntasks_atm>675</ntasks_atm>
           <ntasks_lnd>684</ntasks_lnd>

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -103,11 +103,11 @@ _TESTS = {
             "ERP_Ln3.ne4pg2_oQU480.F2010",
             "SMS_Ln9.ne4pg2_oQU480.F2010.eam-outfrq9s",
             "SMS.ne4pg2_oQU480.F2010.eam-cosplite",
-            "SMS_R_Ld5.ne4pg2_ne4pg2.FSCM-ARM97.eam-scm",
+            "SMS_R_Ld5.ne4_ne4.FSCM-ARM97.eam-scm",
             "SMS_D_Ln5.ne4pg2_oQU480.F2010",
             "SMS_Ln5.ne4pg2_oQU480.F2010",
             "ERS_D.ne4pg2_oQU480.F2010.eam-hommexx",
-            "SMS_Ln9_P24x1.ne4pg2_ne4pg2.FDPSCREAM-ARM97",
+            "SMS_Ln9_P24x1.ne4_ne4.FDPSCREAM-ARM97",
             )
         },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -236,8 +236,8 @@ _TESTS = {
     "e3sm_ocnice_extra_coverage" : {
         "inherit" : ("e3sm_ocnice_stealth_features"),
         "tests" : (
-            "ERS_P480_Ld5.T62_ECwISC30to60E2r1.GMPAS-DIB-IAF-PISMF",
-            "PEM_P480_Ld5.T62_ECwISC30to60E2r1.GMPAS-DIB-IAF-PISMF",
+            "ERS_P480_Ld5.TL319_IcoswISC30E3r5.GMPAS-JRA1p5-DIB-PISMF.mpaso-jra_1958",
+            "PEM_P480_Ld5.TL319_IcoswISC30E3r5.GMPAS-JRA1p5-DIB-PISMF.mpaso-jra_1958",
             "SMS.ne30_oECv3_gis.IGELM_MLI.elm-extrasnowlayers",
             )
         },

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -65,7 +65,7 @@ _TESTS = {
         "tests" : (
             "ERS_D.f19_f19.IELM.elm-ic_f19_f19_ielm",
             "ERS_D.f09_g16.I1850ELMCN",
-            "ERS_D.ne4pg2_oQU480.I20TRELM",
+            "ERS_D.ne4pg2_oQU480.I20TRELM.elm-disableDynpftCheck",
             "SMS_Ly2_P1x1_D.1x1_smallvilleIA.IELMCNCROP.elm-lulcc_sville",
             "ERS_D.f19_g16.I1850GSWCNPRDCTCBC.elm-ctc_f19_g16_I1850GSWCNPRDCTCBC",
             "ERS_D.f09_f09.IELM.elm-solar_rad",

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -167,7 +167,7 @@ _TESTS = {
     "e3sm_atm_integration" : {
         "inherit" : ("eam_preqx", "eam_theta"),
         "tests" : (
-            "ERP_Ln9.ne4_ne4.FAQP",
+            "ERP_Ln9.ne4pg2_ne4pg2.FAQP",
             "SMS_Ld1.ne4pg2_ne4pg2.FAQP.eam-clubb_only",
             "ERP_Ln9.ne4pg2_ne4pg2.FRCE",
             "PET_Ln5.ne4pg2_oQU480.F2010.allactive-mach-pet",
@@ -181,7 +181,7 @@ _TESTS = {
             "ERS_Ld5.ne4pg2_oQU480.F2010.eam-rrtmgpxx",
             "REP_Ln5.ne4pg2_oQU480.F2010",
             "SMS_Ld9.ne4pg2_oQU480.F2010.eam-thetahy_sl_pg2_mass",
-            "ERP_Ld9.ne4_ne4.FIDEAL.allactive-pioroot1",
+            "ERP_Ld9.ne4pg2_ne4pg2.FIDEAL.allactive-pioroot1",
             )
         },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -349,8 +349,8 @@ _TESTS = {
             "SMS_Ld1.ne30pg2_r05_IcoswISC30E3r5.WCYCL1850-1pctCO2.allactive-wcprod_1850_1pctCO2",
             "SMS_Ld1.ne30pg2_r05_IcoswISC30E3r5.WCYCL1850-4xCO2.allactive-wcprod_1850_4xCO2",
             "SMS_Ld1.ne30pg2_r05_IcoswISC30E3r5.WCYCL1850.allactive-wcprod_1850",
-            "SMS_Ld1.ne30pg2_EC30to60E2r2.WCYCLSSP370.allactive-wcprodssp",
-            "SMS_Ld1.ne30pg2_EC30to60E2r2.WCYCLSSP585.allactive-wcprodssp",
+            "SMS_Ld1.ne30pg2_r05_IcoswISC30E3r5.WCYCLSSP370.allactive-wcprodssp",
+            "SMS_Ld1.ne30pg2_r05_IcoswISC30E3r5.WCYCLSSP585.allactive-wcprodssp",
             "SMS_PS.northamericax4v1pg2_WC14to60E2r3.WCYCL1850.allactive-wcprodrrm_1850",
             )
         },

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -100,7 +100,7 @@ _TESTS = {
     "e3sm_atm_developer" : {
         "inherit" : ("eam_theta_pg2"),
         "tests"   : (
-            "ERP_Ln18.ne4pg2_oQU480.F2010",
+            "ERP_Ln3.ne4pg2_oQU480.F2010",
             "SMS_Ln9.ne4pg2_oQU480.F2010.eam-outfrq9s",
             "SMS.ne4pg2_oQU480.F2010.eam-cosplite",
             "SMS_R_Ld5.ne4pg2_ne4pg2.FSCM-ARM97.eam-scm",
@@ -124,8 +124,8 @@ _TESTS = {
         "tests"   : (
             "SMS_D_Ln5.ne4pg2_oQU480.F2010",
             "SMS_D_Ln5.ne4pg2_oQU480.F2010.eam-condidiag_dcape",
-            "ERP_Ln18.ne4pg2_oQU480.F2010.eam-condidiag_dcape",
-            "ERP_Ln18.ne4pg2_oQU480.F2010.eam-condidiag_rhi",
+            "ERP_Ld3.ne4pg2_oQU480.F2010.eam-condidiag_dcape",
+            "ERP_Ld3.ne4pg2_oQU480.F2010.eam-condidiag_rhi",
             )
         },
 
@@ -197,8 +197,8 @@ _TESTS = {
 	    "SMS_D_Ln5.ne45pg2_ne45pg2.FAQP",
             "SMS_D_Ln5.ne4pg2_oQU480.F2010.eam-implicit_stress",
             "ERS_Ld5.ne30pg2_r05_IcoswISC30E3r5.F2010.eam-implicit_stress",
-            "ERP_Ln18.ne4pg2_oQU480.F2010.eam-condidiag_dcape",
-            "ERP_Ln18.ne4pg2_oQU480.F2010.eam-condidiag_rhi",
+            "ERP_Ld3.ne4pg2_oQU480.F2010.eam-condidiag_dcape",
+            "ERP_Ld3.ne4pg2_oQU480.F2010.eam-condidiag_rhi",
             )
         },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -100,7 +100,7 @@ _TESTS = {
     "e3sm_atm_developer" : {
         "inherit" : ("eam_theta_pg2"),
         "tests"   : (
-            "ERP_Ln3.ne4pg2_oQU480.F2010",
+            "ERP_Ld3.ne4pg2_oQU480.F2010",
             "SMS_Ln9.ne4pg2_oQU480.F2010.eam-outfrq9s",
             "SMS.ne4pg2_oQU480.F2010.eam-cosplite",
             "SMS_R_Ld5.ne4_ne4.FSCM-ARM97.eam-scm",
@@ -180,8 +180,8 @@ _TESTS = {
             "ERS_Ld5.ne4pg2_oQU480.F2010.eam-rrtmgp",
             "ERS_Ld5.ne4pg2_oQU480.F2010.eam-rrtmgpxx",
             "REP_Ln5.ne4pg2_oQU480.F2010",
-            "SMS_Ld9.ne4pg2_oQU480.F2010.eam-thetahy_sl_pg2_mass",
-            "ERP_Ld9.ne4pg2_ne4pg2.FIDEAL.allactive-pioroot1",
+            "SMS_Ld3.ne4pg2_oQU480.F2010.eam-thetahy_sl_pg2_mass",
+            "ERP_Ld3.ne4pg2_ne4pg2.FIDEAL.allactive-pioroot1",
             )
         },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -25,7 +25,7 @@ _TESTS = {
     "e3sm_mosart_exenoshare": {
         "time"  : "0:45:00",
         "tests" : (
-            "ERS.ne30pg2_r05_EC30to60E2r2.GPMPAS-JRA.mosart-rof_ocn_2way",
+            "ERS.ne30pg2_r05_IcoswISC30E3r5.GPMPAS-JRA.mosart-rof_ocn_2way",
             )
         },
 
@@ -65,7 +65,7 @@ _TESTS = {
         "tests" : (
             "ERS_D.f19_f19.IELM.elm-ic_f19_f19_ielm",
             "ERS_D.f09_g16.I1850ELMCN",
-            "ERS_D.ne11_oQU240.I20TRELM",
+            "ERS_D.ne4pg2_oQU480.I20TRELM",
             "SMS_Ly2_P1x1_D.1x1_smallvilleIA.IELMCNCROP.elm-lulcc_sville",
             "ERS_D.f19_g16.I1850GSWCNPRDCTCBC.elm-ctc_f19_g16_I1850GSWCNPRDCTCBC",
             "ERS_D.f09_f09.IELM.elm-solar_rad",
@@ -100,20 +100,20 @@ _TESTS = {
     "e3sm_atm_developer" : {
         "inherit" : ("eam_theta_pg2"),
         "tests"   : (
-            "ERP_Ln18.ne4_oQU240.F2010",
-            "SMS_Ln9.ne4_oQU240.F2010.eam-outfrq9s",
-            "SMS.ne4_oQU240.F2010.eam-cosplite",
-            "SMS_R_Ld5.ne4_ne4.FSCM-ARM97.eam-scm",
-            "SMS_D_Ln5.ne4_oQU240.F2010",
+            "ERP_Ln18.ne4pg2_oQU480.F2010",
+            "SMS_Ln9.ne4pg2_oQU480.F2010.eam-outfrq9s",
+            "SMS.ne4pg2_oQU480.F2010.eam-cosplite",
+            "SMS_R_Ld5.ne4pg2_ne4pg2.FSCM-ARM97.eam-scm",
+            "SMS_D_Ln5.ne4pg2_oQU480.F2010",
             "SMS_Ln5.ne4pg2_oQU480.F2010",
-            "ERS_D.ne4_oQU240.F2010.eam-hommexx",
-            "SMS_Ln9_P24x1.ne4_ne4.FDPSCREAM-ARM97",
+            "ERS_D.ne4pg2_oQU480.F2010.eam-hommexx",
+            "SMS_Ln9_P24x1.ne4pg2_ne4pg2.FDPSCREAM-ARM97",
             )
         },
 
     "e3sm_ice_developer" : {
         "tests"   : (
-            "SMS_D_Ld1.TL319_EC30to60E2r2.DTESTM-JRA1p5.mpassi-jra_1958",
+            "SMS_D_Ld1.TL319_IcoswISC30E3r5.DTESTM-JRA1p5.mpassi-jra_1958",
             "ERS_Ld5.T62_oQU240.DTESTM",
             "PEM_Ln5.T62_oQU240wLI.DTESTM",
             "PET_Ln5.T62_oQU240.DTESTM",
@@ -124,8 +124,8 @@ _TESTS = {
         "tests"   : (
             "SMS_D_Ln5.ne4pg2_oQU480.F2010",
             "SMS_D_Ln5.ne4pg2_oQU480.F2010.eam-condidiag_dcape",
-            "ERP_Ln18.ne4_oQU240.F2010.eam-condidiag_dcape",
-            "ERP_Ln18.ne4_oQU240.F2010.eam-condidiag_rhi",
+            "ERP_Ln18.ne4pg2_oQU480.F2010.eam-condidiag_dcape",
+            "ERP_Ln18.ne4pg2_oQU480.F2010.eam-condidiag_rhi",
             )
         },
 
@@ -168,18 +168,18 @@ _TESTS = {
         "inherit" : ("eam_preqx", "eam_theta"),
         "tests" : (
             "ERP_Ln9.ne4_ne4.FAQP",
-            "SMS_Ld1.ne4_ne4.FAQP.eam-clubb_only",
-            "ERP_Ln9.ne4_ne4.FRCE",
-            "PET_Ln5.ne4_oQU240.F2010.allactive-mach-pet",
-            "PEM_Ln5.ne4_oQU240.F2010",
-            "SMS_D_Ln5.ne4_oQU240.F2010.eam-cosplite_nhtfrq5",
-            "SMS_Ln1.ne4_oQU240.F2010.eam-chem_pp",
-            "SMS_Ln5.ne30pg2_r05_EC30to60E2r2.BGCEXP_LNDATM_CNPRDCTC_20TR",
-            "SMS_Ln5.ne30pg2_r05_EC30to60E2r2.BGCEXP_LNDATM_CNPRDCTC_1850",
-            "SMS_D_Ln5.ne4_oQU240.F2010.eam-clubb_sp",
-            "ERS_Ld5.ne4_oQU240.F2010.eam-rrtmgp",
-            "ERS_Ld5.ne4_oQU240.F2010.eam-rrtmgpxx",
-            "REP_Ln5.ne4_oQU240.F2010",
+            "SMS_Ld1.ne4pg2_ne4pg2.FAQP.eam-clubb_only",
+            "ERP_Ln9.ne4pg2_ne4pg2.FRCE",
+            "PET_Ln5.ne4pg2_oQU480.F2010.allactive-mach-pet",
+            "PEM_Ln5.ne4pg2_oQU480.F2010",
+            "SMS_D_Ln5.ne4pg2_oQU480.F2010.eam-cosplite_nhtfrq5",
+            "SMS_Ln1.ne4pg2_oQU480.F2010.eam-chem_pp",
+            "SMS_Ln5.ne30pg2_r05_IcoswISC30E3r5.BGCEXP_LNDATM_CNPRDCTC_20TR",
+            "SMS_Ln5.ne30pg2_r05_IcoswISC30E3r5.BGCEXP_LNDATM_CNPRDCTC_1850",
+            "SMS_D_Ln5.ne4pg2_oQU480.F2010.eam-clubb_sp",
+            "ERS_Ld5.ne4pg2_oQU480.F2010.eam-rrtmgp",
+            "ERS_Ld5.ne4pg2_oQU480.F2010.eam-rrtmgpxx",
+            "REP_Ln5.ne4pg2_oQU480.F2010",
             "SMS_Ld9.ne4pg2_oQU480.F2010.eam-thetahy_sl_pg2_mass",
             "ERP_Ld9.ne4_ne4.FIDEAL.allactive-pioroot1",
             )
@@ -188,17 +188,17 @@ _TESTS = {
     #atmopheric tests for extra coverage
     "e3sm_atm_extra_coverage" : {
         "tests" : (
-            "SMS_Lm1.ne4_oQU240.F2010",
-            "ERS_Ld31.ne4_oQU240.F2010",
-            "ERP_Lm3.ne4_oQU240.F2010",
-            "SMS_D_Ln5.ne30_oECv3.F2010",
-            "ERP_Ld3.ne30_oECv3.F2010.allactive-pioroot1",
-            "SMS_Ly1.ne4_oQU240.F2010",
+            "SMS_Lm1.ne4pg2_oQU480.F2010",
+            "ERS_Ld31.ne4pg2_oQU480.F2010",
+            "ERP_Lm3.ne4pg2_oQU480.F2010",
+            "SMS_D_Ln5.ne30pg2_r05_IcoswISC30E3r5.F2010",
+            "ERP_Ld3.ne30pg2_r05_IcoswISC30E3r5.F2010.allactive-pioroot1",
+            "SMS_Ly1.ne4pg2_oQU480.F2010",
 	    "SMS_D_Ln5.ne45pg2_ne45pg2.FAQP",
-            "SMS_D_Ln5.ne4_oQU240.F2010.eam-implicit_stress",
-            "ERS_Ld5.ne30_oECv3.F2010.eam-implicit_stress",
-            "ERP_Ln18.ne4_oQU240.F2010.eam-condidiag_dcape",
-            "ERP_Ln18.ne4_oQU240.F2010.eam-condidiag_rhi",
+            "SMS_D_Ln5.ne4pg2_oQU480.F2010.eam-implicit_stress",
+            "ERS_Ld5.ne30pg2_r05_IcoswISC30E3r5.F2010.eam-implicit_stress",
+            "ERP_Ln18.ne4pg2_oQU480.F2010.eam-condidiag_dcape",
+            "ERP_Ln18.ne4pg2_oQU480.F2010.eam-condidiag_rhi",
             )
         },
 
@@ -247,7 +247,7 @@ _TESTS = {
         "tests"   : (
             "ERP.ne4pg2_oQU480.F2010.eam-v3atm_dustemis",
             "REP.ne4pg2_oQU480.F2010.eam-v3atm_dustemis",
-            "SMS.ne30pg2_EC30to60E2r2.F2010.eam-v3atm_dustemis",
+            "SMS.ne30pg2_IcoswISC30E3r5.F2010.eam-v3atm_dustemis",
             "SMS_D_Ln5.ne4pg2_oQU480.F2010.eam-v3atm_dustemis",
             "PET_Ln5.ne4pg2_oQU480.F2010.eam-v3atm_dustemis",
             "PEM_Ln5.ne4pg2_oQU480.F2010.eam-v3atm_dustemis",
@@ -270,7 +270,7 @@ _TESTS = {
             "ERS.f09_g16_g.MALISIA",
             "SMS.T62_oQU120_ais20.MPAS_LISIO_TEST",
             "SMS.f09_g16_a.IGELM_MLI",
-            "SMS_P12x2.ne4_oQU240.WCYCL1850NS.allactive-mach_mods",
+            "SMS_P12x2.ne4pg2_oQU480.WCYCL1850NS.allactive-mach_mods",
             "ERS_Ln9.ne4pg2_ne4pg2.F2010-MMF1.eam-mmf_crmout",
             )
         },
@@ -284,27 +284,26 @@ _TESTS = {
         },
 
     "e3sm_integration" : {
-        "inherit" : ("e3sm_developer", "e3sm_atm_integration", "e3sm_mmf_integration"),
+        "inherit" : ("e3sm_developer", "e3sm_atm_integration", "e3sm_mmf_integration", "e3sm_rrm"),
         "time"    : "03:00:00",
         "tests"   : (
             "ERS.ne4pg2_oQU480.WCYCL1850NS",
-            "SMS_D_Ld1.ne30pg2_EC30to60E2r2.WCYCL1850.allactive-wcprod",
-            "SMS_D_Ld1.ne30pg2_EC30to60E2r2.WCYCLSSP370.allactive-wcprodssp",
-            "ERS_Ld3.ne4_oQU240.F2010",
+            "SMS_D_Ld1.ne30pg2_r05_IcoswISC30E3r5.WCYCL1850.allactive-wcprod",
+            "SMS_D_Ld1.ne30pg2_r05_IcoswISC30E3r5.WCYCLSSP370.allactive-wcprodssp",
+            "ERS_Ld3.ne4pg2_oQU480.F2010",
             #"ERT_Ld31.ne16_g37.B1850C5",#add this line back in with the new correct compset
             "NCK.ne4pg2_oQU480.WCYCL1850NS",
             "PET.f19_g16.X.allactive-mach-pet",
             "PET.f45_g37_rx1.A.allactive-mach-pet",
-            "PET_Ln9_PS.ne30pg2_EC30to60E2r2.WCYCL1850.allactive-mach-pet",
-            "PEM_Ln9.ne30pg2_EC30to60E2r2.WCYCL1850",
-            "ERP_Ld3.ne30pg2_EC30to60E2r2.WCYCL1850.allactive-pioroot1",
-            "SMS_D_Ln5.conusx4v1_r05_oECv3.F2010",
-            "SMS_Ld2.ne30pg2_r05_EC30to60E2r2.BGCEXP_CNTL_CNPECACNT_1850.elm-bgcexp",
-            "SMS_Ld2.ne30pg2_r05_EC30to60E2r2.BGCEXP_CNTL_CNPRDCTC_1850.elm-bgcexp",
+            "PET_Ln9_PS.ne30pg2_r05_IcoswISC30E3r5.WCYCL1850.allactive-mach-pet",
+            "PEM_Ln9.ne30pg2_r05_IcoswISC30E3r5.WCYCL1850",
+            "ERP_Ld3.ne30pg2_r05_IcoswISC30E3r5.WCYCL1850.allactive-pioroot1",
+            "SMS_Ld2.ne30pg2_r05_IcoswISC30E3r5.BGCEXP_CNTL_CNPECACNT_1850.elm-bgcexp",
+            "SMS_Ld2.ne30pg2_r05_IcoswISC30E3r5.BGCEXP_CNTL_CNPRDCTC_1850.elm-bgcexp",
             "SMS_D_Ld3.T62_oQU120.CMPASO-IAF",
-            "SMS_D_Ld1.ne30pg2_r05_EC30to60E2r2.WCYCL1850",
+            "SMS_D_Ld1.ne30pg2_r05_IcoswISC30E3r5.WCYCL1850",
             "SMS_Ln5.ne30pg2_ne30pg2.F2010-SCREAM-LR-DYAMOND2",
-            "ERS_Ld3.ne30pg2_r05_EC30to60E2r2.WCYCL1850.allactive-nlmaps",
+            "ERS_Ld3.ne30pg2_r05_IcoswISC30E3r5.WCYCL1850.allactive-nlmaps",
             )
         },
 
@@ -328,7 +327,7 @@ _TESTS = {
     #e3sm tests for RRM grids
     "e3sm_rrm" : {
         "tests" : (
-            "SMS_D_Ln5.conusx4v1_r05_oECv3.F2010",
+            "SMS_D_Ln5.conusx4v1pg2_r05_IcoswISC30E3r5.F2010",
             )
         },
 
@@ -454,27 +453,27 @@ _TESTS = {
         "share"    : True,
         "time"     : "01:00:00",
         "tests"    : (
-                 "SMS.ne4_oQU240.F2010.eam-preqx_ftype0",
-                 "SMS.ne4_oQU240.F2010.eam-preqx_ftype1",
-                 "SMS.ne4_oQU240.F2010.eam-preqx_ftype4",
+                 "SMS.ne4pg2_oQU480.F2010.eam-preqx_ftype0",
+                 "SMS.ne4pg2_oQU480.F2010.eam-preqx_ftype1",
+                 "SMS.ne4pg2_oQU480.F2010.eam-preqx_ftype4",
                  )
     },
     "eam_theta" : {
         "share"    : True,
         "time"     : "02:00:00",
         "tests"    : (
-                 "SMS.ne4_oQU240.F2010.eam-thetahy_ftype0",
-                 "SMS.ne4_oQU240.F2010.eam-thetahy_ftype1",
-                 "SMS.ne4_oQU240.F2010.eam-thetahy_ftype2",
-                 "SMS.ne4_oQU240.F2010.eam-thetahy_ftype2_energy",
-                 "SMS.ne4_oQU240.F2010.eam-thetahy_ftype4",
-                 "SMS.ne4_oQU240.F2010.eam-thetanh_ftype0",
-                 "SMS.ne4_oQU240.F2010.eam-thetanh_ftype1",
-                 "SMS.ne4_oQU240.F2010.eam-thetanh_ftype2",
-                 "SMS.ne4_oQU240.F2010.eam-thetanh_ftype4",
-                 "SMS.ne4_oQU240.F2010.eam-thetahy_sl",
-                 "ERS.ne4_oQU240.F2010.eam-thetahy_ftype2",
-                 "ERS.ne4_oQU240.F2010.eam-thetanh_ftype2",
+                 "SMS.ne4pg2_oQU480.F2010.eam-thetahy_ftype0",
+                 "SMS.ne4pg2_oQU480.F2010.eam-thetahy_ftype1",
+                 "SMS.ne4pg2_oQU480.F2010.eam-thetahy_ftype2",
+                 "SMS.ne4pg2_oQU480.F2010.eam-thetahy_ftype2_energy",
+                 "SMS.ne4pg2_oQU480.F2010.eam-thetahy_ftype4",
+                 "SMS.ne4pg2_oQU480.F2010.eam-thetanh_ftype0",
+                 "SMS.ne4pg2_oQU480.F2010.eam-thetanh_ftype1",
+                 "SMS.ne4pg2_oQU480.F2010.eam-thetanh_ftype2",
+                 "SMS.ne4pg2_oQU480.F2010.eam-thetanh_ftype4",
+                 "SMS.ne4pg2_oQU480.F2010.eam-thetahy_sl",
+                 "ERS.ne4pg2_oQU480.F2010.eam-thetahy_ftype2",
+                 "ERS.ne4pg2_oQU480.F2010.eam-thetanh_ftype2",
                  )
     },
     "eam_theta_pg2" : {

--- a/components/eam/cime_config/config_pes.xml
+++ b/components/eam/cime_config/config_pes.xml
@@ -840,6 +840,22 @@
       </pes>
     </mach>
   </grid>
+  <grid name="a%ne30np4.pg2.+_oi%IcoswISC30E3r5.+">
+    <mach name="gcp12">
+      <!--2010_EAM%CMIP6_ELM%CNPRDCTCBCTOP_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV_SIAC_SESP-->
+      <pes compset=".*EAM.+ELM.+MPASSI.+DOCN.+MOSART.+" pesize="any">
+	<comment> gcp12 eam F compset  --res ne30pg2_IcoswISC30E3r5 on 4 nodes </comment>
+	<ntasks>
+	  <ntasks_atm>-4</ntasks_atm>
+	  <ntasks_cpl>-4</ntasks_cpl>
+	  <ntasks_ocn>-4</ntasks_ocn>
+	  <ntasks_ice>-4</ntasks_ice>
+	  <ntasks_rof>-4</ntasks_rof>
+	  <ntasks_lnd>-4</ntasks_lnd>
+	</ntasks>
+      </pes>
+    </mach>
+  </grid>
   <grid name="a%ne30np4.pg.+_oi%EC30to60E2r2">
     <mach name="chrysalis">
       <pes compset=".*EAM.+ELM.+MPASSI.+DOCN.+MOSART.+" pesize="T">

--- a/components/eam/cime_config/config_pes.xml
+++ b/components/eam/cime_config/config_pes.xml
@@ -140,7 +140,7 @@
         </nthrds>
       </pes>
     </mach>
-    <mach name="theta|pm-cpu|alvarez|pm-gpu|muller|jlse">
+    <mach name="theta|pm-cpu|muller-cpu|alvarez|pm-gpu|muller|jlse">
       <pes compset="any" pesize="any">
         <comment>eam: default, 1 node x MAX_MPITASKS_PER_NODE mpi x 1 omp @ root 0</comment>
         <ntasks>
@@ -290,6 +290,21 @@
           <ntasks_cpl>56</ntasks_cpl>
           <ntasks_glc>56</ntasks_glc>
           <ntasks_wav>56</ntasks_wav>
+        </ntasks>
+      </pes>
+    </mach>
+    <mach name="pm-cpu|muller-cpu">
+      <pes compset="any" pesize="any">
+        <comment>pm-cpu: any compset on ne4pg2 grid</comment>
+        <ntasks>
+          <ntasks_atm>96</ntasks_atm>
+          <ntasks_lnd>96</ntasks_lnd>
+          <ntasks_rof>96</ntasks_rof>
+          <ntasks_ice>96</ntasks_ice>
+          <ntasks_ocn>96</ntasks_ocn>
+          <ntasks_cpl>96</ntasks_cpl>
+          <ntasks_glc>1</ntasks_glc>
+          <ntasks_wav>1</ntasks_wav>
         </ntasks>
       </pes>
     </mach>
@@ -774,7 +789,7 @@
   </grid>
   <grid name="a%ne30.+_oi%.*EC.*to">
     <mach name="gcp12">
-      <!--Pes setting: grid          is a%ne30np4_l%ne30np4_oi%oEC60to30v3_r%r05_g%null_w%null_z%null_m%oEC60to30v3 
+      <!--Pes setting: grid          is a%ne30np4_l%ne30np4_oi%oEC60to30v3_r%r05_g%null_w%null_z%null_m%oEC60to30v3
           Pes setting: compset       is 2010_EAM%CMIP6_ELM%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV_SIAC_SESP
                                or       a%ne30np4.pg2_l%r05_oi%EC30to60E2r2_r%null_g%null_w%null_z%null_m%EC30to60E2r2
                                         1850_EAM%CMIP6_ELM%CNPRDCTCBC_MPASSI%PRES_DOCN%DOM_SROF_SGLC_SWAV_SIAC_SESP_BGC%LNDATM  -->
@@ -799,7 +814,7 @@
       </pes>
     </mach>
     <mach name="gcp10">
-      <!--Pes setting: grid          is a%ne30np4_l%ne30np4_oi%oEC60to30v3_r%r05_g%null_w%null_z%null_m%oEC60to30v3 
+      <!--Pes setting: grid          is a%ne30np4_l%ne30np4_oi%oEC60to30v3_r%r05_g%null_w%null_z%null_m%oEC60to30v3
           Pes setting: compset       is 2010_EAM%CMIP6_ELM%SPBC_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV_SIAC_SESP
                                or       a%ne30np4.pg2_l%r05_oi%EC30to60E2r2_r%null_g%null_w%null_z%null_m%EC30to60E2r2
                                         1850_EAM%CMIP6_ELM%CNPRDCTCBC_MPASSI%PRES_DOCN%DOM_SROF_SGLC_SWAV_SIAC_SESP_BGC%LNDATM  -->
@@ -844,15 +859,15 @@
     <mach name="gcp12">
       <!--2010_EAM%CMIP6_ELM%CNPRDCTCBCTOP_MPASSI%PRES_DOCN%DOM_MOSART_SGLC_SWAV_SIAC_SESP-->
       <pes compset=".*EAM.+ELM.+MPASSI.+DOCN.+MOSART.+" pesize="any">
-	<comment> gcp12 eam F compset  --res ne30pg2_IcoswISC30E3r5 on 4 nodes </comment>
-	<ntasks>
-	  <ntasks_atm>-4</ntasks_atm>
-	  <ntasks_cpl>-4</ntasks_cpl>
-	  <ntasks_ocn>-4</ntasks_ocn>
-	  <ntasks_ice>-4</ntasks_ice>
-	  <ntasks_rof>-4</ntasks_rof>
-	  <ntasks_lnd>-4</ntasks_lnd>
-	</ntasks>
+        <comment> gcp12 eam F compset  --res ne30pg2_IcoswISC30E3r5 on 4 nodes </comment>
+        <ntasks>
+          <ntasks_atm>-4</ntasks_atm>
+          <ntasks_cpl>-4</ntasks_cpl>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_ice>-4</ntasks_ice>
+          <ntasks_rof>-4</ntasks_rof>
+          <ntasks_lnd>-4</ntasks_lnd>
+        </ntasks>
       </pes>
     </mach>
   </grid>

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/thetahy_ftype0/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/thetahy_ftype0/user_nl_eam
@@ -1,4 +1,4 @@
 se_ftype=0
-cubed_sphere_map=0
+cubed_sphere_map=2
 theta_hydrostatic_mode=.true.
 

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/thetahy_ftype1/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/thetahy_ftype1/user_nl_eam
@@ -1,5 +1,5 @@
 se_ftype=1
-cubed_sphere_map=0
+cubed_sphere_map=2
 theta_hydrostatic_mode=.true.
 
 

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/thetahy_ftype2/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/thetahy_ftype2/user_nl_eam
@@ -1,5 +1,5 @@
 se_ftype=2
-cubed_sphere_map=0
+cubed_sphere_map=2
 theta_hydrostatic_mode=.true.
 
 

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/thetahy_ftype4/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/thetahy_ftype4/user_nl_eam
@@ -1,5 +1,5 @@
 se_ftype=4
-cubed_sphere_map=0
+cubed_sphere_map=2
 theta_hydrostatic_mode=.true.
 
 

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/thetahy_sl/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/thetahy_sl/user_nl_eam
@@ -1,7 +1,7 @@
 
 theta_hydrostatic_mode=.true.
 tstep_type=5
-cubed_sphere_map=0
+cubed_sphere_map=2
 
 transport_alg=12
 semi_lagrange_cdr_alg=20

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/thetanh_ftype0/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/thetanh_ftype0/user_nl_eam
@@ -1,5 +1,5 @@
 se_ftype=0
-cubed_sphere_map=0
+cubed_sphere_map=2
 theta_hydrostatic_mode=.false.
 tstep_type=7
 se_nsplit=10

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/thetanh_ftype1/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/thetanh_ftype1/user_nl_eam
@@ -1,5 +1,5 @@
 se_ftype=1
-cubed_sphere_map=0
+cubed_sphere_map=2
 theta_hydrostatic_mode=.false.
 tstep_type=7
 se_nsplit=10

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/thetanh_ftype2/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/thetanh_ftype2/user_nl_eam
@@ -1,5 +1,5 @@
 se_ftype=2
-cubed_sphere_map=0
+cubed_sphere_map=2
 theta_hydrostatic_mode=.false.
 tstep_type=7
 transport_alg=0

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/thetanh_ftype4/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/thetanh_ftype4/user_nl_eam
@@ -1,5 +1,5 @@
 se_ftype=4
-cubed_sphere_map=0
+cubed_sphere_map=2
 theta_hydrostatic_mode=.false.
 tstep_type=7
 se_nsplit=10

--- a/components/elm/bld/namelist_files/use_cases/2015-2100_SSP370_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/2015-2100_SSP370_transient.xml
@@ -32,8 +32,12 @@
 
 <!-- CMIP6 DECK compsets -->
 
-<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_SSP3_RCP70_simyr2015_c220420_with_TOP.nc </fsurdat>
-<flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30pg2_SSP3_RCP70_simyr2015-2100_c211015.nc</flanduse_timeseries>
+<fsurdat hgrid="ne30np4.pg2">lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_SSP3_RCP70_simyr2015_c220420_with_TOP.nc </fsurdat -->
+<!-- fsurdat needs to be updated to simyr2015. but ok to run with the simyr1850 one used from piControl then historical -->
+<fsurdat hgrid="r05>"lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr1850_c200609_with_TOP.nc</fsurdat -->
+<flanduse_timeseries hgrid="ne30np4.pg2">lnd/clm2/surfdata_map/landuse.timeseries_ne30pg2_SSP3_RCP70_simyr2015-2100_c211015.nc</flanduse_timeseries>
+<!-- flanduse_timeseries files is a place holder for r05 which is for historical. Disable transient_pfts tentatively as in wcprodssp testmod-->
+<flanduse_timeseries hgrid="r05">lnd/clm2/surfdata_map/landuse.timeseries_ne30pg2_SSP3_RCP70_simyr2015-2100_c211015.nc</flanduse_timeseries>
 
 <!-- Add following for hybrid run of SSP370 continuing from a historical simulation -->
 

--- a/components/elm/bld/namelist_files/use_cases/2015-2100_SSP585_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/2015-2100_SSP585_transient.xml
@@ -32,8 +32,12 @@
 
 <!-- CMIP6 DECK compsets -->
 
-<fsurdat>lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_SSP5_RCP85_simyr2015_c220420_with_TOP.nc </fsurdat>
-<flanduse_timeseries>lnd/clm2/surfdata_map/landuse.timeseries_ne30pg2_SSP5_RCP85_simyr2015-2100_c220310.nc</flanduse_timeseries>
+<fsurdat hgrid="ne30np4.pg2">lnd/clm2/surfdata_map/surfdata_ne30np4.pg2_SSP5_RCP85_simyr2015_c220420_with_TOP.nc </fsurdat>
+<!-- fsurdat needs to be updated to simyr2015. but ok to run with the simyr1850 one used from piControl then historical -->
+<fsurdat hgrid="r05>"lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr1850_c200609_with_TOP.nc</fsurdat -->
+<flanduse_timeseries hgrid="ne30np4.pg2">lnd/clm2/surfdata_map/landuse.timeseries_ne30pg2_SSP5_RCP85_simyr2015-2100_c220310.nc</flanduse_timeseries>
+<!-- flanduse_timeseries files is a place holder for r05 which is for historical. Disable transient_pfts tentatively as in wcprodssp testmod-->
+<flanduse_timeseries hgrid="r05">lnd/clm2/surfdata_map/landuse.timeseries_ne30pg2_SSP3_RCP70_simyr2015-2100_c211015.nc</flanduse_timeseries>
 
 <!-- Add following for hybrid run of SSP370 continuing from a historical simulation -->
 

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/disableDynpftCheck/user_nl_elm
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/disableDynpftCheck/user_nl_elm
@@ -1,0 +1,1 @@
+check_dynpft_consistency = .false.

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/jra_1958/shell_commands
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/jra_1958/shell_commands
@@ -1,0 +1,4 @@
+./xmlchange DATM_CLMNCEP_YR_START=1958
+./xmlchange DATM_CLMNCEP_YR_END=1958
+./xmlchange DROF_STRM_YR_START=1958
+./xmlchange DROF_STRM_YR_END=1958

--- a/driver-mct/cime_config/config_component.xml
+++ b/driver-mct/cime_config/config_component.xml
@@ -1375,6 +1375,14 @@
     <desc>atm2ocn flux mapping file</desc>
   </entry>
 
+  <entry id="ATM2ICE_FMAPNAME_NONLINEAR">
+    <type>char</type>
+    <default_value>idmap_ignore</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>atm2ice flux mapping file</desc>
+  </entry>
+
   <entry id="ATM2OCN_SMAPNAME">
     <type>char</type>
     <default_value>idmap</default_value>


### PR DESCRIPTION
Update resolutions in test cases to replace ne4 and ne11 with ne4pg2,
replace oQU240 with oQU480 and update v2 mpas mesh with v3 IcoswISC30E3r5 in tests of the production config.  Also change those from bigrid to trigrid.

Update test length for some 2-case tests to work with new coupling frequencies.
Make non-linear maps default for the v3 low res mesh ne30pg2_r05_IcoswISC30E3r5 since v3 uses those in production.

------

At least one test was changed in all of the following test suites.  
- e3sm_integration
  -  e3sm_rrm
  -  e3sm_atm_integration
     - eam_preqx
     - eam_theta
  - e3sm_developer
    - e3sm_atm_developer
    - e3sm_ice_developer
    - e3sm_land_developer
      - e3sm_mosart_exenoshare
      - e3sm_land_debug
        
- e3sm_extra_coverage
  - e3sm_atm_extra_coverage
- eam_condidiag
- e3sm_atm_dustemis

