### PR TITLE
Evaluate time-dependent tendencies at correct time for each RK4 stage

### DIFF
--- a/components/mpas-framework/src/framework/mpas_forcing.F
+++ b/components/mpas-framework/src/framework/mpas_forcing.F
@@ -35,7 +35,8 @@ module mpas_forcing
        mpas_forcing_init_field_data, &
        mpas_forcing_get_forcing, &
        mpas_forcing_get_forcing_time, &
-       mpas_forcing_write_restart_times
+       mpas_forcing_write_restart_times, &
+       mpas_advance_forcing_clock
 
 contains
 
@@ -1193,7 +1194,7 @@ contains
        if (trim(forcingGroup % forcingGroupName) == trim(forcingGroupName)) then
 
           ! advance the forcing time
-          call advance_forcing_clock(forcingGroup, dt)
+          call mpas_advance_forcing_clock(forcingGroup, dt)
 
           ! cycle the forcing clock
           if (forcingGroup % forcingCycleUse) then
@@ -1230,7 +1231,7 @@ contains
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  advance_forcing_clock
+!  mpas_advance_forcing_clock
 !
 !> \brief set the forcing clock
 !> \author Adrian K. Turner, LANL
@@ -1241,7 +1242,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine advance_forcing_clock(&!{{{
+  subroutine mpas_advance_forcing_clock(&!{{{
        forcingGroup, &
        dt)
 
@@ -1254,11 +1255,44 @@ contains
     type(MPAS_TimeInterval_type) :: &
          timeStep ! time step interval
 
+    ! assuming it is not possible to give dts of months or years
+    integer :: DD, H, M, S, S_n, S_d, foundNumAndDen, powerOfTen
+
+    real(kind=RKIND) :: factor
+
+    DD = dt / 86400_RKIND
+    H = dt / 3600_RKIND
+    M = dt / 60_RKIND
+    S = dt
+    S_n = 0
+    S_d = 0
+    if (abs(real(S) - dt) > 1.e-10) then !the time step has decimals
+       S = 0
+       foundNumAndDen = 0
+       powerOfTen = 1
+       factor = 10_RKIND
+       S_n = abs(dt) * factor
+       S_d = factor
+       do while (foundNumAndDen == 0 .and. powerOfTen < 11) 
+          if (abs(real(S_n)/real(S_d) - abs(dt)) < 1.e-10) then
+             foundNumAndDen = 1
+          else 
+             powerOfTen = powerOfTen + 1
+             factor = 10_RKIND ** powerOfTen
+             S_n = abs(dt) * factor
+             S_d = factor
+          end if
+       end do
+       if (dt < 0.0_RKIND) then
+          S_n = - S_n
+       end if
+    end if
+
     ! increment clock with timestep
-    call mpas_set_timeInterval(timeStep, dt=dt)
+    call mpas_set_timeInterval(timeStep, DD=DD, H=H, M=M, S=S, S_n=S_n, S_d=S_d)
     call mpas_advance_clock(forcingGroup % forcingClock, timeStep)
 
-  end subroutine advance_forcing_clock!}}}
+  end subroutine mpas_advance_forcing_clock!}}}
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-framework/src/framework/mpas_forcing.F
+++ b/components/mpas-framework/src/framework/mpas_forcing.F
@@ -1255,41 +1255,44 @@ contains
     type(MPAS_TimeInterval_type) :: &
          timeStep ! time step interval
 
-    ! assuming it is not possible to give dts of months or years
-    integer :: DD, H, M, S, S_n, S_d, foundNumAndDen, powerOfTen
+    !! assuming it is not possible to give dts of months or years
+    !integer :: DD, H, M, S, S_n, S_d, foundNumAndDen, powerOfTen
 
-    real(kind=RKIND) :: factor
+    !real(kind=RKIND) :: factor
 
-    DD = dt / 86400_RKIND
-    H = dt / 3600_RKIND
-    M = dt / 60_RKIND
-    S = dt
-    S_n = 0
-    S_d = 0
-    if (abs(real(S) - dt) > 1.e-10) then !the time step has decimals
-       S = 0
-       foundNumAndDen = 0
-       powerOfTen = 1
-       factor = 10_RKIND
-       S_n = abs(dt) * factor
-       S_d = factor
-       do while (foundNumAndDen == 0 .and. powerOfTen < 11) 
-          if (abs(real(S_n)/real(S_d) - abs(dt)) < 1.e-10) then
-             foundNumAndDen = 1
-          else 
-             powerOfTen = powerOfTen + 1
-             factor = 10_RKIND ** powerOfTen
-             S_n = abs(dt) * factor
-             S_d = factor
-          end if
-       end do
-       if (dt < 0.0_RKIND) then
-          S_n = - S_n
-       end if
-    end if
+    !DD = dt / 86400_RKIND
+    !H = dt / 3600_RKIND
+    !M = dt / 60_RKIND
+    !S = dt
+    !S_n = 0
+    !S_d = 0
+    !if (abs(real(S) - dt) > 1.e-10) then !the time step has decimals
+    !   S = 0
+    !   foundNumAndDen = 0
+    !   powerOfTen = 1
+    !   factor = 10_RKIND
+    !   S_n = abs(dt) * factor
+    !   S_d = factor
+    !   do while (foundNumAndDen == 0 .and. powerOfTen < 11) 
+    !      if (abs(real(S_n)/real(S_d) - abs(dt)) < 1.e-10) then
+    !         foundNumAndDen = 1
+    !      else 
+    !         powerOfTen = powerOfTen + 1
+    !         factor = 10_RKIND ** powerOfTen
+    !         S_n = abs(dt) * factor
+    !         S_d = factor
+    !      end if
+    !   end do
+    !   if (dt < 0.0_RKIND) then
+    !      S_n = - S_n
+    !   end if
+    !end if
 
     ! increment clock with timestep
-    call mpas_set_timeInterval(timeStep, DD=DD, H=H, M=M, S=S, S_n=S_n, S_d=S_d)
+    ! call mpas_set_timeInterval(timeStep, DD=DD, H=H, M=M, S=S, S_n=S_n, S_d=S_d)
+    call mpas_set_timeInterval(timeStep, dt=dt)
+    !call mpas_log_write('jl time step $i $i $i', intArgs=(/S, S_n, S_d /))
+    !call mpas_log_write('time step $i $i $i', intArgs=(/int(timeStep%ti%basetime%S), int(timeStep%ti%basetime%Sn), int(timeStep%ti%basetime%Sd) /))
     call mpas_advance_clock(forcingGroup % forcingClock, timeStep)
 
   end subroutine mpas_advance_forcing_clock!}}}
