### PR TITLE
Add SAL updates and topographic wave drag schemes for barotropic tides

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -718,7 +718,7 @@ add_default($nl, 'config_enable_shortwave_energy_fixer');
 ###########################################
 
 add_default($nl, 'config_use_self_attraction_loading');
-add_default($nl, 'config_self_attraction_loading_smoothing_width');
+add_default($nl, 'config_self_attraction_loading_depth_cutoff');
 add_default($nl, 'config_mpas_to_grid_weights_file');
 add_default($nl, 'config_grid_to_mpas_weights_file');
 add_default($nl, 'config_self_attraction_loading_compute_interval');
@@ -818,8 +818,11 @@ add_default($nl, 'config_loglaw_bottom_drag_min');
 add_default($nl, 'config_loglaw_bottom_drag_max');
 add_default($nl, 'config_explicit_bottom_drag_coeff');
 add_default($nl, 'config_use_topographic_wave_drag');
+add_default($nl, 'config_topographic_wave_drag_scheme');
 add_default($nl, 'config_topographic_wave_drag_coeff');
 add_default($nl, 'config_thickness_drag_type');
+add_default($nl, 'config_topographic_wave_drag_cutoff_depth');
+add_default($nl, 'config_topographic_wave_drag_cutoff_width');
 
 ####################################
 # Namelist group: Rayleigh_damping #

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -243,7 +243,7 @@ add_default($nl, 'config_enable_shortwave_energy_fixer');
 ###########################################
 
 add_default($nl, 'config_use_self_attraction_loading');
-add_default($nl, 'config_self_attraction_loading_smoothing_width');
+add_default($nl, 'config_self_attraction_loading_depth_cutoff');
 add_default($nl, 'config_mpas_to_grid_weights_file');
 add_default($nl, 'config_grid_to_mpas_weights_file');
 add_default($nl, 'config_self_attraction_loading_compute_interval');
@@ -335,8 +335,11 @@ add_default($nl, 'config_loglaw_bottom_drag_min');
 add_default($nl, 'config_loglaw_bottom_drag_max');
 add_default($nl, 'config_explicit_bottom_drag_coeff');
 add_default($nl, 'config_use_topographic_wave_drag');
+add_default($nl, 'config_topographic_wave_drag_scheme');
 add_default($nl, 'config_topographic_wave_drag_coeff');
 add_default($nl, 'config_thickness_drag_type');
+add_default($nl, 'config_topographic_wave_drag_cutoff_depth');
+add_default($nl, 'config_topographic_wave_drag_cutoff_width');
 
 ####################################
 # Namelist group: Rayleigh_damping #

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -295,7 +295,7 @@
 
 <!-- self_attraction_loading -->
 <config_use_self_attraction_loading>.false.</config_use_self_attraction_loading>
-<config_self_attraction_loading_smoothing_width>1.0</config_self_attraction_loading_smoothing_width>
+<config_self_attraction_loading_depth_cutoff>10.0</config_self_attraction_loading_depth_cutoff>
 <config_mpas_to_grid_weights_file>'mpas_to_grid.nc'</config_mpas_to_grid_weights_file>
 <config_grid_to_mpas_weights_file>'grid_to_mpas.nc'</config_grid_to_mpas_weights_file>
 <config_self_attraction_loading_compute_interval>'0000-00-00_00:30:00'</config_self_attraction_loading_compute_interval>
@@ -399,8 +399,11 @@
 <config_loglaw_bottom_drag_max>1.0e-1</config_loglaw_bottom_drag_max>
 <config_explicit_bottom_drag_coeff>1.0e-3</config_explicit_bottom_drag_coeff>
 <config_use_topographic_wave_drag>.false.</config_use_topographic_wave_drag>
+<config_topographic_wave_drag_scheme>'ZAE'</config_topographic_wave_drag_scheme>
 <config_topographic_wave_drag_coeff>5.0e-4</config_topographic_wave_drag_coeff>
 <config_thickness_drag_type>'centered'</config_thickness_drag_type>
+<config_topographic_wave_drag_cutoff_depth>500</config_topographic_wave_drag_cutoff_depth>
+<config_topographic_wave_drag_cutoff_width>10</config_topographic_wave_drag_cutoff_width>
 
 <!-- Rayleigh_damping -->
 <config_Rayleigh_damping_coeff>0.0</config_Rayleigh_damping_coeff>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1229,9 +1229,9 @@ Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_self_attraction_loading_smoothing_width" type="real"
+<entry id="config_self_attraction_loading_depth_cutoff" type="real"
 	category="self_attraction_loading" group="self_attraction_loading">
-Defines region over which ssh is smoothed to zero at coasts for SAL calculation.
+Defines depths over which ssh is smoothed to zero for SAL calculation.
 
 Valid values: Any positive real number.
 Default: Defined in namelist_defaults.xml
@@ -1780,11 +1780,19 @@ Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_topographic_wave_drag_scheme" type="char*1024"
+	category="bottom_drag" group="bottom_drag">
+Which of the following three wave drag schemes to use: JSL: Jayne and St. Laurent; ZAE: Zaron and Egbert; or LGF: Local generation formula
+
+Valid values: JSL or ZAE or LGF
+Default: Defined in namelist_defaults.xml
+</entry>
+
 <entry id="config_topographic_wave_drag_coeff" type="real"
 	category="bottom_drag" group="bottom_drag">
 Dimensionless topographic wave drag coefficient, $c_{topo}$.
 
-Valid values: any positive real, typically 5.0e-4
+Valid values: any positive real
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -1793,6 +1801,22 @@ Default: Defined in namelist_defaults.xml
 The type of layerThickness averaging to use on the drag term. The standard MPAS-O approach is 'centered'.
 
 Valid values: 'harmonic-mean', 'centered'
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_topographic_wave_drag_cutoff_depth" type="real"
+	category="bottom_drag" group="bottom_drag">
+Specifies minimum depth at which topographic wave drag is applied
+
+Valid values: any positive real
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_topographic_wave_drag_cutoff_width" type="real"
+	category="bottom_drag" group="bottom_drag">
+Width over which the topographic wave drag is progressively turned off
+
+Valid values: any positive real
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1108,7 +1108,11 @@
 					description="If true, topographic wave drag is used on the momentum equation."
 					possible_values=".true. or .false."
 		/>
-		<nml_option name="config_topographic_wave_drag_coeff" type="real" default_value="5.0e-4"
+		<nml_option name="config_topographic_wave_drag_scheme" type="character" default_value="JSL" units="unitless"
+					description="hich of the following three wave drag schemes to use: JSL: Jayne and St. Laurent; ZAE: Zaron and Egbert; or NYC: Nycander"
+					possible_values="JSL or ZAE or NYC"
+		/>
+		<nml_option name="config_topographic_wave_drag_coeff" type="real" default_value="5.0e-4" units="unitless"
 					description="Dimensionless topographic wave drag coefficient, $c_{topo}$."
 					possible_values="any positive real, typically 5.0e-4"
 		/>
@@ -2262,7 +2266,11 @@
 				filename_template="topographic_wave_drag.nc"
 				runtime_format="single_file"
 				mode="forward;analysis">
-			<var name="topographic_wave_drag"/>
+			<var name="topo_rinv"/>
+			<var name="topo_buoyancy_N1V"/>
+			<var name="topo_buoyancy_N1B"/>
+			<var name="bathy_stddev"/>
+			<var name="bed_slope_edges"/>
 		</stream>
 
 	</streams>
@@ -3233,8 +3241,24 @@
 		<var name="surfaceFluxAttenuationCoefficientRunoff" type="real" dimensions="nCells Time" units="m"
 			description="The spatially-dependent length scale of exponential decay of river runoff. Fluxes are multiplied by $e^{z/\gamma}$, where this coefficient is $\gamma$."
 		/>
-		<var name="topographic_wave_drag" type="real" dimensions="nEdges" units="1"
+		<var name="topo_rinv" type="real" dimensions="nEdges" units="unitless"
 			description="wave drag coefficient or 1/(rinv) where rinv is the e-folding time used in HyCOM"
+			packages="topographicWaveDragPKG"
+		/>
+		<var name="topo_buoyancy_N1V" type="real" dimensions="nEdges" units="unitless"
+			description="Vertically averaged buoyancy frequencies from WOA 2013 data"
+			packages="topographicWaveDragPKG"
+		/>
+		<var name="topo_buoyancy_N1B" type="real" dimensions="nEdges" units="unitless"
+			description="Bottom buoyancy frequencies from WOA 2013 data"
+			packages="topographicWaveDragPKG"
+		/>
+		<var name="bathy_stddev" type="real" dimensions="nEdges" units="unitless"
+			description="Standard deviation of the bathymetry within a given cell"
+			packages="topographicWaveDragPKG"
+		/>
+		<var name="bed_slope_edges" type="real" dimensions="nEdges" units="unitless"
+			description="The integral gradient average per cell"
 			packages="topographicWaveDragPKG"
 		/>
 		<!-- diagnostic fields for land-ice fluxes -->

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1975,10 +1975,6 @@
             <var name="gotmDissTopOfCell"/>
             <var name="gotmLengthTopOfCell"/>
             <var name="pgf_sal"/>
-            <var name="temp_twd"/>
-            <var name="normalCoeff"/>
-            <var name="tangentialCoeff"/>
-            <var name="topographicWaveDrag"/>
 		</stream>
 
 		<stream name="output"
@@ -3486,11 +3482,11 @@
 			description="tendency perturbation due to topographic wave drag"
 			packages="tidalPotentialForcingPKG"
 		/>
-		<var name="normalCoeff" type="real" dimensions="nEdges" units=""
+		<var name="normalCoeffTWD" type="real" dimensions="nEdges" units=""
 			description="Coefficient multiplied by the normal velocity in the topographic wave drag"
 			packages="tidalPotentialForcingPKG"
 		/>
-		<var name="tangentialCoeff" type="real" dimensions="nEdges" units=""
+		<var name="tangentialCoeffTWD" type="real" dimensions="nEdges" units=""
 			description="Coefficient multiplied by the tangential velocity in the topographic wave drag"
 			packages="tidalPotentialForcingPKG"
 		/>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1109,8 +1109,8 @@
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_topographic_wave_drag_scheme" type="character" default_value="JSL" units="unitless"
-					description="hich of the following three wave drag schemes to use: JSL: Jayne and St. Laurent; ZAE: Zaron and Egbert; or NYC: Nycander"
-					possible_values="JSL or ZAE or NYC"
+					description="hich of the following three wave drag schemes to use: JSL: Jayne and St. Laurent; ZAE: Zaron and Egbert; or LGF: Local generation formula"
+					possible_values="JSL or ZAE or LGF"
 		/>
 		<nml_option name="config_topographic_wave_drag_coeff" type="real" default_value="5.0e-4" units="unitless"
 					description="Dimensionless topographic wave drag coefficient, $c_{topo}$."
@@ -1119,6 +1119,14 @@
 		<nml_option name="config_thickness_drag_type" type="character" default_value="centered"
 					description="The type of layerThickness averaging to use on the drag term. The standard MPAS-O approach is 'centered'."
 					possible_values="'harmonic-mean', 'centered'"
+		/>
+		<nml_option name="config_topographic_wave_drag_cutoff_depth" type="real" default_value="500" units="m"
+					description="Specifies minimum depth at which topographic wave drag is applied"
+					possible_values="any positive real"
+		/>
+		<nml_option name="config_topographic_wave_drag_cutoff_width" type="real" default_value="10" units="m"
+					description="Width over which the topographic wave drag is progressively turned off"
+					possible_values="any positive real"
 		/>
 	</nml_record>
 	<nml_record name="Rayleigh_damping" mode="forward">
@@ -1967,6 +1975,10 @@
             <var name="gotmDissTopOfCell"/>
             <var name="gotmLengthTopOfCell"/>
             <var name="pgf_sal"/>
+            <var name="temp_twd"/>
+            <var name="normalCoeff"/>
+            <var name="tangentialCoeff"/>
+            <var name="topographicWaveDrag"/>
 		</stream>
 
 		<stream name="output"
@@ -2271,6 +2283,9 @@
 			<var name="topo_buoyancy_N1B"/>
 			<var name="bathy_stddev"/>
 			<var name="bed_slope_edges"/>
+			<var name="bottomDepthEdge"/>
+			<var name="lonGradEdge"/>
+			<var name="latGradEdge"/>
 		</stream>
 
 	</streams>
@@ -3261,6 +3276,18 @@
 			description="The integral gradient average per cell"
 			packages="topographicWaveDragPKG"
 		/>
+		<var name="bottomDepthEdge" type="real" dimensions="nEdges" units="unitless"
+			description="bottom depth at the cell edges"
+			packages="topographicWaveDragPKG"
+		/>
+		<var name="lonGradEdge" type="real" dimensions="nEdges" units="unitless"
+			description="Meridional gradient of bathymetry"
+			packages="topographicWaveDragPKG"
+		/>
+		<var name="latGradEdge" type="real" dimensions="nEdges" units="unitless"
+			description="Zonal gradient of bathymetry"
+			packages="topographicWaveDragPKG"
+		/>
 		<!-- diagnostic fields for land-ice fluxes -->
 		<var name="landIceFrictionVelocity" type="real" dimensions="nCells Time" units="m s^-1"
 			description="The friction velocity $u_*$ under land ice"
@@ -3459,6 +3486,22 @@
 		<var name="CoriolisTermOld" type="real" dimensions="nVertLevels nEdges Time" units="m s^-2"
                         description="Coriolis term at the previous time step used in the split-explicit AB2 time stepping"
 			packages="splitAB2TimeIntegrator"
+		/>
+		<var name="temp_twd" type="real" dimensions="nEdges Time" units=""
+			description="tendency perturbation due to topographic wave drag"
+			packages="tidalPotentialForcingPKG"
+		/>
+		<var name="normalCoeff" type="real" dimensions="nEdges" units=""
+			description="Coefficient multiplied by the normal velocity in the topographic wave drag"
+			packages="tidalPotentialForcingPKG"
+		/>
+		<var name="tangentialCoeff" type="real" dimensions="nEdges" units=""
+			description="Coefficient multiplied by the tangential velocity in the topographic wave drag"
+			packages="tidalPotentialForcingPKG"
+		/>
+		<var name="topographicWaveDrag" type="real" dimensions="nEdges" units=""
+			description="topographic wave drag multiplicative factor"
+			packages="tidalPotentialForcingPKG"
 		/>
 	</var_struct>
 	<var_struct name="shortwave" time_levs="1">

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -829,8 +829,8 @@
 					description="Controls if self-attraction and loading is applied to ssh"
 					possible_values=".true. or .false."
 		/>
-		<nml_option name="config_self_attraction_loading_smoothing_width" type="real" default_value="1.0" units="km"
-					description="Defines region over which ssh is smoothed to zero at coasts for SAL calculation."
+		<nml_option name="config_self_attraction_loading_depth_cutoff" type="real" default_value="10.0" units="m"
+					description="Defines depths over which ssh is smoothed to zero for SAL calculation."
 					possible_values="Any positive real number."
 		/>
 		<nml_option name="config_mpas_to_grid_weights_file" type="character" default_value="mpas_to_grid.nc"
@@ -1962,7 +1962,7 @@
             <var name="gotmEpsbTopOfCell"/>
             <var name="gotmDissTopOfCell"/>
             <var name="gotmLengthTopOfCell"/>
-            <var name="ssh_sal"/>
+            <var name="pgf_sal"/>
 		</stream>
 
 		<stream name="output"
@@ -3419,12 +3419,12 @@
 			description="A vector used in the split-implicit barotropic mode solver"
 			packages="semiImplicitTimePKG"
 		/>
-		<var name="ssh_sal" type="real" dimensions="nCells Time" units="m"
-			description="sea surface height perturbation from self-attraction and loading"
+		<var name="pgf_sal" type="real" dimensions="nCells Time" units="m"
+			description="Barotropic pressure perturbation due to self-attraction and loading"
 			packages="tidalPotentialForcingPKG"
 		/>
-		<var name="ssh_sal_grad" type="real" dimensions="nEdges Time" units=""
-			description="gradient of sea surface height perturbation from self-attraction and loading"
+		<var name="pgf_sal_grad" type="real" dimensions="nEdges Time" units=""
+			description="Gradient of barotropic pressure perturbation due to self-attraction and loading"
 			packages="tidalPotentialForcingPKG"
 		/>
 		<!-- FIELD split_explicit AB2 time stepping -->

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2283,7 +2283,7 @@
 			<var name="topo_buoyancy_N1B"/>
 			<var name="bathy_stddev"/>
 			<var name="bed_slope_edges"/>
