### PR TITLE
Single Column Model Updates & Fixes for v3

### DIFF
--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -917,6 +917,7 @@
 <cld_sed              microphys="mg2">  1.0D0       </cld_sed>
 <mg_prc_coeff_fix     microphys="mg2">  .false.     </mg_prc_coeff_fix>
 <micro_nccons         microphys="mg2">  100.D6      </micro_nccons>
+<micro_nccons         microphys="p3">   200.D6      </micro_nccons>
 <micro_nicons         microphys="mg2">  0.1D6       </micro_nicons>
 <micro_mincdnc        microphys="mg2">  -999.       </micro_mincdnc>
 <p3_mincdnc           microphys="p3">  -999.        </p3_mincdnc> 

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -4706,7 +4706,9 @@ Default: FALSE
 
 <entry id="precip_off" type="logical" category="scm"
        group="cam_inparm" valid_values="">
-Turn off microphysics computation.
+Turn off microphysics computation for MG2.  For P3 this disables the generation of
+liquid precipitation via autoconversion only, to be used for idealized simulations of
+warm phase boundary layer clouds.
 Default: FALSE
 </entry>                                                                        |
                                                                                 |

--- a/components/eam/bld/namelist_files/use_cases/scam_generic.xml
+++ b/components/eam/bld/namelist_files/use_cases/scam_generic.xml
@@ -3,7 +3,6 @@
 
 <namelist_defaults>
 
-<ncdata             >atm/cam/inic/homme/cami_mam3_Linoz_ne4np4_L72_c160909.nc</ncdata>
 <soag_ext_file      >atm/cam/chem/trop_mozart_aero/emis/aces4bgc_nvsoa_soag_elev_2000_c160427.nc</soag_ext_file>
 
 <!-- SCM is configured with ne4 grid, but we want settings for an ne30 simulation -->

--- a/components/eam/cime_config/config_component.xml
+++ b/components/eam/cime_config/config_component.xml
@@ -136,7 +136,7 @@
       <value compset="20TR(?:SOI)?_EAM.*CHEMUCI.*LINOZ.*MAM5"  >20TR_eam_chemUCI-Linoz-mam5</value>
       <value compset="ARM95_EAM"                        >scam_arm95</value>
       <value compset="ARM97_EAM"                        >scm_arm97_chemUCI-Linoz-mam5-vbs</value>
-      <value compset="SCM_EAM"                          >scm_generic_chemUCI-Linoz-mam5-vbs</value>
+      <value compset="SCM_EAM"                          >scam_generic</value>
       <value compset="PIPD_EAM"                         >1850-PD_cam5</value>
       <value compset="_EAM%AQP_"                        >aquaplanet_EAMv1</value>
       <value compset="_EAM%RCE_"                        >RCEMIP_EAMv1</value>

--- a/components/eam/src/dynamics/se/se_iop_intr_mod.F90
+++ b/components/eam/src/dynamics/se/se_iop_intr_mod.F90
@@ -56,7 +56,7 @@ subroutine iop_setinitial(elem)
   integer i, j, k, cix, ie, thelev
   integer inumliq, inumice, icldliq, icldice
 
-  if (.not. use_replay .and. get_nstep() .eq. 0 .and. par%dynproc) then
+  if (get_nstep() .eq. 0 .and. par%dynproc) then
     call cnst_get_ind('NUMLIQ', inumliq, abrtf=.false.)
     call cnst_get_ind('NUMICE', inumice, abrtf=.false.)
     call cnst_get_ind('CLDLIQ', icldliq)
@@ -215,8 +215,7 @@ subroutine iop_setfield(elem,iop_update_phase1)
   integer i, j, k, ie
 
   do ie=1,nelemd
-    if (have_ps .and. use_replay .and. .not. iop_update_phase1) elem(ie)%state%ps_v(:,:,:) = psobs
-    if (have_ps .and. .not. use_replay) elem(ie)%state%ps_v(:,:,:) = psobs
+    if (have_ps) elem(ie)%state%ps_v(:,:,:) = psobs
     do i=1, PLEV
       ! If DP CRM mode do NOT write over dycore vertical velocity
       if ((have_omega .and. iop_update_phase1) .and. .not. dp_crm) elem(ie)%derived%omega_p(:,:,i)=wfld(i)  !     set t to tobs at first

--- a/components/eam/src/physics/p3/eam/micro_p3_interface.F90
+++ b/components/eam/src/physics/p3/eam/micro_p3_interface.F90
@@ -42,6 +42,7 @@ module micro_p3_interface
   use ncdio_atm,       only: infld
   use ppgrid,         only: begchunk, endchunk, pcols, pver, pverp,psubcols
   use cam_history_support, only: add_hist_coord
+  use iop_data_mod,   only: precip_off
        
   implicit none
   save
