### PR TITLE
Make ne30_r025_IcoswISC30E3r5 configuration functional

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -1607,7 +1607,7 @@
       <grid name="atm">ne30np4.pg2</grid>
       <grid name="lnd">r025</grid>
       <grid name="ocnice">IcoswISC30E3r5</grid>
-      <grid name="rof">null</grid>
+      <grid name="rof">r025</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
       <mask>IcoswISC30E3r5</mask>
@@ -4028,6 +4028,9 @@
       <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne120pg2/map_ne30pg2_to_r025_esmfbilin.20240206.nc</map>
       <map name="LND2ATM_FMAPNAME">cpl/gridmaps/ne120pg2/map_r025_to_ne30pg2_traave.20240206.nc</map>
       <map name="LND2ATM_SMAPNAME">cpl/gridmaps/ne120pg2/map_r025_to_ne30pg2_traave.20240206.nc</map>
+      <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/ne120pg2/map_ne30pg2_to_r025_traave.20240206.nc</map>
+      <map name="ATM2ROF_FMAPNAME_NONLINEAR">cpl/gridmaps/ne120pg2/map_ne30pg2_to_r025_trfv2.20240206.nc</map>
+      <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/ne120pg2/map_ne30pg2_to_r025_esmfbilin.20240206.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4" lnd_grid="r0125">


### PR DESCRIPTION
Add mapping files and fix resolution definition in order to allow the ne30_r025_IcoswISC30E3r5 to work correctly.

[BFB]