### PR TITLE
Revise forcing specifications for single forcing compsets

### DIFF
--- a/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6-GHG_chemUCI-Linoz-mam5-vbs.xml
+++ b/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6-GHG_chemUCI-Linoz-mam5-vbs.xml
@@ -19,23 +19,21 @@
 <scenario_ghg>RAMPED</scenario_ghg>
 
 <!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
-<ext_frc_type         >CYCLICAL</ext_frc_type>
-<ext_frc_cycle_yr     >1850</ext_frc_cycle_yr>
+<ext_frc_type         >INTERP_MISSING_MONTHS</ext_frc_type>
 <no2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_NO2_aircraft_vertical_1750-2015_1.9x2.5_c20170608.nc </no2_ext_file>
-<!--  Use 1850-2014 averaged volcanic SO2 emission for 1850 -->
-<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_1850_2014_avg_so2_elev_strat_1850.nc </so2_ext_file>
-<soag0_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/emissions-cmip6_e3sm_SOAG0_elev_1850-2014_1.9x2.5_c20230201.nc </soag0_ext_file>
-<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1850-2014_c180205.nc </bc_a4_ext_file>
-<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1850-2014_c180205.nc </mam7_num_a1_ext_file>
-<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1850-2014_c180205.nc </num_a2_ext_file>
-<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1850-2014_c180205.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c180205.nc </pom_a4_ext_file>
-<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c180205.nc </so4_a1_ext_file>
-<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c180205.nc </so4_a2_ext_file>
+<!--  Repeat 1850 aerosol, aerosol precursors, and volcanic emissions -->
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/cmip6_mam4_so2_elev_1850-2014_c180205_hist-aero_1850-volcano_1850_repeated_c20241122.nc </so2_ext_file>
+<soag0_ext_file       >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/emissions-cmip6_e3sm_SOAG0_elev_1850-2014_1.9x2.5_c20230201_1850_repeated_c20241122.nc </soag0_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/cmip6_mam4_bc_a4_elev_1850-2014_c180205_1850_repeated_c20241122.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/cmip6_mam4_num_a1_elev_1850-2014_c180205_1850_repeated_c20241122.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/cmip6_mam4_num_a2_elev_1850-2014_c180205_1850_repeated_c20241122.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/cmip6_mam4_num_a4_elev_1850-2014_c180205_1850_repeated_c20241122.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/cmip6_mam4_pom_a4_elev_1850-2014_c180205_1850_repeated_c20241122.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/cmip6_mam4_so4_a1_elev_1850-2014_c180205_1850_repeated_c20241122.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/cmip6_mam4_so4_a2_elev_1850-2014_c180205_1850_repeated_c20241122.nc </so4_a2_ext_file>
 
 <!-- Surface emissions for chemUCI-Linoz, MAM5, VBS SOA.  CMIP6 input4mips data -->
-<srf_emis_type        >CYCLICAL</srf_emis_type>
-<srf_emis_cycle_yr    >1850</srf_emis_cycle_yr>
+<srf_emis_type        >INTERP_MISSING_MONTHS</srf_emis_type>
 <c2h4_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C2H4_surface_1850-2014_1.9x2.5_c20210323.nc </c2h4_emis_file>
 <c2h6_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C2H6_surface_1850-2014_1.9x2.5_c20210323.nc </c2h6_emis_file>
 <c3h8_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C3H8_surface_1850-2014_1.9x2.5_c20210323.nc </c3h8_emis_file>
@@ -44,19 +42,19 @@
 <ch3coch3_emis_file   >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH3COCH3_surface_1850-2014_1.9x2.5_c20210323.nc </ch3coch3_emis_file>
 <co_emis_file         >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CO_surface_1850-2014_1.9x2.5_c20210323.nc </co_emis_file>
 <isop_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323.nc </isop_emis_file>
-<isop_vbs_emis_file   >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323.nc </isop_vbs_emis_file>
+<isop_vbs_emis_file   >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323_1850_repeated_c20241122.nc </isop_vbs_emis_file>
 <c10h16_emis_file     >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_MTERP_surface_1850-2014_1.9x2.5_c20230126.nc </c10h16_emis_file>
 <nox_emis_file        >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_NO_surface_1850-2014_1.9x2.5_c20220425.nc </nox_emis_file>
