### PR TITLE
ROF data moab driver

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -2583,7 +2583,7 @@
       <file grid="atm|lnd" mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_gx3v7.090911.nc</file>
       <file grid="atm|lnd" mask="oQU480">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oQU480.240513.nc</file>
       <file grid="atm|lnd" mask="oQU240">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oQU240.240513.nc</file>
-      <file grid="atm|lnd" mask="oQU240wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oQU240wLI_mask.240513.nc</file>
+      <file grid="atm|lnd" mask="oQU240wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oQU240wLI.240513.nc</file>
       <file grid="atm|lnd" mask="oQU120">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oQU120.240513.nc</file>
       <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oEC60to30v3.240513.nc</file>
       <file grid="atm|lnd" mask="oEC60to30v3wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oEC60to30v3wLI.240513.nc</file>

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -2581,16 +2581,16 @@
       <ny>96</ny>
       <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_gx1v6.090320.nc</file>
       <file grid="atm|lnd" mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_gx3v7.090911.nc</file>
-      <file grid="atm|lnd" mask="oQU480">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oQU480.151209.nc</file>
-      <file grid="atm|lnd" mask="oQU240">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oQU240.151209.nc</file>
-      <file grid="atm|lnd" mask="oQU240wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oQU240wLI_mask.160929.nc</file>
-      <file grid="atm|lnd" mask="oQU120">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oQU120.151209.nc</file>
-      <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oEC60to30v3.161222.nc</file>
-      <file grid="atm|lnd" mask="oEC60to30v3wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oEC60to30v3wLI_mask.170328.nc</file>
+      <file grid="atm|lnd" mask="oQU480">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oQU480.240513.nc</file>
+      <file grid="atm|lnd" mask="oQU240">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oQU240.240513.nc</file>
+      <file grid="atm|lnd" mask="oQU240wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oQU240wLI_mask.240513.nc</file>
+      <file grid="atm|lnd" mask="oQU120">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oQU120.240513.nc</file>
+      <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oEC60to30v3.240513.nc</file>
+      <file grid="atm|lnd" mask="oEC60to30v3wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oEC60to30v3wLI.240513.nc</file>
       <file grid="atm|lnd" mask="ECwISC30to60E1r2">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_ECwISC30to60E1r2.200410.nc</file>
-      <file grid="atm|lnd" mask="oRRS30to10v3">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oRRS30to10v3.171129.nc</file>
-      <file grid="atm|lnd" mask="oRRS30to10v3wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oRRS30to10v3wLI_mask.171109.nc</file>
-      <file grid="atm|lnd" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oRRS18to6v3.170111.nc</file>
+      <file grid="atm|lnd" mask="oRRS30to10v3">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oRRS30to10v3.240513.nc</file>
+      <file grid="atm|lnd" mask="oRRS30to10v3wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oRRS30to10v3wLI.240513.nc</file>
+      <file grid="atm|lnd" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oRRS18to6v3.240513.nc</file>
       <file grid="atm|lnd" mask="oRRS15to5">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oRRS15to5.150722.nc</file>
       <file grid="atm|lnd" mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oARRM60to10.180716.nc</file>
       <file grid="atm|lnd" mask="oARRM60to6">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oARRM60to6.180803.nc</file>
