### PR TITLE
Fix potential uninitialised variable bug in E3SM buildlib files.

### DIFF
--- a/share/build/buildlib.mct
+++ b/share/build/buildlib.mct
@@ -101,6 +101,8 @@ def buildlib(bldroot, installpath, case):
         netcdf_args = f"NETCDF_PATH={os.environ['NETCDF_PATH']} "
     elif "NETCDF_C_PATH" in os.environ:
         netcdf_args = f"NETCDF_PATH={os.environ['NETCDF_C_PATH']} "
+    else:
+        netcdf_args = f" "
 
     config_cmd = f"{mct_path}/configure CC={cc} FC={fc} MPICC={mcc} MPIFC={mfc} FCFLAGS='{fflags}' CPPDEFS='{cppdefs}' CFLAGS='{cflags}' LDFLAGS='{ldflags}' {config_args} {netcdf_args} --srcdir {mct_path}"
 

--- a/share/build/buildlib.mpi-serial
+++ b/share/build/buildlib.mpi-serial
@@ -77,6 +77,8 @@ def buildlib(bldroot, installpath, case):
         netcdf_args = f"NETCDF_PATH={os.environ['NETCDF_PATH']} "
     elif "NETCDF_C_PATH" in os.environ:
         netcdf_args = f"NETCDF_PATH={os.environ['NETCDF_C_PATH']} "
+    else:
+        netcdf_args = f" "
 
     config_cmd = f"{mpi_serial_path}/configure CC={cc} FC={fc} FCFLAGS='{fflags}' CPPDEFS='{cppdefs}' CFLAGS='{cflags}' LDFLAGS='{ldflags}' {config_args} {netcdf_args} --srcdir {mpi_serial_path}"
 


### PR DESCRIPTION
Add an else clause to two blocks in buildlib that are missing one.

[BFB]

-------

At least with my computer, the compilation was issuing an "uninitialised risk" error. My understanding is that this risk occurs because variable `netcdf_args` was defined inside an `if`/`elif` block that had no `else`. My edits define a dummy value for `netcdf_args` that is empty for the `else` case.
