### PR TITLE
Hommexx: Temporarily work around some EAMxx-Hommexx incompatibilities.

### DIFF
--- a/components/homme/src/preqx_kokkos/cxx/cxx_f90_interface_preqx.cpp
+++ b/components/homme/src/preqx_kokkos/cxx/cxx_f90_interface_preqx.cpp
@@ -91,6 +91,7 @@ void init_simulation_params_c (const int& remap_alg, const int& limiter_option, 
   params.hypervis_scaling              = hypervis_scaling;
   params.disable_diagnostics           = disable_diagnostics;
   params.use_moisture                  = use_moisture;
+  params.moisture = params.use_moisture ? MoistDry::MOIST : MoistDry::DRY; //todo-repo-unification
   params.use_cpstar                    = use_cpstar;
   params.transport_alg                 = transport_alg;
   // SphereOperators parameters; preqx supports only the sphere.

--- a/components/homme/src/share/cxx/HommexxEnums.hpp
+++ b/components/homme/src/share/cxx/HommexxEnums.hpp
@@ -40,6 +40,12 @@ enum class ComparisonOp {
 
 // =================== Run parameters enums ====================== //
 
+//todo-repo-unification Remove this enum in favor of bool
+// SimulationParams::use_moisture once we change EAMxx to use
+// use_moisture. Search "todo-repo-unification" for other bits of code to
+// remove.
+enum class MoistDry { MOIST, DRY };
+
 enum class ForcingAlg : int {
   FORCING_OFF =-1,
   FORCING_0   = 0, 

--- a/components/homme/src/share/cxx/SimulationParams.hpp
+++ b/components/homme/src/share/cxx/SimulationParams.hpp
@@ -24,6 +24,7 @@ struct SimulationParams
 
   TimeStepType  time_step_type;
   bool          use_moisture;
+  MoistDry moisture; //todo-repo-unification
   RemapAlg      remap_alg;
   TestCase      test_case;
   ForcingAlg    ftype = ForcingAlg::FORCING_OFF;

--- a/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
@@ -114,6 +114,7 @@ void init_simulation_params_c (const int& remap_alg, const int& limiter_option, 
   params.hypervis_scaling              = hypervis_scaling;
   params.disable_diagnostics           = (bool)disable_diagnostics;
   params.use_moisture                  = (bool)use_moisture;
+  params.moisture = params.use_moisture ? MoistDry::MOIST : MoistDry::DRY; //todo-repo-unification
   params.use_cpstar                    = (bool)use_cpstar;
   params.transport_alg                 = transport_alg;
   params.theta_hydrostatic_mode        = (bool)theta_hydrostatic_mode;

--- a/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
+++ b/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
@@ -353,12 +353,14 @@ contains
   end subroutine prim_init_elements_views
 
   subroutine prim_init_kokkos_functors (allocate_buffer)
-    use iso_c_binding, only : c_int
+    !todo-repo-unification Remove the use of c_bool here. It's used in purely
+    ! F90 code.
+    use iso_c_binding, only : c_int, c_bool
     use theta_f2c_mod, only : init_functors_c, init_boundary_exchanges_c
     !
     ! Optional Input
     !
-    logical, intent(in), optional :: allocate_buffer  ! Whether functor memory buffer should be allocated internally
+    logical(kind=c_bool), intent(in), optional :: allocate_buffer  ! Whether functor memory buffer should be allocated internally
     integer(kind=c_int) :: ab
     ! Initialize the C++ functors in the C++ context
     ! If no argument allocate_buffer is present,


### PR DESCRIPTION
These are due to PR #6594 and break the E3SM-repo EAMxx build. Once the SCREAM and E3SM repos are unified, we can back out these workarounds.

The workarounds are isolated to components/homme, keeping the commit separation of components/eamxx (SCREAM repo) and components/homme (E3SM repo) clean.

Fixes #6635.