### PR TITLE
EAMxx: fix handling of time dim in data interpolation

### DIFF
--- a/components/eamxx/src/physics/mam/readfiles/tracer_reader_utils.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/tracer_reader_utils.hpp
@@ -296,7 +296,7 @@ inline void setup_tracer_data(TracerData &tracer_data,             // out
                               const int cyclical_ymd)              // in
 {
   scorpio::register_file(trace_data_file, scorpio::Read);
-  scorpio::pretend_dim_is_unlimited(trace_data_file, "time");
+  scorpio::mark_dim_as_time(trace_data_file, "time");
   // by default, I am assuming a zonal file.
   TracerFileType tracer_file_type = ZONAL;
 

--- a/components/eamxx/src/physics/mam/readfiles/tracer_reader_utils.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/tracer_reader_utils.hpp
@@ -296,7 +296,9 @@ inline void setup_tracer_data(TracerData &tracer_data,             // out
                               const int cyclical_ymd)              // in
 {
   scorpio::register_file(trace_data_file, scorpio::Read);
-  scorpio::mark_dim_as_time(trace_data_file, "time");
+  if (not scorpio::has_time_dim(trace_data_file)) {
+    scorpio::mark_dim_as_time(trace_data_file, "time");
+  }
   // by default, I am assuming a zonal file.
   TracerFileType tracer_file_type = ZONAL;
 

--- a/components/eamxx/src/share/atm_process/IOPDataManager.cpp
+++ b/components/eamxx/src/share/atm_process/IOPDataManager.cpp
@@ -233,7 +233,9 @@ initialize_iop_file(const util::TimeStamp& run_t0,
   else if (scorpio::has_dim(iop_file, "tsec")) time_dimname = "tsec";
   else EKAT_ERROR_MSG("Error! No valid dimension for tsec in "+iop_file+".\n");
 
-  // When we read vars, "time" must be treated as unlimited, to avoid issues
+  // When we read vars, we need time to be a "record" dimension, so that buffers
+  // are only filled with one time slice at a time. In our scorpio interfaces,
+  // we call the record dimension "time" (since that's what it virtually always is)
   if (not scorpio::has_time_dim(iop_file)) {
     scorpio::mark_dim_as_time(iop_file,time_dimname);
   }

--- a/components/eamxx/src/share/atm_process/IOPDataManager.cpp
+++ b/components/eamxx/src/share/atm_process/IOPDataManager.cpp
@@ -234,7 +234,7 @@ initialize_iop_file(const util::TimeStamp& run_t0,
   else EKAT_ERROR_MSG("Error! No valid dimension for tsec in "+iop_file+".\n");
 
   // When we read vars, "time" must be treated as unlimited, to avoid issues
-  if (not scorpio::is_dim_unlimited(iop_file,time_dimname)) {
+  if (not scorpio::has_time_dim(iop_file)) {
     scorpio::mark_dim_as_time(iop_file,time_dimname);
   }
 

--- a/components/eamxx/src/share/atm_process/IOPDataManager.cpp
+++ b/components/eamxx/src/share/atm_process/IOPDataManager.cpp
@@ -235,7 +235,7 @@ initialize_iop_file(const util::TimeStamp& run_t0,
 
   // When we read vars, "time" must be treated as unlimited, to avoid issues
   if (not scorpio::is_dim_unlimited(iop_file,time_dimname)) {
-    scorpio::pretend_dim_is_unlimited(iop_file,time_dimname);
+    scorpio::mark_dim_as_time(iop_file,time_dimname);
   }
 
   const auto ntimes = scorpio::get_dimlen(iop_file, time_dimname);

--- a/components/eamxx/src/share/io/eamxx_output_manager.cpp
+++ b/components/eamxx/src/share/io/eamxx_output_manager.cpp
@@ -803,7 +803,7 @@ setup_file (      IOFileSpecs& filespecs,
       }
     }
     if (ngood<ntimes) {
-      scorpio::reset_unlimited_dim_len(filename,ngood);
+      scorpio::reset_time_dim_len(filename,ngood);
     }
     scorpio::redef(filename);
   } else {

--- a/components/eamxx/src/share/io/eamxx_scorpio_interface.cpp
+++ b/components/eamxx/src/share/io/eamxx_scorpio_interface.cpp
@@ -681,20 +681,6 @@ int get_dimlen_local (const std::string& filename, const std::string& dimname)
   return dim->offsets==nullptr ? dim->length : dim->offsets->size();
 }
 
-bool is_dim_unlimited (const std::string& filename,
-                       const std::string& dimname)
-{
-  // If file wasn't open, open it on the fly. See comment in PeekFile class above.
-  impl::PeekFile pf(filename);
-
-  EKAT_REQUIRE_MSG (has_dim(filename,dimname),
-      "Error! Could not inquire if dimension is unlimited. The dimension is not in the file.\n"
-      " - filename: " + filename + "\n"
-      " - dimname : " + dimname + "\n");
-
-  return pf.file->dims.at(dimname)->unlimited;
-}
-
 bool has_time_dim (const std::string& filename)
 {
   // If file wasn't open, open it on the fly. See comment in PeekFile class above.

--- a/components/eamxx/src/share/io/eamxx_scorpio_interface.hpp
+++ b/components/eamxx/src/share/io/eamxx_scorpio_interface.hpp
@@ -100,24 +100,20 @@ bool has_dim (const std::string& filename,
 int get_dimlen (const std::string& filename, const std::string& dimname);
 int get_dimlen_local (const std::string& filename, const std::string& dimname);
 
-// Checks if the dimension is unlimited
-bool is_dim_unlimited (const std::string& filename,
-                       const std::string& dimname);
-
-bool has_time_dim (const std::string& filename);
-// When we read a file, we interpret "time" as a "record" dimension, and we read only
-// ONE time slice at a time. If the time dim is unlimited, this is already set up when
-// the file is opened. But on some files, the time dim has a FIXED length (rather than
-// UNLIMITED), which prevents this logic to automatically kick in. To overcome this
-// issue, users can call this function to mark any existing dim as the time dim.
-// This function throws if a time dim is already set.
+// When we read/write a var, we may want to only process one slice of the var,
+// orresponding to a particular time index. In this case, the time dim is a
+// "record" dimension. When we open a file, if there is an unlimited dim, it is
+// automatically marked as the "time" dim (regardless of its name). But if there
+// is no unlimited dim, we may need to tell the interface to interpret one of the
+// dims as the record dimension (which in the interface we refer to as "time" dim).
 void mark_dim_as_time (const std::string& filename, const std::string& dimname);
+bool has_time_dim (const std::string& filename);
 
 // This is used by I/O when restarting a simulation after a crash: the existing file
 // may contain some snapshots after the rest time, but we may want to overwrite them.
 void reset_time_dim_len(const std::string& filename, const int new_length);
 
-// Get len/name of the time dimension (i.e., the unlimited one)
+// Get len/name of the time dimension
 // NOTE: these throw if time dim is not present. Use has_dim to check first.
 int get_time_len (const std::string& filename);
 std::string get_time_name (const std::string& filename);

--- a/components/eamxx/src/share/io/eamxx_scorpio_interface.hpp
+++ b/components/eamxx/src/share/io/eamxx_scorpio_interface.hpp
@@ -104,11 +104,23 @@ int get_dimlen_local (const std::string& filename, const std::string& dimname);
 bool is_dim_unlimited (const std::string& filename,
                        const std::string& dimname);
 
+bool has_time_dim (const std::string& filename);
+// When we read a file, we interpret "time" as a "record" dimension, and we read only
+// ONE time slice at a time. If the time dim is unlimited, this is already set up when
+// the file is opened. But on some files, the time dim has a FIXED length (rather than
+// UNLIMITED), which prevents this logic to automatically kick in. To overcome this
+// issue, users can call this function to mark any existing dim as the time dim.
+// This function throws if a time dim is already set.
+void mark_dim_as_time (const std::string& filename, const std::string& dimname);
+
+// This is used by I/O when restarting a simulation after a crash: the existing file
+// may contain some snapshots after the rest time, but we may want to overwrite them.
+void reset_time_dim_len(const std::string& filename, const int new_length);
+
 // Get len/name of the time dimension (i.e., the unlimited one)
 // NOTE: these throw if time dim is not present. Use has_dim to check first.
 int get_time_len (const std::string& filename);
 std::string get_time_name (const std::string& filename);
-void reset_unlimited_dim_len(const std::string& filename, const int new_length);
 
 // =================== Decompositions operations ==================== //
 
@@ -176,11 +188,6 @@ const PIOVar& get_var (const std::string& filename,
 // Defines both a time dimension and a time variable
 void define_time (const std::string& filename, const std::string& units,
                   const std::string& time_name = default_time_name());
-
-// When we read a file, and there is a "time" dimension that is FIXED rather than UNLIMITED,
-// we may have some issues with our read/write logics. Hence, we can use mark a dimension
-// as if it was the UNLIMITED time dim.
-void pretend_dim_is_unlimited (const std::string& filename, const std::string& dimname);
 
 // Update value of time variable, increasing time dim length
 void update_time(const std::string &filename, const double time);

--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -390,10 +390,11 @@ void AtmosphereInput::init_scorpio_structures()
   scorpio::register_file(m_filename,scorpio::Read,iotype);
 
   // Some input files have the "time" dimension as non-unlimited. This messes up our
-  // scorpio interface. To avoid trouble, if a dim called 'time' is present we
-  // treat it as unlimited, even though it isn't.
-  if (scorpio::has_dim(m_filename,"time") and not scorpio::is_dim_unlimited(m_filename,"time")) {
-    scorpio::pretend_dim_is_unlimited(m_filename,"time");
+  // scorpio interface, which stores a pointer to a "time" dim to be used to read/write
+  // slices. This ptr is automatically inited to the unlimited dim in the file. If there is
+  // no unlim dim, this ptr remains inited.
+  if (not scorpio::has_time_dim(m_filename) and scorpio::has_dim(m_filename,"time")) {
+    scorpio::mark_dim_as_time(m_filename,"time");
   }
 
   // Check variables are in the input file

--- a/components/eamxx/src/share/io/scorpio_scm_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_scm_input.cpp
@@ -43,10 +43,11 @@ SCMInput (const std::string& filename,
   scorpio::register_file(m_filename,scorpio::Read,iotype);
 
   // Some input files have the "time" dimension as non-unlimited. This messes up our
-  // scorpio interface. To avoid trouble, if a dim called 'time' is present we
-  // treat it as unlimited, even though it isn't.
-  if (scorpio::has_dim(m_filename,"time") and not scorpio::is_dim_unlimited(m_filename,"time")) {
-    scorpio::pretend_dim_is_unlimited(m_filename,"time");
+  // scorpio interface, which stores a pointer to a "time" dim to be used to read/write
+  // slices. This ptr is automatically inited to the unlimited dim in the file. If there is
+  // no unlim dim, this ptr remains inited.
+  if (not scorpio::has_time_dim(m_filename) and scorpio::has_dim(m_filename,"time")) {
+    scorpio::mark_dim_as_time(m_filename,"time");
   }
 
   create_io_grid ();

--- a/components/eamxx/src/share/util/eamxx_data_interpolation.cpp
+++ b/components/eamxx/src/share/util/eamxx_data_interpolation.cpp
@@ -220,6 +220,12 @@ setup_time_database (const strvec_t& input_files,
 
     scorpio::register_file(fname,scorpio::Read);
 
+    if (not scorpio::has_time_dim(fname)) {
+      EKAT_REQUIRE_MSG (scorpio::has_dim(fname,"time"),
+        "[DataInterpolation] Error! Input file does not contain a 'time' dimension.\n"
+        " - file name: " + fname + "\n");
+      scorpio::mark_dim_as_time(fname,"time");
+    }
     auto file_times = scorpio::get_all_times(fname);
     EKAT_REQUIRE_MSG (file_times.size()>0,
         "[DataInterpolation] Error! Input file contains no time variable.\n"


### PR DESCRIPTION
* In DataInterpolation, make sure the "time" dim is always interpreted as a record dim, allowing to read time slices even if "time" is not unlimited.
* Change names to some scorpio interface functions (for consistency)

[BFB]

---

Fixes #7066 