### PR TITLE
Update chicoma to cmake/3.29.6

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -4221,7 +4221,7 @@
         <command name="load">cray-hdf5-parallel/1.12.2.9</command>
         <command name="load">cray-netcdf-hdf5parallel/4.9.0.9</command>
         <command name="load">cray-parallel-netcdf/1.12.3.9</command>
-        <command name="load">cmake/3.27.7</command>
+        <command name="load">cmake/3.29.6</command>
       </modules>
     </module_system>
 


### PR DESCRIPTION
After recent update, the previous cmake version was not available and caused an error.

[BFB]