### PR TITLE
Update machine and compiler files for Frontier (Nov. 2024)

### DIFF
--- a/cime_config/machines/cmake_macros/amdclanggpu_frontier.cmake
+++ b/cime_config/machines/cmake_macros/amdclanggpu_frontier.cmake
@@ -13,8 +13,6 @@ string(APPEND CMAKE_C_FLAGS_RELEASE   " -O2")
 string(APPEND CMAKE_CXX_FLAGS_RELEASE " -O2")
 string(APPEND CMAKE_Fortran_FLAGS_RELEASE   " -O2")
 
-string(APPEND SPIO_CMAKE_OPTS " -DPIO_ENABLE_TOOLS:BOOL=OFF")
-
 string(APPEND CMAKE_CXX_FLAGS " --offload-arch=gfx90a")
 string(APPEND CMAKE_EXE_LINKER_FLAGS " -L$ENV{CRAY_MPICH_ROOTDIR}/gtl/lib -lmpi_gtl_hsa")
 string(APPEND CMAKE_EXE_LINKER_FLAGS " -L/opt/cray/pe/gcc/12.2.0/snos/lib64 -lgfortran -lstdc++")

--- a/cime_config/machines/cmake_macros/crayclanggpu_frontier.cmake
+++ b/cime_config/machines/cmake_macros/crayclanggpu_frontier.cmake
@@ -52,8 +52,6 @@ endif()
 # https://github.com/E3SM-Project/E3SM/pull/5208
 string(APPEND CMAKE_Fortran_FLAGS " -hipa0 -hzero -em -ef -hnoacc")
 
-string(APPEND SPIO_CMAKE_OPTS " -DPIO_ENABLE_TOOLS:BOOL=OFF")
-
 string(APPEND CMAKE_CXX_FLAGS " --offload-arch=gfx90a")
 string(APPEND CMAKE_EXE_LINKER_FLAGS " -L$ENV{CRAY_MPICH_ROOTDIR}/gtl/lib -lmpi_gtl_hsa")
 string(APPEND CMAKE_EXE_LINKER_FLAGS " -L$ENV{ROCM_PATH}/lib -lamdhip64")

--- a/cime_config/machines/cmake_macros/gnugpu_frontier.cmake
+++ b/cime_config/machines/cmake_macros/gnugpu_frontier.cmake
@@ -14,7 +14,6 @@ string(APPEND CMAKE_Fortran_FLAGS " -Wno-implicit-interface")
 string(APPEND CMAKE_C_FLAGS_RELEASE   " -O2")
 string(APPEND CMAKE_CXX_FLAGS_RELEASE " -O2")
 string(APPEND CMAKE_Fortran_FLAGS_RELEASE   " -O2")
-string(APPEND SPIO_CMAKE_OPTS " -DPIO_ENABLE_TOOLS:BOOL=OFF")
 
 string(APPEND CMAKE_CXX_FLAGS " --offload-arch=gfx90a")
 string(APPEND CMAKE_EXE_LINKER_FLAGS " -L$ENV{CRAY_MPICH_ROOTDIR}/gtl/lib -lmpi_gtl_hsa")

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1069,7 +1069,7 @@
       <cmd_path lang="python">/usr/share/lmod/lmod/libexec/lmod python</cmd_path>
       <modules compiler="crayclang.*">
         <command name="reset"></command>
-        <command name="switch">Core/24.07</command>
+        <command name="switch">Core Core/24.07</command>
         <command name="switch">PrgEnv-cray PrgEnv-cray/8.3.3</command>
         <command name="switch">cce cce/15.0.1</command>
         <!-- craype module to address tcmalloc runtime errors at startup -->
@@ -1082,7 +1082,7 @@
       </modules>
       <modules compiler="amdclang.*">
         <command name="reset"></command>
-        <command name="switch">Core/24.07</command>
+        <command name="switch">Core Core/24.07</command>
         <command name="switch">PrgEnv-cray PrgEnv-amd/8.3.3</command>
         <command name="switch">amd amd/5.4.0</command>
       </modules>
@@ -1091,7 +1091,7 @@
       </modules>
       <modules compiler="gnu.*">
         <command name="reset"></command>
-        <command name="switch">Core/24.07</command>
+        <command name="switch">Core Core/24.07</command>
         <command name="switch">PrgEnv-cray PrgEnv-gnu/8.3.3</command>
         <command name="switch">gcc gcc/12.2.0</command>
       </modules>
@@ -1106,6 +1106,7 @@
         <command name="load">subversion</command>
         <command name="load">git</command>
         <command name="load">zlib</command>
+        <command name="load">libfabric/1.15.2.0</command>
         <command name="load">cray-hdf5-parallel/1.12.2.1</command>
         <command name="load">cray-netcdf-hdf5parallel/4.9.0.1</command>
         <command name="load">cray-parallel-netcdf/1.12.3.1</command>
@@ -1139,9 +1140,6 @@
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
     </environment_variables>
-<!--
-commented out until "*** No rule to make target '.../libadios2pio-nm-lib.a'" issue is resolved.
-
     <environment_variables compiler="gnu.*" mpilib="mpich">
       <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /lustre/orion/cli115/world-shared/frontier/3rdparty/adios2/2.9.1/cray-mpich-8.1.23/gcc-11.2.0; else echo "$ADIOS2_ROOT"; fi}</env>
     </environment_variables>
@@ -1151,7 +1149,6 @@ commented out until "*** No rule to make target '.../libadios2pio-nm-lib.a'" iss
     <environment_variables compiler="amdclang.*" mpilib="mpich">
       <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /lustre/orion/cli115/world-shared/frontier/3rdparty/adios2/2.9.1/cray-mpich-8.1.23/amdclang-15.0.0; else echo "$ADIOS2_ROOT"; fi}</env>
     </environment_variables>
--->
   </machine>
 
   <machine MACH="frontier-scream-gpu">


### PR DESCRIPTION
This PR updates the machine and compiler files for Frontier (Nov. 2024), including the following:

- Recovery of ADIOS support
- Loading of the libfabric/1.15.2.0 module
- Correction of typos

There is no change in the number of PASS and FAIL test cases after this update.

With this update, model throughput (simulated years per day) is generally improved when using the Crayclang compiler, with the following speedups :

- Max speedup: 28.29
- Min speedup: 0.69
- Average speedup: 4.26
- Median speedup: 1.25