-<dms_emis_file        >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160416.nc </dms_emis_file>
-<soag0_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/emissions-cmip6_e3sm_SOAG0_surf_1850-2014_1.9x2.5_c20230201.nc </soag0_emis_file>
-<so2_emis_file        >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c180205.nc </so2_emis_file>
-<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c180205.nc </bc_a4_emis_file>
-<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c180205.nc </mam7_num_a1_emis_file>
-<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1850-2014_c180205.nc </num_a2_emis_file>
-<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1850-2014_c180205.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1850-2014_c180205.nc </pom_a4_emis_file>
-<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1850-2014_c180205.nc </so4_a1_emis_file>
-<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1850-2014_c180205.nc </so4_a2_emis_file>
+<dms_emis_file        >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727_1850_repeated_c20241122.nc </dms_emis_file>
+<soag0_emis_file     >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/emissions-cmip6_e3sm_SOAG0_surf_1850-2014_1.9x2.5_c20230201_1850_repeated_c20241122.nc </soag0_emis_file>
+<so2_emis_file        >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/cmip6_mam4_so2_surf_1850-2014_c180205_1850_repeated_c20241122.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/cmip6_mam4_bc_a4_surf_1850-2014_c180205_1850_repeated_c20241122.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/cmip6_mam4_num_a1_surf_1850-2014_c180205_1850_repeated_c20241122.nc </mam7_num_a1_emis_file>
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/cmip6_mam4_num_a2_surf_1850-2014_c180205_1850_repeated_c20241122.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/cmip6_mam4_num_a4_surf_1850-2014_c180205_1850_repeated_c20241122.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/cmip6_mam4_pom_a4_surf_1850-2014_c180205_1850_repeated_c20241122.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/cmip6_mam4_so4_a1_surf_1850-2014_c180205_1850_repeated_c20241122.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/cmip6_mam4_so4_a2_surf_1850-2014_c180205_1850_repeated_c20241122.nc </so4_a2_emis_file>
 <e90_emis_file        >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions_E90_surface_1750-2015_1.9x2.5_c20210408.nc </e90_emis_file>
 
 <airpl_emis_file></airpl_emis_file>   <!-- need to be empty, but if specifying empty here, the value would be root of input_data_path -->
@@ -101,12 +99,10 @@
 
 <!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
 <chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_0003-2017_c20171114.nc</chlorine_loading_file>
-<chlorine_loading_fixed_ymd >18500101</chlorine_loading_fixed_ymd>
-<chlorine_loading_type      >FIXED</chlorine_loading_type>
-<linoz_data_cycle_yr        >1850</linoz_data_cycle_yr>
+<chlorine_loading_type      >SERIAL</chlorine_loading_type>
 <linoz_data_file            >linv3_1849-2017_CMIP6_Hist_10deg_58km_c20230705.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
-<linoz_data_type            >CYCLICAL</linoz_data_type>
+<linoz_data_type            >INTERP_MISSING_MONTHS</linoz_data_type>
 
 <!-- Set surface area density (SAD) variables -->
 <sad_type>SERIAL</sad_type>

--- a/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6-GHG_chemUCI-Linoz-mam5-vbs.xml
+++ b/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6-GHG_chemUCI-Linoz-mam5-vbs.xml
@@ -43,7 +43,7 @@
 <co_emis_file         >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CO_surface_1850-2014_1.9x2.5_c20210323.nc </co_emis_file>
 <isop_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323.nc </isop_emis_file>
 <isop_vbs_emis_file   >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323_1850_repeated_c20241122.nc </isop_vbs_emis_file>
-<c10h16_emis_file     >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_MTERP_surface_1850-2014_1.9x2.5_c20230126.nc </c10h16_emis_file>
+<c10h16_emis_file     >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/emissions-cmip6_e3sm_MTERP_surface_1850-2014_1.9x2.5_c20230126_1850_repeated_c20241122.nc </c10h16_emis_file>
 <nox_emis_file        >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_NO_surface_1850-2014_1.9x2.5_c20220425.nc </nox_emis_file>
 <dms_emis_file        >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727_1850_repeated_c20241122.nc </dms_emis_file>
 <soag0_emis_file     >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/emissions-cmip6_e3sm_SOAG0_surf_1850-2014_1.9x2.5_c20230201_1850_repeated_c20241122.nc </soag0_emis_file>

