### PR TITLE
Update gcc libs for eamxx on Anvil

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2324,10 +2324,12 @@
       <cmd_path lang="csh">module</cmd_path>
       <modules>
         <command name="purge"/>
+        <command name="use">/lcrc/group/e3sm/soft/modulefiles/anvil</command>
+        <command name="load">python/3.9.16-gm6ql7v</command>
         <command name="load">cmake/3.26.3-nszudya</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">gcc/7.4.0</command>
+        <command name="load">gcc/8.2.0</command>
         <command name="load">intel/20.0.4-lednsve</command>
         <command name="load">intel-mkl/2020.4.304-voqlapk</command>
       </modules>

--- a/cime_config/testmods_dirs/config_pes_tests.xml
+++ b/cime_config/testmods_dirs/config_pes_tests.xml
@@ -101,7 +101,7 @@
       <pes compset="any" pesize="any">
         <comment>test+anvil: any compset on ne4 grid -- 4 nodes pure-MPI </comment>
         <ntasks>
-          <ntasks_atm>108</ntasks_atm>
+          <ntasks_atm>96</ntasks_atm>
           <ntasks_ice>108</ntasks_ice>
           <ntasks_cpl>108</ntasks_cpl>
           <ntasks_lnd>36</ntasks_lnd>

--- a/components/eamxx/cmake/machine-files/anvil.cmake
+++ b/components/eamxx/cmake/machine-files/anvil.cmake
@@ -1,0 +1,15 @@
+include(${CMAKE_CURRENT_LIST_DIR}/common.cmake)
+common_setup()
+
+set(EKAT_MACH_FILES_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../../externals/ekat/cmake/machine-files)
+
+# Get arch settings
+include(${EKAT_MACH_FILES_PATH}/kokkos/intel-bdw.cmake)
+
+# Add OpenMP settings in standalone mode OR e3sm with compile_threaded=ON
+if (NOT "${PROJECT_NAME}" STREQUAL "E3SM" OR compile_threaded)
+  include(${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
+endif()
+
+# Use srun for standalone testing
+include(${EKAT_MACH_FILES_PATH}/mpi/srun.cmake)


### PR DESCRIPTION
Update gcc libs for eamxx on Anvil:
- update gcc from 7.4.0 to 8.2.0 to fix build fails in eamxx's
    references to newer C++ API
- avoid over-decomposing ne4 grid: run with 96 mpi tasks
- add eamxx cmake machine-file for anvil

[NML] - due to PE changes