### PR TITLE
Update modules for intel,openmpi on Chrysalis.

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2565,12 +2565,12 @@
         <command name="load">intel-mkl/2020.4.304-g2qaxzf</command>
       </modules>
       <modules compiler="intel" mpilib="openmpi">
-        <command name="load">openmpi/4.1.3-pin4k7o</command>
-        <command name="load">hdf5/1.10.7-eewgp6v</command>
-        <command name="load">netcdf-c/4.4.1-ihoo4zq</command>
-        <command name="load">netcdf-cxx/4.2-soitsxm</command>
-        <command name="load">netcdf-fortran/4.4.4-tplolxh</command>
-        <command name="load">parallel-netcdf/1.11.0-gvcfihh</command>
+        <command name="load">openmpi/4.1.6-2mm63n2</command>
+        <command name="load">hdf5/1.10.7-4cghwvq</command>
+        <command name="load">netcdf-c/4.4.1-a4hji6e</command>
+        <command name="load">netcdf-cxx/4.2-ldoxr43</command>
+        <command name="load">netcdf-fortran/4.4.4-husened</command>
+        <command name="load">parallel-netcdf/1.11.0-icrpxty</command>
       </modules>
       <modules compiler="intel" mpilib="impi">
         <command name="load">intel-mpi/2019.9.304-tkzvizk</command>
@@ -2622,6 +2622,7 @@
       <env name="NETCDF_C_PATH">$SHELL{dirname $(dirname $(which nc-config))}</env>
       <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
+      <env name="OMPI_MCA_sharedfp">^lockedfile,individual</env>
     </environment_variables>
     <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>


### PR DESCRIPTION
Update modules for intel,openmpi on Chrysalis to get system software more update-to-date.

OpenMPI from 4.1.3 to 4.1.6
HDF, netcdf, pnetcdf versions unchanged but built with new OpenMPI.
Also add env variable suggested in an issue about lock files.

Lower level:  RHEL OS from 8.4 to 8.9

[BFB] except for one MALI test.
