### PR TITLE
Frontier craygnu compilers module update

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1070,13 +1070,14 @@
       <modules compiler="craygnu.*">
         <command name="reset"></command>
         <!-- PrgEnv-gnu before cpe, or cray-mpich module doesn't update correctly -->
+        <command name="load">Core/25.03</command>
         <command name="load">PrgEnv-gnu</command>
         <command name="load">cpe/24.11</command>
         <command name="load">libunwind/1.8.1</command>
         <command name="load">cray-python/3.11.7</command>
-        <command name="load">subversion/1.14.2</command>
-        <command name="load">git/2.45.1</command>
-        <command name="load">cmake/3.27.9</command>
+        <command name="load">subversion</command>
+        <command name="load">git</command>
+        <command name="load">cmake</command>
         <command name="load">cray-hdf5-parallel/1.14.3.3</command>
         <command name="load">cray-netcdf-hdf5parallel/4.9.0.15</command>
         <command name="load">cray-parallel-netcdf/1.12.3.15</command>


### PR DESCRIPTION
This PR is to prepare for the upcoming Frontier software update on April 1, 2025.

* Explicitly load Core/25.03 for gnugpu-hipcc and gnugpu-mphipcc compilers
* Removes version information when loading subversion, git, and cmake modules