### PR TITLE
EAMxx:Fixes aerosol microphysics kernel rgss=0 fail and update all-procs MAM4xx test

### DIFF
--- a/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/mam4xx/all_mam4xx_procs/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/mam4xx/all_mam4xx_procs/shell_commands
@@ -4,11 +4,8 @@
 #------------------------------------------------------
 $CIMEROOT/../components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/mam4xx/update_eamxx_num_tracers.sh
 
-#modify initial condition file to get aerosol species ICs
-$CIMEROOT/../components/eamxx/scripts/atmchange initial_conditions::Filename='$DIN_LOC_ROOT/atm/scream/init/screami_mam4xx_ne4np4L72_c20240208.nc' -b
-
 # Add all MAM4 processes (except ACI)
-$CIMEROOT/../components/eamxx/scripts/atmchange physics::atm_procs_list="mam4_constituent_fluxes,mac_aero_mic,mam4_wetscav,mam4_optics,rrtmgp,mam4_srf_online_emiss,mam4_drydep" -b
+$CIMEROOT/../components/eamxx/scripts/atmchange physics::atm_procs_list="mam4_constituent_fluxes,mac_aero_mic,mam4_wetscav,mam4_optics,rrtmgp,mam4_srf_online_emiss,mam4_aero_microphys,mam4_drydep" -b
 
 # Add mam4_aci in mac_aero_mic
 $CIMEROOT/../components/eamxx/scripts/atmchange mac_aero_mic::atm_procs_list="tms,shoc,cldFraction,mam4_aci,p3" -b


### PR DESCRIPTION
EAMxx-MAM4xx model crashes due to a kernel fail in debug model. 
This PR fixes that by adding a missing initialization logic. An existing
MAM4xx all process test is also updated to include aerosol
microphysics process.

The updated test should now act as a guard to check `rgss` values
and it should fail if rgss=0.

The logic to add MAM4xx initial condition file is removed as this logic is
now already present in namelist_scream.xml

[NBFB] for MAM4xx all-processes test only