### PR TITLE
Add the dust emission cap (and its switch) as a tunable parameter in the namelist

### DIFF
--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1046,7 +1046,9 @@
 
 <dust_emis_fact dyn="se"                   phys="cam5"                  >0.55D0</dust_emis_fact>
 <dust_emis_fact dyn="fv"                   phys="cam5" clubb_sgs="1"    >0.13D0</dust_emis_fact>
-
+<!-- Dust emission cap (avoid the model crash by extremely high AOD)-->
+<dstemislimit phys="default"> 1.D-4 </dstemislimit>
+<dstemislimitswitch phys="default"> .false. </dstemislimitswitch>
 
 <!-- Sea Salt tuning option for scavenging mods by PNNL -->
 <ssalt_tuning>.false.</ssalt_tuning>

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -5051,6 +5051,18 @@ In-cloud scav for cloud-borne aerosol tuning factor
 Default: set by build-namelist.
 </entry>
 
+<entry id="dstemislimit" type="real" category="cam_chem"
+       group="aerosol_nl" valid_values="" >
+Dust emission cap used to avoid extremely high AOD
+Default: set by build-namelist.
+</entry>
+
+<entry id="dstemislimitswitch" type="logical" category="cam_chem"
+       group="aerosol_nl" valid_values="" >
+The switch for the dust emission cap used to avoid extremely high AOD
+Default: set by build-namelist.
+</entry>
+
 <entry id="modal_strat_sulfate_aod_treatment" type="logical"  category="cam_chem"
        group="phys_ctl_nl" valid_values="" >
 Flag for H2SO4 specific stratospheric wateruptake treatment

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -102,7 +102,8 @@ module aero_model
   real(r8)          :: sol_factic_interstitial = 0.4_r8
   real(r8)          :: seasalt_emis_scale
   real(r8)          :: small = 1.e-36
-
+  real(r8)          :: dstemislimit = 1.e-4_r8
+  logical           :: dstemislimitswitch = .false.
   integer :: ndrydep = 0
   integer,allocatable :: drydep_indices(:)
   integer :: nwetdep = 0
@@ -132,8 +133,7 @@ contains
     character(len=16) :: aer_drydep_list(pcnst) = ' '
     namelist /aerosol_nl/ aer_wetdep_list, aer_drydep_list,          &
              sol_facti_cloud_borne, seasalt_emis_scale, sscav_tuning, &
-       sol_factb_interstitial, sol_factic_interstitial
-
+             sol_factb_interstitial, sol_factic_interstitial,dstemislimit,dstemislimitswitch
     !-----------------------------------------------------------------------------
 
     ! Read namelist
@@ -161,6 +161,8 @@ contains
     call mpibcast(sol_factic_interstitial, 1,                       mpir8,   0, mpicom)
     call mpibcast(sscav_tuning,          1,                         mpilog,  0, mpicom)
     call mpibcast(seasalt_emis_scale, 1, mpir8,   0, mpicom)
+    call mpibcast(dstemislimit, 1,                       mpir8,   0, mpicom) !dstemislimit
+    call mpibcast(dstemislimitswitch, 1,                  mpilog,  0, mpicom) !dstemislimit
 #endif
 
     wetdep_list = aer_wetdep_list
@@ -2805,7 +2807,8 @@ do_lphase2_conditional: &
          has_mam_mom, F_eff_out, nslt_om
     use dust_model,    only: dust_emis, dust_names, dust_indices, dust_active,dust_nbin, dust_nnum
     use physics_types, only: physics_state
-
+    use phys_grid,      only: get_rlat_all_p, get_rlon_all_p
+    use physconst,      only: pi
     ! Arguments:
 
     type(physics_state),    intent(in)    :: state   ! Physics state variables
@@ -2822,7 +2825,12 @@ do_lphase2_conditional: &
     real(r8) :: F_eff(pcols) ! optional diagnostic output -- organic enrichment ratio
 
     real (r8), parameter :: z0=0.0001_r8  ! m roughness length over oceans--from ocean model
-
+    integer :: icol,mmn
+    real(r8) :: tmp_lat(pcols),tmp_lon(pcols)
+    tmp_lat(:) =-999._r8
+    tmp_lon(:) =-999._r8
+    icol=0
+    mmn=0
     lchnk = state%lchnk
     ncol = state%ncol
 
@@ -2834,6 +2842,21 @@ do_lphase2_conditional: &
        sflx(:)=0._r8
        do m=1,dust_nbin+dust_nnum
           mm = dust_indices(m)
+          if(dstemislimitswitch) then
+           do icol=1,ncol
+            if((cam_in%cflx(icol,mm).ge.dstemislimit).and.(m.le.dust_nbin)) then
+             call get_rlon_all_p(lchnk,ncol,tmp_lon)
+             call get_rlat_all_p(lchnk,ncol,tmp_lat)
+             mmn=dust_indices(m+2)
+             cam_in%cflx(icol,mmn)=cam_in%cflx(icol,mmn)*dstemislimit/cam_in%cflx(icol,mm)
+             cam_in%cflx(icol,mm)=dstemislimit
+             write(iulog,'((a,1x,i10,1x),2(a,1x,f7.2))') &
+                     'The dust emission cap is hit at icol= ',icol, &
+                     ' Latitude=',tmp_lat(icol)*180.0/pi, &
+                     ' Longitude=',tmp_lon(icol)*180.0/pi
+            end if
+           end do
+          end if
           if (m<=dust_nbin) sflx(:ncol)=sflx(:ncol)+cam_in%cflx(:ncol,mm)
           call outfld(trim(dust_names(m))//'SF',cam_in%cflx(:,mm),pcols, lchnk)
        enddo


### PR DESCRIPTION

To address the issue of overly strong dust emissions causing crashes in high-resolution (HR) simulations, a dust emission cap has been implemented. The cap ensures that dust emissions remain within a reasonable range to maintain simulation stability.

Additionally, the dust emission cap and its enabling switch have been added as configurable namelist items, allowing users to easily activate and adjust the cap as needed for their specific simulation setups.

Output the lat-lon coordinate of overly high dust emission cases.
