### PR TITLE
Fix SCREAM_LIB_ONLY typo in p3 and shoc

### DIFF
--- a/components/eam/src/physics/crm/pam/CMakeLists.txt
+++ b/components/eam/src/physics/crm/pam/CMakeLists.txt
@@ -11,7 +11,7 @@ set(PAM_DRIVER_SRC
 add_library(pam_driver 
   ${PAM_DRIVER_SRC})
 
-set(SCREAM_LIBS_ONLY TRUE)
+set(SCREAM_LIB_ONLY TRUE)
 set(SCREAM_HOME ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../..)
 add_library(eamxx_physics INTERFACE ${SCREAM_HOME}/components/eamxx/src/physics/)
 

--- a/components/eamxx/src/physics/p3/CMakeLists.txt
+++ b/components/eamxx/src/physics/p3/CMakeLists.txt
@@ -69,7 +69,7 @@ else()
   add_library(p3 ${P3_SRCS})
   # If small kernels are ON, we don't need a separate executable to test them.
   # Also, we never want to generate baselines with this separate executable
-  if (NOT SCREAM_LIBS_ONLY AND NOT SCREAM_ONLY_GENERATE_BASELINES)
+  if (NOT SCREAM_LIB_ONLY AND NOT SCREAM_ONLY_GENERATE_BASELINES)
     add_library(p3_sk ${P3_SRCS} ${P3_SK_SRCS})
     # Always build p3_sk with SCREAM_P3_SMALL_KERNELS on
     target_compile_definitions(p3_sk PUBLIC "SCREAM_P3_SMALL_KERNELS")

--- a/components/eamxx/src/physics/shoc/CMakeLists.txt
+++ b/components/eamxx/src/physics/shoc/CMakeLists.txt
@@ -96,7 +96,7 @@ if (SCREAM_SHOC_SMALL_KERNELS)
   add_library(shoc ${SHOC_SRCS} ${SHOC_SK_SRCS})
 else()
   add_library(shoc ${SHOC_SRCS})
-  if (NOT SCREAM_LIBS_ONLY AND NOT SCREAM_ONLY_GENERATE_BASELINES)
+  if (NOT SCREAM_LIB_ONLY AND NOT SCREAM_ONLY_GENERATE_BASELINES)
     add_library(shoc_sk ${SHOC_SRCS} ${SHOC_SK_SRCS})
     # Always build shoc_sk with SCREAM_SHOC_SMALL_KERNELS on
     target_compile_definitions(shoc_sk PUBLIC "SCREAM_SHOC_SMALL_KERNELS")


### PR DESCRIPTION
Fix `SCREAM_LIB_ONLY` typo in p3 and shoc. This was misspelled `SCREAM_LIBS_ONLY` in the CMakeLists.txt, which would also evaluate to FALSE in a cmake logical, which in this case meant that the `disp` sources for p3 and shoc would always be built for non-standalone (cime) builds of p3 and shoc.