### PR TITLE
Adding cryo fields to coupler budget accounting

### DIFF
--- a/components/mpas-ocean/driver/mpaso_cpl_indices.F
+++ b/components/mpas-ocean/driver/mpaso_cpl_indices.F
@@ -17,7 +17,9 @@ module mpaso_cpl_indices
   integer :: index_o2x_So_dhdx
   integer :: index_o2x_So_dhdy
   integer :: index_o2x_Fioo_q
+  integer :: index_o2x_Foxo_q_li
   integer :: index_o2x_Fioo_frazil
+  integer :: index_o2x_Foxo_frazil_li
   integer :: index_o2x_Faoo_h2otemp
   integer :: index_o2x_Faoo_fco2_ocn
   integer :: index_o2x_Faoo_fdms_ocn
@@ -186,7 +188,9 @@ contains
     index_o2x_So_dhdx       = mct_avect_indexra(o2x,'So_dhdx')
     index_o2x_So_dhdy       = mct_avect_indexra(o2x,'So_dhdy')
     index_o2x_Fioo_q        = mct_avect_indexra(o2x,'Fioo_q',perrWith='quiet')
+    index_o2x_Foxo_q_li     = mct_avect_indexra(o2x,'Foxo_q_li',perrWith='quiet')
     index_o2x_Fioo_frazil   = mct_avect_indexra(o2x,'Fioo_frazil',perrWith='quiet')
+    index_o2x_Foxo_frazil_li= mct_avect_indexra(o2x,'Foxo_frazil_li',perrWith='quiet')
     index_o2x_Faoo_h2otemp  = mct_avect_indexra(o2x,'Faoo_h2otemp',perrWith='quiet')
     index_o2x_Faoo_fco2_ocn = mct_avect_indexra(o2x,'Faoo_fco2_ocn',perrWith='quiet')
     index_o2x_Faoo_fdms_ocn = mct_avect_indexra(o2x,'Faoo_fdms_ocn',perrWith='quiet')

--- a/components/mpas-ocean/driver/mpaso_cpl_indices.F
+++ b/components/mpas-ocean/driver/mpaso_cpl_indices.F
@@ -192,12 +192,12 @@ contains
     index_o2x_Faoo_fdms_ocn = mct_avect_indexra(o2x,'Faoo_fdms_ocn',perrWith='quiet')
     index_o2x_So_ssh        = mct_avect_indexra(o2x,'So_ssh')
 
-    index_o2x_Foxo_ismw     = mct_avect_indexra(o2x,'Foxo_ismw')
-    index_o2x_Foxo_rrofl    = mct_avect_indexra(o2x,'Foxo_rrofl')
-    index_o2x_Foxo_rrofi    = mct_avect_indexra(o2x,'Foxo_rrofi')
+    index_o2x_Foxo_ismw     = mct_avect_indexra(o2x,'Foxo_ismw',perrWith='quiet')
+    index_o2x_Foxo_rrofl    = mct_avect_indexra(o2x,'Foxo_rrofl',perrWith='quiet')
+    index_o2x_Foxo_rrofi    = mct_avect_indexra(o2x,'Foxo_rrofi',perrWith='quiet')
 
-    index_o2x_Foxo_ismh     = mct_avect_indexra(o2x,'Foxo_ismh')
-    index_o2x_Foxo_rrofih   = mct_avect_indexra(o2x,'Foxo_rrofih')
+    index_o2x_Foxo_ismh     = mct_avect_indexra(o2x,'Foxo_ismh',perrWith='quiet')
+    index_o2x_Foxo_rrofih   = mct_avect_indexra(o2x,'Foxo_rrofih',perrWith='quiet')
 
     index_o2x_So_blt        = mct_avect_indexra(o2x,'So_blt')
     index_o2x_So_bls        = mct_avect_indexra(o2x,'So_bls')

--- a/components/mpas-ocean/driver/mpaso_cpl_indices.F
+++ b/components/mpas-ocean/driver/mpaso_cpl_indices.F
@@ -22,7 +22,11 @@ module mpaso_cpl_indices
   integer :: index_o2x_Faoo_fco2_ocn
   integer :: index_o2x_Faoo_fdms_ocn
   integer :: index_o2x_So_ssh
-
+  integer :: index_o2x_Foxo_ismw
+  integer :: index_o2x_Foxo_rrofl
+  integer :: index_o2x_Foxo_rrofi
+  integer :: index_o2x_Foxo_ismh
+  integer :: index_o2x_Foxo_rrofih
 
   ! ocn -> drv for calculation of ocean-ice sheet interactions
 
@@ -187,6 +191,13 @@ contains
     index_o2x_Faoo_fco2_ocn = mct_avect_indexra(o2x,'Faoo_fco2_ocn',perrWith='quiet')
     index_o2x_Faoo_fdms_ocn = mct_avect_indexra(o2x,'Faoo_fdms_ocn',perrWith='quiet')
     index_o2x_So_ssh        = mct_avect_indexra(o2x,'So_ssh')
+
+    index_o2x_Foxo_ismw     = mct_avect_indexra(o2x,'Foxo_ismw')
+    index_o2x_Foxo_rrofl    = mct_avect_indexra(o2x,'Foxo_rrofl')
+    index_o2x_Foxo_rrofi    = mct_avect_indexra(o2x,'Foxo_rrofi')
+
+    index_o2x_Foxo_ismh     = mct_avect_indexra(o2x,'Foxo_ismh')
+    index_o2x_Foxo_rrofih   = mct_avect_indexra(o2x,'Foxo_rrofih')
 
     index_o2x_So_blt        = mct_avect_indexra(o2x,'So_blt')
     index_o2x_So_bls        = mct_avect_indexra(o2x,'So_bls')

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -2882,6 +2882,10 @@ contains
 
              o2x_o % rAttr(index_o2x_Fioo_q, n)  = 0.0_RKIND
              o2x_o % rAttr(index_o2x_Fioo_frazil, n) = 0.0_RKIND
+             if (trim(config_land_ice_flux_mode) == 'standalone' .or. trim(config_land_ice_flux_mode) == 'data') then
+                o2x_o % rAttr(index_o2x_Foxo_q_li, n) = accumulatedFrazilIceMass(i) * config_frazil_heat_of_fusion / ocn_cpl_dt
+                o2x_o % rAttr(index_o2x_Foxo_frazil_li, n) = accumulatedFrazilIceMass(i) / ocn_cpl_dt
+             endif
 
           end if
 
@@ -4084,7 +4088,7 @@ contains
             call mpas_pool_get_array(statePool, 'accumulatedFrazilIceMass', accumulatedFrazilIceMass, 1)
          end if
 
-        if (trim(config_land_ice_flux_mode == 'standalone') .or. trim(config_land_ice_flux_mode) == 'data') then
+        if (trim(config_land_ice_flux_mode) == 'standalone' .or. trim(config_land_ice_flux_mode) == 'data') then
            call mpas_pool_get_array(forcingPool, 'avgLandIceFreshwaterFlux', avgLandIceFreshwaterFlux)
            call mpas_pool_get_array(forcingPool, 'avgLandIceHeatFlux', avgLandIceHeatFlux)
         endif
@@ -4145,7 +4149,7 @@ contains
    
             o2x_om(n, index_o2x_Faoo_h2otemp) = avgTotalFreshWaterTemperatureFlux(i) * rho_sw * cp_sw
 
-            if (trim(config_land_ice_flux_mode == 'standalone') .or. trim(config_land_ice_flux_mode) == 'data') then
+            if (trim(config_land_ice_flux_mode) == 'standalone' .or. trim(config_land_ice_flux_mode) == 'data') then
                o2x_om(n, index_o2x_Foxo_ismw)  = avgLandIceFreshwaterFlux(i)
                o2x_om(n, index_o2x_Foxo_ismh)  = avgLandIceHeatFlux(i)
             endif
@@ -4190,7 +4194,10 @@ contains
    
                   o2x_om(n, index_o2x_Fioo_q)      = 0.0_RKIND
                   o2x_om(n, index_o2x_Fioo_frazil) = 0.0_RKIND
-   
+                  if (trim(config_land_ice_flux_mode) == 'standalone' .or. trim(config_land_ice_flux_mode) == 'data') then
+                     o2x_om(n, index_o2x_Foxo_q_li)      = accumulatedFrazilIceMass(i) * config_frazil_heat_of_fusion / ocn_cpl_dt
+                     o2x_om(n, index_o2x_Foxo_frazil_li) = accumulatedFrazilIceMass(i) / ocn_cpl_dt
+                  endif
                end if
    
                ! Reset SeaIce Energy and Accumulated Frazil Ice

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -689,7 +689,6 @@ contains
    if ( ierr /= 0 ) then
       write(ocnLogUnit,*) 'Fail to set define dom fields '
    endif
-
    ent_type = 1 ! cells
       
 

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -689,6 +689,7 @@ contains
    if ( ierr /= 0 ) then
       write(ocnLogUnit,*) 'Fail to set define dom fields '
    endif
+
    ent_type = 1 ! cells
       
 
@@ -2700,7 +2701,12 @@ contains
                                                avgOceanSurfaceDOCSemiLabile, &
                                                avgOceanSurfaceFeParticulate, &
                                                avgOceanSurfaceFeDissolved, &
-                                               ssh
+                                               ssh, &
+                                               avgLandIceFreshwaterFlux, &
+                                               avgRemovedRiverRunoffFlux, &
+                                               avgRemovedIceRunoffFlux, &
+                                               avgLandIceHeatFlux, &
+                                               avgRemovedIceRunoffHeatFlux
 
    real (kind=RKIND), dimension(:,:), pointer :: avgTracersSurfaceValue, avgSurfaceVelocity, &
                                                  avgSSHGradient, avgOceanSurfacePhytoC, &
@@ -2709,6 +2715,7 @@ contains
    real (kind=RKIND) :: surfaceFreezingTemp
 
    logical, pointer :: frazilIceActive,          &
+                       config_remove_AIS_coupler_runoff, &
                        config_use_ecosysTracers, &
                        config_use_DMSTracers,    &
                        config_use_MacroMoleculesTracers,  &
