### PR TITLE
Add missing omp private variables for data subglacial runoff

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -275,7 +275,7 @@ _TESTS = {
             "ERS_P480_Ld5.TL319_IcoswISC30E3r5.GMPAS-JRA1p5-DIB-PISMF.mpaso-jra_1958",
             "PEM_P480_Ld5.TL319_IcoswISC30E3r5.GMPAS-JRA1p5-DIB-PISMF.mpaso-jra_1958",
             "SMS_P480_Ld5.TL319_IcoswISC30E3r5.GMPAS-JRA1p5-DIB-PISMF-TMIX.mpaso-jra_1958",
-            "SMS_P480_Ld5.TL319_IcoswISC30E3r5.GMPAS-JRA1p5-DIB-PISMF-DSGR.mpaso-jra_1958",
+            "PET_P480_Ld2.TL319_IcoswISC30E3r5.GMPAS-JRA1p5-DIB-PISMF-DSGR.mpaso-jra_1958",
             )
         },
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -3540,6 +3540,7 @@ contains
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp private(kmin, fracAbsorbed, fracAbsorbedRunoff, fracAbsorbedSubglacialRunoff, &
+      !$omp         zTop, k, zBot, transmissionCoeffTop, transmissionCoeffBot, &
       !$omp         sumSurfaceStressSquared, i, iEdge)
       do iCell = 1, nCells
 


### PR DESCRIPTION
Adds some variables were introduced in PR #6508 and not icluded in the appropriate omp private statement. These variables are only used for data subglacial runoff, so this does not impact current tests.

[BFB]