### PR TITLE
update circleci image spec due to upstream changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: previous
+      image: ubuntu-2004:2024.01.1
     steps:
       - checkout
       - run: bash .circleci/setup.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: ubuntu-2004:202010-01
+      image: previous
     steps:
       - checkout
       - run: bash .circleci/setup.sh

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -11,6 +11,10 @@ function download
     return $?
 }
 
+# Install Singularity deps:
+
+sudo apt-get update && sudo apt-get -y install uuid-dev
+
 # Install Singularity
 download && \
     tar -xzf singularity-${VERSION}.tar.gz && \


### PR DESCRIPTION
Addresses CircleCI new image requirements, lest we are affected by brownouts and eventual blackouts.

--

We expreienced our first brownout in https://app.circleci.com/pipelines/github/E3SM-Project/E3SM/10529/workflows/8d2afe3d-53a7-456d-ae39-ecf6378f23f9/jobs/10059 (as part of PR #6276). See the note by CircleCI here: https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177. The fix in this PR is simply putting a band-aid on our CircleCI testing until we have some time for a proper fix and for a thorough upgrade of our containers. 