--- a/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6-aer_chemUCI-Linoz-mam5-vbs.xml
+++ b/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6-aer_chemUCI-Linoz-mam5-vbs.xml
@@ -23,7 +23,7 @@
 
 <!-- External forcing for BAM or MAM.  CMIP6 input4mips data. SO2 file contains 1850 (background) volcanic but historical for other sectors -->
 <ext_frc_type>INTERP_MISSING_MONTHS</ext_frc_type>
-<no2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_NO2_aircraft_vertical_1750-2015_1.9x2.5_c20170608.nc </no2_ext_file>
+<no2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/emissions-cmip6_NO2_aircraft_vertical_1750-2015_1.9x2.5_c20170608_1850_repeated_c20241122.nc </no2_ext_file>
 <so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1850-2014_c180205_hist-aero_1850-volcano.nc </so2_ext_file>
 <soag0_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/emissions-cmip6_e3sm_SOAG0_elev_1850-2014_1.9x2.5_c20230201.nc </soag0_ext_file>
 <bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1850-2014_c180205.nc </bc_a4_ext_file>
@@ -36,17 +36,18 @@
 
 <!-- Surface emissions for chemUCI-Linoz, MAM5, VBS SOA.  CMIP6 input4mips data -->
 <srf_emis_type>INTERP_MISSING_MONTHS</srf_emis_type>
-<c2h4_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C2H4_surface_1850-2014_1.9x2.5_c20210323.nc </c2h4_emis_file>
-<c2h6_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C2H6_surface_1850-2014_1.9x2.5_c20210323.nc </c2h6_emis_file>
-<c3h8_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C3H8_surface_1850-2014_1.9x2.5_c20210323.nc </c3h8_emis_file>
-<ch2o_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH2O_surface_1850-2014_1.9x2.5_c20210323.nc </ch2o_emis_file>
-<ch3cho_emis_file     >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH3CHO_surface_1850-2014_1.9x2.5_c20210323.nc </ch3cho_emis_file>
-<ch3coch3_emis_file   >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH3COCH3_surface_1850-2014_1.9x2.5_c20210323.nc </ch3coch3_emis_file>
-<co_emis_file         >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CO_surface_1850-2014_1.9x2.5_c20210323.nc </co_emis_file>
-<isop_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323.nc </isop_emis_file>
+<c2h4_emis_file       >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/emissions-cmip6_e3sm_C2H4_surface_1850-2014_1.9x2.5_c20210323_1850_repeated_c20241122.nc </c2h4_emis_file>
+<c2h6_emis_file       >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/emissions-cmip6_e3sm_C2H6_surface_1850-2014_1.9x2.5_c20210323_1850_repeated_c20241122.nc </c2h6_emis_file>
+<c3h8_emis_file       >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/emissions-cmip6_e3sm_C3H8_surface_1850-2014_1.9x2.5_c20210323_1850_repeated_c20241122.nc </c3h8_emis_file>
+<ch2o_emis_file       >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/emissions-cmip6_e3sm_CH2O_surface_1850-2014_1.9x2.5_c20210323_1850_repeated_c20241122.nc </ch2o_emis_file>
+<ch3cho_emis_file     >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/emissions-cmip6_e3sm_CH3CHO_surface_1850-2014_1.9x2.5_c20210323_1850_repeated_c20241122.nc </ch3cho_emis_file>
+<ch3coch3_emis_file   >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/emissions-cmip6_e3sm_CH3COCH3_surface_1850-2014_1.9x2.5_c20210323_1850_repeated_c20241122.nc </ch3coch3_emis_file>
+<co_emis_file         >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/emissions-cmip6_e3sm_CO_surface_1850-2014_1.9x2.5_c20210323_1850_repeated_c20241122.nc </co_emis_file>
+<isop_emis_file       >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323_1850_repeated_c20241122.nc </isop_emis_file>
 <isop_vbs_emis_file   >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323.nc </isop_vbs_emis_file>
 <c10h16_emis_file     >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_MTERP_surface_1850-2014_1.9x2.5_c20230126.nc </c10h16_emis_file>
