### PR TITLE
Fixes a I1850ELMCN test

### DIFF
--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/qian_1948/user_nl_elm
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/qian_1948/user_nl_elm
@@ -1,0 +1,1 @@
+ create_crop_landunit = .false.


### PR DESCRIPTION
Adds namelist options to disable the creation of crop landunits in qian-1948 testmod

Fixes #6192
[BFB]