### PR TITLE
EAMxx: Updates MAM4xx submodule to fix uninitialized photos variable

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -788,7 +788,8 @@ _TESTS = {
             "ERS.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.eamxx-mam4xx-optics",
             "ERS.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.eamxx-mam4xx-wetscav",
             "ERS.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.eamxx-mam4xx-aero_microphysics",
-            "ERS.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.eamxx-mam4xx-drydep"
+            "ERS.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.eamxx-mam4xx-drydep",
+            "ERS.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.eamxx-mam4xx-all_mam4xx_procs"
         )
     },
 


### PR DESCRIPTION
The variable `photos` was uninitialized. The fix also fixes the ERS test with all
 mam4xx processes.
An ERS test is also added with all MAM4xx processes.

[NBFB] for MAM4xx tests