### PR TITLE
Use nested team policies for P3 pre/post process

### DIFF
--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -310,7 +310,7 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   auto dz         = m_buffer.dz;
 
   // -- Set values for the pre-amble structure
-  p3_preproc.set_variables(m_num_cols,nk_pack,pmid,pmid_dry,pseudo_density,pseudo_density_dry,
+  p3_preproc.set_variables(m_num_cols,m_num_levs,pmid,pmid_dry,pseudo_density,pseudo_density_dry,
                         T_atm,cld_frac_t_in,cld_frac_l_in,cld_frac_i_in,
                         qv, qc, nc, qr, nr, qi, qm, ni, bm, qv_prev,
                         inv_exner, th_atm, cld_frac_l, cld_frac_i, cld_frac_r, dz, runtime_options);

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.hpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.hpp
@@ -138,7 +138,6 @@ public:
           if (active_range.any()) {
             const auto set_to_t_in = cld_frac_t_in_km1 > cld_frac_r(icol, ipack);
             cld_frac_r(icol,ipack).set(active_range and set_to_t_in, cld_frac_t_in_km1);
-            cld_frac_r(icol,ipack).set(active_range and not set_to_t_in, cld_frac_r(icol, ipack));
           }
         }
       });

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.hpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.hpp
@@ -271,9 +271,13 @@ public:
       }); // for ipack
 
       // Microphysics can be subcycled together during a single physics timestep,
-      // therefore we must accumulate these fluxes
-      precip_liq_surf_mass(icol) += precip_liq_surf_flux(icol) * PC::RHO_H2O * m_dt;
-      precip_ice_surf_mass(icol) += precip_ice_surf_flux(icol) * PC::RHO_H2O * m_dt;
+      // therefore we must accumulate these fluxes.
+      // Note: we need to ensure that only a single thread within the team is
+      //       updating the mass value.
+      Kokkos::single(Kokkos::PerTeam(team), [&] {
+        precip_liq_surf_mass(icol) += precip_liq_surf_flux(icol) * PC::RHO_H2O * m_dt;
+        precip_ice_surf_mass(icol) += precip_ice_surf_flux(icol) * PC::RHO_H2O * m_dt;
+      });
 
       // If necessary, set appropriate boundary fluxes for energy and mass
       // conservation checks. Any boundary fluxes not included in SHOC

--- a/components/eamxx/src/physics/p3/eamxx_p3_run.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_run.cpp
@@ -7,12 +7,16 @@ void P3Microphysics::run_impl (const double dt)
   // Set the dt for p3 postprocessing
   p3_postproc.m_dt = dt;
 
+  // Create policy for pre and post process pfor
+  const auto nlev_packs  = ekat::npack<Spack>(m_num_levs);
+  const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nlev_packs);
+
   // Assign values to local arrays used by P3, these are now stored in p3_loc.
   Kokkos::parallel_for(
-    "p3_main_local_vals",
-    Kokkos::RangePolicy<>(0,m_num_cols),
+    "p3_pre_process",
+    policy,
     p3_preproc
-  ); // Kokkos::parallel_for(p3_main_local_vals)
+  );
   Kokkos::fence();
 
   // Update the variables in the p3 input structures with local values.
@@ -37,10 +41,10 @@ void P3Microphysics::run_impl (const double dt)
 
   // Conduct the post-processing of the p3_main output.
   Kokkos::parallel_for(
-    "p3_main_local_vals",
-    Kokkos::RangePolicy<>(0,m_num_cols),
+    "p3_post_process",
+    policy,
     p3_postproc
-  ); // Kokkos::parallel_for(p3_main_local_vals)
+  );
   Kokkos::fence();
 }
 


### PR DESCRIPTION
Ideally we have nested parallelism in these pre/post process kernels. Chatting with @ndkeen, there's potential for a decent perf improvement (update with timings later) as pre/post process could be up to 50% of total P3 run time.

[BFB]