### PR TITLE
fix underflow in methane calculation

### DIFF
--- a/components/elm/src/biogeochem/CH4Mod.F90
+++ b/components/elm/src/biogeochem/CH4Mod.F90
@@ -3028,7 +3028,7 @@ contains
     real(r8), pointer :: co2_decomp_depth (:,:)
     real(r8), pointer :: conc_o2          (:,:)
     real(r8), pointer :: conc_ch4         (:,:)
-
+    real(r8), parameter :: smallparameter = tiny(1._r8)
     integer  :: nstep                       ! time step number
     character(len=32) :: subname='ch4_tran' ! subroutine name
     !-----------------------------------------------------------------------
@@ -3117,14 +3117,14 @@ contains
             c = filter_methc (fc)
 
             o2demand = o2_decomp_depth(c,j) + o2_oxid_depth(c,j) ! o2_decomp_depth includes autotrophic root respiration
-            if (o2demand > 0._r8) then
+            if (o2demand > smallparameter) then
                o2stress(c,j) = min((conc_o2(c,j) / dtime + o2_aere_depth(c,j)) / o2demand, 1._r8)
             else
                o2stress(c,j) = 1._r8
             end if
 
             ch4demand = ch4_oxid_depth(c,j) + ch4_aere_depth(c,j) + ch4_ebul_depth(c,j)
-            if (ch4demand > 0._r8) then
+            if (ch4demand > smallparameter) then
                ch4stress(c,j) = min((conc_ch4(c,j) / dtime + ch4_prod_depth(c,j)) / ch4demand, 1._r8)
             else
                ch4stress(c,j) = 1._r8


### PR DESCRIPTION
Replace `>0._r8` check in CH4Mod with a small parameter set by `tiny` intrinsic function.  The exact value of `tiny(1._r8)` may depend on the compiler and machine but is on the order of `1.E-308` 

Tested on pm-cpu_intel and pm-cpu_gnu

Fixes #6428 
[BFB] 