### PR TITLE
radiative feedbacks for Sea ice BGC 

### DIFF
--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -629,11 +629,7 @@ add_default($nl, 'config_recover_tracer_means_check');
 # Namelist group: column_package #
 ##################################
 
-if ($ice_bgc eq 'ice_bgc') {
-        add_default($nl, 'config_column_physics_type', 'val'=>"column_package");
-} else {
-        add_default($nl, 'config_column_physics_type');
-}
+add_default($nl, 'config_column_physics_type');
 add_default($nl, 'config_use_column_shortwave');
 add_default($nl, 'config_use_column_vertical_thermodynamics');
 if ($ice_bgc eq 'ice_bgc') {

--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -666,7 +666,6 @@ add_default($nl, 'config_use_floe_size_distribution');
 ###################################
 
 add_default($nl, 'config_use_vertical_zsalinity');
-add_default($nl, 'config_use_shortwave_bioabsorption');
 add_default($nl, 'config_use_skeletal_biochemistry');
 if ($ice_bgc eq 'ice_bgc') {
         add_default($nl, 'config_use_vertical_biochemistry', 'val'=>".true.");
@@ -681,6 +680,8 @@ if ($ice_bgc eq 'ice_bgc') {
         add_default($nl, 'config_use_humics', 'val'=>".true.");
         add_default($nl, 'config_use_DON', 'val'=>".true.");
         add_default($nl, 'config_use_iron', 'val'=>".true.");
+	add_default($nl, 'config_use_shortwave_bioabsorption', 'val'=>".true.");
+	add_default($nl, 'config_use_zaerosols', 'val'=>".true.");
         add_default($nl, 'config_couple_biogeochemistry_fields');
 } else {
         add_default($nl, 'config_use_vertical_biochemistry', 'val'=>".false.");
@@ -695,14 +696,15 @@ if ($ice_bgc eq 'ice_bgc') {
         add_default($nl, 'config_use_humics', 'val'=>".false.");
         add_default($nl, 'config_use_DON', 'val'=>".false.");
         add_default($nl, 'config_use_iron', 'val'=>".false.");
+	add_default($nl, 'config_use_shortwave_bioabsorption');
+	add_default($nl, 'config_use_zaerosols');
         add_default($nl, 'config_couple_biogeochemistry_fields', 'val'=>".false.");
 }
+add_default($nl, 'config_use_atm_dust_file');
 add_default($nl, 'config_use_chlorophyll');
+add_default($nl, 'config_use_iron_solubility_file');
 add_default($nl, 'config_use_macromolecules');
 add_default($nl, 'config_use_modal_aerosols');
-add_default($nl, 'config_use_zaerosols');
-add_default($nl, 'config_use_atm_dust_file');
-add_default($nl, 'config_use_iron_solubility_file');
 add_default($nl, 'config_skeletal_bgc_flux_type');
 add_default($nl, 'config_scale_initial_vertical_bgc');
 add_default($nl, 'config_biogrid_bottom_molecular_sublayer');

--- a/components/mpas-seaice/src/model_forward/mpas_seaice_core.F
+++ b/components/mpas-seaice/src/model_forward/mpas_seaice_core.F
@@ -38,6 +38,9 @@ module seaice_core
       use seaice_diagnostics, only: &
            seaice_initialize_time_diagnostics
 
+      use seaice_forcing, only: &
+           use_restart_ic
+
       implicit none
 
       type (domain_type), intent(inout) :: domain
@@ -90,11 +93,15 @@ module seaice_core
       ! Regardless of which stream we read for initial conditions, reset the
       ! input alarms for both input and restart before reading any remaining input streams.
       !
+      ! tracks if restart_ic was used to properly initialize new forcing files
+      use_restart_ic = .false.
+
       if (config_do_restart) then
          call MPAS_stream_mgr_read(domain % streamManager, streamID='restart', ierr=ierr)
       else
          if (trim(config_initial_condition_type) == "restart") then
             call MPAS_stream_mgr_read(domain % streamManager, streamID='restart_ic', ierr=ierr)
+            use_restart_ic = .true.
          else
             call MPAS_stream_mgr_read(domain % streamManager, streamID='input', ierr=ierr)
          end if

--- a/components/mpas-seaice/src/shared/mpas_seaice_forcing.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_forcing.F
@@ -35,6 +35,7 @@ module seaice_forcing
        post_oceanic_coupling
 
   type (MPAS_forcing_group_type), pointer, public :: seaiceForcingGroups
+  logical, public :: use_restart_ic
 
   ! forcing parameters
   real (kind=RKIND), parameter :: &
@@ -1841,19 +1842,38 @@ contains
          forcingIntervalMonthly, &
          forcingReferenceTimeMonthly
 
+    type (MPAS_Time_Type) :: currTime
+    character(len=strKIND) :: timeStamp
+    integer :: ierr
+
     ! get forcing configuration options
     call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
 
+    currTime = mpas_get_clock_time(clock, MPAS_NOW, ierr)
+    call mpas_get_time(curr_time=currTime, dateTimeString=timeStamp, ierr=ierr)
+    timeStamp = '0000'//trim(timeStamp(5:))
+
     ! create the dust iron solubility forcing group
 
-    call MPAS_forcing_init_group(&
-         seaiceForcingGroups, &
-         "seaice_atm_bgc_forcing_monthly", &
-         domain, &
-         '0000-01-01_00:00:00', &
-         '0000-01-01_00:00:00', &
-         '0001-00-00_00:00:00', &
-         config_do_restart)
+    if (use_restart_ic) then
+       call MPAS_forcing_init_group(&
+            seaiceForcingGroups, &
+            "seaice_atm_bgc_forcing_monthly", &
+            domain, &
+            '0000-01-01_00:00:00', &
+            '0000-01-01_00:00:00', &
+            '0001-00-00_00:00:00', &
+            .false.)
+    else
+       call MPAS_forcing_init_group(&
+            seaiceForcingGroups, &
+            "seaice_atm_bgc_forcing_monthly", &
+            domain, &
+            '0000-01-01_00:00:00', & !timeStamp, &
+            '0000-01-01_00:00:00', &
+            '0001-00-00_00:00:00', &
+            config_do_restart)
+    endif
 
     forcingIntervalMonthly = "00-01-00_00:00:00"
     forcingReferenceTimeMonthly = "0001-01-15_00:00:00"
@@ -1862,12 +1882,12 @@ contains
     call MPAS_forcing_init_field(&
          domain % streamManager, &
          seaiceForcingGroups, &
-         'seaice_atm_bgc_forcing_monthly', &
-         'IRON_Zolubility_wet', &
-         'DustIronMonthlyForcing', &
-         'atmos_forcing', &
-         'IRON_Zolubility_wet', &
-         'linear', &
+         "seaice_atm_bgc_forcing_monthly", &
+         "IRON_Zolubility_wet", &
+         "DustIronMonthlyForcing", &
+         "atmos_forcing", &
+         "IRON_Zolubility_wet", &
+         "linear", &
          forcingReferenceTimeMonthly, &
          forcingIntervalMonthly)
 
@@ -1875,12 +1895,12 @@ contains
     call MPAS_forcing_init_field(&
          domain % streamManager, &
          seaiceForcingGroups, &
-         'seaice_atm_bgc_forcing_monthly', &
-         'IRON_Zolubility_dry', &
-         'DustIronMonthlyForcing', &
-         'atmos_forcing', &
-         'IRON_Zolubility_dry', &
-         'linear', &
+         "seaice_atm_bgc_forcing_monthly", &
+         "IRON_Zolubility_dry", &
+         "DustIronMonthlyForcing", &
+         "atmos_forcing", &
+         "IRON_Zolubility_dry", &
+         "linear", &
          forcingReferenceTimeMonthly, &
          forcingIntervalMonthly)
 
@@ -1888,12 +1908,12 @@ contains
     call MPAS_forcing_init_field(&
          domain % streamManager, &
          seaiceForcingGroups, &
-         'seaice_atm_bgc_forcing_monthly', &
-         'dust_FLUZ_WET', &
-         'DustIronMonthlyForcing', &
-         'atmos_forcing', &
-         'dust_FLUZ_WET', &
-         'linear', &
+         "seaice_atm_bgc_forcing_monthly", &
+         "dust_FLUZ_WET", &
+         "DustIronMonthlyForcing", &
+         "atmos_forcing", &
+         "dust_FLUZ_WET", &
+         "linear", &
          forcingReferenceTimeMonthly, &
          forcingIntervalMonthly)
 
@@ -1901,12 +1921,12 @@ contains
     call MPAS_forcing_init_field(&
          domain % streamManager, &
          seaiceForcingGroups, &
-         'seaice_atm_bgc_forcing_monthly', &
-         'dust_FLUZ_DRY', &
-         'DustIronMonthlyForcing', &
-         'atmos_forcing', &
-         'dust_FLUZ_DRY', &
-         'linear', &
+         "seaice_atm_bgc_forcing_monthly", &
+         "dust_FLUZ_DRY", &
+         "DustIronMonthlyForcing", &
+         "atmos_forcing", &
+         "dust_FLUZ_DRY", &
+         "linear", &
          forcingReferenceTimeMonthly, &
          forcingIntervalMonthly)
 
@@ -1914,18 +1934,18 @@ contains
     call MPAS_forcing_init_field(&
          domain % streamManager, &
          seaiceForcingGroups, &
-         'seaice_atm_bgc_forcing_monthly', &
-         'IRON_in_duzt_fraction', &
-         'DustIronMonthlyForcing', &
-         'atmos_forcing', &
-         'IRON_in_duzt_fraction', &
-         'linear', &
+         "seaice_atm_bgc_forcing_monthly", &
+         "IRON_in_duzt_fraction", &
+         "DustIronMonthlyForcing", &
+         "atmos_forcing", &
+         "IRON_in_duzt_fraction", &
+         "linear", &
          forcingReferenceTimeMonthly, &
          forcingIntervalMonthly)
 
     call MPAS_forcing_init_field_data(&
          seaiceForcingGroups, &
-         'seaice_atm_bgc_forcing_monthly', &
+         "seaice_atm_bgc_forcing_monthly", &
          domain % streamManager, &
          config_do_restart, &
          .false.)


### PR DESCRIPTION
Changes namelist defaults when ice bgc is active
to add aerosols and radiative feedbacks.

[non-BFB] for BGC cases. BFB otherwise.

----

Tested in 1850-2012 historical transient fully-coupled simulation with active BGC.
See: https://acme-climate.atlassian.net/wiki/spaces/HESF/pages/4969857026/20250122.v3.LR.CBGC.20TR.newDustFe.iceRad

Climate impacts are small.  Most notable impacts are in the Arctic sea ice volume:

<img width="1341" alt="Screenshot 2025-04-11 at 9 42 43 AM" src="https://github.com/user-attachments/assets/86c5951f-92d1-46b6-8a5d-854096d75b97" />

<img width="1341" alt="Screenshot 2025-04-11 at 9 43 13 AM" src="https://github.com/user-attachments/assets/2b3352a3-d02c-4201-95fd-25ba6d1b0119" />

<img width="1051" alt="Screenshot 2025-04-11 at 9 43 58 AM" src="https://github.com/user-attachments/assets/bfcd87ce-4a3e-43dc-9ccb-5ce8d7b1b402" />

