### PR TITLE
For NERSC machines (including pm-cpu, pm-gpu) remove `exclusive` slurm batch directive

### DIFF
--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -291,7 +291,6 @@
       <directive> --job-name={{ job_id }}</directive>
       <directive> --nodes={{ num_nodes }}</directive>
       <directive> --output={{ job_id }}.%j </directive>
-      <directive> --exclusive </directive>
     </directives>
   </batch_system>
 


### PR DESCRIPTION
Remove the `exclusive` directive from the batch files for all NERSC machines.
The reason we want to do this: 
a) no longer needed (in fact default)
b) it allows a user to use `--qos shared` when desired (and there is no flag to turn _off_ exclusive)

Note that using `-q shared or --qos shared` allows a job to share resources with other jobs on the node.
The advantage is that jobs using shared are not charged as much as a full node.

There will be no performance impact.

[bfb]
