### PR TITLE
Updates to the Redi isopycnal mixing scheme

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -565,7 +565,10 @@ add_default($nl, 'config_Leith_visc2_max');
 #########################################
 
 add_default($nl, 'config_use_Redi');
+add_default($nl, 'config_Redi_use_new_sfc_taper');
+add_default($nl, 'config_Redi_use_cavity_fix');
 add_default($nl, 'config_Redi_closure');
+add_default($nl, 'config_redi_transition_layer_mld_offset');
 add_default($nl, 'config_Redi_constant_kappa');
 add_default($nl, 'config_Redi_maximum_slope');
 add_default($nl, 'config_Redi_use_slope_taper');

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -565,11 +565,13 @@ add_default($nl, 'config_Leith_visc2_max');
 #########################################
 
 add_default($nl, 'config_use_Redi');
+add_default($nl, 'config_Redi_closure');
+add_default($nl, 'config_redi_transition_layer_bld_fraction');
 add_default($nl, 'config_Redi_use_new_sfc_taper');
 add_default($nl, 'config_Redi_use_cavity_fix');
-add_default($nl, 'config_Redi_closure');
-add_default($nl, 'config_redi_transition_layer_mld_offset');
 add_default($nl, 'config_Redi_constant_kappa');
+add_default($nl, 'config_redi_spatially_variable_min_kappa');
+add_default($nl, 'config_redi_spatially_variable_max_kappa');
 add_default($nl, 'config_Redi_maximum_slope');
 add_default($nl, 'config_Redi_use_slope_taper');
 add_default($nl, 'config_Redi_use_surface_taper');

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -91,11 +91,13 @@ add_default($nl, 'config_Leith_visc2_max');
 #########################################
 
 add_default($nl, 'config_use_Redi');
+add_default($nl, 'config_Redi_closure');
+add_default($nl, 'config_redi_transition_layer_bld_fraction');
 add_default($nl, 'config_Redi_use_new_sfc_taper');
 add_default($nl, 'config_Redi_use_cavity_fix');
-add_default($nl, 'config_Redi_closure');
-add_default($nl, 'config_redi_transition_layer_mld_offset');
 add_default($nl, 'config_Redi_constant_kappa');
+add_default($nl, 'config_redi_spatially_variable_min_kappa');
+add_default($nl, 'config_redi_spatially_variable_max_kappa');
 add_default($nl, 'config_Redi_maximum_slope');
 add_default($nl, 'config_Redi_use_slope_taper');
 add_default($nl, 'config_Redi_use_surface_taper');

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -91,7 +91,10 @@ add_default($nl, 'config_Leith_visc2_max');
 #########################################
 
 add_default($nl, 'config_use_Redi');
+add_default($nl, 'config_Redi_use_new_sfc_taper');
+add_default($nl, 'config_Redi_use_cavity_fix');
 add_default($nl, 'config_Redi_closure');
+add_default($nl, 'config_redi_transition_layer_mld_offset');
 add_default($nl, 'config_Redi_constant_kappa');
 add_default($nl, 'config_Redi_maximum_slope');
 add_default($nl, 'config_Redi_use_slope_taper');

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -176,12 +176,14 @@
 <config_use_Redi ocn_grid="oRRS18to6v3">.false.</config_use_Redi>
 <config_use_Redi ocn_grid="oRRS15to5">.false.</config_use_Redi>
 <config_use_Redi ocn_grid="RRSwISC6to18E3r5">.false.</config_use_Redi>
+<config_Redi_closure>'constant'</config_Redi_closure>
+<config_redi_transition_layer_bld_fraction>0.8</config_redi_transition_layer_bld_fraction>
 <config_Redi_use_new_sfc_taper>.false.</config_Redi_use_new_sfc_taper>
 <config_Redi_use_cavity_fix>.false.</config_Redi_use_cavity_fix>
-<config_Redi_closure>'constant'</config_Redi_closure>
-<config_redi_transition_layer_mld_offset>100.0</config_redi_transition_layer_mld_offset>
 <config_Redi_constant_kappa>400.0</config_Redi_constant_kappa>
 <config_Redi_constant_kappa ocn_forcing="datm_forced_restoring">400.0</config_Redi_constant_kappa>
+<config_redi_spatially_variable_min_kappa>100.0</config_redi_spatially_variable_min_kappa>
+<config_redi_spatially_variable_max_kappa>1000.0</config_redi_spatially_variable_max_kappa>
 <config_Redi_maximum_slope>0.01</config_Redi_maximum_slope>
 <config_Redi_use_slope_taper>.true.</config_Redi_use_slope_taper>
 <config_Redi_use_surface_taper>.true.</config_Redi_use_surface_taper>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -176,7 +176,10 @@
 <config_use_Redi ocn_grid="oRRS18to6v3">.false.</config_use_Redi>
 <config_use_Redi ocn_grid="oRRS15to5">.false.</config_use_Redi>
 <config_use_Redi ocn_grid="RRSwISC6to18E3r5">.false.</config_use_Redi>
+<config_Redi_use_new_sfc_taper>.false.</config_Redi_use_new_sfc_taper>
+<config_Redi_use_cavity_fix>.false.</config_Redi_use_cavity_fix>
 <config_Redi_closure>'constant'</config_Redi_closure>
+<config_redi_transition_layer_mld_offset>100.0</config_redi_transition_layer_mld_offset>
 <config_Redi_constant_kappa>400.0</config_Redi_constant_kappa>
 <config_Redi_constant_kappa ocn_forcing="datm_forced_restoring">400.0</config_Redi_constant_kappa>
 <config_Redi_maximum_slope>0.01</config_Redi_maximum_slope>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -383,11 +383,35 @@ Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_Redi_use_new_sfc_taper" type="logical"
+  category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
+  If true, the new surface taper is used where Redi is horizontal in the boundary layer instead of off
+
+  Valid values: .true. or .false.
+  Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_Redi_use_cavity_fix" type="logical"
+  category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
+  If true, use the correction for horizontal T and S gradients in the redi calculation
+
+  Valid values: .true. or .false.
+  Default: Defined in namelist_defaults.xml
+</entry>
+
 <entry id="config_Redi_closure" type="char*1024"
 	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
 Control what type of function is used for Redi $\kappa$. For 'equalGM', RediKappa is set to gmBolusKappa, so picks up the closure used by GM. Note that equalGM should only be used with 2D GM schemes (e.g. config_GM_closure=constant or Visbeck), not with EdenGreatbatch.
 
 Valid values: 'constant', 'equalGM', 'data'
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_redi_transition_layer_mld_offset" type="real"
+	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
+For instances where MLD lt BLD, the MLD for the transition layer (from isopycnal at depth to horizontal in the BLD) is set to BLD + this config value
+
+Valid values: Positive real numbers.
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -383,35 +383,35 @@ Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_Redi_use_new_sfc_taper" type="logical"
-  category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
-  If true, the new surface taper is used where Redi is horizontal in the boundary layer instead of off
-
-  Valid values: .true. or .false.
-  Default: Defined in namelist_defaults.xml
-</entry>
-
-<entry id="config_Redi_use_cavity_fix" type="logical"
-  category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
-  If true, use the correction for horizontal T and S gradients in the redi calculation
-
-  Valid values: .true. or .false.
-  Default: Defined in namelist_defaults.xml
-</entry>
-
 <entry id="config_Redi_closure" type="char*1024"
 	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
-Control what type of function is used for Redi $\kappa$. For 'equalGM', RediKappa is set to gmBolusKappa, so picks up the closure used by GM. Note that equalGM should only be used with 2D GM schemes (e.g. config_GM_closure=constant or Visbeck), not with EdenGreatbatch.
+Control what type of function is used for Redi $\kappa$. For 'equalGM', RediKappa is set to gmBolusKappa, so picks up the closure used by GM. For N2_dependent, the range varies from config_redi_constant_kappa down to 10% of that value
 
-Valid values: 'constant', 'equalGM', 'data'
+Valid values: 'constant', 'N2_dependent', 'equalGM', 'data'
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_redi_transition_layer_mld_offset" type="real"
+<entry id="config_redi_transition_layer_bld_fraction" type="real"
 	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
-For instances where MLD lt BLD, the MLD for the transition layer (from isopycnal at depth to horizontal in the BLD) is set to BLD + this config value
+Parameter that controls over what fraction the redi tensor transitions from isopycnal to horizontal.  For example a value of 0.8 means at z = -0.8*bld the tensor is fully horizontal.  Transition is linear between the bld base and this point
 
 Valid values: Positive real numbers.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_Redi_use_new_sfc_taper" type="logical"
+	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
+Controls if the taper where redi is purely horizontal in the boundary layer instead of off
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_Redi_use_cavity_fix" type="logical"
+	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
+if true use the corrected form of the horizontal temperature and salinity gradients
+
+Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -420,6 +420,22 @@ Default: Defined in namelist_defaults.xml
 The Redi diffusion coefficient. Only used when config_Redi_closure = 'constant'.
 
 Valid values: Positive real numbers.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_redi_spatially_variable_min_kappa" type="real"
+	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
+minimum value of redi diffusivity for N2_dependent redi scheme.
+
+Valid values: values around 100s
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_redi_spatially_variable_max_kappa" type="real"
+	category="Redi_isopycnal_mixing" group="Redi_isopycnal_mixing">
+minimum value of redi diffusivity for N2_dependent redi scheme.
+
+Valid values: values around 100s
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -1160,7 +1160,7 @@ contains
             end if
             ! Compute normalGMBolusVelocity, relativeSlope and RediDiffVertCoef if respective flags are turned on
             if (config_use_Redi.or.config_use_GM) then
-              call ocn_gm_compute_Bolus_velocity(statePool, meshPool, scratchPool, timeLevelIn=1)
+              call ocn_gm_compute_Bolus_velocity(statePool, meshPool, timeLevelIn=1)
             endif
 
             block_ptr => block_ptr % next

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -304,7 +304,7 @@
 					description="Control what type of function is used for Redi $\kappa$. For 'equalGM', RediKappa is set to gmBolusKappa, so picks up the closure used by GM. For N2_dependent, the range varies from config_redi_constant_kappa down to 10% of that value" 
 					possible_values="'constant', 'N2_dependent', 'equalGM', 'data'"
 		/>
-		<nml_option name="config_redi_transition_layer_mld_offset" type="real" default_value="0.8" units="m"
+		<nml_option name="config_redi_transition_layer_bld_fraction" type="real" default_value="0.8" units="m"
 		            description="Parameter that controls over what fraction the redi tensor transitions from isopycnal to horizontal.  For example a value of 0.8 means at z = -0.8*bld the tensor is fully horizontal.  Transition is linear between the bld base and this point"
 					possible_values="Positive real numbers."
 		/>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -304,13 +304,13 @@
 					description="Control what type of function is used for Redi $\kappa$. For 'equalGM', RediKappa is set to gmBolusKappa, so picks up the closure used by GM. For N2_dependent, the range varies from config_redi_constant_kappa down to 10% of that value" 
 					possible_values="'constant', 'N2_dependent', 'equalGM', 'data'"
 		/>
-		<nml_option name="config_redi_transition_layer_mld_offset" type="real" default_value="100.0" units="m"
-		            description="For instances where MLD lt BLD, the MLD for the transition layer (from isopycnal at depth to horizontal in the BLD) is set to BLD + this config value"
+		<nml_option name="config_redi_transition_layer_mld_offset" type="real" default_value="0.8" units="m"
+		            description="Parameter that controls over what fraction the redi tensor transitions from isopycnal to horizontal.  For example a value of 0.8 means at z = -0.8*bld the tensor is fully horizontal.  Transition is linear between the bld base and this point"
 					possible_values="Positive real numbers."
 		/>
 		<nml_option name="config_Redi_use_new_sfc_taper" type="logical" default_value=".false."
 					description="Controls if the taper where redi is purely horizontal in the boundary layer instead of off"
-					posible_values=".true. or .false."
+					possible_values=".true. or .false."
 		/>
 	  <nml_option name="config_Redi_use_cavity_fix" type="logical" default_value=".false."
 					description="if true use the corrected form of the horizontal temperature and salinity gradients"
@@ -320,7 +320,15 @@
 					description="The Redi diffusion coefficient. Only used when config_Redi_closure = 'constant'."
 					possible_values="Positive real numbers."
 		/>
-		<nml_option name="config_Redi_maximum_slope" type="real" default_value="0.3" units="non-dimensional"
+	   <nml_option name="config_redi_spatially_variable_min_kappa" type="real" default_value="100.0" units="m^2 s^-1"
+					description="minimum value of redi diffusivity for N2_dependent redi scheme."
+					possible_values="values around 100s"
+		/>
+		<nml_option name="config_redi_spatially_variable_max_kappa" type="real" default_value="1000.0" units="m^2 s^-1"
+					description="minimum value of redi diffusivity for N2_dependent redi scheme."
+					possible_values="values around 100s"
+		/>
+	<nml_option name="config_Redi_maximum_slope" type="real" default_value="0.3" units="non-dimensional"
 					description="value of maximum allowed isopycnal slope from Danabasoglu et al 2008 equation (2)"
 					possible_values="positive real numbers, but small"
 		/>
@@ -3370,19 +3378,19 @@
 		/>
 		<var name="slopeTriadUp" type="real" dimensions="nVertLevels TWO nEdges Time" units="non-dimensional" default_value="0.0"
 			 description="Magnitude of slope of isopycnal surface, using triad through this cell and edge, angled up. Uses expansion of equation of state."
-			 packages="redi"
+			 packages="forwardMode;analysisMode"
 		/>
 		<var name="slopeTriadDown" type="real" dimensions="nVertLevels TWO nEdges Time" units="non-dimensional" default_value="0.0"
 			 description="Magnitude of slope of isopycnal surface, using triad through this cell and edge, angled up. Uses expansion of equation of state."
-			 packages="redi"
+			 packages="forwardMode;analysisMode"
 		/>
 		<var name="limiterUp" type="real" dimensions="nVertLevels TWO nEdges Time" units="non-dimensional" default_value="0.0"
 			 description="Magnitude of slope of isopycnal surface, using triad through this cell and edge, angled up. Uses expansion of equation of state."
-			 packages="redi"
+			 packages="forwardMode;analysisMode"
 		/>
 		<var name="limiterDown" type="real" dimensions="nVertLevels TWO nEdges Time" units="non-dimensional" default_value="0.0"
 			 description="Magnitude of slope of isopycnal surface, using triad through this cell and edge, angled up. Uses expansion of equation of state."
-			 packages="redi"
+			 packages="forwardMode;analysisMode"
 		/>
 		<var name="k33" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2 s^-1"
 			 description="The (3,3) entry of the Redi diffusion tensor. Added to the model vertical diffusion. Defined at the top of cell k"
@@ -3418,7 +3426,7 @@
 		/>
 		<var name="RediKappa" type="real" dimensions="nVertLevelsP1 nEdges Time" units="m^2 s^-1"
 			 description="Redi Kappa value.  On output, it has already been multiplied by the horizontal taper array RediHorizontalTaper (as opposed to gmBolusKappa, which has not been multiplied by the horizontal taper)."
