### PR TITLE
For machine gcp12, load python module to reach minimum python version

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -5139,6 +5139,7 @@
       </modules>
 
       <modules compiler="gnu">
+	<command name="load">python</command>
 	<command name="load">cmake</command>
 	<command name="load">perl</command>
 	<command name="load">perl-xml-libxml</command>


### PR DESCRIPTION
After updated CIME PR, some of the tests on gcp12 were failing and a newer python allows *some* tests to pass.
Simply add line to load python module instead of using the default.

We now see that newer python version is needed at create_test time for all tests to pass.
Still merging this PR to include python.

[bfb]
