### PR TITLE
Add DLND to moab coupler

### DIFF
--- a/components/data_comps/dlnd/src/dlnd_comp_mod.F90
+++ b/components/data_comps/dlnd/src/dlnd_comp_mod.F90
@@ -148,10 +148,10 @@ CONTAINS
 #ifdef HAVE_MOAB
     character*400  tagname
     real(R8) latv, lonv
-    integer iv, tagindex, ilat, ilon  !, arrsize, nfields ! ierr is already defined as integer above
+    integer iv, tagindex, ilat, ilon 
     real(R8), allocatable, target :: data(:)
     integer(IN), pointer :: idata(:)   ! temporary
-    real(r8), dimension(:), allocatable :: moab_vert_coords  ! temporary
+    real(R8), dimension(:), allocatable :: moab_vert_coords  ! temporary
 #ifdef MOABDEBUG
     character*100 outfile, wopts
 #endif

--- a/components/data_comps/dlnd/src/dlnd_comp_mod.F90
+++ b/components/data_comps/dlnd/src/dlnd_comp_mod.F90
@@ -29,6 +29,10 @@ module dlnd_comp_mod
   use dlnd_shr_mod   , only: domain_fracname ! namelist input
   use dlnd_shr_mod   , only: nullstr
 
+#ifdef HAVE_MOAB
+  use seq_comm_mct,     only : mlnid ! id of moab lnd app
+  use iso_c_binding
+#endif
   ! !PUBLIC TYPES:
   implicit none
   private ! except
@@ -100,6 +104,12 @@ CONTAINS
        scmMode, scmlat, scmlon)
 
     ! !DESCRIPTION: initialize dlnd model
+#ifdef HAVE_MOAB
+       use iMOAB, only: iMOAB_DefineTagStorage, iMOAB_GetDoubleTagStorage, &
+                        iMOAB_SetIntTagStorage, iMOAB_SetDoubleTagStorage, &
+                        iMOAB_ResolveSharedEntities, iMOAB_CreateVertices, &
+                        iMOAB_GetMeshInfo, iMOAB_UpdateMeshInfo, iMOAB_WriteMesh
+#endif
     implicit none
 
     ! !INPUT/OUTPUT PARAMETERS:
@@ -134,6 +144,18 @@ CONTAINS
     integer(IN)        :: field_num ! field number
     character(nec_len) :: nec_str   ! elevation class, as character string
     character(*), parameter :: domain_fracname_unset = 'null'
+
+#ifdef HAVE_MOAB
+    character*400  tagname
+    real(R8) latv, lonv
+    integer iv, tagindex, ilat, ilon  !, arrsize, nfields ! ierr is already defined as integer above
+    real(R8), allocatable, target :: data(:)
+    integer(IN), pointer :: idata(:)   ! temporary
+    real(r8), dimension(:), allocatable :: moab_vert_coords  ! temporary
+#ifdef MOABDEBUG
+    character*100 outfile, wopts
+#endif
+#endif
 
     !--- formats ---
     character(*), parameter :: F00   = "('(dlnd_comp_init) ',8a)"
@@ -256,6 +278,119 @@ CONTAINS
 
     call t_stopf('dlnd_initmctdom')
 
