### PR TITLE
Change range of solid ice runoff removal from 60S to 57S

### DIFF
--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -2181,7 +2181,7 @@ contains
                call shr_sys_abort ('Error: incoming rofi_F is negative')
            end if
            if (config_remove_ais_ice_runoff) then
-              if (latCell(i) < -0.78539816325_RKIND) then ! 45S in radians
+              if (latCell(i) < -0.99483767345_RKIND) then ! 57S in radians
                  removedIceRunoffFlux(i) = iceRunoffFlux(i)
                  iceRunoffFlux(i) = 0.0_RKIND
                  removedIceRunoffFluxThisProc = removedIceRunoffFluxThisProc + removedIceRunoffFlux(i)
@@ -3714,7 +3714,7 @@ contains
                call shr_sys_abort ('Error: incoming rofi_F is negative')
            end if
            if (config_remove_ais_ice_runoff) then
-              if (latCell(i) < -0.78539816325_RKIND) then ! 45S in radians
+              if (latCell(i) < -0.99483767345_RKIND) then ! 57S in radians
                  removedIceRunoffFlux(i) = iceRunoffFlux(i)
                  iceRunoffFlux(i) = 0.0_RKIND
                  removedIceRunoffFluxThisProc = removedIceRunoffFluxThisProc + removedIceRunoffFlux(i)

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -2181,7 +2181,7 @@ contains
                call shr_sys_abort ('Error: incoming rofi_F is negative')
            end if
            if (config_remove_ais_ice_runoff) then
-              if (latCell(i) < -1.04719666667_RKIND) then ! 60S in radians
+              if (latCell(i) < -0.78539816325_RKIND) then ! 45S in radians
                  removedIceRunoffFlux(i) = iceRunoffFlux(i)
                  iceRunoffFlux(i) = 0.0_RKIND
                  removedIceRunoffFluxThisProc = removedIceRunoffFluxThisProc + removedIceRunoffFlux(i)
@@ -3714,7 +3714,7 @@ contains
                call shr_sys_abort ('Error: incoming rofi_F is negative')
            end if
            if (config_remove_ais_ice_runoff) then
-              if (latCell(i) < -1.04719666667_RKIND) then ! 60S in radians
+              if (latCell(i) < -0.78539816325_RKIND) then ! 45S in radians
                  removedIceRunoffFlux(i) = iceRunoffFlux(i)
                  iceRunoffFlux(i) = 0.0_RKIND
                  removedIceRunoffFluxThisProc = removedIceRunoffFluxThisProc + removedIceRunoffFlux(i)


### PR DESCRIPTION
Extends the northern range of solid ice runoff from Antarctica from 60S to ~~45S~~ 57S when the ocean's namelist option `config_remove_ais_ice_runoff = .true.`. The new solid ice runoff mapping with increased smoothing for the `SOwISC12to30E3r3` mesh in https://github.com/E3SM-Project/E3SM/pull/6759 has a small amount of runoff north of 60S, which needs to be removed when Antarctic solid ice runoff is intended to be removed.

[BFB]
All current configurations that do not use the mapping file in the above PR do not have solid ice runoff between 60S and ~~45S~~ 57S, so there is no impact.