### PR TITLE
ZM cleanup - Create zm_conv_cape module

### DIFF
--- a/components/eam/src/physics/cam/conditional_diag_main.F90
+++ b/components/eam/src/physics/cam/conditional_diag_main.F90
@@ -380,7 +380,7 @@ end subroutine apply_masking
 !========================================================
 subroutine get_values( arrayout, varname, state, pbuf, cam_in, cam_out )
 
-  use ppgrid,         only: pcols,pver
+  use ppgrid,         only: pcols,pver,pverp
   use physics_types,  only: physics_state
   use camsrfexch,     only: cam_in_t, cam_out_t
   use physics_buffer, only: physics_buffer_desc, pbuf_get_index, pbuf_get_field
@@ -595,14 +595,14 @@ subroutine get_values( arrayout, varname, state, pbuf, cam_in, cam_out )
                                    arrayout(:ncol,:)  )                      ! out
 
         case ('CAPE')
-          call compute_cape_diags( state, pbuf, pcols, pver, cape ) ! 4xin, 1xout
+          call compute_cape_diags( state, pbuf, pcols, pver, pverp, cape ) ! 5xin, 1xout
           arrayout(:,1) = cape(:)
 
         case ('dCAPE')
 
           arrayout(:,:) = 0._r8
 
-          call compute_cape_diags( state, pbuf, pcols, pver, cape, dcape ) ! 4xin, 2xout
+          call compute_cape_diags( state, pbuf, pcols, pver, pverp, cape, dcape ) ! 5xin, 2xout
 
           arrayout(:,1:3) = dcape(:,1:3)   ! 1=dCAPE, 2=dCAPEp, 3=dCAPEe
 

--- a/components/eam/src/physics/cam/misc_diagnostics.F90
+++ b/components/eam/src/physics/cam/misc_diagnostics.F90
@@ -171,7 +171,8 @@ subroutine compute_cape_diags( state, pbuf, pcols, pver, cape_out, dcape_out )
   use physics_types,  only: physics_state
   use physics_buffer, only: physics_buffer_desc, pbuf_get_index, pbuf_get_field
   use physconst,      only: cpair, gravit, rair, latvap
-  use zm_conv,        only: buoyan_dilute, limcnv
+  use zm_conv,        only: zm_constants, zm_parameters
+  use zm_conv_parcel, only: buoyan_dilute
 
   type(physics_state),intent(in),target:: state
   type(physics_buffer_desc),pointer    :: pbuf(:)
@@ -218,7 +219,6 @@ subroutine compute_cape_diags( state, pbuf, pcols, pver, cape_out, dcape_out )
   real(r8) ::   ztl(pcols)      ! parcel temperature at lcl.
   integer  ::  zlcl(pcols)      ! base level index of deep cumulus convection.
   integer  ::  zlel(pcols)      ! index of highest theoretical convective plume.
-  integer  ::  zlon(pcols)      ! index of onset level for deep convection.
   integer  ::   zmx(pcols)      ! launching level index 
 
   ! CAPE calculated using different combinations of environmental profiles and parcel properties
@@ -248,7 +248,7 @@ subroutine compute_cape_diags( state, pbuf, pcols, pver, cape_out, dcape_out )
   !-----------------------------------
   ! Time-independent quantities 
   !-----------------------------------
-  msg = limcnv - 1  ! limcnv is the top interface level limit for convection
+  msg = zm_parameters%limcnv - 1  ! limcnv is the top pressure interface level to limit deep convection
 
   idx = pbuf_get_index('tpert') ; call pbuf_get_field( pbuf, idx, tpert )
 
@@ -291,21 +291,20 @@ subroutine compute_cape_diags( state, pbuf, pcols, pver, cape_out, dcape_out )
   ! and T, qv values at (new) launching level
   !------------------------------------------------------------------------
   iclosure = .true.
-  call buoyan_dilute(lchnk ,ncol,                      &! in
-                     qv_new, temp_new,                 &! in  !!
-                     pmid_in_hPa, zmid_above_sealevel, &! in
-                     pint_in_hPa,                      &! in
-                     ztp, zqstp, ztl,                  &! out
-                     latvap,                           &! in
-                     cape_new_pcl_new_env,             &! out !!
-                     pblt,                             &! in
-                     zlcl, zlel, zlon,                 &! out
-                     mx_new,                           &! out !!
-                     rair, gravit, cpair, msg, tpert,  &! in
-                     iclosure,                         &! in
-                     use_input_parcel_tq_in = .false., &! in  !!
-                     q_mx = q_mx_new,                  &! out !!
-                     t_mx = t_mx_new                   )! out !!
+  call buoyan_dilute(lchnk ,ncol,                      &
+                     zm_parameters%num_cin,            &
+                     qv_new, temp_new,                 &
+                     zmid_above_sealevel,              &
+                     pmid_in_hPa, pint_in_hPa,         &
+                     pblt, msg, tpert,                 &
+                     ztp, zqstp, zmx, ztl, zlcl, zlel, &
+                     cape_new_pcl_new_env,             &
+                     zm_constants,                     &
+                     zm_parameters,                    &
+                     iclosure,                         &
+                     use_input_parcel_tq = .false.,    &
+                     q_mx = q_mx_new,                  &
+                     t_mx = t_mx_new                   )
 
   cape_out(:ncol) = cape_new_pcl_new_env(:ncol)
  
@@ -327,22 +326,21 @@ subroutine compute_cape_diags( state, pbuf, pcols, pver, cape_out, dcape_out )
     !  - old launching level and parcel T, qv
 
     iclosure = .true.
-    call buoyan_dilute(lchnk ,ncol,                      &! in
-                       qv_new, temp_new,                 &! in  !!!
-                       pmid_in_hPa, zmid_above_sealevel, &! in
-                       pint_in_hPa,                      &! in
-                       ztp, zqstp, ztl,                  &! out
-                       latvap,                           &! in
-                       cape_old_pcl_new_env,             &! out !!!
-                       pblt,                             &! in
-                       zlcl, zlel, zlon,                 &! out
-                       zmx,                              &! out 
-                       rair, gravit, cpair, msg, tpert,  &! in
-                       iclosure,                         &! in
-                       dcapemx = mx_old,                 &! in  !!!
-                       use_input_parcel_tq_in = .true.,  &! in  !!!
-                       q_mx = q_mx_old,                  &! in  !!!
-                       t_mx = t_mx_old                   )! in  !!!
+    call buoyan_dilute(lchnk ,ncol,                      &
+                       zm_parameters%num_cin,            &
+                       qv_new, temp_new,                 &
+                       zmid_above_sealevel,              &
+                       pmid_in_hPa, pint_in_hPa,         &
+                       pblt, msg, tpert,                 &
+                       ztp, zqstp, zmx, ztl, zlcl, zlel, &
+                       cape_old_pcl_new_env,             &
+                       zm_constants,                     &
+                       zm_parameters,                    &
+                       iclosure,                         &
+                       dcapemx = mx_old,                 &
+                       use_input_parcel_tq = .true.,     &
+                       q_mx = q_mx_old,                  &
+                       t_mx = t_mx_old                   )
 
     ! dCAPEp = CAPE(new parcel, new env) - CAPE( old parcel, new env)
     dcape_out(:ncol,2) = cape_new_pcl_new_env(:ncol) - cape_old_pcl_new_env(:ncol)

--- a/components/eam/src/physics/cam/misc_diagnostics.F90
+++ b/components/eam/src/physics/cam/misc_diagnostics.F90
@@ -155,7 +155,7 @@ subroutine relhum_ice_percent( ncol, pver, tair, pair, qv,  rhi_percent )
 
 end subroutine relhum_ice_percent
 
-subroutine compute_cape_diags( state, pbuf, pcols, pver, cape_out, dcape_out )
+subroutine compute_cape_diags( state, pbuf, pcols, pver, pverp, cape_out, dcape_out )
 !-------------------------------------------------------------------------------------------
 ! Purpose: 
 ! - CAPE, the convecitve available potential energy
@@ -177,6 +177,7 @@ subroutine compute_cape_diags( state, pbuf, pcols, pver, cape_out, dcape_out )
   type(physics_state),intent(in),target:: state
   type(physics_buffer_desc),pointer    :: pbuf(:)
   integer,                  intent(in) :: pver
+  integer,                  intent(in) :: pverp
   integer,                  intent(in) :: pcols
 
   real(r8),                 intent(out) ::  cape_out(pcols)
@@ -291,7 +292,8 @@ subroutine compute_cape_diags( state, pbuf, pcols, pver, cape_out, dcape_out )
   ! and T, qv values at (new) launching level
   !------------------------------------------------------------------------
   iclosure = .true.
