### PR TITLE
For pm-cpu (and only GNU builds), remove link flag to allow building

### DIFF
--- a/cime_config/machines/cmake_macros/gnu_pm-cpu.cmake
+++ b/cime_config/machines/cmake_macros/gnu_pm-cpu.cmake
@@ -11,5 +11,5 @@ set(SCC "gcc")
 set(SCXX "g++")
 set(SFC "gfortran")
 
-string(APPEND CMAKE_EXE_LINKER_FLAGS " -static-libstdc++")
+#string(APPEND CMAKE_EXE_LINKER_FLAGS " -static-libstdc++") # was causing link error after Feb 18/19 maintenance
 


### PR DESCRIPTION
After Feb 18/19 NERSC maintenance, ran into a link error on pm-cpu with GNU builds.
Removing this link line fixes build, but need more testing to ensure all ok (ie is this needed for some test).

`string(APPEND CMAKE_EXE_LINKER_FLAGS " -static-libstdc++")`

Fixes https://github.com/E3SM-Project/E3SM/issues/7040

BFB
