### PR TITLE
For pm-cpu, add environment variable adjustment to avoid hdf errors with certain netcdf files

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -175,6 +175,7 @@
       <env name="MPICH_COLL_SYNC">MPI_Bcast</env>
       <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
+      <env name="LD_LIBRARY_PATH">$ENV{CRAY_LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}</env> <!-- https://github.com/E3SM-Project/E3SM/issues/7117 -->
     </environment_variables>
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>


### PR DESCRIPTION
PR only impacts pm-cpu.
After Feb18th nersc maintenance, the software stack changed in a way that broke certain tests even though no module versions were changed.
This is work-around suggested by nersc staff and also implemented in e3sm master in https://github.com/E3SM-Project/E3SM/pull/7144

Fixes https://github.com/E3SM-Project/E3SM/issues/7122

[bfb]