### PR TITLE
Add domain info to MOAB meshes and make h5m DEBUG file names consistent

### DIFF
--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -96,6 +96,9 @@ contains
     use perf_mod         , only : t_startf, t_stopf
     use mct_mod
     use ESMF
+#ifdef MOABDEBUG
+    use iMOAB        , only: iMOAB_WriteMesh
+#endif
 
     !
     ! !ARGUMENTS:
@@ -146,6 +149,7 @@ contains
     character(len=*),  parameter :: format = "('("//trim(sub)//") :',A)"
 
 #ifdef HAVE_MOAB
+    character*100 outfile, wopts, localmeshfile
     integer :: ierr, nsend,n
     character(len=SHR_KIND_CL) :: atm_gnam          ! atm grid
     character(len=SHR_KIND_CL) :: lnd_gnam          ! lnd grid
@@ -397,6 +401,14 @@ contains
        call memmon_dump_fort('memmon.out','lnd_int_mct:end::',lbnum)
        call memmon_reset_addr()
     endif
+#endif
+#ifdef MOABDEBUG
+    !     write out the mesh file to disk, in parallel
+    outfile = 'wholeLnd.h5m'//C_NULL_CHAR
+    wopts   = 'PARALLEL=WRITE_PART'//C_NULL_CHAR
+    ierr = iMOAB_WriteMesh(mlnid, outfile, wopts)
+    if (ierr > 0 )  &
+      call endrun('Error: fail to write the land mesh file')
 #endif
 
   end subroutine lnd_init_mct
@@ -991,14 +1003,7 @@ contains
       call endrun('Error: fail to set lat lon mask tag ')
     deallocate(moab_vert_coords)
     deallocate(vgids)
-#ifdef MOABDEBUG
-    !     write out the mesh file to disk, in parallel
-    outfile = 'wholeLnd.h5m'//C_NULL_CHAR
-    wopts   = 'PARALLEL=WRITE_PART'//C_NULL_CHAR
-    ierr = iMOAB_WriteMesh(mlnid, outfile, wopts)
-    if (ierr > 0 )  &
-      call endrun('Error: fail to write the land mesh file')
-#endif
+
   ! define all tags from seq_flds_l2x_fields
   ! define tags according to the seq_flds_l2x_fields 
     tagtype = 1  ! dense, double

--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -1326,7 +1326,7 @@ contains
     call seq_timemgr_EClockGetData( EClock, stepno=cur_lnd_stepno )
 #ifdef MOABDEBUG
     write(lnum,"(I0.2)")cur_lnd_stepno
-    outfile = 'LndImp_'//trim(lnum)//'.h5m'//C_NULL_CHAR
+    outfile = 'lnd_import_'//trim(lnum)//'.h5m'//C_NULL_CHAR
     wopts   = 'PARALLEL=WRITE_PART'//C_NULL_CHAR
     ierr = iMOAB_WriteMesh(mlnid, outfile, wopts)
     if (ierr > 0 )  &

--- a/components/mosart/src/cpl/rof_comp_mct.F90
+++ b/components/mosart/src/cpl/rof_comp_mct.F90
@@ -117,6 +117,9 @@ contains
     !
     ! !ARGUMENTS:
 #ifdef HAVE_MOAB
+#ifdef MOABDEBUG
+    use iMOAB,  only       : iMOAB_WriteMesh
+#endif
     integer :: nsend ! number of fields in seq_flds_r2x_fields
     integer :: nrecv ! number of fields in seq_flds_x2r_fields
 #endif
@@ -163,6 +166,7 @@ contains
     character(len=*),  parameter :: format = "('("//trim(sub)//") :',A)"
 
 #ifdef HAVE_MOAB
+    character*100 outfile, wopts
     integer :: ierr, tagtype, numco,  tagindex 
     character(CXX) ::  tagname ! for fields 
     integer ::  ent_type
@@ -314,6 +318,7 @@ contains
        nsend = mct_avect_nRattr(r2x_r)
        totalmbls = mblsize * nsend ! size of the double array
        allocate (r2x_rm(lsize, nsend) )
+
       ! define tags according to the seq_flds_r2x_fields 
        tagtype = 1  ! dense, double
        numco = 1 !  one value per cell / entity
