### PR TITLE
Workflows: test MMF in eamxx v1 workflow

### DIFF
--- a/.github/workflows/eamxx-v1-testing.yml
+++ b/.github/workflows/eamxx-v1-testing.yml
@@ -71,6 +71,8 @@ jobs:
             short_name: ERS_Ln22.ne4pg2_ne4pg2.F2010-SCREAMv1.scream-small_kernels--scream-output-preset-5
           - full_name: SMS_D_Ln5.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.ghci-snl-cpu_gnu.scream-mam4xx-all_mam4xx_procs
             short_name: SMS_D_Ln5.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.scream-mam4xx-all_mam4xx_procs
+          - full_name: SMS_Ln3_P4.ne4pg2_oQU480.F2010-MMF2.ghci-snl-cpu_gnu
+            short_name: SMS_Ln3_P4.ne4pg2_oQU480.F2010-MMF2
       fail-fast: false
     name: cpu-gcc / ${{ matrix.test.short_name }}
     steps:


### PR DESCRIPTION
Allows to verify that MMF tests (relying on scream physics) are not broken by EAMxx PRs.

FIxes #6766