### PR TITLE
Update fates parameter file to API 37.1

### DIFF
--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -134,7 +134,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- ================================================================== -->
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
-<fates_paramfile >lnd/clm2/paramdata/fates_params_api.36.1.0_14pft_c241003.nc</fates_paramfile>
+<fates_paramfile >lnd/clm2/paramdata/fates_params_api.37.1.0_14pft_c250214.nc</fates_paramfile>
 
 <!-- soil order related parameters (relative to {csmdata}) -->
 <fsoilordercon             >lnd/clm2/paramdata/CNP_parameters_c131108.nc</fsoilordercon>


### PR DESCRIPTION
This simple PR updates the default fates parameter file as well as the fates tag.

This parameter file should be coordinated with https://github.com/NGEET/fates/pull/1334.

This PR should also precede #6918.

[non-B4B] for FATES tests only