### PR TITLE
extract code from print_cfl into dss_hvtensor routine

### DIFF
--- a/components/homme/src/share/global_norms_mod.F90
+++ b/components/homme/src/share/global_norms_mod.F90
@@ -26,6 +26,9 @@ module global_norms_mod
   public :: wrap_repro_sum
 
   private :: global_maximum
+
+  ! EdgeBuffer_t variables are shared by all thread,
+  ! therefore we need this to be module static
   type (EdgeBuffer_t), private :: edgebuf
 
 contains
@@ -112,8 +115,6 @@ contains
     use reduction_mod, only : ParallelMin,ParallelMax
     use physical_constants, only : scale_factor,dd_pi
     use parallel_mod, only : abortmp, global_shared_buf, global_shared_sum
-    use edgetype_mod, only : EdgeBuffer_t
-    use edge_mod, only :  initedgebuffer, FreeEdgeBuffer, edgeVpack, edgeVunpack
     use bndry_mod, only : bndry_exchangeV
     use control_mod, only : geometry
 

--- a/components/homme/src/share/global_norms_mod.F90
+++ b/components/homme/src/share/global_norms_mod.F90
@@ -20,6 +20,7 @@ module global_norms_mod
   public :: linf_vnorm
 
   public :: print_cfl
+  public :: dss_hvtensor
   public :: test_global_integral
   public :: global_integral
   public :: wrap_repro_sum
@@ -252,19 +253,14 @@ contains
 #ifdef MODEL_THETA_L
     use element_state, only : nu_scale_top
 #endif
-    use dimensions_mod, only : np,ne,nelem,nelemd,qsize
+    use dimensions_mod, only : np
     use quadrature_mod, only : gausslobatto, quadrature_t
 
     use reduction_mod, only : ParallelMin,ParallelMax
-    use physical_constants, only : scale_factor_inv, scale_factor,dd_pi
+    use physical_constants, only : scale_factor_inv
     use control_mod, only : nu, nu_q, nu_div, hypervis_order, nu_top,  &
-                            hypervis_scaling, dcmip16_mu,dcmip16_mu_s,dcmip16_mu_q
+                            hypervis_scaling, dcmip16_mu,dcmip16_mu_s
     use control_mod, only : tstep_type
-    use parallel_mod, only : abortmp, global_shared_buf, global_shared_sum
-    use edgetype_mod, only : EdgeBuffer_t 
-    use edge_mod, only : initedgebuffer, FreeEdgeBuffer, edgeVpack, edgeVunpack
-    use bndry_mod, only : bndry_exchangeV
-    use time_mod, only : tstep
 
     type(element_t)      , intent(inout) :: elem(:)
     integer              , intent(in) :: nets,nete
@@ -274,12 +270,9 @@ contains
     ! Element statisics
     real (kind=real_kind) :: min_max_dx,max_unif_dx   ! used for normalizing scalar HV
     real (kind=real_kind) :: max_normDinv  ! used for CFL
-    real (kind=real_kind) :: min_hypervis, max_hypervis, avg_hypervis, stable_hv
     real (kind=real_kind) :: normDinv_hypervis
-    real (kind=real_kind) :: x, y, noreast, nw, se, sw
-    real (kind=real_kind), dimension(np,np,nets:nete) :: zeta
     real (kind=real_kind) :: lambda_max, lambda_vis, min_gw, lambda, nu_div_actual, nu_top_actual
-    integer :: ie,corner, i, j, rowind, colind
+    integer :: ie
     type (quadrature_t)    :: gp
 
 
@@ -327,6 +320,8 @@ contains
     gp=gausslobatto(np)
     min_gw = minval(gp%weights)
 
+    deallocate(gp%weights)
+
     max_normDinv=0
     min_max_dx=1d99
     do ie=nets,nete
@@ -348,64 +343,6 @@ contains
        ! constant coefficient formula:
        normDinv_hypervis = (lambda_vis**2) * (scale_factor_inv*max_normDinv)**4
     endif
