### PR TITLE
Put ".rtd." in WW3 obstructions/shadow file names 

### DIFF
--- a/components/ww3/bld/build-namelist
+++ b/components/ww3/bld/build-namelist
@@ -398,8 +398,8 @@ if ($NML_TYPE eq "ww3_grid_nml") {
     add_default($nl, 'icedisp');
     add_default($nl, 'rwndc');
 
-    add_default($nl, 'uostfilelocal', 'val'=>"'${DIN_LOC_ROOT}/wav/ww3/obstructions_local.${WAV_GRID}${WAV_SPEC}.in'");
-    add_default($nl, 'uostfileshadow', 'val'=>"'${DIN_LOC_ROOT}/wav/ww3/obstructions_shadow.${WAV_GRID}${WAV_SPEC}.in'");
+    add_default($nl, 'uostfilelocal', 'val'=>"'${DIN_LOC_ROOT}/wav/ww3/obstructions_local.${WAV_GRID}${WAV_SPEC}.rtd.in'");
+    add_default($nl, 'uostfileshadow', 'val'=>"'${DIN_LOC_ROOT}/wav/ww3/obstructions_shadow.${WAV_GRID}${WAV_SPEC}.rtd.in'");
     
 }
 

--- a/components/ww3/cime_config/buildnml
+++ b/components/ww3/cime_config/buildnml
@@ -66,8 +66,8 @@ def buildnml(case, caseroot, compname):
 
         input_list.write("mesh = {}/wav/ww3/{}.msh\n".format(din_loc_root,wav_grid))
         input_list.write("stations = {}/wav/ww3/stations.txt\n".format(din_loc_root))
-        input_list.write("uostfilelocal = {}/wav/ww3/obstructions_local.{}{}.in\n".format(din_loc_root,wav_grid,wav_spec))
-        input_list.write("uostfileshadow = {}/wav/ww3/obstructions_shadow.{}{}.in\n".format(din_loc_root,wav_grid,wav_spec))
+        input_list.write("uostfilelocal = {}/wav/ww3/obstructions_local.{}{}.rtd.in\n".format(din_loc_root,wav_grid,wav_spec))
+        input_list.write("uostfileshadow = {}/wav/ww3/obstructions_shadow.{}{}.rtd.in\n".format(din_loc_root,wav_grid,wav_spec))
 
     #--------------------------------------------------------------------
     # Invoke ww3 build-namelist - output will go in $CASEBUILD/ww3conf


### PR DESCRIPTION
The WW3 obstructions/shadow files should include ".rtd." in the name. 
This stands for 'rotated grid'. It will be much easier to keep track of WW3 input files required. Some input files need to be on the WW3 rotated grid (and should specify this with the tag "rtd" in the file name), while other files need to be on the un-rotated grid. 