### PR TITLE
Add ocean divergenceAtSurface to highFrequencyStats

### DIFF
--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -964,6 +964,7 @@ def buildnml(case, caseroot, compname):
             lines.append('    <var name="kineticEnergyAt250m"/>')
             lines.append('    <var name="relativeVorticityAtSurface"/>')
             lines.append('    <var name="relativeVorticityAt250m"/>')
+            lines.append('    <var name="divergenceAtSurface"/>')
             lines.append('    <var name="ssh"/>')
             lines.append('    <var name="pressureAdjustedSSH"/>')
             lines.append('    <var name="boundaryLayerDepth"/>')

--- a/components/mpas-ocean/src/analysis_members/Registry_high_frequency_output.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_high_frequency_output.xml
@@ -30,6 +30,9 @@
 		<var name="relativeVorticityAtSurface" type="real" dimensions="nCells Time" units="s^-1"
 			description="relative vorticity at cell centers at surface"
 		/>
+		<var name="divergenceAtSurface" type="real" dimensions="nCells Time" units="s^-1"
+			description="divergence at cell centers at surface"
+		/>
 		<var name="vertGMvelocitySFC" type="real" dimensions="nCells Time" units="m s^-1"
 			description="vertical velocity due to GM parameterization"
 		/>
@@ -308,6 +311,7 @@
 			<var name="xtime"/>
 			<var name="kineticEnergyAtSurface"/>
 			<var name="relativeVorticityAtSurface"/>
+			<var name="divergenceAtSurface"/>
 			<var_array name="activeTracersAtSurface"/>
 			<var name="ssh"/>
 			<var name="kineticEnergyAt250m"/>

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_high_frequency_output.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_high_frequency_output.F
@@ -183,7 +183,7 @@ contains
       integer, dimension(:,:), pointer :: edgesOnCell, cellsOnEdge, edgesOnEdge
 
       real (kind=RKIND) :: invAreaCell1, layerThicknessEdge1, coeff, weightedNormalVel, cellArea
-      real (kind=RKIND), dimension(:), pointer :: refBottomDepth, kineticEnergyAt250m, kineticEnergyAtSurface, relativeVorticityAt250m, relativeVorticityAtSurface
+      real (kind=RKIND), dimension(:), pointer :: refBottomDepth, kineticEnergyAt250m, kineticEnergyAtSurface, relativeVorticityAt250m, relativeVorticityAtSurface, divergenceAtSurface
       real (kind=RKIND), dimension(:), pointer :: divergenceAt250m, relativeVorticityVertexAt250m
       real (kind=RKIND), dimension(:), pointer :: divergenceAtBottom,relativeVorticityAtBottom,kineticEnergyAtBottom
       real (kind=RKIND), dimension(:), pointer :: vertVelAt250m
@@ -265,6 +265,7 @@ contains
          call mpas_pool_get_array(highFrequencyOutputAMPool, 'relativeVorticityAt250m', relativeVorticityAt250m)
          call mpas_pool_get_array(highFrequencyOutputAMPool, 'relativeVorticityAtSurface', relativeVorticityAtSurface)
          call mpas_pool_get_array(highFrequencyOutputAMPool, 'divergenceAt250m', divergenceAt250m)
+         call mpas_pool_get_array(highFrequencyOutputAMPool, 'divergenceAtSurface', divergenceAtSurface)
          call mpas_pool_get_array(highFrequencyOutputAMPool, 'relativeVorticityAtBottom', relativeVorticityAtBottom)
          call mpas_pool_get_array(highFrequencyOutputAMPool, 'divergenceAtBottom', divergenceAtBottom)
          call mpas_pool_get_array(highFrequencyOutputAMPool, 'kineticEnergyAtBottom', kineticEnergyAtBottom)
@@ -424,6 +425,7 @@ contains
          relativeVorticityVertexAt250m(:) = relativeVorticity(iLevel0250,:)
          kineticEnergyAtSurface(:) = kineticEnergyCell(1,:)
          relativeVorticityAtSurface(:) = relativeVorticityCell(1,:)
+         divergenceAtSurface(:) = divergence(1,:)
          activeTracersAtSurface(1,:) = activeTracers(1,1,:)
          activeTracersAtSurface(2,:) = activeTracers(2,1,:)
          activeTracersAt250m(1,:) = activeTracers(1,iLevel0250,:)


### PR DESCRIPTION
This commit mirrors https://github.com/E3SM-Project/E3SM/pull/6566, but adds divergence at the surface. This is useful for MPAS-O meshes capable of permitting or resolving submesoscale processes. Divergence is a key diagnostic of submesoscale flows, in particular identifying regions of frontogenesis and frontolysis. The variable is added to the default output for ```highFrequencyStats```, but is an optional 2D field.

Currently, this is used for our high-resolution Gulf of Mexico simulations and will be useful for future high-resolution campaigns. 