### PR TITLE
Give "NoPreference" tracers advection option.

### DIFF
--- a/components/eamxx/src/share/atm_process/atmosphere_process_group.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_group.hpp
@@ -112,6 +112,11 @@ public:
     }
   }
 
+  // Pre-process tracer requests by checking for
+  // consistency among processes and correctly
+  // determining turbulence advection property
+  void pre_process_tracer_requests ();
+
 protected:
 
   // Adds fid to the list of required/computed fields of the group (as a whole).

--- a/components/eamxx/src/share/field/field_request.hpp
+++ b/components/eamxx/src/share/field/field_request.hpp
@@ -16,7 +16,9 @@ enum RequestType {
 // Whether a tracer should be advected by both Dynamics
 // and Turbulance, or only by Dynamics
 enum TracerAdvection {
-  DynamicsAndTurbulence, // Default use case
+  NoPreference, // Default. In the case that no process gives a preference,
+                // the tracer is advected by dynamics and turbulence
+  DynamicsAndTurbulence,
   DynamicsOnly,
 };
 


### PR DESCRIPTION
If all processes register a tracer with "NoPreference", the tracer will be both dynamics and shoc advected.

Also, moves tracer consistency check to AtmosphereProcessGroup.

[BFB]