### PR TITLE
adds new anvil environmental variables

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2378,6 +2378,8 @@
       <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
       <env name="PATH">/lcrc/group/e3sm/soft/perl/5.26.0/bin:$ENV{PATH}</env>
+      <env name="UCX_TLS">self,sm,ud</env>
+      <env name="UCX_UD_MLX5_RX_QUEUE_LEN">16384</env>
     </environment_variables>
     <environment_variables mpilib="mvapich">
       <env name="MV2_ENABLE_AFFINITY">0</env>


### PR DESCRIPTION
this adds two environmental variables to the anvil machine file to mitigate frequent node errors of the form 

```
1300: [b659:110218:0:110218] ib_mlx5_log.c:139  Transport retry count exceeded on mlx5_0:1/IB (synd 0x15 vend 0x81 hw_synd 0/0)             1300: [b659:110218:0:110218] ib_mlx5_log.c:139  DCI QP 0x24822 wqe[255]: SEND s-e [rqpn 0x288e7 rlid 344] [va 0x2b3e26bcb780 len 8192 lkey 0xf3906]
```

These lines are from lcrc support to address these failures.