+#ifdef HAVE_MOAB
+    ilat = mct_aVect_indexRA(ggrid%data,'lat')
+    ilon = mct_aVect_indexRA(ggrid%data,'lon')
+    allocate(moab_vert_coords(lsize*3))
+    do iv = 1, lsize
+       lonv = ggrid%data%rAttr(ilon, iv) * SHR_CONST_PI/180.
+       latv = ggrid%data%rAttr(ilat, iv) * SHR_CONST_PI/180.
+       moab_vert_coords(3*iv-2)=COS(latv)*COS(lonv)
+       moab_vert_coords(3*iv-1)=COS(latv)*SIN(lonv)
+       moab_vert_coords(3*iv  )=SIN(latv)
+    enddo
+ 
+    ! create the vertices with coordinates from MCT domain
+    ierr = iMOAB_CreateVertices(mlnid, lsize*3, 3, moab_vert_coords)
+    if (ierr .ne. 0)  &
+       call shr_sys_abort('Error: fail to create MOAB vertices in data lnd model')
+ 
+    tagname='GLOBAL_ID'//C_NULL_CHAR
+    ierr = iMOAB_DefineTagStorage(mlnid, tagname, &
+                                  0, & ! dense, integer
+                                  1, & ! number of components
+                                  tagindex )
+    if (ierr .ne. 0)  &
+       call shr_sys_abort('Error: fail to retrieve GLOBAL_ID tag ')
+ 
+    ! get list of global IDs for Dofs
+    call mct_gsMap_orderedPoints(gsMap, my_task, idata)
+ 
+    ierr = iMOAB_SetIntTagStorage ( mlnid, tagname, lsize, &
+                                     0, & ! vertex type
+                                     idata)
+    if (ierr .ne. 0)  &
+       call shr_sys_abort('Error: fail to set GLOBAL_ID tag ')
+ 
+    ierr = iMOAB_ResolveSharedEntities( mlnid, lsize, idata );
+    if (ierr .ne. 0)  &
+       call shr_sys_abort('Error: fail to resolve shared entities')
+ 
+    deallocate(moab_vert_coords)
+    deallocate(idata)
+ 
+    ierr = iMOAB_UpdateMeshInfo( mlnid )
+    if (ierr .ne. 0)  &
+       call shr_sys_abort('Error: fail to update mesh info ')
+ 
+    allocate(data(lsize))
+    ierr = iMOAB_DefineTagStorage( mlnid, "area:aream:frac:mask"//C_NULL_CHAR, &
+                                     1, & ! dense, double
+                                     1, & ! number of components
+                                     tagindex )
+    if (ierr > 0 )  &
+       call shr_sys_abort('Error: fail to create tag: area:aream:frac:mask' )
+ 
+    data(:) = ggrid%data%rAttr(mct_aVect_indexRA(ggrid%data,'area'),:)
+    tagname='area'//C_NULL_CHAR
+    ierr = iMOAB_SetDoubleTagStorage ( mlnid, tagname, lsize, &
+                                     0, & ! set data on vertices
+                                     data)
+    if (ierr > 0 )  &
+       call shr_sys_abort('Error: fail to get area tag ')
+ 
+    ! set the same data for aream (model area) as area
+    ! data(:) = ggrid%data%rAttr(mct_aVect_indexRA(ggrid%data,'aream'),:)
+    tagname='aream'//C_NULL_CHAR
+    ierr = iMOAB_SetDoubleTagStorage ( mlnid, tagname, lsize, &
+                                     0, & ! set data on vertices
+                                     data)
+    if (ierr > 0 )  &
+       call shr_sys_abort('Error: fail to set aream tag ')
+ 
+    data(:) = ggrid%data%rAttr(mct_aVect_indexRA(ggrid%data,'mask'),:)
+    tagname='mask'//C_NULL_CHAR
+    ierr = iMOAB_SetDoubleTagStorage ( mlnid, tagname, lsize, &
+                                     0, & ! set data on vertices
+                                     data)
+    if (ierr > 0 )  &
+       call shr_sys_abort('Error: fail to set mask tag ')
+ 
+    data(:) = ggrid%data%rAttr(mct_aVect_indexRA(ggrid%data,'frac'),:)
+    tagname='frac'//C_NULL_CHAR
+    ierr = iMOAB_SetDoubleTagStorage ( mlnid, tagname, lsize, &
+                                     0, & ! set data on vertices
+                                     data)
+    if (ierr > 0 )  &
+       call shr_sys_abort('Error: fail to set frac tag ')
+ 
+    deallocate(data)
+ 
+    ! define tags
+    ierr = iMOAB_DefineTagStorage( mlnid, trim(seq_flds_x2l_fields)//C_NULL_CHAR, &
+                                     1, & ! dense, double
+                                     1, & ! number of components
+                                     tagindex )
+    if (ierr > 0 )  &
+       call shr_sys_abort('Error: fail to create seq_flds_x2l_fields tags ')
+ 
+    ierr = iMOAB_DefineTagStorage( mlnid, trim(seq_flds_l2x_fields)//C_NULL_CHAR, &
+                                     1, & ! dense, double
+                                     1, & ! number of components
+                                     tagindex )
+    if (ierr > 0 )  &
+       call shr_sys_abort('Error: fail to create seq_flds_l2x_fields tags ')
+#ifdef MOABDEBUG
+       !      debug test
+    outfile = 'LndDataMesh.h5m'//C_NULL_CHAR
+    wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
+       !      write out the mesh file to disk
+    ierr = iMOAB_WriteMesh(mlnid, trim(outfile), trim(wopts))
+    if (ierr .ne. 0) then
+       call shr_sys_abort(subname//' ERROR in writing data mesh lnd ')
+    endif
+#endif
+#endif
     !----------------------------------------------------------------------------
     ! Initialize MCT attribute vectors
     !----------------------------------------------------------------------------
@@ -339,8 +474,15 @@ CONTAINS
        inst_suffix, logunit, case_name)
 
     ! !DESCRIPTION:  run method for dlnd model
-    implicit none
+#ifdef HAVE_MOAB
+#ifdef MOABDEBUG
+    use iMOAB, only: iMOAB_WriteMesh
+#endif
+    use seq_flds_mod    , only: seq_flds_l2x_fields 
+    use seq_flds_mod    , only: moab_set_tag_from_av
+#endif
 
+    implicit none
     ! !INPUT/OUTPUT PARAMETERS:
     type(ESMF_Clock)       , intent(in)    :: EClock
     type(mct_aVect)        , intent(inout) :: x2l
