### PR TITLE
Update nitrogen deposition and population density files

### DIFF
--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -666,7 +666,7 @@ this mask will have smb calculated over the entire global land surface
 <stream_year_first_ndep use_cn=".true."   sim_year="constant" sim_year_range="2000-2100" >2000</stream_year_first_ndep>
 <stream_year_last_ndep  use_cn=".true."   sim_year="constant" sim_year_range="2000-2100" >2100</stream_year_last_ndep>
 
-<stream_fldfilename_ndep hgrid="1.9x2.5"   use_cn=".true."   >lnd/clm2/ndepdata/fndep_elm_cbgc_exp_simyr1849-2101_1.9x2.5_c190103.nc</stream_fldfilename_ndep>
+<stream_fldfilename_ndep hgrid="1.9x2.5"   use_cn=".true."   >lnd/clm2/ndepdata/fndep_elm_cbgc_exp_simyr1849-2101_1.9x2.5_ssp245_c240903.nc</stream_fldfilename_ndep>
 <stream_fldfilename_ndep hgrid="1.9x2.5"   use_cn=".true."   rcp="8.5" >lnd/clm2/ndepdata/fndep_clm_rcp8.5_simyr1849-2106_1.9x2.5_c100428.nc</stream_fldfilename_ndep>
 <stream_fldfilename_ndep hgrid="1.9x2.5"   use_cn=".true."   rcp="6"   >lnd/clm2/ndepdata/fndep_clm_rcp6.0_simyr1849-2106_1.9x2.5_c100810.nc</stream_fldfilename_ndep>
 <stream_fldfilename_ndep hgrid="1.9x2.5"   use_cn=".true."   rcp="4.5" >lnd/clm2/ndepdata/fndep_clm_rcp4.5_simyr1849-2106_1.9x2.5_c100428.nc</stream_fldfilename_ndep>
@@ -899,8 +899,8 @@ this mask will have smb calculated over the entire global land surface
 <stream_year_first_popdens use_fates=".true."   sim_year="constant" sim_year_range="2000-2100" >1850</stream_year_first_popdens>
 <stream_year_last_popdens  use_fates=".true."   sim_year="constant" sim_year_range="2000-2100" >2010</stream_year_last_popdens>
 
-<stream_fldfilename_popdens hgrid="0.5x0.5"   use_cn=".true."                   >lnd/clm2/firedata/elmforc.ssp5_hdm_0.5x0.5_simyr1850-2100_c190109.nc</stream_fldfilename_popdens>
-<stream_fldfilename_popdens hgrid="0.5x0.5"   use_fates=".true."                   >lnd/clm2/firedata/elmforc.ssp5_hdm_0.5x0.5_simyr1850-2100_c190109.nc</stream_fldfilename_popdens>
+<stream_fldfilename_popdens hgrid="0.5x0.5"   use_cn=".true."    >lnd/clm2/firedata/elmforc.Li_20181205_mod_hist_SSP2_CMIP6_hdm_0.5x0.5_AVHRR_simyr1850-2100_c240906.nc</stream_fldfilename_popdens>
+<stream_fldfilename_popdens hgrid="0.5x0.5"   use_fates=".true." >lnd/clm2/firedata/elmforc.Li_20181205_mod_hist_SSP2_CMIP6_hdm_0.5x0.5_AVHRR_simyr1850-2100_c240906.nc</stream_fldfilename_popdens>
 
 <popdensmapalgo use_cn=".true."                               >bilinear</popdensmapalgo>
 

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -485,48 +485,48 @@ lnd/clm2/surfdata_map/surfdata_conusx4v1_simyr2000_c160503.nc</fsurdat>
      dataset (arbitrarily, RCP8.5) for the historical period, because all of the
      RCP datasets contain the 1850-2000 period as well as the future period. -->
 
