### PR TITLE
Add FRIS meshes

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -2444,14 +2444,14 @@
       <file grid="ice|ocn" mask="WCAtl12to45E2r4">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_WCAtl12to45E2r4.210318.nc</file>
       <file grid="atm|lnd" mask="SOwISC12to60E2r4">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_SOwISC12to60E2r4.210119.nc</file>
       <file grid="ice|ocn" mask="SOwISC12to60E2r4">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_SOwISC12to60E2r4.210119.nc</file>
-      <file grid="atm|lnd" mask="FRISwISC08to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_FRISwISC08to60E3r1.230926.nc</file>
-      <file grid="ice|ocn" mask="FRISwISC08to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC08to60E3r1.230926.nc</file>
-      <file grid="atm|lnd" mask="FRISwISC04to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_FRISwISC04to60E3r1.230912.nc</file>
-      <file grid="ice|ocn" mask="FRISwISC04to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC04to60E3r1.230912.nc</file>
-      <file grid="atm|lnd" mask="FRISwISC02to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_FRISwISC02to60E3r1.230926.nc</file>
-      <file grid="ice|ocn" mask="FRISwISC02to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC02to60E3r1.230926.nc</file>
-      <file grid="atm|lnd" mask="FRISwISC01to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_FRISwISC01to60E3r1.231005.nc</file>
-      <file grid="ice|ocn" mask="FRISwISC01to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC01to60E3r1.231005.nc</file>
+      <file grid="atm|lnd" mask="FRISwISC08to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_FRISwISC08to60E3r1.240214.nc</file>
+      <file grid="ice|ocn" mask="FRISwISC08to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC08to60E3r1.240214.nc</file>
+      <file grid="atm|lnd" mask="FRISwISC04to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_FRISwISC04to60E3r1.240214.nc</file>
+      <file grid="ice|ocn" mask="FRISwISC04to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC04to60E3r1.240214.nc</file>
+      <file grid="atm|lnd" mask="FRISwISC02to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_FRISwISC02to60E3r1.240214.nc</file>
+      <file grid="ice|ocn" mask="FRISwISC02to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC02to60E3r1.240214.nc</file>
+      <file grid="atm|lnd" mask="FRISwISC01to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_FRISwISC01to60E3r1.240216.nc</file>
+      <file grid="ice|ocn" mask="FRISwISC01to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC01to60E3r1.240216.nc</file>
       <file grid="atm|lnd" mask="ECwISC30to60E2r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_ECwISC30to60E2r1.201007.nc</file>
       <file grid="ice|ocn" mask="ECwISC30to60E2r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_ECwISC30to60E2r1.201007.nc</file>
       <file grid="atm|lnd" mask="IcoswISC30E3r5">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_IcoswISC30E3r5.231121.nc</file>
@@ -2828,28 +2828,28 @@
     <domain name="FRISwISC08to60E3r1">
       <nx>605169</nx>
       <ny>1</ny>
-      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.FRISwISC08to60E3r1.230926.nc</file>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.FRISwISC08to60E3r1.240214.nc</file>
       <desc>FRISwISC08to60E3r1 is a MPAS ice/ocean grid with enhanced resolution of 12km in the Southern Ocean around Antarctica and 4 km beneath the Filchner-Ronne Ice Shelf. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid:</desc>
     </domain>
 
     <domain name="FRISwISC04to60E3r1">
       <nx>718054</nx>
       <ny>1</ny>
-      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.FRISwISC04to60E3r1.230912.nc</file>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.FRISwISC04to60E3r1.240214.nc</file>
       <desc>FRISwISC04to60E3r1 is a MPAS ice/ocean grid with enhanced resolution of 12km in the Southern Ocean around Antarctica and 4 km beneath the Filchner-Ronne Ice Shelf. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid:</desc>
     </domain>
 
     <domain name="FRISwISC02to60E3r1">
       <nx>1055045</nx>
       <ny>1</ny>
-      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.FRISwISC02to60E3r1.230926.nc</file>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.FRISwISC02to60E3r1.240214.nc</file>
       <desc>FRISwISC02to60E3r1 is a MPAS ice/ocean grid with enhanced resolution of 12km in the Southern Ocean around Antarctica and 4 km beneath the Filchner-Ronne Ice Shelf. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid:</desc>
     </domain>
 
     <domain name="FRISwISC01to60E3r1">
       <nx>2162616</nx>
       <ny>1</ny>
-      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.FRISwISC01to60E3r1.231005.nc</file>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.FRISwISC01to60E3r1.240216.nc</file>
       <desc>FRISwISC01to60E3r1 is a MPAS ice/ocean grid with enhanced resolution of 12km in the Southern Ocean around Antarctica and 4 km beneath the Filchner-Ronne Ice Shelf. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid:</desc>
     </domain>
 
@@ -4161,35 +4161,35 @@
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="FRISwISC08to60E3r1">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC08to60E3r1_mono.230926.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC08to60E3r1-nomask_bilin.230926.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC08to60E3r1_patch.230926.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/FRISwISC08to60E3r1/map_FRISwISC08to60E3r1_to_TL319_mono.230926.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/FRISwISC08to60E3r1/map_FRISwISC08to60E3r1_to_TL319_mono.230926.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC08to60E3r1_traave.20240214.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC08to60E3r1-nomask_trbilin.20240214.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC08to60E3r1_esmfpatch.20240214.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/FRISwISC08to60E3r1/map_FRISwISC08to60E3r1_to_TL319_traave.20240214.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/FRISwISC08to60E3r1/map_FRISwISC08to60E3r1_to_TL319_traave.20240214.nc</map>
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="FRISwISC04to60E3r1">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC04to60E3r1_mono.230912.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC04to60E3r1-nomask_bilin.230912.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC04to60E3r1_patch.230912.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/FRISwISC04to60E3r1/map_FRISwISC04to60E3r1_to_TL319_mono.230912.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/FRISwISC04to60E3r1/map_FRISwISC04to60E3r1_to_TL319_mono.230912.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC04to60E3r1_traave.20240214.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC04to60E3r1-nomask_trbilin.20240214.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC04to60E3r1_esmfpatch.20240214.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/FRISwISC04to60E3r1/map_FRISwISC04to60E3r1_to_TL319_traave.20240214.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/FRISwISC04to60E3r1/map_FRISwISC04to60E3r1_to_TL319_traave.20240214.nc</map>
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="FRISwISC02to60E3r1">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC02to60E3r1_mono.230926.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC02to60E3r1-nomask_bilin.230926.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC02to60E3r1_patch.230926.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/FRISwISC02to60E3r1/map_FRISwISC02to60E3r1_to_TL319_mono.230926.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/FRISwISC02to60E3r1/map_FRISwISC02to60E3r1_to_TL319_mono.230926.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC02to60E3r1_traave.20240214.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC02to60E3r1-nomask_trbilin.20240214.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC02to60E3r1_esmfpatch.20240214.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/FRISwISC02to60E3r1/map_FRISwISC02to60E3r1_to_TL319_traave.20240214.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/FRISwISC02to60E3r1/map_FRISwISC02to60E3r1_to_TL319_traave.20240214.nc</map>
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="FRISwISC01to60E3r1">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC01to60E3r1_mono.231004.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC01to60E3r1-nomask_bilin.230927.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC01to60E3r1_patch.230927.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/FRISwISC01to60E3r1/map_FRISwISC01to60E3r1_to_TL319_mono.231004.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/FRISwISC01to60E3r1/map_FRISwISC01to60E3r1_to_TL319_mono.231004.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC01to60E3r1_traave.20240216.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC01to60E3r1-nomask_trbilin.20240216.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC01to60E3r1_esmfpatch.20240216.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/FRISwISC01to60E3r1/map_FRISwISC01to60E3r1_to_TL319_traave.20240216.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/FRISwISC01to60E3r1/map_FRISwISC01to60E3r1_to_TL319_traave.20240216.nc</map>
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="ECwISC30to60E2r1">
@@ -4719,23 +4719,23 @@
     </gridmap>
 
     <gridmap ocn_grid="FRISwISC08to60E3r1" rof_grid="JRA025">
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC08to60E3r1_smoothed.r150e300.230926.nc</map>
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC08to60E3r1_smoothed.r150e300.230926.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC08to60E3r1_cstmnn.r150e300.20230926.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC08to60E3r1_cstmnn.r150e300.20230926.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="FRISwISC04to60E3r1" rof_grid="JRA025">
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC04to60E3r1_smoothed.r150e300.230912.nc</map>
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC04to60E3r1_smoothed.r150e300.230912.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC04to60E3r1_cstmnn.r150e300.20230912.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC04to60E3r1_cstmnn.r150e300.20230912.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="FRISwISC02to60E3r1" rof_grid="JRA025">
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC02to60E3r1_smoothed.r150e300.230926.nc</map>
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC02to60E3r1_smoothed.r150e300.230926.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC02to60E3r1_cstmnn.r150e300.20230926.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC02to60E3r1_cstmnn.r150e300.20230926.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="FRISwISC01to60E3r1" rof_grid="JRA025">
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC01to60E3r1_smoothed.r150e300.230926.nc</map>
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC01to60E3r1_smoothed.r150e300.230926.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC01to60E3r1_cstmnn.r150e300.20230926.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC01to60E3r1_cstmnn.r150e300.20230926.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="ECwISC30to60E2r1" rof_grid="JRA025">

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -2826,7 +2826,7 @@
     </domain>
 
     <domain name="FRISwISC08to60E3r1">
-      <nx>718054</nx>
+      <nx>605169</nx>
       <ny>1</ny>
       <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.FRISwISC08to60E3r1.230926.nc</file>
       <desc>FRISwISC08to60E3r1 is a MPAS ice/ocean grid with enhanced resolution of 12km in the Southern Ocean around Antarctica and 4 km beneath the Filchner-Ronne Ice Shelf. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid:</desc>
@@ -2840,14 +2840,14 @@
     </domain>
 
     <domain name="FRISwISC02to60E3r1">
-      <nx>718054</nx>
+      <nx>1055045</nx>
       <ny>1</ny>
       <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.FRISwISC02to60E3r1.230926.nc</file>
       <desc>FRISwISC02to60E3r1 is a MPAS ice/ocean grid with enhanced resolution of 12km in the Southern Ocean around Antarctica and 4 km beneath the Filchner-Ronne Ice Shelf. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid:</desc>
     </domain>
 
     <domain name="FRISwISC01to60E3r1">
-      <nx>718054</nx>
+      <nx>2162616</nx>
       <ny>1</ny>
       <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.FRISwISC01to60E3r1.231005.nc</file>
       <desc>FRISwISC01to60E3r1 is a MPAS ice/ocean grid with enhanced resolution of 12km in the Southern Ocean around Antarctica and 4 km beneath the Filchner-Ronne Ice Shelf. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid:</desc>

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -509,6 +509,16 @@
       <mask>SOwISC12to60E2r4</mask>
     </model_grid>
 
+    <model_grid alias="TL319_FRISwISC04to60E3r1" compset="(DATM|XATM|SATM)">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">TL319</grid>
+      <grid name="ocnice">FRISwISC04to60E3r1</grid>
+      <grid name="rof">JRA025</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>FRISwISC04to60E3r1</mask>
+    </model_grid>
+
     <model_grid alias="TL319_ECwISC30to60E2r1" compset="(DATM|XATM|SATM)">
       <grid name="atm">TL319</grid>
       <grid name="lnd">TL319</grid>
@@ -2404,6 +2414,8 @@
       <file grid="ice|ocn" mask="WCAtl12to45E2r4">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_WCAtl12to45E2r4.210318.nc</file>
       <file grid="atm|lnd" mask="SOwISC12to60E2r4">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_SOwISC12to60E2r4.210119.nc</file>
       <file grid="ice|ocn" mask="SOwISC12to60E2r4">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_SOwISC12to60E2r4.210119.nc</file>
+      <file grid="atm|lnd" mask="FRISwISC04to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_FRISwISC04to60E3r1.230912.nc</file>
+      <file grid="ice|ocn" mask="FRISwISC04to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC04to60E3r1.230912.nc</file>
       <file grid="atm|lnd" mask="ECwISC30to60E2r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_ECwISC30to60E2r1.201007.nc</file>
       <file grid="ice|ocn" mask="ECwISC30to60E2r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_ECwISC30to60E2r1.201007.nc</file>
       <file grid="atm|lnd" mask="IcoswISC30E3r5">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_IcoswISC30E3r5.231121.nc</file>
@@ -2775,6 +2787,13 @@
       <ny>1</ny>
       <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.SOwISC12to60E2r4.210119.nc</file>
       <desc>SOwISC12to60E2r4 is a MPAS ice/ocean grid with enhanced resolution of 12km in the Southern Ocean around Antarctica. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid:</desc>
+    </domain>
+
+    <domain name="FRISwISC04to60E3r1">
+      <nx>718054</nx>
+      <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.FRISwISC04to60E3r1.230912.nc</file>
+      <desc>FRISwISC04to60E3r1 is a MPAS ice/ocean grid with enhanced resolution of 12km in the Southern Ocean around Antarctica and 4 km beneath the Filchner-Ronne Ice Shelf. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid:</desc>
     </domain>
 
     <domain name="ECwISC30to60E2r1">
@@ -4084,6 +4103,11 @@
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/SOwISC12to60E2r4/map_SOwISC12to60E2r4_to_TL319_aave.210119.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="TL319" ocn_grid="FRISwISC04to60E3r1">
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC04to60E3r1-nomask_bilin.230912.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC04to60E3r1_patch.230912.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="TL319" ocn_grid="ECwISC30to60E2r1">
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_ECwISC30to60E2r1_aave.201006.nc</map>
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_ECwISC30to60E2r1-nomask_bilin.201006.nc</map>
@@ -4608,6 +4632,11 @@
     <gridmap ocn_grid="SOwISC12to60E2r4" rof_grid="JRA025">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_SOwISC12to60E2r4_smoothed.r150e300.210119.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_SOwISC12to60E2r4_smoothed.r150e300.210119.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="FRISwISC04to60E3r1" rof_grid="JRA025">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC04to60E3r1_smoothed.r150e300.230912.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC04to60E3r1_smoothed.r150e300.230912.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="ECwISC30to60E2r1" rof_grid="JRA025">

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -4104,8 +4104,11 @@
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="FRISwISC04to60E3r1">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC04to60E3r1_mono.230912.nc</map>
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC04to60E3r1-nomask_bilin.230912.nc</map>
       <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC04to60E3r1_patch.230912.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/FRISwISC04to60E3r1/map_FRISwISC04to60E3r1_to_TL319_mono.230912.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/FRISwISC04to60E3r1/map_FRISwISC04to60E3r1_to_TL319_mono.230912.nc</map>
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="ECwISC30to60E2r1">

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -509,6 +509,16 @@
       <mask>SOwISC12to60E2r4</mask>
     </model_grid>
 
