### PR TITLE
Calculate fluxes in MOAB coupler with MOAB data

### DIFF
--- a/driver-moab/main/cime_comp_mod.F90
+++ b/driver-moab/main/cime_comp_mod.F90
@@ -134,8 +134,8 @@ module cime_comp_mod
 #endif
 
   ! flux calc routines
-  use seq_flux_mct, only: seq_flux_init_mct, seq_flux_initexch_mct, seq_flux_ocnalb_mct
-  use seq_flux_mct, only: seq_flux_atmocn_mct, seq_flux_atmocnexch_mct, seq_flux_readnl_mct
+  use seq_flux_mct, only: seq_flux_init, seq_flux_initexch_mct, seq_flux_ocnalb_mct
+  use seq_flux_mct, only: seq_flux_atmocnexch_mct, seq_flux_readnl_mct
 
   use seq_flux_mct, only: seq_flux_atmocn_moab ! will set the ao fluxes on atm or ocn coupler mesh
 
@@ -2358,11 +2358,11 @@ contains
 
           if (trim(aoflux_grid) == 'ocn') then
 
-             call seq_flux_init_mct(ocn(ens1), fractions_ox(ens1),mboxid)
+             call seq_flux_init(ocn(ens1), fractions_ox(ens1),mboxid)
 
           elseif (trim(aoflux_grid) == 'atm') then
 
-             call seq_flux_init_mct(atm(ens1), fractions_ax(ens1),mbaxid)
+             call seq_flux_init(atm(ens1), fractions_ax(ens1),mbaxid)
 
           elseif (trim(aoflux_grid) == 'exch') then
 
@@ -3989,8 +3989,7 @@ contains
           o2x_ax => prep_atm_get_o2x_ax()    ! array over all instances
           xao_ax => prep_aoflux_get_xao_ax() ! array over all instances
           ! TODO:  Fix this so it works with fluxes on atm mesh.  Need mbafxid
-          call seq_flux_atmocn_mct(infodata, tod, dtime, a2x_ax, o2x_ax(eoi), xao_ax(exi), mbaxid, mbofxid)
-          !call seq_flux_atmocn_moab( atm(eai), xao_ax(exi) ) ! should be only one ensemble probably
+          call seq_flux_atmocn_moab(infodata, tod, dtime, a2x_ax, o2x_ax(eoi), xao_ax(exi), mbaxid, mbofxid)
        enddo
        call t_drvstopf  ('CPL:atmocna_fluxa',hashint=hashint(6))
 
@@ -4009,8 +4008,7 @@ contains
           a2x_ox => prep_ocn_get_a2x_ox()
           o2x_ox => component_get_c2x_cx(ocn(eoi))
           xao_ox => prep_aoflux_get_xao_ox()
-          call seq_flux_atmocn_mct(infodata, tod, dtime, a2x_ox(eai), o2x_ox, xao_ox(exi), mboxid, mbofxid)
-          call seq_flux_atmocn_moab( ocn(eoi), xao_ox(exi) )
+          call seq_flux_atmocn_moab(infodata, tod, dtime, a2x_ox(eai), o2x_ox, xao_ox(exi), mboxid, mbofxid)
        enddo
        call t_drvstopf  ('CPL:atmocnp_fluxo',hashint=hashint(6))
     endif  ! aoflux_grid

--- a/driver-moab/main/cime_comp_mod.F90
+++ b/driver-moab/main/cime_comp_mod.F90
@@ -2358,11 +2358,11 @@ contains
 
           if (trim(aoflux_grid) == 'ocn') then
 
-             call seq_flux_init_mct(ocn(ens1), fractions_ox(ens1))
+             call seq_flux_init_mct(ocn(ens1), fractions_ox(ens1),mboxid)
 
           elseif (trim(aoflux_grid) == 'atm') then
 
-             call seq_flux_init_mct(atm(ens1), fractions_ax(ens1))
+             call seq_flux_init_mct(atm(ens1), fractions_ax(ens1),mbaxid)
 
           elseif (trim(aoflux_grid) == 'exch') then
 
@@ -3969,6 +3969,7 @@ contains
   !===============================================================================
 
   subroutine cime_run_atmocn_fluxes(hashint)
+    use seq_comm_mct , only :  mbaxid, mboxid, mbofxid 
     integer, intent(inout) :: hashint(:)
 
     !----------------------------------------------------------
@@ -3987,7 +3988,8 @@ contains
           a2x_ax => component_get_c2x_cx(atm(eai))
           o2x_ax => prep_atm_get_o2x_ax()    ! array over all instances
           xao_ax => prep_aoflux_get_xao_ax() ! array over all instances
-          call seq_flux_atmocn_mct(infodata, tod, dtime, a2x_ax, o2x_ax(eoi), xao_ax(exi))
+          ! TODO:  Fix this so it works with fluxes on atm mesh.  Need mbafxid
+          call seq_flux_atmocn_mct(infodata, tod, dtime, a2x_ax, o2x_ax(eoi), xao_ax(exi), mbaxid, mbofxid)
           !call seq_flux_atmocn_moab( atm(eai), xao_ax(exi) ) ! should be only one ensemble probably
        enddo
        call t_drvstopf  ('CPL:atmocna_fluxa',hashint=hashint(6))
@@ -4007,7 +4009,7 @@ contains
           a2x_ox => prep_ocn_get_a2x_ox()
           o2x_ox => component_get_c2x_cx(ocn(eoi))
           xao_ox => prep_aoflux_get_xao_ox()
