### PR TITLE
Update Albany/Trilinos and fix preinstalled kokkos logic

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -275,8 +275,8 @@
     <environment_variables compiler="gnu" mpilib="mpich">
       <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/adios2/2.9.1/cray-mpich-8.1.25/gcc-11.2.0; else echo "$ADIOS2_ROOT"; fi}</env>
       <env name="BLA_VENDOR">Generic</env>
-      <env name="Albany_ROOT">$SHELL{if [ -z "$Albany_ROOT" ]; then echo /global/common/software/e3sm/mali_tpls/albany-e3sm-serial-release-gcc-cmake-fix; else echo "$Albany_ROOT"; fi}</env>
-      <env name="Trilinos_ROOT">$SHELL{if [ -z "$Trilinos_ROOT" ]; then echo /global/common/software/e3sm/mali_tpls/trilinos-e3sm-serial-release-gcc; else echo "$Trilinos_ROOT"; fi}</env>
+      <env name="Albany_ROOT">$SHELL{if [ -z "$Albany_ROOT" ]; then echo /global/common/software/e3sm/albany/2024.03.26/gcc/11.2.0; else echo "$Albany_ROOT"; fi}</env>
+      <env name="Trilinos_ROOT">$SHELL{if [ -z "$Trilinos_ROOT" ]; then echo /global/common/software/e3sm/trilinos/15.1.1/gcc/11.2.0; else echo "$Trilinos_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="nvidia" mpilib="mpich">
       <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/adios2/2.9.1/cray-mpich-8.1.25/nvidia-22.7; else echo "$ADIOS2_ROOT"; fi}</env>
@@ -2652,13 +2652,13 @@
     </environment_variables>
     <environment_variables compiler="intel" mpilib="openmpi">
       <env name="MOAB_ROOT">$SHELL{if [ -z "$MOAB_ROOT" ]; then echo /lcrc/soft/climate/moab/chrysalis/intel; else echo "$MOAB_ROOT"; fi}</env>
