### PR TITLE
EAMxx: add field utility to get a mask for a given field

### DIFF
--- a/components/eamxx/src/share/eamxx_types.hpp
+++ b/components/eamxx/src/share/eamxx_types.hpp
@@ -37,6 +37,15 @@ enum class RunType {
   Restart
 };
 
+enum class Comparison : int {
+  EQ,   // equal-to
+  NE,   // not-equal-to
+  GT,   // greater-than
+  GE,   // greater-than-or-equal-to
+  LT,   // less-than
+  LE    // less-than-or-equal-to
+};
+
 // We cannot expect BFB results between f90 and cxx if optimizations are on.
 // Same goes for cuda-memcheck because it makes the bfb math layer prohibitively
 // expensive and so must be turned off. SCREAM_SHORT_TESTS is a proxy

--- a/components/eamxx/src/share/field/field_utils.hpp
+++ b/components/eamxx/src/share/field/field_utils.hpp
@@ -376,6 +376,10 @@ void compute_mask (const Field& x, const ST value, Field& mask)
   EKAT_REQUIRE_MSG (not mask.is_read_only(),
       "Error! Cannot update mask field, as it is read-only.\n"
       " - mask name: " + mask.name() + "\n");
+  EKAT_REQUIRE_MSG (mask.data_type()==DataType::IntType,
+      "Error! The data type of the mask field must be 'int'.\n"
+      " - mask field name: " << mask.name() << "\n"
+      " - mask field data type: " << etoi(mask.data_type()) << "\n");
 
   const auto& x_layout = x.get_header().get_identifier().get_layout();
   const auto& m_layout = mask.get_header().get_identifier().get_layout();

--- a/components/eamxx/src/share/field/field_utils.hpp
+++ b/components/eamxx/src/share/field/field_utils.hpp
@@ -365,6 +365,47 @@ print_field_hyperslab (const Field& f,
   }
 }
 
+template<Comparison CMP, typename ST>
+void compute_mask (const Field& x, const ST value, Field& mask)
+{
+  // Sanity checks
+  EKAT_REQUIRE_MSG (x.is_allocated(),
+      "Error! Input field was not yet allocated.\n");
+  EKAT_REQUIRE_MSG (mask.is_allocated(),
+      "Error! Mask field was not yet allocated.\n");
+  EKAT_REQUIRE_MSG (not mask.is_read_only(),
+      "Error! Cannot update mask field, as it is read-only.\n"
+      " - mask name: " + mask.name() + "\n");
+
+  const auto& x_layout = x.get_header().get_identifier().get_layout();
+  const auto& m_layout = mask.get_header().get_identifier().get_layout();
+
+  EKAT_REQUIRE_MSG (m_layout.congruent(x_layout),
+      "Error! Mask field layout is incompatible with this field.\n"
+      " - field name  : " + x.name() + "\n"
+      " - mask name   : " + mask.name() + "\n"
+      " - field layout: " + x_layout.to_string() + "\n"
+      " - mask layout : " + m_layout.to_string() + "\n");
+
+  const auto x_dt   = x.data_type();
+  const auto val_dt = get_data_type<ST>();
+  EKAT_REQUIRE_MSG (not is_narrowing_conversion(val_dt,x_dt),
+      "Error! Target value may be narrowed when converted to field data type.\n"
+      " - field data type: " + e2str(x_dt) + "\n"
+      " - value data type: " + e2str(val_dt) + "\n");
+
+  switch (x_dt) {
+    case DataType::IntType:
+      impl::compute_mask<CMP>(x,static_cast<int>(value),mask); break;
+    case DataType::FloatType:
+      impl::compute_mask<CMP>(x,static_cast<float>(value),mask); break;
+    case DataType::DoubleType:
+      impl::compute_mask<CMP>(x,static_cast<double>(value),mask); break;
+    default:
+      EKAT_ERROR_MSG ("Error! Unexpected/unsupported data type.\n");
+  }
+}
+
 } // namespace scream
 
 #endif // SCREAM_FIELD_UTILS_HPP

--- a/components/eamxx/src/share/tests/field_utils.cpp
+++ b/components/eamxx/src/share/tests/field_utils.cpp
@@ -707,4 +707,105 @@ TEST_CASE ("print_field_hyperslab") {
   }
 }
 