@@ -1631,8 +1634,10 @@ contains
     call mpas_get_timeInterval(diff1, forcingStream % forcingTimes(1), dt=diffr1)
     call mpas_get_timeInterval(diff2, currentTime, dt=diffr2)
 
+    !call mpas_log_write('diffr2 $r, diffr, $r', realArgs=(/ diffr2, diffr /))
     interpolants(1) = diffr2 / diffr
     interpolants(2) = 1.0_RKIND - interpolants(1) !diffr1 / diffr
+    
 
   end subroutine get_interpolants_linear!}}}
 
@@ -1646,7 +1651,7 @@ contains
 !> \details
 !>  Given the current time and forcing times calculate the correct
 !>  interpolants with piecewise constant interpolation
-!
+
 !-----------------------------------------------------------------------
 
   subroutine get_interpolants_constant(interpolants, forcingStream, currentTime)!{{{

--- a/components/mpas-framework/src/framework/mpas_forcing.F
+++ b/components/mpas-framework/src/framework/mpas_forcing.F
@@ -1255,44 +1255,9 @@ contains
     type(MPAS_TimeInterval_type) :: &
          timeStep ! time step interval
 
-    !! assuming it is not possible to give dts of months or years
-    !integer :: DD, H, M, S, S_n, S_d, foundNumAndDen, powerOfTen
-
-    !real(kind=RKIND) :: factor
-
-    !DD = dt / 86400_RKIND
-    !H = dt / 3600_RKIND
-    !M = dt / 60_RKIND
-    !S = dt
-    !S_n = 0
-    !S_d = 0
-    !if (abs(real(S) - dt) > 1.e-10) then !the time step has decimals
-    !   S = 0
-    !   foundNumAndDen = 0
-    !   powerOfTen = 1
-    !   factor = 10_RKIND
-    !   S_n = abs(dt) * factor
-    !   S_d = factor
-    !   do while (foundNumAndDen == 0 .and. powerOfTen < 11) 
-    !      if (abs(real(S_n)/real(S_d) - abs(dt)) < 1.e-10) then
-    !         foundNumAndDen = 1
-    !      else 
-    !         powerOfTen = powerOfTen + 1
-    !         factor = 10_RKIND ** powerOfTen
-    !         S_n = abs(dt) * factor
-    !         S_d = factor
-    !      end if
-    !   end do
-    !   if (dt < 0.0_RKIND) then
-    !      S_n = - S_n
-    !   end if
-    !end if
-
     ! increment clock with timestep
-    ! call mpas_set_timeInterval(timeStep, DD=DD, H=H, M=M, S=S, S_n=S_n, S_d=S_d)
     call mpas_set_timeInterval(timeStep, dt=dt)
-    !call mpas_log_write('jl time step $i $i $i', intArgs=(/S, S_n, S_d /))
-    !call mpas_log_write('time step $i $i $i', intArgs=(/int(timeStep%ti%basetime%S), int(timeStep%ti%basetime%Sn), int(timeStep%ti%basetime%Sd) /))
+    !call mpas_log_write('time step from mpas_set_timeInterval: $i $i $i', intArgs=(/int(timeStep%ti%basetime%S), int(timeStep%ti%basetime%Sn), int(timeStep%ti%basetime%Sd) /))
     call mpas_advance_clock(forcingGroup % forcingClock, timeStep)
 
   end subroutine mpas_advance_forcing_clock!}}}

