### PR TITLE
Removes the FAN dataset from mksurfdata.pl

### DIFF
--- a/components/elm/tools/mksurfdata_map/mksurfdata.pl
+++ b/components/elm/tools/mksurfdata_map/mksurfdata.pl
@@ -422,7 +422,7 @@ EOF
       foreach my $typ ( "lak", "veg", "voc", "top", "tex", "col","ord", 
                         "fmx", "lai", "urb", "org", "glc", "utp", "wet",
 		        "gdp", "peat","abm", "topostats" , "vic", "ch4", 
-                        "pho", "grvl", "slp10", "ero", "fert") {
+                        "pho", "grvl", "slp10", "ero") {
          my $lmask = `$scrdir/../../bld/queryDefaultNamelist.pl $mopts -silent -options type=$typ,mergeGIS=$merge_gis,hirespft=$hirespft -var lmask`;
          $lmask = trim($lmask);
          my $hgrid = `$scrdir/../../bld/queryDefaultNamelist.pl $mopts -options type=$typ,hirespft=$hirespft -var hgrid`;
@@ -538,7 +538,6 @@ EOF
  map_fgrvl         = '$map{'grvl'}'
  map_fslp10        = '$map{'slp10'}'
  map_fero          = '$map{'ero'}'
- map_ffert         = '$map{'fert'}'
  mksrf_fsoitex     = '$datfil{'tex'}'
  mksrf_forganic    = '$datfil{'org'}'
  mksrf_flakwat     = '$datfil{'lak'}'
@@ -562,7 +561,6 @@ EOF
  mksrf_fgrvl       = '$datfil{'grvl'}'
  mksrf_fslp10      = '$datfil{'slp10'}'
  mksrf_fero        = '$datfil{'ero'}'
- mksrf_ffert       = '$datfil{'fert'}'
 EOF
             my $urbdesc = "urb3den";
             my $rcp_option= "";

--- a/components/elm/tools/mksurfdata_map/src/Srcfiles
+++ b/components/elm/tools/mksurfdata_map/src/Srcfiles
@@ -1,4 +1,5 @@
 mkdomainMod.F90
+mkFertMod.F90
 mkgridmapMod.F90
 mkindexmapMod.F90
 mkfileMod.F90

--- a/components/elm/tools/mksurfdata_map/src/mksurfdat.F90
+++ b/components/elm/tools/mksurfdata_map/src/mksurfdat.F90
@@ -554,7 +554,7 @@ program mksurfdat
     write(ndiag,*) 'VIC parameters from:         ',trim(mksrf_fvic)
     write(ndiag,*) 'CH4 parameters from:         ',trim(mksrf_fch4)
     write(ndiag,*) 'Soil phosphorus from:        ',trim(mksrf_fphosphorus)
-    write(ndiag,*) 'Fertilizer from:             ',trim(mksrf_ffert)
+    !write(ndiag,*) 'Fertilizer from:             ',trim(mksrf_ffert)
     write(ndiag,*)' mapping for pft              ',trim(map_fpft)
     write(ndiag,*)' mapping for lake water       ',trim(map_flakwat)
     write(ndiag,*)' mapping for wetland          ',trim(map_fwetlnd)
@@ -763,8 +763,8 @@ program mksurfdat
          ero_c1_o=ero_c1, ero_c2_o=ero_c2, ero_c3_o=ero_c3, tillage_o=tillage, &
          litho_o=litho)
 
-    call mkfert(ldomain, mapfname=map_ffert, datfname=mksrf_ffert, ndiag=ndiag, &
-         nfert_o=nfert, pfert_o=pfert)
+    !call mkfert(ldomain, mapfname=map_ffert, datfname=mksrf_ffert, ndiag=ndiag, &
+    !     nfert_o=nfert, pfert_o=pfert)
 
     do n = 1,ns_o
 

--- a/components/elm/tools/mksurfdata_map/src/mkvarctl.F90
+++ b/components/elm/tools/mksurfdata_map/src/mkvarctl.F90
@@ -52,7 +52,7 @@ module mkvarctl
   character(len=256), public :: mksrf_fslp10     = ' '  ! slope percentile file name
   character(len=256), public :: mksrf_fero       = ' '  ! ELM-Erosion parameters data file name
   character(len=256), public :: mksrf_ffert      = ' '  ! crop fertilizer data file name
-  integer           , public :: numpft         = 50   ! number of plant types
+  integer           , public :: numpft         = 16   ! number of plant types
 
   character(len=256), public :: map_fpft        = ' ' ! Mapping file for PFT
   character(len=256), public :: map_flakwat     = ' ' ! Mapping file for lake water


### PR DESCRIPTION
The settings for the FAN dataset are not fully implemented in xml files. 
Since the FAN dataset is not currently used in simulation campaigns, 
the settings for this dataset are removed from mksurfdata.pl for the time being.

Fixes #6137
[BFB]