-<flanduse_timeseries hgrid="360x720cru"    sim_year_range="1850-2000"
+<flanduse_timeseries hgrid="360x720cru"    sim_year_range="1850-2015"
  use_crop=".false." >lnd/clm2/surfdata_map/landuse.timeseries_360x720cru_hist_simyr1850-2015_c180220.nc</flanduse_timeseries>
-<flanduse_timeseries hgrid="0.9x1.25"      sim_year_range="1850-2000"
+<flanduse_timeseries hgrid="0.9x1.25"      sim_year_range="1850-2015"
  use_crop=".false." >lnd/clm2/surfdata_map/landuse.timeseries_0.9x1.25_hist_simyr1850-2015_c180306.nc</flanduse_timeseries>
-<flanduse_timeseries hgrid="1.9x2.5"       sim_year_range="1850-2000"
+<flanduse_timeseries hgrid="1.9x2.5"       sim_year_range="1850-2015"
  use_crop=".false." >lnd/clm2/surfdata_map/landuse.timeseries_1.9x2.5_hist_simyr1850-2015_c180306.nc</flanduse_timeseries>
-<flanduse_timeseries hgrid="10x15"         sim_year_range="1850-2000"
+<flanduse_timeseries hgrid="10x15"         sim_year_range="1850-2015"
  use_crop=".false." >lnd/clm2/surfdata_map/surfdata.pftdyn_10x15_rcp8.5_simyr1850-2100_c130524.nc</flanduse_timeseries>
-<flanduse_timeseries hgrid="48x96"         sim_year_range="1850-2000"
+<flanduse_timeseries hgrid="48x96"         sim_year_range="1850-2015"
  use_crop=".false."  >lnd/clm2/surfdata_map/surfdata.pftdyn_48x96_rcp8.5_simyr1850-2100_c130524.nc</flanduse_timeseries>
 <flanduse_timeseries hgrid="ne0np4_antarcticax4v1"    sim_year_range="1850-2015"
  use_crop=".false." >lnd/clm2/surfdata_map/landuse.timeseries_antarcticax4v1pg2_hist_simyr1850-2015_c210131.nc</flanduse_timeseries>
 
-<flanduse_timeseries hgrid="1x1_tropicAtl" sim_year_range="1850-2000"
+<flanduse_timeseries hgrid="1x1_tropicAtl" sim_year_range="1850-2015"
  use_crop=".false."  >lnd/clm2/surfdata_map/surfdata.pftdyn_1x1_tropicAtl_hist_simyr1850-2005_c130627.nc</flanduse_timeseries>
-<flanduse_timeseries hgrid="1x1_brazil"    sim_year_range="1850-2000"
+<flanduse_timeseries hgrid="1x1_brazil"    sim_year_range="1850-2015"
  use_crop=".false."  >lnd/clm2/surfdata_map/landuse.timeseries_1x1_brazil_rcp8.5_simyr1850-2100_c140610.nc</flanduse_timeseries>
 
-<flanduse_timeseries hgrid="ne30np4"       sim_year_range="1850-2000"
+<flanduse_timeseries hgrid="ne30np4"       sim_year_range="1850-2015"
  use_crop=".false."  >lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_simyr1850-2015_c180306.nc</flanduse_timeseries>
- <flanduse_timeseries hgrid="ne30np4.pg2"  sim_year_range="1850-2000" 
+ <flanduse_timeseries hgrid="ne30np4.pg2"  sim_year_range="1850-2015" 
  use_crop=".false."  >lnd/clm2/surfdata_map/landuse.timeseries_ne30np4.pg2_hist_simyr1850-2015_c210113.nc</flanduse_timeseries>
- <flanduse_timeseries hgrid="ne4np4.pg2"  sim_year_range="1850-2000"
+ <flanduse_timeseries hgrid="ne4np4.pg2"  sim_year_range="1850-2015"
  use_crop=".false."  >lnd/clm2/surfdata_map/landuse.timeseries_ne4pg2_hist_simyr1850-2015_c210722.nc</flanduse_timeseries>
