### PR TITLE
Disable land ice frazil unless ISMF is on

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -782,7 +782,7 @@ if ($OCN_ISMF eq 'coupled') {
 	add_default($nl, 'config_frazil_under_land_ice', 'val'=>".true.");
 } elsif ($OCN_ISMF eq 'data') {
 	add_default($nl, 'config_land_ice_flux_mode', 'val'=>"data");
-	add_default($nl, 'config_frazil_under_land_ice');
+	add_default($nl, 'config_frazil_under_land_ice', 'val'=>".false.");
 } else {
 	add_default($nl, 'config_land_ice_flux_mode');
 	add_default($nl, 'config_frazil_under_land_ice');

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -761,7 +761,6 @@ add_default($nl, 'config_self_attraction_and_loading_beta');
 
 add_default($nl, 'config_use_frazil_ice_formation');
 add_default($nl, 'config_frazil_in_open_ocean');
-add_default($nl, 'config_frazil_under_land_ice');
 add_default($nl, 'config_frazil_heat_of_fusion');
 add_default($nl, 'config_frazil_ice_density');
 add_default($nl, 'config_frazil_fractional_thickness_limit');
@@ -777,12 +776,16 @@ add_default($nl, 'config_frazil_use_surface_pressure');
 
 if ($OCN_ISMF eq 'coupled') {
 	add_default($nl, 'config_land_ice_flux_mode', 'val'=>"coupled");
+	add_default($nl, 'config_frazil_under_land_ice', 'val'=>".true.");
 } elsif ($OCN_ISMF eq 'internal') {
 	add_default($nl, 'config_land_ice_flux_mode', 'val'=>"standalone");
+	add_default($nl, 'config_frazil_under_land_ice', 'val'=>".true.");
 } elsif ($OCN_ISMF eq 'data') {
 	add_default($nl, 'config_land_ice_flux_mode', 'val'=>"data");
+	add_default($nl, 'config_frazil_under_land_ice');
 } else {
 	add_default($nl, 'config_land_ice_flux_mode');
+	add_default($nl, 'config_frazil_under_land_ice');
 }
 if ($OCN_TIDAL_MIXING eq 'true') {
 	add_default($nl, 'config_land_ice_flux_tidal_Jourdain_alpha', 'val'=>"0.777");

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -770,6 +770,16 @@ add_default($nl, 'config_frazil_sea_ice_reference_salinity');
 add_default($nl, 'config_frazil_maximum_freezing_temperature');
 add_default($nl, 'config_frazil_use_surface_pressure');
 
+if ($OCN_ISMF eq 'coupled') {
+	add_default($nl, 'config_frazil_under_land_ice', 'val'=>".true.");
+} elsif ($OCN_ISMF eq 'internal') {
+	add_default($nl, 'config_frazil_under_land_ice', 'val'=>".true.");
+} elsif ($OCN_ISMF eq 'data') {
+	add_default($nl, 'config_frazil_under_land_ice', 'val'=>".false.");
+} else {
+	add_default($nl, 'config_frazil_under_land_ice');
+}
+
 ###################################
 # Namelist group: land_ice_fluxes #
 ###################################

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -375,7 +375,7 @@
 <!-- frazil_ice -->
 <config_use_frazil_ice_formation>.true.</config_use_frazil_ice_formation>
 <config_frazil_in_open_ocean>.true.</config_frazil_in_open_ocean>
-<config_frazil_under_land_ice>.true.</config_frazil_under_land_ice>
+<config_frazil_under_land_ice>.false.</config_frazil_under_land_ice>
 <config_frazil_heat_of_fusion>3.337e5</config_frazil_heat_of_fusion>
 <config_frazil_ice_density>1000.0</config_frazil_ice_density>
 <config_frazil_fractional_thickness_limit>0.1</config_frazil_fractional_thickness_limit>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -940,7 +940,7 @@
 					description="If frazil formation is used, controls if frazil fluxes are computed in the open ocean (as opposed to under land ice)."
 					possible_values=".true. or .false."
 		/>
-		<nml_option name="config_frazil_under_land_ice" type="logical" default_value=".true."
+		<nml_option name="config_frazil_under_land_ice" type="logical" default_value=".false."
 					description="If frazil formation is used, controls if frazil fluxes are computed under land ice."
 					possible_values=".true. or .false."
 		/>


### PR DESCRIPTION
This PR turns land ice frazil off by default and re-enables it when ice-shelf melt fluxes are enabled in standalone or coupled mode. Land ice frazil is not enabled in data ISMF because frazil fluxes are already included in satellite-derived ISMF products.

[NML]
[non-BFB] when ice-shelf cavities are present in the mesh and (ocn_ismf is off or ocn_ismf is data)
[BFB] when ice-shelf cavities are absent from the mesh or ice-shelf cavities are present in the mesh and (ocn_ismf is coupled or ocn_ismf is internal)