### PR TITLE
Add overrun qos for pm-cpu/pm-gpu

### DIFF
--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -448,6 +448,7 @@
       <queue walltimemax="00:45:00" nodemax="1792" default="true">regular</queue>
       <queue walltimemax="00:45:00" nodemax="1792" strict="true">preempt</queue>
       <queue walltimemax="00:45:00" nodemax="1792" strict="true">shared</queue>
+      <queue walltimemax="00:45:00" nodemax="1792" strict="true">overrun</queue>
       <queue walltimemax="00:15:00" nodemax="4" strict="true">debug</queue>
     </queues>
   </batch_system>
@@ -502,10 +503,11 @@
       <queue walltimemax="00:30:00" nodemax="3072" default="true">regular</queue>
       <queue walltimemax="00:30:00" nodemax="3072" strict="true">preempt</queue>
       <queue walltimemax="00:30:00" nodemax="3072" strict="true">shared</queue>
+      <queue walltimemax="00:30:00" nodemax="3072" strict="true">overrun</queue>
       <queue walltimemax="00:30:00" nodemax="8" strict="true">debug</queue>
     </queues>
   </batch_system>
-  
+
   <batch_system MACH="alvarez" type="nersc_slurm">
     <directives>
       <directive> --constraint=cpu</directive>


### PR DESCRIPTION
Add `overrun` as an option for submitting jobs via CIME on pm-cpu/pm-gpu.
Currently, jobs can submit to the `overrun` qos with `case.submit -a="-q overrun"`.
However, without this PR, tests like this will fail:
```
create_test SMS_D.ne4pg2_oQU480.F2010 --compiler gnu -q overrun
```

[bfb]