-<nox_emis_file        >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_NO_surface_1850-2014_1.9x2.5_c20220425.nc </nox_emis_file>
+<nox_emis_file        >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/emissions-cmip6_e3sm_NO_surface_1850-2014_1.9x2.5_c20220425_1850_repeated_c20241122.nc </nox_emis_file>
+
 <dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727.nc</dms_emis_file>
 <soag0_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/emissions-cmip6_e3sm_SOAG0_surf_1850-2014_1.9x2.5_c20230201.nc </soag0_emis_file>
 <so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c180205.nc </so2_emis_file>

--- a/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6-xGHG-xaer_chemUCI-Linoz-mam5-vbs.xml
+++ b/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6-xGHG-xaer_chemUCI-Linoz-mam5-vbs.xml
@@ -103,10 +103,12 @@
 <mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'			 </mam_mom_specifier >
 
 <chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_0003-2017_c20171114.nc</chlorine_loading_file>
-<chlorine_loading_type      >SERIAL</chlorine_loading_type>
+<chlorine_loading_fixed_ymd >18500101</chlorine_loading_fixed_ymd>
+<chlorine_loading_type      >FIXED</chlorine_loading_type>
+<linoz_data_cycle_yr        >1850</linoz_data_cycle_yr>
 <linoz_data_file            >linv3_1849-2017_CMIP6_Hist_10deg_58km_c20230705.nc</linoz_data_file>
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
-<linoz_data_type            >INTERP_MISSING_MONTHS</linoz_data_type>
+<linoz_data_type            >CYCLICAL</linoz_data_type>
 
 <!-- Set surface area density (SAD) variables -->
 <sad_type>SERIAL</sad_type>

--- a/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6-xaer_chemUCI-Linoz-mam5-vbs.xml
+++ b/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6-xaer_chemUCI-Linoz-mam5-vbs.xml
@@ -43,7 +43,7 @@
 <isop_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323.nc </isop_emis_file>
 <isop_vbs_emis_file   >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323_1850_repeated_c20241122.nc </isop_vbs_emis_file>
 <c10h16_emis_file     >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/emissions-cmip6_e3sm_MTERP_surface_1850-2014_1.9x2.5_c20230126_1850_repeated_c20241122.nc </c10h16_emis_file>
-<nox_emis_file        >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/emissions-cmip6_e3sm_NO_surface_1850-2014_1.9x2.5_c20220425.nc </nox_emis_file>
+<nox_emis_file        >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_NO_surface_1850-2014_1.9x2.5_c20220425.nc </nox_emis_file>
 <dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/DMSflux.1850.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160416_1850_repeated_c20241122.nc </dms_emis_file>
 <soag0_emis_file      >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/emissions-cmip6_e3sm_SOAG0_surf_1850-2014_1.9x2.5_c20230201_1850_repeated_c20241122.nc </soag0_emis_file>
 <so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/cmip6_mam4_so2_surf_1850-2014_c180205_1850_repeated_c20241122.nc </so2_emis_file>

--- a/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6-xaer_chemUCI-Linoz-mam5-vbs.xml
+++ b/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6-xaer_chemUCI-Linoz-mam5-vbs.xml
@@ -21,7 +21,7 @@
 <!-- Need to use INTERP_MISSING_MONTHS for ext_frc_volc_type to go with ths updated SO2 file -->
 <ext_frc_type         >INTERP_MISSING_MONTHS</ext_frc_type>
 <no2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_NO2_aircraft_vertical_1750-2015_1.9x2.5_c20170608.nc </no2_ext_file>
-<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/cmip6_mam4_so2_elev_1850-2014_c180205_1850-aero_hist-volcano.nc </so2_ext_file>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1850-2014_c180205_1850-aero_hist-volcano.nc </so2_ext_file>
 <soag0_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/emissions-cmip6_e3sm_SOAG0_elev_1850-2014_1.9x2.5_c20230201_1850_repeated_c20241122.nc </soag0_ext_file>
 <bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/cmip6_mam4_bc_a4_elev_1850-2014_c180205_1850_repeated_c20241122.nc </bc_a4_ext_file>
 <mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/cmip6_mam4_num_a1_elev_1850-2014_c180205_1850_repeated_c20241122.nc </mam7_num_a1_ext_file>

