### PR TITLE
fix topo weights in maint2.1 for proper restart

### DIFF
--- a/components/elm/src/main/restFileMod.F90
+++ b/components/elm/src/main/restFileMod.F90
@@ -64,7 +64,7 @@ module restFileMod
   use VegetationDataType   , only : veg_ns, veg_nf
   use VegetationDataType   , only : veg_ps, veg_pf
   use GridcellDataType     , only : grc_cs, grc_ws 
-  
+  use subgridWeightsMod    , only : compute_higher_order_weights
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -524,6 +524,7 @@ contains
     !$OMP PARALLEL DO PRIVATE (nc, bounds_clump)
     do nc = 1, nclumps
        call get_clump_bounds(nc, bounds_clump)
+       call compute_higher_order_weights(bounds_clump) 
        call reweight_wrapup(bounds_clump, glc2lnd_vars%icemask_grc(bounds_clump%begg:bounds_clump%endg))
     end do
     !$OMP END PARALLEL DO

--- a/components/elm/src/main/subgridRestMod.F90
+++ b/components/elm/src/main/subgridRestMod.F90
@@ -12,8 +12,8 @@ module subgridRestMod
   use clm_time_manager   , only : get_curr_date
   use elm_varcon         , only : nameg, namet, namel, namec, namep
   use elm_varpar         , only : nlevsno
-  use pio                , only : file_desc_t
-  use ncdio_pio          , only : ncd_int, ncd_double
+  use pio                , only : file_desc_t, var_desc_t
+  use ncdio_pio          , only : ncd_int, ncd_double, check_var
   use GetGlobalValuesMod , only : GetGlobalIndexArray
   use GridcellType       , only : grc_pp
   use TopounitType       , only : top_pp
@@ -463,6 +463,7 @@ contains
     !
     ! !LOCAL VARIABLES:
     logical :: readvar              ! temporary
+    type(var_desc_t)  :: vardesc            ! variable descriptor
     real(r8), pointer :: temp2d(:,:) ! temporary for sno column variables
     
     character(len=*), parameter :: subname = 'subgridRest_write_and_read'
@@ -476,6 +477,23 @@ contains
          dim1name='landunit',                                                      &
          long_name='landunit weight relative to corresponding gridcell',           &
          interpinic_flag='skip', readvar=readvar, data=lun_pp%wtgcell)
+        
+    
+    if(flag == 'read') then 
+      ! For backwards compatibility, check if wttopounit is on restart file
+      call check_var(ncid=ncid, varname='land1d_wttopounit', vardesc=vardesc, readvar=readvar)
+      if(readvar) then 
+        call restartvar(ncid=ncid, flag=flag, varname='land1d_wttopounit', xtype=ncd_double, &
+           dim1name='landunit',                                                            &
+           long_name='landunit weight relative to corresponding topounit', units='',         &
+           interpinic_flag='skip', readvar=readvar, data=lun_pp%wttopounit)
+       endif
+    else ! flag == 'write' 
+       call restartvar(ncid=ncid, flag=flag, varname='land1d_wttopounit', xtype=ncd_double, &
+           dim1name='landunit',                                                            &
+           long_name='landunit weight relative to corresponding topounit', units='',         &
+           interpinic_flag='skip', readvar=readvar, data=lun_pp%wttopounit)
+    endif 
 
     call restartvar(ncid=ncid, flag=flag, varname='cols1d_wtxy', xtype=ncd_double,  &
          dim1name='column',                                                         &

--- a/components/elm/src/main/subgridRestMod.F90
+++ b/components/elm/src/main/subgridRestMod.F90
@@ -479,10 +479,10 @@ contains
          interpinic_flag='skip', readvar=readvar, data=lun_pp%wtgcell)
         
     
-    if(flag == 'read') then 
+    if (flag == 'read') then 
       ! For backwards compatibility, check if wttopounit is on restart file
       call check_var(ncid=ncid, varname='land1d_wttopounit', vardesc=vardesc, readvar=readvar)
-      if(readvar) then 
+      if (readvar) then 
         call restartvar(ncid=ncid, flag=flag, varname='land1d_wttopounit', xtype=ncd_double, &
            dim1name='landunit',                                                            &
            long_name='landunit weight relative to corresponding topounit', units='',         &


### PR DESCRIPTION
`lun_pp%wttopounit` is added to the restart file and call to `compute_higher_order_weights` 
is added to the subgridRest module to ensure proper calculation of all weights prior to evaluating them.

Fixes #6296 

[BFB]