### PR TITLE
Turn off xpmem in OFED 5.8 on Chrysalis

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2622,6 +2622,7 @@
       <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
       <env name="OMPI_MCA_sharedfp">^lockedfile,individual</env>
+      <env name="UCX_TLS">^xpmem</env>
     </environment_variables>
     <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>


### PR DESCRIPTION
Add env var to chrysalis to turn off xpmem when using the new OFED 5.8 network drivers.
A bug in xpmem can leave nodes stuck in an unkillable state after a model crash.

[BFB]