### PR TITLE
EAMxx: speed up valgrind testing to make it doable

### DIFF
--- a/components/eamxx/CMakeLists.txt
+++ b/components/eamxx/CMakeLists.txt
@@ -453,10 +453,6 @@ if (NOT SCREAM_LIB_ONLY)
   # for LONG use 100. It is *completely* up to the test to decide what short, medium, and long mean.
   if (EKAT_ENABLE_COVERAGE OR EKAT_ENABLE_CUDA_MEMCHECK OR EKAT_ENABLE_VALGRIND OR EKAT_ENABLE_COMPUTE_SANITIZER)
     set (SCREAM_TEST_SIZE_DEFAULT SHORT)
-    # also set thread_ing=$max_thread - 1, so we test at most 2 threading configurations
-    if (SCREAM_TEST_MAX_THREADS GREATER 1)
-      math (EXPR SCREAM_TEST_THREAD_INC ${SCREAM_TEST_MAX_THREADS}-1)
-    endif()
   else()
     set (SCREAM_TEST_SIZE_DEFAULT MEDIUM)
   endif()

--- a/components/eamxx/scripts/scripts-tests
+++ b/components/eamxx/scripts/scripts-tests
@@ -292,12 +292,13 @@ class TestTestAllScream(TestBaseOuter.TestBase):
                                 self._machine)
             run_cmd_assert_result(self, cmd, from_dir=TEST_DIR)
             builddir = "compute_sanitizer_memcheck" if self._machine.gpu_arch=="cuda" else "valgrind"
-            test_cmake_cache_contents(self, builddir, "CMAKE_BUILD_TYPE", "Debug")
             test_cmake_cache_contents(self, builddir, "SCREAM_TEST_SIZE", "SHORT")
             if self._machine.gpu_arch=="cuda":
+                test_cmake_cache_contents(self, builddir, "CMAKE_BUILD_TYPE", "Debug")
                 test_cmake_cache_contents(self, builddir, "EKAT_ENABLE_COMPUTE_SANITIZER", "TRUE")
                 test_cmake_cache_contents(self, builddir, "EKAT_COMPUTE_SANITIZER_OPTIONS", "--tool=memcheck")
             else:
+                test_cmake_cache_contents(self, builddir, "CMAKE_BUILD_TYPE", "RelWithDebInfo")
                 test_cmake_cache_contents(self, builddir, "EKAT_ENABLE_VALGRIND", "TRUE")
         else:
             self.skipTest("Skipping config-only run for jenkins test")

--- a/components/eamxx/scripts/test_factory.py
+++ b/components/eamxx/scripts/test_factory.py
@@ -153,8 +153,10 @@ class VALG(TestProperty):
         TestProperty.__init__(
             self,
             "valgrind",
-            "debug with valgrind",
-            [("CMAKE_BUILD_TYPE", "Debug"), ("EKAT_ENABLE_VALGRIND", "True")],
+            "Release build where tests run through valgrind",
+            [("CMAKE_BUILD_TYPE", "RelWithDebInfo"),
+             ("EKAT_ENABLE_VALGRIND", "True"),
+             ("SCREAM_TEST_MAX_THREADS", "2")],
             uses_baselines=False,
             on_by_default=False,
             default_test_len="short"


### PR DESCRIPTION
Our valgrind testsuite for eamxx standalone testing was too slow, to the point that it never completed before timing out. This PR compromises between exec speed and analysis thoroughness by:

- using CMAKE_BUILD_TYPE=RelWithDebInfo: less optimized than Release (-O2 vs -O3), and adds debug symbols in case we want to manually run through a debugger
- limiting the number of OMP threads to 2: if we are doing bad index math to cause OOB access or uninitialized var usage, we can spot that with just 2 threads. Valgrind does not do concurrency checks anyways.

Depends-On: #6761 