### PR TITLE
MALI update to fix issues from earlier PR causing sporadic test failures

### DIFF
--- a/components/mpas-albany-landice/bld/namelist_files/namelist_defaults_mali.xml
+++ b/components/mpas-albany-landice/bld/namelist_files/namelist_defaults_mali.xml
@@ -18,7 +18,7 @@
 
 <!-- advection -->
 <config_thickness_advection>'fo'</config_thickness_advection>
-<config_tracer_advection>'none'</config_tracer_advection>
+<config_tracer_advection>'fo'</config_tracer_advection>
 <config_horiz_tracer_adv_order>3</config_horiz_tracer_adv_order>
 <config_advection_coef_3rd_order>0.25</config_advection_coef_3rd_order>
 <config_restore_thickness_after_advection>.false.</config_restore_thickness_after_advection>

--- a/components/mpas-albany-landice/cime_config/buildnml
+++ b/components/mpas-albany-landice/cime_config/buildnml
@@ -280,7 +280,9 @@ def buildnml(case, caseroot, compname):
         lines.append('    <var name="simulationStartTime"/>')
         lines.append('    <var name="allowableDtACFL"/>')
         lines.append('    <var name="allowableDtDCFL"/>')
-        lines.append('    <var name="albanyVelocityError"/>')
+        if mali_use_albany:
+            lines.append('    <var name="albanyVelocityError"/>')
+
         lines.append('</stream>')
         lines.append('')
         lines.append('<!--')


### PR DESCRIPTION
Including a variable that was deactivated in the globalStats stream caused sporadic failures during the second run of some ERS tests on several platform/compiler combinations. That variable is now only included when MALI is using Albany. Also updates a namelist default that had been missed but does not change answers.

Fixes #6600 

[NML] for configurations with MALI
[BFB]