--- a/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6-xaer_chemUCI-Linoz-mam5-vbs.xml
+++ b/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6-xaer_chemUCI-Linoz-mam5-vbs.xml
@@ -19,23 +19,20 @@
 
 <!-- External forcing for BAM or MAM.  CMIP6 input4mips data. SO2 file contains historical volcanic but 1850 for other sectors -->
 <!-- Need to use INTERP_MISSING_MONTHS for ext_frc_volc_type to go with ths updated SO2 file -->
-<ext_frc_volc_type    >INTERP_MISSING_MONTHS</ext_frc_volc_type>
-<ext_frc_type         >CYCLICAL</ext_frc_type>
-<ext_frc_cycle_yr     >1850</ext_frc_cycle_yr>
+<ext_frc_type         >INTERP_MISSING_MONTHS</ext_frc_type>
 <no2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_NO2_aircraft_vertical_1750-2015_1.9x2.5_c20170608.nc </no2_ext_file>
-<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1850-2014_c180205_1850-aero_hist-volcano.nc </so2_ext_file>
-<soag0_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/emissions-cmip6_e3sm_SOAG0_elev_1850-2014_1.9x2.5_c20230201.nc </soag0_ext_file>
-<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1850-2014_c180205.nc </bc_a4_ext_file>
-<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1850-2014_c180205.nc </mam7_num_a1_ext_file>
-<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1850-2014_c180205.nc </num_a2_ext_file>
-<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1850-2014_c180205.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c180205.nc </pom_a4_ext_file>
-<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c180205.nc </so4_a1_ext_file>
-<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c180205.nc </so4_a2_ext_file>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/cmip6_mam4_so2_elev_1850-2014_c180205_1850-aero_hist-volcano.nc </so2_ext_file>
+<soag0_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/emissions-cmip6_e3sm_SOAG0_elev_1850-2014_1.9x2.5_c20230201_1850_repeated_c20241122.nc </soag0_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/cmip6_mam4_bc_a4_elev_1850-2014_c180205_1850_repeated_c20241122.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/cmip6_mam4_num_a1_elev_1850-2014_c180205_1850_repeated_c20241122.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/cmip6_mam4_num_a2_elev_1850-2014_c180205_1850_repeated_c20241122.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/cmip6_mam4_num_a4_elev_1850-2014_c180205_1850_repeated_c20241122.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/cmip6_mam4_pom_a4_elev_1850-2014_c180205_1850_repeated_c20241122.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/cmip6_mam4_so4_a1_elev_1850-2014_c180205_1850_repeated_c20241122.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/single_forcings/elev/cmip6_mam4_so4_a2_elev_1850-2014_c180205_1850_repeated_c20241122.nc </so4_a2_ext_file>
 
 <!-- Surface emissions for chemUCI-Linoz, MAM5, VBS SOA.  CMIP6 input4mips data -->
-<srf_emis_type        >CYCLICAL</srf_emis_type>
-<srf_emis_cycle_yr    >1850</srf_emis_cycle_yr>
+<srf_emis_type        >INTERP_MISSING_MONTHS</srf_emis_type>
 <c2h4_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C2H4_surface_1850-2014_1.9x2.5_c20210323.nc </c2h4_emis_file>
 <c2h6_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C2H6_surface_1850-2014_1.9x2.5_c20210323.nc </c2h6_emis_file>
 <c3h8_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C3H8_surface_1850-2014_1.9x2.5_c20210323.nc </c3h8_emis_file>
@@ -44,19 +41,19 @@
 <ch3coch3_emis_file   >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH3COCH3_surface_1850-2014_1.9x2.5_c20210323.nc </ch3coch3_emis_file>
 <co_emis_file         >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CO_surface_1850-2014_1.9x2.5_c20210323.nc </co_emis_file>
 <isop_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323.nc </isop_emis_file>