-			 packages="gm;redi"
+			 packages="forwardMode;analysisMode"
 		/>
 		<var name="RediHorizontalTaper" type="real" dimensions="nEdges Time"
 			 description="Horizontal tapering for Redi. Varies between 0 and 1."

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -301,8 +301,24 @@
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_Redi_closure" type="character" default_value="constant"
-					description="Control what type of function is used for Redi $\kappa$. For 'equalGM', RediKappa is set to gmBolusKappa, so picks up the closure used by GM. Note that equalGM should only be used with 2D GM schemes (e.g. config_GM_closure=constant or Visbeck), not with EdenGreatbatch."
-					possible_values="'constant', 'equalGM', 'data'"
+					description="Control what type of function is used for Redi $\kappa$. For 'equalGM', RediKappa is set to gmBolusKappa, so picks up the closure used by GM. For N2_dependent, the range varies from config_redi_constant_kappa down to 10% of that value" 
+					possible_values="'constant', 'N2_dependent', 'equalGM', 'data'"
+		/>
+		<nml_option name="config_redi_transition_layer_mld_offset" type="real" default_value="100.0" units="m"
+		            description="For instances where MLD lt BLD, the MLD for the transition layer (from isopycnal at depth to horizontal in the BLD) is set to BLD + this config value"
+					possible_values="Positive real numbers."
+		/>
+		<nml_option name="config_Redi_use_new_sfc_taper" type="logical" default_value=".false."
+					description="Controls if the taper where redi is purely horizontal in the boundary layer instead of off"
+					posible_values=".true. or .false."
+		/>
+	  <nml_option name="config_Redi_use_cavity_fix" type="logical" default_value=".false."
+					description="if true use the corrected form of the horizontal temperature and salinity gradients"
+					possible_values=".true. or .false."
+		/>
+	    <nml_option name="config_redi_transition_layer_mld_offset" type="real" default_value="100.0" units="m"
+		            description="For instances where MLD lt BLD, the MLD for the transition layer (from isopycnal at depth to horizontal in the BLD) is set to BLD + this config value"
+					possible_values="Positive real numbers."
 		/>
 		<nml_option name="config_Redi_constant_kappa" type="real" default_value="600.0" units="m^2 s^-1"
 					description="The Redi diffusion coefficient. Only used when config_Redi_closure = 'constant'."
@@ -378,7 +394,7 @@
 		/>
 		<nml_option name="config_GM_closure" type="character" default_value="EdenGreatbatch"
 					description="Control what method used to compute GM $\kappa$. Both 'constant' and 'N2_dependent' use the method in Ferrari et al. 2010 (https://doi.org/10.1016/j.ocemod.2010.01.004). 'constant' uses a constant kappa in eqn 16a, while 'N2_dependent' varies kappa in the vertical according to Danabasoglu and Marshall 2007 (https://doi.org/10.1016/j.ocemod.2007.03.006). 'Visbeck' implements a horizontally varying diffusivity of Visbeck et al 1997. EdenGreatbatch implements a simplified form of the EKE scheme in Eden and Greatbatch (2008) Ocean modeling"
-					possible_values="'constant', 'N2_dependent', 'Visbeck', 'EdenGreatbatch'"
+					possible_values="'constant', 'N2_dependent', 'N2_dependent_orig', 'Visbeck', 'EdenGreatbatch'"
 		/>
 		<nml_option name="config_GM_constant_kappa" type="real" default_value="600.0" units="m^2 s^-1"
 					description="Coefficient of standard GM parametrization of eddy transport (Bolus component), $\kappa$. Only used when config_GM_closure is set to constant."
@@ -1742,6 +1758,7 @@
 		<package name="tracerBudget" description="This package controls variables that record the tracer budget."/>
 		<package name="gm" description="This package is for GM variables, which are only needed at lower resolutions."/>
 		<package name="submeso" description="This package is for submesoscale eddy (MLE) variables, needed at resolutions greater than O(1km)"/>
+		<package name="redi" description="This package is for redi isoneutral mixing, it is used when the rossby radius is not resolved"/>
 		<package name="tidalPotentialForcingPKG" description="This package controls variables required for tidal potential forcing"/>
 		<package name="topographicWaveDragPKG" description="This package controls variables required for topographic wave drag"/>
 		<package name="gotmPKG" description="This package is for GOTM variables, which are only needed when using GOTM for the vertical turbulence closure."/>
@@ -2057,6 +2074,7 @@
 			<var_array name="SSHGradient"/>
 			<var_array name="vertNonLocalFlux"/>
 			<var name="boundaryLayerDepth"/>
+			<var name="dThreshMLD"/>
 			<var name="effectiveDensityInLandIce"/>
 			<var_struct name="ecosysAuxiliary"/>
 			<var name="accumulatedFrazilIceMass"/>
@@ -3202,7 +3220,7 @@
 		<var name="normalGMBolusVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
 			 description="Bolus velocity in Gent-McWilliams eddy parameterization"
 			 missing_value="FILLVAL" missing_value_mask="edgeMask"
-			 packages="gm"
+			 packages="gm;redi"
 		/>
 		<var name="normalMLEvelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^-1"
 			description="Velocity from mixed layer eddies (fox kemper 2011 submesoscale parameterization)"
@@ -3219,13 +3237,13 @@
 			description="spatially and depth varying GM kappa.  The scaling is based on the Brunt Vaisala Frequency relative to a maximum value below the mixed layer, follows from Danabasoglu and Marshall 2007.  If config_GM_closure is not set to N2_dependent the scaling value is set to 1 everywhere."
 			packages="gm"
 		/>
-		<var name="RediKappaSfcTaper" type="real" dimensions="nVertLevelsP1 nCells Time" units="1"
+		<var name="RediKappaSfcTaper" type="real" dimensions="nVertLevelsP1 nEdges Time" units="1"
 			description="Scaling coefficient for Redi kappa. Varies from 0 to 1."
-			packages="gm"
+			packages="gm;redi"
 		/>
 		<var name="rediLimiterCount" type="integer" dimensions="nVertLevels nCells Time"
 			description="count of times redi limiter is invoked on a timestep"
-			packages="gm"
+			packages="gm;redi"
 		/>
 		<var name="gradDensityEddy" type="real" dimensions="nVertLevels nEdges Time" units="kg m^-4"
 			description="horizontal gradient of density at cell edge and interfaces in vertical.  this is used for the GM parameterization and the submesoscale eddy parameterization"
@@ -3356,23 +3374,23 @@
 		/>
 		<var name="slopeTriadUp" type="real" dimensions="nVertLevels TWO nEdges Time" units="non-dimensional" default_value="0.0"
 			 description="Magnitude of slope of isopycnal surface, using triad through this cell and edge, angled up. Uses expansion of equation of state."
-			 packages="forwardMode;analysisMode"
+			 packages="redi"
 		/>
 		<var name="slopeTriadDown" type="real" dimensions="nVertLevels TWO nEdges Time" units="non-dimensional" default_value="0.0"
 			 description="Magnitude of slope of isopycnal surface, using triad through this cell and edge, angled up. Uses expansion of equation of state."
-			 packages="forwardMode;analysisMode"
+			 packages="redi"
 		/>
 		<var name="limiterUp" type="real" dimensions="nVertLevels TWO nEdges Time" units="non-dimensional" default_value="0.0"
 			 description="Magnitude of slope of isopycnal surface, using triad through this cell and edge, angled up. Uses expansion of equation of state."
-			 packages="forwardMode;analysisMode"
+			 packages="redi"
 		/>
 		<var name="limiterDown" type="real" dimensions="nVertLevels TWO nEdges Time" units="non-dimensional" default_value="0.0"
 			 description="Magnitude of slope of isopycnal surface, using triad through this cell and edge, angled up. Uses expansion of equation of state."
-			 packages="forwardMode;analysisMode"
+			 packages="redi"
 		/>
 		<var name="k33" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2 s^-1"
 			 description="The (3,3) entry of the Redi diffusion tensor. Added to the model vertical diffusion. Defined at the top of cell k"
-			 packages="forwardMode;analysisMode"
+			 packages="redi"
 		/>
 		<var name="gmStreamFuncTopOfEdge" type="real" dimensions="nVertLevelsP1 nEdges Time" units="m^2 s^-1"
 			 description="GM stream function"
@@ -3400,23 +3418,23 @@
 		/>
 		<var name="gmBolusKappa" type="real" dimensions="nEdges Time" units="m^2 s^-1"
 			 description="GM Bolus Kappa value.  On output, it has NOT been multiplied by the horizontal taper array gmHorizontalTaper, because that is applied at the end to the normalGMBolusVelocity variable, not to the gmBolusKappa."
-			 packages="gm"
+			 packages="gm;redi"
 		/>
-		<var name="RediKappa" type="real" dimensions="nEdges Time" units="m^2 s^-1"
+		<var name="RediKappa" type="real" dimensions="nVertLevelsP1 nEdges Time" units="m^2 s^-1"
 			 description="Redi Kappa value.  On output, it has already been multiplied by the horizontal taper array RediHorizontalTaper (as opposed to gmBolusKappa, which has not been multiplied by the horizontal taper)."
-			 packages="gm"
+			 packages="gm;redi"
 		/>
 		<var name="RediHorizontalTaper" type="real" dimensions="nEdges Time"
 			 description="Horizontal tapering for Redi. Varies between 0 and 1."
-			 packages="gm"
+			 packages="gm;redi"
 		/>
 		<var name="gmHorizontalTaper" type="real" dimensions="nEdges Time"
 			 description="Horizontal tapering for GM. Varies between 0 and 1."
-			 packages="gm"
+			 packages="gm;redi"
 		/>
 		<var name="RossbyRadius" type="real" dimensions="nEdges Time" units="m"
 			 description="Rossby Radius, computed in GM routine for some settings"
-			 packages="gm"
+			 packages="gm;redi"
 		/>
 		<var name="surfaceFluxAttenuationCoefficient" type="real" dimensions="nCells Time" units="m"
 			description="The spatially-dependent length scale of exponential decay of surface fluxes. Fluxes are multiplied by $e^{z/\gamma}$, where this coefficient is $\gamma$."

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -316,10 +316,6 @@
 					description="if true use the corrected form of the horizontal temperature and salinity gradients"
 					possible_values=".true. or .false."
 		/>
-	    <nml_option name="config_redi_transition_layer_mld_offset" type="real" default_value="100.0" units="m"
-		            description="For instances where MLD lt BLD, the MLD for the transition layer (from isopycnal at depth to horizontal in the BLD) is set to BLD + this config value"
-					possible_values="Positive real numbers."
-		/>
 		<nml_option name="config_Redi_constant_kappa" type="real" default_value="600.0" units="m^2 s^-1"
 					description="The Redi diffusion coefficient. Only used when config_Redi_closure = 'constant'."
 					possible_values="Positive real numbers."
@@ -394,7 +390,7 @@
 		/>
 		<nml_option name="config_GM_closure" type="character" default_value="EdenGreatbatch"
 					description="Control what method used to compute GM $\kappa$. Both 'constant' and 'N2_dependent' use the method in Ferrari et al. 2010 (https://doi.org/10.1016/j.ocemod.2010.01.004). 'constant' uses a constant kappa in eqn 16a, while 'N2_dependent' varies kappa in the vertical according to Danabasoglu and Marshall 2007 (https://doi.org/10.1016/j.ocemod.2007.03.006). 'Visbeck' implements a horizontally varying diffusivity of Visbeck et al 1997. EdenGreatbatch implements a simplified form of the EKE scheme in Eden and Greatbatch (2008) Ocean modeling"
-					possible_values="'constant', 'N2_dependent', 'N2_dependent_orig', 'Visbeck', 'EdenGreatbatch'"
+					possible_values="'constant', 'N2_dependent', 'Visbeck', 'EdenGreatbatch'"
 		/>
 		<nml_option name="config_GM_constant_kappa" type="real" default_value="600.0" units="m^2 s^-1"
 					description="Coefficient of standard GM parametrization of eddy transport (Bolus component), $\kappa$. Only used when config_GM_closure is set to constant."

--- a/components/mpas-ocean/src/driver/mpas_ocn_core_interface.F
+++ b/components/mpas-ocean/src/driver/mpas_ocn_core_interface.F
@@ -133,6 +133,7 @@ module ocn_core_interface
       logical, pointer :: inSituEOSActive
       logical, pointer :: variableShortwaveActive
       logical, pointer :: gmActive
+      logical, pointer :: rediActive
       logical, pointer :: submesoActive
       logical, pointer :: timeVaryingAtmosphericForcingPKGActive
       logical, pointer :: timeVaryingLandIceForcingPKGActive
@@ -380,13 +381,18 @@ module ocn_core_interface
       end if
 
       !
-      ! test for use of gm
+      ! test for use of gm/redi
       !
       call mpas_pool_get_package(packagePool, 'gmActive', gmActive)
+      call mpas_pool_get_package(packagePool, 'rediActive', rediActive)
       call mpas_pool_get_config(configPool, 'config_use_GM', config_use_GM)
       call mpas_pool_get_config(configPool, 'config_use_Redi', config_use_Redi)
-      if (config_use_GM.or.config_use_Redi) then
+      if (config_use_GM) then
          gmActive = .true.
+      end if
+
+      if (config_use_Redi) then
+         rediActive = .true.
       end if
 
       !

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -35,6 +35,7 @@ module ocn_forward_mode
    use ocn_analysis_driver
    use ocn_init_routines
 
+   use ocn_redi
    use ocn_time_integration
    use ocn_time_integration_split
    use ocn_time_integration_split_ab2
@@ -475,6 +476,8 @@ module ocn_forward_mode
       ierr = ior(ierr,err_tmp)
       call ocn_gm_init(domain, err_tmp)
       ierr = ior(ierr,err_tmp)
+      call ocn_redi_init(err_tmp)
+      ierr = ior(ierr,err_tmp)
       call ocn_submesoscale_init(err_tmp)
       ierr = ior(ierr,err_tmp)
       call ocn_tracer_nonlocalflux_init(err_tmp)
@@ -664,6 +667,14 @@ module ocn_forward_mode
         call mpas_timer_stop('io_monthly_surface_salinity')
       endif
 
+      ! ---  update halos for diagnostic ocean boundary layer depth
+      if (config_use_cvmix_kpp) then
+         call mpas_timer_start("se halo diag obd")
+         call mpas_dmpar_field_halo_exch(domain,'boundaryLayerDepth')
+         call mpas_dmpar_field_halo_exch(domain,'dThreshMLD')
+         call mpas_timer_stop("se halo diag obd")
+      end if
+
       ! initialize time-varying forcing
       call ocn_time_varying_forcing_init(domain)
 
@@ -734,7 +745,7 @@ module ocn_forward_mode
            end if
 
            if (config_use_Redi.or.config_use_GM) then
-               call ocn_gm_compute_Bolus_velocity(statePool, meshPool, scratchPool, timeLevelIn=1)
+               call ocn_gm_compute_Bolus_velocity(statePool, meshPool, timeLevelIn=1)
            end if
 
            block_ptr => block_ptr % next

