### PR TITLE
Update LULC file for v3 historical compset

### DIFF
--- a/components/elm/bld/namelist_files/use_cases/20thC_CMIP6_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/20thC_CMIP6_transient.xml
@@ -37,7 +37,7 @@
 <flanduse_timeseries hgrid="ne30np4">lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850_2015_c20171018.nc</flanduse_timeseries>
 <finidat hgrid="ne30np4" mask="oEC60to30v3">lnd/clm2/initdata_map/20180316.DECKv1b_A1.ne30_oEC.edison.clm2.r.1980-01-01-00000.8575c3f_c20190904.nc</finidat>
 
-<flanduse_timeseries hgrid="r05">lnd/clm2/surfdata_map/landuse.timeseries_0.5x0.5_hist_simyr1850-2015_c191004.nc</flanduse_timeseries>
+<flanduse_timeseries hgrid="r05">lnd/clm2/surfdata_map/landuse.timeseries_0.5x0.5_hist_simyr1850-2015_c240308.nc</flanduse_timeseries>
 
 <flanduse_timeseries hgrid="ne120np4">lnd/clm2/surfdata_map/landuse.timeseries_ne120np4_historical_simyr1850-2015_c190904.nc</flanduse_timeseries>
 


### PR DESCRIPTION
The is to replace the old r05 landuse.timeseries file for the historical compsets 
(e.g., F20TR and WCYCL20TR), which is considered outdated (probably using CMIP5 raw data).
This was noticed after the creation of v3.0.0 tag and before the start of v3.LR.historical simulations.
The updated file is currently specified in the run script to override the default.

[non-BFB] for F20TR and WCYCL20TR tests
[NML] same as above for variable flanduse_timeseries