@@ -2725,6 +2732,7 @@ contains
    call mpas_pool_get_package(domain % packages, 'frazilIceActive', frazilIceActive)
    call mpas_pool_get_config(domain % configs, 'config_use_ecosysTracers', config_use_ecosysTracers)
    call mpas_pool_get_config(domain % configs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
+   call mpas_pool_get_config(domain % configs, 'config_remove_AIS_coupler_runoff', config_remove_AIS_coupler_runoff)
    call mpas_pool_get_config(domain % configs, 'config_use_DMSTracers', config_use_DMSTracers)
    call mpas_pool_get_config(domain % configs, 'config_use_MacroMoleculesTracers', config_use_MacroMoleculesTracers)
    call mpas_pool_get_config(domain % configs, 'config_use_ecosysTracers_sea_ice_coupling',  &
@@ -2766,6 +2774,17 @@ contains
         call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
         call mpas_pool_get_array(statePool, 'accumulatedFrazilIceMass', accumulatedFrazilIceMass, 1)
      end if
+
+     ! Cryo fields
+     if (trim(config_land_ice_flux_mode) == 'standalone' .or. trim(config_land_ice_flux_mode) == 'data') then
+        call mpas_pool_get_array(forcingPool, 'avgLandIceFreshwaterFlux', avgLandIceFreshwaterFlux)
+        call mpas_pool_get_array(forcingPool, 'avgLandIceHeatFlux', avgLandIceHeatFlux)
+     endif
+     if (config_remove_AIS_coupler_runoff) then
+        call mpas_pool_get_array(forcingPool, 'avgRemovedRiverRunoffFlux', avgRemovedRiverRunoffFlux)
+        call mpas_pool_get_array(forcingPool, 'avgRemovedIceRunoffFlux', avgRemovedIceRunoffFlux)
+        call mpas_pool_get_array(forcingPool, 'avgRemovedIceRunoffHeatFlux', avgRemovedIceRunoffHeatFlux)
+     endif
 
      ! BGC fields
      if (config_use_ecosysTracers) then
@@ -2817,6 +2836,17 @@ contains
        o2x_o % rAttr(index_o2x_So_dhdy, n) = avgSSHGradient(index_avgMeridionalSSHGradient, i)
 
        o2x_o % rAttr(index_o2x_Faoo_h2otemp, n) = avgTotalFreshWaterTemperatureFlux(i) * rho_sw * cp_sw
+
+       ! Cryo fields
+       if (trim(config_land_ice_flux_mode) == 'standalone' .or. trim(config_land_ice_flux_mode) == 'data') then
+          o2x_o % rAttr(index_o2x_Foxo_ismw, n)  = avgLandIceFreshwaterFlux(i)
+          o2x_o % rAttr(index_o2x_Foxo_ismh, n)  = avgLandIceHeatFlux(i)
+       endif
+       if (config_remove_AIS_coupler_runoff) then
+          o2x_o % rAttr(index_o2x_Foxo_rrofl, n) = avgRemovedRiverRunoffFlux(i)
+          o2x_o % rAttr(index_o2x_Foxo_rrofi, n) = avgRemovedIceRunoffFlux(i)
+          o2x_o % rAttr(index_o2x_Foxo_rrofih, n) = avgRemovedIceRunoffHeatFlux(i)
+       endif
 
        if ( frazilIceActive ) then
           ! negative when frazil ice can be melted
@@ -3981,7 +4011,12 @@ contains
                                                    avgOceanSurfaceDOCSemiLabile, &
                                                    avgOceanSurfaceFeParticulate, &
                                                    avgOceanSurfaceFeDissolved, &
-                                                   ssh
+                                                   ssh, &
+                                                   avgLandIceFreshwaterFlux, &
+                                                   avgRemovedRiverRunoffFlux, &
+                                                   avgRemovedIceRunoffFlux, &
+                                                   avgLandIceHeatFlux, &
+                                                   avgRemovedIceRunoffHeatFlux
    
       real (kind=RKIND), dimension(:,:), pointer :: avgTracersSurfaceValue, avgSurfaceVelocity, &
                                                       avgSSHGradient, avgOceanSurfacePhytoC, &
@@ -3990,6 +4025,7 @@ contains
       real (kind=RKIND) :: surfaceFreezingTemp
    
       logical, pointer :: frazilIceActive,          &
+                           config_remove_AIS_coupler_runoff, &
                            config_use_ecosysTracers, &
                            config_use_DMSTracers,    &
                            config_use_MacroMoleculesTracers,  &
@@ -4006,6 +4042,7 @@ contains
       call mpas_pool_get_package(domain % packages, 'frazilIceActive', frazilIceActive)
       call mpas_pool_get_config(domain % configs, 'config_use_ecosysTracers', config_use_ecosysTracers)
       call mpas_pool_get_config(domain % configs, 'config_land_ice_flux_mode', config_land_ice_flux_mode)
+      call mpas_pool_get_config(domain % configs, 'config_remove_AIS_coupler_runoff', config_remove_AIS_coupler_runoff)
       call mpas_pool_get_config(domain % configs, 'config_use_DMSTracers', config_use_DMSTracers)
       call mpas_pool_get_config(domain % configs, 'config_use_MacroMoleculesTracers', config_use_MacroMoleculesTracers)
       call mpas_pool_get_config(domain % configs, 'config_use_ecosysTracers_sea_ice_coupling',  &
@@ -4047,6 +4084,16 @@ contains
             call mpas_pool_get_array(forcingPool, 'frazilSurfacePressure', frazilSurfacePressure)
             call mpas_pool_get_array(statePool, 'accumulatedFrazilIceMass', accumulatedFrazilIceMass, 1)
          end if
+
+        if (trim(config_land_ice_flux_mode == 'standalone') .or. trim(config_land_ice_flux_mode) == 'data') then
+           call mpas_pool_get_array(forcingPool, 'avgLandIceFreshwaterFlux', avgLandIceFreshwaterFlux)
+           call mpas_pool_get_array(forcingPool, 'avgLandIceHeatFlux', avgLandIceHeatFlux)
+        endif
+        if (config_remove_AIS_coupler_runoff) then
+           call mpas_pool_get_array(forcingPool, 'avgRemovedRiverRunoffFlux', avgRemovedRiverRunoffFlux)
+           call mpas_pool_get_array(forcingPool, 'avgRemovedIceRunoffFlux', avgRemovedIceRunoffFlux)
+           call mpas_pool_get_array(forcingPool, 'avgRemovedIceRunoffHeatFlux', avgRemovedIceRunoffHeatFlux)
+        endif
    
          ! BGC fields
          if (config_use_ecosysTracers) then
@@ -4098,7 +4145,17 @@ contains
             o2x_om(n, index_o2x_So_dhdy) = avgSSHGradient(index_avgMeridionalSSHGradient, i)
    
             o2x_om(n, index_o2x_Faoo_h2otemp) = avgTotalFreshWaterTemperatureFlux(i) * rho_sw * cp_sw
-   
+
+            if (trim(config_land_ice_flux_mode == 'standalone') .or. trim(config_land_ice_flux_mode) == 'data') then
+               o2x_om(n, index_o2x_Foxo_ismw)  = avgLandIceFreshwaterFlux(i)
+               o2x_om(n, index_o2x_Foxo_ismh)  = avgLandIceHeatFlux(i)
+            endif
+            if (config_remove_AIS_coupler_runoff) then
+               o2x_om(n, index_o2x_Foxo_rrofl) = avgRemovedRiverRunoffFlux(i)
+               o2x_om(n, index_o2x_Foxo_rrofi) = avgRemovedIceRunoffFlux(i)
+               o2x_om(n, index_o2x_Foxo_rrofih) = avgRemovedIceRunoffHeatFlux(i)
+            endif
+
             if ( frazilIceActive ) then
                ! negative when frazil ice can be melted
                keepFrazil = .true.

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -3608,6 +3608,7 @@
 			 packages="activeTracersBulkRestoringPKG;thicknessBulkPKG"
 		/>
 
+
 		<!-- Misc. coupling fields -->
 		<var name="iceFraction" type="real" dimensions="nCells Time" units="fractional"
 			 description="Fraction of sea ice coverage at cell centers from coupler. Positive into the ocean."
@@ -3688,6 +3689,21 @@
 		</var_array>
 		<var name="avgTotalFreshWaterTemperatureFlux" type="real" dimensions="nCells Time" units="C m s^-1"
 			 description="Sum of heat fluxes associated with water fluxes cell centers sent to coupler. Positive into the ocean."
+		/>
+		<var name="avgLandIceFreshwaterFlux" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
+		         description="Time-averaged sum of freshwater fluxes associated with ice shelf basal melt fluxes cell centers sent to coupler. Positive into the ocean."
+		/>
+		<var name="avgLandIceHeatFlux" type="real" dimensions="nCells Time" units="W m^-2"
+			 description="Time-averaged sum of heat fluxes associated with ice shelf basal melt fluxes cell centers sent to coupler. Positive into the ocean."
+		/>
+		<var name="avgRemovedRiverRunoffFlux" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
+			 description="Time-averaged sum of freshwater fluxes associated with removed liquid runoff fluxes cell centers sent to coupler. Positive into the ocean."
+		/>
+		<var name="avgRemovedIceRunoffFlux" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
+			 description="Time-averaged sum of freshwater fluxes associated with removed ice runoff fluxes cell centers sent to coupler. Positive into the ocean."
+	        />
+		<var name="avgRemovedIceRunoffHeatFlux" type="real" dimensions="nCells Time" units="W m^-2"
+			 description="Time-averaged sum of heat fluxes associated with removed ice runoff fluxes cell centers sent to coupler. Positive into the ocean."
 		/>
 
 		<!-- Input fields from coupler or initial condition for forcing under land ice -->

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -954,8 +954,12 @@
 					possible_values="Any positive real number."
 		/>
 		<nml_option name="config_frazil_sea_ice_reference_salinity" type="real" default_value="4.0" units="1.e-3"
-					description="assumed salinity of frazil ice in the open ocean. Land ice frazil salinity is always 0."
+					description="assumed salinity of frazil ice in the open ocean."
 					possible_values="Any positive real number."
+		/>
+		<nml_option name="config_frazil_land_ice_reference_salinity" type="real" default_value="0.0" units="1.e-3"
+					description="assumed salinity of frazil ice under land ice."
+					possible_values="Any non-negative real number."
 		/>
 		<nml_option name="config_frazil_maximum_freezing_temperature" type="real" default_value="0.0" units="C"
 			description="Maximum freezing temperature for the creation of frazil"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -954,12 +954,8 @@
 					possible_values="Any positive real number."
 		/>
 		<nml_option name="config_frazil_sea_ice_reference_salinity" type="real" default_value="4.0" units="1.e-3"
-					description="assumed salinity of frazil ice in the open ocean."
+					description="assumed salinity of frazil ice in the open ocean. Land ice frazil salinity is always 0."
 					possible_values="Any positive real number."
-		/>
-		<nml_option name="config_frazil_land_ice_reference_salinity" type="real" default_value="0.0" units="1.e-3"
-					description="assumed salinity of frazil ice under land ice."
-					possible_values="Any non-negative real number."
 		/>
 		<nml_option name="config_frazil_maximum_freezing_temperature" type="real" default_value="0.0" units="C"
 			description="Maximum freezing temperature for the creation of frazil"

--- a/components/mpas-ocean/src/analysis_members/Registry_conservation_check.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_conservation_check.xml
@@ -129,43 +129,43 @@
 		<var name="relativeMassError" type="real" dimensions="Time" units="1"
 			description="Relative mass conservation error"
 		/>
-		<var name="accumulatedRainFlux" type="real" dimensions="Time" units="kg s^-1"
+		<var name="accumulatedRainFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
 			 description="Fresh water flux from rain from coupler. Positive into the ocean."
 		/>
-		<var name="accumulatedSnowFlux" type="real" dimensions="Time" units="kg s^-1"
+		<var name="accumulatedSnowFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
 			 description="Fresh water flux from snow from coupler. Positive into the ocean."
 		/>
-		<var name="accumulatedEvaporationFlux" type="real" dimensions="Time" units="kg s^-1"
+		<var name="accumulatedEvaporationFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
 			 description="Evaporation flux from coupler. Positive into the ocean."
 		/>
-		<var name="accumulatedSeaIceFlux" type="real" dimensions="Time" units="kg s^-1"
+		<var name="accumulatedSeaIceFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
 			 description="Fresh water flux from sea ice from coupler. Positive into the ocean."
 		/>
-		<var name="accumulatedRiverRunoffFlux" type="real" dimensions="Time" units="kg s^-1"
+		<var name="accumulatedRiverRunoffFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
 			 description="Fresh water flux from river runoff from coupler. Positive into the ocean."
 			 packages="thicknessBulkPKG"
 		/>
-		<var name="accumulatedIceRunoffFlux" type="real" dimensions="Time" units="kg s^-1"
+		<var name="accumulatedIceRunoffFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
 			 description="Fresh water flux from ice runoff from coupler. Positive into the ocean."
 		/>
-		<var name="accumulatedRemovedRiverRunoffFlux" type="real" dimensions="Time" units="kg s^-1"
+		<var name="accumulatedRemovedRiverRunoffFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
 			 description="Fresh water flux from river runoff from the coupler that was removed due to config_remove_AIS_coupler_runoff option. Positive into the ocean."
 			 packages="thicknessBulkPKG"
 		/>
-		<var name="accumulatedRemovedIceRunoffFlux" type="real" dimensions="Time" units="kg s^-1"
+		<var name="accumulatedRemovedIceRunoffFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
 			 description="Fresh water flux from ice runoff from the coupler that was removed due to config_remove_AIS_coupler_runoff option. Positive into the ocean."
 			 packages="thicknessBulkPKG;activeTracersBulkRestoringPKG"
 		/>
-		<var name="accumulatedIcebergFlux" type="real" dimensions="Time" units="kg s^-1"
+		<var name="accumulatedIcebergFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
 			 description="Fresh water flux from iceberg melt from coupler. Positive into the ocean."
 		/>
-		<var name="accumulatedFrazilFlux" type="real" dimensions="Time" units="kg s^-1"
+		<var name="accumulatedFrazilFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
 			 description="Fresh water flux from frazil freezing under sea ice. Positive into the ocean."
 		/>
-		<var name="accumulatedLandIceFlux" type="real" dimensions="Time" units="kg s^-1"
+		<var name="accumulatedLandIceFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
 			 description="Fresh water flux from land ice melt from coupler. Positive into the ocean."
 		/>
-		<var name="accumulatedLandIceFrazilFlux" type="real" dimensions="Time" units="kg s^-1"
+		<var name="accumulatedLandIceFrazilFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
 			 description="Fresh water flux from frazil freezing under land ice. Positive into the ocean."
 		/>
 	</var_struct>

--- a/components/mpas-ocean/src/analysis_members/Registry_conservation_check.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_conservation_check.xml
@@ -129,43 +129,43 @@
 		<var name="relativeMassError" type="real" dimensions="Time" units="1"
 			description="Relative mass conservation error"
 		/>
-		<var name="accumulatedRainFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedRainFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Fresh water flux from rain from coupler. Positive into the ocean."
 		/>
-		<var name="accumulatedSnowFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedSnowFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Fresh water flux from snow from coupler. Positive into the ocean."
 		/>
-		<var name="accumulatedEvaporationFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedEvaporationFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Evaporation flux from coupler. Positive into the ocean."
 		/>
-		<var name="accumulatedSeaIceFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedSeaIceFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Fresh water flux from sea ice from coupler. Positive into the ocean."
 		/>
-		<var name="accumulatedRiverRunoffFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedRiverRunoffFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Fresh water flux from river runoff from coupler. Positive into the ocean."
 			 packages="thicknessBulkPKG"
 		/>
-		<var name="accumulatedIceRunoffFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedIceRunoffFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Fresh water flux from ice runoff from coupler. Positive into the ocean."
 		/>
-		<var name="accumulatedRemovedRiverRunoffFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedRemovedRiverRunoffFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Fresh water flux from river runoff from the coupler that was removed due to config_remove_AIS_coupler_runoff option. Positive into the ocean."
 			 packages="thicknessBulkPKG"
 		/>
-		<var name="accumulatedRemovedIceRunoffFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedRemovedIceRunoffFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Fresh water flux from ice runoff from the coupler that was removed due to config_remove_AIS_coupler_runoff option. Positive into the ocean."
 			 packages="thicknessBulkPKG;activeTracersBulkRestoringPKG"
 		/>
-		<var name="accumulatedIcebergFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedIcebergFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Fresh water flux from iceberg melt from coupler. Positive into the ocean."
 		/>
-		<var name="accumulatedFrazilFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedFrazilFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Fresh water flux from frazil freezing under sea ice. Positive into the ocean."
 		/>
-		<var name="accumulatedLandIceFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedLandIceFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Fresh water flux from land ice melt from coupler. Positive into the ocean."
 		/>
-		<var name="accumulatedLandIceFrazilFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
+		<var name="accumulatedLandIceFrazilFlux" type="real" dimensions="Time" units="kg s^-1"
 			 description="Fresh water flux from frazil freezing under land ice. Positive into the ocean."
 		/>
 	</var_struct>

--- a/components/mpas-ocean/src/analysis_members/Registry_conservation_check.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_conservation_check.xml
@@ -192,10 +192,7 @@
 			 description="Sea ice salinity flux from coupler. Positive into the ocean."
 		/>
 		<var name="accumulatedFrazilSalinityFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
-			 description="Salinity flux from frazil to sea ice, given to coupler. Positive into the ocean."
-		/>
-		<var name="accumulatedLandIceFrazilSalinityFlux" type="real" dimensions="Time" units="kg m^-2 s^-1"
-			 description="Salinity flux from frazil to Land Ice, given to coupler. Positive into the ocean."
+			 description="Salinity flux from frazil to sea ice, given to coupler. Land ice does not contribute because its frazil salinity is assumed 0. Positive into the ocean."
 		/>
 	</var_struct>
             <var_struct name="conservationCheckCarbonAM" time_levs="1" packages="conservationCheckAMPKG">
@@ -305,7 +302,6 @@
             <var name="accumulatedLandIceFrazilFlux"/>
             <var name="accumulatedSeaIceSalinityFlux"/>
             <var name="accumulatedFrazilSalinityFlux"/>
-            <var name="accumulatedLandIceFrazilSalinityFlux"/>
             <var name="initialCarbon"/>
             <var name="finalCarbon"/>
             <var name="carbonChange"/>
@@ -362,7 +358,6 @@
             <var name="accumulatedLandIceFrazilFlux"/>
             <var name="accumulatedSeaIceSalinityFlux"/>
             <var name="accumulatedFrazilSalinityFlux"/>
-            <var name="accumulatedLandIceFrazilSalinityFlux"/>
             <var name="initialCarbon"/>
             <var name="accumulatedAbsoluteCarbonError"/>
             <var name="accumulatedRelativeCarbonError"/>

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_conservation_check.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_conservation_check.F
@@ -1162,8 +1162,8 @@ v=accumulatedLandIceFrazilFlux     ; write(m,"('  landIceFrazilFlux    ',es16.8,
 
       real(kind=RKIND), pointer :: &
            accumulatedSeaIceSalinityFlux, &
-           accumulatedFrazilSalinityFlux, &
-           accumulatedLandIceFrazilSalinityFlux
+           accumulatedFrazilSalinityFlux
+           ! accumulatedLandIceFrazilSalinityFlux is not present because it is always 0
 
       real(kind=RKIND), dimension(:), allocatable :: &
            sumArray, &
@@ -1209,7 +1209,6 @@ v=accumulatedLandIceFrazilFlux     ; write(m,"('  landIceFrazilFlux    ',es16.8,
 
       call MPAS_pool_get_array(conservationCheckSaltAMPool, "accumulatedSeaIceSalinityFlux", accumulatedSeaIceSalinityFlux)
       call MPAS_pool_get_array(conservationCheckSaltAMPool, "accumulatedFrazilSalinityFlux", accumulatedFrazilSalinityFlux)
-      call MPAS_pool_get_array(conservationCheckSaltAMPool, "accumulatedLandIceFrazilSalinityFlux", accumulatedLandIceFrazilSalinityFlux)
 
       !-------------------------------------------------------------
       ! Net salt flux to ice
@@ -1251,11 +1250,9 @@ v=accumulatedLandIceFrazilFlux     ; write(m,"('  landIceFrazilFlux    ',es16.8,
             end if
 
             if (config_use_frazil_ice_formation .and. config_frazil_under_land_ice) then
-               call mpas_pool_get_array(statePool, 'accumulatedLandIceFrazilMass', accumulatedLandIceFrazilMassOld, 1)
-               call mpas_pool_get_array(statePool, 'accumulatedLandIceFrazilMass', accumulatedLandIceFrazilMassNew, 2)
+               ! Land ice frazil salinity is always 0
                do iCell = 1, nCellsSolve
-                  sumArray(3) = sumArray(3) + areaCell(iCell) &
-                                 * (accumulatedLandIceFrazilMassNew(iCell) - accumulatedLandIceFrazilMassOld(iCell))/dt
+                  sumArray(3) = sumArray(3) + 0.0_RKIND
                enddo
             end if
 
@@ -1268,7 +1265,6 @@ v=accumulatedLandIceFrazilFlux     ; write(m,"('  landIceFrazilFlux    ',es16.8,
          ! accumulate fluxes
          accumulatedSeaIceSalinityFlux = accumulatedSeaIceSalinityFlux + sumArrayOut(1)
          accumulatedFrazilSalinityFlux = accumulatedFrazilSalinityFlux + sumArrayOut(2)
-         accumulatedLandIceFrazilSalinityFlux = accumulatedLandIceFrazilSalinityFlux + sumArrayOut(3)
 
          ! cleanup
          deallocate(sumArray)
@@ -1285,7 +1281,6 @@ v=accumulatedLandIceFrazilFlux     ; write(m,"('  landIceFrazilFlux    ',es16.8,
          ! Average the fluxes
          accumulatedSeaIceSalinityFlux = accumulatedSeaIceSalinityFlux /accumulatedFluxCounter
          accumulatedFrazilSalinityFlux = accumulatedFrazilSalinityFlux /accumulatedFluxCounter
-         accumulatedLandIceFrazilSalinityFlux = accumulatedLandIceFrazilSalinityFlux /accumulatedFluxCounter
 
          ! get initial salt content
          call MPAS_pool_get_array(conservationCheckSaltAMPool, "initialSalt", initialSalt)
@@ -1302,8 +1297,7 @@ v=accumulatedLandIceFrazilFlux     ; write(m,"('  landIceFrazilFlux    ',es16.8,
          call MPAS_pool_get_array(conservationCheckSaltAMPool, "netSaltFlux", netSaltFlux)
 
          netSaltFlux = accumulatedSeaIceSalinityFlux &
-                     + accumulatedFrazilSalinityFlux &
-                     + accumulatedLandIceFrazilSalinityFlux
+                     + accumulatedFrazilSalinityFlux
 
          ! compute the final salt error
          call MPAS_pool_get_array(conservationCheckSaltAMPool, "absoluteSaltError", absoluteSaltError)
@@ -1331,7 +1325,7 @@ v=accumulatedSeaIceSalinityFlux    ; write(m,"('seaIceSalinityFlux     ',es16.8,
             if (landIceFreshwaterFluxesOn &
                .and.config_use_frazil_ice_formation &
                .and.config_frazil_under_land_ice) then
-v=accumulatedLandIceFrazilSalinityFlux; write(m,"('LandIceFrazilSalinityFlux',es16.8,' (already in wmelt, do not sum)                  ',f16.8)") v,v*c; call mpas_log_write(m); !no sum: s=s+v
+v=0; write(m,"('LandIceFrazilSalinityFlux',es16.8,' (already in wmelt, do not sum)                  ',f16.8)") v,v*c; call mpas_log_write(m); !no sum: s=s+v
             end if
 
                                      write(m,"('SUM VOLUME FLUXES      ',es16.8,'                                 ',f16.8,es16.8)") s, s*c; call mpas_log_write(m)
@@ -2256,8 +2250,7 @@ v=accumulatedLandIceFrazilSalinityFlux; write(m,"('LandIceFrazilSalinityFlux',es
 
       real(kind=RKIND), pointer :: &
            accumulatedSeaIceSalinityFlux, &
-           accumulatedFrazilSalinityFlux, &
-           accumulatedLandIceFrazilSalinityFlux
+           accumulatedFrazilSalinityFlux
 
       real(kind=RKIND), pointer :: &
            accumulatedCarbonSourceSink, &
@@ -2343,11 +2336,9 @@ v=accumulatedLandIceFrazilSalinityFlux; write(m,"('LandIceFrazilSalinityFlux',es
 
       call MPAS_pool_get_array(conservationCheckSaltAMPool, "accumulatedSeaIceSalinityFlux", accumulatedSeaIceSalinityFlux)
       call MPAS_pool_get_array(conservationCheckSaltAMPool, "accumulatedFrazilSalinityFlux", accumulatedFrazilSalinityFlux)
-      call MPAS_pool_get_array(conservationCheckSaltAMPool, "accumulatedLandIceFrazilSalinityFlux", accumulatedLandIceFrazilSalinityFlux)
 
       accumulatedSeaIceSalinityFlux = 0.0_RKIND
       accumulatedFrazilSalinityFlux = 0.0_RKIND
-      accumulatedLandIceFrazilSalinityFlux = 0.0_RKIND
 
       call MPAS_pool_get_subpool(domain % blocklist % structs, "conservationCheckCarbonAM", conservationCheckCarbonAMPool)
 

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_conservation_check.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_conservation_check.F
@@ -598,16 +598,14 @@ contains
                enddo
             end if
 
-            if (landIceFreshwaterFluxesOn &
-               .and.config_use_frazil_ice_formation &
-               .and.config_frazil_under_land_ice) then
+            if (config_use_frazil_ice_formation .and. config_frazil_under_land_ice) then
                call mpas_pool_get_array(statePool, 'accumulatedLandIceFrazilMass', accumulatedLandIceFrazilMassOld, 1)
                call mpas_pool_get_array(statePool, 'accumulatedLandIceFrazilMass', accumulatedLandIceFrazilMassNew, 2)
                do iCell = 1, nCellsSolve
                   ! Frazil ice mass is negative. Negative coefficient makes heat
                   ! flux positive, because freezing ice releases heat.
                   sumArray(18) = sumArray(18) - areaCell(iCell) * config_frazil_heat_of_fusion &
-                                 * (accumulatedLandIceFrazilMassNew(iCell) - accumulatedLandIceFrazilMassOld(iCell))
+                                 * (accumulatedLandIceFrazilMassNew(iCell) - accumulatedLandIceFrazilMassOld(iCell))/dt
                enddo
             end if
 
@@ -748,9 +746,7 @@ v=accumulatedIcebergHeatFlux         ; write(m,"('icebergHeatFlux          ',es1
             if (landIceFreshwaterFluxesOn) then
 v=accumulatedLandIceHeatFlux         ; write(m,"('landIceHeatFlux          ',es16.8,'                                 ',f16.8)") v,v/A; call mpas_log_write(m); s=s+v
             end if
-            if (landIceFreshwaterFluxesOn &
-               .and.config_use_frazil_ice_formation &
-               .and.config_frazil_under_land_ice) then
+            if (config_use_frazil_ice_formation .and. config_frazil_under_land_ice) then
 v=accumulatedLandIceFrazilHeatFlux   ; write(m,"('   landIceFrazilHeatFlux ',es16.8,' (already in hfreeze, do not sum                )',f16.8)") v,v/A; call mpas_log_write(m); ! no sum: s=s+v
             end if
                                        write(m,"('SUM EXPLICIT HEAT FLUXES ',es16.8,'                                 ',f16.8)") s, s/A; call mpas_log_write(m)
@@ -976,9 +972,7 @@ v=accumulatedIcebergTemperatureFlux*rho_sw*cp_sw; write(m,"('IcebergTemperatureF
                enddo
             end if
 
-            if (landIceFreshwaterFluxesOn &
-               .and.config_use_frazil_ice_formation &
-               .and.config_frazil_under_land_ice) then
+            if (config_use_frazil_ice_formation .and. config_frazil_under_land_ice) then
                call mpas_pool_get_array(statePool, 'accumulatedLandIceFrazilMass', accumulatedLandIceFrazilMassOld, 1)
                call mpas_pool_get_array(statePool, 'accumulatedLandIceFrazilMass', accumulatedLandIceFrazilMassNew, 2)
                do iCell = 1, nCellsSolve
@@ -1101,9 +1095,7 @@ v=accumulatedIceRunoffFlux+accumulatedRemovedIceRunoffFlux;
                                      write(m,"('      SUM: ice runoff  ',es16.8,' x2o_Foxx_rofi    wfrzrof SUM                    ',f16.8)") v,v*c; call mpas_log_write(m)
 v=accumulatedLandIceFlux           ; write(m,"('landIceFreshwaterFlux  ',es16.8,'                                 ',f16.8)") v,v*c; call mpas_log_write(m); s=s+v
             endif
-            if (landIceFreshwaterFluxesOn &
-               .and.config_use_frazil_ice_formation &
-               .and.config_frazil_under_land_ice) then
+            if (config_use_frazil_ice_formation .and. config_frazil_under_land_ice) then
 v=accumulatedLandIceFrazilFlux     ; write(m,"('  landIceFrazilFlux    ',es16.8,' (already in wfreeze, do not sum                )',f16.8)") v,v*c; call mpas_log_write(m); ! no sum: s=s+v
             endif
                                      write(m,"('SUM VOLUME FLUXES      ',es16.8,'                                 ',f16.8,es16.8)") s, s*c; call mpas_log_write(m)
@@ -1258,9 +1250,7 @@ v=accumulatedLandIceFrazilFlux     ; write(m,"('  landIceFrazilFlux    ',es16.8,
                enddo
             end if
 
-            if (landIceFreshwaterFluxesOn &
-               .and.config_use_frazil_ice_formation &
-               .and.config_frazil_under_land_ice) then
+            if (config_use_frazil_ice_formation .and. config_frazil_under_land_ice) then
                call mpas_pool_get_array(statePool, 'accumulatedLandIceFrazilMass', accumulatedLandIceFrazilMassOld, 1)
                call mpas_pool_get_array(statePool, 'accumulatedLandIceFrazilMass', accumulatedLandIceFrazilMassNew, 2)
                do iCell = 1, nCellsSolve

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_conservation_check.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_conservation_check.F
@@ -2432,7 +2432,8 @@ v=accumulatedLandIceFrazilSalinityFlux; write(m,"('LandIceFrazilSalinityFlux',es
       err = 0
 
       if ( trim(config_land_ice_flux_mode) == 'standalone' .or. &
-           trim(config_land_ice_flux_mode) == 'coupled' ) then
+           trim(config_land_ice_flux_mode) == 'coupled' .or. &
+           trim(config_land_ice_flux_mode) == 'data' ) then
          landIceFreshwaterFluxesOn = .true.
       end if
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
@@ -618,7 +618,6 @@ contains
            ! for freshwater budgets
            accumulatedLandIceFrazilMassNew(iCell) = accumulatedLandIceFrazilMassOld(iCell) &
                                                   + sumNewFrazilIceThickness * config_frazil_ice_density
-           ! There is no accumulatedLandIceFrazilSalinity because it is always 0
         end if
 
       enddo   ! do iCell = 1, nCells

--- a/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
@@ -527,7 +527,7 @@ contains
 
             ! get frazil salinity
             if (underLandIce) then
-              frazilSalinity = config_frazil_land_ice_reference_salinity
+              frazilSalinity = 0.0_RKIND
             else
               frazilSalinity = config_frazil_sea_ice_reference_salinity
             end if
@@ -618,6 +618,7 @@ contains
            ! for freshwater budgets
            accumulatedLandIceFrazilMassNew(iCell) = accumulatedLandIceFrazilMassOld(iCell) &
                                                   + sumNewFrazilIceThickness * config_frazil_ice_density
+           ! There is no accumulatedLandIceFrazilSalinity because it is always 0
         end if
 
       enddo   ! do iCell = 1, nCells

--- a/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
@@ -527,7 +527,7 @@ contains
 
             ! get frazil salinity
             if (underLandIce) then
-              frazilSalinity = 0.0_RKIND
+              frazilSalinity = config_frazil_land_ice_reference_salinity
             else
               frazilSalinity = config_frazil_sea_ice_reference_salinity
             end if

--- a/components/mpas-ocean/src/shared/mpas_ocn_time_average_coupled.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_time_average_coupled.F
@@ -53,7 +53,10 @@ module ocn_time_average_coupled
         real (kind=RKIND), dimension(:,:), pointer :: avgTracersSurfaceValue, avgSurfaceVelocity, avgSSHGradient, &
                                                       avgLandIceBoundaryLayerTracers, avgLandIceTracerTransferVelocities
 
-        real (kind=RKIND), dimension(:), pointer :: avgEffectiveDensityInLandIce, avgTotalFreshWaterTemperatureFlux
+        real (kind=RKIND), dimension(:), pointer :: avgEffectiveDensityInLandIce, avgTotalFreshWaterTemperatureFlux, &
+                                                    avgLandIceFreshwaterFlux, &
+                                                    avgRemovedRiverRunoffFlux, avgRemovedIceRunoffFlux, &
+                                                    avgLandIceHeatFlux, avgRemovedIceRunoffHeatFlux
 
         integer :: iCell
         integer, pointer :: nAccumulatedCoupled, nCells
@@ -111,6 +114,37 @@ module ocn_time_average_coupled
               avgLandIceBoundaryLayerTracers(:, iCell) = 0.0_RKIND
               avgLandIceTracerTransferVelocities(:, iCell) = 0.0_RKIND
               avgEffectiveDensityInLandIce(iCell) = 0.0_RKIND
+           end do
+           !$omp end do
+           !$omp end parallel
+        end if
+
+        ! Set up polar fields if necessary
+        if(trim(config_land_ice_flux_mode)=='standalone' .or. trim(config_land_ice_flux_mode) == 'data') then
+           call mpas_pool_get_array(forcingPool, 'avgLandIceFreshwaterFlux', avgLandIceFreshwaterFlux)
+           call mpas_pool_get_array(forcingPool, 'avgLandIceHeatFlux', avgLandIceHeatFlux)
+
+           !$omp parallel
+           !$omp do schedule(runtime)
+           do iCell = 1, nCells
+              avgLandIceFreshwaterFlux(iCell) = 0.0_RKIND
+              avgLandIceHeatFlux(iCell) = 0.0_RKIND
+           end do
+           !$omp end do
+           !$omp end parallel
+        end if
+
+        if(config_remove_AIS_coupler_runoff) then
+           call mpas_pool_get_array(forcingPool, 'avgRemovedRiverRunoffFlux', avgRemovedRiverRunoffFlux)
+           call mpas_pool_get_array(forcingPool, 'avgRemovedIceRunoffFlux', avgRemovedIceRunoffFlux)
+           call mpas_pool_get_array(forcingPool, 'avgRemovedIceRunoffHeatFlux', avgRemovedIceRunoffHeatFlux)
+
+           !$omp parallel
+           !$omp do schedule(runtime)
+           do iCell = 1, nCells
+              avgRemovedRiverRunoffFlux(iCell) = 0.0_RKIND
+              avgRemovedIceRunoffFlux(iCell) = 0.0_RKIND
+              avgRemovedIceRunoffHeatFlux(iCell) = 0.0_RKIND
            end do
            !$omp end do
            !$omp end parallel
@@ -201,6 +235,9 @@ module ocn_time_average_coupled
 !
 !-----------------------------------------------------------------------
     subroutine ocn_time_average_coupled_accumulate(statePool, forcingPool, timeLevel)!{{{
+        use ocn_constants, only: &
+             latent_heat_fusion_mks
+
         type (mpas_pool_type), intent(in) :: statePool
         type (mpas_pool_type), intent(inout) :: forcingPool
         integer, intent(in) :: timeLevel
@@ -215,7 +252,12 @@ module ocn_time_average_coupled
         real (kind=RKIND), dimension(:,:), pointer :: &
                                                       avgLandIceBoundaryLayerTracers, avgLandIceTracerTransferVelocities
         real (kind=RKIND), dimension(:), pointer :: effectiveDensityInLandIce, avgEffectiveDensityInLandIce, &
-                                                    totalFreshWaterTemperatureFlux, avgTotalFreshWaterTemperatureFlux
+                                                    totalFreshWaterTemperatureFlux, avgTotalFreshWaterTemperatureFlux, &
+                                                    landIceFreshwaterFlux, avgLandIceFreshwaterFlux, &
+                                                    landIceHeatFlux, avgLandIceHeatFlux, &
+                                                    removedRiverRunoffFlux, avgRemovedRiverRunoffFlux, &
+                                                    removedIceRunoffFlux, avgRemovedIceRunoffFlux, &
+                                                    avgRemovedIceRunoffHeatFlux
 
         type (mpas_pool_type), pointer :: tracersPool
 
@@ -309,6 +351,48 @@ module ocn_time_average_coupled
            end do
            !$omp end do
            !$omp end parallel
+        end if
+
+        ! Accumulate polar fields if necessary
+        if(trim(config_land_ice_flux_mode) == 'standalone' .or. trim(config_land_ice_flux_mode) == 'data') then
+           call mpas_pool_get_array(forcingPool, 'avgLandIceFreshwaterFlux', avgLandIceFreshwaterFlux)
+           call mpas_pool_get_array(forcingPool, 'landIceFreshwaterFlux', landIceFreshwaterFlux)
+           call mpas_pool_get_array(forcingPool, 'avgLandIceHeatFlux', avgLandIceHeatFlux)
+           call mpas_pool_get_array(forcingPool, 'landIceHeatFlux', landIceHeatFlux)
+
+           !$omp parallel
+           !$omp do schedule(runtime)
+           do iCell = 1, nCells
+              avgLandIceFreshwaterFlux(iCell) = ( avgLandIceFreshwaterFlux(iCell) * nAccumulatedCoupled &
+                                              + landIceFreshwaterFlux(iCell) ) / ( nAccumulatedCoupled + 1)
+              avgLandIceHeatFlux(iCell) = ( avgLandIceHeatFlux(iCell) * nAccumulatedCoupled &
+                                        + landIceHeatFlux(iCell) ) / ( nAccumulatedCoupled + 1)
+           end do
+           !$omp end do
+           !$omp end parallel
+
+        end if
+
+        if (config_remove_AIS_coupler_runoff) then
+           call mpas_pool_get_array(forcingPool, 'avgRemovedRiverRunoffFlux', avgRemovedRiverRunoffFlux)
+           call mpas_pool_get_array(forcingPool, 'avgRemovedIceRunoffFlux', avgRemovedIceRunoffFlux)
+           call mpas_pool_get_array(forcingPool, 'avgRemovedIceRunoffHeatFlux', avgRemovedIceRunoffHeatFlux)
+           call mpas_pool_get_array(forcingPool, 'removedRiverRunoffFlux', removedRiverRunoffFlux)
+           call mpas_pool_get_array(forcingPool, 'removedIceRunoffFlux', removedIceRunoffFlux)
+
+           !$omp parallel
+           !$omp do schedule(runtime)
+           do iCell = 1, nCells
+              avgRemovedRiverRunoffFlux(iCell) = ( avgRemovedRiverRunoffFlux(iCell) * nAccumulatedCoupled &
+                                               + removedRiverRunoffFlux(iCell) ) / ( nAccumulatedCoupled + 1)
+              avgRemovedIceRunoffFlux(iCell) = ( avgRemovedIceRunoffFlux(iCell) * nAccumulatedCoupled &
+                                             + removedIceRunoffFlux(iCell) ) / ( nAccumulatedCoupled + 1)
+              avgRemovedIceRunoffHeatFlux(iCell) = ( avgRemovedIceRunoffHeatFlux(iCell) * nAccumulatedCoupled &
+                                             + removedIceRunoffFlux(iCell)*latent_heat_fusion_mks ) / ( nAccumulatedCoupled + 1)
+           end do
+           !$omp end do
+           !$omp end parallel
+
         end if
 
         !  accumulate BGC coupling fields if necessary

--- a/driver-mct/cime_config/buildnml
+++ b/driver-mct/cime_config/buildnml
@@ -40,6 +40,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     config['CPL_ALBAV'] = case.get_value('CPL_ALBAV')
     config['CPL_EPBAL'] = case.get_value('CPL_EPBAL')
     config['FLDS_WISO'] = case.get_value('FLDS_WISO')
+    config['FLDS_POLAR'] = case.get_value('FLDS_POLAR')
     config['BUDGETS'] = case.get_value('BUDGETS')
     config['MACH'] = case.get_value('MACH')
     config['MPILIB'] = case.get_value('MPILIB')

--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -172,6 +172,18 @@
     <desc>Turn on the passing of water isotope fields through the coupler</desc>
   </entry>
 
+  <entry id="FLDS_POLAR">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <values match="last">
+      <value compset="%ISMF">TRUE</value>
+    </values>
+    <group>run_flags</group>
+    <file>env_run.xml</file>
+    <desc>Turn on the passing of polar fields through the coupler</desc>
+  </entry>
+
   <entry id="TFREEZE_SALTWATER_OPTION">
     <type>char</type>
     <valid_values>minus1p8,linear_salt,mushy</valid_values>

--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -177,7 +177,9 @@
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
     <values match="last">
-      <value compset="%ISMF">TRUE</value>
+      <value compset="_MPASO%IBPISMF_">TRUE</value>
+      <value compset="_MPASO%IBDISMF_">TRUE</value>
+      <value compset="_MPASSI%DIB_">TRUE</value>
     </values>
     <group>run_flags</group>
     <file>env_run.xml</file>

--- a/driver-mct/cime_config/namelist_definition_drv.xml
+++ b/driver-mct/cime_config/namelist_definition_drv.xml
@@ -137,6 +137,18 @@
     </values>
   </entry>
 
+  <entry id="flds_polar" modify_via_xml="FLDS_POLAR">
+    <type>logical</type>
+    <category>seq_flds</category>
+    <group>seq_cplflds_inparm</group>
+    <desc>
+      If set to .true. Polar fields will be passed from the ocean to the coupler.
+    </desc>
+    <values>
+      <value>$FLDS_POLAR</value>
+    </values>
+  </entry>
+
   <entry  id="flds_wiso" modify_via_xml="FLDS_WISO">
     <type>logical</type>
     <category>seq_flds</category>

--- a/driver-mct/cime_config/namelist_definition_drv.xml
+++ b/driver-mct/cime_config/namelist_definition_drv.xml
@@ -137,7 +137,7 @@
     </values>
   </entry>
 
-  <entry id="flds_polar" modify_via_xml="FLDS_POLAR">
+  <entry id="flds_polar">
     <type>logical</type>
     <category>seq_flds</category>
     <group>seq_cplflds_inparm</group>

--- a/driver-mct/main/seq_diag_mct.F90
+++ b/driver-mct/main/seq_diag_mct.F90
@@ -139,37 +139,42 @@ module seq_diag_mct
   integer(in),parameter :: f_hioff     = 9     ! heat : latent, fusion, frozen runoff
   integer(in),parameter :: f_hsen      =10     ! heat : sensible
   integer(in),parameter :: f_hberg     =11     ! heat : data icebergs
-  integer(in),parameter :: f_hh2ot     =12     ! heat : water temperature
-  integer(in),parameter :: f_wfrz      =13     ! water: freezing
-  integer(in),parameter :: f_wmelt     =14     ! water: melting
-  integer(in),parameter :: f_wrain     =15     ! water: precip, liquid
-  integer(in),parameter :: f_wsnow     =16     ! water: precip, frozen
-  integer(in),parameter :: f_wberg     =17     ! water: data icebergs
-  integer(in),parameter :: f_wevap     =18     ! water: evaporation
-  integer(in),parameter :: f_wroff     =19     ! water: runoff/flood
-  integer(in),parameter :: f_wioff     =20     ! water: frozen runoff
-  integer(in),parameter :: f_wirrig    =21     ! water: irrigation
-  integer(in),parameter :: f_wfrz_16O  =22     ! water: freezing
-  integer(in),parameter :: f_wmelt_16O =23     ! water: melting
-  integer(in),parameter :: f_wrain_16O =24     ! water: precip, liquid
-  integer(in),parameter :: f_wsnow_16O =25     ! water: precip, frozen
-  integer(in),parameter :: f_wevap_16O =26     ! water: evaporation
-  integer(in),parameter :: f_wroff_16O =27     ! water: runoff/flood
-  integer(in),parameter :: f_wioff_16O =28     ! water: frozen runoff
-  integer(in),parameter :: f_wfrz_18O  =29     ! water: freezing
-  integer(in),parameter :: f_wmelt_18O =30     ! water: melting
-  integer(in),parameter :: f_wrain_18O =31     ! water: precip, liquid
-  integer(in),parameter :: f_wsnow_18O =32     ! water: precip, frozen
-  integer(in),parameter :: f_wevap_18O =33     ! water: evaporation
-  integer(in),parameter :: f_wroff_18O =34     ! water: runoff/flood
-  integer(in),parameter :: f_wioff_18O =35     ! water: frozen runoff
-  integer(in),parameter :: f_wfrz_HDO  =36     ! water: freezing
-  integer(in),parameter :: f_wmelt_HDO =37     ! water: melting
-  integer(in),parameter :: f_wrain_HDO =38     ! water: precip, liquid
-  integer(in),parameter :: f_wsnow_HDO =39     ! water: precip, frozen
-  integer(in),parameter :: f_wevap_HDO =40     ! water: evaporation
-  integer(in),parameter :: f_wroff_HDO =41     ! water: runoff/flood
-  integer(in),parameter :: f_wioff_HDO =42     ! water: frozen runoff
+  integer(in),parameter :: f_hism      =12     ! heat : ice shelf melt
+  integer(in),parameter :: f_hriof     =13     ! heat : data icebergs
+  integer(in),parameter :: f_hh2ot     =14     ! heat : water temperature
+  integer(in),parameter :: f_wfrz      =15     ! water: freezing
+  integer(in),parameter :: f_wmelt     =16     ! water: melting
+  integer(in),parameter :: f_wrain     =17     ! water: precip, liquid
+  integer(in),parameter :: f_wsnow     =18     ! water: precip, frozen
+  integer(in),parameter :: f_wevap     =19     ! water: evaporation
+  integer(in),parameter :: f_wroff     =20     ! water: runoff/flood
+  integer(in),parameter :: f_wioff     =21     ! water: frozen runoff
+  integer(in),parameter :: f_wberg     =22     ! water: data icebergs
+  integer(in),parameter :: f_wism      =23     ! water: ice-shelf melt
+  integer(in),parameter :: f_wrrof     =24     ! water: removed liquid runoff
+  integer(in),parameter :: f_wriof     =25     ! water: removed ice runoff
+  integer(in),parameter :: f_wirrig    =26     ! water: irrigation
+  integer(in),parameter :: f_wfrz_16O  =27     ! water: freezing
+  integer(in),parameter :: f_wmelt_16O =28     ! water: melting
+  integer(in),parameter :: f_wrain_16O =29     ! water: precip, liquid
+  integer(in),parameter :: f_wsnow_16O =30     ! water: precip, frozen
+  integer(in),parameter :: f_wevap_16O =31     ! water: evaporation
+  integer(in),parameter :: f_wroff_16O =32     ! water: runoff/flood
+  integer(in),parameter :: f_wioff_16O =33     ! water: frozen runoff
+  integer(in),parameter :: f_wfrz_18O  =34     ! water: freezing
+  integer(in),parameter :: f_wmelt_18O =35     ! water: melting
+  integer(in),parameter :: f_wrain_18O =36     ! water: precip, liquid
+  integer(in),parameter :: f_wsnow_18O =37     ! water: precip, frozen
+  integer(in),parameter :: f_wevap_18O =38     ! water: evaporation
+  integer(in),parameter :: f_wroff_18O =39     ! water: runoff/flood
+  integer(in),parameter :: f_wioff_18O =40     ! water: frozen runoff
+  integer(in),parameter :: f_wfrz_HDO  =41     ! water: freezing
+  integer(in),parameter :: f_wmelt_HDO =42     ! water: melting
+  integer(in),parameter :: f_wrain_HDO =43     ! water: precip, liquid
+  integer(in),parameter :: f_wsnow_HDO =44     ! water: precip, frozen
+  integer(in),parameter :: f_wevap_HDO =45     ! water: evaporation
+  integer(in),parameter :: f_wroff_HDO =46     ! water: runoff/flood
+  integer(in),parameter :: f_wioff_HDO =47     ! water: frozen runoff
 
   integer(in),parameter :: f_size     = f_wioff_HDO   ! Total array size of all elements
   integer(in),parameter :: f_a        = f_area        ! 1st index for area
@@ -189,8 +194,10 @@ module seq_diag_mct
 
        (/'        area','     hfreeze','       hmelt','      hnetsw','       hlwdn', &
        '       hlwup','     hlatvap','     hlatfus','      hiroff','        hsen', &
-       '       hberg','    hh2otemp','     wfreeze','       wmelt','       wrain', &
-       '       wsnow','       wberg','       wevap','     wrunoff','     wfrzrof', &
+       '       hberg','        hism','       hriof',                               &
+       '    hh2otemp','     wfreeze','       wmelt','       wrain',                &
+       '       wsnow','       wevap','     wrunoff','     wfrzrof',                &
+       '       wberg','        wism','       wrrof','       wriof',                &
        '      wirrig',                                                             &
        ' wfreeze_16O','   wmelt_16O','   wrain_16O','   wsnow_16O',                &
        '   wevap_16O',' wrunoff_16O',' wfrzrof_16O',                               &
@@ -287,6 +294,12 @@ module seq_diag_mct
   integer :: index_o2x_Faoo_h2otemp
   integer :: index_o2x_Fioo_frazil
   integer :: index_o2x_Fioo_q
+
+  integer :: index_o2x_Foxo_ismw
+  integer :: index_o2x_Foxo_rrofl
+  integer :: index_o2x_Foxo_rrofi
+  integer :: index_o2x_Foxo_ismh
+  integer :: index_o2x_Foxo_rrofih
 
   integer :: index_xao_Faox_lwup
   integer :: index_xao_Faox_lat
@@ -1337,7 +1350,7 @@ contains
     integer(in)              :: kArea        ! index of area field in aVect
     integer(in)              :: ko,ki  ! fraction indices
     integer(in)              :: lSize        ! size of aVect
-    real(r8)                 :: ca_i,ca_o  ! area of a grid cell
+    real(r8)                 :: ca_i,ca_o,ca_c  ! area of a grid cell
     logical,save             :: first_time    = .true.
     logical,save             :: flds_wiso_ocn = .false.
 
@@ -1373,6 +1386,11 @@ contains
           index_o2x_Fioo_frazil  = mct_aVect_indexRA(o2x_o,'Fioo_frazil')
           index_o2x_Fioo_q       = mct_aVect_indexRA(o2x_o,'Fioo_q')
           index_o2x_Faoo_h2otemp = mct_aVect_indexRA(o2x_o,'Faoo_h2otemp')
+          index_o2x_Foxo_ismw  = mct_aVect_indexRA(o2x_o,'Foxo_ismw')
+          index_o2x_Foxo_rrofl = mct_aVect_indexRA(o2x_o,'Foxo_rrofl')
+          index_o2x_Foxo_rrofi = mct_aVect_indexRA(o2x_o,'Foxo_rrofi')
+          index_o2x_Foxo_ismh  = mct_aVect_indexRA(o2x_o,'Foxo_ismh')
+          index_o2x_Foxo_rrofih  = mct_aVect_indexRA(o2x_o,'Foxo_rrofih')
        end if
 
        lSize = mct_avect_lSize(o2x_o)
@@ -1380,10 +1398,16 @@ contains
        do n=1,lSize
           ca_o =  dom_o%data%rAttr(kArea,n) * frac_o%rAttr(ko,n)
           ca_i =  dom_o%data%rAttr(kArea,n) * frac_o%rAttr(ki,n)
+          ca_c =  dom_o%data%rAttr(kArea,n)
           nf = f_area; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_o
           nf = f_wfrz;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*max(0.0_r8,o2x_o%rAttr(index_o2x_Fioo_frazil,n))
           nf = f_hfrz;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*max(0.0_r8,o2x_o%rAttr(index_o2x_Fioo_q,n))
           nf = f_hh2ot; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Faoo_h2otemp,n)
+          nf = f_wism;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismw,n)
+          nf = f_wrrof; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofl,n)
+          nf = f_wriof; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofi,n)
+          nf = f_hism;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismh,n)
+          nf = f_hriof; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_rrofih,n)
        end do
     end if
 
@@ -1613,8 +1637,8 @@ contains
     if (present(do_i2x)) then
        index_i2x_Fioi_melth  = mct_aVect_indexRA(i2x_i,'Fioi_melth')
        index_i2x_Fioi_meltw  = mct_aVect_indexRA(i2x_i,'Fioi_meltw')
-       index_i2x_Fioi_bergh  = mct_aVect_indexRA(i2x_i,'PFioi_bergh')
-       index_i2x_Fioi_bergw  = mct_aVect_indexRA(i2x_i,'PFioi_bergw')
+!       index_i2x_Fioi_bergh  = mct_aVect_indexRA(i2x_i,'PFioi_bergh')
+!       index_i2x_Fioi_bergw  = mct_aVect_indexRA(i2x_i,'PFioi_bergw')
        index_i2x_Fioi_swpen  = mct_aVect_indexRA(i2x_i,'Fioi_swpen')
        index_i2x_Faii_swnet  = mct_aVect_indexRA(i2x_i,'Faii_swnet')
        index_i2x_Faii_lwup   = mct_aVect_indexRA(i2x_i,'Faii_lwup')
@@ -1650,9 +1674,9 @@ contains
           nf = f_hlwup ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i*i2x_i%rAttr(index_i2x_Faii_lwup,n)
           nf = f_hlatv ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i*i2x_i%rAttr(index_i2x_Faii_lat,n)
           nf = f_hsen  ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i*i2x_i%rAttr(index_i2x_Faii_sen,n)
-          nf = f_hberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*i2x_i%rAttr(index_i2x_Fioi_bergh,n)
+!          nf = f_hberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*i2x_i%rAttr(index_i2x_Fioi_bergh,n)
           nf = f_wmelt ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - ca_i*i2x_i%rAttr(index_i2x_Fioi_meltw,n)
-          nf = f_wberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*i2x_i%rAttr(index_i2x_Fioi_bergw,n)
+!          nf = f_wberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*i2x_i%rAttr(index_i2x_Fioi_bergw,n)
           nf = f_wevap ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i*i2x_i%rAttr(index_i2x_Faii_evap,n)
 
           if ( flds_wiso_ice )then

--- a/driver-mct/main/seq_diag_mct.F90
+++ b/driver-mct/main/seq_diag_mct.F90
@@ -1402,7 +1402,7 @@ contains
              nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismw,n)
              nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofl,n)
              nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofi,n)
-             nf = f_hpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - ca_c*o2x_o%rAttr(index_o2x_Foxo_ismh,n)
+             nf = f_hpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismh,n)
              nf = f_hpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_rrofih,n)
           end if
        end do

--- a/driver-mct/main/seq_diag_mct.F90
+++ b/driver-mct/main/seq_diag_mct.F90
@@ -317,8 +317,6 @@ module seq_diag_mct
 
   integer :: index_i2x_Fioi_melth
   integer :: index_i2x_Fioi_meltw
-  integer :: index_i2x_Fioi_bergh
-  integer :: index_i2x_Fioi_bergw
   integer :: index_i2x_Fioi_salt
   integer :: index_i2x_Faii_swnet
   integer :: index_i2x_Fioi_swpen
@@ -1346,6 +1344,7 @@ contains
     real(r8)                 :: ca_i,ca_o,ca_c  ! area of a grid cell
     logical,save             :: first_time    = .true.
     logical,save             :: flds_wiso_ocn = .false.
+    logical,save             :: flds_polar = .false.
 
     !----- formats -----
     character(*),parameter :: subName = '(seq_diag_ocn_mct) '
@@ -1379,11 +1378,14 @@ contains
           index_o2x_Fioo_frazil  = mct_aVect_indexRA(o2x_o,'Fioo_frazil')
           index_o2x_Fioo_q       = mct_aVect_indexRA(o2x_o,'Fioo_q')
           index_o2x_Faoo_h2otemp = mct_aVect_indexRA(o2x_o,'Faoo_h2otemp')
-          index_o2x_Foxo_ismw  = mct_aVect_indexRA(o2x_o,'Foxo_ismw',perrWith='quiet')
-          index_o2x_Foxo_rrofl = mct_aVect_indexRA(o2x_o,'Foxo_rrofl',perrWith='quiet')
-          index_o2x_Foxo_rrofi = mct_aVect_indexRA(o2x_o,'Foxo_rrofi',perrWith='quiet')
-          index_o2x_Foxo_ismh  = mct_aVect_indexRA(o2x_o,'Foxo_ismh',perrWith='quiet')
-          index_o2x_Foxo_rrofih  = mct_aVect_indexRA(o2x_o,'Foxo_rrofih',perrWith='quiet')
+          index_o2x_Foxo_ismw    = mct_aVect_indexRA(o2x_o,'Foxo_ismw',perrWith='quiet')
+          if ( index_o2x_Foxo_ismw /= 0 ) flds_polar = .true.
+          if ( flds_polar ) then
+             index_o2x_Foxo_rrofl   = mct_aVect_indexRA(o2x_o,'Foxo_rrofl',perrWith='quiet')
+             index_o2x_Foxo_rrofi   = mct_aVect_indexRA(o2x_o,'Foxo_rrofi',perrWith='quiet')
+             index_o2x_Foxo_ismh    = mct_aVect_indexRA(o2x_o,'Foxo_ismh',perrWith='quiet')
+             index_o2x_Foxo_rrofih  = mct_aVect_indexRA(o2x_o,'Foxo_rrofih',perrWith='quiet')
+          end if
        end if
 
        lSize = mct_avect_lSize(o2x_o)
@@ -1396,16 +1398,13 @@ contains
           nf = f_wfrz;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*max(0.0_r8,o2x_o%rAttr(index_o2x_Fioo_frazil,n))
           nf = f_hfrz;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*max(0.0_r8,o2x_o%rAttr(index_o2x_Fioo_q,n))
           nf = f_hh2ot; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Faoo_h2otemp,n)
-          nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismw,n)
-          nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofl,n)
-          nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofi,n)
-!          nf = f_wism;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismw,n)
-!          nf = f_wrrof; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofl,n)
-!          nf = f_wriof; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofi,n)
-          nf = f_hpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismh,n)
-          nf = f_hpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_rrofih,n)
-!          nf = f_hism;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismh,n)
-!          nf = f_hriof; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_rrofih,n)
+          if (flds_polar) then
+             nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismw,n)
+             nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofl,n)
+             nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofi,n)
+             nf = f_hpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - ca_c*o2x_o%rAttr(index_o2x_Foxo_ismh,n)
+             nf = f_hpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_rrofih,n)
+          end if
        end do
     end if
 
