### PR TITLE
Provenance: do not crash if config_src does not exist

### DIFF
--- a/cime_config/customize/provenance.py
+++ b/cime_config/customize/provenance.py
@@ -78,8 +78,9 @@ def _record_git_provenance(srcroot, exeroot, lid):
 
     # Git config
     config_src = os.path.join(gitroot, "config")
-    config_prov = os.path.join(exeroot, "GIT_CONFIG.{}".format(lid))
-    utils.safe_copy(config_src, config_prov, preserve_meta=False)
+    if os.path.exists(config_src):
+        config_prov = os.path.join(exeroot, "GIT_CONFIG.{}".format(lid))
+        utils.safe_copy(config_src, config_prov, preserve_meta=False)
 
 
 def _find_git_root(srcroot):


### PR DESCRIPTION
Just skip that file. This should help with containerized E3SM.

Fixes #6225 

[BFB]