### PR TITLE
Change SORRMv3 ocean initial condition

### DIFF
--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -414,8 +414,8 @@ def buildnml(case, caseroot, compname):
         ic_date = '20240829'
         ic_prefix = 'mpaso.SOwISC12to30E3r3'
         if ocn_ic_mode == 'spunup':
-            ic_date = '20240829'
-            ic_prefix = 'mpaso.SOwISC12to30E3r3.rstFromG-chrysalis'
+            ic_date = '20241023'
+            ic_prefix = 'mpaso.SOwISC12to30E3r3.interpFrom2p1-anvil'
         if ocn_ismf == 'data':
             data_ismf_file = 'prescribed_ismf_paolo2023.SOwISC12to30E3r3.20240829.nc'
 


### PR DESCRIPTION
Changes ocean initial condition for B-cases with the `SOwISC12to30E3r3` ocean mesh. The previous default initial condition is from a one-month G-case restart from cold-start (standard default). The initial condition here has been interpolated from year 701 of the SORRM v2.1 1950 control simulation, in an effort to bypass/speed-up ocean spinup.

New ocean initial condition file is staged in public inputdata repo, world-readable.

[BFB] except
[non-BFB] for B-cases with the `SOwISC12to30E3r3` ocean mesh (not in current testing).