### PR TITLE
Set default config_check_ssh_consistency for oQU240wLI to false

### DIFF
--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -630,6 +630,7 @@
 <!-- debug -->
 <config_check_zlevel_consistency>.false.</config_check_zlevel_consistency>
 <config_check_ssh_consistency>.true.</config_check_ssh_consistency>
+<config_check_ssh_consistency ocn_grid="oQU240wLI">.false.</config_check_ssh_consistency>
 <config_check_ssh_consistency ocn_grid="oEC60to30v3wLI">.false.</config_check_ssh_consistency>
 <config_check_ssh_consistency ocn_grid="ECwISC30to60E1r2">.false.</config_check_ssh_consistency>
 <config_check_ssh_consistency ocn_grid="oRRS30to10v3wLI">.false.</config_check_ssh_consistency>


### PR DESCRIPTION
Change the default config_check_ssh_consistency setting for oQU240wLI to false, to avoid confusing warnings/errors from tests with this grid. Otherwise we end up with log.ocean.err files complaining about:
    "ERROR:  Warning: Sea surface height outside of acceptable range (20m)."
In general, mpaso sets config_check_ssh_consistency to false for grids with ice shelf cavities, but this one was missed.

[NML] for configurations with oQU240wLI
[BFB]