### PR TITLE
Add four new joint histograms to the MODIS simulator

### DIFF
--- a/components/eam/src/physics/cam/cospsimulator_intr.F90
+++ b/components/eam/src/physics/cam/cospsimulator_intr.F90
@@ -1062,22 +1062,22 @@ CONTAINS
        call addfld ('CLMODIS',(/'cosp_tau_modis','cosp_prs      '/),'A','%','MODIS Cloud Area Fraction',            &
             flag_xyfill=.true., fill_value=R_UNDEF)
        ! float clliqmodis ( time, plev, tau, loc )
-       call addfld ('CLLIQMODIS',(/'cosp_tau_modis','cosp_prs      '/),'A','%','MODIS Cloud Area Fraction',            &
+       call addfld ('CLLIQMODIS',(/'cosp_tau_modis','cosp_prs      '/),'A','%','MODIS Cloud-Fraction Joint Histogram of Cloud-top Pressure vs Cloud Optical Thickness for Liquid-topped Clouds', &
             flag_xyfill=.true., fill_value=R_UNDEF)
        ! float clicemodis ( time, plev, tau, loc )
-       call addfld ('CLICEMODIS',(/'cosp_tau_modis','cosp_prs      '/),'A','%','MODIS Cloud Area Fraction',            &
+       call addfld ('CLICEMODIS',(/'cosp_tau_modis','cosp_prs      '/),'A','%','MODIS Cloud-Fraction Joint Histogram of Cloud-top Pressure vs Cloud Optical Thickness for Ice-topped Clouds', &
             flag_xyfill=.true., fill_value=R_UNDEF)
        ! float clrimodis ( time, plev, tau, loc )
-       call addfld ('CLRIMODIS',(/'cosp_tau_modis','cosp_reffice  '/),'A','%','MODIS Cloud Area Fraction',            &
+       call addfld ('CLRIMODIS',(/'cosp_tau_modis','cosp_reffice  '/),'A','%','MODIS Cloud-Fraction Joint Histogram of Cloud Optical Thickness vs Cloud Particle Size for Ice-topped Clouds', &
             flag_xyfill=.true., fill_value=R_UNDEF)
        ! float clrlmodis ( time, plev, tau, loc )
-       call addfld ('CLRLMODIS',(/'cosp_tau_modis','cosp_reffliq  '/),'A','%','MODIS Cloud Area Fraction',            &
+       call addfld ('CLRLMODIS',(/'cosp_tau_modis','cosp_reffliq  '/),'A','%','MODIS Cloud-Fraction Joint Histogram of Cloud Optical Thickness vs Cloud Particle Size for Liquid-topped Clouds', &
             flag_xyfill=.true., fill_value=R_UNDEF)
        ! float iwprimodis ( time, reffice, iwp, loc )
-       call addfld ('IWPRIMODIS',(/'cosp_iwp_modis','cosp_reffice  '/),'A','%','MODIS Cloud Area Fraction',            &
+       call addfld ('IWPRIMODIS',(/'cosp_iwp_modis','cosp_reffice  '/),'A','%','MODIS Cloud-Fraction Joint Histogram of Cloud Water Path vs Cloud Particle Size for Ice-topped Clouds', &
             flag_xyfill=.true., fill_value=R_UNDEF)
        ! float lwprlmodis ( time, reffliq, lwp, loc )
-       call addfld ('LWPRLMODIS',(/'cosp_lwp_modis','cosp_reffliq  '/),'A','%','MODIS Cloud Area Fraction',            &
+       call addfld ('LWPRLMODIS',(/'cosp_lwp_modis','cosp_reffliq  '/),'A','%','MODIS Cloud-Fraction Joint Histogram of Cloud Water Path vs Cloud Particle Size for Liquid-topped Clouds', &
             flag_xyfill=.true., fill_value=R_UNDEF)
        
        !! add MODIS output to history file specified by the CAM namelist variable cosp_histfile_num

--- a/components/eam/src/physics/cam/cospsimulator_intr.F90
+++ b/components/eam/src/physics/cam/cospsimulator_intr.F90
@@ -29,6 +29,8 @@ module cospsimulator_intr
        numMODISTauBins, numMODISPresBins, numMODISReffIceBins, numMODISReffLiqBins,    &
        numISCCPTauBins, numISCCPPresBins, numMISRTauBins, reffICE_binEdges,            &
        reffICE_binCenters, reffLIQ_binEdges, reffLIQ_binCenters, LIDAR_NTYPE,          &
+       numMODISLWPBins, numMODISIWPBins, LWP_binCenters, LWP_binEdges,                 &
+       IWP_binCenters, IWP_binEdges,                                                   &
        LIDAR_PHASE_TEMP,LIDAR_PHASE_TEMP_BNDS, &
        nCloudsatPrecipClass, &
        nsza_cosp         => PARASOL_NREFL,       &
@@ -97,6 +99,10 @@ module cospsimulator_intr
   real(r8), target :: reffLIQ_binEdges_cosp(2,numMODISReffLiqBins)
   real(r8), target :: reffICE_binCenters_cosp(numMODISReffIceBins)
   real(r8), target :: reffLIQ_binCenters_cosp(numMODISReffLiqBins)
+  real(r8), target :: LWP_binEdges_cosp(2,numMODISLWPBins)
+  real(r8), target :: IWP_binEdges_cosp(2,numMODISIWPBins)
+  real(r8), target :: LWP_binCenters_cosp(numMODISLWPBins)
+  real(r8), target :: IWP_binCenters_cosp(numMODISIWPBins)
 
   real(r8) :: htmlmid_cosp(nhtml_cosp)                     ! Model level height midpoints for output
   integer  :: prstau_cosp(nprs_cosp*ntau_cosp)             ! ISCCP mixed output dimension index
@@ -311,7 +317,11 @@ CONTAINS
     reffICE_binEdges_cosp   = reffICE_binEdges
     reffLIQ_binCenters_cosp = reffLIQ_binCenters
     reffLIQ_binEdges_cosp   = reffLIQ_binEdges
-                                  
+    LWP_binCenters_cosp     = LWP_binCenters
+    LWP_binEdges_cosp       = LWP_binEdges
+    IWP_binCenters_cosp     = IWP_binCenters
+    IWP_binEdges_cosp       = IWP_binEdges
+
     ! Initialize the distributional parameters for hydrometeors in radar simulator. In COSPv1.4, this was declared in
     ! cosp_defs.f.
     if (cloudsat_micro_scheme == 'MMF_v3.5_two_moment')  then
@@ -676,6 +686,12 @@ CONTAINS
        call add_hist_coord('cosp_reffliq',numMODISReffLiqBins,                 &
             'COSP Mean MODIS effective radius (liquid)', 'm', reffLIQ_binCenters_cosp, &
             bounds_name='cosp_reffliq_bnds',bounds=reffLIQ_binEdges_cosp)      
+       call add_hist_coord('cosp_iwp_modis',numMODISIWPBins,                 &
+            'COSP Mean MODIS ice water path (ice)', 'kg/m2', IWP_binCenters_cosp, &
+            bounds_name='cosp_iwp_modis_bnds',bounds=IWP_binEdges_cosp)
+       call add_hist_coord('cosp_lwp_modis',numMODISLWPBins,                 &
+            'COSP Mean MODIS liquid water path (liquid)', 'kg/m2', LWP_binCenters_cosp, &
+            bounds_name='cosp_lwp_modis_bnds',bounds=LWP_binEdges_cosp)
     end if
     
 #endif
@@ -1045,11 +1061,23 @@ CONTAINS
        ! float clmodis ( time, plev, tau, loc )
        call addfld ('CLMODIS',(/'cosp_tau_modis','cosp_prs      '/),'A','%','MODIS Cloud Area Fraction',            &
             flag_xyfill=.true., fill_value=R_UNDEF)
+       ! float clliqmodis ( time, plev, tau, loc )
+       call addfld ('CLLIQMODIS',(/'cosp_tau_modis','cosp_prs      '/),'A','%','MODIS Cloud Area Fraction',            &
+            flag_xyfill=.true., fill_value=R_UNDEF)
+       ! float clicemodis ( time, plev, tau, loc )
+       call addfld ('CLICEMODIS',(/'cosp_tau_modis','cosp_prs      '/),'A','%','MODIS Cloud Area Fraction',            &
+            flag_xyfill=.true., fill_value=R_UNDEF)
        ! float clrimodis ( time, plev, tau, loc )
        call addfld ('CLRIMODIS',(/'cosp_tau_modis','cosp_reffice  '/),'A','%','MODIS Cloud Area Fraction',            &
             flag_xyfill=.true., fill_value=R_UNDEF)
        ! float clrlmodis ( time, plev, tau, loc )
        call addfld ('CLRLMODIS',(/'cosp_tau_modis','cosp_reffliq  '/),'A','%','MODIS Cloud Area Fraction',            &
+            flag_xyfill=.true., fill_value=R_UNDEF)
+       ! float iwprimodis ( time, reffice, iwp, loc )
+       call addfld ('IWPRIMODIS',(/'cosp_iwp_modis','cosp_reffice  '/),'A','%','MODIS Cloud Area Fraction',            &
+            flag_xyfill=.true., fill_value=R_UNDEF)
+       ! float lwprlmodis ( time, reffliq, lwp, loc )
+       call addfld ('LWPRLMODIS',(/'cosp_lwp_modis','cosp_reffliq  '/),'A','%','MODIS Cloud Area Fraction',            &
             flag_xyfill=.true., fill_value=R_UNDEF)
        
        !! add MODIS output to history file specified by the CAM namelist variable cosp_histfile_num
@@ -1076,6 +1104,8 @@ CONTAINS
        call add_default ('CLMODIS',cosp_histfile_num,' ')
        call add_default ('CLRIMODIS',cosp_histfile_num,' ')
        call add_default ('CLRLMODIS',cosp_histfile_num,' ')
+       call add_default ('IWPRIMODIS',cosp_histfile_num,' ')
+       call add_default ('LWPRLMODIS',cosp_histfile_num,' ')
     end if
     
     ! SUB-COLUMN OUTPUT
@@ -1369,7 +1399,7 @@ CONTAINS
     integer, parameter :: nf_calipso=28                  ! number of calipso outputs
     integer, parameter :: nf_isccp=9                     ! number of isccp outputs
     integer, parameter :: nf_misr=1                      ! number of misr outputs
-    integer, parameter :: nf_modis=23                    ! number of modis outputs
+    integer, parameter :: nf_modis=27                    ! number of modis outputs
     
     ! Cloudsat outputs
     character(len=max_fieldname_len),dimension(nf_radar),parameter ::          &
@@ -1409,7 +1439,7 @@ CONTAINS
                        'CLLMODIS    ','TAUTMODIS   ','TAUWMODIS   ','TAUIMODIS   ','TAUTLOGMODIS',&
                        'TAUWLOGMODIS','TAUILOGMODIS','REFFCLWMODIS','REFFCLIMODIS',&
                        'PCTMODIS    ','LWPMODIS    ','IWPMODIS    ','CLMODIS     ','CLRIMODIS   ',&
-                       'CLRLMODIS   '/)
+                       'CLRLMODIS   ','LWPRLMODIS  ','IWPRIMODIS  ','CLLIQMODIS  ','CLICEMODIS  '/)
     
     logical :: run_radar(nf_radar,pcols)                 ! logical telling you if you should run radar simulator
     logical :: run_calipso(nf_calipso,pcols)                 ! logical telling you if you should run calipso simulator
@@ -1569,10 +1599,18 @@ CONTAINS
     real(r8) :: iwpmodis(pcols)
     real(r8) :: clmodis_cam(pcols,ntau_cosp_modis*nprs_cosp)
     real(r8) :: clmodis(pcols,ntau_cosp_modis,nprs_cosp)
+    real(r8) :: clliqmodis_cam(pcols,ntau_cosp_modis*nprs_cosp)
+    real(r8) :: clliqmodis(pcols,ntau_cosp_modis,nprs_cosp)
+    real(r8) :: clicemodis_cam(pcols,ntau_cosp_modis*nprs_cosp)
+    real(r8) :: clicemodis(pcols,ntau_cosp_modis,nprs_cosp)
     real(r8) :: clrimodis_cam(pcols,ntau_cosp*numMODISReffIceBins)
     real(r8) :: clrimodis(pcols,ntau_cosp,numMODISReffIceBins)
     real(r8) :: clrlmodis_cam(pcols,ntau_cosp*numMODISReffLiqBins)
     real(r8) :: clrlmodis(pcols,ntau_cosp,numMODISReffLiqBins)
+    real(r8) :: iwprimodis_cam(pcols,numMODISIWPBins*numMODISReffIceBins)
+    real(r8) :: iwprimodis(pcols,numMODISIWPBins,numMODISReffIceBins)
+    real(r8) :: lwprlmodis_cam(pcols,numMODISLWPBins*numMODISReffLiqBins)
+    real(r8) :: lwprlmodis(pcols,numMODISLWPBins,numMODISReffLiqBins)
     !real(r8) :: tau067_out(pcols,nhtml_cosp*nscol_cosp),emis11_out(pcols,nhtml_cosp*nscol_cosp)
     real(r8),dimension(pcols,nhtml_cosp*nscol_cosp) :: &
          tau067_out,emis11_out,fracliq_out,cal_betatot,cal_betatot_ice, &
@@ -1710,10 +1748,18 @@ CONTAINS
     iwpmodis(1:pcols)                                = R_UNDEF
     clmodis_cam(1:pcols,1:ntau_cosp_modis*nprs_cosp) = R_UNDEF
     clmodis(1:pcols,1:ntau_cosp_modis,1:nprs_cosp)   = R_UNDEF
+    clliqmodis_cam(1:pcols,1:ntau_cosp_modis*nprs_cosp) = R_UNDEF
+    clliqmodis(1:pcols,1:ntau_cosp_modis,1:nprs_cosp)   = R_UNDEF
+    clicemodis_cam(1:pcols,1:ntau_cosp_modis*nprs_cosp) = R_UNDEF
+    clicemodis(1:pcols,1:ntau_cosp_modis,1:nprs_cosp)   = R_UNDEF
     clrimodis_cam(1:pcols,1:ntau_cosp_modis*numMODISReffIceBins) = R_UNDEF ! +cosp2
     clrimodis(1:pcols,1:ntau_cosp_modis,1:numMODISReffIceBins)   = R_UNDEF ! +cosp2
     clrlmodis_cam(1:pcols,1:ntau_cosp_modis*numMODISReffLiqBins) = R_UNDEF ! +cosp2
     clrlmodis(1:pcols,1:ntau_cosp_modis,1:numMODISReffLiqBins)   = R_UNDEF ! +cosp2
+    iwprimodis_cam(1:pcols,1:numMODISIWPBins*numMODISReffIceBins) = R_UNDEF ! +cosp2
+    iwprimodis(1:pcols,1:numMODISIWPBins,1:numMODISReffIceBins)   = R_UNDEF ! +cosp2
+    lwprlmodis_cam(1:pcols,1:numMODISLWPBins*numMODISReffLiqBins) = R_UNDEF ! +cosp2
+    lwprlmodis(1:pcols,1:numMODISLWPBins,1:numMODISReffLiqBins)   = R_UNDEF ! +cosp2
     tau067_out(1:pcols,1:nhtml_cosp*nscol_cosp)      = R_UNDEF ! +cosp2
     emis11_out(1:pcols,1:nhtml_cosp*nscol_cosp)      = R_UNDEF ! +cosp2
     asym34_out(1:pcols,1:nhtml_cosp*nscol_cosp)      = R_UNDEF ! +cosp2
@@ -2280,6 +2326,12 @@ CONTAINS
                 where(cam_sunlit(1:ncol) .eq. 0)
                    cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure(1:ncol,i,k) = R_UNDEF 
                 end where
+                where(cam_sunlit(1:ncol) .eq. 0)
+                   cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq(1:ncol,i,k) = R_UNDEF 
+                end where
+                where(cam_sunlit(1:ncol) .eq. 0)
+                   cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice(1:ncol,i,k) = R_UNDEF 
+                end where
              enddo
              do k=1,numMODISReffIceBins
                 where(cam_sunlit(1:ncol) .eq. 0)
@@ -2291,6 +2343,20 @@ CONTAINS
                    cospOUT%modis_Optical_Thickness_vs_ReffLIQ(1:ncol,i,k) = R_UNDEF
                 end where
              enddo
+          enddo !loop i
+          do i=1,numMODISIWPBins
+             do k=1,numMODISReffIceBins
+                where(cam_sunlit(1:ncol) .eq. 0)
+                   cospOUT%modis_IWP_vs_ReffICE(1:ncol,i,k) = R_UNDEF
+                end where
+             end do
+          enddo
+          do i=1,numMODISLWPBins
+             do k=1,numMODISReffLiqBins
+                where(cam_sunlit(1:ncol) .eq. 0)
+                   cospOUT%modis_LWP_vs_ReffLIQ(1:ncol,i,k) = R_UNDEF
+                end where
+             end do
           enddo
        end if
     end if
@@ -2424,8 +2490,12 @@ CONTAINS
        lwpmodis(1:ncol)     = cospOUT%modis_Liquid_Water_Path_Mean
        iwpmodis(1:ncol)     = cospOUT%modis_Ice_Water_Path_Mean
        clmodis(1:ncol,1:ntau_cosp_modis,1:nprs_cosp)  = cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure 
+       clliqmodis(1:ncol,1:ntau_cosp_modis,1:nprs_cosp)  = cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq 
+       clicemodis(1:ncol,1:ntau_cosp_modis,1:nprs_cosp)  = cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice 
        clrimodis(1:ncol,1:ntau_cosp_modis,1:numMODISReffIceBins) = cospOUT%modis_Optical_Thickness_vs_ReffICE
        clrlmodis(1:ncol,1:ntau_cosp_modis,1:numMODISReffLiqBins) = cospOUT%modis_Optical_Thickness_vs_ReffLIQ
+       iwprimodis(1:ncol,1:numMODISIWPBins,1:numMODISReffIceBins) = cospOUT%modis_IWP_vs_ReffICE
+       lwprlmodis(1:ncol,1:numMODISLWPBins,1:numMODISReffLiqBins) = cospOUT%modis_LWP_vs_ReffLIQ
     endif
     
     ! Use high-dimensional output to populate CAM collapsed output variables
@@ -2484,6 +2554,20 @@ CONTAINS
                 clmodis_cam(i,ipt) = clmodis(i,it,ip)
              end do
           end do
+          ! CAM clliqmodis
+          do ip=1,nprs_cosp
+             do it=1,ntau_cosp_modis
+                ipt=(ip-1)*ntau_cosp_modis+it
+                clliqmodis_cam(i,ipt) = clliqmodis(i,it,ip)
+             end do
+          end do
+          ! CAM clicemodis
+          do ip=1,nprs_cosp
+             do it=1,ntau_cosp_modis
+                ipt=(ip-1)*ntau_cosp_modis+it
+                clicemodis_cam(i,ipt) = clicemodis(i,it,ip)
+             end do
+          end do
           ! CAM clrimodis
           do ip=1,numMODISReffIceBins
              do it=1,ntau_cosp_modis
@@ -2496,6 +2580,20 @@ CONTAINS
              do it=1,ntau_cosp_modis
                 ipt=(ip-1)*ntau_cosp_modis+it
                 clrlmodis_cam(i,ipt) = clrlmodis(i,it,ip)
+             end do
+          end do
+          ! CAM iwprimodis
+          do ip=1,numMODISReffIceBins
+             do it=1,numMODISIWPBins
+                ipt=(ip-1)*numMODISIWPBins+it
+                iwprimodis_cam(i,ipt) = iwprimodis(i,it,ip)
+             end do
+          end do
+          ! CAM lwprlmodis
+          do ip=1,numMODISReffLiqBins
+             do it=1,numMODISLWPBins
+                ipt=(ip-1)*numMODISLWPBins+it
+                lwprlmodis_cam(i,ipt) = lwprlmodis(i,it,ip)
              end do
           end do
        endif
@@ -2824,8 +2922,12 @@ CONTAINS
        call outfld('IWPMODIS',iwpmodis    ,pcols,lchnk)
        
        call outfld('CLMODIS',clmodis_cam  ,pcols,lchnk) 
+       call outfld('CLLIQMODIS',clliqmodis_cam  ,pcols,lchnk) 
+       call outfld('CLICEMODIS',clicemodis_cam  ,pcols,lchnk) 
        call outfld('CLRIMODIS',clrimodis_cam  ,pcols,lchnk) 
        call outfld('CLRLMODIS',clrlmodis_cam  ,pcols,lchnk) 
+       call outfld('IWPRIMODIS',iwprimodis_cam  ,pcols,lchnk) 
+       call outfld('LWPRLMODIS',lwprlmodis_cam  ,pcols,lchnk) 
     end if
     
     ! SUB-COLUMN OUTPUT
@@ -3456,8 +3558,12 @@ CONTAINS
        allocate(x%modis_Liquid_Water_Path_Mean(Npoints))
        allocate(x%modis_Ice_Water_Path_Mean(Npoints))
        allocate(x%modis_Optical_Thickness_vs_Cloud_Top_Pressure(nPoints,numModisTauBins,numMODISPresBins))
+       allocate(x%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq(nPoints,numModisTauBins,numMODISPresBins))
+       allocate(x%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice(nPoints,numModisTauBins,numMODISPresBins))
        allocate(x%modis_Optical_thickness_vs_ReffLIQ(nPoints,numMODISTauBins,numMODISReffLiqBins))   
        allocate(x%modis_Optical_Thickness_vs_ReffICE(nPoints,numMODISTauBins,numMODISReffIceBins))
+       allocate(x%modis_LWP_vs_ReffLIQ(nPoints,numMODISLWPBins,numMODISReffLiqBins))   
+       allocate(x%modis_IWP_vs_ReffICE(nPoints,numMODISIWPBins,numMODISReffIceBins))
     endif
     
     ! CALIPSO simulator
@@ -3778,6 +3884,14 @@ CONTAINS
         deallocate(y%modis_Optical_Thickness_vs_Cloud_Top_Pressure)     
         nullify(y%modis_Optical_Thickness_vs_Cloud_Top_Pressure)     
      endif
+     if (associated(y%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq))        then
+        deallocate(y%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq)     
+        nullify(y%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq)     
+     endif
+     if (associated(y%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice))        then
+        deallocate(y%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice)     
+        nullify(y%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice)     
+     endif
      if (associated(y%modis_Optical_thickness_vs_ReffLIQ))                   then
         deallocate(y%modis_Optical_thickness_vs_ReffLIQ)
         nullify(y%modis_Optical_thickness_vs_ReffLIQ)
@@ -3785,6 +3899,14 @@ CONTAINS
      if (associated(y%modis_Optical_thickness_vs_ReffICE))                   then
         deallocate(y%modis_Optical_thickness_vs_ReffICE)
         nullify(y%modis_Optical_thickness_vs_ReffICE)
+     endif
+     if (associated(y%modis_LWP_vs_ReffLIQ))                   then
+        deallocate(y%modis_LWP_vs_ReffLIQ)
+        nullify(y%modis_LWP_vs_ReffLIQ)
+     endif
+     if (associated(y%modis_IWP_vs_ReffICE))                   then
+        deallocate(y%modis_IWP_vs_ReffICE)
+        nullify(y%modis_IWP_vs_ReffICE)
      endif
      if (associated(y%calipso_cldtype)) then
         deallocate(y%calipso_cldtype)

--- a/components/eam/src/physics/cosp2/Cosp.cmake
+++ b/components/eam/src/physics/cosp2/Cosp.cmake
@@ -5,7 +5,7 @@ set(COSP_SOURCES
    eam/src/physics/cosp2/cosp_kinds.F90
    eam/src/physics/cosp2/external/src/cosp_constants.F90
    eam/src/physics/cosp2/external/src/simulator/cosp_cloudsat_interface.F90
-   eam/src/physics/cosp2/external/src/cosp_config.F90
+   eam/src/physics/cosp2/local/cosp_config.F90
    eam/src/physics/cosp2/local/cosp.F90
    eam/src/physics/cosp2/external/src/cosp_stats.F90
    eam/src/physics/cosp2/external/src/simulator/quickbeam/quickbeam.F90
@@ -19,7 +19,7 @@ set(COSP_SOURCES
    eam/src/physics/cosp2/external/src/simulator/cosp_misr_interface.F90
    eam/src/physics/cosp2/external/src/simulator/MISR_simulator/MISR_simulator.F90
    eam/src/physics/cosp2/external/src/simulator/cosp_modis_interface.F90
-   eam/src/physics/cosp2/external/src/simulator/MODIS_simulator/modis_simulator.F90
+   eam/src/physics/cosp2/local/modis_simulator.F90
    eam/src/physics/cosp2/external/src/simulator/cosp_rttov_interfaceSTUB.F90
    eam/src/physics/cosp2/external/src/simulator/rttov/cosp_rttovSTUB.F90
    eam/src/physics/cosp2/external/src/simulator/cosp_parasol_interface.F90

--- a/components/eam/src/physics/cosp2/local/cosp.F90
+++ b/components/eam/src/physics/cosp2/local/cosp.F90
@@ -30,6 +30,8 @@
 ! May 2015- D. Swales - Original version
 ! Mar 2018- R. Guzman - Added OPAQ diagnostics and GLID simulator
 ! Apr 2018- R. Guzman - Added ATLID simulator
+! Nov 2018- T. Michibata - Added CloudSat+MODIS Warmrain Diagnostics
+! Mar 2024- C. Wall - Added MODIS joint-histogram diagnostics
 !
 ! %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -39,9 +41,12 @@ MODULE MOD_COSP
   USE MOD_COSP_CONFIG,             ONLY: R_UNDEF,PARASOL_NREFL,LIDAR_NCAT,LIDAR_NTYPE, SR_BINS,&
                                          N_HYDRO,RTTOV_MAX_CHANNELS,numMISRHgtBins,      &
                                          cloudsat_DBZE_BINS,LIDAR_NTEMP,calipso_histBsct,&
-                                         use_vgrid,Nlvgrid,vgrid_zu,vgrid_zl,vgrid_z,    &
+                                         use_vgrid,Nlvgrid,vgrid_zu,vgrid_zl,vgrid_z,dz, &
+                                         WR_NREGIME, CFODD_NCLASS,                       &
+                                         CFODD_NDBZE,   CFODD_NICOD,                     &
                                          numMODISTauBins,numMODISPresBins,               &
                                          numMODISReffIceBins,numMODISReffLiqBins,        &
+                                         numMODISLWPBins,numMODISIWPBins,                &
                                          numISCCPTauBins,numISCCPPresBins,numMISRTauBins,&
                                          ntau,modis_histTau,tau_binBounds,               &
                                          modis_histTauEdges,tau_binEdges,nCloudsatPrecipClass,&
@@ -63,7 +68,8 @@ MODULE MOD_COSP
   USE MOD_MODIS_SIM,                 ONLY: modis_subcolumn,       modis_column
   USE MOD_PARASOL,                   ONLY: parasol_subcolumn,     parasol_column
   use mod_cosp_rttov,                ONLY: rttov_column
-  USE MOD_COSP_STATS,                ONLY: COSP_LIDAR_ONLY_CLOUD,COSP_CHANGE_VERTICAL_GRID
+  USE MOD_COSP_STATS,                ONLY: COSP_LIDAR_ONLY_CLOUD,COSP_CHANGE_VERTICAL_GRID, &
+                                           COSP_DIAG_WARMRAIN
 
   IMPLICIT NONE
 
@@ -86,8 +92,10 @@ MODULE MOD_COSP
           pfull,               & ! Pressure                               (Pa)
           phalf,               & ! Pressure at half-levels                (Pa)
           qv,                  & ! Specific humidity                      (kg/kg)
-          hgt_matrix,          & ! Height of hydrometeors                 (km)
-          hgt_matrix_half        ! Height of hydrometeors at half levels  (km)
+          hgt_matrix,          & ! Height of atmosphere layer             (km)
+          hgt_matrix_half        ! Height of bottom interface of atm layer(km)
+                                 ! First level contains the bottom of the top layer.
+                                 ! Last level contains the bottom of the surface layer.
 
      real(wp),allocatable,dimension(:) :: &
           land,                & ! Land/Sea mask                          (0-1)
@@ -284,9 +292,21 @@ MODULE MOD_COSP
           modis_Optical_Thickness_vs_ReffICE => null(),            & ! Tau/ReffICE joint histogram
           modis_Optical_Thickness_vs_ReffLIQ => null()               ! Tau/ReffLIQ joint histogram
 
+     real(wp),pointer,dimension(:,:,:) ::  &
+          modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq => null(), & ! Tau/Pressure Liq joint histogram
+          modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice => null(), & ! Tau/Pressure Ice joint histogram
+          modis_LWP_vs_ReffLIQ => null(), &                              ! LWP/ReffLIQ joint histogram
+          modis_IWP_vs_ReffICE => null()                                 ! IWP/ReffICE joint histogram
+
      ! RTTOV outputs
      real(wp),pointer :: &
           rttov_tbs(:,:) => null() ! Brightness Temperature
+
+     ! Joint CloudSat+MODIS simulators outputs
+     real(wp),dimension(:,:,:,:),pointer :: &
+          cfodd_ntotal => null()       ! # of CFODD (Npoints,CFODD_NDBZE,CFODD_NICOD,CFODD_NCLASS)
+     real(wp),dimension(:,:),    pointer :: &
+          wr_occfreq_ntotal => null()  ! # of nonprecip/drizzle/precip (Npoints,WR_NREGIME)
 
   end type cosp_outputs
 
@@ -318,6 +338,7 @@ CONTAINS
     ! Local variables
     integer :: &
          i,icol,ij,ik,nError
+    integer :: k
     integer,target :: &
          Npoints
     logical :: &
@@ -340,15 +361,16 @@ CONTAINS
          Lmodis_column,        & ! On/Off switch for column MODIS simulator
          Lrttov_column,        & ! On/Off switch for column RTTOV simulator (not used)
          Lradar_lidar_tcc,     & ! On/Off switch from joint Calipso/Cloudsat product
-         Lcloudsat_tcc,       & !
-         Lcloudsat_tcc2,      & !         
-         Llidar_only_freq_cloud  ! On/Off switch from joint Calipso/Cloudsat product
+         Lcloudsat_tcc,        & !
+         Lcloudsat_tcc2,       & !         
+         Llidar_only_freq_cloud, & ! On/Off switch from joint Calipso/Cloudsat product
+         Lcloudsat_modis_wr      ! On/Off switch from joint CloudSat/MODIS warm rain product
     logical :: &
          ok_lidar_cfad    = .false., &
          ok_lidar_cfad_grLidar532 = .false., & 
          ok_lidar_cfad_atlid = .false., &
          lrttov_cleanUp   = .false.
-    
+
     integer, dimension(:,:),allocatable  :: &
          modisRetrievedPhase,isccpLEVMATCH
     real(wp), dimension(:),  allocatable  :: &
@@ -365,13 +387,21 @@ CONTAINS
          grLidar532_beta_mol,atlid_beta_mol 
     REAL(WP), dimension(:,:,:),allocatable :: &
          modisJointHistogram,modisJointHistogramIce,modisJointHistogramLiq,     &
+         modisJointHistogram_CtpCodLiq,modisJointHistogram_CtpCodIce,           &
+         modisJointHistogram_LwpRefLiq,modisJointHistogram_IwpRefIce,           &
          calipso_beta_tot,calipso_betaperp_tot, cloudsatDBZe,parasolPix_refl,   &
          grLidar532_beta_tot,atlid_beta_tot,cloudsatZe_non
     real(wp),dimension(:),allocatable,target :: &
          out1D_1,out1D_2,out1D_3,out1D_4,out1D_5,out1D_6,out1D_7,out1D_8,       &
          out1D_9,out1D_10,out1D_11,out1D_12 
     real(wp),dimension(:,:,:),allocatable :: &
-       betamol_in,betamoli,pnormi,ze_toti,ze_noni
+       betamol_in,betamoli,pnormi,ze_toti
+    real(wp),dimension(:,:,:),allocatable :: &
+         t_in,tempI,frac_outI      ! subscript "I": vertical interpolation (use_vgrid=.true.)
+    real(wp), allocatable ::     &
+         zlev   (:,:),           & ! altitude (used only when use_vgrid=.true.)
+         cfodd_ntotal (:,:,:,:), & ! # of total samples for CFODD (Npoints,CFODD_NDBZE,CFODD_NICOD,CFODD_NCLASS)
+         wr_occfreq_ntotal(:,:)    ! # of warm-rain (nonprecip/drizzle/precip) (Npoints,WR_NREGIME)
 
     ! Initialize error reporting for output
     cosp_simulator(:)=''
@@ -417,6 +447,7 @@ CONTAINS
     Llidar_only_freq_cloud = .false.
     Lcloudsat_tcc       = .false.
     Lcloudsat_tcc2      = .false.
+    Lcloudsat_modis_wr  = .false.
 
     ! CLOUDSAT subcolumn
     if (associated(cospOUT%cloudsat_Ze_tot)) Lcloudsat_subcolumn = .true.
@@ -478,9 +509,7 @@ CONTAINS
        Lrttov_column    = .true.
 
     ! Set flag to deallocate rttov types (only done on final call to simulator)
-    if (associated(cospOUT%isccp_meantb)) then
-       if (size(cospOUT%isccp_meantb) .eq. stop_idx) lrttov_cleanUp = .true.
-    endif
+    if (size(cospOUT%isccp_meantb) .eq. stop_idx) lrttov_cleanUp = .true.
 
     ! ISCCP column
     if (associated(cospOUT%isccp_fq)                                       .or.          &
@@ -582,6 +611,15 @@ CONTAINS
        Lcloudsat_tcc2      = .true.
     endif
 
+    ! CloudSat+MODIS joint simulator product
+    if ( associated(cospOUT%cfodd_ntotal) .or. associated(cospOUT%wr_occfreq_ntotal) ) then
+       Lmodis_column       = .true.
+       Lmodis_subcolumn    = .true.
+       Lcloudsat_column    = .true.
+       Lcloudsat_subcolumn = .true.
+       Lcloudsat_modis_wr  = .true. ! WR: warm rain product
+    endif
+
     !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     ! 2b) Error Checking
     !     Enforce bounds on input fields. If input field is out-of-bounds, report error
@@ -592,8 +630,8 @@ CONTAINS
          Lcloudsat_subcolumn, Lcloudsat_column, Lcalipso_subcolumn, Lcalipso_column,     &
          Latlid_subcolumn, Latlid_column, LgrLidar532_subcolumn, LgrLidar532_column,     &
          Lrttov_subcolumn, Lrttov_column, Lparasol_subcolumn, Lparasol_column,           &
-         Lradar_lidar_tcc, Llidar_only_freq_cloud, Lcloudsat_tcc,Lcloudsat_tcc2, cospOUT,&
-         cosp_simulator, nError)
+         Lradar_lidar_tcc, Llidar_only_freq_cloud, Lcloudsat_tcc,Lcloudsat_tcc2,         &
+         Lcloudsat_modis_wr, cospOUT, cosp_simulator, nError)
 
     !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     ! 3) Populate instrument simulator inputs
@@ -708,7 +746,7 @@ CONTAINS
        rttovIN%n2o        => cospgridIN%n2o
        rttovIN%co         => cospgridIN%co
        rttovIN%surfem     => cospgridIN%emis_sfc
-       rttovIN%h_surf     => cospgridIN%hgt_matrix_half(:,cospIN%Nlevels+1)
+       rttovIN%h_surf     => cospgridIN%hgt_matrix_half(:,cospIN%Nlevels)
        rttovIN%u_surf     => cospgridIN%u_sfc
        rttovIN%v_surf     => cospgridIN%v_sfc
        rttovIN%t_skin     => cospgridIN%skt
@@ -1064,7 +1102,7 @@ CONTAINS
        ok_lidar_cfad=.true.
        call lidar_column(calipsoIN%Npoints, calipsoIN%Ncolumns, calipsoIN%Nlevels,       &
             Nlvgrid, SR_BINS, LIDAR_NTYPE, 'calipso',calipso_beta_tot(:,:,:), calipso_beta_mol(:,:),&
-            cospgridIN%phalf(:,2:calipsoIN%Nlevels+1),cospgridIN%hgt_matrix,               &
+            cospgridIN%phalf(:,2:calipsoIN%Nlevels+1),cospgridIN%hgt_matrix,             &
             cospgridIN%hgt_matrix_half, vgrid_z(:), ok_lidar_cfad, LIDAR_NCAT,           &
             cospOUT%calipso_cfad_sr(ij:ik,:,:), cospOUT%calipso_lidarcld(ij:ik,:),       &
             cospOUT%calipso_cldlayer(ij:ik,:),                                           &
@@ -1281,7 +1319,12 @@ CONTAINS
                    modisMeanIceWaterPath(modisIN%nSunlit),                               &
                    modisJointHistogram(modisIN%nSunlit,numMODISTauBins,numMODISPresBins),&
                    modisJointHistogramIce(modisIN%nSunlit,numModisTauBins,numMODISReffIceBins),&
-                   modisJointHistogramLiq(modisIN%nSunlit,numModisTauBins,numMODISReffLiqBins))
+                   modisJointHistogramLiq(modisIN%nSunlit,numModisTauBins,numMODISReffLiqBins),&
+                   modisJointHistogram_CtpCodLiq(modisIN%nSunlit,numMODISTauBins,numMODISPresBins),&
+                   modisJointHistogram_CtpCodIce(modisIN%nSunlit,numMODISTauBins,numMODISPresBins),&
+                   modisJointHistogram_LwpRefLiq(modisIN%nSunlit,numMODISLWPBins,numMODISReffLiqBins), &
+                   modisJointHistogram_IwpRefIce(modisIN%nSunlit,numMODISIWPBins,numMODISReffIceBins) &
+                   )
           ! Call simulator
           call modis_column(modisIN%nSunlit, modisIN%Ncolumns,modisRetrievedPhase,       &
                              modisRetrievedCloudTopPressure,modisRetrievedTau,           &
@@ -1292,7 +1335,12 @@ CONTAINS
                              modisMeanSizeLiquid, modisMeanSizeIce,                      &
                              modisMeanCloudTopPressure, modisMeanLiquidWaterPath,        &
                              modisMeanIceWaterPath, modisJointHistogram,                 &
-                             modisJointHistogramIce,modisJointHistogramLiq)
+                             modisJointHistogramIce,modisJointHistogramLiq,              &
+                             modisJointHistogram_CtpCodLiq,                              &
+                             modisJointHistogram_CtpCodIce,                              &
+                             modisJointHistogram_LwpRefLiq,                              &
+                             modisJointHistogram_IwpRefIce                               &
+                             )
           ! Store data (if requested)
           if (associated(cospOUT%modis_Cloud_Fraction_Total_Mean)) then
              cospOUT%modis_Cloud_Fraction_Total_Mean(ij+int(modisIN%sunlit(:))-1)   =    &
@@ -1369,6 +1417,30 @@ CONTAINS
              cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure(ij:ik,:,:) = &
                   cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure(ij:ik,:,numMODISPresBins:1:-1)
           endif
+
+          if (associated(cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq)) then
+             cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq(ij+            &
+                  int(modisIN%sunlit(:))-1, 1:numModisTauBins, :) = modisJointHistogram_CtpCodLiq(:, :, :)
+             ! Reorder pressure bins in joint histogram to go from surface to TOA
+             cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq(ij:ik,:,:) = &
+                  cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq(ij:ik,:,numMODISPresBins:1:-1)
+          endif
+          if (associated(cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice)) then
+             cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice(ij+            &
+                  int(modisIN%sunlit(:))-1, 1:numModisTauBins, :) = modisJointHistogram_CtpCodIce(:, :, :)
+             ! Reorder pressure bins in joint histogram to go from surface to TOA
+             cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice(ij:ik,:,:) = &
+                  cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice(ij:ik,:,numMODISPresBins:1:-1)
+          endif
+          if (associated(cospOUT%modis_LWP_vs_ReffLIQ)) then
+             cospOUT%modis_LWP_vs_ReffLIQ(ij+int(modisIN%sunlit(:))-1, 1:numMODISLWPBins,:) = &
+                modisJointHistogram_LwpRefLiq(:,:,:)
+          endif
+          if (associated(cospOUT%modis_IWP_vs_ReffICE)) then
+             cospOUT%modis_IWP_vs_ReffICE(ij+int(modisIN%sunlit(:))-1, 1:numMODISIWPBins,:) = &
+                modisJointHistogram_IwpRefIce(:,:,:)
+          endif
+
           if (associated(cospOUT%modis_Optical_Thickness_vs_ReffIce)) then
              cospOUT%modis_Optical_Thickness_vs_ReffIce(ij+int(modisIN%sunlit(:))-1, 1:numMODISTauBins,:) = &
                 modisJointHistogramIce(:,:,:)
@@ -1479,6 +1551,10 @@ CONTAINS
        if (allocated(modisMeanLiquidWaterPath))        deallocate(modisMeanLiquidWaterPath)
        if (allocated(modisMeanIceWaterPath))           deallocate(modisMeanIceWaterPath)
        if (allocated(modisJointHistogram))             deallocate(modisJointHistogram)
+       if (allocated(modisJointHistogram_CtpCodLiq))   deallocate(modisJointHistogram_CtpCodLiq)
+       if (allocated(modisJointHistogram_CtpCodIce))   deallocate(modisJointHistogram_CtpCodIce)
+       if (allocated(modisJointHistogram_LwpRefLiq))   deallocate(modisJointHistogram_LwpRefLiq)
+       if (allocated(modisJointHistogram_IwpRefIce))   deallocate(modisJointHistogram_IwpRefIce)
        if (allocated(modisJointHistogramIce))          deallocate(modisJointHistogramIce)
        if (allocated(modisJointHistogramLiq))          deallocate(modisJointHistogramLiq)
        if (allocated(isccp_boxttop))                   deallocate(isccp_boxttop)
@@ -1572,6 +1648,85 @@ CONTAINS
        endif
     endif
 
+    ! CloudSat/MODIS joint products (CFODDs and Occurrence Frequency of Warm Clouds)
+    if (Lcloudsat_modis_wr) then
+       allocate( cfodd_ntotal(cloudsatIN%Npoints, CFODD_NDBZE, CFODD_NICOD, CFODD_NCLASS) )
+       allocate( wr_occfreq_ntotal(cloudsatIN%Npoints, WR_NREGIME) )
+
+       if ( use_vgrid ) then
+          !! interporation for fixed vertical grid:
+          allocate( zlev(cloudsatIN%Npoints,Nlvgrid),                         &
+                    t_in(cloudsatIN%Npoints,1,cloudsatIN%Nlevels),            &
+                    tempI(cloudsatIN%Npoints,1,Nlvgrid),                      &
+                    Ze_totI(cloudsatIN%Npoints,cloudsatIN%Ncolumns,Nlvgrid),  &
+                    frac_outI(cloudsatIN%Npoints,cloudsatIN%Ncolumns,Nlvgrid) )
+          do k = 1, Nlvgrid
+             zlev(:,k) = vgrid_zu(k)
+          enddo
+          t_in(:,1,:) = cospgridIN%at(:,:)
+          call cosp_change_vertical_grid (                                    &
+               cloudsatIN%Npoints, 1, cloudsatIN%Nlevels,                     &
+               cospgridIN%hgt_matrix(:,cloudsatIN%Nlevels:1:-1),              &
+               cospgridIN%hgt_matrix_half(:,cloudsatIN%Nlevels:1:-1),         &
+               t_in(:,:,cloudsatIN%Nlevels:1:-1), Nlvgrid,                    &
+               vgrid_zl(Nlvgrid:1:-1), vgrid_zu(Nlvgrid:1:-1),                &
+               tempI(:,:,Nlvgrid:1:-1)                                        )
+          call cosp_change_vertical_grid (                                    &
+               cloudsatIN%Npoints, cloudsatIN%Ncolumns, cloudsatIN%Nlevels,   &
+               cospgridIN%hgt_matrix(:,cloudsatIN%Nlevels:1:-1),              &
+               cospgridIN%hgt_matrix_half(:,cloudsatIN%Nlevels:1:-1),         &
+               cloudsatDBZe(:,:,cloudsatIN%Nlevels:1:-1), Nlvgrid,            &
+               vgrid_zl(Nlvgrid:1:-1), vgrid_zu(Nlvgrid:1:-1),                &
+               Ze_totI(:,:,Nlvgrid:1:-1), log_units=.true.                    )
+          call cosp_change_vertical_grid (                                    &
+               cloudsatIN%Npoints, cloudsatIN%Ncolumns, cloudsatIN%Nlevels,   &
+               cospgridIN%hgt_matrix(:,cloudsatIN%Nlevels:1:-1),              &
+               cospgridIN%hgt_matrix_half(:,cloudsatIN%Nlevels:1:-1),         &
+               cospIN%frac_out(:,:,cloudsatIN%Nlevels:1:-1), Nlvgrid,         &
+               vgrid_zl(Nlvgrid:1:-1), vgrid_zu(Nlvgrid:1:-1),                &
+               frac_outI(:,:,Nlvgrid:1:-1)                                    )
+          call cosp_diag_warmrain(                                            &
+               cloudsatIN%Npoints, cloudsatIN%Ncolumns, Nlvgrid,              & !! in
+               tempI, zlev,                                                   & !! in
+               cospOUT%modis_Liquid_Water_Path_Mean,                          & !! in
+               cospOUT%modis_Optical_Thickness_Water_Mean,                    & !! in
+               cospOUT%modis_Cloud_Particle_Size_Water_Mean,                  & !! in
+               cospOUT%modis_Cloud_Fraction_Water_Mean,                       & !! in
+               cospOUT%modis_Ice_Water_Path_Mean,                             & !! in
+               cospOUT%modis_Optical_Thickness_Ice_Mean,                      & !! in
+               cospOUT%modis_Cloud_Particle_Size_Ice_Mean,                    & !! in
+               cospOUT%modis_Cloud_Fraction_Ice_Mean,                         & !! in
+               frac_outI,                                                     & !! in
+               Ze_totI,                                                       & !! in
+               cfodd_ntotal, wr_occfreq_ntotal                                ) !! inout
+          deallocate( zlev, t_in, tempI, frac_outI, Ze_totI )
+       else  ! do not use vgrid interporation ---------------------------------------!
+          !! original model grid
+          call cosp_diag_warmrain(                                            &
+               cloudsatIN%Npoints, cloudsatIN%Ncolumns, cospIN%Nlevels,       & !! in
+               cospgridIN%at, cospgridIN%hgt_matrix,                          & !! in
+               cospOUT%modis_Liquid_Water_Path_Mean,                          & !! in
+               cospOUT%modis_Optical_Thickness_Water_Mean,                    & !! in
+               cospOUT%modis_Cloud_Particle_Size_Water_Mean,                  & !! in
+               cospOUT%modis_Cloud_Fraction_Water_Mean,                       & !! in
+               cospOUT%modis_Ice_Water_Path_Mean,                             & !! in
+               cospOUT%modis_Optical_Thickness_Ice_Mean,                      & !! in
+               cospOUT%modis_Cloud_Particle_Size_Ice_Mean,                    & !! in
+               cospOUT%modis_Cloud_Fraction_Ice_Mean,                         & !! in
+               cospIN%frac_out,                                               & !! in
+               cloudsatDBZe,                                                  & !! in
+               cfodd_ntotal, wr_occfreq_ntotal                                ) !! inout
+       endif  !! use_vgrid or not
+
+       ! Store, when necessary
+       if ( associated(cospOUT%cfodd_ntotal) ) then
+          cospOUT%cfodd_ntotal(ij:ik,:,:,:) = cfodd_ntotal
+       endif
+       if ( associated(cospOUT%wr_occfreq_ntotal) ) then
+          cospOUT%wr_occfreq_ntotal(ij:ik,:) = wr_occfreq_ntotal
+       endif
+    endif
+ 
     !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     ! 7) Cleanup
     !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1633,6 +1788,8 @@ CONTAINS
     if (allocated(radar_lidar_tcc))       deallocate(radar_lidar_tcc)
     if (allocated(cloudsat_tcc))          deallocate(cloudsat_tcc)
     if (allocated(cloudsat_tcc2))         deallocate(cloudsat_tcc2)
