### PR TITLE
Fix ncol/pcols mismatch on interpolating aerosol mass fields to pressure levels

### DIFF
--- a/components/eam/src/chemistry/mozart/mo_chm_diags.F90
+++ b/components/eam/src/chemistry/mozart/mo_chm_diags.F90
@@ -1488,16 +1488,16 @@ contains
           
           call outfld( 'Mass_'//trim(aerosol_name(aerosol_idx))//'_srf',  mass_3d_tmp(:ncol,pver), ncol, lchnk )
 
-          call vertinterp(ncol, pcols, pver, pmid,  85000._r8, mass_3d_tmp, mass_at_pressure)
+          call vertinterp(ncol, ncol, pver, pmid(:ncol,:),  85000._r8, mass_3d_tmp, mass_at_pressure)
           call outfld( 'Mass_'//trim(aerosol_name(aerosol_idx))//'_850',  mass_at_pressure, ncol, lchnk )
 
-          call vertinterp(ncol, pcols, pver, pmid,  50000._r8, mass_3d_tmp, mass_at_pressure)
+          call vertinterp(ncol, ncol, pver, pmid(:ncol,:),  50000._r8, mass_3d_tmp, mass_at_pressure)
           call outfld( 'Mass_'//trim(aerosol_name(aerosol_idx))//'_500',  mass_at_pressure, ncol, lchnk )
 
-          call vertinterp(ncol, pcols, pver, pmid,  33000._r8, mass_3d_tmp, mass_at_pressure)
+          call vertinterp(ncol, ncol, pver, pmid(:ncol,:),  33000._r8, mass_3d_tmp, mass_at_pressure)
           call outfld( 'Mass_'//trim(aerosol_name(aerosol_idx))//'_330',  mass_at_pressure, ncol, lchnk )
 
-          call vertinterp(ncol, pcols, pver, pmid,  20000._r8, mass_3d_tmp, mass_at_pressure)
+          call vertinterp(ncol, ncol, pver, pmid(:ncol,:),  20000._r8, mass_3d_tmp, mass_at_pressure)
           call outfld( 'Mass_'//trim(aerosol_name(aerosol_idx))//'_200',  mass_at_pressure, ncol, lchnk )
 
        end do


### PR DESCRIPTION
The input dimension size specified in call vertinterp to interpolate aerosol masses to
pressure levels can be larger than the actual mass array (pcols >= ncol). This can cause
unintended values, either from different levels or random values outside the memory 
space associated with the array being used for interpolation, resulting in NaN values for
some configuration or on some machines. Even though not resulting in NaN values for a run,
such mismatch is also expected to cause the interpolated arrays being corrupted.

Fixes #6259.

[BFB] Differences only for diagnostic fields such as mass_bc_850 in eam.h0, if they are saved for a test