+    <model_grid alias="TL319_FRISwISC08to60E3r1" compset="(DATM|XATM|SATM)">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">TL319</grid>
+      <grid name="ocnice">FRISwISC08to60E3r1</grid>
+      <grid name="rof">JRA025</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>FRISwISC08to60E3r1</mask>
+    </model_grid>
+
     <model_grid alias="TL319_FRISwISC04to60E3r1" compset="(DATM|XATM|SATM)">
       <grid name="atm">TL319</grid>
       <grid name="lnd">TL319</grid>
@@ -517,6 +527,26 @@
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
       <mask>FRISwISC04to60E3r1</mask>
+    </model_grid>
+
+    <model_grid alias="TL319_FRISwISC02to60E3r1" compset="(DATM|XATM|SATM)">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">TL319</grid>
+      <grid name="ocnice">FRISwISC02to60E3r1</grid>
+      <grid name="rof">JRA025</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>FRISwISC02to60E3r1</mask>
+    </model_grid>
+
+    <model_grid alias="TL319_FRISwISC01to60E3r1" compset="(DATM|XATM|SATM)">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">TL319</grid>
+      <grid name="ocnice">FRISwISC01to60E3r1</grid>
+      <grid name="rof">JRA025</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>FRISwISC01to60E3r1</mask>
     </model_grid>
 
     <model_grid alias="TL319_ECwISC30to60E2r1" compset="(DATM|XATM|SATM)">
@@ -2414,8 +2444,14 @@
       <file grid="ice|ocn" mask="WCAtl12to45E2r4">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_WCAtl12to45E2r4.210318.nc</file>
       <file grid="atm|lnd" mask="SOwISC12to60E2r4">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_SOwISC12to60E2r4.210119.nc</file>
       <file grid="ice|ocn" mask="SOwISC12to60E2r4">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_SOwISC12to60E2r4.210119.nc</file>
+      <file grid="atm|lnd" mask="FRISwISC08to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_FRISwISC08to60E3r1.230913.nc</file>
+      <file grid="ice|ocn" mask="FRISwISC08to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC08to60E3r1.230913.nc</file>
       <file grid="atm|lnd" mask="FRISwISC04to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_FRISwISC04to60E3r1.230912.nc</file>
       <file grid="ice|ocn" mask="FRISwISC04to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC04to60E3r1.230912.nc</file>
+      <file grid="atm|lnd" mask="FRISwISC02to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_FRISwISC02to60E3r1.230914.nc</file>
+      <file grid="ice|ocn" mask="FRISwISC02to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC02to60E3r1.230914.nc</file>
+      <file grid="atm|lnd" mask="FRISwISC01to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_FRISwISC01to60E3r1.230915.nc</file>
+      <file grid="ice|ocn" mask="FRISwISC01to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC01to60E3r1.230915.nc</file>
       <file grid="atm|lnd" mask="ECwISC30to60E2r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_ECwISC30to60E2r1.201007.nc</file>
       <file grid="ice|ocn" mask="ECwISC30to60E2r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_ECwISC30to60E2r1.201007.nc</file>
       <file grid="atm|lnd" mask="IcoswISC30E3r5">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_IcoswISC30E3r5.231121.nc</file>
@@ -2789,11 +2825,32 @@
       <desc>SOwISC12to60E2r4 is a MPAS ice/ocean grid with enhanced resolution of 12km in the Southern Ocean around Antarctica. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid:</desc>
     </domain>
 
+    <domain name="FRISwISC08to60E3r1">
+      <nx>718054</nx>
+      <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.FRISwISC08to60E3r1.230913.nc</file>
+      <desc>FRISwISC08to60E3r1 is a MPAS ice/ocean grid with enhanced resolution of 12km in the Southern Ocean around Antarctica and 4 km beneath the Filchner-Ronne Ice Shelf. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid:</desc>
+    </domain>
+
     <domain name="FRISwISC04to60E3r1">
       <nx>718054</nx>
       <ny>1</ny>
       <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.FRISwISC04to60E3r1.230912.nc</file>
       <desc>FRISwISC04to60E3r1 is a MPAS ice/ocean grid with enhanced resolution of 12km in the Southern Ocean around Antarctica and 4 km beneath the Filchner-Ronne Ice Shelf. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid:</desc>
+    </domain>
+
+    <domain name="FRISwISC02to60E3r1">
+      <nx>718054</nx>
+      <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.FRISwISC02to60E3r1.230914.nc</file>
+      <desc>FRISwISC02to60E3r1 is a MPAS ice/ocean grid with enhanced resolution of 12km in the Southern Ocean around Antarctica and 4 km beneath the Filchner-Ronne Ice Shelf. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid:</desc>
+    </domain>
+
+    <domain name="FRISwISC01to60E3r1">
+      <nx>718054</nx>
+      <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.FRISwISC01to60E3r1.230915.nc</file>
+      <desc>FRISwISC01to60E3r1 is a MPAS ice/ocean grid with enhanced resolution of 12km in the Southern Ocean around Antarctica and 4 km beneath the Filchner-Ronne Ice Shelf. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid:</desc>
     </domain>
 
     <domain name="ECwISC30to60E2r1">
@@ -4103,12 +4160,36 @@
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/SOwISC12to60E2r4/map_SOwISC12to60E2r4_to_TL319_aave.210119.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="TL319" ocn_grid="FRISwISC08to60E3r1">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC08to60E3r1_mono.230913.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC08to60E3r1-nomask_bilin.230913.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC08to60E3r1_patch.230913.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/FRISwISC08to60E3r1/map_FRISwISC08to60E3r1_to_TL319_mono.230913.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/FRISwISC08to60E3r1/map_FRISwISC08to60E3r1_to_TL319_mono.230913.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="TL319" ocn_grid="FRISwISC04to60E3r1">
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC04to60E3r1_mono.230912.nc</map>
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC04to60E3r1-nomask_bilin.230912.nc</map>
       <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC04to60E3r1_patch.230912.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/FRISwISC04to60E3r1/map_FRISwISC04to60E3r1_to_TL319_mono.230912.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/FRISwISC04to60E3r1/map_FRISwISC04to60E3r1_to_TL319_mono.230912.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="TL319" ocn_grid="FRISwISC02to60E3r1">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC02to60E3r1_mono.230914.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC02to60E3r1-nomask_bilin.230914.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC02to60E3r1_patch.230914.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/FRISwISC02to60E3r1/map_FRISwISC02to60E3r1_to_TL319_mono.230914.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/FRISwISC02to60E3r1/map_FRISwISC02to60E3r1_to_TL319_mono.230914.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="TL319" ocn_grid="FRISwISC01to60E3r1">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC01to60E3r1_mono.230915.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC01to60E3r1-nomask_bilin.230915.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC01to60E3r1_patch.230915.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/FRISwISC01to60E3r1/map_FRISwISC01to60E3r1_to_TL319_mono.230915.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/FRISwISC01to60E3r1/map_FRISwISC01to60E3r1_to_TL319_mono.230915.nc</map>
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="ECwISC30to60E2r1">
@@ -4637,9 +4718,24 @@
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_SOwISC12to60E2r4_smoothed.r150e300.210119.nc</map>
     </gridmap>
 
+    <gridmap ocn_grid="FRISwISC08to60E3r1" rof_grid="JRA025">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC08to60E3r1_smoothed.r150e300.230913.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC08to60E3r1_smoothed.r150e300.230913.nc</map>
+    </gridmap>
+
     <gridmap ocn_grid="FRISwISC04to60E3r1" rof_grid="JRA025">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC04to60E3r1_smoothed.r150e300.230912.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC04to60E3r1_smoothed.r150e300.230912.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="FRISwISC02to60E3r1" rof_grid="JRA025">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC02to60E3r1_smoothed.r150e300.230914.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC02to60E3r1_smoothed.r150e300.230914.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="FRISwISC01to60E3r1" rof_grid="JRA025">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC01to60E3r1_smoothed.r150e300.230915.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC01to60E3r1_smoothed.r150e300.230915.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="ECwISC30to60E2r1" rof_grid="JRA025">

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -2450,8 +2450,8 @@
       <file grid="ice|ocn" mask="FRISwISC04to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC04to60E3r1.230912.nc</file>
       <file grid="atm|lnd" mask="FRISwISC02to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_FRISwISC02to60E3r1.230926.nc</file>
       <file grid="ice|ocn" mask="FRISwISC02to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC02to60E3r1.230926.nc</file>
-      <file grid="atm|lnd" mask="FRISwISC01to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_FRISwISC01to60E3r1.230915.nc</file>
-      <file grid="ice|ocn" mask="FRISwISC01to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC01to60E3r1.230915.nc</file>
+      <file grid="atm|lnd" mask="FRISwISC01to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_FRISwISC01to60E3r1.231005.nc</file>
+      <file grid="ice|ocn" mask="FRISwISC01to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC01to60E3r1.231005.nc</file>
       <file grid="atm|lnd" mask="ECwISC30to60E2r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_ECwISC30to60E2r1.201007.nc</file>
       <file grid="ice|ocn" mask="ECwISC30to60E2r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_ECwISC30to60E2r1.201007.nc</file>
       <file grid="atm|lnd" mask="IcoswISC30E3r5">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_IcoswISC30E3r5.231121.nc</file>
@@ -2849,7 +2849,7 @@
     <domain name="FRISwISC01to60E3r1">
       <nx>718054</nx>
       <ny>1</ny>
-      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.FRISwISC01to60E3r1.230915.nc</file>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.FRISwISC01to60E3r1.231005.nc</file>
       <desc>FRISwISC01to60E3r1 is a MPAS ice/ocean grid with enhanced resolution of 12km in the Southern Ocean around Antarctica and 4 km beneath the Filchner-Ronne Ice Shelf. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid:</desc>
     </domain>
 
@@ -4185,11 +4185,11 @@
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="FRISwISC01to60E3r1">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC01to60E3r1_mono.230915.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC01to60E3r1-nomask_bilin.230915.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC01to60E3r1_patch.230915.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/FRISwISC01to60E3r1/map_FRISwISC01to60E3r1_to_TL319_mono.230915.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/FRISwISC01to60E3r1/map_FRISwISC01to60E3r1_to_TL319_mono.230915.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC01to60E3r1_mono.231004.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC01to60E3r1-nomask_bilin.230927.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC01to60E3r1_patch.230927.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/FRISwISC01to60E3r1/map_FRISwISC01to60E3r1_to_TL319_mono.231004.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/FRISwISC01to60E3r1/map_FRISwISC01to60E3r1_to_TL319_mono.231004.nc</map>
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="ECwISC30to60E2r1">
@@ -4734,8 +4734,8 @@
     </gridmap>
 
     <gridmap ocn_grid="FRISwISC01to60E3r1" rof_grid="JRA025">
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC01to60E3r1_smoothed.r150e300.230915.nc</map>
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC01to60E3r1_smoothed.r150e300.230915.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC01to60E3r1_smoothed.r150e300.230926.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC01to60E3r1_smoothed.r150e300.230926.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="ECwISC30to60E2r1" rof_grid="JRA025">

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -2444,12 +2444,12 @@
       <file grid="ice|ocn" mask="WCAtl12to45E2r4">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_WCAtl12to45E2r4.210318.nc</file>
       <file grid="atm|lnd" mask="SOwISC12to60E2r4">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_SOwISC12to60E2r4.210119.nc</file>
       <file grid="ice|ocn" mask="SOwISC12to60E2r4">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_SOwISC12to60E2r4.210119.nc</file>
-      <file grid="atm|lnd" mask="FRISwISC08to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_FRISwISC08to60E3r1.230913.nc</file>
-      <file grid="ice|ocn" mask="FRISwISC08to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC08to60E3r1.230913.nc</file>
+      <file grid="atm|lnd" mask="FRISwISC08to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_FRISwISC08to60E3r1.230926.nc</file>
+      <file grid="ice|ocn" mask="FRISwISC08to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC08to60E3r1.230926.nc</file>
       <file grid="atm|lnd" mask="FRISwISC04to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_FRISwISC04to60E3r1.230912.nc</file>
       <file grid="ice|ocn" mask="FRISwISC04to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC04to60E3r1.230912.nc</file>
-      <file grid="atm|lnd" mask="FRISwISC02to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_FRISwISC02to60E3r1.230914.nc</file>
-      <file grid="ice|ocn" mask="FRISwISC02to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC02to60E3r1.230914.nc</file>
+      <file grid="atm|lnd" mask="FRISwISC02to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_FRISwISC02to60E3r1.230926.nc</file>
+      <file grid="ice|ocn" mask="FRISwISC02to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC02to60E3r1.230926.nc</file>
       <file grid="atm|lnd" mask="FRISwISC01to60E3r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_FRISwISC01to60E3r1.230915.nc</file>
       <file grid="ice|ocn" mask="FRISwISC01to60E3r1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_FRISwISC01to60E3r1.230915.nc</file>
       <file grid="atm|lnd" mask="ECwISC30to60E2r1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_ECwISC30to60E2r1.201007.nc</file>
@@ -2828,7 +2828,7 @@
     <domain name="FRISwISC08to60E3r1">
       <nx>718054</nx>
       <ny>1</ny>
