### PR TITLE
Updates Intel's  MKL version to mkl/2020 on Compy

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -3821,7 +3821,7 @@
       <modules>
         <command name="load">netcdf/4.6.3</command>
         <command name="load">pnetcdf/1.9.0</command>
-        <command name="load">mkl/2019u5</command>
+        <command name="load">mkl/2020</command>
       </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>


### PR DESCRIPTION
The older version of MKL (`mkl/2019u5`) produced linking errors with the EAMxx `test-all-scream` script. The new version (`mkl/2020`) fixes these errors.

[NBFB] possibly for compy only