### PR TITLE
EAMxx: add ability to use separate cloud fractions in p3

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -228,6 +228,7 @@ be lost if SCREAM_HACK_XML is not enabled.
       <set_cld_frac_l_to_one type="logical" doc="set P3 input liquid cloud fraction to 1 everywhere">false</set_cld_frac_l_to_one>
       <set_cld_frac_r_to_one type="logical" doc="set P3 input rain cloud fraction to 1 everywhere"  >false</set_cld_frac_r_to_one>
       <set_cld_frac_i_to_one type="logical" doc="set P3 input ice cloud fraction to 1 everywhere"   >false</set_cld_frac_i_to_one>
+      <use_separate_ice_liq_frac type="logical" doc="use separate ice and liquid cloud fractions from shoc">false</use_separate_ice_liq_frac>
     </p3>
 
     <!-- SHOC macrophysics -->

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -279,14 +279,14 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   const  auto& pseudo_density_dry = get_field_in("pseudo_density_dry").get_view<const Pack**>();
   const  auto& T_atm          = get_field_out("T_mid").get_view<Pack**>();
   const  auto& cld_frac_t_in  = get_field_in("cldfrac_tot").get_view<const Pack**>();
-  // FIXME: This is hack to get things going, these fields should be strictly const
-  // But to get around bfb testing and needing to declare these fields elsewhere,
-  // We will just use this workaround ...
-         auto  cld_frac_l_in  = cld_frac_t_in;
-         auto  cld_frac_i_in  = cld_frac_t_in;
-  if (runtime_options.use_separate_ice_liq_frac) {
-               cld_frac_l_in  = get_field_in("cldfrac_liq").get_view<const Pack**>();
-               cld_frac_i_in  = get_field_in("cldfrac_ice").get_view<const Pack**>();
+  // FIXME: This is hack to get things going, these fields should be strictly
+  // const But to get around bfb testing and needing to declare these fields
+  // elsewhere, We will just use this workaround ...
+  auto cld_frac_l_in = cld_frac_t_in;
+  auto cld_frac_i_in = cld_frac_t_in;
+  if(runtime_options.use_separate_ice_liq_frac) {
+    cld_frac_l_in = get_field_in("cldfrac_liq").get_view<const Pack **>();
+    cld_frac_i_in = get_field_in("cldfrac_ice").get_view<const Pack **>();
   }
   const  auto& qv             = get_field_out("qv").get_view<Pack**>();
   const  auto& qc             = get_field_out("qc").get_view<Pack**>();

--- a/components/eamxx/src/physics/p3/impl/p3_back_to_cell_average_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_back_to_cell_average_impl.hpp
@@ -28,15 +28,8 @@ void Functions<S,D>
   Spack& nr2ni_immers_freeze_tend, Spack& ni_sublim_tend, Spack& qv2qi_nucleat_tend,
   Spack& ni_nucleat_tend, Spack& qc2qi_berg_tend,
   Spack& ncheti_cnt, Spack& qcheti_cnt, Spack& nicnt, Spack& qicnt, Spack& ninuc_cnt,
-  Spack& qinuc_cnt, const Smask& context, const P3Runtime* runtime_options)
+  Spack& qinuc_cnt, const Smask& context, const P3Runtime& runtime_options)
 {
-  bool use_separate_ice_liq_frac;
-  if (runtime_options) {
-    use_separate_ice_liq_frac = runtime_options->use_separate_ice_liq_frac;
-  } else {
-    use_separate_ice_liq_frac = false;
-  }
-
   Spack ir_cldm, il_cldm, lr_cldm;
   ir_cldm = min(cld_frac_i,cld_frac_r); // Intersection of ICE and RAIN cloud
   il_cldm = min(cld_frac_i,cld_frac_l); // Intersection of ICE and LIQUID cloud
@@ -73,7 +66,7 @@ void Functions<S,D>
   nc2ni_immers_freeze_tend.set(context, nc2ni_immers_freeze_tend * cld_frac_l);   // Number change associated with freexzing of cld drops
   nr_collect_tend.set(context, nr_collect_tend * ir_cldm);  // Rain number change due to collection from ice
   ni_selfcollect_tend.set(context, ni_selfcollect_tend * cld_frac_i);    // Ice self collection
-  if (use_separate_ice_liq_frac) {
+  if (runtime_options.use_separate_ice_liq_frac) {
     qv2qi_vapdep_tend.set(context, qv2qi_vapdep_tend * (cld_frac_i-il_cldm));    // Vapor deposition to ice phase
   } else {
     qv2qi_vapdep_tend.set(context, qv2qi_vapdep_tend * cld_frac_i);    // Vapor deposition to ice phase

--- a/components/eamxx/src/physics/p3/impl/p3_back_to_cell_average_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_back_to_cell_average_impl.hpp
@@ -28,8 +28,15 @@ void Functions<S,D>
   Spack& nr2ni_immers_freeze_tend, Spack& ni_sublim_tend, Spack& qv2qi_nucleat_tend,
   Spack& ni_nucleat_tend, Spack& qc2qi_berg_tend,
   Spack& ncheti_cnt, Spack& qcheti_cnt, Spack& nicnt, Spack& qicnt, Spack& ninuc_cnt,
-  Spack& qinuc_cnt, const Smask& context)
+  Spack& qinuc_cnt, const Smask& context, const P3Runtime* runtime_options)
 {
+  bool use_separate_ice_liq_frac;
+  if (runtime_options) {
+    use_separate_ice_liq_frac = runtime_options->use_separate_ice_liq_frac;
+  } else {
+    use_separate_ice_liq_frac = false;
+  }
+
   Spack ir_cldm, il_cldm, lr_cldm;
   ir_cldm = min(cld_frac_i,cld_frac_r); // Intersection of ICE and RAIN cloud
   il_cldm = min(cld_frac_i,cld_frac_l); // Intersection of ICE and LIQUID cloud
@@ -66,7 +73,11 @@ void Functions<S,D>
   nc2ni_immers_freeze_tend.set(context, nc2ni_immers_freeze_tend * cld_frac_l);   // Number change associated with freexzing of cld drops
   nr_collect_tend.set(context, nr_collect_tend * ir_cldm);  // Rain number change due to collection from ice
   ni_selfcollect_tend.set(context, ni_selfcollect_tend * cld_frac_i);    // Ice self collection
-  qv2qi_vapdep_tend.set(context, qv2qi_vapdep_tend * cld_frac_i);    // Vapor deposition to ice phase
+  if (use_separate_ice_liq_frac) {
+    qv2qi_vapdep_tend.set(context, qv2qi_vapdep_tend * (cld_frac_i-il_cldm));    // Vapor deposition to ice phase
+  } else {
+    qv2qi_vapdep_tend.set(context, qv2qi_vapdep_tend * cld_frac_i);    // Vapor deposition to ice phase
+  }
   nr2ni_immers_freeze_tend.set(context, nr2ni_immers_freeze_tend * cld_frac_r);   // Change in number due to immersion freezing of rain
   ni_sublim_tend.set(context, ni_sublim_tend * cld_frac_i);    // Number change due to sublimation of ice
   qc2qi_berg_tend.set(context, qc2qi_berg_tend * il_cldm); // Bergeron process

--- a/components/eamxx/src/physics/p3/impl/p3_conservation_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_conservation_impl.hpp
@@ -13,6 +13,66 @@ void Functions<S,D>
 ::cloud_water_conservation(const Spack& qc, const Scalar dt,
   Spack& qc2qr_autoconv_tend, Spack& qc2qr_accret_tend, Spack &qc2qi_collect_tend, Spack& qc2qi_hetero_freeze_tend, 
   Spack& qc2qr_ice_shed_tend, Spack& qc2qi_berg_tend, Spack& qi2qv_sublim_tend, Spack& qv2qi_vapdep_tend,
+  Spack& qcheti_cnt, Spack& qicnt, const bool& use_hetfrz_classnuc, const Spack& cld_frac_l, const Spack& cld_frac_i, const Smask& context)
+{
+
+  Spack sinks;
+  if(use_hetfrz_classnuc){
+    sinks = (qc2qr_autoconv_tend+qc2qr_accret_tend+qc2qi_collect_tend+qcheti_cnt+qc2qr_ice_shed_tend+qc2qi_berg_tend)*dt; // Sinks of cloud water
+  }
+  else{
+    sinks = (qc2qr_autoconv_tend+qc2qr_accret_tend+qc2qi_collect_tend+qc2qi_hetero_freeze_tend+qc2qr_ice_shed_tend+qc2qi_berg_tend)*dt; // Sinks of cloud water
+  }
+  const auto sources = qc; // Source of cloud water
+  const auto il_cldm = min(cld_frac_i,cld_frac_l); 
+  Spack ratio;
+
+  constexpr Scalar qtendsmall = C::QTENDSMALL;
+  Smask enforce_conservation  = sinks > sources && sinks >= qtendsmall && context;  // determine if  conservation corrction is necessary
+  Smask nothing_todo = !enforce_conservation && context;
+
+  if (enforce_conservation.any()){
+    ratio.set(enforce_conservation, sources/sinks);
+    qc2qr_autoconv_tend.set(enforce_conservation, qc2qr_autoconv_tend*ratio);
+    qc2qr_accret_tend.set(enforce_conservation, qc2qr_accret_tend*ratio);
+    qc2qi_collect_tend.set(enforce_conservation, qc2qi_collect_tend*ratio);
+    if(use_hetfrz_classnuc){
+         qcheti_cnt.set(enforce_conservation, qcheti_cnt*ratio);
+         qicnt.set(enforce_conservation, qicnt*ratio);
+    }
+    else{
+      qc2qi_hetero_freeze_tend.set(enforce_conservation, qc2qi_hetero_freeze_tend*ratio);
+    }
+    qc2qr_ice_shed_tend.set(enforce_conservation, qc2qr_ice_shed_tend*ratio);
+    qc2qi_berg_tend.set(enforce_conservation, qc2qi_berg_tend*ratio);
+  }
+
+  if(nothing_todo.any()){
+    ratio.set(nothing_todo, 1); // If not limiting sinks on qc then most likely did not run out of qc
+  }
+
+  //PMC: ratio is also frac of step w/ liq. thus we apply qc2qi_berg_tend for
+  //"ratio" of timestep and vapor deposition and sublimation  for the
+  //remaining frac of the timestep.  Only limit if there will be cloud
+  // water to begin with.
+  // in instances where ratio < 1 and we have qc, qidep needs to take over
+  // but this is an in addition to the qidep we computed outside the mixed
+  // phase cloud. qidep*(1._rtype-ratio)*(il_cldm/cld_frac_i) is the additional
+  // vapor depositional growth rate that takes place within the mixed phase cloud
+  // after qc is depleted
+  enforce_conservation = sources > qtendsmall && context;
+  if (enforce_conservation.any()){
+    qv2qi_vapdep_tend.set(enforce_conservation, qv2qi_vapdep_tend + qv2qi_vapdep_tend*(1-ratio)*(il_cldm/(cld_frac_i-il_cldm)));
+    qi2qv_sublim_tend.set(enforce_conservation, qi2qv_sublim_tend*(1-ratio));
+  }
+}
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>
+::cloud_water_conservation(const Spack& qc, const Scalar dt,
+  Spack& qc2qr_autoconv_tend, Spack& qc2qr_accret_tend, Spack &qc2qi_collect_tend, Spack& qc2qi_hetero_freeze_tend, 
+  Spack& qc2qr_ice_shed_tend, Spack& qc2qi_berg_tend, Spack& qi2qv_sublim_tend, Spack& qv2qi_vapdep_tend,
   Spack& qcheti_cnt, Spack& qicnt, const bool& use_hetfrz_classnuc, const Smask& context)
 {
 

--- a/components/eamxx/src/physics/p3/impl/p3_conservation_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_conservation_impl.hpp
@@ -13,7 +13,8 @@ void Functions<S,D>
 ::cloud_water_conservation(const Spack& qc, const Scalar dt,
   Spack& qc2qr_autoconv_tend, Spack& qc2qr_accret_tend, Spack &qc2qi_collect_tend, Spack& qc2qi_hetero_freeze_tend, 
   Spack& qc2qr_ice_shed_tend, Spack& qc2qi_berg_tend, Spack& qi2qv_sublim_tend, Spack& qv2qi_vapdep_tend,
-  Spack& qcheti_cnt, Spack& qicnt, const bool& use_hetfrz_classnuc, const Spack& cld_frac_l, const Spack& cld_frac_i, const Smask& context)
+  Spack& qcheti_cnt, Spack& qicnt, const bool& use_hetfrz_classnuc, const Smask& context,
+  const Spack& cld_frac_l, const Spack& cld_frac_i, const P3Runtime& runtime_options)
 {
 
   Spack sinks;
@@ -24,7 +25,10 @@ void Functions<S,D>
     sinks = (qc2qr_autoconv_tend+qc2qr_accret_tend+qc2qi_collect_tend+qc2qi_hetero_freeze_tend+qc2qr_ice_shed_tend+qc2qi_berg_tend)*dt; // Sinks of cloud water
   }
   const auto sources = qc; // Source of cloud water
-  const auto il_cldm = min(cld_frac_i,cld_frac_l); 
+  // il_cldm is the intersection of ice and liquid cloud fractions
+  const auto il_cldm = (runtime_options.use_separate_ice_liq_frac)
+                           ? min(cld_frac_i, cld_frac_l)
+                           : Spack(1);
   Spack ratio;
 
   constexpr Scalar qtendsmall = C::QTENDSMALL;
@@ -55,6 +59,7 @@ void Functions<S,D>
   //"ratio" of timestep and vapor deposition and sublimation  for the
   //remaining frac of the timestep.  Only limit if there will be cloud
   // water to begin with.
+  // for the case of separate ice and liquid cloud fractions,
   // in instances where ratio < 1 and we have qc, qidep needs to take over
   // but this is an in addition to the qidep we computed outside the mixed
   // phase cloud. qidep*(1._rtype-ratio)*(il_cldm/cld_frac_i) is the additional
@@ -62,61 +67,11 @@ void Functions<S,D>
   // after qc is depleted
   enforce_conservation = sources > qtendsmall && context;
   if (enforce_conservation.any()){
-    qv2qi_vapdep_tend.set(enforce_conservation, qv2qi_vapdep_tend + qv2qi_vapdep_tend*(1-ratio)*(il_cldm/(cld_frac_i-il_cldm)));
-    qi2qv_sublim_tend.set(enforce_conservation, qi2qv_sublim_tend*(1-ratio));
-  }
-}
-
-template<typename S, typename D>
-KOKKOS_FUNCTION
-void Functions<S,D>
-::cloud_water_conservation(const Spack& qc, const Scalar dt,
-  Spack& qc2qr_autoconv_tend, Spack& qc2qr_accret_tend, Spack &qc2qi_collect_tend, Spack& qc2qi_hetero_freeze_tend, 
-  Spack& qc2qr_ice_shed_tend, Spack& qc2qi_berg_tend, Spack& qi2qv_sublim_tend, Spack& qv2qi_vapdep_tend,
-  Spack& qcheti_cnt, Spack& qicnt, const bool& use_hetfrz_classnuc, const Smask& context)
-{
-
-  Spack sinks;
-  if(use_hetfrz_classnuc){
-    sinks = (qc2qr_autoconv_tend+qc2qr_accret_tend+qc2qi_collect_tend+qcheti_cnt+qc2qr_ice_shed_tend+qc2qi_berg_tend)*dt; // Sinks of cloud water
-  }
-  else{
-    sinks = (qc2qr_autoconv_tend+qc2qr_accret_tend+qc2qi_collect_tend+qc2qi_hetero_freeze_tend+qc2qr_ice_shed_tend+qc2qi_berg_tend)*dt; // Sinks of cloud water
-  }
-  const auto sources = qc; // Source of cloud water
-  Spack ratio;
-
-  constexpr Scalar qtendsmall = C::QTENDSMALL;
-  Smask enforce_conservation  = sinks > sources && sinks >= qtendsmall && context;  // determine if  conservation corrction is necessary
-  Smask nothing_todo = !enforce_conservation && context;
-
-  if (enforce_conservation.any()){
-    ratio.set(enforce_conservation, sources/sinks);
-    qc2qr_autoconv_tend.set(enforce_conservation, qc2qr_autoconv_tend*ratio);
-    qc2qr_accret_tend.set(enforce_conservation, qc2qr_accret_tend*ratio);
-    qc2qi_collect_tend.set(enforce_conservation, qc2qi_collect_tend*ratio);
-    if(use_hetfrz_classnuc){
-         qcheti_cnt.set(enforce_conservation, qcheti_cnt*ratio);
-         qicnt.set(enforce_conservation, qicnt*ratio);
+    if (runtime_options.use_separate_ice_liq_frac) {
+      qv2qi_vapdep_tend.set(enforce_conservation, qv2qi_vapdep_tend + qv2qi_vapdep_tend*(1-ratio)*(il_cldm/(cld_frac_i-il_cldm)));
+    } else {
+      qv2qi_vapdep_tend.set(enforce_conservation, qv2qi_vapdep_tend*(1-ratio));
     }
-    else{
-      qc2qi_hetero_freeze_tend.set(enforce_conservation, qc2qi_hetero_freeze_tend*ratio);
-    }
-    qc2qr_ice_shed_tend.set(enforce_conservation, qc2qr_ice_shed_tend*ratio);
-    qc2qi_berg_tend.set(enforce_conservation, qc2qi_berg_tend*ratio);
-  }
-
-  if(nothing_todo.any()){
-    ratio.set(nothing_todo, 1); // If not limiting sinks on qc then most likely did not run out of qc
-  }
-
-  //PMC: ratio is also frac of step w/ liq. thus we apply qc2qi_berg_tend for
-  //"ratio" of timestep and vapor deposition and sublimation  for the
-  //remaining frac of the timestep.  Only limit if there will be cloud
-  // water to begin with.
-  enforce_conservation = sources > qtendsmall && context;
-  if (enforce_conservation.any()){
-    qv2qi_vapdep_tend.set(enforce_conservation, qv2qi_vapdep_tend*(1-ratio));
     qi2qv_sublim_tend.set(enforce_conservation, qi2qv_sublim_tend*(1-ratio));
   }
 }

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
@@ -109,6 +109,7 @@ void Functions<S,D>
 
   const bool do_ice_production   = runtime_options.do_ice_production;
   const bool use_hetfrz_classnuc = runtime_options.use_hetfrz_classnuc;
+  const bool use_separate_ice_liq_frac = runtime_options.use_separate_ice_liq_frac;
 
   team.team_barrier();
   hydrometeorsPresent = false;
@@ -418,7 +419,7 @@ void Functions<S,D>
       qr2qi_collect_tend, qc2qr_ice_shed_tend, qi2qr_melt_tend, qc2qi_collect_tend, qr2qi_immers_freeze_tend, ni2nr_melt_tend, nc_collect_tend,
       ncshdc, nc2ni_immers_freeze_tend, nr_collect_tend, ni_selfcollect_tend,
       qv2qi_vapdep_tend, nr2ni_immers_freeze_tend, ni_sublim_tend, qv2qi_nucleat_tend, ni_nucleat_tend, qc2qi_berg_tend, 
-      ncheti_cnt, qcheti_cnt, nicnt, qicnt, ninuc_cnt, qinuc_cnt, not_skip_all);
+      ncheti_cnt, qcheti_cnt, nicnt, qicnt, ninuc_cnt, qinuc_cnt, not_skip_all, &runtime_options);
 
     //
     // conservation of water
