### PR TITLE
Add Initial Condition Handling to EAMxx DAG Generator

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -685,6 +685,21 @@ void AtmosphereDriver::create_fields()
     fm->add_to_group(fid.name(),"RESTART");
   }
 
+  auto& driver_options_pl = m_atm_params.sublist("driver_options");
+  const int verb_lvl = driver_options_pl.get<int>("atmosphere_dag_verbosity_level",-1);
+  if (verb_lvl>0) {
+    // now that we've got fields, generate a DAG with fields and dependencies
+    // NOTE: at this point, fields provided by initial conditions may (will)
+    // appear as unmet dependencies
+    AtmProcDAG dag;
+    // First, add all atm processes
+    dag.create_dag(*m_atm_process_group);
+    // Write a dot file for visualization
+    if (m_atm_comm.am_i_root()) {
+      dag.write_dag("scream_atm_createField_dag.dot", std::max(verb_lvl,0));
+    }
+  }
+
   m_ad_status |= s_fields_created;
 
   // If the user requested it, we can save a dictionary of the FM fields to file
@@ -900,28 +915,6 @@ initialize_fields ()
   // See the [rrtmgp active gases] note in share/util/eamxx_fv_phys_rrtmgp_active_gases_workaround.hpp
   if (fvphyshack) {
     TraceGasesWorkaround::singleton().run_type = m_run_type;
-  }
-
-  // See if we need to print a DAG. We do this first, cause if any input
-  // field is missing from the initial condition file, an error will be thrown.
-  // By printing the DAG first, we give the user the possibility of seeing
-  // what fields are inputs to the atm time step, so he/she can fix the i.c. file.
-  // TODO: would be nice to do the IC input first, and mark the fields in the
-  //       DAG node "Begin of atm time step" in red if there's no initialization
-  //       mechanism set for them. That is, allow field XYZ to not be found in
-  //       the IC file, and throw an error when the dag is created.
-
-  auto& driver_options_pl = m_atm_params.sublist("driver_options");
-  const int verb_lvl = driver_options_pl.get<int>("atmosphere_dag_verbosity_level",-1);
-  if (verb_lvl>0) {
-    // Check the atm DAG for missing stuff
-    AtmProcDAG dag;
-
-    // First, add all atm processes
-    dag.create_dag(*m_atm_process_group);
-
-    // Write a dot file for visualization
-    dag.write_dag("scream_atm_dag.dot",std::max(verb_lvl,0));
   }
 
   // Initialize fields
@@ -1146,7 +1139,7 @@ void AtmosphereDriver::set_initial_conditions ()
                    grid_name == "Point Grid") {
           this_grid_topo_file_fnames.push_back("PHIS_d");
           this_grid_topo_eamxx_fnames.push_back(fname);
-          fields_inited[grid_name].push_back(fname);
+          m_fields_inited[grid_name].push_back(fname);
         } else {
           EKAT_ERROR_MSG ("Error! Requesting phis on an unknown grid: " + grid_name + ".\n");
         }
@@ -1158,7 +1151,7 @@ void AtmosphereDriver::set_initial_conditions ()
                         " topo file only has sgh30 for Physics PG2.\n");
         topography_file_fields_names[grid_name].push_back("SGH30");
         topography_eamxx_fields_names[grid_name].push_back(fname);
-	fields_inited[grid_name].push_back(fname);
+        m_fields_inited[grid_name].push_back(fname);
       }
     } else if (not (fvphyshack and grid_name == "Physics PG2")) {
       // The IC file is written for the GLL grid, so we only load
@@ -1170,7 +1163,7 @@ void AtmosphereDriver::set_initial_conditions ()
         // If this field is the parent of other subfields, we only read from file the subfields.
         if (not ekat::contains(this_grid_ic_fnames,fname)) {
           this_grid_ic_fnames.push_back(fname);
-	  fields_inited[grid_name].push_back(fname);
+          m_fields_inited[grid_name].push_back(fname);
         }
       } else if (fvphyshack and grid_name == "Physics GLL") {
         // [CGLL ICs in pg2] I tried doing something like this in
@@ -1187,7 +1180,7 @@ void AtmosphereDriver::set_initial_conditions ()
           } else {
             this_grid_ic_fnames.push_back(fname);
           }
