### PR TITLE
EAMxx: enhance vert remap support in DataInterpolation

### DIFF
--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -294,7 +294,7 @@ AbstractGrid::get_geometry_data (const std::string& name) const {
 }
 
 Field
-AbstractGrid::create_geometry_data (const FieldIdentifier& fid)
+AbstractGrid::create_geometry_data (const FieldIdentifier& fid, const int pack_size)
 {
   const auto& name = fid.name();
 
@@ -307,6 +307,7 @@ AbstractGrid::create_geometry_data (const FieldIdentifier& fid)
 
   // Create field and the read only copy as well
   auto& f = m_geo_fields[name] = Field(fid);
+  f.get_header().get_alloc_properties().request_allocation(pack_size);
   f.allocate_view();
   return f;
 }

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -136,11 +136,12 @@ public:
   Field get_geometry_data (const std::string& name) const;
 
   // Create geometry data, throws if already existing. Returns writable field
-  Field create_geometry_data (const FieldIdentifier& fid);
+  Field create_geometry_data (const FieldIdentifier& fid, const int pack_size = 1);
   Field create_geometry_data (const std::string& name, const FieldLayout& layout,
                               const ekat::units::Units& units = ekat::units::Units::invalid(),
-                              const DataType data_type = DataType::RealType) {
-    return create_geometry_data(FieldIdentifier(name,layout,units,this->name(),data_type));
+                              const DataType data_type = DataType::RealType,
+                              const int pack_size = 1) {
+    return create_geometry_data(FieldIdentifier(name,layout,units,this->name(),data_type),pack_size);
   }
 
   // Sets pre-existing field as geometry data.

--- a/components/eamxx/src/share/io/scream_scorpio_interface.cpp
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.cpp
@@ -1204,19 +1204,6 @@ void read_var (const std::string &filename, const std::string &varname, T* buf, 
         " - time len: " + std::to_string(f.time_dim->length));
     err = PIOc_setframe(f.ncid,var.ncid,frame);
     check_scorpio_noerr (err,f.name,"variable",varname,"read_var","setframe");
-  } else if (time_index>=0) {
-    // This is a bit of a hacky usage. We want to read a time index of a var,
-    // but the time dim is NOT unlimited in the input file. Apparently, SCORPIO
-    // supports this, and some E3SM input files are indeed like this, so we
-    // need to support it here too, hacky as it may be.
-    frame = time_index;
-
-    EKAT_REQUIRE_MSG (frame<var.dims[0]->length,
-        "Error! First dim index out of bounds.\n"
-        " - filename     : " + filename + "\n"
-        " - varname      : " + varname + "\n"
-        " - first dim idx: " + std::to_string(time_index) + "\n"
-        " - first dim len: " + std::to_string(var.dims[0]->length) + "\n");
   }
 
   std::string pioc_func;

--- a/components/eamxx/src/share/tests/data_interpolation_tests.hpp
+++ b/components/eamxx/src/share/tests/data_interpolation_tests.hpp
@@ -58,7 +58,6 @@ create_fields (const std::shared_ptr<const AbstractGrid>& grid,
   int nlevs = grid->get_num_vertical_levels();
 
   // Create fields
-
   auto layout_s2d   = grid->get_2d_scalar_layout();
   auto layout_v2d   = grid->get_2d_vector_layout(ncmps);
   auto layout_s3d_m = grid->get_3d_scalar_layout(true);

--- a/components/eamxx/src/share/util/eamxx_data_interpolation.hpp
+++ b/components/eamxx/src/share/util/eamxx_data_interpolation.hpp
@@ -18,8 +18,9 @@ public:
   using strvec_t = std::vector<std::string>;
   enum VRemapType {
     None,
-    Static1D,
-    Dynamic3D
+    Static1D,     // USes a constant 1d (vertical) pressure from input data
+    Dynamic3D,    // Uses a time-dep 3d pressure from input data
+    Dynamic3DRef, // Reconstructs a reference 3d pressure from time-dep PS in input data
   };
 
   // Constructor(s) & Destructor
@@ -90,7 +91,10 @@ protected:
   std::shared_ptr<AbstractRemapper> m_horiz_remapper_beg;
   std::shared_ptr<AbstractRemapper> m_horiz_remapper_end;
   std::shared_ptr<AbstractRemapper> m_vert_remapper;
-  std::shared_ptr<VerticalRemapper> m_vremap;
+
+  // If vertical remap happens, at runtime we may need to access some
+  // versions of certain perssure fields. Store them here for convenient access
+  std::map<std::string,Field>     m_helper_pressure_fields;
 
   VRemapType            m_vr_type;
   int                   m_nfields;


### PR DESCRIPTION
Support using a source pressure profule reconstructed from ps and hyam/hybm.

---

This is what SPA currently does, so this addition is needed in order to start using DataInterpolation in SPA. Note: another upgrade to DataInterpolation is needed, to handle IOP, but I want to integrate one thing at a time.

The unit test for the new feature was surprisingly simple. Since the unit test builds p3d in a way that it is basically the tensor product of s2d (a 2d scalar) and p1d, all we had to do was saving p2d=s2d, and hybm=p1d, with hyam=0. This makes the reconstructed p3d=p2d*p1d, so the expected fields for `Dynamic3DRef` are the same as in the case of `Dynamic3D`.

Also, the name `Dynamic3DRef` is up for discussion. With `Dynamic3DRef` I wanted to emphasize these were "reference" levels. Other names I considered are `Dynamic3DFromPs`, `DynamicHybrid3D`/`Dynamic3DHybrid`, or `DynamicPseudo3D`. Let me know if you have any preference here.