### PR TITLE
Adds NOOPT_FILES concept to mpas cmake system

### DIFF
--- a/components/mpas-framework/src/build_core.cmake
+++ b/components/mpas-framework/src/build_core.cmake
@@ -62,6 +62,13 @@ function(build_core CORE)
     endforeach()
   endif()
 
+  # Disable optimizations on some files that would take too long to compile, expect these to all be fortran files
+  foreach (SOURCE_FILE IN LISTS NOOPT_FILES)
+    get_filename_component(SOURCE_EXT ${SOURCE_FILE} EXT)
+    string(REPLACE "${SOURCE_EXT}" ".f90" SOURCE_F90 ${SOURCE_FILE})
+    e3sm_deoptimize_file(${CMAKE_BINARY_DIR}/${SOURCE_F90})
+  endforeach()
+
   genf90_targets("${RAW_SOURCES}" "${INCLUDES}" "${CPPDEFS}" "${NO_PREPROCESS}" "${INC_DIR}")
   target_sources(${COMPONENT} PRIVATE ${SOURCES})
 

--- a/components/mpas-seaice/src/seaice.cmake
+++ b/components/mpas-seaice/src/seaice.cmake
@@ -144,6 +144,7 @@ set(SEAICE_MODEL_FORWARD
 )
 list(APPEND RAW_SOURCES ${SEAICE_MODEL_FORWARD})
 list(APPEND DISABLE_QSMP ${SEAICE_MODEL_FORWARD})
+list(APPEND NOOPT_FILES "core_seaice/icepack/columnphysics/icepack_shortwave_data.F90")
 
 # Generate core input
 handle_st_nl_gen("namelist.seaice" "streams.seaice stream_list.seaice. listed" ${CORE_INPUT_DIR} ${CORE_BLDDIR})


### PR DESCRIPTION
And uses this system to deoptimize icepack_shortwave_data.F90, a file that takes a very long time to compile and is just setting up consts.

[BFB]