### PR TITLE
CsmShare: use mpi module rather than mpif include

### DIFF
--- a/share/util/shr_mct_mod.F90
+++ b/share/util/shr_mct_mod.F90
@@ -792,7 +792,7 @@ subroutine shr_mct_sMatWritednc(sMat,iosystem, io_type, io_format, fileName,comp
 ! !USES:
    use pio, only : iosystem_desc_t
    use shr_pcdf_mod, only : shr_pcdf_readwrite
-   use mpi, only: mpi_comm_size, mpi_comm_rank, mpi_gather, mpi_integer
+   use mpi
    implicit none
 
 ! !INPUT/OUTPUT PARAMETERS:

--- a/share/util/shr_mct_mod.F90
+++ b/share/util/shr_mct_mod.F90
@@ -790,10 +790,10 @@ end subroutine shr_mct_sMatReaddnc
 subroutine shr_mct_sMatWritednc(sMat,iosystem, io_type, io_format, fileName,compid, mpicom)
 
 ! !USES:
-  use pio, only : iosystem_desc_t
+   use pio, only : iosystem_desc_t
    use shr_pcdf_mod, only : shr_pcdf_readwrite
+   use mpi, only: mpi_comm_size, mpi_comm_rank, mpi_gather, mpi_integer
    implicit none
-#include <mpif.h>
 
 ! !INPUT/OUTPUT PARAMETERS:
 
@@ -828,7 +828,7 @@ subroutine shr_mct_sMatWritednc(sMat,iosystem, io_type, io_format, fileName,comp
    count(:) = -999
    pe_loc(:) = -999
    ssize(:) = 1
-   call MPI_GATHER(lsize,1,MPI_INTEGER,count,ssize,MPI_INTEGER,0,mpicom,ierr)
+   call MPI_GATHER(lsize,1,MPI_INTEGER,count,1,MPI_INTEGER,0,mpicom,ierr)
 
    if (my_task == 0) then
       if (minval(count) < 0) then

--- a/share/util/shr_mpi_mod.F90
+++ b/share/util/shr_mpi_mod.F90
@@ -8,19 +8,8 @@ Module shr_mpi_mod
   use shr_log_mod, only: s_loglev  => shr_log_Level
   use shr_log_mod, only: s_logunit => shr_log_Unit
 
-  ! Import MPI fcns used throughout this module
-  use mpi, only: &
-    mpi_init, mpi_send, mpi_recv, mpi_bcast, mpi_gather, mpi_gatherv, &
-    mpi_scatterv, mpi_allreduce, mpi_reduce, mpi_abort, &
-    mpi_finalize, mpi_comm_rank, mpi_comm_size, &
-    mpi_initialized, mpi_comm_world, &
-    mpi_error_string, mpi_max_error_string, mpi_success
-
-  ! Import MPI types/constants used througout this module
-  use mpi, only: &
-    mpi_integer, mpi_integer8, mpi_real8, mpi_logical, &
-    mpi_character, mpi_status_size, &
-    mpi_max, mpi_min, mpi_sum
+  ! Import MPI fcns/types
+  use mpi
 
   implicit none
   private

--- a/share/util/shr_reprosum_mod.F90
+++ b/share/util/shr_reprosum_mod.F90
@@ -47,16 +47,20 @@ module shr_reprosum_mod
                             shr_infnan_isposinf, shr_infnan_isneginf
    use perf_mod
 
+   ! Import MPI fcns used throughout this module
+   use mpi, only: mpi_allreduce
+
+   ! Import MPI types/constants used througout this module
+   use mpi, only: &
+     mpi_integer, mpi_integer8, mpi_real8, mpi_logical, mpi_complex16, &
+     mpi_comm_world, &
+     mpi_max, mpi_min, mpi_sum, mpi_lor
+
 !------------------------------------------------------------------------
 !- module boilerplate ---------------------------------------------------
 !------------------------------------------------------------------------
    implicit none
    private
-
-!------------------------------------------------------------------------
-!- include statements ---------------------------------------------------
-!------------------------------------------------------------------------
-#include <mpif.h>
 
    save
 

--- a/share/util/shr_reprosum_mod.F90
+++ b/share/util/shr_reprosum_mod.F90
@@ -47,14 +47,8 @@ module shr_reprosum_mod
                             shr_infnan_isposinf, shr_infnan_isneginf
    use perf_mod
 
-   ! Import MPI fcns used throughout this module
-   use mpi, only: mpi_allreduce
-
-   ! Import MPI types/constants used througout this module
-   use mpi, only: &
-     mpi_integer, mpi_integer8, mpi_real8, mpi_logical, mpi_complex16, &
-     mpi_comm_world, &
-     mpi_max, mpi_min, mpi_sum, mpi_lor
+   ! Import MPI fcns/types
+   use mpi
 
 !------------------------------------------------------------------------
 !- module boilerplate ---------------------------------------------------

--- a/share/util/shr_taskmap_mod.F90
+++ b/share/util/shr_taskmap_mod.F90
@@ -25,7 +25,6 @@ module shr_taskmap_mod
 !- module boilerplate --------------------------------------------------
 !-----------------------------------------------------------------------
    implicit none
-   include 'mpif.h'
    private
    save                             ! Make the default access private
 
@@ -45,6 +44,8 @@ module shr_taskmap_mod
    subroutine shr_taskmap_write (unit_num, comm_id, comm_name, &
                                  verbose, no_output, &
                                  save_nnodes, save_task_node_map)
+
+     use mpi, only: mpi_bcast, mpi_integer, mpi_max_processor_name, mpi_character
 
 !-----------------------------------------------------------------------
 ! Purpose: Write out list of nodes used by processes in a given

--- a/share/util/shr_taskmap_mod.F90
+++ b/share/util/shr_taskmap_mod.F90
@@ -45,7 +45,7 @@ module shr_taskmap_mod
                                  verbose, no_output, &
                                  save_nnodes, save_task_node_map)
 
-     use mpi, only: mpi_bcast, mpi_integer, mpi_max_processor_name, mpi_character
+     use mpi
 
 !-----------------------------------------------------------------------
 ! Purpose: Write out list of nodes used by processes in a given


### PR DESCRIPTION
Using the mpi module rather than mpif.h allows for better type checking.
This revealed some usage of some MPI functions that was not conformal to
the standard (e.g., passing arrays when a scalar was expected).

[BFB]

---

The errors that were arising are all usually suppressed (at least with gnu) via the flag `-fallow-argument-mismatch`, which turns the errors into warnings. After this mod, the csm_share lib builds without any such warning (though I still see them in other f90 libs that use mpif, like mct).