### PR TITLE
Add polygonal tundra landunits, with subsidence and variable surface hydrology (NGEE Arctic IM1)

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -104,6 +104,16 @@
       <mask>reg</mask>
     </model_grid>
 
+    <model_grid alias="1x1_icycape" compset="DATM.+ELM">
+      <grid name="atm">1x1_icycape</grid>
+      <grid name="lnd">1x1_icycape</grid>
+      <grid name="ocnice">1x1_icycape</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>reg</mask>
+    </model_grid>
+
     <model_grid alias="1x1_smallvilleIA" compset="(DATM|SATM).+ELM">
       <grid name="atm">1x1_smallvilleIA</grid>
       <grid name="lnd">1x1_smallvilleIA</grid>
@@ -2692,6 +2702,13 @@
       <ny>1</ny>
       <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-brazil_navy.090715.nc</file>
       <desc>1x1 Brazil -- only valid for DATM/ELM compset</desc>
+    </domain>
+
+    <domain name="1x1_icycape">
+      <nx>1</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt_icycape_c240909.nc</file>
+      <desc>1x1 Icy Cape -- only valid for DATM/ELM compset</desc>
     </domain>
 
     <domain name="1x1_smallvilleIA">

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -99,7 +99,7 @@ _TESTS = {
             "ERS.ELM_USRDAT.I1850ELM.elm-usrdat",
             "ERS.r05_r05.IELM.elm-lnd_rof_2way",
             "ERS.r05_r05.IELM.elm-V2_ELM_MOSART_features",
-            "ERS.ELM_USRDAT.IELM.elm-surface_water_dynamics"
+            "ERS.ELM_USRDAT.IELM.elm-surface_water_dynamics",
             "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-polygonal_tundra"
             )
         },

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -100,6 +100,7 @@ _TESTS = {
             "ERS.r05_r05.IELM.elm-lnd_rof_2way",
             "ERS.r05_r05.IELM.elm-V2_ELM_MOSART_features",
             "ERS.ELM_USRDAT.IELM.elm-surface_water_dynamics"
+            "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-polygonal_tundra"
             )
         },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -52,6 +52,7 @@ _TESTS = {
             "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-snowveg_arctic",
             "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-usrpft_default_I1850CNPRDCTCBC",
             "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-usrpft_codetest_I1850CNPRDCTCBC",
+            "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-polygonal_tundra"
             )
         },
 
@@ -99,8 +100,7 @@ _TESTS = {
             "ERS.ELM_USRDAT.I1850ELM.elm-usrdat",
             "ERS.r05_r05.IELM.elm-lnd_rof_2way",
             "ERS.r05_r05.IELM.elm-V2_ELM_MOSART_features",
-            "ERS.ELM_USRDAT.IELM.elm-surface_water_dynamics",
-            "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-polygonal_tundra"
+            "ERS.ELM_USRDAT.IELM.elm-surface_water_dynamics"
             )
         },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -52,7 +52,7 @@ _TESTS = {
             "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-snowveg_arctic",
             "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-usrpft_default_I1850CNPRDCTCBC",
             "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-usrpft_codetest_I1850CNPRDCTCBC",
-            "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-polygonal_tundra"
+            "ERS.1x1pt_icycape.I1850CNPRDCTCBC.elm-polygonal_tundra"
             )
         },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -52,7 +52,7 @@ _TESTS = {
             "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-snowveg_arctic",
             "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-usrpft_default_I1850CNPRDCTCBC",
             "ERS.ELM_USRDAT.I1850CNPRDCTCBC.elm-usrpft_codetest_I1850CNPRDCTCBC",
-            "ERS.1x1pt_icycape.I1850CNPRDCTCBC.elm-polygonal_tundra"
+            "ERS.1x1_icycape.I1850GSWCNPRDCTCBC.elm-polygonal_tundra"
             )
         },
 

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -2250,5 +2250,6 @@ this mask will have smb calculated over the entire global land surface
 
 <!-- NGEE Arctic Options -->
 <use_polygonal_tundra>.false.</use_polygonal_tundra>;
+<use_arctic_init>.false.</use_arctic_init>;
 
 </namelist_defaults>

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -2248,4 +2248,7 @@ this mask will have smb calculated over the entire global land surface
 <use_fan use_fates=".true." >.false.</use_fan>
 <use_fan fan_mode='disable'>.false.</use_fan>
 
+<!-- NGEE Arctic Options -->
+<use_polygonal_tundra>.false.</use_polygonal_tundra>;
+
 </namelist_defaults>

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -396,7 +396,7 @@ lnd/clm2/surfdata_map/surfdata_5x5_amazon_simyr2000_c130927.nc</fsurdat>
 <fsurdat hgrid="1x1_brazil"    sim_year="2000" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_1x1_brazil_simyr2000_c130927.nc</fsurdat>
 <fsurdat hgrid="1x1_icycape"    sim_year="2000" use_crop=".false." >
-lnd/clm2/surfdata_map/surfdata_1x1_IcyCape_polygons_c240909.nc</fsurdat>
+lnd/clm2/surfdata_map/surfdata_1x1pt_IcyCape_polygons_c240909.nc</fsurdat>
 <fsurdat hgrid="1x1_tropicAtl" sim_year="2000" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_1x1_tropicAtl_simyr2000_c130927.nc</fsurdat>
 

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -395,6 +395,8 @@ lnd/clm2/surfdata_map/surfdata_1x1_smallvilleIA_mp50_simyr2000_c230905.nc</fsurd
 lnd/clm2/surfdata_map/surfdata_5x5_amazon_simyr2000_c130927.nc</fsurdat>
 <fsurdat hgrid="1x1_brazil"    sim_year="2000" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_1x1_brazil_simyr2000_c130927.nc</fsurdat>
+<fsurdat hgrid="1x1_icycape"    sim_year="2000" use_crop=".false." >
+lnd/clm2/surfdata_map/surfdata_1x1_IcyCape_polygons_c240909.nc</fsurdat>
 <fsurdat hgrid="1x1_tropicAtl" sim_year="2000" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_1x1_tropicAtl_simyr2000_c130927.nc</fsurdat>
 
@@ -433,6 +435,8 @@ lnd/clm2/surfdata_map/surfdata_antarcticax4v1pg2_simyr2010_c210131.nc</fsurdat>
 lnd/clm2/surfdata_map/surfdata_1x1_tropicAtl_simyr1850_c130927.nc</fsurdat>
 <fsurdat hgrid="1x1_brazil"    sim_year="1850" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_1x1_brazil_simyr1850_c140610.nc</fsurdat>
+<fsurdat hgrid="1x1_icycape"    sim_year="1850" use_crop=".false." >
+lnd/clm2/surfdata_map/surfdata_1x1pt_IcyCape_polygons_c240909.nc</fsurdat>
 
 
 <fsurdat hgrid="ne30np4"      sim_year="1850" use_crop=".false." >

--- a/components/elm/bld/namelist_files/namelist_defaults_tools.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults_tools.xml
@@ -101,6 +101,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- Single-point / Regional grids -->
 <scripgriddata hgrid="1x1_asphaltjungleNJ" lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_camdenNJ_nomask_c110308.nc</scripgriddata>
 <scripgriddata hgrid="1x1_brazil"          lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_brazil_nomask_c110308.nc</scripgriddata>
+<scripgriddata hgrid="1x1_icycape"         lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_icycape_nomask.nc</scripgriddata>
 <scripgriddata hgrid="1x1_camdenNJ"        lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_camdenNJ_nomask_c110308.nc</scripgriddata>
 <scripgriddata hgrid="1x1_mexicocityMEX"   lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_mexicocityMEX_nomask_c110308.nc</scripgriddata>
 <scripgriddata hgrid="1x1_numaIA"          lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_numaIA_nomask_c110308.nc</scripgriddata>

--- a/components/elm/bld/namelist_files/namelist_defaults_tools.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults_tools.xml
@@ -101,7 +101,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- Single-point / Regional grids -->
 <scripgriddata hgrid="1x1_asphaltjungleNJ" lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_camdenNJ_nomask_c110308.nc</scripgriddata>
 <scripgriddata hgrid="1x1_brazil"          lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_brazil_nomask_c110308.nc</scripgriddata>
-<scripgriddata hgrid="1x1_icycape"         lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_icycape_nomask.nc</scripgriddata>
 <scripgriddata hgrid="1x1_camdenNJ"        lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_camdenNJ_nomask_c110308.nc</scripgriddata>
 <scripgriddata hgrid="1x1_mexicocityMEX"   lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_mexicocityMEX_nomask_c110308.nc</scripgriddata>
 <scripgriddata hgrid="1x1_numaIA"          lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_numaIA_nomask_c110308.nc</scripgriddata>

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -2176,6 +2176,16 @@ default: 0
 </entry>
 
 <!-- ========================================================================================  -->
+<!-- NGEE Arctic Options                                                                       -->
+<!-- ========================================================================================  -->
+
+<entry id="use_arctic_init" type="logical" category="default_settings"
+	group="elm_inparm" value=".false.">
+Cold-start initialization conditions in tundra start saturated and frozen.
+<default>Default: .false.</default>
+</entry>
+
+<!-- ========================================================================================  -->
 <!-- Namelist options for soil erosion model                                                   -->
 <!-- ========================================================================================  -->
 

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -2237,4 +2237,14 @@ not be called.
 <default>Default: 0</default>
 </entry>
 
+<!-- ========================================================================================  -->
+<!-- NGEE Arctic Options                                                                       -->
+<!-- ========================================================================================  -->
+
+<entry id="use_polygonal_tundra" type="logical" category="default_settings"
+	group="elm_inparm" value=".false.">
+Use polygonal tundra parameterizations for ice wedge polygon microtopography and inindation fraction
+<default>Default: .false.</default>
+</entry>
+
 </namelist_definition>

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -1483,7 +1483,7 @@ CLM run type.
 <entry id="res" type="char*30" category="default_settings"
        group="default_settings"
        valid_values=
-"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_tropicAtl,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,ne4np4,ne4np4.pg2,ne11np4,ne16np4,ne30np4,ne30np4.pg2,ne60np4,ne120np4,ne120np4.pg2,ne240np4,ne256np4,ne256np4.pg2,ne512np4.pg2,ne1024np4,ne1024np4.pg2,1km-merge-10min,ne0np4_CAx32v1.pg2,ne0np4_arm_x8v3_lowcon,ne0np4_conus_x4v1_lowcon,ne0np4_enax4v1,ne0np4_twpx4v1,r2,r05,r0125,NLDAS,ne0np4_northamericax4v1.pg2,ne0np4_arcticx4v1.pg2,r025">
+"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_tropicAtl,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_icycape,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,ne4np4,ne4np4.pg2,ne11np4,ne16np4,ne30np4,ne30np4.pg2,ne60np4,ne120np4,ne120np4.pg2,ne240np4,ne256np4,ne256np4.pg2,ne512np4.pg2,ne1024np4,ne1024np4.pg2,1km-merge-10min,ne0np4_CAx32v1.pg2,ne0np4_arm_x8v3_lowcon,ne0np4_conus_x4v1_lowcon,ne0np4_enax4v1,ne0np4_twpx4v1,r2,r05,r0125,NLDAS,ne0np4_northamericax4v1.pg2,ne0np4_arcticx4v1.pg2,r025">
 Horizontal resolutions
 Note: 0.1x0.1, 0.5x0.5, 5x5min, 10x10min, 3x3min and 0.33x0.33 are only used for CLM tools
 </entry>

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/shell_commands
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/shell_commands
@@ -1,0 +1,10 @@
+./xmlchange LND_DOMAIN_FILE=domain.lnd.1x1pt_icycape_c240909.nc
+./xmlchange ATM_DOMAIN_FILE=domain.lnd.1x1pt_icycape_c240909.nc
+./xmlchange LND_DOMAIN_PATH="\$DIN_LOC_ROOT/share/domains/domain.clm"
+./xmlchange ATM_DOMAIN_PATH="\$DIN_LOC_ROOT/share/domains/domain.clm"
+./xmlchange DATM_MODE=CLM1PT
+./xmlchange DATM_CLMNCEP_YR_START=2000
+./xmlchange DATM_CLMNCEP_YR_END=2000
+./xmlchange ELM_USRDAT_NAME=ELMERA5
+./xmlchange NTASKS=1
+./xmlchange NTHRDS=1

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/shell_commands
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/shell_commands
@@ -2,9 +2,8 @@
 ./xmlchange ATM_DOMAIN_FILE=domain.lnd.1x1pt_icycape_c240909.nc
 ./xmlchange LND_DOMAIN_PATH="\$DIN_LOC_ROOT/share/domains/domain.clm"
 ./xmlchange ATM_DOMAIN_PATH="\$DIN_LOC_ROOT/share/domains/domain.clm"
-./xmlchange DATM_MODE=CLM1PT
+./xmlchange DATM_MODE=CLMGSWP3v1
 ./xmlchange DATM_CLMNCEP_YR_START=2000
 ./xmlchange DATM_CLMNCEP_YR_END=2000
-./xmlchange ELM_USRDAT_NAME=ELMERA5
 ./xmlchange NTASKS=1
 ./xmlchange NTHRDS=1

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/shell_commands
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/shell_commands
@@ -1,7 +1,3 @@
-./xmlchange LND_DOMAIN_FILE=domain.lnd.1x1pt_icycape_c240909.nc
-./xmlchange ATM_DOMAIN_FILE=domain.lnd.1x1pt_icycape_c240909.nc
-./xmlchange LND_DOMAIN_PATH="\$DIN_LOC_ROOT/share/domains/domain.clm"
-./xmlchange ATM_DOMAIN_PATH="\$DIN_LOC_ROOT/share/domains/domain.clm"
 ./xmlchange DATM_MODE=CLMGSWP3v1
 ./xmlchange DATM_CLMNCEP_YR_START=2000
 ./xmlchange DATM_CLMNCEP_YR_END=2000

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/shell_commands
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/shell_commands
@@ -1,5 +1,4 @@
-./xmlchange DATM_MODE=CLMGSWP3v1
-./xmlchange DATM_CLMNCEP_YR_START=2000
-./xmlchange DATM_CLMNCEP_YR_END=2000
+./xmlchange DATM_CLMNCEP_YR_START=1901
+./xmlchange DATM_CLMNCEP_YR_END=1901
 ./xmlchange NTASKS=1
 ./xmlchange NTHRDS=1

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/user_nl_elm
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/user_nl_elm
@@ -1,1 +1,2 @@
+use_polygonal_tundra = .true.
 fsurdat = '$DIN_LOC_ROOT/lnd/clm2/surfdata_map/surfdata_1x1pt_IcyCape_polygons_c240909.nc'

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/user_nl_elm
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/user_nl_elm
@@ -1,2 +1,3 @@
 use_polygonal_tundra = .true.
+use_arctic_init = .true.
 fsurdat = '$DIN_LOC_ROOT/lnd/clm2/surfdata_map/surfdata_1x1pt_IcyCape_polygons_c240909.nc'

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/user_nl_elm
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/user_nl_elm
@@ -1,0 +1,1 @@
+fsurdat = '$DIN_LOC_ROOT/lnd/clm2/surfdata_map/surfdata_1x1pt_IcyCape_polygons_c240909.nc'

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -188,18 +188,21 @@ contains
          ! subsidence is integral of melt profile:
          subsidence(c) = subsidence(c) + sum(melt_profile)
 
+         ! limit subsidence to 0.4 m
+         subsidence(c) = min(0.4_r8, subsidence(c))
+
          ! update ice wedge polygon microtopographic parameters if in polygonal ground
-         ! TODO: need to retrieve landunit this column is on.
-         if (lun_pp%ispolygon(c)) then
-            if (lun_pp%polygontype(c) .eq. ilowcenpoly) then
+         !rf - min/max logic may be redunant w/ subsidence limiter above
+         if (lun_pp%ispolygon(col_pp%landunit(c))) then
+            if (lun_pp%polygontype(col_pp%landunit(c)) .eq. ilowcenpoly) then
                rmax(c) = 0.4_r8
                vexc(c) = 0.2_r8
-               ddep(c) = 0.15_r8 ! TODO - update based on subsidence calcs.
-            elseif (lun_pp%polygontype(c) .eq. iflatcenpoly) then
-               rmax(c) = 0.1_r8  ! TODO - update based on subsidence calcs.
-               vexc(c) = 0.05_r8 ! TODO - update based on subsidence calcs.
-               ddep(c) = 0.01_r8 ! TODO - update based on subsidence calcs.
-            elseif (lun_pp%polygontype(c) .eq. ihighcenpoly) then
+               ddep(c) = min(0.05_r8, max(0.15_r8 - 0.25_r8*subsidence(c), 0.15_r8))
+            elseif (lun_pp%polygontype(col_pp%landunit(c)) .eq. iflatcenpoly) then
+               rmax(c) = min(0.1_r8, max(0.4_r8, 0.1_r8 + 0.75_r8*subsidence(c)))
+               vexc(c) = min(0.05_r8, max(0.2_r8, 0.05_r8 + 0.375_r8*subsidence(c)))
+               ddep(c) = min(0.01_r8, max(0.05_r8, 0.01_r8 + 0.1_r8*subsidence(c)))
+            elseif (lun_pp%polygontype(col_pp%landunit(c)) .eq. ihighcenpoly) then
                rmax(c) = 0.4_r8
                vexc(c) = 0.2_r8
                ddep(c) = 0.05_r8

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -184,7 +184,7 @@ contains
          ! update subsidence based on change in ALT
          ! melt_profile stores the amount of excess_ice
          ! melted in this timestep.
-         do j = nlevgrnd-1,1,-1
+         do j = 1,nlevgrnd
             if (j < k_frz) then
                melt_profile(j) = 0.0_r8
             else if (j .eq. k_frz) then

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -193,7 +193,6 @@ contains
            melt_profile(:) = 0._r8
 
            do j = nlevgrnd,1,-1 ! note, this will go from bottom to top
-              !write(iulog,*) "processing level j,",j,k_frz,excess_ice(c,j)
               if (j .gt. k_frz + 1) then ! all layers below k_frz + 1 remain frozen
                 melt_profile(j) = 0.0_r8
               else if (j .eq. k_frz + 1) then ! first layer below the 'thawed' layer

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -71,9 +71,6 @@ contains
     real(r8), dimension(nlevgrnd) :: melt_profile       ! profile of melted excess ice
     !-----------------------------------------------------------------------
 
