### PR TITLE
EAMxx: add field utility to scale with inverse of input field

### DIFF
--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -224,6 +224,10 @@ public:
   template<HostOrDevice HD = Device>
   void scale (const Field& x);
 
+  // Scale a field y as y=y/x where x is also a field
+  template<HostOrDevice HD = Device>
+  void scale_inv (const Field& x);
+
   // Returns a subview of this field, slicing at entry k along dimension idim
   // NOTES:
   //   - the output field stores *the same* 1d view as this field. In order

--- a/components/eamxx/src/share/field/field_impl.hpp
+++ b/components/eamxx/src/share/field/field_impl.hpp
@@ -695,6 +695,34 @@ scale (const ST beta)
 
 template<HostOrDevice HD>
 void Field::
+scale_inv (const Field& x)
+{
+  const auto& dt = data_type();
+  if (dt==DataType::IntType) {
+    int fill_val = constants::DefaultFillValue<int>().value;
+    if (get_header().has_extra_data("mask_value")) {
+      fill_val = get_header().get_extra_data<int>("mask_value");
+    }
+    return update_impl<CombineMode::Divide,HD,int>(x,0,0,fill_val);
+  } else if (dt==DataType::FloatType) {
+    float fill_val = constants::DefaultFillValue<float>().value;
+    if (get_header().has_extra_data("mask_value")) {
+      fill_val = get_header().get_extra_data<float>("mask_value");
+    }
+    return update_impl<CombineMode::Divide,HD,float>(x,0,0,fill_val);
+  } else if (dt==DataType::DoubleType) {
+    double fill_val = constants::DefaultFillValue<double>().value;
+    if (get_header().has_extra_data("mask_value")) {
+      fill_val = get_header().get_extra_data<double>("mask_value");
+    }
+    return update_impl<CombineMode::Divide,HD,double>(x,0,0,fill_val);
+  } else {
+    EKAT_ERROR_MSG ("Error! Unrecognized/unsupported field data type in Field::scale_inv.\n");
+  }
+}
+
+template<HostOrDevice HD>
+void Field::
 scale (const Field& x)
 {
   const auto& dt = data_type();
@@ -720,8 +748,6 @@ scale (const Field& x)
     EKAT_ERROR_MSG ("Error! Unrecognized/unsupported field data type in Field::scale.\n");
   }
 }