+    if (allocated(cfodd_ntotal))          deallocate(cfodd_ntotal)
+    if (allocated(wr_occfreq_ntotal))     deallocate(wr_occfreq_ntotal)
 
   end function COSP_SIMULATOR
   ! ######################################################################################
@@ -1684,7 +1841,7 @@ CONTAINS
 
     if (use_vgrid) then
       Nlvgrid  = Nvgrid
-       allocate(vgrid_zl(Nlvgrid),vgrid_zu(Nlvgrid),vgrid_z(Nlvgrid))
+       allocate(vgrid_zl(Nlvgrid),vgrid_zu(Nlvgrid),vgrid_z(Nlvgrid),dz(Nlvgrid))
        ! CloudSat grid requested
        if (luseCSATvgrid)       zstep = 480._wp
        ! Other grid requested. Constant vertical spacing with top at 20 km
@@ -1694,9 +1851,14 @@ CONTAINS
           vgrid_zu(Nlvgrid-i+1) = i*zstep
        enddo
        vgrid_z = (vgrid_zl+vgrid_zu)/2._wp
+       dz = zstep
     else
        Nlvgrid = Nlevels
-       allocate(vgrid_zl(Nlvgrid),vgrid_zu(Nlvgrid),vgrid_z(Nlvgrid))
+       allocate(vgrid_zl(Nlvgrid),vgrid_zu(Nlvgrid),vgrid_z(Nlvgrid),dz(Nlvgrid))
+       vgrid_zl = 0._wp
+       vgrid_zu = 0._wp
+       vgrid_z  = 0._wp
+       dz       = 0._wp
     endif
 
     ! Initialize simulators