-  call compute_dilute_cape( ncol, zm_param%num_cin, msg,      &
+  call compute_dilute_cape( pcols, ncol, pver, pverp,         &
+                            zm_param%num_cin, msg,            &
                             qv_new, temp_new,                 &
                             zmid_above_sealevel,              &
                             pmid_in_hPa, pint_in_hPa,         &
@@ -300,7 +302,7 @@ subroutine compute_cape_diags( state, pbuf, pcols, pver, cape_out, dcape_out )
                             cape_new_pcl_new_env,             &
                             zm_const, zm_param,               &
                             iclosure,                         &
-                            use_input_parcel_tq = .false.,    &
+                            use_input_tq_mx = .false.,        &
                             q_mx = q_mx_new,                  &
                             t_mx = t_mx_new                   )
 
@@ -315,16 +317,15 @@ subroutine compute_cape_diags( state, pbuf, pcols, pver, cape_out, dcape_out )
     !-----------------------------------------------------------------
     ! dCAPE is the difference between the new CAPE calculated above 
     ! and the old CAPE retrieved from pbuf
-
      dcape_out(:ncol,1) = cape_new_pcl_new_env(:ncol) - cape_old_pcl_old_env(:ncol)
 
     !-----------------------------------------------------------------
     ! Calculate cape_old_pcl_new_env using
     !  - new state (T, qv profiles)
     !  - old launching level and parcel T, qv
-
     iclosure = .true.
-    call compute_dilute_cape( ncol, zm_param%num_cin, msg,      &
+    call compute_dilute_cape( pcols, ncol, pver, pverp,         &
+                              zm_param%num_cin, msg,            &
                               qv_new, temp_new,                 &
                               zmid_above_sealevel,              &
                               pmid_in_hPa, pint_in_hPa,         &
@@ -334,7 +335,7 @@ subroutine compute_cape_diags( state, pbuf, pcols, pver, cape_out, dcape_out )
                               zm_const, zm_param,               &
                               iclosure,                         &
                               dcapemx = mx_old,                 &
-                              use_input_parcel_tq = .true.,     &
+                              use_input_tq_mx = .true.,         &
                               q_mx = q_mx_old,                  &
                               t_mx = t_mx_old                   )
 

--- a/components/eam/src/physics/cam/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm_conv.F90
@@ -809,7 +809,8 @@ subroutine zm_convr(lchnk   ,ncol    , &
    ! DCAPE is the difference in CAPE between the two calls using the same launch level
 
    iclosure = .true.
-   call compute_dilute_cape( ncol, zm_param%num_cin, msg, &
+   call compute_dilute_cape( pcols, ncol, pver, pverp, &
+                             zm_param%num_cin, msg, &
                              q, t, z, p, pf, &
                              pblt, tpert, &
                              tp, qstp, maxi, tl, &
@@ -821,7 +822,8 @@ subroutine zm_convr(lchnk   ,ncol    , &
    ! Calculate dcape trigger condition
    if ( .not.is_first_step() .and. zm_param%trig_dcape ) then
       iclosure = .false.
-      call compute_dilute_cape( ncol, zm_param%num_cin, msg, &
+      call compute_dilute_cape( pcols, ncol, pver, pverp, &
+                                zm_param%num_cin, msg, &
                                 q_star, t_star, z, p, pf, &
                                 pblt, tpert, &
                                 tpm1, qstpm1, maxim1, tlm1, &

--- a/components/eam/src/physics/cam/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm_conv.F90
@@ -50,7 +50,6 @@ module zm_conv
   public MCSP_moisture_coeff      ! MCSP coefficient setting degree of moisture transport
   public MCSP_uwind_coeff         ! MCSP coefficient setting degree of zonal wind transport
   public MCSP_vwind_coeff         ! MCSP coefficient setting degree of meridional wind transport
-  ! public buoyan_dilute_old
 
 !
 ! PUBLIC: data

--- a/components/eam/src/physics/cam/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm_conv.F90
@@ -23,9 +23,11 @@ module zm_conv
                                     cpwv, cpliq, rh2o
   use cam_abortutils,         only: endrun
   use cam_logfile,            only: iulog
+  use zm_conv_cape,           only: compute_dilute_cape
+  use zm_conv_types,          only: zm_const_t, zm_param_t
+  use zm_conv_util,           only: qsat_hpa ! remove after moving cldprp to new module
   use zm_aero,                only: zm_aero_t
   use zm_microphysics,        only: zm_mphy
-  use zm_conv_util,           only: entropy, ientropy, qsat_hPa
   use zm_microphysics_state,  only: zm_microp_st, zm_microp_st_alloc, zm_microp_st_dealloc, zm_microp_st_ini, zm_microp_st_gb
 
   implicit none
@@ -42,18 +44,20 @@ module zm_conv
   public trigdcape_ull            ! true if to use dcape-ULL trigger
   public trig_dcape_only          ! true if to use dcape only trigger
   public trig_ull_only            ! true if to ULL along with default CAPE-based trigger
-  public buoyan_dilute            ! subroutine that calculates CAPE
   public zm_microp                ! true for convective microphysics
   public MCSP                     ! true if running MCSP
   public MCSP_heat_coeff          ! MCSP coefficient setting degree of dry static energy transport
   public MCSP_moisture_coeff      ! MCSP coefficient setting degree of moisture transport
   public MCSP_uwind_coeff         ! MCSP coefficient setting degree of zonal wind transport
   public MCSP_vwind_coeff         ! MCSP coefficient setting degree of meridional wind transport
+  ! public buoyan_dilute_old
 
 !
 ! PUBLIC: data
 !
-  public limcnv                   ! top interface level limit for convection
+
+   type(zm_const_t), public :: zm_const ! derived type to hold ZM constants
+   type(zm_param_t), public :: zm_param ! derived type to hold ZM tunable parameters
 
 !
 ! Private data
@@ -83,7 +87,7 @@ module zm_conv
    real(r8) :: zmconv_MCSP_heat_coeff = 0._r8
    real(r8) :: zmconv_MCSP_moisture_coeff = 0._r8
    real(r8) :: zmconv_MCSP_uwind_coeff = 0._r8
-   real(r8) :: zmconv_MCSP_vwind_coeff = 0._r8   
+   real(r8) :: zmconv_MCSP_vwind_coeff = 0._r8
 
    real(r8) rl         ! wg latent heat of vaporization.
    real(r8) cpres      ! specific heat at constant pressure in j/kg-degk.
@@ -95,19 +99,13 @@ module zm_conv
    logical :: trig_dcape_only  = .false. !true to use DCAPE trigger, ULL not used
    logical :: trig_ull_only    = .false. !true to use ULL along with default CAPE-based trigger
 
-
    real(r8) :: ke           ! Tunable evaporation efficiency set from namelist input zmconv_ke
    real(r8) :: c0_lnd       ! set from namelist input zmconv_c0_lnd
    real(r8) :: c0_ocn       ! set from namelist input zmconv_c0_ocn
-   real(r8) :: dmpdz          = unset_r8  ! Parcel fractional mass entrainment rate (/m)
    real(r8) :: alfa_scalar  ! maximum downdraft mass flux fraction  
-   real(r8) :: tiedke_add    = unset_r8
    logical  :: zm_microp    = .false.   ! switch for convective microphysics                   
    logical  :: clos_dyn_adj = .false.   ! true if apply mass flux adjustment to CAPE closure   
-   logical  :: tpert_fix    = .false.   ! true if apply tpert only to PBL-rooted convection    
 
-   integer  :: num_cin        = unset_int !number of negative buoyancy regions that are allowed before the conv. top and CAPE calc are completed
-   integer  :: mx_bot_lyr_adj = unset_int !bottom layer adjustment for setting "launching" level(mx) (to be at maximum moist static energy).
    real(r8) tau   ! convective time scale
    real(r8),parameter :: c1 = 6.112_r8
    real(r8),parameter :: c2 = 17.67_r8
@@ -126,9 +124,8 @@ module zm_conv
    real(r8) :: grav        ! = gravit
    real(r8) :: cp          ! = cpres = cpair
    
-   integer,protected ::  limcnv   ! top interface level limit for convection
+   ! integer,protected :: limcnv ! upper pressure interface level to limit deep convection
 
-   real(r8) :: tp_fac = unset_r8  
    real(r8) :: auto_fac = unset_r8
    real(r8) :: accr_fac = unset_r8
    real(r8) :: micro_dcs= unset_r8
@@ -139,12 +136,15 @@ module zm_conv
    real(r8) :: MCSP_uwind_coeff = unset_r8
    real(r8) :: MCSP_vwind_coeff = unset_r8
 
+!===================================================================================================
 contains
+!===================================================================================================
 
 subroutine zmconv_readnl(nlfile)
 
    use namelist_utils,  only: find_group_name
    use units,           only: getunit, freeunit
+   use zm_conv_types,   only: zm_param_mpi_broadcast
    use mpishorthand
 
    character(len=*), intent(in) :: nlfile  ! filepath for file containing namelist input
@@ -186,20 +186,24 @@ subroutine zmconv_readnl(nlfile)
       trig_ull_only    = zmconv_trig_ull_only
       zm_microp        = zmconv_microp
       clos_dyn_adj     = zmconv_clos_dyn_adj
-      tpert_fix        = zmconv_tpert_fix
-      tiedke_add       = zmconv_tiedke_add
-      num_cin          = zmconv_cape_cin
-      mx_bot_lyr_adj   = zmconv_mx_bot_lyr_adj
-      dmpdz            = zmconv_dmpdz
-      tp_fac           = zmconv_tp_fac
       auto_fac         = zmconv_auto_fac
       accr_fac         = zmconv_accr_fac
       micro_dcs        = zmconv_micro_dcs
       MCSP_heat_coeff  = zmconv_MCSP_heat_coeff
       MCSP_moisture_coeff = zmconv_MCSP_moisture_coeff
       MCSP_uwind_coeff = zmconv_MCSP_uwind_coeff
-      MCSP_vwind_coeff = zmconv_MCSP_vwind_coeff     
- 
+      MCSP_vwind_coeff = zmconv_MCSP_vwind_coeff
+
+      ! set zm_param values
+      zm_param%trig_dcape      = trigdcape_ull .or. trig_dcape_only
+      zm_param%trig_ull        = trigdcape_ull .or. trig_ull_only
+      zm_param%tiedke_add      = zmconv_tiedke_add
+      zm_param%dmpdz           = zmconv_dmpdz
+      zm_param%num_cin         = zmconv_cape_cin
+      zm_param%tpert_fix       = zmconv_tpert_fix
+      zm_param%tpert_fac       = zmconv_tp_fac
+      zm_param%mx_bot_lyr_adj  = zmconv_mx_bot_lyr_adj
+
       if( abs(MCSP_heat_coeff)+abs(MCSP_moisture_coeff)+abs(MCSP_uwind_coeff)+abs(MCSP_vwind_coeff) > 0._r8 ) then
            MCSP = .true.
       else
@@ -236,8 +240,8 @@ subroutine zmconv_readnl(nlfile)
          write(iulog,*)'**** ZM scheme uses cloud-base mass flux adjustment:',clos_dyn_adj
       end if
 
-      if(tpert_fix) then
-         write(iulog,*)'**** ZM scheme uses tpert_fix:',tpert_fix
+      if(zm_param%tpert_fix) then
+         write(iulog,*)'**** ZM scheme uses tpert_fix:',zm_param%tpert_fix
       end if
    end if
 
@@ -247,18 +251,12 @@ subroutine zmconv_readnl(nlfile)
    call mpibcast(c0_ocn,            1, mpir8,  0, mpicom)
    call mpibcast(ke,                1, mpir8,  0, mpicom)
    call mpibcast(tau,               1, mpir8,  0, mpicom)
-   call mpibcast(dmpdz,             1, mpir8,  0, mpicom)
    call mpibcast(alfa_scalar,       1, mpir8,  0, mpicom)
    call mpibcast(trigdcape_ull,     1, mpilog, 0, mpicom)
    call mpibcast(trig_dcape_only,   1, mpilog, 0, mpicom)
    call mpibcast(trig_ull_only,     1, mpilog, 0, mpicom)
    call mpibcast(zm_microp,         1, mpilog, 0, mpicom)
    call mpibcast(clos_dyn_adj,      1, mpilog, 0, mpicom)
-   call mpibcast(tpert_fix,         1, mpilog, 0, mpicom)
-   call mpibcast(tiedke_add,        1, mpir8,  0, mpicom)
-   call mpibcast(num_cin,           1, mpiint, 0, mpicom)
-   call mpibcast(mx_bot_lyr_adj,    1, mpiint, 0, mpicom)
-   call mpibcast(tp_fac,            1, mpir8,  0, mpicom)
    call mpibcast(auto_fac,          1, mpir8,  0, mpicom)
    call mpibcast(accr_fac,          1, mpir8,  0, mpicom)
    call mpibcast(micro_dcs,         1, mpir8,  0, mpicom)  
@@ -266,7 +264,10 @@ subroutine zmconv_readnl(nlfile)
    call mpibcast(MCSP_heat_coeff,   1, mpir8,  0, mpicom)
    call mpibcast(MCSP_moisture_coeff,1, mpir8,  0, mpicom)
    call mpibcast(MCSP_uwind_coeff,  1, mpir8,  0, mpicom)
-   call mpibcast(MCSP_vwind_coeff,  1, mpir8,  0, mpicom)  
+   call mpibcast(MCSP_vwind_coeff,  1, mpir8,  0, mpicom)
+
+   call zm_param_mpi_broadcast(zm_param)
+
 #endif
 
 end subroutine zmconv_readnl
@@ -275,6 +276,7 @@ end subroutine zmconv_readnl
 subroutine zm_convi(limcnv_in, no_deep_pbl_in)
 
    use dycore,       only: dycore_is, get_resolution
+   use zm_conv_types, only: zm_const_set_to_global
 
    integer, intent(in)           :: limcnv_in       ! top interface level limit for convection
    logical, intent(in), optional :: no_deep_pbl_in  ! no_deep_pbl = .true. eliminates ZM convection entirely within PBL 
@@ -283,7 +285,7 @@ subroutine zm_convi(limcnv_in, no_deep_pbl_in)
    character(len=32)   :: hgrid           ! horizontal grid specifier
 
    ! Initialization of ZM constants
-   limcnv = limcnv_in
+   zm_param%limcnv = limcnv_in
    tfreez = tmelt
    eps1   = epsilo
    rl     = latvap
@@ -304,11 +306,14 @@ subroutine zm_convi(limcnv_in, no_deep_pbl_in)
 
    hgrid = get_resolution()
 
+   ! set zm_const using global values
+   call zm_const_set_to_global(zm_const)
+
    if ( masterproc ) then
       write(iulog,*) 'tuning parameters zm_convi: tau',tau
       write(iulog,*) 'tuning parameters zm_convi: c0_lnd',c0_lnd, ', c0_ocn', c0_ocn 
       write(iulog,*) 'tuning parameters zm_convi: ke',ke
-      write(iulog,*) 'tuning parameters zm_convi: dmpdz',dmpdz
+      write(iulog,*) 'tuning parameters zm_convi: dmpdz',zm_param%dmpdz
       write(iulog,*) 'tuning parameters zm_convi: alfa',alfa_scalar
       write(iulog,*) 'tuning parameters zm_convi: no_deep_pbl',no_deep_pbl
    endif
@@ -665,7 +670,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
 !
 ! Set internal variable "msg" (convection limit) to "limcnv-1"
 !
-   msg = limcnv - 1
+   msg = zm_param%limcnv - 1
 !
 ! initialize necessary arrays.
 ! zero out variables not used in cam
@@ -805,30 +810,27 @@ subroutine zm_convr(lchnk   ,ncol    , &
    ! DCAPE is the difference in CAPE between the two calls using the same launch level
 
    iclosure = .true.
-   call buoyan_dilute(lchnk   ,ncol    ,                             &
-                      q       ,t       ,p       ,z       ,pf       , &
-                      tp      ,qstp    ,tl      ,rl      ,cape     , &
-                      pblt    ,lcl     ,lel     ,lon     ,maxi     , &
-                      rgas    ,grav    ,cpres   ,msg               , &
-                      tpert   ,iclosure                            )
-
+   call compute_dilute_cape( ncol, zm_param%num_cin, msg, &
+                             q, t, z, p, pf, &
+                             pblt, tpert, &
+                             tp, qstp, maxi, tl, &
+                             lcl, lel, cape, &
+                             zm_const, zm_param, &
+                             iclosure )
    if (trigdcape_ull .or. trig_dcape_only) dcapemx(:ncol) = maxi(:ncol)
 
-   !DCAPE-ULL
-   if ( .not.is_first_step() .and. (trigdcape_ull.or.trig_dcape_only) ) then
-
+   ! Calculate dcape trigger condition
+   if ( .not.is_first_step() .and. zm_param%trig_dcape ) then
       iclosure = .false.
-      call buoyan_dilute( lchnk   ,ncol    ,                             &
-                          q_star  ,t_star  ,p       ,z       ,pf       , &
-                          tpm1    ,qstpm1  ,tlm1    ,rl      ,capem1   , &
-                          pblt    ,lclm1   ,lelm1   ,lonm1   ,maxim1   , &
-                          rgas    ,grav    ,cpres   ,msg               , &
-                          tpert   ,iclosure, dcapemx                   )
-
+      call compute_dilute_cape( ncol, zm_param%num_cin, msg, &
+                                q_star, t_star, z, p, pf, &
+                                pblt, tpert, &
+                                tpm1, qstpm1, maxim1, tlm1, &
+                                lclm1, lelm1, capem1, &
+                                zm_const, zm_param, &
+                                iclosure, dcapemx )
       dcape(:ncol) = (cape(:ncol)-capem1(:ncol))/(delt*2._r8)
-
    endif
-
 
 !
 ! determine whether grid points will undergo some deep convection
@@ -989,7 +991,7 @@ subroutine zm_convr(lchnk   ,ncol    , &
                cmeg    ,maxg    ,lelg    ,jt      ,jlcl    , &
                maxg    ,j0      ,jd      ,rl      ,lengath , &
                rgas    ,grav    ,cpres   ,msg     , &
-               pflxg   ,evpg    ,cug     ,rprdg   ,limcnv  , &
+               pflxg   ,evpg    ,cug     ,rprdg   ,zm_param%limcnv  , &
                landfracg, tpertg, &  
                aero    ,qhat ,lambdadpcug,mudpcug ,sprdg   ,frzg ,  &
                qldeg   ,qideg   ,qsdeg   ,ncdeg   ,nideg   ,nsdeg,  &
@@ -2092,15 +2094,15 @@ subroutine cldprp(lchnk   , &
            ! represent subgrid temperature perturbation. If PBL temperature perturbation (tpert)
            ! is used to represent subgrid temperature perturbation, tiedke_add may need to be 
            ! removed. In addition, current calculation of PBL temperature perturbation is not 
-           ! accurate enough so that a new tunable parameter tp_fac was introduced. This introduced
+           ! accurate enough so that a new tunable parameter tpert_fac was introduced. This introduced
            ! new uncertainties into the ZM scheme. The original code of ZM scheme will be used 
            ! when tpert_fix=.true.  
-           if(tpert_fix) then
-             hu(i,k) = hmn(i,mx(i)) + cp*tiedke_add 
-             su(i,k) = s(i,mx(i)) + tiedke_add
+           if(zm_param%tpert_fix) then
+             hu(i,k) = hmn(i,mx(i)) + cp*zm_param%tiedke_add 
+             su(i,k) = s(i,mx(i))   +    zm_param%tiedke_add
            else
-             hu(i,k) = hmn(i,mx(i)) + cp*(tiedke_add+tp_fac*tpertg(i)) 
-             su(i,k) = s(i,mx(i)) + tiedke_add+tp_fac*tpertg(i)
+             hu(i,k) = hmn(i,mx(i)) + cp*(zm_param%tiedke_add+zm_param%tpert_fac*tpertg(i)) 
+             su(i,k) = s(i,mx(i))   +     zm_param%tiedke_add+zm_param%tpert_fac*tpertg(i)
            end if
          end if
       end do
@@ -2215,7 +2217,7 @@ subroutine cldprp(lchnk   , &
       end do
       do i = 1,il2g
           totpcp(i) = 0._r8
-          if (zm_microp)  hu(i,jb(i)) = hmn(i,jb(i)) + cp*tiedke_add
+          if (zm_microp)  hu(i,jb(i)) = hmn(i,jb(i)) + cp*zm_param%tiedke_add
       end do
 
 !
@@ -3089,689 +3091,6 @@ subroutine q1q2_pjr(lchnk   , &
 end subroutine q1q2_pjr
 
 
-subroutine buoyan_dilute(lchnk   ,ncol    , &! in
-                  q_in    ,t_in    ,p       ,z       ,pf      , &! in
-                  tp      ,qstp    ,tl      ,rl      ,cape    , &! rl = in, others = out
-                  pblt    ,lcl     ,lel     ,lon     ,mx      , &! pblt = in; others = out
-                  rd      ,grav    ,cp      ,msg     ,          &! in
-                  tpert   ,iclosure,                            &! in
-                  dcapemx , use_input_parcel_tq_in,             &! in, optional
-                  q_mx    ,t_mx                                 )! in, optional
 
-!----------------------------------------------------------------------- 
-! 
-! Purpose: 
-! Calculates CAPE the lifting condensation level and the convective top
-! where buoyancy is first -ve.
-! 
-! Method: Calculates the parcel temperature based on a simple constant
-! entraining plume model. CAPE is integrated from buoyancy.
-! 09/09/04 - Simplest approach using an assumed entrainment rate for 
-!            testing (dmpdp). 
-! 08/04/05 - Swap to convert dmpdz to dmpdp  
-!
-! SCAM Logical Switches - DILUTE:RBN - Now Disabled 
-! ---------------------
-! switch(1) = .T. - Uses the dilute parcel calculation to obtain tendencies.
-! switch(2) = .T. - Includes entropy/q changes due to condensate loss and freezing.
-! switch(3) = .T. - Adds the PBL Tpert for the parcel temperature at all levels.
-! 
-! References:
-! Raymond and Blythe (1992) JAS 
-! 
-! Author:
-! Richard Neale - September 2004
-! 
-!-----------------------------------------------------------------------
-   implicit none
-!-----------------------------------------------------------------------
-!
-! input arguments
-!
-   integer, intent(in) :: lchnk                 ! chunk identifier
-   integer, intent(in) :: ncol                  ! number of atmospheric columns
-
-   real(r8), intent(in) :: q_in(pcols,pver)     ! spec. humidity
-   real(r8), intent(in) :: t_in(pcols,pver)     ! temperature
-   real(r8), intent(in) :: p(pcols,pver)        ! pressure
-   real(r8), intent(in) :: z(pcols,pver)        ! height
-   real(r8), intent(in) :: pf(pcols,pver+1)     ! pressure at interfaces
-
-   integer,  intent(in) :: pblt(pcols)          ! index of pbl depth
-
-   real(r8), intent(in) :: rl
-   real(r8), intent(in) :: rd
-   real(r8), intent(in) :: cp
-   real(r8), intent(in) :: grav
-   integer,  intent(in) :: msg
-   real(r8), intent(in) :: tpert(pcols)          ! perturbation temperature by pbl processes
-   logical,  intent(in) :: iclosure              ! true for normal procedure, otherwise use dcapemx from 1st call
-
-   integer, intent(in), optional :: dcapemx(pcols)
-
-   logical, intent(in),    optional :: use_input_parcel_tq_in  ! if .true., use input values of dcapemx, q_mx, t_mx
-   real(r8),intent(inout), optional :: q_mx(pcols)             ! in the CAPE calculation
-   real(r8),intent(inout), optional :: t_mx(pcols)
-!
-! output arguments
-!
-   real(r8), intent(out) :: tp(pcols,pver)       ! parcel temperature
-   real(r8), intent(out) :: qstp(pcols,pver)     ! saturation mixing ratio of parcel (only above lcl, just q below).
-   real(r8), intent(out) :: tl(pcols)            ! parcel temperature at lcl
-   real(r8), intent(out) :: cape(pcols)          ! convective aval. pot. energy.
-
-   integer, intent(out) :: lcl(pcols)        !
-   integer, intent(out) :: lel(pcols)        !
-   integer, intent(out) :: lon(pcols)        ! level of onset of deep convection
-   integer, intent(out) :: mx(pcols)         ! level of max moist static energy
-!
-!--------------------------Local Variables------------------------------
-!
-   logical  :: use_input_parcel_tq
-   real(r8) :: q(pcols,pver)        ! spec. humidity
-   real(r8) :: t(pcols,pver)        ! temperature
-
-   real(r8) capeten(pcols,num_cin)     ! provisional value of cape
-   real(r8) tv(pcols,pver)       !
-   real(r8) tpv(pcols,pver)      !
-   real(r8) buoy(pcols,pver)
-   real(r8) a1(pcols)
-   real(r8) a2(pcols)
-   real(r8) estp(pcols)
-   real(r8) pl(pcols)
-   real(r8) plexp(pcols)
-   real(r8) hmax(pcols)
-   real(r8) hmn(pcols)
-   real(r8) y(pcols)
-
-   logical plge600(pcols)
-   integer knt(pcols)
-   integer lelten(pcols,num_cin)
-
-! DCAPE-ULL
-   integer pblt600(pcols)
-   integer top_k(pcols)
-
-   real(r8) e
-   integer i
-   integer k
-   integer n
-   integer bot_layer
-
-#ifdef PERGRO
-   real(r8) rhd
-#endif
-!
-!-----------------------------------------------------------------------
-!
-   if (PRESENT(use_input_parcel_tq_in)) then
-      use_input_parcel_tq = use_input_parcel_tq_in
-   else
-      use_input_parcel_tq = .false.
-   end if
-
-   if (  use_input_parcel_tq  .and. &
-        ((.not.PRESENT(t_mx)) .or.  &
-         (.not.PRESENT(q_mx)) .or.  &
-         (.not.PRESENT(dcapemx)) )  ) then
-     call endrun('buoyan_dilute :: use_input_parcel_tq = .t. but dcapemx, t_mx or q_mx is not provided')
-  end if
-
-  !------------------------------------------------------------------------------------
-  ! Copy the incoming temperature and specific humidity values to work arrays. 
-  ! The latter will be used in the buoyancy calculation.
-  !-----------------------------------------------------------------------------------
-  t(:ncol,:) = t_in(:ncol,:)
-  q(:ncol,:) = q_in(:ncol,:)
-
-
-  if (use_input_parcel_tq) then
-  !------------------------------------------------------------------------------------
-  ! We expect 
-  ! (1) the incoming array dcapemx contains previously identified launching level index, and 
-  ! (2) the arrays q_mx and t_mx contain q and T values at the old launching level 
-  !     at the time when the old launching level was identified. 
-  ! Copy the old values to work arrays for calculations in the rest of this subroutine
-  !------------------------------------------------------------------------------------
-
-     mx(:ncol) = dcapemx(:ncol)
-
-     do i=1,ncol
-        q(i,mx(i)) = q_mx(i)
-        t(i,mx(i)) = t_mx(i)
-     end do
-
-  else ! initialize the mx array
-
-     mx(:) = pver
-
-  end if
-
-!-----------------------------------------------------------------------
-
-   do n = 1,num_cin
-      do i = 1,ncol
-         lelten(i,n) = pver
-         capeten(i,n) = 0._r8
-      end do
-   end do
-!
-   do i = 1,ncol
-      lon(i) = pver
-      knt(i) = 0
-      lel(i) = pver
-      cape(i) = 0._r8
-      hmax(i) = 0._r8
-   end do
-
-   tp(:ncol,:) = t(:ncol,:)
-   qstp(:ncol,:) = q(:ncol,:)
-
-!DCAPE-ULL
-   if (trigdcape_ull .or. trig_ull_only) then
-      pblt600(:ncol) = 1
-      do k = pver - 1,msg + 1,-1
-      do i = 1,ncol
-         if ((p(i,k).le.600._r8) .and. (p(i,k+1).gt.600._r8)) pblt600(i) = k
-      end do
-      end do
-   endif
-
-!!! RBN - Initialize tv and buoy for output.
-!!! tv=tv : tpv=tpv : qstp=q : buoy=0.
-   tv(:ncol,:) = t(:ncol,:) *(1._r8+1.608_r8*q(:ncol,:))/ (1._r8+q(:ncol,:))
-   tpv(:ncol,:) = tv(:ncol,:)
-   buoy(:ncol,:) = 0._r8
-!
-! set "launching" level(mx) to be at maximum moist static energy.
-! search for this level stops at planetary boundary layer top.
-!
-   bot_layer = pver - mx_bot_lyr_adj
-
-! DCAPE-ULL
-  if ((trigdcape_ull .or. trig_dcape_only ).and. (.not. iclosure)) then
-  !------------------------------------------------------
-  ! Use max moist static energy level that is passed in
-  !------------------------------------------------------
-     if (.not.PRESENT(dcapemx)) call endrun('** ZM CONV buoyan_dilute: dcapemx not present **')
-     mx(:ncol) = dcapemx(:ncol)
-
-  elseif (.not.use_input_parcel_tq) then
-  !----------------------------------------------
-  ! Search for max moist static energy level
-  !----------------------------------------------
-   if (trigdcape_ull .or. trig_ull_only) then !DCAPE-ULL
-      top_k(:ncol) = pblt600(:ncol)
-   else
-      top_k(:ncol) = pblt(:ncol)
-   end if
-
-#ifdef PERGRO
-   do k = bot_layer,msg + 1,-1
-      do i = 1,ncol
-         hmn(i) = cp*t(i,k) + grav*z(i,k) + rl*q(i,k)
-!
-! Reset max moist static energy level when relative difference exceeds 1.e-4
-!
-         rhd = (hmn(i) - hmax(i))/(hmn(i) + hmax(i))
-
-           if (k >= top_k(i) .and. k <= lon(i) .and. rhd > -1.e-4_r8) then
-              hmax(i) = hmn(i)
-              mx(i) = k
-           end if
-
-      end do
-   end do
-#else
-   do k = bot_layer,msg + 1,-1
-      do i = 1,ncol
-         hmn(i) = cp*t(i,k) + grav*z(i,k) + rl*q(i,k)
-
-            if (k >= top_k(i) .and. k <= lon(i) .and. hmn(i) > hmax(i)) then
-               hmax(i) = hmn(i)
-               mx(i) = k
-            end if
-
-      end do
-   end do
-#endif
-
-  end if
-
-!--------------------------------------
-! Save launching level T, q for output
-!--------------------------------------
-  if ( .not.use_input_parcel_tq .and. PRESENT(q_mx) .and. PRESENT(t_mx) ) then
-     do i=1,ncol
-        q_mx(i) = q(i,mx(i))
-        t_mx(i) = t(i,mx(i))
-     end do
-  end if
-
-! LCL dilute calculation - initialize to mx(i)
-! Determine lcl in parcel_dilute and get pl,tl after parcel_dilute
-! Original code actually sets LCL as level above wher condensate forms.
-! Therefore in parcel_dilute lcl(i) will be at first level where qsmix < qtmix.
-
-   do i = 1,ncol ! Initialise LCL variables.
-      lcl(i) = mx(i)
-      tl(i) = t(i,mx(i))
-      pl(i) = p(i,mx(i))
-   end do
-
-!
-! main buoyancy calculation.
-!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!!! DILUTE PLUME CALCULATION USING ENTRAINING PLUME !!!
-!!!   RBN 9/9/04   !!!
-    call parcel_dilute(lchnk, ncol, msg, mx, p, t, q, tpert, pblt, tp, tpv, qstp, pl, tl, lcl) 
-    
-
-! If lcl is above the nominal level of non-divergence (600 mbs),
-! no deep convection is permitted (ensuing calculations
-! skipped and cape retains initialized value of zero).
-!
-   do i = 1,ncol
-      plge600(i) = pl(i).ge.600._r8 ! Just change to always allow buoy calculation.
-   end do
-
-!
-! Main buoyancy calculation.
-!
-   do k = pver,msg + 1,-1
-      do i=1,ncol
-         if (k <= mx(i) .and. plge600(i)) then   ! Define buoy from launch level to cloud top.
-            tv(i,k) = t(i,k)* (1._r8+1.608_r8*q(i,k))/ (1._r8+q(i,k))
-            buoy(i,k) = tpv(i,k) - tv(i,k) + tiedke_add  ! +0.5K or not?
-         else
-            qstp(i,k) = q(i,k)
-            tp(i,k)   = t(i,k)            
-            tpv(i,k)  = tv(i,k)
-         endif
-      end do
-   end do
-
-
-
-!-------------------------------------------------------------------------------
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-
-!
-   do k = msg + 2,pver
-      do i = 1,ncol
-         if (k < lcl(i) .and. plge600(i)) then
-            if (buoy(i,k+1) > 0._r8 .and. buoy(i,k) <= 0._r8) then
-               knt(i) = min(num_cin,knt(i) + 1)
-               lelten(i,knt(i)) = k
-            end if
-         end if
-      end do
-   end do
-!
-! calculate convective available potential energy (cape).
-!
-   do n = 1,num_cin
-      do k = msg + 1,pver
-         do i = 1,ncol
-            if (plge600(i) .and. k <= mx(i) .and. k > lelten(i,n)) then
-               capeten(i,n) = capeten(i,n) + rd*buoy(i,k)*log(pf(i,k+1)/pf(i,k))
-            end if
-         end do
-      end do
-   end do
-!
-! find maximum cape from all possible tentative capes from
-! one sounding,
-! and use it as the final cape, april 26, 1995
-!
-   do n = 1,num_cin
-      do i = 1,ncol
-         if (capeten(i,n) > cape(i)) then
-            cape(i) = capeten(i,n)
-            lel(i) = lelten(i,n)
-         end if
-      end do
-   end do
-!
-! put lower bound on cape for diagnostic purposes.
-!
-   do i = 1,ncol
-      cape(i) = max(cape(i), 0._r8)
-   end do
-!
-   return
-end subroutine buoyan_dilute
-
-subroutine parcel_dilute (lchnk, ncol, msg, klaunch, p, t, q, tpert, pblt, tp, tpv, qstp, pl, tl, lcl) 
-! Routine  to determine 
-!   1. Tp   - Parcel temperature
-!   2. qstp - Saturated mixing ratio at the parcel temperature.
-
-!--------------------
-implicit none
-!--------------------
-
-integer, intent(in) :: lchnk
-integer, intent(in) :: ncol
-integer, intent(in) :: msg
-
-integer, intent(in), dimension(pcols) :: klaunch(pcols)
-
-real(r8), intent(in), dimension(pcols,pver) :: p
-real(r8), intent(in), dimension(pcols,pver) :: t
-real(r8), intent(in), dimension(pcols,pver) :: q
-real(r8), intent(in), dimension(pcols) :: tpert ! PBL temperature perturbation.
-integer,  intent(in), dimension(pcols) :: pblt          ! index of pbl depth 
-
-real(r8), intent(inout), dimension(pcols,pver) :: tp    ! Parcel temp.
-real(r8), intent(inout), dimension(pcols,pver) :: qstp  ! Parcel water vapour (sat value above lcl).
-real(r8), intent(inout), dimension(pcols) :: tl         ! Actual temp of LCL.
-real(r8), intent(inout), dimension(pcols) :: pl          ! Actual pressure of LCL. 
-
-integer, intent(inout), dimension(pcols) :: lcl ! Lifting condesation level (first model level with saturation).
-
-real(r8), intent(out), dimension(pcols,pver) :: tpv   ! Define tpv within this routine.
-
-!--------------------
-
-! Have to be careful as s is also dry static energy.
-
-
-! If we are to retain the fact that CAM loops over grid-points in the internal
-! loop then we need to dimension sp,atp,mp,xsh2o with ncol.
-
-
-real(r8) tmix(pcols,pver)        ! Tempertaure of the entraining parcel.
-real(r8) qtmix(pcols,pver)       ! Total water of the entraining parcel.
-real(r8) qsmix(pcols,pver)       ! Saturated mixing ratio at the tmix.
-real(r8) smix(pcols,pver)        ! Entropy of the entraining parcel.
-real(r8) xsh2o(pcols,pver)       ! Precipitate lost from parcel.
-real(r8) ds_xsh2o(pcols,pver)    ! Entropy change due to loss of condensate.
-real(r8) ds_freeze(pcols,pver)   ! Entropy change sue to freezing of precip.
-
-real(r8) mp(pcols)    ! Parcel mass flux.
-real(r8) qtp(pcols)   ! Parcel total water.
-real(r8) sp(pcols)    ! Parcel entropy.
-
-real(r8) sp0(pcols)    ! Parcel launch entropy.
-real(r8) qtp0(pcols)   ! Parcel launch total water.
-real(r8) mp0(pcols)    ! Parcel launch relative mass flux.
-
-real(r8) tpertg(pcols)
-
-real(r8) lwmax      ! Maximum condesate that can be held in cloud before rainout.
-real(r8) dmpdp      ! Parcel fractional mass entrainment rate (/mb).
-!real(r8) dmpdpc     ! In cloud parcel mass entrainment rate (/mb).
-!real(r8) dmpdz      ! Parcel fractional mass entrainment rate (/m)
-real(r8) dpdz,dzdp  ! Hydrstatic relation and inverse of.
-real(r8) senv       ! Environmental entropy at each grid point.
-real(r8) qtenv      ! Environmental total water "   "   ".
-real(r8) penv       ! Environmental total pressure "   "   ".
-real(r8) tenv       ! Environmental total temperature "   "   ".
-real(r8) new_s      ! Hold value for entropy after condensation/freezing adjustments.
-real(r8) new_q      ! Hold value for total water after condensation/freezing adjustments.
-real(r8) dp         ! Layer thickness (center to center)
-real(r8) tfguess    ! First guess for entropy inversion - crucial for efficiency!
-real(r8) tscool     ! Super cooled temperature offset (in degC) (eg -35).
-
-real(r8) qxsk, qxskp1        ! LCL excess water (k, k+1)
-real(r8) dsdp, dqtdp, dqxsdp ! LCL s, qt, p gradients (k, k+1)
-real(r8) slcl,qtlcl,qslcl    ! LCL s, qt, qs values.
-
-integer rcall       ! Number of ientropy call for errors recording
-integer nit_lheat     ! Number of iterations for condensation/freezing loop.
-integer i,k,ii   ! Loop counters.
-
-!======================================================================
-!    SUMMARY
-!
-!  9/9/04 - Assumes parcel is initiated from level of maxh (klaunch)
-!           and entrains at each level with a specified entrainment rate.
-!
-! 15/9/04 - Calculates lcl(i) based on k where qsmix is first < qtmix.          
-!
-!======================================================================
-!
-! Set some values that may be changed frequently.
-!
-
-nit_lheat = 2 ! iterations for ds,dq changes from condensation freezing.
-
-
-!dmpdpc = 3.e-2_r8   ! In cloud entrainment rate (/mb).
-lwmax = 1.e-3_r8    ! Need to put formula in for this.
-tscool = 0.0_r8   ! Temp at which water loading freezes in the cloud.
-
-qtmix=0._r8
-smix=0._r8
-
-qtenv = 0._r8
-senv = 0._r8
-tenv = 0._r8
-penv = 0._r8
-
-qtp0 = 0._r8
-sp0  = 0._r8
-mp0 = 0._r8
-
-qtp = 0._r8
-sp = 0._r8
-mp = 0._r8
-
-new_q = 0._r8
-new_s = 0._r8
-
-
-! The original ZM scheme only treats PBL-rooted convection. PBL temperature perturbation (tpert) was  
-! used to increase the parcel temperatue at launch level, which is in PBL.
-! The dcape_ull or ull triggr enables ZM scheme to treat elevated convection with launch level above PBL.
-! If parcel launch level is above PBL top, tempeature perturbation in PBL should not be able to influence 
-! it. In this situation, the temporary varaible tpertg is reset to zero.  
-do i=1,ncol
-  tpertg(i)=tpert(i)
-  if ( tpert_fix .and. klaunch(i)<pblt(i)) tpertg(i)=0._r8
-end do
-
-
-! **** Begin loops ****
-
-do k = pver, msg+1, -1
-   do i=1,ncol 
-
-! Initialize parcel values at launch level.
-
-      if (k == klaunch(i)) then 
-         qtp0(i) = q(i,k)   ! Parcel launch total water (assuming subsaturated) - OK????.
-         sp0(i)  = entropy(t(i,k),p(i,k),qtp0(i))  ! Parcel launch entropy.
-         mp0(i)  = 1._r8       ! Parcel launch relative mass (i.e. 1 parcel stays 1 parcel for dmpdp=0, undilute). 
-         smix(i,k)  = sp0(i)
-         qtmix(i,k) = qtp0(i)
-         tfguess = t(i,k)
-         rcall = 1
-         call ientropy (rcall,i,lchnk,smix(i,k),p(i,k),qtmix(i,k),tmix(i,k),qsmix(i,k),tfguess)
-      end if
-
-! Entraining levels
-      
-      if (k < klaunch(i)) then 
-
-! Set environmental values for this level.                 
-         
-         dp = (p(i,k)-p(i,k+1)) ! In -ve mb as p decreasing with height - difference between center of layers.
-         qtenv = 0.5_r8*(q(i,k)+q(i,k+1))         ! Total water of environment.
-         tenv  = 0.5_r8*(t(i,k)+t(i,k+1)) 
-         penv  = 0.5_r8*(p(i,k)+p(i,k+1))
-
-         senv  = entropy(tenv,penv,qtenv)  ! Entropy of environment.   
-
-! Determine fractional entrainment rate /pa given value /m.
-
-         dpdz = -(penv*grav)/(rgas*tenv) ! in mb/m since  p in mb.
-         dzdp = 1._r8/dpdz                  ! in m/mb
-         dmpdp = dmpdz*dzdp              ! /mb Fractional entrainment
-! Sum entrainment to current level
-! entrains q,s out of intervening dp layers, in which linear variation is assumed
-! so really it entrains the mean of the 2 stored values.
-
-         sp(i)  = sp(i)  - dmpdp*dp*senv 
-         qtp(i) = qtp(i) - dmpdp*dp*qtenv 
-         mp(i)  = mp(i)  - dmpdp*dp
-            
-! Entrain s and qt to next level.
-
-         smix(i,k)  = (sp0(i)  +  sp(i)) / (mp0(i) + mp(i))
-         qtmix(i,k) = (qtp0(i) + qtp(i)) / (mp0(i) + mp(i))
-
-! Invert entropy from s and q to determine T and saturation-capped q of mixture.
-! t(i,k) used as a first guess so that it converges faster.
-
-         tfguess = tmix(i,k+1)
-         rcall = 2
-         call ientropy(rcall,i,lchnk,smix(i,k),p(i,k),qtmix(i,k),tmix(i,k),qsmix(i,k),tfguess)   
-
-!
-! Determine if this is lcl of this column if qsmix <= qtmix.
-! FIRST LEVEL where this happens on ascending.
-
-         if (qsmix(i,k) <= qtmix(i,k) .and. qsmix(i,k+1) > qtmix(i,k+1)) then
-            lcl(i) = k
-            qxsk   = qtmix(i,k) - qsmix(i,k)
-            qxskp1 = qtmix(i,k+1) - qsmix(i,k+1)
-            dqxsdp = (qxsk - qxskp1)/dp
-            pl(i)  = p(i,k+1) - qxskp1/dqxsdp    ! pressure level of actual lcl.
-            dsdp   = (smix(i,k)  - smix(i,k+1))/dp
-            dqtdp  = (qtmix(i,k) - qtmix(i,k+1))/dp
-            slcl   = smix(i,k+1)  +  dsdp* (pl(i)-p(i,k+1))  
-            qtlcl  = qtmix(i,k+1) +  dqtdp*(pl(i)-p(i,k+1))
-
-            tfguess = tmix(i,k)
-            rcall = 3
-            call ientropy (rcall,i,lchnk,slcl,pl(i),qtlcl,tl(i),qslcl,tfguess)
-
-!            write(iulog,*)' '
-!            write(iulog,*)' p',p(i,k+1),pl(i),p(i,lcl(i))
-!            write(iulog,*)' t',tmix(i,k+1),tl(i),tmix(i,lcl(i))
-!            write(iulog,*)' s',smix(i,k+1),slcl,smix(i,lcl(i))
-!            write(iulog,*)'qt',qtmix(i,k+1),qtlcl,qtmix(i,lcl(i))
-!            write(iulog,*)'qs',qsmix(i,k+1),qslcl,qsmix(i,lcl(i))
-
-         endif
-!         
-      end if !  k < klaunch
-
- 
-   end do ! Levels loop
-end do ! Columns loop
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!END ENTRAINMENT LOOP!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-!! Could stop now and test with this as it will provide some estimate of buoyancy
-!! without the effects of freezing/condensation taken into account for tmix.
-
-!! So we now have a profile of entropy and total water of the entraining parcel
-!! Varying with height from the launch level klaunch parcel=environment. To the 
-!! top allowed level for the existence of convection.
-
-!! Now we have to adjust these values such that the water held in vaopor is < or 
-!! = to qsmix. Therefore, we assume that the cloud holds a certain amount of
-!! condensate (lwmax) and the rest is rained out (xsh2o). This, obviously 
-!! provides latent heating to the mixed parcel and so this has to be added back 
-!! to it. But does this also increase qsmix as well? Also freezing processes
- 
-
-xsh2o = 0._r8
-ds_xsh2o = 0._r8
-ds_freeze = 0._r8
-
-!!!!!!!!!!!!!!!!!!!!!!!!!PRECIPITATION/FREEZING LOOP!!!!!!!!!!!!!!!!!!!!!!!!!!
-!! Iterate solution twice for accuracy
-
-
-
-do k = pver, msg+1, -1
-   do i=1,ncol    
-      
-! Initialize variables at k=klaunch
-      
-      if (k == klaunch(i)) then
-
-! Set parcel values at launch level assume no liquid water.            
-
-         tp(i,k)    = tmix(i,k)
-         qstp(i,k)  = q(i,k) 
-         tpv(i,k)   =  (tp(i,k) + tp_fac*tpertg(i)) * (1._r8+1.608_r8*qstp(i,k)) / (1._r8+qstp(i,k))
-         
-      end if
-
-      if (k < klaunch(i)) then
-            
-! Initiaite loop if switch(2) = .T. - RBN:DILUTE - TAKEN OUT BUT COULD BE RETURNED LATER.
-
-! Iterate nit_lheat times for s,qt changes.
-
-         do ii=0,nit_lheat-1            
-
-! Rain (xsh2o) is excess condensate, bar LWMAX (Accumulated loss from qtmix).
-
-            xsh2o(i,k) = max (0._r8, qtmix(i,k) - qsmix(i,k) - lwmax)
-
-! Contribution to ds from precip loss of condensate (Accumulated change from smix).(-ve)                     
-                     
-            ds_xsh2o(i,k) = ds_xsh2o(i,k+1) - cpliq * log (tmix(i,k)/tfreez) * max(0._r8,(xsh2o(i,k)-xsh2o(i,k+1)))
-!
-! Entropy of freezing: latice times amount of water involved divided by T.
-!
- 
-            if (tmix(i,k) <= tfreez+tscool .and. ds_freeze(i,k+1) == 0._r8) then ! One off freezing of condensate. 
-               ds_freeze(i,k) = (latice/tmix(i,k)) * max(0._r8,qtmix(i,k)-qsmix(i,k)-xsh2o(i,k)) ! Gain of LH
-            end if
-            
-            if (tmix(i,k) <= tfreez+tscool .and. ds_freeze(i,k+1) /= 0._r8) then ! Continual freezing of additional condensate.
-               ds_freeze(i,k) = ds_freeze(i,k+1)+(latice/tmix(i,k)) * max(0._r8,(qsmix(i,k+1)-qsmix(i,k)))
-            end if
-            
-! Adjust entropy and accordingly to sum of ds (be careful of signs).
-
-            new_s = smix(i,k) + ds_xsh2o(i,k) + ds_freeze(i,k) 
-
-! Adjust liquid water and accordingly to xsh2o.
-
-            new_q = qtmix(i,k) - xsh2o(i,k)
-
-! Invert entropy to get updated Tmix and qsmix of parcel.
-
-            tfguess = tmix(i,k)
-            rcall =4
-            call ientropy (rcall,i,lchnk,new_s, p(i,k), new_q, tmix(i,k), qsmix(i,k), tfguess)
-            
-         end do  ! Iteration loop for freezing processes.
-
-! tp  - Parcel temp is temp of mixture.
-! tpv - Parcel v. temp should be density temp with new_q total water. 
-
-         tp(i,k)    = tmix(i,k)
-
-! tpv = tprho in the presence of condensate (i.e. when new_q > qsmix)
-
-         if (new_q > qsmix(i,k)) then  ! Super-saturated so condensate present - reduces buoyancy.
-            qstp(i,k) = qsmix(i,k)
-         else                          ! Just saturated/sub-saturated - no condensate virtual effects.
-            qstp(i,k) = new_q
-         end if
-
-         tpv(i,k) = (tp(i,k)+tp_fac*tpertg(i))* (1._r8+1.608_r8*qstp(i,k)) / (1._r8+ new_q)
-
-      end if ! k < klaunch
-      
-   end do ! Loop for columns
-   
-end do  ! Loop for vertical levels.
-
-
-return
-end subroutine parcel_dilute
 
 end module zm_conv

--- a/components/eam/src/physics/cam/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm_conv.F90
@@ -3090,7 +3090,4 @@ subroutine q1q2_pjr(lchnk   , &
    return
 end subroutine q1q2_pjr
 
-
-
-
 end module zm_conv

--- a/components/eam/src/physics/cam/zm_conv_cape.F90
+++ b/components/eam/src/physics/cam/zm_conv_cape.F90
@@ -1,34 +1,52 @@
-module zm_conv_parcel
+module zm_conv_cape
    !----------------------------------------------------------------------------
-   ! Purpose: plume/parcel/cloud model methods for ZM deep convection scheme
+   ! Purpose: CAPE calculation methods for ZM deep convection scheme
    !----------------------------------------------------------------------------
    use shr_kind_mod,     only: r8=>shr_kind_r8
    use ppgrid,           only: pcols, pver, pverp
    use cam_abortutils,   only: endrun
    use zm_conv_util,     only: entropy, ientropy, qsat_hPa
-   use zm_conv_util,     only: zm_constants_t, zm_parameters_t
+   use zm_conv_types,    only: zm_const_t, zm_param_t
 
    implicit none
    private
 
-   public :: buoyan_dilute ! subroutine that calculates CAPE
+   public :: compute_dilute_cape       ! ?
+   ! public :: find_mse_max              ! ?
+   ! public :: compute_dilute_parcel     ! ?
+   ! public :: compute_cape_from_parcel  ! ?
 
-   private :: find_mse_max
-   private :: parcel_dilute
-   private :: calculate_cape_from_parcel
-
-   real(r8) :: lcl_pressure_threshold     = 600._r8   ! if LCL pressure is lower => no convection and cape is zero
-   real(r8) :: ull_upper_launch_pressure  = 600._r8   ! upper search limit for unrestricted launch level (ULL)
-   real(r8) :: pergro_rhd_threshold       = -1.e-4_r8 ! MSE difference threshold for perturbation growth test
+   real(r8), parameter :: lcl_pressure_threshold     = 600._r8   ! if LCL pressure is lower => no convection and cape is zero
+   real(r8), parameter :: ull_upper_launch_pressure  = 600._r8   ! upper search limit for unrestricted launch level (ULL)
+   real(r8), parameter :: pergro_rhd_threshold       = -1.e-4_r8 ! MSE difference threshold for perturbation growth test
 !===================================================================================================
 contains
 !===================================================================================================
 
-subroutine buoyan_dilute(lchnk, ncol, num_cin, &
-                         q_in, t_in, z, p, pint, pblt, msg, tpert, &
-                         tp, qstp, mse_max_klev, lcl_tl, lcl_klev, eql_klev, cape, &
-                         zm_constants, zm_parameters, &
-                         iclosure, dcapemx, use_input_parcel_tq, q_mx, t_mx )
+
+! NOTES / to-do
+! - add arguments for pcols/pver/pverp ?
+! - Create MPI broadcast routines for params and consts
+! - rename
+!   - mse_max_klev => msemax_klev
+!   - eql_klev     => cldtop_klev
+!   - lcl_klev     => cldbot_klev
+!   - lcl_pl       => cldbot_pressure
+!   - lcl_tl       => cldbot_temperature
+!   - tp           => parcel_temperature
+!   - msg          => ?
+!   - ?            => ?
+
+
+!===================================================================================================
+
+subroutine compute_dilute_cape( ncol, num_cin, msg, &
+                                q_in, t_in, z, p, pint, &
+                                pblt, tpert, &
+                                tp, qstp, mse_max_klev, lcl_tl, &
+                                lcl_klev, eql_klev, cape, &
+                                zm_const, zm_param, &
+                                iclosure, dcapemx, use_input_parcel_tq, q_mx, t_mx )
    !----------------------------------------------------------------------------
    ! Purpose: Calculate convective available potential energy (CAPE), lifting 
    !          condensation level (LCL), and convective top
@@ -43,26 +61,25 @@ subroutine buoyan_dilute(lchnk, ncol, num_cin, &
    implicit none
    !----------------------------------------------------------------------------
    ! Arguments
-   integer,                              intent(in   ) :: lchnk               ! chunk identifier
    integer,                              intent(in   ) :: ncol                ! number of atmospheric columns
    integer,                              intent(in   ) :: num_cin             ! num of negative buoyancy regions that are allowed before the conv. top and CAPE calc are completed
+   integer,                              intent(in   ) :: msg                 ! index of highest level convection is allowed
    real(r8), dimension(pcols,pver),      intent(in   ) :: q_in                ! specific humidity
    real(r8), dimension(pcols,pver),      intent(in   ) :: t_in                ! temperature
    real(r8), dimension(pcols,pver),      intent(in   ) :: z                   ! height
    real(r8), dimension(pcols,pver),      intent(in   ) :: p                   ! pressure at mid-levels
    real(r8), dimension(pcols,pverp),     intent(in   ) :: pint                ! pressure at interfaces
-   integer,  dimension(pcols),           intent(in   ) :: pblt                ! index of pbl depth used as upper limit index of max MSE search
-   integer,                              intent(in   ) :: msg                 ! number of missing moisture levels at the top of model
+   integer,  dimension(pcols),           intent(in   ) :: pblt                ! index of pbl top used as upper limit index of max MSE search
    real(r8), dimension(pcols),           intent(in   ) :: tpert               ! perturbation temperature by pbl processes
    real(r8), dimension(pcols,pver),      intent(  out) :: tp                  ! parcel temperature
    real(r8), dimension(pcols,pver),      intent(inout) :: qstp                ! parcel saturation mixing ratio
    integer,  dimension(pcols),           intent(inout) :: mse_max_klev        ! index of max MSE at parcel launch level
    real(r8), dimension(pcols),           intent(  out) :: lcl_tl              ! LCL temperature
-   integer,  dimension(pcols),           intent(inout) :: lcl_klev            ! base level index of deep cumulus convection
-   integer,  dimension(pcols),           intent(inout) :: eql_klev            ! index of highest convective plume
+   integer,  dimension(pcols),           intent(inout) :: lcl_klev            ! base level index of deep cumulus convection (i.e. lifting condensation level)
+   integer,  dimension(pcols),           intent(inout) :: eql_klev            ! index of highest convective plume (i.e. equilibrium level)
    real(r8), dimension(pcols),           intent(inout) :: cape                ! convective available potential energy
-   type(zm_constants_t),                 intent(in   ) :: zm_constants        ! derived type to hold ZM constants
-   type(zm_parameters_t),                intent(in   ) :: zm_parameters       ! derived type to hold ZM tunable parameters
+   type(zm_const_t),                     intent(in   ) :: zm_const            ! derived type to hold ZM constants
+   type(zm_param_t),                     intent(in   ) :: zm_param            ! derived type to hold ZM tunable parameters
    logical,                              intent(in   ) :: iclosure            ! true for normal procedure, otherwise use dcapemx from 1st call
    integer,  dimension(pcols), optional, intent(in   ) :: dcapemx             ! ?
    logical,                    optional, intent(in   ) :: use_input_parcel_tq ! if .true., use input values of dcapemx, q_mx, t_mx in the CAPE calculation
@@ -91,10 +108,14 @@ subroutine buoyan_dilute(lchnk, ncol, num_cin, &
    pergro_active = .false.
 #endif
    !----------------------------------------------------------------------------
-   if (PRESENT(use_input_parcel_tq)) then
-      use_input_parcel_tq_loc = use_input_parcel_tq
-   else
-      use_input_parcel_tq_loc = .false.
+   use_input_parcel_tq_loc = .false.
+   if (present(use_input_parcel_tq)) use_input_parcel_tq_loc = use_input_parcel_tq
+
+   if ( use_input_parcel_tq_loc  .and. &
+       ((.not.present(t_mx)) .or.  &
+        (.not.present(q_mx)) .or.  &
+        (.not.present(dcapemx)) )  ) then
+      call endrun('compute_dilute_cape: use_input_parcel_tq = .true. but dcapemx, t_mx or q_mx is not provided')
    end if
 
    !----------------------------------------------------------------------------
@@ -103,46 +124,37 @@ subroutine buoyan_dilute(lchnk, ncol, num_cin, &
    q(:ncol,:) = q_in(:ncol,:)
 
    !----------------------------------------------------------------------------
-   if ( use_input_parcel_tq_loc  .and. &
-       ((.not.PRESENT(t_mx)) .or.  &
-        (.not.PRESENT(q_mx)) .or.  &
-        (.not.PRESENT(dcapemx)) )  ) then
-      call endrun('buoyan_dilute :: use_input_parcel_tq = .true. but dcapemx, t_mx or q_mx is not provided')
-   end if
-
+   ! initialize mse_max_klev and potentially modify T/q
    if (use_input_parcel_tq_loc) then
-      !-------------------------------------------------------------------------
-      ! We expect 
+      ! note - in this case we expect:
       ! (1) the incoming array dcapemx contains prev identified launching level index, and 
       ! (2) the arrays q_mx and t_mx contain q and T values at the old launching level 
       !     at the time when the old launching level was identified. 
       ! Copy the old values to work arrays for calculations in the rest of this subroutine
-      !-------------------------------------------------------------------------
       mse_max_klev(:ncol) = dcapemx(:ncol)
       do i=1,ncol
          q(i,mse_max_klev(i)) = q_mx(i)
          t(i,mse_max_klev(i)) = t_mx(i)
       end do
-   else ! initialize the mx array
-      mse_max_klev(1:ncol) = pver
+   else
+      mse_max_klev(:) = pver
    end if
 
    !----------------------------------------------------------------------------
    ! Initialize variables
-   mse_max_val(1:ncol)           = 0._r8
    tp         (1:ncol,1:pver)    = t(1:ncol,1:pver)
    qstp       (1:ncol,1:pver)    = q(1:ncol,1:pver)
 
    !----------------------------------------------------------------------------
    ! calculate virtual temperature (tv)
-   tv  (1:ncol,1:pver) = t(:ncol,:) * ( 1._r8+zvir*q(:ncol,:) ) / ( 1._r8+q(:ncol,:) )
-   tpv (1:ncol,1:pver) = tv(:ncol,:)
+   tv (1:ncol,1:pver) = t(1:ncol,1:pver) * ( 1._r8+zvir*q(1:ncol,1:pver) ) / ( 1._r8+q(1:ncol,1:pver) )
+   tpv(1:ncol,1:pver) = tv(1:ncol,1:pver)
 
    !----------------------------------------------------------------------------
    ! Find new upper bound for parcel starting level - unrestricted launch level (ULL)
-   if (zm_parameters%trig_ull) then
-      pblt_ull(1:ncol) = 1
-      do k = pver - 1,msg + 1,-1
+   if (zm_param%trig_ull) then
+      pblt_ull(:) = 1
+      do k = pver-1, msg+1, -1
          do i = 1,ncol
             if ( (p(i,k)  .le.ull_upper_launch_pressure) .and. &
                  (p(i,k+1).gt.ull_upper_launch_pressure) ) then
@@ -154,15 +166,15 @@ subroutine buoyan_dilute(lchnk, ncol, num_cin, &
 
    !----------------------------------------------------------------------------
    ! Set level of max moist static energy for parcel initialization
-   if ( zm_parameters%trig_dcape .and. (.not.iclosure) ) then
+   if ( zm_param%trig_dcape .and. (.not.iclosure) ) then
       ! Use max moist static energy level that is passed in
-      if (.not.present(dcapemx)) call endrun('** ZM CONV buoyan_dilute: dcapemx not present **')
+      if (.not.present(dcapemx)) call endrun('** ZM CONV compute_dilute_cape: dcapemx not present **')
       mse_max_klev(1:ncol) = dcapemx(1:ncol)
    elseif (.not.use_input_parcel_tq_loc) then
-      if (     zm_parameters%trig_ull) top_k(:ncol) = pblt_ull(:ncol)
-      if (.not.zm_parameters%trig_ull) top_k(:ncol) = pblt(:ncol)
+      if (     zm_param%trig_ull) top_k(:ncol) = pblt_ull(:ncol)
+      if (.not.zm_param%trig_ull) top_k(:ncol) = pblt(:ncol)
       call find_mse_max( ncol, t, z, q, msg, top_k, pergro_active, &
-                         zm_constants, zm_parameters, &
+                         zm_const, zm_param, &
                          mse_max_klev, mse_max_val )
    end if
 
@@ -173,36 +185,36 @@ subroutine buoyan_dilute(lchnk, ncol, num_cin, &
          q_mx(i) = q(i,mse_max_klev(i))
          t_mx(i) = t(i,mse_max_klev(i))
       end if
-      ! save LCL values for parcel_dilute()
+      ! save LCL values for compute_dilute_parcel()
       lcl_klev(i) = mse_max_klev(i)
-      lcl_tl(i) = t(i,lcl_klev(i))
-      lcl_pl(i) = p(i,lcl_klev(i))
+      lcl_tl(i) = t(i,mse_max_klev(i))
+      lcl_pl(i) = p(i,mse_max_klev(i))
    end do
 
    !----------------------------------------------------------------------------
-   ! entraining plume calculation
-   call parcel_dilute( lchnk, ncol, msg, mse_max_klev, &
-                       p, t, q, tpert, pblt, &
-                       zm_constants, zm_parameters, &
-                       tp, tpv, qstp, lcl_pl, lcl_tl, lcl_klev )
+   ! entraining parcel calculation
+   call compute_dilute_parcel( ncol, msg, mse_max_klev, &
+                               p, t, q, tpert, pblt, &
+                               zm_const, zm_param, &
+                               tp, tpv, qstp, lcl_pl, lcl_tl, lcl_klev )
 
    !----------------------------------------------------------------------------
    ! calculate CAPE
-   call calculate_cape_from_parcel( ncol, num_cin, &
-                                    t, tv, z, q, qstp, tp, tpv, &
-                                    pint, lcl_pl, msg, mse_max_klev, &
-                                    zm_constants, zm_parameters, &
-                                    lcl_klev, eql_klev, cape )
+   call compute_cape_from_parcel( ncol, num_cin, msg, &
+                                  t, tv, z, q, pint, lcl_pl,  &
+                                  mse_max_klev, lcl_klev, &
+                                  zm_const, zm_param, &
+                                  qstp, tp, tpv, eql_klev, cape )
 
    !----------------------------------------------------------------------------
    return
 
-end subroutine buoyan_dilute
+end subroutine compute_dilute_cape
 
 !===================================================================================================
 
 subroutine find_mse_max( ncol, t, z, q, msg, top_k, pergro_active, &
-                         zm_constants, zm_parameters, mse_max_klev, mse_max_val)
+                         zm_const, zm_param, mse_max_klev, mse_max_val)
    !----------------------------------------------------------------------------
    ! Purpose: find level of max moist static energy for parcel initialization
    !----------------------------------------------------------------------------
@@ -214,8 +226,8 @@ subroutine find_mse_max( ncol, t, z, q, msg, top_k, pergro_active, &
    integer,                         intent(in   ) :: msg             ! number of missing moisture levels at the top of model
    integer,  dimension(pcols),      intent(in   ) :: top_k           ! upper limit index of max MSE search
    logical,                         intent(in   ) :: pergro_active   ! flag for perturbation growth test (pergro)
-   type(zm_constants_t),            intent(in   ) :: zm_constants    ! derived type to hold ZM constants
-   type(zm_parameters_t),           intent(in   ) :: zm_parameters   ! derived type to hold ZM tunable parameters
+   type(zm_const_t),                intent(in   ) :: zm_const        ! derived type to hold ZM constants
+   type(zm_param_t),                intent(in   ) :: zm_param        ! derived type to hold ZM tunable parameters
    integer,  dimension(pcols),      intent(inout) :: mse_max_klev    ! index of max MSE at parcel launch level
    real(r8), dimension(pcols),      intent(inout) :: mse_max_val     ! value of max MSE at parcel launch level
    !----------------------------------------------------------------------------
@@ -225,12 +237,14 @@ subroutine find_mse_max( ncol, t, z, q, msg, top_k, pergro_active, &
    real(r8) :: pergro_rhd                ! relative MSE (h) difference for perturbation growth test (pergro)
    real(r8), dimension(pcols) :: mse_env ! env moist static energy
    !----------------------------------------------------------------------------
-   ! set lower limit to search for launch level with maximum moist static energy
-   bot_layer = pver - zm_parameters%mx_bot_lyr_adj
-   do k = bot_layer,msg + 1,-1
+   ! initialize values
+   mse_max_val(1:ncol) = 0._r8
+   bot_layer = pver - zm_param%mx_bot_lyr_adj ! set lower limit to search for launch level with max MSE
+   !----------------------------------------------------------------------------
+   do k = bot_layer, msg+1, -1
       do i = 1,ncol
          ! calculate moist static energy
-         mse_env(i) = zm_constants%cpair*t(i,k) + zm_constants%grav*z(i,k) + zm_constants%latvap*q(i,k)
+         mse_env(i) = zm_const%cpair*t(i,k) + zm_const%grav*z(i,k) + zm_const%latvap*q(i,k)
          if (pergro_active) then
             ! Reset max moist static energy level when relative difference exceeds 1.e-4
             pergro_rhd = (mse_env(i) - mse_max_val(i))/(mse_env(i) + mse_max_val(i))
@@ -252,19 +266,18 @@ end subroutine find_mse_max
 
 !===================================================================================================
 
-subroutine parcel_dilute( lchnk, ncol, msg, klaunch, &
-                          p, t, q, tpert, pblt, &
-                          tp, tpv, qstp, lcl_pl, lcl_tl, lcl_klev, &
-                          zm_constants, zm_parameters )
+subroutine compute_dilute_parcel( ncol, msg, klaunch, &
+                                  p, t, q, tpert, pblt, &
+                                  zm_const, zm_param, &
+                                  tp, tpv, qstp, lcl_pl, lcl_tl, lcl_klev )
    !----------------------------------------------------------------------------
    ! Purpose: Calculate thermodynamic properties of an entraining air parcel 
    !          lifted from the PBL using fractional mass entrainment rate 
-   !          specified by zm_parameters%dmpdz
+   !          specified by zm_param%dmpdz
    !----------------------------------------------------------------------------
    implicit none
    !----------------------------------------------------------------------------
    ! Arguments
-   integer,                         intent(in   ) :: lchnk           ! chunk identifier
    integer,                         intent(in   ) :: ncol            ! number of atmospheric columns
    integer,                         intent(in   ) :: msg             ! number of missing moisture levels at the top of model
    integer,  dimension(pcols),      intent(in   ) :: klaunch         ! index of parcel launch level based on max MSE
@@ -273,13 +286,13 @@ subroutine parcel_dilute( lchnk, ncol, msg, klaunch, &
    real(r8), dimension(pcols,pver), intent(in   ) :: q               ! ambient env specific humidity at cell center
    real(r8), dimension(pcols),      intent(in   ) :: tpert           ! PBL temperature perturbation
    integer,  dimension(pcols),      intent(in   ) :: pblt            ! index of pbl depth 
-   type(zm_constants_t),            intent(in   ) :: zm_constants    ! derived type to hold ZM constants
-   type(zm_parameters_t),           intent(in   ) :: zm_parameters   ! derived type to hold ZM tunable parameters
+   type(zm_const_t),                intent(in   ) :: zm_const        ! derived type to hold ZM constants
+   type(zm_param_t),                intent(in   ) :: zm_param        ! derived type to hold ZM tunable parameters
    real(r8), dimension(pcols,pver), intent(inout) :: tp              ! Parcel temperature
-   real(r8), dimension(pcols,pver), intent(  out) :: tpv             ! Parcel virtual temperature
+   real(r8), dimension(pcols,pver), intent(inout) :: tpv             ! Parcel virtual temperature
    real(r8), dimension(pcols,pver), intent(inout) :: qstp            ! Parcel water vapour (sat value above lcl)
-   real(r8), dimension(pcols)     , intent(inout) :: lcl_tl          ! LCL temperature
    real(r8), dimension(pcols)     , intent(inout) :: lcl_pl          ! LCL pressure
+   real(r8), dimension(pcols)     , intent(inout) :: lcl_tl          ! LCL temperature
    integer,  dimension(pcols)     , intent(inout) :: lcl_klev        ! Lifting condesation level (first model level with saturation)
    !----------------------------------------------------------------------------
    ! Local variables
@@ -313,7 +326,7 @@ subroutine parcel_dilute( lchnk, ncol, msg, klaunch, &
    real(r8) new_q    ! hold value for total water after condensation/freezing adjustments
    real(r8) dp       ! layer thickness (center to center)
    real(r8) tfguess  ! first guess for entropy inversion
-   real(r8) tscool   ! super cooled temperature offset [degC] (sets when cloud water loading freezes)
+   real(r8) tscool   ! super cooled temperature offset from freezing temperature when cloud water loading freezes
 
    real(r8) qxsk     ! LCL excess water @ k
    real(r8) qxskp1   ! LCL excess water @ k+1
@@ -331,7 +344,7 @@ subroutine parcel_dilute( lchnk, ncol, msg, klaunch, &
 
    !----------------------------------------------------------------------------
    ! initialize values
-   tscool      = 0._r8    ! temperature (degC) at which water loading freezes in the cloud
+   tscool      = 0._r8
    qtmix       = 0._r8
    smix        = 0._r8
    qtenv       = 0._r8
@@ -355,7 +368,7 @@ subroutine parcel_dilute( lchnk, ncol, msg, klaunch, &
    ! it. In this situation, the temporary variable tpert_loc is reset to zero.  
    do i=1,ncol
       tpert_loc(i) = tpert(i)
-      if ( zm_parameters%tpert_fix .and. klaunch(i)<pblt(i) ) then
+      if ( zm_param%tpert_fix .and. klaunch(i)<pblt(i) ) then
          tpert_loc(i) = 0._r8
       end if
    end do
@@ -370,12 +383,12 @@ subroutine parcel_dilute( lchnk, ncol, msg, klaunch, &
             ! initialize values at launch level
             mp0(i)      = 1._r8    ! initial relative mass - value of 1.0 does not change for undilute (dmpdp=0)
             qtp0(i)     = q(i,k)   ! initial total water - assuming subsaturated
-            sp0(i)      = entropy(t(i,k),p(i,k),qtp0(i))
+            sp0(i)      = entropy( t(i,k), p(i,k), qtp0(i), zm_const )
             smix(i,k)   = sp0(i)
             qtmix(i,k)  = qtp0(i)
             tfguess     = t(i,k)
             rcall = 1
-            call ientropy( rcall, smix(i,k), p(i,k), qtmix(i,k), tmix(i,k), qsmix(i,k), tfguess )
+            call ientropy( rcall, smix(i,k), p(i,k), qtmix(i,k), tmix(i,k), qsmix(i,k), tfguess, zm_const )
          
          elseif ( k < klaunch(i) ) then 
 
@@ -384,12 +397,12 @@ subroutine parcel_dilute( lchnk, ncol, msg, klaunch, &
             qtenv = 0.5_r8*(q(i,k)+q(i,k+1))
             tenv  = 0.5_r8*(t(i,k)+t(i,k+1)) 
             penv  = 0.5_r8*(p(i,k)+p(i,k+1))
-            senv  = entropy(tenv,penv,qtenv)
+            senv  = entropy( tenv, penv, qtenv, zm_const )
 
             ! determine fractional entrainment rate 1/pa given value 1/m
-            dpdz = -(penv*zm_constants%grav)/(zm_constants%rdair*tenv) ! [mb/m] since pressure should be [mb]
+            dpdz = -(penv*zm_const%grav)/(zm_const%rdair*tenv) ! [mb/m] since pressure should be [mb]
             dzdp = 1._r8/dpdz                  ! [m/mb]
-            dmpdp = zm_parameters%dmpdz*dzdp   ! Fractional entrainment [1/mb]
+            dmpdp = zm_param%dmpdz*dzdp   ! Fractional entrainment [1/mb]
 
             ! sum entrainment to current level - entrain q,s out of intervening dp layers, 
             ! assuming linear variation (i.e. entrain the mean of the 2 stored values)
@@ -406,7 +419,7 @@ subroutine parcel_dilute( lchnk, ncol, msg, klaunch, &
 
             tfguess = tmix(i,k+1)
             rcall = 2
-            call ientropy( rcall, smix(i,k), p(i,k), qtmix(i,k), tmix(i,k), qsmix(i,k), tfguess )
+            call ientropy( rcall, smix(i,k), p(i,k), qtmix(i,k), tmix(i,k), qsmix(i,k), tfguess, zm_const )
 
             ! determine if we are at the LCL if this is first level where qsmix<=qtmix on ascending
             if ( qsmix(i,k)<=qtmix(i,k) .and. qsmix(i,k+1)>qtmix(i,k+1) ) then
@@ -421,7 +434,7 @@ subroutine parcel_dilute( lchnk, ncol, msg, klaunch, &
                qtlcl       = qtmix(i,k+1) + dqtdp*(lcl_pl(i)-p(i,k+1))
                tfguess     = tmix(i,k)
                rcall = 3
-               call ientropy( rcall, slcl, lcl_pl(i), qtlcl, lcl_tl(i), qslcl, tfguess )
+               call ientropy( rcall, slcl, lcl_pl(i), qtlcl, lcl_tl(i), qslcl, tfguess, zm_const )
             endif
 
          end if !  k < klaunch
@@ -430,19 +443,17 @@ subroutine parcel_dilute( lchnk, ncol, msg, klaunch, &
    end do ! k = pver, msg+1, -1
    !----------------------------------------------------------------------------
    ! end of entrainment loop
-   ! 
-   ! Could stop now and test with this as it will provide some estimate of buoyancy
-   ! without the effects of freezing/condensation taken into account for tmix.
-   !  
-   ! So we now have a profile of entropy and total water of the entraining parcel
+   
+   !----------------------------------------------------------------------------
+   ! We now have a profile of entropy and total water of the entraining parcel
    ! Varying with height from the launch level klaunch parcel=environment. To the
-   ! top allowed level for the existence of convection.
+   ! top allowed level for the existence of convection. If we stop now it will 
+   ! provide some estimate of buoyancy without the effects of freezing/condensation.
    ! 
-   ! Now we have to adjust these values such that the water held in vaopor is < or
-   ! = to qsmix. Therefore, we assume that the cloud holds a certain amount of
-   ! condensate (lwmax) and the rest is rained out (xsh2o). This, obviously 
-   ! provides latent heating to the mixed parcel and so this has to be added back
-   ! to it. But does this also increase qsmix as well? Also freezing processes
+   ! Instead, we will adjust these values such that the water held in vapor is
+   ! <=qsmix. We assume that the cloud holds a certain amount of condensate (lwmax)
+   ! and the rest is rained out (xsh2o). This provides latent heating to the
+   ! mixed parcel and so this has to be added back to it.
 
    !----------------------------------------------------------------------------
    ! precipitation/freezing loop - iterate twice for accuracy
@@ -457,7 +468,7 @@ subroutine parcel_dilute( lchnk, ncol, msg, klaunch, &
             ! initialize values at launch level - assume no liquid water
             tp(i,k)    = tmix(i,k)
             qstp(i,k)  = q(i,k) 
-            tpv(i,k)   = (tp(i,k) + zm_parameters%tpert_fac*tpert_loc(i)) * (1._r8+1.608_r8*qstp(i,k)) / (1._r8+qstp(i,k))
+            tpv(i,k)   = (tp(i,k) + zm_param%tpert_fac*tpert_loc(i)) * (1._r8+1.608_r8*qstp(i,k)) / (1._r8+qstp(i,k))
 
          elseif ( k < klaunch(i) ) then
 
@@ -468,19 +479,19 @@ subroutine parcel_dilute( lchnk, ncol, msg, klaunch, &
                xsh2o(i,k) = max (0._r8, qtmix(i,k) - qsmix(i,k) - lwmax)
 
                ! contribution to ds from precip loss of condensate (accumulated change from smix)
-               ds_xsh2o(i,k) = ds_xsh2o(i,k+1) - zm_constants%cpliq * log (tmix(i,k)/zm_constants%tfreez) * max(0._r8,(xsh2o(i,k)-xsh2o(i,k+1)))
+               ds_xsh2o(i,k) = ds_xsh2o(i,k+1) - zm_const%cpliq * log (tmix(i,k)/zm_const%tfreez) * max(0._r8,(xsh2o(i,k)-xsh2o(i,k+1)))
 
                ! calculate entropy of freezing => ( latice x amount of water involved ) / T
 
                ! one off freezing of condensate
-               if (tmix(i,k) <= (zm_constants%tfreez+tscool) .and. ds_freeze(i,k+1) == 0._r8) then 
+               if (tmix(i,k) <= (zm_const%tfreez+tscool) .and. ds_freeze(i,k+1) == 0._r8) then 
                   ! entropy change from latent heat
-                  ds_freeze(i,k) = (zm_constants%latice/tmix(i,k)) * max(0._r8,qtmix(i,k)-qsmix(i,k)-xsh2o(i,k)) 
+                  ds_freeze(i,k) = (zm_const%latice/tmix(i,k)) * max(0._r8,qtmix(i,k)-qsmix(i,k)-xsh2o(i,k)) 
                end if
             
-               if (tmix(i,k) <= zm_constants%tfreez+tscool .and. ds_freeze(i,k+1) /= 0._r8) then 
+               if (tmix(i,k) <= zm_const%tfreez+tscool .and. ds_freeze(i,k+1) /= 0._r8) then 
                   ! continual freezing of additional condensate
-                  ds_freeze(i,k) = ds_freeze(i,k+1)+(zm_constants%latice/tmix(i,k)) * max(0._r8,(qsmix(i,k+1)-qsmix(i,k)))
+                  ds_freeze(i,k) = ds_freeze(i,k+1)+(zm_const%latice/tmix(i,k)) * max(0._r8,(qsmix(i,k+1)-qsmix(i,k)))
                end if
             
                ! adjust entropy and accordingly to sum of ds (be careful of signs)
@@ -492,13 +503,13 @@ subroutine parcel_dilute( lchnk, ncol, msg, klaunch, &
                ! invert entropy to get updated Tmix and qsmix of parcel
                tfguess = tmix(i,k)
                rcall =4
-               call ientropy( rcall, new_s, p(i,k), new_q, tmix(i,k), qsmix(i,k), tfguess )
+               call ientropy( rcall, new_s, p(i,k), new_q, tmix(i,k), qsmix(i,k), tfguess, zm_const )
                
             end do  ! iteration loop for freezing processes
 
             ! tp  - Parcel temp is temp of mixture
             ! tpv - Parcel virtual temp should be density temp with new_q total water
-            tp(i,k)    = tmix(i,k)
+            tp(i,k) = tmix(i,k)
 
             ! tpv=tprho in the presence of condensate (i.e. when new_q > qsmix)
             if (new_q > qsmix(i,k)) then  ! super-saturated so condensate present - reduces buoyancy
@@ -507,7 +518,7 @@ subroutine parcel_dilute( lchnk, ncol, msg, klaunch, &
                qstp(i,k) = new_q
             end if
 
-            tpv(i,k) = (tp(i,k)+zm_parameters%tpert_fac*tpert_loc(i))* (1._r8+1.608_r8*qstp(i,k)) / (1._r8+ new_q)
+            tpv(i,k) = (tp(i,k)+zm_param%tpert_fac*tpert_loc(i))* (1._r8+1.608_r8*qstp(i,k)) / (1._r8+ new_q)
 
          end if ! k < klaunch
       
@@ -517,35 +528,35 @@ subroutine parcel_dilute( lchnk, ncol, msg, klaunch, &
    !----------------------------------------------------------------------------
    return
 
-end subroutine parcel_dilute
+end subroutine compute_dilute_parcel
 
 !===================================================================================================
 
-subroutine calculate_cape_from_parcel( ncol, num_cin, &
-                                       t, tv, z, q, qstp, tp, tpv, &
-                                       pint, lcl_pl, msg, mse_max_klev, &
-                                       zm_constants, zm_parameters, &
-                                       lcl_klev, eql_klev, cape )
+subroutine compute_cape_from_parcel( ncol, num_cin, msg, &
+                                     t, tv, z, q, pint, lcl_pl, &
+                                     mse_max_klev, lcl_klev, &
+                                     zm_const, zm_param, &
+                                     qstp, tp, tpv, eql_klev, cape )
    !----------------------------------------------------------------------------
    ! Purpose: calculate convective available potential energy (CAPE)
-   !          from parcel thermodynamic properties from parcel_dilute()
+   !          from parcel thermodynamic properties from compute_dilute_parcel()
    !----------------------------------------------------------------------------
    integer,                         intent(in   ) :: ncol            ! number of atmospheric columns
    integer,                         intent(in   ) :: num_cin         ! num of negative buoyancy regions that are allowed before the conv. top and CAPE calc are completed
+   integer,                         intent(in   ) :: msg             ! number of missing moisture levels at the top of model
    real(r8), dimension(pcols,pver), intent(in   ) :: t               ! temperature
    real(r8), dimension(pcols,pver), intent(in   ) :: tv              ! virtual temperature
    real(r8), dimension(pcols,pver), intent(in   ) :: z               ! height
    real(r8), dimension(pcols,pver), intent(in   ) :: q               ! specific humidity
+   real(r8), dimension(pcols,pverp),intent(in   ) :: pint            ! pressure at interfaces
+   real(r8), dimension(pcols),      intent(in   ) :: lcl_pl          ! LCL pressure
+   integer,  dimension(pcols),      intent(in   ) :: mse_max_klev    ! index of max MSE at parcel launch level
+   integer,  dimension(pcols),      intent(in   ) :: lcl_klev        ! base level index of deep cumulus convection
+   type(zm_const_t),                intent(in   ) :: zm_const        ! derived type to hold ZM constants
+   type(zm_param_t),                intent(in   ) :: zm_param        ! derived type to hold ZM tunable parameters
    real(r8), dimension(pcols,pver), intent(inout) :: qstp            ! parcel saturation mixing ratio
    real(r8), dimension(pcols,pver), intent(inout) :: tp              ! parcel temperature
    real(r8), dimension(pcols,pver), intent(inout) :: tpv             ! parcel virtual temperature
-   real(r8), dimension(pcols,pverp),intent(in   ) :: pint            ! pressure at interfaces
-   real(r8), dimension(pcols),      intent(in   ) :: lcl_pl          ! LCL pressure
-   integer,                         intent(in   ) :: msg             ! number of missing moisture levels at the top of model
-   integer,  dimension(pcols),      intent(in   ) :: mse_max_klev    ! index of max MSE at parcel launch level
-   type(zm_constants_t),            intent(in   ) :: zm_constants    ! derived type to hold ZM constants
-   type(zm_parameters_t),           intent(in   ) :: zm_parameters   ! derived type to hold ZM tunable parameters
-   integer,  dimension(pcols),      intent(in   ) :: lcl_klev        ! base level index of deep cumulus convection
    integer,  dimension(pcols),      intent(inout) :: eql_klev        ! index of highest convective plume
    real(r8), dimension(pcols),      intent(inout) :: cape            ! convective available potential energy
    !----------------------------------------------------------------------------
@@ -555,6 +566,8 @@ subroutine calculate_cape_from_parcel( ncol, num_cin, &
    real(r8), dimension(pcols,num_cin) :: cape_tmp           ! provisional value of cape
    integer,  dimension(pcols,num_cin) :: eql_klev_tmp       ! provisional value of index of highest convective plume
    integer,  dimension(pcols)         :: neg_buoyancy_cnt   ! counter for levels with negative bounancy
+
+   logical plge600(pcols) ! for testing - remove!
    !----------------------------------------------------------------------------
    ! Initialize variables
    eql_klev        (1:ncol)           = pver
@@ -569,7 +582,7 @@ subroutine calculate_cape_from_parcel( ncol, num_cin, &
       do i=1,ncol
          ! Define buoyancy from launch level to cloud top
          if ( k <= mse_max_klev(i) .and. lcl_pl(i).ge.lcl_pressure_threshold ) then
-            buoyancy(i,k) = tpv(i,k) - tv(i,k) + zm_parameters%tiedke_add
+            buoyancy(i,k) = tpv(i,k) - tv(i,k) + zm_param%tiedke_add
          else
             qstp(i,k) = q(i,k)
             tp(i,k)   = t(i,k)            
@@ -582,10 +595,11 @@ subroutine calculate_cape_from_parcel( ncol, num_cin, &
    ! find convective equilibrium level accounting for negative buoyancy levels
    do k = msg+2,pver
       do i = 1,ncol
+         ! if ( k < lcl_klev(i) .and. lcl_pl(i).ge.lcl_pressure_threshold ) then
          if ( k < lcl_klev(i) .and. lcl_pl(i).ge.lcl_pressure_threshold ) then
             if ( buoyancy(i,k+1) > 0._r8 .and. &
                  buoyancy(i,k)   <=0._r8 ) then
-               neg_buoyancy_cnt(i) = min(num_cin,neg_buoyancy_cnt(i) + 1)
+               neg_buoyancy_cnt(i) = min( num_cin, neg_buoyancy_cnt(i)+1 )
                eql_klev_tmp(i,neg_buoyancy_cnt(i)) = k
             end if
          end if
@@ -593,21 +607,21 @@ subroutine calculate_cape_from_parcel( ncol, num_cin, &
    end do
 
    !----------------------------------------------------------------------------
-   ! calculate CAPE
+   ! integrate buoyancy to obtain possible CAPE values
    do n = 1,num_cin
       do k = msg + 1,pver
          do i = 1,ncol
+            ! if ( lcl_pl(i).ge.lcl_pressure_threshold .and. &
             if ( lcl_pl(i).ge.lcl_pressure_threshold .and. &
-                 k <= mse_max_klev(i) .and. &
-                 k > eql_klev_tmp(i,n)) then
-               cape_tmp(i,n) = cape_tmp(i,n) + zm_constants%rdair*buoyancy(i,k)*log(pint(i,k+1)/pint(i,k))
+                 k <= mse_max_klev(i) .and. k > eql_klev_tmp(i,n)) then
+               cape_tmp(i,n) = cape_tmp(i,n) + zm_const%rdair*buoyancy(i,k)*log(pint(i,k+1)/pint(i,k))
             end if
          end do
       end do
    end do
 
    !----------------------------------------------------------------------------
-   ! find maximum cape from all possible tentative capes from one sounding,
+   ! find maximum cape from all possible tentative CAPE values
    ! and use it as the final cape (April 26, 1995)
    do n = 1,num_cin
       do i = 1,ncol
@@ -619,7 +633,7 @@ subroutine calculate_cape_from_parcel( ncol, num_cin, &
    end do
 
    !----------------------------------------------------------------------------
-   ! put lower bound on cape for diagnostic purposes.
+   ! apply limiter to ensure CAPE is positive
    do i = 1,ncol
       cape(i) = max(cape(i), 0._r8)
    end do
@@ -627,8 +641,8 @@ subroutine calculate_cape_from_parcel( ncol, num_cin, &
    !----------------------------------------------------------------------------
    return
 
-end subroutine calculate_cape_from_parcel
+end subroutine compute_cape_from_parcel
 
 !===================================================================================================
 
-end module zm_conv_parcel
+end module zm_conv_cape

--- a/components/eam/src/physics/cam/zm_conv_cape.F90
+++ b/components/eam/src/physics/cam/zm_conv_cape.F90
@@ -3,7 +3,6 @@ module zm_conv_cape
    ! Purpose: CAPE calculation methods for ZM deep convection scheme
    !----------------------------------------------------------------------------
    use shr_kind_mod,     only: r8=>shr_kind_r8
-   use ppgrid,           only: pcols, pver, pverp
    use cam_abortutils,   only: endrun
    use zm_conv_util,     only: entropy, ientropy, qsat_hPa
    use zm_conv_types,    only: zm_const_t, zm_param_t
@@ -20,29 +19,16 @@ module zm_conv_cape
 contains
 !===================================================================================================
 
-
-! NOTES / to-do
-! - add arguments for pcols/pver/pverp ?
-! - rename
-!   - mse_max_klev => msemax_klev
-!   - eql_klev     => cldtop_klev
-!   - lcl_klev     => cldbot_klev
-!   - lcl_pl       => cldbot_pressure
-!   - lcl_tl       => cldbot_temperature
-!   - tp           => parcel_temperature
-!   - msg          => ?
-!   - ?            => ?
-
-
-!===================================================================================================
-
-subroutine compute_dilute_cape( ncol, num_cin, msg, &
-                                q_in, t_in, z, p, pint, &
-                                pblt, tpert, &
-                                tp, qstp, mse_max_klev, lcl_tl, &
-                                lcl_klev, eql_klev, cape, &
+subroutine compute_dilute_cape( pcols, ncol, pver, pverp, &
+                                num_cin, num_msg, &
+                                sp_humidity_in, temperature_in, &
+                                zmid, pmid, pint, pblt, tpert, &
+                                parcel_temp, parcel_qsat, msemax_klev, &
+                                cldbot_temperature, cldbot_klev, &
+                                cldtop_klev, cape, &
                                 zm_const, zm_param, &
-                                iclosure, dcapemx, use_input_parcel_tq, q_mx, t_mx )
+                                iclosure, dcapemx, &
+                                use_input_tq_mx, q_mx, t_mx )
    !----------------------------------------------------------------------------
    ! Purpose: calculate convective available potential energy (CAPE), lifting
    !          condensation level (LCL), and convective top with dilute parcel ascent
@@ -57,45 +43,47 @@ subroutine compute_dilute_cape( ncol, num_cin, msg, &
    implicit none
    !----------------------------------------------------------------------------
    ! Arguments
-   integer,                              intent(in   ) :: ncol                ! number of atmospheric columns
+   integer,                              intent(in   ) :: pcols               ! number of atmospheric columns (max)
+   integer,                              intent(in   ) :: ncol                ! number of atmospheric columns (actual)
+   integer,                              intent(in   ) :: pver                ! number of mid-point vertical levels
+   integer,                              intent(in   ) :: pverp               ! number of interface vertical levels
    integer,                              intent(in   ) :: num_cin             ! num of negative buoyancy regions that are allowed before the conv. top and CAPE calc are completed
-   integer,                              intent(in   ) :: msg                 ! index of highest level convection is allowed
-   real(r8), dimension(pcols,pver),      intent(in   ) :: q_in                ! specific humidity
-   real(r8), dimension(pcols,pver),      intent(in   ) :: t_in                ! temperature
-   real(r8), dimension(pcols,pver),      intent(in   ) :: z                   ! height
-   real(r8), dimension(pcols,pver),      intent(in   ) :: p                   ! pressure at mid-levels
+   integer,                              intent(in   ) :: num_msg             ! index of highest level convection is allowed
+   real(r8), dimension(pcols,pver),      intent(in   ) :: sp_humidity_in      ! specific humidity
+   real(r8), dimension(pcols,pver),      intent(in   ) :: temperature_in      ! temperature
+   real(r8), dimension(pcols,pver),      intent(in   ) :: zmid                ! altitude/height at mid-levels
+   real(r8), dimension(pcols,pver),      intent(in   ) :: pmid                ! pressure at mid-levels
    real(r8), dimension(pcols,pverp),     intent(in   ) :: pint                ! pressure at interfaces
    integer,  dimension(pcols),           intent(in   ) :: pblt                ! index of pbl top used as upper limit index of max MSE search
    real(r8), dimension(pcols),           intent(in   ) :: tpert               ! perturbation temperature by pbl processes
-   real(r8), dimension(pcols,pver),      intent(  out) :: tp                  ! parcel temperature
-   real(r8), dimension(pcols,pver),      intent(inout) :: qstp                ! parcel saturation mixing ratio
-   integer,  dimension(pcols),           intent(inout) :: mse_max_klev        ! index of max MSE at parcel launch level
-   real(r8), dimension(pcols),           intent(  out) :: lcl_tl              ! LCL temperature
-   integer,  dimension(pcols),           intent(inout) :: lcl_klev            ! base level index of deep cumulus convection (i.e. lifting condensation level)
-   integer,  dimension(pcols),           intent(inout) :: eql_klev            ! index of highest convective plume (i.e. equilibrium level)
+   real(r8), dimension(pcols,pver),      intent(  out) :: parcel_temp         ! parcel temperature
+   real(r8), dimension(pcols,pver),      intent(inout) :: parcel_qsat         ! parcel saturation mixing ratio
+   integer,  dimension(pcols),           intent(inout) :: msemax_klev         ! index of max MSE at parcel launch level
+   real(r8), dimension(pcols),           intent(  out) :: cldbot_temperature  ! cloud bottom (LCL) temperature
+   integer,  dimension(pcols),           intent(inout) :: cldbot_klev         ! index of cloud bottom (i.e. lifting condensation level)
+   integer,  dimension(pcols),           intent(inout) :: cldtop_klev         ! index of cloud top (i.e. equilibrium level)
    real(r8), dimension(pcols),           intent(inout) :: cape                ! convective available potential energy
    type(zm_const_t),                     intent(in   ) :: zm_const            ! derived type to hold ZM constants
    type(zm_param_t),                     intent(in   ) :: zm_param            ! derived type to hold ZM tunable parameters
    logical,                              intent(in   ) :: iclosure            ! true for normal procedure, otherwise use dcapemx from 1st call
-   integer,  dimension(pcols), optional, intent(in   ) :: dcapemx             ! ?
-   logical,                    optional, intent(in   ) :: use_input_parcel_tq ! if .true., use input values of dcapemx, q_mx, t_mx in the CAPE calculation
-   real(r8), dimension(pcols), optional, intent(inout) :: q_mx                ! ?
-   real(r8), dimension(pcols), optional, intent(inout) :: t_mx                ! ?
+   integer,  dimension(pcols), optional, intent(in   ) :: dcapemx             ! values of msemax_klev from previous call for dcape closure
+   logical,                    optional, intent(in   ) :: use_input_tq_mx     ! if .true., use input values of dcapemx, q_mx, t_mx in the CAPE calculation
+   real(r8), dimension(pcols), optional, intent(inout) :: q_mx                ! specified sp humidity to apply at level of max MSE if use_input_tq_mx=.true.
+   real(r8), dimension(pcols), optional, intent(inout) :: t_mx                ! specified temperature to apply at level of max MSE if use_input_tq_mx=.true.
    !----------------------------------------------------------------------------
    ! Local variables
-   real(r8), dimension(pcols,pver)    :: q                  ! local version of specific humidity
-   real(r8), dimension(pcols,pver)    :: t                  ! local version of temperature
-   real(r8), dimension(pcols,pver)    :: tv                 ! virtual temperature
-   real(r8), dimension(pcols,pver)    :: tpv                ! parcel virtual temperature
-   real(r8), dimension(pcols)         :: lcl_pl             ! LCL pressure
-   real(r8), dimension(pcols)         :: mse_max_val        ! value of max MSE at parcel launch level
-   integer,  dimension(pcols)         :: pblt_ull           ! upper limit index of max MSE search for ULL
-   integer,  dimension(pcols)         :: top_k              ! upper limit index of max MSE search
+   real(r8), dimension(pcols,pver)    :: sp_humidity     ! local version of specific humidity
+   real(r8), dimension(pcols,pver)    :: temperature     ! local version of temperature
+   real(r8), dimension(pcols,pver)    :: tv              ! virtual temperature
+   real(r8), dimension(pcols,pver)    :: parcel_vtemp    ! parcel virtual temperature
+   real(r8), dimension(pcols)         :: cldbot_pmid     ! cloud bottom (LCL) pressure
+   real(r8), dimension(pcols)         :: mse_max_val     ! value of max MSE at parcel launch level
+   integer,  dimension(pcols)         :: pblt_ull        ! upper limit index of max MSE search for ULL
+   integer,  dimension(pcols)         :: msemax_top_k    ! upper limit index of max MSE search
+
    integer  :: i, k                       ! loop iterators
    logical  :: pergro_active              ! flag for perturbation growth test (pergro)
-   logical  :: use_input_parcel_tq_loc    ! flag to use input parcel temperature and specific humidity
-   
-   real(r8), parameter :: zvir = 1.608_r8 ! this should be replaced with value from physconst module
+   logical  :: use_input_tq_mx_loc    ! flag to use input parcel temperature and specific humidity
    !----------------------------------------------------------------------------
    ! set flag for perturbation growth test
 #ifdef PERGRO
@@ -104,56 +92,55 @@ subroutine compute_dilute_cape( ncol, num_cin, msg, &
    pergro_active = .false.
 #endif
    !----------------------------------------------------------------------------
-   use_input_parcel_tq_loc = .false.
-   if (present(use_input_parcel_tq)) use_input_parcel_tq_loc = use_input_parcel_tq
+   use_input_tq_mx_loc = .false.
+   if (present(use_input_tq_mx)) use_input_tq_mx_loc = use_input_tq_mx
 
-   if ( use_input_parcel_tq_loc  .and. &
+   if ( use_input_tq_mx_loc  .and. &
        ((.not.present(t_mx)) .or.  &
         (.not.present(q_mx)) .or.  &
         (.not.present(dcapemx)) )  ) then
-      call endrun('compute_dilute_cape: use_input_parcel_tq = .true. but dcapemx, t_mx or q_mx is not provided')
+      call endrun('compute_dilute_cape: use_input_tq_mx = .true. but dcapemx, t_mx or q_mx is not provided')
    end if
 
    !----------------------------------------------------------------------------
    ! Copy the incoming temperature and specific humidity values to local arrays 
-   t(:ncol,:) = t_in(:ncol,:)
-   q(:ncol,:) = q_in(:ncol,:)
+   temperature(:ncol,:) = temperature_in(:ncol,:)
+   sp_humidity(:ncol,:) = sp_humidity_in(:ncol,:)
 
    !----------------------------------------------------------------------------
-   ! initialize mse_max_klev and potentially modify T/q
-   if (use_input_parcel_tq_loc) then
+   ! initialize msemax_klev and potentially modify T/q
+   if (use_input_tq_mx_loc) then
       ! note - in this case we expect:
       ! (1) the incoming array dcapemx contains prev identified launching level index, and 
       ! (2) the arrays q_mx and t_mx contain q and T values at the old launching level 
       !     at the time when the old launching level was identified. 
       ! Copy the old values to work arrays for calculations in the rest of this subroutine
-      mse_max_klev(:ncol) = dcapemx(:ncol)
+      msemax_klev(:ncol) = dcapemx(:ncol)
       do i=1,ncol
-         q(i,mse_max_klev(i)) = q_mx(i)
-         t(i,mse_max_klev(i)) = t_mx(i)
+         sp_humidity(i,msemax_klev(i)) = q_mx(i)
+         temperature(i,msemax_klev(i)) = t_mx(i)
       end do
    else
-      mse_max_klev(:) = pver
+      msemax_klev(:) = pver
    end if
 
    !----------------------------------------------------------------------------
-   ! Initialize variables
-   tp         (1:ncol,1:pver)    = t(1:ncol,1:pver)
-   qstp       (1:ncol,1:pver)    = q(1:ncol,1:pver)
-
-   !----------------------------------------------------------------------------
-   ! calculate virtual temperature (tv)
-   tv (1:ncol,1:pver) = t(1:ncol,1:pver) * ( 1._r8+zvir*q(1:ncol,1:pver) ) / ( 1._r8+q(1:ncol,1:pver) )
-   tpv(1:ncol,1:pver) = tv(1:ncol,1:pver)
+   ! Initialize parcel properties
+   parcel_temp(1:ncol,1:pver) = temperature(1:ncol,1:pver)
+   parcel_qsat(1:ncol,1:pver) = sp_humidity(1:ncol,1:pver)
+   tv  (1:ncol,1:pver) = temperature(1:ncol,1:pver) &
+                         * ( 1._r8+zm_const%zvir*sp_humidity(1:ncol,1:pver) ) &
+                         / ( 1._r8+sp_humidity(1:ncol,1:pver) )
+   parcel_vtemp (1:ncol,1:pver) = tv(1:ncol,1:pver)
 
    !----------------------------------------------------------------------------
    ! Find new upper bound for parcel starting level - unrestricted launch level (ULL)
    if (zm_param%trig_ull) then
       pblt_ull(:) = 1
-      do k = pver-1, msg+1, -1
+      do k = pver-1, num_msg+1, -1
          do i = 1,ncol
-            if ( (p(i,k)  .le.ull_upper_launch_pressure) .and. &
-                 (p(i,k+1).gt.ull_upper_launch_pressure) ) then
+            if ( (pmid(i,k)  .le.ull_upper_launch_pressure) .and. &
+                 (pmid(i,k+1).gt.ull_upper_launch_pressure) ) then
                pblt_ull(i) = k
             end if
          end do
@@ -165,42 +152,44 @@ subroutine compute_dilute_cape( ncol, num_cin, msg, &
    if ( zm_param%trig_dcape .and. (.not.iclosure) ) then
       ! Use max moist static energy level that is passed in
       if (.not.present(dcapemx)) call endrun('** ZM CONV compute_dilute_cape: dcapemx not present **')
-      mse_max_klev(1:ncol) = dcapemx(1:ncol)
-   elseif (.not.use_input_parcel_tq_loc) then
-      if (     zm_param%trig_ull) top_k(:ncol) = pblt_ull(:ncol)
-      if (.not.zm_param%trig_ull) top_k(:ncol) = pblt(:ncol)
-      call find_mse_max( ncol, t, z, q, msg, top_k, pergro_active, &
-                         zm_const, zm_param, &
-                         mse_max_klev, mse_max_val )
+      msemax_klev(1:ncol) = dcapemx(1:ncol)
+   elseif (.not.use_input_tq_mx_loc) then
+      if (     zm_param%trig_ull) msemax_top_k(:ncol) = pblt_ull(:ncol)
+      if (.not.zm_param%trig_ull) msemax_top_k(:ncol) = pblt(:ncol)
+      call find_mse_max( pcols, ncol, pver, num_msg, msemax_top_k, pergro_active, &
+                         temperature, zmid, sp_humidity, zm_const, zm_param, &
+                         msemax_klev, mse_max_val )
    end if
 
    !----------------------------------------------------------------------------
    do i=1,ncol
       ! Save launching level T, q for output
-      if ( .not.use_input_parcel_tq_loc .and. present(q_mx) .and. present(t_mx) ) then
-         q_mx(i) = q(i,mse_max_klev(i))
-         t_mx(i) = t(i,mse_max_klev(i))
+      if ( .not.use_input_tq_mx_loc .and. present(q_mx) .and. present(t_mx) ) then
+         q_mx(i) = sp_humidity(i,msemax_klev(i))
+         t_mx(i) = temperature(i,msemax_klev(i))
       end if
       ! save LCL values for compute_dilute_parcel()
-      lcl_klev(i) = mse_max_klev(i)
-      lcl_tl(i) = t(i,mse_max_klev(i))
-      lcl_pl(i) = p(i,mse_max_klev(i))
+      cldbot_klev(i) = msemax_klev(i)
+      cldbot_pmid(i) = pmid(i,msemax_klev(i))
+      cldbot_temperature(i) = temperature(i,msemax_klev(i))
    end do
 
    !----------------------------------------------------------------------------
    ! entraining parcel calculation
-   call compute_dilute_parcel( ncol, msg, mse_max_klev, &
-                               p, t, q, tpert, pblt, &
+   call compute_dilute_parcel( pcols, ncol, pver, num_msg, msemax_klev, &
+                               pmid, temperature, sp_humidity, tpert, pblt, &
                                zm_const, zm_param, &
-                               tp, tpv, qstp, lcl_pl, lcl_tl, lcl_klev )
+                               parcel_temp, parcel_vtemp, parcel_qsat, &
+                               cldbot_pmid, cldbot_temperature, cldbot_klev )
 
    !----------------------------------------------------------------------------
    ! calculate CAPE
-   call compute_cape_from_parcel( ncol, num_cin, msg, &
-                                  t, tv, z, q, pint, lcl_pl,  &
-                                  mse_max_klev, lcl_klev, &
+   call compute_cape_from_parcel( pcols, ncol, pver, pverp, num_cin, num_msg, &
+                                  temperature, tv, zmid, sp_humidity, pint, &
+                                  cldbot_pmid,  msemax_klev, cldbot_klev, &
                                   zm_const, zm_param, &
-                                  qstp, tp, tpv, eql_klev, cape )
+                                  parcel_qsat, parcel_temp, parcel_vtemp, &
+                                  cldtop_klev, cape )
 
    !----------------------------------------------------------------------------
    return
@@ -209,22 +198,25 @@ end subroutine compute_dilute_cape
 
 !===================================================================================================
 
-subroutine find_mse_max( ncol, t, z, q, msg, top_k, pergro_active, &
-                         zm_const, zm_param, mse_max_klev, mse_max_val)
+subroutine find_mse_max( pcols, ncol, pver, num_msg, msemax_top_k, pergro_active, &
+                         temperature, zmid, sp_humidity, zm_const, zm_param, &
+                         msemax_klev, mse_max_val)
    !----------------------------------------------------------------------------
    ! Purpose: find level of max moist static energy for parcel initialization
    !----------------------------------------------------------------------------
    ! Arguments
-   integer,                         intent(in   ) :: ncol            ! number of atmospheric columns
-   real(r8), dimension(pcols,pver), intent(in   ) :: t               ! temperature
-   real(r8), dimension(pcols,pver), intent(in   ) :: z               ! height
-   real(r8), dimension(pcols,pver), intent(in   ) :: q               ! specific humidity
-   integer,                         intent(in   ) :: msg             ! number of missing moisture levels at the top of model
-   integer,  dimension(pcols),      intent(in   ) :: top_k           ! upper limit index of max MSE search
+   integer,                         intent(in   ) :: pcols           ! number of atmospheric columns (max)
+   integer,                         intent(in   ) :: ncol            ! number of atmospheric columns (actual)
+   integer,                         intent(in   ) :: pver            ! number of mid-point vertical levels
+   integer,                         intent(in   ) :: num_msg         ! number of missing moisture levels at the top of model
+   integer,  dimension(pcols),      intent(in   ) :: msemax_top_k    ! upper limit index of max MSE search
    logical,                         intent(in   ) :: pergro_active   ! flag for perturbation growth test (pergro)
+   real(r8), dimension(pcols,pver), intent(in   ) :: temperature     ! environement temperature
+   real(r8), dimension(pcols,pver), intent(in   ) :: zmid            ! height/altitude at mid-levels
+   real(r8), dimension(pcols,pver), intent(in   ) :: sp_humidity     ! specific humidity
    type(zm_const_t),                intent(in   ) :: zm_const        ! derived type to hold ZM constants
    type(zm_param_t),                intent(in   ) :: zm_param        ! derived type to hold ZM tunable parameters
-   integer,  dimension(pcols),      intent(inout) :: mse_max_klev    ! index of max MSE at parcel launch level
+   integer,  dimension(pcols),      intent(inout) :: msemax_klev     ! index of max MSE at parcel launch level
    real(r8), dimension(pcols),      intent(inout) :: mse_max_val     ! value of max MSE at parcel launch level
    !----------------------------------------------------------------------------
    ! Local variables
@@ -237,22 +229,22 @@ subroutine find_mse_max( ncol, t, z, q, msg, top_k, pergro_active, &
    mse_max_val(1:ncol) = 0._r8
    bot_layer = pver - zm_param%mx_bot_lyr_adj ! set lower limit to search for launch level with max MSE
    !----------------------------------------------------------------------------
-   do k = bot_layer, msg+1, -1
+   do k = bot_layer, num_msg+1, -1
       do i = 1,ncol
          ! calculate moist static energy
-         mse_env(i) = zm_const%cpair*t(i,k) + zm_const%grav*z(i,k) + zm_const%latvap*q(i,k)
+         mse_env(i) = zm_const%cpair*temperature(i,k) + zm_const%grav*zmid(i,k) + zm_const%latvap*sp_humidity(i,k)
          if (pergro_active) then
             ! Reset max moist static energy level when relative difference exceeds 1.e-4
             pergro_rhd = (mse_env(i) - mse_max_val(i))/(mse_env(i) + mse_max_val(i))
-            if (k >= top_k(i) .and. pergro_rhd > pergro_rhd_threshold) then
+            if (k >= msemax_top_k(i) .and. pergro_rhd > pergro_rhd_threshold) then
                mse_max_val(i) = mse_env(i)
-               mse_max_klev(i) = k
+               msemax_klev(i) = k
             end if
          else
             ! find level and value of max moist static energy
-            if (k >= top_k(i) .and. mse_env(i) > mse_max_val(i)) then
+            if (k >= msemax_top_k(i) .and. mse_env(i) > mse_max_val(i)) then
                mse_max_val(i) = mse_env(i)
-               mse_max_klev(i) = k
+               msemax_klev(i) = k
             end if
          end if
       end do
@@ -262,10 +254,11 @@ end subroutine find_mse_max
 
 !===================================================================================================
 
-subroutine compute_dilute_parcel( ncol, msg, klaunch, &
-                                  p, t, q, tpert, pblt, &
+subroutine compute_dilute_parcel( pcols, ncol, pver, num_msg, klaunch, &
+                                  pmid, temperature, sp_humidity, tpert, pblt, &
                                   zm_const, zm_param, &
-                                  tp, tpv, qstp, lcl_pl, lcl_tl, lcl_klev )
+                                  parcel_temp, parcel_vtemp, parcel_qsat, &
+                                  cldbot_pmid, cldbot_temperature, cldbot_klev )
    !----------------------------------------------------------------------------
    ! Purpose: Calculate thermodynamic properties of an entraining air parcel 
    !          lifted from the PBL using fractional mass entrainment rate 
@@ -274,22 +267,24 @@ subroutine compute_dilute_parcel( ncol, msg, klaunch, &
    implicit none
    !----------------------------------------------------------------------------
    ! Arguments
-   integer,                         intent(in   ) :: ncol            ! number of atmospheric columns
-   integer,                         intent(in   ) :: msg             ! number of missing moisture levels at the top of model
-   integer,  dimension(pcols),      intent(in   ) :: klaunch         ! index of parcel launch level based on max MSE
-   real(r8), dimension(pcols,pver), intent(in   ) :: p               ! ambient env pressure at cell center
-   real(r8), dimension(pcols,pver), intent(in   ) :: t               ! ambient env temperature at cell center
-   real(r8), dimension(pcols,pver), intent(in   ) :: q               ! ambient env specific humidity at cell center
-   real(r8), dimension(pcols),      intent(in   ) :: tpert           ! PBL temperature perturbation
-   integer,  dimension(pcols),      intent(in   ) :: pblt            ! index of pbl depth 
-   type(zm_const_t),                intent(in   ) :: zm_const        ! derived type to hold ZM constants
-   type(zm_param_t),                intent(in   ) :: zm_param        ! derived type to hold ZM tunable parameters
-   real(r8), dimension(pcols,pver), intent(inout) :: tp              ! Parcel temperature
-   real(r8), dimension(pcols,pver), intent(inout) :: tpv             ! Parcel virtual temperature
-   real(r8), dimension(pcols,pver), intent(inout) :: qstp            ! Parcel water vapour (sat value above lcl)
-   real(r8), dimension(pcols)     , intent(inout) :: lcl_pl          ! LCL pressure
-   real(r8), dimension(pcols)     , intent(inout) :: lcl_tl          ! LCL temperature
-   integer,  dimension(pcols)     , intent(inout) :: lcl_klev        ! Lifting condesation level (first model level with saturation)
+   integer,                         intent(in   ) :: pcols              ! number of atmospheric columns (max)
+   integer,                         intent(in   ) :: ncol               ! number of atmospheric columns (actual)
+   integer,                         intent(in   ) :: pver               ! number of mid-point vertical levels
+   integer,                         intent(in   ) :: num_msg            ! number of missing moisture levels at the top of model
+   integer,  dimension(pcols),      intent(in   ) :: klaunch            ! index of parcel launch level based on max MSE
+   real(r8), dimension(pcols,pver), intent(in   ) :: pmid               ! ambient env pressure at cell center
+   real(r8), dimension(pcols,pver), intent(in   ) :: temperature        ! ambient env temperature at cell center
+   real(r8), dimension(pcols,pver), intent(in   ) :: sp_humidity        ! ambient env specific humidity at cell center
+   real(r8), dimension(pcols),      intent(in   ) :: tpert              ! PBL temperature perturbation
+   integer,  dimension(pcols),      intent(in   ) :: pblt               ! index of pbl depth 
+   type(zm_const_t),                intent(in   ) :: zm_const           ! derived type to hold ZM constants
+   type(zm_param_t),                intent(in   ) :: zm_param           ! derived type to hold ZM tunable parameters
+   real(r8), dimension(pcols,pver), intent(inout) :: parcel_temp        ! Parcel temperature
+   real(r8), dimension(pcols,pver), intent(inout) :: parcel_vtemp       ! Parcel virtual temperature
+   real(r8), dimension(pcols,pver), intent(inout) :: parcel_qsat        ! Parcel water vapour (sat value above lcl)
+   real(r8), dimension(pcols)     , intent(inout) :: cldbot_pmid        ! cloud bottom (LCL) pressure
+   real(r8), dimension(pcols)     , intent(inout) :: cldbot_temperature ! cloud bottom (LCL) temperature
+   integer,  dimension(pcols)     , intent(inout) :: cldbot_klev        ! cloud bottom (LCL) vertical index
    !----------------------------------------------------------------------------
    ! Local variables
    integer i,k,ii   ! loop iterators
@@ -324,14 +319,14 @@ subroutine compute_dilute_parcel( ncol, msg, klaunch, &
    real(r8) tfguess  ! first guess for entropy inversion
    real(r8) tscool   ! super cooled temperature offset from freezing temperature when cloud water loading freezes
 
-   real(r8) qxsk     ! LCL excess water @ k
-   real(r8) qxskp1   ! LCL excess water @ k+1
-   real(r8) dsdp     ! LCL entropy gradient @ k
-   real(r8) dqtdp    ! LCL total water gradient @ k
-   real(r8) dqxsdp   ! LCL excess water gradient @ k+1
-   real(r8) slcl     ! LCL entropy
-   real(r8) qtlcl    ! LCL total water
-   real(r8) qslcl    ! LCL saturated vapor mixing ratio
+   real(r8) qxsk     ! cloud bottom (LCL) excess water @ k
+   real(r8) qxskp1   ! cloud bottom (LCL) excess water @ k+1
+   real(r8) dsdp     ! cloud bottom (LCL) entropy gradient @ k
+   real(r8) dqtdp    ! cloud bottom (LCL) total water gradient @ k
+   real(r8) dqxsdp   ! cloud bottom (LCL) excess water gradient @ k+1
+   real(r8) slcl     ! cloud bottom (LCL) entropy
+   real(r8) qtlcl    ! cloud bottom (LCL) total water
+   real(r8) qslcl    ! cloud bottom (LCL) saturated vapor mixing ratio
 
    integer rcall     ! ientropy call id for error message
    
@@ -371,28 +366,28 @@ subroutine compute_dilute_parcel( ncol, msg, klaunch, &
 
    !----------------------------------------------------------------------------
    ! entrainment loop
-   do k = pver, msg+1, -1
+   do k = pver, num_msg+1, -1
       do i = 1,ncol
 
          if ( k == klaunch(i) ) then 
 
             ! initialize values at launch level
-            mp0(i)      = 1._r8    ! initial relative mass - value of 1.0 does not change for undilute (dmpdp=0)
-            qtp0(i)     = q(i,k)   ! initial total water - assuming subsaturated
-            sp0(i)      = entropy( t(i,k), p(i,k), qtp0(i), zm_const )
+            mp0(i)      = 1._r8            ! initial relative mass - value of 1.0 does not change for undilute (dmpdp=0)
+            qtp0(i)     = sp_humidity(i,k) ! initial total water - assuming subsaturated
+            sp0(i)      = entropy( temperature(i,k), pmid(i,k), qtp0(i), zm_const )
             smix(i,k)   = sp0(i)
             qtmix(i,k)  = qtp0(i)
-            tfguess     = t(i,k)
+            tfguess     = temperature(i,k)
             rcall = 1
-            call ientropy( rcall, smix(i,k), p(i,k), qtmix(i,k), tmix(i,k), qsmix(i,k), tfguess, zm_const )
+            call ientropy( rcall, smix(i,k), pmid(i,k), qtmix(i,k), tmix(i,k), qsmix(i,k), tfguess, zm_const )
          
          elseif ( k < klaunch(i) ) then 
 
             ! set environmental values for this level
-            dp    = p(i,k) - p(i,k+1)
-            qtenv = 0.5_r8*(q(i,k)+q(i,k+1))
-            tenv  = 0.5_r8*(t(i,k)+t(i,k+1)) 
-            penv  = 0.5_r8*(p(i,k)+p(i,k+1))
+            dp    = pmid(i,k) - pmid(i,k+1)
+            qtenv = 0.5_r8*(sp_humidity(i,k)+sp_humidity(i,k+1))
+            tenv  = 0.5_r8*(temperature(i,k)+temperature(i,k+1)) 
+            penv  = 0.5_r8*(pmid(i,k)+pmid(i,k+1))
             senv  = entropy( tenv, penv, qtenv, zm_const )
 
             ! determine fractional entrainment rate 1/pa given value 1/m
@@ -410,33 +405,33 @@ subroutine compute_dilute_parcel( ncol, msg, klaunch, &
             smix(i,k)  = (sp0(i)  +  sp(i)) / (mp0(i) + mp(i))
             qtmix(i,k) = (qtp0(i) + qtp(i)) / (mp0(i) + mp(i))
 
-            ! Invert entropy from s and q to determine T and saturation-capped q of mixture.
-            ! t(i,k) used as a first guess so that it converges faster.
+            ! Invert entropy from s and q to determine T and saturation-capped q of mixture
+            ! temperature(i,k) used as a first guess so that it converges faster
 
             tfguess = tmix(i,k+1)
             rcall = 2
-            call ientropy( rcall, smix(i,k), p(i,k), qtmix(i,k), tmix(i,k), qsmix(i,k), tfguess, zm_const )
+            call ientropy( rcall, smix(i,k), pmid(i,k), qtmix(i,k), tmix(i,k), qsmix(i,k), tfguess, zm_const )
 
             ! determine if we are at the LCL if this is first level where qsmix<=qtmix on ascending
             if ( qsmix(i,k)<=qtmix(i,k) .and. qsmix(i,k+1)>qtmix(i,k+1) ) then
-               lcl_klev(i) = k
-               qxsk        = qtmix(i,k) - qsmix(i,k)
-               qxskp1      = qtmix(i,k+1) - qsmix(i,k+1)
-               dqxsdp      = (qxsk - qxskp1)/dp
-               lcl_pl(i)   = p(i,k+1) - qxskp1/dqxsdp ! pressure level of actual lcl
-               dsdp        = (smix(i,k)  - smix(i,k+1))/dp
-               dqtdp       = (qtmix(i,k) - qtmix(i,k+1))/dp
-               slcl        = smix(i,k+1)  + dsdp* (lcl_pl(i)-p(i,k+1))  
-               qtlcl       = qtmix(i,k+1) + dqtdp*(lcl_pl(i)-p(i,k+1))
-               tfguess     = tmix(i,k)
+               cldbot_klev(i) = k
+               qxsk           = qtmix(i,k) - qsmix(i,k)
+               qxskp1         = qtmix(i,k+1) - qsmix(i,k+1)
+               dqxsdp         = (qxsk - qxskp1)/dp
+               cldbot_pmid(i)      = pmid(i,k+1) - qxskp1/dqxsdp ! pressure level of actual lcl
+               dsdp           = (smix(i,k)  - smix(i,k+1))/dp
+               dqtdp          = (qtmix(i,k) - qtmix(i,k+1))/dp
+               slcl           = smix(i,k+1)  + dsdp* (cldbot_pmid(i)-pmid(i,k+1))  
+               qtlcl          = qtmix(i,k+1) + dqtdp*(cldbot_pmid(i)-pmid(i,k+1))
+               tfguess        = tmix(i,k)
                rcall = 3
-               call ientropy( rcall, slcl, lcl_pl(i), qtlcl, lcl_tl(i), qslcl, tfguess, zm_const )
+               call ientropy( rcall, slcl, cldbot_pmid(i), qtlcl, cldbot_temperature(i), qslcl, tfguess, zm_const )
             endif
 
          end if !  k < klaunch
 
       end do ! i = 1,ncol
-   end do ! k = pver, msg+1, -1
+   end do ! k = pver, num_msg+1, -1
    !----------------------------------------------------------------------------
    ! end of entrainment loop
    
@@ -456,15 +451,16 @@ subroutine compute_dilute_parcel( ncol, msg, klaunch, &
    xsh2o = 0._r8
    ds_xsh2o = 0._r8
    ds_freeze = 0._r8
-   do k = pver,msg+1,-1
+   do k = pver, num_msg+1, -1
       do i = 1,ncol      
 
          if ( k == klaunch(i) ) then
 
             ! initialize values at launch level - assume no liquid water
-            tp(i,k)    = tmix(i,k)
-            qstp(i,k)  = q(i,k) 
-            tpv(i,k)   = (tp(i,k) + zm_param%tpert_fac*tpert_loc(i)) * (1._r8+1.608_r8*qstp(i,k)) / (1._r8+qstp(i,k))
+            parcel_temp(i,k)  = tmix(i,k)
+            parcel_qsat(i,k)  = sp_humidity(i,k) 
+            parcel_vtemp(i,k) = ( parcel_temp(i,k) +zm_param%tpert_fac*tpert_loc(i) ) & 
+                                * (1._r8+zm_const%zvir*parcel_qsat(i,k)) / (1._r8+parcel_qsat(i,k))
 
          elseif ( k < klaunch(i) ) then
 
@@ -499,27 +495,28 @@ subroutine compute_dilute_parcel( ncol, msg, klaunch, &
                ! invert entropy to get updated Tmix and qsmix of parcel
                tfguess = tmix(i,k)
                rcall =4
-               call ientropy( rcall, new_s, p(i,k), new_q, tmix(i,k), qsmix(i,k), tfguess, zm_const )
+               call ientropy( rcall, new_s, pmid(i,k), new_q, tmix(i,k), qsmix(i,k), tfguess, zm_const )
                
             end do  ! iteration loop for freezing processes
 
-            ! tp  - Parcel temp is temp of mixture
-            ! tpv - Parcel virtual temp should be density temp with new_q total water
-            tp(i,k) = tmix(i,k)
+            ! parcel temp is temp of mixture
+            ! parcel virtual temp should be density temp with new_q total water
+            parcel_temp(i,k) = tmix(i,k)
 
-            ! tpv=tprho in the presence of condensate (i.e. when new_q > qsmix)
+            ! parcel_vtemp=tprho in the presence of condensate (i.e. when new_q > qsmix)
             if (new_q > qsmix(i,k)) then  ! super-saturated so condensate present - reduces buoyancy
-               qstp(i,k) = qsmix(i,k)
+               parcel_qsat(i,k) = qsmix(i,k)
             else                          ! just saturated/sub-saturated - no condensate virtual effects
-               qstp(i,k) = new_q
+               parcel_qsat(i,k) = new_q
             end if
 
-            tpv(i,k) = (tp(i,k)+zm_param%tpert_fac*tpert_loc(i))* (1._r8+1.608_r8*qstp(i,k)) / (1._r8+ new_q)
+            parcel_vtemp(i,k) = ( parcel_temp(i,k) +zm_param%tpert_fac*tpert_loc(i) ) &
+                                * (1._r8+zm_const%zvir*parcel_qsat(i,k)) / (1._r8+ new_q)
 
          end if ! k < klaunch
       
       end do ! i = 1,ncol
-   end do ! k = pver, msg+1, -1
+   end do ! k = pver, num_msg+1, -1
 
    !----------------------------------------------------------------------------
    return
@@ -528,75 +525,78 @@ end subroutine compute_dilute_parcel
 
 !===================================================================================================
 
-subroutine compute_cape_from_parcel( ncol, num_cin, msg, &
-                                     t, tv, z, q, pint, lcl_pl, &
-                                     mse_max_klev, lcl_klev, &
+subroutine compute_cape_from_parcel( pcols, ncol, pver, pverp, num_cin, num_msg, &
+                                     temperature, tv, zmid, sp_humidity, pint, cldbot_pmid, &
+                                     msemax_klev, cldbot_klev, &
                                      zm_const, zm_param, &
-                                     qstp, tp, tpv, eql_klev, cape )
+                                     parcel_qsat, parcel_temp, parcel_vtemp, &
+                                     cldtop_klev, cape )
    !----------------------------------------------------------------------------
    ! Purpose: calculate convective available potential energy (CAPE)
    !          from parcel thermodynamic properties from compute_dilute_parcel()
    !----------------------------------------------------------------------------
-   integer,                         intent(in   ) :: ncol            ! number of atmospheric columns
-   integer,                         intent(in   ) :: num_cin         ! num of negative buoyancy regions that are allowed before the conv. top and CAPE calc are completed
-   integer,                         intent(in   ) :: msg             ! number of missing moisture levels at the top of model
-   real(r8), dimension(pcols,pver), intent(in   ) :: t               ! temperature
-   real(r8), dimension(pcols,pver), intent(in   ) :: tv              ! virtual temperature
-   real(r8), dimension(pcols,pver), intent(in   ) :: z               ! height
-   real(r8), dimension(pcols,pver), intent(in   ) :: q               ! specific humidity
-   real(r8), dimension(pcols,pverp),intent(in   ) :: pint            ! pressure at interfaces
-   real(r8), dimension(pcols),      intent(in   ) :: lcl_pl          ! LCL pressure
-   integer,  dimension(pcols),      intent(in   ) :: mse_max_klev    ! index of max MSE at parcel launch level
-   integer,  dimension(pcols),      intent(in   ) :: lcl_klev        ! base level index of deep cumulus convection
-   type(zm_const_t),                intent(in   ) :: zm_const        ! derived type to hold ZM constants
-   type(zm_param_t),                intent(in   ) :: zm_param        ! derived type to hold ZM tunable parameters
-   real(r8), dimension(pcols,pver), intent(inout) :: qstp            ! parcel saturation mixing ratio
-   real(r8), dimension(pcols,pver), intent(inout) :: tp              ! parcel temperature
-   real(r8), dimension(pcols,pver), intent(inout) :: tpv             ! parcel virtual temperature
-   integer,  dimension(pcols),      intent(inout) :: eql_klev        ! index of highest convective plume
-   real(r8), dimension(pcols),      intent(inout) :: cape            ! convective available potential energy
+   integer,                         intent(in   ) :: pcols        ! number of atmospheric columns (max)
+   integer,                         intent(in   ) :: ncol         ! number of atmospheric columns (actual)
+   integer,                         intent(in   ) :: pver         ! number of mid-point vertical levels
+   integer,                         intent(in   ) :: pverp        ! number of interface vertical levels
+   integer,                         intent(in   ) :: num_cin      ! num of negative buoyancy regions that are allowed before the conv. top and CAPE calc are completed
+   integer,                         intent(in   ) :: num_msg      ! number of missing moisture levels at the top of model
+   real(r8), dimension(pcols,pver), intent(in   ) :: temperature  ! temperature
+   real(r8), dimension(pcols,pver), intent(in   ) :: tv           ! virtual temperature
+   real(r8), dimension(pcols,pver), intent(in   ) :: zmid         ! height/altitude at mid-levels
+   real(r8), dimension(pcols,pver), intent(in   ) :: sp_humidity  ! specific humidity
+   real(r8), dimension(pcols,pverp),intent(in   ) :: pint         ! pressure at interfaces
+   real(r8), dimension(pcols),      intent(in   ) :: cldbot_pmid  ! cloud bottom (LCL) pressure
+   integer,  dimension(pcols),      intent(in   ) :: msemax_klev  ! index of max MSE at parcel launch level
+   integer,  dimension(pcols),      intent(in   ) :: cldbot_klev  ! index of cloud bottom
+   type(zm_const_t),                intent(in   ) :: zm_const     ! derived type to hold ZM constants
+   type(zm_param_t),                intent(in   ) :: zm_param     ! derived type to hold ZM tunable parameters
+   real(r8), dimension(pcols,pver), intent(inout) :: parcel_qsat  ! parcel saturation mixing ratio
+   real(r8), dimension(pcols,pver), intent(inout) :: parcel_temp  ! parcel temperature
+   real(r8), dimension(pcols,pver), intent(inout) :: parcel_vtemp ! parcel virtual temperature
+   integer,  dimension(pcols),      intent(inout) :: cldtop_klev  ! index of cloud top
+   real(r8), dimension(pcols),      intent(inout) :: cape         ! convective available potential energy
    !----------------------------------------------------------------------------
    ! Local variables
    integer  :: i, k, n                                      ! loop iterators
    real(r8), dimension(pcols,pver)    :: buoyancy           ! parcel buoyancy
    real(r8), dimension(pcols,num_cin) :: cape_tmp           ! provisional value of cape
-   integer,  dimension(pcols,num_cin) :: eql_klev_tmp       ! provisional value of index of highest convective plume
+   integer,  dimension(pcols,num_cin) :: cldtop_klev_tmp    ! provisional value of cloud top index
    integer,  dimension(pcols)         :: neg_buoyancy_cnt   ! counter for levels with negative bounancy
 
    logical plge600(pcols) ! for testing - remove!
    !----------------------------------------------------------------------------
    ! Initialize variables
-   eql_klev        (1:ncol)           = pver
-   eql_klev_tmp    (1:ncol,1:num_cin) = pver
+   cldtop_klev     (1:ncol)           = pver
+   cldtop_klev_tmp (1:ncol,1:num_cin) = pver
    cape            (1:ncol)           = 0._r8
    cape_tmp        (1:ncol,1:num_cin) = 0._r8
    buoyancy        (1:ncol,1:pver)    = 0._r8
    neg_buoyancy_cnt(1:ncol)           = 0
    !----------------------------------------------------------------------------
    ! Calculate buoyancy
-   do k = pver,msg + 1,-1
+   do k = pver, num_msg+1, -1
       do i=1,ncol
          ! Define buoyancy from launch level to cloud top
-         if ( k <= mse_max_klev(i) .and. lcl_pl(i).ge.lcl_pressure_threshold ) then
-            buoyancy(i,k) = tpv(i,k) - tv(i,k) + zm_param%tiedke_add
+         if ( k <= msemax_klev(i) .and. cldbot_pmid(i).ge.lcl_pressure_threshold ) then
+            buoyancy(i,k) = parcel_vtemp(i,k) - tv(i,k) + zm_param%tiedke_add
          else
-            qstp(i,k) = q(i,k)
-            tp(i,k)   = t(i,k)            
-            tpv(i,k)  = tv(i,k)
+            parcel_qsat(i,k)  = sp_humidity(i,k)
+            parcel_temp(i,k)  = temperature(i,k)            
+            parcel_vtemp(i,k) = tv(i,k)
          endif
       end do
    end do
 
    !----------------------------------------------------------------------------
    ! find convective equilibrium level accounting for negative buoyancy levels
-   do k = msg+2,pver
+   do k = num_msg+2, pver
       do i = 1,ncol
-         ! if ( k < lcl_klev(i) .and. lcl_pl(i).ge.lcl_pressure_threshold ) then
-         if ( k < lcl_klev(i) .and. lcl_pl(i).ge.lcl_pressure_threshold ) then
+         if ( k < cldbot_klev(i) .and. cldbot_pmid(i).ge.lcl_pressure_threshold ) then
             if ( buoyancy(i,k+1) > 0._r8 .and. &
                  buoyancy(i,k)   <=0._r8 ) then
                neg_buoyancy_cnt(i) = min( num_cin, neg_buoyancy_cnt(i)+1 )
-               eql_klev_tmp(i,neg_buoyancy_cnt(i)) = k
+               cldtop_klev_tmp(i,neg_buoyancy_cnt(i)) = k
             end if
          end if
       end do
@@ -605,11 +605,11 @@ subroutine compute_cape_from_parcel( ncol, num_cin, msg, &
    !----------------------------------------------------------------------------
    ! integrate buoyancy to obtain possible CAPE values
    do n = 1,num_cin
-      do k = msg + 1,pver
+      do k = num_msg+1, pver
          do i = 1,ncol
-            ! if ( lcl_pl(i).ge.lcl_pressure_threshold .and. &
-            if ( lcl_pl(i).ge.lcl_pressure_threshold .and. &
-                 k <= mse_max_klev(i) .and. k > eql_klev_tmp(i,n)) then
+            ! if ( cldbot_pmid(i).ge.lcl_pressure_threshold .and. &
+            if ( cldbot_pmid(i).ge.lcl_pressure_threshold .and. &
+                 k <= msemax_klev(i) .and. k > cldtop_klev_tmp(i,n)) then
                cape_tmp(i,n) = cape_tmp(i,n) + zm_const%rdair*buoyancy(i,k)*log(pint(i,k+1)/pint(i,k))
             end if
          end do
@@ -623,7 +623,7 @@ subroutine compute_cape_from_parcel( ncol, num_cin, msg, &
       do i = 1,ncol
          if (cape_tmp(i,n) > cape(i)) then
             cape(i) = cape_tmp(i,n)
-            eql_klev(i) = eql_klev_tmp(i,n)
+            cldtop_klev(i) = cldtop_klev_tmp(i,n)
          end if
       end do
    end do

--- a/components/eam/src/physics/cam/zm_conv_cape.F90
+++ b/components/eam/src/physics/cam/zm_conv_cape.F90
@@ -11,10 +11,7 @@ module zm_conv_cape
    implicit none
    private
 
-   public :: compute_dilute_cape       ! ?
-   ! public :: find_mse_max              ! ?
-   ! public :: compute_dilute_parcel     ! ?
-   ! public :: compute_cape_from_parcel  ! ?
+   public :: compute_dilute_cape ! calculate convective available potential energy (CAPE) with dilute parcel ascent
 
    real(r8), parameter :: lcl_pressure_threshold     = 600._r8   ! if LCL pressure is lower => no convection and cape is zero
    real(r8), parameter :: ull_upper_launch_pressure  = 600._r8   ! upper search limit for unrestricted launch level (ULL)
@@ -26,7 +23,6 @@ contains
 
 ! NOTES / to-do
 ! - add arguments for pcols/pver/pverp ?
-! - Create MPI broadcast routines for params and consts
 ! - rename
 !   - mse_max_klev => msemax_klev
 !   - eql_klev     => cldtop_klev
@@ -48,8 +44,8 @@ subroutine compute_dilute_cape( ncol, num_cin, msg, &
                                 zm_const, zm_param, &
                                 iclosure, dcapemx, use_input_parcel_tq, q_mx, t_mx )
    !----------------------------------------------------------------------------
-   ! Purpose: Calculate convective available potential energy (CAPE), lifting 
-   !          condensation level (LCL), and convective top
+   ! Purpose: calculate convective available potential energy (CAPE), lifting
+   !          condensation level (LCL), and convective top with dilute parcel ascent
    ! Method: parcel temperature based on a plume model with constant entrainment
    ! Original Author: Richard Neale - September 2004
    ! References:

--- a/components/eam/src/physics/cam/zm_conv_parcel.F90
+++ b/components/eam/src/physics/cam/zm_conv_parcel.F90
@@ -1,0 +1,634 @@
+module zm_conv_parcel
+   !----------------------------------------------------------------------------
+   ! Purpose: plume/parcel/cloud model methods for ZM deep convection scheme
+   !----------------------------------------------------------------------------
+   use shr_kind_mod,     only: r8=>shr_kind_r8
+   use ppgrid,           only: pcols, pver, pverp
+   use cam_abortutils,   only: endrun
+   use zm_conv_util,     only: entropy, ientropy, qsat_hPa
+   use zm_conv_util,     only: zm_constants_t, zm_parameters_t
+
+   implicit none
+   private
+
+   public :: buoyan_dilute ! subroutine that calculates CAPE
+
+   private :: find_mse_max
+   private :: parcel_dilute
+   private :: calculate_cape_from_parcel
+
+   real(r8) :: lcl_pressure_threshold     = 600._r8   ! if LCL pressure is lower => no convection and cape is zero
+   real(r8) :: ull_upper_launch_pressure  = 600._r8   ! upper search limit for unrestricted launch level (ULL)
+   real(r8) :: pergro_rhd_threshold       = -1.e-4_r8 ! MSE difference threshold for perturbation growth test
+!===================================================================================================
+contains
+!===================================================================================================
+
+subroutine buoyan_dilute(lchnk, ncol, num_cin, &
+                         q_in, t_in, z, p, pint, pblt, msg, tpert, &
+                         tp, qstp, mse_max_klev, lcl_tl, lcl_klev, eql_klev, cape, &
+                         zm_constants, zm_parameters, &
+                         iclosure, dcapemx, use_input_parcel_tq, q_mx, t_mx )
+   !----------------------------------------------------------------------------
+   ! Purpose: Calculate convective available potential energy (CAPE), lifting 
+   !          condensation level (LCL), and convective top
+   ! Method: parcel temperature based on a plume model with constant entrainment
+   ! Original Author: Richard Neale - September 2004
+   ! References:
+   !   Raymond, D. J., and A. M. Blyth, 1986: A Stochastic Mixing Model for
+   !     Nonprecipitating Cumulus Clouds. J. Atmos. Sci., 43, 2708–2718
+   !   Raymond, D. J., and A. M. Blyth, 1992: Extension of the Stochastic Mixing
+   !     Model to Cumulonimbus Clouds. J. Atmos. Sci., 49, 1968–1983
+   !----------------------------------------------------------------------------
+   implicit none
+   !----------------------------------------------------------------------------
+   ! Arguments
+   integer,                              intent(in   ) :: lchnk               ! chunk identifier
+   integer,                              intent(in   ) :: ncol                ! number of atmospheric columns
+   integer,                              intent(in   ) :: num_cin             ! num of negative buoyancy regions that are allowed before the conv. top and CAPE calc are completed
+   real(r8), dimension(pcols,pver),      intent(in   ) :: q_in                ! specific humidity
+   real(r8), dimension(pcols,pver),      intent(in   ) :: t_in                ! temperature
+   real(r8), dimension(pcols,pver),      intent(in   ) :: z                   ! height
+   real(r8), dimension(pcols,pver),      intent(in   ) :: p                   ! pressure at mid-levels
+   real(r8), dimension(pcols,pverp),     intent(in   ) :: pint                ! pressure at interfaces
+   integer,  dimension(pcols),           intent(in   ) :: pblt                ! index of pbl depth used as upper limit index of max MSE search
+   integer,                              intent(in   ) :: msg                 ! number of missing moisture levels at the top of model
+   real(r8), dimension(pcols),           intent(in   ) :: tpert               ! perturbation temperature by pbl processes
+   real(r8), dimension(pcols,pver),      intent(  out) :: tp                  ! parcel temperature
+   real(r8), dimension(pcols,pver),      intent(inout) :: qstp                ! parcel saturation mixing ratio
+   integer,  dimension(pcols),           intent(inout) :: mse_max_klev        ! index of max MSE at parcel launch level
+   real(r8), dimension(pcols),           intent(  out) :: lcl_tl              ! LCL temperature
+   integer,  dimension(pcols),           intent(inout) :: lcl_klev            ! base level index of deep cumulus convection
+   integer,  dimension(pcols),           intent(inout) :: eql_klev            ! index of highest convective plume
+   real(r8), dimension(pcols),           intent(inout) :: cape                ! convective available potential energy
+   type(zm_constants_t),                 intent(in   ) :: zm_constants        ! derived type to hold ZM constants
+   type(zm_parameters_t),                intent(in   ) :: zm_parameters       ! derived type to hold ZM tunable parameters
+   logical,                              intent(in   ) :: iclosure            ! true for normal procedure, otherwise use dcapemx from 1st call
+   integer,  dimension(pcols), optional, intent(in   ) :: dcapemx             ! ?
+   logical,                    optional, intent(in   ) :: use_input_parcel_tq ! if .true., use input values of dcapemx, q_mx, t_mx in the CAPE calculation
+   real(r8), dimension(pcols), optional, intent(inout) :: q_mx                ! ?
+   real(r8), dimension(pcols), optional, intent(inout) :: t_mx                ! ?
+   !----------------------------------------------------------------------------
+   ! Local variables
+   real(r8), dimension(pcols,pver)    :: q                  ! local version of specific humidity
+   real(r8), dimension(pcols,pver)    :: t                  ! local version of temperature
+   real(r8), dimension(pcols,pver)    :: tv                 ! virtual temperature
+   real(r8), dimension(pcols,pver)    :: tpv                ! parcel virtual temperature
+   real(r8), dimension(pcols)         :: lcl_pl             ! LCL pressure
+   real(r8), dimension(pcols)         :: mse_max_val        ! value of max MSE at parcel launch level
+   integer,  dimension(pcols)         :: pblt_ull           ! upper limit index of max MSE search for ULL
+   integer,  dimension(pcols)         :: top_k              ! upper limit index of max MSE search
+   integer  :: i, k                       ! loop iterators
+   logical  :: pergro_active              ! flag for perturbation growth test (pergro)
+   logical  :: use_input_parcel_tq_loc    ! flag to use input parcel temperature and specific humidity
+   
+   real(r8), parameter :: zvir = 1.608_r8 ! this should be replaced with value from physconst module
+   !----------------------------------------------------------------------------
+   ! set flag for perturbation growth test
+#ifdef PERGRO
+   pergro_active = .true.
+#else
+   pergro_active = .false.
+#endif
+   !----------------------------------------------------------------------------
+   if (PRESENT(use_input_parcel_tq)) then
+      use_input_parcel_tq_loc = use_input_parcel_tq
+   else
+      use_input_parcel_tq_loc = .false.
+   end if
+
+   !----------------------------------------------------------------------------
+   ! Copy the incoming temperature and specific humidity values to local arrays 
+   t(:ncol,:) = t_in(:ncol,:)
+   q(:ncol,:) = q_in(:ncol,:)
+
+   !----------------------------------------------------------------------------
+   if ( use_input_parcel_tq_loc  .and. &
+       ((.not.PRESENT(t_mx)) .or.  &
+        (.not.PRESENT(q_mx)) .or.  &
+        (.not.PRESENT(dcapemx)) )  ) then
+      call endrun('buoyan_dilute :: use_input_parcel_tq = .true. but dcapemx, t_mx or q_mx is not provided')
+   end if
+
+   if (use_input_parcel_tq_loc) then
+      !-------------------------------------------------------------------------
+      ! We expect 
+      ! (1) the incoming array dcapemx contains prev identified launching level index, and 
+      ! (2) the arrays q_mx and t_mx contain q and T values at the old launching level 
+      !     at the time when the old launching level was identified. 
+      ! Copy the old values to work arrays for calculations in the rest of this subroutine
+      !-------------------------------------------------------------------------
+      mse_max_klev(:ncol) = dcapemx(:ncol)
+      do i=1,ncol
+         q(i,mse_max_klev(i)) = q_mx(i)
+         t(i,mse_max_klev(i)) = t_mx(i)
+      end do
+   else ! initialize the mx array
+      mse_max_klev(1:ncol) = pver
+   end if
+
+   !----------------------------------------------------------------------------
+   ! Initialize variables
+   mse_max_val(1:ncol)           = 0._r8
+   tp         (1:ncol,1:pver)    = t(1:ncol,1:pver)
+   qstp       (1:ncol,1:pver)    = q(1:ncol,1:pver)
+
+   !----------------------------------------------------------------------------
+   ! calculate virtual temperature (tv)
+   tv  (1:ncol,1:pver) = t(:ncol,:) * ( 1._r8+zvir*q(:ncol,:) ) / ( 1._r8+q(:ncol,:) )
+   tpv (1:ncol,1:pver) = tv(:ncol,:)
+
+   !----------------------------------------------------------------------------
+   ! Find new upper bound for parcel starting level - unrestricted launch level (ULL)
+   if (zm_parameters%trig_ull) then
+      pblt_ull(1:ncol) = 1
+      do k = pver - 1,msg + 1,-1
+         do i = 1,ncol
+            if ( (p(i,k)  .le.ull_upper_launch_pressure) .and. &
+                 (p(i,k+1).gt.ull_upper_launch_pressure) ) then
+               pblt_ull(i) = k
+            end if
+         end do
+      end do
+   endif
+
+   !----------------------------------------------------------------------------
+   ! Set level of max moist static energy for parcel initialization
+   if ( zm_parameters%trig_dcape .and. (.not.iclosure) ) then
+      ! Use max moist static energy level that is passed in
+      if (.not.present(dcapemx)) call endrun('** ZM CONV buoyan_dilute: dcapemx not present **')
+      mse_max_klev(1:ncol) = dcapemx(1:ncol)
+   elseif (.not.use_input_parcel_tq_loc) then
+      if (     zm_parameters%trig_ull) top_k(:ncol) = pblt_ull(:ncol)
+      if (.not.zm_parameters%trig_ull) top_k(:ncol) = pblt(:ncol)
+      call find_mse_max( ncol, t, z, q, msg, top_k, pergro_active, &
+                         zm_constants, zm_parameters, &
+                         mse_max_klev, mse_max_val )
+   end if
+
+   !----------------------------------------------------------------------------
+   do i=1,ncol
+      ! Save launching level T, q for output
+      if ( .not.use_input_parcel_tq_loc .and. present(q_mx) .and. present(t_mx) ) then
+         q_mx(i) = q(i,mse_max_klev(i))
+         t_mx(i) = t(i,mse_max_klev(i))
+      end if
+      ! save LCL values for parcel_dilute()
+      lcl_klev(i) = mse_max_klev(i)
+      lcl_tl(i) = t(i,lcl_klev(i))
+      lcl_pl(i) = p(i,lcl_klev(i))
+   end do
+
+   !----------------------------------------------------------------------------
+   ! entraining plume calculation
+   call parcel_dilute( lchnk, ncol, msg, mse_max_klev, &
+                       p, t, q, tpert, pblt, &
+                       zm_constants, zm_parameters, &
+                       tp, tpv, qstp, lcl_pl, lcl_tl, lcl_klev )
+
+   !----------------------------------------------------------------------------
+   ! calculate CAPE
+   call calculate_cape_from_parcel( ncol, num_cin, &
+                                    t, tv, z, q, qstp, tp, tpv, &
+                                    pint, lcl_pl, msg, mse_max_klev, &
+                                    zm_constants, zm_parameters, &
+                                    lcl_klev, eql_klev, cape )
+
+   !----------------------------------------------------------------------------
+   return
+
+end subroutine buoyan_dilute
+
+!===================================================================================================
+
+subroutine find_mse_max( ncol, t, z, q, msg, top_k, pergro_active, &
+                         zm_constants, zm_parameters, mse_max_klev, mse_max_val)
+   !----------------------------------------------------------------------------
+   ! Purpose: find level of max moist static energy for parcel initialization
+   !----------------------------------------------------------------------------
+   ! Arguments
+   integer,                         intent(in   ) :: ncol            ! number of atmospheric columns
+   real(r8), dimension(pcols,pver), intent(in   ) :: t               ! temperature
+   real(r8), dimension(pcols,pver), intent(in   ) :: z               ! height
+   real(r8), dimension(pcols,pver), intent(in   ) :: q               ! specific humidity
+   integer,                         intent(in   ) :: msg             ! number of missing moisture levels at the top of model
+   integer,  dimension(pcols),      intent(in   ) :: top_k           ! upper limit index of max MSE search
+   logical,                         intent(in   ) :: pergro_active   ! flag for perturbation growth test (pergro)
+   type(zm_constants_t),            intent(in   ) :: zm_constants    ! derived type to hold ZM constants
+   type(zm_parameters_t),           intent(in   ) :: zm_parameters   ! derived type to hold ZM tunable parameters
+   integer,  dimension(pcols),      intent(inout) :: mse_max_klev    ! index of max MSE at parcel launch level
+   real(r8), dimension(pcols),      intent(inout) :: mse_max_val     ! value of max MSE at parcel launch level
+   !----------------------------------------------------------------------------
+   ! Local variables
+   integer  :: i,k                       ! loop iterators
+   integer  :: bot_layer                 ! lower limit to search for parcel launch level
+   real(r8) :: pergro_rhd                ! relative MSE (h) difference for perturbation growth test (pergro)
+   real(r8), dimension(pcols) :: mse_env ! env moist static energy
+   !----------------------------------------------------------------------------
+   ! set lower limit to search for launch level with maximum moist static energy
+   bot_layer = pver - zm_parameters%mx_bot_lyr_adj
+   do k = bot_layer,msg + 1,-1
+      do i = 1,ncol
+         ! calculate moist static energy
+         mse_env(i) = zm_constants%cpair*t(i,k) + zm_constants%grav*z(i,k) + zm_constants%latvap*q(i,k)
+         if (pergro_active) then
+            ! Reset max moist static energy level when relative difference exceeds 1.e-4
+            pergro_rhd = (mse_env(i) - mse_max_val(i))/(mse_env(i) + mse_max_val(i))
+            if (k >= top_k(i) .and. pergro_rhd > pergro_rhd_threshold) then
+               mse_max_val(i) = mse_env(i)
+               mse_max_klev(i) = k
+            end if
+         else
+            ! find level and value of max moist static energy
+            if (k >= top_k(i) .and. mse_env(i) > mse_max_val(i)) then
+               mse_max_val(i) = mse_env(i)
+               mse_max_klev(i) = k
+            end if
+         end if
+      end do
+   end do
+   !----------------------------------------------------------------------------
+end subroutine find_mse_max
+
+!===================================================================================================
+
+subroutine parcel_dilute( lchnk, ncol, msg, klaunch, &
+                          p, t, q, tpert, pblt, &
+                          tp, tpv, qstp, lcl_pl, lcl_tl, lcl_klev, &
+                          zm_constants, zm_parameters )
+   !----------------------------------------------------------------------------
+   ! Purpose: Calculate thermodynamic properties of an entraining air parcel 
+   !          lifted from the PBL using fractional mass entrainment rate 
+   !          specified by zm_parameters%dmpdz
+   !----------------------------------------------------------------------------
+   implicit none
+   !----------------------------------------------------------------------------
+   ! Arguments
+   integer,                         intent(in   ) :: lchnk           ! chunk identifier
+   integer,                         intent(in   ) :: ncol            ! number of atmospheric columns
+   integer,                         intent(in   ) :: msg             ! number of missing moisture levels at the top of model
+   integer,  dimension(pcols),      intent(in   ) :: klaunch         ! index of parcel launch level based on max MSE
+   real(r8), dimension(pcols,pver), intent(in   ) :: p               ! ambient env pressure at cell center
+   real(r8), dimension(pcols,pver), intent(in   ) :: t               ! ambient env temperature at cell center
+   real(r8), dimension(pcols,pver), intent(in   ) :: q               ! ambient env specific humidity at cell center
+   real(r8), dimension(pcols),      intent(in   ) :: tpert           ! PBL temperature perturbation
+   integer,  dimension(pcols),      intent(in   ) :: pblt            ! index of pbl depth 
+   type(zm_constants_t),            intent(in   ) :: zm_constants    ! derived type to hold ZM constants
+   type(zm_parameters_t),           intent(in   ) :: zm_parameters   ! derived type to hold ZM tunable parameters
+   real(r8), dimension(pcols,pver), intent(inout) :: tp              ! Parcel temperature
+   real(r8), dimension(pcols,pver), intent(  out) :: tpv             ! Parcel virtual temperature
+   real(r8), dimension(pcols,pver), intent(inout) :: qstp            ! Parcel water vapour (sat value above lcl)
+   real(r8), dimension(pcols)     , intent(inout) :: lcl_tl          ! LCL temperature
+   real(r8), dimension(pcols)     , intent(inout) :: lcl_pl          ! LCL pressure
+   integer,  dimension(pcols)     , intent(inout) :: lcl_klev        ! Lifting condesation level (first model level with saturation)
+   !----------------------------------------------------------------------------
+   ! Local variables
+   integer i,k,ii   ! loop iterators
+
+   real(r8), dimension(pcols,pver) :: tmix        ! tempertaure of the entraining parcel.
+   real(r8), dimension(pcols,pver) :: qtmix       ! total water of the entraining parcel.
+   real(r8), dimension(pcols,pver) :: qsmix       ! saturated mixing ratio at the tmix.
+   real(r8), dimension(pcols,pver) :: smix        ! entropy of the entraining parcel.
+   real(r8), dimension(pcols,pver) :: xsh2o       ! precipitate lost from parcel.
+   real(r8), dimension(pcols,pver) :: ds_xsh2o    ! entropy change due to loss of condensate.
+   real(r8), dimension(pcols,pver) :: ds_freeze   ! entropy change sue to freezing of precip.
+
+   real(r8), dimension(pcols) :: mp               ! parcel mass flux
+   real(r8), dimension(pcols) :: qtp              ! parcel total water
+   real(r8), dimension(pcols) :: sp               ! parcel entropy
+   real(r8), dimension(pcols) :: sp0              ! parcel launch entropy
+   real(r8), dimension(pcols) :: qtp0             ! parcel launch total water
+   real(r8), dimension(pcols) :: mp0              ! parcel launch relative mass [0-1]
+
+   real(r8), dimension(pcols) :: tpert_loc           ! gather parcel temperature perturbation
+
+   real(r8) dmpdp    ! parcel fractional mass entrainment rate [1/mb]
+   real(r8) dpdz     ! hydrstatic relation
+   real(r8) dzdp     ! inverse hydrstatic relation
+   real(r8) senv     ! environmental entropy
+   real(r8) qtenv    ! environmental total water
+   real(r8) penv     ! environmental total pressure
+   real(r8) tenv     ! environmental total temperature
+   real(r8) new_s    ! hold value for entropy after condensation/freezing adjustments
+   real(r8) new_q    ! hold value for total water after condensation/freezing adjustments
+   real(r8) dp       ! layer thickness (center to center)
+   real(r8) tfguess  ! first guess for entropy inversion
+   real(r8) tscool   ! super cooled temperature offset [degC] (sets when cloud water loading freezes)
+
+   real(r8) qxsk     ! LCL excess water @ k
+   real(r8) qxskp1   ! LCL excess water @ k+1
+   real(r8) dsdp     ! LCL entropy gradient @ k
+   real(r8) dqtdp    ! LCL total water gradient @ k
+   real(r8) dqxsdp   ! LCL excess water gradient @ k+1
+   real(r8) slcl     ! LCL entropy
+   real(r8) qtlcl    ! LCL total water
+   real(r8) qslcl    ! LCL saturated vapor mixing ratio
+
+   integer rcall     ! ientropy call id for error message
+   
+   integer,  parameter :: nit_lheat = 2      ! Number of iterations for condensation/freezing loop
+   real(r8), parameter :: lwmax = 1.e-3_r8   ! maximum condesate that can be held in cloud before rainout
+
+   !----------------------------------------------------------------------------
+   ! initialize values
+   tscool      = 0._r8    ! temperature (degC) at which water loading freezes in the cloud
+   qtmix       = 0._r8
+   smix        = 0._r8
+   qtenv       = 0._r8
+   senv        = 0._r8
+   tenv        = 0._r8
+   penv        = 0._r8
+   qtp0        = 0._r8
+   sp0         = 0._r8
+   mp0         = 0._r8
+   qtp         = 0._r8
+   sp          = 0._r8
+   mp          = 0._r8
+   new_q       = 0._r8
+   new_s       = 0._r8
+   !----------------------------------------------------------------------------
+   ! The original ZM scheme only treated PBL-rooted convection. A PBL temperature 
+   ! perturbation (tpert) was then used to increase the parcel temperatue at launch
+   ! level, which is in PBL. The dcape_ull or ull triggr enables ZM scheme to treat
+   ! elevated convection with launch level above PBL. If parcel launch level is
+   ! above PBL top, tempeature perturbation in PBL should not be able to influence 
+   ! it. In this situation, the temporary variable tpert_loc is reset to zero.  
+   do i=1,ncol
+      tpert_loc(i) = tpert(i)
+      if ( zm_parameters%tpert_fix .and. klaunch(i)<pblt(i) ) then
+         tpert_loc(i) = 0._r8
+      end if
+   end do
+
+   !----------------------------------------------------------------------------
+   ! entrainment loop
+   do k = pver, msg+1, -1
+      do i = 1,ncol
+
+         if ( k == klaunch(i) ) then 
+
+            ! initialize values at launch level
+            mp0(i)      = 1._r8    ! initial relative mass - value of 1.0 does not change for undilute (dmpdp=0)
+            qtp0(i)     = q(i,k)   ! initial total water - assuming subsaturated
+            sp0(i)      = entropy(t(i,k),p(i,k),qtp0(i))
+            smix(i,k)   = sp0(i)
+            qtmix(i,k)  = qtp0(i)
+            tfguess     = t(i,k)
+            rcall = 1
+            call ientropy( rcall, smix(i,k), p(i,k), qtmix(i,k), tmix(i,k), qsmix(i,k), tfguess )
+         
+         elseif ( k < klaunch(i) ) then 
+
+            ! set environmental values for this level
+            dp    = p(i,k) - p(i,k+1)
+            qtenv = 0.5_r8*(q(i,k)+q(i,k+1))
+            tenv  = 0.5_r8*(t(i,k)+t(i,k+1)) 
+            penv  = 0.5_r8*(p(i,k)+p(i,k+1))
+            senv  = entropy(tenv,penv,qtenv)
+
+            ! determine fractional entrainment rate 1/pa given value 1/m
+            dpdz = -(penv*zm_constants%grav)/(zm_constants%rdair*tenv) ! [mb/m] since pressure should be [mb]
+            dzdp = 1._r8/dpdz                  ! [m/mb]
+            dmpdp = zm_parameters%dmpdz*dzdp   ! Fractional entrainment [1/mb]
+
+            ! sum entrainment to current level - entrain q,s out of intervening dp layers, 
+            ! assuming linear variation (i.e. entrain the mean of the 2 stored values)
+            sp(i)  = sp(i)  - dmpdp*dp*senv 
+            qtp(i) = qtp(i) - dmpdp*dp*qtenv 
+            mp(i)  = mp(i)  - dmpdp*dp
+            
+            ! entrain s and qt to next level
+            smix(i,k)  = (sp0(i)  +  sp(i)) / (mp0(i) + mp(i))
+            qtmix(i,k) = (qtp0(i) + qtp(i)) / (mp0(i) + mp(i))
+
+            ! Invert entropy from s and q to determine T and saturation-capped q of mixture.
+            ! t(i,k) used as a first guess so that it converges faster.
+
+            tfguess = tmix(i,k+1)
+            rcall = 2
+            call ientropy( rcall, smix(i,k), p(i,k), qtmix(i,k), tmix(i,k), qsmix(i,k), tfguess )
+
+            ! determine if we are at the LCL if this is first level where qsmix<=qtmix on ascending
+            if ( qsmix(i,k)<=qtmix(i,k) .and. qsmix(i,k+1)>qtmix(i,k+1) ) then
+               lcl_klev(i) = k
+               qxsk        = qtmix(i,k) - qsmix(i,k)
+               qxskp1      = qtmix(i,k+1) - qsmix(i,k+1)
+               dqxsdp      = (qxsk - qxskp1)/dp
+               lcl_pl(i)   = p(i,k+1) - qxskp1/dqxsdp ! pressure level of actual lcl
+               dsdp        = (smix(i,k)  - smix(i,k+1))/dp
+               dqtdp       = (qtmix(i,k) - qtmix(i,k+1))/dp
+               slcl        = smix(i,k+1)  + dsdp* (lcl_pl(i)-p(i,k+1))  
+               qtlcl       = qtmix(i,k+1) + dqtdp*(lcl_pl(i)-p(i,k+1))
+               tfguess     = tmix(i,k)
+               rcall = 3
+               call ientropy( rcall, slcl, lcl_pl(i), qtlcl, lcl_tl(i), qslcl, tfguess )
+            endif
+
+         end if !  k < klaunch
+
+      end do ! i = 1,ncol
+   end do ! k = pver, msg+1, -1
+   !----------------------------------------------------------------------------
+   ! end of entrainment loop
+   ! 
+   ! Could stop now and test with this as it will provide some estimate of buoyancy
+   ! without the effects of freezing/condensation taken into account for tmix.
+   !  
+   ! So we now have a profile of entropy and total water of the entraining parcel
+   ! Varying with height from the launch level klaunch parcel=environment. To the
+   ! top allowed level for the existence of convection.
+   ! 
+   ! Now we have to adjust these values such that the water held in vaopor is < or
+   ! = to qsmix. Therefore, we assume that the cloud holds a certain amount of
+   ! condensate (lwmax) and the rest is rained out (xsh2o). This, obviously 
+   ! provides latent heating to the mixed parcel and so this has to be added back
+   ! to it. But does this also increase qsmix as well? Also freezing processes
+
+   !----------------------------------------------------------------------------
+   ! precipitation/freezing loop - iterate twice for accuracy
+   xsh2o = 0._r8
+   ds_xsh2o = 0._r8
+   ds_freeze = 0._r8
+   do k = pver,msg+1,-1
+      do i = 1,ncol      
+
+         if ( k == klaunch(i) ) then
+
+            ! initialize values at launch level - assume no liquid water
+            tp(i,k)    = tmix(i,k)
+            qstp(i,k)  = q(i,k) 
+            tpv(i,k)   = (tp(i,k) + zm_parameters%tpert_fac*tpert_loc(i)) * (1._r8+1.608_r8*qstp(i,k)) / (1._r8+qstp(i,k))
+
+         elseif ( k < klaunch(i) ) then
+
+            ! iterate nit_lheat times for s,qt changes
+            do ii = 0,nit_lheat-1
+
+               ! rain (xsh2o) is excess condensate, bar lwmax (accumulated loss from qtmix)
+               xsh2o(i,k) = max (0._r8, qtmix(i,k) - qsmix(i,k) - lwmax)
+
+               ! contribution to ds from precip loss of condensate (accumulated change from smix)
+               ds_xsh2o(i,k) = ds_xsh2o(i,k+1) - zm_constants%cpliq * log (tmix(i,k)/zm_constants%tfreez) * max(0._r8,(xsh2o(i,k)-xsh2o(i,k+1)))
+
+               ! calculate entropy of freezing => ( latice x amount of water involved ) / T
+
+               ! one off freezing of condensate
+               if (tmix(i,k) <= (zm_constants%tfreez+tscool) .and. ds_freeze(i,k+1) == 0._r8) then 
+                  ! entropy change from latent heat
+                  ds_freeze(i,k) = (zm_constants%latice/tmix(i,k)) * max(0._r8,qtmix(i,k)-qsmix(i,k)-xsh2o(i,k)) 
+               end if
+            
+               if (tmix(i,k) <= zm_constants%tfreez+tscool .and. ds_freeze(i,k+1) /= 0._r8) then 
+                  ! continual freezing of additional condensate
+                  ds_freeze(i,k) = ds_freeze(i,k+1)+(zm_constants%latice/tmix(i,k)) * max(0._r8,(qsmix(i,k+1)-qsmix(i,k)))
+               end if
+            
+               ! adjust entropy and accordingly to sum of ds (be careful of signs)
+               new_s = smix(i,k) + ds_xsh2o(i,k) + ds_freeze(i,k) 
+
+               ! adjust liquid water and accordingly to xsh2o
+               new_q = qtmix(i,k) - xsh2o(i,k)
+
+               ! invert entropy to get updated Tmix and qsmix of parcel
+               tfguess = tmix(i,k)
+               rcall =4
+               call ientropy( rcall, new_s, p(i,k), new_q, tmix(i,k), qsmix(i,k), tfguess )
+               
+            end do  ! iteration loop for freezing processes
+
+            ! tp  - Parcel temp is temp of mixture
+            ! tpv - Parcel virtual temp should be density temp with new_q total water
+            tp(i,k)    = tmix(i,k)
+
+            ! tpv=tprho in the presence of condensate (i.e. when new_q > qsmix)
+            if (new_q > qsmix(i,k)) then  ! super-saturated so condensate present - reduces buoyancy
+               qstp(i,k) = qsmix(i,k)
+            else                          ! just saturated/sub-saturated - no condensate virtual effects
+               qstp(i,k) = new_q
+            end if
+
+            tpv(i,k) = (tp(i,k)+zm_parameters%tpert_fac*tpert_loc(i))* (1._r8+1.608_r8*qstp(i,k)) / (1._r8+ new_q)
+
+         end if ! k < klaunch
+      
+      end do ! i = 1,ncol
+   end do ! k = pver, msg+1, -1
+
+   !----------------------------------------------------------------------------
+   return
+
+end subroutine parcel_dilute
+
+!===================================================================================================
+
+subroutine calculate_cape_from_parcel( ncol, num_cin, &
+                                       t, tv, z, q, qstp, tp, tpv, &
+                                       pint, lcl_pl, msg, mse_max_klev, &
+                                       zm_constants, zm_parameters, &
+                                       lcl_klev, eql_klev, cape )
+   !----------------------------------------------------------------------------
+   ! Purpose: calculate convective available potential energy (CAPE)
+   !          from parcel thermodynamic properties from parcel_dilute()
+   !----------------------------------------------------------------------------
+   integer,                         intent(in   ) :: ncol            ! number of atmospheric columns
+   integer,                         intent(in   ) :: num_cin         ! num of negative buoyancy regions that are allowed before the conv. top and CAPE calc are completed
+   real(r8), dimension(pcols,pver), intent(in   ) :: t               ! temperature
+   real(r8), dimension(pcols,pver), intent(in   ) :: tv              ! virtual temperature
+   real(r8), dimension(pcols,pver), intent(in   ) :: z               ! height
+   real(r8), dimension(pcols,pver), intent(in   ) :: q               ! specific humidity
+   real(r8), dimension(pcols,pver), intent(inout) :: qstp            ! parcel saturation mixing ratio
+   real(r8), dimension(pcols,pver), intent(inout) :: tp              ! parcel temperature
+   real(r8), dimension(pcols,pver), intent(inout) :: tpv             ! parcel virtual temperature
+   real(r8), dimension(pcols,pverp),intent(in   ) :: pint            ! pressure at interfaces
+   real(r8), dimension(pcols),      intent(in   ) :: lcl_pl          ! LCL pressure
+   integer,                         intent(in   ) :: msg             ! number of missing moisture levels at the top of model
+   integer,  dimension(pcols),      intent(in   ) :: mse_max_klev    ! index of max MSE at parcel launch level
+   type(zm_constants_t),            intent(in   ) :: zm_constants    ! derived type to hold ZM constants
+   type(zm_parameters_t),           intent(in   ) :: zm_parameters   ! derived type to hold ZM tunable parameters
+   integer,  dimension(pcols),      intent(in   ) :: lcl_klev        ! base level index of deep cumulus convection
+   integer,  dimension(pcols),      intent(inout) :: eql_klev        ! index of highest convective plume
+   real(r8), dimension(pcols),      intent(inout) :: cape            ! convective available potential energy
+   !----------------------------------------------------------------------------
+   ! Local variables
+   integer  :: i, k, n                                      ! loop iterators
+   real(r8), dimension(pcols,pver)    :: buoyancy           ! parcel buoyancy
+   real(r8), dimension(pcols,num_cin) :: cape_tmp           ! provisional value of cape
+   integer,  dimension(pcols,num_cin) :: eql_klev_tmp       ! provisional value of index of highest convective plume
+   integer,  dimension(pcols)         :: neg_buoyancy_cnt   ! counter for levels with negative bounancy
+   !----------------------------------------------------------------------------
+   ! Initialize variables
+   eql_klev        (1:ncol)           = pver
+   eql_klev_tmp    (1:ncol,1:num_cin) = pver
+   cape            (1:ncol)           = 0._r8
+   cape_tmp        (1:ncol,1:num_cin) = 0._r8
+   buoyancy        (1:ncol,1:pver)    = 0._r8
+   neg_buoyancy_cnt(1:ncol)           = 0
+   !----------------------------------------------------------------------------
+   ! Calculate buoyancy
+   do k = pver,msg + 1,-1
+      do i=1,ncol
+         ! Define buoyancy from launch level to cloud top
+         if ( k <= mse_max_klev(i) .and. lcl_pl(i).ge.lcl_pressure_threshold ) then
+            buoyancy(i,k) = tpv(i,k) - tv(i,k) + zm_parameters%tiedke_add
+         else
+            qstp(i,k) = q(i,k)
+            tp(i,k)   = t(i,k)            
+            tpv(i,k)  = tv(i,k)
+         endif
+      end do
+   end do
+
+   !----------------------------------------------------------------------------
+   ! find convective equilibrium level accounting for negative buoyancy levels
+   do k = msg+2,pver
+      do i = 1,ncol
+         if ( k < lcl_klev(i) .and. lcl_pl(i).ge.lcl_pressure_threshold ) then
+            if ( buoyancy(i,k+1) > 0._r8 .and. &
+                 buoyancy(i,k)   <=0._r8 ) then
+               neg_buoyancy_cnt(i) = min(num_cin,neg_buoyancy_cnt(i) + 1)
+               eql_klev_tmp(i,neg_buoyancy_cnt(i)) = k
+            end if
+         end if
+      end do
+   end do
+
+   !----------------------------------------------------------------------------
+   ! calculate CAPE
+   do n = 1,num_cin
+      do k = msg + 1,pver
+         do i = 1,ncol
+            if ( lcl_pl(i).ge.lcl_pressure_threshold .and. &
+                 k <= mse_max_klev(i) .and. &
+                 k > eql_klev_tmp(i,n)) then
+               cape_tmp(i,n) = cape_tmp(i,n) + zm_constants%rdair*buoyancy(i,k)*log(pint(i,k+1)/pint(i,k))
+            end if
+         end do
+      end do
+   end do
+
+   !----------------------------------------------------------------------------
+   ! find maximum cape from all possible tentative capes from one sounding,
+   ! and use it as the final cape (April 26, 1995)
+   do n = 1,num_cin
+      do i = 1,ncol
+         if (cape_tmp(i,n) > cape(i)) then
+            cape(i) = cape_tmp(i,n)
+            eql_klev(i) = eql_klev_tmp(i,n)
+         end if
+      end do
+   end do
+
+   !----------------------------------------------------------------------------
+   ! put lower bound on cape for diagnostic purposes.
+   do i = 1,ncol
+      cape(i) = max(cape(i), 0._r8)
+   end do
+   
+   !----------------------------------------------------------------------------
+   return
+
+end subroutine calculate_cape_from_parcel
+
+!===================================================================================================
+
+end module zm_conv_parcel

--- a/components/eam/src/physics/cam/zm_conv_types.F90
+++ b/components/eam/src/physics/cam/zm_conv_types.F90
@@ -1,0 +1,127 @@
+module zm_conv_types
+   !----------------------------------------------------------------------------
+   ! Purpose: utility methods for ZM deep convection scheme
+   !----------------------------------------------------------------------------
+   use shr_kind_mod,     only: r8=>shr_kind_r8
+
+   public :: zm_const_set_to_global    ! set zm_const using global values from physconst/shr_const_mod
+   public :: zm_const_set_for_testing  ! set zm_const consistent with shr_const_mod for testing
+   public :: zm_param_mpi_broadcast    ! broadcast parameter values to all MPI ranks
+   
+   ! ZM derived types
+   public :: zm_const_t  ! derived type to hold ZM constants
+   public :: zm_param_t ! derived type to hold ZM tunable parameters
+
+   ! invalid values for parameter initialization
+   real(r8), parameter :: unset_r8   = huge(1.0_r8)
+   integer , parameter :: unset_int  = huge(1)
+
+!===================================================================================================
+
+type :: zm_const_t
+   real(r8) :: grav    ! gravitational acceleration      [m/s2]
+   real(r8) :: boltz   ! Boltzmann's constant            [J/K/molecule]
+   real(r8) :: avogad  ! Avogadro's number               [molecules/kmole]
+   real(r8) :: rgas    ! Universal gas constant          [J/K/kmole]
+   real(r8) :: mwdair  ! molecular weight dry air        [kg/kmole]
+   real(r8) :: mwwv    ! molecular weight water vapor    [kg/kmole]
+   real(r8) :: rdair   ! gas constant for dry air        [J/K/kg]
+   real(r8) :: rh2o    ! gas constant for water vapor    [J/K/kg]
+   real(r8) :: zvir    ! virtual temperature parameter   []
+   real(r8) :: cpair   ! specific heat of dry air        [J/K/kg]
+   real(r8) :: cpwv    ! specific heat of water vapor    [J/K/kg]
+   real(r8) :: cpliq   ! specific heat of liquid water   [J/K/kg]
+   real(r8) :: tfreez  ! freezing point of water         [K]
+   real(r8) :: latvap  ! latent heat of vaporization     [J/kg]
+   real(r8) :: latice  ! latent heat of fusion           [J/kg]
+   real(r8) :: epsilo  ! ratio of h2o to dry air molecular weights
+end type zm_const_t
+
+!===================================================================================================
+
+type :: zm_param_t
+   logical  :: trig_dcape      = .false.     ! true if to using DCAPE trigger - based on CAPE generation by the dycor
+   logical  :: trig_ull        = .false.     ! true if to using the "unrestricted launch level" (ULL) mode
+   integer  :: num_cin         = 0           ! num of neg buoyancy regions allowed before the conv top and CAPE calc are completed
+   integer  :: limcnv          = 0           ! upper pressure interface level to limit deep convection
+   logical  :: tpert_fix       = .false.     ! flag to disable using applying tpert to PBL-rooted convection
+   real(r8) :: tpert_fac       = 0           ! tunable temperature perturbation factor
+   real(r8) :: dmpdz           = unset_r8    ! fractional mass entrainment rate [1/m]
+   real(r8) :: tiedke_add      = unset_r8    ! tunable temperature perturbation
+   integer  :: mx_bot_lyr_adj  = unset_int   ! bot layer index adjustment for launch level search
+end type zm_param_t
+
+!===================================================================================================
+contains
+!===================================================================================================
+
+subroutine zm_const_set_to_global(zm_const)
+   !----------------------------------------------------------------------------
+   ! Purpose: set zm_const using global values from physconst/shr_const_mod
+   !----------------------------------------------------------------------------
+   use physconst, only: gravit,rair,cpair,cpwv,cpliq,rh2o,tmelt,latvap,latice,epsilo
+   !----------------------------------------------------------------------------
+   type(zm_const_t), intent(inout) :: zm_const
+   !----------------------------------------------------------------------------
+   zm_const%grav          = gravit
+   zm_const%rdair         = rair
+   zm_const%cpair         = cpair
+   zm_const%cpwv          = cpwv
+   zm_const%cpliq         = cpliq
+   zm_const%rh2o          = rh2o
+   zm_const%tfreez        = tmelt
+   zm_const%latvap        = latvap
+   zm_const%latice        = latice
+   zm_const%epsilo        = epsilo
+end subroutine zm_const_set_to_global
+
+!===================================================================================================
+
+subroutine zm_const_set_for_testing(zm_const)
+   !----------------------------------------------------------------------------
+   ! Purpose: set zm_const consistent with shr_const_mod for testing
+   ! Note - normal model operation should use zm_const_set_to_global()
+   !----------------------------------------------------------------------------
+   type(zm_const_t), intent(inout) :: zm_const
+   !----------------------------------------------------------------------------
+   zm_const%grav     = 9.80616_r8
+   zm_const%boltz    = 1.38065e-23_r8
+   zm_const%avogad   = 6.02214e26_r8
+   zm_const%rgas     = zm_const%avogad*zm_const%boltz
+   zm_const%mwdair   = 28.966_r8
+   zm_const%mwwv     = 18.016_r8
+   zm_const%rdair    = zm_const%rgas/zm_const%mwdair
+   zm_const%rh2o     = zm_const%rgas/zm_const%mwwv
+   zm_const%zvir     = zm_const%rh2o/zm_const%rdair - 1.0_r8
+   zm_const%cpair    = 1.00464e3_r8
+   zm_const%cpwv     = 1.810e3_r8
+   zm_const%cpliq    = 4.188e3_r8
+   zm_const%tfreez   = 273.15_r8
+   zm_const%latvap   = 2.501e6_r8
+   zm_const%latice   = 3.337e5_r8
+   zm_const%epsilo   = zm_const%mwwv/zm_const%mwdair
+end subroutine zm_const_set_for_testing
+
+!===================================================================================================
+
+subroutine zm_param_mpi_broadcast(zm_param)
+   !----------------------------------------------------------------------------
+   ! Purpose: broadcast parameter values to all MPI ranks
+   !----------------------------------------------------------------------------
+   use mpishorthand
+   !----------------------------------------------------------------------------
+   type(zm_param_t), intent(inout) :: zm_param
+   !----------------------------------------------------------------------------
+   call mpibcast(zm_param%trig_dcape,        1, mpilog, 0, mpicom)
+   call mpibcast(zm_param%trig_ull,          1, mpilog, 0, mpicom)
+   call mpibcast(zm_param%tiedke_add,        1, mpir8,  0, mpicom)
+   call mpibcast(zm_param%dmpdz,             1, mpir8,  0, mpicom)
+   call mpibcast(zm_param%num_cin,           1, mpiint, 0, mpicom)
+   call mpibcast(zm_param%mx_bot_lyr_adj,    1, mpiint, 0, mpicom)
+   call mpibcast(zm_param%tpert_fix,         1, mpilog, 0, mpicom)
+   call mpibcast(zm_param%tpert_fac,         1, mpir8,  0, mpicom)
+end subroutine zm_param_mpi_broadcast
+
+!===================================================================================================
+
+end module zm_conv_types

--- a/components/eam/src/physics/cam/zm_conv_types.F90
+++ b/components/eam/src/physics/cam/zm_conv_types.F90
@@ -9,12 +9,12 @@ module zm_conv_types
    public :: zm_param_mpi_broadcast    ! broadcast parameter values to all MPI ranks
    
    ! ZM derived types
-   public :: zm_const_t  ! derived type to hold ZM constants
+   public :: zm_const_t ! derived type to hold ZM constants
    public :: zm_param_t ! derived type to hold ZM tunable parameters
 
    ! invalid values for parameter initialization
-   real(r8), parameter :: unset_r8   = huge(1.0_r8)
-   integer , parameter :: unset_int  = huge(1)
+   real(r8), parameter :: unset_r8  = huge(1.0_r8)
+   integer , parameter :: unset_int = huge(1)
 
 !===================================================================================================
 
@@ -63,16 +63,16 @@ subroutine zm_const_set_to_global(zm_const)
    !----------------------------------------------------------------------------
    type(zm_const_t), intent(inout) :: zm_const
    !----------------------------------------------------------------------------
-   zm_const%grav          = gravit
-   zm_const%rdair         = rair
-   zm_const%cpair         = cpair
-   zm_const%cpwv          = cpwv
-   zm_const%cpliq         = cpliq
-   zm_const%rh2o          = rh2o
-   zm_const%tfreez        = tmelt
-   zm_const%latvap        = latvap
-   zm_const%latice        = latice
-   zm_const%epsilo        = epsilo
+   zm_const%grav     = gravit
+   zm_const%rdair    = rair
+   zm_const%cpair    = cpair
+   zm_const%cpwv     = cpwv
+   zm_const%cpliq    = cpliq
+   zm_const%rh2o     = rh2o
+   zm_const%tfreez   = tmelt
+   zm_const%latvap   = latvap
+   zm_const%latice   = latice
+   zm_const%epsilo   = epsilo
 end subroutine zm_const_set_to_global
 
 !===================================================================================================

--- a/components/eam/src/physics/cam/zm_conv_types.F90
+++ b/components/eam/src/physics/cam/zm_conv_types.F90
@@ -73,6 +73,7 @@ subroutine zm_const_set_to_global(zm_const)
    zm_const%latvap   = latvap
    zm_const%latice   = latice
    zm_const%epsilo   = epsilo
+   zm_const%zvir     = 1.608_r8 ! use this instead of physconst value to avoid non-BFB diffs
 end subroutine zm_const_set_to_global
 
 !===================================================================================================


### PR DESCRIPTION
This phase of the ZM cleanup was oriented around moving the `buoyan_dilute()` and `parcel_dilute()` subroutines out of the `zm_conv` module and into a new `zm_conv_cape` module. The primary routine was renamed to `compute_dilute_cape` and various portions of code were broken into private subroutines to improve modularity. I also extensively renamed variables throughout the `zm_conv_cape` module for better readability and grep-ability.

As part of the interface cleanup for this I decided that creating derived types fo hold ZM constants and namelist parameters would bee beneficial. I created the `zm_conv_types` module to contain the definition of derived types `zm_const_t` and `zm_param_t` in addition to some subroutines for initialization andMPI broadcasting. 

[non-BFB] only for GNU on pm-cpu