### PR TITLE
Revert "EAMxx: Adds a flag to control vertical mixing of interstitial aerosols during aerosol activation process"

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -251,7 +251,6 @@ be lost if SCREAM_HACK_XML is not enabled.
     <!-- MAM4xx-ACI -->
     <mam4_aci inherit="atm_proc_base">
       <wsubmin type="real" doc="Minimum diagnostic sub-grid vertical velocity">0.001</wsubmin>
-      <enable_aero_vertical_mix type="logical" doc="Enable vertical mixing of interstitial aerosols and liquid number during activation">true</enable_aero_vertical_mix>
       <top_level_mam4xx type="integer" doc="Level corresponding to the top of troposphere clouds" nlev="72"  >6</top_level_mam4xx>
       <top_level_mam4xx type="integer" doc="level corresponding to the top of troposphere clouds" nlev="128" >0</top_level_mam4xx>
     </mam4_aci>

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
@@ -205,7 +205,6 @@ void call_function_dropmixnuc(
     const MAMAci::view_2d wsub,
     const MAMAci::view_2d cloud_frac, const MAMAci::view_2d cloud_frac_prev,
     const mam_coupling::AerosolState &dry_aero, const int nlev,
-    const bool &enable_aero_vertical_mix,
 
     // Following outputs are all diagnostics
     MAMAci::view_2d coltend[mam4::ndrop::ncnst_tot],
@@ -319,7 +318,7 @@ void call_function_dropmixnuc(
                           num2vol_ratio_max_nmodes);
   //---------------------------------------------------------------------------
   //---------------------------------------------------------------------------
-  const bool local_enable_aero_vertical_mix = enable_aero_vertical_mix;
+
   Kokkos::parallel_for(
       team_policy, KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
         const int icol = team.league_rank();
@@ -407,6 +406,10 @@ void call_function_dropmixnuc(
               }
             });
         team.team_barrier();
