### PR TITLE
Adds a lower limit to stem allocation to avoid negative states

### DIFF
--- a/components/elm/src/biogeochem/AllocationMod.F90
+++ b/components/elm/src/biogeochem/AllocationMod.F90
@@ -645,7 +645,7 @@ contains
 
          if (stem_leaf(ivt(p)) < 0._r8) then
              if (stem_leaf(ivt(p)) == -1._r8) then
-                 f3 = (2.7/(1.0+exp(-0.004*(annsum_npp(p) - 300.0)))) - 0.4
+                 f3 = max((2.7/(1.0+exp(-0.004*(annsum_npp(p) - 300.0)))) - 0.4_r8, 0.2_r8)
              else
                  f3 = max((-1.0_r8*stem_leaf(ivt(p))*2.7_r8)/(1.0_r8+exp(-0.004_r8*(annsum_npp(p) - &
                            300.0_r8))) - 0.4_r8, 0.2_r8)
@@ -2118,7 +2118,7 @@ contains
 
              if (stem_leaf(ivt(p)) < 0._r8) then
                  if (stem_leaf(ivt(p)) == -1._r8) then
-                     f3 = (2.7/(1.0+exp(-0.004*(annsum_npp(p) - 300.0)))) - 0.4
+                     f3 = max((2.7/(1.0+exp(-0.004*(annsum_npp(p) - 300.0)))) - 0.4_r8, 0.2_r8)
                  else
                      f3 = max((-1.0_r8*stem_leaf(ivt(p))*2.7_r8)/(1.0_r8+exp(-0.004_r8*(annsum_npp(p) - &
                                300.0_r8))) - 0.4_r8, 0.2_r8)


### PR DESCRIPTION
The stem:leaf allocation variable can go negative without this limiter, which
can cause negative stem carbon pools.

Fixes #6591 
[non-BFB]