--- a/components/mpas-ocean/src/ocean.cmake
+++ b/components/mpas-ocean/src/ocean.cmake
@@ -39,6 +39,7 @@ list(APPEND RAW_SOURCES
 
   core_ocean/shared/mpas_ocn_init_routines.F
   core_ocean/shared/mpas_ocn_gm.F
+  core_ocean/shared/mpas_ocn_redi.F
   core_ocean/shared/mpas_ocn_submesoscale_eddies.F
   core_ocean/shared/mpas_ocn_eddy_parameterization_helpers.F
   core_ocean/shared/mpas_ocn_diagnostics.F

--- a/components/mpas-ocean/src/shared/Makefile
+++ b/components/mpas-ocean/src/shared/Makefile
@@ -2,6 +2,7 @@
 
 OBJS = mpas_ocn_init_routines.o \
 	   mpas_ocn_gm.o \
+	   mpas_ocn_redi.o \
 	   mpas_ocn_eddy_parameterization_helpers.o \
 	   mpas_ocn_submesoscale_eddies.o \
 	   mpas_ocn_diagnostics.o \
@@ -81,7 +82,7 @@ OBJS = mpas_ocn_init_routines.o \
 
 all: $(OBJS)
 
-mpas_ocn_init_routines.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics.o mpas_ocn_diagnostics_variables.o mpas_ocn_gm.o mpas_ocn_submesoscale_eddies.o mpas_ocn_forcing.o mpas_ocn_surface_land_ice_fluxes.o
+mpas_ocn_init_routines.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics.o mpas_ocn_diagnostics_variables.o mpas_ocn_gm.o mpas_ocn_redi.o mpas_ocn_submesoscale_eddies.o mpas_ocn_forcing.o mpas_ocn_surface_land_ice_fluxes.o
 
 mpas_ocn_tendency.o: mpas_ocn_high_freq_thickness_hmix_del2.o mpas_ocn_tracer_surface_restoring.o mpas_ocn_thick_surface_flux.o mpas_ocn_tracer_short_wave_absorption.o mpas_ocn_tracer_advection.o mpas_ocn_tracer_hmix.o mpas_ocn_tracer_nonlocalflux.o mpas_ocn_surface_bulk_forcing.o mpas_ocn_surface_land_ice_fluxes.o mpas_ocn_tracer_surface_flux_to_tend.o mpas_ocn_tracer_interior_restoring.o mpas_ocn_tracer_exponential_decay.o mpas_ocn_tracer_ideal_age.o mpas_ocn_tracer_TTD.o mpas_ocn_vmix.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_frazil_forcing.o mpas_ocn_tidal_forcing.o mpas_ocn_tracer_ecosys.o mpas_ocn_tracer_DMS.o mpas_ocn_tracer_MacroMolecules.o mpas_ocn_tracer_CFC.o mpas_ocn_diagnostics.o mpas_ocn_wetting_drying.o mpas_ocn_vel_self_attraction_loading.o  mpas_ocn_vel_tidal_potential.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o mpas_ocn_thick_hadv.o mpas_ocn_thick_vadv.o mpas_ocn_vel_hadv_coriolis.o mpas_ocn_vel_pressure_grad.o mpas_ocn_vel_vadv.o mpas_ocn_vel_hmix.o mpas_ocn_vel_forcing.o mpas_ocn_manufactured_solution.o
 
@@ -101,7 +102,9 @@ mpas_ocn_thick_vadv.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o
 
 mpas_ocn_thick_surface_flux.o: mpas_ocn_forcing.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o
 
-mpas_ocn_gm.o:  mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o mpas_ocn_submesoscale_eddies.o
+mpas_ocn_gm.o:  mpas_ocn_redi.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o mpas_ocn_submesoscale_eddies.o
+
+mpas_ocn_redi.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o mpas_ocn_mesh.o
 
 mpas_ocn_submesoscale_eddies.o:  mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_diagnostics_variables.o mpas_ocn_mesh.o
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -143,6 +143,7 @@ module ocn_diagnostics_variables
 
    integer, dimension(:), pointer :: indMLD
    real(kind=RKIND), dimension(:), pointer :: dThreshMLD
+
    real (kind=RKIND), dimension(:,:), pointer :: velocityX, velocityY, velocityZ
 
    real (kind=RKIND), dimension(:,:), pointer :: vertAleTransportTop
@@ -164,7 +165,7 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:,:,:), pointer :: activeTracerNonLocalTendency
    real (kind=RKIND), dimension(:,:,:), pointer :: activeTracerHorMixTendency
    real (kind=RKIND), dimension(:,:), pointer :: temperatureShortWaveTendency
-   real (kind=RKIND), dimension(:), pointer :: RediKappa
+   real (kind=RKIND), dimension(:,:), pointer :: RediKappa
 
    ! pointers for tendencies used in diagnostic budget computation
    real (kind=RKIND), dimension(:,:,:), pointer, contiguous :: &

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -207,6 +207,56 @@ module ocn_gm
 
          nCells = nCellsArray(4)
 
+         !$omp parallel
+         !$omp do schedule(runtime) private(k, cell1, cell2, sum_hN, lt1, lt2, c_mode1, resolution, dc_Lr)
+         do iEdge = 1, nEdges
+            cell1 = cellsOnEdge(1, iEdge)
+            cell2 = cellsOnEdge(2, iEdge)
+            sum_hN = 0.0
+
+            do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)-1
+
+               lt1 = 0.5_RKIND*(layerThickness(k,cell1) + layerThickness(k-1,cell1))
+               lt2 = 0.5_RKIND*(layerThickness(k,cell2) + layerThickness(k-1,cell2))
+               sum_hN = sum_hN + 0.5_RKIND*(lt1*sqrt(max(BruntVaisalaFreqTop(k,cell1),0.0_RKIND)) + &
+                               lt2*sqrt(max(BruntVaisalaFreqTop(k,cell2),0.0_RKIND)))
+            end do
+
+            ! See Chelton (1998)
+            ! https://journals.ametsoc.org/view/journals/phoc/28/3/1520-0485_1998_028_0433_gvotfb_2.0.co_2.xml
+            ! eqn 2.2a, also Appendix A,
+            ! for the first-mode (m=1) baroclinic gravity wave speed in m/s
+            ! c_m = 1/pi integral(N dz )
+
+            c_mode1 = max(1.0E-5_RKIND, sum_hN/pi)
+
+            ! See Hallberg (2013) https://doi.org/10.1016/j.ocemod.2013.08.007
+            ! just after eqn 4 the defines the deformation
+            ! radius as:
+            ! L = sqrt( c_g^2/ ( f^2 + 2*beta*c_g) )
+            !   = c_g * sqrt(1/( f^2 + 2*beta*c_g) )  (note c_g is guaranteed non-negative)
+            ! This comes from a combination of Chelton (1998) eqns 2.3a and
+            ! 2.3b, with a smooth transition in between.
+            RossbyRadius(iEdge) = c_mode1*sqrt( 1.0_RKIND / &
+               (fEdge(iEdge)*fEdge(iEdge) + 2.0_RKIND*betaEdge(iEdge)*c_mode1 + 1.0E-15_RKIND))
+
+            dc_Lr = dcEdge(iEdge)/RossbyRadius(iEdge)
+
+            ! Ramp the parameterization between the given min and max values
+            ! of the ratio of the cell width to the Rossby radius
+            if (dc_Lr <= config_GMRedi_Rossby_ramp_min) then
+               RossbyRadiusTaper(iEdge) = 0.0_RKIND
+            else if (dc_Lr >= config_GMRedi_Rossby_ramp_max) then
+               RossbyRadiusTaper(iEdge) = 1.0_RKIND
+            else
+               ! a linear ramp between the min and max of dc_Lr
+               RossbyRadiusTaper(iEdge) = (dc_Lr - config_GMRedi_Rossby_ramp_min) / &
+                  (config_GMRedi_Rossby_ramp_max - config_GMRedi_Rossby_ramp_min)
+            end if
+         end do
+         !$omp end do
+         !$omp end parallel
+
          if (config_GM_horizontal_taper == 'RossbyRadius') then
             !$omp parallel
             !$omp do schedule(runtime)

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -13,6 +13,7 @@ module ocn_gm
    use mpas_constants
    use mpas_threading
 
+   use ocn_redi
    use ocn_constants
    use ocn_config
    use ocn_diagnostics_variables
@@ -54,30 +55,12 @@ module ocn_gm
    logical :: local_config_GM_lat_variable_c2
    logical :: local_config_GM_kappa_lat_depth_variable
    logical :: local_config_GM_compute_EdenGreatbatch
-   real(kind=RKIND) :: slopeTaperFactor, sfcTaperFactor, rediGMinitValue
+   logical :: local_config_GM_kappa_lat_depth_variable_orig
+   real(kind=RKIND) :: rediGMinitValue
    real(kind=RKIND) :: local_config_GM_constant_bclModeSpeed
    real(kind=RKIND) :: gm_minBclModeSpeed_constant, gm_minBclModeSpeed_compute_on
 
-!***********************************************************************
-
-contains
-
-   function safe_slope(num, den) result(slope)
-
-      real(kind=RKIND), intent(in) :: num, den
-      real(kind=RKIND) :: slope
-
-      ! compute isopycnal slopes safely wrt. finite precision
-      ! small slope assumption, so don't want |s| > 1
-
-      if (abs(den) > abs(num)) then
-         slope = num / den
-      else
-         slope = sign(1.0_RKIND, den * num)
-      end if
-
-   end function
-
+   contains
 !***********************************************************************
 !
 !  routine ocn_GM_compute_Bolus_velocity
@@ -106,7 +89,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_GM_compute_Bolus_velocity(statePool, &
-                                            meshPool, scratchPool, timeLevelIn)
+                                            meshPool, timeLevelIn)
       !{{{
 
       !-----------------------------------------------------------------
@@ -128,9 +111,6 @@ contains
       !
       !-----------------------------------------------------------------
 
-      type(mpas_pool_type), intent(inout) :: &
-         scratchPool           ! pool containing some scratch space
-
       !-----------------------------------------------------------------
       !
       ! local variables
@@ -149,25 +129,21 @@ contains
       integer                          :: i, k, iEdge, cell1, cell2, iCell, N, iCellSelf, maxLocation
       real(kind=RKIND)                 :: h1, h2, areaEdge, BruntVaisalaFreqTopEdge, rtmp
       real(kind=RKIND)                 :: sum_hN, countN2, maxN, ltSum
-      real(kind=RKIND)                 :: sumRi, RiTopOfEdge, zEdge, zMLD, sfcTaper
-      real(kind=RKIND) :: dcEdgeInv, drhoDx, drhoDT, drhoDS, dTdx, dSdx
-      real(kind=RKIND) :: slopeTaperUp, slopeTaperDown, sfcTaperUp, sfcTaperDown, invAreaCell
+      real(kind=RKIND)                 :: sumRi, RiTopOfEdge, zEdge
+      real(kind=RKIND) :: dcEdgeInv, invAreaCell
       real(kind=RKIND) :: lt1, lt2, c_min
       real(kind=RKIND) :: sigma, Lr, Length, L_rhines, shearEdgeInv
       real (kind=RKIND) :: eddyLength, eddyTime
-      real(kind=RKIND), dimension(:), allocatable :: dzTop, dTdzTop, dSdzTop, k33Norm
       real(kind=RKIND), dimension(:), allocatable :: RossbyRadiusTaper
       real(kind=RKIND) :: c_Visbeck   ! baroclinic wave speed from Visbeck parameterization
-      real(kind=RKIND) :: c_mode1, resolution, dc_Lr
+      real(kind=RKIND) :: c_mode1, dc_Lr
       ! Dimensions
-      integer :: nCells, nEdges
+      integer :: kmin, kmax, nCells, nEdges
       integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nCellsArray, nEdgesArray
 
       type(mpas_pool_type), pointer :: tracersPool
       real(kind=RKIND), dimension(:, :, :), pointer :: activeTracers
-      integer, pointer :: indexTemperaturePtr, indexSalinityPtr
-      integer :: indexTemperature, indexSalinity
       integer :: timeLevel
 
       if (present(timeLevelIn)) then
@@ -183,10 +159,6 @@ contains
       call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
       call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
       call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, timeLevel)
-      call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperaturePtr)
-      call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinityPtr)
-      indexTemperature = indexTemperaturePtr
-      indexSalinity    = indexSalinityPtr
 
       call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', minLevelEdgeBot)
       call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
@@ -219,192 +191,7 @@ contains
          end do
       end do
       !$omp end do
-
-      !$omp do schedule(runtime) private(k)
-      do iCell = 1, nCells + 1
-         do k = 1, nVertLevels
-            k33(k, iCell) = 0.0_RKIND
-         end do
-      end do
-      !$omp end do
-
-      !$omp do schedule(runtime)
-      do iCell = 1, nCells
-         RediKappaSfcTaper(:, iCell) = 1.0_RKIND
-      end do
-      !$omp end do
       !$omp end parallel
-
-      ! The following code computes scaling for Redi mixing terms and the slope triads
-      ! It is only needed when Redi mixing is enabled.
-      if ( config_use_Redi ) then
-
-         allocate(dzTop(nVertLevels + 1))
-         allocate(dTdzTop(nVertLevels + 1))
-         allocate(dSdzTop(nVertLevels + 1))
-         allocate(k33Norm(nVertLevels + 1))
-
-         if (config_Redi_use_surface_taper) then
-            !$omp parallel
-            !$omp do schedule (runtime) private(zMLD, k)
-            do iCell = 1, nCells
-               k = max(minLevelCell(iCell), indMLD(iCell))
-               zMLD = ssh(iCell) - zMid(k, iCell)
-
-               do k = minLevelCell(iCell), indMLD(iCell)
-                  RediKappaSfcTaper(k, iCell) = abs((ssh(iCell) - zMid(k, iCell))/(zMLD))
-               end do
-            end do
-            !$omp end do
-            !$omp end parallel
-         end if
-
-         nCells = nCellsArray(3)
-         !$omp parallel
-         !$omp do schedule(runtime)  &
-         !$omp private(invAreaCell, k33Norm, k, dzTop, dTdzTop, dSdzTop, i, iEdge, cell1, cell2, &
-         !$omp         iCellSelf, dcEdgeInv, areaEdge, drhoDT, drhoDS, dTdx, dSdx, drhoDx, &
-         !$omp         slopeTaperUp, slopeTaperDown, sfcTaperUp, sfcTaperDown, sfcTaper)
-         do iCell = 1, nCells
-            invAreaCell = 1.0_RKIND/areaCell(iCell)
-            k33(1:maxLevelCell(iCell) + 1, iCell) = 0.0_RKIND
-            k33Norm(1:maxLevelCell(iCell) + 1) = epsGM
-            ! prep dz, dTdz and dSdz for this column
-            do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
-               dzTop(k) = 0.5_RKIND*(layerThickness(k - 1, iCell) + layerThickness(k, iCell))
-               dTdzTop(k) = (activeTracers(indexTemperature, k - 1, iCell) &
-                             - activeTracers(indexTemperature, k, iCell)) &
-                            /dzTop(k)
-               dSdzTop(k) = (activeTracers(indexSalinity, k - 1, iCell) &
-                             - activeTracers(indexSalinity, k, iCell)) &
-                            /dzTop(k)
-            end do
-            dzTop(1:minLevelCell(iCell)) = -1e-15_RKIND
-            dTdzTop(1:minLevelCell(iCell)) = -1e-15_RKIND
-            dSdzTop(1:minLevelCell(iCell)) = -1e-15_RKIND
-            dzTop(maxLevelCell(iCell) + 1) = -1e-15_RKIND
-            dTdzTop(maxLevelCell(iCell) + 1) = -1e-15_RKIND
-            dSdzTop(maxLevelCell(iCell) + 1) = -1e-15_RKIND
-
-            do i = 1, nEdgesOnCell(iCell)
-               iEdge = edgesOnCell(i, iCell)
-               cell1 = cellsOnEdge(1, iEdge)
-               cell2 = cellsOnEdge(2, iEdge)
-               if (cell1 == iCell) then
-                  iCellSelf = 1
-               else  ! cell2 == iCell
-                  iCellSelf = 2
-               end if
-               dcEdgeInv = 1.0_RKIND/dcEdge(iEdge)
-               areaEdge = dcEdge(iEdge)*dvEdge(iEdge)
-
-               do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-                  drhoDT = -thermExpCoeff(k, iCell)
-                  drhoDS = salineContractCoeff(k, iCell)
-                  dTdx = (activeTracers(indexTemperature, k, cell2) &
-                          - activeTracers(indexTemperature, k, cell1)) &
-                         *dcEdgeInv
-                  dSdx = (activeTracers(indexSalinity, k, cell2) &
-                          - activeTracers(indexSalinity, k, cell1)) &
-                         *dcEdgeInv
-                  drhoDx = drhoDT*dTdx + drhoDS*dSdx
-
-
-                  sfcTaperUp = drhoDT*dTdzTop(k) + drhoDS*dSdzTop(k)
-                  sfcTaperDown = drhoDT*dTdzTop(k+1) + drhoDS*dSdzTop(k+1)
-
-                  ! Always compute *Up on the top cell and *Down on the bottom
-                  ! cell, even though they are never used. This avoids an if
-                  ! statement or separate computation for top and bottom.
-                  slopeTriadUp(k, iCellSelf, iEdge) = &
-                     safe_slope( -drhoDx, sfcTaperUp )
-                  slopeTriadDown(k, iCellSelf, iEdge) = &
-                      safe_slope( -drhoDx, sfcTaperDown )
-
-                  ! set taper of slope ('F' function from Danabasoglu and McWilliams 95)
-                  if (abs(slopeTriadDown(k, iCellSelf, iEdge)) > 0.6_RKIND*config_redi_maximum_slope) then
-                     slopeTaperDown = 0.0_RKIND
-                  else if (abs(slopeTriadDown(k, iCellSelf, iEdge)) < 0.2_RKIND*config_redi_maximum_slope) then
-                     slopeTaperDown = 1.0_RKIND
-                  else
-                     slopeTaperDown = 0.5_RKIND*(1.0_RKIND - ((2.5_RKIND*abs(slopeTriadDown(k, iCellSelf, iEdge)))/ &
-                                      config_Redi_maximum_slope - 1.0_RKIND)*(4.0_RKIND - abs(10.0_RKIND* &
-                                      abs(slopeTriadDown(k, iCellSelf, iEdge))/config_Redi_maximum_slope - 4.0_RKIND)))
-                  end if
-                  if (abs(slopeTriadUp(k, iCellSelf, iEdge)) > 0.6_RKIND*config_redi_maximum_slope) then
-                     slopeTaperUp = 0.0_RKIND
-                  else if (abs(slopeTriadUp(k, iCellSelf, iEdge)) < 0.2_RKIND*config_redi_maximum_slope) then
-                     slopeTaperUp = 1.0_RKIND
-                  else
-                     slopeTaperUp = 0.5_RKIND*(1.0_RKIND - ((2.5_RKIND*abs(slopeTriadUp(k, iCellSelf, iEdge)))/ &
-                                    config_Redi_maximum_slope - 1.0_RKIND)*(4.0_RKIND - abs(10.0_RKIND* &
-                                    abs(slopeTriadUp(k, iCellSelf, iEdge))/config_Redi_maximum_slope - 4.0_RKIND)))
-                  end if
-
-                  slopeTaperUp = 1.0_RKIND + slopeTaperFactor*(slopeTaperUp - 1.0_RKIND)
-                  slopeTaperDown = 1.0_RKIND + slopeTaperFactor*(slopeTaperDown - 1.0_RKIND)
-
-                  sfcTaper = min(RediKappaSfcTaper(k, cell1), RediKappaSfcTaper(k, cell2))
-                  if (k < min( indMLD(cell1), indMLD(cell2))) then
-                    sfcTaper = 0.0_RKIND
-                  else
-                    sfcTaper = 1.0_RKIND
-                  end if
-
-                  sfcTaperUp = 1.0_RKIND + sfcTaperFactor*(sfcTaper - 1.0_RKIND)
-                  sfcTaperDown = 1.0_RKIND + sfcTaperFactor*(sfcTaper - 1.0_RKIND)
-
-!                  ! Griffies 1998 eqn 34
-                  if (k > minLevelCell(iCell)) then
-                     k33(k, iCell) = k33(k, iCell) +  &
-                                     slopeTaperUp*sfcTaperUp*areaEdge*dzTop(k)*slopeTriadUp(k, iCellSelf, iEdge)**2
-                     k33Norm(k) = k33Norm(k) + areaEdge*dzTop(k)
-                  end if
-
-!                  !Taper Redi by tapering the slopes
-                  k33(k + 1, iCell) = k33(k + 1, iCell) +  &
-                                      slopeTaperDown*sfcTaperDown*areaEdge*dzTop(k + 1)*slopeTriadDown(k, iCellSelf, iEdge)**2
-                  k33Norm(k + 1) = k33Norm(k + 1) + areaEdge*dzTop(k + 1)
-
-                  limiterUp(k,iCellSelf,iEdge) = slopeTaperUp*sfcTaperUp
-                  limiterDown(k,iCellSelf,iEdge) = slopeTaperDown*sfcTaperDown
-
-                  slopeTriadUp(k, iCellSelf, iEdge) = &
-                     slopeTaperUp*sfcTaperUp*slopeTriadUp(k, iCellSelf, iEdge)
-                  slopeTriadDown(k, iCellSelf, iEdge) = &
-                     slopeTaperDown*sfcTaperDown*slopeTriadDown(k, iCellSelf, iEdge)
-
-               end do ! maxLevelEdgeTop(iEdge)
-            end do ! nEdgesOnCell(iCell)
-
-!            ! Normalize k33
-            do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
-               k33(k, iCell) = k33(k, iCell)/k33Norm(k)
-            end do
-            k33(1:minLevelCell(iCell), iCell) = 0.0_RKIND
-            k33(maxLevelCell(iCell) + 1, iCell) = 0.0_RKIND
-         end do ! iCell
-         !$omp end do
-         !$omp end parallel
-
-         deallocate (dzTop)
-         deallocate (dTdzTop)
-         deallocate (dSdzTop)
-         deallocate (k33Norm)
-
-      endif  !config_use_Redi
-
-      ! allow disabling of K33 for testing
-      if (config_disable_redi_k33) then
-         nCells = nCellsArray(size(nCellsArray))
-         !$omp parallel
-         !$omp do schedule(runtime)
-         do iCell = 1, nCells
-            k33(:, iCell) = 0.0_RKIND
-         end do
-         !$omp end do
-         !$omp end parallel
-      end if
 
       !--------------------------------------------------------------------
       !
