### PR TITLE
EAMxx: Add diag_equiv_reflectivity as an output

### DIFF
--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
@@ -161,6 +161,7 @@ Int Functions<Real,DefaultDevice>
   auto precip_ice_flux         = diagnostic_outputs.precip_ice_flux;
   auto precip_total_tend       = diagnostic_outputs.precip_total_tend;
   auto nevapr                  = diagnostic_outputs.nevapr;
+  auto diag_equiv_reflectivity = diagnostic_outputs.diag_equiv_reflectivity;
   auto qv_prev                 = diagnostic_inputs.qv_prev;
   auto t_prev                  = diagnostic_inputs.t_prev;
   // Inputs for the heteogeneous freezing
@@ -205,7 +206,6 @@ Int Functions<Real,DefaultDevice>
   auto qv_supersat_i           = temporaries.qv_supersat_i;
   auto tmparr2                 = temporaries.tmparr2;
   auto exner                   = temporaries.exner;
-  auto diag_equiv_reflectivity = temporaries.diag_equiv_reflectivity;
   auto diag_vm_qi              = temporaries.diag_vm_qi;
   auto diag_diam_qi            = temporaries.diag_diam_qi;
   auto pratot                  = temporaries.pratot;

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -118,13 +118,14 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
   }
 
   // Diagnostic Outputs: (all fields are just outputs w.r.t. P3)
-  add_field<Updated>("precip_liq_surf_mass", scalar2d_layout,     kg/m2,     grid_name, "ACCUMULATED");
-  add_field<Updated>("precip_ice_surf_mass", scalar2d_layout,     kg/m2,     grid_name, "ACCUMULATED");
-  add_field<Computed>("eff_radius_qc",       scalar3d_layout_mid, micron,    grid_name, ps);
-  add_field<Computed>("eff_radius_qi",       scalar3d_layout_mid, micron,    grid_name, ps);
-  add_field<Computed>("eff_radius_qr",       scalar3d_layout_mid, micron,    grid_name, ps);
-  add_field<Computed>("precip_total_tend",   scalar3d_layout_mid, kg/(kg*s), grid_name, ps);
-  add_field<Computed>("nevapr",              scalar3d_layout_mid, kg/(kg*s), grid_name, ps);
+  add_field<Updated>("precip_liq_surf_mass",     scalar2d_layout,     kg/m2,     grid_name, "ACCUMULATED");
+  add_field<Updated>("precip_ice_surf_mass",     scalar2d_layout,     kg/m2,     grid_name, "ACCUMULATED");
+  add_field<Computed>("eff_radius_qc",           scalar3d_layout_mid, micron,    grid_name, ps);
+  add_field<Computed>("eff_radius_qi",           scalar3d_layout_mid, micron,    grid_name, ps);
+  add_field<Computed>("eff_radius_qr",           scalar3d_layout_mid, micron,    grid_name, ps);
+  add_field<Computed>("precip_total_tend",       scalar3d_layout_mid, kg/(kg*s), grid_name, ps);
+  add_field<Computed>("nevapr",                  scalar3d_layout_mid, kg/(kg*s), grid_name, ps);
+  add_field<Computed>("diag_equiv_reflectivity", scalar3d_layout_mid, nondim,    grid_name, ps);
 
   // History Only: (all fields are just outputs and are really only meant for I/O purposes)
   // TODO: These should be averaged over subcycle as well.  But there is no simple mechanism
@@ -206,7 +207,7 @@ void P3Microphysics::init_buffers(const ATMBufferManager &buffer_manager)
     &m_buffer.ni_incld, &m_buffer.bm_incld, &m_buffer.inv_dz, &m_buffer.inv_rho, &m_buffer.ze_ice,
     &m_buffer.ze_rain, &m_buffer.prec, &m_buffer.rho, &m_buffer.rhofacr, &m_buffer.rhofaci,
     &m_buffer.acn, &m_buffer.qv_sat_l, &m_buffer.qv_sat_i, &m_buffer.sup, &m_buffer.qv_supersat_i,
-    &m_buffer.tmparr2, &m_buffer.exner, &m_buffer.diag_equiv_reflectivity, &m_buffer.diag_vm_qi,
+    &m_buffer.tmparr2, &m_buffer.exner, &m_buffer.diag_vm_qi,
     &m_buffer.diag_diam_qi, &m_buffer.pratot, &m_buffer.prctot, &m_buffer.qtend_ignore,
     &m_buffer.ntend_ignore, &m_buffer.mu_c, &m_buffer.lamc, &m_buffer.qr_evap_tend, &m_buffer.v_qc,
     &m_buffer.v_nc, &m_buffer.flux_qx, &m_buffer.flux_nx, &m_buffer.v_qit, &m_buffer.v_nit,
