### PR TITLE
EAMxx: refactor field manipulation interfaces, and add new ones

### DIFF
--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -201,11 +201,11 @@ public:
 
   // Set the field to a constant value (on host or device)
   template<typename T, HostOrDevice HD = Device>
-  void deep_copy (const T value) const;
+  void deep_copy (const T value);
 
-  // Copy the data from one field to this field
+  // Copy the data from one field to this field (recycle update method)
   template<HostOrDevice HD = Device>
-  void deep_copy (const Field& src) const;
+  void deep_copy (const Field& src) { update<HD,CombineMode::Replace>(src,1,0); }
 
   // Updates this field y as y=alpha*x+beta*y
   // NOTE: ST=void is just so we can give a default to HD,
@@ -325,10 +325,7 @@ protected:
   void sync_views_impl () const;
 
   template<HostOrDevice HD, typename ST>
-  void deep_copy_impl (const ST value) const;
-
-  template<HostOrDevice HD, typename ST>
-  void deep_copy_impl (const Field& src) const;
+  void deep_copy_impl (const ST value);
 
   // The update method calls this, with ST matching this field data type.
   // Note: use_fill is used to determine *at compile time* whether to use
@@ -342,6 +339,7 @@ protected:
   // NOTE: if neither lsh nor rhs has "mask_value" extra data, this will throw.
   template<typename T>
   static T get_mask_value (const Field& lhs, const Field& rhs) {
+    // If present, prefer using the lhs native mask value.
     if (lhs.get_header().has_extra_data("mask_value")) {
       return lhs.get_header().get_extra_data<T>("mask_value");
     } else if (rhs.get_header().has_extra_data("mask_value")) {

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -229,6 +229,14 @@ public:
   template<HostOrDevice HD = Device>
   void scale_inv (const Field& x) { update<HD,CombineMode::Divide>(x,1,0); }
 
+  // Replace *this with max(*this, x)
+  template<HostOrDevice HD = Device>
+  void max (const Field& x) { update<HD,CombineMode::Max>(x,1,0); }
+
+  // Replace *this with min(*this, x)
+  template<HostOrDevice HD = Device>
+  void min (const Field& x) { update<HD,CombineMode::Min>(x,1,0); }
+
   // Returns a subview of this field, slicing at entry k along dimension idim
   // NOTES:
   //   - the output field stores *the same* 1d view as this field. In order

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -213,20 +213,21 @@ public:
   // NOTE: the type ST  must be such that no narrowing happens when
   //       casting the values to whatever the data type of this field is.
   //       E.g., if data_type()=IntType, you can't pass double's.
-  template<HostOrDevice HD = Device, typename ST = void>
+  // See share/util/scream_combine_ops.hpp for more details on CombineMode options
+  template<HostOrDevice HD = Device, CombineMode CM = CombineMode::ScaleUpdate, typename ST = void>
   void update (const Field& x, const ST alpha, const ST beta);
 
-  // Special case of update with alpha=0
+  // Special case of update for particular choices of the combine mode
   template<HostOrDevice HD = Device, typename ST = void>
-  void scale (const ST beta);
+  void scale (const ST beta) { update<HD,CombineMode::Rescale>(*this,ST(0),beta); }
 
   // Scale a field y as y=y*x where x is also a field
   template<HostOrDevice HD = Device>
-  void scale (const Field& x);
+  void scale (const Field& x) { update<HD,CombineMode::Multiply>(x,1,0); }
 
   // Scale a field y as y=y/x where x is also a field
   template<HostOrDevice HD = Device>
-  void scale_inv (const Field& x);
+  void scale_inv (const Field& x) { update<HD,CombineMode::Divide>(x,1,0); }
 
   // Returns a subview of this field, slicing at entry k along dimension idim
   // NOTES:
@@ -321,10 +322,30 @@ protected:
   template<HostOrDevice HD, typename ST>
   void deep_copy_impl (const Field& src) const;
 
-  template<CombineMode CM, HostOrDevice HD, typename ST>
-  void update_impl (const Field& x, const ST alpha, const ST beta, const ST fill_val);
+  // The update method calls this, with ST matching this field data type.
+  // Note: use_fill is used to determine *at compile time* whether to use
+  // the combine<CM> utility or combine_and_fill<CM>
+  template<CombineMode CM, HostOrDevice HD, bool use_fill, typename ST>
+  void update_impl (const Field& x, const ST alpha, const ST beta, const ST fill_val = 0);
 
 protected:
+
+  // This is helpful in the update method, and it can't be a lambda due to templating
+  // NOTE: if neither lsh nor rhs has "mask_value" extra data, this will throw.
+  template<typename T>
+  static T get_mask_value (const Field& lhs, const Field& rhs) {
+    if (lhs.get_header().has_extra_data("mask_value")) {
+      return lhs.get_header().get_extra_data<T>("mask_value");
+    } else if (rhs.get_header().has_extra_data("mask_value")) {
+      return rhs.get_header().get_extra_data<T>("mask_value");
+    } else {
+      EKAT_ERROR_MSG ("Error! Neither of the fields has the 'mask_value' extra data.\n"
+          " - lhs name: " + lhs.name() + "\n"
+          " - rhs name: " + rhs.name() + "\n");
+
+      return 0; // unreachable return
+    }
+  }
 
   template<HostOrDevice HD>
   const get_view_type<char*,HD>&

--- a/components/eamxx/src/share/field/field_impl.hpp
+++ b/components/eamxx/src/share/field/field_impl.hpp
@@ -617,27 +617,15 @@ void Field::deep_copy_impl (const ST value) const {
   }
 }
 
-template<HostOrDevice HD, typename ST>
+template<HostOrDevice HD, CombineMode CM, typename ST>
 void Field::
 update (const Field& x, const ST alpha, const ST beta)
 {
   const auto& dt = data_type();
 
   // Determine if there is a FillValue that requires extra treatment.
-  ST fill_val = constants::DefaultFillValue<ST>().value;
-
-  if (x.get_header().has_extra_data("mask_value")) {
-
-    if (dt==DataType::IntType) {
-      fill_val = x.get_header().get_extra_data<int>("mask_value");
-    } else if (dt==DataType::FloatType) {
-      fill_val = x.get_header().get_extra_data<float>("mask_value");
-    } else if (dt==DataType::DoubleType) {
-      fill_val = x.get_header().get_extra_data<double>("mask_value");
-    } else {
-      EKAT_ERROR_MSG ("Error! Unrecognized/unsupported field data type in Field::update.\n");
-    }
-  }
+  bool use_fill = get_header().has_extra_data("mask_value") or
+                  x.get_header().has_extra_data("mask_value");
 
   // If user passes, say, double alpha/beta for an int field, we should error out, warning about
   // a potential narrowing rounding. The other way around, otoh, is allowed (even though
@@ -650,106 +638,29 @@ update (const Field& x, const ST alpha, const ST beta)
       " - coeff data type: " + e2str(dt_st) + "\n");
 
   if (dt==DataType::IntType) {
-    return update_impl<CombineMode::ScaleUpdate,HD,int>(x,alpha,beta,fill_val);
+    if (use_fill) {
+      return update_impl<CM,HD,true,int>(x,alpha,beta,get_mask_value<int>(*this,x));
+    } else {
+      return update_impl<CM,HD,false,int>(x,alpha,beta);
+    }
   } else if (dt==DataType::FloatType) {
-    return update_impl<CombineMode::ScaleUpdate,HD,float>(x,alpha,beta,fill_val);
+    if (use_fill) {
+      return update_impl<CM,HD,true, float>(x,alpha,beta,get_mask_value<int>(*this,x));
+    } else {
+      return update_impl<CM,HD,false,float>(x,alpha,beta);
+    }
   } else if (dt==DataType::DoubleType) {
-    return update_impl<CombineMode::ScaleUpdate,HD,double>(x,alpha,beta,fill_val);
+    if (use_fill) {
+      return update_impl<CM,HD,true,double>(x,alpha,beta,get_mask_value<int>(*this,x));
+    } else {
+      return update_impl<CM,HD,false,double>(x,alpha,beta);
+    }
   } else {
     EKAT_ERROR_MSG ("Error! Unrecognized/unsupported field data type in Field::update.\n");
   }
 }
 
