### PR TITLE
Homme(xx): Flush the log before calling MPI_Abort in Homme's abortmp.

### DIFF
--- a/components/homme/src/share/parallel_mod.F90
+++ b/components/homme/src/share/parallel_mod.F90
@@ -274,6 +274,7 @@ contains
 #endif
 #endif
     character*(*) string
+    call flush(iulog)
 #ifdef CAM
     call endrun(string)
 #else


### PR DESCRIPTION
This is an attempt to assure atm.log (EAM) and homme_atm.log (EAMxx) get full output when the dycore calls MPI_Abort.

[BFB]