### PR TITLE
Update Aurora config

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -1461,21 +1461,6 @@
         </rootpe>
       </pes>
     </mach>
-    <mach name="sunspot|aurora">
-      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+SGLC_SWAV_SIAC_SESP_BGC.*" pesize="any">
-        <comment>sunspot|aurora: --compset BGC* --res ne30pg2_r05_IcoswISC30E3r5 on 2 nodes pure-MPI</comment>
-        <ntasks>
-          <ntasks_atm>-2</ntasks_atm>
-          <ntasks_lnd>-2</ntasks_lnd>
-          <ntasks_rof>-2</ntasks_rof>
-          <ntasks_ice>-2</ntasks_ice>
-          <ntasks_ocn>-2</ntasks_ocn>
-          <ntasks_cpl>-2</ntasks_cpl>
-          <ntasks_glc>-2</ntasks_glc>
-          <ntasks_wav>-2</ntasks_wav>
-        </ntasks>
-      </pes>
-    </mach>
   </grid>
   <grid name="a%ne30np4.pg2_l%r05_oi%IcosXISC30E3r7_r%r05_.+">
     <mach name="chrysalis">

--- a/cime_config/machines/Depends.oneapi-ifx.cmake
+++ b/cime_config/machines/Depends.oneapi-ifx.cmake
@@ -1,5 +1,0 @@
-
-# compile mpas_seaice_core_interface.f90 with ifort, not ifx
-if (NOT MPILIB STREQUAL "openmpi")
-  e3sm_add_flags("${CMAKE_BINARY_DIR}/core_seaice/model_forward/mpas_seaice_core_interface.f90" "-fc=ifort")
-endif()

--- a/cime_config/machines/Depends.oneapi-ifxgpu.cmake
+++ b/cime_config/machines/Depends.oneapi-ifxgpu.cmake
@@ -1,5 +1,0 @@
-
-# compile mpas_seaice_core_interface.f90 with ifort, not ifx
-if (NOT MPILIB STREQUAL "openmpi")
-  e3sm_add_flags("${CMAKE_BINARY_DIR}/core_seaice/model_forward/mpas_seaice_core_interface.f90" "-fc=ifort")
-endif()