@@ -1719,7 +1881,7 @@ CONTAINS
   ! SUBROUTINE cosp_cleanUp
   !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   subroutine cosp_cleanUp()
-    deallocate(vgrid_zl,vgrid_zu,vgrid_z)
+    deallocate(vgrid_zl,vgrid_zu,vgrid_z,dz)
   end subroutine cosp_cleanUp
 
   !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1728,9 +1890,10 @@ CONTAINS
   subroutine cosp_errorCheck(cospgridIN, cospIN, Lisccp_subcolumn, Lisccp_column,           &
        Lmisr_subcolumn, Lmisr_column, Lmodis_subcolumn, Lmodis_column, Lcloudsat_subcolumn, &
        Lcloudsat_column, Lcalipso_subcolumn, Lcalipso_column, Latlid_subcolumn,             &
-       Latlid_column, LgrLidar532_subcolumn, LgrLidar532_column, Lrttov_subcolumn,        &
+       Latlid_column, LgrLidar532_subcolumn, LgrLidar532_column, Lrttov_subcolumn,          &
        Lrttov_column, Lparasol_subcolumn, Lparasol_column, Lradar_lidar_tcc,                &
-       Llidar_only_freq_cloud, Lcloudsat_tcc, Lcloudsat_tcc2, cospOUT, errorMessage, nError)
+       Llidar_only_freq_cloud, Lcloudsat_tcc, Lcloudsat_tcc2, Lcloudsat_modis_wr,           &
+       cospOUT, errorMessage, nError)
     
     ! Inputs
     type(cosp_column_inputs),intent(in) :: &
@@ -1761,14 +1924,14 @@ CONTAINS
          Lcloudsat_tcc,       & !
          Lcloudsat_tcc2,      & !
          Lradar_lidar_tcc,    & ! On/Off switch for joint Calipso/Cloudsat product
-         Llidar_only_freq_cloud ! On/Off switch for joint Calipso/Cloudsat product
+         Llidar_only_freq_cloud, & ! On/Off switch for joint Calipso/Cloudsat product
+         Lcloudsat_modis_wr     ! On/Off switch for joint CloudSat/MODIS warm rain product
     type(cosp_outputs),intent(inout) :: &
          cospOUT                ! COSP Outputs
     character(len=256),dimension(100) :: errorMessage
     integer,intent(out) :: nError
     
     ! Local variables
-    character(len=100) :: parasolErrorMessage
     logical :: alloc_status
     
     nError = 0
@@ -2080,6 +2243,11 @@ CONTAINS
           errorMessage(nError) = 'ERROR: COSP input variable (Calipso Lidar simulator): cospgridIN%at has not been allocated'
           alloc_status = .false.
        endif
+       if (.not. allocated(cospgridIN%surfelev)) then
+          nError=nError+1
+          errorMessage(nError) = 'ERROR: COSP input variable (Calipso Lidar simulator): cospgridIN%surfelev has not been allocated'
+          alloc_status = .false.
+       endif
        if (.not. allocated(cospgridIN%phalf)) then
           nError=nError+1
           errorMessage(nError) = 'ERROR: COSP input variable (Calipso Lidar simulator): cospgridIN%phalf has not been allocated'
@@ -2173,6 +2341,12 @@ CONTAINS
                ' cospgridIN%hgt_matrix has not been allocated'
           alloc_status = .false.
        endif
+       if (.not. allocated(cospgridIN%surfelev)) then
+          nError=nError+1
+          errorMessage(nError) = 'ERROR: COSP input variable (Cloudsat radar simulator):'//&
+               ' cospgridIN%surfelev has not been allocated'
+          alloc_status = .false.
+       endif
        if (.not. alloc_status) then
           Lcloudsat_subcolumn  = .false.
           Lcloudsat_column     = .false.
@@ -2194,6 +2368,11 @@ CONTAINS
           if (Llidar_only_freq_cloud) then
              Llidar_only_freq_cloud = .false.
              if (associated(cospOUT%lidar_only_freq_cloud)) cospOUT%lidar_only_freq_cloud(:,:) = R_UNDEF
+          endif
+          if (Lcloudsat_modis_wr) then
+             Lcloudsat_modis_wr = .false.
+             if (associated(cospOUT%cfodd_ntotal)) cospOUT%cfodd_ntotal(:,:,:,:) = R_UNDEF
+             if (associated(cospOUT%wr_occfreq_ntotal)) cospOUT%wr_occfreq_ntotal(:,:) = R_UNDEF
           endif
        endif
        
@@ -2224,6 +2403,11 @@ CONTAINS
           if (Llidar_only_freq_cloud) then
              Llidar_only_freq_cloud = .false.
              if (associated(cospOUT%lidar_only_freq_cloud)) cospOUT%lidar_only_freq_cloud(:,:) = R_UNDEF
+          endif
+          if (Lcloudsat_modis_wr) then
+             Lcloudsat_modis_wr = .false.
+             if (associated(cospOUT%cfodd_ntotal)) cospOUT%cfodd_ntotal(:,:,:,:) = R_UNDEF
+             if (associated(cospOUT%wr_occfreq_ntotal)) cospOUT%wr_occfreq_ntotal(:,:) = R_UNDEF
           endif
        endif
     endif
@@ -2295,10 +2479,24 @@ CONTAINS
                cospOUT%modis_Ice_Water_Path_Mean(:)                         = R_UNDEF
           if (associated(cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure))            &
                cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq))            &
+               cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice))            &
+               cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_LWP_vs_ReffLIQ))            &
+               cospOUT%modis_LWP_vs_ReffLIQ(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_IWP_vs_ReffICE))            &
+               cospOUT%modis_IWP_vs_ReffICE(:,:,:) = R_UNDEF
           if (associated(cospOUT%modis_Optical_Thickness_vs_ReffICE))                       &
                cospOUT%modis_Optical_Thickness_vs_ReffICE(:,:,:)            = R_UNDEF
           if (associated(cospOUT%modis_Optical_Thickness_vs_ReffLIQ))                       &
                cospOUT%modis_Optical_Thickness_vs_ReffLIQ(:,:,:)            = R_UNDEF          
+          ! Also, turn-off joint-products 
+          if (Lcloudsat_modis_wr) then
+             Lcloudsat_modis_wr = .false.
+             if (associated(cospOUT%cfodd_ntotal)) cospOUT%cfodd_ntotal(:,:,:,:) = R_UNDEF
+             if (associated(cospOUT%wr_occfreq_ntotal)) cospOUT%wr_occfreq_ntotal(:,:) = R_UNDEF
+          endif
        endif
     endif
     
@@ -2427,7 +2625,8 @@ CONTAINS
     !         an undefined value (set in cosp_config.f90) and if necessary, that simulator
     !         is turned off.
     !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    if (any([Lisccp_subcolumn, Lisccp_column, Lmisr_subcolumn, Lmisr_column, Lmodis_subcolumn, Lmodis_column])) then
+    if (any([Lisccp_subcolumn, Lisccp_column, Lmisr_subcolumn, Lmisr_column, &
+             Lmodis_subcolumn, Lmodis_column, Lcloudsat_modis_wr])) then
        if (any(cospgridIN%sunlit .lt. 0)) then
           nError=nError+1
           errorMessage(nError) = 'ERROR: COSP input variable: cospgridIN%sunlit contains values out of range (0 or 1)'
@@ -2437,6 +2636,7 @@ CONTAINS
           Lmisr_column     = .false.
           Lmodis_subcolumn = .false.
           Lmodis_column    = .false.
+          Lcloudsat_modis_wr = .false.
           if (associated(cospOUT%isccp_totalcldarea))  cospOUT%isccp_totalcldarea(:)  = R_UNDEF
           if (associated(cospOUT%isccp_meantb))        cospOUT%isccp_meantb(:)        = R_UNDEF
           if (associated(cospOUT%isccp_meantbclr))     cospOUT%isccp_meantbclr(:)     = R_UNDEF
@@ -2486,16 +2686,26 @@ CONTAINS
                cospOUT%modis_Ice_Water_Path_Mean(:)                         = R_UNDEF
           if (associated(cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure))            &
                cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq))            &
+               cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice))            &
+               cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_LWP_vs_ReffLIQ))            &
+               cospOUT%modis_LWP_vs_ReffLIQ(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_IWP_vs_ReffICE))            &
+               cospOUT%modis_IWP_vs_ReffICE(:,:,:) = R_UNDEF    
           if (associated(cospOUT%modis_Optical_Thickness_vs_ReffICE))                       &
                cospOUT%modis_Optical_Thickness_vs_ReffICE(:,:,:)            = R_UNDEF
           if (associated(cospOUT%modis_Optical_Thickness_vs_ReffLIQ))                       &
                cospOUT%modis_Optical_Thickness_vs_ReffLIQ(:,:,:)            = R_UNDEF
+          if (associated(cospOUT%cfodd_ntotal)) cospOUT%cfodd_ntotal(:,:,:,:) = R_UNDEF
+          if (associated(cospOUT%wr_occfreq_ntotal)) cospOUT%wr_occfreq_ntotal(:,:) = R_UNDEF
        endif
     endif
 
     if (any([Lisccp_subcolumn, Lisccp_column, Lmisr_subcolumn, Lmisr_column, Lrttov_column,&
          Lcalipso_column, Lcloudsat_column, Lradar_lidar_tcc,Llidar_only_freq_cloud, &
-         Lcloudsat_tcc, Lcloudsat_tcc2])) then
+         Lcloudsat_tcc, Lcloudsat_tcc2, Lcloudsat_modis_wr])) then
        if (any(cospgridIN%at .lt. 0)) then
           nError=nError+1
           errorMessage(nError) = 'ERROR: COSP input variable: cospgridIN%at contains values out of range (at<0), expected units (K)'
@@ -2510,6 +2720,7 @@ CONTAINS
           Llidar_only_freq_cloud = .false.
           Lcloudsat_tcc    = .false.
           Lcloudsat_tcc2   = .false.
+          Lcloudsat_modis_wr = .false.
           if (associated(cospOUT%rttov_tbs)) cospOUT%rttov_tbs(:,:)         = R_UNDEF
           if (associated(cospOUT%isccp_totalcldarea))  cospOUT%isccp_totalcldarea(:)  = R_UNDEF
           if (associated(cospOUT%isccp_meantb))        cospOUT%isccp_meantb(:)        = R_UNDEF
@@ -2541,6 +2752,8 @@ CONTAINS
           if (associated(cospOUT%radar_lidar_tcc))       cospOUT%radar_lidar_tcc(:)           = R_UNDEF
           if (associated(cospOUT%cloudsat_tcc)) cospOUT%cloudsat_tcc(:) = R_UNDEF
           if (associated(cospOUT%cloudsat_tcc2)) cospOUT%cloudsat_tcc2(:) = R_UNDEF
+          if (associated(cospOUT%cfodd_ntotal)) cospOUT%cfodd_ntotal(:,:,:,:) = R_UNDEF
+          if (associated(cospOUT%wr_occfreq_ntotal)) cospOUT%wr_occfreq_ntotal(:,:) = R_UNDEF
        endif
     endif
     if (any([Lisccp_subcolumn, Lisccp_column, Lrttov_column])) then
@@ -2621,6 +2834,14 @@ CONTAINS
                cospOUT%modis_Ice_Water_Path_Mean(:)                         = R_UNDEF
           if (associated(cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure))            &
                cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq))            &
+               cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice))            &
+               cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_LWP_vs_ReffLIQ))            &
+               cospOUT%modis_LWP_vs_ReffLIQ(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_IWP_vs_ReffICE))            &
+               cospOUT%modis_IWP_vs_ReffICE(:,:,:) = R_UNDEF    
           if (associated(cospOUT%modis_Optical_Thickness_vs_ReffICE))                       &
                cospOUT%modis_Optical_Thickness_vs_ReffICE(:,:,:)            = R_UNDEF
           if (associated(cospOUT%modis_Optical_Thickness_vs_ReffLIQ))                       &
