### PR TITLE
fix sat hist capability and add test

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -207,6 +207,7 @@ _TESTS = {
             "REP_Ln5.ne4pg2_oQU480.F2010",
             "SMS_Ld3.ne4pg2_oQU480.F2010.eam-thetahy_sl_pg2_mass",
             "ERP_Ld3.ne4pg2_ne4pg2.FIDEAL.allactive-pioroot1",
+            "ERS_Ld5.ne4pg2_oQU480.F2010.eam-sathist_F2010",
             )
         },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -207,7 +207,7 @@ _TESTS = {
             "REP_Ln5.ne4pg2_oQU480.F2010",
             "SMS_Ld3.ne4pg2_oQU480.F2010.eam-thetahy_sl_pg2_mass",
             "ERP_Ld3.ne4pg2_ne4pg2.FIDEAL.allactive-pioroot1",
-            "SMS_Ld5.ne4pg2_oQU480.F2010.eam-sathist_F2010",
+            "ERS_Ld5.ne4pg2_oQU480.F2010.eam-sathist_F2010",
             )
         },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -207,6 +207,7 @@ _TESTS = {
             "REP_Ln5.ne4pg2_oQU480.F2010",
             "SMS_Ld3.ne4pg2_oQU480.F2010.eam-thetahy_sl_pg2_mass",
             "ERP_Ld3.ne4pg2_ne4pg2.FIDEAL.allactive-pioroot1",
+            "SMS_Ld5.ne4pg2_oQU480.F2010.eam-sathist_F2010",
             )
         },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -207,7 +207,6 @@ _TESTS = {
             "REP_Ln5.ne4pg2_oQU480.F2010",
             "SMS_Ld3.ne4pg2_oQU480.F2010.eam-thetahy_sl_pg2_mass",
             "ERP_Ld3.ne4pg2_ne4pg2.FIDEAL.allactive-pioroot1",
-            "ERS_Ld5.ne4pg2_oQU480.F2010.eam-sathist_F2010",
             )
         },
 

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/sathist_F2010/readme
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/sathist_F2010/readme
@@ -1,0 +1,1 @@
+test for sat hist capability components/eam/src/control/sat_hist.F90

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/sathist_F2010/shell_commands
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/sathist_F2010/shell_commands
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./xmlchange RUN_STARTDATE=2015-01-01
+./xmlchange RUN_STARTDATE=2018-01-01

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/sathist_F2010/shell_commands
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/sathist_F2010/shell_commands
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./xmlchange RUN_STARTDATE=2015-01-01

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/sathist_F2010/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/sathist_F2010/user_nl_eam
@@ -1,7 +1,7 @@
 &satellite_options_nl
  sathist_mfilt          = 10000,
  sathist_track_infile   = '$DIN_LOC_ROOT/atm/waccm/sat/sathist_master_19700410-20150419_c20150616.nc'
- sathist_hfilename_spec = '%c.sathist_master_19700410-20150419_c20150616.%y-%m-%d-%s.nc'
+ sathist_hfilename_spec = '%c.eam.h9.sathist.%y-%m-%d-%s.nc'
  sathist_nclosest       = 1
  sathist_ntimestep      = 1
  sathist_fincl          = 'T', 'PS'

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/sathist_F2010/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/sathist_F2010/user_nl_eam
@@ -1,6 +1,6 @@
 &satellite_options_nl
  sathist_mfilt          = 10000,
- sathist_track_infile   = '$DIN_LOC_ROOT/atm/waccm/sat/sathist_master_19700410-20150419_c20150616.nc'
+ sathist_track_infile   = '$DIN_LOC_ROOT/atm/waccm/sat/satellite_profilelist_orcas_to_socrates_c190208.nc'
  sathist_hfilename_spec = '%c.eam.h9.sathist.%y-%m-%d-%s.nc'
  sathist_nclosest       = 1
  sathist_ntimestep      = 1

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/sathist_F2010/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/sathist_F2010/user_nl_eam
@@ -1,0 +1,7 @@
+&satellite_options_nl
+ sathist_mfilt          = 10000,
+ sathist_track_infile   = '$DIN_LOC_ROOT/atm/waccm/sat/sathist_master_19700410-20150419_c20150616.nc'
+ sathist_hfilename_spec = '%c.sathist_master_19700410-20150419_c20150616.%y-%m-%d-%s.nc'
+ sathist_nclosest       = 1
+ sathist_ntimestep      = 1
+ sathist_fincl          = 'T', 'PS'

