### PR TITLE
Make JRA streams yr_align set by DATM_CLMNCEP_YR_ALIGN

### DIFF
--- a/components/data_comps/datm/cime_config/config_component.xml
+++ b/components/data_comps/datm/cime_config/config_component.xml
@@ -240,6 +240,8 @@ data (see cime issue #3653 -- https://github.com/ESMCI/cime/issues/3653).
       <value compset="1850.*_DATM%CRU">1</value>
       <value compset="1850.*_DATM%GSW">1</value>
       <value compset="2000.*_DATM">$DATM_CLMNCEP_YR_START</value>
+      <value compset="2000_DATM%JRA">1</value>
+      <value compset="2000_DATM%JRA-1p5">1</value>
       <value compset="2003.*_DATM">$DATM_CLMNCEP_YR_START</value>
       <value compset="2010.*_DATM">$DATM_CLMNCEP_YR_START</value>
       <value compset="4804.*_DATM">$DATM_CLMNCEP_YR_START</value>

--- a/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+++ b/components/data_comps/datm/cime_config/namelist_definition_datm.xml
@@ -1798,8 +1798,8 @@
       <value stream="CORE2_NYF">1</value>
       <value stream="CORE2_IAF.CORE2.ArcFactor">1</value>
       <value stream="CORE2_IAF">1</value>
-      <value stream="CORE_IAF_JRA.*">1</value>
-      <value stream="IAF_JRA_1p5.*">1</value>
+      <value stream="CORE_IAF_JRA.*">$DATM_CLMNCEP_YR_ALIGN</value>
+      <value stream="IAF_JRA_1p5.*">$DATM_CLMNCEP_YR_ALIGN</value>
       <value stream="CORE_RYF*">1</value>
       <value stream="co2tseries.20tr">1850</value>
       <!-- ncycles*(year_end-year_start+1)-(year_end-co2_year_start) -->


### PR DESCRIPTION
Modifies datm files to allow more user control of JRA forcing settings, so that it accepts DATM_CLMNCEP_YR_ALIGN in env_run.xml to control the yr_align in its streams. This is useful when trying to run JRA-forced G-cases at specific start dates.

[BFB]