### PR TITLE
For pm-cpu: set MPICH environment variable to avoid gradual slowdowns of simulations

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -272,6 +272,7 @@
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
       <env name="GATOR_INITIAL_MB">4000MB</env>
       <env name="LD_LIBRARY_PATH">$ENV{CRAY_LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}</env> <!-- https://github.com/E3SM-Project/E3SM/issues/7117 -->
+      <env name="MPICH_SMP_SINGLE_COPY_MODE">CMA</env> <!-- https://github.com/E3SM-Project/E3SM/issues/7207 -->
     </environment_variables>
     <environment_variables compiler="intel" mpilib="mpich">
       <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/adios2/2.9.1/cray-mpich-8.1.25/intel-2023.1.0; else echo "$ADIOS2_ROOT"; fi}</env>


### PR DESCRIPTION
A major OS upgrade happened during the Feb18th maintenance (COS 2.5 to 3.1) and this changed how XPMEM works,
which controls how memory is managed for on-node communication. The default is XPMEM and is what E3SM has always
used. Something is causing longer simulations* to gradually slow down and using CMA instead seems to resolve.
This PR simply adds an environment variable setting: `MPICH_SMP_SINGLE_COPY_MODE=CMA` which changes
the default. Do not expect any changes to the results or performance (aside from not slowing down over time).

(*) not all cases seem affected and it's not clear what situations trigger condition

Fixes https://github.com/E3SM-Project/E3SM/issues/7207

[bfb]
