### PR TITLE
DOCS: only run docs when docs are touched

### DIFF
--- a/.github/workflows/e3sm-gh-pages.yml
+++ b/.github/workflows/e3sm-gh-pages.yml
@@ -4,9 +4,27 @@ on:
   # Runs every time master branch is updated
   push:
     branches: ["master"]
+    # But only if docs-related files are touched
+    paths:
+      - .github/workflows/e3sm-gh-pages.yml
+      - ./mkdocs.yml
+      - ./tools/*/mkdocs.yml
+      - ./tools/docs/**
+      - components/*/mkdocs.yaml
+      - components/*/docs/**
+      - components/eamxx/cime_config/namelist_defaults_scream.xml
   # Runs every time a PR is open against master
   pull_request:
     branches: ["master"]
+    # But only if docs-related files are touched
+    paths:
+      - .github/workflows/e3sm-gh-pages.yml
+      - ./mkdocs.yml
+      - ./tools/*/mkdocs.yml
+      - ./tools/docs/**
+      - components/*/mkdocs.yaml
+      - components/*/docs/**
+      - components/eamxx/cime_config/namelist_defaults_scream.xml
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Only run docs workflows when docs are touched. This reduces the comments by the GitHub-actions [bot] on PRs.

[BFB]
