### PR TITLE
Delete initializing tbot to posinf to allow info_dbug level 2 and above

### DIFF
--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -526,10 +526,6 @@ subroutine phys_inidat( cam_out, pbuf2d )
     end do
     deallocate(tptr)
 
-    do lchnk=begchunk,endchunk
-       cam_out(lchnk)%tbot(:) = posinf
-    end do
-
     !
     ! 3-D fields
     !


### PR DESCRIPTION
Runs with INFO_DBUG = 2 or above would fail when coupler computes
the global summary diagnostics for IC data. The cause is TBOT is set to
positive infinity during the first stage of atm initialization. TBOT is still
initialized with 0 kelvin, which can also serve as an unphysical fillvalue.

Fixes #6307 

[BFB]