### PR TITLE
clean up debugging code and comments

### DIFF
--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -10656,15 +10656,6 @@ contains
 
     call seaice_icepack_write_warnings(icepack_warnings_aborted())
 
-!note that icepack_recompute_constants, called from icepck_init_parameters above, recomputes Lfresh
-! - make Lfresh optional for E3SM?
-
-! tcraig, this will write out icepack parameters to fort.101, need to uncomment 3 lines
-    if (mpas_log_info % taskID == 0) then
-      call icepack_write_parameters(101)
-    endif
-!    call seaice_icepack_write_warnings(icepack_warnings_aborted())
-
     call mpas_log_write(" ----- compare values after icepack init -----")
 
     ! Lfresh is derived in Icepack, not sent in from driver


### PR DESCRIPTION
Remove extraneous comments and a write statement used for debugging.
Verified that the code compiles and no longer produces the fort.101 file.
Fixes https://github.com/E3SM-Project/E3SM/issues/6573
[BFB]