-      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.FRISwISC08to60E3r1.230913.nc</file>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.FRISwISC08to60E3r1.230926.nc</file>
       <desc>FRISwISC08to60E3r1 is a MPAS ice/ocean grid with enhanced resolution of 12km in the Southern Ocean around Antarctica and 4 km beneath the Filchner-Ronne Ice Shelf. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid:</desc>
     </domain>
 
@@ -2842,7 +2842,7 @@
     <domain name="FRISwISC02to60E3r1">
       <nx>718054</nx>
       <ny>1</ny>
-      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.FRISwISC02to60E3r1.230914.nc</file>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.FRISwISC02to60E3r1.230926.nc</file>
       <desc>FRISwISC02to60E3r1 is a MPAS ice/ocean grid with enhanced resolution of 12km in the Southern Ocean around Antarctica and 4 km beneath the Filchner-Ronne Ice Shelf. The high resolution regions smoothly transition to the background resolution of the standard low resolution 60to30km grid:</desc>
     </domain>
 
@@ -4161,11 +4161,11 @@
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="FRISwISC08to60E3r1">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC08to60E3r1_mono.230913.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC08to60E3r1-nomask_bilin.230913.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC08to60E3r1_patch.230913.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/FRISwISC08to60E3r1/map_FRISwISC08to60E3r1_to_TL319_mono.230913.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/FRISwISC08to60E3r1/map_FRISwISC08to60E3r1_to_TL319_mono.230913.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC08to60E3r1_mono.230926.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC08to60E3r1-nomask_bilin.230926.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC08to60E3r1_patch.230926.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/FRISwISC08to60E3r1/map_FRISwISC08to60E3r1_to_TL319_mono.230926.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/FRISwISC08to60E3r1/map_FRISwISC08to60E3r1_to_TL319_mono.230926.nc</map>
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="FRISwISC04to60E3r1">
@@ -4177,11 +4177,11 @@
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="FRISwISC02to60E3r1">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC02to60E3r1_mono.230914.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC02to60E3r1-nomask_bilin.230914.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC02to60E3r1_patch.230914.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/FRISwISC02to60E3r1/map_FRISwISC02to60E3r1_to_TL319_mono.230914.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/FRISwISC02to60E3r1/map_FRISwISC02to60E3r1_to_TL319_mono.230914.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC02to60E3r1_mono.230926.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC02to60E3r1-nomask_bilin.230926.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_FRISwISC02to60E3r1_patch.230926.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/FRISwISC02to60E3r1/map_FRISwISC02to60E3r1_to_TL319_mono.230926.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/FRISwISC02to60E3r1/map_FRISwISC02to60E3r1_to_TL319_mono.230926.nc</map>
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="FRISwISC01to60E3r1">
@@ -4719,8 +4719,8 @@
     </gridmap>
 
     <gridmap ocn_grid="FRISwISC08to60E3r1" rof_grid="JRA025">
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC08to60E3r1_smoothed.r150e300.230913.nc</map>
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC08to60E3r1_smoothed.r150e300.230913.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC08to60E3r1_smoothed.r150e300.230926.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC08to60E3r1_smoothed.r150e300.230926.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="FRISwISC04to60E3r1" rof_grid="JRA025">
@@ -4729,8 +4729,8 @@
     </gridmap>
 
     <gridmap ocn_grid="FRISwISC02to60E3r1" rof_grid="JRA025">
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC02to60E3r1_smoothed.r150e300.230914.nc</map>
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC02to60E3r1_smoothed.r150e300.230914.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC02to60E3r1_smoothed.r150e300.230926.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_FRISwISC02to60E3r1_smoothed.r150e300.230926.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="FRISwISC01to60E3r1" rof_grid="JRA025">

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -49,8 +49,8 @@
 <config_dt ocn_grid="SOwISC12to60E2r4">'00:10:00'</config_dt>
 <config_dt ocn_grid="ECwISC30to60E2r1">'00:30:00'</config_dt>
 <config_dt ocn_grid="IcoswISC30E3r5">'00:30:00'</config_dt>
-<config_dt ocn_grid="FRISwISC08to60E3r1">'00:07:30'</config_dt>
-<config_dt ocn_grid="FRISwISC04to60E3r1">'00:03:45'</config_dt>
+<config_dt ocn_grid="FRISwISC08to60E3r1">'00:08:00'</config_dt>
+<config_dt ocn_grid="FRISwISC04to60E3r1">'00:04:00'</config_dt>
 <config_dt ocn_grid="FRISwISC02to60E3r1">'00:02:00'</config_dt>
 <config_dt ocn_grid="FRISwISC01to60E3r1">'00:01:00'</config_dt>
 <config_time_integrator>'split_explicit_ab2'</config_time_integrator>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -50,9 +50,9 @@
 <config_dt ocn_grid="ECwISC30to60E2r1">'00:30:00'</config_dt>
 <config_dt ocn_grid="IcoswISC30E3r5">'00:30:00'</config_dt>
 <config_dt ocn_grid="FRISwISC08to60E3r1">'00:07:30'</config_dt>
-<config_dt ocn_grid="FRISwISC04to60E3r1">'00:03:20'</config_dt>
-<config_dt ocn_grid="FRISwISC02to60E3r1">'00:01:40'</config_dt>
-<config_dt ocn_grid="FRISwISC01to60E3r1">'00:00:50'</config_dt>
+<config_dt ocn_grid="FRISwISC04to60E3r1">'00:03:45'</config_dt>
+<config_dt ocn_grid="FRISwISC02to60E3r1">'00:02:00'</config_dt>
+<config_dt ocn_grid="FRISwISC01to60E3r1">'00:01:00'</config_dt>
 <config_time_integrator>'split_explicit_ab2'</config_time_integrator>
 <config_number_of_time_levels>2</config_number_of_time_levels>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -49,7 +49,7 @@
 <config_dt ocn_grid="SOwISC12to60E2r4">'00:10:00'</config_dt>
 <config_dt ocn_grid="ECwISC30to60E2r1">'00:30:00'</config_dt>
 <config_dt ocn_grid="IcoswISC30E3r5">'00:30:00'</config_dt>
-<config_dt ocn_grid="FRISwISC08to60E3r1">'00:06:40'</config_dt>
+<config_dt ocn_grid="FRISwISC08to60E3r1">'00:07:30'</config_dt>
 <config_dt ocn_grid="FRISwISC04to60E3r1">'00:03:20'</config_dt>
 <config_dt ocn_grid="FRISwISC02to60E3r1">'00:01:40'</config_dt>
 <config_dt ocn_grid="FRISwISC01to60E3r1">'00:00:50'</config_dt>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -49,6 +49,7 @@
 <config_dt ocn_grid="SOwISC12to60E2r4">'00:10:00'</config_dt>
 <config_dt ocn_grid="ECwISC30to60E2r1">'00:30:00'</config_dt>
 <config_dt ocn_grid="IcoswISC30E3r5">'00:30:00'</config_dt>
+<config_dt ocn_grid="FRISwISC04to60E3r1">'00:03:20'</config_dt>
 <config_time_integrator>'split_explicit_ab2'</config_time_integrator>
 <config_number_of_time_levels>2</config_number_of_time_levels>
 
@@ -73,6 +74,7 @@
 <config_hmix_scaleWithMesh ocn_grid="SOwISC12to60E2r4">.true.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="ECwISC30to60E2r1">.true.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="IcoswISC30E3r5">.true.</config_hmix_scaleWithMesh>
+<config_hmix_scaleWithMesh ocn_grid="FRISwISC04to60E3r1">.true.</config_hmix_scaleWithMesh>
 <config_maxMeshDensity>-1.0</config_maxMeshDensity>
 <config_hmix_use_ref_cell_width>.false.</config_hmix_use_ref_cell_width>
 <config_hmix_ref_cell_width>30.0e3</config_hmix_ref_cell_width>
@@ -89,6 +91,7 @@
 <config_use_mom_del2 ocn_grid="SOwISC12to60E2r4">.true.</config_use_mom_del2>
 <config_use_mom_del2 ocn_grid="ECwISC30to60E2r1">.true.</config_use_mom_del2>
 <config_use_mom_del2 ocn_grid="IcoswISC30E3r5">.true.</config_use_mom_del2>
+<config_use_mom_del2 ocn_grid="FRISwISC04to60E3r1">.true.</config_use_mom_del2>
 <config_mom_del2>10.0</config_mom_del2>
 <config_mom_del2 ocn_grid="oEC60to30v3">1000.0</config_mom_del2>
 <config_mom_del2 ocn_grid="oEC60to30v3wLI">1000.0</config_mom_del2>
@@ -99,6 +102,7 @@
 <config_mom_del2 ocn_grid="SOwISC12to60E2r4">462.0</config_mom_del2>
 <config_mom_del2 ocn_grid="ECwISC30to60E2r1">1000.0</config_mom_del2>
 <config_mom_del2 ocn_grid="IcoswISC30E3r5">1000.0</config_mom_del2>
+<config_mom_del2 ocn_grid="FRISwISC04to60E3r1">154.0</config_mom_del2>
 <config_use_tracer_del2>.false.</config_use_tracer_del2>
 <config_tracer_del2>10.0</config_tracer_del2>
 
@@ -124,6 +128,7 @@
 <config_mom_del4 ocn_grid="SOwISC12to60E2r4">1.18e10</config_mom_del4>
 <config_mom_del4 ocn_grid="ECwISC30to60E2r1">1.2e11</config_mom_del4>
 <config_mom_del4 ocn_grid="IcoswISC30E3r5">1.2e11</config_mom_del4>
+<config_mom_del4 ocn_grid="FRISwISC04to60E3r1">4.37e08</config_mom_del4>
 <config_mom_del4_div_factor>1.0</config_mom_del4_div_factor>
 <config_use_tracer_del4>.false.</config_use_tracer_del4>
 <config_tracer_del4>0.0</config_tracer_del4>
@@ -156,6 +161,7 @@
 <config_Redi_horizontal_taper ocn_grid="ECwISC30to60E2r1">'RossbyRadius'</config_Redi_horizontal_taper>
 <!-- To do: ramp for WC but RossbyRadius for Cryo -->
 <config_Redi_horizontal_taper ocn_grid="IcoswISC30E3r5">'ramp'</config_Redi_horizontal_taper>
+<config_Redi_horizontal_taper ocn_grid="FRISwISC04to60E3r1">'RossbyRadius'</config_Redi_horizontal_taper>
 <config_Redi_horizontal_ramp_min>20e3</config_Redi_horizontal_ramp_min>
 <config_Redi_horizontal_ramp_min ocn_grid="WCAtl12to45E2r4">30e3</config_Redi_horizontal_ramp_min>
 <config_Redi_horizontal_ramp_max>30e3</config_Redi_horizontal_ramp_max>
@@ -182,6 +188,7 @@
 <config_GM_closure ocn_grid="ECwISC30to60E2r1">'N2_dependent'</config_GM_closure>
 <!-- To do: constant for WC but N2_dependent for Cryo -->
 <config_GM_closure ocn_grid="IcoswISC30E3r5">'constant'</config_GM_closure>
+<config_GM_closure ocn_grid="FRISwISC04to60E3r1">'N2_dependent'</config_GM_closure>
 <config_GM_constant_kappa>900.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="oEC60to30v3wLI">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="ECwISC30to60E1r2">600.0</config_GM_constant_kappa>
@@ -191,6 +198,7 @@
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="SOwISC12to60E2r4">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="ECwISC30to60E2r1">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="IcoswISC30E3r5">600.0</config_GM_constant_kappa>
+<config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="FRISwISC04to60E3r1">600.0</config_GM_constant_kappa>
 <config_GM_constant_bclModeSpeed>0.3</config_GM_constant_bclModeSpeed>
 <config_GM_minBclModeSpeed_method>'constant'</config_GM_minBclModeSpeed_method>
 <config_GM_spatially_variable_min_kappa>300.0</config_GM_spatially_variable_min_kappa>
@@ -200,6 +208,7 @@
 <config_GM_spatially_variable_baroclinic_mode ocn_grid="ECwISC30to60E2r1">1.0</config_GM_spatially_variable_baroclinic_mode>
 <!-- To do: 3.0 for WC but 1.0 for Cryo? -->
 <config_GM_spatially_variable_baroclinic_mode ocn_grid="IcoswISC30E3r5">3.0</config_GM_spatially_variable_baroclinic_mode>
+<config_GM_spatially_variable_baroclinic_mode ocn_grid="FRISwISC04to60E3r1">1.0</config_GM_spatially_variable_baroclinic_mode>
 <config_GM_Visbeck_alpha>0.13</config_GM_Visbeck_alpha>
 <config_GM_Visbeck_max_depth>1000.0</config_GM_Visbeck_max_depth>
 <config_GM_EG_riMin>200.0</config_GM_EG_riMin>
@@ -211,6 +220,7 @@
 <config_GM_horizontal_taper ocn_grid="ECwISC30to60E2r1">'RossbyRadius'</config_GM_horizontal_taper>
 <!-- To do: ramp for WC but RossbyRadius for Cryo -->
 <config_GM_horizontal_taper ocn_grid="IcoswISC30E3r5">'ramp'</config_GM_horizontal_taper>
+<config_GM_horizontal_taper ocn_grid="FRISwISC04to60E3r1">'RossbyRadius'</config_GM_horizontal_taper>
 <config_GM_horizontal_ramp_min>20e3</config_GM_horizontal_ramp_min>
 <config_GM_horizontal_ramp_min ocn_grid="WCAtl12to45E2r4">30e3</config_GM_horizontal_ramp_min>
 <config_GM_horizontal_ramp_max>30e3</config_GM_horizontal_ramp_max>
@@ -347,6 +357,7 @@
 <config_land_ice_flux_mode ocn_grid="SOwISC12to60E2r4">'pressure_only'</config_land_ice_flux_mode>
 <config_land_ice_flux_mode ocn_grid="ECwISC30to60E2r1">'pressure_only'</config_land_ice_flux_mode>
 <config_land_ice_flux_mode ocn_grid="IcoswISC30E3r5">'pressure_only'</config_land_ice_flux_mode>
