### PR TITLE
Chemistry output bug fix for maint-3.0

### DIFF
--- a/.github/workflows/e3sm-gh-ci-cime-tests.yml
+++ b/.github/workflows/e3sm-gh-ci-cime-tests.yml
@@ -2,7 +2,9 @@ name: gh
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: 
+      - master
+      - maint-3.0
     paths:
       # first, yes to these
       - '.github/workflows/e3sm-gh-ci-cime-tests.yml'
@@ -22,10 +24,14 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
   ci:
-    if: ${{ github.event.repository.name == 'e3sm' }}
+    if: ${{ github.repository == 'E3SM-Project/E3SM' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -36,7 +42,7 @@ jobs:
           - SMS_D_Ln5_P4.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.ghci-oci_gnu
           - ERS_Ld5_P4.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.ghci-oci_gnu.eamxx-prod
     container: 
-      image: ghcr.io/e3sm-project/containers-ghci:ghci-0.1.0
+      image: ghcr.io/e3sm-project/containers-ghci:ghci-0.2.0
 
     steps:
       - 

--- a/.github/workflows/e3sm-gh-ci-w-cime-tests.yml
+++ b/.github/workflows/e3sm-gh-ci-w-cime-tests.yml
@@ -1,8 +1,10 @@
-name: gh
+name: gh-w
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: 
+      - master
+      - maint-3.0
     paths-ignore:
       - 'mkdocs.yaml'
       - 'docs/**'
@@ -11,10 +13,14 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
-  ci-w:
-    if: ${{ github.event.repository.name == 'e3sm' }}
+  ci:
+    if: ${{ github.repository == 'E3SM-Project/E3SM' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -23,7 +29,7 @@ jobs:
           - SMS_D_Ld1_P8.ne4pg2_oQU480.WCYCL2010NS.ghci-oci_gnu
           - ERS_Ld3_P8.ne4pg2_oQU480.WCYCL2010NS.ghci-oci_gnu.allactive-wcprod_1850
     container: 
-      image: ghcr.io/e3sm-project/containers-ghci:ghci-0.1.0
+      image: ghcr.io/e3sm-project/containers-ghci:ghci-0.2.0
 
     steps:
       - 

--- a/.github/workflows/e3sm-gh-md-linter.yml
+++ b/.github/workflows/e3sm-gh-md-linter.yml
@@ -10,8 +10,13 @@ on:
         # for now let's not lint files in eamxx
         - '!components/eamxx/**/*.md'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   linter:
+    if: ${{ github.repository == 'E3SM-Project/E3SM' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/e3sm-gh-pages.yml
+++ b/.github/workflows/e3sm-gh-pages.yml
@@ -15,7 +15,7 @@ concurrency:
   
 jobs:
   Build-and-Deploy-docs:
-    if: ${{ github.event.repository.name == 'e3sm' }}
+    if: ${{ github.repository == 'E3SM-Project/E3SM' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e3sm-gh-tools-mkatmsrffile-test.yml
+++ b/.github/workflows/e3sm-gh-tools-mkatmsrffile-test.yml
@@ -11,8 +11,13 @@ on:
     - cron: '00 15 * * 2'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   mkatmsrffile-test:
+    if: ${{ github.repository == 'E3SM-Project/E3SM' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -31,10 +36,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: "envmkatmsrffile"
-          miniforge-variant: Mambaforge
           miniforge-version: latest
-          use-mamba: true
-          mamba-version: "*"
           channel-priority: strict
           auto-update-conda: true
           python-version: 3.11
@@ -42,7 +44,7 @@ jobs:
         name: Install dependencies
         run: |
           echo $CONDA_PREFIX
-          mamba install -y nco xarray numba numpy netcdf4
+          conda install -y nco xarray numba numpy netcdf4 -c conda-forge
       - 
         name: Run tests
         working-directory: components/eam/tools/mkatmsrffile

--- a/.github/workflows/eamxx-gh-ci-standalone.yml
+++ b/.github/workflows/eamxx-gh-ci-standalone.yml
@@ -15,9 +15,14 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
   ci:
+    if: ${{ github.repository == 'E3SM-Project/E3SM' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/eamxx-gh-pages.yml
+++ b/.github/workflows/eamxx-gh-pages.yml
@@ -34,7 +34,7 @@ concurrency:
 jobs:
 
   eamxx-docs:
-    if: ${{ github.event.repository.name == 'scream' }}
+    if: ${{ github.repository == 'E3SM-Project/scream' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/eamxx_default_files.yml
+++ b/.github/workflows/eamxx_default_files.yml
@@ -11,9 +11,13 @@ on:
     - cron: '00 00 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   scream-defaults:
-    if: ${{ github.event.repository.name == 'e3sm' }}
+    if: ${{ github.repository == 'E3SM-Project/E3SM' }}
     runs-on: ubuntu-latest
     outputs:
       event_name: ${{ github.event_name }}

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -278,6 +278,7 @@
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
       <env name="PERL5LIB">/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch</env>
       <env name="FI_CXI_RX_MATCH_MODE">software</env>
+      <env name="FI_MR_CACHE_MONITOR">kdreg2</env>
       <env name="MPICH_COLL_SYNC">MPI_Bcast</env>
       <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
@@ -445,6 +446,7 @@
       <env name="OMP_PLACES">threads</env>
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
       <env name="PERL5LIB">/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch</env>
+      <env name="FI_MR_CACHE_MONITOR">kdreg2</env>
       <env name="MPICH_COLL_SYNC">MPI_Bcast</env>
       <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
@@ -591,6 +593,7 @@
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
       <env name="PERL5LIB">/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch</env>
       <env name="FI_CXI_RX_MATCH_MODE">software</env>
+      <env name="FI_MR_CACHE_MONITOR">kdreg2</env>
       <env name="MPICH_COLL_SYNC">MPI_Bcast</env>
       <env name="Albany_ROOT">$SHELL{if [ -z "$Albany_ROOT" ]; then echo /global/common/software/e3sm/mali_tpls/albany-e3sm-serial-release-gcc; else echo "$Albany_ROOT"; fi}</env>
       <env name="Trilinos_ROOT">$SHELL{if [ -z "$Trilinos_ROOT" ]; then echo /global/common/software/e3sm/mali_tpls/trilinos-e3sm-serial-release-gcc; else echo "$Trilinos_ROOT"; fi}</env>
@@ -752,6 +755,7 @@
       <env name="OMP_PLACES">threads</env>
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
       <env name="PERL5LIB">/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch</env>
+      <env name="FI_MR_CACHE_MONITOR">kdreg2</env>
       <env name="MPICH_COLL_SYNC">MPI_Bcast</env>
       <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
@@ -894,6 +898,7 @@
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
       <env name="PERL5LIB">/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch</env>
       <env name="FI_CXI_RX_MATCH_MODE">software</env>
+      <env name="FI_MR_CACHE_MONITOR">kdreg2</env>
       <env name="MPICH_COLL_SYNC">MPI_Bcast</env>
       <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>

--- a/components/eam/src/chemistry/mozart/rate_diags.F90
+++ b/components/eam/src/chemistry/mozart/rate_diags.F90
@@ -126,7 +126,7 @@ contains
        rxt_rates(:ncol,:,rxt_tag_map(i)) = rxt_rates(:ncol,:,rxt_tag_map(i)) *  m(:,:)
        call outfld( rate_names(i), rxt_rates(:ncol,:,rxt_tag_map(i)), ncol, lchnk )
 
-       if ( .not. history_UCIgaschmbudget_2D .and. .not. history_UCIgaschmbudget_2D_levels) return
+       if (history_UCIgaschmbudget_2D .or. history_UCIgaschmbudget_2D_levels) then
 
        if (rate_names(i) .eq. 'r_lch4') then
           !kg/m2/sec
@@ -163,6 +163,8 @@ contains
                wrk(:ncol,1) = wrk(:ncol,1) + wrk(:ncol,k)
             enddo
             call outfld( 'r_lch4_2D', wrk(:ncol,1), ncol ,lchnk )
+       endif
+
        endif
 
        endif


### PR DESCRIPTION
The chemistry reaction rate of r_lch4 and r_lco_h are output as 0 due to a bug in the output of chemistry file, when no chemistry output flags are set. The related issues and discussion is shown https://github.com/E3SM-Project/E3SM/issues/6711#issuecomment-2441390495. The bug is fixed by modifying the if clause in the code.