### PR TITLE
Add ability for MALI to create separate logs from each processor

### DIFF
--- a/components/mpas-albany-landice/bld/build-namelist
+++ b/components/mpas-albany-landice/bld/build-namelist
@@ -620,6 +620,7 @@ add_default($nl, 'config_pio_stride');
 add_default($nl, 'config_year_digits');
 add_default($nl, 'config_output_external_velocity_solver_data');
 add_default($nl, 'config_write_albany_ascii_mesh');
+add_default($nl, 'config_create_all_logs_in_e3sm');
 
 #################################
 # Namelist group: decomposition #

--- a/components/mpas-albany-landice/bld/build-namelist-section
+++ b/components/mpas-albany-landice/bld/build-namelist-section
@@ -182,6 +182,7 @@ add_default($nl, 'config_pio_stride');
 add_default($nl, 'config_year_digits');
 add_default($nl, 'config_output_external_velocity_solver_data');
 add_default($nl, 'config_write_albany_ascii_mesh');
+add_default($nl, 'config_create_all_logs_in_e3sm');
 
 #################################
 # Namelist group: decomposition #

--- a/components/mpas-albany-landice/bld/namelist_files/namelist_defaults_mali.xml
+++ b/components/mpas-albany-landice/bld/namelist_files/namelist_defaults_mali.xml
@@ -150,6 +150,7 @@
 <config_year_digits>4</config_year_digits>
 <config_output_external_velocity_solver_data>.false.</config_output_external_velocity_solver_data>
 <config_write_albany_ascii_mesh>.false.</config_write_albany_ascii_mesh>
+<config_create_all_logs_in_e3sm>.false.</config_create_all_logs_in_e3sm>
 
 <!-- decomposition -->
 <config_num_halos>3</config_num_halos>

--- a/components/mpas-albany-landice/bld/namelist_files/namelist_definition_mali.xml
+++ b/components/mpas-albany-landice/bld/namelist_files/namelist_definition_mali.xml
@@ -1087,6 +1087,14 @@ Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_create_all_logs_in_e3sm" type="logical"
+	category="io" group="io">
+Logical flag determining if log files will be created for each processor in an E3SM configuration.  If .true., the model initializes and writes to one files per processor.
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- decomposition -->
 

--- a/components/mpas-albany-landice/driver/glc_comp_mct.F
+++ b/components/mpas-albany-landice/driver/glc_comp_mct.F
@@ -181,7 +181,7 @@ contains
     logical :: streamsExists
     integer :: mesh_iotype
 
-    logical, pointer :: tempLogicalConfig
+    logical, pointer :: tempLogicalConfig, config_create_all_logs_in_e3sm
     character(len=StrKIND), pointer :: tempCharConfig
 
 
@@ -332,22 +332,6 @@ contains
        call mpas_dmpar_abort(domain % dminfo)
     end if
 
-    ! Set core specific options here
-    ! Disable output from all but the master task for E3SM!
-    ! (This overrides the default set by mpas_log_init based on MPAS_DEBUG setting.)
-    if (iam /= 0) then
-       domain % logInfo % outputLog % isActive = .false.
-    endif
-
-    ! After core has had a chance to modify log defaults, open the output log
-    call mpas_log_open(err=ierr)
-    if ( ierr /= 0 ) then
-       write(glcLogUnit,*) 'ERROR: log open failed for core ' // trim(domain % core % coreName)
-       call mpas_dmpar_abort(domain % dminfo)
-    end if
-    ! ===========
-
-
     ! ----------
     ! Process namelist and streams files
     ! ----------
@@ -360,6 +344,26 @@ contains
     if ( ierr /= 0 ) then
        call mpas_log_write('Namelist setup failed for core ' // trim(domain % core % coreName), MPAS_LOG_CRIT)
     end if
+
+    ! Set core specific options here
+    ! Disable output from all but the master task for E3SM!
+    ! (This overrides the default set by mpas_log_init based on MPAS_DEBUG setting.)
+    call mpas_pool_get_config(domain % configs, 'config_create_all_logs_in_e3sm', config_create_all_logs_in_e3sm)
+    if (config_create_all_logs_in_e3sm) then
+       domain % logInfo % outputLog % isActive = .true.
+    else
+       if (iam /= 0) then
+          domain % logInfo % outputLog % isActive = .false.
+       endif
+    endif
+
+    ! After core has had a chance to modify log defaults, open the output log
+    call mpas_log_open(err=ierr)
+    if ( ierr /= 0 ) then
+       write(glcLogUnit,*) 'ERROR: log open failed for core ' // trim(domain % core % coreName)
+       call mpas_dmpar_abort(domain % dminfo)
+    end if
+    ! ===========
 
     call mpas_framework_init_phase2(domain, io_system)
 

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -609,6 +609,10 @@
 		            description="Logical flag determining if ascii mesh files will be created.  These files are written in a format that can be used by the standalone Albany velocity solver for optimization.  If .true., the model initializes, writes the mesh files, and then terminates."
 		            possible_values=".true. or .false."
                 />
+                <nml_option name="config_create_all_logs_in_e3sm" type="logical" default_value=".false." units="unitless"
+		            description="Logical flag determining if log files will be created for each processor in an E3SM configuration.  If .true., the model initializes and writes to one files per processor."
+		            possible_values=".true. or .false."
+                />
 
 	</nml_record>
 


### PR DESCRIPTION
Adds a new variable config_create_all_logs_in_e3sm to MALI that allows users to choose to get a separate log file from each processor

[NML] for configurations with MALI
[BFB]