--- a/components/eam/src/control/sat_hist.F90
+++ b/components/eam/src/control/sat_hist.F90
@@ -722,8 +722,14 @@ contains
 
        call read_buffered_datetime( datetime, i )
 
-       if ( datetime>begdatetime .and. beg_ndx<0 ) beg_ndx = i
-       if ( datetime>enddatetime ) exit bnds_loop
+       if (datetime > begdatetime .and. beg_ndx < 0) then
+          beg_ndx = i
+       end if
+
+       if (datetime > enddatetime) then
+          exit bnds_loop
+       end if
+
        end_ndx = i
 
     enddo bnds_loop

--- a/components/eam/src/control/sat_hist.F90
+++ b/components/eam/src/control/sat_hist.F90
@@ -6,18 +6,20 @@
 module sat_hist
 
   use perf_mod,      only: t_startf, t_stopf
-  use shr_kind_mod,  only: r8 => shr_kind_r8
+  use shr_kind_mod,  only: r4 => shr_kind_r4
+  use shr_kind_mod,  only: r8 => shr_kind_r8, cl=>shr_kind_cl
   use cam_logfile,   only: iulog
-  use ppgrid,        only: pcols, pver, begchunk, endchunk
+  use ppgrid,        only: pcols, pver, pverp, begchunk, endchunk
   use cam_history_support, only: fieldname_lenp2, max_string_len, ptapes
   use spmd_utils,    only: masterproc, iam
   use cam_abortutils,    only: endrun
 
-  use pio,           only: file_desc_t, iosystem_desc_t, iosystem_desc_t, var_desc_t, io_desc_t
-  use pio,           only: pio_openfile, pio_redef, pio_enddef, pio_inq_dimid, pio_inq_varid, pio_seterrorhandling, pio_def_var
+  use pio,           only: file_desc_t,iosystem_desc_t, var_desc_t, io_desc_t
+  use pio,           only: pio_inq_dimid, pio_inq_varid
+  use pio,           only: pio_seterrorhandling, pio_def_var
   use pio,           only: pio_inq_dimlen, pio_get_att, pio_put_att, pio_get_var, pio_put_var, pio_write_darray
-  use pio,           only: pio_real, pio_int, pio_double
-  use pio,           only: PIO_WRITE,PIO_NOWRITE, PIO_NOERR, PIO_BCAST_ERROR, PIO_INTERNAL_ERROR, PIO_Rearr_box, PIO_GLOBAL
+  use pio,           only: pio_real,pio_double
+  use pio,           only: PIO_NOWRITE, PIO_NOERR, PIO_BCAST_ERROR, PIO_INTERNAL_ERROR, PIO_GLOBAL
   use spmd_utils,    only: mpicom
 #ifdef SPMD
   use mpishorthand,  only: mpichar, mpiint
@@ -81,6 +83,7 @@ module sat_hist
   logical, parameter :: debug = .false.
 
   real(r8), parameter :: rad2deg = 180._r8/pi            ! degrees per radian
+
 
 contains
   
@@ -189,14 +192,13 @@ contains
   subroutine sat_hist_init
     use cam_pio_utils, only: cam_pio_openfile
     use ioFileMod,     only: getfil
-    use spmd_utils,    only: npes
     use time_manager,  only: get_step_size
     use string_utils,  only: to_lower, GLC
 
     implicit none
 
     character(len=max_string_len)  :: locfn       ! Local filename
-    integer :: ierr, dimid, i
+    integer :: ierr, dimid
 
     character(len=128) :: date_format
 