-    ! RF NOTE: use of 1989 ALT in these parameterizations is somewhat of a placeholder used to compare against
-    ! ATS runs for NGEE Arctic Phase 3. It should ultimately be replaced by a more physically based threshold
-    ! later on.
     associate(                                                                &
          t_soisno             =>    col_es%t_soisno        ,    & ! Input:   [real(r8) (:,:) ]  soil temperature (Kelvin)  (-nlevsno+1:nlevgrnd)
 
@@ -175,14 +172,14 @@ contains
             endif
          endif
 
-         ! special loop for if year = 1989, see above note regarding
-         ! replacing with more physically based mechanism.
-         if (year .eq. 1989) then
-            altmax_1989(c) = altmax(c)
-            altmax_1989_indx(c) = altmax_indx(c)
-         endif
-
          if (use_polygonal_tundra) then
+            ! special case for year = 1989. For now it is the assumed baseline year for 
+            ! changes in polygonal ground
+            if (year .eq. 1989) then
+               altmax_1989(c) = altmax(c)
+               altmax_1989_indx(c) = altmax_indx(c)
+            endif
+
            ! update subsidence based on change in ALT
            ! melt_profile stores the amount of excess_ice
            ! melted in this timestep.
@@ -241,10 +238,6 @@ contains
            subsidence(c) = min(0.4_r8, subsidence(c))
 
            ! update ice wedge polygon microtopographic parameters if in polygonal ground
-           !rpf - min/max logic may be redunant w/ subsidence limiter above
-           !rpf - TODO: many of these (particularly the invariant ones) should be
-           ! moved to data_types/ColumnDataType.F90 to avoid the highcenpoly elseif condition
-           ! each time step.
            if (lun_pp%ispolygon(col_pp%landunit(c))) then
              if (lun_pp%polygontype(col_pp%landunit(c)) .eq. ilowcenpoly) then
                rmax(c) = 0.4_r8

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -189,15 +189,22 @@ contains
                melt_profile(j) = 0.0_r8
             else if (j .eq. k_frz) then
                melt_profile(j) = excess_ice(c,j) + ((z2-alt(c))/(z2-z1))*excess_ice(c,j+1) ! TODO: check indices here!!
+               ! remove melted excess ice:
+               excess_ice(c,j) = 0._r8
+               excess_ice(c,j+1) = excess_ice(c,j+1)*(1._r8 - min(1._r8,(z2-alt(c))/(z2-z1)))
             else
                melt_profile(j) = excess_ice(c,j)
+               ! remove melted excess ice
+               excess_ice(c,j) = 0._r8
             end if
             ! calculate subsidence at this layer:
             melt_profile(j) = melt_profile(j) * dzsoi(j)
          end do
 
          ! subsidence is integral of melt profile:
-         subsidence(c) = subsidence(c) + sum(melt_profile)
+         if ((year .ge. 1989) .and. (altmax_ever(c) .ge. altmax_1989(c))) then
+            subsidence(c) = subsidence(c) + sum(melt_profile)
+         end if
 
          ! limit subsidence to 0.4 m
          subsidence(c) = min(0.4_r8, subsidence(c))

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -88,10 +88,10 @@ contains
          altmax_1989_indx     =>    canopystate_vars%altmax_1989_indx_col,      & ! Output:  [integer  (:)   ]  index of maximum ALT in 1989
          altmax_ever_indx     =>    canopystate_vars%altmax_ever_indx_col,      & ! Output:  [integer  (:)   ]  maximum thaw depth since initialization
          excess_ice           =>    col_ws%excess_ice                    ,      & ! Input:   [real(r8) (:,:) ]  depth variable excess ice content in soil column (-)
-         rmax                 =>    col_pp%iwp_microrel                  ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon microtopographic relief (m)
-         vexc                 =>    col_pp%iwp_exclvol                   ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon excluded volume (m)
-         ddep                 =>    col_pp%iwp_ddep                      ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon depression depth (m)
-         subsidence           =>    col_pp%iwp_subsidence                       & ! Input/output:[real(r8) (:)   ]  ice wedge polygon subsidence (m)
+         rmax                 =>    col_ws%iwp_microrel                  ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon microtopographic relief (m)
+         vexc                 =>    col_ws%iwp_exclvol                   ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon excluded volume (m)
+         ddep                 =>    col_ws%iwp_ddep                      ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon depression depth (m)
+         subsidence           =>    col_ws%iwp_subsidence                       & ! Input/output:[real(r8) (:)   ]  ice wedge polygon subsidence (m)
          )
 
       ! on a set annual timestep, update annual maxima

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -71,16 +71,21 @@ contains
     real(r8), dimension(nlevgrnd) :: melt_profile ! profile of melted excess ice
     !-----------------------------------------------------------------------
 
