### PR TITLE
Update LISIO test to include ocn-glcshelf coupling

### DIFF
--- a/cime_config/allactive/config_compsets.xml
+++ b/cime_config/allactive/config_compsets.xml
@@ -412,8 +412,8 @@
 
 <!-- OCN + CICE + GLC Only Compsets -->
 <compset>
-  <alias>MPAS_LISIO_TEST</alias>
-  <lname>2000_DATM%NYF_SLND_MPASSI_MPASO_DROF%NYF_MALI%SIA_SWAV</lname>
+  <alias>MPAS_LISIO_JRA1p5</alias>
+  <lname>2000_DATM%JRA-1p5_SLND_MPASSI_MPASO%DATMFORCED_DROF%JRA-1p5_MALI%SIA_SWAV</lname>
 </compset>
 
 <!-- Slab ocean cases -->

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -5428,15 +5428,22 @@
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_TO_f09_aave.151005.nc</map>
     </gridmap>
 
+    <gridmap glc_grid="mpas.ais20" lnd_grid="TL319">
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_ais20km_traave.20240509.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_ais20km_trbilin.20240509.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_to_TL319_traave.20240509.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_to_TL319_traave.20240509.nc</map>
+    </gridmap>
+
     <gridmap glc_grid="mpas.ais20km" ocn_grid="oQU240wLI">
-      <map name="OCN2GLC_FMAPNAME"></map>
-      <map name="OCN2GLC_SMAPNAME"></map>
-      <map name="GLC2ICE_FMAPNAME"></map>
-      <map name="GLC2ICE_SMAPNAME"></map>
-      <map name="GLC2OCN_FMAPNAME"></map>
-      <map name="GLC2OCN_SMAPNAME"></map>
-      <map name="GLC2OCN_LIQ_RMAPNAME"></map>
-      <map name="GLC2OCN_ICE_RMAPNAME"></map>
+      <map name="OCN2GLC_FMAPNAME">cpl/gridmaps/oQU240wLI/map_oQU240wLI-nomask_to_ais20km_esmfaave.20240509.nc</map>
+      <map name="OCN2GLC_SMAPNAME">cpl/gridmaps/oQU240wLI/map_oQU240wLI-nomask_to_ais20km_esmfbilin.20240509.nc</map>
+      <map name="GLC2ICE_FMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU240wLI-nomask_esmfaave.20240509.nc</map>
+      <map name="GLC2ICE_SMAPNAME">cpl/gridmaps/mpas.ais20km/imap_ais20km_to_oQU240wLI-nomask_esmfbilin.20240509.nc</map>
+      <map name="GLC2OCN_FMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU240wLI-nomask_esmfaave.20240509.nc</map>
+      <map name="GLC2OCN_SMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU240wLI-nomask_esmfbilin.20240509.nc</map>
+      <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU240wLI-nomask_esmfnearestdtos.20240509.nc</map>
+      <map name="GLC2OCN_ICE_RMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU240wLI_esmfnearestdtos.20240509.nc</map>
     </gridmap>
 
     <!-- ======================================================== -->

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -406,6 +406,16 @@
       <mask>IcoswISC30E3r5</mask>
     </model_grid>
 
+    <model_grid alias="TL319_oQU240wLI" compset="(DATM|XATM|SATM)">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">TL319</grid>
+      <grid name="ocnice">oQU240wLI</grid>
+      <grid name="rof">JRA025</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oQU240wLI</mask>
+    </model_grid>
+
     <model_grid alias="TL319_oEC60to30v3" compset="(DATM|XATM|SATM)">
       <grid name="atm">TL319</grid>
       <grid name="lnd">TL319</grid>
@@ -2611,6 +2621,8 @@
     <domain name="TL319">
       <nx>640</nx>
       <ny>320</ny>
+      <file grid="atm|lnd" mask="oQU240wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_oQU240wLI.240509.nc</file>
+      <file grid="ice|ocn" mask="oQU240wLI">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oQU240wLI.240509.nc</file>
       <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_oEC60to30v3.181203.nc</file>
       <file grid="ice|ocn" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oEC60to30v3.181203.nc</file>
       <file grid="atm|lnd" mask="oEC60to30v3wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_oEC60to30v3wLI.200108.nc</file>
@@ -4356,6 +4368,14 @@
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/IcoswISC30E3r5/map_IcoswISC30E3r5_to_T62_traave.20231121.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="TL319" ocn_grid="oQU240wLI">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oQU240wLI_traave.20240509.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oQU240wLI-nomask_trbilin.20240509.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oQU240wLI_esmfpatch.20240509.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oQU240wLI/map_oQU240wLI_to_TL319_traave.20240509.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oQU240wLI/map_oQU240wLI_to_TL319_traave.20240509.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="TL319" ocn_grid="oEC60to30v3">
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oEC60to30v3_aave.181203.nc</map>
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_oEC60to30v3_bilin.181203.nc</map>
@@ -4982,6 +5002,11 @@
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_IcoswISC30E3r5_cstmnn.r150e300.20231121.nc</map>
     </gridmap>
 
