### PR TITLE
EAMxx: change extrapolation of SPA fields at the top of the atm

### DIFF
--- a/components/eamxx/src/diagnostics/tests/horiz_avg_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/horiz_avg_test.cpp
@@ -29,10 +29,6 @@ std::shared_ptr<GridsManager> create_gm(const ekat::Comm &comm, const int ncols,
 TEST_CASE("horiz_avg") {
   using namespace ShortFieldTagsNames;
   using namespace ekat::units;
-  using TeamPolicy = Kokkos::TeamPolicy<Field::device_t::execution_space>;
-  using TeamMember = typename TeamPolicy::member_type;
-  using KT         = ekat::KokkosTypes<DefaultDevice>;
-  using ESU        = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
 
   // A numerical tolerance
   auto tol = std::numeric_limits<Real>::epsilon() * 100;

--- a/components/eamxx/src/physics/spa/spa_functions_impl.hpp
+++ b/components/eamxx/src/physics/spa/spa_functions_impl.hpp
@@ -521,14 +521,14 @@ void SPAFunctions<S,D>
     // Set the first/last entries of the spa data, so that linear interp
     // can extrapolate if the p_tgt is outside the p_src bounds
     Kokkos::single(Kokkos::PerTeam(team),[&]{
-      spa_data_ccn3(icol,0) = 0;
+      spa_data_ccn3(icol,0) = ccn3(icol,0);
       for (int isw=0; isw<nswbands; ++isw) {
-        spa_data_aero_g_sw(icol,isw,0)   = 0;
-        spa_data_aero_ssa_sw(icol,isw,0) = 0;
-        spa_data_aero_tau_sw(icol,isw,0) = 0;
+        spa_data_aero_g_sw(icol,isw,0)   = aero_g_sw(icol,isw,0);
+        spa_data_aero_ssa_sw(icol,isw,0) = aero_ssa_sw(icol,isw,0);
+        spa_data_aero_tau_sw(icol,isw,0) = aero_tau_sw(icol,isw,0);
       }
       for (int ilw=0; ilw<nlwbands; ++ilw) {
-        spa_data_aero_tau_lw(icol,ilw,0) = 0;
+        spa_data_aero_tau_lw(icol,ilw,0) = aero_tau_lw(icol,ilw,0);
       }
       spa_data_ccn3(icol,nlevs+1) = ccn3(icol,nlevs-1);
       for (int isw=0; isw<nswbands; ++isw) {

--- a/components/eamxx/src/physics/spa/tests/spa_one_to_one_remap_test.cpp
+++ b/components/eamxx/src/physics/spa/tests/spa_one_to_one_remap_test.cpp
@@ -123,16 +123,19 @@ Real ccn3_func(const int t, const gid_type i, const int klev)
 //
 Real aer_func(const int t, const gid_type i, const int bnd, const int klev, const int mode)
 {
+  Real ret = -1;
   if (mode==0) {  // G
-    return  t;
+    ret = t;
   } else if (mode==1) { // SSA
-    return  i;
+    ret = i;
   } else if (mode==2) { // TAU
-    return  bnd;
+    ret = bnd;
   } else if (mode==3) { // LW-TAU
-    return  klev;
+    ret = klev;
+  } else {
+    EKAT_REQUIRE_MSG(false,"Error in aer_func, incorrect mode passed"); // Shouldn't get here, but just in case
   }
-  EKAT_REQUIRE_MSG(false,"Error in aer_func, incorrect mode passed"); // Shouldn't get here, but just in case
+  return ret;
 } // aer_func
 
 } // namespace

--- a/components/eamxx/src/share/field/field_utils.hpp
+++ b/components/eamxx/src/share/field/field_utils.hpp
@@ -11,16 +11,18 @@ inline bool views_are_equal(const Field& f1, const Field& f2, const ekat::Comm* 
   EKAT_REQUIRE_MSG (f1.data_type()==f2.data_type(),
       "Error! Views have different data types.\n");
 
+  bool ret = false;
   switch (f1.data_type()) {
     case DataType::IntType:
-      return impl::views_are_equal<const int>(f1,f2,comm);
+      ret = impl::views_are_equal<const int>(f1,f2,comm); break;
     case DataType::FloatType:
-      return impl::views_are_equal<const float>(f1,f2,comm);
+      ret = impl::views_are_equal<const float>(f1,f2,comm); break;
     case DataType::DoubleType:
-      return impl::views_are_equal<const double>(f1,f2,comm);
+      ret = impl::views_are_equal<const double>(f1,f2,comm); break;
     default:
       EKAT_ERROR_MSG ("Error! Unrecognized field data type.\n");
   }
+  return ret;
 }
 
 template<typename Engine, typename PDF>


### PR DESCRIPTION
Do constant extrapolation rather than linear ramp down to 0 (for p=0).

---

The goal is to change to an extrapolation that is currently handled by `VerticalRemapper`, so that, later, we can switch SPA to use `DataInterpolation` and see no diffs.

The change will likely have a very minimal effect (if any). Looking at our SPA input file, I notice that hyam(0)~1e-4, hybm(0)=0, and P0=100,000 which means the data at lev=0 is assumed to be at p~10Pa. SCRAM TOM pressure is ~225Pa, if I understand correctly, so extrapolation outside of the input data range never occurs in practice. We may not even see a DIFF in the CI/dashboard tests... Nevertheless, I added the non-BFB label, since in theory it is non BFB.

Note: all changes except in `spa_functions_impl.hpp` are just to fix some compiler warnings.