@@ -429,10 +430,18 @@ void Functions<S,D>
     // check qv because it is typically much greater than zero so seldom goes negative (and if it does
     // catastrophic failure is appropriate)]
 
-    // cloud
-    cloud_water_conservation(
-      qc(k), dt,
-      qc2qr_autoconv_tend, qc2qr_accret_tend, qc2qi_collect_tend, qc2qi_hetero_freeze_tend, qc2qr_ice_shed_tend, qc2qi_berg_tend, qi2qv_sublim_tend, qv2qi_vapdep_tend, qcheti_cnt, qicnt, use_hetfrz_classnuc, not_skip_all);
+    if (use_separate_ice_liq_frac) {
+      // cloud
+      cloud_water_conservation(
+        qc(k), dt,
+        qc2qr_autoconv_tend, qc2qr_accret_tend, qc2qi_collect_tend, qc2qi_hetero_freeze_tend, qc2qr_ice_shed_tend, qc2qi_berg_tend, qi2qv_sublim_tend, qv2qi_vapdep_tend, qcheti_cnt, qicnt, use_hetfrz_classnuc,
+        cld_frac_l(k), cld_frac_i(k), not_skip_all);
+    } else {
+      // cloud
+      cloud_water_conservation(
+        qc(k), dt,
+        qc2qr_autoconv_tend, qc2qr_accret_tend, qc2qi_collect_tend, qc2qi_hetero_freeze_tend, qc2qr_ice_shed_tend, qc2qi_berg_tend, qi2qv_sublim_tend, qv2qi_vapdep_tend, qcheti_cnt, qicnt, use_hetfrz_classnuc, not_skip_all);
+    }
 
     // rain
     rain_water_conservation(

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
@@ -434,8 +434,8 @@ void Functions<S,D>
       // cloud
       cloud_water_conservation(
         qc(k), dt,
-        qc2qr_autoconv_tend, qc2qr_accret_tend, qc2qi_collect_tend, qc2qi_hetero_freeze_tend, qc2qr_ice_shed_tend, qc2qi_berg_tend, qi2qv_sublim_tend, qv2qi_vapdep_tend, qcheti_cnt, qicnt, use_hetfrz_classnuc,
-        cld_frac_l(k), cld_frac_i(k), not_skip_all);
+        qc2qr_autoconv_tend, qc2qr_accret_tend, qc2qi_collect_tend, qc2qi_hetero_freeze_tend, qc2qr_ice_shed_tend, qc2qi_berg_tend, qi2qv_sublim_tend, qv2qi_vapdep_tend, qcheti_cnt, qicnt, use_hetfrz_classnuc, not_skip_all,
+        cld_frac_l(k), cld_frac_i(k), runtime_options);
     } else {
       // cloud
       cloud_water_conservation(

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
@@ -419,7 +419,7 @@ void Functions<S,D>
       qr2qi_collect_tend, qc2qr_ice_shed_tend, qi2qr_melt_tend, qc2qi_collect_tend, qr2qi_immers_freeze_tend, ni2nr_melt_tend, nc_collect_tend,
       ncshdc, nc2ni_immers_freeze_tend, nr_collect_tend, ni_selfcollect_tend,
       qv2qi_vapdep_tend, nr2ni_immers_freeze_tend, ni_sublim_tend, qv2qi_nucleat_tend, ni_nucleat_tend, qc2qi_berg_tend, 
-      ncheti_cnt, qcheti_cnt, nicnt, qicnt, ninuc_cnt, qinuc_cnt, not_skip_all, &runtime_options);
+      ncheti_cnt, qcheti_cnt, nicnt, qicnt, ninuc_cnt, qinuc_cnt, not_skip_all, runtime_options);
 
     //
     // conservation of water

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -703,15 +703,8 @@ struct Functions
   static void cloud_water_conservation(const Spack& qc, const Scalar dt,
     Spack& qc2qr_autoconv_tend, Spack& qc2qr_accret_tend, Spack &qc2qi_collect_tend, Spack& qc2qi_hetero_freeze_tend,
     Spack& qc2qr_ice_shed_tend, Spack& qc2qi_berg_tend, Spack& qi2qv_sublim_tend, Spack& qv2qi_vapdep_tend,
-    Spack& qcheti_cnt, Spack& qicnt, const bool& use_hetfrz_classnuc, 
-    const Spack& cld_frac_l, const Spack& cld_frac_i,
-    const Smask& context = Smask(true) );
-
-  KOKKOS_FUNCTION
-  static void cloud_water_conservation(const Spack& qc, const Scalar dt,
-    Spack& qc2qr_autoconv_tend, Spack& qc2qr_accret_tend, Spack &qc2qi_collect_tend, Spack& qc2qi_hetero_freeze_tend,
-    Spack& qc2qr_ice_shed_tend, Spack& qc2qi_berg_tend, Spack& qi2qv_sublim_tend, Spack& qv2qi_vapdep_tend,
-    Spack& qcheti_cnt, Spack& qicnt, const bool& use_hetfrz_classnuc, const Smask& context = Smask(true) );
+    Spack& qcheti_cnt, Spack& qicnt, const bool& use_hetfrz_classnuc, const Smask& context = Smask(true),
+    const Spack& cld_frac_l = Spack(), const Spack& cld_frac_i = Spack(), const P3Runtime& runtime_options = {} );
 
   KOKKOS_FUNCTION
   static void rain_water_conservation(

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -397,7 +397,7 @@ struct Functions
                                    Spack& nr2ni_immers_freeze_tend, Spack& ni_sublim_tend, Spack& qv2qi_nucleat_tend,
                                    Spack& ni_nucleat_tend, Spack& qc2qi_berg_tend, Spack& ncheti_cnt, Spack& qcheti_cnt, 
                                    Spack& nicnt, Spack& qicnt, Spack& ninuc_cnt, Spack& qinuc_cnt, 
-                                   const Smask& context = Smask(true), const P3Runtime* runtime_options = nullptr );
+                                   const Smask& context = Smask(true), const P3Runtime& runtime_options = {} );
 
   //------------------------------------------------------------------------------------------!
   // Finds indices in 3D ice (only) lookup table

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -135,6 +135,7 @@ struct Functions
     bool set_cld_frac_i_to_one = false;
     bool set_cld_frac_r_to_one = false;
     bool use_hetfrz_classnuc   = false;