+<config_land_ice_flux_mode ocn_grid="FRISwISC04to60E3r1">'pressure_only'</config_land_ice_flux_mode>
 <config_land_ice_flux_formulation>'Jenkins'</config_land_ice_flux_formulation>
 <config_land_ice_flux_useHollandJenkinsAdvDiff>.false.</config_land_ice_flux_useHollandJenkinsAdvDiff>
 <config_land_ice_flux_attenuation_coefficient>10.0</config_land_ice_flux_attenuation_coefficient>
@@ -360,6 +371,7 @@
 <config_land_ice_flux_explicit_topDragCoeff ocn_grid="SOwISC12to60E2r4">4.48e-3</config_land_ice_flux_explicit_topDragCoeff>
 <config_land_ice_flux_explicit_topDragCoeff ocn_grid="ECwISC30to60E2r1">4.48e-3</config_land_ice_flux_explicit_topDragCoeff>
 <config_land_ice_flux_explicit_topDragCoeff ocn_grid="IcoswISC30E3r5">4.48e-3</config_land_ice_flux_explicit_topDragCoeff>
+<config_land_ice_flux_explicit_topDragCoeff ocn_grid="FRISwISC04to60E3r1">4.48e-3</config_land_ice_flux_explicit_topDragCoeff>
 <config_land_ice_flux_ISOMIP_gammaT>1e-4</config_land_ice_flux_ISOMIP_gammaT>
 <config_land_ice_flux_rms_tidal_velocity>5e-2</config_land_ice_flux_rms_tidal_velocity>
 <config_land_ice_flux_jenkins_heat_transfer_coefficient>0.011</config_land_ice_flux_jenkins_heat_transfer_coefficient>
@@ -368,12 +380,14 @@
 <config_land_ice_flux_jenkins_heat_transfer_coefficient ocn_grid="SOwISC12to60E2r4">0.00295</config_land_ice_flux_jenkins_heat_transfer_coefficient>
 <config_land_ice_flux_jenkins_heat_transfer_coefficient ocn_grid="ECwISC30to60E2r1">0.00295</config_land_ice_flux_jenkins_heat_transfer_coefficient>
 <config_land_ice_flux_jenkins_heat_transfer_coefficient ocn_grid="IcoswISC30E3r5">0.00295</config_land_ice_flux_jenkins_heat_transfer_coefficient>
+<config_land_ice_flux_jenkins_heat_transfer_coefficient ocn_grid="FRISwISC04to60E3r1">0.00295</config_land_ice_flux_jenkins_heat_transfer_coefficient>
 <config_land_ice_flux_jenkins_salt_transfer_coefficient>3.1e-4</config_land_ice_flux_jenkins_salt_transfer_coefficient>
 <config_land_ice_flux_jenkins_salt_transfer_coefficient ocn_grid="oEC60to30v3wLI">8.42e-5</config_land_ice_flux_jenkins_salt_transfer_coefficient>
 <config_land_ice_flux_jenkins_salt_transfer_coefficient ocn_grid="ECwISC30to60E1r2">8.42e-5</config_land_ice_flux_jenkins_salt_transfer_coefficient>
 <config_land_ice_flux_jenkins_salt_transfer_coefficient ocn_grid="SOwISC12to60E2r4">8.42e-5</config_land_ice_flux_jenkins_salt_transfer_coefficient>
 <config_land_ice_flux_jenkins_salt_transfer_coefficient ocn_grid="ECwISC30to60E2r1">8.42e-5</config_land_ice_flux_jenkins_salt_transfer_coefficient>
 <config_land_ice_flux_jenkins_salt_transfer_coefficient ocn_grid="IcoswISC30E3r5">8.42e-5</config_land_ice_flux_jenkins_salt_transfer_coefficient>
+<config_land_ice_flux_jenkins_salt_transfer_coefficient ocn_grid="FRISwISC04to60E3r1">8.42e-5</config_land_ice_flux_jenkins_salt_transfer_coefficient>
 
 <!-- advection -->
 <config_vert_advection_method>'flux-form'</config_vert_advection_method>
@@ -397,6 +411,7 @@
 <config_implicit_top_drag_coeff ocn_grid="SOwISC12to60E2r4">4.48e-3</config_implicit_top_drag_coeff>
 <config_implicit_top_drag_coeff ocn_grid="ECwISC30to60E2r1">4.48e-3</config_implicit_top_drag_coeff>
 <config_implicit_top_drag_coeff ocn_grid="IcoswISC30E3r5">4.48e-3</config_implicit_top_drag_coeff>
+<config_implicit_top_drag_coeff ocn_grid="FRISwISC04to60E3r1">4.48e-3</config_implicit_top_drag_coeff>
 <config_loglaw_bottom_roughness>1.0e-3</config_loglaw_bottom_roughness>
 <config_loglaw_layer_depth_max>10.0</config_loglaw_layer_depth_max>
 <config_loglaw_bottom_drag_min>2.5e-3</config_loglaw_bottom_drag_min>
@@ -475,6 +490,7 @@
 <config_btr_dt ocn_grid="SOwISC12to60E2r4">'0000_00:00:15'</config_btr_dt>
 <config_btr_dt ocn_grid="ECwISC30to60E2r1">'0000_00:01:15'</config_btr_dt>
 <config_btr_dt ocn_grid="IcoswISC30E3r5">'0000_00:01:00'</config_btr_dt>
+<config_btr_dt ocn_grid="FRISwISC04to60E3r1">'0000_00:00:05'</config_btr_dt>
 <config_n_btr_cor_iter>2</config_n_btr_cor_iter>
 <config_vel_correction>.true.</config_vel_correction>
 <config_btr_subcycle_loop_factor>2</config_btr_subcycle_loop_factor>
@@ -516,6 +532,7 @@
 <config_check_ssh_consistency ocn_grid="SOwISC12to60E2r4">.false.</config_check_ssh_consistency>
 <config_check_ssh_consistency ocn_grid="ECwISC30to60E2r1">.false.</config_check_ssh_consistency>
 <config_check_ssh_consistency ocn_grid="IcoswISC30E3r5">.false.</config_check_ssh_consistency>
+<config_check_ssh_consistency ocn_grid="FRISwISC04to60E3r1">.false.</config_check_ssh_consistency>
 <config_filter_btr_mode>.false.</config_filter_btr_mode>
 <config_prescribe_velocity>.false.</config_prescribe_velocity>
 <config_prescribe_thickness>.false.</config_prescribe_thickness>
@@ -1033,6 +1050,7 @@
 <config_AM_mocStreamfunction_enable ocn_grid="SOwISC12to60E2r4">.true.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="ECwISC30to60E2r1">.true.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="IcoswISC30E3r5">.true.</config_AM_mocStreamfunction_enable>
+<config_AM_mocStreamfunction_enable ocn_grid="FRISwISC04to60E3r1">.true.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_compute_interval>'0000-00-00_01:00:00'</config_AM_mocStreamfunction_compute_interval>
 <config_AM_mocStreamfunction_output_stream>'mocStreamfunctionOutput'</config_AM_mocStreamfunction_output_stream>
 <config_AM_mocStreamfunction_compute_on_startup>.true.</config_AM_mocStreamfunction_compute_on_startup>
@@ -1115,16 +1133,19 @@
 <config_AM_conservationCheck_enable ocn_grid="SOwISC12to60E2r4">.true.</config_AM_conservationCheck_enable>
 <config_AM_conservationCheck_enable ocn_grid="ECwISC30to60E2r1">.true.</config_AM_conservationCheck_enable>
 <config_AM_conservationCheck_enable ocn_grid="IcoswISC30E3r5">.true.</config_AM_conservationCheck_enable>
+<config_AM_conservationCheck_enable ocn_grid="FRISwISC04to60E3r1">.true.</config_AM_conservationCheck_enable>
 <config_AM_conservationCheck_compute_interval>'dt'</config_AM_conservationCheck_compute_interval>
 <config_AM_conservationCheck_output_stream>'conservationCheckOutput'</config_AM_conservationCheck_output_stream>
 <config_AM_conservationCheck_compute_on_startup>.false.</config_AM_conservationCheck_compute_on_startup>
 <config_AM_conservationCheck_compute_on_startup ocn_grid="SOwISC12to60E2r4">.true.</config_AM_conservationCheck_compute_on_startup>
 <config_AM_conservationCheck_compute_on_startup ocn_grid="ECwISC30to60E2r1">.true.</config_AM_conservationCheck_compute_on_startup>
 <config_AM_conservationCheck_compute_on_startup ocn_grid="IcoswISC30E3r5">.true.</config_AM_conservationCheck_compute_on_startup>
+<config_AM_conservationCheck_compute_on_startup ocn_grid="FRISwISC04to60E3r1">.true.</config_AM_conservationCheck_compute_on_startup>
 <config_AM_conservationCheck_write_on_startup>.false.</config_AM_conservationCheck_write_on_startup>
 <config_AM_conservationCheck_write_on_startup ocn_grid="SOwISC12to60E2r4">.true.</config_AM_conservationCheck_write_on_startup>
 <config_AM_conservationCheck_write_on_startup ocn_grid="ECwISC30to60E2r1">.true.</config_AM_conservationCheck_write_on_startup>
 <config_AM_conservationCheck_write_on_startup ocn_grid="IcoswISC30E3r5">.true.</config_AM_conservationCheck_write_on_startup>
+<config_AM_conservationCheck_write_on_startup ocn_grid="FRISwISC04to60E3r1">.true.</config_AM_conservationCheck_write_on_startup>
 <config_AM_conservationCheck_write_to_logfile>.true.</config_AM_conservationCheck_write_to_logfile>
 <config_AM_conservationCheck_restart_stream>'conservationCheckRestart'</config_AM_conservationCheck_restart_stream>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -49,7 +49,10 @@
 <config_dt ocn_grid="SOwISC12to60E2r4">'00:10:00'</config_dt>
 <config_dt ocn_grid="ECwISC30to60E2r1">'00:30:00'</config_dt>
 <config_dt ocn_grid="IcoswISC30E3r5">'00:30:00'</config_dt>
+<config_dt ocn_grid="FRISwISC08to60E3r1">'00:06:40'</config_dt>
 <config_dt ocn_grid="FRISwISC04to60E3r1">'00:03:20'</config_dt>
+<config_dt ocn_grid="FRISwISC02to60E3r1">'00:01:40'</config_dt>
+<config_dt ocn_grid="FRISwISC01to60E3r1">'00:00:50'</config_dt>
 <config_time_integrator>'split_explicit_ab2'</config_time_integrator>
 <config_number_of_time_levels>2</config_number_of_time_levels>
 
@@ -74,7 +77,10 @@
 <config_hmix_scaleWithMesh ocn_grid="SOwISC12to60E2r4">.true.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="ECwISC30to60E2r1">.true.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="IcoswISC30E3r5">.true.</config_hmix_scaleWithMesh>
+<config_hmix_scaleWithMesh ocn_grid="FRISwISC08to60E3r1">.true.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="FRISwISC04to60E3r1">.true.</config_hmix_scaleWithMesh>
+<config_hmix_scaleWithMesh ocn_grid="FRISwISC02to60E3r1">.true.</config_hmix_scaleWithMesh>
+<config_hmix_scaleWithMesh ocn_grid="FRISwISC01to60E3r1">.true.</config_hmix_scaleWithMesh>
 <config_maxMeshDensity>-1.0</config_maxMeshDensity>
 <config_hmix_use_ref_cell_width>.false.</config_hmix_use_ref_cell_width>
 <config_hmix_ref_cell_width>30.0e3</config_hmix_ref_cell_width>
@@ -91,7 +97,10 @@
 <config_use_mom_del2 ocn_grid="SOwISC12to60E2r4">.true.</config_use_mom_del2>
 <config_use_mom_del2 ocn_grid="ECwISC30to60E2r1">.true.</config_use_mom_del2>
 <config_use_mom_del2 ocn_grid="IcoswISC30E3r5">.true.</config_use_mom_del2>
+<config_use_mom_del2 ocn_grid="FRISwISC08to60E3r1">.true.</config_use_mom_del2>
 <config_use_mom_del2 ocn_grid="FRISwISC04to60E3r1">.true.</config_use_mom_del2>
+<config_use_mom_del2 ocn_grid="FRISwISC02to60E3r1">.true.</config_use_mom_del2>
+<config_use_mom_del2 ocn_grid="FRISwISC01to60E3r1">.true.</config_use_mom_del2>
 <config_mom_del2>10.0</config_mom_del2>
 <config_mom_del2 ocn_grid="oEC60to30v3">1000.0</config_mom_del2>
 <config_mom_del2 ocn_grid="oEC60to30v3wLI">1000.0</config_mom_del2>
@@ -102,7 +111,10 @@
 <config_mom_del2 ocn_grid="SOwISC12to60E2r4">462.0</config_mom_del2>
 <config_mom_del2 ocn_grid="ECwISC30to60E2r1">1000.0</config_mom_del2>
 <config_mom_del2 ocn_grid="IcoswISC30E3r5">1000.0</config_mom_del2>
+<config_mom_del2 ocn_grid="FRISwISC08to60E3r1">308.0</config_mom_del2>
 <config_mom_del2 ocn_grid="FRISwISC04to60E3r1">154.0</config_mom_del2>
+<config_mom_del2 ocn_grid="FRISwISC02to60E3r1">77.0</config_mom_del2>
+<config_mom_del2 ocn_grid="FRISwISC01to60E3r1">38.5</config_mom_del2>
 <config_use_tracer_del2>.false.</config_use_tracer_del2>
 <config_tracer_del2>10.0</config_tracer_del2>
 
@@ -128,7 +140,10 @@
 <config_mom_del4 ocn_grid="SOwISC12to60E2r4">1.18e10</config_mom_del4>
 <config_mom_del4 ocn_grid="ECwISC30to60E2r1">1.2e11</config_mom_del4>
 <config_mom_del4 ocn_grid="IcoswISC30E3r5">1.2e11</config_mom_del4>
+<config_mom_del4 ocn_grid="FRISwISC08to60E3r1">3.50e09</config_mom_del4>
 <config_mom_del4 ocn_grid="FRISwISC04to60E3r1">4.37e08</config_mom_del4>
