### PR TITLE
harden eamxx/prod testmod

### DIFF
--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -29,7 +29,7 @@
     <rest_file_extension>r\.(INSTANT|AVERAGE|MAX|MIN)\.n(step|sec|min|hour|day|month|year)s_x\d*</rest_file_extension>
     <rest_file_extension>rhist\.(INSTANT|AVERAGE|MAX|MIN)\.n(step|sec|min|hour|day|month|year)s_x\d*</rest_file_extension>
     <!-- The following matches "hi.AVGTYPE.FREQUNITS_xFREQ.TIMESTAMP.nc"-->
-    <hist_file_extension>hi\.(INSTANT|AVERAGE|MAX|MIN)\.n(step|sec|min|hour|day|month|year)s_x\d*\.\d{4}-\d{2}-\d{2}-\d{5}\.nc$</hist_file_extension>
+    <hist_file_extension>.*\.h\.(?!rhist\.).*\.nc$</hist_file_extension>
   </comp_archive_spec>
 
   <comp_archive_spec compname="elm" compclass="lnd">

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/shell_commands
@@ -3,6 +3,7 @@
 cime_root=$(./xmlquery --value CIMEROOT)
 input_data_dir=$(./xmlquery --value DIN_LOC_ROOT)
 atmchange=$cime_root/../components/eamxx/scripts/atmchange
+case_name=$(./xmlquery --value CASE)
 
 # Change run length
 ./xmlchange RUN_STARTDATE="1994-10-01"
@@ -82,6 +83,8 @@ for file in ${output_yaml_files[@]}; do
         sed -i "s|horiz_remap_file:.*_to_ne30.*|horiz_remap_file: ${hmapfile}|" ./$(basename ${file})
         sed -i "s|horiz_remap_file:.*_to_DecadalSites.*|horiz_remap_file: ${armmapfile}|" ./$(basename ${file})
     fi
+    # replace all filename prefixes so that st_archive works...
+    sed -i "s|eamxx_output.decadal|${case_name}.scream|" ./$(basename ${file})
 done
 
 # TODO:

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/shell_commands
@@ -61,7 +61,7 @@ else
 fi
 
 # set the output yaml files
-output_yaml_files=$(find ${cime_root}/../components/eamxx/cime_config/testdefs/testmods_dirs/scream/v1prod/yaml_outs/ -maxdepth 1 -type f)
+output_yaml_files=$(find ${cime_root}/../components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/ -maxdepth 1 -type f)
 for file in ${output_yaml_files[@]}; do
     # if the word "coarse" is in the file name, do nothing
     if [[ "${file}" == *"_coarse.yaml" && "${hmapfile}" == "not-supported-yet" ]]; then

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/eamxx_output.decadal.1dailyAVG_native.yaml
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/eamxx_output.decadal.1dailyAVG_native.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-filename_prefix: scream_output.decadal.1dailyAVG_native.h
+filename_prefix: eamxx_output.decadal.1dailyAVG_native.h
 iotype: pnetcdf
 Averaging Type: Average
 Max Snapshots Per File: 1

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/eamxx_output.decadal.1dailyMAX_native.yaml
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/eamxx_output.decadal.1dailyMAX_native.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-filename_prefix: scream_output.decadal.1dailyMAX_native.h
+filename_prefix: eamxx_output.decadal.1dailyMAX_native.h
 iotype: pnetcdf
 Averaging Type: Max
 Max Snapshots Per File: 1

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/eamxx_output.decadal.1dailyMIN_native.yaml
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/eamxx_output.decadal.1dailyMIN_native.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-filename_prefix: scream_output.decadal.1dailyMIN_native.h
+filename_prefix: eamxx_output.decadal.1dailyMIN_native.h
 iotype: pnetcdf
 Averaging Type: Min
 Max Snapshots Per File: 1

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/eamxx_output.decadal.1hourlyINST_arm.yaml
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/eamxx_output.decadal.1hourlyINST_arm.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-filename_prefix: scream_output.decadal.1hourlyINST_arm.h
+filename_prefix: eamxx_output.decadal.1hourlyINST_arm.h
 iotype: pnetcdf
 Averaging Type: Instant
 Max Snapshots Per File: 24  # one file per day

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/eamxx_output.decadal.1hourlyINST_native.yaml
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/eamxx_output.decadal.1hourlyINST_native.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-filename_prefix: scream_output.decadal.1hourlyINST_native.h
+filename_prefix: eamxx_output.decadal.1hourlyINST_native.h
 iotype: pnetcdf
 Averaging Type: Instant
 Max Snapshots Per File: 24

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/eamxx_output.decadal.3hourlyAVG_coarse.yaml
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/eamxx_output.decadal.3hourlyAVG_coarse.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-filename_prefix: scream_output.decadal.3hourlyAVG_coarse.h
+filename_prefix: eamxx_output.decadal.3hourlyAVG_coarse.h
 iotype: pnetcdf
 Averaging Type: Average
 Max Snapshots Per File: 8 # one file per day

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/eamxx_output.decadal.3hourlyINST_coarse.yaml
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/eamxx_output.decadal.3hourlyINST_coarse.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-filename_prefix: scream_output.decadal.3hourlyINST_coarse.h
+filename_prefix: eamxx_output.decadal.3hourlyINST_coarse.h
 iotype: pnetcdf
 Averaging Type: Instant
 Max Snapshots Per File: 8  # one file per day

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/eamxx_output.decadal.6hourlyAVG_coarse.yaml
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/eamxx_output.decadal.6hourlyAVG_coarse.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-filename_prefix: scream_output.decadal.6hourlyAVG_coarse.h
+filename_prefix: eamxx_output.decadal.6hourlyAVG_coarse.h
 iotype: pnetcdf
 Averaging Type: Average
 Max Snapshots Per File: 4  # one file per day

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/eamxx_output.decadal.6hourlyINST_coarse.yaml
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/eamxx_output.decadal.6hourlyINST_coarse.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-filename_prefix: scream_output.decadal.6hourlyINST_coarse.h
+filename_prefix: eamxx_output.decadal.6hourlyINST_coarse.h
 iotype: pnetcdf
 Averaging Type: Instant
 Max Snapshots Per File: 4  # one file per day

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/eamxx_output.decadal.6hourlyINST_native.yaml
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/eamxx_output.decadal.6hourlyINST_native.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-filename_prefix: scream_output.decadal.6hourlyINST_native.h
+filename_prefix: eamxx_output.decadal.6hourlyINST_native.h
 iotype: pnetcdf
 Averaging Type: Instant
 Max Snapshots Per File: 4  # one file per day

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/eamxx_output.decadal.dailyAVG_coarse.yaml
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/eamxx_output.decadal.dailyAVG_coarse.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-filename_prefix: scream_output.decadal.dailyAVG_coarse.h
+filename_prefix: eamxx_output.decadal.dailyAVG_coarse.h
 iotype: pnetcdf
 Averaging Type: Average
 Max Snapshots Per File: 1


### PR DESCRIPTION
makes the ERS eamxx/prod test compare outputs in all files, requiring pulling a bugfix from the scream repo.