@@ -1635,8 +1634,6 @@ contains
     if (present(do_i2x)) then
        index_i2x_Fioi_melth  = mct_aVect_indexRA(i2x_i,'Fioi_melth')
        index_i2x_Fioi_meltw  = mct_aVect_indexRA(i2x_i,'Fioi_meltw')
-!       index_i2x_Fioi_bergh  = mct_aVect_indexRA(i2x_i,'PFioi_bergh')
-!       index_i2x_Fioi_bergw  = mct_aVect_indexRA(i2x_i,'PFioi_bergw')
        index_i2x_Fioi_swpen  = mct_aVect_indexRA(i2x_i,'Fioi_swpen')
        index_i2x_Faii_swnet  = mct_aVect_indexRA(i2x_i,'Faii_swnet')
        index_i2x_Faii_lwup   = mct_aVect_indexRA(i2x_i,'Faii_lwup')
@@ -1672,9 +1669,7 @@ contains
           nf = f_hlwup ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i*i2x_i%rAttr(index_i2x_Faii_lwup,n)
           nf = f_hlatv ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i*i2x_i%rAttr(index_i2x_Faii_lat,n)
           nf = f_hsen  ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i*i2x_i%rAttr(index_i2x_Faii_sen,n)
-!          nf = f_hberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*i2x_i%rAttr(index_i2x_Fioi_bergh,n)
           nf = f_wmelt ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - ca_i*i2x_i%rAttr(index_i2x_Fioi_meltw,n)