@@ -406,17 +408,15 @@ contains
 !-------------------------------------------------------------------------------
   subroutine sat_hist_write( tape , nflds, nfils)
 
-    use ppgrid,   only : pcols, begchunk, endchunk
     use phys_grid, only: phys_decomp
     use dyn_grid, only: dyn_decomp
     use cam_history_support, only : active_entry
-    use pio, only : pio_file_is_open
-    implicit none
+    use pio, only : pio_file_is_open, pio_syncfile
     type(active_entry) :: tape
     integer, intent(in) :: nflds
     integer, intent(inout) :: nfils
 
-    integer :: t, f, i, ncols, nocols    
+    integer :: ncols, nocols
     integer :: ierr
 
     integer, allocatable :: col_ndxs(:)
@@ -430,9 +430,13 @@ contains
     real(r8),allocatable :: phs_dists(:)
 
     integer :: coldim
-
-    integer :: io_type
-    logical :: has_dyn_flds
+    logical :: has_dyn_flds = .false.
+    logical :: has_phys_srf_flds = .false.
+    logical :: has_phys_lev_flds = .false.
+    logical :: has_phys_ilev_flds = .false.
+    logical :: has_dyn_srf_flds = .false.
+    logical :: has_dyn_lev_flds = .false.
+    logical :: has_dyn_ilev_flds = .false.
 
     if (.not.has_sat_hist) return
 
@@ -456,13 +460,11 @@ contains
     allocate( mlons(nocols) )
     allocate( phs_dists(nocols) )
 
-    has_dyn_flds = .false.
-    dyn_flds_loop: do f=1,nflds
-       if ( tape%hlist(f)%field%decomp_type == dyn_decomp ) then
-          has_dyn_flds = .true.
-          exit dyn_flds_loop
-       endif
-    enddo dyn_flds_loop
+    call scan_flds( tape, nflds & 
+       , has_phys_srf_flds, has_phys_lev_flds, has_phys_ilev_flds &
+       , has_dyn_srf_flds, has_dyn_lev_flds, has_dyn_ilev_flds )
+
+    has_dyn_flds = has_dyn_srf_flds .or. has_dyn_lev_flds .or. has_dyn_ilev_flds
 
     call get_indices( obs_lats, obs_lons, ncols, nocols, has_dyn_flds, col_ndxs, chk_ndxs, &
          fdyn_ndxs, ldyn_ndxs, phs_owners, dyn_owners, mlats, mlons, phs_dists )
@@ -479,16 +481,35 @@ contains
 
     call write_record_coord( tape, mlats(:), mlons(:), phs_dists(:), ncols, nfils )
 
-    do f=1,nflds
+   ! dump columns of 2D fields
+    if (has_phys_srf_flds) then
+       call dump_columns( tape%File, tape%hlist, nflds, nocols, 1, nfils, &
+                          col_ndxs, chk_ndxs, phs_owners, phys_decomp )
+    endif
+    if (has_dyn_srf_flds) then
+       call dump_columns( tape%File, tape%hlist, nflds, nocols, 1, nfils, &
+                          fdyn_ndxs, ldyn_ndxs, dyn_owners, dyn_decomp )
+    endif
 
-       select case (tape%hlist(f)%field%decomp_type)
-       case (phys_decomp)
-          call dump_columns(tape%File, tape%hlist(f), nocols, nfils, col_ndxs(:), chk_ndxs(:), phs_owners(:) )
-       case (dyn_decomp)
-          call dump_columns(tape%File, tape%hlist(f), nocols, nfils, fdyn_ndxs(:), ldyn_ndxs(:), dyn_owners(:) )
-       end select
+   ! dump columns of 3D fields defined on mid pres levels
+    if (has_phys_lev_flds) then
+       call dump_columns( tape%File, tape%hlist, nflds, nocols, pver, nfils, &
+                          col_ndxs, chk_ndxs, phs_owners, phys_decomp )
+    endif
+    if (has_dyn_lev_flds) then
+       call dump_columns( tape%File, tape%hlist, nflds, nocols, pver, nfils, &
+                          fdyn_ndxs, ldyn_ndxs, dyn_owners, dyn_decomp )
+    endif
 
