### PR TITLE
EAMxx: Make only MAM4xx-ACI mix droplet number when ACI is active

### DIFF
--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
@@ -84,9 +84,6 @@ void MAMAci::set_grids(
   add_tracers_wet_atm();
   add_fields_dry_atm();
 
-  //NOTE: droplet number (nc) is treated in a special way by MAM4xx
-  //depending on the MAM4xx processes active in a simulation
-  
   // cloud liquid number mixing ratio [1/kg]
   add_tracer<Required>("nc", grid_, n_unit);
   

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
@@ -85,7 +85,9 @@ void MAMAci::set_grids(
   add_fields_dry_atm();
 
   // cloud liquid number mixing ratio [1/kg]
-  add_tracer<Required>("nc", grid_, n_unit);
+  // NOTE: Advected by dynamics only, ACI vertically mixes nc
+  // Updates to nc from ACI are applied in P3 microphysics
+  add_tracer<Required>("nc", grid_, n_unit, 1, TracerAdvection::DynamicsOnly);
   
   constexpr auto m2 = pow(m, 2);
   constexpr auto s2 = pow(s, 2);

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
@@ -84,6 +84,12 @@ void MAMAci::set_grids(
   add_tracers_wet_atm();
   add_fields_dry_atm();
 
+  //NOTE: droplet number (nc) is treated in a special way by MAM4xx
+  //depending on the MAM4xx processes active in a simulation
+  
+  // cloud liquid number mixing ratio [1/kg]
+  add_tracer<Required>("nc", grid_, n_unit);
+  
   constexpr auto m2 = pow(m, 2);
   constexpr auto s2 = pow(s, 2);
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_constituent_fluxes_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_constituent_fluxes_interface.cpp
@@ -41,6 +41,7 @@ void MAMConstituentFluxes::set_grids(
   //depending on the MAM4xx processes active in a simulation
   
   // cloud liquid number mixing ratio [1/kg]
+  auto n_unit           = 1 / kg;   // units of number mixing ratios of tracers
   add_tracer<Required>("nc", grid_, n_unit);
   
   static constexpr Units m2(m * m, "m2");

--- a/components/eamxx/src/physics/mam/eamxx_mam_constituent_fluxes_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_constituent_fluxes_interface.cpp
@@ -36,6 +36,13 @@ void MAMConstituentFluxes::set_grids(
 
   add_tracers_wet_atm();
   add_fields_dry_atm();
+
+  //NOTE: droplet number (nc) is treated in a special way by MAM4xx
+  //depending on the MAM4xx processes active in a simulation
+  
+  // cloud liquid number mixing ratio [1/kg]
+  add_tracer<Required>("nc", grid_, n_unit);
+  
   static constexpr Units m2(m * m, "m2");
   // Constituent fluxes at the surface (gasses and aerosols)
   //[units: kg/m2/s (mass) or #/m2/s (number)]

--- a/components/eamxx/src/physics/mam/eamxx_mam_constituent_fluxes_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_constituent_fluxes_interface.cpp
@@ -37,9 +37,6 @@ void MAMConstituentFluxes::set_grids(
   add_tracers_wet_atm();
   add_fields_dry_atm();
 
-  //NOTE: droplet number (nc) is treated in a special way by MAM4xx
-  //depending on the MAM4xx processes active in a simulation
-  
   // cloud liquid number mixing ratio [1/kg]
   auto n_unit           = 1 / kg;   // units of number mixing ratios of tracers
   add_tracer<Required>("nc", grid_, n_unit);

--- a/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
@@ -71,9 +71,6 @@ void MAMDryDep::set_grids(
 
   add_tracers_wet_atm();
   add_fields_dry_atm();
-
-    //NOTE: droplet number (nc) is treated in a special way by MAM4xx
-  //depending on the MAM4xx processes active in a simulation
   
   // cloud liquid number mixing ratio [1/kg]
   auto n_unit           = 1 / kg;   // units of number mixing ratios of tracers

--- a/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
@@ -76,6 +76,7 @@ void MAMDryDep::set_grids(
   //depending on the MAM4xx processes active in a simulation
   
   // cloud liquid number mixing ratio [1/kg]
+  auto n_unit           = 1 / kg;   // units of number mixing ratios of tracers
   add_tracer<Required>("nc", grid_, n_unit);
 
   static constexpr auto m2 = m * m;

--- a/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
@@ -72,6 +72,12 @@ void MAMDryDep::set_grids(
   add_tracers_wet_atm();
   add_fields_dry_atm();
 
+    //NOTE: droplet number (nc) is treated in a special way by MAM4xx
+  //depending on the MAM4xx processes active in a simulation
+  
+  // cloud liquid number mixing ratio [1/kg]
+  add_tracer<Required>("nc", grid_, n_unit);
+
   static constexpr auto m2 = m * m;
   static constexpr auto s2 = s * s;
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.cpp
@@ -341,9 +341,6 @@ void MAMGenericInterface::add_tracers_wet_atm() {
   // cloud ice mass mixing ratio [kg/kg]
   add_tracer<Required>("qi", grid_, q_unit);
 
-  // cloud liquid number mixing ratio [1/kg]
-  add_tracer<Required>("nc", grid_, n_unit);
-
   // cloud ice number mixing ratio [1/kg]
   add_tracer<Required>("ni", grid_, n_unit);
 }

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -82,6 +82,7 @@ void MAMMicrophysics::set_grids(
   //depending on the MAM4xx processes active in a simulation
   
   // cloud liquid number mixing ratio [1/kg]
+  auto n_unit           = 1 / kg;   // units of number mixing ratios of tracers
   add_tracer<Required>("nc", grid_, n_unit);
 
   constexpr auto m2 = pow(m, 2);

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -78,6 +78,12 @@ void MAMMicrophysics::set_grids(
   add_tracers_wet_atm();
   add_fields_dry_atm();
 
+    //NOTE: droplet number (nc) is treated in a special way by MAM4xx
+  //depending on the MAM4xx processes active in a simulation
+  
+  // cloud liquid number mixing ratio [1/kg]
+  add_tracer<Required>("nc", grid_, n_unit);
+
   constexpr auto m2 = pow(m, 2);
   constexpr auto s2 = pow(s, 2);
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -78,9 +78,6 @@ void MAMMicrophysics::set_grids(
   add_tracers_wet_atm();
   add_fields_dry_atm();
 
-    //NOTE: droplet number (nc) is treated in a special way by MAM4xx
-  //depending on the MAM4xx processes active in a simulation
-  
   // cloud liquid number mixing ratio [1/kg]
   auto n_unit           = 1 / kg;   // units of number mixing ratios of tracers
   add_tracer<Required>("nc", grid_, n_unit);

--- a/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
@@ -49,10 +49,7 @@ void MAMOptics::set_grids(
   FieldLayout scalar3d_int = grid_->get_3d_scalar_layout(false);
   add_tracers_wet_atm();
   add_fields_dry_atm();
-  
-    //NOTE: droplet number (nc) is treated in a special way by MAM4xx
-  //depending on the MAM4xx processes active in a simulation
-  
+    
   // cloud liquid number mixing ratio [1/kg]
   add_tracer<Required>("nc", grid_, n_unit);
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
@@ -49,6 +49,12 @@ void MAMOptics::set_grids(
   FieldLayout scalar3d_int = grid_->get_3d_scalar_layout(false);
   add_tracers_wet_atm();
   add_fields_dry_atm();
+  
+    //NOTE: droplet number (nc) is treated in a special way by MAM4xx
+  //depending on the MAM4xx processes active in a simulation
+  
+  // cloud liquid number mixing ratio [1/kg]
+  add_tracer<Required>("nc", grid_, n_unit);
 
   // layout for 2D (1d horiz X 1d vertical) variables
   FieldLayout scalar2d = grid_->get_2d_scalar_layout();

--- a/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
@@ -67,6 +67,7 @@ void MAMSrfOnlineEmiss::set_grids(
   //depending on the MAM4xx processes active in a simulation
   
   // cloud liquid number mixing ratio [1/kg]
+  auto n_unit           = 1 / kg;   // units of number mixing ratios of tracers
   add_tracer<Required>("nc", grid_, n_unit);
   
   //----------- Variables from microphysics scheme -------------

--- a/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
@@ -62,9 +62,6 @@ void MAMSrfOnlineEmiss::set_grids(
   // Specific humidity [kg/kg]
   add_tracers_wet_atm();
   add_fields_dry_atm();
-
-  //NOTE: droplet number (nc) is treated in a special way by MAM4xx
-  //depending on the MAM4xx processes active in a simulation
   
   // cloud liquid number mixing ratio [1/kg]
   auto n_unit           = 1 / kg;   // units of number mixing ratios of tracers

--- a/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
@@ -63,6 +63,12 @@ void MAMSrfOnlineEmiss::set_grids(
   add_tracers_wet_atm();
   add_fields_dry_atm();
 
+  //NOTE: droplet number (nc) is treated in a special way by MAM4xx
+  //depending on the MAM4xx processes active in a simulation
+  
+  // cloud liquid number mixing ratio [1/kg]
+  add_tracer<Required>("nc", grid_, n_unit);
+  
   //----------- Variables from microphysics scheme -------------
 
   // Surface geopotential [m2/s2]

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
@@ -61,10 +61,6 @@ void MAMWetscav::set_grids(
   add_tracers_wet_atm();
   add_fields_dry_atm();
 
-
-  //NOTE: droplet number (nc) is treated in a special way by MAM4xx
-  //depending on the MAM4xx processes active in a simulation
-  
   // cloud liquid number mixing ratio [1/kg]
   auto n_unit           = 1 / kg;   // units of number mixing ratios of tracers
   add_tracer<Required>("nc", grid_, n_unit);

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
@@ -61,6 +61,13 @@ void MAMWetscav::set_grids(
   add_tracers_wet_atm();
   add_fields_dry_atm();
 
+
+  //NOTE: droplet number (nc) is treated in a special way by MAM4xx
+  //depending on the MAM4xx processes active in a simulation
+  
+  // cloud liquid number mixing ratio [1/kg]
+  add_tracer<Required>("nc", grid_, n_unit);
+  
   static constexpr auto m2 = m * m;
   static constexpr auto s2 = s * s;
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
@@ -66,6 +66,7 @@ void MAMWetscav::set_grids(
   //depending on the MAM4xx processes active in a simulation
   
   // cloud liquid number mixing ratio [1/kg]
+  auto n_unit           = 1 / kg;   // units of number mixing ratios of tracers
   add_tracer<Required>("nc", grid_, n_unit);
   
   static constexpr auto m2 = m * m;


### PR DESCRIPTION
Currently, the droplet number (`nc`) is vertically mixed by both SHOC and ACI when ACI is
 active. `nc` is moved out of the MAM4xx generic interface so that each process decides
how to mix `nc`. When the ACI process is active, only ACI mixes `nc`.

[NBFB] for tests that have active MAM4xx ACI process