### PR TITLE
EAMxx: improve horiz/vert contraction tests

### DIFF
--- a/components/eamxx/src/share/field/field_utils.hpp
+++ b/components/eamxx/src/share/field/field_utils.hpp
@@ -131,24 +131,24 @@ void horiz_contraction(const Field &f_out, const Field &f_in,
   // Sanity checks before handing off to the implementation
   EKAT_REQUIRE_MSG(l_w.rank() == 1,
                    "Error! The weight field must be rank-1.\n"
-                   "The input has rank "
+                   "The input weight has rank "
                        << l_w.rank() << ".\n");
   EKAT_REQUIRE_MSG(l_w.tags() == std::vector<FieldTag>({COL}),
                    "Error! The weight field must have a column dimension.\n"
-                   "The input f1 layout is "
+                   "The input field has layout "
                        << l_w.tags() << ".\n");
   EKAT_REQUIRE_MSG(l_in.rank() <= 3,
                    "Error! The input field must be at most rank-3.\n"
-                   "The input f_in rank is "
+                   "The input field's rank is "
                        << l_in.rank() << ".\n");
   EKAT_REQUIRE_MSG(l_in.tags()[0] == COL,
                    "Error! The input field must have a column dimension.\n"
-                   "The input f_in layout is "
+                   "The input field's layout is "
                        << l_in.to_string() << ".\n");
   EKAT_REQUIRE_MSG(
       l_w.dim(0) == l_in.dim(0),
       "Error! input and weight fields must have the same dimension along "
-      "which we are taking the reducing the field.\n"
+      "which we are reducing the field.\n"
       "The weight field has dimension "
           << l_w.dim(0)
           << " while "
@@ -157,20 +157,20 @@ void horiz_contraction(const Field &f_out, const Field &f_in,
   EKAT_REQUIRE_MSG(
       l_in.dim(0) > 0,
       "Error! The input field must have a non-zero column dimension.\n"
-      "The input f_in layout is "
+      "The input field's layout is "
           << l_in.to_string() << ".\n");
   EKAT_REQUIRE_MSG(
       l_out == l_in.clone().strip_dim(0),
       "Error! The output field must have the same layout as the input field "
       "without the column dimension.\n"
-      "The input f_in layout is "
-          << l_in.to_string() << " and the output f_out layout is "
+      "The input field's layout is "
+          << l_in.to_string() << " and the output field's layout is "
           << l_out.to_string() << ".\n");
   EKAT_REQUIRE_MSG(
       f_out.is_allocated() && f_in.is_allocated() && weight.is_allocated(),
       "Error! All fields must be allocated.");
   EKAT_REQUIRE_MSG(f_out.data_type() == f_in.data_type(),
-                   "Error! In/out Fields have matching data types.");
+                   "Error! In/out fields have matching data types.");
   EKAT_REQUIRE_MSG(
       f_out.data_type() == weight.data_type(),
       "Error! Weight field must have the same data type as input fields.");
@@ -258,7 +258,7 @@ void vert_contraction(const Field &f_out, const Field &f_in,
       f_out.is_allocated() && f_in.is_allocated() && weight.is_allocated(),
       "Error! All fields must be allocated.");
   EKAT_REQUIRE_MSG(f_out.data_type() == f_in.data_type(),
-                   "Error! In/out Fields have matching data types.");
+                   "Error! In/out fields have matching data types.");
   EKAT_REQUIRE_MSG(
       f_out.data_type() == weight.data_type(),
       "Error! Weight field must have the same data type as input field.");

--- a/components/eamxx/src/share/field/field_utils.hpp
+++ b/components/eamxx/src/share/field/field_utils.hpp
@@ -170,7 +170,7 @@ void horiz_contraction(const Field &f_out, const Field &f_in,
       f_out.is_allocated() && f_in.is_allocated() && weight.is_allocated(),
       "Error! All fields must be allocated.");
   EKAT_REQUIRE_MSG(f_out.data_type() == f_in.data_type(),
-                   "Error! In/out fields have matching data types.");
+                   "Error! In/out fields must have matching data types.");
   EKAT_REQUIRE_MSG(
       f_out.data_type() == weight.data_type(),
       "Error! Weight field must have the same data type as input fields.");
@@ -258,7 +258,7 @@ void vert_contraction(const Field &f_out, const Field &f_in,
       f_out.is_allocated() && f_in.is_allocated() && weight.is_allocated(),
       "Error! All fields must be allocated.");
   EKAT_REQUIRE_MSG(f_out.data_type() == f_in.data_type(),
-                   "Error! In/out fields have matching data types.");
+                   "Error! In/out fields must have matching data types.");
   EKAT_REQUIRE_MSG(
       f_out.data_type() == weight.data_type(),
       "Error! Weight field must have the same data type as input field.");

