### PR TITLE
Update CIME submodule

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2315,6 +2315,7 @@
       <cmd_path lang="csh">module</cmd_path>
       <modules>
         <command name="purge"/>
+        <command name="load">python/3.9.16-gm6ql7v</command>
         <command name="load">cmake/3.26.3-nszudya</command>
       </modules>
       <modules compiler="intel">
@@ -2446,6 +2447,7 @@
       <cmd_path lang="csh">module</cmd_path>
       <modules>
         <command name="purge"/>
+        <command name="load">python/3.11.7-iexc6vq</command>
         <command name="load">subversion/1.14.0-e4smcy3</command>
         <command name="load">perl/5.32.0-bsnc6lt</command>
         <command name="load">cmake/3.24.2-whgdv7y</command>
@@ -3368,6 +3370,7 @@
        <cmd_path lang="csh">module</cmd_path>
        <cmd_path lang="python">/soft/sunspot_migrate/soft/packaging/lmod/lmod/libexec/lmod python</cmd_path>
        <modules>
+          <command name="load">python</command>
           <command name="load">cmake</command>
         </modules>
         <modules compiler="!gnu">

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -228,7 +228,7 @@ _TESTS = {
         "tests" : (
             "SMS_Lm1.ne4pg2_oQU480.F2010",
             "ERS_Ld31.ne4pg2_oQU480.F2010",
-            "ERP_Lm3.ne4pg2_oQU480.F2010",
+            "ERP_Ld90.ne4pg2_oQU480.F2010",
             "SMS_D_Ln5.ne30pg2_r05_IcoswISC30E3r5.F2010",
             "ERP_Ld3.ne30pg2_r05_IcoswISC30E3r5.F2010.allactive-pioroot1",
             "SMS_Ly1.ne4pg2_oQU480.F2010",
@@ -450,8 +450,8 @@ _TESTS = {
         "time"    : "00:40:00",
         "tests"   : (
             "SMS_D_Lm6.f45_g37.IELMFATES.elm-fates_cold",
-            "ERS_D_Lm13.ne4pg2_ne4pg2.IELMFATES.elm-fates_long",
-            "ERS_Lm25.ne4pg2_ne4pg2.IELMFATES.elm-fates_cold_nocomp",
+            "ERS_D_Ld390.ne4pg2_ne4pg2.IELMFATES.elm-fates_long",
+            "ERS_Ld750.ne4pg2_ne4pg2.IELMFATES.elm-fates_cold_nocomp",
             )
         },
 


### PR DESCRIPTION
... to 954266b46ec8e32ea222322602d7fcff76d3bf5a

Fixes:
1) fix the restart tests by using ceil instead of int
2) Fix for PES append feature
3) MVK/PGN: Import the shutil module rather than the "shutils" module typo
4) Fix BFAILs, they need to be considered DIFF
5) avoid breaking Python environment by prepending CIME paths to PYTHONPATH
6) Remove distutils
7) Fixes test status reporting errors during successful baseline comparison
8) check_input_data: skip three files when staging refcase files to avoid a rmtree error
9) Fix multidriver for MCT: logic was incorrect
10) Fixes compare_xml method for env_batch
11) fix correction for no_leap calendar in tests
12) correct rpointer name in resubmit
13) create_clone: correct the SRCROOT path when using create_clone

Changes:
1) create_test: add --driver support for e3sm
2) make the hidden status of batch jobs xml dependent
3) Mark SETUP as FAIL if case.cmpgen_namelists fails 
4) improve functionality of hidden workflow flag
5) refine the git interface to handle no git and old git
6) do not report memcomp if no baseline exists
7) clarify prereq option in case.submit
8) Add mem variables to env_batch
9) Updates MVK SystemTest to be configurable via testmod
10) If batch script is already executable, don't chmod it
11) Add timing to git operations
12) Add timestamp to rpointers
13) case.run: add try except clauses to reduce errors in testing
14) jenkins: Canceling batch jobs needs to happen immediately when a signal occurs.
15) bless_test_results: Add option to lock baselines (remove group write)

[BFB]