### PR TITLE
Add ERA5r025 configurations

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -1979,6 +1979,26 @@
       <mask>IcoswISC30E3r5</mask>
     </model_grid>
 
+    <model_grid alias="ERA5r025_r05_IcoswISC30E3r5_gis1to10r02" compset="_MALI">
+      <grid name="atm">ERA5r025</grid>
+      <grid name="lnd">r05</grid>
+      <grid name="ocnice">IcoswISC30E3r5</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">mpas.gis1to10kmR2</grid>
+      <grid name="wav">null</grid>
+      <mask>IcoswISC30E3r5</mask>
+    </model_grid>
+
+    <model_grid alias="ERA5r025_r025_IcoswISC30E3r5_gis1to10r02" compset="_MALI">
+      <grid name="atm">ERA5r025</grid>
+      <grid name="lnd">r025</grid>
+      <grid name="ocnice">IcoswISC30E3r5</grid>
+      <grid name="rof">r025</grid>
+      <grid name="glc">mpas.gis1to10kmR2</grid>
+      <grid name="wav">null</grid>
+      <mask>IcoswISC30E3r5</mask>
+    </model_grid>
+
     <model_grid alias="ne120pg2_r0125_EC30to60E2r2_gis1to10" compset="_MALI">
       <grid name="atm">ne120np4.pg2</grid>
       <grid name="lnd">r0125</grid>
@@ -2799,6 +2819,14 @@
       <file grid="atm|lnd" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.lnd.TL319_oRRS18to6v3.220124.nc</file>
       <file grid="ice|ocn" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.ocn.TL319_oRRS18to6v3.220124.nc</file>
       <desc>TL319 is JRA lat/lon grid:</desc>
+    </domain>
+
+    <domain name="ERA5r025">
+      <nx>1440</nx>
+      <ny>721</ny>
+      <file grid="atm|lnd" mask="IcoswISC30E3r5">$DIN_LOC_ROOT/share/domains/domain.lnd.ERA5r025_IcoswISC30E3r5.240903.nc</file>
+      <file grid="ice|ocn" mask="IcoswISC30E3r5">$DIN_LOC_ROOT/share/domains/domain.ocn.ERA5r025_IcoswISC30E3r5.240903.nc</file>
+      <desc>ERA5r025 is the lat/lon cap grid used by ERA5 data:</desc>
     </domain>
 
     <!--=====================================================================-->
@@ -4732,6 +4760,38 @@
        <map name="LND2ATM_SMAPNAME">cpl/gridmaps/TL319/map_r05_to_TL319_traave.20240212.nc</map>
     </gridmap>
 
+    <gridmap atm_grid="ERA5r025" ocn_grid="IcoswISC30E3r5">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ERA5r025/map_ERA5r025_to_IcoswISC30E3r5_traave.20240903.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ERA5r025/map_ERA5r025_to_IcoswISC30E3r5-nomask_trbilin.20240903.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ERA5r025/map_ERA5r025_to_IcoswISC30E3r5_esmfpatch.20240903.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/IcoswISC30E3r5/map_IcoswISC30E3r5_to_ERA5r025_traave.20240903.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/IcoswISC30E3r5/map_IcoswISC30E3r5_to_ERA5r025_traave.20240903.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ERA5r025" lnd_grid="r05">
+       <map name="ATM2LND_FMAPNAME">cpl/gridmaps/ERA5r025/map_ERA5r025_to_r05_traave.20240905.nc</map>
+       <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ERA5r025/map_ERA5r025_to_r05_esmfbilin.20240907.nc</map>
+       <map name="LND2ATM_FMAPNAME">cpl/gridmaps/r05/map_r05_to_ERA5r025_traave.20240905.nc</map>
+       <map name="LND2ATM_SMAPNAME">cpl/gridmaps/r05/map_r05_to_ERA5r025_traave.20240905.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ERA5r025" rof_grid="r05">
+       <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/ERA5r025/map_ERA5r025_to_r05_traave.20240905.nc</map>
+       <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/ERA5r025/map_ERA5r025_to_r05_esmfbilin.20240907.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ERA5r025" lnd_grid="r025">
+       <map name="ATM2LND_FMAPNAME">cpl/gridmaps/ERA5r025/map_ERA5r025_to_r025_traave.20240903.nc</map>
+       <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ERA5r025/map_ERA5r025_to_r025_trbilin.20240903.nc</map>
+       <map name="LND2ATM_FMAPNAME">cpl/gridmaps/r025/map_r025_to_ERA5r025_traave.20240903.nc</map>
+       <map name="LND2ATM_SMAPNAME">cpl/gridmaps/r025/map_r025_to_ERA5r025_traave.20240903.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ERA5r025" rof_grid="r025">
+       <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/ERA5r025/map_ERA5r025_to_r025_traave.20240903.nc</map>
+       <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/ERA5r025/map_ERA5r025_to_r025_trbilin.20240903.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="T31" ocn_grid="gx3v7">
       <map name="ATM2OCN_FMAPNAME">cpl/cpl6/map_T31_to_gx3v7_aave_da_090903.nc</map>
       <map name="ATM2OCN_SMAPNAME">cpl/cpl6/map_T31_to_gx3v7_patch_090903.nc</map>