-template<HostOrDevice HD, typename ST>
-void Field::
-scale (const ST beta)
-{
-  const auto& dt = data_type();
-
-  // Determine if there is a FillValue that requires extra treatment.
-  ST fill_val = constants::DefaultFillValue<ST>().value;
-  if (get_header().has_extra_data("mask_value")) {
-    fill_val = get_header().get_extra_data<ST>("mask_value");
-  }
-
-  // If user passes, say, double beta for an int field, we should error out, warning about
-  // a potential narrowing rounding. The other way around, otoh, is allowed (even though
-  // there's an upper limit to the int values that a double can store, it is unlikely the user
-  // will use such large factors).
-  const auto dt_st = get_data_type<ST>();
-  EKAT_REQUIRE_MSG (not is_narrowing_conversion(dt_st,dt),
-      "Error! Coefficients alpha/beta may be narrowed when converted to x/y data type.\n"
-      " - x/y data type  : " + e2str(dt) + "\n"
-      " - coeff data type: " + e2str(dt_st) + "\n");
-
-  if (dt==DataType::IntType) {
-    return update_impl<CombineMode::Rescale,HD,int>(*this,ST(0),beta,fill_val);
-  } else if (dt==DataType::FloatType) {
-    return update_impl<CombineMode::Rescale,HD,float>(*this,ST(0),beta,fill_val);
-  } else if (dt==DataType::DoubleType) {
-    return update_impl<CombineMode::Rescale,HD,double>(*this,ST(0),beta,fill_val);
-  } else {
-    EKAT_ERROR_MSG ("Error! Unrecognized/unsupported field data type in Field::scale.\n");
-  }
-}
-
-template<HostOrDevice HD>
-void Field::
-scale_inv (const Field& x)
-{
-  const auto& dt = data_type();
-  if (dt==DataType::IntType) {
-    int fill_val = constants::DefaultFillValue<int>().value;
-    if (get_header().has_extra_data("mask_value")) {
-      fill_val = get_header().get_extra_data<int>("mask_value");
-    }
-    return update_impl<CombineMode::Divide,HD,int>(x,0,0,fill_val);
-  } else if (dt==DataType::FloatType) {
-    float fill_val = constants::DefaultFillValue<float>().value;
-    if (get_header().has_extra_data("mask_value")) {
-      fill_val = get_header().get_extra_data<float>("mask_value");
-    }
-    return update_impl<CombineMode::Divide,HD,float>(x,0,0,fill_val);
-  } else if (dt==DataType::DoubleType) {
-    double fill_val = constants::DefaultFillValue<double>().value;
-    if (get_header().has_extra_data("mask_value")) {
-      fill_val = get_header().get_extra_data<double>("mask_value");
-    }
-    return update_impl<CombineMode::Divide,HD,double>(x,0,0,fill_val);
-  } else {
-    EKAT_ERROR_MSG ("Error! Unrecognized/unsupported field data type in Field::scale_inv.\n");
-  }
-}
-
-template<HostOrDevice HD>
-void Field::
-scale (const Field& x)
-{
-  const auto& dt = data_type();
-  if (dt==DataType::IntType) {
-    int fill_val = constants::DefaultFillValue<int>().value;
-    if (get_header().has_extra_data("mask_value")) {
-      fill_val = get_header().get_extra_data<int>("mask_value");
-    }
-    return update_impl<CombineMode::Multiply,HD,int>(x,0,0,fill_val);
-  } else if (dt==DataType::FloatType) {
-    float fill_val = constants::DefaultFillValue<float>().value;
-    if (get_header().has_extra_data("mask_value")) {
-      fill_val = get_header().get_extra_data<float>("mask_value");
-    }
-    return update_impl<CombineMode::Multiply,HD,float>(x,0,0,fill_val);
-  } else if (dt==DataType::DoubleType) {
-    double fill_val = constants::DefaultFillValue<double>().value;
-    if (get_header().has_extra_data("mask_value")) {
-      fill_val = get_header().get_extra_data<double>("mask_value");
-    }
-    return update_impl<CombineMode::Multiply,HD,double>(x,0,0,fill_val);
-  } else {
-    EKAT_ERROR_MSG ("Error! Unrecognized/unsupported field data type in Field::scale.\n");
-  }
-}
-
-template<CombineMode CM, HostOrDevice HD,typename ST>
+template<CombineMode CM, HostOrDevice HD, bool use_fill, typename ST>
 void Field::
 update_impl (const Field& x, const ST alpha, const ST beta, const ST fill_val)
 {
@@ -808,7 +719,10 @@ update_impl (const Field& x, const ST alpha, const ST beta, const ST fill_val)
         auto xv = x.get_view<const ST,HD>();
         auto yv =   get_view<      ST,HD>();
         Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int /*idx*/) {
-          combine_and_fill<CM>(xv(),yv(),fill_val,alpha,beta);
+          if constexpr (use_fill)
+            combine_and_fill<CM>(xv(),yv(),fill_val,alpha,beta);
+          else
+            combine<CM>(xv(),yv(),alpha,beta);
         });
       }
       break;
