### PR TITLE
Move extrasnowlayers test to e3sm_landice_developer suite

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -124,6 +124,7 @@ _TESTS = {
         "tests"   : (
             "SMS.ne30pg2_r05_EC30to60E2r2_gis20.IGELM_MLI.elm-gis20kmSMS",
             "ERS.ne30pg2_r05_EC30to60E2r2_gis20.IGELM_MLI.elm-gis20kmERS",
+            "SMS.ne30_oECv3_gis.IGELM_MLI.elm-extrasnowlayers",
             )
         },
 
@@ -256,7 +257,6 @@ _TESTS = {
         "tests" : (
             "ERS_P480_Ld5.TL319_IcoswISC30E3r5.GMPAS-JRA1p5-DIB-PISMF.mpaso-jra_1958",
             "PEM_P480_Ld5.TL319_IcoswISC30E3r5.GMPAS-JRA1p5-DIB-PISMF.mpaso-jra_1958",
-            "SMS.ne30_oECv3_gis.IGELM_MLI.elm-extrasnowlayers",
             )
         },
 


### PR DESCRIPTION
Since PR #6226 redefined the IGELM compset, the SMS.ne30_oECv3_gis.IGELM_MLI.elm-extrasnowlayers test has been failing. This moves that test from the e3sm_ocnice_extra_coverage suite to the e3sm_landice_developer suite, which is only run on platform/compiler combinations that support active MALI.

[BFB] for all current E3SM tests