### PR TITLE
Update to new version of AIS 4km mesh

### DIFF
--- a/components/mpas-albany-landice/cime_config/buildnml
+++ b/components/mpas-albany-landice/cime_config/buildnml
@@ -73,7 +73,7 @@ def buildnml(case, caseroot, compname):
         decomp_date += '240507'
         decomp_prefix += 'mpasli.graph.info.'
     elif glc_grid == 'mpas.ais4to20km':
-        grid_date += '20240708'
+        grid_date += '20241224'
         grid_prefix += 'ais_4to20km'
         decomp_date += '240507'
         decomp_prefix += 'mpasli.graph.info.'


### PR DESCRIPTION
This PR update the GLC mpas.ais4to20km mesh to a new version that has corrected some artifacts in ice shelf and grounding line position in the Amundsen Sea.  This AIS geometry will also be used to define AIS geometry in MPAS-Ocean as part of the in-development SOwISC12to30E3r4 ocean mesh.