+    bool use_separate_ice_liq_frac = false;
 
     void load_runtime_options_from_file(ekat::ParameterList& params) {
       max_total_ni = params.get<double>("max_total_ni", max_total_ni);
@@ -161,6 +162,7 @@ struct Functions
       set_cld_frac_i_to_one = params.get<bool>("set_cld_frac_i_to_one", set_cld_frac_i_to_one);
       set_cld_frac_r_to_one = params.get<bool>("set_cld_frac_r_to_one", set_cld_frac_r_to_one);
       use_hetfrz_classnuc   = params.get<bool>("use_hetfrz_classnuc", use_hetfrz_classnuc);
+      use_separate_ice_liq_frac = params.get<bool>("use_separate_ice_liq_frac", use_separate_ice_liq_frac);
     }
 
   };
@@ -395,7 +397,7 @@ struct Functions
                                    Spack& nr2ni_immers_freeze_tend, Spack& ni_sublim_tend, Spack& qv2qi_nucleat_tend,
                                    Spack& ni_nucleat_tend, Spack& qc2qi_berg_tend, Spack& ncheti_cnt, Spack& qcheti_cnt, 
                                    Spack& nicnt, Spack& qicnt, Spack& ninuc_cnt, Spack& qinuc_cnt, 
-                                   const Smask& context = Smask(true) );
+                                   const Smask& context = Smask(true), const P3Runtime* runtime_options = nullptr );
 
   //------------------------------------------------------------------------------------------!
   // Finds indices in 3D ice (only) lookup table
