### PR TITLE
Bugfix for inconsistent iceberg melt temperature

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -815,6 +815,13 @@ if ($OCN_ISMF eq 'coupled') {
 	add_default($nl, 'config_frazil_under_land_ice');
 }
 
+##################################
+# Namelist group: iceberg_fluxes #
+##################################
+
+add_default($nl, 'config_iceberg_flux_cp_ice');
+add_default($nl, 'config_iceberg_flux_temperature_ice');
+
 ###################################
 # Namelist group: land_ice_fluxes #
 ###################################

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -305,6 +305,13 @@ add_default($nl, 'config_frazil_sea_ice_reference_salinity');
 add_default($nl, 'config_frazil_maximum_freezing_temperature');
 add_default($nl, 'config_frazil_use_surface_pressure');
 
+##################################
+# Namelist group: iceberg_fluxes #
+##################################
+
+add_default($nl, 'config_iceberg_flux_cp_ice');
+add_default($nl, 'config_iceberg_flux_temperature_ice');
+
 ###################################
 # Namelist group: land_ice_fluxes #
 ###################################

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -418,6 +418,10 @@
 <config_frazil_maximum_freezing_temperature>0.0</config_frazil_maximum_freezing_temperature>
 <config_frazil_use_surface_pressure>.false.</config_frazil_use_surface_pressure>
 
+<!-- iceberg_fluxes -->
+<config_iceberg_flux_cp_ice>2106.0</config_iceberg_flux_cp_ice>
+<config_iceberg_flux_temperature_ice>-4.0</config_iceberg_flux_temperature_ice>
+
 <!-- land_ice_fluxes -->
 <config_land_ice_flux_mode>'off'</config_land_ice_flux_mode>
 <config_land_ice_flux_mode ocn_grid="oQU240wLI">'pressure_only'</config_land_ice_flux_mode>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1644,6 +1644,23 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 
+<!-- iceberg_fluxes -->
+
+<entry id="config_iceberg_flux_temperature_ice" type="real"
+	category="iceberg_fluxes" group="iceberg_fluxes">
+Initial temperature of icebergs. If iceberg flux is sourced from snowcapping, should be representative of the average temperature of ice runoff fluxed out the base of the snowpack.
+Valid values: Any positive real number.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_iceberg_flux_cp_ice" type="real"
+	category="iceberg_fluxes" group="iceberg_fluxes">
+Energy per kilogram per C needed to raise iceberg temperature 1 C.
+Valid values: Any positive real number.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+
 <!-- land_ice_fluxes -->
 
 <entry id="config_land_ice_flux_mode" type="char*1024"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1045,6 +1045,16 @@
 			possible_values=".true. or .false."
 		/>
 	</nml_record>
+	<nml_record name="iceberg_fluxes" mode="forward">
+		<nml_option name="config_iceberg_flux_cp_ice" type="real" default_value="2106.0" units="J kg^-1 C^-1"
+					description="Energy per kilogram per C needed to raise iceberg temperature 1 C."
+					possible_values="Any positive real number."
+		/>
+		<nml_option name="config_iceberg_flux_temperature_ice" type="real" default_value="-4.0" units="C"
+					description="Initial temperature of icebergs. If iceberg flux is sourced from snowcapping, should be representative of the average temperature of ice runoff fluxed out the base of the snowpack."
+					possible_values="Any positive real number."
+		/>
+	</nml_record>
 	<nml_record name="land_ice_fluxes" mode="init;forward">
 		<nml_option name="config_land_ice_flux_mode" type="character" default_value="off"
 					description="Selects the mode in which land-ice fluxes are computed."

--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
@@ -64,6 +64,9 @@ module ocn_surface_bulk_forcing
    logical ::              &
       bulkWindStressOff,   &! on/off switch for bulk wind stress
       bulkThicknessFluxOff  ! on/off switch for bulk thickness flux
+   real(kind=RKIND) ::     &
+      temperature_iceberg, &
+      cp_iceberg
 
 !***********************************************************************
 
@@ -550,6 +553,9 @@ contains
       if (config_use_bulk_thickness_flux) &
          bulkThicknessFluxOff = .false.
 
+      cp_iceberg = config_iceberg_flux_cp_ice
+      temperature_iceberg = config_iceberg_flux_temperature_ice
+
       !-----------------------------------------------------------------
 
    end subroutine ocn_surface_bulk_forcing_init!}}}
@@ -626,7 +632,7 @@ contains
                                                   seaIceTemperatureFlux, icebergTemperatureFlux, &
                                                   totalFreshWaterTemperatureFlux
       real (kind=RKIND), dimension(:), pointer :: landIcePressure
-      real (kind=RKIND) :: requiredSalt, allowedSalt, surfaceTemperatureFluxWithoutRunoff
+      real (kind=RKIND) :: requiredSalt, allowedSalt, surfaceTemperatureFluxWithoutRunoff, freezingTemperature
 
       err = 0
 
@@ -673,12 +679,18 @@ contains
 
       ! Build surface fluxes at cell centers
       !$omp parallel
-      !$omp do schedule(runtime) private(allowedSalt, requiredSalt)
+      !$omp do schedule(runtime) private(allowedSalt, requiredSalt, freezingTemperature)
       do iCell = 1, nCells
