### PR TITLE
EAMxx: Fixes dry deposition of gases removal from  constituent flux 

### DIFF
--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -985,7 +985,7 @@ void MAMMicrophysics::run_impl(const double dt) {
         // constituent_fluxes is kg/m2/s) (Following mimics Fortran code
         // behavior but we should look into it)
         for(int ispc = offset_aerosol; ispc < mam4::pcnst; ++ispc) {
-          constituent_fluxes(icol, ispc) = dflx[ispc - offset_aerosol];
+          constituent_fluxes(icol, ispc) -= dflx[ispc - offset_aerosol];
         }
       });  // parallel_for for the column loop
   Kokkos::fence();

--- a/components/eamxx/tests/single-process/mam/aero_microphys/output.yaml
+++ b/components/eamxx/tests/single-process/mam/aero_microphys/output.yaml
@@ -62,6 +62,7 @@ Fields:
       - num_c2
       - num_c3
       - num_c4
+      - constituent_fluxes
       # To save these fields make sure to turn on
       # OUTPUT_TRACER_FIELDS
       #- oxi_fields


### PR DESCRIPTION
Dry deposition of gasses was assigned to constituent fluxes view. Since dry deposition
is the flux removed, we should subtract it from the constituent flux view. 

**MAM4xx submodule update**:
MAM4xx submodule is updated to include a fix for uninitialized `dz`(layer thickness)
in the activation code (ndrop.hpp)

**Changes to the tests**:
Constituent flux was not part of the output from the standalone tests. It has been added now in output.yaml file for the microphysics test.

[NBFB] for MAM4xx