### PR TITLE
Fix issue with mpas-seaice for branch and hybrid runs

### DIFF
--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -61,6 +61,8 @@ def buildnml(case, caseroot, compname):
         ice_ic_mode = 'spunup'
     if ice_bgc == 'ice_bgc':
         ice_ic_mode = 'spunup'
+    if run_type == 'hybrid' or run_type == 'branch':
+        ice_ic_mode = 'spunup'
 
     #--------------------------------------------------------------------
     # Determine date stamp, from grid names


### PR DESCRIPTION
There has been an issue with mpas-seaice in branch and hybrid runs when the compset does not include SOI, indicating spunup ocn/ice initial conditions. In that situation, which mostly occurs for D- and G-compsets, the seaice would not correctly set config_initial_condition_type and add a restart_ic stream. This fixes that issue by making ice_ic_mode equal to spunup when run_type is branch or hybrid.

Fixes #6925
[BFB] for all currently tested configurations