### PR TITLE
EAMxx: create rrtmgp allsky baseline target with CreateUnitTest utility

### DIFF
--- a/components/eamxx/src/physics/rrtmgp/tests/CMakeLists.txt
+++ b/components/eamxx/src/physics/rrtmgp/tests/CMakeLists.txt
@@ -1,14 +1,12 @@
 if (SCREAM_ONLY_GENERATE_BASELINES)
-  # Build baseline code
-  add_executable(generate_baseline generate_baseline.cpp)
-  target_link_libraries(generate_baseline PUBLIC scream_rrtmgp rrtmgp_test_utils)
-
-  # Generate allsky baseline with the usual cmake custom command-target pair pattern
+  # Generate allsky baseline
   # Note: these "baselines" are not to compare scream with a previous version, but
   #       rather to compare scream::rrtmgp with raw rrtmgp.
-  CreateUnitTestFromExec(
-    rrtmgp-allsky-baseline generate_baseline
+  CreateUnitTest (
+    rrtmgp-allsky-baseline generate_baseline.cpp
+    LIBS scream_rrtmgp rrtmgp_test_utils
     LABELS baseline_gen rrtmgp
+    EXCLUDE_MAIN_CPP
     EXE_ARGS "${SCREAM_DATA_DIR}/init/rrtmgp-allsky.nc ${SCREAM_BASELINES_DIR}/data/rrtmgp-allsky-baseline.nc"
   )
 


### PR DESCRIPTION
Fix issue in eamxx build system when we generate baselines using shared libs.

---

The cmake utility links (indirectly) against scream_io, which avoids link errors in case of shared libraries. The errors are due to the fact that scream_share _does_ use scream_io stuff, but the rrtmgp executable was not linking against it (directly or indirectly). However, since the exec was indeed not using ANY of the scream_io symbols, static linking is fine, but dynamic linking is not (one of the key differences in static vs dynamic linking).