### PR TITLE
Minor updates to set SNICAR-AD model as the default

### DIFF
--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -655,7 +655,6 @@ this mask will have smb calculated over the entire global land surface
 <!--  ***********  Resolution independent:   ***********  -->
 <fsnowoptics >lnd/clm2/snicardata/snicar_optics_5bnd_mam_c160322.nc</fsnowoptics>
 <fsnowaging  >lnd/clm2/snicardata/snicar_drdt_bst_fit_60_c070416.nc</fsnowaging>
-<use_snicar_ad>.true.</use_snicar_ad>
 <snow_shape>sphere</snow_shape>
 <snicar_atm_type>default</snicar_atm_type>
 <use_dust_snow_internal_mixing>.false.</use_dust_snow_internal_mixing>

--- a/components/elm/src/main/elm_varctl.F90
+++ b/components/elm/src/main/elm_varctl.F90
@@ -373,7 +373,7 @@ module elm_varctl
   logical, public :: use_cndv            = .false.
   logical, public :: use_crop            = .false.
   logical, public :: use_snicar_frc      = .false.
-  logical, public :: use_snicar_ad       = .false.
+  logical, public :: use_snicar_ad       = .true.
   logical, public :: use_extrasnowlayers = .false.
   logical, public :: use_firn_percolation_and_compaction  = .false.
   logical, public :: use_vancouver       = .false.


### PR DESCRIPTION
Makes the SNICAR-AD model for snow albedo in ELM the default model by setting it to true
in the code, instead of turning it on via namelist.

[BFB]