### PR TITLE
upgrades and fixes to gh workflows

### DIFF
--- a/.github/workflows/e3sm-gh-ci-cime-tests.yml
+++ b/.github/workflows/e3sm-gh-ci-cime-tests.yml
@@ -22,10 +22,14 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
   ci:
-    if: ${{ github.event.repository.name == 'e3sm' }}
+    if: ${{ github.repository == 'E3SM-Project/E3SM' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -36,7 +40,7 @@ jobs:
           - SMS_D_Ln5_P4.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.ghci-oci_gnu
           - ERS_Ld5_P4.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.ghci-oci_gnu.eamxx-prod
     container: 
-      image: ghcr.io/e3sm-project/containers-ghci:ghci-0.1.0
+      image: ghcr.io/e3sm-project/containers-ghci:ghci-0.2.0
 
     steps:
       - 

--- a/.github/workflows/e3sm-gh-ci-w-cime-tests.yml
+++ b/.github/workflows/e3sm-gh-ci-w-cime-tests.yml
@@ -1,4 +1,4 @@
-name: gh
+name: gh-w
 
 on:
   pull_request:
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
 
-  ci-w:
+  ci:
     if: ${{ github.repository == 'E3SM-Project/E3SM' }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/e3sm-gh-ci-w-cime-tests.yml
+++ b/.github/workflows/e3sm-gh-ci-w-cime-tests.yml
@@ -11,10 +11,14 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
   ci-w:
-    if: ${{ github.event.repository.name == 'e3sm' }}
+    if: ${{ github.repository == 'E3SM-Project/E3SM' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -23,7 +27,7 @@ jobs:
           - SMS_D_Ld1_P8.ne4pg2_oQU480.WCYCL2010NS.ghci-oci_gnu
           - ERS_Ld3_P8.ne4pg2_oQU480.WCYCL2010NS.ghci-oci_gnu.allactive-wcprod_1850
     container: 
-      image: ghcr.io/e3sm-project/containers-ghci:ghci-0.1.0
+      image: ghcr.io/e3sm-project/containers-ghci:ghci-0.2.0
 
     steps:
       - 

--- a/.github/workflows/e3sm-gh-md-linter.yml
+++ b/.github/workflows/e3sm-gh-md-linter.yml
@@ -10,8 +10,13 @@ on:
         # for now let's not lint files in eamxx
         - '!components/eamxx/**/*.md'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   linter:
+    if: ${{ github.repository == 'E3SM-Project/E3SM' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/e3sm-gh-pages.yml
+++ b/.github/workflows/e3sm-gh-pages.yml
@@ -15,7 +15,7 @@ concurrency:
   
 jobs:
   Build-and-Deploy-docs:
-    if: ${{ github.event.repository.name == 'e3sm' }}
+    if: ${{ github.repository == 'E3SM-Project/E3SM' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e3sm-gh-tools-mkatmsrffile-test.yml
+++ b/.github/workflows/e3sm-gh-tools-mkatmsrffile-test.yml
@@ -36,10 +36,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: "envmkatmsrffile"
-          miniforge-variant: Mambaforge
           miniforge-version: latest
-          use-mamba: true
-          mamba-version: "*"
           channel-priority: strict
           auto-update-conda: true
           python-version: 3.11
@@ -47,7 +44,7 @@ jobs:
         name: Install dependencies
         run: |
           echo $CONDA_PREFIX
-          mamba install -y nco xarray numba numpy netcdf4
+          conda install -y nco xarray numba numpy netcdf4 -c conda-forge
       - 
         name: Run tests
         working-directory: components/eam/tools/mkatmsrffile

--- a/.github/workflows/e3sm-gh-tools-mkatmsrffile-test.yml
+++ b/.github/workflows/e3sm-gh-tools-mkatmsrffile-test.yml
@@ -11,8 +11,13 @@ on:
     - cron: '00 15 * * 2'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   mkatmsrffile-test:
+    if: ${{ github.repository == 'E3SM-Project/E3SM' }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/eamxx-gh-ci-standalone.yml
+++ b/.github/workflows/eamxx-gh-ci-standalone.yml
@@ -18,6 +18,7 @@ on:
 jobs:
 
   ci:
+    if: ${{ github.repository == 'E3SM-Project/E3SM' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/eamxx-gh-ci-standalone.yml
+++ b/.github/workflows/eamxx-gh-ci-standalone.yml
@@ -15,6 +15,10 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
   ci:

--- a/.github/workflows/eamxx-gh-pages.yml
+++ b/.github/workflows/eamxx-gh-pages.yml
@@ -34,7 +34,7 @@ concurrency:
 jobs:
 
   eamxx-docs:
-    if: ${{ github.event.repository.name == 'scream' }}
+    if: ${{ github.repository == 'E3SM-Project/scream' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/eamxx_default_files.yml
+++ b/.github/workflows/eamxx_default_files.yml
@@ -11,9 +11,13 @@ on:
     - cron: '00 00 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   scream-defaults:
-    if: ${{ github.event.repository.name == 'e3sm' }}
+    if: ${{ github.repository == 'E3SM-Project/E3SM' }}
     runs-on: ubuntu-latest
     outputs:
       event_name: ${{ github.event_name }}


### PR DESCRIPTION
Adds concurrency checks so that only one version of each workflow is running from the same type of event. Ensures these workflows only run in E3SM-Project/E3SM for now. Also upgrades container for f and w cases to add new lnd files that were made default recently.

Fixes #6652 