### PR TITLE
Improve path for finding csh in shell_commands

### DIFF
--- a/components/eam/cime_config/usermods_dirs/scm/shell_commands
+++ b/components/eam/cime_config/usermods_dirs/scm/shell_commands
@@ -1,4 +1,4 @@
-#!/bin/csh
+#!/usr/bin/env csh
 # need to use single thread
 foreach component ( ATM LND ICE OCN CPL GLC ROF WAV )
  ./xmlchange NTASKS_$component=1


### PR DESCRIPTION
On GCP, csh not found at this location, using `/usr/bin/env csh` instead.
The following tests were failing create_newcase:
```
SMS_R_Ld5.ne4_ne4.FSCM-ARM97.gcp12_gnu.eam-scm
SMS_Ln5.ne4_ne4.FSCM-ARM97-MMF1.gcp12_gnu
```

[BFB]