### PR TITLE
Writes/reads C budget related variables in history file

### DIFF
--- a/components/elm/src/biogeochem/CNPBudgetMod.F90
+++ b/components/elm/src/biogeochem/CNPBudgetMod.F90
@@ -1193,8 +1193,7 @@ contains
     type(gridcell_carbon_state), intent(inout) :: grc_cs
     !
     ! !LOCAL VARIABLES:
-    integer :: year_prev, month_prev, day_prev, sec_prev
-    integer :: year_curr, month_curr, day_curr, sec_curr
+    integer :: year, month, day, sec
     !-----------------------------------------------------------------------
 
     associate(                                                       &
@@ -1203,26 +1202,19 @@ contains
          tcs_month_end_grc =>    grc_cs%tcs_month_end   & ! Output: [real(r8) (:)   ]  grid-level carbon mass at the ending of a month
          )
 
-      ! Get current and previous dates to determine if a new month started
-      call get_curr_date(year_curr, month_curr, day_curr, sec_curr);
-
-      ! If at the beginning of a simulation, save grid-level TCS based on
-      ! 'begcb' from the current time step
-      if ( day_curr == 1 .and. sec_curr == 0 .and. get_nstep() <= 1 ) then
-         call c2g( bounds, &
-              begcb(bounds%begc:bounds%endc), &
-              tcs_month_end_grc(bounds%begg:bounds%endg), &
-              c2l_scale_type= 'unity', l2g_scale_type='unity' )
-      endif
+      ! Get current dates to determine if a new month started
+      call get_curr_date(year, month, day, sec);
 
       ! If multiple steps into a simulation and the last time step was the
       ! end of a month, save grid-level TCS based on 'endcb' from the last
       ! time step
-      if (get_nstep() > 1 .and. day_curr == 1 .and. sec_curr == 0) then
+      if (get_nstep() > 1 .and. day == 1 .and. sec == 0) then
          call c2g( bounds, &
               endcb(bounds%begc:bounds%endc), &
               tcs_month_end_grc(bounds%begg:bounds%endg), &
               c2l_scale_type= 'unity', l2g_scale_type='unity' )
+      else
+         tcs_month_end_grc(bounds%begg:bounds%endg) = spval
       endif
 
     end associate

--- a/components/elm/src/biogeochem/CNPBudgetMod.F90
+++ b/components/elm/src/biogeochem/CNPBudgetMod.F90
@@ -1200,7 +1200,7 @@ contains
     associate(                                                       &
          begcb             =>    col_cs%begcb         , & ! Input : [real(r8) (:)   ]  carbon mass begining of the time step
          endcb             =>    col_cs%endcb         , & ! Input : [real(r8) (:)   ]  carbon mass begining of the time step
-         tcs_month_end_grc =>    grc_cs%tcs_month_beg   & ! Output: [real(r8) (:)   ]  grid-level carbon mass at the begining of a month
+         tcs_month_beg_grc =>    grc_cs%tcs_month_beg   & ! Output: [real(r8) (:)   ]  grid-level carbon mass at the begining of a month
          )
 
       ! Get current and previous dates to determine if a new month started
@@ -1212,7 +1212,7 @@ contains
       if ( day_curr == 1 .and. sec_curr == 0 .and. get_nstep() <= 1 ) then
          call c2g( bounds, &
               begcb(bounds%begc:bounds%endc), &
-              tcs_month_end_grc(bounds%begg:bounds%endg), &
+              tcs_month_beg_grc(bounds%begg:bounds%endg), &
               c2l_scale_type= 'unity', l2g_scale_type='unity' )
       endif
 
@@ -1222,7 +1222,7 @@ contains
       if (get_nstep() > 1 .and. day_prev == 1 .and. sec_prev == 0) then
          call c2g( bounds, &
               endcb(bounds%begc:bounds%endc), &
-              tcs_month_end_grc(bounds%begg:bounds%endg), &
+              tcs_month_beg_grc(bounds%begg:bounds%endg), &
               c2l_scale_type= 'unity', l2g_scale_type='unity' )
       endif
 

