### PR TITLE
fix stream full_file mode

### DIFF
--- a/components/elm/src/biogeochem/FireDataBaseType.F90
+++ b/components/elm/src/biogeochem/FireDataBaseType.F90
@@ -376,6 +376,7 @@ module FireDataBaseType
    
       call elm_domain_mct (bounds, dom_elm)
    
+      write(iulog,*) " SHR STRDATA CREATE!!"
       call shr_strdata_create(this%sdat_lnfm,name="clmlnfm", &
            pio_subsystem=pio_subsystem,                      &
            pio_iotype=shr_pio_getiotype(inst_name),          &
@@ -401,7 +402,8 @@ module FireDataBaseType
            tintalgo=lightng_tintalgo,                        &
            mapalgo=lightngmapalgo,                           &
            calendar=get_calendar(),                          &
-           taxmode='cycle'                            )
+           taxmode='cycle' , &
+           readmode='full_file')
    
       if (masterproc) then
          call shr_strdata_print(this%sdat_lnfm,'Lightning data')

--- a/components/elm/src/biogeochem/FireMod.F90
+++ b/components/elm/src/biogeochem/FireMod.F90
@@ -1732,7 +1732,8 @@ subroutine lnfm_init( bounds )
         fillalgo='none',                              &
         mapalgo=lightngmapalgo,                       &
         calendar=get_calendar(),                      &
-        taxmode='cycle'                            )
+        taxmode='cycle' , &
+        readmode='full_file')
 
    if (masterproc) then
       call shr_strdata_print(sdat_lnfm,'Lightning data')

--- a/share/streams/shr_strdata_mod.F90
+++ b/share/streams/shr_strdata_mod.F90
@@ -1717,7 +1717,7 @@ contains
     type(shr_strdata_type)  ,intent(in) :: SDAT  ! strdata data data-type
     character(len=*),optional,intent(in) :: name  ! just a name for tracking
 
-    integer(IN)   :: n
+    integer(IN)   :: n, fn
     character(CL) :: lname
 
     !----- formats -----
@@ -1762,6 +1762,13 @@ contains
 
     do n=1, SDAT%nstreams
        write(logunit,F04) "  streams (",n,") = ",trim(SDAT%streams(n))
+       write(logunit,*) "  num files for stream (",n,") = ",SDAT%stream(n)%nfiles
+
+       do fn=1,SDAT%stream(n)%nfiles
+         write(logunit,*) "  file: (",fn,") = ",trim(SDAT%stream(n)%file(fn)%name)
+         write(logunit,*) "  time slices: (",fn,") = ",SDAT%stream(n)%file(fn)%nt
+         write(logunit,*) " readin time slices: (",fn,") = ",SDAT%stream(n)%file(fn)%haveData
+       end do
        write(logunit,F04) "  taxMode (",n,") = ",trim(SDAT%taxMode(n))
        write(logunit,F07) "  dtlimit (",n,") = ",SDAT%dtlimit(n)
        write(logunit,F05) "  strnxg  (",n,") = ",SDAT%strnxg(n)


### PR DESCRIPTION
The `"full_file" `read mode for streams appears to have stopped being supported at some point.
After looking at all the stream settings, I could not figure out a way to enable `shr_dmodel_readstrm_fullfile` to work correctly, 
so I attempted to re-write the subroutine so that it essentially works like `shr_dmodel_readstrm` but with a loop over all the time steps present in the file, using `pio_setframe` to go through the time slices.

If someone knows of how to get the original function to work or a better way to implement this, I would love to use that instead.

Fixes #6742