### PR TITLE
Data ice fixes for moab driver

### DIFF
--- a/components/data_comps/dice/src/ice_comp_mct.F90
+++ b/components/data_comps/dice/src/ice_comp_mct.F90
@@ -155,7 +155,13 @@ CONTAINS
     !----------------------------------------------------------------------------
     ! Initialize dice
     !----------------------------------------------------------------------------
-
+#ifdef HAVE_MOAB
+    ierr = iMOAB_RegisterApplication(trim("DICE")//C_NULL_CHAR, mpicom, compid, MPSIID)
+    if (ierr .ne. 0) then
+      write(logunit,*) subname,' error in registering data ice comp'
+      call shr_sys_abort(subname//' ERROR in registering data ice comp')
+    endif
+#endif
     call dice_comp_init(Eclock, x2i, i2x, &
          seq_flds_x2i_fields, seq_flds_i2x_fields, seq_flds_i2o_per_cat, &
          SDICE, gsmap, ggrid, mpicom, compid, my_task, master_task, &
@@ -164,11 +170,6 @@ CONTAINS
 
 
 #ifdef HAVE_MOAB
-    ierr = iMOAB_RegisterApplication(trim("DICE")//C_NULL_CHAR, mpicom, compid, MPSIID)
-    if (ierr .ne. 0) then
-      write(logunit,*) subname,' error in registering data ice comp'
-      call shr_sys_abort(subname//' ERROR in registering data ice comp')
-    endif
     if (my_task == master_task) then
        call shr_stream_getDomainInfo(SDICE%stream(1), filePath,fileName,timeName,lonName, &
                latName,hgtName,maskName,areaName)

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -1020,6 +1020,7 @@ contains
       character(CL)            :: rtm_mesh, rof_domain
       character(CL)            :: lnd_domain
       character(CL)            :: ocn_domain
+      character(CL)            :: ice_domain   ! used for data ice only?
       character(CL)            :: atm_mesh
       integer                  :: maxMH, maxMPO, maxMLID, maxMSID, maxMRID ! max pids for moab apps atm, ocn, lnd, sea-ice, rof
       integer                  :: tagtype, numco,  tagindex, partMethod, nghlay
@@ -1543,37 +1544,60 @@ contains
       if (comp%oneletterid == 'i'  .and. maxMSID /= -1) then
          call seq_comm_getinfo(cplid ,mpigrp=mpigrp_cplid)  ! receiver group
          call seq_comm_getinfo(id_old,mpigrp=mpigrp_old)   !  component group pes
-
+         ! find ice domain file if it exists; it would be for data ice model (ice_prognostic false)
+         call seq_infodata_GetData(infodata,ice_domain=ice_domain)
          if (MPI_COMM_NULL /= mpicom_old ) then ! it means we are on the component p
 #ifdef MOABDEBUG
-         outfile = 'wholeSeaIce.h5m'//C_NULL_CHAR
-         wopts   = 'PARALLEL=WRITE_PART'//C_NULL_CHAR
-         ierr = iMOAB_WriteMesh(MPSIID, outfile, wopts)
-         if (ierr .ne. 0) then
-            write(logunit,*) subname,' error in writing sea-ice'
-            call shr_sys_abort(subname//' ERROR in writing sea-ice')
-         endif
+            outfile = 'wholeSeaIce.h5m'//C_NULL_CHAR
+            wopts   = 'PARALLEL=WRITE_PART'//C_NULL_CHAR
+            ierr = iMOAB_WriteMesh(MPSIID, outfile, wopts)
+            if (ierr .ne. 0) then
+               write(logunit,*) subname,' error in writing sea-ice'
+               call shr_sys_abort(subname//' ERROR in writing sea-ice')
+            endif
 #endif
    ! start copy from ocean code
-         !  send sea ice mesh to coupler
-         ierr = iMOAB_SendMesh(MPSIID, mpicom_join, mpigrp_cplid, id_join, partMethod)
-         if (ierr .ne. 0) then
-            write(logunit,*) subname,' error in sending sea ice mesh to coupler '
-            call shr_sys_abort(subname//' ERROR in sending sea ice mesh to coupler ')
-         endif
-         if (MPSIID >= 0) then
-            ierr  = iMOAB_GetMeshInfo ( MPSIID, nvert, nvise, nbl, nsurf, nvisBC )
-            comp%mbApCCid = MPSIID ! phys atm 
-            comp%mbGridType = 1 ! 0 or 1, pc or cells 
-            comp%mblsize = nvise(1) ! vertices
-         endif
-
-         endif
+            if (MPSIID >= 0) then
+               ierr  = iMOAB_GetMeshInfo ( MPSIID, nvert, nvise, nbl, nsurf, nvisBC )
+               comp%mbApCCid = MPSIID ! ice imoab app id
+            endif
+            if ( trim(ice_domain) == 'none' ) then ! regular ice model
+               comp%mbGridType = 1 ! 0 or 1, pc or cells 
+               comp%mblsize = nvise(1) ! cells   
+               !  send sea ice mesh to coupler
+               ierr = iMOAB_SendMesh(MPSIID, mpicom_join, mpigrp_cplid, id_join, partMethod)
+               if (ierr .ne. 0) then
+                  write(logunit,*) subname,' error in sending sea ice mesh to coupler '
+                  call shr_sys_abort(subname//' ERROR in sending sea ice mesh to coupler ')
+               endif
+            else
+               comp%mbGridType = 0 ! 0 or 1, pc or cells
+               comp%mblsize = nvert(1) ! vertices
+            endif
+         endif 
          if (MPI_COMM_NULL /= mpicom_new ) then !  we are on the coupler pes
             appname = "COUPLE_MPASSI"//C_NULL_CHAR
             ! migrated mesh gets another app id, moab moab sea ice to coupler (mbix)
             ierr = iMOAB_RegisterApplication(trim(appname), mpicom_new, id_join, mbixid)
-            ierr = iMOAB_ReceiveMesh(mbixid, mpicom_join, mpigrp_old, id_old)
+            if ( trim(ice_domain) == 'none' ) then ! regular ice model
+               ierr = iMOAB_ReceiveMesh(mbixid, mpicom_join, mpigrp_old, id_old)
+               if (ierr .ne. 0) then
+                  write(logunit,*) subname,' error in receiving ice mesh in coupler '
+                  call shr_sys_abort(subname//' ERROR in receiving sea ice mesh in coupler ')
+               endif
+            else
+               ! we need to read the mesh ice (domain file) 
+               ierr = iMOAB_LoadMesh(mbixid, trim(ice_domain)//C_NULL_CHAR, &
+                "PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION", 0)
+               if ( ierr /= 0 ) then
+                  write(logunit,*) 'Failed to load ice domain mesh on coupler'
+                  call shr_sys_abort(subname//' ERROR Failed to load ice domain mesh on coupler  ')
+               endif
+               if (seq_comm_iamroot(CPLID)) then
+                  write(logunit,'(A)') subname//' load ice domain mesh from file '//trim(ice_domain)
+               endif
+
+            endif
             tagtype = 1  ! dense, double
             numco = 1 !  one value per cell / entity
             tagname = trim(seq_flds_i2x_fields)//C_NULL_CHAR
@@ -1626,11 +1650,13 @@ contains
 #endif
          endif
          if (MPSIID .ge. 0) then  ! we are on component sea ice pes
-            context_id = id_join
-            ierr = iMOAB_FreeSenderBuffers(MPSIID, context_id)
-            if (ierr .ne. 0) then
-            write(logunit,*) subname,' error in freeing buffers '
-            call shr_sys_abort(subname//' ERROR in freeing buffers ')
+            if ( trim(ice_domain) == 'none' ) then
+               context_id = id_join
+               ierr = iMOAB_FreeSenderBuffers(MPSIID, context_id)
+               if (ierr .ne. 0) then
+                 write(logunit,*) subname,' error in freeing buffers '
+                 call shr_sys_abort(subname//' ERROR in freeing buffers ')
+               endif
             endif
          endif
 

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -1596,6 +1596,15 @@ contains
                if (seq_comm_iamroot(CPLID)) then
                   write(logunit,'(A)') subname//' load ice domain mesh from file '//trim(ice_domain)
                endif
+               ! need to add global id tag to the app, it will be used in restart
+               tagtype = 0  ! dense, integer
+               numco = 1
+               tagname='GLOBAL_ID'//C_NULL_CHAR
+               ierr = iMOAB_DefineTagStorage(mbixid, tagname, tagtype, numco,  tagindex )
+               if (ierr .ne. 0) then
+                  write(logunit,*) subname,' error in adding global id tag to icex'
+                  call shr_sys_abort(subname//' ERROR in adding global id tag to icex ')
+               endif
 #ifdef MOABDEBUG
       !        debug test
                outfile = 'recSeaIceInit.h5m'//C_NULL_CHAR

--- a/driver-moab/shr/seq_infodata_mod.F90
+++ b/driver-moab/shr/seq_infodata_mod.F90
@@ -234,6 +234,7 @@ MODULE seq_infodata_mod
      character(SHR_KIND_CL)  :: rof_mesh        ! path to river mesh file
      character(SHR_KIND_CL)  :: rof_domain      ! path to river domain file; only for data rof for now
      character(SHR_KIND_CL)  :: ocn_domain      ! path to ocean domain file, used by data ocean models only
+     character(SHR_KIND_CL)  :: ice_domain      ! path to ice domain file, used by data ice models only
      character(SHR_KIND_CL)  :: atm_mesh        ! path to atmosphere domain/mesh file, used by data atm models only
 
      !--- set via components and may be time varying ---
@@ -795,6 +796,7 @@ CONTAINS
        infodata%rof_mesh = 'none'
        infodata%rof_domain = 'none'
        infodata%ocn_domain = 'none' ! will be used for ocean data models only; will be used as a signal 
+       infodata%ice_domain = 'none' ! will be used for ice   data models only; will be used as a signal 
        infodata%atm_mesh = 'none' ! will be used for atmosphere data models only; will be used as a signal
                                     ! not sure if it exists always actually
 
@@ -1040,7 +1042,7 @@ CONTAINS
        wav_phase, iac_phase, esp_phase, wav_nx, wav_ny, atm_nx, atm_ny,   &
        lnd_nx, lnd_ny, rof_nx, rof_ny, ice_nx, ice_ny, ocn_nx, ocn_ny,    &
        iac_nx, iac_ny, glc_nx, glc_ny, lnd_domain, rof_mesh, rof_domain,  &
-       ocn_domain,  atm_mesh, eps_frac,                                   &
+       ocn_domain, ice_domain,  atm_mesh, eps_frac,                       &
        eps_amask, eps_agrid, eps_aarea, eps_omask, eps_ogrid, eps_oarea,  &
        reprosum_use_ddpdd, reprosum_allow_infnan,                         &
        reprosum_diffmax, reprosum_recompute,                              &
@@ -1216,6 +1218,7 @@ CONTAINS
     character(SHR_KIND_CL), optional, intent(OUT) :: rof_mesh
     character(SHR_KIND_CL), optional, intent(OUT) :: rof_domain
     character(SHR_KIND_CL), optional, intent(OUT) :: ocn_domain
+    character(SHR_KIND_CL), optional, intent(OUT) :: ice_domain
     character(SHR_KIND_CL), optional, intent(OUT) :: atm_mesh
 
     real(SHR_KIND_R8),      optional, intent(OUT) :: nextsw_cday             ! calendar of next atm shortwave
@@ -1406,6 +1409,7 @@ CONTAINS
     if ( present(rof_mesh)       ) rof_mesh       = infodata%rof_mesh
     if ( present(rof_domain)     ) rof_domain     = infodata%rof_domain
     if ( present(ocn_domain)     ) ocn_domain     = infodata%ocn_domain
+    if ( present(ice_domain)     ) ice_domain     = infodata%ice_domain
     if ( present(atm_mesh)       ) atm_mesh       = infodata%atm_mesh
 
     if ( present(nextsw_cday)    ) nextsw_cday    = infodata%nextsw_cday
@@ -1602,8 +1606,8 @@ CONTAINS
        wav_phase, iac_phase, esp_phase, wav_nx, wav_ny, atm_nx, atm_ny,   &
        lnd_nx, lnd_ny, rof_nx, rof_ny, ice_nx, ice_ny, ocn_nx, ocn_ny,    &
        iac_nx, iac_ny, glc_nx, glc_ny, eps_frac, eps_amask, lnd_domain,   &
-       rof_mesh, rof_domain, ocn_domain, atm_mesh, eps_agrid, eps_aarea,  &
-       eps_omask, eps_ogrid, eps_oarea,                                   &
+       rof_mesh, rof_domain, ocn_domain, ice_domain, atm_mesh, eps_agrid, &
+       eps_aarea, eps_omask, eps_ogrid, eps_oarea,                        &
        reprosum_use_ddpdd, reprosum_allow_infnan,                         &
        reprosum_diffmax, reprosum_recompute,                              &
        mct_usealltoall, mct_usevector, glc_valid_input, nlmaps_verbosity)
@@ -1777,6 +1781,7 @@ CONTAINS
     character(SHR_KIND_CL), optional, intent(IN)    :: rof_mesh
     character(SHR_KIND_CL), optional, intent(IN)    :: rof_domain
     character(SHR_KIND_CL), optional, intent(IN)    :: ocn_domain
+    character(SHR_KIND_CL), optional, intent(IN)    :: ice_domain
     character(SHR_KIND_CL), optional, intent(IN)    :: atm_mesh
 
     real(SHR_KIND_R8),      optional, intent(IN)    :: nextsw_cday        ! calendar of next atm shortwave
@@ -1966,6 +1971,7 @@ CONTAINS
     if ( present(rof_mesh)       ) infodata%rof_mesh       = rof_mesh
     if ( present(rof_domain)     ) infodata%rof_domain     = rof_domain
     if ( present(ocn_domain)     ) infodata%ocn_domain     = ocn_domain
+    if ( present(ice_domain)     ) infodata%ice_domain     = ice_domain
     if ( present(atm_mesh)       ) infodata%atm_mesh       = atm_mesh
 
     if ( present(nextsw_cday)    ) infodata%nextsw_cday    = nextsw_cday
@@ -2279,6 +2285,7 @@ CONTAINS
     call shr_mpi_bcast(infodata%rof_mesh,                mpicom)
     call shr_mpi_bcast(infodata%rof_domain,              mpicom)
     call shr_mpi_bcast(infodata%ocn_domain,              mpicom)
+    call shr_mpi_bcast(infodata%ice_domain,              mpicom)
     call shr_mpi_bcast(infodata%atm_mesh,                mpicom)
     call shr_mpi_bcast(infodata%nextsw_cday,             mpicom)
     call shr_mpi_bcast(infodata%precip_fact,             mpicom)
@@ -2552,6 +2559,7 @@ CONTAINS
        call shr_mpi_bcast(infodata%iceberg_prognostic, mpicom, pebcast=cmppe)
        call shr_mpi_bcast(infodata%ice_nx,             mpicom, pebcast=cmppe)
        call shr_mpi_bcast(infodata%ice_ny,             mpicom, pebcast=cmppe)
+       call shr_mpi_bcast(infodata%ice_domain,         mpicom, pebcast=cmppe)
        ! dead_comps is true if it's ever set to true
        deads = infodata%dead_comps
        call shr_mpi_bcast(deads,                       mpicom, pebcast=cmppe)
@@ -3000,6 +3008,7 @@ CONTAINS
     write(logunit,F0I) subname,'rof_mesh                 = ', infodata%rof_mesh
     write(logunit,F0I) subname,'rof_domain               = ', infodata%rof_domain
     write(logunit,F0I) subname,'ocn_domain               = ', infodata%ocn_domain
+    write(logunit,F0I) subname,'ice_domain               = ', infodata%ice_domain
     write(logunit,F0I) subname,'atm_mesh                 = ', infodata%atm_mesh
 
     write(logunit,F0R) subname,'nextsw_cday              = ', infodata%nextsw_cday


### PR DESCRIPTION
Extend moab driver for data ice cases
case tested: --res T62_oQU120 --compset CMPASO-NYF
it uses the same approach as data ocean; data ice mesh on coupler side is instanced from the sea ice domain file, while
on the  data component side, mesh is "point cloud" only, aligned with mct grid
On atmosphere side, it uses the T62 RLL grid that was corrected earlier with 'jonbob/cpl/fix-t62-files' (PR #6459)
