### PR TITLE
Move cime_run_calc_budgets2 to just before atm runs

### DIFF
--- a/driver-mct/main/cime_comp_mod.F90
+++ b/driver-mct/main/cime_comp_mod.F90
@@ -3193,6 +3193,13 @@ contains
        end if
 
        !----------------------------------------------------------
+       !| Budget with new fractions
+       !----------------------------------------------------------
+       if (do_budgets) then
+          call cime_run_calc_budgets2()
+       endif
+
+       !----------------------------------------------------------
        !| RUN ATM MODEL
        !----------------------------------------------------------
        if (atm_present .and. atmrun_alarm) then
@@ -3235,13 +3242,6 @@ contains
        !----------------------------------------------------------
        if (atm_present .and. atmrun_alarm) then
           call cime_run_atm_recv_post
-       endif
-
-       !----------------------------------------------------------
-       !| Budget with new fractions
-       !----------------------------------------------------------
-       if (do_budgets) then
-          call cime_run_calc_budgets2()
        endif
 
        !----------------------------------------------------------

--- a/driver-moab/main/cime_comp_mod.F90
+++ b/driver-moab/main/cime_comp_mod.F90
@@ -3325,6 +3325,13 @@ contains
        end if
 
        !----------------------------------------------------------
+       !| Budget with new fractions
+       !----------------------------------------------------------
+       if (do_budgets) then
+          call cime_run_calc_budgets2()
+       endif
+
+       !----------------------------------------------------------
        !| RUN ATM MODEL
        !----------------------------------------------------------
        if (atm_present .and. atmrun_alarm) then
@@ -3367,14 +3374,6 @@ contains
        !----------------------------------------------------------
        if (atm_present .and. atmrun_alarm) then
           call cime_run_atm_recv_post
-       endif
-
-
-       !----------------------------------------------------------
-       !| Budget with new fractions
-       !----------------------------------------------------------
-       if (do_budgets) then
-          call cime_run_calc_budgets2()
        endif
 
        !----------------------------------------------------------


### PR DESCRIPTION
During the implementation of atm2srf in PR #7111, @ambrad discovered that the current call to cime_run_calc_budgets2 caused the atm budget to be off by one coupling interval, and that moving it to just before the atm run call would fix that issue. This PR implements that change.

[BFB] - just impacts the budget output