- <flanduse_timeseries hgrid="ne0np4_northamericax4v1.pg2"  sim_year_range="1850-2000" 
+ <flanduse_timeseries hgrid="ne0np4_northamericax4v1.pg2"  sim_year_range="1850-2015" 
  use_crop=".false."  >lnd/clm2/surfdata_map/landuse.timeseries_ne0np4_northamericax4v1.pg2_hist_simyr1850-2015_c211015.nc</flanduse_timeseries>
-<flanduse_timeseries hgrid="ne16np4" sim_year_range="1850-2000"
+<flanduse_timeseries hgrid="ne16np4" sim_year_range="1850-2015"
  use_crop=".false."  >lnd/clm2/surfdata_map/surfdata.pftdyn_ne16np4_hist_simyr1850-2005_c160803.nc</flanduse_timeseries>
-<flanduse_timeseries hgrid="ne11np4" sim_year_range="1850-2000"
+<flanduse_timeseries hgrid="ne11np4" sim_year_range="1850-2015"
  use_crop=".false."  >lnd/clm2/surfdata_map/surfdata.pftdyn_ne11np4_hist_simyr1850-2005_c160803.nc</flanduse_timeseries>
 <flanduse_timeseries hgrid="ne1024np4.pg2"
  use_crop=".false."  >lnd/clm2/surfdata_map/landuse.timeseries_ne1024pg2_historical_simyr1990-2014_c240109.nc</flanduse_timeseries>
 <flanduse_timeseries hgrid="ne256np4.pg2"
  use_crop=".false."  >lnd/clm2/surfdata_map/landuse.timeseries_ne256pg2_hist_simyr1850-2015_c240131.nc</flanduse_timeseries>
 
-<flanduse_timeseries hgrid="r0125" sim_year_range="1850-2000"
+<flanduse_timeseries hgrid="r0125" sim_year_range="1850-2015"
  use_crop=".false." >lnd/clm2/surfdata_map/landuse.timeseries_0.125x0.125_hist_simyr1850-2015_c191004.nc</flanduse_timeseries>
 
-<flanduse_timeseries hgrid="r05" sim_year_range="1850-2000"
+<flanduse_timeseries hgrid="r05" sim_year_range="1850-2015"
   use_crop=".false." use_cn=".true." >lnd/clm2/surfdata_map/landuse.timeseries_0.5x0.5_HIST_simyr1850-2015_c211019.nc</flanduse_timeseries>
 
-<flanduse_timeseries hgrid="r05" sim_year_range="1850-2000"
+<flanduse_timeseries hgrid="r05" sim_year_range="1850-2015"
   use_crop=".false." use_cn=".false." >lnd/clm2/surfdata_map/landuse.timeseries_0.5x0.5_hist_simyr1850-2015_c191004.nc</flanduse_timeseries>
 
 <!-- Dynamic PFT surface datasets for future scenarios(relative to {csmdata}) -->

--- a/components/elm/bld/namelist_files/use_cases/2015-2100_SSP245_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/2015-2100_SSP245_transient.xml
@@ -17,8 +17,10 @@
 
 <!-- *** BELOW NOT USED FOR SATELLITE PHENOLOGY *** -->
 
+<!-- *** SSP245 stream_fldfilename_ndep stream_fldfilename_popden are set as default *** -->
+
 <stream_year_first_ndep phys="elm" use_cn=".true."   >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="elm" use_cn=".true."   >2005</stream_year_last_ndep>
+<stream_year_last_ndep  phys="elm" use_cn=".true."   >2101</stream_year_last_ndep>
 <model_year_align_ndep  phys="elm" use_cn=".true."   >1850</model_year_align_ndep>
 
 <stream_year_first_pdep phys="elm" use_cn=".true."   >2000</stream_year_first_pdep>
@@ -26,7 +28,7 @@
 <model_year_align_pdep  phys="elm" use_cn=".true."   >2000</model_year_align_pdep>
 
 <stream_year_first_popdens phys="elm" use_cn=".true."   >1850</stream_year_first_popdens>
