### PR TITLE
change the grid to r05_r05 for lnd_rof_two_way test

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -91,7 +91,7 @@ _TESTS = {
             "SMS_Ly2_P1x1.1x1_smallvilleIA.IELMCNCROP.elm-fan",
             "SMS.r05_r05.IELM.elm-topounit",
             "ERS.ELM_USRDAT.I1850ELM.elm-usrdat",
-            "ERS.f09_f09.IELM.elm-lnd_rof_2way",
+            "ERS.r05_r05.IELM.elm-lnd_rof_2way",
             "ERS.r05_r05.IELM.elm-V2_ELM_MOSART_features",
             "ERS.ELM_USRDAT.IELM.elm-surface_water_dynamics"
             )


### PR DESCRIPTION
ERS.f09_f09.IELM.elm-lnd_rof_2way in the test suits results in negative channel water storage in MOSART. 
This was raised in https://github.com/E3SM-Project/E3SM/pull/6313. 
 The reason is that f09_f09 uses different spatial resolutions in ELM and MOSART. 
This is problematic for land river two-way coupling, which requires the same grid in ELM and MOSART. 

This PR changed f09_f09 to r05_r05 for the land river two-way test, and there is no negative main channel storage.

[BFB]