### PR TITLE
Workflows: fix test-all-scream action syntax

### DIFF
--- a/.github/actions/test-all-scream/action.yml
+++ b/.github/actions/test-all-scream/action.yml
@@ -30,6 +30,13 @@ inputs:
     valid_values:
       - 'true'
       - 'false'
+  ekat:
+    description: 'Whether to enable tests for EKAT as well'
+    required: true
+    default: 'false'
+    valid_values:
+      - 'true'
+      - 'false'
   cmake-configs:
     description: 'Semicolon-separated list of key=value pairs for CMake to pass to test-all-scream'
     required: false
@@ -82,7 +89,7 @@ runs:
         fi
 
         if [ "${{ inputs.ekat }}" = "true" ]; then
-           cmd+= " -c EKAT_ENABLE_TESTS=ON"
+         cmd+=" -c EKAT_ENABLE_TESTS=ON"
         fi
 
         # If cmake-configs is non-empty, add tokens to test-all-scream via "-c key=val"

--- a/.github/workflows/eamxx-sa-testing.yml
+++ b/.github/workflows/eamxx-sa-testing.yml
@@ -8,6 +8,7 @@ on:
     paths:
       # first, yes to these
       - '.github/workflows/eamxx-sa-testing.yml'
+      - '.github/actions/test-all-scream/**'
       - 'cime_config/machine/config_machines.xml'
       - 'components/eamxx/**'
       - 'components/homme/**'


### PR DESCRIPTION
This should fix the eamxx-sa workflow, which has not been running correctly in the nightlies.

Also, run eamxx-sa-testing workflow when the test-all-scream action is updated.

[BFB]

---