-<stream_year_last_popdens  phys="elm" use_cn=".true."   >2010</stream_year_last_popdens>
+<stream_year_last_popdens  phys="elm" use_cn=".true."   >2100</stream_year_last_popdens>
 <model_year_align_popdens  phys="elm" use_cn=".true."   >1850</model_year_align_popdens>
 
 <!-- CMIP6 DECK compsets -->

--- a/components/elm/bld/namelist_files/use_cases/2015-2100_SSP370_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/2015-2100_SSP370_transient.xml
@@ -18,16 +18,18 @@
 <!-- *** BELOW NOT USED FOR SATELLITE PHENOLOGY *** -->
 
 <stream_year_first_ndep phys="elm" use_cn=".true."   >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="elm" use_cn=".true."   >2005</stream_year_last_ndep>
+<stream_year_last_ndep  phys="elm" use_cn=".true."   >2101</stream_year_last_ndep>
 <model_year_align_ndep  phys="elm" use_cn=".true."   >1850</model_year_align_ndep>
+<stream_fldfilename_ndep use_cn=".true."  >lnd/clm2/ndepdata/fndep_elm_cbgc_exp_simyr1849-2101_1.9x2.5_ssp370_c220614.nc</stream_fldfilename_ndep>
 
 <stream_year_first_pdep phys="elm" use_cn=".true."   >2000</stream_year_first_pdep>
 <stream_year_last_pdep  phys="elm" use_cn=".true."   >2000</stream_year_last_pdep>
 <model_year_align_pdep  phys="elm" use_cn=".true."   >2000</model_year_align_pdep>
 
 <stream_year_first_popdens phys="elm" use_cn=".true."   >1850</stream_year_first_popdens>
-<stream_year_last_popdens  phys="elm" use_cn=".true."   >2010</stream_year_last_popdens>
+<stream_year_last_popdens  phys="elm" use_cn=".true."   >2100</stream_year_last_popdens>
 <model_year_align_popdens  phys="elm" use_cn=".true."   >1850</model_year_align_popdens>
+<stream_fldfilename_popdens hgrid="0.5x0.5"   use_cn=".true." >lnd/clm2/firedata/elmforc.Li_20181205_mod_hist_SSP3_CMIP6_hdm_0.5x0.5_AVHRR_simyr1850-2100_c240906.nc</stream_fldfilename_popdens>
 
 <!-- CMIP6 DECK compsets -->
 

--- a/components/elm/bld/namelist_files/use_cases/2015-2100_SSP585_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/2015-2100_SSP585_transient.xml
@@ -18,16 +18,18 @@
 <!-- *** BELOW NOT USED FOR SATELLITE PHENOLOGY *** -->
 
 <stream_year_first_ndep phys="elm" use_cn=".true."   >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="elm" use_cn=".true."   >2005</stream_year_last_ndep>
+<stream_year_last_ndep  phys="elm" use_cn=".true."   >2101</stream_year_last_ndep>
 <model_year_align_ndep  phys="elm" use_cn=".true."   >1850</model_year_align_ndep>
+<stream_fldfilename_ndep use_cn=".true."  >lnd/clm2/ndepdata/fndep_elm_cbgc_exp_simyr1849-2101_1.9x2.5_ssp585_c190103.nc</stream_fldfilename_ndep>
 
 <stream_year_first_pdep phys="elm" use_cn=".true."   >2000</stream_year_first_pdep>
 <stream_year_last_pdep  phys="elm" use_cn=".true."   >2000</stream_year_last_pdep>
 <model_year_align_pdep  phys="elm" use_cn=".true."   >2000</model_year_align_pdep>
 
 <stream_year_first_popdens phys="elm" use_cn=".true."   >1850</stream_year_first_popdens>
-<stream_year_last_popdens  phys="elm" use_cn=".true."   >2010</stream_year_last_popdens>
+<stream_year_last_popdens  phys="elm" use_cn=".true."   >2100</stream_year_last_popdens>
 <model_year_align_popdens  phys="elm" use_cn=".true."   >1850</model_year_align_popdens>
