### PR TITLE
Update MALI static mode

### DIFF
--- a/components/mpas-albany-landice/bld/build-namelist
+++ b/components/mpas-albany-landice/bld/build-namelist
@@ -517,7 +517,11 @@ add_default($nl, 'config_update_velocity_before_calving');
 # Namelist group: thermal_solver #
 ##################################
 
-add_default($nl, 'config_thermal_solver');
+if ($MALI_DYNAMIC eq 'TRUE') {
+    add_default($nl, 'config_thermal_solver');
+} else {
+    add_default($nl, 'config_thermal_solver', 'val'=>"none");
+}
 add_default($nl, 'config_thermal_calculate_bmb');
 add_default($nl, 'config_temperature_init');
 add_default($nl, 'config_thermal_thickness');
@@ -533,7 +537,11 @@ add_default($nl, 'config_max_water_fraction');
 # Namelist group: iceshelf_melt #
 #################################
 
-add_default($nl, 'config_basal_mass_bal_float');
+if ($MALI_DYNAMIC eq 'TRUE') {
+    add_default($nl, 'config_basal_mass_bal_float');
+} else {
+    add_default($nl, 'config_basal_mass_bal_float', 'val'=>"none");
+}
 add_default($nl, 'config_bmlt_float_flux');
 add_default($nl, 'config_bmlt_float_xlimit');
 add_default($nl, 'config_basal_mass_bal_seroussi_amplitude');
@@ -551,7 +559,11 @@ add_default($nl, 'config_temperature_profile_variability_amplitude');
 add_default($nl, 'config_temperature_profile_variability_period');
 add_default($nl, 'config_temperature_profile_variability_phase');
 add_default($nl, 'config_temperature_profile_GL_depth_fraction');
-add_default($nl, 'config_front_mass_bal_grounded');
+if ($MALI_DYNAMIC eq 'TRUE') {
+    add_default($nl, 'config_front_mass_bal_grounded');
+} else {
+    add_default($nl, 'config_front_mass_bal_grounded', 'val'=>"none");
+}
 add_default($nl, 'config_use_3d_thermal_forcing_for_face_melt');
 add_default($nl, 'config_beta_ocean_thermal_forcing');
 add_default($nl, 'config_add_ocean_thermal_forcing');
@@ -651,7 +663,11 @@ add_default($nl, 'config_check_tracer_monotonicity');
 # Namelist group: subglacial_hydro #
 ####################################
 
-add_default($nl, 'config_SGH');
+if ($MALI_DYNAMIC eq 'TRUE') {
+    add_default($nl, 'config_SGH');
+} else {
+    add_default($nl, 'config_SGH', 'val'=>".false.");
+}
 add_default($nl, 'config_ocean_connection_N');
 add_default($nl, 'config_SGH_adaptive_timestep_fraction');
 add_default($nl, 'config_SGH_max_adaptive_timestep');


### PR DESCRIPTION
MALI static mode is used as a data mode where MALI is an active component but its state does not change.  This commit updates data mode to ensure that additional physics packages are disabled: 
* thermal solver
* ice-shelf basal melting
* facemelting
* subglacial hydrology

These physics packages were previously defaulted to off or are still defaulted to off in E3SM, so these changes ensure that after (or if) those defaults are changed that the MALI state will remain unchanged in "static" mode.