### PR TITLE
Prefer HINTS to PATHS in cmake find modules

### DIFF
--- a/components/cmake/modules/FindCsmShare.cmake
+++ b/components/cmake/modules/FindCsmShare.cmake
@@ -24,7 +24,7 @@ endif()
 set(CSM_SHARE "${INSTALL_SHAREDPATH}/${COMP_INTERFACE}/${ESMFDIR}/${NINST_VALUE}/csm_share")
 
 # Look for libcsm_share in the complex path we built above
-find_library(CSM_SHARE_LIB csm_share REQUIRED PATHS ${CSM_SHARE})
+find_library(CSM_SHARE_LIB csm_share REQUIRED HINTS ${CSM_SHARE})
 
 set(CSM_LIBS  ${CSM_SHARE_LIB};mct;spio)
 set(CSM_INCLS ${CSM_SHARE})

--- a/components/cmake/modules/FindMCT.cmake
+++ b/components/cmake/modules/FindMCT.cmake
@@ -16,8 +16,8 @@ if (TARGET mct)
 endif()
 
 # Look for libmct in INSTALL_SHAREDPATH/lib
-find_library(MCT_LIB  mct  REQUIRED PATHS ${INSTALL_SHAREDPATH}/lib)
-find_library(MPEU_LIB mpeu REQUIRED PATHS ${INSTALL_SHAREDPATH}/lib $ENV{mct_ROOT})
+find_library(MCT_LIB  mct  REQUIRED HINTS ${INSTALL_SHAREDPATH}/lib)
+find_library(MPEU_LIB mpeu REQUIRED HINTS ${INSTALL_SHAREDPATH}/lib $ENV{mct_ROOT})
 
 # Create the interface library, and set target properties
 add_library(mct INTERFACE)

--- a/components/cmake/modules/FindNETCDF.cmake
+++ b/components/cmake/modules/FindNETCDF.cmake
@@ -24,7 +24,7 @@ function(get_netcdf_libs ncpath nfpath)
 
   # Fall back to find_library
   if (NOT nclibs)
-    find_library(nclibs_temp netcdf REQUIRED PATHS ${ncpath}/lib ${ncpath}/lib64)
+    find_library(nclibs_temp netcdf REQUIRED HINTS ${ncpath}/lib ${ncpath}/lib64)
     set(nclibs ${nclibs_temp})
   endif()
 
@@ -34,7 +34,7 @@ function(get_netcdf_libs ncpath nfpath)
   endif()
 
   if (NOT nflibs)
-    find_library(nflibs_temp netcdff REQUIRED PATHS ${nfpath}/lib ${nfpath}/lib64)
+    find_library(nflibs_temp netcdff REQUIRED HINTS ${nfpath}/lib ${nfpath}/lib64)
     set(nflibs ${nflibs_temp})
   endif()
 
@@ -53,8 +53,8 @@ function(create_netcdf_target)
   # Pnetcdf is optional, and only if not running serial
   if (NOT MPILIB STREQUAL mpi-serial)
     if (PNETCDF_PATH)
-      find_library(pnetcdf_lib pnetcdf REQUIRED PATHS ${PNETCDF_PATH}/lib)
-      find_path (pnetcdf_incdir pnetcdf.h REQUIRED PATHS ${PNETCDF_PATH}/include)
+      find_library(pnetcdf_lib pnetcdf REQUIRED HINTS ${PNETCDF_PATH}/lib)
+      find_path (pnetcdf_incdir pnetcdf.h REQUIRED HINTS ${PNETCDF_PATH}/include)
     endif()
   endif()
 
@@ -71,8 +71,8 @@ function(create_netcdf_target)
     endif ()
 
     get_netcdf_libs(${NETCDF_C_PATH} ${NETCDF_FORTRAN_PATH})
-    find_path (netcdf_c_incdir netcdf.h REQUIRED PATHS ${NETCDF_C_PATH}/include)
-    find_path (netcdf_f_incdir netcdf.inc REQUIRED PATHS ${NETCDF_FORTRAN_PATH}/include)
+    find_path (netcdf_c_incdir netcdf.h REQUIRED HINTS ${NETCDF_C_PATH}/include)
+    find_path (netcdf_f_incdir netcdf.inc REQUIRED HINTS ${NETCDF_FORTRAN_PATH}/include)
 
   elseif (NETCDF_FORTRAN_PATH)
     message(FATAL_ERROR "NETCDF_FORTRAN_PATH specified without NETCDF_C_PATH")
@@ -84,8 +84,8 @@ function(create_netcdf_target)
     endif ()
 
     get_netcdf_libs(${NETCDF_PATH} ${NETCDF_PATH})
-    find_path(netcdf_c_incdir netcdf.h REQUIRED PATHS ${NETCDF_PATH}/include)
-    find_path(netcdf_f_incdir netcdf.inc REQUIRED PATHS ${NETCDF_PATH}/include)
+    find_path(netcdf_c_incdir netcdf.h REQUIRED HINTS ${NETCDF_PATH}/include)
+    find_path(netcdf_f_incdir netcdf.inc REQUIRED HINTS ${NETCDF_PATH}/include)
 
   else()
     message(FATAL_ERROR "NETCDF not found: Define NETCDF_PATH or NETCDF_C_PATH and NETCDF_FORTRAN_PATH in config_machines.xml or config_compilers.xml")


### PR DESCRIPTION
For all the cmake `find_XYZ` utilities, there is a well defined ordered list in which CMake scans paths while searching. In this list, the paths passed via the argument `HINTS` appear early on. On the other hand, the paths passed via the argument `PATHS` appear quite late. After trying `HINTS` and before trying `PATHS`, CMake consider other options, among which we have

- system paths (e.g., `/usr` directory on linux)
- cmake package registry (this is only for `find_package`, but can be _quite_ annoying and hard to find, as we experienced with EKAT)

CMake states that HINTS and PATHS should be used for different reasons. In particular, regarding `HINTS` it states that

> These should be paths computed by system introspection, such as a hint provided by the location of another item already found. Hard-coded guesses should be specified with the PATHS option.

However, the fact that `PATHS` is scanned after system folders makes its usage more complicated. Since `HINTS` and `PATHS` are treated in the same way (meaning, CMake grabs the paths contained in them, and just scan them), from the practical point of view, the difference between the two is just the fact that one is considered much earlier than the other.

The alternative would have been to add `NO_SYSTEM_PATH` to the `find_XYZ` calls, but it comes with a drawback: if on some testing machine (a shared workstation, perhaps) we _do_ have a valid installation of a tpl in the system paths, we would not pick it up. Using `HINTS`, we can still pick up the system install (leaving HINTS empty).

Fixes #6217 .