-	  fields_inited[grid_name].push_back(fname);
+          m_fields_inited[grid_name].push_back(fname);
         }
       }
     }
@@ -1655,6 +1648,23 @@ void AtmosphereDriver::initialize_atm_procs ()
   m_atm_logger->info("[EAMxx] initialize_atm_procs ... done!");
 
   report_res_dep_memory_footprint ();
+
+  auto& driver_options_pl = m_atm_params.sublist("driver_options");
+  const int verb_lvl = driver_options_pl.get<int>("atmosphere_dag_verbosity_level",-1);
+  if (verb_lvl>0) {
+    // now that we've got fields, generate a DAG with fields and dependencies
+    // NOTE: at this point, fields provided by initial conditions may (will)
+    // appear as unmet dependencies
+    AtmProcDAG dag;
+    // First, add all atm processes
+    dag.create_dag(*m_atm_process_group);
+    // process the initial conditions to maybe fulfill unmet dependencies
+    dag.process_initial_conditions(m_fields_inited);
+    // Write a dot file for visualization
+    if (m_atm_comm.am_i_root()) {
+      dag.write_dag("scream_atm_initProc_dag.dot", std::max(verb_lvl,0));
+    }
+  }
 }
 
 void AtmosphereDriver::

--- a/components/eamxx/src/control/atmosphere_driver.hpp
+++ b/components/eamxx/src/control/atmosphere_driver.hpp
@@ -264,6 +264,8 @@ protected:
 
   // Current simulation casename
   std::string m_casename;
+  // maps grid name to a vector of its initialized fields
+  std::map<std::string, std::vector<std::string>> m_fields_inited;
 };
 
 }  // namespace control

--- a/components/eamxx/src/share/atm_process/atmosphere_process_dag.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_dag.cpp
@@ -171,64 +171,117 @@ void AtmProcDAG::write_dag (const std::string& fname, const int verbosity) const
   ofile.open (fname.c_str());
 
   ofile << "strict digraph G {\n"
-        << "rankdir=\"LR\"";
+        << "rankdir=\"LR\"\n";
 