-
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!  TENSOR, RESOLUTION-AWARE HYPERVISCOSITY
-!  The tensorVisc() array is computed in cube_mod.F90
-!  this block of code will DSS it so the tensor if C0
-!  and also make it bilinear in each element.
-!  Oksana Guba
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-   if (hypervis_scaling /= 0) then
-    call initEdgeBuffer(hybrid%par,edgebuf,elem,1)
-    do rowind=1,2
-      do colind=1,2
-	do ie=nets,nete
-	  zeta(:,:,ie) = elem(ie)%tensorVisc(:,:,rowind,colind)*elem(ie)%spheremp(:,:)
-	  call edgeVpack(edgebuf,zeta(1,1,ie),1,0,ie)
-	end do
-
-	call bndry_exchangeV(hybrid,edgebuf)
-	do ie=nets,nete
-	  call edgeVunpack(edgebuf,zeta(1,1,ie),1,0,ie)
-          elem(ie)%tensorVisc(:,:,rowind,colind) = zeta(:,:,ie)*elem(ie)%rspheremp(:,:)
-	end do
-      enddo !rowind
-    enddo !colind
-    call FreeEdgeBuffer(edgebuf)
-
-!IF BILINEAR MAP OF V NEEDED
-    do rowind=1,2
-      do colind=1,2
-    ! replace hypervis w/ bilinear based on continuous corner values
-	do ie=nets,nete
-	  noreast = elem(ie)%tensorVisc(np,np,rowind,colind)
-	  nw = elem(ie)%tensorVisc(1,np,rowind,colind)
-	  se = elem(ie)%tensorVisc(np,1,rowind,colind)
-	  sw = elem(ie)%tensorVisc(1,1,rowind,colind)
-	  do i=1,np
-	    x = gp%points(i)
-	    do j=1,np
-		y = gp%points(j)
-		elem(ie)%tensorVisc(i,j,rowind,colind) = 0.25d0*( &
-					(1.0d0-x)*(1.0d0-y)*sw + &
-					(1.0d0-x)*(y+1.0d0)*nw + &
-					(x+1.0d0)*(1.0d0-y)*se + &
-					(x+1.0d0)*(y+1.0d0)*noreast)
-	    end do
-	  end do
-	end do
-      enddo !rowind
-    enddo !colind
-    endif
-    deallocate(gp%points)
-    deallocate(gp%weights)
-
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!    
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
      if (hybrid%masterthread) then
        write(iulog,'(a,f10.2)') 'CFL estimates in terms of S=time step stability region'
@@ -462,6 +399,94 @@ contains
     end if
 
   end subroutine print_cfl
+
+  ! ================================
+  ! dss_hvtensor:
+  !
+  ! apply dss and bilinear projection
+  ! to tensor coefficients
+  !
+  ! ================================
+
+  subroutine dss_hvtensor(elem,hybrid,nets,nete)
+    use kinds,       only : real_kind
+    use hybrid_mod,  only : hybrid_t
+    use element_mod, only : element_t
+
+    use dimensions_mod, only : np
+    use quadrature_mod, only : gausslobatto, quadrature_t
+
+    use control_mod, only : hypervis_scaling
+    use edge_mod, only : initedgebuffer, FreeEdgeBuffer, edgeVpack, edgeVunpack
+    use bndry_mod, only : bndry_exchangeV
+
+    type(element_t)      , intent(inout) :: elem(:)
+    integer              , intent(in) :: nets,nete
+    type (hybrid_t)      , intent(in) :: hybrid
+
+    ! Element statisics
+    real (kind=real_kind) :: x, y, noreast, nw, se, sw
+    real (kind=real_kind), dimension(np,np,nets:nete) :: zeta
+    integer :: ie, i, j, rowind, colind
+    type (quadrature_t)    :: gp
+
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    !  TENSOR, RESOLUTION-AWARE HYPERVISCOSITY
+    !  The tensorVisc() array is computed in cube_mod.F90
+    !  this block of code will DSS it so the tensor if C0
+    !  and also make it bilinear in each element.
+    !  Oksana Guba
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+    if (hypervis_scaling /= 0) then
+      call initEdgeBuffer(hybrid%par,edgebuf,elem,1)
+      do rowind=1,2
+        do colind=1,2
+          do ie=nets,nete
+            zeta(:,:,ie) = elem(ie)%tensorVisc(:,:,rowind,colind)*elem(ie)%spheremp(:,:)
+            call edgeVpack(edgebuf,zeta(1,1,ie),1,0,ie)
+          end do
+
+          call bndry_exchangeV(hybrid,edgebuf)
+          do ie=nets,nete
+            call edgeVunpack(edgebuf,zeta(1,1,ie),1,0,ie)
+            elem(ie)%tensorVisc(:,:,rowind,colind) = zeta(:,:,ie)*elem(ie)%rspheremp(:,:)
+          end do
+        enddo !rowind
+      enddo !colind
+      call FreeEdgeBuffer(edgebuf)
+
+      gp=gausslobatto(np)
+
+      !IF BILINEAR MAP OF V NEEDED
+      do rowind=1,2
+        do colind=1,2
+          ! replace hypervis w/ bilinear based on continuous corner values
+          do ie=nets,nete
+            noreast = elem(ie)%tensorVisc(np,np,rowind,colind)
+            nw = elem(ie)%tensorVisc(1,np,rowind,colind)
+            se = elem(ie)%tensorVisc(np,1,rowind,colind)
+            sw = elem(ie)%tensorVisc(1,1,rowind,colind)
+            do i=1,np
+              x = gp%points(i)
+              do j=1,np
+                y = gp%points(j)
+                elem(ie)%tensorVisc(i,j,rowind,colind) = 0.25d0*( &
+                (1.0d0-x)*(1.0d0-y)*sw + &
+                (1.0d0-x)*(y+1.0d0)*nw + &
+                (x+1.0d0)*(1.0d0-y)*se + &
+                (x+1.0d0)*(y+1.0d0)*noreast)
+              end do
+            end do
+          end do
+        enddo !rowind
+      enddo !colind
+
+      deallocate(gp%points)
+      deallocate(gp%weights)
+    endif
+
+   end subroutine dss_hvtensor
 
   ! ================================
   ! global_maximum:

--- a/components/homme/src/share/prim_driver_base.F90
+++ b/components/homme/src/share/prim_driver_base.F90
@@ -743,7 +743,7 @@ contains
                                     sub_case, limiter_option, nu, nu_q, nu_div, tstep_type, hypervis_subcycle, &
                                     hypervis_subcycle_q, hypervis_subcycle_tom, &
                                     transport_alg, prim_step_type
-    use global_norms_mod,     only: test_global_integral, print_cfl
+    use global_norms_mod,     only: test_global_integral, print_cfl, dss_hvtensor
     use hybvcoord_mod,        only: hvcoord_t
     use parallel_mod,         only: parallel_t, haltmp, syncmp, abortmp
     use prim_state_mod,       only: prim_printstate, prim_diag_scalars
@@ -982,9 +982,10 @@ contains
     endif
 
     call model_init2(elem(:), hybrid,deriv1,hvcoord,tl,nets,nete)
+    ! apply dss and bilinear projection to tensor coefficients
+    call dss_hvtensor(elem,hybrid,nets,nete)
 
     ! advective and viscious CFL estimates
-    ! may also adjust tensor coefficients based on CFL
     call print_cfl(elem,hybrid,nets,nete,dtnu)
 
     ! Use the flexible time stepper if dt_remap_factor == 0 (vertically Eulerian

--- a/components/homme/src/sweqx/sweq_mod.F90
+++ b/components/homme/src/sweqx/sweq_mod.F90
@@ -33,7 +33,7 @@ contains
     use shal_movie_mod, only : shal_movie_init, shal_movie_output, shal_movie_finish
 #endif
     !-----------------
-    use global_norms_mod, only : test_global_integral, print_cfl
+    use global_norms_mod, only : test_global_integral, print_cfl, dss_hvtensor
     !-----------------
     use quadrature_mod, only : quadrature_t, gausslobatto
     !-----------------
@@ -192,7 +192,7 @@ contains
     hybrid = hybrid_create(par,ithr,hthreads)
     simday=0
        call test_global_integral(elem,hybrid,nets,nete)
-
+       call dss_hvtensor(elem,hybrid,nets,nete)
        dtnu = 2.0d0*tstep*max(nu,nu_s)/hypervis_subcycle
        call print_cfl(elem,hybrid,nets,nete,dtnu)
 
@@ -847,7 +847,7 @@ contains
 
 #endif
     !-----------------
-    use global_norms_mod, only : test_global_integral, print_cfl
+    use global_norms_mod, only : test_global_integral, print_cfl, dss_hvtensor
     !-----------------
     use quadrature_mod, only : quadrature_t, gausslobatto
     !-----------------
@@ -932,6 +932,7 @@ contains
     hybrid = hybrid_create(par,ithr,hthreads)
 
        call test_global_integral(elem,hybrid,nets,nete,mindx)
+       call dss_hvtensor(elem,hybrid,nets,nete)
        dtnu = (tstep/rk_stage_user)*max(nu,nu_s)/hypervis_subcycle
        call print_cfl(elem,hybrid,nets,nete,dtnu)
 


### PR DESCRIPTION
HOMME fortran init code refactor: important code hidden in print_cfl() is extracted into a new routine, dss_hvtensor

dss_hvtensor improves HV results by making the HV coefficients smooth accross elements.  It also does a bilinear projection of the coefficients within each element to minimize oscillations in the tensor coefficieints.

[BFB]