@@ -2665,7 +2886,8 @@ CONTAINS
        endif
     endif
     if (any([Lmisr_subcolumn,Lmisr_column,Lcloudsat_subcolumn,Lcloudsat_column,Lcalipso_column,Lradar_lidar_tcc,&
-         Llidar_only_freq_cloud,LgrLidar532_column,Latlid_column,Lcloudsat_tcc, Lcloudsat_tcc2])) then
+         Llidar_only_freq_cloud,LgrLidar532_column,Latlid_column,Lcloudsat_tcc, Lcloudsat_tcc2, &
+         Lcloudsat_modis_wr])) then
        if (any(cospgridIN%hgt_matrix .lt. -300)) then
           nError=nError+1
           errorMessage(nError) = 'ERROR: COSP input variable: cospgridIN%hgt_matrix contains values out of range'
@@ -2680,6 +2902,7 @@ CONTAINS
           Lcloudsat_tcc2      = .false.
           Latlid_column       = .false.
           LgrLidar532_column  = .false.
+          Lcloudsat_modis_wr  = .false.
           if (associated(cospOUT%misr_fq))                   cospOUT%misr_fq(:,:,:)                 = R_UNDEF
           if (associated(cospOUT%misr_dist_model_layertops)) cospOUT%misr_dist_model_layertops(:,:) = R_UNDEF
           if (associated(cospOUT%misr_meanztop))             cospOUT%misr_meanztop(:)               = R_UNDEF
@@ -2708,10 +2931,12 @@ CONTAINS
           if (associated(cospOUT%calipso_cldtypemeanz))      cospOUT%calipso_cldtypemeanz(:,:)      = R_UNDEF 
           if (associated(cospOUT%calipso_cldtypemeanzse))    cospOUT%calipso_cldtypemeanzse(:,:)    = R_UNDEF
           if (associated(cospOUT%calipso_cldthinemis))       cospOUT%calipso_cldthinemis(:)         = R_UNDEF
+          if (associated(cospOUT%cfodd_ntotal))              cospOUT%cfodd_ntotal(:,:,:,:)          = R_UNDEF
+          if (associated(cospOUT%wr_occfreq_ntotal))         cospOUT%wr_occfreq_ntotal(:,:)         = R_UNDEF
        endif
     endif
     if (any([Lrttov_column,Lcloudsat_column,Lcalipso_column,Lradar_lidar_tcc,Llidar_only_freq_cloud, &
-             LgrLidar532_column, Latlid_column, Lcloudsat_tcc, Lcloudsat_tcc2])) then
+             LgrLidar532_column, Latlid_column, Lcloudsat_tcc, Lcloudsat_tcc2, Lcloudsat_modis_wr])) then
        if (any(cospgridIN%hgt_matrix_half .lt. -300)) then
           nError=nError+1
           errorMessage(nError) = 'ERROR: COSP input variable: cospgridIN%hgt_matrix_half contains values out of range'
@@ -2724,6 +2949,7 @@ CONTAINS
           Lcloudsat_tcc2   = .false.
           Latlid_column       = .false.
           LgrLidar532_column = .false.
+          Lcloudsat_modis_wr = .false.
           if (associated(cospOUT%rttov_tbs))              cospOUT%rttov_tbs(:,:)               = R_UNDEF
           if (associated(cospOUT%calipso_cfad_sr))        cospOUT%calipso_cfad_sr(:,:,:)       = R_UNDEF
           if (associated(cospOUT%calipso_lidarcld))       cospOUT%calipso_lidarcld(:,:)        = R_UNDEF
@@ -2748,6 +2974,8 @@ CONTAINS
           if (associated(cospOUT%calipso_cldtypemeanz))   cospOUT%calipso_cldtypemeanz(:,:)    = R_UNDEF 
           if (associated(cospOUT%calipso_cldtypemeanzse)) cospOUT%calipso_cldtypemeanzse(:,:)  = R_UNDEF 
           if (associated(cospOUT%calipso_cldthinemis))    cospOUT%calipso_cldthinemis(:)       = R_UNDEF
+          if (associated(cospOUT%cfodd_ntotal))           cospOUT%cfodd_ntotal(:,:,:,:)        = R_UNDEF
+          if (associated(cospOUT%wr_occfreq_ntotal))      cospOUT%wr_occfreq_ntotal(:,:)       = R_UNDEF
        endif
     endif
     if (any([Lrttov_column,Lcalipso_column,Lparasol_column])) then
@@ -2934,6 +3162,14 @@ CONTAINS
                cospOUT%modis_Ice_Water_Path_Mean(:)                         = R_UNDEF
           if (associated(cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure))            &
                cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq))            &
+               cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice))            &
+               cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_LWP_vs_ReffLIQ))            &
+               cospOUT%modis_LWP_vs_ReffLIQ(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_IWP_vs_ReffICE))            &
+               cospOUT%modis_IWP_vs_ReffICE(:,:,:) = R_UNDEF     
           if (associated(cospOUT%modis_Optical_Thickness_vs_ReffICE))                       &
                cospOUT%modis_Optical_Thickness_vs_ReffICE(:,:,:)            = R_UNDEF
           if (associated(cospOUT%modis_Optical_Thickness_vs_ReffLIQ))                       &
@@ -2999,6 +3235,14 @@ CONTAINS
                cospOUT%modis_Ice_Water_Path_Mean(:)                         = R_UNDEF
           if (associated(cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure))            &
                cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq))            &
+               cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice))            &
+               cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_LWP_vs_ReffLIQ))            &
+               cospOUT%modis_LWP_vs_ReffLIQ(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_IWP_vs_ReffICE))            &
+               cospOUT%modis_IWP_vs_ReffICE(:,:,:) = R_UNDEF    
           if (associated(cospOUT%modis_Optical_Thickness_vs_ReffICE))                       &
                cospOUT%modis_Optical_Thickness_vs_ReffICE(:,:,:)            = R_UNDEF
           if (associated(cospOUT%modis_Optical_Thickness_vs_ReffLIQ))                       &
@@ -3045,6 +3289,14 @@ CONTAINS
                cospOUT%modis_Ice_Water_Path_Mean(:)                         = R_UNDEF
           if (associated(cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure))            &
                cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq))            &
+               cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice))            &
+               cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_LWP_vs_ReffLIQ))            &
+               cospOUT%modis_LWP_vs_ReffLIQ(:,:,:) = R_UNDEF
+          if (associated(cospOUT%modis_IWP_vs_ReffICE))            &
+               cospOUT%modis_IWP_vs_ReffICE(:,:,:) = R_UNDEF     
           if (associated(cospOUT%modis_Optical_Thickness_vs_ReffICE))                       &
                cospOUT%modis_Optical_Thickness_vs_ReffICE(:,:,:)            = R_UNDEF
           if (associated(cospOUT%modis_Optical_Thickness_vs_ReffLIQ))                       &
@@ -3331,7 +3583,7 @@ CONTAINS
        endif
     endif
     if (any([Lcloudsat_subcolumn,Lcloudsat_column,Lradar_lidar_tcc,Llidar_only_freq_cloud, &
-        Lcloudsat_tcc, Lcloudsat_tcc2])) then
+        Lcloudsat_tcc, Lcloudsat_tcc2, Lcloudsat_modis_wr])) then
        if (any(cospIN%z_vol_cloudsat .lt. 0)) then
           nError=nError+1
           errorMessage(nError) = 'ERROR: COSP input variable: cospIN%z_vol_cloudsat contains values out of range'
@@ -3341,12 +3593,15 @@ CONTAINS
           Llidar_only_freq_cloud = .false.
           Lcloudsat_tcc       = .false.
           Lcloudsat_tcc2      = .false.
+          Lcloudsat_modis_wr  = .false.
           if (associated(cospOUT%cloudsat_cfad_ze))          cospOUT%cloudsat_cfad_ze(:,:,:)        = R_UNDEF
           if (associated(cospOUT%cloudsat_Ze_tot))           cospOUT%cloudsat_Ze_tot(:,:,:)         = R_UNDEF
           if (associated(cospOUT%lidar_only_freq_cloud))     cospOUT%lidar_only_freq_cloud(:,:)     = R_UNDEF
           if (associated(cospOUT%radar_lidar_tcc))           cospOUT%radar_lidar_tcc(:)             = R_UNDEF
           if (associated(cospOUT%cloudsat_tcc)) cospOUT%cloudsat_tcc(:) = R_UNDEF
           if (associated(cospOUT%cloudsat_tcc2)) cospOUT%cloudsat_tcc2(:) = R_UNDEF
+          if (associated(cospOUT%cfodd_ntotal)) cospOUT%cfodd_ntotal(:,:,:,:) = R_UNDEF
+          if (associated(cospOUT%wr_occfreq_ntotal)) cospOUT%wr_occfreq_ntotal(:,:) = R_UNDEF
        endif
        if (any(cospIN%kr_vol_cloudsat .lt. 0)) then
           nError=nError+1
@@ -3357,12 +3612,15 @@ CONTAINS
           Llidar_only_freq_cloud = .false.
           Lcloudsat_tcc       = .false.
           Lcloudsat_tcc2      = .false.
+          Lcloudsat_modis_wr  = .false.
           if (associated(cospOUT%cloudsat_cfad_ze))          cospOUT%cloudsat_cfad_ze(:,:,:)        = R_UNDEF
           if (associated(cospOUT%cloudsat_Ze_tot))           cospOUT%cloudsat_Ze_tot(:,:,:)         = R_UNDEF
           if (associated(cospOUT%lidar_only_freq_cloud))     cospOUT%lidar_only_freq_cloud(:,:)     = R_UNDEF
           if (associated(cospOUT%radar_lidar_tcc))           cospOUT%radar_lidar_tcc(:)             = R_UNDEF
           if (associated(cospOUT%cloudsat_tcc)) cospOUT%cloudsat_tcc(:) = R_UNDEF
           if (associated(cospOUT%cloudsat_tcc2)) cospOUT%cloudsat_tcc2(:) = R_UNDEF
+          if (associated(cospOUT%cfodd_ntotal)) cospOUT%cfodd_ntotal(:,:,:,:) = R_UNDEF
+          if (associated(cospOUT%wr_occfreq_ntotal)) cospOUT%wr_occfreq_ntotal(:,:) = R_UNDEF
        endif
        if (any(cospIN%g_vol_cloudsat .lt. 0)) then
           nError=nError+1
@@ -3373,12 +3631,15 @@ CONTAINS
           Llidar_only_freq_cloud = .false.
           Lcloudsat_tcc       = .false.
           Lcloudsat_tcc2      = .false.          
+          Lcloudsat_modis_wr  = .false.
           if (associated(cospOUT%cloudsat_cfad_ze))          cospOUT%cloudsat_cfad_ze(:,:,:)        = R_UNDEF
           if (associated(cospOUT%cloudsat_Ze_tot))           cospOUT%cloudsat_Ze_tot(:,:,:)         = R_UNDEF
           if (associated(cospOUT%lidar_only_freq_cloud))     cospOUT%lidar_only_freq_cloud(:,:)     = R_UNDEF
           if (associated(cospOUT%radar_lidar_tcc))           cospOUT%radar_lidar_tcc(:)             = R_UNDEF
           if (associated(cospOUT%cloudsat_tcc)) cospOUT%cloudsat_tcc(:) = R_UNDEF
           if (associated(cospOUT%cloudsat_tcc2)) cospOUT%cloudsat_tcc2(:) = R_UNDEF          
+          if (associated(cospOUT%cfodd_ntotal)) cospOUT%cfodd_ntotal(:,:,:,:) = R_UNDEF
+          if (associated(cospOUT%wr_occfreq_ntotal)) cospOUT%wr_occfreq_ntotal(:,:) = R_UNDEF
        endif
     endif
     !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -3648,7 +3909,7 @@ CONTAINS
        if (size(cospgridIN%pfull,2)           .ne. cospIN%Nlevels   .OR. &
            size(cospgridIN%at,2)              .ne. cospIN%Nlevels   .OR. &
            size(cospgridIN%qv,2)              .ne. cospIN%Nlevels   .OR. &
-           size(cospgridIN%hgt_matrix_half,2) .ne. cospIN%Nlevels+1 .OR. &
+           size(cospgridIN%hgt_matrix_half,2) .ne. cospIN%Nlevels   .OR. &
            size(cospgridIN%phalf,2)           .ne. cospIN%Nlevels+1 .OR. &
            size(cospgridIN%qv,2)              .ne. cospIN%Nlevels) then
           Lrttov_column    = .false.

