### PR TITLE
Add the dust emission cap 

### DIFF
--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1047,7 +1047,8 @@
 
 <dust_emis_fact dyn="se"                   phys="cam5"                  >0.55D0</dust_emis_fact>
 <dust_emis_fact dyn="fv"                   phys="cam5" clubb_sgs="1"    >0.13D0</dust_emis_fact>
-
+<!-- Dust emission cap (avoid the model crash by extremely high AOD)-->
+<dstemislimit phys="default"> 1.D-4 </dstemislimit>
 
 <!-- Sea Salt tuning option for scavenging mods by PNNL -->
 <ssalt_tuning>.false.</ssalt_tuning>

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1049,6 +1049,7 @@
 <dust_emis_fact dyn="fv"                   phys="cam5" clubb_sgs="1"    >0.13D0</dust_emis_fact>
 <!-- Dust emission cap (avoid the model crash by extremely high AOD)-->
 <dstemislimit phys="default"> 1.D-4 </dstemislimit>
+<dstemislimitswitch phys="default"> .false. </dstemislimitswitch>
 
 <!-- Sea Salt tuning option for scavenging mods by PNNL -->
 <ssalt_tuning>.false.</ssalt_tuning>

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -5015,6 +5015,13 @@ Dust emission cap used to avoid extremely high AOD
 Default: set by build-namelist.
 </entry>
 
+<entry id="dstemislimitswitch" type="logical" category="cam_chem"
+       group="aerosol_nl" valid_values="" >
+The switch for the dust emission cap used to avoid extremely high AOD
+Default: set by build-namelist.
+</entry>
+
+
 <entry id="modal_strat_sulfate_aod_treatment" type="logical"  category="cam_chem"
        group="phys_ctl_nl" valid_values="" >
 Flag for H2SO4 specific stratospheric wateruptake treatment

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -5009,6 +5009,12 @@ In-cloud scav for cloud-borne aerosol tuning factor
 Default: set by build-namelist.
 </entry>
 
+<entry id="dstemislimit" type="real" category="cam_chem"
+       group="aerosol_nl" valid_values="" >
+Dust emission cap used to avoid extremely high AOD
+Default: set by build-namelist.
+</entry>
+
 <entry id="modal_strat_sulfate_aod_treatment" type="logical"  category="cam_chem"
        group="phys_ctl_nl" valid_values="" >
 Flag for H2SO4 specific stratospheric wateruptake treatment

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -168,7 +168,7 @@ contains
     call mpibcast(seasalt_emis_scale, 1, mpir8,   0, mpicom)
 !<shanyp 01132025
     call mpibcast(dstemislimit, 1,                       mpir8,   0, mpicom) !dstemislimit
-    call mpibcast(dstemislimitswith, 1,                  mpilog,  0, mpicom) !dstemislimit
+    call mpibcast(dstemislimitswitch, 1,                  mpilog,  0, mpicom) !dstemislimit
 !shanyp 01130225>
 #endif
 

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -2822,7 +2822,12 @@ do_lphase2_conditional: &
     real(r8) :: F_eff(pcols) ! optional diagnostic output -- organic enrichment ratio
 
     real (r8), parameter :: z0=0.0001_r8  ! m roughness length over oceans--from ocean model
-
+!<shanyp 07052024
+    real (r8), parameter :: dstemislimit=1.e-4  ! kg/m2/s dust emission upper bound
+    integer :: icol,mmn
+    icol=0
+    mmn=0
+!shanyp 07052024>
     lchnk = state%lchnk
     ncol = state%ncol
 
@@ -2834,6 +2839,15 @@ do_lphase2_conditional: &
        sflx(:)=0._r8
        do m=1,dust_nbin+dust_nnum
           mm = dust_indices(m)
+!<shanyp 07052024
+          do icol=1,ncol
+           if((cam_in%cflx(icol,mm).ge.dstemislimit).and.(m.le.dust_nbin)) then
+            mmn=dust_indices(m+2)
+            cam_in%cflx(icol,mmn)=cam_in%cflx(icol,mmn)*dstemislimit/cam_in%cflx(icol,mm)
+            cam_in%cflx(icol,mm)=dstemislimit
+           end if
+          end do
+!shanyp 07052024>
           if (m<=dust_nbin) sflx(:ncol)=sflx(:ncol)+cam_in%cflx(:ncol,mm)
           call outfld(trim(dust_names(m))//'SF',cam_in%cflx(:,mm),pcols, lchnk)
        enddo

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -102,7 +102,9 @@ module aero_model
   real(r8)          :: sol_factic_interstitial = 0.4_r8
   real(r8)          :: seasalt_emis_scale
   real(r8)          :: small = 1.e-36
-
+!<shanyp 01132025
+  real(r8)          :: dstemislimit = 1.e-4_r8
+!shanyp 01132025>
   integer :: ndrydep = 0
   integer,allocatable :: drydep_indices(:)
   integer :: nwetdep = 0
@@ -132,8 +134,10 @@ contains
     character(len=16) :: aer_drydep_list(pcnst) = ' '
     namelist /aerosol_nl/ aer_wetdep_list, aer_drydep_list,          &
              sol_facti_cloud_borne, seasalt_emis_scale, sscav_tuning, &
-       sol_factb_interstitial, sol_factic_interstitial
-
+!<shanyp 01132025
+!             sol_factb_interstitial, sol_factic_interstitial
+             sol_factb_interstitial, sol_factic_interstitial,dstemislimit
+!shanyp 01132025>
     !-----------------------------------------------------------------------------
 
     ! Read namelist
@@ -161,6 +165,9 @@ contains
     call mpibcast(sol_factic_interstitial, 1,                       mpir8,   0, mpicom)
     call mpibcast(sscav_tuning,          1,                         mpilog,  0, mpicom)
     call mpibcast(seasalt_emis_scale, 1, mpir8,   0, mpicom)
+!<shanyp 01132025
+    call mpibcast(dstemislimit, 1,                       mpir8,   0, mpicom) !dstemislimit
+!shanyp 01130225>
 #endif
 
     wetdep_list = aer_wetdep_list
@@ -2823,7 +2830,7 @@ do_lphase2_conditional: &
 
     real (r8), parameter :: z0=0.0001_r8  ! m roughness length over oceans--from ocean model
 !<shanyp 07052024
-    real (r8), parameter :: dstemislimit=1.e-4  ! kg/m2/s dust emission upper bound
+!    real (r8), parameter :: dstemislimit=1.e-4  ! kg/m2/s dust emission upper bound
     integer :: icol,mmn
     icol=0
     mmn=0


### PR DESCRIPTION
To address the issue of overly strong dust emissions causing crashes in high-resolution (HR) simulations, a dust emission cap has been implemented. The cap ensures that dust emissions remain within a reasonable range to maintain simulation stability.

Additionally, the dust emission cap and its enabling switch have been added as configurable namelist items, allowing users to easily activate and adjust the cap as needed for their specific simulation setups.