### PR TITLE
link to separate eamxx docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ research problems and Department of Energy mission needs while efficiently using
 ## Component Models
 
 - [EAM](./EAM/index.md)
-- EAMxx — not yet supported.
+- [EAMxx](https://docs.e3sm.org/scream/)
 - [ELM](./ELM/index.md)
 - [MOSART](./MOSART/index.md)
 - [MPAS-Ocean](./MPAS-Ocean/index.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ research problems and Department of Energy mission needs while efficiently using
 ## Component Models
 
 - [EAM](./EAM/index.md)
-- [EAMxx](https://docs.e3sm.org/scream/)
+- [EAMxx](https://docs.e3sm.org/scream/) — not yet supported.
 - [ELM](./ELM/index.md)
 - [MOSART](./MOSART/index.md)
 - [MPAS-Ocean](./MPAS-Ocean/index.md)


### PR DESCRIPTION
Add a link to EAMxx docs in a separate subdomain (docs.e3sm.org/scream).