### PR TITLE
Update test-PEs for ne30+Icos WCYCL cases on Chrysalis

### DIFF
--- a/cime_config/testmods_dirs/config_pes_tests.xml
+++ b/cime_config/testmods_dirs/config_pes_tests.xml
@@ -118,17 +118,17 @@
   <grid name="a%ne30np4.pg.+_oi%IcoswISC30E3r5">
     <mach name="chrysalis">
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+_SESP$" pesize="any">
-        <comment>tests+chrysalis: -compset WCYCL* -res ne30pg*IcoswISC30E3r5 on 4 nodes pure-MPI </comment>
+        <comment>tests+chrysalis: -compset WCYCL* -res ne30pg*IcoswISC30E3r5 on 6 nodes pure-MPI </comment>
         <ntasks>
-          <ntasks_atm>192</ntasks_atm>
-          <ntasks_lnd>192</ntasks_lnd>
-          <ntasks_rof>192</ntasks_rof>
-          <ntasks_ice>192</ntasks_ice>
+          <ntasks_atm>320</ntasks_atm>
+          <ntasks_lnd>320</ntasks_lnd>
+          <ntasks_rof>320</ntasks_rof>
+          <ntasks_ice>320</ntasks_ice>
           <ntasks_ocn>64</ntasks_ocn>
-          <ntasks_cpl>192</ntasks_cpl>
+          <ntasks_cpl>320</ntasks_cpl>
         </ntasks>
         <rootpe>
-          <rootpe_ocn>192</rootpe_ocn>
+          <rootpe_ocn>320</rootpe_ocn>
         </rootpe>
       </pes>
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+SGLC_SWAV_SIAC_SESP_BGC.*" pesize="any">


### PR DESCRIPTION
This fixes OOM errors for ERP and PEM tests.

[NML]