### PR TITLE
Update non-bfb test grid

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -219,9 +219,9 @@ _TESTS = {
     #atmopheric nbfb tests
     "e3sm_atm_nbfb" : {
         "tests" : (
-            "PGN_P1x1.ne4_oQU240.F2010",
-            "TSC_PS.ne4_oQU240.F2010",
-            "MVK_PS.ne4_oQU240.F2010",
+            "PGN_P1x1.ne4pg2_oQU480.F2010",
+            "TSC_PS.ne4pg2_oQU480.F2010",
+            "MVK_PS.ne4pg2_oQU480.F2010",
             )
         },
 


### PR DESCRIPTION
Use the new v3 ultra low-res test grids for e3sm_atm_nbfb test suite.
Depends on https://github.com/ESMCI/cime/pull/4595 for TSC / PGN