@@ -412,12 +199,108 @@ contains
       !
       !--------------------------------------------------------------------
 
+      nEdges = nEdgesArray(3)
+      if (config_GM_horizontal_taper == 'RossbyRadius'.or. &
+         config_Redi_horizontal_taper == 'RossbyRadius') then
+         allocate (RossbyRadiusTaper(nEdges))
+         call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
+
+         !$omp parallel
+         !$omp do schedule(runtime) private(k, cell1, cell2, sum_hN, lt1, lt2, c_mode1, dc_Lr)
+         do iEdge = 1, nEdges
+            cell1 = cellsOnEdge(1, iEdge)
+            cell2 = cellsOnEdge(2, iEdge)
+            sum_hN = 0.0
+
+            bldEdge = 0.5_RKIND*(boundaryLayerDepth(cell1) + boundaryLayerDepth(cell2))
+            mldEdge = config_redi_transition_layer_mld_offset*bldEdge
+
+            thickSlope = 1.0_RKIND/max(1.0E-15, 1.0_RKIND - min(config_redi_transition_layer_mld_offset,1.0_RKIND))
+
+            do k=minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
+               scaleFactor = thickslope*(0.5_RKIND*abs(zMid(k,cell1)+zMid(k,cell2))/bldEdge - &
+                             config_redi_transition_layer_mld_offset)
+               scaleFactor = min(1.0_RKIND,max(0.0_RKIND,scaleFactor))
+               RediKappaSfcTaper(k,iEdge) = scaleFactor
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
+
+! old approach, potentially remove based on testing
+!         !$omp parallel
+!         !$omp do schedule(runtime)  &
+!         !$omp private(k, iEdge, cell1, cell2, kmin, kmax, n2check, mld1, mld2, mldEdge, &
+!         !$omp         bldEdge, sfcTaper, thickSlope, scaleFactor)
+!         do iEdge = 1, nEdges
+!            cell1 = cellsOnEdge(1, iEdge)
+!            cell2 = cellsOnEdge(2, iEdge)
+!
+!            if(dThreshMLD(cell1) < boundaryLayerDepth(cell1)) then
+!              mld1 = boundaryLayerDepth(cell1) + config_redi_transition_layer_mld_offset 
+!            else
+!              mld1 = dThreshMLD(cell1)
+!            end if
+!
+!            if(dThreshMLD(cell2) < boundaryLayerDepth(cell2)) then
+!              mld2 = boundaryLayerDepth(cell2) + config_redi_transition_layer_mld_offset
+!            else
+!              mld2 = dThreshMLD(cell2)
+!            end if
+
+!            mldEdge = 0.5_RKIND*(mld1+mld2)
+!            bldEdge = 0.5_RKIND*(boundaryLayerDepth(cell1) + boundaryLayerDepth(cell2))
+!
+!            ! if we need to turn off sfc taper we need to set rediKappaSfcTaper to 0 I think
+!            ! so just wrap this in a use sfc taper thing and it's good
+!            thickSlope = mldEdge - bldEdge
+!
+!            do k=minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
+!               scaleFactor = (0.5_RKIND*abs(zMid(k,cell1)+zMid(k,cell2)) - &
+!                            bldEdge)/thickSlope
+!               scaleFactor = max(0.0_RKIND,scaleFactor)
+!               scaleFactor = min(1.0_RKIND,scaleFactor)
+!
+!               RediKappaSfcTaper(k,iEdge) = scaleFactor
+!            end do
+!         end do 
+!         !$omp end do
+!         !$omp end parallel
+
+         nCells = nCellsArray(4)
+
+         if (config_GM_horizontal_taper == 'RossbyRadius') then
+            !$omp parallel
+            !$omp do schedule(runtime)
+            do iEdge = 1,nEdges
+               gmHorizontalTaper(iEdge) = RossbyRadiusTaper(iEdge)
+            end do
+         end do 
+         !$omp end do
+         !$omp end parallel
+
+         if (config_Redi_horizontal_taper == 'RossbyRadius') then
+            !$omp parallel
+            !$omp do schedule(runtime)
+            do iEdge = 1,nEdges
+               RediHorizontalTaper(iEdge) = RossbyRadiusTaper(iEdge)
+            end do
+            !$omp end do
+            !$omp end parallel
+         end if
+
+         deallocate (RossbyRadiusTaper)
+      end if
+
+      if (config_use_redi) then
+         call ocn_redi_compute_isopycnal_slopes(statePool,timeLevel)
+      end if
+
       if (config_use_GM) then
 
          nEdges = nEdgesArray(3)
-         ! For config_GM_closure = 'N2_dependent' use a scaling to taper gmBolusKappa
-         ! based on stratification relative to the maximum in the column
-         if (local_config_GM_kappa_lat_depth_variable) then
+         ! add back original N2 dependent 'N2_dependent_orig' for bluetip testing
+         if (local_config_GM_kappa_lat_depth_variable_orig) then
             !$omp parallel
             !$omp do schedule(runtime) private(k, BruntVaisalaFreqTopEdge, maxN, cell1, cell2)
             do iEdge=1,nEdges
@@ -435,6 +318,47 @@ contains
 
                do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
                   BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k,cell1) + &
+                                                       BruntVaisalaFreqTop(k,cell2))
+                  BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
+
+                  gmKappaScaling(k, iEdge) = min(max(config_GM_spatially_variable_min_kappa /         &
+                                                     config_GM_spatially_variable_max_kappa,          &
+                                                     BruntVaisalaFreqTopEdge/(maxN + 1.0E-10_RKIND)), &
+                                                     1.0_RKIND)
+               end do
+           enddo
+           !$omp end do
+           !$omp end parallel
+
+         end if
+
+         ! For config_GM_closure = 'N2_dependent' use a scaling to taper gmBolusKappa
+         ! based on stratification relative to the maximum in the column
+         if (local_config_GM_kappa_lat_depth_variable) then
+            !$omp parallel
+            !$omp do schedule(runtime) private(i, k, BruntVaisalaFreqTopEdge, maxN, cell1, cell2)
+            do iEdge=1,nEdges
+               k=minLevelEdgeBot(iEdge)
+               cell1 = cellsOnEdge(1,iEdge)
+               cell2 = cellsOnEdge(2,iEdge)
+               i = max(1,min(int(indexBoundaryLayerDepth(cell1)),int(indexBoundaryLayerDepth(cell2))))
+               BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTop(i,cell1), &
+                                                    BruntVaisalaFreqTop(i,cell2))
+               maxN = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
+               !Scan from the boundary layer depth only
+               do k = i+1, maxLevelEdgeTop(iEdge)
+                 !According to Danabasoglu and Marshall (2007) take max BVF
+                 BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTop(k,cell1), &
+                                                      BruntVaisalaFreqTop(k,cell2))
+                 maxN = max(maxN,max(BruntVaisalaFreqTopEdge, 0.0_RKIND))
+               enddo
+
+               do k = minLevelEdgeBot(iEdge), i
+                  gmKappaScaling(k,iEdge) = 1.0_RKIND
+               end do
+
+               do k = i+1, maxLevelEdgeTop(iEdge)
+                  BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTop(k,cell1), &
                                                        BruntVaisalaFreqTop(k,cell2))
                   BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
 
@@ -518,8 +442,7 @@ contains
               cell2 = cellsOnEdge(2, iEdge)
 
               k = minLevelEdgeBot(iEdge)+1
-              zEdge = -layerThickEdgeMean(k-1,iEdge)
-              do while(zEdge > -config_GM_Visbeck_max_depth .and. k < maxLevelEdgeTop(iEdge))
+              do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)-1
                 lt1 = 0.5_RKIND*(layerThickness(k,cell1) + layerThickness(k-1,cell1))
                 lt2 = 0.5_RKIND*(layerThickness(k,cell2) + layerThickness(k-1,cell2))
                 sum_hN = sum_hN + 0.5_RKIND*(lt1*max(BruntVaisalaFreqTop(k,cell1),0.0_RKIND) + &
@@ -528,13 +451,10 @@ contains
                                     lt2*max(RiTopOfCell(k,cell2),0.0_RKIND))
                 ltsum = ltsum + 0.5_RKIND*(lt1+lt2)
                 countN2 = countN2 + 1
-
-                k = k + 1
-                zEdge = zEdge - layerThickEdgeMean(k-1,iEdge)
               end do
 
               if (countN2 > 0) then
-                c_Visbeck = sqrt(sum_hN*ltsum)
+                c_Visbeck = cGMphaseSpeed(iEdge)
                 sumRi = sumRi / (ltsum + 1.0E-11_RKIND)
 
                 eddyLength = max(dcEdge(iEdge), min(c_Visbeck/(1.0E-15_RKIND + abs(fEdge(iEdge))), &
@@ -587,108 +507,6 @@ contains
            !$omp end do
            !$omp end parallel
          endif
-
-         nEdges = nEdgesArray(3)
-         if (config_GM_horizontal_taper == 'RossbyRadius'.or. &
-             config_Redi_horizontal_taper == 'RossbyRadius') then
-            allocate (RossbyRadiusTaper(nEdges))
-            call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
-
-            !$omp parallel
-            !$omp do schedule(runtime) private(k, cell1, cell2, sum_hN, lt1, lt2, c_mode1, resolution, dc_Lr)
-            do iEdge = 1, nEdges
-               cell1 = cellsOnEdge(1, iEdge)
-               cell2 = cellsOnEdge(2, iEdge)
-               sum_hN = 0.0
-
-               do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)-1
-
-                  lt1 = 0.5_RKIND*(layerThickness(k,cell1) + layerThickness(k-1,cell1))
-                  lt2 = 0.5_RKIND*(layerThickness(k,cell2) + layerThickness(k-1,cell2))
-                  sum_hN = sum_hN + 0.5_RKIND*(lt1*sqrt(max(BruntVaisalaFreqTop(k,cell1),0.0_RKIND)) + &
-                                  lt2*sqrt(max(BruntVaisalaFreqTop(k,cell2),0.0_RKIND)))
-               end do
-
-               ! See Chelton (1998)
-               ! https://journals.ametsoc.org/view/journals/phoc/28/3/1520-0485_1998_028_0433_gvotfb_2.0.co_2.xml
-               ! eqn 2.2a, also Appendix A,
-               ! for the first-mode (m=1) baroclinic gravity wave speed in m/s
-               ! c_m = 1/pi integral(N dz )
-
-               c_mode1 = max(1.0E-5_RKIND, sum_hN/pi)
-
-               ! See Hallberg (2013) https://doi.org/10.1016/j.ocemod.2013.08.007
-               ! just after eqn 4 the defines the deformation
-               ! radius as:
-               ! L = sqrt( c_g^2/ ( f^2 + 2*beta*c_g) )
-               !   = c_g * sqrt(1/( f^2 + 2*beta*c_g) )  (note c_g is guaranteed non-negative)
-               ! This comes from a combination of Chelton (1998) eqns 2.3a and
-               ! 2.3b, with a smooth transition in between.
-               RossbyRadius(iEdge) = c_mode1*sqrt( 1.0_RKIND / &
-                  (fEdge(iEdge)*fEdge(iEdge) + 2.0_RKIND*betaEdge(iEdge)*c_mode1 + 1.0E-15_RKIND))
-
-               dc_Lr = dcEdge(iEdge)/RossbyRadius(iEdge)
-
-               ! Ramp the parameterization between the given min and max values
-               ! of the ratio of the cell width to the Rossby radius
-               if (dc_Lr <= config_GMRedi_Rossby_ramp_min) then
-                  RossbyRadiusTaper(iEdge) = 0.0_RKIND
-               else if (dc_Lr >= config_GMRedi_Rossby_ramp_max) then
-                  RossbyRadiusTaper(iEdge) = 1.0_RKIND
-               else
-                  ! a linear ramp between the min and max of dc_Lr
-                  RossbyRadiusTaper(iEdge) = (dc_Lr - config_GMRedi_Rossby_ramp_min) / &
-                     (config_GMRedi_Rossby_ramp_max - config_GMRedi_Rossby_ramp_min)
-               end if
-            end do
-            !$omp end do
-            !$omp end parallel
-
-            if (config_GM_horizontal_taper == 'RossbyRadius') then
-               !$omp parallel
-               !$omp do schedule(runtime)
-               do iEdge = 1,nEdges
-                  gmHorizontalTaper(iEdge) = RossbyRadiusTaper(iEdge)
-               end do
-               !$omp end do
-               !$omp end parallel
-            end if
-
-            if (config_Redi_horizontal_taper == 'RossbyRadius') then
-               !$omp parallel
-               !$omp do schedule(runtime)
-               do iEdge = 1,nEdges
-                  RediHorizontalTaper(iEdge) = RossbyRadiusTaper(iEdge)
-               end do
-               !$omp end do
-               !$omp end parallel
-            end if
-
-            deallocate (RossbyRadiusTaper)
-         end if
-
-         if (config_Redi_closure == 'equalGM') then
-            ! Set Redi closure to be the same as the GM closure, i.e. if
-            ! config_GM_closure is EdenGreatbatch or Visbeck, you will see those
-            ! same closure fields in RediKappa. The horizontal tapering still
-            ! comes from the config_Redi_horizontal_taper flag, not GM.
-            !$omp parallel
-            !$omp do schedule(runtime)
-            do iEdge=1, nEdges
-               RediKappa(iEdge) = gmHorizontalTaper(iEdge) * gmBolusKappa(iEdge)
-            end do
-            !$omp end do
-            !$omp end parallel
-         else if (config_Redi_closure == 'constant'.and. &
-                   config_Redi_horizontal_taper == 'RossbyRadius') then
-            !$omp parallel
-            !$omp do schedule(runtime)
-            do iEdge=1, nEdges
-               RediKappa(iEdge) = RediHorizontalTaper(iEdge) * config_Redi_constant_kappa
-            end do
-            !$omp end do
-            !$omp end parallel
-         end if
 
          !!$omp parallel
          !!$omp do schedule(runtime) private(cell1, cell2, k, &
@@ -772,6 +590,10 @@ contains
       end if !end config_use_GM
 
       call mpas_timer_stop('gm bolus velocity')
+
+      if (config_use_redi) then
+         call ocn_redi_compute_isopycnal_slopes(statePool, timeLevel)
+      end if
 
    end subroutine ocn_GM_compute_Bolus_velocity!}}}
 
