### PR TITLE
EAMxx: Set the defaults for flushing output files

### DIFF
--- a/components/eamxx/src/share/io/eamxx_output_manager.cpp
+++ b/components/eamxx/src/share/io/eamxx_output_manager.cpp
@@ -227,7 +227,7 @@ setup (const std::map<std::string,std::shared_ptr<fm_type>>& field_mgrs,
       // Check if the prev run wrote any output file (it may have not, if the restart was written
       // before the 1st output step). If there is a file, check if there's still room in it.
       const auto& last_output_filename = get_attribute<std::string>(rhist_file,"GLOBAL","last_output_filename");
-      m_resume_output_file = last_output_filename!="" and not restart_pl.get("force_new_file",false);
+      m_resume_output_file = last_output_filename!="" and not restart_pl.get("force_new_file",true);
       if (m_resume_output_file) {
         m_output_file_specs.storage.num_snapshots_in_file = scorpio::get_attribute<int>(rhist_file,"GLOBAL","last_output_file_num_snaps");
 
@@ -705,7 +705,7 @@ setup_internals (const std::map<std::string,std::shared_ptr<fm_type>>& field_mgr
       EKAT_ERROR_MSG ("Error! Unrecognized/unsupported file storage type.\n");
     }
     m_filename_prefix = m_params.get<std::string>("filename_prefix");
-    m_output_file_specs.flush_frequency = m_params.get("flush_frequency",large_int);
+    m_output_file_specs.flush_frequency = m_params.get("flush_frequency",1);
 
     // Allow user to ask for higher precision for normal model output,
     // but default to single to save on storage

--- a/components/eamxx/src/share/io/tests/output_restart.cpp
+++ b/components/eamxx/src/share/io/tests/output_restart.cpp
@@ -79,6 +79,7 @@ TEST_CASE("output_restart","io")
   output_params.set<std::vector<std::string>>("Field Names",{"field_1", "field_2", "field_3", "field_4","field_5"});
   output_params.set<double>("fill_value",FillValue);
   output_params.set<int>("flush_frequency",1);
+  output_params.sublist("Restart").set<bool>("force_new_file",false);
   output_params.sublist("output_control").set<std::string>("frequency_units","nsteps");
   output_params.sublist("output_control").set<int>("Frequency",10);
   output_params.sublist("Checkpoint Control").set<int>("Frequency",5);


### PR DESCRIPTION
Temporary fix to an issue in the EAMxx I/O that can cause some output files to be missing or overwritten.  This commit sets the default flush frequency to 1 and forces a new file to be opened for output after every restart.

[BFB]