### PR TITLE
EAMxx:Fixes for non bit-for-bitness in eamxx-mam4xx-all_mam4xx_procs.

### DIFF
--- a/components/eamxx/src/physics/mam/eamxx_mam_constituent_fluxes_functions.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_constituent_fluxes_functions.hpp
@@ -24,22 +24,8 @@ void update_gas_aerosols_using_constituents(
   // get the start index for gas species in the state_q array
   int istart = mam4::utils::gasses_start_ind();
 
-  // number of constituents to update (currently updating only MAM4xx
-  // constituents)
-  const int nconstituents = pcnst - istart;
-
-  // Create a policy to loop over columns annd number of constituents
-  // to update
-  // FIXME: TODO:We don't need a team for "nconstituents", so we can make the
-  // kookos_for simple by using just ncols
-  const auto policy = ekat::ExeSpaceUtils<MAMConstituentFluxes::KT::ExeSpace>::
-      get_default_team_policy(ncol, nconstituents);
-
   // Loop through all columns to update tracer mixing rations
-  Kokkos::parallel_for(
-      policy, KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
-        const int icol = team.league_rank();
-
+  Kokkos::parallel_for( "get_activate_frac", ncol, KOKKOS_LAMBDA(int icol) {
         //----------------------------------------------------------------------
         // To form EAM like state%q array, we need prognostics (gas and aerosol
         // mmrs) atmosphere (qv, qc, nc, ni, etc.)

--- a/components/eamxx/src/physics/mam/eamxx_mam_constituent_fluxes_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_constituent_fluxes_interface.cpp
@@ -1,4 +1,3 @@
-#include <share/util/eamxx_bfbhash.hpp>
 #include <physics/mam/eamxx_mam_constituent_fluxes_functions.hpp>
 #include <physics/mam/eamxx_mam_constituent_fluxes_interface.hpp>
 #include <physics/mam/physical_limits.hpp>

--- a/components/eamxx/src/physics/mam/eamxx_mam_constituent_fluxes_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_constituent_fluxes_interface.cpp
@@ -1,3 +1,4 @@
+#include <share/util/eamxx_bfbhash.hpp>
 #include <physics/mam/eamxx_mam_constituent_fluxes_functions.hpp>
 #include <physics/mam/eamxx_mam_constituent_fluxes_interface.hpp>
 #include <physics/mam/physical_limits.hpp>
@@ -166,6 +167,7 @@ void MAMConstituentFluxes::run_impl(const double dt) {
     compute_vertical_layer_heights(team,       // in
                                    dry_atm,    // out
                                    icol);      // in
+    team.team_barrier();
     compute_updraft_velocities(team, wet_atm,  // in
                                dry_atm,        // out
                                icol);          // in
@@ -175,11 +177,14 @@ void MAMConstituentFluxes::run_impl(const double dt) {
       KT::ExeSpace>::get_thread_range_parallel_scan_team_policy(ncol_, nlev_);
 
   Kokkos::parallel_for("mam_cfi_compute_updraft", scan_policy, lambda);
+  Kokkos::fence();
 
   update_gas_aerosols_using_constituents(ncol_, nlev_, dt, dry_atm_,
                                          constituent_fluxes_,
                                          // output
                                          wet_aero_);
+  Kokkos::fence();
+
 }  // run_impl ends
 
 // =============================================================================

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -745,7 +745,6 @@ void MAMMicrophysics::run_impl(const double dt) {
   auto &dflx = dflx_;
   auto &dvel = dvel_;
 
-  this->print_fast_global_state_hash("microphysics(pre)");
   // loop over atmosphere columns and compute aerosol microphyscs
   Kokkos::parallel_for(
       "MAMMicrophysics::run_impl", policy,
@@ -893,7 +892,6 @@ void MAMMicrophysics::run_impl(const double dt) {
   // postprocess output
   post_process(wet_aero_, dry_aero_, dry_atm_);
   Kokkos::fence();
-  this->print_fast_global_state_hash("microphysics(post)");
 }  // MAMMicrophysics::run_impl
 
 }  // namespace scream

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
@@ -153,6 +153,9 @@ class MAMMicrophysics final : public MAMGenericInterface {
   // workspace manager for internal local variables
   mam_coupling::Buffer buffer_;
 
+  // Work arrays for return values from perform_atmospheric_chemistry_and_microphysics
+  view_2d dflx_;
+  view_2d dvel_;
 };  // MAMMicrophysics
 
 }  // namespace scream

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
@@ -1,4 +1,3 @@
-#include <share/util/eamxx_bfbhash.hpp>
 #include "physics/mam/eamxx_mam_wetscav_process_interface.hpp"
 
 /*

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
@@ -1,3 +1,4 @@
+#include <share/util/eamxx_bfbhash.hpp>
 #include "physics/mam/eamxx_mam_wetscav_process_interface.hpp"
 
 /*
@@ -249,7 +250,7 @@ void MAMWetscav::initialize_impl(const RunType run_type) {
   // Allocate work array
   const int work_len = mam4::wetdep::get_aero_model_wetdep_work_len();
   work_              = view_2d("work", ncol_, work_len);
-
+  isprx_             = int_view_2d("isprx", ncol_, nlev_);
   // TODO: Following variables are from convective parameterization (not
   // implemented yet in EAMxx), so should be zero for now
 
@@ -304,6 +305,7 @@ void MAMWetscav::run_impl(const double dt) {
   const mam_coupling::DryAtmosphere &dry_atm = dry_atm_;
   const auto &dry_aero                       = dry_aero_;
   const auto &work                           = work_;
+  const auto &isprx                          = isprx_;
   const auto &dry_aero_tends                 = dry_aero_tends_;
 
   // ---------------------------------------------------------------
@@ -433,6 +435,7 @@ void MAMWetscav::run_impl(const double dt) {
         auto wetdens_icol     = ekat::subview(wetdens, icol);
         const auto prain_icol = ekat::subview(prain, icol);
 
+        auto isprx_icol = ekat::subview(isprx, icol);
 
         mam4::wetdep::aero_model_wetdep(
             team, atm, progs, tends, dt,
@@ -442,7 +445,7 @@ void MAMWetscav::run_impl(const double dt) {
             dlf_icol, prain_icol, scavimptblnum, scavimptblvol,
             // outputs
             wet_diameter_icol, dry_diameter_icol, qaerwat_icol, wetdens_icol,
-            aerdepwetis_icol, aerdepwetcw_icol, work_icol);
+            aerdepwetis_icol, aerdepwetcw_icol, work_icol, isprx_icol);
         team.team_barrier();
         // update interstitial aerosol state
         Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev), [&](int kk) {
@@ -461,6 +464,7 @@ void MAMWetscav::run_impl(const double dt) {
 
   // call post processing to convert dry mixing ratios to wet mixing ratios
   // and update the state
+  Kokkos::fence();
   post_process(wet_aero_, dry_aero_, dry_atm_);
   Kokkos::fence();  // wait before returning to calling function
 }

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
@@ -23,6 +23,7 @@ namespace scream {
 class MAMWetscav : public MAMGenericInterface {
   using KT      = ekat::KokkosTypes<DefaultDevice>;
   using view_2d = typename KT::template view_2d<Real>;
+  using int_view_2d = typename KT::template view_2d<int>;
 
   // a thread team dispatched to a single vertical column
   using ThreadTeam = mam4::ThreadTeam;
@@ -65,6 +66,7 @@ class MAMWetscav : public MAMGenericInterface {
 
   // Work arrays
   view_2d work_;
+  int_view_2d isprx_;
 
   // TODO: Following variables are from convective parameterization (not
   // implemented yet in EAMxx), so should be zero for now


### PR DESCRIPTION
Fixes the NBFB issue in MAM4xx threaded simulations that were using the complete suite
of MAM4xx processes.

It was mainly a `team.barrier` in the right place but fixed some other things along the way.

[BFB] For all tests except the ones using CPU threading