-    enddo
+   ! dump columns of 3D fields defined on interface pres levels
+    if (has_phys_ilev_flds) then
+       call dump_columns( tape%File, tape%hlist, nflds, nocols, pverp, nfils, &
+                          col_ndxs, chk_ndxs, phs_owners, phys_decomp )
+    endif
+    if (has_dyn_ilev_flds) then
+       call dump_columns( tape%File, tape%hlist, nflds, nocols, pverp, nfils, &
+                          fdyn_ndxs, ldyn_ndxs, dyn_owners, dyn_decomp )
+    endif
 
     deallocate( col_ndxs, chk_ndxs, fdyn_ndxs, ldyn_ndxs, phs_owners, dyn_owners )
     deallocate( mlons, mlats, phs_dists )
@@ -501,92 +522,150 @@ contains
   end subroutine sat_hist_write
 
 !-------------------------------------------------------------------------------
-  subroutine dump_columns( File, hitem, ncols, nfils, fdims, ldims, owners  )
-    use cam_history_support,  only: field_info, hentry, hist_coords, fillvalue
-    use pio,            only: pio_initdecomp, pio_freedecomp, pio_setframe, pio_iam_iotask, pio_setdebuglevel, pio_offset_kind
+  subroutine dump_columns( File, hitems, nflds, ncols, nlevs, nfils, fdims, ldims, owners, decomp )
+    use cam_history_support, only: field_info, hentry, fillvalue
+    use pio,                 only: pio_setframe, pio_offset_kind
+    use spmd_utils, only:  mpi_real4, mpi_real8, mpicom, mpi_sum
 
     type(File_desc_t),intent(inout)  :: File
-    type(hentry),     intent(in), target     :: hitem
+    type(hentry),     intent(in), target     :: hitems(:)
+    integer,          intent(in)     :: nflds
     integer,          intent(in)     :: ncols
+    integer,          intent(in)     :: nlevs
     integer,          intent(in)     :: nfils
     integer,          intent(in)     :: fdims(:)
     integer,          intent(in)     :: ldims(:)
     integer,          intent(in)     :: owners(:)
+    integer,          intent(in)     :: decomp
+
 
     type(field_info), pointer :: field
     type(var_desc_t) :: vardesc
-    type(iosystem_desc_t), pointer :: sat_iosystem
-    type(io_desc_t) :: iodesc
-    integer :: t, ierr, ndims
-    integer, allocatable :: dimlens(:)
+    integer :: ierr
 
-    real(r8), allocatable :: buf(:)
-    integer,  allocatable :: dof(:)
-    integer :: i,k, cnt
+    real(r8) :: sbuf1d(ncols),rbuf1d(ncols)
+    real(r4) :: buf1d(ncols)
+    real(r8) :: sbuf2d(nlevs,ncols), rbuf2d(nlevs,ncols)
+    real(r4) :: buf2d(nlevs,ncols)
+    integer :: i,k,f, cnt
 
     call t_startf ('sat_hist::dump_columns')
 
-    sat_iosystem => File%iosystem
-    field => hitem%field
-    vardesc = hitem%varid(1)
+    do f = 1,nflds
+       field => hitems(f)%field
 
+       if (field%numlev==nlevs .and. field%decomp_type==decomp) then
+          vardesc = hitems(f)%varid(1)
 
