### PR TITLE
Changes the default setting for `rof_heat`

### DIFF
--- a/driver-mct/cime_config/namelist_definition_drv.xml
+++ b/driver-mct/cime_config/namelist_definition_drv.xml
@@ -228,7 +228,6 @@
     </desc>
     <values>
       <value>.false.</value>
-      <value cime_model='e3sm'>.true.</value>
     </values>
   </entry>
 

--- a/driver-moab/cime_config/namelist_definition_drv.xml
+++ b/driver-moab/cime_config/namelist_definition_drv.xml
@@ -228,7 +228,6 @@
     </desc>
     <values>
       <value>.false.</value>
-      <value cime_model='e3sm'>.true.</value>
     </values>
   </entry>
 


### PR DESCRIPTION
The heat model in MOSART is not supported by default. Thus, the 
default value of `rof_heat` is set to `.false.`.

[NML]
[BFB] but removes fields from coupler history.