### PR TITLE
Fix zonal mean TEM output

### DIFF
--- a/components/eam/src/physics/cam/phys_grid_ctem.F90
+++ b/components/eam/src/physics/cam/phys_grid_ctem.F90
@@ -243,7 +243,7 @@ subroutine phys_grid_ctem_diags(phys_state)
 
    character(len=*), parameter :: prefix = 'phys_grid_ctem_diags: '
 
-   real(r8) :: ps(pcols,pver,begchunk:endchunk)
+   real(r8) :: ps(pcols,begchunk:endchunk)
 
    real(r8) :: u(pcols,pver,begchunk:endchunk)
    real(r8) :: v(pcols,pver,begchunk:endchunk)

--- a/components/eam/src/physics/cam/phys_grid_ctem.F90
+++ b/components/eam/src/physics/cam/phys_grid_ctem.F90
@@ -236,6 +236,8 @@ end subroutine phys_grid_ctem_init
 !-----------------------------------------------------------------------------
 !-----------------------------------------------------------------------------
 subroutine phys_grid_ctem_diags(phys_state)
+   use physconst,     only: rair, cpair
+
    type(physics_state), intent(in) :: phys_state(begchunk:endchunk)
 
    character(len=*), parameter :: prefix = 'phys_grid_ctem_diags: '
@@ -275,7 +277,6 @@ subroutine phys_grid_ctem_diags(phys_state)
    real(r8) :: thza(nzalat,pver)
 
    real(r8) :: mbarv ! molecular weight of dry air (g/mol)
-   real(r8) :: sheight(pcols,pver) ! pressure scale height (m)
 
    if (.not.do_calc()) return
 
@@ -287,14 +288,11 @@ subroutine phys_grid_ctem_diags(phys_state)
 
       ncol = phys_state(lchnk)%ncol
 
-      ! scale height
-      sheight(:ncol,:) = phys_state(lchnk)%t(:ncol,:) * rgas / ( mbarv * grav ) ! meters
-
       ! potential temperature
-      theta(:ncol,:,lchnk) = phys_state(lchnk)%t(:ncol,:) * phys_state(lchnk)%exner(:ncol,:)
+      theta(:ncol,:,lchnk) = phys_state(lchnk)%t(:ncol,:) * ( 1000e2 / phys_state(lchnk)%pmid(:ncol,:) )**(rair/cpair)
 
-      ! vertical velocity
-      w(:ncol,:,lchnk) = -sheight(:ncol,:) *  phys_state(lchnk)%omega(:ncol,:) / phys_state(lchnk)%pmid(:ncol,:)
+      ! vertical pressure velocity
+      w(:ncol,:,lchnk) = phys_state(lchnk)%omega(:ncol,:)
 
       u(:ncol,:,lchnk) =  phys_state(lchnk)%u(:ncol,:)
       v(:ncol,:,lchnk) =  phys_state(lchnk)%v(:ncol,:)

--- a/components/eam/src/physics/cam/phys_grid_ctem.F90
+++ b/components/eam/src/physics/cam/phys_grid_ctem.F90
@@ -282,10 +282,6 @@ subroutine phys_grid_ctem_diags(phys_state)
    real(r8) :: wza(nzalat,pver)
    real(r8) :: thza(nzalat,pver)
 
-   ! In CESM/WACCM the variable mbarv is provided by the "air_composition" 
-   ! module, which is not in E3SM, so we just use a rough approximation
-   real(r8) :: mbarv = 28.97 ! molecular weight of dry air (g/mol)
-
    if (.not.do_calc()) return
 
    do lchnk = begchunk,endchunk

--- a/components/eam/src/physics/cam/phys_grid_ctem.F90
+++ b/components/eam/src/physics/cam/phys_grid_ctem.F90
@@ -385,7 +385,7 @@ subroutine phys_grid_ctem_diags(phys_state)
    function zmean_fld_2D( fld ) result(fldzm)
       real(r8), intent(in) :: fld(pcols,begchunk:endchunk)
       real(r8) :: fldzm(pcols,begchunk:endchunk)
-      real(r8) :: Zonal_Bamp2d(nzmbas,pver)
+      real(r8) :: Zonal_Bamp2d(nzmbas)
       call ZMobj%calc_amps(fld,Zonal_Bamp2d)
       call ZMobj%eval_grid(Zonal_Bamp2d,fldzm)
    end function zmean_fld_2D

--- a/components/eam/src/physics/cam/phys_grid_ctem.F90
+++ b/components/eam/src/physics/cam/phys_grid_ctem.F90
@@ -22,7 +22,7 @@ module phys_grid_ctem
 use shr_kind_mod,  only: r8 => shr_kind_r8
 use ppgrid,        only: begchunk, endchunk, pcols, pver
 use physics_types, only: physics_state
-use cam_history,   only: addfld, outfld
+use cam_history,   only: addfld, outfld, horiz_only
 use zonal_mean_mod,only: ZonalAverage_t, ZonalMean_t
 use physconst,     only: pi
 use cam_logfile,   only: iulog
@@ -221,7 +221,7 @@ subroutine phys_grid_ctem_init
 
    if (.not.do_tem_diags) return
 
-   call addfld ('PSzm', (/'lev'/), 'A','m s-1',  'Zonal-Mean surface pressure', gridname='ctem_zavg_phys' )
+   call addfld ('PSzm',horiz_only, 'A','m s-1',  'Zonal-Mean surface pressure', gridname='ctem_zavg_phys' )
    call addfld ('Uzm',  (/'lev'/), 'A','m s-1',  'Zonal-Mean zonal wind', gridname='ctem_zavg_phys' )
    call addfld ('Vzm',  (/'lev'/), 'A','m s-1',  'Zonal-Mean meridional wind', gridname='ctem_zavg_phys' )
    call addfld ('Wzm',  (/'lev'/), 'A','m s-1',  'Zonal-Mean vertical wind', gridname='ctem_zavg_phys' )


### PR DESCRIPTION
This provides some minor fixes for the recent zonal mean output capability. The most notable change is in how the zonal mean vertical velocity and theta are modified.

[BFB] (except for ZM variables) 