-    ndims=1
-    if(associated(field%mdims)) then
-       ndims = size(field%mdims)+1
-    else if(field%numlev>1) then
-       ndims=2
-    end if
-    allocate(dimlens(ndims))
-    dimlens(ndims)=ncols
-    if(ndims>2) then
-       do i=1,ndims-1
-          dimlens(i)=hist_coords(field%mdims(i))%dimsize
-       enddo
-    else if(field%numlev>1) then
-       dimlens(1) = field%numlev
-    end if
-   
-
-    allocate( buf( product(dimlens) ) )
-    allocate( dof( product(dimlens) ) )
-
-    cnt = 0
-    buf = fillvalue
-    dof = 0
-
-    do i = 1,ncols
-       do k = 1,field%numlev
-          cnt = cnt+1
-          if ( iam == owners(i) ) then
-             buf(cnt) = hitem%hbuf( fdims(i), k, ldims(i) )
-             dof(cnt) = cnt
+          if (nlevs==1) then
+             sbuf1d = 0.0_r8
+             rbuf1d = 0.0_r8
+             do i=1,ncols
+                if ( iam == owners(i) ) then
+                   sbuf1d(i) = hitems(f)%hbuf( fdims(i), 1, ldims(i) )
+                endif
+             enddo
+             call mpi_allreduce(sbuf1d,rbuf1d,ncols,mpi_real8, mpi_sum, mpicom, ierr)
+             buf1d(:) = real(rbuf1d(:),r4)
+             ierr = pio_put_var(File, vardesc, (/nfils/),(/ncols/), buf1d(:))
+          else
+             sbuf2d = 0.0_r8
+             rbuf2d = 0.0_r8
+             do i=1,ncols
+                if ( iam == owners(i) ) then
+                   do k = 1,nlevs
+                      sbuf2d(k,i) = hitems(f)%hbuf( fdims(i), k, ldims(i) )
+                   enddo
+                endif
+             enddo
+             call mpi_allreduce(sbuf2d,rbuf2d,ncols*nlevs,mpi_real8, mpi_sum, mpicom, ierr)
+             buf2d(:,:) = real(rbuf2d(:,:),r4)
+             ierr = pio_put_var(File, vardesc, (/1,nfils/),(/nlevs,ncols/), buf2d(:,:))
           endif
-       enddo
+
+       endif
+
     enddo
-
-    call pio_setframe(File, vardesc, int(-1,kind=PIO_OFFSET_KIND))
-
-    call pio_initdecomp(sat_iosystem, pio_double, dimlens, dof, iodesc )
-
-    call pio_setframe(File, vardesc, int(nfils,kind=PIO_OFFSET_KIND))
-
-    call pio_write_darray(File, vardesc, iodesc, buf, ierr, fillval=fillvalue)
-
-    call pio_freedecomp(sat_iosystem, iodesc)
-
-    deallocate( buf )
-    deallocate( dof )
-    deallocate( dimlens )
 
     call t_stopf ('sat_hist::dump_columns')
 
   end subroutine dump_columns
 
 !-------------------------------------------------------------------------------
