### PR TITLE
Fix a bug in Bug in VBS SOA gas-aerosol partition calculation

### DIFF
--- a/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
@@ -3530,7 +3530,7 @@ do_newnuc_if_block50: &
          ! convert sat vapor conc from ug/m^3 to mol/m^3 then to mol/liter
          tmpa = (c0_soa_298(ll)*1.0e-6_r8/mw_gas(igas)) * 1.0e-3_r8  
          ! calc sat vapor pressure (atm) from molar-conc and temp [ 0.082056 = gas constant in (atm/deg-K/(mol/liter)) ]
-         p0_soa_298(ll) = 0.082056_r8*tmpa*temp  
+         p0_soa_298(ll) = 0.082056_r8*tmpa*298.0_r8 
       end do
 
 ! calc soa gas saturation molar-mixing-ratio at local temp and air-pressure


### PR DESCRIPTION
This bug fix corrects issue #6474 

In subroutine mam_soaexch_vbs_1subarea in components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90

The calculation of p0_soa_298 is not correct. Temperature of 298 K should be used instead of ambient temperature

This fix has very small impact on global mean climate

See e3sm_diags:

and IICE comparison:
