### PR TITLE
Init rino when short tests are on

### DIFF
--- a/components/eamxx/scripts/machines_specs.py
+++ b/components/eamxx/scripts/machines_specs.py
@@ -124,7 +124,7 @@ class PM(CrayMachine):
             cls.batch += "--time 00:30:00 --nodes=1 -q debug"
         else:
             cls.batch += "--time 02:00:00 --nodes=4 --gpus-per-node=4 --gpu-bind=none --exclusive -q regular"
-        
+
         cls.baselines_dir = f"/global/cfs/cdirs/e3sm/baselines/{compiler}/scream/{cls.name}"
 
 ###############################################################################

--- a/components/eamxx/src/physics/shoc/impl/shoc_pblintd_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_pblintd_impl.hpp
@@ -78,8 +78,10 @@ void Functions<S,D>::pblintd(
 
   // Initialize
   bool check = true;
-  // The loop below fixes valgrind uninitialized mem errs
-#ifndef NDEBUG
+  // The loop below fixes valgrind uninitialized mem errs. As in other
+  // places in eamxx, we use SCREAM_SHORT_TESTS as a proxy for knowing
+  // mem checking is on.
+#if !defined(NDEBUG) || defined(SCREAM_SHORT_TESTS)
   for (size_t i=0; i<rino.size(); ++i) {
     rino(i)=0;
   }

--- a/components/eamxx/src/share/scream_types.hpp
+++ b/components/eamxx/src/share/scream_types.hpp
@@ -39,7 +39,8 @@ enum class RunType {
 
 // We cannot expect BFB results between f90 and cxx if optimizations are on.
 // Same goes for cuda-memcheck because it makes the bfb math layer prohibitively
-// expensive and so must be turned off.
+// expensive and so must be turned off. SCREAM_SHORT_TESTS is a proxy
+// for mem checking.
 #if defined (NDEBUG) || defined (SCREAM_SHORT_TESTS)
 static constexpr bool SCREAM_BFB_TESTING = false;
 #else


### PR DESCRIPTION
The mem tests are no longer guaranteed to have NDEBUG on. We use SCREAM_SHORT_TESTS as a proxy for knowing that mem checking is on.