### PR TITLE
Updates Frontier machine file

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1027,7 +1027,7 @@
   <machine MACH="frontier">
     <DESC>Frontier. AMD EPYC 7A53 64C nodes, 128 hwthreads, 512GB DDR4, 4 MI250X GPUs.</DESC>
     <NODENAME_REGEX>.*frontier.*</NODENAME_REGEX>
-    <OS>CNL</OS>
+    <OS>Linux</OS>
     <COMPILERS>craygnu-hipcc,craygnu-mphipcc,craycray-mphipcc,crayamd-mphipcc,craygnu,craycray,crayamd</COMPILERS>
     <MPILIBS>mpich</MPILIBS>
     <PROJECT>cli115</PROJECT>
@@ -1052,7 +1052,6 @@
       <arguments>
         <arg name="num_tasks"> -l -K -n {{ total_tasks }} -N {{ num_nodes }} </arg>
         <arg name="thread_count">-c $ENV{OMP_NUM_THREADS}</arg>
-        <arg name="gpus_per_node">$ENV{GPUS_PER_NODE}</arg>
         <arg name="ntasks_per_gpu">$ENV{NTASKS_PER_GPU}</arg>
         <arg name="gpu_bind">$ENV{GPU_BIND_ARGS}</arg>
       </arguments>
@@ -1106,6 +1105,8 @@
         <command name="switch">Core Core/24.00</command>
         <command name="switch">PrgEnv-cray PrgEnv-amd/8.3.3</command>
         <command name="switch">amd amd/5.4.0</command>
+        <command name="load">cray-libsci/22.12.1.1</command>
+
       </modules>
       <modules compiler="crayamd-mphipcc">
         <command name="load">craype-accel-amd-gfx90a</command>


### PR DESCRIPTION
* changes Frontier OS type from CNL to Linux
* removes --gpus-per-node srun argument
* loads cray-libsci/22.12.1.1 for AMD compiler

[BFB]
Fixes #7065
Fixes #7057