### PR TITLE
EAMxx: miscellanea improvement of Field class

### DIFF
--- a/components/eamxx/src/diagnostics/tests/aerocom_cld_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/aerocom_cld_test.cpp
@@ -194,7 +194,7 @@ TEST_CASE("aerocom_cld") {
     }
 
     // Case 3: test the max overlap (if contiguous cloudy layers, then max)
-    cd.deep_copy<Host>(0.0);
+    cd.deep_copy<Host>(0);
     auto cd_v  = cd.get_view<Real **, Host>();
     cd_v(0, 1) = 0.5;
     cd_v(0, 2) = 0.7;  // ------> max!
@@ -264,7 +264,7 @@ TEST_CASE("aerocom_cld") {
     // We will revisit and validate this assumption later
     auto qc_v = qc.get_view<Real **, Host>();
     auto qi_v = qi.get_view<Real **, Host>();
-    cd.deep_copy<Host>(0.0);
+    cd.deep_copy<Host>(0);
     cd_v(0, 1) = 0.5;  // ice
     cd_v(0, 2) = 0.7;  // ice ------> max!
     cd_v(0, 3) = 0.3;  // ice
@@ -273,12 +273,12 @@ TEST_CASE("aerocom_cld") {
     cd_v(0, 6) = 0.5;  // liq ------> not max!
     cd_v(0, 7) = 0.1;  // liq
     // note cd_v(0, 8) is 0.0
-    qi.deep_copy<Host>(0.0);
+    qi.deep_copy<Host>(0);
     qi_v(0, 1) = 100;
     qi_v(0, 2) = 200;
     qi_v(0, 3) = 50;
     // note qi_v(0, 4) = 0.0
-    qc.deep_copy<Host>(0.0);
+    qc.deep_copy<Host>(0);
     // note qc_v(0, 4) = 0.0
     qc_v(0, 5) = 20;
     qc_v(0, 6) = 50;

--- a/components/eamxx/src/diagnostics/tests/aerocom_cld_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/aerocom_cld_test.cpp
@@ -194,7 +194,7 @@ TEST_CASE("aerocom_cld") {
     }
 
     // Case 3: test the max overlap (if contiguous cloudy layers, then max)
-    cd.deep_copy<double, Host>(0.0);
+    cd.deep_copy<Host>(0.0);
     auto cd_v  = cd.get_view<Real **, Host>();
     cd_v(0, 1) = 0.5;
     cd_v(0, 2) = 0.7;  // ------> max!
@@ -264,7 +264,7 @@ TEST_CASE("aerocom_cld") {
     // We will revisit and validate this assumption later
     auto qc_v = qc.get_view<Real **, Host>();
     auto qi_v = qi.get_view<Real **, Host>();
-    cd.deep_copy<double, Host>(0.0);
+    cd.deep_copy<Host>(0.0);
     cd_v(0, 1) = 0.5;  // ice
     cd_v(0, 2) = 0.7;  // ice ------> max!
     cd_v(0, 3) = 0.3;  // ice
@@ -273,12 +273,12 @@ TEST_CASE("aerocom_cld") {
     cd_v(0, 6) = 0.5;  // liq ------> not max!
     cd_v(0, 7) = 0.1;  // liq
     // note cd_v(0, 8) is 0.0
-    qi.deep_copy<double, Host>(0.0);
+    qi.deep_copy<Host>(0.0);
     qi_v(0, 1) = 100;
     qi_v(0, 2) = 200;
     qi_v(0, 3) = 50;
     // note qi_v(0, 4) = 0.0
-    qc.deep_copy<double, Host>(0.0);
+    qc.deep_copy<Host>(0.0);
     // note qc_v(0, 4) = 0.0
     qc_v(0, 5) = 20;
     qc_v(0, 6) = 50;

--- a/components/eamxx/src/diagnostics/tests/aodvis_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/aodvis_test.cpp
@@ -115,7 +115,7 @@ TEST_CASE("aodvis") {
     const auto aod_hf = diag->get_diagnostic();
 
     Field aod_tf = diag->get_diagnostic().clone();
-    aod_tf.deep_copy<Host>(0.0);
+    aod_tf.deep_copy<Host>(0);
     auto aod_t = aod_tf.get_view<Real *, Host>();
 
     for(int icol = 0; icol < grid->get_num_local_dofs(); ++icol) {

--- a/components/eamxx/src/diagnostics/tests/aodvis_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/aodvis_test.cpp
@@ -115,7 +115,7 @@ TEST_CASE("aodvis") {
     const auto aod_hf = diag->get_diagnostic();
 
     Field aod_tf = diag->get_diagnostic().clone();
-    aod_tf.deep_copy<double, Host>(0.0);
+    aod_tf.deep_copy<Host>(0.0);
     auto aod_t = aod_tf.get_view<Real *, Host>();
 
     for(int icol = 0; icol < grid->get_num_local_dofs(); ++icol) {

--- a/components/eamxx/src/diagnostics/tests/longwave_cloud_forcing_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/longwave_cloud_forcing_tests.cpp
@@ -127,7 +127,7 @@ void run(std::mt19937_64& engine)
     diag->compute_diagnostic();
     const auto& diag_out = diag->get_diagnostic();
     Field LWCF_f = diag_out.clone();
-    LWCF_f.deep_copy(0.0);
+    LWCF_f.deep_copy(0);
     const auto& LWCF_v = LWCF_f.get_view<Real*>();
     Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int icol = team.league_rank();

--- a/components/eamxx/src/diagnostics/tests/longwave_cloud_forcing_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/longwave_cloud_forcing_tests.cpp
@@ -127,8 +127,7 @@ void run(std::mt19937_64& engine)
     diag->compute_diagnostic();
     const auto& diag_out = diag->get_diagnostic();
     Field LWCF_f = diag_out.clone();
-    LWCF_f.deep_copy<double,Host>(0.0);
-    LWCF_f.sync_to_dev();
+    LWCF_f.deep_copy(0.0);
     const auto& LWCF_v = LWCF_f.get_view<Real*>();
     Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int icol = team.league_rank();

--- a/components/eamxx/src/diagnostics/tests/precip_surf_mass_flux_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/precip_surf_mass_flux_tests.cpp
@@ -123,9 +123,9 @@ void run(std::mt19937_64& engine)
   Field preicp_total_f = diag_total->get_diagnostic().clone();
   Field preicp_liq_f   = diag_liq->get_diagnostic().clone();
   Field preicp_ice_f   = diag_ice->get_diagnostic().clone();
-  preicp_total_f.deep_copy(0.0);
-  preicp_liq_f.deep_copy(0.0);
-  preicp_ice_f.deep_copy(0.0);
+  preicp_total_f.deep_copy(0);
+  preicp_liq_f.deep_copy(0);
+  preicp_ice_f.deep_copy(0);
   auto precip_total_v = preicp_total_f.get_view<Real*>();
   auto precip_liq_v   = preicp_liq_f.get_view<Real*>();
   auto precip_ice_v   = preicp_ice_f.get_view<Real*>();

--- a/components/eamxx/src/diagnostics/tests/precip_surf_mass_flux_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/precip_surf_mass_flux_tests.cpp
@@ -123,9 +123,9 @@ void run(std::mt19937_64& engine)
   Field preicp_total_f = diag_total->get_diagnostic().clone();
   Field preicp_liq_f   = diag_liq->get_diagnostic().clone();
   Field preicp_ice_f   = diag_ice->get_diagnostic().clone();
-  preicp_total_f.deep_copy<double>(0.0);
-  preicp_liq_f.deep_copy<double>(0.0);
-  preicp_ice_f.deep_copy<double>(0.0);
+  preicp_total_f.deep_copy(0.0);
+  preicp_liq_f.deep_copy(0.0);
+  preicp_ice_f.deep_copy(0.0);
   auto precip_total_v = preicp_total_f.get_view<Real*>();
   auto precip_liq_v   = preicp_liq_f.get_view<Real*>();
   auto precip_ice_v   = preicp_ice_f.get_view<Real*>();

--- a/components/eamxx/src/diagnostics/tests/relative_humidity_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/relative_humidity_tests.cpp
@@ -155,7 +155,7 @@ void run(std::mt19937_64& engine)
 
     // Run diagnostic and compare with manual calculation
     Field rh_f = T_mid_f.clone();
-    rh_f.deep_copy(0.0);
+    rh_f.deep_copy(0);
     const auto& rh_v = rh_f.get_view<Pack**>();
     using physics = scream::physics::Functions<Real, DefaultDevice>;
     using Smask = ekat::Mask<Pack::n>;

--- a/components/eamxx/src/diagnostics/tests/relative_humidity_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/relative_humidity_tests.cpp
@@ -155,8 +155,7 @@ void run(std::mt19937_64& engine)
 
     // Run diagnostic and compare with manual calculation
     Field rh_f = T_mid_f.clone();
-    rh_f.deep_copy<double,Host>(0.0);
-    rh_f.sync_to_dev();
+    rh_f.deep_copy(0.0);
     const auto& rh_v = rh_f.get_view<Pack**>();
     using physics = scream::physics::Functions<Real, DefaultDevice>;
     using Smask = ekat::Mask<Pack::n>;

--- a/components/eamxx/src/diagnostics/tests/sea_level_pressure_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/sea_level_pressure_test.cpp
@@ -114,7 +114,7 @@ void run(std::mt19937_64& engine)
     diag->compute_diagnostic();
     const auto& diag_out = diag->get_diagnostic();
     Field p_sealevel_f = diag_out.clone();
-    p_sealevel_f.deep_copy(0.0);
+    p_sealevel_f.deep_copy(0);
     const int surf_lev = num_levs - 1;
     const auto& p_sealevel_v = p_sealevel_f.get_view<Real*>();
     auto T_mid_s = ekat::scalarize(T_mid_v);

--- a/components/eamxx/src/diagnostics/tests/sea_level_pressure_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/sea_level_pressure_test.cpp
@@ -114,8 +114,7 @@ void run(std::mt19937_64& engine)
     diag->compute_diagnostic();
     const auto& diag_out = diag->get_diagnostic();
     Field p_sealevel_f = diag_out.clone();
-    p_sealevel_f.deep_copy<double,Host>(0.0);
-    p_sealevel_f.sync_to_dev();
+    p_sealevel_f.deep_copy(0.0);
     const int surf_lev = num_levs - 1;
     const auto& p_sealevel_v = p_sealevel_f.get_view<Real*>();
     auto T_mid_s = ekat::scalarize(T_mid_v);

--- a/components/eamxx/src/diagnostics/tests/shortwave_cloud_forcing_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/shortwave_cloud_forcing_tests.cpp
@@ -139,8 +139,7 @@ void run(std::mt19937_64& engine)
     diag->compute_diagnostic();
     const auto& diag_out = diag->get_diagnostic();
     Field SWCF_f = diag_out.clone();
-    SWCF_f.deep_copy<double,Host>(0.0);
-    SWCF_f.sync_to_dev();
+    SWCF_f.deep_copy(0.0);
     const auto& SWCF_v = SWCF_f.get_view<Real*>();
     Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int icol = team.league_rank();

--- a/components/eamxx/src/diagnostics/tests/shortwave_cloud_forcing_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/shortwave_cloud_forcing_tests.cpp
@@ -139,7 +139,7 @@ void run(std::mt19937_64& engine)
     diag->compute_diagnostic();
     const auto& diag_out = diag->get_diagnostic();
     Field SWCF_f = diag_out.clone();
-    SWCF_f.deep_copy(0.0);
+    SWCF_f.deep_copy(0);
     const auto& SWCF_v = SWCF_f.get_view<Real*>();
     Kokkos::parallel_for("", policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int icol = team.league_rank();

--- a/components/eamxx/src/diagnostics/tests/surf_upward_latent_heat_flux_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/surf_upward_latent_heat_flux_tests.cpp
@@ -85,7 +85,7 @@ void run(std::mt19937_64& engine, const ekat::Comm& comm, LoggerType& logger)
   diag_latent_heat->compute_diagnostic();
   const auto diag_latent_heat_out = diag_latent_heat->get_diagnostic();
   Field surf_lhf = diag_latent_heat_out.clone();
-  surf_lhf.deep_copy(0.0);
+  surf_lhf.deep_copy(0);
   const auto& surf_lhf_v = surf_lhf.get_view<Real*>();
   constexpr auto latent_heat_evap = PC::LatVap; // [J/kg]
   Kokkos::parallel_for("surf_upward_latent_heat_flux_test",

--- a/components/eamxx/src/diagnostics/tests/surf_upward_latent_heat_flux_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/surf_upward_latent_heat_flux_tests.cpp
@@ -85,8 +85,7 @@ void run(std::mt19937_64& engine, const ekat::Comm& comm, LoggerType& logger)
   diag_latent_heat->compute_diagnostic();
   const auto diag_latent_heat_out = diag_latent_heat->get_diagnostic();
   Field surf_lhf = diag_latent_heat_out.clone();
-  surf_lhf.deep_copy<double,Host>(0.0);
-  surf_lhf.sync_to_dev();
+  surf_lhf.deep_copy(0.0);
   const auto& surf_lhf_v = surf_lhf.get_view<Real*>();
   constexpr auto latent_heat_evap = PC::LatVap; // [J/kg]
   Kokkos::parallel_for("surf_upward_latent_heat_flux_test",

--- a/components/eamxx/src/diagnostics/tests/vapor_flux_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/vapor_flux_tests.cpp
@@ -134,7 +134,7 @@ void run(std::mt19937_64& engine)
       diag->compute_diagnostic();
       const auto& diag_out = diag->get_diagnostic();
       Field qv_vert_integrated_flux_u_f = diag_out.clone();
-      qv_vert_integrated_flux_u_f.deep_copy(0.0);
+      qv_vert_integrated_flux_u_f.deep_copy(0);
       const auto& qv_vert_integrated_flux_u_v = qv_vert_integrated_flux_u_f.get_view<Real*>();
       constexpr Real g = PC::gravit;
       int comp = which_comp=="Zonal" ? 0 : 1;

--- a/components/eamxx/src/diagnostics/tests/vapor_flux_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/vapor_flux_tests.cpp
@@ -134,8 +134,7 @@ void run(std::mt19937_64& engine)
       diag->compute_diagnostic();
       const auto& diag_out = diag->get_diagnostic();
       Field qv_vert_integrated_flux_u_f = diag_out.clone();
-      qv_vert_integrated_flux_u_f.deep_copy<double,Host>(0.0);
-      qv_vert_integrated_flux_u_f.sync_to_dev();
+      qv_vert_integrated_flux_u_f.deep_copy(0.0);
       const auto& qv_vert_integrated_flux_u_v = qv_vert_integrated_flux_u_f.get_view<Real*>();
       constexpr Real g = PC::gravit;
       int comp = which_comp=="Zonal" ? 0 : 1;

--- a/components/eamxx/src/share/field/eti/field_eti_deep_copy_double_device.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_deep_copy_double_device.cpp
@@ -2,6 +2,7 @@
 
 namespace scream {
 
-template void Field::deep_copy_impl<Device,double>(const double);
+template void Field::deep_copy_impl<Device,true,double>(const double, const Field&);
+template void Field::deep_copy_impl<Device,false,double>(const double, const Field&);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_deep_copy_double_host.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_deep_copy_double_host.cpp
@@ -2,6 +2,7 @@
 
 namespace scream {
 
-template void Field::deep_copy_impl<Host,double>(const double);
+template void Field::deep_copy_impl<Host,true,double>(const double, const Field&);
+template void Field::deep_copy_impl<Host,false,double>(const double, const Field&);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_deep_copy_float_device.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_deep_copy_float_device.cpp
@@ -2,6 +2,7 @@
 
 namespace scream {
 
-template void Field::deep_copy_impl<Device,float>(const float);
+template void Field::deep_copy_impl<Device,true,float>(const float, const Field&);
+template void Field::deep_copy_impl<Device,false,float>(const float, const Field&);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_deep_copy_float_host.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_deep_copy_float_host.cpp
@@ -2,6 +2,7 @@
 
 namespace scream {
 
-template void Field::deep_copy_impl<Host,float>(const float);
+template void Field::deep_copy_impl<Host,true,float>(const float, const Field&);
+template void Field::deep_copy_impl<Host,false,float>(const float, const Field&);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_deep_copy_int_device.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_deep_copy_int_device.cpp
@@ -2,6 +2,7 @@
 
 namespace scream {
 
-template void Field::deep_copy_impl<Device,int>(const int);
+template void Field::deep_copy_impl<Device,true,int>(const int, const Field&);
+template void Field::deep_copy_impl<Device,false,int>(const int, const Field&);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_deep_copy_int_host.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_deep_copy_int_host.cpp
@@ -2,6 +2,7 @@
 
 namespace scream {
 
-template void Field::deep_copy_impl<Host,int>(const int);
+template void Field::deep_copy_impl<Host,true,int>(const int, const Field&);
+template void Field::deep_copy_impl<Host,false,int>(const int, const Field&);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_impl_double_device.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_impl_double_device.cpp
@@ -2,8 +2,16 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Update,  Device, false, double>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Multiply,Device, false, double>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Divide,  Device, false, double>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Update,  Device, false, double, double>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Multiply,Device, false, double, double>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Divide,  Device, false, double, double>(const Field&, const double, const double);
+
+template void Field::update_impl<CombineMode::Update,  Device, false, double, float>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Multiply,Device, false, double, float>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Divide,  Device, false, double, float>(const Field&, const double, const double);
+
+template void Field::update_impl<CombineMode::Update,  Device, false, double, int>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Multiply,Device, false, double, int>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Divide,  Device, false, double, int>(const Field&, const double, const double);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_impl_double_host.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_impl_double_host.cpp
@@ -2,8 +2,16 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Update,  Host, false, double>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Multiply,Host, false, double>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Divide,  Host, false, double>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Update,  Host, false, double, double>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Multiply,Host, false, double, double>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Divide,  Host, false, double, double>(const Field&, const double, const double);
+
+template void Field::update_impl<CombineMode::Update,  Host, false, double, float>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Multiply,Host, false, double, float>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Divide,  Host, false, double, float>(const Field&, const double, const double);
+
+template void Field::update_impl<CombineMode::Update,  Host, false, double, int>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Multiply,Host, false, double, int>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Divide,  Host, false, double, int>(const Field&, const double, const double);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_impl_fill_double_device.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_impl_fill_double_device.cpp
@@ -2,8 +2,16 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Update,  Device, true, double>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Multiply,Device, true, double>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Divide,  Device, true, double>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Update,  Device, true, double, double>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Multiply,Device, true, double, double>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Divide,  Device, true, double, double>(const Field&, const double, const double);
+
+template void Field::update_impl<CombineMode::Update,  Device, true, double, float>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Multiply,Device, true, double, float>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Divide,  Device, true, double, float>(const Field&, const double, const double);
+
+template void Field::update_impl<CombineMode::Update,  Device, true, double, int>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Multiply,Device, true, double, int>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Divide,  Device, true, double, int>(const Field&, const double, const double);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_impl_fill_double_host.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_impl_fill_double_host.cpp
@@ -2,8 +2,16 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Update,  Host, true, double>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Multiply,Host, true, double>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Divide,  Host, true, double>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Update,  Host, true, double, double>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Multiply,Host, true, double, double>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Divide,  Host, true, double, double>(const Field&, const double, const double);
+
+template void Field::update_impl<CombineMode::Update,  Host, true, double, float>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Multiply,Host, true, double, float>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Divide,  Host, true, double, float>(const Field&, const double, const double);
+
+template void Field::update_impl<CombineMode::Update,  Host, true, double, int>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Multiply,Host, true, double, int>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Divide,  Host, true, double, int>(const Field&, const double, const double);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_impl_fill_float_device.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_impl_fill_float_device.cpp
@@ -2,8 +2,12 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Update,  Device, true, float>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Multiply,Device, true, float>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Divide,  Device, true, float>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Update,  Device, true, float, float>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Multiply,Device, true, float, float>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Divide,  Device, true, float, float>(const Field&, const float, const float);
+
+template void Field::update_impl<CombineMode::Update,  Device, true, float, int>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Multiply,Device, true, float, int>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Divide,  Device, true, float, int>(const Field&, const float, const float);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_impl_fill_float_host.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_impl_fill_float_host.cpp
@@ -2,8 +2,12 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Update,  Host, true, float>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Multiply,Host, true, float>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Divide,  Host, true, float>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Update,  Host, true, float, float>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Multiply,Host, true, float, float>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Divide,  Host, true, float, float>(const Field&, const float, const float);
+
+template void Field::update_impl<CombineMode::Update,  Host, true, float, int>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Multiply,Host, true, float, int>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Divide,  Host, true, float, int>(const Field&, const float, const float);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_impl_fill_int_device.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_impl_fill_int_device.cpp
@@ -2,8 +2,8 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Update,  Device, true, int>(const Field&, const int, const int);
-template void Field::update_impl<CombineMode::Multiply,Device, true, int>(const Field&, const int, const int);
-template void Field::update_impl<CombineMode::Divide,  Device, true, int>(const Field&, const int, const int);
+template void Field::update_impl<CombineMode::Update,  Device, true, int, int>(const Field&, const int, const int);
+template void Field::update_impl<CombineMode::Multiply,Device, true, int, int>(const Field&, const int, const int);
+template void Field::update_impl<CombineMode::Divide,  Device, true, int, int>(const Field&, const int, const int);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_impl_fill_int_host.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_impl_fill_int_host.cpp
@@ -2,8 +2,8 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Update,  Host, true, int>(const Field&, const int, const int);
-template void Field::update_impl<CombineMode::Multiply,Host, true, int>(const Field&, const int, const int);
-template void Field::update_impl<CombineMode::Divide,  Host, true, int>(const Field&, const int, const int);
+template void Field::update_impl<CombineMode::Update,  Host, true, int, int>(const Field&, const int, const int);
+template void Field::update_impl<CombineMode::Multiply,Host, true, int, int>(const Field&, const int, const int);
+template void Field::update_impl<CombineMode::Divide,  Host, true, int, int>(const Field&, const int, const int);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_impl_float_device.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_impl_float_device.cpp
@@ -2,8 +2,12 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Update,  Device, false, float>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Multiply,Device, false, float>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Divide,  Device, false, float>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Update,  Device, false, float, float>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Multiply,Device, false, float, float>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Divide,  Device, false, float, float>(const Field&, const float, const float);
+
+template void Field::update_impl<CombineMode::Update,  Device, false, float, int>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Multiply,Device, false, float, int>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Divide,  Device, false, float, int>(const Field&, const float, const float);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_impl_float_host.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_impl_float_host.cpp
@@ -2,8 +2,12 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Update,  Host, false, float>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Multiply,Host, false, float>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Divide,  Host, false, float>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Update,  Host, false, float, float>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Multiply,Host, false, float, float>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Divide,  Host, false, float, float>(const Field&, const float, const float);
+
+template void Field::update_impl<CombineMode::Update,  Host, false, float, int>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Multiply,Host, false, float, int>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Divide,  Host, false, float, int>(const Field&, const float, const float);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_impl_int_device.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_impl_int_device.cpp
@@ -2,8 +2,8 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Update,  Device, false, int>(const Field&, const int, const int);
-template void Field::update_impl<CombineMode::Multiply,Device, false, int>(const Field&, const int, const int);
-template void Field::update_impl<CombineMode::Divide,  Device, false, int>(const Field&, const int, const int);
+template void Field::update_impl<CombineMode::Update,  Device, false, int, int>(const Field&, const int, const int);
+template void Field::update_impl<CombineMode::Multiply,Device, false, int, int>(const Field&, const int, const int);
+template void Field::update_impl<CombineMode::Divide,  Device, false, int, int>(const Field&, const int, const int);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_impl_int_host.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_impl_int_host.cpp
@@ -2,8 +2,8 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Update,  Host, false, int>(const Field&, const int, const int);
-template void Field::update_impl<CombineMode::Multiply,Host, false, int>(const Field&, const int, const int);
-template void Field::update_impl<CombineMode::Divide,  Host, false, int>(const Field&, const int, const int);
+template void Field::update_impl<CombineMode::Update,  Host, false, int, int>(const Field&, const int, const int);
+template void Field::update_impl<CombineMode::Multiply,Host, false, int, int>(const Field&, const int, const int);
+template void Field::update_impl<CombineMode::Divide,  Host, false, int, int>(const Field&, const int, const int);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -165,9 +165,13 @@ public:
     using nonconst_ST = typename std::remove_const<ST>::type;
     EKAT_REQUIRE_MSG ((field_valid_data_types().at<nonconst_ST>()==m_header->get_identifier().data_type()
                        or std::is_same<nonconst_ST,char>::value),
-        "Error! Attempt to access raw field pointere with the wrong scalar type.\n");
+        "Error! Attempt to access raw field pointer with the wrong scalar type.\n"
+        " - field name: " + name() + "\n"
+        " - field data type: " + e2str(data_type()) + "\n"
+        " - requested type : " + e2str(field_valid_data_types().at<nonconst_ST>()) + "\n");
     EKAT_REQUIRE_MSG (not m_is_read_only || std::is_const<ST>::value,
-        "Error! Cannot get a non-const raw pointer to the field data if the field is read-only.\n");
+        "Error! Cannot get a non-const raw pointer to the field data if the field is read-only.\n"
+        " - field name: " + name() + "\n");
 
     return reinterpret_cast<ST*>(get_view_impl<HD>().data());
   }
@@ -186,7 +190,10 @@ public:
     EKAT_REQUIRE_MSG ((std::is_same<nonconst_ST,char>::value or std::is_same<nonconst_ST,void>::value or
                        (field_valid_data_types().has_t<nonconst_ST>() and
                         get_data_type<nonconst_ST>()==m_header->get_identifier().data_type())),
-          "Error! Attempt to access raw field pointere with the wrong scalar type.\n");
+        "Error! Attempt to access raw field pointer with the wrong scalar type.\n"
+        " - field name: " + name() + "\n"
+        " - field data type: " + e2str(data_type()) + "\n"
+        " - requested type : " + e2str(field_valid_data_types().at<nonconst_ST>()) + "\n");
 
     return reinterpret_cast<ST*>(get_view_impl<HD>().data());
   }

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -209,8 +209,11 @@ public:
   void sync_to_dev (const bool fence = true) const;
 
   // Set the field to a constant value (on host or device)
-  template<typename T, HostOrDevice HD = Device>
-  void deep_copy (const T value);
+  // Note: as done below in 'update', the default for ST is only to allow
+  //       giving a default for HD. In practice, ST will ALWAYS be
+  //       deduced from the type of 'value'
+  template<HostOrDevice HD = Device, typename ST = void>
+  void deep_copy (const ST value);
 
   // Copy the data from one field to this field (recycle update method)
   template<HostOrDevice HD = Device>

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -334,7 +334,7 @@ protected:
   // The update method calls this, with ST matching this field data type.
   // Note: use_fill is used to determine *at compile time* whether to use
   // the combine<CM> utility or combine_and_fill<CM>
-  template<CombineMode CM, HostOrDevice HD, bool use_fill, typename ST>
+  template<CombineMode CM, HostOrDevice HD, bool use_fill, typename ST, typename STX>
   void update_impl (const Field& x, const ST alpha, const ST beta);
 
 protected:
@@ -409,13 +409,15 @@ inline bool operator== (const Field& lhs, const Field& rhs) {
 #define EAMXX_FIELD_ETI_DECL_UPDATE(S,T) \
 extern template void Field::update<CombineMode::Update, S, T>(const Field&, const T, const T);              \
 extern template void Field::update<CombineMode::Multiply, S, T>(const Field&, const T, const T);            \
-extern template void Field::update<CombineMode::Divide, S, T>(const Field&, const T, const T);              \
-extern template void Field::update_impl<CombineMode::Update,  S, true, T>(const Field&, const T, const T);  \
-extern template void Field::update_impl<CombineMode::Multiply,S, true, T>(const Field&, const T, const T);  \
-extern template void Field::update_impl<CombineMode::Divide,  S, true, T>(const Field&, const T, const T);  \
-extern template void Field::update_impl<CombineMode::Update,  S, false, T>(const Field&, const T, const T); \
-extern template void Field::update_impl<CombineMode::Multiply,S, false, T>(const Field&, const T, const T); \
-extern template void Field::update_impl<CombineMode::Divide,  S, false, T>(const Field&, const T, const T)
+extern template void Field::update<CombineMode::Divide, S, T>(const Field&, const T, const T)
+
+#define EAMXX_FIELD_ETI_DECL_UPDATE_IMPL(S,T1,T2) \
+extern template void Field::update_impl<CombineMode::Update,  S, true, T1, T2>(const Field&, const T1, const T1);  \
+extern template void Field::update_impl<CombineMode::Multiply,S, true, T1, T2>(const Field&, const T1, const T1);  \
+extern template void Field::update_impl<CombineMode::Divide,  S, true, T1, T2>(const Field&, const T1, const T1);  \
+extern template void Field::update_impl<CombineMode::Update,  S, false, T1, T2>(const Field&, const T1, const T1); \
+extern template void Field::update_impl<CombineMode::Multiply,S, false, T1, T2>(const Field&, const T1, const T1); \
+extern template void Field::update_impl<CombineMode::Divide,  S, false, T1, T2>(const Field&, const T1, const T1)
 
 #define EAMXX_FIELD_ETI_DECL_DEEP_COPY(S,T) \
 extern template void Field::deep_copy_impl<S,T>(const T)
@@ -436,7 +438,7 @@ extern template Field::get_strided_view_type<T****,S> Field::get_strided_view<T*
 extern template Field::get_strided_view_type<T*****,S> Field::get_strided_view<T*****,S> () const; \
 extern template Field::get_strided_view_type<T******,S> Field::get_strided_view<T******,S> () const
 
-#define EAMXX_FIELD_ETI_DECL_FOR_TYPE(T) \
+#define EAMXX_FIELD_ETI_DECL_FOR_ONE_TYPE(T) \
 EAMXX_FIELD_ETI_DECL_UPDATE(Device,T);          \
 EAMXX_FIELD_ETI_DECL_UPDATE(Host,T);            \
 EAMXX_FIELD_ETI_DECL_DEEP_COPY(Device,T);       \
@@ -444,15 +446,25 @@ EAMXX_FIELD_ETI_DECL_DEEP_COPY(Host,T);         \
 EAMXX_FIELD_ETI_DECL_GET_VIEW(Device,T);        \
 EAMXX_FIELD_ETI_DECL_GET_VIEW(Host,T);          \
 EAMXX_FIELD_ETI_DECL_GET_VIEW(Device,const T);  \
-EAMXX_FIELD_ETI_DECL_GET_VIEW(Host,const T);
+EAMXX_FIELD_ETI_DECL_GET_VIEW(Host,const T)
+
+#define EAMXX_FIELD_ETI_DECL_FOR_TWO_TYPES(T1,T2) \
+EAMXX_FIELD_ETI_DECL_UPDATE_IMPL(Device,T1,T2);   \
+EAMXX_FIELD_ETI_DECL_UPDATE_IMPL(Host,T1,T2)
 
 // TODO: should we ETI other scalar types too? E.g. Pack<Real,SCREAM_PACK_SIZE??
 //       Real is by far the most common, so it'd be nice to just to that. But
 //       all the update/update_impl methods use get_view for all 3 types, so just ETI all of them
-EAMXX_FIELD_ETI_DECL_FOR_TYPE(double);
-EAMXX_FIELD_ETI_DECL_FOR_TYPE(float);
-EAMXX_FIELD_ETI_DECL_FOR_TYPE(int);
+EAMXX_FIELD_ETI_DECL_FOR_ONE_TYPE(double);
+EAMXX_FIELD_ETI_DECL_FOR_ONE_TYPE(float);
+EAMXX_FIELD_ETI_DECL_FOR_ONE_TYPE(int);
 
+EAMXX_FIELD_ETI_DECL_FOR_TWO_TYPES(double,double);
+EAMXX_FIELD_ETI_DECL_FOR_TWO_TYPES(double,float);
+EAMXX_FIELD_ETI_DECL_FOR_TWO_TYPES(double,int);
+EAMXX_FIELD_ETI_DECL_FOR_TWO_TYPES(float,float);
+EAMXX_FIELD_ETI_DECL_FOR_TWO_TYPES(float,int);
+EAMXX_FIELD_ETI_DECL_FOR_TWO_TYPES(int,int);
 } // namespace scream
 
 // Include template methods implementation

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -215,6 +215,12 @@ public:
   template<HostOrDevice HD = Device, typename ST = void>
   void deep_copy (const ST value);
 
+  // Like the above one, but only sets the value where the mask is active
+  // NOTE: mask field must have data type IntType, and hold the extra data
+  // "true_value", to specify where the mask is active
+  template<HostOrDevice HD = Device, typename ST = void>
+  void deep_copy (const ST value, const Field& mask);
+
   // Copy the data from one field to this field (recycle update method)
   template<HostOrDevice HD = Device>
   void deep_copy (const Field& src) { update<CombineMode::Replace,HD>(src,1,0); }
@@ -328,8 +334,8 @@ protected:
   template<typename ST, HostOrDevice From, HostOrDevice To>
   void sync_views_impl () const;
 
-  template<HostOrDevice HD, typename ST>
-  void deep_copy_impl (const ST value);
+  template<HostOrDevice HD, bool use_mask, typename ST>
+  void deep_copy_impl (const ST value, const Field& mask);
 
   // The update method calls this, with ST matching this field data type.
   // Note: use_fill is used to determine *at compile time* whether to use
@@ -420,7 +426,8 @@ extern template void Field::update_impl<CombineMode::Multiply,S, false, T1, T2>(
 extern template void Field::update_impl<CombineMode::Divide,  S, false, T1, T2>(const Field&, const T1, const T1)
 
 #define EAMXX_FIELD_ETI_DECL_DEEP_COPY(S,T) \
-extern template void Field::deep_copy_impl<S,T>(const T)
+extern template void Field::deep_copy_impl<S,true,T>(const T, const Field&); \
+extern template void Field::deep_copy_impl<S,false,T>(const T, const Field&)
 
 #define EAMXX_FIELD_ETI_DECL_GET_VIEW(S,T) \
 extern template Field::get_view_type<T,S> Field::get_view<T,S> () const; \

--- a/components/eamxx/src/share/field/field_impl.hpp
+++ b/components/eamxx/src/share/field/field_impl.hpp
@@ -445,7 +445,7 @@ void Field::sync_views_impl () const {
   }
 }
 
-template<typename ST, HostOrDevice HD>
+template<HostOrDevice HD, typename ST>
 void Field::
 deep_copy (const ST value) {
   EKAT_REQUIRE_MSG (not m_is_read_only,

--- a/components/eamxx/src/share/field/field_impl.hpp
+++ b/components/eamxx/src/share/field/field_impl.hpp
@@ -2,6 +2,7 @@
 #define SCREAM_FIELD_IMPL_HPP
 
 #include "share/field/field.hpp"
+#include "share/field/field_impl_details.hpp"
 #include "share/util/eamxx_array_utils.hpp"
 #include "share/util/eamxx_universal_constants.hpp"
 
@@ -9,126 +10,6 @@
 
 namespace scream
 {
-
-namespace impl {
-
-template<CombineMode CM, bool use_fill, typename LhsView, typename RhsView, typename ST>
-struct CombineViewsHelper {
-
-  using exec_space = typename LhsView::traits::execution_space;
-
-  static constexpr int N = LhsView::rank();
-
-  template<int M>
-  using MDRange = Kokkos::MDRangePolicy<
-                    exec_space,
-                    Kokkos::Rank<M,Kokkos::Iterate::Right,Kokkos::Iterate::Right>
-                  >;
-
-  void run (const std::vector<int>& dims) const {
-    if constexpr (N==0) {
-      Kokkos::RangePolicy<exec_space> policy(0,1);
-      Kokkos::parallel_for(policy,*this);
-    } else if constexpr (N==1) {
-      Kokkos::RangePolicy<exec_space> policy(0,dims[0]);
-      Kokkos::parallel_for(policy,*this);
-    } else if constexpr (N==2) {
-      MDRange<2> policy({0,0},{dims[0],dims[1]});
-      Kokkos::parallel_for(policy,*this);
-    } else if constexpr (N==3) {
-      MDRange<3> policy({0,0,0},{dims[0],dims[1],dims[2]});
-      Kokkos::parallel_for(policy,*this);
-    } else if constexpr (N==4) {
-      MDRange<4> policy({0,0,0,0},{dims[0],dims[1],dims[2],dims[3]});
-      Kokkos::parallel_for(policy,*this);
-    } else if constexpr (N==5) {
-      MDRange<5> policy({0,0,0,0,0},{dims[0],dims[1],dims[2],dims[3],dims[4]});
-      Kokkos::parallel_for(policy,*this);
-    } else if constexpr (N==6) {
-      MDRange<6> policy({0,0,0,0,0,0},{dims[0],dims[1],dims[2],dims[3],dims[4],dims[5]});
-      Kokkos::parallel_for(policy,*this);
-    } else {
-      EKAT_ERROR_MSG ("Unsupported rank! Should be in [2,6].\n");
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i) const {
-    if constexpr (use_fill)
-      if constexpr (N==0)
-        combine_and_fill<CM>(rhs(),lhs(),fill_val,alpha,beta);
-      else
-        combine_and_fill<CM>(rhs(i),lhs(i),fill_val,alpha,beta);
-    else
-      if constexpr (N==0)
-        combine<CM>(rhs(),lhs(),alpha,beta);
-      else
-        combine<CM>(rhs(i),lhs(i),alpha,beta);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j) const {
-    if constexpr (use_fill)
-      combine_and_fill<CM>(rhs(i,j),lhs(i,j),fill_val,alpha,beta);
-    else
-      combine<CM>(rhs(i,j),lhs(i,j),alpha,beta);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j, int k) const {
-    if constexpr (use_fill)
-      combine_and_fill<CM>(rhs(i,j,k),lhs(i,j,k),fill_val,alpha,beta);
-    else
-      combine<CM>(rhs(i,j,k),lhs(i,j,k),alpha,beta);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j, int k, int l) const {
-    if constexpr (use_fill)
-      combine_and_fill<CM>(rhs(i,j,k,l),lhs(i,j,k,l),fill_val,alpha,beta);
-    else
-      combine<CM>(rhs(i,j,k,l),lhs(i,j,k,l),alpha,beta);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j, int k, int l, int m) const {
-    if constexpr (use_fill)
-      combine_and_fill<CM>(rhs(i,j,k,l,m),lhs(i,j,k,l,m),fill_val,alpha,beta);
-    else
-      combine<CM>(rhs(i,j,k,l,m),lhs(i,j,k,l,m),alpha,beta);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j, int k, int l, int m, int n) const {
-    if constexpr (use_fill)
-      combine_and_fill<CM>(rhs(i,j,k,l,m,n),lhs(i,j,k,l,m,n),fill_val,alpha,beta);
-    else
-      combine<CM>(rhs(i,j,k,l,m,n),lhs(i,j,k,l,m,n),alpha,beta);
-  }
-
-  ST alpha;
-  ST beta;
-  LhsView lhs;
-  RhsView rhs;
-  typename LhsView::traits::value_type fill_val;
-};
-
-template<CombineMode CM, bool use_fill, typename LhsView, typename RhsView, typename ST>
-void
-cvh (LhsView lhs, RhsView rhs,
-     ST alpha, ST beta, typename LhsView::traits::value_type fill_val,
-     const std::vector<int>& dims)
-{
-  CombineViewsHelper <CM, use_fill, LhsView, RhsView,  ST> helper;
-  helper.lhs = lhs;
-  helper.rhs = rhs;
-  helper.alpha = alpha;
-  helper.beta = beta;
-  helper.fill_val = fill_val;
-  helper.run(dims);
-}
-
-} // namespace impl
 
 template<typename ViewT, typename>
 Field::
@@ -666,127 +547,127 @@ update_impl (const Field& x, const ST alpha, const ST beta)
   switch (layout.rank()) {
     case 0:
       if (x_contig and y_contig)
-        impl::cvh<CM,use_fill>(get_view<ST,HD>(),
+        details::cvh<CM,use_fill>(get_view<ST,HD>(),
                                x.get_view<const ST,HD>(),
                                alpha,beta,fill_val,dims);
       else if (x_contig)
-        impl::cvh<CM,use_fill>(get_strided_view<ST,HD>(),
+        details::cvh<CM,use_fill>(get_strided_view<ST,HD>(),
                                x.get_view<const ST,HD>(),
                                alpha,beta,fill_val,dims);
       else if (y_contig)
-        impl::cvh<CM,use_fill>(get_view<ST,HD>(),
+        details::cvh<CM,use_fill>(get_view<ST,HD>(),
                                x.get_strided_view<const ST,HD>(),
                                alpha,beta,fill_val,dims);
       else
-        impl::cvh<CM,use_fill>(get_strided_view<ST,HD>(),
+        details::cvh<CM,use_fill>(get_strided_view<ST,HD>(),
                                x.get_strided_view<const ST,HD>(),
                                alpha,beta,fill_val,dims);
       break;
     case 1:
       if (x_contig and y_contig)
-        impl::cvh<CM,use_fill>(get_view<ST*,HD>(),
+        details::cvh<CM,use_fill>(get_view<ST*,HD>(),
                                x.get_view<const ST*,HD>(),
                                alpha,beta,fill_val,dims);
       else if (x_contig)
-        impl::cvh<CM,use_fill>(get_strided_view<ST*,HD>(),
+        details::cvh<CM,use_fill>(get_strided_view<ST*,HD>(),
                                x.get_view<const ST*,HD>(),
                                alpha,beta,fill_val,dims);
       else if (y_contig)
-        impl::cvh<CM,use_fill>(get_view<ST*,HD>(),
+        details::cvh<CM,use_fill>(get_view<ST*,HD>(),
                                x.get_strided_view<const ST*,HD>(),
                                alpha,beta,fill_val,dims);
       else
-        impl::cvh<CM,use_fill>(get_strided_view<ST*,HD>(),
+        details::cvh<CM,use_fill>(get_strided_view<ST*,HD>(),
                                x.get_strided_view<const ST*,HD>(),
                                alpha,beta,fill_val,dims);
       break;
     case 2:
       if (x_contig and y_contig)
-        impl::cvh<CM,use_fill>(get_view<ST**,HD>(),
+        details::cvh<CM,use_fill>(get_view<ST**,HD>(),
                                x.get_view<const ST**,HD>(),
                                alpha,beta,fill_val,dims);
       else if (x_contig)
-        impl::cvh<CM,use_fill>(get_strided_view<ST**,HD>(),
+        details::cvh<CM,use_fill>(get_strided_view<ST**,HD>(),
                                x.get_view<const ST**,HD>(),
                                alpha,beta,fill_val,dims);
       else if (y_contig)
-        impl::cvh<CM,use_fill>(get_view<ST**,HD>(),
+        details::cvh<CM,use_fill>(get_view<ST**,HD>(),
                                x.get_strided_view<const ST**,HD>(),
                                alpha,beta,fill_val,dims);
       else
-        impl::cvh<CM,use_fill>(get_strided_view<ST**,HD>(),
+        details::cvh<CM,use_fill>(get_strided_view<ST**,HD>(),
                                x.get_strided_view<const ST**,HD>(),
                                alpha,beta,fill_val,dims);
       break;
     case 3:
       if (x_contig and y_contig)
-        impl::cvh<CM,use_fill>(get_view<ST***,HD>(),
+        details::cvh<CM,use_fill>(get_view<ST***,HD>(),
                                x.get_view<const ST***,HD>(),
                                alpha,beta,fill_val,dims);
       else if (x_contig)
-        impl::cvh<CM,use_fill>(get_strided_view<ST***,HD>(),
+        details::cvh<CM,use_fill>(get_strided_view<ST***,HD>(),
                                x.get_view<const ST***,HD>(),
                                alpha,beta,fill_val,dims);
       else if (y_contig)
-        impl::cvh<CM,use_fill>(get_view<ST***,HD>(),
+        details::cvh<CM,use_fill>(get_view<ST***,HD>(),
                                x.get_strided_view<const ST***,HD>(),
                                alpha,beta,fill_val,dims);
       else
-        impl::cvh<CM,use_fill>(get_strided_view<ST***,HD>(),
+        details::cvh<CM,use_fill>(get_strided_view<ST***,HD>(),
                                x.get_strided_view<const ST***,HD>(),
                                alpha,beta,fill_val,dims);
       break;
     case 4:
       if (x_contig and y_contig)
-        impl::cvh<CM,use_fill>(get_view<ST****,HD>(),
+        details::cvh<CM,use_fill>(get_view<ST****,HD>(),
                                x.get_view<const ST****,HD>(),
                                alpha,beta,fill_val,dims);
       else if (x_contig)
-        impl::cvh<CM,use_fill>(get_strided_view<ST****,HD>(),
+        details::cvh<CM,use_fill>(get_strided_view<ST****,HD>(),
                                x.get_view<const ST****,HD>(),
                                alpha,beta,fill_val,dims);
       else if (y_contig)
-        impl::cvh<CM,use_fill>(get_view<ST****,HD>(),
+        details::cvh<CM,use_fill>(get_view<ST****,HD>(),
                                x.get_strided_view<const ST****,HD>(),
                                alpha,beta,fill_val,dims);
       else
-        impl::cvh<CM,use_fill>(get_strided_view<ST****,HD>(),
+        details::cvh<CM,use_fill>(get_strided_view<ST****,HD>(),
                                x.get_strided_view<const ST****,HD>(),
                                alpha,beta,fill_val,dims);
       break;
     case 5:
       if (x_contig and y_contig)
-        impl::cvh<CM,use_fill>(get_view<ST*****,HD>(),
+        details::cvh<CM,use_fill>(get_view<ST*****,HD>(),
                                x.get_view<const ST*****,HD>(),
                                alpha,beta,fill_val,dims);
       else if (x_contig)
-        impl::cvh<CM,use_fill>(get_strided_view<ST*****,HD>(),
+        details::cvh<CM,use_fill>(get_strided_view<ST*****,HD>(),
                                x.get_view<const ST*****,HD>(),
                                alpha,beta,fill_val,dims);
       else if (y_contig)
-        impl::cvh<CM,use_fill>(get_view<ST*****,HD>(),
+        details::cvh<CM,use_fill>(get_view<ST*****,HD>(),
                                x.get_strided_view<const ST*****,HD>(),
                                alpha,beta,fill_val,dims);
       else
-        impl::cvh<CM,use_fill>(get_strided_view<ST*****,HD>(),
+        details::cvh<CM,use_fill>(get_strided_view<ST*****,HD>(),
                                x.get_strided_view<const ST*****,HD>(),
                                alpha,beta,fill_val,dims);
       break;
     case 6:
       if (x_contig and y_contig)
-        impl::cvh<CM,use_fill>(get_view<ST******,HD>(),
+        details::cvh<CM,use_fill>(get_view<ST******,HD>(),
                                x.get_view<const ST******,HD>(),
                                alpha,beta,fill_val,dims);
       else if (x_contig)
-        impl::cvh<CM,use_fill>(get_strided_view<ST******,HD>(),
+        details::cvh<CM,use_fill>(get_strided_view<ST******,HD>(),
                                x.get_view<const ST******,HD>(),
                                alpha,beta,fill_val,dims);
       else if (y_contig)
-        impl::cvh<CM,use_fill>(get_view<ST******,HD>(),
+        details::cvh<CM,use_fill>(get_view<ST******,HD>(),
                                x.get_strided_view<const ST******,HD>(),
                                alpha,beta,fill_val,dims);
       else
-        impl::cvh<CM,use_fill>(get_strided_view<ST******,HD>(),
+        details::cvh<CM,use_fill>(get_strided_view<ST******,HD>(),
                                x.get_strided_view<const ST******,HD>(),
                                alpha,beta,fill_val,dims);
       break;

--- a/components/eamxx/src/share/field/field_impl_details.hpp
+++ b/components/eamxx/src/share/field/field_impl_details.hpp
@@ -1,0 +1,133 @@
+#ifndef SCREAM_FIELD_IMPL_DETAILS_HPP
+#define SCREAM_FIELD_IMPL_DETAILS_HPP
+
+#include <ekat/kokkos/ekat_kokkos_types.hpp>
+
+#include <vector>
+
+namespace scream
+{
+
+namespace details {
+
+template<CombineMode CM, bool use_fill, typename LhsView, typename RhsView, typename ST>
+struct CombineViewsHelper {
+
+  using exec_space = typename LhsView::traits::execution_space;
+
+  static constexpr int N = LhsView::rank();
+
+  template<int M>
+  using MDRange = Kokkos::MDRangePolicy<
+                    exec_space,
+                    Kokkos::Rank<M,Kokkos::Iterate::Right,Kokkos::Iterate::Right>
+                  >;
+
+  void run (const std::vector<int>& dims) const {
+    if constexpr (N==0) {
+      Kokkos::RangePolicy<exec_space> policy(0,1);
+      Kokkos::parallel_for(policy,*this);
+    } else if constexpr (N==1) {
+      Kokkos::RangePolicy<exec_space> policy(0,dims[0]);
+      Kokkos::parallel_for(policy,*this);
+    } else if constexpr (N==2) {
+      MDRange<2> policy({0,0},{dims[0],dims[1]});
+      Kokkos::parallel_for(policy,*this);
+    } else if constexpr (N==3) {
+      MDRange<3> policy({0,0,0},{dims[0],dims[1],dims[2]});
+      Kokkos::parallel_for(policy,*this);
+    } else if constexpr (N==4) {
+      MDRange<4> policy({0,0,0,0},{dims[0],dims[1],dims[2],dims[3]});
+      Kokkos::parallel_for(policy,*this);
+    } else if constexpr (N==5) {
+      MDRange<5> policy({0,0,0,0,0},{dims[0],dims[1],dims[2],dims[3],dims[4]});
+      Kokkos::parallel_for(policy,*this);
+    } else if constexpr (N==6) {
+      MDRange<6> policy({0,0,0,0,0,0},{dims[0],dims[1],dims[2],dims[3],dims[4],dims[5]});
+      Kokkos::parallel_for(policy,*this);
+    } else {
+      EKAT_ERROR_MSG ("Unsupported rank! Should be in [2,6].\n");
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (int i) const {
+    if constexpr (use_fill)
+      if constexpr (N==0)
+        combine_and_fill<CM>(rhs(),lhs(),fill_val,alpha,beta);
+      else
+        combine_and_fill<CM>(rhs(i),lhs(i),fill_val,alpha,beta);
+    else
+      if constexpr (N==0)
+        combine<CM>(rhs(),lhs(),alpha,beta);
+      else
+        combine<CM>(rhs(i),lhs(i),alpha,beta);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (int i, int j) const {
+    if constexpr (use_fill)
+      combine_and_fill<CM>(rhs(i,j),lhs(i,j),fill_val,alpha,beta);
+    else
+      combine<CM>(rhs(i,j),lhs(i,j),alpha,beta);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (int i, int j, int k) const {
+    if constexpr (use_fill)
+      combine_and_fill<CM>(rhs(i,j,k),lhs(i,j,k),fill_val,alpha,beta);
+    else
+      combine<CM>(rhs(i,j,k),lhs(i,j,k),alpha,beta);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (int i, int j, int k, int l) const {
+    if constexpr (use_fill)
+      combine_and_fill<CM>(rhs(i,j,k,l),lhs(i,j,k,l),fill_val,alpha,beta);
+    else
+      combine<CM>(rhs(i,j,k,l),lhs(i,j,k,l),alpha,beta);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (int i, int j, int k, int l, int m) const {
+    if constexpr (use_fill)
+      combine_and_fill<CM>(rhs(i,j,k,l,m),lhs(i,j,k,l,m),fill_val,alpha,beta);
+    else
+      combine<CM>(rhs(i,j,k,l,m),lhs(i,j,k,l,m),alpha,beta);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (int i, int j, int k, int l, int m, int n) const {
+    if constexpr (use_fill)
+      combine_and_fill<CM>(rhs(i,j,k,l,m,n),lhs(i,j,k,l,m,n),fill_val,alpha,beta);
+    else
+      combine<CM>(rhs(i,j,k,l,m,n),lhs(i,j,k,l,m,n),alpha,beta);
+  }
+
+  ST alpha;
+  ST beta;
+  LhsView lhs;
+  RhsView rhs;
+  typename LhsView::traits::value_type fill_val;
+};
+
+template<CombineMode CM, bool use_fill, typename LhsView, typename RhsView, typename ST>
+void
+cvh (LhsView lhs, RhsView rhs,
+     ST alpha, ST beta, typename LhsView::traits::value_type fill_val,
+     const std::vector<int>& dims)
+{
+  CombineViewsHelper <CM, use_fill, LhsView, RhsView,  ST> helper;
+  helper.lhs = lhs;
+  helper.rhs = rhs;
+  helper.alpha = alpha;
+  helper.beta = beta;
+  helper.fill_val = fill_val;
+  helper.run(dims);
+}
+
+} // namespace details
+
+} // namespace scream
+
+#endif // SCREAM_FIELD_IMPL_DETAILS_HPP

--- a/components/eamxx/src/share/field/field_impl_details.hpp
+++ b/components/eamxx/src/share/field/field_impl_details.hpp
@@ -126,6 +126,112 @@ cvh (LhsView lhs, RhsView rhs,
   helper.run(dims);
 }
 
+template<typename LhsView, typename MaskView, bool use_mask>
+struct SetValueMasked
+{
+  using exec_space = typename LhsView::traits::execution_space;
+
+  using ST = typename LhsView::traits::value_type;
+
+  static constexpr int N = LhsView::rank();
+
+  template<int M>
+  using MDRange = Kokkos::MDRangePolicy<
+                    exec_space,
+                    Kokkos::Rank<M,Kokkos::Iterate::Right,Kokkos::Iterate::Right>
+                  >;
+
+  void run (const std::vector<int>& dims) const {
+    if constexpr (N==0) {
+      Kokkos::RangePolicy<exec_space> policy(0,1);
+      Kokkos::parallel_for(policy,*this);
+    } else if constexpr (N==1) {
+      Kokkos::RangePolicy<exec_space> policy(0,dims[0]);
+      Kokkos::parallel_for(policy,*this);
+    } else if constexpr (N==2) {
+      MDRange<2> policy({0,0},{dims[0],dims[1]});
+      Kokkos::parallel_for(policy,*this);
+    } else if constexpr (N==3) {
+      MDRange<3> policy({0,0,0},{dims[0],dims[1],dims[2]});
+      Kokkos::parallel_for(policy,*this);
+    } else if constexpr (N==4) {
+      MDRange<4> policy({0,0,0,0},{dims[0],dims[1],dims[2],dims[3]});
+      Kokkos::parallel_for(policy,*this);
+    } else if constexpr (N==5) {
+      MDRange<5> policy({0,0,0,0,0},{dims[0],dims[1],dims[2],dims[3],dims[4]});
+      Kokkos::parallel_for(policy,*this);
+    } else if constexpr (N==6) {
+      MDRange<6> policy({0,0,0,0,0,0},{dims[0],dims[1],dims[2],dims[3],dims[4],dims[5]});
+      Kokkos::parallel_for(policy,*this);
+    } else {
+      EKAT_ERROR_MSG ("Unsupported rank! Should be in [2,6].\n");
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (int i) const {
+    if constexpr (N==0) {
+      auto& lhs_ref = lhs();
+      lhs_ref = not use_mask or mask() ? value : lhs_ref;
+    } else {
+      auto& lhs_ref = lhs(i);
+      lhs_ref = not use_mask or mask(i) ? value : lhs_ref;
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (int i, int j) const {
+    auto& lhs_ref = lhs(i,j);
+    lhs_ref = not use_mask or mask(i,j) ? value : lhs_ref;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (int i, int j, int k) const {
+    auto& lhs_ref = lhs(i,j,k);
+    lhs_ref = not use_mask or mask(i,j,k) ? value : lhs_ref;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (int i, int j, int k, int l) const {
+    auto& lhs_ref = lhs(i,j,k,l);
+    lhs_ref = not use_mask or mask(i,j,k,l) ? value : lhs_ref;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (int i, int j, int k, int l, int m) const {
+    auto& lhs_ref = lhs(i,j,k,l,m);
+    lhs_ref = not use_mask or mask(i,j,k,l,m) ? value : lhs_ref;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (int i, int j, int k, int l, int m, int n) const {
+    auto& lhs_ref = lhs(i,j,k,l,m,n);
+    lhs_ref = not use_mask or mask(i,j,k,l,m,n) ? value : lhs_ref;
+  }
+
+  ST value;
+  LhsView lhs;
+  MaskView mask;
+};
+
+template<bool use_mask, typename LhsView, typename MaskView = LhsView>
+void
+svm (LhsView lhs,
+     typename LhsView::traits::value_type value,
+     const std::vector<int>& dims,
+     MaskView mask = MaskView())
+{
+  SetValueMasked <LhsView, MaskView, use_mask> helper;
+  helper.lhs = lhs;
+  helper.mask = mask;
+  helper.value = value;
+
+  EKAT_REQUIRE_MSG (not use_mask or mask.data()!=nullptr,
+      "Error! Calling scream::details::svm with use_mask=true, but input mask view is invalid.\n");
+
+  helper.run(dims);
+}
+
 } // namespace details
 
 } // namespace scream

--- a/components/eamxx/src/share/tests/atm_process_tests.cpp
+++ b/components/eamxx/src/share/tests/atm_process_tests.cpp
@@ -624,9 +624,9 @@ TEST_CASE ("diagnostics") {
     REQUIRE_THROWS(diag_fail->set_computed_field(f));
     if (name == "Field A") {
       diag_identity->set_required_field(f.get_const());
-      f.deep_copy<double,Host>(1.0);
+      f.deep_copy<Host>(1.0);
     } else {
-      f.deep_copy<double,Host>(2.0);
+      f.deep_copy<Host>(2.0);
     } 
     input_fields.emplace(name,f);
   }

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -825,6 +825,39 @@ TEST_CASE ("update") {
     }
   }
 
+  SECTION ("masked_deep_copy") {
+    auto f1 = f_real.clone();
+    auto f2 = f_real.clone();
+    auto f3 = f_real.clone();
+    f3.deep_copy(0);
+    for (int icol=0; icol<ncol; ++ icol) {
+      auto val = icol % 2 == 0 ? 1 : -1;
+      f1.subfield(0,icol).deep_copy(val);
+    }
+
+    // Compute mask where f1>0 (should be all even cols)
+    auto mask = f_int.clone("mask");
+    compute_mask<Comparison::GT>(f1,0,mask);
+
+    // Set f3=1 where mask=1
+    f3.deep_copy(1,mask);
+
+    auto one = f1.subfield(0,0).clone("one");
+    auto zero = f1.subfield(0,0).clone("zero");
+    one.deep_copy(1);
+    zero.deep_copy(0);
+
+    // Check
+    for (int icol=0; icol<ncol; ++ icol) {
+      auto f3i = f3.subfield(0,icol);
+      if (icol % 2 == 0) {
+        REQUIRE (views_are_equal(f3i,one));
+      } else {
+        REQUIRE (views_are_equal(f3i,zero));
+      }
+    }
+  }
+
   SECTION ("scale") {
     SECTION ("real") {
       Field f1 = f_real.clone();

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -220,7 +220,7 @@ TEST_CASE("field", "") {
     REQUIRE(views_are_equal(f1,f2));
 
     // Changing f2 should leave f1 unchanged
-    f2.deep_copy<Real>(0.0);
+    f2.deep_copy(0);
     REQUIRE (field_max<Real>(f2)==0.0);
     REQUIRE (field_min<Real>(f2)==0.0);
     REQUIRE (field_max<Real>(f1)==3.0);
@@ -969,7 +969,7 @@ TEST_CASE ("sync_subfields") {
 
   // Set subfield values to their index on host
   for (int c=0; c<ndims; ++c) {
-    f.get_component(c).deep_copy<int, Host>(c);
+    f.get_component(c).deep_copy<Host>(c);
   }
 
   // Sync only component 0 to device


### PR DESCRIPTION
In random order

- fix template args order in deep_copy
- allow to deep copy only where a mask field is active
- allow calling update with rhs of different (but compatible) data type
- move impl namespace to separate file

[BFB]

---

Note: this PR is built on top of #7190, and should be merged after that. This PR is also in view of relying more on Field interfaces inside IO classes.