@@ -917,18 +739,6 @@ contains
          call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
          call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
 
-         if (config_Redi_use_slope_taper) then
-            slopeTaperFactor = 1.0_RKIND
-         else
-            slopeTaperFactor = 0.0_RKIND
-         end if
-
-         if (config_Redi_use_surface_taper) then
-            sfcTaperFactor = 1.0_RKIND
-         else
-            sfcTaperFactor = 0.0_RKIND
-         end if
-
          local_config_GM_constant_bclModeSpeed = config_GM_constant_bclModeSpeed
 
          if (config_GM_minBclModeSpeed_method=='constant') then
@@ -970,6 +780,22 @@ contains
          else if (config_GM_closure == 'N2_dependent') then
             local_config_GM_lat_variable_c2 = .true.
             local_config_GM_kappa_lat_depth_variable = .true.
+            local_config_GM_compute_Visbeck = .false.
+            local_config_GM_compute_EdenGreatbatch = .false.
+
+            RediGMinitValue = 0.0_RKIND
+            ! for N2 dependence, we still assign Kappa as a constant to be multiplied by N2 scaling.
+            !$omp parallel
+            !$omp do schedule(runtime)
+            do iEdge = 1, nEdges
+               gmBolusKappa(iEdge) = config_GM_spatially_variable_max_kappa
+            end do
+            !$omp end do
+            !$omp end parallel
+         else if (config_GM_closure == 'N2_dependent_orig') then
+            local_config_GM_lat_variable_c2 = .true.
+            local_config_GM_kappa_lat_depth_variable_orig = .true.
+            local_config_GM_kappa_lat_depth_variable = .false.
             local_config_GM_compute_Visbeck = .false.
             local_config_GM_compute_EdenGreatbatch = .false.
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_gm.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_gm.F
@@ -205,68 +205,6 @@ module ocn_gm
          allocate (RossbyRadiusTaper(nEdges))
          call mpas_pool_get_array(meshPool, 'fEdge', fEdge)
 
-         !$omp parallel
-         !$omp do schedule(runtime) private(k, cell1, cell2, sum_hN, lt1, lt2, c_mode1, dc_Lr)
-         do iEdge = 1, nEdges
-            cell1 = cellsOnEdge(1, iEdge)
-            cell2 = cellsOnEdge(2, iEdge)
-            sum_hN = 0.0
-
-            bldEdge = 0.5_RKIND*(boundaryLayerDepth(cell1) + boundaryLayerDepth(cell2))
-            mldEdge = config_redi_transition_layer_mld_offset*bldEdge
-
-            thickSlope = 1.0_RKIND/max(1.0E-15, 1.0_RKIND - min(config_redi_transition_layer_mld_offset,1.0_RKIND))
-
-            do k=minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
-               scaleFactor = thickslope*(0.5_RKIND*abs(zMid(k,cell1)+zMid(k,cell2))/bldEdge - &
-                             config_redi_transition_layer_mld_offset)
-               scaleFactor = min(1.0_RKIND,max(0.0_RKIND,scaleFactor))
-               RediKappaSfcTaper(k,iEdge) = scaleFactor
-            end do
-         end do
-         !$omp end do
-         !$omp end parallel
-
-! old approach, potentially remove based on testing
-!         !$omp parallel
-!         !$omp do schedule(runtime)  &
-!         !$omp private(k, iEdge, cell1, cell2, kmin, kmax, n2check, mld1, mld2, mldEdge, &
-!         !$omp         bldEdge, sfcTaper, thickSlope, scaleFactor)
-!         do iEdge = 1, nEdges
-!            cell1 = cellsOnEdge(1, iEdge)
-!            cell2 = cellsOnEdge(2, iEdge)
-!
-!            if(dThreshMLD(cell1) < boundaryLayerDepth(cell1)) then
-!              mld1 = boundaryLayerDepth(cell1) + config_redi_transition_layer_mld_offset 
-!            else
-!              mld1 = dThreshMLD(cell1)
-!            end if
-!
-!            if(dThreshMLD(cell2) < boundaryLayerDepth(cell2)) then
-!              mld2 = boundaryLayerDepth(cell2) + config_redi_transition_layer_mld_offset
-!            else
-!              mld2 = dThreshMLD(cell2)
-!            end if
-
-!            mldEdge = 0.5_RKIND*(mld1+mld2)
-!            bldEdge = 0.5_RKIND*(boundaryLayerDepth(cell1) + boundaryLayerDepth(cell2))
-!
-!            ! if we need to turn off sfc taper we need to set rediKappaSfcTaper to 0 I think
-!            ! so just wrap this in a use sfc taper thing and it's good
-!            thickSlope = mldEdge - bldEdge
-!
-!            do k=minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
-!               scaleFactor = (0.5_RKIND*abs(zMid(k,cell1)+zMid(k,cell2)) - &
-!                            bldEdge)/thickSlope
-!               scaleFactor = max(0.0_RKIND,scaleFactor)
-!               scaleFactor = min(1.0_RKIND,scaleFactor)
-!
-!               RediKappaSfcTaper(k,iEdge) = scaleFactor
-!            end do
-!         end do 
-!         !$omp end do
-!         !$omp end parallel
-
          nCells = nCellsArray(4)
 
          if (config_GM_horizontal_taper == 'RossbyRadius') then
@@ -275,9 +213,9 @@ module ocn_gm
             do iEdge = 1,nEdges
                gmHorizontalTaper(iEdge) = RossbyRadiusTaper(iEdge)
             end do
-         end do 
-         !$omp end do
-         !$omp end parallel
+            !$omp end do
+            !$omp end parallel
+         end if
 
          if (config_Redi_horizontal_taper == 'RossbyRadius') then
             !$omp parallel
@@ -297,40 +235,6 @@ module ocn_gm
       end if
 
       if (config_use_GM) then
-
-         nEdges = nEdgesArray(3)
-         ! add back original N2 dependent 'N2_dependent_orig' for bluetip testing
-         if (local_config_GM_kappa_lat_depth_variable_orig) then
-            !$omp parallel
-            !$omp do schedule(runtime) private(k, BruntVaisalaFreqTopEdge, maxN, cell1, cell2)
-            do iEdge=1,nEdges
-               k=minLevelEdgeBot(iEdge)
-               cell1 = cellsOnEdge(1,iEdge)
-               cell2 = cellsOnEdge(2,iEdge)
-               BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k,cell1) + &
-                                                    BruntVaisalaFreqTop(k,cell2))
-               maxN = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
-               do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
-                 BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k,cell1) + &
-                                                      BruntVaisalaFreqTop(k,cell2))
-                 maxN = max(maxN,max(BruntVaisalaFreqTopEdge, 0.0_RKIND))
-               enddo
-
-               do k = minLevelEdgeBot(iEdge)+1, maxLevelEdgeTop(iEdge)
-                  BruntVaisalaFreqTopEdge = 0.5_RKIND*(BruntVaisalaFreqTop(k,cell1) + &
-                                                       BruntVaisalaFreqTop(k,cell2))
-                  BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
-
-                  gmKappaScaling(k, iEdge) = min(max(config_GM_spatially_variable_min_kappa /         &
-                                                     config_GM_spatially_variable_max_kappa,          &
-                                                     BruntVaisalaFreqTopEdge/(maxN + 1.0E-10_RKIND)), &
-                                                     1.0_RKIND)
-               end do
-           enddo
-           !$omp end do
-           !$omp end parallel
-
-         end if
 
          ! For config_GM_closure = 'N2_dependent' use a scaling to taper gmBolusKappa
          ! based on stratification relative to the maximum in the column
@@ -780,22 +684,6 @@ module ocn_gm
          else if (config_GM_closure == 'N2_dependent') then
             local_config_GM_lat_variable_c2 = .true.
             local_config_GM_kappa_lat_depth_variable = .true.
-            local_config_GM_compute_Visbeck = .false.
-            local_config_GM_compute_EdenGreatbatch = .false.
-
-            RediGMinitValue = 0.0_RKIND
-            ! for N2 dependence, we still assign Kappa as a constant to be multiplied by N2 scaling.
-            !$omp parallel
-            !$omp do schedule(runtime)
-            do iEdge = 1, nEdges
-               gmBolusKappa(iEdge) = config_GM_spatially_variable_max_kappa
-            end do
-            !$omp end do
-            !$omp end parallel
-         else if (config_GM_closure == 'N2_dependent_orig') then
-            local_config_GM_lat_variable_c2 = .true.
-            local_config_GM_kappa_lat_depth_variable_orig = .true.
-            local_config_GM_kappa_lat_depth_variable = .false.
             local_config_GM_compute_Visbeck = .false.
             local_config_GM_compute_EdenGreatbatch = .false.
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_redi.F
@@ -225,7 +225,8 @@ module ocn_redi
      !$omp do schedule(runtime)  &
      !$omp private(k33Norm, k, i, iEdge, cell1, cell2, &
      !$omp         iCellSelf, dcEdgeInv, areaEdge, drhoDT, drhoDS, dTdx, dSdx, drhoDx, &
-     !$omp         slopeTaperUp, slopeTaperDown, tempSlopeUp, tempSlopeDown, sfcTaper)
+     !$omp         slopeTaperUp, slopeTaperDown, tempSlopeUp, tempSlopeDown, sfcTaperTemp, &
+     !$omp         sfcTaper)
      do iCell = 1, nCells
         k33(1:maxLevelCell(iCell) + 1, iCell) = 0.0_RKIND
         k33Norm(1:maxLevelCell(iCell) + 1) = epsGM

