### PR TITLE
EAMxx: set valgrind supp file in ghci-snl mach file

### DIFF
--- a/components/eamxx/cmake/BuildCprnc.cmake
+++ b/components/eamxx/cmake/BuildCprnc.cmake
@@ -18,7 +18,9 @@ macro(BuildCprnc)
     configure_file (${SCREAM_BASE_DIR}/cmake/CprncTest.cmake.in
                     ${CMAKE_BINARY_DIR}/bin/CprncTest.cmake @ONLY)
   else()
-    message(WARNING "Path ${CCSM_CPRNC} does not exist, so we will try to build it")
+    if (NOT "${CCSM_CPRNC}" STREQUAL "")
+      message(WARNING "Path ${CCSM_CPRNC} does not exist, so we will try to build it")
+    endif()
     # Make sure this is built only once
     if (NOT TARGET cprnc)
       if (SCREAM_CIME_BUILD)

--- a/components/eamxx/cmake/machine-files/ghci-snl.cmake
+++ b/components/eamxx/cmake/machine-files/ghci-snl.cmake
@@ -17,3 +17,5 @@ option (EKAT_TEST_LAUNCHER_MANAGE_RESOURCES "" ON)
 # Needed by EkatCreateUnitTest
 set (EKAT_MPIRUN_EXE "mpirun" CACHE STRING "")
 set (EKAT_MPI_NP_FLAG "-n" CACHE STRING "")
+
+set(EKAT_VALGRIND_SUPPRESSION_FILE "/projects/e3sm/baselines/scream/ghci-snl-cpu/eamxx-valgrind.supp" CACHE FILEPATH "Use this valgrind suppression file if valgrind is enabled.")


### PR DESCRIPTION
This will allow us to use a pre-existing supp file, rather than relying on EKAT to build it on the fly. The reason is twofold: first, the simple program that EKAT uses to generate the file only picks up one of the many valg errors we get; second, and more important, the current EKAT infrastructure generates an empty file...

We will modify the supp file for ghci-snl when new suppressions are needed. For now, I have it to contain openmpi-valgrind.supp (shipped by our mpi installation) plus a few suppressions I generated running some eamxx tests...