### PR TITLE
EAMxx: Fixes variable name for num constituents to be consistent

### DIFF
--- a/components/eamxx/CMakeLists.txt
+++ b/components/eamxx/CMakeLists.txt
@@ -205,12 +205,7 @@ set(NetCDF_Fortran_PATH ${DEFAULT_NetCDF_Fortran_PATH} CACHE FILEPATH "Path to n
 set(NetCDF_C_PATH ${DEFAULT_NetCDF_C_PATH} CACHE FILEPATH "Path to netcdf C installation")
 set(SCREAM_MACHINE ${DEFAULT_SCREAM_MACHINE} CACHE STRING "The CIME/SCREAM name for the current machine")
 option(SCREAM_MPI_ON_DEVICE "Whether to use device pointers for MPI calls" ON)
-
-if (Kokkos_ENABLE_SYCL)
-  option(SCREAM_ENABLE_MAM "Whether to enable MAM aerosol support" OFF)
-else()
-  option(SCREAM_ENABLE_MAM "Whether to enable MAM aerosol support" ON)
-endif()
+option(SCREAM_ENABLE_MAM "Whether to enable MAM aerosol support" ON)
 
 set(SCREAM_SMALL_KERNELS ${DEFAULT_SMALL_KERNELS} CACHE STRING "Use small, non-monolothic kokkos kernels for ALL components that support them")
 set(SCREAM_P3_SMALL_KERNELS ${SCREAM_SMALL_KERNELS} CACHE STRING "Use small, non-monolothic kokkos kernels for P3 only")

--- a/components/eamxx/CMakeLists.txt
+++ b/components/eamxx/CMakeLists.txt
@@ -205,7 +205,12 @@ set(NetCDF_Fortran_PATH ${DEFAULT_NetCDF_Fortran_PATH} CACHE FILEPATH "Path to n
 set(NetCDF_C_PATH ${DEFAULT_NetCDF_C_PATH} CACHE FILEPATH "Path to netcdf C installation")
 set(SCREAM_MACHINE ${DEFAULT_SCREAM_MACHINE} CACHE STRING "The CIME/SCREAM name for the current machine")
 option(SCREAM_MPI_ON_DEVICE "Whether to use device pointers for MPI calls" ON)
-option(SCREAM_ENABLE_MAM "Whether to enable MAM aerosol support" ON)
+
+if (Kokkos_ENABLE_SYCL)
+  option(SCREAM_ENABLE_MAM "Whether to enable MAM aerosol support" OFF)
+else()
+  option(SCREAM_ENABLE_MAM "Whether to enable MAM aerosol support" ON)
+endif()
 
 set(SCREAM_SMALL_KERNELS ${DEFAULT_SMALL_KERNELS} CACHE STRING "Use small, non-monolothic kokkos kernels for ALL components that support them")
 set(SCREAM_P3_SMALL_KERNELS ${SCREAM_SMALL_KERNELS} CACHE STRING "Use small, non-monolothic kokkos kernels for P3 only")

--- a/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
@@ -50,7 +50,7 @@ void MAMDryDep::set_grids(
   // layout for 2D (ncol, pcnst)
   constexpr int pcnst = mam4::aero_model::pcnst;
   const FieldLayout vector2d_pcnst =
-      grid_->get_2d_vector_layout(pcnst, "num_phys_constants");
+      grid_->get_2d_vector_layout(pcnst, "num_phys_constituents");
   const FieldLayout vector2d_class =
       grid_->get_2d_vector_layout(n_land_type, "class");
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
@@ -50,7 +50,7 @@ void MAMWetscav::set_grids(
 
   // layout for 2D (ncol, pcnst)
   FieldLayout scalar2d_pconst =
-      grid_->get_2d_vector_layout(pcnst, "num_phys_constants");
+      grid_->get_2d_vector_layout(pcnst, "num_phys_constituents");
 
   // --------------------------------------------------------------------------
   // These variables are "required" or pure inputs for the process

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
@@ -49,7 +49,7 @@ void MAMWetscav::set_grids(
       true, nmodes, mam_coupling::num_modes_tag_name());
 
   // layout for 2D (ncol, pcnst)
-  FieldLayout scalar2d_pconst =
+  FieldLayout scalar2d_pcnst =
       grid_->get_2d_vector_layout(pcnst, "num_phys_constituents");
 
   // --------------------------------------------------------------------------
@@ -152,10 +152,10 @@ void MAMWetscav::set_grids(
   add_field<Computed>("fracis", scalar3d_mid, nondim, grid_name);
 
   // Aerosol wet deposition (interstitial) [kg/m2/s]
-  add_field<Computed>("aerdepwetis", scalar2d_pconst, kg / m2 / s, grid_name);
+  add_field<Computed>("aerdepwetis", scalar2d_pcnst, kg / m2 / s, grid_name);
 
   // Aerosol wet deposition (cloud water) [kg/m2/s]
-  add_field<Computed>("aerdepwetcw", scalar2d_pconst, kg / m2 / s, grid_name);
+  add_field<Computed>("aerdepwetcw", scalar2d_pcnst, kg / m2 / s, grid_name);
 }
 
 // ================================================================


### PR DESCRIPTION
@TaufiqHassan found a dimension name mismatch. Renaming `num_phys_constants` to `num_phys_constituents`

It may not be BFB if variables with the old dimensions are an output. 