### PR TITLE
Update node list for anlgce-ub22

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1872,7 +1872,7 @@
 
   <machine MACH="anlgce-ub22">
     <DESC>ANL CELS General Computing Environment (Linux) workstation (Ubuntu 22.04)</DESC>
-    <NODENAME_REGEX>compute-386-(01|02|03|05|07|08)|compute-240-(15)</NODENAME_REGEX>
+    <NODENAME_REGEX>compute-386-(01|02|03|05|07|08)|compute-240-(10|15)</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>gnu</COMPILERS>
     <MPILIBS>mpich,openmpi</MPILIBS>


### PR DESCRIPTION
One ANL GCE node (compute-240-10) has recently been upgraded from
Ubuntu 20.04 to 22.04. This PR updates the configuration of machine
anlgce-ub22 to include this newly upgraded node.

[BFB]