### PR TITLE
Correct ocean conservation check settings

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -266,6 +266,7 @@ _TESTS = {
             "SMS_D_Ld1.T62_oQU240wLI.GMPAS-IAF-PISMF.mpaso-impl_top_drag",
             "SMS_D_Ld1.T62_oQU240.GMPAS-IAF.mpaso-harmonic_mean_drag",
             "SMS_D_Ld1.T62_oQU240.GMPAS-IAF.mpaso-upwind_advection",
+            "ERS_D.T62_oQU240.GMPAS-IAF.mpaso-conservation_check",
             )
         },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -266,7 +266,7 @@ _TESTS = {
             "SMS_D_Ld1.T62_oQU240wLI.GMPAS-IAF-PISMF.mpaso-impl_top_drag",
             "SMS_D_Ld1.T62_oQU240.GMPAS-IAF.mpaso-harmonic_mean_drag",
             "SMS_D_Ld1.T62_oQU240.GMPAS-IAF.mpaso-upwind_advection",
-            "ERS_D.T62_oQU240.GMPAS-IAF.mpaso-conservation_check",
+            "ERS_Ld5_D.T62_oQU240.GMPAS-IAF.mpaso-conservation_check",
             )
         },
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -1232,37 +1232,10 @@
 
 <!-- AM_conservationCheck -->
 <config_AM_conservationCheck_enable>.false.</config_AM_conservationCheck_enable>
-<config_AM_conservationCheck_enable ocn_grid="SOwISC12to60E2r4">.true.</config_AM_conservationCheck_enable>
-<config_AM_conservationCheck_enable ocn_grid="ECwISC30to60E2r1">.true.</config_AM_conservationCheck_enable>
-<config_AM_conservationCheck_enable ocn_grid="IcoswISC30E3r5">.true.</config_AM_conservationCheck_enable>
-<config_AM_conservationCheck_enable ocn_grid="IcosXISC30E3r7">.true.</config_AM_conservationCheck_enable>
-<config_AM_conservationCheck_enable ocn_grid="FRISwISC08to60E3r1">.true.</config_AM_conservationCheck_enable>
-<config_AM_conservationCheck_enable ocn_grid="FRISwISC04to60E3r1">.true.</config_AM_conservationCheck_enable>
-<config_AM_conservationCheck_enable ocn_grid="FRISwISC02to60E3r1">.true.</config_AM_conservationCheck_enable>
-<config_AM_conservationCheck_enable ocn_grid="FRISwISC01to60E3r1">.true.</config_AM_conservationCheck_enable>
-<config_AM_conservationCheck_enable ocn_grid="RRSwISC6to18E3r5">.true.</config_AM_conservationCheck_enable>
 <config_AM_conservationCheck_compute_interval>'dt'</config_AM_conservationCheck_compute_interval>
 <config_AM_conservationCheck_output_stream>'conservationCheckOutput'</config_AM_conservationCheck_output_stream>
 <config_AM_conservationCheck_compute_on_startup>.false.</config_AM_conservationCheck_compute_on_startup>
-<config_AM_conservationCheck_compute_on_startup ocn_grid="SOwISC12to60E2r4">.true.</config_AM_conservationCheck_compute_on_startup>
-<config_AM_conservationCheck_compute_on_startup ocn_grid="ECwISC30to60E2r1">.true.</config_AM_conservationCheck_compute_on_startup>
-<config_AM_conservationCheck_compute_on_startup ocn_grid="IcoswISC30E3r5">.true.</config_AM_conservationCheck_compute_on_startup>
-<config_AM_conservationCheck_compute_on_startup ocn_grid="IcosXISC30E3r7">.true.</config_AM_conservationCheck_compute_on_startup>
-<config_AM_conservationCheck_compute_on_startup ocn_grid="FRISwISC08to60E3r1">.true.</config_AM_conservationCheck_compute_on_startup>
-<config_AM_conservationCheck_compute_on_startup ocn_grid="FRISwISC04to60E3r1">.true.</config_AM_conservationCheck_compute_on_startup>
-<config_AM_conservationCheck_compute_on_startup ocn_grid="FRISwISC02to60E3r1">.true.</config_AM_conservationCheck_compute_on_startup>
-<config_AM_conservationCheck_compute_on_startup ocn_grid="FRISwISC01to60E3r1">.true.</config_AM_conservationCheck_compute_on_startup>
-<config_AM_conservationCheck_compute_on_startup ocn_grid="RRSwISC6to18E3r5">.true.</config_AM_conservationCheck_compute_on_startup>
 <config_AM_conservationCheck_write_on_startup>.false.</config_AM_conservationCheck_write_on_startup>
