### PR TITLE
Add IC and monthly forcing file to support BGC for IcoswISC30E3r5

### DIFF
--- a/cime_config/testmods_dirs/config_pes_tests.xml
+++ b/cime_config/testmods_dirs/config_pes_tests.xml
@@ -132,17 +132,17 @@
         </rootpe>
       </pes>
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+SGLC_SWAV_SIAC_SESP_BGC.*" pesize="any">
-        <comment>tests+chrysalis: --compset BGC* --res ne30pg2_r05_IcoswISC30E3r5 on 5 nodes pure-MPI </comment>
+        <comment>tests+chrysalis: --compset BGC* --res ne30pg2_r05_IcoswISC30E3r5 on 9 nodes pure-MPI </comment>
         <ntasks>
-          <ntasks_atm>256</ntasks_atm>
-          <ntasks_lnd>256</ntasks_lnd>
-          <ntasks_rof>256</ntasks_rof>
-          <ntasks_ice>256</ntasks_ice>
-          <ntasks_ocn>64</ntasks_ocn>
-          <ntasks_cpl>256</ntasks_cpl>
+          <ntasks_atm>448</ntasks_atm>
+          <ntasks_lnd>448</ntasks_lnd>
+          <ntasks_rof>448</ntasks_rof>
+          <ntasks_ice>448</ntasks_ice>
+          <ntasks_ocn>128</ntasks_ocn>
+          <ntasks_cpl>448</ntasks_cpl>
         </ntasks>
         <rootpe>
-          <rootpe_ocn>256</rootpe_ocn>
+          <rootpe_ocn>448</rootpe_ocn>
         </rootpe>
       </pes>
     </mach>

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -293,6 +293,10 @@ def buildnml(case, caseroot, compname):
         if ocn_ic_mode == 'spunup':
             ic_date = '20231121'
             ic_prefix = 'mpaso.IcoswISC30E3r5.rstFromG-chrysalis'
+        if ocn_bgc in ['eco_only', 'eco_and_dms', 'eco_and_macromolecules', 'eco_and_dms_and_macromolecules']:
+            ic_date = '20231215'
+            ic_prefix = 'mpaso.IcoswISC30E3r5.20231120+MARBL_ICfromOMIP_64levels'
+            eco_forcing_file = 'ecoForcingSurfaceMonthly.IcoswISC30E3r5.20231215.nc'
         if ocn_ismf == 'data':
             data_ismf_file = 'prescribed_ismf_adusumilli2020.IcoswISC30E3r5.20231120.nc'
 


### PR DESCRIPTION
Adds new initial condition and monthly forcing file to support BGC compsets using the IcoswISC30E3r5 resolution.

With thanks to Mat Maltrud for making and providing the new files.

[NML] - only for tests with marine BGC and IcoswISC30E3r5
[BFB] - for all current E3SM tests