### PR TITLE
EAMxx: enable YAKL when generating rrtmgp baselines

### DIFF
--- a/components/eamxx/src/physics/rrtmgp/CMakeLists.txt
+++ b/components/eamxx/src/physics/rrtmgp/CMakeLists.txt
@@ -50,6 +50,11 @@ endmacro()
 #             YAKL               #
 ##################################
 
+# TODO: The generate_baselines.cpp in tests needs to be ported to not use YAKL
+if (SCREAM_ONLY_GENERATE_BASELINES)
+  set (SCREAM_RRTMGP_ENABLE_YAKL ON)
+endif()
+
 # RRTMGP++ requires YAKL
 if (SCREAM_RRTMGP_ENABLE_YAKL)
   string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_ci)


### PR DESCRIPTION
In EAMxx standalone testing, some rrtmgp unit tests generate baselines with a file that has not been ported to use kokkos. Hence, when generating baselines, we must have YAKL enabled, or the code will fail to build.