### PR TITLE
Add stealth test for mpaso frazil_ice_porosity model and related testdef

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -283,6 +283,7 @@ _TESTS = {
             "ERS_Ld5_D.T62_oQU240.GMPAS-IAF.mpaso-conservation_check",
             "ERS_Ld5_PS.ne30pg2_r05_IcoswISC30E3r5.CRYO1850-DISMF.mpaso-scaled_dib_dismf",
             "ERS_Ld5.TL319_oQU240wLI_gis20.MPAS_LISIO_JRA1p5.mpaso-ocn_glc_tf_coupling",
+            "SMS_PS.ne30pg2_r05_IcoswISC30E3r5.WCYCL1850.mpaso-frazil_ice_porosity",
             )
         },
 

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/frazil_ice_porosity/README
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/frazil_ice_porosity/README
@@ -1,0 +1,7 @@
+This testdef is used to test a stealth feature in mpaso introduced by
+PR #6802. It uses mpaso namelist variables to turn on the
+frazil_ice_porosity model:
+   config_use_frazil_ice_porosity = .true.
+and set the frazil_ice_porosity to 1:
+   config_frazil_ice_porosity = 1.0
+It will have an impact on all mpaso runs.

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/frazil_ice_porosity/user_nl_mpaso
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/frazil_ice_porosity/user_nl_mpaso
@@ -1,0 +1,2 @@
+ config_use_frazil_ice_porosity = .true.
+ config_frazil_ice_porosity = 1.0


### PR DESCRIPTION
Adds a stealth test and associated testdef for the mpaso model for frazil_ice_porosity. This model was introduced in PR #6802 but the corresponding stealth test was missed.

[BFB]