@@ -696,6 +698,14 @@ struct Functions
     const uview_1d<const Scalar>& v, const Scalar& small,
     const Int& kbot, const Int& ktop, const Int& kdir,
     bool& log_present);
+
+  KOKKOS_FUNCTION
+  static void cloud_water_conservation(const Spack& qc, const Scalar dt,
+    Spack& qc2qr_autoconv_tend, Spack& qc2qr_accret_tend, Spack &qc2qi_collect_tend, Spack& qc2qi_hetero_freeze_tend,
+    Spack& qc2qr_ice_shed_tend, Spack& qc2qi_berg_tend, Spack& qi2qv_sublim_tend, Spack& qv2qi_vapdep_tend,
+    Spack& qcheti_cnt, Spack& qicnt, const bool& use_hetfrz_classnuc, 
+    const Spack& cld_frac_l, const Spack& cld_frac_i,
+    const Smask& context = Smask(true) );
 
   KOKKOS_FUNCTION
   static void cloud_water_conservation(const Spack& qc, const Scalar dt,


### PR DESCRIPTION
This PR is an attempt at allowing P3 to see separate liquid and ice fractions. Code changes involve passing cldfrac_liq and cldfrac_ice to P3 (instead of cldfrac_tot) and modifying the WBF process based on work done by Lin Lin in THREAD.

[BFB]