+    ! RF NOTE: use of 1989 ALT in these parameterizations is somewhat of a placeholder used to compare against
+    ! ATS runs for NGEE Arctic Phase 3. It should ultimately be replaced by a more physically based threshold
+    ! later on.
     associate(                                                                &
          t_soisno             =>    col_es%t_soisno        ,    & ! Input:   [real(r8) (:,:) ]  soil temperature (Kelvin)  (-nlevsno+1:nlevgrnd)
 
          alt                  =>    canopystate_vars%alt_col             ,      & ! Output:  [real(r8) (:)   ]  current depth of thaw
          altmax               =>    canopystate_vars%altmax_col          ,      & ! Output:  [real(r8) (:)   ]  maximum annual depth of thaw
          altmax_lastyear      =>    canopystate_vars%altmax_lastyear_col ,      & ! Output:  [real(r8) (:)   ]  prior year maximum annual depth of thaw
+         altmax_1989          =>    canopystate_vars%altmax_1989_col     ,      & ! Output:  [real(r8) (:)   ]  maximum ALT in 1989
          altmax_ever          =>    canopystate_vars%altmax_ever_col     ,      & ! Output:  [real(r8) (:)   ]  maximum thaw depth since initialization
          alt_indx             =>    canopystate_vars%alt_indx_col        ,      & ! Output:  [integer  (:)   ]  current depth of thaw
          altmax_indx          =>    canopystate_vars%altmax_indx_col     ,      & ! Output:  [integer  (:)   ]  maximum annual depth of thaw
          altmax_lastyear_indx =>    canopystate_vars%altmax_lastyear_indx_col , & ! Output:  [integer  (:)   ]  prior year maximum annual depth of thaw
+         altmax_1989_indx     =>    canopystate_vars%altmax_1989_indx_col,      & ! Output:  [integer  (:)   ]  index of maximum ALT in 1989
          altmax_ever_indx     =>    canopystate_vars%altmax_ever_indx_col,      & ! Output:  [integer  (:)   ]  maximum thaw depth since initialization
          excess_ice           =>    col_ws%excess_ice                    ,      & ! Input:   [real(r8) (:,:) ]  depth variable excess ice content in soil column (-)
          rmax                 =>    col_pp%iwp_microrel                  ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon microtopographic relief (m)
@@ -154,7 +159,6 @@ contains
             endif
          endif
 
-
          ! if appropriate, update maximum annual active layer thickness
          if (alt(c) > altmax(c)) then
             altmax(c) = alt(c)
@@ -168,6 +172,13 @@ contains
                 altmax_ever(c) = 0._r8
                 altmax_ever_indx(c) = 0
             endif
+         endif
+
+         ! special loop for if year = 1989, see above note regarding
+         ! replacing with more physically based mechanism.
+         if (year .eq. 1989) then
+            altmax_1989(c) = altmax(c)
+            altmax_1989_indx(c) = altmax_indx(c)
          endif
 
          ! update subsidence based on change in ALT

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -215,11 +215,11 @@ contains
             if (lun_pp%polygontype(col_pp%landunit(c)) .eq. ilowcenpoly) then
                rmax(c) = 0.4_r8
                vexc(c) = 0.2_r8
-               ddep(c) = min(0.05_r8, max(0.15_r8 - 0.25_r8*subsidence(c), 0.15_r8))
+               ddep(c) = max(0.05_r8, 0.15_r8 - 0.25_r8*subsidence(c))
             elseif (lun_pp%polygontype(col_pp%landunit(c)) .eq. iflatcenpoly) then
-               rmax(c) = min(0.1_r8, max(0.4_r8, 0.1_r8 + 0.75_r8*subsidence(c)))
-               vexc(c) = min(0.05_r8, max(0.2_r8, 0.05_r8 + 0.375_r8*subsidence(c)))
-               ddep(c) = min(0.01_r8, max(0.05_r8, 0.01_r8 + 0.1_r8*subsidence(c)))
+               rmax(c) = min(0.4_r8, 0.1_r8 + 0.75_r8*subsidence(c))
+               vexc(c) = min(0.2_r8, 0.05_r8 + 0.375_r8*subsidence(c))
+               ddep(c) = min(0.05_r8, 0.01_r8 + 0.1_r8*subsidence(c))
             elseif (lun_pp%polygontype(col_pp%landunit(c)) .eq. ihighcenpoly) then
                rmax(c) = 0.4_r8
                vexc(c) = 0.2_r8

--- a/components/elm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/elm/src/biogeophys/CanopyHydrologyMod.F90
@@ -795,9 +795,9 @@ contains
      !
      ! !LOCAL VARIABLES:
      integer :: c,f,l,k          ! indices
-     real(r8):: d,fd,dfdd      ! temporary variable for frac_h2oscs iteration
-     real(r8):: sigma          ! microtopography pdf sigma in mm
-     real(r8):: swc            ! surface water content in m
+     real(r8):: d,fd,dfdd        ! temporary variable for frac_h2oscs iteration
+     real(r8):: sigma            ! microtopography pdf sigma in mm
+     real(r8):: swc              ! surface water content in m
      real(r8):: min_h2osfc
      !-----------------------------------------------------------------------
 
@@ -805,8 +805,8 @@ contains
           micro_sigma  => col_pp%micro_sigma  , & ! Input:  [real(r8) (:)   ] microtopography pdf sigma (m)
 
           iwp_microrel => col_pp%iwp_microrel , & ! Input:  [real(r8) (:)   ] ice wedge polygon microtopographic relief (m)
-          iwp_exclvol  => col_pp%iwp_exclvol  , & ! Input:  [real(r8) (:)   ] microtopography pdf sigma (m)
-          iwp_ddep     => col_pp%iwp_ddep     , & ! Input:  [real(r8) (:)   ] microtopography pdf sigma (m)
+          iwp_exclvol  => col_pp%iwp_exclvol  , & ! Input:  [real(r8) (:)   ] ice wedge polygon excluded volume (m)
+          iwp_ddep     => col_pp%iwp_ddep     , & ! Input:  [real(r8) (:)   ] ice wedge polygon depression depth (m)
 
           h2osno       => col_ws%h2osno       , & ! Input:  [real(r8) (:)   ] snow water (mm H2O)
 

--- a/components/elm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/elm/src/biogeophys/CanopyHydrologyMod.F90
@@ -804,9 +804,9 @@ contains
      associate(                                 &
           micro_sigma  => col_pp%micro_sigma  , & ! Input:  [real(r8) (:)   ] microtopography pdf sigma (m)
 
-          iwp_microrel => col_pp%iwp_microrel , & ! Input:  [real(r8) (:)   ] ice wedge polygon microtopographic relief (m)
-          iwp_exclvol  => col_pp%iwp_exclvol  , & ! Input:  [real(r8) (:)   ] ice wedge polygon excluded volume (m)
-          iwp_ddep     => col_pp%iwp_ddep     , & ! Input:  [real(r8) (:)   ] ice wedge polygon depression depth (m)
+          iwp_microrel => col_ws%iwp_microrel , & ! Input:  [real(r8) (:)   ] ice wedge polygon microtopographic relief (m)
+          iwp_exclvol  => col_ws%iwp_exclvol  , & ! Input:  [real(r8) (:)   ] ice wedge polygon excluded volume (m)
+          iwp_ddep     => col_ws%iwp_ddep     , & ! Input:  [real(r8) (:)   ] ice wedge polygon depression depth (m)
 
           h2osno       => col_ws%h2osno       , & ! Input:  [real(r8) (:)   ] snow water (mm H2O)
 

--- a/components/elm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/elm/src/biogeophys/CanopyHydrologyMod.F90
@@ -800,17 +800,18 @@ contains
      real(r8):: min_h2osfc
      !-----------------------------------------------------------------------
 
-     associate(                                 & 
-          micro_sigma  => col_pp%micro_sigma  , & ! Input:  [real(r8) (:)   ] microtopography pdf sigma (m)                     
+     associate(                                 &
+          micro_sigma  => col_pp%micro_sigma  , & ! Input:  [real(r8) (:)   ] microtopography pdf sigma (m)
 
-          h2osno       => col_ws%h2osno       , & ! Input:  [real(r8) (:)   ] snow water (mm H2O)                               
-          
-          h2osoi_liq   => col_ws%h2osoi_liq   , & ! Output: [real(r8) (:,:) ] liquid water (col,lyr) [kg/m2]                  
-          h2osfc       => col_ws%h2osfc       , & ! Output: [real(r8) (:)   ] surface water (mm)                                
-          frac_sno     => col_ws%frac_sno     , & ! Output: [real(r8) (:)   ] fraction of ground covered by snow (0 to 1)       
-          frac_sno_eff => col_ws%frac_sno_eff , & ! Output: [real(r8) (:)   ] eff. fraction of ground covered by snow (0 to 1)  
-          frac_h2osfc  => col_ws%frac_h2osfc  , & ! Output: [real(r8) (:)   ] col fractional area with surface water greater than zero 
-          frac_h2osfc_act => col_ws%frac_h2osfc_act & ! Output: [real(r8) (:)   ] col fractional area with surface water greater than zero
+          h2osno       => col_ws%h2osno            , & ! Input:  [real(r8) (:)   ] snow water (mm H2O)
+          excess_ice   => col_ws%excess_ice        , & ! Input:  [real(r8) (:,:)   ] excess ground ice [kg/m2]
+
+          h2osoi_liq   => col_ws%h2osoi_liq        , & ! Output: [real(r8) (:,:) ] liquid water (col,lyr) [kg/m2]
+          h2osfc       => col_ws%h2osfc            , & ! Output: [real(r8) (:)   ] surface water (mm)
+          frac_sno     => col_ws%frac_sno          , & ! Output: [real(r8) (:)   ] fraction of ground covered by snow (0 to 1)
+          frac_sno_eff => col_ws%frac_sno_eff      , & ! Output: [real(r8) (:)   ] eff. fraction of ground covered by snow (0 to 1)
+          frac_h2osfc  => col_ws%frac_h2osfc       , & ! Output: [real(r8) (:)   ] col fractional area with surface water greater than zero
+          frac_h2osfc_act => col_ws%frac_h2osfc_act  & ! Output: [real(r8) (:)   ] col fractional area with surface water greater than zero
           )
 
        ! arbitrary lower limit on h2osfc for safer numerics...

--- a/components/elm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/elm/src/biogeophys/CanopyHydrologyMod.F90
@@ -863,18 +863,18 @@ contains
                                      + (2_r8/iwp_microrel(c)) * (2_r8*iwp_microrel(c) - 3_r8*iwp_exclvol(c)) * (d/iwp_microrel(c))
 
                 else ! calculate water depth and inudation fraction if column is non-polygonal
-                    d=0.0
-                    sigma=1.0e3 * micro_sigma(c) ! convert to mm
+                    d=0.0_r8
+                    sigma=1.0e3_r8 * micro_sigma(c) ! convert to mm
                     do k=1,10
-                       fd = 0.5*d*(1.0_r8+erf(d/(sigma*sqrt(2.0)))) &
-                            +sigma/sqrt(2.0*shr_const_pi)*exp(-d**2/(2.0*sigma**2)) &
+                       fd = 0.5_r8*d*(1.0_r8+erf(d/(sigma*sqrt(2.0_r8)))) &
+                            +sigma/sqrt(2.0_r8*shr_const_pi)*exp(-d**2_r8/(2.0_r8*sigma**2_r8)) &
                             -h2osfc(c)
-                       dfdd = 0.5*(1.0_r8+erf(d/(sigma*sqrt(2.0))))
+                       dfdd = 0.5_r8*(1.0_r8+erf(d/(sigma*sqrt(2.0_r8))))
 
                        d = d - fd/dfdd
                     enddo
                     !--  update the submerged areal fraction using the new d value
-                    frac_h2osfc(c) = 0.5*(1.0_r8+erf(d/(sigma*sqrt(2.0))))
+                    frac_h2osfc(c) = 0.5_r8*(1.0_r8+erf(d/(sigma*sqrt(2.0_r8))))
                 endif ! end if polygonal test
              else ! if h2osfc(c) <= min_h2osfc
                 frac_h2osfc(c) = 0._r8

--- a/components/elm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/elm/src/biogeophys/CanopyHydrologyMod.F90
@@ -863,18 +863,18 @@ contains
                                      + (2_r8/iwp_microrel(c)) * (2_r8*iwp_microrel(c) - 3_r8*iwp_exclvol(c)) * (d/iwp_microrel(c))
 
                 else ! calculate water depth and inudation fraction if column is non-polygonal
-                    d=0.0_r8
+                    d=0.0
                     sigma=1.0e3_r8 * micro_sigma(c) ! convert to mm
                     do k=1,10
-                       fd = 0.5_r8*d*(1.0_r8+erf(d/(sigma*sqrt(2.0_r8)))) &
-                            +sigma/sqrt(2.0_r8*shr_const_pi)*exp(-d**2_r8/(2.0_r8*sigma**2_r8)) &
+                       fd = 0.5*d*(1.0_r8+erf(d/(sigma*sqrt(2.0)))) &
+                            +sigma/sqrt(2.0*shr_const_pi)*exp(-d**2/(2.0*sigma**2)) &
                             -h2osfc(c)
-                       dfdd = 0.5_r8*(1.0_r8+erf(d/(sigma*sqrt(2.0_r8))))
+                       dfdd = 0.5*(1.0_r8+erf(d/(sigma*sqrt(2.0))))
 
                        d = d - fd/dfdd
                     enddo
                     !--  update the submerged areal fraction using the new d value
-                    frac_h2osfc(c) = 0.5_r8*(1.0_r8+erf(d/(sigma*sqrt(2.0_r8))))
+                    frac_h2osfc(c) = 0.5*(1.0_r8+erf(d/(sigma*sqrt(2.0))))
                 endif ! end if polygonal test
              else ! if h2osfc(c) <= min_h2osfc
                 frac_h2osfc(c) = 0._r8

--- a/components/elm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/elm/src/biogeophys/CanopyHydrologyMod.F90
@@ -783,7 +783,7 @@ contains
      ! !USES:
      use shr_const_mod   , only : shr_const_pi
      use shr_spfn_mod    , only : erf => shr_spfn_erf
-     use landunit_varcon , only : istsoil, istcrop, ispolygon
+     use landunit_varcon , only : istsoil, istcrop
      !
      ! !ARGUMENTS:
      type(bounds_type)     , intent(in)           :: bounds           
@@ -839,25 +839,25 @@ contains
 
                 if (lun_pp%ispolygon(l)) then
                     ! calculate water depth and inundation fraction if column is polygonal
-                    swc = h2osfc(c)/1000 ! convert to m
+                    swc = h2osfc(c)/1000_r8 ! convert to m
 
-                    if (swc > iwp_microrel - iwp_exclvol) then
-                        d = swc + iwp_exclvol
+                    if (swc > iwp_microrel(c) - iwp_exclvol(c)) then
+                        d = swc + iwp_exclvol(c)
                     else
                         d = 0.0
                         do k=1,10
-                            fd = (2_r8*iwp_exclvol - iwp_microrel) * (d/iwp_microrel)**3_r8 &
-                                 + (2_r8*iwp_microrel - 3_r8*iwp_exclvol) * (d/iwp_microrel)**2_r8 &
+                            fd = (2_r8*iwp_exclvol(c) - iwp_microrel(c)) * (d/iwp_microrel(c))**3_r8 &
+                                 + (2_r8*iwp_microrel(c) - 3_r8*iwp_exclvol(c)) * (d/iwp_microrel(c))**2_r8 &
                                  - swc
-                            dfdd = (3_r8/iwp_microrel) * (2_r8*iwp_exclvol - iwp_microrel) * (d/iwp_microrel)**2_r8 &
-                                   + (2_r8/iwp_microrel) * (2_r8*iwp_microrel - 3_r8*iwp_exclvol) * (d/iwp_microrel)
+                            dfdd = (3_r8/iwp_microrel(c)) * (2_r8*iwp_exclvol(c) - iwp_microrel(c)) * (d/iwp_microrel(c))**2_r8 &
+                                   + (2_r8/iwp_microrel(c)) * (2_r8*iwp_microrel(c) - 3_r8*iwp_exclvol(c)) * (d/iwp_microrel(c))
                             d = d - fd/dfdd
                         enddo
                     endif
 
                     !--  update the submerged areal fraction using the new d value
-                    frac_h2osfc(c) = (3_r8/iwp_microrel) * (2_r8*iwp_exclvol - iwp_microrel) * (d/iwp_microrel)**2_r8 &
-                                     + (2_r8/iwp_microrel) * (2_r8*iwp_microrel - 3_r8*iwp_exclvol) * (d/iwp_microrel)
+                    frac_h2osfc(c) = (3_r8/iwp_microrel(c)) * (2_r8*iwp_exclvol(c) - iwp_microrel(c)) * (d/iwp_microrel(c))**2_r8 &
+                                     + (2_r8/iwp_microrel(c)) * (2_r8*iwp_microrel(c) - 3_r8*iwp_exclvol(c)) * (d/iwp_microrel(c))
 
                 else ! calculate water depth and inudation fraction if column is non-polygonal
                     d=0.0

--- a/components/elm/src/biogeophys/CanopyHydrologyMod.F90
+++ b/components/elm/src/biogeophys/CanopyHydrologyMod.F90
@@ -844,13 +844,16 @@ contains
                     if (swc > iwp_microrel(c) - iwp_exclvol(c)) then
                         d = swc + iwp_exclvol(c)
                     else
-                        d = 0.0
+                        d = swc + iwp_exclvol(c)
                         do k=1,10
                             fd = (2_r8*iwp_exclvol(c) - iwp_microrel(c)) * (d/iwp_microrel(c))**3_r8 &
                                  + (2_r8*iwp_microrel(c) - 3_r8*iwp_exclvol(c)) * (d/iwp_microrel(c))**2_r8 &
                                  - swc
                             dfdd = (3_r8/iwp_microrel(c)) * (2_r8*iwp_exclvol(c) - iwp_microrel(c)) * (d/iwp_microrel(c))**2_r8 &
                                    + (2_r8/iwp_microrel(c)) * (2_r8*iwp_microrel(c) - 3_r8*iwp_exclvol(c)) * (d/iwp_microrel(c))
+                            if (dfdd < 1.0e-12_r8) then
+                              write(iulog,*) "careful! getting close to dividing by 0..."
+                            end if
                             d = d - fd/dfdd
                         enddo
                     endif

--- a/components/elm/src/biogeophys/CanopyStateType.F90
+++ b/components/elm/src/biogeophys/CanopyStateType.F90
@@ -62,8 +62,10 @@ module CanopyStateType
      integer  , pointer :: alt_indx_col             (:)   ! col current depth of thaw
      real(r8) , pointer :: altmax_col               (:)   ! col maximum annual depth of thaw
      real(r8) , pointer :: altmax_lastyear_col      (:)   ! col prior year maximum annual depth of thaw
+     real(r8) , pointer :: altmax_ever_col          (:)   ! col maximum thaw depth from beginning of simulation
      integer  , pointer :: altmax_indx_col          (:)   ! col maximum annual depth of thaw
      integer  , pointer :: altmax_lastyear_indx_col (:)   ! col prior year maximum annual depth of thaw
+     integer  , pointer :: altmax_ever_indx_col     (:)   ! col maximum thaw depth from beginning of simulation
 
      real(r8) , pointer :: dewmx_patch              (:)   ! patch maximum allowed dew [mm]
 
@@ -142,9 +144,11 @@ contains
     allocate(this%alt_col                  (begc:endc))           ; this%alt_col                  (:)   = spval;
     allocate(this%altmax_col               (begc:endc))           ; this%altmax_col               (:)   = spval
     allocate(this%altmax_lastyear_col      (begc:endc))           ; this%altmax_lastyear_col      (:)   = spval
+    allocate(this%altmax_ever_col          (begc:endc))           ; this%altmax_ever_col          (:)   = spval
     allocate(this%alt_indx_col             (begc:endc))           ; this%alt_indx_col             (:)   = huge(1)
     allocate(this%altmax_indx_col          (begc:endc))           ; this%altmax_indx_col          (:)   = huge(1)
     allocate(this%altmax_lastyear_indx_col (begc:endc))           ; this%altmax_lastyear_indx_col (:)   = huge(1)
+    allocate(this%altmax_ever_indx_col     (begc:endc))           ; this%altmax_ever_indx_col     (:)   = huge(1) 
 
     allocate(this%dewmx_patch              (begp:endp))           ; this%dewmx_patch              (:)   = spval
     allocate(this%dleaf_patch              (begp:endp))           ; this%dleaf_patch              (:)   = spval
@@ -277,6 +281,11 @@ contains
        call hist_addfld1d (fname='ALTMAX_LASTYEAR', units='m', &
             avgflag='A', long_name='maximum prior year active layer thickness', &
             ptr_col=this%altmax_lastyear_col)
+
+       this%altmax_ever_col(begc:endc) = spval
+       call hist_addfld1d (fname='ALTMAX_EVER', units='m', &
+            avgflag='A', long_name='maximum ever active layer thickness throughout simulation', &
+            ptr_col=this%altmax_ever_col)
     end if
 
     ! Allow active layer fields to be optionally output even if not running CN
@@ -296,6 +305,11 @@ contains
        call hist_addfld1d (fname='ALTMAX_LASTYEAR', units='m', &
             avgflag='A', long_name='maximum prior year active layer thickness', &
             ptr_col=this%altmax_lastyear_col, default='inactive')
+
+       this%altmax_ever_col(begc:endc) = spval
+       call hist_addfld1d (fname='ALTMAX_EVER', units='m', &
+            avgflag='A', long_name='maximum ever active layer thickness throughout simulation', &
+            ptr_col=this%altmax_ever_col, default='inactive')
     end if
 
     ! Accumulated fields
@@ -502,9 +516,11 @@ contains
           this%alt_col(c)                  = 0._r8
           this%altmax_col(c)               = 0._r8
           this%altmax_lastyear_col(c)      = 0._r8
+          this%altmax_ever_col(c)          = 0._r8
           this%alt_indx_col(c)             = 0
           this%altmax_indx_col(c)          = 0
           this%altmax_lastyear_indx_col(c) = 0
+          this%altmax_ever_indx_col(c)     = 0
        end if
     end do
 
@@ -572,12 +588,18 @@ contains
        call restartvar(ncid=ncid, flag=flag, varname='altmax_lastyear', xtype=ncd_double,  &
             dim1name='column', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%altmax_lastyear_col)
+       call restartvar(ncid=ncid, flag=flag, varname='altmax_ever', xtype=ncd_double,  &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%altmax_ever_col)
        call restartvar(ncid=ncid, flag=flag, varname='altmax_indx', xtype=ncd_int,  &
             dim1name='column', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%altmax_indx_col)
        call restartvar(ncid=ncid, flag=flag, varname='altmax_lastyear_indx', xtype=ncd_int,  &
             dim1name='column', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%altmax_lastyear_indx_col)
+       call restartvar(ncid=ncid, flag=flag, varname='altmax_ever_indx', xtype=ncd_int,  &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%altmax_ever_indx_col)
     end if
     if ( use_hydrstress ) then
        call restartvar(ncid=ncid, flag=flag, varname='vegwp', xtype=ncd_double, &

--- a/components/elm/src/biogeophys/CanopyStateType.F90
+++ b/components/elm/src/biogeophys/CanopyStateType.F90
@@ -62,9 +62,11 @@ module CanopyStateType
      integer  , pointer :: alt_indx_col             (:)   ! col current depth of thaw
      real(r8) , pointer :: altmax_col               (:)   ! col maximum annual depth of thaw
      real(r8) , pointer :: altmax_lastyear_col      (:)   ! col prior year maximum annual depth of thaw
+     real(r8) , pointer :: altmax_1989_col          (:)   ! col maximum annual thaw depth in 1989 RF note: temporary for IM1!
      real(r8) , pointer :: altmax_ever_col          (:)   ! col maximum thaw depth from beginning of simulation
      integer  , pointer :: altmax_indx_col          (:)   ! col maximum annual depth of thaw
      integer  , pointer :: altmax_lastyear_indx_col (:)   ! col prior year maximum annual depth of thaw
+     integer  , pointer :: altmax_1989_indx_col     (:)   ! col 1989 maximum thaw depth RF note: temporary for IM1!
      integer  , pointer :: altmax_ever_indx_col     (:)   ! col maximum thaw depth from beginning of simulation
 
      real(r8) , pointer :: dewmx_patch              (:)   ! patch maximum allowed dew [mm]
@@ -144,11 +146,13 @@ contains
     allocate(this%alt_col                  (begc:endc))           ; this%alt_col                  (:)   = spval;
     allocate(this%altmax_col               (begc:endc))           ; this%altmax_col               (:)   = spval
     allocate(this%altmax_lastyear_col      (begc:endc))           ; this%altmax_lastyear_col      (:)   = spval
+    allocate(this%altmax_1989_col          (begc:endc))           ; this%altmax_1989_col          (:)   = spval
     allocate(this%altmax_ever_col          (begc:endc))           ; this%altmax_ever_col          (:)   = spval
     allocate(this%alt_indx_col             (begc:endc))           ; this%alt_indx_col             (:)   = huge(1)
     allocate(this%altmax_indx_col          (begc:endc))           ; this%altmax_indx_col          (:)   = huge(1)
     allocate(this%altmax_lastyear_indx_col (begc:endc))           ; this%altmax_lastyear_indx_col (:)   = huge(1)
-    allocate(this%altmax_ever_indx_col     (begc:endc))           ; this%altmax_ever_indx_col     (:)   = huge(1) 
+    allocate(this%altmax_1989_indx_col     (begc:endc))           ; this%altmax_1989_indx_col     (:)   = huge(1)
+    allocate(this%altmax_ever_indx_col     (begc:endc))           ; this%altmax_ever_indx_col     (:)   = huge(1)
 
     allocate(this%dewmx_patch              (begp:endp))           ; this%dewmx_patch              (:)   = spval
     allocate(this%dleaf_patch              (begp:endp))           ; this%dleaf_patch              (:)   = spval
@@ -282,6 +286,11 @@ contains
             avgflag='A', long_name='maximum prior year active layer thickness', &
             ptr_col=this%altmax_lastyear_col)
 
+       this%altmax_1989_col(begc:endc) = spval
+       call hist_addfld1d (fname='ALTMAX_1989', units='m', &
+            avgflag='A', long_name='maximum 1989 active layer thickness', &
+            ptr_col=this%altmax_1989_col)
+
        this%altmax_ever_col(begc:endc) = spval
        call hist_addfld1d (fname='ALTMAX_EVER', units='m', &
             avgflag='A', long_name='maximum ever active layer thickness throughout simulation', &
@@ -305,6 +314,11 @@ contains
        call hist_addfld1d (fname='ALTMAX_LASTYEAR', units='m', &
             avgflag='A', long_name='maximum prior year active layer thickness', &
             ptr_col=this%altmax_lastyear_col, default='inactive')
+
+       this%altmax_1989_col(begc:endc) = spval
+       call hist_addfld1d (fname='ALTMAX_1989', units='m', &
+            avgflag='A', long_name='maximum 1989 active layer thickness', &
+            ptr_col=this%altmax_1989_col, default='inactive')
 
        this%altmax_ever_col(begc:endc) = spval
        call hist_addfld1d (fname='ALTMAX_EVER', units='m', &
@@ -516,10 +530,12 @@ contains
           this%alt_col(c)                  = 0._r8
           this%altmax_col(c)               = 0._r8
           this%altmax_lastyear_col(c)      = 0._r8
+          this%altmax_1989_col(c)          = 0._r8
           this%altmax_ever_col(c)          = 0._r8
           this%alt_indx_col(c)             = 0
           this%altmax_indx_col(c)          = 0
           this%altmax_lastyear_indx_col(c) = 0
+          this%altmax_1989_indx_col(c)     = 0
           this%altmax_ever_indx_col(c)     = 0
        end if
     end do
@@ -588,6 +604,9 @@ contains
        call restartvar(ncid=ncid, flag=flag, varname='altmax_lastyear', xtype=ncd_double,  &
             dim1name='column', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%altmax_lastyear_col)
+       call restartvar(ncid=ncid, flag=flag, varname='altmax_1989', xtype=ncd_double,  &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%altmax_1989_col)
        call restartvar(ncid=ncid, flag=flag, varname='altmax_ever', xtype=ncd_double,  &
             dim1name='column', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%altmax_ever_col)
@@ -597,6 +616,9 @@ contains
        call restartvar(ncid=ncid, flag=flag, varname='altmax_lastyear_indx', xtype=ncd_int,  &
             dim1name='column', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%altmax_lastyear_indx_col)
+       call restartvar(ncid=ncid, flag=flag, varname='altmax_1989_indx', xtype=ncd_double,  &
+            dim1name='column', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%altmax_1989_indx_col)
        call restartvar(ncid=ncid, flag=flag, varname='altmax_ever_indx', xtype=ncd_int,  &
             dim1name='column', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%altmax_ever_indx_col)

--- a/components/elm/src/biogeophys/CanopyStateType.F90
+++ b/components/elm/src/biogeophys/CanopyStateType.F90
@@ -10,6 +10,7 @@ module CanopyStateType
   use elm_varcon      , only : spval,ispval
   use elm_varpar      , only : nlevcan, nvegwcs
   use elm_varctl      , only : iulog, use_cn, use_fates, use_hydrstress, use_fates_sp
+  use elm_varctl      , only : use_polygonal_tundra
   use LandunitType    , only : lun_pp
   use ColumnType      , only : col_pp
   use VegetationType       , only : veg_pp
@@ -62,10 +63,10 @@ module CanopyStateType
      integer  , pointer :: alt_indx_col             (:)   ! col current depth of thaw
      real(r8) , pointer :: altmax_col               (:)   ! col maximum annual depth of thaw
      real(r8) , pointer :: altmax_lastyear_col      (:)   ! col prior year maximum annual depth of thaw
-     real(r8) , pointer :: altmax_1989_col          (:)   ! col maximum annual thaw depth in 1989 RF note: temporary for IM1!
-     real(r8) , pointer :: altmax_ever_col          (:)   ! col maximum thaw depth from beginning of simulation
      integer  , pointer :: altmax_indx_col          (:)   ! col maximum annual depth of thaw
      integer  , pointer :: altmax_lastyear_indx_col (:)   ! col prior year maximum annual depth of thaw
+     real(r8) , pointer :: altmax_1989_col          (:)   ! col maximum annual thaw depth in 1989 RF note: temporary for IM1!
+     real(r8) , pointer :: altmax_ever_col          (:)   ! col maximum thaw depth from beginning of simulation
      integer  , pointer :: altmax_1989_indx_col     (:)   ! col 1989 maximum thaw depth RF note: temporary for IM1!
      integer  , pointer :: altmax_ever_indx_col     (:)   ! col maximum thaw depth from beginning of simulation
 
@@ -286,15 +287,17 @@ contains
             avgflag='A', long_name='maximum prior year active layer thickness', &
             ptr_col=this%altmax_lastyear_col)
 
-       this%altmax_1989_col(begc:endc) = spval
-       call hist_addfld1d (fname='ALTMAX_1989', units='m', &
-            avgflag='A', long_name='maximum 1989 active layer thickness', &
-            ptr_col=this%altmax_1989_col)
+       if (use_polygonal_tundra) then
+          this%altmax_1989_col(begc:endc) = spval
+          call hist_addfld1d (fname='ALTMAX_1989', units='m', &
+               avgflag='A', long_name='maximum 1989 active layer thickness', &
+               ptr_col=this%altmax_1989_col)
 
-       this%altmax_ever_col(begc:endc) = spval
-       call hist_addfld1d (fname='ALTMAX_EVER', units='m', &
-            avgflag='A', long_name='maximum ever active layer thickness throughout simulation', &
-            ptr_col=this%altmax_ever_col)
+          this%altmax_ever_col(begc:endc) = spval
+          call hist_addfld1d (fname='ALTMAX_EVER', units='m', &
+               avgflag='A', long_name='maximum ever active layer thickness throughout simulation', &
+               ptr_col=this%altmax_ever_col)
+       end if
     end if
 
     ! Allow active layer fields to be optionally output even if not running CN
@@ -315,15 +318,17 @@ contains
             avgflag='A', long_name='maximum prior year active layer thickness', &
             ptr_col=this%altmax_lastyear_col, default='inactive')
 
-       this%altmax_1989_col(begc:endc) = spval
-       call hist_addfld1d (fname='ALTMAX_1989', units='m', &
-            avgflag='A', long_name='maximum 1989 active layer thickness', &
-            ptr_col=this%altmax_1989_col, default='inactive')
+       if (use_polygonal_tundra) then
+          this%altmax_1989_col(begc:endc) = spval
+          call hist_addfld1d (fname='ALTMAX_1989', units='m', &
+               avgflag='A', long_name='maximum 1989 active layer thickness', &
+               ptr_col=this%altmax_1989_col, default='inactive')
 
-       this%altmax_ever_col(begc:endc) = spval
-       call hist_addfld1d (fname='ALTMAX_EVER', units='m', &
-            avgflag='A', long_name='maximum ever active layer thickness throughout simulation', &
-            ptr_col=this%altmax_ever_col, default='inactive')
+          this%altmax_ever_col(begc:endc) = spval
+          call hist_addfld1d (fname='ALTMAX_EVER', units='m', &
+               avgflag='A', long_name='maximum ever active layer thickness throughout simulation', &
+               ptr_col=this%altmax_ever_col, default='inactive')
+       end if
     end if
 
     ! Accumulated fields
@@ -604,25 +609,27 @@ contains
        call restartvar(ncid=ncid, flag=flag, varname='altmax_lastyear', xtype=ncd_double,  &
             dim1name='column', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%altmax_lastyear_col)
-       call restartvar(ncid=ncid, flag=flag, varname='altmax_1989', xtype=ncd_double,  &
-            dim1name='column', long_name='', units='', &
-            interpinic_flag='interp', readvar=readvar, data=this%altmax_1989_col)
-       call restartvar(ncid=ncid, flag=flag, varname='altmax_ever', xtype=ncd_double,  &
-            dim1name='column', long_name='', units='', &
-            interpinic_flag='interp', readvar=readvar, data=this%altmax_ever_col)
        call restartvar(ncid=ncid, flag=flag, varname='altmax_indx', xtype=ncd_int,  &
             dim1name='column', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%altmax_indx_col)
        call restartvar(ncid=ncid, flag=flag, varname='altmax_lastyear_indx', xtype=ncd_int,  &
             dim1name='column', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%altmax_lastyear_indx_col)
-       call restartvar(ncid=ncid, flag=flag, varname='altmax_1989_indx', xtype=ncd_double,  &
-            dim1name='column', long_name='', units='', &
-            interpinic_flag='interp', readvar=readvar, data=this%altmax_1989_indx_col)
-       call restartvar(ncid=ncid, flag=flag, varname='altmax_ever_indx', xtype=ncd_int,  &
-            dim1name='column', long_name='', units='', &
-            interpinic_flag='interp', readvar=readvar, data=this%altmax_ever_indx_col)
-    end if
+       if (use_polygonal_tundra) then
+          call restartvar(ncid=ncid, flag=flag, varname='altmax_1989_indx', xtype=ncd_double,  &
+               dim1name='column', long_name='', units='', &
+               interpinic_flag='interp', readvar=readvar, data=this%altmax_1989_indx_col)
+          call restartvar(ncid=ncid, flag=flag, varname='altmax_ever_indx', xtype=ncd_int,  &
+               dim1name='column', long_name='', units='', &
+               interpinic_flag='interp', readvar=readvar, data=this%altmax_ever_indx_col)
+          call restartvar(ncid=ncid, flag=flag, varname='altmax_1989', xtype=ncd_double,  &
+               dim1name='column', long_name='', units='', &
+               interpinic_flag='interp', readvar=readvar, data=this%altmax_1989_col)
+          call restartvar(ncid=ncid, flag=flag, varname='altmax_ever', xtype=ncd_double,  &
+               dim1name='column', long_name='', units='', &
+               interpinic_flag='interp', readvar=readvar, data=this%altmax_ever_col)
+       end if ! polygonal tundra
+    end if ! cn or fates
     if ( use_hydrstress ) then
        call restartvar(ncid=ncid, flag=flag, varname='vegwp', xtype=ncd_double, &
             dim1name='pft', dim2name='vegwcs', switchdim=.true., &

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -562,7 +562,7 @@ contains
              if (lun_pp%ispolygon(col_pp%landunit(c))) then
                 vdep = (2_r8*iwp_exclvol(c) - iwp_microrel(c)) * (iwp_ddep(c)/iwp_microrel(c))**3_r8 &
                        + (2_r8*iwp_microrel(c) - 3_r8*iwp_exclvol(c)) * (iwp_ddep(c)/iwp_microrel(c))**2_r8
-                phi_eff = min(iwp_subsidence(c), 0.4)  !fix this variable when available to pull from alt calculations
+                phi_eff = min(iwp_subsidence(c), 0.4_r8)  !fix this variable when available to pull from alt calculations
                 swc = h2osfc(c)/1000_r8 ! convert to m
                 
                 if (swc >= vdep) then

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -207,7 +207,7 @@ contains
          l = col_pp%landunit(c)
          ! no qflx_surf in polygonal ground
          if (lun_pp%ispolygon(l)) then
-            qflx_surf(c) = 0
+            qflx_surf(c) = 0._r8
          else
             ! assume qinmax large relative to qflx_top_soil in control
             if (origflag == 1) then
@@ -849,7 +849,7 @@ contains
        ! Water table changes due to qcharge
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)
-             nlevbed = nlev2bed(c)
+          nlevbed = nlev2bed(c)
 
           !scs: use analytical expression for aquifer specific yield
           rous = watsat(c,nlevbed) &
@@ -857,7 +857,7 @@ contains
           rous=max(rous,0.02_r8)
 
           !--  water table is below the soil column  --------------------------------------
-              g = col_pp%gridcell(c)
+          g = col_pp%gridcell(c)
           l = col_pp%landunit(c)
           qcharge_temp = qcharge(c)
 
@@ -865,10 +865,10 @@ contains
           zwt(c) = zwt(c) + (qflx_grnd_irrig_col(c) * dtime)/1000._r8/rous
 
           if(jwt(c) == nlevbed) then
-               if (.not. (zengdecker_2009_with_var_soil_thick)) then
-                wa(c)  = wa(c) + qcharge(c)  * dtime
-                zwt(c) = zwt(c) - (qcharge(c)  * dtime)/1000._r8/rous
-             end if
+            if (.not. (zengdecker_2009_with_var_soil_thick)) then
+              wa(c)  = wa(c) + qcharge(c)  * dtime
+              zwt(c) = zwt(c) - (qcharge(c)  * dtime)/1000._r8/rous
+            end if
           else
              !-- water table within soil layers 1-9  -------------------------------------
              ! try to raise water table to account for qcharge
@@ -931,7 +931,7 @@ contains
        ! perched water table code
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)
-             nlevbed = nlev2bed(c)
+          nlevbed = nlev2bed(c)
 
           ! define frost table as first frozen layer with unfrozen layer above it
           if(t_soisno(c,1) > tfrz) then
@@ -941,10 +941,10 @@ contains
           endif
 
           do k=2, nlevbed
-             if (t_soisno(c,k-1) > tfrz .and. t_soisno(c,k) <= tfrz) then
-                k_frz=k
-                exit
-             endif
+            if (t_soisno(c,k-1) > tfrz .and. t_soisno(c,k) <= tfrz) then
+               k_frz=k
+               exit
+            endif
           enddo
 
           frost_table(c)=z(c,k_frz)
@@ -1201,7 +1201,7 @@ contains
 
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)
-             nlevbed = nlev2bed(c)
+          nlevbed = nlev2bed(c)
           jwt(c) = nlevbed
           ! allow jwt to equal zero when zwt is in top layer
           do j = 1,nlevbed
@@ -1211,7 +1211,7 @@ contains
                 else
                    jwt(c) = j-1
                    exit
-            end if
+                end if
              end if
           enddo
        end do
@@ -1426,11 +1426,11 @@ contains
                 ! make sure baseflow isn't negative
                 rsub_top(c) = max(0._r8, rsub_top(c))
              else
-            if (jwt(c) == nlevbed .and. zengdecker_2009_with_var_soil_thick) then
+              if (jwt(c) == nlevbed .and. zengdecker_2009_with_var_soil_thick) then
                    rsub_top(c)    = 0._r8
                 else
                    rsub_top(c)    = imped * rsub_top_max* exp(-fff(c)*zwt(c))
-        end if
+              end if
              end if
 
              if (use_vsfm) rsub_top(c) = 0._r8
@@ -1442,28 +1442,28 @@ contains
 
              !--  water table is below the soil column  --------------------------------------
              if(jwt(c) == nlevbed) then
-            if (zengdecker_2009_with_var_soil_thick) then
-                if (-1._r8 * smp_l(c,nlevbed) < 0.5_r8 * dzmm(c,nlevbed)) then
+               if (zengdecker_2009_with_var_soil_thick) then
+                 if (-1._r8 * smp_l(c,nlevbed) < 0.5_r8 * dzmm(c,nlevbed)) then
                      zwt(c) = z(c,nlevbed) - (smp_l(c,nlevbed) / 1000._r8)
-           end if
-                   rsub_top(c) = imped * rsub_top_max * exp(-fff(c) * zwt(c))
-                   rsub_top_tot = - rsub_top(c) * dtime
-                   s_y = watsat(c,nlevbed) &
+                 end if
+                 rsub_top(c) = imped * rsub_top_max * exp(-fff(c) * zwt(c))
+                 rsub_top_tot = - rsub_top(c) * dtime
+                 s_y = watsat(c,nlevbed) &
                      * ( 1. - (1.+1.e3*zwt(c)/sucsat(c,nlevbed))**(-1./bsw(c,nlevbed)))
-                   s_y=max(s_y,0.02_r8)
-                   rsub_top_layer=max(rsub_top_tot,-(s_y*(zi(c,nlevbed) - zwt(c))*1.e3))
-                   rsub_top_layer=min(rsub_top_layer,0._r8)
-                   h2osoi_liq(c,nlevbed) = h2osoi_liq(c,nlevbed) + rsub_top_layer
-                   rsub_top_tot = rsub_top_tot - rsub_top_layer
-                   if (rsub_top_tot >= 0.) then
-                      zwt(c) = zwt(c) - rsub_top_layer/s_y/1000._r8
-                   else
-                      zwt(c) = zi(c,nlevbed)
-                   end if
-               if (rsub_top_tot < 0.) then
-                  rsub_top(c) = rsub_top(c) + rsub_top_tot / dtime
-                      rsub_top_tot = 0.
-                   end if
+                 s_y=max(s_y,0.02_r8)
+                 rsub_top_layer=max(rsub_top_tot,-(s_y*(zi(c,nlevbed) - zwt(c))*1.e3))
+                 rsub_top_layer=min(rsub_top_layer,0._r8)
+                 h2osoi_liq(c,nlevbed) = h2osoi_liq(c,nlevbed) + rsub_top_layer
+                 rsub_top_tot = rsub_top_tot - rsub_top_layer
+                 if (rsub_top_tot >= 0.) then
+                    zwt(c) = zwt(c) - rsub_top_layer/s_y/1000._r8
+                 else
+                    zwt(c) = zi(c,nlevbed)
+                 end if
+                 if (rsub_top_tot < 0.) then
+                   rsub_top(c) = rsub_top(c) + rsub_top_tot / dtime
+                   rsub_top_tot = 0.
+                 end if
                 else
                    wa(c)  = wa(c) - rsub_top(c) * dtime
                    zwt(c)     = zwt(c) + (rsub_top(c) * dtime)/1000._r8/rous
@@ -1609,8 +1609,8 @@ contains
 
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)
-             nlevbed = nlev2bed(c)
-             do j = 1, nlevbed-1
+          nlevbed = nlev2bed(c)
+          do j = 1, nlevbed-1
              if (h2osoi_liq(c,j) < watmin) then
                 xs(c) = watmin - h2osoi_liq(c,j)
                 ! deepen water table if water is passed from below zwt layer
