### PR TITLE
Changing clobber mode in ocean conservation analysis

### DIFF
--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -1006,7 +1006,7 @@ def buildnml(case, caseroot, compname):
             lines.append('        filename_interval="00-01-00_00:00:00"')
             lines.append('        reference_time="01-01-01_00:00:00"')
             lines.append('        output_interval="00-01-00_00:00:00"')
-            lines.append('        clobber_mode="append"')
+            lines.append('        clobber_mode="truncate"')
             lines.append('        packages="conservationCheckAMPKG">')
             lines.append('')
             lines.append('<var name="xtime"/>')


### PR DESCRIPTION
Previously the clobber mode in the ocean conservation analysis member was set to 'append', which would throw errors to `log.ocean.*.err` files when rerunning a case:

```
ERROR: Writing to stream 'conservationCheckOutput' would overwrite record    1 in file 'SMS_Lm1_P512.ne30pg2_r05_IcoswISC30E3r5.CRYO1850.chrysalis_intel.20240225_133103_09nrwo.mpaso.hist.am.conservationCheck.0001-02-01.nc',
ERROR:     but clobber_mode is set to 'append'.
```

Changing clobber mode to `truncate` avoids these errors.

[BFB]