### PR TITLE
Fix for bad leaf C:N ratios during transient land simulations

### DIFF
--- a/components/elm/src/biogeochem/ComputeSeedMod.F90
+++ b/components/elm/src/biogeochem/ComputeSeedMod.F90
@@ -183,16 +183,10 @@ contains
     pstorage = 0._r8
     pxfer    = 0._r8
 
-    if (tot_leaf == 0._r8 .or. ignore_current_state) then
-       if (veg_vp%evergreen(pft_type) == 1._r8) then
-          pleaf    = 1._r8
-       else
-          pstorage = 1._r8
-       end if
+    if (veg_vp%evergreen(pft_type) == 1._r8) then
+       pleaf    = 1._r8
     else
-       pleaf    = leaf        /tot_leaf
-       pstorage = leaf_storage/tot_leaf
-       pxfer    = leaf_xfer   /tot_leaf
+       pstorage = 1._r8
     end if
 
   end subroutine LeafProportions


### PR DESCRIPTION
Fix for seed initialization that caused C:N an C:P ratios to diverge for some grid cells in transient simulations.

Fixes #6368  

[non-BFB]