### PR TITLE
EAMxx: Lower min sfc pressure in post-condition check

### DIFF
--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
@@ -466,7 +466,7 @@ void HommeDynamics::initialize_impl (const RunType run_type)
   add_postcondition_check<LowerBound>(*get_group_out("Q",pgn).m_bundle,m_phys_grid,0,true);
   add_postcondition_check<Interval>(get_field_out("T_mid",pgn),m_phys_grid,100.0, 500.0,false);
   add_postcondition_check<Interval>(get_field_out("horiz_winds",pgn),m_phys_grid,-400.0, 400.0,false);
-  add_postcondition_check<Interval>(get_field_out("ps"),m_phys_grid,40000.0, 120000.0,false);
+  add_postcondition_check<Interval>(get_field_out("ps"),m_phys_grid,30000.0, 120000.0,false);
 
   // Initialize Rayleigh friction variables
   rayleigh_friction_init();


### PR DESCRIPTION
The current minimum sfc pressure threshold is 400mb, even though lower values have been observed on the summit of mt everest. Multiple simulations have hit this minimum pressure threshold for conditions that seem reasonable, so this PR lowers the threshold to 300 mb.

[BFB]