### PR TITLE
EAMxx: add vert_contraction field utility

### DIFF
--- a/components/eamxx/src/share/field/field_utils.hpp
+++ b/components/eamxx/src/share/field/field_utils.hpp
@@ -179,6 +179,99 @@ void horiz_contraction(const Field &f_out, const Field &f_in,
   impl::horiz_contraction<ST>(f_out, f_in, weight, comm);
 }
 
+// Utility to compute the contraction of a field along its level dimension.
+// This is equivalent to f_out = einsum('...k->...', weight, f_in).
+// The impl is such that:
+// - f_out, f_in, and weight must be provided and allocated
+// - The last dimension is for the levels (LEV)
+// - There can be only up to 3 dimensions of f_in
+// - Weight is assumed to be (in order of checking/impl):
+//   - rank-1, with only LEV dimension
+//   - rank-2, with only COL and LEV dimensions
+template <typename ST>
+void vert_contraction(const Field &f_out, const Field &f_in,
+                      const Field &weight, const ekat::Comm *comm = nullptr) {
+  using namespace ShortFieldTagsNames;
+
+  const auto &l_out = f_out.get_header().get_identifier().get_layout();
+
+  const auto &l_in = f_in.get_header().get_identifier().get_layout();
+
+  const auto &l_w = weight.get_header().get_identifier().get_layout();
+
+  // Sanity checks before handing off to the implementation
+  EKAT_REQUIRE_MSG(
+      l_w.rank() >= 1 && l_w.rank() <= 2,
+      "Error! The weight field must be at least rank-1 and at most rank-2.\n"
+      "The weight field has rank "
+          << l_w.rank() << ".\n");
+  EKAT_REQUIRE_MSG(
+      l_w.tags().back() == LEV,
+      "Error! The weight field must have LEV as its last dimension.\n"
+      "The weight field layout is "
+          << l_w.to_string() << ".\n");
+  EKAT_REQUIRE_MSG(l_in.rank() <= 3,
+                   "Error! The input field must be at most rank-3.\n"
+                   "The input field rank is "
+                       << l_in.rank() << ".\n");
+  EKAT_REQUIRE_MSG(l_in.rank() >= l_w.rank(),
+                   "Error! The input field must have at least as many "
+                   "dimensions as the weight field.\n"
+                   "The input field rank is "
+                       << l_in.rank() << " and the weight field rank is "
+                       << l_w.rank() << ".\n");
+  EKAT_REQUIRE_MSG(l_in.tags().back() == LEV,
+                   "Error! The input field must have a level dimension.\n"
+                   "The input field layout is "
+                       << l_in.to_string() << ".\n");
+  EKAT_REQUIRE_MSG(
+      l_in.dim(l_in.rank() - 1) == l_w.dim(l_w.rank() - 1),
+      "Error! input and weight fields must have the same dimension along "
+      "which we are taking the reducing the field (last dimensions).\n"
+      "The weight field has last dimension "
+          << l_w.dim(l_w.rank() - 1)
+          << " while "
+             "the input field has last dimension "
+          << l_in.dim(l_in.rank() - 1) << ".\n");
+  EKAT_REQUIRE_MSG(
+      l_in.dim(l_in.rank() - 1) > 0,
+      "Error! The input field must have a non-zero level dimension.\n"
+      "The input field layout is "
+          << l_in.to_string() << ".\n");
+  if(l_w.rank() == 2) {
+    EKAT_REQUIRE_MSG(
+        l_w.tags()[0] == COL && l_in.tags()[0] == COL,
+        "Error! Rank-2 weight field must have COL as first dimension");
+    EKAT_REQUIRE_MSG(
+        l_w.dim(0) == l_in.dim(0),
+        "Error! input and weight fields must have the same dimension along "
+        "which we are taking the reducing the field (first dimensions).\n"
+        "The weight field has first dimension "
+            << l_w.dim(0)
+            << " while "
+               "the input field has first dimension "
+            << l_in.dim(0) << ".\n");
+  }
+  EKAT_REQUIRE_MSG(
+      l_out == l_in.clone().strip_dim(l_in.rank() - 1),
+      "Error! The output field must have the same layout as the input field "
+      "without the level dimension.\n"
+      "The input field layout is "
+          << l_in.to_string() << " and the output field layout is "
+          << l_out.to_string() << ".\n");
+  EKAT_REQUIRE_MSG(
+      f_out.is_allocated() && f_in.is_allocated() && weight.is_allocated(),
+      "Error! All fields must be allocated.");
+  EKAT_REQUIRE_MSG(f_out.data_type() == f_in.data_type(),
+                   "Error! In/out Fields have matching data types.");
+  EKAT_REQUIRE_MSG(
+      f_out.data_type() == weight.data_type(),
+      "Error! Weight field must have the same data type as input field.");
+
+  // All good, call the implementation
+  impl::vert_contraction<ST>(f_out, f_in, weight, comm);
+}
+
 template<typename ST>
 ST frobenius_norm(const Field& f, const ekat::Comm* comm = nullptr)
 {

--- a/components/eamxx/src/share/field/field_utils_impl.hpp
+++ b/components/eamxx/src/share/field/field_utils_impl.hpp
@@ -366,6 +366,105 @@ void horiz_contraction(const Field &f_out, const Field &f_in,
   }
 }
 