--- a/components/mpas-ocean/src/shared/mpas_ocn_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_redi.F
@@ -1,0 +1,440 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.io/license.html
+!
+module ocn_redi
+
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_timer
+   use mpas_constants
+   use mpas_threading
+
+   use ocn_mesh
+   use ocn_constants
+   use ocn_config
+   use ocn_diagnostics_variables
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: ocn_redi_compute_isopycnal_slopes, &
+             ocn_redi_init
+
+   real(kind=RKIND) :: slopeTaperFactor, sfcTaperFactor
+   real(kind=RKIND) :: cavityFix, oldLimiter
+
+!***********************************************************************
+!
+!  routine ocn_redi_compute_isopycnal_slopes
+!
+!> \brief   Computes slope triads for redi mixing
+!> \details
+!>  This routine is the main driver for the slope triad scheme from
+!
+!   Isoneutral diffusion in a z-coordinate model - by Griffies et al (1998)
+!   https://doi.org/10.1175/1520-0485(1998)028%3C0805:IDIAZC%3E2.0.CO;2
+!
+!   Important differences are
+!     1. a correction term is added to accomadate steeply sloping model surfaces
+!     2. a safe_slope function is added to limit slope when d rho/dz is small
+!-----------------------------------------------------------------------
+
+  contains
+
+     function safe_slope(num, den) result(slope)
+
+        real(kind=RKIND), intent(in) :: num, den
+        real(kind=RKIND) :: slope
+
+        ! compute isopycnal slopes safely wrt. finite precision
+        ! small slope assumption, so don't want |s| > 1
+
+        if (abs(den) > abs(num)) then
+           slope = num / den
+        else
+           slope = sign(1.0_RKIND, den * num)
+        end if
+
+     end function
+
+!***********************************************************************
+
+   subroutine ocn_redi_compute_isopycnal_slopes(statePool, &
+                                                timeLevelIn)
+
+     !-----------------------------------------------------------------
+     !
+     ! input/output variables
+     !
+     !-----------------------------------------------------------------
+
+     type(mpas_pool_type), intent(in) :: &
+        statePool ! pool containing state variables
+
+     integer, intent(in), optional :: &
+                     timeLevelIn          ! time level for state variables
+
+     !-----------------------------------------------------------------
+     !
+     ! local variables
+     !
+     !-----------------------------------------------------------------
+
+     type(mpas_pool_type), pointer :: tracersPool
+     real(kind=RKIND), dimension(:, :, :), pointer :: activeTracers
+     integer, pointer :: indexTemperaturePtr, indexSalinityPtr
+     integer :: indexTemperature, indexSalinity, i, iCellSelf
+     real(kind=RKIND), dimension(:,:), allocatable :: dzTop, dTdzTop, dSdzTop
+     real(kind=RKIND), dimension(:), allocatable :: k33Norm
+
+     real(kind=RKIND), dimension(:,:), pointer :: layerThickness
+     real(kind=RKIND), dimension(:), pointer :: ssh
+
+     real(kind=RKIND) :: bldedge, mldedge, thickslope, scalefactor
+     real(kind=RKIND) :: dcEdgeInv, areaEdge, drhoDT, drhoDS, dTdx
+     real(kind=RKIND) :: dSdx, drhoDx, tempSlopeUp, tempSlopeDown
+     real(kind=RKIND) :: slopeTaperUp, slopeTaperDown, sfcTaper
+     real(kind=RKIND) :: zMLD, BruntVaisalaFreqTopEdge, maxN, sfcTaperTemp
+     integer :: cell1, cell2, iCell, iEdge, k, timeLevel, nCells, nEdges
+
+     real(kind=RKIND), parameter :: epsGM = 1.0e-12_RKIND
+     if (present(timeLevelIn)) then
+        timeLevel = timeLevelIn
+     else
+        timeLevel = 1
+     end if
+
+     call mpas_timer_start('redi compute slopes')
+
+     call mpas_pool_get_array(statePool, 'layerThickness', layerThickness, timeLevel)
+     call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
+     call mpas_pool_get_array(statePool, 'ssh', ssh, timeLevel)
+     call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracers, timeLevel)
+     call mpas_pool_get_dimension(tracersPool, 'index_temperature', indexTemperaturePtr)
+     call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinityPtr)
+     indexTemperature = indexTemperaturePtr
+     indexSalinity    = indexSalinityPtr
+
+     !Initialize RediKappa to the constant coefficient value and modify if equalGM or N2_dependent
+     !$omp parallel
+     !$omp do schedule(runtime) private(k)
+     do iEdge = 1, nEdgesAll
+        do k = 1, nVertLevels
+           RediKappaSfcTaper(k,iEdge) = 1.0_RKIND
+           RediKappa(k,iEdge) = config_Redi_constant_kappa*RediHorizontalTaper(iEdge)
+        end do
+     end do
+     !$omp end do
+
+     !$omp do schedule(runtime) private(k)
+     do iCell = 1, nCellsAll + 1
+        do k = 1, nVertLevels + 1
+           k33(k, iCell) = 0.0_RKIND
+        end do
+     end do
+     !$omp end do
+     !$omp end parallel
+
+     allocate(dzTop(nVertLevels + 1,nCellsAll))
+     allocate(dTdzTop(nVertLevels + 1,nCellsAll))
+     allocate(dSdzTop(nVertLevels + 1,nCellsAll))
+     allocate(k33Norm(nVertLevels + 1))
+
+     nEdges = nEdgesAll
+     if ( config_Redi_use_surface_taper ) then
+         !$omp parallel
+         !$omp do schedule(runtime) &
+         !$omp private(k, cell1, cell2, mldEdge, bldEdge, thickSlope, scaleFactor)
+         do iEdge = 1, nEdges
+            cell1 = cellsOnEdge(1, iEdge)
+            cell2 = cellsOnEdge(2, iEdge)
+
+            bldEdge = 0.5_RKIND*(boundaryLayerDepth(cell1) + boundaryLayerDepth(cell2))
+            mldEdge = config_redi_transition_layer_mld_offset*bldEdge
+
+            thickSlope = 1.0_RKIND/max(1.0E-15, 1.0_RKIND - min(config_redi_transition_layer_mld_offset,1.0_RKIND))
+
+            do k=minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
+               scaleFactor = thickslope*(0.5_RKIND*abs(zMid(k,cell1)+zMid(k,cell2))/bldEdge - &
+                             config_redi_transition_layer_mld_offset)
+               scaleFactor = min(1.0_RKIND,max(0.0_RKIND,scaleFactor))
+               RediKappaSfcTaper(k,iEdge) = scaleFactor
+            end do
+         end do
+         !$omp end do
+         !$omp end parallel
+     end if
+
+     nCells = nCellsAll
+     !$omp parallel
+     !$omp do schedule(runtime)  &
+     !$omp private(k)
+     do iCell = 1, nCells
+        ! prep dz, dTdz and dSdz for this column
+        do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
+           dzTop(k,iCell) = 0.5_RKIND*(layerThickness(k - 1, iCell) + layerThickness(k, iCell))
+           dTdzTop(k,iCell) = (activeTracers(indexTemperature, k - 1, iCell) &
+                              - activeTracers(indexTemperature, k, iCell)) &
+                              /dzTop(k,iCell)
+           dSdzTop(k,iCell) = (activeTracers(indexSalinity, k - 1, iCell) &
+                              - activeTracers(indexSalinity, k, iCell)) &
+                              /dzTop(k,iCell)
+        end do
+        dzTop(1:minLevelCell(iCell),iCell) = -1e-15_RKIND
+        dTdzTop(1:minLevelCell(iCell),iCell) = -1e-15_RKIND
+        dSdzTop(1:minLevelCell(iCell),iCell) = -1e-15_RKIND
+        dzTop(maxLevelCell(iCell) + 1,iCell) = -1e-15_RKIND
+        dTdzTop(maxLevelCell(iCell) + 1,iCell) = -1e-15_RKIND
+        dSdzTop(maxLevelCell(iCell) + 1,iCell) = -1e-15_RKIND
+     end do
+     !$omp end do
+     !$omp end parallel
+
+     nCells = nCellsHalo(2)
+     !$omp parallel
+     !$omp do schedule(runtime)  &
+     !$omp private(k33Norm, k, i, iEdge, cell1, cell2, &
+     !$omp         iCellSelf, dcEdgeInv, areaEdge, drhoDT, drhoDS, dTdx, dSdx, drhoDx, &
+     !$omp         slopeTaperUp, slopeTaperDown, tempSlopeUp, tempSlopeDown, sfcTaper)
+     do iCell = 1, nCells
+        k33(1:maxLevelCell(iCell) + 1, iCell) = 0.0_RKIND
+        k33Norm(1:maxLevelCell(iCell) + 1) = epsGM
+
+        do i = 1, nEdgesOnCell(iCell)
+           iEdge = edgesOnCell(i, iCell)
+           cell1 = cellsOnEdge(1, iEdge)
+           cell2 = cellsOnEdge(2, iEdge)
+           if (cell1 == iCell) then
+              iCellSelf = 1
+           else  ! cell2 == iCell
+              iCellSelf = 2
+           end if
+           dcEdgeInv = 1.0_RKIND/dcEdge(iEdge)
+           areaEdge = dcEdge(iEdge)*dvEdge(iEdge)
+
+           do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+              drhoDT = -thermExpCoeff(k, iCell)
+              drhoDS = salineContractCoeff(k, iCell)
+              dTdx = (activeTracers(indexTemperature, k, cell2) &
+                     - activeTracers(indexTemperature, k, cell1)) &
+                     *dcEdgeInv + cavityFix*0.5_RKIND*(dTdzTop(k,cell2) + &
+                      dTdzTop(k,cell1))*(zMid(k,cell2) - zMid(k,cell1))* &
+                            dcEdgeInv
+              dSdx = (activeTracers(indexSalinity, k, cell2) &
+                      - activeTracers(indexSalinity, k, cell1)) &
+                       *dcEdgeInv + cavityFix*0.5_RKIND*(dSdzTop(k,cell1) + &
+                       dSdzTop(k,cell2))*(zMid(k,cell2) - zMid(k,cell1))* &
+                       dcEdgeInv
+              drhoDx = drhoDT*dTdx + drhoDS*dSdx
+
+              tempSlopeUp = drhoDT*dTdzTop(k,iCell) + drhoDS*dSdzTop(k,iCell)
+              tempSlopeDown = drhoDT*dTdzTop(k+1,iCell) + drhoDS*dSdzTop(k+1,iCell)
+
+              ! Always compute *Up on the top cell and *Down on the bottom
+              ! cell, even though they are never used. This avoids an if
+              ! statement or separate computation for top and bottom.
+              slopeTriadUp(k, iCellSelf, iEdge) = &
+                       safe_slope( -drhoDx, tempSlopeUp )
+              slopeTriadDown(k, iCellSelf, iEdge) = &
+                       safe_slope( -drhoDx, tempSlopeDown )
+
+              ! set taper of slope ('F' function from Danabasoglu and McWilliams 95)
+              if (abs(slopeTriadDown(k, iCellSelf, iEdge)) > 0.6_RKIND*config_redi_maximum_slope) then
+                 slopeTaperDown = 0.0_RKIND
+              else if (abs(slopeTriadDown(k, iCellSelf, iEdge)) < 0.2_RKIND*config_redi_maximum_slope) then
+                 slopeTaperDown = 1.0_RKIND
+              else
+                 slopeTaperDown = 0.5_RKIND*(1.0_RKIND - ((2.5_RKIND*abs(slopeTriadDown(k, iCellSelf, iEdge)))/ &
+                                  config_Redi_maximum_slope - 1.0_RKIND)*(4.0_RKIND - abs(10.0_RKIND* &
+                                  abs(slopeTriadDown(k, iCellSelf, iEdge))/config_Redi_maximum_slope - 4.0_RKIND)))
+              end if
+              if (abs(slopeTriadUp(k, iCellSelf, iEdge)) > 0.6_RKIND*config_redi_maximum_slope) then
+                 slopeTaperUp = 0.0_RKIND
+              else if (abs(slopeTriadUp(k, iCellSelf, iEdge)) < 0.2_RKIND*config_redi_maximum_slope) then
+                 slopeTaperUp = 1.0_RKIND
+              else
+                 slopeTaperUp = 0.5_RKIND*(1.0_RKIND - ((2.5_RKIND*abs(slopeTriadUp(k, iCellSelf, iEdge)))/ &
+                                  config_Redi_maximum_slope - 1.0_RKIND)*(4.0_RKIND - abs(10.0_RKIND* &
+                                  abs(slopeTriadUp(k, iCellSelf, iEdge))/config_Redi_maximum_slope - 4.0_RKIND)))
+              end if
+
+              slopeTaperUp = 1.0_RKIND + slopeTaperFactor*(slopeTaperUp - 1.0_RKIND)
+              slopeTaperDown = 1.0_RKIND + slopeTaperFactor*(slopeTaperDown - 1.0_RKIND)
+
+              if (config_Redi_use_new_sfc_taper) then
+                 sfcTaperTemp = RediKappaSfcTaper(k,iEdge)
+              else
+                 if (k < min( indMLD(cell1), indMLD(cell2))) then
+                    sfcTaperTemp = 0.0_RKIND
+                 else
+                    sfcTaperTemp = 1.0_RKIND
+                 end if
+              end if
+
+              sfcTaper = 1.0_RKIND + sfcTaperFactor*(sfcTaperTemp - 1.0_RKIND)
+
+              !For Redi term 1 no limiting in the boundary layer and slope limiting below
+              !in the boundary layer the first term is zero, so 1.0 is added to allow term 1 to stay active
+              !the second term is 1 in the boundary layer and 0 below the boundary layer
+              limiterUp(k,iCellSelf,iEdge) = slopeTaperUp*(1.0_RKIND - oldlimiter) + &
+                                             oldlimiter*slopeTaperUp*sfcTaper
+              limiterDown(k,iCellSelf,iEdge) = slopeTaperDown*(1.0_RKIND - oldlimiter) + &
+                                               oldlimiter*slopeTaperDown*sfcTaper
+
+              !removing sfcTaperUp/Down as they are identical
+              if (k > minLevelCell(iCell)) then
+                 k33(k, iCell) = k33(k, iCell) +  &
+                                 slopeTaperUp*sfcTaper*areaEdge*dzTop(k,iCell)*slopeTriadUp(k, iCellSelf, iEdge)**2
+                 k33Norm(k) = k33Norm(k) + areaEdge*dzTop(k,iCell)
+              end if
+
+              !Taper Redi by tapering the slopes
+              k33(k + 1, iCell) = k33(k + 1, iCell) +  &
+                                  slopeTaperDown*sfcTaper*areaEdge*dzTop(k + 1,iCell)*slopeTriadDown(k, iCellSelf, iEdge)**2
+              k33Norm(k + 1) = k33Norm(k + 1) + areaEdge*dzTop(k + 1,iCell)
+
+              slopeTriadUp(k, iCellSelf, iEdge) = &
+                       slopeTaperUp*sfcTaper*slopeTriadUp(k, iCellSelf, iEdge)
+              slopeTriadDown(k, iCellSelf, iEdge) = &
+                       slopeTaperDown*sfcTaper*slopeTriadDown(k, iCellSelf, iEdge)
+
+           end do ! maxLevelEdgeTop(iEdge)
+        end do ! nEdgesOnCell(iCell)
+
+        ! Normalize k33
+        do k = minLevelCell(iCell)+1, maxLevelCell(iCell)
+           k33(k, iCell) = k33(k, iCell)/k33Norm(k)
+        end do
+        k33(1:minLevelCell(iCell), iCell) = 0.0_RKIND
+        k33(maxLevelCell(iCell) + 1, iCell) = 0.0_RKIND
+     end do ! iCell
+     !$omp end do
+     !$omp end parallel
+
+     deallocate (dzTop)
+     deallocate (dTdzTop)
+     deallocate (dSdzTop)
+     deallocate (k33Norm)
+
+     ! allow disabling of K33 for testing
+     if (config_disable_redi_k33) then
+        nCells = nCellsAll
+        !$omp parallel
+        !$omp do schedule(runtime)
+        do iCell = 1, nCells
+           k33(:, iCell) = 0.0_RKIND
+        end do
+        !$omp end do
+        !$omp end parallel
+     end if
+
+     ! add a N2 dependent redi here
+
+     if (config_Redi_closure == 'N2_dependent') then
+        !$omp parallel
+        !$omp do schedule(runtime) private(i, k, BruntVaisalaFreqTopEdge, maxN, cell1, cell2)
+        do iEdge=1,nEdges
+           k=minLevelEdgeBot(iEdge)
+           cell1 = cellsOnEdge(1,iEdge)
+           cell2 = cellsOnEdge(2,iEdge)
+           i = max(1,min(int(indexBoundaryLayerDepth(cell1)),int(indexBoundaryLayerDepth(cell2))))
+           BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTop(i,cell1), &
+                                         BruntVaisalaFreqTop(i,cell2))
+           maxN = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
+           !Scan from the boundary layer depth only
+           do k = i+1, maxLevelEdgeTop(iEdge)
+              !According to Danabasoglu and Marshall (2007) take max BVF
+              BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTop(k,cell1), &
+                                            BruntVaisalaFreqTop(k,cell2))
+              maxN = max(maxN,max(BruntVaisalaFreqTopEdge, 0.0_RKIND))
+           enddo
+
+           do k = i+1, maxLevelEdgeTop(iEdge)
+              BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTop(k,cell1), &
+                                            BruntVaisalaFreqTop(k,cell2))
+              BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
+
+              !Unlike for GM, here we force RediKappa min to be 0.1*config_Redi_constant_kappa
+              RediKappa(k, iEdge) = min(max(0.1_RKIND,         &
+                                        BruntVaisalaFreqTopEdge/(maxN + 1.0E-10_RKIND)), &
+                                                   1.0_RKIND)*config_Redi_constant_kappa
+           end do
+       enddo
+       !$omp end do
+       !$omp end parallel
+     end if
+
+     if (config_Redi_closure == 'equalGM') then
+        ! Set Redi closure to be the same as the GM closure, i.e. if
+        ! config_GM_closure is EdenGreatbatch or Visbeck, you will see those
+        ! same closure fields in RediKappa. The horizontal tapering still
+        ! comes from the config_Redi_horizontal_taper flag, not GM.
+        !$omp parallel
+        !$omp do schedule(runtime) private(k)
+        do iEdge=1, nEdges
+           do k = minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
+              RediKappa(k,iEdge) = RediHorizontalTaper(iEdge) * gmBolusKappa(iEdge)
+           end do
+        end do
+        !$omp end do
+        !$omp end parallel
+     else if (config_Redi_closure == 'constant' .or. &
+              config_Redi_closure == 'N2_dependent' .and. &
+              config_Redi_horizontal_taper == 'RossbyRadius') then
+        !$omp parallel
+        !$omp do schedule(runtime) private(k)
+        do iEdge=1, nEdges
+           do k = minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
+              RediKappa(k,iEdge) = RediHorizontalTaper(iEdge) * RediKappa(k,iEdge)
+           end do
+        end do
+        !$omp end do
+        !$omp end parallel
+     end if
+
+     call mpas_timer_start('redi compute slopes')
+
+   end subroutine ocn_redi_compute_isopycnal_slopes
+
+   subroutine ocn_redi_init(ierr)
+
+     integer, intent(in) :: ierr
+
+     oldlimiter = 1.0_RKIND
+     if (config_Redi_use_new_sfc_taper) oldlimiter = 0.0_RKIND
+
+     cavityFix = 0.0_RKIND
+     if (config_Redi_use_cavity_fix) cavityFix = 1.0_RKIND
+
+     if (config_Redi_use_slope_taper) then
+        slopeTaperFactor = 1.0_RKIND
+     else
+        slopeTaperFactor = 0.0_RKIND
+     end if
+
+     if (config_Redi_use_surface_taper) then
+        sfcTaperFactor = 1.0_RKIND
+     else
+        sfcTaperFactor = 0.0_RKIND
+     end if
+
+   end subroutine ocn_redi_init
+
+end module ocn_redi

