### PR TITLE
Restores sbatch arguments and Depends files on Frontier

### DIFF
--- a/cime_config/machines/Depends.craygnu-hipcc.cmake
+++ b/cime_config/machines/Depends.craygnu-hipcc.cmake
@@ -1,0 +1,26 @@
+list(APPEND MPAS_ICE_SHORTWAVE
+  ${CMAKE_BINARY_DIR}/core_seaice/column/ice_shortwave.f90
+)
+
+# For optimized GNU builds that use v9 or higher, remove an optimization on one file
+if (NOT DEBUG)
+  if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 9)
+    foreach(ITEM IN LISTS MPAS_ICE_SHORTWAVE)
+      e3sm_add_flags("${ITEM}" "-fno-tree-pta") # avoids an error that shows up in solver with gnu9 and higher
+    endforeach()
+  endif()
+endif()
+
+list(APPEND NO_INLINE_ARG_PACKING_LIST
+  eam/src/dynamics/se/inidat.F90
+)
+
+if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+  if (NOT DEBUG)
+    # new in gnu10, inline arg packing was causing INF values with SMS_P4x1.ne4pg2_ne4pg2.F-MMFXX
+    foreach(ITEM IN LISTS NO_INLINE_ARG_PACKING_LIST)
+      e3sm_add_flags("${ITEM}" " -fno-inline-arg-packing")
+    endforeach()
+  endif()
+endif()
+

--- a/cime_config/machines/Depends.craygnu-mphipcc.cmake
+++ b/cime_config/machines/Depends.craygnu-mphipcc.cmake
@@ -1,0 +1,26 @@
+list(APPEND MPAS_ICE_SHORTWAVE
+  ${CMAKE_BINARY_DIR}/core_seaice/column/ice_shortwave.f90
+)
+
+# For optimized GNU builds that use v9 or higher, remove an optimization on one file
+if (NOT DEBUG)
+  if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 9)
+    foreach(ITEM IN LISTS MPAS_ICE_SHORTWAVE)
+      e3sm_add_flags("${ITEM}" "-fno-tree-pta") # avoids an error that shows up in solver with gnu9 and higher
+    endforeach()
+  endif()
+endif()
+
+list(APPEND NO_INLINE_ARG_PACKING_LIST
+  eam/src/dynamics/se/inidat.F90
+)
+
+if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+  if (NOT DEBUG)
+    # new in gnu10, inline arg packing was causing INF values with SMS_P4x1.ne4pg2_ne4pg2.F-MMFXX
+    foreach(ITEM IN LISTS NO_INLINE_ARG_PACKING_LIST)
+      e3sm_add_flags("${ITEM}" " -fno-inline-arg-packing")
+    endforeach()
+  endif()
+endif()
+

--- a/cime_config/machines/Depends.craygnu.cmake
+++ b/cime_config/machines/Depends.craygnu.cmake
@@ -1,0 +1,27 @@
+e3sm_add_flags("eam/src/dynamics/fv/geopk.F90" "-fcray-pointer")
+
+list(APPEND MPAS_ICE_SHORTWAVE
+  ${CMAKE_BINARY_DIR}/core_seaice/column/ice_shortwave.f90
+)
+
+# For optimized GNU builds that use v9 or higher, remove an optimization on one file
+if (NOT DEBUG)
+  if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 9)
+    foreach(ITEM IN LISTS MPAS_ICE_SHORTWAVE)
+      e3sm_add_flags("${ITEM}" "-fno-tree-pta") # avoids an error that shows up in solver with gnu9 and higher
+    endforeach()
+  endif()
+endif()
+
+list(APPEND NO_INLINE_ARG_PACKING_LIST
+  eam/src/dynamics/se/inidat.F90
+)
+
+if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+  if (NOT DEBUG)
+    # new in gnu10, inline arg packing was causing INF values with SMS_P4x1.ne4pg2_ne4pg2.F-MMFXX
+    foreach(ITEM IN LISTS NO_INLINE_ARG_PACKING_LIST)
+      e3sm_add_flags("${ITEM}" " -fno-inline-arg-packing")
+    endforeach()
+  endif()
+endif()

--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -775,7 +775,10 @@
    </batch_system>
 
    <batch_system MACH="frontier" type="slurm">
-	   <batch_submit>/lustre/orion/cli115/world-shared/e3sm/tools/sbatch/throttle</batch_submit>
+    <batch_submit>sbatch</batch_submit>
+     <directives>
+       <directive> --core-spec=$SHELL{tpn=`./xmlquery --value MAX_TASKS_PER_NODE`; if [[ $tpn > 56 ]]; then echo "64-$tpn"|bc; else echo 8; fi; }</directive>
+     </directives>
      <queues>
        <queue strict="true" nodemin="1" nodemax="91" walltimemax="2:00:00" default="true">batch</queue>
        <queue strict="true" nodemin="92" nodemax="183" walltimemax="6:00:00">batch</queue>


### PR DESCRIPTION
* The --core-spec argument has been restored to its state before the February 18, 2025, Frontier update.
* Some Depends files for the GNU compiler on Frontier have been created.

[BFB] No baseline for Frontier yet
Fixes #7046 
Fixes #7037 