### PR TITLE
Fix OpenACC deletes for topographic wave drag

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -1009,7 +1009,13 @@ contains
          !$acc                   velocityTidalRMS)
       end if
       if (config_use_topographic_wave_drag) then
-         !$acc exit data delete(topographic_wave_drag)
+         !$acc exit data delete(topo_rinv)
+         !$acc exit data delete(topo_buoyancy_N1V)
+         !$acc exit data delete(topo_buoyancy_N1B)
+         !$acc exit data delete(bathy_stddev)
+         !$acc exit data delete(bed_slope_edges)
+         !$acc exit data delete(lonGradEdge)
+         !$acc exit data delete(latGradEdge)
          !$acc exit data delete(temp_twd)
          !$acc exit data delete(normalCoeffTWD)
          !$acc exit data delete(tangentialCoeffTWD)


### PR DESCRIPTION
Partially addresses #6470 

The errors were introduced in https://github.com/E3SM-Project/E3SM/pull/6310, when variables were introduced and renamed, including in the OpenACC create directives but corresponding changes were incomplete for the OpenACC directives for deleting them.