### PR TITLE
Add support for BGWCYCL20TR compset

### DIFF
--- a/cime_config/allactive/config_compsets.xml
+++ b/cime_config/allactive/config_compsets.xml
@@ -459,6 +459,11 @@
   <lname>1850_EAM%CMIP6_ELM%SPBC_MPASSI_MPASO_MOSART_MALI_SWAV</lname>
 </compset>
 
+<compset>
+  <alias>BGWCYCL20TR</alias>
+  <lname>20TRSOI_EAM%CMIP6_ELM%CNPRDCTCBCTOP_MPASSI_MPASO_MOSART_MALI_SWAV</lname>
+</compset>
+
 <!-- EAMXX fully coupled compset -->
 
 <compset>


### PR DESCRIPTION
This PR adds support for a v3, WCYCL-like 20TR compset, but including an active glc component (MALI). 

Currently, this allows for an active / dynamic Greenland component only.