### PR TITLE
EAMxx: add new required param to mam4_aci tests input files

### DIFF
--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
@@ -41,7 +41,7 @@ MAMAci::MAMAci(const ekat::Comm &comm, const ekat::ParameterList &params)
   EKAT_REQUIRE_MSG(m_params.isParameter("wsubmin"),
                    "ERROR: wsubmin is missing from mam_aci parameter list.");
   EKAT_REQUIRE_MSG(m_params.isParameter("enable_aero_vertical_mix"),
-                   "ERROR: enable_aero_vertical_mixing is missing from mam_aci "
+                   "ERROR: enable_aero_vertical_mix is missing from mam_aci "
                    "parameter list.");
   EKAT_REQUIRE_MSG(
       m_params.isParameter("top_level_mam4xx"),

--- a/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_mam_aci_p3_mam_optics_rrtmgp_mam_drydep/input.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_mam_aci_p3_mam_optics_rrtmgp_mam_drydep/input.yaml
@@ -55,6 +55,7 @@ atmosphere_processes:
       mam4_aci:
         wsubmin: 0.001
         top_level_mam4xx: 6
+        enable_aero_vertical_mix: true
       p3:
         do_prescribed_ccn: false
         enable_column_conservation_checks: true

--- a/components/eamxx/tests/multi-process/physics_only/mam/shoc_cldfrac_mam4_aci_p3/input.yaml
+++ b/components/eamxx/tests/multi-process/physics_only/mam/shoc_cldfrac_mam4_aci_p3/input.yaml
@@ -35,6 +35,7 @@ atmosphere_processes:
     mam4_aci:
       wsubmin: 0.001
       top_level_mam4xx: 6
+      enable_aero_vertical_mix: true
 
 grids_manager:
   Type: Mesh Free

--- a/components/eamxx/tests/multi-process/physics_only/mam/shoc_cldfrac_mam4_aci_p3_mam4_optics_rrtmgp/input.yaml
+++ b/components/eamxx/tests/multi-process/physics_only/mam/shoc_cldfrac_mam4_aci_p3_mam4_optics_rrtmgp/input.yaml
@@ -19,6 +19,7 @@ atmosphere_processes:
     mam4_aci:
       wsubmin: 0.001
       top_level_mam4xx: 6
+      enable_aero_vertical_mix: true
     p3:
       max_total_ni: 740.0e3
       do_prescribed_ccn: false

--- a/components/eamxx/tests/multi-process/physics_only/mam/shoc_cldfrac_mam4_aci_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/multi-process/physics_only/mam/shoc_cldfrac_mam4_aci_p3_rrtmgp/input.yaml
@@ -19,6 +19,7 @@ atmosphere_processes:
     mam4_aci:
       wsubmin: 0.001
       top_level_mam4xx: 6
+      enable_aero_vertical_mix: true
     p3:
       max_total_ni: 740.0e3
       do_prescribed_ccn: false

--- a/components/eamxx/tests/multi-process/physics_only/mam/shoc_mam4_aci/input.yaml
+++ b/components/eamxx/tests/multi-process/physics_only/mam/shoc_mam4_aci/input.yaml
@@ -19,6 +19,7 @@ atmosphere_processes:
     mam4_aci:
       wsubmin: 0.001
       top_level_mam4xx: 6
+      enable_aero_vertical_mix: true
     shoc:
       lambda_low: 0.001
       lambda_high: 0.08


### PR DESCRIPTION
Fixes mam4_aci unit tests that failed after a too hastily merging of #6926

---
