### PR TITLE
Add support for new JRA forcing through year 2023

### DIFF
--- a/components/data_comps/datm/cime_config/config_component.xml
+++ b/components/data_comps/datm/cime_config/config_component.xml
@@ -10,7 +10,7 @@
        This file may have atm desc entries.
   -->
   <description modifier_mode="1">
-    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%ERA5][%ERA56HR][%GSWP3w5e5][%MOSARTTEST][%NLDAS2][%CPLHIST][%E3SMWCv2][%CPLWCH][%1PT][%NYF][%IAF][%JRA][%JRA-1p5][%JRA-1p4-2018][%JRA-RYF8485][%JRA-RYF9091][%JRA-RYF0304][%CFSv2][%CFSR]"> Data driven ATM </desc>
+    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%ERA5][%ERA56HR][%GSWP3w5e5][%MOSARTTEST][%NLDAS2][%CPLHIST][%E3SMWCv2][%CPLWCH][%1PT][%NYF][%IAF][%JRA][%JRA-1p5][%JRA-1p5-2023][%JRA-1p4-2018][%JRA-RYF8485][%JRA-RYF9091][%JRA-RYF0304][%CFSv2][%CFSR]"> Data driven ATM </desc>
     <desc option="QIA"> QIAN data set </desc>
     <desc option="WISOQIA">QIAN with water isotopes</desc>
     <desc option="CRU"> CRUNCEP data set </desc>
@@ -28,8 +28,9 @@
     <desc option="NYF">COREv2 normal year forcing</desc>
     <desc option="IAF">COREv2 interannual forcing</desc>
     <desc option="JRA">interannual JRA55 forcing</desc>
-    <desc option="JRA-1p5">interannual JRA55 forcing, v1.5, through 2020</desc>
     <desc option="JRA-1p4-2018">interannual JRA55 forcing, v1.4, through 2018</desc>
+    <desc option="JRA-1p5">interannual JRA55 forcing, v1.5, through 2020</desc>
+    <desc option="JRA-1p5-2023">interannual JRA55 forcing, v1.5, through 2023</desc>
     <desc option="JRA-RYF8485"> JRA55 Repeat Year Forcing v1.3 1984-1985</desc>
     <desc option="JRA-RYF9091"> JRA55 Repeat Year Forcing v1.3 1990-1991</desc>
     <desc option="JRA-RYF0304"> JRA55 Repeat Year Forcing v1.3 2003-2004</desc>
