### PR TITLE
run F gh/ci only if eam/elm/coupler mods

### DIFF
--- a/.github/workflows/e3sm-gh-ci-cime-tests.yml
+++ b/.github/workflows/e3sm-gh-ci-cime-tests.yml
@@ -3,6 +3,18 @@ name: gh
 on:
   pull_request:
     branches: [ master ]
+    paths:
+      # first, yes to these
+      - 'cime_config/**'
+      - 'components/eam/**'
+      - 'components/elm/**'
+      - 'driver-moab/**'
+      - 'driver-mct/**'
+      # second, no to these
+      - '!components/eam/docs/**'
+      - '!components/eam/mkdocs.yml'
+      - '!components/elm/docs/**'
+      - '!components/elm/mkdocs.yml'
 
   workflow_dispatch:
 


### PR DESCRIPTION
In preparation to run more of gh/ci, we are limiting the F cases to run only if there are edits in EAM, ELM, or the driver-mct/driver-moab dirs, but not their docs. 