### PR TITLE
EAMxx: Using top_lev from namelist.

### DIFF
--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
@@ -223,6 +223,7 @@ void call_function_dropmixnuc(
 
     // tendnd is used by microphysics scheme (e.g. P3)
     MAMAci::view_2d tendnd,
+    const int top_lev,
 
     // ## work arrays ##
     MAMAci::view_2d raercol_cw[mam4::ndrop::pver][2],
@@ -424,6 +425,7 @@ void call_function_dropmixnuc(
             ekat::subview(ndropmix, icol), ekat::subview(nsource, icol),
             ekat::subview(wtke, icol), ekat::subview(ccn, icol), coltend_view,
             coltend_cw_view,
+            top_lev,
             // work arrays
             raercol_cw_view, raercol_view, ekat::subview(nact, icol),
             ekat::subview(mact, icol), ekat::subview(eddy_diff, icol),

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
@@ -203,6 +203,7 @@ void call_function_dropmixnuc(
     const MAMAci::view_2d wsub, const MAMAci::view_2d cloud_frac,
     const MAMAci::view_2d cloud_frac_prev,
     const mam_coupling::AerosolState &dry_aero, const int nlev,
+    const int top_lev,
     const bool &enable_aero_vertical_mix,
 
     // Following outputs are all diagnostics
@@ -223,7 +224,6 @@ void call_function_dropmixnuc(
 
     // tendnd is used by microphysics scheme (e.g. P3)
     MAMAci::view_2d tendnd,
-    const int top_lev,
 
     // ## work arrays ##
     MAMAci::view_2d raercol_cw[mam4::ndrop::pver][2],

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
@@ -506,6 +506,7 @@ void MAMAci::run_impl(const double dt) {
       coltend_, coltend_cw_, qcld_, ndropcol_, ndropmix_, nsource_, wtke_, ccn_,
       // ## output to be used by the other processes ##
       qqcw_fld_work_, ptend_q_, factnum_, tendnd_,
+      top_lev_,
       // work arrays
       raercol_cw_, raercol_, state_q_work_, nact_, mact_,
       dropmixnuc_scratch_mem_);

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
@@ -501,12 +501,11 @@ void MAMAci::run_impl(const double dt) {
   //  aerosols tendencies
   call_function_dropmixnuc(
       team_policy, dt, dry_atm_, rpdel_, kvh_mid_, kvh_int_, wsub_, cloud_frac_,
-      cloud_frac_prev_, dry_aero_, nlev_, enable_aero_vertical_mix_,
+      cloud_frac_prev_, dry_aero_, nlev_, top_lev_, enable_aero_vertical_mix_,
       // output
       coltend_, coltend_cw_, qcld_, ndropcol_, ndropmix_, nsource_, wtke_, ccn_,
       // ## output to be used by the other processes ##
       qqcw_fld_work_, ptend_q_, factnum_, tendnd_,
-      top_lev_,
       // work arrays
       raercol_cw_, raercol_, state_q_work_, nact_, mact_,
       dropmixnuc_scratch_mem_);


### PR DESCRIPTION
Update the interface to pass the 'top_lev' parameter to ndrop. 

The value of the `top_lev` parameter can be changed using the namelist
variable `top_level_mam4xx`.

See also [PR 414](https://github.com/eagles-project/mam4xx/pull/414) 
in mam4xx. 

[BFB]