@@ -131,8 +132,8 @@ module micro_p3_interface
       p3_wbf_coeff             = huge(1.0_rtype), &
       p3_mincdnc               = huge(1.0_rtype), & 
       p3_max_mean_rain_size    = huge(1.0_rtype), &
-      p3_embryonic_rain_size   = huge(1.0_rtype)
-   
+      p3_embryonic_rain_size   = huge(1.0_rtype), &
+      micro_nccons             = huge(1.0_rtype)
 
    integer :: ncnst
 
@@ -165,7 +166,7 @@ subroutine micro_p3_readnl(nlfile)
        micro_p3_tableversion, micro_p3_lookup_dir, micro_aerosolactivation, micro_subgrid_cloud, &
        micro_tend_output, p3_autocon_coeff, p3_qc_autocon_expon, p3_nc_autocon_expon, p3_accret_coeff, &
        p3_qc_accret_expon, p3_wbf_coeff, p3_max_mean_rain_size, p3_embryonic_rain_size, &
-       do_prescribed_CCN, do_Cooper_inP3, p3_mincdnc 
+       do_prescribed_CCN, do_Cooper_inP3, p3_mincdnc, micro_nccons
 
   !-----------------------------------------------------------------------------
 
@@ -220,6 +221,7 @@ subroutine micro_p3_readnl(nlfile)
   call mpibcast(p3_embryonic_rain_size,  1 ,                         mpir8,   0, mpicom)
   call mpibcast(do_prescribed_CCN,       1,                          mpilog,  0, mpicom)
   call mpibcast(do_Cooper_inP3,          1,                          mpilog,  0, mpicom)
+  call mpibcast(micro_nccons,            1,                          mpir8,   0, mpicom)
 
 #endif
 
@@ -1363,6 +1365,8 @@ end subroutine micro_p3_readnl
          qv_prev(its:ite,kts:kte),         & ! IN  qv at end of prev p3_main call   kg kg-1
          t_prev(its:ite,kts:kte),          & ! IN  t at end of prev p3_main call    K
          col_location(its:ite,:3),         & ! IN column locations
+         precip_off,                       & ! IN Option to turn precip (liquid) off
+         micro_nccons,                     & ! IN Option for constant droplet concentration
          diag_equiv_reflectivity(its:ite,kts:kte), & !OUT equivalent reflectivity (rain + ice) [dBz]
          diag_ze_rain(its:ite,kts:kte),diag_ze_ice(its:ite,kts:kte)) !OUT equivalent reflectivity for rain and ice [dBz]
          

--- a/components/eam/src/physics/p3/eam/micro_p3_utils.F90
+++ b/components/eam/src/physics/p3/eam/micro_p3_utils.F90
@@ -33,9 +33,6 @@ module micro_p3_utils
     ! maximum total ice concentration (sum of all categories)
     real(rtype), public, parameter :: max_total_ni = 500.e+3_rtype  ! (m)
 
-    ! droplet concentration (m-3)
-    real(rtype), public, parameter :: nccnst = 200.e+6_rtype
-
     ! parameters for Seifert and Beheng (2001) autoconversion/accretion
     real(rtype), public, parameter :: kc     = 9.44e+9_rtype
     real(rtype), public, parameter :: kr     = 5.78e+3_rtype


### PR DESCRIPTION
Modify and fix the single column model (SCM) to make it compatible with master and v3.  Specifically: 

1. The config_component for SCM_EAM has been changed to “scam_generic” (which should have never been changed).  When running cases with the standardized scripts prescribed aerosols are used, which is not compatible with the scm_generic_chemUCI-Linoz-mam5-vbs component currently specified.  (Aside: a new prescribed aerosol file has been generated by running E3SM with mam5.  This file has been uploaded to the E3SM data server and the E3SM SCM scripts have been updated to use this file).
2. Idealization flags have been added to the P3 microphysics to allow for:
    1. Runs with no precipitation.  Note that in the P3 implementation this only turns off liquid precipitation, which is used in several GCSS boundary layer cloud cases in the E3SM SCM library.  
    2. Prescribed droplet concentration.  This was already a feature in place in P3 but this PR connects this functionality to the EAM namelist.
3. Fixes to allow the ability to “replay” a column once again (back by semi-popular demand!).  This was a feature that worked in E3SMv1 but has not been functional for sometime.  The fix in this PR allows users to generate output needed to make IOP forcing files to replay a single column.  Note that additional post-processing is required to actually do an SCM run (in which the user needs to consult with the E3SM wiki page).  

Further documentation and scripts have been updated on the E3SM SCM wiki to reflect changes made in this PR (https://github.com/E3SM-Project/scmlib/wiki/E3SM-Single-Column-Model-Home).

[BFB]

All e3sm_developer tests pass on pm-cpu.