### PR TITLE
Introduce land ice surface mass balance fields in default runs without MECs/GLC

### DIFF
--- a/components/elm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/elm/src/biogeophys/BalanceCheckMod.F90
@@ -167,7 +167,7 @@ contains
      use elm_varcon        , only : spval
      use column_varcon     , only : icol_roof, icol_sunwall, icol_shadewall
      use column_varcon     , only : icol_road_perv, icol_road_imperv
-     use landunit_varcon   , only : istice_mec, istice, istdlak, istsoil,istcrop,istwet
+     use landunit_varcon   , only : istice_mec, istdlak, istsoil,istcrop,istwet
      use elm_varctl        , only : create_glacier_mec_landunit
      use elm_initializeMod , only : surfalb_vars  
      use CanopyStateType   , only : canopystate_type

--- a/components/elm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/elm/src/biogeophys/BalanceCheckMod.F90
@@ -167,7 +167,7 @@ contains
      use elm_varcon        , only : spval
      use column_varcon     , only : icol_roof, icol_sunwall, icol_shadewall
      use column_varcon     , only : icol_road_perv, icol_road_imperv
-     use landunit_varcon   , only : istice_mec, istdlak, istsoil,istcrop,istwet
+     use landunit_varcon   , only : istice_mec, istice, istdlak, istsoil,istcrop,istwet
      use elm_varctl        , only : create_glacier_mec_landunit
      use elm_initializeMod , only : surfalb_vars  
      use CanopyStateType   , only : canopystate_type
@@ -503,11 +503,7 @@ contains
                 if (glc_dyn_runoff_routing(g)) then
                    ! Need to add qflx_glcice_frz to snow_sinks for the same reason as it is
                    ! added to errh2o above - see the comment above for details.
-                   if (lun_pp%itype(l) == istice) then 
-                        snow_sinks(c) = snow_sinks(c)
-                   else 
-                        snow_sinks(c) = snow_sinks(c) + qflx_glcice_frz(c)
-                   end if
+                   snow_sinks(c) = snow_sinks(c) + qflx_glcice_frz(c)
                 end if
 
                 errh2osno(c) = (h2osno(c) - h2osno_old(c)) - (snow_sources(c) - snow_sinks(c)) * dtime

--- a/components/elm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/elm/src/biogeophys/BalanceCheckMod.F90
@@ -503,7 +503,11 @@ contains
                 if (glc_dyn_runoff_routing(g)) then
                    ! Need to add qflx_glcice_frz to snow_sinks for the same reason as it is
                    ! added to errh2o above - see the comment above for details.
-                   snow_sinks(c) = snow_sinks(c) + qflx_glcice_frz(c)
+                   if (lun_pp%itype(l) == istice) then 
+                        snow_sinks(c) = snow_sinks(c)
+                   else 
+                        snow_sinks(c) = snow_sinks(c) + qflx_glcice_frz(c)
+                   end if
                 end if
 
                 errh2osno(c) = (h2osno(c) - h2osno_old(c)) - (snow_sources(c) - snow_sinks(c)) * dtime

--- a/components/elm/src/biogeophys/HydrologyDrainageMod.F90
+++ b/components/elm/src/biogeophys/HydrologyDrainageMod.F90
@@ -222,7 +222,7 @@ contains
          g = col_pp%gridcell(c)
          ! In the following, we convert glc_snow_persistence_max_days to r8 to avoid overflow
          if ( (snow_persistence(c) >= (real(glc_snow_persistence_max_days, r8) * secspday)) &
-              .or. lun_pp%itype(l) == istice_mec) then
+              .or. lun_pp%itype(l) == istice_mec .or. lun_pp%itype(l) == istice) then
             qflx_glcice_frz(c) = qflx_snwcp_ice(c)
             qflx_glcice(c) = qflx_glcice(c) + qflx_glcice_frz(c)
             if (glc_dyn_runoff_routing(g)) qflx_snwcp_ice(c) = 0._r8

--- a/components/elm/src/biogeophys/HydrologyDrainageMod.F90
+++ b/components/elm/src/biogeophys/HydrologyDrainageMod.F90
@@ -47,7 +47,7 @@ contains
     !
     ! !USES:
       !$acc routine seq
-    use landunit_varcon  , only : istice, istwet, istsoil, istice_mec, istcrop
+    use landunit_varcon  , only : istice, istwet, istsoil, istice_mec, istcrop, istice
     use column_varcon    , only : icol_roof, icol_road_imperv, icol_road_perv, icol_sunwall, icol_shadewall
     use elm_varcon       , only : denh2o, denice, secspday
     use elm_varctl       , only : glc_snow_persistence_max_days, use_vichydro, use_betr