+    <gridmap ocn_grid="oQU240wLI" rof_grid="JRA025">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_oQU240wLI_cstmnn.r150e300.20240516.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_oQU240wLI_cstmnn.r150e300.20240516.nc</map>
+    </gridmap>
+
     <gridmap ocn_grid="oEC60to30v3" rof_grid="JRA025">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_JRA025_to_oEC60to30v3_smoothed.r150e300.181204.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_JRA025_to_oEC60to30v3_smoothed.r150e300.181204.nc</map>
@@ -5439,7 +5464,7 @@
       <map name="OCN2GLC_FMAPNAME">cpl/gridmaps/oQU240wLI/map_oQU240wLI-nomask_to_ais20km_esmfaave.20240509.nc</map>
       <map name="OCN2GLC_SMAPNAME">cpl/gridmaps/oQU240wLI/map_oQU240wLI-nomask_to_ais20km_esmfbilin.20240509.nc</map>
       <map name="GLC2ICE_FMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU240wLI-nomask_esmfaave.20240509.nc</map>
-      <map name="GLC2ICE_SMAPNAME">cpl/gridmaps/mpas.ais20km/imap_ais20km_to_oQU240wLI-nomask_esmfbilin.20240509.nc</map>
+      <map name="GLC2ICE_SMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU240wLI-nomask_esmfbilin.20240509.nc</map>
       <map name="GLC2OCN_FMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU240wLI-nomask_esmfaave.20240509.nc</map>
       <map name="GLC2OCN_SMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU240wLI-nomask_esmfbilin.20240509.nc</map>
       <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU240wLI-nomask_esmfnearestdtos.20240509.nc</map>

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -1925,6 +1925,16 @@
       <mask>gx1v6</mask>
     </model_grid>
 
+    <model_grid alias="TL319_oQU240wLI_ais20" compset="_MALI">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">TL319</grid>
+      <grid name="ocnice">oQU240wLI</grid>
+      <grid name="rof">JRA025</grid>
+      <grid name="glc">mpas.ais20km</grid>
+      <grid name="wav">null</grid>
+      <mask>oQU240wLI</mask>
+    </model_grid>
+
     <!-- new runoff grids for data runoff model DROF -->
 
     <model_grid alias="T31_g37_rx1" compset="_DROF">
@@ -5416,6 +5426,17 @@
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv0.9x1.25/map_f09_TO_ais20km_bilin.151005.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_TO_f09_aave.151005.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_TO_f09_aave.151005.nc</map>
+    </gridmap>
+
+    <gridmap glc_grid="mpas.ais20km" ocn_grid="oQU240wLI">
+      <map name="OCN2GLC_FMAPNAME"></map>
+      <map name="OCN2GLC_SMAPNAME"></map>
+      <map name="GLC2ICE_FMAPNAME"></map>
+      <map name="GLC2ICE_SMAPNAME"></map>
+      <map name="GLC2OCN_FMAPNAME"></map>
+      <map name="GLC2OCN_SMAPNAME"></map>
+      <map name="GLC2OCN_LIQ_RMAPNAME"></map>
+      <map name="GLC2OCN_ICE_RMAPNAME"></map>
     </gridmap>
 
     <!-- ======================================================== -->

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -249,7 +249,6 @@ _TESTS = {
             "SMS_D_Ld1.T62_oQU240wLI.GMPAS-IAF-PISMF.mpaso-impl_top_drag",
             "SMS_D_Ld1.T62_oQU240.GMPAS-IAF.mpaso-harmonic_mean_drag",
             "SMS_D_Ld1.T62_oQU240.GMPAS-IAF.mpaso-upwind_advection",
-            "SMS_P512_D_Ld5.T62_oEC60to30v3wLI_ais20.MPAS_LISIO_TEST.mpaso-ocn_glcshelf",
             )
         },
 