@@ -1628,8 +1628,8 @@ contains
        ! Get water for bottom layer from layers above if possible
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)
-             nlevbed = nlev2bed(c)
-             j = nlevbed
+          nlevbed = nlev2bed(c)
+          j = nlevbed
           if (h2osoi_liq(c,j) < watmin) then
              xs(c) = watmin-h2osoi_liq(c,j)
              searchforwater: do i = nlevbed-1, 1, -1

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -369,10 +369,6 @@ contains
           nlev2bed             =>    col_pp%nlevbed              , & ! Input:  [integer  (:)   ]  number of layers to bedrock
           cgridcell            =>    col_pp%gridcell             , & ! Input:  [integer  (:)   ]  column's gridcell    
           wtgcell              =>    col_pp%wtgcell              , & ! Input:  [real(r8) (:)   ]  weight (relative to gridcell)
-          iwp_microrel         =>    col_pp%iwp_microrel         , & ! Input:  [real(r8) (:)   ]  ice wedge polygon microtopographic relief (m)
-          iwp_exclvol          =>    col_pp%iwp_exclvol          , & ! Input:  [real(r8) (:)   ]  ice wedge polygon excluded volume (m)
-          iwp_ddep             =>    col_pp%iwp_ddep             , & ! Input:  [real(r8) (:)   ]  ice wedge polygon depression depth (m)
-          iwp_subsidence       =>    col_pp%iwp_subsidence       , & ! Input:  [real(r8) (:)   ]  ice wedge polygon ground subsidence (m)
           meangradz            =>    col_pp%meangradz            , & ! Input:  [real(r8) (:)   ]  mean topographic gradient at the column level (unitless)
 
           t_soisno             =>    col_es%t_soisno             , & ! Input:  [real(r8) (:,:) ]  soil temperature (Kelvin)
@@ -387,6 +383,10 @@ contains
           h2osfc               =>    col_ws%h2osfc               , & ! Output: [real(r8) (:)   ]  surface water (mm)
           h2orof               =>    col_ws%h2orof               , & ! Output:  [real(r8) (:)   ]  floodplain inudntion volume (mm)
           frac_h2orof          =>    col_ws%frac_h2orof          , & ! Output:  [real(r8) (:)   ]  floodplain inudntion fraction (-)
+          iwp_microrel         =>    col_ws%iwp_microrel         , & ! Input:  [real(r8) (:)   ]  ice wedge polygon microtopographic relief (m)
+          iwp_exclvol          =>    col_ws%iwp_exclvol          , & ! Input:  [real(r8) (:)   ]  ice wedge polygon excluded volume (m)
+          iwp_ddep             =>    col_ws%iwp_ddep             , & ! Input:  [real(r8) (:)   ]  ice wedge polygon depression depth (m)
+          iwp_subsidence       =>    col_ws%iwp_subsidence       , & ! Input:  [real(r8) (:)   ]  ice wedge polygon ground subsidence (m)
 
           qflx_ev_soil         =>    col_wf%qflx_ev_soil         , & ! Input:  [real(r8) (:)   ]  evaporation flux from soil (W/m**2) [+ to atm]
           qflx_evap_soi        =>    col_wf%qflx_evap_soi        , & ! Input:  [real(r8) (:)   ]  ground surface evaporation rate (mm H2O/s) [+]

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -572,7 +572,7 @@ contains
                    else
                       k_wet = 24.925_r8 * (710.3_r8*meangradz(c)**2 - 28.736_r8*meangradz(c) + 12.74_r8)
                    endif
-                   qflx_h2osfc_surf(c) = k_wet * (swc - vdep)
+                   qflx_h2osfc_surf(c) = k_wet * (swc - vdep) / 86400_r8 ! coefficients estimated for mm/day; convert from mm/day -> mm/s
                    qflx_h2osfc_surf(c) = min(qflx_h2osfc_surf(c), (swc - vdep)*1000_r8/dtime)
                 else
                    qflx_h2osfc_surf(c) = 0._r8

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -372,6 +372,7 @@ contains
           iwp_microrel         =>    col_pp%iwp_microrel         , & ! Input:  [real(r8) (:)   ]  ice wedge polygon microtopographic relief (m)
           iwp_exclvol          =>    col_pp%iwp_exclvol          , & ! Input:  [real(r8) (:)   ]  ice wedge polygon excluded volume (m)
           iwp_ddep             =>    col_pp%iwp_ddep             , & ! Input:  [real(r8) (:)   ]  ice wedge polygon depression depth (m)
+          iwp_subsidence       =>    col_pp%iwp_subsidence       , & ! Input:  [real(r8) (:)   ]  ice wedge polygon ground subsidence (m)
           meangradz            =>    col_pp%meangradz            , & ! Input:  [real(r8) (:)   ]  mean topographic gradient at the column level (unitless)
 
           t_soisno             =>    col_es%t_soisno             , & ! Input:  [real(r8) (:,:) ]  soil temperature (Kelvin)
@@ -561,7 +562,7 @@ contains
              if (lun_pp%ispolygon(col_pp%landunit(c))) then
                 vdep = (2_r8*iwp_exclvol(c) - iwp_microrel(c)) * (iwp_ddep(c)/iwp_microrel(c))**3_r8 &
                        + (2_r8*iwp_microrel(c) - 3_r8*iwp_exclvol(c)) * (iwp_ddep(c)/iwp_microrel(c))**2_r8
-                phi_eff = min(subsidence, 0.4)  !fix this variable when available to pull from alt calculations
+                phi_eff = min(iwp_subsidence(c), 0.4)  !fix this variable when available to pull from alt calculations
                 swc = h2osfc(c)/1000_r8 ! convert to m
                 
                 if (swc >= vdep) then

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -304,7 +304,7 @@ contains
      use elm_varcon       , only : denh2o, denice, roverg, wimp, mu, tfrz
      use elm_varcon       , only : pondmx, watmin
      use column_varcon    , only : icol_roof, icol_road_imperv, icol_sunwall, icol_shadewall, icol_road_perv
-     use landunit_varcon  , only : istsoil, istcrop, ilowcenpoly
+     use landunit_varcon  , only : istsoil, istcrop, ilowcenpoly, iflatcenpoly, ihighcenpoly
      use elm_time_manager , only : get_step_size, get_nstep
      use atm2lndType      , only : atm2lnd_type ! land river two way coupling
      use lnd2atmType      , only : lnd2atm_type

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -567,10 +567,10 @@ contains
                 
                 if (swc >= vdep) then
                    if (lun_pp%polygontype(col_pp%landunit(c)) == ilowcenpoly) then
-                      k_wet = (2890_r8*phi_eff**4 - 1171.1_r8*phi_eff**3 + 144.94_r8*phi_eff**2 + 1.682_r8*phi_eff + 2.028) &
-                              * (710.3_r8*meangradz(c)**2 - 28.736_r8*meangradz(c) + 12.74_r8)
+                      k_wet = (2890_r8*phi_eff**4_r8 - 1171.1_r8*phi_eff**3_r8 + 144.94_r8*phi_eff**2_r8 + 1.682_r8*phi_eff + 2.028_r8) &
+                              * (710.3_r8*meangradz(c)**2_r8 - 28.736_r8*meangradz(c) + 12.74_r8)
                    else
-                      k_wet = 24.925_r8 * (710.3_r8*meangradz(c)**2 - 28.736_r8*meangradz(c) + 12.74_r8)
+                      k_wet = 24.925_r8 * (710.3_r8*meangradz(c)**2_r8 - 28.736_r8*meangradz(c) + 12.74_r8)
                    endif
                    qflx_h2osfc_surf(c) = k_wet * (swc - vdep) / 86400_r8 ! coefficients estimated for mm/day; convert from mm/day -> mm/s
                    qflx_h2osfc_surf(c) = min(qflx_h2osfc_surf(c), (swc - vdep)*1000_r8/dtime)
@@ -582,7 +582,7 @@ contains
                 ! limit runoff to value of storage above S(pc)
                 if(h2osfc(c) >= h2osfc_thresh(c) .and. h2osfcflag/=0) then
                    ! spatially variable k_wet
-                   k_wet=1.0_r8 * sin((rpi/180.) * col_pp%topo_slope(c))
+                   k_wet=1.0_r8 * sin((rpi/180._r8) * col_pp%topo_slope(c))
                    qflx_h2osfc_surf(c) = k_wet * frac_infclust * (h2osfc(c) - h2osfc_thresh(c))
 
                    qflx_h2osfc_surf(c)=min(qflx_h2osfc_surf(c),(h2osfc(c) - h2osfc_thresh(c))/dtime)
@@ -1451,11 +1451,11 @@ contains
                  s_y = watsat(c,nlevbed) &
                      * ( 1. - (1.+1.e3*zwt(c)/sucsat(c,nlevbed))**(-1./bsw(c,nlevbed)))
                  s_y=max(s_y,0.02_r8)
-                 rsub_top_layer=max(rsub_top_tot,-(s_y*(zi(c,nlevbed) - zwt(c))*1.e3))
+                 rsub_top_layer=max(rsub_top_tot,-(s_y*(zi(c,nlevbed) - zwt(c))*1.e3_r8))
                  rsub_top_layer=min(rsub_top_layer,0._r8)
                  h2osoi_liq(c,nlevbed) = h2osoi_liq(c,nlevbed) + rsub_top_layer
                  rsub_top_tot = rsub_top_tot - rsub_top_layer
