### PR TITLE
Make bgc balance_check_tolerance a nml variable and increase the default

### DIFF
--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -139,6 +139,12 @@ If TRUE consider priority of plant to get a fraction of
 symbiotic N fixation and P phosphatase
 </entry>
 
+<entry id="balance_check_tolerance" type="real" category="elm_physics"
+       group="elm_inparm" valid_values="" >
+BGC balance check tolerance
+Default 1.0e-7 hardwired
+</entry>
+
 <entry id="startdate_add_temperature" type="char*8" category="elm_physics"
        group="elm_inparm" valid_values="" >
 Set date for beginning of adding temperature to atmospheric forcing

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -139,7 +139,7 @@ If TRUE consider priority of plant to get a fraction of
 symbiotic N fixation and P phosphatase
 </entry>
 
-<entry id="balance_check_tolerance" type="real" category="elm_physics"
+<entry id="bgc_balance_check_tolerance" type="real" category="elm_physics"
        group="elm_inparm" valid_values="" >
 BGC balance check tolerance
 Default 1.0e-7 hardwired

--- a/components/elm/src/biogeochem/EcosystemBalanceCheckMod.F90
+++ b/components/elm/src/biogeochem/EcosystemBalanceCheckMod.F90
@@ -48,7 +48,8 @@ module EcosystemBalanceCheckMod
   implicit none
   save
   private
-  real(r8), parameter :: balance_check_tolerance = 1e-8_r8
+
+  real(r8), public  :: balance_check_tolerance = 1e-7_r8
   !
   ! !PUBLIC MEMBER FUNCTIONS:
   public :: BeginColCBalance
@@ -64,6 +65,8 @@ module EcosystemBalanceCheckMod
   public :: EndGridCBalanceAfterDynSubgridDriver
   public :: EndGridNBalanceAfterDynSubgridDriver
   public :: EndGridPBalanceAfterDynSubgridDriver
+
+
   !-----------------------------------------------------------------------
 
 contains
@@ -498,7 +501,7 @@ contains
             ! here is '-' adjustment. It says that the adding to PF decomp n pools was less.
          end if
 
-         if (abs(col_errnb(c)) > 1e-8_r8) then
+         if (abs(col_errnb(c)) > balance_check_tolerance) then
             err_found = .true.
             err_index = c
          end if

--- a/components/elm/src/biogeochem/EcosystemBalanceCheckMod.F90
+++ b/components/elm/src/biogeochem/EcosystemBalanceCheckMod.F90
@@ -49,7 +49,9 @@ module EcosystemBalanceCheckMod
   save
   private
 
+  ! This corersponds to namelist variable bgc_balance_check_tolerance
   real(r8), public  :: balance_check_tolerance = 1e-7_r8
+
   !
   ! !PUBLIC MEMBER FUNCTIONS:
   public :: BeginColCBalance

--- a/components/elm/src/biogeochem/EcosystemBalanceCheckMod.F90
+++ b/components/elm/src/biogeochem/EcosystemBalanceCheckMod.F90
@@ -65,8 +65,6 @@ module EcosystemBalanceCheckMod
   public :: EndGridCBalanceAfterDynSubgridDriver
   public :: EndGridNBalanceAfterDynSubgridDriver
   public :: EndGridPBalanceAfterDynSubgridDriver
-
-
   !-----------------------------------------------------------------------
 
 contains

--- a/components/elm/src/biogeochem/EcosystemBalanceCheckMod.F90
+++ b/components/elm/src/biogeochem/EcosystemBalanceCheckMod.F90
@@ -281,7 +281,7 @@ contains
          end if
 
          ! check for significant errors
-         if (abs(col_errcb(c)) > 1e-8_r8) then
+         if (abs(col_errcb(c)) > balance_check_tolerance) then
             err_found = .true.
             err_index = c
          end if
@@ -734,7 +734,7 @@ contains
          col_errpb(c) = (col_pinputs(c) - col_poutputs(c))*dt - &
               (col_endpb(c) - col_begpb(c))
 
