### PR TITLE
Add a new snow thermal conductivity calculation to ELM 

### DIFF
--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -767,7 +767,7 @@ snowpack conditions on glaciers and ice sheets, including a semi-empirical
 firn densification model. uses the same physics as use_extrasnowlayers but
 uses the original 5 snow layer scheme
 
-<entry id="use_snow_thk" type="logical" category="physics"
+<entry id="use_T_rho_dependent_snowthk" type="logical" category="physics"
 	group="elm_inparm" valid_values="" value=".false.">
 Toggle to use new snow thermal conductivity that relies on snow temperature and density. 
 </entry>

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -766,6 +766,10 @@ This option enables more realistic
 snowpack conditions on glaciers and ice sheets, including a semi-empirical
 firn densification model. uses the same physics as use_extrasnowlayers but
 uses the original 5 snow layer scheme
+
+<entry id="use_snow_thk" type="logical" category="physics"
+	group="elm_inparm" valid_values="" value=".false.">
+Toggle to use new snow thermal conductivity that relies on snow temperature and density. 
 </entry>
 
 <entry id="use_noio" type="logical" category="default_settings"

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -952,7 +952,6 @@ contains
             if (use_T_rho_dependent_snowthk) then ! chose which snow thermal conductivity to use 
                if (snl(c)+1 < 1 .AND. (j >= snl(c)+1) .AND. (j <= 0)) then
                     bw(c,j) = (h2osoi_ice(c,j)+h2osoi_liq(c,j))/(frac_sno(c)*dz(c,j))
-                    !write(iulog,*)"CAW bw(c,j)",bw(c,j)
 
                        do i = 1, 5
                         if (i == 1) then
@@ -981,10 +980,6 @@ contains
                            thk(c,j) = k_snw_vals(size(k_snw_tmps))
                        end if
 
-                     !  write(iulog,*)"CAW snow layer:",j
-                     !  write(iulog,*)"CAW snow temp:",t_soisno(c,j)
-                     !  write(iulog,*)"CAW snow density:",bw(c,j)
-                     !  write(iulog,*)"CAW snow thk:",thk(c,j) 
                end if
 
 

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -864,7 +864,7 @@ contains
     real(r8) :: k_snw_coe2(5)
     real(r8) :: k_snw_coe3(5)
     data k_snw_tmps(:) /223.0_r8, 248.0_r8, 263.0_r8, 268.0_r8, 273.0_r8/
-    data k_snw_coe1(:) /2.564_r8,2.172_r8,1.985_r8,1.883_r8,1.776_r8/
+    data k_snw_coe1(:) /2.564_r8, 2.172_r8, 1.985_r8, 1.883_r8, 1.776_r8/
     data k_snw_coe2(:) /-0.059_r8, 0.015_r8, 0.073_r8, 0.107_r8, 0.147_r8/
     data k_snw_coe3(:) /0.0205_r8, 0.0252_r8, 0.0336_r8, 0.0386_r8, 0.0455_r8/
     !-----------------------------------------------------------------------
@@ -982,9 +982,9 @@ contains
             else 
                     ! Thermal conductivity of snow, which from Jordan (1991) pp. 18
                     ! Only examine levels from snl(c)+1 -> 0 where snl(c) < 1
-                    if (snl(c)+1 < 1 .AND. (j >= snl(c)+1) .AND. (j <= 0)) then
-                       bw(c,j) = (h2osoi_ice(c,j)+h2osoi_liq(c,j))/(frac_sno(c)*dz(c,j))
-                       thk(c,j) = tkair + (7.75e-5_r8 *bw(c,j) + 1.105e-6_r8*bw(c,j)*bw(c,j))*(tkice-tkair)
+                    if (snl(c) + 1 < 1 .AND. (j >= snl(c) + 1) .AND. (j <= 0)) then
+                       bw(c,j) = (h2osoi_ice(c,j) + h2osoi_liq(c,j)) / (frac_sno(c) * dz(c,j))
+                       thk(c,j) = tkair + (7.75e-5_r8 * bw(c,j) + 1.105e-6_r8 * bw(c,j) * bw(c,j)) * (tkice - tkair)
                     end if
             endif
          end do

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -834,7 +834,7 @@ contains
     use elm_varcon      , only : denh2o, denice, tfrz, tkwat, tkice, tkair, cpice,  cpliq, thk_bedrock
     use landunit_varcon , only : istice, istice_mec, istwet
     use column_varcon   , only : icol_roof, icol_sunwall, icol_shadewall, icol_road_perv, icol_road_imperv
