### PR TITLE
Fix logical on flds_polar driver namelist

### DIFF
--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -177,8 +177,7 @@
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
     <values match="last">
-      <value compset="_MPASO%IBPISMF_">TRUE</value>
-      <value compset="_MPASO%IBDISMF_">TRUE</value>
+      <value compset="_MPASO%[^_]*ISMF">TRUE</value>
       <value compset="_MPASSI%DIB_">TRUE</value>
     </values>
     <group>run_flags</group>

--- a/driver-moab/cime_config/config_component_e3sm.xml
+++ b/driver-moab/cime_config/config_component_e3sm.xml
@@ -177,8 +177,7 @@
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
     <values match="last">
-      <value compset="_MPASO%IBPISMF_">TRUE</value>
-      <value compset="_MPASO%IBDISMF_">TRUE</value>
+      <value compset="_MPASO%[^_]*ISMF">TRUE</value>
       <value compset="_MPASSI%DIB_">TRUE</value>
     </values>
     <group>run_flags</group>


### PR DESCRIPTION
In https://github.com/E3SM-Project/E3SM/pull/6229, the logic on the new driver namelist option `flds_polar` was not set to true in G-cases where data icebergs were not active, but ice-shelf melt fluxes were. This caused the model to crash on ocn init in `ocn_comp_mct.F`. This expands the logic for defining that namelist option to TRUE to include these cases.

[BFB]

Fixes https://github.com/E3SM-Project/E3SM/issues/6349