### PR TITLE
Update TOP solar radiation parameterization

### DIFF
--- a/components/elm/src/biogeophys/SurfaceAlbedoMod.F90
+++ b/components/elm/src/biogeophys/SurfaceAlbedoMod.F90
@@ -1811,7 +1811,7 @@ contains
         lon_180 = lon(g)
          if (lon_180 > pi) lon_180 = lon_180-2._r8*pi    
     
-         if (cosz > 0._r8 .and. abs(lat(g)) < 1.047_r8 .and. stdev_elev(g) > 0._r8) then
+         if (cosz > 0._r8 .and. stdev_elev(g) > 0._r8) then
             local_timeofday = next_tod + lon_180 / pi * 180._r8 * 240._r8
 
             if (local_timeofday >= 86400._r8) then

--- a/components/elm/src/biogeophys/SurfaceAlbedoMod.F90
+++ b/components/elm/src/biogeophys/SurfaceAlbedoMod.F90
@@ -1811,7 +1811,7 @@ contains
         lon_180 = lon(g)
          if (lon_180 > pi) lon_180 = lon_180-2._r8*pi    
     
-         if (cosz > 0._r8 .and. stdev_elev(g) > 0._r8) then
+         if (cosz > 0._r8 .and. abs(lat(g)) < 1.047_r8 .and. stdev_elev(g) > 0._r8) then
             local_timeofday = next_tod + lon_180 / pi * 180._r8 * 240._r8
 
             if (local_timeofday >= 86400._r8) then

--- a/components/elm/src/main/surfrdMod.F90
+++ b/components/elm/src/main/surfrdMod.F90
@@ -1702,7 +1702,12 @@ contains
 
     call ncd_io(ncid=ncid, varname='STDEV_ELEV', flag='read', data=domain%stdev_elev, &
          dim1name=grlnd, readvar=readvar)
-    if (.not. readvar) call endrun( trim(subname)//' ERROR: STDEV_ELEV  NOT on fsurdat file' )
+    if (.not. readvar) then
+         write(iulog,*) trim(subname),' ERROR: STDEV_ELEV  NOT on fsurdat file'
+         call ncd_io(ncid=ncid, varname='STD_ELEV', flag='read', data=domain%stdev_elev, &
+              dim1name=grlnd, readvar=readvar)
+         if (.not. readvar) call endrun( trim(subname)//' ERROR: BOTH STD_ELEV and STDEV_ELEV NOT on fsurdat file' )
+    endif
     call ncd_io(ncid=ncid, varname='SKY_VIEW', flag='read', data=domain%sky_view, &
          dim1name=grlnd, readvar=readvar)
     if (.not. readvar) call endrun( trim(subname)//' ERROR: SKY_VIEW  NOT on fsurdat file' )

--- a/components/elm/src/main/surfrdMod.F90
+++ b/components/elm/src/main/surfrdMod.F90
@@ -1703,7 +1703,7 @@ contains
     call ncd_io(ncid=ncid, varname='STDEV_ELEV', flag='read', data=domain%stdev_elev, &
          dim1name=grlnd, readvar=readvar)
     if (.not. readvar) then
-         write(iulog,*) trim(subname),' ERROR: STDEV_ELEV  NOT on fsurdat file'
+         write(iulog,*) trim(subname),' WARNING: STDEV_ELEV  NOT on fsurdat file. Try to use STD_ELEV instead.'
          call ncd_io(ncid=ncid, varname='STD_ELEV', flag='read', data=domain%stdev_elev, &
               dim1name=grlnd, readvar=readvar)
          if (.not. readvar) call endrun( trim(subname)//' ERROR: BOTH STD_ELEV and STDEV_ELEV NOT on fsurdat file' )


### PR DESCRIPTION
Minor modification for TOP solar radiation parameterization: 
Use `STD_ELEV` std_elev when `STDEV_ELEV` is not available in fsurdata.

[BFB]