+
+        ! Raise the iceberg temperature to the local freezing point, should be negative for extraction of heat
+        freezingTemperature = ocn_freezing_temperature( tracerGroup(index_salinity_flux, minLevelCell(iCell), iCell), pressure=0.0_RKIND, &
+                                                        inLandIceCavity=.false.)
+
         tracersSurfaceFlux(index_temperature_flux, iCell) = tracersSurfaceFlux(index_temperature_flux, iCell) &
                                                            + (latentHeatFlux(iCell) + sensibleHeatFlux(iCell) &
                                                            + longWaveHeatFluxUp(iCell) + longWaveHeatFluxDown(iCell) &
                                                            + seaIceHeatFlux(iCell) + icebergHeatFlux(iCell) &
+                                                           + cp_iceberg * icebergFreshWaterFlux(iCell) * (temperature_iceberg - freezingTemperature) &
                                                            - (snowFlux(iCell) + iceRunoffFlux(iCell)) &
                                                            * latent_heat_fusion_mks) * hflux_factor
 
@@ -703,6 +715,7 @@ contains
       !$omp end do
       !$omp end parallel
       ! assume that snow comes in at 0 C
+      ! assume that icebergs enter at a constant temperature not equal to the local freezing point
 
       ! Surface fluxes of water have an associated heat content, but the coupled system does not account for this
       ! Assume surface fluxes of water have a temperature dependent on the incoming mass flux.
@@ -711,7 +724,7 @@ contains
       ! indices on tracerGroup are (iTracer, iLevel, iCell)
       if (.not. bulkThicknessFluxOff) then
          !$omp parallel
-         !$omp do schedule(runtime) private(surfaceTemperatureFluxWithoutRunoff)
+         !$omp do schedule(runtime) private(surfaceTemperatureFluxWithoutRunoff, freezingTemperature)
          do iCell = 1, nCells
 
            ! Accumulate fluxes that use the surface temperature
@@ -724,12 +737,12 @@ contains
 
            ! Accumulate fluxes that use the freezing point
 ! mrp performance note: should call ocn_freezing_temperature just once here
+           freezingTemperature = ocn_freezing_temperature( tracerGroup(index_salinity_flux, minLevelCell(iCell), iCell), pressure=0.0_RKIND, &
+                                                           inLandIceCavity=.false.)
            seaIceTemperatureFlux(iCell) = seaIceFreshWaterFlux(iCell) * &
-               ocn_freezing_temperature( tracerGroup(index_salinity_flux, minLevelCell(iCell), iCell), pressure=0.0_RKIND, &
-                                         inLandIceCavity=.false.) / rho_sw
+               freezingTemperature / rho_sw
            icebergTemperatureFlux(iCell) = icebergFreshWaterFlux(iCell) * &
-               ocn_freezing_temperature( tracerGroup(index_salinity_flux, minLevelCell(iCell), iCell), pressure=0.0_RKIND, &
-                                         inLandIceCavity=.false.) / rho_sw
+               freezingTemperature / rho_sw
 
            surfaceTemperatureFluxWithoutRunoff = rainTemperatureFlux(iCell) + evapTemperatureFlux(iCell) + &
                                                  seaIceTemperatureFlux(iCell) + icebergTemperatureFlux(iCell)

--- a/components/mpas-seaice/src/shared/mpas_seaice_forcing.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_forcing.F
@@ -3339,12 +3339,6 @@ contains
     real(kind=RKIND) :: &
          scaling
 
-    ! dc including as parameters here so as not to create new namelist options
-    real(kind=RKIND), parameter :: &
-         specificHeatFreshIce = 2106.0_RKIND, & ! specific heat of fresh ice J * kg^-1 * K^-1
-         bergTemperature = -4.0_RKIND           ! iceberg temperature, assumed constant
-
-
     call MPAS_pool_get_config(domain % configs, "config_scale_dib_by_removed_ice_runoff", &
                               config_scale_dib_by_removed_ice_runoff)
 
@@ -3374,10 +3368,8 @@ contains
 
        do iCell = 1, nCellsSolve
 
-          bergFreshwaterFlux(iCell) = scaling * bergFreshwaterFluxData(iCell)
-          bergLatentHeatFlux(iCell) = -scaling * bergFreshwaterFluxData(iCell) * &
-                                     (seaiceLatentHeatMelting - specificHeatFreshIce*bergTemperature)
-
+          bergFreshwaterFlux(iCell) = bergFreshwaterFluxData(iCell)
+          bergLatentHeatFlux(iCell) = -bergFreshwaterFluxData(iCell) * seaiceLatentHeatMelting
        enddo
 
        block => block % next


### PR DESCRIPTION
Currently:
* MPAS-Seaice iceberg heat flux term includes both latent heat associated with melting and the heat needed to raise icebergs from -4 degC to 0 degC
* MPAS-Ocean assumes that iceberg mass flux entered at the local freezing point, which is inconsistent with the temperature adjustment above

With this PR:
* MPAS-Seaice iceberg heat flux term includes only the latent heat associated with melting
* MPAS-Ocean assumes that iceberg mass flux entered at the local freezing point, and includes the heat flux needed to raise icebergs from a namelist-derived initial temperature (default -4 degC) to the local freezing point

Local freezing point is the pressure and salinity-dependent freezing point consistent with mushy thermodynamics.

Addresses https://github.com/E3SM-Project/E3SM/issues/7110