### PR TITLE
remove the exact integration in cube_to_target to avoid negative weights

### DIFF
--- a/components/eam/tools/topo_tool/cube_to_target/remap.F90
+++ b/components/eam/tools/topo_tool/cube_to_target/remap.F90
@@ -850,7 +850,8 @@ MODULE remap
 
             if (xseg(1).EQ.xseg(2))then
               slope = bignum
-            else if (abs(yseg(1) -yseg(2))<fuzzy_width) then
+            !else if (abs(yseg(1) -yseg(2))<fuzzy_width) then !remove the exact integration
+            else if (.false.) then
               slope = 0.0
             else
               slope    = (yseg(2)-yseg(1))/(xseg(2)-xseg(1))
@@ -955,7 +956,8 @@ MODULE remap
 !    if (fuzzy(abs(xseg(1) -xseg(2)),fuzzy_width)==0)then
     if (xseg(1).EQ.xseg(2))then
       weights = 0.0D0
-    else if (abs(yseg(1) -yseg(2))<fuzzy_width) then
+    !else if (abs(yseg(1) -yseg(2))<fuzzy_width) then !remove the exact integration
+    else if (.false.) then
       !
       ! line segment parallel to latitude - compute weights exactly
       !

--- a/components/eam/tools/topo_tool/cube_to_target/remap.F90
+++ b/components/eam/tools/topo_tool/cube_to_target/remap.F90
@@ -850,7 +850,8 @@ MODULE remap
 
             if (xseg(1).EQ.xseg(2))then
               slope = bignum
-            !else if (abs(yseg(1) -yseg(2))<fuzzy_width) then !remove the exact integration
+            ! this will enable exact integration, which was found to create problematic negative weights
+            ! else if (abs(yseg(1) -yseg(2))<fuzzy_width) then
             else if (.false.) then
               slope = 0.0
             else
@@ -956,7 +957,8 @@ MODULE remap
 !    if (fuzzy(abs(xseg(1) -xseg(2)),fuzzy_width)==0)then
     if (xseg(1).EQ.xseg(2))then
       weights = 0.0D0
-    !else if (abs(yseg(1) -yseg(2))<fuzzy_width) then !remove the exact integration
+    ! this will enable exact integration, which was found to create problematic negative weights
+    ! else if (abs(yseg(1) -yseg(2))<fuzzy_width) then
     else if (.false.) then
       !
       ! line segment parallel to latitude - compute weights exactly


### PR DESCRIPTION
Fix the negative weights in cube_to_target.

In the experience of using the cube_to_target for regionally refined meshes, we encountered issues with large negative 
values for terr_target. This generally happened when the dx of the target mesh was comparable/smaller than the dx of the
 base cube.

Peter Lauritzen helped us to identify the underlying reasons for the negative weights and suggested a solution. 
The current practice is to keep the exact integration algorithm, but never enable it.
Since the original version of the judgement condition is rich in semantics, the original judgement was not deleted but 
annotated.

--------

```
In remamp.F90 change:
    else if (abs(yseg(1) -yseg(2))<fuzzy_width) then
to
    else if (.false.) then
```
