### PR TITLE
number of ghost layers needs to be set for bilinear maps

### DIFF
--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -203,7 +203,7 @@ contains
     use iMOAB, only: iMOAB_ComputeMeshIntersectionOnSphere, iMOAB_RegisterApplication, &
       iMOAB_WriteMesh, iMOAB_DefineTagStorage, iMOAB_ComputeCommGraph, iMOAB_ComputeScalarProjectionWeights, &
       iMOAB_MigrateMapMesh, iMOAB_WriteLocalMesh, iMOAB_GetMeshInfo, iMOAB_SetDoubleTagStorage, &
-      iMOAB_WriteMappingWeightsToFile
+      iMOAB_WriteMappingWeightsToFile, iMOAB_SetGhostLayers
     !---------------------------------------------------------------
     ! Description
     ! Initialize module attribute vectors and all other non-mapping
@@ -269,6 +269,7 @@ contains
     integer ent_type ! for setting tags
     integer noflds   ! used for number of fields in allocating moab accumulated array x2oacc_om
     real (kind=R8) , allocatable :: tmparray (:) ! used to set the r2x fields to 0
+    integer  nghlay ! used to set the number of ghost layers, needed for bilinear map
 
     !---------------------------------------------------------------
 
@@ -426,6 +427,13 @@ contains
             ! next, let us compute the ATM and OCN data transfer
             if (.not. samegrid_ao) then ! not a data OCN model
 
+               ! for bilinear maps, we need to have a layer of ghosts on source
+               nghlay = 1  ! number of ghost layers
+               ierr   = iMOAB_SetGhostLayers( mbaxid, nghlay )
+               if (ierr .ne. 0) then
+                  write(logunit,*) subname,' error in setting the number of layers'
+                  call shr_sys_abort(subname//' error in setting the number of layers')
+               endif
                ! first compute the overlap mesh between mbaxid (ATM) and mboxid (OCN) on coupler PEs
                ierr =  iMOAB_ComputeMeshIntersectionOnSphere (mbaxid, mboxid, mbintxao)
                if (ierr .ne. 0) then


### PR DESCRIPTION
number of ghost layers needs to be setup correctly for the bilinear maps;
different PE layouts should result in the same map.

[BFB]