@@ -366,6 +508,17 @@ CONTAINS
     integer(IN)   :: nu                    ! unit number
     logical       :: write_restart         ! restart now
     character(len=18) :: date_str
+#ifdef HAVE_MOAB
+    real(R8), allocatable, target :: datam(:)
+    type(mct_list) :: temp_list
+    integer :: size_list, index_list, lsize
+    type(mct_string)    :: mctOStr  !
+    character*400  tagname, mct_field
+#ifdef MOABDEBUG
+    integer  :: cur_dlnd_stepno, ierr
+    character*100 outfile, wopts, lnum
+#endif
+#endif
 
     character(*), parameter :: F00   = "('(dlnd_comp_run) ',8a)"
     character(*), parameter :: F04   = "('(dlnd_comp_run) ',2a,2i8,'s')"
@@ -463,6 +616,32 @@ CONTAINS
     call t_stopf('dlnd_run2')
 
     call t_stopf('DLND_RUN')
+
+#ifdef HAVE_MOAB
+    lsize = mct_avect_lsize(l2x) ! is it the same as mct_avect_lsize(avstrm) ?
+    allocate(datam(lsize)) ! 
+    call mct_list_init(temp_list ,seq_flds_l2x_fields)
+    size_list=mct_list_nitem (temp_list)
+    do index_list = 1, size_list
+      call mct_list_get(mctOStr,index_list,temp_list)
+      mct_field = mct_string_toChar(mctOStr)
+      tagname= trim(mct_field)//C_NULL_CHAR
+      call moab_set_tag_from_av(tagname, l2x, index_list, mlnid, datam, lsize) ! loop over all a2x fields, not just a few
+    enddo
+    call mct_list_clean(temp_list)
+    deallocate(datam) ! maybe we should keep it around, deallocate at the final only?
+
+#ifdef MOABDEBUG
+    call seq_timemgr_EClockGetData( EClock, stepno=cur_dlnd_stepno )
+    write(lnum,"(I0.2)")cur_dlnd_stepno
+    outfile = 'dlnd_comp_run_'//trim(lnum)//'.h5m'//C_NULL_CHAR
+    wopts   = 'PARALLEL=WRITE_PART'//C_NULL_CHAR
+    ierr = iMOAB_WriteMesh(mlnid, outfile, wopts)
+    if (ierr > 0 )  then
+       write(logunit,*) 'Failed to write data lnd component state '
+    endif
+#endif
+#endif
 
   end subroutine dlnd_comp_run
 

--- a/components/data_comps/dlnd/src/dlnd_comp_mod.F90
+++ b/components/data_comps/dlnd/src/dlnd_comp_mod.F90
@@ -105,10 +105,13 @@ CONTAINS
 
     ! !DESCRIPTION: initialize dlnd model
 #ifdef HAVE_MOAB
-       use iMOAB, only: iMOAB_DefineTagStorage, iMOAB_GetDoubleTagStorage, &
+       use iMOAB, only: iMOAB_DefineTagStorage, &
                         iMOAB_SetIntTagStorage, iMOAB_SetDoubleTagStorage, &
                         iMOAB_ResolveSharedEntities, iMOAB_CreateVertices, &
-                        iMOAB_GetMeshInfo, iMOAB_UpdateMeshInfo, iMOAB_WriteMesh
+                        iMOAB_UpdateMeshInfo
+#ifdef MOABDEBUG
+       use iMOAB, only: iMOAB_WriteMesh
+#endif
 #endif
     implicit none
 

--- a/components/data_comps/dlnd/src/lnd_comp_mct.F90
+++ b/components/data_comps/dlnd/src/lnd_comp_mct.F90
@@ -84,16 +84,6 @@ CONTAINS
     real(R8)          :: scmLon  = shr_const_SPVAL ! single column lon
     character(*), parameter :: subName = "(lnd_init_mct) "
     !-------------------------------------------------------------------------------
-#ifdef HAVE_MOAB
-    character(CL)        :: filePath ! generic file path
-    character(CL)        :: fileName ! generic file name
-    character(CS)        :: timeName ! domain file: time variable name
-    character(CS)        :: lonName  ! domain file: lon  variable name
-    character(CS)        :: latName  ! domain file: lat  variable name
-    character(CS)        :: hgtName  ! domain file: hgt  variable name
-    character(CS)        :: maskName ! domain file: mask variable name
-    character(CS)        :: areaName ! domain file: area variable name
-#endif
 
     ! Set cdata pointers
     call seq_cdata_setptrs(cdata, &
@@ -176,13 +166,9 @@ CONTAINS
          scmMode, scmlat, scmlon)
 #ifdef HAVE_MOAB
      if (my_task == master_task) then
