### PR TITLE
EAMxx: add IOPRemapper and use it in SPA and IOPDataManager

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.hpp
+++ b/components/eamxx/src/control/atmosphere_driver.hpp
@@ -185,21 +185,10 @@ protected:
   void set_initial_conditions ();
   void restart_model ();
 
-  // Read fields from a file when the names of the fields in
-  // EAMxx do not match exactly with the .nc file. Example is
-  // for topography data files, where GLL and PG2 grid have
-  // different naming conventions for phis.
-  void read_fields_from_file (const std::vector<std::string>& field_names_nc,
-                              const std::vector<std::string>& field_names_eamxx,
+  // Read fields from a file
+  void read_fields_from_file (const std::vector<Field>& fields,
                               const std::shared_ptr<const AbstractGrid>& grid,
-                              const std::string& file_name,
-                              const util::TimeStamp& t0);
-  // Read fields from a file when the names of the fields in
-  // EAMxx match with the .nc file.
-  void read_fields_from_file (const std::vector<std::string>& field_names,
-                              const std::shared_ptr<const AbstractGrid>& grid,
-                              const std::string& file_name,
-                              const util::TimeStamp& t0);
+                              const std::string& file_name);
   void register_groups ();
 
   std::map<std::string,field_mgr_ptr>       m_field_mgrs;

--- a/components/eamxx/src/physics/spa/eamxx_spa_process_interface.hpp
+++ b/components/eamxx/src/physics/spa/eamxx_spa_process_interface.hpp
@@ -79,8 +79,6 @@ protected:
 
   // IO structure to read in data for standard grids (keep it around to avoid re-creating PIO decomps)
   std::shared_ptr<AtmosphereInput>   SPADataReader;
-  // Similar to above, but stores info to read data for IOP grid
-  std::shared_ptr<SPAFunc::IOPReader>  SPAIOPDataReader;
 
   // Structures to store the data used for interpolation
   std::shared_ptr<AbstractRemapper>  SPAHorizInterp;

--- a/components/eamxx/src/physics/spa/tests/spa_one_to_one_remap_test.cpp
+++ b/components/eamxx/src/physics/spa/tests/spa_one_to_one_remap_test.cpp
@@ -47,8 +47,6 @@ TEST_CASE("spa_one_to_one_remap","spa")
   // Create spa data reader
   auto reader = SPAFunc::create_spa_data_reader(remapper,spa_data_file);
   // TODO: We can add lat/lon to spa_data_file and test the impl for IOP
-  util::TimeStamp dummy_ts;
-  std::shared_ptr<SPAFunc::IOPReader> dummy_iop_reader;
 
   // Recall, SPA data is padded, so we initialize with 2 more levels than the source data file.
   SPAFunc::SPAInput spa_data(grid_model->get_num_local_dofs(), nlevs+2, nswbands, nlwbands);
