### PR TITLE
Remove `use mct_mod` to avoid build error with nvidia

### DIFF
--- a/components/data_comps/docn/src/docn_comp_mod.F90
+++ b/components/data_comps/docn/src/docn_comp_mod.F90
@@ -120,7 +120,6 @@ CONTAINS
        scmMode, scm_multcols, scmlat, scmlon, scm_nx, scm_ny)
 
     ! !DESCRIPTION: initialize docn model
-    use mct_mod
     use pio        , only : iosystem_desc_t
     use shr_pio_mod, only : shr_pio_getiosys, shr_pio_getiotype
 #ifdef HAVE_MOAB


### PR DESCRIPTION
Remove using mct_mod in a routine to avoid a build error with nvidia
(as lsize was in both the module and routine using it)

Fixes https://github.com/E3SM-Project/E3SM/issues/6332
[bfb]