### PR TITLE
For pm-cpu, increase default pelayout to 3 nodes for tests using `l%360x720cru`

### DIFF
--- a/components/elm/cime_config/config_pes.xml
+++ b/components/elm/cime_config/config_pes.xml
@@ -239,14 +239,14 @@
       <pes compset="any" pesize="any">
         <comment>elm: pm-cpu 2 nodes for grid l%360x720cru</comment>
         <ntasks>
-          <ntasks_atm>192</ntasks_atm>
-          <ntasks_lnd>192</ntasks_lnd>
-          <ntasks_rof>192</ntasks_rof>
-          <ntasks_ice>192</ntasks_ice>
-          <ntasks_ocn>192</ntasks_ocn>
-          <ntasks_glc>192</ntasks_glc>
-          <ntasks_wav>192</ntasks_wav>
-          <ntasks_cpl>192</ntasks_cpl>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_glc>-2</ntasks_glc>
+          <ntasks_wav>-2</ntasks_wav>
+          <ntasks_cpl>-2</ntasks_cpl>
         </ntasks>
       </pes>
     </mach>
@@ -568,7 +568,7 @@
     </mach>
   </grid>
   <grid name="a%ne30np4.pg2_l%r05_oi%null_r%r05_g%mpas.gis20km_w%null_z%null_m%EC30to60E2r2">
-    <mach name="chrysalis|pm-cpu|alvarez">
+    <mach name="chrysalis|pm-cpu|muller-cpu|alvarez">
       <pes compset="any" pesize="any">
         <comment>GIS 20km (low-res) testing config</comment>
         <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
@@ -606,7 +606,7 @@
     </mach>
   </grid>
   <grid name="a%ne30np4.pg2_l%r05_oi%null_r%r05_g%mpas.gis1to10kmR2_w%null_z%null_m%EC30to60E2r2">
-    <mach name="chrysalis|pm-cpu|alvarez">
+    <mach name="chrysalis|pm-cpu|muller-cpu|alvarez">
       <pes compset="any" pesize="any">
         <comment>GIS 1-to-10km (high-res) config</comment>
         <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>

--- a/components/elm/cime_config/config_pes.xml
+++ b/components/elm/cime_config/config_pes.xml
@@ -237,16 +237,16 @@
   <grid name="l%360x720cru">
     <mach name="pm-cpu|muller-cpu|alvarez">
       <pes compset="any" pesize="any">
-        <comment>elm: pm-cpu 2 nodes for grid l%360x720cru</comment>
+        <comment>elm: pm-cpu 3 nodes for grid l%360x720cru</comment>
         <ntasks>
-          <ntasks_atm>-2</ntasks_atm>
-          <ntasks_lnd>-2</ntasks_lnd>
-          <ntasks_rof>-2</ntasks_rof>
-          <ntasks_ice>-2</ntasks_ice>
-          <ntasks_ocn>-2</ntasks_ocn>
-          <ntasks_glc>-2</ntasks_glc>
-          <ntasks_wav>-2</ntasks_wav>
-          <ntasks_cpl>-2</ntasks_cpl>
+          <ntasks_atm>-3</ntasks_atm>
+          <ntasks_lnd>-3</ntasks_lnd>
+          <ntasks_rof>-3</ntasks_rof>
+          <ntasks_ice>-3</ntasks_ice>
+          <ntasks_ocn>-3</ntasks_ocn>
+          <ntasks_glc>-3</ntasks_glc>
+          <ntasks_wav>-3</ntasks_wav>
+          <ntasks_cpl>-3</ntasks_cpl>
         </ntasks>
       </pes>
     </mach>


### PR DESCRIPTION
Currently, the tests for this resolution use 192 MPI's on pm-cpu which is an odd value (1.5 nodes).
Here it's being changed to use `-3` (or 384 MPI's).

Example of test that would use this layout: `SMS.hcru_hcru.IELM`

This change is effective work-around (but not fix) for #6521 with #6486 in mind as noted below.

[bfb]
