### PR TITLE
EAMxx: fix internal_diagnostics_level testmod and add bfb hash standalone test

### DIFF
--- a/components/eamxx/cmake/CompareTextFiles.cmake
+++ b/components/eamxx/cmake/CompareTextFiles.cmake
@@ -1,0 +1,40 @@
+# Compare two text files
+
+# Get the source and target file paths from the command line arguments
+# NOTE: when using cmake -P <script> args, CMAKE_ARGVn will contain
+#  n=0: cmake
+#  n=1: -P
+#  n=2: script name
+#  n=3,..: args
+set(SRC_FILE "${CMAKE_ARGV3}")
+set(TGT_FILE "${CMAKE_ARGV4}")
+
+# Print the files being compared
+message(STATUS "Comparing files: ${SRC_FILE} and ${TGT_FILE}")
+
+# Check if the source file exists
+if(NOT EXISTS ${SRC_FILE})
+    message(FATAL_ERROR "Error: Source file not found: ${SRC_FILE}")
+endif()
+
+# Check if the target file exists
+if(NOT EXISTS ${TGT_FILE})
+    message(FATAL_ERROR "Error: Target file not found: ${TGT_FILE}")
+endif()
+
+# Compare the files (note: works only on UNIX)
+execute_process(
+    COMMAND diff ${SRC_FILE} ${TGT_FILE}
+    RESULT_VARIABLE result
+    OUTPUT_VARIABLE diff_output
+    ERROR_VARIABLE diff_error
+)
+
+# Check the result of the comparison
+if(result)
+    message(STATUS "Files differ:")
+    message(STATUS "${diff_output}")
+    message(FATAL_ERROR "Comparison failed.")
+else()
+    message(STATUS "Files are identical.")
+endif()

