### PR TITLE
Set diagnositc ice falling flux as zero to avoid ice double counting in COSP.

### DIFF
--- a/components/eam/src/physics/p3/eam/micro_p3.F90
+++ b/components/eam/src/physics/p3/eam/micro_p3.F90
@@ -4350,7 +4350,6 @@ subroutine ice_sedimentation(kts,kte,ktop,kbot,kdir,    &
               dt_left, prt_accum, inv_dz, inv_rho, rho, num_arrays, vs, fluxes, qnr, dt_sub)
 
          do k = k_qxbot,k_qxtop,kdir
-!            precip_ice_flux(k+1) = precip_ice_flux(k+1) + flux_qit(k)*dt_sub ! shanyp
             sflx(k+1) = sflx(k+1) + flux_qit(k)*dt_sub
          enddo     
 
@@ -4363,7 +4362,6 @@ subroutine ice_sedimentation(kts,kte,ktop,kbot,kdir,    &
          bm_incld(:) = bm(:)/cld_frac_i(:)
 
       enddo substep_sedi_i
-!      precip_ice_flux(:)=precip_ice_flux(:)*inv_dt
       sflx(:)=sflx(:)*inv_dt
       precip_ice_surf = precip_ice_surf + prt_accum*inv_rho_h2o*inv_dt
 

--- a/components/eam/src/physics/p3/eam/micro_p3.F90
+++ b/components/eam/src/physics/p3/eam/micro_p3.F90
@@ -4350,7 +4350,7 @@ subroutine ice_sedimentation(kts,kte,ktop,kbot,kdir,    &
               dt_left, prt_accum, inv_dz, inv_rho, rho, num_arrays, vs, fluxes, qnr, dt_sub)
 
          do k = k_qxbot,k_qxtop,kdir
-            precip_ice_flux(k+1) = precip_ice_flux(k+1) + flux_qit(k)*dt_sub ! shanyp
+!            precip_ice_flux(k+1) = precip_ice_flux(k+1) + flux_qit(k)*dt_sub ! shanyp
             sflx(k+1) = sflx(k+1) + flux_qit(k)*dt_sub
          enddo     
 
@@ -4363,7 +4363,7 @@ subroutine ice_sedimentation(kts,kte,ktop,kbot,kdir,    &
          bm_incld(:) = bm(:)/cld_frac_i(:)
 
       enddo substep_sedi_i
-      precip_ice_flux(:)=precip_ice_flux(:)*inv_dt
+!      precip_ice_flux(:)=precip_ice_flux(:)*inv_dt
       sflx(:)=sflx(:)*inv_dt
       precip_ice_surf = precip_ice_surf + prt_accum*inv_rho_h2o*inv_dt
 


### PR DESCRIPTION
PR#5827 introduced an unexpected issue affecting the COSP CALIPSO 
simulator diagnostics. This issue arises from assigning the P3 diagnostic 
precipitating solid phase particle falling flux to “precip_ice_flux” for 
diagnostic purposes. Since “precip_ice_flux” is also a required input field
 and is treated as snow in the CALIPSO simulator, this results in the 
double-counting of solid phase particles. This is because the E3SMv3 
implemented the single-ice category version of P3 as used in SCREAM, 
where the simulated solid particles are either precipitating or non-precipitating. 

While assigning the P3 diagnostic precipitating solid phase particle falling
 flux to “precip_ice_flux” is technically correct, it inadvertently leads to 
double-counting of ice in the CALIPSO simulator's cloud diagnostics. 
Note that this issue does not impact model simulations.

[BFB] except for tests with COSP CALIPSO simulator output