### PR TITLE
FATES API update for SPITFIRE refactor

### DIFF
--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -314,7 +314,7 @@ Allowed values are:
  5 : use gross domestic production and population datasets to simulate anthropogenic fire supression
 </entry>
 
-<entry id="fates_harvest_mode" type="char*18" category="physics"
+<entry id="fates_harvest_mode" type="char*256" category="physics"
         group="elm_inparm"
         valid_values="no_harvest,event_code,landuse_timeseries,luhdata_area,luhdata_mass" >
 Set FATES harvesting mode by setting fates_harvest_mode

--- a/components/elm/src/main/elm_varctl.F90
+++ b/components/elm/src/main/elm_varctl.F90
@@ -221,7 +221,7 @@ module elm_varctl
 
   logical, public            :: use_fates = .false.                     ! true => use  ED
   integer, public            :: fates_spitfire_mode = 0                 ! 0 for no fire; 1 for constant ignitions
-  character(len=13), public  :: fates_harvest_mode = ''                 ! five different harvest modes; see namelist_definitions
+  character(len=256), public :: fates_harvest_mode = ''                 ! five different harvest modes; see namelist_definitions
   logical, public            :: use_fates_fixed_biogeog = .false.       ! true => use fixed biogeography mode
   logical, public            :: use_fates_planthydro = .false.          ! true => turn on fates hydro
   logical, public            :: use_fates_cohort_age_tracking = .false. ! true => turn on cohort age tracking

--- a/components/elm/src/main/elmfates_interfaceMod.F90
+++ b/components/elm/src/main/elmfates_interfaceMod.F90
@@ -3517,7 +3517,7 @@ end subroutine wrap_update_hifrq_hist
    use FatesInterfaceTypesMod, only : nlevage_fates    => nlevage
    use FatesInterfaceTypesMod, only : nlevheight_fates => nlevheight
    use FatesInterfaceTypesMod, only : nlevdamage_fates => nlevdamage
-   use FatesLitterMod,        only : nfsc_fates       => nfsc
+   use FatesFuelClassesMod,        only : nfc_fates   => num_fuel_classes
    use FatesLitterMod,    only : ncwd_fates       => ncwd
    use EDParamsMod,       only : nlevleaf_fates   => nlevleaf
    use EDParamsMod,       only : nclmax_fates     => nclmax
@@ -3555,7 +3555,7 @@ end subroutine wrap_update_hifrq_hist
    fates%sizeage_class_end   = nlevsclass_fates * nlevage_fates
 
    fates%fuel_begin = 1
-   fates%fuel_end = nfsc_fates
+   fates%fuel_end = nfc_fates
 
    fates%cdpf_begin = 1
    fates%cdpf_end = nlevdamage_fates * numpft_fates * nlevsclass_fates
@@ -3606,7 +3606,7 @@ end subroutine wrap_update_hifrq_hist
    fates%coage_class_end = nlevcoage
 
    fates%agefuel_begin = 1
-   fates%agefuel_end   = nlevage_fates * nfsc_fates
+   fates%agefuel_end   = nlevage_fates * nfc_fates
 
    fates%landuse_begin = 1
    fates%landuse_end   = n_landuse_cats

--- a/components/elm/src/main/histFileMod.F90
+++ b/components/elm/src/main/histFileMod.F90
@@ -28,7 +28,7 @@ module histFileMod
   use FatesInterfaceTypesMod , only : nlevheight_fates => nlevheight
   use FatesInterfaceTypesMod , only : nlevdamage_fates => nlevdamage
   use FatesInterfaceTypesMod , only : nlevcoage
-  use FatesLitterMod         , only : nfsc_fates       => nfsc
+  use FatesFuelClassesMod    , only : nfc_fates       => num_fuel_classes
   use FatesConstantsMod      , only : n_landuse_cats
   use FatesLitterMod         , only : ncwd_fates       => ncwd
   use FatesInterfaceTypesMod , only : numpft_fates     => numpft
@@ -1933,7 +1933,7 @@ contains
        call ncd_defdim(lnfid, 'fates_levcacls',nlevcoage, dimid)
        call ncd_defdim(lnfid, 'fates_levpft', numpft_fates, dimid)
        call ncd_defdim(lnfid, 'fates_levage', nlevage_fates, dimid)
-       call ncd_defdim(lnfid, 'fates_levfuel', nfsc_fates, dimid)
+       call ncd_defdim(lnfid, 'fates_levfuel', nfc_fates, dimid)
        call ncd_defdim(lnfid, 'fates_levcwdsc', ncwd_fates, dimid)
        call ncd_defdim(lnfid, 'fates_levscpf', nlevsclass_fates*numpft_fates, dimid)
        call ncd_defdim(lnfid, 'fates_levcapf',  nlevcoage*numpft_fates, dimid)
@@ -1951,7 +1951,7 @@ contains
        call ncd_defdim(lnfid, 'fates_levelpft', nelements_fates * numpft_fates, dimid)
        call ncd_defdim(lnfid, 'fates_levelcwd', nelements_fates * ncwd_fates, dimid)
        call ncd_defdim(lnfid, 'fates_levelage', nelements_fates * nlevage_fates, dimid)
-       call ncd_defdim(lnfid, 'fates_levagefuel', nlevage_fates * nfsc_fates, dimid)
+       call ncd_defdim(lnfid, 'fates_levagefuel', nlevage_fates * nfc_fates, dimid)
        call ncd_defdim(lnfid, 'fates_levlanduse', n_landuse_cats, dimid)
        call ncd_defdim(lnfid, 'fates_levlulu', n_landuse_cats * n_landuse_cats, dimid)
     end if
@@ -4796,7 +4796,7 @@ contains
     case ('fates_levelage')
        num2d = nelements_fates*nlevage_fates
     case ('fates_levagefuel')
-       num2d = nlevage_fates*nfsc_fates
+       num2d = nlevage_fates*nfc_fates
     case('cft')
        if (cft_size > 0) then
           num2d = cft_size
@@ -4842,7 +4842,7 @@ contains
     case ('fates_levage')
        num2d = nlevage_fates
     case ('fates_levfuel')
-       num2d = nfsc_fates
+       num2d = nfc_fates
     case ('fates_levcwdsc')
        num2d = ncwd_fates
     case ('fates_levscpf')


### PR DESCRIPTION
Updates fates to API37 per a fates-side fire refactor which renames and moves `nfsc`.  
This updates the fates tag with a number of fates-side fixes and feature updates so 
fates tests will be answer changing.

Fixes #6806  
[non-B4B] for fates tests