### PR TITLE
Update new freshwater_tracers test to only require one year of JRA data

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -311,7 +311,7 @@ _TESTS = {
             "PEM_P480_Ld5.TL319_IcoswISC30E3r5.GMPAS-JRA1p5-DIB-PISMF.mpaso-jra_1958",
             "SMS_P480_Ld5.TL319_IcoswISC30E3r5.GMPAS-JRA1p5-DIB-PISMF-TMIX.mpaso-jra_1958",
             "PET_P480_Ld2.TL319_IcoswISC30E3r5.GMPAS-JRA1p5-DIB-PISMF-DSGR.mpaso-jra_1958",
-            "PET_P480_Ld2.TL319_IcoswISC30E3r5.GMPAS-JRA1p5-DIB-PISMF-DSGR.mpaso-freshwater_tracers",
+            "PET_P480_Ld2.TL319_IcoswISC30E3r5.GMPAS-JRA1p5-DIB-PISMF-DSGR.mpaso-freshwater_tracers_jra_1958",
             )
         },
 

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/freshwater_tracers_jra_1958/README
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/freshwater_tracers_jra_1958/README
@@ -1,0 +1,6 @@
+This testdef is used to test a stealth feature in mpaso introduced by
+PR #7087. It simplies changes one mpaso namelist variable,
+    config_use_freshwaterTracers
+from its default value of .false. to .true.. This particular testdef
+also limmits the required JRA forcing data to a single year to reduce
+the number of files needed for testing.

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/freshwater_tracers_jra_1958/shell_commands
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/freshwater_tracers_jra_1958/shell_commands
@@ -1,0 +1,4 @@
+./xmlchange DATM_CLMNCEP_YR_START=1958
+./xmlchange DATM_CLMNCEP_YR_END=1958
+./xmlchange DROF_STRM_YR_START=1958
+./xmlchange DROF_STRM_YR_END=1958

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/freshwater_tracers_jra_1958/user_nl_mpaso
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/freshwater_tracers_jra_1958/user_nl_mpaso
@@ -1,0 +1,1 @@
+config_use_freshwaterTracers = .true.


### PR DESCRIPTION
A new stealth test added by PR #7087 did not limit the amount of JRA data necessary for testing. This PR fixes that by adding a new testdef and having the new test use that.

[BFB]