### PR TITLE
Add ucx env-vars to Anvil on maint-3.0

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2456,6 +2456,8 @@ commented out until "*** No rule to make target '.../libadios2pio-nm-lib.a'" iss
       <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
       <env name="PATH">/lcrc/group/e3sm/soft/perl/5.26.0/bin:$ENV{PATH}</env>
+      <env name="UCX_TLS">self,sm,ud</env>
+      <env name="UCX_UD_MLX5_RX_QUEUE_LEN">16384</env>
     </environment_variables>
     <environment_variables mpilib="mvapich">
       <env name="MV2_ENABLE_AFFINITY">0</env>


### PR DESCRIPTION
Add ucx env-vars to Anvil on maint-3.0 to mitigate frequent network errors.

[BFB]