### PR TITLE
Change fully-coupled HR test to WCYCL1850NS

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -351,7 +351,7 @@ _TESTS = {
     "e3sm_hi_res" : {
         "inherit" : "e3sm_atm_hi_res",
         "tests"   : (
-            "SMS_Ld3.ne120pg2_r025_RRSwISC6to18E3r5.WCYCL1850.eam-cosplite",
+            "SMS_Ld3.ne120pg2_r025_RRSwISC6to18E3r5.WCYCL1850NS.eam-cosplite",
             "SMS.T62_SOwISC12to60E2r4.GMPAS-IAF",
             )
         },


### PR DESCRIPTION
This was intended to be part of [PR #6479](https://github.com/E3SM-Project/E3SM/pull/6479) but I missed that commit. It changes the current fully-active high-res test from WCYCL1850 to WCYCL1850NS because the ocn and ice do not have spunup initial conditions defined yet for the RRSwISC6to18E3r5 mesh.

[BFB] for all tested configurations