### PR TITLE
Change cosp submodule remote

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,8 +22,8 @@
 	branch = scorpio_classic
 [submodule "cosp2"]
 	path = components/eam/src/physics/cosp2/external
-	url = git@github.com:bartgol/COSPv2.0.git
-	branch = bartgol/fix-cosp_optical_inputs
+	url = git@github.com:e3sm-project/COSPv2.0.git
+	branch = e3sm-master
 [submodule "cime"]
 	path = cime
 	url = git@github.com:ESMCI/cime.git


### PR DESCRIPTION
Make COSP submodule point to a fork in the e3sm-project org.

Fixes #7252 

---

@rljacob I am not planning on canceling my account any time soon, so not a big deal, but maybe we should merge this PR into maint branches as well?