### PR TITLE
Add namelist vars for disabling P3 subgrid cldfrac in EAMxx

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -223,6 +223,10 @@ be lost if SCREAM_HACK_XML is not enabled.
       <deposition_nucleation_exponent type="real" doc="Deposition nucleation exponent factor">0.304</deposition_nucleation_exponent>
       <ice_sedimentation_factor type="real" doc="Ice sedimentation fall speed factor">1.0</ice_sedimentation_factor>
       <do_ice_production type="logical" doc="Flag to turn on ice production processes (loss processes unaffected)">true</do_ice_production>
+      <!-- flags to override subgrid coud fraction by setting them to 1 everywhere if true -->
+      <fix_cld_frac_r>false</fix_cld_frac_r>
+      <fix_cld_frac_i>false</fix_cld_frac_i>
+      <fix_cld_frac_l>false</fix_cld_frac_l>
     </p3>
 
     <!-- SHOC macrophysics -->

--- a/components/eamxx/src/physics/p3/eamxx_p3_run.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_run.cpp
@@ -15,6 +15,20 @@ void P3Microphysics::run_impl (const double dt)
   ); // Kokkos::parallel_for(p3_main_local_vals)
   Kokkos::fence();
 
+  // allow namelist flags to override sub-grid cloud fraction (set it to 1 everywhere)
+  if (m_params.get<bool>("fix_cld_frac_l", false)) {
+    auto& cld_frac_l = p3_preproc.cld_frac_l;
+    Kokkos::deep_copy(cld_frac_l,1.0);
+  }
+  if (m_params.get<bool>("fix_cld_frac_r", false)) {
+    auto& cld_frac_r = p3_preproc.cld_frac_r;
+    Kokkos::deep_copy(cld_frac_r,1.0);
+  }
+  if (m_params.get<bool>("fix_cld_frac_i", false)) {
+    auto& cld_frac_i = p3_preproc.cld_frac_i;
+    Kokkos::deep_copy(cld_frac_i,1.0);
+  }
+
   // Update the variables in the p3 input structures with local values.
 
   infrastructure.dt = dt;


### PR DESCRIPTION
These flags change the input P3 cloud fraction by setting them to 1 everywhere. Currently they default to False, but we will likely enable them as part of the effort to address the popcorn convection problem.

[BFB]