### PR TITLE
Fix bottom depth deepening in global_ocean init mode

### DIFF
--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_global_ocean.F
@@ -894,7 +894,7 @@ contains
              if (isOcean) then
                 ! Enforce minimum depth
                 bottomDepth(iCell) = max(bottomDepthObserved(iCell), config_global_ocean_minimum_depth)
-                bottomDepth(iCell) = min(bottomDepth(iCell), refBottomDepth(minimum_levels))
+                bottomDepth(iCell) = max(bottomDepth(iCell), refBottomDepth(minimum_levels))
 
                 maxLevelCell(iCell) = -1
                 do k = 1, nVertLevels


### PR DESCRIPTION
A bug was introduced in #6310 that made the ocean shallower rather than deeper than the minimum allowed depth.  This merge fixes that bug.

Fixes #6453 
[BFB] -- mpas-ocean standalone only