### PR TITLE
define new GMPAS, GPMAS, ECO compsets with JRA

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -489,6 +489,36 @@
       <mask>WC14to60E2r3</mask>
     </model_grid>
 
+    <model_grid alias="TL319_r05_WC14to60E2r3" compset="(DATM|XATM|SATM)">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">r05</grid>
+      <grid name="ocnice">WC14to60E2r3</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>WC14to60E2r3</mask>
+    </model_grid>
+
+    <model_grid alias="TL319_r05_EC30to60E2r2" compset="(DATM|XATM|SATM)">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">r05</grid>
+      <grid name="ocnice">EC30to60E2r2</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>EC30to60E2r2</mask>
+    </model_grid>
+
+    <model_grid alias="TL319_r05_ARRM10to60E2r1" compset="(DATM|XATM|SATM)">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">r05</grid>
+      <grid name="ocnice">ARRM10to60E2r1</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>ARRM10to60E2r1</mask>
+    </model_grid>
+
     <model_grid alias="TL319_WCAtl12to45E2r4" compset="(DATM|XATM|SATM)">
       <grid name="atm">TL319</grid>
       <grid name="lnd">TL319</grid>
@@ -4108,6 +4138,13 @@
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS18to6v3/map_oRRS18to6v3_to_TL319_aave.220124.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="TL319" lnd_grid="r05">
+       <map name="ATM2LND_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_r05_traave.20240212.nc</map>
+       <map name="ATM2LND_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_r05_trbilin.20240212.nc</map>
+       <map name="LND2ATM_FMAPNAME">cpl/gridmaps/TL319/map_r05_to_TL319_traave.20240212.nc</map>
+       <map name="LND2ATM_SMAPNAME">cpl/gridmaps/TL319/map_r05_to_TL319_traave.20240212.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="T31" ocn_grid="gx3v7">
       <map name="ATM2OCN_FMAPNAME">cpl/cpl6/map_T31_to_gx3v7_aave_da_090903.nc</map>
       <map name="ATM2OCN_SMAPNAME">cpl/cpl6/map_T31_to_gx3v7_patch_090903.nc</map>
@@ -4220,6 +4257,11 @@
     <gridmap atm_grid="ne120np4" rof_grid="r0125">
       <map name="ATM2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/ne120np4/map_ne120np4_to_0.125_nomask_aave.160613.nc</map>
       <map name="ATM2ROF_SMAPNAME">lnd/clm2/mappingdata/maps/ne120np4/map_ne120np4_to_0.125_nomask_aave.160613.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="TL319" rof_grid="r05">
+       <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_r05_traave.20240212.nc</map>
+       <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_r05_trbilin.20240212.nc</map>
     </gridmap>
 
     <!--  QL, 150525, wav to ocn, atm, ice mapping files  -->

--- a/components/mpas-ocean/cime_config/config_compsets.xml
+++ b/components/mpas-ocean/cime_config/config_compsets.xml
@@ -63,6 +63,66 @@
   </compset>
 
   <compset>
+    <alias>GMPAS-OECO-JRA</alias>
+    <lname>2000_DATM%JRA_SLND_MPASSI_MPASO%OECODATMFORCED_DROF%JRA_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>GMPAS-OECO-JRA1p4</alias>
+    <lname>2000_DATM%JRA-1p4-2018_SLND_MPASSI_MPASO%OECODATMFORCED_DROF%JRA-1p4-2018_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>GMPAS-OECO-JRA1p5</alias>
+    <lname>2000_DATM%JRA-1p5_SLND_MPASSI_MPASO%OECODATMFORCED_DROF%JRA-1p5_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>GMPAS-OIECO-JRA</alias>
+    <lname>2000_DATM%JRA_SLND_MPASSI%BGC_MPASO%OIECODATMFORCED_DROF%JRA_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>GMPAS-OIECO-JRA1p4</alias>
+    <lname>2000_DATM%JRA-1p4-2018_SLND_MPASSI%BGC_MPASO%OIECODATMFORCED_DROF%JRA-1p4-2018_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>GMPAS-OIECO-JRA1p5</alias>
+    <lname>2000_DATM%JRA-1p5_SLND_MPASSI%BGC_MPASO%OIECODATMFORCED_DROF%JRA-1p5_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>GPMPAS-OECO-JRA</alias>
+    <lname>2000_DATM%JRA_ELM%SPBC_MPASSI_MPASO%OECODATMFORCED_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>GPMPAS-OECO-JRA1p4</alias>
+    <lname>2000_DATM%JRA-1p4-2018_ELM%SPBC_MPASSI_MPASO%OECODATMFORCED_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>GPMPAS-OECO-JRA1p5</alias>
+    <lname>2000_DATM%JRA-1p5_ELM%SPBC_MPASSI_MPASO%OECODATMFORCED_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>GPMPAS-OIECO-JRA</alias>
+    <lname>2000_DATM%JRA_ELM%SPBC_MPASSI%BGC_MPASO%OIECODATMFORCED_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>GPMPAS-OIECO-JRA1p4</alias>
+    <lname>2000_DATM%JRA-1p4-2018_ELM%SPBC_MPASSI%BGC_MPASO%OIECODATMFORCED_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>GPMPAS-OIECO-JRA1p5</alias>
+    <lname>2000_DATM%JRA-1p5_ELM%SPBC_MPASSI%BGC_MPASO%OIECODATMFORCED_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>GMPAS-JRA1p5-DIB-PISMF</alias>
     <lname>2000_DATM%JRA-1p5_SLND_MPASSI%DIB_MPASO%IBPISMFDATMFORCED_DROF%JRA-1p5-AIS0ROF_SGLC_SWAV</lname>
   </compset>

