### PR TITLE
Fix valgrind error in atm proc DAG creation

### DIFF
--- a/components/eamxx/src/share/atm_process/atmosphere_process_dag.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_dag.cpp
@@ -594,13 +594,16 @@ void AtmProcDAG::add_edges () {
 void AtmProcDAG::process_initial_conditions(const grid_field_map &ic_inited) {
   // First, add the fields that were determined to come from the previous time
   // step => IC for t = 0
-  // get the begin_node since the IC is identical at first
-  const Node &begin_node = m_nodes[m_nodes.size() - 2];
-  int id = m_nodes.size();
-  // Create a node for the ICs by copying the begin_node
-  m_nodes.push_back(Node(begin_node));
-  Node& ic_node = m_nodes.back();
+
+  // Create a node for the ICs by copying the begin_node. Recall that so far
+  // m_nodes contains [<processes>, 'beg-of-step', 'end-of-step']
+  // WARNING: do NOT get a ref to beg-of-step node, since calls to m_nodes.push_back
+  //          may resize the vector, invalidating the reference.
+  auto begin_node = m_nodes[m_nodes.size()-2];
+  auto& ic_node = m_nodes.emplace_back(begin_node);
+
   // now set/clear the basic data for the ic_node
+  int id = m_nodes.size();
   ic_node.id = id;
   ic_node.name = "Initial Conditions";
   m_unmet_deps[id].clear();
@@ -650,8 +653,6 @@ void AtmProcDAG::process_initial_conditions(const grid_field_map &ic_inited) {
   }
   m_IC_processed = true;
 }
-
-
 
 int AtmProcDAG::add_fid (const FieldIdentifier& fid) {
   auto it = ekat::find(m_fids,fid);

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -1110,7 +1110,7 @@ AtmosphereOutput::get_var_dof_offsets(const FieldLayout& layout)
 
   // Precompute this *before* the early return, since it involves collectives.
   // If one rank owns zero cols, and returns prematurely, the others will be left waiting.
-  AbstractGrid::gid_type min_gid;
+  AbstractGrid::gid_type min_gid = -1;
   if (layout.has_tag(COL) or layout.has_tag(EL)) {
     min_gid = m_io_grid->get_global_min_dof_gid();
   }


### PR DESCRIPTION
The issue was simply that we were grabbing a ref to an element in a vector that was later resized, invalidating the ref.