### PR TITLE
EAMxx: fix valgrind failures

### DIFF
--- a/components/eamxx/scripts/test_factory.py
+++ b/components/eamxx/scripts/test_factory.py
@@ -156,6 +156,7 @@ class VALG(TestProperty):
             "Release build where tests run through valgrind",
             [("CMAKE_BUILD_TYPE", "RelWithDebInfo"),
              ("EKAT_ENABLE_VALGRIND", "True"),
+             ("SCREAM_PACK_SIZE", "1"),
              ("SCREAM_TEST_MAX_THREADS", "2")],
             uses_baselines=False,
             on_by_default=False,

--- a/components/eamxx/tests/generic/fail_check/valg_fail.cpp
+++ b/components/eamxx/tests/generic/fail_check/valg_fail.cpp
@@ -6,15 +6,18 @@ namespace scream {
 
 TEST_CASE("force_valgrind_err")
 {
-  bool uninit;
+  bool* uninit = new bool[1];
   int i = 0;
-  if (uninit) {
+  if (uninit[0]) {
     ++i;
   }
   else {
     i += 4;
   }
-  REQUIRE(i < 10);
+  if (i<4) {
+    printf("less than four\n");
+  }
+  delete uninit;
 }
 
 } // empty namespace

--- a/components/homme/src/share/namelist_mod.F90
+++ b/components/homme/src/share/namelist_mod.F90
@@ -426,6 +426,13 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     se_ftype = ftype   ! MNL: For non-CAM runs, ftype=0 in control_mod
     nsplit = 1
     pertlim = 0.0_real_kind
+#else
+    se_partmethod = SFCURVE
+    se_ne = 0
+    se_ne_x = 0
+    se_ne_y = 0
+    se_lx = 0
+    se_ly = 0
 #endif
     sub_case      = 1
     numnodes      = -1


### PR DESCRIPTION
Fixes valgrind tests failures in eamxx standalone tests.

---

I was able to fix our valgrind failures by doing a few mods. Namely:

- use pack size 1 in our valg build: avoids issues with `pow(UNINITED,exponent)`. The altearnative is to ensure the base is always inited, but there may be quite a few ramifications.
- set some defaults for `se_XYZ` namelist variables in HOMME before reading them, in case they are missing in the input namelist. Usually, they are missing if not used (e.g., no point in setting `se_ne` for DP runs, since `se_ne_x` and `se_ne_y` will be used), but valgrind doesn't know that. @oksanaguba I added you as a reviewer for the handful of lines in namelist mod, just in case.
- the valg test that ensures failures are detected was somewhat broken, due to compiler optimizations (I think the compiler was able to detect that the condition `i<10` was always going to be verified).

NOTE: this PR _does_ touch stuff outside of eamxx, so it will have to undergo nightly testing through next.