### PR TITLE
Add explicit Core/24.00 module to Frontier

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1033,6 +1033,7 @@
       <cmd_path lang="python">/usr/share/lmod/lmod/libexec/lmod python</cmd_path>
       <modules compiler="crayclang.*">
         <command name="reset"></command>
+        <command name="load">Core/24.00</command>
         <command name="switch">PrgEnv-cray PrgEnv-cray/8.3.3</command>
         <command name="switch">cce cce/15.0.1</command>
         <!-- craype module to address tcmalloc runtime errors at startup -->
@@ -1045,6 +1046,7 @@
       </modules>
       <modules compiler="amdclang.*">
         <command name="reset"></command>
+        <command name="load">Core/24.00</command>
         <command name="switch">PrgEnv-cray PrgEnv-amd/8.3.3</command>
         <command name="switch">amd amd/5.4.0</command>
       </modules>
@@ -1053,6 +1055,7 @@
       </modules>
       <modules compiler="gnu.*">
         <command name="reset"></command>
+        <command name="load">Core/24.00</command>
         <command name="switch">PrgEnv-cray PrgEnv-gnu/8.3.3</command>
         <command name="switch">gcc gcc/12.2.0</command>
       </modules>


### PR DESCRIPTION
Explicitly load the Core/24.00 module to prevent the new default Core/24.07 module from loading on Frontier. NOTE: https://github.com/E3SM-Project/scream/pull/3029

Ran a subset of e3sm_developer tests, which showed similar results to previous tests.

BFB (no reference on Frontier).