@@ -80,7 +78,7 @@ TEST_CASE("spa_one_to_one_remap","spa")
 
   const int max_time = 3;
   for (int time_index = 0;time_index<max_time; time_index++) {
-    SPAFunc::update_spa_data_from_file(reader, dummy_iop_reader, dummy_ts, time_index, *remapper, spa_data);
+    SPAFunc::update_spa_data_from_file(*reader, time_index, *remapper, spa_data);
     Kokkos::deep_copy(ps_h,ps_d);
     Kokkos::deep_copy(ccn3_h,ccn3_d);
     Kokkos::deep_copy(aer_g_sw_h,aer_g_sw_d);

--- a/components/eamxx/src/physics/spa/tests/spa_read_data_from_file_test.cpp
+++ b/components/eamxx/src/physics/spa/tests/spa_read_data_from_file_test.cpp
@@ -45,8 +45,6 @@ TEST_CASE("spa_read_data","spa")
   // Create spa data reader
   auto reader = SPAFunc::create_spa_data_reader(remapper,spa_data_file);
   // TODO: We can add lat/lon to spa_data_file and test the impl for IOP
-  std::shared_ptr<SPAFunc::IOPReader> dummy_iop_reader;
-  util::TimeStamp dummy_iop_ts;
 
   // Recall, SPA data is padded, so we initialize with 2 more levels than the source data file.
   SPAFunc::SPAInput spa_data(grid_model->get_num_local_dofs(), nlevs+2, nswbands, nlwbands);
@@ -76,7 +74,7 @@ TEST_CASE("spa_read_data","spa")
 
   const int max_time = 3;
   for (int time_index = 0;time_index<max_time; time_index++) {
-    SPAFunc::update_spa_data_from_file(reader, dummy_iop_reader, dummy_iop_ts, time_index, *remapper, spa_data);
+    SPAFunc::update_spa_data_from_file(*reader, time_index, *remapper, spa_data);
 
     Kokkos::deep_copy(ps_h,        ps_d);
     Kokkos::deep_copy(ccn3_h,      ccn3_d);

--- a/components/eamxx/src/share/CMakeLists.txt
+++ b/components/eamxx/src/share/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SHARE_SRC
   grid/remap/coarsening_remapper.cpp
   grid/remap/horiz_interp_remapper_base.cpp
   grid/remap/horiz_interp_remapper_data.cpp
+  grid/remap/iop_remapper.cpp
   grid/remap/identity_remapper.cpp
   grid/remap/refining_remapper_p2p.cpp
   grid/remap/vertical_remapper.cpp

--- a/components/eamxx/src/share/atm_process/IOPDataManager.cpp
+++ b/components/eamxx/src/share/atm_process/IOPDataManager.cpp
@@ -1,4 +1,5 @@
 #include "share/grid/point_grid.hpp"
+#include "share/grid/remap/iop_remapper.hpp"
 #include "share/io/scorpio_input.hpp"
 #include "share/io/scream_scorpio_interface.hpp"
 #include "share/atm_process/IOPDataManager.hpp"
@@ -7,22 +8,6 @@
 #include "ekat/util/ekat_lin_interp.hpp"
 
 #include <numeric>
-
-// Extend ekat mpi type for <Real,int> pairs,
-// used for reduction of type MPI_MINLOC.
-namespace ekat {
-#ifdef SCREAM_DOUBLE_PRECISION
-  template<>
-  MPI_Datatype get_mpi_type<std::pair<double, int>> () {
-    return MPI_DOUBLE_INT;
-  }
-#else
-  template<>
-  MPI_Datatype get_mpi_type<std::pair<float, int>> () {
-    return MPI_FLOAT_INT;
-  }
-#endif
-}
 
 namespace scream {
 namespace control {
@@ -99,7 +84,7 @@ initialize_iop_file(const util::TimeStamp& run_t0,
   //                  First entry will be the variable name used when accessing in class
   //   - fl:          IOP field layout (acceptable ranks: 0, 1)
   //   - srf_varname: Name of surface variable potentially in iop file associated with iop variable.
-  auto setup_iop_field = [&, this] (const vos&         varnames,
+  auto setup_iop_field = [&, this] (const std::vector<std::string>& varnames,
                                     const FieldLayout& fl,
                                     const std::string& srf_varname = "none") {
     EKAT_REQUIRE_MSG(fl.rank() == 0 || fl.rank() == 1,
@@ -321,184 +306,62 @@ setup_io_info(const std::string& file_name,
     // IO grid needs to have ncol dimension equal to the IC/topo file
     const auto nc_file_ncols = scorpio::get_dimlen(file_name, "ncol");
     const auto nlevs = grid->get_num_vertical_levels();
-    m_io_grids[grid_name] = create_point_grid(grid_name,
-                                              nc_file_ncols,
-                                              nlevs,
-                                              m_comm);
-  }
+    auto grid = create_point_grid(grid_name,nc_file_ncols,nlevs,m_comm);
 
-  // Store closest lat/lon info for this grid if doesn't exist
-  if (m_lat_lon_info.count(grid_name) == 0) {
-    const auto& io_grid = m_io_grids[grid_name];
+    // Read lat/lon fields from dile
+    auto lat = grid->create_geometry_data("lat",grid->get_2d_scalar_layout());
+    auto lon = grid->create_geometry_data("lon",grid->get_2d_scalar_layout());
+    AtmosphereInput latlon_reader (file_name,grid,{lat,lon});
+    latlon_reader.read_variables();
 
-    // Create lat/lon fields
-    const auto ncols = io_grid->get_num_local_dofs();
-    std::vector<Field> fields;
-
-    FieldIdentifier lat_fid("lat",
-                            FieldLayout({FieldTag::Column},{ncols}),
-                            ekat::units::Units::nondimensional(),
-                            grid_name);
-    Field lat_f(lat_fid);
-    lat_f.allocate_view();
-    fields.push_back(lat_f);
-
-    FieldIdentifier lon_fid("lon",
-                            FieldLayout({FieldTag::Column},{ncols}),
-                            ekat::units::Units::nondimensional(),
-                            grid_name);
-    Field lon_f(lon_fid);
-    lon_f.allocate_view();
-    fields.push_back(lon_f);
-
-    // Read from file
-    AtmosphereInput file_reader(file_name, io_grid, fields);
-    file_reader.read_variables();
-    file_reader.finalize();
-
-    // Find column index of closest lat/lon to target_lat/lon params
-    auto lat_v = fields[0].get_view<Real*>();
-    auto lon_v = fields[1].get_view<Real*>();
-    const auto target_lat = m_params.get<Real>("target_latitude");
-    const auto target_lon = m_params.get<Real>("target_longitude");
-    using minloc_t = Kokkos::MinLoc<Real,int>;
-    using minloc_value_t = typename minloc_t::value_type;
-    minloc_value_t minloc;
-    Kokkos::parallel_reduce(ncols, KOKKOS_LAMBDA (int icol, minloc_value_t& result) {
-      auto dist = std::abs(lat_v(icol)-target_lat)+std::abs(lon_v(icol)-target_lon);
-      if(dist<result.val) {
-        result.val = dist;
-        result.loc = icol;
-      }
-    }, minloc_t(minloc));
-
-    // Find processor with closest lat/lon match
-    const auto my_rank = m_comm.rank();
-    std::pair<Real, int> min_dist_and_rank = {minloc.val, my_rank};
-    m_comm.all_reduce<std::pair<Real, int>>(&min_dist_and_rank, 1, MPI_MINLOC);
-
-    // Broadcast closest lat/lon values to all ranks
-    const auto lat_v_h = lat_f.get_view<Real*,Host>();
-    const auto lon_v_h = lon_f.get_view<Real*,Host>();
-    auto local_column_idx = minloc.loc;
-    auto min_dist_rank = min_dist_and_rank.second;
-    Real lat_lon_vals[2];
-    if (my_rank == min_dist_rank) {
-      lat_lon_vals[0] = lat_v_h(local_column_idx);
-      lat_lon_vals[1] = lon_v_h(local_column_idx);
-    }
-    m_comm.broadcast(lat_lon_vals, 2, min_dist_rank);
-
-    // Set local_column_idx=-1 for mpi ranks not containing minimum lat/lon distance
-    if (my_rank != min_dist_rank) local_column_idx = -1;
-
-    // Store closest lat/lon info for this grid, used later when reading ICs
-    m_lat_lon_info[grid_name] = ClosestLatLonInfo{lat_lon_vals[0], lat_lon_vals[1], min_dist_rank, local_column_idx};
+    m_io_grids[grid_name] = grid;
   }
 }
 
 void IOPDataManager::
 read_fields_from_file_for_iop (const std::string& file_name,
-                               const vos& field_names_nc,
-                               const vos& field_names_eamxx,
-                               const util::TimeStamp& initial_ts,
-                               const field_mgr_ptr field_mgr,
-                               const int time_index)
+                               const std::vector<Field>& fields,
+                               const std::shared_ptr<const AbstractGrid>& grid)
 {
-  const auto dummy_units = ekat::units::Units::nondimensional();
-
-  EKAT_REQUIRE_MSG(field_names_nc.size()==field_names_eamxx.size(),
-                  "Error! Field name arrays must have same size.\n");
-
-  if (field_names_nc.size()==0) {
+  if (fields.size()==0) {
+    // Does this ever happen?
     return;
   }
 
-  const auto& grid_name = field_mgr->get_grid()->name();
-  EKAT_REQUIRE_MSG(m_io_grids.count(grid_name) > 0,
-                   "Error! Attempting to read IOP initial conditions on "
-                   +grid_name+" grid, but m_io_grid entry has not been created.\n");
-  EKAT_REQUIRE_MSG(m_lat_lon_info.count(grid_name) > 0,
-                   "Error! Attempting to read IOP initial conditions on "
-                   +grid_name+" grid, but m_lat_lon_info entry has not been created.\n");
+  auto io_grid = m_io_grids[grid->name()];
+  EKAT_REQUIRE_MSG(io_grid!=nullptr,
+      "Error! Attempting to read IOP initial conditions on" +
+      grid->name() + " grid, but m_io_grid entry has not been created.\n");
 
-  auto io_grid = m_io_grids[grid_name];
-  if (grid_name=="Physics GLL" && scorpio::has_dim(file_name,"ncol_d")) {
-    // If we are on GLL grid, and nc file contains "ncol_d" dimension,
-    // we need to reset COL dim tag
-    using namespace ShortFieldTagsNames;
+  if (grid->name()=="Physics GLL" and scorpio::has_dim(file_name,"ncol_d")) {
+    // If we are on GLL grid, and nc file contains "ncol_d" dimension, we need to reset COL dim tag
     auto grid = io_grid->clone(io_grid->name(),true);
-    grid->reset_field_tag_name(COL,"ncol_d");
+    grid->reset_field_tag_name(FieldTag::Column,"ncol_d");
     io_grid = grid;
   }
 
-  // Create vector of fields with correct dimensions to read from file
-  std::vector<Field> io_fields;
-  for (size_t i=0; i<field_names_nc.size(); ++i) {
-    const auto& nc_name    = field_names_nc[i];
-    const auto& eamxx_name = field_names_eamxx[i];
-    const auto& fm_field = eamxx_name!=nc_name
-                           ?
-                           field_mgr->get_field(eamxx_name).alias(nc_name)
-                           :
-                           field_mgr->get_field(eamxx_name);
-    auto fm_fid = fm_field.get_header().get_identifier();
-    EKAT_REQUIRE_MSG(fm_fid.get_layout().tag(0)==FieldTag::Column,
-                     "Error! IOP inputs read from IC/topo file must have Column "
-                     "as first dim tag.\n");
+  // Create IOP remapper
+  const auto lat = m_params.get<Real>("target_latitude");
+  const auto lon = m_params.get<Real>("target_longitude");
+  auto remapper = std::make_shared<IOPRemapper>(io_grid,grid,lat,lon);
 
-    // Set first dimension to match input file
-    FieldLayout io_fl = fm_fid.get_layout();
-    io_fl.reset_dim(0,io_grid->get_num_local_dofs());
-    FieldIdentifier io_fid(fm_fid.name(), io_fl, fm_fid.get_units(), io_grid->name());
-    Field io_field(io_fid);
-    io_field.allocate_view();
-    io_fields.push_back(io_field);
+  remapper->registration_begins();
+  for (const auto& f : fields) {
+    remapper->register_field_from_tgt(f);
   }
+  remapper->registration_ends();
 
-  // Read data from file
+  // Read remapper src fields (which may have different layout than fields in input vector)
+  std::vector<Field> io_fields;
+  for (int i=0; i<remapper->get_num_fields(); ++i) {
+    io_fields.push_back(remapper->get_src_field(i));
+  }
   AtmosphereInput file_reader(file_name,io_grid,io_fields);
-  file_reader.read_variables(time_index);
+  file_reader.read_variables();
   file_reader.finalize();
 
-  // For each field, broadcast data from closest lat/lon column to all processors
-  // and copy data into each field's column in the field manager.
-  for (size_t i=0; i<io_fields.size(); ++i) {
-    const auto& io_field = io_fields[i];
-    const auto& fname = field_names_eamxx[i];
-    auto& fm_field = field_mgr->get_field(fname);
-
-    // Create a temporary field to store the data from the
-    // single column of the closest lat/lon pair
-    const auto io_fid = io_field.get_header().get_identifier();
-    FieldLayout col_data_fl = io_fid.get_layout().clone().strip_dim(0);
-    FieldIdentifier col_data_fid("col_data", col_data_fl, dummy_units, "");
-    Field col_data(col_data_fid);
-    col_data.allocate_view();
-
-    // MPI rank with closest column index store column data
-    const auto mpi_rank_with_col = m_lat_lon_info[grid_name].mpi_rank_of_closest_column;
-    if (m_comm.rank() == mpi_rank_with_col) {
-      const auto col_idx_with_data = m_lat_lon_info[grid_name].local_column_index_of_closest_column;
-      col_data.deep_copy<Host>(io_field.subfield(0,col_idx_with_data));
-    }
-
-    // Broadcast column data to all other ranks
-    const auto col_size = col_data.get_header().get_identifier().get_layout().size();
-    m_comm.broadcast(col_data.get_internal_view_data<Real,Host>(), col_size, mpi_rank_with_col);
-
-    // Copy column data to all columns in field manager field
-    const auto ncols = fm_field.get_header().get_identifier().get_layout().dim(0);
-    for (auto icol=0; icol<ncols; ++icol) {
-      fm_field.subfield(0,icol).deep_copy<Host>(col_data);
-    }
-
-    // Sync fields to device
-    fm_field.sync_to_dev();
-
-    // Set the initial time stamp on FM fields
-    fm_field.get_header().get_tracking().update_time_stamp(initial_ts);
-  }
+  // Remap
+  remapper->remap_fwd();
 }
 
 void IOPDataManager::

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -163,6 +163,12 @@ subfield (const int idim, const int index, const bool dynamic) const {
   return subfield(m_header->get_identifier().name(),idim,index,dynamic);
 }
 
+Field Field::
+subfield (const FieldTag tag, const int index, const bool dynamic) const {
+  int idim = get_header().get_identifier().get_layout().dim_idx(tag);
+  return subfield(idim,index,dynamic);
+}
+
 // slice at index idim, extracting the N = (index_end - index_beg) entries
 // written in math notation: [index_beg, index_end)
 // or equivalently, subF = F(index_beg, ... , index_beg + N)

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -245,6 +245,7 @@ public:
   Field subfield (const std::string& sf_name, const int idim,
                   const int index, const bool dynamic = false) const;
   Field subfield (const int idim, const int k, const bool dynamic = false) const;
+  Field subfield (const FieldTag tag, const int k, const bool dynamic = false) const;
   // extracts a subfield composed of multiple slices in a continuous range of indices
   // e.g., (in matlab syntax) subf = f.subfield(:, 1:3, :)
   // but NOT subf = f.subfield(:, [1, 3, 4], :)

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -92,6 +92,8 @@ public:
   // The rank is the number of tags associated to this field.
   int rank () const  { return m_rank; }
 
+  int dim_idx (const FieldTag t) const;
+
   int dim (const std::string& name) const;
   int dim (const FieldTag tag) const;
   int dim (const int idim) const;
@@ -166,19 +168,19 @@ bool operator== (const FieldLayout& fl1, const FieldLayout& fl2);
 
 // ========================== IMPLEMENTATION ======================= //
 
+inline int FieldLayout::dim_idx (const FieldTag t) const {
+  // Check exactly one tag (no ambiguity)
+  EKAT_REQUIRE_MSG(ekat::count(m_tags,t)==1,
+      "Error! FieldTag::dim_idx requires that the tag appears exactly once.\n"
+      "  - field tag: " + e2str(t) + "\n"
+      "  - tag count: " + std::to_string(ekat::count(m_tags,t)) + "\n");
+
+  return std::distance(m_tags.begin(),ekat::find(m_tags,t));
+}
+
 // returns extent
 inline int FieldLayout::dim (const FieldTag t) const {
-  auto it = ekat::find(m_tags,t);
-
-  // Check if found
-  EKAT_REQUIRE_MSG(it!=m_tags.end(), "Error! Tag '" + e2str(t) + "' not found.\n");
-
-  // Check only one tag (no ambiguity)
-  EKAT_REQUIRE_MSG(ekat::count(m_tags,t)==1,
-      "Error! Tag '" + e2str(t) + "' appears multiple times.\n"
-      "       You must inspect tags() and dims() manually.\n");
-
-  return m_dims[std::distance(m_tags.begin(),it)];
+  return m_dims[dim_idx(t)];
 }
 
 inline int FieldLayout::dim (const std::string& name) const {

--- a/components/eamxx/src/share/grid/remap/iop_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/iop_remapper.cpp
@@ -1,0 +1,154 @@
+#include "share/grid/remap/iop_remapper.hpp"
+
+// Anonymous namespace, in case other TU's define the same type
+namespace {
+struct RealInt
+{
+  scream::Real val;
+  int  idx;
+};
+}
+// Specialize ekat's get_mpi_type for RealInt (needed for the all_reduce call)
+namespace ekat {
+  template<>
+  MPI_Datatype get_mpi_type<RealInt> () {
+#ifdef SCREAM_DOUBLE_PRECISION
+    return MPI_DOUBLE_INT;
+#else
+    return MPI_FLOAT_INT;
+#endif
+  }
+} // namespace ekat
+
+namespace scream
+{
+
+IOPRemapper::
+IOPRemapper (const grid_ptr_type src_grid,
+             const grid_ptr_type tgt_grid,
+             const Real lat, const Real lon)
+ : AbstractRemapper (src_grid,tgt_grid)
+{
+  m_bwd_allowed = false;
+
+  EKAT_REQUIRE_MSG (src_grid->has_geometry_data("lat") and src_grid->has_geometry_data("lon"),
+      "Error! IOP remapper requires lat/lon geometry data in the source grid.\n");
+  EKAT_REQUIRE_MSG (src_grid->get_num_vertical_levels()==tgt_grid->get_num_vertical_levels(),
+      "Error! IOP remapper requires src/tgt grid to have the same number of vertical levels.\n");
+  EKAT_REQUIRE_MSG (src_grid->type()==GridType::Point and tgt_grid->type()==GridType::Point,
+      "Error! IOP remapper requires src/tgt grid to be PointGrid instances.\n");
+  
+  m_comm = src_grid->get_comm();
+
+  setup_closest_col_info (lat,lon);
+}
+
+void IOPRemapper::
+setup_closest_col_info (const Real lat, const Real lon)
+{
+  auto lat_f = m_src_grid->get_geometry_data("lat");
+  auto lon_f = m_src_grid->get_geometry_data("lon");
+  EKAT_REQUIRE_MSG (lat_f.get_header().get_identifier().get_layout().type()==LayoutType::Scalar2D,
+      "Error! Source grid 'lat' field has the wrong layout.\n"
+      " - expected layout: " + e2str(LayoutType::Scalar2D) + "\n"
+      " - actual layout  : " + e2str(lat_f.get_header().get_identifier().get_layout().type()) + "\n");
+  EKAT_REQUIRE_MSG (lon_f.get_header().get_identifier().get_layout().type()==LayoutType::Scalar2D,
+      "Error! Source grid 'lon' field has the wrong layout.\n"
+      " - expected layout: " + e2str(LayoutType::Scalar2D) + "\n"
+      " - actual layout  : " + e2str(lon_f.get_header().get_identifier().get_layout().type()) + "\n");
+  EKAT_REQUIRE_MSG(-90 <= lat and lat <= 90,
+      "Error! IOPRemapper lat="+std::to_string(lat) +" outside of expected range [-90, 90].\n");
+  EKAT_REQUIRE_MSG(0 <= lon and lon <= 360,
+      "Error! IOPRemapper lon="+std::to_string(lon) +" outside of expected range [0, 360].\n");
+
+  auto lat_v = lat_f.get_view<const Real*>();
+  auto lon_v = lon_f.get_view<const Real*>();
+  using minloc_t = Kokkos::MinLoc<Real,int>;
+  using minloc_value_t = typename minloc_t::value_type;
+  minloc_value_t minloc;
+
+  auto lambda = KOKKOS_LAMBDA (int icol, minloc_value_t& result) {
+    auto dist = Kokkos::abs(lat_v(icol)-lat)+std::abs(lon_v(icol)-lon);
+    if(dist<result.val) {
+      result.val = dist;
+      result.loc = icol;
+    }   
+  };
+  const int ncols = m_src_grid->get_num_local_dofs();
+  Kokkos::parallel_reduce(ncols, lambda, minloc_t(minloc));
+
+  RealInt dist_rank;
+  dist_rank.val = minloc.val;
+  dist_rank.idx = m_comm.rank();
+
+  m_comm.all_reduce(&dist_rank,1,MPI_MINLOC);
+  m_closest_col_info.mpi_rank = dist_rank.idx;
+  if (dist_rank.idx==m_comm.rank()) {
+    m_closest_col_info.col_lid = minloc.loc;
+  }
+}
+
+void IOPRemapper::registration_ends_impl ()
+{
+  // NOTE: one could think to make the single-col fields to NOT be clones
+  //       on the rank that owns the closest col. However, src fields MAY
+  //       be read-only, and MPI_Bcast needs a pointer to non-const (since
+  //       the receiving ranks must write on it).
+  //       MOREOVER, by cloning, we do away with padding shenaningans, which
+  //       may require a bit more attention for bcast operations.
+  using namespace ShortFieldTagsNames;
+  for (const auto& f : m_src_fields) {
+    auto col = f.subfield(COL,0).clone();
+    m_single_col_fields.push_back(col);
+  }
+}
+
+void IOPRemapper::remap_fwd_impl ()
+{
+  using namespace ShortFieldTagsNames;
+
+  const auto root_id  = m_closest_col_info.mpi_rank;
+  const auto iam_root = root_id==m_comm.rank();
+
+  // 1. Rank root_id extracts the closest col for all fields
+  if (iam_root) {
+    for (int i=0; i<m_num_fields; ++i) {
+      auto& dst = m_single_col_fields[i];
+      auto  src = m_src_fields[i].subfield(COL,m_closest_col_info.col_lid);
+      dst.deep_copy(src);
+    }
+  }
+
+  // 2. Rank root_id broadcasts the single-col fields
+  for (int i=0; i<m_num_fields; ++i) {
+    auto& f = m_single_col_fields[i];
+    int col_size = f.get_header().get_identifier().get_layout().size();
+#ifdef SCREAM_MPI_ON_DEVICE
+    m_comm.broadcast(f.get_internal_view_data<Real>(),col_size,root_id);
+#else
+    if (iam_root) {
+      f.sync_to_host();
+    }
+    m_comm.broadcast(f.get_internal_view_data<Real,Host>(),col_size,root_id);
+    if (not iam_root) {
+      f.sync_to_dev();
+    }
+#endif
+  }
+
+  // 3. Every rank copies the single col into ALL cols of the tgt fields
+  int ncols = m_tgt_grid->get_num_local_dofs();
+  for (int i=0; i<m_num_fields; ++i) {
+    auto& col = m_single_col_fields[i];
+    auto& tgt = m_tgt_fields[i];
+
+    // TODO: one may think of dispatching a TP kernel, to reduce latency.
+    //       That's fine, but you make the remapper code longer, since you need
+    //       to handle different ranks separately.
+    for (int icol=0; icol<ncols; ++icol) {
+      tgt.subfield(COL,icol).deep_copy(col);
+    }
+  }
+}
+
+} // namespace scream

--- a/components/eamxx/src/share/grid/remap/iop_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/iop_remapper.cpp
@@ -123,7 +123,7 @@ void IOPRemapper::remap_fwd_impl ()
   for (int i=0; i<m_num_fields; ++i) {
     auto& f = m_single_col_fields[i];
     int col_size = f.get_header().get_identifier().get_layout().size();
-#ifdef SCREAM_MPI_ON_DEVICE
+#if SCREAM_MPI_ON_DEVICE
     m_comm.broadcast(f.get_internal_view_data<Real>(),col_size,root_id);
 #else
     if (iam_root) {

--- a/components/eamxx/src/share/grid/remap/iop_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/iop_remapper.hpp
@@ -32,7 +32,12 @@ protected:
     int col_lid = -1;
   };  
 
+// CUDA requires the parent fcn of a KOKKOS_LAMBDA to have public access
+#ifdef EAMXX_ENABLE_GPU
+public:
+#endif
   void setup_closest_col_info (const Real lat, const Real lon);
+protected:
 
   void registration_ends_impl () override;
 

--- a/components/eamxx/src/share/grid/remap/iop_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/iop_remapper.hpp
@@ -1,0 +1,50 @@
+#ifndef EAMXX_IOP_REMAPPER_HPP
+#define EAMXX_IOP_REMAPPER_HPP
+
+#include "share/grid/remap/abstract_remapper.hpp"
+
+namespace scream
+{
+
+/*
+ *  A remapper for IOP-like needs
+ *
+ *  This remapper does the following operations:
+ *    - extract col closest to given lat/lon coordinates
+ *    - broadcast the closest col to ALL the model columns
+ */
+
+class IOPRemapper : public AbstractRemapper
+{
+public:
+  IOPRemapper (const grid_ptr_type src_grid,
+               const grid_ptr_type tgt_grid,
+               const Real lat, const Real lon);
+
+  ~IOPRemapper () = default;
+
+protected:
+
+  struct ClosestColInfo {
+    // MPI rank which owns the closest column to the requested lat/lon
+    int mpi_rank;
+    // Local column index of on rank=mpi_rank (-1 on all other ranks)
+    int col_lid = -1;
+  };  
+
+  void setup_closest_col_info (const Real lat, const Real lon);
+
+  void registration_ends_impl () override;
+
+  void remap_fwd_impl () override;
+
+  std::vector<Field>    m_single_col_fields;
+
+  ClosestColInfo        m_closest_col_info;
+
+  ekat::Comm            m_comm;
+};
+
+} // namespace scream
+
+#endif // EAMXX_IOP_REMAPPER_HPP

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
@@ -70,9 +70,6 @@ public:
   static std::shared_ptr<AbstractGrid>
   create_tgt_grid (const grid_ptr_type& src_grid, const std::string& map_file);
 
-  FieldLayout create_src_layout (const FieldLayout& tgt_layout) const override;
-  FieldLayout create_tgt_layout (const FieldLayout& src_layout) const override;
-
   bool compatible_layouts (const FieldLayout& src, const FieldLayout& tgt) const override;
 
   bool is_valid_tgt_layout (const FieldLayout& layout) const override;
@@ -81,8 +78,7 @@ protected:
 
   void set_pressure (const Field& p, const std::string& src_or_tgt, const ProfileType ptype);
   FieldLayout create_layout (const FieldLayout& from_layout,
-                             const std::shared_ptr<const AbstractGrid>& to_grid,
-                             const bool int_same_as_mid) const;
+                             const std::shared_ptr<const AbstractGrid>& to_grid) const override;
 
   void registration_ends_impl () override;
 
@@ -126,8 +122,8 @@ protected:
   Field                 m_tgt_pmid;
   Field                 m_tgt_pint;
 
-  bool m_src_mid_same_as_int = false;
-  bool m_tgt_mid_same_as_int = false;
+  bool m_src_int_same_as_mid = false;
+  bool m_tgt_int_same_as_mid = false;
 
   // Extrapolation settings at top/bottom. Default to P0 extrapolation
   ExtrapType            m_etype_top = P0;

--- a/components/eamxx/src/share/io/scorpio_scm_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_scm_input.cpp
@@ -126,7 +126,7 @@ void SCMInput::create_closest_col_info (double target_lat, double target_lon)
   m_comm.all_reduce(&min_dist_and_rank, 1, MPI_MINLOC);
 
   // Set local col idx to -1 for mpi ranks not containing minimum lat/lon distance
-  m_closest_col_info.mpi_rank = min_dist_and_rank.val;
+  m_closest_col_info.mpi_rank = min_dist_and_rank.idx;
   m_closest_col_info.col_lid  = my_rank==min_dist_and_rank.idx ? minloc.loc : -1;
 }
 

--- a/components/eamxx/src/share/io/scorpio_scm_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_scm_input.cpp
@@ -8,6 +8,26 @@
 
 #include <memory>
 
+// Anonymous namespace, in case other TU's define the same type
+namespace {
+struct RealInt
+{
+  scream::Real val;
+  int  idx;
+};
+}
+// Specialize ekat's get_mpi_type for RealInt (needed for the all_reduce call)
+namespace ekat {
+  template<>
+  MPI_Datatype get_mpi_type<RealInt> () {
+#ifdef SCREAM_DOUBLE_PRECISION
+    return MPI_DOUBLE_INT;
+#else
+    return MPI_FLOAT_INT;
+#endif
+  }
+} // namespace ekat
+
 namespace scream
 {
 
@@ -102,12 +122,12 @@ void SCMInput::create_closest_col_info (double target_lat, double target_lon)
 
   // Find processor with closest lat/lon match
   const auto my_rank = m_comm.rank();
-  std::pair<Real, int> min_dist_and_rank = {minloc.val, my_rank};
-  m_comm.all_reduce<std::pair<Real, int>>(&min_dist_and_rank, 1, MPI_MINLOC);
+  RealInt min_dist_and_rank = {minloc.val, my_rank};
+  m_comm.all_reduce(&min_dist_and_rank, 1, MPI_MINLOC);
 
   // Set local col idx to -1 for mpi ranks not containing minimum lat/lon distance
-  m_closest_col_info.mpi_rank = min_dist_and_rank.second;
-  m_closest_col_info.col_lid  = my_rank==min_dist_and_rank.second ? minloc.loc : -1;
+  m_closest_col_info.mpi_rank = min_dist_and_rank.val;
+  m_closest_col_info.col_lid  = my_rank==min_dist_and_rank.idx ? minloc.loc : -1;
 }
 
 void SCMInput::read_variables (const int time_index)

--- a/components/eamxx/src/share/io/tests/io_scm_reader.cpp
+++ b/components/eamxx/src/share/io/tests/io_scm_reader.cpp
@@ -12,15 +12,23 @@
 namespace scream {
 
 // Returns fields after initialization
-void write (const int seed, const int ncols, const int nlevs, const ekat::Comm& comm)
+void write (const int seed, const ekat::Comm& comm)
 {
   using ekat::units::Units;
   using RPDF = std::uniform_real_distribution<Real>;
+  using IPDF = std::uniform_int_distribution<int>;
   using Engine = std::mt19937_64;
 
   Engine engine(seed);
+
   RPDF lat_pdf(-90.0,90.0);
   RPDF lon_pdf(-180.0,180.0);
+
+  int nlevs = IPDF(5,8)(engine);
+  int ncols = IPDF(4,5)(engine);
+
+  comm.broadcast(&ncols,1,comm.root_rank());
+  comm.broadcast(&nlevs,1,comm.root_rank());
 
   // Create grid
   auto grid = create_point_grid("test",ncols,nlevs,comm);
@@ -66,35 +74,37 @@ void write (const int seed, const int ncols, const int nlevs, const ekat::Comm& 
   scorpio::release_file(filename);
 }
 
-void read (const int seed, const int nlevs, const ekat::Comm& comm)
+void read (const int seed, const ekat::Comm& comm)
 {
   using ekat::units::Units;
   using IPDF = std::uniform_int_distribution<int>;
   using Engine = std::mt19937_64;
 
-  Engine engine(seed);
-
-  auto grid = std::make_shared<PointGrid>("scm_grid",1,nlevs,comm);
-  auto dofs_gids = grid->get_dofs_gids();
-  dofs_gids.deep_copy(0);
-
   // Pick a col index, and find its lat/lon from file
   auto filename = "io_scm_np" + std::to_string(comm.size()) + ".nc";
   scorpio::register_file(filename,scorpio::Read,scorpio::DefaultIOType);
-  int ncols = scorpio::get_dimlen(filename,"ncol");
 
+  int ncols = scorpio::get_dimlen(filename,"ncol");
+  int nlevs = scorpio::get_dimlen(filename,"lev");
+
+  Engine engine(seed);
+
+  // Read lat/lon/var on ALL ranks. Rank 0 decides what's the tgt lat/lon
   std::vector<Real> lat(ncols), lon(ncols), var(ncols*nlevs);
   scorpio::read_var(filename,"lat",lat.data());
   scorpio::read_var(filename,"lon",lon.data());
   scorpio::read_var(filename,"var",var.data());
-
-  scorpio::release_file(filename);
 
   auto tgt_col = IPDF(0,ncols-1)(engine);
   comm.broadcast(&tgt_col,1,comm.root_rank());
 
   auto tgt_lat = lat[tgt_col];
   auto tgt_lon = lon[tgt_col];
+
+  // Create single-col grid
+  auto grid = std::make_shared<PointGrid>("scm_grid",1,nlevs,comm);
+  auto dofs_gids = grid->get_dofs_gids();
+  dofs_gids.deep_copy(0);
 
   // Create field to read
   FieldIdentifier fid("var",grid->get_3d_scalar_layout(true),Units::nondimensional(),"");
@@ -110,25 +120,18 @@ void read (const int seed, const int nlevs, const ekat::Comm& comm)
   for (int ilev=0; ilev<nlevs; ++ilev) {
     REQUIRE (var_h(0,ilev)==var[tgt_col*nlevs+ilev]);
   }
+
+  scorpio::release_file(filename);
 }
 
 TEST_CASE ("scm_io") {
-  using IPDF = std::uniform_int_distribution<int>;
-  using Engine = std::mt19937_64;
-
   ekat::Comm comm(MPI_COMM_WORLD);
   scorpio::init_subsystem(comm);
 
   auto seed = get_random_test_seed(&comm);
-  Engine engine(seed);
-  int nlevs = IPDF(5,8)(engine);
-  int ncols = IPDF(4,5)(engine);
 
-  comm.broadcast(&ncols,1,comm.root_rank());
-  comm.broadcast(&nlevs,1,comm.root_rank());
-
-  write(seed,ncols,nlevs,comm);
-  read(seed,nlevs,comm);
+  write(seed,comm);
+  read(seed,comm);
 
   scorpio::finalize_subsystem();
 }

--- a/components/eamxx/src/share/tests/CMakeLists.txt
+++ b/components/eamxx/src/share/tests/CMakeLists.txt
@@ -29,6 +29,10 @@ if (NOT SCREAM_ONLY_GENERATE_BASELINES)
   CreateUnitTest(grid_imp_exp "grid_import_export_tests.cpp"
     MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS})
 
+  # Test iop remap
+  CreateUnitTest(iop_remapper "iop_remapper_tests.cpp"
+    MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS})
+
   # Test coarsening remap
   CreateUnitTest(coarsening_remapper "coarsening_remapper_tests.cpp"
     LIBS scream_io

--- a/components/eamxx/src/share/tests/iop_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/iop_remapper_tests.cpp
@@ -120,8 +120,8 @@ TEST_CASE("iop_remap")
     lat = src_lat.get_view<const Real*,Host>()[closest_lid];
     lon = src_lon.get_view<const Real*,Host>()[closest_lid];
   }
-  comm.broadcast(&lat,1,0);
-  comm.broadcast(&lon,1,0);
+  comm.broadcast(&lat,1,closest_rank);
+  comm.broadcast(&lon,1,closest_rank);
 
   auto remap = std::make_shared<IOPRemapper>(src_grid,tgt_grid,lat,lon);
 

--- a/components/eamxx/src/share/tests/iop_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/iop_remapper_tests.cpp
@@ -1,0 +1,188 @@
+#include <catch2/catch.hpp>
+
+#include "share/grid/remap/iop_remapper.hpp"
+#include "share/grid/point_grid.hpp"
+#include "share/grid/se_grid.hpp"
+#include "share/util/scream_setup_random_test.hpp"
+#include "share/field/field_utils.hpp"
+
+namespace scream {
+
+void root_print (const std::string& msg, const ekat::Comm& comm) {
+  if (comm.am_i_root()) {
+    printf("%s",msg.c_str());
+  }
+}
+
+constexpr int vec_dim = 2;
+constexpr int tens_dim1 = 3;
+constexpr int tens_dim2 = 4;
+
+template<typename Engine, typename PDF>
+Field create_field (const std::string& name,
+                    const LayoutType lt,
+                    const AbstractGrid& grid,
+                    const bool midpoints,
+                    Engine& engine, PDF& pdf)
+{
+  const auto u = ekat::units::Units::nondimensional();
+  const auto& gn = grid.name();
+  Field f;
+  switch (lt) {
+    case LayoutType::Scalar2D:
+      f = Field(FieldIdentifier(name,grid.get_2d_scalar_layout(),u,gn));  break;
+    case LayoutType::Vector2D:
+      f = Field(FieldIdentifier(name,grid.get_2d_vector_layout(vec_dim),u,gn));  break;
+    case LayoutType::Tensor2D:
+      f = Field(FieldIdentifier(name,grid.get_2d_tensor_layout({tens_dim1,tens_dim2}),u,gn));  break;
+    case LayoutType::Scalar3D:
+      f = Field(FieldIdentifier(name,grid.get_3d_scalar_layout(midpoints),u,gn));
+      f.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
+      break;
+    case LayoutType::Vector3D:
+      f = Field(FieldIdentifier(name,grid.get_3d_vector_layout(midpoints,vec_dim),u,gn));
+      f.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
+      break;
+    case LayoutType::Tensor3D:
+      f = Field(FieldIdentifier(name,grid.get_3d_tensor_layout(midpoints,{tens_dim1,tens_dim2}),u,gn));
+      f.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
+      break;
+    default:
+      EKAT_ERROR_MSG ("Invalid layout type for this unit test.\n");
+  }
+  f.allocate_view();
+
+  randomize(f,engine,pdf);
+
+  return f;
+}
+
+TEST_CASE("iop_remap")
+{
+  ekat::Comm comm(MPI_COMM_WORLD);
+
+  root_print ("\n +---------------------------------+\n",comm);
+  root_print (" |       Testing iop remapper      |\n",comm);
+  root_print (" +---------------------------------+\n\n",comm);
+
+  using IPDF = std::uniform_int_distribution<int>;
+  using RPDF = std::uniform_real_distribution<Real>;
+
+  auto engine = setup_random_test (&comm);
+  IPDF ipdf (2*comm.size(),10*comm.size());
+  RPDF rpdf (0,1);
+
+  // -------------------------------------- //
+  //      Build src grid and remapper       //
+  // -------------------------------------- //
+
+  int src_ngcols = ipdf(engine);
+  int tgt_ngcols = ipdf(engine);
+  comm.broadcast(&src_ngcols,1,0);
+  comm.broadcast(&tgt_ngcols,1,0);
+
+  auto src_grid = create_point_grid("src", src_ngcols,10,comm);
+  auto tgt_grid = create_point_grid("tgt", tgt_ngcols,10,comm);
+  int src_nlcols = src_grid->get_num_local_dofs();
+  int tgt_nlcols = tgt_grid->get_num_local_dofs();
+
+  REQUIRE_THROWS (std::make_shared<IOPRemapper>(src_grid,tgt_grid,0,0)); // not lat/lon in src
+
+  auto bad_src = create_point_grid("src", src_ngcols,10,comm);
+  bad_src->create_geometry_data("lat",src_grid->get_3d_scalar_layout(true));
+  bad_src->create_geometry_data("lon",src_grid->get_3d_scalar_layout(true));
+  REQUIRE_THROWS (std::make_shared<IOPRemapper>(bad_src,tgt_grid,0,0)); // lat/lon bad layout
+
+  auto src_lat = src_grid->create_geometry_data("lat",src_grid->get_2d_scalar_layout());
+  auto src_lon = src_grid->create_geometry_data("lon",src_grid->get_2d_scalar_layout());
+  randomize(src_lat,engine,rpdf);
+  randomize(src_lon,engine,rpdf);
+
+  auto se_grid = std::make_shared<SEGrid>("se",5,4,10,comm);
+  se_grid->create_geometry_data("lat",se_grid->get_2d_scalar_layout());
+  se_grid->create_geometry_data("lon",se_grid->get_2d_scalar_layout());
+  REQUIRE_THROWS (std::make_shared<IOPRemapper>(src_grid,se_grid,0,0)); // tgt!=PointGrid
+  REQUIRE_THROWS (std::make_shared<IOPRemapper>(se_grid,tgt_grid,0,0)); // src!=PointGrid
+
+  auto bad_tgt = tgt_grid->clone("bad_tgt",true);
+  bad_tgt->reset_num_vertical_lev(12);
+  REQUIRE_THROWS (std::make_shared<IOPRemapper>(src_grid,bad_tgt,0,0)); // nlevs doesn't match
+
+  REQUIRE_THROWS (std::make_shared<IOPRemapper>(src_grid,bad_tgt,91,0)); // lat OOB
+  REQUIRE_THROWS (std::make_shared<IOPRemapper>(src_grid,bad_tgt,0,-1)); // lat OOB
+
+  // Finally a working remapper
+  int closest_rank = IPDF(0,comm.size()-1)(engine);
+  comm.broadcast(&closest_rank,1,0);
+  int closest_lid = IPDF(0,src_nlcols-1)(engine);
+  Real lat,lon;
+  if (closest_rank==comm.rank()) {
+    lat = src_lat.get_view<const Real*,Host>()[closest_lid];
+    lon = src_lon.get_view<const Real*,Host>()[closest_lid];
+  }
+  comm.broadcast(&lat,1,0);
+  comm.broadcast(&lon,1,0);
+
+  auto remap = std::make_shared<IOPRemapper>(src_grid,tgt_grid,lat,lon);
+
+  // -------------------------------------- //
+  //     Create fields and register them    //
+  // -------------------------------------- //
+
+  auto layouts = {
+    LayoutType::Scalar2D,
+    LayoutType::Vector2D,
+    LayoutType::Tensor2D,
+    LayoutType::Scalar3D,
+    LayoutType::Scalar3D,
+    LayoutType::Vector3D,
+    LayoutType::Vector3D,
+    LayoutType::Tensor3D,
+    LayoutType::Tensor3D
+  };
+
+  remap->registration_begins();
+
+  bool midpoints = false; // midpoints is unused for 2d layouts
+  for (auto l : layouts) {
+    auto n = e2str(l);
+    auto src = create_field(n+"_src",l,*src_grid,midpoints,engine,rpdf);
+    auto tgt = create_field(n+"_tgt",l,*tgt_grid,midpoints,engine,rpdf);
+    remap->register_field(src,tgt);
+
+    midpoints = not midpoints; // ensure we create both mid and int fields
+  }
+  remap->registration_ends();
+
+  // -------------------------------------- //
+  //        Remap fields and check          //
+  // -------------------------------------- //
+
+  REQUIRE_THROWS (remap->remap_bwd()); // NO bwd remap
+  remap->remap_fwd();
+
+  using namespace ShortFieldTagsNames;
+  for (int i=0; i<remap->get_num_fields(); ++i) {
+    const auto& src = remap->get_src_field(i);
+    const auto& tgt = remap->get_tgt_field(i);
+
+    auto col = src.subfield(COL,0).clone("col");
+    int col_size = col.get_header().get_identifier().get_layout().size();
+    if (comm.rank()==closest_rank) {
+      col.deep_copy(src.subfield(COL,closest_lid));
+    }
+#ifdef SCREAM_MPI_ON_DEVICE
+    comm.broadcast(col.get_internal_view_data<Real>(),col_size,closest_rank);
+#else
+    col.sync_to_host();
+    comm.broadcast(col.get_internal_view_data<Real,Host>(),col_size,closest_rank);
+    col.sync_to_dev();
+#endif
+
+    for (int icol=0; icol<tgt_nlcols; ++icol) {
+      REQUIRE (views_are_equal(col,tgt.subfield(COL,icol)));
+    }
+  }
+}
+
+} // namespace scream

--- a/components/eamxx/src/share/tests/iop_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/iop_remapper_tests.cpp
@@ -171,7 +171,7 @@ TEST_CASE("iop_remap")
     if (comm.rank()==closest_rank) {
       col.deep_copy(src.subfield(COL,closest_lid));
     }
-#ifdef SCREAM_MPI_ON_DEVICE
+#if SCREAM_MPI_ON_DEVICE
     comm.broadcast(col.get_internal_view_data<Real>(),col_size,closest_rank);
 #else
     col.sync_to_host();

--- a/components/eamxx/src/share/util/scream_setup_random_test.hpp
+++ b/components/eamxx/src/share/util/scream_setup_random_test.hpp
@@ -18,7 +18,7 @@ inline int get_random_test_seed(const ekat::Comm* comm=nullptr)
 
   std::random_device rdev;
   const int catchRngSeed = Catch::rngSeed();
-  int seed = catchRngSeed==0 ? rdev() : catchRngSeed;
+  int seed = catchRngSeed==0 ? rdev()/2 : catchRngSeed;
 
   if (comm == nullptr || comm->am_i_root()) {
     // Print seed to screen to trace tests that fail.


### PR DESCRIPTION
Implement an IOP remapper, with the goal of simplifying downstream code, expressing it in terms of more generic interfaces.

---

@tcclevenger @AaronDonahue You guys should review only the last 3 commits of this branch, since the other ones are from the remappers-api-cleanup branch.

he main part of the PR is the IOPRemapper, but I wanted to verify its correctness by also using it somewhere. The easiest place was SPA, since it has minimal IOP-related stuff (only the single-col remap stuff). All in all, I think SPA gets simplified, and it gets to a good state to be later refactored in terms of a DataInterpolation structure.

I could also start using IOPRemapper in other places of the code (most notably inside the IOPDataManager class itself). Perhaps it's best to do things in steps though, and integrate one small change at a time? Or maybe @tcclevenger could do that step later, since he's more familiar with the IOP class and its assumptions?

Depends on #6908 