-    use elm_varctl      , only : iulog, use_snow_thk
+    use elm_varctl      , only : iulog, use_T_rho_dependent_snowthk
     !
     ! !ARGUMENTS:
     type(bounds_type)      , intent(in)    :: bounds
@@ -949,7 +949,7 @@ contains
                endif
             endif
             
-            if (use_snow_thk) then ! chose which snow thermal conductivity to use 
+            if (use_T_rho_dependent_snowthk) then ! chose which snow thermal conductivity to use 
                if (snl(c)+1 < 1 .AND. (j >= snl(c)+1) .AND. (j <= 0)) then
                     bw(c,j) = (h2osoi_ice(c,j)+h2osoi_liq(c,j))/(frac_sno(c)*dz(c,j))
                     !write(iulog,*)"CAW bw(c,j)",bw(c,j)

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -860,7 +860,13 @@ contains
     real(r8), parameter :: rho_ice     = 917._r8
     real(r8) :: k_snw_vals(5)
     real(r8) :: k_snw_tmps(5)
-    data k_snw_tmps(:) /223.0, 248.0, 263.0, 268.0, 273.0/
+    real(r8) :: k_snw_coe1(5)
+    real(r8) :: k_snw_coe2(5)
+    real(r8) :: k_snw_coe3(5)
+    data k_snw_tmps(:) /223.0_r8, 248.0_r8, 263.0_r8, 268.0_r8, 273.0_r8/
+    data k_snw_coe1(:) /2.564_r8,2.172_r8,1.985_r8,1.883_r8,1.776_r8/
+    data k_snw_coe2(:) /-0.059_r8, 0.015_r8, 0.073_r8, 0.107_r8, 0.147_r8/
+    data k_snw_coe3(:) /0.0205_r8, 0.0252_r8, 0.0336_r8, 0.0386_r8, 0.0455_r8/
     !-----------------------------------------------------------------------
     event = 'SoilThermProp'
     call t_start_lnd( event )
@@ -949,27 +955,17 @@ contains
                endif
             endif
             
-            if (use_T_rho_dependent_snowthk) then ! chose which snow thermal conductivity to use 
+            if (use_T_rho_dependent_snowthk) then ! choose which snow thermal conductivity to use 
                if (snl(c)+1 < 1 .AND. (j >= snl(c)+1) .AND. (j <= 0)) then
-                    bw(c,j) = (h2osoi_ice(c,j)+h2osoi_liq(c,j))/(frac_sno(c)*dz(c,j))
+                    bw(c,j) = (h2osoi_ice(c,j) + h2osoi_liq(c,j)) / (frac_sno(c) * dz(c,j))
 
                        do i = 1, 5
-                        if (i == 1) then
-                            k_snw_vals(i) = 2.564 * (bw(c,j)/ rho_ice)**2 - 0.059 * (bw(c,j)/ rho_ice) + 0.0205
-                        else if (i == 2) then
-                            k_snw_vals(i) = 2.172 * (bw(c,j)/ rho_ice)**2 + 0.015 * (bw(c,j)/ rho_ice) + 0.0252
-                        else if (i == 3) then
-                            k_snw_vals(i) = 1.985 * (bw(c,j)/ rho_ice)**2 + 0.073 * (bw(c,j)/ rho_ice) + 0.0336
-                        else if (i == 4) then
-                            k_snw_vals(i) = 1.883 * (bw(c,j)/ rho_ice)**2 + 0.107 * (bw(c,j)/ rho_ice) + 0.0386
-                        else if (i == 5) then
-                            k_snw_vals(i) = 1.776 * (bw(c,j)/ rho_ice)**2 + 0.147 * (bw(c,j)/ rho_ice) + 0.0455
-                        end if
+                            k_snw_vals(i) = k_snw_coe1(i) * (bw(c,j) / rho_ice)**2 - k_snw_coe2(i) * (bw(c,j) / rho_ice) + k_snw_coe3(i)
                        end do
 
                        do i = 1, size(k_snw_tmps) - 1
                         if (k_snw_tmps(i) <= t_soisno(c,j) .and. t_soisno(c,j) <= k_snw_tmps(i + 1)) then
-                            thk(c,j) = k_snw_vals(i) + (t_soisno(c,j) - k_snw_tmps(i))*(k_snw_vals(i + 1)-k_snw_vals(i))/(k_snw_tmps(i + 1)-k_snw_tmps(i))
+                            thk(c,j) = k_snw_vals(i) + (t_soisno(c,j) - k_snw_tmps(i)) * (k_snw_vals(i + 1)-k_snw_vals(i)) / (k_snw_tmps(i + 1) - k_snw_tmps(i))
                         end if
                        end do
 

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -285,7 +285,7 @@ contains
          use_nofire, use_lch4, use_vertsoilc, use_extralakelayers, &
          use_vichydro, use_century_decomp, use_cn, use_crop, use_snicar_frc, &
          use_snicar_ad, use_firn_percolation_and_compaction, use_extrasnowlayers,&
