### PR TITLE
EAMxx: Some EAMxx-specific Aurora cleanups

### DIFF
--- a/components/eamxx/cmake/machine-files/aurora.cmake
+++ b/components/eamxx/cmake/machine-files/aurora.cmake
@@ -11,15 +11,6 @@ set(EKAT_MPI_THREAD_FLAG "-d" CACHE STRING "")
 SET(SYCL_COMPILE_FLAGS "-std=c++17 -fsycl -fsycl-device-code-split=per_kernel -fno-sycl-id-queries-fit-in-int -fsycl-unnamed-lambda")
 SET(SYCL_LINK_FLAGS "-fsycl -fsycl-link-huge-device-code -fsycl-device-code-split=per_kernel  -fsycl-targets=spir64_gen -Xsycl-target-backend \"-device 12.60.7\"")
 
-set(CMAKE_CXX_FLAGS " -\-intel -Xclang -fsycl-allow-virtual-functions -mlong-double-64 -O3 -DNDEBUG ${SYCL_COMPILE_FLAGS}" CACHE STRING "" FORCE)
-set(CMAKE_Fortran_FLAGS "-fc=ifx -O3 -DNDEBUG -DCPRINTEL -g" CACHE STRING "" FORCE)
-set(CMAKE_C_FLAGS "-O3 -DNDEBUG" CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS " -\-intel -Xclang -fsycl-allow-virtual-functions -mlong-double-64 ${SYCL_COMPILE_FLAGS}" CACHE STRING "" FORCE)
+set(CMAKE_Fortran_FLAGS "-fc=ifx -DCPRINTEL -g" CACHE STRING "" FORCE)
 set(CMAKE_EXE_LINKER_FLAGS " -lifcore -\-intel -Xclang -fsycl-allow-virtual-functions -lsycl -mlong-double-64 -DNDEBUG ${SYCL_LINK_FLAGS} -fortlib" CACHE STRING "" FORCE)
-
-#this is needed for cime builds!
-set(NETCDF_PATH "/lus/flare/projects/E3SM_Dec/soft/netcdf/4.9.2c-4.6.1f/oneapi.eng.2024.07.30.002")
-set(NETCDF_DIR  "/lus/flare/projects/E3SM_Dec/soft/netcdf/4.9.2c-4.6.1f/oneapi.eng.2024.07.30.002")
-set(NETCDF_C_PATH "/lus/flare/projects/E3SM_Dec/soft/netcdf/4.9.2c-4.6.1f/oneapi.eng.2024.07.30.002")
-set(NETCDF_C      "/lus/flare/projects/E3SM_Dec/soft/netcdf/4.9.2c-4.6.1f/oneapi.eng.2024.07.30.002")
-
-

--- a/components/eamxx/cmake/machine-files/aurora.cmake
+++ b/components/eamxx/cmake/machine-files/aurora.cmake
@@ -12,5 +12,4 @@ SET(SYCL_COMPILE_FLAGS "-std=c++17 -fsycl -fsycl-device-code-split=per_kernel -f
 SET(SYCL_LINK_FLAGS "-fsycl -fsycl-link-huge-device-code -fsycl-device-code-split=per_kernel  -fsycl-targets=spir64_gen -Xsycl-target-backend \"-device 12.60.7\"")
 
 set(CMAKE_CXX_FLAGS " -\-intel -Xclang -fsycl-allow-virtual-functions -mlong-double-64 ${SYCL_COMPILE_FLAGS}" CACHE STRING "" FORCE)
-set(CMAKE_Fortran_FLAGS "-fc=ifx -DCPRINTEL -g" CACHE STRING "" FORCE)
-set(CMAKE_EXE_LINKER_FLAGS " -lifcore -\-intel -Xclang -fsycl-allow-virtual-functions -lsycl -mlong-double-64 -DNDEBUG ${SYCL_LINK_FLAGS} -fortlib" CACHE STRING "" FORCE)
+set(CMAKE_EXE_LINKER_FLAGS " -lifcore -\-intel -Xclang -fsycl-allow-virtual-functions -lsycl -mlong-double-64 ${SYCL_LINK_FLAGS} -fortlib" CACHE STRING "" FORCE)

--- a/components/homme/src/share/cxx/ComposeTransportImplEnhancedTrajectoryImpl.hpp
+++ b/components/homme/src/share/cxx/ComposeTransportImplEnhancedTrajectoryImpl.hpp
@@ -163,8 +163,8 @@ linterp (const Range& range,
 #ifndef NDEBUG
   if (xi[0] < x[0] or xi[ni-1] > x[n-1]) {
     if (caller)
-      printf("linterp: xi out of bounds: %s %1.15e %1.15e %1.15e %1.15e\n",
-             caller ? caller : "NONE", x[0], xi[0], xi[ni-1], x[n-1]);
+      Kokkos::printf("linterp: xi out of bounds: %s %1.15e %1.15e %1.15e %1.15e\n",
+                     caller ? caller : "NONE", x[0], xi[0], xi[ni-1], x[n-1]);
     assert(false);
   }
 #endif


### PR DESCRIPTION
Some non-cime_config configuration cleanups:
- Remove '-O3 -NDEBUG'; this is already taken care of and interferes with debug builds.
- Remove Netcdf-related lines; CIME provides these.
- Use Kokkos::printf.

[BFB]