### PR TITLE
EAMxx: fix postrun script for ERS hash checking

### DIFF
--- a/components/eamxx/scripts/check-hashes-ers
+++ b/components/eamxx/scripts/check-hashes-ers
@@ -61,30 +61,38 @@ def get_log_glob_from_atm_modelio(case_dir):
     run_dir = pathlib.Path(ln.split()[2].split('"')[1])
     ln = grep('logfile = ', filename)[0]
     atm_log_fn = ln.split()[2].split('"')[1]
-    id_ = atm_log_fn.split('.')[2]
-    return str(run_dir / '**' / f'atm.log.{id_}*')
+    return str(run_dir / '**' / f'atm.log.*')
 
 ###############################################################################
-def get_hash_lines(fn):
+def get_hash_lines(fn,start_from_line):
 ###############################################################################
     times = []
     hash_lines = []
-    with gzip.open(fn,'rt') as fd:
-        lines = fd.readlines()
-        i = 0
-        while i < len(lines):
-            line = lines[i]
-            i = i+1
-            if "eamxx hash>" in line:
-                # eamxx hash line has the form "eamxx hash> date=YYYY-MM-DD-XXXXX (STRING), naccum=INT
-                times.append(parse_time(line))
-                naccum_index = line.index("naccum=") + len("naccum=")
-                N = int(line[naccum_index:])
-                hashes = []
-                for j in range(N):
-                    hashes.append(lines[i].strip('\n'))
-                    i += 1
-                hash_lines.append(hashes)
+
+    lines = []
+    with gzip.open(fn,'rt') as file:
+        start_line_found = False
+        for line in file:
+            if start_line_found:
+                lines.append(line)
+            elif start_from_line in line:
+                start_line_found = True
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        i = i+1
+        # eamxx hash line has the form "eamxx hash> date=YYYY-MM-DD-XXXXX (STRING), naccum=INT
+        # The INT at the end says how many of the following line contain hashes for this proc-step
+        if "eamxx hash>" in line:
+            times.append(parse_time(line))
+            naccum_index = line.index("naccum=") + len("naccum=")
+            N = int(line[naccum_index:])
+            hashes = []
+            for j in range(N):
+                hashes.append(lines[i].strip('\n'))
+                i += 1
+            hash_lines.append(hashes)
 
     return times, hash_lines
 
@@ -119,6 +127,16 @@ def diff(times, l1, l2):
     return diffs
 
 ###############################################################################
+def get_model_start_of_step_lines (atm_log):
+###############################################################################
+    lines = []
+    with gzip.open(atm_log,'rt') as file:
+        for line in file:
+            if "model start-of-step time" in line:
+                lines.append(line)
+    return lines
+
+###############################################################################
 def check_hashes_ers(case_dir):
 ###############################################################################
     case_dir_p = pathlib.Path(case_dir)
@@ -130,31 +148,31 @@ def check_hashes_ers(case_dir):
     if len(atm_fns) == 0:
         print('Could not find atm.log files with glob string {}'.format(glob_pat))
         return False
-    atm_fns.sort()
     if len(atm_fns) == 1:
         # This is the first run. Exit and wait for the second
         # run. (POSTRUN_SCRIPT is called after each of the two runs.)
         print('Exiting on first run.')
         return True
+    else:
+        expect(len(atm_fns)==2,
+               "Error! Found more than 2 atm log files. Not sure what to do here."
+               " NOTE: if you run ERS test twice, clear the run folder from old logs first.")
 
+    atm_fns.sort()
     print('Diffing base {} and restart {}'.format(atm_fns[0], atm_fns[1]))
 
-    # Extract hash lines, along with their timestamps
+    start_line = get_model_start_of_step_lines(atm_fns[1])[0]
+
+    # Extract hash lines, along with their timestamps, but ignore anything
+    # before the line $start_line
     hash_lines = []
     times = []
     for f in atm_fns:
-        t,h = get_hash_lines(f)
+        t,h = get_hash_lines(f,start_line)
         hash_lines.append(h)
         times.append(t)
 
-    # For run1, ignore all lines before the first timestamp from run2
-    rest_time = times[1][0]
-    run1_rest_time_idx = find_first_index_at_time(times[0], rest_time)
-    if run1_rest_time_idx is None:
-        print('Could not find the first timestamp of run2 inside the log of run1.')
-        return False
-
-    run1_hashes = hash_lines[0][run1_rest_time_idx:]
+    run1_hashes = hash_lines[0]
     run2_hashes = hash_lines[1]
     if len(run1_hashes) != len(run2_hashes):
         print('Number of hash lines starting at restart time do not agree.')


### PR DESCRIPTION
Fixes problem in `check-hashes-ers` postrun script

[BFB]

Fixes #7211 

---

The issue was that looking for the 1st timestamp corresponding to the restart time was no longer ok after #7114 , since the timestamp used for post-subcycle was the "end-of-subcycle" timestamp (which toward the end of the 1st chunk of run1 would indeed print the restart time). The solution is to first parse the whole log scanning for the lines with `model start-of-step time` in it, to find the portions of the log1 that overlap with log2. This is more stable than grabbing all hashes, and looking for the timestamp afterwards.

I manually verified on mappy that `ERS_Ln22.ne30_ne30.F2010-SCREAMv1.mappy_gnu.eamxx-internal_diagnostics_level--eamxx-output-preset-3` passes on this branch, while it fails on master (due to the number of hash lines from log1 being too large)