### PR TITLE
Update EAM case descriptions

### DIFF
--- a/components/eam/cime_config/config_component.xml
+++ b/components/eam/cime_config/config_component.xml
@@ -194,24 +194,24 @@
   </entry>
 
   <description>
-    <desc compset="_EAM"  >cam5 physics:</desc>
-    <desc compset="_EAM.*CMIP6"    >EAM with complete set of E3SM atmospheric mods for V3 (72 layers model) with chemUCI, Linozv3, MAM5 and VBS SOA - CMIP6-DECK:</desc>
-    <desc compset="_EAM.*CMIP6-HR" >high-res (ne120 w/ 18to6 ocn) 72 layer E3SM v1 atmos model with CMIP6 forcings </desc>
-    <desc compset="_EAM.*CMIP6-LR" >low-res (ne30 w/ oECv3 ocn) 72 layer E3SM v1 atmos model with CMIP6 forcings </desc>
+    <desc compset="_EAM.*">EAM with </desc>
+    <desc compset="^.*_EAM(?:(?!MMF|SCREAM|IDEAL|ADIAB).)*$">complete set of E3SM atmospheric mods for V3 (80 layers, P3, ZM  with convective microphysics, chemUCI, Linozv3, MAM5 and VBS SOA): </desc>
+    <desc compset="_EAM.*CMIP6"    >CMIP6 forcings:</desc>
     <desc compset="_EAM.*AR5sf"    >E3SM plus super-fast chemistry with AR5 emissions:</desc>
     <desc compset="_EAM%FCHM">EAM super_fast_llnl chemistry:</desc>
     <desc compset="_EAM%RCO2">EAM CO2 ramp: </desc>
-    <desc compset="ARM95_EAM%">single column EAM ARM95 IOP test case:</desc>
-    <desc compset="ARM97_EAM%">single column EAM ARM97 IOP test case:</desc>
+    <desc compset="ARM95_EAM%">single column ARM95 IOP test case:</desc>
+    <desc compset="ARM97_EAM%">single column ARM97 IOP test case:</desc>
     <desc compset="RICO_EAM%">single column EAM RICO IOP test case:</desc>
-    <desc compset="ADIAB"        >EAM adiabatic physics:</desc>
-    <desc compset="IDEAL"        >EAM ideal physics:</desc>
+    <desc compset="ADIAB"        >adiabatic physics:</desc>
+    <desc compset="IDEAL"        >ideal physics:</desc>
     <desc compset="AMIP">Atmospheric Model Intercomparison Project protocol: </desc>
-    <desc compset="EAM.*_BGC%*">EAM prognostic CO2 cycle turned on.</desc>
+    <desc compset="EAM.*_BGC%*">prognostic CO2 cycle turned on.</desc>
     <desc compset="_EAM%SCREAM-LR-DYAMOND1">Fortran version of SCREAM with SHOC, P3, RRTMGP, and prescribed aerosol. Initialized for DYAMOND1 (2016-08-01).</desc>
     <desc compset="_EAM%SCREAM-HR-DYAMOND1">Fortran version of SCREAM with NH dycore, SHOC, P3, RRTMGP, prescribed aerosol, and no deep convection. Initialized for DYAMOND1 (2016-08-01).</desc>
     <desc compset="_EAM%SCREAM-LR-DYAMOND2">Fortran version of SCREAM with SHOC, P3, RRTMGP, and prescribed aerosol. Initialized for DYAMOND2 (2020-01-20).</desc>
     <desc compset="_EAM%SCREAM-HR-DYAMOND2">Fortran version of SCREAM with NH dycore, SHOC, P3, RRTMGP, prescribed aerosol, and no deep convection. Initialized for DYAMOND2 (2020-01-20).</desc>
+    <desc compset="_EAM%DPSCREAM">Fortran version of SCREAM with SHOC, P3, RRTMGP, and prescribed aerosol: doubly periodic boundary conditions.</desc>
     <desc compset="_EAM%SCREAM-LR_">Fortran version of SCREAM with SHOC, P3, RRTMGP, and prescribed aerosol.</desc>
     <desc compset="_EAM%SCREAM-HR_">Fortran version of SCREAM with NH dycore, SHOC, P3, RRTMGP, prescribed aerosol, and no deep convection.</desc>
     <!-- MMF / Super-Parameterization -->


### PR DESCRIPTION
The case descriptions for E3SM atmosphere component are outdated for various
configurations.  Changes are made to update the description for standard EAMv3.
Additional changes are made to have proper distinction for describing 
SCM, DPSCREAM, MMF and idealized (IDEAL, ADIAB) cases .

Fixes #6244.

[BFB] Only changes atm case description in README.case

------------------------------------------------------------------------------------
Use negative look-around to have a single regex to recognize various configurations (compsets)
to apply the default EAMv3 description. 

With the changes, the case descriptions for ATM for the following representative cases become

```
FIDEAL:   Component ATM is EAM with ideal physics:
F2010:   Component ATM is EAM with complete set of E3SM atmospheric mods for V3 (80 layers, P3, ZM  with convective microphysics, chemUCI, Linozv3, MAM5 and VBS SOA): CMIP6 forcings:
FSCM-ARM97:   Component ATM is EAM with complete set of E3SM atmospheric mods for V3 (80 layers, P3, ZM  with convective microphysics, chemUCI, Linozv3, MAM5 and VBS SOA): single column ARM97 IOP test case:
F2010-MMF1:  Component ATM is EAM with E3SM-MMF, RRTMGPXX, 1-mom micro, prescribed aerosol
FDPSCREAM-ARM97:   Component ATM is EAM with single column ARM97 IOP test case:Fortran version of SCREAM with SHOC, P3, RRTMGP, and prescribed aerosol: doubly periodic boundary conditions.

```