### PR TITLE
Loads newer python in Compy's machine files

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -3886,6 +3886,7 @@
 	<command name="load">intelmpi/2019u3</command>
       </modules>
       <modules>
+        <command name="load">python/3.11.5</command>
         <command name="load">netcdf/4.6.3</command>
         <command name="load">pnetcdf/1.9.0</command>
         <command name="load">mkl/2020</command>


### PR DESCRIPTION
The current master requires Python version >3.8. The default
Python on Compy of 3.7.x. This PR loads Python/3.11.5 in Compy's machine files.

[BFB]
