### PR TITLE
remove leftover debug statement

### DIFF
--- a/components/data_comps/docn/src/docn_comp_mod.F90
+++ b/components/data_comps/docn/src/docn_comp_mod.F90
@@ -620,8 +620,6 @@ CONTAINS
 
     call t_startf('DOCN_RUN')
 
-    dbug = 1
-
     call t_startf('docn_run1')
     call seq_timemgr_EClockGetData( EClock, dtime=idt)
     dt = idt * 1.0_R8


### PR DESCRIPTION
A debug statement was left by mistake, resulting in large log files in data ocean