--- a/components/elm/src/biogeochem/CNPBudgetMod.F90
+++ b/components/elm/src/biogeochem/CNPBudgetMod.F90
@@ -1200,7 +1200,7 @@ contains
     associate(                                                       &
          begcb             =>    col_cs%begcb         , & ! Input : [real(r8) (:)   ]  carbon mass begining of the time step
          endcb             =>    col_cs%endcb         , & ! Input : [real(r8) (:)   ]  carbon mass begining of the time step
-         tcs_month_beg_grc =>    grc_cs%tcs_month_beg   & ! Output: [real(r8) (:)   ]  grid-level carbon mass at the begining of a month
+         tcs_month_end_grc =>    grc_cs%tcs_month_end   & ! Output: [real(r8) (:)   ]  grid-level carbon mass at the ending of a month
          )
 
       ! Get current and previous dates to determine if a new month started
@@ -1212,7 +1212,7 @@ contains
       if ( day_curr == 1 .and. sec_curr == 0 .and. get_nstep() <= 1 ) then
          call c2g( bounds, &
               begcb(bounds%begc:bounds%endc), &
-              tcs_month_beg_grc(bounds%begg:bounds%endg), &
+              tcs_month_end_grc(bounds%begg:bounds%endg), &
               c2l_scale_type= 'unity', l2g_scale_type='unity' )
       endif
 
@@ -1222,7 +1222,7 @@ contains
       if (get_nstep() > 1 .and. day_prev == 1 .and. sec_prev == 0) then
          call c2g( bounds, &
               endcb(bounds%begc:bounds%endc), &
-              tcs_month_beg_grc(bounds%begg:bounds%endg), &
+              tcs_month_end_grc(bounds%begg:bounds%endg), &
               c2l_scale_type= 'unity', l2g_scale_type='unity' )
       endif
 

--- a/components/elm/src/biogeochem/CNPBudgetMod.F90
+++ b/components/elm/src/biogeochem/CNPBudgetMod.F90
@@ -1204,8 +1204,7 @@ contains
          )
 
       ! Get current and previous dates to determine if a new month started
-      call get_prev_date(year_curr, month_curr, day_curr, sec_curr);
-      call get_prev_date(year_prev, month_prev, day_prev, sec_prev)
+      call get_curr_date(year_curr, month_curr, day_curr, sec_curr);
 
       ! If at the beginning of a simulation, save grid-level TCS based on
       ! 'begcb' from the current time step
@@ -1219,7 +1218,7 @@ contains
       ! If multiple steps into a simulation and the last time step was the
       ! end of a month, save grid-level TCS based on 'endcb' from the last
       ! time step
-      if (get_nstep() > 1 .and. day_prev == 1 .and. sec_prev == 0) then
+      if (get_nstep() > 1 .and. day_curr == 1 .and. sec_curr == 0) then
          call c2g( bounds, &
               endcb(bounds%begc:bounds%endc), &
               tcs_month_end_grc(bounds%begg:bounds%endg), &

--- a/components/elm/src/data_types/GridcellDataType.F90
+++ b/components/elm/src/data_types/GridcellDataType.F90
@@ -647,6 +647,10 @@ contains
          long_name='total carbon storage at the beginning of a month', units='gC/m^2', &
           interpinic_flag='interp', readvar=readvar, data=this%tcs_month_beg)
 
+    call restartvar(ncid=ncid, flag=flag, varname='TCS_MONTH_END', xtype=ncd_double,  &
+         dim1name='gridcell', &
+         long_name='total carbon storage at the end of a month', units='gC/m^2', &
+          interpinic_flag='interp', readvar=readvar, data=this%tcs_month_end)
   end subroutine grc_cs_restart
 
   !------------------------------------------------------------------------

--- a/components/elm/src/main/restFileMod.F90
+++ b/components/elm/src/main/restFileMod.F90
@@ -404,6 +404,8 @@ contains
        call veg_ps%Restart(bounds, ncid, flag='write')
        call veg_pf%Restart(bounds, ncid, flag='write')
        call crop_vars%Restart(bounds, ncid, flag='write')
+
+       call grc_cs%Restart(bounds, ncid, flag='write')
     end if
 
 
@@ -627,6 +629,8 @@ contains
        call veg_ps%Restart(bounds, ncid, flag='read')
        call veg_pf%Restart(bounds, ncid, flag='read')
        call crop_vars%Restart(bounds, ncid, flag='read')
+
+       call grc_cs%Restart(bounds, ncid, flag='read')
     end if
 
     if (use_fates) then


### PR DESCRIPTION
The `TCS_MONTH_BEGIN`  and `TCS_MONTH_END` variables are written and read from the ELM restart file. 

[non-BFB] just for those variables.  No change in answers otherwise.