### PR TITLE
Temporarily disable MMF2 integration test

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -339,7 +339,7 @@ _TESTS = {
             "ERP_Ln9.ne4pg2_oQU480.WCYCL20TRNS-MMF1.allactive-mmf_fixed_subcycle",
             "ERS_Ln9.ne4pg2_ne4pg2.FRCE-MMF1.eam-cosp_nhtfrq9",
             "SMS_Ln5.ne4_ne4.FSCM-ARM97-MMF1",
-            "SMS_Ln3.ne4pg2_ne4pg2.F2010-MMF2",
+            # "SMS_Ln3.ne4pg2_ne4pg2.F2010-MMF2", - temporarily disabled due to ongoing dev issues
             )
         },
 


### PR DESCRIPTION
Due to ongoing complications in updating PAM that would otherwise fix the MMF2 test failures,
it was decided to temporarily disable this test until those issues could be ironed out.
Whenever the PAM PR can provide a working MMF2 test it will be re-enabled there, but the timeline for this is unclear.

[BFB]