### PR TITLE
bug fix in use_extrasnowlayers

### DIFF
--- a/components/elm/src/main/elm_instMod.F90
+++ b/components/elm/src/main/elm_instMod.F90
@@ -352,7 +352,6 @@ contains
               snow_depth_col(c) = h2osno_col(c) / bdsno
            endif
        endif
-       snow_depth_col(c)  = h2osno_col(c) / bdsno
     end do
 
    ! Initialize urban constants


### PR DESCRIPTION
Removes incorrectly placed line  in elm_instMod.F90 for `use_extrasnowlayers = .true.`

[BFB]