-          call seq_flux_atmocn_mct(infodata, tod, dtime, a2x_ox(eai), o2x_ox, xao_ox(exi))
+          call seq_flux_atmocn_mct(infodata, tod, dtime, a2x_ox(eai), o2x_ox, xao_ox(exi), mboxid, mbofxid)
           call seq_flux_atmocn_moab( ocn(eoi), xao_ox(exi) )
        enddo
        call t_drvstopf  ('CPL:atmocnp_fluxo',hashint=hashint(6))

--- a/driver-moab/main/cime_comp_mod.F90
+++ b/driver-moab/main/cime_comp_mod.F90
@@ -134,7 +134,7 @@ module cime_comp_mod
 #endif
 
   ! flux calc routines
-  use seq_flux_mct, only: seq_flux_init, seq_flux_initexch_mct, seq_flux_ocnalb_mct
+  use seq_flux_mct, only: seq_flux_init, seq_flux_initexch_mct, seq_flux_ocnalb
   use seq_flux_mct, only: seq_flux_atmocnexch_mct, seq_flux_readnl_mct
 
   use seq_flux_mct, only: seq_flux_atmocn_moab ! will set the ao fluxes on atm or ocn coupler mesh
@@ -2362,10 +2362,12 @@ contains
 
           elseif (trim(aoflux_grid) == 'atm') then
 
+          !TODO check that atm works
              call seq_flux_init(atm(ens1), fractions_ax(ens1),mbaxid)
 
           elseif (trim(aoflux_grid) == 'exch') then
 
