### PR TITLE
Fixes z-level mode in overflow test case

### DIFF
--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_overflow.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_overflow.F
@@ -80,7 +80,7 @@ contains
       integer, intent(out) :: iErr
       real (kind=RKIND) :: yMin, yMax, dcEdgeMin
       real (kind=RKIND) :: yMinGlobal, yMaxGlobal, dcEdgeMinGlobal
-      real (kind=RKIND) :: plugWidth
+      real (kind=RKIND) :: ltSum, plugWidth
       real (kind=RKIND) :: slopeCenter, slopeWidth
 
       type (block_type), pointer :: block_ptr
@@ -228,10 +228,20 @@ contains
 
            ! Set layerThickness and restingThickness
            if ( trim(config_overflow_layer_type) == 'z-level' ) then
+              layerThickness(:,iCell) = 0.0_RKIND
+              ltSum = 0.0_RKIND
               do k = 1, maxLevelCell(iCell)
                  layerThickness(k, iCell) = config_overflow_bottom_depth * (interfaceLocations(k+1) - interfaceLocations(k))
+                 ltSum = ltSum + layerThickness(k, iCell)
+              end do
+
+              !Change bottom layer thickness to ensure flat sea surface
+              layerThickness(maxLevelCell(iCell),iCell) = layerThickness(maxLevelCell(iCell),iCell) - &
+                                                                 abs(bottomDepth(iCell) - ltSum)
+              do k=1, maxLevelCell(iCell)
                  restingThickness(k, iCell) = layerThickness(k, iCell)
               end do
+
            else if ( trim(config_overflow_layer_type) == 'sigma' ) then
               do k = 1, nVertLevels
                  layerThickness(k, iCell) = bottomDepth(iCell) / nVertLevels


### PR DESCRIPTION
In current master, setting `config_overflow_layer_type = 'z-level'` caused a failure in forward mode on the first time step.  This is due to very large gradients in sea surface height.  This PR fixes those issues and with the changes, z-level mode has been run for 5-day simulations.