-!          nf = f_wberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*i2x_i%rAttr(index_i2x_Fioi_bergw,n)
           nf = f_wevap ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_i*i2x_i%rAttr(index_i2x_Faii_evap,n)
 
           if ( flds_wiso_ice )then

--- a/driver-mct/main/seq_diag_mct.F90
+++ b/driver-mct/main/seq_diag_mct.F90
@@ -286,7 +286,9 @@ module seq_diag_mct
 
   integer :: index_o2x_Faoo_h2otemp
   integer :: index_o2x_Fioo_frazil
+  integer :: index_o2x_Foxo_frazil_li
   integer :: index_o2x_Fioo_q
+  integer :: index_o2x_Foxo_q_li
 
   integer :: index_o2x_Foxo_ismw
   integer :: index_o2x_Foxo_rrofl
@@ -1376,7 +1378,9 @@ contains
     if (present(do_o2x)) then
        if (first_time) then
           index_o2x_Fioo_frazil  = mct_aVect_indexRA(o2x_o,'Fioo_frazil')
+          index_o2x_Foxo_frazil_li= mct_aVect_indexRA(o2x_o,'Foxo_frazil_li',perrWith='quiet')
           index_o2x_Fioo_q       = mct_aVect_indexRA(o2x_o,'Fioo_q')