--- a/components/mpas-framework/src/framework/mpas_timekeeping.F
+++ b/components/mpas-framework/src/framework/mpas_timekeeping.F
@@ -1427,6 +1427,8 @@ module mpas_timekeeping
             timeString_ = timeString
          end if
 
+         !call mpas_log_write('timeString_ '//trim(timeString_))
+
          numerator = 0
          denominator = 1
 
@@ -1518,6 +1520,12 @@ module mpas_timekeeping
             call mpas_log_write('Invalid TimeInterval string (invalid time substring) ' // trim(timeString), MPAS_LOG_ERR)
             return
          end if
+
+         if (sec < 0) then
+            numerator = -numerator
+         end if
+
+         !call mpas_log_write('sec $i, num $i, denom $i', intArgs=(/int(sec),numerator,denominator/))
 
          call ESMF_TimeIntervalSet(interval % ti, YY=year, MM=month, D=day, H=hour, M=min, S_i8=sec, Sn=numerator, Sd=denominator, rc=ierr)
 

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -4130,6 +4130,10 @@
 			 description="Multiplication factors to smooth ssh at coastlines for SAL caculation"
 			 packages="tidalPotentialForcingPKG"
 		/>
+               	<var name="forcingTimeIncrement" type="real" dimensions="" units="s"
+			description="Time increment to compute forcing terms at intermediate time intervals"
+			packages="forwardMode"
+		/>
 	</var_struct>
 	<var_struct name="timeVaryingForcing" time_levs="1">
 		<var name="windSpeedU" type="real" dimensions="nCells Time" units="m s^-1"

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -26,6 +26,7 @@ module ocn_forward_mode
    use mpas_stream_manager
    use mpas_timekeeping
    use mpas_dmpar
+   use mpas_forcing
    use mpas_timer
    use mpas_log
    use mpas_decomp
@@ -94,6 +95,7 @@ module ocn_forward_mode
 
    use ocn_forcing
    use ocn_time_varying_forcing
+   use ocn_framework_forcing
 
    use ocn_constants
    use ocn_config
@@ -664,7 +666,12 @@ module ocn_forward_mode
 
       ! initialize time-varying forcing
       call ocn_time_varying_forcing_init(domain)
-      call ocn_time_varying_forcing_get(domain % streamManager, domain, domain % clock)
+
+      ! if not using RK4, calculate time varying forcing terms once per
+      ! time-step as opposed at each RK substage as implemented in RK4 
+      if (timeIntegratorChoice /= 4) then
+        call ocn_time_varying_forcing_get(domain % streamManager, domain, domain % clock)
+      endif
 
       ! During integration, time level 1 stores the model state at the beginning of the
       !   time step, and time level 2 stores the state advanced dt in time by timestep(...)
@@ -834,7 +841,14 @@ module ocn_forward_mode
          endif
 
          ! read in next time level data required for time-varying forcing
-         call ocn_time_varying_forcing_get(domain % streamManager, domain, domain % clock)
+         if (timeIntegratorChoice /= 4) then
+           ! if not using RK4, calculate time varying forcing terms once per
+           ! time-step as opposed at each RK substage as implemented in RK4
+           call ocn_time_varying_forcing_get(domain % streamManager, domain, domain % clock)
+         else
+           ! increment forcing clock to next time-step
+           call mpas_advance_forcing_clock(forcingGroupHead, dt)
+         endif
 
          ! Validate that the state is OK to run with for the next timestep.
          call ocn_validate_state(domain, timeLevel=1)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -846,8 +846,11 @@ module ocn_forward_mode
            ! time-step as opposed at each RK substage as implemented in RK4
            call ocn_time_varying_forcing_get(domain % streamManager, domain, domain % clock)
          else
-           ! increment forcing clock to next time-step
-           call mpas_advance_forcing_clock(forcingGroupHead, dt)
+           if (config_use_time_varying_atmospheric_forcing .or. &
+               config_use_time_varying_land_ice_forcing) then
+             ! increment forcing clock to next time-step
+             call mpas_advance_forcing_clock(forcingGroupHead, dt)
+           endif
          endif
 
          ! Validate that the state is OK to run with for the next timestep.

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -669,7 +669,7 @@ module ocn_forward_mode
 
       ! if not using RK4, calculate time varying forcing terms once per
       ! time-step as opposed at each RK substage as implemented in RK4 
-      if (timeIntegratorChoice /= 4) then
+      if (timeIntegratorChoice /= timeIntRK4) then
         call ocn_time_varying_forcing_get(domain % streamManager, domain, domain % clock)
       endif
 
@@ -841,7 +841,7 @@ module ocn_forward_mode
          endif
 
          ! read in next time level data required for time-varying forcing
-         if (timeIntegratorChoice /= 4) then
+         if (timeIntegratorChoice /= timeIntRK4) then
            ! if not using RK4, calculate time varying forcing terms once per
            ! time-step as opposed at each RK substage as implemented in RK4
            call ocn_time_varying_forcing_get(domain % streamManager, domain, domain % clock)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration.F
@@ -48,6 +48,9 @@ module ocn_time_integration
    !
    !--------------------------------------------------------------------
 
+    ! Enum for selecting different time integrators
+    integer, public :: timeIntegratorChoice
+
    !--------------------------------------------------------------------
    !
    ! Public member functions
@@ -62,9 +65,6 @@ module ocn_time_integration
    ! Private module variables
    !
    !--------------------------------------------------------------------
-
-    ! Enum for selecting different time integrators
-    integer :: timeIntegratorChoice
 
     integer, parameter :: &
        timeIntUnknown          = 0, &! unknown or undefined

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration.F
@@ -51,6 +51,16 @@ module ocn_time_integration
     ! Enum for selecting different time integrators
     integer, public :: timeIntegratorChoice
 
+    integer, public, parameter :: &
+       timeIntUnknown          = 0, &! unknown or undefined
+       timeIntSplitExplicit    = 1, &! split-explicit
+       timeIntUnsplitExplicit  = 2, &! unsplit-explicit
+       timeIntSemiImplicit     = 3, &! Semi-implicit
+       timeIntRK4              = 4, &! 4th-order Runge-Kutta
+       timeIntLTS              = 5, &! local time-stepping
+       timeIntFBLTS            = 6, &! forward-backward lts
+       timeIntSplitExplicitAB2 = 7   ! split-explicit AB2 baroclinic
+
    !--------------------------------------------------------------------
    !
    ! Public member functions
@@ -66,15 +76,6 @@ module ocn_time_integration
    !
    !--------------------------------------------------------------------
 
-    integer, parameter :: &
-       timeIntUnknown          = 0, &! unknown or undefined
-       timeIntSplitExplicit    = 1, &! split-explicit
-       timeIntUnsplitExplicit  = 2, &! unsplit-explicit
-       timeIntSemiImplicit     = 3, &! Semi-implicit
-       timeIntRK4              = 4, &! 4th-order Runge-Kutta
-       timeIntLTS              = 5, &! local time-stepping
-       timeIntFBLTS            = 6, &! forward-backward lts
-       timeIntSplitExplicitAB2 = 7   ! split-explicit AB2 baroclinic
 
 !***********************************************************************
 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -43,6 +43,7 @@ module ocn_time_integration_rk4
    use ocn_effective_density_in_land_ice
    use ocn_surface_land_ice_fluxes
    use ocn_transport_tests
+   use ocn_time_varying_forcing
 
    use ocn_subgrid
 
@@ -491,6 +492,8 @@ module ocn_time_integration_rk4
         ! In RK4 notation, we are computing the right hand side f(t,y),
         ! which is the same as k_j / h.
         call mpas_timer_start("RK4 vel/thick tendency computations")
+
+       call ocn_time_varying_forcing_get(domain % streamManager, domain, domain % clock)
 
         block => domain % blocklist
         do while (associated(block))

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -118,7 +118,7 @@ module ocn_time_integration_rk4
 
       type (mpas_pool_type), pointer :: nextProvisPool, prevProvisPool
 
-      real (kind=RKIND), dimension(4) :: rk_weights, rk_substep_weights
+      real (kind=RKIND), dimension(4) :: rk_weights, rk_substep_weights, forcingTimeIncrementRK4
 
       real (kind=RKIND) :: coef
       real (kind=RKIND), dimension(:,:), pointer :: &
@@ -186,6 +186,7 @@ module ocn_time_integration_rk4
       ! Tidal boundary condition
       logical, pointer :: config_use_tidal_forcing
       character (len=StrKIND), pointer :: config_tidal_forcing_type
+      real (kind=RKIND), pointer :: forcingTimeIncrement
       real (kind=RKIND), dimension(:), pointer :: tidalInputMask, tidalBCValue
       real (kind=RKIND), dimension(:,:), pointer :: restingThickness
       real (kind=RKIND) :: totalDepth
@@ -233,6 +234,7 @@ module ocn_time_integration_rk4
          call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
+         call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
 
          call mpas_pool_get_subpool(block % structs, 'provis_state', provisStatePool)
 
@@ -260,6 +262,9 @@ module ocn_time_integration_rk4
          call mpas_pool_get_array(meshPool, 'subgridSshCellTableRange', &
                                 subgridSshCellTableRange)
 
+         call mpas_pool_get_array(forcingPool, 'forcingTimeIncrement', forcingTimeIncrement)
+
+         forcingTimeIncrement = 0.0_RKIND
 
          ! Lower k-loop limit of 1 rather than minLevel* needed in *New = *Cur
          ! assignments below are needed to maintain bit-for-bit results
@@ -359,6 +364,14 @@ module ocn_time_integration_rk4
       rk_substep_weights(2) = dt/2.
       rk_substep_weights(3) = dt
       rk_substep_weights(4) = dt ! a_4 only used for ALE step, otherwise it is skipped.
+
+      ! these are time increments to evaluate the tidal forcing at the
+      ! intermediate time-steps as required by RK4
+
+      forcingTimeIncrementRK4(1) = 0.0_RKIND
+      forcingTimeIncrementRK4(2) = dt/2.
+      forcingTimeIncrementRK4(3) = dt/2.
+      forcingTimeIncrementRK4(4) = dt
 
       call mpas_timer_start("RK4-main loop")
 
@@ -481,6 +494,10 @@ module ocn_time_integration_rk4
 
         block => domain % blocklist
         do while (associated(block))
+           call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
+           call mpas_pool_get_array(forcingPool, 'forcingTimeIncrement', forcingTimeIncrement)
+           forcingTimeIncrement = forcingTimeIncrementRK4(rk_step)
+           
            call ocn_time_integrator_rk4_compute_vel_tends(domain, block, dt, rk_substep_weights(rk_step), domain % dminfo, err )
 
            call ocn_time_integrator_rk4_compute_thick_tends( block, dt, rk_substep_weights(rk_step), err )

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -493,16 +493,19 @@ module ocn_time_integration_rk4
         ! which is the same as k_j / h.
         call mpas_timer_start("RK4 vel/thick tendency computations")
 
-       call ocn_time_varying_forcing_get(domain % streamManager, domain, domain % clock)
-
         block => domain % blocklist
         do while (associated(block))
            call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
            call mpas_pool_get_array(forcingPool, 'forcingTimeIncrement', forcingTimeIncrement)
            forcingTimeIncrement = forcingTimeIncrementRK4(rk_step)
-           
-           call ocn_time_integrator_rk4_compute_vel_tends(domain, block, dt, rk_substep_weights(rk_step), domain % dminfo, err )
+           block => block % next
+        end do
 
+        call ocn_time_varying_forcing_get(domain % streamManager, domain, domain % clock)
+
+        block => domain % blocklist
+        do while (associated(block))
+           call ocn_time_integrator_rk4_compute_vel_tends(domain, block, dt, rk_substep_weights(rk_step), domain % dminfo, err )
            call ocn_time_integrator_rk4_compute_thick_tends( block, dt, rk_substep_weights(rk_step), err )
            block => block % next
         end do

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_rk4.F
@@ -349,10 +349,10 @@ module ocn_time_integration_rk4
       ! The coefficients of k_j are b_j = (1/6, 1/3, 1/3, 1/6) and are
       ! initialized here as delta t * b_j:
 
-      rk_weights(1) = dt/6.
-      rk_weights(2) = dt/3.
-      rk_weights(3) = dt/3.
-      rk_weights(4) = dt/6.
+      rk_weights(1) = dt/6.0_RKIND
+      rk_weights(2) = dt/3.0_RKIND
+      rk_weights(3) = dt/3.0_RKIND
+      rk_weights(4) = dt/6.0_RKIND
 
       ! The a_j coefficients of h in the computation of k_j are typically written (0, 1/2, 1/2, 1).
       ! However, in the algorithm below we pre-compute the state for the tendency one iteration early.
@@ -361,8 +361,8 @@ module ocn_time_integration_rk4
       ! That is why the coefficients of h are one index early in the following, i.e.
       ! a = (1/2, 1/2, 1)
 
-      rk_substep_weights(1) = dt/2.
-      rk_substep_weights(2) = dt/2.
+      rk_substep_weights(1) = dt/2.0_RKIND
+      rk_substep_weights(2) = dt/2.0_RKIND
       rk_substep_weights(3) = dt
       rk_substep_weights(4) = dt ! a_4 only used for ALE step, otherwise it is skipped.
 
@@ -370,8 +370,8 @@ module ocn_time_integration_rk4
       ! intermediate time-steps as required by RK4
 
       forcingTimeIncrementRK4(1) = 0.0_RKIND
-      forcingTimeIncrementRK4(2) = dt/2.
-      forcingTimeIncrementRK4(3) = dt/2.
+      forcingTimeIncrementRK4(2) = dt/2.0_RKIND
+      forcingTimeIncrementRK4(3) = dt/2.0_RKIND
       forcingTimeIncrementRK4(4) = dt
 
       call mpas_timer_start("RK4-main loop")

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -380,6 +380,8 @@ module ocn_time_integration_si
 
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracersNew
 
+      real (kind=RKIND), pointer :: forcingTimeIncrement
+
       ! Remap variables
       real (kind=RKIND), dimension(:,:), pointer :: &
          layerThicknessLagNew
@@ -506,6 +508,11 @@ module ocn_time_integration_si
                                           lowFreqDivergenceTend)
 
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracersNew, 2)
+
+      call mpas_pool_get_array(forcingPool, 'forcingTimeIncrement', &
+                                             forcingTimeIncrement)
+
+      forcingTimeIncrement = 0.0_RKIND
 
       allocate(bottomDepthEdge(nEdgesAll+1))
 

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -280,6 +280,8 @@ module ocn_time_integration_split
 
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracersNew
 
