### PR TITLE
Add Omega docs link to index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ research problems and Department of Energy mission needs while efficiently using
 - [MOSART](./MOSART/index.md)
 - [MPAS-Ocean](./MPAS-Ocean/index.md)
 - [MPAS-seaice](./MPAS-seaice/index.md)
+- [Omega](https://docs.e3sm.org/Omega/omega/) — not yet supported.
 
 ## Tools
 


### PR DESCRIPTION
Add a link to the Omega documentation to `docs/index.md`.