### PR TITLE
Change MPAS-Ocean high-frequency output mode to `append`

### DIFF
--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -859,7 +859,7 @@ def buildnml(case, caseroot, compname):
             lines.append('        filename_interval="00-01-00_00:00:00"')
             lines.append('        reference_time="01-01-01_00:00:00"')
             lines.append('        output_interval="00-00-05_00:00:00"')
-            lines.append('        clobber_mode="truncate"')
+            lines.append('        clobber_mode="append"')
             lines.append('        packages="highFrequencyOutputAMPKG">')
             lines.append('')
             lines.append('    <var name="xtime"/>')


### PR DESCRIPTION
Without this, the first output is missing after each restart

fixes #6432