### PR TITLE
EAMxx: improve granularity of eamxx hash

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -152,7 +152,11 @@ be lost if SCREAM_HACK_XML is not enabled.
       <repair_log_level type="string" valid_values="trace,debug,info,warn">trace</repair_log_level>
       <!-- Run internal checks on code correctness.
            <= 0: off; >= 1: global hashes over state -->
-      <internal_diagnostics_level type="integer">0</internal_diagnostics_level>
+      <internal_diagnostics_level
+        type="integer"
+        valid_values="0,1,2"
+        doc="Whether to print hashes of the atm proc fields: 0=no, 1=yes (lump fields), 2=yes (individual fields)"
+      >0</internal_diagnostics_level>
       <compute_tendencies
         type="array(string)"
         doc="list of computed fields for which this process will back out tendencies"

--- a/components/eamxx/src/share/atm_process/atmosphere_process.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.cpp
@@ -110,6 +110,7 @@ void AtmosphereProcess::run (const double dt) {
     }
 
     if (m_internal_diagnostics_level > 0)
+      // Print hash of INPUTS before run
       print_global_state_hash(name() + "-pre-sc-" + std::to_string(m_subcycle_iter),
                               true, false, false);
 
@@ -117,6 +118,7 @@ void AtmosphereProcess::run (const double dt) {
     run_impl(dt_sub);
 
     if (m_internal_diagnostics_level > 0)
+      // Print hash of OUTPUTS/INTERNALS after run
       print_global_state_hash(name() + "-pst-sc-" + std::to_string(m_subcycle_iter),
                               true, true, true);
 

--- a/components/eamxx/src/share/atm_process/atmosphere_process.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.hpp
@@ -272,10 +272,13 @@ public:
   // Boolean that dictates whether or not the conservation checks are run for this process
   bool has_column_conservation_check () { return m_column_conservation_check_data.has_check; }
 
-  // For internal diagnostics and debugging.
+  // Print a global hash of internal fields (useful for debugging non-bfbness)
+  // Note: (mem, nmem) describe an arbitrary device array. If mem!=nullptr,
+  // the array will be hashed and reported as an additional entry
   void print_global_state_hash(const std::string& label, const bool in = true,
                                const bool out = true, const bool internal = true,
                                const Real* mem = nullptr, const int nmem = 0) const;
+
   // For BFB tracking in production simulations.
   void print_fast_global_state_hash(const std::string& label) const;
 
@@ -289,7 +292,6 @@ public:
   }
 
 protected:
-
   // Sends a message to the atm log
   void log (const LogLevel lev, const std::string& msg) const;
 


### PR DESCRIPTION
Allow to hash individual fields separately, to detect _which_ field is not BFB.

[BFB]

---

While trying to figure out why an ERS test was failing the base-rest comparison, I ended up implementing a more fine-grained hash, which may be useful in deep dives debugging. In my case, the fail was due to rad freq being not compatible with restart freq, something that I realized only after printing the hashes of individual fields, and seeing the rad fields with a zero hash upon restart (which made the light bulb FINALLY go on).

The hash function has been upgraded (keeping the signature fixed), to allow printing a separate hash for each field. This can be requested by setting `internal_diagnostics_level=2` (a value of 1 will still print the "lumped" hash, as it was doing before).

Obviously, an internal_diagnostics_level=2 will print _a lot_ more stuff, so it should be used cautiously.