+<config_mom_del4 ocn_grid="FRISwISC02to60E3r1">5.46e07</config_mom_del4>
+<config_mom_del4 ocn_grid="FRISwISC01to60E3r1">6.83e06</config_mom_del4>
 <config_mom_del4_div_factor>1.0</config_mom_del4_div_factor>
 <config_use_tracer_del4>.false.</config_use_tracer_del4>
 <config_tracer_del4>0.0</config_tracer_del4>
@@ -161,7 +176,10 @@
 <config_Redi_horizontal_taper ocn_grid="ECwISC30to60E2r1">'RossbyRadius'</config_Redi_horizontal_taper>
 <!-- To do: ramp for WC but RossbyRadius for Cryo -->
 <config_Redi_horizontal_taper ocn_grid="IcoswISC30E3r5">'ramp'</config_Redi_horizontal_taper>
+<config_Redi_horizontal_taper ocn_grid="FRISwISC08to60E3r1">'RossbyRadius'</config_Redi_horizontal_taper>
 <config_Redi_horizontal_taper ocn_grid="FRISwISC04to60E3r1">'RossbyRadius'</config_Redi_horizontal_taper>
+<config_Redi_horizontal_taper ocn_grid="FRISwISC02to60E3r1">'RossbyRadius'</config_Redi_horizontal_taper>
+<config_Redi_horizontal_taper ocn_grid="FRISwISC01to60E3r1">'RossbyRadius'</config_Redi_horizontal_taper>
 <config_Redi_horizontal_ramp_min>20e3</config_Redi_horizontal_ramp_min>
 <config_Redi_horizontal_ramp_min ocn_grid="WCAtl12to45E2r4">30e3</config_Redi_horizontal_ramp_min>
 <config_Redi_horizontal_ramp_max>30e3</config_Redi_horizontal_ramp_max>
@@ -188,7 +206,10 @@
 <config_GM_closure ocn_grid="ECwISC30to60E2r1">'N2_dependent'</config_GM_closure>
 <!-- To do: constant for WC but N2_dependent for Cryo -->
 <config_GM_closure ocn_grid="IcoswISC30E3r5">'constant'</config_GM_closure>
+<config_GM_closure ocn_grid="FRISwISC08to60E3r1">'N2_dependent'</config_GM_closure>
 <config_GM_closure ocn_grid="FRISwISC04to60E3r1">'N2_dependent'</config_GM_closure>
+<config_GM_closure ocn_grid="FRISwISC02to60E3r1">'N2_dependent'</config_GM_closure>
+<config_GM_closure ocn_grid="FRISwISC01to60E3r1">'N2_dependent'</config_GM_closure>
 <config_GM_constant_kappa>900.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="oEC60to30v3wLI">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="ECwISC30to60E1r2">600.0</config_GM_constant_kappa>
@@ -198,7 +219,10 @@
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="SOwISC12to60E2r4">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="ECwISC30to60E2r1">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="IcoswISC30E3r5">600.0</config_GM_constant_kappa>
+<config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="FRISwISC08to60E3r1">600.0</config_GM_constant_kappa>
 <config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="FRISwISC04to60E3r1">600.0</config_GM_constant_kappa>
+<config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="FRISwISC02to60E3r1">600.0</config_GM_constant_kappa>
+<config_GM_constant_kappa ocn_forcing="datm_forced_restoring" ocn_grid="FRISwISC01to60E3r1">600.0</config_GM_constant_kappa>
 <config_GM_constant_bclModeSpeed>0.3</config_GM_constant_bclModeSpeed>
 <config_GM_minBclModeSpeed_method>'constant'</config_GM_minBclModeSpeed_method>
 <config_GM_spatially_variable_min_kappa>300.0</config_GM_spatially_variable_min_kappa>
@@ -208,7 +232,10 @@
 <config_GM_spatially_variable_baroclinic_mode ocn_grid="ECwISC30to60E2r1">1.0</config_GM_spatially_variable_baroclinic_mode>
 <!-- To do: 3.0 for WC but 1.0 for Cryo? -->
 <config_GM_spatially_variable_baroclinic_mode ocn_grid="IcoswISC30E3r5">3.0</config_GM_spatially_variable_baroclinic_mode>
+<config_GM_spatially_variable_baroclinic_mode ocn_grid="FRISwISC08to60E3r1">1.0</config_GM_spatially_variable_baroclinic_mode>
 <config_GM_spatially_variable_baroclinic_mode ocn_grid="FRISwISC04to60E3r1">1.0</config_GM_spatially_variable_baroclinic_mode>
+<config_GM_spatially_variable_baroclinic_mode ocn_grid="FRISwISC02to60E3r1">1.0</config_GM_spatially_variable_baroclinic_mode>
+<config_GM_spatially_variable_baroclinic_mode ocn_grid="FRISwISC01to60E3r1">1.0</config_GM_spatially_variable_baroclinic_mode>
 <config_GM_Visbeck_alpha>0.13</config_GM_Visbeck_alpha>
 <config_GM_Visbeck_max_depth>1000.0</config_GM_Visbeck_max_depth>
 <config_GM_EG_riMin>200.0</config_GM_EG_riMin>
@@ -220,7 +247,10 @@
 <config_GM_horizontal_taper ocn_grid="ECwISC30to60E2r1">'RossbyRadius'</config_GM_horizontal_taper>
 <!-- To do: ramp for WC but RossbyRadius for Cryo -->
 <config_GM_horizontal_taper ocn_grid="IcoswISC30E3r5">'ramp'</config_GM_horizontal_taper>
+<config_GM_horizontal_taper ocn_grid="FRISwISC08to60E3r1">'RossbyRadius'</config_GM_horizontal_taper>
 <config_GM_horizontal_taper ocn_grid="FRISwISC04to60E3r1">'RossbyRadius'</config_GM_horizontal_taper>
+<config_GM_horizontal_taper ocn_grid="FRISwISC02to60E3r1">'RossbyRadius'</config_GM_horizontal_taper>
+<config_GM_horizontal_taper ocn_grid="FRISwISC01to60E3r1">'RossbyRadius'</config_GM_horizontal_taper>
 <config_GM_horizontal_ramp_min>20e3</config_GM_horizontal_ramp_min>
 <config_GM_horizontal_ramp_min ocn_grid="WCAtl12to45E2r4">30e3</config_GM_horizontal_ramp_min>
 <config_GM_horizontal_ramp_max>30e3</config_GM_horizontal_ramp_max>
@@ -357,7 +387,10 @@
 <config_land_ice_flux_mode ocn_grid="SOwISC12to60E2r4">'pressure_only'</config_land_ice_flux_mode>
 <config_land_ice_flux_mode ocn_grid="ECwISC30to60E2r1">'pressure_only'</config_land_ice_flux_mode>
 <config_land_ice_flux_mode ocn_grid="IcoswISC30E3r5">'pressure_only'</config_land_ice_flux_mode>
+<config_land_ice_flux_mode ocn_grid="FRISwISC08to60E3r1">'pressure_only'</config_land_ice_flux_mode>
 <config_land_ice_flux_mode ocn_grid="FRISwISC04to60E3r1">'pressure_only'</config_land_ice_flux_mode>
+<config_land_ice_flux_mode ocn_grid="FRISwISC02to60E3r1">'pressure_only'</config_land_ice_flux_mode>
+<config_land_ice_flux_mode ocn_grid="FRISwISC01to60E3r1">'pressure_only'</config_land_ice_flux_mode>
 <config_land_ice_flux_formulation>'Jenkins'</config_land_ice_flux_formulation>
 <config_land_ice_flux_useHollandJenkinsAdvDiff>.false.</config_land_ice_flux_useHollandJenkinsAdvDiff>
 <config_land_ice_flux_attenuation_coefficient>10.0</config_land_ice_flux_attenuation_coefficient>
@@ -371,7 +404,10 @@
 <config_land_ice_flux_explicit_topDragCoeff ocn_grid="SOwISC12to60E2r4">4.48e-3</config_land_ice_flux_explicit_topDragCoeff>
 <config_land_ice_flux_explicit_topDragCoeff ocn_grid="ECwISC30to60E2r1">4.48e-3</config_land_ice_flux_explicit_topDragCoeff>
 <config_land_ice_flux_explicit_topDragCoeff ocn_grid="IcoswISC30E3r5">4.48e-3</config_land_ice_flux_explicit_topDragCoeff>
+<config_land_ice_flux_explicit_topDragCoeff ocn_grid="FRISwISC08to60E3r1">4.48e-3</config_land_ice_flux_explicit_topDragCoeff>
 <config_land_ice_flux_explicit_topDragCoeff ocn_grid="FRISwISC04to60E3r1">4.48e-3</config_land_ice_flux_explicit_topDragCoeff>
+<config_land_ice_flux_explicit_topDragCoeff ocn_grid="FRISwISC02to60E3r1">4.48e-3</config_land_ice_flux_explicit_topDragCoeff>
+<config_land_ice_flux_explicit_topDragCoeff ocn_grid="FRISwISC01to60E3r1">4.48e-3</config_land_ice_flux_explicit_topDragCoeff>
 <config_land_ice_flux_ISOMIP_gammaT>1e-4</config_land_ice_flux_ISOMIP_gammaT>
 <config_land_ice_flux_rms_tidal_velocity>5e-2</config_land_ice_flux_rms_tidal_velocity>
 <config_land_ice_flux_jenkins_heat_transfer_coefficient>0.011</config_land_ice_flux_jenkins_heat_transfer_coefficient>
@@ -380,14 +416,20 @@
 <config_land_ice_flux_jenkins_heat_transfer_coefficient ocn_grid="SOwISC12to60E2r4">0.00295</config_land_ice_flux_jenkins_heat_transfer_coefficient>
 <config_land_ice_flux_jenkins_heat_transfer_coefficient ocn_grid="ECwISC30to60E2r1">0.00295</config_land_ice_flux_jenkins_heat_transfer_coefficient>
 <config_land_ice_flux_jenkins_heat_transfer_coefficient ocn_grid="IcoswISC30E3r5">0.00295</config_land_ice_flux_jenkins_heat_transfer_coefficient>
+<config_land_ice_flux_jenkins_heat_transfer_coefficient ocn_grid="FRISwISC08to60E3r1">0.00295</config_land_ice_flux_jenkins_heat_transfer_coefficient>
 <config_land_ice_flux_jenkins_heat_transfer_coefficient ocn_grid="FRISwISC04to60E3r1">0.00295</config_land_ice_flux_jenkins_heat_transfer_coefficient>
+<config_land_ice_flux_jenkins_heat_transfer_coefficient ocn_grid="FRISwISC02to60E3r1">0.00295</config_land_ice_flux_jenkins_heat_transfer_coefficient>
+<config_land_ice_flux_jenkins_heat_transfer_coefficient ocn_grid="FRISwISC01to60E3r1">0.00295</config_land_ice_flux_jenkins_heat_transfer_coefficient>
 <config_land_ice_flux_jenkins_salt_transfer_coefficient>3.1e-4</config_land_ice_flux_jenkins_salt_transfer_coefficient>
 <config_land_ice_flux_jenkins_salt_transfer_coefficient ocn_grid="oEC60to30v3wLI">8.42e-5</config_land_ice_flux_jenkins_salt_transfer_coefficient>
 <config_land_ice_flux_jenkins_salt_transfer_coefficient ocn_grid="ECwISC30to60E1r2">8.42e-5</config_land_ice_flux_jenkins_salt_transfer_coefficient>
 <config_land_ice_flux_jenkins_salt_transfer_coefficient ocn_grid="SOwISC12to60E2r4">8.42e-5</config_land_ice_flux_jenkins_salt_transfer_coefficient>
 <config_land_ice_flux_jenkins_salt_transfer_coefficient ocn_grid="ECwISC30to60E2r1">8.42e-5</config_land_ice_flux_jenkins_salt_transfer_coefficient>
 <config_land_ice_flux_jenkins_salt_transfer_coefficient ocn_grid="IcoswISC30E3r5">8.42e-5</config_land_ice_flux_jenkins_salt_transfer_coefficient>
+<config_land_ice_flux_jenkins_salt_transfer_coefficient ocn_grid="FRISwISC08to60E3r1">8.42e-5</config_land_ice_flux_jenkins_salt_transfer_coefficient>
 <config_land_ice_flux_jenkins_salt_transfer_coefficient ocn_grid="FRISwISC04to60E3r1">8.42e-5</config_land_ice_flux_jenkins_salt_transfer_coefficient>
+<config_land_ice_flux_jenkins_salt_transfer_coefficient ocn_grid="FRISwISC02to60E3r1">8.42e-5</config_land_ice_flux_jenkins_salt_transfer_coefficient>
+<config_land_ice_flux_jenkins_salt_transfer_coefficient ocn_grid="FRISwISC01to60E3r1">8.42e-5</config_land_ice_flux_jenkins_salt_transfer_coefficient>
 
 <!-- advection -->
 <config_vert_advection_method>'flux-form'</config_vert_advection_method>
@@ -411,7 +453,10 @@
 <config_implicit_top_drag_coeff ocn_grid="SOwISC12to60E2r4">4.48e-3</config_implicit_top_drag_coeff>
 <config_implicit_top_drag_coeff ocn_grid="ECwISC30to60E2r1">4.48e-3</config_implicit_top_drag_coeff>
 <config_implicit_top_drag_coeff ocn_grid="IcoswISC30E3r5">4.48e-3</config_implicit_top_drag_coeff>
+<config_implicit_top_drag_coeff ocn_grid="FRISwISC08to60E3r1">4.48e-3</config_implicit_top_drag_coeff>
 <config_implicit_top_drag_coeff ocn_grid="FRISwISC04to60E3r1">4.48e-3</config_implicit_top_drag_coeff>