+template <typename ST>
+void vert_contraction(const Field &f_out, const Field &f_in,
+                      const Field &weight, const ekat::Comm *comm) {
+  using KT          = ekat::KokkosTypes<DefaultDevice>;
+  using RangePolicy = Kokkos::RangePolicy<Field::device_t::execution_space>;
+  using TeamPolicy  = Kokkos::TeamPolicy<Field::device_t::execution_space>;
+  using TeamMember  = typename TeamPolicy::member_type;
+  using ESU         = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
+
+  auto l_out = f_out.get_header().get_identifier().get_layout();
+  auto l_in  = f_in.get_header().get_identifier().get_layout();
+  auto l_w   = weight.get_header().get_identifier().get_layout();
+
+  const int nlevs = l_in.dim(l_in.rank() - 1);
+
+  switch(l_in.rank()) {
+    case 1: {
+      auto v_w   = weight.get_view<const ST *>();
+      auto v_in  = f_in.get_view<const ST *>();
+      auto v_out = f_out.get_view<ST>();
+      Kokkos::parallel_reduce(
+          f_out.name(), RangePolicy(0, nlevs),
+          KOKKOS_LAMBDA(const int i, ST &ls) { ls += v_w(i) * v_in(i); },
+          v_out);
+    } break;
+    case 2: {
+      auto v_in    = f_in.get_view<const ST **>();
+      auto v_out   = f_out.get_view<ST *>();
+      const int d0 = l_in.dim(0);
+      auto p       = ESU::get_default_team_policy(d0, nlevs);
+      if(l_w.rank() == 1) {
+        auto v_w = weight.get_view<const ST *>();
+        Kokkos::parallel_for(
+            f_out.name(), p, KOKKOS_LAMBDA(const TeamMember &tm) {
+              const int i = tm.league_rank();
+              Kokkos::parallel_reduce(
+                  Kokkos::TeamVectorRange(tm, nlevs),
+                  [&](int j, ST &ac) { ac += v_w(j) * v_in(i, j); }, v_out(i));
+            });
+      } else {
+        auto v_w = weight.get_view<const ST **>();
+        Kokkos::parallel_for(
+            f_out.name(), p, KOKKOS_LAMBDA(const TeamMember &tm) {
+              const int i = tm.league_rank();
+              Kokkos::parallel_reduce(
+                  Kokkos::TeamVectorRange(tm, nlevs),
+                  [&](int j, ST &ac) { ac += v_w(i, j) * v_in(i, j); },
+                  v_out(i));
+            });
+      }
+    } break;
+    case 3: {
+      auto v_in    = f_in.get_view<const ST ***>();
+      auto v_out   = f_out.get_view<ST **>();
+      const int d0 = l_in.dim(0);
+      const int d1 = l_in.dim(1);
+      auto p       = ESU::get_default_team_policy(d0 * d1, nlevs);
+      if(l_w.rank() == 1) {
+        auto v_w = weight.get_view<const ST *>();
+        Kokkos::parallel_for(
+            f_out.name(), p, KOKKOS_LAMBDA(const TeamMember &tm) {
+              const int idx = tm.league_rank();
+              const int i   = idx / d1;
+              const int j   = idx % d1;
+              Kokkos::parallel_reduce(
+                  Kokkos::TeamVectorRange(tm, nlevs),
+                  [&](int k, ST &ac) { ac += v_w(k) * v_in(i, j, k); },
+                  v_out(i, j));
+            });
+      } else {
+        auto v_w = weight.get_view<const ST **>();
+        Kokkos::parallel_for(
+            f_out.name(), p, KOKKOS_LAMBDA(const TeamMember &tm) {
+              const int idx = tm.league_rank();
+              const int i   = idx / d1;
+              const int j   = idx % d1;
+              Kokkos::parallel_reduce(
+                  Kokkos::TeamVectorRange(tm, nlevs),
+                  [&](int k, ST &ac) { ac += v_w(i, k) * v_in(i, j, k); },
+                  v_out(i, j));
+            });
+      }
+    } break;
+    default:
+      EKAT_ERROR_MSG("Error! Unsupported field rank in vert_contraction.\n");
+  }
+
+  if(comm) {
+    // TODO: use device-side MPI calls
+    // TODO: the dev ptr causes problems; revisit this later
+    // TODO: doing cuda-aware MPI allreduce would be ~10% faster
+    Kokkos::fence();
+    f_out.sync_to_host();
+    comm->all_reduce(f_out.template get_internal_view_data<ST, Host>(),
+                     l_out.size(), MPI_SUM);
+    f_out.sync_to_dev();
+  }
+}
+
 template<typename ST>
 ST frobenius_norm(const Field& f, const ekat::Comm* comm)
 {

--- a/components/eamxx/src/share/field/field_utils_impl.hpp
+++ b/components/eamxx/src/share/field/field_utils_impl.hpp
@@ -381,6 +381,17 @@ void vert_contraction(const Field &f_out, const Field &f_in,
 
   const int nlevs = l_in.dim(l_in.rank() - 1);
 
+  // To avoid duplicating code for the 1d and 2d weight cases,
+  // we use a view to access the weight ahead of time
+  typename Field::get_view_type<const ST *, Device> w1d;
+  typename Field::get_view_type<const ST **, Device> w2d;
+  auto w_is_1d = l_w.rank() == 1;
+  if(w_is_1d) {
+    w1d = weight.get_view<const ST *>();
+  } else {
+    w2d = weight.get_view<const ST **>();
+  }
+
   switch(l_in.rank()) {
     case 1: {
       auto v_w   = weight.get_view<const ST *>();
@@ -396,26 +407,16 @@ void vert_contraction(const Field &f_out, const Field &f_in,
       auto v_out   = f_out.get_view<ST *>();
       const int d0 = l_in.dim(0);
       auto p       = ESU::get_default_team_policy(d0, nlevs);
-      if(l_w.rank() == 1) {
-        auto v_w = weight.get_view<const ST *>();
-        Kokkos::parallel_for(
-            f_out.name(), p, KOKKOS_LAMBDA(const TeamMember &tm) {
-              const int i = tm.league_rank();
-              Kokkos::parallel_reduce(
-                  Kokkos::TeamVectorRange(tm, nlevs),
-                  [&](int j, ST &ac) { ac += v_w(j) * v_in(i, j); }, v_out(i));
-            });
-      } else {
-        auto v_w = weight.get_view<const ST **>();
-        Kokkos::parallel_for(
-            f_out.name(), p, KOKKOS_LAMBDA(const TeamMember &tm) {
-              const int i = tm.league_rank();
-              Kokkos::parallel_reduce(
-                  Kokkos::TeamVectorRange(tm, nlevs),
-                  [&](int j, ST &ac) { ac += v_w(i, j) * v_in(i, j); },
-                  v_out(i));
-            });
-      }
+      Kokkos::parallel_for(
+          f_out.name(), p, KOKKOS_LAMBDA(const TeamMember &tm) {
+            const int i = tm.league_rank();
+            Kokkos::parallel_reduce(
+                Kokkos::TeamVectorRange(tm, nlevs),
+                [&](int j, ST &ac) {
+                  ac += w_is_1d ? w1d(j) * v_in(i, j) : w2d(i, j) * v_in(i, j);
+                },
+                v_out(i));
+          });
     } break;
     case 3: {
       auto v_in    = f_in.get_view<const ST ***>();
@@ -423,31 +424,19 @@ void vert_contraction(const Field &f_out, const Field &f_in,
       const int d0 = l_in.dim(0);
       const int d1 = l_in.dim(1);
       auto p       = ESU::get_default_team_policy(d0 * d1, nlevs);
-      if(l_w.rank() == 1) {
-        auto v_w = weight.get_view<const ST *>();
-        Kokkos::parallel_for(
-            f_out.name(), p, KOKKOS_LAMBDA(const TeamMember &tm) {
-              const int idx = tm.league_rank();
-              const int i   = idx / d1;
-              const int j   = idx % d1;
-              Kokkos::parallel_reduce(
-                  Kokkos::TeamVectorRange(tm, nlevs),
-                  [&](int k, ST &ac) { ac += v_w(k) * v_in(i, j, k); },
-                  v_out(i, j));
-            });
-      } else {
-        auto v_w = weight.get_view<const ST **>();
-        Kokkos::parallel_for(
-            f_out.name(), p, KOKKOS_LAMBDA(const TeamMember &tm) {
-              const int idx = tm.league_rank();
-              const int i   = idx / d1;
-              const int j   = idx % d1;
-              Kokkos::parallel_reduce(
-                  Kokkos::TeamVectorRange(tm, nlevs),
-                  [&](int k, ST &ac) { ac += v_w(i, k) * v_in(i, j, k); },
-                  v_out(i, j));
-            });
-      }
+      Kokkos::parallel_for(
+          f_out.name(), p, KOKKOS_LAMBDA(const TeamMember &tm) {
+            const int idx = tm.league_rank();
+            const int i   = idx / d1;
+            const int j   = idx % d1;
+            Kokkos::parallel_reduce(
+                Kokkos::TeamVectorRange(tm, nlevs),
+                [&](int k, ST &ac) {
+                  ac += w_is_1d ? w1d(k) * v_in(i, j, k)
+                                : w2d(i, k) * v_in(i, j, k);
+                },
+                v_out(i, j));
+          });
     } break;
     default:
       EKAT_ERROR_MSG("Error! Unsupported field rank in vert_contraction.\n");

--- a/components/eamxx/src/share/tests/field_utils.cpp
+++ b/components/eamxx/src/share/tests/field_utils.cpp
@@ -237,165 +237,175 @@ TEST_CASE("utils") {
   }
 
   SECTION("vert_contraction") {
-    using RPDF  = std::uniform_real_distribution<Real>;
-    auto engine = setup_random_test();
-    RPDF pdf(0, 1);
+    std::vector<FieldTag> lev_tags = {LEV, ILEV};
+    // iterate over lev_tags
+    for(auto lev_tag : lev_tags) {
+      using RPDF  = std::uniform_real_distribution<Real>;
+      auto engine = setup_random_test();
+      RPDF pdf(0, 1);
 
-    int dim0 = 4;
-    int dim1 = 9;
-    int dim2 = 3;
+      int dim0 = 4;
+      int dim1 = 9;
+      // Note that parallel reduction is happening over dim2 (LEV/ILEV)
+      // If it is more than 3, the order of ops will lead to non-bfb results
+      int dim2 = lev_tag == LEV ? 3 : 3; 
 
-    // Set a weight field
-    FieldIdentifier f00("f", {{LEV}, {dim2}}, m / s, "g");
-    Field field00(f00);
-    field00.allocate_view();
-    field00.sync_to_host();
-    auto v00 = field00.get_strided_view<Real *, Host>();
-    for(int i = 0; i < dim2; ++i) {
-      v00(i) = sp(i + 1) / sp(6);
-    }
-    field00.sync_to_dev();
-
-    // Create (random) sample fields
-    FieldIdentifier fsc("f", {{}, {}}, m / s, "g");  // scalar
-    FieldIdentifier f10("f", {{COL, LEV}, {dim0, dim2}}, m / s, "g");
-    FieldIdentifier f11("f", {{CMP, LEV}, {dim1, dim2}}, m / s, "g");
-    FieldIdentifier f20("f", {{COL, CMP, LEV}, {dim0, dim1, dim2}}, m / s, "g");
-    Field fieldsc(fsc);
-    Field field10(f10);
-    Field field11(f11);
-    Field field20(f20);
-    fieldsc.allocate_view();
-    field10.allocate_view();
-    field11.allocate_view();
-    field20.allocate_view();
-    randomize(fieldsc, engine, pdf);
-    randomize(field10, engine, pdf);
-    randomize(field11, engine, pdf);
-    randomize(field20, engine, pdf);
-
-    FieldIdentifier F_x("fx", {{COL}, {dim0}}, m / s, "g");
-    FieldIdentifier F_y("fy", {{CMP}, {dim1}}, m / s, "g");
-    FieldIdentifier F_z("fz", {{COL, CMP}, {dim0, dim1}}, m / s, "g");
-
-    Field field_x(F_x);
-    Field field_y(F_y);
-    Field field_z(F_z);
-
-    // Test invalid inputs
-    REQUIRE_THROWS(vert_contraction<Real>(fieldsc, field_x,
-                                          field00));  // x not allocated yet
-
-    field_x.allocate_view();
-    field_y.allocate_view();
-    field_z.allocate_view();
-
-    REQUIRE_THROWS(vert_contraction<Real>(fieldsc, field_y,
-                                          field_x));  // unmatching layout
-    REQUIRE_THROWS(vert_contraction<Real>(field_z, field11,
-                                          field11));  // wrong weight layout
-
-    Field result;
-
-    // Add test for invalid rank-2 weight field layout
-    FieldIdentifier bad_w("bad_w", {{CMP, LEV}, {dim1, dim2}}, m / s, "g");
-    Field bad_weight(bad_w);
-    bad_weight.allocate_view();
-    REQUIRE_THROWS(vert_contraction<Real>(result, field20, bad_weight));
-
-    // Add test for mismatched weight field dimensions
-    FieldIdentifier wrong_size_w("wrong_w", {{COL, LEV}, {dim0 + 1, dim2}},
-                                 m / s, "g");
-    Field wrong_weight(wrong_size_w);
-    wrong_weight.allocate_view();
-    REQUIRE_THROWS(vert_contraction<Real>(result, field20, wrong_weight));
-
-    // Ensure a scalar case works
-    result = fieldsc.clone();
-    vert_contraction<Real>(result, field00, field00);
-    result.sync_to_host();
-    auto v = result.get_view<Real, Host>();
-    REQUIRE(v() == sp(1 + 4 + 9) / sp(36));
-
-    // Test higher-order cases
-    result = field_x.clone();
-    vert_contraction<Real>(result, field10, field00);
-    REQUIRE(result.get_header().get_identifier().get_layout().tags() ==
-            std::vector<FieldTag>({COL}));
-    REQUIRE(result.get_header().get_identifier().get_layout().dim(0) == dim0);
-
-    // Check a 2D case with 1D weight
-    field10.sync_to_host();
-    auto manual_result = result.clone();
-    manual_result.deep_copy(0);
-    manual_result.sync_to_host();
-    auto v1 = field10.get_strided_view<Real **, Host>();
-    auto mr = manual_result.get_strided_view<Real *, Host>();
-    for(int i = 0; i < dim0; ++i) {
-      for(int j = 0; j < dim2; ++j) {
-        mr(i) += v00(j) * v1(i, j);
+      // Set a weight field
+      FieldIdentifier f00("f", {{lev_tag}, {dim2}}, m / s, "g");
+      Field field00(f00);
+      field00.allocate_view();
+      field00.sync_to_host();
+      auto v00 = field00.get_strided_view<Real *, Host>();
+      for(int i = 0; i < dim2; ++i) {
+        // denominator is the sum of the first dim2 integers (analytically known)
+        v00(i) = sp(i + 1) / sp(dim2*(dim2+1)/2);
       }
-    }
-    field11.sync_to_dev();
-    manual_result.sync_to_dev();
-    REQUIRE(views_are_equal(result, manual_result));
+      field00.sync_to_dev();
 
-    result = field_y.clone();
-    vert_contraction<Real>(result, field11, field00);
-    REQUIRE(result.get_header().get_identifier().get_layout().tags() ==
-            std::vector<FieldTag>({CMP}));
-    REQUIRE(result.get_header().get_identifier().get_layout().dim(0) == dim1);
+      // Create (random) sample fields
+      FieldIdentifier fsc("f", {{}, {}}, m / s, "g");  // scalar
+      FieldIdentifier f10("f", {{COL, lev_tag}, {dim0, dim2}}, m / s, "g");
+      FieldIdentifier f11("f", {{CMP, lev_tag}, {dim1, dim2}}, m / s, "g");
+      FieldIdentifier f20("f", {{COL, CMP, lev_tag}, {dim0, dim1, dim2}}, m / s,
+                          "g");
+      Field fieldsc(fsc);
+      Field field10(f10);
+      Field field11(f11);
+      Field field20(f20);
+      fieldsc.allocate_view();
+      field10.allocate_view();
+      field11.allocate_view();
+      field20.allocate_view();
+      randomize(fieldsc, engine, pdf);
+      randomize(field10, engine, pdf);
+      randomize(field11, engine, pdf);
+      randomize(field20, engine, pdf);
 
-    result = field_z.clone();
-    vert_contraction<Real>(result, field20, field00);
-    REQUIRE(result.get_header().get_identifier().get_layout().tags() ==
-            std::vector<FieldTag>({COL, CMP}));
-    REQUIRE(result.get_header().get_identifier().get_layout().dim(0) == dim0);
-    REQUIRE(result.get_header().get_identifier().get_layout().dim(1) == dim1);
+      FieldIdentifier F_x("fx", {{COL}, {dim0}}, m / s, "g");
+      FieldIdentifier F_y("fy", {{CMP}, {dim1}}, m / s, "g");
+      FieldIdentifier F_z("fz", {{COL, CMP}, {dim0, dim1}}, m / s, "g");
 
-    // Check a 3D case with 1D weight
-    field20.sync_to_host();
-    result.sync_to_host();
-    manual_result = result.clone();
-    manual_result.deep_copy(0);
-    manual_result.sync_to_host();
-    auto v2  = field20.get_strided_view<Real ***, Host>();
-    auto mr2 = manual_result.get_strided_view<Real **, Host>();
-    for(int i = 0; i < dim0; ++i) {
-      for(int j = 0; j < dim1; ++j) {
-        for(int k = 0; k < dim2; ++k) {
-          mr2(i, j) += v00(k) * v2(i, j, k);
+      Field field_x(F_x);
+      Field field_y(F_y);
+      Field field_z(F_z);
+
+      // Test invalid inputs
+      REQUIRE_THROWS(vert_contraction<Real>(fieldsc, field_x,
+                                            field00));  // x not allocated yet
+
+      field_x.allocate_view();
+      field_y.allocate_view();
+      field_z.allocate_view();
+
+      REQUIRE_THROWS(vert_contraction<Real>(fieldsc, field_y,
+                                            field_x));  // unmatching layout
+      REQUIRE_THROWS(vert_contraction<Real>(field_z, field11,
+                                            field11));  // wrong weight layout
+
+      Field result;
+
+      // Add test for invalid rank-2 weight field layout
+      FieldIdentifier bad_w("bad_w", {{CMP, lev_tag}, {dim1, dim2}}, m / s, "g");
+      Field bad_weight(bad_w);
+      bad_weight.allocate_view();
+      REQUIRE_THROWS(vert_contraction<Real>(result, field20, bad_weight));
+
+      // Add test for mismatched weight field dimensions
+      FieldIdentifier wrong_size_w("wrong_w", {{COL, lev_tag}, {dim0 + 1, dim2}},
+                                   m / s, "g");
+      Field wrong_weight(wrong_size_w);
+      wrong_weight.allocate_view();
+      REQUIRE_THROWS(vert_contraction<Real>(result, field20, wrong_weight));
+
+      // Ensure a scalar case works
+      result = fieldsc.clone();
+      vert_contraction<Real>(result, field00, field00);
+      result.sync_to_host();
+      auto v = result.get_view<Real, Host>();
+      // numerator is the sum of the suqares of the first dim2 integers (analytically known)
+      // denominator is the sum of the first dim2 integers squared (analytically known)
+      REQUIRE(v() == sp(dim2*(dim2+1)*(2*dim2+1)/6) / sp((dim2*(dim2+1)/2)*(dim2*(dim2+1)/2)));
+
+      // Test higher-order cases
+      result = field_x.clone();
+      vert_contraction<Real>(result, field10, field00);
+      REQUIRE(result.get_header().get_identifier().get_layout().tags() ==
+              std::vector<FieldTag>({COL}));
+      REQUIRE(result.get_header().get_identifier().get_layout().dim(0) == dim0);
+
+      // Check a 2D case with 1D weight
+      field10.sync_to_host();
+      auto manual_result = result.clone();
+      manual_result.deep_copy(0);
+      manual_result.sync_to_host();
+      auto v1 = field10.get_strided_view<Real **, Host>();
+      auto mr = manual_result.get_strided_view<Real *, Host>();
+      for(int i = 0; i < dim0; ++i) {
+        for(int j = 0; j < dim2; ++j) {
+          mr(i) += v00(j) * v1(i, j);
         }
       }
-    }
-    field20.sync_to_dev();
-    manual_result.sync_to_dev();
-    REQUIRE(views_are_equal(result, manual_result));
+      field11.sync_to_dev();
+      manual_result.sync_to_dev();
+      REQUIRE(views_are_equal(result, manual_result));
 
-    // Check a 3D case with 2D weight
-    result = field_z.clone();
-    vert_contraction<Real>(result, field20, field10);
-    REQUIRE(result.get_header().get_identifier().get_layout().tags() ==
-            std::vector<FieldTag>({COL, CMP}));
-    REQUIRE(result.get_header().get_identifier().get_layout().dim(0) == dim0);
-    REQUIRE(result.get_header().get_identifier().get_layout().dim(1) == dim1);
+      result = field_y.clone();
+      vert_contraction<Real>(result, field11, field00);
+      REQUIRE(result.get_header().get_identifier().get_layout().tags() ==
+              std::vector<FieldTag>({CMP}));
+      REQUIRE(result.get_header().get_identifier().get_layout().dim(0) == dim1);
 
-    field20.sync_to_host();
-    result.sync_to_host();
-    manual_result = result.clone();
-    manual_result.deep_copy(0);
-    manual_result.sync_to_host();
-    auto mr3 = manual_result.get_strided_view<Real **, Host>();
-    for(int i = 0; i < dim0; ++i) {
-      for(int j = 0; j < dim1; ++j) {
-        for(int k = 0; k < dim2; ++k) {
-          mr3(i, j) += v1(i, k) * v2(i, j, k);
+      result = field_z.clone();
+      vert_contraction<Real>(result, field20, field00);
+      REQUIRE(result.get_header().get_identifier().get_layout().tags() ==
+              std::vector<FieldTag>({COL, CMP}));
+      REQUIRE(result.get_header().get_identifier().get_layout().dim(0) == dim0);
+      REQUIRE(result.get_header().get_identifier().get_layout().dim(1) == dim1);
+
+      // Check a 3D case with 1D weight
+      field20.sync_to_host();
+      result.sync_to_host();
+      manual_result = result.clone();
+      manual_result.deep_copy(0);
+      manual_result.sync_to_host();
+      auto v2  = field20.get_strided_view<Real ***, Host>();
+      auto mr2 = manual_result.get_strided_view<Real **, Host>();
+      for(int i = 0; i < dim0; ++i) {
+        for(int j = 0; j < dim1; ++j) {
+          for(int k = 0; k < dim2; ++k) {
+            mr2(i, j) += v00(k) * v2(i, j, k);
+          }
         }
       }
+      field20.sync_to_dev();
+      manual_result.sync_to_dev();
+      REQUIRE(views_are_equal(result, manual_result));
+
+      // Check a 3D case with 2D weight
+      result = field_z.clone();
+      vert_contraction<Real>(result, field20, field10);
+      REQUIRE(result.get_header().get_identifier().get_layout().tags() ==
+              std::vector<FieldTag>({COL, CMP}));
+      REQUIRE(result.get_header().get_identifier().get_layout().dim(0) == dim0);
+      REQUIRE(result.get_header().get_identifier().get_layout().dim(1) == dim1);
+
+      field20.sync_to_host();
+      result.sync_to_host();
+      manual_result = result.clone();
+      manual_result.deep_copy(0);
+      manual_result.sync_to_host();
+      auto mr3 = manual_result.get_strided_view<Real **, Host>();
+      for(int i = 0; i < dim0; ++i) {
+        for(int j = 0; j < dim1; ++j) {
+          for(int k = 0; k < dim2; ++k) {
+            mr3(i, j) += v1(i, k) * v2(i, j, k);
+          }
+        }
+      }
+      field20.sync_to_dev();
+      manual_result.sync_to_dev();
+      REQUIRE(views_are_equal(result, manual_result));
     }
-    field20.sync_to_dev();
-    manual_result.sync_to_dev();
-    REQUIRE(views_are_equal(result, manual_result));
   }
 
   SECTION ("frobenius") {

--- a/components/eamxx/src/share/tests/field_utils.cpp
+++ b/components/eamxx/src/share/tests/field_utils.cpp
@@ -236,6 +236,168 @@ TEST_CASE("utils") {
     REQUIRE(views_are_equal(result, manual_result));
   }
 
+  SECTION("vert_contraction") {
+    using RPDF  = std::uniform_real_distribution<Real>;
+    auto engine = setup_random_test();
+    RPDF pdf(0, 1);
+
+    int dim0 = 4;
+    int dim1 = 9;
+    int dim2 = 3;
+
+    // Set a weight field
+    FieldIdentifier f00("f", {{LEV}, {dim2}}, m / s, "g");
+    Field field00(f00);
+    field00.allocate_view();
+    field00.sync_to_host();
+    auto v00 = field00.get_strided_view<Real *, Host>();
+    for(int i = 0; i < dim2; ++i) {
+      v00(i) = sp(i + 1) / sp(6);
+    }
+    field00.sync_to_dev();
+
+    // Create (random) sample fields
+    FieldIdentifier fsc("f", {{}, {}}, m / s, "g");  // scalar
+    FieldIdentifier f10("f", {{COL, LEV}, {dim0, dim2}}, m / s, "g");
+    FieldIdentifier f11("f", {{CMP, LEV}, {dim1, dim2}}, m / s, "g");
+    FieldIdentifier f20("f", {{COL, CMP, LEV}, {dim0, dim1, dim2}}, m / s, "g");
+    Field fieldsc(fsc);
+    Field field10(f10);
+    Field field11(f11);
+    Field field20(f20);
+    fieldsc.allocate_view();
+    field10.allocate_view();
+    field11.allocate_view();
+    field20.allocate_view();
+    randomize(fieldsc, engine, pdf);
+    randomize(field10, engine, pdf);
+    randomize(field11, engine, pdf);
+    randomize(field20, engine, pdf);
+
+    FieldIdentifier F_x("fx", {{COL}, {dim0}}, m / s, "g");
+    FieldIdentifier F_y("fy", {{CMP}, {dim1}}, m / s, "g");
+    FieldIdentifier F_z("fz", {{COL, CMP}, {dim0, dim1}}, m / s, "g");
+
+    Field field_x(F_x);
+    Field field_y(F_y);
+    Field field_z(F_z);
+
+    // Test invalid inputs
+    REQUIRE_THROWS(vert_contraction<Real>(fieldsc, field_x,
+                                          field00));  // x not allocated yet
+
+    field_x.allocate_view();
+    field_y.allocate_view();
+    field_z.allocate_view();
+
+    REQUIRE_THROWS(vert_contraction<Real>(fieldsc, field_y,
+                                          field_x));  // unmatching layout
+    REQUIRE_THROWS(vert_contraction<Real>(field_z, field11,
+                                          field11));  // wrong weight layout
+
+    Field result;
+
+    // Add test for invalid rank-2 weight field layout
+    FieldIdentifier bad_w("bad_w", {{CMP, LEV}, {dim1, dim2}}, m / s, "g");
+    Field bad_weight(bad_w);
+    bad_weight.allocate_view();
+    REQUIRE_THROWS(vert_contraction<Real>(result, field20, bad_weight));
+
+    // Add test for mismatched weight field dimensions
+    FieldIdentifier wrong_size_w("wrong_w", {{COL, LEV}, {dim0 + 1, dim2}},
+                                 m / s, "g");
+    Field wrong_weight(wrong_size_w);
+    wrong_weight.allocate_view();
+    REQUIRE_THROWS(vert_contraction<Real>(result, field20, wrong_weight));
+
+    // Ensure a scalar case works
+    result = fieldsc.clone();
+    vert_contraction<Real>(result, field00, field00);
+    result.sync_to_host();
+    auto v = result.get_view<Real, Host>();
+    REQUIRE(v() == sp(1 + 4 + 9) / sp(36));
+
+    // Test higher-order cases
+    result = field_x.clone();
+    vert_contraction<Real>(result, field10, field00);
+    REQUIRE(result.get_header().get_identifier().get_layout().tags() ==
+            std::vector<FieldTag>({COL}));
+    REQUIRE(result.get_header().get_identifier().get_layout().dim(0) == dim0);
+
+    // Check a 2D case with 1D weight
+    field10.sync_to_host();
+    auto manual_result = result.clone();
+    manual_result.deep_copy(0);
+    manual_result.sync_to_host();
+    auto v1 = field10.get_strided_view<Real **, Host>();
+    auto mr = manual_result.get_strided_view<Real *, Host>();
+    for(int i = 0; i < dim0; ++i) {
+      for(int j = 0; j < dim2; ++j) {
+        mr(i) += v00(j) * v1(i, j);
+      }
+    }
+    field11.sync_to_dev();
+    manual_result.sync_to_dev();
+    REQUIRE(views_are_equal(result, manual_result));
+
+    result = field_y.clone();
+    vert_contraction<Real>(result, field11, field00);
+    REQUIRE(result.get_header().get_identifier().get_layout().tags() ==
+            std::vector<FieldTag>({CMP}));
+    REQUIRE(result.get_header().get_identifier().get_layout().dim(0) == dim1);
+
+    result = field_z.clone();
+    vert_contraction<Real>(result, field20, field00);
+    REQUIRE(result.get_header().get_identifier().get_layout().tags() ==
+            std::vector<FieldTag>({COL, CMP}));
+    REQUIRE(result.get_header().get_identifier().get_layout().dim(0) == dim0);
+    REQUIRE(result.get_header().get_identifier().get_layout().dim(1) == dim1);
+
+    // Check a 3D case with 1D weight
+    field20.sync_to_host();
+    result.sync_to_host();
+    manual_result = result.clone();
+    manual_result.deep_copy(0);
+    manual_result.sync_to_host();
+    auto v2  = field20.get_strided_view<Real ***, Host>();
+    auto mr2 = manual_result.get_strided_view<Real **, Host>();
+    for(int i = 0; i < dim0; ++i) {
+      for(int j = 0; j < dim1; ++j) {
+        for(int k = 0; k < dim2; ++k) {
+          mr2(i, j) += v00(k) * v2(i, j, k);
+        }
+      }
+    }
+    field20.sync_to_dev();
+    manual_result.sync_to_dev();
+    REQUIRE(views_are_equal(result, manual_result));
+
+    // Check a 3D case with 2D weight
+    result = field_z.clone();
+    vert_contraction<Real>(result, field20, field10);
+    REQUIRE(result.get_header().get_identifier().get_layout().tags() ==
+            std::vector<FieldTag>({COL, CMP}));
+    REQUIRE(result.get_header().get_identifier().get_layout().dim(0) == dim0);
+    REQUIRE(result.get_header().get_identifier().get_layout().dim(1) == dim1);
+
+    field20.sync_to_host();
+    result.sync_to_host();
+    manual_result = result.clone();
+    manual_result.deep_copy(0);
+    manual_result.sync_to_host();
+    auto mr3 = manual_result.get_strided_view<Real **, Host>();
+    for(int i = 0; i < dim0; ++i) {
+      for(int j = 0; j < dim1; ++j) {
+        for(int k = 0; k < dim2; ++k) {
+          mr3(i, j) += v1(i, k) * v2(i, j, k);
+        }
+      }
+    }
+    field20.sync_to_dev();
+    manual_result.sync_to_dev();
+    REQUIRE(views_are_equal(result, manual_result));
+  }
+
   SECTION ("frobenius") {
 
     auto v1 = f1.get_strided_view<Real**>();


### PR DESCRIPTION
adds a vertical contraction utility equivalent to einsum('k,...k->...', weight, field) or einsum('ik,i...k->i...', weight, field)

---

Following #6776 but for the vertical, except with some added complexity and more caveats. Bare-bones impl for now. Design notes regarding two broad cases supported:
- if the weight provided is 1D, its lone dim must be LEV; this will be used to calculate vertical sums or means whose weight is column-invariant, say for aodvis (see diagnostic impl).
- if the weight provided is 2D, its dims must be COL,LEV; this will be used to calculate vertical sums or means whose weight is column-variant, say waterpath (see diagnostic waterpath)