### PR TITLE
EAMxx: avoid MPI tags in GridImportExport gather/scatter methods

### DIFF
--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -175,6 +175,8 @@ bool AbstractGrid::is_unique () const {
     return unique_gids==1;
   };
 
+
+  std::lock_guard<std::mutex> lock(m_mutex); // Lock the mutex
   if (not m_is_unique_computed) {
     m_is_unique = compute_is_unique();
     m_is_unique_computed = true;
@@ -218,6 +220,7 @@ is_valid_layout (const FieldLayout& layout) const
 auto AbstractGrid::
 get_global_min_dof_gid () const ->gid_type
 {
+  std::lock_guard<std::mutex> lock(m_mutex); // Lock the mutex
   // Lazy calculation
   if (m_global_min_dof_gid==std::numeric_limits<gid_type>::max()) {
     m_global_min_dof_gid = field_min<gid_type>(m_dofs_gids,&get_comm());
@@ -228,6 +231,7 @@ get_global_min_dof_gid () const ->gid_type
 auto AbstractGrid::
 get_global_max_dof_gid () const ->gid_type
 {
+  std::lock_guard<std::mutex> lock(m_mutex); // Lock the mutex
   // Lazy calculation
   if (m_global_max_dof_gid==-std::numeric_limits<gid_type>::max()) {
     m_global_max_dof_gid = field_max<gid_type>(m_dofs_gids,&get_comm());
@@ -238,6 +242,7 @@ get_global_max_dof_gid () const ->gid_type
 auto AbstractGrid::
 get_global_min_partitioned_dim_gid () const ->gid_type
 {
+  std::lock_guard<std::mutex> lock(m_mutex); // Lock the mutex
   // Lazy calculation
   if (m_global_min_partitioned_dim_gid==std::numeric_limits<gid_type>::max()) {
     m_global_min_partitioned_dim_gid = field_min<gid_type>(m_partitioned_dim_gids,&get_comm());
@@ -248,6 +253,7 @@ get_global_min_partitioned_dim_gid () const ->gid_type
 auto AbstractGrid::
 get_global_max_partitioned_dim_gid () const ->gid_type
 {
+  std::lock_guard<std::mutex> lock(m_mutex); // Lock the mutex
   // Lazy calculation
   if (m_global_max_partitioned_dim_gid==-std::numeric_limits<gid_type>::max()) {
     m_global_max_partitioned_dim_gid = field_max<gid_type>(m_partitioned_dim_gids,&get_comm());
@@ -552,11 +558,16 @@ void AbstractGrid::create_dof_fields (const int scalar2d_layout_rank)
 auto AbstractGrid::get_gid2lid_map () const
  -> const std::map<gid_type,int>&
 {
-  auto gids_h = get_dofs_gids().get_view<const gid_type*,Host>();
-  for (int i=0; i<get_num_local_dofs(); ++i) {
-    m_gid2lid[gids_h[i]] = i;
+  std::lock_guard<std::mutex> lock(m_mutex); // Lock the mutex
+
+  int cur_sz = m_gid2lid.size();
+  if (cur_sz<get_num_local_dofs()) {
+    auto gids_h = get_dofs_gids().get_view<const gid_type*, Host>();
+    for (int i = 0; i < get_num_local_dofs(); ++i) {
+        m_gid2lid[gids_h[i]] = i; // Modify the mutable member
+    }
   }
-  return m_gid2lid;
+  return m_gid2lid; // Return the map
 }
 
 void AbstractGrid::copy_data (const AbstractGrid& src, const bool shallow)

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -550,14 +550,13 @@ void AbstractGrid::create_dof_fields (const int scalar2d_layout_rank)
 }
 
 auto AbstractGrid::get_gid2lid_map () const
- -> std::map<gid_type,int>
+ -> const std::map<gid_type,int>&
 {
-  std::map<gid_type,int> m;
   auto gids_h = get_dofs_gids().get_view<const gid_type*,Host>();
   for (int i=0; i<get_num_local_dofs(); ++i) {
-    m[gids_h[i]] = i;
+    m_gid2lid[gids_h[i]] = i;
   }
-  return m;
+  return m_gid2lid;
 }
 
 void AbstractGrid::copy_data (const AbstractGrid& src, const bool shallow)

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -11,6 +11,7 @@
 #include <map>
 #include <list>
 #include <memory>
+#include <mutex>
 
 namespace scream
 {
@@ -254,6 +255,9 @@ protected:
 
   // Mutable, for lazy calculation
   mutable std::map<gid_type,int> m_gid2lid;
+
+  // For thread safety in modifying mutable items (just in case someone ever runs this code in threaded regions)
+  mutable std::mutex m_mutex;
 
   // The MPI comm containing the ranks across which the global mesh is partitioned
   ekat::Comm            m_comm;

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -205,7 +205,7 @@ public:
 
   int get_unique_grid_id () const { return m_unique_grid_id; }
 
-  std::map<gid_type,int> get_gid2lid_map () const;
+  const std::map<gid_type,int>& get_gid2lid_map () const;
 
 protected:
 
@@ -251,6 +251,9 @@ protected:
   Field     m_lid_to_idx;
 
   mutable std::map<std::string,Field>  m_geo_fields;
+
+  // Mutable, for lazy calculation
+  mutable std::map<gid_type,int> m_gid2lid;
 
   // The MPI comm containing the ranks across which the global mesh is partitioned
   ekat::Comm            m_comm;

--- a/components/eamxx/src/share/grid/grid_import_export.cpp
+++ b/components/eamxx/src/share/grid/grid_import_export.cpp
@@ -15,8 +15,6 @@ GridImportExport (const std::shared_ptr<const AbstractGrid>& unique,
   EKAT_REQUIRE_MSG (unique->is_unique(),
       "Error! GridImportExport unique grid is not unique.\n");
 
-  using gid_type = AbstractGrid::gid_type;
-
   m_unique = unique;
   m_overlapped = overlapped;
   m_comm = unique->get_comm();
@@ -153,22 +151,19 @@ GridImportExport (const std::shared_ptr<const AbstractGrid>& unique,
   Kokkos::deep_copy(m_export_lids,m_export_lids_h);
 
   // Compute counts per pid
-  {
-    m_num_exports_per_pid = view_1d<int>("",m_comm.size());
-    m_num_exports_per_pid_h = Kokkos::create_mirror_view(m_num_exports_per_pid);
-    for (size_t i=0; i<m_export_pids.size(); ++i) {
-      ++m_num_exports_per_pid_h[m_export_pids_h[i]];
-    }
-    Kokkos::deep_copy(m_num_exports_per_pid,m_num_exports_per_pid_h);
+  m_num_exports_per_pid = view_1d<int>("",m_comm.size());
+  m_num_exports_per_pid_h = Kokkos::create_mirror_view(m_num_exports_per_pid);
+  for (size_t i=0; i<m_export_pids.size(); ++i) {
+    ++m_num_exports_per_pid_h[m_export_pids_h[i]];
   }
-  {
-    m_num_imports_per_pid = view_1d<int>("",m_comm.size());
-    m_num_imports_per_pid_h = Kokkos::create_mirror_view(m_num_imports_per_pid);
-    for (size_t i=0; i<m_import_pids.size(); ++i) {
-      ++m_num_imports_per_pid_h[m_import_pids_h[i]];
-    }
-    Kokkos::deep_copy(m_num_imports_per_pid,m_num_imports_per_pid_h);
+  Kokkos::deep_copy(m_num_exports_per_pid,m_num_exports_per_pid_h);
+
+  m_num_imports_per_pid = view_1d<int>("",m_comm.size());
+  m_num_imports_per_pid_h = Kokkos::create_mirror_view(m_num_imports_per_pid);
+  for (size_t i=0; i<m_import_pids.size(); ++i) {
+    ++m_num_imports_per_pid_h[m_import_pids_h[i]];
   }
+  Kokkos::deep_copy(m_num_imports_per_pid,m_num_imports_per_pid_h);
 }
 
 } // namespace scream

--- a/components/eamxx/src/share/grid/grid_import_export.hpp
+++ b/components/eamxx/src/share/grid/grid_import_export.hpp
@@ -78,6 +78,8 @@ public:
 
 protected:
 
+  using gid_type = AbstractGrid::gid_type;
+
   std::shared_ptr<const AbstractGrid>   m_unique;
   std::shared_ptr<const AbstractGrid>   m_overlapped;
 
@@ -104,70 +106,85 @@ protected:
 
 // --------------------- IMPLEMENTATION ------------------------ //
 
+// Both gather and scatter proceed in 4 stages. If pid1 needs to send data to pid2, then
+//  1. pid1 sends pid2 the list of GIDs [gid1,...,gidN] it will send. Although pid2
+//     already knows the GIDs, this step specifies the ORDER, since GIDs
+//     may be ordered differently on different pids
+//  2. pid1 sends pid2 the number of T's it will send for each of those gids
+//  3. pid1 sends pid3 all T's (first T's for gid1, then T's for gid2, etc)
+//  4. Finally, pid2 parses the data received, stuffing it into dst, according
+//     to the lid on pid2 (needs converting gids to lids)
+// The two only differ in which members to use. They are mostly specular: where one
+// uses m_unique grid, the other uses m_overlapped grid, and where one use m_export_lids/pids,
+// the other uses m_import_lids/pids. That's b/c they do the same operation, just
+// in opposite directions.
+
 template<typename T>
 void GridImportExport::
 scatter (const MPI_Datatype mpi_data_t,
          const std::map<int,std::vector<T>>& src,
                std::map<int,std::vector<T>>& dst) const
 {
-  using gid_type = AbstractGrid::gid_type;
+  const auto tag = 0;
 
   std::vector<MPI_Request> send_req, recv_req;
   
   const int nexp = m_export_lids.size();
   const int nimp = m_import_lids.size();
   auto mpi_comm = m_comm.mpi_comm();
+  auto mpi_gid_t = ekat::get_mpi_type<gid_type>();
 
-  auto unique_gids_h = m_unique->get_dofs_gids().get_view<const gid_type*,Host>();
-  auto overlap_gids_h = m_overlapped->get_dofs_gids().get_view<const gid_type*,Host>();
+  auto gids_h = m_unique->get_dofs_gids().get_view<const gid_type*,Host>();
 
-  // 1. Communicate to the recv pids how many items per lid
-  // we need to send
-  std::vector<int> send_count(m_export_lids_h.size(),0);
+  // 1. Communicate GIDs lists to recv pids
+  std::map<int,std::vector<gid_type>> send_pid2gids;
   for (int i=0; i<nexp; ++i) {
+    auto pid = m_export_pids_h[i];
     auto lid = m_export_lids_h[i];
-    auto gid = unique_gids_h[lid];
-    send_count[i] = src.at(lid).size();
+    send_pid2gids[pid].push_back(gids_h[lid]);
+  }
+  for (auto& [pid,gids] : send_pid2gids) {
     auto& req = send_req.emplace_back();
-
-    check_mpi_call(MPI_Isend (&send_count[i],1,MPI_INT,
-                              m_export_pids_h[i],gid,mpi_comm,&req),
+    check_mpi_call(MPI_Isend (gids.data(),gids.size(),mpi_gid_t,pid,tag,mpi_comm,&req),
                    "GridImportExport::scatter, creating send request (step 1)");
   }
-  std::vector<int> recv_count(m_import_lids_h.size(),0);
+  std::map<int,std::vector<gid_type>> recv_pid2gids;
   for (int i=0; i<nimp; ++i) {
-    auto lid = m_import_lids_h[i];
-    auto gid = overlap_gids_h[lid];
+    auto pid = m_import_pids_h[i];
+    recv_pid2gids[pid].push_back(-1);
+  }
+  for (auto& [pid,gids] : recv_pid2gids) {
     auto& req = recv_req.emplace_back();
-    check_mpi_call(MPI_Irecv (&recv_count[i],1,MPI_INT,
-                              m_import_pids_h[i],gid,mpi_comm,&req),
+    check_mpi_call(MPI_Irecv (gids.data(),gids.size(),mpi_gid_t,pid,tag,mpi_comm,&req),
                    "GridImportExport::scatter, creating recv request (step 1)");
   }
-
   check_mpi_call(MPI_Waitall(send_req.size(),send_req.data(),MPI_STATUSES_IGNORE),
                  "GridImportExport::scatter, waiting on send requests (step 1)");
   check_mpi_call(MPI_Waitall(recv_req.size(),recv_req.data(),MPI_STATUSES_IGNORE),
                  "GridImportExport::scatter, waiting on recv requests (step 1)");
   send_req.clear();
   recv_req.clear();
-
-  // 2. Size dst and create recv/send requests
-  for (int i=0; i<nimp; ++i) {
-    auto lid = m_import_lids_h[i];
-    auto gid = overlap_gids_h[lid];
-    dst[lid].resize(recv_count[i]);
-    auto& req = recv_req.emplace_back();
-    check_mpi_call(MPI_Irecv(dst[lid].data(),recv_count[i],mpi_data_t,
-                             m_import_pids_h[i],gid,mpi_comm,&req),
-                   "GridImportExport::scatter, creating recv request (step 2)");
+  
+  // 2. Communicate T's count for each GID to recv pids
+  std::map<int,std::vector<int>> send_pid2count;
+  for (int i=0; i<nexp; ++i) {
+    auto pid = m_export_pids_h[i];
+    auto lid = m_export_lids_h[i];
+    send_pid2count[pid].push_back(src.at(lid).size());
+  }
+  for (auto& [pid,count] : send_pid2count) {
+    auto& req = send_req.emplace_back();
+    check_mpi_call(MPI_Isend (count.data(),count.size(),MPI_INT,pid,tag,mpi_comm,&req),
+                   "GridImportExport::scatter, creating send request (step 2)");
   }
 
-  for (int i=0; i<nexp; ++i) {
-    auto lid = m_export_lids_h[i];
-    auto gid = unique_gids_h[lid];
-    auto& req = send_req.emplace_back();
-    check_mpi_call(MPI_Isend(src.at(lid).data(),src.at(lid).size(),mpi_data_t,
-                             m_export_pids_h[i],gid,mpi_comm,&req),
+  std::map<int,std::vector<int>>      recv_pid2count;
+  for (auto& [pid,gids] : recv_pid2gids) {
+    recv_pid2count[pid].resize(gids.size());
+  }
+  for (auto& [pid,count] : recv_pid2count) {
+    auto& req = recv_req.emplace_back();
+    check_mpi_call(MPI_Irecv (count.data(),count.size(),MPI_INT,pid,tag,mpi_comm,&req),
                    "GridImportExport::scatter, creating recv request (step 2)");
   }
   check_mpi_call(MPI_Waitall(send_req.size(),send_req.data(),MPI_STATUSES_IGNORE),
@@ -176,6 +193,58 @@ scatter (const MPI_Datatype mpi_data_t,
                  "GridImportExport::scatter, waiting on recv requests (step 2)");
   send_req.clear();
   recv_req.clear();
+
+  // 3. Pack and send the data.
+  std::map<int,std::vector<T>> send_pid2data;
+  const auto& gid2lid = m_unique->get_gid2lid_map();
+  for (const auto& [pid,gids] : send_pid2gids) {
+    auto& data = send_pid2data[pid];
+    for (auto g : gids) {
+      auto lid = gid2lid.at(g);
+      data.insert(data.end(),src.at(lid).begin(),src.at(lid).end());
+    }
+  }
+  for (auto& [pid,data] : send_pid2data) {
+    auto& req = send_req.emplace_back();
+    check_mpi_call(MPI_Isend (data.data(),data.size(),mpi_data_t,pid,tag,mpi_comm,&req),
+                   "GridImportExport::scatter, creating send request (step 3)");
+  }
+
+  std::map<int,std::vector<T>> recv_pid2data;
+  for (const auto& [pid,count] : recv_pid2count) {
+    int n = 0;
+    for (auto c : count) n += c;
+
+    auto& data = recv_pid2data[pid];
+    data.resize(n);
+  }
+  for (auto& [pid,data] : recv_pid2data) {
+    auto& req = recv_req.emplace_back();
+    check_mpi_call(MPI_Irecv (data.data(),data.size(),mpi_data_t,pid,tag,mpi_comm,&req),
+                   "GridImportExport::scatter, creating recv request (step 3)");
+  }
+  check_mpi_call(MPI_Waitall(send_req.size(),send_req.data(),MPI_STATUSES_IGNORE),
+                 "GridImportExport::scatter, waiting on send requests (step 3)");
+  check_mpi_call(MPI_Waitall(recv_req.size(),recv_req.data(),MPI_STATUSES_IGNORE),
+                 "GridImportExport::scatter, waiting on recv requests (step 3)");
+  send_req.clear();
+  recv_req.clear();
+
+  // 4. Unpack received data in dst map
+  const auto& recv_gid2lid = m_overlapped->get_gid2lid_map();
+  for (const auto& [pid,data] : recv_pid2data) {
+    const auto& count = recv_pid2count[pid];
+    const auto& gids  = recv_pid2gids[pid];
+    const int num_gids = count.size();
+    for (int i=0, pos=0; i<num_gids; ++i) {
+      auto lid = recv_gid2lid.at(gids[i]);
+      auto curr_sz = dst[lid].size();
+      dst[lid].resize(curr_sz+count[i]);
+      for (int k=0; k<count[i]; ++k, ++pos) {
+        dst[lid][curr_sz+k] = data[pos];
+      }
+    }
+  }
 }
 
 template<typename T>
@@ -184,66 +253,66 @@ gather (const MPI_Datatype mpi_data_t,
         const std::map<int,std::vector<T>>& src,
               std::map<int,std::vector<T>>& dst) const
 {
-  using gid_type = AbstractGrid::gid_type;
+  const auto tag = 0;
 
   std::vector<MPI_Request> send_req, recv_req;
   
   const int nexp = m_export_lids.size();
   const int nimp = m_import_lids.size();
   auto mpi_comm = m_comm.mpi_comm();
+  auto mpi_gid_t = ekat::get_mpi_type<gid_type>();
 
-  auto unique_gids_h = m_unique->get_dofs_gids().get_view<const gid_type*,Host>();
-  auto overlap_gids_h = m_overlapped->get_dofs_gids().get_view<const gid_type*,Host>();
+  auto ov_gids_h = m_overlapped->get_dofs_gids().get_view<const gid_type*,Host>();
 
-  const int num_ov_gids = overlap_gids_h.size();
-
-  // 1. Communicate to the recv pids how many items per lid
-  // we need to send
-  std::vector<int> send_count(num_ov_gids,0);
+  // 1. Communicate GIDs lists to recv pids
+  std::map<int,std::vector<gid_type>> send_pid2gids;
   for (int i=0; i<nimp; ++i) {
+    auto pid = m_import_pids_h[i];
     auto lid = m_import_lids_h[i];
-    auto gid = overlap_gids_h[lid];
-    send_count[lid] = src.at(lid).size();
+    send_pid2gids[pid].push_back(ov_gids_h[lid]);
+  }
+  for (auto& [pid,gids] : send_pid2gids) {
     auto& req = send_req.emplace_back();
-    check_mpi_call(MPI_Isend (&send_count[lid],1,MPI_INT,
-                              m_import_pids_h[i],gid,mpi_comm,&req),
+    check_mpi_call(MPI_Isend (gids.data(),gids.size(),mpi_gid_t,pid,tag,mpi_comm,&req),
                    "GridImportExport::gather, creating send request (step 1)");
   }
-  std::vector<int> recv_count(m_export_lids_h.size(),0);
+  std::map<int,std::vector<gid_type>> recv_pid2gids;
   for (int i=0; i<nexp; ++i) {
+    auto pid = m_export_pids_h[i];
+    recv_pid2gids[pid].push_back(-1);
+  }
+  for (auto& [pid,gids] : recv_pid2gids) {
     auto& req = recv_req.emplace_back();
-    auto lid = m_export_lids_h[i];
-    auto gid = unique_gids_h[lid];
-    check_mpi_call(MPI_Irecv (&recv_count[i],1,MPI_INT,
-                              m_export_pids_h[i],gid,mpi_comm,&req),
+    check_mpi_call(MPI_Irecv (gids.data(),gids.size(),mpi_gid_t,pid,tag,mpi_comm,&req),
                    "GridImportExport::gather, creating recv request (step 1)");
   }
-
   check_mpi_call(MPI_Waitall(send_req.size(),send_req.data(),MPI_STATUSES_IGNORE),
                  "GridImportExport::gather, waiting on send requests (step 1)");
   check_mpi_call(MPI_Waitall(recv_req.size(),recv_req.data(),MPI_STATUSES_IGNORE),
                  "GridImportExport::gather, waiting on recv requests (step 1)");
   send_req.clear();
   recv_req.clear();
-
-  // 2. Create recv buf and recv/send requests
-  std::map<int,std::vector<T>> recv_buf;
-  for (int i=0; i<nexp; ++i) {
-    auto lid = m_export_lids_h[i];
-    auto gid = unique_gids_h[lid];
-    recv_buf[i].resize(recv_count[i]);
-    auto& req = recv_req.emplace_back();
-    check_mpi_call(MPI_Irecv(recv_buf[i].data(),recv_count[i],mpi_data_t,
-                             m_export_pids_h[i],gid,mpi_comm,&req),
-                   "GridImportExport::gather, creating recv request (step 2)");
+  
+  // 2. Communicate T's count for each GID to recv pids
+  std::map<int,std::vector<int>> send_pid2count;
+  for (int i=0; i<nimp; ++i) {
+    auto pid = m_import_pids_h[i];
+    auto lid = m_import_lids_h[i];
+    send_pid2count[pid].push_back(src.at(lid).size());
+  }
+  for (auto& [pid,count] : send_pid2count) {
+    auto& req = send_req.emplace_back();
+    check_mpi_call(MPI_Isend (count.data(),count.size(),MPI_INT,pid,tag,mpi_comm,&req),
+                   "GridImportExport::gather, creating send request (step 2)");
   }
 
-  for (int i=0; i<nimp; ++i) {
-    auto lid = m_import_lids_h[i];
-    auto& req = send_req.emplace_back();
-    auto gid = overlap_gids_h[lid];
-    check_mpi_call(MPI_Isend(src.at(lid).data(),src.at(lid).size(),mpi_data_t,
-                             m_import_pids_h[i],gid,mpi_comm,&req),
+  std::map<int,std::vector<int>>      recv_pid2count;
+  for (auto& [pid,gids] : recv_pid2gids) {
+    recv_pid2count[pid].resize(gids.size());
+  }
+  for (auto& [pid,count] : recv_pid2count) {
+    auto& req = recv_req.emplace_back();
+    check_mpi_call(MPI_Irecv (count.data(),count.size(),MPI_INT,pid,tag,mpi_comm,&req),
                    "GridImportExport::gather, creating recv request (step 2)");
   }
   check_mpi_call(MPI_Waitall(send_req.size(),send_req.data(),MPI_STATUSES_IGNORE),
@@ -253,13 +322,56 @@ gather (const MPI_Datatype mpi_data_t,
   send_req.clear();
   recv_req.clear();
 
-  // 3. Fill dst map with content from the recv buffer
-  for (const auto& it : recv_buf) {
-    auto lid = m_export_lids_h[it.first];
-    auto& curr = dst[lid];
-    auto& add = it.second;
-    curr.reserve(curr.size()+add.size());
-    std::move(add.begin(),add.end(),std::back_inserter(curr));
+  // 3. Pack and send the data.
+  std::map<int,std::vector<T>> send_pid2data;
+  const auto& ov_gid2lid = m_overlapped->get_gid2lid_map();
+  for (const auto& [pid,gids] : send_pid2gids) {
+    auto& data = send_pid2data[pid];
+    for (auto g : gids) {
+      auto lid = ov_gid2lid.at(g);
+      data.insert(data.end(),src.at(lid).begin(),src.at(lid).end());
+    }
+  }
+  for (auto& [pid,data] : send_pid2data) {
+    auto& req = send_req.emplace_back();
+    check_mpi_call(MPI_Isend (data.data(),data.size(),mpi_data_t,pid,tag,mpi_comm,&req),
+                   "GridImportExport::gather, creating send request (step 3)");
+  }
+
+  std::map<int,std::vector<T>> recv_pid2data;
+  for (const auto& [pid,count] : recv_pid2count) {
+    int n = 0;
+    for (auto c : count) n += c;
+
+    auto& data = recv_pid2data[pid];
+    data.resize(n);
+  }
+  for (auto& [pid,data] : recv_pid2data) {
+    auto& req = recv_req.emplace_back();
+    check_mpi_call(MPI_Irecv (data.data(),data.size(),mpi_data_t,pid,tag,mpi_comm,&req),
+                   "GridImportExport::gather, creating recv request (step 3)");
+  }
+  check_mpi_call(MPI_Waitall(send_req.size(),send_req.data(),MPI_STATUSES_IGNORE),
+                 "GridImportExport::gather, waiting on send requests (step 3)");
+  check_mpi_call(MPI_Waitall(recv_req.size(),recv_req.data(),MPI_STATUSES_IGNORE),
+                 "GridImportExport::gather, waiting on recv requests (step 3)");
+  send_req.clear();
+  recv_req.clear();
+
+  // 4. Unpack received data in dst map
+  const auto& recv_gid2lid = m_unique->get_gid2lid_map();
+  for (const auto& [pid,data] : recv_pid2data) {
+    const auto& count = recv_pid2count[pid];
+    const auto& gids  = recv_pid2gids[pid];
+    const int num_gids = count.size();
+    for (int i=0, pos=0; i<num_gids; ++i) {
+      auto lid = recv_gid2lid.at(gids[i]);
+      auto curr_sz = dst[lid].size();
+      dst[lid].resize(curr_sz+count[i]);
+      for (int k=0; k<count[i]; ++k, ++pos) {
+        dst[lid][curr_sz+k] = data[pos];
+      }
+    }
   }
 }
 

--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_data.cpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_data.cpp
@@ -133,10 +133,10 @@ get_my_triplets (const std::string& map_file) const
 
   // Create Triplets to export, sorted by gid
   std::map<int,std::vector<Triplet>> io_triplets;
-  auto io_grid_gid2lid = io_grid->get_gid2lid_map();
+  const auto& io_grid_gid2lid = io_grid->get_gid2lid_map();
   for (int i=0; i<nlweights; ++i) {
     auto gid = gids[i];
-    auto io_lid = io_grid_gid2lid[gid];
+    auto io_lid = io_grid_gid2lid.at(gid);
     io_triplets[io_lid].emplace_back(rows[i], cols[i], S[i]);
   }
 
@@ -207,8 +207,8 @@ create_crs_matrix_structures (std::vector<Triplet>& triplets)
   auto col_grid = refine ? ov_coarse_grid : fine_grid;
   const int num_rows = row_grid->get_num_local_dofs();
 
-  auto col_gid2lid = col_grid->get_gid2lid_map();
-  auto row_gid2lid = row_grid->get_gid2lid_map();
+  const auto& col_gid2lid = col_grid->get_gid2lid_map();
+  const auto& row_gid2lid = row_grid->get_gid2lid_map();
 
   // Sort triplets so that row GIDs appear in the same order as
   // in the row grid. If two row GIDs are the same, use same logic
@@ -234,7 +234,7 @@ create_crs_matrix_structures (std::vector<Triplet>& triplets)
 
   // Fill col ids and weights
   for (int i=0; i<nnz; ++i) {
-    col_lids_h(i) = col_gid2lid[triplets[i].col];
+    col_lids_h(i) = col_gid2lid.at(triplets[i].col);
     weights_h(i)  = triplets[i].w;
   }
   Kokkos::deep_copy(weights,weights_h);
@@ -243,7 +243,7 @@ create_crs_matrix_structures (std::vector<Triplet>& triplets)
   // Compute row offsets
   std::vector<int> row_counts(num_rows);
   for (int i=0; i<nnz; ++i) {
-    ++row_counts[row_gid2lid[triplets[i].row]];
+    ++row_counts[row_gid2lid.at(triplets[i].row)];
   }
   std::partial_sum(row_counts.begin(),row_counts.end(),row_offsets_h.data()+1);
   EKAT_REQUIRE_MSG (

--- a/components/eamxx/src/share/tests/grid_import_export_tests.cpp
+++ b/components/eamxx/src/share/tests/grid_import_export_tests.cpp
@@ -124,12 +124,19 @@ TEST_CASE ("grid_import_export") {
     printf(" -> Testing export views ...... %s\n",ok ? "PASS" : "FAIL");
   }
 
-  // Later, we design the tests in such a way that, serially, the data stored for
-  // gid N is [0,...,N-1]. We want this to also be the case in parallel, but the
-  // same GID may be owned by 2+ processors in the ov grid. For the gather ops,
-  // we will fill the overlapped data in a way that, after gather is called, we
-  // obtain the same serial data. To do so, we need to know what GIDs that we own
-  // are also owned by others.
+  // Test gather
+  if (comm.am_i_root()) {
+    printf(" -> Testing gather routine ....\n");
+  }
+  ok  = true;
+
+  // We design the tests in such a way that, serially, the data stored for
+  // gid N is [0,...,N]. We want this to also be the case in parallel, but the
+  // same GID may be owned by 2+ processors in the ov grid. This would cause duplicate
+  // entries upon gather completion, making checking the results harder.
+  // To avoid this, we store a map gid->pids so that all ranks know how many ranks
+  // have a give gid in the ov grid. When filling up the ov_data for gather,
+  // rank P will only fill data for gid N if it is the smallest gid owning it.
   std::map<gid_type,std::vector<int>> gid2pids;
   for (int pid=0; pid<comm.size(); ++pid) {
     std::vector<gid_type> pid_gids;
@@ -147,33 +154,17 @@ TEST_CASE ("grid_import_export") {
       gid2pids[g].push_back(pid);
     }
   }
-
-  // Test gather
-  if (comm.am_i_root()) {
-    printf(" -> Testing gather routine ....\n");
+  for (auto& [gid,pids] : gid2pids) {
+    std::sort(pids.begin(),pids.end());
   }
-  ok  = true;
 
   std::map<int,std::vector<Real>> ov_data;
   for (int i=0; i<ov_grid->get_num_local_dofs(); ++i) {
     auto& v = ov_data[i];
     auto gid = ov_gids[i];
-    // Serially, the data should contain N for N in [0,...,gid-1]
-    // We make the ov data array be such that when patched together they give the
-    // same array (albeit possibly permuted). We do this by distributing the
-    auto& pids = gid2pids[gid];
-    if (pids.size()==1) {
-      // I own this gid, and don't share it with any other rank. Fill [0,..,gid-1]
+    if (comm.rank()==gid2pids[gid][0]) {
       for (int k=0; k<=gid; ++k) {
         v.push_back(k);
-      }
-    } else {
-      for (int k=0,p=0; k<=gid; ++k) {
-        if (comm.rank()==pids[p]) {
-          v.push_back(k);
-        }
-        ++p;
-        p = p % pids.size();
       }
     }
   }

--- a/components/eamxx/src/share/tests/grid_import_export_tests.cpp
+++ b/components/eamxx/src/share/tests/grid_import_export_tests.cpp
@@ -26,13 +26,13 @@ TEST_CASE ("grid_import_export") {
   auto engine = setup_random_test(&comm);
 
   bool ok;
-  const int overlap    = 5;
-  const int nldofs_src = 10;
-  const int ngdofs     = nldofs_src*comm.size();;
+  const int overlap = 5;
+  const int nldofs  = 10;
+  const int ngdofs  = nldofs*comm.size();;
 
   // Create the unique grid
-  auto src_grid = create_point_grid("src",ngdofs,0,comm);
-  auto src_gids = src_grid->get_dofs_gids().get_view<const gid_type*, Host>();
+  auto grid = create_point_grid("src",ngdofs,0,comm);
+  auto gids = grid->get_dofs_gids().get_view<const gid_type*, Host>();
 
   // For the dst grid, shuffle dofs around randomly. Then,
   // have each rank grab a few extra dofs
@@ -45,20 +45,20 @@ TEST_CASE ("grid_import_export") {
 
   const bool first = comm.rank()==0;
   const bool last  = comm.rank()==(comm.size()-1);
-  auto start = all_dofs.data() + nldofs_src*comm.rank();
-  auto end   = start + nldofs_src;
+  auto start = all_dofs.data() + nldofs*comm.rank();
+  auto end   = start + nldofs;
   end   += last ? 0 : overlap;
   start -= first ? 0 : overlap;
-  const int ndofs_dst = nldofs_src + (first ? 0 : overlap) + (last ? 0 : overlap);
+  const int nldofs_ov = nldofs + (first ? 0 : overlap) + (last ? 0 : overlap);
 
-  auto dst_grid = std::make_shared<PointGrid>("grid",ndofs_dst,0,comm);
-  auto dst_gids_field = dst_grid->get_dofs_gids();
-  auto dst_gids = dst_gids_field.get_view<gid_type*,Host>();
+  auto ov_grid = std::make_shared<PointGrid>("grid",nldofs_ov,0,comm);
+  auto ov_gids_field = ov_grid->get_dofs_gids();
+  auto ov_gids = ov_gids_field.get_view<gid_type*,Host>();
 
-  std::copy (start,end,dst_gids.data());
-  dst_gids_field.sync_to_dev();
+  std::copy (start,end,ov_gids.data());
+  ov_gids_field.sync_to_dev();
 
-  GridImportExport imp_exp(src_grid,dst_grid);
+  GridImportExport imp_exp(grid,ov_grid);
 
   // Test import views
   if (comm.am_i_root()) {
@@ -70,8 +70,8 @@ TEST_CASE ("grid_import_export") {
   std::set<int> all_imp_lids;
   for (size_t i=0; i<imp_pids.size(); ++i) {
     auto lid = imp_lids[i];
-    auto gid = dst_gids[lid];
-    auto pid = gid / nldofs_src;
+    auto gid = ov_gids[lid];
+    auto pid = gid / nldofs;
     CHECK (imp_pids[i]==pid);
     ok &= catch_capture.lastAssertionPassed();
     all_imp_lids.insert(lid);
@@ -90,11 +90,11 @@ TEST_CASE ("grid_import_export") {
   auto exp_pids = imp_exp.export_pids_h();
   auto exp_lids = imp_exp.export_lids_h();
   std::map<int,std::vector<int>> pid2lid;
-  auto src_gid2lid = src_grid->get_gid2lid_map();
+  auto gid2lid = grid->get_gid2lid_map();
   for (int pid=0; pid<comm.size(); ++pid) {
     pid2lid[pid].resize(0);
-    int pid_start = pid*nldofs_src;
-    int pid_end   = pid_start+nldofs_src;
+    int pid_start = pid*nldofs;
+    int pid_end   = pid_start+nldofs;
     if (pid!=0) {
       pid_start -= overlap;
     }
@@ -103,8 +103,8 @@ TEST_CASE ("grid_import_export") {
     }
     for (int i=pid_start;i<pid_end; ++i) {
       auto gid = all_dofs[i];
-      if (src_gid2lid.count(gid)==1) {
-        pid2lid[pid].push_back(src_gid2lid.at(gid));
+      if (gid2lid.count(gid)==1) {
+        pid2lid[pid].push_back(gid2lid.at(gid));
       }
     }
     std::sort(pid2lid[pid].begin(),pid2lid[pid].end());
@@ -124,39 +124,76 @@ TEST_CASE ("grid_import_export") {
     printf(" -> Testing export views ...... %s\n",ok ? "PASS" : "FAIL");
   }
 
+  // Later, we design the tests in such a way that, serially, the data stored for
+  // gid N is [0,...,N-1]. We want this to also be the case in parallel, but the
+  // same GID may be owned by 2+ processors in the ov grid. For the gather ops,
+  // we will fill the overlapped data in a way that, after gather is called, we
+  // obtain the same serial data. To do so, we need to know what GIDs that we own
+  // are also owned by others.
+  std::map<gid_type,std::vector<int>> gid2pids;
+  for (int pid=0; pid<comm.size(); ++pid) {
+    std::vector<gid_type> pid_gids;
+    int n = ov_gids.size();
+    comm.broadcast(&n,1,pid);
+    pid_gids.resize(n);
+    if (pid==comm.rank()) {
+      for (int i=0; i<n; ++i) {
+        pid_gids[i] = ov_gids[i];
+      }
+    }
+    comm.broadcast(pid_gids.data(),n,pid);
+
+    for (auto g : pid_gids) {
+      gid2pids[g].push_back(pid);
+    }
+  }
+
   // Test gather
   if (comm.am_i_root()) {
     printf(" -> Testing gather routine ....\n");
   }
   ok  = true;
-  std::map<int,std::vector<Real>> src_data;
-  for (int i=0; i<dst_grid->get_num_local_dofs(); ++i) {
-    auto& v = src_data[i];
-    auto gid = dst_gids[i];
-    v.resize(gid);
-    std::iota(v.begin(),v.end(),0);
-  }
-  std::map<int,std::vector<Real>> dst_data;
-  imp_exp.gather(ekat::get_mpi_type<Real>(),src_data,dst_data);
 
-  std::vector<size_t> num_imp_per_lid (nldofs_src,0);
-  for (size_t i=0; i<exp_lids.size(); ++i) {
-    ++num_imp_per_lid[exp_lids[i]];
+  std::map<int,std::vector<Real>> ov_data;
+  for (int i=0; i<ov_grid->get_num_local_dofs(); ++i) {
+    auto& v = ov_data[i];
+    auto gid = ov_gids[i];
+    // Serially, the data should contain N for N in [0,...,gid-1]
+    // We make the ov data array be such that when patched together they give the
+    // same array (albeit possibly permuted). We do this by distributing the
+    auto& pids = gid2pids[gid];
+    if (pids.size()==1) {
+      // I own this gid, and don't share it with any other rank. Fill [0,..,gid-1]
+      for (int k=0; k<=gid; ++k) {
+        v.push_back(k);
+      }
+    } else {
+      for (int k=0,p=0; k<=gid; ++k) {
+        if (comm.rank()==pids[p]) {
+          v.push_back(k);
+        }
+        ++p;
+        p = p % pids.size();
+      }
+    }
   }
-  // std::cout << "num imp per lid: " << ekat::join(num_imp_per_lid," ") << "\n";
-  for (const auto& it : dst_data) {
-    auto lid = it.first;
-    auto gid = src_gids[lid];
-    const auto& v = it.second;
-    CHECK (v.size()==gid*num_imp_per_lid[lid]);
+
+  std::map<int,std::vector<Real>> data;
+  imp_exp.gather(ekat::get_mpi_type<Real>(),ov_data,data);
+
+  for (auto [lid,v] : data) {
+    auto gid = gids[lid];
+    CHECK (static_cast<int>(v.size())==(gid+1));
     ok &= catch_capture.lastAssertionPassed();
 
-    std::vector<Real> expected(gid);
+    std::vector<Real> expected(gid+1);
     std::iota(expected.begin(),expected.end(),0);
-    for (size_t imp=0; imp<num_imp_per_lid[lid]; ++imp) {
-      CHECK (std::equal(expected.begin(),expected.end(),v.begin()+gid*imp));
-      ok &= catch_capture.lastAssertionPassed();
-    }
+
+    // Values may be gathered in a way that is just a permutation
+    // of what we'd get serially, which is [0,...,gid-1]
+    std::sort(v.begin(),v.end());
+    CHECK (std::equal(expected.begin(),expected.end(),v.begin()));
+    ok &= catch_capture.lastAssertionPassed();
   }
   if (comm.am_i_root()) {
     printf(" -> Testing gather routine .... %s\n",ok ? "PASS" : "FAIL");
@@ -167,28 +204,22 @@ TEST_CASE ("grid_import_export") {
     printf(" -> Testing scatter routine ...\n");
   }
   ok = true;
-  src_data.clear();
-  // std::cout << "src_data:\n";
-  for (int i=0; i<src_grid->get_num_local_dofs(); ++i) {
-    auto& v = src_data[i];
-    auto gid = src_gids[i];
-    v.resize(gid);
+  data.clear();
+  for (int i=0; i<grid->get_num_local_dofs(); ++i) {
+    auto& v = data[i];
+    auto gid = gids[i];
+    v.resize(gid+1);
     std::iota(v.begin(),v.end(),0);
-    // std::cout << " " << gid << ":" << ekat::join(v," ") << "\n";
   }
-  dst_data.clear();
-  imp_exp.scatter(ekat::get_mpi_type<Real>(),src_data,dst_data);
+  ov_data.clear();
+  imp_exp.scatter(ekat::get_mpi_type<Real>(),data,ov_data);
 
-  // std::cout << "dst_data:\n";
-  for (const auto& it : dst_data) {
-    auto lid = it.first;
-    auto gid = dst_gids[lid];
-    const auto& v = it.second;
-    CHECK (static_cast<int>(v.size())==gid);
+  for (const auto& [lid,v] : ov_data) {
+    auto gid = ov_gids[lid];
+    CHECK (static_cast<int>(v.size())==(gid+1));
     ok &= catch_capture.lastAssertionPassed();
-    // std::cout << " " << gid << ":" << ekat::join(v," ") << "\n";
 
-    std::vector<Real> expected(gid);
+    std::vector<Real> expected(gid+1);
     std::iota(expected.begin(),expected.end(),0);
     CHECK (std::equal(expected.begin(),expected.end(),v.begin()));
     ok &= catch_capture.lastAssertionPassed();


### PR DESCRIPTION
Fixes an issue encountered during testing of PR #6977 (see [this](https://github.com/E3SM-Project/E3SM/pull/6977#issuecomment-2655101357) comment), where the tags we used went above the max tag allowed by the MPI distribution

[BFB]
---

Instead of sending one msg per grid point, we follow the common pack/unpack paradigm, and send/recv a single message per PID, allowing us to just always use 0 as a tag. It's worth reminding that the gather/scatter routines are used only during initialization, to set up remappers weights (we read map files "evenly" across ranks, and then ship the CRS matrix triplets to the ranks that need them).

@trey-ornl This PR should fix the tags issue. The unit tests for this struct pass on my laptop, but I won't claim it works until I run some tests where coarsening remappers are used (our CI runs ne4 only, so no coarsened output). But if you want to give it a shot, you could try to integrate it on the branch of the Frontier software update, and give it a try on Frontier...

@tcclevenger I don't know if you've ever taken a look at this part of the code. Let me know if you're not familiar with it, and you'd rather walk through it together.