+<config_implicit_top_drag_coeff ocn_grid="FRISwISC02to60E3r1">4.48e-3</config_implicit_top_drag_coeff>
+<config_implicit_top_drag_coeff ocn_grid="FRISwISC01to60E3r1">4.48e-3</config_implicit_top_drag_coeff>
 <config_loglaw_bottom_roughness>1.0e-3</config_loglaw_bottom_roughness>
 <config_loglaw_layer_depth_max>10.0</config_loglaw_layer_depth_max>
 <config_loglaw_bottom_drag_min>2.5e-3</config_loglaw_bottom_drag_min>
@@ -490,7 +535,10 @@
 <config_btr_dt ocn_grid="SOwISC12to60E2r4">'0000_00:00:15'</config_btr_dt>
 <config_btr_dt ocn_grid="ECwISC30to60E2r1">'0000_00:01:15'</config_btr_dt>
 <config_btr_dt ocn_grid="IcoswISC30E3r5">'0000_00:01:00'</config_btr_dt>
+<config_btr_dt ocn_grid="FRISwISC08to60E3r1">'0000_00:00:10'</config_btr_dt>
 <config_btr_dt ocn_grid="FRISwISC04to60E3r1">'0000_00:00:05'</config_btr_dt>
+<config_btr_dt ocn_grid="FRISwISC02to60E3r1">'0000_00:00:02.5'</config_btr_dt>
+<config_btr_dt ocn_grid="FRISwISC01to60E3r1">'0000_00:00:01.25'</config_btr_dt>
 <config_n_btr_cor_iter>2</config_n_btr_cor_iter>
 <config_vel_correction>.true.</config_vel_correction>
 <config_btr_subcycle_loop_factor>2</config_btr_subcycle_loop_factor>
@@ -532,7 +580,10 @@
 <config_check_ssh_consistency ocn_grid="SOwISC12to60E2r4">.false.</config_check_ssh_consistency>
 <config_check_ssh_consistency ocn_grid="ECwISC30to60E2r1">.false.</config_check_ssh_consistency>
 <config_check_ssh_consistency ocn_grid="IcoswISC30E3r5">.false.</config_check_ssh_consistency>
+<config_check_ssh_consistency ocn_grid="FRISwISC08to60E3r1">.false.</config_check_ssh_consistency>
 <config_check_ssh_consistency ocn_grid="FRISwISC04to60E3r1">.false.</config_check_ssh_consistency>
+<config_check_ssh_consistency ocn_grid="FRISwISC02to60E3r1">.false.</config_check_ssh_consistency>
+<config_check_ssh_consistency ocn_grid="FRISwISC01to60E3r1">.false.</config_check_ssh_consistency>
 <config_filter_btr_mode>.false.</config_filter_btr_mode>
 <config_prescribe_velocity>.false.</config_prescribe_velocity>
 <config_prescribe_thickness>.false.</config_prescribe_thickness>
@@ -1050,7 +1101,10 @@
 <config_AM_mocStreamfunction_enable ocn_grid="SOwISC12to60E2r4">.true.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="ECwISC30to60E2r1">.true.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="IcoswISC30E3r5">.true.</config_AM_mocStreamfunction_enable>
+<config_AM_mocStreamfunction_enable ocn_grid="FRISwISC08to60E3r1">.true.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_enable ocn_grid="FRISwISC04to60E3r1">.true.</config_AM_mocStreamfunction_enable>
+<config_AM_mocStreamfunction_enable ocn_grid="FRISwISC02to60E3r1">.true.</config_AM_mocStreamfunction_enable>
+<config_AM_mocStreamfunction_enable ocn_grid="FRISwISC01to60E3r1">.true.</config_AM_mocStreamfunction_enable>
 <config_AM_mocStreamfunction_compute_interval>'0000-00-00_01:00:00'</config_AM_mocStreamfunction_compute_interval>
 <config_AM_mocStreamfunction_output_stream>'mocStreamfunctionOutput'</config_AM_mocStreamfunction_output_stream>
 <config_AM_mocStreamfunction_compute_on_startup>.true.</config_AM_mocStreamfunction_compute_on_startup>
@@ -1133,19 +1187,28 @@
 <config_AM_conservationCheck_enable ocn_grid="SOwISC12to60E2r4">.true.</config_AM_conservationCheck_enable>
 <config_AM_conservationCheck_enable ocn_grid="ECwISC30to60E2r1">.true.</config_AM_conservationCheck_enable>
 <config_AM_conservationCheck_enable ocn_grid="IcoswISC30E3r5">.true.</config_AM_conservationCheck_enable>
+<config_AM_conservationCheck_enable ocn_grid="FRISwISC08to60E3r1">.true.</config_AM_conservationCheck_enable>
 <config_AM_conservationCheck_enable ocn_grid="FRISwISC04to60E3r1">.true.</config_AM_conservationCheck_enable>
+<config_AM_conservationCheck_enable ocn_grid="FRISwISC02to60E3r1">.true.</config_AM_conservationCheck_enable>
+<config_AM_conservationCheck_enable ocn_grid="FRISwISC01to60E3r1">.true.</config_AM_conservationCheck_enable>
 <config_AM_conservationCheck_compute_interval>'dt'</config_AM_conservationCheck_compute_interval>
 <config_AM_conservationCheck_output_stream>'conservationCheckOutput'</config_AM_conservationCheck_output_stream>
 <config_AM_conservationCheck_compute_on_startup>.false.</config_AM_conservationCheck_compute_on_startup>
 <config_AM_conservationCheck_compute_on_startup ocn_grid="SOwISC12to60E2r4">.true.</config_AM_conservationCheck_compute_on_startup>
 <config_AM_conservationCheck_compute_on_startup ocn_grid="ECwISC30to60E2r1">.true.</config_AM_conservationCheck_compute_on_startup>
 <config_AM_conservationCheck_compute_on_startup ocn_grid="IcoswISC30E3r5">.true.</config_AM_conservationCheck_compute_on_startup>
+<config_AM_conservationCheck_compute_on_startup ocn_grid="FRISwISC08to60E3r1">.true.</config_AM_conservationCheck_compute_on_startup>
 <config_AM_conservationCheck_compute_on_startup ocn_grid="FRISwISC04to60E3r1">.true.</config_AM_conservationCheck_compute_on_startup>
+<config_AM_conservationCheck_compute_on_startup ocn_grid="FRISwISC02to60E3r1">.true.</config_AM_conservationCheck_compute_on_startup>
+<config_AM_conservationCheck_compute_on_startup ocn_grid="FRISwISC01to60E3r1">.true.</config_AM_conservationCheck_compute_on_startup>
 <config_AM_conservationCheck_write_on_startup>.false.</config_AM_conservationCheck_write_on_startup>
 <config_AM_conservationCheck_write_on_startup ocn_grid="SOwISC12to60E2r4">.true.</config_AM_conservationCheck_write_on_startup>
 <config_AM_conservationCheck_write_on_startup ocn_grid="ECwISC30to60E2r1">.true.</config_AM_conservationCheck_write_on_startup>
 <config_AM_conservationCheck_write_on_startup ocn_grid="IcoswISC30E3r5">.true.</config_AM_conservationCheck_write_on_startup>
+<config_AM_conservationCheck_write_on_startup ocn_grid="FRISwISC08to60E3r1">.true.</config_AM_conservationCheck_write_on_startup>
 <config_AM_conservationCheck_write_on_startup ocn_grid="FRISwISC04to60E3r1">.true.</config_AM_conservationCheck_write_on_startup>
+<config_AM_conservationCheck_write_on_startup ocn_grid="FRISwISC02to60E3r1">.true.</config_AM_conservationCheck_write_on_startup>
+<config_AM_conservationCheck_write_on_startup ocn_grid="FRISwISC01to60E3r1">.true.</config_AM_conservationCheck_write_on_startup>
 <config_AM_conservationCheck_write_to_logfile>.true.</config_AM_conservationCheck_write_to_logfile>
 <config_AM_conservationCheck_restart_stream>'conservationCheckRestart'</config_AM_conservationCheck_restart_stream>
 

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -271,17 +271,17 @@ def buildnml(case, caseroot, compname):
             data_ismf_file = 'prescribed_ismf_adusumilli2020.SOwISC12to60E2r4.230516.nc'
 
     elif ocn_grid == 'FRISwISC04to60E3r1':
-        decomp_date = '20230817'  # changed to date of partiotions in ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-o/FRISwISC04to60E3r1/partitions
+        decomp_date = '20230913'  # changed to date of partiotions in ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-o/FRISwISC04to60E3r1/partitions
         decomp_prefix = 'partitions/mpas-o.graph.info.'
-        restoring_file = 'sss.PHC2_monthlyClimatology.FRISwISC04to60E3r1.20230817.nc'
+        restoring_file = 'sss.PHC2_monthlyClimatology.FRISwISC04to60E3r1.20230913.nc'
         analysis_mask_file = 'FRISwISC04to60E3r1_mocBasinsAndTransects20210623.nc'
-        ic_date = '20230817'
-        ic_prefix = 'ocean.FRISwISC04to60E3r1'  # from ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-o/FRISwISC04to60E3r1/mpaso.FRISwISC04to60E3r1.20230817.nc
+        ic_date = '20230913'
+        ic_prefix = 'ocean.FRISwISC04to60E3r1'  # from ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-o/FRISwISC04to60E3r1/mpaso.FRISwISC04to60E3r1.20230913.nc
         if ocn_ic_mode == 'spunup':
-            ic_date = '20230817'  # changed to same as decomp_date, but the spun up file does not yet exist
+            ic_date = '20230913'  # changed to same as decomp_date, but the spun up file does not yet exist
             ic_prefix = 'mpaso.FRISwISC04to60E3r1.rstFromG-anvil'   # the spun up file does not yet exist
         if ocn_ismf == 'data':
-            data_ismf_file = 'prescribed_ismf_adusumilli2020.FRISwISC04to60E3r1.20230817.nc'
+            data_ismf_file = 'prescribed_ismf_adusumilli2020.FRISwISC04to60E3r1.20230913.nc'
 
     elif ocn_grid == 'ECwISC30to60E2r1':
         decomp_date = '200915'

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -270,6 +270,19 @@ def buildnml(case, caseroot, compname):
         if ocn_ismf == 'data':
             data_ismf_file = 'prescribed_ismf_adusumilli2020.SOwISC12to60E2r4.230516.nc'
 
+    elif ocn_grid == 'FRISwISC08to60E3r1':
+        decomp_date = '20230913'  # changed to date of partiotions in ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-o/FRISwISC08to60E3r1/partitions
+        decomp_prefix = 'partitions/mpas-o.graph.info.'
+        restoring_file = 'sss.PHC2_monthlyClimatology.FRISwISC08to60E3r1.20230913.nc'
+        analysis_mask_file = 'FRISwISC08to60E3r1_mocBasinsAndTransects20210623.nc'
+        ic_date = '20230913'
+        ic_prefix = 'mpaso.FRISwISC08to60E3r1'  # from ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-o/FRISwISC08to60E3r1/mpaso.FRISwISC08to60E3r1.20230913.nc
+        if ocn_ic_mode == 'spunup':
+            ic_date = '20230913'  # changed to same as decomp_date, but the spun up file does not yet exist
+            ic_prefix = 'mpaso.FRISwISC08to60E3r1.rstFromG-anvil'   # the spun up file does not yet exist
+        if ocn_ismf == 'data':
+            data_ismf_file = 'prescribed_ismf_adusumilli2020.FRISwISC08to60E3r1.20230913.nc'
+
     elif ocn_grid == 'FRISwISC04to60E3r1':
         decomp_date = '20230913'  # changed to date of partiotions in ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-o/FRISwISC04to60E3r1/partitions
         decomp_prefix = 'partitions/mpas-o.graph.info.'
@@ -282,6 +295,32 @@ def buildnml(case, caseroot, compname):
             ic_prefix = 'mpaso.FRISwISC04to60E3r1.rstFromG-anvil'   # the spun up file does not yet exist
         if ocn_ismf == 'data':
             data_ismf_file = 'prescribed_ismf_adusumilli2020.FRISwISC04to60E3r1.20230913.nc'
+
+    elif ocn_grid == 'FRISwISC02to60E3r1':
+        decomp_date = '20230914'  # changed to date of partiotions in ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-o/FRISwISC02to60E3r1/partitions
+        decomp_prefix = 'partitions/mpas-o.graph.info.'
+        restoring_file = 'sss.PHC2_monthlyClimatology.FRISwISC02to60E3r1.20230914.nc'
+        analysis_mask_file = 'FRISwISC02to60E3r1_mocBasinsAndTransects20210623.nc'
+        ic_date = '20230914'
+        ic_prefix = 'mpaso.FRISwISC02to60E3r1'  # from ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-o/FRISwISC02to60E3r1/mpaso.FRISwISC02to60E3r1.20230914.nc
+        if ocn_ic_mode == 'spunup':
+            ic_date = '20230914'  # changed to same as decomp_date, but the spun up file does not yet exist
+            ic_prefix = 'mpaso.FRISwISC02to60E3r1.rstFromG-anvil'   # the spun up file does not yet exist
+        if ocn_ismf == 'data':
+            data_ismf_file = 'prescribed_ismf_adusumilli2020.FRISwISC02to60E3r1.20230914.nc'
+
+    elif ocn_grid == 'FRISwISC01to60E3r1':
+        decomp_date = '20230915'  # changed to date of partiotions in ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-o/FRISwISC01to60E3r1/partitions
+        decomp_prefix = 'partitions/mpas-o.graph.info.'
+        restoring_file = 'sss.PHC2_monthlyClimatology.FRISwISC01to60E3r1.20230915.nc'
+        analysis_mask_file = 'FRISwISC01to60E3r1_mocBasinsAndTransects20210623.nc'
+        ic_date = '20230915'
+        ic_prefix = 'mpaso.FRISwISC01to60E3r1'  # from ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-o/FRISwISC01to60E3r1/mpaso.FRISwISC01to60E3r1.20230915.nc
+        if ocn_ic_mode == 'spunup':
+            ic_date = '20230915'  # changed to same as decomp_date, but the spun up file does not yet exist
+            ic_prefix = 'mpaso.FRISwISC01to60E3r1.rstFromG-anvil'   # the spun up file does not yet exist
+        if ocn_ismf == 'data':
+            data_ismf_file = 'prescribed_ismf_adusumilli2020.FRISwISC01to60E3r1.20230915.nc'
 
     elif ocn_grid == 'ECwISC30to60E2r1':
         decomp_date = '200915'

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -273,7 +273,7 @@ def buildnml(case, caseroot, compname):
     elif ocn_grid == 'FRISwISC04to60E3r1':
         decomp_date = '20230817'  # changed to date of partiotions in ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-o/FRISwISC04to60E3r1/partitions
         decomp_prefix = 'partitions/mpas-o.graph.info.'