--- a/components/elm/src/biogeophys/HydrologyDrainageMod.F90
+++ b/components/elm/src/biogeophys/HydrologyDrainageMod.F90
@@ -222,11 +222,17 @@ contains
          g = col_pp%gridcell(c)
          ! In the following, we convert glc_snow_persistence_max_days to r8 to avoid overflow
          if ( (snow_persistence(c) >= (real(glc_snow_persistence_max_days, r8) * secspday)) &
-              .or. lun_pp%itype(l) == istice_mec .or. lun_pp%itype(l) == istice) then
+              .or. lun_pp%itype(l) == istice_mec) then
             qflx_glcice_frz(c) = qflx_snwcp_ice(c)
             qflx_glcice(c) = qflx_glcice(c) + qflx_glcice_frz(c)
             if (glc_dyn_runoff_routing(g)) qflx_snwcp_ice(c) = 0._r8
          end if
+
+         if (lun_pp%itype(l) == istice) then 
+                 qflx_glcice_frz(c) = qflx_snwcp_ice(c)
+                 qflx_glcice(c) = qflx_glcice(c) + qflx_glcice_frz(c)
+         end if
+
       end do
 
       ! Determine wetland and land ice hydrology (must be placed here

--- a/components/elm/src/biogeophys/HydrologyDrainageMod.F90
+++ b/components/elm/src/biogeophys/HydrologyDrainageMod.F90
@@ -218,6 +218,11 @@ contains
       do c = bounds%begc,bounds%endc
          qflx_glcice_frz(c) = 0._r8
          qflx_glcice_frz_diag(c) = 0._r8
+
+         if (lun_pp%itype(l)==istice .and. qflx_snwcp_ice(c) > 0.0_r8) then
+               qflx_glcice_frz_diag(c) = qflx_snwcp_ice(c)
+               qflx_glcice_diag(c) = qflx_glcice_diag(c) + qflx_glcice_frz_diag(c)
+         endif
       end do
       do fc = 1,num_do_smb_c
          c = filter_do_smb_c(fc)

--- a/components/elm/src/biogeophys/HydrologyDrainageMod.F90
+++ b/components/elm/src/biogeophys/HydrologyDrainageMod.F90
@@ -217,6 +217,7 @@ contains
 
       do c = bounds%begc,bounds%endc
          qflx_glcice_frz(c) = 0._r8
+         qflx_glcice_frz_diag(c) = 0._r8
       end do
       do fc = 1,num_do_smb_c
          c = filter_do_smb_c(fc)
@@ -233,6 +234,8 @@ contains
          if (lun_pp%itype(l)==istice) then
                qflx_glcice_frz_diag(c) = qflx_snwcp_ice(c)
                qflx_glcice_diag(c) = qflx_glcice_diag(c) + qflx_glcice_frz_diag(c)
+               !write(iulog,*) 'CAW lun_pp%itype(l)==istice',lun_pp%itype(l)==istice
+               !write(iulog,*) 'qflx_snwcp_ice(c)',qflx_snwcp_ice(c)
          endif
 
       end do

--- a/components/elm/src/biogeophys/HydrologyDrainageMod.F90
+++ b/components/elm/src/biogeophys/HydrologyDrainageMod.F90
@@ -224,13 +224,14 @@ contains
          if ( (snow_persistence(c) >= (real(glc_snow_persistence_max_days, r8) * secspday)) &
               .or. lun_pp%itype(l) == istice_mec .or. lun_pp%itype(l) == istice) then
 
-              if (lun_pp%itype(l) == istice) then
-                      qflx_glcice_frz(c) = qflx_snwcp_ice(c)
-                      qflx_glcice(c) = qflx_glcice(c) + qflx_glcice_frz(c)
-              else 
+              if ( (snow_persistence(c) >= (real(glc_snow_persistence_max_days, r8) * secspday)) &
+                 .or. lun_pp%itype(l) == istice_mec) then 
                       qflx_glcice_frz(c) = qflx_snwcp_ice(c)
                       qflx_glcice(c) = qflx_glcice(c) + qflx_glcice_frz(c)
                       if (glc_dyn_runoff_routing(g)) qflx_snwcp_ice(c) = 0._r8
+              else
+                      qflx_glcice_frz(c) = qflx_snwcp_ice(c)
+                      qflx_glcice(c) = qflx_glcice(c) + qflx_glcice_frz(c)
               end if ! lun_pp%itype(l) == istice
          end if
 

--- a/components/elm/src/biogeophys/HydrologyDrainageMod.F90
+++ b/components/elm/src/biogeophys/HydrologyDrainageMod.F90
@@ -236,10 +236,10 @@ contains
                    if (glc_dyn_runoff_routing(g)) qflx_snwcp_ice(c) = 0._r8
          end if
 
-         if (lun_pp%itype(l)==istice) then
-               qflx_glcice_frz_diag(c) = qflx_snwcp_ice(c)
-               qflx_glcice_diag(c) = qflx_glcice_diag(c) + qflx_glcice_frz_diag(c)
-         endif
+         !if (lun_pp%itype(l)==istice) then
+         !      qflx_glcice_frz_diag(c) = qflx_snwcp_ice(c)
+         !      qflx_glcice_diag(c) = qflx_glcice_diag(c) + qflx_glcice_frz_diag(c)
+         !endif
 
       end do
 

--- a/components/elm/src/biogeophys/HydrologyDrainageMod.F90
+++ b/components/elm/src/biogeophys/HydrologyDrainageMod.F90
@@ -123,6 +123,7 @@ contains
          qflx_glcice_frz        => col_wf%qflx_glcice_frz         , & ! Output: [real(r8) (:)   ]  ice growth (positive definite) (mm H2O/s)
          qflx_glcice_diag       => col_wf%qflx_glcice_diag        , & ! Output: [real(r8) (:)   ]  flux of new glacier ice (mm H2O/s) - diagnostic, no MECs or GLC
          qflx_glcice_frz_diag   => col_wf%qflx_glcice_frz_diag      & ! Output: [real(r8) (:)   ]  ice growth (positive definite) (mm H2O/s)) - diagnostic, no MECs or GLC
