### PR TITLE
EAMxx: Fixes NBFBness in MAM4xx microphysics test and LINOZ file read

### DIFF
--- a/components/eamxx/src/physics/mam/readfiles/tracer_reader_utils.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/tracer_reader_utils.hpp
@@ -295,6 +295,7 @@ inline void setup_tracer_data(TracerData &tracer_data,             // out
                               const int cyclical_ymd)              // in
 {
   scorpio::register_file(trace_data_file, scorpio::Read);
+  scorpio::pretend_dim_is_unlimited(trace_data_file,"time");
   // by default, I am assuming a zonal file.
   TracerFileType tracer_file_type = ZONAL;
 

--- a/components/eamxx/tests/single-process/CMakeLists.txt
+++ b/components/eamxx/tests/single-process/CMakeLists.txt
@@ -16,19 +16,13 @@ else()
   message(STATUS "RRTMGP and COSP only supported for double precision builds; skipping")
 endif()
 if (SCREAM_ENABLE_MAM)
-  # Once the mam4xx aerosol microphysics AtmosphereProcess is running, the
-  # corresponding test here needs to be reworked with valid aerosol
-  # initial conditions.
   add_subdirectory(mam/optics)
   add_subdirectory(mam/aci)
   add_subdirectory(mam/drydep)
   add_subdirectory(mam/emissions)
   add_subdirectory(mam/constituent_fluxes)
   add_subdirectory(mam/wet_scav)
-
-  # Currently this test produces non-deterministic output.
-  # Commenting it so the other PRs can test normally
-  # add_subdirectory(mam/aero_microphys)
+  add_subdirectory(mam/aero_microphys)
 endif()
 if (SCREAM_TEST_LEVEL GREATER_EQUAL SCREAM_TEST_LEVEL_EXPERIMENTAL)
   add_subdirectory(zm)


### PR DESCRIPTION
The MAM4xx microphysics standalone test shows NBFB behavior for
two consecutive runs on GPUs. This PR fixes that, and all the fixes are
 in the MAM4xx submodule.

This PR also fixes an issue related to the LINOZ file read in the microphysics 
interface. The time dimension in the LINOZ file is not unlimited. Adding
a function call to `pretend_dim_is_unlimited` fixes this issue.