### PR TITLE
Fix alarm error for MALI adaptive timestepper

### DIFF
--- a/components/mpas-albany-landice/cime_config/testdefs/testmods_dirs/mali/gis20km/user_nl_mali
+++ b/components/mpas-albany-landice/cime_config/testdefs/testmods_dirs/mali/gis20km/user_nl_mali
@@ -1,1 +1,3 @@
 config_am_globalstats_enable = .false.
+config_adaptive_timestep = .true.
+config_adaptive_timestep_force_interval = '0000-00-01_00:00:00'

--- a/components/mpas-albany-landice/driver/glc_comp_mct.F
+++ b/components/mpas-albany-landice/driver/glc_comp_mct.F
@@ -557,6 +557,13 @@ contains
     call check_clocks_sync(domain % clock, Eclock, err_tmp)
     ierr = ior(ierr,err_tmp)
 
+    ! Reset the alarm for checking for force setting of the adaptive timestep interval
+    if (mpas_is_alarm_ringing(domain % clock, 'adaptiveTimestepForceInterval', ierr=err_tmp)) then
+       ierr = ior(ierr, err_tmp)
+       call mpas_reset_clock_alarm(domain % clock, 'adaptiveTimestepForceInterval', ierr=err_tmp)
+       ierr = ior(ierr, err_tmp)
+    endif
+    ierr = ior(ierr, err_tmp)
 
 !-----------------------------------------------------------------------
 !


### PR DESCRIPTION
MALI uses an MPAS alarm to handle ensuring its adaptive timestepper does not step past a coupling interval.  In recent attempts to enable the adaptive timestepper in MALI within E3SM, it was discovered that the required alarm is not being reset properly during init in the glc driver, which results in an error because MALI tries to use a 0 second dt on the first timestep.  This PR resets the alarm in glc_init_mct after the component clock is finished being set up, which solves the problem.

This PR also enables the adaptive timestepper for the `mali-gis20km` testmod to ensure this functionality gets tested.  Because the coupling interval in this test (1 day) is much smaller than the CFL-limiting timestep, the dt being applied remain unchanged, so there are no answer changes.  But the adaptive timestepper functionality in MALI is active and being run.

[NML] only for testdef mali-gis20km
[BFB]