### PR TITLE
On pm-gpu, use 4 nodes for new test using `ne30pg2_EC30to60E2r2.WCYCLXX2010`

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -1836,6 +1836,27 @@
           <nthrds_cpl>8</nthrds_cpl>
         </nthrds>
       </pes>
+      <pes compset=".*2010_SCREAM_ELM.*" pesize="any">
+        <comment>"pm-gpu ne30 with WCYCLXX2010 4 nodes, 4x16"</comment>
+        <ntasks>
+          <ntasks_atm>-4</ntasks_atm>
+          <ntasks_lnd>-4</ntasks_lnd>
+          <ntasks_rof>-4</ntasks_rof>
+          <ntasks_ice>-4</ntasks_ice>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_glc>-4</ntasks_glc>
+          <ntasks_wav>-4</ntasks_wav>
+          <ntasks_cpl>-4</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>16</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>16</nthrds_ice>
+          <nthrds_ocn>16</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+      </pes>
     </mach>
     <mach name="pm-cpu|muller-cpu|alvarez">
       <pes compset="any" pesize="any">


### PR DESCRIPTION
The new test `ne30pg2_EC30to60E2r2.WCYCLXX2010` use default 2-node PE layout which was fine, but running slow enough to not fit in the 30-min time cutoff for debug qos. Here just updating to use 4 nodes. 

[BFB]