### PR TITLE
standalone HOMME support on PM-CPU

### DIFF
--- a/components/homme/cmake/SetCompilerFlags.cmake
+++ b/components/homme/cmake/SetCompilerFlags.cmake
@@ -259,15 +259,11 @@ IF (ENABLE_HORIZ_OPENMP OR ENABLE_COLUMN_OPENMP)
           SET(OpenMP_C_FLAGS "-qsmp=omp:nested_par -qsuppress=1520-045:1506-793")
         ENDIF ()
       ENDIF ()
-      # This file is needed for the timing library - this is currently
-      # inaccessible from the timing CMake script
-      SET(OpenMP_Fortran_FLAGS "${OpenMP_C_FLAGS}")
       MESSAGE(STATUS "OpenMP_Fortran_FLAGS: ${OpenMP_Fortran_FLAGS}")
       MESSAGE(STATUS "OpenMP_C_FLAGS: ${OpenMP_C_FLAGS}")
       MESSAGE(STATUS "OpenMP_CXX_FLAGS: ${OpenMP_CXX_FLAGS}")
       MESSAGE(STATUS "OpenMP_EXE_LINKER_FLAGS: ${OpenMP_EXE_LINKER_FLAGS}")
-      # The fortran openmp flag should be the same as the C Flag
-      SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${OpenMP_C_FLAGS}")
+      SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${OpenMP_Fortran_FLAGS}")
       SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
       SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
       SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")

--- a/components/homme/cmake/machineFiles/pm-cpu.cmake
+++ b/components/homme/cmake/machineFiles/pm-cpu.cmake
@@ -1,0 +1,49 @@
+# CMake initial cache file
+#
+# This machine file works with either Intel or gnu
+# (selected by which modules are loaded)
+# 
+#
+# Perlmutter generic MPI enabled compiler wrappers:
+SET (CMAKE_Fortran_COMPILER ftn   CACHE FILEPATH "")
+SET (CMAKE_C_COMPILER       cc    CACHE FILEPATH "")
+SET (CMAKE_CXX_COMPILER     CC    CACHE FILEPATH "")
+
+
+# Set kokkos arch, to get correct avx flags
+SET (Kokkos_ARCH_ZEN2 ON CACHE BOOL "")
+
+SET (WITH_PNETCDF FALSE CACHE FILEPATH "")
+
+EXECUTE_PROCESS(COMMAND nf-config --prefix
+  RESULT_VARIABLE NFCONFIG_RESULT
+  OUTPUT_VARIABLE NFCONFIG_OUTPUT
+  ERROR_VARIABLE  NFCONFIG_ERROR
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+SET (NetCDF_Fortran_PATH "${NFCONFIG_OUTPUT}" CACHE STRING "")
+
+EXECUTE_PROCESS(COMMAND nc-config --prefix
+  RESULT_VARIABLE NCCONFIG_RESULT
+  OUTPUT_VARIABLE NCCONFIG_OUTPUT
+  ERROR_VARIABLE  NCCONFIG_ERROR
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+SET (NetCDF_C_PATH "${NCCONFIG_OUTPUT}" CACHE STRING "")
+
+SET (USE_QUEUING FALSE CACHE BOOL "")
+# for standalone HOMME builds:
+SET(CPRNC_DIR /global/cfs/cdirs/e3sm/tools/cprnc CACHE FILEPATH "")
+
+SET (HOMME_FIND_BLASLAPACK TRUE CACHE BOOL "")
+IF(DEFINED ENV{MKLROOT})
+  SET (HOMME_USE_MKL "TRUE" CACHE FILEPATH "")
+  # turn on additional intel compiler flags
+  SET (ADD_Fortran_FLAGS "-traceback" CACHE STRING "")
+  SET (ADD_C_FLAGS       "-traceback" CACHE STRING "")
+  SET (ADD_CXX_FLAGS     "-traceback" CACHE STRING "")
+ENDIF()
+
+
+SET(USE_MPIEXEC "srun" CACHE STRING "")
+SET(USE_MPI_OPTIONS "-K --cpu_bind=cores" CACHE STRING "")

--- a/components/homme/test/reg_test/run_tests/testing-utils.sh
+++ b/components/homme/test/reg_test/run_tests/testing-utils.sh
@@ -486,7 +486,10 @@ createAllRunScriptsGeneric() {
     if [ -n "${OMP_NUM_TESTS}" -a "${RUN_OPENMP}" = ON ]; then
       echo "export OMP_NUM_THREADS=${OMP_NUMBER_THREADS}" >> $thisRunScript
       if [ "${MPI_EXEC}" = "srun" ] ; then
-         echo "export SLURM_CPUS_PER_TASK=${OMP_NUMBER_THREADS}" >> $thisRunScript
+          # set enviroment variable (srun's -c argument)
+          # system dependent. done this way since we dont have logic to add -c argument
+          echo "export SLURM_CPUS_PER_TASK=${OMP_NUMBER_THREADS}" >> $thisRunScript
+          echo "export SRUN_CPUS_PER_TASK=${OMP_NUMBER_THREADS}" >> $thisRunScript
       fi
       echo "export OMP_STACKSIZE=128M" >> $thisRunScript
       echo "" >> $thisRunScript # new line


### PR DESCRIPTION
Add support for running standalone HOMME on PM-CPU

With this PR, standalone HOMME can be build on PM-CPU, with either GNU or Intel compilers.  In particular, both of these will work:

./create_test   --machine pm-cpu --compiler intel HOMME_P24.f19_g16_rx1.A                    
./create_test   --machine pm-cpu --compiler gnu  HOMME_P24.f19_g16_rx1.A                                                                           

- Single cmake file (pm-cpu.cmake, to match CIME machine names) supports both GNU and Intel without hardcoded netcdf paths.  
- Also updated test scripts to set  SRUN_CPUS_PER_TASK properly, otherwise openMP performance is terrible.  
- removed assumption that fortran and C compiler flags for openMP are the same ( they are different under PM's oneAPI compilers)

[BFB]