+         )
 
       ! Determine time step and step size
 
@@ -230,8 +231,8 @@ contains
          end if
 
          if (lun_pp%itype(l)==istice) then
-               qflx_glcice_frz_diags(c) = qflx_snwcp_ice(c)
-               qflx_glcice_diags(c) = qflx_glcice_diags(c) + qflx_glcice_frz_diags(c)
+               qflx_glcice_frz_diag(c) = qflx_snwcp_ice(c)
+               qflx_glcice_diag(c) = qflx_glcice_diag(c) + qflx_glcice_frz_diag(c)
          endif
 
       end do

--- a/components/elm/src/biogeophys/HydrologyDrainageMod.F90
+++ b/components/elm/src/biogeophys/HydrologyDrainageMod.F90
@@ -222,15 +222,16 @@ contains
          g = col_pp%gridcell(c)
          ! In the following, we convert glc_snow_persistence_max_days to r8 to avoid overflow
          if ( (snow_persistence(c) >= (real(glc_snow_persistence_max_days, r8) * secspday)) &
-              .or. lun_pp%itype(l) == istice_mec) then
-            qflx_glcice_frz(c) = qflx_snwcp_ice(c)
-            qflx_glcice(c) = qflx_glcice(c) + qflx_glcice_frz(c)
-            if (glc_dyn_runoff_routing(g)) qflx_snwcp_ice(c) = 0._r8
-         end if
+              .or. lun_pp%itype(l) == istice_mec .or. lun_pp%itype(l) == istice) then
 
-         if (lun_pp%itype(l) == istice) then 
-                 qflx_glcice_frz(c) = qflx_snwcp_ice(c)
-                 qflx_glcice(c) = qflx_glcice(c) + qflx_glcice_frz(c)
+              if (lun_pp%itype(l) == istice) then
+                      qflx_glcice_frz(c) = qflx_snwcp_ice(c)
+                      qflx_glcice(c) = qflx_glcice(c) + qflx_glcice_frz(c)
+              else 
+                      qflx_glcice_frz(c) = qflx_snwcp_ice(c)
+                      qflx_glcice(c) = qflx_glcice(c) + qflx_glcice_frz(c)
+                      if (glc_dyn_runoff_routing(g)) qflx_snwcp_ice(c) = 0._r8
+              end if ! lun_pp%itype(l) == istice
          end if
 
       end do

