### PR TITLE
EAMxx: Replacing temporary views with the emaxx buffer.

### DIFF
--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
@@ -363,7 +363,6 @@ void MAMAci::initialize_impl(const RunType run_type) {
   // Allocate memory for the class members
   // (Kokkos::resize only works on host to allocates memory)
   //---------------------------------------------------------------------------------
-
   set_field_w_scratch_buffer(rho_, buffer_, true);
   set_field_w_scratch_buffer(w0_, buffer_, true);
   set_field_w_scratch_buffer(wsub_, buffer_, true);
@@ -401,10 +400,10 @@ void MAMAci::initialize_impl(const RunType run_type) {
   // cloud droplet number mixing ratio [#/kg]
   set_field_w_scratch_buffer(qcld_, buffer_, true);
 
-  init_temporal_views();
-
   // column-integrated droplet number [#/m2]
   set_field_w_scratch_buffer(ndropcol_, buffer_, true);
+
+  init_temporal_views();
 
   // droplet number mixing ratio tendency due to mixing [#/kg/s]
   // Kokkos::resize(ndropmix_, ncol_, nlev_);

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
@@ -65,9 +65,9 @@ void MAMAci::set_grids(
 
   ncol_ = grid_->get_num_local_dofs();       // Number of columns on this rank
   nlev_ = grid_->get_num_vertical_levels();  // Number of levels per column
-  len_temporal_views_ = get_len_temporal_views();
+  len_temporary_views_ = get_len_temporary_views();
   buffer_.set_num_scratch(num_2d_scratch_);
-  buffer_.set_len_temporal_views(len_temporal_views_);
+  buffer_.set_len_temporary_views(len_temporary_views_);
 
   // Define the different field layouts that will be used for this process
   using namespace ShortFieldTagsNames;
@@ -203,7 +203,7 @@ void MAMAci::init_buffers(const ATMBufferManager &buffer_manager) {
       "Error! Used memory != requested memory for MAMMicrophysics.");
 }  // function init_buffers ends
 
-int MAMAci::get_len_temporal_views() {
+int MAMAci::get_len_temporary_views() {
   // tke_
   int work_len = 0;
   work_len += ncol_ * (nlev_ + 1);
@@ -220,8 +220,8 @@ int MAMAci::get_len_temporal_views() {
   return work_len;
 }
 
-void MAMAci::init_temporal_views() {
-  auto work_ptr = (Real *)buffer_.temporal_views.data();
+void MAMAci::init_temporary_views() {
+  auto work_ptr = (Real *)buffer_.temporary_views.data();
   tke_          = view_2d(work_ptr, ncol_, nlev_ + 1);
   work_ptr += ncol_ * (nlev_ + 1);
   // number conc of aerosols activated at supersat [#/m^3]
@@ -272,8 +272,8 @@ void MAMAci::init_temporal_views() {
   /// error check
   // NOTE: workspace_provided can be larger than workspace_used, but let's try
   // to use the minimum amount of memory
-  const int workspace_used     = work_ptr - buffer_.temporal_views.data();
-  const int workspace_provided = buffer_.temporal_views.extent(0);
+  const int workspace_used     = work_ptr - buffer_.temporary_views.data();
+  const int workspace_provided = buffer_.temporary_views.extent(0);
   EKAT_REQUIRE_MSG(workspace_used == workspace_provided,
                    "Error: workspace_used (" + std::to_string(workspace_used) +
                        ") and workspace_provided (" +
@@ -411,7 +411,7 @@ void MAMAci::initialize_impl(const RunType run_type) {
   // column-integrated droplet number [#/m2]
   set_field_w_scratch_buffer(ndropcol_, buffer_, true);
 
-  init_temporal_views();
+  init_temporary_views();
 
   // droplet number mixing ratio tendency due to mixing [#/kg/s]
   // Kokkos::resize(ndropmix_, ncol_, nlev_);

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.hpp
@@ -149,11 +149,12 @@ class MAMAci final : public MAMGenericInterface {
 
   // management of common atm process memory
   size_t requested_buffer_size_in_bytes() const override {
-    return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_, 0);
+    return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_, 0) + sizeof(Real) * len_temporal_views_;
   }
 
   void init_buffers(const ATMBufferManager &buffer_manager) override;
-
+  int get_len_temporal_views();
+  void init_temporal_views();
   // process behavior
   void initialize_impl(const RunType run_type) override;
   void run_impl(const double dt) override;
@@ -221,6 +222,7 @@ class MAMAci final : public MAMGenericInterface {
   mam_coupling::Buffer buffer_;
 
   int num_2d_scratch_= 192;
+  int len_temporal_views_{0};
 
 };  // MAMAci
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.hpp
@@ -122,7 +122,7 @@ class MAMAci final : public MAMGenericInterface {
   view_2d diagnostic_scratch_[hetro_scratch_];
 
   // Subgrid scale velocities
-  view_2d wsub_, wsubice_, wsig_;//, w2_;
+  view_2d wsub_, wsubice_, wsig_;  //, w2_;
 
   // local atmospheric state column variables
   const_view_2d pdel_;       // pressure thickess of layer [Pa]
@@ -149,7 +149,8 @@ class MAMAci final : public MAMGenericInterface {
 
   // management of common atm process memory
   size_t requested_buffer_size_in_bytes() const override {
-    return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_, len_temporal_views_);
+    return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_,
+                                     len_temporal_views_);
   }
 
   void init_buffers(const ATMBufferManager &buffer_manager) override;
@@ -221,7 +222,7 @@ class MAMAci final : public MAMGenericInterface {
   // workspace manager for internal local variables
   mam_coupling::Buffer buffer_;
 
-  int num_2d_scratch_= 94;
+  int num_2d_scratch_ = 94;
   int len_temporal_views_{0};
 
 };  // MAMAci

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.hpp
@@ -149,7 +149,7 @@ class MAMAci final : public MAMGenericInterface {
 
   // management of common atm process memory
   size_t requested_buffer_size_in_bytes() const override {
-    return mam_coupling::buffer_size(ncol_, nlev_);
+    return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_, 0);
   }
 
   void init_buffers(const ATMBufferManager &buffer_manager) override;
@@ -219,6 +219,8 @@ class MAMAci final : public MAMGenericInterface {
   mam_coupling::DryAtmosphere dry_atm_;
   // workspace manager for internal local variables
   mam_coupling::Buffer buffer_;
+
+  int num_2d_scratch_= 192;
 
 };  // MAMAci
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.hpp
@@ -122,7 +122,7 @@ class MAMAci final : public MAMGenericInterface {
   view_2d diagnostic_scratch_[hetro_scratch_];
 
   // Subgrid scale velocities
-  view_2d wsub_, wsubice_, wsig_, w2_;
+  view_2d wsub_, wsubice_, wsig_;//, w2_;
 
   // local atmospheric state column variables
   const_view_2d pdel_;       // pressure thickess of layer [Pa]
@@ -221,7 +221,7 @@ class MAMAci final : public MAMGenericInterface {
   // workspace manager for internal local variables
   mam_coupling::Buffer buffer_;
 
-  int num_2d_scratch_= 192;
+  int num_2d_scratch_= 94;
   int len_temporal_views_{0};
 
 };  // MAMAci

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.hpp
@@ -149,7 +149,7 @@ class MAMAci final : public MAMGenericInterface {
 
   // management of common atm process memory
   size_t requested_buffer_size_in_bytes() const override {
-    return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_, 0) + sizeof(Real) * len_temporal_views_;
+    return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_, len_temporal_views_);
   }
 
   void init_buffers(const ATMBufferManager &buffer_manager) override;

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.hpp
@@ -150,12 +150,12 @@ class MAMAci final : public MAMGenericInterface {
   // management of common atm process memory
   size_t requested_buffer_size_in_bytes() const override {
     return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_,
-                                     len_temporal_views_);
+                                     len_temporary_views_);
   }
 
   void init_buffers(const ATMBufferManager &buffer_manager) override;
-  int get_len_temporal_views();
-  void init_temporal_views();
+  int get_len_temporary_views();
+  void init_temporary_views();
   // process behavior
   void initialize_impl(const RunType run_type) override;
   void run_impl(const double dt) override;
@@ -223,7 +223,7 @@ class MAMAci final : public MAMGenericInterface {
   mam_coupling::Buffer buffer_;
 
   int num_2d_scratch_ = 94;
-  int len_temporal_views_{0};
+  int len_temporary_views_{0};
 
 };  // MAMAci
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_constituent_fluxes_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_constituent_fluxes_interface.cpp
@@ -64,7 +64,7 @@ void MAMConstituentFluxes::set_grids(
 // ON HOST, returns the number of bytes of device memory needed by the above
 // Buffer type given the number of columns and vertical levels
 size_t MAMConstituentFluxes::requested_buffer_size_in_bytes() const {
-  return mam_coupling::buffer_size(ncol_, nlev_);
+  return mam_coupling::buffer_size(ncol_, nlev_, 0, 0);
 }
 
 // ================================================================

--- a/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
@@ -170,7 +170,7 @@ void MAMDryDep::set_grids(
 // the above. Buffer type given the number of columns and vertical
 // levels
 size_t MAMDryDep::requested_buffer_size_in_bytes() const {
-  return mam_coupling::buffer_size(ncol_, nlev_);
+  return mam_coupling::buffer_size(ncol_, nlev_,0, 0);
 }  // requested_buffer_size_in_bytes
 
 // ================================================================
@@ -186,7 +186,7 @@ void MAMDryDep::init_buffers(const ATMBufferManager &buffer_manager) {
       "Error! Insufficient buffer size.\n");
 
   size_t used_mem =
-      mam_coupling::init_buffer(buffer_manager, ncol_, nlev_, buffer_);
+      mam_coupling::init_buffer(buffer_manager, ncol_, nlev_, buffer_, 0);
   EKAT_REQUIRE_MSG(used_mem == requested_buffer_size_in_bytes(),
                    "Error! Used memory != requested memory for MAMDryDep.");
 }  // init_buffers

--- a/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
@@ -35,7 +35,7 @@ void MAMDryDep::set_grids(
 
   ncol_ = grid_->get_num_local_dofs();       // Number of columns on this rank
   nlev_ = grid_->get_num_vertical_levels();  // Number of levels per column
-  len_temporal_views_=get_len_temporal_views();
+  len_temporal_views_ = get_len_temporal_views();
   buffer_.set_len_temporal_views(len_temporal_views_);
 
   // Define the different field layouts that will be used for this process
@@ -172,7 +172,7 @@ void MAMDryDep::set_grids(
 // the above. Buffer type given the number of columns and vertical
 // levels
 size_t MAMDryDep::requested_buffer_size_in_bytes() const {
-  return mam_coupling::buffer_size(ncol_, nlev_, 0, len_temporal_views_) ;
+  return mam_coupling::buffer_size(ncol_, nlev_, 0, len_temporal_views_);
 }  // requested_buffer_size_in_bytes
 
 // ================================================================
@@ -193,76 +193,74 @@ void MAMDryDep::init_buffers(const ATMBufferManager &buffer_manager) {
                    "Error! Used memory != requested memory for MAMDryDep.");
 }  // init_buffers
 
-int MAMDryDep::get_len_temporal_views()
-{
+int MAMDryDep::get_len_temporal_views() {
   constexpr int pcnst = mam4::aero_model::pcnst;
-  int work_len=0;
+  int work_len        = 0;
   // vlc_trb_
-  work_len += mam4::AeroConfig::num_modes()*
-                     aerosol_categories_*ncol_;
+  work_len += mam4::AeroConfig::num_modes() * aerosol_categories_ * ncol_;
   // vlc_grv_, vlc_dry_
-  work_len += 2 * mam4::AeroConfig::num_modes()*
-                     aerosol_categories_*ncol_*nlev_;
+  work_len +=
+      2 * mam4::AeroConfig::num_modes() * aerosol_categories_ * ncol_ * nlev_;
   // rho_
-  work_len +=ncol_*nlev_;
+  work_len += ncol_ * nlev_;
   // qqcw_, dqdt_tmp_, qtracers_, ptend_q_
-  work_len +=4*pcnst*ncol_*nlev_;
+  work_len += 4 * pcnst * ncol_ * nlev_;
   return work_len;
 }
-void MAMDryDep::init_temporal_views()
-{
+void MAMDryDep::init_temporal_views() {
   //-----------------------------------------------------------------
   // Allocate memory
   //-----------------------------------------------------------------
   const int pcnst = mam4::aero_model::pcnst;
-  auto work_ptr = (Real *)buffer_.temporal_views.data();
+  auto work_ptr   = (Real *)buffer_.temporal_views.data();
 
   // Output of the the mixing ratio tendencies [kg/kg/s or 1/kg/s]
   ptend_q_ = view_3d(work_ptr, ncol_, nlev_, pcnst);
-  work_ptr +=ncol_*nlev_*pcnst;
+  work_ptr += ncol_ * nlev_ * pcnst;
 
   // Deposition velocity of turbulent dry deposition [m/s]
   vlc_trb_ = view_3d(work_ptr, mam4::AeroConfig::num_modes(),
                      aerosol_categories_, ncol_);
-  work_ptr += mam4::AeroConfig::num_modes()*
-                     aerosol_categories_*ncol_;
+  work_ptr += mam4::AeroConfig::num_modes() * aerosol_categories_ * ncol_;
 
   // Deposition velocity of gravitational settling [m/s]
   vlc_grv_ = view_4d(work_ptr, mam4::AeroConfig::num_modes(),
                      aerosol_categories_, ncol_, nlev_);
-  work_ptr += mam4::AeroConfig::num_modes()*
-                     aerosol_categories_*ncol_*nlev_;
+  work_ptr +=
+      mam4::AeroConfig::num_modes() * aerosol_categories_ * ncol_ * nlev_;
   // Deposition velocity, [m/s]
   // Fraction landuse weighted sum of vlc_grv and vlc_trb
   vlc_dry_ = view_4d(work_ptr, mam4::AeroConfig::num_modes(),
                      aerosol_categories_, ncol_, nlev_);
-  work_ptr += mam4::AeroConfig::num_modes()*
-                     aerosol_categories_*ncol_*nlev_;
+  work_ptr +=
+      mam4::AeroConfig::num_modes() * aerosol_categories_ * ncol_ * nlev_;
   // Work array to hold the mixing ratios [kg/kg or 1/kg]
   // Packs AerosolState::int_aero_nmr and AerosolState::int_aero_nmr
   // into one array.
   qtracers_ = view_3d(work_ptr, ncol_, nlev_, pcnst);
-  work_ptr += ncol_*nlev_*pcnst;
+  work_ptr += ncol_ * nlev_ * pcnst;
   // Work array to hold the air density [kg/m3]
   rho_ = view_2d(work_ptr, ncol_, nlev_);
-  work_ptr += ncol_*nlev_;
+  work_ptr += ncol_ * nlev_;
   // Work array to hold cloud borne aerosols mixing ratios [kg/kg or 1/kg]
   // Filled with Prognostics::n_mode_c and Prognostics::q_aero_c
   qqcw_ = view_3d(work_ptr, pcnst, ncol_, nlev_);
-  work_ptr +=pcnst*ncol_*nlev_;
+  work_ptr += pcnst * ncol_ * nlev_;
 
   // Work array to hold tendency for 1 species [kg/kg/s] or [1/kg/s]
   dqdt_tmp_ = view_3d(work_ptr, pcnst, ncol_, nlev_);
-  work_ptr+=pcnst*ncol_*nlev_;
+  work_ptr += pcnst * ncol_ * nlev_;
 
   /// error check
-  // NOTE: workspace_provided can be larger than workspace_used, but let's try to use the minimum amount of memory
-  const int workspace_used = work_ptr - buffer_.temporal_views.data();
+  // NOTE: workspace_provided can be larger than workspace_used, but let's try
+  // to use the minimum amount of memory
+  const int workspace_used     = work_ptr - buffer_.temporal_views.data();
   const int workspace_provided = buffer_.temporal_views.extent(0);
   EKAT_REQUIRE_MSG(workspace_used == workspace_provided,
-    "Error: workspace_used (" + std::to_string(workspace_used) +
-    ") and workspace_provided (" + std::to_string(workspace_provided) +
-    ") should be equal. \n");
+                   "Error: workspace_used (" + std::to_string(workspace_used) +
+                       ") and workspace_provided (" +
+                       std::to_string(workspace_provided) +
+                       ") should be equal. \n");
 }
 
 // ================================================================
@@ -316,7 +314,6 @@ void MAMDryDep::initialize_impl(const RunType run_type) {
 
   init_temporal_views();
 
-
   //-----------------------------------------------------------------
   // Read fractional land use data
   //-----------------------------------------------------------------
@@ -335,7 +332,6 @@ void MAMDryDep::initialize_impl(const RunType run_type) {
 void MAMDryDep::run_impl(const double dt) {
   const auto scan_policy = ekat::ExeSpaceUtils<
       KT::ExeSpace>::get_thread_range_parallel_scan_team_policy(ncol_, nlev_);
-
 
   // preprocess input -- needs a scan for the calculation of atm height
   pre_process(wet_aero_, dry_aero_, wet_atm_, dry_atm_);

--- a/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
@@ -172,7 +172,7 @@ void MAMDryDep::set_grids(
 // the above. Buffer type given the number of columns and vertical
 // levels
 size_t MAMDryDep::requested_buffer_size_in_bytes() const {
-  return mam_coupling::buffer_size(ncol_, nlev_, 0, 0)+ sizeof(Real) * len_temporal_views_;
+  return mam_coupling::buffer_size(ncol_, nlev_, 0, len_temporal_views_) ;
 }  // requested_buffer_size_in_bytes
 
 // ================================================================
@@ -188,7 +188,7 @@ void MAMDryDep::init_buffers(const ATMBufferManager &buffer_manager) {
       "Error! Insufficient buffer size.\n");
 
   size_t used_mem =
-      mam_coupling::init_buffer(buffer_manager, ncol_, nlev_, buffer_, 0);
+      mam_coupling::init_buffer(buffer_manager, ncol_, nlev_, buffer_);
   EKAT_REQUIRE_MSG(used_mem == requested_buffer_size_in_bytes(),
                    "Error! Used memory != requested memory for MAMDryDep.");
 }  // init_buffers

--- a/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.hpp
@@ -104,9 +104,9 @@ class MAMDryDep final : public MAMGenericInterface {
   // workspace manager for internal local variables
   mam_coupling::Buffer buffer_;
 
-  int get_len_temporal_views();
-  void init_temporal_views();
-  int len_temporal_views_{0};
+  int get_len_temporary_views();
+  void init_temporary_views();
+  int len_temporary_views_{0};
 
  public:
   using KT = ekat::KokkosTypes<DefaultDevice>;

--- a/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.hpp
@@ -104,6 +104,10 @@ class MAMDryDep final : public MAMGenericInterface {
   // workspace manager for internal local variables
   mam_coupling::Buffer buffer_;
 
+  int get_len_temporal_views();
+  void init_temporal_views();
+  int len_temporal_views_{0};
+
  public:
   using KT = ekat::KokkosTypes<DefaultDevice>;
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.cpp
@@ -224,8 +224,10 @@ void MAMGenericInterface::set_field_w_scratch_buffer(mam_coupling::view_2d& var,
   var = buffer.scratch[i_scratch_vars_];
   i_scratch_vars_++;
   EKAT_REQUIRE_MSG(
-      i_scratch_vars_ < buffer.max_num_2d_scratch ,
-      "Error! Insufficient number of scratch size in mam buffer.\n");
+      i_scratch_vars_ < buffer.num_2d_scratch ,
+      "Error! Insufficient number of scratch size in mam buffer.\n"
+      "  - i_scratch_vars_: " + std::to_string(i_scratch_vars_) + "\n"
+      "  -  buffer.num_2d_scratch: " +  std::to_string(buffer.num_2d_scratch) + "\n");
   if (set_to_zero){
     Kokkos::deep_copy(var, 0.0);
   }

--- a/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.cpp
@@ -218,6 +218,19 @@ void MAMGenericInterface::populate_cloudborne_dry_aero(
   }
 }
 // ================================================================
+void MAMGenericInterface::set_field_w_scratch_buffer(mam_coupling::view_2d& var,
+  mam_coupling::Buffer &buffer, const bool set_to_zero)
+{
+  var = buffer.scratch[i_scratch_vars_];
+  i_scratch_vars_++;
+  EKAT_REQUIRE_MSG(
+      i_scratch_vars_ < buffer.max_num_2d_scratch ,
+      "Error! Insufficient number of scratch size in mam buffer.\n");
+  if (set_to_zero){
+    Kokkos::deep_copy(var, 0.0);
+  }
+}
+// ================================================================
 void MAMGenericInterface::populate_gases_dry_aero(
     mam_coupling::AerosolState &dry_aero, mam_coupling::Buffer &buffer) {
   for(int g = 0; g < mam_coupling::num_aero_gases(); ++g) {

--- a/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.cpp
@@ -239,7 +239,13 @@ void MAMGenericInterface::populate_gases_dry_aero(
     dry_aero.gas_mmr[g] = buffer.dry_gas_mmr[g];
   }
 }
-
+// ================================================================
+void  MAMGenericInterface::set_buffer_scratch_to_zero(mam_coupling::Buffer &buffer)
+{
+  for(int f = 0; f <  buffer.num_2d_scratch; ++f){
+    Kokkos::deep_copy(buffer.scratch[f],0.0);
+  }
+}
 // ================================================================
 void MAMGenericInterface::populate_gases_wet_aero(
     mam_coupling::AerosolState &wet_aero) {

--- a/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.cpp
@@ -218,17 +218,19 @@ void MAMGenericInterface::populate_cloudborne_dry_aero(
   }
 }
 // ================================================================
-void MAMGenericInterface::set_field_w_scratch_buffer(mam_coupling::view_2d& var,
-  mam_coupling::Buffer &buffer, const bool set_to_zero)
-{
+void MAMGenericInterface::set_field_w_scratch_buffer(
+    mam_coupling::view_2d &var, mam_coupling::Buffer &buffer,
+    const bool set_to_zero) {
   var = buffer.scratch[i_scratch_vars_];
   i_scratch_vars_++;
-  EKAT_REQUIRE_MSG(
-      i_scratch_vars_ < buffer.num_2d_scratch ,
-      "Error! Insufficient number of scratch size in mam buffer.\n"
-      "  - i_scratch_vars_: " + std::to_string(i_scratch_vars_) + "\n"
-      "  -  buffer.num_2d_scratch: " +  std::to_string(buffer.num_2d_scratch) + "\n");
-  if (set_to_zero){
+  EKAT_REQUIRE_MSG(i_scratch_vars_ < buffer.num_2d_scratch,
+                   "Error! Insufficient number of scratch size in mam buffer.\n"
+                   "  - i_scratch_vars_: " +
+                       std::to_string(i_scratch_vars_) +
+                       "\n"
+                       "  -  buffer.num_2d_scratch: " +
+                       std::to_string(buffer.num_2d_scratch) + "\n");
+  if(set_to_zero) {
     Kokkos::deep_copy(var, 0.0);
   }
 }
@@ -240,10 +242,10 @@ void MAMGenericInterface::populate_gases_dry_aero(
   }
 }
 // ================================================================
-void  MAMGenericInterface::set_buffer_scratch_to_zero(mam_coupling::Buffer &buffer)
-{
-  for(int f = 0; f <  buffer.num_2d_scratch; ++f){
-    Kokkos::deep_copy(buffer.scratch[f],0.0);
+void MAMGenericInterface::set_buffer_scratch_to_zero(
+    mam_coupling::Buffer &buffer) {
+  for(int f = 0; f < buffer.num_2d_scratch; ++f) {
+    Kokkos::deep_copy(buffer.scratch[f], 0.0);
   }
 }
 // ================================================================

--- a/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.hpp
@@ -64,6 +64,8 @@ class MAMGenericInterface : public scream::AtmosphereProcess {
                     mam_coupling::AerosolState &dry_aero,
                     mam_coupling::DryAtmosphere &dry_atm);
   // Physics grid for column information.
+  void set_field_w_scratch_buffer(mam_coupling::view_2d& var,
+  mam_coupling::Buffer &buffer, const bool set_to_zero);
   std::shared_ptr<const AbstractGrid> grid_;
   bool check_fields_intervals_{false};
   // number of horizontal columns and vertical levels
@@ -81,6 +83,7 @@ class MAMGenericInterface : public scream::AtmosphereProcess {
   const std::pair<Real, Real> get_ranges(const std::string &field_name);
   std::map<std::string, std::pair<Real, Real>> max_min_process_;
   bool set_ranges_{false};
+  int i_scratch_vars_{0};
 
 };  // MAMGenericInterface
 }  // namespace scream

--- a/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.hpp
@@ -72,6 +72,7 @@ class MAMGenericInterface : public scream::AtmosphereProcess {
   int ncol_, nlev_;
   void set_ranges_process(
       const std::map<std::string, std::pair<Real, Real>> &max_min_process);
+  void set_buffer_scratch_to_zero(mam_coupling::Buffer &buffer);
 
  private:
   // The type of subcomponent

--- a/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.hpp
@@ -64,8 +64,9 @@ class MAMGenericInterface : public scream::AtmosphereProcess {
                     mam_coupling::AerosolState &dry_aero,
                     mam_coupling::DryAtmosphere &dry_atm);
   // Physics grid for column information.
-  void set_field_w_scratch_buffer(mam_coupling::view_2d& var,
-  mam_coupling::Buffer &buffer, const bool set_to_zero);
+  void set_field_w_scratch_buffer(mam_coupling::view_2d &var,
+                                  mam_coupling::Buffer &buffer,
+                                  const bool set_to_zero);
   std::shared_ptr<const AbstractGrid> grid_;
   bool check_fields_intervals_{false};
   // number of horizontal columns and vertical levels

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -344,7 +344,7 @@ void MAMMicrophysics::set_grids(
 // the above. Buffer type given the number of columns and vertical
 // levels
 size_t MAMMicrophysics::requested_buffer_size_in_bytes() const {
-  return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_, 0) + sizeof(Real) * len_temporal_views_;
+  return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_, len_temporal_views_);
 }
 
 // ================================================================
@@ -357,7 +357,7 @@ size_t MAMMicrophysics::requested_buffer_size_in_bytes() const {
 
 void MAMMicrophysics::init_buffers(const ATMBufferManager &buffer_manager) {
   size_t used_mem =
-      mam_coupling::init_buffer(buffer_manager, ncol_, nlev_, buffer_, 0);
+      mam_coupling::init_buffer(buffer_manager, ncol_, nlev_, buffer_);
   EKAT_REQUIRE_MSG(used_mem == requested_buffer_size_in_bytes(),
                    "Error! Used memory != requested memory for MAMMicrophysics."
                    " Used memory: "

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -339,7 +339,7 @@ void MAMMicrophysics::set_grids(
 // the above. Buffer type given the number of columns and vertical
 // levels
 size_t MAMMicrophysics::requested_buffer_size_in_bytes() const {
-  return mam_coupling::buffer_size(ncol_, nlev_);
+  return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_, 0);
 }
 
 // ================================================================
@@ -351,8 +351,9 @@ size_t MAMMicrophysics::requested_buffer_size_in_bytes() const {
 // number of bytes allocated.
 
 void MAMMicrophysics::init_buffers(const ATMBufferManager &buffer_manager) {
+  buffer_.set_num_scratch(num_2d_scratch_);
   size_t used_mem =
-      mam_coupling::init_buffer(buffer_manager, ncol_, nlev_, buffer_);
+      mam_coupling::init_buffer(buffer_manager, ncol_, nlev_, buffer_, 0);
   EKAT_REQUIRE_MSG(used_mem == requested_buffer_size_in_bytes(),
                    "Error! Used memory != requested memory for MAMMicrophysics."
                    " Used memory: "

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -53,6 +53,17 @@ void MAMMicrophysics::set_grids(
   ncol_ = grid_->get_num_local_dofs();       // number of columns on this rank
   nlev_ = grid_->get_num_vertical_levels();  // number of levels per column
 
+  // create our photolysis rate calculation table
+  const std::string rsf_file = m_params.get<std::string>("mam4_rsf_file");
+  const std::string xs_long_file =
+      m_params.get<std::string>("mam4_xs_long_file");
+
+  photo_table_ = impl::read_photo_table(rsf_file, xs_long_file);
+  // NOTE: we need photo_table_ before getting len_temporal_views_.
+  len_temporal_views_=get_len_temporal_views();
+  buffer_.set_len_temporal_views(len_temporal_views_);
+  buffer_.set_num_scratch(num_2d_scratch_);
+
   // get column geometry and locations
   col_latitudes_ = grid_->get_geometry_data("lat").get_view<const Real *>();
 
@@ -324,12 +335,6 @@ void MAMMicrophysics::set_grids(
     mam_coupling::find_season_index_reader(season_wes_file, clat,
                                            index_season_lai_);
   }
-
-  // Work arrays for return values from
-  // perform_atmospheric_chemistry_and_microphysics
-  constexpr int gas_pcnst = mam_coupling::gas_pcnst();
-  dflx_                   = view_2d("dflx", ncol_, gas_pcnst);
-  dvel_                   = view_2d("dvel", ncol_, gas_pcnst);
 }  // set_grids
 
 // ================================================================
@@ -339,7 +344,7 @@ void MAMMicrophysics::set_grids(
 // the above. Buffer type given the number of columns and vertical
 // levels
 size_t MAMMicrophysics::requested_buffer_size_in_bytes() const {
-  return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_, 0);
+  return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_, 0) + sizeof(Real) * len_temporal_views_;
 }
 
 // ================================================================
@@ -351,7 +356,6 @@ size_t MAMMicrophysics::requested_buffer_size_in_bytes() const {
 // number of bytes allocated.
 
 void MAMMicrophysics::init_buffers(const ATMBufferManager &buffer_manager) {
-  buffer_.set_num_scratch(num_2d_scratch_);
   size_t used_mem =
       mam_coupling::init_buffer(buffer_manager, ncol_, nlev_, buffer_, 0);
   EKAT_REQUIRE_MSG(used_mem == requested_buffer_size_in_bytes(),
@@ -363,7 +367,52 @@ void MAMMicrophysics::init_buffers(const ATMBufferManager &buffer_manager) {
                        << std::to_string(requested_buffer_size_in_bytes())
                        << ". \n");
 }
+int MAMMicrophysics::get_len_temporal_views()
+{
+  const int photo_table_len = get_photo_table_work_len(photo_table_);
+  const int sethet_work_len = mam4::mo_sethet::get_total_work_len_sethet();
+  constexpr int extcnt = mam4::gas_chemistry::extcnt;
+  int work_len=0;
+  // work_photo_table_
+  work_len += ncol_*photo_table_len;
+  // work_set_het_
+  work_len += ncol_*sethet_work_len;
+  // photo_rates_
+  work_len += ncol_*nlev_*mam4::mo_photo::phtcnt;
+  // invariants_
+  work_len += ncol_*nlev_*mam4::gas_chemistry::nfs;
+  // extfrc_
+  work_len +=ncol_*nlev_*extcnt;
+  // dflx_, dvel_
+  constexpr int gas_pcnst = mam_coupling::gas_pcnst();
+  work_len+=2*ncol_*gas_pcnst;
+  return work_len;
+}
+void MAMMicrophysics::init_temporal_views()
+{
+  const int photo_table_len = get_photo_table_work_len(photo_table_);
+  const int sethet_work_len = mam4::mo_sethet::get_total_work_len_sethet();
+  constexpr int extcnt = mam4::gas_chemistry::extcnt;
+  auto work_ptr = (Real *)buffer_.temporal_views.data();
 
+  work_photo_table_ = view_2d(work_ptr, ncol_, photo_table_len);
+  work_ptr += ncol_*photo_table_len;
+  work_set_het_ = view_2d(work_ptr, ncol_, sethet_work_len);
+  work_ptr += ncol_*sethet_work_len;
+  // here's where we store per-column photolysis rates
+  photo_rates_ = view_3d(work_ptr, ncol_, nlev_, mam4::mo_photo::phtcnt);
+  work_ptr += ncol_*nlev_*mam4::mo_photo::phtcnt;
+  invariants_ = view_3d(work_ptr, ncol_, nlev_, mam4::gas_chemistry::nfs);
+  work_ptr += ncol_*nlev_*mam4::gas_chemistry::nfs;
+  extfrc_              = view_3d(work_ptr, ncol_, nlev_, extcnt);
+  work_ptr +=ncol_*nlev_*extcnt;
+  // Work arrays for return values from perform_atmospheric_chemistry_and_microphysics
+  constexpr int gas_pcnst = mam_coupling::gas_pcnst();
+  dflx_ = view_2d(work_ptr, ncol_, gas_pcnst);
+  work_ptr += ncol_*gas_pcnst;
+  dvel_ = view_2d(work_ptr, ncol_, gas_pcnst);
+  work_ptr +=ncol_*gas_pcnst;
+}
 // ================================================================
 //  INITIALIZE_IMPL
 // ================================================================
@@ -424,12 +473,7 @@ void MAMMicrophysics::initialize_impl(const RunType run_type) {
   // cloudborne aerosol, e.g., soa_c_1
   populate_cloudborne_dry_aero(dry_aero_, buffer_);
 
-  // create our photolysis rate calculation table
-  const std::string rsf_file = m_params.get<std::string>("mam4_rsf_file");
-  const std::string xs_long_file =
-      m_params.get<std::string>("mam4_xs_long_file");
 
-  photo_table_ = impl::read_photo_table(rsf_file, xs_long_file);
 
   // set field property checks for the fields in this process
   /* e.g.
@@ -468,15 +512,9 @@ void MAMMicrophysics::initialize_impl(const RunType run_type) {
         chlorine_time_secs_);
   }  // LINOZ
 
-  const int photo_table_len = get_photo_table_work_len(photo_table_);
-  work_photo_table_ = view_2d("work_photo_table", ncol_, photo_table_len);
-  const int sethet_work_len = mam4::mo_sethet::get_total_work_len_sethet();
-  work_set_het_ = view_2d("work_set_het_array", ncol_, sethet_work_len);
+  init_temporal_views();
+  // FIXME : why are we only using nlev_ instead of ncol_xnlev?
   cmfdqr_       = view_1d("cmfdqr_", nlev_);
-
-  // here's where we store per-column photolysis rates
-  photo_rates_ = view_3d("photo_rates", ncol_, nlev_, mam4::mo_photo::phtcnt);
-
   // Load the first month into extfrc_lst_end.
   // Note: At the first time step, the data will be moved into extfrc_lst_beg,
   //       and extfrc_lst_end will be reloaded from file with the new month.
@@ -493,13 +531,7 @@ void MAMMicrophysics::initialize_impl(const RunType run_type) {
         ElevatedEmissionsDataReader_[i], curr_month,
         *ElevatedEmissionsHorizInterp_[i], elevated_emis_data_[i]);
   }
-
-  invariants_ = view_3d("invarians", ncol_, nlev_, mam4::gas_chemistry::nfs);
-
-  constexpr int extcnt = mam4::gas_chemistry::extcnt;
-  extfrc_              = view_3d("extfrc_", ncol_, nlev_, extcnt);
-
-  //
+  // //
   acos_cosine_zenith_host_ = view_1d_host("host_acos(cosine_zenith)", ncol_);
   acos_cosine_zenith_      = view_1d("device_acos(cosine_zenith)", ncol_);
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -412,6 +412,14 @@ void MAMMicrophysics::init_temporal_views()
   work_ptr += ncol_*gas_pcnst;
   dvel_ = view_2d(work_ptr, ncol_, gas_pcnst);
   work_ptr +=ncol_*gas_pcnst;
+      /// error check
+    // NOTE: workspace_provided can be larger than workspace_used, but let's try to use the minimum amount of memory
+    const int workspace_used = work_ptr - buffer_.temporal_views.data();
+    const int workspace_provided = buffer_.temporal_views.extent(0);
+    EKAT_REQUIRE_MSG(workspace_used == workspace_provided,
+    "Error: workspace_used (" + std::to_string(workspace_used) +
+    ") and workspace_provided (" + std::to_string(workspace_provided) +
+    ") should be equal. \n");
 }
 // ================================================================
 //  INITIALIZE_IMPL

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
@@ -158,9 +158,9 @@ class MAMMicrophysics final : public MAMGenericInterface {
   view_2d dflx_;
   view_2d dvel_;
   int num_2d_scratch_ = 9;
-  int get_len_temporal_views();
-  void init_temporal_views();
-  int len_temporal_views_{0};
+  int get_len_temporary_views();
+  void init_temporary_views();
+  int len_temporary_views_{0};
 
 };  // MAMMicrophysics
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
@@ -157,6 +157,7 @@ class MAMMicrophysics final : public MAMGenericInterface {
   // perform_atmospheric_chemistry_and_microphysics
   view_2d dflx_;
   view_2d dvel_;
+  int num_2d_scratch_= 9;
 };  // MAMMicrophysics
 
 }  // namespace scream

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
@@ -158,6 +158,10 @@ class MAMMicrophysics final : public MAMGenericInterface {
   view_2d dflx_;
   view_2d dvel_;
   int num_2d_scratch_= 9;
+  int get_len_temporal_views();
+  void init_temporal_views();
+  int len_temporal_views_{0};
+
 };  // MAMMicrophysics
 
 }  // namespace scream

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
@@ -157,7 +157,7 @@ class MAMMicrophysics final : public MAMGenericInterface {
   // perform_atmospheric_chemistry_and_microphysics
   view_2d dflx_;
   view_2d dvel_;
-  int num_2d_scratch_= 9;
+  int num_2d_scratch_ = 9;
   int get_len_temporal_views();
   void init_temporal_views();
   int len_temporal_views_{0};

--- a/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
@@ -32,8 +32,8 @@ void MAMOptics::set_grids(
   nswbands_ = mam4::modal_aer_opt::nswbands;     // number of shortwave bands
   nlwbands_ = mam4::modal_aer_opt::nlwbands;     // number of longwave bands
 
-  len_temporal_views_ = get_len_temporal_views();
-  buffer_.set_len_temporal_views(len_temporal_views_);
+  len_temporary_views_ = get_len_temporary_views();
+  buffer_.set_len_temporary_views(len_temporary_views_);
   buffer_.set_num_scratch(num_2d_scratch_);
   // Define the different field layouts that will be used for this process
 
@@ -92,10 +92,10 @@ void MAMOptics::set_grids(
 
 size_t MAMOptics::requested_buffer_size_in_bytes() const {
   return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_,
-                                   len_temporal_views_);
+                                   len_temporary_views_);
 }
 
-int MAMOptics::get_len_temporal_views() {
+int MAMOptics::get_len_temporary_views() {
   int work_len = 0;
   // work_
   work_len += ncol_ * mam4::modal_aer_opt::get_work_len_aerosol_optics();
@@ -104,8 +104,8 @@ int MAMOptics::get_len_temporal_views() {
   work_len += 4 * ncol_ * nswbands_ * nlev_f;
   return work_len;
 }
-void MAMOptics::init_temporal_views() {
-  auto work_ptr      = (Real *)buffer_.temporal_views.data();
+void MAMOptics::init_temporary_views() {
+  auto work_ptr      = (Real *)buffer_.temporary_views.data();
   const int work_len = mam4::modal_aer_opt::get_work_len_aerosol_optics();
   work_              = mam_coupling::view_2d(work_ptr, ncol_, work_len);
   work_ptr += ncol_ * work_len;
@@ -127,8 +127,8 @@ void MAMOptics::init_temporal_views() {
   /// error check
   // NOTE: workspace_provided can be larger than workspace_used, but let's try
   // to use the minimum amount of memory
-  const int workspace_used     = work_ptr - buffer_.temporal_views.data();
-  const int workspace_provided = buffer_.temporal_views.extent(0);
+  const int workspace_used     = work_ptr - buffer_.temporary_views.data();
+  const int workspace_provided = buffer_.temporary_views.extent(0);
   EKAT_REQUIRE_MSG(workspace_used == workspace_provided,
                    "Error: workspace_used (" + std::to_string(workspace_used) +
                        ") and workspace_provided (" +
@@ -201,7 +201,7 @@ void MAMOptics::initialize_impl(const RunType run_type) {
   ext_cmip6_lw_ =
       mam_coupling::view_3d("ext_cmip6_lw_", ncol_, nlev_, nlwbands_);
 
-  init_temporal_views();
+  init_temporary_views();
 
   // read table info
   {

--- a/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
@@ -32,7 +32,7 @@ void MAMOptics::set_grids(
   nswbands_ = mam4::modal_aer_opt::nswbands;     // number of shortwave bands
   nlwbands_ = mam4::modal_aer_opt::nlwbands;     // number of longwave bands
 
-  len_temporal_views_=get_len_temporal_views();
+  len_temporal_views_ = get_len_temporal_views();
   buffer_.set_len_temporal_views(len_temporal_views_);
   buffer_.set_num_scratch(num_2d_scratch_);
   // Define the different field layouts that will be used for this process
@@ -91,51 +91,49 @@ void MAMOptics::set_grids(
 }
 
 size_t MAMOptics::requested_buffer_size_in_bytes() const {
-  return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_, len_temporal_views_);
+  return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_,
+                                   len_temporal_views_);
 }
 
-int MAMOptics::get_len_temporal_views()
-{
-  int work_len=0;
+int MAMOptics::get_len_temporal_views() {
+  int work_len = 0;
   // work_
-  work_len += ncol_*mam4::modal_aer_opt::get_work_len_aerosol_optics();
+  work_len += ncol_ * mam4::modal_aer_opt::get_work_len_aerosol_optics();
   // tau_ssa_g_sw_, tau_ssa_sw_, tau_sw_, tau_f_sw_
   const int nlev_f = nlev_ + 1;
-  work_len+= 4*ncol_*nswbands_*nlev_f;
+  work_len += 4 * ncol_ * nswbands_ * nlev_f;
   return work_len;
 }
-void MAMOptics::init_temporal_views()
-{
-  auto work_ptr = (Real *)buffer_.temporal_views.data();
+void MAMOptics::init_temporal_views() {
+  auto work_ptr      = (Real *)buffer_.temporal_views.data();
   const int work_len = mam4::modal_aer_opt::get_work_len_aerosol_optics();
-  work_              = mam_coupling::view_2d(work_ptr, ncol_, work_len );
-  work_ptr += ncol_*work_len;
+  work_              = mam_coupling::view_2d(work_ptr, ncol_, work_len);
+  work_ptr += ncol_ * work_len;
 
   // shortwave aerosol scattering asymmetry parameter [unitless]
-  tau_ssa_g_sw_ =
-      mam_coupling::view_3d(work_ptr, ncol_, nswbands_, nlev_ + 1);
+  tau_ssa_g_sw_ = mam_coupling::view_3d(work_ptr, ncol_, nswbands_, nlev_ + 1);
   const int nlev_f = nlev_ + 1;
-  work_ptr += ncol_*nswbands_*nlev_f;
+  work_ptr += ncol_ * nswbands_ * nlev_f;
   // shortwave aerosol single-scattering albedo [unitless]
-  tau_ssa_sw_ =
-      mam_coupling::view_3d(work_ptr, ncol_, nswbands_, nlev_ + 1);
-  work_ptr += ncol_*nswbands_*nlev_f;
+  tau_ssa_sw_ = mam_coupling::view_3d(work_ptr, ncol_, nswbands_, nlev_ + 1);
+  work_ptr += ncol_ * nswbands_ * nlev_f;
   // shortwave aerosol extinction optical depth [unitless]
   tau_sw_ = mam_coupling::view_3d(work_ptr, ncol_, nswbands_, nlev_ + 1);
-  work_ptr += ncol_*nswbands_*nlev_f;
+  work_ptr += ncol_ * nswbands_ * nlev_f;
   // aerosol forward scattered fraction * tau * w
   tau_f_sw_ = mam_coupling::view_3d(work_ptr, ncol_, nswbands_, nlev_ + 1);
-  work_ptr += ncol_*nswbands_*nlev_f;
+  work_ptr += ncol_ * nswbands_ * nlev_f;
 
-      /// error check
-    // NOTE: workspace_provided can be larger than workspace_used, but let's try to use the minimum amount of memory
-    const int workspace_used = work_ptr - buffer_.temporal_views.data();
-    const int workspace_provided = buffer_.temporal_views.extent(0);
-    EKAT_REQUIRE_MSG(workspace_used == workspace_provided,
-    "Error: workspace_used (" + std::to_string(workspace_used) +
-    ") and workspace_provided (" + std::to_string(workspace_provided) +
-    ") should be equal. \n");
-
+  /// error check
+  // NOTE: workspace_provided can be larger than workspace_used, but let's try
+  // to use the minimum amount of memory
+  const int workspace_used     = work_ptr - buffer_.temporal_views.data();
+  const int workspace_provided = buffer_.temporal_views.extent(0);
+  EKAT_REQUIRE_MSG(workspace_used == workspace_provided,
+                   "Error: workspace_used (" + std::to_string(workspace_used) +
+                       ") and workspace_provided (" +
+                       std::to_string(workspace_provided) +
+                       ") should be equal. \n");
 }
 
 void MAMOptics::init_buffers(const ATMBufferManager &buffer_manager) {

--- a/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
@@ -91,7 +91,7 @@ void MAMOptics::set_grids(
 }
 
 size_t MAMOptics::requested_buffer_size_in_bytes() const {
-  return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_, 0) + sizeof(Real) * len_temporal_views_;
+  return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_, len_temporal_views_);
 }
 
 int MAMOptics::get_len_temporal_views()
@@ -152,7 +152,7 @@ void MAMOptics::init_buffers(const ATMBufferManager &buffer_manager) {
       "Error! Insufficient buffer size.\n");
 
   size_t used_mem =
-      mam_coupling::init_buffer(buffer_manager, ncol_, nlev_, buffer_, 0);
+      mam_coupling::init_buffer(buffer_manager, ncol_, nlev_, buffer_);
   EKAT_REQUIRE_MSG(used_mem == requested_buffer_size_in_bytes(),
                    "Error! Used memory != requested memory for MAMMOptics.");
 }

--- a/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.hpp
@@ -89,9 +89,12 @@ class MAMOptics final : public MAMGenericInterface {
   // parameters for calcsize
   mam4::modal_aer_opt::CalcsizeData calsize_data_;
 
-  int work_len_;
-
   int num_2d_scratch_= 8;
+
+  int get_len_temporal_views();
+  void init_temporal_views();
+  int len_temporal_views_{0};
+
 };  // MAMOptics
 
 }  // namespace scream

--- a/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.hpp
@@ -88,6 +88,10 @@ class MAMOptics final : public MAMGenericInterface {
   mam_coupling::Buffer buffer_;
   // parameters for calcsize
   mam4::modal_aer_opt::CalcsizeData calsize_data_;
+
+  int work_len_;
+
+  int num_2d_scratch_= 8;
 };  // MAMOptics
 
 }  // namespace scream

--- a/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.hpp
@@ -91,9 +91,9 @@ class MAMOptics final : public MAMGenericInterface {
 
   int num_2d_scratch_= 8;
 
-  int get_len_temporal_views();
-  void init_temporal_views();
-  int len_temporal_views_{0};
+  int get_len_temporary_views();
+  void init_temporary_views();
+  int len_temporary_views_{0};
 
 };  // MAMOptics
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
@@ -256,7 +256,7 @@ void MAMSrfOnlineEmiss::set_grids(
 // ON HOST, returns the number of bytes of device memory needed by the above
 // Buffer type given the number of columns and vertical levels
 size_t MAMSrfOnlineEmiss::requested_buffer_size_in_bytes() const {
-  return mam_coupling::buffer_size(ncol_, nlev_);
+  return mam_coupling::buffer_size(ncol_, nlev_, 0, 0);
 }
 
 // ================================================================

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
@@ -35,6 +35,7 @@ void MAMWetscav::set_grids(
   nlev_ = grid_->get_num_vertical_levels();  // Number of levels per column
   const int nmodes    = mam4::AeroConfig::num_modes();  // Number of modes
   constexpr int pcnst = mam4::aero_model::pcnst;
+  set_work_len();
 
   // layout for 3D (2d horiz X 1d vertical) variables at level
   // midpoints/interfaces
@@ -158,6 +159,11 @@ void MAMWetscav::set_grids(
   add_field<Computed>("aerdepwetcw", scalar2d_pconst, kg / m2 / s, grid_name);
 }
 
+void MAMWetscav::set_work_len()
+{
+  work_len_ = mam4::wetdep::get_aero_model_wetdep_work_len();
+}
+
 // ================================================================
 //  INIT_BUFFERS
 // ================================================================
@@ -165,15 +171,20 @@ void MAMWetscav::set_grids(
 // intermediate (dry) quantities on the given number of columns with the given
 // number of vertical levels. Returns the number of bytes allocated.
 void MAMWetscav::init_buffers(const ATMBufferManager &buffer_manager) {
+
   EKAT_REQUIRE_MSG(
       buffer_manager.allocated_bytes() >= requested_buffer_size_in_bytes(),
       "Error! Insufficient buffer size.\n");
 
+  buffer_.set_num_scratch(num_2d_scratch_);
   size_t used_mem =
-      mam_coupling::init_buffer(buffer_manager, ncol_, nlev_, buffer_);
+      mam_coupling::init_buffer(buffer_manager, ncol_, nlev_, buffer_, work_len_);
+  std::cout << "used_mem " << used_mem << "requested_buffer_size_in_bytes() "<< requested_buffer_size_in_bytes() << "\n";
   EKAT_REQUIRE_MSG(used_mem == requested_buffer_size_in_bytes(),
                    "Error! Used memory != requested memory for MAMWetscav.");
 }
+
+
 
 // ================================================================
 //  INITIALIZE_IMPL
@@ -233,64 +244,49 @@ void MAMWetscav::initialize_impl(const RunType run_type) {
   //---------------------------------------------------------------------------------
   // Alllocate aerosol-related gas tendencies
   for(int g = 0; g < mam_coupling::num_aero_gases(); ++g) {
-    dry_aero_tends_.gas_mmr[g] = view_2d("gas_mmr", ncol_, nlev_);
+    set_field_w_scratch_buffer(dry_aero_tends_.gas_mmr[g], buffer_, true);
   }
 
   // Allocate aerosol state tendencies (interstitial aerosols only)
   for(int imode = 0; imode < mam_coupling::num_aero_modes(); ++imode) {
-    dry_aero_tends_.int_aero_nmr[imode] = view_2d("int_aero_nmr", ncol_, nlev_);
+    set_field_w_scratch_buffer(dry_aero_tends_.int_aero_nmr[imode], buffer_, true);
 
     for(int ispec = 0; ispec < mam_coupling::num_aero_species(); ++ispec) {
-      dry_aero_tends_.int_aero_mmr[imode][ispec] =
-          view_2d("int_aero_mmr", ncol_, nlev_);
+      set_field_w_scratch_buffer(dry_aero_tends_.int_aero_mmr[imode][ispec], buffer_, true);
     }
   }
-
   // Allocate work array
   const int work_len = mam4::wetdep::get_aero_model_wetdep_work_len();
   work_              = view_2d("work", ncol_, work_len);
   isprx_             = int_view_2d("isprx", ncol_, nlev_);
   // TODO: Following variables are from convective parameterization (not
   // implemented yet in EAMxx), so should be zero for now
-
-  sh_frac_ = view_2d("sh_frac", ncol_, nlev_);
-  Kokkos::deep_copy(sh_frac_, 0);
+  set_field_w_scratch_buffer(sh_frac_, buffer_, true);
 
   // Deep convective cloud fraction [fraction]
-  dp_frac_ = view_2d("dp_frac", ncol_, nlev_);
-  Kokkos::deep_copy(dp_frac_, 0);
+  set_field_w_scratch_buffer(dp_frac_, buffer_, true);
 
   // Evaporation rate of shallow convective precipitation >=0. [kg/kg/s]
-  evapcsh_ = view_2d("evapcsh", ncol_, nlev_);
-  Kokkos::deep_copy(evapcsh_, 0);
+  set_field_w_scratch_buffer(evapcsh_, buffer_, true);
 
   // Evaporation rate of deep convective precipitation >=0. [kg/kg/s]
-  evapcdp_ = view_2d("evapcdp", ncol_, nlev_);
-  Kokkos::deep_copy(evapcdp_, 0);
+  set_field_w_scratch_buffer(evapcdp_, buffer_, true);
 
   // Rain production, shallow convection [kg/kg/s]
-  rprdsh_ = view_2d("rprdsh", ncol_, nlev_);
-  Kokkos::deep_copy(rprdsh_, 0);
+  set_field_w_scratch_buffer(rprdsh_, buffer_, true);
 
   // Rain production, deep convection [kg/kg/s]
-  rprddp_ = view_2d("rprddp", ncol_, nlev_);
-  Kokkos::deep_copy(rprddp_, 0);
+  set_field_w_scratch_buffer(rprddp_, buffer_, true);
 
   // In cloud water mixing ratio, deep convection
-  icwmrdp_ = view_2d("icwmrdp", ncol_, nlev_);
-  Kokkos::deep_copy(icwmrdp_, 0);
+  set_field_w_scratch_buffer(icwmrdp_, buffer_, true);
 
   // In cloud water mixing ratio, shallow convection
-  icwmrsh_ = view_2d("icwmrsh", ncol_, nlev_);
-  Kokkos::deep_copy(icwmrsh_, 0);
+  set_field_w_scratch_buffer(icwmrsh_, buffer_, true);
 
   // Detraining cld H20 from deep convection [kg/kg/s]
-  dlf_ = view_2d("dlf", ncol_, nlev_);
-  Kokkos::deep_copy(dlf_, 0);
+  set_field_w_scratch_buffer(dlf_, buffer_, true);
 
-  calsize_data_.initialize();
-  // wetscav uses update_mmr=true;
-  calsize_data_.set_update_mmr(true);
 }
 
 // ================================================================

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
@@ -193,6 +193,15 @@ void MAMWetscav::init_temporal_views()
   const int work_len = mam4::wetdep::get_aero_model_wetdep_work_len();
   work_              = view_2d(work_ptr, ncol_, work_len);
   work_ptr +=ncol_*work_len;
+
+      /// error check
+    // NOTE: workspace_provided can be larger than workspace_used, but let's try to use the minimum amount of memory
+    const int workspace_used = work_ptr - buffer_.temporal_views.data();
+    const int workspace_provided = buffer_.temporal_views.extent(0);
+    EKAT_REQUIRE_MSG(workspace_used == workspace_provided,
+    "Error: workspace_used (" + std::to_string(workspace_used) +
+    ") and workspace_provided (" + std::to_string(workspace_provided) +
+    ") should be equal. \n");
 }
 // ================================================================
 //  INITIALIZE_IMPL
@@ -268,31 +277,33 @@ void MAMWetscav::initialize_impl(const RunType run_type) {
   isprx_             = int_view_2d("isprx", ncol_, nlev_);
   // TODO: Following variables are from convective parameterization (not
   // implemented yet in EAMxx), so should be zero for now
-  set_field_w_scratch_buffer(sh_frac_, buffer_, true);
+  // NOTE:If we use buffer_ to set the following inputs,
+  // we must set these views to zero at every time step.
+  sh_frac_ = view_2d("sh_frac_", ncol_, nlev_);
 
   // Deep convective cloud fraction [fraction]
-  set_field_w_scratch_buffer(dp_frac_, buffer_, true);
+  dp_frac_ = view_2d("dp_frac_", ncol_, nlev_);
 
   // Evaporation rate of shallow convective precipitation >=0. [kg/kg/s]
-  set_field_w_scratch_buffer(evapcsh_, buffer_, true);
+  evapcsh_ = view_2d("evapcsh_", ncol_, nlev_);
 
   // Evaporation rate of deep convective precipitation >=0. [kg/kg/s]
-  set_field_w_scratch_buffer(evapcdp_, buffer_, true);
+  evapcdp_ = view_2d("evapcdp_", ncol_, nlev_);
 
   // Rain production, shallow convection [kg/kg/s]
-  set_field_w_scratch_buffer(rprdsh_, buffer_, true);
+  rprdsh_ = view_2d("rprdsh_", ncol_, nlev_);
 
   // Rain production, deep convection [kg/kg/s]
-  set_field_w_scratch_buffer(rprddp_, buffer_, true);
+  rprddp_ = view_2d("rprddp_", ncol_, nlev_);
 
   // In cloud water mixing ratio, deep convection
-  set_field_w_scratch_buffer(icwmrdp_, buffer_, true);
+  icwmrdp_ = view_2d("icwmrdp_", ncol_, nlev_);
 
   // In cloud water mixing ratio, shallow convection
-  set_field_w_scratch_buffer(icwmrsh_, buffer_, true);
+  icwmrsh_ = view_2d("icwmrsh_", ncol_, nlev_);
 
   // Detraining cld H20 from deep convection [kg/kg/s]
-  set_field_w_scratch_buffer(dlf_, buffer_, true);
+  dlf_ = view_2d("dlf_", ncol_, nlev_);
 
 }
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
@@ -33,7 +33,7 @@ void MAMWetscav::set_grids(
 
   ncol_ = grid_->get_num_local_dofs();       // Number of columns on this rank
   nlev_ = grid_->get_num_vertical_levels();  // Number of levels per column
-  len_temporal_views_=get_len_temporal_views();
+  len_temporal_views_ = get_len_temporal_views();
   buffer_.set_len_temporal_views(len_temporal_views_);
   buffer_.set_num_scratch(num_2d_scratch_);
 
@@ -169,39 +169,39 @@ void MAMWetscav::set_grids(
 // intermediate (dry) quantities on the given number of columns with the given
 // number of vertical levels. Returns the number of bytes allocated.
 void MAMWetscav::init_buffers(const ATMBufferManager &buffer_manager) {
-
   EKAT_REQUIRE_MSG(
       buffer_manager.allocated_bytes() >= requested_buffer_size_in_bytes(),
       "Error! Insufficient buffer size.\n");
   size_t used_mem =
       mam_coupling::init_buffer(buffer_manager, ncol_, nlev_, buffer_);
-  std::cout << "used_mem " << used_mem << "requested_buffer_size_in_bytes() "<< requested_buffer_size_in_bytes() << "\n";
+  std::cout << "used_mem " << used_mem << "requested_buffer_size_in_bytes() "
+            << requested_buffer_size_in_bytes() << "\n";
   EKAT_REQUIRE_MSG(used_mem == requested_buffer_size_in_bytes(),
                    "Error! Used memory != requested memory for MAMWetscav.");
 }
 
-int MAMWetscav::get_len_temporal_views()
-{
-  const int work_len = mam4::wetdep::get_aero_model_wetdep_work_len()*ncol_;
+int MAMWetscav::get_len_temporal_views() {
+  const int work_len = mam4::wetdep::get_aero_model_wetdep_work_len() * ncol_;
   return work_len;
 }
 
-void MAMWetscav::init_temporal_views()
-{
+void MAMWetscav::init_temporal_views() {
   auto work_ptr = (Real *)buffer_.temporal_views.data();
-    // Allocate work array
+  // Allocate work array
   const int work_len = mam4::wetdep::get_aero_model_wetdep_work_len();
   work_              = view_2d(work_ptr, ncol_, work_len);
-  work_ptr +=ncol_*work_len;
+  work_ptr += ncol_ * work_len;
 
-      /// error check
-    // NOTE: workspace_provided can be larger than workspace_used, but let's try to use the minimum amount of memory
-    const int workspace_used = work_ptr - buffer_.temporal_views.data();
-    const int workspace_provided = buffer_.temporal_views.extent(0);
-    EKAT_REQUIRE_MSG(workspace_used == workspace_provided,
-    "Error: workspace_used (" + std::to_string(workspace_used) +
-    ") and workspace_provided (" + std::to_string(workspace_provided) +
-    ") should be equal. \n");
+  /// error check
+  // NOTE: workspace_provided can be larger than workspace_used, but let's try
+  // to use the minimum amount of memory
+  const int workspace_used     = work_ptr - buffer_.temporal_views.data();
+  const int workspace_provided = buffer_.temporal_views.extent(0);
+  EKAT_REQUIRE_MSG(workspace_used == workspace_provided,
+                   "Error: workspace_used (" + std::to_string(workspace_used) +
+                       ") and workspace_provided (" +
+                       std::to_string(workspace_provided) +
+                       ") should be equal. \n");
 }
 // ================================================================
 //  INITIALIZE_IMPL
@@ -266,15 +266,17 @@ void MAMWetscav::initialize_impl(const RunType run_type) {
 
   // Allocate aerosol state tendencies (interstitial aerosols only)
   for(int imode = 0; imode < mam_coupling::num_aero_modes(); ++imode) {
-    set_field_w_scratch_buffer(dry_aero_tends_.int_aero_nmr[imode], buffer_, true);
+    set_field_w_scratch_buffer(dry_aero_tends_.int_aero_nmr[imode], buffer_,
+                               true);
 
     for(int ispec = 0; ispec < mam_coupling::num_aero_species(); ++ispec) {
-      set_field_w_scratch_buffer(dry_aero_tends_.int_aero_mmr[imode][ispec], buffer_, true);
+      set_field_w_scratch_buffer(dry_aero_tends_.int_aero_mmr[imode][ispec],
+                                 buffer_, true);
     }
   }
   // Allocate work array
   init_temporal_views();
-  isprx_             = int_view_2d("isprx", ncol_, nlev_);
+  isprx_ = int_view_2d("isprx", ncol_, nlev_);
   // TODO: Following variables are from convective parameterization (not
   // implemented yet in EAMxx), so should be zero for now
   // NOTE:If we use buffer_ to set the following inputs,
@@ -304,7 +306,6 @@ void MAMWetscav::initialize_impl(const RunType run_type) {
 
   // Detraining cld H20 from deep convection [kg/kg/s]
   dlf_ = view_2d("dlf_", ncol_, nlev_);
-
 }
 
 // ================================================================

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
@@ -174,7 +174,7 @@ void MAMWetscav::init_buffers(const ATMBufferManager &buffer_manager) {
       buffer_manager.allocated_bytes() >= requested_buffer_size_in_bytes(),
       "Error! Insufficient buffer size.\n");
   size_t used_mem =
-      mam_coupling::init_buffer(buffer_manager, ncol_, nlev_, buffer_, 0);
+      mam_coupling::init_buffer(buffer_manager, ncol_, nlev_, buffer_);
   std::cout << "used_mem " << used_mem << "requested_buffer_size_in_bytes() "<< requested_buffer_size_in_bytes() << "\n";
   EKAT_REQUIRE_MSG(used_mem == requested_buffer_size_in_bytes(),
                    "Error! Used memory != requested memory for MAMWetscav.");

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
@@ -43,7 +43,8 @@ class MAMWetscav : public MAMGenericInterface {
   // ON HOST, returns the number of bytes of device memory needed by the above
   // Buffer type given the number of columns and vertical levels
   size_t requested_buffer_size_in_bytes() const override {
-    return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_, len_temporal_views_);
+    return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_,
+                                     len_temporal_views_);
   }
   void init_buffers(const ATMBufferManager &buffer_manager) override;
 
@@ -96,7 +97,7 @@ class MAMWetscav : public MAMGenericInterface {
   // Detraining cld H20 from deep convection [kg/kg/s]
   view_2d dlf_;
 
-  int num_2d_scratch_= 39;
+  int num_2d_scratch_ = 39;
 
   // Aerosol states
   mam_coupling::AerosolState dry_aero_tends_;

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
@@ -43,7 +43,7 @@ class MAMWetscav : public MAMGenericInterface {
   // ON HOST, returns the number of bytes of device memory needed by the above
   // Buffer type given the number of columns and vertical levels
   size_t requested_buffer_size_in_bytes() const override {
-    return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_, 0) + sizeof(Real) * len_temporal_views_;
+    return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_, len_temporal_views_);
   }
   void init_buffers(const ATMBufferManager &buffer_manager) override;
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
@@ -43,7 +43,7 @@ class MAMWetscav : public MAMGenericInterface {
   // ON HOST, returns the number of bytes of device memory needed by the above
   // Buffer type given the number of columns and vertical levels
   size_t requested_buffer_size_in_bytes() const override {
-    return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_, work_len_);
+    return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_, 0) + sizeof(Real) * len_temporal_views_;
   }
   void init_buffers(const ATMBufferManager &buffer_manager) override;
 
@@ -98,10 +98,6 @@ class MAMWetscav : public MAMGenericInterface {
 
   int num_2d_scratch_= 48;
 
-  int work_len_=0;
-
-  void set_work_len();
-
   // Aerosol states
   mam_coupling::AerosolState dry_aero_tends_;
 
@@ -115,6 +111,9 @@ class MAMWetscav : public MAMGenericInterface {
   mam_coupling::Buffer buffer_;
   // parameters for calcsize
   mam4::modal_aer_opt::CalcsizeData calsize_data_;
+  int get_len_temporal_views();
+  void init_temporal_views();
+  int len_temporal_views_{0};
 
 };  // class MAMWetscav
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
@@ -44,7 +44,7 @@ class MAMWetscav : public MAMGenericInterface {
   // Buffer type given the number of columns and vertical levels
   size_t requested_buffer_size_in_bytes() const override {
     return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_,
-                                     len_temporal_views_);
+                                     len_temporary_views_);
   }
   void init_buffers(const ATMBufferManager &buffer_manager) override;
 
@@ -112,9 +112,9 @@ class MAMWetscav : public MAMGenericInterface {
   mam_coupling::Buffer buffer_;
   // parameters for calcsize
   mam4::modal_aer_opt::CalcsizeData calsize_data_;
-  int get_len_temporal_views();
-  void init_temporal_views();
-  int len_temporal_views_{0};
+  int get_len_temporary_views();
+  void init_temporary_views();
+  int len_temporary_views_{0};
 
 };  // class MAMWetscav
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
@@ -43,7 +43,7 @@ class MAMWetscav : public MAMGenericInterface {
   // ON HOST, returns the number of bytes of device memory needed by the above
   // Buffer type given the number of columns and vertical levels
   size_t requested_buffer_size_in_bytes() const override {
-    return mam_coupling::buffer_size(ncol_, nlev_);
+    return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_, work_len_);
   }
   void init_buffers(const ATMBufferManager &buffer_manager) override;
 
@@ -95,6 +95,12 @@ class MAMWetscav : public MAMGenericInterface {
 
   // Detraining cld H20 from deep convection [kg/kg/s]
   view_2d dlf_;
+
+  int num_2d_scratch_= 48;
+
+  int work_len_=0;
+
+  void set_work_len();
 
   // Aerosol states
   mam_coupling::AerosolState dry_aero_tends_;

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
@@ -96,7 +96,7 @@ class MAMWetscav : public MAMGenericInterface {
   // Detraining cld H20 from deep convection [kg/kg/s]
   view_2d dlf_;
 
-  int num_2d_scratch_= 48;
+  int num_2d_scratch_= 39;
 
   // Aerosol states
   mam_coupling::AerosolState dry_aero_tends_;

--- a/components/eamxx/src/physics/mam/mam_coupling.hpp
+++ b/components/eamxx/src/physics/mam/mam_coupling.hpp
@@ -307,7 +307,7 @@ struct Buffer {
   // number of "scratch" fields that hold process-specific data
   // (e.g. gas-phase chemistry fields that are only needed by aerosol
   //  microphysics)
-  static constexpr int max_num_2d_scratch = 50;
+  static constexpr int max_num_2d_scratch = 201;
 
   // number of local fields stored at column midpoints
   static constexpr int min_num_2d_mid =
@@ -365,13 +365,6 @@ struct Buffer {
 
 // ON HOST, returns the number of bytes of device memory needed by the above
 // Buffer type given the number of columns and vertical levels
-inline size_t buffer_size(const int ncol, const int nlev) {
-  //FIXME: max_num_2d_scratch
-  const int num_2d_mid = Buffer::min_num_2d_mid + Buffer::max_num_2d_scratch;
-  return sizeof(Real) * (num_2d_mid* ncol * nlev +
-                         Buffer::num_2d_iface * ncol * (nlev + 1));
-}
-
 inline size_t buffer_size(const int ncol, const int nlev,
                           const int num_2d_scratch, const int work_len) {
   const int num_2d_mid = Buffer::min_num_2d_mid + num_2d_scratch;

--- a/components/eamxx/src/physics/mam/mam_coupling.hpp
+++ b/components/eamxx/src/physics/mam/mam_coupling.hpp
@@ -351,6 +351,10 @@ struct Buffer {
 
   uview_2d work;
 
+  uview_1d temporal_views;
+
+  int len_temporal_views{0};
+
   // storage
   Real *wsm_data;
 
@@ -361,12 +365,19 @@ struct Buffer {
       num_2d_scratch < max_num_2d_scratch ,
       "Error! Insufficient number of scratch size in mam buffer; increase max_num_2d_scratch\n");
   }
+
+  void set_len_temporal_views(const int len_temporal_views_len)
+  {
+    len_temporal_views=len_temporal_views_len;
+  }
+
 };
 
 // ON HOST, returns the number of bytes of device memory needed by the above
 // Buffer type given the number of columns and vertical levels
 inline size_t buffer_size(const int ncol, const int nlev,
-                          const int num_2d_scratch, const int work_len) {
+                          const int num_2d_scratch,
+                          const int work_len) {
   const int num_2d_mid = Buffer::min_num_2d_mid + num_2d_scratch;
   return sizeof(Real) * (num_2d_mid* ncol * nlev + ncol * work_len +
                          Buffer::num_2d_iface * ncol * (nlev + 1));
@@ -451,6 +462,9 @@ inline size_t init_buffer(const ATMBufferManager &buffer_manager,
   // views
   buffer.work = view_2d(mem, ncol, work_len);
   mem += ncol*work_len;
+
+  buffer.temporal_views= view_1d(mem, buffer.len_temporal_views);
+  mem += buffer.len_temporal_views;
 
   // WSM data
   buffer.wsm_data = mem;

--- a/components/eamxx/src/physics/mam/mam_coupling.hpp
+++ b/components/eamxx/src/physics/mam/mam_coupling.hpp
@@ -313,8 +313,8 @@ struct Buffer {
   static constexpr int min_num_2d_mid =
       8 +  // number of dry atm fields
       2 * (num_aero_modes() + num_aero_tracers()) + num_aero_gases();
-      // +
-      //num_2d_scratch;
+  // +
+  // num_2d_scratch;
   int num_2d_scratch{0};
   // (dry) atmospheric state
   uview_2d z_mid;      // height at midpoints
@@ -356,19 +356,16 @@ struct Buffer {
   // storage
   Real *wsm_data;
 
-  void set_num_scratch(const int num_2d_scratch_in)
-  {
+  void set_num_scratch(const int num_2d_scratch_in) {
     num_2d_scratch = num_2d_scratch_in;
-    EKAT_REQUIRE_MSG(
-      num_2d_scratch < max_num_2d_scratch ,
-      "Error! Insufficient number of scratch size in mam buffer; increase max_num_2d_scratch\n");
+    EKAT_REQUIRE_MSG(num_2d_scratch < max_num_2d_scratch,
+                     "Error! Insufficient number of scratch size in mam "
+                     "buffer; increase max_num_2d_scratch\n");
   }
 
-  void set_len_temporal_views(const int len_temporal_views_len)
-  {
-    len_temporal_views=len_temporal_views_len;
+  void set_len_temporal_views(const int len_temporal_views_len) {
+    len_temporal_views = len_temporal_views_len;
   }
-
 };
 
 // ON HOST, returns the number of bytes of device memory needed by the above
@@ -377,17 +374,16 @@ inline size_t buffer_size(const int ncol, const int nlev,
                           const int num_2d_scratch,
                           const int len_temporal_views) {
   const int num_2d_mid = Buffer::min_num_2d_mid + num_2d_scratch;
-  return sizeof(Real) * (num_2d_mid* ncol * nlev +
+  return sizeof(Real) * (num_2d_mid * ncol * nlev +
                          Buffer::num_2d_iface * ncol * (nlev + 1)) +
-                         sizeof(Real) *len_temporal_views;
+         sizeof(Real) * len_temporal_views;
 }
 
 // ON HOST, initializeѕ the Buffer type with sufficient memory to store
 // intermediate (dry) quantities on the given number of columns with the given
 // number of vertical levels. Returns the number of bytes allocated.
 inline size_t init_buffer(const ATMBufferManager &buffer_manager,
-                          const int ncol, const int nlev,
-                          Buffer &buffer) {
+                          const int ncol, const int nlev, Buffer &buffer) {
   Real *mem = reinterpret_cast<Real *>(buffer_manager.get_memory());
 
   // set view pointers for midpoint fields
@@ -444,8 +440,7 @@ inline size_t init_buffer(const ATMBufferManager &buffer_manager,
 
   uview_2d *view_2d_min_scratch_ptrs[buffer.num_2d_scratch];
   for(int i = 0; i < buffer.num_2d_scratch; ++i) {
-    view_2d_min_scratch_ptrs[i] =
-        &buffer.scratch[i];
+    view_2d_min_scratch_ptrs[i]  = &buffer.scratch[i];
     *view_2d_min_scratch_ptrs[i] = view_2d(mem, ncol, nlev);
     mem += view_2d_min_scratch_ptrs[i]->size();
   }
@@ -458,7 +453,7 @@ inline size_t init_buffer(const ATMBufferManager &buffer_manager,
   }
 
   // Views with layouts different from (ncol, nlev).
-  buffer.temporal_views= view_1d(mem, buffer.len_temporal_views);
+  buffer.temporal_views = view_1d(mem, buffer.len_temporal_views);
   mem += buffer.len_temporal_views;
 
   // WSM data

--- a/components/eamxx/src/physics/mam/mam_coupling.hpp
+++ b/components/eamxx/src/physics/mam/mam_coupling.hpp
@@ -349,9 +349,9 @@ struct Buffer {
 
   uview_2d z_iface;  // height at interfaces
 
-  uview_1d temporal_views;
+  uview_1d temporary_views;
 
-  int len_temporal_views{0};
+  int len_temporary_views{0};
 
   // storage
   Real *wsm_data;
@@ -363,8 +363,8 @@ struct Buffer {
                      "buffer; increase max_num_2d_scratch\n");
   }
 
-  void set_len_temporal_views(const int len_temporal_views_len) {
-    len_temporal_views = len_temporal_views_len;
+  void set_len_temporary_views(const int len_temporary_views_len) {
+    len_temporary_views = len_temporary_views_len;
   }
 };
 
@@ -372,11 +372,11 @@ struct Buffer {
 // Buffer type given the number of columns and vertical levels
 inline size_t buffer_size(const int ncol, const int nlev,
                           const int num_2d_scratch,
-                          const int len_temporal_views) {
+                          const int len_temporary_views) {
   const int num_2d_mid = Buffer::min_num_2d_mid + num_2d_scratch;
   return sizeof(Real) * (num_2d_mid * ncol * nlev +
                          Buffer::num_2d_iface * ncol * (nlev + 1)) +
-         sizeof(Real) * len_temporal_views;
+         sizeof(Real) * len_temporary_views;
 }
 
 // ON HOST, initializeѕ the Buffer type with sufficient memory to store
@@ -453,8 +453,8 @@ inline size_t init_buffer(const ATMBufferManager &buffer_manager,
   }
 
   // Views with layouts different from (ncol, nlev).
-  buffer.temporal_views = view_1d(mem, buffer.len_temporal_views);
-  mem += buffer.len_temporal_views;
+  buffer.temporary_views = view_1d(mem, buffer.len_temporary_views);
+  mem += buffer.len_temporary_views;
 
   // WSM data
   buffer.wsm_data = mem;

--- a/components/eamxx/src/physics/mam/readfiles/tracer_reader_utils.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/tracer_reader_utils.hpp
@@ -153,7 +153,7 @@ struct TracerData {
   // only for zonal files
   view_1d zonal_levs_;
 
-  void allocate_temporal_views() {
+  void allocate_temporary_views() {
     // BEG and OUT data views.
     EKAT_REQUIRE_MSG(ncol_ != int(-1), "Error! ncols has not been set. \n");
     EKAT_REQUIRE_MSG(nlev_ != int(-1), "Error! nlevs has not been set. \n");


### PR DESCRIPTION
I modified the `mam4::buffer` to be utilized across all `mam4` processes by making the number of `buffer.scratch` processes dependent on the layout. These variables are specifically designed for the `ncol x nlev` layout. For other layout types, I introduced `buffer.temporary_views`, which is a 1D view. To configure `buffer.temporary_views`, I implemented the methods `get_len_temporary_views` and `init_temporary_views` in each process. Additionally, I did not replace views that need to be reset to zero each time `run_impl` is invoked.

[BFB]