### PR TITLE
Update default FATES parameter file with arctic shrubs and understory allometry update

### DIFF
--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -134,7 +134,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- ================================================================== -->
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
-<fates_paramfile >lnd/clm2/paramdata/fates_params_api.36.0.0_12pft_c240517.nc</fates_paramfile>
+<fates_paramfile >lnd/clm2/paramdata/fates_params_api.36.1.0_12pft_c240926.nc</fates_paramfile>
 
 <!-- soil order related parameters (relative to {csmdata}) -->
 <fsoilordercon             >lnd/clm2/paramdata/CNP_parameters_c131108.nc</fsoilordercon>

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -134,7 +134,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- ================================================================== -->
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
-<fates_paramfile >lnd/clm2/paramdata/fates_params_api.36.1.0_12pft_c240926.nc</fates_paramfile>
+<fates_paramfile >lnd/clm2/paramdata/fates_params_api.36.1.0_14pft_c241003.nc</fates_paramfile>
 
 <!-- soil order related parameters (relative to {csmdata}) -->
 <fsoilordercon             >lnd/clm2/paramdata/CNP_parameters_c131108.nc</fsoilordercon>

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/fateshydro/shell_commands
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/fateshydro/shell_commands
@@ -1,17 +1,2 @@
 #!/bin/bash
 if [ `./xmlquery --value MACH` == bebop ]; then ./xmlchange --id LND_PIO_TYPENAME --val netcdf; fi
-module load e4s
-spack env activate gcc
-spack load nco
-
-SRCDIR=`./xmlquery SRCROOT --value`
-CASEDIR=`./xmlquery CASEROOT --value`
-FATESDIR=$SRCDIR/src/fates
-FATESPARAMFILE=$CASEDIR/fates_params_hydrograsstempfix.nc
-
-ncgen -o $FATESPARAMFILE $FATESDIR/parameter_files/fates_params_default.cdl
-
-$FATESDIR/tools/modify_fates_paramfile.py --O --fin $FATESPARAMFILE --fout $FATESPARAMFILE --var fates_allom_smode --val 1 --allpfts
-
-spack unload nco
-module unload e4s

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/fateshydro/shell_commands
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/fateshydro/shell_commands
@@ -1,2 +1,17 @@
 #!/bin/bash
 if [ `./xmlquery --value MACH` == bebop ]; then ./xmlchange --id LND_PIO_TYPENAME --val netcdf; fi
+module load e4s
+spack env activate gcc
+spack load nco
+
+SRCDIR=`./xmlquery SRCROOT --value`
+CASEDIR=`./xmlquery CASEROOT --value`
+FATESDIR=$SRCDIR/src/fates
+FATESPARAMFILE=$CASEDIR/fates_params_hydrograsstempfix.nc
+
+ncgen -o $FATESPARAMFILE $FATESDIR/parameter_files/fates_params_default.cdl
+
+$FATESDIR/tools/modify_fates_paramfile.py --O --fin $FATESPARAMFILE --fout $FATESPARAMFILE --var fates_allom_smode --val 1 --allpfts
+
+spack unload nco
+module unload e4s

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/fateshydro/user_nl_elm
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/fateshydro/user_nl_elm
@@ -5,6 +5,7 @@ hist_nhtfrq       = -24
 hist_empty_htapes = .true.
 use_fates_planthydro = .true.
 fates_spitfire_mode = 1
+fates_paramfile = '$CASEROOT/fates_params_hydrograsstempfix.nc'
 hist_fincl1       = 'FATES_ERRH2O_SZPF', 'FATES_TRAN_SZPF',
 'FATES_SAPFLOW_SZPF', 'FATES_ITERH1_SZPF','FATES_ABSROOT_H2O_SZPF',
 'FATES_TRANSROOT_H2O_SZPF','FATES_STEM_H2O_SZPF','FATES_LEAF_H2O_SZPF',

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/fateshydro/user_nl_elm
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/fateshydro/user_nl_elm
@@ -5,7 +5,6 @@ hist_nhtfrq       = -24
 hist_empty_htapes = .true.
 use_fates_planthydro = .true.
 fates_spitfire_mode = 1
-fates_paramfile = '$CASEROOT/fates_params_hydrograsstempfix.nc'
 hist_fincl1       = 'FATES_ERRH2O_SZPF', 'FATES_TRAN_SZPF',
 'FATES_SAPFLOW_SZPF', 'FATES_ITERH1_SZPF','FATES_ABSROOT_H2O_SZPF',
 'FATES_TRANSROOT_H2O_SZPF','FATES_STEM_H2O_SZPF','FATES_LEAF_H2O_SZPF',


### PR DESCRIPTION
Updates the FATES default parameter file to include improvements to arctic shrub pft represetation per NGEET/fates#1236 conducting per the NGEE-Arctic project.  The parameter file update also includes improvements in understory survival rates per NGEET/fates#1136.  

[non-BFB] for fates