@@ -4209,51 +4209,51 @@
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oQU480">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU480_aave.151209.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU480_patc.151209.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU480_blin.151209.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oQU480/map_oQU480_TO_T62_aave.151209.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oQU480/map_oQU480_TO_T62_aave.151209.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_oQU480_traave.20240513.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_oQU480_trbilin.20240513.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_oQU480_esmfpatch.20240513.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oQU480/map_oQU480_to_T62_traave.20240513.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oQU480/map_oQU480_to_T62_traave.20240513.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oQU240">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU240_aave.151209.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU240_patc.151209.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU240_blin.151209.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oQU240/map_oQU240_TO_T62_aave.151209.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oQU240/map_oQU240_TO_T62_aave.151209.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_oQU240_traave.20240513.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_oQU240_trbilin.20240513.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_oQU240_esmfpatch.20240513.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oQU240/map_oQU240_to_T62_traave.20240513.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oQU240/map_oQU240_to_T62_traave.20240513.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oQU240wLI">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU240wLI_mask_aave.160929.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU240wLI_nomask_aave.160929.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU240wLI_mask_patc.160929.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oQU240wLI/map_oQU240wLI_mask_TO_T62_aave.160929.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oQU240wLI/map_oQU240wLI_mask_TO_T62_aave.160929.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_oQU240wLI_traave.20240513.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_oQU240wLI-nomask_trbilin.20240513.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_oQU240wLI_esmfpatch.20240513.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oQU240wLI/map_oQU240wLI_to_T62_traave.20240513.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oQU240wLI/map_oQU240wLI_to_T62_traave.20240513.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oQU120">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU120_aave.151209.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU120_patc.151209.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU120_blin.151209.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oQU120/map_oQU120_TO_T62_aave.151209.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oQU120/map_oQU120_TO_T62_aave.151209.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_oQU120_traave.20240513.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_oQU120_trbilin.20240513.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_oQU120_esmfpatch.20240513.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oQU120/map_oQU120_to_T62_traave.20240513.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oQU120/map_oQU120_to_T62_traave.20240513.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oEC60to30v3">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oEC60to30v3_aave.161222.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oEC60to30v3_blin.161222.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oEC60to30v3_patc.161222.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_TO_T62_aave.161222.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_TO_T62_aave.161222.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_oEC60to30v3_traave.20240513.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_oEC60to30v3_trbilin.20240513.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_oEC60to30v3_esmfpatch.20240513.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_T62_traave.20240513.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_T62_traave.20240513.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oEC60to30v3wLI">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oEC60to30v3wLI_mask_aave.170328.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oEC60to30v3wLI_nomask_blin.170328.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oEC60to30v3wLI_mask_patc.170328.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30v3wLI/map_oEC60to30v3wLI_mask_TO_T62_aave.170328.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3wLI/map_oEC60to30v3wLI_mask_TO_T62_aave.170328.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_oEC60to30v3wLI_traave.20240513.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_oEC60to30v3wLI-nomask_trbilin.20240513.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_oEC60to30v3wLI_esmfpatch.20240513.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30v3wLI/map_oEC60to30v3wLI_to_T62_traave.20240513.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3wLI/map_oEC60to30v3wLI_to_T62_traave.20240513.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="ECwISC30to60E1r2">
@@ -4265,27 +4265,27 @@
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oRRS30to10v3">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oRRS30to10v3_aave.171128.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oRRS30to10v3_blin.171128.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oRRS30to10v3_patc.171128.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS30to10v3/map_oRRS30to10v3_TO_T62_aave.171128.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS30to10v3/map_oRRS30to10v3_TO_T62_aave.171128.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_oRRS30to10v3_traave.20240513.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_oRRS30to10v3_trbilin.20240513.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_oRRS30to10v3_esmfpatch.20240513.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS30to10v3/map_oRRS30to10v3_to_T62_traave.20240513.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS30to10v3/map_oRRS30to10v3_to_T62_traave.20240513.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oRRS30to10v3wLI">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oRRS30to10v3wLI_mask_aave.171109.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oRRS30to10v3wLI_nomask_blin.171109.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oRRS30to10v3wLI_mask_patc.171109.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS30to10v3wLI/map_oRRS30to10v3wLI_mask_TO_T62_aave.171109.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS30to10v3wLI/map_oRRS30to10v3wLI_mask_TO_T62_aave.171109.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_oRRS30to10v3wLI_traave.20240513.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_oRRS30to10v3wLI-nomask_trbilin.20240513.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_oRRS30to10v3wLI_esmfpatch.20240513.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS30to10v3wLI/map_oRRS30to10v3wLI_to_T62_traave.20240513.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS30to10v3wLI/map_oRRS30to10v3wLI_to_T62_traave.20240513.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oRRS18to6v3">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_oRRS18to6v3_aave.170111.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_oRRS18to6v3_patc.170111.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_oRRS18to6v3_blin.170111.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS18to6v3/map_oRRS18to6v3_to_T62_aave.170111.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS18to6v3/map_oRRS18to6v3_to_T62_aave.170111.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_oRRS18to6v3_traave.20240513.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_oRRS18to6v3_trbilin.20240513.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_oRRS18to6v3_esmfpatch.20240513.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS18to6v3/map_oRRS18to6v3_to_T62_traave.20240513.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS18to6v3/map_oRRS18to6v3_to_T62_traave.20240513.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oRRS15to5">

--- a/components/data_comps/drof/src/drof_comp_mod.F90
+++ b/components/data_comps/drof/src/drof_comp_mod.F90
@@ -25,7 +25,11 @@ module drof_comp_mod
   use drof_shr_mod   , only: rest_file      ! namelist input
   use drof_shr_mod   , only: rest_file_strm ! namelist input
   use drof_shr_mod   , only: nullstr
-
+#ifdef HAVE_MOAB
+  use seq_comm_mct,     only : mrofid ! id of moab rof app
+  use seq_comm_mct,     only : mbrof_data ! turn on if the data rof
+  use iso_c_binding
+#endif
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -67,6 +71,12 @@ CONTAINS
        SDROF, gsmap, ggrid, mpicom, compid, my_task, master_task, &
        inst_suffix, inst_name, logunit, read_restart)
 
+#ifdef HAVE_MOAB
+    use iMOAB, only: iMOAB_DefineTagStorage, iMOAB_GetDoubleTagStorage, &
+                     iMOAB_SetIntTagStorage, iMOAB_SetDoubleTagStorage, &
+                     iMOAB_ResolveSharedEntities, iMOAB_CreateVertices, &
+                     iMOAB_GetMeshInfo, iMOAB_UpdateMeshInfo, iMOAB_WriteMesh
+#endif
     ! !DESCRIPTION: initialize drof model
     implicit none
 
@@ -92,7 +102,19 @@ CONTAINS
     logical       :: exists      ! file existance logical
     integer(IN)   :: nu          ! unit number
     character(CL) :: calendar ! model calendar