-
-
 
 template<CombineMode CM, HostOrDevice HD,typename ST>
 void Field::

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -810,57 +810,113 @@ TEST_CASE ("update") {
   }
 
   SECTION ("deep_copy") {
-    Field f2 (fid_r);
-    f2.allocate_view();
+    SECTION ("real") {
+      Field f2 (fid_r);
+      f2.allocate_view();
 
-    // Replace f2's content with f_real's content
-    f2.update(f_real,1,0);
-    REQUIRE (views_are_equal(f2,f_real));
-  }
+      // Replace f2's content with f_real's content
+      f2.deep_copy(f_real);
+      REQUIRE (views_are_equal(f2,f_real));
+    }
+    SECTION ("int") {
+      Field f2 (fid_i);
+      f2.allocate_view();
 
-  SECTION ("update") {
-    Field f2 = f_real.clone();
-    Field f3 = f_real.clone();
-
-    // x+x == 2*x
-    f2.update(f_real,1,1);
-    f3.scale(2);
-    REQUIRE (views_are_equal(f2,f3));
-
-    // Adding 2*f_real to N*f3 should give 2*f_real (f3==0)
-    f3.deep_copy(0.0);
-    f3.update(f_real,2,10);
-    REQUIRE (views_are_equal(f3,f2));
-
-    // Same, but we discard current content of f3
-    f3.update(f_real,2,0);
-    REQUIRE (views_are_equal(f3,f2));
+      // Replace f2's content with f_int's content
+      f2.deep_copy(f_int);
+      REQUIRE (views_are_equal(f2,f_int));
+    }
   }
 
   SECTION ("scale") {
-    Field f1 = f_real.clone();
-    Field f2 = f_real.clone();
+    SECTION ("real") {
+      Field f1 = f_real.clone();
+      Field f2 = f_real.clone();
 
-    // x=2, x*y = 2*y
-    f1.deep_copy(2.0);
-    f1.scale(f2);
-    f2.scale(2.0);
-    REQUIRE (views_are_equal(f1, f2));
+      // x=2, x*y = 2*y
+      f1.deep_copy(2.0);
+      f1.scale(f2);
+      f2.scale(2.0);
+      REQUIRE (views_are_equal(f1, f2));
+    }
+
+    SECTION ("int") {
+      Field f1 = f_int.clone();
+      f1.deep_copy(4);
+      Field f2 = f_int.clone();
+      f2.deep_copy(2);
+      Field f3 = f_int.clone();
+      f3.deep_copy(2);
+
+      f2.scale(f3);
+      REQUIRE (views_are_equal(f1, f2));
+    }
   }
 
   SECTION ("scale_inv") {
-    Field f1 = f_real.clone();
-    Field f2 = f_real.clone();
-    Field f3 = f_real.clone();
+    SECTION ("real") {
+      Field f1 = f_real.clone();
+      Field f2 = f_real.clone();
+      Field f3 = f_real.clone();
 
-    f3.deep_copy(2.0);
-    f1.scale(f3);
-    f3.deep_copy(0.5);
-    f2.scale_inv(f3);
-    REQUIRE (views_are_equal(f1, f2));
+      f3.deep_copy(2.0);
+      f1.scale(f3);
+      f3.deep_copy(0.5);
+      f2.scale_inv(f3);
+      REQUIRE (views_are_equal(f1, f2));
+    }
+
+    SECTION ("int") {
+      Field f1 = f_int.clone();
+      f1.deep_copy(4);
+      Field f2 = f_int.clone();
+      f2.deep_copy(2);
+
+      f1.scale_inv(f2);
+      REQUIRE (views_are_equal(f1, f2));
+    }
+  }
+
+  SECTION ("update") {
+    SECTION ("real") {
+      Field f2 = f_real.clone();
+      Field f3 = f_real.clone();
+
+      // x+x == 2*x
+      f2.update(f_real,1,1);
+      f3.scale(2);
+      REQUIRE (views_are_equal(f2,f3));
+
+      // Adding 2*f_real to N*f3 should give 2*f_real (f3==0)
+      f3.deep_copy(0.0);
+      f3.update(f_real,2,10);
+      REQUIRE (views_are_equal(f3,f2));
+
+      // Same, but we discard current content of f3
+      f3.update(f_real,2,0);
+      REQUIRE (views_are_equal(f3,f2));
+    }
+
+    SECTION ("int") {
+      Field f2 = f_int.clone();
+      Field f3 = f_int.clone();
+
+      // x+x == 2*x
+      f2.update(f_int,1,1);
+      f3.scale(2);
+      REQUIRE (views_are_equal(f2,f3));
+
+      // Adding 2*f_int to N*f3 should give 2*f_int (f3==0)
+      f3.deep_copy(0);
+      f3.update(f_int,2,10);
+      REQUIRE (views_are_equal(f3,f2));
+
+      // Same, but we discard current content of f3
+      f3.update(f_int,2,0);
+      REQUIRE (views_are_equal(f3,f2));
+    }
   }
 }
-
 
 TEST_CASE ("sync_subfields") {
   // This test is for previously incorrect behavior, where syncing a subfield

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -847,6 +847,18 @@ TEST_CASE ("update") {
     f2.scale(2.0);
     REQUIRE (views_are_equal(f1, f2));
   }
+
+  SECTION ("scale_inv") {
+    Field f1 = f_real.clone();
+    Field f2 = f_real.clone();
+    Field f3 = f_real.clone();
+
+    f3.deep_copy(2.0);
+    f1.scale(f3);
+    f3.deep_copy(0.5);
+    f2.scale_inv(f3);
+    REQUIRE (views_are_equal(f1, f2));
+  }
 }
 
 


### PR DESCRIPTION
Similar to the existing `Field::scale`. It helps making unit tests (or non-perf critical code) easier to read.

[B4B]