+<stream_fldfilename_popdens hgrid="0.5x0.5"   use_cn=".true." >lnd/clm2/firedata/elmforc.Li_20181205_mod_hist_SSP5_CMIP6_hdm_0.5x0.5_AVHRR_simyr1850-2100_c240906.nc</stream_fldfilename_popdens>
 
 <!-- CMIP6 DECK compsets -->
 

--- a/components/elm/bld/namelist_files/use_cases/20thC_CMIP6_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/20thC_CMIP6_transient.xml
@@ -9,7 +9,7 @@
 
 <sim_year>1850</sim_year>
 
-<sim_year_range>1850-2000</sim_year_range>
+<sim_year_range>1850-2015</sim_year_range>
 
 <clm_start_type>arb_ic</clm_start_type>
 
@@ -18,7 +18,7 @@
 
 
 <stream_year_first_ndep phys="elm" use_cn=".true."   >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="elm" use_cn=".true."   >2005</stream_year_last_ndep>
+<stream_year_last_ndep  phys="elm" use_cn=".true."   >2101</stream_year_last_ndep>
 <model_year_align_ndep  phys="elm" use_cn=".true."   >1850</model_year_align_ndep>
 
 
@@ -27,7 +27,7 @@
 <model_year_align_pdep  phys="elm" use_cn=".true."   >2000</model_year_align_pdep>
 
 <stream_year_first_popdens phys="elm" use_cn=".true."   >1850</stream_year_first_popdens>
-<stream_year_last_popdens  phys="elm" use_cn=".true."   >2010</stream_year_last_popdens>
+<stream_year_last_popdens  phys="elm" use_cn=".true."   >2100</stream_year_last_popdens>
 <model_year_align_popdens  phys="elm" use_cn=".true."   >1850</model_year_align_popdens>
 
 

--- a/components/elm/bld/namelist_files/use_cases/20thC_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/20thC_transient.xml
@@ -9,7 +9,7 @@
 
 <sim_year>1850</sim_year>
 
-<sim_year_range>1850-2000</sim_year_range>
+<sim_year_range>1850-2015</sim_year_range>
 
 <clm_start_type>arb_ic</clm_start_type>
 

--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -753,8 +753,7 @@
       <value compset="^1950.+CMIP6"                             >312.821</value>
       <value compset="^2010"                                    >388.717</value>
       <value compset="^2010.+CMIP6"                             >388.717</value>
-      <value compset="^SSP585.+CMIP6"				>0.000001</value>
-      <value compset="^SSP370.+CMIP6"                           >0.000001</value>
+      <value compset="^SSP.+CMIP6"                              >0.000001</value>
       <value compset="^20TR.*BGC%BCRC"                          >284.317</value>
       <value compset="^20TR.*BGC%BCRD"                          >284.317</value>
       <value compset="^20TR.*BGC%BDRC"                          >284.317</value>


### PR DESCRIPTION
An old SSP5 based nitrogen deposition (ndep) and population density (popdens)
files were specified as default for all v3 configurations. This PR makes them 
dependent of SSP scenarios. New ndep and popdens files are introduced for 
each SSP, and the SSP245 files is set as new default for non-SSP compsets. 

The changes will impact simulation results for F2010 and all SSP compsets. Historical 
compset simulation will be BFB after 1989. piControl simulations remain BFB.  
Cold start (e.g., same small grid F2010 nightly tests) without specifying a finidat 
would not see differences in short runs as there would be no vegetation to begin 
with as far as the fire model is concerned.

Default value for co2vmr is also updated for SSP245. This has no impact on 
simulation as its value is a placeholder for the transient compset.

[NML] diff for tests involving active land, due to changes of data stream 
           file and stream year_last_align
[non-BFB]

----------------------------------------------------------------------------------
Tests have been done to verify piControl simulations are not affected, and historical simulations start to differ 4 steps into 1990-01. This is because popdens data changes only starting 1990. 