-			<var name="bottomDepthEdge"/>
+			<var name="bottomDepthEdgeTWD"/>
 			<var name="lonGradEdge"/>
 			<var name="latGradEdge"/>
 		</stream>
@@ -3276,7 +3276,7 @@
 			description="The integral gradient average per cell"
 			packages="topographicWaveDragPKG"
 		/>
-		<var name="bottomDepthEdge" type="real" dimensions="nEdges" units="unitless"
+		<var name="bottomDepthEdgeTWD" type="real" dimensions="nEdges" units="unitless"
 			description="bottom depth at the cell edges"
 			packages="topographicWaveDragPKG"
 		/>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1108,13 +1108,13 @@
 					description="If true, topographic wave drag is used on the momentum equation."
 					possible_values=".true. or .false."
 		/>
-		<nml_option name="config_topographic_wave_drag_scheme" type="character" default_value="JSL" units="unitless"
-					description="hich of the following three wave drag schemes to use: JSL: Jayne and St. Laurent; ZAE: Zaron and Egbert; or LGF: Local generation formula"
+		<nml_option name="config_topographic_wave_drag_scheme" type="character" default_value="ZAE" units="unitless"
+					description="Which of the following three wave drag schemes to use: JSL: Jayne and St. Laurent; ZAE: Zaron and Egbert; or LGF: Local generation formula"
 					possible_values="JSL or ZAE or LGF"
 		/>
-		<nml_option name="config_topographic_wave_drag_coeff" type="real" default_value="5.0e-4" units="unitless"
+		<nml_option name="config_topographic_wave_drag_coeff" type="real" default_value="0.3" units="unitless"
 					description="Dimensionless topographic wave drag coefficient, $c_{topo}$."
-					possible_values="any positive real, typically 5.0e-4"
+					possible_values="any positive real"
 		/>
 		<nml_option name="config_thickness_drag_type" type="character" default_value="centered"
 					description="The type of layerThickness averaging to use on the drag term. The standard MPAS-O approach is 'centered'."

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2283,7 +2283,6 @@
 			<var name="topo_buoyancy_N1B"/>
 			<var name="bathy_stddev"/>
 			<var name="bed_slope_edges"/>
-			<var name="bottomDepthEdgeTWD"/>
 			<var name="lonGradEdge"/>
 			<var name="latGradEdge"/>
 		</stream>
@@ -3274,10 +3273,6 @@
 		/>
 		<var name="bed_slope_edges" type="real" dimensions="nEdges" units="unitless"
 			description="The integral gradient average per cell"
-			packages="topographicWaveDragPKG"
-		/>
-		<var name="bottomDepthEdgeTWD" type="real" dimensions="nEdges" units="unitless"
-			description="bottom depth at the cell edges"
 			packages="topographicWaveDragPKG"
 		/>
 		<var name="lonGradEdge" type="real" dimensions="nEdges" units="unitless"

--- a/components/mpas-ocean/src/analysis_members/Registry_harmonic_analysis.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_harmonic_analysis.xml
@@ -81,7 +81,7 @@
 			description="Frequency of each constituent"
 		/>
 		<var name="sshInit" type="real" dimensions="nCells" units="m"
-			description="Copy of initial ssh distribution"
+			description="Copy of the initial ssh distribution. Used to compute analysis with respect to ssh anomalies, ensuring cells with initial ssh offsets are handled correctly"
 		/>
 		<var name="leastSquaresLHSMatrix" type="real" dimensions="maxTidalConstituentsX2 maxTidalConstituentsX2 Time" units="rad/s"
 			description="Frequency of each constituent"
@@ -157,6 +157,7 @@
 		                 output_interval="stream:restart:output_interval"
 		                 immutable="false"
 		                 mode="forward;analysis">
+		    <var name="sshInit"/>
 			<var name="leastSquaresLHSMatrix"/>
 			<var name="leastSquaresRHSVector"/>
 		</stream>

--- a/components/mpas-ocean/src/analysis_members/Registry_harmonic_analysis.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_harmonic_analysis.xml
@@ -80,6 +80,9 @@
 		<var name="analysisConstituentNodalPhase" type="real" dimensions="maxTidalConstituents Time" units="rad/s"
 			description="Frequency of each constituent"
 		/>
+		<var name="sshInit" type="real" dimensions="nCells" units="m"
+			description="Copy of initial ssh distribution"
+		/>
 		<var name="leastSquaresLHSMatrix" type="real" dimensions="maxTidalConstituentsX2 maxTidalConstituentsX2 Time" units="rad/s"
 			description="Frequency of each constituent"
 		/>

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_harmonic_analysis.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_harmonic_analysis.F
@@ -117,11 +117,12 @@ contains
 
       type (dm_info) :: dminfo
       type (block_type), pointer :: block
-      type (mpas_pool_type), pointer :: harmonicAnalysisAMPool 
+      type (mpas_pool_type), pointer :: statePool, harmonicAnalysisAMPool 
 
-      integer, pointer :: nAnalysisConstituents 
+      integer, pointer :: nAnalysisConstituents, nCellsSolve
       real (kind=RKIND), pointer :: harmonicAnalysisStart
       real (kind=RKIND), pointer :: harmonicAnalysisEnd
+      real (kind=RKIND), dimension(:),   pointer :: ssh, sshInit
       real (kind=RKIND), dimension(:,:), pointer :: leastSquaresLHSMatrix
       real (kind=RKIND), dimension(:,:), pointer :: leastSquaresRHSVector
       real (kind=RKIND), dimension(:,:), pointer :: decomposedConstituentAmplitude 
@@ -135,7 +136,7 @@ contains
       integer, dimension(:), allocatable :: tidalConstituentType
 
       type (MPAS_Time_Type) :: refTime
-      integer :: iCon
+      integer :: iCon, iCell
 
       err = 0
 
@@ -145,8 +146,13 @@ contains
 
       block => domain % blocklist
       do while (associated(block))
+         call mpas_pool_get_subpool(block % structs, 'state', statePool)
          call mpas_pool_get_subpool(block % structs, 'harmonicAnalysisAM', harmonicAnalysisAMPool)
 
+         call mpas_pool_get_dimension(block % dimensions, 'nCellsSolve', nCellsSolve)
+         call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
+
+         call mpas_pool_get_array(harmonicAnalysisAMPool, 'sshInit', sshInit)
          call mpas_pool_get_array(harmonicAnalysisAMPool, 'nAnalysisConstituents', nAnalysisConstituents)
          call mpas_pool_get_array(harmonicAnalysisAMPool, 'leastSquaresLHSMatrix', leastSquaresLHSMatrix)
          call mpas_pool_get_array(harmonicAnalysisAMPool, 'leastSquaresRHSVector', leastSquaresRHSVector)
@@ -214,11 +220,14 @@ contains
                                         tidalConstituentType, &
                                         err)
 
-          if (.not. config_do_restart) then
-            leastSquaresRHSVector = 0.0_RKIND
-            leastSquaresLHSMatrix = 0.0_RKIND
-          end if
+         if (.not. config_do_restart) then
+           leastSquaresRHSVector = 0.0_RKIND
+           leastSquaresLHSMatrix = 0.0_RKIND
+         end if
            
+         do iCell = 1,nCellSSolve
+           sshInit(iCell) = ssh(iCell)
+         end do
 
          do iCon = 1,nAnalysisConstituents  
            call mpas_log_write('Constituent '//constituentList(iCon)%constituent)
@@ -291,7 +300,8 @@ contains
 
       integer, pointer :: nCellsSolve      
       integer, pointer :: nAnalysisConstituents
-      real (kind=RKIND), dimension(:),   pointer :: ssh
+      real (kind=RKIND), dimension(:),   pointer :: ssh, sshInit
+      real (kind=RKIND), dimension(:), allocatable :: sshDiff
       real (kind=RKIND), dimension(:,:), pointer :: leastSquaresLHSMatrix
       real (kind=RKIND), dimension(:,:), pointer :: leastSquaresRHSVector
       real (kind=RKIND), dimension(:),   pointer :: analysisConstituentFrequency 
@@ -334,6 +344,7 @@ contains
 
          call mpas_pool_get_dimension(block % dimensions, 'nCellsSolve', nCellsSolve)
          call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
+         call mpas_pool_get_array(harmonicAnalysisAMPool, 'sshInit', sshInit)
          call mpas_pool_get_array(harmonicAnalysisAMPool, 'nAnalysisConstituents', nAnalysisConstituents)
          call mpas_pool_get_array(harmonicAnalysisAMPool, 'leastSquaresLHSMatrix', leastSquaresLHSMatrix)
          call mpas_pool_get_array(harmonicAnalysisAMPool, 'leastSquaresRHSVector', leastSquaresRHSVector)
@@ -355,6 +366,12 @@ contains
 
          ! update if within harmonic analysis period 
          if (daysSinceStartOfSim .le. harmonicAnalysisEnd) then
+           allocate(sshDiff(nCellsSolve))
+
+           do iCell = 1,nCellsSolve
+             sshDiff(iCell) = ssh(iCell) - sshInit(iCell)
+           end do
+
            CALL update_least_squares_LHS_matrix(nAnalysisConstituents, &
                                                 time, &
                                                 analysisConstituentFrequency, &
@@ -364,8 +381,9 @@ contains
                                                 time, &
                                                 nCellsSolve, &
                                                 analysisConstituentFrequency, &
-                                                ssh, &
+                                                sshDiff, &
                                                 leastSquaresRHSVector)
+           deallocate(sshDiff)
            call mpas_log_write('harmonicAnalysisAM update')
          end if
 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -155,7 +155,7 @@ module ocn_time_integration_si
       SIvec_zh1_field,SIvec_wh0_field,SIvec_rh1_field   
                          ! field pointer for halo update
 
-   integer :: pgf_sal_on
+   real(kind=RKIND) :: pgf_sal_on
 
 #ifdef USE_GPU_AWARE_MPI
    ! SI - halo exch related variables ----------------------------------
@@ -1170,7 +1170,7 @@ module ocn_time_integration_si
                            sshSubcycleCur(iCell) - &
                         tidalPotentialEta(iCell) - &
                      pgf_sal_on * pgf_sal(iCell) - &
-                     (1 - pgf_sal_on) * self_attraction_and_loading_beta* &
+                     (1.0_RKIND - pgf_sal_on) * self_attraction_and_loading_beta* &
                            sshSubcycleCur(iCell)
                end do
 #ifndef MPAS_OPENACC
@@ -3502,9 +3502,9 @@ module ocn_time_integration_si
 
       if (config_use_self_attraction_loading) then
          ! set pgf_sal_on to 1
-         pgf_sal_on = 1
+         pgf_sal_on = 1.0_RKIND
       else
-         pgf_sal_on = 0
+         pgf_sal_on = 0.0_RKIND
       endif
 
       self_attraction_and_loading_beta = config_self_attraction_and_loading_beta

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -155,7 +155,7 @@ module ocn_time_integration_si
       SIvec_zh1_field,SIvec_wh0_field,SIvec_rh1_field   
                          ! field pointer for halo update
 
-   integer :: ssh_sal_on
+   integer :: pgf_sal_on
 
 #ifdef USE_GPU_AWARE_MPI
    ! SI - halo exch related variables ----------------------------------
@@ -715,7 +715,7 @@ module ocn_time_integration_si
       endif
 
       if (config_use_tidal_potential_forcing) then
-         !$acc enter data copyin(ssh_sal)
+         !$acc enter data copyin(pgf_sal)
          !$acc enter data create(sshSubcycleCurWithTides,tidalPotentialEta)
       endif
 #endif
@@ -1160,7 +1160,7 @@ module ocn_time_integration_si
  
                !$acc parallel loop gang  &
                !$acc    present(sshSubcycleCurWithTides,sshSubcycleCur, &
-               !$acc       tidalPotentialEta,ssh_sal,sshSubcycleCur)
+               !$acc       tidalPotentialEta,pgf_sal,sshSubcycleCur)
 #else
                !$omp parallel
                !$omp do schedule(runtime)
@@ -1169,8 +1169,8 @@ module ocn_time_integration_si
                   sshSubcycleCurWithTides(iCell) = &
                            sshSubcycleCur(iCell) - &
                         tidalPotentialEta(iCell) - &
-                     ssh_sal_on * ssh_sal(iCell) - &
-                     (1 - ssh_sal_on) * self_attraction_and_loading_beta* &
+                     pgf_sal_on * pgf_sal(iCell) - &
+                     (1 - pgf_sal_on) * self_attraction_and_loading_beta* &
                            sshSubcycleCur(iCell)
                end do
 #ifndef MPAS_OPENACC
@@ -2801,7 +2801,7 @@ module ocn_time_integration_si
 
 #ifdef MPAS_OPENACC
       if (config_use_tidal_potential_forcing) then
-         !$acc exit data delete(ssh_sal,tidalPotentialEta)
+         !$acc exit data delete(pgf_sal,tidalPotentialEta)
          !$acc exit data copyout(sshSubcycleCurWithTides)
       endif
 #endif
@@ -3501,10 +3501,10 @@ module ocn_time_integration_si
       !--------------------------------------------------------------------
 
       if (config_use_self_attraction_loading) then
-         ! set ssh_sal_on to 1
-         ssh_sal_on = 1
+         ! set pgf_sal_on to 1
+         pgf_sal_on = 1
       else
-         ssh_sal_on = 0
+         pgf_sal_on = 0
       endif
 
       self_attraction_and_loading_beta = config_self_attraction_and_loading_beta

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -91,12 +91,12 @@ module ocn_time_integration_split
       numTSIterations, &! number of outer timestep iterations
       nBtrSubcycles     ! number of barotropic subcycles
 
-   integer :: pgf_sal_on
    integer :: &
       thickEdgeFluxChoice ! choice of thickness flux type
    integer, parameter :: &
       thickEdgeFluxCenter   = 1, &! use mean thickness of cell neighbors
       thickEdgeFluxUpwind   = 2   ! use upwind cell thickness at edge
+   real (kind=RKIND) :: pgf_sal_on
 
    real (kind=RKIND) :: &
       useVelocityCorrection,&! mask for velocity correction
@@ -1021,7 +1021,7 @@ module ocn_time_integration_split
                                  sshSubcycleCur(iCell) - &
                               tidalPotentialEta(iCell) - &
                            pgf_sal_on * pgf_sal(iCell) - &
-                           (1 - pgf_sal_on) * self_attraction_and_loading_beta* &
+                           (1.0_RKIND - pgf_sal_on) * self_attraction_and_loading_beta* &
                                  sshSubcycleCur(iCell)
                      end do
                      !$omp end do
@@ -1269,14 +1269,14 @@ module ocn_time_integration_split
                                  sshSubcycleCur(iCell) - &
                               tidalPotentialEta(iCell) - &
                            pgf_sal_on * pgf_sal(iCell) - &
-                           (1 - pgf_sal_on) * self_attraction_and_loading_beta* &
+                           (1.0_RKIND - pgf_sal_on) * self_attraction_and_loading_beta* &
                                  sshSubcycleCur(iCell)
 
                         sshSubcycleNewWithTides(iCell) = &
                                  sshSubcycleNew(iCell) - &
                               tidalPotentialEta(iCell) - &
                            pgf_sal_on * pgf_sal(iCell) - &
-                           (1 - pgf_sal_on) * self_attraction_and_loading_beta* &
+                           (1.0_RKIND - pgf_sal_on) * self_attraction_and_loading_beta* &
                                  sshSubcycleNew(iCell)
                      end do
                      !$omp end do
@@ -3072,9 +3072,9 @@ module ocn_time_integration_split
       !-----------------------------------------------------------------
       if (config_use_self_attraction_loading) then
          ! set pgf_sal_on to 1
-         pgf_sal_on = 1
+         pgf_sal_on = 1.0_RKIND
       else
-         pgf_sal_on = 0
+         pgf_sal_on = 0.0_RKIND
       endif
 
       self_attraction_and_loading_beta = config_self_attraction_and_loading_beta

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -91,7 +91,7 @@ module ocn_time_integration_split
       numTSIterations, &! number of outer timestep iterations
       nBtrSubcycles     ! number of barotropic subcycles
 
-   integer :: ssh_sal_on
+   integer :: pgf_sal_on
    integer :: &
       thickEdgeFluxChoice ! choice of thickness flux type
    integer, parameter :: &
@@ -1020,8 +1020,8 @@ module ocn_time_integration_split
                         sshSubcycleCurWithTides(iCell) = &
                                  sshSubcycleCur(iCell) - &
                               tidalPotentialEta(iCell) - &