--- a/components/eam/src/physics/cosp2/local/cosp_config.F90
+++ b/components/eam/src/physics/cosp2/local/cosp_config.F90
@@ -1,0 +1,502 @@
+! %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+! Copyright (c) 2015, Regents of the University of Colorado
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without modification, are 
+! permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of 
+!    conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list
+!    of conditions and the following disclaimer in the documentation and/or other 
+!    materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be 
+!    used to endorse or promote products derived from this software without specific prior
+!    written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
+! EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+! MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL 
+! THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+! SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+! OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+! INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! History:
+! Jul 2007 - A. Bodas-Salcedo - Initial version
+! Jul 2008 - A. Bodas-Salcedo - Added definitions of ISCCP axes
+! Oct 2008 - H. Chepfer       - Added PARASOL_NREFL
+! Jun 2010 - R. Marchand      - Modified to support quickbeam V3, added ifdef for  
+!                               hydrometeor definitions
+! May 2015 - D. Swales        - Tidied up. Set up appropriate fields during initialization. 
+! June 2015- D. Swales        - Moved hydrometeor class variables to hydro_class_init in
+!                               the module quickbeam_optics.
+! Mar 2016 - D. Swales        - Added scops_ccfrac. Was previously hardcoded in prec_scops.f90.  
+! Mar 2018 - R. Guzman        - Added LIDAR_NTYPE for the OPAQ diagnostics
+! Apr 2018 - R. Guzman        - Added parameters for GROUND LIDAR and ATLID simulators
+! Nov 2018 - T. Michibata     - Added CloudSat+MODIS Warmrain Diagnostics
+! Mar 2024 - C. Wall          - Added MODIS joint-histogram diagnostics
+!
+! %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+MODULE MOD_COSP_CONFIG
+    USE COSP_KINDS, ONLY: wp,dp
+    IMPLICIT NONE
+
+   ! #####################################################################################
+   ! Common COSP information
+   ! #####################################################################################
+    character(len=32) ::   &
+         COSP_VERSION              ! COSP Version ID (set in cosp_interface_init)
+    real(wp),parameter ::  &
+         R_UNDEF      = -1.0E30, & ! Missing value
+         R_GROUND     = -1.0E20, & ! Flag for below ground results
+         scops_ccfrac = 0.05       ! Fraction of column (or subcolumn) covered with convective
+                                   ! precipitation (default is 5%). *NOTE* This quantity may vary
+                                   ! between modeling centers.
+    logical :: &
+         use_vgrid                 ! True=Use new grid for L3 CLOUDAT and CALIPSO
+    integer,parameter ::   &
+         SR_BINS = 15,           & ! Number of bins (backscattering coefficient) in CALOPSO LIDAR simulator.
+         N_HYDRO = 9               ! Number of hydrometeor classes used by quickbeam radar simulator.
+
+    ! ####################################################################################  
+    ! Joint histogram bin-boundaries
+    ! tau is used by ISCCP and MISR
+    ! pres is used by ISCCP
+    ! hgt is used by MISR
+    ! ReffLiq is used by MODIS
+    ! ReffIce is used by MODIS
+    ! *NOTE* ALL JOINT-HISTOGRAM BIN BOUNDARIES ARE DECLARED AND DEFINED HERE IN
+    !        COSP_CONFIG, WITH THE EXCEPTION OF THE TAU AXIS USED BY THE MODIS SIMULATOR,
+    !        WHICH IS SET DURING INITIALIZATION IN COSP_INTERFACE_INIT.
+    ! ####################################################################################
+    ! Optical depth bin axis
+    integer,parameter :: &
+         ntau=7  
+    real(wp),parameter,dimension(ntau+1) :: &
+       tau_binBounds = (/0.0, 0.3, 1.3, 3.6, 9.4, 23., 60., 10000./)
+    real(wp),parameter,dimension(ntau) :: &
+         tau_binCenters = (/0.15, 0.80, 2.45, 6.5, 16.2, 41.5, 100.0/)
+    real(wp),parameter,dimension(2,ntau) :: &
+         tau_binEdges = reshape(source=(/0.0, 0.3,  0.3,  1.3,  1.3,  3.6,      3.6,     &
+                                         9.4, 9.4, 23.0, 23.0, 60.0, 60.0, 100000.0/),   &
+                                         shape=(/2,ntau/)) 
+
+    ! Optical depth bin axes (ONLY USED BY MODIS SIMULATOR IN v1.4)
+    integer :: l,k
+    integer,parameter :: &
+         ntauV1p4 = 6
+    real(wp),parameter,dimension(ntauV1p4+1) :: &
+         tau_binBoundsV1p4 = (/0.3, 1.3, 3.6, 9.4, 23., 60., 10000./)
+    real(wp),parameter,dimension(2,ntauV1p4) :: &
+         tau_binEdgesV1p4 = reshape(source =(/tau_binBoundsV1p4(1),((tau_binBoundsV1p4(k),l=1,2),   &
+                                             k=2,ntauV1p4),100000._wp/),shape = (/2,ntauV1p4/)) 
+    real(wp),parameter,dimension(ntauV1p4) :: &
+         tau_binCentersV1p4 = (tau_binEdgesV1p4(1,:)+tau_binEdgesV1p4(2,:))/2._wp  
+    
+    ! Cloud-top height pressure bin axis
+    integer,parameter :: &
+         npres = 7     
+    real(wp),parameter,dimension(npres+1) :: &
+         pres_binBounds = (/0., 180., 310., 440., 560., 680., 800., 10000./)
+    real(wp),parameter,dimension(npres) :: &
+         pres_binCenters = (/90000., 74000., 62000., 50000., 37500., 24500., 9000./)   
+    real(wp),parameter,dimension(2,npres) :: &
+         pres_binEdges = reshape(source=(/100000.0, 80000.0, 80000.0, 68000.0, 68000.0,    &
+                                           56000.0, 56000.0, 44000.0, 44000.0, 31000.0,    &
+                                           31000.0, 18000.0, 18000.0,     0.0/),           &
+                                           shape=(/2,npres/))
+
+    ! Cloud-top height bin axis #1
+    integer,parameter :: &
+         nhgt = 16
+    real(wp),parameter,dimension(nhgt+1) :: &
+         hgt_binBounds = (/-.99,0.,0.5,1.,1.5,2.,2.5,3.,4.,5.,7.,9.,11.,13.,15.,17.,99./)
+    real(wp),parameter,dimension(nhgt) :: &
+         hgt_binCenters = 1000*(/0.,0.25,0.75,1.25,1.75,2.25,2.75,3.5,4.5,6.,8.,10.,12.,   &
+         14.5,16.,18./)  
+    real(wp),parameter,dimension(2,nhgt) :: &
+         hgt_binEdges = 1000.0*reshape(source=(/-99.0, 0.0, 0.0, 0.5, 0.5, 1.0, 1.0, 1.5,  &
+                                                  1.5, 2.0, 2.0, 2.5, 2.5, 3.0, 3.0, 4.0,  &
+                                                  4.0, 5.0, 5.0, 7.0, 7.0, 9.0, 9.0,11.0,  &
+                                                  11.0,13.0,13.0,15.0,15.0,17.0,17.0,99.0/),&
+                                                  shape=(/2,nhgt/))    
+
+    ! Liquid and Ice particle bins for MODIS joint histogram of optical-depth and particle
+    ! size
+    ! Bin edges match Pincus et al. 2023 observational data (doi:10.5194/essd-15-2483-2023)
+    integer :: i,j
+    integer,parameter :: &
+         nReffLiq = 6, & ! Number of ReffLiq bins for tau/ReffLiq and LWP/ReffLiq joint-histogram
+         nReffIce = 6    ! Number of ReffIce bins for tau/ReffICE and IWP/ReffIce joint-histogram
+    real(wp),parameter,dimension(nReffLiq+1) :: &
+         reffLIQ_binBounds = (/4.0e-6, 8e-6, 1.0e-5, 1.25e-5, 1.5e-5, 2.0e-5, 3.0e-5/)
+    real(wp),parameter,dimension(nReffIce+1) :: &
+         reffICE_binBounds = (/5.0e-6, 1.0e-5, 2.0e-5, 3.0e-5, 4.0e-5, 5.0e-5, 6.0e-5/)
+    real(wp),parameter,dimension(2,nReffICE) :: &
+         reffICE_binEdges = reshape(source=(/reffICE_binBounds(1),((reffICE_binBounds(k),  &
+                                    l=1,2),k=2,nReffICE),reffICE_binBounds(nReffICE+1)/),  &
+                                    shape = (/2,nReffICE/)) 
+    real(wp),parameter,dimension(2,nReffLIQ) :: &
+         reffLIQ_binEdges = reshape(source=(/reffLIQ_binBounds(1),((reffLIQ_binBounds(k),  &
+                                    l=1,2),k=2,nReffLIQ),reffLIQ_binBounds(nReffLIQ+1)/),  &
+                                    shape = (/2,nReffLIQ/))             
+    real(wp),parameter,dimension(nReffICE) :: &
+         reffICE_binCenters = (reffICE_binEdges(1,:)+reffICE_binEdges(2,:))/2._wp
+    real(wp),parameter,dimension(nReffLIQ) :: &
+         reffLIQ_binCenters = (reffLIQ_binEdges(1,:)+reffLIQ_binEdges(2,:))/2._wp
+
+    ! LWP and IWP bins for MODIS joint histogram of (1) LWP and droplet size
+    ! and (2) IWP and particle size
+    integer, parameter :: &
+         nLWP = 7, & ! Number of bins for LWP/ReffLiq joint-histogram
+         nIWP = 7    ! Number of bins for IWP/ReffIce joint-histogram
+    real(wp),parameter,dimension(nLWP+1) :: &
+         LWP_binBounds = (/0., 0.01, 0.03, 0.06, 0.10, 0.15, 0.25, 20.0/) ! kg/m2
+    real(wp),parameter,dimension(nIWP+1) :: &
+         IWP_binBounds = (/0., 0.02, 0.05, 0.10, 0.20, 0.40, 1.00, 20.0/) ! kg/m2
+    real(wp),parameter,dimension(2,nLWP) :: &
+         LWP_binEdges = reshape(source=(/LWP_binBounds(1),((LWP_binBounds(k),  &
+                                l=1,2),k=2,nLWP),LWP_binBounds(nLWP+1)/),  &
+                                shape = (/2,nLWP/))
+    real(wp),parameter,dimension(2,nIWP) :: &
+         IWP_binEdges = reshape(source=(/IWP_binBounds(1),((IWP_binBounds(k),  &
+                                l=1,2),k=2,nIWP),IWP_binBounds(nIWP+1)/),  &
+                                shape = (/2,nIWP/))
+    real(wp),parameter,dimension(nLWP) :: &
+         LWP_binCenters = (LWP_binEdges(1,:)+LWP_binEdges(2,:))/2._wp
+    real(wp),parameter,dimension(nIWP) :: &
+         IWP_binCenters = (IWP_binEdges(1,:)+IWP_binEdges(2,:))/2._wp
+    ! ####################################################################################  
+    ! Constants used by RTTOV.
+    ! ####################################################################################  
+    integer,parameter :: &
+         RTTOV_MAX_CHANNELS = 20
+    character(len=256),parameter :: &
+         rttovDir = '/homedata/rguzman/CALIPSO/RTTOV/rttov_11.3/'
+    ! ####################################################################################  
+    ! Constants used by the PARASOL simulator.
+    ! ####################################################################################  
+    integer,parameter :: &
+         PARASOL_NREFL = 5,  & ! Number of angles in LUT
+         PARASOL_NTAU  = 7     ! Number of optical depths in LUT
+    real(wp),parameter,dimension(PARASOL_NREFL) :: &
+         PARASOL_SZA = (/0.0, 20.0, 40.0, 60.0, 80.0/)
+    REAL(WP),parameter,dimension(PARASOL_NTAU) :: &
+         PARASOL_TAU = (/0., 1., 5., 10., 20., 50., 100./)
+    
+    ! LUTs
+    REAL(WP),parameter,dimension(PARASOL_NREFL,PARASOL_NTAU) :: &
+         ! LUT for liquid particles
+         rlumA = reshape(source=(/ 0.03,     0.03,     0.03,     0.03,     0.03,         &
+                                   0.090886, 0.072185, 0.058410, 0.052498, 0.034730,     &
+                                   0.283965, 0.252596, 0.224707, 0.175844, 0.064488,     &
+                                   0.480587, 0.436401, 0.367451, 0.252916, 0.081667,     &
+                                   0.695235, 0.631352, 0.509180, 0.326551, 0.098215,     &
+                                   0.908229, 0.823924, 0.648152, 0.398581, 0.114411,     &
+                                   1.0,      0.909013, 0.709554, 0.430405, 0.121567/),   &
+                                   shape=(/PARASOL_NREFL,PARASOL_NTAU/)),                & 
+         ! LUT for ice particles         			     
+         rlumB = reshape(source=(/ 0.03,     0.03,     0.03,     0.03,     0.03,         &
+                                   0.092170, 0.087082, 0.083325, 0.084935, 0.054157,     &
+                                   0.311941, 0.304293, 0.285193, 0.233450, 0.089911,     &
+                                   0.511298, 0.490879, 0.430266, 0.312280, 0.107854,     &
+                                   0.712079, 0.673565, 0.563747, 0.382376, 0.124127,     &
+                                   0.898243, 0.842026, 0.685773, 0.446371, 0.139004,     &
+                                   0.976646, 0.912966, 0.737154, 0.473317, 0.145269/),   &
+                                   shape=(/PARASOL_NREFL,PARASOL_NTAU/))  
+
+    ! ####################################################################################
+    ! ISCCP simulator tau/CTP joint histogram information
+    ! ####################################################################################
+    integer,parameter :: &
+         numISCCPTauBins  = ntau, &              ! Number of optical depth bins
+         numISCCPPresBins = npres                ! Number of pressure bins     
+    real(wp),parameter,dimension(ntau+1) :: &
+         isccp_histTau = tau_binBounds           ! Joint-histogram boundaries (optical depth)
+    real(wp),parameter,dimension(npres+1) :: &
+         isccp_histPres = pres_binBounds         ! Joint-histogram boundaries (cloud pressure)
+    real(wp),parameter,dimension(ntau) :: &
+         isccp_histTauCenters = tau_binCenters   ! Joint histogram bin centers (optical depth)
+    real(wp),parameter,dimension(npres) :: &   
+         isccp_histPresCenters = pres_binCenters ! Joint histogram bin centers (cloud pressure) 
+    real(wp),parameter,dimension(2,ntau) :: &
+         isccp_histTauEdges = tau_binEdges       ! Joint histogram bin edges (optical depth)
+    real(wp),parameter,dimension(2,npres) :: &    
+         isccp_histPresEdges = pres_binEdges     ! Joint histogram bin edges (cloud pressure)   
+    
+    ! ####################################################################################
+    ! MISR simulator tau/CTH joint histogram information 
+    ! ####################################################################################
+    integer,parameter ::  &
+         numMISRHgtBins = nhgt, &             ! Number of cloud-top height bins
+         numMISRTauBins = ntau                ! Number of optical depth bins
+    ! Joint histogram boundaries
+    real(wp),parameter,dimension(numMISRHgtBins+1) :: &
+         misr_histHgt = hgt_binBounds         ! Joint-histogram boundaries (cloud height)
+    real(wp),parameter,dimension(numMISRTauBins+1) :: &
+         misr_histTau = tau_binBounds         ! Joint-histogram boundaries (optical-depth)
+    real(wp),parameter,dimension(numMISRHgtBins) :: &
+         misr_histHgtCenters = hgt_binCenters ! Joint-histogram bin centers (cloud height)
+    real(wp),parameter,dimension(2,numMISRHgtBins) :: &
+         misr_histHgtEdges = hgt_BinEdges     ! Joint-histogram bin edges (cloud height)
+ 
+    ! ####################################################################################
+    ! MODIS simulator tau/CTP joint histogram information 
+    ! ####################################################################################
+    integer,parameter :: &
+         numMODISPresBins = npres                    ! Number of pressure bins for joint-histogram    
+    real(wp),parameter,dimension(numMODISPresBins + 1) :: & 
+         modis_histPres = 100*pres_binBounds         ! Joint-histogram boundaries (cloud pressure)
+    real(wp),parameter,dimension(2, numMODISPresBins) :: &
+         modis_histPresEdges = 100*pres_binEdges     ! Joint-histogram bin edges (cloud pressure)
+    real(wp),parameter,dimension(numMODISPresBins) :: &
+         modis_histPresCenters = 100*pres_binCenters ! Joint-histogram bin centers (cloud pressure)
+
+    ! For the MODIS simulator we want to preserve the ability for cospV1.4.0 to use the
+    ! old histogram bin boundaries for optical depth, so these are set up in initialization.
+    integer :: &
+         numMODISTauBins          ! Number of tau bins for joint-histogram
+    real(wp),allocatable,dimension(:) :: &
+         modis_histTau            ! Joint-histogram boundaries (optical depth)
+    real(wp),allocatable,dimension(:,:) :: &
+         modis_histTauEdges       ! Joint-histogram bin edges (optical depth)
+    real(wp),allocatable,dimension(:) :: &
+         modis_histTauCenters     ! Joint-histogram bin centers (optical depth)
+    
+    ! ####################################################################################
+    ! MODIS simulator tau/ReffICE and tau/ReffLIQ joint-histogram information
+    ! ####################################################################################
+    ! Ice
+    integer,parameter :: &
+         numMODISReffIceBins = nReffIce                ! Number of bins for joint-histogram
+    real(wp),parameter,dimension(nReffIce+1) :: &
+         modis_histReffIce = reffICE_binBounds         ! Effective radius bin boundaries
+    real(wp),parameter,dimension(nReffIce) :: &
+         modis_histReffIceCenters = reffICE_binCenters ! Effective radius bin centers
+    real(wp),parameter,dimension(2,nReffICE) :: &
+         modis_histReffIceEdges = reffICE_binEdges     ! Effective radius bin edges
+       
+    ! Liquid
+    integer,parameter :: &
+         numMODISReffLiqBins = nReffLiq                ! Number of bins for joint-histogram
+    real(wp),parameter,dimension(nReffLiq+1) :: &
+         modis_histReffLiq = reffLIQ_binBounds         ! Effective radius bin boundaries 
+    real(wp),parameter,dimension(nReffLiq) :: &
+         modis_histReffLiqCenters = reffLIQ_binCenters ! Effective radius bin centers
+    real(wp),parameter,dimension(2,nReffLiq) :: &
+         modis_histReffLiqEdges = reffLIQ_binEdges     ! Effective radius bin edges
+    ! ####################################################################################
+    ! MODIS simulator LWP/ReffLIQ and IWP/ReffIce joint-histogram information
+    ! ####################################################################################
+    ! Liquid
+    integer,parameter :: &
+         numMODISLWPBins = nLWP                        ! Number of bins for joint-histogram
+    real(wp),parameter,dimension(nLWP+1) :: &
+         modis_histLWP = LWP_binBounds                 ! LWP bin boundaries 
+    real(wp),parameter,dimension(nLWP) :: &
+         modis_histLWPCenters = LWP_binCenters         ! LWP bin centers
+    real(wp),parameter,dimension(2,nLWP) :: &
+         modis_histLWPEdges = LWP_binEdges             ! LWP bin edges
+
+    ! Ice
+    integer,parameter :: &
+         numMODISIWPBins = nIWP                        ! Number of bins for joint-histogram
+    real(wp),parameter,dimension(nIWP+1) :: &
+         modis_histIWP = IWP_binBounds                 ! IWP bin boundaries 
+    real(wp),parameter,dimension(nIWP) :: &
+         modis_histIWPCenters = IWP_binCenters         ! IWP bin centers
+    real(wp),parameter,dimension(2,nIWP) :: &
+         modis_histIWPEdges = IWP_binEdges             ! IWP bin edges     
+
+    ! ####################################################################################
+    ! CLOUDSAT reflectivity histogram information 
+    ! ####################################################################################
+    integer,parameter :: &
+       CLOUDSAT_DBZE_BINS     =   15, & ! Number of dBZe bins in histogram (cfad)
+       CLOUDSAT_DBZE_MIN      = -100, & ! Minimum value for radar reflectivity
+       CLOUDSAT_DBZE_MAX      =   80, & ! Maximum value for radar reflectivity
+       CLOUDSAT_CFAD_ZE_MIN   =  -50, & ! Lower value of the first CFAD Ze bin
+       CLOUDSAT_CFAD_ZE_WIDTH =    5    ! Bin width (dBZe)
+
+    real(wp),parameter,dimension(CLOUDSAT_DBZE_BINS+1) :: &
+         cloudsat_histRef = (/CLOUDSAT_DBZE_MIN,(/(i, i=int(CLOUDSAT_CFAD_ZE_MIN+CLOUDSAT_CFAD_ZE_WIDTH),&
+                             int(CLOUDSAT_CFAD_ZE_MIN+(CLOUDSAT_DBZE_BINS-1)*CLOUDSAT_CFAD_ZE_WIDTH),    &
+                             int(CLOUDSAT_CFAD_ZE_WIDTH))/),CLOUDSAT_DBZE_MAX/)
+    real(wp),parameter,dimension(2,CLOUDSAT_DBZE_BINS) :: &
+         cloudsat_binEdges = reshape(source=(/cloudsat_histRef(1),((cloudsat_histRef(k), &
+                                   l=1,2),k=2,CLOUDSAT_DBZE_BINS),cloudsat_histRef(CLOUDSAT_DBZE_BINS+1)/),&
+                                   shape = (/2,CLOUDSAT_DBZE_BINS/))     
+    real(wp),parameter,dimension(CLOUDSAT_DBZE_BINS) :: &
+         cloudsat_binCenters = (cloudsat_binEdges(1,:)+cloudsat_binEdges(2,:))/2._wp
+
+    ! Parameters for Cloudsat near-surface precipitation diagnostics.
+    ! Precipitation classes.
+    integer, parameter :: &
+         nCloudsatPrecipClass = 10
+    integer, parameter :: &
+         pClass_noPrecip      = 0, & ! No precipitation
+         pClass_Rain1         = 1, & ! Rain possible
+         pClass_Rain2         = 2, & ! Rain probable
+         pClass_Rain3         = 3, & ! Rain certain
+         pClass_Snow1         = 4, & ! Snow possible
+         pClass_Snow2         = 5, & ! Snow certain
+         pClass_Mixed1        = 6, & ! Mixed-precipitation possible
+         pClass_Mixed2        = 7, & ! Mixed-precipitation certain
+         pClass_Rain4         = 8, & ! Heavy rain
+         pClass_default       = 9    ! Default
+    ! Reflectivity bin boundaries, used by decision tree to classify precipitation type.
+    real(wp), dimension(4),parameter :: &
+         Zenonbinval =(/0._wp, -5._wp, -7.5_wp, -15._wp/)
+    real(wp), dimension(6),parameter :: &
+         Zbinvallnd = (/10._wp, 5._wp, 2.5_wp, -2.5_wp, -5._wp, -15._wp/)
+    ! Vertical level index(Nlvgrid) for Cloudsat precipitation occurence/frequency diagnostics.
+    ! Level 39 of Nlvgrid(40) is 480-960m.
+    integer, parameter :: &
+         cloudsat_preclvl = 39
+
+    ! ####################################################################################
+    ! CLOUDSAT and MODIS joint product information (2018.11.22)
+    ! ####################################################################################
+    ! @ COSP_DIAG_WARMRAIN:
+    integer, parameter :: CFODD_NCLASS  =    3 ! # of classes for CFODD (classified by MODIS Reff)
+    integer, parameter :: WR_NREGIME    =    3 ! # of warm-rain regimes (non-precip/drizzling/raining)
+    integer, parameter :: SGCLD_CLR     =    0 ! sub-grid cloud ID (fracout): clear-sky
+    integer, parameter :: SGCLD_ST      =    1 ! sub-grid cloud ID (fracout): stratiform
+    integer, parameter :: SGCLD_CUM     =    2 ! sub-grid cloud ID (fracout): cumulus
+    real(wp),parameter :: CWP_THRESHOLD = 0.00 ! cloud water path threshold
+    real(wp),parameter :: COT_THRESHOLD = 0.30 ! cloud optical thickness threshold
+    real(wp),parameter,dimension(CFODD_NCLASS+1) :: &
+         CFODD_BNDRE = (/5.0e-6, 12.0e-6, 18.0e-6, 35.0e-6/) ! Reff bnds
+    real(wp),parameter,dimension(2) :: &
+         CFODD_BNDZE = (/-15.0, 0.0/)                        ! dBZe bnds (cloud/drizzle/precip)
+    real(wp),parameter :: CFODD_DBZE_MIN    =  -30.0 ! Minimum value of CFODD dBZe bin
+    real(wp),parameter :: CFODD_DBZE_MAX    =   20.0 ! Maximum value of CFODD dBZe bin
+    real(wp),parameter :: CFODD_ICOD_MIN    =    0.0 ! Minimum value of CFODD ICOD bin
+    real(wp),parameter :: CFODD_ICOD_MAX    =   60.0 ! Maximum value of CFODD ICOD bin
+    real(wp),parameter :: CFODD_DBZE_WIDTH  =    2.0 ! Bin width (dBZe)
+    real(wp),parameter :: CFODD_ICOD_WIDTH  =    2.0 ! Bin width (ICOD)
+    integer,parameter :: &
+         CFODD_NDBZE = INT( (CFODD_DBZE_MAX-CFODD_DBZE_MIN)/CFODD_DBZE_WIDTH ) ! Number of CFODD dBZe bins
+    integer,parameter :: &
+         CFODD_NICOD = INT( (CFODD_ICOD_MAX-CFODD_ICOD_MIN)/CFODD_ICOD_WIDTH ) ! Number of CFODD ICOD bins
+    real(wp),parameter,dimension(CFODD_NDBZE+1) :: &
+         CFODD_HISTDBZE = (/int(CFODD_DBZE_MIN),(/(i, i=int(CFODD_DBZE_MIN+CFODD_DBZE_WIDTH), &
+                           int(CFODD_DBZE_MIN+(CFODD_NDBZE-1)*CFODD_DBZE_WIDTH),              &
+                           int(CFODD_DBZE_WIDTH))/),int(CFODD_DBZE_MAX)/)
+    real(wp),parameter,dimension(CFODD_NICOD+1) :: &
+         CFODD_HISTICOD = (/int(CFODD_ICOD_MIN),(/(i, i=int(CFODD_ICOD_MIN+CFODD_ICOD_WIDTH), &
+                           int(CFODD_ICOD_MIN+(CFODD_NICOD-1)*CFODD_ICOD_WIDTH),              &
+                           int(CFODD_ICOD_WIDTH))/),int(CFODD_ICOD_MAX)/)
+    real(wp),parameter,dimension(2,CFODD_NDBZE) :: &
+         CFODD_HISTDBZEedges = reshape(source=(/CFODD_HISTDBZE(1),((CFODD_HISTDBZE(k),    &
+                                 l=1,2),k=2,CFODD_NDBZE),CFODD_HISTDBZE(CFODD_NDBZE+1)/), &
+                                 shape = (/2,CFODD_NDBZE/))
+    real(wp),parameter,dimension(CFODD_NDBZE) :: &
+         CFODD_HISTDBZEcenters = (CFODD_HISTDBZEedges(1,:)+CFODD_HISTDBZEedges(2,:))/2._wp
+    real(wp),parameter,dimension(2,CFODD_NICOD) :: &
+         CFODD_HISTICODedges = reshape(source=(/CFODD_HISTICOD(1),((CFODD_HISTICOD(k),    &
+                                 l=1,2),k=2,CFODD_NICOD),CFODD_HISTICOD(CFODD_NICOD+1)/), &
+                                 shape = (/2,CFODD_NICOD/))
+    real(wp),parameter,dimension(CFODD_NICOD) :: &
+         CFODD_HISTICODcenters = (CFODD_HISTICODedges(1,:)+CFODD_HISTICODedges(2,:))/2._wp
+
+    ! ####################################################################################
+    ! Parameters used by the CALIPSO LIDAR simulator
+    ! #################################################################################### 
+    ! CALISPO backscatter histogram bins 
+    real(wp),parameter ::     &
+       S_cld       = 5.0,     & ! Threshold for cloud detection
+       S_att       = 0.01,    & !
+       S_cld_att   = 30.        ! Threshold for undefined cloud phase detection
+    real(wp),parameter,dimension(SR_BINS+1) :: &
+         calipso_histBsct = (/-1.,0.01,1.2,3.0,5.0,7.0,10.0,15.0,20.0,25.0,30.0,40.0,50.0,   &
+                              60.0,80.0,999./)         ! Backscatter histogram bins
+    real(wp),parameter,dimension(2,SR_BINS) :: &
+         calipso_binEdges = reshape(source=(/calipso_histBsct(1),((calipso_histBsct(k),  &
+                                    l=1,2),k=2,SR_BINS),calipso_histBsct(SR_BINS+1)/),   &
+                                    shape = (/2,SR_BINS/))     
+    real(wp),parameter,dimension(SR_BINS) :: &
+         calipso_binCenters = (calipso_binEdges(1,:)+calipso_binEdges(2,:))/2._wp  
+
+    integer,parameter  ::     &
+       LIDAR_NTEMP = 40, & 
+       LIDAR_NCAT  = 4,  & ! Number of categories for cloudtop heights (high/mid/low/tot)
+       LIDAR_NTYPE = 3     ! Number of categories for OPAQ (opaque/thin cloud + z_opaque)
+    real(wp),parameter,dimension(LIDAR_NTEMP) :: &
+       LIDAR_PHASE_TEMP=                                                                 &
+       (/-91.5,-88.5,-85.5,-82.5,-79.5,-76.5,-73.5,-70.5,-67.5,-64.5,                    &
+         -61.5,-58.5,-55.5,-52.5,-49.5,-46.5,-43.5,-40.5,-37.5,-34.5,                    &
+         -31.5,-28.5,-25.5,-22.5,-19.5,-16.5,-13.5,-10.5, -7.5, -4.5,                    &
+          -1.5,  1.5,  4.5,  7.5, 10.5, 13.5, 16.5, 19.5, 22.5, 25.5/)
+    real(wp),parameter,dimension(2,LIDAR_NTEMP) :: &
+       LIDAR_PHASE_TEMP_BNDS=reshape(source=                                             &
+          (/-273.15, -90., -90., -87., -87., -84., -84., -81., -81., -78.,               &
+             -78.,   -75., -75., -72., -72., -69., -69., -66., -66., -63.,               &
+             -63.,   -60., -60., -57., -57., -54., -54., -51., -51., -48.,               &
+             -48.,   -45., -45., -42., -42., -39., -39., -36., -36., -33.,               &
+             -33.,   -30., -30., -27., -27., -24., -24., -21., -21., -18.,               &
+             -18.,   -15., -15., -12., -12.,  -9.,  -9.,  -6.,  -6.,  -3.,               &
+              -3.,     0.,   0.,   3.,   3.,   6.,   6.,   9.,   9.,  12.,               &
+              12.,    15.,  15.,  18.,  18.,  21.,  21.,  24.,  24., 100. /),            &
+              shape=(/2,40/))        
+
+    ! ####################################################################################
+    ! Parameters used by the GROUND LIDAR simulator
+    ! #################################################################################### 
+    ! GROUND LIDAR backscatter histogram bins 
+!    real(wp),parameter ::     &
+!       S_cld       = 5.0,     & ! Threshold for cloud detection
+!       S_att       = 0.01,    & !
+!       S_cld_att   = 30.        ! Threshold for undefined cloud phase detection
+    real(wp),parameter,dimension(SR_BINS+1) :: &
+         grLidar532_histBsct = (/-1.,0.01,1.2,3.0,5.0,7.0,10.0,15.0,20.0,25.0,30.0,40.0,50.0,  &
+                                 60.0,80.0,999./)         ! Backscatter histogram bins
+    real(wp),parameter,dimension(2,SR_BINS) :: &
+         grLidar532_binEdges = reshape(source=(/grLidar532_histBsct(1),((grLidar532_histBsct(k),  &
+                                    l=1,2),k=2,SR_BINS),grLidar532_histBsct(SR_BINS+1)/),   &
+                                    shape = (/2,SR_BINS/))     
+    real(wp),parameter,dimension(SR_BINS) :: &
+         grLidar532_binCenters = (grLidar532_binEdges(1,:)+grLidar532_binEdges(2,:))/2._wp  
+
+!    integer,parameter  ::     &
+!       LIDAR_NCAT  = 4       ! Number of categories for cloudtop heights (high/mid/low/tot)
+
+    ! ####################################################################################
+    ! Parameters used by the ATLID LIDAR simulator
+    ! #################################################################################### 
+    ! ATLID LIDAR backscatter histogram bins 
+    real(wp),parameter ::     &
+       S_cld_atlid       = 1.74,    & ! Threshold for cloud detection
+       S_att_atlid       = 0.01,    & !
+       S_cld_att_atlid   = 6.67        ! Threshold for undefined cloud phase detection
+    real(wp),parameter,dimension(SR_BINS+1) :: &
+         atlid_histBsct = (/-1.,0.01,1.03,1.38,1.74,2.07,2.62,3.65,4.63,5.63,6.67,8.8,11.25,  &
+                                 13.2,17.2,999./)         ! Backscatter histogram bins
+    real(wp),parameter,dimension(2,SR_BINS) :: &
+         atlid_binEdges = reshape(source=(/atlid_histBsct(1),((atlid_histBsct(k),  &
+                                    l=1,2),k=2,SR_BINS),atlid_histBsct(SR_BINS+1)/),   &
+                                    shape = (/2,SR_BINS/))     
+    real(wp),parameter,dimension(SR_BINS) :: &
+         atlid_binCenters = (atlid_binEdges(1,:)+atlid_binEdges(2,:))/2._wp  
+
+!    integer,parameter  ::     &
+!       LIDAR_NCAT  = 4       ! Number of categories for cloudtop heights (high/mid/low/tot)
+
+    ! ####################################################################################
+    ! New vertical grid used by CALIPSO and CLOUDSAT L3 (set up during initialization)
+    ! ####################################################################################
+    integer :: &
+         Nlvgrid      ! Number of levels in New grid
+    real(wp),dimension(:),allocatable :: &
+       vgrid_zl,  & ! New grid bottoms
+       vgrid_zu,  & ! New grid tops
+       vgrid_z,   & ! New grid center
+       dz           ! dZ
+
+END MODULE MOD_COSP_CONFIG

