### PR TITLE
For pm-cpu, adjust environment variable to avoid issues after Feb18th NERSC maintenance

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -283,6 +283,7 @@
       <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
       <env name="GATOR_INITIAL_MB">4000MB</env>
+      <env name="LD_LIBRARY_PATH">$ENV{CRAY_LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}</env> <!-- https://github.com/E3SM-Project/E3SM/issues/7117 -->
     </environment_variables>
     <environment_variables compiler="intel" mpilib="mpich">
       <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/adios2/2.9.1/cray-mpich-8.1.25/intel-2023.1.0; else echo "$ADIOS2_ROOT"; fi}</env>


### PR DESCRIPTION
Only impacts pm-cpu.
Making same change as on E3SM master: https://github.com/E3SM-Project/E3SM/pull/7144

After Feb18the NERSC maintenance, there were changes to the SW stack -- new CPE (cray programming environment).
While no module versions were changed, this still broke a few things.
NERSC staff suggestion:
`export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH`

Fixes https://github.com/E3SM-Project/E3SM/issues/7117

[bfb]