### PR TITLE
EAMXX: add a DataInterpolation class

### DIFF
--- a/components/eamxx/src/dynamics/homme/interface/homme_context_mod.F90
+++ b/components/eamxx/src/dynamics/homme/interface/homme_context_mod.F90
@@ -168,37 +168,37 @@ contains
   function is_parallel_inited_f90 () result(inited) bind(c)
     logical (kind=c_bool) :: inited
 
-    inited = is_parallel_inited
+    inited = LOGICAL(is_parallel_inited,kind=c_bool)
   end function is_parallel_inited_f90
 
   function is_params_inited_f90 () result(inited) bind(c)
     logical (kind=c_bool) :: inited
 
-    inited = is_params_inited
+    inited = LOGICAL(is_params_inited,kind=c_bool)
   end function is_params_inited_f90
 
   function is_geometry_inited_f90 () result(inited) bind(c)
     logical (kind=c_bool) :: inited
 
-    inited = is_geometry_inited
+    inited = LOGICAL(is_geometry_inited,kind=c_bool)
   end function is_geometry_inited_f90
 
   function is_data_structures_inited_f90 () result(inited) bind(c)
     logical (kind=c_bool) :: inited
 
-    inited = is_data_structures_inited
+    inited = LOGICAL(is_data_structures_inited,kind=c_bool)
   end function is_data_structures_inited_f90
 
   function is_model_inited_f90 () result(inited) bind(c)
     logical (kind=c_bool) :: inited
 
-    inited = is_model_inited
+    inited = LOGICAL(is_model_inited,kind=c_bool)
   end function is_model_inited_f90
 
   function is_hommexx_functors_inited_f90 () result(inited) bind(c)
     logical (kind=c_bool) :: inited
 
-    inited = is_hommexx_functors_inited
+    inited = LOGICAL(is_hommexx_functors_inited,kind=c_bool)
   end function is_hommexx_functors_inited_f90
 
 end module homme_context_mod

