### PR TITLE
Fixes bugs in CMix/KPP interface

### DIFF
--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2008,6 +2008,7 @@
 			<var name="normalBarotropicVelocity"/>
 			<var name="vertCoordMovementWeights"/>
 			<var name="xtime"/>
+			<var_array name="nonLocalSurfaceTracerFlux"/>
 			<var name="simulationStartTime"/>
 			<var name="landIcePressure"/>
 			<var name="landIceDraft"/>

--- a/components/mpas-ocean/src/shared/Makefile
+++ b/components/mpas-ocean/src/shared/Makefile
@@ -157,7 +157,7 @@ mpas_ocn_tracer_short_wave_absorption_variable.o: mpas_ocn_constants.o mpas_ocn_
 
 mpas_ocn_tracer_short_wave_absorption_jerlov.o: mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_vmix.o: mpas_ocn_vmix_cvmix.o mpas_ocn_vmix_coefs_redi.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o mpas_ocn_vmix_gotm.o
+mpas_ocn_vmix.o: mpas_ocn_vmix_cvmix.o mpas_ocn_vmix_coefs_redi.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o mpas_ocn_vmix_gotm.o mpas_ocn_diagnostics.o
 
 mpas_ocn_vmix_cvmix.o:  mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o mpas_ocn_mesh.o mpas_ocn_stokes_drift.o
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -3353,7 +3353,7 @@ contains
       !-----------------------------------------------------------------
 
       integer :: &
-         iCell, iEdge, i, &! loop indices for cell, edge, neighbors
+         iCell, iEdge, i, k, &! loop indices for cell, edge, neighbors
          kmin,               &! topmost active cell index
          nCells,             &! number of cells
          err,                &! local error code
@@ -3362,6 +3362,9 @@ contains
       real (kind=RKIND) :: &
          fracAbsorbed,       &! fraction of sfc flux absorbed
          fracAbsorbedRunoff, &! same for runoff
+         fracAbsorbedSubglacialRunoff, &! same for subglacial runoff
+         zTop,zBot,          &! temporary variables
+         transmissionCoeffTop,transmissionCoeffBot,     &! temporary variables
          sumSurfaceStressSquared ! sum of sfc stress squared
 
       ! pointers for variable/pool retrievals

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -64,7 +64,7 @@ module ocn_diagnostics
              ocn_fuperp, &
              ocn_filter_btr_mode_tend_vel, &
              ocn_reconstruct_eddy_vectors, &
-             ocn_compute_kpp_input_fields, &
+             ocn_compute_mixing_input_fields, &
              ocn_validate_state, &
              ocn_build_log_filename, &
              ocn_diagnostics_init
@@ -3319,12 +3319,12 @@ contains
 
 !***********************************************************************
 !
-!  routine ocn_compute_KPP_input_fields
+!  routine ocn_compute_mixing_input_fields
 !
 !> \brief
-!>    Compute fields necessary to drive the CVMix KPP module
-!> \author  Todd Ringler
-!> \date    20 August 2013
+!>    Compute fields necessary to drive the CVMix KPP and gotm modules
+!> \author  Todd Ringler, Luke Van Roekel
+!> \date    11 July 2024
 !> \details
 !>    CVMix/KPP requires the following fields as intent(in):
 !>       surfaceBuoyancyForcing