-                 if (rsub_top_tot >= 0.) then
+                 if (rsub_top_tot >= 0._r8) then
                     zwt(c) = zwt(c) - rsub_top_layer/s_y/1000._r8
                  else
                     zwt(c) = zi(c,nlevbed)

--- a/components/elm/src/biogeophys/WaterStateType.F90
+++ b/components/elm/src/biogeophys/WaterStateType.F90
@@ -35,7 +35,8 @@ module WaterstateType
      real(r8), pointer :: bw_col                 (:,:) ! col partial density of water in the snow pack (ice + liquid) [kg/m3] 
      real(r8), pointer :: finundated_col         (:)   ! fraction of column that is inundated, this is for bgc caclulation in betr
      real(r8), pointer :: h2osoi_tend_tsl_col    (:)   ! col moisture tendency due to vertical movement at topmost layer (m3/m3/s)
- 
+     real(r8), pointer :: excess_ice             (:,:) ! excess ground ice in polygonal tundra areas [kg/m2]
+
      real(r8), pointer :: rhvap_soi_col          (:,:)
      real(r8), pointer :: rho_vap_col            (:,:)
      real(r8), pointer :: smp_l_col              (:,:) ! col liquid phase soil matric potential, mm
@@ -211,6 +212,7 @@ contains
     if (use_fan) then
        allocate(this%h2osoi_tend_tsl_col(begc:endc))                      ; this%h2osoi_tend_tsl_col    (:)   = nan
     end if
+    allocate(this%excess_ice             (begc:endc, 1:nlevgrnd))         ; this%excess_ice             (:,:) = nan
 
     allocate(this%h2osno_col             (begc:endc))                     ; this%h2osno_col             (:)   = nan   
     allocate(this%h2osno_old_col         (begc:endc))                     ; this%h2osno_old_col         (:)   = nan   

--- a/components/elm/src/biogeophys/WaterStateType.F90
+++ b/components/elm/src/biogeophys/WaterStateType.F90
@@ -35,7 +35,6 @@ module WaterstateType
      real(r8), pointer :: bw_col                 (:,:) ! col partial density of water in the snow pack (ice + liquid) [kg/m3] 
      real(r8), pointer :: finundated_col         (:)   ! fraction of column that is inundated, this is for bgc caclulation in betr
      real(r8), pointer :: h2osoi_tend_tsl_col    (:)   ! col moisture tendency due to vertical movement at topmost layer (m3/m3/s)
-     real(r8), pointer :: excess_ice             (:,:) ! excess ground ice in polygonal tundra areas [kg/m2]
 
      real(r8), pointer :: rhvap_soi_col          (:,:)
      real(r8), pointer :: rho_vap_col            (:,:)
@@ -212,7 +211,6 @@ contains
     if (use_fan) then
        allocate(this%h2osoi_tend_tsl_col(begc:endc))                      ; this%h2osoi_tend_tsl_col    (:)   = nan
     end if
-    allocate(this%excess_ice             (begc:endc, 1:nlevgrnd))         ; this%excess_ice             (:,:) = nan
 
     allocate(this%h2osno_col             (begc:endc))                     ; this%h2osno_col             (:)   = nan   
     allocate(this%h2osno_old_col         (begc:endc))                     ; this%h2osno_old_col         (:)   = nan   

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -1522,9 +1522,9 @@ contains
             long_name='microtopographic depression depth (m)', ptr_col=this%iwp_ddep)
       call hist_addfld1d (fname="EXCLUDED_VOL", units='m', avgflag='A', &
             long_name='volume of soil above lowest point on IWP surface, normalized by polygon area', &
-            ptr_col=this%iwp_ddep)
+            ptr_col=this%iwp_exclvol)
       call hist_addfld1d (fname="MICROREL", units='m', avgflag='A', &
-            long_name='microtopographic relief (m)', ptr_col=this%iwp_ddep)
+            long_name='microtopographic relief (m)', ptr_col=this%iwp_microrel)
     endif
     !/polygonal tundra
 
@@ -1687,6 +1687,7 @@ contains
        this%frac_h2osfc_act(c)        = 0._r8
        this%h2orof(c)                 = 0._r8
        this%frac_h2orof(c)            = 0._r8
+       this%iwp_subsidence(c)         = 0._r8
 
        if (lun_pp%urbpoi(l)) then
           ! From Bonan 1996 (LSM technical note)

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -1690,8 +1690,6 @@ contains
        this%frac_h2osfc_act(c)        = 0._r8
        this%h2orof(c)                 = 0._r8
        this%frac_h2orof(c)            = 0._r8
-       this%iwp_subsidence(c)         = 0._r8
-       this%frac_melted(c,:)          = 0._r8
 
        if (lun_pp%urbpoi(l)) then
           ! From Bonan 1996 (LSM technical note)
@@ -1861,6 +1859,8 @@ contains
        if (use_polygonal_tundra) then
          ! RPF 240713 - notes from Chuck Abolt: initialize all to 0.36_r8
          this%excess_ice(c,:) = 0.36_r8
+         this%iwp_subsidence(c) = 0._r8
+         this%frac_melted(c,:)  = 0._r8
        end if
     end do
 

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -1574,9 +1574,9 @@ contains
     end if
 
     this%excess_ice(begc:endc) = spval
