### PR TITLE
EAM: fix cmake configuration of crm/pam

### DIFF
--- a/components/eam/src/physics/crm/pam/CMakeLists.txt
+++ b/components/eam/src/physics/crm/pam/CMakeLists.txt
@@ -13,7 +13,6 @@ add_library(pam_driver
 
 set(SCREAM_LIB_ONLY TRUE)
 set(SCREAM_HOME ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../..)
-add_library(eamxx_physics INTERFACE ${SCREAM_HOME}/components/eamxx/src/physics/)
 
 if (${USE_CUDA})
   # PAM will be CUDA-linked with device symbols resolved at library creation
@@ -127,7 +126,7 @@ target_compile_options(pam_driver PUBLIC
 )
 
 if (PAM_SCREAM_USE_CXX)
-  target_link_libraries(pam_driver pam_core physics dynamics pam_scream_cxx_interfaces ekat p3 shoc physics_share scream_share eamxx_physics)
+  target_link_libraries(pam_driver pam_core physics dynamics pam_scream_cxx_interfaces ekat p3 shoc physics_share scream_share)
 else()
   target_link_libraries(pam_driver pam_core physics dynamics )
 endif()

--- a/components/eamxx/src/physics/cld_fraction/CMakeLists.txt
+++ b/components/eamxx/src/physics/cld_fraction/CMakeLists.txt
@@ -14,8 +14,10 @@ target_compile_definitions(cld_fraction PUBLIC EAMXX_HAS_CLD_FRACTION)
 target_link_libraries(cld_fraction physics_share scream_share)
 target_compile_options(cld_fraction PUBLIC)
 
-# Add this library to eamxx_physics
-target_link_libraries(eamxx_physics INTERFACE cld_fraction)
+if (TARGET eamxx_physics)
+  # Add this library to eamxx_physics
+  target_link_libraries(eamxx_physics INTERFACE cld_fraction)
+endif()
 
 # Cloud fraction does not yet have a set of unit tests or a BFB test comparing with the F90
 # code.

--- a/components/eamxx/src/physics/cosp/CMakeLists.txt
+++ b/components/eamxx/src/physics/cosp/CMakeLists.txt
@@ -54,5 +54,7 @@ target_link_libraries(eamxx_cosp physics_share scream_share cosp)
 target_compile_options(eamxx_cosp PUBLIC)
 target_compile_definitions(eamxx_cosp PUBLIC EAMXX_HAS_COSP)
 
-# Add this library to eamxx_physics
-target_link_libraries(eamxx_physics INTERFACE eamxx_cosp)
+if (TARGET eamxx_physics)
+  # Add this library to eamxx_physics
+  target_link_libraries(eamxx_physics INTERFACE eamxx_cosp)
+endif()

--- a/components/eamxx/src/physics/iop_forcing/CMakeLists.txt
+++ b/components/eamxx/src/physics/iop_forcing/CMakeLists.txt
@@ -2,4 +2,7 @@ add_library(iop_forcing eamxx_iop_forcing_process_interface.cpp)
 target_compile_definitions(iop_forcing PUBLIC EAMXX_HAS_IOP_FORCING)
 target_link_libraries(iop_forcing physics_share scream_share)
 
-target_link_libraries(eamxx_physics INTERFACE iop_forcing)
+if (TARGET eamxx_physics)
+  # Add this library to eamxx_physics
+  target_link_libraries(eamxx_physics INTERFACE iop_forcing)
+endif()

--- a/components/eamxx/src/physics/mam/CMakeLists.txt
+++ b/components/eamxx/src/physics/mam/CMakeLists.txt
@@ -61,5 +61,7 @@ target_link_libraries(mam PUBLIC physics_share csm_share scream_share mam4xx hae
 #  add_subdirectory(tests)
 #endif()
 
-# Add this library to eamxx_physics
-target_link_libraries(eamxx_physics INTERFACE mam)
+if (TARGET eamxx_physics)
+  # Add this library to eamxx_physics
+  target_link_libraries(eamxx_physics INTERFACE mam)
+endif()

--- a/components/eamxx/src/physics/ml_correction/CMakeLists.txt
+++ b/components/eamxx/src/physics/ml_correction/CMakeLists.txt
@@ -23,5 +23,7 @@ target_compile_definitions(ml_correction PRIVATE -DML_CORRECTION_CUSTOM_PATH="${
 target_include_directories(ml_correction SYSTEM PUBLIC ${PYTHON_INCLUDE_DIRS})
 target_link_libraries(ml_correction physics_share scream_share pybind11::pybind11 Python::Python)
 
-# Add this library to eamxx_physics
-target_link_libraries(eamxx_physics INTERFACE ml_correction)
+if (TARGET eamxx_physics)
+  # Add this library to eamxx_physics
+  target_link_libraries(eamxx_physics INTERFACE ml_correction)
+endif()

--- a/components/eamxx/src/physics/nudging/CMakeLists.txt
+++ b/components/eamxx/src/physics/nudging/CMakeLists.txt
@@ -6,5 +6,7 @@ if (NOT SCREAM_LIB_ONLY)
   add_subdirectory(tests)
 endif()
 
-# Add this library to eamxx_physics
-target_link_libraries(eamxx_physics INTERFACE nudging)
+if (TARGET eamxx_physics)
+  # Add this library to eamxx_physics
+  target_link_libraries(eamxx_physics INTERFACE nudging)
+endif()

--- a/components/eamxx/src/physics/p3/CMakeLists.txt
+++ b/components/eamxx/src/physics/p3/CMakeLists.txt
@@ -111,5 +111,7 @@ if (NOT SCREAM_LIB_ONLY)
   add_subdirectory(tests)
 endif()
 
-# Add this library to eamxx_physics
-target_link_libraries(eamxx_physics INTERFACE p3)
+if (TARGET eamxx_physics)
+  # Add this library to eamxx_physics
+  target_link_libraries(eamxx_physics INTERFACE p3)
+endif()

--- a/components/eamxx/src/physics/rrtmgp/CMakeLists.txt
+++ b/components/eamxx/src/physics/rrtmgp/CMakeLists.txt
@@ -244,5 +244,7 @@ if (NOT SCREAM_LIB_ONLY)
   add_subdirectory(tests)
 endif()
 
-# Add this library to eamxx_physics
-target_link_libraries(eamxx_physics INTERFACE scream_rrtmgp)
+if (TARGET eamxx_physics)
+  # Add this library to eamxx_physics
+  target_link_libraries(eamxx_physics INTERFACE scream_rrtmgp)
+endif()

--- a/components/eamxx/src/physics/share/CMakeLists.txt
+++ b/components/eamxx/src/physics/share/CMakeLists.txt
@@ -25,5 +25,7 @@ if (NOT SCREAM_LIB_ONLY)
   add_subdirectory(tests)
 endif()
 
-# Add this library to eamxx_physics
-target_link_libraries(eamxx_physics INTERFACE physics_share)
+if (TARGET eamxx_physics)
+  # Add this library to eamxx_physics
+  target_link_libraries(eamxx_physics INTERFACE physics_share)
+endif()

--- a/components/eamxx/src/physics/shoc/CMakeLists.txt
+++ b/components/eamxx/src/physics/shoc/CMakeLists.txt
@@ -121,5 +121,7 @@ if (NOT SCREAM_LIB_ONLY)
   add_subdirectory(tests)
 endif()
 
-# Add this library to eamxx_physics
-target_link_libraries(eamxx_physics INTERFACE shoc)
+if (TARGET eamxx_physics)
+  # Add this library to eamxx_physics
+  target_link_libraries(eamxx_physics INTERFACE shoc)
+endif()

--- a/components/eamxx/src/physics/spa/CMakeLists.txt
+++ b/components/eamxx/src/physics/spa/CMakeLists.txt
@@ -2,5 +2,7 @@ add_library(spa eamxx_spa_process_interface.cpp)
 target_compile_definitions(spa PUBLIC EAMXX_HAS_SPA)
 target_link_libraries(spa physics_share scream_share)
 
-# Add this library to eamxx_physics
-target_link_libraries(eamxx_physics INTERFACE spa)
+if (TARGET eamxx_physics)
+  # Add this library to eamxx_physics
+  target_link_libraries(eamxx_physics INTERFACE spa)
+endif()

--- a/components/eamxx/src/physics/tms/CMakeLists.txt
+++ b/components/eamxx/src/physics/tms/CMakeLists.txt
@@ -29,5 +29,7 @@ if (NOT SCREAM_LIB_ONLY)
   add_subdirectory(tests)
 endif()
 
-# Add this library to eamxx_physics
-target_link_libraries(eamxx_physics INTERFACE tms)
+if (TARGET eamxx_physics)
+  # Add this library to eamxx_physics
+  target_link_libraries(eamxx_physics INTERFACE tms)
+endif()


### PR DESCRIPTION
Fixes CI error in building MMF case (see e.g. [this](https://github.com/E3SM-Project/E3SM/actions/runs/13300838076/job/37141874007?pr=7007) build)

[BFB]

---

Details:
- pam does not need eamxx_physics, since it already links against p3 and shoc
- the submod pam had a problem with correctly getting SCREAM_DATA_DIR into the scream_config.h file