### PR TITLE
EAMxx: allow to decomposing fast-striding dimensions in IO

### DIFF
--- a/components/eamxx/src/share/io/eamxx_scorpio_interface.hpp
+++ b/components/eamxx/src/share/io/eamxx_scorpio_interface.hpp
@@ -136,12 +136,12 @@ std::string get_time_name (const std::string& filename);
 
 void set_dim_decomp (const std::string& filename,
                      const std::string& dimname,
-                     const std::vector<offset_t>& my_offsets,
+                     const std::vector<int>& my_offsets,
                      const bool allow_reset = false);
 
 void set_dim_decomp (const std::string& filename,
                      const std::string& dimname,
-                     const offset_t start, const offset_t count,
+                     const int start, const int count,
                      const bool allow_reset = false);
 
 void set_dim_decomp (const std::string& filename,

--- a/components/eamxx/src/share/io/eamxx_scorpio_types.hpp
+++ b/components/eamxx/src/share/io/eamxx_scorpio_types.hpp
@@ -34,9 +34,6 @@ enum IOType {
 IOType str2iotype(const std::string &str);
 std::string iotype2str(const IOType iotype);
 
-// The type used by PIOc for offsets
-using offset_t = std::int64_t;
-
 /*
  * The following PIOxyz types each represent an entity that
  * is associated in scorpio with an id. For each of them, we add some
@@ -66,22 +63,25 @@ struct PIODim : public PIOFileEntity {
   int length       = -1;
   bool unlimited   = false;
 
-  // In case we decompose the dimension, this will store
-  // the owned offsets on this rank
+  // In case we decompose the dimension, this will store the owned offsets on this rank
   // NOTE: use a pointer, so we can detect if a decomposition already
   //       existed or not when we set one.
-  std::shared_ptr<std::vector<offset_t>> offsets;
+  std::shared_ptr<std::vector<int>> offsets;
 };
 
 // A decomposition
-// NOTE: the offsets of a PIODecomp are not the same as the offsets of
+// NOTE: the offsets of a PIODecomp are not the same as the offsets
 //       stored in its dim. The latter are the offsets *along that dim*.
 //       A PIODecomp is associated with a Nd layout, which includes decomp_dim
-//       among its dimensions. PIODecomp::offsets are the offsets of the full
+//       among its dimensions. PIODecomp::offsets contains the offsets of the full
 //       array layout owned by this rank. Hence, there can be many PIODecomp
 //       all storing the same dim
+
+// Use pimpl idiom, so we can avoid including pio.h here to get the PIO_Offset type
+struct OffsetsVec;
+
 struct PIODecomp : public PIOEntity {
-  std::vector<offset_t>           offsets;  // Owned offsets
+  std::shared_ptr<OffsetsVec>     offsets;
   std::shared_ptr<const PIODim>   dim; 
 };
 

--- a/components/eamxx/src/share/io/eamxx_scorpio_types.hpp
+++ b/components/eamxx/src/share/io/eamxx_scorpio_types.hpp
@@ -64,9 +64,8 @@ struct PIODim : public PIOFileEntity {
   bool unlimited   = false;
 
   // In case we decompose the dimension, this will store the owned offsets on this rank
-  // NOTE: use a pointer, so we can detect if a decomposition already
-  //       existed or not when we set one.
-  std::shared_ptr<std::vector<int>> offsets;
+  std::vector<int> offsets;
+  bool decomposed = false;
 };
 
 // A decomposition

--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -499,7 +499,7 @@ void AtmosphereInput::set_decompositions()
   auto gids_f = m_io_grid->get_partitioned_dim_gids();
   auto gids_h = gids_f.get_view<const AbstractGrid::gid_type*,Host>();
   auto min_gid = m_io_grid->get_global_min_partitioned_dim_gid();
-  std::vector<scorpio::offset_t> offsets(local_dim);
+  std::vector<int> offsets(local_dim);
   for (int idof=0; idof<local_dim; ++idof) {
     offsets[idof] = gids_h[idof] - min_gid;
   }

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -173,7 +173,6 @@ protected:
   void register_dimensions(const std::string& name);
   void register_variables(const std::string& filename, const std::string& fp_precision, const scorpio::FileMode mode);
   void set_decompositions(const std::string& filename);
-  std::vector<scorpio::offset_t> get_var_dof_offsets (const FieldLayout& layout);
   void register_views();
   Field get_field(const std::string& name, const std::string& mode) const;
   void compute_diagnostic (const std::string& name, const bool allow_invalid_fields = false);

--- a/components/eamxx/src/share/io/scorpio_scm_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_scm_input.cpp
@@ -257,7 +257,7 @@ void SCMInput::set_decompositions()
   auto gids_f = m_io_grid->get_partitioned_dim_gids();
   auto gids_h = gids_f.get_view<const AbstractGrid::gid_type*,Host>();
   auto min_gid = m_io_grid->get_global_min_partitioned_dim_gid();
-  std::vector<scorpio::offset_t> offsets(local_dim);
+  std::vector<int> offsets(local_dim);
   for (int idof=0; idof<local_dim; ++idof) {
     offsets[idof] = gids_h[idof] - min_gid;
   }

--- a/components/eamxx/src/share/io/tests/io_scm_reader.cpp
+++ b/components/eamxx/src/share/io/tests/io_scm_reader.cpp
@@ -59,7 +59,7 @@ void write (const int seed, const ekat::Comm& comm)
   scorpio::define_var(filename,"var",{"ncol","lev"},"real");
 
   auto my_col_gids = grid->get_partitioned_dim_gids().get_view<const AbstractGrid::gid_type*,Host>();
-  std::vector<scorpio::offset_t> my_offsets(my_col_gids.size());
+  std::vector<int> my_offsets(my_col_gids.size());
   for (size_t i=0; i<my_offsets.size(); ++i) {
     my_offsets[i] = my_col_gids[i] - grid->get_global_min_partitioned_dim_gid ();
   }

--- a/components/eamxx/src/share/io/tests/scorpio_interface_tests.cpp
+++ b/components/eamxx/src/share/io/tests/scorpio_interface_tests.cpp
@@ -48,10 +48,12 @@ TEST_CASE ("write_and_read") {
     define_dim (filename,"dim2",dim2); // OK, same specs
     REQUIRE_THROWS (define_dim (filename,"dim2",dim2+3)); // ERROR: changing dim length
     define_dim (filename,"dim3",dim3);
+    define_dim (filename,"dim4",dim3);
 
-    REQUIRE_THROWS (set_dim_decomp (filename,"dim4",my_offsets)); // ERROR: dimension not found
+    REQUIRE_THROWS (set_dim_decomp (filename,"dim5",my_offsets)); // ERROR: dimension not found
 
     set_dim_decomp (filename,"dim3",my_offsets);
+    set_dim_decomp (filename,"dim4",my_offsets);
 
     REQUIRE_THROWS (define_var (filename,"var1",{"dim1"},"double",true)); // ERROR: no time dimension (yet)
     REQUIRE_THROWS (define_var (filename,"var1",{"dim0"},"double",false)); // ERROR: dim0 not found
@@ -69,6 +71,7 @@ TEST_CASE ("write_and_read") {
     REQUIRE_THROWS (define_var (filename,"var3",{},"int",false)); // ERROR: changing time_dep flag
     define_var (filename,"var4",{"dim3","dim1"},"double",false);
     define_var (filename,"var5",{"dim3","dim1"},"double",true);
+    define_var (filename,"var6",{"dim1","dim4"},"double",true); // decomp is on fast striding dim!
 
     enddef (filename);
 
@@ -76,18 +79,25 @@ TEST_CASE ("write_and_read") {
     std::vector<float> var2 (dim1*dim2);
     std::vector<int> var3 (1);
     std::vector<double> var45 (ldim3*dim1);
+    std::vector<double> var6 (ldim3*dim1);
 
     // Write first time slice
     update_time (filename,0.0);
     std::iota (var1.begin(),var1.end(),100);
     std::iota (var2.begin(),var2.end(),100);
     std::iota (var3.begin(),var3.end(),100);
-    std::iota (var45.begin(),var45.end(),100+comm.rank()*ldim3*dim1);
+    for (int i=0; i<ldim3; ++i) {
+      for (int j=0; j<dim1; ++j) {
+        var45[i*dim1+j] = my_offsets[i]*dim1 + j;
+        var6[j*ldim3+i] = j*dim3 + my_offsets[i];
+      }
+    }
     write_var (filename,"var1",var1.data());
     write_var (filename,"var2",var2.data());
     write_var (filename,"var3",var3.data());
     write_var (filename,"var4",var45.data());
     write_var (filename,"var5",var45.data());
+    write_var (filename,"var6",var6.data());
 
     REQUIRE_THROWS (write_var (filename,"var3",static_cast<int*>(nullptr))); // ERROR: invalid pointer
 
@@ -95,11 +105,17 @@ TEST_CASE ("write_and_read") {
     update_time (filename,0.5);
     std::iota (var2.begin(),var2.end(),  200);
     std::iota (var3.begin(),var3.end(),  200);
-    std::iota (var45.begin(),var45.end(),200+comm.rank()*ldim3*dim1);
+    for (int i=0; i<ldim3; ++i) {
+      for (int j=0; j<dim1; ++j) {
+        var45[i*dim1+j] = 100 + my_offsets[i]*dim1 + j;
+        var6[j*ldim3+i] = 100 + j*dim3 + my_offsets[i];
+      }
+    }
     write_var (filename,"var2",var2.data());
     write_var (filename,"var3",var3.data());
     double minus_one = -1;
     write_var (filename,"var5",var45.data(),&minus_one);
+    write_var (filename,"var6",var6.data(),&minus_one);
 
     // Cleanup
     release_file (filename);
@@ -155,20 +171,29 @@ TEST_CASE ("write_and_read") {
     REQUIRE (not has_var(filename,"var0")); // Var not in file
 
     set_dim_decomp (filename,"dim3",my_offsets);
+    set_dim_decomp (filename,"dim4",my_offsets);
 
     std::vector<double> var1 (dim1);
     std::vector<float> var2 (dim1*dim2);
     std::vector<int> var3 (1);
     std::vector<double> var45 (ldim3*dim1);
+    std::vector<double> var6 (ldim3*dim1);
 
     std::vector<double> tgt_var1 (dim1);
     std::vector<float> tgt_var2 (dim1*dim2);
     std::vector<int> tgt_var3 (1);
     std::vector<double> tgt_var45 (ldim3*dim1);
+    std::vector<double> tgt_var6 (ldim3*dim1);
     std::iota (tgt_var1.begin(),tgt_var1.end(),  100);
     std::iota (tgt_var2.begin(),tgt_var2.end(),  100);
     std::iota (tgt_var3.begin(),tgt_var3.end(),  100);
-    std::iota (tgt_var45.begin(),tgt_var45.end(),100+comm.rank()*ldim3*dim1);
+
+    for (int i=0; i<ldim3; ++i) {
+      for (int j=0; j<dim1; ++j) {
+        tgt_var45[i*dim1+j] = my_offsets[i]*dim1 + j;
+        tgt_var6[j*ldim3+i] = j*dim3 + my_offsets[i];
+      }
+    }
 
     read_var (filename,"var1",var1.data());
     REQUIRE (tgt_var1==var1);
@@ -189,10 +214,19 @@ TEST_CASE ("write_and_read") {
     read_var (filename,"var5",var45.data(),0);
     REQUIRE (tgt_var45==var45);
 
+    read_var (filename,"var6",var6.data(),0);
+    REQUIRE (tgt_var6==var6);
+
     // Read second time slice
     std::iota (tgt_var2.begin(),tgt_var2.end(),  200);
     std::iota (tgt_var3.begin(),tgt_var3.end(),  200);
-    std::iota (tgt_var45.begin(),tgt_var45.end(),200+comm.rank()*ldim3*dim1);
+
+    for (int i=0; i<ldim3; ++i) {
+      for (int j=0; j<dim1; ++j) {
+        tgt_var45[i*dim1+j] = 100 + my_offsets[i]*dim1 + j;
+        tgt_var6[j*ldim3+i] = 100 + j*dim3 + my_offsets[i];
+      }
+    }
 
     read_var (filename,"var2",var2.data(),1);
     REQUIRE (tgt_var2==var2);
@@ -202,6 +236,9 @@ TEST_CASE ("write_and_read") {
 
     read_var (filename,"var5",var45.data(),1);
     REQUIRE (tgt_var45==var45);
+
+    read_var (filename,"var6",var6.data(),1);
+    REQUIRE (tgt_var6==var6);
 
     // Cleanup
     release_file (filename);

--- a/components/eamxx/src/share/io/tests/scorpio_interface_tests.cpp
+++ b/components/eamxx/src/share/io/tests/scorpio_interface_tests.cpp
@@ -30,7 +30,7 @@ TEST_CASE ("write_and_read") {
   const int dim3  = ldim3 * comm.size();
 
   // Offsets for dim3 decomp owned by this rank
-  std::vector<offset_t> my_offsets;
+  std::vector<int> my_offsets;
   for (int i=0; i<ldim3; ++i) {
     my_offsets.push_back(ldim3*comm.rank() + i);
   }


### PR DESCRIPTION
Main change: allow our IO layer to output decomposed variables where the decomposition is not on the slowest-striding dimension.

Minor changes:
- use structured binding in eamxx_scorpio_interface.cpp
- remove implicit assumption that PIO_Offset is 64 bit: it probably always will be, but no need to hard code assumptions.
- be more clear/explicit when marking a dim as decomposed: use a bool to mark it as such, rather than relying on whether the shared ptr of the offsets is null or not...

[BFB]

---

Note: this PR enables a couple of things that we may want to implement sooner or later:

1. Use lat-lon grids, where we decompose the lon dim (not the fast striding one)
2. Rearrange the layout of our fields from (ncol,nlev) to (nlev,ncol), so that we output in a format that nco tools can easily digest (a topic discussed at E3SM all hands).