--- a/components/elm/src/biogeophys/HydrologyDrainageMod.F90
+++ b/components/elm/src/biogeophys/HydrologyDrainageMod.F90
@@ -120,8 +120,9 @@ contains
          qflx_runoff_r          => col_wf%qflx_runoff_r           , & ! Output: [real(r8) (:)   ]  Rural total runoff (qflx_drain+qflx_surf+qflx_qrgwl) (mm H2O /s)
          qflx_snwcp_ice         => col_wf%qflx_snwcp_ice          , & ! Output: [real(r8) (:)   ]  excess snowfall due to snow capping (mm H2O /s) [+]`
          qflx_glcice            => col_wf%qflx_glcice             , & ! Output: [real(r8) (:)   ]  flux of new glacier ice (mm H2O /s)
-         qflx_glcice_frz        => col_wf%qflx_glcice_frz           & ! Output: [real(r8) (:)   ]  ice growth (positive definite) (mm H2O/s)
-         )
+         qflx_glcice_frz        => col_wf%qflx_glcice_frz         , & ! Output: [real(r8) (:)   ]  ice growth (positive definite) (mm H2O/s)
+         qflx_glcice_diag       => col_wf%qflx_glcice_diag        , & ! Output: [real(r8) (:)   ]  flux of new glacier ice (mm H2O/s) - diagnostic, no MECs or GLC
+         qflx_glcice_frz_diag   => col_wf%qflx_glcice_frz_diag      & ! Output: [real(r8) (:)   ]  ice growth (positive definite) (mm H2O/s)) - diagnostic, no MECs or GLC
 
       ! Determine time step and step size
 
@@ -222,18 +223,16 @@ contains
          g = col_pp%gridcell(c)
          ! In the following, we convert glc_snow_persistence_max_days to r8 to avoid overflow
          if ( (snow_persistence(c) >= (real(glc_snow_persistence_max_days, r8) * secspday)) &
-              .or. lun_pp%itype(l) == istice_mec .or. lun_pp%itype(l) == istice) then
-
-              if ( (snow_persistence(c) >= (real(glc_snow_persistence_max_days, r8) * secspday)) &
-                 .or. lun_pp%itype(l) == istice_mec) then 
-                      qflx_glcice_frz(c) = qflx_snwcp_ice(c)
-                      qflx_glcice(c) = qflx_glcice(c) + qflx_glcice_frz(c)
-                      if (glc_dyn_runoff_routing(g)) qflx_snwcp_ice(c) = 0._r8
-              else
-                      qflx_glcice_frz(c) = qflx_snwcp_ice(c)
-                      qflx_glcice(c) = qflx_glcice(c) + qflx_glcice_frz(c)
-              end if ! lun_pp%itype(l) == istice
+              .or. lun_pp%itype(l) == istice_mec ) then
+                   qflx_glcice_frz(c) = qflx_snwcp_ice(c)
+                   qflx_glcice(c) = qflx_glcice(c) + qflx_glcice_frz(c)
+                   if (glc_dyn_runoff_routing(g)) qflx_snwcp_ice(c) = 0._r8
          end if
+
+         if (lun_pp%itype(l)==istice) then
+               qflx_glcice_frz_diags(c) = qflx_snwcp_ice(c)
+               qflx_glcice_diags(c) = qflx_glcice_diags(c) + qflx_glcice_frz_diags(c)
+         endif
 
       end do
 

--- a/components/elm/src/biogeophys/HydrologyDrainageMod.F90
+++ b/components/elm/src/biogeophys/HydrologyDrainageMod.F90
@@ -234,8 +234,6 @@ contains
          if (lun_pp%itype(l)==istice) then
                qflx_glcice_frz_diag(c) = qflx_snwcp_ice(c)
                qflx_glcice_diag(c) = qflx_glcice_diag(c) + qflx_glcice_frz_diag(c)
-               !write(iulog,*) 'CAW lun_pp%itype(l)==istice',lun_pp%itype(l)==istice
-               !write(iulog,*) 'qflx_snwcp_ice(c)',qflx_snwcp_ice(c)
          endif
 
       end do

--- a/components/elm/src/biogeophys/HydrologyDrainageMod.F90
+++ b/components/elm/src/biogeophys/HydrologyDrainageMod.F90
@@ -231,16 +231,10 @@ contains
          ! In the following, we convert glc_snow_persistence_max_days to r8 to avoid overflow
          if ( (snow_persistence(c) >= (real(glc_snow_persistence_max_days, r8) * secspday)) &
               .or. lun_pp%itype(l) == istice_mec ) then
-                   qflx_glcice_frz(c) = qflx_snwcp_ice(c)
-                   qflx_glcice(c) = qflx_glcice(c) + qflx_glcice_frz(c)
-                   if (glc_dyn_runoff_routing(g)) qflx_snwcp_ice(c) = 0._r8
+           qflx_glcice_frz(c) = qflx_snwcp_ice(c)
+           qflx_glcice(c) = qflx_glcice(c) + qflx_glcice_frz(c)
+           if (glc_dyn_runoff_routing(g)) qflx_snwcp_ice(c) = 0._r8
          end if
-
-         !if (lun_pp%itype(l)==istice) then
-         !      qflx_glcice_frz_diag(c) = qflx_snwcp_ice(c)
-         !      qflx_glcice_diag(c) = qflx_glcice_diag(c) + qflx_glcice_frz_diag(c)
-         !endif
-
       end do
 
       ! Determine wetland and land ice hydrology (must be placed here

--- a/components/elm/src/biogeophys/SnowHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SnowHydrologyMod.F90
@@ -670,7 +670,7 @@ contains
                       if (bi > dm) ddz1 = ddz1*exp(-46.0e-3_r8*(bi-dm))
                    else
                       ddz1_fresh = (-grav * (burden(c) + wx/2._r8)) / &
-                                   (0.007_r8 * bi**(4.75_r8 + td/40._r8))
+                                   (0.007_r8 * min(max(bi,dm),denice)**(4.75_r8 + min(td,0._r8)/40._r8))
                       snw_ssa = 3.e6_r8 / (denice * snw_rds(c,j))
                       if (snw_ssa < 50._r8) then
                           ddz1_fresh = ddz1_fresh * exp(-46.e-2_r8 * (50._r8 - snw_ssa))

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -1643,7 +1643,7 @@ contains
             ! as computed in HydrologyDrainageMod.F90.
 
             l = col_pp%landunit(c)
-            if ( (lun_pp%itype(l)==istice) .or. (lun_pp%itype(l)==istice_mec) ) then
+            if ( lun_pp%itype(l)==istice_mec) then
                if (j>=1 .and. h2osoi_liq(c,j) > 0._r8) then   ! ice layer with meltwater
                   ! melting corresponds to a negative ice flux
                   qflx_glcice_melt(c) = qflx_glcice_melt(c) + h2osoi_liq(c,j)/dtime
@@ -1655,6 +1655,16 @@ contains
 
                endif  ! liquid water is present
             endif     ! istice_mec
+            ! for diagnostic QICE SMB output only - 
+            ! these are to calculate SMB even without MECs 
+            if ( lun_pp%itype(l)==istice) then
+               if (j>=1 .and. h2osoi_liq(c,j) > 0._r8) then   ! ice layer with meltwater
+                  ! melting corresponds to a negative ice flux
+                  qflx_glcice_melt(c) = qflx_glcice_melt(c) + h2osoi_liq(c,j)/dtime
+                  qflx_glcice(c) = qflx_glcice(c) - h2osoi_liq(c,j)/dtime
+               endif  ! liquid water is present
+            endif     ! istice_mec
+
 
          end do   ! end of column-loop
       enddo   ! end of level-loop

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -1316,7 +1316,7 @@ contains
     use elm_varctl       , only : iulog
     use elm_varcon       , only : tfrz, hfus, grav
     use column_varcon    , only : icol_roof, icol_sunwall, icol_shadewall, icol_road_perv
-    use landunit_varcon  , only : istsoil, istcrop, istice_mec
+    use landunit_varcon  , only : istsoil, istcrop, istice_mec,istice
     !
     ! !ARGUMENTS:
     type(bounds_type)      , intent(in)    :: bounds

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -1643,8 +1643,7 @@ contains
             ! as computed in HydrologyDrainageMod.F90.
 
             l = col_pp%landunit(c)
-            if (lun_pp%itype(l)==istice_mec) then
-
+            if ( (lun_pp%itype(l)==istice) .or. (lun_pp%itype(l)==istice_mec) ) then
                if (j>=1 .and. h2osoi_liq(c,j) > 0._r8) then   ! ice layer with meltwater
                   ! melting corresponds to a negative ice flux
                   qflx_glcice_melt(c) = qflx_glcice_melt(c) + h2osoi_liq(c,j)/dtime

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -1369,6 +1369,8 @@ contains
          qflx_snofrz_col  =>    col_wf%qflx_snofrz      , & ! Output: [real(r8) (:)   ] column-integrated snow freezing rate (positive definite) [kg m-2 s-1]
          qflx_glcice      =>    col_wf%qflx_glcice      , & ! Output: [real(r8) (:)   ] flux of new glacier ice (mm H2O/s) [+ = ice grows]
          qflx_glcice_melt =>    col_wf%qflx_glcice_melt , & ! Output: [real(r8) (:)   ] ice melt (positive definite) (mm H2O/s)
+         qflx_glcice_diag      =>    col_wf%qflx_glcice_diag      , & ! Output: [real(r8) (:)   ] flux of new glacier ice (mm H2O/s) [+ = ice grows]
+         qflx_glcice_melt_diag =>    col_wf%qflx_glcice_melt_diag , & ! Output: [real(r8) (:)   ] ice melt (positive definite) (mm H2O/s)
          qflx_snomelt     =>    col_wf%qflx_snomelt     , & ! Output: [real(r8) (:)   ] snow melt (mm H2O /s)
 
          eflx_snomelt     =>    col_ef%eflx_snomelt    , & ! Output: [real(r8) (:)   ] snow melt heat flux (W/m**2)
@@ -1660,8 +1662,8 @@ contains
             if ( lun_pp%itype(l)==istice) then
                if (j>=1 .and. h2osoi_liq(c,j) > 0._r8) then   ! ice layer with meltwater
                   ! melting corresponds to a negative ice flux
-                  qflx_glcice_melt(c) = qflx_glcice_melt(c) + h2osoi_liq(c,j)/dtime
-                  qflx_glcice(c) = qflx_glcice(c) - h2osoi_liq(c,j)/dtime
+                  qflx_glcice_melt_diags(c) = qflx_glcice_melt_diags(c) + h2osoi_liq(c,j)/dtime
+                  qflx_glcice_diags(c) = qflx_glcice_daigs(c) - h2osoi_liq(c,j)/dtime
                endif  ! liquid water is present
             endif     ! istice_mec
 

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -1662,8 +1662,8 @@ contains
             if ( lun_pp%itype(l)==istice) then
                if (j>=1 .and. h2osoi_liq(c,j) > 0._r8) then   ! ice layer with meltwater
                   ! melting corresponds to a negative ice flux
-                  qflx_glcice_melt_diags(c) = qflx_glcice_melt_diags(c) + h2osoi_liq(c,j)/dtime
-                  qflx_glcice_diags(c) = qflx_glcice_daigs(c) - h2osoi_liq(c,j)/dtime
+                  qflx_glcice_melt_diag(c) = qflx_glcice_melt_diag(c) + h2osoi_liq(c,j)/dtime
+                  qflx_glcice_diag(c) = qflx_glcice_diag(c) - h2osoi_liq(c,j)/dtime
                endif  ! liquid water is present
             endif     ! istice_mec
 

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -1665,9 +1665,6 @@ contains
                   ! melting corresponds to a negative ice flux
                   qflx_glcice_melt_diag(c) = qflx_glcice_melt_diag(c) + h2osoi_liq(c,j)/dtime
                   qflx_glcice_diag(c) = qflx_glcice_diag(c) - h2osoi_liq(c,j)/dtime
-                  !write(iulog,*) 'CAW lun_pp%itype(l)==istice',lun_pp%itype(l)==istice
-                  !write(iulog,*) 'CAW j',j
-                  !write(iulog,*) 'CAW h2osoi_liq(c,j) ',h2osoi_liq(c,j)   
                endif  ! liquid water is present
             endif     ! istice_mec
 

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -1646,6 +1646,7 @@ contains
             ! as computed in HydrologyDrainageMod.F90.
 
             l = col_pp%landunit(c)
+
             if ( lun_pp%itype(l)==istice_mec) then
                if (j>=1 .and. h2osoi_liq(c,j) > 0._r8) then   ! ice layer with meltwater
                   ! melting corresponds to a negative ice flux

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -1395,6 +1395,7 @@ contains
          qflx_snofrz_lyr(c,-nlevsno+1:0) = 0._r8
          qflx_snofrz_col(c) = 0._r8
          qflx_glcice_melt(c) = 0._r8
+         qflx_glcice_melt_diag(c) = 0._r8
          qflx_snow_melt(c) = 0._r8
       end do
 
@@ -1664,6 +1665,9 @@ contains
                   ! melting corresponds to a negative ice flux
                   qflx_glcice_melt_diag(c) = qflx_glcice_melt_diag(c) + h2osoi_liq(c,j)/dtime
                   qflx_glcice_diag(c) = qflx_glcice_diag(c) - h2osoi_liq(c,j)/dtime
+                  !write(iulog,*) 'CAW lun_pp%itype(l)==istice',lun_pp%itype(l)==istice
+                  !write(iulog,*) 'CAW j',j
+                  !write(iulog,*) 'CAW h2osoi_liq(c,j) ',h2osoi_liq(c,j)   
                endif  ! liquid water is present
             endif     ! istice_mec
 

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -5843,22 +5843,20 @@ contains
           avgflag='A', long_name='column-integrated snow freezing rate', &
            ptr_col=this%qflx_snofrz, set_lake=spval, c2l_scale_type='urbanf', default='inactive')
 
-    if (create_glacier_mec_landunit) then
-       this%qflx_glcice(begc:endc) = spval
-       call hist_addfld1d (fname='QICE',  units='mm/s',  &
-            avgflag='A', long_name='ice growth/melt', &
-            ptr_col=this%qflx_glcice, l2g_scale_type='ice')
+    this%qflx_glcice(begc:endc) = spval
+     call hist_addfld1d (fname='QICE',  units='mm/s',  &
+          avgflag='A', long_name='ice growth/melt', &
+           ptr_col=this%qflx_glcice, l2g_scale_type='ice')
 
-       this%qflx_glcice_frz(begc:endc) = spval
-       call hist_addfld1d (fname='QICE_FRZ',  units='mm/s',  &
-            avgflag='A', long_name='ice growth', &
-            ptr_col=this%qflx_glcice_frz, l2g_scale_type='ice')
+    this%qflx_glcice_frz(begc:endc) = spval
+     call hist_addfld1d (fname='QICE_FRZ',  units='mm/s',  &
+          avgflag='A', long_name='ice growth', &
+           ptr_col=this%qflx_glcice_frz, l2g_scale_type='ice')
 
-       this%qflx_glcice_melt(begc:endc) = spval
-       call hist_addfld1d (fname='QICE_MELT',  units='mm/s',  &
-            avgflag='A', long_name='ice melt', &
-            ptr_col=this%qflx_glcice_melt, l2g_scale_type='ice')
-    endif
+    this%qflx_glcice_melt(begc:endc) = spval
+     call hist_addfld1d (fname='QICE_MELT',  units='mm/s',  &
+          avgflag='A', long_name='ice melt', &
+           ptr_col=this%qflx_glcice_melt, l2g_scale_type='ice')
 
     ! As defined here, snow_sources - snow_sinks will equal the change in h2osno at any
     ! given time step but only if there is at least one snow layer (for all landunits

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -504,7 +504,7 @@ module ColumnDataType
     real(r8), pointer :: qflx_glcice_melt     (:)   => null() ! ice melt (positive definite) (mm H2O/s)
     real(r8), pointer :: qflx_glcice_diag     (:)   => null() ! net flux of new glacial ice (growth - melt) (mm H2O/s), passed to GLC
     real(r8), pointer :: qflx_glcice_frz_diag (:)   => null() ! ice growth (positive definite) (mm H2O/s)
-    real(r8), pointer :: qflx_glcice_melt_daig(:)   => null() ! ice melt (positive definite) (mm H2O/s)
+    real(r8), pointer :: qflx_glcice_melt_diag(:)   => null() ! ice melt (positive definite) (mm H2O/s)
     real(r8), pointer :: qflx_drain_vr        (:,:) => null() ! liquid water lost as drainage (m /time step)
     real(r8), pointer :: qflx_h2osfc2topsoi   (:)   => null() ! liquid water coming from surface standing water top soil (mm H2O/s)
     real(r8), pointer :: qflx_snow2topsoi     (:)   => null() ! liquid water coming from residual snow to topsoil (mm H2O/s)
@@ -5728,7 +5728,7 @@ contains
     allocate(this%qflx_glcice            (begc:endc))             ; this%qflx_glcice          (:)   = spval
     allocate(this%qflx_glcice_frz        (begc:endc))             ; this%qflx_glcice_frz      (:)   = spval
     allocate(this%qflx_glcice_melt       (begc:endc))             ; this%qflx_glcice_melt     (:)   = spval
-    allocate(this%qflx_glcice_diag       (begc:endc))             ; this%qflx_glcice_daig     (:)   = spval
+    allocate(this%qflx_glcice_diag       (begc:endc))             ; this%qflx_glcice_diag     (:)   = spval
     allocate(this%qflx_glcice_frz_diag   (begc:endc))             ; this%qflx_glcice_frz_diag (:)   = spval
     allocate(this%qflx_glcice_melt_diag  (begc:endc))             ; this%qflx_glcice_melt_diag(:)   = spval
     allocate(this%qflx_drain_vr          (begc:endc,1:nlevgrnd))  ; this%qflx_drain_vr        (:,:) = spval

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -5852,17 +5852,17 @@ contains
     if (create_glacier_mec_landunit) then
             this%qflx_glcice(begc:endc) = spval
              call hist_addfld1d (fname='QICE',  units='mm/s',  &
-                  avgflag='A', long_name='ice growth/melt', &
+                  avgflag='A', long_name='ice growth/melt (with active GLC/MECs)', &
                    ptr_col=this%qflx_glcice, l2g_scale_type='ice')
 
             this%qflx_glcice_frz(begc:endc) = spval
              call hist_addfld1d (fname='QICE_FRZ',  units='mm/s',  &
-                  avgflag='A', long_name='ice growth', &
+                  avgflag='A', long_name='ice growth (with active GLC/MECs)', &
                    ptr_col=this%qflx_glcice_frz, l2g_scale_type='ice')
 
             this%qflx_glcice_melt(begc:endc) = spval
              call hist_addfld1d (fname='QICE_MELT',  units='mm/s',  &
-                  avgflag='A', long_name='ice melt', &
+                  avgflag='A', long_name='ice melt (with active GLC/MECs)', &
                    ptr_col=this%qflx_glcice_melt, l2g_scale_type='ice')
     else 
              this%qflx_glcice_diag(begc:endc) = spval

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -502,6 +502,9 @@ module ColumnDataType
     real(r8), pointer :: qflx_glcice          (:)   => null() ! net flux of new glacial ice (growth - melt) (mm H2O/s), passed to GLC
     real(r8), pointer :: qflx_glcice_frz      (:)   => null() ! ice growth (positive definite) (mm H2O/s)
     real(r8), pointer :: qflx_glcice_melt     (:)   => null() ! ice melt (positive definite) (mm H2O/s)
+    real(r8), pointer :: qflx_glcice_diag     (:)   => null() ! net flux of new glacial ice (growth - melt) (mm H2O/s), passed to GLC
+    real(r8), pointer :: qflx_glcice_frz_diag (:)   => null() ! ice growth (positive definite) (mm H2O/s)
+    real(r8), pointer :: qflx_glcice_melt_daig(:)   => null() ! ice melt (positive definite) (mm H2O/s)
     real(r8), pointer :: qflx_drain_vr        (:,:) => null() ! liquid water lost as drainage (m /time step)
     real(r8), pointer :: qflx_h2osfc2topsoi   (:)   => null() ! liquid water coming from surface standing water top soil (mm H2O/s)
     real(r8), pointer :: qflx_snow2topsoi     (:)   => null() ! liquid water coming from residual snow to topsoil (mm H2O/s)
@@ -5725,6 +5728,9 @@ contains
     allocate(this%qflx_glcice            (begc:endc))             ; this%qflx_glcice          (:)   = spval
     allocate(this%qflx_glcice_frz        (begc:endc))             ; this%qflx_glcice_frz      (:)   = spval
     allocate(this%qflx_glcice_melt       (begc:endc))             ; this%qflx_glcice_melt     (:)   = spval
+    allocate(this%qflx_glcice_diag       (begc:endc))             ; this%qflx_glcice_daig     (:)   = spval
+    allocate(this%qflx_glcice_frz_diag   (begc:endc))             ; this%qflx_glcice_frz_diag (:)   = spval
+    allocate(this%qflx_glcice_melt_diag  (begc:endc))             ; this%qflx_glcice_melt_diag(:)   = spval
     allocate(this%qflx_drain_vr          (begc:endc,1:nlevgrnd))  ; this%qflx_drain_vr        (:,:) = spval
     allocate(this%qflx_h2osfc2topsoi     (begc:endc))             ; this%qflx_h2osfc2topsoi   (:)   = spval
     allocate(this%qflx_snow2topsoi       (begc:endc))             ; this%qflx_snow2topsoi     (:)   = spval
@@ -5842,21 +5848,39 @@ contains
      call hist_addfld1d (fname='QSNOFRZ', units='kg/m2/s', &
           avgflag='A', long_name='column-integrated snow freezing rate', &
            ptr_col=this%qflx_snofrz, set_lake=spval, c2l_scale_type='urbanf', default='inactive')
+   
+    if (create_glacier_mec_landunit) then
+            this%qflx_glcice(begc:endc) = spval
+             call hist_addfld1d (fname='QICE',  units='mm/s',  &
+                  avgflag='A', long_name='ice growth/melt', &
+                   ptr_col=this%qflx_glcice, l2g_scale_type='ice')
 
-    this%qflx_glcice(begc:endc) = spval
-     call hist_addfld1d (fname='QICE',  units='mm/s',  &
-          avgflag='A', long_name='ice growth/melt', &
-           ptr_col=this%qflx_glcice, l2g_scale_type='ice')
+            this%qflx_glcice_frz(begc:endc) = spval
+             call hist_addfld1d (fname='QICE_FRZ',  units='mm/s',  &
+                  avgflag='A', long_name='ice growth', &
+                   ptr_col=this%qflx_glcice_frz, l2g_scale_type='ice')
 
-    this%qflx_glcice_frz(begc:endc) = spval
-     call hist_addfld1d (fname='QICE_FRZ',  units='mm/s',  &
-          avgflag='A', long_name='ice growth', &
-           ptr_col=this%qflx_glcice_frz, l2g_scale_type='ice')
+            this%qflx_glcice_melt(begc:endc) = spval
+             call hist_addfld1d (fname='QICE_MELT',  units='mm/s',  &
+                  avgflag='A', long_name='ice melt', &
+                   ptr_col=this%qflx_glcice_melt, l2g_scale_type='ice')
+    else 
+             this%qflx_glcice_diag(begc:endc) = spval
+             call hist_addfld1d (fname='QICE',  units='mm/s',  &
+                  avgflag='A', long_name='diagnostic ice growth/melt (no active GLC/MECs)', &
+                   ptr_col=this%qflx_glcice_diag, l2g_scale_type='ice')
 
-    this%qflx_glcice_melt(begc:endc) = spval
-     call hist_addfld1d (fname='QICE_MELT',  units='mm/s',  &
-          avgflag='A', long_name='ice melt', &
-           ptr_col=this%qflx_glcice_melt, l2g_scale_type='ice')
+            this%qflx_glcice_frz_diag(begc:endc) = spval
+             call hist_addfld1d (fname='QICE_FRZ',  units='mm/s',  &
+                  avgflag='A', long_name='diagnostic ice growth (no active GLC/MECs)', &
+                   ptr_col=this%qflx_glcice_frz_diag, l2g_scale_type='ice')
+
+            this%qflx_glcice_melt_diag(begc:endc) = spval
+             call hist_addfld1d (fname='QICE_MELT',  units='mm/s',  &
+                  avgflag='A', long_name='diagnostic ice melt (no active GLC/MECs)', &
+                   ptr_col=this%qflx_glcice_melt_diag, l2g_scale_type='ice')
+   end if
+
 
     ! As defined here, snow_sources - snow_sinks will equal the change in h2osno at any
     ! given time step but only if there is at least one snow layer (for all landunits

--- a/components/elm/src/main/elm_driver.F90
+++ b/components/elm/src/main/elm_driver.F90
@@ -1604,6 +1604,8 @@ contains
 
          qflx_glcice        => col_wf%qflx_glcice            , & ! Output: [real(r8) (:)   ]  flux of new glacier ice (mm H2O/s) [+ = ice grows]
 
+         qflx_glcice_diag   => col_wf%qflx_glcice_diag       , & ! Output: [real(r8) (:)   ]  flux of new glacier ice (mm H2O/s) [+ = ice grows]
+
          eflx_bot           => col_ef%eflx_bot              , & ! Output: [real(r8) (:)   ]  heat flux from beneath soil/ice column (W/m**2)
 
          cisun_z            => photosyns_vars%cisun_z_patch              , & ! Output: [real(r8) (:)   ]  intracellular sunlit leaf CO2 (Pa)
@@ -1637,6 +1639,7 @@ contains
 
          ! Initialize qflx_glcice everywhere, to zero.
          qflx_glcice(c) = 0._r8
+         qflx_glcice_diag(c) = 0._r8
 
       end do
 


### PR DESCRIPTION
Introduced new diagnostic Surface Mass Balance fields, they are calculated as if there is a coupled land ice component but are only diagnostic - it does not modify the energy/water budgets in default or coupled GLC simulations. 

[BFB]

-----

More info on modifications and testing can be found [here](https://acme-climate.atlassian.net/wiki/spaces/FAN/pages/4619599888/New+Feature+Overview+Document+ELM+Ice+SMB+h0+fields) 

