### PR TITLE
upgrade e3sm-imgs to 0.0.9 and add singularity2 machine

### DIFF
--- a/.github/workflows/e3sm-gh-ci-cime-tests.yml
+++ b/.github/workflows/e3sm-gh-ci-cime-tests.yml
@@ -27,16 +27,16 @@ jobs:
       fail-fast: false
       matrix:
         test: 
-          - SMS_D_P4.ne4pg2_oQU480.F2010.singularity_gnu
-          - SMS_P4.ne4pg2_oQU480.F2010.singularity_gnu
-          - REP_P4.ne4pg2_oQU480.F2010.singularity_gnu
-          - ERS_P4.ne4pg2_oQU480.F2010.singularity_gnu
-          - ERS_P4.ne4pg2_oQU480.F2010.singularity_gnu.eam-wcprod_F2010
-          - ERP_P4.ne4pg2_oQU480.F2010.singularity_gnu
-          - PET_P4.ne4pg2_oQU480.F2010.singularity_gnu
-          - PEM_P4.ne4pg2_oQU480.F2010.singularity_gnu
+          - SMS_D_P4.ne4pg2_oQU480.F2010.singularity2_gnu
+          - SMS_P4.ne4pg2_oQU480.F2010.singularity2_gnu
+          - REP_P4.ne4pg2_oQU480.F2010.singularity2_gnu
+          - ERS_P4.ne4pg2_oQU480.F2010.singularity2_gnu
+          - ERS_P4.ne4pg2_oQU480.F2010.singularity2_gnu.eam-wcprod_F2010
+          - ERP_P4.ne4pg2_oQU480.F2010.singularity2_gnu
+          - PET_P4.ne4pg2_oQU480.F2010.singularity2_gnu
+          - PEM_P4.ne4pg2_oQU480.F2010.singularity2_gnu
     container: 
-      image: ghcr.io/mahf708/e3sm-imgs:v0.0.6
+      image: ghcr.io/mahf708/e3sm-imgs:v0.0.9
 
     steps:
       - 

--- a/.github/workflows/e3sm-gh-ci-w-cime-tests.yml
+++ b/.github/workflows/e3sm-gh-ci-w-cime-tests.yml
@@ -19,16 +19,16 @@ jobs:
       fail-fast: false
       matrix:
         test: 
-          - SMS_D_P8.ne4pg2_oQU480.WCYCL2010NS.singularity_gnu
-          - SMS_P8.ne4pg2_oQU480.WCYCL2010NS.singularity_gnu
-          - REP_P8.ne4pg2_oQU480.WCYCL2010NS.singularity_gnu
-          - ERS_P8.ne4pg2_oQU480.WCYCL2010NS.singularity_gnu
-          - ERS_P8.ne4pg2_oQU480.WCYCL2010NS.singularity_gnu.allactive-wcprod_1850
-          - ERP_P8.ne4pg2_oQU480.WCYCL2010NS.singularity_gnu
-          - PET_P8.ne4pg2_oQU480.WCYCL2010NS.singularity_gnu
-          - PEM_P8.ne4pg2_oQU480.WCYCL2010NS.singularity_gnu
+          - SMS_D_P8.ne4pg2_oQU480.WCYCL2010NS.singularity2_gnu
+          - SMS_P8.ne4pg2_oQU480.WCYCL2010NS.singularity2_gnu
+          - REP_P8.ne4pg2_oQU480.WCYCL2010NS.singularity2_gnu
+          - ERS_P8.ne4pg2_oQU480.WCYCL2010NS.singularity2_gnu
+          - ERS_P8.ne4pg2_oQU480.WCYCL2010NS.singularity2_gnu.allactive-wcprod_1850
+          - ERP_P8.ne4pg2_oQU480.WCYCL2010NS.singularity2_gnu
+          - PET_P8.ne4pg2_oQU480.WCYCL2010NS.singularity2_gnu
+          - PEM_P8.ne4pg2_oQU480.WCYCL2010NS.singularity2_gnu
     container: 
-      image: ghcr.io/mahf708/e3sm-imgs:v0.0.6
+      image: ghcr.io/mahf708/e3sm-imgs:v0.0.9
 
     steps:
       - 

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1714,6 +1714,51 @@
     </environment_variables>
   </machine>
 
+  <machine MACH="singularity2">
+    <DESC>Singularity container 2.0</DESC>
+    <NODENAME_REGEX>singularity2</NODENAME_REGEX>
+    <OS>LINUX</OS>
+    <COMPILERS>gnu</COMPILERS>
+    <MPILIBS>mpich</MPILIBS>
+    <CIME_OUTPUT_ROOT>$ENV{HOME}/projects/e3sm/scratch</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>$ENV{HOME}/projects/e3sm/cesm-inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>$ENV{HOME}/projects/e3sm/ptclm-data</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$ENV{HOME}/projects/e3sm/scratch/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>$ENV{HOME}/projects/e3sm/baselines/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/usr/local/packages/bin/cprnc</CCSM_CPRNC>
+    <GMAKE>make</GMAKE>
+    <GMAKE_J>4</GMAKE_J>
+    <TESTS>e3sm_developer</TESTS>
+    <BATCH_SYSTEM>none</BATCH_SYSTEM>
+    <SUPPORTED_BY>e3sm-team</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
+    <mpirun mpilib="default">
+      <executable>mpirun</executable>
+      <arguments>
+        <arg name="num_tasks"> -launcher fork -hosts localhost -np {{ total_tasks }}</arg>
+      </arguments>
+    </mpirun>
+    <module_system type="none"/>
+    <RUNDIR>$ENV{HOME}/projects/e3sm/scratch/$CASE/run</RUNDIR>
+    <EXEROOT>$ENV{HOME}/projects/e3sm/scratch/$CASE/bld</EXEROOT>
+    <environment_variables>
+      <env name="E3SM_SRCROOT">$SRCROOT</env>
+    </environment_variables>
+    <environment_variables mpilib="mpi-serial">
+      <env name="NETCDF_PATH">/usr/local/packages</env>
+      <env name="PATH">/usr/local/packages/bin:$ENV{PATH}</env>
+      <env name="LD_LIBRARY_PATH">/usr/local/packages/lib</env>
+    </environment_variables>
+    <environment_variables mpilib="!mpi-serial">
+      <env name="NETCDF_PATH">/usr/local/packages</env>
+      <env name="PNETCDF_PATH">/usr/local/packages</env>
+      <env name="HDF5_ROOT">/usr/local/packages</env>
+      <env name="PATH">/usr/local/packages/bin:$ENV{PATH}</env>
+      <env name="LD_LIBRARY_PATH">/usr/local/packages/lib</env>
+    </environment_variables>
+  </machine>
+
   <machine MACH="melvin">
     <DESC>Linux workstation for Jenkins testing</DESC>
     <NODENAME_REGEX>(melvin|watson|s999964|climate|penn|sems)</NODENAME_REGEX>


### PR DESCRIPTION
A significant update in the underlying container image we are using for the "gh" testing suite. These updates primarily include moving to a spack-based installation/building of key tools. The container is now based on ubuntu 22.04 (apr 2022) with gcc 11 (the default gcc compilers for ubuntu 22.04). This update is the first step towards operationalizing these containers (with different varieties, e.g., oneapi compilers, etc.) for production-grade runs.

Relevant changes in container repo: https://github.com/mahf708/e3sm-imgs/compare/v0.0.6...v0.0.9