-        restoring_file = 'sss.PHC2_monthlyClimatology.FRISwISC04to60E3r1_nomask.210120.nc'  # will be generated manually
+        restoring_file = 'sss.PHC2_monthlyClimatology.FRISwISC04to60E3r1.20230817.nc'
         analysis_mask_file = 'FRISwISC04to60E3r1_mocBasinsAndTransects20210623.nc'
         ic_date = '20230817'
         ic_prefix = 'ocean.FRISwISC04to60E3r1'  # from ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-o/FRISwISC04to60E3r1/mpaso.FRISwISC04to60E3r1.20230817.nc

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -270,6 +270,19 @@ def buildnml(case, caseroot, compname):
         if ocn_ismf == 'data':
             data_ismf_file = 'prescribed_ismf_adusumilli2020.SOwISC12to60E2r4.230516.nc'
 
+    elif ocn_grid == 'FRISwISC04to60E3r1':
+        decomp_date = '20230817'  # changed to date of partiotions in ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-o/FRISwISC04to60E3r1/partitions
+        decomp_prefix = 'partitions/mpas-o.graph.info.'
+        restoring_file = 'sss.PHC2_monthlyClimatology.FRISwISC04to60E3r1_nomask.210120.nc'  # will be generated manually
+        analysis_mask_file = 'FRISwISC04to60E3r1_mocBasinsAndTransects20210623.nc'
+        ic_date = '20230817'
+        ic_prefix = 'ocean.FRISwISC04to60E3r1'  # from ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-o/FRISwISC04to60E3r1/mpaso.FRISwISC04to60E3r1.20230817.nc
+        if ocn_ic_mode == 'spunup':
+            ic_date = '20230817'  # changed to same as decomp_date, but the spun up file does not yet exist
+            ic_prefix = 'mpaso.FRISwISC04to60E3r1.rstFromG-anvil'   # the spun up file does not yet exist
+        if ocn_ismf == 'data':
+            data_ismf_file = 'prescribed_ismf_adusumilli2020.FRISwISC04to60E3r1.20230817.nc'
+
     elif ocn_grid == 'ECwISC30to60E2r1':
         decomp_date = '200915'
         decomp_prefix = 'mpas-o.graph.info.'

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -276,7 +276,7 @@ def buildnml(case, caseroot, compname):
         restoring_file = 'sss.PHC2_monthlyClimatology.FRISwISC04to60E3r1.20230913.nc'
         analysis_mask_file = 'FRISwISC04to60E3r1_mocBasinsAndTransects20210623.nc'
         ic_date = '20230913'
-        ic_prefix = 'ocean.FRISwISC04to60E3r1'  # from ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-o/FRISwISC04to60E3r1/mpaso.FRISwISC04to60E3r1.20230913.nc
+        ic_prefix = 'mpaso.FRISwISC04to60E3r1'  # from ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-o/FRISwISC04to60E3r1/mpaso.FRISwISC04to60E3r1.20230913.nc
         if ocn_ic_mode == 'spunup':
             ic_date = '20230913'  # changed to same as decomp_date, but the spun up file does not yet exist
             ic_prefix = 'mpaso.FRISwISC04to60E3r1.rstFromG-anvil'   # the spun up file does not yet exist

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -474,7 +474,7 @@ def buildnml(case, caseroot, compname):
             lines.append('')
             lines.append('<immutable_stream name="mesh"')
             lines.append('                  type="none"')
-            if ocn_grid.startswith("oRRS1"):
+            if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS"):
                 lines.append('                  io_type="pnetcdf,cdf5"')
             else:
                 lines.append('                  io_type="{}"'.format(ocn_pio_typename))
@@ -483,7 +483,7 @@ def buildnml(case, caseroot, compname):
             lines.append('/>')
             lines.append('<immutable_stream name="input"')
             lines.append('                  type="input"')
-            if ocn_grid.startswith("oRRS1"):
+            if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS"):
                 lines.append('                  io_type="pnetcdf,cdf5"')
             else:
                 lines.append('                  io_type="{}"'.format(ocn_pio_typename))
@@ -504,7 +504,7 @@ def buildnml(case, caseroot, compname):
             lines.append('-->')
             lines.append('<immutable_stream name="restart"')
             lines.append('                  type="input;output"')
-            if ocn_grid.startswith("oRRS1"):
+            if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS"):
                 lines.append('                  io_type="pnetcdf,cdf5"')
             else:
                 lines.append('                  io_type="{}"'.format(ocn_pio_typename))
@@ -523,7 +523,7 @@ def buildnml(case, caseroot, compname):
             lines.append('')
             lines.append('<stream name="output"')
             lines.append('        type="output"')
-            if ocn_grid.startswith("oRRS1"):
+            if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS"):
                 lines.append('        io_type="pnetcdf,cdf5"')
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))
@@ -807,7 +807,7 @@ def buildnml(case, caseroot, compname):
             lines.append('<stream name="eddyProductVariablesOutput"')
             lines.append('        type="output"')
             lines.append('        precision="single"')
-            if ocn_grid.startswith("oRRS1"):
+            if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS"):
                 lines.append('        io_type="pnetcdf,cdf5"')
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))
@@ -1187,7 +1187,7 @@ def buildnml(case, caseroot, compname):
             lines.append('<stream name="timeSeriesStatsMonthlyOutput"')
             lines.append('        type="output"')
             lines.append('        precision="single"')
-            if ocn_grid.startswith("oRRS1"):
+            if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS"):
                 lines.append('        io_type="pnetcdf,cdf5"')
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))
@@ -1239,6 +1239,9 @@ def buildnml(case, caseroot, compname):
                 lines.append('    <var name="cGMphaseSpeed"/>')
                 lines.append('    <var name="mocStreamvalLatAndDepthGM"/>')
                 lines.append('    <var name="mocStreamvalLatAndDepthRegionGM"/>')
+
+            if ocn_grid.startswith("FRIS"):
+                lines.append('    <var name="gmHorizontalTaper"/>')
 
             lines.append('    <var name="mocStreamvalLatAndDepthMLE"/>')
             lines.append('    <var name="mocStreamvalLatAndDepthRegionMLE"/>')
@@ -1414,7 +1417,7 @@ def buildnml(case, caseroot, compname):
             lines.append('<stream name="timeSeriesStatsMonthlyMaxOutput"')
             lines.append('        type="output"')
             lines.append('        precision="single"')
-            if ocn_grid.startswith("oRRS1"):
+            if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS"):
                 lines.append('        io_type="pnetcdf,cdf5"')
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))
@@ -1476,7 +1479,7 @@ def buildnml(case, caseroot, compname):
             lines.append('<stream name="timeSeriesStatsMonthlyMinOutput"')
             lines.append('        type="output"')
             lines.append('        precision="single"')
-            if ocn_grid.startswith("oRRS1"):
+            if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS"):
                 lines.append('        io_type="pnetcdf,cdf5"')
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))
@@ -1579,7 +1582,7 @@ def buildnml(case, caseroot, compname):
             lines.append('')
             lines.append('<stream name="timeSeriesStatsMonthlyRestart"')
             lines.append('        type="input;output"')
-            if ocn_grid.startswith("oRRS1"):
+            if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS"):
                 lines.append('        io_type="pnetcdf,cdf5"')
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))
@@ -1595,7 +1598,7 @@ def buildnml(case, caseroot, compname):
             lines.append('')
             lines.append('<stream name="timeSeriesStatsMonthlyMaxRestart"')
             lines.append('        type="input;output"')
-            if ocn_grid.startswith("oRRS1"):
+            if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS"):
                 lines.append('        io_type="pnetcdf,cdf5"')
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))
@@ -1611,7 +1614,7 @@ def buildnml(case, caseroot, compname):
             lines.append('')
             lines.append('<stream name="timeSeriesStatsMonthlyMinRestart"')
             lines.append('        type="input;output"')
-            if ocn_grid.startswith("oRRS1"):
+            if ocn_grid.startswith("oRRS1") or ocn_grid.startswith("FRIS"):
                 lines.append('        io_type="pnetcdf,cdf5"')
             else:
                 lines.append('        io_type="{}"'.format(ocn_pio_typename))

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -25,6 +25,7 @@
 <config_dt ice_grid="SOwISC12to60E2r4">1800.0</config_dt>
 <config_dt ice_grid="ECwISC30to60E2r1">1800.0</config_dt>
 <config_dt ice_grid="IcoswISC30E3r5">1800.0</config_dt>
+<config_dt ice_grid="FRISwISC04to60E3r1">1800.0</config_dt>
 <config_calendar_type>'noleap'</config_calendar_type>
 <config_start_time>'2000-01-01_00:00:00'</config_start_time>
 <config_stop_time>'none'</config_stop_time>
@@ -77,6 +78,7 @@
 <config_initial_latitude_north ice_grid="ECwISC30to60E2r1">75.0</config_initial_latitude_north>
 <!-- To do: 70.0 for WC but 75.0 for Cryo -->
 <config_initial_latitude_north ice_grid="IcoswISC30E3r5">70.0</config_initial_latitude_north>
+<config_initial_latitude_north ice_grid="FRISwISC04to60E3r1">85.0</config_initial_latitude_north>
 <config_initial_latitude_north ice_grid="ARRM10to60E2r1">75.0</config_initial_latitude_north>
 <config_initial_latitude_north ice_grid="oRRS30to10v3wLI">85.0</config_initial_latitude_north>
 <config_initial_latitude_north ice_grid="oRRS18to6v3">85.0</config_initial_latitude_north>
@@ -87,6 +89,7 @@
 <config_initial_latitude_south ice_grid="ECwISC30to60E2r1">-75.0</config_initial_latitude_south>
 <!-- To do: -60.0 for WC but -75.0 for Cryo -->
 <config_initial_latitude_south ice_grid="IcoswISC30E3r5">-60.0</config_initial_latitude_south>
+<config_initial_latitude_south ice_grid="FRISwISC04to60E3r1">-85.0</config_initial_latitude_south>
 <config_initial_latitude_south ice_grid="ARRM10to60E2r1">-85.0</config_initial_latitude_south>
 <config_initial_latitude_south ice_grid="oRRS30to10v3wLI">-85.0</config_initial_latitude_south>
 <config_initial_latitude_south ice_grid="oRRS18to6v3">-85.0</config_initial_latitude_south>
@@ -148,6 +151,7 @@
 <config_dynamics_subcycle_number ice_grid="SOwISC12to60E2r4">1</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="ECwISC30to60E2r1">1</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="IcoswISC30E3r5">1</config_dynamics_subcycle_number>
+<config_dynamics_subcycle_number ice_grid="FRISwISC04to60E3r1">1</config_dynamics_subcycle_number>
 <config_rotate_cartesian_grid>true</config_rotate_cartesian_grid>
 <config_include_metric_terms>true</config_include_metric_terms>
 <config_elastic_subcycle_number>120</config_elastic_subcycle_number>

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -25,10 +25,10 @@
 <config_dt ice_grid="SOwISC12to60E2r4">1800.0</config_dt>
 <config_dt ice_grid="ECwISC30to60E2r1">1800.0</config_dt>
 <config_dt ice_grid="IcoswISC30E3r5">1800.0</config_dt>
-<config_dt ice_grid="FRISwISC08to60E3r1">1800.0</config_dt>
-<config_dt ice_grid="FRISwISC04to60E3r1">1800.0</config_dt>
-<config_dt ice_grid="FRISwISC02to60E3r1">1800.0</config_dt>
-<config_dt ice_grid="FRISwISC01to60E3r1">1800.0</config_dt>
+<config_dt ice_grid="FRISwISC08to60E3r1">480.0</config_dt>
+<config_dt ice_grid="FRISwISC04to60E3r1">240.0</config_dt>
+<config_dt ice_grid="FRISwISC02to60E3r1">120.0</config_dt>
+<config_dt ice_grid="FRISwISC01to60E3r1">60.0</config_dt>
 <config_calendar_type>'noleap'</config_calendar_type>
 <config_start_time>'2000-01-01_00:00:00'</config_start_time>
 <config_stop_time>'none'</config_stop_time>

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -25,7 +25,10 @@
 <config_dt ice_grid="SOwISC12to60E2r4">1800.0</config_dt>
 <config_dt ice_grid="ECwISC30to60E2r1">1800.0</config_dt>
 <config_dt ice_grid="IcoswISC30E3r5">1800.0</config_dt>
+<config_dt ice_grid="FRISwISC08to60E3r1">1800.0</config_dt>
 <config_dt ice_grid="FRISwISC04to60E3r1">1800.0</config_dt>
+<config_dt ice_grid="FRISwISC02to60E3r1">1800.0</config_dt>
+<config_dt ice_grid="FRISwISC01to60E3r1">1800.0</config_dt>
 <config_calendar_type>'noleap'</config_calendar_type>
 <config_start_time>'2000-01-01_00:00:00'</config_start_time>
 <config_stop_time>'none'</config_stop_time>
@@ -78,7 +81,10 @@
 <config_initial_latitude_north ice_grid="ECwISC30to60E2r1">75.0</config_initial_latitude_north>
 <!-- To do: 70.0 for WC but 75.0 for Cryo -->
 <config_initial_latitude_north ice_grid="IcoswISC30E3r5">70.0</config_initial_latitude_north>
+<config_initial_latitude_north ice_grid="FRISwISC08to60E3r1">85.0</config_initial_latitude_north>
 <config_initial_latitude_north ice_grid="FRISwISC04to60E3r1">85.0</config_initial_latitude_north>