@@ -820,13 +734,19 @@ update_impl (const Field& x, const ST alpha, const ST beta, const ST fill_val)
           auto xv = x.get_view<const ST*,HD>();
           auto yv =   get_view<      ST*,HD>();
           Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
-            combine_and_fill<CM>(xv(idx),yv(idx),fill_val,alpha,beta);
+            if constexpr (use_fill)
+              combine_and_fill<CM>(xv(idx),yv(idx),fill_val,alpha,beta);
+            else
+              combine<CM>(xv(idx),yv(idx),alpha,beta);
           });
         } else {
           auto xv = x.get_strided_view<const ST*,HD>();
           auto yv =   get_strided_view<      ST*,HD>();
           Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
-            combine_and_fill<CM>(xv(idx),yv(idx),fill_val,alpha,beta);
+            if constexpr (use_fill)
+              combine_and_fill<CM>(xv(idx),yv(idx),fill_val,alpha,beta);
+            else
+              combine<CM>(xv(idx),yv(idx),alpha,beta);
           });
         }
       }
@@ -838,7 +758,10 @@ update_impl (const Field& x, const ST alpha, const ST beta, const ST fill_val)
         Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
           int i,j;
           unflatten_idx(idx,ext,i,j);
-          combine_and_fill<CM>(xv(i,j),yv(i,j),fill_val,alpha,beta);
+          if constexpr (use_fill)
+            combine_and_fill<CM>(xv(i,j),yv(i,j),fill_val,alpha,beta);
+          else
+            combine<CM>(xv(i,j),yv(i,j),alpha,beta);
         });
       }
       break;
