### PR TITLE
EAMxx: fix check in SPA for IOP cases

### DIFF
--- a/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
+++ b/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
@@ -92,7 +92,7 @@ void SPA::initialize_impl (const RunType /* run_type */)
   remap_data.hremap_file = spa_map_file=="None" ? "" : spa_map_file;
   if (m_iop_data_manager!=nullptr) {
     // IOP cases cannot have a remap file. We will create a IOPRemapper as the horiz remapper
-    EKAT_REQUIRE_MSG(spa_map_file == "",
+    EKAT_REQUIRE_MSG(spa_map_file == "" or spa_map_file=="None",
       "Error! Cannot define spa_remap_file for cases with an Intensive Observation Period defined. "
       "The IOP class defines it's own remap from file data -> model data.\n");
 


### PR DESCRIPTION
The remap file is set to "None" in IOP cases, so the check needed to be adjusted.

[BFB]