--- a/components/eamxx/scripts/check-hashes-ers
+++ b/components/eamxx/scripts/check-hashes-ers
@@ -8,7 +8,7 @@ This script is used by the scream-internal_diagnostics_level testmod to check
 hash output after a test has run.
 """
 
-import sys, re, glob, pathlib, argparse
+import sys, re, glob, pathlib, argparse, gzip
 
 from utils import run_cmd_no_fail, expect, GoodFormatter
 
@@ -62,23 +62,37 @@ def get_log_glob_from_atm_modelio(case_dir):
     ln = grep('logfile = ', filename)[0]
     atm_log_fn = ln.split()[2].split('"')[1]
     id_ = atm_log_fn.split('.')[2]
-    return str(run_dir / '**' / f'e3sm.log.{id_}*')
+    return str(run_dir / '**' / f'atm.log.{id_}*')
 
 ###############################################################################
 def get_hash_lines(fn):
 ###############################################################################
-    rlns = run_cmd_no_fail(f'zgrep exxhash {fn}').splitlines()
-    lns = []
-    if len(rlns) == 0: return lns
-    for rln in rlns:
-        pos = rln.find('exxhash')
-        lns.append(rln[pos:])
-    return lns
+    times = []
+    hash_lines = []
+    with gzip.open(fn,'rt') as fd:
+        lines = fd.readlines()
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            i = i+1
+            if "eamxx hash>" in line:
+                # eamxx hash line has the form "eamxx hash> date=YYYY-MM-DD-XXXXX (STRING), naccum=INT
+                times.append(parse_time(line))
+                naccum_index = line.index("naccum=") + len("naccum=")
+                N = int(line[naccum_index:])
+                hashes = []
+                for j in range(N):
+                    hashes.append(lines[i].strip('\n'))
+                    i += 1
+                hash_lines.append(hashes)
+
+    return times, hash_lines
 
 ###############################################################################
 def parse_time(hash_ln):
 ###############################################################################
-    return hash_ln.split()[1:3]
+    # hash_ln has the form "eamxx hash> date=YYYY-MM-DD-XXXXX (STRING), naccum=INT
+    return hash_ln.split()[2].split('=')[1]
 
 ###############################################################################
 def all_equal(t1, t2):
@@ -89,20 +103,19 @@ def all_equal(t1, t2):
     return True
 
 ###############################################################################
-def find_first_index_at_time(lns, time):
+def find_first_index_at_time(times, time):
 ###############################################################################
-    for i, ln in enumerate(lns):
-        t = parse_time(ln)
-        if all_equal(time, t): return i
+    for i, t in enumerate(times):
+        if t==time: return i
     return None
 
 ###############################################################################
-def diff(l1, l2):
+def diff(times, l1, l2):
 ###############################################################################
     diffs = []
     for i in range(len(l1)):
         if l1[i] != l2[i]:
-            diffs.append((l1[i], l2[i]))
+            diffs.append((times[i], l1[i], l2[i]))
     return diffs
 
 ###############################################################################
@@ -111,53 +124,62 @@ def check_hashes_ers(case_dir):
     case_dir_p = pathlib.Path(case_dir)
     expect(case_dir_p.is_dir(), f"{case_dir} is not a dir")
 
-    # Look for the two e3sm.log files.
+    # Look for the two atm.log files.
     glob_pat = get_log_glob_from_atm_modelio(case_dir_p)
-    e3sm_fns = glob.glob(glob_pat, recursive=True)
-    if len(e3sm_fns) == 0:
-        print('Could not find e3sm.log files with glob string {}'.format(glob_pat))
+    atm_fns = glob.glob(glob_pat, recursive=True)
+    if len(atm_fns) == 0:
+        print('Could not find atm.log files with glob string {}'.format(glob_pat))
         return False
-    e3sm_fns.sort()
-    if len(e3sm_fns) == 1:
+    atm_fns.sort()
+    if len(atm_fns) == 1:
         # This is the first run. Exit and wait for the second
         # run. (POSTRUN_SCRIPT is called after each of the two runs.)
         print('Exiting on first run.')
         return True
-    print('Diffing base {} and restart {}'.format(e3sm_fns[0], e3sm_fns[1]))
 
-    # Because of the prefixed 1: and 2: on some systems, we can't just use
-    # zdiff.
-    lns = []
-    for f in e3sm_fns:
-        lns.append(get_hash_lines(f))
-    time = parse_time(lns[1][0])
-    time_idx = find_first_index_at_time(lns[0], time)
-    if time_idx is None:
-        print('Could not find a start time.')
+    print('Diffing base {} and restart {}'.format(atm_fns[0], atm_fns[1]))
+
+    # Extract hash lines, along with their timestamps
+    hash_lines = []
+    times = []
+    for f in atm_fns:
+        t,h = get_hash_lines(f)
+        hash_lines.append(h)
+        times.append(t)
+
+    # For run1, ignore all lines before the first timestamp from run2
+    rest_time = times[1][0]
+    run1_rest_time_idx = find_first_index_at_time(times[0], rest_time)
+    if run1_rest_time_idx is None:
+        print('Could not find the first timestamp of run2 inside the log of run1.')
         return False
-    lns[0] = lns[0][time_idx:]
-    if len(lns[0]) != len(lns[1]):
+
+    run1_hashes = hash_lines[0][run1_rest_time_idx:]
+    run2_hashes = hash_lines[1]
+    if len(run1_hashes) != len(run2_hashes):
         print('Number of hash lines starting at restart time do not agree.')
+        print(f' run1 number of hash lines (after rest time): {len(run1_hashes)}')
+        print(f' run2 number of hash lines: {len(run2_hashes)}')
+        print(run1_hashes)
         return False
-    diffs = diff(lns[0], lns[1])
 
-    # Flushed prints to e3sm.log can sometimes conflict with other
-    # output. Permit up to 'thr' diffs so we don't fail due to badly printed
-    # lines. This isn't a big loss in checking because an ERS_Ln22 second run
-    # writes > 1000 hash lines, and a true loss of BFBness is nearly certain to
-    # propagate to a large number of subsequent hashes.
-    thr = 5
-    if len(lns[0]) < 100: thr = 0
+    diffs = diff(times[1],run1_hashes, run2_hashes)
 
-    ok = True
-    if len(diffs) > thr:
-        print('DIFF')
-        print(diffs[-10:])
-        ok = False
-    else:
+    if run1_hashes==run2_hashes:
         print('OK')
-
-    return ok
+        return True
+    else:
+        # Nicely print the diffing hashes, grouped by their timestamp
+        print(f'FOUND DIFFS')
+        for d in diffs[-10:]:
+            print (f' timestamp: {d[0]}')
+            slen = len(d[1][0])
+            print("run1".center(slen) + " | " + "run2".center(slen))
+            for r1,r2 in zip(d[1],d[2]):
+                # Print only the hash entry(ies) that diff in this timestamp
+                if r1!=r2:
+                    print (f'{r1} | {r2}')
+        return False
 
 ###############################################################################
 def _main_func(description):

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -1017,6 +1017,10 @@ void AtmosphereDriver::create_logger () {
   auto& driver_options_pl = m_atm_params.sublist("driver_options");
 
   ci_string log_fname = driver_options_pl.get<std::string>("Atm Log File","atm.log");
+  if (is_scream_standalone()) {
+    // Useful for concurrent unit tests in the same folder
+    log_fname += ".np" + std::to_string (m_atm_comm.size());
+  }
   ci_string log_level = driver_options_pl.get<std::string>("atm_log_level","info");
   ci_string flush_level = driver_options_pl.get<std::string>("atm_flush_level","warn");
   EKAT_REQUIRE_MSG (log_fname!="",

--- a/components/eamxx/src/share/atm_process/atmosphere_process.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.hpp
@@ -295,6 +295,11 @@ protected:
   // Sends a message to the atm log
   void log (const LogLevel lev, const std::string& msg) const;
 
+  // Like the above, but ALWAYS sends the message (regardless of logger log level)
+  void log (const std::string& msg) const {
+    log(m_atm_logger->log_level(),msg);
+  }
+
   int get_num_subcycles () const { return m_num_subcycles; }
   int get_subcycle_iter () const { return m_subcycle_iter; }
   bool do_update_time_stamp () const { return m_update_time_stamps; }

--- a/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
@@ -88,7 +88,6 @@ void hash (const Field::view_dev_t<const Real*****>& v,
 void hash (const Field& f, HashType& accum) {
   const auto& hd = f.get_header();
   const auto& id = hd.get_identifier();
-  if (id.data_type() != DataType::DoubleType) return;
   const auto& lo = id.get_layout();
   const auto rank = lo.rank();
   switch (rank) {

--- a/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
@@ -232,6 +232,7 @@ void AtmosphereProcess
          << std::hex << std::setfill('0') << std::setw(16) << gaccum[i];
       log (ss.str());
     }
+    m_atm_logger->flush();
   }
 }
 

--- a/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
@@ -5,6 +5,7 @@
 #include "ekat/ekat_assert.hpp"
 
 #include <cstdint>
+#include <iomanip>
 
 namespace scream {
 namespace {
@@ -214,9 +215,24 @@ void AtmosphereProcess
 
     const auto& date = timestamp().get_date();
     const auto& tod  = timestamp().sec_of_day();
-    printf("eamxx hash> date=%04d-%02d-%02d-%05d (%s)\n", date[0],date[1],date[2],tod,label.c_str());
-    for (int i = 0; i < naccum; ++i)
-      printf("  %*s: %16" PRIx64 "\n",slen,hash_names[i].c_str(),gaccum[i]);
+
+    std::stringstream ss;
+
+    ss << "eamxx hash> date="
+       << std::setw(4) << std::setfill('0') << date[0] << "-" // Year
+       << std::setw(2) << std::setfill('0') << date[1] << "-" // Month
+       << std::setw(2) << std::setfill('0') << date[2] << "-" // Day
+       << std::setw(5) << std::setfill('0') << tod << " "     // Time of day
+       << "(" << label << "), naccum=" << naccum;             // Label and number of accum
+    log (ss.str());
+
+    for (int i = 0; i < naccum; ++i) {
+      ss.str(""); // Clear content
+      ss.clear(); // Clear error flags
+      ss << std::setw(slen) << std::setfill(' ') << hash_names[i] << ": "
+         << std::hex << std::setfill('0') << std::setw(16) << gaccum[i];
+      log (ss.str());
+    }
   }
 }
 

--- a/components/eamxx/tests/single-process/p3/CMakeLists.txt
+++ b/components/eamxx/tests/single-process/p3/CMakeLists.txt
@@ -54,4 +54,25 @@ if (SCREAM_ENABLE_BASELINE_TESTS)
   # Note: one is enough, since we already check that np1 is BFB with npX
   set (OUT_FILE ${TEST_BASE_NAME}_output.INSTANT.nsteps_x1.np${TEST_RANK_END}.${RUN_T0}.nc)
   CreateBaselineTest(${TEST_BASE_NAME} ${TEST_RANK_END} ${OUT_FILE} ${FIXTURES_BASE_NAME}) 
+
+  # Grab all bfb hash lines into a text file (only np1_omp1 test)
+  CreateUnitTest (${TEST_BASE_NAME}_bfb_hash "p3_bfb_hash.cpp"
+    FIXTURES_REQUIRED ${FIXTURES_BASE_NAME}_np1_omp1
+    FIXTURES_SETUP ${TEST_BASE_NAME}_gen_bfb_hash
+    EXE_ARGS "--args --log-file atm.log.np1 --output-file p3_bfb_hash.txt"
+  )
+
+  # Compare against bfb hashes in baseline dir
+  set (SRC_FILE ${CMAKE_CURRENT_BINARY_DIR}/p3_bfb_hash.txt)
+  set (TGT_FILE ${SCREAM_BASELINES_DIR}/data/p3_bfb_hash.txt)
+  add_test (NAME ${TEST_BASE_NAME}_bfb_hash_baseline_cmp
+    COMMAND ${CMAKE_COMMAND} -P ${SCREAM_BASE_DIR}/cmake/CompareTextFiles.cmake ${SRC_FILE} ${TGT_FILE})
+
+  set_tests_properties (${TEST_BASE_NAME}_bfb_hash_baseline_cmp
+    PROPERTIES FIXTURES_REQUIRED ${TEST_BASE_NAME}_gen_bfb_hash)
+
+  # Store p3_bfb_hash.txt in the baseline folder
+  file (APPEND ${SCREAM_TEST_OUTPUT_DIR}/baseline_list
+    "${SRC_FILE}\n"
+  )
 endif()

--- a/components/eamxx/tests/single-process/p3/input.yaml
+++ b/components/eamxx/tests/single-process/p3/input.yaml
@@ -15,6 +15,7 @@ atmosphere_processes:
     compute_tendencies: [T_mid,qc]
     do_prescribed_ccn: false
     use_hetfrz_classnuc: false
+    internal_diagnostics_level: 2
 
 grids_manager:
   Type: Mesh Free

--- a/components/eamxx/tests/single-process/p3/p3_bfb_hash.cpp
+++ b/components/eamxx/tests/single-process/p3/p3_bfb_hash.cpp
@@ -1,0 +1,60 @@
+#include <catch2/catch.hpp>
+
+#include <ekat/util/ekat_test_utils.hpp>
+
+#include <fstream>
+
+namespace scream {
+
+TEST_CASE("check_bfb_sha") {
+
+  auto& ts = ekat::TestSession::get();
+
+  auto log_file = ts.params.at("log-file");
+  std::ifstream ifile(log_file);
+
+  EKAT_REQUIRE_MSG (ifile.is_open(),
+      "Error! Could not open log file '" << log_file << ".\n");
+
+  std::string line;
+  std::vector<std::string> collected_lines;
+  while (std::getline(ifile, line)) {
+    // Check if the line starts with "eamxx hash>" and ends with "naccum=N"
+    if (line.find("eamxx hash>") == std::string::npos)
+      continue;
+
+    // Find the position of "naccum="
+    size_t pos = line.find("naccum=");
+    EKAT_REQUIRE_MSG (pos!=std::string::npos,
+        "Error! Could not locate 'naccum' in the 'eamxx hash>' line.\n"
+        "  - line: " + line + "\n");
+
+    // Extract the value of N
+    std::string naccum = line.substr(pos + 7); // Skip "naccum="
+    int N = std::stoi(naccum); // Convert to integer
+
+    // Store the current line
+    collected_lines.push_back(line);
+
+    // Read the next N lines
+    for (int i = 0; i < N; ++i) {
+      if (std::getline(ifile, line)) {
+        collected_lines.push_back(line);
+      } else {
+        EKAT_ERROR_MSG (
+            "Error! Could not find the declared number of accum lines.\n"
+            " - expected accum lines: " << N << "\n"
+            " - actual accum lines  : " << i << "\n");
+      }
+    }
+  }
+
+  auto output_fname = ts.params.at("output-file");
+  std::ofstream ofile (output_fname);
+
+  for (const auto& l : collected_lines) {
+    ofile << l << "\n";
+  }
+}
+
+} // e namespace


### PR DESCRIPTION
Two separate efforts:

- Add a bfb hash unit test in standalone. This required moving the bfb hash from stdout to the atm log, since the former is not redirected to a parseable file when using ctest.
- Fix the eamxx-internal_diagnostics_level testmod (the failing test now passes for me on mappy, while it fails if I hack the atm.log files)

[BFB]

