### PR TITLE
Fix indexing of layers in high freq. output

### DIFF
--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_high_frequency_output.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_high_frequency_output.F
@@ -175,7 +175,7 @@ contains
       type (mpas_pool_type), pointer :: highFrequencyOutputAMPool
       type (mpas_pool_type), pointer :: tracersPool
 
-      integer :: iLevel, iLevelTarget, iCell, iEdge, i, cell1, cell2, k, eoe
+      integer :: iLevel, iCell, iEdge, i, cell1, cell2, k, eoe
       integer :: iLevel0100, iLevel0250, iLevel0700, iLevel2000
       real (kind=RKIND) :: sumLayerThickness
       integer, pointer :: nVertLevels, nCells, nEdges
@@ -377,37 +377,41 @@ contains
          call mpas_pool_get_array(highFrequencyOutputAMPool, 'columnIntegratedSpeed', columnIntegratedSpeed)
 
          ! find vertical level that is just above the 100 m reference level
-         iLevel0100 = 1
-         do iLevel=2,nVertLevels
+         ! if even the bottom level isn't deep enough, we still default to the bottom level
+         iLevel0100 = nVertLevels
+         do iLevel=1,nVertLevels
            if(refBottomDepth(iLevel) > 100.0_RKIND) then
-              iLevel0100 = iLevel-1
+              iLevel0100 = iLevel
               exit
            endif
          enddo
 
          ! find vertical level that is just above the 250 m reference level
-         iLevel0250 = 1
+         ! if even the bottom level isn't deep enough, we still default to the bottom level
+         iLevel0250 = nVertLevels
          do iLevel=iLevel0100,nVertLevels
            if(refBottomDepth(iLevel) > 250.0_RKIND) then
-              iLevel0250 = iLevel-1
+              iLevel0250 = iLevel
               exit
            endif
          enddo
 
          ! find vertical level that is just above the 700 m reference level
-         iLevel0700 = 1
+         ! if even the bottom level isn't deep enough, we still default to the bottom level
+         iLevel0700 = nVertLevels
          do iLevel=iLevel0250,nVertLevels
            if(refBottomDepth(iLevel) > 700.0_RKIND) then
-              iLevel0700 = iLevel-1
+              iLevel0700 = iLevel
               exit
            endif
          enddo
 
          ! find vertical level that is just above the 2000 m reference level
-         iLevel2000 = 1
+         ! if even the bottom level isn't deep enough, we still default to the bottom level
+         iLevel2000 = nVertLevels
          do iLevel=iLevel0700,nVertLevels
            if(refBottomDepth(iLevel) > 2000.0_RKIND) then
-              iLevel2000 = iLevel-1
+              iLevel2000 = iLevel
               exit
            endif
          enddo


### PR DESCRIPTION
Previously, the layer above the one containing the desired depth was being selected, rather than the layer containing the depth.

The default depth if no layer is found is now the deepest layer, rather than the first layer.  This is because, if no layer is found, it means that even the deepest layer is shallower than the desired depth, and the only sensible default is the deepest layer.

non-BFB only for MPAS-Ocean high-frequency output.

Fixes #6496