+<config_initial_latitude_north ice_grid="FRISwISC02to60E3r1">85.0</config_initial_latitude_north>
+<config_initial_latitude_north ice_grid="FRISwISC01to60E3r1">85.0</config_initial_latitude_north>
 <config_initial_latitude_north ice_grid="ARRM10to60E2r1">75.0</config_initial_latitude_north>
 <config_initial_latitude_north ice_grid="oRRS30to10v3wLI">85.0</config_initial_latitude_north>
 <config_initial_latitude_north ice_grid="oRRS18to6v3">85.0</config_initial_latitude_north>
@@ -89,7 +95,10 @@
 <config_initial_latitude_south ice_grid="ECwISC30to60E2r1">-75.0</config_initial_latitude_south>
 <!-- To do: -60.0 for WC but -75.0 for Cryo -->
 <config_initial_latitude_south ice_grid="IcoswISC30E3r5">-60.0</config_initial_latitude_south>
+<config_initial_latitude_south ice_grid="FRISwISC08to60E3r1">-85.0</config_initial_latitude_south>
 <config_initial_latitude_south ice_grid="FRISwISC04to60E3r1">-85.0</config_initial_latitude_south>
+<config_initial_latitude_south ice_grid="FRISwISC02to60E3r1">-85.0</config_initial_latitude_south>
+<config_initial_latitude_south ice_grid="FRISwISC01to60E3r1">-85.0</config_initial_latitude_south>
 <config_initial_latitude_south ice_grid="ARRM10to60E2r1">-85.0</config_initial_latitude_south>
 <config_initial_latitude_south ice_grid="oRRS30to10v3wLI">-85.0</config_initial_latitude_south>
 <config_initial_latitude_south ice_grid="oRRS18to6v3">-85.0</config_initial_latitude_south>
@@ -151,7 +160,10 @@
 <config_dynamics_subcycle_number ice_grid="SOwISC12to60E2r4">1</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="ECwISC30to60E2r1">1</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="IcoswISC30E3r5">1</config_dynamics_subcycle_number>
+<config_dynamics_subcycle_number ice_grid="FRISwISC08to60E3r1">1</config_dynamics_subcycle_number>
 <config_dynamics_subcycle_number ice_grid="FRISwISC04to60E3r1">1</config_dynamics_subcycle_number>
+<config_dynamics_subcycle_number ice_grid="FRISwISC02to60E3r1">1</config_dynamics_subcycle_number>
+<config_dynamics_subcycle_number ice_grid="FRISwISC01to60E3r1">1</config_dynamics_subcycle_number>
 <config_rotate_cartesian_grid>true</config_rotate_cartesian_grid>
 <config_include_metric_terms>true</config_include_metric_terms>
 <config_elastic_subcycle_number>120</config_elastic_subcycle_number>

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -243,6 +243,16 @@ def buildnml(case, caseroot, compname):
             grid_date = '210203'
             grid_prefix = 'mpassi.SOwISC12to60E2r4.rstFromG-anvil'
 
+    elif ice_grid == 'FRISwISC08to60E3r1':
+        decomp_date = '20230913'  # changed to date of partiotions in ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-seaice/FRISwISC08to60E3r1/partitions
+        decomp_prefix = 'partitions/mpas-seaice.graph.info.'
+        grid_date = '20230913'  # changed to same as decomp_date
+        grid_prefix = 'mpassi.FRISwISC08to60E3r1'  # name from ../files_for_e3sm/assembled_files/inputdata/ice/mpas-seaice/FRISwISC08to60E3r1/mpassi.FRISwISC08to60E3r1.20230913.nc
+        data_iceberg_file += 'Iceberg_Climatology_Merino.FRISwISC08to60E3r1.20230913.nc'
+        if ice_ic_mode == 'spunup':
+            grid_date = '20230913'  # changed to same as decomp_date, but the spun up file does not yet exist
+            grid_prefix = 'mpassi.FRISwISC08to60E3r1.rstFromG-anvil'  #the spun up file does not yet exist
+
     elif ice_grid == 'FRISwISC04to60E3r1':
         decomp_date = '20230913'  # changed to date of partiotions in ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-seaice/FRISwISC04to60E3r1/partitions
         decomp_prefix = 'partitions/mpas-seaice.graph.info.'
@@ -252,6 +262,26 @@ def buildnml(case, caseroot, compname):
         if ice_ic_mode == 'spunup':
             grid_date = '20230913'  # changed to same as decomp_date, but the spun up file does not yet exist
             grid_prefix = 'mpassi.FRISwISC04to60E3r1.rstFromG-anvil'  #the spun up file does not yet exist
+
+    elif ice_grid == 'FRISwISC02to60E3r1':
+        decomp_date = '20230914'  # changed to date of partiotions in ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-seaice/FRISwISC02to60E3r1/partitions
+        decomp_prefix = 'partitions/mpas-seaice.graph.info.'
+        grid_date = '20230914'  # changed to same as decomp_date
+        grid_prefix = 'mpassi.FRISwISC02to60E3r1'  # name from ../files_for_e3sm/assembled_files/inputdata/ice/mpas-seaice/FRISwISC02to60E3r1/mpassi.FRISwISC02to60E3r1.20230914.nc
+        data_iceberg_file += 'Iceberg_Climatology_Merino.FRISwISC02to60E3r1.20230914.nc'
+        if ice_ic_mode == 'spunup':
+            grid_date = '20230914'  # changed to same as decomp_date, but the spun up file does not yet exist
+            grid_prefix = 'mpassi.FRISwISC02to60E3r1.rstFromG-anvil'  #the spun up file does not yet exist
+
+    elif ice_grid == 'FRISwISC01to60E3r1':
+        decomp_date = '20230915'  # changed to date of partiotions in ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-seaice/FRISwISC01to60E3r1/partitions
+        decomp_prefix = 'partitions/mpas-seaice.graph.info.'
+        grid_date = '20230915'  # changed to same as decomp_date
+        grid_prefix = 'mpassi.FRISwISC01to60E3r1'  # name from ../files_for_e3sm/assembled_files/inputdata/ice/mpas-seaice/FRISwISC01to60E3r1/mpassi.FRISwISC01to60E3r1.20230915.nc
+        data_iceberg_file += 'Iceberg_Climatology_Merino.FRISwISC01to60E3r1.20230915.nc'
+        if ice_ic_mode == 'spunup':
+            grid_date = '20230915'  # changed to same as decomp_date, but the spun up file does not yet exist
+            grid_prefix = 'mpassi.FRISwISC01to60E3r1.rstFromG-anvil'  #the spun up file does not yet exist
 
     elif ice_grid == 'ECwISC30to60E2r1':
         grid_date = '210413'

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -244,13 +244,13 @@ def buildnml(case, caseroot, compname):
             grid_prefix = 'mpassi.SOwISC12to60E2r4.rstFromG-anvil'
 
     elif ice_grid == 'FRISwISC04to60E3r1':
-        decomp_date = '20230817'  # changed to date of partiotions in ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-seaice/FRISwISC04to60E3r1/partitions
+        decomp_date = '20230913'  # changed to date of partiotions in ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-seaice/FRISwISC04to60E3r1/partitions
         decomp_prefix = 'partitions/mpas-seaice.graph.info.'
-        grid_date = '20230817'  # changed to same as decomp_date
-        grid_prefix = 'mpassi.FRISwISC04to60E3r1'  # name from ../files_for_e3sm/assembled_files/inputdata/ice/mpas-seaice/FRISwISC04to60E3r1/mpassi.FRISwISC04to60E3r1.20230817.nc
+        grid_date = '20230913'  # changed to same as decomp_date
+        grid_prefix = 'mpassi.FRISwISC04to60E3r1'  # name from ../files_for_e3sm/assembled_files/inputdata/ice/mpas-seaice/FRISwISC04to60E3r1/mpassi.FRISwISC04to60E3r1.20230913.nc
         data_iceberg_file += 'Iceberg_Interannual_Merino_FRISwISC04to60E3r1.nc'
         if ice_ic_mode == 'spunup':
-            grid_date = '20230817'  # changed to same as decomp_date, but the spun up file does not yet exist
+            grid_date = '20230913'  # changed to same as decomp_date, but the spun up file does not yet exist
             grid_prefix = 'mpassi.FRISwISC04to60E3r1.rstFromG-anvil'  #the spun up file does not yet exist
 
     elif ice_grid == 'ECwISC30to60E2r1':

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -243,6 +243,16 @@ def buildnml(case, caseroot, compname):
             grid_date = '210203'
             grid_prefix = 'mpassi.SOwISC12to60E2r4.rstFromG-anvil'
 
+    elif ice_grid == 'FRISwISC04to60E3r1':
+        decomp_date = '20230817'  # changed to date of partiotions in ../files_for_e3sm/assembled_files/inputdata/ocn/mpas-seaice/FRISwISC04to60E3r1/partitions
+        decomp_prefix = 'partitions/mpas-seaice.graph.info.'
+        grid_date = '20230817'  # changed to same as decomp_date
+        grid_prefix = 'mpassi.FRISwISC04to60E3r1'  # name from ../files_for_e3sm/assembled_files/inputdata/ice/mpas-seaice/FRISwISC04to60E3r1/mpassi.FRISwISC04to60E3r1.20230817.nc
+        data_iceberg_file += 'Iceberg_Interannual_Merino_FRISwISC04to60E3r1.nc'
+        if ice_ic_mode == 'spunup':
+            grid_date = '20230817'  # changed to same as decomp_date, but the spun up file does not yet exist
+            grid_prefix = 'mpassi.FRISwISC04to60E3r1.rstFromG-anvil'  #the spun up file does not yet exist
+
     elif ice_grid == 'ECwISC30to60E2r1':
         grid_date = '210413'
         grid_prefix = 'seaice.ECwISC30to60E2r1'

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -248,7 +248,7 @@ def buildnml(case, caseroot, compname):
         decomp_prefix = 'partitions/mpas-seaice.graph.info.'
         grid_date = '20230913'  # changed to same as decomp_date
         grid_prefix = 'mpassi.FRISwISC04to60E3r1'  # name from ../files_for_e3sm/assembled_files/inputdata/ice/mpas-seaice/FRISwISC04to60E3r1/mpassi.FRISwISC04to60E3r1.20230913.nc
-        data_iceberg_file += 'Iceberg_Interannual_Merino_FRISwISC04to60E3r1.nc'
+        data_iceberg_file += 'Iceberg_Climatology_Merino.FRISwISC04to60E3r1.20230913.nc'
         if ice_ic_mode == 'spunup':
             grid_date = '20230913'  # changed to same as decomp_date, but the spun up file does not yet exist
             grid_prefix = 'mpassi.FRISwISC04to60E3r1.rstFromG-anvil'  #the spun up file does not yet exist

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -436,7 +436,7 @@ def buildnml(case, caseroot, compname):
             lines.append('<streams>')
             lines.append('<immutable_stream name="mesh"')
             lines.append('                  type="none"')
-            if ice_grid.startswith("oRRS1"):
+            if ice_grid.startswith("oRRS1") or ice_grid.startswith("FRIS"):
                 lines.append('                  io_type="pnetcdf,cdf5"')
             else:
                 lines.append('                  io_type="{}"'.format(ice_pio_typename))
@@ -445,7 +445,7 @@ def buildnml(case, caseroot, compname):
             lines.append('')
             lines.append('<immutable_stream name="input"')
             lines.append('                  type="input"')
-            if ice_grid.startswith("oRRS1"):
+            if ice_grid.startswith("oRRS1") or ice_grid.startswith("FRIS"):
                 lines.append('                  io_type="pnetcdf,cdf5"')
             else:
                 lines.append('                  io_type="{}"'.format(ice_pio_typename))
@@ -467,7 +467,7 @@ def buildnml(case, caseroot, compname):
             lines.append('')
             lines.append('<immutable_stream name="restart"')
             lines.append('                  type="input;output"')
-            if ice_grid.startswith("oRRS1"):
+            if ice_grid.startswith("oRRS1") or ice_grid.startswith("FRIS"):
                 lines.append('                  io_type="pnetcdf,cdf5"')
             else:
                 lines.append('                  io_type="{}"'.format(ice_pio_typename))
@@ -483,7 +483,7 @@ def buildnml(case, caseroot, compname):
             if ice_ic_mode == 'spunup':
                 lines.append('<immutable_stream name="restart_ic"')
                 lines.append('                  type="input"')
-                if ice_grid.startswith("oRRS1"):
+                if ice_grid.startswith("oRRS1") or ice_grid.startswith("FRIS"):
                     lines.append('                  io_type="pnetcdf,cdf5"')
                 else:
                     lines.append('                  io_type="{}"'.format(ice_pio_typename))

--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -369,6 +369,10 @@
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oQU120">24</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oEC60to30v3">48</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%ECwISC30to60E1r2">48</value>
+      <value compset="_DATM.*_SLND.*MPAS" grid="oi%FRISwISC08to60E3r1">180</value>
+      <value compset="_DATM.*_SLND.*MPAS" grid="oi%FRISwISC04to60E3r1">360</value>
+      <value compset="_DATM.*_SLND.*MPAS" grid="oi%FRISwISC02to60E3r1">720</value>
+      <value compset="_DATM.*_SLND.*MPAS" grid="oi%FRISwISC01to60E3r1">1440</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%EC30to60E2r2">48</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%WC14to60E2r3">48</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oRRS30to10v3">96</value>


### PR DESCRIPTION
Meshes with high resolution in the southern Weddell Sea and beneath the Filchner Ronne Ice Shelf (FRIS). The meshes go down to 1, 2, 4, and 8 km beneath FRIS and on the continental shelf in front of it.

Meshes are:
`FRISwISC01to60E3r1`
`FRISwISC02to60E3r1`
`FRISwISC04to60E3r1`
`FRISwISC08to60E3r1`

They are intended only for use in E3SM G-case simulations.  Mapping and domain files for supporting B-cases or other coupled configurations are not included and will not be supported.

Related Ocean Discussion is here:

https://github.com/E3SM-Ocean-Discussion/E3SM/pull/75