+! scan the fields for possible different decompositions
+!-------------------------------------------------------------------------------
+  subroutine scan_flds( tape, nflds & 
+       , has_phys_srf_flds, has_phys_lev_flds, has_phys_ilev_flds &
+       , has_dyn_srf_flds, has_dyn_lev_flds, has_dyn_ilev_flds )
+    use cam_history_support, only : active_entry
+    use phys_grid, only: phys_decomp
+    use dyn_grid,  only: dyn_decomp
+
+    type(active_entry), intent(in) :: tape
+    integer, intent(in) :: nflds
+    logical, save :: flds_scanned
+    logical, intent(out) :: has_phys_srf_flds
+    logical, intent(out) :: has_phys_lev_flds
+    logical, intent(out) :: has_phys_ilev_flds
+    logical, intent(out) :: has_dyn_srf_flds
+    logical, intent(out) :: has_dyn_lev_flds
+    logical, intent(out) :: has_dyn_ilev_flds
+
+    integer :: f
+    character(len=cl) :: msg1, msg2
+
+    if (flds_scanned) return
+
+    do f = 1,nflds
+       if ( tape%hlist(f)%field%decomp_type == phys_decomp ) then
+          if ( tape%hlist(f)%field%numlev == 1 ) then
+             has_phys_srf_flds = .true.
+          elseif ( tape%hlist(f)%field%numlev == pver ) then
+             has_phys_lev_flds = .true.
+          elseif ( tape%hlist(f)%field%numlev == pverp ) then
+             has_phys_ilev_flds = .true.
+          else
+             call endrun('sat_hist::scan_flds numlev error : '//tape%hlist(f)%field%name)
+          endif
+       elseif ( tape%hlist(f)%field%decomp_type == dyn_decomp ) then
+          if ( tape%hlist(f)%field%numlev == 1 ) then
+             has_dyn_srf_flds = .true.
+          elseif ( tape%hlist(f)%field%numlev == pver ) then
+             has_dyn_lev_flds = .true.
+          elseif ( tape%hlist(f)%field%numlev == pverp ) then
+             has_dyn_ilev_flds = .true.
+          else
+             call endrun('sat_hist::scan_flds numlev error : '//tape%hlist(f)%field%name)
+          endif
+       else
+          call endrun('sat_hist::scan_flds decomp_type error : '//tape%hlist(f)%field%name)
+       endif
+
+       ! Check that the only "mdim" is the vertical coordinate.
+       if (has_phys_srf_flds .or. has_phys_lev_flds .or. has_phys_ilev_flds .or. &
+           has_dyn_srf_flds .or. has_dyn_lev_flds .or. has_dyn_ilev_flds) then
+          ! The mdims pointer is unassociated on a restart.  The restart initialization
+          ! should be fixed rather than requiring the check to make sure it is associated.
+          if (associated(tape%hlist(f)%field%mdims)) then
+             if (size(tape%hlist(f)%field%mdims) > 1) then
+                msg1 = 'sat_hist::scan_flds mdims error :'//tape%hlist(f)%field%name
+                msg2 = trim(msg1)//' has mdims in addition to the vertical coordinate.'//&
+                   new_line('a')//'  This is not currently supported.'
+                write(iulog,*) msg2
+                call endrun(msg1)
+             end if
+          end if
+       end if
+
+    enddo
+
+    flds_scanned = .true.
+  end subroutine scan_flds
+
+!-------------------------------------------------------------------------------
 !-------------------------------------------------------------------------------
   subroutine read_next_position( ncols )
-    use time_manager, only: get_curr_date, get_prev_date
+    use time_manager, only: get_curr_date
     use time_manager, only: set_time_float_from_date
    
     implicit none
@@ -660,7 +739,7 @@ contains
 !-------------------------------------------------------------------------------
   subroutine write_record_coord( tape, mod_lats, mod_lons, mod_dists, ncols, nfils )
 
-    use time_manager,  only: get_nstep, get_curr_date, get_curr_time
+    use time_manager,  only: get_curr_date, get_curr_time
     use cam_history_support, only : active_entry
     implicit none
     type(active_entry), intent(inout) :: tape
@@ -671,9 +750,8 @@ contains
     real(r8), intent(in) :: mod_dists(ncols * sathist_nclosest)
     integer,  intent(in) ::  nfils
 
-    integer :: t, ierr, i
+    integer :: ierr, i
     integer :: yr, mon, day      ! year, month, and day components of a date
-    integer :: nstep             ! current timestep number
     integer :: ncdate            ! current date in integer format [yyyymmdd]
     integer :: ncsec             ! current time of day [seconds]
     integer :: ndcur             ! day component of current time
@@ -686,7 +764,6 @@ contains
 
     call t_startf ('sat_hist::write_record_coord')
 
-    nstep = get_nstep()
     call get_curr_date(yr, mon, day, ncsec)
     ncdate = yr*10000 + mon*100 + day
     call get_curr_time(ndcur, nscur)


### PR DESCRIPTION
Ressurecting a long-forgotten capability to output variable along ship/flight tracks,
and adding a test to (weakly try to) ensure it doesn't break again.

Fixes #6543

[BFB]

Note: I don't have full provenance from where the code edits are from. I recall attempting to fix this capability in July and August 2024, and I recall trying different versions of available CAM code to do so. But the final version isn't easily traceable (so it could be a mix of edits from CAM and debug edits to make it work in current EAM). For reference, here's the CAM code: https://github.com/ESCOMP/CAM/blob/cam_cesm2_1_rel/src/control/sat_hist.F90. I don't claim ownership of the code at all, and I am happy to give "authorship" to whomever claims it.