@@ -288,7 +287,7 @@ _TESTS = {
             "ERS_Ld5.T62_oQU120.CMPASO-NYF",
             "SMS_Ld1.T62_oQU240wLI.GMPAS-IAF-DISMF",
             "ERS.f09_g16_g.MALISIA",
-            "SMS.T62_oQU120_ais20.MPAS_LISIO_TEST",
+            "ERS_Ld5.TL319_oQU240wLI_ais20.MPAS_LISIO_JRA1p5.mpaso-ocn_glcshelf",
             "SMS_P12x2.ne4pg2_oQU480.WCYCL1850NS.allactive-mach_mods",
             "ERS_Ln9.ne4pg2_ne4pg2.F2010-MMF1.eam-mmf_crmout",
             )

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -249,6 +249,7 @@ _TESTS = {
             "SMS_D_Ld1.T62_oQU240wLI.GMPAS-IAF-PISMF.mpaso-impl_top_drag",
             "SMS_D_Ld1.T62_oQU240.GMPAS-IAF.mpaso-harmonic_mean_drag",
             "SMS_D_Ld1.T62_oQU240.GMPAS-IAF.mpaso-upwind_advection",
+            "SMS_P512_D_Ld5.T62_oEC60to30v3wLI_ais20.MPAS_LISIO_TEST.mpaso-ocn_glcshelf",
             )
         },
 

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/ocn_glcshelf/README
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/ocn_glcshelf/README
@@ -1,0 +1,5 @@
+This testdef is used to test a stealth feature in mpaso introduced by
+PR #2726. It simply changes one mpaso namelist variable,
+    config_land_ice_flux_mode
+from its default value to 'coupled'.
+This tests the ocn/glcshelf coupling.

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/ocn_glcshelf/README
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/ocn_glcshelf/README
@@ -1,5 +1,8 @@
 This testdef is used to test a stealth feature in mpaso introduced by
-PR #2726. It simply changes one mpaso namelist variable,
+PR #2726. It changes one mpaso namelist variable,
     config_land_ice_flux_mode
 from its default value to 'coupled'.
 This tests the ocn/glcshelf coupling.
+
+It also specified that DATM forcing should be restricted to 1958.
+This allows JRA1p5 forcing to be used without a large input data requirement.

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/ocn_glcshelf/shell_commands
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/ocn_glcshelf/shell_commands
@@ -1,0 +1,4 @@
+./xmlchange DATM_CLMNCEP_YR_START=1958
+./xmlchange DATM_CLMNCEP_YR_END=1958
+./xmlchange DROF_STRM_YR_START=1958
+./xmlchange DROF_STRM_YR_END=1958

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/ocn_glcshelf/user_nl_mpaso
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/ocn_glcshelf/user_nl_mpaso
@@ -1,0 +1,1 @@
+ config_land_ice_flux_mode = 'coupled'

--- a/components/mpas-ocean/src/shared/mpas_ocn_effective_density_in_land_ice.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_effective_density_in_land_ice.F
@@ -111,7 +111,7 @@ contains
          landIcePressure,     &! land ice pressure
          effectiveDensityCur, &! effective density at current time
          effectiveDensityNew   ! effective density at new time level
-                                                  
+
       integer, dimension(:), pointer :: &
          landIceFloatingMask   ! mask for land ice presence on cell
 
@@ -179,15 +179,17 @@ contains
 #else
       !$omp do schedule(runtime) private(weightSum, i, cell2)
 #endif
-      do iCell = 1, nCellsAll
+      do iCell = 1, nCellsOwned
          weightSum = 1.0_RKIND
          effectiveDensityNew(iCell) = effectiveDensityScratch(iCell)
          do i = 1, nEdgesOnCell(iCell)
             cell2 = cellsOnCell(i,iCell)
-            effectiveDensityNew(iCell) = effectiveDensityNew(iCell) &
-                                       + cellMask(1,cell2)* &
-                                         effectiveDensityScratch(cell2)
-            weightSum = weightSum + cellMask(1,cell2)
+            if (cell2 <= nCellsAll) then
+               effectiveDensityNew(iCell) = effectiveDensityNew(iCell) &
+                                          + cellMask(1,cell2)* &
+                                            effectiveDensityScratch(cell2)
+               weightSum = weightSum + cellMask(1,cell2)
+            end if
          end do
          effectiveDensityNew(iCell) = effectiveDensityNew(iCell)/ &
                                       weightSum


### PR DESCRIPTION
This PR replaces the MPAS_LISIO_TEST ("LandIce-SeaIce-Ocean") test with a new compset that is more up to date and updates test coverage for OCN-GLC coupling work in development.  It makes the following changes:
* updates compset and grid definition to use JRA1p5 data atmosphere instead of CORE II-NYF
* updates ocean mesh to use oQU240wLI mesh, which is cheaper and includes ice-shelf cavities
* introduces a testmod that activates ocn-glcshelf coupling. That coupling was added in PR https://github.com/E3SM-Project/E3SM/pull/2726, but a test was never added.

The PR also includes a small MPAS-Ocean bug fix that activating ocn-glcshelf coupling revealed.