### PR TITLE
Add outfld lines for in-cloud properties output.

### DIFF
--- a/components/eam/src/physics/p3/eam/micro_p3_interface.F90
+++ b/components/eam/src/physics/p3/eam/micro_p3_interface.F90
@@ -1630,6 +1630,12 @@ end subroutine micro_p3_readnl
    call outfld('FREQI',       freqi,       pcols,    lchnk)
    call outfld('FREQR',       freqr,       psetcols, lchnk)
    call outfld('CDNUMC',      cdnumc,      pcols,    lchnk)
+!<shanyp 05182024
+   call outfld('ICIMRST',     icimrst,      pcols,    lchnk)
+   call outfld('ICWMRST',     icwmrst,      pcols,    lchnk)
+   call outfld('ICINC' ,      icinc,        pcols,    lchnk)
+   call outfld('ICWNC' ,      icwnc,        pcols,    lchnk)
+!shanyp 05182024>
 
    call outfld('CLOUDFRAC_LIQ_MICRO',  cld_frac_l,      pcols, lchnk)
    call outfld('CLOUDFRAC_ICE_MICRO',  cld_frac_i,      pcols, lchnk)


### PR DESCRIPTION
Add output lines for in-cloud qc​, nc​, qi​, and ni in P3​ to ensure that their values are correctly output. Without these lines, their values will be zero.

The changes have no impact on simulation results - except for the outputs that are fixed: `ICIMRST`, `ICWMRST`, `ICINC`, `ICWNC`. 

[BFB] No tests are affected. These in-cloud variables are not in default eam.h0.