+      real (kind=RKIND), pointer :: forcingTimeIncrement
+
       ! Remap variables
       real (kind=RKIND), dimension(:,:), pointer :: &
          layerThicknessLagNew
@@ -397,6 +399,11 @@ module ocn_time_integration_split
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracersNew, 2)
 
       allocate(baroclinicThickness(nEdgesAll+1))
+
+      call mpas_pool_get_array(forcingPool, 'forcingTimeIncrement', &
+                                             forcingTimeIncrement)
+
+      forcingTimeIncrement = 0.0_RKIND
 
       if (config_transport_tests_flow_id > 0) then
         ! This is a transport test. Write advection velocity from prescribed

--- a/components/mpas-ocean/src/shared/mpas_ocn_manufactured_solution.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_manufactured_solution.F
@@ -76,7 +76,13 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_manufactured_solution_tend_thick(tend, err)!{{{
+   subroutine ocn_manufactured_solution_tend_thick(forcingPool, tend, err)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: forcingPool
 
       !-----------------------------------------------------------------
       ! input/output variables
@@ -97,6 +103,7 @@ contains
 
       integer :: iCell, kmin, kmax, k
       real (kind=RKIND) :: phase, time
+      real (kind=RKIND), pointer :: forcingTimeIncrement
 
       ! End preamble
       !-------------
@@ -104,7 +111,9 @@ contains
 
       if (.not. config_use_manufactured_solution) return
 
-      time = daysSinceStartOfSim*86400.0_RKIND
+      call mpas_pool_get_array(forcingPool, 'forcingTimeIncrement', forcingTimeIncrement) 
+
+      time = daysSinceStartOfSim*86400.0_RKIND + forcingTimeIncrement 
 
       do iCell = 1,nCellsOwned
 
@@ -137,7 +146,13 @@ contains
 !>  This routine computes the velocity tendency for the manufactured solution
 !
 !-----------------------------------------------------------------------
-   subroutine ocn_manufactured_solution_tend_vel(tend, err)!{{{
+   subroutine ocn_manufactured_solution_tend_vel(forcingPool, tend, err)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: forcingPool
 
       !-----------------------------------------------------------------
       ! input/output variables
@@ -158,6 +173,7 @@ contains
 
       integer :: iEdge, kmin, kmax, k
       real (kind=RKIND) :: phase, u, v, time
+      real (kind=RKIND), pointer :: forcingTimeIncrement
 
       ! End preamble
       !-----------------------------------------------------------------
@@ -165,7 +181,9 @@ contains
 
       if (.not. config_use_manufactured_solution) return
 
-      time = daysSinceStartOfSim*86400.0_RKIND
+      call mpas_pool_get_array(forcingPool, 'forcingTimeIncrement', forcingTimeIncrement) 
+
+      time = daysSinceStartOfSim*86400.0_RKIND + forcingTimeIncrement 
 
       do iEdge = 1, nEdgesOwned
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
@@ -264,7 +264,8 @@ contains
                                              tendThick, err)
 
       ! Compute thickness tendency to manufactured solution
-      call ocn_manufactured_solution_tend_thick(tendThick, err)
+      call ocn_manufactured_solution_tend_thick(forcingPool, &
+                                                tendThick, err)
 
 #ifdef MPAS_OPENACC
       !$acc exit data copyout(tendThick, surfaceThicknessFlux, surfaceThicknessFluxRunoff, &
@@ -493,7 +494,8 @@ contains
                                 layerThickEdgeMean, tendVel, err)
  
       ! Compute tendency term for manufactured solution
-      call ocn_manufactured_solution_tend_vel(tendVel, err)
+      call ocn_manufactured_solution_tend_vel(forcingPool, &
+                                              tendVel, err)
 
       ! vertical mixing treated implicitly in a later routine
       ! adjust total velocity tendency based on wetting/drying

--- a/components/mpas-ocean/src/shared/mpas_ocn_time_varying_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_time_varying_forcing.F
@@ -286,7 +286,7 @@ contains
          "ocn_atmospheric_forcing", &      ! forcingGroupName
          currentForcingTime)               ! forcingTime
     call mpas_get_time(curr_time=currentForcingTime, dateTimeString=timeStamp, ierr=err)
-    call mpas_log_write('Forcing time for atmospheric forcing' // trim(timeStamp))
+    !call mpas_log_write('Forcing time for atmospheric forcing' // trim(timeStamp))
 
     call mpas_advance_forcing_clock(forcingGroupHead, dtSimReverse)
 
@@ -296,7 +296,7 @@ contains
          currentForcingTime)               ! forcingTime
 
     call mpas_get_time(curr_time=currentForcingTime, dateTimeString=timeStamp, ierr=err)
-    call mpas_log_write('Forcing time reversed for atmospheric forcing' // trim(timeStamp))
+    !call mpas_log_write('Forcing time reversed for atmospheric forcing' // trim(timeStamp))
 
     ! perform post forcing
     block => domain % blocklist

--- a/components/mpas-ocean/src/shared/mpas_ocn_time_varying_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_time_varying_forcing.F
@@ -258,13 +258,21 @@ contains
 
     character(len=StrKIND) :: timeStamp
 
-    real (kind=RKIND) :: dtSim
+    real (kind=RKIND) :: dtSim, dtSimReverse
+
+    real (kind=RKIND), pointer :: forcingTimeIncrement
+
+    type (mpas_pool_type), pointer :: forcingPool
 
     integer :: err
 
+    call mpas_pool_get_subpool(domain % blocklist % structs, 'forcing', forcingPool)
+    call mpas_pool_get_array(forcingPool, 'forcingTimeIncrement', forcingTimeIncrement)    
+
     ! convert config_dt to real
     call mpas_set_timeInterval(timeStepESMF, timeString=config_dt,ierr=err)
-    call mpas_get_timeInterval(timeStepESMF, dt=dtSim)
+    dtSim = forcingTimeIncrement
+    dtSimReverse = -dtSim
 
     ! use the forcing layer to get data
     call MPAS_forcing_get_forcing(&
@@ -277,8 +285,18 @@ contains
          forcingGroupHead, &               ! forcingGroupHead
          "ocn_atmospheric_forcing", &      ! forcingGroupName
          currentForcingTime)               ! forcingTime
-    !call mpas_get_time(curr_time=currentForcingTime, dateTimeString=timeStamp, ierr=err)
-    !call mpas_log_write('Forcing time ' // trim(timeStamp))
+    call mpas_get_time(curr_time=currentForcingTime, dateTimeString=timeStamp, ierr=err)
+    call mpas_log_write('Forcing time for atmospheric forcing' // trim(timeStamp))
+
+    call mpas_advance_forcing_clock(forcingGroupHead, dtSimReverse)
+
+    call MPAS_forcing_get_forcing_time(&
+         forcingGroupHead, &               ! forcingGroupHead
+         "ocn_atmospheric_forcing", &      ! forcingGroupName
+         currentForcingTime)               ! forcingTime
+
+    call mpas_get_time(curr_time=currentForcingTime, dateTimeString=timeStamp, ierr=err)
+    call mpas_log_write('Forcing time reversed for atmospheric forcing' // trim(timeStamp))
 
     ! perform post forcing
     block => domain % blocklist
@@ -332,7 +350,10 @@ contains
          windStressCoefficient, &
          rhoAir, &
          ramp, &
-         windStressCoefficientLimit
+         windStressCoefficientLimit, &
+         t
+
+    real(kind=RKIND), pointer :: forcingTimeIncrement
 
     integer, pointer :: &
          nCells
@@ -354,12 +375,14 @@ contains
 
     call MPAS_pool_get_array(timeVaryingForcingPool, "atmosPressure", atmosPressure)
     call MPAS_pool_get_array(forcingPool, "atmosphericPressure", atmosphericPressure)
+    call mpas_pool_get_array(forcingPool, 'forcingTimeIncrement', forcingTimeIncrement)
 
     rhoAir = 1.225_RKIND
     windStressCoefficientLimit = 0.0035_RKIND
 
     if (daysSinceStartOfSim >= config_time_varying_atmospheric_forcing_ramp_delay) then
-      ramp = tanh((2.0_RKIND*(daysSinceStartOfSim-config_time_varying_atmospheric_forcing_ramp_delay)) &
+      t = (daysSinceStartOfSim*86400_RKIND + forcingTimeIncrement)/86400.0_RKIND
+      ramp = tanh((2.0_RKIND*(t-config_time_varying_atmospheric_forcing_ramp_delay)) &
                               /config_time_varying_atmospheric_forcing_ramp)
     else
       ramp = 0.0_RKIND
@@ -483,11 +506,13 @@ contains
 
     type (block_type), pointer :: block
 
-!    character(len=StrKIND), pointer :: config_dt
+    character(len=StrKIND) :: timeStamp
 
     type (MPAS_timeInterval_type) :: timeStepESMF
 
-    real (kind=RKIND) :: dtSim
+    real (kind=RKIND) :: dtSim, dtSimReverse
+
+    real (kind=RKIND), pointer :: forcingTimeIncrement
 
     integer :: err
 
@@ -512,14 +537,41 @@ contains
     integer :: &
          iCell
 
+    call mpas_pool_get_subpool(domain % blocklist % structs, 'forcing', forcingPool)
+    call mpas_pool_get_array(forcingPool, 'forcingTimeIncrement', forcingTimeIncrement)
+
     ! convert config_dt to real
     call mpas_set_timeInterval(timeStepESMF, timeString=config_dt,ierr=err)
     call mpas_get_timeInterval(timeStepESMF, dt=dtSim)
 
-    ! use the forcing layer to get data
-    call mpas_forcing_get_forcing(forcingGroupHead, "ocn_land_ice_forcing", streamManager, dtSim)
+    dtSim = forcingTimeIncrement
+    dtSimReverse = -dtSim
 
-    call mpas_forcing_get_forcing_time(forcingGroupHead, "ocn_land_ice_forcing", currentForcingTime)
+    ! use the forcing layer to get data
+    call MPAS_forcing_get_forcing(&
+         forcingGroupHead, &               ! forcingGroupHead
+         "ocn_land_ice_forcing", &         ! forcingGroupName
+         streamManager, &                  ! streamManager
+         dtSim)                            ! dt
+
+    call MPAS_forcing_get_forcing_time(&
+         forcingGroupHead, &               ! forcingGroupHead
+         "ocn_land_ice_forcing", &         ! forcingGroupName
+         currentForcingTime)               ! forcingTime
+
+    call mpas_get_time(curr_time=currentForcingTime, dateTimeString=timeStamp, ierr=err)
+    call mpas_log_write('Forcing time for land ice forcing' // trim(timeStamp))
+
+
+    call mpas_advance_forcing_clock(forcingGroupHead, dtSimReverse)
+
+    call MPAS_forcing_get_forcing_time(&
+         forcingGroupHead, &               ! forcingGroupHead
+         "ocn_land_ice_forcing", &         ! forcingGroupName
+         currentForcingTime)               ! forcingTime
+
+    call mpas_get_time(curr_time=currentForcingTime, dateTimeString=timeStamp, ierr=err)
+    call mpas_log_write('Forcing time reversed for land ice forcing' // trim(timeStamp))
 
     block => domain % blocklist
     do while (associated(block))

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_tidal_potential.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_tidal_potential.F
@@ -80,6 +80,8 @@ module ocn_vel_tidal_potential
       tidalConstituentAstronomical,   &!
       tidalConstituentNodalPhase       !
 
+   real (kind=RKIND), pointer :: forcingTimeIncrement
+
    real (kind=RKIND), dimension(:,:), pointer :: &
       latitudeFunction 
 
@@ -273,8 +275,8 @@ contains
       err = 0
       if (tidalPotentialOff) return
 
-      ramp = tanh((2.0_RKIND*daysSinceStartOfSim)/tidalPotRamp)
-      t = daysSinceStartOfSim*86400.0_RKIND
+      t = daysSinceStartOfSim*86400.0_RKIND + forcingTimeIncrement
+      ramp = tanh((2.0_RKIND*t/86400.0_RKIND)/tidalPotRamp)
 
       do iCell = 1, nCellsAll
          tidalPotEta(iCell) = 0.0_RKIND
@@ -416,6 +418,9 @@ contains
          call mpas_pool_get_array(forcingPool, &
                             'tidalPotentialLatitudeFunction', &
                             latitudeFunction)
+         call mpas_pool_get_array(forcingPool, &
+                            'forcingTimeIncrement', &
+                            forcingTimeIncrement)
 
          call mpas_set_time(refTime, &
                dateTimeString=config_tidal_potential_reference_time)


### PR DESCRIPTION
This PR corrects a longstanding issue with RK4 and tendency terms which have an explicit time dependence (see https://github.com/E3SM-Project/E3SM/issues/5364 and https://github.com/MPAS-Dev/MPAS-Model/issues/375). Big thanks to @gcapodag and @jeremy-lilly for providing the fix in their LTS development branch linked in https://github.com/E3SM-Project/E3SM/issues/5364.

Here, I have migrated these changes from their MPAS-Dev branch to E3SM and added the modifications to correct the convergence issues for the manufactured solution test case: https://github.com/E3SM-Project/polaris/pull/72

[BFB] (for all standard E3SM tests)