### PR TITLE
Fix issue with mpas-seaice restart_contents

### DIFF
--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -2106,7 +2106,6 @@
 			<var name="testArrayRestartability"/>
 			<var name="forcingGroupNames"/>
 			<var name="forcingGroupRestartTimes"/>
-			<var name="runningMeanRemovedIceRunoff" packages="pkgScaledDIB"/>
 		</stream>
 
 		<stream name="restart"
@@ -2120,6 +2119,7 @@
 			<var name="xtime"/>
 			<var name="simulationStartTime"/>
 			<stream name="restart_contents"/>
+			<var name="runningMeanRemovedIceRunoff" packages="pkgScaledDIB"/>
 		</stream>
 
 		<stream name="restart_ic"
@@ -2131,6 +2131,7 @@
 				immutable="true">
 			<stream name="mesh"/>
 			<stream name="restart_contents"/>
+			<var name="runningMeanRemovedIceRunoff" packages="pkgScaledDIB"/>
 		</stream>
 
 		<stream name="output"


### PR DESCRIPTION
A new field runningMeanRemovedIceRunoff was added in PR #6696 that causes errors in some configurations on pm-cpu and frontier with the gnu compiler. This moves the new field from a shared "meta-stream" to the streams themselves because attached package wasn't getting inherited correctly.

Fixes #6855 
[BFB]