-<config_AM_conservationCheck_write_on_startup ocn_grid="SOwISC12to60E2r4">.true.</config_AM_conservationCheck_write_on_startup>
-<config_AM_conservationCheck_write_on_startup ocn_grid="ECwISC30to60E2r1">.true.</config_AM_conservationCheck_write_on_startup>
-<config_AM_conservationCheck_write_on_startup ocn_grid="IcoswISC30E3r5">.true.</config_AM_conservationCheck_write_on_startup>
-<config_AM_conservationCheck_write_on_startup ocn_grid="IcosXISC30E3r7">.true.</config_AM_conservationCheck_write_on_startup>
-<config_AM_conservationCheck_write_on_startup ocn_grid="FRISwISC08to60E3r1">.true.</config_AM_conservationCheck_write_on_startup>
-<config_AM_conservationCheck_write_on_startup ocn_grid="FRISwISC04to60E3r1">.true.</config_AM_conservationCheck_write_on_startup>
-<config_AM_conservationCheck_write_on_startup ocn_grid="FRISwISC02to60E3r1">.true.</config_AM_conservationCheck_write_on_startup>
-<config_AM_conservationCheck_write_on_startup ocn_grid="FRISwISC01to60E3r1">.true.</config_AM_conservationCheck_write_on_startup>
-<config_AM_conservationCheck_write_on_startup ocn_grid="RRSwISC6to18E3r5">.true.</config_AM_conservationCheck_write_on_startup>
 <config_AM_conservationCheck_write_to_logfile>.true.</config_AM_conservationCheck_write_to_logfile>
 <config_AM_conservationCheck_restart_stream>'conservationCheckRestart'</config_AM_conservationCheck_restart_stream>
 

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -1156,7 +1156,7 @@ def buildnml(case, caseroot, compname):
             lines.append('        filename_interval="00-01-00_00:00:00"')
             lines.append('        reference_time="01-01-01_00:00:00"')
             lines.append('        output_interval="00-00-01_00:00:00"')
-            lines.append('        clobber_mode="truncate"')
+            lines.append('        clobber_mode="append"')
             lines.append('        packages="conservationCheckAMPKG">')
             lines.append('')
             lines.append('<var name="xtime"/>')

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/conservation_check/README
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/conservation_check/README
@@ -4,5 +4,7 @@ wasintroduced in MPAS-Ocean PR #4521 and has been made a stealth feature in
 
     config_AM_conservationCheck_enable = .true.
 
-Then, it enables the use of MPAS-Ocean history files in testing by running
-a sed command to modify env_archive.xml.
+However, it shoudl be noted that MPAS-Ocean history files are not currently
+included in E3SM testing so non-BFB results will not be detected unless one
+manually changes to 'compname="mpaso" exclude_testing="false"' in the file
+cime_config/config_archive.xml.

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/conservation_check/README
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/conservation_check/README
@@ -1,0 +1,8 @@
+This testdef is used to test the conservation check analysis member, which
+wasintroduced in MPAS-Ocean PR #4521 and has been made a stealth feature in
+#6643. This test turns on the consevation check analysis member by setting:
+
+    config_AM_conservationCheck_enable = .true.
+
+Then, it enables the use of MPAS-Ocean history files in testing by running
+a sed command to modify env_archive.xml.

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/conservation_check/README
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/conservation_check/README
@@ -4,7 +4,5 @@ wasintroduced in MPAS-Ocean PR #4521 and has been made a stealth feature in
 
     config_AM_conservationCheck_enable = .true.
 
-However, it shoudl be noted that MPAS-Ocean history files are not currently
-included in E3SM testing so non-BFB results will not be detected unless one
-manually changes to 'compname="mpaso" exclude_testing="false"' in the file
-cime_config/config_archive.xml.
+However, it should be noted that MPAS-Ocean history files are not currently
+included in E3SM testing so non-BFB results will not be detected.

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/conservation_check/shell_commands
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/conservation_check/shell_commands
@@ -1,3 +1,0 @@
-# include mpas-ocean outputs in testing
-sed 's|compname="mpaso" exclude_testing="true"|compname="mpaso" exclude_testing="false"|' env_archive.xml > tmp_env_archive.xml
-mv tmp_env_archive.xml env_archive.xml

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/conservation_check/shell_commands
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/conservation_check/shell_commands
@@ -1,2 +1,3 @@
 # include mpas-ocean outputs in testing
-sed -i 's#compclass="ocn" exclude_testing="true"#compclass="ocn" exclude_testing="false"#g' env_archive.xml
+sed 's|compname="mpaso" exclude_testing="true"|compname="mpaso" exclude_testing="false"|' env_archive.xml > tmp_env_archive.xml
+mv tmp_env_archive.xml env_archive.xml

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/conservation_check/shell_commands
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/conservation_check/shell_commands
@@ -1,0 +1,2 @@
+# include mpas-ocean outputs in testing
+sed -i 's#compclass="ocn" exclude_testing="true"#compclass="ocn" exclude_testing="false"#g' env_archive.xml

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/conservation_check/user_nl_mpaso
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/conservation_check/user_nl_mpaso
@@ -1,0 +1,1 @@
+ config_AM_conservationCheck_enable = .true.


### PR DESCRIPTION
Currently, the ocean conservation check analysis member overwrites the first entry in the file with a zero after restarts for some variables. This PR corrects this behavior so that the first day's entry in a monthly conservation check file is identical between continuous runs and a run with a restart break.

Fixes https://github.com/E3SM-Project/E3SM/issues/6642

[NML] for some mpaso resolutions
[BFB] for all tested files