@@ -322,12 +327,14 @@ contains
        if ( ierr == 1 ) then
            call shr_sys_abort( sub//' ERROR: cannot define tags fro seq_flds_r2x_fields in moab' )
        end if
+
        ! set those fields to 0 in moab
        r2x_rm = 0._r8
        ent_type = 0 ! rof is point cloud on this side
        ierr = iMOAB_SetDoubleTagStorage ( mrofid, tagname, totalmbls , ent_type, r2x_rm(1,1))
        if (ierr > 0 )  &
           call shr_sys_abort( sub//' Error: fail to set to 0 seq_flds_x2r_fields ')
+
        ! allocate now the import from coupler array
        nrecv = mct_avect_nRattr(x2r_r)
        totalmbls_r = mblsize * nrecv ! size of the double array
@@ -340,6 +347,7 @@ contains
        if ( ierr == 1 ) then
            call shr_sys_abort( sub//' ERROR: cannot define tags for seq_flds_x2r_fields in moab' )
        end if
+
        ! set those fields to 0 in moab
        x2r_rm = 0._r8
        ierr = iMOAB_SetDoubleTagStorage ( mrofid, tagname, totalmbls_r , ent_type, x2r_rm(1,1))
@@ -374,6 +382,15 @@ contains
        call memmon_dump_fort('memmon.out','rof_int_mct:end::',lbnum)
        call memmon_reset_addr()
     endif
+#endif
+
+#ifdef MOABDEBUG
+    !     write out the mesh file to disk, in parallel
+    outfile = 'wholeRof.h5m'//C_NULL_CHAR
+    wopts   = 'PARALLEL=WRITE_PART'//C_NULL_CHAR
+    ierr = iMOAB_WriteMesh(mrofid, outfile, wopts)
+    if (ierr > 0 )  &
+      call shr_sys_abort( sub//' Error: fail to write the moab runoff mesh file')
 #endif
 
   end subroutine rof_init_mct
@@ -946,7 +963,7 @@ contains
     ! use rtmCTL that has all we need
     use seq_comm_mct,      only: mrofid  ! id of moab rof app
     use shr_const_mod, only: SHR_CONST_PI
-    use iMOAB,  only       : iMOAB_RegisterApplication, iMOAB_CreateVertices, iMOAB_WriteMesh, &
+    use iMOAB,  only       : iMOAB_RegisterApplication, iMOAB_CreateVertices, &
     iMOAB_SetIntTagStorage, &
     iMOAB_ResolveSharedEntities, iMOAB_CreateElements, iMOAB_MergeVertices, iMOAB_UpdateMeshInfo
 
@@ -1066,8 +1083,31 @@ contains
     if (ierr > 0 )  &
       call shr_sys_abort(sub//' Error: fail to set area tag ')
 
-    tagname='aream'//C_NULL_CHAR
+    ni = 0
+    do n = rtmCTL%begr,rtmCTL%endr
+       ni = ni + 1
+       coords(ni) = rtmCTL%latc(n)
+    end do
 
+    tagname='lat'//C_NULL_CHAR
+
+    ierr = iMOAB_SetDoubleTagStorage ( mrofid, tagname, lsz , ent_type, coords)
+    if (ierr > 0 )  &
+      call shr_sys_abort(sub//' Error: fail to set lat tag ')
+
+    ni = 0
+    do n = rtmCTL%begr,rtmCTL%endr
+       ni = ni + 1
+       coords(ni) = rtmCTL%lonc(n)
+    end do
+
+    tagname='lon'//C_NULL_CHAR
+
+    ierr = iMOAB_SetDoubleTagStorage ( mrofid, tagname, lsz , ent_type, coords)
+    if (ierr > 0 )  &
+      call shr_sys_abort(sub//' Error: fail to set lat tag ')
+
+   !  tagname='aream'//C_NULL_CHAR
    !  ierr = iMOAB_SetDoubleTagStorage ( mrofid, tagname, lsz , ent_type, coords)
    !  if (ierr > 0 )  &
    !    call shr_sys_abort(sub//' Error: fail to set aream tag ')
@@ -1075,17 +1115,11 @@ contains
     ierr = iMOAB_UpdateMeshInfo ( mrofid )
     if (ierr > 0 )  &
       call shr_sys_abort(sub//' Error: fail to update mesh info ')
+
     deallocate(moab_vert_coords)
     deallocate(vgids)
     deallocate(coords)
-#ifdef MOABDEBUG
-    !     write out the mesh file to disk, in parallel
-    outfile = 'wholeRof.h5m'//C_NULL_CHAR
-    wopts   = 'PARALLEL=WRITE_PART'//C_NULL_CHAR
-    ierr = iMOAB_WriteMesh(mrofid, outfile, wopts)
-    if (ierr > 0 )  &
-      call shr_sys_abort( sub//' Error: fail to write the moab runoff mesh file')
-#endif
+
   end subroutine init_moab_rof
 
 

--- a/components/mosart/src/cpl/rof_comp_mct.F90
+++ b/components/mosart/src/cpl/rof_comp_mct.F90
@@ -1200,7 +1200,7 @@ subroutine rof_export_moab(EClock)
    call seq_timemgr_EClockGetData( EClock, stepno=cur_rof_stepno )
 #ifdef MOABDEBUG
       write(lnum,"(I0.2)")cur_rof_stepno
-      outfile = 'wholeRof_'//trim(lnum)//'.h5m'//C_NULL_CHAR
+      outfile = 'rof_export_'//trim(lnum)//'.h5m'//C_NULL_CHAR
       wopts   = 'PARALLEL=WRITE_PART'//C_NULL_CHAR
       ierr = iMOAB_WriteMesh(mrofid, outfile, wopts)
       if (ierr > 0 )  &
@@ -1242,7 +1242,7 @@ end subroutine rof_export_moab
     call seq_timemgr_EClockGetData( EClock, stepno=cur_rof_stepno )
 #ifdef MOABDEBUG
     write(lnum,"(I0.2)")cur_rof_stepno
-    outfile = 'RofImp_'//trim(lnum)//'.h5m'//C_NULL_CHAR
+    outfile = 'rof_import_'//trim(lnum)//'.h5m'//C_NULL_CHAR
     wopts   = 'PARALLEL=WRITE_PART'//C_NULL_CHAR
     ierr = iMOAB_WriteMesh(mrofid, outfile, wopts)
     if (ierr > 0 )  then

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -3453,7 +3453,7 @@ contains
     call seq_timemgr_EClockGetData( EClock, stepno=cur_ocn_stepno )
 #ifdef MOABDEBUG
     write(lnum,"(I0.2)")cur_ocn_stepno
-    outfile = 'OcnImp_'//trim(lnum)//'.h5m'//C_NULL_CHAR
+    outfile = 'ocn_import_'//trim(lnum)//'.h5m'//C_NULL_CHAR
     wopts   = 'PARALLEL=WRITE_PART'//C_NULL_CHAR
     ierr = iMOAB_WriteMesh(MPOID, outfile, wopts)
     if (ierr > 0 )  then

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -42,7 +42,7 @@ module ocn_comp_mct
    use mpas_moabmesh
    use seq_comm_mct, only: MPOID
    use seq_comm_mct,      only: num_moab_exports
-   use iMOAB, only: iMOAB_DefineTagStorage, iMOAB_SetDoubleTagStorage
+   use iMOAB, only: iMOAB_DefineTagStorage, iMOAB_SetDoubleTagStorage, iMOAB_GetMeshInfo
    use seq_comm_mct, only:  seq_comm_compare_mb_mct
 #endif
    use iso_c_binding, only : c_char, c_loc, c_ptr, c_int
@@ -601,10 +601,6 @@ contains
        call mpas_log_write('Core init failed for core ' // trim(domain % core % coreName), MPAS_LOG_CRIT)
     end if
     call t_stopf('mpaso_init2')
-#ifdef HAVE_MOAB
-    call init_moab_mpas(domain_ptr, OCNID, MPOID) ! should return MPOID ..
-    call mpas_log_write('initialized MOAB MPAS ocean instance... ')
-#endif
 
 
 !-----------------------------------------------------------------------
@@ -658,11 +654,15 @@ contains
     nsend = mct_avect_nRattr(o2x_o)
     nrecv = mct_avect_nRattr(x2o_o)
 #ifdef HAVE_MOAB
+    call init_moab_mpas(domain_ptr, OCNID, MPOID) ! should return MPOID ..
+    call mpas_log_write('initialized MOAB MPAS ocean instance... ')
+
     ! initialize moab tag fields array
    mblsize = lsize
    totalmbls = mblsize * nsend ! size of the double array for exporting to coupler
    allocate (o2x_om(lsize, nsend) )
    o2x_om = 0._r8
+
   ! define tags according to the seq_flds_o2x_fields
    tagtype = 1  ! dense, double
    numco = 1 !  one value per cell / entity
@@ -678,6 +678,7 @@ contains
       write(ocnLogUnit,*) 'Fail to set MOAB fields '
    endif
 
+  ! define tags according to the seq_flds_x2o_fields
    totalmbls_r = mblsize * nrecv ! size of the double array for importing
    allocate (x2o_om(lsize, nrecv) )
    x2o_om = 0._r8
@@ -702,7 +703,7 @@ contains
    endif
    ent_type = 1 ! cells
 
-
+   call ocn_domain_moab(MPOID)
 #endif
 !-----------------------------------------------------------------------
 !
@@ -1700,6 +1701,173 @@ contains
 !EOC
 
   end subroutine ocn_domain_mct!}}}
+
+#ifdef HAVE_MOAB
+!***********************************************************************
+!BOP
+! !IROUTINE: ocn_domain_moab
+! !INTERFACE:
+
+ subroutine ocn_domain_moab( mbid )!{{{
+
+  use iso_c_binding, only : C_NULL_CHAR
+! !DESCRIPTION:
+!  This routine sets up the MOAB domain-related info for MPASO
+!
+! !REVISION HISTORY:
+!  2025-01-21: initial version is copy from ocn_domain_mct
+!
+! !INPUT/OUTPUT PARAMETERS:
+
+    integer        , intent(in)    :: mbid
+
+!EOP
+!BOC
+!-----------------------------------------------------------------------
+!
+!  local variables
+!
+!-----------------------------------------------------------------------
+    real(kind=RKIND), pointer :: data(:)
+    real(kind=RKIND) :: r2d
+
+    integer :: i, n, ier, ierr
+    character(CXX)           :: tagname
+
+    type (block_type), pointer :: block_ptr
+
+    type (mpas_pool_type), pointer :: meshPool, forcingPool
+
+    integer, pointer :: nCellsSolve
+
+    real (kind=RKIND), dimension(:), pointer :: lonCell, latCell, areaCell
+
+    integer, dimension(:), pointer :: landIceMask
+
+    real (kind=RKIND), pointer :: sphere_radius
+
+    integer nvert(3), nvise(3), nbl(3), nsurf(3), nvisBC(3)
+    integer arrsize, ent_type
+
+    r2d = 180.0/pii
+
+!-------------------------------------------------------------------
+!
+! Determine local grid size
+!
+!-------------------------------------------------------------------
+    ierr  = iMOAB_GetMeshInfo ( mbid, nvert, nvise, nbl, nsurf, nvisBC )
+
+    arrsize = nvise(1)
+
+    allocate(data(arrsize))
+
+
+!-------------------------------------------------------------------
+!
+! Fill in correct values for domain tags
+!
+!-------------------------------------------------------------------
+
+    n = 0
+    block_ptr => domain % blocklist
+    do while(associated(block_ptr))
+       call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+
+       call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+
+       call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
+
+       do i = 1, nCellsSolve
+          n = n + 1
+          data(n) = lonCell(i) * r2d
+       end do
+
+       block_ptr => block_ptr % next
+    end do
+    write(0,*) "MPASO arrsize",n, arrsize
+    tagname = "lon"//C_NULL_CHAR
+    ent_type=1
+    ierr = iMOAB_SetDoubleTagStorage ( mbid, tagname, arrSize , ent_type, data)
+
+    n = 0
+    block_ptr => domain % blocklist
+    do while(associated(block_ptr))
+       call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+
+       call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+
+       call mpas_pool_get_array(meshPool, 'latCell', latCell)
+
+       do i = 1, nCellsSolve
+          n = n + 1
+          data(n) = latCell(i) * r2d
+       end do
+       block_ptr => block_ptr % next
+    end do
+    tagname = "lat"//C_NULL_CHAR
+    ent_type=1
+    ierr = iMOAB_SetDoubleTagStorage ( mbid, tagname, arrSize , ent_type, data)
+
+    n = 0
+    block_ptr => domain % blocklist
+    do while(associated(block_ptr))
+       call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+
+       call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+
+       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
+
+       call mpas_pool_get_config(meshPool, 'sphere_radius', sphere_radius)
+       do i = 1, nCellsSolve
+          n = n + 1
+          data(n) = areaCell(i) / (sphere_radius * sphere_radius)
+       end do
+       block_ptr => block_ptr % next
+    end do
+    tagname = "area"//C_NULL_CHAR
+    ent_type=1
+    ierr = iMOAB_SetDoubleTagStorage ( mbid, tagname, arrSize , ent_type, data)
+
+    ! Build mask and frac based on landIceMask
+    block_ptr => domain % blocklist
+    do while (associated(block_ptr))
+       call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+       call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
+
+       call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+
+       call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+
+       if ( associated(landIceMask) ) then
+          do i = 1, nCellsSolve
+             if ( landIceMask(i) == 1 ) then
+                 data(i) = 0.0_RKIND
+             else
+                 data(i) = 1.0_RKIND
+             end if
+          end do
+       else
+          do i = 1, nCellsSolve
+             data(i) = 1.0_RKIND
+          end do
+       end if
+
+       block_ptr => block_ptr % next
+    end do
+    tagname = "mask"//C_NULL_CHAR
+    ent_type=1
+    ierr = iMOAB_SetDoubleTagStorage ( mbid, tagname, arrSize , ent_type, data)
+    tagname = "frac"//C_NULL_CHAR
+    ent_type=1
+    ierr = iMOAB_SetDoubleTagStorage ( mbid, tagname, arrSize , ent_type, data)
+
+    deallocate(data)
+
+!-----------------------------------------------------------------------
+!EOC
+  end subroutine ocn_domain_moab !}}}
+#endif
 
 
 !***********************************************************************

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -1785,7 +1785,6 @@ contains
 
        block_ptr => block_ptr % next
     end do
-    write(0,*) "MPASO arrsize",n, arrsize
     tagname = "lon"//C_NULL_CHAR
     ent_type=1
     ierr = iMOAB_SetDoubleTagStorage ( mbid, tagname, arrSize , ent_type, data)

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -3713,7 +3713,7 @@ contains
     call seq_timemgr_EClockGetData( EClock, stepno=cur_ice_stepno )
 #ifdef MOABDEBUG
     write(lnum,"(I0.2)")cur_ice_stepno
-    outfile = 'IceImp_'//trim(lnum)//'.h5m'//C_NULL_CHAR
+    outfile = 'ice_import_'//trim(lnum)//'.h5m'//C_NULL_CHAR
     wopts   = 'PARALLEL=WRITE_PART'//C_NULL_CHAR
     ierr = iMOAB_WriteMesh(MPSIID, outfile, wopts)
     if (ierr > 0 )  then

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -779,6 +779,7 @@ contains
        call mpas_log_write('Fail to set define dom fields ',  MPAS_LOG_ERR)
     endif
 
+    call ice_domain_moab(MPSIID)
 #endif
 
 
@@ -1852,6 +1853,173 @@ contains
 
   end subroutine ice_domain_mct!}}}
 
+#ifdef HAVE_MOAB
+!***********************************************************************
+!BOP
+! !IROUTINE: ice_domain_moab
+! !INTERFACE:
+
+ subroutine ice_domain_moab( mbid )!{{{
+
+  use iso_c_binding, only : C_NULL_CHAR
+  use iMOAB, only: iMOAB_GetMeshInfo
+! !DESCRIPTION:
+!  This routine sets up the MOAB domain-related info for MPASSI
+!
+! !REVISION HISTORY:
+!  2025-01-23: initial version is copy from ice_domain_mct
+!
+! !INPUT/OUTPUT PARAMETERS:
+
+    integer        , intent(in)    :: mbid
+
+!EOP
+!BOC
+!-----------------------------------------------------------------------
+!
+!  local variables
+!
+!-----------------------------------------------------------------------
+    real(kind=RKIND), pointer :: data(:)
+    real(kind=RKIND) :: r2d
+
+    integer :: i, n, ier, ierr
+    character(CXX)           :: tagname
+
+    type (block_type), pointer :: block_ptr
+
+    type (mpas_pool_type), pointer :: meshPool, oceanCouplingPool
+
+    integer, pointer :: nCellsSolve
+
+    real (kind=RKIND), dimension(:), pointer :: lonCell, latCell, areaCell
+
+    integer, dimension(:), pointer :: landIceMask
+
+    real (kind=RKIND), pointer :: sphere_radius
+
+    integer nvert(3), nvise(3), nbl(3), nsurf(3), nvisBC(3)
+    integer arrsize, ent_type
+
+    r2d = 180.0/pii
+
+!-------------------------------------------------------------------
+!
+! Determine local grid size
+!
+!-------------------------------------------------------------------
+    ierr  = iMOAB_GetMeshInfo ( mbid, nvert, nvise, nbl, nsurf, nvisBC )
+
+    arrsize = nvise(1)
+
+    allocate(data(arrsize))
+
+
+!-------------------------------------------------------------------
+!
+! Fill in correct values for domain tags
+!
+!-------------------------------------------------------------------
+
+    n = 0
+    block_ptr => domain % blocklist
+    do while(associated(block_ptr))
+       call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+
+       call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+
+       call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
+
+       do i = 1, nCellsSolve
+          n = n + 1
+          data(n) = lonCell(i) * r2d
+       end do
+
+       block_ptr => block_ptr % next
+    end do
+    tagname = "lon"//C_NULL_CHAR
+    ent_type=1
+    ierr = iMOAB_SetDoubleTagStorage ( mbid, tagname, arrSize , ent_type, data)
+
+    n = 0
+    block_ptr => domain % blocklist
+    do while(associated(block_ptr))
+       call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+
+       call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+
+       call mpas_pool_get_array(meshPool, 'latCell', latCell)
+
+       do i = 1, nCellsSolve
+          n = n + 1
+          data(n) = latCell(i) * r2d
+       end do
+       block_ptr => block_ptr % next
+    end do
+    tagname = "lat"//C_NULL_CHAR
+    ent_type=1
+    ierr = iMOAB_SetDoubleTagStorage ( mbid, tagname, arrSize , ent_type, data)
+
+    n = 0
+    block_ptr => domain % blocklist
+    do while(associated(block_ptr))
+       call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+
+       call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+
+       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
+
+       call mpas_pool_get_config(meshPool, 'sphere_radius', sphere_radius)
+       do i = 1, nCellsSolve
+          n = n + 1
+          data(n) = areaCell(i) / (sphere_radius * sphere_radius)
+       end do
+       block_ptr => block_ptr % next
+    end do
+    tagname = "area"//C_NULL_CHAR
+    ent_type=1
+    ierr = iMOAB_SetDoubleTagStorage ( mbid, tagname, arrSize , ent_type, data)
+
+    ! Build mask and frac based on landIceMask
+    block_ptr => domain % blocklist
+    do while (associated(block_ptr))
+       call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+
+       call mpas_pool_get_subpool(block_ptr % structs, 'ocean_coupling',oceanCouplingPool)
+
+       call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+
+       call mpas_pool_get_array(oceanCouplingPool, 'landIceMask',landIceMask)
+
+       if ( associated(landIceMask) ) then
+          do i = 1, nCellsSolve
+             if ( landIceMask(i) == 1 ) then
+                 data(i) = 0.0_RKIND
+             else
+                 data(i) = 1.0_RKIND
+             end if
+          end do
+       else
+          do i = 1, nCellsSolve
+             data(i) = 1.0_RKIND
+          end do
+       end if
+
+       block_ptr => block_ptr % next
+    end do
+    tagname = "mask"//C_NULL_CHAR
+    ent_type=1
+    ierr = iMOAB_SetDoubleTagStorage ( mbid, tagname, arrSize , ent_type, data)
+    tagname = "frac"//C_NULL_CHAR
+    ent_type=1
+    ierr = iMOAB_SetDoubleTagStorage ( mbid, tagname, arrSize , ent_type, data)
+
+    deallocate(data)
+
+!-----------------------------------------------------------------------
+!EOC
+  end subroutine ice_domain_moab !}}}
+#endif
 
 !***********************************************************************
 !BOP

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -1199,9 +1199,9 @@ contains
                write(logunit,*) subname,' error in defining tags seq_flds_dom_fields on atm on coupler '
                call shr_sys_abort(subname//' ERROR in defining tags ')
             endif
-            ! also, frac, area, aream, masks has to come from atm mphaid, not from domain file reader
+            ! also, frac, area,  masks has to come from atm mphaid, not from domain file reader
             ! this is hard to digest :(
-            tagname = 'lat:lon:area:aream:frac:mask'//C_NULL_CHAR
+            tagname = 'lat:lon:area:frac:mask'//C_NULL_CHAR
             call component_exch_moab(comp, mphaid, mbaxid, 0, tagname)
 
          endif ! coupler pes
@@ -1361,9 +1361,9 @@ contains
                write(logunit,*) subname,' error in computing comm graph for data ocn model '
                call shr_sys_abort(subname//' ERROR in computing comm graph for data ocn model ')
             endif
-            ! also, frac, area, aream, masks has to come from ocean mpoid, not from domain file reader
+            ! also, frac, area,  masks has to come from ocean mpoid, not from domain file reader
             ! this is hard to digest :(
-            tagname = 'area:aream:frac:mask'//C_NULL_CHAR
+            tagname = 'area:frac:mask'//C_NULL_CHAR
             call component_exch_moab(comp, mpoid, mboxid, 0, tagname)
          endif 
 
@@ -1539,11 +1539,11 @@ contains
             call shr_sys_abort(subname//' ERROR in computing comm graph for lnd model ')
          endif
 
-         tagname = 'lat:lon:area:aream:frac:mask'//C_NULL_CHAR
+         tagname = 'lat:lon:area:frac:mask'//C_NULL_CHAR
          call component_exch_moab(comp, mlnid, mblxid, 0, tagname)
 
 #ifdef MOABDEBUG
-            outfile = 'recLand.h5m'//C_NULL_CHAR
+            outfile = 'recMeshLand.h5m'//C_NULL_CHAR
             wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
       !       write out the mesh file to disk
             ierr = iMOAB_WriteMesh(mblxid, trim(outfile), trim(wopts))
@@ -1686,9 +1686,9 @@ contains
                write(logunit,*) subname,' error in computing comm graph for data ice model '
                call shr_sys_abort(subname//' ERROR in computing comm graph for data ice model ')
             endif
-            ! also, frac, area, aream, masks has to come from ice MPSIID , not from domain file reader
+            ! also, frac, area,  masks has to come from ice MPSIID , not from domain file reader
             ! this is hard to digest :(
-            tagname = 'area:aream:frac:mask'//C_NULL_CHAR
+            tagname = 'area:frac:mask'//C_NULL_CHAR
             call component_exch_moab(comp, MPSIID, mbixid, 0, tagname)
          endif 
 #ifdef MOABDEBUG
@@ -1783,7 +1783,7 @@ contains
             call shr_sys_abort(subname//' ERROR in computing comm graph for rof model ')
          endif
 
-         tagname = 'area:aream:lon:lat:frac:mask'//C_NULL_CHAR
+         tagname = 'area:lon:lat:frac:mask'//C_NULL_CHAR
          call component_exch_moab(comp, mrofid, mbrxid, 0, tagname)
 
          ! if (mrofid .ge. 0) then  ! we are on component rof  pes

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -331,11 +331,11 @@ contains
 
     call seq_comm_getinfo(CPLID, mpicom=mpicom_CPLID)
 
-    id_new  = cplid
+    id_new  = CPLID
     id_old  = comp%compid
     id_join = comp%cplcompid
 
-    mpicom_new  = mpicom_cplid
+    mpicom_new  = mpicom_CPLID
     mpicom_old  = comp%mpicom_compid
     mpicom_join = comp%mpicom_cplcompid
 
@@ -1037,11 +1037,11 @@ contains
 
       call seq_comm_getinfo(CPLID, mpicom=mpicom_CPLID, iam=rank)
 
-      id_new  = cplid
+      id_new  = CPLID
       id_old  = comp%compid
       id_join = comp%cplcompid
 
-      mpicom_new  = mpicom_cplid
+      mpicom_new  = mpicom_CPLID
       mpicom_old  = comp%mpicom_compid
       mpicom_join = comp%mpicom_cplcompid
 
@@ -1062,9 +1062,10 @@ contains
       call shr_mpi_max(MPSIID, maxMSID, mpicom_join, all=.true.)
       call shr_mpi_max(mrofid, maxMRID, mpicom_join, all=.true.)
       if (seq_comm_iamroot(CPLID) ) then
-         write(logunit, *) "MOAB coupling for ", comp%ntype
+         write(logunit, *) "MOAB coupling for ", comp%oneletterid,' ', comp%ntype
       endif
-      ! this works now for atmosphere;
+
+!!!!!!!!!!!!!!!! ATMOSPHERE
       if ( comp%oneletterid == 'a' .and. maxMH /= -1) then
          call seq_comm_getinfo(cplid ,mpigrp=mpigrp_cplid)  ! receiver group
          call seq_comm_getinfo(id_old,mpigrp=mpigrp_old)   !  component group pes
@@ -1073,7 +1074,7 @@ contains
          call seq_infodata_GetData(infodata,atm_mesh = atm_mesh)
          ! now, if on coupler pes, receive mesh; if on comp pes, send mesh
 
-         if (mphaid >= 0) then
+         if (mphaid >= 0) then  ! component atm procs
             ierr  = iMOAB_GetMeshInfo ( mphaid, nvert, nvise, nbl, nsurf, nvisBC )
             comp%mbApCCid = mphaid ! phys atm 
             comp%mbGridType = 0 ! point cloud
@@ -1082,7 +1083,7 @@ contains
 
          if (MPI_COMM_NULL /= mpicom_old ) then ! it means we are on the component pes (atmosphere)
          !  send mesh to coupler
-            if ( trim(atm_mesh) == 'none' ) then
+            if ( trim(atm_mesh) == 'none' ) then ! full model
                if (atm_pg_active) then !  change : send the pg2 mesh, not coarse mesh, when atm pg active
                   ierr = iMOAB_SendMesh(mhpgid, mpicom_join, mpigrp_cplid, id_join, partMethod)
                else
@@ -1094,7 +1095,7 @@ contains
                   call shr_sys_abort(subname//' ERROR in sending mesh from atm comp')
                endif
             endif
-         endif
+         endif ! atmosphere pes
          if (MPI_COMM_NULL /= mpicom_new ) then !  we are on the coupler pes
             appname = "COUPLE_ATM"//C_NULL_CHAR
             ! migrated mesh gets another app id, moab atm to coupler (mbax)
@@ -1103,13 +1104,13 @@ contains
                write(logunit,*) subname,' error in registering ', appname
                call shr_sys_abort(subname//' ERROR registering '// appname)
             endif
-            if ( trim(atm_mesh) == 'none' ) then
+            if ( trim(atm_mesh) == 'none' ) then ! full atm
                ierr = iMOAB_ReceiveMesh(mbaxid, mpicom_join, mpigrp_old, id_old)
                if (ierr .ne. 0) then
                   write(logunit,*) subname,' error in receiving mesh on atm coupler '
                   call shr_sys_abort(subname//' ERROR in receiving mesh on atm coupler ')
                endif
-            else
+            else   ! data atm
               ! we need to read the atm mesh on coupler, from domain file 
                ierr = iMOAB_LoadMesh(mbaxid, trim(atm_mesh)//C_NULL_CHAR, &
                 "PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION;NO_CULLING", 0)
@@ -1132,14 +1133,12 @@ contains
                   call shr_sys_abort(subname//' ERROR in adding global id tag to atmx ')
                endif
             endif
-
             
-
-         endif
+         endif  ! on coupler pes
          !  iMOAB_FreeSenderBuffers needs to be called after receiving the mesh
 
          if (mhid .ge. 0) then  ! we are on component atm pes
-            if ( trim(atm_mesh) == 'none' ) then
+            if ( trim(atm_mesh) == 'none' ) then  ! full atmosphere
                context_id = id_join
                if (atm_pg_active) then! we send mesh from mhpgid app
                   ierr = iMOAB_FreeSenderBuffers(mhpgid, context_id)
@@ -1151,7 +1150,7 @@ contains
                   call shr_sys_abort(subname//' ERROR in freeing send buffers')
                endif
             endif
-         endif
+         endif  ! component atm pes
 
          ! graph between atm phys, mphaid, and atm dyn on coupler, mbaxid
          ! phys atm group is mpigrp_old, coupler group is mpigrp_cplid
@@ -1169,8 +1168,9 @@ contains
 
          ! we can receive those tags only on coupler pes, when mbaxid exists
          ! we have to check that before we can define the tag
-         if (mbaxid .ge. 0 ) then
-             tagtype = 1  ! dense, double
+         if (mbaxid .ge. 0 ) then   !  coupler pes
+            tagtype = 1  ! dense, double
+
             if (atm_pg_active) then
               tagname = trim(seq_flds_a2x_fields)//C_NULL_CHAR
               numco = 1 !  usually 1 value per cell
@@ -1178,23 +1178,18 @@ contains
               tagname = trim(seq_flds_a2x_ext_fields)//C_NULL_CHAR ! MOAB versions of a2x for spectral
               numco = 16 ! np*np !  usually 16 values per cell, GLL points; should be 4 x 4 = 16
             endif
+
             ierr = iMOAB_DefineTagStorage(mbaxid, tagname, tagtype, numco,  tagindex )
             if (ierr .ne. 0) then
                write(logunit,*) subname,' error in defining tags on atm on coupler '
                call shr_sys_abort(subname//' ERROR in defining tags ')
             endif
+
             tagname = trim(seq_flds_x2a_fields)//C_NULL_CHAR ! TODO should be also x2a_ext for spectral case 
             ierr = iMOAB_DefineTagStorage(mbaxid, tagname, tagtype, numco,  tagindex )
             if (ierr .ne. 0) then
                write(logunit,*) subname,' error in defining tags seq_flds_x2a_fields on atm on coupler '
                call shr_sys_abort(subname//' ERROR in defining tags ')
-            endif
-            ! zero out the fields for seq_flds_x2a_fields and seq_flds_a2x_fields, on mbaxid
-            ! first determine the size of array 
-            ierr  = iMOAB_GetMeshInfo ( mbaxid, nvert, nvise, nbl, nsurf, nvisBC )
-            if (ierr .ne. 0) then
-               write(logunit,*) subname,' error in getting mesh info on atm on coupler '
-               call shr_sys_abort(subname//' ERROR in getting mesh info on atm on coupler  ')
             endif
 
             !add the normalization tag
@@ -1204,14 +1199,12 @@ contains
                write(logunit,*) subname,' error in defining tags seq_flds_dom_fields on atm on coupler '
                call shr_sys_abort(subname//' ERROR in defining tags ')
             endif
-            if ( trim(atm_mesh) /= 'none' ) then
-               ! also, frac, area, aream, masks has to come from atm mphaid, not from domain file reader
-               ! this is hard to digest :(
-               tagname = 'area:aream:frac:mask'//C_NULL_CHAR
-               call component_exch_moab(comp, mphaid, mbaxid, 0, tagname)
-            endif
+            ! also, frac, area, aream, masks has to come from atm mphaid, not from domain file reader
+            ! this is hard to digest :(
+            tagname = 'lat:lon:area:aream:frac:mask'//C_NULL_CHAR
+            call component_exch_moab(comp, mphaid, mbaxid, 0, tagname)
 
-         endif
+         endif ! coupler pes
 
 #ifdef MOABDEBUG
          if (MPI_COMM_NULL /= mpicom_new ) then !  we are on the coupler pes
@@ -1228,12 +1221,11 @@ contains
                write(logunit,*) subname,' error in writing mesh '
                call shr_sys_abort(subname//' ERROR in writing mesh ')
             endif
-         endif
+         endif ! coupler pes
 #endif
+      endif  ! comp%oneletterid == 'a'
 
-
-
-      endif
+!!!!!!!!!!!!!!!! OCEAN
       ! ocean
       if (comp%oneletterid == 'o'  .and. maxMPO /= -1) then
          call seq_comm_getinfo(cplid ,mpigrp=mpigrp_cplid)  ! receiver group
@@ -1310,7 +1302,8 @@ contains
                   write(logunit,*) subname,' error in adding global id tag to ocnx'
                   call shr_sys_abort(subname//' ERROR in adding global id tag to ocnx ')
                endif
-            endif
+            endif  ! end of defining couplers copy of ocean mesh
+
             tagname = trim(seq_flds_o2x_fields)//C_NULL_CHAR 
             tagtype = 1  ! dense, double
             numco = 1 !  one value per cell
@@ -1388,6 +1381,7 @@ contains
                endif
             endif
          endif
+
          if (MPI_COMM_NULL /= mpicom_new ) then !  we are on the coupler pes
             appname = "COUPLE_MPASOF"//C_NULL_CHAR
             ! migrated mesh gets another app id, moab ocean to coupler (mbox)
@@ -1423,8 +1417,18 @@ contains
                   call shr_sys_abort(subname//' ERROR in adding global id tag to ocnx ')
                endif
             endif
-            
+
+            tagtype = 1  ! dense, real
+            numco = 1
+            tagname = trim(seq_flds_dom_fields)//":norm8wt"//C_NULL_CHAR
+            ierr = iMOAB_DefineTagStorage(mbofxid, tagname, tagtype, numco,  tagindex )
+            if (ierr .ne. 0) then
+               write(logunit,*) subname,' error in defining tags seq_flds_dom_fields on ocn on coupler '
+               call shr_sys_abort(subname//' ERROR in defining tags ')
+            endif
+
          endif
+
          if (mpoid .ge. 0) then  ! we are on component ocn pes again, release buffers 
              if ( trim(ocn_domain) == 'none' ) then
                context_id = id_join
@@ -1436,12 +1440,24 @@ contains
              endif
          endif
          ! end copy 
-      endif
+#ifdef MOABDEBUG
+         outfile = 'recMeshOcnF.h5m'//C_NULL_CHAR
+         wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
+      !  write out the mesh file to disk
+         ierr = iMOAB_WriteMesh(mbofxid, trim(outfile), trim(wopts))
+         if (ierr .ne. 0) then
+             write(logunit,*) subname,' error in writing ocean mesh coupler '
+             call shr_sys_abort(subname//' ERROR in writing ocean mesh coupler ')
+         endif
+#endif
+      endif  ! end ocean
 
+!!!!!!!!!!!!!!!! LAND
    !   land
       if (comp%oneletterid == 'l'  .and. maxMLID /= -1) then
          call seq_comm_getinfo(cplid ,mpigrp=mpigrp_cplid)  ! receiver group
          call seq_comm_getinfo(id_old,mpigrp=mpigrp_old)   !  component group pes
+
          ! use land full mesh 
          if (MPI_COMM_NULL /= mpicom_new ) then !  we are on the coupler pes
             appname = "COUPLE_LAND"//C_NULL_CHAR
@@ -1479,16 +1495,7 @@ contains
                write(logunit,*) subname,' error in adding global id tag to lndx'
                call shr_sys_abort(subname//' ERROR in adding global id tag to lndx ')
             endif
-#ifdef MOABDEBUG
-            outfile = 'recLand.h5m'//C_NULL_CHAR
-            wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
-      !       write out the mesh file to disk
-            ierr = iMOAB_WriteMesh(mblxid, trim(outfile), trim(wopts))
-            if (ierr .ne. 0) then
-               write(logunit,*) subname,' error in writing land coupler mesh'
-               call shr_sys_abort(subname//' ERROR in writing land coupler mesh')
-            endif
-#endif
+
    !  need to define tags on land too
             tagname = trim(seq_flds_l2x_fields)//C_NULL_CHAR 
             tagtype = 1  ! dense, double
@@ -1514,8 +1521,7 @@ contains
                call shr_sys_abort(subname//' ERROR in defining tags ')
             endif
 
-
-         endif
+         endif ! end of coupler pes
 
          ! we are now on joint pes, compute comm graph between lnd and coupler model 
          typeA = 2 ! point cloud on component PEs, land
@@ -1533,8 +1539,23 @@ contains
             call shr_sys_abort(subname//' ERROR in computing comm graph for lnd model ')
          endif
 
-      endif
+         tagname = 'lat:lon:area:aream:frac:mask'//C_NULL_CHAR
+         call component_exch_moab(comp, mlnid, mblxid, 0, tagname)
 
+#ifdef MOABDEBUG
+            outfile = 'recLand.h5m'//C_NULL_CHAR
+            wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
+      !       write out the mesh file to disk
+            ierr = iMOAB_WriteMesh(mblxid, trim(outfile), trim(wopts))
+            if (ierr .ne. 0) then
+               write(logunit,*) subname,' error in writing land coupler mesh'
+               call shr_sys_abort(subname//' ERROR in writing land coupler mesh')
+            endif
+#endif
+
+      endif  ! End of land model
+
+!!!!!!!!!!!!!!!! SEA ICE
       ! sea - ice
       if (comp%oneletterid == 'i'  .and. maxMSID /= -1) then
          call seq_comm_getinfo(cplid ,mpigrp=mpigrp_cplid)  ! receiver group
@@ -1600,18 +1621,8 @@ contains
                   write(logunit,*) subname,' error in adding global id tag to icex'
                   call shr_sys_abort(subname//' ERROR in adding global id tag to icex ')
                endif
-#ifdef MOABDEBUG
-      !        debug test
-               outfile = 'recSeaIceInit.h5m'//C_NULL_CHAR
-               wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
-      !        write out the mesh file to disk
-               ierr = iMOAB_WriteMesh(mbixid, trim(outfile), trim(wopts))
-               if (ierr .ne. 0) then
-                 write(logunit,*) subname,' error in writing sea ice mesh on coupler '
-                 call shr_sys_abort(subname//' ERROR in writing sea ice mesh on coupler ')
-               endif
-#endif
-            endif
+            endif ! end data ice
+
             tagtype = 1  ! dense, double
             numco = 1 !  one value per cell / entity
             tagname = trim(seq_flds_i2x_fields)//C_NULL_CHAR
@@ -1632,6 +1643,8 @@ contains
                write(logunit,*) subname,' error in defining tags seq_flds_dom_fields on ice on coupler '
                call shr_sys_abort(subname//' ERROR in defining tags ')
             endif
+
+            ! add data that is interpolated to sea ice
             tagname = trim(seq_flds_a2x_fields)//C_NULL_CHAR
             tagtype = 1 ! dense
             numco = 1 ! 
@@ -1641,6 +1654,7 @@ contains
                call shr_sys_abort(subname//' ERROR in coin defining tags for seq_flds_a2x_fields on ice cpl')
             endif
 
+            ! add data that is interpolated to sea ice
             tagname = trim(seq_flds_r2x_fields)//C_NULL_CHAR
             tagtype = 1 ! dense
             numco = 1 ! 
@@ -1650,17 +1664,6 @@ contains
                call shr_sys_abort(subname//' ERROR in coin defining tags for seq_flds_a2x_fields on ice cpl')
             endif
 
-#ifdef MOABDEBUG
-      !      debug test
-            outfile = 'recSeaIce.h5m'//C_NULL_CHAR
-            wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
-      !      write out the mesh file to disk
-            ierr = iMOAB_WriteMesh(mbixid, trim(outfile), trim(wopts))
-            if (ierr .ne. 0) then
-               write(logunit,*) subname,' error in writing sea ice mesh on coupler '
-               call shr_sys_abort(subname//' ERROR in writing sea ice mesh on coupler ')
-            endif
-#endif
          endif
          if (MPSIID .ge. 0) then  ! we are on component sea ice pes
             if ( trim(ice_domain) == 'none' ) then
@@ -1688,8 +1691,21 @@ contains
             tagname = 'area:aream:frac:mask'//C_NULL_CHAR
             call component_exch_moab(comp, MPSIID, mbixid, 0, tagname)
          endif 
+#ifdef MOABDEBUG
+  !      debug test
+         outfile = 'recMeshSeaIce.h5m'//C_NULL_CHAR
+         wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
+  !      write out the mesh file to disk
+         ierr = iMOAB_WriteMesh(mbixid, trim(outfile), trim(wopts))
+         if (ierr .ne. 0) then
+             write(logunit,*) subname,' error in writing sea ice mesh on coupler '
+             call shr_sys_abort(subname//' ERROR in writing sea ice mesh on coupler ')
+         endif
+#endif
 
       endif
+
+!!!!!!!!!!!!!!!! RIVER
      ! rof
       if (comp%oneletterid == 'r'  .and. maxMRID /= -1) then
          call seq_comm_getinfo(cplid ,mpigrp=mpigrp_cplid)  ! receiver group
@@ -1727,17 +1743,6 @@ contains
                call shr_sys_abort(subname//' ERROR in adding global id tag to rof ')
             endif
             
-#ifdef MOABDEBUG
-   !      debug test
-            outfile = 'recRof.h5m'//C_NULL_CHAR
-            wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
-      !      write out the mesh file to disk
-            ierr = iMOAB_WriteMesh(mbrxid, trim(outfile), trim(wopts))
-            if (ierr .ne. 0) then
-               write(logunit,*) subname,' error in writing rof mesh on coupler '
-               call shr_sys_abort(subname//' ERROR in writing rof mesh on coupler ')
-            endif
-#endif
             tagtype = 1  ! dense, double
             numco = 1 !  one value per cell / entity
             tagname = trim(seq_flds_r2x_fields)//C_NULL_CHAR
@@ -1759,13 +1764,15 @@ contains
                call shr_sys_abort(subname//' ERROR in defining tags ')
             endif
 
-         endif
-         if (mrofid >= 0) then
+         endif  ! coupler pes
+
+         if (mrofid >= 0) then  ! component pes
             ierr  = iMOAB_GetMeshInfo ( mrofid, nvert, nvise, nbl, nsurf, nvisBC )
             comp%mbApCCid = mrofid ! 
             comp%mbGridType = 0 ! 0 or 1, pc or cells 
             comp%mblsize = nvert(1) ! vertices
          endif
+
          ! we are now on joint pes, compute comm graph between rof and coupler model 
          typeA = 2 ! point cloud on component PEs
          typeB = 3 ! full mesh on coupler pes, we just read it
@@ -1776,6 +1783,9 @@ contains
             call shr_sys_abort(subname//' ERROR in computing comm graph for rof model ')
          endif
 
+         tagname = 'area:aream:lon:lat:frac:mask'//C_NULL_CHAR
+         call component_exch_moab(comp, mrofid, mbrxid, 0, tagname)
+
          ! if (mrofid .ge. 0) then  ! we are on component rof  pes
          !    context_id = id_join
          !    ierr = iMOAB_FreeSenderBuffers(mrofid, context_id)
@@ -1784,6 +1794,16 @@ contains
          !    call shr_sys_abort(subname//' ERROR in freeing buffers ')
          !    endif
          ! endif
+#ifdef MOABDEBUG
+         outfile = 'recMeshRof.h5m'//C_NULL_CHAR
+         wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
+  !      write out the mesh file to disk
+         ierr = iMOAB_WriteMesh(mbrxid, trim(outfile), trim(wopts))
+         if (ierr .ne. 0) then
+            write(logunit,*) subname,' error in writing rof mesh on coupler '
+            call shr_sys_abort(subname//' ERROR in writing rof mesh on coupler ')
+         endif
+#endif
       endif ! end for rof coupler set up 
 
    end subroutine cplcomp_moab_Init

--- a/driver-moab/shr/seq_flds_mod.F90
+++ b/driver-moab/shr/seq_flds_mod.F90
@@ -4102,6 +4102,7 @@ contains
 
    
     if (seq_comm_iamroot(ID)) then
+      write(logunit,*) subname//': seq_flds_dom_fields= ',trim(seq_flds_dom_fields)
       write(logunit,*) subname//': seq_flds_a2x_ext_states= ',trim(seq_flds_a2x_ext_states)
       write(logunit,*) subname//': seq_flds_a2x_ext_fluxes= ',trim(seq_flds_a2x_ext_fluxes)
       write(logunit,*) subname//': seq_flds_a2x_ext_fields= ',trim(seq_flds_a2x_ext_fields)


### PR DESCRIPTION
Make sure lat, lon, area and mask tags are all defined and have values in the component MOAB meshes
on both the component and coupler sides.

As part of confirming the above, MOABDEBUG writes of h5m files were modified so they occur at the end
of each init phase.  Also changed names of some to follow a consistent naming scheme.  All coupler-side
meshes start with "RecMesh".  All export and import states have "export" or "import" in the title.

[BFB]