@@ -849,7 +772,10 @@ update_impl (const Field& x, const ST alpha, const ST beta, const ST fill_val)
         Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
           int i,j,k;
           unflatten_idx(idx,ext,i,j,k);
-          combine_and_fill<CM>(xv(i,j,k),yv(i,j,k),fill_val,alpha,beta);
+          if constexpr (use_fill)
+            combine_and_fill<CM>(xv(i,j,k),yv(i,j,k),fill_val,alpha,beta);
+          else
+            combine<CM>(xv(i,j,k),yv(i,j,k),alpha,beta);
         });
       }
       break;
@@ -860,7 +786,10 @@ update_impl (const Field& x, const ST alpha, const ST beta, const ST fill_val)
         Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
           int i,j,k,l;
           unflatten_idx(idx,ext,i,j,k,l);
-          combine_and_fill<CM>(xv(i,j,k,l),yv(i,j,k,l),fill_val,alpha,beta);
+          if constexpr (use_fill)
+            combine_and_fill<CM>(xv(i,j,k,l),yv(i,j,k,l),fill_val,alpha,beta);
+          else
+            combine<CM>(xv(i,j,k,l),yv(i,j,k,l),alpha,beta);
         });
       }
       break;
@@ -871,7 +800,10 @@ update_impl (const Field& x, const ST alpha, const ST beta, const ST fill_val)
         Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
           int i,j,k,l,m;
           unflatten_idx(idx,ext,i,j,k,l,m);
-          combine_and_fill<CM>(xv(i,j,k,l,m),yv(i,j,k,l,m),fill_val,alpha,beta);
+          if constexpr (use_fill)
+            combine_and_fill<CM>(xv(i,j,k,l,m),yv(i,j,k,l,m),fill_val,alpha,beta);
+          else
+            combine<CM>(xv(i,j,k,l,m),yv(i,j,k,l,m),alpha,beta);
         });
       }
       break;
@@ -882,7 +814,10 @@ update_impl (const Field& x, const ST alpha, const ST beta, const ST fill_val)
         Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
           int i,j,k,l,m,n;
           unflatten_idx(idx,ext,i,j,k,l,m,n);