+          index_o2x_Foxo_q_li    = mct_aVect_indexRA(o2x_o,'Foxo_q_li',perrWith='quiet')
           index_o2x_Faoo_h2otemp = mct_aVect_indexRA(o2x_o,'Faoo_h2otemp')
           index_o2x_Foxo_ismw    = mct_aVect_indexRA(o2x_o,'Foxo_ismw',perrWith='quiet')
           if ( index_o2x_Foxo_ismw /= 0 ) flds_polar = .true.
@@ -1399,9 +1403,11 @@ contains
           nf = f_hfrz;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*max(0.0_r8,o2x_o%rAttr(index_o2x_Fioo_q,n))
           nf = f_hh2ot; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Faoo_h2otemp,n)
           if (flds_polar) then
+             nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - ca_c*o2x_o%rAttr(index_o2x_Foxo_frazil_li,n)
              nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismw,n)
              nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofl,n)
              nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofi,n)
+             nf = f_hpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_q_li,n)
              nf = f_hpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismh,n)
              nf = f_hpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_rrofih,n)
           end if

--- a/driver-mct/main/seq_diag_mct.F90
+++ b/driver-mct/main/seq_diag_mct.F90
@@ -138,43 +138,38 @@ module seq_diag_mct
   integer(in),parameter :: f_hlatf     = 8     ! heat : latent, fusion, snow
   integer(in),parameter :: f_hioff     = 9     ! heat : latent, fusion, frozen runoff
   integer(in),parameter :: f_hsen      =10     ! heat : sensible
