### PR TITLE
pm-cpu: linking work-around for DEBUG builds after Feb 2025 NERSC maintenance

### DIFF
--- a/cime_config/machines/cmake_macros/amdclang_pm-cpu.cmake
+++ b/cime_config/machines/cmake_macros/amdclang_pm-cpu.cmake
@@ -16,3 +16,8 @@ if (compile_threaded)
   string(APPEND CMAKE_Fortran_FLAGS " -mp")
   string(APPEND CMAKE_EXE_LINKER_FLAGS " -mp")
 endif()
+
+# https://github.com/E3SM-Project/E3SM/issues/7049
+if (DEBUG)
+  string(APPEND CMAKE_EXE_LINKER_FLAGS " /opt/cray/pe/lib64/libhdf5_hl_parallel_aocc.so.200")
+endif()

--- a/cime_config/machines/cmake_macros/gnu_pm-cpu.cmake
+++ b/cime_config/machines/cmake_macros/gnu_pm-cpu.cmake
@@ -13,3 +13,7 @@ set(SFC "gfortran")
 
 #string(APPEND CMAKE_EXE_LINKER_FLAGS " -static-libstdc++") # was causing link error after Feb 18/19 maintenance
 
+# https://github.com/E3SM-Project/E3SM/issues/7049
+if (DEBUG)
+  string(APPEND CMAKE_EXE_LINKER_FLAGS " /opt/cray/pe/lib64/libhdf5_hl_parallel_gnu_91.so.200")
+endif()

--- a/cime_config/machines/cmake_macros/intel_pm-cpu.cmake
+++ b/cime_config/machines/cmake_macros/intel_pm-cpu.cmake
@@ -25,7 +25,12 @@ string(APPEND CMAKE_CXX_FLAGS " -fp-model=precise") # and manually add precise
 #message(STATUS "ndk CXXFLAGS=${CXXFLAGS}")
 
 string(APPEND CMAKE_Fortran_FLAGS " -fp-model=consistent -fimf-use-svml")
-   #  string(APPEND FFLAGS " -qno-opt-dynamic-align")
- string(APPEND CMAKE_Fortran_FLAGS_RELEASE " -g -traceback")
+#string(APPEND FFLAGS " -qno-opt-dynamic-align")
+string(APPEND CMAKE_Fortran_FLAGS_RELEASE " -g -traceback")
 string(APPEND CMAKE_Fortran_FLAGS " -DHAVE_ERF_INTRINSICS")
 string(APPEND CMAKE_CXX_FLAGS " -fp-model=consistent")
+
+# https://github.com/E3SM-Project/E3SM/issues/7049
+if (DEBUG)
+  string(APPEND CMAKE_EXE_LINKER_FLAGS " /opt/cray/pe/lib64/libhdf5_hl_parallel_intel.so.200")
+endif()

--- a/cime_config/machines/cmake_macros/nvidia_pm-cpu.cmake
+++ b/cime_config/machines/cmake_macros/nvidia_pm-cpu.cmake
@@ -14,3 +14,8 @@ set(MPIFC "ftn")
 set(SCC "cc")
 set(SCXX "CC")
 set(SFC "ftn")
+
+# https://github.com/E3SM-Project/E3SM/issues/7049
+if (DEBUG)
+  string(APPEND CMAKE_EXE_LINKER_FLAGS " /opt/cray/pe/lib64/libhdf5_hl_parallel_nvidia.so.200")
+endif()


### PR DESCRIPTION
After the NERSC Feb 2025 maintenance, our modules remained the same, but there were some software stack changes that seemed to have caused an issue with running almost any DEBUG (with floating-point exceptions) executable on pm-cpu. The issue appears to be within HDF, and there may be a fix in newer version that may take time to install. This PR meant to be temporary work-around to add older HDF link library.

Fixes https://github.com/E3SM-Project/E3SM/issues/7049

[BFB]