### PR TITLE
For gcp12, update eam ne4 pelayout

### DIFF
--- a/components/eam/cime_config/config_pes.xml
+++ b/components/eam/cime_config/config_pes.xml
@@ -157,7 +157,7 @@
     </mach>
     <mach name="gcp12">
       <pes compset="any" pesize="any">
-        <comment>eam+gcp: default 1 node</comment>
+        <comment>eam+gcp12: default 1 node, 56x1</comment>
         <ntasks>
           <ntasks_atm>-1</ntasks_atm>
           <ntasks_lnd>-1</ntasks_lnd>
@@ -280,16 +280,16 @@
     </mach>
     <mach name="gcp12">
       <pes compset="any" pesize="any">
-        <comment>gcp12: any compset on ne4np4.pg2 grid, 56x1 except 36 for ice/ocn</comment>
+        <comment>gcp12: any compset on ne4np4.pg2 grid, 2 nodes 96x1</comment>
         <ntasks>
-          <ntasks_atm>56</ntasks_atm>
-          <ntasks_lnd>56</ntasks_lnd>
-          <ntasks_rof>56</ntasks_rof>
-          <ntasks_ice>36</ntasks_ice>
-          <ntasks_ocn>36</ntasks_ocn>
-          <ntasks_cpl>56</ntasks_cpl>
-          <ntasks_glc>56</ntasks_glc>
-          <ntasks_wav>56</ntasks_wav>
+          <ntasks_atm>96</ntasks_atm>
+          <ntasks_lnd>96</ntasks_lnd>
+          <ntasks_rof>96</ntasks_rof>
+          <ntasks_ice>96</ntasks_ice>
+          <ntasks_ocn>96</ntasks_ocn>
+          <ntasks_cpl>96</ntasks_cpl>
+          <ntasks_glc>96</ntasks_glc>
+          <ntasks_wav>96</ntasks_wav>
         </ntasks>
       </pes>
     </mach>


### PR DESCRIPTION
For gcp12, update ne4 eam pelayout to use 96 tasks which needs 2 nodes (previously 1 node).
This is not node-efficient, but can hopefully improve overall testing time as extra_coverage always waits
for `SMS_Ly1.ne4pg2_oQU480.F2010.gcp12_gnu`

Tested with `e3sm_integration`.

As noted in next comment, `PEM_D_Ln5.ne4pg2_oQU480.F2010.gcp12_gnu.eam-implicit_stress` will fail as it looks like this test is not BFB when changing number of tasks.
Otherwise, BFB except NML diff for change in pelayout