### PR TITLE
Revert "EAMxx: allow to decomposing fast-striding dimensions in IO"

### DIFF
--- a/components/eamxx/src/share/io/eamxx_scorpio_interface.hpp
+++ b/components/eamxx/src/share/io/eamxx_scorpio_interface.hpp
@@ -136,12 +136,12 @@ std::string get_time_name (const std::string& filename);
 
 void set_dim_decomp (const std::string& filename,
                      const std::string& dimname,
-                     const std::vector<int>& my_offsets,
+                     const std::vector<offset_t>& my_offsets,
                      const bool allow_reset = false);
 
 void set_dim_decomp (const std::string& filename,
                      const std::string& dimname,
-                     const int start, const int count,
+                     const offset_t start, const offset_t count,
                      const bool allow_reset = false);
 
 void set_dim_decomp (const std::string& filename,

--- a/components/eamxx/src/share/io/eamxx_scorpio_types.hpp
+++ b/components/eamxx/src/share/io/eamxx_scorpio_types.hpp
@@ -34,6 +34,9 @@ enum IOType {
 IOType str2iotype(const std::string &str);
 std::string iotype2str(const IOType iotype);
 
+// The type used by PIOc for offsets
+using offset_t = std::int64_t;
+
 /*
  * The following PIOxyz types each represent an entity that
  * is associated in scorpio with an id. For each of them, we add some
@@ -63,24 +66,22 @@ struct PIODim : public PIOFileEntity {
   int length       = -1;
   bool unlimited   = false;
 
-  // In case we decompose the dimension, this will store the owned offsets on this rank
-  std::vector<int> offsets;
-  bool decomposed = false;
+  // In case we decompose the dimension, this will store
+  // the owned offsets on this rank
+  // NOTE: use a pointer, so we can detect if a decomposition already
+  //       existed or not when we set one.
+  std::shared_ptr<std::vector<offset_t>> offsets;
 };
 
 // A decomposition
-// NOTE: the offsets of a PIODecomp are not the same as the offsets
+// NOTE: the offsets of a PIODecomp are not the same as the offsets of
 //       stored in its dim. The latter are the offsets *along that dim*.
 //       A PIODecomp is associated with a Nd layout, which includes decomp_dim
-//       among its dimensions. PIODecomp::offsets contains the offsets of the full
+//       among its dimensions. PIODecomp::offsets are the offsets of the full
 //       array layout owned by this rank. Hence, there can be many PIODecomp
 //       all storing the same dim
-
-// Use pimpl idiom, so we can avoid including pio.h here to get the PIO_Offset type
-struct OffsetsVec;
-
 struct PIODecomp : public PIOEntity {
-  std::shared_ptr<OffsetsVec>     offsets;
+  std::vector<offset_t>           offsets;  // Owned offsets
   std::shared_ptr<const PIODim>   dim; 
 };
 

--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -499,7 +499,7 @@ void AtmosphereInput::set_decompositions()
   auto gids_f = m_io_grid->get_partitioned_dim_gids();
   auto gids_h = gids_f.get_view<const AbstractGrid::gid_type*,Host>();
   auto min_gid = m_io_grid->get_global_min_partitioned_dim_gid();
-  std::vector<int> offsets(local_dim);
+  std::vector<scorpio::offset_t> offsets(local_dim);
   for (int idof=0; idof<local_dim; ++idof) {
     offsets[idof] = gids_h[idof] - min_gid;
   }

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -1105,6 +1105,89 @@ register_variables(const std::string& filename,
     }
   }
 } // register_variables
+/* ---------------------------------------------------------- */
+std::vector<scorpio::offset_t>
+AtmosphereOutput::get_var_dof_offsets(const FieldLayout& layout)
+{
+  using namespace ShortFieldTagsNames;
+
+  // Precompute this *before* the early return, since it involves collectives.
+  // If one rank owns zero cols, and returns prematurely, the others will be left waiting.
+  AbstractGrid::gid_type min_gid = -1;
+  if (layout.has_tag(COL) or layout.has_tag(EL)) {
+    min_gid = m_io_grid->get_global_min_dof_gid();
+  }
+
+  // It may be that this MPI rank owns no chunk of the field
+  if (layout.size()==0) {
+    return {};
+  }
+
+  std::vector<scorpio::offset_t> var_dof(layout.size());
+
+  // Gather the offsets of the dofs of this variable w.r.t. the *global* array.
+  // Since we order the global array based on dof gid, and we *assume* (we actually
+  // check this during set_grid) that the grid global gids are in the interval
+  // [gid_0, gid_0+num_global_dofs), the offset is simply given by
+  // (dof_gid-gid_0)*column_size (for partitioned arrays).
+  // NOTE: we allow gid_0!=0, so that we don't have to worry about 1-based numbering
+  //       vs 0-based numbering. The key feature is that the global gids are a
+  //       contiguous array. The starting point doesn't matter.
+  // NOTE: a "dof" in the grid object is not the same as a "dof" in scorpio.
+  //       For a SEGrid 3d vector field with (MPI local) layout (nelem,2,np,np,nlev),
+  //       scorpio sees nelem*2*np*np*nlev dofs, while the SE grid sees nelem*np*np dofs.
+  //       All we need to do in this routine is to compute the offset of all the entries
+  //       of the MPI-local array w.r.t. the global array. So long as the offsets are in
+  //       the same order as the corresponding entry in the data to be read/written, we're good.
+  // NOTE: In the case of regional output this rank may have 0 columns to write, thus, var_dof
+  //       should be empty, we check for this special case and return an empty var_dof.
+  auto dofs_h = m_io_grid->get_dofs_gids().get_view<const AbstractGrid::gid_type*,Host>();
+  if (layout.has_tag(COL)) {
+    const int num_cols = m_io_grid->get_num_local_dofs();
+
+    // Note: col_size might be *larger* than the number of vertical levels, or even smaller.
+    //       E.g., (ncols,2,nlevs), or (ncols,2) respectively.
+    scorpio::offset_t col_size = layout.size() / num_cols;
+
+    for (int icol=0; icol<num_cols; ++icol) {
+      // Get chunk of var_dof to fill
+      auto start = var_dof.begin()+icol*col_size;
+      auto end   = start+col_size;
+
+      // Compute start of the column offset, then fill column adding 1 to each entry
+      auto gid = dofs_h(icol);
+      auto offset = (gid-min_gid)*col_size;
+      std::iota(start,end,offset);
+    }
+  } else if (layout.has_tag(EL)) {
+    auto layout2d = m_io_grid->get_2d_scalar_layout();
+    const int num_my_elems = layout2d.dim(0);
+    const int ngp = layout2d.dim(1);
+    const int num_cols = num_my_elems*ngp*ngp;
+
+    // Note: col_size might be *larger* than the number of vertical levels, or even smaller.
+    //       E.g., (ncols,2,nlevs), or (ncols,2) respectively.
+    scorpio::offset_t col_size = layout.size() / num_cols;
+
+    for (int ie=0,icol=0; ie<num_my_elems; ++ie) {
+      for (int igp=0; igp<ngp; ++igp) {
+        for (int jgp=0; jgp<ngp; ++jgp,++icol) {
+          // Get chunk of var_dof to fill
+          auto start = var_dof.begin()+icol*col_size;
+          auto end   = start+col_size;
+
+          // Compute start of the column offset, then fill column adding 1 to each entry
+          auto gid = dofs_h(icol);
+          auto offset = (gid-min_gid)*col_size;
+          std::iota(start,end,offset);
+    }}}
+  } else {
+    // This field is *not* defined over columns, so it is not partitioned.
+    std::iota(var_dof.begin(),var_dof.end(),0);
+  }
+
+  return var_dof;
+}
 
 void AtmosphereOutput::set_decompositions(const std::string& filename)
 {
@@ -1134,7 +1217,7 @@ void AtmosphereOutput::set_decompositions(const std::string& filename)
   auto gids_f = m_io_grid->get_partitioned_dim_gids();
   auto gids_h = gids_f.get_view<const AbstractGrid::gid_type*,Host>();
   auto min_gid = m_io_grid->get_global_min_partitioned_dim_gid();
-  std::vector<int> offsets(local_dim);
+  std::vector<scorpio::offset_t> offsets(local_dim);
   for (int idof=0; idof<local_dim; ++idof) {
     offsets[idof] = gids_h[idof] - min_gid;
   }

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -173,6 +173,7 @@ protected:
   void register_dimensions(const std::string& name);
   void register_variables(const std::string& filename, const std::string& fp_precision, const scorpio::FileMode mode);
   void set_decompositions(const std::string& filename);
+  std::vector<scorpio::offset_t> get_var_dof_offsets (const FieldLayout& layout);
   void register_views();
   Field get_field(const std::string& name, const std::string& mode) const;
   void compute_diagnostic (const std::string& name, const bool allow_invalid_fields = false);

--- a/components/eamxx/src/share/io/scorpio_scm_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_scm_input.cpp
@@ -257,7 +257,7 @@ void SCMInput::set_decompositions()
   auto gids_f = m_io_grid->get_partitioned_dim_gids();
   auto gids_h = gids_f.get_view<const AbstractGrid::gid_type*,Host>();
   auto min_gid = m_io_grid->get_global_min_partitioned_dim_gid();
-  std::vector<int> offsets(local_dim);
+  std::vector<scorpio::offset_t> offsets(local_dim);
   for (int idof=0; idof<local_dim; ++idof) {
     offsets[idof] = gids_h[idof] - min_gid;
   }

--- a/components/eamxx/src/share/io/tests/io_scm_reader.cpp
+++ b/components/eamxx/src/share/io/tests/io_scm_reader.cpp
@@ -59,7 +59,7 @@ void write (const int seed, const ekat::Comm& comm)
   scorpio::define_var(filename,"var",{"ncol","lev"},"real");
 
   auto my_col_gids = grid->get_partitioned_dim_gids().get_view<const AbstractGrid::gid_type*,Host>();
-  std::vector<int> my_offsets(my_col_gids.size());
+  std::vector<scorpio::offset_t> my_offsets(my_col_gids.size());
   for (size_t i=0; i<my_offsets.size(); ++i) {
     my_offsets[i] = my_col_gids[i] - grid->get_global_min_partitioned_dim_gid ();
   }


### PR DESCRIPTION
Reverts E3SM-Project/E3SM#7175

---

PR #7175 ended up causing problems with restart saving running at ne256pg2 resolution. Since the PR isn't immediately needed, let's revert it and investigate later. The PR is needed for another PR but we can work around the blockage for now.