-                           ssh_sal_on * ssh_sal(iCell) - &
-                           (1 - ssh_sal_on) * self_attraction_and_loading_beta* &
+                           pgf_sal_on * pgf_sal(iCell) - &
+                           (1 - pgf_sal_on) * self_attraction_and_loading_beta* &
                                  sshSubcycleCur(iCell)
                      end do
                      !$omp end do
@@ -1268,15 +1268,15 @@ module ocn_time_integration_split
                         sshSubcycleCurWithTides(iCell) = &
                                  sshSubcycleCur(iCell) - &
                               tidalPotentialEta(iCell) - &
-                           ssh_sal_on * ssh_sal(iCell) - &
-                           (1 - ssh_sal_on) * self_attraction_and_loading_beta* &
+                           pgf_sal_on * pgf_sal(iCell) - &
+                           (1 - pgf_sal_on) * self_attraction_and_loading_beta* &
                                  sshSubcycleCur(iCell)
 
                         sshSubcycleNewWithTides(iCell) = &
                                  sshSubcycleNew(iCell) - &
                               tidalPotentialEta(iCell) - &
-                           ssh_sal_on * ssh_sal(iCell) - &
-                           (1 - ssh_sal_on) * self_attraction_and_loading_beta* &
+                           pgf_sal_on * pgf_sal(iCell) - &
+                           (1 - pgf_sal_on) * self_attraction_and_loading_beta* &
                                  sshSubcycleNew(iCell)
                      end do
                      !$omp end do
@@ -3071,10 +3071,10 @@ module ocn_time_integration_split
 
       !-----------------------------------------------------------------
       if (config_use_self_attraction_loading) then
-         ! set ssh_sal_on to 1
-         ssh_sal_on = 1
+         ! set pgf_sal_on to 1
+         pgf_sal_on = 1
       else
-         ssh_sal_on = 0
+         pgf_sal_on = 0
       endif
 
       self_attraction_and_loading_beta = config_self_attraction_and_loading_beta

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split_ab2.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split_ab2.F
@@ -92,7 +92,7 @@ module ocn_time_integration_split_ab2
       numTSIterations, &! number of outer timestep iterations
       nBtrSubcycles     ! number of barotropic subcycles
 
-   integer :: ssh_sal_on
+   real (kind=RKIND) :: pgf_sal_on
    integer :: &
       thickEdgeFluxChoice ! choice of thickness flux type
    integer, parameter :: &
@@ -1076,8 +1076,8 @@ module ocn_time_integration_split_ab2
                      sshSubcycleCurWithTides(iCell) = &
                               sshSubcycleCur(iCell) - &
                            tidalPotentialEta(iCell) - &
-                        ssh_sal_on * ssh_sal(iCell) - &
-                        (1 - ssh_sal_on) * self_attraction_and_loading_beta* &
+                        pgf_sal_on * pgf_sal(iCell) - &
+                        (1.0_RKIND - pgf_sal_on) * self_attraction_and_loading_beta* &
                               sshSubcycleCur(iCell)
                   end do
                   !$omp end do
@@ -1294,15 +1294,15 @@ module ocn_time_integration_split_ab2
                      sshSubcycleCurWithTides(iCell) = &
                               sshSubcycleCur(iCell) - &
                            tidalPotentialEta(iCell) - &
-                        ssh_sal_on * ssh_sal(iCell) - &
-                        (1 - ssh_sal_on) * self_attraction_and_loading_beta* &
+                        pgf_sal_on * pgf_sal(iCell) - &
+                        (1.0_RKIND - pgf_sal_on) * self_attraction_and_loading_beta* &
                               sshSubcycleCur(iCell)
 
                      sshSubcycleNewWithTides(iCell) = &
                               sshSubcycleNew(iCell) - &
                            tidalPotentialEta(iCell) - &
-                        ssh_sal_on * ssh_sal(iCell) - &
-                        (1 - ssh_sal_on) * self_attraction_and_loading_beta* &
+                        pgf_sal_on * pgf_sal(iCell) - &
+                        (1.0_RKIND - pgf_sal_on) * self_attraction_and_loading_beta* &
                               sshSubcycleNew(iCell)
                   end do
                   !$omp end do
@@ -3215,10 +3215,10 @@ module ocn_time_integration_split_ab2
 
       !-----------------------------------------------------------------
       if (config_use_self_attraction_loading) then
-         ! set ssh_sal_on to 1
-         ssh_sal_on = 1
+         ! set pgf_sal_on to 1
+         pgf_sal_on = 1.0_RKIND
       else
-         ssh_sal_on = 0
+         pgf_sal_on = 0.0_RKIND
       endif
 
       self_attraction_and_loading_beta = config_self_attraction_and_loading_beta

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
@@ -893,7 +893,8 @@ contains
              end if
              if (isOcean) then
                 ! Enforce minimum depth
-                bottomDepth(iCell) = max(bottomDepthObserved(iCell), refBottomDepth(minimum_levels))
+                bottomDepth(iCell) = max(bottomDepthObserved(iCell), config_global_ocean_minimum_depth)
+                bottomDepth(iCell) = min(bottomDepth(iCell), refBottomDepth(minimum_levels))
 
                 maxLevelCell(iCell) = -1
                 do k = 1, nVertLevels

--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_test_sht.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_test_sht.F
@@ -89,7 +89,7 @@ contains
       integer, pointer :: nCellsSolve
       real (kind=RKIND), dimension(:), pointer :: lonCell, latCell
       real (kind=RKIND), dimension(:), pointer :: xCell, yCell, zCell
-      real (kind=RKIND), dimension(:), pointer :: ssh, ssh_sal, ssh_sal_grad
+      real (kind=RKIND), dimension(:), pointer :: ssh, surfacePressure, pgf_sal, pgf_sal_grad
       real (kind=RKIND), dimension(:), pointer :: areaCell, dcEdge
       real (kind=RKIND), pointer :: config_test_sht_cosine_bell_lat_center, &
                                     config_test_sht_cosine_bell_lon_center, &
@@ -188,9 +188,11 @@ contains
         call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
 
         call mpas_pool_get_array(statePool, 'ssh', ssh)
-        call mpas_pool_get_array(diagnosticsPool, 'ssh_sal', ssh_sal)
-        call mpas_pool_get_array(diagnosticsPool, 'ssh_sal_grad', ssh_sal_grad)
+        call mpas_pool_get_array(diagnosticsPool, 'surfacePressure', surfacePressure)
+        call mpas_pool_get_array(diagnosticsPool, 'pgf_sal', pgf_sal)
+        call mpas_pool_get_array(diagnosticsPool, 'pgf_sal_grad', pgf_sal_grad)
 
+        surfacePressure(:) = 0.0_RKIND
         
         ! Setup function to approximate
         if (config_test_sht_function_option == 1) then
@@ -283,22 +285,23 @@ contains
         call ocn_vel_self_attraction_loading_init(domain,err)
         do i = 1,config_test_sht_n_iterations
           call mpas_log_write('Iteration = $i',intArgs=(/i/))
-          call ocn_compute_self_attraction_loading(domain, forcingPool, domain % dminfo, ssh, err)
+          call ocn_compute_self_attraction_loading(domain, forcingPool, domain % dminfo, &
+                                                   ssh, surfacePressure, err)
         enddo
 
         ! Compute gradient
         do iEdge = 1,nEdgesArray(1)
           cell1 = cellsOnEdge(1,iEdge)
           cell2 = cellsOnEdge(2,iEdge)
-          ssh_sal_grad(iEdge) = (ssh_sal(cell2) - ssh_sal(cell1))/dcEdge(iEdge) 
+          pgf_sal_grad(iEdge) = (pgf_sal(cell2) - pgf_sal(cell1))/dcEdge(iEdge) 
         enddo
 
         ! Compute RMS Error
         error_local_area = 0.0_RKIND
         error_local = 0.0_RKIND
         do iCell = 1,nCellsSolve
-          error_local_area = error_local_area + areaCell(iCell)*(ssh(iCell)-ssh_sal(iCell))**2
-          error_local = error_local + (ssh(iCell)-ssh_sal(iCell))**2
+          error_local_area = error_local_area + areaCell(iCell)*(ssh(iCell)-pgf_sal(iCell))**2
+          error_local = error_local + (ssh(iCell)-pgf_sal(iCell))**2
         enddo 
         call mpas_dmpar_sum_real(domain % dminfo,error_local_area,error_global_area)
         call mpas_dmpar_sum_real(domain % dminfo,error_local,error_global)

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -73,6 +73,10 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:), pointer :: gradSSH
    real (kind=RKIND), dimension(:), pointer :: pressureAdjustedSSH
    real (kind=RKIND), dimension(:), pointer :: pgf_sal
+   real (kind=RKIND), dimension(:), pointer :: temp_twd
+   real (kind=RKIND), dimension(:), pointer :: normalCoeff 
+   real (kind=RKIND), dimension(:), pointer :: tangentialCoeff 
+   real (kind=RKIND), dimension(:), pointer :: topographicWaveDrag 
 
    real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceValue
    real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceLayerValue
@@ -90,6 +94,9 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:), pointer :: topo_buoyancy_N1B
    real (kind=RKIND), dimension(:), pointer :: bathy_stddev
    real (kind=RKIND), dimension(:), pointer :: bed_slope_edges
+   real (kind=RKIND), dimension(:), pointer :: bottomDepthEdge
+   real (kind=RKIND), dimension(:), pointer :: lonGradEdge
+   real (kind=RKIND), dimension(:), pointer :: latGradEdge
    real (kind=RKIND), dimension(:,:), pointer :: landIceBoundaryLayerTracers
    real (kind=RKIND), dimension(:,:), pointer :: landIceTracerTransferVelocities
 
@@ -263,6 +270,9 @@ contains
          call mpas_pool_get_array(diagnosticsPool, 'topo_buoyancy_N1B', topo_buoyancy_N1B)
          call mpas_pool_get_array(diagnosticsPool, 'bathy_stddev', bathy_stddev)
          call mpas_pool_get_array(diagnosticsPool, 'bed_slope_edges', bed_slope_edges)
+         call mpas_pool_get_array(diagnosticsPool, 'bottomDepthEdge', bottomDepthEdge)
+         call mpas_pool_get_array(diagnosticsPool, 'lonGradEdge', lonGradEdge)
+         call mpas_pool_get_array(diagnosticsPool, 'latGradEdge', latGradEdge)
       end if
 
       if ( trim(config_ocean_run_mode) == 'forward' ) then
@@ -389,6 +399,15 @@ contains
          call mpas_pool_get_array(diagnosticsPool, &
                     'bed_slope_edges', &
                      bed_slope_edges)
+         call mpas_pool_get_array(diagnosticsPool, &
+                    'bottomDepthEdge', &
+                     bottomDepthEdge)
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'lonGradEdge', &
+                   lonGradEdge)
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'latGradEdge', &
+                   latGradEdge)
       end if
 
       if (config_use_tidal_potential_forcing) then
@@ -396,7 +415,22 @@ contains
                   'pgf_sal', &
                    pgf_sal)
       end if
-
+      if (config_use_topographic_wave_drag) then
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'temp_twd', &
+                   temp_twd)
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'normalCoeff', &
+                   normalCoeff)
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'tangentialCoeff', &
+                   tangentialCoeff)
+      end if
+      if (config_use_topographic_wave_drag) then
+         call mpas_pool_get_array(diagnosticsPool, &
+                  'topographicWaveDrag', &
+                   topographicWaveDrag)
+      end if
       if ( trim(config_ocean_run_mode) == 'init' .or. &
                 config_AM_debugDiagnostics_enable ) then
          call mpas_pool_get_array(diagnosticsPool, 'rx1MaxCell', &
@@ -711,6 +745,13 @@ contains
          !$acc enter data create(topo_buoyancy_N1B)
          !$acc enter data create(bathy_stddev)
          !$acc enter data create(bed_slope_edges)
+         !$acc enter data create(bottomDepthEdge)
+         !$acc enter data create(lonGradEdge)
+         !$acc enter data create(latGradEdge)
+         !$acc enter data create(temp_twd)
+         !$acc enter data create(normalCoeff)
+         !$acc enter data create(tangentialCoeff)
+         !$acc enter data create(topographicWaveDrag)
       end if
       if (config_use_self_attraction_loading) then
          !$acc enter data copyin(pgf_sal)
@@ -958,6 +999,10 @@ contains
       end if
       if (config_use_topographic_wave_drag) then
          !$acc exit data delete(topographic_wave_drag)
+         !$acc exit data delete(temp_twd)
+         !$acc exit data delete(normalCoeff)
+         !$acc exit data delete(tangentialCoeff)
+         !$acc exit data delete(topographicWaveDrag)
       end if
       if (config_use_self_attraction_loading) then
          !$acc exit data delete(pgf_sal)
@@ -1298,6 +1343,12 @@ contains
       end if
       if ( config_use_self_attraction_loading ) then
          nullify(pgf_sal)
+      end if
+      if ( config_use_topographic_wave_drag) then
+         nullify(temp_twd)
+         nullify(normalCoeff)
+         nullify(tangentialCoeff)
+         nullify(topographicWaveDrag)
       end if
       if ( trim(config_time_integrator) == 'split_implicit' ) then
          nullify(SIvec_r0,              &

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -94,7 +94,6 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:), pointer :: topo_buoyancy_N1B
    real (kind=RKIND), dimension(:), pointer :: bathy_stddev
    real (kind=RKIND), dimension(:), pointer :: bed_slope_edges
-   real (kind=RKIND), dimension(:), pointer :: bottomDepthEdgeTWD
    real (kind=RKIND), dimension(:), pointer :: lonGradEdge
    real (kind=RKIND), dimension(:), pointer :: latGradEdge
    real (kind=RKIND), dimension(:,:), pointer :: landIceBoundaryLayerTracers
@@ -270,7 +269,6 @@ contains
          call mpas_pool_get_array(diagnosticsPool, 'topo_buoyancy_N1B', topo_buoyancy_N1B)
          call mpas_pool_get_array(diagnosticsPool, 'bathy_stddev', bathy_stddev)
          call mpas_pool_get_array(diagnosticsPool, 'bed_slope_edges', bed_slope_edges)
-         call mpas_pool_get_array(diagnosticsPool, 'bottomDepthEdgeTWD', bottomDepthEdgeTWD)
          call mpas_pool_get_array(diagnosticsPool, 'lonGradEdge', lonGradEdge)
          call mpas_pool_get_array(diagnosticsPool, 'latGradEdge', latGradEdge)
       end if
@@ -399,9 +397,6 @@ contains
          call mpas_pool_get_array(diagnosticsPool, &
                     'bed_slope_edges', &
                      bed_slope_edges)
-         call mpas_pool_get_array(diagnosticsPool, &
-                    'bottomDepthEdgeTWD', &
-                     bottomDepthEdgeTWD)
          call mpas_pool_get_array(diagnosticsPool, &
                   'lonGradEdge', &
                    lonGradEdge)
@@ -745,7 +740,6 @@ contains
          !$acc enter data create(topo_buoyancy_N1B)
          !$acc enter data create(bathy_stddev)
          !$acc enter data create(bed_slope_edges)
-         !$acc enter data create(bottomDepthEdgeTWD)
          !$acc enter data create(lonGradEdge)
          !$acc enter data create(latGradEdge)
          !$acc enter data create(temp_twd)

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -74,8 +74,8 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:), pointer :: pressureAdjustedSSH
    real (kind=RKIND), dimension(:), pointer :: pgf_sal
    real (kind=RKIND), dimension(:), pointer :: temp_twd
-   real (kind=RKIND), dimension(:), pointer :: normalCoeff 
-   real (kind=RKIND), dimension(:), pointer :: tangentialCoeff 
+   real (kind=RKIND), dimension(:), pointer :: normalCoeffTWD 
+   real (kind=RKIND), dimension(:), pointer :: tangentialCoeffTWD 
    real (kind=RKIND), dimension(:), pointer :: topographicWaveDrag 
 
    real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceValue
