### PR TITLE
EAMxx: prefer HostMirrors over Views on HostSpace

### DIFF
--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -39,7 +39,6 @@ public:
   using device_t      = DefaultDevice;
   using host_device_t = HostDevice;
   using kt_dev        = KokkosTypes<device_t>;
-  using kt_host       = KokkosTypes<host_device_t>;
 
   template<HostOrDevice HD>
   using get_device = cond_t<HD==Device, device_t,host_device_t>;
@@ -52,13 +51,13 @@ public:
   template<typename DT, typename MT = Kokkos::MemoryManaged>
   using view_dev_t = typename kt_dev::template view<DT,MT>;
   template<typename DT, typename MT = Kokkos::MemoryManaged>
-  using view_host_t = typename kt_host::template view<DT,MT>;
+  using view_host_t = typename view_dev_t<DT,MT>::HostMirror;
 
   // Analogue of the above, but with LayoutStride
   template<typename DT, typename MT = Kokkos::MemoryManaged>
   using strided_view_dev_t = typename kt_dev::template sview<DT,MT>;
   template<typename DT, typename MT = Kokkos::MemoryManaged>
-  using strided_view_host_t = typename kt_host::template sview<DT,MT>;
+  using strided_view_host_t = typename strided_view_dev_t<DT,MT>::HostMirror;
 
 private:
   // A bare DualView-like struct. This is an impl detail, so don't expose it.

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -177,20 +177,10 @@ public:
 
   // For each entry in the input list of GIDs, retrieve the process id that owns it
   std::vector<int> get_owners (const gid_view_h& gids) const;
-  std::vector<int> get_owners (const std::vector<gid_type>& gids) const {
-    gid_view_h gids_v(gids.data(),gids.size());
-    return get_owners(gids_v);
-  }
 
   void get_remote_pids_and_lids (const gid_view_h& gids,
                                  std::vector<int>& pids,
                                  std::vector<int>& lids) const;
-  void get_remote_pids_and_lids (const std::vector<gid_type>& gids,
-                                 std::vector<int>& pids,
-                                 std::vector<int>& lids) const {
-    gid_view_h gids_v(gids.data(),gids.size());
-    get_remote_pids_and_lids(gids_v,pids,lids);
-  }
 
   // Derived classes can override these methods to verify that the
   // dofs have been set to something that satisfies any requirement of the grid type.


### PR DESCRIPTION
Prefer using ViewT::HostMirror over a hard-coded view type with HostSpace as mem space.

[BFB]

---

Note: this fixes an issue reported in #6916 . Since the issue is independent of the kokkos update, I decided to fix it here, separately. This is the same kind of error I encountered when trying to use CudaUVM in eamxx: assigning a `View<DT,ExecSpace>::HostMirror` to a `View<DT,HostSpace>` is only ok if the `HostMirror` is indeed a view with `HostSpace` memory space. However, when we use "host-accessible" mem spaces on device (such as CudaUVM, or Cuda/HIP pinned host space, or HIPManaged, etc.), the two types are not the same type, so they can't be assigned. The solution is to *always* rely on `ViewT::HostMirror` (rather than hand-crafter host view type) to get the type of a view that matches the current view, but is accessible from host.

@ndkeen You can try to cherry pick this commit into that branch, if you want to verify it works. I am like 99.7% sure this fixes the issue behind the compiler error you reported.

Update: the issue is more pervasive than just the Field class in eamxx. In particular, there are a lot of places in Hommexx where we assume that a HostMirror is the same as a View on the HostSpace, which fails with CudaUVM, as well as with the new APUs by AMD. I need to go through hommexx, and make sure we no longer do this assumption.