-          combine_and_fill<CM>(xv(i,j,k,l,m,n),yv(i,j,k,l,m,n),fill_val,alpha,beta);
+          if constexpr (use_fill)
+            combine_and_fill<CM>(xv(i,j,k,l,m,n),yv(i,j,k,l,m,n),fill_val,alpha,beta);
+          else
+            combine<CM>(xv(i,j,k,l,m,n),yv(i,j,k,l,m,n),alpha,beta);
         });
       }
       break;

--- a/components/eamxx/src/share/field/field_impl.hpp
+++ b/components/eamxx/src/share/field/field_impl.hpp
@@ -325,33 +325,9 @@ void Field::sync_views_impl () const {
   }
 }
 
-template<HostOrDevice HD>
-void Field::
-deep_copy (const Field& src) const {
-  EKAT_REQUIRE_MSG (not m_is_read_only,
-      "Error! Cannot call deep_copy on read-only fields.\n");
-
-  EKAT_REQUIRE_MSG (data_type()==src.data_type(),
-      "Error! Cannot copy fields with different data type.\n");
-
-  switch (data_type()) {
-    case DataType::IntType:
-      deep_copy_impl<HD,int>(src);
-      break;
-    case DataType::FloatType:
-      deep_copy_impl<HD,float>(src);
-      break;
-    case DataType::DoubleType:
-      deep_copy_impl<HD,double>(src);
-      break;
-    default:
-      EKAT_ERROR_MSG ("Error! Unrecognized field data type in Field::deep_copy.\n");
-  }
-}
-
 template<typename ST, HostOrDevice HD>
 void Field::
