### PR TITLE
EAMxxx: Use strided view types for shoc tracers

### DIFF
--- a/components/eamxx/src/physics/shoc/disp/shoc_update_prognostics_implicit_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_update_prognostics_implicit_disp.cpp
@@ -28,7 +28,7 @@ void Functions<Real,DefaultDevice>
   const WorkspaceMgr&          workspace_mgr,
   const view_2d<Spack>&        thetal,
   const view_2d<Spack>&        qw,
-  const view_3d<Spack>&        tracer,
+  const view_3d_strided<Spack>& tracer,
   const view_2d<Spack>&        tke,
   const view_2d<Spack>&        u_wind,
   const view_2d<Spack>&        v_wind)
@@ -58,7 +58,7 @@ void Functions<Real,DefaultDevice>
                                 workspace,
                                 ekat::subview(thetal, i),
                                 ekat::subview(qw, i),
-                                ekat::subview(tracer, i),
+                                Kokkos::subview(tracer, i, Kokkos::ALL(), Kokkos::ALL()),
                                 ekat::subview(tke, i),
                                 ekat::subview(u_wind, i),
                                 ekat::subview(v_wind, i));

--- a/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
@@ -112,7 +112,7 @@ void Functions<S,D>::shoc_main_internal(
   const uview_1d<Spack>&       u_wind,
   const uview_1d<Spack>&       v_wind,
   const uview_1d<Spack>&       wthv_sec,
-  const uview_2d<Spack>&       qtracers,
+  const uview_2d_strided<Spack>& qtracers,
   const uview_1d<Spack>&       tk,
   const uview_1d<Spack>&       shoc_cldfrac,
   const uview_1d<Spack>&       shoc_ql,
@@ -367,7 +367,7 @@ void Functions<S,D>::shoc_main_internal(
   const uview_2d<Spack>&      u_wind,
   const uview_2d<Spack>&      v_wind,
   const view_2d<Spack>&       wthv_sec,
-  const view_3d<Spack>&       qtracers,
+  const view_3d_strided<Spack>& qtracers,
   const view_2d<Spack>&       tk,
   const view_2d<Spack>&       shoc_cldfrac,
   const view_2d<Spack>&       shoc_ql,
@@ -595,10 +595,10 @@ Int Functions<S,D>::shoc_main(
   auto start = std::chrono::steady_clock::now();
 
   // Runtime options
-  const Scalar lambda_low    = shoc_runtime.lambda_low;    
-  const Scalar lambda_high   = shoc_runtime.lambda_high;   
-  const Scalar lambda_slope  = shoc_runtime.lambda_slope;  
-  const Scalar lambda_thresh = shoc_runtime.lambda_thresh; 
+  const Scalar lambda_low    = shoc_runtime.lambda_low;
+  const Scalar lambda_high   = shoc_runtime.lambda_high;
+  const Scalar lambda_slope  = shoc_runtime.lambda_slope;
+  const Scalar lambda_thresh = shoc_runtime.lambda_thresh;
   const Scalar thl2tune      = shoc_runtime.thl2tune;
   const Scalar qw2tune       = shoc_runtime.qw2tune;
   const Scalar qwthl2tune    = shoc_runtime.qwthl2tune;

--- a/components/eamxx/src/physics/shoc/shoc_functions.hpp
+++ b/components/eamxx/src/physics/shoc/shoc_functions.hpp
@@ -56,6 +56,8 @@ struct Functions
   using view_3d = typename KT::template view_3d<S>;
 
   template <typename S>
+  using view_2d_strided = typename KT::template sview<S**>;
+  template <typename S>
   using view_3d_strided = typename KT::template sview<S***>;
 
   template <typename S, int N>
@@ -66,6 +68,9 @@ struct Functions
 
   template <typename S>
   using uview_2d = typename ekat::template Unmanaged<view_2d<S> >;
+
+  template <typename S>
+  using uview_2d_strided = typename ekat::template Unmanaged<view_2d_strided<S> >;
 
   using MemberType = typename KT::MemberType;
 
@@ -649,7 +654,7 @@ struct Functions
     const Workspace&             workspace,
     const uview_1d<Spack>&       thetal,
     const uview_1d<Spack>&       qw,
-    const uview_2d<Spack>&       tracer,
+    const uview_2d_strided<Spack>& tracer,
     const uview_1d<Spack>&       tke,
     const uview_1d<Spack>&       u_wind,
     const uview_1d<Spack>&       v_wind);
@@ -675,7 +680,7 @@ struct Functions
     const WorkspaceMgr&          workspace_mgr,
     const view_2d<Spack>&        thetal,
     const view_2d<Spack>&        qw,
-    const view_3d<Spack>&        tracer,
+    const view_3d_strided<Spack>& tracer,
     const view_2d<Spack>&        tke,
     const view_2d<Spack>&        u_wind,
     const view_2d<Spack>&        v_wind);
@@ -1036,7 +1041,7 @@ struct Functions
     const uview_1d<Spack>&       u_wind,
     const uview_1d<Spack>&       v_wind,
     const uview_1d<Spack>&       wthv_sec,
-    const uview_2d<Spack>&       qtracers,
+    const uview_2d_strided<Spack>& qtracers,
     const uview_1d<Spack>&       tk,
     const uview_1d<Spack>&       shoc_cldfrac,
     const uview_1d<Spack>&       shoc_ql,
@@ -1110,7 +1115,7 @@ struct Functions
     const uview_2d<Spack>&      u_wind,
     const uview_2d<Spack>&      v_wind,
     const view_2d<Spack>&       wthv_sec,
-    const view_3d<Spack>&       qtracers,
+    const view_3d_strided<Spack>& qtracers,
     const view_2d<Spack>&       tk,
     const view_2d<Spack>&       shoc_cldfrac,
     const view_2d<Spack>&       shoc_ql,


### PR DESCRIPTION
This was a bug where I was passing around `StridedLayout` views to functions expecting `LayoutLeft`. Only caught in the PM-GPU nightlies and by https://github.com/E3SM-Project/E3SM/pull/6916, so I will ensure those pass before merging.

[BFB]