### PR TITLE
Change order of passing the fates_use_luh2 namelist flag 

### DIFF
--- a/components/elm/src/main/elmfates_interfaceMod.F90
+++ b/components/elm/src/main/elmfates_interfaceMod.F90
@@ -311,9 +311,10 @@ contains
     ! namelist variables to determine how many patches need to be allocated
     ! in ELM
     ! --------------------------------------------------------------------------------
-    integer                                        :: pass_biogeog
-    integer                                        :: pass_nocomp
-    integer                                        :: pass_sp
+    integer                                        :: pass_use_biogeog
+    integer                                        :: pass_use_nocomp
+    integer                                        :: pass_use_sp
+    integer                                        :: pass_use_luh2
     integer                                        :: pass_masterproc
     logical                                        :: verbose_output
     type(fates_param_reader_ctsm_impl)             :: var_reader
@@ -328,26 +329,34 @@ contains
 
        ! Send parameters individually
        if(use_fates_fixed_biogeog)then
-          pass_biogeog = 1
+          pass_use_biogeog = 1
        else
-          pass_biogeog = 0
+          pass_use_biogeog = 0
        end if
-       call set_fates_ctrlparms('use_fixed_biogeog',ival=pass_biogeog)
+       call set_fates_ctrlparms('use_fixed_biogeog',ival=pass_use_biogeog)
 
        if(use_fates_nocomp)then
-          pass_nocomp = 1
+          pass_use_nocomp = 1
        else
-          pass_nocomp = 0
+          pass_use_nocomp = 0
        end if
-       call set_fates_ctrlparms('use_nocomp',ival=pass_nocomp)
+       call set_fates_ctrlparms('use_nocomp',ival=pass_use_nocomp)
 
        if(use_fates_sp)then
-          pass_sp = 1
+          pass_use_sp = 1
        else
-          pass_sp = 0
+          pass_use_sp = 0
        end if
-       call set_fates_ctrlparms('use_sp',ival=pass_sp)
+       call set_fates_ctrlparms('use_sp',ival=pass_use_sp)
 
+       ! FATES landuse modes
+       if(use_fates_luh) then
+          pass_use_luh2 = 1
+       else
+          pass_use_luh2 = 0
+       end if
+       call set_fates_ctrlparms('use_luh2',ival=pass_use_luh2)
+       
        if(masterproc)then
           pass_masterproc = 1
        else
@@ -405,7 +414,6 @@ contains
      integer                                        :: pass_num_lu_harvest_cats
      integer                                        :: pass_lu_harvest
      integer                                        :: pass_tree_damage
-     integer                                        :: pass_use_luh
      integer                                        :: pass_use_potentialveg     
      integer                                        :: pass_num_luh_states
      integer                                        :: pass_num_luh_transitions
@@ -546,16 +554,13 @@ contains
         call set_fates_ctrlparms('use_logging',ival=pass_logging)
 
         if(use_fates_luh) then
-           pass_use_luh = 1
            pass_num_luh_states = num_landuse_state_vars
            pass_num_luh_transitions = num_landuse_transition_vars
         else
-           pass_use_luh = 0
            pass_num_luh_states = 0
            pass_num_luh_transitions = 0
         end if
 
-        call set_fates_ctrlparms('use_luh2',ival=pass_use_luh)
         call set_fates_ctrlparms('num_luh2_states',ival=pass_num_luh_states)
         call set_fates_ctrlparms('num_luh2_transitions',ival=pass_num_luh_transitions)
 


### PR DESCRIPTION
This small set of changes moves the passing of the namelist flag "fates_use_luh2" to 
earlier in the initialization call sequence, which is necessary for a more efficient allocation
 of memory in some FATES configurations.  In addition, some local variable names were
updated for consistency.

[BFB]