@@ -361,11 +362,12 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   }
 
   // --Diagnostic Outputs
-  diag_outputs.diag_eff_radius_qc = get_field_out("eff_radius_qc").get_view<Pack**>();
-  diag_outputs.diag_eff_radius_qi = get_field_out("eff_radius_qi").get_view<Pack**>();
-  diag_outputs.diag_eff_radius_qr = get_field_out("eff_radius_qr").get_view<Pack**>();
-  diag_outputs.precip_total_tend  = get_field_out("precip_total_tend").get_view<Pack**>();
-  diag_outputs.nevapr             = get_field_out("nevapr").get_view<Pack**>();
+  diag_outputs.diag_eff_radius_qc      = get_field_out("eff_radius_qc").get_view<Pack**>();
+  diag_outputs.diag_eff_radius_qi      = get_field_out("eff_radius_qi").get_view<Pack**>();
+  diag_outputs.diag_eff_radius_qr      = get_field_out("eff_radius_qr").get_view<Pack**>();
+  diag_outputs.precip_total_tend       = get_field_out("precip_total_tend").get_view<Pack**>();
+  diag_outputs.nevapr                  = get_field_out("nevapr").get_view<Pack**>();
+  diag_outputs.diag_equiv_reflectivity = get_field_out("diag_equiv_reflectivity").get_view<Pack**>();
 
   diag_outputs.precip_liq_surf  = m_buffer.precip_liq_surf_flux;
   diag_outputs.precip_ice_surf  = m_buffer.precip_ice_surf_flux;
@@ -415,7 +417,6 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   temporaries.qv_supersat_i           = m_buffer.qv_supersat_i;
   temporaries.tmparr2                 = m_buffer.tmparr2;
   temporaries.exner                   = m_buffer.exner;
-  temporaries.diag_equiv_reflectivity = m_buffer.diag_equiv_reflectivity;
   temporaries.diag_vm_qi              = m_buffer.diag_vm_qi;
   temporaries.diag_diam_qi            = m_buffer.diag_diam_qi;
   temporaries.pratot                  = m_buffer.pratot;

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.hpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.hpp
@@ -391,7 +391,7 @@ public:
     static constexpr int num_1d_scalar = 2; //no 2d vars now, but keeping 1d struct for future expansion
     // 2d view packed, size (ncol, nlev_packs)
 #ifdef SCREAM_P3_SMALL_KERNELS
-    static constexpr int num_2d_vector = 64;
+    static constexpr int num_2d_vector = 63;
 #else
     static constexpr int num_2d_vector = 8;
 #endif

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.hpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.hpp
@@ -418,7 +418,7 @@ public:
       nc_incld, nr_incld, ni_incld, bm_incld,
       inv_dz, inv_rho, ze_ice, ze_rain, prec, rho, rhofacr,
       rhofaci, acn, qv_sat_l, qv_sat_i, sup, qv_supersat_i,
-      tmparr2, exner, diag_equiv_reflectivity, diag_vm_qi,
+      tmparr2, exner, diag_vm_qi,
       diag_diam_qi, pratot, prctot, qtend_ignore, ntend_ignore,
       mu_c, lamc, qr_evap_tend, v_qc, v_nc, flux_qx, flux_nx,
       v_qit, v_nit, flux_nit, flux_bir, flux_qir, flux_qit,

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
@@ -132,7 +132,7 @@ Int Functions<S,D>
       // Other
       inv_dz, inv_rho, ze_ice, ze_rain, prec, rho,
       rhofacr, rhofaci, acn, qv_sat_l, qv_sat_i, sup, qv_supersat_i,
-      tmparr1, exner, diag_equiv_reflectivity, diag_vm_qi, diag_diam_qi, pratot, prctot,
+      tmparr1, exner, diag_vm_qi, diag_diam_qi, pratot, prctot,
 
       // p3_tend_out, may not need these
       qtend_ignore, ntend_ignore,
@@ -140,14 +140,14 @@ Int Functions<S,D>
       // Variables still used in F90 but removed from C++ interface
       mu_c, lamc, qr_evap_tend;
 
