### PR TITLE
Add default setting for abortFlag in check_tracer_conservation

### DIFF
--- a/components/mpas-seaice/src/shared/mpas_seaice_advection_incremental_remap.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_advection_incremental_remap.F
@@ -8144,6 +8144,8 @@ contains
 
     thisTracer => tracersHead
 
+    abortFlag = .false.
+
     do while (associated(thisTracer))
 
        if (thisTracer % ndims == 2) then


### PR DESCRIPTION
The abortFlag was missing a default setting in the check_tracer_conservation subroutine, which was sometimes causing a critical error since it was otherwise unset.

Fixes: #7237 

[BFB] for all tested configurations because the observed error this fixes only occurs using a non-default setting