### PR TITLE
Bug fix for N balance error due to spval value for land use simulation

### DIFF
--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -7538,14 +7538,16 @@ contains
                 c = filter_soilc(fc)
                 this%decomp_cpools_leached(c,l) = 0._r8
              end do
-             do j = 1, nlev
-                do fc = 1,num_soilc
+             if(l /= i_cwd)then
+               do j = 1, nlev
+                 do fc = 1,num_soilc
                    c = filter_soilc(fc)
                    this%decomp_cpools_leached(c,l) = &
                      this%decomp_cpools_leached(c,l) + &
                      this%decomp_cpools_transport_tendency(c,j,l) * dzsoi_decomp(j)
-                end do
-             end do
+                 end do
+               end do
+             endif
              do fc = 1,num_soilc
                 c = filter_soilc(fc)
                 this%som_c_leached(c) = &
@@ -9784,8 +9786,9 @@ contains
           c = filter_soilc(fc)
           this%decomp_npools_leached(c,l) = 0._r8
        end do
-       do j = 1, nlev
-          do fc = 1,num_soilc
+       if(l /= i_cwd)then
+         do j = 1, nlev
+           do fc = 1,num_soilc
              c = filter_soilc(fc)
              this%decomp_npools_leached(c,l) = &
                   this%decomp_npools_leached(c,l) + &
@@ -9793,8 +9796,9 @@ contains
 
              this%bgc_npool_inputs(c,l) = this%bgc_npool_inputs(c,l) + &
                 (this%bgc_npool_ext_inputs_vr(c,j,l)-this%bgc_npool_ext_loss_vr(c,j,l))*dzsoi_decomp(j)
-          end do
-       end do
+           end do
+         end do
+       endif
        do fc = 1,num_soilc
           c = filter_soilc(fc)
           this%som_n_leached(c) = &
@@ -11314,16 +11318,16 @@ contains
           c = filter_soilc(fc)
           this%decomp_ppools_leached(c,l) = 0._r8
        end do
-
-       do j = 1, nlevdecomp
-          do fc = 1,num_soilc
+       if(l /= i_cwd)then
+         do j = 1, nlevdecomp
+           do fc = 1,num_soilc
              c = filter_soilc(fc)
              this%decomp_ppools_leached(c,l) = &
                   this%decomp_ppools_leached(c,l) + &
                   this%decomp_ppools_transport_tendency(c,j,l) * dzsoi_decomp(j)
-          end do
-       end do
-
+           end do
+         end do
+       endif
        do fc = 1,num_soilc
           c = filter_soilc(fc)
           this%som_p_leached(c) = &


### PR DESCRIPTION
When the land use data is on, at the begining of every year, the model
may crash with N balance error due to including spval value in N leaching
flux update. This update fixes this error by keeping those spval values away
from the N balance. 

Fixes #6604 

[BFB]