+#ifdef HAVE_MOAB
+    character*400  tagname
+    real(R8) latv, lonv
+    integer iv, tagindex, ilat, ilon, ierr  !, arrsize, nfields
+    real(R8), allocatable, target :: data(:)
+    integer(IN), pointer :: idata(:)   ! temporary
+    real(r8), dimension(:), allocatable :: moab_vert_coords  ! temporary
+    !real(R8), allocatable, target :: vtags_zero(:, :)
 
+#ifdef MOABDEBUG
+    character*100 outfile, wopts
+#endif
+#endif
     !--- formats ---
     character(*), parameter :: F00   = "('(drof_comp_init) ',8a)"
     character(*), parameter :: F0L   = "('(drof_comp_init) ',a, l2)"
@@ -164,6 +186,121 @@ CONTAINS
 
     call t_stopf('drof_initmctdom')
 
+
+#ifdef HAVE_MOAB
+   ilat = mct_aVect_indexRA(ggrid%data,'lat')
+   ilon = mct_aVect_indexRA(ggrid%data,'lon')
+   allocate(moab_vert_coords(lsize*3))
+   do iv = 1, lsize
+      lonv = ggrid%data%rAttr(ilon, iv) * SHR_CONST_PI/180.
+      latv = ggrid%data%rAttr(ilat, iv) * SHR_CONST_PI/180.
+      moab_vert_coords(3*iv-2)=COS(latv)*COS(lonv)
+      moab_vert_coords(3*iv-1)=COS(latv)*SIN(lonv)
+      moab_vert_coords(3*iv  )=SIN(latv)
+   enddo
+
+   ! create the vertices with coordinates from MCT domain
+   ierr = iMOAB_CreateVertices(mrofid, lsize*3, 3, moab_vert_coords)
+   if (ierr .ne. 0)  &
+      call shr_sys_abort('Error: fail to create MOAB vertices in land model')
+
+   tagname='GLOBAL_ID'//C_NULL_CHAR
+   ierr = iMOAB_DefineTagStorage(mrofid, tagname, &
+                                 0, & ! dense, integer
+                                 1, & ! number of components
+                                 tagindex )
+   if (ierr .ne. 0)  &
+      call shr_sys_abort('Error: fail to retrieve GLOBAL_ID tag ')
+
+   ! get list of global IDs for Dofs
+   call mct_gsMap_orderedPoints(gsMap, my_task, idata)
+
+   ierr = iMOAB_SetIntTagStorage ( mrofid, tagname, lsize, &
+                                    0, & ! vertex type
+                                    idata)
+   if (ierr .ne. 0)  &
+      call shr_sys_abort('Error: fail to set GLOBAL_ID tag ')
+
+   ierr = iMOAB_ResolveSharedEntities( mrofid, lsize, idata );
+   if (ierr .ne. 0)  &
+      call shr_sys_abort('Error: fail to resolve shared entities')
+
+   deallocate(moab_vert_coords)
+   deallocate(idata)
+
+   ierr = iMOAB_UpdateMeshInfo( mrofid )
+   if (ierr .ne. 0)  &
+      call shr_sys_abort('Error: fail to update mesh info ')
+
+   allocate(data(lsize))
+   ierr = iMOAB_DefineTagStorage( mrofid, "area:aream:frac:mask"//C_NULL_CHAR, &
+                                    1, & ! dense, double
+                                    1, & ! number of components
+                                    tagindex )
+   if (ierr > 0 )  &
+      call shr_sys_abort('Error: fail to create tag: area:aream:frac:mask' )
+
+   data(:) = ggrid%data%rAttr(mct_aVect_indexRA(ggrid%data,'area'),:)
+   tagname='area'//C_NULL_CHAR
+   ierr = iMOAB_SetDoubleTagStorage ( mrofid, tagname, lsize, &
+                                    0, & ! set data on vertices
+                                    data)
+   if (ierr > 0 )  &
+      call shr_sys_abort('Error: fail to get area tag ')
+
+   ! set the same data for aream (model area) as area
+   ! data(:) = ggrid%data%rAttr(mct_aVect_indexRA(ggrid%data,'aream'),:)
+   tagname='aream'//C_NULL_CHAR
+   ierr = iMOAB_SetDoubleTagStorage ( mrofid, tagname, lsize, &
+                                    0, & ! set data on vertices
+                                    data)
+   if (ierr > 0 )  &
+      call shr_sys_abort('Error: fail to set aream tag ')
+
+   data(:) = ggrid%data%rAttr(mct_aVect_indexRA(ggrid%data,'mask'),:)
+   tagname='mask'//C_NULL_CHAR
+   ierr = iMOAB_SetDoubleTagStorage ( mrofid, tagname, lsize, &
+                                    0, & ! set data on vertices
+                                    data)
+   if (ierr > 0 )  &
+      call shr_sys_abort('Error: fail to set mask tag ')
+
+   data(:) = ggrid%data%rAttr(mct_aVect_indexRA(ggrid%data,'frac'),:)
+   tagname='frac'//C_NULL_CHAR
+   ierr = iMOAB_SetDoubleTagStorage ( mrofid, tagname, lsize, &
+                                    0, & ! set data on vertices
+                                    data)
+   if (ierr > 0 )  &
+      call shr_sys_abort('Error: fail to set frac tag ')
+
+   deallocate(data)
+
+   ! define tags
+   ierr = iMOAB_DefineTagStorage( mrofid, trim(seq_flds_x2r_fields)//C_NULL_CHAR, &
+                                    1, & ! dense, double
+                                    1, & ! number of components
+                                    tagindex )
+   if (ierr > 0 )  &
+      call shr_sys_abort('Error: fail to create seq_flds_x2r_fields tags ')
+
+   ierr = iMOAB_DefineTagStorage( mrofid, trim(seq_flds_r2x_fields)//C_NULL_CHAR, &
+                                    1, & ! dense, double
+                                    1, & ! number of components
+                                    tagindex )
+   if (ierr > 0 )  &
+      call shr_sys_abort('Error: fail to create seq_flds_r2x_fields tags ')
+   mbrof_data = .true. ! will have effects 
+#ifdef MOABDEBUG
+      !      debug test
+   outfile = 'RofDataMesh.h5m'//C_NULL_CHAR
+   wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
+      !      write out the mesh file to disk
+   ierr = iMOAB_WriteMesh(mrofid, trim(outfile), trim(wopts))
+   if (ierr .ne. 0) then
+      call shr_sys_abort(subname//' ERROR in writing data mesh rof ')
+   endif
+#endif
+#endif
     !----------------------------------------------------------------------------
     ! Initialize MCT attribute vectors
     !----------------------------------------------------------------------------
@@ -256,6 +393,13 @@ CONTAINS
        SDROF, gsmap, ggrid, mpicom, compid, my_task, master_task, &
        inst_suffix, logunit, case_name)
 
