### PR TITLE
EAMxx: add external forcings / elevated emission fluxes diagnostics

### DIFF
--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -986,7 +986,7 @@ void MAMMicrophysics::run_impl(const double dt) {
     Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0,0}, {ncol, extcnt}),
     KOKKOS_LAMBDA(const int i, const int j) {
       Real sum = 0.0;
-      for (int k = 0; k < nlev_local; ++k) {
+      for (int k = 0; k < nlev; ++k) {
         Real dz_m = z_int(i,k) - z_int(i,k+1); 
         Real dz_cm = dz_m * 100.0;
         sum += extfrc(i,k,j) * dz_cm;

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -947,6 +947,8 @@ void MAMMicrophysics::run_impl(const double dt) {
   // TODO: getting rid of hard-coded indices
   const int extfrc_pcnst_index[extcnt] = {3, 6, 14, 27, 28, 13, 18, 30, 5};
 
+  auto molar_mass_g_per_mol_tmp = mam4::gas_chemistry::adv_mass;
+
   // Transpose extfrc_ from internal layout [ncol][nlev][extcnt]
   // to output layout [ncol][extcnt][nlev]
   // This aligns with expected field storage in the EAMxx infrastructure.

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -956,7 +956,7 @@ void MAMMicrophysics::run_impl(const double dt) {
     Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0,0,0}, {ncol, extcnt, nlev}),
     KOKKOS_LAMBDA(const int i, const int j, const int k) {
       const int pcnst_idx = extfrc_pcnst_index[j];
-      const Real molar_mass_g_per_mol = mam4::gas_chemistry::adv_mass[pcnst_idx]; // g/mol
+      auto molar_mass_g_per_mol = molar_mass_g_per_mol_tmp[pcnst_idx]; // g/mol
       
       // Convert g → kg (× 1e-3), cm³ → m³ (× 1e6) → total factor: 1e-3 × 1e6 = 1e3 = 1000.0
       extfrc_fm(i,j,k) = extfrc(i,k,j) * (molar_mass_g_per_mol / Avogadro) * 1000.0;  // transpose [ncol][nlev][extcnt] -> [ncol][extcnt][nlev]

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -947,9 +947,6 @@ void MAMMicrophysics::run_impl(const double dt) {
   // TODO: getting rid of hard-coded indices
   const int extfrc_pcnst_index[extcnt] = {3, 6, 14, 27, 28, 13, 18, 30, 5};
 
-  // Heights at vertical interfaces [m]
-  const auto z_int = dry_atm_.z_iface;
-
   // Transpose extfrc_ from internal layout [ncol][nlev][extcnt]
   // to output layout [ncol][extcnt][nlev]
   // This aligns with expected field storage in the EAMxx infrastructure.

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -966,18 +966,14 @@ void MAMMicrophysics::run_impl(const double dt) {
   Kokkos::fence();
 
   auto extfrc_fm = get_field_out("extfrc").get_view<Real***>();
-  // Create local copies to safely access class members in device code on GPUs
-  const int ncol_local = ncol_;
-  const int extcnt_local = extcnt;
-  const int nlev_local = nlev_;
 
   // Transpose extfrc_ from internal layout [ncol][nlev][extcnt]
   // to output layout [ncol][extcnt][nlev]
   // This aligns with expected field storage in the EAMxx infrastructure.
   Kokkos::parallel_for("transpose_extfrc", 
-    Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0,0,0}, {ncol_local, extcnt_local, nlev_local}),
+    Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0,0,0}, {ncol, extcnt, nlev}),
     KOKKOS_LAMBDA(const int i, const int j, const int k) {
-      extfrc_fm(i,j,k) = extfrc_(i,k,j);  // transpose [ncol][nlev][extcnt] -> [ncol][extcnt][nlev]
+      extfrc_fm(i,j,k) = extfrc(i,k,j);  // transpose [ncol][nlev][extcnt] -> [ncol][extcnt][nlev]
   });
 
   // Interface heights [m]
@@ -987,13 +983,13 @@ void MAMMicrophysics::run_impl(const double dt) {
   // Integrate external forcing vertically using layer thickness (dz)
   // extfrc_ is in [molec/cm³/s], dz in [cm], so result is [molec/cm²/s]
   Kokkos::parallel_for("compute_extfrc_vertsum", 
-    Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0,0}, {ncol_local, extcnt_local}),
+    Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0,0}, {ncol, extcnt}),
     KOKKOS_LAMBDA(const int i, const int j) {
       Real sum = 0.0;
       for (int k = 0; k < nlev_local; ++k) {
         Real dz_m = z_int(i,k) - z_int(i,k+1); 
         Real dz_cm = dz_m * 100.0;
-        sum += extfrc_(i,k,j) * dz_cm;
+        sum += extfrc(i,k,j) * dz_cm;
       }
       extfrc_vertsum(i,j) = sum;
   });

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -94,7 +94,7 @@ void MAMMicrophysics::set_grids(
   add_tracer<Required>("nc", grid_, n_unit);
 
   constexpr auto m2 = pow(m, 2);
-  constexpr auto s2 = pow(s, 2);
+  constexpr auto s2 = pow(s, 2); 
 
   // Surface geopotential [m2/s2]
   add_field<Required>("phis", scalar2d, m2 / s2, grid_name);
@@ -181,6 +181,29 @@ void MAMMicrophysics::set_grids(
   // Constituent fluxes of species in [kg/m2/s]
   add_field<Updated>("constituent_fluxes", scalar2d_pcnst, kg / m2 / s,
                      grid_name);
+
+  // Define unit constants for external forcing fields
+  // -----------------------------------------------------------------------------
+  // Note: The following units are technically redundant, as the output units
+  //       are explicitly overridden later for clean NetCDF metadata. However,
+  //       we define them here to document the intended physical units in code.
+  // -----------------------------------------------------------------------------
+  constexpr auto molec = ekat::units::Units::nondimensional();
+  constexpr auto cm     = m / 100;
+  const auto cm2       = pow(cm, 2);
+  const auto cm3       = pow(cm, 3);
+
+  // Number of externally forced chemical species
+  constexpr int extcnt = mam4::gas_chemistry::extcnt;
+
+  FieldLayout scalar3d_extcnt = grid_->get_3d_vector_layout(true, extcnt, "ext_cnt");
+  FieldLayout scalar2d_extcnt = grid_->get_2d_vector_layout(extcnt, "ext_cnt");
+
+  // Register computed fields for external forcing
+  // - extfrc: 3D instantaneous forcing rate [molec/cm³/s]
+  // - extfrc_vertsum: Vertically integrated forcing rate [molec/cm²/s]
+  add_field<Computed>("extfrc", scalar3d_extcnt, molec / cm3 / s, grid_name);
+  add_field<Computed>("extfrc_vertsum", scalar2d_extcnt, molec / cm2 / s, grid_name);
 
   // Creating a Linoz reader and setting Linoz parameters involves reading data
   // from a file and configuring the necessary parameters for the Linoz model.
@@ -454,6 +477,20 @@ void MAMMicrophysics::initialize_impl(const RunType run_type) {
   // ---------------------------------------------------------------
   populate_wet_atm(wet_atm_);
   populate_dry_atm(dry_atm_, buffer_);
+
+  // Override unit strings for clean NetCDF output
+  using str_atts_t = std::map<std::string, std::string>;
+
+  {
+    auto& extfrc_field = get_field_out("extfrc");
+    auto& io_atts = extfrc_field.get_header().get_extra_data<str_atts_t>("io: string attributes");
+    io_atts["units"] = "molec/cm3/s";
+
+    auto& extfrc_vertsum_field = get_field_out("extfrc_vertsum");
+    auto& io_atts2 = extfrc_vertsum_field.get_header().get_extra_data<str_atts_t>("io: string attributes");
+    io_atts2["units"] = "molec/cm2/s";
+  }
+  
   // FIXME: we are using cldfrac_tot in other mam4xx process.
   dry_atm_.cldfrac = get_field_in("cldfrac_liq").get_view<const Real **>();
   // FIXME: phis is not populated by populate_wet_and_dry_atm.
@@ -534,7 +571,9 @@ void MAMMicrophysics::initialize_impl(const RunType run_type) {
         ElevatedEmissionsDataReader_[i], curr_month,
         *ElevatedEmissionsHorizInterp_[i], elevated_emis_data_[i]);
   }
+
   // //
+
   acos_cosine_zenith_host_ = view_1d_host("host_acos(cosine_zenith)", ncol_);
   acos_cosine_zenith_      = view_1d("device_acos(cosine_zenith)", ncol_);
 
@@ -925,6 +964,34 @@ void MAMMicrophysics::run_impl(const double dt) {
 
       });  // parallel_for for the column loop
   Kokkos::fence();
+
+  auto extfrc_fm = get_field_out("extfrc").get_view<Real***>();
+  // Transpose extfrc_ from internal layout [ncol][nlev][extcnt]
+  // to output layout [ncol][extcnt][nlev]
+  // This aligns with expected field storage in the EAMxx infrastructure.
+  Kokkos::parallel_for("transpose_extfrc", 
+    Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0,0,0}, {ncol_, extcnt, nlev_}),
+    KOKKOS_LAMBDA(const int i, const int j, const int k) {
+      extfrc_fm(i,j,k) = extfrc_(i,k,j);  // transpose [ncol][nlev][extcnt] -> [ncol][extcnt][nlev]
+  });
+
+  // Interface heights [m]
+  const auto z_int = dry_atm_.z_iface;
+  auto extfrc_vertsum = get_field_out("extfrc_vertsum").get_view<Real **>();
+
+  // Integrate external forcing vertically using layer thickness (dz)
+  // extfrc_ is in [molec/cm³/s], dz in [cm], so result is [molec/cm²/s]
+  Kokkos::parallel_for("compute_extfrc_vertsum", 
+    Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0,0}, {ncol_, extcnt}),
+    KOKKOS_LAMBDA(const int i, const int j) {
+      Real sum = 0.0;
+      for (int k = 0; k < nlev_; ++k) {
+        Real dz_m = z_int(i,k) - z_int(i,k+1); 
+        Real dz_cm = dz_m * 100.0;
+        sum += extfrc_(i,k,j) * dz_cm;
+      }
+      extfrc_vertsum(i,j) = sum;
+  });
 
   // postprocess output
   post_process(wet_aero_, dry_aero_, dry_atm_);

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -94,7 +94,7 @@ void MAMMicrophysics::set_grids(
   add_tracer<Required>("nc", grid_, n_unit);
 
   constexpr auto m2 = pow(m, 2);
-  constexpr auto s2 = pow(s, 2); 
+  constexpr auto s2 = pow(s, 2);
 
   // Surface geopotential [m2/s2]
   add_field<Required>("phis", scalar2d, m2 / s2, grid_name);


### PR DESCRIPTION
This PR adds external forcings (analogous to `*_XFRC` in EAM) in MKS 
units (`kg/m2/s`) as additional diagnostics for aerosol budget analysis. 
Users may output the column-integrated forcings
 (analogous to `*_CLXF` in EAM) using `vert_contraction` as 
shown by @mahf708 [here](https://github.com/E3SM-Project/E3SM/pull/7284#pullrequestreview-2800486247). 

[Relevant Link](https://acme-climate.atlassian.net/wiki/spaces/EAMXX/pages/5098831873/Adding+additional+diagnostics?force_transition=94620a2e-2c02-4537-a2e6-c1983db43cd3)

[BFB]