### PR TITLE
Bugfix for frazil ice temperature tendency

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_frazil_forcing.F
@@ -599,6 +599,10 @@ contains
                                                  * config_frazil_ice_density ) / (config_specific_heat_sea_water * rho_sw) &
                                                  / dt
 
+              ! ocean fluid temperature is modified due to mixing of existing water with meltwater at the freezing point
+              frazilTemperatureTendency(k,iCell) = frazilTemperatureTendency(k,iCell) + &
+                   meltedFrazilIceThickness * oceanFreezingTemperature / dt
+
               ! keep track of new frazil ice
               sumNewThicknessWeightedSaltContent = sumNewThicknessWeightedSaltContent - meltedThicknessWeightedSaltContent
               sumNewFrazilIceThickness = sumNewFrazilIceThickness - meltedFrazilIceThickness


### PR DESCRIPTION
Add temperature tendency due to mixing of frazil meltwater with seawater:

When frazil ice melts in MPAS-Ocean it is a freshwater volume flux (not a virtual flux). As such, there should be two components to the temperature tendency due to frazil melt, a latent heat flux and a flux associated with the mixing of water at the freezing point with the ambient seawater. The latter was not included (a bug).

Fixes #6975
[non-BFB]