### PR TITLE
EAMxx: set testing max ranks to 2 on ghci-snl-cuda

### DIFF
--- a/components/eamxx/cmake/machine-files/ghci-snl-cuda.cmake
+++ b/components/eamxx/cmake/machine-files/ghci-snl-cuda.cmake
@@ -12,3 +12,6 @@ set(EKAT_MPI_NP_FLAG "-n" CACHE STRING "The mpirun flag for designating the tota
 
 # TODO: rebuild cuda image with cuda-aware MPI, so we can set this to ON
 option(SCREAM_MPI_ON_DEVICE "Whether to use device pointers for MPI calls" OFF)
+
+# Currently, we have 2 GPUs/node on Blake, and we run a SINGLE build per node, so we can fit 2 ranks there
+set(SCREAM_TEST_MAX_RANKS 2 CACHE STRING "Upper limit on ranks for mpi tests")

--- a/components/eamxx/src/share/io/tests/io_se_grid.cpp
+++ b/components/eamxx/src/share/io/tests/io_se_grid.cpp
@@ -152,8 +152,9 @@ get_test_fm(const std::shared_ptr<const AbstractGrid>& grid,
 
   // field_2 is not partitioned, so let's sync it across ranks
   auto f2 = fm->get_field("field_2");
-  auto v2 = f2.get_view<Real*>();
+  auto v2 = f2.get_view<Real*,Host>();
   comm.all_reduce(v2.data(),nlevs,MPI_MAX);
+  f2.sync_to_dev();
 
   return fm;
 }


### PR DESCRIPTION
Back when we tested on Weaver, we ran 3 builds in parallel on compute nodes (which had 4 GPUs). So on GPU platforms, we just set all builds with max test ranks to 1, to avoid having to deal with which build had 1 gpu and which had 2 gpus.

Now, the gh workflow we use for testing runs a _single_ build on each blake node, which have 2 GPUs. Hence, we can finally run multi-rank tests with our GPU standalone tests. This should add tests like `np1_vs_np2` to our AD system tests, which can help verifying non-deterministic behavior (a simple DIFF against baselines is not clear enough: are baselines simply not blessed or is the PR causing DIFFs?)