### PR TITLE
Chemistry output bug fix

### DIFF
--- a/components/eam/src/chemistry/mozart/rate_diags.F90
+++ b/components/eam/src/chemistry/mozart/rate_diags.F90
@@ -126,7 +126,7 @@ contains
        rxt_rates(:ncol,:,rxt_tag_map(i)) = rxt_rates(:ncol,:,rxt_tag_map(i)) *  m(:,:)
        call outfld( rate_names(i), rxt_rates(:ncol,:,rxt_tag_map(i)), ncol, lchnk )
 
-       if ( .not. history_UCIgaschmbudget_2D .and. .not. history_UCIgaschmbudget_2D_levels) return
+       if (history_UCIgaschmbudget_2D .or. history_UCIgaschmbudget_2D_levels) then
 
        if (rate_names(i) .eq. 'r_lch4') then
           !kg/m2/sec
@@ -163,6 +163,8 @@ contains
                wrk(:ncol,1) = wrk(:ncol,1) + wrk(:ncol,k)
             enddo
             call outfld( 'r_lch4_2D', wrk(:ncol,1), ncol ,lchnk )
+       endif
+
        endif
 
        endif


### PR DESCRIPTION
Due to a bug in the output of the chemistry reaction rate, 
the r_lch4 and r_lco_h are output as 0 when no chemistry output 
flags are set. The bug is fixed by modifying the if clause in the code.

Fixes #6711

[BFB]
-------
Git info
1. The output of reaction rate of r_lch4 and r_lco_h are not output due to a bug, fixed it in the code.

	modified:   components/eam/src/chemistry/mozart/rate_diags.F90
[BFB]