-         use_vancouver, use_mexicocity, use_noio
+         use_snow_thk, use_vancouver, use_mexicocity, use_noio
 
     ! cpl_bypass variables
     namelist /elm_inparm/ metdata_type, metdata_bypass, metdata_biases, &
@@ -726,7 +726,11 @@ contains
     call mpi_bcast (use_vertsoilc, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_extralakelayers, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_extrasnowlayers, 1, MPI_LOGICAL, 0, mpicom, ier)
+<<<<<<< HEAD
     call mpi_bcast (use_firn_percolation_and_compaction, 1, MPI_LOGICAL, 0, mpicom, ier)
+=======
+    call mpi_bcast (use_snow_thk, 1, MPI_LOGICAL, 0, mpicom, ier)
+>>>>>>> aa0f583905 (Added new snow Thermal Conductivity in SoilTemperatureMod.F90)
     call mpi_bcast (use_vichydro, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_century_decomp, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_cn, 1, MPI_LOGICAL, 0, mpicom, ier)
@@ -1030,7 +1034,11 @@ contains
     write(iulog,*) '    use_lake_wat_storage = ', use_lake_wat_storage
     write(iulog,*) '    use_extralakelayers = ', use_extralakelayers
     write(iulog,*) '    use_extrasnowlayers = ', use_extrasnowlayers
+<<<<<<< HEAD
     write(iulog,*) '    use_firn_percolation_and_compaction = ', use_firn_percolation_and_compaction
+=======
+    write(iulog,*) '    use_snow_thk = ', use_snow_thk
+>>>>>>> aa0f583905 (Added new snow Thermal Conductivity in SoilTemperatureMod.F90)
     write(iulog,*) '    use_vichydro = ', use_vichydro
     write(iulog,*) '    use_century_decomp = ', use_century_decomp
     write(iulog,*) '    use_cn = ', use_cn

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -726,15 +726,8 @@ contains
     call mpi_bcast (use_vertsoilc, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_extralakelayers, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_extrasnowlayers, 1, MPI_LOGICAL, 0, mpicom, ier)
-<<<<<<< HEAD
-<<<<<<< HEAD
     call mpi_bcast (use_firn_percolation_and_compaction, 1, MPI_LOGICAL, 0, mpicom, ier)
-=======
-    call mpi_bcast (use_snow_thk, 1, MPI_LOGICAL, 0, mpicom, ier)
->>>>>>> aa0f583905 (Added new snow Thermal Conductivity in SoilTemperatureMod.F90)
-=======
     call mpi_bcast (use_T_rho_dependent_snowthk, 1, MPI_LOGICAL, 0, mpicom, ier)
->>>>>>> 7d87f8c1ac (changed flag name for new snow thk flag to be more descriptive)
     call mpi_bcast (use_vichydro, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_century_decomp, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_cn, 1, MPI_LOGICAL, 0, mpicom, ier)
@@ -1038,15 +1031,8 @@ contains
     write(iulog,*) '    use_lake_wat_storage = ', use_lake_wat_storage
     write(iulog,*) '    use_extralakelayers = ', use_extralakelayers
     write(iulog,*) '    use_extrasnowlayers = ', use_extrasnowlayers
-<<<<<<< HEAD
-<<<<<<< HEAD
     write(iulog,*) '    use_firn_percolation_and_compaction = ', use_firn_percolation_and_compaction
-=======
-    write(iulog,*) '    use_snow_thk = ', use_snow_thk
->>>>>>> aa0f583905 (Added new snow Thermal Conductivity in SoilTemperatureMod.F90)
-=======
     write(iulog,*) '    use_T_rho_dependent_snowthk = ', use_T_rho_dependent_snowthk
->>>>>>> 7d87f8c1ac (changed flag name for new snow thk flag to be more descriptive)
     write(iulog,*) '    use_vichydro = ', use_vichydro
     write(iulog,*) '    use_century_decomp = ', use_century_decomp
     write(iulog,*) '    use_cn = ', use_cn

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -285,7 +285,7 @@ contains
          use_nofire, use_lch4, use_vertsoilc, use_extralakelayers, &
          use_vichydro, use_century_decomp, use_cn, use_crop, use_snicar_frc, &
          use_snicar_ad, use_firn_percolation_and_compaction, use_extrasnowlayers,&
