### PR TITLE
EAMxx: use env vars to set blas/lapack libs in ghci machines

### DIFF
--- a/components/eamxx/cmake/machine-files/ghci-snl.cmake
+++ b/components/eamxx/cmake/machine-files/ghci-snl.cmake
@@ -5,8 +5,8 @@ set(CMAKE_Fortran_FLAGS "-fallow-argument-mismatch" CACHE STRING "Fortran compil
 set(SCREAM_INPUT_ROOT /projects/e3sm/inputdata CACHE PATH "Path to SCREAM input data" FORCE)
 
 # Set the path to BLAS/LAPACK libraries
-set(BLAS_LIBRARIES "/spack-installs/netlib-lapack/3.11.0/gcc/12.3.0/base/65x6uge/lib64/libblas.so" CACHE STRING "Path to BLAS library" FORCE)
-set(LAPACK_LIBRARIES "/spack-installs/netlib-lapack/3.11.0/gcc/12.3.0/base/65x6uge/lib64/liblapack.so" CACHE STRING "Path to LAPACK library" FORCE)
+set(BLAS_LIBRARIES "$ENV{BLAS_ROOT}/lib64/libblas.so" CACHE STRING "Path to BLAS library" FORCE)
+set(LAPACK_LIBRARIES "$ENV{BLAS_ROOT}/lib64/liblapack.so" CACHE STRING "Path to LAPACK library" FORCE)
 
 # Let's catch usage of code deprecated in Kokkos 4
 option (Kokkos_ENABLE_DEPRECATED_CODE_4 "" OFF)


### PR DESCRIPTION
Using env vars allow mach file to continue to work even if underlying
container image is rebuilt (and paths change).

[BFB]

---

