### PR TITLE
EAMxx: use uniform tag name for num modes in mam4xx

### DIFF
--- a/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
@@ -56,7 +56,7 @@ void MAMDryDep::set_grids(
   // at mid points
   const int num_aero_modes = mam_coupling::num_aero_modes();
   const FieldLayout vector3d_mid =
-      grid_->get_3d_vector_layout(true, num_aero_modes, "num_modes");
+      grid_->get_3d_vector_layout(true, num_aero_modes, mam_coupling::num_modes_tag_name());
 
   using namespace ekat::units;
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -154,7 +154,7 @@ void MAMMicrophysics::set_grids(
 
   // layout for 3D (ncol, nmodes, nlevs)
   FieldLayout scalar3d_mid_nmodes =
-      grid_->get_3d_vector_layout(true, nmodes, "nmodes");
+      grid_->get_3d_vector_layout(true, nmodes, mam_coupling::num_modes_tag_name());
 
   // Geometric mean dry diameter for number distribution [m]
   add_field<Required>("dgnum", scalar3d_mid_nmodes, m, grid_name);

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
@@ -49,7 +49,7 @@ void MAMWetscav::set_grids(
 
   // layout for 3D (ncol, nmodes, nlevs)
   FieldLayout scalar3d_mid_nmodes =
-      m_grid->get_3d_vector_layout(true, nmodes, "nmodes");
+      m_grid->get_3d_vector_layout(true, nmodes, mam_coupling::num_modes_tag_name());
 
   // layout for 2D (ncol, pcnst)
   FieldLayout scalar2d_pconst =

--- a/components/eamxx/src/physics/mam/mam_coupling.hpp
+++ b/components/eamxx/src/physics/mam/mam_coupling.hpp
@@ -44,6 +44,8 @@ constexpr int gas_pcnst() {
   return gas_pcnst_;
 }
 
+constexpr const char* num_modes_tag_name () { return "nmodes"; }
+
 // number of aerosol/gas species tendencies
 KOKKOS_INLINE_FUNCTION
 constexpr int nqtendbb() { return 4; }


### PR DESCRIPTION
Fixes an issue in FieldManager when checking that a field wasn't registered with a different layout before.

[BFB]

---

NOTE: there's no pb in master, but this causes a fail in testing another PR that fixes something else. :) I thought it was more appropriate to have its own bug-fix PR.