### PR TITLE
Generalize cice-qc scripts to work with E3SM-Polar-Developer.sh output

### DIFF
--- a/components/mpas-seaice/testing/cice-qc/job_script.cice-qc.anvil
+++ b/components/mpas-seaice/testing/cice-qc/job_script.cice-qc.anvil
@@ -14,7 +14,11 @@ source /lcrc/soft/climate/e3sm-unified/load_latest_e3sm_unified_anvil.sh
 
 export HDF5_USE_FILE_LOCKING=FALSE
 
-export BASE=/lcrc/group/acme/ac.dcomeau/scratch/chrys/20221218.DMPAS-JRA1p5.TL319_EC30to60E2r2.chrysalis.column-package.intel/run
-export TEST=/lcrc/group/acme/ac.dcomeau/scratch/chrys/20221218.DMPAS-JRA1p5.TL319_EC30to60E2r2.chrysalis.icepack.intel/run
+# paths should end in the directory containing mpassi.hist files (run.k001 and/or run.k000 if using output from the E3SM-Polar-Developer script)
+export BASE=/lcrc/group/acme/ac.dcomeau/scratch/chrys/20221218.DMPAS-JRA1p5.TL319_EC30to60E2r2.anvil.column-package.intel/run
+export TEST=/lcrc/group/acme/ac.dcomeau/scratch/chrys/20221218.DMPAS-JRA1p5.TL319_EC30to60E2r2.anvil.icepack.intel/run
+
+#export BASE=/lcrc/group/e3sm/ac.eclare/E3SM-Polar/D12.qcbaseline.emc.qcbaseline20240413.master.E3SM-Project.anvil/run.k000
+#export TEST=/lcrc/group/e3sm/ac.eclare/E3SM-Polar/D12.qcbaseline.emc.update_icepack_20240412.master.E3SM-Project.anvil/run.k000
 
 srun -N 1 -n 1 python mpas-seaice.t-test.py $BASE $TEST

--- a/components/mpas-seaice/testing/cice-qc/job_script.cice-qc.chrysalis
+++ b/components/mpas-seaice/testing/cice-qc/job_script.cice-qc.chrysalis
@@ -14,6 +14,7 @@ source /lcrc/soft/climate/e3sm-unified/load_latest_e3sm_unified_chrysalis.sh
 
 export HDF5_USE_FILE_LOCKING=FALSE
 
+# paths should end in the directory containing mpassi.hist files (run.k001 and/or run.k000 if using output from the E3SM-Polar-Developer script)
 export BASE=/lcrc/group/acme/ac.dcomeau/scratch/chrys/20221218.DMPAS-JRA1p5.TL319_EC30to60E2r2.chrysalis.column-package.intel/run
 export TEST=/lcrc/group/acme/ac.dcomeau/scratch/chrys/20221218.DMPAS-JRA1p5.TL319_EC30to60E2r2.chrysalis.icepack.intel/run
 

--- a/components/mpas-seaice/testing/cice-qc/mpas-seaice.t-test.py
+++ b/components/mpas-seaice/testing/cice-qc/mpas-seaice.t-test.py
@@ -41,16 +41,10 @@ def gen_filenames(base_dir, test_dir):
     files and generates a list of filenames for each.
     '''
     # The path to output files for simulation 'a' (the '-bc' simulation)
-    if base_dir.endswith(('run', 'run/')):
-        path_a = base_dir
-    else:
-        path_a = base_dir + '/run/'
+    path_a = base_dir
 
     # The path to output files for simulation 'b' (the test simulation)
-    if test_dir.endswith(('run', 'run/')):
-        path_b = test_dir
-    else:
-        path_b = test_dir + '/run/'
+    path_b = test_dir
 
     # Find the number of output files to be read in
     files_a = fnmatch.filter(os.listdir(path_a+'/'), '*mpassi.hist.000*')


### PR DESCRIPTION
Original scripts assumed that the run directories being compared are named 'run'.  The E3SM-Polar-Developer scripts append the run directory names with .k000, .k001 etc for different combinations of configuration options.  This PR generalizes the cice-qc scripts to allow other run directory names, which are input by the user.  Also changed the sample paths in the anvil script to use anvil paths rather than chrysalis paths.

Changes only post-processing scripts.  Tested on a new pair of runs updating the icepack submodule (QC passed).
[BFB]