@@ -415,11 +415,11 @@ contains
                   'temp_twd', &
                    temp_twd)
          call mpas_pool_get_array(diagnosticsPool, &
-                  'normalCoeff', &
-                   normalCoeff)
+                  'normalCoeffTWD', &
+                   normalCoeffTWD)
          call mpas_pool_get_array(diagnosticsPool, &
-                  'tangentialCoeff', &
-                   tangentialCoeff)
+                  'tangentialCoeffTWD', &
+                   tangentialCoeffTWD)
       end if
       if (config_use_topographic_wave_drag) then
          call mpas_pool_get_array(diagnosticsPool, &
@@ -743,8 +743,8 @@ contains
          !$acc enter data create(lonGradEdge)
          !$acc enter data create(latGradEdge)
          !$acc enter data create(temp_twd)
-         !$acc enter data create(normalCoeff)
-         !$acc enter data create(tangentialCoeff)
+         !$acc enter data create(normalCoeffTWD)
+         !$acc enter data create(tangentialCoeffTWD)
          !$acc enter data create(topographicWaveDrag)
       end if
       if (config_use_self_attraction_loading) then
@@ -994,8 +994,8 @@ contains
       if (config_use_topographic_wave_drag) then
          !$acc exit data delete(topographic_wave_drag)
          !$acc exit data delete(temp_twd)
-         !$acc exit data delete(normalCoeff)
-         !$acc exit data delete(tangentialCoeff)
+         !$acc exit data delete(normalCoeffTWD)
+         !$acc exit data delete(tangentialCoeffTWD)
          !$acc exit data delete(topographicWaveDrag)
       end if
       if (config_use_self_attraction_loading) then
@@ -1340,8 +1340,8 @@ contains
       end if
       if ( config_use_topographic_wave_drag) then
          nullify(temp_twd)
-         nullify(normalCoeff)
-         nullify(tangentialCoeff)
+         nullify(normalCoeffTWD)
+         nullify(tangentialCoeffTWD)
          nullify(topographicWaveDrag)
       end if
       if ( trim(config_time_integrator) == 'split_implicit' ) then

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -72,7 +72,7 @@ module ocn_diagnostics_variables
 
    real (kind=RKIND), dimension(:), pointer :: gradSSH
    real (kind=RKIND), dimension(:), pointer :: pressureAdjustedSSH
-   real (kind=RKIND), dimension(:), pointer :: ssh_sal
+   real (kind=RKIND), dimension(:), pointer :: pgf_sal
 
    real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceValue
    real (kind=RKIND), dimension(:,:), pointer :: tracersSurfaceLayerValue
@@ -375,8 +375,8 @@ contains
 
       if (config_use_tidal_potential_forcing) then
          call mpas_pool_get_array(diagnosticsPool, &
-                  'ssh_sal', &
-                   ssh_sal)
+                  'pgf_sal', &
+                   pgf_sal)
       end if
 
       if ( trim(config_ocean_run_mode) == 'init' .or. &
@@ -691,7 +691,7 @@ contains
          !$acc enter data create(topographic_wave_drag)
       end if
       if (config_use_self_attraction_loading) then
-         !$acc enter data copyin(ssh_sal)
+         !$acc enter data copyin(pgf_sal)
       end if
       if ( trim(config_ocean_run_mode) == 'init' ) then
          !$acc enter data create(                          &
@@ -938,7 +938,7 @@ contains
          !$acc exit data delete(topographic_wave_drag)
       end if
       if (config_use_self_attraction_loading) then
-         !$acc exit data delete(ssh_sal)
+         !$acc exit data delete(pgf_sal)
       end if
       if ( trim(config_ocean_run_mode) == 'init' ) then
          !$acc exit data delete(                           &
@@ -1275,7 +1275,7 @@ contains
          nullify(salinitySurfaceRestoringTendency)
       end if
       if ( config_use_self_attraction_loading ) then
-         nullify(ssh_sal)
+         nullify(pgf_sal)
       end if
       if ( trim(config_time_integrator) == 'split_implicit' ) then
          nullify(SIvec_r0,              &

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -94,7 +94,7 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:), pointer :: topo_buoyancy_N1B
    real (kind=RKIND), dimension(:), pointer :: bathy_stddev
    real (kind=RKIND), dimension(:), pointer :: bed_slope_edges
-   real (kind=RKIND), dimension(:), pointer :: bottomDepthEdge
+   real (kind=RKIND), dimension(:), pointer :: bottomDepthEdgeTWD
    real (kind=RKIND), dimension(:), pointer :: lonGradEdge
    real (kind=RKIND), dimension(:), pointer :: latGradEdge
    real (kind=RKIND), dimension(:,:), pointer :: landIceBoundaryLayerTracers
@@ -270,7 +270,7 @@ contains
          call mpas_pool_get_array(diagnosticsPool, 'topo_buoyancy_N1B', topo_buoyancy_N1B)
          call mpas_pool_get_array(diagnosticsPool, 'bathy_stddev', bathy_stddev)
          call mpas_pool_get_array(diagnosticsPool, 'bed_slope_edges', bed_slope_edges)
-         call mpas_pool_get_array(diagnosticsPool, 'bottomDepthEdge', bottomDepthEdge)
+         call mpas_pool_get_array(diagnosticsPool, 'bottomDepthEdgeTWD', bottomDepthEdgeTWD)
          call mpas_pool_get_array(diagnosticsPool, 'lonGradEdge', lonGradEdge)
          call mpas_pool_get_array(diagnosticsPool, 'latGradEdge', latGradEdge)
       end if
@@ -400,8 +400,8 @@ contains
                     'bed_slope_edges', &
                      bed_slope_edges)
          call mpas_pool_get_array(diagnosticsPool, &
-                    'bottomDepthEdge', &
-                     bottomDepthEdge)
+                    'bottomDepthEdgeTWD', &
+                     bottomDepthEdgeTWD)
          call mpas_pool_get_array(diagnosticsPool, &
                   'lonGradEdge', &
                    lonGradEdge)
@@ -745,7 +745,7 @@ contains
          !$acc enter data create(topo_buoyancy_N1B)
          !$acc enter data create(bathy_stddev)
          !$acc enter data create(bed_slope_edges)
-         !$acc enter data create(bottomDepthEdge)
+         !$acc enter data create(bottomDepthEdgeTWD)
          !$acc enter data create(lonGradEdge)
          !$acc enter data create(latGradEdge)
          !$acc enter data create(temp_twd)

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -85,7 +85,11 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:), pointer :: landIceFrictionVelocity
    real (kind=RKIND), dimension(:), pointer :: topDrag
    real (kind=RKIND), dimension(:), pointer :: topDragMag
-   real (kind=RKIND), dimension(:), pointer :: topographic_wave_drag
+   real (kind=RKIND), dimension(:), pointer :: topo_rinv
+   real (kind=RKIND), dimension(:), pointer :: topo_buoyancy_N1V
+   real (kind=RKIND), dimension(:), pointer :: topo_buoyancy_N1B
+   real (kind=RKIND), dimension(:), pointer :: bathy_stddev
+   real (kind=RKIND), dimension(:), pointer :: bed_slope_edges
    real (kind=RKIND), dimension(:,:), pointer :: landIceBoundaryLayerTracers
    real (kind=RKIND), dimension(:,:), pointer :: landIceTracerTransferVelocities
 
@@ -254,7 +258,11 @@ contains
       call mpas_pool_get_subpool(domain % blocklist % structs, 'diagnostics', diagnosticsPool)
 
       if (config_use_topographic_wave_drag) then
-         call mpas_pool_get_array(diagnosticsPool, 'topographic_wave_drag', topographic_wave_drag)
+         call mpas_pool_get_array(diagnosticsPool, 'topo_rinv', topo_rinv)
+         call mpas_pool_get_array(diagnosticsPool, 'topo_buoyancy_N1V', topo_buoyancy_N1V)
+         call mpas_pool_get_array(diagnosticsPool, 'topo_buoyancy_N1B', topo_buoyancy_N1B)
+         call mpas_pool_get_array(diagnosticsPool, 'bathy_stddev', bathy_stddev)
+         call mpas_pool_get_array(diagnosticsPool, 'bed_slope_edges', bed_slope_edges)
       end if
 
       if ( trim(config_ocean_run_mode) == 'forward' ) then
@@ -368,9 +376,19 @@ contains
       end if
 
       if (config_use_topographic_wave_drag) then
+         call mpas_pool_get_array(diagnosticsPool, 'topo_rinv', topo_rinv)
          call mpas_pool_get_array(diagnosticsPool, &
-                  'topographic_wave_drag', &
-                   topographic_wave_drag)
+                    'topo_buoyancy_N1V', &
+                     topo_buoyancy_N1V)
+         call mpas_pool_get_array(diagnosticsPool, &
+                    'topo_buoyancy_N1B', &
+                     topo_buoyancy_N1B)
+         call mpas_pool_get_array(diagnosticsPool, &
+                    'bathy_stddev', &
+                     bathy_stddev)
+         call mpas_pool_get_array(diagnosticsPool, &
+                    'bed_slope_edges', &
+                     bed_slope_edges)
       end if
 
       if (config_use_tidal_potential_forcing) then
@@ -688,7 +706,11 @@ contains
          !$acc                   landIceFrictionVelocity)
       end if
       if (config_use_topographic_wave_drag) then
-         !$acc enter data create(topographic_wave_drag)
+         !$acc enter data create(topo_rinv)
+         !$acc enter data create(topo_buoyancy_N1V)
+         !$acc enter data create(topo_buoyancy_N1B)
+         !$acc enter data create(bathy_stddev)
+         !$acc enter data create(bed_slope_edges)
       end if
       if (config_use_self_attraction_loading) then
          !$acc enter data copyin(pgf_sal)

--- a/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
@@ -426,12 +426,13 @@ contains
                                thermExpCoeff, salineContractCoeff, &
                                tendVel, err)
 
-      ! Compute ssh additions due to self-attraction and loading
+      ! Compute pgf additions due to self-attraction and loading
       if(mpas_is_alarm_ringing(domain % clock, 'salComputeAlarm', ierr=err)) then 
 #ifdef MPAS_DEBUG
           call mpas_log_write('       Computing SAL')
 #endif
-          call ocn_compute_self_attraction_loading(domain, forcingPool, dminfo, ssh, err)
+          call ocn_compute_self_attraction_loading(domain, forcingPool, dminfo, &
+                                                   ssh, surfacePressure, err)
           call mpas_reset_clock_alarm(domain % clock, 'salComputeAlarm', ierr=err)
       endif
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing.F
@@ -129,7 +129,7 @@ contains
                    kineticEnergyCell, layerThickEdgeDrag, tend, err1)
       err = ior(err, err1)
 
-      call ocn_vel_forcing_topographic_wave_drag_tend(normalVelocity, &
+      call ocn_vel_forcing_topographic_wave_drag_scalar_tend(normalVelocity, &
                    tend, err1)
 
       err = ior(err, err1)

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing.F
@@ -129,7 +129,7 @@ contains
                    kineticEnergyCell, layerThickEdgeDrag, tend, err1)
       err = ior(err, err1)
 
