### PR TITLE
Add TL319_r05_IcoswISC30E3r5 configuration

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -519,6 +519,16 @@
       <mask>ARRM10to60E2r1</mask>
     </model_grid>
 
+    <model_grid alias="TL319_r05_IcoswISC30E3r5" compset="(DATM|XATM|SATM)">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">r05</grid>
+      <grid name="ocnice">IcoswISC30E3r5</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>IcoswISC30E3r5</mask>
+    </model_grid>
+
     <model_grid alias="TL319_WCAtl12to45E2r4" compset="(DATM|XATM|SATM)">
       <grid name="atm">TL319</grid>
       <grid name="lnd">TL319</grid>


### PR DESCRIPTION
Add a trigrid configuration for the IcoswISC30E3r5 ocn/ice mesh when using JRA forcing, for C- and G-cases.

[BFB]