-  integer(in),parameter :: f_hberg     =11     ! heat : data icebergs
-  integer(in),parameter :: f_hism      =12     ! heat : ice shelf melt
-  integer(in),parameter :: f_hriof     =13     ! heat : data icebergs
-  integer(in),parameter :: f_hh2ot     =14     ! heat : water temperature
-  integer(in),parameter :: f_wfrz      =15     ! water: freezing
-  integer(in),parameter :: f_wmelt     =16     ! water: melting
-  integer(in),parameter :: f_wrain     =17     ! water: precip, liquid
-  integer(in),parameter :: f_wsnow     =18     ! water: precip, frozen
-  integer(in),parameter :: f_wevap     =19     ! water: evaporation
-  integer(in),parameter :: f_wroff     =20     ! water: runoff/flood
-  integer(in),parameter :: f_wioff     =21     ! water: frozen runoff
-  integer(in),parameter :: f_wberg     =22     ! water: data icebergs
-  integer(in),parameter :: f_wism      =23     ! water: ice-shelf melt
-  integer(in),parameter :: f_wrrof     =24     ! water: removed liquid runoff
-  integer(in),parameter :: f_wriof     =25     ! water: removed ice runoff
-  integer(in),parameter :: f_wirrig    =26     ! water: irrigation
-  integer(in),parameter :: f_wfrz_16O  =27     ! water: freezing
-  integer(in),parameter :: f_wmelt_16O =28     ! water: melting
-  integer(in),parameter :: f_wrain_16O =29     ! water: precip, liquid
-  integer(in),parameter :: f_wsnow_16O =30     ! water: precip, frozen
-  integer(in),parameter :: f_wevap_16O =31     ! water: evaporation
-  integer(in),parameter :: f_wroff_16O =32     ! water: runoff/flood
-  integer(in),parameter :: f_wioff_16O =33     ! water: frozen runoff
-  integer(in),parameter :: f_wfrz_18O  =34     ! water: freezing
-  integer(in),parameter :: f_wmelt_18O =35     ! water: melting
-  integer(in),parameter :: f_wrain_18O =36     ! water: precip, liquid
-  integer(in),parameter :: f_wsnow_18O =37     ! water: precip, frozen
-  integer(in),parameter :: f_wevap_18O =38     ! water: evaporation
-  integer(in),parameter :: f_wroff_18O =39     ! water: runoff/flood
-  integer(in),parameter :: f_wioff_18O =40     ! water: frozen runoff
-  integer(in),parameter :: f_wfrz_HDO  =41     ! water: freezing
-  integer(in),parameter :: f_wmelt_HDO =42     ! water: melting
-  integer(in),parameter :: f_wrain_HDO =43     ! water: precip, liquid
-  integer(in),parameter :: f_wsnow_HDO =44     ! water: precip, frozen
-  integer(in),parameter :: f_wevap_HDO =45     ! water: evaporation
-  integer(in),parameter :: f_wroff_HDO =46     ! water: runoff/flood
-  integer(in),parameter :: f_wioff_HDO =47     ! water: frozen runoff
+  integer(in),parameter :: f_hpolar    =11     ! heat : AIS imbalance
+  integer(in),parameter :: f_hh2ot     =12     ! heat : water temperature
+  integer(in),parameter :: f_wfrz      =13     ! water: freezing
+  integer(in),parameter :: f_wmelt     =14     ! water: melting
+  integer(in),parameter :: f_wrain     =15     ! water: precip, liquid
+  integer(in),parameter :: f_wsnow     =16     ! water: precip, frozen
+  integer(in),parameter :: f_wpolar    =17     ! water: AIS imbalance
+  integer(in),parameter :: f_wevap     =18     ! water: evaporation
+  integer(in),parameter :: f_wroff     =19     ! water: runoff/flood
+  integer(in),parameter :: f_wioff     =20     ! water: frozen runoff
+  integer(in),parameter :: f_wirrig    =21     ! water: irrigation
+  integer(in),parameter :: f_wfrz_16O  =22     ! water: freezing
+  integer(in),parameter :: f_wmelt_16O =23     ! water: melting
+  integer(in),parameter :: f_wrain_16O =24     ! water: precip, liquid
+  integer(in),parameter :: f_wsnow_16O =25     ! water: precip, frozen
+  integer(in),parameter :: f_wevap_16O =26     ! water: evaporation
+  integer(in),parameter :: f_wroff_16O =27     ! water: runoff/flood
+  integer(in),parameter :: f_wioff_16O =28     ! water: frozen runoff
+  integer(in),parameter :: f_wfrz_18O  =29     ! water: freezing
+  integer(in),parameter :: f_wmelt_18O =30     ! water: melting
+  integer(in),parameter :: f_wrain_18O =31     ! water: precip, liquid
+  integer(in),parameter :: f_wsnow_18O =32     ! water: precip, frozen
+  integer(in),parameter :: f_wevap_18O =33     ! water: evaporation
+  integer(in),parameter :: f_wroff_18O =34     ! water: runoff/flood
+  integer(in),parameter :: f_wioff_18O =35     ! water: frozen runoff
+  integer(in),parameter :: f_wfrz_HDO  =36     ! water: freezing
+  integer(in),parameter :: f_wmelt_HDO =37     ! water: melting
+  integer(in),parameter :: f_wrain_HDO =38     ! water: precip, liquid
+  integer(in),parameter :: f_wsnow_HDO =39     ! water: precip, frozen
+  integer(in),parameter :: f_wevap_HDO =40     ! water: evaporation
+  integer(in),parameter :: f_wroff_HDO =41     ! water: runoff/flood
+  integer(in),parameter :: f_wioff_HDO =42     ! water: frozen runoff
 
   integer(in),parameter :: f_size     = f_wioff_HDO   ! Total array size of all elements
   integer(in),parameter :: f_a        = f_area        ! 1st index for area
