### PR TITLE
Move WW3 Build Location

### DIFF
--- a/components/ww3/cime_config/buildlib_cmake
+++ b/components/ww3/cime_config/buildlib_cmake
@@ -43,14 +43,23 @@ def buildlib(bldroot, installpath, case):
     # Define WW3 repository directories
     repodir  = "{}/components/ww3/src".format(srcroot)
     modeldir = "{}/WW3/model".format(repodir)
+    builddir = "{}/wav".format(exeroot)
 
     # TODO: these work dirs will have to be changed to live in the binary/build area.
     # Achieving this will probably require a significant refactor of the ww3 infrastructure.
     # Doing this stuff in-source not only clutters the repo, but also introduces potential race
     # conditions if we were to try to build multiple ww3 cases simultaneously.
-    bindir   = "{}/bin".format(modeldir)
-    exedir   = "{}/exe".format(modeldir)
-    tmpdir   = "{}/tmp".format(modeldir)
+    bindir1   = "{}/bin".format(modeldir)
+    bindir   = "{}/wav/bin".format(exeroot)
+    shutil.copytree(bindir1, bindir)
+    auxdir1   = "{}/aux".format(modeldir)
+    auxdir   = "{}/wav/aux".format(exeroot)
+    shutil.copytree(auxdir1, auxdir)
+    ftndir1   = "{}/ftn".format(modeldir)
+    ftndir   = "{}/wav/ftn".format(exeroot)
+    shutil.copytree(ftndir1, ftndir)
+    
+    tmpdir   = "{}/wav/tmp".format(exeroot)
 
     # Run w3_setup to create wwatch3.env file
     env_file = os.path.join(bindir, "wwatch3.env")
@@ -77,7 +86,7 @@ def buildlib(bldroot, installpath, case):
 y
 """.format(sf90, scc, tmpdir))
 
-    run_bld_cmd_ensure_logging("./w3_setup {} -s E3SM < w3_setup.inp".format(modeldir), logger, from_dir=bindir)
+    run_bld_cmd_ensure_logging("./w3_setup {} -s E3SM < w3_setup.inp".format(builddir), logger, from_dir=bindir)
     os.remove(inp_file)
 
     # Generate pre-processed WW3 source code
@@ -85,7 +94,7 @@ y
     for exe in ww3_exe:
       run_bld_cmd_ensure_logging("./w3_source {}".format(exe), logger, from_dir=bindir)
     for exe in ww3_exe:
-      tarfile = "{}/work/{}.tar.gz".format(modeldir,exe)
+      tarfile = "{}/work/{}.tar.gz".format(builddir,exe)
       shutil.move(tarfile, tmpdir)
       run_bld_cmd_ensure_logging("tar -xzvf {}.tar.gz".format(exe), logger, from_dir=tmpdir)
     run_bld_cmd_ensure_logging("rm ww3_shel.F90", logger, from_dir=tmpdir)

--- a/components/ww3/cime_config/buildlib_cmake
+++ b/components/ww3/cime_config/buildlib_cmake
@@ -45,21 +45,18 @@ def buildlib(bldroot, installpath, case):
     modeldir = "{}/WW3/model".format(repodir)
     builddir = "{}/wav".format(exeroot)
 
-    # TODO: these work dirs will have to be changed to live in the binary/build area.
-    # Achieving this will probably require a significant refactor of the ww3 infrastructure.
-    # Doing this stuff in-source not only clutters the repo, but also introduces potential race
-    # conditions if we were to try to build multiple ww3 cases simultaneously.
-    bindir1   = "{}/bin".format(modeldir)
-    bindir   = "{}/wav/bin".format(exeroot)
-    shutil.copytree(bindir1, bindir)
-    auxdir1   = "{}/aux".format(modeldir)
-    auxdir   = "{}/wav/aux".format(exeroot)
-    shutil.copytree(auxdir1, auxdir)
-    ftndir1   = "{}/ftn".format(modeldir)
-    ftndir   = "{}/wav/ftn".format(exeroot)
-    shutil.copytree(ftndir1, ftndir)
+    # work dirs are placed in the binary/build area.
+    bindir_source  = "{}/bin".format(modeldir)
+    bindir   = "{}/bin".format(builddir)
+    shutil.copytree(bindir_source, bindir)
+    auxdir_source  = "{}/aux".format(modeldir)
+    auxdir   = "{}/aux".format(builddir)
+    shutil.copytree(auxdir_source, auxdir)
+    ftndir_source  = "{}/ftn".format(modeldir)
+    ftndir   = "{}/ftn".format(builddir)
+    shutil.copytree(ftndir_source, ftndir)
     
-    tmpdir   = "{}/wav/tmp".format(exeroot)
+    tmpdir   = "{}/tmp".format(builddir)
 
     # Run w3_setup to create wwatch3.env file
     env_file = os.path.join(bindir, "wwatch3.env")


### PR DESCRIPTION
WW3 code currently compiles in the source code repo. This is severely problematic and creates several issues including:
a) cluttering the source code directory
b) creating problematic 'race-conditions' when more than one case with WW3 need to be compiled (such as running test suites)

This PR simply copies the required directories from the WW3 source code repo (the aux, ftn, and bin directories) to the "build/wav" directory and compiles all WW3 code there.
The compiled .F90 and executable tar files are now located here: "/build/wav/tmp/"

The E3SM commands _./case.build_ and _./case.build --clean-all_ correctly compile and clean all WW3 code.

[BFB]