### PR TITLE
For pm-cpu, upgrade Intel compiler to `2023.2.0` as well as other modules for Intel only

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -223,8 +223,8 @@
       </modules>
 
       <modules compiler="intel">
-        <command name="load">PrgEnv-intel/8.3.3</command>
-        <command name="load">intel/2023.1.0</command>
+        <command name="load">PrgEnv-intel/8.5.0</command>
+        <command name="load">intel/2023.2.0</command>
       </modules>
 
       <modules compiler="nvidia">
@@ -239,13 +239,25 @@
         <command name="load">cray-libsci/23.02.1.1</command>
       </modules>
 
-      <modules>
+      <modules compiler="intel">
+        <command name="load">craype-accel-host</command>
+        <command name="load">craype/2.7.30</command>
+        <command name="load">cray-mpich/8.1.28</command>
+        <command name="load">cray-hdf5-parallel/1.12.2.9</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.9.0.9</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.9</command>
+      </modules>
+
+      <modules compiler="!intel">
         <command name="load">craype-accel-host</command>
         <command name="load">craype/2.7.20</command>
         <command name="load">cray-mpich/8.1.25</command>
         <command name="load">cray-hdf5-parallel/1.12.2.3</command>
         <command name="load">cray-netcdf-hdf5parallel/4.9.0.3</command>
         <command name="load">cray-parallel-netcdf/1.12.3.3</command>
+      </modules>
+
+      <modules>
         <command name="load">cmake/3.24.3</command>
         <command name="load">evp-patch</command>
       </modules>


### PR DESCRIPTION
For pm-cpu, move from `intel/2023.1.0` to `intel/2023.2.0`.
Updating to this version allows us to also update several other module versions.
These are the updates to other modules we are doing at the same *just* for Intel compiler for now:

```
PrgEnv-intel/8.3.3                   PrgEnv-intel/8.5.0
craype/2.7.20                        craype/2.7.30                    
cray-mpich/8.1.25                    cray-mpich/8.1.28                
cray-hdf5-parallel/1.12.2.3          cray-hdf5-parallel/1.12.2.9      
cray-netcdf-hdf5parallel/4.9.0.3     cray-netcdf-hdf5parallel/4.9.0.9 
cray-parallel-netcdf/1.12.3.3        cray-parallel-netcdf/1.12.3.9
```
While this change does not address a known issue, and the versions are higher than machine defaults, this is in preparation for upcoming SW changes. Also do not expect any significant performance changes, but more testing warranted.

So far, testing shows the results are BFB, but would rather not assume the PR is BFB as it changes compiler version.
