### PR TITLE
Adjust PEs for MPAS dev-tests on Anvil

### DIFF
--- a/cime_config/testmods_dirs/config_pes_tests.xml
+++ b/cime_config/testmods_dirs/config_pes_tests.xml
@@ -37,6 +37,8 @@
           <ntasks_rof>-4</ntasks_rof>
           <ntasks_ice>-4</ntasks_ice>
           <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_glc>-4</ntasks_glc>
+          <ntasks_wav>-4</ntasks_wav>
           <ntasks_cpl>-4</ntasks_cpl>
         </ntasks>
       </pes>
@@ -199,6 +201,23 @@
           <ntasks_ice>-6</ntasks_ice>
           <ntasks_ocn>-6</ntasks_ocn>
           <ntasks_cpl>-6</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="oi%IcoswISC30.*">
+    <mach name="anvil">
+      <pes compset=".*DATM.+MPASSI.+MPASO.+DROF.+_SESP$" pesize="any">
+        <comment>tests+anvil: --compset GMPAS-JRA1p5-DIB-PISMF, 8 nodes</comment>
+        <ntasks>
+          <ntasks_atm>-8</ntasks_atm>
+          <ntasks_lnd>-8</ntasks_lnd>
+          <ntasks_rof>-8</ntasks_rof>
+          <ntasks_ice>-8</ntasks_ice>
+          <ntasks_ocn>-8</ntasks_ocn>
+          <ntasks_cpl>-8</ntasks_cpl>
+          <ntasks_glc>-8</ntasks_glc>
+          <ntasks_wav>-8</ntasks_wav>
         </ntasks>
       </pes>
     </mach>


### PR DESCRIPTION
Adjust PEs for MPAS dev-tests on Anvil.

[non-BFB] - in ERS.f09_g16_g.MALISIA's AM due to GLC PE changes
[NML] - due to PE changes