### PR TITLE
WIP: Fix an issue in EAMxx with incorrect metadata in rhist file

### DIFF
--- a/components/eamxx/src/share/io/scream_output_manager.cpp
+++ b/components/eamxx/src/share/io/scream_output_manager.cpp
@@ -494,9 +494,14 @@ void OutputManager::run(const util::TimeStamp& timestamp)
         if (filespecs.ftype==FileType::HistoryRestart) {
           // Update the date of last write and sample size
           write_timestamp (filespecs.filename,"last_write",m_output_control.last_write_ts,true);
-          scorpio::set_attribute (filespecs.filename,"GLOBAL","last_output_filename",m_output_file_specs.filename);
           scorpio::set_attribute (filespecs.filename,"GLOBAL","num_snapshots_since_last_write",m_output_control.nsamples_since_last_write);
-          scorpio::set_attribute (filespecs.filename,"GLOBAL","last_output_file_num_snaps",m_output_file_specs.storage.num_snapshots_in_file);
+	  if (m_output_file_specs.is_open) {
+              scorpio::set_attribute (filespecs.filename,"GLOBAL","last_output_file_num_snaps",m_output_file_specs.storage.num_snapshots_in_file);
+              scorpio::set_attribute (filespecs.filename,"GLOBAL","last_output_filename",m_output_file_specs.filename);
+	  } else {
+	      scorpio::set_attribute (filespecs.filename,"GLOBAL","last_output_file_num_snaps", std::numeric_limits<int>::max());
+              scorpio::set_attribute (filespecs.filename,"GLOBAL","last_output_filename","");
+	  }
         }
         // Write these in both output and rhist file. The former, b/c we need these info when we postprocess
         // output, and the latter b/c we want to make sure these params don't change across restarts


### PR DESCRIPTION
This commit fixes an issue during restarts that occurs with averaged type output.  The restart history file (rhist) metadata was incorrectly setup which could lead EAMxx to reopen files that already had the max number of snaps in them and continue to fill them at the restart step.

Fixes #6795