@@ -5633,6 +5693,13 @@
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/r05/map_r05_to_gis1to10kmR2_trbilin.20240403.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10kmR2_to_r05_traave.20240403.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10kmR2_to_r05_traave.20240403.nc</map>
+    </gridmap>
+ 
+    <gridmap glc_grid="mpas.gis1to10kmR2" lnd_grid="r025">
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/r025/map_r025_to_gis1to10kmR2_traave.20240903.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/r025/map_r025_to_gis1to10kmR2_trbilin.20240903.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10kmR2_to_r025_traave.20240903.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis1to10km/map_gis1to10kmR2_to_r025_traave.20240903.nc</map>
     </gridmap>
  
     <gridmap glc_grid="mpas.gis1to10kmR2" lnd_grid="ne30np4.pg2">

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -613,6 +613,7 @@ this mask will have smb calculated over the entire global land surface
 <fglcmask hgrid="0.9x1.25" glc_grid="mpas.ais20km">lnd/clm2/griddata/glcmaskdata_0.9x1.25_60S.nc</fglcmask>
 <fglcmask hgrid="r05"      glc_grid="mpas.gis20km">lnd/clm2/griddata/glcmaskdata_0.5x0.5_GIS_AIS.nc</fglcmask>
 <fglcmask hgrid="r05"      glc_grid="mpas.gis1to10km">lnd/clm2/griddata/glcmaskdata_0.5x0.5_GIS_AIS.nc</fglcmask>
+<fglcmask hgrid="r025"     glc_grid="mpas.gis1to10km">lnd/clm2/griddata/glcmaskdata_r025_GIS_AIS.20240910.nc</fglcmask>
 <fglcmask hgrid="r0125"    glc_grid="mpas.gis1to10km">lnd/clm2/griddata/glcmaskdata_r0125_GIS_AIS.210407.nc</fglcmask>
 <fglcmask hgrid="ne30np4.pg2"  glc_grid="mpas.gis1to10km">lnd/clm2/griddata/glcmaskdata_ne30pg2_GIS_AIS.210407.nc</fglcmask>
 
@@ -623,6 +624,7 @@ this mask will have smb calculated over the entire global land surface
 <flndtopo hgrid="48x96"     >lnd/clm2/griddata/topodata_48x96_USGS_070110.nc</flndtopo>
 <flndtopo hgrid="r05"       use_cn=".false.">lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr1850_c200609.nc</flndtopo>
 <flndtopo hgrid="r05"       use_cn=".true.">lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr1850_c211019.nc</flndtopo>
+<flndtopo hgrid="r025"      >lnd/clm2/surfdata_map/surfdata_0.25x0.25_simyr1850_c240125.nc</flndtopo>
 <flndtopo hgrid="r0125"     >lnd/clm2/surfdata_map/surfdata_0.125x0.125_simyr1850_c190730.nc</flndtopo>
 <flndtopo hgrid="ne30np4.pg2"      >lnd/clm2/surfdata_map/surfdata_ne30pg2_simyr1850_c210402.nc</flndtopo>
 

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -360,6 +360,8 @@ lnd/clm2/surfdata_map/surfdata_ne256np4_simyr2010_c220518.nc</fsurdat>
 lnd/clm2/surfdata_map/surfdata_ne256np4_simyr2010_c220518.nc</fsurdat>
 <fsurdat hgrid="r05"         sim_year="2000" >
 lnd/clm2/surfdata_map/surfdata_0.5x0.5_simyr2000_c200624.nc</fsurdat>
+<fsurdat hgrid="r025"         sim_year="2000" >
+lnd/clm2/surfdata_map/surfdata_r025_simyr1980_c240920.nc</fsurdat>
 <fsurdat hgrid="r0125"       sim_year="2000" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_0.125x0.125_simyr2000_c190730.nc</fsurdat>
 

--- a/components/elm/cime_config/config_compsets.xml
+++ b/components/elm/cime_config/config_compsets.xml
@@ -973,6 +973,11 @@
   </compset>
 
   <compset>
+    <alias>IGERA5ELM_MLI</alias>
+    <lname>2000_DATM%ERA5_ELM%SP_SICE_SOCN_MOSART_MALI_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>I1PTELM</alias>
     <lname>2000_DATM%1PT_ELM%SP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>	  


### PR DESCRIPTION
Adds new configurations for:
* ERA5r025_r05_IcoswISC30E3r5_gis1to10r02
* ERA5r025_r025_IcoswISC30E3r5_gis1to10r02
to be used with a new IGERA5ELM_MLI compset that is active ELM, MOSART and MALI plus datm using ERA5 forcing data

[BFB]