### PR TITLE
Fix PIO_iotype_adiosc compile error for MPAS-Ocean standalone

### DIFF
--- a/components/mpas-framework/src/framework/mpas_io_types.inc
+++ b/components/mpas-framework/src/framework/mpas_io_types.inc
@@ -16,6 +16,8 @@
                          MPAS_IO_ADIOS    = 7, &
                          MPAS_IO_ADIOSC   = 8
 
+  integer, parameter :: PIO_IOTYPE_ADIOSC= 6
+
    ! Field and attribute types
    integer, parameter :: MPAS_IO_REAL     =  9,  &
                          MPAS_IO_DOUBLE   = 10,  &


### PR DESCRIPTION
When compiling standalone, `PIO_iotype_adiosc` is undefined. I add the definition to an mpas-framework include file.

Fixes https://github.com/E3SM-Project/E3SM/issues/7077