--- a/components/eamxx/src/physics/mam/readfiles/marine_organics_impl.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/marine_organics_impl.hpp
@@ -154,10 +154,8 @@ void marineOrganicsFunctions<S, D>::update_marine_organics_timestate(
   if(month != time_state.current_month) {
     // Update the marineOrganics time state information
     time_state.current_month = month;
-    time_state.t_beg_month =
-        util::TimeStamp({ts.get_year(), month + 1, 1}, {0, 0, 0})
-            .frac_of_year_in_days();
-    time_state.days_this_month = util::days_in_month(ts.get_year(), month + 1);
+    time_state.t_beg_month = ts.curr_month_beg().frac_of_year_in_days();
+    time_state.days_this_month = ts.days_in_curr_month();
 
     // Copy end'data into beg'data, and read in the new
     // end

--- a/components/eamxx/src/physics/mam/readfiles/tracer_reader_utils.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/tracer_reader_utils.hpp
@@ -508,10 +508,8 @@ inline void update_tracer_timestate(
 
     // Update the tracer external forcing time state information
     time_state.current_month = month;
-    time_state.t_beg_month =
-        util::TimeStamp({ts.get_year(), month + 1, 1}, {0, 0, 0})
-            .frac_of_year_in_days();
-    time_state.days_this_month = util::days_in_month(ts.get_year(), month + 1);
+    time_state.t_beg_month = ts.curr_month_beg().frac_of_year_in_days();
+    time_state.days_this_month = ts.days_in_curr_month();
 
     // Copy spa_end'data into spa_beg'data, and read in the new spa_end
     for(int ivar = 0; ivar < nvars; ++ivar) {

--- a/components/eamxx/src/physics/mam/srf_emission_impl.hpp
+++ b/components/eamxx/src/physics/mam/srf_emission_impl.hpp
@@ -227,10 +227,8 @@ void srfEmissFunctions<S, D>::update_srfEmiss_timestate(
   if(month != time_state.current_month) {
     // Update the srfEmiss time state information
     time_state.current_month = month;
-    time_state.t_beg_month =
-        util::TimeStamp({ts.get_year(), month + 1, 1}, {0, 0, 0})
-            .frac_of_year_in_days();
-    time_state.days_this_month = util::days_in_month(ts.get_year(), month + 1);
+    time_state.t_beg_month = ts.curr_month_beg().frac_of_year_in_days();
+    time_state.days_this_month = ts.days_in_curr_month();
 
     // Copy srfEmiss_end'data into srfEmiss_beg'data, and read in the new
     // srfEmiss_end

--- a/components/eamxx/src/physics/shoc/tests/shoc_pdf_thl_parameters_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pdf_thl_parameters_tests.cpp
@@ -50,8 +50,6 @@ struct UnitWrap::UnitTest<D>::TestShocThlParameters {
     static constexpr Real Skew_w_test1 = 3;
     // Define fraction of first gaussian
     static constexpr Real a_test1 = 0.2;
-    // Define logical
-    static constexpr bool dothetal_skew = false;
 
     // Define reasonable bounds checking for output
     static constexpr Real thl_bound_low = 200; // [K]

--- a/components/eamxx/src/physics/spa/spa_functions_impl.hpp
+++ b/components/eamxx/src/physics/spa/spa_functions_impl.hpp
@@ -568,8 +568,8 @@ void SPAFunctions<S,D>
   if (month != time_state.current_month) {
     // Update the SPA time state information
     time_state.current_month = month;
-    time_state.t_beg_month = util::TimeStamp({ts.get_year(),month+1,1}, {0,0,0}).frac_of_year_in_days();
-    time_state.days_this_month = util::days_in_month(ts.get_year(),month+1);
+    time_state.t_beg_month = ts.curr_month_beg().frac_of_year_in_days();
+    time_state.days_this_month = ts.days_in_curr_month();
 
     // Copy spa_end'data into spa_beg'data, and read in the new spa_end
     std::swap(spa_beg,spa_end);

--- a/components/eamxx/src/physics/spa/tests/spa_main_test.cpp
+++ b/components/eamxx/src/physics/spa/tests/spa_main_test.cpp
@@ -107,7 +107,7 @@ TEST_CASE("spa_main")
   util::TimeStamp t_end(1900,2,1,0,0,0);
   spa_time_state.current_month = t_beg.get_month();
   spa_time_state.t_beg_month = t_beg.frac_of_year_in_days();
-  spa_time_state.days_this_month = util::days_in_month(t_beg.get_year(),t_beg.get_month());
+  spa_time_state.days_this_month = t_beg.days_in_curr_month();
 
   // Generate random beg/end data
   randomize(spa_beg.data,engine,RPDF(1.0,10.0));

--- a/components/eamxx/src/share/CMakeLists.txt
+++ b/components/eamxx/src/share/CMakeLists.txt
@@ -49,14 +49,10 @@ if (EAMXX_ENABLE_EXPERIMENTAL_CODE)
 endif()
 
 add_library(scream_share ${SHARE_SRC})
-set_target_properties(scream_share PROPERTIES
-  Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/modules
-)
 target_include_directories(scream_share PUBLIC
   ${SCREAM_SRC_DIR}
   ${SCREAM_BIN_DIR}/src
   ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR}/modules
 )
 
 if (GPTL_PATH)

--- a/components/eamxx/src/share/CMakeLists.txt
+++ b/components/eamxx/src/share/CMakeLists.txt
@@ -32,13 +32,13 @@ set(SHARE_SRC
   property_checks/field_nan_check.cpp
   property_checks/field_within_interval_check.cpp
   property_checks/mass_and_energy_column_conservation_check.cpp
+  util/eamxx_data_interpolation.cpp
   util/eamxx_fv_phys_rrtmgp_active_gases_workaround.cpp
+  util/eamxx_time_interpolation.cpp
   util/scream_time_stamp.cpp
   util/scream_timing.cpp
   util/scream_utils.cpp
-  util/eamxx_time_interpolation.cpp
   util/scream_bfbhash.cpp
-  util/eamxx_time_interpolation.cpp
 )
 
 if (EAMXX_ENABLE_EXPERIMENTAL_CODE)
@@ -54,6 +54,9 @@ target_include_directories(scream_share PUBLIC
   ${SCREAM_BIN_DIR}/src
   ${CMAKE_CURRENT_SOURCE_DIR}
 )
+# Used in the data interpolation
+target_link_libraries(scream_share PUBLIC stdc++fs)
+
 
 if (GPTL_PATH)
   target_include_directories(scream_share PUBLIC ${GPTL_PATH})

--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
@@ -183,7 +183,7 @@ do_register_field (const identifier_type& src, const identifier_type& tgt)
 {
   constexpr auto COL = ShortFieldTagsNames::COL;
   EKAT_REQUIRE_MSG (src.get_layout().has_tag(COL),
-      "Error! Cannot register a field without COL tag in RefiningRemapperP2P.\n"
+      "Error! Cannot register a field without COL tag in HorizInterpRemapperBase.\n"
       "  - field name: " + src.name() + "\n"
       "  - field layout: " + src.get_layout().to_string() + "\n");
   m_src_fields.push_back(field_type(src));
@@ -194,11 +194,11 @@ void HorizInterpRemapperBase::
 do_bind_field (const int ifield, const field_type& src, const field_type& tgt)
 {
   EKAT_REQUIRE_MSG (src.data_type()==DataType::RealType,
-      "Error! RefiningRemapperRMA only allows fields with RealType data.\n"
+      "Error! HorizInterpRemapperBase only allows fields with RealType data.\n"
       "  - src field name: " + src.name() + "\n"
       "  - src field type: " + e2str(src.data_type()) + "\n");
   EKAT_REQUIRE_MSG (tgt.data_type()==DataType::RealType,
-      "Error! RefiningRemapperRMA only allows fields with RealType data.\n"
+      "Error! HorizInterpRemapperBase only allows fields with RealType data.\n"
       "  - tgt field name: " + tgt.name() + "\n"
       "  - tgt field type: " + e2str(tgt.data_type()) + "\n");
 
@@ -352,7 +352,7 @@ local_mat_vec (const Field& x, const Field& y) const
     }
     default:
     {
-      EKAT_ERROR_MSG("Error::refining_remapper::local_mat_vec doesn't support fields of rank 4 or greater");
+      EKAT_ERROR_MSG("[HorizInterpRemapperBase::local_mat_vec] Error! Fields of rank 4 or greater are not supported.\n");
     }
   }
 }

--- a/components/eamxx/src/share/grid/remap/refining_remapper_p2p.cpp
+++ b/components/eamxx/src/share/grid/remap/refining_remapper_p2p.cpp
@@ -52,7 +52,7 @@ void RefiningRemapperP2P::do_remap_fwd ()
   for (int i=0; i<m_num_fields; ++i) {
     auto& f_tgt = m_tgt_fields[i];
 
-    // Allow to register fields that do not have the COL tag
+    // It's ok to register fields that do not have the COL tag
     // These fields are simply copied from src to tgt.
     if (not f_tgt.get_header().get_identifier().get_layout().has_tag(COL)) {
       f_tgt.deep_copy(m_src_fields[i]);
@@ -89,7 +89,9 @@ void RefiningRemapperP2P::setup_mpi_data_structures ()
   for (int i=0; i<m_num_fields; ++i) {
     const auto& f = m_src_fields[i];
     const auto& fl = f.get_header().get_identifier().get_layout();
-    const auto& col_size = fl.clone().strip_dim(COL).size();
+
+    // Fields without COL tag are nor remapped, so consider their col size as 0
+    auto col_size = fl.has_tag(COL) ? fl.clone().strip_dim(COL).size() : 0;
     m_fields_col_sizes_scan_sum[i+1] = m_fields_col_sizes_scan_sum[i] + col_size;
   }
   auto total_col_size = m_fields_col_sizes_scan_sum.back();
@@ -164,6 +166,8 @@ void RefiningRemapperP2P::pack_and_send ()
   using TeamMember  = typename KT::MemberType;
   using ESU         = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
 
+  constexpr auto COL = ShortFieldTagsNames::COL;
+
   auto export_pids = m_imp_exp->export_pids();
   auto export_lids = m_imp_exp->export_lids();
   auto ncols_send  = m_imp_exp->num_exports_per_pid();
@@ -174,6 +178,10 @@ void RefiningRemapperP2P::pack_and_send ()
   for (int ifield=0; ifield<m_num_fields; ++ifield) {
     const auto& f = m_src_fields[ifield];
     const auto& fl = f.get_header().get_identifier().get_layout();
+    if (not fl.has_tag(COL)) {
+      // No need to process this field. We'll deep copy src->tgt later
+      continue;
+    }
     const auto f_col_sizes_scan_sum = m_fields_col_sizes_scan_sum[ifield];
     switch (fl.rank()) {
       case 1:
@@ -308,6 +316,8 @@ void RefiningRemapperP2P::recv_and_unpack ()
   using TeamMember  = typename KT::MemberType;
   using ESU         = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
 
+  constexpr auto COL = ShortFieldTagsNames::COL;
+
   auto import_pids = m_imp_exp->import_pids();
   auto import_lids = m_imp_exp->import_lids();
   auto ncols_recv  = m_imp_exp->num_imports_per_pid();
@@ -318,6 +328,10 @@ void RefiningRemapperP2P::recv_and_unpack ()
   for (int ifield=0; ifield<m_num_fields; ++ifield) {
           auto& f  = m_ov_fields[ifield];
     const auto& fl = f.get_header().get_identifier().get_layout();
+    if (not fl.has_tag(COL)) {
+      // No need to process this field. We'll deep copy src->tgt later
+      continue;
+    }
     const auto f_col_sizes_scan_sum = m_fields_col_sizes_scan_sum[ifield];
     switch (fl.rank()) {
       case 1:

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -50,13 +50,7 @@ VerticalRemapper (const grid_ptr_type& src_grid,
                   const std::string& map_file)
  : VerticalRemapper(src_grid,create_tgt_grid(src_grid,map_file))
 {
-  // NOTE: we prescribe a uniform tgt pressure levels, so pmid_tgt = pint_tgt (1d field)
-  //       Cannot call set_target_pressure(p_tgt,p_tgt), since in there we do check the
-  //       number of levels (i.e., pint/pmid cannot have the same nlevs). Since we remap
-  //       every field (mid or int) to the same pressure coords, we just hard-code them.
-  m_tgt_pmid = m_tgt_pint = m_tgt_grid->get_geometry_data("p_levs");
-
-  m_tgt_int_same_as_mid = true;
+  set_target_pressure (m_tgt_grid->get_geometry_data("p_levs"),Both);
 }
 
 VerticalRemapper::
@@ -77,56 +71,75 @@ VerticalRemapper (const grid_ptr_type& src_grid,
 FieldLayout VerticalRemapper::
 create_src_layout (const FieldLayout& tgt_layout) const
 {
-  // Since we don't know if the tgt layout is "LEV for everything",
-  // we cannot infer what the corresponding src layout was.
-  // This function should never be used for this remapper.
-  EKAT_ERROR_MSG ("Error! VerticalRemapper does not support creating a src layout from a tgt layout.\n");
-  return FieldLayout();
+  EKAT_REQUIRE_MSG (is_valid_tgt_layout(tgt_layout),
+      "[VerticalRemapper] Error! Input target layout is not valid for this remapper.\n"
+      " - input layout: " + tgt_layout.to_string());
+
+  EKAT_REQUIRE_MSG (not m_tgt_mid_same_as_int,
+      "[VerticalRemapper::create_src_layout] Error! Cannot deduce source layout.\n"
+      " The target layout does not distinguish between LEV and ILEV.\n");
+
+  const auto& mid_layout = m_src_pmid.get_header().get_identifier().get_layout();
+  const auto& int_layout = m_src_pint.get_header().get_identifier().get_layout();
+  return create_layout(tgt_layout,m_src_grid,mid_layout.congruent(int_layout));
 }
 
 FieldLayout VerticalRemapper::
 create_tgt_layout (const FieldLayout& src_layout) const
 {
-  using namespace ShortFieldTagsNames;
-
   EKAT_REQUIRE_MSG (is_valid_src_layout(src_layout),
-      "[VerticalRemapper] Error! Input source layout is not valid for this remapper.\n"
+      "[VerticalRemapper::create_tgt_layout] Error! Input source layout is not valid for this remapper.\n"
       " - input layout: " + src_layout.to_string());
 
-  // If we remap to a fixed set of pressure levels during I/O,
-  // it doesn't really make sense to distinguish between midpoints
-  //  and interfaces, so choose fl_out to have LEV as vertical tag.
-  auto tgt_layout = FieldLayout::invalid();
+  EKAT_REQUIRE_MSG (not m_src_mid_same_as_int,
+      "[VerticalRemapper::create_tgt_layout] Error! Cannot deduce target layout.\n"
+      " The source layout does not distinguish between LEV and ILEV.\n");
+
+  const auto& mid_layout = m_tgt_pmid.get_header().get_identifier().get_layout();
+  const auto& int_layout = m_tgt_pint.get_header().get_identifier().get_layout();
+  return create_layout(src_layout,m_tgt_grid,mid_layout.congruent(int_layout));
+}
+
+FieldLayout VerticalRemapper::
+create_layout (const FieldLayout& from_layout,
+               const std::shared_ptr<const AbstractGrid>& to_grid,
+               const bool int_same_as_mid) const
+{
+  using namespace ShortFieldTagsNames;
+
+  auto to_layout = FieldLayout::invalid();
   bool midpoints;
-  switch (src_layout.type()) {
+  std::string vdim_name;
+  switch (from_layout.type()) {
     case LayoutType::Scalar0D: [[ fallthrough ]];
     case LayoutType::Vector0D: [[ fallthrough ]];
     case LayoutType::Scalar2D: [[ fallthrough ]];
     case LayoutType::Vector2D: [[ fallthrough ]];
     case LayoutType::Tensor2D:
       // These layouts do not have vertical dim tags, so no change
-      tgt_layout = src_layout;
+      to_layout = from_layout;
       break;
     case LayoutType::Scalar1D:
-      midpoints = m_tgt_int_same_as_mid || src_layout.tags().back()==LEV;
-      tgt_layout = m_tgt_grid->get_vertical_layout(midpoints);
+      midpoints = int_same_as_mid || from_layout.tags().back()==LEV;
+      to_layout = to_grid->get_vertical_layout(midpoints);
       break;
     case LayoutType::Scalar3D:
-      midpoints = m_tgt_int_same_as_mid || src_layout.tags().back()==LEV;
-      tgt_layout = m_tgt_grid->get_3d_scalar_layout(midpoints);
+      midpoints = int_same_as_mid || from_layout.tags().back()==LEV;
+      to_layout = to_grid->get_3d_scalar_layout(midpoints);
       break;
     case LayoutType::Vector3D:
-      midpoints = m_tgt_int_same_as_mid || src_layout.tags().back()==LEV;
-      tgt_layout = m_tgt_grid->get_3d_vector_layout(midpoints,src_layout.get_vector_dim());
+      vdim_name = from_layout.name(from_layout.get_vector_component_idx());
+      midpoints = int_same_as_mid || from_layout.tags().back()==LEV;
+      to_layout = to_grid->get_3d_vector_layout(midpoints,from_layout.get_vector_dim(),vdim_name);
       break;
     default:
       // NOTE: this also include Tensor3D. We don't really have any atm proc
       //       that needs to handle a tensor3d quantity, so no need to add it
       EKAT_ERROR_MSG (
         "[VerticalRemapper] Error! Layout not supported by VerticalRemapper.\n"
-        " - input layout: " + src_layout.to_string() + "\n");
+        " - input layout: " + from_layout.to_string() + "\n");
   }
-  return tgt_layout;
+  return to_layout;
 }
 
 void VerticalRemapper::
@@ -150,71 +163,83 @@ set_mask_value (const Real mask_val)
 }
 
 void VerticalRemapper::
-set_source_pressure (const Field& pmid, const Field& pint)
+set_source_pressure (const Field& p, const ProfileType ptype)
+{
+  set_pressure (p, "source", ptype);
+}
+
+void VerticalRemapper::
+set_target_pressure (const Field& p, const ProfileType ptype)
+{
+  set_pressure (p, "target", ptype);
+}
+
+void VerticalRemapper::
+set_pressure (const Field& p, const std::string& src_or_tgt, const ProfileType ptype)
 {
   using namespace ShortFieldTagsNames;
   using PackT = ekat::Pack<Real,SCREAM_PACK_SIZE>;
 
-  EKAT_REQUIRE_MSG(pmid.is_allocated(),
-      "Error! Source midpoint pressure field is not yet allocated.\n"
-      " - field name: " + pmid.name() + "\n");
+  bool src = src_or_tgt=="source";
 
-  EKAT_REQUIRE_MSG(pint.is_allocated(),
-      "Error! Source interface pressure field is not yet allocated.\n"
-      " - field name: " + pint.name() + "\n");
+  std::string msg_prefix = "[VerticalRemapper::set_" + src_or_tgt + "_pressure] ";
 
-  EKAT_REQUIRE_MSG(pmid.get_header().get_alloc_properties().is_compatible<PackT>(),
-      "Error! Source midpoints pressure field not compatible with default pack size.\n"
-      " - pack size: " + std::to_string(SCREAM_PACK_SIZE) + "\n");
-  EKAT_REQUIRE_MSG(pint.get_header().get_alloc_properties().is_compatible<PackT>(),
-      "Error! Source interfaces pressure field not compatible with default pack size.\n"
+  EKAT_REQUIRE_MSG(p.is_allocated(),
+      msg_prefix + "Field is not yet allocated.\n"
+      " - field name: " + p.name() + "\n");
+
+  EKAT_REQUIRE_MSG(p.get_header().get_alloc_properties().is_compatible<PackT>(),
+      msg_prefix + "Field not compatible with default pack size.\n"
       " - pack size: " + std::to_string(SCREAM_PACK_SIZE) + "\n");
 
-  const auto& pmid_layout = pmid.get_header().get_identifier().get_layout();
-  const auto& pint_layout = pint.get_header().get_identifier().get_layout();
-  EKAT_REQUIRE_MSG(pmid_layout.dim(LEV)==m_src_grid->get_num_vertical_levels(),
-      "Error! Source midpoint pressure field has the wrong layout.\n"
-      " - field name: " + pmid.name() + "\n"
-      " - field layout: " + pmid_layout.to_string() + "\n"
-      " - expected num levels: " + std::to_string(m_src_grid->get_num_vertical_levels()) + "\n");
-  EKAT_REQUIRE_MSG(pint_layout.dim(ILEV)==m_src_grid->get_num_vertical_levels()+1,
-      "Error! Source interface pressure field has the wrong layout.\n"
-      " - field name: " + pint.name() + "\n"
-      " - field layout: " + pint_layout.to_string() + "\n"
-      " - expected num levels: " + std::to_string(m_src_grid->get_num_vertical_levels()+1) + "\n");
+  const int nlevs = src ? m_src_grid->get_num_vertical_levels()
+                        : m_tgt_grid->get_num_vertical_levels();
+  const auto& p_layout = p.get_header().get_identifier().get_layout();
+  const auto vtag = p_layout.tags().back();
+  const auto vdim = p_layout.dims().back();
 
-  m_src_pmid = pmid;
-  m_src_pint = pint;
-}
-
-void VerticalRemapper::
-set_target_pressure (const Field& pmid, const Field& pint)
-{
-  using namespace ShortFieldTagsNames;
-
-  EKAT_REQUIRE_MSG(pmid.is_allocated(),
-      "Error! Target midpoint pressure field is not yet allocated.\n"
-      " - field name: " + pmid.name() + "\n");
-
-  EKAT_REQUIRE_MSG(pint.is_allocated(),
-      "Error! Target interface pressure field is not yet allocated.\n"
-      " - field name: " + pint.name() + "\n");
-
-  const auto& pmid_layout = pmid.get_header().get_identifier().get_layout();
-  const auto& pint_layout = pint.get_header().get_identifier().get_layout();
-  EKAT_REQUIRE_MSG(pmid_layout.dim(LEV)==m_tgt_grid->get_num_vertical_levels(),
-      "Error! Target midpoint pressure field has the wrong layout.\n"
-      " - field name: " + pmid.name() + "\n"
-      " - field layout: " + pmid_layout.to_string() + "\n"
-      " - expected num levels: " + std::to_string(m_tgt_grid->get_num_vertical_levels()) + "\n");
-  EKAT_REQUIRE_MSG(pint_layout.dim(ILEV)==m_tgt_grid->get_num_vertical_levels()+1,
-      "Error! Target interface pressure field has the wrong layout.\n"
-      " - field name: " + pint.name() + "\n"
-      " - field layout: " + pint_layout.to_string() + "\n"
-      " - expected num levels: " + std::to_string(m_tgt_grid->get_num_vertical_levels()+1) + "\n");
-
-  m_tgt_pmid = pmid;
-  m_tgt_pint = pint;
+  FieldTag expected_tag;
+  int      expected_dim;
+  switch (ptype) {
+    case Midpoints:
+      expected_tag = LEV;
+      expected_dim = nlevs;
+      if (src) {
+        m_src_pmid = p;
+      } else {
+        m_tgt_pmid = p;
+      }
+      break;
+    case Interfaces:
+      expected_tag = ILEV;
+      expected_dim = nlevs+1;
+      if (src) {
+        m_src_pint = p;
+      } else {
+        m_tgt_pint = p;
+      }
+      break;
+    case Both:
+      expected_tag = LEV;
+      expected_dim = nlevs;
+      if (src) {
+        m_src_pint = p;
+        m_src_pmid = p;
+        m_src_mid_same_as_int = true;
+      } else {
+        m_tgt_pint = p;
+        m_tgt_pmid = p;
+        m_tgt_mid_same_as_int = true;
+      }
+      break;
+    default:
+      EKAT_ERROR_MSG ("[VerticalRemapper::set_source_pressure] Error! Unrecognized value for 'ptype'.\n");
+  }
+  EKAT_REQUIRE_MSG (vtag==expected_tag and vdim==expected_dim,
+      msg_prefix + "Invalid pressure layout.\n"
+      "  - layout: " + p_layout.to_string() + "\n"
+      "  - expected last layout tag: " + e2str(expected_tag) + "\n"
+      "  - expected last layout dim: " + std::to_string(expected_dim) + "\n");
 }
 
 void VerticalRemapper::

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
@@ -54,21 +54,23 @@ public:
     // NOTE: tgt layouts always use LEV (not ILEV), while src can have ILEV or LEV.
 
     using namespace ShortFieldTagsNames;
-    auto src_stripped = src.clone().strip_dim(ILEV,false).strip_dim(LEV,false);
-    auto tgt_stripped = tgt.clone().strip_dim(LEV,false);
+    auto src_stripped = src.clone().strip_dims({LEV,ILEV});
+    auto tgt_stripped = tgt.clone().strip_dims({LEV,ILEV});
 
     return src.rank()==tgt.rank() and
            src_stripped.congruent(tgt_stripped);
   }
 
-  // NOTE: for the vert remapper, it doesn't really make sense to distinguish
-  //       between midpoints and interfaces: we're simply asking for a quantity
-  //       at a given set of pressure levels. So we choose to NOT allow a tgt
-  //       layout with ILEV tag.
   bool is_valid_tgt_layout (const layout_type& layout) const override {
     using namespace ShortFieldTagsNames;
-    return not layout.has_tag(ILEV)
+    return !(m_tgt_mid_same_as_int and layout.has_tag(ILEV))
            and AbstractRemapper::is_valid_tgt_layout(layout);
+  }
+
+  bool is_valid_src_layout (const layout_type& layout) const override {
+    using namespace ShortFieldTagsNames;
+    return !(m_src_mid_same_as_int and layout.has_tag(ILEV))
+           and AbstractRemapper::is_valid_src_layout(layout);
   }
 
   void set_extrapolation_type (const ExtrapType etype, const TopBot where = TopAndBot);

--- a/components/eamxx/src/share/io/scorpio_input.hpp
+++ b/components/eamxx/src/share/io/scorpio_input.hpp
@@ -61,6 +61,10 @@ public:
                    const std::shared_ptr<const grid_type>& grid,
                    const std::vector<Field>& fields,
                    const bool skip_grid_checks = false);
+  // This constructor only sets the minimal info, deferring initialization
+  // to when set_field_manager/reset_fields and reset_filename are called
+  AtmosphereInput (const std::vector<std::string>& fields_names,
+                   const std::shared_ptr<const grid_type>& grid);
 
   // Due to resource acquisition (in scorpio), avoid copies
   AtmosphereInput (const AtmosphereInput&) = delete;
@@ -98,9 +102,11 @@ public:
   // Getters
   std::string get_filename() { return m_filename; } // Simple getter to query the filename for this stream.
 
-  // Expose the ability to set field manager for cases like time_interpolation where we swap fields
-  // between field managers to avoid deep_copy.
+  // Expose the ability to set/reset fields/field_manager for cases like data interpolation,
+  // where we swap pointers but all the scorpio data structures are unchanged.
   void set_field_manager (const std::shared_ptr<const fm_type>& field_mgr);
+  void set_fields (const std::vector<Field>& fields);
+  void reset_filename (const std::string& filename);
 
   // Option to add a logger
   void set_logger(const std::shared_ptr<ekat::logger::LoggerBase>& atm_logger) {

--- a/components/eamxx/src/share/tests/CMakeLists.txt
+++ b/components/eamxx/src/share/tests/CMakeLists.txt
@@ -51,10 +51,16 @@ if (NOT SCREAM_ONLY_GENERATE_BASELINES)
     LIBS scream_io
     MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS})
 
-  # Test vertical remap
-  CreateUnitTest(time_interpolation "eamxx_time_interpolation_tests.cpp"
+  # Generate data for data interpolation test
+  CreateUnitTest(data_interpolation_setup "data_interpolation_setup.cpp"
     LIBS scream_io
-    MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS})
+    FIXTURES_SETUP data_interpolation_setup)
+
+  # Test data interpolation
+  CreateUnitTest(data_interpolation "data_interpolation_tests.cpp"
+    LIBS scream_io
+    MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
+    FIXTURES_REQUIRED data_interpolation_setup)
 
   # Test common physics functions
   CreateUnitTest(common_physics "common_physics_functions_tests.cpp")

--- a/components/eamxx/src/share/tests/data_interpolation_setup.cpp
+++ b/components/eamxx/src/share/tests/data_interpolation_setup.cpp
@@ -1,0 +1,91 @@
+#include <catch2/catch.hpp>
+
+#include "data_interpolation_tests.hpp"
+
+#include "share/io/scream_io_utils.hpp"
+#include "share/io/scream_scorpio_interface.hpp"
+#include "share/grid/point_grid.hpp"
+
+namespace scream {
+
+TEST_CASE ("data_interpolation_setup")
+{
+  // NOTE: ensure these match what's used in data_interpolation_tests.cpp
+  constexpr int ncols = 12;
+  constexpr int nlevs = 32;
+
+  auto t_ref = get_t_ref();
+
+  // Init test session
+  ekat::Comm comm(MPI_COMM_WORLD);
+  scorpio::init_subsystem(comm);
+
+  EKAT_REQUIRE_MSG (comm.size()==1,
+      "Error! You should run the data_interpolation_setup test with ONE rank.\n");
+
+  // Create grid
+  std::shared_ptr<const AbstractGrid> grid = create_point_grid("pg",ncols,nlevs,comm);
+
+  // Create and setup two files, so we can test both YearlyPeriodic and LinearHistory
+  std::vector<std::string> files = {
+    "data_interpolation_0.nc",
+    "data_interpolation_1.nc",
+    "data_interpolation_2.nc",
+    "data_interpolation_3.nc"
+  };
+  for (const std::string& fname : files) {
+    scorpio::register_file(fname,scorpio::Write);
+    scorpio::define_dim(fname,"ncol",ncols);
+    scorpio::define_dim(fname,"lev",nlevs);
+    scorpio::define_dim(fname,"ilev",nlevs+1);
+    scorpio::define_dim(fname,"dim2",ncmps);
+    scorpio::define_time(fname,"days since " + t_ref.to_string());
+
+    scorpio::define_var(fname,"s2d",  {"ncol"},              "real", true);
+    scorpio::define_var(fname,"v2d",  {"ncol","dim2"},       "real", true);
+    scorpio::define_var(fname,"s3d_m",{"ncol","lev"},        "real", true);
+    scorpio::define_var(fname,"v3d_m",{"ncol","dim2","lev"}, "real", true);
+    scorpio::define_var(fname,"s3d_i",{"ncol","ilev"},       "real", true);
+    scorpio::define_var(fname,"v3d_i",{"ncol","dim2","ilev"},"real", true);
+
+    scorpio::enddef(fname);
+  }
+
+  // Fields and some helper fields (for later)
+  auto base_fields = create_fields (grid,true);
+  auto fields = create_fields(grid,false);
+  auto ones = create_fields(grid,false);
+  for (const auto& f : ones) {
+    f.deep_copy(1);
+  }
+  int nfields = fields.size();
+
+  // Loop over time, and add 30 to the value for the first 6 months,
+  // and subtract 30 for the last 6 months. This guarantees that the data
+  // is indeed periodic. We'll write at the 15th of each month
+  // Generate three files:
+  //   - one to be used for yearly-periodic interp
+  //   - two to be used for linear-hystory interp
+  util::TimeStamp time = get_first_slice_time ();
+  for (int mm=0; mm<24; ++mm) {
+    std::string file_name = "data_interpolation_" + std::to_string(mm/6) + ".nc";
+
+    scorpio::update_time(file_name,time.days_from(t_ref));
+    for (int i=0; i<nfields; ++i) {
+      auto& f = fields[i];
+      f.deep_copy(base_fields[i]);
+      f.update(ones[i],delta_data[mm % 12],1.0);
+      scorpio::write_var(file_name,f.name(),f.get_internal_view_data<Real,Host>());
+    }
+    time += 86400*time.days_in_curr_month();
+  }
+
+  for (const std::string& fname : files) {
+    write_timestamp(fname,"reference_time_stamp",t_ref);
+    scorpio::release_file(fname);
+  }
+
+  scorpio::finalize_subsystem();
+}
+
+} // anonymous namespace

--- a/components/eamxx/src/share/tests/data_interpolation_setup.cpp
+++ b/components/eamxx/src/share/tests/data_interpolation_setup.cpp
@@ -11,8 +11,8 @@ namespace scream {
 TEST_CASE ("data_interpolation_setup")
 {
   // NOTE: ensure these match what's used in data_interpolation_tests.cpp
-  constexpr int ncols = 12;
-  constexpr int nlevs = 32;
+  constexpr int ngcols = data_ngcols;
+  constexpr int nlevs  = data_nlevs;
 
   auto t_ref = get_t_ref();
 
@@ -24,66 +24,145 @@ TEST_CASE ("data_interpolation_setup")
       "Error! You should run the data_interpolation_setup test with ONE rank.\n");
 
   // Create grid
-  std::shared_ptr<const AbstractGrid> grid = create_point_grid("pg",ncols,nlevs,comm);
+  std::shared_ptr<const AbstractGrid> grid = create_point_grid("pg",ngcols,nlevs,comm);
 
   // Create and setup two files, so we can test both YearlyPeriodic and LinearHistory
   std::vector<std::string> files = {
-    "data_interpolation_0.nc",
-    "data_interpolation_1.nc",
-    "data_interpolation_2.nc",
-    "data_interpolation_3.nc"
+    "data_interpolation_0",
+    "data_interpolation_1"
   };
-  for (const std::string& fname : files) {
-    scorpio::register_file(fname,scorpio::Write);
-    scorpio::define_dim(fname,"ncol",ncols);
-    scorpio::define_dim(fname,"lev",nlevs);
-    scorpio::define_dim(fname,"ilev",nlevs+1);
-    scorpio::define_dim(fname,"dim2",ncmps);
-    scorpio::define_time(fname,"days since " + t_ref.to_string());
 
-    scorpio::define_var(fname,"s2d",  {"ncol"},              "real", true);
-    scorpio::define_var(fname,"v2d",  {"ncol","dim2"},       "real", true);
-    scorpio::define_var(fname,"s3d_m",{"ncol","lev"},        "real", true);
-    scorpio::define_var(fname,"v3d_m",{"ncol","dim2","lev"}, "real", true);
-    scorpio::define_var(fname,"s3d_i",{"ncol","ilev"},       "real", true);
-    scorpio::define_var(fname,"v3d_i",{"ncol","dim2","ilev"},"real", true);
+  for (auto with_pressure : {true, false}) {
+    auto suffix = with_pressure ? "_with_p.nc" : ".nc";
+    for (const std::string& fname : files) {
+      scorpio::register_file(fname+suffix,scorpio::Write);
 
-    scorpio::enddef(fname);
-  }
+      scorpio::define_dim (fname+suffix,"ncol",ngcols);
+      scorpio::define_dim (fname+suffix,"lev",nlevs);
+      if (not with_pressure) {
+        scorpio::define_dim (fname+suffix,"ilev",nlevs+1);
+      }
+      scorpio::define_dim (fname+suffix,"dim2",ncmps);
+      scorpio::define_time(fname+suffix,"days since " + t_ref.to_string());
 
-  // Fields and some helper fields (for later)
-  auto base_fields = create_fields (grid,true);
-  auto fields = create_fields(grid,false);
-  auto ones = create_fields(grid,false);
-  for (const auto& f : ones) {
-    f.deep_copy(1);
-  }
-  int nfields = fields.size();
+      std::string ilev_tag = with_pressure ? "lev" : "ilev";
 
-  // Loop over time, and add 30 to the value for the first 6 months,
-  // and subtract 30 for the last 6 months. This guarantees that the data
-  // is indeed periodic. We'll write at the 15th of each month
-  // Generate three files:
-  //   - one to be used for yearly-periodic interp
-  //   - two to be used for linear-hystory interp
-  util::TimeStamp time = get_first_slice_time ();
-  for (int mm=0; mm<24; ++mm) {
-    std::string file_name = "data_interpolation_" + std::to_string(mm/6) + ".nc";
+      scorpio::define_var(fname+suffix,"s2d",  {"ncol"},                 "real", true);
+      scorpio::define_var(fname+suffix,"s2d",  {"ncol"},                 "real", true);
+      scorpio::define_var(fname+suffix,"v2d",  {"ncol","dim2"},          "real", true);
+      scorpio::define_var(fname+suffix,"s3d_m",{"ncol","lev"},           "real", true);
+      scorpio::define_var(fname+suffix,"v3d_m",{"ncol","dim2","lev"},    "real", true);
+      scorpio::define_var(fname+suffix,"s3d_i",{"ncol",ilev_tag},        "real", true);
+      scorpio::define_var(fname+suffix,"v3d_i",{"ncol","dim2",ilev_tag}, "real", true);
 
-    scorpio::update_time(file_name,time.days_from(t_ref));
-    for (int i=0; i<nfields; ++i) {
-      auto& f = fields[i];
-      f.deep_copy(base_fields[i]);
-      f.update(ones[i],delta_data[mm % 12],1.0);
-      scorpio::write_var(file_name,f.name(),f.get_internal_view_data<Real,Host>());
+      if (with_pressure) {
+        scorpio::define_var(fname+suffix,"p1d",{"lev"},"real", false);
+        scorpio::define_var(fname+suffix,"p3d",{"ncol","lev"},"real", true);
+      }
+
+      scorpio::enddef(fname+suffix);
     }
-    time += 86400*time.days_in_curr_month();
+
+    // Fields and some helper fields (for later)
+    // NOTE: if we save a pressure field, there is not distinction
+    //       between interfaces and midpoints in the file
+    auto base_fields = create_fields (grid,true,with_pressure);
+    auto fields      = create_fields(grid,false,with_pressure);
+    auto ones        = create_fields(grid,false,with_pressure);
+    for (const auto& f : ones) {
+      f.deep_copy(1);
+    }
+    int nfields = fields.size();
+
+    // Loop over time, and add 30 to the value for the first 6 months,
+    // and subtract 30 for the last 6 months. This guarantees that the data
+    // is indeed periodic. We'll write at the 15th of each month
+    // Generate three files:
+    //   - one to be used for yearly-periodic interp
+    //   - two to be used for linear-hystory interp
+    util::TimeStamp time = get_first_slice_time ();
+
+    if (with_pressure) {
+      // Create p1d as slice of p3d, and ensure it's the same on all ranks, then write it.
+      auto p1d = fields.back().subfield(0,0).clone("p1d");
+      auto comm = grid->get_comm();
+      comm.broadcast(p1d.get_internal_view_data<Real,Host>(),nlevs,0);
+      p1d.sync_to_dev();
+      for (const std::string& fname : files) {
+        scorpio::write_var(fname+suffix,p1d.name(),p1d.get_internal_view_data<Real,Host>());
+      }
+    }
+
+    for (int mm=0; mm<12; ++mm) {
+      std::string file_name = "data_interpolation_" + std::to_string(mm/6) + suffix;
+
+      // We start the files with July
+      int mm_index = mm+6;
+      scorpio::update_time(file_name,time.days_from(t_ref));
+      for (int i=0; i<nfields; ++i) {
+        auto& f = fields[i];
+        f.deep_copy(base_fields[i]);
+        f.update(ones[i],delta_data[ mm_index % 12],1.0);
+        scorpio::write_var(file_name,f.name(),f.get_internal_view_data<Real,Host>());
+      }
+      time += 86400*time.days_in_curr_month();
+    }
+
+    for (const std::string& fname : files) {
+      write_timestamp(fname+suffix,"reference_time_stamp",t_ref);
+      scorpio::release_file(fname+suffix);
+    }
   }
 
-  for (const std::string& fname : files) {
-    write_timestamp(fname,"reference_time_stamp",t_ref);
-    scorpio::release_file(fname);
+  // Now write a map file for horiz remap, that splits each dof interval in two
+  const int ngdofs_src = data_ngcols;
+  const int ngdofs_tgt = fine_ngcols;
+
+  // Existing dofs are "copied", added dofs are averaged from neighbors
+  const int nnz = ngdofs_src + 2*(ngdofs_src-1);
+  
+  std::string filename = map_file_name;
+  scorpio::register_file(filename, scorpio::FileMode::Write);
+
+  scorpio::define_dim(filename, "n_a", ngdofs_src);
+  scorpio::define_dim(filename, "n_b", ngdofs_tgt);
+  scorpio::define_dim(filename, "n_s", nnz);
+
+  scorpio::define_var(filename, "col", {"n_s"}, "int");
+  scorpio::define_var(filename, "row", {"n_s"}, "int");
+  scorpio::define_var(filename, "S",   {"n_s"}, "double");
+
+  scorpio::enddef(filename);
+
+  std::vector<int> col(nnz), row(nnz);
+  std::vector<double> S(nnz);
+  for (int i=0,nnz=0; i<ngdofs_tgt; ++i) {
+    if (i % 2 == 0) {
+      // Fine grid point also in the src grid: only diag entry
+      col[nnz] = i / 2;
+      row[nnz] = i;
+        S[nnz] = 1.0;
+
+      ++nnz;
+    } else {
+      // Add 0.5 times the left src dof and 0.5 times the right src dof
+      col[nnz] = i / 2;
+      row[nnz] = i;
+        S[nnz] = 0.5;
+      ++nnz;
+
+      col[nnz] = (i / 2) + 1;
+      row[nnz] = i;
+        S[nnz] = 0.5;
+      ++nnz;
+    }
   }
+
+  scorpio::write_var(filename,"row",row.data());
+  scorpio::write_var(filename,"col",col.data());
+  scorpio::write_var(filename,"S",  S.data());
+
+  scorpio::release_file(filename);
 
   scorpio::finalize_subsystem();
 }

--- a/components/eamxx/src/share/tests/data_interpolation_tests.cpp
+++ b/components/eamxx/src/share/tests/data_interpolation_tests.cpp
@@ -1,0 +1,219 @@
+#include <catch2/catch.hpp>
+
+#include "data_interpolation_tests.hpp"
+
+#include "share/io/scream_scorpio_interface.hpp"
+#include "share/util/eamxx_data_interpolation.hpp"
+#include "share/grid/point_grid.hpp"
+#include "share/field/field_utils.hpp"
+#include "share/scream_config.hpp"
+
+// NOTE: ensure these are the same used in data_interpolation_setup.cpp
+constexpr int data_ncols = 12;
+constexpr int data_nlevs = 32;
+
+namespace scream {
+
+using strvec_t = std::vector<std::string>;
+
+std::shared_ptr<DataInterpolation>
+create_interp (const std::shared_ptr<const AbstractGrid>& grid,
+               const std::vector<Field>& fields)
+{
+  return std::make_shared<DataInterpolation>(grid,fields);
+}
+
+TEST_CASE ("exceptions")
+{
+  // Test correctness of some exception handling inside the DataInterpolation source code
+  ekat::Comm comm(MPI_COMM_WORLD);
+  scorpio::init_subsystem(comm);
+  auto grid = create_point_grid("pg",data_ncols,data_nlevs,comm);
+
+  auto fields = create_fields(grid,false);
+
+  REQUIRE_THROWS (create_interp(nullptr,fields)); // Invalid grid pointer
+
+  auto interp = create_interp(grid,fields);
+
+  strvec_t files = {"/etc/shadow"};
+  REQUIRE_THROWS (interp->setup_time_database(files,util::TimeLine::Linear)); // Input file not readable
+  
+  interp->setup_time_database({"./data_interpolation_0.nc"},util::TimeLine::Linear);
+  util::TimeStamp t0 ({2000,1,1},{0,0,0});
+  REQUIRE_THROWS (interp->init_data_interval(t0)); // linear timeline, but t0<first_slice
+
+  util::TimeStamp t1 ({2020,1,1},{0,0,0});
+  REQUIRE_THROWS (interp->init_data_interval(t1)); // linear timeline, but t0>last_slice
+
+  scorpio::finalize_subsystem();
+}
+
+TEST_CASE ("interpolation")
+{
+  ekat::Comm comm(MPI_COMM_WORLD);
+
+  // Regardless of how EAMxx is configured, ignore leap years for this test
+  set_use_leap_year(false);
+
+  scorpio::init_subsystem(comm);
+
+  Real tol = std::numeric_limits<Real>::epsilon()*10;
+  SECTION ("only-time")
+  {
+    auto grid = create_point_grid("pg",data_ncols,data_nlevs,comm);
+
+    // Create a bunch of copies of the fields. All but the first set of them
+    // are used in the test phase to check the result against what's expected
+    auto fields   = create_fields(grid,false);
+    auto base_f   = create_fields(grid,true);
+    auto ones     = create_fields (grid,false);
+    auto diff     = create_fields (grid,false);
+    auto expected = create_fields (grid,false);
+    for (auto& f : ones) {
+      f.deep_copy(1);
+    }
+    int nfields = fields.size();
+
+    auto interp = create_interp(grid,fields);
+
+    SECTION ("periodic")
+    {
+      strvec_t files = {"data_interpolation_0.nc","data_interpolation_1.nc"};
+
+      util::TimeStamp t0 ({2020,1,1},{0,0,0});
+
+      // t_beg/t_end keep track of the interval [beg,end] where we currently are,
+      // where beg/end are timestamps at which we have data.
+      // We assume we start with t0 after the last input slice of the 1st year.
+      // NOTE: -365*spd is since we actually need to *rewind* t0, if we want beg<t0<end
+      util::TimeStamp t_beg = t0 + get_last_slice_time().frac_of_year_in_days()*spd - 365*spd;
+      util::TimeStamp t_end = t_beg + t_beg.days_in_curr_month()*spd;
+
+      interp->setup_time_database(files,util::TimeLine::YearlyPeriodic);
+      interp->init_data_interval(t0);
+
+      // Loop for two year at a 20 day increment
+      int dt = 20*spd;
+      for (auto time = t0+dt; time.days_from(t0)<365; time+=dt) {
+        if (t_end<time) {
+          // update t_beg/t_end
+          t_beg = t_end;
+          t_end += t_end.days_in_curr_month()*spd;
+        }
+
+        // Compute the delta to add to field base value for mm_beg and mm_end
+        int mm_beg = t_beg.get_month()-1;
+        int mm_end = t_end.get_month()-1;
+
+        // Since input data is at the 15th of the month, we need to compute
+        // the distance between current time and the beg slice, then use it
+        // to do a convex interpolation between f(t=t_beg) and f(t=t_end).
+        util::TimeInterval time_from_beg(t_beg,time,util::TimeLine::YearlyPeriodic);;
+        double alpha = time_from_beg.length / t_beg.days_in_curr_month();
+        double delta = delta_data[mm_beg]*(1-alpha) + delta_data[mm_end]*alpha;
+
+        if (alpha<0 or alpha>1) {
+          std::cout << "TEST ERROR:\n"
+                    << " t beg: " << t_beg.to_string() << "\n"
+                    << " t end: " << t_end.to_string() << "\n"
+                    << " time : " << time.to_string() << "\n"
+                    << " t-beg: " << time_from_beg.length << "\n"
+                    << " days in mm_beg: " << t_beg.days_in_curr_month() << "\n"
+                    << " alpha: " << alpha << "\n"
+                    << " delta_beg: " << delta_data[mm_beg] << "\n"
+                    << " delta_end: " << delta_data[mm_end] << "\n"
+                    << " delta: " << delta << "\n";
+        }
+        // Compute expected difference from base value
+        interp->run(time);  
+        for (int i=0; i<nfields; ++i) {
+          // Compute expected, then subtract computed field
+          expected[i].update(base_f[i],1,0);
+          expected[i].update(ones[i],delta,1.0);
+          diff[i].update(fields[i],1,1);
+          diff[i].update(expected[i],-1,1);
+          diff[i].scale(1.0 / frobenius_norm<Real>(expected[i]));
+          if (frobenius_norm<Real>(diff[i])>=tol) {
+            auto n = fields[i].name();
+            print_field_hyperslab(fields[i].alias(n+"_computed"));
+            print_field_hyperslab(expected[i].alias(n+"_expected"));
+            print_field_hyperslab(diff[i].alias(n+"_diff"));
+          }
+          REQUIRE (frobenius_norm<Real>(diff[i])<tol);
+        }
+      }
+    }
+
+    SECTION ("linear")
+    {
+      // t_beg/t_end keep track of the interval [beg,end] where we currently are,
+      // where beg/end are timestamps at which we have data.
+      // We assume we start with t0 sometime between the first and second input slice.
+      auto t_beg = get_first_slice_time();
+      for (int mm=0; mm<6; ++mm) {
+        t_beg += spd*t_beg.days_in_curr_month();
+      }
+      auto t_end = t_beg + spd*t_beg.days_in_curr_month();
+      auto t0    = t_beg + spd*10;
+
+      strvec_t files = {"data_interpolation_1.nc","data_interpolation_2.nc"};
+      interp->setup_time_database(files,util::TimeLine::Linear);
+      interp->init_data_interval(t0);
+
+      // Loop for two year at a 20 day increment
+      int dt = 20*spd;
+      for (auto time = t0+dt; time.days_from(t0)<200; time+=dt) {
+        if (t_end<time) {
+          // update t_beg/t_end
+          t_beg = t_end;
+          t_end += t_end.days_in_curr_month()*spd;
+        }
+
+        // Compute the delta to add to field base value for mm_beg and mm_end
+        int mm_beg = t_beg.get_month()-1;
+        int mm_end = t_end.get_month()-1;
+
+        // Since input data is at the 15th of the month, we need to compute
+        // the distance between current time and the beg slice, then use it
+        // to do a convex interpolation between f(t=t_beg) and f(t=t_end).
+        util::TimeInterval time_from_beg(t_beg,time,util::TimeLine::Linear);;
+        double alpha = time_from_beg.length / t_beg.days_in_curr_month();
+        double delta = delta_data[mm_beg]*(1-alpha) + delta_data[mm_end]*alpha;
+
+        if (alpha<0 or alpha>1) {
+          std::cout << "TEST ERROR:\n"
+                    << " t beg: " << t_beg.to_string() << "\n"
+                    << " t end: " << t_end.to_string() << "\n"
+                    << " time : " << time.to_string() << "\n"
+                    << " t-beg: " << time_from_beg.length << "\n"
+                    << " days in mm_beg: " << t_beg.days_in_curr_month() << "\n"
+                    << " alpha: " << alpha << "\n"
+                    << " delta_beg: " << delta_data[mm_beg] << "\n"
+                    << " delta_end: " << delta_data[mm_end] << "\n"
+                    << " delta: " << delta << "\n";
+        }
+        // Compute expected difference from base value
+        interp->run(time);  
+        for (int i=0; i<nfields; ++i) {
+          // Compute expected, then subtract computed field
+          expected[i].update(base_f[i],1,0);
+          expected[i].update(ones[i],delta,1.0);
+          diff[i].update(fields[i],1,1);
+          diff[i].update(expected[i],-1,1);
+          diff[i].scale(1.0 / frobenius_norm<Real>(expected[i]));
+          if (frobenius_norm<Real>(diff[i])>=tol) {
+            print_field_hyperslab(fields[i]);
+            print_field_hyperslab(expected[i]);
+            print_field_hyperslab(diff[i]);
+          }
+          REQUIRE (frobenius_norm<Real>(diff[i])<tol);
+        }
+      }
+    }
+  }
+
+  scorpio::finalize_subsystem();
+}
+
+} // anonymous namespace

--- a/components/eamxx/src/share/tests/data_interpolation_tests.cpp
+++ b/components/eamxx/src/share/tests/data_interpolation_tests.cpp
@@ -8,13 +8,20 @@
 #include "share/field/field_utils.hpp"
 #include "share/scream_config.hpp"
 
-// NOTE: ensure these are the same used in data_interpolation_setup.cpp
-constexpr int data_ncols = 12;
-constexpr int data_nlevs = 32;
-
 namespace scream {
 
+constexpr auto tol = std::numeric_limits<Real>::epsilon()*10;
+constexpr auto P1D = DataInterpolation::Static1D;
+constexpr auto P3D = DataInterpolation::Dynamic3D;
 using strvec_t = std::vector<std::string>;
+
+util::TimeStamp reset_year (const util::TimeStamp& t_in, int yy)
+{
+  auto date = t_in.get_date();
+  auto time = t_in.get_time();
+  date[0] = yy;
+  return util::TimeStamp(date,time);
+}
 
 std::shared_ptr<DataInterpolation>
 create_interp (const std::shared_ptr<const AbstractGrid>& grid,
@@ -23,14 +30,107 @@ create_interp (const std::shared_ptr<const AbstractGrid>& grid,
   return std::make_shared<DataInterpolation>(grid,fields);
 }
 
+void root_print (const ekat::Comm& comm,
+                 const std::string& msg)
+{
+  if (comm.am_i_root()) {
+    printf("%s",msg.c_str());
+  }
+}
+
+// Run the data interpolation to the input grid, and check against expected values
+void run_tests (const std::shared_ptr<const AbstractGrid>& grid,
+                const strvec_t& input_files, util::TimeStamp t_beg,
+                const util::TimeLine timeline,
+                const DataInterpolation::VRemapType vr_type = DataInterpolation::None)
+{
+  auto t_end = t_beg + t_beg.days_in_curr_month()*spd;
+  auto t0 = t_beg + (t_end-t_beg)/2;
+
+  // These are the fields we will compute
+  auto fields = create_fields(grid,false,false);
+
+  std::string map_file = grid->get_num_global_dofs()==data_ngcols ? "" : map_file_name;
+
+  // These are used to check the answer
+  auto base_f   = create_fields(grid,true);
+  auto ones     = create_fields(grid,false);
+  auto diff     = create_fields(grid,false);
+  auto expected = create_fields(grid,false);
+  for (auto& f : ones) {
+    f.deep_copy(1);
+  }
+  int nfields = fields.size();
+
+  std::string data_pname = vr_type==P1D ? "p1d" : "p3d";  // if vr_type==None, it's not used anyways
+  auto model_pmid = base_f[2].clone("pmid"); // ensure the 2nd field is s3d_m
+  auto model_pint = base_f[4].clone("pint"); // ensure the 4th field is s3d_i
+
+  auto interp = create_interp(grid,fields);
+  interp->setup_time_database(input_files,util::TimeLine::YearlyPeriodic);
+  interp->setup_remappers (map_file,vr_type,data_pname,model_pmid,model_pint);
+  interp->init_data_interval(t0);
+
+  // Loop for two year at a 20 day increment
+  int dt = 20*spd;
+  for (auto time = t0+dt; time.days_from(t0)<365; time+=dt) {
+    if (t_end<time) {
+      // update t_beg/t_end
+      t_beg = t_end;
+      t_end += t_end.days_in_curr_month()*spd;
+    }
+
+    // Compute the delta to add to field base value for mm_beg and mm_end
+    int mm_beg = t_beg.get_month()-1;
+    int mm_end = t_end.get_month()-1;
+
+    // Since input data is at the 15th of the month, we need to compute
+    // the distance between current time and the beg slice, then use it
+    // to do a convex interpolation between f(t=t_beg) and f(t=t_end).
+    util::TimeInterval time_from_beg(t_beg,time,timeline);
+    double alpha = time_from_beg.length / t_beg.days_in_curr_month();
+    double delta = delta_data[mm_beg]*(1-alpha) + delta_data[mm_end]*alpha;
+
+    if (alpha<0 or alpha>1) {
+      std::cout << "TEST ERROR:\n"
+                << " t beg: " << t_beg.to_string() << "\n"
+                << " t end: " << t_end.to_string() << "\n"
+                << " time : " << time.to_string() << "\n"
+                << " t-beg: " << time_from_beg.length << "\n"
+                << " days in mm_beg: " << t_beg.days_in_curr_month() << "\n"
+                << " alpha: " << alpha << "\n"
+                << " delta_beg: " << delta_data[mm_beg] << "\n"
+                << " delta_end: " << delta_data[mm_end] << "\n"
+                << " delta: " << delta << "\n";
+    }
+    // Compute expected difference from base value
+    interp->run(time);  
+    for (int i=0; i<nfields; ++i) {
+      // Compute expected, then subtract computed field
+      expected[i].update(base_f[i],1,0);
+      expected[i].update(ones[i],delta,1.0);
+      diff[i].update(fields[i],1,1);
+      diff[i].update(expected[i],-1,1);
+      diff[i].scale(1.0 / frobenius_norm<Real>(expected[i]));
+      if (frobenius_norm<Real>(diff[i])>=tol) {
+        auto n = fields[i].name();
+        print_field_hyperslab(fields[i].alias(n+"_computed"));
+        print_field_hyperslab(expected[i].alias(n+"_expected"));
+        print_field_hyperslab(diff[i].alias(n+"_diff"));
+      }
+      REQUIRE (frobenius_norm<Real>(diff[i])<tol);
+    }
+  }
+}
+
 TEST_CASE ("exceptions")
 {
   // Test correctness of some exception handling inside the DataInterpolation source code
   ekat::Comm comm(MPI_COMM_WORLD);
   scorpio::init_subsystem(comm);
-  auto grid = create_point_grid("pg",data_ncols,data_nlevs,comm);
+  auto grid = create_point_grid("pg",data_ngcols,data_nlevs,comm);
 
-  auto fields = create_fields(grid,false);
+  auto fields = create_fields(grid,false,false);
 
   REQUIRE_THROWS (create_interp(nullptr,fields)); // Invalid grid pointer
 
@@ -58,158 +158,71 @@ TEST_CASE ("interpolation")
 
   scorpio::init_subsystem(comm);
 
-  Real tol = std::numeric_limits<Real>::epsilon()*10;
-  SECTION ("only-time")
-  {
-    auto grid = create_point_grid("pg",data_ncols,data_nlevs,comm);
+  auto data_grid   = create_point_grid("pg",data_ngcols,data_nlevs,comm);
+  auto hfine_grid  = create_point_grid("pg",fine_ngcols,data_nlevs,comm);
+  auto vfine_grid  = create_point_grid("pg",data_ngcols,fine_nlevs,comm);
+  auto hvfine_grid = create_point_grid("pg",fine_ngcols,fine_nlevs,comm);
 
-    // Create a bunch of copies of the fields. All but the first set of them
-    // are used in the test phase to check the result against what's expected
-    auto fields   = create_fields(grid,false);
-    auto base_f   = create_fields(grid,true);
-    auto ones     = create_fields (grid,false);
-    auto diff     = create_fields (grid,false);
-    auto expected = create_fields (grid,false);
-    for (auto& f : ones) {
-      f.deep_copy(1);
-    }
-    int nfields = fields.size();
+  SECTION ("periodic") {
+    // We assume we start with t0 sometime between the first and second input slice.
+    auto t_beg = reset_year(get_last_slice_time(),2019);
+    auto timeline = util::TimeLine::YearlyPeriodic;
+    strvec_t files = {"data_interpolation_0.nc","data_interpolation_1.nc"};
+    strvec_t files_with_p = {"data_interpolation_0_with_p.nc","data_interpolation_1_with_p.nc"};
 
-    auto interp = create_interp(grid,fields);
-
-    SECTION ("periodic")
-    {
-      strvec_t files = {"data_interpolation_0.nc","data_interpolation_1.nc"};
-
-      util::TimeStamp t0 ({2020,1,1},{0,0,0});
-
-      // t_beg/t_end keep track of the interval [beg,end] where we currently are,
-      // where beg/end are timestamps at which we have data.
-      // We assume we start with t0 after the last input slice of the 1st year.
-      // NOTE: -365*spd is since we actually need to *rewind* t0, if we want beg<t0<end
-      util::TimeStamp t_beg = t0 + get_last_slice_time().frac_of_year_in_days()*spd - 365*spd;
-      util::TimeStamp t_end = t_beg + t_beg.days_in_curr_month()*spd;
-
-      interp->setup_time_database(files,util::TimeLine::YearlyPeriodic);
-      interp->init_data_interval(t0);
-
-      // Loop for two year at a 20 day increment
-      int dt = 20*spd;
-      for (auto time = t0+dt; time.days_from(t0)<365; time+=dt) {
-        if (t_end<time) {
-          // update t_beg/t_end
-          t_beg = t_end;
-          t_end += t_end.days_in_curr_month()*spd;
-        }
-
-        // Compute the delta to add to field base value for mm_beg and mm_end
-        int mm_beg = t_beg.get_month()-1;
-        int mm_end = t_end.get_month()-1;
-
-        // Since input data is at the 15th of the month, we need to compute
-        // the distance between current time and the beg slice, then use it
-        // to do a convex interpolation between f(t=t_beg) and f(t=t_end).
-        util::TimeInterval time_from_beg(t_beg,time,util::TimeLine::YearlyPeriodic);;
-        double alpha = time_from_beg.length / t_beg.days_in_curr_month();
-        double delta = delta_data[mm_beg]*(1-alpha) + delta_data[mm_end]*alpha;
-
-        if (alpha<0 or alpha>1) {
-          std::cout << "TEST ERROR:\n"
-                    << " t beg: " << t_beg.to_string() << "\n"
-                    << " t end: " << t_end.to_string() << "\n"
-                    << " time : " << time.to_string() << "\n"
-                    << " t-beg: " << time_from_beg.length << "\n"
-                    << " days in mm_beg: " << t_beg.days_in_curr_month() << "\n"
-                    << " alpha: " << alpha << "\n"
-                    << " delta_beg: " << delta_data[mm_beg] << "\n"
-                    << " delta_end: " << delta_data[mm_end] << "\n"
-                    << " delta: " << delta << "\n";
-        }
-        // Compute expected difference from base value
-        interp->run(time);  
-        for (int i=0; i<nfields; ++i) {
-          // Compute expected, then subtract computed field
-          expected[i].update(base_f[i],1,0);
-          expected[i].update(ones[i],delta,1.0);
-          diff[i].update(fields[i],1,1);
-          diff[i].update(expected[i],-1,1);
-          diff[i].scale(1.0 / frobenius_norm<Real>(expected[i]));
-          if (frobenius_norm<Real>(diff[i])>=tol) {
-            auto n = fields[i].name();
-            print_field_hyperslab(fields[i].alias(n+"_computed"));
-            print_field_hyperslab(expected[i].alias(n+"_expected"));
-            print_field_hyperslab(diff[i].alias(n+"_diff"));
-          }
-          REQUIRE (frobenius_norm<Real>(diff[i])<tol);
-        }
+    SECTION ("no-horiz") {
+      SECTION ("no-vert") {
+        root_print(comm,"  timeline=PERIODIC, horiz_remap=NO,  vert_remap=NO ..........\n");
+        run_tests (data_grid,files,t_beg,timeline);
+        root_print(comm,"  timeline=PERIODIC, horiz_remap=NO,  vert_remap=NO .......... PASS\n");
+      }
+      SECTION ("p1d-vert") {
+        root_print(comm,"  timeline=PERIODIC, horiz_remap=NO,  vert_remap=p1d .........\n");
+        run_tests (data_grid,files_with_p,t_beg,timeline,P1D);
+        root_print(comm,"  timeline=PERIODIC, horiz_remap=NO,  vert_remap=p1d ......... PASS\n");
+      }
+      SECTION ("p3d-vert") {
+        root_print(comm,"  timeline=PERIODIC, horiz_remap=NO,  vert_remap=p3d .........\n");
+        run_tests (data_grid,files_with_p,t_beg,timeline,P3D);
+        root_print(comm,"  timeline=PERIODIC, horiz_remap=NO,  vert_remap=p3d ......... PASS\n");
       }
     }
 
-    SECTION ("linear")
-    {
-      // t_beg/t_end keep track of the interval [beg,end] where we currently are,
-      // where beg/end are timestamps at which we have data.
-      // We assume we start with t0 sometime between the first and second input slice.
-      auto t_beg = get_first_slice_time();
-      for (int mm=0; mm<6; ++mm) {
-        t_beg += spd*t_beg.days_in_curr_month();
+    SECTION ("yes-horiz") {
+      SECTION ("no-vert") {
+        root_print(comm,"  timeline=PERIODIC, horiz_remap=YES, vert_remap=NO ..........\n");
+        run_tests (hfine_grid,files,t_beg,timeline);
+        root_print(comm,"  timeline=PERIODIC, horiz_remap=YES, vert_remap=NO .......... PASS\n");
       }
-      auto t_end = t_beg + spd*t_beg.days_in_curr_month();
-      auto t0    = t_beg + spd*10;
-
-      strvec_t files = {"data_interpolation_1.nc","data_interpolation_2.nc"};
-      interp->setup_time_database(files,util::TimeLine::Linear);
-      interp->init_data_interval(t0);
-
-      // Loop for two year at a 20 day increment
-      int dt = 20*spd;
-      for (auto time = t0+dt; time.days_from(t0)<200; time+=dt) {
-        if (t_end<time) {
-          // update t_beg/t_end
-          t_beg = t_end;
-          t_end += t_end.days_in_curr_month()*spd;
-        }
-
-        // Compute the delta to add to field base value for mm_beg and mm_end
-        int mm_beg = t_beg.get_month()-1;
-        int mm_end = t_end.get_month()-1;
-
-        // Since input data is at the 15th of the month, we need to compute
-        // the distance between current time and the beg slice, then use it
-        // to do a convex interpolation between f(t=t_beg) and f(t=t_end).
-        util::TimeInterval time_from_beg(t_beg,time,util::TimeLine::Linear);;
-        double alpha = time_from_beg.length / t_beg.days_in_curr_month();
-        double delta = delta_data[mm_beg]*(1-alpha) + delta_data[mm_end]*alpha;
-
-        if (alpha<0 or alpha>1) {
-          std::cout << "TEST ERROR:\n"
-                    << " t beg: " << t_beg.to_string() << "\n"
-                    << " t end: " << t_end.to_string() << "\n"
-                    << " time : " << time.to_string() << "\n"
-                    << " t-beg: " << time_from_beg.length << "\n"
-                    << " days in mm_beg: " << t_beg.days_in_curr_month() << "\n"
-                    << " alpha: " << alpha << "\n"
-                    << " delta_beg: " << delta_data[mm_beg] << "\n"
-                    << " delta_end: " << delta_data[mm_end] << "\n"
-                    << " delta: " << delta << "\n";
-        }
-        // Compute expected difference from base value
-        interp->run(time);  
-        for (int i=0; i<nfields; ++i) {
-          // Compute expected, then subtract computed field
-          expected[i].update(base_f[i],1,0);
-          expected[i].update(ones[i],delta,1.0);
-          diff[i].update(fields[i],1,1);
-          diff[i].update(expected[i],-1,1);
-          diff[i].scale(1.0 / frobenius_norm<Real>(expected[i]));
-          if (frobenius_norm<Real>(diff[i])>=tol) {
-            print_field_hyperslab(fields[i]);
-            print_field_hyperslab(expected[i]);
-            print_field_hyperslab(diff[i]);
-          }
-          REQUIRE (frobenius_norm<Real>(diff[i])<tol);
-        }
+      SECTION ("p1d-vert") {
+        root_print(comm,"  timeline=PERIODIC, horiz_remap=NO,  vert_remap=p1d .........\n");
+        run_tests (data_grid,files_with_p,t_beg,timeline,P1D);
+        root_print(comm,"  timeline=PERIODIC, horiz_remap=NO,  vert_remap=p1d ......... PASS\n");
       }
+      SECTION ("p3d-vert") {
+        root_print(comm,"  timeline=PERIODIC, horiz_remap=NO,  vert_remap=p3d .........\n");
+        run_tests (data_grid,files_with_p,t_beg,timeline,P3D);
+        root_print(comm,"  timeline=PERIODIC, horiz_remap=NO,  vert_remap=p3d ......... PASS\n");
+      }
+    }
+  }
+
+  SECTION ("linear") {
+    // We assume we start with t0 sometime between the first and second input slice.
+    auto t_beg = get_first_slice_time();
+    auto timeline = util::TimeLine::Linear;
+    strvec_t files = {"data_interpolation_0.nc","data_interpolation_1.nc"};
+
+    SECTION ("no-horiz-no-vert") {
+      root_print(comm,"  timeline=LINEAR,   horiz_remap=NO,  vert_remap=NO ..........\n");
+      run_tests (data_grid,files,t_beg,timeline);
+      root_print(comm,"  timeline=LINEAR,   horiz_remap=NO,  vert_remap=NO .......... PASS\n");
+    }
+
+    SECTION ("yes-horiz-no-vert") {
+      root_print(comm,"  timeline=LINEAR,   horiz_remap=YES, vert_remap=NO ..........\n");
+      run_tests (hfine_grid,files,t_beg,timeline);
+      root_print(comm,"  timeline=LINEAR,   horiz_remap=YES, vert_remap=NO .......... PASS\n");
     }
   }
 

--- a/components/eamxx/src/share/tests/data_interpolation_tests.hpp
+++ b/components/eamxx/src/share/tests/data_interpolation_tests.hpp
@@ -12,6 +12,11 @@ namespace scream
 
 constexpr int ncmps = 2;
 constexpr auto spd = constants::seconds_per_day;
+constexpr int data_ngcols = 12;
+constexpr int fine_ngcols = 2*data_ngcols-1; // stick one dof between each data dofs
+constexpr int data_nlevs = 32;
+constexpr int fine_nlevs = 64;
+const std::string map_file_name = "map_file_for_data_interp.nc";
 
 // At each month in the input data, we are adding a delta to the "base" value of the fields.
 constexpr double delta_data[12] = {0, 30, 60, 90, 120, 150, 180, 150, 120, 90, 60, 30};
@@ -20,37 +25,45 @@ inline util::TimeStamp get_t_ref () {
   return util::TimeStamp ({2010,1,1},{0,0,0});
 }
 
+// Slices are at midnight between 15th and 16th of each month
+// First slice is Jul 15th
 inline util::TimeStamp get_first_slice_time () {
   // 15 days after the reference time
-  return get_t_ref() + 86400*15;
+  auto t = get_t_ref() + spd*15;      // Mid Jan
+  for (int mm=0; mm<6; ++mm) {
+    t += spd*t.days_in_curr_month();
+  }
+  return t;
 }
 
 inline util::TimeStamp get_last_slice_time () {
   // 11 months after the 1st slice
   auto t = get_first_slice_time();
-
-  for (int mm=0; mm<23; ++mm) {
-    t += constants::seconds_per_day*t.days_in_curr_month();
+  for (int mm=0; mm<11; ++mm) {
+    t += spd*t.days_in_curr_month();
   }
   return t;
 }
 
 std::vector<Field>
 create_fields (const std::shared_ptr<const AbstractGrid>& grid,
-               const bool init_values)
+               const bool init_values,
+               const bool with_pressure = false)
 {
-  constexpr auto m = ekat::units::m;
+  constexpr auto m  = ekat::units::m;
+  constexpr auto Pa = ekat::units::Pa;
   const auto& gn = grid->name();
 
-  // Create fields and initialize their data as
-  //   set data as f(icol,icmp,ilev) = icol*ncmp*nlev + icmp*nlev + ilev
+  auto int_same_as_mid = with_pressure;
+
+  // Create fields
 
   auto layout_s2d   = grid->get_2d_scalar_layout();
   auto layout_v2d   = grid->get_2d_vector_layout(ncmps);
   auto layout_s3d_m = grid->get_3d_scalar_layout(true);
   auto layout_v3d_m = grid->get_3d_vector_layout(true,ncmps);
-  auto layout_s3d_i = grid->get_3d_scalar_layout(false);
-  auto layout_v3d_i = grid->get_3d_vector_layout(false,ncmps);
+  auto layout_s3d_i = grid->get_3d_scalar_layout(int_same_as_mid);
+  auto layout_v3d_i = grid->get_3d_vector_layout(int_same_as_mid,ncmps);
 
   Field s2d  (FieldIdentifier("s2d",   layout_s2d,   m, gn));
   Field v2d  (FieldIdentifier("v2d",   layout_v2d,   m, gn));
@@ -58,6 +71,11 @@ create_fields (const std::shared_ptr<const AbstractGrid>& grid,
   Field v3d_m(FieldIdentifier("v3d_m", layout_v3d_m, m, gn));
   Field s3d_i(FieldIdentifier("s3d_i", layout_s3d_i, m, gn));
   Field v3d_i(FieldIdentifier("v3d_i", layout_v3d_i, m, gn));
+
+  s3d_m.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
+  v3d_m.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
+  s3d_i.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
+  v3d_i.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
 
   s2d.allocate_view();
   v2d.allocate_view();
@@ -67,24 +85,49 @@ create_fields (const std::shared_ptr<const AbstractGrid>& grid,
   v3d_i.allocate_view();
 
   if (init_values) {
+    // We set horiz/vert values based on the position of the dof, assuming that
+    //  - we have a 1d horiz grid
+    //  - leftmost h dof gets a value of 0, rightmost a value of 1.0
+    //  - bottom interface gets a value of 0, top interface get a value of 1.0
+    //  - midpoints are the avg of interfaces
+    //  - we do hvalue*prod_other_dims + icmp*num_v_levs + v_value
     int ncols = grid->get_num_local_dofs();
     int nlevs = grid->get_num_vertical_levels();
     int nlevsp1 = nlevs+1;
+    int ngcols = grid->get_num_global_dofs();
+    int nh_intervals = ngcols - 1;
+    double h_value, v_value;
+    double h_max = 1.0;
+    double v_max = 1.0;
+    double dh = h_max / nh_intervals;
+    double dv = v_max / nlevs;
+    auto gids = grid->get_dofs_gids().get_view<const int*,Host>();
     for (int icol=0; icol<ncols; ++icol) {
+      auto gid = gids[icol];
+      h_value = gid*dh;
+      // 3D quantities
       for (int ilev=0; ilev<nlevs; ++ilev) {
+        v_value = ilev*dv;
         for (int icmp=0; icmp<ncmps; ++icmp) {
-          v3d_m.get_view<Real***,Host>()(icol,icmp,ilev) = icol*ncmps*nlevs   + icmp*nlevs   + ilev;
-          v3d_i.get_view<Real***,Host>()(icol,icmp,ilev) = icol*ncmps*nlevsp1 + icmp*nlevsp1 + ilev;
+          v3d_m.get_view<Real***,Host>()(icol,icmp,ilev) = h_value*ncmps*nlevs   + icmp*nlevs   + v_value + dv/2;
+          v3d_i.get_view<Real***,Host>()(icol,icmp,ilev) = h_value*ncmps*nlevsp1 + icmp*nlevsp1 + v_value;
         }
-        s3d_m.get_view<Real**,Host>()(icol,ilev) = icol*nlevs   + ilev;
-        s3d_i.get_view<Real**,Host>()(icol,ilev) = icol*nlevsp1 + ilev;
+        s3d_m.get_view<Real**,Host>()(icol,ilev) = h_value*nlevs   + v_value;
+        s3d_i.get_view<Real**,Host>()(icol,ilev) = h_value*nlevsp1 + v_value;
       }
-      s3d_i.get_view<Real**,Host>()(icol,nlevs) = icol*nlevsp1 + nlevs;
+      // Last interface (if mid!=int)
+      if (not int_same_as_mid) {
+        s3d_i.get_view<Real**,Host>()(icol,nlevs) = h_value*nlevsp1 + v_max;
+        for (int icmp=0; icmp<ncmps; ++icmp) {
+          v3d_i.get_view<Real***,Host>()(icol,icmp,nlevs) = h_value*ncmps*nlevsp1 + icmp*nlevsp1 + v_max;
+        }
+      }
+
+      // 2D quantities
       for (int icmp=0; icmp<ncmps; ++icmp) {
-        v3d_i.get_view<Real***,Host>()(icol,icmp,nlevs) = icol*ncmps*nlevsp1 + icmp*nlevsp1 + nlevs;
-        v2d.get_view<Real**,Host>()(icol,icmp) = icol*ncmps + icmp;
+        v2d.get_view<Real**,Host>()(icol,icmp) = h_value*ncmps + icmp;
       }
-      s2d.get_view<Real*,Host>()(icol) = icol;
+      s2d.get_view<Real*,Host>()(icol) = h_value;
     }
 
     s2d.sync_to_dev();
@@ -95,7 +138,16 @@ create_fields (const std::shared_ptr<const AbstractGrid>& grid,
     v3d_i.sync_to_dev();
   }
 
-  return {s2d, v2d, s3d_m, v3d_m, s3d_i, v3d_i};
+  if (with_pressure) {
+    // Don't just clone s3d_m, so we actually get "Pa" in the nc file units
+    Field p3d(FieldIdentifier("p3d",layout_s3d_m,Pa,gn));
+    p3d.allocate_view();
+    p3d.deep_copy(s3d_m);
+
+    return {s2d, v2d, s3d_m, v3d_m, s3d_i, v3d_i, p3d};
+  } else {
+    return {s2d, v2d, s3d_m, v3d_m, s3d_i, v3d_i};
+  }
 }
 
 } // namespace scream

--- a/components/eamxx/src/share/tests/data_interpolation_tests.hpp
+++ b/components/eamxx/src/share/tests/data_interpolation_tests.hpp
@@ -1,0 +1,103 @@
+#ifndef EAMXX_DATA_INTERPOLATION_TESTS_HPP
+#define EAMXX_DATA_INTERPOLATION_TESTS_HPP
+
+#include "share/grid/abstract_grid.hpp"
+#include "share/field/field.hpp"
+#include "share/util/scream_universal_constants.hpp"
+
+#include <vector>
+
+namespace scream
+{
+
+constexpr int ncmps = 2;
+constexpr auto spd = constants::seconds_per_day;
+
+// At each month in the input data, we are adding a delta to the "base" value of the fields.
+constexpr double delta_data[12] = {0, 30, 60, 90, 120, 150, 180, 150, 120, 90, 60, 30};
+
+inline util::TimeStamp get_t_ref () {
+  return util::TimeStamp ({2010,1,1},{0,0,0});
+}
+
+inline util::TimeStamp get_first_slice_time () {
+  // 15 days after the reference time
+  return get_t_ref() + 86400*15;
+}
+
+inline util::TimeStamp get_last_slice_time () {
+  // 11 months after the 1st slice
+  auto t = get_first_slice_time();
+
+  for (int mm=0; mm<23; ++mm) {
+    t += constants::seconds_per_day*t.days_in_curr_month();
+  }
+  return t;
+}
+
+std::vector<Field>
+create_fields (const std::shared_ptr<const AbstractGrid>& grid,
+               const bool init_values)
+{
+  constexpr auto m = ekat::units::m;
+  const auto& gn = grid->name();
+
+  // Create fields and initialize their data as
+  //   set data as f(icol,icmp,ilev) = icol*ncmp*nlev + icmp*nlev + ilev
+
+  auto layout_s2d   = grid->get_2d_scalar_layout();
+  auto layout_v2d   = grid->get_2d_vector_layout(ncmps);
+  auto layout_s3d_m = grid->get_3d_scalar_layout(true);
+  auto layout_v3d_m = grid->get_3d_vector_layout(true,ncmps);
+  auto layout_s3d_i = grid->get_3d_scalar_layout(false);
+  auto layout_v3d_i = grid->get_3d_vector_layout(false,ncmps);
+
+  Field s2d  (FieldIdentifier("s2d",   layout_s2d,   m, gn));
+  Field v2d  (FieldIdentifier("v2d",   layout_v2d,   m, gn));
+  Field s3d_m(FieldIdentifier("s3d_m", layout_s3d_m, m, gn));
+  Field v3d_m(FieldIdentifier("v3d_m", layout_v3d_m, m, gn));
+  Field s3d_i(FieldIdentifier("s3d_i", layout_s3d_i, m, gn));
+  Field v3d_i(FieldIdentifier("v3d_i", layout_v3d_i, m, gn));
+
+  s2d.allocate_view();
+  v2d.allocate_view();
+  s3d_m.allocate_view();
+  v3d_m.allocate_view();
+  s3d_i.allocate_view();
+  v3d_i.allocate_view();
+
+  if (init_values) {
+    int ncols = grid->get_num_local_dofs();
+    int nlevs = grid->get_num_vertical_levels();
+    int nlevsp1 = nlevs+1;
+    for (int icol=0; icol<ncols; ++icol) {
+      for (int ilev=0; ilev<nlevs; ++ilev) {
+        for (int icmp=0; icmp<ncmps; ++icmp) {
+          v3d_m.get_view<Real***,Host>()(icol,icmp,ilev) = icol*ncmps*nlevs   + icmp*nlevs   + ilev;
+          v3d_i.get_view<Real***,Host>()(icol,icmp,ilev) = icol*ncmps*nlevsp1 + icmp*nlevsp1 + ilev;
+        }
+        s3d_m.get_view<Real**,Host>()(icol,ilev) = icol*nlevs   + ilev;
+        s3d_i.get_view<Real**,Host>()(icol,ilev) = icol*nlevsp1 + ilev;
+      }
+      s3d_i.get_view<Real**,Host>()(icol,nlevs) = icol*nlevsp1 + nlevs;
+      for (int icmp=0; icmp<ncmps; ++icmp) {
+        v3d_i.get_view<Real***,Host>()(icol,icmp,nlevs) = icol*ncmps*nlevsp1 + icmp*nlevsp1 + nlevs;
+        v2d.get_view<Real**,Host>()(icol,icmp) = icol*ncmps + icmp;
+      }
+      s2d.get_view<Real*,Host>()(icol) = icol;
+    }
+
+    s2d.sync_to_dev();
+    v2d.sync_to_dev();
+    s3d_m.sync_to_dev();
+    v3d_m.sync_to_dev();
+    s3d_i.sync_to_dev();
+    v3d_i.sync_to_dev();
+  }
+
+  return {s2d, v2d, s3d_m, v3d_m, s3d_i, v3d_i};
+}
+
+} // namespace scream
+
+#endif // EAMXX_DATA_INTERPOLATION_TESTS_HPP

--- a/components/eamxx/src/share/util/eamxx_data_interpolation.cpp
+++ b/components/eamxx/src/share/util/eamxx_data_interpolation.cpp
@@ -1,0 +1,399 @@
+#include "share/util/eamxx_data_interpolation.hpp"
+
+#include "share/grid/remap/identity_remapper.hpp"
+#include "share/grid/remap/vertical_remapper.hpp"
+#include "share/grid/remap/refining_remapper_p2p.hpp"
+#include "share/io/scream_scorpio_interface.hpp"
+#include "share/io/scream_io_utils.hpp"
+#include "share/field/field_utils.hpp"
+#include "share/util/scream_universal_constants.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <regex>
+#include <unordered_set>
+
+namespace scream{
+
+DataInterpolation::
+DataInterpolation (const std::shared_ptr<const AbstractGrid>& model_grid,
+                   const std::vector<Field>& fields)
+ : m_model_grid (model_grid)
+ , m_fields     (fields)
+{
+  EKAT_REQUIRE_MSG (model_grid!=nullptr,
+      "[DataInterpolation] Error! Invalid grid pointer.\n");
+
+  m_comm = model_grid->get_comm();
+}
+
+void DataInterpolation::run (const util::TimeStamp& ts)
+{
+  EKAT_REQUIRE_MSG (m_data_initialized,
+      "[DataInterpolation] Error! You must call 'init_data_interval' before calling 'run'.\n");
+
+  // If we went past the current interval end, we need to update the end state
+  if (not m_data_interval.contains(ts)) {
+    shift_data_interval ();
+  }
+
+  // Perform the time interpolation: f_out = f_beg*alpha + f_end*(1-alpha),
+  // where alpha = (ts-t_beg) / (t_end-t_beg).
+  // NOTE: pay attention to time strategy, since for YearlyPeriodic you may
+  //       have t_beg>t_end
+  util::TimeInterval beg_to_ts (m_data_interval.beg,ts,m_data_interval.timeline);
+  double alpha = beg_to_ts.length / m_data_interval.length;
+  EKAT_REQUIRE_MSG (alpha>=0 and alpha<=1,
+    "[DataInterpolation] Error! Input timestamp is outside the current data time interval.\n"
+    "  data interval beg  ; " + m_data_interval.beg.to_string() + "\n"
+    "  data interval end  ; " + m_data_interval.end.to_string() + "\n"
+    "  input timestamp    ; " + ts.to_string() + "\n"
+    "  interval length    : " + std::to_string(m_data_interval.length) + "\n"
+    "  interpolation coeff: " + std::to_string(alpha) + "\n");
+
+  int nfields = m_fields.size();
+  for (int i=0; i<nfields; ++i) {
+    const auto& beg = m_horiz_remapper_beg->get_tgt_field(i);
+    const auto& end = m_horiz_remapper_end->get_tgt_field(i);
+          auto  out = m_vert_remapper->get_src_field(i);
+
+    out.deep_copy(beg);
+    out.update(end,alpha,1-alpha);
+  }
+  
+  m_vert_remapper->remap(true);
+}
+
+void DataInterpolation::shift_data_interval ()
+{
+  m_curr_interval_idx.first = m_curr_interval_idx.second;
+  m_curr_interval_idx.second = m_time_database.get_next_idx(m_curr_interval_idx.first);
+
+  m_data_interval.advance(m_time_database.slices[m_curr_interval_idx.second].time);
+  std::swap (m_horiz_remapper_beg,m_horiz_remapper_end);
+  update_end_fields ();
+}
+
+void DataInterpolation::
+update_end_fields ()
+{
+  // First, set the correct fields in the reader
+  int nfields = m_horiz_remapper_end->get_num_fields();
+  std::vector<Field> fields;
+  for (int i=0; i<nfields; ++i) {
+    fields.push_back(m_horiz_remapper_end->get_src_field(i));
+  }
+  m_reader->set_fields(fields);
+
+  // If we're also changing the file, must (re)init the scorpio structures
+  const auto& slice = m_time_database.slices[m_curr_interval_idx.second];
+  if (m_reader->get_filename()!=slice.filename) {
+    m_reader->reset_filename(slice.filename);
+  }
+
+  // Read and interpolate fields
+  m_reader->read_variables(slice.time_idx);
+  m_horiz_remapper_end->remap(true);
+}
+
+void DataInterpolation::
+init_data_interval (const util::TimeStamp& t0)
+{
+  EKAT_REQUIRE_MSG (m_remappers_created,
+      "[DataInterpolation] Error! Cannot call 'init_data_interval' until after remappers creation.\n");
+
+  // Create a bare reader. Fields and filename are set inside the update_end_fields call
+  strvec_t fnames;
+  for (auto f : m_fields) {
+    fnames.push_back(f.name());
+  }
+  m_reader = std::make_shared<AtmosphereInput>(fnames,m_horiz_remapper_beg->get_src_grid());
+
+  // Loop over all stored time slices to find an interval that contains t0
+  auto t0_interval = m_time_database.find_interval(t0);
+  const auto& t_beg = m_time_database.slices[t0_interval].time;
+
+  // We need to read in the beg/end fields for the initial interval. However, our generic
+  // framework can only load the end slice (since that's what we need at runtime).
+  // So, load end state for t=t_beg, then call shift_data_interval
+  // NOTE: don't compute length now, since beg time point is invalid (we don't need length yet).
+  m_data_interval = util::TimeInterval (util::TimeStamp(),t_beg,m_time_database.timeline,false);
+  m_curr_interval_idx.second = t0_interval;
+  update_end_fields ();
+  shift_data_interval ();
+
+  m_data_initialized = true;
+}
+
+void DataInterpolation::
+setup_time_database (const strvec_t& input_files,
+                     const util::TimeLine timeline)
+{
+  // Make sure there are no repetitions
+  EKAT_REQUIRE_MSG (std::unordered_set(input_files.begin(),input_files.end()).size()==input_files.size(),
+      "[DataInterpolation] Error! The input files list contains duplicates.\n"
+      " - input_files:\n     " + ekat::join(input_files,"\n     ") + "\n");
+
+  // We perform a bunch of checks on the input files
+  namespace fs = std::filesystem;
+
+  auto file_readable = [] (const std::string& fileName) {
+    std::ifstream file(fileName);
+    return file.good(); // Check if the file can be opened
+  };
+
+  // Log the final list of files, so the user know if something went wrong (e.g. a bad regex)
+  if (m_comm.am_i_root()) {
+    std::cout << "Setting up DataInerpolation object. List of input files:\n";
+    for (const auto& fname : input_files) {
+      std::cout << "  - " << fname << "\n";
+    }
+  }
+
+  // Read what time stamps we have in each file
+  auto ts2str = [](const util::TimeStamp& t) { return t.to_string(); };
+  std::vector<std::vector<util::TimeStamp>> times;
+  for (const auto& fname : input_files) {
+    EKAT_REQUIRE_MSG (file_readable(input_files.back()),
+        "Error! One of the input files is not readable.\n"
+        " - file   : " + input_files.back() + "\n");
+
+    scorpio::register_file(fname,scorpio::Read);
+
+    auto file_times = scorpio::get_all_times(fname);
+    EKAT_REQUIRE_MSG (file_times.size()>0,
+        "[DataInterpolation] Error! Input file contains no time variable.\n"
+        " - file name: " + fname + "\n");
+
+    auto t_ref = read_timestamp (fname,"reference_time_stamp");
+
+    times.emplace_back();
+    for (const auto& t : file_times) {
+      times.back().push_back(t_ref + t*constants::seconds_per_day);
+    }
+    scorpio::release_file(fname);
+
+    // Ensure time slices are sorted (it would make code messy otherwise)
+    EKAT_REQUIRE_MSG (std::is_sorted(times.back().begin(),times.back().end()),
+        "[DataInterpolation] Error! One of the input files has time slices not sorted.\n"
+        " - file name  : " + fname + "\n"
+        " - time stamps: " + ekat::join(times.back(),ts2str,", ") + "\n");
+  }
+
+  // Sort the files based on start date
+  auto fileCmp = [](const std::vector<util::TimeStamp>& times1,
+                    const std::vector<util::TimeStamp>& times2)
+  {
+    return times1.front() < times2.front();
+  };
+  std::sort(times.begin(),times.end(),fileCmp);
+
+  // Setup the time database
+  m_time_database.timeline = timeline;
+  m_time_database.files = input_files;
+
+  int nfiles = input_files.size();
+  for (int i=0; i<nfiles; ++i) {
+    int time_idx = 0;
+    for (const auto& t : times[i]) {
+      auto& slice = m_time_database.slices.emplace_back();
+      slice.time = t;
+      slice.filename = input_files[i];
+      slice.time_idx = time_idx;
+      ++time_idx;
+    }
+
+    if (i>0) {
+      // Ensure files don't overlap (it would be a mess)
+      const auto& prev = times[i-1];
+      const auto& next = times[i];
+      EKAT_REQUIRE_MSG (prev.back() < next.front(),
+          "[DataInterpolation] Error! The input files contain overlapping time slices.\n"
+          " - file1 name : " + input_files[i-1] + "\n"
+          " - file2 name : " + input_files[i] + "\n"
+          " - file1 times: " + ekat::join(prev,ts2str,", ") + "\n"
+          " - file2 times: " + ekat::join(next,ts2str,", ") + "\n");
+    }
+  }
+
+  // To avoid trouble in our logic of handling time stamps relationshipc,
+  // we must ensure we have 2+ time slices overall
+  EKAT_REQUIRE_MSG (m_time_database.size()>=2,
+      "[DataInterpolation] Error! Input file(s) only contain 1 time slice overall.\n");
+
+  m_time_db_created = true;
+
+  // Initialize horiz/vert remappers to identities
+  setup_remappers ("",None,"",{},{});
+}
+
+void DataInterpolation::
+setup_remappers (const std::string& hremap_filename,
+                 const VRemapType vr_type,
+                 const std::string& data_pname,
+                 const Field& model_pmid,
+                 const Field& model_pint)
+{
+  EKAT_REQUIRE_MSG (m_time_db_created,
+      "[DataInterpolation] Error! Cannot create remappers before time database.\n");
+
+  using IDR = IdentityRemapper;
+  constexpr auto SAT = IDR::SrcAliasTgt;
+
+  // Whether horiz remap happens or not, the tgt grid of hremap is the same
+  // as the model grid, but with the same nubmer of levels as in the input files
+  auto grid_after_hremap = m_model_grid->clone("after_hremap",true);
+  int nlevs_data = get_input_files_dimlen ("lev");
+  grid_after_hremap->reset_num_vertical_lev(nlevs_data);
+
+  if (hremap_filename!="") {
+    m_horiz_remapper_beg = std::make_shared<RefiningRemapperP2P>(grid_after_hremap,hremap_filename);
+    m_horiz_remapper_end = std::make_shared<RefiningRemapperP2P>(grid_after_hremap,hremap_filename);
+  } else {
+    // If there's NO hremap, then ncols from the data must match the model grid (nlev can differ)
+    int ncols = get_input_files_dimlen ("ncol");
+    EKAT_REQUIRE_MSG (ncols==m_model_grid->get_num_global_dofs(),
+        "Error! No horiz remap was requested, but the 'ncol' dim from file does not match with the model grid one.\n"
+        " - model grid num global cols: " + std::to_string(m_model_grid->get_num_global_dofs()) + "\n"
+        " - input data num global cols: " + std::to_string(ncols) + "\n");
+
+    m_horiz_remapper_beg = std::make_shared<IDR>(grid_after_hremap,SAT);
+    m_horiz_remapper_end = std::make_shared<IDR>(grid_after_hremap,SAT);
+  }
+
+  if (vr_type!=None) {
+    m_vert_remapper = std::make_shared<VerticalRemapper>(grid_after_hremap,m_model_grid);
+  } else {
+    // If no vert remap is requested, model_grid and grid_after_hremap MUST have same nlevs
+    int model_nlevs = m_model_grid->get_num_vertical_levels();
+    EKAT_REQUIRE_MSG (model_nlevs==nlevs_data,
+        "Error! No vertical remap was requested, but the 'lev' dim from file does not match the model grid one.\n"
+        " - model grid num vert levels: " + std::to_string(model_nlevs) + "\n"
+        " - input data num vert levels: " + std::to_string(nlevs_data) + "\n");
+    m_vert_remapper = std::make_shared<IDR>(grid_after_hremap,SAT);
+  }
+
+  // Setup remappers. Vertical first, since we only have model-grid fields
+  int nfields = m_fields.size();
+  m_vert_remapper->registration_begins();
+  for (int i=0; i<nfields; ++i) {
+    m_vert_remapper->register_field_from_tgt(m_fields[i]);
+  }
+  m_vert_remapper->registration_ends();
+
+  m_horiz_remapper_beg->registration_begins();
+  m_horiz_remapper_end->registration_begins();
+  for (int i=0; i<nfields; ++i) {
+    const auto& f = m_vert_remapper->get_src_field(i);
+    m_horiz_remapper_beg->register_field_from_tgt(f.clone());
+    m_horiz_remapper_end->register_field_from_tgt(f.clone());
+  }
+
+  // Setup vertical pressure profiles (which can add 1 extra field to hremap)
+  if (vr_type==Dynamic3D) {
+    // We also need to load and remap the pressure from the input files
+    auto hr_tgt_grid = m_horiz_remapper_beg->get_tgt_grid();
+    auto p_layout = hr_tgt_grid->get_3d_scalar_layout(true);
+    Field data_p (FieldIdentifier(data_pname,p_layout,ekat::units::Pa,hr_tgt_grid->name()));
+    data_p.allocate_view();
+    m_horiz_remapper_beg->register_field_from_tgt(data_p.clone());
+    m_horiz_remapper_end->register_field_from_tgt(data_p.clone());
+
+    auto vremap = std::dynamic_pointer_cast<VerticalRemapper>(m_vert_remapper);
+    vremap->set_source_pressure (data_p,VerticalRemapper::Both);
+    vremap->set_target_pressure (model_pmid,model_pint);
+  } else if (vr_type==Static1D) {
+    auto hr_tgt_grid = m_horiz_remapper_beg->get_tgt_grid();
+    auto p_layout = hr_tgt_grid->get_vertical_layout(true);
+    Field data_p (FieldIdentifier(data_pname,p_layout,ekat::units::Pa,hr_tgt_grid->name()));
+    data_p.allocate_view();
+
+    auto vremap = std::dynamic_pointer_cast<VerticalRemapper>(m_vert_remapper);
+    vremap->set_target_pressure (data_p,VerticalRemapper::Both);
+    vremap->set_source_pressure (model_pmid,model_pint);
+  }
+
+  m_horiz_remapper_beg->registration_ends();
+  m_horiz_remapper_end->registration_ends();
+
+  m_remappers_created = true;
+}
+
+int DataInterpolation::TimeDatabase::
+get_next_idx (int prev) const
+{
+  int next = prev+1;
+  if (next >= size()) {
+    EKAT_REQUIRE_MSG (timeline==util::TimeLine::YearlyPeriodic,
+        "[TimeDatabase::get_next_idx] Error! Requesting slice that is past the database end.\n");
+    next = next % size();
+  }
+  return next;
+}
+
+int DataInterpolation::TimeDatabase::
+find_interval (const util::TimeStamp& t) const
+{
+  EKAT_REQUIRE_MSG (size()>1,
+      "[TimeDatabase::find_interval] Error! The database has not been initialized yet.\n");
+
+  auto contains = [&](int beg, int end, const util::TimeStamp& t) {
+    const auto& t_beg = slices[beg].time;
+    const auto& t_end = slices[end].time;
+    util::TimeInterval t_int (t_beg,t_end,timeline);
+    return t_int.contains(t);
+  };
+  int beg=0;
+  int end=1;
+  while (end<size()) {
+    if (contains(beg,end,t)) {
+      return beg;
+    }
+    beg = end;
+    end = get_next_idx(beg);
+  };
+
+  // If we got here, no interval [i,i+1] contains t. If the timeline is Linear,
+  // this is an error (in fact, there should have been an error before!).
+  // But if the timeline is YearlyPeriodic, then it must be the case that
+  // t is in the interval (slices[N],slices[0]).
+  EKAT_REQUIRE_MSG (timeline==util::TimeLine::YearlyPeriodic and contains(size(),0,t),
+      "[TimeDatabase::find_interval] Error! Could not locate interval containing input timestamp.\n"
+      "  - input time : " + t.to_string() + "\n"
+      "  - timeline   : " + (timeline==util::TimeLine::Linear ? "linear" : "yearly_periodic") + "\n"
+      "  - first slice: " + slices.front().time.to_string() + "\n"
+      "  - last slice : " + slices.back().time.to_string() + "\n"
+      "Did you mean to use YearlyPeriodic timeline?\n");
+
+  // Since we are in YearlyPeriodic timeline, the interval starts at the last slice
+  return size()-1;
+}
+
+int DataInterpolation::
+get_input_files_dimlen (const std::string& dimname) const
+{
+  // Retrieve a dim len from input file.
+  // Also check that all files agree on that dim len
+  int dimlen = -1;
+  for (const auto& fname : m_time_database.files) {
+    scorpio::register_file(fname,scorpio::Read);
+
+    EKAT_REQUIRE_MSG (scorpio::has_dim(fname,dimname),
+        "Error! Input file is missing '" + dimname + "' dimension.\n"
+        "  - input file: " + fname + "\n");
+
+    auto this_file_dimlen = scorpio::get_dimlen(fname,dimname);
+    EKAT_REQUIRE_MSG (dimlen==-1 or dimlen==this_file_dimlen,
+        "Error! Input files do not agree on '" + dimname + "' dimension length.\n"
+        "  - file1: " + m_time_database.files.front() + "\n"
+        "  - file2: " + fname + "\n"
+        "  - file1 dim len: " + std::to_string(dimlen) + "\n"
+        "  - file2 dim len: " + std::to_string(this_file_dimlen) + "\n");
+    scorpio::release_file(fname);
+
+    dimlen = this_file_dimlen;
+  }
+  return dimlen;
+}
+
+} // namespace scream

--- a/components/eamxx/src/share/util/eamxx_data_interpolation.cpp
+++ b/components/eamxx/src/share/util/eamxx_data_interpolation.cpp
@@ -323,6 +323,13 @@ setup_remappers (const std::string& hremap_filename,
     data_p = Field (FieldIdentifier(data_pname,p_layout,ekat::units::Pa,hr_tgt_grid->name()));
     data_p.allocate_view();
 
+    // Use raw scorpio to read this var, since it's not decomposed. Use any file, since it's static
+    auto filename = m_time_database.files.front();
+    scorpio::register_file(filename,scorpio::Read);
+    scorpio::read_var(filename,data_pname,data_p.get_internal_view_data<Real,Host>());
+    scorpio::release_file(filename);
+    data_p.sync_to_dev();
+
     vremap->set_source_pressure (data_p,VerticalRemapper::Both);
     vremap->set_target_pressure (model_pmid,model_pint);
   }

--- a/components/eamxx/src/share/util/eamxx_data_interpolation.hpp
+++ b/components/eamxx/src/share/util/eamxx_data_interpolation.hpp
@@ -1,0 +1,96 @@
+#ifndef EAMXX_DATA_INTERPOLATION_HPP
+#define EAMXX_DATA_INTERPOLATION_HPP
+
+#include "share/grid/abstract_grid.hpp"
+#include "share/grid/remap/abstract_remapper.hpp"
+#include "share/util/scream_time_stamp.hpp"
+#include "share/field/field.hpp"
+#include "share/io/scorpio_input.hpp"
+#include "share/util/scream_time_stamp.hpp"
+
+namespace scream{
+
+class DataInterpolation
+{
+public:
+  using strvec_t = std::vector<std::string>;
+  enum VRemapType {
+    None,
+    Static1D,
+    Dynamic3D
+  };
+
+  // Constructor(s) & Destructor
+  DataInterpolation (const std::shared_ptr<const AbstractGrid>& model_grid,
+                     const std::vector<Field>& fields);
+
+  ~DataInterpolation () = default;
+
+  void setup_time_database (const strvec_t& input_files, const util::TimeLine timeline);
+
+  void setup_remappers (const std::string& hremap_filename,
+                        const VRemapType vremap,
+                        const std::string& data_pname,
+                        const Field& model_pmid,
+                        const Field& model_pint);
+
+  void init_data_interval (const util::TimeStamp& t0);
+
+  void run (const util::TimeStamp& ts);
+
+protected:
+
+  void shift_data_interval ();
+  void update_end_fields ();
+
+  int get_input_files_dimlen (const std::string& dimname) const;
+
+  // ----------- Internal data types ---------- //
+
+  struct DataSlice {
+    util::TimeStamp time;
+    std::string     filename;
+    int             time_idx; // slice index within the input file
+  };
+
+  struct TimeDatabase {
+    strvec_t                files;
+    std::vector<DataSlice>  slices;
+    util::TimeLine          timeline;
+
+    int size () const { return slices.size(); }
+    int get_next_idx (int prev_idx) const;
+
+    // Find interval containing t
+    int find_interval (const util::TimeStamp& t) const;
+  };
+
+  // --------------- Internal data ------------- //
+
+  std::shared_ptr<AtmosphereInput> m_reader;
+
+  std::shared_ptr<const AbstractGrid> m_model_grid;
+
+  std::vector<Field>                  m_fields;
+
+  // Use two horiz remappers, so we only set them up once (it may be costly)
+  std::shared_ptr<AbstractRemapper> m_horiz_remapper_beg;
+  std::shared_ptr<AbstractRemapper> m_horiz_remapper_end;
+  std::shared_ptr<AbstractRemapper> m_vert_remapper;
+
+  util::TimeInterval    m_data_interval;
+  std::pair<int,int>    m_curr_interval_idx;
+
+  TimeDatabase          m_time_database;
+
+  ekat::Comm            m_comm;
+  ekat::ParameterList   m_params;
+
+  bool                  m_time_db_created   = false;
+  bool                  m_remappers_created = false;
+  bool                  m_data_initialized  = false;
+};
+
+} // namespace scream
+
+#endif // EAMXX_DATA_INTERPOLATION_HPP

--- a/components/eamxx/src/share/util/eamxx_data_interpolation.hpp
+++ b/components/eamxx/src/share/util/eamxx_data_interpolation.hpp
@@ -26,6 +26,8 @@ public:
 
   ~DataInterpolation () = default;
 
+  void toggle_debug_output (bool enable_dbg_output) { m_dbg_output = enable_dbg_output; }
+
   void setup_time_database (const strvec_t& input_files, const util::TimeLine timeline);
 
   void setup_remappers (const std::string& hremap_filename,
@@ -89,6 +91,8 @@ protected:
   bool                  m_time_db_created   = false;
   bool                  m_remappers_created = false;
   bool                  m_data_initialized  = false;
+
+  bool m_dbg_output = false;
 };
 
 } // namespace scream

--- a/components/eamxx/src/share/util/eamxx_data_interpolation.hpp
+++ b/components/eamxx/src/share/util/eamxx_data_interpolation.hpp
@@ -31,7 +31,16 @@ public:
   void setup_time_database (const strvec_t& input_files, const util::TimeLine timeline);
 
   void setup_remappers (const std::string& hremap_filename,
-                        const VRemapType vremap,
+                        const VRemapType vr_type,
+                        const std::string& data_pname,
+                        const Field& model_pmid,
+                        const Field& model_pint);
+
+  void setup_remappers (const std::string& hremap_filename,
+                        const VRemapType vr_type,
+                        const std::string& extrap_type_top,
+                        const std::string& extrap_type_bot,
+                        const Real mask_value,
                         const std::string& data_pname,
                         const Field& model_pmid,
                         const Field& model_pint);

--- a/components/eamxx/src/share/util/eamxx_data_interpolation.hpp
+++ b/components/eamxx/src/share/util/eamxx_data_interpolation.hpp
@@ -10,6 +10,8 @@
 
 namespace scream{
 
+class VerticalRemapper;
+
 class DataInterpolation
 {
 public:
@@ -88,6 +90,10 @@ protected:
   std::shared_ptr<AbstractRemapper> m_horiz_remapper_beg;
   std::shared_ptr<AbstractRemapper> m_horiz_remapper_end;
   std::shared_ptr<AbstractRemapper> m_vert_remapper;
+  std::shared_ptr<VerticalRemapper> m_vremap;
+
+  VRemapType            m_vr_type;
+  int                   m_nfields;
 
   util::TimeInterval    m_data_interval;
   std::pair<int,int>    m_curr_interval_idx;

--- a/components/eamxx/src/share/util/scream_time_stamp.cpp
+++ b/components/eamxx/src/share/util/scream_time_stamp.cpp
@@ -16,15 +16,6 @@
 namespace scream {
 namespace util {
 
-int days_in_month (const int yy, const int mm) {
-  EKAT_REQUIRE_MSG (mm>=1 && mm<=12,
-      "Error! Month out of bounds. Did you call `days_in_month` with yy and mm swapped?\n");
-  constexpr int nonleap_days [12] = {31,28,31,30,31,30,31,31,30,31,30,31};
-  constexpr int leap_days    [12] = {31,29,31,30,31,30,31,31,30,31,30,31};
-  auto& arr = is_leap_year(yy) ? leap_days : nonleap_days;
-  return arr[mm-1];
-}
-
 bool is_leap_year (const int yy) {
   if (use_leap_year()) {
     if (yy%4==0) {
@@ -39,6 +30,15 @@ bool is_leap_year (const int yy) {
     }
   }
   return false;
+}
+
+int days_in_month (const int yy, const int mm) {
+  EKAT_REQUIRE_MSG (mm>=1 && mm<=12,
+      "Error! Month out of bounds. Did you call `days_in_month` with yy and mm swapped?\n");
+  constexpr int nonleap_days [12] = {31,28,31,30,31,30,31,31,30,31,30,31};
+  constexpr int leap_days    [12] = {31,29,31,30,31,30,31,31,30,31,30,31};
+  auto& arr = is_leap_year(yy) ? leap_days : nonleap_days;
+  return arr[mm-1];
 }
 
 TimeStamp::TimeStamp()
@@ -133,6 +133,23 @@ double TimeStamp::frac_of_year_in_days () const {
     doy += days_in_month(m_date[0],m);
   }
   return doy;
+}
+
+int TimeStamp::days_in_curr_month () const
+{
+  return days_in_month(m_date[0],m_date[1]);
+}
+
+int TimeStamp::days_in_curr_year () const
+{
+  return is_leap_year(m_date[0]) ? 366 : 365;
+}
+
+TimeStamp TimeStamp::curr_month_beg () const
+{
+  auto date = m_date;
+  date[2] = 1;
+  return TimeStamp (date,m_time);
 }
 
 TimeStamp& TimeStamp::operator+=(const double seconds) {

--- a/components/eamxx/src/share/util/scream_time_stamp.cpp
+++ b/components/eamxx/src/share/util/scream_time_stamp.cpp
@@ -149,7 +149,7 @@ TimeStamp TimeStamp::curr_month_beg () const
 {
   auto date = m_date;
   date[2] = 1;
-  return TimeStamp (date,m_time);
+  return TimeStamp (date,{0,0,0});
 }
 
 TimeStamp& TimeStamp::operator+=(const double seconds) {

--- a/components/eamxx/src/share/util/scream_time_stamp.hpp
+++ b/components/eamxx/src/share/util/scream_time_stamp.hpp
@@ -86,6 +86,86 @@ TimeStamp operator- (const TimeStamp& ts, const int dt);
 // If input string is not of the format YYYY-MM-DD-XXXXX, returns an invalid time stamp
 TimeStamp str_to_time_stamp (const std::string& s);
 
+// An enum describing two ways to look at timestamps:
+//  - Linear: treat them as part of a 1d line
+//  - YearlyPeriodic: treat them as part of a yearly periodic orbit
+// This is used in the TimeInterval class below to correctly handle time stamps differences
+enum class TimeLine {
+  YearlyPeriodic,
+  Linear
+};
+
+/*
+ * Small struct to deal with time intervals
+ *
+ * The struct simply contains timestamps for [begin,end] interval,
+ * and allows two things: compute the interval length (in days), and check if
+ * a timestamp lies within the interval.
+ *
+ * When the TimeLine arg to the ctor is YearlyPeriodic, the year part of beg/end
+ * time points is ignored. In this case, the length of the time interval is bound
+ * to be in the interval [0,365] (in non-leap years)
+ */
+struct TimeInterval {
+
+  TimeStamp beg;
+  TimeStamp end;
+  TimeLine  timeline = TimeLine::Linear;
+  double length  = -1; // the interval length
+
+  TimeInterval () = default;
+  TimeInterval (const util::TimeStamp& b, const util::TimeStamp& e, TimeLine tl, bool do_compute_length = true)
+   : beg (b), end (e), timeline (tl)
+  {
+    if (do_compute_length)
+      compute_length ();
+  }
+
+  bool contains (const util::TimeStamp& t) const {
+    if (timeline==TimeLine::Linear) {
+      // Compare the full time stamps
+      return beg<=t and t<=end;
+    } else {
+      // Compare the fraction of year for beg/end and t.
+      // Pay extra attention to the case where new year's eve
+      // is in [bec,end]
+      auto t_frac = t.frac_of_year_in_days();
+      auto end_frac = end.frac_of_year_in_days();
+      auto beg_frac = beg.frac_of_year_in_days();
+      bool across_nye = beg.get_month()>end.get_month();
+      if (not across_nye) {
+        return beg_frac<=t_frac and t_frac<=end_frac;
+      } else {
+        // We are either PAST beg or BEFORE end (but not both)
+        return t_frac>=beg_frac or t_frac<=end_frac;
+      }
+    }
+  }
+
+  void compute_length () {
+    if (timeline==TimeLine::Linear) {
+      length = end.days_from(beg);
+    } else {
+      bool across_nye = beg.get_month()>end.get_month();
+      auto frac_beg = beg.frac_of_year_in_days();
+      auto frac_end = end.frac_of_year_in_days();
+      if (across_nye) {
+        double year = end.days_in_curr_year();
+        length = frac_end + (year - frac_beg);
+      } else {
+        length = frac_end - frac_beg;
+      }
+    }
+  }
+
+  // Advance the interval, so that it now starts from the old end
+  void advance(const TimeStamp& new_end) {
+    beg = end;
+    end = new_end;
+    compute_length();
+  }
+};
+
 } // namespace util
 
 } // namespace scream

--- a/components/eamxx/src/share/util/scream_time_stamp.hpp
+++ b/components/eamxx/src/share/util/scream_time_stamp.hpp
@@ -45,6 +45,11 @@ public:
   std::string get_time_string () const;
   double frac_of_year_in_days () const;
 
+  int days_in_curr_month () const;
+  int days_in_curr_year () const;
+
+  TimeStamp curr_month_beg () const;
+
   // === Update method(s) === //
 
   // Set the counter for the number of steps.
@@ -77,10 +82,6 @@ std::int64_t operator- (const TimeStamp& ts1, const TimeStamp& ts2);
 
 // Rewind time by given number of seconds
 TimeStamp operator- (const TimeStamp& ts, const int dt);
-
-// Time-related free-functions
-int days_in_month (const int year, const int month);
-bool is_leap_year (const int year);
 
 // If input string is not of the format YYYY-MM-DD-XXXXX, returns an invalid time stamp
 TimeStamp str_to_time_stamp (const std::string& s);


### PR DESCRIPTION
The class is in charge of reading in time-dependent datasets from input file(s), interpolate to current model time, and possibly do horizontal/vertical interpolation

---

The implementation is not yet complete, but some early thoughts on whether we're on the right track or not may help. Besides, getting some early testing on ghci machines can also help.

Things left to do:
- [x] testing for time-only interpolation for Linear timeline
- [x] add creation of vert/horiz remappers: this needs some extra input from parameter list (a map file, and for vert remap some choices for top/bot extrapolation)
- [x] testing for time+horiz, time+vert, and time+horiz+vert
- [ ] add possibility of using an "IOP remapper" (a closest-column kind for horiz interpolation). This may allow the upcoming IOP forcing atm proc to use the DataIntepolation routine directly.
- [ ] start using DataInterpolation in eamxx. E.g., use in SPA, and fix the alloc issue (see linked issue)

I am NOT implementing a data interpolation for variables without a time dependence. It simply reduces to constructing 2 remappers, and since non-time dep data is most likely load-able at init, there's no real need for a complex data structure. Time interpolation is the most tricky of the 3 anyways, due to the different needs (nudging uses Linear timeline, while SPA uses a YearlyPeriodic one)

For reviewers: i recommend reviewing one commit at a time. That would help isolate concepts, so you can hopefully better follow. The hardest thing to review is the data interpolation unit tests, since there is quite a bit of code needed to generate cases that we can manually check without redoing the same operation as the interpolation class (copy+paste of src code in tests folder doesn't help).

Fixes #6810 
Fixes #6820