+      <env name="Albany_ROOT">$SHELL{if [ -z "$Albany_ROOT" ]; then echo /lcrc/group/e3sm/soft/albany/2024.03.26/intel/20.0.4; else echo "$Albany_ROOT"; fi}</env>
+      <env name="Trilinos_ROOT">$SHELL{if [ -z "$Trilinos_ROOT" ]; then echo /lcrc/group/e3sm/soft/trilinos/15.1.1/intel/20.0.4; else echo "$Trilinos_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="gnu" mpilib="openmpi">
       <env name="MOAB_ROOT">$SHELL{if [ -z "$MOAB_ROOT" ]; then echo /lcrc/soft/climate/moab/chrysalis/gnu; else echo "$MOAB_ROOT"; fi}</env>
-    </environment_variables>
-    <environment_variables compiler="gnu">
-      <env name="Albany_ROOT">$SHELL{if [ -z "$Albany_ROOT" ]; then echo /lcrc/group/e3sm/ac.jwatkins/LandIce/AlbanyBuilds/build-gcc-sfad12-e3sm/install; else echo "$Albany_ROOT"; fi}</env>
-      <env name="Trilinos_ROOT">$SHELL{if [ -z "$Trilinos_ROOT" ]; then echo /lcrc/group/e3sm/ac.jwatkins/LandIce/TrilinosBuilds/build-gcc-e3sm/install; else echo "$Trilinos_ROOT"; fi}</env>
+      <env name="Albany_ROOT">$SHELL{if [ -z "$Albany_ROOT" ]; then echo /lcrc/group/e3sm/soft/albany/2024.03.26/gcc/9.2.0; else echo "$Albany_ROOT"; fi}</env>
+      <env name="Trilinos_ROOT">$SHELL{if [ -z "$Trilinos_ROOT" ]; then echo /lcrc/group/e3sm/soft/trilinos/15.1.1/gcc/9.2.0; else echo "$Trilinos_ROOT"; fi}</env>
     </environment_variables>
   </machine>
 

--- a/components/cmake/find_dep_packages.cmake
+++ b/components/cmake/find_dep_packages.cmake
@@ -16,10 +16,14 @@
 # errors.
 if (USE_KOKKOS)
 
-  # Kokkos will be built in the sharedlibs if Kokkos_ROOT is
-  # unset.
   if (NOT DEFINED ENV{Kokkos_ROOT})
-    set(ENV{Kokkos_ROOT} ${INSTALL_SHAREDPATH})
+    # We should use the kokkos from Trilinos if we are using Trilinos
+    if (USE_TRILINOS)
+      set (ENV{Kokkos_ROOT} ${Trilinos_ROOT})
+    else()
+      # Kokkos will be built in the sharedlibs if Kokkos_ROOT is unset.
+      set(ENV{Kokkos_ROOT} ${INSTALL_SHAREDPATH})
+    endif()
   endif()
 
   find_package(Kokkos REQUIRED)

--- a/components/cmake/find_dep_packages.cmake
+++ b/components/cmake/find_dep_packages.cmake
@@ -11,35 +11,22 @@
 # This will allow users to easily specify a different location for all their cases by
 # simply setting ${Package}_ROOT in their shell.
 
-# Kokkos' find_package needs to come before other find_packages
-# that may define Kokkos targets so we can avoid duplicate target
-# errors.
-if (USE_KOKKOS)
-
+# If using albany or trilinos, we should already have kokkos
+if (USE_ALBANY)
+  find_package(Albany REQUIRED)
+elseif(USE_TRILINOS)
+  find_package(Trilinos REQUIRED)
+elseif(USE_KOKKOS)
   if (NOT DEFINED ENV{Kokkos_ROOT})
-    # We should use the kokkos from Trilinos if we are using Trilinos
-    if (USE_TRILINOS)
-      set (ENV{Kokkos_ROOT} ${Trilinos_ROOT})
-    else()
-      # Kokkos will be built in the sharedlibs if Kokkos_ROOT is unset.
-      set(ENV{Kokkos_ROOT} ${INSTALL_SHAREDPATH})
-    endif()
+    # Kokkos will be built in the sharedlibs if Kokkos_ROOT is unset.
+    set(ENV{Kokkos_ROOT} ${INSTALL_SHAREDPATH})
   endif()
 
   find_package(Kokkos REQUIRED)
 endif()
 
-# Albany depends on Trilinos
-if (USE_ALBANY OR USE_TRILINOS)
-  find_package(Trilinos REQUIRED)
-endif()
-
 if (USE_MOAB)
   find_package(MOAB REQUIRED)
-endif()
-
-if (USE_ALBANY)
-  find_package(Albany REQUIRED)
 endif()
 
 if (USE_PETSC)

--- a/components/cmake/find_dep_packages.cmake
+++ b/components/cmake/find_dep_packages.cmake
@@ -12,22 +12,23 @@
 # simply setting ${Package}_ROOT in their shell.
 
 # If using albany or trilinos, we should already have kokkos
-if(USE_TRILINOS)
+if (USE_ALBANY OR USE_TRILINOS)
   find_package(Trilinos REQUIRED)
-elseif(USE_KOKKOS)
+
+  # When Albany becomes a nice cmake package, that finds its deps, you can
+  # move this line above if (USE_TRILINOS), and turn that if in elseif.
+  # Until then, we must find Albany *after* trilinos has been found
+  if (USE_ALBANY)
+    find_package(Albany REQUIRED)
+  endif()
+elseif (USE_KOKKOS)
+  # Kokkos will be built in the sharedlibs if Kokkos_ROOT is
+  # unset.
   if (NOT DEFINED ENV{Kokkos_ROOT})
     # Kokkos will be built in the sharedlibs if Kokkos_ROOT is unset.
     set(ENV{Kokkos_ROOT} ${INSTALL_SHAREDPATH})
   endif()
-
   find_package(Kokkos REQUIRED)
-endif()
-
-# When Albany becomes a nice cmake package, that finds its deps, you can
-# move this line above if (USE_TRILINOS), and turn that if in elseif.
-# Until then, we must find Albany *after* trilinos has been found
-if (USE_ALBANY)
-  find_package(Albany REQUIRED)
 endif()
 
 if (USE_MOAB)

--- a/components/cmake/find_dep_packages.cmake
+++ b/components/cmake/find_dep_packages.cmake
@@ -12,9 +12,7 @@
 # simply setting ${Package}_ROOT in their shell.
 
 # If using albany or trilinos, we should already have kokkos
-if (USE_ALBANY)
-  find_package(Albany REQUIRED)
-elseif(USE_TRILINOS)
+if(USE_TRILINOS)
   find_package(Trilinos REQUIRED)
 elseif(USE_KOKKOS)
   if (NOT DEFINED ENV{Kokkos_ROOT})
@@ -23,6 +21,13 @@ elseif(USE_KOKKOS)
   endif()
 
   find_package(Kokkos REQUIRED)
+endif()
+
+# When Albany becomes a nice cmake package, that finds its deps, you can
+# move this line above if (USE_TRILINOS), and turn that if in elseif.
+# Until then, we must find Albany *after* trilinos has been found
+if (USE_ALBANY)
+  find_package(Albany REQUIRED)
 endif()
 
 if (USE_MOAB)

--- a/components/mpas-albany-landice/bld/namelist_files/albany_input.yaml
+++ b/components/mpas-albany-landice/bld/namelist_files/albany_input.yaml
@@ -1,16 +1,14 @@
 %YAML 1.1
 ---
 ANONYMOUS:
-  Build Type: Tpetra
-
   Problem:
+    Basal Cubature Degree: 4
     LandIce Field Norm:
       sliding_velocity_basalside:
         Regularization Type: Given Value
         Regularization Value: 1.0e-4
     LandIce BCs:
       BC 0:
-        Cubature Degree: 4
         Basal Friction Coefficient:
           Type: Power Law
           Power Exponent: 1.0
@@ -82,14 +80,6 @@ ANONYMOUS:
 #             Linear Solver Information
               Linear Solver Type: Belos
               Linear Solver Types: 
-                AztecOO: 
-                  Forward Solve: 
-                    AztecOO Settings: 
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 200
                 Belos:
                   Solver Type: Block GMRES
                   Solver Types:

--- a/share/build/buildlib.kokkos
+++ b/share/build/buildlib.kokkos
@@ -50,9 +50,9 @@ OR
 ###############################################################################
 def buildlib(bldroot, installpath, case):
 ###############################################################################
-    # If we are using Trilinos, we must use the Kokkos that comes with it
-    if case.get_value("USE_TRILINOS"):
-        print ("You case is using Trilinos and will use its Kokkos")
+    # If we are using Albany/Trilinos, we must use the Kokkos that comes with it
+    if case.get_value("USE_ALBANY") or case.get_value("USE_TRILINOS"):
+        print ("case is using Trilinos and will use its Kokkos")
         return
 
     installed_kokkos_dir = os.environ.get("Kokkos_ROOT")

--- a/share/build/buildlib.kokkos
+++ b/share/build/buildlib.kokkos
@@ -50,6 +50,11 @@ OR
 ###############################################################################
 def buildlib(bldroot, installpath, case):
 ###############################################################################
+    # If we are using Trilinos, we must use the Kokkos that comes with it
+    if case.get_value("USE_TRILINOS"):
+        print ("You case is using Trilinos and will use its Kokkos")
+        return
+
     installed_kokkos_dir = os.environ.get("Kokkos_ROOT")
     if installed_kokkos_dir is not None:
         # We are trying to use a pre-installed kokkos. Look for the relevant folders/libs,
@@ -65,9 +70,10 @@ def buildlib(bldroot, installpath, case):
         # often arch dependent (e.g., $prefix/lib or $prefix/lib64)... The best thing
         # would be to run a small cmake script, that calls find_package. But E3SM's
         # cmake build system will do that soon enough, so any error will be caught there.
+        print (f"Using pre-installed Kokkos_ROOT: {kokkos_root}")
         return
     else:
-        print ("no value foudn in env for Kokkos_ROOT. building from scratch")
+        print ("no value found in env for Kokkos_ROOT. building from scratch")
 
     srcroot = case.get_value("SRCROOT")
     ekat_dir = os.path.join(srcroot, "externals", "ekat")


### PR DESCRIPTION
This updates preinstalled Albany/Trilinos on pmcpu/chrysalis to versions that are compatible with e3sm/kokkos (https://github.com/E3SM-Project/kokkos/tree/e3sm-kokkos-4.2.00). e3sm/kokkos is first preinstalled and is then used as a tpl to build trilinos.

This also fixes preinstalled kokkos logic so that the preinstalled e3sm/kokkos is only used when `USE_ALBANY` or `USE_TRILINOS` is enabled (I think this only happens when MALI is built). This is based on https://github.com/E3SM-Project/E3SM/pull/6473 and https://github.com/E3SM-Project/E3SM/tree/bartgol/find-kokkos-after-albany so we can close those once this is pushed.

`SMS.ne30pg2_r05_IcoswISC30E3r5_gis20.BGWCYCL1850.chrysalis_gnu.allactive-gis20km` works with this PR.

[non-BFB] only for tests with active MALI