-<isop_vbs_emis_file   >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323.nc </isop_vbs_emis_file>
-<c10h16_emis_file     >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_MTERP_surface_1850-2014_1.9x2.5_c20230126.nc </c10h16_emis_file>
-<nox_emis_file        >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_NO_surface_1850-2014_1.9x2.5_c20220425.nc </nox_emis_file>
-<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160416.nc </dms_emis_file>
-<soag0_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/emissions-cmip6_e3sm_SOAG0_surf_1850-2014_1.9x2.5_c20230201.nc </soag0_emis_file>
-<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c180205.nc </so2_emis_file>
-<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c180205.nc </bc_a4_emis_file>
-<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c180205.nc </mam7_num_a1_emis_file> 
-<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1850-2014_c180205.nc </num_a2_emis_file>
-<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1850-2014_c180205.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
-<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1850-2014_c180205.nc </pom_a4_emis_file>
-<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1850-2014_c180205.nc </so4_a1_emis_file>
-<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1850-2014_c180205.nc </so4_a2_emis_file>
+<isop_vbs_emis_file   >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323_1850_repeated_c20241122.nc </isop_vbs_emis_file>
+<c10h16_emis_file     >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/emissions-cmip6_e3sm_MTERP_surface_1850-2014_1.9x2.5_c20230126_1850_repeated_c20241122.nc </c10h16_emis_file>
+<nox_emis_file        >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/emissions-cmip6_e3sm_NO_surface_1850-2014_1.9x2.5_c20220425.nc </nox_emis_file>
+<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/DMSflux.1850.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160416_1850_repeated_c20241122.nc </dms_emis_file>
+<soag0_emis_file      >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/emissions-cmip6_e3sm_SOAG0_surf_1850-2014_1.9x2.5_c20230201_1850_repeated_c20241122.nc </soag0_emis_file>
+<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/cmip6_mam4_so2_surf_1850-2014_c180205_1850_repeated_c20241122.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/cmip6_mam4_bc_a4_surf_1850-2014_c180205_1850_repeated_c20241122.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/cmip6_mam4_num_a1_surf_1850-2014_c180205_1850_repeated_c20241122.nc </mam7_num_a1_emis_file> 
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/cmip6_mam4_num_a2_surf_1850-2014_c180205_1850_repeated_c20241122.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/cmip6_mam4_num_a4_surf_1850-2014_c180205_1850_repeated_c20241122.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/cmip6_mam4_pom_a4_surf_1850-2014_c180205_1850_repeated_c20241122.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/cmip6_mam4_so4_a1_surf_1850-2014_c180205_1850_repeated_c20241122.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/single_forcings/surf/cmip6_mam4_so4_a2_surf_1850-2014_c180205_1850_repeated_c20241122.nc </so4_a2_emis_file>
 <e90_emis_file        >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions_E90_surface_1750-2015_1.9x2.5_c20210408.nc </e90_emis_file>
 
 <airpl_emis_file></airpl_emis_file>   <!-- need to be empty, but if specifying empty here, the value would be root of input_data_path -->


### PR DESCRIPTION
Revisions to single-forcing compsets' forcing specification focusing on
where to include the GHG warming contribution of CH4, N2O, and O3 due to
v3atm's interactive chemistry.

Core to the changes is to separate the transient aerosol and chemical precursors for different
single forcing compsets. New virtually transient forcing files are introduced to satisfy the unified data 
stream control for surface and elevated emissions. Historical evolution of stratospheric ozone 
is moved from the all-else configuration to the GHG only configuration.

Fixes #6837

[BFB] non-BFB only for single forcing compsets
[NML] Different only for single forcing compsets

------------------------------------------------------------------------------------------------
Related info

- [Summary of 11/20/24 discussion ](https://acme-climate.atlassian.net/wiki/spaces/CM/pages/4784193564/2024-11-20+Special+topic+-+Single-forcing+simulations#Summary) on the current set of single-forcing simulations

- [Break down the forcings for the revision](https://acme-climate.atlassian.net/wiki/spaces/CM/pages/4524900353/v3+LR+single-forcing+simulations#Revision-to-single-forcings-configurations)

Review Guide

Revision to composition of forcings (changes in dark red)
![image](https://github.com/user-attachments/assets/750e16b9-0776-4bc6-96c5-1c02643c0cb3)
![image](https://github.com/user-attachments/assets/1c7cb3a9-be77-40c8-834c-7cf6f41354f2)

No changes for `hist-nat`, `hist-ozone`, `hist-lulc`, and `hist-volc`. `hist-ozone` is limited to stratospheric zone changes. 