### PR TITLE
Bug fix for changing orodrag tuning parameters via namelist

### DIFF
--- a/components/eam/src/control/runtime_opts.F90
+++ b/components/eam/src/control/runtime_opts.F90
@@ -246,6 +246,7 @@ contains
    use uwshcu,              only: uwshcu_readnl
    use pkg_cld_sediment,    only: cld_sediment_readnl
    use gw_drag,             only: gw_drag_readnl
+   use od_common,           only: oro_drag_readnl
    use qbo,                 only: qbo_readnl
    use iondrag,             only: iondrag_readnl
    use phys_debug_util,     only: phys_debug_readnl
@@ -516,6 +517,7 @@ contains
    call uwshcu_readnl(nlfilename)
    call cld_sediment_readnl(nlfilename)
    call gw_drag_readnl(nlfilename)
+   call oro_drag_readnl(nlfilename)
    call qbo_readnl(nlfilename)
    call iondrag_readnl(nlfilename)
    call phys_debug_readnl(nlfilename)

--- a/components/eam/src/physics/cam/clubb_intr.F90
+++ b/components/eam/src/physics/cam/clubb_intr.F90
@@ -20,7 +20,8 @@ module clubb_intr
   use shr_kind_mod,  only: r8=>shr_kind_r8
   use shr_log_mod ,  only: errMsg => shr_log_errMsg
   use ppgrid,        only: pver, pverp
-  use phys_control,  only: phys_getopts, use_od_ss, use_od_fd, od_ls_ncleff, od_bl_ncd, od_ss_sncleff
+  use phys_control,  only: phys_getopts, use_od_ss, use_od_fd
+  use od_common,     only: od_ls_ncleff, od_bl_ncd, od_ss_sncleff
   use physconst,     only: rair, cpair, gravit, latvap, latice, zvir, rh2o, karman, &
                            tms_orocnst, tms_z0fac, pi
   use cam_logfile,   only: iulog

--- a/components/eam/src/physics/cam/gw_drag.F90
+++ b/components/eam/src/physics/cam/gw_drag.F90
@@ -38,7 +38,8 @@ module gw_drag
 
   ! These are the actual switches for different gravity wave sources.
   ! The orographic control switches are also here
-  use phys_control,  only: use_gw_oro, use_gw_front, use_gw_convect, use_gw_energy_fix, use_od_ls, use_od_bl, use_od_ss, od_ls_ncleff, od_bl_ncd, od_ss_sncleff
+  use phys_control,  only: use_gw_oro, use_gw_front, use_gw_convect, use_gw_energy_fix, use_od_ls, use_od_bl, use_od_ss
+  use od_common,     only: od_ls_ncleff, od_bl_ncd, od_ss_sncleff
 
 ! Typical module header
   implicit none

--- a/components/eam/src/physics/cam/phys_control.F90
+++ b/components/eam/src/physics/cam/phys_control.F90
@@ -182,9 +182,6 @@ logical, public, protected :: use_od_ls = .false.
 logical, public, protected :: use_od_bl = .false.
 logical, public, protected :: use_od_ss = .false.
 logical, public, protected :: use_od_fd = .false.
-real(r8),public, protected :: od_ls_ncleff     = 3._r8 !tunable parameter for oGWD
-real(r8),public, protected :: od_bl_ncd        = 3._r8 !tunable parameter for FBD
-real(r8),public, protected :: od_ss_sncleff    = 1._r8 !tunable parameter for sGWD
 !
 ! Switches that turn on/off individual parameterizations.
 !
@@ -259,7 +256,6 @@ subroutine phys_ctl_readnl(nlfile)
       use_hetfrz_classnuc, use_gw_oro, use_gw_front, use_gw_convect, &
       use_gw_energy_fix, &
       use_od_ls,use_od_bl,use_od_ss,use_od_fd,&
-      od_ls_ncleff,od_bl_ncd,od_ss_sncleff,&
       cld_macmic_num_steps, micro_do_icesupersat, &
       fix_g1_err_ndrop, ssalt_tuning, resus_fix, convproc_do_aer, &
       convproc_do_gas, convproc_method_activate, liqcf_fix, regen_fix, demott_ice_nuc, pergro_mods, pergro_test_active, &
@@ -383,9 +379,6 @@ subroutine phys_ctl_readnl(nlfile)
    call mpibcast(use_od_bl,                       1 , mpilog,  0, mpicom)
    call mpibcast(use_od_ss,                       1 , mpilog,  0, mpicom)
    call mpibcast(use_od_fd,                       1 , mpilog,  0, mpicom)
-   call mpibcast(od_ls_ncleff,                    1 , mpilog,  0, mpicom)
-   call mpibcast(od_bl_ncd,                       1 , mpilog,  0, mpicom)
-   call mpibcast(od_ss_sncleff,                   1 , mpilog,  0, mpicom)
    call mpibcast(fix_g1_err_ndrop,                1 , mpilog,  0, mpicom)
    call mpibcast(ssalt_tuning,                    1 , mpilog,  0, mpicom)
    call mpibcast(resus_fix,                       1 , mpilog,  0, mpicom)


### PR DESCRIPTION
This is a bug fix for the latest orodrag parameterization merged into master. The setup of the parameter tuning for the schemes is intended to read in orodrag parameters such as od_ls_ncleff, od_bl_ncd, od_ss_sncleff into the model for tuning via phys_control.F90. However, the orodrag parameters are set in a separate place spot in atm_in (e.g. oro_drag_nl), and thus a separate oro_drag_readnl is added in od_common.F90 to read these parameters in atm_in. It is tested and works well both use the new od schemes or the default schemes.

----------------------

Git log
Fixed the namelist bug for changing tuning par in oro_drag.	
        modified:   control/runtime_opts.F90
	modified:   physics/cam/clubb_intr.F90
	modified:   physics/cam/gw_drag.F90
	modified:   physics/cam/od_common.F90
	modified:   physics/cam/phys_control.F90

[BFB]