### PR TITLE
Adds fice initialization to conv_water_init

### DIFF
--- a/components/eam/src/physics/cam/conv_water.F90
+++ b/components/eam/src/physics/cam/conv_water.F90
@@ -72,20 +72,23 @@ module conv_water
   !                                                                             !
   !============================================================================ !
 
-   subroutine conv_water_init()
+   subroutine conv_water_init(pbuf2d)
    ! --------------------------------------------------------------------- ! 
    ! Purpose:                                                              !
    !   Initializes the pbuf indices required by conv_water
    ! --------------------------------------------------------------------- ! 
 
    
-   use physics_buffer, only : pbuf_get_index
+   use physics_buffer, only : physics_buffer_desc, pbuf_get_index, pbuf_set_field
    use cam_history,    only : addfld
    use phys_control,   only : phys_getopts
 
    use constituents,  only: cnst_get_ind
 
    implicit none
+
+   type(physics_buffer_desc), pointer :: pbuf2d(:,:)
+
    logical :: use_MMF
 
    call phys_getopts(use_MMF_out = use_MMF)
@@ -101,6 +104,8 @@ module conv_water
    dp_frac_idx  = pbuf_get_index('DP_FRAC')
    ast_idx      = pbuf_get_index('AST')
    rei_idx      = pbuf_get_index('REI')
+
+   call pbuf_set_field(pbuf2d, fice_idx, 0.0_r8)
 
    ! Convective cloud water variables.
    call addfld ('ICIMRCU', (/ 'lev' /), 'A', 'kg/kg', 'Convection in-cloud ice mixing ratio '                   )

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -964,7 +964,7 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
        if (.not. do_clubb_sgs .and. .not. do_shoc_sgs) call macrop_driver_init(pbuf2d)
        call microp_aero_init()
        call microp_driver_init(pbuf2d)
-       call conv_water_init
+       call conv_water_init(pbuf2d)
     end if
 
     ! initiate CLUBB within CAM

--- a/components/eam/src/physics/crm/physpkg.F90
+++ b/components/eam/src/physics/crm/physpkg.F90
@@ -660,7 +660,7 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
   call nucleate_ice_cam_init(mincld, bulk_scale)
   call hetfrz_classnuc_cam_init(mincld)
 
-  call conv_water_init
+  call conv_water_init(pbuf2d)
 
   call crm_physics_init(phys_state, pbuf2d, species_class)
 


### PR DESCRIPTION
Add initialization of the "fice" pbuf variable within conv_water_init to avoid debug mode failure when shr_infnan_isnan is called. 

Fixes #6179.

[BFB]