### PR TITLE
Add ocean relativeVorticityAtSurface to highFrequencyStats

### DIFF
--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -922,6 +922,7 @@ def buildnml(case, caseroot, compname):
             lines.append('    <var_array name="activeTracersAtBottom"/>')
             lines.append('    <var name="kineticEnergyAtSurface"/>')
             lines.append('    <var name="kineticEnergyAt250m"/>')
+            lines.append('    <var name="relativeVorticityAtSurface"/>')
             lines.append('    <var name="relativeVorticityAt250m"/>')
             lines.append('    <var name="ssh"/>')
             lines.append('    <var name="pressureAdjustedSSH"/>')

--- a/components/mpas-ocean/src/analysis_members/Registry_high_frequency_output.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_high_frequency_output.xml
@@ -27,6 +27,9 @@
 		<var name="kineticEnergyAtSurface" type="real" dimensions="nCells Time" units="m^2 s^-2"
 			description="kinetic energy at surface"
 		/>
+		<var name="relativeVorticityAtSurface" type="real" dimensions="nCells Time" units="s^-1"
+			description="relative vorticity at cell centers at surface"
+		/>
 		<var name="vertGMvelocitySFC" type="real" dimensions="nCells Time" units="m s^-1"
 			description="vertical velocity due to GM parameterization"
 		/>
@@ -304,12 +307,12 @@
 			<stream name="mesh"/>
 			<var name="xtime"/>
 			<var name="kineticEnergyAtSurface"/>
+			<var name="relativeVorticityAtSurface"/>
 			<var_array name="activeTracersAtSurface"/>
 			<var name="ssh"/>
 			<var name="kineticEnergyAt250m"/>
 			<var name="relativeVorticityAt250m"/>
 			<var name="divergenceAt250m"/>
-			<var name="relativeVorticityAt250m"/>
 			<var name="barotropicSpeed"/>
 			<var name="columnIntegratedSpeed"/>
 			<var name="relativeVorticityVertexAt250m"/>

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_high_frequency_output.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_high_frequency_output.F
@@ -183,7 +183,7 @@ contains
       integer, dimension(:,:), pointer :: edgesOnCell, cellsOnEdge, edgesOnEdge
 
       real (kind=RKIND) :: invAreaCell1, layerThicknessEdge1, coeff, weightedNormalVel, cellArea
-      real (kind=RKIND), dimension(:), pointer :: refBottomDepth, kineticEnergyAt250m, kineticEnergyAtSurface, relativeVorticityAt250m
+      real (kind=RKIND), dimension(:), pointer :: refBottomDepth, kineticEnergyAt250m, kineticEnergyAtSurface, relativeVorticityAt250m, relativeVorticityAtSurface
       real (kind=RKIND), dimension(:), pointer :: divergenceAt250m, relativeVorticityVertexAt250m
       real (kind=RKIND), dimension(:), pointer :: divergenceAtBottom,relativeVorticityAtBottom,kineticEnergyAtBottom
       real (kind=RKIND), dimension(:), pointer :: vertVelAt250m
@@ -263,6 +263,7 @@ contains
          call mpas_pool_get_array(highFrequencyOutputAMPool, 'kineticEnergyAt250m', kineticEnergyAt250m)
          call mpas_pool_get_array(highFrequencyOutputAMPool, 'kineticEnergyAtSurface', kineticEnergyAtSurface)
          call mpas_pool_get_array(highFrequencyOutputAMPool, 'relativeVorticityAt250m', relativeVorticityAt250m)
+         call mpas_pool_get_array(highFrequencyOutputAMPool, 'relativeVorticityAtSurface', relativeVorticityAtSurface)
          call mpas_pool_get_array(highFrequencyOutputAMPool, 'divergenceAt250m', divergenceAt250m)
          call mpas_pool_get_array(highFrequencyOutputAMPool, 'relativeVorticityAtBottom', relativeVorticityAtBottom)
          call mpas_pool_get_array(highFrequencyOutputAMPool, 'divergenceAtBottom', divergenceAtBottom)
@@ -418,6 +419,7 @@ contains
          divergenceAt250m(:) = divergence(iLevel0250,:)
          relativeVorticityVertexAt250m(:) = relativeVorticity(iLevel0250,:)
          kineticEnergyAtSurface(:) = kineticEnergyCell(1,:)
+         relativeVorticityAtSurface(:) = relativeVorticityCell(1,:)
          activeTracersAtSurface(1,:) = activeTracers(1,1,:)
          activeTracersAtSurface(2,:) = activeTracers(2,1,:)
          activeTracersAt250m(1,:) = activeTracers(1,iLevel0250,:)


### PR DESCRIPTION
It is useful to visualize relative vorticity at the surface, which was not saved in high frequency stats in the past. I have added this commit to several recent simulations, including for the high-resolution Gulf of Mexico work. It works as expected. The variable is added to the default output for `highFrequencyStats`, but is only a 2D field and is optional. 

We commonly use relative vorticity at the surface for images and movies, in addition to surface kinetic energy.