### PR TITLE
Restore EKAT nightly testing

### DIFF
--- a/.github/actions/test-all-scream/action.yml
+++ b/.github/actions/test-all-scream/action.yml
@@ -77,8 +77,12 @@ runs:
         cmd="./scripts/test-all-scream -m ${{ inputs.machine }} -t ${{inputs.build_type}} --baseline-dir AUTO -c EKAT_DISABLE_TPL_WARNINGS=ON"
         if [ "${{ inputs.generate }}" = "true" ]; then
           cmd+=" -g"
-        elif [ "${{ inputs.submit }}" = "true" ]; then 
+        elif [ "${{ inputs.submit }}" = "true" ]; then
           cmd+=" -s"
+        fi
+
+        if [ "${{ inputs.ekat }}" = "true" ]; then
+           cmd+= " -c EKAT_ENABLE_TESTS=ON"
         fi
 
         # If cmake-configs is non-empty, add tokens to test-all-scream via "-c key=val"

--- a/.github/workflows/eamxx-sa-testing.yml
+++ b/.github/workflows/eamxx-sa-testing.yml
@@ -54,6 +54,8 @@ env:
   # Submit to cdash only for nightlies or if the user explicitly forced a submission via workflow dispatch
   submit: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.submit) }}
   generate: ${{ github.event_name == 'workflow_dispatch' && inputs.bless }}
+  # Do EKAT testing for nightlies or (TODO: if EKAT label is present)
+  ekat: ${{ github.event_name == 'schedule' }}
 
 jobs:
   gcc-openmp:
@@ -61,7 +63,7 @@ jobs:
       ${{
         github.event_name != 'workflow_dispatch' ||
         (
-          github.event.inputs.job_to_run == 'gcc-openmp' || 
+          github.event.inputs.job_to_run == 'gcc-openmp' ||
           github.event.inputs.job_to_run == 'all'
         )
       }}
@@ -88,12 +90,13 @@ jobs:
           generate: ${{ env.generate }}
           submit: ${{ env.submit }}
           cmake-configs: Kokkos_ENABLE_OPENMP=ON
+          ekat: ${{ env.ekat }}
   gcc-cuda:
     if: |
       ${{
         github.event_name != 'workflow_dispatch' ||
         (
-          github.event.inputs.job_to_run == 'gcc-cuda' || 
+          github.event.inputs.job_to_run == 'gcc-cuda' ||
           github.event.inputs.job_to_run == 'all'
         )
       }}
@@ -149,3 +152,4 @@ jobs:
           generate: ${{ env.generate }}
           submit: ${{ env.submit }}
           cmake-configs: Kokkos_ARCH_HOPPER90=${{ env.Hopper }};Kokkos_ARCH_AMPERE80=${{ env.Ampere }};Kokkos_ARCH_VOLTA70=${{ env.Volta }};CMAKE_CUDA_ARCHITECTURES=${{ env.CUDA_ARCH }}
+          ekat: ${{ env.ekat }}


### PR DESCRIPTION
The Jenkins scripts used to enable EKAT testing for nightly runs:

```
  if [ -n "$PULLREQUESTNUM" ]; then
      is_at_run=1
  else
      TAS_ARGS="${TAS_ARGS} --test-level nightly"
      # We never want to submit a fake run to the dashboard                                                                                                                                                                    
      if [ -z "$SCREAM_FAKE_ONLY" ]; then
          # Run EKAT tests for real nightly runs                                                                                                                                                                               
          TAS_ARGS="${TAS_ARGS} --submit -c EKAT_ENABLE_TESTS=ON"
      fi
  fi
```

It looks like we also lost the `--test-level nightly` flag. Looking around eamxx, it looks like the cmake setting `SCREAM_TEST_LEVEL` is not really used for much, so maybe this is fine for now.

This PR will re-enable EKAT testing for scheduled runs (nightlies). I'd also like to enable them when the EKAT label is present on a PR is present, but that seems to be pretty hard to do in the YAML.

Also, remove trailing whitespace in a few places.

[BFB]