### PR TITLE
[MPAS-Ocean standalone] Fix bottom depth when filling bathymetry holes

### DIFF
--- a/components/mpas-ocean/src/mode_init/mpas_ocn_init_vertical_grids.F
+++ b/components/mpas-ocean/src/mode_init/mpas_ocn_init_vertical_grids.F
@@ -1480,6 +1480,7 @@ contains
           call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
           call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
           call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+          call mpas_pool_get_array(meshPool, 'bottomDepth', bottomDepth)
 
           ! Fill bathymetry holes, i.e. single cells that are deeper than all neighbors.
           ! These cells can collect tracer extrema and are not able to use
@@ -1497,6 +1498,9 @@ contains
 
              if (maxLevelCell(iCell) > maxLevelNeighbors) then
                 maxLevelCell(iCell) = maxLevelNeighbors
+                if (smoothingMask(iCell) == 0) then
+                   bottomDepth(iCell) = refBottomDepth(maxLevelNeighbors)
+                end if
              end if
           end do
 


### PR DESCRIPTION
In MPAS-Ocean init mode, when filling holes in the bathymetry (cells with deepest layers that are deeper than any of their neighbors) as part of the Haney-number-constrained vertical coordinate used for ice shelves, the bottom depth was not also being updated correctly for some cells.  This merge fixes the issue for cells in the z-level region of the ocean (far from ice-shelf cavities) by setting the bottom depth to the deepest depth within the same z level as the deepest neighbor.