### PR TITLE
Remove y100k testmod

### DIFF
--- a/driver-mct/cime_config/testdefs/testmods_dirs/drv/y100k/README
+++ b/driver-mct/cime_config/testdefs/testmods_dirs/drv/y100k/README
@@ -1,5 +1,0 @@
-This tests the ability to use 6-digit years.
-
-As of the time this test was created, the max year is about 214747 -
-otherwise we exceed the limit of 4-byte integers when storing dates as
-integers (yyyyyymmdd).

--- a/driver-mct/cime_config/testdefs/testmods_dirs/drv/y100k/shell_commands
+++ b/driver-mct/cime_config/testdefs/testmods_dirs/drv/y100k/shell_commands
@@ -1,1 +1,0 @@
-./xmlchange RUN_STARTDATE=99999-12-28


### PR DESCRIPTION
CIME does not support years>9999. This has been the case for quite a while and no one has complained, so I think we should just drop this testmod.

[BFB]