### PR TITLE
Change snow shape default to hexagonal_plate

### DIFF
--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -659,7 +659,7 @@ this mask will have smb calculated over the entire global land surface
 <!--  ***********  Resolution independent:   ***********  -->
 <fsnowoptics >lnd/clm2/snicardata/snicar_optics_5bnd_mam_c160322.nc</fsnowoptics>
 <fsnowaging  >lnd/clm2/snicardata/snicar_drdt_bst_fit_60_c070416.nc</fsnowaging>
-<snow_shape>sphere</snow_shape>
+<snow_shape>hexagonal_plate</snow_shape>
 <snicar_atm_type>default</snicar_atm_type>
 <use_dust_snow_internal_mixing>.false.</use_dust_snow_internal_mixing>
 

--- a/components/elm/src/main/elm_varctl.F90
+++ b/components/elm/src/main/elm_varctl.F90
@@ -559,7 +559,7 @@ module elm_varctl
    !----------------------------------------------------------
    ! SNICAR-AD
    !----------------------------------------------------------
-   character(len=256), public :: snow_shape = 'sphere'
+   character(len=256), public :: snow_shape = 'hexagonal_plate'
    character(len=256), public :: snicar_atm_type = 'default'
    logical, public :: use_dust_snow_internal_mixing = .false.
 


### PR DESCRIPTION
This PR changes the default namelist option for snow grain shape for all configurations to
`hexagonal_plate`, which is used by the SNICAR-ADv3 model to scatter light. Thus, this
option has an appreciable impact on albedo in snow-covered regions. The current default
is `sphere`, thus this change increases albedo in snow-covered regions (aspect ratio of
snow grains increases from 1 to 2.5).

This change is motivated by a significant albedo bias over polar ice sheets and a related
summertime warm surface air temperature bias. 

This change is supported by `hexagonal_plate` being the default in CLM5.

[CC]