### PR TITLE
Adding IcoswISC30E3r5 ice initial condition with DIB

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -305,6 +305,8 @@ _TESTS = {
             "SMS_D_Ld1.ne30pg2_r05_EC30to60E2r2.WCYCL1850",
             "SMS_Ln5.ne30pg2_ne30pg2.F2010-SCREAM-LR-DYAMOND2",
             "ERS_Ld3.ne30pg2_r05_EC30to60E2r2.WCYCL1850.allactive-nlmaps",
+            "SMS_D_Ld1.ne30pg2_r05_IcoswISC30E3r5.CRYO1850",
+            "SMS_D_Ld1.ne30pg2_r05_IcoswISC30E3r5.CRYO1850-DISMF",
             )
         },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -305,7 +305,6 @@ _TESTS = {
             "SMS_D_Ld1.ne30pg2_r05_EC30to60E2r2.WCYCL1850",
             "SMS_Ln5.ne30pg2_ne30pg2.F2010-SCREAM-LR-DYAMOND2",
             "ERS_Ld3.ne30pg2_r05_EC30to60E2r2.WCYCL1850.allactive-nlmaps",
-            "SMS_D_Ld1.ne30pg2_r05_IcoswISC30E3r5.CRYO1850",
             "SMS_D_Ld1.ne30pg2_r05_IcoswISC30E3r5.CRYO1850-DISMF",
             )
         },
@@ -355,6 +354,7 @@ _TESTS = {
             "SMS_Ld1.ne30pg2_EC30to60E2r2.WCYCLSSP370.allactive-wcprodssp",
             "SMS_Ld1.ne30pg2_EC30to60E2r2.WCYCLSSP585.allactive-wcprodssp",
             "SMS_PS.northamericax4v1pg2_WC14to60E2r3.WCYCL1850.allactive-wcprodrrm_1850",
+            "SMS_D_Ld1.ne30pg2_r05_IcoswISC30E3r5.CRYO1850",
             )
         },
 

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -260,8 +260,12 @@ def buildnml(case, caseroot, compname):
         decomp_prefix = 'partitions/mpas-seaice.graph.info.'
         data_iceberg_file = 'Iceberg_Climatology_Merino.IcoswISC30E3r5.20231120.nc'
         if ice_ic_mode == 'spunup':
-            grid_date = '20231121'
-            grid_prefix = 'mpassi.IcoswISC30E3r5.rstFromG-chrysalis'
+            if iceberg_mode == 'data':
+                grid_date = '20240207'
+                grid_prefix = 'mpassi.IcoswISC30E3r5.rstFromG-DIB-chrysalis'
+            else:
+                grid_date = '20231121'
+                grid_prefix = 'mpassi.IcoswISC30E3r5.rstFromG-chrysalis'
 
     elif ice_grid == 'ICOS10':
         grid_date = '211015'


### PR DESCRIPTION
This adds an initial condition for MPAS-Seaice for cases where the `IcoswISC30E3r5` mesh is paired with a `CRYO*` compset, which utilize data iceberg (DIB) forcing. The new initial condition is from a restart from a one month `GMPAS-JRA1p5-DIB-PISMF` case.

The current sea ice IC for this mesh in B-cases ('spun-up' ICs) was not run with DIB forcing, and as such MPAS-Seaice cannot use it as a restart for a case with DIB.

This also adds `CRYO1850` and `CRYO1850-DISMF` tests with this mesh to the e3sm_integration test suite, which prior to this would not pass.

[BFB] Only impacts configurations with `IcoswISC30E3r5` and a `CRYO*` compset, which prior to this would seg fault in ice during initialization.

Credit to @xylar for rooting out the problem.