+        // HACK: dropmixnuc() requires the parameter enable_aero_vertical_mix,
+        //       so we define it here until we have a better idea of where it
+        //       might come from
+        const bool enable_aero_vertical_mix = true;
         mam4::ndrop::dropmixnuc(
             team, dt, ekat::subview(T_mid, icol), ekat::subview(p_mid, icol),
             ekat::subview(p_int, icol), ekat::subview(pdel, icol),
@@ -418,10 +421,11 @@ void call_function_dropmixnuc(
             spechygro, lmassptr_amode, num2vol_ratio_min_nmodes,
             num2vol_ratio_max_nmodes, numptr_amode, nspec_amode, exp45logsig,
             alogsig, aten, mam_idx, mam_cnst_idx,
-            local_enable_aero_vertical_mix, ekat::subview(qcld, icol),  // out
-            ekat::subview(wsub, icol),                                  // in
-            ekat::subview(cloud_frac_prev, icol),                       // in
-            qqcw_view,                                                  // inout
+            enable_aero_vertical_mix,
+            ekat::subview(qcld, icol),             // out
+            ekat::subview(wsub, icol),             // in
+            ekat::subview(cloud_frac_prev, icol),  // in
+            qqcw_view,                             // inout
             ptend_q_view, ekat::subview(tendnd, icol),
             ekat::subview(factnum, icol), ekat::subview(ndropcol, icol),
             ekat::subview(ndropmix, icol), ekat::subview(nsource, icol),
@@ -530,7 +534,6 @@ void call_hetfrz_compute_tendencies(
         haero::Atmosphere haero_atm =
             atmosphere_for_column(dry_atmosphere, icol);
         haero::Surface surf{};
-        set_min_background_mmr(team, dry_aero,icol);
         mam4::Prognostics progs =
             mam_coupling::aerosols_for_column(dry_aero, icol);
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
@@ -40,9 +40,6 @@ MAMAci::MAMAci(const ekat::Comm &comm, const ekat::ParameterList &params)
   // Asserts for the runtime or namelist options
   EKAT_REQUIRE_MSG(m_params.isParameter("wsubmin"),
                    "ERROR: wsubmin is missing from mam_aci parameter list.");
-  EKAT_REQUIRE_MSG(m_params.isParameter("enable_aero_vertical_mix"),
-                   "ERROR: enable_aero_vertical_mixing is missing from mam_aci "
-                   "parameter list.");
   EKAT_REQUIRE_MSG(
       m_params.isParameter("top_level_mam4xx"),
       "ERROR: top_level_mam4xx is missing from mam_aci parameter list.");
@@ -274,9 +271,8 @@ void MAMAci::initialize_impl(const RunType run_type) {
   // ## Runtime options
   // ------------------------------------------------------------------------
 
-  wsubmin_                  = m_params.get<double>("wsubmin");
-  enable_aero_vertical_mix_ = m_params.get<bool>("enable_aero_vertical_mix");
-  top_lev_                  = m_params.get<int>("top_level_mam4xx");
+  wsubmin_ = m_params.get<double>("wsubmin");
+  top_lev_ = m_params.get<int>("top_level_mam4xx");
 
   // ------------------------------------------------------------------------
   // Input fields read in from IC file, namelist or other processes
@@ -604,7 +600,7 @@ void MAMAci::run_impl(const double dt) {
   //  aerosols tendencies
   call_function_dropmixnuc(
       team_policy, dt, dry_atm_, rpdel_, kvh_mid_, kvh_int_, wsub_, cloud_frac_,
-      cloud_frac_prev_, dry_aero_, nlev_, enable_aero_vertical_mix_,
+      cloud_frac_prev_, dry_aero_, nlev_,
       // output
       coltend_, coltend_cw_, qcld_, ndropcol_, ndropmix_, nsource_, wtke_, ccn_,
       // ## output to be used by the other processes ##

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.hpp
@@ -41,9 +41,8 @@ class MAMAci final : public scream::AtmosphereProcess {
   // ACI runtime ( or namelist) options
   //------------------------------------------------------------------------
 
-  Real wsubmin_;                   // Minimum subgrid vertical velocity
-  bool enable_aero_vertical_mix_;  // To enable vertical mixing of aerosols
-  int top_lev_;                    // Top level for MAM4xx
+  Real wsubmin_;  // Minimum subgrid vertical velocity
+  int top_lev_;   // Top level for MAM4xx
 
   //------------------------------------------------------------------------
   // END: ACI runtime ( or namelist) options
@@ -213,9 +212,7 @@ class MAMAci final : public scream::AtmosphereProcess {
       // for atmosphere
       compute_vertical_layer_heights(team, dry_atm_pre_, i);
       compute_updraft_velocities(team, wet_atm_pre_, dry_atm_pre_, i);
-      set_min_background_mmr(team, dry_aero_pre_,
-                             i);  // dry_atm_pre_ is the output
-    }                             // operator()
+    }  // operator()
 
     // local variables for preprocess struct
     // number of horizontal columns and vertical levels

--- a/components/eamxx/src/physics/mam/mam_coupling.hpp
+++ b/components/eamxx/src/physics/mam/mam_coupling.hpp
@@ -776,32 +776,6 @@ void compute_wet_mixing_ratios(const Team& team,
   });
 }
 
-// Set minimum background MMR for the interstitial aerosols
-KOKKOS_INLINE_FUNCTION
-void set_min_background_mmr(const Team& team,
-                               const AerosolState& dry_aero,
-                               const int column_index) {
-
-  EKAT_KERNEL_ASSERT_MSG(column_index == team.league_rank(),
-    "Given column index does not correspond to given team!");
-
-  //Minimum background value for the interstitial aerosols
-  constexpr Real INTERSTITIAL_AERO_MIN_VAL = 1e-36;
-
-  constexpr int nlev = mam4::nlev;
-  const int icol = column_index;
-  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev), [&] (const int klev) {
-    for (int imode = 0; imode < num_aero_modes(); ++imode) {
-      dry_aero.int_aero_nmr[imode](icol,klev) = haero::max(dry_aero.int_aero_nmr[imode](icol,klev), INTERSTITIAL_AERO_MIN_VAL);
-      for (int ispec = 0; ispec < num_aero_species(); ++ispec) {
-        if (dry_aero.int_aero_mmr[imode][ispec].data()) {
-          dry_aero.int_aero_mmr[imode][ispec](icol,klev) = haero::max(dry_aero.int_aero_mmr[imode][ispec](icol,klev), INTERSTITIAL_AERO_MIN_VAL);
-        }
-      }//ispec
-    }//imode
-  });
-} // set_min_background_mmr
-
 // Computes the reciprocal of pseudo density for a column
 inline
 void compute_recipical_pseudo_density(haero::ThreadTeamPolicy team_policy,

--- a/components/eamxx/tests/single-process/mam/aci/input.yaml
+++ b/components/eamxx/tests/single-process/mam/aci/input.yaml
@@ -12,7 +12,6 @@ atmosphere_processes:
   atm_procs_list: [mam4_aci]
   mam4_aci:
     wsubmin: 0.001
-    enable_aero_vertical_mix: true
     top_level_mam4xx: 6
 
 grids_manager:


### PR DESCRIPTION
Reverts E3SM-Project/E3SM#6926

I failed to realize that some unit tests in MAM4xx were failing.