### PR TITLE
For pm-gpu: Only use new 4-node ne30 pelayout for the new coupled test

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -1853,8 +1853,8 @@
           <nthrds_cpl>8</nthrds_cpl>
         </nthrds>
       </pes>
-      <pes compset=".*2010_SCREAM_ELM.*" pesize="any">
-        <comment>"pm-gpu ne30 with WCYCLXX2010 4 nodes, 4x16"</comment>
+      <pes compset=".*2010_SCREAM_ELM.*MPASSI_MPASO.*" pesize="any">
+        <comment>"pm-gpu ne30 for fully coupled cases with ATM on GPU, MPAS on CPU -- WCYCLXX2010 4 nodes, 4x16"</comment>
         <ntasks>
           <ntasks_atm>-4</ntasks_atm>
           <ntasks_lnd>-4</ntasks_lnd>


### PR DESCRIPTION
In PR https://github.com/E3SM-Project/E3SM/pull/7061, I made mistake such that all ne30 cases would use 4 nodes.
Here making it so that only coupled cases will use 4 nodes, allowing other tests to behave as normal.

BFB, except NML diffs due to PE layout changes