--- a/components/eam/src/physics/cosp2/local/modis_simulator.F90
+++ b/components/eam/src/physics/cosp2/local/modis_simulator.F90
@@ -1,0 +1,959 @@
+! %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+! Copyright (c) 2015, Regents of the University of Colorado
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without modification, are 
+! permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of 
+!    conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list
+!    of conditions and the following disclaimer in the documentation and/or other 
+!    materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be 
+!    used to endorse or promote products derived from this software without specific prior
+!    written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
+! EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+! MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL 
+! THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+! SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+! OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+! INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! History
+! May 2009:      Robert Pincus - Initial version
+! June 2009:     Steve Platnick and Robert Pincus - Simple radiative transfer for size 
+!                retrievals
+! August 2009:   Robert Pincus - Consistency and bug fixes suggested by Rick Hemler (GFDL) 
+! November 2009: Robert Pincus - Bux fixes and speed-ups after experience with Rick Hemler 
+!                using AM2 (GFDL) 
+! January 2010:  Robert Pincus - Added high, middle, low cloud fractions
+! May 2015:      Dustin Swales - Modified for COSPv2.0
+! %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+!
+! Notes on using the MODIS simulator: 
+!  *) You may provide either layer-by-layer values of optical thickness at 0.67 and 2.1
+!     microns, or optical thickness at 0.67 microns and ice- and liquid-water contents 
+!     (in consistent units of your choosing)
+!  *) Required input also includes the optical thickness and cloud top pressure 
+!     derived from the ISCCP simulator run with parameter top_height = 1. 
+!  *) Cloud particle sizes are specified as radii, measured in meters, though within the 
+!     module we use units of microns. Where particle sizes are outside the bounds used in 
+!     the MODIS retrieval libraries (parameters re_water_min, re_ice_min, etc.) the 
+!     simulator returns missing values (re_fill)
+!
+! When error conditions are encountered this code calls the function complain_and_die, 
+! supplied at the bottom of this module. Users probably want to replace this with 
+! something more graceful. 
+!
+module mod_modis_sim
+  USE MOD_COSP_CONFIG, only: R_UNDEF,modis_histTau,modis_histPres,numMODISTauBins,       &
+                             numMODISPresBins,numMODISReffIceBins,numMODISReffLiqBins,   &
+                             modis_histReffIce,modis_histReffLiq,                        &
+                             modis_histLWP,modis_histIWP,                                &
+                             numMODISLWPBins,numMODISIWPBins
+  USE COSP_KINDS,      ONLY: wp
+  use MOD_COSP_STATS,  ONLY: hist2D
+
+  implicit none
+  ! ##########################################################################
+  ! Retrieval parameters
+   integer, parameter :: &
+        num_trial_res = 15              ! Increase to make the linear pseudo-retrieval of size more accurate
+   
+   real(wp) :: &
+       min_OpticalThickness,          & ! Minimum detectable optical thickness
+       CO2Slicing_PressureLimit,      & ! Cloud with higher pressures use thermal methods, units Pa
+       CO2Slicing_TauLimit,           & ! How deep into the cloud does CO2 slicing see? 
+       phase_TauLimit,                & ! How deep into the cloud does the phase detection see?
+       size_TauLimit,                 & ! Depth of the re retreivals
+       phaseDiscrimination_Threshold, & ! What fraction of total extincton needs to be in a single
+                                        ! category to make phase discrim. work? 
+       re_fill,                       & !
+       re_water_min,                  & ! Minimum effective radius (liquid)
+       re_water_max,                  & ! Maximum effective radius (liquid)
+       re_ice_min,                    & ! Minimum effective radius (ice)
+       re_ice_max,                    & ! Minimum effective radius (ice)
+       highCloudPressureLimit,        & ! High cloud pressure limit (Pa)
+       lowCloudPressureLimit            ! Low cloud pressure limit (Pa)
+  integer :: &
+       phaseIsNone,                   & !
+       phaseIsLiquid,                 & !
+       phaseIsIce,                    & !
+       phaseIsUndetermined              !
+ 
+  real(wp),dimension(num_trial_res) :: &
+       trial_re_w, & ! Near-IR optical params vs size for retrieval scheme (liquid)
+       trial_re_i    ! Near-IR optical params vs size for retrieval scheme (ice)
+  real(wp),dimension(num_trial_res) :: &
+       g_w,        & ! Assymettry parameter for size retrieval (liquid)
+       g_i,        & ! Assymettry parameter for size retrieval (ice)
+       w0_w,       & ! Single-scattering albedo for size retrieval (liquid)
+       w0_i          ! Single-scattering albedo for size retrieval (ice)
+  ! Algorithmic parameters
+  real(wp),parameter :: &
+     ice_density = 0.93_wp ! Liquid density is 1. 
+      
+contains
+  ! ########################################################################################
+  ! MODIS simulator using specified liquid and ice optical thickness in each layer 
+  !
+  ! Note: this simulator operates on all points; to match MODIS itself night-time 
+  !       points should be excluded
+  !
+  ! Note: the simulator requires as input the optical thickness and cloud top pressure 
+  !       derived from the ISCCP simulator run with parameter top_height = 1. 
+  !       If cloud top pressure is higher than about 700 mb, MODIS can't use CO2 slicing 
+  !       and reverts to a thermal algorithm much like ISCCP's. Rather than replicate that 
+  !       alogrithm in this simulator we simply report the values from the ISCCP simulator. 
+  ! ########################################################################################
+  subroutine modis_subcolumn(nSubCols, nLevels, pressureLevels, optical_thickness,       & 
+                         tauLiquidFraction, g, w0,isccpCloudTopPressure,                 &
+                         retrievedPhase, retrievedCloudTopPressure,                      &
+                         retrievedTau,   retrievedSize)
+
+    ! INPUTS
+    integer,intent(in) :: &
+         nSubCols,                  & ! Number of subcolumns
+         nLevels                      ! Number of levels         
+    real(wp),dimension(nLevels+1),intent(in) :: &
+         pressureLevels               ! Gridmean pressure at layer edges (Pa)                  
+    real(wp),dimension(nSubCols,nLevels),intent(in) :: &
+         optical_thickness,         & ! Subcolumn optical thickness @ 0.67 microns.
+         tauLiquidFraction,         & ! Liquid water fraction
+         g,                         & ! Subcolumn assymetry parameter  
+         w0                           ! Subcolumn single-scattering albedo 
+    real(wp),dimension(nSubCols),intent(in) :: &
+         isccpCloudTopPressure        ! ISCCP retrieved cloud top pressure (Pa)
+
+    ! OUTPUTS
+    integer, dimension(nSubCols), intent(inout) :: &
+         retrievedPhase               ! MODIS retrieved phase (liquid/ice/other)              
+    real(wp),dimension(nSubCols), intent(inout) :: &
+         retrievedCloudTopPressure, & ! MODIS retrieved CTP (Pa)
+         retrievedTau,              & ! MODIS retrieved optical depth (unitless)              
+         retrievedSize                ! MODIS retrieved particle size (microns)              
+
+    ! LOCAL VARIABLES
+    logical, dimension(nSubCols)      :: &
+         cloudMask
+    real(wp)                          :: &
+         integratedLiquidFraction,       &
+         obs_Refl_nir
+    real(wp),dimension(num_trial_res) :: &
+         predicted_Refl_nir
+    integer                           :: &
+         i
+
+    ! ########################################################################################
+    !                           Optical depth retrieval 
+    ! This is simply a sum over the optical thickness in each layer. 
+    ! It should agree with the ISCCP values after min values have been excluded.
+    ! ########################################################################################
+    retrievedTau(1:nSubCols) = sum(optical_thickness(1:nSubCols,1:nLevels), dim = 2)
+
+    ! ########################################################################################
+    !                                 Cloud detection
+    ! does optical thickness exceed detection threshold? 
+    ! ########################################################################################
+    cloudMask = retrievedTau(1:nSubCols) >= min_OpticalThickness
+    
+    do i = 1, nSubCols
+       if(cloudMask(i)) then 
+          ! ##################################################################################
+          !                       Cloud top pressure determination 
+          ! MODIS uses CO2 slicing for clouds with tops above about 700 mb and thermal 
+          ! methods for clouds lower than that. For CO2 slicing we report the optical-depth
+          ! weighted pressure, integrating to a specified optical depth.
+          ! This assumes linear variation in p between levels. Linear in ln(p) is probably 
+          ! better, though we'd need to deal with the lowest pressure gracefully. 
+          ! ##################################################################################
+          retrievedCloudTopPressure(i) = cloud_top_pressure(nLevels,(/ 0._wp, optical_thickness(i,1:nLevels) /), &
+                                                            pressureLevels(1:nLevels),CO2Slicing_TauLimit)  
+        
+          ! ##################################################################################
+          !                               Phase determination 
+          ! Determine fraction of total tau that's liquid when ice and water contribute about 
+          ! equally to the extinction we can't tell what the phase is.
+          ! ##################################################################################
+          integratedLiquidFraction = weight_by_extinction(nLevels,optical_thickness(i,1:nLevels),       &
+                                                          tauLiquidFraction(i, 1:nLevels), &
+                                                          phase_TauLimit)
+          if(integratedLiquidFraction >= phaseDiscrimination_Threshold) then 
+             retrievedPhase(i) = phaseIsLiquid
+          else if (integratedLiquidFraction <= 1._wp- phaseDiscrimination_Threshold) then 
+             retrievedPhase(i) = phaseIsIce
+          else 
+             retrievedPhase(i) = phaseIsUndetermined
+          end if
+        
+          ! ##################################################################################
+          !                                 Size determination 
+          ! ##################################################################################
+          
+          ! Compute observed reflectance
+          obs_Refl_nir = compute_toa_reflectace(nLevels,optical_thickness(i,1:nLevels), g(i,1:nLevels), w0(i,1:nLevels))
+
+          ! Compute predicted reflectance
+          if(any(retrievedPhase(i) == (/ phaseIsLiquid, phaseIsUndetermined, phaseIsIce /))) then 
+             if (retrievedPhase(i) == phaseIsLiquid .OR. retrievedPhase(i) == phaseIsUndetermined) then
+                predicted_Refl_nir(1:num_trial_res) = two_stream_reflectance(retrievedTau(i), &
+                     g_w(1:num_trial_res), w0_w(1:num_trial_res))
+                retrievedSize(i) = 1.0e-06_wp*interpolate_to_min(trial_re_w(1:num_trial_res), &
+                     predicted_Refl_nir(1:num_trial_res), obs_Refl_nir)
+             else
+                predicted_Refl_nir(1:num_trial_res) = two_stream_reflectance(retrievedTau(i), &
+                     g_i(1:num_trial_res), w0_i(1:num_trial_res))
+                retrievedSize(i) = 1.0e-06_wp*interpolate_to_min(trial_re_i(1:num_trial_res), &
+                     predicted_Refl_nir(1:num_trial_res), obs_Refl_nir)
+             endif
+          else 
+             retrievedSize(i) = re_fill
+          endif
+       else   
+          ! Values when we don't think there's a cloud. 
+          retrievedCloudTopPressure(i) = R_UNDEF 
+          retrievedPhase(i)            = phaseIsNone
+          retrievedSize(i)             = R_UNDEF 
+          retrievedTau(i)              = R_UNDEF 
+       end if
+    end do
+    where((retrievedSize(1:nSubCols) < 0.).and.(retrievedSize(1:nSubCols) /= R_UNDEF)) &
+         retrievedSize(1:nSubCols) = 1.0e-06_wp*re_fill
+
+    ! We use the ISCCP-derived CTP for low clouds, since the ISCCP simulator ICARUS 
+    ! mimics what MODIS does to first order. 
+    ! Of course, ISCCP cloud top pressures are in mb.   
+    where(cloudMask(1:nSubCols) .and. retrievedCloudTopPressure(1:nSubCols) > CO2Slicing_PressureLimit) &
+         retrievedCloudTopPressure(1:nSubCols) = isccpCloudTopPressure! * 100._wp
+    
+  end subroutine modis_subcolumn
+
+  ! ########################################################################################
+  subroutine modis_column(nPoints,nSubCols,phase, cloud_top_pressure, optical_thickness, particle_size,     &
+       Cloud_Fraction_Total_Mean,         Cloud_Fraction_Water_Mean,         Cloud_Fraction_Ice_Mean,        &
+       Cloud_Fraction_High_Mean,          Cloud_Fraction_Mid_Mean,           Cloud_Fraction_Low_Mean,        &
+       Optical_Thickness_Total_Mean,      Optical_Thickness_Water_Mean,      Optical_Thickness_Ice_Mean,     &
+       Optical_Thickness_Total_MeanLog10, Optical_Thickness_Water_MeanLog10, Optical_Thickness_Ice_MeanLog10,&
+       Cloud_Particle_Size_Water_Mean,    Cloud_Particle_Size_Ice_Mean,      Cloud_Top_Pressure_Total_Mean,  &
+       Liquid_Water_Path_Mean,            Ice_Water_Path_Mean,                                               &    
+       Optical_Thickness_vs_Cloud_Top_Pressure,Optical_Thickness_vs_ReffIce,Optical_Thickness_vs_ReffLiq,    &
+       Optical_Thickness_vs_Cloud_Top_Pressure_Liq,                                                          &
+       Optical_Thickness_vs_Cloud_Top_Pressure_Ice,                                                          &
+       LWP_vs_ReffLiq,                    IWP_vs_ReffIce                                                     &
+       )
+    
+    ! INPUTS
+    integer,intent(in) :: &
+         nPoints,                           & ! Number of horizontal gridpoints
+         nSubCols                             ! Number of subcolumns
+    integer,intent(in), dimension(nPoints, nSubCols) ::  &
+         phase                             
+    real(wp),intent(in),dimension(nPoints, nSubCols) ::  &
+         cloud_top_pressure,                &
+         optical_thickness,                 &
+         particle_size
+ 
+    ! OUTPUTS 
+    real(wp),intent(inout),dimension(nPoints)  ::   & !
+         Cloud_Fraction_Total_Mean,         & !
+         Cloud_Fraction_Water_Mean,         & !
+         Cloud_Fraction_Ice_Mean,           & !
+         Cloud_Fraction_High_Mean,          & !
+         Cloud_Fraction_Mid_Mean,           & !
+         Cloud_Fraction_Low_Mean,           & !
+         Optical_Thickness_Total_Mean,      & !
+         Optical_Thickness_Water_Mean,      & !
+         Optical_Thickness_Ice_Mean,        & !
+         Optical_Thickness_Total_MeanLog10, & !
+         Optical_Thickness_Water_MeanLog10, & !
+         Optical_Thickness_Ice_MeanLog10,   & !
+         Cloud_Particle_Size_Water_Mean,    & !
+         Cloud_Particle_Size_Ice_Mean,      & !
+         Cloud_Top_Pressure_Total_Mean,     & !
+         Liquid_Water_Path_Mean,            & !
+         Ice_Water_Path_Mean                  !
+    real(wp),intent(inout),dimension(nPoints,numMODISTauBins,numMODISPresBins) :: &
+         Optical_Thickness_vs_Cloud_Top_Pressure, &
+         Optical_Thickness_vs_Cloud_Top_Pressure_Liq, &
+         Optical_Thickness_vs_Cloud_Top_Pressure_Ice 
+    real(wp),intent(inout),dimension(nPoints,numMODISLWPBins,numMODISReffLiqBins) :: &    
+         LWP_vs_ReffLiq
+    real(wp),intent(inout),dimension(nPoints,numMODISIWPBins,numMODISReffIceBins) :: &    
+         IWP_vs_ReffIce              
+    real(wp),intent(inout),dimension(nPoints,numMODISTauBins,numMODISReffIceBins) :: &    
+         Optical_Thickness_vs_ReffIce
+    real(wp),intent(inout),dimension(nPoints,numMODISTauBins,numMODISReffLiqBins) :: &    
+         Optical_Thickness_vs_ReffLiq         
+
+    ! LOCAL VARIABLES
+    real(wp), parameter :: &
+         LWP_conversion = 2._wp/3._wp * 1000._wp ! MKS units  
+    integer :: j
+    logical, dimension(nPoints,nSubCols) :: &
+         cloudMask,      &
+         waterCloudMask, &
+         iceCloudMask,   &
+         validRetrievalMask
+    real(wp),dimension(nPoints,nSubCols) :: &
+         tauWRK,ctpWRK,reffIceWRK,reffLiqWRK, &
+         tauLiqWRK,tauIceWRK,lwpWRK,iwpWRK
+
+    ! ########################################################################################
+    ! Include only those pixels with successful retrievals in the statistics 
+    ! ########################################################################################
+    validRetrievalMask(1:nPoints,1:nSubCols) = particle_size(1:nPoints,1:nSubCols) > 0.
+    cloudMask(1:nPoints,1:nSubCols) = phase(1:nPoints,1:nSubCols) /= phaseIsNone .and.       &
+         validRetrievalMask(1:nPoints,1:nSubCols)
+    waterCloudMask(1:nPoints,1:nSubCols) = phase(1:nPoints,1:nSubCols) == phaseIsLiquid .and. &
+         validRetrievalMask(1:nPoints,1:nSubCols)
+    iceCloudMask(1:nPoints,1:nSubCols)   = phase(1:nPoints,1:nSubCols) == phaseIsIce .and.    &
+         validRetrievalMask(1:nPoints,1:nSubCols)
+    
+    ! ########################################################################################
+    ! Use these as pixel counts at first 
+    ! ########################################################################################
+    Cloud_Fraction_Total_Mean(1:nPoints) = real(count(cloudMask,      dim = 2))
+    Cloud_Fraction_Water_Mean(1:nPoints) = real(count(waterCloudMask, dim = 2))
+    Cloud_Fraction_Ice_Mean(1:nPoints)   = real(count(iceCloudMask,   dim = 2))
+    Cloud_Fraction_High_Mean(1:nPoints)  = real(count(cloudMask .and. cloud_top_pressure <=          &
+                                           highCloudPressureLimit, dim = 2)) 
+    Cloud_Fraction_Low_Mean(1:nPoints)   = real(count(cloudMask .and. cloud_top_pressure >           &
+                                           lowCloudPressureLimit,  dim = 2)) 
+    Cloud_Fraction_Mid_Mean(1:nPoints)   = Cloud_Fraction_Total_Mean(1:nPoints) - Cloud_Fraction_High_Mean(1:nPoints)&
+                                           - Cloud_Fraction_Low_Mean(1:nPoints)
+
+    ! ########################################################################################
+    ! Compute column amounts.
+    ! ########################################################################################
+    where(Cloud_Fraction_Total_Mean(1:nPoints) > 0)
+       Optical_Thickness_Total_Mean(1:nPoints) = sum(optical_thickness, mask = cloudMask,      dim = 2) / &
+            Cloud_Fraction_Total_Mean(1:nPoints)
+       Optical_Thickness_Total_MeanLog10(1:nPoints) = sum(log10(abs(optical_thickness)), mask = cloudMask, &
+            dim = 2) / Cloud_Fraction_Total_Mean(1:nPoints)
+    elsewhere
+       Optical_Thickness_Total_Mean      = R_UNDEF
+       Optical_Thickness_Total_MeanLog10 = R_UNDEF
+    endwhere
+    where(Cloud_Fraction_Water_Mean(1:nPoints) > 0)
+       Optical_Thickness_Water_Mean(1:nPoints) = sum(optical_thickness, mask = waterCloudMask, dim = 2) / &
+            Cloud_Fraction_Water_Mean(1:nPoints)
+       Liquid_Water_Path_Mean(1:nPoints) = LWP_conversion*sum(particle_size*optical_thickness, &
+            mask=waterCloudMask,dim=2)/Cloud_Fraction_Water_Mean(1:nPoints)
+       Optical_Thickness_Water_MeanLog10(1:nPoints) = sum(log10(abs(optical_thickness)), mask = waterCloudMask,&
+            dim = 2) / Cloud_Fraction_Water_Mean(1:nPoints)
+       Cloud_Particle_Size_Water_Mean(1:nPoints) = sum(particle_size, mask = waterCloudMask, dim = 2) / &
+            Cloud_Fraction_Water_Mean(1:nPoints)
+    elsewhere
+       Optical_Thickness_Water_Mean      = R_UNDEF
+       Optical_Thickness_Water_MeanLog10 = R_UNDEF
+       Cloud_Particle_Size_Water_Mean    = R_UNDEF
+       Liquid_Water_Path_Mean            = R_UNDEF
+    endwhere
+    where(Cloud_Fraction_Ice_Mean(1:nPoints) > 0)
+       Optical_Thickness_Ice_Mean(1:nPoints)   = sum(optical_thickness, mask = iceCloudMask,   dim = 2) / &
+            Cloud_Fraction_Ice_Mean(1:nPoints)
+       Ice_Water_Path_Mean(1:nPoints) = LWP_conversion * ice_density*sum(particle_size*optical_thickness,&
+            mask=iceCloudMask,dim = 2) /Cloud_Fraction_Ice_Mean(1:nPoints) 
+       Optical_Thickness_Ice_MeanLog10(1:nPoints) = sum(log10(abs(optical_thickness)), mask = iceCloudMask,&
+            dim = 2) / Cloud_Fraction_Ice_Mean(1:nPoints)
+       Cloud_Particle_Size_Ice_Mean(1:nPoints) = sum(particle_size, mask = iceCloudMask,   dim = 2) / &
+            Cloud_Fraction_Ice_Mean(1:nPoints)    
+    elsewhere
+       Optical_Thickness_Ice_Mean        = R_UNDEF
+       Optical_Thickness_Ice_MeanLog10   = R_UNDEF
+       Cloud_Particle_Size_Ice_Mean      = R_UNDEF
+       Ice_Water_Path_Mean               = R_UNDEF
+    endwhere
+    Cloud_Top_Pressure_Total_Mean  = sum(cloud_top_pressure, mask = cloudMask, dim = 2) / &
+                                     max(1, count(cloudMask, dim = 2))
+
+    ! ########################################################################################
+    ! Normalize pixel counts to fraction. 
+    ! ########################################################################################
+    Cloud_Fraction_High_Mean(1:nPoints)  = Cloud_Fraction_High_Mean(1:nPoints)  /nSubcols
+    Cloud_Fraction_Mid_Mean(1:nPoints)   = Cloud_Fraction_Mid_Mean(1:nPoints)   /nSubcols
+    Cloud_Fraction_Low_Mean(1:nPoints)   = Cloud_Fraction_Low_Mean(1:nPoints)   /nSubcols
+    Cloud_Fraction_Total_Mean(1:nPoints) = Cloud_Fraction_Total_Mean(1:nPoints) /nSubcols
+    Cloud_Fraction_Ice_Mean(1:nPoints)   = Cloud_Fraction_Ice_Mean(1:nPoints)   /nSubcols
+    Cloud_Fraction_Water_Mean(1:nPoints) = Cloud_Fraction_Water_Mean(1:nPoints) /nSubcols
+    
+    ! ########################################################################################
+    ! Joint histograms
+    ! ########################################################################################
+    ! Loop over all points
+    tauWRK(1:nPoints,1:nSubCols)     = optical_thickness(1:nPoints,1:nSubCols)
+    ctpWRK(1:nPoints,1:nSubCols)     = cloud_top_pressure(1:nPoints,1:nSubCols)
+    reffIceWRK(1:nPoints,1:nSubCols) = merge(particle_size,R_UNDEF,iceCloudMask)
+    reffLiqWRK(1:nPoints,1:nSubCols) = merge(particle_size,R_UNDEF,waterCloudMask)
+    tauLiqWRK(1:nPoints,1:nSubCols) = merge(optical_thickness,R_UNDEF,waterCloudMask)
+    tauIceWRK(1:nPoints,1:nSubCols) = merge(optical_thickness,R_UNDEF,iceCloudMask)
+    lwpWRK(1:nPoints,1:nSubCols)    = merge(LWP_conversion*particle_size*optical_thickness,R_UNDEF,waterCloudMask)
+    iwpWRK(1:nPoints,1:nSubCols)    = merge(LWP_conversion*ice_density*particle_size*optical_thickness,R_UNDEF,iceCloudMask)
+    do j=1,nPoints
+
+       ! Fill clear and optically thin subcolumns with fill
+       where(.not. cloudMask(j,1:nSubCols)) 
+          tauWRK(j,1:nSubCols) = -999._wp
+          ctpWRK(j,1:nSubCols) = -999._wp
+          tauLiqWRK(j,1:nSubCols) = -999._wp
+          tauIceWRK(j,1:nSubCols) = -999._wp
+          lwpWRK(j,1:nSubCols)    = -999._wp
+          iwpWRK(j,1:nSubCols)    = -999._wp
+       endwhere
+       ! Joint histogram of tau/CTP
+       call hist2D(tauWRK(j,1:nSubCols),ctpWRK(j,1:nSubCols),nSubCols,&
+                   modis_histTau,numMODISTauBins,&
+                   modis_histPres,numMODISPresBins,&
+                   Optical_Thickness_vs_Cloud_Top_Pressure(j,1:numMODISTauBins,1:numMODISPresBins))
+       ! Joint histogram of tau/CTP for Liquid clouds
+       call hist2D(tauLiqWRK(j,1:nSubCols),ctpWRK(j,1:nSubCols),nSubCols,&
+                   modis_histTau,numMODISTauBins,&
+                   modis_histPres,numMODISPresBins,&
+                   Optical_Thickness_vs_Cloud_Top_Pressure_Liq(j,1:numMODISTauBins,1:numMODISPresBins))
+       ! Joint histogram of tau/CTP for Ice clouds
+       call hist2D(tauIceWRK(j,1:nSubCols),ctpWRK(j,1:nSubCols),nSubCols,&
+                   modis_histTau,numMODISTauBins,&
+                   modis_histPres,numMODISPresBins,&
+                   Optical_Thickness_vs_Cloud_Top_Pressure_Ice(j,1:numMODISTauBins,1:numMODISPresBins))
+       ! Joint histogram of LWP/ReffLiq
+       call hist2D(lwpWRK(j,1:nSubCols),reffLiqWRK(j,1:nSubCols),nSubCols,               &
+                   modis_histLWP,numMODISLWPBins,modis_histReffLiq,         &
+                   numMODISReffLiqBins, LWP_vs_ReffLiq(j,1:numMODISLWPBins,1:numMODISReffLiqBins))  
+       ! Joint histogram of IWP/ReffIce
+       call hist2D(iwpWRK(j,1:nSubCols),reffIceWRK(j,1:nSubCols),nSubCols,               &
+                   modis_histIWP,numMODISIWPBins,modis_histReffIce,         &
+                   numMODISReffIceBins, IWP_vs_ReffIce(j,1:numMODISIWPBins,1:numMODISReffIceBins))                               
+       ! Joint histogram of tau/ReffICE
+       call hist2D(tauWRK(j,1:nSubCols),reffIceWrk(j,1:nSubCols),nSubCols,               &
+                   modis_histTau,numMODISTauBins,modis_histReffIce,         &
+                   numMODISReffIceBins, Optical_Thickness_vs_ReffIce(j,1:numMODISTauBins,1:numMODISReffIceBins))
+       ! Joint histogram of tau/ReffLIQ
+       call hist2D(tauWRK(j,1:nSubCols),reffLiqWrk(j,1:nSubCols),nSubCols,               &
+                   modis_histTau,numMODISTauBins,modis_histReffLiq,         &
+                   numMODISReffLiqBins, Optical_Thickness_vs_ReffLiq(j,1:numMODISTauBins,1:numMODISReffLiqBins))                   
+
+    enddo   
+    Optical_Thickness_vs_Cloud_Top_Pressure(1:nPoints,1:numMODISTauBins,1:numMODISPresBins) = &
+         Optical_Thickness_vs_Cloud_Top_Pressure(1:nPoints,1:numMODISTauBins,1:numMODISPresBins)/nSubCols
+    Optical_Thickness_vs_Cloud_Top_Pressure_Liq(1:nPoints,1:numMODISTauBins,1:numMODISPresBins) = &
+         Optical_Thickness_vs_Cloud_Top_Pressure_Liq(1:nPoints,1:numMODISTauBins,1:numMODISPresBins)/nSubCols
+    Optical_Thickness_vs_Cloud_Top_Pressure_Ice(1:nPoints,1:numMODISTauBins,1:numMODISPresBins) = &
+         Optical_Thickness_vs_Cloud_Top_Pressure_Ice(1:nPoints,1:numMODISTauBins,1:numMODISPresBins)/nSubCols
+    LWP_vs_ReffLiq(1:nPoints,1:numMODISLWPBins,1:numMODISReffLiqBins) = &
+         LWP_vs_ReffLiq(1:nPoints,1:numMODISLWPBins,1:numMODISReffLiqBins)/nSubCols 
+    IWP_vs_ReffIce(1:nPoints,1:numMODISIWPBins,1:numMODISReffIceBins) = &
+         IWP_vs_ReffIce(1:nPoints,1:numMODISIWPBins,1:numMODISReffIceBins)/nSubCols      
+    Optical_Thickness_vs_ReffIce(1:nPoints,1:numMODISTauBins,1:numMODISReffIceBins) = &
+         Optical_Thickness_vs_ReffIce(1:nPoints,1:numMODISTauBins,1:numMODISReffIceBins)/nSubCols
+    Optical_Thickness_vs_ReffLiq(1:nPoints,1:numMODISTauBins,1:numMODISReffLiqBins) = &
+         Optical_Thickness_vs_ReffLiq(1:nPoints,1:numMODISTauBins,1:numMODISReffLiqBins)/nSubCols 
+                 
+
+    ! Unit conversion
+    where(Optical_Thickness_vs_Cloud_Top_Pressure /= R_UNDEF) &
+      Optical_Thickness_vs_Cloud_Top_Pressure = Optical_Thickness_vs_Cloud_Top_Pressure*100._wp
+    where(Optical_Thickness_vs_Cloud_Top_Pressure_Liq /= R_UNDEF) &
+      Optical_Thickness_vs_Cloud_Top_Pressure_Liq = Optical_Thickness_vs_Cloud_Top_Pressure_Liq*100._wp
+    where(Optical_Thickness_vs_Cloud_Top_Pressure_Ice /= R_UNDEF) &
+      Optical_Thickness_vs_Cloud_Top_Pressure_Ice = Optical_Thickness_vs_Cloud_Top_Pressure_Ice*100._wp
+    where(LWP_vs_ReffLiq /= R_UNDEF) LWP_vs_ReffLiq = LWP_vs_ReffLiq*100._wp 
+    where(IWP_vs_ReffIce /= R_UNDEF) IWP_vs_ReffIce = IWP_vs_ReffIce*100._wp 
+    where(Optical_Thickness_vs_ReffIce /= R_UNDEF) Optical_Thickness_vs_ReffIce = Optical_Thickness_vs_ReffIce*100._wp
+    where(Optical_Thickness_vs_ReffLiq /= R_UNDEF) Optical_Thickness_vs_ReffLiq = Optical_Thickness_vs_ReffLiq*100._wp
+    where(Cloud_Fraction_Total_Mean /= R_UNDEF) Cloud_Fraction_Total_Mean = Cloud_Fraction_Total_Mean*100._wp
+    where(Cloud_Fraction_Water_Mean /= R_UNDEF) Cloud_Fraction_Water_Mean = Cloud_Fraction_Water_Mean*100._wp
+    where(Cloud_Fraction_Ice_Mean /= R_UNDEF)   Cloud_Fraction_Ice_Mean = Cloud_Fraction_Ice_Mean*100._wp
+    where(Cloud_Fraction_High_Mean /= R_UNDEF)  Cloud_Fraction_High_Mean = Cloud_Fraction_High_Mean*100._wp
+    where(Cloud_Fraction_Mid_Mean /= R_UNDEF)   Cloud_Fraction_Mid_Mean = Cloud_Fraction_Mid_Mean*100._wp
+    where(Cloud_Fraction_Low_Mean /= R_UNDEF)   Cloud_Fraction_Low_Mean = Cloud_Fraction_Low_Mean*100._wp
+
+  end subroutine modis_column
+
+  ! ########################################################################################
+  function cloud_top_pressure(nLevels,tauIncrement, pressure, tauLimit) 
+    ! INPUTS
+    integer, intent(in)                    :: nLevels
+    real(wp),intent(in),dimension(nLevels) :: tauIncrement, pressure
+    real(wp),intent(in)                    :: tauLimit
+    ! OUTPUTS
+    real(wp)                               :: cloud_top_pressure
+    ! LOCAL VARIABLES
+    real(wp)                               :: deltaX, totalTau, totalProduct
+    integer                                :: i 
+    
+    ! Find the extinction-weighted pressure. Assume that pressure varies linearly between 
+    !   layers and use the trapezoidal rule.
+    totalTau = 0._wp; totalProduct = 0._wp
+    do i = 2, size(tauIncrement)
+      if(totalTau + tauIncrement(i) > tauLimit) then 
+        deltaX = tauLimit - totalTau
+        totalTau = totalTau + deltaX
+        !
+        ! Result for trapezoidal rule when you take less than a full step
+        !   tauIncrement is a layer-integrated value
+        !
+        totalProduct = totalProduct           &
+                     + pressure(i-1) * deltaX &
+                     + (pressure(i) - pressure(i-1)) * deltaX**2/(2._wp * tauIncrement(i)) 
+      else
+        totalTau =     totalTau     + tauIncrement(i) 
+        totalProduct = totalProduct + tauIncrement(i) * (pressure(i) + pressure(i-1)) / 2._wp
+      end if 
+      if(totalTau >= tauLimit) exit
+    end do 
+
+    if (totalTau > 0._wp) then
+       cloud_top_pressure = totalProduct/totalTau
+    else
+       cloud_top_pressure = 0._wp
+    endif
+    
+  end function cloud_top_pressure
+
+  ! ########################################################################################
+  function weight_by_extinction(nLevels,tauIncrement, f, tauLimit) 
+    ! INPUTS
+    integer, intent(in)                    :: nLevels
+    real(wp),intent(in),dimension(nLevels) :: tauIncrement, f
+    real(wp),intent(in)                    :: tauLimit
+    ! OUTPUTS
+    real(wp)                               :: weight_by_extinction
+    ! LOCAL VARIABLES
+    real(wp)                               :: deltaX, totalTau, totalProduct
+    integer                                :: i 
+    
+    ! Find the extinction-weighted value of f(tau), assuming constant f within each layer
+    totalTau = 0._wp; totalProduct = 0._wp
+    do i = 1, size(tauIncrement)
+      if(totalTau + tauIncrement(i) > tauLimit) then 
+        deltaX       = tauLimit - totalTau
+        totalTau     = totalTau     + deltaX
+        totalProduct = totalProduct + deltaX * f(i) 
+      else
+        totalTau     = totalTau     + tauIncrement(i) 
+        totalProduct = totalProduct + tauIncrement(i) * f(i) 
+      end if 
+      if(totalTau >= tauLimit) exit
+    end do 
+
+    if (totalTau > 0._wp) then
+       weight_by_extinction = totalProduct/totalTau
+    else
+       weight_by_extinction = 0._wp
+    endif
+    
+  end function weight_by_extinction
+
+  ! ########################################################################################
+  pure function interpolate_to_min(x, y, yobs)
+    ! INPUTS
+    real(wp),intent(in),dimension(num_trial_res) :: x, y 
+    real(wp),intent(in)                          :: yobs
+    ! OUTPUTS
+    real(wp)                                     :: interpolate_to_min
+    ! LOCAL VARIABLES
+    real(wp), dimension(num_trial_res)           :: diff
+    integer                                      :: nPoints, minDiffLoc, lowerBound, upperBound
+    
+    ! Given a set of values of y as y(x), find the value of x that minimizes abs(y - yobs)
+    !   y must be monotonic in x
+ 
+    nPoints = size(y)
+    diff(1:num_trial_res) = y(1:num_trial_res) - yobs
+    minDiffLoc = minloc(abs(diff), dim = 1) 
+    
+    if(minDiffLoc == 1) then 
+      lowerBound = minDiffLoc
+      upperBound = minDiffLoc + 1
+    else if(minDiffLoc == nPoints) then
+      lowerBound = minDiffLoc - 1
+      upperBound = minDiffLoc
+    else
+      if(diff(minDiffLoc-1) * diff(minDiffLoc) < 0) then
+        lowerBound = minDiffLoc-1
+        upperBound = minDiffLoc
+      else 
+        lowerBound = minDiffLoc
+        upperBound = minDiffLoc + 1
+      end if 
+    end if 
+    
+    if(diff(lowerBound) * diff(upperBound) < 0) then     
+      !
+      ! Interpolate the root position linearly if we bracket the root
+      !
+      interpolate_to_min = x(upperBound) - & 
+                           diff(upperBound) * (x(upperBound) - x(lowerBound)) / (diff(upperBound) - diff(lowerBound))
+    else 
+      interpolate_to_min = re_fill
+    end if 
+    
+
+  end function interpolate_to_min
+
+  ! ########################################################################################
+  ! Optical properties
+  ! ########################################################################################
+  elemental function get_g_nir_old (phase, re)
+    ! Polynomial fit for asummetry parameter g in MODIS band 7 (near IR) as a function 
+    !   of size for ice and water
+    ! Fits from Steve Platnick
+
+    ! INPUTS
+    integer, intent(in) :: phase
+    real(wp),intent(in) :: re
+    ! OUTPUTS
+    real(wp)            :: get_g_nir_old 
+    ! LOCAL VARIABLES(parameters)
+    real(wp), dimension(3), parameter :: &
+         ice_coefficients         = (/ 0.7432,  4.5563e-3, -2.8697e-5 /), & 
+         small_water_coefficients = (/ 0.8027, -1.0496e-2,  1.7071e-3 /), & 
+         big_water_coefficients   = (/ 0.7931,  5.3087e-3, -7.4995e-5 /) 
+   
+    ! approx. fits from MODIS Collection 5 LUT scattering calculations
+    if(phase == phaseIsLiquid) then
+      if(re < 8.) then 
+        get_g_nir_old = fit_to_quadratic(re, small_water_coefficients)
+        if(re < re_water_min) get_g_nir_old = fit_to_quadratic(re_water_min, small_water_coefficients)
+      else
+        get_g_nir_old = fit_to_quadratic(re,   big_water_coefficients)
+        if(re > re_water_max) get_g_nir_old = fit_to_quadratic(re_water_max, big_water_coefficients)
+      end if 
+    else
+      get_g_nir_old = fit_to_quadratic(re, ice_coefficients)
+      if(re < re_ice_min) get_g_nir_old = fit_to_quadratic(re_ice_min, ice_coefficients)
+      if(re > re_ice_max) get_g_nir_old = fit_to_quadratic(re_ice_max, ice_coefficients)
+    end if 
+    
+  end function get_g_nir_old
+
+  ! ########################################################################################
+  elemental function get_ssa_nir_old (phase, re)
+    ! Polynomial fit for single scattering albedo in MODIS band 7 (near IR) as a function 
+    !   of size for ice and water
+    ! Fits from Steve Platnick
+    
+    ! INPUTS
+    integer, intent(in) :: phase
+    real(wp),intent(in) :: re
+    ! OUTPUTS
+    real(wp)            :: get_ssa_nir_old
+    ! LOCAL VARIABLES (parameters)
+    real(wp), dimension(4), parameter :: ice_coefficients   = (/ 0.9994, -4.5199e-3, 3.9370e-5, -1.5235e-7 /)
+    real(wp), dimension(3), parameter :: water_coefficients = (/ 1.0008, -2.5626e-3, 1.6024e-5 /) 
+    
+    ! approx. fits from MODIS Collection 5 LUT scattering calculations
+    if(phase == phaseIsLiquid) then
+       get_ssa_nir_old = fit_to_quadratic(re, water_coefficients)
+       if(re < re_water_min) get_ssa_nir_old = fit_to_quadratic(re_water_min, water_coefficients)
+       if(re > re_water_max) get_ssa_nir_old = fit_to_quadratic(re_water_max, water_coefficients)
+    else
+       get_ssa_nir_old = fit_to_cubic(re, ice_coefficients)
+       if(re < re_ice_min) get_ssa_nir_old = fit_to_cubic(re_ice_min, ice_coefficients)
+       if(re > re_ice_max) get_ssa_nir_old = fit_to_cubic(re_ice_max, ice_coefficients)
+    end if
+    
+  end function get_ssa_nir_old
+  
+  elemental function get_g_nir (phase, re)
+    !
+    ! Polynomial fit for asummetry parameter g in MODIS band 7 (near IR) as a function 
+    !   of size for ice and water
+    ! Fits from Steve Platnick
+    !
+
+    integer, intent(in) :: phase
+    real(wp),    intent(in) :: re
+    real(wp) :: get_g_nir 
+
+    real(wp), dimension(3), parameter :: ice_coefficients         = (/ 0.7490, 6.5153e-3, -5.4136e-5 /), &
+                                         small_water_coefficients = (/ 1.0364, -8.8800e-2, 7.0000e-3 /)
+    real(wp), dimension(4), parameter :: big_water_coefficients   = (/ 0.6035, 2.8993e-2, -1.1051e-3, 1.5134e-5 /)
+
+    ! approx. fits from MODIS Collection 6 LUT scattering calculations for 3.7 µm channel size retrievals
+    if(phase == phaseIsLiquid) then 
+       if(re < 7.) then
+          get_g_nir = fit_to_quadratic(re, small_water_coefficients)
+          if(re < re_water_min) get_g_nir = fit_to_quadratic(re_water_min, small_water_coefficients)
+       else
+          get_g_nir = fit_to_cubic(re, big_water_coefficients)
+          if(re > re_water_max) get_g_nir = fit_to_cubic(re_water_max, big_water_coefficients)
+       end if
+    else
+       get_g_nir = fit_to_quadratic(re, ice_coefficients)
+      if(re < re_ice_min) get_g_nir = fit_to_quadratic(re_ice_min, ice_coefficients)
+      if(re > re_ice_max) get_g_nir = fit_to_quadratic(re_ice_max, ice_coefficients)
+    end if 
+    
+  end function get_g_nir
+
+  ! --------------------------------------------
+    elemental function get_ssa_nir (phase, re)
+        integer, intent(in) :: phase
+        real(wp),    intent(in) :: re
+        real(wp)                :: get_ssa_nir
+        !
+        ! Polynomial fit for single scattering albedo in MODIS band 7 (near IR) as a function 
+        !   of size for ice and water
+        ! Fits from Steve Platnick
+        !
+        real(wp), dimension(4), parameter :: ice_coefficients   = (/ 0.9625, -1.8069e-2, 3.3281e-4,-2.2865e-6/)
+        real(wp), dimension(3), parameter :: water_coefficients = (/ 1.0044, -1.1397e-2, 1.3300e-4 /)
+        
+        ! approx. fits from MODIS Collection 6 LUT scattering calculations
+        if(phase == phaseIsLiquid) then
+          get_ssa_nir = fit_to_quadratic(re, water_coefficients)
+          if(re < re_water_min) get_ssa_nir = fit_to_quadratic(re_water_min, water_coefficients)
+          if(re > re_water_max) get_ssa_nir = fit_to_quadratic(re_water_max, water_coefficients)
+        else
+          get_ssa_nir = fit_to_cubic(re, ice_coefficients)
+          if(re < re_ice_min) get_ssa_nir = fit_to_cubic(re_ice_min, ice_coefficients)
+          if(re > re_ice_max) get_ssa_nir = fit_to_cubic(re_ice_max, ice_coefficients)
+        end if 
+
+    end function get_ssa_nir
+
+  
+
+  ! ########################################################################################
+  pure function fit_to_cubic(x, coefficients) 
+    ! INPUTS
+    real(wp),               intent(in) :: x
+    real(wp), dimension(4), intent(in) :: coefficients
+    ! OUTPUTS
+    real(wp)                           :: fit_to_cubic  
+    
+    fit_to_cubic = coefficients(1) + x * (coefficients(2) + x * (coefficients(3) + x * coefficients(4)))
+  end function fit_to_cubic
+    
+  ! ########################################################################################
+  pure function fit_to_quadratic(x, coefficients) 
+    ! INPUTS
+    real(wp),               intent(in) :: x
+    real(wp), dimension(3), intent(in) :: coefficients
+    ! OUTPUTS
+    real(wp)                           :: fit_to_quadratic
+    
+    fit_to_quadratic = coefficients(1) + x * (coefficients(2) + x * (coefficients(3)))
+  end function fit_to_quadratic
+
+  ! ########################################################################################
+  ! Radiative transfer
+  ! ########################################################################################
+  pure function compute_toa_reflectace(nLevels,tau, g, w0)
+    ! This wrapper reports reflectance only and strips out non-cloudy elements from the 
+    ! calculation
+    
+    ! INPUTS
+    integer,intent(in)                     :: nLevels
+    real(wp),intent(in),dimension(nLevels) :: tau, g, w0
+    ! OUTPUTS
+    real(wp)                               :: compute_toa_reflectace
+    ! LOCAL VARIABLES
+    logical, dimension(nLevels)                   :: cloudMask
+    integer, dimension(count(tau(1:nLevels) > 0)) :: cloudIndicies
+    real(wp),dimension(count(tau(1:nLevels) > 0)) :: Refl,Trans
+    real(wp)                                      :: Refl_tot, Trans_tot
+    integer                                       :: i
+
+    cloudMask(1:nLevels) = tau(1:nLevels) > 0. 
+    cloudIndicies = pack((/ (i, i = 1, nLevels) /), mask = cloudMask) 
+    do i = 1, size(cloudIndicies)
+       call two_stream(tau(cloudIndicies(i)), g(cloudIndicies(i)), w0(cloudIndicies(i)), Refl(i), Trans(i))
+    end do
+    
+    call adding_doubling(count(tau(1:nLevels) > 0),Refl(:), Trans(:), Refl_tot, Trans_tot)  
+    
+    compute_toa_reflectace = Refl_tot
+    
+  end function compute_toa_reflectace
+ 
+  ! ########################################################################################
+  pure subroutine two_stream(tauint, gint, w0int, ref, tra) 
+    ! Compute reflectance in a single layer using the two stream approximation 
+    !   The code itself is from Lazaros Oreopoulos via Steve Platnick 
+    ! INPUTS
+    real(wp), intent(in)  :: tauint, gint, w0int
+    ! OUTPUTS
+    real(wp), intent(out) :: ref, tra
+    ! LOCAL VARIABLES
+    !   for delta Eddington code
+    !   xmu, gamma3, and gamma4 only used for collimated beam approximation (i.e., beam=1)
+    integer, parameter :: beam = 2
+    real(wp),parameter :: xmu = 0.866, minConservativeW0 = 0.9999999
+    real(wp) :: tau, w0, g, f, gamma1, gamma2, gamma3, gamma4, &
+         rh, a1, a2, rk, r1, r2, r3, r4, r5, t1, t2, t3, t4, t5, beta, e1, e2, ef1, ef2, den, th
+    
+    ! Compute reflectance and transmittance in a single layer using the two stream approximation 
+    !   The code itself is from Lazaros Oreopoulos via Steve Platnick 
+    f   = gint**2
+    tau = (1._wp - w0int * f) * tauint
+    w0  = (1._wp - f) * w0int / (1._wp - w0int * f)
+    g   = (gint - f) / (1._wp - f)
+
+    ! delta-Eddington (Joseph et al. 1976)
+    gamma1 =  (7._wp - w0* (4._wp + 3._wp * g)) / 4._wp
+    gamma2 = -(1._wp - w0* (4._wp - 3._wp * g)) / 4._wp
+    gamma3 =  (2._wp - 3._wp*g*xmu) / 4._wp
+    gamma4 =   1._wp - gamma3
+
+    if (w0int > minConservativeW0) then
+      ! Conservative scattering
+      if (beam == 1) then
+          rh = (gamma1*tau+(gamma3-gamma1*xmu)*(1-exp(-tau/xmu)))
+  
+          ref = rh / (1._wp + gamma1 * tau)
+          tra = 1._wp - ref       
+      else if(beam == 2) then
+          ref = gamma1*tau/(1._wp + gamma1*tau)
+          tra = 1._wp - ref
+      endif
+    else
+      ! Non-conservative scattering
+      a1 = gamma1 * gamma4 + gamma2 * gamma3
+      a2 = gamma1 * gamma3 + gamma2 * gamma4
+
+      rk = sqrt(gamma1**2 - gamma2**2)
+      
+      r1 = (1._wp - rk * xmu) * (a2 + rk * gamma3)
+      r2 = (1._wp + rk * xmu) * (a2 - rk * gamma3)
+      r3 = 2._wp * rk *(gamma3 - a2 * xmu)
+      r4 = (1._wp - (rk * xmu)**2) * (rk + gamma1)
+      r5 = (1._wp - (rk * xmu)**2) * (rk - gamma1)
+      
+      t1 = (1._wp + rk * xmu) * (a1 + rk * gamma4)
+      t2 = (1._wp - rk * xmu) * (a1 - rk * gamma4)
+      t3 = 2._wp * rk * (gamma4 + a1 * xmu)
+      t4 = r4
+      t5 = r5
+
+      beta = -r5 / r4         
+  
+      e1 = min(rk * tau, 500._wp) 
+      e2 = min(tau / xmu, 500._wp) 
+      
+      if (beam == 1) then
+         den = r4 * exp(e1) + r5 * exp(-e1)
+         ref  = w0*(r1*exp(e1)-r2*exp(-e1)-r3*exp(-e2))/den
+         den = t4 * exp(e1) + t5 * exp(-e1)
+         th  = exp(-e2)
+         tra = th-th*w0*(t1*exp(e1)-t2*exp(-e1)-t3*exp(e2))/den
+      elseif (beam == 2) then
+         ef1 = exp(-e1)
+         ef2 = exp(-2*e1)
+         ref = (gamma2*(1._wp-ef2))/((rk+gamma1)*(1._wp-beta*ef2))
+         tra = (2._wp*rk*ef1)/((rk+gamma1)*(1._wp-beta*ef2))
+      endif
+    end if
+  end subroutine two_stream
+
+  ! ########################################################################################
+  elemental function two_stream_reflectance(tauint, gint, w0int)
+    ! Compute reflectance in a single layer using the two stream approximation 
+    !   The code itself is from Lazaros Oreopoulos via Steve Platnick 
+    
+    ! INPUTS
+    real(wp), intent(in) :: tauint, gint, w0int
+    ! OUTPUTS
+    real(wp)             :: two_stream_reflectance
+    ! LOCAL VARIABLES
+    !   for delta Eddington code
+    !   xmu, gamma3, and gamma4 only used for collimated beam approximation (i.e., beam=1)
+    integer, parameter :: beam = 2
+    real(wp),parameter :: xmu = 0.866, minConservativeW0 = 0.9999999
+    real(wp) :: tau, w0, g, f, gamma1, gamma2, gamma3, gamma4, &
+         rh, a1, a2, rk, r1, r2, r3, r4, r5, t1, t2, t3, t4, t5, beta, e1, e2, ef1, ef2, den
+
+    f   = gint**2
+    tau = (1._wp - w0int * f) * tauint
+    w0  = (1._wp - f) * w0int / (1._wp - w0int * f)
+    g   = (gint - f) / (1._wp - f)
+
+    ! delta-Eddington (Joseph et al. 1976)
+    gamma1 =  (7._wp - w0* (4._wp + 3._wp * g)) / 4._wp
+    gamma2 = -(1._wp - w0* (4._wp - 3._wp * g)) / 4._wp
+    gamma3 =  (2._wp - 3._wp*g*xmu) / 4._wp
+    gamma4 =   1._wp - gamma3
+
+    if (w0int > minConservativeW0) then
+      ! Conservative scattering
+      if (beam == 1) then
+          rh = (gamma1*tau+(gamma3-gamma1*xmu)*(1-exp(-tau/xmu)))
+          two_stream_reflectance = rh / (1._wp + gamma1 * tau)
+      elseif (beam == 2) then
+          two_stream_reflectance = gamma1*tau/(1._wp + gamma1*tau)
+      endif
+        
+    else    !
+
+        ! Non-conservative scattering
+         a1 = gamma1 * gamma4 + gamma2 * gamma3
+         a2 = gamma1 * gamma3 + gamma2 * gamma4
+
+         rk = sqrt(gamma1**2 - gamma2**2)
+         
+         r1 = (1._wp - rk * xmu) * (a2 + rk * gamma3)
+         r2 = (1._wp + rk * xmu) * (a2 - rk * gamma3)
+         r3 = 2._wp * rk *(gamma3 - a2 * xmu)
+         r4 = (1._wp - (rk * xmu)**2) * (rk + gamma1)
+         r5 = (1._wp - (rk * xmu)**2) * (rk - gamma1)
+         
+         t1 = (1._wp + rk * xmu) * (a1 + rk * gamma4)
+         t2 = (1._wp - rk * xmu) * (a1 - rk * gamma4)
+         t3 = 2._wp * rk * (gamma4 + a1 * xmu)
+         t4 = r4
+         t5 = r5
+
+         beta = -r5 / r4         
+         
+         e1 = min(rk * tau, 500._wp) 
+         e2 = min(tau / xmu, 500._wp) 
+         
+         if (beam == 1) then
+           den = r4 * exp(e1) + r5 * exp(-e1)
+           two_stream_reflectance  = w0*(r1*exp(e1)-r2*exp(-e1)-r3*exp(-e2))/den
+         elseif (beam == 2) then
+           ef1 = exp(-e1)
+           ef2 = exp(-2*e1)
+           two_stream_reflectance = (gamma2*(1._wp-ef2))/((rk+gamma1)*(1._wp-beta*ef2))
+         endif
+           
+      end if
+  end function two_stream_reflectance 
+
+  ! ########################################################################################
+  pure subroutine adding_doubling (npts,Refl, Tran, Refl_tot, Tran_tot)      
+    ! Use adding/doubling formulas to compute total reflectance and transmittance from 
+    ! layer values
+    
+    ! INPUTS
+    integer,intent(in)                  :: npts
+    real(wp),intent(in),dimension(npts) :: Refl,Tran
+    ! OUTPUTS
+    real(wp),intent(out)                :: Refl_tot, Tran_tot
+    ! LOCAL VARIABLES
+    integer :: i
+    real(wp), dimension(npts) :: Refl_cumulative, Tran_cumulative
+    
+    Refl_cumulative(1) = Refl(1)
+    Tran_cumulative(1) = Tran(1)    
+    
+    do i=2, npts
+       ! place (add) previous combined layer(s) reflectance on top of layer i, w/black surface (or ignoring surface):
+       Refl_cumulative(i) = Refl_cumulative(i-1) + Refl(i)*(Tran_cumulative(i-1)**2)/(1._wp - Refl_cumulative(i-1) * Refl(i))
+       Tran_cumulative(i) = (Tran_cumulative(i-1)*Tran(i)) / (1._wp - Refl_cumulative(i-1) * Refl(i))
+    end do
+    
+    Refl_tot = Refl_cumulative(size(Refl))
+    Tran_tot = Tran_cumulative(size(Refl))
+    
+  end subroutine adding_doubling
+
+end module mod_modis_sim


