### PR TITLE
MOAB Coupler: Support loading of maps from disk instead of online computation

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -800,6 +800,19 @@ _TESTS = {
         )
     },
 
+    "e3sm_moab_pem" : {
+        "time"  : "01:00:00",
+        "tests" : (
+            "PEM_Vmoab_Ld3.ne4pg2_r05_oQU480.WCYCL1850NS",
+            "PEM_Vmoab_Ld3.ne4pg2_oQU480.WCYCL1850NS",
+            "PEM_Vmoab_Ld3.ne4pg2_oQU480.F1850",
+            "PEM_Vmoab_Ld3.ne4pg2_ne4pg2.I1850CNPRDCTCBCTOP",
+            "PEM_Vmoab_Ld3.T62_oQU240wLI.GMPAS-IAF",
+            "PEM_Vmoab_Ld3.T62_oQU120.CMPASO-NYF",
+            "PEM_Vmoab_Ld3.r05_r05.RMOSGPCC",
+        )
+    },
+
 
 
     "e3sm_gpuacc" : {

--- a/components/eam/src/cpl/atm_comp_mct.F90
+++ b/components/eam/src/cpl/atm_comp_mct.F90
@@ -3,7 +3,7 @@ module atm_comp_mct
   use pio              , only: file_desc_t, io_desc_t, var_desc_t, pio_double, pio_def_dim, &
                                pio_put_att, pio_enddef, pio_initdecomp, pio_read_darray, pio_freedecomp, &
                                pio_closefile, pio_write_darray, pio_def_var, pio_inq_varid, &
-	                       pio_noerr, pio_bcast_error, pio_internal_error, pio_seterrorhandling 
+	                       pio_noerr, pio_bcast_error, pio_internal_error, pio_seterrorhandling
   use mct_mod
   use seq_comm_mct     , only: info_taskmap_comp
   use seq_cdata_mod
@@ -23,7 +23,7 @@ module atm_comp_mct
   use shr_taskmap_mod  , only: shr_taskmap_write
 
   use cam_cpl_indices
-  ! it has atm_import, atm_export 
+  ! it has atm_import, atm_export
   use atm_import_export
   !  atm_export_moab is private here, atm_import_moab too
 
@@ -33,9 +33,9 @@ module atm_comp_mct
   use radiation        , only: radiation_do, radiation_nextsw_cday
   use phys_grid        , only: get_ncols_p, ngcols, get_gcol_p, get_rlat_all_p, &
 	                       get_rlon_all_p, get_area_all_p
-  use ppgrid           , only: pcols, begchunk, endchunk       
+  use ppgrid           , only: pcols, begchunk, endchunk
   use dyn_grid         , only: get_horiz_grid_dim_d
-  use camsrfexch       , only: cam_out_t, cam_in_t     
+  use camsrfexch       , only: cam_out_t, cam_in_t
   use cam_restart      , only: get_restcase, get_restartdir
   use cam_history      , only: outfld, ctitle
   use cam_abortutils       , only: endrun
@@ -62,7 +62,7 @@ module atm_comp_mct
 
 #ifdef HAVE_MOAB
   use seq_comm_mct     , only: mphaid ! atm physics grid id in MOAB, on atm pes
-  use iso_c_binding 
+  use iso_c_binding
   use seq_comm_mct,     only : num_moab_exports
 #ifdef MOABCOMP
   use seq_comm_mct, only:  seq_comm_compare_mb_mct
@@ -114,7 +114,7 @@ module atm_comp_mct
   ! Filename specifier for restart surface file
   character(len=cl) :: rsfilename_spec_cam
 
-  ! Are all surface types present   
+  ! Are all surface types present
   logical :: lnd_present ! if true => land is present
   logical :: ocn_present ! if true => ocean is present
 
@@ -122,7 +122,7 @@ module atm_comp_mct
   type(seq_infodata_type), pointer :: infodata
 
 #ifdef HAVE_MOAB
-  ! to store all fields to be set in moab 
+  ! to store all fields to be set in moab
   integer , private :: mblsize, totalmbls, nsend, totalmbls_r, nrecv
   real(r8) , allocatable, private :: a2x_am(:,:) ! atm to coupler, on atm mesh, on atm component pes
   real(r8) , allocatable, private :: x2a_am(:,:) ! coupler to atm, on atm mesh, on atm component pes
@@ -133,7 +133,7 @@ module atm_comp_mct
   integer :: rank2
 #endif
 
-#endif 
+#endif
 
 !================================================================================
 CONTAINS
@@ -148,7 +148,7 @@ CONTAINS
     type(ESMF_Clock),intent(inout)              :: EClock
     type(seq_cdata), intent(inout)              :: cdata_a
     type(mct_aVect), intent(inout)              :: x2a_a
-    type(mct_aVect), intent(inout)              :: a2x_a   
+    type(mct_aVect), intent(inout)              :: a2x_a
     character(len=*), optional,   intent(IN)    :: NLFilename ! Namelist filename
     !
     ! Locals
@@ -163,11 +163,11 @@ CONTAINS
     integer :: iradsw
     logical :: exists           ! true if file exists
     real(r8):: nextsw_cday      ! calendar of next atm shortwave
-    integer :: stepno           ! time step			 
+    integer :: stepno           ! time step
     integer :: dtime_sync       ! integer timestep size
     integer :: currentymd       ! current year-month-day
     integer :: dtime            ! time step increment (sec)
-    integer :: atm_cpl_dt       ! driver atm coupling time step 
+    integer :: atm_cpl_dt       ! driver atm coupling time step
     integer :: nstep            ! CAM nstep
     real(r8):: caldayp1         ! CAM calendar day for for next cam time step
     integer :: dtime_cam        ! Time-step increment (sec)
@@ -202,7 +202,7 @@ CONTAINS
     integer :: size_list, index_list, ent_type
     type(mct_string)    :: mctOStr  !
     character(CXX) ::tagname, mct_field, modelStr
-#endif 
+#endif
 
     !-----------------------------------------------------------------------
     !
@@ -212,8 +212,8 @@ CONTAINS
     if(masterproc) then
       lbnum=1
       call memmon_dump_fort('memmon.out','atm_init_mct:start::',lbnum)
-    endif                      
-#endif                         
+    endif
+#endif
 
     call seq_cdata_setptrs(cdata_a, ID=ATMID, mpicom=mpicom_atm, &
          gsMap=gsMap_atm, dom=dom_a, infodata=infodata)
@@ -221,10 +221,10 @@ CONTAINS
 #ifdef MOABCOMP
     mpicom_atm_moab = mpicom_atm ! just store it now, for later use
     call shr_mpi_commrank( mpicom_atm_moab, rank2 )
-#endif 
+#endif
 
     if (first_time) then
-       
+
        call cam_instance_init(ATMID)
 
        ! Set filename specifier for restart surface file
@@ -238,9 +238,9 @@ CONTAINS
        ! Initialize MPI for CAM
 
        call spmdinit(mpicom_atm, calc_proc_smp_map=.false.)
-       
+
        ! Redirect share output to cam log
-       
+
        if (masterproc) then
           inquire(file='atm_modelio.nml'//trim(inst_suffix), exist=exists)
           if (exists) then
@@ -249,7 +249,7 @@ CONTAINS
           endif
           write(iulog,*) "CAM atmosphere model initialization"
        endif
-       
+
        call shr_file_getLogUnit (shrlogunit)
        call shr_file_getLogLevel(shrloglev)
        call shr_file_setLogUnit (iulog)
@@ -295,14 +295,14 @@ CONTAINS
        call shr_sys_flush(iulog)
        call t_stopf('shr_taskmap_write')
 
-       ! 
-       ! Consistency check                              
+       !
+       ! Consistency check
        !
        if (co2_readFlux_ocn .and. index_x2a_Faoo_fco2_ocn /= 0) then
           write(iulog,*)'error co2_readFlux_ocn and index_x2a_Faoo_fco2_ocn cannot both be active'
           call shr_sys_abort()
        end if
-       ! 
+       !
        ! Get data from infodata object
        !
        call seq_infodata_GetData( infodata,                                           &
@@ -357,11 +357,11 @@ CONTAINS
                perpetual_ymd=perpetual_ymd )
        end if
        !
-       ! First phase of cam initialization 
-       ! Initialize mpicom_atm, allocate cam_in and cam_out and determine 
-       ! atm decomposition (needed to initialize gsmap) 
+       ! First phase of cam initialization
+       ! Initialize mpicom_atm, allocate cam_in and cam_out and determine
+       ! atm decomposition (needed to initialize gsmap)
        ! for an initial run, cam_in and cam_out are allocated in cam_initial
-       ! for a restart/branch run, cam_in and cam_out are allocated in restart 
+       ! for a restart/branch run, cam_in and cam_out are allocated in restart
        ! Set defaults then override with user-specified input and initialize time manager
        ! Note that the following arguments are needed to cam_init for timemgr_restart only
        !
@@ -395,8 +395,8 @@ CONTAINS
        !
        call mct_aVect_init(a2x_a, rList=seq_flds_a2x_fields, lsize=lsize)
        call mct_aVect_zero(a2x_a)
-       
-       call mct_aVect_init(x2a_a, rList=seq_flds_x2a_fields, lsize=lsize) 
+
+       call mct_aVect_init(x2a_a, rList=seq_flds_x2a_fields, lsize=lsize)
        call mct_aVect_zero(x2a_a)
        !
        ! Create initial atm export state
@@ -442,21 +442,41 @@ CONTAINS
           nextsw_cday = get_curr_calday()
           call seq_infodata_PutData( infodata, nextsw_cday=nextsw_cday )
        end if
-       
+
        ! End redirection of share output to cam log
-       
+
        call shr_file_setLogUnit (shrlogunit)
        call shr_file_setLogLevel(shrloglev)
+       ! when called first time, initialize MOAB atm phis grid, and create the mesh
+       ! on the atm
+#ifdef HAVE_MOAB
+       call init_moab_atm_phys( cdata_a )
+       mblsize = lsize
+       nsend = mct_avect_nRattr(a2x_a)
+       totalmbls = mblsize * nsend   ! size of the double array
+       allocate (a2x_am(mblsize, nsend) )
+       a2x_am = 0.0
+
+       nrecv = mct_avect_nRattr(x2a_a)
+       totalmbls_r = mblsize * nrecv   ! size of the double array used to receive
+       allocate (x2a_am(mblsize, nrecv) ) ! these will be received by moab tags, then used to set cam in surf data
+       x2a_am = 0.0
+       !
+       ! Create initial atm export state inside moab
+       !
+       call atm_export_moab(Eclock, cam_out )
+
+#endif
 
        first_time = .false.
 
     else ! so here first_time == .false.
-       
+
        ! For initial run, run cam radiation/clouds and return
        ! For restart run, read restart x2a_a
        ! Note - a2x_a is computed upon the completion of the previous run - cam_run1 is called
        ! only for the purposes of finishing the flux averaged calculation to compute a2x_a
-       ! Note - cam_run1 is called on restart only to have cam internal state consistent with the 
+       ! Note - cam_run1 is called on restart only to have cam internal state consistent with the
        ! a2x_a state sent to the coupler
 
        !Obtain the precipitation downscaling method from the land model
@@ -488,23 +508,23 @@ CONTAINS
           call mct_list_clean(temp_list)
 
 #endif
-       ! so the cam import is before moab    
+       ! so the cam import is before moab
           call atm_import( x2a_a%rattr, cam_in )
 #ifdef HAVE_MOAB
        ! move moab import after cam import, so moab takes precedence
           call atm_import_moab(Eclock, cam_in)
-#endif    
+#endif
 
 
 
           call t_startf('CAM_run1')
-          call cam_run1 ( cam_in, cam_out ) 
+          call cam_run1 ( cam_in, cam_out )
           call t_stopf('CAM_run1')
-        
+
           call atm_export( cam_out, a2x_a%rattr )
 #ifdef HAVE_MOAB
           call atm_export_moab(Eclock, cam_out)
-#endif   
+#endif
        else ! if (StepNo != 0) then
 
           call t_startf('atm_read_srfrest_mct')
@@ -519,34 +539,34 @@ CONTAINS
           call atm_import( x2a_a%rattr, cam_in, .true. )
 #ifdef HAVE_MOAB
           call atm_import_moab(Eclock, cam_in, .true. )
-#endif   
+#endif
 
           call t_startf('cam_run1')
-          call cam_run1 ( cam_in, cam_out ) 
+          call cam_run1 ( cam_in, cam_out )
           call t_stopf('cam_run1')
        end if
 
        ! Compute time of next radiation computation, like in run method for exact restart
 
        call seq_timemgr_EClockGetData(Eclock,dtime=atm_cpl_dt)
-       dtime = get_step_size()          
+       dtime = get_step_size()
        nstep = get_nstep()
        if (nstep < 1 .or. dtime < atm_cpl_dt) then
-          nextsw_cday = radiation_nextsw_cday() 
+          nextsw_cday = radiation_nextsw_cday()
        else if (dtime == atm_cpl_dt) then
           caldayp1 = get_curr_calday(offset=int(dtime))
-          nextsw_cday = radiation_nextsw_cday() 
+          nextsw_cday = radiation_nextsw_cday()
           if (caldayp1 /= nextsw_cday) nextsw_cday = -1._r8
        else
           call shr_sys_abort('dtime must be less than or equal to atm_cpl_dt')
        end if
-       call seq_infodata_PutData( infodata, nextsw_cday=nextsw_cday ) 
+       call seq_infodata_PutData( infodata, nextsw_cday=nextsw_cday )
 
        ! End redirection of share output to cam log
-       
+
        call shr_file_setLogUnit (shrlogunit)
        call shr_file_setLogLevel(shrloglev)
-       
+
     end if
 
 #if (defined _MEMTRACE )
@@ -556,7 +576,7 @@ CONTAINS
       call memmon_reset_addr()
     endif
 #endif
-    
+
     call shr_sys_flush(iulog)
 
  end subroutine atm_init_mct
@@ -573,7 +593,7 @@ CONTAINS
     use constituents,    only: pcnst
     use shr_sys_mod,     only: shr_sys_flush
 
-    ! 
+    !
     ! Arguments
     !
     type(ESMF_Clock)            ,intent(inout) :: EClock
@@ -584,13 +604,13 @@ CONTAINS
     ! Local variables
     !
     integer :: lsize           ! size of attribute vector
-    integer :: StepNo          ! time step			 
+    integer :: StepNo          ! time step
     integer :: DTime_Sync      ! integer timestep size
     integer :: CurrentYMD      ! current year-month-day
-    integer :: iradsw          ! shortwave radation frequency (time steps) 
+    integer :: iradsw          ! shortwave radation frequency (time steps)
     logical :: dosend          ! true => send data back to driver
     integer :: dtime           ! time step increment (sec)
-    integer :: atm_cpl_dt      ! driver atm coupling time step 
+    integer :: atm_cpl_dt      ! driver atm coupling time step
     integer :: ymd_sync        ! Sync date (YYYYMMDD)
     integer :: yr_sync         ! Sync current year
     integer :: mon_sync        ! Sync current month
@@ -619,7 +639,7 @@ CONTAINS
     integer :: size_list, index_list, ent_type
     type(mct_string)    :: mctOStr  !
     character(CXX) ::tagname, mct_field, modelStr
-#endif 
+#endif
 
 #if (defined _MEMTRACE)
     if(masterproc) then
@@ -629,17 +649,17 @@ CONTAINS
 #endif
 
     ! Redirect share output to cam log
-    
+
     call shr_file_getLogUnit (shrlogunit)
     call shr_file_getLogLevel(shrloglev)
     call shr_file_setLogUnit (iulog)
-    
+
     ! Note that sync clock time should match cam time at end of time step/loop not beginning
-    
+
     call seq_timemgr_EClockGetData(EClock,curr_ymd=ymd_sync,curr_tod=tod_sync, &
        curr_yr=yr_sync,curr_mon=mon_sync,curr_day=day_sync)
 
-    !load orbital parameters 
+    !load orbital parameters
 
     call seq_infodata_GetData( infodata,                                           &
        orb_eccen=eccen, orb_mvelpp=mvelpp, orb_lambm0=lambm0, orb_obliqr=obliqr)
@@ -672,38 +692,38 @@ CONTAINS
 
      call atm_import_moab(Eclock, cam_in)
 #endif
-   
+
     call t_stopf  ('CAM_import')
-    
+
     ! Cycle over all time steps in the atm coupling interval
-    
+
     dosend = .false.
     do while (.not. dosend)
 
        ! Determine if dosend
        ! When time is not updated at the beginning of the loop - then return only if
        ! are in sync with clock before time is updated
-       
+
        call get_curr_date( yr, mon, day, tod )
        ymd = yr*10000 + mon*100 + day
        tod = tod
        dosend = (seq_timemgr_EClockDateInSync( EClock, ymd, tod))
-       
+
        ! Determine if time to write cam restart and stop
-       
+
        rstwr = .false.
        if (rstwr_sync .and. dosend) rstwr = .true.
        nlend = .false.
        if (nlend_sync .and. dosend) nlend = .true.
-       
-       ! Single column specific input 
-       
+
+       ! Single column specific input
+
        if (single_column) then
           call scam_use_iop_srf( cam_in )
        endif
 
        ! Run CAM (run2, run3, run4)
-       
+
        call t_startf ('CAM_run2')
        call cam_run2( cam_out, cam_in )
        call t_stopf  ('CAM_run2')
@@ -711,26 +731,26 @@ CONTAINS
        call t_startf ('CAM_run3')
        call cam_run3( cam_out )
        call t_stopf  ('CAM_run3')
-       
+
        call t_startf ('CAM_run4')
        call cam_run4( cam_out, cam_in, rstwr, nlend, &
             yr_spec=yr_sync, mon_spec=mon_sync, day_spec=day_sync, sec_spec=tod_sync)
        call t_stopf  ('CAM_run4')
-       
-       ! Advance cam time step 
-       
+
+       ! Advance cam time step
+
        call t_startf ('CAM_adv_timestep')
        call advance_timestep()
        call t_stopf  ('CAM_adv_timestep')
-       
+
        ! Run cam radiation/clouds (run1)
-          
+
        call t_startf ('CAM_run1')
-       call cam_run1 ( cam_in, cam_out ) 
+       call cam_run1 ( cam_in, cam_out )
        call t_stopf  ('CAM_run1')
-       
+
        ! Map output from cam to mct data structures
-       
+
        call t_startf ('CAM_export')
        call atm_export( cam_out, a2x_a%rattr )
 #ifdef HAVE_MOAB
@@ -741,30 +761,30 @@ CONTAINS
 
 #endif
        call t_stopf ('CAM_export')
-       
+
     end do
 
 
 
-    ! Get time of next radiation calculation - albedos will need to be 
+    ! Get time of next radiation calculation - albedos will need to be
     ! calculated by each surface model at this time
-    
+
     call seq_timemgr_EClockGetData(Eclock,dtime=atm_cpl_dt)
-    dtime = get_step_size()          
+    dtime = get_step_size()
     if (dtime < atm_cpl_dt) then
-       nextsw_cday = radiation_nextsw_cday() 
+       nextsw_cday = radiation_nextsw_cday()
     else if (dtime == atm_cpl_dt) then
        caldayp1 = get_curr_calday(offset=int(dtime))
-       nextsw_cday = radiation_nextsw_cday() 
+       nextsw_cday = radiation_nextsw_cday()
        if (caldayp1 /= nextsw_cday) nextsw_cday = -1._r8
     else
        call shr_sys_abort('dtime must be less than or equal to atm_cpl_dt')
     end if
 
-    call seq_infodata_PutData( infodata, nextsw_cday=nextsw_cday ) 
-    
+    call seq_infodata_PutData( infodata, nextsw_cday=nextsw_cday )
+
     ! Write merged surface data restart file if appropriate
-    
+
     if (rstwr_sync) then
        call t_startf('atm_write_srfrest_mct')
        call atm_write_srfrest_mct( x2a_a, a2x_a, &
@@ -775,9 +795,9 @@ CONTAINS
             mon_spec=mon_sync, day_spec=day_sync, sec_spec=tod_sync)
 #endif
     end if
-    
-    ! Check for consistency of internal cam clock with master sync clock 
-    
+
+    ! Check for consistency of internal cam clock with master sync clock
+
     dtime = get_step_size()
     call get_curr_date( yr, mon, day, tod, offset=-dtime )
     ymd = yr*10000 + mon*100 + day
@@ -788,7 +808,7 @@ CONTAINS
        write(iulog,*)'sync ymd=',ymd_sync,' sync tod= ',tod_sync
        call shr_sys_abort( subname//': CAM clock is not in sync with master Sync Clock' )
     end if
-    
+
     ! End redirection of share output to cam log
 
     call shr_file_setLogUnit (shrlogunit)
@@ -842,7 +862,7 @@ CONTAINS
     ! Build the atmosphere grid numbering for MCT
     ! NOTE:  Numbering scheme is: West to East and South to North
     ! starting at south pole.  Should be the same as what's used in SCRIP
-    
+
     ! Determine global seg map
 
     sizebuf=0
@@ -881,11 +901,11 @@ CONTAINS
     !
     integer        , intent(in)   :: lsize
     type(mct_gsMap), intent(in)   :: gsMap_a
-    type(mct_ggrid), intent(inout):: dom_a  
+    type(mct_ggrid), intent(inout):: dom_a
     !
     ! Local Variables
     !
-    integer  :: n,i,c,ncols           ! indices	
+    integer  :: n,i,c,ncols           ! indices
     real(r8) :: lats(pcols)           ! array of chunk latitudes
     real(r8) :: lons(pcols)           ! array of chunk longitude
     real(r8) :: area(pcols)           ! area in radians squared for each grid point
@@ -912,13 +932,13 @@ CONTAINS
     ! Determine domain (numbering scheme is: West to East and South to North to South pole)
     ! Initialize attribute vector with special value
     !
-    data(:) = -9999.0_R8 
-    call mct_gGrid_importRAttr(dom_a,"lat"  ,data,lsize) 
-    call mct_gGrid_importRAttr(dom_a,"lon"  ,data,lsize) 
-    call mct_gGrid_importRAttr(dom_a,"area" ,data,lsize) 
-    call mct_gGrid_importRAttr(dom_a,"aream",data,lsize) 
-    data(:) = 0.0_R8     
-    call mct_gGrid_importRAttr(dom_a,"mask" ,data,lsize) 
+    data(:) = -9999.0_R8
+    call mct_gGrid_importRAttr(dom_a,"lat"  ,data,lsize)
+    call mct_gGrid_importRAttr(dom_a,"lon"  ,data,lsize)
+    call mct_gGrid_importRAttr(dom_a,"area" ,data,lsize)
+    call mct_gGrid_importRAttr(dom_a,"aream",data,lsize)
+    data(:) = 0.0_R8
+    call mct_gGrid_importRAttr(dom_a,"mask" ,data,lsize)
     data(:) = 1.0_R8
     call mct_gGrid_importRAttr(dom_a,"frac" ,data,lsize)
     !
@@ -933,7 +953,7 @@ CONTAINS
           data(n) = lats(i)*radtodeg
        end do
     end do
-    call mct_gGrid_importRAttr(dom_a,"lat",data,lsize) 
+    call mct_gGrid_importRAttr(dom_a,"lat",data,lsize)
 
     n=0
     do c = begchunk, endchunk
@@ -944,7 +964,7 @@ CONTAINS
           data(n) = lons(i)*radtodeg
        end do
     end do
-    call mct_gGrid_importRAttr(dom_a,"lon",data,lsize) 
+    call mct_gGrid_importRAttr(dom_a,"lon",data,lsize)
 
     n=0
     do c = begchunk, endchunk
@@ -952,10 +972,10 @@ CONTAINS
        call get_area_all_p(c, ncols, area)
        do i=1,ncols
           n = n+1
-          data(n) = area(i) 
+          data(n) = area(i)
        end do
     end do
-    call mct_gGrid_importRAttr(dom_a,"area",data,lsize) 
+    call mct_gGrid_importRAttr(dom_a,"area",data,lsize)
 
     n=0
     do c = begchunk, endchunk
@@ -965,7 +985,7 @@ CONTAINS
           data(n) = 1._r8 ! mask
        end do
     end do
-    call mct_gGrid_importRAttr(dom_a,"mask"   ,data,lsize) 
+    call mct_gGrid_importRAttr(dom_a,"mask"   ,data,lsize)
     deallocate(data)
 
   end subroutine atm_domain_mct
@@ -982,7 +1002,7 @@ CONTAINS
    ! Arguments
    !
    type(ESMF_Clock),intent(inout) :: EClock
-   ! 
+   !
    ! Local variables
    !
    integer               :: rcode        ! return error code
@@ -1007,19 +1027,19 @@ CONTAINS
    ! Determine and open surface restart dataset
 
    call seq_timemgr_EClockGetData( EClock, curr_yr=yr_spec,curr_mon=mon_spec, &
-        curr_day=day_spec, curr_tod=sec_spec ) 
+        curr_day=day_spec, curr_tod=sec_spec )
    fname_srf_cam = interpret_filename_spec( rsfilename_spec_cam, case=get_restcase(), &
         yr_spec=yr_spec, mon_spec=mon_spec, day_spec=day_spec, sec_spec= sec_spec )
    moab_fname_srf_cam = 'moab_'//trim(fname_srf_cam)
    moab_pname_srf_cam = trim(get_restartdir() )//trim(moab_fname_srf_cam)
    call getfil(moab_pname_srf_cam, moab_fname_srf_cam)
-   
+
    call cam_pio_openfile(File, moab_fname_srf_cam, 0)
-   
+
    call pio_initdecomp(pio_subsystem, pio_double, (/ngcols/), global_ids, iodesc)
-   
+
    allocate(tmp(size(global_ids)))
-   
+
    call mct_list_init(temp_list, seq_flds_x2a_fields)
    size_list=mct_list_nitem (temp_list) ! it should be the same as nrecv
 
@@ -1049,7 +1069,7 @@ CONTAINS
       call endrun('Error: fail to set  seq_flds_a2x_fields for atm physgrid moab mesh in restart')
     endif
 
-   
+
    call mct_list_clean(temp_list)
 
    call mct_list_init(temp_list, seq_flds_a2x_fields)
@@ -1078,7 +1098,7 @@ CONTAINS
     if ( ierr > 0) then
       call endrun('Error: fail to set  seq_flds_a2x_fields for atm physgrid moab mesh in restart')
     endif
-   
+
    ! write moab phys atm after reading restart surface file
 
    call pio_freedecomp(File,iodesc)
@@ -1127,23 +1147,23 @@ CONTAINS
       ! Determine and open surface restart dataset
 
    moab_fname_srf_cam = 'moab_'//trim(fname_srf_cam)
-   
+
    call cam_pio_createfile(File, trim(moab_fname_srf_cam))
    if (masterproc) then
-      write(iulog,*)'create file :', trim(moab_fname_srf_cam) 
+      write(iulog,*)'create file :', trim(moab_fname_srf_cam)
    end if
 
    call pio_initdecomp(pio_subsystem, pio_double, (/ngcols/), global_ids, iodesc)
    allocate(tmp(size(global_ids)))
-   
+
    rcode = pio_def_dim(File,'x2a_nx',ngcols,dimid(1))
    call mct_list_init(temp_list ,seq_flds_x2a_fields)
    size_list=mct_list_nitem (temp_list) ! it should be the same as nrecv
    allocate(varid_x2a(size_list))
    if (masterproc) then
-      write(iulog,*)'size list:', size_list, seq_flds_x2a_fields 
+      write(iulog,*)'size list:', size_list, seq_flds_x2a_fields
    end if
-    
+
    do k = 1, size_list
       call mct_list_get(mstring, k, temp_list)
       itemc = mct_string_toChar(mstring)
@@ -1156,7 +1176,7 @@ CONTAINS
    call mct_list_init(temp_list ,seq_flds_a2x_fields)
    size_list=mct_list_nitem (temp_list) ! it should be the same as nsend
    allocate(varid_a2x(size_list))
-   
+
    rcode = pio_def_dim(File,'a2x_nx',ngcols,dimid(1))
    do k = 1,size_list
       call mct_list_get(mstring,k,temp_list)
@@ -1168,7 +1188,7 @@ CONTAINS
 
    rcode = pio_enddef(File)  ! don't check return code, might be enddef already
 
-! do we need to fill it up with values? 
+! do we need to fill it up with values?
    ! ccsm sign convention is that fluxes are positive downward
    tagname=trim(seq_flds_x2a_fields)//C_NULL_CHAR
    ent_type = 0 ! vertices, point cloud
@@ -1189,7 +1209,7 @@ CONTAINS
    end do
 
    do k=1,nsend
-      call pio_write_darray(File, varid_a2x(k), iodesc, a2x_am(:,k), rcode)       
+      call pio_write_darray(File, varid_a2x(k), iodesc, a2x_am(:,k), rcode)
    end do
 
    deallocate(varid_x2a, varid_a2x)
@@ -1213,7 +1233,7 @@ CONTAINS
     type(ESMF_Clock),intent(inout) :: EClock
     type(mct_aVect), intent(inout) :: x2a_a
     type(mct_aVect), intent(inout) :: a2x_a
-    ! 
+    !
     ! Local variables
     !
     integer               :: rcode        ! return error code
@@ -1233,16 +1253,16 @@ CONTAINS
     ! Determine and open surface restart dataset
 
     call seq_timemgr_EClockGetData( EClock, curr_yr=yr_spec,curr_mon=mon_spec, &
-         curr_day=day_spec, curr_tod=sec_spec ) 
+         curr_day=day_spec, curr_tod=sec_spec )
     fname_srf_cam = interpret_filename_spec( rsfilename_spec_cam, case=get_restcase(), &
          yr_spec=yr_spec, mon_spec=mon_spec, day_spec=day_spec, sec_spec= sec_spec )
     pname_srf_cam = trim(get_restartdir() )//fname_srf_cam
     call getfil(pname_srf_cam, fname_srf_cam)
-    
+
     call cam_pio_openfile(File, fname_srf_cam, 0)
     call pio_initdecomp(pio_subsystem, pio_double, (/ngcols/), dof, iodesc)
     allocate(tmp(size(dof)))
-    
+
     nf_x2a = mct_aVect_nRattr(x2a_a)
     do k=1,nf_x2a
        call mct_aVect_getRList(mstring,k,x2a_a)
@@ -1283,7 +1303,7 @@ CONTAINS
 
   !===========================================================================================
 
-  subroutine atm_write_srfrest_mct( x2a_a, a2x_a, & 
+  subroutine atm_write_srfrest_mct( x2a_a, a2x_a, &
        yr_spec, mon_spec, day_spec, sec_spec)
 
     !-----------------------------------------------------------------------
@@ -1320,7 +1340,7 @@ CONTAINS
 
     nf_x2a = mct_aVect_nRattr(x2a_a)
     allocate(varid_x2a(nf_x2a))
-    
+
     rcode = pio_def_dim(File,'x2a_nx',ngcols,dimid(1))
     do k = 1,nf_x2a
        call mct_aVect_getRList(mstring,k,x2a_a)
@@ -1332,7 +1352,7 @@ CONTAINS
 
     nf_a2x = mct_aVect_nRattr(a2x_a)
     allocate(varid_a2x(nf_a2x))
-    
+
     rcode = pio_def_dim(File,'a2x_nx',ngcols,dimid(1))
     do k = 1,nf_a2x
        call mct_aVect_getRList(mstring,k,a2x_a)
@@ -1350,7 +1370,7 @@ CONTAINS
     end do
 
     do k=1,nf_a2x
-       call pio_write_darray(File, varid_a2x(k), iodesc, a2x_a%rattr(k,:), rcode)       
+       call pio_write_darray(File, varid_a2x(k), iodesc, a2x_a%rattr(k,:), rcode)
     end do
 
     deallocate(varid_x2a, varid_a2x)
@@ -1400,7 +1420,7 @@ CONTAINS
     real(r8), parameter:: radtodeg = 180.0_r8/SHR_CONST_PI
 
     character*100 outfile, wopts
-    character(CXX) :: tagname ! will store all seq_flds_a2x_fields 
+    character(CXX) :: tagname ! will store all seq_flds_a2x_fields
     character*32 appname
 
 
@@ -1494,8 +1514,8 @@ CONTAINS
     if (ierr > 0 )  &
       call endrun('Error: fail to set chunk id tag tag ')
 
-    ! use areavals for area, aream; define also dom fields 
-    ! define all  on moab 
+    ! use areavals for area, aream; define also dom fields
+    ! define all  on moab
 
     tagname=trim(seq_flds_dom_fields)//C_NULL_CHAR !  mask is double too lat:lon:hgt:area:aream:mask:frac
     tagtype = 1 ! dense, double
@@ -1515,9 +1535,9 @@ CONTAINS
       call endrun('Error: fail to set mask tag ')
 
     areavals = 1._r8 ! double
-    
+
     ! set lat, lon, and frac tags at the same time, reusing the moab_vert_coords array already allocated
-    ! we set all at the same time, so use the 1-d array carefully, with values interlaced/or not 
+    ! we set all at the same time, so use the 1-d array carefully, with values interlaced/or not
     n=0
     do c = begchunk, endchunk
        ncols = get_ncols_p(c)
@@ -1546,7 +1566,7 @@ CONTAINS
     if (ierr > 0 )  &
       call endrun('Error: fail to write the atm phys mesh file')
 #endif
-   ! define fields seq_flds_a2x_fields 
+   ! define fields seq_flds_a2x_fields
     tagtype = 1  ! dense, double
     numco = 1 !  one value per vertex / entity
     tagname = trim(seq_flds_a2x_fields)//C_NULL_CHAR
@@ -1554,7 +1574,7 @@ CONTAINS
     if ( ierr > 0) then
        call endrun('Error: fail to define seq_flds_a2x_fields for atm physgrid moab mesh')
     endif
-    ! make sure this is defined too; it could have the same fields, but in different order, or really different 
+    ! make sure this is defined too; it could have the same fields, but in different order, or really different
     ! fields; need to make sure we have them
     tagname = trim(seq_flds_x2a_fields)//C_NULL_CHAR
     ierr = iMOAB_DefineTagStorage(mphaid, tagname, tagtype, numco,  tagindex )
@@ -1572,12 +1592,16 @@ CONTAINS
   subroutine atm_export_moab(Eclock, cam_out)
   !-------------------------------------------------------------------
     use camsrfexch, only: cam_out_t
-    use phys_grid , only: get_ncols_p, get_nlcols_p
+    use phys_grid , only: get_ncols_p
     use ppgrid    , only: begchunk, endchunk
-    use seq_comm_mct, only: mphaid ! imoab pid for atm physics
     use cam_abortutils       , only: endrun
+    use cam_cpl_indices
+    use phys_control, only: phys_getopts
+    use lnd_infodata, only: precip_downscaling_method
+
+    use seq_comm_mct, only: mphaid ! imoab pid for atm physics
     use iMOAB, only:  iMOAB_WriteMesh,  iMOAB_SetDoubleTagStorage
-    use iso_c_binding 
+    use iso_c_binding
     !
     ! Arguments
     !
@@ -1585,33 +1609,51 @@ CONTAINS
     type(cam_out_t), intent(in)    :: cam_out(begchunk:endchunk)
 
     integer tagtype, numco, ent_type
-    character(CXX) ::  tagname ! 
+    character(CXX) ::  tagname !
 
-    integer ierr, c, nlcols, ig, i, ncols
-    integer  :: cur_atm_stepno
+    integer :: i,c,n,ig         ! indices
+    integer :: ncols            ! Number of columns
+    logical :: linearize_pbl_winds
+    integer :: ierr             ! MOAB error code
 
 #ifdef MOABDEBUG
+    integer  :: cur_atm_stepno
     character*100 outfile, wopts, lnum
     integer, save :: local_count = 0
     character*100 lnum2
-#endif 
+#endif
+
+    call phys_getopts(linearize_pbl_winds_out=linearize_pbl_winds)
+
     ! Copy from component arrays into chunk array data structure
     ! Rearrange data from chunk structure into lat-lon buffer and subsequently
     ! create double array for moab tags
-
     ig=1
     do c=begchunk, endchunk
        ncols = get_ncols_p(c)
        do i=1,ncols
           a2x_am(ig, index_a2x_Sa_pslv   ) = cam_out(c)%psl(i)
-          a2x_am(ig, index_a2x_Sa_z      ) = cam_out(c)%zbot(i)   
-          a2x_am(ig, index_a2x_Sa_u      ) = cam_out(c)%ubot(i)   
-          a2x_am(ig, index_a2x_Sa_v      ) = cam_out(c)%vbot(i)   
-          a2x_am(ig, index_a2x_Sa_tbot   ) = cam_out(c)%tbot(i)   
-          a2x_am(ig, index_a2x_Sa_ptem   ) = cam_out(c)%thbot(i)  
-          a2x_am(ig, index_a2x_Sa_pbot   ) = cam_out(c)%pbot(i)   
-          a2x_am(ig, index_a2x_Sa_shum   ) = cam_out(c)%qbot(i,1) 
+          a2x_am(ig, index_a2x_Sa_z      ) = cam_out(c)%zbot(i)
+          a2x_am(ig, index_a2x_Sa_u      ) = cam_out(c)%ubot(i)
+          a2x_am(ig, index_a2x_Sa_v      ) = cam_out(c)%vbot(i)
+          if (linearize_pbl_winds) then
+             a2x_am(ig, index_a2x_Sa_wsresp) = cam_out(c)%wsresp(i)
+             a2x_am(ig, index_a2x_Sa_tau_est) = cam_out(c)%tau_est(i)
+          end if
+          ! This check is only for SCREAMv0; otherwise gustiness should always
+          ! be exported.
+          if (index_a2x_Sa_ugust /= 0) then
+             a2x_am(ig, index_a2x_Sa_ugust) = cam_out(c)%ugust(i)
+          end if
+          if (index_a2x_Sa_topo /= 0) then
+             a2x_am(ig, index_a2x_Sa_topo   ) = 0.0 ! unsure how to get this data from ATM
+          end if
+          a2x_am(ig, index_a2x_Sa_tbot   ) = cam_out(c)%tbot(i)
+          a2x_am(ig, index_a2x_Sa_ptem   ) = cam_out(c)%thbot(i)
+          a2x_am(ig, index_a2x_Sa_pbot   ) = cam_out(c)%pbot(i)
+          a2x_am(ig, index_a2x_Sa_shum   ) = cam_out(c)%qbot(i,1)
           a2x_am(ig, index_a2x_Sa_dens   ) = cam_out(c)%rho(i)
+
           if (trim(adjustl(precip_downscaling_method)) == "FNM") then
              !if the land model's precip downscaling method is FNM, export uovern to the coupler
              a2x_am(ig, index_a2x_Sa_uovern) = cam_out(c)%uovern(i)
@@ -1619,16 +1661,16 @@ CONTAINS
              a2x_am(ig, index_a2x_Sa_uovern) = 0._R8
           endif
 
-          a2x_am(ig, index_a2x_Faxa_swnet) = cam_out(c)%netsw(i)      
-          a2x_am(ig, index_a2x_Faxa_lwdn ) = cam_out(c)%flwds(i)  
+          a2x_am(ig, index_a2x_Faxa_swnet) = cam_out(c)%netsw(i)
+          a2x_am(ig, index_a2x_Faxa_lwdn ) = cam_out(c)%flwds(i)
           a2x_am(ig, index_a2x_Faxa_rainc) = (cam_out(c)%precc(i)-cam_out(c)%precsc(i))*1000._r8
           a2x_am(ig, index_a2x_Faxa_rainl) = (cam_out(c)%precl(i)-cam_out(c)%precsl(i))*1000._r8
           a2x_am(ig, index_a2x_Faxa_snowc) = cam_out(c)%precsc(i)*1000._r8
           a2x_am(ig, index_a2x_Faxa_snowl) = cam_out(c)%precsl(i)*1000._r8
-          a2x_am(ig, index_a2x_Faxa_swndr) = cam_out(c)%soll(i)   
-          a2x_am(ig, index_a2x_Faxa_swvdr) = cam_out(c)%sols(i)   
-          a2x_am(ig, index_a2x_Faxa_swndf) = cam_out(c)%solld(i)  
-          a2x_am(ig, index_a2x_Faxa_swvdf) = cam_out(c)%solsd(i)  
+          a2x_am(ig, index_a2x_Faxa_swndr) = cam_out(c)%soll(i)
+          a2x_am(ig, index_a2x_Faxa_swvdr) = cam_out(c)%sols(i)
+          a2x_am(ig, index_a2x_Faxa_swndf) = cam_out(c)%solld(i)
+          a2x_am(ig, index_a2x_Faxa_swvdf) = cam_out(c)%solsd(i)
 
           ! aerosol deposition fluxes
           a2x_am(ig, index_a2x_Faxa_bcphidry) = cam_out(c)%bcphidry(i)
@@ -1662,8 +1704,8 @@ CONTAINS
     if ( ierr > 0) then
       call endrun('Error: fail to set  seq_flds_a2x_fields for atm physgrid moab mesh')
     endif
-    call seq_timemgr_EClockGetData( EClock, stepno=cur_atm_stepno )
 #ifdef MOABDEBUG
+    call seq_timemgr_EClockGetData( EClock, stepno=cur_atm_stepno )
     write(lnum,"(I0.2)")cur_atm_stepno
     local_count = local_count + 1
     write(lnum2,"(I0.2)")local_count
@@ -1673,7 +1715,7 @@ CONTAINS
     if (ierr > 0 )  &
       call endrun('Error: fail to write the atm phys mesh file with data')
 #endif
-    
+
 
   end subroutine atm_export_moab
 
@@ -1683,7 +1725,7 @@ subroutine atm_import_moab(Eclock, cam_in, restart_init )
     use cam_cpl_indices
     use camsrfexch,     only: cam_in_t
     use phys_grid ,     only: get_ncols_p
-    use ppgrid    ,     only: begchunk, endchunk       
+    use ppgrid    ,     only: begchunk, endchunk
     use shr_const_mod,  only: shr_const_stebol
     use seq_drydep_mod, only: n_drydep
     use co2_cycle     , only: c_i, co2_readFlux_ocn, co2_readFlux_fuel
@@ -1696,13 +1738,13 @@ subroutine atm_import_moab(Eclock, cam_in, restart_init )
     !
     ! Arguments
     !
-    ! real(r8)      , intent(in)    :: x2a_am(:,:) will be retrieved from moab tags, and used to set cam_in 
+    ! real(r8)      , intent(in)    :: x2a_am(:,:) will be retrieved from moab tags, and used to set cam_in
     type(ESMF_Clock),intent(inout) :: EClock
     type(cam_in_t), intent(inout) :: cam_in(begchunk:endchunk)
     logical, optional, intent(in) :: restart_init
     !
     ! Local variables
-    !		
+    !
     integer            :: i,lat,n,c,ig  ! indices
     integer            :: ncols         ! number of columns
     logical, save      :: first_time = .true.
@@ -1712,17 +1754,17 @@ subroutine atm_import_moab(Eclock, cam_in, restart_init )
     integer, pointer   :: dst_a1_ndx, dst_a3_ndx
     logical :: overwrite_flds
 
-    character(CXX) ::  tagname ! 
+    character(CXX) ::  tagname !
     integer  :: ent_type, ierr
     integer  :: cur_atm_stepno
 
     call seq_timemgr_EClockGetData( EClock, stepno=cur_atm_stepno )
     !-----------------------------------------------------------------------
     overwrite_flds = .true.
-    ! don't overwrite fields if invoked during the initialization phase 
+    ! don't overwrite fields if invoked during the initialization phase
     ! of a 'continue' or 'branch' run type with data from .rs file
     if (present(restart_init)) overwrite_flds = .not. restart_init
-    
+
 
     ! ccsm sign convention is that fluxes are positive downward
     tagname=trim(seq_flds_x2a_fields)//C_NULL_CHAR
@@ -1734,47 +1776,48 @@ subroutine atm_import_moab(Eclock, cam_in, restart_init )
 
     ig=1
     do c=begchunk,endchunk
-       ncols = get_ncols_p(c) 
+       ncols = get_ncols_p(c)
 
        ! initialize constituent surface fluxes to zero
        ! NOTE:overwrite_flds is .FALSE. for the first restart
        ! time step making cflx(:,1)=0.0 for the first restart time step.
        ! cflx(:,1) should not be zeroed out, start the second index of cflx from 2.
-       ! cam_in(c)%cflx(:,2:) = 0._r8 
-                                               
-       do i =1,ncols                                                               
+       ! cam_in(c)%cflx(:,2:) = 0._r8
+
+       do i =1,ncols
           if (overwrite_flds) then
              ! Prior to this change, "overwrite_flds" was always .true. therefore wsx and wsy were always updated.
-             ! Now, overwrite_flds is .false. for the first time step of the restart run. Move wsx and wsy out of 
+             ! Now, overwrite_flds is .false. for the first time step of the restart run. Move wsx and wsy out of
              ! this if-condition so that they are still updated everytime irrespective of the value of overwrite_flds.
 
-             ! Move lhf to this if-block so that it is not overwritten to ensure BFB restarts when qneg4 correction 
+             ! Move lhf to this if-block so that it is not overwritten to ensure BFB restarts when qneg4 correction
              ! occurs at the restart time step
              ! Modified by Wuyin Lin
-             cam_in(c)%shf(i)    = -x2a_am(ig,index_x2a_Faxx_sen)     
-             cam_in(c)%cflx(i,1) = -x2a_am(ig,index_x2a_Faxx_evap)                
-             cam_in(c)%lhf(i)    = -x2a_am(ig,index_x2a_Faxx_lat)     
+             cam_in(c)%shf(i)    = -x2a_am(ig,index_x2a_Faxx_sen)
+             cam_in(c)%cflx(i,1) = -x2a_am(ig,index_x2a_Faxx_evap)
+             cam_in(c)%lhf(i)    = -x2a_am(ig,index_x2a_Faxx_lat)
           endif
 
           if (index_x2a_Faoo_h2otemp /= 0) then
              cam_in(c)%h2otemp(i) = -x2a_am(ig,index_x2a_Faoo_h2otemp)
           end if
-           
-          cam_in(c)%wsx(i)    = -x2a_am(ig,index_x2a_Faxx_taux)     
-          cam_in(c)%wsy(i)    = -x2a_am(ig,index_x2a_Faxx_tauy)     
-          cam_in(c)%lwup(i)      = -x2a_am(ig,index_x2a_Faxx_lwup)    
-          cam_in(c)%asdir(i)     =  x2a_am(ig,index_x2a_Sx_avsdr)  
-          cam_in(c)%aldir(i)     =  x2a_am(ig,index_x2a_Sx_anidr)  
-          cam_in(c)%asdif(i)     =  x2a_am(ig,index_x2a_Sx_avsdf)  
+
+          cam_in(c)%wsx(i)    = -x2a_am(ig,index_x2a_Faxx_taux)
+          cam_in(c)%wsy(i)    = -x2a_am(ig,index_x2a_Faxx_tauy)
+          cam_in(c)%lwup(i)      = -x2a_am(ig,index_x2a_Faxx_lwup)
+          cam_in(c)%asdir(i)     =  x2a_am(ig,index_x2a_Sx_avsdr)
+          cam_in(c)%aldir(i)     =  x2a_am(ig,index_x2a_Sx_anidr)
+          cam_in(c)%asdif(i)     =  x2a_am(ig,index_x2a_Sx_avsdf)
           cam_in(c)%aldif(i)     =  x2a_am(ig,index_x2a_Sx_anidf)
-          cam_in(c)%ts(i)        =  x2a_am(ig,index_x2a_Sx_t)  
-          cam_in(c)%sst(i)       =  x2a_am(ig,index_x2a_So_t)             
-          cam_in(c)%snowhland(i) =  x2a_am(ig,index_x2a_Sl_snowh)  
-          cam_in(c)%snowhice(i)  =  x2a_am(ig,index_x2a_Si_snowh)  
-          cam_in(c)%tref(i)      =  x2a_am(ig,index_x2a_Sx_tref)  
+          cam_in(c)%ts(i)        =  x2a_am(ig,index_x2a_Sx_t)
+          cam_in(c)%sst(i)       =  x2a_am(ig,index_x2a_So_t)
+          cam_in(c)%snowhland(i) =  x2a_am(ig,index_x2a_Sl_snowh)
+          cam_in(c)%snowhice(i)  =  x2a_am(ig,index_x2a_Si_snowh)
+          cam_in(c)%tref(i)      =  x2a_am(ig,index_x2a_Sx_tref)
           cam_in(c)%qref(i)      =  x2a_am(ig,index_x2a_Sx_qref)
           cam_in(c)%u10(i)       =  x2a_am(ig,index_x2a_Sx_u10)
-          cam_in(c)%icefrac(i)   =  x2a_am(ig,index_x2a_Sf_ifrac)  
+          cam_in(c)%u10withgusts(i) = x2a_am(ig,index_x2a_Sx_u10withgusts)
+          cam_in(c)%icefrac(i)   =  x2a_am(ig,index_x2a_Sf_ifrac)
           cam_in(c)%ocnfrac(i)   =  x2a_am(ig,index_x2a_Sf_ofrac)
           cam_in(c)%landfrac(i)  =  x2a_am(ig,index_x2a_Sf_lfrac)
           if ( associated(cam_in(c)%ram1) ) &
@@ -1835,22 +1878,22 @@ subroutine atm_import_moab(Eclock, cam_in, restart_init )
        if (co2_readFlux_fuel) then
           call co2_time_interp_fuel
        end if
-       
+
        ! from ocn : data read in or from coupler or zero
        ! from fuel: data read in or zero
        ! from lnd : through coupler or zero
        do c=begchunk,endchunk
-          ncols = get_ncols_p(c)                                                 
-          do i=1,ncols                                                               
-             
-             ! all co2 fluxes in unit kgCO2/m2/s ! co2 flux from ocn 
+          ncols = get_ncols_p(c)
+          do i=1,ncols
+
+             ! all co2 fluxes in unit kgCO2/m2/s ! co2 flux from ocn
              if (index_x2a_Faoo_fco2_ocn /= 0) then
                 cam_in(c)%cflx(i,c_i(1)) = cam_in(c)%fco2_ocn(i)
-             else if (co2_readFlux_ocn) then 
+             else if (co2_readFlux_ocn) then
                 ! convert from molesCO2/m2/s to kgCO2/m2/s
 ! The below section involves a temporary workaround for fluxes from data (read in from a file)
 ! There is an issue with infld that does not allow time-varying 2D files to be read correctly.
-! The work around involves adding a singleton 3rd dimension offline and reading the files as 
+! The work around involves adding a singleton 3rd dimension offline and reading the files as
 ! 3D fields.  Once this issue is corrected, the old implementation can be reinstated.
 ! This is the case for both data_flux_ocn and data_flux_fuel
 !++BEH  vvv old implementation vvv
@@ -1865,7 +1908,7 @@ subroutine atm_import_moab(Eclock, cam_in, restart_init )
              else
                 cam_in(c)%cflx(i,c_i(1)) = 0._r8
              end if
-             
+
              ! co2 flux from fossil fuel
              if (co2_readFlux_fuel) then
 !++BEH  vvv old implementation vvv
@@ -1876,14 +1919,14 @@ subroutine atm_import_moab(Eclock, cam_in, restart_init )
              else
                 cam_in(c)%cflx(i,c_i(2)) = 0._r8
              end if
-             
+
              ! co2 flux from land (cpl already multiplies flux by land fraction)
              if (index_x2a_Fall_fco2_lnd /= 0) then
                 cam_in(c)%cflx(i,c_i(3)) = cam_in(c)%fco2_lnd(i)
              else
                 cam_in(c)%cflx(i,c_i(3)) = 0._r8
              end if
-             
+
              ! merged co2 flux
              cam_in(c)%cflx(i,c_i(4)) = cam_in(c)%cflx(i,c_i(1)) + &
                                         cam_in(c)%cflx(i,c_i(2)) + &
@@ -1892,7 +1935,7 @@ subroutine atm_import_moab(Eclock, cam_in, restart_init )
        end do
     end if
     !
-    ! if first step, determine longwave up flux from the surface temperature 
+    ! if first step, determine longwave up flux from the surface temperature
     !
     if (first_time) then
        if (is_first_step()) then

--- a/components/eam/src/cpl/atm_comp_mct.F90
+++ b/components/eam/src/cpl/atm_comp_mct.F90
@@ -444,7 +444,7 @@ CONTAINS
 
        call shr_file_setLogUnit (shrlogunit)
        call shr_file_setLogLevel(shrloglev)
-      
+
 
        first_time = .false.
 
@@ -1603,9 +1603,12 @@ CONTAINS
 
     call phys_getopts(linearize_pbl_winds_out=linearize_pbl_winds)
 
+    ! initialize/reset all export data to zero
+    a2x_am = 0.0D0
+
     ! Copy from component arrays into chunk array data structure
     ! Rearrange data from chunk structure into lat-lon buffer and subsequently
-    ! create double array for moab tags
+    ! Create double array for MOAB tags
     ig=1
     do c=begchunk, endchunk
        ncols = get_ncols_p(c)

--- a/components/eam/src/cpl/atm_comp_mct.F90
+++ b/components/eam/src/cpl/atm_comp_mct.F90
@@ -399,6 +399,9 @@ CONTAINS
        call mct_aVect_init(x2a_a, rList=seq_flds_x2a_fields, lsize=lsize)
        call mct_aVect_zero(x2a_a)
        !
+       ! Create initial atm export state
+       !
+       call atm_export( cam_out, a2x_a%rattr )
 
 #ifdef HAVE_MOAB
        ! Initialize MOAB physgrid mesh and add coordinate,mask data

--- a/components/eam/src/cpl/atm_comp_mct.F90
+++ b/components/eam/src/cpl/atm_comp_mct.F90
@@ -399,9 +399,6 @@ CONTAINS
        call mct_aVect_init(x2a_a, rList=seq_flds_x2a_fields, lsize=lsize)
        call mct_aVect_zero(x2a_a)
        !
-       ! Create initial atm export state
-       !
-       call atm_export( cam_out, a2x_a%rattr )
 
 #ifdef HAVE_MOAB
        ! Initialize MOAB physgrid mesh and add coordinate,mask data
@@ -447,26 +444,7 @@ CONTAINS
 
        call shr_file_setLogUnit (shrlogunit)
        call shr_file_setLogLevel(shrloglev)
-       ! when called first time, initialize MOAB atm phis grid, and create the mesh
-       ! on the atm
-#ifdef HAVE_MOAB
-       call init_moab_atm_phys( cdata_a )
-       mblsize = lsize
-       nsend = mct_avect_nRattr(a2x_a)
-       totalmbls = mblsize * nsend   ! size of the double array
-       allocate (a2x_am(mblsize, nsend) )
-       a2x_am = 0.0
-
-       nrecv = mct_avect_nRattr(x2a_a)
-       totalmbls_r = mblsize * nrecv   ! size of the double array used to receive
-       allocate (x2a_am(mblsize, nrecv) ) ! these will be received by moab tags, then used to set cam in surf data
-       x2a_am = 0.0
-       !
-       ! Create initial atm export state inside moab
-       !
-       call atm_export_moab(Eclock, cam_out )
-
-#endif
+      
 
        first_time = .false.
 

--- a/components/eam/src/cpl/atm_import_export.F90
+++ b/components/eam/src/cpl/atm_import_export.F90
@@ -11,7 +11,7 @@ contains
     use cam_cpl_indices
     use camsrfexch,     only: cam_in_t
     use phys_grid ,     only: get_ncols_p
-    use ppgrid    ,     only: begchunk, endchunk       
+    use ppgrid    ,     only: begchunk, endchunk
     use shr_const_mod,  only: shr_const_stebol
     use seq_drydep_mod, only: n_drydep
     use co2_cycle     , only: c_i, co2_readFlux_ocn, co2_readFlux_fuel
@@ -27,7 +27,7 @@ contains
     logical, optional, intent(in) :: restart_init
     !
     ! Local variables
-    !		
+    !
     integer            :: i,lat,n,c,ig  ! indices
     integer            :: ncols         ! number of columns
     logical, save      :: first_time = .true.
@@ -38,7 +38,7 @@ contains
     logical :: overwrite_flds
     !-----------------------------------------------------------------------
     overwrite_flds = .true.
-    ! don't overwrite fields if invoked during the initialization phase 
+    ! don't overwrite fields if invoked during the initialization phase
     ! of a 'continue' or 'branch' run type with data from .rs file
     if (present(restart_init)) overwrite_flds = .not. restart_init
 
@@ -46,7 +46,7 @@ contains
 
     ig=1
     do c=begchunk,endchunk
-       ncols = get_ncols_p(c) 
+       ncols = get_ncols_p(c)
 
        ! initialize constituent surface fluxes to zero
        ! NOTE:overwrite_flds is .FALSE. for the first restart
@@ -55,51 +55,51 @@ contains
 
        ! +++ Update from 2022-09 +++
        ! For some of the new process coupling options in EAM, some of the constituents'
-       ! cam_in%cflx are used not in tphysac but in the tphysbc call of the next time step. 
+       ! cam_in%cflx are used not in tphysac but in the tphysbc call of the next time step.
        ! This means for an exact restart, we also need to write out cam_in%cflx(:,2:)
-       ! and then read them back in. Because the present subroutine is called after 
-       ! the cflx variables are read in in the subroutine read_restart_physics 
-       ! in physics/cam/restart_physics.F90, we need to move the following line 
+       ! and then read them back in. Because the present subroutine is called after
+       ! the cflx variables are read in in the subroutine read_restart_physics
+       ! in physics/cam/restart_physics.F90, we need to move the following line
        ! to that read_restart_physics to avoid incorrectly zeroing out the needed values.
        !
-       !cam_in(c)%cflx(:,2:) = 0._r8 
+       !cam_in(c)%cflx(:,2:) = 0._r8
        !
        ! === Update from 2022-09 ===
-                                               
-       do i =1,ncols                                                               
+
+       do i =1,ncols
           if (overwrite_flds) then
              ! Prior to this change, "overwrite_flds" was always .true. therefore wsx and wsy were always updated.
-             ! Now, overwrite_flds is .false. for the first time step of the restart run. Move wsx and wsy out of 
+             ! Now, overwrite_flds is .false. for the first time step of the restart run. Move wsx and wsy out of
              ! this if-condition so that they are still updated everytime irrespective of the value of overwrite_flds.
 
-             ! Move lhf to this if-block so that it is not overwritten to ensure BFB restarts when qneg4 correction 
+             ! Move lhf to this if-block so that it is not overwritten to ensure BFB restarts when qneg4 correction
              ! occurs at the restart time step
              ! Modified by Wuyin Lin
-             cam_in(c)%shf(i)    = -x2a(index_x2a_Faxx_sen, ig)     
-             cam_in(c)%cflx(i,1) = -x2a(index_x2a_Faxx_evap,ig)                
-             cam_in(c)%lhf(i)    = -x2a(index_x2a_Faxx_lat, ig)     
+             cam_in(c)%shf(i)    = -x2a(index_x2a_Faxx_sen, ig)
+             cam_in(c)%cflx(i,1) = -x2a(index_x2a_Faxx_evap,ig)
+             cam_in(c)%lhf(i)    = -x2a(index_x2a_Faxx_lat, ig)
           endif
 
           if (index_x2a_Faoo_h2otemp /= 0) then
              cam_in(c)%h2otemp(i) = -x2a(index_x2a_Faoo_h2otemp,ig)
           end if
-           
-          cam_in(c)%wsx(i)    = -x2a(index_x2a_Faxx_taux,ig)     
-          cam_in(c)%wsy(i)    = -x2a(index_x2a_Faxx_tauy,ig)     
-          cam_in(c)%lwup(i)      = -x2a(index_x2a_Faxx_lwup,ig)    
-          cam_in(c)%asdir(i)     =  x2a(index_x2a_Sx_avsdr, ig)  
-          cam_in(c)%aldir(i)     =  x2a(index_x2a_Sx_anidr, ig)  
-          cam_in(c)%asdif(i)     =  x2a(index_x2a_Sx_avsdf, ig)  
+
+          cam_in(c)%wsx(i)    = -x2a(index_x2a_Faxx_taux,ig)
+          cam_in(c)%wsy(i)    = -x2a(index_x2a_Faxx_tauy,ig)
+          cam_in(c)%lwup(i)      = -x2a(index_x2a_Faxx_lwup,ig)
+          cam_in(c)%asdir(i)     =  x2a(index_x2a_Sx_avsdr, ig)
+          cam_in(c)%aldir(i)     =  x2a(index_x2a_Sx_anidr, ig)
+          cam_in(c)%asdif(i)     =  x2a(index_x2a_Sx_avsdf, ig)
           cam_in(c)%aldif(i)     =  x2a(index_x2a_Sx_anidf, ig)
-          cam_in(c)%ts(i)        =  x2a(index_x2a_Sx_t,     ig)  
-          cam_in(c)%sst(i)       =  x2a(index_x2a_So_t,     ig)             
-          cam_in(c)%snowhland(i) =  x2a(index_x2a_Sl_snowh, ig)  
-          cam_in(c)%snowhice(i)  =  x2a(index_x2a_Si_snowh, ig)  
-          cam_in(c)%tref(i)      =  x2a(index_x2a_Sx_tref,  ig)  
+          cam_in(c)%ts(i)        =  x2a(index_x2a_Sx_t,     ig)
+          cam_in(c)%sst(i)       =  x2a(index_x2a_So_t,     ig)
+          cam_in(c)%snowhland(i) =  x2a(index_x2a_Sl_snowh, ig)
+          cam_in(c)%snowhice(i)  =  x2a(index_x2a_Si_snowh, ig)
+          cam_in(c)%tref(i)      =  x2a(index_x2a_Sx_tref,  ig)
           cam_in(c)%qref(i)      =  x2a(index_x2a_Sx_qref,  ig)
           cam_in(c)%u10(i)       =  x2a(index_x2a_Sx_u10,   ig)
           cam_in(c)%u10withgusts(i) = x2a(index_x2a_Sx_u10withgusts, ig)
-          cam_in(c)%icefrac(i)   =  x2a(index_x2a_Sf_ifrac, ig)  
+          cam_in(c)%icefrac(i)   =  x2a(index_x2a_Sf_ifrac, ig)
           cam_in(c)%ocnfrac(i)   =  x2a(index_x2a_Sf_ofrac, ig)
           cam_in(c)%landfrac(i)  =  x2a(index_x2a_Sf_lfrac, ig)
           if ( associated(cam_in(c)%ram1) ) &
@@ -160,22 +160,22 @@ contains
        if (co2_readFlux_fuel) then
           call co2_time_interp_fuel
        end if
-       
+
        ! from ocn : data read in or from coupler or zero
        ! from fuel: data read in or zero
        ! from lnd : through coupler or zero
        do c=begchunk,endchunk
-          ncols = get_ncols_p(c)                                                 
-          do i=1,ncols                                                               
-             
-             ! all co2 fluxes in unit kgCO2/m2/s ! co2 flux from ocn 
+          ncols = get_ncols_p(c)
+          do i=1,ncols
+
+             ! all co2 fluxes in unit kgCO2/m2/s ! co2 flux from ocn
              if (index_x2a_Faoo_fco2_ocn /= 0) then
                 cam_in(c)%cflx(i,c_i(1)) = cam_in(c)%fco2_ocn(i)
-             else if (co2_readFlux_ocn) then 
+             else if (co2_readFlux_ocn) then
                 ! convert from molesCO2/m2/s to kgCO2/m2/s
 ! The below section involves a temporary workaround for fluxes from data (read in from a file)
 ! There is an issue with infld that does not allow time-varying 2D files to be read correctly.
-! The work around involves adding a singleton 3rd dimension offline and reading the files as 
+! The work around involves adding a singleton 3rd dimension offline and reading the files as
 ! 3D fields.  Once this issue is corrected, the old implementation can be reinstated.
 ! This is the case for both data_flux_ocn and data_flux_fuel
 !++BEH  vvv old implementation vvv
@@ -190,7 +190,7 @@ contains
              else
                 cam_in(c)%cflx(i,c_i(1)) = 0._r8
              end if
-             
+
              ! co2 flux from fossil fuel
              if (co2_readFlux_fuel) then
 !++BEH  vvv old implementation vvv
@@ -201,14 +201,14 @@ contains
              else
                 cam_in(c)%cflx(i,c_i(2)) = 0._r8
              end if
-             
+
              ! co2 flux from land (cpl already multiplies flux by land fraction)
              if (index_x2a_Fall_fco2_lnd /= 0) then
                 cam_in(c)%cflx(i,c_i(3)) = cam_in(c)%fco2_lnd(i)
              else
                 cam_in(c)%cflx(i,c_i(3)) = 0._r8
              end if
-             
+
              ! merged co2 flux
              cam_in(c)%cflx(i,c_i(4)) = cam_in(c)%cflx(i,c_i(1)) + &
                                         cam_in(c)%cflx(i,c_i(2)) + &
@@ -217,7 +217,7 @@ contains
        end do
     end if
     !
-    ! if first step, determine longwave up flux from the surface temperature 
+    ! if first step, determine longwave up flux from the surface temperature
     !
     if (first_time) then
        if (is_first_step()) then
@@ -240,20 +240,19 @@ contains
     !-------------------------------------------------------------------
     use camsrfexch, only: cam_out_t
     use phys_grid , only: get_ncols_p
-    use ppgrid    , only: begchunk, endchunk       
+    use ppgrid    , only: begchunk, endchunk
     use cam_cpl_indices
     use phys_control, only: phys_getopts
     use lnd_infodata, only: precip_downscaling_method
     !
     ! Arguments
     !
-    type(cam_out_t), intent(in)    :: cam_out(begchunk:endchunk) 
+    type(cam_out_t), intent(in)    :: cam_out(begchunk:endchunk)
     real(r8)       , intent(inout) :: a2x(:,:)
     !
     ! Local variables
     !
-    integer :: avsize, avnat
-    integer :: i,m,c,n,ig       ! indices
+    integer :: i,c,n,ig         ! indices
     integer :: ncols            ! Number of columns
     logical :: linearize_pbl_winds
     !-----------------------------------------------------------------------
@@ -269,8 +268,8 @@ contains
        ncols = get_ncols_p(c)
        do i=1,ncols
           a2x(index_a2x_Sa_pslv   ,ig) = cam_out(c)%psl(i)
-          a2x(index_a2x_Sa_z      ,ig) = cam_out(c)%zbot(i)   
-          a2x(index_a2x_Sa_u      ,ig) = cam_out(c)%ubot(i)   
+          a2x(index_a2x_Sa_z      ,ig) = cam_out(c)%zbot(i)
+          a2x(index_a2x_Sa_u      ,ig) = cam_out(c)%ubot(i)
           a2x(index_a2x_Sa_v      ,ig) = cam_out(c)%vbot(i)
           if (linearize_pbl_winds) then
              a2x(index_a2x_Sa_wsresp ,ig) = cam_out(c)%wsresp(i)
@@ -281,26 +280,26 @@ contains
           if (index_a2x_Sa_ugust /= 0) then
              a2x(index_a2x_Sa_ugust  ,ig) = cam_out(c)%ugust(i)
           end if
-          a2x(index_a2x_Sa_tbot   ,ig) = cam_out(c)%tbot(i)   
-          a2x(index_a2x_Sa_ptem   ,ig) = cam_out(c)%thbot(i)  
-          a2x(index_a2x_Sa_pbot   ,ig) = cam_out(c)%pbot(i)   
-          a2x(index_a2x_Sa_shum   ,ig) = cam_out(c)%qbot(i,1) 
-	  a2x(index_a2x_Sa_dens   ,ig) = cam_out(c)%rho(i)
+          a2x(index_a2x_Sa_tbot   ,ig) = cam_out(c)%tbot(i)
+          a2x(index_a2x_Sa_ptem   ,ig) = cam_out(c)%thbot(i)
+          a2x(index_a2x_Sa_pbot   ,ig) = cam_out(c)%pbot(i)
+          a2x(index_a2x_Sa_shum   ,ig) = cam_out(c)%qbot(i,1)
+          a2x(index_a2x_Sa_dens   ,ig) = cam_out(c)%rho(i)
 
           if (trim(adjustl(precip_downscaling_method)) == "FNM") then
              !if the land model's precip downscaling method is FNM, export uovern to the coupler
              a2x(index_a2x_Sa_uovern ,ig) = cam_out(c)%uovern(i)
           end if
-          a2x(index_a2x_Faxa_swnet,ig) = cam_out(c)%netsw(i)      
-          a2x(index_a2x_Faxa_lwdn ,ig) = cam_out(c)%flwds(i)  
+          a2x(index_a2x_Faxa_swnet,ig) = cam_out(c)%netsw(i)
+          a2x(index_a2x_Faxa_lwdn ,ig) = cam_out(c)%flwds(i)
           a2x(index_a2x_Faxa_rainc,ig) = (cam_out(c)%precc(i)-cam_out(c)%precsc(i))*1000._r8
           a2x(index_a2x_Faxa_rainl,ig) = (cam_out(c)%precl(i)-cam_out(c)%precsl(i))*1000._r8
           a2x(index_a2x_Faxa_snowc,ig) = cam_out(c)%precsc(i)*1000._r8
           a2x(index_a2x_Faxa_snowl,ig) = cam_out(c)%precsl(i)*1000._r8
-          a2x(index_a2x_Faxa_swndr,ig) = cam_out(c)%soll(i)   
-          a2x(index_a2x_Faxa_swvdr,ig) = cam_out(c)%sols(i)   
-          a2x(index_a2x_Faxa_swndf,ig) = cam_out(c)%solld(i)  
-          a2x(index_a2x_Faxa_swvdf,ig) = cam_out(c)%solsd(i)  
+          a2x(index_a2x_Faxa_swndr,ig) = cam_out(c)%soll(i)
+          a2x(index_a2x_Faxa_swvdr,ig) = cam_out(c)%sols(i)
+          a2x(index_a2x_Faxa_swndf,ig) = cam_out(c)%solld(i)
+          a2x(index_a2x_Faxa_swvdf,ig) = cam_out(c)%solsd(i)
 
           ! aerosol deposition fluxes
           a2x(index_a2x_Faxa_bcphidry,ig) = cam_out(c)%bcphidry(i)
@@ -328,7 +327,7 @@ contains
           ig=ig+1
        end do
     end do
-    
-  end subroutine atm_export 
+
+  end subroutine atm_export
 
 end module atm_import_export

--- a/components/eam/src/cpl/cam_cpl_indices.F90
+++ b/components/eam/src/cpl/cam_cpl_indices.F90
@@ -1,5 +1,5 @@
 module cam_cpl_indices
-  
+
   use seq_flds_mod
   use mct_mod
   use seq_drydep_mod, only: drydep_fields_token, lnd_drydep
@@ -16,6 +16,7 @@ module cam_cpl_indices
   integer :: index_a2x_Sa_wsresp       ! first order response of wind to stress
   integer :: index_a2x_Sa_tau_est      ! estimated stress in equilibrium with ubot/vbot
   integer :: index_a2x_Sa_ugust        ! magnitude of gustiness at surface
+  integer :: index_a2x_Sa_topo         ! topography
   integer :: index_a2x_Sa_tbot         ! bottom atm level temp
   integer :: index_a2x_Sa_ptem         ! bottom atm level pot temp
   integer :: index_a2x_Sa_shum         ! bottom atm level spec hum
@@ -50,40 +51,40 @@ module cam_cpl_indices
   integer :: index_a2x_Sa_co2prog      ! bottom atm level prognostic co2
   integer :: index_a2x_Sa_co2diag      ! bottom atm level diagnostic co2
 
-  integer :: index_x2a_Sx_t            ! surface temperature             
-  integer :: index_x2a_So_t            ! sea surface temperature         
-  integer :: index_x2a_Sf_lfrac        ! surface land fraction           
-  integer :: index_x2a_Sf_ifrac        ! surface ice fraction            
-  integer :: index_x2a_Sf_ofrac        ! surface ocn fraction            
-  integer :: index_x2a_Sx_tref         ! 2m reference temperature        
-  integer :: index_x2a_Sx_qref         ! 2m reference specific humidity  
-  integer :: index_x2a_Sx_avsdr        ! albedo, visible, direct         
-  integer :: index_x2a_Sx_anidr        ! albedo, near-ir, direct         
-  integer :: index_x2a_Sx_avsdf        ! albedo, visible, diffuse        
-  integer :: index_x2a_Sx_anidf        ! albedo, near-ir, diffuse        
+  integer :: index_x2a_Sx_t            ! surface temperature
+  integer :: index_x2a_So_t            ! sea surface temperature
+  integer :: index_x2a_Sf_lfrac        ! surface land fraction
+  integer :: index_x2a_Sf_ifrac        ! surface ice fraction
+  integer :: index_x2a_Sf_ofrac        ! surface ocn fraction
+  integer :: index_x2a_Sx_tref         ! 2m reference temperature
+  integer :: index_x2a_Sx_qref         ! 2m reference specific humidity
+  integer :: index_x2a_Sx_avsdr        ! albedo, visible, direct
+  integer :: index_x2a_Sx_anidr        ! albedo, near-ir, direct
+  integer :: index_x2a_Sx_avsdf        ! albedo, visible, diffuse
+  integer :: index_x2a_Sx_anidf        ! albedo, near-ir, diffuse
   integer :: index_x2a_Sl_snowh        ! surface snow depth over land
   integer :: index_x2a_Si_snowh        ! surface snow depth over ice
   integer :: index_x2a_Sl_fv           ! friction velocity
   integer :: index_x2a_Sl_ram1         ! aerodynamical resistance
   integer :: index_x2a_Sl_soilw        ! volumetric soil water
-  integer :: index_x2a_Faxx_taux       ! wind stress, zonal              
-  integer :: index_x2a_Faxx_tauy       ! wind stress, meridional         
-  integer :: index_x2a_Faxx_lat        ! latent          heat flux       
-  integer :: index_x2a_Faxx_sen        ! sensible        heat flux       
-  integer :: index_x2a_Faxx_lwup       ! upward longwave heat flux       
-  integer :: index_x2a_Faxx_evap       ! evaporation    water flux       
-  integer :: index_x2a_Fall_flxdst1    ! dust flux size bin 1    
-  integer :: index_x2a_Fall_flxdst2    ! dust flux size bin 2    
-  integer :: index_x2a_Fall_flxdst3    ! dust flux size bin 3    
+  integer :: index_x2a_Faxx_taux       ! wind stress, zonal
+  integer :: index_x2a_Faxx_tauy       ! wind stress, meridional
+  integer :: index_x2a_Faxx_lat        ! latent          heat flux
+  integer :: index_x2a_Faxx_sen        ! sensible        heat flux
+  integer :: index_x2a_Faxx_lwup       ! upward longwave heat flux
+  integer :: index_x2a_Faxx_evap       ! evaporation    water flux
+  integer :: index_x2a_Fall_flxdst1    ! dust flux size bin 1
+  integer :: index_x2a_Fall_flxdst2    ! dust flux size bin 2
+  integer :: index_x2a_Fall_flxdst3    ! dust flux size bin 3
   integer :: index_x2a_Fall_flxdst4    ! dust flux size bin 4
-  integer :: index_x2a_Fall_flxvoc     ! MEGAN emissions fluxes   
-  integer :: index_x2a_Fall_fco2_lnd   ! co2 flux from land   
-  integer :: index_x2a_Faoo_fco2_ocn   ! co2 flux from ocean  
+  integer :: index_x2a_Fall_flxvoc     ! MEGAN emissions fluxes
+  integer :: index_x2a_Fall_fco2_lnd   ! co2 flux from land
+  integer :: index_x2a_Faoo_fco2_ocn   ! co2 flux from ocean
   integer :: index_x2a_Faoo_fdms_ocn   ! dms flux from ocean
-  integer :: index_x2a_Faoo_h2otemp    ! water temperature heat flux from ocean  
+  integer :: index_x2a_Faoo_h2otemp    ! water temperature heat flux from ocean
   integer :: index_x2a_So_ustar	       ! surface friction velocity in ocean
-  integer :: index_x2a_So_re           ! square of atm/ocn exch. coeff 
-  integer :: index_x2a_So_ssq          ! surface saturation specific humidity in ocean 
+  integer :: index_x2a_So_re           ! square of atm/ocn exch. coeff
+  integer :: index_x2a_So_ssq          ! surface saturation specific humidity in ocean
   integer :: index_x2a_Sl_ddvel        ! dry deposition velocities from land
   integer :: index_x2a_Sx_u10          ! 10m wind
   integer :: index_x2a_Sx_u10withgusts ! 10m wind with gusts
@@ -110,11 +111,11 @@ contains
     index_x2a_So_t          = mct_avect_indexra(x2a,'So_t')
     index_x2a_Sl_snowh      = mct_avect_indexra(x2a,'Sl_snowh')
     index_x2a_Si_snowh      = mct_avect_indexra(x2a,'Si_snowh')
-    
+
     index_x2a_Sl_fv         = mct_avect_indexra(x2a,'Sl_fv')
     index_x2a_Sl_ram1       = mct_avect_indexra(x2a,'Sl_ram1')
     index_x2a_Sl_soilw      = mct_avect_indexra(x2a,'Sl_soilw',perrWith='quiet')
-    
+
     index_x2a_Sx_tref       = mct_avect_indexra(x2a,'Sx_tref')
     index_x2a_Sx_qref       = mct_avect_indexra(x2a,'Sx_qref')
 

--- a/driver-moab/cime_config/config_component_e3sm.xml
+++ b/driver-moab/cime_config/config_component_e3sm.xml
@@ -279,6 +279,24 @@
     </desc>
   </entry>
 
+  <entry id="CPL_COMPUTE_MAPS_ONLINE">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <values match="last">
+      <value/>
+    </values>
+    <group>run_coupling</group>
+    <file>env_run.xml</file>
+    <desc>User option to specify whether MOAB coupler maps should be computed 
+      online or to load precomputed maps from disk at runtime (similar to MCT).
+      Note that this option enforces the same behavior for all coupler maps 
+      (A-O, A-L, R-L, I-O etc) except R2O at the moment 
+      (which is always loaded from disk). Default is false to replicate behavior
+      of existing MCT coupler.
+    </desc>
+  </entry>
+
   <entry id="CCSM_BGC">
     <type>char</type>
     <valid_values>none,CO2A,CO2A_OI,CO2B,CO2C,CO2C_OI,CO2_DMSA</valid_values>

--- a/driver-moab/cime_config/namelist_definition_drv.xml
+++ b/driver-moab/cime_config/namelist_definition_drv.xml
@@ -1054,6 +1054,19 @@
     </values>
   </entry>
 
+  <entry id="cpl_compute_maps_online" modify_via_xml="CPL_COMPUTE_MAPS_ONLINE">
+    <type>logical</type>
+    <category>expdef</category>
+    <group>seq_infodata_inparm</group>
+    <desc>
+      Logical to turn on computation of coupler maps online at runtime or if false, use the pre-computed
+      offline maps and read from disk.
+    </desc>
+    <values>
+      <value>$CPL_COMPUTE_MAPS_ONLINE</value>
+    </values>
+  </entry>
+
   <entry id="do_budgets" modify_via_xml="BUDGETS">
     <type>logical</type>
     <category>budget</category>

--- a/driver-moab/main/cime_comp_mod.F90
+++ b/driver-moab/main/cime_comp_mod.F90
@@ -487,6 +487,7 @@ module cime_comp_mod
   logical  :: atm_aero               ! atm provides aerosol data
 
   character(CL) :: cpl_seq_option    ! coupler sequencing option
+  logical  :: cpl_compute_maps_online ! coupler map online/offline option
   logical  :: skip_ocean_run         ! skip the ocean model first pass
   logical  :: cpl2ocn_first          ! use to call initial cpl2ocn timer
   logical  :: run_barriers           ! barrier the component run calls
@@ -1158,6 +1159,7 @@ contains
          scm_ny=scm_ny                             , &
          aqua_planet=aqua_planet                   , &
          cpl_seq_option=cpl_seq_option             , &
+         cpl_compute_maps_online=cpl_compute_maps_online, &
          drv_threading=drv_threading               , &
          do_histinit=do_histinit                   , &
          do_budgets=do_budgets                     , &

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -1284,14 +1284,14 @@ contains
                endif
             else
               ! we need to read the ocean mesh on coupler, from domain file 
+               if (seq_comm_iamroot(CPLID)) then
+                  write(logunit,'(A)') subname//' loading ocn domain mesh from file '//trim(ocn_domain)
+               endif
                ierr = iMOAB_LoadMesh(mboxid, trim(ocn_domain)//C_NULL_CHAR, &
                 "PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION", 0)
                if ( ierr /= 0 ) then
                   write(logunit,*) 'Failed to load ocean domain mesh on coupler'
                   call shr_sys_abort(subname//' ERROR Failed to load ocean domain mesh on coupler  ')
-               endif
-               if (seq_comm_iamroot(CPLID)) then
-                  write(logunit,'(A)') subname//' load ocn domain mesh from file '//trim(ocn_domain)
                endif
                ! need to add global id tag to the app, it will be used in restart
                tagtype = 0  ! dense, integer

--- a/driver-moab/main/prep_atm_mod.F90
+++ b/driver-moab/main/prep_atm_mod.F90
@@ -343,9 +343,6 @@ contains
                endif
 
                ! now take care of the mapper
-               if ( mapper_So2a%src_mbid .gt. -1 .and. iamroot_CPLID ) then
-                     write(logunit,F00) 'overwriting '// trim(mapper_So2a%mbname) // ' with MOAB'
-               endif
                mapper_So2a%intx_context = idintx
 
                if (compute_maps_online_o2a) then
@@ -389,7 +386,7 @@ contains
 
                   call moab_map_init_rcfile( mboxid, mbaxid, mbintxoa, type1, &
                         'seq_maps.rc', 'ocn2atm_smapname:', 'ocn2atm_smaptype:',samegrid_ao, &
-                        wgtIdo2a, 'mapper_Sof2a MOAB init', esmf_map_flag)
+                        wgtIdo2a, 'mapper_So2a MOAB init', esmf_map_flag)
                endif
 
             else ! samegrid_ao = TRUE
@@ -421,7 +418,7 @@ contains
          if ((mbaxid .ge. 0) .and.  (mbofxid .ge. 0)) then
             if (iamroot_CPLID) then
               write(logunit,*) ' '
-              write(logunit,F00) 'Initializing MOAB mapper_Sof2a'
+              write(logunit,F00) 'Initializing MOAB mapper_Sof2a with copy of mapper_So2a'
             endif
             ! We also need to compute the comm graph for the second hop, from the OCN on the coupler to the
             ! OCN for the intersection of OCN-ATM context (coverage)
@@ -432,9 +429,6 @@ contains
                call shr_sys_abort(subname//' ERROR in computing comm graph for second hop, ocnf-atm')
             endif
 
-            if ( mapper_Sof2a%src_mbid .gt. -1 .and. iamroot_CPLID) then
-               write(logunit,F00) 'overwriting '// trim(mapper_Sof2a%mbname) // ' with MOAB'
-            endif
             ! we identified the app mbofxid with !id_join = id_join + 1000! kind of random
             ! line 1267 in cplcomp_exchange_mod.F90
             context_id = ocn(1)%cplcompid + 1000
@@ -492,15 +486,9 @@ contains
          if ((mbaxid .ge. 0) .and.  (mboxid .ge. 0)) then
             if (iamroot_CPLID) then
               write(logunit,*) ' '
-              write(logunit,F00) 'Initializing MOAB mapper_Fo2a'
+              write(logunit,F00) 'Initializing MOAB mapper_Fo2a with copy of mapper_So2a'
             endif
             ! now take care of the mapper
-            if ( mapper_Fo2a%src_mbid .gt. -1 ) then
-                if (iamroot_CPLID) then
-                     write(logunit,F00) 'overwriting '//trim(mapper_Fo2a%mbname) &
-                             //' with MOAB'
-                endif
-            endif
             mapper_Fo2a%src_mbid = mboxid
             mapper_Fo2a%tgt_mbid = mbaxid
             mapper_Fo2a%intx_mbid = mbintxoa
@@ -512,15 +500,9 @@ contains
          if ((mbaxid .ge. 0) .and.  (mbofxid .ge. 0)) then
             if (iamroot_CPLID) then
               write(logunit,*) ' '
-              write(logunit,F00) 'Initializing MOAB mapper_Fof2a'
+              write(logunit,F00) 'Initializing MOAB mapper_Fof2a with copy of mapper_Sof2a'
             endif
             ! now take care of the mapper
-            if ( mapper_Fof2a%src_mbid .gt. -1 ) then
-                if (iamroot_CPLID) then
-                     write(logunit,F00) 'overwriting '//trim(mapper_Fof2a%mbname) &
-                             //' with MOAB'
-                endif
-            endif
             mapper_Fof2a%src_mbid = mbofxid
             mapper_Fof2a%tgt_mbid = mbaxid
             mapper_Fof2a%intx_mbid = mbintxoa
@@ -611,12 +593,6 @@ contains
                call shr_sys_abort(subname//' ERROR in computing comm graph for second hop, ice-atm')
             endif
             ! now take care of the mapper
-            if ( mapper_Si2a%src_mbid .gt. -1 ) then
-                if (iamroot_CPLID) then
-                     write(logunit,F00) 'overwriting '//trim(mapper_Si2a%mbname) &
-                             //' with MOAB'
-                endif
-            endif
             mapper_Si2a%src_mbid = mbixid
             mapper_Si2a%tgt_mbid = mbaxid
             mapper_Si2a%intx_mbid = mbintxia
@@ -705,13 +681,7 @@ contains
          if (ice_c2_atm) then
             if (iamroot_CPLID) then
               write(logunit,*) ' '
-              write(logunit,F00) 'Initializing MOAB mapper_Fi2a'
-            endif
-            if ( mapper_Fi2a%src_mbid .gt. -1 ) then
-                if (iamroot_CPLID) then
-                     write(logunit,F00) 'overwriting '//trim(mapper_Fi2a%mbname) &
-                             //' with MOAB'
-                endif
+              write(logunit,F00) 'Initializing MOAB mapper_Fi2a with copy of mapper_Si2a'
             endif
 
             mapper_Fi2a%src_mbid = mbixid
@@ -770,12 +740,6 @@ contains
             if (ierr .ne. 0) then
               write(logunit,*) subname,' error in registering lnd atm intx '
               call shr_sys_abort(subname//' ERROR in registering lnd atm intx ')
-            endif
-            if ( mapper_Fl2a%src_mbid .gt. -1 ) then
-                if (iamroot_CPLID) then
-                     write(logunit,F00) 'overwriting '//trim(mapper_Fl2a%mbname) &
-                             //' with MOAB'
-                endif
             endif
             mapper_Fl2a%src_mbid = mblxid
             mapper_Fl2a%tgt_mbid = mbaxid !
@@ -912,13 +876,7 @@ contains
          if ((mbaxid .ge. 0) .and.  (mblxid .ge. 0) ) then
             if (iamroot_CPLID) then
               write(logunit,*) ' '
-              write(logunit,F00) 'Initializing MOAB mapper_Sl2a'
-            endif
-            if ( mapper_Sl2a%src_mbid .gt. -1 ) then
-                if (iamroot_CPLID) then
-                     write(logunit,F00) 'overwriting '//trim(mapper_Sl2a%mbname) &
-                             //' with MOAB'
-                endif
+              write(logunit,F00) 'Initializing MOAB mapper_Sl2a with copy from mapper_Fl2a'
             endif
             mapper_Sl2a%src_mbid = mblxid
             mapper_Sl2a%tgt_mbid = mapper_Fl2a%tgt_mbid !

--- a/driver-moab/main/prep_atm_mod.F90
+++ b/driver-moab/main/prep_atm_mod.F90
@@ -300,17 +300,16 @@ contains
                if (.not. load_maps_from_disk_o2a) then
                   ierr =  iMOAB_ComputeMeshIntersectionOnSphere ( mboxid, mbaxid, mbintxoa )
                   if (ierr .ne. 0) then
-                     write(logunit,*) subname,' error in computing ocn atm intx'
-                     call shr_sys_abort(subname//' ERROR in computing ocn atm intx')
+                     write(logunit,*) subname,' error in computing OCN-ATM mesh intersection'
+                     call shr_sys_abort(subname//' ERROR in computing OCN-ATM mesh intersection')
                   endif
                   if (iamroot_CPLID) then
-                     write(logunit,*) 'iMOAB intersection between ocean and atm with id:', idintx
+                     write(logunit,*) 'iMOAB mesh intersection between OCN and ATM with id:', idintx
                   endif
                endif
 
                ! we also need to compute the comm graph for the second hop, from the ocn on coupler to the
                ! ocean for the intx ocean-atm context (coverage)
-               !
                type1 = 3; !  fv for ocean and atm; fv-cgll does not work anyway
                type2 = 3;
                ! ierr      = iMOAB_ComputeCommGraph( mboxid, mbintxoa, &mpicom_CPLID, &mpigrp_CPLID, &mpigrp_CPLID, &type1, &type2,
@@ -323,13 +322,9 @@ contains
                endif
 
                ! now take care of the mapper
-               if ( mapper_So2a%src_mbid .gt. -1 ) then
-                  if (iamroot_CPLID) then
-                        write(logunit,F00) 'overwriting '//trim(mapper_So2a%mbname) &
-                              //' mapper_So2a'
-                  endif
+               if ( mapper_So2a%src_mbid .gt. -1 .and. iamroot_CPLID ) then
+                     write(logunit,F00) 'overwriting '// trim(mapper_So2a%mbname) // ' mapper_So2a'
                endif
-
                mapper_So2a%intx_context = idintx
 
                if (.not. load_maps_from_disk_o2a) then
@@ -373,7 +368,7 @@ contains
 
                   call moab_map_init_rcfile( mboxid, mbaxid, mbintxoa, type1, &
                         'seq_maps.rc', 'ocn2atm_smapname:', 'ocn2atm_smaptype:',samegrid_ao, &
-                        wgtIdo2a, 'mapper_Sof2a moab initialization', esmf_map_flag)
+                        wgtIdo2a, 'mapper_Sof2a MOAB initialization', esmf_map_flag)
 
                endif
 
@@ -427,11 +422,8 @@ contains
                call shr_sys_abort(subname//' ERROR in computing comm graph for second hop, ocnf-atm')
             endif
 
-            if ( mapper_Sof2a%src_mbid .gt. -1 ) then
-                if (iamroot_CPLID) then
-                     write(logunit,F00) 'overwriting '//trim(mapper_Sof2a%mbname) &
-                             //' mapper_Sof2a'
-                endif
+            if ( mapper_Sof2a%src_mbid .gt. -1 .and. iamroot_CPLID) then
+               write(logunit,F00) 'overwriting '// trim(mapper_Sof2a%mbname) // ' mapper_Sof2a'
             endif
             ! we identified the app mbofxid with !id_join = id_join + 1000! kind of random
             ! line 1267 in cplcomp_exchange_mod.F90
@@ -649,10 +641,9 @@ contains
 
             else
                type1 = 3 ! this is type of grid, maybe should be saved on imoab app ?
-
                call moab_map_init_rcfile(mbixid, mbaxid, mbintxia, type1, &
                      'seq_maps.rc', 'ice2atm_smapname:', 'ice2atm_smaptype:', samegrid_ao, &
-                     wgtIdi2a, 'mapper_Si2a moab initialization', esmf_map_flag)
+                     wgtIdi2a, 'mapper_Si2a MOAB initialization', esmf_map_flag)
             endif
 
 #ifdef MOABDEBUG
@@ -850,11 +841,9 @@ contains
                   endif
                else
                   type1 = 3 ! this is type of grid, maybe should be saved on imoab app ?
-
                   call moab_map_init_rcfile(mblxid, mbaxid, mbintxla, type1, &
                         'seq_maps.rc', 'lnd2atm_fmapname:', 'lnd2atm_fmaptype:', samegrid_al, &
-                        wgtIdl2a, 'mapper_Fl2a moab initialization', esmf_map_flag)
-
+                        wgtIdl2a, 'mapper_Fl2a MOAB initialization', esmf_map_flag)
                endif
 
             else  ! the same mesh , atm and lnd use the same dofs, but restricted

--- a/driver-moab/main/prep_atm_mod.F90
+++ b/driver-moab/main/prep_atm_mod.F90
@@ -1222,18 +1222,6 @@ contains
           endif
 
        end do
-#ifdef HAVE_MOAB
-       ! just to mark it; we know that l2x_am should be 0, and we should init everything to 0 just because it will affect
-       l2x_am = 0!
-       ! allocate(l2x_am (lsize, nlflds))
-       tagname = trim(seq_flds_l2x_fields)//C_NULL_CHAR
-       arrsize = lsize * nlflds
-       ent_type = 1 ! always atm on coupler is cells
-       ierr = iMOAB_SetDoubleTagStorage ( mbaxid, tagname, arrsize , ent_type, l2x_am)
-       if (ierr .ne. 0) then
-           call shr_sys_abort(subname//' error in setting l2x_am array in init ')
-       endif
-#endif
     endif
 
     ! Zero attribute vector

--- a/driver-moab/main/prep_atm_mod.F90
+++ b/driver-moab/main/prep_atm_mod.F90
@@ -149,6 +149,7 @@ contains
    logical                          :: ocn_present    ! .true.  => ocn is present
    logical                          :: ice_present    ! .true.  => ice is present
    logical                          :: lnd_present    ! .true.  => lnd is prsent
+   logical                          :: cpl_compute_maps_online    ! .true.  => maps are computed online 
    character(CL)                    :: ocn_gnam       ! ocn grid
    character(CL)                    :: atm_gnam       ! atm grid
    character(CL)                    :: lnd_gnam       ! lnd grid
@@ -182,6 +183,7 @@ contains
       atm_gnam=atm_gnam,             &
       ocn_gnam=ocn_gnam,             &
       lnd_gnam=lnd_gnam,             &
+      cpl_compute_maps_online=cpl_compute_maps_online, &
       esmf_map_flag=esmf_map_flag)
 
    allocate(mapper_So2a)
@@ -226,10 +228,10 @@ contains
       wgtIdo2a = 'conservative_o2a'//C_NULL_CHAR
       wgtIdi2a = 'conservative_i2a'//C_NULL_CHAR
       wgtIdl2a = 'conservative_l2a'//C_NULL_CHAR
-      load_maps_from_disk_o2a = .true. ! Force read from disk
-      load_maps_from_disk_i2a = .true. ! Force read from disk
-      ! load_maps_from_disk_l2a = .false. ! Force online computation
-      load_maps_from_disk_l2a = .true. ! Force read from disk
+      load_maps_from_disk_o2a = not(cpl_compute_maps_online) ! read from disk or compute online
+      load_maps_from_disk_i2a = not(cpl_compute_maps_online) ! read from disk or compute online
+      load_maps_from_disk_l2a = not(cpl_compute_maps_online) ! read from disk or compute online
+      ! load_maps_from_disk_l2a = .false. ! Explicitly force online computation
 #endif
 
       if (ocn_c2_atm) then

--- a/driver-moab/main/prep_atm_mod.F90
+++ b/driver-moab/main/prep_atm_mod.F90
@@ -228,9 +228,9 @@ contains
       wgtIdo2a = 'conservative_o2a'//C_NULL_CHAR
       wgtIdi2a = 'conservative_i2a'//C_NULL_CHAR
       wgtIdl2a = 'conservative_l2a'//C_NULL_CHAR
-      load_maps_from_disk_o2a = not(cpl_compute_maps_online) ! read from disk or compute online
-      load_maps_from_disk_i2a = not(cpl_compute_maps_online) ! read from disk or compute online
-      load_maps_from_disk_l2a = not(cpl_compute_maps_online) ! read from disk or compute online
+      load_maps_from_disk_o2a = .not. cpl_compute_maps_online ! read from disk or compute online
+      load_maps_from_disk_i2a = .not. cpl_compute_maps_online ! read from disk or compute online
+      load_maps_from_disk_l2a = .not. cpl_compute_maps_online ! read from disk or compute online
       ! load_maps_from_disk_l2a = .false. ! Explicitly force online computation
 #endif
 

--- a/driver-moab/main/prep_ice_mod.F90
+++ b/driver-moab/main/prep_ice_mod.F90
@@ -127,7 +127,6 @@ contains
     ! MOAB stuff
     integer                  :: ierr, idintx, rank
     character*32             :: appname, outfile, wopts, lnum
-    character*32             :: dm1, dm2, dofnameS, dofnameT, wgtIdef
     integer                  :: orderS, orderT, volumetric, noConserve, validate, fInverseDistanceMap
     integer                  :: fNoBubble, monotonicity
 ! will do comm graph over coupler PES, in 2-hop strategy
@@ -197,16 +196,13 @@ contains
 
 #ifdef HAVE_MOAB
           if ( (mbixid .ge. 0) .and. (mboxid .ge. 0)) then
-            ! moab also will do just a rearrange, hopefully, in this case, based on the comm graph
-            !   that is computed here
+            ! MOAB will do just a rearrange, based on the comm graph that is computed here
             call seq_comm_getinfo(CPLID ,mpigrp=mpigrp_CPLID)   !  second group, the coupler group CPLID is global variable
 
             type1 = 3
-            type2 = 3 ! fv-fv graph
-            ! iMOAB compute comm graph ice-ocn, based on the same global id
-            ! it will be a simple migrate from ice mesh directly to ocean, using the comm graph computed here
-            ! TODO: find if CommGraph already exists.
-
+            type2 = 3 ! FV-FV graph
+            ! iMOAB compute comm graph ICE-OCN, based on the same global ID
+            ! This will be a simple migration from ICE mesh directly to OCN, using the comm graph computed here
             ierr = iMOAB_ComputeCommGraph( mboxid, mbixid, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, &
                type1, type2, ocn(1)%cplcompid, ice(1)%cplcompid)
             if (ierr .ne. 0) then

--- a/driver-moab/main/prep_ice_mod.F90
+++ b/driver-moab/main/prep_ice_mod.F90
@@ -196,6 +196,10 @@ contains
 
 #ifdef HAVE_MOAB
           if ( (mbixid .ge. 0) .and. (mboxid .ge. 0)) then
+            if (iamroot_CPLID) then
+               write(logunit,*) ' '
+               write(logunit,F00) 'Initializing MOAB mapper_SFo2i'
+            end if
             ! MOAB will do just a rearrange, based on the comm graph that is computed here
             call seq_comm_getinfo(CPLID ,mpigrp=mpigrp_CPLID)   !  second group, the coupler group CPLID is global variable
 

--- a/driver-moab/main/prep_lnd_mod.F90
+++ b/driver-moab/main/prep_lnd_mod.F90
@@ -242,6 +242,10 @@ contains
 #ifdef HAVE_MOAB
           ! Call moab intx only if land and river are init in moab
           if ((mbrxid .ge. 0) .and.  (mblxid .ge. 0)) then
+            if (iamroot_CPLID) then
+               write(logunit,*) ' '
+               write(logunit,F00) 'Initializing MOAB mapper_Fr2l'
+            end if
             appname = "ROF_LND_COU"//C_NULL_CHAR
             ! idintx is a unique number of MOAB app that takes care of intx between rof and lnd mesh
             idintx = 100*rof(1)%cplcompid + lnd(1)%cplcompid ! something different, to differentiate it
@@ -436,6 +440,10 @@ contains
           ! we will use just a comm graph to send data from atm to land on coupler
           ! this is just a rearrange in a way
           if ((mbaxid .ge. 0) .and.  (mblxid .ge. 0) ) then
+            if (iamroot_CPLID) then
+               write(logunit,*) ' '
+               write(logunit,F00) 'Initializing MOAB mapper_Sa2l and mapper_Fa2l'
+            end if
             appname = "ATM_LND_COU"//C_NULL_CHAR
             ! idintx is a unique number of MOAB app that takes care of intx between lnd and atm mesh
             idintx = 100*atm(1)%cplcompid + lnd(1)%cplcompid ! something different, to differentiate it

--- a/driver-moab/main/prep_lnd_mod.F90
+++ b/driver-moab/main/prep_lnd_mod.F90
@@ -138,6 +138,7 @@ contains
     logical                  :: samegrid_lg   ! samegrid land and glc
     logical                  :: esmf_map_flag ! .true. => use esmf for mapping
     logical                  :: lnd_present   ! .true. => land is present
+    logical                  :: cpl_compute_maps_online    ! .true.  => maps are computed online 
     logical                  :: iamroot_CPLID ! .true. => CPLID masterproc
     character(CL)            :: atm_gnam      ! atm grid
     character(CL)            :: lnd_gnam      ! lnd grid
@@ -180,7 +181,8 @@ contains
          atm_gnam=atm_gnam,             &
          lnd_gnam=lnd_gnam,             &
          rof_gnam=rof_gnam,             &
-         glc_gnam=glc_gnam)
+         glc_gnam=glc_gnam,             &
+         cpl_compute_maps_online=cpl_compute_maps_online )
 
     allocate(mapper_Sa2l)
     allocate(mapper_Fa2l)
@@ -192,9 +194,9 @@ contains
       wgtIdr2l = 'conservative_r2l'//C_NULL_CHAR
       wgtIda2l_conservative = 'conservative_a2l'//C_NULL_CHAR
       wgtIda2l_bilinear = 'bilinear_a2l'//C_NULL_CHAR
-      load_maps_from_disk_r2l = .true. ! Force read from disk
-      load_maps_from_disk_a2l = .true. ! Force read from disk
-      ! load_maps_from_disk_a2l = .false. ! Force online computation
+      load_maps_from_disk_r2l = not(cpl_compute_maps_online) ! read from disk or compute online
+      load_maps_from_disk_a2l = not(cpl_compute_maps_online) ! read from disk or compute online
+      ! load_maps_from_disk_a2l = .false. ! Explicitly force online computation
 #endif
 
     if (lnd_present) then

--- a/driver-moab/main/prep_lnd_mod.F90
+++ b/driver-moab/main/prep_lnd_mod.F90
@@ -18,7 +18,6 @@ module prep_lnd_mod
   use seq_comm_mct,     only: mbrxid   !          iMOAB id of moab rof on coupler pes (FV now)
   use seq_comm_mct,     only: mbintxal ! iMOAB id for intx mesh between atm and lnd
   use seq_comm_mct,     only: mbintxrl ! iMOAB id for intx mesh between river and land
-  use seq_comm_mct,     only: mb_rof_aream_computed  ! signal
 
   use seq_comm_mct,     only: mbaxid   ! iMOAB id for atm migrated mesh to coupler pes
   use seq_comm_mct,     only: atm_pg_active  ! whether the atm uses FV mesh or not ; made true if fv_nphys > 0
@@ -364,7 +363,6 @@ contains
                                                     trim(dofnameS), trim(dofnameT) )
 
                   ! signal that the aream for rof has been computed
-                  mb_rof_aream_computed = .true.
                   if (ierr .ne. 0) then
                     write(logunit,*) subname,' error in computing rl weights '
                     call shr_sys_abort(subname//' ERROR in computing rl weights ')

--- a/driver-moab/main/prep_lnd_mod.F90
+++ b/driver-moab/main/prep_lnd_mod.F90
@@ -194,8 +194,8 @@ contains
       wgtIdr2l = 'conservative_r2l'//C_NULL_CHAR
       wgtIda2l_conservative = 'conservative_a2l'//C_NULL_CHAR
       wgtIda2l_bilinear = 'bilinear_a2l'//C_NULL_CHAR
-      load_maps_from_disk_r2l = not(cpl_compute_maps_online) ! read from disk or compute online
-      load_maps_from_disk_a2l = not(cpl_compute_maps_online) ! read from disk or compute online
+      load_maps_from_disk_r2l = .not. cpl_compute_maps_online ! read from disk or compute online
+      load_maps_from_disk_a2l = .not. cpl_compute_maps_online ! read from disk or compute online
       ! load_maps_from_disk_a2l = .false. ! Explicitly force online computation
 #endif
 

--- a/driver-moab/main/prep_lnd_mod.F90
+++ b/driver-moab/main/prep_lnd_mod.F90
@@ -138,7 +138,7 @@ contains
     logical                  :: samegrid_lg   ! samegrid land and glc
     logical                  :: esmf_map_flag ! .true. => use esmf for mapping
     logical                  :: lnd_present   ! .true. => land is present
-    logical                  :: cpl_compute_maps_online    ! .true.  => maps are computed online 
+    logical                  :: cpl_compute_maps_online    ! .true.  => maps are computed online
     logical                  :: iamroot_CPLID ! .true. => CPLID masterproc
     character(CL)            :: atm_gnam      ! atm grid
     character(CL)            :: lnd_gnam      ! lnd grid
@@ -165,7 +165,7 @@ contains
     integer arrsize  ! for setting the r2x fields on land to 0
     integer ent_type ! for setting tags
     real (kind=R8) , allocatable :: tmparray (:) ! used to set the r2x fields to 0
-    logical :: load_maps_from_disk_r2l, load_maps_from_disk_a2l
+    logical :: compute_maps_online_r2l, compute_maps_online_a2l
 
     integer  nghlay ! used to set the number of ghost layers, needed for bilinear map
     integer  nghlay_tgt
@@ -194,9 +194,9 @@ contains
       wgtIdr2l = 'conservative_r2l'//C_NULL_CHAR
       wgtIda2l_conservative = 'conservative_a2l'//C_NULL_CHAR
       wgtIda2l_bilinear = 'bilinear_a2l'//C_NULL_CHAR
-      load_maps_from_disk_r2l = .not. cpl_compute_maps_online ! read from disk or compute online
-      load_maps_from_disk_a2l = .not. cpl_compute_maps_online ! read from disk or compute online
-      ! load_maps_from_disk_a2l = .false. ! Explicitly force online computation
+      compute_maps_online_r2l = cpl_compute_maps_online ! read from disk or compute online
+      compute_maps_online_a2l = cpl_compute_maps_online ! read from disk or compute online
+      ! compute_maps_online_a2l = .false. ! Explicitly force read from disk
 #endif
 
     if (lnd_present) then
@@ -286,7 +286,7 @@ contains
                   call shr_sys_abort(subname//' ERROR in computing ROF-LND coverage')
                endif
 
-              if (.not. load_maps_from_disk_r2l) then
+              if (compute_maps_online_r2l) then
                   ierr =  iMOAB_ComputeMeshIntersectionOnSphere( mbrxid, mblxid, mbintxrl )
                   if (ierr .ne. 0) then
                     write(logunit,*) subname,' error in computing   rof lnd intx'
@@ -338,7 +338,7 @@ contains
 
               ! because we will project fields from rof to lnd grid, we need to define
               !  the r2x fields to lnd grid on coupler side
-              if (.not. load_maps_from_disk_r2l) then
+              if (compute_maps_online_r2l) then
                   volumetric = 0 ! can be 1 only for FV->DGLL or FV->CGLL;
                   dm1 = "fv"//C_NULL_CHAR
                   dofnameS="GLOBAL_ID"//C_NULL_CHAR
@@ -480,7 +480,7 @@ contains
                   call shr_sys_abort(subname//' ERROR in computing ATM-LND coverage')
                endif
 
-              if (.not. load_maps_from_disk_a2l) then
+              if (compute_maps_online_a2l) then
                 if (iamroot_CPLID) then
                   write(logunit,*) 'iMOAB intersection between atm and land with id:', idintx
                 endif
@@ -521,7 +521,7 @@ contains
                 call shr_sys_abort(subname//' ERROR in computing comm graph for second hop, atm-lnd')
               endif
 
-              if (.not. load_maps_from_disk_a2l) then
+              if (compute_maps_online_a2l) then
                   volumetric = 0 ! can be 1 only for FV->DGLL or FV->CGLL;
                   if (atm_pg_active) then
                     dm1 = "fv"//C_NULL_CHAR

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -174,7 +174,7 @@ module prep_ocn_mod
   logical                  :: iamin_CPLALLICEID     ! pe associated with CPLALLICEID
 
 #ifdef HAVE_MOAB
-  logical                  :: load_maps_from_disk_a2o
+  logical                  :: compute_maps_online_a2o
 #endif
 
 contains
@@ -230,7 +230,7 @@ contains
     logical                  :: ocn_present    ! .true.  => ocn is present
     logical                  :: atm_present    ! .true.  => atm is present
     logical                  :: ice_present    ! .true.  => ice is present
-    logical                  :: cpl_compute_maps_online    ! .true.  => maps are computed online 
+    logical                  :: cpl_compute_maps_online    ! .true.  => maps are computed online
     logical                  :: samegrid_ao    ! samegrid atm and ocean
     logical                  :: samegrid_og    ! samegrid glc and ocean
     logical                  :: samegrid_ow    ! samegrid ocean and wave
@@ -298,7 +298,7 @@ contains
          esmf_map_flag=esmf_map_flag   )
 
 #ifdef HAVE_MOAB
-    load_maps_from_disk_a2o = .not. cpl_compute_maps_online  ! read from disk or compute online
+    compute_maps_online_a2o = cpl_compute_maps_online  ! read from disk or compute online
     wgtIda2o_conservative = 'conservative_a2o'//C_NULL_CHAR
     wgtIda2o_bilinear = 'bilinear_a2o'//C_NULL_CHAR
     wgtIdr2o_conservative = 'conservative_r2o'//C_NULL_CHAR
@@ -460,7 +460,7 @@ contains
                   call shr_sys_abort(subname//' ERROR in computing ATM-OCN coverage')
                endif
 
-               if (.not. load_maps_from_disk_a2o) then
+               if (compute_maps_online_a2o) then
                   ! first compute the overlap mesh between mbaxid (ATM) and mboxid (OCN) on coupler PEs
                   ierr =  iMOAB_ComputeMeshIntersectionOnSphere( mbaxid, mboxid, mbintxao )
                   if (ierr .ne. 0) then
@@ -490,7 +490,7 @@ contains
                   call shr_sys_abort(subname//' ERROR in coin defining tags for seq_flds_a2x_fields on OCN cpl')
                endif
 
-               if (.not. load_maps_from_disk_a2o) then
+               if (compute_maps_online_a2o) then
                   volumetric = 0 ! can be 1 only for FV->DGLL or FV->CGLL;
                   if (atm_pg_active) then
                      dm1 = "fv"//C_NULL_CHAR
@@ -571,7 +571,7 @@ contains
 #ifdef MOABDEBUG
                wopts = C_NULL_CHAR
                call shr_mpi_commrank( mpicom_CPLID, rank )
-               if (rank .lt. 5 .and. .not. load_maps_from_disk_a2o) then
+               if (rank .lt. 5 .and. compute_maps_online_a2o) then
                   write(lnum,"(I0.2)")rank !
                   outfile = 'intx_ao_'//trim(lnum)// '.h5m' // C_NULL_CHAR
                   ierr = iMOAB_WriteMesh(mbintxao, outfile, wopts) ! write local intx file

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -420,6 +420,10 @@ contains
 #ifdef HAVE_MOAB
           ! Call moab intx only if atm and ocn are init in moab
           if ((mbaxid .ge. 0) .and.  (mboxid .ge. 0)) then
+            if (iamroot_CPLID) then
+               write(logunit,*) ' '
+               write(logunit,F00) 'Initializing MOAB mapper_Fa2o and mapper_Sa2o'
+            end if
             appname = "ATM_OCN_COU"//C_NULL_CHAR
             ! idintx is a unique number of MOAB app that takes care of intx between ocn and atm mesh
             idintx = 100*atm(1)%cplcompid + ocn(1)%cplcompid ! something different, to differentiate it
@@ -473,9 +477,6 @@ contains
                end if
 
                ! now take care of the mapper
-               if ( mapper_Fa2o%src_mbid .gt. -1 .and. iamroot_CPLID ) then
-                     write(logunit,F00) 'overwriting '// trim(mapper_Fa2o%mbname) // ' mapper_Fa2o'
-               endif
                mapper_Fa2o%intx_context = idintx
                !! updated mapper_Fa2o --
 
@@ -640,9 +641,10 @@ contains
           if ((mbaxid .ge. 0) .and.  (mboxid .ge. 0)) then
 
             ! now take care of the 2 new mappers
-            if ( mapper_Sa2o%src_mbid .gt. -1 .and. iamroot_CPLID ) then
-               write(logunit,F00) 'overwriting mapper_Sa2o with MOAB contexts'
-            endif
+            if (iamroot_CPLID) then
+               write(logunit,*) ' '
+               write(logunit,F00) 'Finish initializing MOAB mapper_Sa2o bilinear'
+            end if
             mapper_Sa2o%src_mbid = mbaxid
             mapper_Sa2o%tgt_mbid = mboxid
             mapper_Sa2o%intx_mbid = mbintxao
@@ -651,9 +653,10 @@ contains
             mapper_Sa2o%weight_identifier = wgtIda2o_bilinear
             mapper_Sa2o%mbname = 'mapper_Sa2o'
 
-            if ( mapper_Va2o%src_mbid .gt. -1 .and. iamroot_CPLID ) then
-               write(logunit,F00) 'overwriting mapper_Va2o with MOAB contexts'
-            endif
+            if (iamroot_CPLID) then
+               write(logunit,*) ' '
+               write(logunit,F00) 'Initializing MOAB mapper_Va2o bilinear same as Sa2o'
+            end if
             mapper_Va2o%src_mbid = mbaxid
             mapper_Va2o%tgt_mbid = mboxid
             mapper_Va2o%intx_mbid = mbintxao
@@ -675,6 +678,10 @@ contains
           call seq_map_init_rearrolap(mapper_SFi2o, ice(1), ocn(1), 'mapper_SFi2o')
 #ifdef HAVE_MOAB
           if ( (mbixid .ge. 0) .and. (mboxid .ge. 0)) then
+             if (iamroot_CPLID) then
+               write(logunit,*) ' '
+               write(logunit,F00) 'Initializing MOAB mapper_SFi2o'
+             end if
             ! moab also will do just a rearrange, hopefully, in this case, based on the comm graph
             !   that is computed here
             call seq_comm_getinfo(CPLID ,mpigrp=mpigrp_CPLID)   !  second group, the coupler group CPLID is global variable
@@ -762,6 +769,10 @@ contains
               write(logunit,*) subname,' error in compute coverage mesh rof for ocean'
               call shr_sys_abort(subname//' ERROR in compute coverage mesh rof for ocean ')
           endif
+          if (iamroot_CPLID) then
+             write(logunit,*) ' '
+             write(logunit,F00) 'Initializing MOAB mapper_Rr2o_liq'
+          end if
 
           type_grid = 3 ! this is type of grid, maybe should be saved on imoab app ?
           call moab_map_init_rcfile(mbrxid, mboxid, mbintxro, type_grid, &
@@ -886,12 +897,10 @@ contains
 ! us the same one for mapper_Rr2o_ice and mapper_Fr2o
 #ifdef HAVE_MOAB
 ! now take care of the mapper for MOAB mapper_Rr2o_ice
-            if ( mapper_Rr2o_ice%src_mbid .gt. -1 ) then
-                if (iamroot_CPLID) then
-                     write(logunit,F00) 'overwriting '//trim(mapper_Rr2o_ice%mbname) &
-                             //' mapper_Rr2o_ice'
-                endif
-            endif
+            if (iamroot_CPLID) then
+               write(logunit,*) ' '
+               write(logunit,F00) 'Initializing MOAB mapper_Rr2o_ice same as mapper_Rr2o_liq'
+            end if
             mapper_Rr2o_ice%src_mbid = mbrxid
             mapper_Rr2o_ice%tgt_mbid = mboxid ! special
             mapper_Rr2o_ice%intx_mbid = mbintxro
@@ -912,12 +921,10 @@ contains
                   string='mapper_Fr2o initialization', esmf_map=esmf_map_flag)
 #ifdef HAVE_MOAB
 ! now take care of the mapper for MOAB mapper_Fr2o
-            if ( mapper_Fr2o%src_mbid .gt. -1 ) then
-                if (iamroot_CPLID) then
-                     write(logunit,F00) 'overwriting '//trim(mapper_Fr2o%mbname) &
-                             //' mapper_Fr2o'
-                endif
-            endif
+             if (iamroot_CPLID) then
+                write(logunit,*) ' '
+                write(logunit,F00) 'Initializing MOAB mapper_Fr2o'
+             end if
                mapper_Fr2o%src_mbid = mbrxid
                mapper_Fr2o%tgt_mbid = mboxid ! special
                mapper_Fr2o%intx_mbid = mbintxro

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -230,6 +230,7 @@ contains
     logical                  :: ocn_present    ! .true.  => ocn is present
     logical                  :: atm_present    ! .true.  => atm is present
     logical                  :: ice_present    ! .true.  => ice is present
+    logical                  :: cpl_compute_maps_online    ! .true.  => maps are computed online 
     logical                  :: samegrid_ao    ! samegrid atm and ocean
     logical                  :: samegrid_og    ! samegrid glc and ocean
     logical                  :: samegrid_ow    ! samegrid ocean and wave
@@ -280,13 +281,6 @@ contains
 
     !---------------------------------------------------------------
 
-#ifdef HAVE_MOAB
-    load_maps_from_disk_a2o = .true. ! Force read from disk
-    wgtIda2o_conservative = 'conservative_a2o'//C_NULL_CHAR
-    wgtIda2o_bilinear = 'bilinear_a2o'//C_NULL_CHAR
-    wgtIdr2o_conservative = 'bilinear_a2o'//C_NULL_CHAR
-#endif
-
     call seq_infodata_getData(infodata , &
          ocn_present=ocn_present       , &
          atm_present=atm_present       , &
@@ -300,7 +294,15 @@ contains
          atm_nx=atm_nx                 , &
          atm_ny=atm_ny                 , &
          glc_gnam=glc_gnam             , &
+         cpl_compute_maps_online=cpl_compute_maps_online, &
          esmf_map_flag=esmf_map_flag   )
+
+#ifdef HAVE_MOAB
+    load_maps_from_disk_a2o = not(cpl_compute_maps_online) ! read from disk or compute online
+    wgtIda2o_conservative = 'conservative_a2o'//C_NULL_CHAR
+    wgtIda2o_bilinear = 'bilinear_a2o'//C_NULL_CHAR
+    wgtIdr2o_conservative = 'conservative_r2o'//C_NULL_CHAR
+#endif
 
     allocate(mapper_Sa2o)
     allocate(mapper_Va2o)

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -298,7 +298,7 @@ contains
          esmf_map_flag=esmf_map_flag   )
 
 #ifdef HAVE_MOAB
-    load_maps_from_disk_a2o = not(cpl_compute_maps_online) ! read from disk or compute online
+    load_maps_from_disk_a2o = .not. cpl_compute_maps_online  ! read from disk or compute online
     wgtIda2o_conservative = 'conservative_a2o'//C_NULL_CHAR
     wgtIda2o_bilinear = 'bilinear_a2o'//C_NULL_CHAR
     wgtIdr2o_conservative = 'conservative_r2o'//C_NULL_CHAR

--- a/driver-moab/main/prep_rof_mod.F90
+++ b/driver-moab/main/prep_rof_mod.F90
@@ -30,7 +30,6 @@ module prep_rof_mod
   use component_type_mod, only: ocn ! used for context for projection towards ocean from rof !
   use prep_lnd_mod, only: prep_lnd_get_mapper_Fr2l
   use map_lnd2rof_irrig_mod, only: map_lnd2rof_irrig
-  use seq_comm_mct,     only: mb_rof_aream_computed  ! signal
 
   use iso_c_binding
 #ifdef MOABCOMP
@@ -455,7 +454,6 @@ contains
                                                    fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
                                                    noConserve, validate, &
                                                    trim(dofnameS), trim(dofnameT) )
-                  mb_rof_aream_computed = .true. ! signal
                   if (ierr .ne. 0) then
                      write(logunit,*) subname,' error in computing lr weights '
                      call shr_sys_abort(subname//' ERROR in computing lr weights ')

--- a/driver-moab/main/prep_rof_mod.F90
+++ b/driver-moab/main/prep_rof_mod.F90
@@ -326,6 +326,10 @@ contains
 #ifdef HAVE_MOAB
           ! Call moab intx only if land and river are init in moab
           if ((mblxid .ge. 0) .and.  (mbrxid .ge. 0)) then
+            if (iamroot_CPLID) then
+               write(logunit,*) ' '
+               write(logunit,F00) 'Initializing MOAB mapper_Fl2r'
+            endif
             appname = "LND_ROF_COU"//C_NULL_CHAR
             ! idintx is a unique number of MOAB app that takes care of intx between lnd and rof mesh
             idintx = 100*lnd(1)%cplcompid + rof(1)%cplcompid ! something different, to differentiate it
@@ -546,6 +550,10 @@ contains
 #ifdef HAVE_MOAB
           ! Call moab intx only if atm  and river are init in moab
           if ((mbrxid .ge. 0) .and.  (mbaxid .ge. 0)) then
+            if (iamroot_CPLID) then
+               write(logunit,*) ' '
+               write(logunit,F00) 'Initializing MOAB mapper_Fa2r'
+            end if
             appname = "ATM_ROF_COU"//C_NULL_CHAR
             ! idintx is a unique number of MOAB app that takes care of intx between rof and atm mesh
             idintx = 100*atm(1)%cplcompid + rof(1)%cplcompid ! something different, to differentiate it
@@ -688,6 +696,10 @@ contains
                string='mapper_Sa2r initialization', esmf_map=esmf_map_flag)
 #ifdef HAVE_MOAB
             ! now take care of the mapper, use the same one as before
+            if (iamroot_CPLID) then
+               write(logunit,*) ' '
+               write(logunit,F00) 'Initializing MOAB mapper_Sa2r'
+            end if
             if ( mapper_Sa2r%src_mbid .gt. -1 ) then
                 if (iamroot_CPLID) then
                      write(logunit,F00) 'overwriting '//trim(mapper_Sa2r%mbname) &

--- a/driver-moab/main/prep_rof_mod.F90
+++ b/driver-moab/main/prep_rof_mod.F90
@@ -12,10 +12,10 @@ module prep_rof_mod
   use seq_comm_mct,     only: mbaxid   ! iMOAB id for atm migrated mesh to coupler pes (migrate either mhid or mhpgx, depending on atm_pg_active)
   use seq_comm_mct,     only: mbrxid   ! iMOAB id of moab rof read on couple pes
   use seq_comm_mct,     only: mbintxar ! iMOAB id for intx mesh between atm and river
-  use seq_comm_mct,     only: mboxid   
+  use seq_comm_mct,     only: mboxid
   use seq_comm_mct,     only: mbintxlr ! iMOAB id for intx mesh between land and river
   use seq_comm_mct,     only : atm_pg_active  ! whether the atm uses FV mesh or not ; made true if fv_nphys > 0
-  !use dimensions_mod,   only : np     ! for atmosphere degree 
+  !use dimensions_mod,   only : np     ! for atmosphere degree
   use seq_comm_mct,     only: seq_comm_getData=>seq_comm_setptrs
   use seq_infodata_mod, only: seq_infodata_type, seq_infodata_getdata
   use shr_log_mod     , only: errMsg => shr_log_errMsg
@@ -50,7 +50,7 @@ module prep_rof_mod
 
 #ifdef HAVE_MOAB
   public :: prep_rof_mrg_moab
-  public :: prep_rof_accum_lnd_moab  
+  public :: prep_rof_accum_lnd_moab
   public :: prep_rof_accum_atm_moab
   public :: prep_rof_accum_ocn_moab
   public :: prep_rof_accum_avg_moab
@@ -76,7 +76,7 @@ module prep_rof_mod
   public :: prep_rof_get_mapper_Fa2r
 
   public :: prep_rof_get_sharedFieldsOcnRof
-  public :: prep_rof_get_o2racc_om ! return a pointer to private array !!! 
+  public :: prep_rof_get_o2racc_om ! return a pointer to private array !!!
   public :: prep_rof_get_o2racc_om_cnt
 
   public :: prep_rof_get_l2racc_lm_cnt
@@ -107,11 +107,11 @@ module prep_rof_mod
   type(mct_aVect), pointer :: l2racc_lx(:)   ! lnd export, lnd grid, cpl pes
   integer        , target  :: l2racc_lx_cnt  ! l2racc_lx: number of time samples accumulated
   type(mct_aVect), pointer :: a2racc_ax(:)   ! atm export, atm grid, cpl pes
-  integer        , target  :: a2racc_ax_cnt  ! a2racc_ax: number of time samples accumulated 
+  integer        , target  :: a2racc_ax_cnt  ! a2racc_ax: number of time samples accumulated
   type(mct_aVect), pointer :: o2racc_ox(:)   ! ocn export, ocn grid, cpl pes
   integer        , target  :: o2racc_ox_cnt  ! o2racc_ox: number of time samples accumulated
 
-  ! accumulation variables over moab fields 
+  ! accumulation variables over moab fields
   character(CXX)                        :: sharedFieldsLndRof ! used in moab to define l2racc_lm
   real (kind=R8) , allocatable, private, target :: l2racc_lm(:,:)   ! lnd export, lnd grid, cpl pes
   real (kind=R8) , allocatable, private :: l2x_lm2(:,:)  ! basically l2x_lm, but in another copy, on rof module
@@ -122,7 +122,7 @@ module prep_rof_mod
   character(CXX)       :: sharedFieldsAtmRof ! used in moab to define a2racc_am
   real (kind=R8) , allocatable, private ::  a2racc_am(:,:)   ! atm export, atm grid, cpl pes
   real (kind=R8) , allocatable, private :: a2x_am2(:,:)  ! basically a2x_am, but in another copy, on rof module
-  integer        , target  :: a2racc_am_cnt  ! a2racc_am: number of time samples accumulated 
+  integer        , target  :: a2racc_am_cnt  ! a2racc_am: number of time samples accumulated
   integer :: nfields_sh_ar ! number of fields in sharedFieldsAtmRof
   integer :: lsize_am ! size of atm in moab, local
 
@@ -147,11 +147,15 @@ module prep_rof_mod
 
   ! moab stuff
    real (kind=R8) , allocatable, private :: fractions_rm (:,:) ! will retrieve the fractions from rof, and use them
-  !  they were init with 
-  ! character(*),parameter :: fraclist_r = 'lfrac:lfrin:rfrac'  in moab, on the fractions 
+  !  they were init with
+  ! character(*),parameter :: fraclist_r = 'lfrac:lfrin:rfrac'  in moab, on the fractions
   real (kind=R8) , allocatable, private :: x2r_rm (:,:) ! result of merge
   real (kind=R8) , allocatable, private :: a2x_rm (:,:)
   real (kind=R8) , allocatable, private :: l2x_rm (:,:)
+
+#ifdef HAVE_MOAB
+  logical :: load_maps_from_disk_l2r, load_maps_from_disk_a2r
+#endif
 
   !================================================================================================
 
@@ -162,8 +166,8 @@ contains
   subroutine prep_rof_init(infodata, lnd_c2_rof, atm_c2_rof, ocn_c2_rof)
 
    use iMOAB, only: iMOAB_ComputeMeshIntersectionOnSphere, iMOAB_RegisterApplication, &
-      iMOAB_WriteMesh, iMOAB_DefineTagStorage, iMOAB_ComputeCommGraph, & 
-      iMOAB_ComputeScalarProjectionWeights, iMOAB_GetMeshInfo
+      iMOAB_WriteMesh, iMOAB_DefineTagStorage, iMOAB_ComputeCommGraph, &
+      iMOAB_ComputeScalarProjectionWeights, iMOAB_GetMeshInfo, iMOAB_ComputeCoverageMesh
     !---------------------------------------------------------------
     ! Description
     ! Initialize module attribute vectors and all other non-mapping
@@ -205,7 +209,8 @@ contains
     ! MOAB stuff
    integer                  :: ierr, idintx, rank
    character*32             :: appname, outfile, wopts, lnum
-   character*32             :: dm1, dm2, dofnameS, dofnameT, wgtIdef
+   character*32             :: dm1, dm2, dofnameS, dofnameT
+   character*32             :: wgtIda2r, wgtIdl2r
    integer                  :: orderS, orderT, volumetric, noConserve, validate, fInverseDistanceMap
    integer                  :: fNoBubble, monotonicity
 ! will do comm graph over coupler PES, in 2-hop strategy
@@ -217,6 +222,14 @@ contains
    integer nvert(3), nvise(3), nbl(3), nsurf(3), nvisBC(3) ! for moab info
 
     !---------------------------------------------------------------
+
+#ifdef HAVE_MOAB
+      wgtIdl2r = 'conservative_l2r'//C_NULL_CHAR
+      wgtIda2r = 'conservative_a2r'//C_NULL_CHAR
+      ! load_maps_from_disk_l2r = .false. ! Force online computation
+      load_maps_from_disk_l2r = .true. ! Force read from disk
+      load_maps_from_disk_a2r = .true. ! Force read from disk
+#endif
 
     call seq_infodata_getData(infodata , &
          esmf_map_flag=esmf_map_flag   , &
@@ -264,7 +277,7 @@ contains
        end do
        l2racc_lx_cnt = 0
 #ifdef HAVE_MOAB
-       ! this l2racc_lm will be over land size ? 
+       ! this l2racc_lm will be over land size ?
        sharedFieldsLndRof=''
        nfields_sh_lr = mct_aVect_nRAttr(l2racc_lx(1))
        if( nfields_sh_lr /= 0 ) sharedFieldsLndRof=trim( mct_aVect_exportRList2c(l2racc_lx(1)) )
@@ -280,7 +293,7 @@ contains
        lsize_lm = nvise(1)
        if(iamroot_CPLID) then
           write(logunit,*) subname,' number of fields=', nfields_sh_lr
-          write(logunit,*) subname,' sharedFieldsLndRof=', trim(sharedFieldsLndRof)      
+          write(logunit,*) subname,' sharedFieldsLndRof=', trim(sharedFieldsLndRof)
           write(logunit,*) subname,'  seq_flds_l2x_fluxes_to_rof=', trim(seq_flds_l2x_fluxes_to_rof)
           write(logunit,*) subname,' lsize_lm=', lsize_lm
        endif
@@ -308,7 +321,7 @@ contains
           call seq_map_init_rcfile(mapper_Fl2r, lnd(1), rof(1), &
                'seq_maps.rc','lnd2rof_fmapname:','lnd2rof_fmaptype:',samegrid_lr, &
                string='mapper_Fl2r initialization', esmf_map=esmf_map_flag)
-! similar to a2r, from below 
+! similar to a2r, from below
 #ifdef HAVE_MOAB
           ! Call moab intx only if land and river are init in moab
           if ((mblxid .ge. 0) .and.  (mbrxid .ge. 0)) then
@@ -322,7 +335,7 @@ contains
             endif
             tagname = trim(seq_flds_l2x_fluxes_to_rof)//C_NULL_CHAR
             tagtype = 1 ! dense
-            numco = 1 ! 
+            numco = 1 !
             ierr = iMOAB_DefineTagStorage(mbrxid, tagname, tagtype, numco,  tagindex )
             if (ierr .ne. 0) then
                write(logunit,*) subname,' error in defining tags for seq_flds_a2x_fields on rof cpl'
@@ -330,9 +343,9 @@ contains
             endif
             call seq_comm_getData(CPLID ,mpigrp=mpigrp_CPLID)
             if (samegrid_lr) then
-               ! the same mesh , lnd and rof use the same dofs, but restricted 
+               ! the same mesh , lnd and rof use the same dofs, but restricted
                ! we do not compute intersection, so we will have to just send data from lnd to rof and viceversa, by GLOBAL_ID matching
-               ! so we compute just a comm graph, between lnd and rof dofs, on the coupler; target is rof 
+               ! so we compute just a comm graph, between lnd and rof dofs, on the coupler; target is rof
                ! land is full mesh
                type1 = 3; !  full mesh for land now
                type2 = 3;  ! fv for target rof
@@ -354,27 +367,52 @@ contains
                mapper_Fl2r%src_context = lnd(1)%cplcompid
                mapper_Fl2r%intx_context = rof(1)%cplcompid
             else
-               ierr =  iMOAB_ComputeMeshIntersectionOnSphere (mblxid, mbrxid, mbintxlr)
+
+               ! compute the LND coverage mesh here on coupler pes
+               ! LND mesh was redistributed to cover target (ROF) partition
+               ierr = iMOAB_ComputeCoverageMesh( mblxid, mbrxid, mbintxlr )
                if (ierr .ne. 0) then
-               write(logunit,*) subname,' error in computing  land rof intx'
-               call shr_sys_abort(subname//' ERROR in computing land rof intx')
+                  write(logunit,*) subname,' cannot compute source LND coverage mesh for ROF'
+                  call shr_sys_abort(subname//' ERROR in computing LND-ROF coverage')
                endif
-               if (iamroot_CPLID) then
-               write(logunit,*) 'iMOAB intersection between  land and rof with id:', idintx
+
+               ! if we are not loading maps from disk, compute the intersection mesh between
+               ! LND and ROF meshes
+               if (.not. load_maps_from_disk_l2r) then
+                  ierr = iMOAB_ComputeMeshIntersectionOnSphere( mblxid, mbrxid, mbintxlr )
+                  if (ierr .ne. 0) then
+                     write(logunit,*) subname,' error in computing LND ROF mesh intersection'
+                     call shr_sys_abort(subname//' ERROR in computingLND ROF mesh intersection')
+                  endif
+                  if (iamroot_CPLID) then
+                     write(logunit,*) 'iMOAB intersection between LND and ROF with id:', idintx
+                  end if
+#ifdef MOABDEBUG
+               wopts = C_NULL_CHAR
+               call shr_mpi_commrank( mpicom_CPLID, rank )
+               if (rank .lt. 3 .and. .not. load_maps_from_disk_l2r) then
+                  write(lnum,"(I0.2)")rank !
+                  outfile = 'intx_lr_'//trim(lnum)// '.h5m' // C_NULL_CHAR
+                  ierr = iMOAB_WriteMesh(mbintxlr, outfile, wopts) ! write local intx file
+                  if (ierr .ne. 0) then
+                     write(logunit,*) subname,' error in writing LND-ROF intersection mesh file '
+                     call shr_sys_abort(subname//' ERROR in writing LND-ROF intersection mesh file ')
+                  endif
+               endif
+#endif
                end if
-               ! we also need to compute the comm graph for the second hop, from the lnd on coupler to the 
+
+               ! we also need to compute the comm graph for the second hop, from the lnd on coupler to the
                ! lnd for the intx lnd-rof context (coverage)
-               !    
                type1 = 3 ! land is FV now on coupler side
                type2 = 3;
-
                ierr = iMOAB_ComputeCommGraph( mblxid, mbintxlr, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type1, type2, &
                                           lnd(1)%cplcompid, idintx)
                if (ierr .ne. 0) then
-                  write(logunit,*) subname,' error in computing comm graph for second hop, lnd-rof'
-                  call shr_sys_abort(subname//' ERROR in computing comm graph for second hop, lnd-rof')
+                  write(logunit,*) subname,' error in computing comm graph for second hop, LND-ROF'
+                  call shr_sys_abort(subname//' ERROR in computing comm graph for second hop, LND-ROF')
                endif
-               ! now take care of the mapper 
+               ! now take care of the mapper
                if ( mapper_Fl2r%src_mbid .gt. -1 ) then
                   if (iamroot_CPLID) then
                         write(logunit,F00) 'overwriting '//trim(mapper_Fl2r%mbname) &
@@ -383,60 +421,51 @@ contains
                endif
                mapper_Fl2r%src_mbid = mblxid
                mapper_Fl2r%tgt_mbid = mbrxid
-               mapper_Fl2r%intx_mbid = mbintxlr 
+               mapper_Fl2r%intx_mbid = mbintxlr
                mapper_Fl2r%src_context = lnd(1)%cplcompid
                mapper_Fl2r%intx_context = idintx
-               wgtIdef = 'scalar'//C_NULL_CHAR
-               mapper_Fl2r%weight_identifier = wgtIdef
+               mapper_Fl2r%weight_identifier = wgtIdl2r
                mapper_Fl2r%mbname = 'mapper_Fl2r'
-               ! because we will project fields from lnd to rof grid, we need to define 
+               ! because we will project fields from lnd to rof grid, we need to define
                !  the l2x fields to rof grid on coupler side
-               
-               volumetric = 0 ! can be 1 only for FV->DGLL or FV->CGLL; 
-               
-               dm1 = "fv"//C_NULL_CHAR
-               dofnameS="GLOBAL_ID"//C_NULL_CHAR
-               orderS = 1 !  fv-fv
-            
-               dm2 = "fv"//C_NULL_CHAR
-               dofnameT="GLOBAL_ID"//C_NULL_CHAR
-               orderT = 1  !  not much arguing
-               fNoBubble = 1
-               monotonicity = 0 !
-               noConserve = 0
-               validate = 0
-               fInverseDistanceMap = 0
-               if (iamroot_CPLID) then
-                  write(logunit,*) subname, 'launch iMOAB weights with args ', 'mbintxlr=', mbintxlr, ' wgtIdef=', wgtIdef, &
-                     'dm1=', trim(dm1), ' orderS=',  orderS, 'dm2=', trim(dm2), ' orderT=', orderT, &
-                                                fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
-                                                noConserve, validate, &
-                                                trim(dofnameS), trim(dofnameT)
-               endif
-               ierr = iMOAB_ComputeScalarProjectionWeights ( mbintxlr, wgtIdef, &
-                                                trim(dm1), orderS, trim(dm2), orderT, ''//C_NULL_CHAR, &
-                                                fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
-                                                noConserve, validate, &
-                                                trim(dofnameS), trim(dofnameT) )
-               mb_rof_aream_computed = .true. ! signal
-               if (ierr .ne. 0) then
-                  write(logunit,*) subname,' error in computing lr weights '
-                  call shr_sys_abort(subname//' ERROR in computing lr weights ')
-               endif
 
-#ifdef MOABDEBUG
-               wopts = C_NULL_CHAR
-               call shr_mpi_commrank( mpicom_CPLID, rank )
-               if (rank .lt. 5) then
-               write(lnum,"(I0.2)")rank !
-               outfile = 'intx_lr_'//trim(lnum)// '.h5m' // C_NULL_CHAR
-               ierr = iMOAB_WriteMesh(mbintxlr, outfile, wopts) ! write local intx file
-               if (ierr .ne. 0) then
-                  write(logunit,*) subname,' error in writing intx lr file '
-                  call shr_sys_abort(subname//' ERROR in writing intx lr file ')
-               endif
-               endif
-#endif
+               if (.not. load_maps_from_disk_l2r) then
+
+                  volumetric = 0 ! can be 1 only for FV->DGLL or FV->CGLL;
+                  dm1 = "fv"//C_NULL_CHAR
+                  dofnameS="GLOBAL_ID"//C_NULL_CHAR
+                  orderS = 1 !  fv-fv
+                  dm2 = "fv"//C_NULL_CHAR
+                  dofnameT="GLOBAL_ID"//C_NULL_CHAR
+                  orderT = 1  !  not much arguing
+                  fNoBubble = 1
+                  monotonicity = 0 !
+                  noConserve = 0
+                  validate = 0
+                  fInverseDistanceMap = 0
+                  if (iamroot_CPLID) then
+                     write(logunit,*) subname, 'launch iMOAB weights with args ', 'mbintxlr=', mbintxlr, ' wgtIdef=', wgtIdl2r, &
+                        'dm1=', trim(dm1), ' orderS=',  orderS, 'dm2=', trim(dm2), ' orderT=', orderT, &
+                                                   fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
+                                                   noConserve, validate, &
+                                                   trim(dofnameS), trim(dofnameT)
+                  endif
+                  ierr = iMOAB_ComputeScalarProjectionWeights ( mbintxlr, wgtIdl2r, &
+                                                   trim(dm1), orderS, trim(dm2), orderT, ''//C_NULL_CHAR, &
+                                                   fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
+                                                   noConserve, validate, &
+                                                   trim(dofnameS), trim(dofnameT) )
+                  mb_rof_aream_computed = .true. ! signal
+                  if (ierr .ne. 0) then
+                     write(logunit,*) subname,' error in computing lr weights '
+                     call shr_sys_abort(subname//' ERROR in computing lr weights ')
+                  endif
+               else
+                  type1 = 3 ! this is type of grid, maybe should be saved on imoab app ?
+                  call moab_map_init_rcfile( mblxid, mbrxid, mbintxlr, type1, &
+                        'seq_maps.rc', 'lnd2rof_fmapname:', 'lnd2rof_fmaptype:',samegrid_lr, &
+                        wgtIdl2r, 'mapper_Fl2r MOAB initialization', esmf_map_flag)
+               end if
             end if ! if ((mblxid .ge. 0) .and.  (mbrxid .ge. 0))
          endif ! samegrid_lr
 #endif
@@ -470,7 +499,7 @@ contains
        end do
        a2racc_ax_cnt = 0
 #ifdef HAVE_MOAB
-       ! this a2racc_am will be over atm size 
+       ! this a2racc_am will be over atm size
        sharedFieldsAtmRof=''
        nfields_sh_ar = mct_aVect_nRAttr(a2racc_ax(1))
        if (nfields_sh_ar /= 0 ) sharedFieldsAtmRof = trim( mct_aVect_exportRList2c(a2racc_ax(1)) )
@@ -494,8 +523,8 @@ contains
        endif
        a2racc_am(:,:) = 0.
        a2racc_am_cnt = 0
-
 #endif
+
        allocate(a2r_rx(num_inst_rof))
        do eri = 1,num_inst_rof
           call mct_avect_init(a2r_rx(eri), rList=seq_flds_a2x_fields_to_rof, lsize=lsize_r)
@@ -513,7 +542,7 @@ contains
           call seq_map_init_rcfile(mapper_Fa2r, atm(1), rof(1), &
                'seq_maps.rc','atm2rof_fmapname:','atm2rof_fmaptype:',samegrid_ar, &
                string='mapper_Fa2r initialization', esmf_map=esmf_map_flag)
-! similar to a2o, prep_ocn 
+! similar to a2o, prep_ocn
 #ifdef HAVE_MOAB
           ! Call moab intx only if atm  and river are init in moab
           if ((mbrxid .ge. 0) .and.  (mbaxid .ge. 0)) then
@@ -522,35 +551,60 @@ contains
             idintx = 100*atm(1)%cplcompid + rof(1)%cplcompid ! something different, to differentiate it
             ierr = iMOAB_RegisterApplication(trim(appname), mpicom_CPLID, idintx, mbintxar)
             if (ierr .ne. 0) then
-              write(logunit,*) subname,' error in registering atm rof intx'
-              call shr_sys_abort(subname//' ERROR in registering atm rof intx')
+              write(logunit,*) subname,' error in registering ATM-ROF mesh intersection context'
+              call shr_sys_abort(subname//' ERROR in registering ATM-ROF mesh intersection context')
             endif
-            ierr =  iMOAB_ComputeMeshIntersectionOnSphere (mbaxid, mbrxid, mbintxar)
+
+            ! compute the OCN coverage mesh here on coupler pes
+            ! ATM mesh was redistributed to cover target (ROF) partition
+            ierr = iMOAB_ComputeCoverageMesh( mbaxid, mbrxid, mbintxar )
             if (ierr .ne. 0) then
-              write(logunit,*) subname,' error in computing  atm rof intx'
-              call shr_sys_abort(subname//' ERROR in computing atm rof intx')
+               write(logunit,*) subname,' cannot compute source ATM coverage mesh for ROF'
+               call shr_sys_abort(subname//' ERROR in computing ATM-ROF coverage')
             endif
-            if (iamroot_CPLID) then
-              write(logunit,*) 'iMOAB intersection between  atm and rof with id:', idintx
+
+            ! if we are not loading maps from disk, compute the intersection mesh between
+            ! ATM and ROF meshes
+            if (.not. load_maps_from_disk_a2r) then
+               ierr =  iMOAB_ComputeMeshIntersectionOnSphere( mbaxid, mbrxid, mbintxar )
+               if (ierr .ne. 0) then
+                  write(logunit,*) subname,' error in computing ATM-ROF mesh intersection'
+                  call shr_sys_abort(subname//' ERROR in computing ATM-ROF mesh intersection')
+               endif
+               if (iamroot_CPLID) then
+                  write(logunit,*) 'iMOAB mesh intersection between ATM and ROF with id:', idintx
+               end if
+#ifdef MOABDEBUG
+               wopts = C_NULL_CHAR
+               call shr_mpi_commrank( mpicom_CPLID, rank )
+               if (rank .lt. 3) then
+                  write(lnum,"(I0.2)")rank !
+                  outfile = 'intx_ar_'//trim(lnum)// '.h5m' // C_NULL_CHAR
+                  ierr = iMOAB_WriteMesh(mbintxar, outfile, wopts) ! write local intx file
+                  if (ierr .ne. 0) then
+                     write(logunit,*) subname,' error in writing ATM-ROF intersection mesh file '
+                     call shr_sys_abort(subname//' ERROR in writing ATM-ROF intersection mesh file ')
+                  endif
+               endif
+#endif
             end if
-            ! we also need to compute the comm graph for the second hop, from the atm on coupler to the 
-            ! atm for the intx atm-rof context (coverage)
-            !    
-            call seq_comm_getData(CPLID ,mpigrp=mpigrp_CPLID) 
+
+            ! we also need to compute the comm graph for the second hop, from the atm on coupler to the
+            ! atm for the intersection of ATM-ROF context (coverage)
+            call seq_comm_getData(CPLID ,mpigrp=mpigrp_CPLID)
             if (atm_pg_active) then
-              type1 = 3; !  fv for both rof and atm; fv-cgll does not work anyway
+              type1 = 3; !  FV for both rof and atm; FV-CGLL does not work anyway
             else
               type1 = 1 ! this does not work anyway in this direction
             endif
             type2 = 3;
-
             ierr = iMOAB_ComputeCommGraph( mbaxid, mbintxar, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type1, type2, &
                                         atm(1)%cplcompid, idintx)
             if (ierr .ne. 0) then
-               write(logunit,*) subname,' error in computing comm graph for second hop, rof-atm'
-               call shr_sys_abort(subname//' ERROR in computing comm graph for second hop, rof-atm')
+               write(logunit,*) subname,' error in computing comm graph for second hop, ATM-ROF'
+               call shr_sys_abort(subname//' ERROR in computing comm graph for second hop, ATM-ROF')
             endif
-            ! now take care of the mapper 
+            ! now take care of the mapper
             if ( mapper_Fa2r%src_mbid .gt. -1 ) then
                 if (iamroot_CPLID) then
                      write(logunit,F00) 'overwriting '//trim(mapper_Fa2r%mbname) &
@@ -559,74 +613,70 @@ contains
             endif
             mapper_Fa2r%src_mbid = mbaxid
             mapper_Fa2r%tgt_mbid = mbrxid
-            mapper_Fa2r%intx_mbid = mbintxar 
+            mapper_Fa2r%intx_mbid = mbintxar
             mapper_Fa2r%src_context = atm(1)%cplcompid
             mapper_Fa2r%intx_context = idintx
-            wgtIdef = 'scalar'//C_NULL_CHAR
-            mapper_Fa2r%weight_identifier = wgtIdef
+            mapper_Fa2r%weight_identifier = wgtIda2r
             mapper_Fa2r%mbname = 'mapper_Fa2r'
-            ! because we will project fields from atm to rof grid, we need to define 
+            ! because we will project fields from atm to rof grid, we need to define
             ! rof a2x fields to rof grid on coupler side
-            
+
             tagname = trim(seq_flds_a2x_fields_to_rof)//':norm8wt'//C_NULL_CHAR
             tagtype = 1 ! dense
-            numco = 1 ! 
+            numco = 1 !
             ierr = iMOAB_DefineTagStorage(mbrxid, tagname, tagtype, numco,  tagindex )
             if (ierr .ne. 0) then
-               write(logunit,*) subname,' error in defining tags for seq_flds_a2x_fields_to_rof on rof cpl'
-               call shr_sys_abort(subname//' ERROR in  defining tags for seq_flds_a2x_fields_to_rof on rof cpl')
-            endif
-            volumetric = 0 ! can be 1 only for FV->DGLL or FV->CGLL; 
-            
-            if (atm_pg_active) then
-              dm1 = "fv"//C_NULL_CHAR
-              dofnameS="GLOBAL_ID"//C_NULL_CHAR
-              orderS = 1 !  fv-fv
-            else ! this part does not work, anyway
-              dm1 = "cgll"//C_NULL_CHAR
-              dofnameS="GLOBAL_DOFS"//C_NULL_CHAR
-              orderS = 4 ! np !  it should be 4
-            endif
-            dm2 = "fv"//C_NULL_CHAR
-            dofnameT="GLOBAL_ID"//C_NULL_CHAR
-            orderT = 1  !  not much arguing
-            fNoBubble = 1
-            monotonicity = 0 !
-            noConserve = 0
-            validate = 0 ! less verbose
-            fInverseDistanceMap = 0
-            if (iamroot_CPLID) then
-               write(logunit,*) subname, 'launch iMOAB weights with args ', 'mbintxar=', mbintxar, ' wgtIdef=', wgtIdef, &
-                   'dm1=', trim(dm1), ' orderS=',  orderS, 'dm2=', trim(dm2), ' orderT=', orderT, &
-                                               fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
-                                               noConserve, validate, &
-                                               trim(dofnameS), trim(dofnameT)
-            endif
-            ierr = iMOAB_ComputeScalarProjectionWeights ( mbintxar, wgtIdef, &
-                                               trim(dm1), orderS, trim(dm2), orderT, ''//C_NULL_CHAR, &
-                                               fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
-                                               noConserve, validate, &
-                                               trim(dofnameS), trim(dofnameT) )
-            if (ierr .ne. 0) then
-               write(logunit,*) subname,' error in computing ar weights '
-               call shr_sys_abort(subname//' ERROR in computing ar weights ')
+               write(logunit,*) subname,' error in defining tags for seq_flds_a2x_fields_to_rof on ROF cpl'
+               call shr_sys_abort(subname//' ERROR in  defining tags for seq_flds_a2x_fields_to_rof on ROF cpl')
             endif
 
-#ifdef MOABDEBUG
-            wopts = C_NULL_CHAR
-            call shr_mpi_commrank( mpicom_CPLID, rank )
-            if (rank .lt. 5) then
-              write(lnum,"(I0.2)")rank !
-              outfile = 'intx_ar_'//trim(lnum)// '.h5m' // C_NULL_CHAR
-              ierr = iMOAB_WriteMesh(mbintxar, outfile, wopts) ! write local intx file
-              if (ierr .ne. 0) then
-                write(logunit,*) subname,' error in writing intx ar file '
-                call shr_sys_abort(subname//' ERROR in writing intx ar file ')
-              endif
-            endif
-#endif
+            if (.not. load_maps_from_disk_a2r) then
+
+               volumetric = 0 ! can be 1 only for FV->DGLL or FV->CGLL;
+               if (atm_pg_active) then
+                  dm1 = "fv"//C_NULL_CHAR
+                  dofnameS="GLOBAL_ID"//C_NULL_CHAR
+                  orderS = 1 !  fv-fv
+               else ! this part does not work, anyway
+                  dm1 = "cgll"//C_NULL_CHAR
+                  dofnameS="GLOBAL_DOFS"//C_NULL_CHAR
+                  orderS = 4 ! np !  it should be 4
+               endif
+               dm2 = "fv"//C_NULL_CHAR
+               dofnameT="GLOBAL_ID"//C_NULL_CHAR
+               orderT = 1  !  not much arguing
+               fNoBubble = 1
+               monotonicity = 0 !
+               noConserve = 0
+               validate = 0 ! less verbose
+               fInverseDistanceMap = 0
+               if (iamroot_CPLID) then
+                  write(logunit,*) subname, 'launch iMOAB weights with args ', 'mbintxar=', mbintxar, ' wgtIdef=', wgtIda2r, &
+                     'dm1=', trim(dm1), ' orderS=',  orderS, 'dm2=', trim(dm2), ' orderT=', orderT, &
+                                                fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
+                                                noConserve, validate, &
+                                                trim(dofnameS), trim(dofnameT)
+               endif
+               ierr = iMOAB_ComputeScalarProjectionWeights ( mbintxar, wgtIda2r, &
+                                                trim(dm1), orderS, trim(dm2), orderT, ''//C_NULL_CHAR, &
+                                                fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
+                                                noConserve, validate, &
+                                                trim(dofnameS), trim(dofnameT) )
+               if (ierr .ne. 0) then
+                  write(logunit,*) subname,' error in computing ATM-ROF weights '
+                  call shr_sys_abort(subname//' ERROR in computing ATM-ROF weights ')
+               endif
+
+            else
+               type1 = 3 ! this is type of grid, maybe should be saved on imoab app ?
+
+               call moab_map_init_rcfile( mbaxid, mbrxid, mbintxar, type1, &
+                     'seq_maps.rc', 'atm2rof_fmapname:', 'atm2rof_fmaptype:',samegrid_ar, &
+                     wgtIda2r, 'mapper_Fa2r MOAB initialization', esmf_map_flag)
+            end if
+
          end if ! if ((mbrxid .ge. 0) .and.  (mbaxid .ge. 0))
-! endif HAVE_MOAB 
+! endif HAVE_MOAB
 #endif
 
           if (iamroot_CPLID) then
@@ -646,15 +696,14 @@ contains
             endif
             mapper_Sa2r%src_mbid = mbaxid
             mapper_Sa2r%tgt_mbid = mbrxid
-            mapper_Sa2r%intx_mbid = mbintxar 
+            mapper_Sa2r%intx_mbid = mbintxar
             mapper_Sa2r%src_context = atm(1)%cplcompid
             mapper_Sa2r%intx_context = idintx
-            wgtIdef = 'scalar'//C_NULL_CHAR
-            mapper_Sa2r%weight_identifier = wgtIdef
+            mapper_Sa2r%weight_identifier = wgtIda2r
             mapper_Sa2r%mbname = 'mapper_Sa2r'
 #endif
        endif
-	   
+
        call shr_sys_flush(logunit)
 
     end if
@@ -677,12 +726,12 @@ contains
        o2racc_ox_cnt = 0
 #ifdef HAVE_MOAB
 
-       ! this o2racc_om will be over ocn size 
+       ! this o2racc_om will be over ocn size
        sharedFieldsOcnRof=''
        nfields_sh_or = mct_aVect_nRAttr(o2racc_ox(1))
        if ( nfields_sh_or /= 0 ) sharedFieldsOcnRof = trim( mct_aVect_exportRList2c(o2racc_ox(1)) )
        tagname = trim(sharedFieldsOcnRof)//C_NULL_CHAR
-      
+
       ! find the size of ocn mesh locally
       ! find out the number of local elements in moab mesh ocn instance on coupler
       ierr  = iMOAB_GetMeshInfo ( mboxid, nvert, nvise, nbl, nsurf, nvisBC )
@@ -1135,7 +1184,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
        efi = mod((eri-1),num_inst_frc) + 1
 
        x2r_rx => component_get_x2c_cx(rof(eri))  ! This is actually modifying x2r_rx
-       if(ocn_rof_two_way) then 
+       if(ocn_rof_two_way) then
          call prep_rof_merge(l2r_rx(eri), a2r_rx(eri), fractions_rx(efi), x2r_rx, cime_model, o2x_r=o2r_rx(eri))
        else
          call prep_rof_merge(l2r_rx(eri), a2r_rx(eri), fractions_rx(efi), x2r_rx, cime_model)
@@ -1220,7 +1269,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
     integer, save :: index_x2r_Flrl_inundinf
     integer, save :: index_x2r_So_ssh
     integer, save :: index_o2x_So_ssh
-    
+
     integer, save :: index_l2x_coszen_str
     integer, save :: index_x2r_coszen_str
 
@@ -1338,7 +1387,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
           mrgstr(index_x2r_Flrl_rofi_HDO) = trim(mrgstr(index_x2r_Flrl_rofi_HDO))//' = '// &
                trim(fracstr)//'*l2x%Flrl_rofi_HDO'
        end if
-   
+
        if ( rof_heat ) then
           index_a2x_Sa_tbot    = mct_aVect_indexRA(a2x_r,'Sa_tbot')
           index_a2x_Sa_pbot    = mct_aVect_indexRA(a2x_r,'Sa_pbot')
@@ -1350,7 +1399,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
           index_a2x_Faxa_swvdr = mct_aVect_indexRA(a2x_r,'Faxa_swvdr')
           index_a2x_Faxa_swvdf = mct_aVect_indexRA(a2x_r,'Faxa_swvdf')
           index_a2x_Faxa_lwdn  = mct_aVect_indexRA(a2x_r,'Faxa_lwdn')
-     
+
           index_x2r_Sa_tbot    = mct_aVect_indexRA(x2r_r,'Sa_tbot')
           index_x2r_Sa_pbot    = mct_aVect_indexRA(x2r_r,'Sa_pbot')
           index_x2r_Sa_u       = mct_aVect_indexRA(x2r_r,'Sa_u')
@@ -1379,7 +1428,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
              mrgstr(index_x2r_Flrl_inundinf) = trim(mrgstr(index_x2r_Flrl_inundinf))//' = '//'l2x%Flrl_inundinf'
           endif
 
-       endif 
+       endif
 
        if (ocn_rof_two_way) then
           index_o2x_So_ssh = mct_aVect_indexRA(o2x_r,'So_ssh')
@@ -1414,7 +1463,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
           x2r_r%rAttr(index_x2r_Flrl_rofl_HDO,i) = l2x_r%rAttr(index_l2x_Flrl_rofl_HDO,i) * frac
           x2r_r%rAttr(index_x2r_Flrl_rofi_HDO,i) = l2x_r%rAttr(index_l2x_Flrl_rofi_HDO,i) * frac
        end if
-      
+
        if ( rof_heat ) then
           x2r_r%rAttr(index_x2r_Sa_tbot,i)    = a2x_r%rAttr(index_a2x_Sa_tbot,i)
           x2r_r%rAttr(index_x2r_Sa_pbot,i)    = a2x_r%rAttr(index_a2x_Sa_pbot,i)
@@ -1467,7 +1516,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
     ! Description
     ! Merge land rof and ice forcing for rof input
     !
-    ! used for indexing 
+    ! used for indexing
     type(mct_avect) , pointer   :: l2x_r
     type(mct_avect) , pointer   :: a2x_r
     type(mct_avect) , pointer    :: fractions_r
@@ -1501,7 +1550,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
     integer, save :: index_l2x_Flrl_rofi_HDO
     integer, save :: index_x2r_Flrl_rofl_HDO
     integer, save :: index_x2r_Flrl_rofi_HDO
-	
+
     integer, save :: index_l2x_Flrl_Tqsur
     integer, save :: index_l2x_Flrl_Tqsub
     integer, save :: index_a2x_Sa_tbot
@@ -1526,7 +1575,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
     integer, save :: index_x2r_Faxa_swvdr
     integer, save :: index_x2r_Faxa_swvdf
     integer, save :: index_x2r_Faxa_lwdn
-    
+
     integer, save :: index_l2x_coszen_str
     integer, save :: index_x2r_coszen_str
 
@@ -1542,10 +1591,10 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
     character(*), parameter   :: subname = '(prep_rof_mrg_moab) '
 
  integer nvert(3), nvise(3), nbl(3), nsurf(3), nvisBC(3) ! for moab info
-   
+
     character(CXX) ::tagname, mct_field
     integer :: ent_type, ierr, arrsize
-    integer, save :: naflds, nlflds ! these are saved the first time 
+    integer, save :: naflds, nlflds ! these are saved the first time
 #ifdef MOABDEBUG
     character*32             :: outfile, wopts, lnum
 #endif
@@ -1554,12 +1603,12 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
     type(mct_list) :: temp_list
     integer :: size_list, index_list
     type(mct_string)    :: mctOStr  !
-#endif 
+#endif
     !-----------------------------------------------------------------------
 
     call seq_comm_getdata(CPLID, iamroot=iamroot)
-    
-! character(*),parameter :: fraclist_r = 'lfrac:lfrin:rfrac' 
+
+! character(*),parameter :: fraclist_r = 'lfrac:lfrin:rfrac'
     if (first_time) then
       ! find out the number of local elements in moab mesh rof instance on coupler
       ierr  = iMOAB_GetMeshInfo ( mbrxid, nvert, nvise, nbl, nsurf, nvisBC )
@@ -1568,7 +1617,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
             call shr_sys_abort(subname//' error in getting info ')
       endif
       lsize = nvise(1) ! number of active cells
-       ! mct avs are used just for their fields metadata, not the actual reals 
+       ! mct avs are used just for their fields metadata, not the actual reals
        ! (name of the fields)
        ! need these always, not only the first time
       l2x_r => l2r_rx(1)
@@ -1638,7 +1687,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
        end if
 
        if (samegrid_al) then ! fraclist_r = 'lfrac:lfrin:rfrac'
-       ! check, in our case, is it always 1  ? 
+       ! check, in our case, is it always 1  ?
           index_frac = 1 ! mct_aVect_indexRA(fractions_r,"lfrac")
           fracstr = 'lfrac'
        else
@@ -1682,7 +1731,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
           mrgstr(index_x2r_Flrl_rofi_HDO) = trim(mrgstr(index_x2r_Flrl_rofi_HDO))//' = '// &
                trim(fracstr)//'*l2x%Flrl_rofi_HDO'
        end if
-	   
+
        if ( rof_heat ) then
           index_a2x_Sa_tbot    = mct_aVect_indexRA(a2x_r,'Sa_tbot')
           index_a2x_Sa_pbot    = mct_aVect_indexRA(a2x_r,'Sa_pbot')
@@ -1694,7 +1743,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
           index_a2x_Faxa_swvdr = mct_aVect_indexRA(a2x_r,'Faxa_swvdr')
           index_a2x_Faxa_swvdf = mct_aVect_indexRA(a2x_r,'Faxa_swvdf')
           index_a2x_Faxa_lwdn  = mct_aVect_indexRA(a2x_r,'Faxa_lwdn')
-     
+
           index_x2r_Sa_tbot    = mct_aVect_indexRA(x2r_r,'Sa_tbot')
           index_x2r_Sa_pbot    = mct_aVect_indexRA(x2r_r,'Sa_pbot')
           index_x2r_Sa_u       = mct_aVect_indexRA(x2r_r,'Sa_u')
@@ -1716,13 +1765,13 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
           mrgstr(index_x2r_Faxa_swvdr) = trim(mrgstr(index_x2r_Faxa_swvdr))//' = '//'a2x%Faxa_swvdr'
           mrgstr(index_x2r_Faxa_swvdf) = trim(mrgstr(index_x2r_Faxa_swvdf))//' = '//'a2x%Faxa_swvdf'
           mrgstr(index_x2r_Faxa_lwdn)  = trim(mrgstr(index_x2r_Faxa_lwdn))//' = '//'a2x%Faxa_lwdn'
-       endif 
+       endif
 
     end if
 ! fill in with data from moab tags
 
 ! fill with fractions from river instance
-! fractions_rm, 
+! fractions_rm,
     ent_type = 1 ! cells
     tagname = 'lfrac:lfrin:rfrac'//C_NULL_CHAR
     arrsize = 3 * lsize
@@ -1736,7 +1785,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
     ierr = iMOAB_GetDoubleTagStorage ( mbrxid, tagname, arrsize , ent_type, x2r_rm)
     if (ierr .ne. 0) then
       call shr_sys_abort(subname//' error in getting x2r_rm array ')
-    endif    
+    endif
     ! a2x_rm (lsize, naflds))
 
     tagname = trim(seq_flds_a2x_fields_to_rof)//C_NULL_CHAR
@@ -1747,7 +1796,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
     endif
     !  l2x_rm
     tagname = trim(seq_flds_l2x_fluxes_to_rof)//C_NULL_CHAR
-    arrsize = nlflds * lsize !        
+    arrsize = nlflds * lsize !
     ierr = iMOAB_GetDoubleTagStorage ( mbrxid, tagname, arrsize , ent_type, l2x_rm)
     if (ierr .ne. 0) then
       call shr_sys_abort(subname//' error in getting l2x_rm array ')
@@ -1780,7 +1829,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
           x2r_rm(i,index_x2r_Flrl_rofl_HDO) = l2x_rm(i,index_l2x_Flrl_rofl_HDO) * frac
           x2r_rm(i,index_x2r_Flrl_rofi_HDO) = l2x_rm(i,index_l2x_Flrl_rofi_HDO) * frac
        end if
-      
+
        if ( rof_heat ) then
           x2r_rm(i,index_x2r_Sa_tbot)    = a2x_rm(i,index_a2x_Sa_tbot)
           x2r_rm(i,index_x2r_Sa_pbot)    = a2x_rm(i,index_a2x_Sa_pbot)
@@ -1842,7 +1891,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
 #endif
 
   end subroutine prep_rof_mrg_moab
-#endif 
+#endif
   !================================================================================================
 
   subroutine prep_rof_calc_l2r_rx(fractions_lx, timer)
@@ -1989,7 +2038,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
     prep_rof_get_mapper_Sa2r => mapper_Sa2r
   end function prep_rof_get_mapper_Sa2r
 
- ! moab 
+ ! moab
  ! for ocean
   function prep_rof_get_o2racc_om_cnt()
     integer, pointer :: prep_rof_get_o2racc_om_cnt
@@ -2005,7 +2054,7 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
      character(CXX) :: prep_rof_get_sharedFieldsOcnRof
      prep_rof_get_sharedFieldsOcnRof = sharedFieldsOcnRof
   end function prep_rof_get_sharedFieldsOcnRof
- 
+
   ! for land
   function prep_rof_get_l2racc_lm_cnt()
     integer, pointer :: prep_rof_get_l2racc_lm_cnt

--- a/driver-moab/main/prep_rof_mod.F90
+++ b/driver-moab/main/prep_rof_mod.F90
@@ -237,8 +237,8 @@ contains
 #ifdef HAVE_MOAB
       wgtIdl2r = 'conservative_l2r'//C_NULL_CHAR
       wgtIda2r = 'conservative_a2r'//C_NULL_CHAR
-      load_maps_from_disk_l2r = not(cpl_compute_maps_online) ! read from disk or compute online
-      load_maps_from_disk_a2r = not(cpl_compute_maps_online) ! read from disk or compute online
+      load_maps_from_disk_l2r = .not. cpl_compute_maps_online ! read from disk or compute online
+      load_maps_from_disk_a2r = .not. cpl_compute_maps_online ! read from disk or compute online
       ! load_maps_from_disk_l2r = .false. ! Explicitly force online computation
 #endif
 

--- a/driver-moab/main/seq_map_mod.F90
+++ b/driver-moab/main/seq_map_mod.F90
@@ -225,7 +225,7 @@ contains
    !sol_identifier = 'map-from-file'//CHAR(0)
    mapfile_term = trim(mapfile)//CHAR(0)
    if (seq_comm_iamroot(CPLID)) then
-       write(logunit,*) subname,' reading map file with iMOAB: ', mapfile_term
+       write(logunit,*) subname,' reading map file with iMOAB: ', trim(mapfile_term)
    endif
 
    ierr = iMOAB_LoadMappingWeightsFromFile( mbsrc, mbtgt, mbintx, discretization_type, &
@@ -235,8 +235,8 @@ contains
       call shr_sys_abort(subname//' ERROR in loading map file')
     endif
    if (seq_comm_iamroot(CPLID)) then
-      write(logunit,'(2A,I6,4A)') subname,' iMOAB map app ID, maptype, mapfile = ', &
-         mbintx,' ',trim(maptype),' ',trim(mapfile), ', identifier: ', sol_identifier
+      write(logunit,'(2A,I6,4A)') subname,'Result: iMOAB map app ID, maptype, mapfile = ', &
+         mbintx,' ',trim(maptype),' ',trim(mapfile), ', identifier: ', trim(sol_identifier)
       call shr_sys_flush(logunit)
    endif
 

--- a/driver-moab/main/seq_map_mod.F90
+++ b/driver-moab/main/seq_map_mod.F90
@@ -236,7 +236,7 @@ contains
     endif
    if (seq_comm_iamroot(CPLID)) then
       write(logunit,'(2A,I6,4A)') subname,' iMOAB map app ID, maptype, mapfile = ', &
-         mbintx,' ',trim(maptype),' ',trim(mapfile)
+         mbintx,' ',trim(maptype),' ',trim(mapfile), ', identifier: ', sol_identifier
       call shr_sys_flush(logunit)
    endif
 

--- a/driver-moab/main/seq_map_mod.F90
+++ b/driver-moab/main/seq_map_mod.F90
@@ -175,8 +175,8 @@ contains
   end subroutine seq_map_init_rcfile
 
 
-  subroutine moab_map_init_rcfile( mbappid, mbtsid, type_grid, comp_s, comp_d, &
-    maprcfile, maprcname, maprctype, samegrid, string, esmf_map)
+  subroutine moab_map_init_rcfile( mbsrc, mbtgt, mbintx, discretization_type, &
+    maprcfile, maprcname, maprctype, samegrid, sol_identifier, string, esmf_map)
 
    use iMOAB, only: iMOAB_LoadMappingWeightsFromFile
    implicit none
@@ -184,15 +184,17 @@ contains
    !
    ! Arguments
    !
-   type(integer)        ,intent(in)            :: mbappid  ! moab app id, identifing the map from source to target
-   type(integer)        ,intent(in)            :: mbtsid   ! moab app id, identifying the target (now), for row based distribution
-   type(integer)        ,intent(in)            :: type_grid ! 1 for SE, 2 for PC, 3 for FV; should be a member data
-   type(component_type) ,intent(inout)         :: comp_s
-   type(component_type) ,intent(inout)         :: comp_d
+   type(integer)        ,intent(in)            :: mbsrc  ! moab source app id
+   type(integer)        ,intent(in)            :: mbtgt  ! moab target app id
+   type(integer)        ,intent(in)            :: mbintx  ! moab intersection app id, identifing the map from source to target
+   type(integer)        ,intent(in)            :: discretization_type ! 1 for SE, 2 for PC, 3 for FV; should be a member data
+   ! type(component_type) ,intent(inout)         :: comp_s
+   ! type(component_type) ,intent(inout)         :: comp_d
    character(len=*)     ,intent(in)            :: maprcfile
    character(len=*)     ,intent(in)            :: maprcname
    character(len=*)     ,intent(in)            :: maprctype
    logical              ,intent(in)            :: samegrid
+   character(len=*)     ,intent(in),optional   :: sol_identifier !   /* "scalar", "flux", "custom" */
    character(len=*)     ,intent(in),optional   :: string
    logical              ,intent(in),optional   :: esmf_map
    !
@@ -205,9 +207,7 @@ contains
    character(CX)               :: mapfile_term
    character(CL)               :: maptype
    integer(IN)                 :: mapid
-   character(CX)               :: sol_identifier !   /* "scalar", "flux", "custom" */
    integer                     :: ierr
-   integer                     :: col_or_row ! 0 for row based, 1 for col based (we use row distribution now)
 
 
    character(len=*),parameter  :: subname = "(moab_map_init_rcfile) "
@@ -222,22 +222,21 @@ contains
    ! --- Initialize Smatp
    call shr_mct_queryConfigFile(mpicom,maprcfile,maprcname,mapfile,maprctype,maptype)
    !call shr_mct_sMatPInitnc(mapper%sMatp, mapper%gsMap_s, mapper%gsMap_d, trim(mapfile),trim(maptype),mpicom)
-   sol_identifier = 'map-from-file'//CHAR(0)
+   !sol_identifier = 'map-from-file'//CHAR(0)
    mapfile_term = trim(mapfile)//CHAR(0)
    if (seq_comm_iamroot(CPLID)) then
        write(logunit,*) subname,' reading map file with iMOAB: ', mapfile_term
    endif
 
-   col_or_row = 0 ! row based distribution
-
-   ierr = iMOAB_LoadMappingWeightsFromFile( mbappid, mbtsid, col_or_row, type_grid, sol_identifier, mapfile_term)
+   ierr = iMOAB_LoadMappingWeightsFromFile( mbsrc, mbtgt, mbintx, discretization_type, &
+                      discretization_type, sol_identifier, mapfile_term)
    if (ierr .ne. 0) then
       write(logunit,*) subname,' error in loading map file'
       call shr_sys_abort(subname//' ERROR in loading map file')
     endif
    if (seq_comm_iamroot(CPLID)) then
       write(logunit,'(2A,I6,4A)') subname,' iMOAB map app ID, maptype, mapfile = ', &
-         mbappid,' ',trim(maptype),' ',trim(mapfile)
+         mbintx,' ',trim(maptype),' ',trim(mapfile)
       call shr_sys_flush(logunit)
    endif
 
@@ -601,7 +600,7 @@ end subroutine moab_map_init_rcfile
          endif  ! end NORMALIZATION
 
          !
-         ierr = iMOAB_SendElementTag( mapper%src_mbid, fldlist_moab, mapper%mpicom, mapper%intx_context );
+         ierr = iMOAB_SendElementTag( mapper%src_mbid, fldlist_moab, mapper%mpicom, mapper%intx_context )
          if (ierr .ne. 0) then
             write(logunit, *) subname,' iMOAB mapper error in sending tags ', mapper%mbname,  trim(fldlist_moab)
             call shr_sys_flush(logunit)

--- a/driver-moab/main/seq_map_mod.F90
+++ b/driver-moab/main/seq_map_mod.F90
@@ -610,24 +610,13 @@ end subroutine moab_map_init_rcfile
        if ( valid_moab_context ) then
          ! receive in the intx app, because it is redistributed according to coverage (trick)
          ! for true intx cases, tgt_mbid is set to be the same as intx_mbid
-         ! just read map is special
-         if (mapper%read_map)  then ! receive indeed in target app
 #ifdef MOABDEBUG
-            if (seq_comm_iamroot(CPLID)) then
-               write(logunit, *) subname,' iMOAB mapper receiving tags with read_map and tgt_mbid: ', &
-                mapper%mbname, trim(fldlist_moab)
-            endif
-#endif
-            ierr = iMOAB_ReceiveElementTag( mapper%tgt_mbid, fldlist_moab, mapper%mpicom, mapper%src_context )
-         else ! receive in the intx app, trick
-#ifdef MOABDEBUG
-            if (seq_comm_iamroot(CPLID)) then
-               write(logunit, *) subname,' iMOAB mapper receiving tags with intx and intx_mbid: ', &
-                mapper%mbname, trim(fldlist_moab)
-            endif
-#endif
-            ierr = iMOAB_ReceiveElementTag( mapper%intx_mbid, fldlist_moab, mapper%mpicom, mapper%src_context )
+         if (seq_comm_iamroot(CPLID)) then
+            write(logunit, *) subname,' iMOAB mapper receiving tags with intx and intx_mbid: ', &
+               mapper%mbname, trim(fldlist_moab)
          endif
+#endif
+         ierr = iMOAB_ReceiveElementTag( mapper%intx_mbid, fldlist_moab, mapper%mpicom, mapper%src_context )
          if (ierr .ne. 0) then
             write(logunit,*) subname,' error in receiving tags ', mapper%mbname, 'recv:',  mapper%intx_mbid, trim(fldlist_moab)
             call shr_sys_flush(logunit)

--- a/driver-moab/main/seq_map_type_mod.F90
+++ b/driver-moab/main/seq_map_type_mod.F90
@@ -47,7 +47,6 @@ module seq_map_type_mod
      character*16            :: mbname
      integer                 :: tag_entity_type
      integer                 :: nentities ! this should be used only if copy_only is true
-     logical                 :: read_map
      !
 #endif
 
@@ -164,7 +163,6 @@ contains
     mapper%nentities =  0
     mapper%tag_entity_type = 1 ! cells most of the time when we need it
     mapper%mbname    = "undefined"
-    mapper%read_map = .false.
 #ifdef MOABCOMP
     if (seq_comm_iamroot(CPLID)) then
       write(logunit,'(A,i6)') subname//' call init map for mapper with id ',mapper%counter

--- a/driver-moab/shr/seq_comm_mct.F90
+++ b/driver-moab/shr/seq_comm_mct.F90
@@ -1551,7 +1551,8 @@ contains
     use shr_kind_mod,     only:  CXX => shr_kind_CXX
     use shr_kind_mod     , only : r8 => shr_kind_r8
     use mct_mod
-    use iMOAB, only : iMOAB_DefineTagStorage,  iMOAB_GetDoubleTagStorage, iMOAB_GetMeshInfo
+    use iMOAB, only : iMOAB_DefineTagStorage,  iMOAB_GetDoubleTagStorage, iMOAB_GetMeshInfo, &
+     iMOAB_SetDoubleTagStorage
 
     use iso_c_binding
     character(*), intent (in) :: modelstr
@@ -1568,7 +1569,7 @@ contains
 
      ! moab
      integer                  :: tagtype, numco,  tagindex, ierr
-     character(CXX)           :: tagname_mct
+     character(CXX)           :: tagname_mct, tagname_diff
 
      real(r8) , allocatable :: values(:), mct_values(:)
      integer nvert(3), nvise(3), nbl(3), nsurf(3), nvisBC(3)
@@ -1599,6 +1600,13 @@ contains
         call shr_sys_abort(subname//'Error: fail to get moab tag values')
 
      values  = mct_values - values
+     ! set the difference tag 
+     tagname_diff = trim(mct_field)//'_diff'//C_NULL_CHAR
+
+     tagtype = 1 ! dense, double
+     numco = 1
+     ierr = iMOAB_DefineTagStorage(appId, tagname_diff, tagtype, numco,  tagindex)
+     ierr = iMOAB_SetDoubleTagStorage ( appId, tagname_diff, mbSize , ent_type, values)
 
      difference = dot_product(values, values)
      differenceg = 0. ! initialize to 0 the total sum

--- a/driver-moab/shr/seq_comm_mct.F90
+++ b/driver-moab/shr/seq_comm_mct.F90
@@ -238,16 +238,17 @@ module seq_comm_mct
   integer, public :: mbintxia ! iMOAB id for intx mesh between ice and atmosphere
   integer, public :: mrofid   ! iMOAB id of moab rof app
   integer, public :: mbrxid   ! iMOAB id of moab rof read from file on coupler pes
-  integer, public :: mbrmapro ! iMOAB id for read map between river and ocean; it exists on coupler PEs
-                              ! similar to intx id, oa, la; 
-  integer, public :: mbrxoid  ! iMOAB id for rof migrated to coupler for ocean context (r2o mapping)
-  logical, public :: mbrof_data = .false. ! made true if no rtm mesh, which means data rof ? 
+!   integer, public :: mbrmapro ! iMOAB id for read map between river and ocean; it exists on coupler PEs
+!                               ! similar to intx id, oa, la;
+!   integer, public :: mbrxoid  ! iMOAB id for rof migrated to coupler for ocean context (r2o mapping)
+  integer, public :: mbintxro ! iMOAB id for read map between river and ocean; it exists on coupler PEs
+  logical, public :: mbrof_data = .false. ! made true if no rtm mesh, which means data rof ?
   integer, public :: mbintxar ! iMOAB id for intx mesh between atm and river
   integer, public :: mbintxlr ! iMOAB id for intx mesh between land and river
   integer, public :: mbintxrl ! iMOAB id for intx mesh between river and land
-  
+
   integer, public :: num_moab_exports   ! iMOAB id for atm phys grid, on atm pes
-  logical, public :: mb_rof_aream_computed = .false.  ! whether the aream for rof has been set or not 
+  logical, public :: mb_rof_aream_computed = .false.  ! whether the aream for rof has been set or not
 
   !=======================================================================
 contains
@@ -678,8 +679,9 @@ contains
     mbintxia = -1 ! iMOAB id for ice intx with atm on coupler pes
     mrofid = -1   ! iMOAB id of moab rof app
     mbrxid = -1   ! iMOAB id of moab rof migrated to coupler
-    mbrmapro = -1 ! iMOAB id of moab instance of map read from rof2ocn map file 
-    mbrxoid = -1  ! iMOAB id of moab instance rof to coupler in ocean context
+   !  mbrmapro = -1 ! iMOAB id of moab instance of map read from rof2ocn map file
+   !  mbrxoid = -1  ! iMOAB id of moab instance rof to coupler in ocean context
+    mbintxro = -1 ! iMOAB id of moab instance of map read from rof2ocn map file
     mbintxar = -1 ! iMOAB id for intx mesh between atm and river
     mbintxlr = -1 ! iMOAB id for intx mesh between land and river
     mbintxrl = -1 ! iMOAB id for intx mesh between river and land
@@ -1551,8 +1553,8 @@ contains
     use shr_kind_mod     , only : r8 => shr_kind_r8
     use mct_mod
     use iMOAB, only : iMOAB_DefineTagStorage,  iMOAB_GetDoubleTagStorage, iMOAB_GetMeshInfo
-    
-    use iso_c_binding 
+
+    use iso_c_binding
     character(*), intent (in) :: modelstr
     integer, intent(in) :: mpicom
     integer , intent(in) :: appId, ent_type
@@ -1568,7 +1570,7 @@ contains
      ! moab
      integer                  :: tagtype, numco,  tagindex, ierr
      character(CXX)           :: tagname_mct
-     
+
      real(r8) , allocatable :: values(:), mct_values(:)
      integer nvert(3), nvise(3), nbl(3), nsurf(3), nvisBC(3)
      logical   :: iamroot
@@ -1580,7 +1582,7 @@ contains
      allocate(mct_values(nloc))
 
      index_avfield     = mct_aVect_indexRA(attrVect,trim(mct_field))
-     mct_values(:) = attrVect%rAttr(index_avfield,:) 
+     mct_values(:) = attrVect%rAttr(index_avfield,:)
 
      ! now get moab tag values; first get info
      ierr  = iMOAB_GetMeshInfo ( appId, nvert, nvise, nbl, nsurf, nvisBC );
@@ -1596,7 +1598,7 @@ contains
      ierr = iMOAB_GetDoubleTagStorage ( appId, tagname, mbSize , ent_type, values)
      if (ierr > 0 )  &
         call shr_sys_abort(subname//'Error: fail to get moab tag values')
-      
+
      values  = mct_values - values
 
      difference = dot_product(values, values)

--- a/driver-moab/shr/seq_comm_mct.F90
+++ b/driver-moab/shr/seq_comm_mct.F90
@@ -248,7 +248,6 @@ module seq_comm_mct
   integer, public :: mbintxrl ! iMOAB id for intx mesh between river and land
 
   integer, public :: num_moab_exports   ! iMOAB id for atm phys grid, on atm pes
-  logical, public :: mb_rof_aream_computed = .false.  ! whether the aream for rof has been set or not
 
   !=======================================================================
 contains

--- a/driver-moab/shr/seq_infodata_mod.F90
+++ b/driver-moab/shr/seq_infodata_mod.F90
@@ -132,6 +132,7 @@ MODULE seq_infodata_mod
      character(SHR_KIND_CS)  :: aoflux_grid     ! grid for atm ocn flux calc
      integer                 :: cpl_decomp      ! coupler decomp
      character(SHR_KIND_CL)  :: cpl_seq_option  ! coupler sequencing option
+     logical                 :: cpl_compute_maps_online   ! moab maps flag (online computation or offline map reading)
 
      logical                 :: do_budgets      ! do heat/water budgets diagnostics
      logical                 :: do_bgc_budgets  ! do BGC budgets diagnostics
@@ -394,6 +395,7 @@ CONTAINS
     character(SHR_KIND_CS) :: aoflux_grid        ! grid for atm ocn flux calc
     integer                :: cpl_decomp         ! coupler decomp
     character(SHR_KIND_CL) :: cpl_seq_option     ! coupler sequencing option
+    logical                :: cpl_compute_maps_online   ! moab maps flag (online computation or offline map reading)
 
     logical                :: do_budgets         ! do heat/water budgets diagnostics
     logical                :: do_bgc_budgets     ! do BGC budgets diagnostics
@@ -474,8 +476,8 @@ CONTAINS
          histavg_atm, histavg_lnd, histavg_ocn, histavg_ice, &
          histavg_rof, histavg_glc, histavg_wav, histavg_xao, &
          histavg_iac, &
-         histaux_l2x1yrg, cpl_seq_option,                   &
-         eps_frac, eps_amask,                   &
+         histaux_l2x1yrg, cpl_seq_option, cpl_compute_maps_online, &
+         eps_frac, eps_amask,                              &
          eps_agrid, eps_aarea, eps_omask, eps_ogrid,       &
          eps_oarea, esmf_map_flag,                         &
          reprosum_use_ddpdd, reprosum_allow_infnan,        &
@@ -558,6 +560,7 @@ CONTAINS
        aoflux_grid           = 'ocn'
        cpl_decomp            = 0
        cpl_seq_option        = 'CESM1_MOD'
+       cpl_compute_maps_online = .false.
        do_budgets            = .false.
        do_bgc_budgets        = .false.
        do_histinit           = .false.
@@ -695,6 +698,7 @@ CONTAINS
        infodata%aoflux_grid           = aoflux_grid
        infodata%cpl_decomp            = cpl_decomp
        infodata%cpl_seq_option        = cpl_seq_option
+       infodata%cpl_compute_maps_online = cpl_compute_maps_online
        infodata%do_budgets            = do_budgets
        infodata%do_bgc_budgets        = do_bgc_budgets
        infodata%do_histinit           = do_histinit
@@ -1024,7 +1028,7 @@ CONTAINS
        flood_present, wav_present, wav_prognostic, rofice_present,        &
        glclnd_present, glcocn_present, glcice_present, iceberg_prognostic,&
        esp_present, esp_prognostic,                                       &
-       bfbflag, lnd_gnam, cpl_decomp, cpl_seq_option,                     &
+       bfbflag, lnd_gnam, cpl_decomp, cpl_seq_option, cpl_compute_maps_online,  &
        ice_gnam, rof_gnam, glc_gnam, wav_gnam, iac_gnam,                  &
        atm_gnam, ocn_gnam, info_debug, dead_comps, read_restart,          &
        shr_map_dopole, vect_map, aoflux_grid, flux_epbalfact,             &
@@ -1128,6 +1132,7 @@ CONTAINS
     character(len=*),       optional, intent(OUT) :: aoflux_grid             ! grid for atm ocn flux calc
     integer,                optional, intent(OUT) :: cpl_decomp              ! coupler decomp
     character(len=*),       optional, intent(OUT) :: cpl_seq_option          ! coupler sequencing option
+    logical,                optional, intent(OUT) :: cpl_compute_maps_online ! coupler online/offline maps flag
     logical,                optional, intent(OUT) :: do_budgets              ! heat/water budgets
     logical,                optional, intent(OUT) :: do_bgc_budgets          ! BGC budgets
     logical,                optional, intent(OUT) :: do_histinit             ! initial history file
@@ -1321,6 +1326,7 @@ CONTAINS
     if ( present(aoflux_grid)    ) aoflux_grid    = infodata%aoflux_grid
     if ( present(cpl_decomp)     ) cpl_decomp     = infodata%cpl_decomp
     if ( present(cpl_seq_option) ) cpl_seq_option = infodata%cpl_seq_option
+    if ( present(cpl_compute_maps_online)  ) cpl_compute_maps_online  = infodata%cpl_compute_maps_online
     if ( present(do_budgets)     ) do_budgets     = infodata%do_budgets
     if ( present(do_bgc_budgets) ) do_bgc_budgets = infodata%do_bgc_budgets
     if ( present(do_histinit)    ) do_histinit    = infodata%do_histinit
@@ -1592,7 +1598,7 @@ CONTAINS
        glclnd_present, glcocn_present, glcice_present, iceberg_prognostic,&
        esp_present, esp_prognostic,                                       &
        iac_present, iac_prognostic,                                       &
-       bfbflag, lnd_gnam, cpl_decomp, cpl_seq_option,                     &
+       bfbflag, lnd_gnam, cpl_decomp, cpl_seq_option, cpl_compute_maps_online,  &
        ice_gnam, rof_gnam, glc_gnam, wav_gnam, iac_gnam,                  &
        atm_gnam, ocn_gnam, info_debug, dead_comps, read_restart,          &
        shr_map_dopole, vect_map, aoflux_grid, run_barriers,               &
@@ -1697,6 +1703,7 @@ CONTAINS
     character(len=*),       optional, intent(IN)    :: aoflux_grid             ! grid for atm ocn flux calc
     integer,                optional, intent(IN)    :: cpl_decomp              ! coupler decomp
     character(len=*),       optional, intent(IN)    :: cpl_seq_option          ! coupler sequencing option
+    logical,                optional, intent(IN)    :: cpl_compute_maps_online ! moab maps flag
     logical,                optional, intent(IN)    :: do_budgets              ! heat/water budgets
     logical,                optional, intent(IN)    :: do_bgc_budgets          ! BGC budgets
     logical,                optional, intent(IN)    :: do_histinit             ! initial history file
@@ -1889,6 +1896,7 @@ CONTAINS
     if ( present(aoflux_grid)    ) infodata%aoflux_grid    = aoflux_grid
     if ( present(cpl_decomp)     ) infodata%cpl_decomp     = cpl_decomp
     if ( present(cpl_seq_option) ) infodata%cpl_seq_option = cpl_seq_option
+    if ( present(cpl_compute_maps_online)  ) infodata%cpl_compute_maps_online  = cpl_compute_maps_online
     if ( present(do_budgets)     ) infodata%do_budgets     = do_budgets
     if ( present(do_bgc_budgets) ) infodata%do_bgc_budgets = do_bgc_budgets
     if ( present(do_histinit)    ) infodata%do_histinit    = do_histinit
@@ -2204,6 +2212,7 @@ CONTAINS
     call shr_mpi_bcast(infodata%aoflux_grid,             mpicom)
     call shr_mpi_bcast(infodata%cpl_decomp,              mpicom)
     call shr_mpi_bcast(infodata%cpl_seq_option,          mpicom)
+    call shr_mpi_bcast(infodata%cpl_compute_maps_online, mpicom)
     call shr_mpi_bcast(infodata%do_budgets,              mpicom)
     call shr_mpi_bcast(infodata%do_bgc_budgets,          mpicom)
     call shr_mpi_bcast(infodata%do_histinit,             mpicom)
@@ -2909,7 +2918,7 @@ CONTAINS
     write(logunit,F0L) subname,'flux_diurnal             = ', infodata%flux_diurnal
     write(logunit,F0L) subname,'ocn_surface_flux_scheme  = ', infodata%ocn_surface_flux_scheme
     write(logunit,F0A) subname,'precip_downscaling_method = ', infodata%precip_downscaling_method
-    write(logunit,F0L) subname,'coldair_outbreak_mod            = ', infodata%coldair_outbreak_mod
+    write(logunit,F0L) subname,'coldair_outbreak_mod     = ', infodata%coldair_outbreak_mod
     write(logunit,F0R) subname,'flux_convergence         = ', infodata%flux_convergence
     write(logunit,F0I) subname,'flux_max_iteration       = ', infodata%flux_max_iteration
     write(logunit,F0A) subname,'glc_renormalize_smb      = ', trim(infodata%glc_renormalize_smb)
@@ -2927,6 +2936,7 @@ CONTAINS
     write(logunit,F0A) subname,'vect_map                 = ', trim(infodata%vect_map)
     write(logunit,F0A) subname,'aoflux_grid              = ', trim(infodata%aoflux_grid)
     write(logunit,F0A) subname,'cpl_seq_option           = ', trim(infodata%cpl_seq_option)
+    write(logunit,F0L) subname,'cpl_compute_maps_online  = ', infodata%cpl_compute_maps_online
     write(logunit,F0S) subname,'cpl_decomp               = ', infodata%cpl_decomp
     write(logunit,F0L) subname,'do_budgets               = ', infodata%do_budgets
     write(logunit,F0L) subname,'do_bgc_budgets           = ', infodata%do_bgc_budgets


### PR DESCRIPTION
This pull request provides several functional updates to the MOAB coupler, including the ability to fully load all coupled maps from disk (similar to MCT), in addition to supporting full online computation of the meshes (controlled through the namelist variable `CPL_COMPUTE_MAPS_ONLINE`).

This branch requires the new updates in MOAB master, including API changes to the map loading routines in parallel.

[BFB]