### PR TITLE
Upgrading to SCORPIO v1.6.3

### DIFF
--- a/cime_config/customize/case_post_run_io.py
+++ b/cime_config/customize/case_post_run_io.py
@@ -74,6 +74,12 @@ def _convert_adios_to_nc(case):
     # Load the environment
     case.load_env(reset=True)
 
+    # Reset MPICH/MPI GPU support, if enabled
+    is_mpich_gpu_enabled = os.environ.get('MPICH_GPU_SUPPORT_ENABLED')
+    if int(0 if is_mpich_gpu_enabled is None else is_mpich_gpu_enabled) == 1:
+      logger.info("Resetting support for GPU in MPICH/MPI library (since its not used by the tool)")
+      os.environ['MPICH_GPU_SUPPORT_ENABLED'] = str(0);
+
     run_func = lambda: run_cmd(cmd, from_dir=rundir)[0]
 
     # Run the modified case

--- a/components/cmake/modules/FindPIO.cmake
+++ b/components/cmake/modules/FindPIO.cmake
@@ -18,6 +18,9 @@ endif()
 if (PIO_VERSION STREQUAL 2)
   # This is a pio2 library
   set(PIOLIBS "${PIO_LIBDIR}/libpiof.a;${PIO_LIBDIR}/libpioc.a")
+  if (DEFINED ENV{ADIOS2_ROOT})
+    list(APPEND PIOLIBS "${PIO_LIBDIR}/libadios2pio-nm-lib.a")
+  endif()
 else()
   # This is a pio1 library
   set(PIOLIBS "${PIO_LIBDIR}/libpio.a")

--- a/driver-mct/cime_config/config_component.xml
+++ b/driver-mct/cime_config/config_component.xml
@@ -2692,10 +2692,10 @@
 
   <entry id="PIO_REARRANGER">
     <type>integer</type>
-    <valid_values>1,2</valid_values>
+    <valid_values>1,2,3</valid_values>
     <group>run_pio</group>
     <file>env_run.xml</file>
-    <desc>pio rearranger choice box=1, subset=2 </desc>
+    <desc>pio rearranger choice box=1, subset=2, any=3 </desc>
     <values>
       <value compclass="ATM">$PIO_VERSION</value>
       <value compclass="CPL">$PIO_VERSION</value>

--- a/driver-mct/cime_config/namelist_definition_modelio.xml
+++ b/driver-mct/cime_config/namelist_definition_modelio.xml
@@ -90,9 +90,9 @@
     <type>integer</type>
     <category>pio</category>
     <group>pio_inparm</group>
-    <valid_values>-99,1,2</valid_values>
+    <valid_values>-99,1,2,3</valid_values>
     <desc>
-      Rearranger method for pio 1=box, 2=subset.
+      Rearranger method for pio 1=box, 2=subset, 3=any.
     </desc>
     <values>
     <value component="cpl">$CPL_PIO_REARRANGER</value>

--- a/driver-moab/cime_config/config_component.xml
+++ b/driver-moab/cime_config/config_component.xml
@@ -2684,10 +2684,10 @@
 
   <entry id="PIO_REARRANGER">
     <type>integer</type>
-    <valid_values>1,2</valid_values>
+    <valid_values>1,2,3</valid_values>
     <group>run_pio</group>
     <file>env_run.xml</file>
-    <desc>pio rearranger choice box=1, subset=2 </desc>
+    <desc>pio rearranger choice box=1, subset=2, any=3 </desc>
     <values>
       <value compclass="ATM">$PIO_VERSION</value>
       <value compclass="CPL">$PIO_VERSION</value>

--- a/driver-moab/cime_config/namelist_definition_modelio.xml
+++ b/driver-moab/cime_config/namelist_definition_modelio.xml
@@ -90,9 +90,9 @@
     <type>integer</type>
     <category>pio</category>
     <group>pio_inparm</group>
-    <valid_values>-99,1,2</valid_values>
+    <valid_values>-99,1,2,3</valid_values>
     <desc>
-      Rearranger method for pio 1=box, 2=subset.
+      Rearranger method for pio 1=box, 2=subset, 3=any.
     </desc>
     <values>
     <value component="cpl">$CPL_PIO_REARRANGER</value>

--- a/share/build/buildlib.spio
+++ b/share/build/buildlib.spio
@@ -106,6 +106,9 @@ def buildlib(bldroot, installpath, case):
 
     if "ADIOS2_ROOT" in os.environ:
         cmake_opts += "-DWITH_ADIOS2:BOOL=ON "
+        if "FROM_CREATE_TEST" in os.environ and os.environ["FROM_CREATE_TEST"] == "True":
+            cmake_opts += "-DADIOS_BP2NC_TEST:BOOL=ON "
+
     if debug:
         cmake_opts += "-DPIO_ENABLE_LOGGING=ON "
     # Case changes for NetCDF/NETCDF forces us to do this. For other packages

--- a/share/util/shr_pio_mod.F90
+++ b/share/util/shr_pio_mod.F90
@@ -730,7 +730,8 @@ contains
     if(pio_stride == 1 .and. .not. pio_async_interface) then
        pio_root = 0
     endif
-    if(pio_rearranger .ne. PIO_REARR_SUBSET .and. pio_rearranger .ne. PIO_REARR_BOX) then
+    if(pio_rearranger .ne. PIO_REARR_SUBSET .and. pio_rearranger .ne. PIO_REARR_BOX .and.&
+        pio_rearranger .ne. PIO_REARR_ANY) then
        write(shr_log_unit,*) 'pio_rearranger value, ',pio_rearranger,&
             ', not supported - using PIO_REARR_BOX'
        pio_rearranger = PIO_REARR_BOX


### PR DESCRIPTION
 Upgrading to SCORPIO v1.6.3 and adding support for the
new rearranger, PIO_REARR_ANY.

 SCORPIO v1.6.3 includes the following enhancements/fixes,
    
 * Support for standalone EAMXX/SCREAM builds
 * A new rearranger, PIO_REARR_ANY
 * Fixes for ADIOS to NetCDF conversion tool hangs/crashes in certain
   scenarios
 * Fixes for ultra high res simulations using the SUBSET rearranger
 * Support for reading ADIOS BP files and updates to the BP to
    NetCDF conversion tool to integrate with CIME/E3SM
 * Adding a SCORPIO CMake package during install
 * Support for new CDF5 types in the C interface
 * Support for pio_set_fill()
 * Fix for performance issues while writing large output files
   (hang during enddef() call)
 * Fix for issues writing/reading ADIOS string attributes
 * Misc bug fixes

[BFB]