--- a/components/mpas-ocean/cime_config/config_compsets.xml
+++ b/components/mpas-ocean/cime_config/config_compsets.xml
@@ -63,23 +63,8 @@
   </compset>
 
   <compset>
-    <alias>GMPAS-OECO-JRA</alias>
-    <lname>2000_DATM%JRA_SLND_MPASSI_MPASO%OECODATMFORCED_DROF%JRA_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
     <alias>GMPAS-OECO-JRA1p4</alias>
     <lname>2000_DATM%JRA-1p4-2018_SLND_MPASSI_MPASO%OECODATMFORCED_DROF%JRA-1p4-2018_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>GMPAS-OECO-JRA1p5</alias>
-    <lname>2000_DATM%JRA-1p5_SLND_MPASSI_MPASO%OECODATMFORCED_DROF%JRA-1p5_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>GMPAS-OIECO-JRA</alias>
-    <lname>2000_DATM%JRA_SLND_MPASSI%BGC_MPASO%OIECODATMFORCED_DROF%JRA_SGLC_SWAV</lname>
   </compset>
 
   <compset>
@@ -88,38 +73,13 @@
   </compset>
 
   <compset>
-    <alias>GMPAS-OIECO-JRA1p5</alias>
-    <lname>2000_DATM%JRA-1p5_SLND_MPASSI%BGC_MPASO%OIECODATMFORCED_DROF%JRA-1p5_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>GPMPAS-OECO-JRA</alias>
-    <lname>2000_DATM%JRA_ELM%SPBC_MPASSI_MPASO%OECODATMFORCED_MOSART_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
     <alias>GPMPAS-OECO-JRA1p4</alias>
     <lname>2000_DATM%JRA-1p4-2018_ELM%SPBC_MPASSI_MPASO%OECODATMFORCED_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
-    <alias>GPMPAS-OECO-JRA1p5</alias>
-    <lname>2000_DATM%JRA-1p5_ELM%SPBC_MPASSI_MPASO%OECODATMFORCED_MOSART_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>GPMPAS-OIECO-JRA</alias>
-    <lname>2000_DATM%JRA_ELM%SPBC_MPASSI%BGC_MPASO%OIECODATMFORCED_MOSART_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
     <alias>GPMPAS-OIECO-JRA1p4</alias>
     <lname>2000_DATM%JRA-1p4-2018_ELM%SPBC_MPASSI%BGC_MPASO%OIECODATMFORCED_MOSART_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>GPMPAS-OIECO-JRA1p5</alias>
-    <lname>2000_DATM%JRA-1p5_ELM%SPBC_MPASSI%BGC_MPASO%OIECODATMFORCED_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>

--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -265,6 +265,7 @@
       <value compset="20TR.*_DATM%(QIA|CRU|GSW)">CO2A</value>
       <value compset="RCP.*_DATM%(QIA|CRU|GSW)" >CO2A</value>
       <value compset="_DATM%IAF.*_MPASO%OECO" >CO2A</value>
+      <value compset="_DATM%JRA.*_MPASO%OECO" >CO2A</value>
       <value compset="_MPASSI%BGC.*_MPASO%OIECO" >CO2A_OI</value>
       <value compset="_MPASSI%BGC.*_MPASO%TOIECO_" >CO2A_OI</value>
       <value compset="_MPASSI_MPASO_.*_BGC%BCRC" >CO2C</value>

--- a/driver-moab/cime_config/config_component_e3sm.xml
+++ b/driver-moab/cime_config/config_component_e3sm.xml
@@ -265,6 +265,7 @@
       <value compset="20TR.*_DATM%(QIA|CRU|GSW)">CO2A</value>
       <value compset="RCP.*_DATM%(QIA|CRU|GSW)" >CO2A</value>
       <value compset="_DATM%IAF.*_MPASO%OECO" >CO2A</value>
+      <value compset="_DATM%JRA.*_MPASO%OECO" >CO2A</value>
       <value compset="_MPASSI%BGC.*_MPASO%OIECO" >CO2A_OI</value>
       <value compset="_MPASSI%BGC.*_MPASO%TOIECO_" >CO2A_OI</value>
       <value compset="_MPASSI_MPASO_.*_BGC%BCRC" >CO2C</value>


### PR DESCRIPTION
Define new compset aliases that support marine BGC using JRA1.4 forcing.  Also allow GPMPAS configurations (with active ELM and MOSART) to work with WC14to60E2r3, EC30to60E2r2, and ARRM10to60E2r1 grids.

Fixes [#6209](https://github.com/E3SM-Project/E3SM/issues/6209) 

Fixes [#6208](https://github.com/E3SM-Project/E3SM/issues/6208)

[BFB]