### PR TITLE
For pm-cpu DEBUG builds, avoid invalid FPE exceptions in coupler sources

### DIFF
--- a/cime_config/machines/cmake_macros/gnu_pm-cpu.cmake
+++ b/cime_config/machines/cmake_macros/gnu_pm-cpu.cmake
@@ -4,12 +4,32 @@ if (COMP_NAME STREQUAL gptl)
 endif()
 string(APPEND CMAKE_C_FLAGS_RELEASE " -O2 -g")
 string(APPEND CMAKE_Fortran_FLAGS_RELEASE " -O2 -g")
+
+# For MCT coupler sources only, try resetting CMAKE_Fortran_FLAGS_DEBUG to avoid setting FPE invalid exceptions
+# https://github.com/E3SM-Project/E3SM/issues/7049
+if (COMP_NAME STREQUAL cpl)
+  set(CMAKE_Fortran_FLAGS_DEBUG " ") # set to blank and rebuild
+  if (CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64")
+    string(APPEND CMAKE_Fortran_FLAGS_DEBUG "-mcmodel=small")
+  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
+    string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -mcmodel=large")
+  else()
+    string(APPEND CMAKE_Fortran_FLAGS_DEBUG "-mcmodel=medium")
+  endif()
+  string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none")
+  if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+     string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -fallow-argument-mismatch")
+  endif()
+  #original string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -g -Wall -fbacktrace -fcheck=bounds,pointer -ffpe-trap=invalid,zero,overflow")
+  string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -g -Wall -fbacktrace -fcheck=bounds,pointer -ffpe-trap=zero,overflow")
+  if (compile_threaded)
+    string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -fopenmp")
+  endif()
+endif()
+
 set(MPICC "cc")
 set(MPICXX "CC")
 set(MPIFC "ftn")
 set(SCC "gcc")
 set(SCXX "g++")
 set(SFC "gfortran")
-
-#string(APPEND CMAKE_EXE_LINKER_FLAGS " -static-libstdc++") # was causing link error after Feb 18/19 maintenance
-

--- a/cime_config/machines/cmake_macros/intel_pm-cpu.cmake
+++ b/cime_config/machines/cmake_macros/intel_pm-cpu.cmake
@@ -25,7 +25,21 @@ string(APPEND CMAKE_CXX_FLAGS " -fp-model=precise") # and manually add precise
 #message(STATUS "ndk CXXFLAGS=${CXXFLAGS}")
 
 string(APPEND CMAKE_Fortran_FLAGS " -fp-model=consistent -fimf-use-svml")
-   #  string(APPEND FFLAGS " -qno-opt-dynamic-align")
- string(APPEND CMAKE_Fortran_FLAGS_RELEASE " -g -traceback")
+#  string(APPEND FFLAGS " -qno-opt-dynamic-align")
+string(APPEND CMAKE_Fortran_FLAGS_RELEASE " -g -traceback")
 string(APPEND CMAKE_Fortran_FLAGS " -DHAVE_ERF_INTRINSICS")
 string(APPEND CMAKE_CXX_FLAGS " -fp-model=consistent")
+
+
+# For MCT coupler sources only, try resetting CMAKE_Fortran_FLAGS_DEBUG to avoid setting FPE invalid exceptions
+# https://github.com/E3SM-Project/E3SM/issues/7049
+if (COMP_NAME STREQUAL cpl)
+  set(CMAKE_Fortran_FLAGS_DEBUG " ") # set to blank and rebuild
+  if (compile_threaded)
+    string(APPEND CMAKE_Fortran_FLAGS_DEBUG   " -qopenmp")
+  endif()
+  #original string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created -init=snan,arrays")
+  string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -O0 -g -check uninit -check bounds -check pointers -check noarg_temp_created -init=nosnan,arrays")
+  string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model source")
+endif()
+

--- a/cime_config/machines/cmake_macros/nvidia_pm-cpu.cmake
+++ b/cime_config/machines/cmake_macros/nvidia_pm-cpu.cmake
@@ -8,6 +8,19 @@ string(APPEND CMAKE_Fortran_FLAGS_RELEASE " -g")
 if (compile_threaded)
   string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_OPENMP=Off") # work-around for nvidia as kokkos is not passing "-mp" for threaded build
 endif()
+
+# For MCT coupler sources only, try resetting CMAKE_Fortran_FLAGS_DEBUG to avoid setting FPE invalid exceptions
+# https://github.com/E3SM-Project/E3SM/issues/7049
+if (COMP_NAME STREQUAL cpl)
+  set(CMAKE_Fortran_FLAGS_DEBUG " ") # set to blank and rebuild
+  string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -i4 -Mstack_arrays  -Mextend -byteswapio -Mflushz -Kieee -DHAVE_IEEE_ARITHMETIC -Mallocatable=03 -DNO_R16 -traceback")
+  #original string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -O0 -g -Ktrap=fp -Mbounds -Kieee")
+  string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -O0 -g -Mbounds -Kieee")
+  if (compile_threaded)
+    string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -mp")
+  endif()
+endif()
+
 set(MPICC "cc")
 set(MPICXX "CC")
 set(MPIFC "ftn")


### PR DESCRIPTION
As a temporary work-around for what looks like an issue with SW stack on the system, simply don't build a few coupler source files with floating-point exceptions that check for `invalid`.
Only impacts pm-cpu and only DEBUG builds.

Fixes https://github.com/E3SM-Project/E3SM/issues/7049

[BFB] 