--- a/components/mpas-ocean/src/shared/mpas_ocn_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_redi.F
@@ -294,7 +294,7 @@ module ocn_redi
               !in the boundary layer the first term is zero, so 1.0 is added to allow term 1 to stay active
               !the second term is 1 in the boundary layer and 0 below the boundary layer
               limiterUp(k,iCellSelf,iEdge) = (1.0_RKIND - oldlimiter)*(1.0_RKIND + &
-                                             sfcTaper*(slopeTaperUp - 1.0_RKIND)) + 
+                                             sfcTaper*(slopeTaperUp - 1.0_RKIND)) + & 
                                              oldlimiter*slopeTaperUp*sfcTaper
               limiterDown(k,iCellSelf,iEdge) = (1.0_RKIND - oldlimiter)*(1.0_RKIND + &
                                                sfcTaper*(slopeTaperDown - 1.0_RKIND)) + &

--- a/components/mpas-ocean/src/shared/mpas_ocn_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_redi.F
@@ -141,6 +141,7 @@ module ocn_redi
         end do
      end do
      !$omp end do
+     !$omp end parallel
 
      if ( config_redi_use_new_sfc_taper ) then
         !$omp parallel
@@ -151,6 +152,7 @@ module ocn_redi
            end do
         end do
         !$omp end do
+        !$omp end parallel
      end if
 
      !$omp do schedule(runtime) private(k)

--- a/components/mpas-ocean/src/shared/mpas_ocn_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_redi.F
@@ -138,10 +138,20 @@ module ocn_redi
      do iEdge = 1, nEdgesAll
         do k = 1, nVertLevels
            RediKappaSfcTaper(k,iEdge) = 1.0_RKIND
-           RediKappa(k,iEdge) = config_Redi_constant_kappa*RediHorizontalTaper(iEdge)
         end do
      end do
      !$omp end do
+
+     if ( config_redi_use_new_sfc_taper ) then
+        !$omp parallel
+        !$omp do schedule(runtime) private(k)
+        do iEdge = 1, nEdgesAll
+           do k = 1, nVertLevels
+              RediKappa(k,iEdge) = config_Redi_constant_kappa*RediHorizontalTaper(iEdge)
+           end do
+        end do
+        !$omp end do
+     end if
 
      !$omp do schedule(runtime) private(k)
      do iCell = 1, nCellsAll + 1
@@ -397,10 +407,12 @@ module ocn_redi
         end do
         !$omp end do
         !$omp end parallel
-     else if (config_Redi_closure == 'constant' .or. &
-              config_Redi_closure == 'N2_dependent' .and. &
-              config_Redi_horizontal_taper == 'RossbyRadius' .or. &
-              config_Redi_horizontal_taper == 'ramp') then
+     else if ( config_Redi_closure == 'constant'     .and. config_Redi_horizontal_taper == 'RossbyRadius' &
+               .or. &
+               config_Redi_closure == 'N2_dependent' .and. config_Redi_horizontal_taper == 'RossbyRadius' &
+               .or. &
+               config_Redi_closure == 'N2_dependent' .and. config_Redi_horizontal_taper == 'ramp' &
+             ) then
         !$omp parallel
         !$omp do schedule(runtime) private(k)
         do iEdge=1, nEdges

--- a/components/mpas-ocean/src/shared/mpas_ocn_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_redi.F
@@ -155,6 +155,7 @@ module ocn_redi
         !$omp end parallel
      end if
 
+     !$omp parallel
      !$omp do schedule(runtime) private(k)
      do iCell = 1, nCellsAll + 1
         do k = 1, nVertLevels + 1

--- a/components/mpas-ocean/src/shared/mpas_ocn_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_redi.F
@@ -293,8 +293,8 @@ module ocn_redi
               !For Redi term 1 no limiting in the boundary layer and slope limiting below
               !in the boundary layer the first term is zero, so 1.0 is added to allow term 1 to stay active
               !the second term is 1 in the boundary layer and 0 below the boundary layer
-              limiterUp(k,iCellSelf,iEdge) = (1.0_RKIND - oldlimiter)*(1.0_RKIND + &
-                                             sfcTaper*(slopeTaperUp - 1.0_RKIND)) + 
+              limiterUp(k,iCellSelf,iEdge) = (1.0_RKIND - oldlimiter)*(1.0_RKIND +  &
+                                             sfcTaper*(slopeTaperUp - 1.0_RKIND)) + &
                                              oldlimiter*slopeTaperUp*sfcTaper
               limiterDown(k,iCellSelf,iEdge) = (1.0_RKIND - oldlimiter)*(1.0_RKIND + &
                                                sfcTaper*(slopeTaperDown - 1.0_RKIND)) + &
@@ -356,9 +356,9 @@ module ocn_redi
            k=minLevelEdgeBot(iEdge)
            cell1 = cellsOnEdge(1,iEdge)
            cell2 = cellsOnEdge(2,iEdge)
-           i = max(1,min(int(indexBoundaryLayerDepth(cell1)),int(indexBoundaryLayerDepth(cell2))))
+           i = max(k,min(int(indexBoundaryLayerDepth(cell1)),int(indexBoundaryLayerDepth(cell2))))
            BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTop(i,cell1), &
-                                         BruntVaisalaFreqTop(i,cell2))
+                       BruntVaisalaFreqTop(i,cell2))
            maxN = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
            !Scan from the boundary layer depth only
            do k = i+1, maxLevelEdgeTop(iEdge)

--- a/components/mpas-ocean/src/shared/mpas_ocn_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_redi.F
@@ -167,13 +167,13 @@ module ocn_redi
             cell2 = cellsOnEdge(2, iEdge)
 
             bldEdge = 0.5_RKIND*(boundaryLayerDepth(cell1) + boundaryLayerDepth(cell2))
-            mldEdge = config_redi_transition_layer_mld_offset*bldEdge
+            mldEdge = config_redi_transition_layer_bld_fraction*bldEdge
 
-            thickSlope = 1.0_RKIND/max(1.0E-15, 1.0_RKIND - min(config_redi_transition_layer_mld_offset,1.0_RKIND))
+            thickSlope = 1.0_RKIND/max(1.0E-15, 1.0_RKIND - min(config_redi_transition_layer_bld_fraction,1.0_RKIND))
 
             do k=minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
                scaleFactor = thickslope*(0.5_RKIND*abs(zMid(k,cell1)+zMid(k,cell2))/bldEdge - &
-                             config_redi_transition_layer_mld_offset)
+                             config_redi_transition_layer_bld_fraction)
                scaleFactor = min(1.0_RKIND,max(0.0_RKIND,scaleFactor))
                RediKappaSfcTaper(k,iEdge) = scaleFactor
             end do
@@ -294,7 +294,7 @@ module ocn_redi
               !in the boundary layer the first term is zero, so 1.0 is added to allow term 1 to stay active
               !the second term is 1 in the boundary layer and 0 below the boundary layer
               limiterUp(k,iCellSelf,iEdge) = (1.0_RKIND - oldlimiter)*(1.0_RKIND + &
-                                             sfcTaper*(slopeTaperUp - 1.0_RKIND)) + & 
+                                             sfcTaper*(slopeTaperUp - 1.0_RKIND)) + 
                                              oldlimiter*slopeTaperUp*sfcTaper
               limiterDown(k,iCellSelf,iEdge) = (1.0_RKIND - oldlimiter)*(1.0_RKIND + &
                                                sfcTaper*(slopeTaperDown - 1.0_RKIND)) + &
@@ -373,8 +373,8 @@ module ocn_redi
                                             BruntVaisalaFreqTop(k,cell2))
               BruntVaisalaFreqTopEdge = max(BruntVaisalaFreqTopEdge, 0.0_RKIND)
 
-              !Unlike for GM, here we force RediKappa min to be 0.1*config_Redi_constant_kappa
-              RediKappa(k, iEdge) = min(max(0.1_RKIND,         &
+              RediKappa(k, iEdge) = min(max(config_redi_spatially_variable_min_kappa /   &
+                                        config_redi_spatially_variable_max_kappa,        &
                                         BruntVaisalaFreqTopEdge/(maxN + 1.0E-10_RKIND)), &
                                                    1.0_RKIND)*config_Redi_constant_kappa
            end do
@@ -399,7 +399,8 @@ module ocn_redi
         !$omp end parallel
      else if (config_Redi_closure == 'constant' .or. &
               config_Redi_closure == 'N2_dependent' .and. &
-              config_Redi_horizontal_taper == 'RossbyRadius') then
+              config_Redi_horizontal_taper == 'RossbyRadius' .or. &
+              config_Redi_horizontal_taper == 'ramp') then
         !$omp parallel
         !$omp do schedule(runtime) private(k)
         do iEdge=1, nEdges
@@ -411,7 +412,7 @@ module ocn_redi
         !$omp end parallel
      end if
 
-     call mpas_timer_start('redi compute slopes')
+     call mpas_timer_stop('redi compute slopes')
 
    end subroutine ocn_redi_compute_isopycnal_slopes
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_redi.F
@@ -293,9 +293,11 @@ module ocn_redi
               !For Redi term 1 no limiting in the boundary layer and slope limiting below
               !in the boundary layer the first term is zero, so 1.0 is added to allow term 1 to stay active
               !the second term is 1 in the boundary layer and 0 below the boundary layer
-              limiterUp(k,iCellSelf,iEdge) = slopeTaperUp*(1.0_RKIND - oldlimiter) + &
+              limiterUp(k,iCellSelf,iEdge) = (1.0_RKIND - oldlimiter)*(1.0_RKIND + &
+                                             sfcTaper*(slopeTaperUp - 1.0_RKIND)) + 
                                              oldlimiter*slopeTaperUp*sfcTaper
-              limiterDown(k,iCellSelf,iEdge) = slopeTaperDown*(1.0_RKIND - oldlimiter) + &
+              limiterDown(k,iCellSelf,iEdge) = (1.0_RKIND - oldlimiter)*(1.0_RKIND + &
+                                               sfcTaper*(slopeTaperDown - 1.0_RKIND)) + &
                                                oldlimiter*slopeTaperDown*sfcTaper
 
               !removing sfcTaperUp/Down as they are identical

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix.F
@@ -91,7 +91,7 @@ contains
       !-----------------------------------------------------------------
       type (mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
 
-      real (kind=RKIND), dimension(:), intent(in), optional :: &
+      real (kind=RKIND), dimension(:,:), intent(in), optional :: &
          RediKappa
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -233,7 +233,7 @@ contains
       !$omp do schedule(runtime) &
       !$omp private(fluxRediZTop, invAreaCell, i, iEdge, cell1, cell2, iCellSelf, r_tmp, coef, k, &
       !$omp         kappaRediEdgeVal, iTr, tracer_turb_flux, flux, flux_term2, flux_term3, &
-      !$omp         dTracerDx, use_Redi_diag_terms, jCell, kUp, kDn)
+      !$omp         dTracerDx, use_Redi_diag_terms, jCell, kUp, kDn, rediKappaAv)
       do iCell = 1, nCells
          if (maxLevelCell(iCell) .ge. config_Redi_min_layers_diag_terms) then
             use_Redi_diag_terms = .true.

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -215,7 +215,7 @@ contains
                                                              * dvEdge(iEdge) * dcEdge(iEdge)
           enddo
         enddo
-        do k = 1,nVertLevels
+        do k = 1,nVertLevels+1
            rediKappaCell(k,iCell) = rediKappaCell(k,iCell) / areaCell(iCell)
         enddo
       enddo
@@ -685,7 +685,7 @@ contains
             !$omp parallel
             !$omp do schedule(runtime) private(k) 
             do iEdge=1,nEdges
-               do k=1,nVertLevels
+               do k=1,nVertLevels+1
                   if (dcEdge(iEdge) <= config_Redi_horizontal_ramp_min) then
                      RediKappa(k,iEdge) = 0.0_RKIND
                      RediHorizontalTaper(iEdge) = 0.0_RKIND

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_hmix_redi.F
@@ -56,7 +56,7 @@ module ocn_tracer_hmix_Redi
    real(kind=RKIND) :: term1TaperFactor
    real(kind=RKIND) :: limiter_safety_factor
    logical :: use_quasi_monotone
-   real(kind=RKIND), dimension(:), allocatable :: rediKappaCell
+   real(kind=RKIND), dimension(:, :), allocatable :: rediKappaCell
    real(kind=RKIND), dimension(:, :, :), allocatable :: redi_term2_edge, redi_term3_topOfCell
    real(kind=RKIND), dimension(:, :, :), allocatable :: redi_term1, redi_term2, redi_term3
    real(kind=RKIND), dimension(:, :, :), allocatable :: redi_flux_scale
@@ -89,7 +89,7 @@ contains
 
       type(mpas_pool_type), intent(in) :: meshPool !< Input: Mesh information
 
-      real(kind=RKIND), dimension(:), intent(in) :: &
+      real(kind=RKIND), dimension(:,:), intent(in) :: &
          RediKappa
 
       real(kind=RKIND), dimension(:, :), intent(in) :: &
@@ -140,7 +140,7 @@ contains
                                         nEdgesOnCell, minLevelCell, maxLevelCell
       integer, dimension(:, :), pointer :: cellsOnEdge, edgesOnCell, edgeSignOnCell, cellsOnCell
 
-      real(kind=RKIND) :: tempTracer, invAreaCell
+      real(kind=RKIND) :: rediKappaAv, tempTracer, invAreaCell
       real(kind=RKIND) :: flux, flux_term2, flux_term3, dTracerDx, coef
       real(kind=RKIND) :: r_tmp, tracer_turb_flux, kappaRediEdgeVal
       real(kind=RKIND) :: over, diff, scal, scalUp, scalDn
@@ -175,7 +175,7 @@ contains
 
       allocate (minimumVal(nTracers))
       allocate (fluxRediZTop(nTracers, nVertLevels + 1))
-      allocate (rediKappaCell(nCells))
+      allocate (rediKappaCell(nVertLevels+1,nCells))
       allocate (redi_term1(nTracers, nVertLevels, nCells))
       allocate (redi_term2(nTracers, nVertLevels, nCells))
       allocate (redi_term3(nTracers, nVertLevels, nCells))
@@ -205,14 +205,19 @@ contains
 
       nCells = nCellsArray(2)
       !$omp parallel
-      !$omp do schedule(runtime) private(i, iEdge)
+      !$omp do schedule(runtime) private(i, k, iEdge)
       do iCell = 1,nCells
-        rediKappaCell(iCell) = 0.0_RKIND
+        rediKappaCell(:, iCell) = 0.0_RKIND
         do i = 1, nEdgesOnCell(iCell)
           iEdge = edgesOnCell(i, iCell)
-          rediKappaCell(iCell) = rediKappaCell(iCell) + 0.25_RKIND*RediKappa(iEdge) * dvEdge(iEdge) * dcEdge(iEdge)
+          do k = 1, nVertLevels+1 
+             rediKappaCell(k,iCell) = rediKappaCell(k,iCell) + 0.25_RKIND*RediKappa(k,iEdge) &
+                                                             * dvEdge(iEdge) * dcEdge(iEdge)
+          enddo
         enddo
-        rediKappaCell(iCell) = rediKappaCell(iCell) / areaCell(iCell)
+        do k = 1,nVertLevels
+           rediKappaCell(k,iCell) = rediKappaCell(k,iCell) / areaCell(iCell)
+        enddo
       enddo
       !$omp end do
       !$omp end parallel
@@ -258,7 +263,6 @@ contains
          redi_term2(:, :, iCell) = 0.0_RKIND
          redi_term3(:, :, iCell) = 0.0_RKIND
          fluxRediZTop(:, :) = 0.0_RKIND
-        !rediKappaCell(iCell) = 0.0_RKIND
          invAreaCell = 1.0_RKIND/areaCell(iCell)
          do i = 1, nEdgesOnCell(iCell)
             ! Check if neighboring cell exists
@@ -303,26 +307,27 @@ contains
             do iTr = 1, nTracers
                ! term 1: div( h grad psi )
                tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)
