### PR TITLE
EAMxx: simplify branch runs and adding new output streams

### DIFF
--- a/components/eamxx/docs/user/model_configuration.md
+++ b/components/eamxx/docs/user/model_configuration.md
@@ -599,12 +599,16 @@ of the parameter value).
       stream listed in the `output_yaml_files` atmosphere option
       (which can be queried via `atmquery output_yaml_files`).
       - The user can specify a few options, in order to tweak the restart behavior:
-          - `skip_restart_if_rhist_not_found` (`Restart` sublist, boolean): this parameter is `false` by default, but can be set
-            to `true` to make the model start the output stream anew (as if this was an initial run) if the proper rhist
-            file name is not found in rpointer.atm. This allows to add a new output stream after a restart.
-            NOTE: this option is more precisely needed when other streams MUST be restarted, but the current one should
-                  be started from scratch. If ALL streams should be started anew, you should set RUN_TYPE=branch in
-                  the case XML settings instead.
+          - `skip_restart_if_rhist_not_found` (`Restart` sublist, boolean):
+            this parameter is `false` by default, but can be set
+            to `true` to make the model start the output stream anew
+            (as if this was an initial run) if the proper rhist
+            file name is not found in rpointer.atm. This allows to add
+            a new output stream after a restart.
+            NOTE: this option is more precisely needed when other streams MUST
+                  be restarted, but the current one should be started from
+                  scratch. If ALL streams should be started anew, you should
+                  set RUN_TYPE=branch in the case XML settings instead.
             scratch, as if this was an initial run.
           - `filename_prefix` (`Restart` sub-list, `string`):
               - By default, this parameter is set to match the value of

--- a/components/eamxx/docs/user/model_configuration.md
+++ b/components/eamxx/docs/user/model_configuration.md
@@ -602,6 +602,9 @@ of the parameter value).
           - `skip_restart_if_rhist_not_found` (`Restart` sublist, boolean): this parameter is `false` by default, but can be set
             to `true` to make the model start the output stream anew (as if this was an initial run) if the proper rhist
             file name is not found in rpointer.atm. This allows to add a new output stream after a restart.
+            NOTE: this option is more precisely needed when other streams MUST be restarted, but the current one should
+                  be started from scratch. If ALL streams should be started anew, you should set RUN_TYPE=branch in
+                  the case XML settings instead.
             scratch, as if this was an initial run.
           - `filename_prefix` (`Restart` sub-list, `string`):
               - By default, this parameter is set to match the value of

--- a/components/eamxx/docs/user/model_configuration.md
+++ b/components/eamxx/docs/user/model_configuration.md
@@ -599,10 +599,9 @@ of the parameter value).
       stream listed in the `output_yaml_files` atmosphere option
       (which can be queried via `atmquery output_yaml_files`).
       - The user can specify a few options, in order to tweak the restart behavior:
-          - `Perform Restart` (`Restart` sub-list, `boolean`):
-              - This parameter is `true` by default, but can be set
-              to `false` to force the model to ignore any history restart files,
-              and start the output stream from
+          - `skip_restart_if_rhist_not_found` (`Restart` sublist, boolean): this parameter is `false` by default, but can be set
+            to `true` to make the model start the output stream anew (as if this was an initial run) if the proper rhist
+            file name is not found in rpointer.atm. This allows to add a new output stream after a restart.
             scratch, as if this was an initial run.
           - `filename_prefix` (`Restart` sub-list, `string`):
               - By default, this parameter is set to match the value of

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -173,6 +173,10 @@ init_time_stamps (const util::TimeStamp& run_t0, const util::TimeStamp& case_t0,
       m_run_type = RunType::Initial; break;
     case 1:
       m_run_type = RunType::Restart; break;
+    case 2:
+      m_run_type = RunType::Restart;
+      m_branch_run = true;
+      break;
     case -1:
       m_run_type = case_t0==run_t0 ? RunType::Initial : RunType::Restart; break;
     default:
@@ -805,6 +809,7 @@ void AtmosphereDriver::create_output_managers () {
       params.set<std::string>("filename_prefix",m_casename+".scream.h");
     }
     params.sublist("provenance") = m_atm_params.sublist("provenance");
+    params.sublist("Restart").set("branch_run",m_branch_run);
 
     auto& om = m_output_managers.emplace_back();
     om.initialize(m_atm_comm,

--- a/components/eamxx/src/control/atmosphere_driver.hpp
+++ b/components/eamxx/src/control/atmosphere_driver.hpp
@@ -217,6 +217,7 @@ protected:
   util::TimeStamp                           m_run_t0;
   util::TimeStamp                           m_case_t0;
   RunType                                   m_run_type;
+  bool                                      m_branch_run = false;
 
   // This is the comm containing all (and only) the processes assigned to the atmosphere
   ekat::Comm                                m_atm_comm;

--- a/components/eamxx/src/mct_coupling/atm_comp_mct.F90
+++ b/components/eamxx/src/mct_coupling/atm_comp_mct.F90
@@ -197,7 +197,7 @@ CONTAINS
     else if (trim(run_type) == trim(seq_infodata_start_type_cont) ) then
       run_type_c = 1
     else if (trim(run_type) == trim(seq_infodata_start_type_brnch) ) then
-      run_type_c = 1
+      run_type_c = 2
     else
       print *, "[eamxx] ERROR! Unsupported run type: "//trim(run_type)
       call mpi_abort(mpicom_atm,ierr,mpi_ierr)

--- a/components/eamxx/src/physics/rrtmgp/rrtmgp_test_utils.hpp
+++ b/components/eamxx/src/physics/rrtmgp/rrtmgp_test_utils.hpp
@@ -46,9 +46,9 @@ template <typename RealT=scream::Real, typename LayoutT=Kokkos::LayoutRight, typ
 struct rrtmgp_test_utils {
 
 using interface_t = scream::rrtmgp::rrtmgp_interface<RealT, LayoutT, DeviceT>;
-using real1dk = typename interface_t::view_t<RealT*>;
-using real2dk = typename interface_t::view_t<RealT**>;
-using real3dk = typename interface_t::view_t<RealT***>;
+using real1dk = typename interface_t::template view_t<RealT*>;
+using real2dk = typename interface_t::template view_t<RealT**>;
+using real3dk = typename interface_t::template view_t<RealT***>;
 using MDRP = typename conv::MDRP<LayoutT>;
 
 static bool all_close(real2dk &arr1, real2dk &arr2, double tolerance)

--- a/components/eamxx/src/share/io/eamxx_io_control.hpp
+++ b/components/eamxx/src/share/io/eamxx_io_control.hpp
@@ -60,7 +60,6 @@ struct IOControl {
       // TODO - add support for "end" as an option
       EKAT_ERROR_MSG("Error! Unsupported frequency units of " + freq_unit + " provided.");
     }
-
   }
 
   void set_dt (const double dt_in) {

--- a/components/eamxx/src/share/io/eamxx_io_utils.hpp
+++ b/components/eamxx/src/share/io/eamxx_io_utils.hpp
@@ -72,6 +72,7 @@ std::string find_filename_in_rpointer (
     const bool model_restart,
     const ekat::Comm& comm,
     const util::TimeStamp& run_t0,
+    const bool allow_not_found = false,
     const OutputAvgType avg_type = OutputAvgType::Instant,
     const IOControl& control = {});
 

--- a/components/eamxx/src/share/io/eamxx_output_manager.cpp
+++ b/components/eamxx/src/share/io/eamxx_output_manager.cpp
@@ -165,7 +165,8 @@ setup (const std::map<std::string,std::shared_ptr<fm_type>>& field_mgrs,
   // Note: the user might decide *not* to restart the output, so give the option
   //       of disabling the restart. Also, the user might want to change the
   //       filename_prefix, so allow to specify a different filename_prefix for the restart file.
-  if (m_run_type==RunType::Restart and not m_is_model_restart_output) {
+  bool branch_run = m_params.sublist("Restart").get("branch_run",false);
+  if (m_run_type==RunType::Restart and not m_is_model_restart_output and not branch_run) {
     // Allow to skip history restart, or to specify a filename_prefix for the restart file
     // that is different from the filename_prefix of the current output.
     auto& restart_pl = m_params.sublist("Restart");

--- a/components/eamxx/src/share/io/eamxx_output_manager.cpp
+++ b/components/eamxx/src/share/io/eamxx_output_manager.cpp
@@ -67,6 +67,11 @@ setup (const std::map<std::string,std::shared_ptr<fm_type>>& field_mgrs,
   // Read input parameters and setup internal data
   setup_internals(field_mgrs);
 
+  if (not m_output_control.output_enabled()) {
+    // If output is not enabled, there's no point in continuing
+    return;
+  }
+
   // Here, store if PG2 fields will be present in output streams.
   // Will be useful if multiple grids are defined (see below).
   bool pg2_grid_in_io_streams = false;
@@ -736,7 +741,7 @@ setup_internals (const std::map<std::string,std::shared_ptr<fm_type>>& field_mgr
   m_output_control.set_frequency_units(out_control_pl.get<std::string>("frequency_units"));
 
   // In case output is disabled, no point in doing anything else
-  if (m_output_control.frequency_units=="none" || m_output_control.frequency_units=="never") {
+  if (not m_output_control.output_enabled()) {
     return;
   }
   m_output_control.frequency = out_control_pl.get<int>("Frequency");

--- a/components/eamxx/src/share/io/eamxx_output_manager.cpp
+++ b/components/eamxx/src/share/io/eamxx_output_manager.cpp
@@ -44,6 +44,10 @@ initialize(const ekat::Comm& io_comm, const ekat::ParameterList& params,
   m_case_t0 = case_t0;
   m_run_type = run_type;
   m_is_model_restart_output = is_model_restart_output;
+
+  // This works if we are not restarting the stream.
+  // If we are, it will get adjusted later
+  m_output_control.last_write_ts = m_run_t0;
 }
 
 void OutputManager::
@@ -165,20 +169,25 @@ setup (const std::map<std::string,std::shared_ptr<fm_type>>& field_mgrs,
     // Allow to skip history restart, or to specify a filename_prefix for the restart file
     // that is different from the filename_prefix of the current output.
     auto& restart_pl = m_params.sublist("Restart");
-    bool perform_history_restart = restart_pl.get("Perform Restart",true);
     auto hist_restart_filename_prefix = restart_pl.get("filename_prefix",m_filename_prefix);
 
-    if (perform_history_restart) {
-      using namespace scorpio;
-      IOFileSpecs hist_restart_specs;
-      hist_restart_specs.ftype = FileType::HistoryRestart;
-      auto rhist_file = find_filename_in_rpointer(hist_restart_filename_prefix,false,m_io_comm,m_run_t0,m_avg_type,m_output_control);
+    bool skip_restart_if_rhist_not_found = restart_pl.get("skip_restart_if_rhist_not_found",false);
+    auto rhist_file = find_filename_in_rpointer(hist_restart_filename_prefix,false,m_io_comm,m_run_t0,
+                                                skip_restart_if_rhist_not_found,m_avg_type,m_output_control);
+
+    if (rhist_file=="") {
+      if (m_atm_logger) {
+        m_atm_logger->warn("[OutputManager::setup] The rhist file not found in rpointer.atm.\n"
+                           "  Continuing without restart, since 'skip_restart_if_rhist_not_found=true'.\n"
+                           "   - output yaml file for this stream: " + m_params.name() + "\n");
+      }
+    } else {
 
       scorpio::register_file(rhist_file,scorpio::Read);
       // From restart file, get the time of last write, as well as the current size of the avg sample
       m_output_control.last_write_ts = read_timestamp(rhist_file,"last_write",true);
       m_output_control.compute_next_write_ts();
-      m_output_control.nsamples_since_last_write = get_attribute<int>(rhist_file,"GLOBAL","num_snapshots_since_last_write");
+      m_output_control.nsamples_since_last_write = scorpio::get_attribute<int>(rhist_file,"GLOBAL","num_snapshots_since_last_write");
 
       if (m_avg_type!=OutputAvgType::Instant) {
         m_time_bnds.resize(2);
@@ -196,7 +205,8 @@ setup (const std::map<std::string,std::shared_ptr<fm_type>>& field_mgrs,
       }
 
       // We do NOT allow changing output specs across restart. If you do want to change
-      // any of these, you MUST start a new output stream (e.g., setting 'Perform Restart: false')
+      // any of these, you MUST start a new output stream, by removing rhist files from
+      // rpointer.atm and set skip_restart_if_rhist_not_found=true
       // NOTE: we do not check that freq/freq_units/avg_type are not changed: since we used
       //       that info to find the correct rhist file, we already know that they match!
       auto old_storage_type = scorpio::get_attribute<std::string>(rhist_file,"GLOBAL","file_max_storage_type");
@@ -226,7 +236,7 @@ setup (const std::map<std::string,std::shared_ptr<fm_type>>& field_mgrs,
 
       // Check if the prev run wrote any output file (it may have not, if the restart was written
       // before the 1st output step). If there is a file, check if there's still room in it.
-      const auto& last_output_filename = get_attribute<std::string>(rhist_file,"GLOBAL","last_output_filename");
+      const auto& last_output_filename = scorpio::get_attribute<std::string>(rhist_file,"GLOBAL","last_output_filename");
       m_resume_output_file = last_output_filename!="" and not restart_pl.get("force_new_file",true);
       if (m_resume_output_file) {
         m_output_file_specs.storage.num_snapshots_in_file = scorpio::get_attribute<int>(rhist_file,"GLOBAL","last_output_file_num_snaps");
@@ -245,6 +255,7 @@ setup (const std::map<std::string,std::shared_ptr<fm_type>>& field_mgrs,
       scorpio::release_file(rhist_file);
     }
   }
+  m_output_control.compute_next_write_ts();
 
   // If m_time_bnds.size()>0, it was already inited during restart
   if (m_avg_type!=OutputAvgType::Instant && m_time_bnds.size()==0) {
@@ -730,16 +741,6 @@ setup_internals (const std::map<std::string,std::shared_ptr<fm_type>>& field_mgr
   m_output_control.frequency = out_control_pl.get<int>("Frequency");
   EKAT_REQUIRE_MSG (m_output_control.frequency>0,
       "Error! Invalid frequency (" + std::to_string(m_output_control.frequency) + ") in Output Control. Please, use positive number.\n");
-
-  // Determine which timestamp to use a reference for output frequency.  Two options:
-  // 	1. use_case_as_start_reference: TRUE  - implies we want to calculate frequency from the beginning of the whole simulation, even if this is a restarted run.
-  // 	2. use_case_as_start_reference: FALSE - implies we want to base the frequency of output on when this particular simulation started.
-  // Note, (2) is needed for restarts since the restart frequency in CIME assumes a reference of when this run began.
-  const bool use_case_as_ref = out_control_pl.get<bool>("use_case_as_start_reference",!m_is_model_restart_output);
-  const bool perform_history_restart = m_params.sublist("Restart").get("Perform Restart",true);
-  const auto& start_ref = use_case_as_ref and perform_history_restart ? m_case_t0 : m_run_t0;
-  m_output_control.last_write_ts = start_ref;
-  m_output_control.compute_next_write_ts();
 
   // File specs
   m_save_grid_data = out_control_pl.get("save_grid_data",!m_is_model_restart_output);

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -26,26 +26,26 @@
  *
  *  The EKAT parameter list contains the following options to control output behavior
  *  ------
- *  filename_prefix:              STRING
- *  Averaging Type:               STRING
- *  Max Snapshots Per File:       INT                   (default: 1)
+ *  filename_prefix:                    STRING
+ *  Averaging Type:                     STRING
+ *  Max Snapshots Per File:             INT                   (default: 1)
  *  Fields:
  *     GRID_NAME_1:
- *        Field Names:            ARRAY OF STRINGS
- *        IO Grid Name:           STRING                (optional)
+ *        Field Names:                  ARRAY OF STRINGS
+ *        IO Grid Name:                 STRING                (optional)
  *     GRID_NAME_2:
- *        Field Names:            ARRAY OF STRINGS
- *        IO Grid Name:           STRING                (optional)
+ *        Field Names:                  ARRAY OF STRINGS
+ *        IO Grid Name:                 STRING                (optional)
  *     ...
  *     GRID_NAME_N:
- *        Field Names:            ARRAY OF STRINGS
- *        IO Grid Name:           STRING                (optional)
+ *        Field Names:                  ARRAY OF STRINGS
+ *        IO Grid Name:                 STRING                (optional)
  *  output_control:
- *    Frequency:                  INT
- *    frequency_units:            STRING                (default: nsteps)
+ *    Frequency:                        INT
+ *    frequency_units:                  STRING                (default: nsteps)
  *  Restart:
- *    filename_prefix:            STRING                (default: ${filename_prefix})
- *    Perform Restart:            BOOL                  (default: true)
+ *    filename_prefix:                  STRING                (default: ${filename_prefix})
+ *    skip_restart_if_rhist_not_found:  BOOL                  (default: false)
  *  -----
  *  The meaning of these parameters is the following:
  *  - filename_prefix: the output filename root.
@@ -73,9 +73,9 @@
  *    - frequency_units: the units of restart history output.
  *  - Restart: parameters for history restart
  *    - filename_prefix: the history restart filename root.
- *    - Perform Restart: if this is a restarted run, and Averaging Type is not Instant, this flag
- *      determines whether we want to restart the output history or start from scrach. That is,
- *      you can set this to false to force a fresh new history, even in a restarted run.
+ *    - skip_restart_if_rhist_not_found: if this is a restarted run and this is true, skip the
+ *      hist restart if the proper filename is not found in rpointer. Allows to add a new stream
+ *      upon restart.
 
  *  Notes:
  *   - you can specify lists with either of the two syntaxes:

--- a/components/eamxx/src/share/io/tests/io_utils.cpp
+++ b/components/eamxx/src/share/io/tests/io_utils.cpp
@@ -36,18 +36,19 @@ TEST_CASE ("find_filename_in_rpointer") {
   rpointer.close();
 
   // Now test find_filename_in_rpointer with different inputs
-  REQUIRE_THROWS (find_filename_in_rpointer("baz",false,comm,t0,AVG)); // missing control (needed for rhist files)
-  REQUIRE_THROWS (find_filename_in_rpointer("baz",false,comm,t0,AVG,bar_c)); // wrong prefix
-  REQUIRE_THROWS (find_filename_in_rpointer("bar",false,comm,t1,AVG,bar_c)); // wrong timestamp
-  REQUIRE_THROWS (find_filename_in_rpointer("bar",true, comm,t0,AVG,bar_c)); // bar is not model restart
-  REQUIRE_THROWS (find_filename_in_rpointer("bar",false,comm,t0,INST,bar_c)); // wrong avg type
-  REQUIRE_THROWS (find_filename_in_rpointer("bar",false,comm,t0,INST,bar2_c)); // wrong freq specs
-  REQUIRE_THROWS (find_filename_in_rpointer("foo",false,comm,t0,INST,foo_c)); // foo is model restart
-  REQUIRE_THROWS (find_filename_in_rpointer("foo",true,comm,t0,AVG)); // model restart MUST be INSTANT
+  REQUIRE_THROWS (find_filename_in_rpointer("baz",false,comm,t0,false,AVG)); // missing control (needed for rhist files)
+  REQUIRE_THROWS (find_filename_in_rpointer("baz",false,comm,t0,false,AVG,bar_c)); // wrong prefix
+  REQUIRE_THROWS (find_filename_in_rpointer("bar",false,comm,t1,false,AVG,bar_c)); // wrong timestamp
+  REQUIRE_THROWS (find_filename_in_rpointer("bar",true, comm,t0,false,AVG,bar_c)); // bar is not model restart
+  REQUIRE_THROWS (find_filename_in_rpointer("bar",false,comm,t0,false,INST,bar_c)); // wrong avg type
+  REQUIRE_THROWS (find_filename_in_rpointer("bar",false,comm,t0,false,INST,bar2_c)); // wrong freq specs
+  REQUIRE_THROWS (find_filename_in_rpointer("foo",false,comm,t0,false,INST,foo_c)); // foo is model restart
+  REQUIRE_THROWS (find_filename_in_rpointer("foo",true, comm,t0,false,AVG)); // model restart MUST be INSTANT
+  auto not_found = find_filename_in_rpointer("bar",false,comm,t0,true,INST,bar2_c); // Allowed to not find it
+  REQUIRE (not_found=="");
 
-  auto test = find_filename_in_rpointer("bar",false,comm,t0,AVG,bar_c);
-  REQUIRE (find_filename_in_rpointer("bar",false,comm,t0,AVG,bar_c)==bar_fname);
-  REQUIRE (find_filename_in_rpointer("bar",false,comm,t0,AVG,bar2_c)==bar2_fname);
+  REQUIRE (find_filename_in_rpointer("bar",false,comm,t0,false,AVG,bar_c)==bar_fname);
+  REQUIRE (find_filename_in_rpointer("bar",false,comm,t0,false,AVG,bar2_c)==bar2_fname);
   REQUIRE (find_filename_in_rpointer("foo",true, comm,t0)==foo_fname);
 }
 


### PR DESCRIPTION
Simplify workflow for branch runs, and, in general, runs where new output streams are added upon restart.

[BFB]

---

Right now, for branch runs, the user needs to add the entry `Perform Restart: false` entry in the `Restart` sublist of their output yaml file. This allows EAMxx to skip the look for the rhist file. However, the user must later remove this entry, so that upon subsequent restarts the stream _IS_ restarted. This is confusing, and may be overlooked.

This PR automatically handles this kind of details. In particular:

- for a branch run, we automatically ignore the rhist file, without need of explicitly adding yaml entries
- for streams added after restarts (not branch runs!), replace `Perform Restart: false` with `skip_restart_if_rhist_not_found: true`. This makes it simpler, since this param does not need to be removed after the 1st "post-restart-run"