### PR TITLE
For pm-cpu: adjust LD_LIBRARY_PATH to use Cray system settings after Feb18th NERSC maintenance made CPE changes

### DIFF
--- a/cime_config/machines/cmake_macros/gnu_pm-cpu.cmake
+++ b/cime_config/machines/cmake_macros/gnu_pm-cpu.cmake
@@ -5,28 +5,6 @@ endif()
 string(APPEND CMAKE_C_FLAGS_RELEASE " -O2 -g")
 string(APPEND CMAKE_Fortran_FLAGS_RELEASE " -O2 -g")
 
-# For MCT coupler sources only, try resetting CMAKE_Fortran_FLAGS_DEBUG to avoid setting FPE invalid exceptions
-# https://github.com/E3SM-Project/E3SM/issues/7049
-if (COMP_NAME STREQUAL cpl)
-  set(CMAKE_Fortran_FLAGS_DEBUG " ") # set to blank and rebuild
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64")
-    string(APPEND CMAKE_Fortran_FLAGS_DEBUG "-mcmodel=small")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
-    string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -mcmodel=large")
-  else()
-    string(APPEND CMAKE_Fortran_FLAGS_DEBUG "-mcmodel=medium")
-  endif()
-  string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none")
-  if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
-     string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -fallow-argument-mismatch")
-  endif()
-  #original string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -g -Wall -fbacktrace -fcheck=bounds,pointer -ffpe-trap=invalid,zero,overflow")
-  string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -g -Wall -fbacktrace -fcheck=bounds,pointer -ffpe-trap=zero,overflow")
-  if (compile_threaded)
-    string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -fopenmp")
-  endif()
-endif()
-
 set(MPICC "cc")
 set(MPICXX "CC")
 set(MPIFC "ftn")

--- a/cime_config/machines/cmake_macros/intel_pm-cpu.cmake
+++ b/cime_config/machines/cmake_macros/intel_pm-cpu.cmake
@@ -29,17 +29,3 @@ string(APPEND CMAKE_Fortran_FLAGS " -fp-model=consistent -fimf-use-svml")
 string(APPEND CMAKE_Fortran_FLAGS_RELEASE " -g -traceback")
 string(APPEND CMAKE_Fortran_FLAGS " -DHAVE_ERF_INTRINSICS")
 string(APPEND CMAKE_CXX_FLAGS " -fp-model=consistent")
-
-
-# For MCT coupler sources only, try resetting CMAKE_Fortran_FLAGS_DEBUG to avoid setting FPE invalid exceptions
-# https://github.com/E3SM-Project/E3SM/issues/7049
-if (COMP_NAME STREQUAL cpl)
-  set(CMAKE_Fortran_FLAGS_DEBUG " ") # set to blank and rebuild
-  if (compile_threaded)
-    string(APPEND CMAKE_Fortran_FLAGS_DEBUG   " -qopenmp")
-  endif()
-  #original string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created -init=snan,arrays")
-  string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -O0 -g -check uninit -check bounds -check pointers -check noarg_temp_created -init=nosnan,arrays")
-  string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model source")
-endif()
-

--- a/cime_config/machines/cmake_macros/nvidia_pm-cpu.cmake
+++ b/cime_config/machines/cmake_macros/nvidia_pm-cpu.cmake
@@ -9,18 +9,6 @@ if (compile_threaded)
   string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_OPENMP=Off") # work-around for nvidia as kokkos is not passing "-mp" for threaded build
 endif()
 
-# For MCT coupler sources only, try resetting CMAKE_Fortran_FLAGS_DEBUG to avoid setting FPE invalid exceptions
-# https://github.com/E3SM-Project/E3SM/issues/7049
-if (COMP_NAME STREQUAL cpl)
-  set(CMAKE_Fortran_FLAGS_DEBUG " ") # set to blank and rebuild
-  string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -i4 -Mstack_arrays  -Mextend -byteswapio -Mflushz -Kieee -DHAVE_IEEE_ARITHMETIC -Mallocatable=03 -DNO_R16 -traceback")
-  #original string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -O0 -g -Ktrap=fp -Mbounds -Kieee")
-  string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -O0 -g -Mbounds -Kieee")
-  if (compile_threaded)
-    string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -mp")
-  endif()
-endif()
-
 set(MPICC "cc")
 set(MPICXX "CC")
 set(MPIFC "ftn")

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -271,6 +271,7 @@
       <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
       <env name="GATOR_INITIAL_MB">4000MB</env>
+      <env name="LD_LIBRARY_PATH">$ENV{CRAY_LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}</env> <!-- https://github.com/E3SM-Project/E3SM/issues/7117 -->
     </environment_variables>
     <environment_variables compiler="intel" mpilib="mpich">
       <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/adios2/2.9.1/cray-mpich-8.1.25/intel-2023.1.0; else echo "$ADIOS2_ROOT"; fi}</env>


### PR DESCRIPTION
PR only impacts pm-cpu.
After Feb18 NERSC maintenance, there were changes to the SW stack -- new CPE (cray programming environment).
While no module versions were changed, this still broke a few things.
PR https://github.com/E3SM-Project/E3SM/pull/7080 was created as a work-around for DEBUG builds, but this PR reverts those changes and instead uses NERSC staff suggestion:
`export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH`

For now, only changing pm-cpu, but may also be safe and better with other nersc machines, including pm-gpu.

Fixes https://github.com/E3SM-Project/E3SM/issues/7117

[bfb]