+#ifdef MOABDEBUG
+    use iMOAB, only: iMOAB_WriteMesh
+#endif
+#ifdef HAVE_MOAB
+    use seq_flds_mod    , only: seq_flds_r2x_fields 
+    use seq_flds_mod    , only: moab_set_tag_from_av
+#endif
     ! !DESCRIPTION:  run method for drof model
     implicit none
 
@@ -285,7 +429,18 @@ CONTAINS
     integer(IN)   :: nu                ! unit number
     integer(IN)   :: nflds_r2x
     character(len=18) :: date_str
+#ifdef HAVE_MOAB
+    real(R8), allocatable, target :: datam(:)
+    type(mct_list) :: temp_list
+    integer :: size_list, index_list
+    type(mct_string)    :: mctOStr  !
+    character*400  tagname, mct_field
+#ifdef MOABDEBUG
+    integer  :: cur_drof_stepno, ierr
+    character*100 outfile, wopts, lnum
+#endif
 
+#endif
     character(*), parameter :: F00   = "('(drof_comp_run) ',8a)"
     character(*), parameter :: F04   = "('(drof_comp_run) ',2a,2i8,'s')"
     character(*), parameter :: subName = "(drof_comp_run) "
@@ -384,6 +539,32 @@ CONTAINS
     !----------------------------------------------------------------------------
     ! Log output for model date
     !----------------------------------------------------------------------------
+#ifdef HAVE_MOAB
+    lsize = mct_avect_lsize(r2x) ! is it the same as mct_avect_lsize(avstrm) ?
+    allocate(datam(lsize)) ! 
+    call mct_list_init(temp_list ,seq_flds_r2x_fields)
+    size_list=mct_list_nitem (temp_list)
+    do index_list = 1, size_list
+      call mct_list_get(mctOStr,index_list,temp_list)
+      mct_field = mct_string_toChar(mctOStr)
+      tagname= trim(mct_field)//C_NULL_CHAR
+      call moab_set_tag_from_av(tagname, r2x, index_list, mrofid, datam, lsize) ! loop over all a2x fields, not just a few
+    enddo
+    call mct_list_clean(temp_list)
+    deallocate(datam) ! maybe we should keep it around, deallocate at the final only?
+
+#ifdef MOABDEBUG
+    call seq_timemgr_EClockGetData( EClock, stepno=cur_drof_stepno )
+    write(lnum,"(I0.2)")cur_drof_stepno
+    outfile = 'drof_comp_run_'//trim(lnum)//'.h5m'//C_NULL_CHAR
+    wopts   = 'PARALLEL=WRITE_PART'//C_NULL_CHAR
+    ierr = iMOAB_WriteMesh(mrofid, outfile, wopts)
+    if (ierr > 0 )  then
+       write(logunit,*) 'Failed to write data rof component state '
+    endif
+#endif
+
+#endif
 
     call t_startf('drof_run2')
     if (my_task == master_task) then

--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -846,7 +846,7 @@ contains
      use spmdmod          , only: masterproc
     use iMOAB        , only: iMOAB_CreateVertices, iMOAB_WriteMesh, iMOAB_RegisterApplication, &
     iMOAB_DefineTagStorage, iMOAB_SetIntTagStorage, iMOAB_SetDoubleTagStorage, &
