### PR TITLE
EAMxx: Adds ERS tests for some MAM4xx individual processes and a PE layout for Compy

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -1697,7 +1697,7 @@
   <grid name="a%ne4np4.pg.">
     <mach name="compy">
       <pes compset="any" pesize="any">
-        <comment>allactive: ne4pg2 grid, 1 nodes x MAX_MPITASKS_PER_NODE mpi x 1 omp @ root 0</comment>
+        <comment>allactive: ne4pg2 grid, 3 nodes x 1 omp @ root 0</comment>
         <ntasks>
           <ntasks_atm>96</ntasks_atm>
           <ntasks_lnd>96</ntasks_lnd>

--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -1694,6 +1694,23 @@
       </pes>
     </mach>
   </grid>
+  <grid name="a%ne4np4.pg.">
+    <mach name="compy">
+      <pes compset="any" pesize="any">
+        <comment>allactive: ne4pg2 grid, 1 nodes x MAX_MPITASKS_PER_NODE mpi x 1 omp @ root 0</comment>
+        <ntasks>
+          <ntasks_atm>96</ntasks_atm>
+          <ntasks_lnd>96</ntasks_lnd>
+          <ntasks_rof>96</ntasks_rof>
+          <ntasks_ice>96</ntasks_ice>
+          <ntasks_ocn>96</ntasks_ocn>
+          <ntasks_glc>96</ntasks_glc>
+          <ntasks_wav>96</ntasks_wav>
+          <ntasks_cpl>96</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
+  </grid>
   <grid name="a%ne4np4_l%ne4np4_oi%oQU240_r%r05_m%oQU240_g%null_w%null">
     <mach name="sandiatoss3">
       <pes compset="EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SGLC.+SWAV"  pesize="M">

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -783,7 +783,10 @@ _TESTS = {
             "SMS_D_Ln5.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.eamxx-mam4xx-aci",
             "SMS_D_Ln5.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.eamxx-mam4xx-wetscav",
             "SMS_D_Ln5.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.eamxx-mam4xx-drydep",
-            "SMS_D_Ln5.ne30pg2_oECv3.F2010-SCREAMv1-MPASSI.eamxx-mam4xx-remap_emiss_ne4_ne30"
+            "SMS_D_Ln5.ne30pg2_oECv3.F2010-SCREAMv1-MPASSI.eamxx-mam4xx-remap_emiss_ne4_ne30",
+            "ERS.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.eamxx-mam4xx-optics",
+            "ERS.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.eamxx-mam4xx-wetscav",
+            "ERS.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.eamxx-mam4xx-drydep"
         )
     },
 


### PR DESCRIPTION
ERS tests for MAM4xx's optics, wet scavenging, and dry 
deposition are added. A PE layout for ne4pg2 grid for Compy 
is added so that the test runs out-of-the-box on Compy.

[BFB]