### PR TITLE
On pm-cpu minor pelayout adjustment for hcru_hcru.I20TRGSWCNPRDCTCBC

### DIFF
--- a/components/elm/cime_config/config_pes.xml
+++ b/components/elm/cime_config/config_pes.xml
@@ -235,6 +235,21 @@
     </mach>
   </grid>
   <grid name="l%360x720cru">
+    <mach name="pm-cpu|muller-cpu|alvarez">
+      <pes compset="any" pesize="any">
+        <comment>elm: pm-cpu 2 nodes for grid l%360x720cru</comment>
+        <ntasks>
+          <ntasks_atm>192</ntasks_atm>
+          <ntasks_lnd>192</ntasks_lnd>
+          <ntasks_rof>192</ntasks_rof>
+          <ntasks_ice>192</ntasks_ice>
+          <ntasks_ocn>192</ntasks_ocn>
+          <ntasks_glc>192</ntasks_glc>
+          <ntasks_wav>192</ntasks_wav>
+          <ntasks_cpl>192</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
     <mach name="anvil">
       <pes compset="any" pesize="any">
         <comment>elm: anvil PEs for grid l%360x720cru</comment>


### PR DESCRIPTION
For pm-cpu, try using 192 tasks instead of 128 tasks for grid `l%360x720cru`.
The `ERS.hcru_hcru.I20TRGSWCNPRDCTCBC.pm-cpu_intel.elm-erosion` test works, but was running over 30 minutes. 
The test currently uses 1 node (128 tasks) and trying with 192 tasks speeds up the overall test from about 30 min to 19 min.

With SMS test, it will also work with 256 tasks (2 full nodes), but see failure with ERS test.

BFB except for NML changes.
