### PR TITLE
Flag to control explicit mixing of aerosols

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -247,6 +247,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <!-- MAM4xx-ACI -->
     <mam4_aci inherit="atm_proc_base">
       <wsubmin type="real" doc="Minimum diagnostic sub-grid vertical velocity">0.001</wsubmin>
+      <enable_aero_vertical_mix type="logical" doc="Enable vertical mixing of interstitial aerosols and liquid number">false</enable_aero_vertical_mix>
       <top_level_mam4xx type="integer" doc="Level corresponding to the top of troposphere clouds" nlev="72"  >6</top_level_mam4xx>
       <top_level_mam4xx type="integer" doc="level corresponding to the top of troposphere clouds" nlev="128" >0</top_level_mam4xx>
     </mam4_aci>

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
@@ -205,6 +205,7 @@ void call_function_dropmixnuc(
     const MAMAci::view_2d wsub,
     const MAMAci::view_2d cloud_frac, const MAMAci::view_2d cloud_frac_prev,
     const mam_coupling::AerosolState &dry_aero, const int nlev,
+    const bool &enable_aero_vertical_mix,
 
     // Following outputs are all diagnostics
     MAMAci::view_2d coltend[mam4::ndrop::ncnst_tot],
@@ -318,7 +319,7 @@ void call_function_dropmixnuc(
                           num2vol_ratio_max_nmodes);
   //---------------------------------------------------------------------------
   //---------------------------------------------------------------------------
-
+  const bool local_enable_aero_vertical_mix = enable_aero_vertical_mix;
   Kokkos::parallel_for(
       team_policy, KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
         const int icol = team.league_rank();
@@ -417,10 +418,10 @@ void call_function_dropmixnuc(
             spechygro, lmassptr_amode, num2vol_ratio_min_nmodes,
             num2vol_ratio_max_nmodes, numptr_amode, nspec_amode, exp45logsig,
             alogsig, aten, mam_idx, mam_cnst_idx,
-            ekat::subview(qcld, icol),             // out
-            ekat::subview(wsub, icol),             // in
-            ekat::subview(cloud_frac_prev, icol),  // in
-            qqcw_view,                             // inout
+            local_enable_aero_vertical_mix, ekat::subview(qcld, icol),  // out
+            ekat::subview(wsub, icol),                                  // in
+            ekat::subview(cloud_frac_prev, icol),                       // in
+            qqcw_view,                                                  // inout
             ptend_q_view, ekat::subview(tendnd, icol),
             ekat::subview(factnum, icol), ekat::subview(ndropcol, icol),
             ekat::subview(ndropmix, icol), ekat::subview(nsource, icol),

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
@@ -40,6 +40,9 @@ MAMAci::MAMAci(const ekat::Comm &comm, const ekat::ParameterList &params)
   // Asserts for the runtime or namelist options
   EKAT_REQUIRE_MSG(m_params.isParameter("wsubmin"),
                    "ERROR: wsubmin is missing from mam_aci parameter list.");
+  EKAT_REQUIRE_MSG(m_params.isParameter("enable_aero_vertical_mix"),
+                   "ERROR: enable_aero_vertical_mixing is missing from mam_aci "
+                   "parameter list.");
   EKAT_REQUIRE_MSG(
       m_params.isParameter("top_level_mam4xx"),
       "ERROR: top_level_mam4xx is missing from mam_aci parameter list.");
@@ -271,8 +274,9 @@ void MAMAci::initialize_impl(const RunType run_type) {
   // ## Runtime options
   // ------------------------------------------------------------------------
 
-  wsubmin_ = m_params.get<double>("wsubmin");
-  top_lev_ = m_params.get<int>("top_level_mam4xx");
+  wsubmin_                  = m_params.get<double>("wsubmin");
+  enable_aero_vertical_mix_ = m_params.get<bool>("enable_aero_vertical_mix");
+  top_lev_                  = m_params.get<int>("top_level_mam4xx");
 
   // ------------------------------------------------------------------------
   // Input fields read in from IC file, namelist or other processes
@@ -600,7 +604,7 @@ void MAMAci::run_impl(const double dt) {
   //  aerosols tendencies
   call_function_dropmixnuc(
       team_policy, dt, dry_atm_, rpdel_, kvh_mid_, kvh_int_, wsub_, cloud_frac_,
-      cloud_frac_prev_, dry_aero_, nlev_,
+      cloud_frac_prev_, dry_aero_, nlev_, enable_aero_vertical_mix_,
       // output
       coltend_, coltend_cw_, qcld_, ndropcol_, ndropmix_, nsource_, wtke_, ccn_,
       // ## output to be used by the other processes ##

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.hpp
@@ -41,8 +41,9 @@ class MAMAci final : public scream::AtmosphereProcess {
   // ACI runtime ( or namelist) options
   //------------------------------------------------------------------------
 
-  Real wsubmin_;  // Minimum subgrid vertical velocity
-  int top_lev_;   // Top level for MAM4xx
+  Real wsubmin_;                   // Minimum subgrid vertical velocity
+  bool enable_aero_vertical_mix_;  // To enable vertical mixing of aerosols
+  int top_lev_;                    // Top level for MAM4xx
 
   //------------------------------------------------------------------------
   // END: ACI runtime ( or namelist) options
@@ -212,7 +213,9 @@ class MAMAci final : public scream::AtmosphereProcess {
       // for atmosphere
       compute_vertical_layer_heights(team, dry_atm_pre_, i);
       compute_updraft_velocities(team, wet_atm_pre_, dry_atm_pre_, i);
-    }  // operator()
+      set_min_background_mmr(team, dry_aero_pre_,
+                             i);  // dry_atm_pre_ is the output
+    }                             // operator()
 
     // local variables for preprocess struct
     // number of horizontal columns and vertical levels

--- a/components/eamxx/tests/single-process/mam/aci/input.yaml
+++ b/components/eamxx/tests/single-process/mam/aci/input.yaml
@@ -12,6 +12,7 @@ atmosphere_processes:
   atm_procs_list: [mam4_aci]
   mam4_aci:
     wsubmin: 0.001
+    enable_aero_vertical_mix: false
     top_level_mam4xx: 6
 
 grids_manager:


### PR DESCRIPTION
A flag is added to control the explicit mixing of aerosols in dropmixnuc. Since interstitial aerosols and droplet number mixing ratios are mixed by SHOC, we added a flag to control explicit mixing by dropmixnuc to avoid double mixing of interstitial aerosols and droplet number.

Please note that the flag is set to false by default so that dropmixnuc does not mix interstitial aerosols and droplet number.