--- a/cime_config/machines/cmake_macros/oneapi-ifxgpu.cmake
+++ b/cime_config/machines/cmake_macros/oneapi-ifxgpu.cmake
@@ -13,7 +13,7 @@ string(APPEND CMAKE_CXX_FLAGS_RELEASE " -fp-model precise -O2 -g -gline-tables-o
 string(APPEND CMAKE_Fortran_FLAGS_DEBUG   " -O0 -g -fpscomp logicals")
 string(APPEND CMAKE_C_FLAGS_DEBUG   " -O0 -g")
 string(APPEND CMAKE_CXX_FLAGS_DEBUG " -O0 -g")
-string(APPEND CMAKE_C_FLAGS   " -fp-model precise -std=gnu99")
+string(APPEND CMAKE_C_FLAGS   " -fp-model precise")
 string(APPEND CMAKE_CXX_FLAGS " -fp-model precise")
 string(APPEND CMAKE_Fortran_FLAGS   " -fpscomp logicals -traceback -convert big_endian -assume byterecl -assume realloc_lhs -fp-model precise")
 string(APPEND CPPDEFS " -DFORTRANUNDERSCORE -DNO_R16 -DCPRINTEL -DHAVE_SLASHPROC -DHIDE_MPI")

--- a/cime_config/machines/cmake_macros/oneapi-ifxgpu_aurora.cmake
+++ b/cime_config/machines/cmake_macros/oneapi-ifxgpu_aurora.cmake
@@ -7,7 +7,6 @@ endif()
 string(APPEND KOKKOS_OPTIONS " -DCMAKE_CXX_STANDARD=17 -DKokkos_ENABLE_SERIAL=On -DKokkos_ARCH_INTEL_PVC=On -DKokkos_ENABLE_SYCL=On -DKokkos_ENABLE_EXPLICIT_INSTANTIATION=Off")
 string(APPEND SYCL_FLAGS " -\-intel -fsycl -fsycl-targets=spir64_gen -mlong-double-64 -Xsycl-target-backend \"-device 12.60.7\"")
 string(APPEND OMEGA_SYCL_EXE_LINKER_FLAGS " -Xsycl-target-backend \"-device 12.60.7\" ")
-string(APPEND CMAKE_CXX_FLAGS " -Xclang -fsycl-allow-virtual-functions")
 
 # Let's start with the best case: using device buffers in MPI calls by default.
 # This is paired with MPIR_CVAR_ENABLE_GPU=1 in config_machines.xml. If this

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -3436,7 +3436,7 @@
     <BATCH_SYSTEM>pbspro</BATCH_SYSTEM>
     <SUPPORTED_BY>e3sm</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>102</MAX_TASKS_PER_NODE>
-    <MAX_TASKS_PER_NODE compiler="oneapi-ifxgpu">12</MAX_TASKS_PER_NODE>
+    <MAX_TASKS_PER_NODE compiler="oneapi-ifxgpu">96</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>102</MAX_MPITASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE compiler="oneapi-ifxgpu">12</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
@@ -3483,9 +3483,6 @@
         <env name="FI_CXI_DEFAULT_CQ_SIZE">131072</env>
         <env name="FI_CXI_CQ_FILL_PERCENT">20</env>
      </environment_variables>
-     <environment_variables DEBUG="TRUE">
-        <env name="HYDRA_TOPO_DEBUG">1</env>
-     </environment_variables>
      <environment_variables compiler="oneapi-ifxgpu">
         <env name="ONEAPI_DEVICE_SELECTOR">level_zero:gpu</env>
 	<env name="MPIR_CVAR_CH4_COLL_SELECTION_TUNING_JSON_FILE"></env>
@@ -3523,7 +3520,7 @@
         <env name="RANKS_BIND">core</env>
     </environment_variables>
     <environment_variables BUILD_THREADED="TRUE" compiler="!gnu">
-        <env name="KMP_AFFINITY">verbose,granularity=core,balanced</env>
+        <env name="KMP_AFFINITY">granularity=core,balanced</env>
         <env name="OMP_STACKSIZE">128M</env>
     </environment_variables>
     <environment_variables BUILD_THREADED="TRUE" compiler="gnu">

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -3419,7 +3419,7 @@
     <DESC>ALCF Aurora, 10624 nodes, 2x52c SPR, 6x2s PVC, 2x512GB DDR5, 2x64GB CPU-HBM, 6x128GB GPU-HBM, Slingshot 11, PBSPro</DESC>
     <NODENAME_REGEX>aurora-uan-.*</NODENAME_REGEX>
     <OS>LINUX</OS>
-    <COMPILERS>oneapi-ifxgpu,oneapi-ifx,gnu</COMPILERS>
+    <COMPILERS>oneapi-ifxgpu,oneapi-ifx</COMPILERS>
     <MPILIBS>mpich</MPILIBS>
     <PROJECT>E3SM_Dec</PROJECT>
     <SAVE_TIMING_DIR>/lus/flare/projects/E3SM_Dec/performance_archive</SAVE_TIMING_DIR>
@@ -3459,17 +3459,8 @@
        <cmd_path lang="csh">module</cmd_path>
        <cmd_path lang="python">/usr/share/lmod/lmod/libexec/lmod python</cmd_path>
        <modules>
-          <command name="load">cmake</command>
-        </modules>
-        <modules compiler="!gnu">
+          <command name="load">cmake/3.27.9</command>
           <command name="load">oneapi/eng-compiler/2024.07.30.002; source /lus/flare/projects/catalyst/world_shared/mpich/setup.sh</command>
-        </modules>
-	<!--<modules compiler="oneapi-ifxgpu"> -->
-	<!--          <command name="load">kokkos/4.4.01-omp-sycl</command> -->
-        <!--</modules> -->
-        <modules compiler="gnu">
-           <command name="unload">spack-pe-gcc cmake</command>
-           <command name="load">gcc/10.3.0</command>
         </modules>
      </module_system>
      <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
@@ -3505,7 +3496,6 @@
         <env name="GATOR_DISABLE">0</env>
         <env name="GPU_TILE_COMPACT">/lus/flare/projects/E3SM_Dec/tools/mpi_wrapper_utils/gpu_tile_compact.sh</env>
         <env name="RANKS_BIND">list:1-8:9-16:17-24:25-32:33-40:41-48:53-60:61-68:69-76:77-84:85-92:93-100</env>
-	<!--<env name="Kokkos_ROOT">$ENV{KOKKOS_ROOT}</env>-->
         <env name="ZES_ENABLE_SYSMAN">1</env>
 	<!-- default is ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE: enable this to run 4 MPI/tile or 48 MPI/node
 	<env name="ZEX_NUMBER_OF_CCS">0:4,1:4,2:4,3:4:4:4,5:4</env>-->
@@ -3519,12 +3509,8 @@
         <env name="GPU_TILE_COMPACT"> </env>
         <env name="RANKS_BIND">core</env>
     </environment_variables>
-    <environment_variables BUILD_THREADED="TRUE" compiler="!gnu">
+    <environment_variables BUILD_THREADED="TRUE">
         <env name="KMP_AFFINITY">granularity=core,balanced</env>
-        <env name="OMP_STACKSIZE">128M</env>
-    </environment_variables>
-    <environment_variables BUILD_THREADED="TRUE" compiler="gnu">
-        <env name="OMP_PLACES">cores</env>
         <env name="OMP_STACKSIZE">128M</env>
     </environment_variables>
     <resource_limits>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -3495,7 +3495,7 @@
         <env name="GATOR_INITIAL_MB">4000MB</env>
         <env name="GATOR_DISABLE">0</env>
         <env name="GPU_TILE_COMPACT">/lus/flare/projects/E3SM_Dec/tools/mpi_wrapper_utils/gpu_tile_compact.sh</env>
-        <env name="RANKS_BIND">list:1-8:9-16:17-24:25-32:33-40:41-48:53-60:61-68:69-76:77-84:85-92:93-100</env>
+        <env name="RANKS_BIND">list:1-8:9-16:17-24:25-32:33-40:41-48:53-60:61-68:69-76:77-84:85-92:93-100 --gpu-bind list:0.0:0.1:1.0:1.1:2.0:2.1:3.0:3.1:4.0:4.1:5.0:5.1 --mem-bind list:0:0:0:0:0:0:1:1:1:1:1:1</env>
         <env name="ZES_ENABLE_SYSMAN">1</env>
 	<!-- default is ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE: enable this to run 4 MPI/tile or 48 MPI/node
 	<env name="ZEX_NUMBER_OF_CCS">0:4,1:4,2:4,3:4:4:4,5:4</env>-->

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -3435,9 +3435,9 @@
     <NTEST_PARALLEL_JOBS>4</NTEST_PARALLEL_JOBS>
     <BATCH_SYSTEM>pbspro</BATCH_SYSTEM>
     <SUPPORTED_BY>e3sm</SUPPORTED_BY>
-    <MAX_TASKS_PER_NODE>104</MAX_TASKS_PER_NODE>
+    <MAX_TASKS_PER_NODE>102</MAX_TASKS_PER_NODE>
     <MAX_TASKS_PER_NODE compiler="oneapi-ifxgpu">12</MAX_TASKS_PER_NODE>
-    <MAX_MPITASKS_PER_NODE>104</MAX_MPITASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>102</MAX_MPITASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE compiler="oneapi-ifxgpu">12</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
@@ -3462,7 +3462,7 @@
           <command name="load">cmake</command>
         </modules>
         <modules compiler="!gnu">
-          <command name="load">oneapi/eng-compiler/2024.07.30.002</command>
+          <command name="load">oneapi/eng-compiler/2024.07.30.002; source /lus/flare/projects/catalyst/world_shared/mpich/setup.sh</command>
         </modules>
 	<!--<modules compiler="oneapi-ifxgpu"> -->
 	<!--          <command name="load">kokkos/4.4.01-omp-sycl</command> -->

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -3459,8 +3459,8 @@
        <cmd_path lang="csh">module</cmd_path>
        <cmd_path lang="python">/usr/share/lmod/lmod/libexec/lmod python</cmd_path>
        <modules>
-          <command name="load">cmake/3.27.9</command>
-          <command name="load">oneapi/eng-compiler/2024.07.30.002; source /lus/flare/projects/catalyst/world_shared/mpich/setup.sh</command>
+          <command name="load">cmake/3.30.5</command>
+          <command name="load">oneapi/release/2025.0.5</command>
         </modules>
      </module_system>
      <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>

--- a/components/eamxx/cmake/machine-files/aurora.cmake
+++ b/components/eamxx/cmake/machine-files/aurora.cmake
@@ -9,7 +9,7 @@ set(EKAT_MPI_EXTRA_ARGS "--label --cpu-bind depth -envall" CACHE STRING "")
 set(EKAT_MPI_THREAD_FLAG "-d" CACHE STRING "")
 
 SET(SYCL_COMPILE_FLAGS "-std=c++17 -fsycl -fsycl-device-code-split=per_kernel -fno-sycl-id-queries-fit-in-int -fsycl-unnamed-lambda")
-SET(SYCL_LINK_FLAGS "-fsycl -fsycl-link-huge-device-code -fsycl-device-code-split=per_kernel  -fsycl-targets=spir64_gen -Xsycl-target-backend \"-device 12.60.7\"")
+SET(SYCL_LINK_FLAGS "-fsycl -fsycl-device-code-split=per_kernel -fsycl-targets=spir64_gen -Xsycl-target-backend \"-device 12.60.7\"")
 
-set(CMAKE_CXX_FLAGS " -\-intel -Xclang -fsycl-allow-virtual-functions -mlong-double-64 ${SYCL_COMPILE_FLAGS}" CACHE STRING "" FORCE)
-set(CMAKE_EXE_LINKER_FLAGS " -lifcore -\-intel -Xclang -fsycl-allow-virtual-functions -lsycl -mlong-double-64 ${SYCL_LINK_FLAGS} -fortlib" CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS " -\-intel -mlong-double-64 ${SYCL_COMPILE_FLAGS}" CACHE STRING "" FORCE)
+set(CMAKE_EXE_LINKER_FLAGS " -lifcore -\-intel -lsycl -mlong-double-64 ${SYCL_LINK_FLAGS} -fortlib" CACHE STRING "" FORCE)

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/lulcc_sville/shell_commands
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/lulcc_sville/shell_commands
@@ -1,4 +1,3 @@
 ./xmlchange ELM_BLDNML_OPTS="-irrig .true." -append
 if [ `./xmlquery --value MACH` == chrysalis ]; then ./xmlchange FORCE_BUILD_SMP=TRUE; fi
-./xmlchange JOB_WALLCLOCK_TIME=2:00:00
 ./xmlchange DATM_CLMNCEP_YR_END=1902

--- a/components/elm/src/main/initGridCellsMod.F90
+++ b/components/elm/src/main/initGridCellsMod.F90
@@ -237,7 +237,9 @@ contains
        ! By putting this check within the loop over clumps, we ensure that (for example)
        ! if a clump is responsible for landunit L, then that same clump is also
        ! responsible for all columns and pfts in L.
+       !$OMP CRITICAL
        call elm_ptrs_check(bounds_clump)
+       !$OMP END CRITICAL
 
        ! Set veg_pp%wtlunit, veg_pp%wtgcell and col_pp%wtgcell
        call compute_higher_order_weights(bounds_clump)


### PR DESCRIPTION
Update Aurora config:
- remove duplicate BGC-PEs
- avoid system-reserved cores in CPU runs
- remove explicit wall-time in ELM test-mod
- remove -std=gnu99 from icx flags in threaded builds
- allow up to 8 threads/task on GPUs
- cleanup unused gnu compiler
- add explicit gpu- and mem-bind
- fix fortran writes during LND-init in threaded runs
- update modules after maint on 2025-04-29
- remove an ifort build, which now works with ifx

[BFB]