-      call ocn_vel_forcing_topographic_wave_drag_scalar_tend(normalVelocity, &
+      call ocn_vel_forcing_topographic_wave_drag_tend(normalVelocity, &
                    tend, err1)
 
       err = ior(err, err1)

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
@@ -46,8 +46,7 @@ module ocn_vel_forcing_topographic_wave_drag
    !
    !--------------------------------------------------------------------
 
-   public :: ocn_vel_forcing_topographic_wave_drag_scalar_tend, &
-             ocn_vel_forcing_topographic_wave_drag_tensor_tend, &
+   public :: ocn_vel_forcing_topographic_wave_drag_tend, &
              ocn_vel_forcing_topographic_wave_drag_init
 
    !--------------------------------------------------------------------
@@ -56,9 +55,9 @@ module ocn_vel_forcing_topographic_wave_drag
    !
    !--------------------------------------------------------------------
 
-   logical :: topographicWaveDragOn
+   logical :: topographicWaveDragOn, tensorScheme 
    real (kind=RKIND) :: topographicWaveDragCoeff
-   real (kind=RKIND), dimension(:), allocatable :: topographicWaveDrag
+!   real (kind=RKIND), dimension(:), allocatable :: topographicWaveDrag
 
 !***********************************************************************
 
@@ -66,7 +65,7 @@ contains
 
 !***********************************************************************
 !
-!  routine ocn_vel_forcing_topographic_wave_drag_scalar_tend
+!  routine ocn_vel_forcing_topographic_wave_drag_tend
 !
 !> \brief   Computes tendency term from topographic wave drag
 !> \author  Nairita Pal
@@ -77,7 +76,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_forcing_topographic_wave_drag_scalar_tend(normalVelocity, & !{{{
+   subroutine ocn_vel_forcing_topographic_wave_drag_tend(normalVelocity, & !{{{
                      tend, err)
 
       !-----------------------------------------------------------------
@@ -124,103 +123,39 @@ contains
       !          N(z) = N_0 exp(z/1300)
       ! Drag: rho_0 C u
       
-      !$omp do schedule(runtime) private(k)
-      do iEdge = 1, nEdgesOwned
-        k =  maxLevelEdgeTop(iEdge)
-        ! topographic wave drag term:
-        ! du/dt = ... 1/rinv * u
-        ! rinv is the e-folding time use in HyCOM. Here
-        ! topographic_wave_drag = 1/rinv
-        if (k>0) then
-          tend(k,iEdge) = tend(k,iEdge) - topographicWaveDragCoeff &
-             * topographicWaveDrag(iEdge) * normalVelocity(k,iEdge)
-        endif
-      enddo
-      !$omp end do
+      if ( .not. tensorScheme) then
+          !$omp do schedule(runtime) private(k)
+          do iEdge = 1, nEdgesOwned
+            k =  maxLevelEdgeTop(iEdge)
+            ! topographic wave drag term:
+            ! du/dt = ... 1/rinv * u
+            ! rinv is the e-folding time use in HyCOM. Here
+            ! topographic_wave_drag = 1/rinv
+            if (k>0) then
+              temp_twd(iEdge) = topographicWaveDragCoeff * topographicWaveDrag(iEdge) * normalVelocity(k,iEdge)
+              tend(k,iEdge) = tend(k,iEdge) - topographicWaveDragCoeff &
+                 * topographicWaveDrag(iEdge) * normalVelocity(k,iEdge)
+            endif
+          enddo
+          !$omp end do
+      else
+          !$omp do schedule(runtime) private(k)
+          do iEdge = 1, nEdgesOwned
+            k =  maxLevelEdgeTop(iEdge)
+            if (k>0) then
+              temp_twd(iEdge) = topographicWaveDrag(iEdge) * (normalVelocity(k,iEdge) * normalCoeff(iEdge) + tangentialVelocity(k,iEdge) * tangentialCoeff(iEdge))
+              tend(k,iEdge) = tend(k,iEdge) - topographicWaveDragCoeff * topographicWaveDrag(iEdge) &
+                 * (normalVelocity(k,iEdge) * normalCoeff(iEdge) + tangentialVelocity(k,iEdge) * tangentialCoeff(iEdge))
+            endif
+          enddo
+          !$omp end do
+      endif
 
       call mpas_timer_stop('vel topographic wave drag')
 
    !--------------------------------------------------------------------
 
-   end subroutine ocn_vel_forcing_topographic_wave_drag_scalar_tend!}}}
-
-!***********************************************************************
-!
-!  routine ocn_vel_forcing_topographic_wave_drag_tensor_tend
-!
-!> \brief   Computes tendency term from topographic wave drag
-!> \author  Kristin Barton
-!> \date    1 Nov 2022
-!> \details
-!>  This routine computes the topographic wave drag tendency for momentum
-!>  based on current state using the tensor formulation
-!
-!***********************************************************************
-
-   subroutine ocn_vel_forcing_topographic_wave_drag_tensor_tend(normalVelocity, & !{{{
-                     tend, err)
-
-      !-----------------------------------------------------------------
-      !
-      ! input variables
-      !
-      !-----------------------------------------------------------------
-
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         normalVelocity   !< Input: velocity
-
-      !-----------------------------------------------------------------
-      !
-      ! input/output variables
-      !
-      !-----------------------------------------------------------------
-
-      real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         tend          !< Input/Output: velocity tendency
-
-      !-----------------------------------------------------------------
-      !
-      ! output variables
-      !
-      !-----------------------------------------------------------------
-
-      integer, intent(out) :: err !< Output: error flag
-
-      !-----------------------------------------------------------------
-      !
-      ! local variables
-      !
-      !-----------------------------------------------------------------
-
-      integer :: iEdge, k
-
-      err = 0
-      if ( .not. topographicWaveDragOn ) return
-
-      call mpas_timer_start('vel topographic wave drag')
-
-      ! JSL: C = pi std(H)^2 N_B / L
-      ! ZAE: C = gamma H (grad(H))^2 N_B bar(N) / (8 * pi^2 * omega)
-      !          N(z) = N_0 exp(z/1300)
-      ! Drag: rho_0 C u
-      
-      !$omp do schedule(runtime) private(k)
-      do iEdge = 1, nEdgesOwned
-        k =  maxLevelEdgeTop(iEdge)
-        ! topographic wave drag term:
-        ! du/dt = ... 1/rinv * u
-        ! rinv is the e-folding time use in HyCOM. Here
-        ! topographic_wave_drag = 1/rinv
-        if (k>0) then
-        endif
-      enddo
-      !$omp end do
-
-      call mpas_timer_stop('vel topographic wave drag')
-
-   !--------------------------------------------------------------------
-
-   end subroutine ocn_vel_forcing_topographic_wave_drag_tensor_tend!}}}
+   end subroutine ocn_vel_forcing_topographic_wave_drag_tend!}}}
 
 !***********************************************************************
 !
@@ -247,44 +182,52 @@ contains
 
       integer, intent(out) :: err !< Output: error flag
 
+      real (kind=RKIND) :: topoDragCutoffDepth, topoDragCutoffWidth
+      real (kind=RKIND) :: omegaM2 = 1.405189e-4_RKIND
+      real (kind=RKIND), dimension(:), allocatable :: topoDragTurnOff
+
       err = 0
+
 
       topographicWaveDragCoeff = 0.0_RKIND
 
       if (config_use_topographic_wave_drag) then
           topographicWaveDragOn = .true.
           topographicWaveDragCoeff = config_topographic_wave_drag_coeff
+          topoDragCutoffDepth = config_topographic_wave_drag_cutoff_depth
+          topoDragCutoffWidth = config_topographic_wave_drag_cutoff_width
+          topoDragTurnOff = (TANH((-bottomDepthEdge-topoDragCutoffDepth)/topoDragCutoffWidth)+1)/2
           if (config_topographic_wave_drag_scheme.EQ."JSL") then
+              tensorScheme = .false.
               call mpas_log_write("")
               call mpas_log_write(" Topographic wave drag scheme is: Jayne and St. Laurent")
               call mpas_log_write("")
+              topographicWaveDrag = topographicWaveDragCoeff*topoDragTurnOff*pii*(bathy_stddev**2)*topo_buoyancy_N1B/10000.0_RKIND
               ! C = pi std(H)^2 Nb / L, L=10,000
-              topographicWaveDrag = pii*(bathy_stddev**2)*topo_buoyancy_N1B/10000.0_RKIND
+
           else if (config_topographic_wave_drag_scheme.EQ."ZAE") then
+              tensorScheme = .false.
               call mpas_log_write("")
               call mpas_log_write(" Topographic wave drag scheme is: Zaron and Egbert")
               call mpas_log_write("")
+              topographicWaveDrag = topographicWaveDragCoeff*bottomDepthEdge*(bed_slope_edges**2)*topo_buoyancy_N1B*topo_buoyancy_N1V / (8.0_RKIND * 1.405189e-4_RKIND * pii**2)
+!              topographicWaveDrag = topographicWaveDragCoeff*topoDragTurnOff*50.0_RKIND*bottomDepthEdge*(bed_slope_edges**2)*((5.24e-3_RKIND)*1300.0_RKIND*(1 - exp(-bottomDepthEdge/1300.0_RKIND))/bottomDepthEdge)*((5.24e-3_RKIND)*exp(-bottomDepthEdge/1300.0_RKIND))/ (8 * 1.405189e-4_RKIND * pii**2)
               ! C = G*H*(grad H)^2 * Nb * Nv / (8 pi^2 omega), take M2 omega = 1.405189e-4_RKIND
 !              Nv = (5.24e-3_RKIND)*1300*(1 - exp(-bottomDepth/1300))/bottomDepth
 !              Nb = (5.24e-3_RKIND)*exp(-bottomDepth/1300)
-              topographicWaveDrag = bottomDepth*(bed_slope_edges**2)*((5.24e-3_RKIND)*1300.0_RKIND*(1 - exp(-bottomDepth/1300.0_RKIND))/bottomDepth)*((5.24e-3_RKIND)*exp(-bottomDepth/1300.0_RKIND))/ (8 * 1.405189e-4_RKIND * pii**2)
-!              topographicWaveDrag = bottomDepth*(bed_slope_edges**2)*topo_buoyancy_N1B*topo_buoyancy_N1V / (8 * 1.405189e-4_RKIND * pii**2)
-          else if (config_topographic_wave_drag_scheme.EQ."NYC") then
+          else if (config_topographic_wave_drag_scheme.EQ."LGF") then
+              tensorScheme = .true.
               call mpas_log_write("")
-              call mpas_log_write(" Topographic wave drag scheme is: Nycander")
+              call mpas_log_write(" Topographic wave drag scheme is: Local Generation Formula")
               call mpas_log_write("")
-              topographicWaveDrag = topo_rinv
-              ! Preperation for Nycander
+              topographicWaveDrag = topographicWaveDragCoeff*topoDragTurnOff*(sqrt((topo_buoyancy_N1B**2 - omegaM2**2)*(topo_buoyancy_N1V**2 - omegaM2**2)))/(4*pii*omegaM2)
+              normalCoeff = (lonGradEdge**2)*(cos(angleEdge)**2) + (latGradEdge**2)*(sin(angleEdge)**2) - 2*latGradEdge*lonGradEdge*sin(angleEdge)*(cos(angleEdge))
+              tangentialCoeff = sin(angleEdge)*cos(angleEdge)*(lonGradEdge**2 - latGradEdge**2) + latGradEdge*lonGradEdge*(cos(angleEdge)**2 - sin(angleEdge)**2)
+
           else 
               call mpas_log_write("")
-              call mpas_log_write("Invalid parameter for config_topopgraphic_wave_drag_scheme. It must be one of: 'JSL', 'ZAE', or 'NYC'" , MPAS_LOG_CRIT)
-              ! C = Cit sqrt((Nb^2 - omega^2)(Nm^2 - omega^2))/(4 pi omega) * [ [grad(hl)^2, grad(hl)*grad(hp)  ], [ grad(hl) * grad(hp), grad(hp)^2  ]  ]
-              ! Cit = tuning coefficint
-              ! Nb = bottom frequency
-              ! Nm = depth-averaged frequency
-              ! grad(hl) = zonal topo gradient
-              ! grad(hp) = meridional topo gradient
 
+              call mpas_log_write("Invalid parameter for config_topopgraphic_wave_drag_scheme. It must be one of: 'JSL', 'ZAE', or 'LGF'" , MPAS_LOG_CRIT)
               call mpas_log_write("")
           end if
       endif

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
@@ -132,9 +132,8 @@ contains
             ! rinv is the e-folding time use in HyCOM. Here
             ! topographic_wave_drag = 1/rinv
             if (k>0) then
-              temp_twd(iEdge) = topographicWaveDragCoeff * topographicWaveDrag(iEdge) * normalVelocity(k,iEdge)
-              tend(k,iEdge) = tend(k,iEdge) - topographicWaveDragCoeff &
-                 * topographicWaveDrag(iEdge) * normalVelocity(k,iEdge)
+              temp_twd(iEdge) = topographicWaveDrag(iEdge) * normalVelocity(k,iEdge)
+              tend(k,iEdge) = tend(k,iEdge) * topographicWaveDrag(iEdge) * normalVelocity(k,iEdge)
             endif
           enddo
           !$omp end do
@@ -144,7 +143,7 @@ contains
             k =  maxLevelEdgeTop(iEdge)
             if (k>0) then
               temp_twd(iEdge) = topographicWaveDrag(iEdge) * (normalVelocity(k,iEdge) * normalCoeff(iEdge) + tangentialVelocity(k,iEdge) * tangentialCoeff(iEdge))
-              tend(k,iEdge) = tend(k,iEdge) - topographicWaveDragCoeff * topographicWaveDrag(iEdge) &
+              tend(k,iEdge) = tend(k,iEdge) * topographicWaveDrag(iEdge) &
                  * (normalVelocity(k,iEdge) * normalCoeff(iEdge) + tangentialVelocity(k,iEdge) * tangentialCoeff(iEdge))
             endif
           enddo

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
@@ -209,11 +209,19 @@ contains
               call mpas_log_write("")
               call mpas_log_write(" Topographic wave drag scheme is: Zaron and Egbert")
               call mpas_log_write("")
-              topographicWaveDrag = topographicWaveDragCoeff*(bed_slope_edges**2)*topo_buoyancy_N1B*topo_buoyancy_N1V / (8.0_RKIND * 1.405189e-4_RKIND * pii**2)
-!              topographicWaveDrag = topographicWaveDragCoeff*topoDragTurnOff*50.0_RKIND*bottomDepthEdge*(bed_slope_edges**2)*((5.24e-3_RKIND)*1300.0_RKIND*(1 - exp(-bottomDepthEdge/1300.0_RKIND))/bottomDepthEdge)*((5.24e-3_RKIND)*exp(-bottomDepthEdge/1300.0_RKIND))/ (8 * 1.405189e-4_RKIND * pii**2)
-              ! C = G*H*(grad H)^2 * Nb * Nv / (8 pi^2 omega), take M2 omega = 1.405189e-4_RKIND
-!              Nv = (5.24e-3_RKIND)*1300*(1 - exp(-bottomDepth/1300))/bottomDepth
-!              Nb = (5.24e-3_RKIND)*exp(-bottomDepth/1300)
+!              topographicWaveDrag = topographicWaveDragCoeff*(bed_slope_edges**2)*topo_buoyancy_N1B*topo_buoyancy_N1V / (8.0_RKIND * 1.405189e-4_RKIND * pii**2)
+
+! Cze = Gamma H grad(H)^2 Nb Nbar / (8 pi^2 omega)
+! Gamma = 50
+! N(z) = N0 exp(z/1300)
+! N0 = 5.24 x 10^-3
+! z = 0 at surface
+! Nb is N(z) evaluated at z = -H
+! Nbar = 1300 N0 (1 - exp(-H/1300))/H
+              topographicWaveDrag = topographicWaveDragCoeff*topoDragTurnOff*50.0_RKIND*(bed_slope_edges**2)  * &
+                        (5.24e-3_RKIND*1300.0_RKIND*(1 - exp(-bottomDepthEdge/1300.0_RKIND))/bottomDepthEdge) * & ! Nbar
+                        (5.24e-3_RKIND*exp(-bottomDepthEdge/1300.0_RKIND))                                    / & ! Nb
+                        (8 * omegaM2 * pii**2)
           else if (config_topographic_wave_drag_scheme.EQ."LGF") then
               tensorScheme = .true.
               call mpas_log_write("")

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
@@ -201,7 +201,7 @@ contains
               call mpas_log_write("")
               call mpas_log_write(" Topographic wave drag scheme is: Jayne and St. Laurent")
               call mpas_log_write("")
-              topographicWaveDrag = topographicWaveDragCoeff*topoDragTurnOff*pii*(bathy_stddev**2)*topo_buoyancy_N1B/10000.0_RKIND
+              topographicWaveDrag = topographicWaveDragCoeff*topoDragTurnOff*pii*(bathy_stddev**2)*topo_buoyancy_N1B/10000.0_RKIND/layerThicknessEdge
               ! C = pi std(H)^2 Nb / L, L=10,000
 
           else if (config_topographic_wave_drag_scheme.EQ."ZAE") then
@@ -209,7 +209,7 @@ contains
               call mpas_log_write("")
               call mpas_log_write(" Topographic wave drag scheme is: Zaron and Egbert")
               call mpas_log_write("")
-              topographicWaveDrag = topographicWaveDragCoeff*bottomDepthEdge*(bed_slope_edges**2)*topo_buoyancy_N1B*topo_buoyancy_N1V / (8.0_RKIND * 1.405189e-4_RKIND * pii**2)
+              topographicWaveDrag = topographicWaveDragCoeff*bottomDepthEdge*(bed_slope_edges**2)*topo_buoyancy_N1B*topo_buoyancy_N1V / (8.0_RKIND * 1.405189e-4_RKIND * pii**2) / layerThicknessEdge
 !              topographicWaveDrag = topographicWaveDragCoeff*topoDragTurnOff*50.0_RKIND*bottomDepthEdge*(bed_slope_edges**2)*((5.24e-3_RKIND)*1300.0_RKIND*(1 - exp(-bottomDepthEdge/1300.0_RKIND))/bottomDepthEdge)*((5.24e-3_RKIND)*exp(-bottomDepthEdge/1300.0_RKIND))/ (8 * 1.405189e-4_RKIND * pii**2)
               ! C = G*H*(grad H)^2 * Nb * Nv / (8 pi^2 omega), take M2 omega = 1.405189e-4_RKIND
 !              Nv = (5.24e-3_RKIND)*1300*(1 - exp(-bottomDepth/1300))/bottomDepth

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
@@ -195,7 +195,7 @@ contains
           topographicWaveDragCoeff = config_topographic_wave_drag_coeff
           topoDragCutoffDepth = config_topographic_wave_drag_cutoff_depth
           topoDragCutoffWidth = config_topographic_wave_drag_cutoff_width
-          topoDragTurnOff = (TANH((-bottomDepthEdge-topoDragCutoffDepth)/topoDragCutoffWidth)+1)/2
+          topoDragTurnOff = (TANH((bottomDepthEdge-topoDragCutoffDepth)/topoDragCutoffWidth)+1)/2
           if (config_topographic_wave_drag_scheme.EQ."JSL") then
               tensorScheme = .false.
               call mpas_log_write("")

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
@@ -133,7 +133,7 @@ contains
             ! topographic_wave_drag = 1/rinv
             if (k>0) then
               temp_twd(iEdge) = topographicWaveDrag(iEdge) * normalVelocity(k,iEdge)
-              tend(k,iEdge) = tend(k,iEdge) * topographicWaveDrag(iEdge) * normalVelocity(k,iEdge)
+              tend(k,iEdge) = tend(k,iEdge) - topographicWaveDrag(iEdge) * normalVelocity(k,iEdge)
             endif
           enddo
           !$omp end do
@@ -143,7 +143,7 @@ contains
             k =  maxLevelEdgeTop(iEdge)
             if (k>0) then
               temp_twd(iEdge) = topographicWaveDrag(iEdge) * (normalVelocity(k,iEdge) * normalCoeff(iEdge) + tangentialVelocity(k,iEdge) * tangentialCoeff(iEdge))
-              tend(k,iEdge) = tend(k,iEdge) * topographicWaveDrag(iEdge) &
+              tend(k,iEdge) = tend(k,iEdge) - topographicWaveDrag(iEdge) &
                  * (normalVelocity(k,iEdge) * normalCoeff(iEdge) + tangentialVelocity(k,iEdge) * tangentialCoeff(iEdge))
             endif
           enddo

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
@@ -10,7 +10,7 @@
 !  ocn_vel_forcing_topographic_wave_drag
 !
 !> \brief MPAS ocean topographic wave drag
-!> \author Nairita Pal
+!> \author Nairita Pal, Kristin Barton
 !> \date   Oct 2020
 !> \details
 !>  This module contains the routine for computing
@@ -68,7 +68,7 @@ contains
 !  routine ocn_vel_forcing_topographic_wave_drag_tend
 !
 !> \brief   Computes tendency term from topographic wave drag
-!> \author  Nairita Pal
+!> \author  Nairita Pal, Kristin Barton
 !> \date    15 Oct 2020
 !> \details
 !>  This routine computes the topographic wave drag tendency for momentum
@@ -127,13 +127,9 @@ contains
           !$omp do schedule(runtime) private(k)
           do iEdge = 1, nEdgesOwned
             k =  maxLevelEdgeTop(iEdge)
-            ! topographic wave drag term:
-            ! du/dt = ... 1/rinv * u
-            ! rinv is the e-folding time use in HyCOM. Here
-            ! topographic_wave_drag = 1/rinv
             if (k>0) then
               temp_twd(iEdge) = topographicWaveDrag(iEdge) * normalVelocity(k,iEdge)
-              tend(k,iEdge) = tend(k,iEdge) - topographicWaveDrag(iEdge) * normalVelocity(k,iEdge)
+              tend(k,iEdge) = tend(k,iEdge) - temp_twd(iEdge)
             endif
           enddo
           !$omp end do
@@ -142,9 +138,8 @@ contains
           do iEdge = 1, nEdgesOwned
             k =  maxLevelEdgeTop(iEdge)
             if (k>0) then
-              temp_twd(iEdge) = topographicWaveDrag(iEdge) * (normalVelocity(k,iEdge) * normalCoeff(iEdge) + tangentialVelocity(k,iEdge) * tangentialCoeff(iEdge))
-              tend(k,iEdge) = tend(k,iEdge) - topographicWaveDrag(iEdge) &
-                 * (normalVelocity(k,iEdge) * normalCoeff(iEdge) + tangentialVelocity(k,iEdge) * tangentialCoeff(iEdge))
+              temp_twd(iEdge) = topographicWaveDrag(iEdge) * (normalVelocity(k,iEdge) * normalCoeffTWD(iEdge) + tangentialVelocity(k,iEdge) * tangentialCoeffTWD(iEdge))
+              tend(k,iEdge) = tend(k,iEdge) - temp_twd(iEdge)
             endif
           enddo
           !$omp end do
@@ -161,7 +156,7 @@ contains
 !  routine ocn_vel_forcing_topographic_wave_drag_init
 !
 !> \brief   Initializes ocean topographic wave drag forcing
-!> \author  Nairita Pal
+!> \author  Nairita Pal, Kristin Barton
 !> \date    Oct 2020
 !> \details
 !>  This routine initializes quantities related to topographic wave  drag
@@ -183,9 +178,11 @@ contains
 
       real (kind=RKIND) :: topoDragCutoffDepth, topoDragCutoffWidth
       real (kind=RKIND) :: omegaM2 = 1.405189e-4_RKIND
+      real (kind=RKIND) :: kappa
+      real (kind=RKIND) :: N0, L, Nb, Nbar, gam
       real (kind=RKIND) :: topoDragTurnOff
 
-      integer :: iEdge, k, kmin, kmax
+      integer :: iEdge, k, kmax
 
       err = 0
 
@@ -202,14 +199,17 @@ contains
               call mpas_log_write(" Topographic wave drag scheme is: Jayne and St. Laurent")
               call mpas_log_write("")
               tensorScheme = .false.
+              kappa = pii/10000.0_RKIND
 
               do iEdge = 1, nEdgesAll
                   kmax =  maxLevelEdgeTop(iEdge)
                   topographicWaveDrag(iEdge) = 0.0_RKIND
                   if (kmax > 0) then
                       k =  maxLevelEdgeTop(iEdge)
-                      topoDragTurnOff = (TANH((layerThickEdgeMean(k,iEdge)-topoDragCutoffDepth)/topoDragCutoffWidth)+1)/2
-                      topographicWaveDrag(iEdge) = topographicWaveDragCoeff*topoDragTurnOff*pii*(bathy_stddev(iEdge)**2)*topo_buoyancy_N1B(iEdge)/10000.0_RKIND/layerThickEdgeMean(k,iEdge)
+                      topographicWaveDrag(iEdge) = topographicWaveDragCoeff*kappa &
+                                                 * bathy_stddev(iEdge)**2 &
+                                                 * topo_buoyancy_N1B(iEdge) &
+                                                 / layerThickEdgeMean(k,iEdge)
                   endif
               end do
 
@@ -218,29 +218,30 @@ contains
               call mpas_log_write("")
               call mpas_log_write(" Topographic wave drag scheme is: Zaron and Egbert")
               call mpas_log_write("")
-!              topographicWaveDrag = topographicWaveDragCoeff*(bed_slope_edges**2)*topo_buoyancy_N1B*topo_buoyancy_N1V / (8.0_RKIND * 1.405189e-4_RKIND * pii**2)
 
-! Cze = Gamma H grad(H)^2 Nb Nbar / (8 pi^2 omega)
-! Gamma = 50
-! N(z) = N0 exp(z/1300)
-! N0 = 5.24 x 10^-3
-! z = 0 at surface
-! Nb is N(z) evaluated at z = -H
-! Nbar = 1300 N0 (1 - exp(-H/1300))/H
+              ! Cze = Gamma H grad(H)^2 Nb Nbar / (8 pi^2 omega)
+              ! Gamma = 50
+              ! N(z) = N0 exp(z/1300)
+              ! N0 = 5.24 x 10^-3
+              ! z = 0 at surface
+              ! Nb is N(z) evaluated at z = -H
+              ! Nbar = 1300 N0 (1 - exp(-H/1300))/H
+
+              N0 = 5.24e-3_RKIND
+              L = 1300.0_RKIND
+              gam = 50.0_RKIND
               do iEdge = 1, nEdgesAll
                   kmax =  maxLevelEdgeTop(iEdge)
-                  kmin =  minLevelEdgeBot(iEdge)
                   topographicWaveDrag(iEdge) = 0.0_RKIND
                   if (kmax > 0) then
                       k = 1 ! Note: Only works for single layer case
-                      topoDragTurnOff = (TANH((layerThickEdgeMean(k,iEdge)-topoDragCutoffDepth)/topoDragCutoffWidth)+1)/2
-                      topographicWaveDrag(iEdge) = topographicWaveDragCoeff*topoDragTurnOff*50.0_RKIND  * &
-                                (bed_slope_edges(iEdge)**2)                                             * &
-                                (5.24e-3_RKIND*1300.0_RKIND                                             * &
-                                    (1 - exp(-layerThickEdgeMean(k,iEdge)/1300.0_RKIND))                / &
-                                        layerThickEdgeMean(k,iEdge))                                    * &
-                                (5.24e-3_RKIND*exp(-layerThickEdgeMean(k,iEdge)/1300.0_RKIND))          / &
-                                (8 * omegaM2 * pii**2)
+
+                      Nb = N0*exp(-layerThickEdgeMean(k,iEdge)/L)
+                      Nbar = N0*L*(1.0_RKIND - exp(-layerThickEdgeMean(k,iEdge)/L)) / layerThickEdgeMean(k,iEdge)
+
+                      topographicWaveDrag(iEdge) = topographicWaveDragCoeff * gam  &
+                                                 * bed_slope_edges(iEdge)**2 * Nbar * Nb &
+                                                 / (8.0_RKIND * omegaM2 * pii**2)
                   endif
               enddo
           else if (config_topographic_wave_drag_scheme.EQ."LGF") then
@@ -250,23 +251,19 @@ contains
               call mpas_log_write("")
               do iEdge = 1, nEdgesAll
                   kmax =  maxLevelEdgeTop(iEdge)
-                  kmin =  minLevelEdgeBot(iEdge)
                   topographicWaveDrag(iEdge) = 0.0_RKIND
                   if (kmax > 0) then
-                      k = 1
-                      topoDragTurnOff = (TANH((layerThickEdgeMean(k,iEdge)-topoDragCutoffDepth)/topoDragCutoffWidth)+1)/2
-                      topographicWaveDrag = topographicWaveDragCoeff  &
-                                            * topoDragTurnOff         &
-                                            * (sqrt((topo_buoyancy_N1B(iEdge)**2 - omegaM2**2) * &
-                                                    (topo_buoyancy_N1V(iEdge)**2 - omegaM2**2))) &
-                                            / (4*pii*omegaM2)
-                      normalCoeff = (lonGradEdge(iEdge)**2) * &
-                                    (cos(angleEdge(iEdge))**2) + (latGradEdge(iEdge)**2)*(sin(angleEdge(iEdge))**2) - &
-                                        2*latGradEdge(iEdge)*lonGradEdge(iEdge)*sin(angleEdge(iEdge))*(cos(angleEdge(iEdge)))
-                      tangentialCoeff = sin(angleEdge(iEdge)) * &
-                                        cos(angleEdge(iEdge)) * &
-                                        (lonGradEdge(iEdge)**2 - latGradEdge(iEdge)**2) + &
-                                        latGradEdge(iEdge)*lonGradEdge(iEdge)*(cos(angleEdge(iEdge))**2 - sin(angleEdge(iEdge))**2)
+                      topographicWaveDrag(iEdge) = topographicWaveDragCoeff  &
+                                                 * (sqrt((topo_buoyancy_N1B(iEdge)**2 - omegaM2**2)   &
+                                                       * (topo_buoyancy_N1V(iEdge)**2 - omegaM2**2))) &
+                                                 / (4.0_RKIND*pii*omegaM2)
+                      normalCoeffTWD(iEdge) = (lonGradEdge(iEdge)**2) &
+                                         * (cos(angleEdge(iEdge))**2) + (latGradEdge(iEdge)**2)*(sin(angleEdge(iEdge))**2) &
+                                         - 2.0_RKIND*latGradEdge(iEdge)*lonGradEdge(iEdge)*sin(angleEdge(iEdge))*(cos(angleEdge(iEdge)))
+                      tangentialCoeffTWD(iEdge) = sin(angleEdge(iEdge)) &
+                                             * cos(angleEdge(iEdge)) &
+                                             * (lonGradEdge(iEdge)**2 - latGradEdge(iEdge)**2) &
+                                             + latGradEdge(iEdge)*lonGradEdge(iEdge)*(cos(angleEdge(iEdge))**2 - sin(angleEdge(iEdge))**2)
                   endif
               enddo
           else 
@@ -275,6 +272,17 @@ contains
               call mpas_log_write("Invalid parameter for config_topopgraphic_wave_drag_scheme. It must be one of: 'JSL', 'ZAE', or 'LGF'" , MPAS_LOG_CRIT)
               call mpas_log_write("")
           end if
+
+          ! Apply ramping factor to wave drag
+          do iEdge = 1, nEdgesAll
+              kmax =  maxLevelEdgeTop(iEdge)
+              if (kmax > 0) then
+                  k = 1
+                  topoDragTurnOff = (TANH((layerThickEdgeMean(k,iEdge)-topoDragCutoffDepth)/topoDragCutoffWidth)+1.0_RKIND)/2.0_RKIND
+                  topographicWaveDrag(iEdge) = topoDragTurnOff * topographicWaveDrag(iEdge)
+              endif
+          enddo
+          
       endif
 
       if (config_disable_vel_topographic_wave_drag) topographicWaveDragOn = .false.

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
@@ -183,7 +183,9 @@ contains
 
       real (kind=RKIND) :: topoDragCutoffDepth, topoDragCutoffWidth
       real (kind=RKIND) :: omegaM2 = 1.405189e-4_RKIND
-      real (kind=RKIND), dimension(:), allocatable :: topoDragTurnOff
+      real (kind=RKIND) :: topoDragTurnOff
+
+      integer :: iEdge, k, kmin, kmax
 
       err = 0
 
@@ -195,14 +197,21 @@ contains
           topographicWaveDragCoeff = config_topographic_wave_drag_coeff
           topoDragCutoffDepth = config_topographic_wave_drag_cutoff_depth
           topoDragCutoffWidth = config_topographic_wave_drag_cutoff_width
-          topoDragTurnOff = (TANH((bottomDepthEdge-topoDragCutoffDepth)/topoDragCutoffWidth)+1)/2
           if (config_topographic_wave_drag_scheme.EQ."JSL") then
-              tensorScheme = .false.
               call mpas_log_write("")
               call mpas_log_write(" Topographic wave drag scheme is: Jayne and St. Laurent")
               call mpas_log_write("")
-              topographicWaveDrag = topographicWaveDragCoeff*topoDragTurnOff*pii*(bathy_stddev**2)*topo_buoyancy_N1B/10000.0_RKIND/bottomDepthEdge
-              ! C = pi std(H)^2 Nb / L, L=10,000
+              tensorScheme = .false.
+
+              do iEdge = 1, nEdgesAll
+                  kmax =  maxLevelEdgeTop(iEdge)
+                  topographicWaveDrag(iEdge) = 0.0_RKIND
+                  if (kmax > 0) then
+                      k =  maxLevelEdgeTop(iEdge)
+                      topoDragTurnOff = (TANH((layerThickEdgeMean(k,iEdge)-topoDragCutoffDepth)/topoDragCutoffWidth)+1)/2
+                      topographicWaveDrag(iEdge) = topographicWaveDragCoeff*topoDragTurnOff*pii*(bathy_stddev(iEdge)**2)*topo_buoyancy_N1B(iEdge)/10000.0_RKIND/layerThickEdgeMean(k,iEdge)
+                  endif
+              end do
 
           else if (config_topographic_wave_drag_scheme.EQ."ZAE") then
               tensorScheme = .false.
@@ -218,19 +227,48 @@ contains
 ! z = 0 at surface
 ! Nb is N(z) evaluated at z = -H
 ! Nbar = 1300 N0 (1 - exp(-H/1300))/H
-              topographicWaveDrag = topographicWaveDragCoeff*topoDragTurnOff*50.0_RKIND*(bed_slope_edges**2)  * &
-                        (5.24e-3_RKIND*1300.0_RKIND*(1 - exp(-bottomDepthEdge/1300.0_RKIND))/bottomDepthEdge) * & ! Nbar
-                        (5.24e-3_RKIND*exp(-bottomDepthEdge/1300.0_RKIND))                                    / & ! Nb
-                        (8 * omegaM2 * pii**2)
+              do iEdge = 1, nEdgesAll
+                  kmax =  maxLevelEdgeTop(iEdge)
+                  kmin =  minLevelEdgeBot(iEdge)
+                  topographicWaveDrag(iEdge) = 0.0_RKIND
+                  if (kmax > 0) then
+                      k = 1 ! Note: Only works for single layer case
+                      topoDragTurnOff = (TANH((layerThickEdgeMean(k,iEdge)-topoDragCutoffDepth)/topoDragCutoffWidth)+1)/2
+                      topographicWaveDrag(iEdge) = topographicWaveDragCoeff*topoDragTurnOff*50.0_RKIND  * &
+                                (bed_slope_edges(iEdge)**2)                                             * &
+                                (5.24e-3_RKIND*1300.0_RKIND                                             * &
+                                    (1 - exp(-layerThickEdgeMean(k,iEdge)/1300.0_RKIND))                / &
+                                        layerThickEdgeMean(k,iEdge))                                    * &
+                                (5.24e-3_RKIND*exp(-layerThickEdgeMean(k,iEdge)/1300.0_RKIND))          / &
+                                (8 * omegaM2 * pii**2)
+                  endif
+              enddo
           else if (config_topographic_wave_drag_scheme.EQ."LGF") then
               tensorScheme = .true.
               call mpas_log_write("")
               call mpas_log_write(" Topographic wave drag scheme is: Local Generation Formula")
               call mpas_log_write("")
-              topographicWaveDrag = topographicWaveDragCoeff*topoDragTurnOff*(sqrt((topo_buoyancy_N1B**2 - omegaM2**2)*(topo_buoyancy_N1V**2 - omegaM2**2)))/(4*pii*omegaM2)
-              normalCoeff = (lonGradEdge**2)*(cos(angleEdge)**2) + (latGradEdge**2)*(sin(angleEdge)**2) - 2*latGradEdge*lonGradEdge*sin(angleEdge)*(cos(angleEdge))
-              tangentialCoeff = sin(angleEdge)*cos(angleEdge)*(lonGradEdge**2 - latGradEdge**2) + latGradEdge*lonGradEdge*(cos(angleEdge)**2 - sin(angleEdge)**2)
-
+              do iEdge = 1, nEdgesAll
+                  kmax =  maxLevelEdgeTop(iEdge)
+                  kmin =  minLevelEdgeBot(iEdge)
+                  topographicWaveDrag(iEdge) = 0.0_RKIND
+                  if (kmax > 0) then
+                      k = 1
+                      topoDragTurnOff = (TANH((layerThickEdgeMean(k,iEdge)-topoDragCutoffDepth)/topoDragCutoffWidth)+1)/2
+                      topographicWaveDrag = topographicWaveDragCoeff  &
+                                            * topoDragTurnOff         &
+                                            * (sqrt((topo_buoyancy_N1B(iEdge)**2 - omegaM2**2) * &
+                                                    (topo_buoyancy_N1V(iEdge)**2 - omegaM2**2))) &
+                                            / (4*pii*omegaM2)
+                      normalCoeff = (lonGradEdge(iEdge)**2) * &
+                                    (cos(angleEdge(iEdge))**2) + (latGradEdge(iEdge)**2)*(sin(angleEdge(iEdge))**2) - &
+                                        2*latGradEdge(iEdge)*lonGradEdge(iEdge)*sin(angleEdge(iEdge))*(cos(angleEdge(iEdge)))
+                      tangentialCoeff = sin(angleEdge(iEdge)) * &
+                                        cos(angleEdge(iEdge)) * &
+                                        (lonGradEdge(iEdge)**2 - latGradEdge(iEdge)**2) + &
+                                        latGradEdge(iEdge)*lonGradEdge(iEdge)*(cos(angleEdge(iEdge))**2 - sin(angleEdge(iEdge))**2)
+                  endif
+              enddo
           else 
               call mpas_log_write("")
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
@@ -46,7 +46,8 @@ module ocn_vel_forcing_topographic_wave_drag
    !
    !--------------------------------------------------------------------
 
-   public :: ocn_vel_forcing_topographic_wave_drag_tend, &
+   public :: ocn_vel_forcing_topographic_wave_drag_scalar_tend, &
+             ocn_vel_forcing_topographic_wave_drag_tensor_tend, &
              ocn_vel_forcing_topographic_wave_drag_init
 
    !--------------------------------------------------------------------
@@ -57,6 +58,7 @@ module ocn_vel_forcing_topographic_wave_drag
 
    logical :: topographicWaveDragOn
    real (kind=RKIND) :: topographicWaveDragCoeff
+   real (kind=RKIND), dimension(:), allocatable :: topographicWaveDrag
 
 !***********************************************************************
 
@@ -64,7 +66,7 @@ contains
 
 !***********************************************************************
 !
-!  routine ocn_vel_forcing_topographic_wave_drag_tend
+!  routine ocn_vel_forcing_topographic_wave_drag_scalar_tend
 !
 !> \brief   Computes tendency term from topographic wave drag
 !> \author  Nairita Pal
@@ -75,7 +77,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_forcing_topographic_wave_drag_tend(normalVelocity, & !{{{
+   subroutine ocn_vel_forcing_topographic_wave_drag_scalar_tend(normalVelocity, & !{{{
                      tend, err)
 
       !-----------------------------------------------------------------
@@ -117,6 +119,11 @@ contains
 
       call mpas_timer_start('vel topographic wave drag')
 
+      ! JSL: C = pi std(H)^2 N_B / L
+      ! ZAE: C = gamma H (grad(H))^2 N_B bar(N) / (8 * pi^2 * omega)
+      !          N(z) = N_0 exp(z/1300)
+      ! Drag: rho_0 C u
+      
       !$omp do schedule(runtime) private(k)
       do iEdge = 1, nEdgesOwned
         k =  maxLevelEdgeTop(iEdge)
@@ -126,7 +133,7 @@ contains
         ! topographic_wave_drag = 1/rinv
         if (k>0) then
           tend(k,iEdge) = tend(k,iEdge) - topographicWaveDragCoeff &
-             * topographic_wave_drag(iEdge) * normalVelocity(k,iEdge)
+             * topographicWaveDrag(iEdge) * normalVelocity(k,iEdge)
         endif
       enddo
       !$omp end do
@@ -135,7 +142,85 @@ contains
 
    !--------------------------------------------------------------------
 
-   end subroutine ocn_vel_forcing_topographic_wave_drag_tend!}}}
+   end subroutine ocn_vel_forcing_topographic_wave_drag_scalar_tend!}}}
+
+!***********************************************************************
+!
+!  routine ocn_vel_forcing_topographic_wave_drag_tensor_tend
+!
+!> \brief   Computes tendency term from topographic wave drag
+!> \author  Kristin Barton
+!> \date    1 Nov 2022
+!> \details
+!>  This routine computes the topographic wave drag tendency for momentum
+!>  based on current state using the tensor formulation
+!
+!***********************************************************************
+
+   subroutine ocn_vel_forcing_topographic_wave_drag_tensor_tend(normalVelocity, & !{{{
+                     tend, err)
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         normalVelocity   !< Input: velocity
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend          !< Input/Output: velocity tendency
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iEdge, k
+
+      err = 0
+      if ( .not. topographicWaveDragOn ) return
+
+      call mpas_timer_start('vel topographic wave drag')
+
+      ! JSL: C = pi std(H)^2 N_B / L
+      ! ZAE: C = gamma H (grad(H))^2 N_B bar(N) / (8 * pi^2 * omega)
+      !          N(z) = N_0 exp(z/1300)
+      ! Drag: rho_0 C u
+      
+      !$omp do schedule(runtime) private(k)
+      do iEdge = 1, nEdgesOwned
+        k =  maxLevelEdgeTop(iEdge)
+        ! topographic wave drag term:
+        ! du/dt = ... 1/rinv * u
+        ! rinv is the e-folding time use in HyCOM. Here
+        ! topographic_wave_drag = 1/rinv
+        if (k>0) then
+        endif
+      enddo
+      !$omp end do
+
+      call mpas_timer_stop('vel topographic wave drag')
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_vel_forcing_topographic_wave_drag_tensor_tend!}}}
 
 !***********************************************************************
 !
@@ -169,6 +254,39 @@ contains
       if (config_use_topographic_wave_drag) then
           topographicWaveDragOn = .true.
           topographicWaveDragCoeff = config_topographic_wave_drag_coeff
+          if (config_topographic_wave_drag_scheme.EQ."JSL") then
+              call mpas_log_write("")
+              call mpas_log_write(" Topographic wave drag scheme is: Jayne and St. Laurent")
+              call mpas_log_write("")
+              ! C = pi std(H)^2 Nb / L, L=10,000
+              topographicWaveDrag = pii*(bathy_stddev**2)*topo_buoyancy_N1B/10000.0_RKIND
+          else if (config_topographic_wave_drag_scheme.EQ."ZAE") then
+              call mpas_log_write("")
+              call mpas_log_write(" Topographic wave drag scheme is: Zaron and Egbert")
+              call mpas_log_write("")
+              ! C = G*H*(grad H)^2 * Nb * Nv / (8 pi^2 omega), take M2 omega = 1.405189e-4_RKIND
+!              Nv = (5.24e-3_RKIND)*1300*(1 - exp(-bottomDepth/1300))/bottomDepth
+!              Nb = (5.24e-3_RKIND)*exp(-bottomDepth/1300)
+              topographicWaveDrag = bottomDepth*(bed_slope_edges**2)*((5.24e-3_RKIND)*1300.0_RKIND*(1 - exp(-bottomDepth/1300.0_RKIND))/bottomDepth)*((5.24e-3_RKIND)*exp(-bottomDepth/1300.0_RKIND))/ (8 * 1.405189e-4_RKIND * pii**2)
+!              topographicWaveDrag = bottomDepth*(bed_slope_edges**2)*topo_buoyancy_N1B*topo_buoyancy_N1V / (8 * 1.405189e-4_RKIND * pii**2)
+          else if (config_topographic_wave_drag_scheme.EQ."NYC") then
+              call mpas_log_write("")
+              call mpas_log_write(" Topographic wave drag scheme is: Nycander")
+              call mpas_log_write("")
+              topographicWaveDrag = topo_rinv
+              ! Preperation for Nycander
+          else 
+              call mpas_log_write("")
+              call mpas_log_write("Invalid parameter for config_topopgraphic_wave_drag_scheme. It must be one of: 'JSL', 'ZAE', or 'NYC'" , MPAS_LOG_CRIT)
+              ! C = Cit sqrt((Nb^2 - omega^2)(Nm^2 - omega^2))/(4 pi omega) * [ [grad(hl)^2, grad(hl)*grad(hp)  ], [ grad(hl) * grad(hp), grad(hp)^2  ]  ]
+              ! Cit = tuning coefficint
+              ! Nb = bottom frequency
+              ! Nm = depth-averaged frequency
+              ! grad(hl) = zonal topo gradient
+              ! grad(hp) = meridional topo gradient
+
+              call mpas_log_write("")
+          end if
       endif
 
       if (config_disable_vel_topographic_wave_drag) topographicWaveDragOn = .false.

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_forcing_topographic_wave_drag.F
@@ -201,7 +201,7 @@ contains
               call mpas_log_write("")
               call mpas_log_write(" Topographic wave drag scheme is: Jayne and St. Laurent")
               call mpas_log_write("")
-              topographicWaveDrag = topographicWaveDragCoeff*topoDragTurnOff*pii*(bathy_stddev**2)*topo_buoyancy_N1B/10000.0_RKIND/layerThicknessEdge
+              topographicWaveDrag = topographicWaveDragCoeff*topoDragTurnOff*pii*(bathy_stddev**2)*topo_buoyancy_N1B/10000.0_RKIND/bottomDepthEdge
               ! C = pi std(H)^2 Nb / L, L=10,000
 
           else if (config_topographic_wave_drag_scheme.EQ."ZAE") then
@@ -209,7 +209,7 @@ contains
               call mpas_log_write("")
               call mpas_log_write(" Topographic wave drag scheme is: Zaron and Egbert")
               call mpas_log_write("")
-              topographicWaveDrag = topographicWaveDragCoeff*bottomDepthEdge*(bed_slope_edges**2)*topo_buoyancy_N1B*topo_buoyancy_N1V / (8.0_RKIND * 1.405189e-4_RKIND * pii**2) / layerThicknessEdge
+              topographicWaveDrag = topographicWaveDragCoeff*(bed_slope_edges**2)*topo_buoyancy_N1B*topo_buoyancy_N1V / (8.0_RKIND * 1.405189e-4_RKIND * pii**2)
 !              topographicWaveDrag = topographicWaveDragCoeff*topoDragTurnOff*50.0_RKIND*bottomDepthEdge*(bed_slope_edges**2)*((5.24e-3_RKIND)*1300.0_RKIND*(1 - exp(-bottomDepthEdge/1300.0_RKIND))/bottomDepthEdge)*((5.24e-3_RKIND)*exp(-bottomDepthEdge/1300.0_RKIND))/ (8 * 1.405189e-4_RKIND * pii**2)
               ! C = G*H*(grad H)^2 * Nb * Nv / (8 pi^2 omega), take M2 omega = 1.405189e-4_RKIND
 !              Nv = (5.24e-3_RKIND)*1300*(1 - exp(-bottomDepth/1300))/bottomDepth

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
@@ -176,6 +176,8 @@ contains
         rho0gInv = 1.0_RKIND / rho_sw / gravity
 
         do iCell = 1,nCellsAll
+          ! an adjusted ssh that accounts for surface pressure,
+          ! with SAL computed wrt the full btr bottom pressure
           sshSmoothed(iCell) = coastalSmoothingFactor(iCell) * ( &
               ssh(iCell) + rho0gInv * surfacePressure(iCell) )
         enddo

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
@@ -103,7 +103,7 @@ module ocn_vel_self_attraction_loading
     real(kind=RKIND), dimension(:),   allocatable :: Snm, SnmRe, SnmIm
     real(kind=RKIND), dimension(:),   allocatable :: Snm_local, SnmRe_local, SnmIm_local
     real(kind=RKIND), dimension(:,:), allocatable :: Snm_local_reproSum, SnmRe_local_reproSum, SnmIm_local_reproSum
-    real(kind=RKIND), dimension(:),   allocatable :: sshSmoothed
+    real(kind=RKIND), dimension(:),   allocatable :: btrPressure
     real(kind=RKIND), dimension(:), pointer :: coastalSmoothingFactor
     integer, dimension(:,:), allocatable :: blockIdxForward
     integer, dimension(:,:), allocatable :: blockIdxInverse
@@ -176,9 +176,8 @@ contains
         rho0gInv = 1.0_RKIND / rho_sw / gravity
 
         do iCell = 1,nCellsAll
-          ! an adjusted ssh that accounts for surface pressure,
-          ! with SAL computed wrt the full btr bottom pressure
-          sshSmoothed(iCell) = coastalSmoothingFactor(iCell) * ( &
+          ! compute SAL wrt. the full barotropic bottom pressure
+          btrPressure(iCell) = coastalSmoothingFactor(iCell) * ( &
               ssh(iCell) + rho0gInv * surfacePressure(iCell) )
         enddo
 
@@ -262,7 +261,7 @@ contains
         endif
 
         ! Gather only the nCellsOwned from pgf (does not include Halos)
-        call MPI_GATHERV(sshSmoothed, nCellsOwned, MPI_DOUBLE, gatheredArray, nCellsPerProc, &
+        call MPI_GATHERV(btrPressure, nCellsOwned, MPI_DOUBLE, gatheredArray, nCellsPerProc, &
                         nCellsDisplacement, MPI_DOUBLE, 0, dminfo % comm, err_tmp)
         err = ior(err, err_tmp)
         call mpas_timer_stop('Serial SAL: Gather')
@@ -402,13 +401,13 @@ contains
                 ! Compute local integral contribution
                 if (config_parallel_self_attraction_loading_bfb) then
                   do iCell = endIdx, startIdx, -1
-                      SnmRe_local_reproSum(iCell,l) = SnmRe_local_reproSum(iCell,l) + sshSmoothed(iCell)*pmnm2(iCell)*complexFactorRe(iCell,m+1)
-                      SnmIm_local_reproSum(iCell,l) = SnmIm_local_reproSum(iCell,l) + sshSmoothed(iCell)*pmnm2(iCell)*complexFactorIm(iCell,m+1)
+                      SnmRe_local_reproSum(iCell,l) = SnmRe_local_reproSum(iCell,l) + btrPressure(iCell)*pmnm2(iCell)*complexFactorRe(iCell,m+1)
+                      SnmIm_local_reproSum(iCell,l) = SnmIm_local_reproSum(iCell,l) + btrPressure(iCell)*pmnm2(iCell)*complexFactorIm(iCell,m+1)
                   enddo
                 else
                   do iCell = endIdx, startIdx, -1
-                      SnmRe_local(l) = SnmRe_local(l) + sshSmoothed(iCell)*pmnm2(iCell)*complexFactorRe(iCell,m+1)
-                      SnmIm_local(l) = SnmIm_local(l) + sshSmoothed(iCell)*pmnm2(iCell)*complexFactorIm(iCell,m+1)
+                      SnmRe_local(l) = SnmRe_local(l) + btrPressure(iCell)*pmnm2(iCell)*complexFactorRe(iCell,m+1)
+                      SnmIm_local(l) = SnmIm_local(l) + btrPressure(iCell)*pmnm2(iCell)*complexFactorIm(iCell,m+1)
                   enddo
                 endif
 
@@ -424,13 +423,13 @@ contains
                     ! Compute local integral contribution
                     if (config_parallel_self_attraction_loading_bfb) then
                       do iCell = endIdx, startIdx, -1
-                          SnmRe_local_reproSum(iCell,l) = SnmRe_local_reproSum(iCell,l) + sshSmoothed(iCell)*pmnm1(iCell)*complexFactorRe(iCell,m+1)
-                          SnmIm_local_reproSum(iCell,l) = SnmIm_local_reproSum(iCell,l) + sshSmoothed(iCell)*pmnm1(iCell)*complexFactorIm(iCell,m+1)
+                          SnmRe_local_reproSum(iCell,l) = SnmRe_local_reproSum(iCell,l) + btrPressure(iCell)*pmnm1(iCell)*complexFactorRe(iCell,m+1)
+                          SnmIm_local_reproSum(iCell,l) = SnmIm_local_reproSum(iCell,l) + btrPressure(iCell)*pmnm1(iCell)*complexFactorIm(iCell,m+1)
                       enddo
                     else
                       do iCell = endIdx, startIdx, -1
-                          SnmRe_local(l) = SnmRe_local(l) + sshSmoothed(iCell)*pmnm1(iCell)*complexFactorRe(iCell,m+1)
-                          SnmIm_local(l) = SnmIm_local(l) + sshSmoothed(iCell)*pmnm1(iCell)*complexFactorIm(iCell,m+1)
+                          SnmRe_local(l) = SnmRe_local(l) + btrPressure(iCell)*pmnm1(iCell)*complexFactorRe(iCell,m+1)
+                          SnmIm_local(l) = SnmIm_local(l) + btrPressure(iCell)*pmnm1(iCell)*complexFactorIm(iCell,m+1)
                       enddo
                     endif
 
@@ -455,13 +454,13 @@ contains
                     ! Compute local integral contribution
                     if (config_parallel_self_attraction_loading_bfb) then
                       do iCell = endIdx, startIdx, -1
-                          SnmRe_local_reproSum(iCell,l) = SnmRe_local_reproSum(iCell,l) + sshSmoothed(iCell)*pmn(iCell)*complexFactorRe(iCell,m+1)
-                          SnmIm_local_reproSum(iCell,l) = SnmIm_local_reproSum(iCell,l) + sshSmoothed(iCell)*pmn(iCell)*complexFactorIm(iCell,m+1)
+                          SnmRe_local_reproSum(iCell,l) = SnmRe_local_reproSum(iCell,l) + btrPressure(iCell)*pmn(iCell)*complexFactorRe(iCell,m+1)
+                          SnmIm_local_reproSum(iCell,l) = SnmIm_local_reproSum(iCell,l) + btrPressure(iCell)*pmn(iCell)*complexFactorIm(iCell,m+1)
                       enddo
                     else
                       do iCell = endIdx, startIdx, -1
-                          SnmRe_local(l) = SnmRe_local(l) + sshSmoothed(iCell)*pmn(iCell)*complexFactorRe(iCell,m+1)
-                          SnmIm_local(l) = SnmIm_local(l) + sshSmoothed(iCell)*pmn(iCell)*complexFactorIm(iCell,m+1)
+                          SnmRe_local(l) = SnmRe_local(l) + btrPressure(iCell)*pmn(iCell)*complexFactorRe(iCell,m+1)
+                          SnmIm_local(l) = SnmIm_local(l) + btrPressure(iCell)*pmn(iCell)*complexFactorIm(iCell,m+1)
                       enddo
                     endif
 
@@ -681,7 +680,7 @@ contains
         call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
 
         ! Set up coastal smoothing
-        allocate(sshSmoothed(nCellsAll))
+        allocate(btrPressure(nCellsAll))
 
         ! Set-up smoothing mask for shallow regions where SAL should not
         ! be computed across e.g. wet-dry cells

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
@@ -163,6 +163,7 @@ contains
         !-----------------------------------------------------------------
 
         integer :: iCell
+        real (kind=RKIND) :: rho0gInv
         
         call mpas_timer_start('SAL Calculation')
 
@@ -171,6 +172,8 @@ contains
             call mpas_timer_stop('SAL Calculation')
             return
         endif
+
+        rho0gInv = 1.0_RKIND / rho_sw / gravity
 
         do iCell = 1,nCellsAll
           sshSmoothed(iCell) = coastalSmoothingFactor(iCell) * ( &

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_self_attraction_loading.F
@@ -128,7 +128,8 @@ contains
 !
 !-----------------------------------------------------------------------
 
-    subroutine ocn_compute_self_attraction_loading(domain, forcingPool, dminfo, ssh, err)!{{{
+    subroutine ocn_compute_self_attraction_loading(domain, forcingPool, &
+        dminfo, ssh, surfacePressure, err)!{{{
 
         !-----------------------------------------------------------------
         !
@@ -137,6 +138,7 @@ contains
         !-----------------------------------------------------------------
         type (dm_info), intent(in) :: dminfo
         real (kind=RKIND), dimension(:), intent(in) :: ssh
+        real (kind=RKIND), dimension(:), intent(in) :: surfacePressure
 
         !-----------------------------------------------------------------
         !
@@ -161,7 +163,7 @@ contains
         !-----------------------------------------------------------------
 
         integer :: iCell
-
+        
         call mpas_timer_start('SAL Calculation')
 
         err = 0
@@ -171,7 +173,8 @@ contains
         endif
 
         do iCell = 1,nCellsAll
-          sshSmoothed(iCell) = coastalSmoothingFactor(iCell)*ssh(iCell)
+          sshSmoothed(iCell) = coastalSmoothingFactor(iCell) * ( &
+              ssh(iCell) + rho0gInv * surfacePressure(iCell) )
         enddo
 
         if (.not. config_use_parallel_self_attraction_loading) then
@@ -184,9 +187,9 @@ contains
 
         endif
 
-        ! ssh_sal currently computed on host but must be transferred
+        ! pgf_sal currently computed on host but must be transferred
         ! to device for later tendency calculations
-        !$acc update device(ssh_sal)
+        !$acc update device(pgf_sal)
 
         call mpas_timer_stop('SAL Calculation')
 
@@ -236,7 +239,7 @@ contains
         !-----------------------------------------------------------------
 
         ! SAL variables
-        real (kind=RKIND), dimension(:), pointer :: ssh_gg
+        real (kind=RKIND), dimension(:), pointer :: pgf_gg
 
         ! MPI Variables
         integer :: iCell, ilm, curProc
@@ -253,7 +256,7 @@ contains
             allocate(globalArray(nCellsGlobal), gatheredArray(nCellsGlobal))
         endif
 
-        ! Gather only the nCellsOwned from ssh (does not include Halos)
+        ! Gather only the nCellsOwned from pgf (does not include Halos)
         call MPI_GATHERV(sshSmoothed, nCellsOwned, MPI_DOUBLE, gatheredArray, nCellsPerProc, &
                         nCellsDisplacement, MPI_DOUBLE, 0, dminfo % comm, err_tmp)
         err = ior(err, err_tmp)
@@ -262,20 +265,20 @@ contains
         ! Perform SAL calculation only on process 0
         if (curProc.eq.0) then
             call mpas_timer_start('Serial SAL: Forward')
-            allocate(ssh_gg(nGrid))
-            ssh_gg(:) = 0.0_dp
+            allocate(pgf_gg(nGrid))
+            pgf_gg(:) = 0.0_dp
             Slm(:)=(0.0_dp, 0.0_dp)
 
-            ! Rearrange ssh into CellID order
+            ! Rearrange into CellID order
             do iCell = 1,nCellsGlobal
                globalArray(indexToCellIDGathered(iCell)) = gatheredArray(iCell)
             enddo
 
-            ! Interpolate ssh onto Gaussian Grid
-            call interpolate( toColValues, toRowValues, toSValues, globalArray, ssh_gg)
+            ! Interpolate pgf onto Gaussian Grid
+            call interpolate( toColValues, toRowValues, toSValues, globalArray, pgf_gg)
             ! Perform spherical harmonic transform
 #ifdef USE_SHTNS
-            call Spat_to_SH(shtns_c, ssh_gg, Slm)
+            call Spat_to_SH(shtns_c, pgf_gg, Slm)
             call mpas_timer_stop('Serial SAL: Forward')
             call mpas_timer_start('Serial SAL: Inverse')
             ! Multiply each harmonic coefficient by the scaling factor
@@ -283,10 +286,10 @@ contains
                 Slm(ilm) = Slm(ilm) * LoveScaling(ilm)
             enddo
             ! Perform inverse spherical harmonic transform
-            call SH_to_spat(shtns_c, Slm, ssh_gg)
+            call SH_to_spat(shtns_c, Slm, pgf_gg)
 #endif
             ! Interpolate back to MPAS mesh
-            call interpolate( fromColValues, fromRowValues, fromSValues, ssh_gg, globalArray)
+            call interpolate( fromColValues, fromRowValues, fromSValues, pgf_gg, globalArray)
 
             ! Rearrange back to index order
             do iCell = 1,nCellsGlobal
@@ -300,18 +303,18 @@ contains
             call mpas_timer_stop('Serial SAL: Inverse')
         endif
 
-        ! Scatter back to ssh_sal
+        ! Scatter back to pgf_sal
         call mpas_timer_start('Serial SAL: Scatter')
         call MPI_SCATTERV(gatheredArray, nCellsPerProc, nCellsDisplacement, MPI_DOUBLE, &
-                    ssh_sal, nCellsAll, MPI_DOUBLE, 0, dminfo % comm, err_tmp)
+                    pgf_sal, nCellsAll, MPI_DOUBLE, 0, dminfo % comm, err_tmp)
         err = ior(err, err_tmp)
 
         if (curProc.eq.0) then
-          deallocate(globalArray, gatheredArray, ssh_gg)
+          deallocate(globalArray, gatheredArray, pgf_gg)
         endif
 
         ! Perform Halo exchange update
-        call mpas_dmpar_field_halo_exch(domain,'ssh_sal')
+        call mpas_dmpar_field_halo_exch(domain,'pgf_sal')
         call mpas_timer_stop('Serial SAL: Scatter')
 
     end subroutine self_attraction_loading_serial!}}}
@@ -514,7 +517,7 @@ contains
         !!!!!!!!!!!!!!!!!!!!
 
         do iCell = 1,nCellsAll
-           ssh_sal(iCell) = 0.0_RKIND
+           pgf_sal(iCell) = 0.0_RKIND
         enddo
 
         do m = 0,nOrder
@@ -539,7 +542,7 @@ contains
 
                 ! Sum together product of spherical harmonic functions and coefficients
                 do iCell = endIdx, startIdx, -1
-                    ssh_sal(iCell) = ssh_sal(iCell) + mFac*pmnm2(iCell)*(SnmRe(l)*complexExpRe(iCell,m+1)+SnmIm(l)*complexExpIm(iCell,m+1))
+                    pgf_sal(iCell) = pgf_sal(iCell) + mFac*pmnm2(iCell)*(SnmRe(l)*complexExpRe(iCell,m+1)+SnmIm(l)*complexExpIm(iCell,m+1))
                 enddo
 
                 !------------
@@ -553,7 +556,7 @@ contains
 
                     ! Sum together product of spherical harmonic functions and coefficients
                     do iCell = endIdx, startIdx, -1
-                        ssh_sal(iCell) = ssh_sal(iCell) + mFac*pmnm1(iCell)*(SnmRe(l)*complexExpRe(iCell,m+1)+SnmIm(l)*complexExpIm(iCell,m+1))
+                        pgf_sal(iCell) = pgf_sal(iCell) + mFac*pmnm1(iCell)*(SnmRe(l)*complexExpRe(iCell,m+1)+SnmIm(l)*complexExpIm(iCell,m+1))
                     enddo
 
                 endif
@@ -576,7 +579,7 @@ contains
 
                     ! Sum together product of spherical harmonic functions and coefficients
                     do iCell = endIdx, startIdx, -1
-                        ssh_sal(iCell) = ssh_sal(iCell) + mFac*pmn(iCell)*(SnmRe(l)*complexExpRe(iCell,m+1)+SnmIm(l)*complexExpIm(iCell,m+1))
+                        pgf_sal(iCell) = pgf_sal(iCell) + mFac*pmn(iCell)*(SnmRe(l)*complexExpRe(iCell,m+1)+SnmIm(l)*complexExpIm(iCell,m+1))
                     enddo
 
                 enddo ! n loop
@@ -609,6 +612,7 @@ contains
         ! Config variables
         type (block_type), pointer :: block_ptr
         type (mpas_pool_type), pointer :: forcingPool
+        type (mpas_pool_type), pointer :: statePool
 
         ! NetCDF and weights file variables
         integer :: toNcId, toNsDimId, toRowId, toColId, toSId
@@ -641,8 +645,8 @@ contains
         integer :: nCellBlock
         integer :: err_tmp
 
-        real(kind=RKIND) :: d
-        real(kind=RKIND) :: trans_start, trans_width
+        real(kind=RKIND), dimension(:), pointer :: ssh
+        real(kind=RKIND) :: depth, depth_tol
 
         call mpas_timer_start('SAL Init')
 
@@ -665,24 +669,24 @@ contains
 
         block_ptr => domain % blocklist
         call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
+        call mpas_pool_get_subpool(block_ptr % structs, 'state', statePool)
 
         call mpas_pool_get_array(forcingPool, 'coastalSmoothingFactor', &
                                                coastalSmoothingFactor)
+        call mpas_pool_get_array(statePool, 'ssh', ssh, 1)
 
-        ! Set up coastal ssh smoothing
+        ! Set up coastal smoothing
         allocate(sshSmoothed(nCellsAll))
 
-        if (config_self_attraction_loading_smoothing_width > 2.0_RKIND) then
-           trans_width = config_self_attraction_loading_smoothing_width*1000.0_RKIND
-           trans_start = 0.0_RKIND
-           do iCell = 1,nCellsAll
-               d = distanceToCoast(iCell)
-               coastalSmoothingFactor(iCell) = 0.5_RKIND*(tanh((d - trans_start - 0.5_RKIND * trans_width) / (0.2_RKIND *trans_width)) + 1.0_RKIND)
-           enddo
-        else
-           coastalSmoothingFactor(:) = 1.0_RKIND
-        endif
-
+        ! Set-up smoothing mask for shallow regions where SAL should not
+        ! be computed across e.g. wet-dry cells
+        depth_tol = config_self_attraction_loading_depth_cutoff
+        do iCell = 1,nCellsAll
+           depth = ssh(iCell) + bottomDepth(iCell)
+           coastalSmoothingFactor(iCell) = 0.5_RKIND*(tanh( &
+              (depth - 0.5_RKIND*depth_tol) / (0.2_RKIND*depth_tol)) + 1.0_RKIND)
+        enddo
+        
         ! Setup Alarm for SAL
         alarmTime = mpas_get_clock_time(domain % clock, MPAS_START_TIME, ierr=err)
         call mpas_set_timeInterval(alarmTimeStep, timeString = &

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_tidal_potential.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_tidal_potential.F
@@ -95,8 +95,8 @@ module ocn_vel_tidal_potential
    type(char_array), dimension(37) :: constituentList
    public :: char_array
 
-   ! Flag for ssh_sal
-   real(kind=RKIND) :: ssh_sal_on
+   ! Flag for pgf_sal
+   real(kind=RKIND) :: pgf_sal_on
 
 !***********************************************************************
 
@@ -162,7 +162,7 @@ contains
 #ifdef MPAS_OPENACC
          !$acc parallel loop &
          !$acc    present(cellsOnEdge, maxLevelEdgeTop, dcEdge, edgeMask, &
-         !$acc            tidalPotEta, ssh, surfacePressure, tend, ssh_sal) &
+         !$acc            tidalPotEta, ssh, surfacePressure, tend, pgf_sal) &
          !$acc    private(cell1, cell2, invdcEdge, potentialGrad, k, kMax)
 #else
          !$omp parallel do schedule(runtime) &
@@ -176,8 +176,8 @@ contains
 
             potentialGrad = - gravity*invdcEdge* &
                ( tidalPotEta(cell2) - tidalPotEta(cell1) &
-                + (1.0_RKIND - ssh_sal_on) * betaSelfAttrLoad * ( rho0gInv*(surfacePressure(cell2) - surfacePressure(cell1))) &
-                + ssh_sal_on * (ssh_sal(cell2) - ssh_sal(cell1)) )
+                + (1.0_RKIND - pgf_sal_on) * betaSelfAttrLoad * ( rho0gInv*(surfacePressure(cell2) - surfacePressure(cell1))) &
+                + pgf_sal_on * (pgf_sal(cell2) - pgf_sal(cell1)) )
 
             do k=1,kMax
                tend(k,iEdge) = tend(k,iEdge) - &
@@ -193,7 +193,7 @@ contains
 #ifdef MPAS_OPENACC
          !$acc parallel loop &
          !$acc    present(cellsOnEdge, maxLevelEdgeTop, dcEdge, edgeMask, &
-         !$acc            tidalPotEta, ssh, surfacePressure, tend, ssh_sal) &
+         !$acc            tidalPotEta, ssh, surfacePressure, tend, pgf_sal) &
          !$acc    private(cell1, cell2, invdcEdge, potentialGrad, k, kMax)
 #else
          !$omp parallel do schedule(runtime) &
@@ -207,9 +207,9 @@ contains
 
             potentialGrad = - gravity*invdcEdge* &
                (  tidalPotEta(cell2) - tidalPotEta(cell1) &
-                + (1.0_RKIND - ssh_sal_on) * betaSelfAttrLoad *( (ssh(cell2) - ssh(cell1)) &
-                                                         + rho0gInv*(surfacePressure(cell2) - surfacePressure(cell1))) &
-                + ssh_sal_on * (ssh_sal(cell2) - ssh_sal(cell1)) )
+               + (1.0_RKIND - pgf_sal_on) * betaSelfAttrLoad *( (ssh(cell2) - ssh(cell1)) & 
+                                                        + rho0gInv*(surfacePressure(cell2) - surfacePressure(cell1))) &
+               + pgf_sal_on * (pgf_sal(cell2) - pgf_sal(cell1)) )
 
             do k=1,kMax
                tend(k,iEdge) = tend(k,iEdge) - &
@@ -366,9 +366,9 @@ contains
 
          tidalPotentialOff = .false.
          if (config_use_self_attraction_loading) then
-            ssh_sal_on = 1.0_RKIND
+            pgf_sal_on = 1.0_RKIND
          else
-            ssh_sal_on = 0.0_RKIND
+            pgf_sal_on = 0.0_RKIND
          endif
 
          betaSelfAttrLoad = config_self_attraction_and_loading_beta


### PR DESCRIPTION
This PR incorporates updates to the global tidal forcing in MPAS-Ocean. It combines two contributions developed under the ICoM project:

1. @dengwirda's modifications to a) include surface pressure in the self attraction and loading (SAL) calculations, b) use a depth rather than distance-based criteria in the SAL coastal smoothing factor, and c) update the harmonic analysis AM to account for initial SSH offsets. See also: https://github.com/E3SM-Ocean-Discussion/E3SM/pull/52.
2. @knbarton's refactoring of the existing [Jayne and St. Laurent](https://journals.ametsoc.org/view/journals/phoc/43/1/jpo-d-12-023.1.xml) topographic wave drag (TWD) parameterization and the addition of the [Zaron and Egbert](https://journals.ametsoc.org/view/journals/phoc/43/1/jpo-d-12-023.1.xml) and [Local Generation Formula](https://eartharxiv.org/repository/view/1252/) TWD schemes.

This PR has been tested using a new compass case, which performs a 125-day tidal run (with a 90 day analysis period) on the VR45to5 mesh using the Zaron and Egbert topographic wave drag option. This results in a 3.3 cm M2 deep water RMSE as compared to the TPXO9 tidal database, which is the most accurate MPAS-Ocean tidal result to date. Here is a link to the compass PR with testing results: https://github.com/MPAS-Dev/compass/pull/802

[NML]
[BFB] - mpas-ocean standalone