### PR TITLE
For nvidia builds on pm-cpu, disable compiler flag to avoid Bus error

### DIFF
--- a/cime_config/machines/Depends.pm-cpu.nvidia.cmake
+++ b/cime_config/machines/Depends.pm-cpu.nvidia.cmake
@@ -10,6 +10,17 @@ if (NOT DEBUG)
   endforeach()
 endif()
 
+list(APPEND NO_STACK_ARRAY_LIST
+  eam/src/physics/cam/phys_grid_ctem.F90
+)
+
+# Remove -Mstack_arrays for this one file to avoid error (likely compiler bug)
+# As we can't remove flag, try adding -Mnostack_arrays https://github.com/E3SM-Project/E3SM/issues/6350
+# Tried with nvidia/22.7 and 23.9 on pm-cpu
+foreach(ITEM IN LISTS NO_STACK_ARRAY_LIST)
+  e3sm_add_flags("${ITEM}" " -Mnostack_arrays")
+endforeach()
+
 # Use -O2 for a few files already found to benefit from increased optimization in Intel Depends file
 set(PERFOBJS
   homme/src/share/prim_advection_base.F90


### PR DESCRIPTION
PR only affects pm-cpu with nvidia compiler.
For `eam/src/physics/cam/phys_grid_ctem.F90`, disable `-Mstack-arrays` to work-around a Bus error. Looks like a compiler bug.

Fixes #6350 

[bfb]
