### PR TITLE
Revert PR #6313 aborting run on negative channel storage

### DIFF
--- a/components/mosart/src/riverroute/MOSART_physics_mod.F90
+++ b/components/mosart/src/riverroute/MOSART_physics_mod.F90
@@ -682,8 +682,8 @@ MODULE MOSART_physics_mod
 
 ! check for negative channel storage
     if (negchan < -1.e-10) then
-       write(iulog,*) 'Error: Negative channel storage found! ',negchan
-       call shr_sys_abort('mosart: negative channel storage')
+       write(iulog,*) 'Warning: Negative channel storage found! ',negchan
+!       call shr_sys_abort('mosart: negative channel storage')
     endif
     TRunoff%flow = TRunoff%flow / Tctl%DLevelH2R
     TRunoff%erowm_regi(:,nt_nmud:nt_nsan) = TRunoff%erowm_regi(:,nt_nmud:nt_nsan) / Tctl%DLevelH2R


### PR DESCRIPTION
The enforced abort whenever MOSART has negative channel storage
may prevent v3.LR simulations from finishing, if the code base that includes
#6313 is used.  This PR is to revert #6313 until v3.0.1 tag is created,
to ensure new v3.LR simulations that need to use the latest commits to master
are free from this issue.

Fixes #6622.
[BFB]

----------------------------------------------
Issue #6302 is expected to reemerge.