--- a/components/eamxx/src/share/tests/field_utils.cpp
+++ b/components/eamxx/src/share/tests/field_utils.cpp
@@ -127,13 +127,16 @@ TEST_CASE("utils") {
   }
 
   SECTION("horiz_contraction") {
+    // A numerical tolerance
+    auto tol = std::numeric_limits<Real>::epsilon() * 100;
+
     using RPDF  = std::uniform_real_distribution<Real>;
     auto engine = setup_random_test();
     RPDF pdf(0, 1);
 
-    int dim0 = 3;
-    int dim1 = 9;
-    int dim2 = 2;
+    int dim0 = 9;
+    int dim1 = 4;
+    int dim2 = 7;
 
     // Set a weight field
     FieldIdentifier f00("f", {{COL}, {dim0}}, m / s, "g");
@@ -142,7 +145,9 @@ TEST_CASE("utils") {
     field00.sync_to_host();
     auto v00 = field00.get_strided_view<Real *, Host>();
     for(int i = 0; i < dim0; ++i) {
-      v00(i) = (i + 1) / sp(6);
+      // By design, denominator is the sum of the first dim0 integers
+      // (analytically known)
+      v00(i) = sp(i + 1) / sp(dim0 * (dim0 + 1) / 2);
     }
     field00.sync_to_dev();
 
@@ -195,7 +200,12 @@ TEST_CASE("utils") {
     horiz_contraction<Real>(result, field00, field00);
     result.sync_to_host();
     auto v = result.get_view<Real, Host>();
-    REQUIRE(v() == (1 / sp(36) + 4 / sp(36) + 9 / sp(36)));
+    // The numerator is the sum of the squares of the first dim0 integers
+    // (analytically known). The denominator is the sum of the first dim0
+    // integers squared (analytically known)
+    Real wavg = sp(dim0 * (dim0 + 1) * (2 * dim0 + 1) / 6) /
+                sp((dim0 * (dim0 + 1) / 2) * (dim0 * (dim0 + 1) / 2));
+    REQUIRE_THAT(v(), Catch::Matchers::WithinRel(wavg, tol));
 
     // Test higher-order cases
     result = field_z.clone();
@@ -219,24 +229,28 @@ TEST_CASE("utils") {
 
     // Check a 3D case
     field20.sync_to_host();
+    result.sync_to_host();
     auto manual_result = result.clone();
     manual_result.deep_copy(0);
     manual_result.sync_to_host();
     auto v2 = field20.get_strided_view<Real ***, Host>();
     auto mr = manual_result.get_strided_view<Real **, Host>();
-    for(int i = 0; i < dim0; ++i) {
-      for(int j = 0; j < dim1; ++j) {
-        for(int k = 0; k < dim2; ++k) {
+    auto rr = result.get_strided_view<Real **, Host>();
+
+    for(int j = 0; j < dim1; ++j) {
+      for(int k = 0; k < dim2; ++k) {
+        for(int i = 0; i < dim0; ++i) {
           mr(j, k) += v00(i) * v2(i, j, k);
         }
+        REQUIRE_THAT(rr(j, k), Catch::Matchers::WithinRel(mr(j, k), tol));
       }
     }
-    field20.sync_to_dev();
-    manual_result.sync_to_dev();
-    REQUIRE(views_are_equal(result, manual_result));
   }
 
   SECTION("vert_contraction") {
+    // A numerical tolerance
+    auto tol = std::numeric_limits<Real>::epsilon() * 100;
+
     std::vector<FieldTag> lev_tags = {LEV, ILEV};
     // iterate over lev_tags
     for(auto lev_tag : lev_tags) {
@@ -244,11 +258,10 @@ TEST_CASE("utils") {
       auto engine = setup_random_test();
       RPDF pdf(0, 1);
 
-      int dim0 = 4;
+      int dim0 = 8;
       int dim1 = 9;
       // Note that parallel reduction is happening over dim2 (LEV/ILEV)
-      // If it is more than 3, the order of ops will lead to non-bfb results
-      int dim2 = lev_tag == LEV ? 3 : 3; 
+      int dim2 = lev_tag == LEV ? 5 : 6;
 
       // Set a weight field
       FieldIdentifier f00("f", {{lev_tag}, {dim2}}, m / s, "g");
@@ -257,8 +270,9 @@ TEST_CASE("utils") {
       field00.sync_to_host();
       auto v00 = field00.get_strided_view<Real *, Host>();
       for(int i = 0; i < dim2; ++i) {
-        // denominator is the sum of the first dim2 integers (analytically known)
-        v00(i) = sp(i + 1) / sp(dim2*(dim2+1)/2);
+        // The denominator is the sum of the first dim2 integers (analytically
+        // known)
+        v00(i) = sp(i + 1) / sp(dim2 * (dim2 + 1) / 2);
       }
       field00.sync_to_dev();
 
@@ -305,14 +319,15 @@ TEST_CASE("utils") {
       Field result;
 
       // Add test for invalid rank-2 weight field layout
-      FieldIdentifier bad_w("bad_w", {{CMP, lev_tag}, {dim1, dim2}}, m / s, "g");
+      FieldIdentifier bad_w("bad_w", {{CMP, lev_tag}, {dim1, dim2}}, m / s,
+                            "g");
       Field bad_weight(bad_w);
       bad_weight.allocate_view();
       REQUIRE_THROWS(vert_contraction<Real>(result, field20, bad_weight));
 
       // Add test for mismatched weight field dimensions
-      FieldIdentifier wrong_size_w("wrong_w", {{COL, lev_tag}, {dim0 + 1, dim2}},
-                                   m / s, "g");
+      FieldIdentifier wrong_size_w(
+          "wrong_w", {{COL, lev_tag}, {dim0 + 1, dim2}}, m / s, "g");
       Field wrong_weight(wrong_size_w);
       wrong_weight.allocate_view();
       REQUIRE_THROWS(vert_contraction<Real>(result, field20, wrong_weight));
@@ -322,9 +337,12 @@ TEST_CASE("utils") {
       vert_contraction<Real>(result, field00, field00);
       result.sync_to_host();
       auto v = result.get_view<Real, Host>();
-      // numerator is the sum of the suqares of the first dim2 integers (analytically known)
-      // denominator is the sum of the first dim2 integers squared (analytically known)
-      REQUIRE(v() == sp(dim2*(dim2+1)*(2*dim2+1)/6) / sp((dim2*(dim2+1)/2)*(dim2*(dim2+1)/2)));
+      // The numerator is the sum of the squares of the first dim2 integers
+      // (analytically known). The denominator is the sum of the first dim2
+      // integers squared (analytically known)
+      Real havg = sp(dim2 * (dim2 + 1) * (2 * dim2 + 1) / 6) /
+                  sp((dim2 * (dim2 + 1) / 2) * (dim2 * (dim2 + 1) / 2));
+      REQUIRE_THAT(v(), Catch::Matchers::WithinRel(havg, tol));
 
       // Test higher-order cases
       result = field_x.clone();
@@ -335,19 +353,19 @@ TEST_CASE("utils") {
 
       // Check a 2D case with 1D weight
       field10.sync_to_host();
+      result.sync_to_host();
       auto manual_result = result.clone();
       manual_result.deep_copy(0);
       manual_result.sync_to_host();
       auto v1 = field10.get_strided_view<Real **, Host>();
       auto mr = manual_result.get_strided_view<Real *, Host>();
+      auto rr = result.get_strided_view<Real *, Host>();
       for(int i = 0; i < dim0; ++i) {
         for(int j = 0; j < dim2; ++j) {
           mr(i) += v00(j) * v1(i, j);
         }
+        REQUIRE_THAT(rr(i), Catch::Matchers::WithinRel(mr(i), tol));
       }
-      field11.sync_to_dev();
-      manual_result.sync_to_dev();
-      REQUIRE(views_are_equal(result, manual_result));
 
       result = field_y.clone();
       vert_contraction<Real>(result, field11, field00);
@@ -370,16 +388,15 @@ TEST_CASE("utils") {
       manual_result.sync_to_host();
       auto v2  = field20.get_strided_view<Real ***, Host>();
       auto mr2 = manual_result.get_strided_view<Real **, Host>();
+      auto rr2 = result.get_strided_view<Real **, Host>();
       for(int i = 0; i < dim0; ++i) {
         for(int j = 0; j < dim1; ++j) {
           for(int k = 0; k < dim2; ++k) {
             mr2(i, j) += v00(k) * v2(i, j, k);
           }
+          REQUIRE_THAT(rr2(i, j), Catch::Matchers::WithinRel(mr2(i, j), tol));
         }
       }
-      field20.sync_to_dev();
-      manual_result.sync_to_dev();
-      REQUIRE(views_are_equal(result, manual_result));
 
       // Check a 3D case with 2D weight
       result = field_z.clone();
@@ -395,16 +412,15 @@ TEST_CASE("utils") {
       manual_result.deep_copy(0);
       manual_result.sync_to_host();
       auto mr3 = manual_result.get_strided_view<Real **, Host>();
+      auto rr3 = result.get_strided_view<Real **, Host>();
       for(int i = 0; i < dim0; ++i) {
         for(int j = 0; j < dim1; ++j) {
           for(int k = 0; k < dim2; ++k) {
             mr3(i, j) += v1(i, k) * v2(i, j, k);
           }
+          REQUIRE_THAT(rr3(i, j), Catch::Matchers::WithinRel(mr3(i, j), tol));
         }
       }
-      field20.sync_to_dev();
-      manual_result.sync_to_dev();
-      REQUIRE(views_are_equal(result, manual_result));
     }
   }
 


### PR DESCRIPTION
imrpoves contraction testing by using catch2 matchers to allow for tolerance and expand contracted dimensions.

Fixes #6893