### PR TITLE
On pm-gpu, update cudatoolkit to 12.4

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -394,12 +394,12 @@
       </modules>
 
       <modules compiler="gnugpu">
-        <command name="load">cudatoolkit/12.2</command>
+        <command name="load">cudatoolkit/12.4</command>
         <command name="load">craype-accel-nvidia80</command>
       </modules>
 
       <modules compiler="nvidiagpu">
-        <command name="load">cudatoolkit/12.2</command>
+        <command name="load">cudatoolkit/12.4</command>
         <command name="load">craype-accel-nvidia80</command>
         <command name="load">gcc-native-mixed/12.3</command>
       </modules>


### PR DESCRIPTION
On pm-gpu, update the version of cudatoolkit from 12.2 to 12.4.

Fixes https://github.com/E3SM-Project/E3SM/issues/7024

NBFB (for GPU cases)
