### PR TITLE
Restore WITH_HDF5 option for SCORPIO and use custom FindHDF5 module

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1299,7 +1299,6 @@
     <environment_variables>
       <env name="NETCDF_PATH">$ENV{NETCDF_DIR}</env>
       <env name="PNETCDF_PATH">$ENV{PNETCDF_DIR}</env>
-      <env name="HDF5_ROOT"/> <!-- frontier cmake cannot find_package(HDF5) for some reason, so disable it -->
       <env name="MPICH_GPU_SUPPORT_ENABLED">0</env>
       <env name="MPICH_VERSION_DISPLAY">1</env>
       <env name="MPICH_OFI_CXI_COUNTER_REPORT">2</env>
@@ -2764,6 +2763,7 @@
     <MAX_GB_OLD_TEST_DATA>0</MAX_GB_OLD_TEST_DATA>
     <environment_variables>
       <env name="PERL5LIB">/lcrc/group/e3sm/soft/perl/chrys/lib/perl5</env>
+      <env name="HDF5_ROOT">$SHELL{dirname $(dirname $(which h5dump))}</env>
       <env name="NETCDF_C_PATH">$SHELL{dirname $(dirname $(which nc-config))}</env>
       <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>

--- a/components/cmake/modules/FindHDF5.cmake
+++ b/components/cmake/modules/FindHDF5.cmake
@@ -1,0 +1,46 @@
+# - Try to find HDF5
+#
+# CMake's built-in FindHDF5 module may fail with certain compilers, so
+# we provide a custom module that avoids relying on compiler wrappers.
+#
+# Once done, this will define:
+#
+#   The "hdf5" target
+#
+
+if (TARGET hdf5)
+  return()
+endif()
+
+set(HDF5_ROOT $ENV{HDF5_ROOT})
+
+if (NOT EXISTS "${HDF5_ROOT}/lib" AND NOT EXISTS "${HDF5_ROOT}/lib64")
+  message(FATAL_ERROR "HDF5_ROOT does not contain a lib or lib64 directory")
+endif()
+
+# Preserve original CMake find library suffixes
+set(ORIGINAL_CMAKE_FIND_LIBRARY_SUFFIXES "${CMAKE_FIND_LIBRARY_SUFFIXES}")
+
+if (HDF5_USE_STATIC_LIBRARIES)
+  set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
+else()
+  set(CMAKE_FIND_LIBRARY_SUFFIXES .so .a)
+endif()
+
+find_library(HDF5_LIBRARIES NAMES hdf5 HINTS "${HDF5_ROOT}/lib" "${HDF5_ROOT}/lib64")
+find_library(HDF5_HL_LIBRARIES NAMES hdf5_hl HINTS "${HDF5_ROOT}/lib" "${HDF5_ROOT}/lib64")
+
+# Restore original CMake find library suffixes
+set(CMAKE_FIND_LIBRARY_SUFFIXES "${ORIGINAL_CMAKE_FIND_LIBRARY_SUFFIXES}")
+
+if (NOT EXISTS "${HDF5_ROOT}/include")
+  message(FATAL_ERROR "HDF5_ROOT does not contain an include directory")
+endif()
+
+find_path(HDF5_INCLUDE_DIR hdf5.h HINTS "${HDF5_ROOT}/include")
+
+# Create the interface library, and set target properties
+# For static libraries, link with HDF5_HL_LIBRARIES before HDF5_LIBRARIES
+add_library(hdf5 INTERFACE)
+target_link_libraries(hdf5 INTERFACE ${HDF5_HL_LIBRARIES} ${HDF5_LIBRARIES})
+target_include_directories(hdf5 INTERFACE "${HDF5_INCLUDE_DIR}")

--- a/components/cmake/modules/FindPIO.cmake
+++ b/components/cmake/modules/FindPIO.cmake
@@ -35,7 +35,7 @@ if (DEFINED ENV{HDF5_ROOT})
   if (DEFINED ENV{HDF5_USE_STATIC_LIBRARIES})
     set(HDF5_USE_STATIC_LIBRARIES On)
   endif()
-  find_package(HDF5 REQUIRED COMPONENTS C HL)
+  find_package(HDF5 REQUIRED)
 endif()
 
 # Not all machines/PIO installations use ADIOS but, for now,
@@ -60,7 +60,7 @@ else()
 endif()
 
 if (DEFINED ENV{HDF5_ROOT})
-  list(APPEND PIOLIBS ${HDF5_HL_LIBRARIES} ${HDF5_LIBRARIES})
+  list(APPEND PIOLIBS hdf5)
 endif()
 
 # Create the interface library, and set target properties

--- a/share/build/buildlib.spio
+++ b/share/build/buildlib.spio
@@ -145,10 +145,8 @@ def buildlib(bldroot, installpath, case):
     # elif which_h5dump is not None:
     #     os.environ["HDF5"] = os.path.dirname(os.path.dirname(which_h5dump))
 
-    # Before E3SM upgrades scorpio submodule to 1.5.0 or higher, keep WITH_HDF5
-    # CMake option OFF by default.
-    # if "HDF5_ROOT" in os.environ:
-    #    cmake_opts += "-DWITH_HDF5:BOOL=ON "
+    if "HDF5_ROOT" in os.environ:
+       cmake_opts += "-DWITH_HDF5:BOOL=ON "
 
     # Same deal with libz and szip
     if "ZLIB_ROOT" in os.environ:


### PR DESCRIPTION
This PR restores the WITH_HDF5 CMake option to configure SCORPIO
in E3SM builds when the HDF5_ROOT environment variable is defined.

Key updates:
* Enables the WITH_HDF5 option during SCORPIO configuration when
  HDF5_ROOT is defined.
* Adds a custom FindHDF5.cmake module to replace CMake's built-in
  version, which has failed to work with certain compiler wrappers
  or to propagate required include paths.
* Restores the implicit HDF5_ROOT definition on Frontier, which is
  automatically set when the HDF5 module is loaded.
* Explicitly sets HDF5_ROOT on Chrysalis.

[BFB]