### PR TITLE
EAMxx: extract diagnostic creation logic outside of output class

### DIFF
--- a/components/eamxx/src/diagnostics/CMakeLists.txt
+++ b/components/eamxx/src/diagnostics/CMakeLists.txt
@@ -1,4 +1,7 @@
 set(DIAGNOSTIC_SRCS
+  aerocom_cld.cpp
+  aodvis.cpp
+  atm_backtend.cpp
   atm_density.cpp
   dry_static_energy.cpp
   exner.cpp
@@ -6,6 +9,7 @@ set(DIAGNOSTIC_SRCS
   field_at_level.cpp
   field_at_pressure_level.cpp
   longwave_cloud_forcing.cpp
+  number_path.cpp
   potential_temperature.cpp
   precip_surf_mass_flux.cpp
   relative_humidity.cpp
@@ -17,15 +21,11 @@ set(DIAGNOSTIC_SRCS
   virtual_temperature.cpp
   water_path.cpp
   wind_speed.cpp
-  aodvis.cpp
-  number_path.cpp
-  aerocom_cld.cpp
-  atm_backtend.cpp
 )
 
 add_library(diagnostics ${DIAGNOSTIC_SRCS})
 target_link_libraries(diagnostics PUBLIC scream_share)
 
-if (NOT SCREAM_LIB_ONLY)
+if (NOT SCREAM_LIB_ONLY AND NOT SCREAM_ONLY_GENERATE_BASELINES)
   add_subdirectory(tests)
 endif()

--- a/components/eamxx/src/diagnostics/aerocom_cld.cpp
+++ b/components/eamxx/src/diagnostics/aerocom_cld.cpp
@@ -22,8 +22,6 @@ AeroComCld::AeroComCld(const ekat::Comm &comm,
                    "to be 'Bot' or 'Top' in its input parameters.\n");
 }
 
-std::string AeroComCld::name() const { return "AeroComCld" + m_topbot; }
-
 void AeroComCld::set_grids(
     const std::shared_ptr<const GridsManager> grids_manager) {
   using namespace ekat::units;
@@ -76,7 +74,8 @@ void AeroComCld::set_grids(
   m_dz.allocate_view();
 
   // Construct and allocate the output field
-  FieldIdentifier fid(name(), vector1d_layout, nondim, grid_name);
+
+  FieldIdentifier fid("AeroComCld"+m_topbot, vector1d_layout, nondim, grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 

--- a/components/eamxx/src/diagnostics/aerocom_cld.hpp
+++ b/components/eamxx/src/diagnostics/aerocom_cld.hpp
@@ -15,7 +15,7 @@ class AeroComCld : public AtmosphereDiagnostic {
   AeroComCld(const ekat::Comm &comm, const ekat::ParameterList &params);
 
   // The name of the diagnostic
-  std::string name() const override;
+  std::string name() const override { return "AeroComCld"; }
 
   // Set the grid
   void set_grids(

--- a/components/eamxx/src/diagnostics/field_at_height.cpp
+++ b/components/eamxx/src/diagnostics/field_at_height.cpp
@@ -45,21 +45,16 @@ FieldAtHeight (const ekat::Comm& comm, const ekat::ParameterList& params)
       " - surface reference: " + surf_ref + "\n"
       " -     valid options: sealevel, surface\n");
   m_z_name = (surf_ref == "sealevel") ? "z" : "height";
-  const auto& location = m_params.get<std::string>("vertical_location");
-  auto chars_start = location.find_first_not_of("0123456789.");
-  EKAT_REQUIRE_MSG (chars_start!=0 && chars_start!=std::string::npos,
-      "Error! Invalid string for height value for FieldAtHeight.\n"
-      " - input string   : " + location + "\n"
-      " - expected format: Nm, with N integer\n");
-  const auto z_str = location.substr(0,chars_start);
-  m_z = std::stod(z_str);
 
-  const auto units = location.substr(chars_start);
+  const auto units = m_params.get<std::string>("height_units");
   EKAT_REQUIRE_MSG (units=="m",
-      "Error! Invalid string for height value for FieldAtHeight.\n"
-      " - input string   : " + location + "\n"
-      " - expected format: Nm, with N integer\n");
-  m_diag_name = m_field_name + "_at_" + m_params.get<std::string>("vertical_location") + "_above_" + surf_ref;
+      "Error! Invalid units for FieldAtHeight.\n"
+      " - input units: " + units + "\n"
+      " - valid units: m\n");
+
+  auto z_val = m_params.get<std::string>("height_value");
+  m_z = std::stod(z_val);
+  m_diag_name = m_field_name + "_at_" + z_val + units + "_above_" + surf_ref;
 }
 
 void FieldAtHeight::

--- a/components/eamxx/src/diagnostics/field_at_height.hpp
+++ b/components/eamxx/src/diagnostics/field_at_height.hpp
@@ -18,7 +18,7 @@ public:
   FieldAtHeight (const ekat::Comm& comm, const ekat::ParameterList& params);
 
   // The name of the diagnostic
-  std::string name () const { return m_diag_name; }
+  std::string name () const { return "FieldAtHeight"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/field_at_level.hpp
+++ b/components/eamxx/src/diagnostics/field_at_level.hpp
@@ -21,7 +21,7 @@ public:
   FieldAtLevel (const ekat::Comm& comm, const ekat::ParameterList& params);
 
   // The name of the diagnostic
-  std::string name () const { return m_diag_name; }
+  std::string name () const { return "FieldAtLevel"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/field_at_pressure_level.cpp
+++ b/components/eamxx/src/diagnostics/field_at_pressure_level.cpp
@@ -15,30 +15,22 @@ FieldAtPressureLevel (const ekat::Comm& comm, const ekat::ParameterList& params)
 {
   m_field_name = m_params.get<std::string>("field_name");
 
-  // Figure out the pressure value
-  const auto& location = m_params.get<std::string>("vertical_location");
-  auto chars_start = location.find_first_not_of("0123456789.");
-  EKAT_REQUIRE_MSG (chars_start!=0 && chars_start!=std::string::npos,
-      "Error! Invalid string for pressure value for FieldAtPressureLevel.\n"
-      " - input string   : " + location + "\n"
-      " - expected format: Nxyz, with N integer, and xyz='mb', 'hPa', or 'Pa'\n");
-  const auto press_str = location.substr(0,chars_start);
-  m_pressure_level = std::stod(press_str);
-
-  const auto units = location.substr(chars_start);
+  const auto units = m_params.get<std::string>("pressure_units");
   EKAT_REQUIRE_MSG (units=="mb" or units=="hPa" or units=="Pa",
-      "Error! Invalid string for pressure value for FieldAtPressureLevel.\n"
-      " - input string   : " + location + "\n"
-      " - expected format: Nxyz, with N integer, and xyz='mb', 'hPa', or 'Pa'\n");
+      "Error! Invalid units for FieldAtPressureLevel.\n"
+      " - input units: " + units + "\n"
+      " - valid units: 'mb', 'hPa', 'Pa'\n");
 
-  // Convert pressure level to Pa, the units of pressure in the simulation
+  // Figure out the pressure value, and convert to Pa if needed
+  auto p_value = m_params.get<std::string>("pressure_value");
+
   if (units=="mb" || units=="hPa") {
-    m_pressure_level *= 100;
+    m_pressure_level = std::stod(p_value)*100;
+  } else {
+    m_pressure_level = std::stod(p_value);
   }
 
-  m_mask_val = m_params.get<double>("mask_value",Real(constants::DefaultFillValue<float>::value));
-
-  m_diag_name = m_field_name + "_at_" + location;
+  m_diag_name = m_field_name + "_at_" + p_value + units;
 }
 
 void FieldAtPressureLevel::
@@ -91,6 +83,8 @@ initialize_impl (const RunType /*run_type*/)
   // Add a field representing the mask as extra data to the diagnostic field.
   auto nondim = ekat::units::Units::nondimensional();
   const auto& gname = fid.get_grid_name();
+  m_mask_val = m_params.get<double>("mask_value",Real(constants::DefaultFillValue<float>::value));
+
 
   std::string mask_name = name() + " mask";
   FieldLayout mask_layout( {COL}, {num_cols});

--- a/components/eamxx/src/diagnostics/field_at_pressure_level.hpp
+++ b/components/eamxx/src/diagnostics/field_at_pressure_level.hpp
@@ -20,7 +20,7 @@ public:
   FieldAtPressureLevel (const ekat::Comm& comm, const ekat::ParameterList& params);
 
   // The name of the diagnostic
-  std::string name () const { return m_diag_name; }
+  std::string name () const { return "FieldAtPressureLevel"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/number_path.cpp
+++ b/components/eamxx/src/diagnostics/number_path.cpp
@@ -33,8 +33,6 @@ NumberPathDiagnostic::NumberPathDiagnostic(const ekat::Comm &comm,
   }
 }
 
-std::string NumberPathDiagnostic::name() const { return m_kind + "NumberPath"; }
-
 void NumberPathDiagnostic::set_grids(
     const std::shared_ptr<const GridsManager> grids_manager) {
   using namespace ekat::units;
@@ -55,7 +53,7 @@ void NumberPathDiagnostic::set_grids(
   add_field<Required>(m_nname, scalar3d, 1 / kg, grid_name);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid(name(), scalar2d, kg/(kg*m2), grid_name);
+  FieldIdentifier fid(m_kind + "NumberPath", scalar2d, kg/(kg*m2), grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 }

--- a/components/eamxx/src/diagnostics/number_path.hpp
+++ b/components/eamxx/src/diagnostics/number_path.hpp
@@ -16,7 +16,7 @@ class NumberPathDiagnostic : public AtmosphereDiagnostic {
                        const ekat::ParameterList &params);
 
   // The name of the diagnostic
-  std::string name() const;
+  std::string name() const override { return "NumberPath"; }
 
   // Set the grid
   void set_grids(const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/potential_temperature.cpp
+++ b/components/eamxx/src/diagnostics/potential_temperature.cpp
@@ -24,11 +24,6 @@ PotentialTemperatureDiagnostic::PotentialTemperatureDiagnostic (const ekat::Comm
   }
 }
 
-std::string PotentialTemperatureDiagnostic::name() const
-{
-  return m_ptype;
-}
-
 // =========================================================================================
 void PotentialTemperatureDiagnostic::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
 {
@@ -51,7 +46,7 @@ void PotentialTemperatureDiagnostic::set_grids(const std::shared_ptr<const Grids
   add_field<Required>("qc",             scalar3d_layout_mid, kg/kg,  grid_name, ps);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar3d_layout_mid, K, grid_name);
+  FieldIdentifier fid (m_ptype, scalar3d_layout_mid, K, grid_name);
   m_diagnostic_output = Field(fid);
   auto& C_ap = m_diagnostic_output.get_header().get_alloc_properties();
   C_ap.request_allocation(ps);

--- a/components/eamxx/src/diagnostics/potential_temperature.hpp
+++ b/components/eamxx/src/diagnostics/potential_temperature.hpp
@@ -22,7 +22,7 @@ public:
   PotentialTemperatureDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
   // The name of the diagnostic
-  std::string name () const;
+  std::string name () const override { return "PotentialTemperature"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/precip_surf_mass_flux.cpp
+++ b/components/eamxx/src/diagnostics/precip_surf_mass_flux.cpp
@@ -47,7 +47,7 @@ set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   }
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid(name(), scalar2d_layout_mid, m/s, grid_name);
+  FieldIdentifier fid(m_name, scalar2d_layout_mid, m/s, grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.get_header().get_alloc_properties().request_allocation();
   m_diagnostic_output.allocate_view();

--- a/components/eamxx/src/diagnostics/precip_surf_mass_flux.hpp
+++ b/components/eamxx/src/diagnostics/precip_surf_mass_flux.hpp
@@ -17,7 +17,7 @@ public:
   PrecipSurfMassFlux (const ekat::Comm& comm, const ekat::ParameterList& params);
 
   // The name of the diagnostic
-  std::string name () const { return m_name; }
+  std::string name () const { return "PrecipSurfMassFlux"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/register_diagnostics.hpp
+++ b/components/eamxx/src/diagnostics/register_diagnostics.hpp
@@ -36,13 +36,6 @@ inline void register_diagnostics () {
   diag_factory.register_product("AtmosphereDensity",&create_atmosphere_diagnostic<AtmDensityDiagnostic>);
   diag_factory.register_product("Exner",&create_atmosphere_diagnostic<ExnerDiagnostic>);
   diag_factory.register_product("VirtualTemperature",&create_atmosphere_diagnostic<VirtualTemperatureDiagnostic>);
-  diag_factory.register_product("z_int",&create_atmosphere_diagnostic<VerticalLayerDiagnostic>);
-  diag_factory.register_product("z_mid",&create_atmosphere_diagnostic<VerticalLayerDiagnostic>);
-  diag_factory.register_product("geopotential_int",&create_atmosphere_diagnostic<VerticalLayerDiagnostic>);
-  diag_factory.register_product("geopotential_mid",&create_atmosphere_diagnostic<VerticalLayerDiagnostic>);
-  diag_factory.register_product("height_int",&create_atmosphere_diagnostic<VerticalLayerDiagnostic>);
-  diag_factory.register_product("height_mid",&create_atmosphere_diagnostic<VerticalLayerDiagnostic>);
-  diag_factory.register_product("dz",&create_atmosphere_diagnostic<VerticalLayerDiagnostic>);
   diag_factory.register_product("DryStaticEnergy",&create_atmosphere_diagnostic<DryStaticEnergyDiagnostic>);
   diag_factory.register_product("SeaLevelPressure",&create_atmosphere_diagnostic<SeaLevelPressureDiagnostic>);
   diag_factory.register_product("WaterPath",&create_atmosphere_diagnostic<WaterPathDiagnostic>);
@@ -50,6 +43,7 @@ inline void register_diagnostics () {
   diag_factory.register_product("LongwaveCloudForcing",&create_atmosphere_diagnostic<LongwaveCloudForcingDiagnostic>);
   diag_factory.register_product("RelativeHumidity",&create_atmosphere_diagnostic<RelativeHumidityDiagnostic>);
   diag_factory.register_product("VaporFlux",&create_atmosphere_diagnostic<VaporFluxDiagnostic>);
+  diag_factory.register_product("VerticalLayer",&create_atmosphere_diagnostic<VerticalLayerDiagnostic>);
   diag_factory.register_product("precip_surf_mass_flux",&create_atmosphere_diagnostic<PrecipSurfMassFlux>);
   diag_factory.register_product("surface_upward_latent_heat_flux",&create_atmosphere_diagnostic<SurfaceUpwardLatentHeatFlux>);
   diag_factory.register_product("wind_speed",&create_atmosphere_diagnostic<WindSpeed>);
@@ -60,4 +54,5 @@ inline void register_diagnostics () {
 }
 
 } // namespace scream
+
 #endif // SCREAM_REGISTER_DIAGNOSTICS_HPP

--- a/components/eamxx/src/diagnostics/tests/CMakeLists.txt
+++ b/components/eamxx/src/diagnostics/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# NOTE: tests inside this if statement won't be built in a baselines-only build
+include(ScreamUtils)
 
 function (createDiagTest test_name test_srcs)
   CreateUnitTest(${test_name} "${test_srcs}"
@@ -6,72 +6,68 @@ function (createDiagTest test_name test_srcs)
     LABELS diagnostics)
 endfunction ()
 
-if (NOT SCREAM_ONLY_GENERATE_BASELINES)
-  include(ScreamUtils)
+# Test extracting a single level of a field
+CreateDiagTest(field_at_level "field_at_level_tests.cpp")
 
-  # Test extracting a single level of a field
-  CreateDiagTest(field_at_level "field_at_level_tests.cpp")
+# Test interpolating a field onto a single pressure level
+CreateDiagTest(field_at_pressure_level "field_at_pressure_level_tests.cpp")
 
-  # Test interpolating a field onto a single pressure level
-  CreateDiagTest(field_at_pressure_level "field_at_pressure_level_tests.cpp")
-  # Test interpolating a field at a specific height
-  CreateDiagTest(field_at_height "field_at_height_tests.cpp")
+# Test interpolating a field at a specific height
+CreateDiagTest(field_at_height "field_at_height_tests.cpp")
 
-  # Test potential temperature diagnostic
-  CreateDiagTest(potential_temperature "potential_temperature_test.cpp")
+# Test potential temperature diagnostic
+CreateDiagTest(potential_temperature "potential_temperature_test.cpp")
 
-  # Test exner diagnostic
-  CreateDiagTest(exner_function "exner_test.cpp")
+# Test exner diagnostic
+CreateDiagTest(exner_function "exner_test.cpp")
 
-  # Test virtual temperature
-  CreateDiagTest(virtual_temperature "virtual_temperature_test.cpp")
+# Test virtual temperature
+CreateDiagTest(virtual_temperature "virtual_temperature_test.cpp")
 
-  # Test atmosphere density
-  CreateDiagTest(atmosphere_density "atm_density_test.cpp")
+# Test atmosphere density
+CreateDiagTest(atmosphere_density "atm_density_test.cpp")
 
-  # Test vertical layer (dz, z_int, z_mid)
-  CreateDiagTest(vertical_layer "vertical_layer_tests.cpp")
+# Test vertical layer (dz, z_int, z_mid)
+CreateDiagTest(vertical_layer "vertical_layer_tests.cpp")
 
-  # Test dry static energy
-  CreateDiagTest(dry_static_energy "dry_static_energy_test.cpp")
+# Test dry static energy
+CreateDiagTest(dry_static_energy "dry_static_energy_test.cpp")
 
-  # Test sea level pressure
-  CreateDiagTest(sea_level_pressure "sea_level_pressure_test.cpp")
+# Test sea level pressure
+CreateDiagTest(sea_level_pressure "sea_level_pressure_test.cpp")
 
-  # Test total water path
-  CreateDiagTest(water_path "water_path_tests.cpp")
+# Test total water path
+CreateDiagTest(water_path "water_path_tests.cpp")
 
-  # Test shortwave cloud forcing
-  CreateDiagTest(shortwave_cloud_forcing "shortwave_cloud_forcing_tests.cpp")
+# Test shortwave cloud forcing
+CreateDiagTest(shortwave_cloud_forcing "shortwave_cloud_forcing_tests.cpp")
 
-  # Test longwave cloud forcing
-  CreateDiagTest(longwave_cloud_forcing "longwave_cloud_forcing_tests.cpp")
+# Test longwave cloud forcing
+CreateDiagTest(longwave_cloud_forcing "longwave_cloud_forcing_tests.cpp")
 
-  # Test Relative Humidity
-  CreateDiagTest(relative_humidity "relative_humidity_tests.cpp")
+# Test Relative Humidity
+CreateDiagTest(relative_humidity "relative_humidity_tests.cpp")
 
-  # Test Vapor Flux
-  CreateDiagTest(vapor_flux "vapor_flux_tests.cpp")
+# Test Vapor Flux
+CreateDiagTest(vapor_flux "vapor_flux_tests.cpp")
 
-  # Test precipitation mass surface flux
-  CreateDiagTest(precip_surf_mass_flux "precip_surf_mass_flux_tests.cpp")
+# Test precipitation mass surface flux
+CreateDiagTest(precip_surf_mass_flux "precip_surf_mass_flux_tests.cpp")
 
-  # Test surface latent heat flux
-  CreateDiagTest(surface_upward_latent_heat_flux "surf_upward_latent_heat_flux_tests.cpp")
+# Test surface latent heat flux
+CreateDiagTest(surface_upward_latent_heat_flux "surf_upward_latent_heat_flux_tests.cpp")
 
-  # Test wind speed diagnostic
-  CreateDiagTest(wind_speed "wind_speed_tests.cpp")
+# Test wind speed diagnostic
+CreateDiagTest(wind_speed "wind_speed_tests.cpp")
 
-  # Test AODVIS
-  CreateDiagTest(aodvis "aodvis_test.cpp")
+# Test AODVIS
+CreateDiagTest(aodvis "aodvis_test.cpp")
 
-  # Test "number" paths
-  CreateDiagTest(number_paths "number_paths_tests.cpp")
+# Test "number" paths
+CreateDiagTest(number_paths "number_paths_tests.cpp")
 
-  # Test AEROCOM_CLD
-  CreateDiagTest(aerocom_cld "aerocom_cld_test.cpp")
+# Test AEROCOM_CLD
+CreateDiagTest(aerocom_cld "aerocom_cld_test.cpp")
 
-  # Test atm_tend
-  CreateDiagTest(atm_backtend "atm_backtend_test.cpp")
-
-endif()
+# Test atm_tend
+CreateDiagTest(atm_backtend "atm_backtend_test.cpp")

--- a/components/eamxx/src/diagnostics/tests/field_at_height_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/field_at_height_tests.cpp
@@ -104,12 +104,13 @@ TEST_CASE("field_at_height")
 
   // Lambda to create and run a diag, and return output
   auto run_diag = [&](const Field& f, const Field& z,
-                      const std::string& loc, const std::string& surf_ref) {
+                      const double h, const std::string& surf_ref) {
     util::TimeStamp t0 ({2022,1,1},{0,0,0});
     auto& factory = AtmosphereDiagnosticFactory::instance();
     ekat::ParameterList pl;
     pl.set("surface_reference",surf_ref);
-    pl.set("vertical_location",loc);
+    pl.set("height_value",std::to_string(h));
+    pl.set("height_units",std::string("m"));
     pl.set("field_name",f.name());
     pl.set("grid_name",grid->name());
     auto diag = factory.create("FieldAtheight",comm,pl);
@@ -173,13 +174,12 @@ TEST_CASE("field_at_height")
   // Make sure that an unsupported reference height throws an error.
   print(" -> Testing throws error with unsupported reference height...\n");
   {
-    REQUIRE_THROWS(run_diag (s_mid,h_mid,"1m","foobar"));
+    REQUIRE_THROWS(run_diag (s_mid,h_mid,1.0,"foobar"));
   }
   print(" -> Testing throws error with unsupported reference height... OK\n");
 
   // Run many times
   int z_tgt;
-  std::string loc;
   for (std::string surf_ref : {"sealevel","surface"}) {
     printf(" -> Testing for a reference height above %s...\n",surf_ref.c_str());
     const auto mid_src = surf_ref == "sealevel" ? z_mid : h_mid;
@@ -197,32 +197,31 @@ TEST_CASE("field_at_height")
 
       // Set target z-slice for testing to a random value.
       z_tgt = pdf_levs(engine)+max_surf_4test;
-      loc = std::to_string(z_tgt) + "m";
-      printf("  -> test at height of %s.............\n",loc.c_str());
+      printf("  -> test at height of %dm............\n",z_tgt);
       {
         print("    -> scalar midpoint field...............\n");
-        auto d = run_diag(s_mid,mid_src,loc,surf_ref);
+        auto d = run_diag(s_mid,mid_src,z_tgt,surf_ref);
         f_z_tgt(inter,slope,z_tgt,mid_src,s_tgt);
         REQUIRE (views_are_approx_equal(d,s_tgt,tol));
         print("    -> scalar midpoint field............... OK!\n");
       }
       {
         print("    -> scalar interface field...............\n");
-        auto d = run_diag (s_int,int_src,loc,surf_ref);
+        auto d = run_diag (s_int,int_src,z_tgt,surf_ref);
         f_z_tgt(inter,slope,z_tgt,int_src,s_tgt);
         REQUIRE (views_are_approx_equal(d,s_tgt,tol));
         print("    -> scalar interface field............... OK!\n");
       }
       {
         print("    -> vector midpoint field...............\n");
-        auto d = run_diag (v_mid,mid_src,loc,surf_ref);
+        auto d = run_diag (v_mid,mid_src,z_tgt,surf_ref);
         f_z_tgt(inter,slope,z_tgt,mid_src,v_tgt);
         REQUIRE (views_are_approx_equal(d,v_tgt,tol));
         print("    -> vector midpoint field............... OK!\n");
       }
       {
         print("    -> vector interface field...............\n");
-        auto d = run_diag (v_int,int_src,loc,surf_ref);
+        auto d = run_diag (v_int,int_src,z_tgt,surf_ref);
         f_z_tgt(inter,slope,z_tgt,int_src,v_tgt);
         REQUIRE (views_are_approx_equal(d,v_tgt,tol));
         print("    -> vector interface field............... OK!\n");
@@ -230,8 +229,7 @@ TEST_CASE("field_at_height")
       {
         print("    -> Forced fail, give incorrect location...............\n");
         const int z_tgt_adj = (z_tgt+max_surf_4test)/2;
-        std::string loc_err = std::to_string(z_tgt_adj) + "m";
-        auto d = run_diag(s_int,int_src,loc_err,surf_ref);
+        auto d = run_diag(s_int,int_src,z_tgt_adj,surf_ref);
         f_z_tgt(inter,slope,z_tgt,int_src,s_tgt);
         REQUIRE (!views_are_approx_equal(d,s_tgt,tol,false));
         print("    -> Forced fail, give incorrect location............... OK!\n");
@@ -243,15 +241,13 @@ TEST_CASE("field_at_height")
       auto inter = pdf_y0(engine);
       f_z_src(inter, slope, int_src, s_int);
       z_tgt = 2*z_top;
-      std::string loc = std::to_string(z_tgt) + "m";
-      auto dtop = run_diag(s_int,int_src,loc,surf_ref);
+      auto dtop = run_diag(s_int,int_src,z_tgt,surf_ref);
       f_z_tgt(inter,slope,z_tgt,int_src,s_tgt);
       REQUIRE (views_are_approx_equal(dtop,s_tgt,tol));
       print("    -> Forced extrapolation at top............... OK!\n");
       print("    -> Forced extrapolation at bot...............\n");
       z_tgt = 0;
-      loc = std::to_string(z_tgt) + "m";
-      auto dbot = run_diag(s_int,int_src,loc,surf_ref);
+      auto dbot = run_diag(s_int,int_src,z_tgt,surf_ref);
       f_z_tgt(inter,slope,z_tgt,int_src,s_tgt);
       REQUIRE (views_are_approx_equal(dbot,s_tgt,tol));
       print("    -> Forced extrapolation at bot............... OK!\n");

--- a/components/eamxx/src/diagnostics/tests/field_at_pressure_level_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/field_at_pressure_level_tests.cpp
@@ -224,7 +224,8 @@ get_test_diag(const ekat::Comm& comm, std::shared_ptr<const FieldManager> fm, st
     ekat::ParameterList params;
     params.set("field_name",field.name());
     params.set("grid_name",fm->get_grid()->name());
-    params.set("vertical_location",std::to_string(plevel) + "Pa");
+    params.set("pressure_value",std::to_string(plevel));
+    params.set("pressure_units",std::string("Pa"));
     auto diag = std::make_shared<FieldAtPressureLevel>(comm,params);
     diag->set_grids(gm);
     for (const auto& req : diag->get_required_field_requests()) {

--- a/components/eamxx/src/diagnostics/tests/vertical_layer_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/vertical_layer_tests.cpp
@@ -50,14 +50,10 @@ void run (const std::string& diag_name, const std::string& location)
   
   // Construct the Diagnostic
   ekat::ParameterList params;
-  std::string name = diag_name;
-  if (location=="midpoints") {
-    name += "_mid";
-  } else if (location=="interfaces") {
-    name += "_int";
-  }
-  params.set<std::string>("diag_name", name);
-  auto diag = diag_factory.create(name,comm,params);
+
+  params.set<std::string>("diag_name", diag_name);
+  params.set<std::string>("vert_location",location);
+  auto diag = diag_factory.create("VerticalLayer",comm,params);
   diag->set_grids(gm);
 
   const bool needs_phis = diag_name=="z" or diag_name=="geopotential";
@@ -180,7 +176,7 @@ TEST_CASE("vertical_layer_test", "vertical_layer_test]"){
     std::string msg = "    -> Testing diag=dz ";
     std::string dots (50-msg.size(),'.');
     root_print (msg + dots + "\n");
-    run<Device, N>("dz", "UNUSED");
+    run<Device, N>("dz", "midpoints");
     root_print (msg + dots + " PASS!\n");
   };
 

--- a/components/eamxx/src/diagnostics/vapor_flux.cpp
+++ b/components/eamxx/src/diagnostics/vapor_flux.cpp
@@ -26,11 +26,6 @@ VaporFluxDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params)
   }
 }
 
-std::string VaporFluxDiagnostic::name() const
-{
-  return m_component==0 ? "ZonalVapFlux" : "MeridionalVapFlux";
-}
-
 void VaporFluxDiagnostic::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
 {
   using namespace ekat::units;
@@ -51,7 +46,8 @@ void VaporFluxDiagnostic::set_grids(const std::shared_ptr<const GridsManager> gr
   add_field<Required>("horiz_winds",    vector3d, m/s,   grid_name);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar2d, kg/m/s, grid_name);
+  std::string dname = m_component==0 ? "ZonalVapFlux" : "MeridionalVapFlux";
+  FieldIdentifier fid (dname, scalar2d, kg/m/s, grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 }

--- a/components/eamxx/src/diagnostics/vapor_flux.hpp
+++ b/components/eamxx/src/diagnostics/vapor_flux.hpp
@@ -17,7 +17,7 @@ public:
   VaporFluxDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
   // The name of the diagnostic
-  std::string name () const;
+  std::string name () const override { return "VaporFlux"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/vertical_layer.cpp
+++ b/components/eamxx/src/diagnostics/vertical_layer.cpp
@@ -13,25 +13,27 @@ VerticalLayerDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& para
   : AtmosphereDiagnostic(comm,params)
 {
   m_diag_name = params.get<std::string>("diag_name");
-  std::vector<std::string> supported = {
-    "z_int",
-    "z_mid",
-    "geopotential_int",
-    "geopotential_mid",
-    "height_int",
-    "height_mid",
-    "dz"
-  };
+  std::vector<std::string> supported = {"z","geopotential","height","dz"};
 
   EKAT_REQUIRE_MSG(ekat::contains(supported,m_diag_name),
       "[VerticalLayerDiagnostic] Error! Invalid diag_name.\n"
       "  - diag_name  : " + m_diag_name + "\n"
       "  - valid names: " + ekat::join(supported,", ") + "\n");
 
-  m_is_interface_layout = m_diag_name.find("_int") != std::string::npos;
+  auto vert_pos = params.get<std::string>("vert_location");
+  EKAT_REQUIRE_MSG (vert_pos=="mid" || vert_pos=="int" ||
+                    vert_pos=="midpoints" || vert_pos=="interfaces",
+      "[VerticalLayerDiagnostic] Error! Invalid 'vert_location'.\n"
+      "  - input value: " + vert_pos + "\n"
+      "  - valid names: mid, midpoints, int, interfaces\n");
+  m_is_interface_layout = vert_pos=="int" || vert_pos=="interfaces";
 
-  m_geopotential = m_diag_name.substr(0,12)=="geopotential";
-  m_from_sea_level = m_diag_name[0]=='z' or m_geopotential;
+  m_geopotential = m_diag_name=="geopotential";
+  m_from_sea_level = m_diag_name=="z" or m_geopotential;
+
+  if (m_diag_name!="dz") {
+    m_diag_name += m_is_interface_layout ? "_int" : "_mid";
+  }
 }
 // ========================================================================================
 void VerticalLayerDiagnostic::
@@ -88,7 +90,7 @@ initialize_impl (const RunType /*run_type*/)
   const auto VLEV  = m_is_interface_layout ? ILEV : LEV;
   const auto nlevs = m_is_interface_layout ? m_num_levs+1 : m_num_levs;
   FieldLayout diag_layout ({COL,VLEV},{m_num_cols,nlevs});
-  FieldIdentifier fid (name(), diag_layout, m_geopotential ? m2/s2 : m, grid_name);
+  FieldIdentifier fid (m_diag_name, diag_layout, m_geopotential ? m2/s2 : m, grid_name);
 
   m_diagnostic_output = Field(fid);
   auto& diag_fap = m_diagnostic_output.get_header().get_alloc_properties();

--- a/components/eamxx/src/diagnostics/vertical_layer.hpp
+++ b/components/eamxx/src/diagnostics/vertical_layer.hpp
@@ -24,7 +24,7 @@ public:
   VerticalLayerDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
   // The name of the diagnostic.
-  std::string name () const { return m_diag_name; }
+  std::string name () const { return "VerticalLayer"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/water_path.cpp
+++ b/components/eamxx/src/diagnostics/water_path.cpp
@@ -32,11 +32,6 @@ WaterPathDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params)
   }
 }
 
-std::string WaterPathDiagnostic::name() const
-{
-  return m_kind + "WaterPath";
-}
-
 void WaterPathDiagnostic::
 set_grids(const std::shared_ptr<const GridsManager> grids_manager)
 {
@@ -57,7 +52,7 @@ set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   add_field<Required>(m_qname,          scalar3d, kg/kg, grid_name);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar2d, kg/m2, grid_name);
+  FieldIdentifier fid (m_kind + "WaterPath", scalar2d, kg/m2, grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 }

--- a/components/eamxx/src/diagnostics/water_path.hpp
+++ b/components/eamxx/src/diagnostics/water_path.hpp
@@ -17,7 +17,7 @@ public:
   WaterPathDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
   // The name of the diagnostic
-  std::string name () const;
+  std::string name () const override { return "WaterPath"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/dynamics/homme/homme_grids_manager.cpp
+++ b/components/eamxx/src/dynamics/homme/homme_grids_manager.cpp
@@ -188,7 +188,7 @@ void HommeGridsManager::build_dynamics_grid () {
   initialize_vertical_coordinates(dyn_grid);
 
   dyn_grid->m_short_name = "dyn";
-  add_grid(dyn_grid);
+  add_nonconst_grid(dyn_grid);
 }
 
 void HommeGridsManager::
@@ -307,7 +307,7 @@ build_physics_grid (const ci_string& type, const ci_string& rebalance) {
   }
 
   phys_grid->m_short_name = type;
-  add_grid(phys_grid);
+  add_nonconst_grid(phys_grid);
 }
 
 void HommeGridsManager::

--- a/components/eamxx/src/share/grid/grids_manager.cpp
+++ b/components/eamxx/src/share/grid/grids_manager.cpp
@@ -7,7 +7,24 @@ auto GridsManager::
 get_grid(const std::string& name) const
  -> grid_ptr_type
 {
-  auto g = get_grid_nonconst(name);
+  EKAT_REQUIRE_MSG (has_grid(name),
+      "Error! Grids manager '" + this->name() + "' does not provide grid '" + name + "'.\n"
+      "       Avaialble grids are: " + print_available_grids()  + "\n");
+
+  grid_ptr_type g;
+  for (const auto& it : m_grids) {
+    if (it.second->name()==name or
+        ekat::contains(it.second->aliases(),name)) {
+      g = it.second;
+      break;
+    }
+  }
+
+  EKAT_REQUIRE_MSG (g!=nullptr,
+      "Something went wrong while looking up a grid.\n"
+      "  - grids manager: " + this->name() + "\n"
+      "  - grid name    : " + name   + "\n");
+
   return g;
 }
 
@@ -51,7 +68,14 @@ create_remapper (const grid_ptr_type& from_grid,
 }
 
 void GridsManager::
-add_grid (nonconstgrid_ptr_type grid)
+add_nonconst_grid (nonconstgrid_ptr_type grid)
+{
+  add_grid(grid);
+  m_nonconst_grids[grid->name()] = grid;
+}
+
+void GridsManager::
+add_grid (grid_ptr_type grid)
 {
   const auto& name = grid->name();
   EKAT_REQUIRE_MSG (not has_grid(name),
@@ -59,7 +83,6 @@ add_grid (nonconstgrid_ptr_type grid)
       "  - grids manager: " + this->name() + "\n"
       "  - grid name    : " + name + "\n");
 
-  m_nonconst_grids[name] = grid;
   m_grids[name] = grid;
 }
 
@@ -86,7 +109,6 @@ get_grid_nonconst (const std::string& name) const
       "  - grid name    : " + name   + "\n");
 
   return g;
-  
 }
 
 void GridsManager::

--- a/components/eamxx/src/share/grid/grids_manager.hpp
+++ b/components/eamxx/src/share/grid/grids_manager.hpp
@@ -56,7 +56,8 @@ public:
 
 protected:
 
-  void add_grid (nonconstgrid_ptr_type grid);
+  void add_nonconst_grid (nonconstgrid_ptr_type grid);
+  void add_grid (grid_ptr_type grid);
   void alias_grid (const std::string& grid_name, const std::string& grid_alias);
 
   virtual remapper_ptr_type

--- a/components/eamxx/src/share/grid/library_grids_manager.hpp
+++ b/components/eamxx/src/share/grid/library_grids_manager.hpp
@@ -1,0 +1,49 @@
+#ifndef EAMXX_LIBRARY_GRIDS_MANAGER_HPP
+#define EAMXX_LIBRARY_GRIDS_MANAGER_HPP
+
+#include "share/grid/grids_manager.hpp"
+
+namespace scream {
+
+// This class is meant to be used within scopes that need a grids manager
+// object, but they only have pre-built grids. The user can then simply
+// create a LibraryGridsManager, and add the pre-existing grids. Afterwards,
+// it's business as usual with GridsManager's interfaces.
+
+class LibraryGridsManager : public GridsManager
+{
+public:
+  template<typename... Pointers>
+  explicit LibraryGridsManager(Pointers&&... ptrs) {
+    add_grids(std::forward<Pointers>(ptrs)...);
+  }
+
+  virtual ~LibraryGridsManager () = default;
+
+  std::string name () const { return "Library grids_manager"; }
+
+  void build_grids () override {}
+
+  void add_grids () {}
+
+  template<typename... Pointers>
+  void add_grids (grid_ptr_type p, Pointers&&... ptrs) {
+    add_grid(p);
+    add_grids(std::forward<Pointers>(ptrs)...);
+  }
+
+protected:
+  remapper_ptr_type
+  do_create_remapper (const grid_ptr_type from_grid,
+                      const grid_ptr_type to_grid) const
+  {
+    EKAT_ERROR_MSG (
+        "Error! LibraryGridsManager is not capable of creating remappers.\n"
+        " - from_grid: " + from_grid->name() + "\n"
+        " - to_grid:   " + to_grid->name() + "\n");
+  }
+};
+
+} // namespace scream
+
+#endif // EAMXX_LIBRARY_GRIDS_MANAGER_HPP

--- a/components/eamxx/src/share/grid/mesh_free_grids_manager.cpp
+++ b/components/eamxx/src/share/grid/mesh_free_grids_manager.cpp
@@ -106,7 +106,7 @@ build_se_grid (const std::string& name, ekat::ParameterList& params)
   se_grid->m_short_name = "se";
   add_geo_data(se_grid);
 
-  add_grid(se_grid);
+  add_nonconst_grid(se_grid);
 }
 
 void MeshFreeGridsManager::
@@ -132,7 +132,7 @@ build_point_grid (const std::string& name, ekat::ParameterList& params)
   add_geo_data(pt_grid);
   pt_grid->m_short_name = "pt";
 
-  add_grid(pt_grid);
+  add_nonconst_grid(pt_grid);
 }
 
 void MeshFreeGridsManager::

--- a/components/eamxx/src/share/io/CMakeLists.txt
+++ b/components/eamxx/src/share/io/CMakeLists.txt
@@ -59,7 +59,7 @@ add_library(scream_io
   scream_io_utils.cpp
 )
 
-target_link_libraries(scream_io PUBLIC scream_share scream_scorpio_interface)
+target_link_libraries(scream_io PUBLIC scream_share scream_scorpio_interface diagnostics)
 
 if (NOT SCREAM_LIB_ONLY)
   add_subdirectory(tests)

--- a/components/eamxx/src/share/io/scream_io_utils.cpp
+++ b/components/eamxx/src/share/io/scream_io_utils.cpp
@@ -1,6 +1,7 @@
 #include "share/io/scream_io_utils.hpp"
 
 #include "share/io/scream_scorpio_interface.hpp"
+#include "share/grid/library_grids_manager.hpp"
 #include "share/util/scream_utils.hpp"
 #include "share/scream_config.hpp"
 
@@ -115,6 +116,92 @@ util::TimeStamp read_timestamp (const std::string& filename,
     ts.set_num_steps(scorpio::get_attribute<int>(filename,"GLOBAL",ts_name+"_nsteps"));
   }
   return ts;
+}
+
+std::shared_ptr<AtmosphereDiagnostic>
+create_diagnostic (const std::string& diag_field_name,
+                   const std::shared_ptr<const AbstractGrid>& grid)
+{
+  // Note: use grouping (the (..) syntax), so you can later query the content
+  //       of each group in the matches output var!
+  // Note: use raw string syntax R"(<string>)" to avoid having to escape the \ character
+  // Note: the number for field_at_p/h can match positive integer/floating-point numbers
+  std::regex field_at_l (R"(([A-Za-z0-9_]+)_at_(lev_(\d+)|model_(top|bot))$)");
+  std::regex field_at_p (R"(([A-Za-z0-9_]+)_at_(\d+(\.\d+)?)(hPa|mb|Pa)$)");
+  std::regex field_at_h (R"(([A-Za-z0-9_]+)_at_(\d+(\.\d+)?)(m)_above_(sealevel|surface)$)");
+  std::regex surf_mass_flux ("precip_(liq|ice|total)_surf_mass_flux$");
+  std::regex water_path ("(Ice|Liq|Rain|Rime|Vap)WaterPath$");
+  std::regex number_path ("(Ice|Liq|Rain)NumberPath$");
+  std::regex aerocom_cld ("AeroComCld(Top|Bot)$");
+  std::regex vap_flux ("(Meridional|Zonal)VapFlux$");
+  std::regex backtend ("([A-Za-z0-9_]+)_atm_backtend$");
+  std::regex pot_temp ("(Liq)?PotentialTemperature$");
+  std::regex vert_layer ("(z|geopotential|height)_(mid|int)$");
+
+  std::string diag_name;
+  std::smatch matches;
+  ekat::ParameterList params(diag_field_name);
+
+  if (std::regex_search(diag_field_name,matches,field_at_l)) {
+    params.set("field_name",matches[1].str());
+    params.set("grid_name",grid->name());
+    params.set("vertical_location", matches[2].str());
+    diag_name = "FieldAtLevel";
+  } else if (std::regex_search(diag_field_name,matches,field_at_p)) {
+    params.set("field_name",matches[1].str());
+    params.set("grid_name",grid->name());
+    params.set("pressure_value",matches[2].str());
+    params.set("pressure_units", matches[4].str());
+    diag_name = "FieldAtPressureLevel";
+  } else if (std::regex_search(diag_field_name,matches,field_at_h)) {
+    params.set("field_name",matches[1].str());
+    params.set("grid_name",grid->name());
+    params.set("height_value",matches[2].str());
+    params.set("height_units",matches[4].str());
+    params.set("surface_reference", matches[5].str());
+    diag_name = "FieldAtHeight";
+  } else if (std::regex_search(diag_field_name,matches,surf_mass_flux)) {
+    diag_name = "precip_surf_mass_flux";
+    params.set<std::string>("precip_type",matches[1].str());
+  } else if (std::regex_search(diag_field_name,matches,water_path)) {
+    diag_name = "WaterPath";
+    params.set<std::string>("Water Kind",matches[1].str());
+  } else if (std::regex_search(diag_field_name,matches,number_path)) {
+    diag_name = "NumberPath";
+    params.set<std::string>("Number Kind",matches[1].str());
+  } else if (std::regex_search(diag_field_name,matches,aerocom_cld)) {
+    diag_name = "AeroComCld";
+    params.set<std::string>("AeroComCld Kind",matches[1].str());
+  } else if (std::regex_search(diag_field_name,matches,vap_flux)) {
+    diag_name = "VaporFlux";
+    params.set<std::string>("Wind Component",matches[1].str());
+  } else if (std::regex_search(diag_field_name,matches,backtend)) {
+    diag_name = "AtmBackTendDiag";
+    // Set the grid_name
+    params.set("grid_name",grid->name());
+    params.set<std::string>("Tendency Name",matches[1].str());
+  } else if (std::regex_search(diag_field_name,matches,pot_temp)) {
+    diag_name = "PotentialTemperature";
+    params.set<std::string>("Temperature Kind", matches[1].str()!="" ? matches[1].str() : std::string("Tot"));
+  } else if (std::regex_search(diag_field_name,matches,vert_layer)) {
+    diag_name = "VerticalLayer";
+    params.set<std::string>("diag_name",matches[1].str());
+    params.set<std::string>("vert_location",matches[2].str());
+  } else if (diag_field_name=="dz") {
+    diag_name = "VerticalLayer";
+    params.set<std::string>("diag_name","dz");
+    params.set<std::string>("vert_location","mid");
+  } else {
+    // No existing special regex matches, so we assume that the diag field name IS the diag name.
+    diag_name = diag_field_name;
+  }
+
+  auto comm = grid->get_comm();
+  auto diag = AtmosphereDiagnosticFactory::instance().create(diag_name,comm,params);
+  auto gm = std::make_shared<LibraryGridsManager>(grid);
+  diag->set_grids(gm);
+
+  return diag;
 }
 
 } // namespace scream

--- a/components/eamxx/src/share/io/scream_io_utils.hpp
+++ b/components/eamxx/src/share/io/scream_io_utils.hpp
@@ -3,11 +3,14 @@
 
 #include "scream_io_control.hpp"
 #include "share/util/scream_time_stamp.hpp"
+#include "share/atm_process/atmosphere_diagnostic.hpp"
+#include "share/grid/abstract_grid.hpp"
 
 #include <ekat/util/ekat_string_utils.hpp>
 #include <ekat/mpi/ekat_comm.hpp>
 
 #include <string>
+#include <memory>
 
 namespace scream
 {
@@ -183,6 +186,12 @@ void write_timestamp (const std::string& filename, const std::string& ts_name,
 util::TimeStamp read_timestamp (const std::string& filename,
                                 const std::string& ts_name,
                                 const bool read_nsteps = false);
+
+// Create a diagnostic from a string representation of it.
+// E.g., create the diag to compute fieldX_at_500hPa.
+std::shared_ptr<AtmosphereDiagnostic>
+create_diagnostic (const std::string& diag_name,
+                   const std::shared_ptr<const AbstractGrid>& grid);
 
 } // namespace scream
 #endif // SCREAM_IO_UTILS_HPP

--- a/components/eamxx/src/share/io/tests/CMakeLists.txt
+++ b/components/eamxx/src/share/io/tests/CMakeLists.txt
@@ -17,6 +17,12 @@ CreateUnitTest(io_utils "io_utils.cpp"
   PROPERTIES RESOURCE_LOCK rpointer_file
 )
 
+# Test creation of diagnostic from diag_field_name
+CreateUnitTest(create_diag "create_diag.cpp"
+  LIBS diagnostics scream_io
+  LABELS io diagnostics
+)
+
 ## Test basic output (no packs, no diags, all avg types, all freq units)
 CreateUnitTest(io_basic "io_basic.cpp"
   LIBS scream_io LABELS io

--- a/components/eamxx/src/share/io/tests/create_diag.cpp
+++ b/components/eamxx/src/share/io/tests/create_diag.cpp
@@ -1,0 +1,166 @@
+#include "catch2/catch.hpp"
+
+#include "diagnostics/register_diagnostics.hpp"
+
+#include "share/io/scream_io_utils.hpp"
+#include "share/grid/point_grid.hpp"
+
+namespace scream {
+
+TEST_CASE("create_diag")
+{
+  ekat::Comm comm(MPI_COMM_WORLD);
+
+  register_diagnostics();
+
+  // Create a grid
+  const int ncols = 3*comm.size();
+  const int nlevs = 10;
+  auto grid = create_point_grid("Physics",ncols,nlevs,comm);
+
+  SECTION ("field_at") {
+    // FieldAtLevel
+    auto d1 = create_diagnostic("BlaH_123_at_model_top",grid);
+    REQUIRE (std::dynamic_pointer_cast<FieldAtLevel>(d1)!=nullptr);
+    auto d2 = create_diagnostic("BlaH_123_at_model_bot",grid);
+    REQUIRE (std::dynamic_pointer_cast<FieldAtLevel>(d2)!=nullptr);
+    auto d3 = create_diagnostic("BlaH_123_at_lev_10",grid);
+    REQUIRE (std::dynamic_pointer_cast<FieldAtLevel>(d3)!=nullptr);
+
+    REQUIRE_THROWS(create_diagnostic("BlaH_123_at_modeltop",grid)); // misspelled
+
+    // FieldAtPressureLevel
+    auto d4 = create_diagnostic("BlaH_123_at_10mb",grid);
+    REQUIRE (std::dynamic_pointer_cast<FieldAtPressureLevel>(d4)!=nullptr);
+    auto d5 = create_diagnostic("BlaH_123_at_10hPa",grid);
+    REQUIRE (std::dynamic_pointer_cast<FieldAtPressureLevel>(d5)!=nullptr);
+    auto d6 = create_diagnostic("BlaH_123_at_10Pa",grid);
+    REQUIRE (std::dynamic_pointer_cast<FieldAtPressureLevel>(d6)!=nullptr);
+
+    REQUIRE_THROWS(create_diagnostic("BlaH_123_at_400KPa",grid)); // invalid units
+
+    // FieldAtHeight
+    auto d7 = create_diagnostic("BlaH_123_at_10m_above_sealevel",grid);
+    REQUIRE (std::dynamic_pointer_cast<FieldAtHeight>(d7)!=nullptr);
+    auto d8 = create_diagnostic("BlaH_123_at_10m_above_surface",grid);
+    REQUIRE (std::dynamic_pointer_cast<FieldAtHeight>(d8)!=nullptr);
+
+    REQUIRE_THROWS(create_diagnostic("BlaH_123_at_10.5m",grid)); // missing _above_X
+    REQUIRE_THROWS(create_diagnostic("BlaH_123_at_1km_above_sealevel",grid)); // invalid units
+    REQUIRE_THROWS(create_diagnostic("BlaH_123_at_1m_above_the_surface",grid)); // invalid reference
+  }
+
+  SECTION ("precip_mass_flux") {
+    auto d1 = create_diagnostic("precip_liq_surf_mass_flux",grid);
+    REQUIRE (std::dynamic_pointer_cast<PrecipSurfMassFlux>(d1)!=nullptr);
+    REQUIRE (d1->get_params().get<std::string>("precip_type")=="liq");
+
+    auto d2 = create_diagnostic("precip_ice_surf_mass_flux",grid);
+    REQUIRE (std::dynamic_pointer_cast<PrecipSurfMassFlux>(d2)!=nullptr);
+    REQUIRE (d2->get_params().get<std::string>("precip_type")=="ice");
+
+    auto d3 = create_diagnostic("precip_total_surf_mass_flux",grid);
+    REQUIRE (std::dynamic_pointer_cast<PrecipSurfMassFlux>(d3)!=nullptr);
+    REQUIRE (d3->get_params().get<std::string>("precip_type")=="total");
+  }
+
+  SECTION ("water_and_number_path") {
+    auto d1 = create_diagnostic("LiqWaterPath",grid);
+    REQUIRE (std::dynamic_pointer_cast<WaterPathDiagnostic>(d1)!=nullptr);
+    REQUIRE (d1->get_params().get<std::string>("Water Kind")=="Liq");
+
+    auto d2 = create_diagnostic("IceWaterPath",grid);
+    REQUIRE (std::dynamic_pointer_cast<WaterPathDiagnostic>(d2)!=nullptr);
+    REQUIRE (d2->get_params().get<std::string>("Water Kind")=="Ice");
+
+    auto d3 = create_diagnostic("RainWaterPath",grid);
+    REQUIRE (std::dynamic_pointer_cast<WaterPathDiagnostic>(d3)!=nullptr);
+    REQUIRE (d3->get_params().get<std::string>("Water Kind")=="Rain");
+
+    auto d4 = create_diagnostic("RimeWaterPath",grid);
+    REQUIRE (std::dynamic_pointer_cast<WaterPathDiagnostic>(d4)!=nullptr);
+    REQUIRE (d4->get_params().get<std::string>("Water Kind")=="Rime");
+
+    auto d5 = create_diagnostic("VapWaterPath",grid);
+    REQUIRE (std::dynamic_pointer_cast<WaterPathDiagnostic>(d5)!=nullptr);
+    REQUIRE (d5->get_params().get<std::string>("Water Kind")=="Vap");
+
+    auto d6 = create_diagnostic("LiqNumberPath",grid);
+    REQUIRE (std::dynamic_pointer_cast<NumberPathDiagnostic>(d6)!=nullptr);
+    REQUIRE (d6->get_params().get<std::string>("Number Kind")=="Liq");
+
+    auto d7 = create_diagnostic("IceNumberPath",grid);
+    REQUIRE (std::dynamic_pointer_cast<NumberPathDiagnostic>(d7)!=nullptr);
+    REQUIRE (d7->get_params().get<std::string>("Number Kind")=="Ice");
+
+    auto d8 = create_diagnostic("RainNumberPath",grid);
+    REQUIRE (std::dynamic_pointer_cast<NumberPathDiagnostic>(d8)!=nullptr);
+    REQUIRE (d8->get_params().get<std::string>("Number Kind")=="Rain");
+  }
+
+  SECTION ("aerocom_cld") {
+    auto d1 = create_diagnostic("AeroComCldTop",grid);
+    REQUIRE (std::dynamic_pointer_cast<AeroComCld>(d1)!=nullptr);
+    REQUIRE (d1->get_params().get<std::string>("AeroComCld Kind")=="Top");
+
+    auto d2 = create_diagnostic("AeroComCldBot",grid);
+    REQUIRE (std::dynamic_pointer_cast<AeroComCld>(d2)!=nullptr);
+    REQUIRE (d2->get_params().get<std::string>("AeroComCld Kind")=="Bot");
+  }
+
+  SECTION ("vapor_flux") {
+    auto d1 = create_diagnostic("MeridionalVapFlux",grid);
+    REQUIRE (std::dynamic_pointer_cast<VaporFluxDiagnostic>(d1)!=nullptr);
+    REQUIRE (d1->get_params().get<std::string>("Wind Component")=="Meridional");
+
+    auto d2 = create_diagnostic("ZonalVapFlux",grid);
+    REQUIRE (std::dynamic_pointer_cast<VaporFluxDiagnostic>(d2)!=nullptr);
+    REQUIRE (d2->get_params().get<std::string>("Wind Component")=="Zonal");
+  }
+
+  SECTION ("atm_tend") {
+    auto d1 = create_diagnostic("BlaH_123_atm_backtend",grid);
+    REQUIRE (std::dynamic_pointer_cast<AtmBackTendDiag>(d1)!=nullptr);
+    REQUIRE (d1->get_params().get<std::string>("Tendency Name")=="BlaH_123");
+  }
+
+  SECTION ("pot_temp") {
+    auto d1 = create_diagnostic("LiqPotentialTemperature",grid);
+    REQUIRE (std::dynamic_pointer_cast<PotentialTemperatureDiagnostic>(d1)!=nullptr);
+    REQUIRE (d1->get_params().get<std::string>("Temperature Kind")=="Liq");
+
+    auto d2 = create_diagnostic("PotentialTemperature",grid);
+    REQUIRE (std::dynamic_pointer_cast<PotentialTemperatureDiagnostic>(d2)!=nullptr);
+    REQUIRE (d2->get_params().get<std::string>("Temperature Kind")=="Tot");
+  }
+
+  SECTION ("vert_layer") {
+    auto d1 = create_diagnostic("z_mid",grid);
+    REQUIRE (std::dynamic_pointer_cast<VerticalLayerDiagnostic>(d1)!=nullptr);
+    REQUIRE (d1->get_params().get<std::string>("vert_location")=="mid");
+    auto d2 = create_diagnostic("z_int",grid);
+    REQUIRE (std::dynamic_pointer_cast<VerticalLayerDiagnostic>(d2)!=nullptr);
+    REQUIRE (d2->get_params().get<std::string>("vert_location")=="int");
+
+    auto d3 = create_diagnostic("height_mid",grid);
+    REQUIRE (std::dynamic_pointer_cast<VerticalLayerDiagnostic>(d3)!=nullptr);
+    REQUIRE (d3->get_params().get<std::string>("vert_location")=="mid");
+    auto d4 = create_diagnostic("height_int",grid);
+    REQUIRE (std::dynamic_pointer_cast<VerticalLayerDiagnostic>(d4)!=nullptr);
+    REQUIRE (d4->get_params().get<std::string>("vert_location")=="int");
+
+    auto d5 = create_diagnostic("geopotential_mid",grid);
+    REQUIRE (std::dynamic_pointer_cast<VerticalLayerDiagnostic>(d5)!=nullptr);
+    REQUIRE (d5->get_params().get<std::string>("vert_location")=="mid");
+    auto d6 = create_diagnostic("geopotential_int",grid);
+    REQUIRE (std::dynamic_pointer_cast<VerticalLayerDiagnostic>(d6)!=nullptr);
+    REQUIRE (d6->get_params().get<std::string>("vert_location")=="int");
+
+    auto d7 = create_diagnostic("dz",grid);
+    REQUIRE (std::dynamic_pointer_cast<VerticalLayerDiagnostic>(d7)!=nullptr);
+    REQUIRE (d7->get_params().get<std::string>("vert_location")=="mid");
+  }
+
+}
+
+} // namespace scream


### PR DESCRIPTION
Extract creation of diagnostic classes out of the AtmosphereOutput class and into its own routine.

---

This allows to
- reduce length of scorpio_output.cpp (which is way too long)
- make the logic we use to translate a diag name into a diag object more transparent and less hidden
- ability to unit test this logic without having to create output streams.

To avoid issues like the ones discussed in [this](https://github.com/E3SM-Project/E3SM/pull/6788#discussion_r1866688005) conversation, we now use std::regex. The regexes look for special strings (such at "at_500mb") _at the end_ of the diagnostic field name. This ensures that we pipe diagnostics correclty, and process them one at a time. In particular, parsing somethin like `blah_at_500hPa_atm_backtend` is univokely parsed as "the back-tendency of the field `blah_at_500hPa`", the latter being itself a diagnostic to be created once the output class process the "outer" diagnostic inputs.

Side note: it is different to request `T_mid_at_500hPa_atm_backtend` vs `T_mid_atm_backtend_at_500hPa`, since the two diags are nested in specular ways. In the end, the result should be similar (up to roundings/truncations), but computationally speaking, one of the two may be cheaper than the other.