### PR TITLE
EAMxx: functionalize SPA activation of CCN->Nc

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -216,6 +216,7 @@ be lost if SCREAM_HACK_XML is not enabled.
       <rain_selfcollection_breakup_diameter type="real" doc="Rain self-collection breakup diameter in meter">0.00028</rain_selfcollection_breakup_diameter>
       <constant_mu_rain type="real" doc="Constant shape parameter (mu) in the rain droplet distribution">1.0</constant_mu_rain>
       <spa_ccn_to_nc_factor type="real" doc="Scaling factor for turning SPA ccn into P3 nc">1.0</spa_ccn_to_nc_factor>
+      <spa_ccn_to_nc_exponent type="real" doc="Exponent for turning SPA ccn into P3 nc">1.0</spa_ccn_to_nc_exponent>      
       <cldliq_to_ice_collection_factor type="real" doc="Cloud liquid to ice collection scaling factor">0.5</cldliq_to_ice_collection_factor>
       <rain_to_ice_collection_factor type="real" doc="Rain to ice collection scaling factor">1.0</rain_to_ice_collection_factor>
       <min_rime_rho type="real" doc="Minimum rime density in kg/m3">50.0</min_rime_rho>

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part1.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part1.hpp
@@ -135,14 +135,20 @@ void Functions<S,D>
 
       if(do_prescribed_CCN) {
         // the SPA equation is of the form:
-        // Nc = max ( Nc , alpha * (nccn_prescribed / cld_frac_l) ^ beta )
+        // Nc = max ( Nc , alpha * (nccn_prescribed / inv_cld_frac_l) ^ beta )
         // where alpha and beta are the factor and exponent, respectively.
         // This functional form accounts for "activation" of CCN into Nc
-        // and it can be made sublinear (e.g., 2000 and 0.55)
+        // and it can be made sublinear (e.g., 2000 and 0.55).
+        // First, scale by cld_frac_l to account for subgrid frac (if any)
+        auto nccn_scaled = nccn_prescribed(k) / inv_cld_frac_l(k);
+        // TODO: HACK: keep BFB, avoid roundoff diff due to pow(x, 1.0)
+        // Second, apply the exponent, but keep strict BFB with defaults
+        if(spa_ccn_to_nc_exponent != sp(1.0)) {
+          nccn_scaled = pow(nccn_scaled, spa_ccn_to_nc_exponent);
+        }
+        // Third, apply the factor, and retain the max
         nc(k).set(not_drymass,
-                  max(nc(k), spa_ccn_to_nc_factor *
-                                 pow(nccn_prescribed(k) / inv_cld_frac_l(k),
-                                     spa_ccn_to_nc_exponent)));
+                  max(nc(k), spa_ccn_to_nc_factor * nccn_scaled));
       } else if(predictNc) {
         nc(k).set(not_drymass, max(nc(k) + nc_nuceat_tend(k) * dt, 0.0));
       } else {

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part1.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part1.hpp
@@ -81,6 +81,7 @@ void Functions<S,D>
   constexpr Scalar latice       = C::LatIce;
 
   const Scalar spa_ccn_to_nc_factor = runtime_options.spa_ccn_to_nc_factor;
+  const Scalar spa_ccn_to_nc_exponent = runtime_options.spa_ccn_to_nc_exponent;
 
   nucleationPossible = false;
   hydrometeorsPresent = false;
@@ -133,9 +134,15 @@ void Functions<S,D>
       // prescribe that value
 
       if(do_prescribed_CCN) {
+        // the SPA equation is of the form:
+        // Nc = max ( Nc , alpha * (nccn_prescribed / cld_frac_l) ^ beta )
+        // where alpha and beta are the factor and exponent, respectively.
+        // This functional form accounts for "activation" of CCN into Nc
+        // and it can be made sublinear (e.g., 2000 and 0.55)
         nc(k).set(not_drymass,
-                  max(nc(k), spa_ccn_to_nc_factor * nccn_prescribed(k) /
-                                 inv_cld_frac_l(k)));
+                  max(nc(k), spa_ccn_to_nc_factor *
+                                 pow(nccn_prescribed(k) / inv_cld_frac_l(k),
+                                     spa_ccn_to_nc_exponent)));
       } else if(predictNc) {
         nc(k).set(not_drymass, max(nc(k) + nc_nuceat_tend(k) * dt, 0.0));
       } else {

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -123,6 +123,7 @@ struct Functions
     Scalar rain_selfcollection_breakup_diameter = 0.00028;
     Scalar constant_mu_rain = 1.0;
     Scalar spa_ccn_to_nc_factor = 1.0;
+    Scalar spa_ccn_to_nc_exponent = 1.0;
     Scalar cldliq_to_ice_collection_factor = 0.5;
     Scalar rain_to_ice_collection_factor = 1.0;
     Scalar min_rime_rho = 50.0;
@@ -150,6 +151,7 @@ struct Functions
       rain_selfcollection_breakup_diameter = params.get<double>("rain_selfcollection_breakup_diameter", rain_selfcollection_breakup_diameter);
       constant_mu_rain = params.get<double>("constant_mu_rain", constant_mu_rain);
       spa_ccn_to_nc_factor = params.get<double>("spa_ccn_to_nc_factor", spa_ccn_to_nc_factor);
+      spa_ccn_to_nc_exponent = params.get<double>("spa_ccn_to_nc_exponent", spa_ccn_to_nc_exponent);
       cldliq_to_ice_collection_factor = params.get<double>("cldliq_to_ice_collection_factor", cldliq_to_ice_collection_factor);
       rain_to_ice_collection_factor = params.get<double>("rain_to_ice_collection_factor", rain_to_ice_collection_factor);
       min_rime_rho = params.get<double>("min_rime_rho", min_rime_rho);


### PR DESCRIPTION
Adds ability to use different forms of activation in SPA.


[BFB]

---

General form is

$$
N_\text{c} = \max\left( N_\text{c}, \alpha \times \left(N_\text{ccn} \times C_\text{f}\right)^{\beta} \right)
$$

- $N_\text{c}$: grid-mean cloud liquid droplet number
- $N_\text{ccn}$: grid-mean cloud condensation nuclei
- $C_\text{f}$: grid-mean liquid cloud fraction
- $\alpha$ is a linear prefactor
- $\beta$ is the log-log slope (generally thought to be <1)

Suggested settings for future studies: $\beta=0.55$ and $\alpha=2000$ (matching v3 activation)