-    iMOAB_ResolveSharedEntities, iMOAB_CreateElements, iMOAB_MergeVertices, iMOAB_UpdateMeshInfo
+    iMOAB_ResolveSharedEntities, iMOAB_CreateElements, iMOAB_UpdateMeshInfo
 
     type(bounds_type) , intent(in)  :: bounds
     integer , intent(in) :: LNDID ! id of the land app

--- a/driver-moab/main/component_type_mod.F90
+++ b/driver-moab/main/component_type_mod.F90
@@ -508,7 +508,7 @@ contains
      difference = sqrt(differenceg)
      iamroot = seq_comm_iamroot(CPLID)
      if ( iamroot ) then
-        print * , subname, trim(comp%ntype), ' comp, difference on tag ', trim(tagname), ' = ', difference
+        print * , subname, trim(comp%ntype), ' on cpl, difference on tag ', trim(tagname), ' = ', difference
         !call shr_sys_abort(subname//'differences between mct and moab values')
      endif
      deallocate(GlobalIds)

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -1017,7 +1017,7 @@ contains
       integer                  :: mpigrp_old   !  component group pes
       integer                  :: ierr, context_id
       character*200            :: appname, outfile, wopts, ropts
-      character(CL)            :: rtm_mesh
+      character(CL)            :: rtm_mesh, rof_domain
       character(CL)            :: lnd_domain
       character(CL)            :: ocn_domain
       character(CL)            :: atm_mesh
@@ -1633,10 +1633,14 @@ contains
             ierr = iMOAB_RegisterApplication(trim(appname), mpicom_new, id_join, mbrxid)
 
             ! load mesh from scrip file passed from river model
-            call seq_infodata_GetData(infodata,rof_mesh=rtm_mesh)
-            outfile = trim(rtm_mesh)//C_NULL_CHAR
-            ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=RCBZOLTAN'//C_NULL_CHAR
-         
+            call seq_infodata_GetData(infodata,rof_mesh=rtm_mesh,rof_domain=rof_domain)
+            if ( trim(rof_domain) == 'none' ) then
+               outfile = trim(rtm_mesh)//C_NULL_CHAR
+               ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=RCBZOLTAN'//C_NULL_CHAR
+            else
+               outfile = trim(rof_domain)//C_NULL_CHAR
+               ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE='//C_NULL_CHAR
+            endif
             nghlay = 0 ! no ghost layers 
             ierr = iMOAB_LoadMesh(mbrxid, outfile, ropts, nghlay)
             if ( ierr .ne. 0  ) then

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -1117,6 +1117,9 @@ contains
                   write(logunit,*) 'Failed to load atm domain mesh on coupler'
                   call shr_sys_abort(subname//' ERROR Failed to load atm domain mesh on coupler  ')
                endif
+               if (seq_comm_iamroot(CPLID)) then
+                  write(logunit,'(A)') subname//' load atm domain mesh from file '//trim(atm_mesh)
+               endif
                ! right now, turn atm_pg_active to true
                atm_pg_active = .true. ! FIXME TODO 
                ! need to add global id tag to the app, it will be used in restart
@@ -1295,6 +1298,9 @@ contains
                   write(logunit,*) 'Failed to load ocean domain mesh on coupler'
                   call shr_sys_abort(subname//' ERROR Failed to load ocean domain mesh on coupler  ')
                endif
+               if (seq_comm_iamroot(CPLID)) then
+                  write(logunit,'(A)') subname//' load ocn domain mesh from file '//trim(ocn_domain)
+               endif
                ! need to add global id tag to the app, it will be used in restart
                tagtype = 0  ! dense, integer
                numco = 1
@@ -1404,6 +1410,9 @@ contains
                   write(logunit,*) 'Failed to load second ocean domain mesh on coupler'
                   call shr_sys_abort(subname//' ERROR Failed to load second ocean domain mesh on coupler  ')
                endif
+               if (seq_comm_iamroot(CPLID)) then
+                  write(logunit,'(A)') subname//' load ocn domain mesh from file for second ocn instance '//trim(ocn_domain)
+               endif
                ! need to add global id tag to the app, it will be used in restart
                tagtype = 0  ! dense, integer
                numco = 1
@@ -1457,6 +1466,9 @@ contains
             if (ierr .ne. 0) then
                write(logunit,*) subname,' error in reading land coupler mesh from ', trim(lnd_domain)
                call shr_sys_abort(subname//' ERROR in reading land coupler mesh')
+            endif
+            if (seq_comm_iamroot(CPLID)) then
+               write(logunit,'(A)') subname//' load lnd domain mesh from file '//trim(lnd_domain)
             endif
             ! need to add global id tag to the app, it will be used in restart
             tagtype = 0  ! dense, integer
@@ -1643,9 +1655,13 @@ contains
             endif
             nghlay = 0 ! no ghost layers 
             ierr = iMOAB_LoadMesh(mbrxid, outfile, ropts, nghlay)
+            if (seq_comm_iamroot(CPLID)) then
+               write(logunit,'(A)') subname//' load rof from file '//trim(outfile)
+            endif
             if ( ierr .ne. 0  ) then
                call shr_sys_abort( subname//' ERROR: cannot read rof mesh on coupler' )
             end if
+            
              ! need to add global id tag to the app, it will be used in restart
             tagtype = 0  ! dense, integer
             numco = 1

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -1112,7 +1112,7 @@ contains
             else
               ! we need to read the atm mesh on coupler, from domain file 
                ierr = iMOAB_LoadMesh(mbaxid, trim(atm_mesh)//C_NULL_CHAR, &
-                "PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;NO_CULLING", 0)
+                "PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION;NO_CULLING", 0)
                if ( ierr /= 0 ) then
                   write(logunit,*) 'Failed to load atm domain mesh on coupler'
                   call shr_sys_abort(subname//' ERROR Failed to load atm domain mesh on coupler  ')
@@ -1290,7 +1290,7 @@ contains
             else
               ! we need to read the ocean mesh on coupler, from domain file 
                ierr = iMOAB_LoadMesh(mboxid, trim(ocn_domain)//C_NULL_CHAR, &
-                "PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;NO_CULLING", 0)
+                "PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION", 0)
                if ( ierr /= 0 ) then
                   write(logunit,*) 'Failed to load ocean domain mesh on coupler'
                   call shr_sys_abort(subname//' ERROR Failed to load ocean domain mesh on coupler  ')
@@ -1399,7 +1399,7 @@ contains
             else
                 ! we need to read the ocean mesh on coupler, from domain file 
                ierr = iMOAB_LoadMesh(mbofxid, trim(ocn_domain)//C_NULL_CHAR, &
-                "PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;NO_CULLING", 0)
+                "PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION", 0)
                if ( ierr /= 0 ) then
                   write(logunit,*) 'Failed to load second ocean domain mesh on coupler'
                   call shr_sys_abort(subname//' ERROR Failed to load second ocean domain mesh on coupler  ')
@@ -1445,7 +1445,7 @@ contains
             ! do not receive the mesh anymore, read it from file, then pair it with mlnid, component land PC mesh
             ! similar to rof mosart mesh  
             
-            ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE='//C_NULL_CHAR
+            ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION'//C_NULL_CHAR
             call seq_infodata_GetData(infodata,lnd_domain=lnd_domain)
             outfile = trim(lnd_domain)//C_NULL_CHAR
             nghlay = 0 ! no ghost layers 
@@ -1639,7 +1639,7 @@ contains
                ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=RCBZOLTAN'//C_NULL_CHAR
             else
                outfile = trim(rof_domain)//C_NULL_CHAR
-               ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE='//C_NULL_CHAR
+               ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION'//C_NULL_CHAR
             endif
             nghlay = 0 ! no ghost layers 
             ierr = iMOAB_LoadMesh(mbrxid, outfile, ropts, nghlay)

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -2876,17 +2876,6 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
 
     call t_drvstartf (trim(timer),barrier=mpicom_CPLID)
     do eri = 1,num_inst_rof
-#ifdef MOABDEBUG
-       if (mboxid .ge. 0 ) then !  we are on coupler pes, for sure
-          write(lnum,"(I0.2)") num_moab_exports
-          outfile = 'OcnCpl_Bef_R2O_'//trim(lnum)//'.h5m'//C_NULL_CHAR
-          wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
-          ierr = iMOAB_WriteMesh(mboxid, trim(outfile), trim(wopts))
-          if (ierr .ne. 0) then
-            call shr_sys_abort(subname//' error in writing ocean before Rof 2 ocn proj')
-          endif
-       endif
-#endif
        r2x_rx => component_get_c2x_cx(rof(eri))
        call seq_map_map(mapper_Rr2o_liq, r2x_rx, r2x_ox(eri), &
             fldlist=seq_flds_r2o_liq_fluxes, norm=.false.)
@@ -2896,25 +2885,6 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
           call seq_map_map(mapper_Fr2o, r2x_rx, r2x_ox(eri), &
                fldlist='Flrr_flood', norm=.true.)
        endif
-#ifdef MOABDEBUG
-       if (mboxid .ge. 0 ) then !  we are on coupler pes, for sure
-          write(lnum,"(I0.2)") num_moab_exports
-          outfile = 'OcnCpl_Aft_R2O_'//trim(lnum)//'.h5m'//C_NULL_CHAR
-          wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
-
-#ifdef MOABCOMP
-          ent_type = 1 ! cell for ocean
-          mct_field = 'Forr_rofi'
-          tagname= 'Forr_rofi'//C_NULL_CHAR
-          call compare_mct_av_moab_tag(ocn(1), r2x_ox(1), mct_field,  mboxid, tagname, ent_type, difference, .true.)
-#endif
-      
-          ierr = iMOAB_WriteMesh(mboxid, trim(outfile), trim(wopts))
-          if (ierr .ne. 0) then
-            call shr_sys_abort(subname//' error in writing ocean after Rof 2 ocn proj')
-          endif
-       endif
-#endif
     enddo
     call t_drvstopf  (trim(timer))
 

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -2860,6 +2860,11 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
     character*32             :: outfile, wopts, lnum
     integer         :: ierr
 #endif
+#ifdef MOABCOMP
+     character*100             :: tagname, mct_field
+     integer :: ent_type
+     real*8 :: difference
+#endif
     ! Arguments
     character(len=*), intent(in) :: timer
     !
@@ -2878,7 +2883,7 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
           wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
           ierr = iMOAB_WriteMesh(mboxid, trim(outfile), trim(wopts))
           if (ierr .ne. 0) then
-            call shr_sys_abort(subname//' error in writing ocean after Rof 2 ocn proj')
+            call shr_sys_abort(subname//' error in writing ocean before Rof 2 ocn proj')
           endif
        endif
 #endif
@@ -2896,6 +2901,14 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
           write(lnum,"(I0.2)") num_moab_exports
           outfile = 'OcnCpl_Aft_R2O_'//trim(lnum)//'.h5m'//C_NULL_CHAR
           wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
+
+#ifdef MOABCOMP
+          ent_type = 1 ! cell for ocean
+          mct_field = 'Forr_rofi'
+          tagname= 'Forr_rofi'//C_NULL_CHAR
+          call compare_mct_av_moab_tag(ocn(1), r2x_ox(1), mct_field,  mboxid, tagname, ent_type, difference, .true.)
+#endif
+      
           ierr = iMOAB_WriteMesh(mboxid, trim(outfile), trim(wopts))
           if (ierr .ne. 0) then
             call shr_sys_abort(subname//' error in writing ocean after Rof 2 ocn proj')

--- a/driver-moab/shr/seq_comm_mct.F90
+++ b/driver-moab/shr/seq_comm_mct.F90
@@ -241,6 +241,7 @@ module seq_comm_mct
   integer, public :: mbrmapro ! iMOAB id for read map between river and ocean; it exists on coupler PEs
                               ! similar to intx id, oa, la; 
   integer, public :: mbrxoid  ! iMOAB id for rof migrated to coupler for ocean context (r2o mapping)
+  logical, public :: mbrof_data = .false. ! made true if no rtm mesh, which means data rof ? 
   integer, public :: mbintxar ! iMOAB id for intx mesh between atm and river
   integer, public :: mbintxlr ! iMOAB id for intx mesh between land and river
   integer, public :: mbintxrl ! iMOAB id for intx mesh between river and land

--- a/driver-moab/shr/seq_infodata_mod.F90
+++ b/driver-moab/shr/seq_infodata_mod.F90
@@ -232,6 +232,7 @@ MODULE seq_infodata_mod
      integer(SHR_KIND_IN)    :: iac_ny          ! nx, ny of "2d" grid
      character(SHR_KIND_CL)  :: lnd_domain      ! path to land domain file
      character(SHR_KIND_CL)  :: rof_mesh        ! path to river mesh file
+     character(SHR_KIND_CL)  :: rof_domain      ! path to river domain file; only for data rof for now
      character(SHR_KIND_CL)  :: ocn_domain      ! path to ocean domain file, used by data ocean models only
      character(SHR_KIND_CL)  :: atm_mesh        ! path to atmosphere domain/mesh file, used by data atm models only
 
@@ -792,6 +793,7 @@ CONTAINS
        infodata%iac_ny = 0
        infodata%lnd_domain = 'none'
        infodata%rof_mesh = 'none'
+       infodata%rof_domain = 'none'
        infodata%ocn_domain = 'none' ! will be used for ocean data models only; will be used as a signal 
        infodata%atm_mesh = 'none' ! will be used for atmosphere data models only; will be used as a signal
                                     ! not sure if it exists always actually
@@ -1037,8 +1039,8 @@ CONTAINS
        glc_phase, rof_phase, atm_phase, lnd_phase, ocn_phase, ice_phase,  &
        wav_phase, iac_phase, esp_phase, wav_nx, wav_ny, atm_nx, atm_ny,   &
        lnd_nx, lnd_ny, rof_nx, rof_ny, ice_nx, ice_ny, ocn_nx, ocn_ny,    &
-       iac_nx, iac_ny, glc_nx, glc_ny, lnd_domain, rof_mesh, ocn_domain,  &
-       atm_mesh, eps_frac,                                                &
+       iac_nx, iac_ny, glc_nx, glc_ny, lnd_domain, rof_mesh, rof_domain,  &
+       ocn_domain,  atm_mesh, eps_frac,                                   &
        eps_amask, eps_agrid, eps_aarea, eps_omask, eps_ogrid, eps_oarea,  &
        reprosum_use_ddpdd, reprosum_allow_infnan,                         &
        reprosum_diffmax, reprosum_recompute,                              &
@@ -1212,6 +1214,7 @@ CONTAINS
     integer(SHR_KIND_IN),   optional, intent(OUT) :: iac_ny
     character(SHR_KIND_CL), optional, intent(OUT) :: lnd_domain
     character(SHR_KIND_CL), optional, intent(OUT) :: rof_mesh
+    character(SHR_KIND_CL), optional, intent(OUT) :: rof_domain
     character(SHR_KIND_CL), optional, intent(OUT) :: ocn_domain
     character(SHR_KIND_CL), optional, intent(OUT) :: atm_mesh
 
@@ -1401,6 +1404,7 @@ CONTAINS
     if ( present(iac_ny)         ) iac_ny         = infodata%iac_ny
     if ( present(lnd_domain)     ) lnd_domain     = infodata%lnd_domain
     if ( present(rof_mesh)       ) rof_mesh       = infodata%rof_mesh
+    if ( present(rof_domain)     ) rof_domain     = infodata%rof_domain
     if ( present(ocn_domain)     ) ocn_domain     = infodata%ocn_domain
     if ( present(atm_mesh)       ) atm_mesh       = infodata%atm_mesh
 
@@ -1598,8 +1602,8 @@ CONTAINS
        wav_phase, iac_phase, esp_phase, wav_nx, wav_ny, atm_nx, atm_ny,   &
        lnd_nx, lnd_ny, rof_nx, rof_ny, ice_nx, ice_ny, ocn_nx, ocn_ny,    &
        iac_nx, iac_ny, glc_nx, glc_ny, eps_frac, eps_amask, lnd_domain,   &
-       rof_mesh, ocn_domain, atm_mesh, eps_agrid, eps_aarea, eps_omask,   &
-       eps_ogrid, eps_oarea,                                              &
+       rof_mesh, rof_domain, ocn_domain, atm_mesh, eps_agrid, eps_aarea,  &
+       eps_omask, eps_ogrid, eps_oarea,                                   &
        reprosum_use_ddpdd, reprosum_allow_infnan,                         &
        reprosum_diffmax, reprosum_recompute,                              &
        mct_usealltoall, mct_usevector, glc_valid_input, nlmaps_verbosity)
@@ -1771,6 +1775,7 @@ CONTAINS
     integer(SHR_KIND_IN),   optional, intent(IN)    :: iac_ny
     character(SHR_KIND_CL), optional, intent(IN)    :: lnd_domain
     character(SHR_KIND_CL), optional, intent(IN)    :: rof_mesh
+    character(SHR_KIND_CL), optional, intent(IN)    :: rof_domain
     character(SHR_KIND_CL), optional, intent(IN)    :: ocn_domain
     character(SHR_KIND_CL), optional, intent(IN)    :: atm_mesh
 
@@ -1959,6 +1964,7 @@ CONTAINS
     if ( present(iac_ny)         ) infodata%iac_ny         = iac_ny
     if ( present(lnd_domain)     ) infodata%lnd_domain     = lnd_domain
     if ( present(rof_mesh)       ) infodata%rof_mesh       = rof_mesh
+    if ( present(rof_domain)     ) infodata%rof_domain     = rof_domain
     if ( present(ocn_domain)     ) infodata%ocn_domain     = ocn_domain
     if ( present(atm_mesh)       ) infodata%atm_mesh       = atm_mesh
 
@@ -2271,6 +2277,7 @@ CONTAINS
     call shr_mpi_bcast(infodata%iac_ny,                  mpicom)
     call shr_mpi_bcast(infodata%lnd_domain,              mpicom)
     call shr_mpi_bcast(infodata%rof_mesh,                mpicom)
+    call shr_mpi_bcast(infodata%rof_domain,              mpicom)
     call shr_mpi_bcast(infodata%ocn_domain,              mpicom)
     call shr_mpi_bcast(infodata%atm_mesh,                mpicom)
     call shr_mpi_bcast(infodata%nextsw_cday,             mpicom)
@@ -2518,6 +2525,7 @@ CONTAINS
        call shr_mpi_bcast(infodata%rof_ny,             mpicom, pebcast=cmppe)
        call shr_mpi_bcast(infodata%flood_present,      mpicom, pebcast=cmppe)
        call shr_mpi_bcast(infodata%rof_mesh,           mpicom, pebcast=cmppe)
+       call shr_mpi_bcast(infodata%rof_domain,         mpicom, pebcast=cmppe)
        ! dead_comps is true if it's ever set to true
        deads = infodata%dead_comps
        call shr_mpi_bcast(deads,                       mpicom, pebcast=cmppe)
@@ -2990,6 +2998,7 @@ CONTAINS
     write(logunit,F0I) subname,'iac_ny                   = ', infodata%iac_ny
     write(logunit,F0I) subname,'lnd_domain               = ', infodata%lnd_domain
     write(logunit,F0I) subname,'rof_mesh                 = ', infodata%rof_mesh
+    write(logunit,F0I) subname,'rof_domain               = ', infodata%rof_domain
     write(logunit,F0I) subname,'ocn_domain               = ', infodata%ocn_domain
     write(logunit,F0I) subname,'atm_mesh                 = ', infodata%atm_mesh
 


### PR DESCRIPTION
Extend moab driver for a case with ROF data 

 Case tested: --compset GMPAS-IAF --res T62_oQU240wLI

iMOAB_MergeVertices is not used anymore in moab land driver, small correction incorporated into this PR

-------

Update on Jun 12, 2024: I rebased the branch [iulian787/moab_data_rof](https://github.com/E3SM-Project/E3SM/tree/iulian787/moab_data_rof)  off Jon Wolfe's branch, that introduces corrected files:
[jonbob/cpl/fix-t62-files] (https://github.com/E3SM-Project/E3SM/tree/jonbob/cpl/fix-t62-files)

https://github.com/E3SM-Project/E3SM/pull/6459

This now works with moab master, tested on gce machine at Argonne

