### PR TITLE
CPL restart: dont attempt to read variables not present in file

### DIFF
--- a/driver-mct/shr/seq_io_read_mod.F90
+++ b/driver-mct/shr/seq_io_read_mod.F90
@@ -147,6 +147,11 @@ contains
        name1 = trim(dname)
     endif
     rcode = pio_inq_varid(pioid,trim(name1),varid)
+    if (rcode/=0) then
+       write(logunit,*) subname,'ERROR: variable=',trim(name1),&
+            ' not found in file=',trim(filename)
+       call shr_sys_abort()
+    endif
     rcode = pio_get_var(pioid,varid,idata)
 
   end subroutine seq_io_read_int1d
@@ -270,6 +275,11 @@ contains
     endif
 
     rcode = pio_inq_varid(pioid,trim(name1),varid)
+    if (rcode/=0) then
+       write(logunit,*) subname,'ERROR: variable=',trim(name1),&
+            ' not found in file=',trim(filename)
+       call shr_sys_abort()
+    endif
     rcode = pio_get_var(pioid,varid,rdata)
 
   end subroutine seq_io_read_r81d
@@ -315,6 +325,11 @@ contains
     endif
 
     rcode = pio_inq_varid(pioid,trim(name1),varid)
+    if (rcode/=0) then
+       write(logunit,*) subname,'ERROR: variable=',trim(name1),&
+            ' not found in file=',trim(filename)
+       call shr_sys_abort()
+    endif
     rcode = pio_get_var(pioid,varid,charvar)
     rdata = trim(charvar)
 


### PR DESCRIPTION
If variable doesn't exist in cpl restart file, print an error message and dont attempt to read the missing variable.

Fixes #6844 
[BFB]

---

Stealth feature #6696 added a new variable to CPL restart files.  If one uses current master to branch/restart from an E3SM V3 restart output, PIO will fail with a misleading (compiler dependent) error message, e.g.:  

```
0: PIO: FATAL ERROR: Aborting... An error occured,  The user buffer passed to PIO_get_var is smaller (total size of user buffer =  1  elements) than the size of the variable (total size of the variable =  256  elements). varid =  3 , file id =  16. 
```

this PR will abort if pio_inq_var failes instead of failing while attempting to read the missing variable, with error message:

```
(seq_io_read_r81d) ERROR: variable=seq_infodata_rmean_rmv_ice_runoff not found in file=decadal-production-run6-20240708.ne1024pg2_ne1024pg2.F20TR-SCREAMv1.pnetcdf.cpl.r.1995-06-03-00000.nc
```

For the variable associated with #6696, you can add it to a old CPL restart file via:
ncks -A -v seq_infodata_rmean_rmv_ice_runoff  new-cpl.r.nc  old-cpl.r.nc