+          !TODO  could use intersection mesh for exchange grid
              call shr_sys_abort(subname//' aoflux_grid = exch not validated')
              call seq_flux_initexch_mct(atm(ens1), ocn(ens1), mpicom_cplid, cplid)
 
@@ -2385,7 +2387,7 @@ contains
              eai = mod((exi-1),num_inst_atm) + 1
              xao_ox => prep_aoflux_get_xao_ox()        ! array over all instances
              a2x_ox => prep_ocn_get_a2x_ox()
-             call seq_flux_ocnalb_mct(infodata, ocn(1), a2x_ox(eai), fractions_ox(efi), xao_ox(exi))
+             call seq_flux_ocnalb(infodata, ocn(1), a2x_ox(eai), fractions_ox(efi), xao_ox(exi))
 
           enddo
 
@@ -4026,7 +4028,7 @@ contains
        eai = mod((exi-1),num_inst_atm) + 1
        xao_ox => prep_aoflux_get_xao_ox()        ! array over all instances
        a2x_ox => prep_ocn_get_a2x_ox()
-       call seq_flux_ocnalb_mct(infodata, ocn(1), a2x_ox(eai), fractions_ox(efi), xao_ox(exi))
+       call seq_flux_ocnalb(infodata, ocn(1), a2x_ox(eai), fractions_ox(efi), xao_ox(exi))
     enddo
     call t_drvstopf  ('CPL:atmocnp_ocnalb', hashint=hashint(5))
 

--- a/driver-moab/main/seq_flux_mct.F90
+++ b/driver-moab/main/seq_flux_mct.F90
@@ -6,15 +6,11 @@ module seq_flux_mct
   use shr_orb_mod,       only: shr_orb_params, shr_orb_cosz, shr_orb_decl
   use shr_mct_mod,       only: shr_mct_queryConfigFile, shr_mct_sMatReaddnc
 
-  use seq_comm_mct,     only : mboxid ! iMOAB app id for ocn on cpl pes
-  use seq_comm_mct,     only : mbofxid ! iMOAB id for mpas ocean migrated mesh to coupler pes, just for xao flux calculations
-  use seq_comm_mct,     only : mbaxid ! iMOAB app id for atm phys grid on cpl pes
 
   use prep_aoflux_mod,   only: prep_aoflux_get_xao_omct, prep_aoflux_get_xao_amct
 
   use iMOAB, only :  iMOAB_SetDoubleTagStorageWithGid, iMOAB_WriteMesh, iMOAB_SetDoubleTagStorage, iMOAB_GetDoubleTagStorage
   use iMOAB, only : iMOAB_GetMeshInfo
-  use seq_comm_mct, only :  num_moab_exports ! for debugging
 
   use mct_mod
   use seq_flds_mod
@@ -59,6 +55,13 @@ module seq_flux_mct
   real(r8), allocatable ::  zbot (:)  ! atm level height
   real(r8), allocatable ::  ubot (:)  ! atm velocity, zonal
   real(r8), allocatable ::  vbot (:)  ! atm velocity, meridional
+
+  real(r8), allocatable ::  rainc (:)  ! convective rain
+  real(r8), allocatable ::  rainl (:)  ! large scale rain
+  real(r8), allocatable ::  snowc (:)  ! convective snow
+  real(r8), allocatable ::  snowl (:)  ! large scale snow
+
+
   real(r8), allocatable ::  wsresp(:) ! atm response to surface stress
   real(r8), allocatable ::  tau_est(:)! estimation of tau in equilibrium with wind
   real(r8), allocatable ::  ugust_atm(:)  ! atm gustiness
@@ -226,7 +229,9 @@ module seq_flux_mct
 contains
   !===============================================================================
 
-  subroutine seq_flux_init_mct(comp, fractions)
+  subroutine seq_flux_init_mct(comp, fractions, mbid)
+
+    use shr_moab_mod,     only: mbGetnCells
 
     !-----------------------------------------------------------------------
     !
@@ -234,22 +239,33 @@ contains
     !
     type(component_type), intent(in) :: comp
     type(mct_aVect), intent(in)  :: fractions
+    integer, intent(in)  :: mbid
     !
     ! Local variables
     !
     type(mct_gsMap), pointer :: gsMap
     type(mct_gGrid), pointer :: dom
-    integer(in)              :: nloc
+    integer                  :: nloc
+    integer                  :: nloc2
     integer                  :: ko,ki     ! fractions indices
     integer                  :: ier
+    integer                  :: ent_type
+    integer                  :: iam_CPLID
     real(r8), pointer        :: rmask(:)  ! ocn domain mask
+    real(r8), pointer        :: ofrac(:)  ! ocn domain mask
+    real(r8), pointer        :: ifrac(:)  ! ocn domain mask
+    character(CXX)           :: tagname
     character(*),parameter   :: subName =   '(seq_flux_init_mct) '
     !-----------------------------------------------------------------------
 
-    gsmap => component_get_gsmap_cx(comp)
+    call seq_comm_setptrs(CPLID,iam=iam_CPLID)
+
     dom   => component_get_dom_cx(comp)
 
-    nloc = mct_avect_lsize(dom%data)
+    nloc2 = mct_avect_lsize(dom%data)
+
+
+    nloc = mbGetnCells(mbid)
 
     ! Input fields atm
     allocate( zbot(nloc),stat=ier)
@@ -274,6 +290,20 @@ contains
        if(ier/=0) call mct_die(subName,'allocate ugust_atm',ier)
        ugust_atm = 0.0_r8
     end if
+
+    allocate( rainc(nloc))
+    if(ier/=0) call mct_die(subName,'allocate rainc',ier)
+    rainc = 0.0_r8
+    allocate( rainl(nloc))
+    if(ier/=0) call mct_die(subName,'allocate rainl',ier)
+    rainl = 0.0_r8
+    allocate( snowc(nloc))
+    if(ier/=0) call mct_die(subName,'allocate snowc',ier)
+    snowc = 0.0_r8
+    allocate( snowl(nloc))
+    if(ier/=0) call mct_die(subName,'allocate snowl',ier)
+    snowl = 0.0_r8
+
     allocate(thbot(nloc),stat=ier)
     if(ier/=0) call mct_die(subName,'allocate thbot',ier)
     thbot = 0.0_r8
@@ -464,8 +494,14 @@ contains
     ! Get lat, lon, mask, which is time-invariant
     allocate(rmask(nloc),stat=ier)
     if(ier/=0) call mct_die(subName,'allocate rmask',ier)
-    call mct_gGrid_exportRAttr(dom, 'lat' , lats , nloc)
-    call mct_gGrid_exportRAttr(dom, 'lon' , lons , nloc)
+
+    !call mct_gGrid_exportRAttr(dom, 'lat' , lats , nloc)
+    !call mct_gGrid_exportRAttr(dom, 'lon' , lons , nloc)
+    ent_type = 1
+    tagname = "lat"//C_NULL_CHAR
+    ier = iMOAB_GetDoubleTagStorage (mbid, tagname, nloc , ent_type, lats)
+    tagname = "lon"//C_NULL_CHAR
+    ier = iMOAB_GetDoubleTagStorage (mbid, tagname, nloc , ent_type, lons)
 
     ! setup the compute mask.
     ! prefer to compute just where ocean exists, so setup a mask here.
@@ -482,14 +518,24 @@ contains
     mask = 1
 
     ! use domain mask first
-    call mct_gGrid_exportRAttr(dom, 'mask', rmask, nloc)
+    tagname = "mask"//C_NULL_CHAR
+    ier = iMOAB_GetDoubleTagStorage (mbid, tagname, nloc , ent_type, rmask)
     where (rmask < 0.5_r8) mask = 0   ! like nint
     deallocate(rmask)
 
+    allocate(ofrac(nloc),stat=ier)
+    if(ier/=0) call mct_die(subName,'allocate ofrac',ier)
+
+    allocate(ifrac(nloc),stat=ier)
+    if(ier/=0) call mct_die(subName,'allocate ifrac',ier)
+    tagname = "ofrac"//C_NULL_CHAR
+    ier = iMOAB_GetDoubleTagStorage (mbid, tagname, nloc , ent_type, ofrac)
+    tagname = "ifrac"//C_NULL_CHAR
+    ier = iMOAB_GetDoubleTagStorage (mbid, tagname, nloc , ent_type, ifrac)
+
     ! then check ofrac + ifrac
-    ko = mct_aVect_indexRA(fractions,"ofrac")
-    ki = mct_aVect_indexRA(fractions,"ifrac")
-    where (fractions%rAttr(ko,:)+fractions%rAttr(ki,:) <= 0.0_r8) mask(:) = 0
+    where (ofrac(:)+ifrac(:) <= 0.0_r8) mask(:) = 0
+    deallocate(ofrac,ifrac)
 
     emask = mask
 
@@ -1444,7 +1490,8 @@ contains
 
   !===============================================================================
 
-  subroutine seq_flux_atmocn_mct(infodata, tod, dt, a2x, o2x, xao)
+  subroutine seq_flux_atmocn_mct(infodata, tod, dt, a2x, o2x, xao, mbid, mbfid)
+    use shr_moab_mod,     only: mbGetnCells,mbGetTagVals,mbSetTagVals
 
     !-----------------------------------------------------------------------
     !
@@ -1455,19 +1502,23 @@ contains
     type(mct_aVect)         , intent(in)         :: a2x  ! a2x_ax or a2x_ox
     type(mct_aVect)         , intent(in)         :: o2x  ! o2x_ax or o2x_ox
     type(mct_aVect)         , intent(inout)      :: xao
+    integer(in)             , intent(in)         :: mbid ! input atm moab app
+    integer(in)             , intent(in)         :: mbfid ! flux moab app
     !
     ! Local variables
     !
     logical     :: flux_albav   ! flux avg option
     logical     :: dead_comps   ! .true.  => dead components are used
-    integer(in) :: n            ! indices
-    integer(in) :: nloc, nloca, nloco    ! number of gridcells
+    integer     :: n            ! indices
+    integer     :: nloc, nloca, nloco    ! number of gridcells
     logical,save:: first_call = .true.
     logical     :: cold_start      ! .true. to initialize internal fields in shr_flux diurnal
     logical     :: read_restart    ! .true. => continue run
     logical     :: ocn_prognostic  ! .true. => ocn is prognostic
     logical     :: flux_diurnal    ! .true. => turn on diurnal cycle in atm/ocn fluxes
     integer     :: ocn_surface_flux_scheme ! 0: E3SMv1  1: COARE  2: UA
+    integer     :: nloc2
+    integer     :: nlocf
     real(r8)    :: flux_convergence ! convergence criteria for imlicit flux computation
     integer(in) :: flux_max_iteration ! maximum number of iterations for convergence
     logical :: coldair_outbreak_mod !  cold air outbreak adjustment  (Mahrt & Sun 1995,MWR)
@@ -1586,11 +1637,12 @@ contains
        call shr_sys_abort(trim(subname)//' ERROR wrong fluxsetting')
     endif
 
-    nloc = mct_aVect_lsize(xao)
-    nloca = mct_aVect_lsize(a2x)
-    nloco = mct_aVect_lsize(o2x)
+    
+    nloc = mbGetnCells(mbid)
 
-    if (nloc /= nloca .or. nloc /= nloco) then
+    nlocf = mbGetnCells(mbfid)
+
+    if (nloc /= nlocf) then
        call shr_sys_abort(trim(subname)//' ERROR nloc sizes do not match')
     endif
 
@@ -1654,52 +1706,111 @@ contains
           swdn       (n) = 0.0_r8
           swup       (n) = 0.0_r8
        enddo
-    else
+    else  ! not dead comps
+
+       call mbGetTagVals(mbid, 'Sa_z', zbot, nloc) 
+       call mbGetTagVals(mbid, 'Sa_u', ubot, nloc) 
+       call mbGetTagVals(mbid, 'Sa_v', vbot, nloc) 
+       if (atm_flux_method == 'implicit_stress') then
+          call mbGetTagVals(mbid, 'Sa_wsresp', wsresp, nloc) 
+          call mbGetTagVals(mbid, 'Sa_tau_est', tau_est, nloc) 
+       endif
+       if (atm_gustiness) then
+          call mbGetTagVals(mbid, 'Sa_ugust', ugust_atm, nloc) 
+       endif
+       call mbGetTagVals(mbid, 'Sa_ptem', thbot, nloc) 
+       call mbGetTagVals(mbid, 'Sa_shum', shum, nloc) 
+       if ( index_a2x_Sa_shum_16O /= 0 ) then
+          call mbGetTagVals(mbid, 'Sa_shum_16O', shum_16O, nloc) 
+       endif
+       if ( index_a2x_Sa_shum_HDO /= 0 ) then
+          call mbGetTagVals(mbid, 'Sa_shum_HDO', shum_HDO, nloc) 
+       endif
+       if ( index_a2x_Sa_shum_18O /= 0 ) then
+          call mbGetTagVals(mbid, 'Sa_shum_18O', shum_18O, nloc) 
+       endif
+       call mbGetTagVals(mbid, 'Sa_dens', dens, nloc) 
+       call mbGetTagVals(mbid, 'Sa_tbot', tbot, nloc) 
+       call mbGetTagVals(mbid, 'Sa_pslv', pslv, nloc) 
+
+       call mbGetTagVals(mbid, 'So_t', tocn, nloc) 
+       call mbGetTagVals(mbid, 'So_u', uocn, nloc) 
+       call mbGetTagVals(mbid, 'So_v', vocn, nloc) 
+
+       if ( index_o2x_So_roce_16O /= 0 ) then
+          call mbGetTagVals(mbid, 'So_roce_16O', roce_16O, nloc)
+       endif
+       if ( index_o2x_So_roce_HDO /= 0 ) then
+          call mbGetTagVals(mbid, 'So_roce_HDO', roce_HDO, nloc)
+       endif
+       if ( index_o2x_So_roce_18O /= 0 ) then
+          call mbGetTagVals(mbid, 'So_roce_18O', roce_18O, nloc)
+       endif
+       call mbGetTagVals(mbid, 'Faxa_lwdn', lwdn, nloc) 
+       call mbGetTagVals(mbid, 'Faxa_rainc', rainc, nloc) 
+       call mbGetTagVals(mbid, 'Faxa_rainl', rainl, nloc) 
+       call mbGetTagVals(mbid, 'Faxa_snowc', snowc, nloc) 
+       call mbGetTagVals(mbid, 'Faxa_snowl', snowl, nloc) 
+
+       call mbGetTagVals(mbid, 'So_fswpen', fswpen, nloc) 
+       call mbGetTagVals(mbid, 'So_s', ocnsal, nloc) 
+
+       if (flux_diurnal) then
+         call mbGetTagVals(mbfid, 'So_warm_diurn', warm, nloc) 
+         call mbGetTagVals(mbfid, 'So_salt_diurn', salt, nloc) 
+         call mbGetTagVals(mbfid, 'So_speed_diurn', speed, nloc) 
+         ! TODO:  Finish
+       endif
+
        do n = 1,nloc
           nInc(n) = 0._r8 ! needed for minval/maxval calculation
+          ! make sure values are 0 where mask is 0
           if (mask(n) /= 0) then
-             zbot(n) = a2x%rAttr(index_a2x_Sa_z   ,n)
-             ubot(n) = a2x%rAttr(index_a2x_Sa_u   ,n)
-             vbot(n) = a2x%rAttr(index_a2x_Sa_v   ,n)
+             uGust(n) = 0.0_r8
+             prec(n)  = rainc(n)+rainl(n)+snowc(n)+snowl(n)
+          endif
+          if (mask(n) == 0) then
+             zbot(n) = 0.0_r8
+             ubot(n) = 0.0_r8
+             vbot(n) = 0.0_r8
              if (atm_flux_method == 'implicit_stress') then
-                wsresp(n) = a2x%rAttr(index_a2x_Sa_wsresp,n)
-                tau_est(n) = a2x%rAttr(index_a2x_Sa_tau_est,n)
+                wsresp(n) = 0.0_r8
+                tau_est(n) = 0.0_r8
              end if
              if (atm_gustiness) then
-                ugust_atm(n) = a2x%rAttr(index_a2x_Sa_ugust,n)
+                ugust_atm(n) = 0.0_r8
              end if
-             thbot(n)= a2x%rAttr(index_a2x_Sa_ptem,n)
-             shum(n) = a2x%rAttr(index_a2x_Sa_shum,n)
-             if ( index_a2x_Sa_shum_16O /= 0 ) shum_16O(n) = a2x%rAttr(index_a2x_Sa_shum_16O,n)
-             if ( index_a2x_Sa_shum_HDO /= 0 ) shum_HDO(n) = a2x%rAttr(index_a2x_Sa_shum_HDO,n)
-             if ( index_a2x_Sa_shum_18O /= 0 ) shum_18O(n) = a2x%rAttr(index_a2x_Sa_shum_18O,n)
-             dens(n) = a2x%rAttr(index_a2x_Sa_dens,n)
-             tbot(n) = a2x%rAttr(index_a2x_Sa_tbot,n)
-             pslv(n) = a2x%rAttr(index_a2x_Sa_pslv,n)
-             tocn(n) = o2x%rAttr(index_o2x_So_t   ,n)
-             uocn(n) = o2x%rAttr(index_o2x_So_u   ,n)
-             vocn(n) = o2x%rAttr(index_o2x_So_v   ,n)
-             if ( index_o2x_So_roce_16O /= 0 ) roce_16O(n) = o2x%rAttr(index_o2x_So_roce_16O, n)
-             if ( index_o2x_So_roce_HDO /= 0 ) roce_HDO(n) = o2x%rAttr(index_o2x_So_roce_HDO, n)
-             if ( index_o2x_So_roce_18O /= 0 ) roce_18O(n) = o2x%rAttr(index_o2x_So_roce_18O, n)
+             thbot(n)= 0.0_r8
+             shum(n) = 0.0_r8
+             if ( index_a2x_Sa_shum_16O /= 0 ) shum_16O(n) = 0.0_r8
+             if ( index_a2x_Sa_shum_HDO /= 0 ) shum_HDO(n) = 0.0_r8
+             if ( index_a2x_Sa_shum_18O /= 0 ) shum_18O(n) = 0.0_r8
+             dens(n) = 0.0_r8
+             tbot(n) = 0.0_r8
+             pslv(n) = 0.0_r8
+
+             tocn(n) = 0.0_r8
+             uocn(n) = 0.0_r8
+             vocn(n) = 0.0_r8
+             if ( index_o2x_So_roce_16O /= 0 ) roce_16O(n) = 0.0_r8
+             if ( index_o2x_So_roce_HDO /= 0 ) roce_HDO(n) = 0.0_r8
+             if ( index_o2x_So_roce_18O /= 0 ) roce_18O(n) = 0.0_r8
+
              !--- mask missing atm or ocn data if found
              if (dens(n) < 1.0e-12 .or. tocn(n) < 1.0) then
                 emask(n) = 0
-                !write(logunit,*) 'aoflux tcx1',n,dens(n),tocn(n)
              endif
              !           !!uGust(n) = 1.5_r8*sqrt(uocn(n)**2 + vocn(n)**2) ! there is no wind gust data from ocn
-             uGust(n) = 0.0_r8
-             lwdn (n) = a2x%rAttr(index_a2x_Faxa_lwdn ,n)
-             prec (n) = a2x%rAttr(index_a2x_Faxa_rainc,n) &
-                  & + a2x%rAttr(index_a2x_Faxa_rainl,n) &
-                  & + a2x%rAttr(index_a2x_Faxa_snowc,n) &
-                  & + a2x%rAttr(index_a2x_Faxa_snowl,n)
-             fswpen(n)= o2x%rAttr(index_o2x_So_fswpen ,n)
-             ocnsal(n)= o2x%rAttr(index_o2x_So_s      ,n)
+             lwdn (n) = 0.0_r8
 
-             warm       (n) = xao%rAttr(index_xao_So_warm_diurn      ,n)
-             salt       (n) = xao%rAttr(index_xao_So_salt_diurn      ,n)
-             speed      (n) = xao%rAttr(index_xao_So_speed_diurn     ,n)
+             prec (n) = 0.0_r8
+             fswpen(n)= 0.0_r8
+             ocnsal(n)= 0.0_r8
+
+             warm       (n) = 0.0_r8
+             salt       (n) = 0.0_r8
+             speed      (n) = 0.0_r8
+#if 0
              regime     (n) = xao%rAttr(index_xao_So_regime_diurn    ,n)
              warmMax    (n) = xao%rAttr(index_xao_So_warmMax_diurn   ,n)
              windMax    (n) = xao%rAttr(index_xao_So_windMax_diurn   ,n)
@@ -1719,9 +1830,10 @@ contains
              ! set in flux_ocnalb using data from previous timestep
              swdn       (n) = xao%rAttr(index_xao_Faox_swdn          ,n)
              swup       (n) = xao%rAttr(index_xao_Faox_swup          ,n)
+#endif
           end if
        enddo
-    end if
+    end if  ! end of if else for dead or live components
 
     if (flux_diurnal) then
        if (ocn_surface_flux_scheme.eq.2) then
@@ -1769,48 +1881,66 @@ contains
        !duu10n,ustar, re  , ssq, missval = 0.0_r8 )
     endif
 
+    call mbSetTagVals(mbfid, 'Faox_sen', sen, nloc) 
+    call mbSetTagVals(mbfid, 'Faox_lat', lat, nloc) 
+    call mbSetTagVals(mbfid, 'Faox_taux', taux, nloc) 
+    call mbSetTagVals(mbfid, 'Faox_tauy', tauy, nloc) 
+    call mbSetTagVals(mbfid, 'Faox_evap', evap, nloc) 
+    ! TODO:  evap isotopes
+    call mbSetTagVals(mbfid, 'So_tref', tref, nloc) 
+    call mbSetTagVals(mbfid, 'So_qref', qref, nloc) 
+    call mbSetTagVals(mbfid, 'So_ustar', ustar, nloc) 
+    call mbSetTagVals(mbfid, 'So_re', re, nloc) 
+    call mbSetTagVals(mbfid, 'So_ssq', ssq, nloc) 
+    call mbSetTagVals(mbfid, 'Faox_lwup', lwup, nloc) 
+    call mbSetTagVals(mbfid, 'So_duu10n', duu10n, nloc) 
+    duu10n= sqrt(duu10n)
+    call mbSetTagVals(mbfid, 'So_u10', duu10n, nloc) 
+    !TODO find better way for above
+
     do n = 1,nloc
-       if (mask(n) /= 0) then
-          xao%rAttr(index_xao_Faox_sen ,n) = sen(n)
-          xao%rAttr(index_xao_Faox_lat ,n) = lat(n)
-          xao%rAttr(index_xao_Faox_taux,n) = taux(n)
-          xao%rAttr(index_xao_Faox_tauy,n) = tauy(n)
-          xao%rAttr(index_xao_Faox_evap,n) = evap(n)
+       if (mask(n) == 0) then
+          xao%rAttr(index_xao_Faox_sen ,n) = 0.0_r8
+          xao%rAttr(index_xao_Faox_lat ,n) = 0.0_r8
+          xao%rAttr(index_xao_Faox_taux,n) = 0.0_r8
+          xao%rAttr(index_xao_Faox_tauy,n) = 0.0_r8
+          xao%rAttr(index_xao_Faox_evap,n) = 0.0_r8
           if ( index_xao_Faox_evap_16O /= 0 ) xao%rAttr(index_xao_Faox_evap_16O,n) = evap_16O(n)
           if ( index_xao_Faox_evap_HDO /= 0 ) xao%rAttr(index_xao_Faox_evap_HDO,n) = evap_HDO(n)
           if ( index_xao_Faox_evap_18O /= 0 ) xao%rAttr(index_xao_Faox_evap_18O,n) = evap_18O(n)
-          xao%rAttr(index_xao_So_tref  ,n) = tref(n)
-          xao%rAttr(index_xao_So_qref  ,n) = qref(n)
-          xao%rAttr(index_xao_So_ustar ,n) = ustar(n)  ! friction velocity
-          xao%rAttr(index_xao_So_re    ,n) = re(n)     ! reynolds number
-          xao%rAttr(index_xao_So_ssq   ,n) = ssq(n)    ! s.hum. saturation at Ts
-          xao%rAttr(index_xao_Faox_lwup,n) = lwup(n)
-          xao%rAttr(index_xao_So_duu10n,n) = duu10n(n)
-          xao%rAttr(index_xao_So_u10   ,n) = sqrt(duu10n(n))
-          xao%rAttr(index_xao_So_warm_diurn       ,n) = warm(n)
-          xao%rAttr(index_xao_So_salt_diurn       ,n) = salt(n)
-          xao%rAttr(index_xao_So_speed_diurn      ,n) = speed(n)
-          xao%rAttr(index_xao_So_regime_diurn     ,n) = regime(n)
-          xao%rAttr(index_xao_So_warmMax_diurn    ,n) = warmMax(n)
-          xao%rAttr(index_xao_So_windMax_diurn    ,n) = windMax(n)
-          xao%rAttr(index_xao_So_qSolAvg_diurn    ,n) = qSolAvg(n)
-          xao%rAttr(index_xao_So_windAvg_diurn    ,n) = windAvg(n)
-          xao%rAttr(index_xao_So_warmMaxInc_diurn ,n) = warmMaxInc(n)
-          xao%rAttr(index_xao_So_windMaxInc_diurn ,n) = windMaxInc(n)
-          xao%rAttr(index_xao_So_qSolInc_diurn    ,n) = qSolInc(n)
-          xao%rAttr(index_xao_So_windInc_diurn    ,n) = windInc(n)
-          xao%rAttr(index_xao_So_nInc_diurn       ,n) = nInc(n)
-          xao%rAttr(index_xao_So_tbulk_diurn      ,n) = tbulk(n)
-          xao%rAttr(index_xao_So_tskin_diurn      ,n) = tskin(n)
-          xao%rAttr(index_xao_So_tskin_day_diurn  ,n) = tskin_day(n)
-          xao%rAttr(index_xao_So_tskin_night_diurn,n) = tskin_night(n)
-          xao%rAttr(index_xao_So_cskin_diurn      ,n) = cskin(n)
-          xao%rAttr(index_xao_So_cskin_night_diurn,n) = cskin_night(n)
-          xao%rAttr(index_xao_So_fswpen           ,n) = fswpen(n)
+          xao%rAttr(index_xao_So_tref  ,n) = 0.0_r8
+          xao%rAttr(index_xao_So_qref  ,n) = 0.0_r8
+          xao%rAttr(index_xao_So_ustar ,n) = 0.0_r8  ! friction velocity
+          xao%rAttr(index_xao_So_re    ,n) = 0.0_r8     ! reynolds number
+          xao%rAttr(index_xao_So_ssq   ,n) = 0.0_r8    ! s.hum. saturation at Ts
+          xao%rAttr(index_xao_Faox_lwup,n) = 0.0_r8 
+          xao%rAttr(index_xao_So_duu10n,n) = 0.0_r8
+          xao%rAttr(index_xao_So_u10   ,n) = 0.0_r8
+          if (flux_diurnal) then
+           xao%rAttr(index_xao_So_warm_diurn       ,n) = warm(n)
+           xao%rAttr(index_xao_So_salt_diurn       ,n) = salt(n)
+           xao%rAttr(index_xao_So_speed_diurn      ,n) = speed(n)
+           xao%rAttr(index_xao_So_regime_diurn     ,n) = regime(n)
+           xao%rAttr(index_xao_So_warmMax_diurn    ,n) = warmMax(n)
+           xao%rAttr(index_xao_So_windMax_diurn    ,n) = windMax(n)
+           xao%rAttr(index_xao_So_qSolAvg_diurn    ,n) = qSolAvg(n)
+           xao%rAttr(index_xao_So_windAvg_diurn    ,n) = windAvg(n)
+           xao%rAttr(index_xao_So_warmMaxInc_diurn ,n) = warmMaxInc(n)
+           xao%rAttr(index_xao_So_windMaxInc_diurn ,n) = windMaxInc(n)
+           xao%rAttr(index_xao_So_qSolInc_diurn    ,n) = qSolInc(n)
+           xao%rAttr(index_xao_So_windInc_diurn    ,n) = windInc(n)
+           xao%rAttr(index_xao_So_nInc_diurn       ,n) = nInc(n)
+           xao%rAttr(index_xao_So_tbulk_diurn      ,n) = tbulk(n)
+           xao%rAttr(index_xao_So_tskin_diurn      ,n) = tskin(n)
+           xao%rAttr(index_xao_So_tskin_day_diurn  ,n) = tskin_day(n)
+           xao%rAttr(index_xao_So_tskin_night_diurn,n) = tskin_night(n)
+           xao%rAttr(index_xao_So_cskin_diurn      ,n) = cskin(n)
+           xao%rAttr(index_xao_So_cskin_night_diurn,n) = cskin_night(n)
+           xao%rAttr(index_xao_So_fswpen           ,n) = fswpen(n)
+          endif
        end if
     enddo
 
-    ! transpose xao to xao_omct, to
   end subroutine seq_flux_atmocn_mct
 
   subroutine seq_flux_atmocn_moab(comp, xao)
@@ -1849,8 +1979,8 @@ contains
      tagname = trim(seq_flds_xao_fields)//C_NULL_CHAR
      arrSize = nloc * listSize
      ent_type = 1 ! cells
-     ! global ids are retrieved by albedo first call; it is a local module variable
-     ierr = iMOAB_SetDoubleTagStorageWithGid ( appId, tagname, arrSize , ent_type, local_xao_mct, GlobalIds )
+     ! global ids are retrieved by albedo first call; it is a local module variable 
+     !ierr = iMOAB_SetDoubleTagStorageWithGid ( appId, tagname, arrSize , ent_type, local_xao_mct, GlobalIds )
      if (ierr .ne. 0) then
        write(logunit,*) subname,' error in setting atm-ocn fluxes  '
        call shr_sys_abort(subname//' ERROR in setting atm-ocn fluxes')

--- a/driver-moab/shr/shr_moab_mod.F90
+++ b/driver-moab/shr/shr_moab_mod.F90
@@ -1,0 +1,137 @@
+!BOP ===========================================================================
+!
+! !MODULE: shr_moab_mod -- moab-based utilities
+!
+! !INTERFACE: ------------------------------------------------------------------
+module shr_moab_mod
+
+#ifdef HAVE_MOAB
+ use shr_sys_mod,      only: shr_sys_abort
+ use seq_comm_mct,     only: logunit
+ use shr_kind_mod,     only: CXX => shr_kind_CXX
+ use shr_kind_mod    , only: R8 => SHR_KIND_R8
+ use iso_c_binding
+ 
+ implicit none
+ private
+
+ public :: mbGetnCells 
+ public :: mbGetTagVals
+ public :: mbSetTagVals
+
+contains
+
+!===============================================================================
+! !BOP =========================================================================
+!
+! !IROUTINE: mbGetnCells -- return number of cells in input moab app
+!
+! !DESCRIPTION:
+!
+!     Return the number of cells in the mesh associated with the input moab app id
+!
+! !REVISION HISTORY:
+!     2024-Jan-02 - R. Jacob - initial version
+! !INTERFACE: ------------------------------------------------------------------
+ integer function mbGetnCells(moabid)
+   use iMOAB , only : iMOAB_GetMeshInfo
+
+   ! Input arguments
+   integer, intent(in):: moabid
+
+   ! Local variables
+   integer :: nvert(3), nvise(3), nbl(3), nsurf(3), nvisBC(3) ! for moab info
+   integer :: ierr
+
+   character(*), parameter   :: subname = '(mbGetnCells) '
+!-----------------------------------------------------------------------
+!
+
+   ierr  = iMOAB_GetMeshInfo ( moabid, nvert, nvise, nbl, nsurf, nvisBC );
+
+   if (ierr .ne. 0) then
+       write(logunit,*) subname,' error in getting info '
+       call shr_sys_abort(subname//' error in getting info ')
+   endif
+
+   mbGetnCells = nvise(1)
+
+  end function mbGetnCells
+
+!===============================================================================
+! !BOP =========================================================================
+!
+! !IROUTINE: mbGetTagVals -- get values from input tagname and mpid and return in input array
+!
+! !DESCRIPTION:
+!
+!      Get values from input tagname and mpid and return in input array
+!
+! !REVISION HISTORY:
+!     2024-Jan-05 - R. Jacob - initial version
+! !INTERFACE: ------------------------------------------------------------------
+
+  subroutine mbGetTagVals(mbid, intag,inarray,nMax)
+    use iMOAB , only : iMOAB_GetDoubleTagStorage
+
+    integer,intent(in)                   :: mbid
+    character(len=*),intent(in)          :: intag
+    real(R8)   ,intent(inout)            :: inarray(nMax) 
+    integer,intent(in)                   :: nMax
+
+! Local variables
+    integer :: ierr, ent_type
+    character(CXX)           :: tagname
+    character(*), parameter   :: subname = '(mbGetTagVals) '
+!-----------------------------------------------------------------------
+!
+
+    ent_type=1
+    tagname = trim(intag)//C_NULL_CHAR
+    ierr = iMOAB_GetDoubleTagStorage (mbid, tagname, nMax , ent_type, inarray)
+    if (ierr .ne. 0) then
+        write(logunit,*) subname,' error in getting tag storage '
+        call shr_sys_abort(subname//' error in getting tag storage ')
+    endif
+
+
+  end subroutine
+!===============================================================================
+! !BOP =========================================================================
+!
+! !IROUTINE: mbSetTagVals -- Set values to input tagname and mpid using input array
+!
+! !DESCRIPTION:
+!
+!      Set values to input tagname and mpid using input array
+!
+! !REVISION HISTORY:
+!     2024-Jan-05 - R. Jacob - initial version
+! !INTERFACE: ------------------------------------------------------------------
+
+  subroutine mbSetTagVals(mbid, intag,inarray,nMax)
+    use iMOAB , only : iMOAB_SetDoubleTagStorage
+
+    integer,intent(in)                   :: mbid
+    character(len=*),intent(in)          :: intag
+    real(R8)   ,intent(inout)            :: inarray(nMax) 
+    integer,intent(in)                   :: nMax
+
+! Local variables
+    integer :: ierr, ent_type
+    character(CXX)           :: tagname
+    character(*), parameter   :: subname = '(mbSetTagVals) '
+!-----------------------------------------------------------------------
+!
+
+    ent_type=1
+    tagname = trim(intag)//C_NULL_CHAR
+    ierr = iMOAB_SetDoubleTagStorage (mbid, tagname, nMax , ent_type, inarray)
+    if (ierr .ne. 0) then
+        write(logunit,*) subname,' error in setting tag storage '
+        call shr_sys_abort(subname//' error in setting tag storage ')
+    endif
+
+  end subroutine
+#endif
+end module shr_moab_mod


### PR DESCRIPTION
Calculate fluxes and ocean albedos in MOAB coupler with data in the MOAB meshes.
Prior to this change, the fluxes were calculated with MCT data and then copied to MOAB data structures.
Verified by inspection of xao fields before and after this change using Visit.

[BFB] 