-    workspace.template take_many_and_reset<44>(
+    workspace.template take_many_and_reset<43>(
       {
         "mu_r", "T_atm", "lamr", "logn0r", "nu", "cdist", "cdist1", "cdistr",
         "inv_cld_frac_i", "inv_cld_frac_l", "inv_cld_frac_r", "qc_incld", "qr_incld", "qi_incld", "qm_incld",
         "nc_incld", "nr_incld", "ni_incld", "bm_incld",
         "inv_dz", "inv_rho", "ze_ice", "ze_rain", "prec", "rho",
         "rhofacr", "rhofaci", "acn", "qv_sat_l", "qv_sat_i", "sup", "qv_supersat_i",
-        "tmparr1", "exner", "diag_equiv_reflectivity", "diag_vm_qi", "diag_diam_qi",
+        "tmparr1", "exner", "diag_vm_qi", "diag_diam_qi",
         "pratot", "prctot", "qtend_ignore", "ntend_ignore",
         "mu_c", "lamc", "qr_evap_tend"
       },
@@ -157,7 +157,7 @@ Int Functions<S,D>
         &nc_incld, &nr_incld, &ni_incld, &bm_incld,
         &inv_dz, &inv_rho, &ze_ice, &ze_rain, &prec, &rho,
         &rhofacr, &rhofaci, &acn, &qv_sat_l, &qv_sat_i, &sup, &qv_supersat_i,
-        &tmparr1, &exner, &diag_equiv_reflectivity, &diag_vm_qi, &diag_diam_qi,
+        &tmparr1, &exner, &diag_vm_qi, &diag_diam_qi,
         &pratot, &prctot, &qtend_ignore, &ntend_ignore,
         &mu_c, &lamc, &qr_evap_tend
       });
@@ -195,6 +195,7 @@ Int Functions<S,D>
     const auto oprecip_ice_flux    = ekat::subview(diagnostic_outputs.precip_ice_flux, i);
     const auto oprecip_total_tend  = ekat::subview(diagnostic_outputs.precip_total_tend, i);
     const auto onevapr             = ekat::subview(diagnostic_outputs.nevapr, i);
+    const auto odiag_equiv_refl    = ekat::subview(diagnostic_outputs.diag_equiv_reflectivity, i);
     const auto oliq_ice_exchange   = ekat::subview(history_only.liq_ice_exchange, i);
     const auto ovap_liq_exchange   = ekat::subview(history_only.vap_liq_exchange, i);
     const auto ovap_ice_exchange   = ekat::subview(history_only.vap_ice_exchange, i);
@@ -224,7 +225,7 @@ Int Functions<S,D>
     // initialize
     p3_main_init(
       team, nk_pack,
-      ocld_frac_i, ocld_frac_l, ocld_frac_r, oinv_exner, oth, odz, diag_equiv_reflectivity,
+      ocld_frac_i, ocld_frac_l, ocld_frac_r, oinv_exner, oth, odz, odiag_equiv_refl,
       ze_ice, ze_rain, odiag_eff_radius_qc, odiag_eff_radius_qi, odiag_eff_radius_qr,
       inv_cld_frac_i, inv_cld_frac_l, inv_cld_frac_r, exner, T_atm, oqv, inv_dz,
       diagnostic_outputs.precip_liq_surf(i), diagnostic_outputs.precip_ice_surf(i), zero_init);
@@ -309,7 +310,7 @@ Int Functions<S,D>
       rho, inv_rho, rhofaci, oqv, oth, oqc, onc, oqr, onr, oqi, oni,
       oqm, obm, mu_c, nu, lamc, mu_r, lamr,
       ovap_liq_exchange, ze_rain, ze_ice, diag_vm_qi, odiag_eff_radius_qi, diag_diam_qi,
-      orho_qi, diag_equiv_reflectivity, odiag_eff_radius_qc, odiag_eff_radius_qr, runtime_options);
+      orho_qi, odiag_equiv_refl, odiag_eff_radius_qc, odiag_eff_radius_qr, runtime_options);
 
     //
     // merge ice categories with similar properties

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -256,6 +256,8 @@ struct Functions
     view_2d<Spack> precip_total_tend;
     // Evaporation of total precipitation (rain + snow) [kg/kg/s]
     view_2d<Spack> nevapr;
+    // Equivalent radar reflectivity [dBz]
+    view_2d<Spack> diag_equiv_reflectivity;
   };
 
   // This struct stores time stepping and grid-index-related information.

