### PR TITLE
Add del2 and del4 terms to manufactured solution test

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_manufactured_solution.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_manufactured_solution.F
@@ -205,13 +205,13 @@ contains
             if (.not. config_disable_vel_hmix) then
                if (config_use_mom_del2) then 
                   viscDel2 = config_mom_del2
-                  u = u + viscDel2 * eta0 * kx**2 * cos(phase)
-                  v = v + viscDel2 * eta0 * ky**2 * cos(phase)
+                  u = u + viscDel2 * eta0 * (kx**2 + ky**2) * cos(phase)
+                  v = v + viscDel2 * eta0 * (kx**2 + ky**2) * cos(phase)
                endif
                if (config_use_mom_del4) then 
                   viscDel4 = config_mom_del4
-                  u = u - viscDel4 * eta0 * (kx**4 * cos(phase) + kx**2 * ky**2 * cos(phase))
-                  v = v - viscDel4 * eta0 * (ky**4 * cos(phase) + kx**2 * ky**2 * cos(phase))
+                  u = u - viscDel4 * eta0 * ((kx**4 + ky**4 + kx**2 * ky**2) * cos(phase))
+                  v = v - viscDel4 * eta0 * ((kx**4 + ky**4 + kx**2 * ky**2) * cos(phase))
                endif
             endif
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_manufactured_solution.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_manufactured_solution.F
@@ -58,6 +58,7 @@ module ocn_manufactured_solution
    real (kind=RKIND) :: kx, ky
    real (kind=RKIND) :: ang_freq
    real (kind=RKIND) :: eta0
+   real (kind=RKIND) :: viscDel2, viscDel4
    real (kind=RKIND) :: H0
 
 !***********************************************************************
@@ -200,6 +201,19 @@ contains
             v = eta0*((fEdge(iEdge) + gravity*ky)*cos(phase) &
                       + ang_freq*sin(phase) &
                       - 0.5_RKIND*eta0*(kx + ky)*sin(2.0_RKIND*(phase))) 
+
+            if (.not. config_disable_vel_hmix) then
+               if (config_use_mom_del2) then 
+                  viscDel2 = config_mom_del2
+                  u = u + viscDel2 * eta0 * kx**2 * cos(phase)
+                  v = v + viscDel2 * eta0 * ky**2 * cos(phase)
+               endif
+               if (config_use_mom_del4) then 
+                  viscDel4 = config_mom_del4
+                  u = u - viscDel4 * eta0 * (kx**4 * cos(phase) + kx**2 * ky**2 * cos(phase))
+                  v = v - viscDel4 * eta0 * (ky**4 * cos(phase) + kx**2 * ky**2 * cos(phase))
+               endif
+            endif
 
             tend(k,iEdge) = tend(k,iEdge) + u*cos(angleEdge(iEdge)) + v*sin(angleEdge(iEdge))
          enddo

--- a/components/mpas-ocean/src/shared/mpas_ocn_manufactured_solution.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_manufactured_solution.F
@@ -204,12 +204,10 @@ contains
 
             if (.not. config_disable_vel_hmix) then
                if (config_use_mom_del2) then 
-                  viscDel2 = config_mom_del2
                   u = u + viscDel2 * eta0 * (kx**2 + ky**2) * cos(phase)
                   v = v + viscDel2 * eta0 * (kx**2 + ky**2) * cos(phase)
                endif
                if (config_use_mom_del4) then 
-                  viscDel4 = config_mom_del4
                   u = u - viscDel4 * eta0 * ((kx**4 + ky**4 + kx**2 * ky**2) * cos(phase))
                   v = v - viscDel4 * eta0 * ((kx**4 + ky**4 + kx**2 * ky**2) * cos(phase))
                endif
@@ -248,6 +246,9 @@ contains
       real (kind=RKIND), dimension(:,:), pointer :: restingThickness
 
       if (.not. config_use_manufactured_solution) return
+
+      viscDel2 = config_mom_del2
+      viscDel4 = config_mom_del4
 
       kx = 2.0_RKIND*pi / config_manufactured_solution_wavelength_x
       ky = 2.0_RKIND*pi / config_manufactured_solution_wavelength_y


### PR DESCRIPTION
This feature is used only for MPAS-Ocean standalone testing of the horizontal mixing operators del2 and del4. It is an extension of the existing manufactured solution test case. When either or both of del2 and del4 momentum terms are included in the dynamics, we add the corresponding source terms to the manufactured solution at runtime.

[BFB]