### PR TITLE
Change SORRMv3 ice runoff mapping

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -5660,7 +5660,7 @@
     </gridmap>
 
     <gridmap ocn_grid="SOwISC12to30E3r3" rof_grid="r05">
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_SOwISC12to30E3r3_cstmnn.r150e300.20240808.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_SOwISC12to30E3r3_Ratio0.5_maxFlux0.001.Greenland100x+Antarctica100x.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_SOwISC12to30E3r3_cstmnn.r150e300.20240808.nc</map>
     </gridmap>
 

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -5660,7 +5660,7 @@
     </gridmap>
 
     <gridmap ocn_grid="SOwISC12to30E3r3" rof_grid="r05">
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_SOwISC12to30E3r3_rat0.5_maxFlx0.001.Grlnd100x_Ant100x.cstmnn.20241120.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_SOwISC12to30E3r3_r250e1250_58NS.cstmnn.20241120.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_SOwISC12to30E3r3_cstmnn.r150e300.20240808.nc</map>
     </gridmap>
 

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -5660,7 +5660,7 @@
     </gridmap>
 
     <gridmap ocn_grid="SOwISC12to30E3r3" rof_grid="r05">
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_SOwISC12to30E3r3_Ratio0.5_maxFlux0.001.Greenland100x+Antarctica100x.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_SOwISC12to30E3r3_rat0.5_maxFlx0.001.Grlnd100x_Ant100x.cstmnn.20241120.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_SOwISC12to30E3r3_cstmnn.r150e300.20240808.nc</map>
     </gridmap>
 


### PR DESCRIPTION
Changes the ice runoff mapping file (`ROF2OCN_ICE_RMAPNAME`) for the `SOwISC12to30E3r3` ocean mesh to version with increased smoothing.

New mapping file has been staged in public inputdata repo, world readable.

[BFB] except
[non-BFB] for cases with the SOwISC12to30E3r3 ocean mesh (not in current testing).