### PR TITLE
EAMxx: minor cleanup of diagnostics classes

### DIFF
--- a/components/eamxx/src/diagnostics/aerocom_cld.cpp
+++ b/components/eamxx/src/diagnostics/aerocom_cld.cpp
@@ -74,8 +74,7 @@ void AeroComCld::set_grids(
   m_dz.allocate_view();
 
   // Construct and allocate the output field
-
-  FieldIdentifier fid("AeroComCld"+m_topbot, vector1d_layout, nondim, grid_name);
+  FieldIdentifier fid(name(), vector1d_layout, nondim, grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 

--- a/components/eamxx/src/diagnostics/aerocom_cld.cpp
+++ b/components/eamxx/src/diagnostics/aerocom_cld.cpp
@@ -22,10 +22,9 @@ AeroComCld::AeroComCld(const ekat::Comm &comm,
                    "to be 'Bot' or 'Top' in its input parameters.\n");
 }
 
-void AeroComCld::set_grids(
-    const std::shared_ptr<const GridsManager> grids_manager) {
+void AeroComCld::
+set_grids(const std::shared_ptr<const GridsManager> grids_manager) {
   using namespace ekat::units;
-  using namespace ShortFieldTagsNames;
 
   auto grid             = grids_manager->get_grid("Physics");
   const auto &grid_name = grid->name();
@@ -52,29 +51,29 @@ void AeroComCld::set_grids(
   m_nlevs = grid->get_num_vertical_levels();
 
   // Define layouts we need (both inputs and outputs)
-  FieldLayout scalar2d_layout{{COL, LEV}, {m_ncols, m_nlevs}};
-  FieldLayout vector1d_layout{{COL, CMP}, {m_ncols, m_ndiag}};
+  auto scalar3d = grid->get_3d_scalar_layout(true);
+  auto vector2d = grid->get_2d_vector_layout(m_ndiag);
 
   // The fields required for this diagnostic to be computed
-  add_field<Required>("T_mid", scalar2d_layout, K, grid_name);
-  add_field<Required>("pseudo_density", scalar2d_layout, Pa, grid_name);
-  add_field<Required>("p_mid", scalar2d_layout, Pa, grid_name);
-  add_field<Required>("qv", scalar2d_layout, kg / kg, grid_name);
-  add_field<Required>("qc", scalar2d_layout, kg / kg, grid_name);
-  add_field<Required>("qi", scalar2d_layout, kg / kg, grid_name);
-  add_field<Required>("eff_radius_qc", scalar2d_layout, micron, grid_name);
-  add_field<Required>("eff_radius_qi", scalar2d_layout, micron, grid_name);
-  add_field<Required>("cldfrac_tot", scalar2d_layout, nondim, grid_name);
-  add_field<Required>("nc", scalar2d_layout, 1 / kg, grid_name);
-  add_field<Required>("ni", scalar2d_layout, 1 / kg, grid_name);
+  add_field<Required>("T_mid",          scalar3d, K,       grid_name);
+  add_field<Required>("pseudo_density", scalar3d, Pa,      grid_name);
+  add_field<Required>("p_mid",          scalar3d, Pa,      grid_name);
+  add_field<Required>("qv",             scalar3d, kg / kg, grid_name);
+  add_field<Required>("qc",             scalar3d, kg / kg, grid_name);
+  add_field<Required>("qi",             scalar3d, kg / kg, grid_name);
+  add_field<Required>("eff_radius_qc",  scalar3d, micron,  grid_name);
+  add_field<Required>("eff_radius_qi",  scalar3d, micron,  grid_name);
+  add_field<Required>("cldfrac_tot",    scalar3d, nondim,  grid_name);
+  add_field<Required>("nc",             scalar3d, 1 / kg,  grid_name);
+  add_field<Required>("ni",             scalar3d, 1 / kg,  grid_name);
 
   // A field to store dz
-  FieldIdentifier m_dz_fid("dz", scalar2d_layout, m, grid_name);
+  FieldIdentifier m_dz_fid("dz", scalar3d, m, grid_name);
   m_dz = Field(m_dz_fid);
   m_dz.allocate_view();
 
   // Construct and allocate the output field
-  FieldIdentifier fid(name(), vector1d_layout, nondim, grid_name);
+  FieldIdentifier fid(name(), vector2d, nondim, grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 

--- a/components/eamxx/src/diagnostics/aerocom_cld.cpp
+++ b/components/eamxx/src/diagnostics/aerocom_cld.cpp
@@ -73,7 +73,7 @@ set_grids(const std::shared_ptr<const GridsManager> grids_manager) {
   m_dz.allocate_view();
 
   // Construct and allocate the output field
-  FieldIdentifier fid(name(), vector2d, nondim, grid_name);
+  FieldIdentifier fid(name() + m_topbot, vector2d, nondim, grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 
@@ -147,7 +147,7 @@ void AeroComCld::compute_diagnostic_impl() {
   auto o_cldfrac_tot   = ekat::subview_1(out, m_index_map["cldfrac_tot"]);
 
   Kokkos::parallel_for(
-      "Compute " + name(), policy, KOKKOS_LAMBDA(const MT &team) {
+      "Compute " + m_diagnostic_output.name(), policy, KOKKOS_LAMBDA(const MT &team) {
         const int icol = team.league_rank();
         // Subview the inputs at icol
         auto tmid_icol = ekat::subview(tmid, icol);

--- a/components/eamxx/src/diagnostics/aerocom_cld.hpp
+++ b/components/eamxx/src/diagnostics/aerocom_cld.hpp
@@ -14,8 +14,8 @@ class AeroComCld : public AtmosphereDiagnostic {
   // Constructors
   AeroComCld(const ekat::Comm &comm, const ekat::ParameterList &params);
 
-  // The name of the diagnostic
-  std::string name() const override { return "AeroComCld" + m_topbot; }
+  // The name of the diagnostic CLASS (not the computed field)
+  std::string name() const override { return "AeroComCld"; }
 
   // Set the grid
   void set_grids(

--- a/components/eamxx/src/diagnostics/aerocom_cld.hpp
+++ b/components/eamxx/src/diagnostics/aerocom_cld.hpp
@@ -15,7 +15,7 @@ class AeroComCld : public AtmosphereDiagnostic {
   AeroComCld(const ekat::Comm &comm, const ekat::ParameterList &params);
 
   // The name of the diagnostic
-  std::string name() const override { return "AeroComCld"; }
+  std::string name() const override { return "AeroComCld" + m_topbot; }
 
   // Set the grid
   void set_grids(

--- a/components/eamxx/src/diagnostics/aodvis.cpp
+++ b/components/eamxx/src/diagnostics/aodvis.cpp
@@ -11,10 +11,10 @@ AODVis::AODVis(const ekat::Comm &comm, const ekat::ParameterList &params)
   // Nothing to do here
 }
 
-void AODVis::set_grids(
-    const std::shared_ptr<const GridsManager> grids_manager) {
+void AODVis::
+set_grids(const std::shared_ptr<const GridsManager> grids_manager)
+{
   using namespace ekat::units;
-  using namespace ShortFieldTagsNames;
 
   auto grid             = grids_manager->get_grid("Physics");
   const auto &grid_name = grid->name();
@@ -25,17 +25,15 @@ void AODVis::set_grids(
   m_nlevs = grid->get_num_vertical_levels();
 
   // Define layouts we need (both inputs and outputs)
-  FieldLayout scalar3d_swband_layout =
-      grid->get_3d_vector_layout(true, m_swbands, "swband");
-  FieldLayout scalar1d_layout = grid->get_2d_scalar_layout();
+  auto vector3d = grid->get_3d_vector_layout(true, m_swbands, "swband");
+  auto scalar2d = grid->get_2d_scalar_layout();
 
   // The fields required for this diagnostic to be computed
-  add_field<Required>("aero_tau_sw", scalar3d_swband_layout, nondim, grid_name);
-  add_field<Required>("sunlit", scalar1d_layout, nondim, grid_name);
+  add_field<Required>("aero_tau_sw", vector3d, nondim, grid_name);
+  add_field<Required>("sunlit",      scalar2d, nondim, grid_name);
 
   // Construct and allocate the aodvis field
-  FieldIdentifier fid(name(), scalar1d_layout, nondim,
-                      grid_name);
+  FieldIdentifier fid(name(), scalar2d, nondim, grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 }

--- a/components/eamxx/src/diagnostics/aodvis.cpp
+++ b/components/eamxx/src/diagnostics/aodvis.cpp
@@ -54,7 +54,7 @@ void AODVis::compute_diagnostic_impl() {
   const auto num_levs = m_nlevs;
   const auto policy   = ESU::get_default_team_policy(m_ncols, m_nlevs);
   Kokkos::parallel_for(
-      "Compute " + name(), policy, KOKKOS_LAMBDA(const MT &team) {
+      "Compute " + m_diagnostic_output.name(), policy, KOKKOS_LAMBDA(const MT &team) {
         const int icol = team.league_rank();
         if(sunlit(icol) == 0.0) {
           aod(icol) = var_fill_value;

--- a/components/eamxx/src/diagnostics/aodvis.cpp
+++ b/components/eamxx/src/diagnostics/aodvis.cpp
@@ -34,7 +34,7 @@ void AODVis::set_grids(
   add_field<Required>("sunlit", scalar1d_layout, nondim, grid_name);
 
   // Construct and allocate the aodvis field
-  FieldIdentifier fid("AerosolOpticalDepth550nm", scalar1d_layout, nondim,
+  FieldIdentifier fid(name(), scalar1d_layout, nondim,
                       grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();

--- a/components/eamxx/src/diagnostics/aodvis.hpp
+++ b/components/eamxx/src/diagnostics/aodvis.hpp
@@ -15,7 +15,7 @@ class AODVis : public AtmosphereDiagnostic {
   // Constructors
   AODVis(const ekat::Comm &comm, const ekat::ParameterList &params);
 
-  // The name of the diagnostic
+  // The name of the diagnostic CLASS (not the computed field)
   std::string name() const override { return "AerosolOpticalDepth550nm"; }
 
   // Set the grid

--- a/components/eamxx/src/diagnostics/atm_backtend.cpp
+++ b/components/eamxx/src/diagnostics/atm_backtend.cpp
@@ -46,12 +46,12 @@ void AtmBackTendDiag::initialize_impl(const RunType /*run_type*/) {
   auto diag_units = fid.get_units() / s;
 
   // All good, create the diag output
-  FieldIdentifier d_fid(name(), layout.clone(), diag_units, gn);
+  FieldIdentifier d_fid(m_name + "_atm_backtend", layout.clone(), diag_units, gn);
   m_diagnostic_output = Field(d_fid);
   m_diagnostic_output.allocate_view();
 
   // Let's also create the previous field
-  FieldIdentifier prev_fid(name() + "_prev", layout.clone(), diag_units, gn);
+  FieldIdentifier prev_fid(m_name + "_atm_backtend_prev", layout.clone(), diag_units, gn);
   m_f_prev = Field(prev_fid);
   m_f_prev.allocate_view();
 }

--- a/components/eamxx/src/diagnostics/atm_backtend.cpp
+++ b/components/eamxx/src/diagnostics/atm_backtend.cpp
@@ -6,9 +6,11 @@
 
 namespace scream {
 
-AtmBackTendDiag::AtmBackTendDiag(const ekat::Comm &comm,
-                                 const ekat::ParameterList &params)
-    : AtmosphereDiagnostic(comm, params) {
+AtmBackTendDiag::
+AtmBackTendDiag(const ekat::Comm &comm,
+                const ekat::ParameterList &params)
+ : AtmosphereDiagnostic(comm, params)
+{
   EKAT_REQUIRE_MSG(params.isParameter("Tendency Name"),
                    "Error! AtmBackTendDiag requires 'Tendency Name' in its "
                    "input parameters.\n");
@@ -16,10 +18,9 @@ AtmBackTendDiag::AtmBackTendDiag(const ekat::Comm &comm,
   m_name = m_params.get<std::string>("Tendency Name");
 }
 
-void AtmBackTendDiag::set_grids(
-    const std::shared_ptr<const GridsManager> grids_manager) {
-  using namespace ekat::units;
-
+void AtmBackTendDiag::
+set_grids(const std::shared_ptr<const GridsManager> grids_manager)
+{
   const auto &gname = m_params.get<std::string>("grid_name");
   add_field<Required>(m_name, gname);
 }
@@ -30,7 +31,6 @@ void AtmBackTendDiag::initialize_impl(const RunType /*run_type*/) {
   const auto &gn  = fid.get_grid_name();
 
   // Sanity checks
-  using namespace ShortFieldTagsNames;
   const auto &layout = fid.get_layout();
   EKAT_REQUIRE_MSG(
       f.data_type() == DataType::RealType,

--- a/components/eamxx/src/diagnostics/atm_backtend.cpp
+++ b/components/eamxx/src/diagnostics/atm_backtend.cpp
@@ -16,8 +16,6 @@ AtmBackTendDiag::AtmBackTendDiag(const ekat::Comm &comm,
   m_name = m_params.get<std::string>("Tendency Name");
 }
 
-std::string AtmBackTendDiag::name() const { return m_name + "_atm_tend"; }
-
 void AtmBackTendDiag::set_grids(
     const std::shared_ptr<const GridsManager> grids_manager) {
   using namespace ekat::units;

--- a/components/eamxx/src/diagnostics/atm_backtend.hpp
+++ b/components/eamxx/src/diagnostics/atm_backtend.hpp
@@ -15,8 +15,8 @@ class AtmBackTendDiag : public AtmosphereDiagnostic {
   // Constructors
   AtmBackTendDiag(const ekat::Comm &comm, const ekat::ParameterList &params);
 
-  // The name of the diagnostic
-  std::string name() const { return m_name + "_atm_backtend"; }
+  // The name of the diagnostic CLASS (not the computed field)
+  std::string name() const { return "AtmBackTendDiag"; }
 
   // Set the grid
   void set_grids(const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/atm_backtend.hpp
+++ b/components/eamxx/src/diagnostics/atm_backtend.hpp
@@ -16,7 +16,7 @@ class AtmBackTendDiag : public AtmosphereDiagnostic {
   AtmBackTendDiag(const ekat::Comm &comm, const ekat::ParameterList &params);
 
   // The name of the diagnostic
-  std::string name() const;
+  std::string name() const { return m_name + "_atm_backtend"; }
 
   // Set the grid
   void set_grids(const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/atm_density.cpp
+++ b/components/eamxx/src/diagnostics/atm_density.cpp
@@ -14,7 +14,6 @@ AtmDensityDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params)
 void AtmDensityDiagnostic::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
 {
   using namespace ekat::units;
-  using namespace ShortFieldTagsNames;
 
   // Boiler Plate
   auto grid  = grids_manager->get_grid("Physics");
@@ -23,16 +22,16 @@ void AtmDensityDiagnostic::set_grids(const std::shared_ptr<const GridsManager> g
   m_num_levs = grid->get_num_vertical_levels();  // Number of levels per column
 
   // Set Field Layouts
-  FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_num_cols,m_num_levs} };
+  auto scalar3d = grid->get_3d_scalar_layout(true);
 
   // The fields required for this diagnostic to be computed
-  add_field<Required>("T_mid",          scalar3d_layout_mid, K,     grid_name);
-  add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa,    grid_name);
-  add_field<Required>("p_mid",          scalar3d_layout_mid, Pa,    grid_name);
-  add_field<Required>("qv",             scalar3d_layout_mid, kg/kg, grid_name);
+  add_field<Required>("T_mid",          scalar3d, K,     grid_name);
+  add_field<Required>("pseudo_density", scalar3d, Pa,    grid_name);
+  add_field<Required>("p_mid",          scalar3d, Pa,    grid_name);
+  add_field<Required>("qv",             scalar3d, kg/kg, grid_name);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar3d_layout_mid, kg/(m*m*m), grid_name);
+  FieldIdentifier fid (name(), scalar3d, kg/(m*m*m), grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 }

--- a/components/eamxx/src/diagnostics/atm_density.cpp
+++ b/components/eamxx/src/diagnostics/atm_density.cpp
@@ -26,38 +26,35 @@ void AtmDensityDiagnostic::set_grids(const std::shared_ptr<const GridsManager> g
   FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_num_cols,m_num_levs} };
 
   // The fields required for this diagnostic to be computed
-  add_field<Required>("T_mid",          scalar3d_layout_mid, K,     grid_name, SCREAM_PACK_SIZE);
-  add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa,    grid_name, SCREAM_PACK_SIZE);
-  add_field<Required>("p_mid",          scalar3d_layout_mid, Pa,    grid_name, SCREAM_PACK_SIZE);
-  add_field<Required>("qv",             scalar3d_layout_mid, kg/kg, grid_name, SCREAM_PACK_SIZE);
+  add_field<Required>("T_mid",          scalar3d_layout_mid, K,     grid_name);
+  add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa,    grid_name);
+  add_field<Required>("p_mid",          scalar3d_layout_mid, Pa,    grid_name);
+  add_field<Required>("qv",             scalar3d_layout_mid, kg/kg, grid_name);
 
   // Construct and allocate the diagnostic field
   FieldIdentifier fid (name(), scalar3d_layout_mid, kg/(m*m*m), grid_name);
   m_diagnostic_output = Field(fid);
-  auto& C_ap = m_diagnostic_output.get_header().get_alloc_properties();
-  C_ap.request_allocation(SCREAM_PACK_SIZE);
   m_diagnostic_output.allocate_view();
 }
 
 void AtmDensityDiagnostic::compute_diagnostic_impl()
 {
-  using Pack          = ekat::Pack<Real,SCREAM_PACK_SIZE>;
-  using PF            = scream::PhysicsFunctions<DefaultDevice>;
+  using PF = scream::PhysicsFunctions<DefaultDevice>;
 
-  const auto npacks  = ekat::npack<Pack>(m_num_levs);
-  const auto atm_dens           = m_diagnostic_output.get_view<Pack**>();
-  const auto T_mid              = get_field_in("T_mid").get_view<const Pack**>();
-  const auto p_mid              = get_field_in("p_mid").get_view<const Pack**>();
-  const auto qv_mid             = get_field_in("qv").get_view<const Pack**>();
-  const auto pseudo_density_mid = get_field_in("pseudo_density").get_view<const Pack**>();
+  const auto atm_dens = m_diagnostic_output.get_view<Real**>();
+  const auto T_mid    = get_field_in("T_mid").get_view<const Real**>();
+  const auto p_mid    = get_field_in("p_mid").get_view<const Real**>();
+  const auto qv_mid   = get_field_in("qv").get_view<const Real**>();
+  const auto pseudo_density_mid = get_field_in("pseudo_density").get_view<const Real**>();
 
+  int nlevs = m_num_levs;
   Kokkos::parallel_for("AtmosphereDensityDiagnostic",
-                       Kokkos::RangePolicy<>(0,m_num_cols*npacks),
+                       Kokkos::RangePolicy<>(0,m_num_cols*nlevs),
                        KOKKOS_LAMBDA(const int& idx) {
-      const int icol  = idx / npacks;
-      const int jpack = idx % npacks;
-      auto dz = PF::calculate_dz(pseudo_density_mid(icol,jpack),p_mid(icol,jpack),T_mid(icol,jpack),qv_mid(icol,jpack));
-      atm_dens(icol,jpack) = PF::calculate_density(pseudo_density_mid(icol,jpack),dz);
+      const int icol  = idx / nlevs;
+      const int ilev = idx % nlevs;
+      auto dz = PF::calculate_dz(pseudo_density_mid(icol,ilev),p_mid(icol,ilev),T_mid(icol,ilev),qv_mid(icol,ilev));
+      atm_dens(icol,ilev) = PF::calculate_density(pseudo_density_mid(icol,ilev),dz);
   });
   Kokkos::fence();
 }

--- a/components/eamxx/src/diagnostics/atm_density.hpp
+++ b/components/eamxx/src/diagnostics/atm_density.hpp
@@ -12,7 +12,7 @@ public:
   // Constructors
   AtmDensityDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // The name of the diagnostic
+  // The name of the diagnostic CLASS (not the computed field)
   std::string name () const { return "AtmosphereDensity"; }
 
   // Set the grid

--- a/components/eamxx/src/diagnostics/dry_static_energy.cpp
+++ b/components/eamxx/src/diagnostics/dry_static_energy.cpp
@@ -18,7 +18,6 @@ DryStaticEnergyDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& pa
 void DryStaticEnergyDiagnostic::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
 {
   using namespace ekat::units;
-  using namespace ShortFieldTagsNames;
 
   auto m2  = pow(m,2);
   auto s2  = pow(s,2);
@@ -28,18 +27,18 @@ void DryStaticEnergyDiagnostic::set_grids(const std::shared_ptr<const GridsManag
   m_num_cols = grid->get_num_local_dofs(); // Number of columns on this rank
   m_num_levs = grid->get_num_vertical_levels();  // Number of levels per column
 
-  FieldLayout scalar2d_layout_col{ {COL}, {m_num_cols} };
-  FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_num_cols,m_num_levs} };
+  auto scalar2d = grid->get_2d_scalar_layout();
+  auto scalar3d = grid->get_3d_scalar_layout(true);
 
   // The fields required for this diagnostic to be computed
-  add_field<Required>("T_mid",          scalar3d_layout_mid, K,      grid_name);
-  add_field<Required>("pseudo_density", scalar3d_layout_mid, Pa,     grid_name);
-  add_field<Required>("p_mid",          scalar3d_layout_mid, Pa,     grid_name);
-  add_field<Required>("qv",             scalar3d_layout_mid, kg/kg,  grid_name);
-  add_field<Required>("phis",           scalar2d_layout_col, m2/s2,  grid_name);
+  add_field<Required>("T_mid",          scalar3d, K,      grid_name);
+  add_field<Required>("pseudo_density", scalar3d, Pa,     grid_name);
+  add_field<Required>("p_mid",          scalar3d, Pa,     grid_name);
+  add_field<Required>("qv",             scalar3d, kg/kg,  grid_name);
+  add_field<Required>("phis",           scalar2d, m2/s2,  grid_name);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar3d_layout_mid, m2/s2, grid_name);
+  FieldIdentifier fid (name(), scalar3d, m2/s2, grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 

--- a/components/eamxx/src/diagnostics/dry_static_energy.hpp
+++ b/components/eamxx/src/diagnostics/dry_static_energy.hpp
@@ -17,7 +17,7 @@ public:
   // Constructors
   DryStaticEnergyDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // The name of the diagnostic
+  // The name of the diagnostic CLASS (not the computed field)
   std::string name () const { return "DryStaticEnergy"; }
 
   // Set the grid

--- a/components/eamxx/src/diagnostics/dry_static_energy.hpp
+++ b/components/eamxx/src/diagnostics/dry_static_energy.hpp
@@ -4,7 +4,6 @@
 #include "share/atm_process/atmosphere_diagnostic.hpp"
 
 #include "share/eamxx_types.hpp"
-#include <ekat/ekat_pack.hpp>
 
 namespace scream
 {
@@ -12,9 +11,8 @@ namespace scream
 class DryStaticEnergyDiagnostic : public AtmosphereDiagnostic
 {
 public:
-  using Pack          = ekat::Pack<Real,SCREAM_PACK_SIZE>;
   using KT            = KokkosTypes<DefaultDevice>;
-  using view_2d       = typename KT::template view_2d<Pack>;
+  using view_2d       = typename KT::template view_2d<Real>;
 
   // Constructors
   DryStaticEnergyDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);

--- a/components/eamxx/src/diagnostics/exner.cpp
+++ b/components/eamxx/src/diagnostics/exner.cpp
@@ -16,7 +16,6 @@ ExnerDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params)
 void ExnerDiagnostic::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
 {
   using namespace ekat::units;
-  using namespace ShortFieldTagsNames;
 
   auto nondim = Units::nondimensional();
 
@@ -25,13 +24,13 @@ void ExnerDiagnostic::set_grids(const std::shared_ptr<const GridsManager> grids_
   m_num_cols = grid->get_num_local_dofs(); // Number of columns on this rank
   m_num_levs = grid->get_num_vertical_levels();  // Number of levels per column
 
-  FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_num_cols,m_num_levs} };
+  auto scalar3d = grid->get_3d_scalar_layout(true);
 
   // The fields required for this diagnostic to be computed
-  add_field<Required>("p_mid", scalar3d_layout_mid, Pa, grid_name);
+  add_field<Required>("p_mid", scalar3d, Pa, grid_name);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar3d_layout_mid, nondim, grid_name);
+  FieldIdentifier fid (name(), scalar3d, nondim, grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 }

--- a/components/eamxx/src/diagnostics/exner.hpp
+++ b/components/eamxx/src/diagnostics/exner.hpp
@@ -16,7 +16,7 @@ public:
   // Constructors
   ExnerDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // The name of the diagnostic
+  // The name of the diagnostic CLASS (not the computed field)
   std::string name () const { return "Exner"; }
 
   // Set the grid

--- a/components/eamxx/src/diagnostics/field_at_height.hpp
+++ b/components/eamxx/src/diagnostics/field_at_height.hpp
@@ -17,8 +17,8 @@ public:
   // Constructors
   FieldAtHeight (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // The name of the diagnostic
-  std::string name () const { return m_diag_name; }
+  // The name of the diagnostic CLASS (not the computed field)
+  std::string name () const { return "FieldAtHeight"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/field_at_height.hpp
+++ b/components/eamxx/src/diagnostics/field_at_height.hpp
@@ -18,7 +18,7 @@ public:
   FieldAtHeight (const ekat::Comm& comm, const ekat::ParameterList& params);
 
   // The name of the diagnostic
-  std::string name () const { return "FieldAtHeight"; }
+  std::string name () const { return m_diag_name; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/field_at_level.hpp
+++ b/components/eamxx/src/diagnostics/field_at_level.hpp
@@ -21,7 +21,7 @@ public:
   FieldAtLevel (const ekat::Comm& comm, const ekat::ParameterList& params);
 
   // The name of the diagnostic
-  std::string name () const { return "FieldAtLevel"; }
+  std::string name () const { return m_diag_name; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/field_at_level.hpp
+++ b/components/eamxx/src/diagnostics/field_at_level.hpp
@@ -16,8 +16,8 @@ public:
   // Constructors
   FieldAtLevel (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // The name of the diagnostic
-  std::string name () const { return m_diag_name; }
+  // The name of the diagnostic CLASS (not the computed field)
+  std::string name () const { return "FieldAtLevel"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/field_at_level.hpp
+++ b/components/eamxx/src/diagnostics/field_at_level.hpp
@@ -3,8 +3,6 @@
 
 #include "share/atm_process/atmosphere_diagnostic.hpp"
 
-#include "ekat/ekat_pack.hpp"
-
 namespace scream
 {
 
@@ -15,8 +13,6 @@ namespace scream
 class FieldAtLevel : public AtmosphereDiagnostic
 {
 public:
-  using Pack = ekat::Pack<Real,SCREAM_PACK_SIZE>;
-
   // Constructors
   FieldAtLevel (const ekat::Comm& comm, const ekat::ParameterList& params);
 

--- a/components/eamxx/src/diagnostics/field_at_pressure_level.cpp
+++ b/components/eamxx/src/diagnostics/field_at_pressure_level.cpp
@@ -88,7 +88,7 @@ initialize_impl (const RunType /*run_type*/)
   m_mask_val = m_params.get<double>("mask_value",Real(constants::DefaultFillValue<float>::value));
 
 
-  std::string mask_name = name() + " mask";
+  std::string mask_name = m_diag_name + " mask";
   FieldLayout mask_layout( {COL}, {num_cols});
   FieldIdentifier mask_fid (mask_name,mask_layout, nondim, gname);
   Field diag_mask(mask_fid);

--- a/components/eamxx/src/diagnostics/field_at_pressure_level.hpp
+++ b/components/eamxx/src/diagnostics/field_at_pressure_level.hpp
@@ -19,8 +19,8 @@ public:
   // Constructors
   FieldAtPressureLevel (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // The name of the diagnostic
-  std::string name () const { return m_diag_name; }
+  // The name of the diagnostic CLASS (not the computed field)
+  std::string name () const { return "FieldAtPressureLevel"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/field_at_pressure_level.hpp
+++ b/components/eamxx/src/diagnostics/field_at_pressure_level.hpp
@@ -20,7 +20,7 @@ public:
   FieldAtPressureLevel (const ekat::Comm& comm, const ekat::ParameterList& params);
 
   // The name of the diagnostic
-  std::string name () const { return "FieldAtPressureLevel"; }
+  std::string name () const { return m_diag_name; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/horiz_avg.hpp
+++ b/components/eamxx/src/diagnostics/horiz_avg.hpp
@@ -16,8 +16,8 @@ class HorizAvgDiag : public AtmosphereDiagnostic {
   // Constructors
   HorizAvgDiag(const ekat::Comm &comm, const ekat::ParameterList &params);
 
-  // The name of the diagnostic
-  std::string name() const { return m_diag_name; }
+  // The name of the diagnostic CLASS (not the computed field)
+  std::string name() const { return "HorizAvg"; }
 
   // Set the grid
   void set_grids(const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/longwave_cloud_forcing.hpp
+++ b/components/eamxx/src/diagnostics/longwave_cloud_forcing.hpp
@@ -16,7 +16,7 @@ public:
   // Constructors
   LongwaveCloudForcingDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // The name of the diagnostic
+  // The name of the diagnostic CLASS (not the computed field)
   std::string name () const { return "LongwaveCloudForcing"; }
 
   // Set the grid

--- a/components/eamxx/src/diagnostics/number_path.cpp
+++ b/components/eamxx/src/diagnostics/number_path.cpp
@@ -53,7 +53,7 @@ void NumberPathDiagnostic::set_grids(
   add_field<Required>(m_nname, scalar3d, 1 / kg, grid_name);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid(m_kind + "NumberPath", scalar2d, kg/(kg*m2), grid_name);
+  FieldIdentifier fid(name(), scalar2d, kg/(kg*m2), grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 }

--- a/components/eamxx/src/diagnostics/number_path.cpp
+++ b/components/eamxx/src/diagnostics/number_path.cpp
@@ -53,7 +53,7 @@ void NumberPathDiagnostic::set_grids(
   add_field<Required>(m_nname, scalar3d, 1 / kg, grid_name);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid(name(), scalar2d, kg/(kg*m2), grid_name);
+  FieldIdentifier fid(m_kind + name(), scalar2d, kg/(kg*m2), grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 }
@@ -74,7 +74,7 @@ void NumberPathDiagnostic::compute_diagnostic_impl() {
   const auto num_levs = m_num_levs;
   const auto policy   = ESU::get_default_team_policy(m_num_cols, m_num_levs);
   Kokkos::parallel_for(
-      "Compute " + name(), policy, KOKKOS_LAMBDA(const MT &team) {
+      "Compute " + m_kind + name(), policy, KOKKOS_LAMBDA(const MT &team) {
         const int icol = team.league_rank();
         auto q_icol    = ekat::subview(q, icol);
         auto n_icol    = ekat::subview(n, icol);

--- a/components/eamxx/src/diagnostics/number_path.hpp
+++ b/components/eamxx/src/diagnostics/number_path.hpp
@@ -15,8 +15,8 @@ class NumberPathDiagnostic : public AtmosphereDiagnostic {
   NumberPathDiagnostic(const ekat::Comm &comm,
                        const ekat::ParameterList &params);
 
-  // The name of the diagnostic
-  std::string name() const override { return m_kind + "NumberPath"; }
+  // The name of the diagnostic CLASS (not the computed field)
+  std::string name() const override { return "NumberPath"; }
 
   // Set the grid
   void set_grids(const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/number_path.hpp
+++ b/components/eamxx/src/diagnostics/number_path.hpp
@@ -16,7 +16,7 @@ class NumberPathDiagnostic : public AtmosphereDiagnostic {
                        const ekat::ParameterList &params);
 
   // The name of the diagnostic
-  std::string name() const override { return "NumberPath"; }
+  std::string name() const override { return m_kind + "NumberPath"; }
 
   // Set the grid
   void set_grids(const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/potential_temperature.cpp
+++ b/components/eamxx/src/diagnostics/potential_temperature.cpp
@@ -1,4 +1,5 @@
 #include "diagnostics/potential_temperature.hpp"
+#include "share/util/eamxx_common_physics_functions.hpp"
 
 namespace scream
 {
@@ -36,45 +37,46 @@ void PotentialTemperatureDiagnostic::set_grids(const std::shared_ptr<const Grids
   m_num_levs = grid->get_num_vertical_levels();  // Number of levels per column
 
   FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_num_cols,m_num_levs} };
-  constexpr int ps = Pack::n;
 
   // The fields required for this diagnostic to be computed
-  add_field<Required>("T_mid",          scalar3d_layout_mid, K,  grid_name, ps);
-  add_field<Required>("p_mid",          scalar3d_layout_mid, Pa, grid_name, ps);
-  // Only needed for LiqPotentialTemperature, but put it here for ease
-  // TODO: only request it if it is needed
-  add_field<Required>("qc",             scalar3d_layout_mid, kg/kg,  grid_name, ps);
+  add_field<Required>("T_mid", scalar3d_layout_mid, K,  grid_name);
+  add_field<Required>("p_mid", scalar3d_layout_mid, Pa, grid_name);
+  if (m_ptype=="LiqPotentialTemperature") {
+    add_field<Required>("qc",    scalar3d_layout_mid, kg/kg,  grid_name);
+  }
 
   // Construct and allocate the diagnostic field
   FieldIdentifier fid (m_ptype, scalar3d_layout_mid, K, grid_name);
   m_diagnostic_output = Field(fid);
-  auto& C_ap = m_diagnostic_output.get_header().get_alloc_properties();
-  C_ap.request_allocation(ps);
   m_diagnostic_output.allocate_view();
 }
 // =========================================================================================
 void PotentialTemperatureDiagnostic::compute_diagnostic_impl()
 {
+  using PF = scream::PhysicsFunctions<DefaultDevice>;
+
   bool is_liq = (m_ptype=="LiqPotentialTemperature");
 
-  const auto npacks  = ekat::npack<Pack>(m_num_levs);
-  auto theta = m_diagnostic_output.get_view<Pack**>();
-  auto T_mid = get_field_in("T_mid").get_view<const Pack**>();
-  auto p_mid = get_field_in("p_mid").get_view<const Pack**>();
-  auto q_mid = get_field_in("qc").get_view<const Pack**>();
+  auto theta = m_diagnostic_output.get_view<Real**>();
+  auto T_mid = get_field_in("T_mid").get_view<const Real**>();
+  auto p_mid = get_field_in("p_mid").get_view<const Real**>();
+  decltype(p_mid) q_mid;
+  if (is_liq)
+   q_mid = get_field_in("qc").get_view<const Real**>();
 
+  int nlevs = m_num_levs;
   Kokkos::parallel_for("PotentialTemperatureDiagnostic",
-                       Kokkos::RangePolicy<>(0,m_num_cols*npacks),
+                       Kokkos::RangePolicy<>(0,m_num_cols*m_num_levs),
                        KOKKOS_LAMBDA (const int& idx) {
-      const int icol  = idx / npacks;
-      const int jpack = idx % npacks;
-      auto temp = PF::calculate_theta_from_T(T_mid(icol,jpack),p_mid(icol,jpack));
+      const int icol = idx / nlevs;
+      const int ilev = idx % nlevs;
+      auto temp = PF::calculate_theta_from_T(T_mid(icol,ilev),p_mid(icol,ilev));
       if (is_liq) {
         // Liquid potential temperature (consistent with how it is calculated in SHOC)
-        theta(icol,jpack) = PF::calculate_thetal_from_theta(temp,T_mid(icol,jpack),q_mid(icol,jpack));
+        theta(icol,ilev) = PF::calculate_thetal_from_theta(temp,T_mid(icol,ilev),q_mid(icol,ilev));
       } else {
         // The total potential temperature
-        theta(icol,jpack) = temp;
+        theta(icol,ilev) = temp;
       }
   });
   Kokkos::fence();

--- a/components/eamxx/src/diagnostics/potential_temperature.hpp
+++ b/components/eamxx/src/diagnostics/potential_temperature.hpp
@@ -16,7 +16,7 @@ public:
   // Constructors
   PotentialTemperatureDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // The name of the diagnostic
+  // The name of the diagnostic CLASS (not the computed field)
   std::string name () const override { return "PotentialTemperature"; }
 
   // Set the grid

--- a/components/eamxx/src/diagnostics/potential_temperature.hpp
+++ b/components/eamxx/src/diagnostics/potential_temperature.hpp
@@ -2,7 +2,6 @@
 #define EAMXX_POTENTIAL_TEMP_DIAGNOSTIC_HPP
 
 #include "share/atm_process/atmosphere_diagnostic.hpp"
-#include "share/util/eamxx_common_physics_functions.hpp"
 
 namespace scream
 {
@@ -14,10 +13,6 @@ namespace scream
 class PotentialTemperatureDiagnostic : public AtmosphereDiagnostic
 {
 public:
-  using Pack          = ekat::Pack<Real,SCREAM_PACK_SIZE>;
-  using PF            = scream::PhysicsFunctions<DefaultDevice>;
-  using C             = physics::Constants<Real>;
-
   // Constructors
   PotentialTemperatureDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 

--- a/components/eamxx/src/diagnostics/precip_surf_mass_flux.cpp
+++ b/components/eamxx/src/diagnostics/precip_surf_mass_flux.cpp
@@ -98,7 +98,7 @@ void PrecipSurfMassFlux::compute_diagnostic_impl()
 
   auto rhodt = PC::RHO_H2O*dt;
   const auto& flux_view  = m_diagnostic_output.get_view<Real*>();
-  Kokkos::parallel_for("PrecipSurfMassFlux",
+  Kokkos::parallel_for(m_name,
                        KT::RangePolicy(0,m_num_cols),
                        KOKKOS_LAMBDA(const Int& icol) {
     if (use_ice) {

--- a/components/eamxx/src/diagnostics/precip_surf_mass_flux.hpp
+++ b/components/eamxx/src/diagnostics/precip_surf_mass_flux.hpp
@@ -16,8 +16,8 @@ public:
   // Constructors
   PrecipSurfMassFlux (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // The name of the diagnostic
-  std::string name () const { return m_name; }
+  // The name of the diagnostic CLASS (not the computed field)
+  std::string name () const { return "PrecipSurfMassFlux"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/precip_surf_mass_flux.hpp
+++ b/components/eamxx/src/diagnostics/precip_surf_mass_flux.hpp
@@ -17,7 +17,7 @@ public:
   PrecipSurfMassFlux (const ekat::Comm& comm, const ekat::ParameterList& params);
 
   // The name of the diagnostic
-  std::string name () const { return "PrecipSurfMassFlux"; }
+  std::string name () const { return m_name; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/relative_humidity.cpp
+++ b/components/eamxx/src/diagnostics/relative_humidity.cpp
@@ -24,17 +24,17 @@ void RelativeHumidityDiagnostic::set_grids(const std::shared_ptr<const GridsMana
   m_num_cols = grid->get_num_local_dofs(); // Number of columns on this rank
   m_num_levs = grid->get_num_vertical_levels();  // Number of levels per column
 
-  FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_num_cols,m_num_levs} };
+  auto scalar3d = grid->get_3d_scalar_layout(true);
 
   // The fields required for this diagnostic to be computed
-  add_field<Required>("T_mid",              scalar3d_layout_mid, K,     grid_name, SCREAM_PACK_SIZE);
-  add_field<Required>("p_dry_mid",          scalar3d_layout_mid, Pa,    grid_name, SCREAM_PACK_SIZE);
-  add_field<Required>("qv",                 scalar3d_layout_mid, kg/kg, grid_name, SCREAM_PACK_SIZE);
-  add_field<Required>("pseudo_density",     scalar3d_layout_mid, Pa,    grid_name, SCREAM_PACK_SIZE);
-  add_field<Required>("pseudo_density_dry", scalar3d_layout_mid, Pa,    grid_name, SCREAM_PACK_SIZE);
+  add_field<Required>("T_mid",              scalar3d, K,     grid_name, SCREAM_PACK_SIZE);
+  add_field<Required>("p_dry_mid",          scalar3d, Pa,    grid_name, SCREAM_PACK_SIZE);
+  add_field<Required>("qv",                 scalar3d, kg/kg, grid_name, SCREAM_PACK_SIZE);
+  add_field<Required>("pseudo_density",     scalar3d, Pa,    grid_name, SCREAM_PACK_SIZE);
+  add_field<Required>("pseudo_density_dry", scalar3d, Pa,    grid_name, SCREAM_PACK_SIZE);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar3d_layout_mid, nondim, grid_name);
+  FieldIdentifier fid (name(), scalar3d, nondim, grid_name);
   m_diagnostic_output = Field(fid);
   auto& C_ap = m_diagnostic_output.get_header().get_alloc_properties();
   C_ap.request_allocation(SCREAM_PACK_SIZE);

--- a/components/eamxx/src/diagnostics/relative_humidity.hpp
+++ b/components/eamxx/src/diagnostics/relative_humidity.hpp
@@ -12,7 +12,7 @@ public:
   // Constructors
   RelativeHumidityDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // The name of the diagnostic
+  // The name of the diagnostic CLASS (not the computed field)
   std::string name () const { return "RelativeHumidity"; }
 
   // Set the grid

--- a/components/eamxx/src/diagnostics/sea_level_pressure.hpp
+++ b/components/eamxx/src/diagnostics/sea_level_pressure.hpp
@@ -17,7 +17,7 @@ public:
   // Constructors
   SeaLevelPressureDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // The name of the diagnostic
+  // The name of the diagnostic CLASS (not the computed field)
   std::string name () const { return "SeaLevelPressure"; }
 
   // Set the grid

--- a/components/eamxx/src/diagnostics/shortwave_cloud_forcing.cpp
+++ b/components/eamxx/src/diagnostics/shortwave_cloud_forcing.cpp
@@ -15,7 +15,6 @@ ShortwaveCloudForcingDiagnostic (const ekat::Comm& comm, const ekat::ParameterLi
 void ShortwaveCloudForcingDiagnostic::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
 {
   using namespace ekat::units;
-  using namespace ShortFieldTagsNames;
 
   Units m2 (m*m,"m2");
 
@@ -24,20 +23,18 @@ void ShortwaveCloudForcingDiagnostic::set_grids(const std::shared_ptr<const Grid
   m_num_cols = grid->get_num_local_dofs(); // Number of columns on this rank
   m_num_levs = grid->get_num_vertical_levels();  // Number of levels per column
 
-  FieldLayout scalar2d_layout_col{ {COL}, {m_num_cols} };
-  FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_num_cols,m_num_levs} };
+  auto scalar2d = grid->get_2d_scalar_layout();
+  auto scalar3d = grid->get_3d_scalar_layout(true);
 
   // The fields required for this diagnostic to be computed
-  add_field<Required>("SW_flux_dn",        scalar3d_layout_mid, W/m2, grid_name);
-  add_field<Required>("SW_flux_up",        scalar3d_layout_mid, W/m2, grid_name);
-  add_field<Required>("SW_clrsky_flux_dn", scalar3d_layout_mid, W/m2, grid_name);
-  add_field<Required>("SW_clrsky_flux_up", scalar3d_layout_mid, W/m2, grid_name);
+  add_field<Required>("SW_flux_dn",        scalar3d, W/m2, grid_name);
+  add_field<Required>("SW_flux_up",        scalar3d, W/m2, grid_name);
+  add_field<Required>("SW_clrsky_flux_dn", scalar3d, W/m2, grid_name);
+  add_field<Required>("SW_clrsky_flux_up", scalar3d, W/m2, grid_name);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar2d_layout_col, W/m2, grid_name);
+  FieldIdentifier fid (name(), scalar2d, W/m2, grid_name);
   m_diagnostic_output = Field(fid);
-  auto& C_ap = m_diagnostic_output.get_header().get_alloc_properties();
-  C_ap.request_allocation();
   m_diagnostic_output.allocate_view();
 }
 

--- a/components/eamxx/src/diagnostics/shortwave_cloud_forcing.hpp
+++ b/components/eamxx/src/diagnostics/shortwave_cloud_forcing.hpp
@@ -16,7 +16,7 @@ public:
   // Constructors
   ShortwaveCloudForcingDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // The name of the diagnostic
+  // The name of the diagnostic CLASS (not the computed field)
   std::string name () const { return "ShortwaveCloudForcing"; }
 
   // Set the grid

--- a/components/eamxx/src/diagnostics/surf_upward_latent_heat_flux.cpp
+++ b/components/eamxx/src/diagnostics/surf_upward_latent_heat_flux.cpp
@@ -36,7 +36,7 @@ set_grids (const std::shared_ptr<const GridsManager> grids_manager)
   add_field<Required>("surf_evap", scalar2d_layout_mid, surf_evap_units,  grid_name);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid(name(), scalar2d_layout_mid, W/m2, grid_name);
+  FieldIdentifier fid(m_name, scalar2d_layout_mid, W/m2, grid_name);
   // handle parent class member variables
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.get_header().get_alloc_properties().request_allocation();

--- a/components/eamxx/src/diagnostics/surf_upward_latent_heat_flux.hpp
+++ b/components/eamxx/src/diagnostics/surf_upward_latent_heat_flux.hpp
@@ -16,10 +16,8 @@ public:
   // Constructors
   SurfaceUpwardLatentHeatFlux (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // The name of the diagnostic
-  // Future extensions to latent heat flux may include processes
-  // other than evaporation, so we don't inline the name function here.
-  std::string name () const { return m_name; }
+  // The name of the diagnostic CLASS (not the computed field)
+  std::string name () const { return "SurfaceUpwardLatentHeatFlux"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/tests/atm_density_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/atm_density_test.cpp
@@ -44,16 +44,12 @@ void run(std::mt19937_64& engine)
 {
   using PF         = scream::PhysicsFunctions<DeviceT>;
   using PC         = scream::physics::Constants<Real>;
-  using Pack       = ekat::Pack<Real,SCREAM_PACK_SIZE>;
   using KT         = ekat::KokkosTypes<DeviceT>;
   using ExecSpace  = typename KT::ExeSpace;
   using MemberType = typename KT::MemberType;
-  using view_1d    = typename KT::template view_1d<Pack>;
-  using rview_1d   = typename KT::template view_1d<Real>;
 
   const     int packsize = SCREAM_PACK_SIZE;
   constexpr int num_levs = packsize*2 + 1; // Number of levels to use for tests, make sure the last pack can also have some empty slots (packsize>1).
-  const     int num_mid_packs = ekat::npack<Pack>(num_levs);
 
   // A world comm
   ekat::Comm comm(MPI_COMM_WORLD);
@@ -63,17 +59,7 @@ void run(std::mt19937_64& engine)
   auto gm = create_gm(comm,ncols,num_levs);
 
   // Kokkos Policy
-  auto policy = ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(ncols, num_mid_packs);
-
-  // Input (randomized) views
-  view_1d temperature("temperature",num_mid_packs),
-          pseudodensity("pseudodensity",num_mid_packs),
-          pressure("pressure",num_mid_packs),
-          watervapor("watervapor",num_mid_packs);
-
-  auto dview_as_real = [&] (const view_1d& v) -> rview_1d {
-    return rview_1d(reinterpret_cast<Real*>(v.data()),v.size()*packsize);
-  };
+  auto policy = ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(ncols, num_levs);
 
   // Construct random input data
   using RPDF = std::uniform_real_distribution<Real>;
@@ -115,40 +101,35 @@ void run(std::mt19937_64& engine)
     // Construct random data to use for test
     // Get views of input data and set to random values
     const auto& T_mid_f       = input_fields["T_mid"];
-    const auto& T_mid_v       = T_mid_f.get_view<Pack**>();
+    const auto& T_mid_v       = T_mid_f.get_view<Real**>();
     const auto& pseudo_dens_f = input_fields["pseudo_density"];
-    const auto& pseudo_dens_v = pseudo_dens_f.get_view<Pack**>();
+    const auto& pseudo_dens_v = pseudo_dens_f.get_view<Real**>();
     const auto& p_mid_f       = input_fields["p_mid"];
-    const auto& p_mid_v       = p_mid_f.get_view<Pack**>();
+    const auto& p_mid_v       = p_mid_f.get_view<Real**>();
     const auto& qv_mid_f      = input_fields["qv"];
-    const auto& qv_mid_v      = qv_mid_f.get_view<Pack**>();
+    const auto& qv_mid_v      = qv_mid_f.get_view<Real**>();
     for (int icol = 0; icol<ncols;++icol) {
       const auto& T_sub      = ekat::subview(T_mid_v,icol);
       const auto& pseudo_sub = ekat::subview(pseudo_dens_v,icol);
       const auto& p_sub      = ekat::subview(p_mid_v,icol);
       const auto& qv_sub     = ekat::subview(qv_mid_v,icol);
-      ekat::genRandArray(dview_as_real(temperature),   engine, pdf_temp);
-      ekat::genRandArray(dview_as_real(pseudodensity), engine, pdf_pseudodens);
-      ekat::genRandArray(dview_as_real(pressure),      engine, pdf_pres);
-      ekat::genRandArray(dview_as_real(watervapor),    engine, pdf_qv);
-      Kokkos::deep_copy(T_sub,temperature);
-      Kokkos::deep_copy(pseudo_sub,pseudodensity);
-      Kokkos::deep_copy(p_sub,pressure);
-      Kokkos::deep_copy(qv_sub,watervapor);
+      ekat::genRandArray(T_sub,      engine, pdf_temp);
+      ekat::genRandArray(pseudo_sub, engine, pdf_pseudodens);
+      ekat::genRandArray(p_sub,      engine, pdf_pres);
+      ekat::genRandArray(qv_sub,     engine, pdf_qv);
     } 
 
     // Run diagnostic and compare with manual calculation
     diag->compute_diagnostic();
     const auto& diag_out = diag->get_diagnostic();
     Field atm_density_f = diag_out.clone();
-    atm_density_f.deep_copy<double,Host>(0.0);
-    atm_density_f.sync_to_dev();
-    const auto& atm_density_v = atm_density_f.get_view<Pack**>();
+    atm_density_f.deep_copy(0);
+    const auto& atm_density_v = atm_density_f.get_view<Real**>();
     Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int icol = team.league_rank();
-      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_mid_packs), [&] (const Int& jpack) {
-        auto dz = PF::calculate_dz(pseudo_dens_v(icol,jpack),p_mid_v(icol,jpack),T_mid_v(icol,jpack),qv_mid_v(icol,jpack));
-        atm_density_v(icol,jpack) = PF::calculate_density(pseudo_dens_v(icol,jpack),dz);
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_levs), [&] (const Int& ilev) {
+        auto dz = PF::calculate_dz(pseudo_dens_v(icol,ilev),p_mid_v(icol,ilev),T_mid_v(icol,ilev),qv_mid_v(icol,ilev));
+        atm_density_v(icol,ilev) = PF::calculate_density(pseudo_dens_v(icol,ilev),dz);
       });
       team.team_barrier();
     });

--- a/components/eamxx/src/diagnostics/tests/dry_static_energy_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/dry_static_energy_test.cpp
@@ -44,17 +44,13 @@ void run(std::mt19937_64& engine)
 {
   using PF         = scream::PhysicsFunctions<DeviceT>;
   using PC         = scream::physics::Constants<Real>;
-  using Pack       = ekat::Pack<Real,SCREAM_PACK_SIZE>;
   using KT         = ekat::KokkosTypes<DeviceT>;
   using ExecSpace  = typename KT::ExeSpace;
   using MemberType = typename KT::MemberType;
-  using view_1d    = typename KT::template view_1d<Pack>;
-  using rview_1d   = typename KT::template view_1d<Real>;
+  using view_1d    = typename KT::template view_1d<Real>;
 
   const     int packsize = SCREAM_PACK_SIZE;
   constexpr int num_levs = packsize*2 + 1; // Number of levels to use for tests, make sure the last pack can also have some empty slots (packsize>1).
-  const     int num_mid_packs    = ekat::npack<Pack>(num_levs);
-  const     int num_mid_packs_p1 = ekat::npack<Pack>(num_levs+1);
 
   // A world comm
   ekat::Comm comm(MPI_COMM_WORLD);
@@ -64,17 +60,7 @@ void run(std::mt19937_64& engine)
   auto gm = create_gm(comm,ncols,num_levs);
 
   // Kokkos Policy
-  auto policy = ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(ncols, num_mid_packs);
-
-  // Input (randomized) views
-  view_1d temperature("temperature",num_mid_packs),
-          pseudodensity("pseudodensity",num_mid_packs),
-          pressure("pressure",num_mid_packs),
-          watervapor("watervapor",num_mid_packs);
-
-  auto dview_as_real = [&] (const view_1d& v) -> rview_1d {
-    return rview_1d(reinterpret_cast<Real*>(v.data()),v.size()*packsize);
-  };
+  auto policy = ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(ncols, num_levs);
 
   // Construct random input data
   using RPDF = std::uniform_real_distribution<Real>;
@@ -117,13 +103,13 @@ void run(std::mt19937_64& engine)
     // Construct random data to use for test
     // Get views of input data and set to random values
     const auto& T_mid_f       = input_fields["T_mid"];
-    const auto& T_mid_v       = T_mid_f.get_view<Pack**>();
+    const auto& T_mid_v       = T_mid_f.get_view<Real**>();
     const auto& pseudo_dens_f = input_fields["pseudo_density"];
-    const auto& pseudo_dens_v = pseudo_dens_f.get_view<Pack**>();
+    const auto& pseudo_dens_v = pseudo_dens_f.get_view<Real**>();
     const auto& p_mid_f       = input_fields["p_mid"];
-    const auto& p_mid_v       = p_mid_f.get_view<Pack**>();
+    const auto& p_mid_v       = p_mid_f.get_view<Real**>();
     const auto& qv_mid_f      = input_fields["qv"];
-    const auto& qv_mid_v      = qv_mid_f.get_view<Pack**>();
+    const auto& qv_mid_v      = qv_mid_f.get_view<Real**>();
     const auto& phis_f        = input_fields["phis"];
     const auto& phis_v        = phis_f.get_view<Real*>();
     for (int icol=0;icol<ncols;icol++) {
@@ -131,14 +117,10 @@ void run(std::mt19937_64& engine)
       const auto& pseudo_sub = ekat::subview(pseudo_dens_v,icol);
       const auto& p_sub      = ekat::subview(p_mid_v,icol);
       const auto& qv_sub     = ekat::subview(qv_mid_v,icol);
-      ekat::genRandArray(dview_as_real(temperature),   engine, pdf_temp);
-      ekat::genRandArray(dview_as_real(pseudodensity), engine, pdf_pseudodens);
-      ekat::genRandArray(dview_as_real(pressure),      engine, pdf_pres);
-      ekat::genRandArray(dview_as_real(watervapor),    engine, pdf_qv);
-      Kokkos::deep_copy(T_sub,temperature);
-      Kokkos::deep_copy(pseudo_sub,pseudodensity);
-      Kokkos::deep_copy(p_sub,pressure);
-      Kokkos::deep_copy(qv_sub,watervapor);
+      ekat::genRandArray(T_sub,      engine, pdf_temp);
+      ekat::genRandArray(pseudo_sub, engine, pdf_pseudodens);
+      ekat::genRandArray(p_sub,      engine, pdf_pres);
+      ekat::genRandArray(qv_sub,     engine, pdf_qv);
     }
     ekat::genRandArray(phis_v, engine, pdf_surface);
 
@@ -146,17 +128,16 @@ void run(std::mt19937_64& engine)
     diag->compute_diagnostic();
     const auto& diag_out = diag->get_diagnostic();
     Field dse_f = diag_out.clone();
-    dse_f.deep_copy<double,Host>(0.0);
-    dse_f.sync_to_dev();
-    const auto& dse_v = dse_f.get_view<Pack**>();
+    dse_f.deep_copy(0);
+    const auto& dse_v = dse_f.get_view<Real**>();
     // We need some temporary views
-    const auto& z_int_v = view_1d("",num_mid_packs_p1);
-    const auto& dz_v    = view_1d("",num_mid_packs);
-    const auto& z_mid_v = view_1d("",num_mid_packs);
+    const auto& z_int_v = view_1d("",num_levs+1);
+    const auto& dz_v    = view_1d("",num_levs);
+    const auto& z_mid_v = view_1d("",num_levs);
     Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int icol = team.league_rank();
-      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_mid_packs), [&] (const Int& jpack) {
-        dz_v(jpack) = PF::calculate_dz(pseudo_dens_v(icol,jpack),p_mid_v(icol,jpack),T_mid_v(icol,jpack),qv_mid_v(icol,jpack));
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_levs), [&] (const Int& ilev) {
+        dz_v(ilev) = PF::calculate_dz(pseudo_dens_v(icol,ilev),p_mid_v(icol,ilev),T_mid_v(icol,ilev),qv_mid_v(icol,ilev));
       });
       team.team_barrier();
       const auto& dse_sub = ekat::subview(dse_v,icol);
@@ -164,8 +145,8 @@ void run(std::mt19937_64& engine)
       team.team_barrier();
       PF::calculate_z_mid(team,num_levs,z_int_v,z_mid_v);
       team.team_barrier();
-      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_mid_packs), [&] (const Int& jpack) {
-        dse_sub(jpack) = PF::calculate_dse(T_mid_v(icol,jpack),z_mid_v(jpack),phis_v(icol));
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_levs), [&] (const Int& ilev) {
+        dse_sub(ilev) = PF::calculate_dse(T_mid_v(icol,ilev),z_mid_v(ilev),phis_v(icol));
       });
       team.team_barrier();
     });

--- a/components/eamxx/src/diagnostics/tests/exner_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/exner_test.cpp
@@ -44,16 +44,12 @@ void run(std::mt19937_64& engine)
 {
   using PF         = scream::PhysicsFunctions<DeviceT>;
   using PC         = scream::physics::Constants<Real>;
-  using Pack       = ekat::Pack<Real,SCREAM_PACK_SIZE>;
   using KT         = ekat::KokkosTypes<DeviceT>;
   using ExecSpace  = typename KT::ExeSpace;
   using MemberType = typename KT::MemberType;
-  using view_1d    = typename KT::template view_1d<Pack>;
-  using rview_1d   = typename KT::template view_1d<Real>;
 
   const     int packsize = SCREAM_PACK_SIZE;
   constexpr int num_levs = packsize*2 + 1; // Number of levels to use for tests, make sure the last pack can also have some empty slots (packsize>1).
-  const     int num_mid_packs = ekat::npack<Pack>(num_levs);
 
   // A world comm
   ekat::Comm comm(MPI_COMM_WORLD);
@@ -63,15 +59,7 @@ void run(std::mt19937_64& engine)
   auto gm = create_gm(comm,ncols,num_levs);
 
   // Kokkos Policy
-  auto policy = ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(ncols, num_mid_packs);
-
-  // Input (randomized) views
-  view_1d temperature("temperature",num_mid_packs),
-          pressure("pressure",num_mid_packs);
-
-  auto dview_as_real = [&] (const view_1d& v) -> rview_1d {
-    return rview_1d(reinterpret_cast<Real*>(v.data()),v.size()*packsize);
-  };
+  auto policy = ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(ncols, num_levs);
 
   // Construct random input data
   using RPDF = std::uniform_real_distribution<Real>;
@@ -110,24 +98,22 @@ void run(std::mt19937_64& engine)
     // Construct random data to use for test
     // Get views of input data and set to random values
     const auto& p_mid_f = input_fields["p_mid"];
-    const auto& p_mid_v = p_mid_f.get_view<Pack**>();
+    const auto& p_mid_v = p_mid_f.get_view<Real**>();
     for (int icol=0;icol<ncols;icol++) {
       const auto& p_sub = ekat::subview(p_mid_v,icol);
-      ekat::genRandArray(dview_as_real(pressure),    engine, pdf_pres);
-      Kokkos::deep_copy(p_sub,pressure);
+      ekat::genRandArray(p_sub, engine, pdf_pres);
     }
 
     // Run diagnostic and compare with manual calculation
     diag->compute_diagnostic();
     const auto& diag_out = diag->get_diagnostic();
     Field exner_f = diag_out.clone();
-    exner_f.deep_copy<double,Host>(0.0);
-    exner_f.sync_to_dev();
-    const auto& exner_v = exner_f.get_view<Pack**>();
+    exner_f.deep_copy(0);
+    const auto& exner_v = exner_f.get_view<Real**>();
     Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int icol = team.league_rank();
-      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_mid_packs), [&] (const Int& jpack) {
-        exner_v(icol,jpack) = PF::exner_function(p_mid_v(icol,jpack));
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_levs), [&] (const Int& ilev) {
+        exner_v(icol,ilev) = PF::exner_function(p_mid_v(icol,ilev));
       });
       team.team_barrier();
     });

--- a/components/eamxx/src/diagnostics/tests/potential_temperature_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/potential_temperature_test.cpp
@@ -44,16 +44,12 @@ void run(std::mt19937_64& engine, int int_ptype)
 {
   using PF         = scream::PhysicsFunctions<DeviceT>;
   using PC         = scream::physics::Constants<Real>;
-  using Pack       = ekat::Pack<Real,SCREAM_PACK_SIZE>;
   using KT         = ekat::KokkosTypes<DeviceT>;
   using ExecSpace  = typename KT::ExeSpace;
   using MemberType = typename KT::MemberType;
-  using view_1d    = typename KT::template view_1d<Pack>;
-  using rview_1d   = typename KT::template view_1d<Real>;
 
   const     int packsize = SCREAM_PACK_SIZE;
   constexpr int num_levs = packsize*2 + 1; // Number of levels to use for tests, make sure the last pack can also have some empty slots (packsize>1).
-  const     int num_mid_packs = ekat::npack<Pack>(num_levs);
 
   // A world comm
   ekat::Comm comm(MPI_COMM_WORLD);
@@ -63,16 +59,7 @@ void run(std::mt19937_64& engine, int int_ptype)
   auto gm = create_gm(comm,ncols,num_levs);
 
   // Kokkos Policy
-  auto policy = ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(ncols, num_mid_packs);
-
-  // Input (randomized) views
-  view_1d temperature("temperature",num_mid_packs),
-          pressure("pressure",num_mid_packs),
-          condensate("condensate",num_mid_packs);
-
-  auto dview_as_real = [&] (const view_1d& v) -> rview_1d {
-    return rview_1d(reinterpret_cast<Real*>(v.data()),v.size()*packsize);
-  };
+  auto policy = ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(ncols, num_levs);
 
   // Construct random input data
   using RPDF = std::uniform_real_distribution<Real>;
@@ -113,37 +100,39 @@ void run(std::mt19937_64& engine, int int_ptype)
     // Construct random data to use for test
     // Get views of input data and set to random values
     const auto& T_mid_f = input_fields["T_mid"];
-    const auto& T_mid_v = T_mid_f.get_view<Pack**>();
     const auto& p_mid_f = input_fields["p_mid"];
-    const auto& p_mid_v = p_mid_f.get_view<Pack**>();
     const auto& q_mid_f = input_fields["qc"];
-    const auto& q_mid_v = q_mid_f.get_view<Pack**>();
+    auto T_mid_v = T_mid_f.get_view<Real**>();
+    auto p_mid_v = p_mid_f.get_view<Real**>();
+    decltype(p_mid_v) q_mid_v;
+    if (q_mid_f.is_allocated()) {
+      q_mid_v = q_mid_f.get_view<Real**>();
+    }
     for (int icol=0;icol<ncols;icol++) {
       const auto& T_sub = ekat::subview(T_mid_v,icol);
       const auto& p_sub = ekat::subview(p_mid_v,icol);
-      const auto& q_sub = ekat::subview(q_mid_v,icol);
-      ekat::genRandArray(dview_as_real(temperature), engine, pdf_temp);
-      ekat::genRandArray(dview_as_real(pressure),    engine, pdf_pres);
-      ekat::genRandArray(dview_as_real(condensate),  engine, pdf_pres);
-      Kokkos::deep_copy(T_sub,temperature);
-      Kokkos::deep_copy(p_sub,pressure);
-      Kokkos::deep_copy(q_sub,condensate);
+      ekat::genRandArray(T_sub, engine, pdf_temp);
+      ekat::genRandArray(p_sub, engine, pdf_pres);
+
+      if (q_mid_f.is_allocated()) {
+        const auto& q_sub = ekat::subview(q_mid_v,icol);
+        ekat::genRandArray(q_sub, engine, pdf_pres);
+      }
     }
 
     // Run diagnostic and compare with manual calculation
     diag->compute_diagnostic();
     const auto& diag_out = diag->get_diagnostic();
     Field theta_f = diag_out.clone();
-    theta_f.deep_copy<double,Host>(0.0);
-    theta_f.sync_to_dev();
-    const auto& theta_v = theta_f.get_view<Pack**>();
+    theta_f.deep_copy(0);
+    const auto& theta_v = theta_f.get_view<Real**>();
     Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int icol = team.league_rank();
-      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_mid_packs), [&] (const Int& jpack) {
-        auto theta = PF::calculate_theta_from_T(T_mid_v(icol,jpack),p_mid_v(icol,jpack));
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_levs), [&] (const Int& ilev) {
+        auto theta = PF::calculate_theta_from_T(T_mid_v(icol,ilev),p_mid_v(icol,ilev));
         if (int_ptype==1) {
-          theta_v(icol,jpack) = theta - (theta/T_mid_v(icol,jpack)) * (PC::LatVap/PC::Cpair) * q_mid_v(icol,jpack);
-        } else { theta_v(icol,jpack) = theta; }
+          theta_v(icol,ilev) = theta - (theta/T_mid_v(icol,ilev)) * (PC::LatVap/PC::Cpair) * q_mid_v(icol,ilev);
+        } else { theta_v(icol,ilev) = theta; }
       });
       team.team_barrier();
     });

--- a/components/eamxx/src/diagnostics/tests/virtual_temperature_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/virtual_temperature_test.cpp
@@ -43,16 +43,12 @@ template<typename DeviceT>
 void run(std::mt19937_64& engine)
 {
   using PF         = scream::PhysicsFunctions<DeviceT>;
-  using Pack       = ekat::Pack<Real,SCREAM_PACK_SIZE>;
   using KT         = ekat::KokkosTypes<DeviceT>;
   using ExecSpace  = typename KT::ExeSpace;
   using MemberType = typename KT::MemberType;
-  using view_1d    = typename KT::template view_1d<Pack>;
-  using rview_1d   = typename KT::template view_1d<Real>;
 
   const     int packsize = SCREAM_PACK_SIZE;
   constexpr int num_levs = packsize*2 + 1; // Number of levels to use for tests, make sure the last pack can also have some empty slots (packsize>1).
-  const     int num_mid_packs = ekat::npack<Pack>(num_levs);
 
   // A world comm
   ekat::Comm comm(MPI_COMM_WORLD);
@@ -62,15 +58,7 @@ void run(std::mt19937_64& engine)
   auto gm = create_gm(comm,ncols,num_levs);
 
   // Kokkos Policy
-  auto policy = ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(ncols, num_mid_packs);
-
-  // Input (randomized) views
-  view_1d temperature("temperature",num_mid_packs),
-          watervapor("watervapor",num_mid_packs);
-
-  auto dview_as_real = [&] (const view_1d& v) -> rview_1d {
-    return rview_1d(reinterpret_cast<Real*>(v.data()),v.size()*packsize);
-  };
+  auto policy = ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(ncols, num_levs);
 
   // Construct random input data
   using RPDF = std::uniform_real_distribution<Real>;
@@ -110,29 +98,26 @@ void run(std::mt19937_64& engine)
     // Construct random data to use for test
     // Get views of input data and set to random values
     const auto& T_mid_f = input_fields["T_mid"];
-    const auto& T_mid_v = T_mid_f.get_view<Pack**>();
+    const auto& T_mid_v = T_mid_f.get_view<Real**>();
     const auto& qv_mid_f = input_fields["qv"];
-    const auto& qv_mid_v = qv_mid_f.get_view<Pack**>();
+    const auto& qv_mid_v = qv_mid_f.get_view<Real**>();
     for (int icol=0;icol<ncols;icol++) {
       const auto& T_sub = ekat::subview(T_mid_v,icol);
       const auto& qv_sub = ekat::subview(qv_mid_v,icol);
-      ekat::genRandArray(dview_as_real(temperature), engine, pdf_temp);
-      ekat::genRandArray(dview_as_real(watervapor),  engine, pdf_qv);
-      Kokkos::deep_copy(T_sub,temperature);
-      Kokkos::deep_copy(qv_sub,watervapor);
+      ekat::genRandArray(T_sub,  engine, pdf_temp);
+      ekat::genRandArray(qv_sub, engine, pdf_qv);
     }
 
     // Run diagnostic and compare with manual calculation
     diag->compute_diagnostic();
     const auto& diag_out = diag->get_diagnostic();
     Field virtualT_f = diag_out.clone();
-    virtualT_f.deep_copy<double,Host>(0.0);
-    virtualT_f.sync_to_dev();
-    const auto& virtualT_v = virtualT_f.get_view<Pack**>();
+    virtualT_f.deep_copy(0);
+    const auto& virtualT_v = virtualT_f.get_view<Real**>();
     Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int icol = team.league_rank();
-      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_mid_packs), [&] (const Int& jpack) {
-        virtualT_v(icol,jpack) = PF::calculate_virtual_temperature(T_mid_v(icol,jpack),qv_mid_v(icol,jpack));
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team,num_levs), [&] (const Int& ilev) {
+        virtualT_v(icol,ilev) = PF::calculate_virtual_temperature(T_mid_v(icol,ilev),qv_mid_v(icol,ilev));
       });
       team.team_barrier();
     });

--- a/components/eamxx/src/diagnostics/vapor_flux.cpp
+++ b/components/eamxx/src/diagnostics/vapor_flux.cpp
@@ -24,6 +24,7 @@ VaporFluxDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params)
         "  - input value: " + comp + "\n"
         "  - valid values: Zonal, Meridional\n");
   }
+  m_name = comp + "VapFlux";
 }
 
 void VaporFluxDiagnostic::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
@@ -46,8 +47,7 @@ void VaporFluxDiagnostic::set_grids(const std::shared_ptr<const GridsManager> gr
   add_field<Required>("horiz_winds",    vector3d, m/s,   grid_name);
 
   // Construct and allocate the diagnostic field
-  std::string dname = m_component==0 ? "ZonalVapFlux" : "MeridionalVapFlux";
-  FieldIdentifier fid (dname, scalar2d, kg/m/s, grid_name);
+  FieldIdentifier fid (name(), scalar2d, kg/m/s, grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 }

--- a/components/eamxx/src/diagnostics/vapor_flux.cpp
+++ b/components/eamxx/src/diagnostics/vapor_flux.cpp
@@ -46,7 +46,7 @@ void VaporFluxDiagnostic::set_grids(const std::shared_ptr<const GridsManager> gr
   add_field<Required>("horiz_winds",    vector3d, m/s,   grid_name);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar2d, kg/m/s, grid_name);
+  FieldIdentifier fid (m_name, scalar2d, kg/m/s, grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 }
@@ -67,7 +67,7 @@ void VaporFluxDiagnostic::compute_diagnostic_impl()
 
   const auto num_levs = m_num_levs;
   const auto policy = ESU::get_default_team_policy(m_num_cols, m_num_levs);
-  Kokkos::parallel_for("Compute " + name(), policy,
+  Kokkos::parallel_for("Compute " + m_name, policy,
                        KOKKOS_LAMBDA(const MT& team) {
     const int icol = team.league_rank();
 

--- a/components/eamxx/src/diagnostics/vapor_flux.cpp
+++ b/components/eamxx/src/diagnostics/vapor_flux.cpp
@@ -30,7 +30,6 @@ VaporFluxDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params)
 void VaporFluxDiagnostic::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
 {
   using namespace ekat::units;
-  using namespace ShortFieldTagsNames;
 
   auto grid  = grids_manager->get_grid("Physics");
   const auto& grid_name = grid->name();

--- a/components/eamxx/src/diagnostics/vapor_flux.hpp
+++ b/components/eamxx/src/diagnostics/vapor_flux.hpp
@@ -16,8 +16,8 @@ public:
   // Constructors
   VaporFluxDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // The name of the diagnostic
-  std::string name () const override { return m_name; }
+  // The name of the diagnostic CLASS (not the computed field)
+  std::string name () const override { return "VaporFlux"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/vapor_flux.hpp
+++ b/components/eamxx/src/diagnostics/vapor_flux.hpp
@@ -17,7 +17,7 @@ public:
   VaporFluxDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
   // The name of the diagnostic
-  std::string name () const override { return "VaporFlux"; }
+  std::string name () const override { return m_name; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
@@ -34,6 +34,8 @@ protected:
   int m_num_levs;
 
   int m_component;
+
+  std::string m_name;
 };
 
 } //namespace scream

--- a/components/eamxx/src/diagnostics/vertical_layer.hpp
+++ b/components/eamxx/src/diagnostics/vertical_layer.hpp
@@ -23,8 +23,8 @@ public:
   // Constructors
   VerticalLayerDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // The name of the diagnostic.
-  std::string name () const { return m_diag_name; }
+  // The name of the diagnostic CLASS (not the computed field)
+  std::string name () const { return "VerticalLayer"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/vertical_layer.hpp
+++ b/components/eamxx/src/diagnostics/vertical_layer.hpp
@@ -24,7 +24,7 @@ public:
   VerticalLayerDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
   // The name of the diagnostic.
-  std::string name () const { return "VerticalLayer"; }
+  std::string name () const { return m_diag_name; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/virtual_temperature.cpp
+++ b/components/eamxx/src/diagnostics/virtual_temperature.cpp
@@ -1,4 +1,5 @@
 #include "diagnostics/virtual_temperature.hpp"
+#include "share/util/eamxx_common_physics_functions.hpp"
 
 namespace scream
 {
@@ -21,33 +22,32 @@ void VirtualTemperatureDiagnostic::set_grids(const std::shared_ptr<const GridsMa
   m_num_levs = grid->get_num_vertical_levels();  // Number of levels per column
 
   FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_num_cols,m_num_levs} };
-  constexpr int ps = Pack::n;
 
   // The fields required for this diagnostic to be computed
-  add_field<Required>("T_mid",       scalar3d_layout_mid, K,     grid_name, ps);
-  add_field<Required>("qv",          scalar3d_layout_mid, kg/kg, grid_name, ps);
+  add_field<Required>("T_mid", scalar3d_layout_mid, K,     grid_name);
+  add_field<Required>("qv",    scalar3d_layout_mid, kg/kg, grid_name);
 
   // Construct and allocate the diagnostic field
   FieldIdentifier fid (name(), scalar3d_layout_mid, K, grid_name);
   m_diagnostic_output = Field(fid);
-  auto& C_ap = m_diagnostic_output.get_header().get_alloc_properties();
-  C_ap.request_allocation(ps);
   m_diagnostic_output.allocate_view();
 }
 
 void VirtualTemperatureDiagnostic::compute_diagnostic_impl()
 {
-  const auto npacks  = ekat::npack<Pack>(m_num_levs);
-  const auto& virtualT = m_diagnostic_output.get_view<Pack**>();
-  const auto& T_mid    = get_field_in("T_mid").get_view<const Pack**>();
-  const auto& qv_mid   = get_field_in("qv").get_view<const Pack**>();
+  using PF = scream::PhysicsFunctions<DefaultDevice>;
 
+  const auto& virtualT = m_diagnostic_output.get_view<Real**>();
+  const auto& T_mid    = get_field_in("T_mid").get_view<const Real**>();
+  const auto& qv_mid   = get_field_in("qv").get_view<const Real**>();
+
+  int nlevs = m_num_levs;
   Kokkos::parallel_for("VirtualTemperatureDiagnostic",
-                       Kokkos::RangePolicy<>(0,m_num_cols*npacks),
+                       Kokkos::RangePolicy<>(0,m_num_cols*nlevs),
                        KOKKOS_LAMBDA(const int& idx) {
-      const int icol  = idx / npacks;
-      const int jpack = idx % npacks;
-      virtualT(icol,jpack) = PF::calculate_virtual_temperature(T_mid(icol,jpack),qv_mid(icol,jpack));
+      const int icol = idx / nlevs;
+      const int ilev = idx % nlevs;
+      virtualT(icol,ilev) = PF::calculate_virtual_temperature(T_mid(icol,ilev),qv_mid(icol,ilev));
   });
   Kokkos::fence();
 }

--- a/components/eamxx/src/diagnostics/virtual_temperature.cpp
+++ b/components/eamxx/src/diagnostics/virtual_temperature.cpp
@@ -21,14 +21,14 @@ void VirtualTemperatureDiagnostic::set_grids(const std::shared_ptr<const GridsMa
   m_num_cols = grid->get_num_local_dofs(); // Number of columns on this rank
   m_num_levs = grid->get_num_vertical_levels();  // Number of levels per column
 
-  FieldLayout scalar3d_layout_mid { {COL,LEV}, {m_num_cols,m_num_levs} };
+  auto scalar3d = grid->get_3d_scalar_layout(true);
 
   // The fields required for this diagnostic to be computed
-  add_field<Required>("T_mid", scalar3d_layout_mid, K,     grid_name);
-  add_field<Required>("qv",    scalar3d_layout_mid, kg/kg, grid_name);
+  add_field<Required>("T_mid", scalar3d, K,     grid_name);
+  add_field<Required>("qv",    scalar3d, kg/kg, grid_name);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar3d_layout_mid, K, grid_name);
+  FieldIdentifier fid (name(), scalar3d, K, grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 }

--- a/components/eamxx/src/diagnostics/virtual_temperature.hpp
+++ b/components/eamxx/src/diagnostics/virtual_temperature.hpp
@@ -17,7 +17,7 @@ public:
   // Constructors
   VirtualTemperatureDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // The name of the diagnostic
+  // The name of the diagnostic CLASS (not the computed field)
   std::string name () const { return "VirtualTemperature"; }
 
   // Set the grid

--- a/components/eamxx/src/diagnostics/virtual_temperature.hpp
+++ b/components/eamxx/src/diagnostics/virtual_temperature.hpp
@@ -2,7 +2,6 @@
 #define EAMXX_VIRTUAL_TEMP_DIAGNOSTIC_HPP
 
 #include "share/atm_process/atmosphere_diagnostic.hpp"
-#include "share/util/eamxx_common_physics_functions.hpp"
 
 namespace scream
 {
@@ -14,8 +13,6 @@ namespace scream
 class VirtualTemperatureDiagnostic : public AtmosphereDiagnostic
 {
 public:
-  using Pack          = ekat::Pack<Real,SCREAM_PACK_SIZE>;
-  using PF            = scream::PhysicsFunctions<DefaultDevice>;
 
   // Constructors
   VirtualTemperatureDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);

--- a/components/eamxx/src/diagnostics/water_path.cpp
+++ b/components/eamxx/src/diagnostics/water_path.cpp
@@ -52,7 +52,7 @@ set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   add_field<Required>(m_qname,          scalar3d, kg/kg, grid_name);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (m_kind + "WaterPath", scalar2d, kg/m2, grid_name);
+  FieldIdentifier fid (name(), scalar2d, kg/m2, grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 }

--- a/components/eamxx/src/diagnostics/water_path.cpp
+++ b/components/eamxx/src/diagnostics/water_path.cpp
@@ -52,7 +52,7 @@ set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   add_field<Required>(m_qname,          scalar3d, kg/kg, grid_name);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar2d, kg/m2, grid_name);
+  FieldIdentifier fid (m_kind + name(), scalar2d, kg/m2, grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 }
@@ -72,7 +72,7 @@ void WaterPathDiagnostic::compute_diagnostic_impl()
 
   const auto num_levs = m_num_levs;
   const auto policy = ESU::get_default_team_policy(m_num_cols, m_num_levs);
-  Kokkos::parallel_for("Compute " + name(), policy,
+  Kokkos::parallel_for("Compute " + m_kind + name(), policy,
                        KOKKOS_LAMBDA(const MT& team) {
     const int icol = team.league_rank();
     auto q_icol    = ekat::subview(q,icol);

--- a/components/eamxx/src/diagnostics/water_path.hpp
+++ b/components/eamxx/src/diagnostics/water_path.hpp
@@ -16,8 +16,8 @@ public:
   // Constructors
   WaterPathDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // The name of the diagnostic
-  std::string name () const override { return m_kind + "WaterPath"; }
+  // The name of the diagnostic CLASS (not the computed field)
+  std::string name () const override { return "WaterPath"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/water_path.hpp
+++ b/components/eamxx/src/diagnostics/water_path.hpp
@@ -17,7 +17,7 @@ public:
   WaterPathDiagnostic (const ekat::Comm& comm, const ekat::ParameterList& params);
 
   // The name of the diagnostic
-  std::string name () const override { return "WaterPath"; }
+  std::string name () const override { return m_kind + "WaterPath"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);

--- a/components/eamxx/src/diagnostics/wind_speed.cpp
+++ b/components/eamxx/src/diagnostics/wind_speed.cpp
@@ -31,7 +31,7 @@ set_grids(const std::shared_ptr<const GridsManager> grids_manager)
   add_field<Required>("horiz_winds", vector3d, Pa, grid_name);
 
   // Construct and allocate the 3d wind_speed field
-  FieldIdentifier fid ("wind_speed", scalar3d, m/s, grid_name);
+  FieldIdentifier fid (name(), scalar3d, m/s, grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 }

--- a/components/eamxx/src/diagnostics/wind_speed.cpp
+++ b/components/eamxx/src/diagnostics/wind_speed.cpp
@@ -16,7 +16,6 @@ void WindSpeed::
 set_grids(const std::shared_ptr<const GridsManager> grids_manager)
 {
   using namespace ekat::units;
-  using namespace ShortFieldTagsNames;
 
   auto grid  = grids_manager->get_grid("Physics");
   const auto& grid_name = grid->name();

--- a/components/eamxx/src/diagnostics/wind_speed.hpp
+++ b/components/eamxx/src/diagnostics/wind_speed.hpp
@@ -16,7 +16,7 @@ public:
   // Constructors
   WindSpeed (const ekat::Comm& comm, const ekat::ParameterList& params);
 
-  // The name of the diagnostic
+  // The name of the diagnostic CLASS (not the computed field)
   std::string name () const override { return "wind_speed"; }
 
   // Set the grid

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -1314,16 +1314,9 @@ void AtmosphereOutput::set_diagnostics()
 {
   const auto sim_field_mgr = get_field_manager("sim");
   // Create all diagnostics
-  for (auto& fname : m_fields_names) {
+  for (const auto& fname : m_fields_names) {
     if (!sim_field_mgr->has_field(fname)) {
-      auto diag = create_diagnostic(fname);
-      auto diag_fname = diag->get_diagnostic().name();
-      m_diagnostics[diag_fname] = diag;
-
-      // Note: the diag field may have a name different from what was used
-      //       in the input file, so update the name with the actual
-      //       diagnostic field name
-      fname = diag_fname;
+      m_diagnostics[fname] = create_diagnostic(fname);
     }
   }
 }


### PR DESCRIPTION
- Ensure the diag field name matches what is used in output yaml files
- Ensure the diag field name matches the output of the `name()` method of the class
- Where possible, remove usage of packs (diags don't have a say in packing of input fields)
- Prefer using grid's methods for creating layouts

[BFB]

---

Regarding packs: when a diagnostic is created, the fields in the FieldManager have already been created/allocated. As such, it is incorrect for diagnostics to request a pack size for their input fields, as the fields allocation is done already. The diagnostics _could_ in theory check if the input fields have a pack size large enough or not, but that makes them more complicated.

In practice, it may be possible to just "assume" inputs are available with a Pack data type, since typical EAMxx process do require packed fields. However, I find this hidden assumption dangerous, so I'd rather avoid that. I'd rather settle for diagnostics that are working without packs (for now), and maybe revisit this if/when we get to reorganize how we provide diagnostics, maybe allowing diag fields to be in the FM (for simplicity). If anyone is interested in the issue, ping me, and we can chat offline.