--- a/components/eamxx/src/physics/p3/tests/infra/p3_test_data.cpp
+++ b/components/eamxx/src/physics/p3/tests/infra/p3_test_data.cpp
@@ -1341,6 +1341,7 @@ Int p3_main_host(
   view_2d lamc_d("lamc_d",nj,nk);
   view_2d precip_total_tend_d("precip_total_tend_d",nj,nk);
   view_2d nevapr_d("nevapr_d",nj,nk);
+  view_2d diag_equiv_reflectivity_d("diag_equiv_reflectivity_d",nj,nk);
   view_2d qr_evap_tend_d("qr_evap_tend_d",nj,nk);
 
   Kokkos::parallel_for(nj, KOKKOS_LAMBDA(const Int& i) {
@@ -1360,7 +1361,7 @@ Int p3_main_host(
                                       inv_exner_d, qv_prev_d, t_prev_d, hetfrz_immersion_nucleation_tend_d, hetfrz_contact_nucleation_tend_d, hetfrz_deposition_nucleation_tend_d};
   P3F::P3DiagnosticOutputs diag_outputs{qv2qi_depos_tend_d, precip_liq_surf_d,
                                         precip_ice_surf_d, diag_eff_radius_qc_d, diag_eff_radius_qi_d, diag_eff_radius_qr_d,
-                                        rho_qi_d,precip_liq_flux_d, precip_ice_flux_d, precip_total_tend_d, nevapr_d};
+                                        rho_qi_d,precip_liq_flux_d, precip_ice_flux_d, precip_total_tend_d, nevapr_d, diag_equiv_reflectivity_d};
   P3F::P3Infrastructure infrastructure{dt, it, its, ite, kts, kte,
                                        do_predict_nc, do_prescribed_CCN, col_location_d};
   P3F::P3HistoryOnly history_only{liq_ice_exchange_d, vap_liq_exchange_d,
@@ -1377,7 +1378,7 @@ Int p3_main_host(
     inv_rho("inv_rho", nj, nk_pack), ze_ice("ze_ice", nj, nk_pack), ze_rain("ze_rain", nj, nk_pack), prec("prec", nj, nk_pack),
     rho("rho", nj, nk_pack), rhofacr("rhofacr", nj, nk_pack), rhofaci("rhofaci", nj, nk_pack),  acn("acn", nj, nk_pack), qv_sat_l("qv_sat", nj, nk_pack),
     qv_sat_i("qv_sat_i", nj, nk_pack), sup("sup", nj, nk_pack), qv_supersat_i("qv_supersat", nj, nk_pack), tmparr2("tmparr2", nj, nk_pack),
-    exner("exner", nj, nk_pack), diag_equiv_reflectivity("diag_equiv_ref", nj, nk_pack), diag_vm_qi("diag_vm_qi", nj, nk_pack),
+    exner("exner", nj, nk_pack), diag_vm_qi("diag_vm_qi", nj, nk_pack),
     diag_diam_qi("diag_diam_qi", nj, nk_pack), pratot("pratot", nj, nk_pack), prctot("prctot", nj, nk_pack), qtend_ignore("qtend_ignore", nj, nk_pack),
     ntend_ignore("ntend_ignore", nj, nk_pack), mu_c("mu_c", nj, nk_pack), lamc("lamc", nj, nk_pack), qr_evap_tend("qr_evap_tend", nj, nk_pack),
     v_qc("v_qc", nj, nk_pack), v_nc("v_nc", nj, nk_pack), flux_qx("flux_qx", nj, nk_pack), flux_nx("flux_nx", nj, nk_pack), v_qit("v_qit", nj, nk_pack),
@@ -1389,7 +1390,7 @@ Int p3_main_host(
     inv_cld_frac_l, inv_cld_frac_r, qc_incld, qr_incld, qi_incld, qm_incld,
     nc_incld, nr_incld, ni_incld, bm_incld, inv_dz, inv_rho, ze_ice, ze_rain,
     prec, rho, rhofacr, rhofaci, acn, qv_sat_l, qv_sat_i, sup, qv_supersat_i,
-    tmparr2, exner, diag_equiv_reflectivity, diag_vm_qi, diag_diam_qi,
+    tmparr2, exner, diag_vm_qi, diag_diam_qi,
     pratot, prctot, qtend_ignore, ntend_ignore, mu_c, lamc, qr_evap_tend,
     v_qc, v_nc, flux_qx, flux_nx, v_qit, v_nit, flux_nit, flux_bir, flux_qir,
     flux_qit, v_qr, v_nr

--- a/components/eamxx/tests/single-process/ml_correction/ml_correction_standalone.cpp
+++ b/components/eamxx/tests/single-process/ml_correction/ml_correction_standalone.cpp
@@ -43,7 +43,7 @@ TEST_CASE("ml_correction-stand-alone", "") {
   ad.initialize(atm_comm, ad_params, t0);
 
   const auto& grid = ad.get_grids_manager()->get_grid("Physics");
-  const auto& field_mgr = *ad.get_field_mgr(grid->name());
+  const auto& field_mgr = *ad.get_field_mgr();
 
   int num_cols = grid->get_num_local_dofs();
   int num_levs = grid->get_num_vertical_levels();


### PR DESCRIPTION
EAMxx: Make diag_equiv_reflectivity an output in P3
    
This commit moves the variable diag_equiv_reflectivity to be a diagnostic output of P3 microsphysics.  Previously it was stored in temporary memory.
    
[BFB]