### PR TITLE
fix variables in data subglacial runoff

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -3574,8 +3574,8 @@ contains
                    do k = maxLevelCell(iCell), minLevelCell(iCell), -1
                       zBot = zTop - layerThickness(k,iCell)
                       if (k == minLevelCell(iCell)) then
-                        transmissionCoeffTop = exp( max(zTop / config_flux_attenuation_coefficient_runoff, -100.0_RKIND) )
-                        transmissionCoeffBot = exp( max(zBot / config_flux_attenuation_coefficient_runoff, -100.0_RKIND) )
+                        transmissionCoeffTop = exp( max(zTop / config_flux_attenuation_coefficient_subglacial_runoff, -100.0_RKIND) )
+                        transmissionCoeffBot = exp( max(zBot / config_flux_attenuation_coefficient_subglacial_runoff, -100.0_RKIND) )
                         fracAbsorbedSubglacialRunoff = transmissionCoeffTop - transmissionCoeffBot
                       end if
                       zTop = zBot


### PR DESCRIPTION
This fixes a typo in PR https://github.com/E3SM-Project/E3SM/pull/6508, where config_flux_attenuation_coefficient_runoff was mistakenly used in kpp loop instead of config_flux_attenuation_coefficient_subglacial_runoff.

These variables are only used for data subglacial runoff, so this does not impact current tests.

[BFB]