-deep_copy (const ST value) const {
+deep_copy (const ST value) {
   EKAT_REQUIRE_MSG (not m_is_read_only,
       "Error! Cannot call deep_copy on read-only fields.\n");
 
@@ -384,155 +360,8 @@ deep_copy (const ST value) const {
 }
 
 template<HostOrDevice HD, typename ST>
-void Field::
-deep_copy_impl (const Field& src) const {
-
-  const auto& layout     =     get_header().get_identifier().get_layout();
-  const auto& layout_src = src.get_header().get_identifier().get_layout();
-  EKAT_REQUIRE_MSG(layout==layout_src,
-       "ERROR: Unable to copy field " + src.get_header().get_identifier().name() +
-          " to field " + get_header().get_identifier().name() + ".  Layouts don't match.\n");
-  const auto  rank = layout.rank();
-
-  // For rank 0 view, we only need to copy a single value and return
-  if (rank == 0) {
-    auto v     =     get_view<      ST,HD>();
-    auto v_src = src.get_view<const ST,HD>();
-    Kokkos::deep_copy(v,v_src);
-    return;
-  }
-
-  // Note: we can't just do a deep copy on get_view_impl<HD>(), since this
-  //       field might be a subfield of another. We need the reshaped view.
-  //       Also, don't call Kokkos::deep_copy if this field and src have
-  //       different pack sizes.
-  auto src_alloc_props = src.get_header().get_alloc_properties();
-  auto tgt_alloc_props =     get_header().get_alloc_properties();
-
-  using device_t = typename Field::get_device<HD>;
-  using exec_space = typename device_t::execution_space;
-  using RangePolicy = Kokkos::RangePolicy<exec_space>;
-
-  auto policy = RangePolicy(0,layout.size());
-
-  using extents_type = typename ekat::KokkosTypes<device_t>::template view_1d<int>;
-  extents_type ext;
-  if constexpr (HD==Device) {
-    ext = layout.extents();
-  } else {
-    ext = layout.extents_h();
-  }
-  switch (rank) {
-    case 1:
-      {
-        if (src_alloc_props.contiguous() and tgt_alloc_props.contiguous()) {
-          auto v     =     get_view<      ST*,HD>();
-          auto v_src = src.get_view<const ST*,HD>();
-          Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
-            v(idx) = v_src(idx);
-          });
-        } else {
-          auto v     =     get_strided_view<      ST*,HD>();
-          auto v_src = src.get_strided_view<const ST*,HD>();
-          Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
-            v(idx) = v_src(idx);
-          });
-        }
-      }
-      break;
-    case 2:
-      {
-        if (src_alloc_props.contiguous() and tgt_alloc_props.contiguous()) {
-          auto v     =     get_view<      ST**,HD>();
-          auto v_src = src.get_view<const ST**,HD>();
-          Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
-            int i,j;
-            unflatten_idx(idx,ext,i,j);
-            v(i,j) = v_src(i,j);
-          });
-        }
-        else {
-          auto v     =     get_strided_view<      ST**,HD>();
-          auto v_src = src.get_strided_view<const ST**,HD>();
-          Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
-            int i,j;
-            unflatten_idx(idx,ext,i,j);
-            v(i,j) = v_src(i,j);
-          });
-        }
-      }
-      break;
-    case 3:
-      {
-        if (src_alloc_props.contiguous() and tgt_alloc_props.contiguous()) {
-          auto v     =     get_view<      ST***,HD>();
-          auto v_src = src.get_view<const ST***,HD>();
-          Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
-            int i,j,k;
-            unflatten_idx(idx,ext,i,j,k);
-            v(i,j,k) = v_src(i,j,k);
-          });
-        } else {
-          auto v     =     get_strided_view<      ST***,HD>();
-          auto v_src = src.get_strided_view<const ST***,HD>();
-          Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
-            int i,j,k;
-            unflatten_idx(idx,ext,i,j,k);
-            v(i,j,k) = v_src(i,j,k);
-          });
-        }
-      }
-      break;
-    case 4:
-      {
-        if (src_alloc_props.contiguous() and tgt_alloc_props.contiguous()) {
-          auto v     =     get_view<      ST****,HD>();
-          auto v_src = src.get_view<const ST****,HD>();
-          Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
-            int i,j,k,l;
-            unflatten_idx(idx,ext,i,j,k,l);
-            v(i,j,k,l) = v_src(i,j,k,l);
-          });
-        } else {
-          auto v     =     get_strided_view<      ST****,HD>();
-          auto v_src = src.get_strided_view<const ST****,HD>();
-          Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
-            int i,j,k,l;
-            unflatten_idx(idx,ext,i,j,k,l);
-            v(i,j,k,l) = v_src(i,j,k,l);
-          });
-        }
-      }
-      break;
-    case 5:
-      {
-        if (src_alloc_props.contiguous() and tgt_alloc_props.contiguous()) {
-          auto v     =     get_view<      ST*****,HD>();
-          auto v_src = src.get_view<const ST*****,HD>();
-          Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
-            int i,j,k,l,m;
-            unflatten_idx(idx,ext,i,j,k,l,m);
-            v(i,j,k,l,m) = v_src(i,j,k,l,m);
-          });
-        } else {
-          auto v     =     get_view<      ST*****,HD>();
-          auto v_src = src.get_view<const ST*****,HD>();
-          Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
-            int i,j,k,l,m;
-            unflatten_idx(idx,ext,i,j,k,l,m);
-            v(i,j,k,l,m) = v_src(i,j,k,l,m);
-          });
-        }
-      }
-      break;
-    default:
-      EKAT_ERROR_MSG ("Error! Unsupported field rank in 'deep_copy'.\n");
-  }
-}
-
-template<HostOrDevice HD, typename ST>
-void Field::deep_copy_impl (const ST value) const {
-
+void Field::deep_copy_impl (const ST value)
+{
   // Note: we can't just do a deep copy on get_view_impl<HD>(), since this
   //       field might be a subfield of another. Instead, get the
   //       reshaped view first, based on the field rank.
@@ -621,6 +450,11 @@ template<HostOrDevice HD, CombineMode CM, typename ST>
 void Field::
 update (const Field& x, const ST alpha, const ST beta)
 {
+  // Check this field is writable
+  EKAT_REQUIRE_MSG (not is_read_only(),
+      "Error! Cannot update field, as it is read-only.\n"
+      " - field name: " + name() + "\n");
+
   const auto& dt = data_type();
 
   // Determine if there is a FillValue that requires extra treatment.
@@ -671,11 +505,6 @@ update_impl (const Field& x, const ST alpha, const ST beta, const ST fill_val)
   EKAT_REQUIRE_MSG (x.is_allocated(),
       "Error! Cannot update field, since source field is not allocated.\n"
       " - field name: " + x.name() + "\n");
-
-  // Check y is writable
-  EKAT_REQUIRE_MSG (not is_read_only(),
-      "Error! Cannot update field, as it is read-only.\n"
-      " - field name: " + name() + "\n");
 
   // Check compatibility between fields data type
   const auto dt_x = x.data_type();

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -853,6 +853,42 @@ TEST_CASE ("update") {
     }
   }
 
+  SECTION ("max-min") {
+    SECTION ("real") {
+      Field one = f_real.clone();
+      Field two = f_real.clone();
+      one.deep_copy(1.0);
+      two.deep_copy(2.0);
+
+      Field f1 = one.clone();
+      Field f2 = two.clone();
+      f1.max(f2);
+      REQUIRE (views_are_equal(f1, f2));
+
+      Field f3 = one.clone();
+      Field f4 = two.clone();
+      f4.min(f3);
+      REQUIRE (views_are_equal(f3, f4));
+    }
+
+    SECTION ("int") {
+      Field one = f_int.clone();
+      Field two = f_int.clone();
+      one.deep_copy(1);
+      two.deep_copy(2);
+
+      Field f1 = one.clone();
+      Field f2 = two.clone();
+      f1.max(f2);
+      REQUIRE (views_are_equal(f1, f2));
+
+      Field f3 = one.clone();
+      Field f4 = two.clone();
+      f4.min(f3);
+      REQUIRE (views_are_equal(f3, f4));
+    }
+  }
+
   SECTION ("scale_inv") {
     SECTION ("real") {
       Field f1 = f_real.clone();

--- a/components/eamxx/src/share/util/scream_combine_ops.hpp
+++ b/components/eamxx/src/share/util/scream_combine_ops.hpp
@@ -3,10 +3,12 @@
 
 #include "share/util/scream_universal_constants.hpp"
 
+#include <ekat/ekat_scalar_traits.hpp>
+#include <ekat/util/ekat_math_utils.hpp>
+
 // For KOKKOS_INLINE_FUNCTION
 #include <Kokkos_Core.hpp>
 #include <type_traits>
-#include "ekat/ekat_scalar_traits.hpp"
 
 namespace scream {
 
@@ -35,7 +37,9 @@ enum class CombineMode {
   Rescale,      // out = beta*out
   Replace,      // out = in
   Multiply,     // out = out*in
-  Divide        // out = out/in
+  Divide,       // out = out/in
+  Max,          // out = max(out,in)
+  Min           // out = min(out,in)
 };
 
 // Functions mostly used for debug purposes. They check whether a combine mode
@@ -52,7 +56,6 @@ static constexpr bool needsBeta () {
   return CM==CombineMode::Update || CM==CombineMode::ScaleUpdate || CM==CombineMode::Rescale;
 }
 
-
 // Small helper functions to combine a new value with an old one.
 // The template argument help reducing the number of operations
 // performed (the if is resolved at compile time). In the most
@@ -68,6 +71,8 @@ void combine (const ScalarIn& newVal, ScalarOut& result,
               const CoeffType alpha = CoeffType(1),
               const CoeffType beta  = CoeffType(0))
 {
+  using ekat::impl::max;
+  using ekat::impl::min;
   switch (CM) {
     case CombineMode::Replace:
       result = newVal;
@@ -97,6 +102,12 @@ void combine (const ScalarIn& newVal, ScalarOut& result,
       break;
     case CombineMode::Divide:
       result /= newVal;
+      break;
+    case CombineMode::Max:
+      result  = max(result,static_cast<const ScalarOut&>(newVal));
+      break;
+    case CombineMode::Min:
+      result  = min(result,static_cast<const ScalarOut&>(newVal));
       break;
   }
 }
@@ -136,6 +147,11 @@ void combine_and_fill (const ScalarIn& newVal, ScalarOut& result, const ScalarOu
         combine<CM>(newVal,result,alpha,beta);
       }
       break;
+    case CombineMode::Max:
+    case CombineMode::Min:
+      if (newVal != fill_val)
+        combine<CM>(newVal,result);
+        
   }
 }
 


### PR DESCRIPTION
Simplify implementation of the scale/scale_inv method, and add new ones for max/min.

[BFB]
---

First, the current implementation had several methods implemented that could just be expressed as a single call to `update`, if only `update` accepted different combine mode values (like `update_impl` did). The solution was simple: template `update` on the combine mode, defaulting to the current behavior (i.e., `ScaleUpdate`). With this modification, `scale`, `scale_impl` and also `deep_copy` (from a Field rhs) could be rewritten as a 1-liner call to `update`.

Second, the PR adds two more values for `CombineMode`, namely `Max` and `Min`. The goal is to later use Field operations inside `scorpio_output.cpp`, to avoid manually handling the same kind of stuff in that class, simplifying its implementation.