### PR TITLE
Uses the Fortran linker for the Cray compiler on Frontier

### DIFF
--- a/cime_config/machines/cmake_macros/crayclang_frontier.cmake
+++ b/cime_config/machines/cmake_macros/crayclang_frontier.cmake
@@ -15,3 +15,6 @@ string(APPEND CMAKE_Fortran_FLAGS " -hipa0 -hzero")
 # -em -ef generates modulename.mod (lowercase files) to support
 # Scorpio installs
 string(APPEND CMAKE_Fortran_FLAGS " -em -ef")
+
+# to support Fortran specific compiler intrinsic functions
+set(E3SM_LINK_WITH_FORTRAN "TRUE")


### PR DESCRIPTION
* add "set(E3SM_LINK_WITH_FORTRAN "TRUE")" in crayclang_frontier.cmake

Some ELM external source files (such as sbetr/src/betr/betr_rxns/Tracer1beckBGCReactionsType.F90) use Fortran-compiler-specific intrinsic functions such as 'erfc', which require linking with the Fortran compiler.

[No baseline for Frontier yet]