### PR TITLE
Update config_machines.xml for Feb 18 software update on Frontier.

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1205,30 +1205,29 @@
     </mpirun>
 
     <module_system type="module" allow_error="true">
-      <init_path lang="sh">/usr/share/lmod/lmod/init/sh</init_path>
-      <init_path lang="csh">/usr/share/lmod/lmod/init/csh</init_path>
-      <init_path lang="perl">/usr/share/lmod/lmod/init/perl</init_path>
-      <init_path lang="python">/usr/share/lmod/lmod/init/env_modules_python.py</init_path>
-      <cmd_path lang="perl">/usr/share/lmod/lmod/libexec/lmod perl</cmd_path>
+      <init_path lang="sh">/opt/cray/pe/lmod/lmod/init/sh</init_path>
+      <init_path lang="csh">/opt/cray/pe/lmod/lmod/init/csh</init_path>
+      <init_path lang="perl">/opt/cray/pe/lmod/lmod/init/perl</init_path>
+      <init_path lang="python">/opt/cray/pe/lmod/lmod/init/env_modules_python.py</init_path>
+      <cmd_path lang="perl">/opt/cray/pe/lmod/lmod/libexec/lmod perl</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
-      <cmd_path lang="python">/usr/share/lmod/lmod/libexec/lmod python</cmd_path>
+      <cmd_path lang="python">/opt/cray/pe/lmod/lmod/libexec/lmod python</cmd_path>
       <modules compiler="craygnuamdgpu">
         <command name="reset"></command>
         <!-- PrgEnv-gnu before cpe, or cray-mpich module doesn't update correctly -->
         <command name="load">PrgEnv-gnu</command>
-        <command name="load">cpe/24.07</command>
-        <command name="load">libfabric/1.15.2.0</command>
+        <command name="load">cpe/24.11</command>
         <command name="load">craype-accel-amd-gfx90a</command>
-        <command name="load">rocm/6.2.0</command>
-        <command name="load">libunwind</command>
-        <command name="load">cray-python</command>
-        <command name="load">subversion</command>
-        <command name="load">git</command>
-        <command name="load">cmake</command>
-        <command name="load">cray-hdf5-parallel</command>
-        <command name="load">cray-netcdf-hdf5parallel</command>
-        <command name="load">cray-parallel-netcdf</command>
+        <command name="load">rocm/6.2.4</command>
+        <command name="load">libunwind/1.6.2</command>
+        <command name="load">cray-python/3.11.7</command>
+        <command name="load">subversion/1.14.2</command>
+        <command name="load">git/2.45.1</command>
+        <command name="load">cmake/3.27.9</command>
+        <command name="load">cray-hdf5-parallel/1.14.3.3</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.9.0.15</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.15</command>
         <command name="unload">darshan-runtime</command>
       </modules>
       <modules compiler="crayclang-scream">
@@ -1239,7 +1238,7 @@
         <command name="load">rocm/5.4.0</command>
         <command name="load">libunwind/1.5.0</command>
         <command name="load">cce/15.0.1</command>
-        <command name="load">libfabric/1.15.2.0</command>
+        <command name="load">libfabric/1.20.1</command>
         <command name="load">craype/2.7.20</command>
         <command name="load">cray-mpich/8.1.26</command>
         <command name="load">cray-python/3.9.13.1</command>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1217,17 +1217,18 @@
         <command name="reset"></command>
         <!-- PrgEnv-gnu before cpe, or cray-mpich module doesn't update correctly -->
         <command name="load">PrgEnv-gnu</command>
-        <command name="load">cpe/24.11</command>
+        <command name="load">cpe/24.07</command>
+        <command name="load">libfabric/1.20.1</command>
         <command name="load">craype-accel-amd-gfx90a</command>
-        <command name="load">rocm/6.2.4</command>
+        <command name="load">rocm/6.1.3</command>
         <command name="load">libunwind/1.6.2</command>
         <command name="load">cray-python/3.11.7</command>
         <command name="load">subversion/1.14.2</command>
         <command name="load">git/2.45.1</command>
         <command name="load">cmake/3.27.9</command>
-        <command name="load">cray-hdf5-parallel/1.14.3.3</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.9.0.15</command>
-        <command name="load">cray-parallel-netcdf/1.12.3.15</command>
+        <command name="load">cray-hdf5-parallel/1.14.3.1</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.9.0.13</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.13</command>
         <command name="unload">darshan-runtime</command>
       </modules>
       <modules compiler="crayclang-scream">


### PR DESCRIPTION
Various changes to `config_machines.xml` in preparation for system software updates on Frontier on 2025-02-18. Within the `frontier-scream-gpu` machine:
* Change `lmod` paths from `/usr/share` to `/opt/cray/pe` because the `/usr/share` software is not maintained and is not available on internal OLCF test computers.
* Update `craygnuamdgpu` to latest version of `cpe` available on Frontier, `cpe/24.11`.
* Add explicit versions to other modules in `craygnuamdgpu`. I used to think this wasn't needed, since `module load cpe/24.11` should set all the appropriate defaults. I recently discovered that this setting of defaults only works if the `module load cpe/24.11` is a separate command before the other `module load`s. Cime uses a single `module load` with a list of modules, which does not update the defaults. I selected the explicit versions based on the `cpe/24.11` defaults, including the default for `rocm`, `rocm/6.2.4`.
* Remove the `libfabric` module from `craygnuamdgpu`. On Feb 18, the default `libfabric` will change from `libfabric/1.20.1` to `libfabric/1.22.0`, but the latter is not yet available on Frontier. Only the default version on a given computer is officially supported by HPE. I removed the `libfabric` module from `craygnuamdgpu` so that it will stay with the default when it changes.
* Change from `libfabric/1.15.2.0` to `libfabric/1.20.1` for `crayclang-scream`. On Feb 18, `libfabric/1.15.2.0` will disappear from Frontier. And the new default, `libfabric/1.22.0`, does not support Cray MPI versions before `cray-mpich/8.1.28`. Because `crayclang-scream` is stuck back at `cpe/22.12` and `cray-mpich/8.1.26`, we have to use `libfabric/1.20.1`. We previously switched from `libfabric/1.20.1` to `libfabric/1.15.2.0` because the former had a serious performance regression. That is supposed to be fixed. And, yes, this does mean that `crayclang-scream` will be using a version of `libfabric` that isn't officially supported with the `libfabric/1.22.0` drivers, mais c'est la vie.

I ran an 8-node test of NE30 on Frontier and on our internal system (for `libfabric/1.22.0`) to confirm that the changes work and probably don't seriously impact performance. Here are timing results as reported in `e3sm_timing.t.*`.

| Compiler | `cpe` | `rocm` | `libfabric` | `CPM:ATM_RUN` |
| --- | --- | --- | --- | --- |
| `crayclang-scream` | 22.12 | 5.4.0 | 1.15.2.0 | 15.855:  16.571 |
| | | | 1.20.1 | 15.885:  16.683 |
| `craygnuamdgpu` | 24.07 | 6.2.0 | 1.15.2.0 | 14.850:  15.594 |
| | 24.11 | 6.2.4 | 1.15.2.0 | 14.727:  15.644 |
| | | | 1.20.1 | 14.729:  15.447 |
| | | | 1.22.0 | 14.990:  15.601 |

It would probably be good to confirm with NE1024 runs.