### PR TITLE
Add testmods to instruct cases to change where it reads inputdata (ie DIN_LOC)

### DIFF
--- a/cime_config/testmods_dirs/dinloc/case/shell_commands
+++ b/cime_config/testmods_dirs/dinloc/case/shell_commands
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Set DIN to be local to the case
+./xmlchange DIN_LOC_ROOT="`./xmlquery --value CASEROOT`/inputdata"
+./xmlchange DIN_LOC_ROOT_CLMFORC="`./xmlquery --value CASEROOT`/inputdata/atm/datm7"

--- a/cime_config/testmods_dirs/dinloc/scratch/shell_commands
+++ b/cime_config/testmods_dirs/dinloc/scratch/shell_commands
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Set DIN to be in SCRATCH space
+./xmlchange DIN_LOC_ROOT="${SCRATCH}/inputdata"
+./xmlchange DIN_LOC_ROOT_CLMFORC="${SCRATCH}/inputdata/atm/datm7"


### PR DESCRIPTION
Add 2 testmods: `dinloc-case` and `dinloc-scratch` that can be added to any test.
With `dinloc-case` testmod, the test will set DIN_LOC to be local to the case (as dir `inputdata`) which forces download of any data test thinks it needs.
With `dinloc-scratch` testmod, the test will set DIN_LOC to be in users `$SCRATCH/inputdata` location and download what's needed there.

With these tesmods, for a given test, we can examine things like:
a) can test that case will find/download all of the data it needs and run?
b) does (a) yield BFB results with using default DIN_LOC?
c) allow user to see exactly which files test needs to confirm it is expected.
d) allow for performance experiments -- for example on different filesystems or with different lustre striping 

[bfb]
 