### PR TITLE
Bump datedstamp on several RRSwISC6to18E3r5 inputdata files

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -5750,7 +5750,7 @@
 
     <gridmap ocn_grid="RRSwISC6to18E3r5" rof_grid="r025">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r025_to_RRSwISC6to18E3r5.cstmnn.r250e1250_58NS.20240328.nc</map>
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r025_to_RRSwISC6to18E3r5_cstmnn.r50e100.20240328.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r025_to_RRSwISC6to18E3r5_cstmnn.r50e100.20250325.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="WC14to60E2r3" rof_grid="r0125">

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -397,7 +397,7 @@ def buildnml(case, caseroot, compname):
         decomp_date = '20240404'
         decomp_prefix = 'partitions/mpas-o.graph.info.'
         restoring_file = 'sss.PHC2_monthlyClimatology.RRSwISC6to18E3r5.20240327.nc'
-        analysis_mask_file = 'RRSwISC6to18E3r5_mocBasinsAndTransects20210623mg.20250205.nc'
+        analysis_mask_file = 'RRSwISC6to18E3r5_mocBasinsAndTransects20210623mg.20250325.nc'
         ic_date = '20250205'
         ic_prefix = 'mpaso.RRSwISC6to18E3r5'
         if ocn_ic_mode == 'spunup':

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -398,7 +398,7 @@ def buildnml(case, caseroot, compname):
         decomp_prefix = 'partitions/mpas-o.graph.info.'
         restoring_file = 'sss.PHC2_monthlyClimatology.RRSwISC6to18E3r5.20240327.nc'
         analysis_mask_file = 'RRSwISC6to18E3r5_mocBasinsAndTransects20210623mg.20250205.nc'
-        ic_date = '20240327'
+        ic_date = '20250205'
         ic_prefix = 'mpaso.RRSwISC6to18E3r5'
         if ocn_ic_mode == 'spunup':
             logger.warning("WARNING: The specified compset is requesting ocean ICs spunup from a G-case")

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -397,7 +397,7 @@ def buildnml(case, caseroot, compname):
         decomp_date = '20240404'
         decomp_prefix = 'partitions/mpas-o.graph.info.'
         restoring_file = 'sss.PHC2_monthlyClimatology.RRSwISC6to18E3r5.20240327.nc'
-        analysis_mask_file = 'RRSwISC6to18E3r5_mocBasinsAndTransects20210623.nc'
+        analysis_mask_file = 'RRSwISC6to18E3r5_mocBasinsAndTransects20210623mg.20250205.nc'
         ic_date = '20240327'
         ic_prefix = 'mpaso.RRSwISC6to18E3r5'
         if ocn_ic_mode == 'spunup':

--- a/components/mpas-seaice/cime_config/buildnml
+++ b/components/mpas-seaice/cime_config/buildnml
@@ -325,7 +325,7 @@ def buildnml(case, caseroot, compname):
     elif ice_grid == 'RRSwISC6to18E3r5':
         decomp_date = '20240404'
         decomp_prefix = 'partitions/mpas-seaice.graph.info.'
-        grid_date = '20240327'
+        grid_date = '20250205'
         grid_prefix = 'mpassi.RRSwISC6to18E3r5'
         data_iceberg_file = 'Iceberg_Climatology_Merino.RRSwISC6to18E3r5.20240327.nc'
         if ice_ic_mode == 'spunup':


### PR DESCRIPTION
This merge adds a unique datestamp to RRSwISC6to18E3r5 MOC mask file. Previously, the file had the datestamp associated with the geometry used to create the masks (which still needs to be retained, now with a suffix `mg` for mask geometry) but now it also has the creation date:
```
RRSwISC6to18E3r5_mocBasinsAndTransects20210623mg.20250205.nc
```

This merge also bumps the time stamp of the ocean and sea-ice initial conditions (before spin-up) because we had to convert the file from netcdf4 to cdf5 format and need to ensure that the cdf5 version is on all machines.

This was requested in #7159 and is one of two PRs toward fixing that problem.