### PR TITLE
EAMxx: change handling of timestamp inside atm proc

### DIFF
--- a/components/eamxx/docs/_presentations_srcs/eamxx-tutorial-2025-part2.md
+++ b/components/eamxx/docs/_presentations_srcs/eamxx-tutorial-2025-part2.md
@@ -487,7 +487,7 @@ void POMPEI::run_impl(const double dt) {
   using PC = scream::physics::Constants<Real>;
   auto g   = PC::gravit;
 
-  auto t    = timestamp() + dt;
+  auto t    = end_of_step_ts();
   auto rate = pompei::ash_emission_rate(t.days_from(m_eruption_start));
   auto mass = dt * rate;
 

--- a/components/eamxx/docs/developer/dev_testing/testing_for_development.md
+++ b/components/eamxx/docs/developer/dev_testing/testing_for_development.md
@@ -76,7 +76,7 @@ be the `eamxx_inject_ash_process_interface.<x>pp` files, located at
       [...] // set source_mask=1 only on area of interest, using lat/lon field
     }
     void MAM_AshInjection::run_impl(const double dt) {
-      auto t = this->timestamp() + dt; // timestamp() is the START of step time
+      auto t = end_of_step_ts();
       auto ash = get_field_out("ash");
       auto rate = compute_ash_injection_rate(
           t); // defined in ash_source_calculation.hpp header

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
@@ -322,7 +322,7 @@ void SurfaceCouplingExporter::do_export(const double dt, const bool called_durin
   }
 
   if (m_num_from_file_exports>0) {
-    set_from_file_exports(dt);
+    set_from_file_exports();
   }
 
   if (m_num_from_model_exports>0) {
@@ -350,15 +350,10 @@ void SurfaceCouplingExporter::set_constant_exports()
 
 }
 // =========================================================================================
-void SurfaceCouplingExporter::set_from_file_exports(const int dt)
+void SurfaceCouplingExporter::set_from_file_exports()
 {
   // Perform interpolation on the data with the latest timestamp
-  auto ts = timestamp();
-  if (dt > 0) {
-    ts += dt;
-  }
-  m_time_interp.perform_time_interpolation(ts);
-
+  m_time_interp.perform_time_interpolation(end_of_step_ts());
 }
 // =========================================================================================
 // This compute_eamxx_exports routine  handles all export variables that are derived from the EAMxx state.

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.hpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.hpp
@@ -81,7 +81,7 @@ public:
   void do_export(const double dt, const bool called_during_initialization=false);             // Main export routine
   void compute_eamxx_exports(const double dt, const bool called_during_initialization=false); // Export vars are derived from eamxx state
   void set_constant_exports();                                                                // Export vars are set to a constant
-  void set_from_file_exports(const int dt);                                                   // Export vars are set by interpolation of data from files
+  void set_from_file_exports();                                                               // Export vars are set by interpolation of data from files
   void do_export_to_cpl(const bool called_during_initialization=false);                       // Finish export by copying data to cpl structures.
 
   // Take and store data from SCDataManager

--- a/components/eamxx/src/control/atmosphere_surface_coupling_importer.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_importer.cpp
@@ -226,7 +226,8 @@ void SurfaceCouplingImporter::overwrite_iop_imports (const bool called_during_in
   const auto has_Tg    = m_iop_data_manager->has_iop_field("Tg");
 
   // Read IOP file for current time step, if necessary
-  m_iop_data_manager->read_iop_file_data(timestamp());
+  // TODO: this is using the TS from the beg of the step. Should it use end_of_step_ts() instead?
+  m_iop_data_manager->read_iop_file_data(start_of_step_ts());
 
   static constexpr Real latvap = C::LatVap;
   static constexpr Real stebol = C::stebol;

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_fv_phys.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_fv_phys.cpp
@@ -93,7 +93,7 @@ static void copy_prev (const int ncols, const int npacks,
   Kokkos::fence();
 }
 
-void HommeDynamics::fv_phys_dyn_to_fv_phys (const bool restart) {
+void HommeDynamics::fv_phys_dyn_to_fv_phys (const util::TimeStamp& ts, const bool restart) {
   if (not fv_phys_active()) return;
   constexpr int N = HOMMEXX_PACK_SIZE;
   using Pack = ekat::Pack<Real,N>;
@@ -136,10 +136,10 @@ void HommeDynamics::fv_phys_dyn_to_fv_phys (const bool restart) {
     // IC for FV fields, this step remains safe (we're setting the same t0)
     for (auto n : {"T_mid","horiz_winds","ps","phis","omega","pseudo_density"}) {
       auto f = get_field_out(n,pgn);
-      f.get_header().get_tracking().update_time_stamp(timestamp());
+      f.get_header().get_tracking().update_time_stamp(ts);
     }
     auto Q = get_group_out("tracers",pgn).m_monolithic_field;
-    Q->get_header().get_tracking().update_time_stamp(timestamp());
+    Q->get_header().get_tracking().update_time_stamp(ts);
   }
   update_pressure(m_phys_grid);
 }
@@ -156,7 +156,7 @@ void HommeDynamics::fv_phys_pre_process () {
 // update_pressure to update p_mid,int.
 void HommeDynamics::fv_phys_post_process () {
   if (not fv_phys_active()) return;
-  fv_phys_dyn_to_fv_phys();
+  fv_phys_dyn_to_fv_phys(end_of_step_ts());
 }
 
 void HommeDynamics::remap_dyn_to_fv_phys (GllFvRemapTmp* t) const {
@@ -304,7 +304,7 @@ void HommeDynamics::fv_phys_rrtmgp_active_gases_remap (const RunType run_type) {
         gfr.remap_tracer_dyn_to_fv_phys(time_idx, 1, in_dgll, out_phys);
         Kokkos::fence();
 
-        f_phys.get_header().get_tracking().update_time_stamp(timestamp());
+        f_phys.get_header().get_tracking().update_time_stamp(start_of_step_ts());
       }
     }
   }

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.hpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.hpp
@@ -98,7 +98,7 @@ protected:
   void fv_phys_set_grids();
   void fv_phys_requested_buffer_size_in_bytes() const;
   void fv_phys_initialize_impl();
-  void fv_phys_dyn_to_fv_phys(const bool restart = false);
+  void fv_phys_dyn_to_fv_phys(const util::TimeStamp& t, const bool restart = false);
   void fv_phys_pre_process();
   void fv_phys_post_process();
   // See [rrtmgp active gases] in eamxx_homme_fv_phys.cpp.

--- a/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
+++ b/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
@@ -138,9 +138,7 @@ void Cosp::run_impl (const double dt)
   // Make sure cosp frequency is multiple of rad frequency?
 
   // Compare frequency in steps with current timestep
-  // NOTE: timestamp() returns the time RIGHT BEFORE the call to run
-  auto end_of_step = timestamp()+dt;
-  auto update_cosp = cosp_do(cosp_freq_in_steps, end_of_step.get_num_steps());
+  auto update_cosp = cosp_do(cosp_freq_in_steps, end_of_step_ts().get_num_steps());
 
   // Call COSP wrapper routines
   if (update_cosp) {

--- a/components/eamxx/src/physics/iop_forcing/eamxx_iop_forcing_process_interface.cpp
+++ b/components/eamxx/src/physics/iop_forcing/eamxx_iop_forcing_process_interface.cpp
@@ -346,7 +346,8 @@ void IOPForcing::run_impl (const double dt)
   const auto Q = get_group_out("tracers").m_monolithic_field->get_view<Pack***>();
 
   // Load data from IOP files, if necessary
-  m_iop_data_manager->read_iop_file_data(timestamp());
+  // TODO: this is using the TS from the beg of the step. Should it use end_of_step_ts() instead?
+  m_iop_data_manager->read_iop_file_data(start_of_step_ts());
 
   // Define local IOP param values
   const auto iop_dosubsidence     = m_iop_data_manager->get_params().get<bool>("iop_dosubsidence");

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -457,7 +457,7 @@ void MAMMicrophysics::initialize_impl(const RunType run_type) {
     auto linoz_cariolle_pscs =
         buffer_.scratch[7];  // Cariolle parameter for PSC loss of ozone [1/s]
 
-    auto ts = timestamp();
+    auto ts = start_of_step_ts();
     std::string linoz_chlorine_file =
         m_params.get<std::string>("mam4_linoz_chlorine_file");
     int chlorine_loading_ymd = m_params.get<int>("mam4_chlorine_loading_ymd");
@@ -478,7 +478,7 @@ void MAMMicrophysics::initialize_impl(const RunType run_type) {
   // Load the first month into extfrc_lst_end.
   // Note: At the first time step, the data will be moved into extfrc_lst_beg,
   //       and extfrc_lst_end will be reloaded from file with the new month.
-  const int curr_month = timestamp().get_month() - 1;  // 0-based
+  const int curr_month = start_of_step_ts().get_month() - 1;  // 0-based
 
   scream::mam_coupling::update_tracer_data_from_file(
       LinozDataReader_, curr_month, *LinozHorizInterp_, linoz_data_);
@@ -601,13 +601,12 @@ void MAMMicrophysics::run_impl(const double dt) {
   auto o3_col_dens = buffer_.scratch[8];
 
   /* Gather time and state information for interpolation */
-  const auto ts = timestamp() + dt;
+  const auto ts = end_of_step_ts();
 
   const Real chlorine_loading = scream::mam_coupling::chlorine_loading_advance(
       ts, chlorine_values_, chlorine_time_secs_);
 
-  // /* Update the TracerTimeState to reflect the current time, note the
-  // addition of dt */
+  // Update the TracerTimeState to reflect the current time
   trace_time_state_.t_now = ts.frac_of_year_in_days();
   scream::mam_coupling::advance_tracer_data(
       TracerDataReader_,                 // in
@@ -665,7 +664,6 @@ void MAMMicrophysics::run_impl(const double dt) {
   // Note: We are following the RRTMGP EAMxx interface to compute the zenith
   // angle. This operation is performed on the host because the routine
   // shr_orb_cosz_c2f has not been ported to C++.
-  auto ts2          = timestamp();
   auto orbital_year = m_orbital_year;
   // Note: We need double precision because
   // shr_orb_params_c2f and shr_orb_decl_c2f only support double precision.
@@ -683,13 +681,13 @@ void MAMMicrophysics::run_impl(const double dt) {
     orbital_year = shr_orb_undef_int_c2f;
   } else if(orbital_year < 0) {
     // compute orbital parameters based on current year
-    orbital_year = ts2.get_year();
+    orbital_year = start_of_step_ts().get_year();
   }
   shr_orb_params_c2f(&orbital_year,                                       // in
                      &eccen, &obliq, &mvelp, &obliqr, &lambm0, &mvelpp);  // out
 
   // Want day + fraction; calday 1 == Jan 1 0Z
-  auto calday = ts2.frac_of_year_in_days() + 1;
+  auto calday = start_of_step_ts().frac_of_year_in_days() + 1;
   shr_orb_decl_c2f(calday, eccen, mvelpp, lambm0, obliqr,  // in
                    &delta, &eccf);                         // out
   {
@@ -739,7 +737,7 @@ void MAMMicrophysics::run_impl(const double dt) {
   const mam4::seq_drydep::Data drydep_data =
       mam4::seq_drydep::set_gas_drydep_data();
   const auto qv                = wet_atm_.qv;
-  const int month              = timestamp().get_month();  // 1-based
+  const int month              = start_of_step_ts().get_month();  // 1-based
   const int surface_lev        = nlev - 1;                 // Surface level
   const auto &index_season_lai = index_season_lai_;
   auto &dflx = dflx_;

--- a/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
@@ -310,7 +310,7 @@ void MAMSrfOnlineEmiss::initialize_impl(const RunType run_type) {
   fluxes_in_mks_units_ = view_1d("fluxes_in_mks_units", ncol_);
 
   // Current month ( 0-based)
-  const int curr_month = timestamp().get_month() - 1;
+  const int curr_month = start_of_step_ts().get_month() - 1;
 
   // Load the first month into data_end.
 
@@ -322,7 +322,7 @@ void MAMSrfOnlineEmiss::initialize_impl(const RunType run_type) {
   //--------------------------------------------------------------------
   for(srf_emiss_ &ispec_srf : srf_emiss_species_) {
     srfEmissFunc::update_srfEmiss_data_from_file(
-        ispec_srf.dataReader_, timestamp(), curr_month, *ispec_srf.horizInterp_,
+        ispec_srf.dataReader_, start_of_step_ts(), curr_month, *ispec_srf.horizInterp_,
         ispec_srf.data_end_);  // output
   }
 
@@ -340,7 +340,7 @@ void MAMSrfOnlineEmiss::initialize_impl(const RunType run_type) {
   //--------------------------------------------------------------------
   // Time dependent data
   marineOrganicsFunc::update_marine_organics_data_from_file(
-      morg_dataReader_, timestamp(), curr_month, *morg_horizInterp_,
+      morg_dataReader_, start_of_step_ts(), curr_month, *morg_horizInterp_,
       morg_data_end_);  // output
 
   //-----------------------------------------------------------------
@@ -369,7 +369,7 @@ void MAMSrfOnlineEmiss::run_impl(const double dt) {
               constituent_fluxes);  // in-out
   Kokkos::fence();
   // Gather time and state information for interpolation
-  const auto ts = timestamp() + dt;
+  const auto ts = end_of_step_ts();
 
   //--------------------------------------------------------------------
   // Online emissions from dust and sea salt

--- a/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
+++ b/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
@@ -99,7 +99,7 @@ void MLCorrection::initialize_impl(const RunType /* run_type */) {
 // =========================================================================================
 void MLCorrection::run_impl(const double dt) {
   // use model time to infer solar zenith angle for the ML prediction
-  auto current_ts = timestamp();
+  auto current_ts = start_of_step_ts();
   std::string datetime_str = current_ts.get_date_string() + " " + current_ts.get_time_string();
 
   const auto &phis            = get_field_in("phis").get_view<const Real *, Host>();

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -328,13 +328,8 @@ void Nudging::run_impl (const double dt)
   using view_1d       = KT::view_1d<PackT>;
   using view_2d       = KT::view_2d<PackT>;
 
-  // Have to add dt because first time iteration is at 0 seconds where you will
-  // not have any data from the field. The timestamp is only iterated at the
-  // end of the full step in scream.
-  auto ts = timestamp()+dt;
-
   // Perform time interpolation
-  m_time_interp.perform_time_interpolation(ts);
+  m_time_interp.perform_time_interpolation(end_of_step_ts());
 
   // If the input data contains "masked" values (sometimes also called "filled" values),
   // the horiz remapping would smear them around. To prevent that, we need to "cure"

--- a/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
+++ b/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
@@ -806,7 +806,7 @@ void RRTMGPRadiation::run_impl (const double dt) {
   const auto do_aerosol_rad = m_do_aerosol_rad;
 
   // Are we going to update fluxes and heating this step?
-  auto ts = timestamp();
+  auto ts = start_of_step_ts();
   auto update_rad = scream::rrtmgp::radiation_do(m_rad_freq_in_steps, ts.get_num_steps());
 
   if (update_rad) {

--- a/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
+++ b/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
@@ -107,7 +107,7 @@ void SPA::initialize_impl (const RunType /* run_type */)
   remap_data.pmid = pmid;
   remap_data.pint = pint;
   m_data_interpolation->setup_remappers (remap_data);
-  m_data_interpolation->init_data_interval (timestamp());
+  m_data_interpolation->init_data_interval (start_of_step_ts());
 
   // Set property checks for fields in this process
   using FWI = FieldWithinIntervalCheck;
@@ -123,9 +123,9 @@ void SPA::initialize_impl (const RunType /* run_type */)
 }
 
 // =========================================================================================
-void SPA::run_impl (const double dt)
+void SPA::run_impl (const double /* dt */)
 {
-  m_data_interpolation->run(timestamp()+dt);
+  m_data_interpolation->run(end_of_step_ts());
 }
 
 } // namespace scream

--- a/components/eamxx/src/share/atm_process/atmosphere_process.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.cpp
@@ -71,7 +71,7 @@ void AtmosphereProcess::initialize (const TimeStamp& t0, const RunType run_type)
     start_timer (m_timer_prefix + this->name() + "::init");
   }
   set_fields_and_groups_pointers();
-  m_time_stamp = t0;
+  m_start_of_step_ts = m_end_of_step_ts = t0;
   initialize_impl(run_type);
 
   // Create all start-of-step fields needed for tendencies calculation
@@ -101,6 +101,8 @@ void AtmosphereProcess::run (const double dt) {
   init_step_tendencies ();
 
   for (m_subcycle_iter=0; m_subcycle_iter<m_num_subcycles; ++m_subcycle_iter) {
+    m_start_of_step_ts = m_end_of_step_ts;
+    m_end_of_step_ts += dt_sub;
 
     if (has_column_conservation_check()) {
       // Column local mass and energy checks requires the total mass and energy
@@ -112,6 +114,7 @@ void AtmosphereProcess::run (const double dt) {
     if (m_internal_diagnostics_level > 0)
       // Print hash of INPUTS before run
       print_global_state_hash(name() + "-pre-sc-" + std::to_string(m_subcycle_iter),
+                              m_start_of_step_ts,
                               true, false, false);
 
     // Run derived class implementation
@@ -120,6 +123,7 @@ void AtmosphereProcess::run (const double dt) {
     if (m_internal_diagnostics_level > 0)
       // Print hash of OUTPUTS/INTERNALS after run
       print_global_state_hash(name() + "-pst-sc-" + std::to_string(m_subcycle_iter),
+                              m_end_of_step_ts,
                               true, true, true);
 
     if (has_column_conservation_check()) {
@@ -136,7 +140,6 @@ void AtmosphereProcess::run (const double dt) {
     run_postcondition_checks();
   }
 
-  m_time_stamp += dt;
   if (m_update_time_stamps) {
     // Update all output fields time stamps
     update_time_stamps ();
@@ -581,7 +584,7 @@ void AtmosphereProcess::set_update_time_stamps (const bool do_update) {
 }
 
 void AtmosphereProcess::update_time_stamps () {
-  const auto& t = timestamp();
+  const auto& t = end_of_step_ts();
 
   // Update *all* output fields/groups, regardless of whether
   // they were touched at all during this time step.

--- a/components/eamxx/src/share/atm_process/atmosphere_process.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.hpp
@@ -275,12 +275,12 @@ public:
   // Print a global hash of internal fields (useful for debugging non-bfbness)
   // Note: (mem, nmem) describe an arbitrary device array. If mem!=nullptr,
   // the array will be hashed and reported as an additional entry
-  void print_global_state_hash(const std::string& label, const bool in = true,
-                               const bool out = true, const bool internal = true,
+  void print_global_state_hash(const std::string& label, const TimeStamp& t,
+                               const bool in = true, const bool out = true, const bool internal = true,
                                const Real* mem = nullptr, const int nmem = 0) const;
 
   // For BFB tracking in production simulations.
-  void print_fast_global_state_hash(const std::string& label) const;
+  void print_fast_global_state_hash(const std::string& label, const TimeStamp& t) const;
 
   // Set IOP object
   virtual void set_iop_data_manager(const iop_data_ptr& iop_data_manager) {
@@ -441,7 +441,10 @@ protected:
   virtual void finalize_impl(/* what inputs? */) = 0;
 
   // This provides access to this process's timestamp.
-  const TimeStamp& timestamp() const { return m_time_stamp; }
+  // NOTE: start_of_step_ts/end_of_step_ts are the TimeStamp at the start/end
+  //       of the current subcycle (at run time).
+  const TimeStamp& start_of_step_ts() const { return m_start_of_step_ts; }
+  const TimeStamp& end_of_step_ts() const { return m_end_of_step_ts; }
 
   // These three methods modify the FieldTracking of the input field (see field_tracking.hpp)
   void update_time_stamps ();
@@ -582,9 +585,9 @@ private:
   };
   ColumnConservationCheckData m_column_conservation_check_data;
 
-  // This process's copy of the timestamp, which is set on initialization and
-  // updated during stepping.
-  TimeStamp m_time_stamp;
+  // This process's copy of the timestamps (current, as well as beg/end of step)
+  TimeStamp m_start_of_step_ts;
+  TimeStamp m_end_of_step_ts;
 
   // The number of times this process needs to be subcycled
   int m_num_subcycles = 1;

--- a/components/eamxx/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_group.cpp
@@ -439,7 +439,7 @@ void AtmosphereProcessGroup::pre_process_tracer_requests () {
 
 void AtmosphereProcessGroup::initialize_impl (const RunType run_type) {
   for (auto& atm_proc : m_atm_processes) {
-    atm_proc->initialize(timestamp(),run_type);
+    atm_proc->initialize(start_of_step_ts(),run_type);
 #ifdef SCREAM_HAS_MEMORY_USAGE
     long long my_mem_usage = get_mem_usage(MB);
     long long max_mem_usage;
@@ -458,10 +458,6 @@ void AtmosphereProcessGroup::run_impl (const double dt) {
 }
 
 void AtmosphereProcessGroup::run_sequential (const double dt) {
-  // Get the timestamp at the beginning of the step and advance it.
-  auto ts = timestamp();
-  ts += dt;
-
   // The stored atm procs should update the timestamp if both
   //  - this is the last subcycle iteration
   //  - nobody from outside told this APG to not update timestamps

--- a/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
@@ -114,8 +114,10 @@ void hash (const std::list<FieldGroup>& fgs, HashType& accum) {
 } // namespace anon
 
 void AtmosphereProcess
-::print_global_state_hash (const std::string& label, const bool in, const bool out,
-                           const bool internal, const Real* mem, const int nmem) const {
+::print_global_state_hash (const std::string& label, const TimeStamp& t,
+                           const bool in, const bool out, const bool internal,
+                           const Real* mem, const int nmem) const
+{
   const bool compute[4] = {in, out, internal, mem!=nullptr};
 
   std::vector<std::string> hash_names;
@@ -212,8 +214,8 @@ void AtmosphereProcess
     for (const auto& n : hash_names)
       slen = std::max(slen,static_cast<int>(n.size()+1));
 
-    const auto& date = timestamp().get_date();
-    const auto& tod  = timestamp().sec_of_day();
+    const auto& date = t.get_date();
+    const auto& tod  = t.sec_of_day();
 
     std::stringstream ss;
 
@@ -236,14 +238,16 @@ void AtmosphereProcess
   }
 }
 
-void AtmosphereProcess::print_fast_global_state_hash (const std::string& label) const {
+void AtmosphereProcess::
+print_fast_global_state_hash (const std::string& label, const TimeStamp& t) const
+{
   HashType laccum = 0;
   hash(m_fields_in, laccum);
   HashType gaccum;
   bfbhash::all_reduce_HashType(m_comm.mpi_comm(), &laccum, &gaccum, 1);
   if (m_comm.am_i_root())
     fprintf(stderr, "bfbhash> %14d %16" PRIx64 " (%s)\n",
-            timestamp().get_num_steps(), gaccum, label.c_str());
+            t.get_num_steps(), gaccum, label.c_str());
 }
 
 } // namespace scream

--- a/components/eamxx/src/share/io/tests/io_diags.cpp
+++ b/components/eamxx/src/share/io/tests/io_diags.cpp
@@ -81,7 +81,7 @@ protected:
   }
 
   void initialize_impl (const RunType /* run_type */ ) override {
-    m_diagnostic_output.get_header().get_tracking().update_time_stamp(timestamp());
+    m_diagnostic_output.get_header().get_tracking().update_time_stamp(start_of_step_ts());
   }
 
   // Clean up


### PR DESCRIPTION
* Update timestamp inside subcycle loop
* Update timestamp before calling run_impl

[non-BFB for eamxx-standalone testing and mam4xx cases only]

Fixes #7074

---

The impact of the PR is twofolds:

1. Processes that are subcycled will see the content of the timestamp returned by `timestamp()` changing between iterations. Before, the base class was updating `m_time_stamp` only after all the subcycles iterations.
2. Instead of returning the time "right before the call to run_impl", the method now returns the time that run_impl is supposed to advance to. In other words, it returns the "end-of-step" time. That's b/c the vast majority of calls to `timestamp()` where interested in the end-of-step time, which forced the calling site to do something like `auto ts = timestamp() + dt;`.

The second change can have a few side effects, as there were a few places inside derived classes where we would call `timestamp()` inside `run_impl` _without_ adding dt. I'll list them here, along with folks who I'd like to review whether the new behavior is ok. If the new behavior is NOT ok (that is, you'd like those calls to `timestamp()` to return the "start-of-step" timestamp (as before), let me know, and I can add a "start-of-step" timestamp getter and use it in your class.

- rrtmgp: the timestamp was used to determine whether this was a rad step (in case of supercycling) as well as to determine the orb parameters. @brhillman 
- iop_forcing: the timestamp was used to read iop file data. It is possible that IOPDataManager was taking care of the fact that timestamp was the "start-of-step", while searching for the iop file time slice. In that case, we can either modify IOPDataManager search logic, or as said above, we can add a "start-of-step" timestamp getter. @tcclevenger 
- ml_correction: the timestamp was used to create the timestamp string, to pass to the ml emulator. I am not familiar with this, but I also think nobody is using this ML, so maybe it's not worth checking if things work as expected? @AaronDonahue 
- mam: the timestamp was used in a few places, in code that does a manual data interpolation (the code was likely copy+pasted and adapted from the old impl of SPA). I feel like using the "end-of-step" data is more appropriate, but I am not entirely sure. There's also an odd timestamp treatment that I will point out in the changes tab. @singhbalwinder 
- sc importer: this is probably the same situation as iop_forcing, as the timestamp is used when calling `overwrite_iop_imports`. @tcclevenger 
- homme dynamics: besides a few places that are only used during init, there was one place where we called timestamp(), and it turns out that what we do now is more appropriate (long story).
