### PR TITLE
For pm-cpu (as well as gcp12, muller-cpu) use 2 nodes instead of 1 for conusx4v1pg2_r05_IcoswISC30E3r5.F2010

### DIFF
--- a/components/eam/cime_config/config_pes.xml
+++ b/components/eam/cime_config/config_pes.xml
@@ -1106,6 +1106,19 @@
         </ntasks>
       </pes>
     </mach>
+    <mach name="pm-cpu|muller-cpu|alvarez|gcp12">
+      <pes compset=".*EAM.+ELM.+MPASSI.+DOCN.+MOSART.+" pesize="any">
+        <comment>pm-cpu/gcp, eam, 2 nodes: --res conusx4v1_r05_oECv3 --compset F2010 </comment>
+        <ntasks>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_cpl>-2</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
   </grid>
   <grid name="a%ne0np4_northamericax4v1.pg2_l%.+_oi%WC14to60E2r3">
     <mach name="chrysalis">


### PR DESCRIPTION
For pm-cpu (as well as gcp12, muller-cpu) use 2 nodes instead of 1 for the F case using new resolution: `conusx4v1pg2_r05_IcoswISC30E3r5.F2010`

The cdash test `SMS_D_Ln5.conusx4v1pg2_r05_IcoswISC30E3r5.F2010`
was sometimes hitting OOM and also could use speed improvement

[bfb]