### PR DESCRIPTION
Four new joint histogram diagnostics are computed and added to the MODIS simulator (shown in attached slide2). The diagnostics include :
1&2) “CLLIQMODIS” and “CLDICEMODIS” : cloud-fraction joint histograms partitioned by cloud-top pressure (CTP) vs. cloud optical thickness (COT) for liquid-topped clouds and ice-topped clouds, respectively
3) “LWPRLMODIS” : LWP vs. cloud particle size (CER) histogram for liquid-topped clouds
4) “IWPRIMODIS” : IWP vs. CER histogram for ice-topped clouds

The joint histograms match the MODIS observational dataset described by Pincus et al. 2023.

Also, the CER edges of the histogram bins have been changed slightly from their original versions. Three changes are :
(1) The lower bound of the smallest CER bin for liquid-topped clouds has been changed from 0 microns to 4 microns
(2) One of the CER bin edges has been changed from 13 microns to 12.5 microns
(3) The lower bound of the smallest CER bin for ice-topped clouds has been changed from 0 microns to 5 microns

This causes minor changes in the MODIS joint histograms (“CLRLMODIS” and “CLRIMODIS”) with CER as a dimension (shown in attached slide1). 
No other variables are affected by the code modifications.

File changes:
cosp2/Cosp.cmake
cosp2/local/cosp.F90
cam/cospsimulator_intr.F90
Add cosp_config.F90 and modis_simulator.F90 into cosp2/local
[MODISdiag_jointhist.pdf](https://github.com/E3SM-Project/E3SM/files/15268700/MODISdiag_jointhist.pdf)


[NBFB]