### PR TITLE
Fix cases and add tests for moab coupler

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -781,6 +781,7 @@ _TESTS = {
     "e3sm_moab_dev" : {
         "time"  : "01:00:00",
         "tests" : (
+            "ERS_Vmoab_Ld3.ne4pg2_r05_oQU480.WCYCL1850NS",
             "ERS_Vmoab_Ld3.ne4pg2_oQU480.WCYCL1850NS",
             "ERS_Vmoab_Ld3.ne4pg2_oQU480.F1850",
             "ERS_Vmoab_Ld3.ne4pg2_ne4pg2.I1850CNPRDCTCBCTOP",

--- a/driver-moab/cime_config/config_component.xml
+++ b/driver-moab/cime_config/config_component.xml
@@ -1375,6 +1375,14 @@
     <desc>atm2ocn flux mapping file</desc>
   </entry>
 
+  <entry id="ATM2ICE_FMAPNAME_NONLINEAR">
+    <type>char</type>
+    <default_value>idmap_ignore</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>atm2ice flux mapping file</desc>
+  </entry>
+
   <entry id="ATM2OCN_SMAPNAME">
     <type>char</type>
     <default_value>idmap</default_value>

--- a/driver-moab/cime_config/config_component_e3sm.xml
+++ b/driver-moab/cime_config/config_component_e3sm.xml
@@ -185,6 +185,18 @@
     <desc>Turn on the passing of polar fields through the coupler</desc>
   </entry>
 
+  <entry id="FLDS_TF">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <values match="last">
+      <value compset="_MPASO.*_MALI">TRUE</value>
+    </values>
+    <group>run_flags</group>
+    <file>env_run.xml</file>
+    <desc>Turn on the passing of ocean thermal forcing fields through the coupler</desc>
+  </entry>
+
   <entry id="TFREEZE_SALTWATER_OPTION">
     <type>char</type>
     <valid_values>minus1p8,linear_salt,mushy</valid_values>
@@ -245,6 +257,7 @@
       <value compset="_SOCN"                     >CESM1_MOD</value>
       <value compset="_MPASO"                    >CESM1_MOD</value>
       <value compset="_MPASSI.*_MPASO"           >RASM_OPTION1</value>
+      <value compset="_MPASSI.*_MPASO" grid="oi%RRSwISC6to18E3r5">RASM_OPTION2</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -275,7 +288,7 @@
       <value compset="_DATM"    >none</value>
       <value compset="_BGC%BPRP">CO2C</value>
       <value compset="HIST.*_DATM%(QIA|CRU|GSW)">CO2A</value>
-      <value compset="20TR.*_DATM%(QIA|CRU|GSW)">CO2A</value>
+      <value compset="20TR.*_DATM%(QIA|CRU|GSW|E3SMWCv2|CPLWCH)">CO2A</value>
       <value compset="RCP.*_DATM%(QIA|CRU|GSW)" >CO2A</value>
       <value compset="_DATM%IAF.*_MPASO%OECO" >CO2A</value>
       <value compset="_DATM%JRA.*_MPASO%OECO" >CO2A</value>
@@ -383,6 +396,10 @@
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oQU120">24</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oEC60to30v3">48</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%ECwISC30to60E1r2">48</value>
+      <value compset="_DATM.*_SLND.*MPAS" grid="oi%FRISwISC08to60E3r1">180</value>
+      <value compset="_DATM.*_SLND.*MPAS" grid="oi%FRISwISC04to60E3r1">360</value>
+      <value compset="_DATM.*_SLND.*MPAS" grid="oi%FRISwISC02to60E3r1">720</value>
+      <value compset="_DATM.*_SLND.*MPAS" grid="oi%FRISwISC01to60E3r1">1440</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%EC30to60E2r2">48</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%WC14to60E2r3">48</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oRRS30to10v3">96</value>
@@ -407,6 +424,7 @@
       <value compset=".+" grid="a%ne256np4">144</value>
       <value compset=".+" grid="a%ne512np4">432</value>
       <value compset=".+" grid="a%ne1024np4">864</value>
+      <value compset=".+" grid="a%ne0np4_CAx32v1">864</value>
       <value compset=".+" grid="a%ne0np4_arm_x8v3" >144</value>
       <value compset=".+" grid="a%ne0np4_conus_x4v1" >96</value>
       <value compset=".+" grid="a%ne0np4_northamericax4v1" >48</value>
@@ -446,6 +464,7 @@
       <value compset="_SLND.*SOCN.*_MALI">1</value>
       <value compset="_DATM.*_SLND.*MPASO.*_MALI">$ATM_NCPL</value>
       <value compset="_EAM.*_ELM.*MPASO">48</value>
+      <value compset="_EAMXX.*_ELM.*MPASO">$ATM_NCPL</value>
       <value compset="_EAM.*_ELM.*MPASO" grid="a%ne4np4">$ATM_NCPL</value>
       <value compset="_EAM.*_ELM.*MPASO" grid="a%ne11np4">12</value>
       <value compset="_EAM.*_ELM.*MPASO" grid="a%ne120np4">96</value>
@@ -747,8 +766,13 @@
       <value compset="^1950.+CMIP6"                             >312.821</value>
       <value compset="^2010"                                    >388.717</value>
       <value compset="^2010.+CMIP6"                             >388.717</value>
-      <value compset="^SSP585.+CMIP6"				>0.000001</value>
-      <value compset="^SSP370.+CMIP6"                           >0.000001</value>
+      <value compset="^20TR.+CMIP6-AER"                         >284.317</value>
+      <value compset="^20TR.+CMIP6-xGHG-xAER"                   >284.317</value>
+      <value compset="^20TR.+CMIP6-NAT"                         >284.317</value>
+      <value compset="^20TR.+CMIP6-OZONE"                       >284.317</value>
+      <value compset="^20TR.+CMIP6-LULC"                        >284.317</value>
+      <value compset="^20TR.+CMIP6-VOLC"                        >284.317</value>
+      <value compset="^SSP.+CMIP6"                              >0.000001</value>
       <value compset="^20TR.*BGC%BCRC"                          >284.317</value>
       <value compset="^20TR.*BGC%BCRD"                          >284.317</value>
       <value compset="^20TR.*BGC%BDRC"                          >284.317</value>
@@ -851,6 +875,7 @@
     <default_value>1</default_value>
     <values match="last">
       <value compset=".+EAM%CMIP6"				>2</value>
+      <value compset=".+EAM%MMF"				>2</value>
     </values>
     <group>shr_dust_nl</group>
     <file>env_run.xml</file>

--- a/driver-moab/shr/seq_infodata_mod.F90
+++ b/driver-moab/shr/seq_infodata_mod.F90
@@ -198,6 +198,7 @@ MODULE seq_infodata_mod
      logical                 :: ocn_prognostic  ! does component model need input data from driver
      logical                 :: ocnrof_prognostic ! does component need rof data
      logical                 :: ocn_c2_glcshelf   ! will ocn component send data for ice shelf fluxes in driver
+     logical                 :: ocn_c2_glctf    ! will ocn component send data for thermal forcing in driver
      logical                 :: ice_present     ! does component model exist
      logical                 :: ice_prognostic  ! does component model need input data from driver
      logical                 :: iceberg_prognostic ! does the ice model support icebergs
@@ -764,6 +765,7 @@ CONTAINS
        infodata%ocn_prognostic = .false.
        infodata%ocnrof_prognostic = .false.
        infodata%ocn_c2_glcshelf = .false.
+       infodata%ocn_c2_glctf = .false.
        infodata%ice_prognostic = .false.
        infodata%glc_prognostic = .false.
        ! It's safest to assume glc_coupled_fluxes = .true. if it's not set elsewhere,
@@ -1013,7 +1015,8 @@ CONTAINS
        atm_present, atm_prognostic,                                       &
        lnd_present, lnd_prognostic,                                       &
        rof_present, rof_prognostic, rofocn_prognostic,                    &
-       ocn_present, ocn_prognostic, ocnrof_prognostic, ocn_c2_glcshelf,   &
+       ocn_present, ocn_prognostic, ocnrof_prognostic,                    &
+       ocn_c2_glcshelf, ocn_c2_glctf,                                     &
        ice_present, ice_prognostic,                                       &
        glc_present, glc_prognostic,                                       &
        iac_present, iac_prognostic,                                       &
@@ -1187,6 +1190,7 @@ CONTAINS
     logical,                optional, intent(OUT) :: ocn_prognostic
     logical,                optional, intent(OUT) :: ocnrof_prognostic
     logical,                optional, intent(OUT) :: ocn_c2_glcshelf
+    logical,                optional, intent(OUT) :: ocn_c2_glctf
     logical,                optional, intent(OUT) :: ice_present
     logical,                optional, intent(OUT) :: ice_prognostic
     logical,                optional, intent(OUT) :: iceberg_prognostic
@@ -1379,6 +1383,7 @@ CONTAINS
     if ( present(ocn_prognostic) ) ocn_prognostic = infodata%ocn_prognostic
     if ( present(ocnrof_prognostic) ) ocnrof_prognostic = infodata%ocnrof_prognostic
     if ( present(ocn_c2_glcshelf) ) ocn_c2_glcshelf = infodata%ocn_c2_glcshelf
+    if ( present(ocn_c2_glctf) ) ocn_c2_glctf = infodata%ocn_c2_glctf
     if ( present(ice_present)    ) ice_present    = infodata%ice_present
     if ( present(ice_prognostic) ) ice_prognostic = infodata%ice_prognostic
     if ( present(iceberg_prognostic)) iceberg_prognostic = infodata%iceberg_prognostic
@@ -1578,7 +1583,8 @@ CONTAINS
        atm_present, atm_prognostic,                                       &
        lnd_present, lnd_prognostic,                                       &
        rof_present, rof_prognostic, rofocn_prognostic,                    &
-       ocn_present, ocn_prognostic, ocnrof_prognostic, ocn_c2_glcshelf,   &
+       ocn_present, ocn_prognostic, ocnrof_prognostic,                    &
+       ocn_c2_glcshelf, ocn_c2_glctf,                                     &
        ice_present, ice_prognostic,                                       &
        glc_present, glc_prognostic,                                       &
        glc_coupled_fluxes,                                                &
@@ -1753,6 +1759,7 @@ CONTAINS
     logical,                optional, intent(IN)    :: ocn_prognostic
     logical,                optional, intent(IN)    :: ocnrof_prognostic
     logical,                optional, intent(IN)    :: ocn_c2_glcshelf
+    logical,                optional, intent(IN)    :: ocn_c2_glctf
     logical,                optional, intent(IN)    :: ice_present
     logical,                optional, intent(IN)    :: ice_prognostic
     logical,                optional, intent(IN)    :: iceberg_prognostic
@@ -1944,6 +1951,7 @@ CONTAINS
     if ( present(ocn_prognostic) ) infodata%ocn_prognostic = ocn_prognostic
     if ( present(ocnrof_prognostic)) infodata%ocnrof_prognostic = ocnrof_prognostic
     if ( present(ocn_c2_glcshelf)) infodata%ocn_c2_glcshelf = ocn_c2_glcshelf
+    if ( present(ocn_c2_glctf))    infodata%ocn_c2_glctf = ocn_c2_glctf
     if ( present(ice_present)    ) infodata%ice_present    = ice_present
     if ( present(ice_prognostic) ) infodata%ice_prognostic = ice_prognostic
     if ( present(iceberg_prognostic)) infodata%iceberg_prognostic = iceberg_prognostic
@@ -2258,6 +2266,7 @@ CONTAINS
     call shr_mpi_bcast(infodata%ocn_prognostic,          mpicom)
     call shr_mpi_bcast(infodata%ocnrof_prognostic,       mpicom)
     call shr_mpi_bcast(infodata%ocn_c2_glcshelf,         mpicom)
+    call shr_mpi_bcast(infodata%ocn_c2_glctf,            mpicom)
     call shr_mpi_bcast(infodata%ice_present,             mpicom)
     call shr_mpi_bcast(infodata%ice_prognostic,          mpicom)
     call shr_mpi_bcast(infodata%iceberg_prognostic,      mpicom)
@@ -2554,6 +2563,7 @@ CONTAINS
        call shr_mpi_bcast(infodata%ocn_prognostic,     mpicom, pebcast=cmppe)
        call shr_mpi_bcast(infodata%ocnrof_prognostic,  mpicom, pebcast=cmppe)
        call shr_mpi_bcast(infodata%ocn_c2_glcshelf,    mpicom, pebcast=cmppe)
+       call shr_mpi_bcast(infodata%ocn_c2_glctf,       mpicom, pebcast=cmppe)
        call shr_mpi_bcast(infodata%ocn_nx,             mpicom, pebcast=cmppe)
        call shr_mpi_bcast(infodata%ocn_ny,             mpicom, pebcast=cmppe)
        call shr_mpi_bcast(infodata%ocn_domain,         mpicom, pebcast=cmppe)
@@ -2632,6 +2642,7 @@ CONTAINS
        call shr_mpi_bcast(infodata%ocn_prognostic,     mpicom, pebcast=cplpe)
        call shr_mpi_bcast(infodata%ocnrof_prognostic,  mpicom, pebcast=cplpe)
        call shr_mpi_bcast(infodata%ocn_c2_glcshelf,    mpicom, pebcast=cplpe)
+       call shr_mpi_bcast(infodata%ocn_c2_glctf,       mpicom, pebcast=cplpe)
        call shr_mpi_bcast(infodata%ice_present,        mpicom, pebcast=cplpe)
        call shr_mpi_bcast(infodata%ice_prognostic,     mpicom, pebcast=cplpe)
        call shr_mpi_bcast(infodata%iceberg_prognostic, mpicom, pebcast=cplpe)
@@ -2984,6 +2995,7 @@ CONTAINS
     write(logunit,F0L) subname,'ocn_prognostic           = ', infodata%ocn_prognostic
     write(logunit,F0L) subname,'ocnrof_prognostic        = ', infodata%ocnrof_prognostic
     write(logunit,F0L) subname,'ocn_c2_glcshelf          = ', infodata%ocn_c2_glcshelf
+    write(logunit,F0L) subname,'ocn_c2_glctf             = ', infodata%ocn_c2_glctf
     write(logunit,F0L) subname,'ice_present              = ', infodata%ice_present
     write(logunit,F0L) subname,'ice_prognostic           = ', infodata%ice_prognostic
     write(logunit,F0L) subname,'iceberg_prognostic       = ', infodata%iceberg_prognostic


### PR DESCRIPTION
Fix a few issues including:

Add ocn_c2_glctf to seq_infodata as in mct coupler which is needed after merging 31d8b7b
Add ATM2ICE_FMAPNAME_NONLINEAR to moab coupler. Needed to create
ne30 cases
Add a tri-grid case to moab dev test suite.
Update config_component_e3sm.xml with latest driver-mct version.

[BFB]