@@ -3333,7 +3333,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-    subroutine ocn_compute_KPP_input_fields(statePool, forcingPool, &
+    subroutine ocn_compute_mixing_input_fields(statePool, forcingPool, &
                                             meshPool, timeLevelIn)!{{{
 
       !-----------------------------------------------------------------
@@ -3353,7 +3353,7 @@ contains
       !-----------------------------------------------------------------
 
       integer :: &
-         iCell, iEdge, i, k, &! loop indices for cell, edge, neighbors
+         iCell, iEdge, i, &! loop indices for cell, edge, neighbors
          kmin,               &! topmost active cell index
          nCells,             &! number of cells
          err,                &! local error code
@@ -3362,9 +3362,6 @@ contains
       real (kind=RKIND) :: &
          fracAbsorbed,       &! fraction of sfc flux absorbed
          fracAbsorbedRunoff, &! same for runoff
-         fracAbsorbedSubglacialRunoff, &! same for subglacial runoff
-         zTop,zBot,          &! temporary variables
-         transmissionCoeffTop,transmissionCoeffBot,     &! temporary variables
          sumSurfaceStressSquared ! sum of sfc stress squared
 
       ! pointers for variable/pool retrievals
@@ -3385,8 +3382,7 @@ contains
          evapTemperatureFlux, &
          icebergTemperatureFlux, &
          seaIceTemperatureFlux, &
-         surfaceStress, &
-         surfaceStressMagnitude
+         sfcStressMag
 
       real (kind=RKIND), dimension(:,:), pointer ::  &
          layerThickness,           &! layer thickness
@@ -3419,7 +3415,7 @@ contains
       !-----------------------------------------------------------------
       ! Begin code
 
-      call mpas_timer_start('KPP input fields')
+      call mpas_timer_start('Mixing input fields')
 
       if (present(timeLevelIn)) then
          timeLevel = timeLevelIn
@@ -3469,18 +3465,8 @@ contains
                                              surfaceThicknessFluxSubglacialRunoff)
       call mpas_pool_get_array(forcingPool, 'penetrativeTemperatureFlux', &
                                              penetrativeTemperatureFlux)
-      call mpas_pool_get_array(forcingPool, 'surfaceStress', &
-                                             surfaceStress)
       call mpas_pool_get_array(forcingPool, 'surfaceStressMagnitude', &
-                                             surfaceStressMagnitude)
-      call mpas_pool_get_array(forcingPool, 'rainTemperatureFlux', &
-                                             rainTemperatureFlux)
-      call mpas_pool_get_array(forcingPool, 'evapTemperatureFlux', &
-                                             evapTemperatureFlux)
-      call mpas_pool_get_array(forcingPool, 'seaIceTemperatureFlux', &
-                                             seaIceTemperatureFlux)
-      call mpas_pool_get_array(forcingPool, 'icebergTemperatureFlux', &
-                                             icebergTemperatureFlux)
+                                             sfcStressMag)
 
       ! allocate scratch space displaced density computation
       ncells = nCellsAll
@@ -3594,17 +3580,8 @@ contains
                    activeTracersSurfaceFlux(indexTempFlux,iCell) &
                  + penetrativeTemperatureFlux(iCell) &
                  - penetrativeTemperatureFluxOBL(iCell)  &
-                 - fracAbsorbed* (rainTemperatureFlux(iCell) + &
-                                  evapTemperatureFlux(iCell) + &
-                                  seaIceTemperatureFlux(iCell) + &
-                                  icebergTemperatureFlux(iCell)) &
-                 - fracAbsorbedRunoff* &
-                   activeTracersSurfaceFluxRunoff(indexTempFlux,iCell)
-         if (trim(config_subglacial_runoff_mode) == 'data') then
-            nonLocalSurfaceTracerFlux(indexTempFlux, iCell) = nonLocalSurfaceTracerFlux(indexTempFlux, iCell) &
-                 - fracAbsorbedSubglacialRunoff* &
-                   activeTracersSurfaceFluxSubglacialRunoff(indexTempFlux,iCell)
-         end if
+                 - fracAbsorbed*surfaceThicknessFlux(iCell) * &
+                   activeTracers(indexTempFlux,kmin,iCell)
 
          nonLocalSurfaceTracerFlux(indexSaltFlux,iCell) = &
                    activeTracersSurfaceFlux(indexSaltFlux,iCell) &
@@ -3630,21 +3607,8 @@ contains
          surfaceBuoyancyForcing(iCell) = surfaceBuoyancyForcing(iCell)* &
                                          gravity
 
-         ! compute magnitude of surface stress
-         sumSurfaceStressSquared = 0.0_RKIND
-         do i = 1, nEdgesOnCell(iCell)
-            iEdge = edgesOnCell(i, iCell)
-            sumSurfaceStressSquared = sumSurfaceStressSquared &
-                                    + edgeAreaFractionOfCell(i,iCell)* &
-                                      surfaceStress(iEdge)**2
-         enddo
-
-         ! NOTE that the factor of 2 is from averaging dot products
-         ! to cell centers on a C-grid
-         surfaceStressMagnitude(iCell) = &
-                           sqrt(2.0_RKIND * sumSurfaceStressSquared)
          surfaceFrictionVelocity(iCell) = &
-                           sqrt(surfaceStressMagnitude(iCell) / rho_sw)
+                           sqrt(sfcStressMag(iCell) / rho_sw)
 
       enddo
       !$omp end do
@@ -3655,11 +3619,11 @@ contains
                  salineContractionCoeff, &
                  densitySurfaceDisplaced)
 
-      call mpas_timer_stop('KPP input fields')
+      call mpas_timer_stop('Mixing input fields')
 
     !-------------------------------------------------------------------
 
-    end subroutine ocn_compute_KPP_input_fields!}}}
+    end subroutine ocn_compute_mixing_input_fields!}}}
 
 !***********************************************************************
 !

--- a/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tendency.F
@@ -1317,12 +1317,9 @@ contains
          !
          ! Compute tracer tendency due to non-local flux computed in KPP
          !
-         if (config_use_cvmix_kpp .or. config_use_gotm) then
-            call ocn_compute_KPP_input_fields(statePool, forcingPool,&
-                                                 meshPool, timeLevel)
-
-            if (.not. config_cvmix_kpp_nonlocal_with_implicit_mix) then
+         if (config_use_cvmix_kpp) then
                call mpas_timer_start("non-local flux from KPP")