@@ -63,8 +64,9 @@ data (see cime issue #3653 -- https://github.com/ESMCI/cime/issues/3653).
       <value compset="%NYF">CORE2_NYF</value>
       <value compset="%IAF">CORE2_IAF</value>
       <value compset="%JRA">CORE_IAF_JRA</value>
-      <value compset="%JRA-1p5">IAF_JRA_1p5</value>
       <value compset="%JRA-1p4-2018">CORE_IAF_JRA_1p4_2018</value>
+      <value compset="%JRA-1p5">IAF_JRA_1p5</value>
+      <value compset="%JRA-1p5-2023">IAF_JRA_1p5</value>
       <value compset="%JRA-RYF8485">CORE_RYF8485_JRA</value>
       <value compset="%JRA-RYF9091">CORE_RYF9091_JRA</value>
       <value compset="%JRA-RYF0304">CORE_RYF0304_JRA</value>
@@ -391,6 +393,7 @@ data (see cime issue #3653 -- https://github.com/ESMCI/cime/issues/3653).
       <value compset="2000.*_DATM">$DATM_CLMNCEP_YR_START</value>
       <value compset="2000_DATM%JRA">1</value>
       <value compset="2000_DATM%JRA-1p5">1</value>
+      <value compset="2000_DATM%JRA-1p5_2023">1</value>
       <value compset="2003.*_DATM">$DATM_CLMNCEP_YR_START</value>
       <value compset="2010.*_DATM">$DATM_CLMNCEP_YR_START</value>
       <value compset="4804.*_DATM">$DATM_CLMNCEP_YR_START</value>
@@ -488,6 +491,7 @@ data (see cime issue #3653 -- https://github.com/ESMCI/cime/issues/3653).
       <value   compset="2003.*_DATM%NLDAS2">2003</value>
       <value   compset="2000_DATM%JRA">2016</value>
       <value   compset="2000_DATM%JRA-1p5">2020</value>
+      <value   compset="2000_DATM%JRA-1p5-2023">2023</value>
       <value   compset="2000.*_DATM%ERA5">1979</value>
       <value   compset="2000.*_DATM%ERA56HR">1979</value>
     </values>

--- a/components/data_comps/drof/cime_config/config_component.xml
+++ b/components/data_comps/drof/cime_config/config_component.xml
@@ -13,7 +13,7 @@
   -->
 
   <description modifier_mode="1">
-    <desc rof="DROF[%NULL][%NYF][%NYFAIS00][%NYFAIS45][%NYFAIS55][%IAF][%IAFAIS00][%IAFAIS45][%IAFAIS55][%CPLHIST][%JRA][%JRA-1p5][%JRA-1p5-AIS0ROF][%JRA-1p4-2018][%JRA-1p4-2018-AIS0ICE][%JRA-1p4-2018-AIS0LIQ][%JRA-1p4-2018-AIS0ROF[%JRA-RYF8485][%JRA-RYF9091][%JRA-RYF0304]">Data runoff model</desc>
+    <desc rof="DROF[%NULL][%NYF][%NYFAIS00][%NYFAIS45][%NYFAIS55][%IAF][%IAFAIS00][%IAFAIS45][%IAFAIS55][%CPLHIST][%JRA][%JRA-1p5][%JRA-1p5-2023][%JRA-1p5-AIS0ROF][%JRA-1p4-2018][%JRA-1p4-2018-AIS0ICE][%JRA-1p4-2018-AIS0LIQ][%JRA-1p4-2018-AIS0ROF[%JRA-RYF8485][%JRA-RYF9091][%JRA-RYF0304]">Data runoff model</desc>
     <desc option="NULL"     >NULL mode</desc>
     <desc option="NYF"      >COREv2 normal year forcing:</desc>
     <desc option="NYFAIS00" >COREv2 normal year forcing:</desc>
@@ -24,6 +24,7 @@
     <desc option="IAFAIS45" >COREv2 interannual year forcing:</desc>
     <desc option="IAFAIS55" >COREv2 interannual year forcing:</desc>
     <desc option="CPLHIST"  >CPLHIST mode:</desc>
+    <desc option="JRA-1p5-2023">JRA55 interannual forcing, v1.5, through 2023</desc>
     <desc option="JRA-1p5">JRA55 interannual forcing, v1.5, through 2020</desc>
     <desc option="JRA-1p5-AIS0ROF">JRA55 interannual forcing, v1.5, through 2020, no rofi or rofl around AIS</desc>
     <desc option="JRA-1p4-2018">JRA55 interannual forcing, v1.4, through 2018</desc>
@@ -61,6 +62,7 @@
       <value compset="_DROF%IAFAIS55" >DIATREN_IAF_AIS55_RX1</value>
       <value compset="_DROF%CPLHIST">CPLHIST</value>
       <value compset="_DROF%JRA" >IAF_JRA</value>
+      <value compset="_DROF%JRA-1p5-2023" >IAF_JRA_1p5</value>
       <value compset="_DROF%JRA-1p5" >IAF_JRA_1p5</value>
       <value compset="_DROF%JRA-1p5-AIS0ROF" >IAF_JRA_1p5_AIS0ROF</value>
       <value compset="_DROF%JRA-1p4-2018" >IAF_JRA_1p4_2018</value>
@@ -165,6 +167,7 @@
       <value compset="_DROF%JRA"          >1</value>
       <value compset="_DROF%JRA-1p4-2018" >1</value>
       <value compset="_DROF%JRA-1p5"      >1</value>
+      <value compset="_DROF%JRA-1p5-2023" >1</value>
     </values>
     <group>run_component_drof</group>
     <file>env_run.xml</file>
@@ -179,6 +182,7 @@
       <value compset="_DROF%JRA"          >1958</value>
       <value compset="_DROF%JRA-1p4-2018" >1958</value>
       <value compset="_DROF%JRA-1p5"      >1958</value>
+      <value compset="_DROF%JRA-1p5-2023" >1958</value>
     </values>
     <group>run_component_drof</group>
     <file>env_run.xml</file>
@@ -193,6 +197,7 @@
       <value compset="_DROF%JRA"          >2016</value>
       <value compset="_DROF%JRA-1p4-2018" >2018</value>
       <value compset="_DROF%JRA-1p5"      >2020</value>
+      <value compset="_DROF%JRA-1p5-2023" >2023</value>
     </values>
     <group>run_component_drof</group>
     <file>env_run.xml</file>

--- a/components/mpas-ocean/cime_config/config_compsets.xml
+++ b/components/mpas-ocean/cime_config/config_compsets.xml
@@ -68,6 +68,11 @@
   </compset>
 
   <compset>
+    <alias>GMPAS-JRA1p5-2023</alias>
+    <lname>2000_DATM%JRA-1p5-2023_SLND_MPASSI_MPASO%DATMFORCED_DROF%JRA-1p5-2023_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>GMPAS-OECO-JRA1p4</alias>
     <lname>2000_DATM%JRA-1p4-2018_SLND_MPASSI_MPASO%OECODATMFORCED_DROF%JRA-1p4-2018_SGLC_SWAV</lname>
   </compset>


### PR DESCRIPTION
Adds new datm and drof settings to support JRA forcing through 2023, as well as a new G-case compset that uses the forcing. It is distinguished from the typical JRA-1p5 in the compset aliases, GMPAS-JRA1p5-2023 and GMPAS-JRA1p5, for backwards compatibility.

[BFB]