### PR TITLE
Update libfabric module for craycray compiler on frontier.

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1113,7 +1113,7 @@
 
       <modules compiler="^(?!craygnu).*">
         <command name="load">libunwind/1.5.0</command>
-        <command name="load">libfabric/1.15.2.0</command>
+        <command name="load">libfabric/1.20.1</command>
         <command name="load">cray-mpich/8.1.26</command>
         <command name="load">cray-python/3.9.13.1</command>
         <command name="load">subversion/1.14.1</command>


### PR DESCRIPTION
Change module from `libfabric/1.15.2.0` to `libfabric/1.20.1` for the `frontier` compilers still using older software stacks, like `craycray` and `crayamd`. Frontier loses access to `libfabric/1.15.2.0` on February 18, 2025, and the Scream decadal run still needs the older build.

We originally switched from `libfabric/1.20.1` to `libfabric/1.15.2.0` because of a serious performance and stability regression. This is supposed to be fixed. I ran an NE1024 run with `libfabric/1.20.1` and confirmed good performance. (`CPL:ATM_RUN 651.012: 710.944`)