### PR TITLE
EAMxx: runtime option to avoid mixing nc in SHOC

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -153,6 +153,8 @@ be lost if SCREAM_HACK_XML is not enabled.
       <!-- Run internal checks on code correctness.
            <= 0: off; >= 1: global hashes over state -->
       <internal_diagnostics_level type="integer">0</internal_diagnostics_level>
+      <!-- FIXME HACK: We need this to allow nc to be mixed in mam only (via nc_tend) but not shoc -->
+      <use_dynamics_advected_only_nc type="logical" doc="use only advected nc from dynamics">false</use_dynamics_advected_only_nc>
       <compute_tendencies
         type="array(string)"
         doc="list of computed fields for which this process will back out tendencies"
@@ -233,8 +235,6 @@ be lost if SCREAM_HACK_XML is not enabled.
       <set_cld_frac_r_to_one type="logical" doc="set P3 input rain cloud fraction to 1 everywhere"  >false</set_cld_frac_r_to_one>
       <set_cld_frac_i_to_one type="logical" doc="set P3 input ice cloud fraction to 1 everywhere"   >false</set_cld_frac_i_to_one>
       <use_separate_ice_liq_frac type="logical" doc="use separate ice and liquid cloud fractions from shoc">false</use_separate_ice_liq_frac>
-      <!-- HACK: P3 should have no knowledge of this stuff! SHOC should decide this and P3 should not care! -->
-      <use_dynamics_advected_only_nc type="logical" doc="use only advected nc from dynamics">false</use_dynamics_advected_only_nc>
     </p3>
 
     <!-- SHOC macrophysics -->

--- a/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.cpp
@@ -13,6 +13,11 @@ MAMGenericInterface::MAMGenericInterface(const ekat::Comm &comm,
   /* Anything that can be initialized without grid information can be
    * initialized here. Like universal constants, mam wetscav options.
    */
+
+  // FIXME: THE FOLLOWING IS A HACK
+  // We need this to allow nc to be mixed in mam (via nc_tend) but not shoc
+   use_dynamics_advected_only_nc_ = 
+      m_params.get<bool>("use_dynamics_advected_only_nc", false);
 }
 // ================================================================
 void MAMGenericInterface::set_aerosol_and_gas_ranges() {
@@ -342,12 +347,13 @@ void MAMGenericInterface::add_tracers_wet_atm() {
   add_tracer<Required>("qi", grid_, q_unit);
 
   // cloud liquid number mixing ratio [1/kg]
-  // HACK: P3 should have no knowledge of this stuff! SHOC should decide this and P3 should not care!
-  // HACK: This is needed because that's how we are declaring the field in P3
-  // TODO: WHY ARE WE NOT UPDATING NC HERE???????????????????????????????????
-  // TODO: IF WE ARE NOT ADVECTING IN SHOC, WHAT ARE DOING HERE?
-  // TODO: Maybe we really should just not mix nc in MAM...
-  add_tracer<Required>("nc", grid_, n_unit, 1, TracerAdvection::DynamicsOnly);
+  // FIXME: THE FOLLOWING IS A HACK
+  // We need this to allow nc to be mixed in mam (via nc_tend) but not shoc
+  if(use_dynamics_advected_only_nc_) {
+    add_tracer<Required>("nc", grid_, n_unit, 1, TracerAdvection::DynamicsOnly);
+  } else {
+    add_tracer<Required>("nc", grid_, n_unit);
+  }
 
   // cloud ice number mixing ratio [1/kg]
   add_tracer<Required>("ni", grid_, n_unit);

--- a/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.hpp
@@ -82,7 +82,11 @@ class MAMGenericInterface : public scream::AtmosphereProcess {
   std::map<std::string, std::pair<Real, Real>> max_min_process_;
   bool set_ranges_{false};
 
+  // FIXME: THE FOLLOWING IS A HACK
+  // We need this to allow nc to be mixed in mam (via nc_tend) but not shoc
+  bool use_dynamics_advected_only_nc_ = false;
+
 };  // MAMGenericInterface
 }  // namespace scream
 
-#endif  // ifdef EAMXX_MAM_CONSTITUTE_FLUXES_FUNCTIONS_HPP
+#endif  // ifdef EAMXX_MAM_GENERIC_PROCESS_HPP

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -81,7 +81,8 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
   add_tracer<Updated>("qr", m_grid, kg/kg, ps);
   add_tracer<Updated>("qi", m_grid, kg/kg, ps);
   add_tracer<Updated>("qm", m_grid, kg/kg, ps);
-  // HACK: P3 should have no knowledge of this stuff! SHOC should decide this and P3 should not care!
+  // FIXME: THE FOLLOWING IS A HACK
+  // We need this to allow nc to be mixed in mam (via nc_tend) but not shoc
   if (runtime_options.use_dynamics_advected_only_nc) {
     add_tracer<Updated>("nc", m_grid, 1/kg,  ps, TracerAdvection::DynamicsOnly);
   } else {

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -137,7 +137,8 @@ struct Functions
     bool set_cld_frac_r_to_one = false;
     bool use_hetfrz_classnuc   = false;
     bool use_separate_ice_liq_frac = false;
-    // HACK: P3 should have no knowledge of this stuff! SHOC should decide this and P3 should not care!
+    // FIXME: THE FOLLOWING IS A HACK
+    // We need this to allow nc to be mixed in mam (via nc_tend) but not shoc
     bool use_dynamics_advected_only_nc = false;
 
     void load_runtime_options_from_file(ekat::ParameterList& params) {
@@ -167,7 +168,8 @@ struct Functions
       set_cld_frac_r_to_one = params.get<bool>("set_cld_frac_r_to_one", set_cld_frac_r_to_one);
       use_hetfrz_classnuc   = params.get<bool>("use_hetfrz_classnuc", use_hetfrz_classnuc);
       use_separate_ice_liq_frac = params.get<bool>("use_separate_ice_liq_frac", use_separate_ice_liq_frac);
-      // HACK: P3 should have no knowledge of this stuff! SHOC should decide this and P3 should not care!
+      // FIXME: THE FOLLOWING IS A HACK
+      // We need this to allow nc to be mixed in mam (via nc_tend) but not shoc
       use_dynamics_advected_only_nc = params.get<bool>("use_dynamics_advected_only_nc", use_dynamics_advected_only_nc);
     }
 

--- a/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_mam_aci_p3_mam_optics_rrtmgp_mam_drydep/input.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_mam_aci_p3_mam_optics_rrtmgp_mam_drydep/input.yaml
@@ -63,8 +63,6 @@ atmosphere_processes:
         do_prescribed_ccn: false
         enable_column_conservation_checks: true
         max_total_ni: 740.0e3
-        # HACK: P3 should have no knowledge of this stuff! SHOC should decide this and P3 should not care!
-        use_dynamics_advected_only_nc: true
       shoc:
         enable_column_conservation_checks: true
         lambda_low: 0.001


### PR DESCRIPTION
add runtime option to avoid mixing nc in SHOC, a requirement by MAM internals ... 

[bfb]
[nml]

---

note while the mixing in mam happens in mam_aci, the mam design is such that it the tracers are set generically outside, so it won't be enough to set use_dynamics_advected_only_nc inside p3 and mam_aci, but one must set it in the generic top group (either mac_mic_aero or physics)