-          call shr_stream_getDomainInfo(SDLND%stream(1), filePath,fileName,timeName,lonName, &
-               latName,hgtName,maskName,areaName)
-          call shr_stream_getFile(filePath,fileName)
-          ! send path of data lnd domain to MOAB coupler.
-          call seq_infodata_PutData( infodata, lnd_domain=fileName) ! we use the same one for regular case
+          call seq_infodata_PutData( infodata, lnd_domain=SDLND%domainFile) ! we use the same one for regular case
           ! in regular case, it is copied from fatmlndfrc ; so we don't know if it is data land or not
-          write(logunit,*), ' filename: ', filename
+          write(logunit,*), ' use this land domain file: ', SDLND%domainFile
      endif
 #endif
     !----------------------------------------------------------------------------

--- a/driver-moab/main/component_mod.F90
+++ b/driver-moab/main/component_mod.F90
@@ -748,6 +748,7 @@ subroutine component_init_areacor_moab (comp, mbccid, mbcxid, seq_flds_c2x_fluxe
          lsize = comp(1)%mblsize
          allocate(areas (lsize, 3)) ! lsize is along grid; read mask too
          allocate(factors (lsize, 2))
+         factors = 1.0 ! initialize with 1.0 all factors; then maybe correct them
          ! get areas
          tagname='area:aream:mask'//C_NULL_CHAR
          arrsize = 3 * lsize

--- a/driver-moab/main/prep_lnd_mod.F90
+++ b/driver-moab/main/prep_lnd_mod.F90
@@ -222,7 +222,6 @@ contains
           call seq_map_init_rcfile(mapper_Fr2l, rof(1), lnd(1), &
                'seq_maps.rc','rof2lnd_fmapname:','rof2lnd_fmaptype:',samegrid_lr, &
                string='mapper_Fr2l initialization',esmf_map=esmf_map_flag)
-       end if
 ! symmetric of l2r, from prep_rof
 #ifdef HAVE_MOAB
           ! Call moab intx only if land and river are init in moab
@@ -381,6 +380,7 @@ contains
          end if ! if ((mbrxid .ge. 0) .and.  (mblxid .ge. 0))
 ! endif HAVE_MOAB
 #endif
+       end if
        call shr_sys_flush(logunit)
 
        if (atm_c2_lnd) then

--- a/driver-moab/main/prep_lnd_mod.F90
+++ b/driver-moab/main/prep_lnd_mod.F90
@@ -1,6 +1,6 @@
 module prep_lnd_mod
 
-  use shr_kind_mod    , only: r8 => SHR_KIND_R8
+  use shr_kind_mod    , only: R8 => SHR_KIND_R8
   use shr_kind_mod    , only: cs => SHR_KIND_CS
   use shr_kind_mod    , only: cl => SHR_KIND_CL
   use shr_kind_mod    , only: cxx => SHR_KIND_CXX
@@ -162,7 +162,7 @@ contains
     integer  nrflds  ! number of rof fields projected on land
     integer arrsize  ! for setting the r2x fields on land to 0
     integer ent_type ! for setting tags
-    real (kind=r8) , allocatable :: tmparray (:) ! used to set the r2x fields to 0
+    real (kind=R8) , allocatable :: tmparray (:) ! used to set the r2x fields to 0
 
 #endif
     character(*), parameter  :: subname = '(prep_lnd_init)'
@@ -369,7 +369,7 @@ contains
             arrsize = nrflds*mlsize
             allocate (tmparray(arrsize)) ! mlsize is the size of local land
             ! do we need to zero out others or just river ?
-            tmparray = 0._r8
+            tmparray = 0._R8
             ierr = iMOAB_SetDoubleTagStorage(mblxid, tagname, arrsize , ent_type, tmparray)
             if (ierr .ne. 0) then
                write(logunit,*) subname,' cant zero out r2x tags on land'
@@ -693,7 +693,7 @@ contains
 #endif
 #ifdef MOABCOMP
     character(CXX)           :: tagname, mct_field
-    real(r8)                 :: difference
+    real(R8)                 :: difference
     type(mct_list) :: temp_list
     integer :: size_list, index_list, ent_type
     type(mct_string)    :: mctOStr  !

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -1,6 +1,6 @@
 module prep_ocn_mod
 
-  use shr_kind_mod,     only: r8 => SHR_KIND_R8
+  use shr_kind_mod,     only: R8 => SHR_KIND_R8
   use shr_kind_mod,     only: cs => SHR_KIND_CS
   use shr_kind_mod,     only: cl => SHR_KIND_CL
   use shr_kind_mod,     only: CX => shr_kind_CX, CXX => shr_kind_CXX
@@ -137,7 +137,7 @@ module prep_ocn_mod
   integer        , target  :: x2oacc_ox_cnt ! x2oacc_ox: number of time samples accumulated
 
   ! accumulation variables for moab data
-  real (kind=r8) , allocatable, private, target :: x2oacc_om (:,:)   ! Ocn import, ocn grid, cpl pes, moab array
+  real (kind=R8) , allocatable, private, target :: x2oacc_om (:,:)   ! Ocn import, ocn grid, cpl pes, moab array
   integer        , target  :: x2oacc_om_cnt ! x2oacc_ox: number of time samples accumulated, in moab array
   integer                  :: arrSize_x2o_om !   this will be a module variable, size moabLocal_size * nof
 
@@ -154,20 +154,20 @@ module prep_ocn_mod
   !================================================================================================
 
 
-  real (kind=r8) , allocatable, private :: fractions_om (:,:) ! will retrieve the fractions from ocean, and use them
+  real (kind=R8) , allocatable, private :: fractions_om (:,:) ! will retrieve the fractions from ocean, and use them
   !  they were init with
   ! character(*),parameter :: fraclist_o = 'afrac:ifrac:ofrac:ifrad:ofrad' in moab, on the fractions
-  real (kind=r8) , allocatable, private :: x2o_om (:,:)
-  real (kind=r8) , allocatable, private :: a2x_om (:,:)
-  real (kind=r8) , allocatable, private :: i2x_om (:,:)
-  real (kind=r8) , allocatable, private :: r2x_om (:,:)
-  real (kind=r8) , allocatable, private :: xao_om (:,:)
+  real (kind=R8) , allocatable, private :: x2o_om (:,:)
+  real (kind=R8) , allocatable, private :: a2x_om (:,:)
+  real (kind=R8) , allocatable, private :: i2x_om (:,:)
+  real (kind=R8) , allocatable, private :: r2x_om (:,:)
+  real (kind=R8) , allocatable, private :: xao_om (:,:)
 
   ! this will be constructed first time, and be used to copy fields for shared indices
   ! between xao and x2o
   character(CXX) :: shared_fields_xao_x2o
   ! will need some array to hold the data for copying
-  real(r8) , allocatable, save :: shared_values(:) ! will be the size of shared indices * lsize
+  real(R8) , allocatable, save :: shared_values(:) ! will be the size of shared indices * lsize
   integer    :: size_of_shared_values
 
   logical                  :: iamin_CPLALLICEID     ! pe associated with CPLALLICEID
@@ -268,7 +268,7 @@ contains
     integer arrsize  ! for setting the r2x fields on land to 0
     integer ent_type ! for setting tags
     integer noflds   ! used for number of fields in allocating moab accumulated array x2oacc_om
-    real (kind=r8) , allocatable :: tmparray (:) ! used to set the r2x fields to 0
+    real (kind=R8) , allocatable :: tmparray (:) ! used to set the r2x fields to 0
 
     !---------------------------------------------------------------
 
@@ -786,7 +786,7 @@ contains
          arrsize = nrflds*mlsize
          allocate (tmparray(arrsize)) ! mlsize is the size of local land
          ! do we need to zero out others or just river ?
-         tmparray = 0._r8
+         tmparray = 0._R8
          ierr = iMOAB_SetDoubleTagStorage(mboxid, tagname, arrsize , ent_type, tmparray)
          if (ierr .ne. 0) then
             write(logunit,*) subname,' cant zero out r2x tags on ocn'
@@ -1095,7 +1095,7 @@ subroutine prep_ocn_accum_avg_moab()
     !
     ! Local Variables
     integer                  :: eii, ewi, egi, eoi, eai, eri, exi, efi, emi
-    real(r8)                 :: flux_epbalfact ! adjusted precip factor
+    real(R8)                 :: flux_epbalfact ! adjusted precip factor
     type(mct_avect), pointer :: x2o_ox
     integer                  :: cnt
     character(*), parameter  :: subname = '(prep_ocn_mrg)'
@@ -1177,7 +1177,7 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
     !---------------------------------------------------------------
 
 
-    real(r8)                 :: flux_epbalfact ! adjusted precip factor
+    real(R8)                 :: flux_epbalfact ! adjusted precip factor
 
     ! will build x2o_om , similar to x2o_ox
     ! no averages, just one ocn instance
@@ -1187,11 +1187,11 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
     integer  :: kof,kif
     integer  :: lsize, arrsize ! for double arrays
     integer , save :: noflds,naflds,niflds,nrflds,nxflds!  ,ngflds,nwflds, no glacier or wave model
-    real(r8) :: ifrac,ifracr
-    real(r8) :: afrac,afracr
-    real(r8) :: frac_sum
-    real(r8) :: avsdr, anidr, avsdf, anidf   ! albedos
-    real(r8) :: fswabsv, fswabsi             ! sw
+    real(R8) :: ifrac,ifracr
+    real(R8) :: afrac,afracr
+    real(R8) :: frac_sum
+    real(R8) :: avsdr, anidr, avsdf, anidf   ! albedos
+    real(R8) :: fswabsv, fswabsi             ! sw
     character(CL),allocatable :: field_ocn(:)   ! string converted to char
     character(CL),allocatable :: field_atm(:)   ! string converted to char
     character(CL),allocatable :: field_ice(:)   ! string converted to char
@@ -1289,7 +1289,7 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
 #endif
 #ifdef MOABCOMP
     character(CXX) :: mct_field
-    real(r8)                 :: difference
+    real(R8)                 :: difference
     type(mct_list) :: temp_list
     integer :: size_list, index_list
     type(mct_string)    :: mctOStr  !
@@ -1345,7 +1345,7 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
        allocate(a2x_om (lsize, naflds))
        allocate(i2x_om (lsize, niflds))
        allocate(r2x_om (lsize, nrflds))
-       r2x_om = 0._r8 ! should we zero out all of them ?
+       r2x_om = 0._R8 ! should we zero out all of them ?
        allocate(xao_om (lsize, nxflds))
        ! allocate fractions too
        ! use the fraclist fraclist_o = 'afrac:ifrac:ofrac:ifrad:ofrad'
@@ -1769,7 +1769,7 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
        ifrac = fractions_om(n,kif) ! fo_kif_ifrac(n) ! fractions_o%rAttr(kif,n)
        afrac = fractions_om(n,kof) ! fo_kof_ofrac(n) ! fractions_o%rAttr(kof,n)
        frac_sum = ifrac + afrac
-       if ((frac_sum) /= 0._r8) then
+       if ((frac_sum) /= 0._R8) then
           ifrac = ifrac / (frac_sum)
           afrac = afrac / (frac_sum)
        endif
@@ -1777,7 +1777,7 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
        ifracr = fractions_om(n,kir) ! fo_kir_ifrad(n)  ! fractions_o%rAttr(kir,n)
        afracr = fractions_om(n,kor) ! fo_kor_ofrad(n) ! fractions_o%rAttr(kor,n)
        frac_sum = ifracr + afracr
-       if ((frac_sum) /= 0._r8) then
+       if ((frac_sum) /= 0._R8) then
           ifracr = ifracr / (frac_sum)
           afracr = afracr / (frac_sum)
        endif
@@ -1913,7 +1913,7 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
           ifrac = fractions_om(n,kif) !fo_kif_ifrac(n) ! fractions_o%rAttr(kif)
           afrac = fractions_om(n,kof) ! fo_kof_ofrac(n) ! fractions_o%rAttr(kof,n)
           frac_sum = ifrac + afrac
-          if ((frac_sum) /= 0._r8) then
+          if ((frac_sum) /= 0._R8) then
              ifrac = ifrac / (frac_sum)
              afrac = afrac / (frac_sum)
           endif
@@ -2046,7 +2046,7 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
     !-----------------------------------------------------------------------
     !
     ! Arguments
-    real(r8)       , intent(in)    :: flux_epbalfact
+    real(R8)       , intent(in)    :: flux_epbalfact
     type(mct_aVect), intent(in)    :: a2x_o
     type(mct_aVect), intent(in)    :: i2x_o
     type(mct_aVect), intent(in)    :: r2x_o
@@ -2061,11 +2061,11 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
     integer  :: kof,kif
     integer  :: lsize
     integer  :: noflds,naflds,niflds,nrflds,nwflds,nxflds,ngflds
-    real(r8) :: ifrac,ifracr
-    real(r8) :: afrac,afracr
-    real(r8) :: frac_sum
-    real(r8) :: avsdr, anidr, avsdf, anidf   ! albedos
-    real(r8) :: fswabsv, fswabsi             ! sw
+    real(R8) :: ifrac,ifracr
+    real(R8) :: afrac,afracr
+    real(R8) :: frac_sum
+    real(R8) :: avsdr, anidr, avsdf, anidf   ! albedos
+    real(R8) :: fswabsv, fswabsi             ! sw
     character(CL),allocatable :: field_ocn(:)   ! string converted to char
     character(CL),allocatable :: field_atm(:)   ! string converted to char
     character(CL),allocatable :: field_ice(:)   ! string converted to char
@@ -2584,7 +2584,7 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
        ifrac = fractions_o%rAttr(kif,n)
        afrac = fractions_o%rAttr(kof,n)
        frac_sum = ifrac + afrac
-       if ((frac_sum) /= 0._r8) then
+       if ((frac_sum) /= 0._R8) then
           ifrac = ifrac / (frac_sum)
           afrac = afrac / (frac_sum)
        endif
@@ -2592,7 +2592,7 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
        ifracr = fractions_o%rAttr(kir,n)
        afracr = fractions_o%rAttr(kor,n)
        frac_sum = ifracr + afracr
-       if ((frac_sum) /= 0._r8) then
+       if ((frac_sum) /= 0._R8) then
           ifracr = ifracr / (frac_sum)
           afracr = afracr / (frac_sum)
        endif
@@ -2738,7 +2738,7 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
           ifrac = fractions_o%rAttr(kif,n)
           afrac = fractions_o%rAttr(kof,n)
           frac_sum = ifrac + afrac
-          if ((frac_sum) /= 0._r8) then
+          if ((frac_sum) /= 0._R8) then
              ifrac = ifrac / (frac_sum)
              afrac = afrac / (frac_sum)
           endif
@@ -3068,7 +3068,7 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
     prep_ocn_get_mapper_Sw2o => mapper_Sw2o
   end function prep_ocn_get_mapper_Sw2o
   function prep_ocn_get_x2oacc_om()
-    real(r8), DIMENSION(:, :), pointer :: prep_ocn_get_x2oacc_om
+    real(R8), DIMENSION(:, :), pointer :: prep_ocn_get_x2oacc_om
     prep_ocn_get_x2oacc_om => x2oacc_om
   end function prep_ocn_get_x2oacc_om
   function prep_ocn_get_x2oacc_om_cnt()

--- a/driver-moab/main/prep_rof_mod.F90
+++ b/driver-moab/main/prep_rof_mod.F90
@@ -1,7 +1,7 @@
 module prep_rof_mod
 
 #include "shr_assert.h"
-  use shr_kind_mod,     only: r8 => SHR_KIND_R8
+  use shr_kind_mod,     only: R8 => SHR_KIND_R8
   use shr_kind_mod,     only: cs => SHR_KIND_CS
   use shr_kind_mod,     only: cl => SHR_KIND_CL
   use shr_kind_mod,     only: cxx => SHR_KIND_CXX
@@ -112,22 +112,22 @@ module prep_rof_mod
 
   ! accumulation variables over moab fields 
   character(CXX)                        :: sharedFieldsLndRof ! used in moab to define l2racc_lm
-  real (kind=r8) , allocatable, private, target :: l2racc_lm(:,:)   ! lnd export, lnd grid, cpl pes
-  real (kind=r8) , allocatable, private :: l2x_lm2(:,:)  ! basically l2x_lm, but in another copy, on rof module
+  real (kind=R8) , allocatable, private, target :: l2racc_lm(:,:)   ! lnd export, lnd grid, cpl pes
+  real (kind=R8) , allocatable, private :: l2x_lm2(:,:)  ! basically l2x_lm, but in another copy, on rof module
   integer        , target  :: l2racc_lm_cnt  ! l2racc_lm: number of time samples accumulated
   integer :: nfields_sh_lr ! number of fields in sharedFieldsLndRof
   integer :: lsize_lm ! size of land in moab, local
 
   character(CXX)       :: sharedFieldsAtmRof ! used in moab to define a2racc_am
-  real (kind=r8) , allocatable, private ::  a2racc_am(:,:)   ! atm export, atm grid, cpl pes
-  real (kind=r8) , allocatable, private :: a2x_am2(:,:)  ! basically a2x_am, but in another copy, on rof module
+  real (kind=R8) , allocatable, private ::  a2racc_am(:,:)   ! atm export, atm grid, cpl pes
+  real (kind=R8) , allocatable, private :: a2x_am2(:,:)  ! basically a2x_am, but in another copy, on rof module
   integer        , target  :: a2racc_am_cnt  ! a2racc_am: number of time samples accumulated 
   integer :: nfields_sh_ar ! number of fields in sharedFieldsAtmRof
   integer :: lsize_am ! size of atm in moab, local
 
   character(CXX)       :: sharedFieldsOcnRof ! used in moab to define o2racc_om
-  real (kind=r8) , allocatable, private, target ::  o2racc_om(:,:)   ! ocn export, ocn grid, cpl pes
-  real (kind=r8) , allocatable, private :: o2r_om2(:,:)  ! basically o2x_om, but in another copy, on rof module, only shared with rof
+  real (kind=R8) , allocatable, private, target ::  o2racc_om(:,:)   ! ocn export, ocn grid, cpl pes
+  real (kind=R8) , allocatable, private :: o2r_om2(:,:)  ! basically o2x_om, but in another copy, on rof module, only shared with rof
   integer        , target  :: o2racc_om_cnt  ! o2racc_om: number of time samples accumulated
   integer :: nfields_sh_or ! number of fields in sharedFieldsOcnRof
   integer :: lsize_om ! size of ocn in moab, local
@@ -145,12 +145,12 @@ module prep_rof_mod
   logical :: samegrid_al   ! samegrid atm and lnd
 
   ! moab stuff
-   real (kind=r8) , allocatable, private :: fractions_rm (:,:) ! will retrieve the fractions from rof, and use them
+   real (kind=R8) , allocatable, private :: fractions_rm (:,:) ! will retrieve the fractions from rof, and use them
   !  they were init with 
   ! character(*),parameter :: fraclist_r = 'lfrac:lfrin:rfrac'  in moab, on the fractions 
-  real (kind=r8) , allocatable, private :: x2r_rm (:,:) ! result of merge
-  real (kind=r8) , allocatable, private :: a2x_rm (:,:)
-  real (kind=r8) , allocatable, private :: l2x_rm (:,:)
+  real (kind=R8) , allocatable, private :: x2r_rm (:,:) ! result of merge
+  real (kind=R8) , allocatable, private :: a2x_rm (:,:)
+  real (kind=R8) , allocatable, private :: l2x_rm (:,:)
 
   !================================================================================================
 
@@ -1223,7 +1223,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
     integer, save :: index_x2r_coszen_str
 
     integer, save :: index_frac
-    real(r8)      :: frac
+    real(R8)      :: frac
     character(CL) :: fracstr
     logical, save :: first_time = .true.
     logical, save :: flds_wiso_rof = .false.
@@ -1529,7 +1529,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
     integer, save :: index_x2r_coszen_str
 
     integer, save :: index_frac
-    real(r8)      :: frac
+    real(R8)      :: frac
     character(CL) :: fracstr
     logical, save :: first_time = .true.
     logical, save :: flds_wiso_rof = .false.
@@ -1548,7 +1548,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
     character*32             :: outfile, wopts, lnum
 #endif
 #ifdef MOABCOMP
-    real(r8)                 :: difference
+    real(R8)                 :: difference
     type(mct_list) :: temp_list
     integer :: size_list, index_list
     type(mct_string)    :: mctOStr  !
@@ -1995,7 +1995,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
   end function prep_rof_get_o2racc_om_cnt
 
   function prep_rof_get_o2racc_om()
-   real(r8), DIMENSION(:, :), pointer :: prep_rof_get_o2racc_om
+   real(R8), DIMENSION(:, :), pointer :: prep_rof_get_o2racc_om
    prep_rof_get_o2racc_om => o2racc_om
   end function prep_rof_get_o2racc_om
 
@@ -2011,7 +2011,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
   end function prep_rof_get_l2racc_lm_cnt
 
   function prep_rof_get_l2racc_lm()
-    real(r8), DIMENSION(:, :), pointer :: prep_rof_get_l2racc_lm
+    real(R8), DIMENSION(:, :), pointer :: prep_rof_get_l2racc_lm
     prep_rof_get_l2racc_lm => l2racc_lm
   end function prep_rof_get_l2racc_lm
 

--- a/driver-moab/main/prep_rof_mod.F90
+++ b/driver-moab/main/prep_rof_mod.F90
@@ -327,6 +327,7 @@ contains
                write(logunit,*) subname,' error in defining tags for seq_flds_a2x_fields on rof cpl'
                call shr_sys_abort(subname//' ERROR in  defining tags for seq_flds_a2x_fields on rof cpl')
             endif
+            call seq_comm_getData(CPLID ,mpigrp=mpigrp_CPLID)
             if (samegrid_lr) then
                ! the same mesh , lnd and rof use the same dofs, but restricted 
                ! we do not compute intersection, so we will have to just send data from lnd to rof and viceversa, by GLOBAL_ID matching
@@ -363,7 +364,6 @@ contains
                ! we also need to compute the comm graph for the second hop, from the lnd on coupler to the 
                ! lnd for the intx lnd-rof context (coverage)
                !    
-               call seq_comm_getData(CPLID ,mpigrp=mpigrp_CPLID) 
                type1 = 3 ! land is FV now on coupler side
                type2 = 3;
 

--- a/driver-moab/main/seq_frac_mct.F90
+++ b/driver-moab/main/seq_frac_mct.F90
@@ -180,7 +180,7 @@ module seq_frac_mct
 
   use iMOAB, only : iMOAB_DefineTagStorage, iMOAB_SetDoubleTagStorage, &
         iMOAB_GetMeshInfo, iMOAB_SetDoubleTagStorageWithGid, iMOAB_WriteMesh, &
-        iMOAB_ApplyScalarProjectionWeights, iMOAB_SendElementTag, iMOAB_ReceiveElementTag, &
+        iMOAB_SendElementTag, iMOAB_ReceiveElementTag, &
         iMOAB_FreeSenderBuffers, iMOAB_GetDoubleTagStorage
 #ifdef MOABDEBUG
    use seq_comm_mct,     only : num_moab_exports


### PR DESCRIPTION
Add data land capability for moab driver;
case tested: --res r05_r05 --compset RMOSGPCC 
standard data moab model, mainly adapt from data ocean implementation

major change: Initialize all factors set by MOAB area correction init routine to 1.0. It affects all models, 
but it seems that some values were not initialized for data land case.
On chrysalis, with intel compiler, it actually complained about non initialized values when applying correction factors. 

The compressing file errors seen during development were caused by non-ascii characters in the log files. 
Those were caused by an uninitialized mapper, for which we were still creating a MOAB map. It was never used, 
it is fixed properly now, the moab map is not computed anymore. 

[BFB]
 