### PR TITLE
Adding I/O type for ADIOS compression & Updating SCORPIO to v1.6.6

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1987,7 +1987,8 @@ commented out until "*** No rule to make target '.../libadios2pio-nm-lib.a'" iss
       <env name="PERL5LIB">/nfs/gce/projects/climate/software/perl5/lib/perl5</env>
     </environment_variables>
     <environment_variables compiler="gnu" mpilib="mpich">
-      <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/adios2/2.9.1/mpich-4.1.2/gcc-12.1.0; else echo "$ADIOS2_ROOT"; fi}</env>
+      <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/adios2/2.10.1/mpich-4.1.2/gcc-12.1.0; else echo "$ADIOS2_ROOT"; fi}</env>
+      <env name="BLOSC2_ROOT">$SHELL{if [ -z "$BLOSC2_ROOT" ]; then echo /nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/c-blosc2/2.15.1/gcc-12.1.0; else echo "$BLOSC2_ROOT"; fi}</env>
     </environment_variables>
   </machine>
 

--- a/cime_config/testmods_dirs/io/force_adiosc/shell_commands
+++ b/cime_config/testmods_dirs/io/force_adiosc/shell_commands
@@ -1,0 +1,2 @@
+#!/bin/bash
+./xmlchange PIO_TYPENAME="adiosc"

--- a/components/cmake/modules/FindPIO.cmake
+++ b/components/cmake/modules/FindPIO.cmake
@@ -42,6 +42,9 @@ endif()
 # we can assume that an MPI case with ADIOS2_ROOT set is probably
 # using adios.
 if (NOT MPILIB STREQUAL "mpi-serial" AND DEFINED ENV{ADIOS2_ROOT})
+  if(DEFINED ENV{BLOSC2_ROOT})
+    set(ENV{Blosc2_DIR} "$ENV{BLOSC2_ROOT}")
+  endif()
   find_package(MPI REQUIRED COMPONENTS C)
   find_package(ADIOS2 REQUIRED COMPONENTS C)
   list(APPEND PIOLIBS adios2::adios2)

--- a/driver-mct/cime_config/config_component.xml
+++ b/driver-mct/cime_config/config_component.xml
@@ -2628,7 +2628,7 @@
 
   <entry id="PIO_TYPENAME">
     <type>char</type>
-    <valid_values>netcdf,pnetcdf,netcdf4p,netcdf4c,adios,hdf5,default</valid_values>
+    <valid_values>netcdf,pnetcdf,netcdf4p,netcdf4c,adios,adiosc,hdf5,default</valid_values>
     <group>run_pio</group>
     <file>env_run.xml</file>
     <desc>pio io type</desc>

--- a/driver-moab/cime_config/config_component.xml
+++ b/driver-moab/cime_config/config_component.xml
@@ -2620,7 +2620,7 @@
 
   <entry id="PIO_TYPENAME">
     <type>char</type>
-    <valid_values>netcdf,pnetcdf,netcdf4p,netcdf4c,adios,hdf5,default</valid_values>
+    <valid_values>netcdf,pnetcdf,netcdf4p,netcdf4c,adios,adiosc,hdf5,default</valid_values>
     <group>run_pio</group>
     <file>env_run.xml</file>
     <desc>pio io type</desc>

--- a/share/build/buildlib.spio
+++ b/share/build/buildlib.spio
@@ -78,6 +78,8 @@ def buildlib(bldroot, installpath, case):
     # ADIOS2_ROOT. This is a workaround
     if "ADIOS2_ROOT" in os.environ:
         os.environ["ADIOS2_DIR"] = os.environ["ADIOS2_ROOT"]
+    if "BLOSC2_ROOT" in os.environ:
+        os.environ["Blosc2_DIR"] = os.environ["BLOSC2_ROOT"]
 
     # If variable PIO_VERSION_MAJOR is defined in the environment then
     # we assume that PIO is installed on the system
@@ -105,10 +107,14 @@ def buildlib(bldroot, installpath, case):
     else:
         cmake_opts += f"-DGENF90_PATH={scorpio_src_dir}/src/genf90 "
 
+    adiosc_found = False
     if "ADIOS2_ROOT" in os.environ:
         cmake_opts += "-DWITH_ADIOS2:BOOL=ON "
         if "FROM_CREATE_TEST" in os.environ and os.environ["FROM_CREATE_TEST"] == "True":
             cmake_opts += "-DADIOS_BP2NC_TEST:BOOL=ON "
+        if "BLOSC2_ROOT" in os.environ:
+            cmake_opts += "-DADIOS_USE_COMPRESSION:BOOL=ON "
+            adiosc_found = True
 
     if debug:
         cmake_opts += "-DPIO_ENABLE_LOGGING=ON "
@@ -281,6 +287,8 @@ def buildlib(bldroot, installpath, case):
         valid_values += ",netcdf4p,netcdf4c"
     if adios_found:
         valid_values += ",adios"
+        if adiosc_found:
+            valid_values += ",adiosc"
     if hdf5_found:
         valid_values += ",hdf5"
 

--- a/share/util/shr_pio_mod.F90
+++ b/share/util/shr_pio_mod.F90
@@ -679,6 +679,8 @@ contains
 #ifndef PIO1
     else if ( typename .eq. 'ADIOS') then
        iotype = pio_iotype_adios
+    else if ( typename .eq. 'ADIOSC') then
+       iotype = pio_iotype_adiosc
     else if ( typename .eq. 'HDF5') then
        iotype = pio_iotype_hdf5
 #endif


### PR DESCRIPTION
Adding preliminary support for ADIOS output compression
and updating to SCORPIO v1.6.6 (which includes patch
to support the new I/O type to use for data compression)

Modifying CIME config and scripts to support writing
ADIOS output files with data compression. A new I/O
type is added to support writing output in ADIOS BP file
format with data compression.

However users would need to move to SCORPIO 
master to write ADIOS output with data compression

Note: Writing ADIOS output with data compression is
now supported in SCORPIO master but is not
included in SCORPIO v1.6.6. A future release of
SCORPIO will include this feature

[BFB]