-               flux = layerThickEdgeMean(k, iEdge)*tracer_turb_flux*r_tmp*RediKappa(iEdge)
+               rediKappaAv = 0.5_RKIND*(RediKappa(k,iEdge)+RediKappa(k+1,iEdge)) 
+               flux = layerThickEdgeMean(k, iEdge)*tracer_turb_flux*r_tmp*rediKappaAv
                redi_term1(iTr, k, iCell) = redi_term1(iTr, k, iCell) - (1.0_RKIND + term1TaperFactor* &
                                            (kappaRediEdgeVal - 1.0_RKIND))*edgeSignOnCell(i, iCell)*flux*invAreaCell
 
                if (.not.use_Redi_diag_terms) cycle
 
                ! term 2: div( h S d/dz psi )
-               flux_term2 = coef*RediKappa(iEdge)*layerThickEdgeMean(k, iEdge)* &
+               flux_term2 = coef*rediKappaAv*layerThickEdgeMean(k, iEdge)* &
                             0.25_RKIND* &
                             (slopeTriadDown(k, 1, iEdge)*(tracers(iTr, k, cell1) - tracers(iTr, k + 1, cell1)) &
                              /(zMid(k, cell1) - zMid(k + 1, cell1)) &
                              + slopeTriadDown(k, 2, iEdge)*(tracers(iTr, k, cell2) - tracers(iTr, k + 1, cell2)) &
                              /(zMid(k, cell2) - zMid(k + 1, cell2)))
                if (minLevelCell(cell1) < minLevelEdgeBot(iEdge)) then
-                  flux_term2 = flux_term2 + coef*RediKappa(iEdge)* &
+                  flux_term2 = flux_term2 + coef*rediKappaAv* &
                                layerThickEdgeMean(k, iEdge)*0.25_RKIND*slopeTriadUp(k, 1, iEdge)* &
                                (tracers(iTr, k - 1, cell1) - tracers(iTr, k, cell1))/(zMid(k - 1, cell1) - zMid(k, cell1))
                endif
                if (minLevelCell(cell2) < minLevelEdgeBot(iEdge)) then
-                  flux_term2 = flux_term2 + coef*RediKappa(iEdge)* &
+                  flux_term2 = flux_term2 + coef*rediKappaAv* &
                                layerThickEdgeMean(k, iEdge)*0.25_RKIND*slopeTriadUp(k, 2, iEdge)* &
                                (tracers(iTr, k - 1, cell2) - tracers(iTr, k, cell2))/(zMid(k - 1, cell2) - zMid(k, cell2))
                endif
@@ -341,14 +346,15 @@ contains
                do iTr = 1, nTracers
                   ! term 1: div( h grad psi )
                   tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)
-                  flux = layerThickEdgeMean(k, iEdge)*tracer_turb_flux*r_tmp*RediKappa(iEdge)
+                  rediKappaAv = 0.5_RKIND*(RediKappa(k,iEdge)+RediKappa(k+1,iEdge))
+                  flux = layerThickEdgeMean(k, iEdge)*tracer_turb_flux*r_tmp*rediKappaAv
                   redi_term1(iTr, k, iCell) = redi_term1(iTr, k, iCell) - (1.0_RKIND + term1TaperFactor* &
                                               (kappaRediEdgeVal - 1.0_RKIND))*edgeSignOnCell(i, iCell)*flux*invAreaCell
 
                   if (.not.use_Redi_diag_terms) cycle
 
                   ! term 2: div( h S d/dz psi )
-                  flux_term2 = coef*RediKappa(iEdge)*layerThickEdgeMean(k, iEdge)* &
+                  flux_term2 = coef*rediKappaAv*layerThickEdgeMean(k, iEdge)* &
                                0.25_RKIND* &
                                (slopeTriadUp(k, 1, iEdge)*(tracers(iTr, k - 1, cell1) - tracers(iTr, k, cell1)) &
                                 /(zMid(k - 1, cell1) - zMid(k, cell1)) &
@@ -377,7 +383,8 @@ contains
             do iTr = 1, nTracers
                ! term 1: div( h grad psi )
                tracer_turb_flux = tracers(iTr, k, cell2) - tracers(iTr, k, cell1)
-               flux = layerThickEdgeMean(k, iEdge)*tracer_turb_flux*r_tmp*RediKappa(iEdge)
+               rediKappaAv = 0.5_RKIND*(RediKappa(k,iEdge)+RediKappa(k+1,iEdge))
+               flux = layerThickEdgeMean(k, iEdge)*tracer_turb_flux*r_tmp*rediKappaAv
                redi_term1(iTr, k, iCell) = redi_term1(iTr, k, iCell) - (1.0_RKIND + term1TaperFactor* &
                                            (kappaRediEdgeVal - 1.0_RKIND))*edgeSignOnCell(i, iCell)*flux*invAreaCell
 
@@ -385,7 +392,7 @@ contains
 
                ! term 2: div( h S d/dz psi )
                ! For bottom layer, only use triads pointing up:
-               flux_term2 = coef*RediKappa(iEdge)*layerThickEdgeMean(k, iEdge)* &
+               flux_term2 = coef*rediKappaAv*layerThickEdgeMean(k, iEdge)* &
                             0.25_RKIND* &
                             (slopeTriadUp(k, 1, iEdge)*(tracers(iTr, k - 1, cell1) - tracers(iTr, k, cell1)) &
                              /(zMid(k - 1, cell1) - zMid(k, cell1)) &
@@ -393,12 +400,12 @@ contains
                              /(zMid(k - 1, cell2) - zMid(k, cell2)))
 
                if (maxLevelCell(cell1) > maxLevelEdgeTop(iEdge)) then
-                  flux_term2 = flux_term2 + coef*RediKappa(iEdge)* &
+                  flux_term2 = flux_term2 + coef*rediKappaAv* &
                                layerThickEdgeMean(k, iEdge)*0.25_RKIND*slopeTriadDown(k, 1, iEdge)* &
                                (tracers(iTr, k, cell1) - tracers(iTr, k + 1, cell1))/(zMid(k, cell1) - zMid(k + 1, cell1))
                endif
                if (maxLevelCell(cell2) > maxLevelEdgeTop(iEdge)) then
-                  flux_term2 = flux_term2 + coef*RediKappa(iEdge)* &
+                  flux_term2 = flux_term2 + coef*rediKappaAv* &
                                layerThickEdgeMean(k, iEdge)*0.25_RKIND*slopeTriadDown(k, 2, iEdge)* &
                                (tracers(iTr, k, cell2) - tracers(iTr, k + 1, cell2))/(zMid(k, cell2) - zMid(k + 1, cell2))
                endif
@@ -427,9 +434,9 @@ contains
             ! take d/dz and remap div( S grad psi ) from edge to cells
             do k = minLevelCell(iCell), maxLevelCell(iCell)
                do iTr = 1, nTracers
-                  flux_term3 = rediKappaCell(iCell) * ( &
-                      redi_term3_topOfCell(iTr, k, iCell) - &
-                      redi_term3_topOfCell(iTr, k + 1, iCell))
+                  flux_term3 =  rediKappaCell(k,iCell) * ( &
+                                redi_term3_topOfCell(iTr, k, iCell) - &
+                                redi_term3_topOfCell(iTr, k + 1, iCell))
 
                   redi_term3(iTr, k, iCell) = redi_term3(iTr, k, iCell) + flux_term3
                end do
@@ -472,7 +479,7 @@ contains
                   ! scale cross-fluxes down relative to size of bnds violation
                   over = max(tempTracer - maximumBnd(iTr, k, iCell), &
                              minimumBnd(iTr, k, iCell) - tempTracer)
-                  
+
                   diff = abs(tempTracer - tracers(iTr, k, iCell))
 
                   scal = min(1.0_RKIND, max(0.0_RKIND, &
@@ -527,7 +534,7 @@ contains
                      redi_flux_scale(iTr, k, iCell) + 1.0E-16_RKIND)
 
                   tend(iTr, k, iCell) = tend(iTr, k, iCell) + &
-                     rediKappaCell(iCell) * ( &
+                     rediKappaCell(k,iCell) * ( &
                         scalUp*redi_term3_topOfCell(iTr, k, iCell) - &
                         scalDn*redi_term3_topOfCell(iTr, k + 1, iCell))
                end do
@@ -596,12 +603,12 @@ contains
       type(mpas_pool_type), pointer :: diagnosticsPool
       type(mpas_pool_type), pointer :: forcingPool
 
-      real(kind=RKIND), dimension(:), pointer :: RediKappa
+      real(kind=RKIND), dimension(:,:), pointer :: RediKappa
       real(kind=RKIND), dimension(:), pointer :: RediHorizontalTaper
       real(kind=RKIND), dimension(:), pointer :: dcEdge
       real(kind=RKIND) :: coef
       integer, dimension(:,:), pointer :: cellsOnEdge
-
+      integer, pointer :: nVertLevels
       integer :: k, iEdge
       integer, pointer :: nEdges
 
@@ -621,6 +628,7 @@ contains
          call mpas_pool_get_subpool(block%structs, 'diagnostics', diagnosticsPool)
          call mpas_pool_get_subpool(block%structs, 'forcing', forcingPool)
          call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
+         call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
          call mpas_pool_get_array(diagnosticsPool, 'RediKappa', RediKappa)
          call mpas_pool_get_array(diagnosticsPool, 'RediHorizontalTaper', RediHorizontalTaper)
          call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
@@ -629,16 +637,20 @@ contains
 
          ! initialize Redi kappa array
          if (config_Redi_closure == 'constant'.or. &
-             config_Redi_closure == 'equalGM') then
+             config_Redi_closure == 'equalGM' .or. &
+             config_Redi_closure == 'N2_dependent') then
              ! For 'equalGM' RediKappa is updated every step. Just
              ! initialize here.
             !$omp parallel
-            !$omp do schedule(runtime)
+            !$omp do schedule(runtime) private(k)
             do iEdge = 1, nEdges
-               RediKappa(iEdge) = config_Redi_constant_kappa
+               do k = 1,nVertLevels+1
+                  RediKappa(k,iEdge) = config_Redi_constant_kappa
+               enddo
             end do
             !$omp end do
             !$omp end parallel
+            RediKappa(:,:) = config_Redi_constant_kappa
          else if (config_Redi_closure == 'data') then
             ! read RediKappa in from input
             call mpas_log_write("config_Redi_closure = 'data'. "// &
@@ -651,7 +663,7 @@ contains
 
          ! quasi bounds-preserving limiter
          use_quasi_monotone = config_Redi_use_quasi_monotone_limiter
-      
+
          ! safety factor for limiter: 0 <= fac <= 1
          limiter_safety_factor = config_Redi_quasi_monotone_safety_factor
 
@@ -671,21 +683,23 @@ contains
             coef = 1.0_RKIND &
                     /(config_Redi_horizontal_ramp_max - config_Redi_horizontal_ramp_min)
             !$omp parallel
-            !$omp do schedule(runtime) 
+            !$omp do schedule(runtime) private(k) 
             do iEdge=1,nEdges
-               if (dcEdge(iEdge) <= config_Redi_horizontal_ramp_min) then
-                  RediKappa(iEdge) = 0.0_RKIND
-                  RediHorizontalTaper(iEdge) = 0.0_RKIND
-               else if (dcEdge(iEdge) >= config_Redi_horizontal_ramp_max) then
-                  ! nothing to do, i.e. RediKappa(iCell) = RediKappa(iCell)
-                  RediHorizontalTaper(iEdge) = 1.0_RKIND
-               else
-                  RediKappa(iEdge) = RediKappa(iEdge) &
-                                     *(dcEdge(iEdge) - config_Redi_horizontal_ramp_min) &
-                                     /(config_Redi_horizontal_ramp_max - config_Redi_horizontal_ramp_min)
-                  RediHorizontalTaper(iEdge) = coef &
-                      *(dcEdge(iEdge) - config_Redi_horizontal_ramp_min)
-               end if
+               do k=1,nVertLevels
+                  if (dcEdge(iEdge) <= config_Redi_horizontal_ramp_min) then
+                     RediKappa(k,iEdge) = 0.0_RKIND
+                     RediHorizontalTaper(iEdge) = 0.0_RKIND
+                  else if (dcEdge(iEdge) >= config_Redi_horizontal_ramp_max) then
+                     ! nothing to do, i.e. RediKappa(iCell) = RediKappa(iCell)
+                     RediHorizontalTaper(iEdge) = 1.0_RKIND
+                  else
+                     RediKappa(k,iEdge) = RediKappa(k,iEdge) &
+                                        *(dcEdge(iEdge) - config_Redi_horizontal_ramp_min) &
+                                        /(config_Redi_horizontal_ramp_max - config_Redi_horizontal_ramp_min)
+                     RediHorizontalTaper(iEdge) = coef &
+                          *(dcEdge(iEdge) - config_Redi_horizontal_ramp_min)
+                  end if
+               end do
             end do ! iEdge
             !$omp end do
             !$omp end parallel

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix_coefs_redi.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix_coefs_redi.F
@@ -161,17 +161,18 @@ contains
       !
       !-----------------------------------------------------------------
 
-      real (kind=RKIND), dimension(:), intent(in) :: &
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
          RediKappa
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
          k33
 
-      real (kind=RKIND) :: rediKappaCell
+      real (kind=RKIND),dimension(:), allocatable :: rediKappaCell
       real (kind=RKIND),dimension(:),pointer :: dvEdge, dcEdge, areaCell
 
-      integer :: i, iCell, nCells, iEdge
+      integer :: i, iCell, k, nCells, iEdge
 
+      integer, pointer :: nVertLevels
       integer, dimension(:), pointer :: nEdgesOnCell, nCellsArray
       integer, dimension(:,:), pointer :: edgesOnCell
 
@@ -195,19 +196,23 @@ contains
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
       call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
       call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
-
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       nCells = nCellsArray(1)
 
+      allocate(rediKappaCell(nVertLevels+1))
       !$omp parallel
-      !$omp do schedule(runtime) private(i, rediKappaCell, iEdge)
+      !$omp do schedule(runtime) private(i, k, rediKappaCell, iEdge)
       do iCell = 1, nCells
-         rediKappaCell = 0.0_RKIND
+         rediKappaCell(:) = 0.0_RKIND
          do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
-            rediKappaCell = rediKappaCell + 0.25_RKIND*RediKappa(iEdge) * dvEdge(iEdge) * dcEdge(iEdge)
+            do k = 1, nVertLevels + 1
+               rediKappaCell(k) = rediKappaCell(k) + 0.25_RKIND*RediKappa(k,iEdge) &
+                                                   * dvEdge(iEdge) * dcEdge(iEdge)
+            enddo
          enddo
 
-         vertDiffTopOfCell(:, iCell) = vertDiffTopOfCell(:, iCell) + rediKappaCell * k33(:, iCell) &
+         vertDiffTopOfCell(:, iCell) = vertDiffTopOfCell(:, iCell) + rediKappaCell(:) * k33(:, iCell) &
                         / areaCell(iCell)
       end do
       !$omp end do


### PR DESCRIPTION
this PR adds numerous changes to Redi isopycnal mixing 
Many changes have been made to improve the readability, physics, and capabilities of the redi iopycnal mixing scheme
    1. Redi slopes are now removed from the gm file and computed on its own
    to reduce the size of the gm file
    2. surface limiting of Redi now ensures surface horizontal mixing (in
    the upper portion of the boundary layer) and is full Redi at the BLD
    base
    3. Redi now has a N2 dependent option that is separate from GM, this
    required making Redi a 3d variable and allows for future changes to the
    distribution of Redi horizontally and vertically
    4. there is a fix in the isopycnal slope calculation for steeply sloping
    coordinate surfaces (e.g. ice shelf cavities)
    
[NML]
 Options are included to ensure this PR is BFB with current master