### PR TITLE
assign alkalinity equals DIC in sea ice melt

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_ecosys.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_ecosys.F
@@ -1975,6 +1975,8 @@ contains
                ecosysSurfaceFlux(fe_ind_MPAS,iCell) + iceFluxFeDissolved(iCell)/parm_Fe_bioavail
             ecosysSurfaceFlux(dic_ind_MPAS,iCell) =  &
                ecosysSurfaceFlux(dic_ind_MPAS,iCell) + iceFluxDIC(iCell)
+            ecosysSurfaceFlux(alk_ind_MPAS,iCell) =  &
+               ecosysSurfaceFlux(alk_ind_MPAS,iCell) + iceFluxDIC(iCell)
             ecosysSurfaceFlux(dic_alt_co2_ind_MPAS,iCell) =  &
                ecosysSurfaceFlux(dic_alt_co2_ind_MPAS,iCell) + iceFluxDIC(iCell)
             ecosysSurfaceFlux(doc_ind_MPAS,iCell) =  &


### PR DESCRIPTION
Set alkalinity of sea ice melt flux into the ocean to be equal to DIC flux, analogous to what is done with river runoff.  Previously the flux was zero, resulting in unphysical dilution.  

Fixes https://github.com/E3SM-Project/E3SM/issues/6210.