### PR TITLE
reduce the warning printing from the atm chemistry implicit solver

### DIFF
--- a/components/eam/src/chemistry/pp_chemuci_linozv3_mam5_vbs/mo_imp_sol.F90
+++ b/components/eam/src/chemistry/pp_chemuci_linozv3_mam5_vbs/mo_imp_sol.F90
@@ -527,8 +527,10 @@ contains
                 !-----------------------------------------------------------------------
                 fail_cnt = fail_cnt + 1
                 nstep = get_nstep()
-                write(iulog,'('' imp_sol: Time step '',1p,e21.13,'' failed to converge @ (lchnk,lev,col,nstep) = '',4i6)') &
-                     dt,lchnk,lev,i,nstep
+                ! to reduce the unnecessary imp_sol printing in production runs
+                ! but this message is still important for debug runs 
+                !write(iulog,'('' imp_sol: Time step '',1p,e21.13,'' failed to converge @ (lchnk,lev,col,nstep) = '',4i6)') &
+                !     dt,lchnk,lev,i,nstep
                 stp_con_cnt = 0
                 if( cut_cnt < cut_limit ) then
                    cut_cnt = cut_cnt + 1
@@ -553,7 +555,12 @@ contains
              !-----------------------------------------------------------------------
              interval_done = interval_done + dt
              if( abs( delt - interval_done ) <= .0001_r8 ) then
-                if( fail_cnt > 0 ) then
+                ! set the threshold to 2 from 0
+                ! if model resolves the convergence issue by using smaller dt,
+                ! the solver works fine
+                ! if model convergence issue can't be resolved by reducing dt twice,
+                ! developer should look at this issue
+                if( fail_cnt > 2 ) then
                    write(iulog,*) 'imp_sol : @ (lchnk,lev,col) = ',lchnk,lev,i,' failed ',fail_cnt,' times'
                 end if
                 exit time_step_loop

--- a/components/eam/src/chemistry/pp_chemuci_linozv3_mam5_vbs/mo_imp_sol.F90
+++ b/components/eam/src/chemistry/pp_chemuci_linozv3_mam5_vbs/mo_imp_sol.F90
@@ -527,7 +527,7 @@ contains
                 !-----------------------------------------------------------------------
                 fail_cnt = fail_cnt + 1
                 nstep = get_nstep()
-                ! to reduce the unnecessary imp_sol printing in production runs
+                ! reduce the frequency of warning printing
                 ! but this message is still important for debug runs 
                 !write(iulog,'('' imp_sol: Time step '',1p,e21.13,'' failed to converge @ (lchnk,lev,col,nstep) = '',4i6)') &
                 !     dt,lchnk,lev,i,nstep


### PR DESCRIPTION
**This PR is to reduce unnecessary warning messages from the atm chemistry implicit solver**.

**Background**: 
The implicit solver for atmospheric chemistry prints out warning messages every time at each location when the solver can't converge at the current delta-t. For most times, the convergence issue could be resolved by reducing the chemistry solver delta-t. Therefore, these messages can be overwhelming and bury other important messages.

**Modifications**:
For production runs, we don't need these messages if the implicit solver can converge by reducing the delta-t two times (halving delta-t each time). We removed the message at line 530, which is responsible for the excessive warnings and duplicated the information especially for the production runs. Additionally, we lift the threshold to report the convergence issue from 0 to 2.

[BFB]

**Test results**:
The test and control runs are BFB according to the 10-day simulation. There is no clear throughput change between the two simulations.
 
Control run
/lcrc/group/e3sm/ac.zke/E3SMv3_dev/20240502.v3.control.F2010-TMSOROC002-Z025-DUST113.ne120pg2_r05_icos30.chrysalis/tests/custom-22_1x10_ndays/run
 
Test run
/lcrc/group/e3sm/ac.zke/E3SMv3_dev/20240501.v3.test.F2010-TMSOROC002-Z025-DUST113.ne120pg2_r05_icos30.chrysalis/tests/custom-22_1x10_ndays/run