-         use_snow_thk, use_vancouver, use_mexicocity, use_noio
+         use_T_rho_dependent_snowthk, use_vancouver, use_mexicocity, use_noio
 
     ! cpl_bypass variables
     namelist /elm_inparm/ metdata_type, metdata_bypass, metdata_biases, &
@@ -727,10 +727,14 @@ contains
     call mpi_bcast (use_extralakelayers, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_extrasnowlayers, 1, MPI_LOGICAL, 0, mpicom, ier)
 <<<<<<< HEAD
+<<<<<<< HEAD
     call mpi_bcast (use_firn_percolation_and_compaction, 1, MPI_LOGICAL, 0, mpicom, ier)
 =======
     call mpi_bcast (use_snow_thk, 1, MPI_LOGICAL, 0, mpicom, ier)
 >>>>>>> aa0f583905 (Added new snow Thermal Conductivity in SoilTemperatureMod.F90)
+=======
+    call mpi_bcast (use_T_rho_dependent_snowthk, 1, MPI_LOGICAL, 0, mpicom, ier)
+>>>>>>> 7d87f8c1ac (changed flag name for new snow thk flag to be more descriptive)
     call mpi_bcast (use_vichydro, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_century_decomp, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_cn, 1, MPI_LOGICAL, 0, mpicom, ier)
@@ -1035,10 +1039,14 @@ contains
     write(iulog,*) '    use_extralakelayers = ', use_extralakelayers
     write(iulog,*) '    use_extrasnowlayers = ', use_extrasnowlayers
 <<<<<<< HEAD
+<<<<<<< HEAD
     write(iulog,*) '    use_firn_percolation_and_compaction = ', use_firn_percolation_and_compaction
 =======
     write(iulog,*) '    use_snow_thk = ', use_snow_thk
 >>>>>>> aa0f583905 (Added new snow Thermal Conductivity in SoilTemperatureMod.F90)
+=======
+    write(iulog,*) '    use_T_rho_dependent_snowthk = ', use_T_rho_dependent_snowthk
+>>>>>>> 7d87f8c1ac (changed flag name for new snow thk flag to be more descriptive)
     write(iulog,*) '    use_vichydro = ', use_vichydro
     write(iulog,*) '    use_century_decomp = ', use_century_decomp
     write(iulog,*) '    use_cn = ', use_cn

--- a/components/elm/src/main/elm_varctl.F90
+++ b/components/elm/src/main/elm_varctl.F90
@@ -376,6 +376,7 @@ module elm_varctl
   logical, public :: use_snicar_ad       = .false.
   logical, public :: use_extrasnowlayers = .false.
   logical, public :: use_firn_percolation_and_compaction  = .false.
+  logical, public :: use_snow_thk        = .false.
   logical, public :: use_vancouver       = .false.
   logical, public :: use_mexicocity      = .false.
   logical, public :: use_noio            = .false.

--- a/components/elm/src/main/elm_varctl.F90
+++ b/components/elm/src/main/elm_varctl.F90
@@ -376,11 +376,11 @@ module elm_varctl
   logical, public :: use_snicar_ad       = .false.
   logical, public :: use_extrasnowlayers = .false.
   logical, public :: use_firn_percolation_and_compaction  = .false.
-  logical, public :: use_snow_thk        = .false.
   logical, public :: use_vancouver       = .false.
   logical, public :: use_mexicocity      = .false.
   logical, public :: use_noio            = .false.
   logical, public :: use_var_soil_thick  = .false.
+  logical, public :: use_T_rho_dependent_snowthk     = .false.
   logical, public :: use_atm_downscaling_to_topunit  = .false.
   character(len = SHR_KIND_CS), public :: precip_downscaling_method  = 'ERMM' ! Precip downscaling method values can be ERMM or FNM
   logical, public :: use_lake_wat_storage = .false.


### PR DESCRIPTION
implemented the new snow thermal conductivity calculation method introduced in  [Fourteau, et al. (2021)](https://tc.copernicus.org/articles/15/2739/2021/) in ELM. This improves the current method, introduced in [Jordan (1991)](https://erdc-library.erdc.dren.mil/jspui/handle/11681/11677) which only depends on the snow density.

More information can be found here: https://acme-climate.atlassian.net/wiki/spaces/FAN/pages/4391501825/Snow+Temperature+and+Density+Dependent+Thermal+Conductivity 

relevant nl changes
`use_T_rho_dependent_snowthk = .true. `
[ELM]
[BFB]
[NML]