### PR TITLE
EAMxx: fix bug in FieldAtPressureLevel

### DIFF
--- a/components/eamxx/src/diagnostics/field_at_pressure_level.cpp
+++ b/components/eamxx/src/diagnostics/field_at_pressure_level.cpp
@@ -146,7 +146,7 @@ void FieldAtPressureLevel::compute_diagnostic_impl()
         auto k1 = ub - beg;
         if (k1==0) {
           // Corner case: p_tgt==y1(0)
-          diag(icol) = y1(icol);
+          diag(icol) = y1(0);
         } else if (k1==nlevs) {
           // Corner case: p_tgt==y1(nlevs-1)
           diag(icol) = y1(nlevs-1);
@@ -181,7 +181,7 @@ void FieldAtPressureLevel::compute_diagnostic_impl()
           auto k1 = ub - beg;
           if (k1==0) {
             // Corner case: p_tgt==y1(0)
-            diag(icol,idim) = y1(icol);
+            diag(icol,idim) = y1(0);
           } else if (k1==nlevs) {
             // Corner case: p_tgt==y1(nlevs-1)
             diag(icol,idim) = y1(nlevs-1);


### PR DESCRIPTION
The src field columng view was accessed using the col index rather than a level index.

Non-BFB for eamxx output that used `X_at_YhPa` diagnostic, but only if Y is _very_ small. Likely BFB for all practical purposes.

---

@jgfouca This should have probably been caught by a debug build with kokkos bounds checks on. I don't think we run those though, which is something we should probably change?

On a side note: the change in Fill pattern of certain output files was indeed due to pr #7053. Turns out that, in addition to the bug fixed here, our master was even more buggy before that PR, since all instances of the `FieldAtPressureLevel` diagnostic were using the same name for the mask field, which were then clashing inside `CoarseningRemapper`. E.g., with `T_mid_at_850hPa` and `T_mid_at_400hPa`, the mask field was called `FieldAtPressureLevel_mask` for both instances, so the remapper would store only one, and use it for remapping both fields.

@brhillman Are you using this diagnostic in the decadal run? If you are, are you using it multiple times, with different pressure heights _in the same stream_? If that's the case, it is possible you will have some garbage output. It's hard to tell which of the `X_at_YhPa` fields in the output stream are garbage and which ones aren't (I can't tell the order in which things are processed, which in this case impacts which field is still computed correctly and which field isn't), so you would either have to manually check the values or simply assume they are all garbage. I hope this is not the case for you.