### PR TITLE
Fix conditional jump on uninitialized mem in SHOC

### DIFF
--- a/components/eamxx/src/physics/shoc/impl/shoc_pblintd_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_pblintd_impl.hpp
@@ -77,7 +77,12 @@ void Functions<S,D>::pblintd(
 
   // Initialize
   bool check = true;
-  Kokkos::deep_copy(rino, 0);
+  // The loop below fixes valgrind uninitialized mem errs
+#ifndef NDEBUG
+  for (size_t i=0; i<rino.size(); ++i) {
+    rino(i)=0;
+  }
+#endif
   pblh = s_z(nlev-1);
 
   // PBL height calculation

--- a/components/eamxx/src/physics/shoc/impl/shoc_pblintd_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_pblintd_impl.hpp
@@ -78,7 +78,7 @@ void Functions<S,D>::pblintd(
 
   // Initialize
   bool check = true;
-  s_rino(nlev-1) = 0;
+  Kokkos::deep_copy(rino, 0);
   pblh = s_z(nlev-1);
 
   // PBL height calculation

--- a/components/eamxx/src/physics/shoc/impl/shoc_pblintd_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_pblintd_impl.hpp
@@ -67,6 +67,7 @@ void Functions<S,D>::pblintd(
   // Scalarize views for single entry access
   const auto s_z    = ekat::scalarize(z);
   const auto s_thv  = ekat::scalarize(thv);
+  const auto s_rino = ekat::scalarize(rino);
   const auto s_zi   = ekat::scalarize(zi);
   const auto s_cldn = ekat::scalarize(cldn);
 
@@ -82,6 +83,8 @@ void Functions<S,D>::pblintd(
   for (size_t i=0; i<rino.size(); ++i) {
     rino(i)=0;
   }
+#else
+  s_rino(nlev-1) = 0;
 #endif
   pblh = s_z(nlev-1);
 

--- a/components/eamxx/src/physics/shoc/impl/shoc_pblintd_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_pblintd_impl.hpp
@@ -67,7 +67,6 @@ void Functions<S,D>::pblintd(
   // Scalarize views for single entry access
   const auto s_z    = ekat::scalarize(z);
   const auto s_thv  = ekat::scalarize(thv);
-  const auto s_rino = ekat::scalarize(rino);
   const auto s_zi   = ekat::scalarize(zi);
   const auto s_cldn = ekat::scalarize(cldn);
 


### PR DESCRIPTION
The rino temp view only had the nlev-1 entry initialized. pblintd_height was accessing other entries.

I looked the the F90 impl and it is also doing this strange initialization of only nlev-1.

This PR will fix valgrind errors for shoc_run_and_cmp that have appeared on our dashboard. This error seems to go back a long time, so I don't understand why it only showed up now.