@@ -194,10 +189,8 @@ module seq_diag_mct
 
        (/'        area','     hfreeze','       hmelt','      hnetsw','       hlwdn', &
        '       hlwup','     hlatvap','     hlatfus','      hiroff','        hsen', &
-       '       hberg','        hism','       hriof',                               &
-       '    hh2otemp','     wfreeze','       wmelt','       wrain',                &
-       '       wsnow','       wevap','     wrunoff','     wfrzrof',                &
-       '       wberg','        wism','       wrrof','       wriof',                &
+       '      hpolar','    hh2otemp','     wfreeze','       wmelt','       wrain', &
+       '       wsnow','      wpolar','       wevap','     wrunoff','     wfrzrof', &
        '      wirrig',                                                             &
        ' wfreeze_16O','   wmelt_16O','   wrain_16O','   wsnow_16O',                &
        '   wevap_16O',' wrunoff_16O',' wfrzrof_16O',                               &
@@ -1386,11 +1379,11 @@ contains
           index_o2x_Fioo_frazil  = mct_aVect_indexRA(o2x_o,'Fioo_frazil')
           index_o2x_Fioo_q       = mct_aVect_indexRA(o2x_o,'Fioo_q')
           index_o2x_Faoo_h2otemp = mct_aVect_indexRA(o2x_o,'Faoo_h2otemp')
-          index_o2x_Foxo_ismw  = mct_aVect_indexRA(o2x_o,'Foxo_ismw')
-          index_o2x_Foxo_rrofl = mct_aVect_indexRA(o2x_o,'Foxo_rrofl')
-          index_o2x_Foxo_rrofi = mct_aVect_indexRA(o2x_o,'Foxo_rrofi')
-          index_o2x_Foxo_ismh  = mct_aVect_indexRA(o2x_o,'Foxo_ismh')
-          index_o2x_Foxo_rrofih  = mct_aVect_indexRA(o2x_o,'Foxo_rrofih')
+          index_o2x_Foxo_ismw  = mct_aVect_indexRA(o2x_o,'Foxo_ismw',perrWith='quiet')
+          index_o2x_Foxo_rrofl = mct_aVect_indexRA(o2x_o,'Foxo_rrofl',perrWith='quiet')
+          index_o2x_Foxo_rrofi = mct_aVect_indexRA(o2x_o,'Foxo_rrofi',perrWith='quiet')
+          index_o2x_Foxo_ismh  = mct_aVect_indexRA(o2x_o,'Foxo_ismh',perrWith='quiet')
+          index_o2x_Foxo_rrofih  = mct_aVect_indexRA(o2x_o,'Foxo_rrofih',perrWith='quiet')
        end if
 
        lSize = mct_avect_lSize(o2x_o)
@@ -1403,11 +1396,16 @@ contains
           nf = f_wfrz;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*max(0.0_r8,o2x_o%rAttr(index_o2x_Fioo_frazil,n))
           nf = f_hfrz;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*max(0.0_r8,o2x_o%rAttr(index_o2x_Fioo_q,n))
           nf = f_hh2ot; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Faoo_h2otemp,n)
-          nf = f_wism;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismw,n)
-          nf = f_wrrof; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofl,n)
-          nf = f_wriof; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofi,n)
-          nf = f_hism;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismh,n)
-          nf = f_hriof; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_rrofih,n)
+          nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismw,n)
+          nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofl,n)
+          nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofi,n)
+!          nf = f_wism;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismw,n)
+!          nf = f_wrrof; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofl,n)
+!          nf = f_wriof; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofi,n)
+          nf = f_hpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismh,n)
+          nf = f_hpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_rrofih,n)
+!          nf = f_hism;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismh,n)
+!          nf = f_hriof; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_rrofih,n)
        end do
     end if
 
@@ -1514,11 +1512,11 @@ contains
           nf = f_hmelt ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_melth,n)
           nf = f_hswnet; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Foxx_swnet,n)
           nf = f_hlwdn ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Faxa_lwdn,n)
-          nf = f_hberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_bergh,n)
+          nf = f_hpolar; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_bergh,n)
           nf = f_wmelt ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_meltw,n)
           nf = f_wrain ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Faxa_rain,n)
           nf = f_wsnow ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Faxa_snow,n)
-          nf = f_wberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_bergw,n)
+          nf = f_wpolar; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_bergw,n)
           nf = f_wroff ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Foxx_rofl,n)
           nf = f_wioff ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Foxx_rofi,n)
 

--- a/driver-mct/shr/seq_flds_mod.F90
+++ b/driver-mct/shr/seq_flds_mod.F90
@@ -379,10 +379,11 @@ contains
     logical :: flds_co2_dmsa
     logical :: flds_bgc_oi
     logical :: flds_wiso
+    logical :: flds_polar
     integer :: glc_nec
 
     namelist /seq_cplflds_inparm/  &
-         flds_co2a, flds_co2b, flds_co2c, flds_co2_dmsa, flds_wiso, glc_nec, &
+         flds_co2a, flds_co2b, flds_co2c, flds_co2_dmsa, flds_wiso, flds_polar, glc_nec, &
          ice_ncat, seq_flds_i2o_per_cat, flds_bgc_oi, &
          nan_check_component_fields, rof_heat, atm_flux_method, atm_gustiness, &
          rof2ocn_nutrients, lnd_rof_two_way, ocn_rof_two_way, rof_sed
@@ -416,6 +417,7 @@ contains
        flds_co2_dmsa = .false.
        flds_bgc_oi   = .false.
        flds_wiso = .false.
+       flds_polar = .false.
        glc_nec   = 0
        ice_ncat  = 1
        seq_flds_i2o_per_cat = .false.
@@ -449,6 +451,7 @@ contains
     call shr_mpi_bcast(flds_co2_dmsa, mpicom)
     call shr_mpi_bcast(flds_bgc_oi  , mpicom)
     call shr_mpi_bcast(flds_wiso    , mpicom)
+    call shr_mpi_bcast(flds_polar   , mpicom)
     call shr_mpi_bcast(glc_nec      , mpicom)
     call shr_mpi_bcast(ice_ncat     , mpicom)
     call shr_mpi_bcast(seq_flds_i2o_per_cat, mpicom)
@@ -1583,45 +1586,53 @@ contains
     attname  = 'PFioi_bergw'
     call metadata_set(attname, longname, stdname, units)
 
-    ! Water flux from ice shelf melt
-    call seq_flds_add(o2x_fluxes,"Foxo_ismw")
-    longname = 'Water flux due to basal melting of ice shelves'
-    stdname  = 'basal_iceshelf_melt_flux'
-    units    = 'kg m-2 s-1'
-    attname  = 'Foxo_ismw'
-    call metadata_set(attname, longname, stdname, units)
+    !--------------------------------
+    ! ocn<->cpl only exchange - Polar
+    !--------------------------------
 
-    ! Heat flux from ice shelf melt
-    call seq_flds_add(o2x_fluxes,"Foxo_ismh")
-    longname = 'Heat flux due to basal melting of ice shelves'
-    stdname  = 'basal_iceshelf_heat_flux'
-    units    = 'W m-2'
-    attname  = 'Foxo_ismh'
-    call metadata_set(attname, longname, stdname, units)
+    if (flds_polar) then
 
-    ! Water flux from removed liquid runoff
-    call seq_flds_add(o2x_fluxes,"Foxo_rrofl")
-    longname = 'Water flux due to removed liqiud runoff'
-    stdname  = 'removed_liquid_runoff_flux'
-    units    = 'kg m-2 s-1'
-    attname  = 'Foxo_rrofl'
-    call metadata_set(attname, longname, stdname, units)
+       ! Water flux from ice shelf melt
+       call seq_flds_add(o2x_fluxes,"Foxo_ismw")
+       longname = 'Water flux due to basal melting of ice shelves'
+       stdname  = 'basal_iceshelf_melt_flux'
+       units    = 'kg m-2 s-1'
+       attname  = 'Foxo_ismw'
+       call metadata_set(attname, longname, stdname, units)
 
-    ! Water flux from removed solid runoff
-    call seq_flds_add(o2x_fluxes,"Foxo_rrofi")
-    longname = 'Water flux due to removed solid runoff'
-    stdname  = 'removed_solid_runoff_flux'
-    units    = 'kg m-2 s-1'
-    attname  = 'Foxo_rrofi'
-    call metadata_set(attname, longname, stdname, units)
+       ! Heat flux from ice shelf melt
+       call seq_flds_add(o2x_fluxes,"Foxo_ismh")
+       longname = 'Heat flux due to basal melting of ice shelves'
+       stdname  = 'basal_iceshelf_heat_flux'
+       units    = 'W m-2'
+       attname  = 'Foxo_ismh'
+       call metadata_set(attname, longname, stdname, units)
 
-    ! Heat flux from removed solid runoff
-    call seq_flds_add(o2x_fluxes,"Foxo_rrofih")
-    longname = 'Heat flux due to removed solid runoff'
-    stdname  = 'removed_solid_runoff_heat_flux'
-    units    = 'W m-2'
-    attname  = 'Foxo_rrofih'
-    call metadata_set(attname, longname, stdname, units)
+       ! Water flux from removed liquid runoff
+       call seq_flds_add(o2x_fluxes,"Foxo_rrofl")
+       longname = 'Water flux due to removed liqiud runoff'
+       stdname  = 'removed_liquid_runoff_flux'
+       units    = 'kg m-2 s-1'
+       attname  = 'Foxo_rrofl'
+       call metadata_set(attname, longname, stdname, units)
+
+       ! Water flux from removed solid runoff
+       call seq_flds_add(o2x_fluxes,"Foxo_rrofi")
+       longname = 'Water flux due to removed solid runoff'
+       stdname  = 'removed_solid_runoff_flux'
+       units    = 'kg m-2 s-1'
+       attname  = 'Foxo_rrofi'
+       call metadata_set(attname, longname, stdname, units)
+
+       ! Heat flux from removed solid runoff
+       call seq_flds_add(o2x_fluxes,"Foxo_rrofih")
+       longname = 'Heat flux due to removed solid runoff'
+       stdname  = 'removed_solid_runoff_heat_flux'
+       units    = 'W m-2'
+       attname  = 'Foxo_rrofih'
+       call metadata_set(attname, longname, stdname, units)
+
+    end if
 
     ! Salt flux
     call seq_flds_add(i2x_fluxes,"Fioi_salt")

--- a/driver-mct/shr/seq_flds_mod.F90
+++ b/driver-mct/shr/seq_flds_mod.F90
@@ -1583,6 +1583,46 @@ contains
     attname  = 'PFioi_bergw'
     call metadata_set(attname, longname, stdname, units)
 
+    ! Water flux from ice shelf melt
+    call seq_flds_add(o2x_fluxes,"Foxo_ismw")
+    longname = 'Water flux due to basal melting of ice shelves'
+    stdname  = 'basal_iceshelf_melt_flux'
+    units    = 'kg m-2 s-1'
+    attname  = 'Foxo_ismw'
+    call metadata_set(attname, longname, stdname, units)
+
+    ! Heat flux from ice shelf melt
+    call seq_flds_add(o2x_fluxes,"Foxo_ismh")
+    longname = 'Heat flux due to basal melting of ice shelves'
+    stdname  = 'basal_iceshelf_heat_flux'
+    units    = 'W m-2'
+    attname  = 'Foxo_ismh'
+    call metadata_set(attname, longname, stdname, units)
+
+    ! Water flux from removed liquid runoff
+    call seq_flds_add(o2x_fluxes,"Foxo_rrofl")
+    longname = 'Water flux due to removed liqiud runoff'
+    stdname  = 'removed_liquid_runoff_flux'
+    units    = 'kg m-2 s-1'
+    attname  = 'Foxo_rrofl'
+    call metadata_set(attname, longname, stdname, units)
+
+    ! Water flux from removed solid runoff
+    call seq_flds_add(o2x_fluxes,"Foxo_rrofi")
+    longname = 'Water flux due to removed solid runoff'
+    stdname  = 'removed_solid_runoff_flux'
+    units    = 'kg m-2 s-1'
+    attname  = 'Foxo_rrofi'
+    call metadata_set(attname, longname, stdname, units)
+
+    ! Heat flux from removed solid runoff
+    call seq_flds_add(o2x_fluxes,"Foxo_rrofih")
+    longname = 'Heat flux due to removed solid runoff'
+    stdname  = 'removed_solid_runoff_heat_flux'
+    units    = 'W m-2'
+    attname  = 'Foxo_rrofih'
+    call metadata_set(attname, longname, stdname, units)
+
     ! Salt flux
     call seq_flds_add(i2x_fluxes,"Fioi_salt")
     call seq_flds_add(x2o_fluxes,"Fioi_salt")

--- a/driver-mct/shr/seq_flds_mod.F90
+++ b/driver-mct/shr/seq_flds_mod.F90
@@ -1592,6 +1592,22 @@ contains
 
     if (flds_polar) then
 
+       ! Ocean Land ice freeze potential
+       call seq_flds_add(o2x_fluxes,"Foxo_q_li")
+       longname = 'Ocean land ice freeze potential'
+       stdname  = 'ice_shelf_cavity_ice_heat_flux'
+       units    = 'W m-2'
+       attname  = 'Foxo_q_li'
+       call metadata_set(attname, longname, stdname, units)
+
+       ! Ocean land ice frazil production
+       call seq_flds_add(o2x_fluxes,"Foxo_frazil_li")
+       longname = 'Ocean land ice frazil production'
+       stdname  = 'ocean_land_ice_frazil_ice_production'
+       units    = 'kg m-2 s-1'
+       attname  = 'Foxo_frazil_li'
+       call metadata_set(attname, longname, stdname, units)
+
        ! Water flux from ice shelf melt
        call seq_flds_add(o2x_fluxes,"Foxo_ismw")
        longname = 'Water flux due to basal melting of ice shelves'

--- a/driver-moab/cime_config/buildnml
+++ b/driver-moab/cime_config/buildnml
@@ -40,6 +40,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     config['CPL_ALBAV'] = case.get_value('CPL_ALBAV')
     config['CPL_EPBAL'] = case.get_value('CPL_EPBAL')
     config['FLDS_WISO'] = case.get_value('FLDS_WISO')
+    config['FLDS_POLAR'] = case.get_value('FLDS_POLAR')
     config['BUDGETS'] = case.get_value('BUDGETS')
     config['MACH'] = case.get_value('MACH')
     config['MPILIB'] = case.get_value('MPILIB')

