### PR TITLE
EAMxx: fix bug in SeaLevelPressure diagnostic

### DIFF
--- a/components/eamxx/src/diagnostics/sea_level_pressure.cpp
+++ b/components/eamxx/src/diagnostics/sea_level_pressure.cpp
@@ -1,4 +1,5 @@
 #include "diagnostics/sea_level_pressure.hpp"
+#include "share/util/scream_common_physics_functions.hpp"
 
 namespace scream
 {
@@ -15,52 +16,43 @@ SeaLevelPressureDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& p
 void SeaLevelPressureDiagnostic::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
 {
   using namespace ekat::units;
-  using namespace ShortFieldTagsNames;
 
   const auto m2 = pow(m,2);
   const auto s2 = pow(s,2);
 
   auto grid  = grids_manager->get_grid("Physics");
-  const auto& grid_name = grid->name();
   m_num_cols = grid->get_num_local_dofs(); // Number of columns on this rank
   m_num_levs = grid->get_num_vertical_levels();  // Number of levels per column
 
-  FieldLayout scalar2d_layout_col{ {COL}, {m_num_cols} };
-  FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_num_cols,m_num_levs} };
-  constexpr int ps = Pack::n;
+  auto scalar2d = grid->get_2d_scalar_layout();
+  auto scalar3d = grid->get_3d_scalar_layout(true);
 
   // The fields required for this diagnostic to be computed
-  add_field<Required>("T_mid",          scalar3d_layout_mid, K,  grid_name, ps);
-  add_field<Required>("p_mid",          scalar3d_layout_mid, Pa, grid_name, ps);
-  add_field<Required>("phis",           scalar2d_layout_col, m2/s2, grid_name, ps);
+  add_field<Required>("T_mid", scalar3d, K,     grid->name());
+  add_field<Required>("p_mid", scalar3d, Pa,    grid->name());
+  add_field<Required>("phis",  scalar2d, m2/s2, grid->name());
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar2d_layout_col, Pa, grid_name);
+  FieldIdentifier fid (name(), scalar2d, Pa, grid->name());
   m_diagnostic_output = Field(fid);
-  auto& C_ap = m_diagnostic_output.get_header().get_alloc_properties();
-  C_ap.request_allocation();
   m_diagnostic_output.allocate_view();
 }
-// =========================================================================================
+
 void SeaLevelPressureDiagnostic::compute_diagnostic_impl()
 {
-  const auto npacks     = ekat::npack<Pack>(m_num_levs);
-  const auto default_policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols,1);
+  const auto& psl   = m_diagnostic_output.get_view<Real*>();
+  const auto& T_mid = get_field_in("T_mid").get_view<const Real**>();
+  const auto& p_mid = get_field_in("p_mid").get_view<const Real**>();
+  const auto& phis  = get_field_in("phis").get_view<const Real*>();
 
-  const auto& p_sealevel         = m_diagnostic_output.get_view<Real*>();
-  const auto& T_mid              = get_field_in("T_mid").get_view<const Pack**>();
-  const auto& p_mid              = get_field_in("p_mid").get_view<const Pack**>();
-  const auto& phis               = get_field_in("phis").get_view<const Real*>();
+  int surf_lev = m_num_levs - 1;
+  using RP = typename KokkosTypes<DefaultDevice>::RangePolicy;
+  using PF = scream::PhysicsFunctions<DefaultDevice>;
 
-  const int pack_surf = std::min(m_num_levs / Pack::n, npacks-1);
-  const int idx_surf  = m_num_levs % Pack::n;
-  Kokkos::parallel_for("SeaLevelPressureDiagnostic",
-                       default_policy,
-                       KOKKOS_LAMBDA(const MemberType& team) {
-    const int icol = team.league_rank();
-    p_sealevel(icol) = PF::calculate_psl(T_mid(icol,pack_surf)[idx_surf],p_mid(icol,pack_surf)[idx_surf],phis(icol));
-  });
-  Kokkos::fence();
+  auto lambda = KOKKOS_LAMBDA(const int& icol) {
+    psl(icol) = PF::calculate_psl(T_mid(icol,surf_lev),p_mid(icol,surf_lev),phis(icol));
+  };
+  Kokkos::parallel_for("SeaLevelPressure", RP(0,m_num_cols), lambda);
 }
-// =========================================================================================
+
 } //namespace scream

--- a/components/eamxx/src/diagnostics/sea_level_pressure.hpp
+++ b/components/eamxx/src/diagnostics/sea_level_pressure.hpp
@@ -2,8 +2,6 @@
 #define EAMXX_SEA_LEVEL_PRESSURE_DIAGNOSTIC_HPP
 
 #include "share/atm_process/atmosphere_diagnostic.hpp"
