### PR TITLE
Change lmod paths and craygnu software versions for Frontier.

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1057,37 +1057,36 @@
     </mpirun>
 
     <module_system type="module" allow_error="true">
-      <init_path lang="sh">/usr/share/lmod/lmod/init/sh</init_path>
-      <init_path lang="csh">/usr/share/lmod/lmod/init/csh</init_path>
-      <init_path lang="perl">/usr/share/lmod/lmod/init/perl</init_path>
-      <init_path lang="python">/usr/share/lmod/lmod/init/env_modules_python.py</init_path>
-      <cmd_path lang="perl">/usr/share/lmod/lmod/libexec/lmod perl</cmd_path>
+      <init_path lang="sh">/opt/cray/pe/lmod/lmod/init/sh</init_path>
+      <init_path lang="csh">/opt/cray/pe/lmod/lmod/init/csh</init_path>
+      <init_path lang="perl">/opt/cray/pe/lmod/lmod/init/perl</init_path>
+      <init_path lang="python">/opt/cray/pe/lmod/lmod/init/env_modules_python.py</init_path>
+      <cmd_path lang="perl">/opt/cray/pe/lmod/lmod/libexec/lmod perl</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
-      <cmd_path lang="python">/usr/share/lmod/lmod/libexec/lmod python</cmd_path>
+      <cmd_path lang="python">/opt/cray/pe/lmod/lmod/libexec/lmod python</cmd_path>
       <modules compiler="craygnu.*">
         <command name="reset"></command>
         <!-- PrgEnv-gnu before cpe, or cray-mpich module doesn't update correctly -->
         <command name="load">PrgEnv-gnu</command>
-        <command name="load">cpe/24.07</command>
-        <command name="load">libfabric/1.15.2.0</command>
-        <command name="load">libunwind</command>
-        <command name="load">cray-python</command>
-        <command name="load">subversion</command>
-        <command name="load">git</command>
-        <command name="load">cmake</command>
-        <command name="load">cray-hdf5-parallel</command>
-        <command name="load">cray-netcdf-hdf5parallel</command>
-        <command name="load">cray-parallel-netcdf</command>
+        <command name="load">cpe/24.11</command>
+        <command name="load">libunwind/1.8.1</command>
+        <command name="load">cray-python/3.11.7</command>
+        <command name="load">subversion/1.14.2</command>
+        <command name="load">git/2.45.1</command>
+        <command name="load">cmake/3.27.9</command>
+        <command name="load">cray-hdf5-parallel/1.14.3.3</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.9.0.15</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.15</command>
         <command name="unload">darshan-runtime</command>
       </modules>
       <modules compiler="craygnu-hipcc">
         <command name="load">craype-accel-amd-gfx90a</command>
-        <command name="load">rocm/6.2.0</command>
+        <command name="load">rocm/6.2.4</command>
       </modules>
       <modules compiler="craygnu-mphipcc">
         <command name="load">craype-accel-amd-gfx90a</command>
-        <command name="load">rocm/6.2.0</command>
+        <command name="load">rocm/6.2.4</command>
       </modules>
       <modules compiler="craycray.*">
         <command name="reset"></command>


### PR DESCRIPTION
* Change `lmod` paths from `/usr/share` to `/opt/cray/pe` because the `/usr/share` software is not maintained and is not available on internal OLCF test computers.
* Update `craygnu` to latest version of `cpe` available on Frontier, `cpe/24.11`.
* Add explicit versions to other modules in `craygnu`. I used to think this wasn't needed, since `module load cpe/24.11` should set all the appropriate defaults. I recently discovered that this setting of defaults only works if the `module load cpe/24.11` is a separate command before the other `module load`s. Cime uses a single `module load` with a list of modules, which does not update the defaults. I selected the explicit versions based on the `cpe/24.11` defaults, including the default for `rocm`, `rocm/6.2.4`.
* Remove the `libfabric` module from `craygnu`. On Feb 18, the default `libfabric` changed from `libfabric/1.20.1` to `libfabric/1.22.0`. Only the default version on a given computer is officially supported by HPE. I removed the `libfabric` module from `craygnu` so that it will stay with the default when it changes.