-    call hist_addfld1d (fname='EXCESS_ICE', units = 'kg/m2', &
-         avgflag='A', long_name='Excess ground ice', &
-         ptr_col=this$excess_ice, l2g_scale_type='veg') ! <- RPF: should this be natveg?
+    call hist_addfld1d (fname='EXCESS_ICE', units = '1', &
+         avgflag='A', long_name='Excess ground ice (0 to 1)', &
+         ptr_col=this%excess_ice, l2g_scale_type='veg') ! <- RPF: should this be natveg?
 
     this%frac_sno(begc:endc) = spval
     call hist_addfld1d (fname='FSNO',  units='1',  &
@@ -1649,6 +1649,7 @@ contains
        this%frac_h2osfc_act(c)        = 0._r8
        this%h2orof(c)                 = 0._r8
        this%frac_h2orof(c)            = 0._r8
+       this%excess_ice(c)             = 0.5_r8
 
        if (lun_pp%urbpoi(l)) then
           ! From Bonan 1996 (LSM technical note)
@@ -1928,7 +1929,7 @@ contains
 
     call restartvar(ncid=ncid, flag=flag, varname='EXCESS_ICE', xtype=ncd_double, &
          dim1name='column', &
-         long_name='excess ground ice', units='kg/m2', &
+         long_name='excess ground ice (0 to 1)', units='1', &
          interpinic_flag='interp', readvar=readvar, data=this%excess_ice)
 
     call restartvar(ncid=ncid, flag=flag, varname='frac_sno', xtype=ncd_double,  &

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -1515,7 +1515,7 @@ contains
 
       call hist_addfld2d (fname='EXCESS_ICE', units = '1', type2d='levgrnd', &
            avgflag='A', long_name='Excess ground ice (0 to 1)', &
-           ptr_col=this%excess_ice, l2g_scale_type='veg') ! <- RPF: should this be natveg?
+           ptr_col=this%excess_ice, l2g_scale_type='veg')
       call hist_addfld1d (fname="SUBSIDENCE", units='m', avgflag='A', &
             long_name='ground subsidence (m)', ptr_col=this%iwp_subsidence)
       call hist_addfld1d (fname="DEPRESS_DEPTH", units='m', avgflag='A', &
@@ -1857,7 +1857,6 @@ contains
        this%h2osoi_liq_old(c,:) = this%h2osoi_liq(c,:)
        this%h2osoi_ice_old(c,:) = this%h2osoi_ice(c,:)
        if (use_polygonal_tundra) then
-         ! RPF 240713 - notes from Chuck Abolt: initialize all to 0.36_r8
          this%excess_ice(c,:) = 0.36_r8
          this%iwp_subsidence(c) = 0._r8
          this%frac_melted(c,:)  = 0._r8

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -48,7 +48,8 @@ module ColumnDataType
   use CNDecompCascadeConType , only : decomp_cascade_con
   use ColumnType      , only : col_pp
   use LandunitType    , only : lun_pp
-  use timeInfoMod , only : nstep_mod 
+  use GridcellType    , only : grc_pp
+  use timeInfoMod , only : nstep_mod
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -1109,7 +1110,7 @@ contains
     !------------------------------------------------------------------------
     !
     ! !LOCAL VARIABLES:
-    integer           :: c,l,j                        ! indices
+    integer           :: c,l,j,g                        ! indices
     real(r8), pointer :: data2dptr(:,:), data1dptr(:) ! temp. pointers for slicing larger arrays
 
     !------------------------------------------------------------------------------
@@ -1234,8 +1235,13 @@ contains
        ! Below snow temperatures - nonlake points (lake points are set below)
        if (.not. lun_pp%lakpoi(l)) then
 
-          if (lun_pp%itype(l)==istice .or. lun_pp%itype(l)==istice_mec .or. use_arctic_init) then
-             this%t_soisno(c,1:nlevgrnd) = 250._r8
+          if (lun_pp%itype(l)==istice .or. lun_pp%itype(l)==istice_mec) then
+            if (use_arctic_init) then
+              g = lun_pp%gridcell(l)
+              this%t_soisnow(c,1:nlevgrnd) = 250._r8 + 40._r8 * cos(grc_pp%lat(g)) ! vary between 250 and 290 based on cos(lat)
+            else
+              this%t_soisno(c,1:nlevgrnd) = 250._r8
+            end if
 
           else if (lun_pp%itype(l) == istwet) then
              this%t_soisno(c,1:nlevgrnd) = 277._r8
@@ -1397,17 +1403,9 @@ contains
     allocate(this%h2osoi_liq         (begc:endc,-nlevsno+1:nlevgrnd)) ; this%h2osoi_liq         (:,:) = spval
     allocate(this%h2osoi_ice         (begc:endc,-nlevsno+1:nlevgrnd)) ; this%h2osoi_ice         (:,:) = spval
     allocate(this%h2osoi_vol         (begc:endc, 1:nlevgrnd))         ; this%h2osoi_vol         (:,:) = spval
-<<<<<<< HEAD
-    allocate(this%h2osfc             (begc:endc))                     ; this%h2osfc             (:)   = spval   
-    allocate(this%h2ocan             (begc:endc))                     ; this%h2ocan             (:)   = spval 
-||||||| parent of 88480f7699 (Update excess_ice from single column value to depth varying)
-    allocate(this%h2osfc             (begc:endc))                     ; this%h2osfc             (:)   = spval
-    allocate(this%h2ocan             (begc:endc))                     ; this%h2ocan             (:)   = spval
-=======
     allocate(this%excess_ice         (begc:endc, 1:nlevgrnd))         ; this%excess_ice         (:,:) = spval
     allocate(this%h2osfc             (begc:endc))                     ; this%h2osfc             (:)   = spval
     allocate(this%h2ocan             (begc:endc))                     ; this%h2ocan             (:)   = spval
->>>>>>> 88480f7699 (Update excess_ice from single column value to depth varying)
     allocate(this%wslake_col         (begc:endc))                     ; this%wslake_col         (:)   = spval
     allocate(this%total_plant_stored_h2o(begc:endc))                  ; this%total_plant_stored_h2o(:)= spval  
     allocate(this%h2osoi_liqvol      (begc:endc,-nlevsno+1:nlevgrnd)) ; this%h2osoi_liqvol      (:,:) = spval

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -1094,7 +1094,7 @@ contains
     !
     ! !USES:
     use landunit_varcon, only : istice, istwet, istsoil, istdlak, istice_mec
-    use elm_varctl     , only : iulog, use_cn, use_vancouver, use_mexicocity
+    use elm_varctl     , only : iulog, use_cn, use_vancouver, use_mexicocity, use_arctic_init
     use column_varcon  , only : icol_road_perv, icol_road_imperv, icol_roof, icol_sunwall, icol_shadewall
     use UrbanParamsType, only : urbanparams_vars
     !
@@ -1229,7 +1229,7 @@ contains
        ! Below snow temperatures - nonlake points (lake points are set below)
        if (.not. lun_pp%lakpoi(l)) then
 
-          if (lun_pp%itype(l)==istice .or. lun_pp%itype(l)==istice_mec) then
+          if (lun_pp%itype(l)==istice .or. lun_pp%itype(l)==istice_mec .or. use_arctic_init) then
              this%t_soisno(c,1:nlevgrnd) = 250._r8
 
           else if (lun_pp%itype(l) == istwet) then
@@ -1371,7 +1371,7 @@ contains
   !------------------------------------------------------------------------
   subroutine col_ws_init(this, begc, endc, h2osno_input, snow_depth_input, watsat_input)
     !
-    use elm_varctl  , only : use_lake_wat_storage
+    use elm_varctl  , only : use_lake_wat_storage, use_arctic_init
     ! !ARGUMENTS:
     class(column_water_state) :: this
     integer , intent(in)      :: begc,endc
@@ -1713,6 +1713,8 @@ contains
                 else
 		               if (use_fates .or. use_hydrstress) then
                       this%h2osoi_vol(c,j) = 0.70_r8*watsat_input(c,j) !0.15_r8 to avoid very dry conditions that cause errors in FATES
+                   else if (use_arctic_init) then
+                     this%h2osoi_vol(c,j) = watsat_input(c,j) ! start saturated for arctic
                    else
                       this%h2osoi_vol(c,j) = 0.15_r8
                    endif

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -1236,12 +1236,7 @@ contains
        if (.not. lun_pp%lakpoi(l)) then
 
           if (lun_pp%itype(l)==istice .or. lun_pp%itype(l)==istice_mec) then
-            if (use_arctic_init) then
-              g = lun_pp%gridcell(l)
-              this%t_soisnow(c,1:nlevgrnd) = 250._r8 + 40._r8 * cos(grc_pp%lat(g)) ! vary between 250 and 290 based on cos(lat)
-            else
-              this%t_soisno(c,1:nlevgrnd) = 250._r8
-            end if
+             this%t_soisno(c,1:nlevgrnd) = 250._r8
 
           else if (lun_pp%itype(l) == istwet) then
              this%t_soisno(c,1:nlevgrnd) = 277._r8
@@ -1286,7 +1281,12 @@ contains
                 end if
              end if
           else
-             this%t_soisno(c,1:nlevgrnd) = 274._r8
+            if (use_arctic_init) then
+              g = lun_pp%gridcell(l)
+              this%t_soisno(c,1:nlevgrnd) = 250._r8 + 40._r8 * cos(grc_pp%lat(g)) ! vary between 250 and 290 based on cos(lat)
+            else
+              this%t_soisno(c,1:nlevgrnd) = 274._r8
+            end if
           endif
           this%t_grnd(c) = this%t_soisno(c,snl(c)+1)
        endif

--- a/components/elm/src/data_types/ColumnType.F90
+++ b/components/elm/src/data_types/ColumnType.F90
@@ -49,17 +49,19 @@ module ColumnType
      logical , pointer :: active       (:) => null() ! true=>do computations on this column
 
      ! topography
-     real(r8), pointer :: glc_topo     (:) => null() ! surface elevation (m)
-     real(r8), pointer :: micro_sigma  (:) => null() ! microtopography pdf sigma (m)
-     real(r8), pointer :: n_melt       (:) => null() ! SCA shape parameter
-     real(r8), pointer :: topo_slope   (:) => null() ! gridcell topographic slope
-     real(r8), pointer :: topo_std     (:) => null() ! gridcell elevation standard deviation
-     real(r8), pointer :: hslp_p10     (:,:) => null() ! hillslope slope percentiles (unitless)
-     integer, pointer  :: nlevbed      (:) => null() ! number of layers to bedrock
-     real(r8), pointer :: zibed        (:) => null() ! bedrock depth in model (interface level at nlevbed)
-     real(r8), pointer :: iwp_microrel (:) => null() ! ice wedge polygon microtopographic relief (m)
-     real(r8), pointer :: iwp_exclvol  (:) => null() ! ice wedge polygon excluded volume (m)
-     real(r8), pointer :: iwp_ddep     (:) => null() ! ice wedge polygon depression depth (m)
+     real(r8), pointer :: glc_topo      (:) => null() ! surface elevation (m)
+     real(r8), pointer :: micro_sigma   (:) => null() ! microtopography pdf sigma (m)
+     real(r8), pointer :: n_melt        (:) => null() ! SCA shape parameter
+     real(r8), pointer :: topo_slope    (:) => null() ! gridcell topographic slope
+     real(r8), pointer :: topo_std      (:) => null() ! gridcell elevation standard deviation
+     real(r8), pointer :: hslp_p10      (:,:) => null() ! hillslope slope percentiles (unitless)
+     integer, pointer  :: nlevbed       (:) => null() ! number of layers to bedrock
+     real(r8), pointer :: zibed         (:) => null() ! bedrock depth in model (interface level at nlevbed)
+     real(r8), pointer :: iwp_microrel  (:) => null() ! ice wedge polygon microtopographic relief (m)
+     real(r8), pointer :: iwp_exclvol   (:) => null() ! ice wedge polygon excluded volume (m)
+     real(r8), pointer :: iwp_ddep      (:) => null() ! ice wedge polygon depression depth (m)
+     real(r8), pointer :: iwp_subsidence(:) => null() ! ice wedge polygon ground subsidence (m)
+     real(r8), pointer :: meangradz     (:) => null() ! mean topographic gradient at the column level
 
      ! vertical levels
      integer , pointer :: snl          (:)   => null() ! number of snow layers
@@ -134,12 +136,18 @@ contains
     allocate(this%hslp_p10    (begc:endc,nlevslp))             ; this%hslp_p10    (:,:) = spval
     allocate(this%nlevbed     (begc:endc))                     ; this%nlevbed     (:)   = ispval
     allocate(this%zibed       (begc:endc))                     ; this%zibed       (:)   = spval
+    ! polygonal tundra/ice wedge polygons:
+    allocate(this%iwp_microrel  (begc:endc))                   ; this%iwp_microrel  (:) = spval
+    allocate(this%iwp_exclvol   (begc:endc))                   ; this%iwp_exclvol   (:) = spval
+    allocate(this%iwp_ddep      (begc:endc))                   ; this%iwp_ddep      (:) = spval
+    allocate(this%iwp_subsidence(begc:endc))                   ; this%iwp_subsidence(:) = spval
+    allocate(this%meangradz     (begc:endc))                   ; this%meangradz     (:) = spval
 
     allocate(this%hydrologically_active(begc:endc))            ; this%hydrologically_active(:) = .false.
 
     ! Assume that columns are not fates columns until fates initialization begins
     allocate(this%is_fates(begc:endc)); this%is_fates(:) = .false.
-    
+
   end subroutine col_pp_init
 
   !------------------------------------------------------------------------
@@ -176,9 +184,14 @@ contains
     deallocate(this%hslp_p10   )
     deallocate(this%nlevbed    )
     deallocate(this%zibed      )
+    deallocate(this%iwp_microrel)
+    deallocate(this%iwp_exclvol )
+    deallocate(this%iwp_ddep    )
+    deallocate(this%iwp_subsidence)
+    deallocate(this%meangradz     )
     deallocate(this%hydrologically_active)
     deallocate(this%is_fates)
-    
+
   end subroutine col_pp_clean
 
 end module ColumnType

--- a/components/elm/src/data_types/ColumnType.F90
+++ b/components/elm/src/data_types/ColumnType.F90
@@ -175,11 +175,6 @@ contains
     deallocate(this%hslp_p10   )
     deallocate(this%nlevbed    )
     deallocate(this%zibed      )
-    ! RPF note: moving these to col_ws, but col_ws never seems to be deallocated?
-    !deallocate(this%iwp_microrel)
-    !deallocate(this%iwp_exclvol )
-    !deallocate(this%iwp_ddep    )
-    !deallocate(this%iwp_subsidence)
     deallocate(this%meangradz     )
     deallocate(this%hydrologically_active)
     deallocate(this%is_fates)

--- a/components/elm/src/data_types/ColumnType.F90
+++ b/components/elm/src/data_types/ColumnType.F90
@@ -57,6 +57,9 @@ module ColumnType
      real(r8), pointer :: hslp_p10     (:,:) => null() ! hillslope slope percentiles (unitless)
      integer, pointer  :: nlevbed      (:) => null() ! number of layers to bedrock
      real(r8), pointer :: zibed        (:) => null() ! bedrock depth in model (interface level at nlevbed)
+	 real(r8), pointer :: iwp_microrel (:) => null() ! ice wedge polygon microtopographic relief (m)
+	 real(r8), pointer :: iwp_exclvol  (:) => null() ! ice wedge polygon excluded volume (m)
+	 real(r8), pointer :: iwp_ddep     (:) => null() ! ice wedge polygon depression depth (m)
 
      ! vertical levels
      integer , pointer :: snl          (:)   => null() ! number of snow layers

--- a/components/elm/src/data_types/ColumnType.F90
+++ b/components/elm/src/data_types/ColumnType.F90
@@ -57,9 +57,9 @@ module ColumnType
      real(r8), pointer :: hslp_p10     (:,:) => null() ! hillslope slope percentiles (unitless)
      integer, pointer  :: nlevbed      (:) => null() ! number of layers to bedrock
      real(r8), pointer :: zibed        (:) => null() ! bedrock depth in model (interface level at nlevbed)
-	 real(r8), pointer :: iwp_microrel (:) => null() ! ice wedge polygon microtopographic relief (m)
-	 real(r8), pointer :: iwp_exclvol  (:) => null() ! ice wedge polygon excluded volume (m)
-	 real(r8), pointer :: iwp_ddep     (:) => null() ! ice wedge polygon depression depth (m)
+     real(r8), pointer :: iwp_microrel (:) => null() ! ice wedge polygon microtopographic relief (m)
+     real(r8), pointer :: iwp_exclvol  (:) => null() ! ice wedge polygon excluded volume (m)
+     real(r8), pointer :: iwp_ddep     (:) => null() ! ice wedge polygon depression depth (m)
 
      ! vertical levels
      integer , pointer :: snl          (:)   => null() ! number of snow layers

--- a/components/elm/src/data_types/ColumnType.F90
+++ b/components/elm/src/data_types/ColumnType.F90
@@ -57,10 +57,6 @@ module ColumnType
      real(r8), pointer :: hslp_p10      (:,:) => null() ! hillslope slope percentiles (unitless)
      integer, pointer  :: nlevbed       (:) => null() ! number of layers to bedrock
      real(r8), pointer :: zibed         (:) => null() ! bedrock depth in model (interface level at nlevbed)
-     real(r8), pointer :: iwp_microrel  (:) => null() ! ice wedge polygon microtopographic relief (m)
-     real(r8), pointer :: iwp_exclvol   (:) => null() ! ice wedge polygon excluded volume (m)
-     real(r8), pointer :: iwp_ddep      (:) => null() ! ice wedge polygon depression depth (m)
-     real(r8), pointer :: iwp_subsidence(:) => null() ! ice wedge polygon ground subsidence (m)
      real(r8), pointer :: meangradz     (:) => null() ! mean topographic gradient at the column level
 
      ! vertical levels
@@ -136,12 +132,7 @@ contains
     allocate(this%hslp_p10    (begc:endc,nlevslp))             ; this%hslp_p10    (:,:) = spval
     allocate(this%nlevbed     (begc:endc))                     ; this%nlevbed     (:)   = ispval
     allocate(this%zibed       (begc:endc))                     ; this%zibed       (:)   = spval
-    ! polygonal tundra/ice wedge polygons:
-    allocate(this%iwp_microrel  (begc:endc))                   ; this%iwp_microrel  (:) = spval
-    allocate(this%iwp_exclvol   (begc:endc))                   ; this%iwp_exclvol   (:) = spval
-    allocate(this%iwp_ddep      (begc:endc))                   ; this%iwp_ddep      (:) = spval
-    allocate(this%iwp_subsidence(begc:endc))                   ; this%iwp_subsidence(:) = spval
-    allocate(this%meangradz     (begc:endc))                   ; this%meangradz     (:) = spval
+    allocate(this%meangradz   (begc:endc))                     ; this%meangradz   (:)   = spval
 
     allocate(this%hydrologically_active(begc:endc))            ; this%hydrologically_active(:) = .false.
 
@@ -184,10 +175,11 @@ contains
     deallocate(this%hslp_p10   )
     deallocate(this%nlevbed    )
     deallocate(this%zibed      )
-    deallocate(this%iwp_microrel)
-    deallocate(this%iwp_exclvol )
-    deallocate(this%iwp_ddep    )
-    deallocate(this%iwp_subsidence)
+    ! RPF note: moving these to col_ws, but col_ws never seems to be deallocated?
+    !deallocate(this%iwp_microrel)
+    !deallocate(this%iwp_exclvol )
+    !deallocate(this%iwp_ddep    )
+    !deallocate(this%iwp_subsidence)
     deallocate(this%meangradz     )
     deallocate(this%hydrologically_active)
     deallocate(this%is_fates)

--- a/components/elm/src/data_types/LandunitType.F90
+++ b/components/elm/src/data_types/LandunitType.F90
@@ -47,6 +47,8 @@ module LandunitType
      logical , pointer :: urbpoi       (:) => null() ! true=>urban point
      logical , pointer :: glcmecpoi    (:) => null() ! true=>glacier_mec point
      logical , pointer :: active       (:) => null() ! true=>do computations on this landunit
+	 logical , pointer :: ispolygon    (:) => null() ! true=>is polygonal tundra
+	 integer , pointer :: polygontype  (:) => null() ! ice wedge polygon initial condition (LCP, FCP, or HCP)
 
      ! urban properties
      real(r8), pointer :: canyon_hwr   (:) => null() ! urban landunit canyon height to width ratio (-)
@@ -93,6 +95,8 @@ contains
     allocate(this%lakpoi       (begl:endl)); this%lakpoi    (:) = .false.
     allocate(this%urbpoi       (begl:endl)); this%urbpoi    (:) = .false.
     allocate(this%glcmecpoi    (begl:endl)); this%glcmecpoi (:) = .false.
+	allocate(this%ispolygon    (begl:endl)); this%ispolygon (:) = .false.
+	allocate(this%polygontype  (begl:endl)); this%polygontype(:) = ispval
 
     ! The following is initialized in routine setActive in module reweightMod
     allocate(this%active       (begl:endl))
@@ -129,6 +133,8 @@ contains
     deallocate(this%lakpoi       )
     deallocate(this%urbpoi       )
     deallocate(this%glcmecpoi    )
+	deallocate(this%ispolygon    )
+	deallocate(this%polygontype  )
     deallocate(this%active       )
     deallocate(this%canyon_hwr   )
     deallocate(this%wtroad_perv  )

--- a/components/elm/src/data_types/LandunitType.F90
+++ b/components/elm/src/data_types/LandunitType.F90
@@ -47,8 +47,8 @@ module LandunitType
      logical , pointer :: urbpoi       (:) => null() ! true=>urban point
      logical , pointer :: glcmecpoi    (:) => null() ! true=>glacier_mec point
      logical , pointer :: active       (:) => null() ! true=>do computations on this landunit
-	 logical , pointer :: ispolygon    (:) => null() ! true=>is polygonal tundra
-	 integer , pointer :: polygontype  (:) => null() ! ice wedge polygon initial condition (LCP, FCP, or HCP)
+     logical , pointer :: ispolygon    (:) => null() ! true=>is polygonal tundra
+     integer , pointer :: polygontype  (:) => null() ! ice wedge polygon initial condition (LCP, FCP, or HCP)
 
      ! urban properties
      real(r8), pointer :: canyon_hwr   (:) => null() ! urban landunit canyon height to width ratio (-)
@@ -95,8 +95,8 @@ contains
     allocate(this%lakpoi       (begl:endl)); this%lakpoi    (:) = .false.
     allocate(this%urbpoi       (begl:endl)); this%urbpoi    (:) = .false.
     allocate(this%glcmecpoi    (begl:endl)); this%glcmecpoi (:) = .false.
-	allocate(this%ispolygon    (begl:endl)); this%ispolygon (:) = .false.
-	allocate(this%polygontype  (begl:endl)); this%polygontype(:) = ispval
+    allocate(this%ispolygon    (begl:endl)); this%ispolygon (:) = .false.
+    allocate(this%polygontype  (begl:endl)); this%polygontype(:) = ispval
 
     ! The following is initialized in routine setActive in module reweightMod
     allocate(this%active       (begl:endl))
@@ -133,8 +133,8 @@ contains
     deallocate(this%lakpoi       )
     deallocate(this%urbpoi       )
     deallocate(this%glcmecpoi    )
-	deallocate(this%ispolygon    )
-	deallocate(this%polygontype  )
+    deallocate(this%ispolygon    )
+    deallocate(this%polygontype  )
     deallocate(this%active       )
     deallocate(this%canyon_hwr   )
     deallocate(this%wtroad_perv  )

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -335,14 +335,17 @@ contains
          lnd_rof_coupling_nstep
 
     namelist /elm_inparm/ &
-         snow_shape, snicar_atm_type, use_dust_snow_internal_mixing 
-    
-    namelist /elm_inparm/ & 
+         snow_shape, snicar_atm_type, use_dust_snow_internal_mixing
+
+    namelist /elm_inparm/ &
          use_modified_infil
 
     namelist /elm_inparm/ &
          use_fan, fan_mode, fan_to_bgc_veg, nh4_ads_coef
 
+   ! NGEE Arctic options
+   namelist /elm_inparm/ &
+         use_polygonal_tundra
     ! ----------------------------------------------------------------------
     ! Default values
     ! ----------------------------------------------------------------------
@@ -1007,6 +1010,8 @@ contains
     ! use modified infiltration scheme in surface water storage
     call mpi_bcast (use_modified_infil, 1, MPI_LOGICAL, 0, mpicom, ier)
 
+    !NGEE Arctic options
+    call mpi_bcast (use_polygonal_tundra, 1, MPI_LOGICAL, 0, mpicom, ier)
   end subroutine control_spmd
 
   !------------------------------------------------------------------------
@@ -1288,6 +1293,8 @@ contains
        write(iulog,*) ' fan_to_bgc_veg = ', fan_to_bgc_veg
     end if
 
+    ! NGEE Arctic options
+    if (use_polygonal_tundra) write(iulog, *) '    use_polygonal_tundra    =', use_polygonal_tundra
   end subroutine control_print
 
 end module controlMod

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -345,7 +345,7 @@ contains
 
    ! NGEE Arctic options
    namelist /elm_inparm/ &
-         use_polygonal_tundra
+         use_polygonal_tundra, use_arctic_init
     ! ----------------------------------------------------------------------
     ! Default values
     ! ----------------------------------------------------------------------
@@ -1012,6 +1012,8 @@ contains
 
     !NGEE Arctic options
     call mpi_bcast (use_polygonal_tundra, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (use_arctic_init, 1, MPI_LOGICAL, 0, mpicom, ier)
+
   end subroutine control_spmd
 
   !------------------------------------------------------------------------
@@ -1295,6 +1297,8 @@ contains
 
     ! NGEE Arctic options
     if (use_polygonal_tundra) write(iulog, *) '    use_polygonal_tundra    =', use_polygonal_tundra
+    if (use_arctic_init) write(iulog, *)      '    use_arctic_init    ='     , use_arctic_init
+
   end subroutine control_print
 
 end module controlMod

--- a/components/elm/src/main/elm_initializeMod.F90
+++ b/components/elm/src/main/elm_initializeMod.F90
@@ -280,12 +280,7 @@ contains
        allocate (wt_glc_mec  (1,1,1))
        allocate (topo_glc_mec(1,1,1))
     endif
-    if (use_polygonal_tundra) then
-      allocate (wt_polygon (begg:endg,1:max_topounits, max_polygon))
-    else
-      allocate (wt_polygon (begg:endg,1:max_topounits, 1)) ! RF-not sure this is needed
-    endif
-
+    allocate (wt_polygon (begg:endg,1:max_topounits, max_polygon))
     allocate (wt_tunit  (begg:endg,1:max_topounits  ))
     allocate (elv_tunit (begg:endg,1:max_topounits  ))
     allocate (slp_tunit (begg:endg,1:max_topounits  ))

--- a/components/elm/src/main/elm_initializeMod.F90
+++ b/components/elm/src/main/elm_initializeMod.F90
@@ -283,7 +283,7 @@ contains
     if (use_polygonal_tundra) then
       allocate (wt_polygon (begg:endg,1:max_topounits, max_polygon))
     else
-      allocate (wt_polygon (1,1,1)) ! RF-not sure this is needed
+      allocate (wt_polygon (begg:endg,1:max_topounits, 1)) ! RF-not sure this is needed
     endif
 
     allocate (wt_tunit  (begg:endg,1:max_topounits  ))

--- a/components/elm/src/main/elm_initializeMod.F90
+++ b/components/elm/src/main/elm_initializeMod.F90
@@ -63,7 +63,7 @@ contains
     use elm_varpar                , only: update_pft_array_bounds
     use elm_varpar                , only: surfpft_lb, surfpft_ub
     use elm_varcon                , only: elm_varcon_init
-    use landunit_varcon           , only: landunit_varcon_init, max_lunit, istice_mec, max_polygon
+    use landunit_varcon           , only: landunit_varcon_init, max_lunit, istice_mec, max_polygon, max_non_poly_lunit
     use column_varcon             , only: col_itype_to_icemec_class
     use elm_varctl                , only: fsurdat, fatmlndfrc, flndtopo, fglcmask, noland, version
     use pftvarcon                 , only: pftconrd
@@ -267,7 +267,11 @@ contains
 
     ! Allocate surface grid dynamic memory (just gridcell bounds dependent)
 
-    allocate (wt_lunit     (begg:endg,1:max_topounits, max_lunit           )) 
+    if (use_polygonal_tundra) then
+      allocate (wt_lunit     (begg:endg,1:max_topounits, max_lunit           ))
+    else
+      allocate (wt_lunit     (begg:endg,1:max_topounits, max_non_poly_lunit  ))
+    end if
     allocate (urban_valid  (begg:endg,1:max_topounits                      ))
     !allocate (wt_nat_patch (begg:endg,1:max_topounits, surfpft_lb:surfpft_ub ))
     !allocate (wt_cft       (begg:endg,1:max_topounits, cft_lb:cft_ub       ))

--- a/components/elm/src/main/elm_initializeMod.F90
+++ b/components/elm/src/main/elm_initializeMod.F90
@@ -14,7 +14,7 @@ module elm_initializeMod
   use elm_varctl       , only : use_lch4, use_cn, use_voc, use_c13, use_c14
   use elm_varctl       , only : use_fates, use_betr, use_fates_sp, use_fan, use_fates_luh
   use elm_varsur       , only : wt_lunit, urban_valid, wt_nat_patch, wt_cft, wt_glc_mec, topo_glc_mec,firrig,f_surf,f_grd
-  use elm_varsur       , only : fert_cft, fert_p_cft
+  use elm_varsur       , only : fert_cft, fert_p_cft, wt_polygon
   use elm_varsur       , only : wt_tunit, elv_tunit, slp_tunit,asp_tunit,num_tunit_per_grd
   use perf_mod         , only : t_startf, t_stopf
   !use readParamsMod    , only : readParameters
@@ -63,7 +63,7 @@ contains
     use elm_varpar                , only: update_pft_array_bounds
     use elm_varpar                , only: surfpft_lb, surfpft_ub
     use elm_varcon                , only: elm_varcon_init
-    use landunit_varcon           , only: landunit_varcon_init, max_lunit, istice_mec
+    use landunit_varcon           , only: landunit_varcon_init, max_lunit, istice_mec, max_polygon
     use column_varcon             , only: col_itype_to_icemec_class
     use elm_varctl                , only: fsurdat, fatmlndfrc, flndtopo, fglcmask, noland, version
     use pftvarcon                 , only: pftconrd
@@ -87,7 +87,7 @@ contains
     use filterMod                 , only: allocFilters
     use reweightMod               , only: reweight_wrapup
     use topounit_varcon           , only: max_topounits, has_topounit, topounit_varcon_init
-    use elm_varctl                , only: use_top_solar_rad
+    use elm_varctl                , only: use_top_solar_rad, use_polygonal_tundra
     !
     ! !LOCAL VARIABLES:
     integer           :: ier                     ! error status
@@ -280,8 +280,13 @@ contains
        allocate (wt_glc_mec  (1,1,1))
        allocate (topo_glc_mec(1,1,1))
     endif
-    
-    allocate (wt_tunit  (begg:endg,1:max_topounits  )) 
+    if (use_polygonal_tundra) then
+      allocate (wt_polygon (begg:endg,1:max_topounits, max_polygon))
+    else
+      allocate (wt_polygon (1,1,1)) ! RF-not sure this is needed
+    endif
+
+    allocate (wt_tunit  (begg:endg,1:max_topounits  ))
     allocate (elv_tunit (begg:endg,1:max_topounits  ))
     allocate (slp_tunit (begg:endg,1:max_topounits  ))
     allocate (asp_tunit (begg:endg,1:max_topounits  ))
@@ -431,6 +436,7 @@ contains
     !deallocate (wt_lunit, wt_cft, wt_glc_mec)
     deallocate (wt_cft, wt_glc_mec)    !wt_lunit not deallocated because it is being used in CanopyHydrologyMod.F90
     deallocate (wt_tunit, elv_tunit, slp_tunit, asp_tunit,num_tunit_per_grd)
+    deallocate (wt_polygon) ! RF - might be used elsewhere, not sure if we want to deallocate here.
     call t_stopf('elm_init1')
 
     ! initialize glc_topo

--- a/components/elm/src/main/elm_varctl.F90
+++ b/components/elm/src/main/elm_varctl.F90
@@ -394,7 +394,11 @@ module elm_varctl
   logical, public :: fan_nh3_to_atm      = .false.
   logical, public :: fan_to_bgc_crop     = .false.
   logical, public :: fan_to_bgc_veg      = .false.
- 
+
+  !----------------------------------------------------------
+  ! NGEE Arctic parameterizations
+  !----------------------------------------------------------
+  logical, public :: use_polygonal_tundra = .false.
 
   !----------------------------------------------------------
   ! VSFM switches

--- a/components/elm/src/main/elm_varctl.F90
+++ b/components/elm/src/main/elm_varctl.F90
@@ -399,6 +399,7 @@ module elm_varctl
   ! NGEE Arctic parameterizations
   !----------------------------------------------------------
   logical, public :: use_polygonal_tundra = .false.
+  logical, public :: use_arctic_init     = .false.
 
   !----------------------------------------------------------
   ! VSFM switches

--- a/components/elm/src/main/elm_varsur.F90
+++ b/components/elm/src/main/elm_varsur.F90
@@ -22,7 +22,13 @@ module elm_varsur
   ! for natural veg landunit, weight of each pft on the landunit (adds to 1.0 on the
   ! landunit for all all grid cells, even! those without any natural pft)
   ! (second dimension goes natpft_lb:natpft_ub)
-  real(r8), pointer :: wt_nat_patch(:,:,:)   
+  real(r8), pointer :: wt_nat_patch(:,:,:)
+
+  ! for polygonal tundra special case of natural veg landunit, weight of polygon type
+  ! with respect to the natural vegetation landunit (NOT the grid cell). these do
+  ! not need to sum to 1 to preserve possibility of polygonal tundra and non-polygonal
+  ! ground on the same grid cell, on the vegetated landunit.
+  real(r8), pointer :: wt_polygon(:,:,:) ! dims: clump, topounit, polygon type
 
   ! for crop landunit, weight of each cft on the landunit (adds to 1.0 on the
   ! landunit for all all grid cells, even  those without any crop)

--- a/components/elm/src/main/initGridCellsMod.F90
+++ b/components/elm/src/main/initGridCellsMod.F90
@@ -376,14 +376,6 @@ contains
     ! c) natural vegetation, flat centered polygons
     ! d) natural vegetation, low centered polygons
 
-    !if (use_polygonal_tundra) then
-    !  orig_wtlunit2topounit = wtlunit2topounit
-    !  ! adjust wtlunit2topounit to subtract fraction that is polygonal
-    !  wtlunit2topounit = wtlunit2topounit * (1._r8 - sum(wt_polygon(gi, topo_ind, :))) ! sum over polygon types
-    !  ! DEBUG:
-    !  write(iulog,*) "DEBUG / new, original, polygon weights are:",wtlunit2topounit,orig_wtlunit2topounit,wt_polygon(gi,topo_ind,:)
-    !endif
-
     ! For FATES: the total number of patches may not match what is in the surface
     ! file, and therefor the weighting can't be used. The weightings in
     ! wt_nat_patch may be meaningful (like with fixed biogeography), but they
@@ -424,8 +416,7 @@ contains
                p_wt = wt_nat_patch(gi,topo_ind,m)
              end if
              call add_patch(pi=pi, ci=ci, ptype=m, wtcol=p_wt)
-             write(iulog,*) "polygon column counter:", z, pi, ci, li, ti
-           end do 
+           end do
          end do
        end if 
 

--- a/components/elm/src/main/initSubgridMod.F90
+++ b/components/elm/src/main/initSubgridMod.F90
@@ -29,6 +29,7 @@ module initSubgridMod
   public :: elm_ptrs_check    ! checks and writes out a summary of subgrid data
   public :: add_topounit      ! add an entry in the topounit-level arrays
   public :: add_landunit      ! add an entry in the landunit-level arrays
+  public :: add_polygon_landunit ! adds an entry in the landunit-level arrays for the special type of polygonal ground.
   public :: add_column        ! add an entry in the column-level arrays
   public :: add_patch         ! add an entry in the patch-level arrays
   !
@@ -476,6 +477,51 @@ contains
     end if
 
   end subroutine add_landunit
+
+!-----------------------------------------------------------------------
+  subroutine add_polygon_landunit(li, ti, ltype, wttopounit, polytype)
+   !
+   ! !DESCRIPTION:
+   ! Add an entry in the landunit-level arrays. li gives the index of the last landunit
+   ! added; the new landunit is added at li+1, and the li argument is incremented
+   ! accordingly.
+   !
+   ! This verison of add_landunit is specific to polygonal tundra.
+   !
+   ! !USES:
+   use landunit_varcon , only : istsoil, istcrop, istice_mec, istdlak, isturb_MIN, isturb_MAX
+   !
+   ! !ARGUMENTS:
+   integer  , intent(inout) :: li         ! input value is index of last landunit added; output value is index of this newly-added landunit
+   integer  , intent(in)    :: ti         ! topounit index on which this landunit should be placed
+   integer  , intent(in)    :: ltype      ! landunit type
+   real(r8) , intent(in)    :: wttopounit ! weight of the landunit relative to the topounit
+   integer  , intent(in)    :: polytype   ! defines the type of ice wedge polygon this landunit corresponds to
+   !
+   ! !LOCAL VARIABLES:
+
+   character(len=*), parameter :: subname = 'add_polygon_landunit'
+   !-----------------------------------------------------------------------
+
+   li = li + 1
+
+   lun_pp%topounit(li) = ti
+   lun_pp%gridcell(li) = top_pp%gridcell(ti)
+
+   lun_pp%wttopounit(li) = wttopounit
+   lun_pp%itype(li) = ltype
+
+   if (ltype == istsoil) then
+      lun_pp%ifspecial(li) = .false.
+      lun_pp%ispolygon(li) = .true.
+      lun_pp%polygontype(li) = polytype
+   else
+      write (iulog, *) "ERROR: attempting to assign polygonal tundra landunit to special or crop landunit type"
+      call endrun(msg=errMsg(__FILE__, __LINE__))
+   end if
+
+ end subroutine add_polygon_landunit
+
 
   !-----------------------------------------------------------------------
   subroutine add_column(ci, li, ctype, wtlunit)

--- a/components/elm/src/main/initSubgridMod.F90
+++ b/components/elm/src/main/initSubgridMod.F90
@@ -499,7 +499,7 @@ contains
    ! This verison of add_landunit is specific to polygonal tundra.
    !
    ! !USES:
-   use landunit_varcon , only : istsoil, istcrop, istice_mec, istdlak, isturb_MIN, isturb_MAX
+   use landunit_varcon , only : istsoil
    !
    ! !ARGUMENTS:
    integer  , intent(inout) :: li         ! input value is index of last landunit added; output value is index of this newly-added landunit

--- a/components/elm/src/main/initVerticalMod.F90
+++ b/components/elm/src/main/initVerticalMod.F90
@@ -22,8 +22,9 @@ module initVerticalMod
   use column_varcon  , only : icol_roof, icol_sunwall, icol_shadewall, icol_road_perv, icol_road_imperv
   use landunit_varcon, only : istdlak, istice_mec
   use fileutils      , only : getfil
-  use LandunitType   , only : lun_pp                
-  use ColumnType     , only : col_pp                
+  use LandunitType   , only : lun_pp
+  use ColumnType     , only : col_pp
+  use ColumnDataType , only : col_ws
   use SnowHydrologyMod, only : InitSnowLayers
   use ncdio_pio
   use topounit_varcon  , only : max_topounits
@@ -584,6 +585,7 @@ contains
             g = col_pp%gridcell(c)
             col_pp%meangradz(c) = gradz(g)
          end do
+         deallocate(gradz)
       end if
 
       allocate(std(bounds%begg:bounds%endg))

--- a/components/elm/src/main/initVerticalMod.F90
+++ b/components/elm/src/main/initVerticalMod.F90
@@ -17,8 +17,8 @@ module initVerticalMod
   use elm_varpar     , only : nlevsoi, nlevsoifl, nlevurb, nlevslp 
   use elm_varctl     , only : fsurdat, iulog, use_var_soil_thick
   use elm_varctl     , only : use_vancouver, use_mexicocity, use_vertsoilc, use_extralakelayers, use_extrasnowlayers
-  use elm_varctl     , only : use_erosion
-  use elm_varcon     , only : zlak, dzlak, zsoi, dzsoi, zisoi, dzsoi_decomp, spval, grlnd 
+  use elm_varctl     , only : use_erosion, use_polygonal_tundra
+  use elm_varcon     , only : zlak, dzlak, zsoi, dzsoi, zisoi, dzsoi_decomp, spval, grlnd
   use column_varcon  , only : icol_roof, icol_sunwall, icol_shadewall, icol_road_perv, icol_road_imperv
   use landunit_varcon, only : istdlak, istice_mec
   use fileutils      , only : getfil
@@ -55,8 +55,9 @@ contains
     logical               :: readvar 
     integer               :: dimid             ! dimension id
     character(len=256)    :: locfn             ! local filename
-    real(r8) ,pointer     :: std (:)           ! read in - topo_std 
-    real(r8) ,pointer     :: tslope (:)        ! read in - topo_slope 
+    real(r8) ,pointer     :: std (:)           ! read in - topo_std
+    real(r8) ,pointer     :: tslope (:)        ! read in - topo_slope
+    real(r8) ,pointer     :: gradz(:)          ! read in - gradz (polygonal tundra only)
     real(r8) ,pointer     :: hslp_p10 (:,:,:)    ! read in - hillslope slope percentiles
     real(r8) ,pointer     :: dtb (:,:)           ! read in - DTB
     real(r8)              :: beddep            ! temporary
@@ -571,6 +572,19 @@ contains
          col_pp%topo_slope(c) = max(tslope(g), 0.2_r8)
       end do
       deallocate(tslope)
+
+      if (use_polygonal_tundra) then
+         allocate(gradz(bounds%begg:bounds%endg))
+         call ncd_io(ncid=ncid, varname='GRADZ', flag='read', data=gradz, dim1name=grlnd, readvar=readvar)
+         if (.not. readvar) then
+            call shr_sys_abort(' ERROR: polygonal tundra turned on, but GRADZ not on surfdata file'//&
+            errMsg(__FILE__, __LINE__))
+         end if
+         do c = begc,endc
+            g = col_pp%gridcell(c)
+            col_pp%meangradz(c) = gradz(g)
+         end do
+      end if
 
       allocate(std(bounds%begg:bounds%endg))
       call ncd_io(ncid=ncid, varname='STD_ELEV', flag='read', data=std, dim1name=grlnd, readvar=readvar)

--- a/components/elm/src/main/landunit_varcon.F90
+++ b/components/elm/src/main/landunit_varcon.F90
@@ -35,7 +35,12 @@ module landunit_varcon
 
   integer, parameter, public                   :: landunit_name_length = 40  ! max length of landunit names
   character(len=landunit_name_length), public  :: landunit_names(max_lunit)  ! name of each landunit type
-
+  
+  ! land unit polygonal ground types
+  integer, parameter, public :: ilowcenpoly     = 1     ! low-centered polygons
+  integer, parameter, public :: iflatcenpoly    = 2	    ! flat-centered polygons
+  integer, parameter, public :: ihighcenpoly    = 3	    ! high-centered polygons
+  
   ! parameters that depend on the above constants
 
   integer, parameter, public :: numurbl = isturb_MAX - isturb_MIN + 1   ! number of urban landunits
@@ -48,6 +53,7 @@ module landunit_varcon
   !
   ! !PRIVATE MEMBER FUNCTIONS:
   private :: set_landunit_names   ! set the landunit_names vector
+  private :: set_polygon_names    ! set the polygon_names vector
 !-----------------------------------------------------------------------
 
 contains
@@ -97,6 +103,30 @@ contains
     end if
 
   end function landunit_is_special
+
+  subroutine set_polygon_names
+    !
+    ! !DESCRIPTION:
+    ! Set the polygon_names vector
+    !
+    ! !USES:
+    use shr_sys_mod, only : shr_sys_abort
+    !
+    character(len=*), parameter :: not_set = 'NOT_SET'
+    character(len=*), parameter :: subname = 'set_polygon_names'
+    !-----------------------------------------------------------------------
+    
+    polygon_names(:) = not_set
+
+    polygon_names(ilowcenpoly) = 'low_centered_polygons'
+    polygon_names(iflatcenpoly) = 'flat_centered_polygons'
+    polygon_names(ihighcenpoly) = 'high_centered_polygons'
+
+    if (any(polygon_names == not_set)) then
+       call shr_sys_abort(trim(subname)//': Not all polygon names set')
+    end if
+ 
+  end subroutine set_polygon_names
 
   !-----------------------------------------------------------------------
   subroutine set_landunit_names

--- a/components/elm/src/main/landunit_varcon.F90
+++ b/components/elm/src/main/landunit_varcon.F90
@@ -29,9 +29,13 @@ module landunit_varcon
   integer, parameter, public :: isturb_hd  = 8  !urban hd     landunit type
   integer, parameter, public :: isturb_md  = 9  !urban md     landunit type
   integer, parameter, public :: isturb_MAX = 9  !maximum urban type index
+  integer, parameter, public :: istlowcenpoly  = 10 ! low centered polygon landunit type
+  integer, parameter, public :: istflatcenpoly = 11 ! flat cenetered polygon landunit type
+  integer, parameter, public :: isthighcenpoly = 12 ! high centered polygon landunit type
 
-  integer, parameter, public :: max_lunit  = 9  !maximum value that lun_pp%itype can have
+  integer, parameter, public :: max_lunit  = 12  !maximum value that lun_pp%itype can have
                                         !(i.e., largest value in the above list)
+  integer, parameter, public :: max_non_poly_lunit = 9 ! maximum non-polygonal tundra land unit
 
   integer, parameter, public                   :: landunit_name_length = 40  ! max length of landunit names
   character(len=landunit_name_length), public  :: landunit_names(max_lunit)  ! name of each landunit type
@@ -160,6 +164,9 @@ contains
     landunit_names(isturb_tbd) = 'urban_tbd'
     landunit_names(isturb_hd) = 'urban_hd'
     landunit_names(isturb_md) = 'urban_md'
+    landunit_names(istlowcenpoly) = 'low_centered_polygon'
+    landunit_names(istflatcenpoly) = 'flat_centered_polygon'
+    landunit_names(isthighcenpoly) = 'high_centered_polygon'
 
     if (any(landunit_names == not_set)) then
        call shr_sys_abort(trim(subname)//': Not all landunit names set')

--- a/components/elm/src/main/landunit_varcon.F90
+++ b/components/elm/src/main/landunit_varcon.F90
@@ -41,6 +41,14 @@ module landunit_varcon
   integer, parameter, public :: iflatcenpoly    = 2	    ! flat-centered polygons
   integer, parameter, public :: ihighcenpoly    = 3	    ! high-centered polygons
   
+  integer, parameter, public :: max_poly  = 3  !maximum value that lun_pp%polygontype can have
+                                        !(i.e., largest value in the above list)
+
+  integer, parameter, public                   :: polygon_name_length = 40  ! max length of landunit names
+  character(len=polygon_name_length), public   :: polygon_names(max_poly)  ! name of each landunit type
+  
+  
+  
   ! parameters that depend on the above constants
 
   integer, parameter, public :: numurbl = isturb_MAX - isturb_MIN + 1   ! number of urban landunits

--- a/components/elm/src/main/landunit_varcon.F90
+++ b/components/elm/src/main/landunit_varcon.F90
@@ -6,6 +6,7 @@ module landunit_varcon
   !
   ! !USES:
 #include "shr_assert.h"
+    use elm_varctl, only : use_polygonal_tundra
   !
   !
   ! !PUBLIC TYPES:
@@ -38,8 +39,8 @@ module landunit_varcon
   integer, parameter, public :: max_non_poly_lunit = 9 ! maximum non-polygonal tundra land unit
 
   integer, parameter, public                   :: landunit_name_length = 40  ! max length of landunit names
-  character(len=landunit_name_length), public  :: landunit_names(max_lunit)  ! name of each landunit type
-  
+  character(len=landunit_name_length), allocatable, public  :: landunit_names(:)  ! name of each landunit type
+
   ! land unit polygonal ground types
   integer, parameter, public :: ilowcenpoly     = 1     ! low-centered polygons
   integer, parameter, public :: iflatcenpoly    = 2     ! flat-centered polygons
@@ -65,6 +66,7 @@ module landunit_varcon
   ! !PRIVATE MEMBER FUNCTIONS:
   private :: set_landunit_names   ! set the landunit_names vector
   private :: set_polygon_names    ! set the polygon_names vector
+
 !-----------------------------------------------------------------------
 
 contains
@@ -148,11 +150,18 @@ contains
     !
     ! !USES:
     use shr_sys_mod, only : shr_sys_abort
+
     !
     character(len=*), parameter :: not_set = 'NOT_SET'
     character(len=*), parameter :: subname = 'set_landunit_names'
     !-----------------------------------------------------------------------
-    
+
+    if (use_polygonal_tundra) then
+      allocate(landunit_names(max_lunit))
+    else
+      allocate(landunit_names(max_non_poly_lunit))
+    end if
+
     landunit_names(:) = not_set
 
     landunit_names(istsoil) = 'vegetated_or_bare_soil'
@@ -164,9 +173,11 @@ contains
     landunit_names(isturb_tbd) = 'urban_tbd'
     landunit_names(isturb_hd) = 'urban_hd'
     landunit_names(isturb_md) = 'urban_md'
-    landunit_names(istlowcenpoly) = 'low_centered_polygon'
-    landunit_names(istflatcenpoly) = 'flat_centered_polygon'
-    landunit_names(isthighcenpoly) = 'high_centered_polygon'
+    if (use_polygonal_tundra) then
+      landunit_names(istlowcenpoly) = 'low_centered_polygon'
+      landunit_names(istflatcenpoly) = 'flat_centered_polygon'
+      landunit_names(isthighcenpoly) = 'high_centered_polygon'
+    end if
 
     if (any(landunit_names == not_set)) then
        call shr_sys_abort(trim(subname)//': Not all landunit names set')

--- a/components/elm/src/main/landunit_varcon.F90
+++ b/components/elm/src/main/landunit_varcon.F90
@@ -40,15 +40,14 @@ module landunit_varcon
   integer, parameter, public :: ilowcenpoly     = 1     ! low-centered polygons
   integer, parameter, public :: iflatcenpoly    = 2     ! flat-centered polygons
   integer, parameter, public :: ihighcenpoly    = 3     ! high-centered polygons
-  
-  integer, parameter, public :: max_poly  = 3  !maximum value that lun_pp%polygontype can have
-                                        !(i.e., largest value in the above list)
+
+  integer, parameter, public :: max_polygon = 3  !maximum value that lun_pp%polygontype can have
+                                                 !(i.e., largest value in the above list)
 
   integer, parameter, public                   :: polygon_name_length = 40  ! max length of landunit names
-  character(len=polygon_name_length), public   :: polygon_names(max_poly)  ! name of each landunit type
-  
-  
-  
+  character(len=polygon_name_length), public   :: polygon_names(max_polygon)! name of each landunit type
+
+
   ! parameters that depend on the above constants
 
   integer, parameter, public :: numurbl = isturb_MAX - isturb_MIN + 1   ! number of urban landunits

--- a/components/elm/src/main/landunit_varcon.F90
+++ b/components/elm/src/main/landunit_varcon.F90
@@ -38,8 +38,8 @@ module landunit_varcon
   
   ! land unit polygonal ground types
   integer, parameter, public :: ilowcenpoly     = 1     ! low-centered polygons
-  integer, parameter, public :: iflatcenpoly    = 2	    ! flat-centered polygons
-  integer, parameter, public :: ihighcenpoly    = 3	    ! high-centered polygons
+  integer, parameter, public :: iflatcenpoly    = 2     ! flat-centered polygons
+  integer, parameter, public :: ihighcenpoly    = 3     ! high-centered polygons
   
   integer, parameter, public :: max_poly  = 3  !maximum value that lun_pp%polygontype can have
                                         !(i.e., largest value in the above list)
@@ -82,6 +82,7 @@ contains
     !-----------------------------------------------------------------------
     
     call set_landunit_names()
+    call set_polygon_names()
 
   end subroutine landunit_varcon_init
   

--- a/components/elm/src/main/restFileMod.F90
+++ b/components/elm/src/main/restFileMod.F90
@@ -1025,7 +1025,8 @@ contains
     ! Add global metadata defining landunit types
     !
     ! !USES:
-    use landunit_varcon, only : max_lunit, landunit_names, landunit_name_length
+    use landunit_varcon, only : max_lunit, max_non_poly_lunit, landunit_names, landunit_name_length
+    use elm_varctl,      only : use_polygonal_tundra
     !
     ! !ARGUMENTS:
     type(file_desc_t), intent(inout) :: ncid ! local file id
@@ -1038,10 +1039,17 @@ contains
     character(len=*), parameter :: subname = 'restFile_add_ilun_metadata'
     !-----------------------------------------------------------------------
     
-    do ltype = 1, max_lunit
-       attname = att_prefix // landunit_names(ltype)
-       call ncd_putatt(ncid, ncd_global, attname, ltype)
-    end do
+    if (use_polygonal_tundra) then
+      do ltype = 1, max_lunit
+        attname = att_prefix // landunit_names(ltype)
+        call ncd_putatt(ncid, ncd_global, attname, ltype)
+      end do
+    else
+      do ltype = 1, max_non_poly_lunit
+        attname = att_prefix // landunit_names(ltype)
+        call ncd_putatt(ncid, ncd_global, attname, ltype)
+      end do
+    end if
 
   end subroutine restFile_add_ilun_metadata
 

--- a/components/elm/src/main/subgridMod.F90
+++ b/components/elm/src/main/subgridMod.F90
@@ -40,7 +40,7 @@ contains
     !
     ! !USES
     use elm_varpar  , only : natpft_size, cft_size, maxpatch_urb, maxpatch_glcmec
-    use elm_varctl  , only : create_crop_landunit
+    use elm_varctl  , only : create_crop_landunit, use_polygonal_tundra
     use elm_varsur  , only : wt_lunit, urban_valid, wt_glc_mec
     use landunit_varcon  , only : istsoil, istcrop, istice, istice_mec, istdlak, istwet, &
                              isturb_tbd, isturb_hd, isturb_md
@@ -159,6 +159,13 @@ contains
 
        if (present(nveg)) nveg = nveg + npfts_per_lunit
 
+       ! polygonal tundra
+       if (use_polygonal_tundra) then
+         ilunits = ilunits + 3
+         icols = icols + 3
+         ipfts = ipfts + 3 * npfts_per_lunit
+         ! if (present(nveg)) nveg = nveg + 3 * npfts_per_lunit
+       endif
        ! -------------------------------------------------------------------------
        ! Set urban landunits
        ! -------------------------------------------------------------------------
@@ -334,7 +341,7 @@ contains
     !
     ! !USES
     use elm_varpar  , only : natpft_size, cft_size, maxpatch_urb, maxpatch_glcmec
-    use elm_varctl  , only : create_crop_landunit
+    use elm_varctl  , only : create_crop_landunit, use_polygonal_tundra
     use elm_varsur  , only : wt_lunit, urban_valid, wt_glc_mec
     use landunit_varcon  , only : istsoil, istcrop, istice, istice_mec, istdlak, istwet, &
                              isturb_tbd, isturb_hd, isturb_md
@@ -422,6 +429,17 @@ contains
     icohorts = fates_maxElementsPerSite
 
     if (present(nveg)) nveg = nveg + npfts_per_lunit
+
+    ! -----------------------------------------------------------------------
+    ! polygonal tundra
+
+    ! polygonal tundra
+    if (use_polygonal_tundra) then
+      ilunits = ilunits + 3
+      icols = icols + 3
+      ipfts = ipfts + 3 * npfts_per_lunit
+      ! if (present(nveg)) nveg = nveg + 3 * npfts_per_lunit
+    endif
 
     ! -------------------------------------------------------------------------
     ! Set urban landunits

--- a/components/elm/src/main/surfrdMod.F90
+++ b/components/elm/src/main/surfrdMod.F90
@@ -1131,8 +1131,6 @@ contains
       wt_polygon(begg:endg,1:max_topounits,ilowcenpoly) = arrayl(begg:endg,1:max_topounits)
     else
       wt_polygon(begg:endg,1:max_topounits,ilowcenpoly:ihighcenpoly) = 0._r8
-      ! this shouldn't be necessary any more, as istolowcenpoly:isthighcenpoly
-     ! wt_lunit(begg:endg,1:max_topounits,istlowcenpoly:isthighcenpoly) = 0._r8
     endif
 
     ! add two other types
@@ -1303,9 +1301,6 @@ contains
         end do
       end do
     end if
-    write(iulog,*) "DEBUG 1 - wt_lunit is:", wt_lunit(begg:endg,1,:)
-    write(iulog,*) "DEBUG 2 - wt_polygon is:", wt_polygon(begg:endg,1,:)
-    write(iulog,*) "DEBUG 3 - wt_nat_patch is:", wt_nat_patch(begg:endg,1,:)
 
   end subroutine surfrd_veg_all
 

--- a/components/elm/src/main/surfrdMod.F90
+++ b/components/elm/src/main/surfrdMod.F90
@@ -30,7 +30,7 @@ module surfrdMod
   !
   ! !PUBLIC MEMBER FUNCTIONS:
   public :: surfrd_get_globmask  ! Reads global land mask (needed for setting domain decomp)
-  public :: surfrd_get_grid      ! Read grid/ladnfrac data into domain (after domain decomp)
+  public :: surfrd_get_grid      ! Read grid/landfrac data into domain (after domain decomp)
   public :: surfrd_get_topo      ! Read grid topography into domain (after domain decomp)
   public :: surfrd_get_data      ! Read surface dataset and determine subgrid weights
   public :: surfrd_get_grid_conn ! Reads grid connectivity information from domain file

--- a/components/elm/src/main/surfrdMod.F90
+++ b/components/elm/src/main/surfrdMod.F90
@@ -1068,12 +1068,12 @@ contains
     ! Determine weight arrays for non-dynamic landuse mode
     !
     ! !USES:
-    use elm_varctl      , only : create_crop_landunit, use_fates
+    use elm_varctl      , only : create_crop_landunit, use_fates, use_polygonal_tundra
     use elm_varctl      , only : irrigate
     use elm_varpar      , only : surfpft_lb, surfpft_ub, surfpft_size, cft_lb, cft_ub, cft_size
     use elm_varpar      , only : crop_prog
-    use elm_varsur      , only : wt_lunit, wt_nat_patch, wt_cft, fert_cft, fert_p_cft
-    use landunit_varcon , only : istsoil, istcrop
+    use elm_varsur      , only : wt_lunit, wt_nat_patch, wt_cft, fert_cft, fert_p_cft, wt_polygon
+    use landunit_varcon , only : istsoil, istcrop, ilowcenpoly, iflatcenpoly, ihighcenpoly
     use pftvarcon       , only : nc3crop, nc3irrig, npcropmin
     use pftvarcon       , only : ncorn, ncornirrig, nsoybean, nsoybeanirrig
     use pftvarcon       , only : nscereal, nscerealirrig, nwcereal, nwcerealirrig
@@ -1112,7 +1112,26 @@ contains
     call ncd_io(ncid=ncid, varname='PCT_NATVEG', flag='read', data=arrayl, &
          dim1name=grlnd, readvar=readvar)
     if (.not. readvar) call endrun( msg=' ERROR: PCT_NATVEG NOT on surfdata file'//errMsg(__FILE__, __LINE__))
-    wt_lunit(begg:endg,1:max_topounits,istsoil) = arrayl(begg:endg,1:max_topounits) 
+    wt_lunit(begg:endg,1:max_topounits,istsoil) = arrayl(begg:endg,1:max_topounits)
+
+    if (use_polygonal_tundra) then
+      call ncd_io(ncid=ncid, varname='PCT_HCP', flag='read', data=arrayl, &
+         dim1name=grlnd, readvar=readvar)
+      if (.not. readvar) call endrun( msg=' ERROR: use_polygonal_tundra = .true., but PCT_HCP NOT on surfdata file'//errMsg(__FILE__, __LINE__))
+      wt_polygon(begg:endg,1:max_topounits,ihighcenpoly) = arrayl(begg:endg,1:max_topounits)
+
+      call ncd_io(ncid=ncid, varname='PCT_FCP', flag='read', data=arrayl, &
+         dim1name=grlnd, readvar=readvar)
+      if (.not. readvar) call endrun( msg=' ERROR: use_polygonal_tundra = .true., but PCT_FCP NOT on surfdata file'//errMsg(__FILE__, __LINE__))
+      wt_polygon(begg:endg,1:max_topounits,iflatcenpoly) = arrayl(begg:endg,1:max_topounits)
+
+      call ncd_io(ncid=ncid, varname='PCT_LCP', flag='read', data=arrayl, &
+         dim1name=grlnd, readvar=readvar)
+      if (.not. readvar) call endrun( msg=' ERROR: use_polygonal_tundra = .true., but PCT_LCP NOT on surfdata file'//errMsg(__FILE__, __LINE__))
+      wt_polygon(begg:endg,1:max_topounits,ilowcenpoly) = arrayl(begg:endg,1:max_topounits)
+    endif
+
+    ! add two other types
 
     call ncd_io(ncid=ncid, varname='PCT_CROP', flag='read', data=arrayl, &
          dim1name=grlnd, readvar=readvar)
@@ -1184,6 +1203,9 @@ contains
     end if
     wt_lunit(begg:endg,:,istsoil) = wt_lunit(begg:endg,:,istsoil) / 100._r8
     wt_lunit(begg:endg,:,istcrop) = wt_lunit(begg:endg,:,istcrop) / 100._r8
+    wt_polygon(begg:endg,:,ihighcenpoly) = wt_polygon(begg:endg,:,ihighcenpoly) / 100._r8
+    wt_polygon(begg:endg,:,iflatcenpoly) = wt_polygon(begg:endg,:,iflatcenpoly) / 100._r8
+    wt_polygon(begg:endg,:,ilowcenpoly) = wt_polygon(begg:endg,:,ilowcenpoly) / 100._r8
     wt_nat_patch(begg:endg,:,:)   = wt_nat_patch(begg:endg,:,:) / 100._r8
     !call check_sums_equal_1_3d(wt_nat_patch, begg, 'wt_nat_patch', subname,ntpu)
     call check_sums_equal_1_3d(wt_nat_patch, begg, 'wt_nat_patch', subname)

--- a/components/elm/src/main/surfrdMod.F90
+++ b/components/elm/src/main/surfrdMod.F90
@@ -669,7 +669,6 @@ contains
        call endrun(msg=errMsg(__FILE__, __LINE__))
     end if
     call domain_clean(surfdata_domain)
-
     ! Obtain special landunit info
 
     call surfrd_special(begg, endg, ncid, ldomain%ns,ldomain%num_tunits_per_grd)
@@ -1073,7 +1072,8 @@ contains
     use elm_varpar      , only : surfpft_lb, surfpft_ub, surfpft_size, cft_lb, cft_ub, cft_size
     use elm_varpar      , only : crop_prog
     use elm_varsur      , only : wt_lunit, wt_nat_patch, wt_cft, fert_cft, fert_p_cft, wt_polygon
-    use landunit_varcon , only : istsoil, istcrop, ilowcenpoly, iflatcenpoly, ihighcenpoly
+    use landunit_varcon , only : istsoil, istcrop
+    use landunit_varcon , only : istlowcenpoly, ilowcenpoly, istflatcenpoly, iflatcenpoly, isthighcenpoly, ihighcenpoly
     use pftvarcon       , only : nc3crop, nc3irrig, npcropmin
     use pftvarcon       , only : ncorn, ncornirrig, nsoybean, nsoybeanirrig
     use pftvarcon       , only : nscereal, nscerealirrig, nwcereal, nwcerealirrig
@@ -1130,7 +1130,8 @@ contains
       if (.not. readvar) call endrun( msg=' ERROR: use_polygonal_tundra = .true., but PCT_LCP NOT on surfdata file'//errMsg(__FILE__, __LINE__))
       wt_polygon(begg:endg,1:max_topounits,ilowcenpoly) = arrayl(begg:endg,1:max_topounits)
     else
-      wt_polygon(begg:endg,1:max_topounits,1) = 0._r8
+      wt_polygon(begg:endg,1:max_topounits,ilowcenpoly:ihighcenpoly) = 0._r8
+      wt_lunit(begg:endg,1:max_topounits,istlowcenpoly:isthighcenpoly) = 0._r8
     endif
 
     ! add two other types

--- a/components/elm/src/main/surfrdMod.F90
+++ b/components/elm/src/main/surfrdMod.F90
@@ -1131,7 +1131,8 @@ contains
       wt_polygon(begg:endg,1:max_topounits,ilowcenpoly) = arrayl(begg:endg,1:max_topounits)
     else
       wt_polygon(begg:endg,1:max_topounits,ilowcenpoly:ihighcenpoly) = 0._r8
-      wt_lunit(begg:endg,1:max_topounits,istlowcenpoly:isthighcenpoly) = 0._r8
+      ! this shouldn't be necessary any more, as istolowcenpoly:isthighcenpoly
+     ! wt_lunit(begg:endg,1:max_topounits,istlowcenpoly:isthighcenpoly) = 0._r8
     endif
 
     ! add two other types

--- a/components/elm/src/main/surfrdMod.F90
+++ b/components/elm/src/main/surfrdMod.F90
@@ -1129,6 +1129,8 @@ contains
          dim1name=grlnd, readvar=readvar)
       if (.not. readvar) call endrun( msg=' ERROR: use_polygonal_tundra = .true., but PCT_LCP NOT on surfdata file'//errMsg(__FILE__, __LINE__))
       wt_polygon(begg:endg,1:max_topounits,ilowcenpoly) = arrayl(begg:endg,1:max_topounits)
+    else
+      wt_polygon(begg:endg,1:max_topounits,1) = 0._r8
     endif
 
     ! add two other types
@@ -1203,9 +1205,7 @@ contains
     end if
     wt_lunit(begg:endg,:,istsoil) = wt_lunit(begg:endg,:,istsoil) / 100._r8
     wt_lunit(begg:endg,:,istcrop) = wt_lunit(begg:endg,:,istcrop) / 100._r8
-    wt_polygon(begg:endg,:,ihighcenpoly) = wt_polygon(begg:endg,:,ihighcenpoly) / 100._r8
-    wt_polygon(begg:endg,:,iflatcenpoly) = wt_polygon(begg:endg,:,iflatcenpoly) / 100._r8
-    wt_polygon(begg:endg,:,ilowcenpoly) = wt_polygon(begg:endg,:,ilowcenpoly) / 100._r8
+    wt_polygon(begg:endg,:,:) = wt_polygon(begg:endg,:,:) / 100._r8
     wt_nat_patch(begg:endg,:,:)   = wt_nat_patch(begg:endg,:,:) / 100._r8
     !call check_sums_equal_1_3d(wt_nat_patch, begg, 'wt_nat_patch', subname,ntpu)
     call check_sums_equal_1_3d(wt_nat_patch, begg, 'wt_nat_patch', subname)

--- a/components/elm/src/main/surfrdUtilsMod.F90
+++ b/components/elm/src/main/surfrdUtilsMod.F90
@@ -72,7 +72,6 @@ contains
     if (found) then
        write(iulog,*) trim(caller), ' ERROR: sum of ', trim(name), ' not 1.0 at nl=', nindx, ' and t=', tindx
        write(iulog,*) 'sum is: ', sum(arr(nindx,t,:))
-       write(iulog,*) arr(nindx,t,:)
        call endrun(msg=errMsg(__FILE__, __LINE__))
     end if
 

--- a/components/elm/src/main/surfrdUtilsMod.F90
+++ b/components/elm/src/main/surfrdUtilsMod.F90
@@ -72,6 +72,7 @@ contains
     if (found) then
        write(iulog,*) trim(caller), ' ERROR: sum of ', trim(name), ' not 1.0 at nl=', nindx, ' and t=', tindx
        write(iulog,*) 'sum is: ', sum(arr(nindx,t,:))
+       write(iulog,*) arr(nindx,t,:)
        call endrun(msg=errMsg(__FILE__, __LINE__))
     end if
 


### PR DESCRIPTION
  Add new specification for polygonal tundra and the type of polygonal tuyndra at the landunit level of subgrid hierarchy,
 in LandunitType.F90.
 ispolygon (true/false) indicates that a landunit is a polygonal tundra type. If true, the variable polygon_type is used to specify one of: 
low-centered polygon, flat-centered polygon, or high-centered-polygon. 
The numeric indices and long names associated with each of these polygon types are specified in landunit_varcon.F90. Data initializing the fractional area for each polygon type are assumed to be on the surface data file 
(see below for testing defaults), and are read in the usual place, in surfrdMod.F90.

Add new variables for tracking active layer thickness in CanopyStateType.F90
Add and initialize new variables tracking ice wedge polygon physical properties in ColumnDataType.F90.

Modify calculation of maximum active layer thickness (alt) when stealth feature is turned on, in ActiveLayerMod.F90

Calculate melt of excess ice in soil column if active layer moves into permafrost, then calculate the 
implied subsidence of the ground surface as a result of loss of massive ice in the permafrost.
 Maximum subsidence is limited to 0.4 m. In ActiveLayerMod.F90

Update parameters controlling fractional inundated area for polygonal ground landunits, based on type of polygonal ground (low-centered, flat-centered, high-centered) and amount of subsidence. In ActiveLayerMod.F90

Use new parameters for inundated area to calculate water stored on ground surface (col_ws%h2osfc) if the landunit is defined as polygonal. In CanopyHydrologyMod.F90

Modify calculation of runoff from stored surface water (col_wf%qflx_h20sfc_surf) for polygonal ground, 
based on microtopographic variables that respond to subsidence.

Add two new namelist variables: use_polygonal_tundra and use_arctic_init, defined in namelist_definition.xml. 
use_polygonal_tundra: Use polygonal tundra parameterizations for ice wedge polygon microtopography and inindation fraction.
 use_arctic_init: Cold-start initialization conditions in tundra start saturated and frozen. Defaults for both set to .false. in namelist_defaults.xml.

Add new test: elm-polygonal_tundra

Use new single point grid for new test (1x1_icycape, added in cime_config/config_grids.xml). 
New valid value for "res" (1x1_icycape) added in namelist_definition.xml
Use new default surfadata file for new test (lnd/clm2/surfdata_map/surfdata_1x1_IcyCape_polygons_c240909.nc) 
through mods in components/elm/bld/namelist_files/namelist_defaults.xml.
Add new shell commands to set up the test, in components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/shell_commands 
Set new user namelist values for the test in components/elm/cime_config/testdefs/testmods_dirs/elm/polygonal_tundra/user_nl_elm

[BFB]