+TEST_CASE ("compute_mask") {
+  using namespace scream;
+
+  using namespace ShortFieldTagsNames;
+
+  // Setup random number generation
+  ekat::Comm comm(MPI_COMM_WORLD);
+
+  const int ncols = 3*comm.size();
+  const int nlevs = 128;
+  const auto units = ekat::units::Units::nondimensional();
+
+  // Create field (if available, use packs, to ensure we don't print garbage)
+  std::vector<FieldTag> tags3d = {COL, CMP, LEV};
+  std::vector<FieldTag> tags2d = {COL, LEV};
+  std::vector<int>      dims3d = {ncols,2,nlevs};
+  std::vector<int>      dims2d = {ncols,nlevs};
+
+  FieldIdentifier fid3d ("foo", {tags3d,dims3d}, units, "some_grid");
+  FieldIdentifier fid2d ("foo", {tags2d,dims2d}, units, "some_grid");
+
+  SECTION ("exceptions") {
+    // Test compute_mask exception handling
+    Field f (fid3d);
+    Field m1 (fid3d);
+
+    REQUIRE_THROWS(compute_mask<Comparison::EQ>(f,1,m1)); // Field not allocated
+    f.allocate_view();
+    REQUIRE_THROWS(compute_mask<Comparison::EQ>(f,1,m1)); // Mask not allocated
+    m1.allocate_view();
+    REQUIRE_THROWS(compute_mask<Comparison::EQ>(f,1,m1)); // Missing 'true_value'/'false_value' extra data
+
+    Field m2 (fid2d);
+    m2.allocate_view();
+    m2.get_header().set_extra_data("true_value",Real(10));
+    m2.get_header().set_extra_data("false_value",Real(10));
+    REQUIRE_THROWS(compute_mask<Comparison::EQ>(f,1,m2)); // incompatible layouts
+  }
+
+  SECTION ("check") {
+    Field x(fid3d), one(fid3d), zero(fid3d), m(fid3d);
+
+    x.allocate_view();
+    one.allocate_view();
+    m.allocate_view();
+    zero.allocate_view();
+
+    one.deep_copy(1);
+    zero.deep_copy(0);
+    x.deep_copy(2);
+
+    m.get_header().set_extra_data("true_value",Real(1));
+    m.get_header().set_extra_data("false_value",Real(0));
+
+    // x==1 is false
+    m.deep_copy(-1);
+    compute_mask<Comparison::EQ>(x,1,m);
+    REQUIRE(views_are_equal(m,zero));
+
+    // x!=1 is true
+    m.deep_copy(-1);
+    compute_mask<Comparison::NE>(x,1,m);
+    REQUIRE(views_are_equal(m,one));
+
+    // x==2 is true
+    m.deep_copy(-1);
+    compute_mask<Comparison::EQ>(x,2,m);
+    REQUIRE(views_are_equal(m,one));
+
+    // x>1 is true
+    m.deep_copy(-1);
+    compute_mask<Comparison::GT>(x,1,m);
+    REQUIRE(views_are_equal(m,one));
+
+    // x>2 is false
+    m.deep_copy(-1);
+    compute_mask<Comparison::GT>(x,2,m);
+    REQUIRE(views_are_equal(m,zero));
+
+    // x>=2 is true
+    m.deep_copy(-1);
+    compute_mask<Comparison::GE>(x,2,m);
+    REQUIRE(views_are_equal(m,one));
+
+    // x<3 is true
+    m.deep_copy(-1);
+    compute_mask<Comparison::LT>(x,3,m);
+    REQUIRE(views_are_equal(m,one));
+
+    // x<2 is flase
+    m.deep_copy(-1);
+    compute_mask<Comparison::LT>(x,2,m);
+    REQUIRE(views_are_equal(m,zero));
+
+    // x<=2 is true
+    m.deep_copy(-1);
+    compute_mask<Comparison::LE>(x,2,m);
+    REQUIRE(views_are_equal(m,one));
+  }
+}
+
 } // anonymous namespace

--- a/components/eamxx/src/share/tests/field_utils.cpp
+++ b/components/eamxx/src/share/tests/field_utils.cpp
@@ -726,6 +726,7 @@ TEST_CASE ("compute_mask") {
   std::vector<int>      dims2d = {ncols,nlevs};
 
   FieldIdentifier fid3d ("foo", {tags3d,dims3d}, units, "some_grid");
+  FieldIdentifier fid3di ("foo", {tags3d,dims3d}, units, "some_grid", DataType::IntType);
   FieldIdentifier fid2d ("foo", {tags2d,dims2d}, units, "some_grid");
 
   SECTION ("exceptions") {
@@ -737,17 +738,14 @@ TEST_CASE ("compute_mask") {
     f.allocate_view();
     REQUIRE_THROWS(compute_mask<Comparison::EQ>(f,1,m1)); // Mask not allocated
     m1.allocate_view();
-    REQUIRE_THROWS(compute_mask<Comparison::EQ>(f,1,m1)); // Missing 'true_value'/'false_value' extra data
 
     Field m2 (fid2d);
     m2.allocate_view();
-    m2.get_header().set_extra_data("true_value",Real(10));
-    m2.get_header().set_extra_data("false_value",Real(10));
     REQUIRE_THROWS(compute_mask<Comparison::EQ>(f,1,m2)); // incompatible layouts
   }
 
   SECTION ("check") {
-    Field x(fid3d), one(fid3d), zero(fid3d), m(fid3d);
+    Field x(fid3d), one(fid3di), zero(fid3di), m(fid3di);
 
     x.allocate_view();
     one.allocate_view();
@@ -757,9 +755,6 @@ TEST_CASE ("compute_mask") {
     one.deep_copy(1);
     zero.deep_copy(0);
     x.deep_copy(2);
-
-    m.get_header().set_extra_data("true_value",Real(1));
-    m.get_header().set_extra_data("false_value",Real(0));
 
     // x==1 is false
     m.deep_copy(-1);


### PR DESCRIPTION
The mask is 1 where the values of the field compare in a desired way with a target value.

[BFB]

---

@mahf708 This utility is not used anywhere. I am using it in another branch where I restructure our AtmosphereOutput class to use more Field class interfaces. To avoid issuing a very large PR, I am breaking the work I did in that branch into separate small PRs, to make reviewing them easier.