--- a/driver-moab/cime_config/config_component_e3sm.xml
+++ b/driver-moab/cime_config/config_component_e3sm.xml
@@ -172,6 +172,18 @@
     <desc>Turn on the passing of water isotope fields through the coupler</desc>
   </entry>
 
+  <entry id="FLDS_POLAR">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <values match="last">
+      <value compset="%ISMF">TRUE</value>
+    </values>
+    <group>run_flags</group>
+    <file>env_run.xml</file>
+    <desc>Turn on the passing of polar fields through the coupler</desc>
+  </entry>
+
   <entry id="TFREEZE_SALTWATER_OPTION">
     <type>char</type>
     <valid_values>minus1p8,linear_salt,mushy</valid_values>

--- a/driver-moab/cime_config/config_component_e3sm.xml
+++ b/driver-moab/cime_config/config_component_e3sm.xml
@@ -177,7 +177,9 @@
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
     <values match="last">
-      <value compset="%ISMF">TRUE</value>
+      <value compset="_MPASO%IBPISMF_">TRUE</value>
+      <value compset="_MPASO%IBDISMF_">TRUE</value>
+      <value compset="_MPASSI%DIB_">TRUE</value>
     </values>
     <group>run_flags</group>
     <file>env_run.xml</file>

--- a/driver-moab/cime_config/namelist_definition_drv.xml
+++ b/driver-moab/cime_config/namelist_definition_drv.xml
@@ -149,6 +149,18 @@
     </values>
   </entry>
 
+  <entry id="flds_polar" modify_via_xml="FLDS_POLAR">
+    <type>logical</type>
+    <category>seq_flds</category>
+    <group>seq_cplflds_inparm</group>
+    <desc>
+      If set to .true. Polar fields will be passed from the ocean to the coupler.
+    </desc>
+    <values>
+      <value>$FLDS_POLAR</value>
+    </values>
+  </entry>
+
   <entry id="atm_flux_method" modify_via_xml="ATM_FLUX_INTEGRATION_METHOD">
     <type>char</type>
     <category>seq_flds</category>

--- a/driver-moab/cime_config/namelist_definition_drv.xml
+++ b/driver-moab/cime_config/namelist_definition_drv.xml
@@ -149,7 +149,7 @@
     </values>
   </entry>
 
-  <entry id="flds_polar" modify_via_xml="FLDS_POLAR">
+  <entry id="flds_polar">
     <type>logical</type>
     <category>seq_flds</category>
     <group>seq_cplflds_inparm</group>

--- a/driver-moab/main/seq_diag_mct.F90
+++ b/driver-moab/main/seq_diag_mct.F90
@@ -317,8 +317,6 @@ module seq_diag_mct
 
   integer :: index_i2x_Fioi_melth
   integer :: index_i2x_Fioi_meltw
-  integer :: index_i2x_Fioi_bergh
-  integer :: index_i2x_Fioi_bergw
   integer :: index_i2x_Fioi_salt
   integer :: index_i2x_Faii_swnet
   integer :: index_i2x_Fioi_swpen
@@ -1404,7 +1402,7 @@ contains
              nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismw,n)
              nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofl,n)
              nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofi,n)
-             nf = f_hpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - ca_c*o2x_o%rAttr(index_o2x_Foxo_ismh,n)
+             nf = f_hpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismh,n)
              nf = f_hpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_rrofih,n)
           end if
        end do
@@ -1513,11 +1511,11 @@ contains
           nf = f_hmelt ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_melth,n)
           nf = f_hswnet; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Foxx_swnet,n)
           nf = f_hlwdn ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Faxa_lwdn,n)
-          nf = f_hberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_bergh,n)
+          nf = f_hpolar; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_bergh,n)
           nf = f_wmelt ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_meltw,n)
           nf = f_wrain ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Faxa_rain,n)
           nf = f_wsnow ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Faxa_snow,n)
-          nf = f_wberg ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_bergw,n)
+          nf = f_wpolar; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Fioi_bergw,n)
           nf = f_wroff ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Foxx_rofl,n)
           nf = f_wioff ; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*x2o_o%rAttr(index_x2o_Foxx_rofi,n)
 

--- a/driver-moab/main/seq_diag_mct.F90
+++ b/driver-moab/main/seq_diag_mct.F90
@@ -286,7 +286,9 @@ module seq_diag_mct
 
   integer :: index_o2x_Faoo_h2otemp
   integer :: index_o2x_Fioo_frazil
+  integer :: index_o2x_Foxo_frazil_li
   integer :: index_o2x_Fioo_q
+  integer :: index_o2x_Foxo_q_li
 
   integer :: index_o2x_Foxo_ismw
   integer :: index_o2x_Foxo_rrofl
@@ -1376,7 +1378,9 @@ contains
     if (present(do_o2x)) then
        if (first_time) then
           index_o2x_Fioo_frazil  = mct_aVect_indexRA(o2x_o,'Fioo_frazil')
+          index_o2x_Foxo_frazil_li= mct_aVect_indexRA(o2x_o,'Foxo_frazil_li',perrWith='quiet')
           index_o2x_Fioo_q       = mct_aVect_indexRA(o2x_o,'Fioo_q')
+          index_o2x_Foxo_q_li    = mct_aVect_indexRA(o2x_o,'Foxo_q_li',perrWith='quiet')
           index_o2x_Faoo_h2otemp = mct_aVect_indexRA(o2x_o,'Faoo_h2otemp')
           index_o2x_Foxo_ismw    = mct_aVect_indexRA(o2x_o,'Foxo_ismw',perrWith='quiet')
           if ( index_o2x_Foxo_ismw /= 0 ) flds_polar = .true.
@@ -1399,9 +1403,11 @@ contains
           nf = f_hfrz;  budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*max(0.0_r8,o2x_o%rAttr(index_o2x_Fioo_q,n))
           nf = f_hh2ot; budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Faoo_h2otemp,n)
           if (flds_polar) then
+             nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - ca_c*o2x_o%rAttr(index_o2x_Foxo_frazil_li,n)
              nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismw,n)
              nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofl,n)
              nf = f_wpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) - (ca_o+ca_i)*o2x_o%rAttr(index_o2x_Foxo_rrofi,n)
+             nf = f_hpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_q_li,n)
              nf = f_hpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_ismh,n)
              nf = f_hpolar;budg_dataL(nf,ic,ip) = budg_dataL(nf,ic,ip) + ca_c*o2x_o%rAttr(index_o2x_Foxo_rrofih,n)
           end if

--- a/driver-moab/shr/seq_flds_mod.F90
+++ b/driver-moab/shr/seq_flds_mod.F90
@@ -1626,6 +1626,14 @@ contains
        attname  = 'Foxo_ismh'
        call metadata_set(attname, longname, stdname, units)
 
+       ! Water flux from removed liquid runoff
+       call seq_flds_add(o2x_fluxes,"Foxo_rrofl")
+       longname = 'Water flux due to removed liqiud runoff'
+       stdname  = 'removed_liquid_runoff_flux'
+       units    = 'kg m-2 s-1'
+       attname  = 'Foxo_rrofl'
+       call metadata_set(attname, longname, stdname, units)
+
        ! Water flux from removed solid runoff
        call seq_flds_add(o2x_fluxes,"Foxo_rrofi")
        longname = 'Water flux due to removed solid runoff'

--- a/driver-moab/shr/seq_flds_mod.F90
+++ b/driver-moab/shr/seq_flds_mod.F90
@@ -395,10 +395,11 @@ contains
     logical :: flds_co2_dmsa
     logical :: flds_bgc_oi
     logical :: flds_wiso
+    logical :: flds_polar
     integer :: glc_nec
 
     namelist /seq_cplflds_inparm/  &
-         flds_co2a, flds_co2b, flds_co2c, flds_co2_dmsa, flds_wiso, glc_nec, &
+         flds_co2a, flds_co2b, flds_co2c, flds_co2_dmsa, flds_wiso, flds_polar, glc_nec, &
          ice_ncat, seq_flds_i2o_per_cat, flds_bgc_oi, &
          nan_check_component_fields, rof_heat, atm_flux_method, atm_gustiness, &
          rof2ocn_nutrients, lnd_rof_two_way, ocn_rof_two_way, rof_sed
@@ -435,6 +436,7 @@ contains
        flds_co2_dmsa = .false.
        flds_bgc_oi   = .false.
        flds_wiso = .false.
+       flds_polar = .false.
        glc_nec   = 0
        ice_ncat  = 1
        seq_flds_i2o_per_cat = .false.
@@ -468,6 +470,7 @@ contains
     call shr_mpi_bcast(flds_co2_dmsa, mpicom)
     call shr_mpi_bcast(flds_bgc_oi  , mpicom)
     call shr_mpi_bcast(flds_wiso    , mpicom)
+    call shr_mpi_bcast(flds_polar    , mpicom)
     call shr_mpi_bcast(glc_nec      , mpicom)
     call shr_mpi_bcast(ice_ncat     , mpicom)
     call shr_mpi_bcast(seq_flds_i2o_per_cat, mpicom)
@@ -1601,6 +1604,45 @@ contains
     units    = 'kg m-2 s-1'
     attname  = 'PFioi_bergw'
     call metadata_set(attname, longname, stdname, units)
+
+    !--------------------------------
+    ! ocn<->cpl only exchange - Polar
+    !--------------------------------
+    if (flds_polar) then
+
+       ! Water flux from ice shelf melt
+       call seq_flds_add(o2x_fluxes,"Foxo_ismw")
+       longname = 'Water flux due to basal melting of ice shelves'
+       stdname  = 'basal_iceshelf_melt_flux'
+       units    = 'kg m-2 s-1'
+       attname  = 'Foxo_ismw'
+       call metadata_set(attname, longname, stdname, units)
+
+       ! Heat flux from ice shelf melt
+       call seq_flds_add(o2x_fluxes,"Foxo_ismh")
+       longname = 'Heat flux due to basal melting of ice shelves'
+       stdname  = 'basal_iceshelf_heat_flux'
+       units    = 'W m-2'
+       attname  = 'Foxo_ismh'
+       call metadata_set(attname, longname, stdname, units)
+
+       ! Water flux from removed solid runoff
+       call seq_flds_add(o2x_fluxes,"Foxo_rrofi")
+       longname = 'Water flux due to removed solid runoff'
+       stdname  = 'removed_solid_runoff_flux'
+       units    = 'kg m-2 s-1'
+       attname  = 'Foxo_rrofi'
+       call metadata_set(attname, longname, stdname, units)
+
+       ! Heat flux from removed solid runoff
+       call seq_flds_add(o2x_fluxes,"Foxo_rrofih")
+       longname = 'Heat flux due to removed solid runoff'
+       stdname  = 'removed_solid_runoff_heat_flux'
+       units    = 'W m-2'
+       attname  = 'Foxo_rrofih'
+       call metadata_set(attname, longname, stdname, units)
+
+    end if
 
     ! Salt flux
     call seq_flds_add(i2x_fluxes,"Fioi_salt")

--- a/driver-moab/shr/seq_flds_mod.F90
+++ b/driver-moab/shr/seq_flds_mod.F90
@@ -1610,6 +1610,22 @@ contains
     !--------------------------------
     if (flds_polar) then
 
+       ! Ocean Land ice freeze potential
+       call seq_flds_add(o2x_fluxes,"Foxo_q_li")
+       longname = 'Ocean land ice freeze potential'
+       stdname  = 'ice_shelf_cavity_ice_heat_flux'
+       units    = 'W m-2'
+       attname  = 'Foxo_q_li'
+       call metadata_set(attname, longname, stdname, units)
+
+       ! Ocean land ice frazil production
+       call seq_flds_add(o2x_fluxes,"Foxo_frazil_li")
+       longname = 'Ocean land ice frazil production'
+       stdname  = 'ocean_land_ice_frazil_ice_production'
+       units    = 'kg m-2 s-1'
+       attname  = 'Foxo_frazil_li'
+       call metadata_set(attname, longname, stdname, units)
+
        ! Water flux from ice shelf melt
        call seq_flds_add(o2x_fluxes,"Foxo_ismw")
        longname = 'Water flux due to basal melting of ice shelves'


### PR DESCRIPTION
Adds five new o2x coupling fields and terms to coupler budget for polar configurations:

`Foxo_ismw` - water from ice shelf basal melting (either prognostic or data)
`Foxo_rrofl` - water removed from Antarctica liquid runoff
`Foxo_rrofi` - water removed from Antarctica solid runoff

`Foxo_ismh` - heat from ice shelf basal melting
`Foxo_rrofih` - heat from removed ice runoff

`Foxo_frazil_li` - frazil ice formed in ice-shelf cavities ('land ice frazil')
`Foxo_frazil_q` - latent heat associated with land ice frazil

These new fields are used to calculate `wpolar` and `hpolar`, which are Antarctic Ice Sheet imbalances in polar configurations. These coupler budget terms replace the existing iceberg `wberg` and `hberg` entries in the budget table, which are included in the `wpolar` and `hpolar` totals.

Adds a driver namelist option (`flds_polar`) to only send these coupling fields in polar configurations.

Changes to ocean conservation analysis member:
 - Turns on terms in ocean conservation analysis member when data ice-shelf melt fluxes are used.
 - Removes `landIceFreshwaterFluxesOn` conditional on writing land ice frazil terms
 - Removes accumulated land ice frazil salinity terms for salt conservation, since land ice frazil is assumed to have 0 salinity.

Further discussion in https://github.com/E3SM-Ocean-Discussion/E3SM/pull/74

[BFB]
[NML]