### PR TITLE
restore topo smoothing defaults

### DIFF
--- a/components/homme/src/share/viscosity_base.F90
+++ b/components/homme/src/share/viscosity_base.F90
@@ -582,7 +582,7 @@ subroutine smooth_phis(phis,elem,hybrid,deriv,nets,nete,minf,numcycle,p2filt,xgl
   real (kind=real_kind), dimension(nets:nete) :: pmin,pmax
   real (kind=real_kind) :: phis4(np)
   integer :: nt,ie,ic,i,j
-  integer :: minmax_halo = 0   ! -1 = disabled.  
+  integer :: minmax_halo =-1   ! -1 = disabled.  
                                ! 0  = recompute each time
 
   if (p2filt>=1 .and. np/=4) then


### PR DESCRIPTION
This PR fixes accidental merge of commits b1667309  and ea28b9d59 into master

mt5555 accidentally pushed to master a branch that adds additional experimental options to the topo smoothing code and changes the default behavior (breaking the homme_tool test in cdash).  In consultation with @rljacob , it was decided not to revert but instead fix the default behavior with a correct PR to next and master.   

Add (disabled by default) ability to apply a local limiter to the topo smoothing operator used when generating topography files for new grids

[BFB] 