### PR TITLE
Add a dust emission cap

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -202,7 +202,7 @@ _TESTS = {
             )
         },
 
-#tests for the dust emission cap shanyp
+#tests for the dust emission cap
         "e3sm_dustemissioncap" : {
         "tests"   : (
             "ERP.ne4pg2_oQU480.F2010.eam-dustemissioncap",

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -202,6 +202,18 @@ _TESTS = {
             )
         },
 
+#tests for the dust emission cap shanyp
+        "e3sm_dustemissioncap" : {
+        "tests"   : (
+            "ERP.ne4pg2_oQU480.F2010.eam-dustemissioncap",
+            "REP_Ln5.ne4pg2_oQU480.F2010.eam-dustemissioncap",
+            "PET.ne4pg2_oQU480.F2010.eam-dustemissioncap",
+            "PEM_Ln18.ne4pg2_oQU480.F2010.eam-dustemissioncap",
+            "SMS_Ln5.ne30pg2_EC30to60E2r2.F2010.eam-dustemissioncap",
+            "SMS_D_Ln5.ne4pg2_oQU480.F2010.eam-dustemissioncap"
+            )
+        },
+
     "e3sm_atm_integration" : {
         "inherit" : ("eam_preqx", "eam_theta"),
         "tests" : (

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1048,7 +1048,9 @@
 
 <dust_emis_fact dyn="se"                   phys="cam5"                  >0.55D0</dust_emis_fact>
 <dust_emis_fact dyn="fv"                   phys="cam5" clubb_sgs="1"    >0.13D0</dust_emis_fact>
-
+<!-- Dust emission cap (avoid the model crash by extremely high AOD)-->
+<dstemislimit phys="default"> 1.D-5 </dstemislimit>
+<dstemislimitswitch phys="default"> .false. </dstemislimitswitch>
 
 <!-- Sea Salt tuning option for scavenging mods by PNNL -->
 <ssalt_tuning>.false.</ssalt_tuning>

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1049,7 +1049,7 @@
 <dust_emis_fact dyn="se"                   phys="cam5"                  >0.55D0</dust_emis_fact>
 <dust_emis_fact dyn="fv"                   phys="cam5" clubb_sgs="1"    >0.13D0</dust_emis_fact>
 <!-- Dust emission cap (avoid the model crash by extremely high AOD)-->
-<dstemislimit phys="default"> 1.D-5 </dstemislimit>
+<dstemislimit phys="default"> 1.D-4 </dstemislimit>
 <dstemislimitswitch phys="default"> .false. </dstemislimitswitch>
 
 <!-- Sea Salt tuning option for scavenging mods by PNNL -->

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -5051,6 +5051,18 @@ In-cloud scav for cloud-borne aerosol tuning factor
 Default: set by build-namelist.
 </entry>
 
+<entry id="dstemislimit" type="real" category="cam_chem"
+       group="aerosol_nl" valid_values="" >
+Dust emission cap used to avoid extremely high AOD
+Default: set by build-namelist.
+</entry>
+
+<entry id="dstemislimitswitch" type="logical" category="cam_chem"
+       group="aerosol_nl" valid_values="" >
+The switch for the dust emission cap used to avoid extremely high AOD
+Default: set by build-namelist.
+</entry>
+
 <entry id="modal_strat_sulfate_aod_treatment" type="logical"  category="cam_chem"
        group="phys_ctl_nl" valid_values="" >
 Flag for H2SO4 specific stratospheric wateruptake treatment

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/dustemissioncap/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/dustemissioncap/user_nl_eam
@@ -1,2 +1,2 @@
 dstemislimitswitch = .true.
-dstemislimit = 1.D-5
+dstemislimit = 1.D-4

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/dustemissioncap/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/dustemissioncap/user_nl_eam
@@ -1,0 +1,2 @@
+dstemislimitswitch = .true.
+dstemislimit = 1.D-5

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -2846,7 +2846,6 @@ do_lphase2_conditional: &
        do m=1,dust_nbin+dust_nnum
           mm = dust_indices(m)
           if (m<=dust_nbin) sflx(:ncol)=sflx(:ncol)+cam_in%cflx(:ncol,mm)
-!          call outfld(trim(dust_names(m))//'SF',cam_in%cflx(:,mm),pcols, lchnk)
        enddo
 
        if(dstemislimitswitch.eqv..true.) then

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -2848,23 +2848,26 @@ do_lphase2_conditional: &
           if (m<=dust_nbin) sflx(:ncol)=sflx(:ncol)+cam_in%cflx(:ncol,mm)
 !          call outfld(trim(dust_names(m))//'SF',cam_in%cflx(:,mm),pcols, lchnk)
        enddo
-       
-       do icol=1,ncol
-        if(sflx(icol).ge.dstemislimit) then
-         call get_rlon_all_p(lchnk,ncol,tmp_lon)
-         call get_rlat_all_p(lchnk,ncol,tmp_lat)
-         do m=1,dust_nbin+dust_nnum
-          mm = dust_indices(m)
-          cam_in%cflx(icol,mm)=cam_in%cflx(icol,mm)*dstemislimit/sflx(icol)
-         end do
-         write(iulog,'((a,1x,i10,1x),2(a,1x,f8.2),(a,1x,e15.5e2))') &
-                 'The dust emission cap is hit at icol= ',icol, &
-                 ' Latitude=',tmp_lat(icol)*180.0/pi, &
-                 ' Longitude=',tmp_lon(icol)*180.0/pi-180., &
-                 ' emission flux before imposing (kg/m2/s): ',sflx(icol)
-         sflx(icol)=dstemislimit
-        end if
-       end do
+
+       if(dstemislimitswitch) then       
+        do icol=1,ncol
+         if(sflx(icol).ge.dstemislimit) then
+          call get_rlon_all_p(lchnk,ncol,tmp_lon)
+          call get_rlat_all_p(lchnk,ncol,tmp_lat)
+          do m=1,dust_nbin+dust_nnum
+           mm = dust_indices(m)
+           cam_in%cflx(icol,mm)=cam_in%cflx(icol,mm)*dstemislimit/sflx(icol)
+          end do
+          write(iulog,'((a,1x,i10,1x),2(a,1x,f8.2),(a,1x,e15.5e2))') &
+                  'The dust emission cap is hit at icol= ',icol, &
+                  ' Latitude=',tmp_lat(icol)*180.0/pi, &
+                  ' Longitude=',tmp_lon(icol)*180.0/pi-180., &
+                  ' emission flux before imposing (kg/m2/s): ',sflx(icol)
+          sflx(icol)=dstemislimit
+         end if
+        end do
+       end if
+
        do m=1,dust_nbin+dust_nnum
         mm = dust_indices(m)
         call outfld(trim(dust_names(m))//'SF',cam_in%cflx(:,mm),pcols, lchnk)

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -102,6 +102,8 @@ module aero_model
   real(r8)          :: sol_factic_interstitial = 0.4_r8
   real(r8)          :: seasalt_emis_scale
   real(r8)          :: small = 1.e-36
+  real(r8)          :: dstemislimit = 1.e-5_r8
+  logical           :: dstemislimitswitch = .false.
 
   integer :: ndrydep = 0
   integer,allocatable :: drydep_indices(:)
@@ -132,8 +134,7 @@ contains
     character(len=16) :: aer_drydep_list(pcnst) = ' '
     namelist /aerosol_nl/ aer_wetdep_list, aer_drydep_list,          &
              sol_facti_cloud_borne, seasalt_emis_scale, sscav_tuning, &
-       sol_factb_interstitial, sol_factic_interstitial
-
+             sol_factb_interstitial, sol_factic_interstitial,dstemislimit,dstemislimitswitch
     !-----------------------------------------------------------------------------
 
     ! Read namelist
@@ -161,6 +162,8 @@ contains
     call mpibcast(sol_factic_interstitial, 1,                       mpir8,   0, mpicom)
     call mpibcast(sscav_tuning,          1,                         mpilog,  0, mpicom)
     call mpibcast(seasalt_emis_scale, 1, mpir8,   0, mpicom)
+    call mpibcast(dstemislimit, 1,                       mpir8,   0, mpicom) !dstemislimit
+    call mpibcast(dstemislimitswitch, 1,                  mpilog,  0, mpicom) !dstemislimit
 #endif
 
     wetdep_list = aer_wetdep_list
@@ -2805,6 +2808,8 @@ do_lphase2_conditional: &
          has_mam_mom, F_eff_out, nslt_om
     use dust_model,    only: dust_emis, dust_names, dust_indices, dust_active,dust_nbin, dust_nnum
     use physics_types, only: physics_state
+    use phys_grid,      only: get_rlat_all_p, get_rlon_all_p
+    use physconst,      only: pi
 
     ! Arguments:
 
@@ -2822,6 +2827,12 @@ do_lphase2_conditional: &
     real(r8) :: F_eff(pcols) ! optional diagnostic output -- organic enrichment ratio
 
     real (r8), parameter :: z0=0.0001_r8  ! m roughness length over oceans--from ocean model
+    integer :: icol,mmn
+    real(r8) :: tmp_lat(pcols),tmp_lon(pcols)
+    tmp_lat(:) =-999._r8
+    tmp_lon(:) =-999._r8
+    icol=0
+    mmn=0
 
     lchnk = state%lchnk
     ncol = state%ncol
@@ -2835,8 +2846,30 @@ do_lphase2_conditional: &
        do m=1,dust_nbin+dust_nnum
           mm = dust_indices(m)
           if (m<=dust_nbin) sflx(:ncol)=sflx(:ncol)+cam_in%cflx(:ncol,mm)
-          call outfld(trim(dust_names(m))//'SF',cam_in%cflx(:,mm),pcols, lchnk)
+!          call outfld(trim(dust_names(m))//'SF',cam_in%cflx(:,mm),pcols, lchnk)
        enddo
+       
+       do icol=1,ncol
+        if(sflx(icol).ge.dstemislimit) then
+         call get_rlon_all_p(lchnk,ncol,tmp_lon)
+         call get_rlat_all_p(lchnk,ncol,tmp_lat)
+         do m=1,dust_nbin+dust_nnum
+          mm = dust_indices(m)
+          cam_in%cflx(icol,mm)=cam_in%cflx(icol,mm)*dstemislimit/sflx(icol)
+         end do
+         write(iulog,'((a,1x,i10,1x),2(a,1x,f8.2),(a,1x,e15.5e2))') &
+                 'The dust emission cap is hit at icol= ',icol, &
+                 ' Latitude=',tmp_lat(icol)*180.0/pi, &
+                 ' Longitude=',tmp_lon(icol)*180.0/pi-180., &
+                 ' emission flux before imposing (kg/m2/s): ',sflx(icol)
+         sflx(icol)=dstemislimit
+        end if
+       end do
+       do m=1,dust_nbin+dust_nnum
+        mm = dust_indices(m)
+        call outfld(trim(dust_names(m))//'SF',cam_in%cflx(:,mm),pcols, lchnk)
+       end do
+
        call outfld('DSTSFMBL',sflx(:),pcols,lchnk)
        call outfld('LND_MBL',soil_erod_tmp(:),pcols, lchnk )
     endif

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -102,7 +102,7 @@ module aero_model
   real(r8)          :: sol_factic_interstitial = 0.4_r8
   real(r8)          :: seasalt_emis_scale
   real(r8)          :: small = 1.e-36
-  real(r8)          :: dstemislimit = 1.e-5_r8
+  real(r8)          :: dstemislimit = 1.e-4_r8
   logical           :: dstemislimitswitch = .false.
 
   integer :: ndrydep = 0

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -2849,7 +2849,7 @@ do_lphase2_conditional: &
 !          call outfld(trim(dust_names(m))//'SF',cam_in%cflx(:,mm),pcols, lchnk)
        enddo
 
-       if(dstemislimitswitch.eq..true.) then       
+       if(dstemislimitswitch.eqv..true.) then
         do icol=1,ncol
          if(sflx(icol).gt.dstemislimit) then
           call get_rlon_all_p(lchnk,ncol,tmp_lon)

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -2849,9 +2849,9 @@ do_lphase2_conditional: &
 !          call outfld(trim(dust_names(m))//'SF',cam_in%cflx(:,mm),pcols, lchnk)
        enddo
 
-       if(dstemislimitswitch) then       
+       if(dstemislimitswitch.eq..true.) then       
         do icol=1,ncol
-         if(sflx(icol).ge.dstemislimit) then
+         if(sflx(icol).gt.dstemislimit) then
           call get_rlon_all_p(lchnk,ncol,tmp_lon)
           call get_rlat_all_p(lchnk,ncol,tmp_lat)
           do m=1,dust_nbin+dust_nnum


### PR DESCRIPTION
To address the issue of excessively strong dust emissions leading to 
crashes in high-resolution (HR) simulations, a dust emission cap has been 
implemented. This cap constrains dust emissions within a reasonable range, 
ensuring simulation stability.

Furthermore, the dust emission cap and its enabling switch have been introduced 
as configurable namelist options, allowing users to easily activate and tune the cap 
based on their specific simulation requirements.

Additionally, the model now outputs the latitude-longitude coordinates of grid cell 
with excessively high dust emissions.

Following Dr. Yan Feng’s suggestion, the dust emission cap has been modified to 
constrain the total dust emissions for both the coarse and accumulation modes.

[BFB]

-----------------------------------------------------------------------------------------------
[NML] new namelist variables introduced to control the use of the emission cap, but not added by default, so won't cause NLFAIL  currently. Default will be set in a future PR.

A minor change recommended by Dr. Wuyin Lin has also been incorporated to ensure successfully passing the CIME tests.