-#include "share/util/scream_common_physics_functions.hpp"
-#include "ekat/kokkos/ekat_subview_utils.hpp"
 
 namespace scream
 {
@@ -15,12 +13,6 @@ namespace scream
 class SeaLevelPressureDiagnostic : public AtmosphereDiagnostic
 {
 public:
-  using Pack          = ekat::Pack<Real,SCREAM_PACK_SIZE>;
-  using PF            = scream::PhysicsFunctions<DefaultDevice>;
-
-  using KT            = KokkosTypes<DefaultDevice>;
-  using MemberType    = typename KT::MemberType;
-  using view_1d       = typename KT::template view_1d<Pack>;
 
   // Constructors
   SeaLevelPressureDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);

--- a/components/eamxx/src/diagnostics/tests/sea_level_pressure_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/sea_level_pressure_test.cpp
@@ -42,18 +42,14 @@ create_gm (const ekat::Comm& comm, const int ncols, const int nlevs) {
 template<typename DeviceT>
 void run(std::mt19937_64& engine)
 {
-  using PF         = scream::PhysicsFunctions<DeviceT>;
-  using PC         = scream::physics::Constants<Real>;
-  using Pack       = ekat::Pack<Real,SCREAM_PACK_SIZE>;
-  using KT         = ekat::KokkosTypes<DeviceT>;
-  using ExecSpace  = typename KT::ExeSpace;
-  using MemberType = typename KT::MemberType;
-  using view_1d    = typename KT::template view_1d<Pack>;
-  using rview_1d   = typename KT::template view_1d<Real>;
+  using PF          = scream::PhysicsFunctions<DeviceT>;
+  using PC          = scream::physics::Constants<Real>;
+  using Pack        = ekat::Pack<Real,SCREAM_PACK_SIZE>;
+  using KT          = ekat::KokkosTypes<DeviceT>;
+  using RangePolicy = typename KT::RangePolicy;
 
   const     int packsize = SCREAM_PACK_SIZE;
   constexpr int num_levs = packsize*2 + 1; // Number of levels to use for tests, make sure the last pack can also have some empty slots (packsize>1).
-  const     int num_mid_packs    = ekat::npack<Pack>(num_levs);
 
   // A world comm
   ekat::Comm comm(MPI_COMM_WORLD);
@@ -61,17 +57,6 @@ void run(std::mt19937_64& engine)
   // Create a grids manager - single column for these tests
   const int ncols = 1;
   auto gm = create_gm(comm,ncols,num_levs);
-
-  // Kokkos Policy
-  auto policy = ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(ncols, num_mid_packs);
-
-  // Input (randomized) views
-  view_1d temperature("temperature",num_mid_packs),
-          pressure("pressure",num_mid_packs);
-
-  auto dview_as_real = [&] (const view_1d& v) -> rview_1d {
-    return rview_1d(reinterpret_cast<Real*>(v.data()),v.size()*packsize);
-  };
 
   // Construct random input data
   using RPDF = std::uniform_real_distribution<Real>;
@@ -120,10 +105,8 @@ void run(std::mt19937_64& engine)
     for (int icol=0;icol<ncols;icol++) {
       const auto& T_sub      = ekat::subview(T_mid_v,icol);
       const auto& p_sub      = ekat::subview(p_mid_v,icol);
-      ekat::genRandArray(dview_as_real(temperature),   engine, pdf_temp);
-      ekat::genRandArray(dview_as_real(pressure),      engine, pdf_pres);
-      Kokkos::deep_copy(T_sub,temperature);
-      Kokkos::deep_copy(p_sub,pressure);
+      ekat::genRandArray(T_sub, engine, pdf_temp);
+      ekat::genRandArray(p_sub, engine, pdf_pres);
     }
     ekat::genRandArray(phis_v, engine, pdf_surface);
 
@@ -133,12 +116,13 @@ void run(std::mt19937_64& engine)
     Field p_sealevel_f = diag_out.clone();
     p_sealevel_f.deep_copy<double,Host>(0.0);
     p_sealevel_f.sync_to_dev();
+    const int surf_lev = num_levs - 1;
     const auto& p_sealevel_v = p_sealevel_f.get_view<Real*>();
-    const int pack_surf = std::min(num_levs / Pack::n, num_mid_packs-1);
-    const int idx_surf  = num_levs % Pack::n;
-    Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
-      const int icol = team.league_rank();
-      p_sealevel_v(icol) = PF::calculate_psl(T_mid_v(icol,pack_surf)[idx_surf],p_mid_v(icol,pack_surf)[idx_surf],phis_v(icol));
+    auto T_mid_s = ekat::scalarize(T_mid_v);
+    auto p_mid_s = ekat::scalarize(p_mid_v);
+    auto policy = RangePolicy(0,ncols);
+    Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const int icol) {
+      p_sealevel_v(icol) = PF::calculate_psl(T_mid_s(icol,surf_lev),p_mid_s(icol,surf_lev),phis_v(icol));
     });
     Kokkos::fence();
     REQUIRE(views_are_equal(diag_out,p_sealevel_f));


### PR DESCRIPTION
The bug was a one-line fix: we were using the wrong index for the midpoint level near the surface. But while at it, I decided to clean up a bit the diagnostic.

[non-bfb only for PSL output]

---

The clean up is mainly getting rid of Pack in the diagnostic. In general, diagnostics should NOT use packs, since they can't affect the allocation of the field (the field is already allocated by the time the diagnostics request it in IO). In this case, using packs makes even less sense, since we only need data at ONE specific level.

[BFB] except for the SeaLevelPressure diagnostic

This should fix the FAIL we saw on pm-cpu. Well, I should probably rephrase: it should make us go _past_ the current point of failure... ;-)

Note: the code WAS buggy, but ONLY if the pack size was larger than 1. That means that all GPU runs would be unaffected by it. OTOH, I fail to understand why our CPU runs have NOT been failing all along....