-         if (abs(col_errpb(c)) > 1e-8_r8) then
+         if (abs(col_errpb(c)) > balance_check_tolerance) then
             err_found = .true.
             err_index = c
          end if

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -55,7 +55,7 @@ module controlMod
   use elm_varctl              , only: const_climate_hist
   use elm_varctl              , only: use_top_solar_rad
   use elm_varctl              , only: snow_shape, snicar_atm_type, use_dust_snow_internal_mixing
-  use EcosystemBalanceCheckMod, only: balance_check_tolerance
+  use EcosystemBalanceCheckMod, only: bgc_balance_check_tolerance => balance_check_tolerance
 
   !
   ! !PUBLIC TYPES:
@@ -184,7 +184,7 @@ contains
 
     ! BGC balance check
     namelist /elm_inparm/ &
-         balance_check_tolerance
+         bgc_balance_check_tolerance
 
     ! For experimental manipulations
     namelist /elm_inparm/ &
@@ -801,7 +801,7 @@ contains
     call mpi_bcast (forest_fert_exp, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (ECA_Pconst_RGspin, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (NFIX_PTASE_plant, 1, MPI_LOGICAL, 0, mpicom, ier)
-    call mpi_bcast (balance_check_tolerance, 1, MPI_REAL8, 0, mpicom, ier)
+    call mpi_bcast (bgc_balance_check_tolerance, 1, MPI_REAL8, 0, mpicom, ier)
     call mpi_bcast (use_pheno_flux_limiter, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (startdate_add_temperature, 1, MPI_CHARACTER, 0, mpicom, ier)
     call mpi_bcast (startdate_add_co2, 1, MPI_CHARACTER, 0, mpicom, ier)

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -55,6 +55,7 @@ module controlMod
   use elm_varctl              , only: const_climate_hist
   use elm_varctl              , only: use_top_solar_rad
   use elm_varctl              , only: snow_shape, snicar_atm_type, use_dust_snow_internal_mixing
+  use EcosystemBalanceCheckMod, only: balance_check_tolerance
 
   !
   ! !PUBLIC TYPES:
@@ -180,6 +181,10 @@ contains
          ECA_Pconst_RGspin
     namelist /elm_inparm/ &
          NFIX_PTASE_plant
+
+    ! BGC balance check
+    namelist /elm_inparm/ &
+         balance_check_tolerance
 
     ! For experimental manipulations
     namelist /elm_inparm/ &
@@ -325,7 +330,7 @@ contains
 
     namelist /elm_mosart/ &
          lnd_rof_coupling_nstep
-		 
+
     namelist /elm_inparm/ &
          snow_shape, snicar_atm_type, use_dust_snow_internal_mixing 
     
@@ -796,6 +801,7 @@ contains
     call mpi_bcast (forest_fert_exp, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (ECA_Pconst_RGspin, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (NFIX_PTASE_plant, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (balance_check_tolerance, 1, MPI_REAL8, 0, mpicom, ier)
     call mpi_bcast (use_pheno_flux_limiter, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (startdate_add_temperature, 1, MPI_CHARACTER, 0, mpicom, ier)
     call mpi_bcast (startdate_add_co2, 1, MPI_CHARACTER, 0, mpicom, ier)


### PR DESCRIPTION
This enables namelist control for the balance_check_tolerance.
The hardwired default of balance_check_tolerance is increased from
1e-8 to 1e-7 for C, N and P based on testing results from investigating a runtime
failure due to grid and column nbalance errors exceeding specified
threshold.

[BFB] for tests never having nbalance issue
[NML] no NML diff for tests as default is not set via nml.

------------------------------------------------------------------------------------
Tested for the [v3.LR.historical_0201 case](https://acme-climate.atlassian.net/wiki/spaces/CM/pages/4182474754/v3.LR.historical+ensemble) that failed in 1996-02 with the original threshold, confirm the effectiveness of the nml control and the new default value for overcoming the nbalance issue.

Previous testings showed the error can reach more than 5e-8 but sufficiently distant from the new default of 1e-7