### PR TITLE
Enable ADIOS to NetCDF conversion

### DIFF
--- a/cime_config/customize/case_post_run_io.py
+++ b/cime_config/customize/case_post_run_io.py
@@ -101,7 +101,7 @@ def case_post_run_io(self):
     I/O Post processing :
     1. Convert ADIOS output files, if any, to NetCDF
     """
-    success = True
+    success = None
     has_adios = False
     self.load_env(job="case.post_run_io")
     component_classes = self.get_values("COMP_CLASSES")
@@ -113,9 +113,12 @@ def case_post_run_io(self):
             has_adios = True
             break
     if has_adios:
-        logger.info("I/O post processing for ADIOS starting")
-        success = _convert_adios_to_nc(self)
-        logger.info("I/O post processing for ADIOS completed")
+        if os.environ.get('SPIO_ENABLE_ADIOSBP2NC_CONVERSION', '').lower() in ('true', '1'):
+            logger.info("I/O post processing for ADIOS starting")
+            success = _convert_adios_to_nc(self)
+            logger.info("I/O post processing for ADIOS completed")
+        else:
+            logger.info("Disabling I/O post processing (conversion to NetCDF) for ADIOS BP files since env['SPIO_ENABLE_ADIOSBP2NC_CONVERSION'] is not set/disabled")
     else:
         logger.info("No I/O post processing required")
 

--- a/cime_config/customize/case_post_run_io.py
+++ b/cime_config/customize/case_post_run_io.py
@@ -109,7 +109,7 @@ def case_post_run_io(self):
     for compclass in component_classes:
         key = "PIO_TYPENAME_{}".format(compclass)
         pio_typename = self.get_value(key)
-        if pio_typename == "adios":
+        if pio_typename.startswith("adios"):
             has_adios = True
             break
     if has_adios:

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2066,6 +2066,9 @@
       <env name="SZ_ROOT">$SHELL{if [ -z "$SZ_ROOT" ]; then echo /nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/sz/2.1.12.5/gcc-12.1.0; else echo "$SZ_ROOT"; fi}</env>
       <env name="ZFP_ROOT">$SHELL{if [ -z "$ZFP_ROOT" ]; then echo /nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/zfp/1.0.1/gcc-12.1.0; else echo "$ZFP_ROOT"; fi}</env>
     </environment_variables>
+    <!--environment_variables>
+      <env name="SPIO_ENABLE_ADIOSBP2NC_CONVERSION">1</env>
+    </environment_variables-->
   </machine>
 
   <machine MACH="anlgce">

--- a/cime_config/machines/config_workflow.xml
+++ b/cime_config/machines/config_workflow.xml
@@ -37,7 +37,7 @@
       <template>template.case.test</template>
       <prereq>$BUILD_COMPLETE and $TEST</prereq>
     </job>
-    <!--job name="case.post_run_io">
+    <job name="case.post_run_io">
       <template>template.post_run_io</template>
       <dependency>case.run</dependency>
       <prereq>case.get_value("PIO_TYPENAME_ATM") == 'adios' or \
@@ -53,12 +53,12 @@
       <runtime_parameters>
         <walltime>0:30:00</walltime>
       </runtime_parameters>
-    </job-->
+    </job>
     <job name="case.st_archive">
       <template>template.st_archive</template>
       <!-- If DOUT_S is true and case.run (or case.test) exits successfully then run st_archive-->
       <!--dependency>(case.run and case.post_run_io) or case.test</dependency-->
-      <dependency>case.run or case.test</dependency>
+      <dependency>(case.run or case.test) and case.post_run_io</dependency>
       <prereq>$DOUT_S</prereq>
       <runtime_parameters>
         <task_count>1</task_count>

--- a/cime_config/machines/config_workflow.xml
+++ b/cime_config/machines/config_workflow.xml
@@ -40,16 +40,16 @@
     <job name="case.post_run_io">
       <template>template.post_run_io</template>
       <dependency>case.run</dependency>
-      <prereq>case.get_value("PIO_TYPENAME_ATM") == 'adios' or \
-              case.get_value("PIO_TYPENAME_CPL") == 'adios' or \
-              case.get_value("PIO_TYPENAME_OCN") == 'adios' or \
-              case.get_value("PIO_TYPENAME_WAV") == 'adios' or \
-              case.get_value("PIO_TYPENAME_GLC") == 'adios' or \
-              case.get_value("PIO_TYPENAME_ICE") == 'adios' or \
-              case.get_value("PIO_TYPENAME_ROF") == 'adios' or \
-              case.get_value("PIO_TYPENAME_LND") == 'adios' or \
-              case.get_value("PIO_TYPENAME_ESP") == 'adios' or \
-              case.get_value("PIO_TYPENAME_IAC") == 'adios'</prereq>
+      <prereq>case.get_value("PIO_TYPENAME_ATM").startswith('adios') or \
+              case.get_value("PIO_TYPENAME_CPL").startswith('adios') or \
+              case.get_value("PIO_TYPENAME_OCN").startswith('adios') or \
+              case.get_value("PIO_TYPENAME_WAV").startswith('adios') or \
+              case.get_value("PIO_TYPENAME_GLC").startswith('adios') or \
+              case.get_value("PIO_TYPENAME_ICE").startswith('adios') or \
+              case.get_value("PIO_TYPENAME_ROF").startswith('adios') or \
+              case.get_value("PIO_TYPENAME_LND").startswith('adios') or \
+              case.get_value("PIO_TYPENAME_ESP").startswith('adios') or \
+              case.get_value("PIO_TYPENAME_IAC").startswith('adios')</prereq>
       <runtime_parameters>
         <walltime>0:30:00</walltime>
       </runtime_parameters>


### PR DESCRIPTION
Re-enabled I/O post processing that was disabled in the
CIME workflow.

Users can enable conversion of ADIOS output files 
(in BP file format) to NetCDF by setting the environment
variable 'SPIO_ENABLE_ADIOSBP2NC_CONVERSION' to 1

[BFB]