+            if (.not. config_cvmix_kpp_nonlocal_with_implicit_mix) then
                if (computeBudgets) then
                   !$omp parallel
                   !$omp do schedule(runtime) private(k,n)
@@ -1365,8 +1362,8 @@ contains
                   !$omp end do
                   !$omp end parallel
                endif ! compute budgets
-               call mpas_timer_stop("non-local flux from KPP")
             end if ! not non-local with implicit mix
+            call mpas_timer_stop("non-local flux from KPP")
          end if ! KPP
 
          ! Compute tracer tendency due to production/destruction of

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -27,6 +27,7 @@ module ocn_vmix
    use mpas_timer
    use ocn_mesh
 
+   use ocn_diagnostics
    use mpas_constants
    use ocn_constants
    use ocn_config
@@ -201,6 +202,11 @@ contains
       !$omp end do
       !$omp end parallel
 #endif
+
+      if(config_use_cvmix_kpp .or. config_use_gotm) then
+         call ocn_compute_mixing_input_fields(statePool, forcingPool,&
+                                              meshPool, timeLevel)
+      end if
 
 #ifdef MPAS_OPENACC
       !$acc update host(vertViscTopOfEdge, vertDiffTopOfCell)

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix_cvmix.F
@@ -64,7 +64,7 @@ module ocn_vmix_cvmix
    type(cvmix_shear_params_type)  :: cvmix_shear_params
    type(cvmix_tidal_params_type)  :: cvmix_tidal_params
 
-   logical :: cvmixOn, cvmixConvectionOn, cvmixKPPOn
+   logical :: lnonzero_surf_nonlocal, cvmixOn, cvmixConvectionOn, cvmixKPPOn
    real (kind=RKIND) :: backgroundVisc, backgroundDiff
 
    integer :: cvmixBackgroundChoice        ! user choice of cvmix background scheme
@@ -1042,18 +1042,21 @@ contains
       ! initialize KPP boundary layer scheme
       !
       if (config_use_cvmix_kpp) then
-        if(config_cvmix_kpp_matching.eq."MatchBoth") then
-           call mpas_log_write( &
-              "Use of option MatchBoth is discouraged, use SimpleShapes instead", &
-               MPAS_LOG_WARN)
-        elseif(.not. config_cvmix_kpp_matching.eq."SimpleShapes") then
+        if(.not. config_cvmix_kpp_matching.eq."SimpleShapes" .and. &
+           .not. config_cvmix_kpp_matching.eq."MatchBoth" .and. &
+           .not. config_cvmix_kpp_matching.eq."ParabolicNonLocal") then
            call mpas_log_write( &
               "Unknown value for config_cvmix_kpp_matching., supported values are:" // &
-              "         SimpleShapes or MatchBoth", &
+              "         SimpleShapes or MatchBoth or ParabolicNonLocal", &
               MPAS_LOG_CRIT)
            err = 1
            return
         endif
+
+        lnonzero_surf_nonlocal = .false.
+        if(config_cvmix_kpp_matching .eq."ParabolicNonLocal") then
+           lnonzero_surf_nonlocal = .true.
+        end if
 
         if (trim(config_cvmix_kpp_langmuir_mixing_opt) .ne. "NONE" .and. &
             trim(config_cvmix_kpp_langmuir_mixing_opt) .ne. "LWF16" .and. &
@@ -1081,13 +1084,15 @@ contains
         call cvmix_init_kpp ( &
                ri_crit = config_cvmix_kpp_criticalBulkRichardsonNumber, &
                interp_type = config_cvmix_kpp_interpolationOMLType, &
-               interp_type2 = config_cvmix_kpp_interpolationOMLType, &
+               interp_type2 = 'LMD94', &
                lEkman = config_cvmix_kpp_EkmanOBL, &
                lMonOb = config_cvmix_kpp_MonObOBL, &
                MatchTechnique = config_cvmix_kpp_matching, &
                surf_layer_ext = config_cvmix_kpp_surface_layer_extent, &
                langmuir_mixing_str = config_cvmix_kpp_langmuir_mixing_opt, &
                langmuir_entrainment_str = config_cvmix_kpp_langmuir_entrainment_opt, &
+               lnoDGat1 = .true., &
+               lnonzero_surf_nonlocal = lnonzero_surf_nonlocal, &
                lenhanced_diff = config_cvmix_kpp_use_enhanced_diff)
       endif
 


### PR DESCRIPTION
Two parts of the KPP interface had bugs

1. The computation of surface buoyancy forcing and friction velocity were incorrect. The surfaceBuoyancyForcing subtracted the wrong values from the heat fluxes from thickness fluxes. The surfaceFrictionVelocity had incorrect interpolation to centers, the interpolation itself was unneeded.  MPAS was interpolating stress to edges (for momentum forcing, but interpolating back (instead of using coupler values) for mixing friction velocity.
2. The KPP interface for matchBoth is fixed and the indexing is fixed for matching interior to boundary layer diffusivities.

