### PR TITLE
Remove leftover add_group() declaration

### DIFF
--- a/components/eamxx/src/share/atm_process/atmosphere_process.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.hpp
@@ -357,11 +357,6 @@ protected:
 
   // Group requests
   template<RequestType RT>
-  void add_group (const std::string& name, const std::string& grid, const int ps, const bool bundled,
-                  const bool imported, const std::string& src_name, const std::string& src_grid)
-  { add_group<RT>(GroupRequest(name,grid,ps,bundled,imported,src_name,src_grid)); }
-
-  template<RequestType RT>
   void add_group (const std::string& name, const std::string& grid_name,
                   const bool bundled = false)
   { add_group<RT> (GroupRequest(name,grid_name,bundled)); }


### PR DESCRIPTION
This was left after imported group tag were removed in https://github.com/E3SM-Project/E3SM/pull/6981, but never called and the `GroupRequest` constructor no longer exists. Interestingly, only some compilers complain.

[BFB]