+  bool has_IC_field = false;
   for (const auto& n : m_nodes) {
     const auto& unmet = m_unmet_deps.at(n.id);
+
+    std::string box_fmt;
+    int id_IC = -1;
+    int id_begin = -1;
+    int id_end = -1;
+    if (n.name == "Begin of atm time step") {
+      id_begin = n.id;
+      box_fmt = "  color=\"#00667E\"\n  fontcolor=\"#00667E\"\n  style=filled\n"
+                "  fillcolor=\"#b9d4dc\"\n";
+    } else if (n.name == "Initial Conditions") {
+      id_IC = n.id;
+      box_fmt = "  color=\"#006219\"\n  fontcolor=\"#006219\"\n  style=filled\n"
+                "  fillcolor=\"#b9dcc2\"\n";
+    } else if (n.name == "End of atm time step") {
+      id_end = n.id;
+      box_fmt = "  color=\"#88621e\"\n  fontcolor=\"#88621e\"\n  style=filled\n"
+                "  fillcolor=\"#dccfb9\"\n";
+    }
 
     // Write node, with computed/required fields
     ofile << n.id
           << " [\n"
           << "  shape=box\n"
+          << box_fmt
+          << "  penwidth=4\n"
+          << "  fontsize=30\n"
           << "  label=<\n"
           << "    <table border=\"0\">\n"
-          << "      <tr><td><b>" << html_fix(n.name) << "</b></td></tr>";
-    if (verbosity>1) {
+          << "      <tr><td><b><font point-size=\"40\">" << html_fix(n.name)
+          << "</font></b></td></tr>\n";
+
+    int sz_comp = n.computed.size(), sz_req = n.required.size(),
+        sz_grcomp = n.gr_computed.size(), sz_grreq = n.gr_required.size();
+    int nfield = sz_comp + sz_req + sz_grcomp + sz_grreq;
+    if (verbosity > 1 && nfield > 0) {
       // FieldIntentifier prints bare min with verb 0.
       // DAG starts printing fids with verb 2, so fid verb is verb-2;
       int fid_verb = verbosity-2;
-      ofile << "<hr/>\n";
+      ofile << "      <hr/>\n";
 
-      // Computed fields
-      if (n.name=="Begin of atm time step") {
-        ofile << "      <tr><td align=\"left\"><font color=\"blue\">Atm input fields from previous time step:</font></td></tr>\n";
-      } else if (n.name!="End of atm time step"){
-        ofile << "      <tr><td align=\"left\"><font color=\"blue\">Computed Fields:</font></td></tr>\n";
-      }
-      for (const auto& fid : n.computed) {
-        std::string fc = "<font color=\"";
-        fc += "black";
-        fc += "\">  ";
-        ofile << "      <tr><td align=\"left\">" << fc << html_fix(print_fid(m_fids[fid],fid_verb)) << "</font></td></tr>\n";
-      }
-
-      // Required fields
-      if (n.name=="End of atm time step") {
-        ofile << "      <tr><td align=\"left\"><font color=\"blue\">Atm output fields for next time step:</font></td></tr>\n";
-      } else if (n.name!="Begin of atm time step") {
-        ofile << "      <tr><td align=\"left\"><font color=\"blue\">Required Fields:</font></td></tr>\n";
-      }
-      for (const auto& fid : n.required) {
-        std::string fc = "<font color=\"";
-        fc += (ekat::contains(unmet,fid) ? "red" : "black");
-        fc += "\">  ";
-        ofile << "      <tr><td align=\"left\">" << fc << html_fix(print_fid(m_fids[fid],fid_verb));
-        if (ekat::contains(m_unmet_deps.at(n.id),fid)) {
-          ofile << "<b>  *** MISSING ***</b>";
+      if (sz_comp > 0) {
+        // Computed fields
+        if (n.id == id_begin) {
+          ofile << "      <tr><td align=\"left\"><b><font color=\"#00667E\">"
+                << "Atm input fields from previous time step:</font></b></td></tr>\n";
+        } else if (n.id == id_IC) {
+          ofile << "      <tr><td align=\"left\"><b><font color=\"#00667E\">"
+                << "Initial Fields:</font></b></td></tr>\n";
+        } else if (n.id != id_end) {
+          ofile << "      <tr><td align=\"left\"><b><font color=\"#88621e\">"
+                << "Computed Fields:</font></b></td></tr>\n";
         }
-        ofile << "</font></td></tr>\n";
+
+        for (const auto& fid : n.computed) {
+          std::string fc = "<font color=\"";
+          fc += "black";
+          fc += "\">  ";
+          ofile << "      <tr><td align=\"left\">" << fc
+                << html_fix(print_fid(m_fids[fid],fid_verb))
+                << "</font></td></tr>\n";
+        }
+      }
+
+      if (sz_req > 0) {
+        // Required fields
+        if (n.id == id_end) {
+          ofile << "      <tr><td align=\"left\"><b><font color=\"#88621e\">"
+                << "Atm output fields for next time step:</font></b></td></tr>\n";
+        } else if (n.id != id_begin && n.id != id_IC) {
+          ofile << "      <tr><td align=\"left\"><b><font color=\"#00667E\">"
+                << "Required Fields:</font></b></td></tr>\n";
+        }
+        for (const auto& fid : n.required) {
+          std::string fc = "<font color=\"";
+          if (ekat::contains(unmet, fid)) {
+            fc += "red";
+          } else if (ekat::contains(unmet, -fid)) {
+            fc +=  "#006219";
+          } else {
+            fc += "black";
+          }
+          fc += "\">  ";
+          ofile << "      <tr><td align=\"left\">" << fc << html_fix(print_fid(m_fids[fid],fid_verb));
+          if (ekat::contains(unmet, fid)) {
+            ofile << "<b>  *** MISSING ***</b>";
+          } else if (ekat::contains(unmet, -fid)) {
+            ofile << "<b>  (Init. Cond.)</b>";
+            has_IC_field = true;
+          }
+          ofile << "</font></td></tr>\n";
+        }
       }
 
       // Computed groups
-      if (n.gr_computed.size()>0) {
-        if (n.name=="Begin of atm time step") {
-          ofile << "      <tr><td align=\"left\"><font color=\"blue\">Atm Input groups:</font></td></tr>\n";
-        } else if (n.name!="End of atm time step"){
-          ofile << "      <tr><td align=\"left\"><font color=\"blue\">Computed Groups:</font></td></tr>\n";
+      if (sz_grcomp > 0) {
+        if (n.id == id_begin) {
+          ofile << "      <tr><td align=\"left\"><b><font color=\"#00667E\">Atm Input groups:</font></b></td></tr>\n";
+        } else if (n.id != id_end){
+          ofile << "      <tr><td align=\"left\"><b><font color=\"#88621e\">Computed Groups:</font></b></td></tr>\n";
         }
         for (const auto& gr_fid : n.gr_computed) {
           std::string fc = "<font color=\"";
-          fc += (ekat::contains(unmet,gr_fid) ? "red" : "black");
+          fc += "black";
+          // i suspect this, and the below, is a typo, since a computed group
+          // being marked unmet doesn't make sense to me
+          // fc += (ekat::contains(unmet,gr_fid) ? "red" : "black");
           fc += "\">  ";
           ofile << "      <tr><td align=\"left\">" << fc << html_fix(print_fid(m_fids[gr_fid],fid_verb));
           ofile << "</font></td></tr>\n";
@@ -242,10 +295,8 @@ void AtmProcDAG::write_dag (const std::string& fname, const int verbosity) const
             size_t i = 0;
             for (const auto& fn : members_names) {
               const auto f = members.at(fn);
-              const auto& mfid = f->get_header().get_identifier();
-              const auto mfid_id = get_fid_index(mfid);
               std::string mfc = "<font color=\"";
-              mfc += (ekat::contains(unmet,mfid_id) ? "red" : "black");
+              mfc += "black";
               mfc += "\">";
               if (len>0) {
                 ofile << ",";
@@ -269,18 +320,18 @@ void AtmProcDAG::write_dag (const std::string& fname, const int verbosity) const
       }
 
       // Required groups
-      if (n.gr_required.size()>0) {
+      if (sz_grreq > 0) {
         if (n.name=="End of atm time step") {
-          ofile << "      <tr><td align=\"left\"><font color=\"blue\">Atm Output Groups:</font></td></tr>\n";
+          ofile << "      <tr><td align=\"left\"><b><font color=\"#00667E\">Atm Output Groups:</font></b></td></tr>\n";
         } else if (n.name!="Begin of atm time step") {
-          ofile << "      <tr><td align=\"left\"><font color=\"blue\">Required Groups:</font></td></tr>\n";
+          ofile << "      <tr><td align=\"left\"><b><font color=\"#00667E\">Required Groups:</font></b></td></tr>\n";
         }
         for (const auto& gr_fid : n.gr_required) {
           std::string fc = "<font color=\"";
           fc += (ekat::contains(unmet,gr_fid) ? "red" : "black");
           fc += "\">  ";
           ofile << "      <tr><td align=\"left\">" << fc << html_fix(print_fid(m_fids[gr_fid],fid_verb));
-          if (ekat::contains(m_unmet_deps.at(n.id),gr_fid)) {
+          if (ekat::contains(unmet, gr_fid)) {
             ofile << "<b>  *** MISSING ***</b>";
           }
           ofile << "</font></td></tr>\n";
@@ -327,8 +378,43 @@ void AtmProcDAG::write_dag (const std::string& fname, const int verbosity) const
 
     // Write all outgoing edges
     for (const auto c : n.children) {
-      ofile << n.id << "->" << c << "\n";
+      ofile << n.id << "->" << c << "[penwidth=4];\n";
     }
+  }
+
+  if (!m_IC_processed && m_has_unmet_deps) {
+    int this_node_id = m_nodes.size() + 1;
+    ofile << this_node_id << " [\n"
+          << "  shape=box\n"
+          << "  color=\"#605d57\"\n"
+          << "  fontcolor=\"#034a4a\"\n"
+          << "  penwidth=8\n"
+          << "  fontsize=40\n"
+          << "  style=filled\n"
+          << "  fillcolor=\"#999999\"\n"
+          << "  align=\"center\"\n"
+          << "  label=<<b><font color=\"#774006\">NOTE:</font> "
+             "Fields marked missing may be<br align=\"center\"/>provided by "
+             "the as-yet-unprocessed<br align=\"center\"/>initial condition</b>>\n"
+          << "];\n";
+  }
+
+  if (m_IC_processed && has_IC_field) {
+    int this_node_id = m_nodes.size() + 1;
+    ofile << this_node_id << " [\n"
+          << "  shape=box\n"
+          << "  color=\"#605d57\"\n"
+          << "  fontcolor=\"#031576\"\n"
+          << "  penwidth=8\n"
+          << "  fontsize=40\n"
+          << "  style=filled\n"
+          << "  fillcolor=\"#cccccc\"\n"
+          << "  align=\"center\"\n"
+          << "  label=<<b><font color=\"#3d2906\">NOTE:</font> Fields denoted "
+             "with <font color=\"#006219\"><b>green text</b></font> "
+             "<br align=\"center\"/>indicate the field was provided by the "
+             "<br align=\"center\"/>initial conditions and never updated</b>>\n"
+          << "];\n";
   }
 
   // Close the file
@@ -341,6 +427,7 @@ void AtmProcDAG::cleanup () {
   m_fid_to_last_provider.clear();
   m_unmet_deps.clear();
   m_has_unmet_deps = false;
+  m_IC_processed = false;
 }
 
 void AtmProcDAG::
@@ -364,10 +451,9 @@ add_nodes (const group_type& atm_procs)
       add_nodes(*group);
     } else {
       // Create a node for the process
-      // Node& node = m_nodes[proc->name()];
       int id = m_nodes.size();
       m_nodes.push_back(Node());
-      Node& node = m_nodes.back();;
+      Node& node = m_nodes.back();
       node.id = id;
       node.name = proc->name();
       m_unmet_deps[id].clear(); // Ensures an entry for this id is in the map
@@ -505,6 +591,60 @@ void AtmProcDAG::add_edges () {
       }
     }
   }
+}
+
+void AtmProcDAG::process_initial_conditions(const grid_field_map &ic_inited) {
+  // First, add the fields that were determined to come from the previous time
+  // step => IC for t = 0
+  // get the begin_node since the IC is identical at first
+  const Node &begin_node = m_nodes[m_nodes.size() - 2];
+  int id = m_nodes.size();
+  // Create a node for the ICs by copying the begin_node
+  m_nodes.push_back(Node(begin_node));
+  Node& ic_node = m_nodes.back();
+  // now set/clear the basic data for the ic_node
+  ic_node.id = id;
+  ic_node.name = "Initial Conditions";
+  m_unmet_deps[id].clear();
+  ic_node.children.clear();
+  // now add the begin_node as a child of the ic_node
+  ic_node.children.push_back(begin_node.id);
+  // return if there's nothing to process in the ic_inited vector
+  if (ic_inited.size() == 0) {
+    return;
+  }
+  for (auto &node : m_nodes) {
+    if (m_unmet_deps.at(node.id).empty()) {
+      continue;
+    } else {
+      // NOTE: node_unmet_fields is a std::set<int>
+      auto &node_unmet_fields = m_unmet_deps.at(node.id);
+      // add the current node as a child of the IC node
+      ic_node.children.push_back(node.id);
+      for (auto um_fid : node_unmet_fields) {
+        for (auto &it1 : ic_inited) {
+          const auto &grid_name = it1.first;
+          // if this unmet-dependency field's name is in the ic_inited map for
+          // the provided grid_name key, then we flip its value negative and
+          // break from the for (ic_inited) and for (node_unmet_fields) loops;
+          // otherwise, keep trying for the next grid_name
+          if (ekat::contains(ic_inited.at(grid_name), m_fids[um_fid].name())) {
+            auto id_now_met = node_unmet_fields.extract(um_fid);
+            id_now_met.value() = -id_now_met.value();
+            node_unmet_fields.insert(std::move(id_now_met));
+            // add the fid of the formerly unmet dep to the initial condition
+            // node's computed list
+            ic_node.computed.insert(um_fid);
+            goto endloop;
+          } else {
+            continue;
+          }
+        }
+      endloop:;
+      }
+    }
+  }
+  m_IC_processed = true;
 }
 
 int AtmProcDAG::add_fid (const FieldIdentifier& fid) {

--- a/components/eamxx/src/share/atm_process/atmosphere_process_dag.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_dag.hpp
@@ -16,6 +16,11 @@ public:
 
   void create_dag (const group_type& atm_procs);
 
+  using grid_field_map = std::map<std::string,std::vector<std::string>>;
+  void process_initial_conditions(const grid_field_map &ic_inited);
+
+  void init_atm_proc_nodes(const group_type& atm_procs);
+
   void add_surface_coupling (const std::set<FieldIdentifier>& imports,
                              const std::set<FieldIdentifier>& exports);
 
@@ -66,6 +71,7 @@ protected:
   // Map a node id to a set of unmet field dependencies
   std::map<int,std::set<int>>     m_unmet_deps;
   bool                            m_has_unmet_deps;
+  bool                            m_IC_processed;
 
   // The nodes in the atm DAG
   std::vector<Node>               m_nodes;


### PR DESCRIPTION
Finishes PR [#3101](https://github.com/E3SM-Project/scream/pull/3101) originally submitted to the scream repo the atmospheric DAG generator (atmosphere_process_dag.xpp) and atmosphere driver to get things working again. Namely,

There are now 2 checkpoints during AtmosphereDriver::initialize() at which we build the most complete DAG available and write it to file.
This is intended to serve as a diagnostic tool in case a build crashes, giving the user information about the created/initialized processes or fields.
These checkpoints occur at the end of the following functions, and the associated DAG is written out to a .dot file in the run directory:
  1. create_fields()--scream_atm_createField_dag.dot
  2. initialize_atm_procs()--scream_atm_initProc_dag.dot

I've added some code that enables the DAG to properly handle initial conditions and determine whether they are missing at the time when he DAG is generated, and if so this is indicated in the corresponding node (see images in [original PR](https://github.com/E3SM-Project/scream/pull/3101) for examples).
In the initial DAG, (within initialize_atm_procs()), an extra box is added to the DAG with a disclaimer that any fields indicated as missing may be provided by the forthcoming initial condition file.
A node for the Initial Condition is now displayed on the DAG with edges leading to the "Begin of Atm Time Step" node adn any nodes for a process that uses and does not change a field from the initial condition.
I've made some minor formatting changes for readability and to more clearly indicate the different types of objects represented on the DAG--e.g., the Begin/End of Atm. Timestep nodes are colored differently, and fields are printed in green when provided directly by the initial condition at initialization.
I've also fenced-off the write_dag() statements to ensure they are only printed by the main MPI thread, since I noticed occasional formatting errors due to a presumptive race condition.
Additionally, when running as an eamxx standalone test, the filenames of the DAGs are tagged with `.np<N>` to avoid conflicts writing to file.
Lastly, I added a `RESOURCE_LOCK` to the standalone test `mam4_srf_online_emiss_mam4_constituent_fluxes` that appeared to be failing due to incorrect order of running the tests being compared.

**Note:** Closes [E3SM/scream Issue #1869](https://github.com/E3SM-Project/scream/issues/1869).