### PR TITLE
EAMxx: support the new SCORPIO I/O type ADIOSC

### DIFF
--- a/components/eamxx/src/share/io/scream_scorpio_interface.cpp
+++ b/components/eamxx/src/share/io/scream_scorpio_interface.cpp
@@ -216,6 +216,7 @@ int pio_iotype (IOType iotype) {
     case IOType::NetCDF:        iotype_int = static_cast<int>(PIO_IOTYPE_NETCDF);   break;
     case IOType::PnetCDF:       iotype_int = static_cast<int>(PIO_IOTYPE_PNETCDF);  break;
     case IOType::Adios:         iotype_int = static_cast<int>(PIO_IOTYPE_ADIOS);    break;
+    case IOType::Adiosc:        iotype_int = static_cast<int>(PIO_IOTYPE_ADIOSC);   break;
     case IOType::Hdf5:          iotype_int = static_cast<int>(PIO_IOTYPE_HDF5);     break;
     default:
       EKAT_ERROR_MSG ("Unrecognized/unsupported iotype.\n");

--- a/components/eamxx/src/share/io/scream_scorpio_types.cpp
+++ b/components/eamxx/src/share/io/scream_scorpio_types.cpp
@@ -32,6 +32,8 @@ IOType str2iotype(const std::string &str)
     return IOType::PnetCDF;
   } else if(str == "adios") {
     return IOType::Adios;
+  } else if (str == "adiosc") {
+    return IOType::Adiosc;
   } else if(str == "hdf5") {
     return IOType::Hdf5;
   } else {
@@ -47,6 +49,7 @@ std::string iotype2str(const IOType iotype)
     case IOType::NetCDF:        s = "netcdf";   break;
     case IOType::PnetCDF:       s = "pnetcdf";  break;
     case IOType::Adios:         s = "adios";    break;
+    case IOType::Adiosc:        s = "adiosc";   break;
     case IOType::Hdf5:          s = "hdf5";     break;
     case IOType::Invalid:       s = "invalid";  break;
     default:

--- a/components/eamxx/src/share/io/scream_scorpio_types.hpp
+++ b/components/eamxx/src/share/io/scream_scorpio_types.hpp
@@ -26,6 +26,7 @@ enum IOType {
   NetCDF,
   PnetCDF,
   Adios,
+  Adiosc,
   Hdf5,
   Invalid
 };


### PR DESCRIPTION
This PR updates the EAMxx-SCORPIO interface to support the new
PIO_IOTYPE_ADIOSC I/O type, enabling read/write functionality
for the ADIOS BP file format with both lossless and lossy
compression.

[BFB]