### PR TITLE
Change source coverage workflow

### DIFF
--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -1340,7 +1340,7 @@ contains
 #endif
     tagname=trim(seq_flds_x2l_fields)//C_NULL_CHAR
     ent_type = 0 ! vertices 
-    ierr = iMOAB_GetDoubleTagStorage ( mlnid, tagname, totalmblsimp , ent_type, x2l_lm(1,1) )
+    ierr = iMOAB_GetDoubleTagStorage ( mlnid, tagname, totalmblsimp , ent_type, x2l_lm )
     if ( ierr > 0) then
       call endrun('Error: fail to get seq_flds_x2l_fields for land moab instance on component')
     endif

--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -406,7 +406,7 @@ contains
     !     write out the mesh file to disk, in parallel
     outfile = 'wholeLnd.h5m'//C_NULL_CHAR
     wopts   = 'PARALLEL=WRITE_PART'//C_NULL_CHAR
-    if (mnlid >= 0) then
+    if (mlnid >= 0) then
        ierr = iMOAB_WriteMesh(mlnid, outfile, wopts)
        if (ierr > 0 )  &
          call endrun('Error: fail to write the land mesh file')

--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -1076,6 +1076,7 @@ contains
        l2x_lm(i,index_l2x_Sl_tref)     =  lnd2atm_vars%t_ref2m_grc(g)
        l2x_lm(i,index_l2x_Sl_qref)     =  lnd2atm_vars%q_ref2m_grc(g)
        l2x_lm(i,index_l2x_Sl_u10)      =  lnd2atm_vars%u_ref10m_grc(g)
+       l2x_lm(i,index_l2x_Sl_u10withgusts)=lnd2atm_vars%u_ref10m_with_gusts_grc(g) ! see commit 5813d4103
        l2x_lm(i,index_l2x_Fall_taux)   = -lnd2atm_vars%taux_grc(g)
        l2x_lm(i,index_l2x_Fall_tauy)   = -lnd2atm_vars%tauy_grc(g)
        l2x_lm(i,index_l2x_Fall_lat)    = -lnd2atm_vars%eflx_lh_tot_grc(g)

--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -406,9 +406,11 @@ contains
     !     write out the mesh file to disk, in parallel
     outfile = 'wholeLnd.h5m'//C_NULL_CHAR
     wopts   = 'PARALLEL=WRITE_PART'//C_NULL_CHAR
-    ierr = iMOAB_WriteMesh(mlnid, outfile, wopts)
-    if (ierr > 0 )  &
-      call endrun('Error: fail to write the land mesh file')
+    if (mnlid >= 0) then
+       ierr = iMOAB_WriteMesh(mlnid, outfile, wopts)
+       if (ierr > 0 )  &
+         call endrun('Error: fail to write the land mesh file')
+    endif
 #endif
 
   end subroutine lnd_init_mct

--- a/components/mosart/src/cpl/rof_comp_mct.F90
+++ b/components/mosart/src/cpl/rof_comp_mct.F90
@@ -1260,7 +1260,7 @@ end subroutine rof_export_moab
      
     !
     ! LOCAL VARIABLES
-    integer :: n2, n, nt, begr, endr, nliq, nfrz
+    integer :: n2, n, nt, begr, endr, nliq, nfrz, nmud, nsan
     real(R8) :: tmp1, tmp2
     real(R8) :: shum
     character(CXX) ::  tagname ! 
@@ -1287,7 +1287,7 @@ end subroutine rof_export_moab
     ! populate the array x2r_rm with data from MOAB tags
     tagname=trim(seq_flds_x2r_fields)//C_NULL_CHAR
     ent_type = 0 ! vertices, point cloud
-    ierr = iMOAB_GetDoubleTagStorage ( mrofid, tagname, totalmbls_r , ent_type, x2r_rm(1,1) )
+    ierr = iMOAB_GetDoubleTagStorage ( mrofid, tagname, totalmbls_r , ent_type, x2r_rm )
     if ( ierr > 0) then
       call shr_sys_abort(sub//'Error: fail to get  seq_flds_a2x_fields for atm physgrid moab mesh')
     endif
@@ -1295,6 +1295,8 @@ end subroutine rof_export_moab
     ! Note that ***runin are fluxes
     nliq = 0
     nfrz = 0
+    nmud = 0
+    nsan = 0
     do nt = 1,nt_rtm
        if (trim(rtm_tracers(nt)) == 'LIQ') then
           nliq = nt
@@ -1302,9 +1304,27 @@ end subroutine rof_export_moab
        if (trim(rtm_tracers(nt)) == 'ICE') then
           nfrz = nt
        endif
+       if (trim(rtm_tracers(nt)) == 'MUD') then
+          nmud = nt
+       endif
+       if (trim(rtm_tracers(nt)) == 'SAN') then
+          nsan = nt
+       endif
     enddo
-    if (nliq == 0 .or. nfrz == 0) then
-       write(iulog,*) trim(sub),': ERROR in rtm_tracers LIQ ICE ',nliq,nfrz,rtm_tracers
+    if (nliq == 0) then
+       write(iulog,*) trim(sub),': ERROR in rtm_tracers LIQ',nliq,rtm_tracers
+       call shr_sys_abort()
+    endif
+    if (nfrz == 0) then
+       write(iulog,*) trim(sub),': ERROR in rtm_tracers ICE',nfrz,rtm_tracers
+       call shr_sys_abort()
+    endif
+    if (nmud == 0) then
+       write(iulog,*) trim(sub),': ERROR in rtm_tracers MUD',nmud,rtm_tracers
+       call shr_sys_abort()
+    endif
+    if (nsan == 0) then
+       write(iulog,*) trim(sub),': ERROR in rtm_tracers SAN',nsan,rtm_tracers
        call shr_sys_abort()
     endif
 
@@ -1351,7 +1371,24 @@ end subroutine rof_export_moab
           THeat%forc_vp(n)   = shum * THeat%forc_pbot(n)  / (0.622_r8 + 0.378_r8 * shum)
           THeat%coszen(n)    = x2r_rm(n2,index_x2r_coszen_str)
        end if
+
+
+       rtmCTL%qsur(n,nmud) = 0.0_r8
+       rtmCTL%qsur(n,nsan) = 0.0_r8
+
+       if (index_x2r_Flrl_inundinf > 0) then
+          rtmCTL%inundinf(n) = x2r_rm(n2,index_x2r_Flrl_inundinf) * (rtmCTL%area(n)*0.001_r8)
+       endif
+
     enddo
+
+    if(sediflag) then
+        do n = begr,endr
+           n2 = n - begr + 1
+           rtmCTL%qsur(n,nmud) = x2r_rm(n2,index_x2r_Flrl_rofmud) * (rtmCTL%area(n)) ! kg/m2/s --> kg/s for sediment
+           rtmCTL%qsur(n,nsan) = 0.0_r8
+        enddo
+    end if
 
   end subroutine rof_import_moab
 

--- a/components/mosart/src/cpl/rof_comp_mct.F90
+++ b/components/mosart/src/cpl/rof_comp_mct.F90
@@ -388,9 +388,11 @@ contains
     !     write out the mesh file to disk, in parallel
     outfile = 'wholeRof.h5m'//C_NULL_CHAR
     wopts   = 'PARALLEL=WRITE_PART'//C_NULL_CHAR
-    ierr = iMOAB_WriteMesh(mrofid, outfile, wopts)
-    if (ierr > 0 )  &
-      call shr_sys_abort( sub//' Error: fail to write the moab runoff mesh file')
+    if (mrofid >= 0) then
+      ierr = iMOAB_WriteMesh(mrofid, outfile, wopts)
+      if (ierr > 0 )  &
+        call shr_sys_abort( sub//' Error: fail to write the moab runoff mesh file')
+    endif
 #endif
 
   end subroutine rof_init_mct

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -3636,7 +3636,7 @@ contains
    ent_type = 1 ! cells
    !  get all tags in one method
    tagname = trim(seq_flds_x2o_fields)//C_NULL_CHAR
-   ierr = iMOAB_GetDoubleTagStorage ( MPOID, tagname, totalmbls_r , ent_type, x2o_om(1, 1) )
+   ierr = iMOAB_GetDoubleTagStorage ( MPOID, tagname, totalmbls_r , ent_type, x2o_om )
    if ( ierr /= 0 ) then
       write(ocnLogUnit,*) 'Fail to get MOAB fields '
    endif

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -3550,6 +3550,7 @@ contains
                i2x_im(n, index_i2x_Si_t)  = Tsrf
                i2x_im(n, index_i2x_Si_bpress)  = basalPressure
                i2x_im(n, index_i2x_Si_u10)  = atmosReferenceSpeed10m(i)
+               i2x_im(n, index_i2x_Si_u10withgusts) = atmosReferenceSpeed10m(i)  ! see commit 5813d4103
                i2x_im(n, index_i2x_Si_tref)  = atmosReferenceTemperature2m(i)
                i2x_im(n, index_i2x_Si_qref)  = atmosReferenceHumidity2m(i)
                i2x_im(n, index_i2x_Si_snowh)  = snowVolumeCell(i) / ailohi

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -3888,7 +3888,7 @@ contains
    ent_type = 1 ! cells
   !  set all tags in one method
    tagname = trim(seq_flds_x2i_fields)//C_NULL_CHAR
-   ierr = iMOAB_GetDoubleTagStorage ( MPSIID, tagname, totalmblr , ent_type, x2i_im(1, 1) )
+   ierr = iMOAB_GetDoubleTagStorage ( MPSIID, tagname, totalmblr , ent_type, x2i_im )
    if ( ierr /= 0 ) then
       write(iceLogUnit,*) 'Fail to get seq_flds_x2i_fields '
    endif

--- a/driver-moab/main/component_mod.F90
+++ b/driver-moab/main/component_mod.F90
@@ -470,6 +470,7 @@ contains
     use iso_c_binding
     !   character(1024)         :: domain_file        ! file containing domain info (set my input)
     use seq_comm_mct,     only: mboxid ! iMOAB id for MPAS ocean migrated mesh to coupler pes
+    use seq_comm_mct,     only: mblxid ! iMOAB id for lnd migrated mesh to coupler pes
     use seq_comm_mct,     only: mbaxid ! iMOAB id for atm migrated mesh to coupler pes
     use seq_comm_mct,     only: mbrxid ! iMOAB id for rof migrated mesh to coupler pes
 #endif
@@ -551,18 +552,6 @@ contains
          ! project now aream on ocean (from atm)
 #endif
          call seq_map_map(mapper_Fa2o, av_s=dom_s%data, av_d=dom_d%data, fldlist='aream')
-
-#ifdef HAVE_MOAB
-#ifdef MOABDEBUG
-         ierr = iMOAB_WriteMesh(mboxid, trim('recMeshOcnWithArea.h5m'//C_NULL_CHAR), &
-                                 trim(';PARALLEL=WRITE_PART'//C_NULL_CHAR))
-         if (ierr .ne. 0) then
-            write(logunit,*) subname,' error in writing ocean mesh coupler '
-            call shr_sys_abort(subname//' ERROR in writing ocean mesh coupler ')
-         endif
-#endif
-#endif
-
           
        else
           gsmap_s => component_get_gsmap_cx(ocn(1)) ! gsmap_ox
@@ -644,6 +633,40 @@ contains
 
        endif
     endif
+#ifdef MOABDEBUG
+     if(mbaxid >=0 ) then
+         ierr = iMOAB_WriteMesh(mbaxid, trim('cplAtmWithAream.h5m'//C_NULL_CHAR), &
+                                 trim(';PARALLEL=WRITE_PART'//C_NULL_CHAR))
+         if (ierr .ne. 0) then
+            write(logunit,*) subname,' error in writing atm mesh coupler '
+            call shr_sys_abort(subname//' ERROR in writing atm mesh coupler ')
+         endif
+     endif
+     if(mblxid >=0 ) then
+         ierr = iMOAB_WriteMesh(mblxid, trim('cplLndWithAream.h5m'//C_NULL_CHAR), &
+                                 trim(';PARALLEL=WRITE_PART'//C_NULL_CHAR))
+         if (ierr .ne. 0) then
+            write(logunit,*) subname,' error in writing lnd mesh coupler '
+            call shr_sys_abort(subname//' ERROR in writing lnd mesh coupler ')
+         endif
+     endif
+     if(mboxid >=0 ) then
+         ierr = iMOAB_WriteMesh(mboxid, trim('cplOcnWithAream.h5m'//C_NULL_CHAR), &
+                                 trim(';PARALLEL=WRITE_PART'//C_NULL_CHAR))
+         if (ierr .ne. 0) then
+            write(logunit,*) subname,' error in writing ocn mesh coupler '
+            call shr_sys_abort(subname//' ERROR in writing ocn mesh coupler ')
+         endif
+     endif
+     if(mbrxid >=0 ) then
+         ierr = iMOAB_WriteMesh(mbrxid, trim('cplRofWithAream.h5m'//C_NULL_CHAR), &
+                                 trim(';PARALLEL=WRITE_PART'//C_NULL_CHAR))
+         if (ierr .ne. 0) then
+            write(logunit,*) subname,' error in writing rof mesh coupler '
+            call shr_sys_abort(subname//' ERROR in writing rof mesh coupler ')
+         endif
+     endif
+#endif
 
   end subroutine component_init_aream
 
@@ -734,11 +757,15 @@ subroutine component_init_areacor_moab (comp, mbccid, mbcxid, seq_flds_c2x_fluxe
    integer :: mpi_tag
    character(*), parameter :: subname = '(component_init_areacor_moab)'
    character(CXX)          :: tagname
+   character(CXX)   :: comment
    integer                 :: tagtype, numco,  tagindex, lsize, i, j, arrsize, ierr, nfields
    real (kind=r8) , allocatable :: areas (:,:), factors(:,:), vals(:,:) ! 2 tags values, area, aream,
-   real (kind=r8)  :: rarea, raream, rmask, fact
+   real (kind=r8)  :: rarea, raream, rmask, fact, rmin1, rmax1, rmin, rmax
    integer     nvert(3), nvise(3), nbl(3), nsurf(3), nvisBC(3)
    type(mct_list) :: temp_list  ! used to count number of fields
+   integer :: mpicom
+   logical :: iamroot
+   character(len=*),parameter :: F0R = "(2A,2g23.15,A )"
    !---------------------------------------------------------------
 
    if (comp(1)%iamin_cplcompid) then
@@ -794,6 +821,23 @@ subroutine component_init_areacor_moab (comp, mbccid, mbcxid, seq_flds_c2x_fluxe
          if (ierr .ne. 0) then
            call shr_sys_abort(subname//' cannot set correction area factors  ')
          endif
+
+! print the computed values for area factors
+         rmin1 = minval(factors(:,1))
+         rmax1 = maxval(factors(:,1))
+         mpicom = comp(1)%mpicom_compid
+         iamroot= comp(1)%iamroot_compid
+         call shr_mpi_min(rmin1,rmin,mpicom)
+         call shr_mpi_max(rmax1,rmax,mpicom)
+         comment = 'areafact_'//trim(comp(1)%name)
+         if (iamroot) write(logunit,F0R) trim(subname),' : min/max mdl2drv ',rmin,rmax,trim(comment)
+
+         rmin1 = minval(factors(:,2))
+         rmax1 = maxval(factors(:,2))
+         call shr_mpi_min(rmin1,rmin,mpicom)
+         call shr_mpi_max(rmax1,rmax,mpicom)
+         if (iamroot) write(logunit,F0R) trim(subname),' : min/max drv2mdl ',rmin,rmax,trim(comment)
+         if (iamroot) call shr_sys_flush(logunit)
 
           ! Area correct component initialization output fields
           ! need to multiply fluxes (correct them) with mdl2drv (factors(i,1))

--- a/driver-moab/main/component_mod.F90
+++ b/driver-moab/main/component_mod.F90
@@ -745,7 +745,7 @@ subroutine component_init_areacor_moab (comp, mbccid, mbcxid, seq_flds_c2x_fluxe
       tagname='aream'//C_NULL_CHAR
       ! bring on the comp side the aream from maps
       ! (it is either computed by mapping routine or read from mapping files)
-      call component_exch_moab(comp(1), mbcxid, mbccid, 1, tagname)
+      call component_exch_moab(comp(1), mbcxid, mbccid, 1, tagname, context_exch='aream')
 
       ! For only component pes
       if (comp(1)%iamin_compid) then
@@ -836,7 +836,7 @@ subroutine component_init_areacor_moab (comp, mbccid, mbcxid, seq_flds_c2x_fluxe
 
       endif
        ! send data to coupler exchange ? everything, not only fluxes ?
-      call component_exch_moab(comp(1), mbccid, mbcxid, 0, seq_flds_c2x_fields)
+      call component_exch_moab(comp(1), mbccid, mbcxid, 0, seq_flds_c2x_fields, context_exch='areacor')
    endif
 
   end subroutine component_init_areacor_moab

--- a/driver-moab/main/component_type_mod.F90
+++ b/driver-moab/main/component_type_mod.F90
@@ -421,6 +421,7 @@ contains
     
     use shr_mpi_mod,       only: shr_mpi_sum
     use shr_kind_mod,     only:  CXX => shr_kind_CXX
+    use shr_kind_mod    , only:  IN=>SHR_KIND_IN
     use seq_comm_mct , only : CPLID, seq_comm_iamroot
     use seq_comm_mct, only:   seq_comm_setptrs
     use iMOAB, only : iMOAB_DefineTagStorage,  iMOAB_GetDoubleTagStorage, &
@@ -431,20 +432,22 @@ contains
     type(component_type), intent(in) :: comp
     integer , intent(in) :: appId, ent_type
     type(mct_aVect) , intent(in), pointer       :: attrVect
+    type(mct_gsmap), pointer    :: gsmap
     character(*) , intent(in)       :: mct_field
     character(*) , intent(in)       :: tagname
+    integer(IN), pointer :: dof(:) 
 
     real(r8)      , intent(out)     :: difference
     logical , intent(in)            :: first_time
 
     real(r8)  :: differenceg ! global, reduced diff
-    type(mct_ggrid), pointer    :: dom
-    integer   :: kgg, mbSize, nloc, index_avfield
+    !type(mct_ggrid), pointer    :: dom
+    integer   :: kgg, mbSize, nloc, index_avfield, my_task
 
      ! moab
      integer                  :: tagtype, numco,  tagindex, ierr
      character(CXX)           :: tagname_mct
-     integer ,    allocatable :: GlobalIds(:) ! used for setting values associated with ids
+     !integer ,    allocatable :: GlobalIds(:) ! used for setting values associated with ids
      
      real(r8) , allocatable :: values(:), mct_values(:)
      integer nvert(3), nvise(3), nbl(3), nsurf(3), nvisBC(3)
@@ -457,11 +460,15 @@ contains
      call seq_comm_setptrs(CPLID, mpicom=mpicom)
 
      nloc = mct_avect_lsize(attrVect)
-     allocate(GlobalIds(nloc))
+     !allocate(GlobalIds(nloc))
      allocate(values(nloc))
-     dom => component_get_dom_cx(comp)
-     kgg = mct_aVect_indexIA(dom%data ,"GlobGridNum" ,perrWith=subName)
-     GlobalIds = dom%data%iAttr(kgg,:)
+     !dom => component_get_dom_cx(comp)
+     !kgg = mct_aVect_indexIA(dom%data ,"GlobGridNum" ,perrWith=subName)
+     !GlobalIds = dom%data%iAttr(kgg,:)
+     gsmap  => component_get_gsmap_cx(comp) ! gsmap_x
+     call mpi_comm_rank(mpicom,my_task,ierr)
+         ! Determine global gridpoint number attribute, GlobGridNum, automatically in ggrid
+     call mct_gsMap_orderedPoints(gsmap, my_task, dof)
 
      index_avfield     = mct_aVect_indexRA(attrVect,trim(mct_field))
      values(:) = attrVect%rAttr(index_avfield,:) 
@@ -476,7 +483,7 @@ contains
         if (ierr > 0 )  &
             call shr_sys_abort(subname//'Error: fail to define new tag for mct')
      endif 
-     ierr = iMOAB_SetDoubleTagStorageWithGid ( appId, tagname_mct, nloc , ent_type, values, GlobalIds )
+     ierr = iMOAB_SetDoubleTagStorageWithGid ( appId, tagname_mct, nloc , ent_type, values, dof )
      if (ierr > 0 )  &
         call shr_sys_abort(subname//'Error: fail to set new tags')
 
@@ -511,7 +518,8 @@ contains
         print * , subname, trim(comp%ntype), ' on cpl, difference on tag ', trim(tagname), ' = ', difference
         !call shr_sys_abort(subname//'differences between mct and moab values')
      endif
-     deallocate(GlobalIds)
+     !deallocate(GlobalIds)
+     deallocate (dof) 
      deallocate(values)
      deallocate(mct_values)
 

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -1479,6 +1479,7 @@ subroutine  copy_aream_from_area(mbappid)
          endif
          ! end copy 
 #ifdef MOABDEBUG
+      if (mbofxid >= 0) then
          outfile = 'recMeshOcnF.h5m'//C_NULL_CHAR
          wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
       !  write out the mesh file to disk
@@ -1487,6 +1488,7 @@ subroutine  copy_aream_from_area(mbappid)
              write(logunit,*) subname,' error in writing ocean mesh coupler '
              call shr_sys_abort(subname//' ERROR in writing ocean mesh coupler ')
          endif
+      endif
 #endif
       endif  ! end ocean
 
@@ -1826,13 +1828,15 @@ subroutine  copy_aream_from_area(mbappid)
          ! initialize aream from area; it may have different values in the end, or reset again
          call copy_aream_from_area(mbrxid)
 #ifdef MOABDEBUG
-         outfile = 'recMeshRof.h5m'//C_NULL_CHAR
-         wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
-  !      write out the mesh file to disk
-         ierr = iMOAB_WriteMesh(mbrxid, trim(outfile), trim(wopts))
-         if (ierr .ne. 0) then
-            write(logunit,*) subname,' error in writing rof mesh on coupler '
-            call shr_sys_abort(subname//' ERROR in writing rof mesh on coupler ')
+         if (mbrxid >= 0) then
+            outfile = 'recMeshRof.h5m'//C_NULL_CHAR
+            wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
+  !         write out the mesh file to disk
+            ierr = iMOAB_WriteMesh(mbrxid, trim(outfile), trim(wopts))
+            if (ierr .ne. 0) then
+              write(logunit,*) subname,' error in writing rof mesh on coupler '
+               call shr_sys_abort(subname//' ERROR in writing rof mesh on coupler ')
+            endif
          endif
 #endif
       endif ! end for rof coupler set up 

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -1204,7 +1204,7 @@ contains
             ! this is hard to digest :(
             tagname = 'lat:lon:area:frac:mask'//C_NULL_CHAR
             call component_exch_moab(comp, mphaid, mbaxid, 0, tagname, context_exch='dom')
-
+           
          endif ! coupler pes
 
 #ifdef MOABDEBUG

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -1928,12 +1928,13 @@ subroutine  copy_aream_from_area(mbappid)
     else
        dir = 'x2c'
     endif
+    write(lnum,"(I0.2)") num_moab_exports
     if (seq_comm_iamroot(CPLID) ) then
-       write(logunit,'(A)') subname//' '//comp%ntype//' called in direction '//trim(dir)//' for fields '//trim(tagname)
+       write(logunit,'(A)') subname//' '//comp%ntype//' at moab count '//lnum//' called in direction '//trim(dir)//' for fields '//trim(tagname)
     endif
     if (mbAPPid2 .ge. 0 ) then !  we are on receiving pes, for sure
       ! number_proj = number_proj+1 ! count the number of projections
-      write(lnum,"(I0.2)") num_moab_exports
+      
       if (present(context_exch)) then
          outfile = comp%ntype//'_'//trim(context_exch)//'_'//trim(dir)//'_'//trim(lnum)//'.h5m'//C_NULL_CHAR
       else

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -60,6 +60,7 @@ module cplcomp_exchange_mod
   private :: seq_mctext_gsmapCreate
   private :: seq_mctext_avCreate
 
+  private :: copy_aream_from_area
   !--------------------------------------------------------------------------
   ! Public data
   !--------------------------------------------------------------------------
@@ -981,7 +982,34 @@ contains
 
   end function seq_mctext_gsmapIdentical
 
+subroutine  copy_aream_from_area(mbappid)
+
+      ! maybe we will move this from here
+      use iMOAB, only: iMOAB_GetDoubleTagStorage, iMOAB_SetDoubleTagStorage, iMOAB_GetMeshInfo
+
+      integer ,  intent(in) :: mbappid
+      character(CXX)           :: tagname
+      integer                  nvert(3), nvise(3), nbl(3), nsurf(3), nvisBC(3)
+      real(r8),    allocatable    :: tagValues(:) ! used for setting aream tags for atm domain read case
+      integer                     :: arrSize ! for the size of tagValues
+      integer :: ierr, ent_type
+
+      ! copy aream from area
+      if (mbappid >= 0) then  ! coupler atm procs
+         ierr  = iMOAB_GetMeshInfo ( mbappid, nvert, nvise, nbl, nsurf, nvisBC )
+         arrSize  = nvise(1) ! cells
+         allocate(tagValues(arrSize))
+         tagname = 'area'//C_NULL_CHAR
+         ent_type = 1 ! cells
+         ierr  = iMOAB_GetDoubleTagStorage( mbappid, tagname, arrsize , ent_type, tagValues )
+         tagname = 'aream'//C_NULL_CHAR
+         ierr  = iMOAB_SetDoubleTagStorage( mbappid, tagname, arrsize , ent_type, tagValues )
+         deallocate(tagValues)
+      endif
+
+      return
   !=======================================================================
+ end subroutine copy_aream_from_area
 
    subroutine cplcomp_moab_Init(infodata,comp)
 
@@ -1029,6 +1057,8 @@ contains
                                                             ! and atm spectral on coupler
       character(CXX)           :: tagname
       integer                  nvert(3), nvise(3), nbl(3), nsurf(3), nvisBC(3)
+      real(r8),    allocatable    :: tagValues(:) ! used for setting aream tags for atm domain read case
+      integer                     :: arrSize ! for the size of tagValues
       ! type(mct_list)           :: temp_list
       ! integer                  :: nfields, arrsize
       ! real(R8), allocatable, target :: values(:)
@@ -1204,7 +1234,8 @@ contains
             ! this is hard to digest :(
             tagname = 'lat:lon:area:frac:mask'//C_NULL_CHAR
             call component_exch_moab(comp, mphaid, mbaxid, 0, tagname, context_exch='dom')
-           
+            ! copy aream from area in case atm_mesh
+            call copy_aream_from_area(mbaxid)
          endif ! coupler pes
 
 #ifdef MOABDEBUG
@@ -1786,15 +1817,9 @@ contains
 
          tagname = 'area:lon:lat:frac:mask'//C_NULL_CHAR
          call component_exch_moab(comp, mrofid, mbrxid, 0, tagname)
-
-         ! if (mrofid .ge. 0) then  ! we are on component rof  pes
-         !    context_id = id_join
-         !    ierr = iMOAB_FreeSenderBuffers(mrofid, context_id)
-         !    if (ierr .ne. 0) then
-         !    write(logunit,*) subname,' error in freeing buffers '
-         !    call shr_sys_abort(subname//' ERROR in freeing buffers ')
-         !    endif
-         ! endif
+         ! copy aream from area in all cases
+         ! initialize aream from area; it may have different values in the end, or reset again
+         call copy_aream_from_area(mbrxid)
 #ifdef MOABDEBUG
          outfile = 'recMeshRof.h5m'//C_NULL_CHAR
          wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
@@ -1910,7 +1935,7 @@ contains
       ! number_proj = number_proj+1 ! count the number of projections
       write(lnum,"(I0.2)") num_moab_exports
       if (present(context_exch)) then
-         outfile = comp%ntype//trim(context_exch)//'_'//trim(dir)//'_'//trim(lnum)//'.h5m'//C_NULL_CHAR
+         outfile = comp%ntype//'_'//trim(context_exch)//'_'//trim(dir)//'_'//trim(lnum)//'.h5m'//C_NULL_CHAR
       else
          outfile = comp%ntype//'_'//trim(dir)//'_'//trim(lnum)//'.h5m'//C_NULL_CHAR
       endif

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -1912,7 +1912,7 @@ contains
       if (present(context_exch)) then
          outfile = comp%ntype//trim(context_exch)//'_'//trim(dir)//'_'//trim(lnum)//'.h5m'//C_NULL_CHAR
       else
-         outfile = comp%ntype//trim(dir)//'_'//trim(lnum)//'.h5m'//C_NULL_CHAR
+         outfile = comp%ntype//'_'//trim(dir)//'_'//trim(lnum)//'.h5m'//C_NULL_CHAR
       endif
       wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
       ierr = iMOAB_WriteMesh(mbAPPid2, trim(outfile), trim(wopts))

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -1044,7 +1044,7 @@ subroutine  copy_aream_from_area(mbappid)
       integer                  :: mpigrp_cplid ! coupler pes
       integer                  :: mpigrp_old   !  component group pes
       integer                  :: ierr, context_id
-      character*200            :: appname, outfile, wopts, ropts
+      character*200            :: appname, outfile, wopts, ropts, infile
       character(CL)            :: rtm_mesh, rof_domain
       character(CL)            :: lnd_domain
       character(CL)            :: ocn_domain
@@ -1143,14 +1143,16 @@ subroutine  copy_aream_from_area(mbappid)
                endif
             else   ! data atm
               ! we need to read the atm mesh on coupler, from domain file 
-               ierr = iMOAB_LoadMesh(mbaxid, trim(atm_mesh)//C_NULL_CHAR, &
-                "PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION;NO_CULLING", 0)
+               infile = trim(atm_mesh)//C_NULL_CHAR
+               ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION;NO_CULLING'//C_NULL_CHAR
+               if (seq_comm_iamroot(CPLID)) then
+                  write(logunit,'(A)') subname//' loading atm domain mesh from file '//trim(atm_mesh) &
+                   , ' with options ' // trim(ropts)
+               endif
+               ierr = iMOAB_LoadMesh(mbaxid, infile, ropts, 0)
                if ( ierr /= 0 ) then
                   write(logunit,*) 'Failed to load atm domain mesh on coupler'
                   call shr_sys_abort(subname//' ERROR Failed to load atm domain mesh on coupler  ')
-               endif
-               if (seq_comm_iamroot(CPLID)) then
-                  write(logunit,'(A)') subname//' load atm domain mesh from file '//trim(atm_mesh)
                endif
                ! right now, turn atm_pg_active to true
                atm_pg_active = .true. ! FIXME TODO 
@@ -1316,11 +1318,13 @@ subroutine  copy_aream_from_area(mbappid)
                endif
             else
               ! we need to read the ocean mesh on coupler, from domain file 
+               infile = trim(ocn_domain)//C_NULL_CHAR
+               ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION'//C_NULL_CHAR
                if (seq_comm_iamroot(CPLID)) then
-                  write(logunit,'(A)') subname//' loading ocn domain mesh from file '//trim(ocn_domain)
+                  write(logunit,'(A)') subname//' loading ocn domain mesh from file '//trim(infile) &
+                   , ' with options ' // trim(ropts)
                endif
-               ierr = iMOAB_LoadMesh(mboxid, trim(ocn_domain)//C_NULL_CHAR, &
-                "PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION", 0)
+               ierr = iMOAB_LoadMesh(mboxid, infile, ropts, 0)
                if ( ierr /= 0 ) then
                   write(logunit,*) 'Failed to load ocean domain mesh on coupler'
                   call shr_sys_abort(subname//' ERROR Failed to load ocean domain mesh on coupler  ')
@@ -1430,14 +1434,16 @@ subroutine  copy_aream_from_area(mbappid)
                endif
             else
                 ! we need to read the ocean mesh on coupler, from domain file 
-               ierr = iMOAB_LoadMesh(mbofxid, trim(ocn_domain)//C_NULL_CHAR, &
-                "PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION", 0)
+               infile = trim(ocn_domain)//C_NULL_CHAR
+               ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION'//C_NULL_CHAR
+               if (seq_comm_iamroot(CPLID)) then
+                  write(logunit,'(A)') subname//' load ocn domain mesh from file for second ocn instance '//trim(ocn_domain) &
+                  , ' with options '//trim(ropts)
+               endif
+               ierr = iMOAB_LoadMesh(mbofxid, infile, ropts, 0)
                if ( ierr /= 0 ) then
                   write(logunit,*) 'Failed to load second ocean domain mesh on coupler'
                   call shr_sys_abort(subname//' ERROR Failed to load second ocean domain mesh on coupler  ')
-               endif
-               if (seq_comm_iamroot(CPLID)) then
-                  write(logunit,'(A)') subname//' load ocn domain mesh from file for second ocn instance '//trim(ocn_domain)
                endif
                ! need to add global id tag to the app, it will be used in restart
                tagtype = 0  ! dense, integer
@@ -1507,16 +1513,13 @@ subroutine  copy_aream_from_area(mbappid)
             outfile = trim(lnd_domain)//C_NULL_CHAR
             nghlay = 0 ! no ghost layers 
             if (seq_comm_iamroot(CPLID) ) then
-               write(logunit, *) "load land domain file from file: ", trim(lnd_domain), &
+               write(logunit, *) "loading land domain file from file: ", trim(lnd_domain), &
                  " with options: ", trim(ropts)
             endif
             ierr = iMOAB_LoadMesh(mblxid, outfile, ropts, nghlay)
             if (ierr .ne. 0) then
                write(logunit,*) subname,' error in reading land coupler mesh from ', trim(lnd_domain)
                call shr_sys_abort(subname//' ERROR in reading land coupler mesh')
-            endif
-            if (seq_comm_iamroot(CPLID)) then
-               write(logunit,'(A)') subname//' load lnd domain mesh from file '//trim(lnd_domain)
             endif
             ! need to add global id tag to the app, it will be used in restart
             tagtype = 0  ! dense, integer
@@ -1635,14 +1638,16 @@ subroutine  copy_aream_from_area(mbappid)
                endif
             else
                ! we need to read the mesh ice (domain file) 
-               ierr = iMOAB_LoadMesh(mbixid, trim(ice_domain)//C_NULL_CHAR, &
-                "PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION", 0)
+               ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION'//C_NULL_CHAR
+               infile = trim(ice_domain)//C_NULL_CHAR
+               if (seq_comm_iamroot(CPLID)) then
+                  write(logunit,'(A)') subname//' loading ice domain mesh from file '//infile &
+                    , ' with options '//trim(ropts)
+               endif
+               ierr = iMOAB_LoadMesh(mbixid, infile, ropts, 0)
                if ( ierr /= 0 ) then
                   write(logunit,*) 'Failed to load ice domain mesh on coupler'
                   call shr_sys_abort(subname//' ERROR Failed to load ice domain mesh on coupler  ')
-               endif
-               if (seq_comm_iamroot(CPLID)) then
-                  write(logunit,'(A)') subname//' load ice domain mesh from file '//trim(ice_domain)
                endif
                ! need to add global id tag to the app, it will be used in restart
                tagtype = 0  ! dense, integer
@@ -1747,7 +1752,7 @@ subroutine  copy_aream_from_area(mbappid)
             appname = "COUPLE_MROF"//C_NULL_CHAR
             ierr = iMOAB_RegisterApplication(trim(appname), mpicom_new, id_join, mbrxid)
 
-            ! load mesh from scrip file passed from river model
+            ! load mesh from scrip file passed from river model, if domain file is not available
             call seq_infodata_GetData(infodata,rof_mesh=rtm_mesh,rof_domain=rof_domain)
             if ( trim(rof_domain) == 'none' ) then
                outfile = trim(rtm_mesh)//C_NULL_CHAR
@@ -1757,14 +1762,14 @@ subroutine  copy_aream_from_area(mbappid)
                ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION'//C_NULL_CHAR
             endif
             nghlay = 0 ! no ghost layers 
-            ierr = iMOAB_LoadMesh(mbrxid, outfile, ropts, nghlay)
             if (seq_comm_iamroot(CPLID)) then
-               write(logunit,'(A)') subname//' load rof from file '//trim(outfile)
+               write(logunit,'(A)') subname//' loading rof from file '//trim(outfile) &
+                  , ' with options ', trim(ropts)
             endif
+            ierr = iMOAB_LoadMesh(mbrxid, outfile, ropts, nghlay)
             if ( ierr .ne. 0  ) then
                call shr_sys_abort( subname//' ERROR: cannot read rof mesh on coupler' )
             end if
-            
              ! need to add global id tag to the app, it will be used in restart
             tagtype = 0  ! dense, integer
             numco = 1
@@ -1930,7 +1935,7 @@ subroutine  copy_aream_from_area(mbappid)
     endif
     write(lnum,"(I0.2)") num_moab_exports
     if (seq_comm_iamroot(CPLID) ) then
-       write(logunit,'(A)') subname//' '//comp%ntype//' at moab count '//lnum//' called in direction '//trim(dir)//' for fields '//trim(tagname)
+       write(logunit,'(A)') subname//' '//comp%ntype//' at moab count '//trim(lnum)//' called in direction '//trim(dir)//' for fields '//trim(tagname)
     endif
     if (mbAPPid2 .ge. 0 ) then !  we are on receiving pes, for sure
       ! number_proj = number_proj+1 ! count the number of projections

--- a/driver-moab/main/prep_lnd_mod.F90
+++ b/driver-moab/main/prep_lnd_mod.F90
@@ -36,8 +36,8 @@ module prep_lnd_mod
 #ifdef  HAVE_MOAB
   use iMOAB , only: iMOAB_ComputeCommGraph, iMOAB_ComputeMeshIntersectionOnSphere, &
     iMOAB_ComputeScalarProjectionWeights, iMOAB_DefineTagStorage, iMOAB_RegisterApplication, &
-    iMOAB_WriteMesh, iMOAB_GetMeshInfo, iMOAB_SetDoubleTagStorage, iMOAB_ComputeCoverageMesh, &
-    iMOAB_SetMapGhostLayers
+    iMOAB_WriteMesh, iMOAB_GetMeshInfo, iMOAB_SetDoubleTagStorage, &
+    iMOAB_SetMapGhostLayers, iMOAB_MigrateMapMesh
   use seq_comm_mct,     only : num_moab_exports
 #endif
 
@@ -254,12 +254,12 @@ contains
               write(logunit,*) subname,' error in registering  rof lnd intx'
               call shr_sys_abort(subname//' ERROR in registering rof lnd intx')
             endif
+            call seq_comm_getData(CPLID ,mpigrp=mpigrp_CPLID)
             if (samegrid_lr) then
                ! the same mesh , lnd and rof use the same dofs, but restricted
                ! we do not compute intersection, so we will have to just send data from lnd to rof and viceversa, by GLOBAL_ID matching
                ! so we compute just a comm graph, between lnd and rof dofs, on the coupler; target is rof
                ! land is full mesh
-               call seq_comm_getData(CPLID ,mpigrp=mpigrp_CPLID)
                type1 = 3; !  full mesh for lrofarnd now
                type2 = 3;  ! fv for target land
                ierr = iMOAB_ComputeCommGraph( mbrxid, mblxid, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type1, type2, &
@@ -281,15 +281,6 @@ contains
                mapper_Fr2l%src_context = rof(1)%cplcompid
                mapper_Fr2l%intx_context = lnd(1)%cplcompid
             else
-
-               ! compute the ROF coverage mesh here on coupler pes
-               ! ROF mesh was redistributed to cover target (LND) partition
-               ierr = iMOAB_ComputeCoverageMesh( mbrxid, mblxid, mbintxrl )
-               if (ierr .ne. 0) then
-                  write(logunit,*) subname,' cannot compute source ROF coverage mesh for LND'
-                  call shr_sys_abort(subname//' ERROR in computing ROF-LND coverage')
-               endif
-
               if (compute_maps_online_r2l) then
                   ierr =  iMOAB_ComputeMeshIntersectionOnSphere( mbrxid, mblxid, mbintxrl )
                   if (ierr .ne. 0) then
@@ -300,30 +291,29 @@ contains
                     write(logunit,*) 'iMOAB intersection between  rof and lnd with id:', idintx
                   end if
 #ifdef MOABDEBUG
-              wopts = C_NULL_CHAR
-              call shr_mpi_commrank( mpicom_CPLID, rank )
-              if (rank .lt. 5) then
-                write(lnum,"(I0.2)")rank !
-                outfile = 'intx_rl_'//trim(lnum)// '.h5m' // C_NULL_CHAR
-                ierr = iMOAB_WriteMesh(mbintxrl, outfile, wopts) ! write local intx file
-                if (ierr .ne. 0) then
-                  write(logunit,*) subname,' error in writing intx rl file '
-                  call shr_sys_abort(subname//' ERROR in writing intx rl file ')
-                endif
-              endif
+                  wopts = C_NULL_CHAR
+                  call shr_mpi_commrank( mpicom_CPLID, rank )
+                  if (rank .lt. 5) then
+                    write(lnum,"(I0.2)")rank !
+                    outfile = 'intx_rl_'//trim(lnum)// '.h5m' // C_NULL_CHAR
+                    ierr = iMOAB_WriteMesh(mbintxrl, outfile, wopts) ! write local intx file
+                    if (ierr .ne. 0) then
+                      write(logunit,*) subname,' error in writing intx rl file '
+                      call shr_sys_abort(subname//' ERROR in writing intx rl file ')
+                    endif
+                  endif
 #endif
-              endif
+                 ! we also need to compute the comm graph for the second hop, from the rof on coupler to the
+                 ! rof for the intx rof-lnd context (coverage)
 
-              ! we also need to compute the comm graph for the second hop, from the rof on coupler to the
-              ! rof for the intx rof-lnd context (coverage)
-              call seq_comm_getData(CPLID ,mpigrp=mpigrp_CPLID)
-              type1 = 3 ! land is FV now on coupler side
-              type2 = 3;
-              ierr = iMOAB_ComputeCommGraph( mbrxid, mbintxrl, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type1, type2, &
-                                          rof(1)%cplcompid, idintx)
-              if (ierr .ne. 0) then
-                write(logunit,*) subname,' error in computing comm graph for second hop, lnd-rof'
-                call shr_sys_abort(subname//' ERROR in computing comm graph for second hop, lnd-rof')
+                  type1 = 3 ! land is FV now on coupler side
+                  type2 = 3;
+                  ierr = iMOAB_ComputeCommGraph( mbrxid, mbintxrl, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type1, type2, &
+                                              rof(1)%cplcompid, idintx)
+                  if (ierr .ne. 0) then
+                    write(logunit,*) subname,' error in computing comm graph for second hop, lnd-rof'
+                    call shr_sys_abort(subname//' ERROR in computing comm graph for second hop, lnd-rof')
+                  endif
               endif
               ! now take care of the mapper
               if ( mapper_Fr2l%src_mbid .gt. -1 ) then
@@ -375,10 +365,17 @@ contains
                   endif
               else
                   type1 = 3 ! this is type of grid, maybe should be saved on imoab app ?
-
                   call moab_map_init_rcfile( mbrxid, mblxid, mbintxrl, type1, &
                         'seq_maps.rc', 'rof2lnd_fmapname:', 'rof2lnd_fmaptype:',samegrid_lr, &
                         wgtIdr2l, 'mapper_Fr2l MOAB initialization', esmf_map_flag)
+                  ! need to call migrate map mesh, which will compute the cov mesh and
+                  !  comm graph too for coverage mesh
+                  ierr = iMOAB_MigrateMapMesh (mbrxid, mbintxrl, mpicom_CPLID, mpigrp_CPLID, &
+                     mpigrp_CPLID, type1, rof(1)%cplcompid, idintx)
+                  if (ierr .ne. 0) then
+                     write(logunit,*) subname,' error in migrating rof mesh for map rof c2 lnd '
+                     call shr_sys_abort(subname//' ERROR in migrating rof mesh for map rof c2 lnd')
+                  endif
               endif
 
             endif
@@ -471,26 +468,17 @@ contains
             call seq_comm_getinfo(CPLID ,mpigrp=mpigrp_CPLID)
             if (.not. samegrid_al) then ! tri grid case
 
-               ! for bilinear maps, we need to have a layer of ghosts on source
-               nghlay = 1  ! number of ghost layers
-               nghlay_tgt = 0
-               ierr   = iMOAB_SetMapGhostLayers( mbintxal, nghlay, nghlay_tgt )
-               if (ierr .ne. 0) then
-                  write(logunit,*) subname,' error in setting the number of ghost layers'
-                  call shr_sys_abort(subname//' error in setting the number of ghost layers')
-               endif
-
-               ! compute the ATM coverage mesh here on coupler pes
-               ! ATM mesh was redistributed to cover target (LND) partition
-               ierr = iMOAB_ComputeCoverageMesh( mbaxid, mblxid, mbintxal )
-               if (ierr .ne. 0) then
-                  write(logunit,*) subname,' cannot compute source ATM coverage mesh for LND'
-                  call shr_sys_abort(subname//' ERROR in computing ATM-LND coverage')
-               endif
-
               if (compute_maps_online_a2l) then
                 if (iamroot_CPLID) then
                   write(logunit,*) 'iMOAB intersection between atm and land with id:', idintx
+                endif
+                ! for bilinear maps, we need to have a layer of ghosts on source
+                nghlay = 1  ! number of ghost layers
+                nghlay_tgt = 0
+                ierr   = iMOAB_SetMapGhostLayers( mbintxal, nghlay, nghlay_tgt )
+                if (ierr .ne. 0) then
+                  write(logunit,*) subname,' error in setting the number of ghost layers'
+                  call shr_sys_abort(subname//' error in setting the number of ghost layers')
                 endif
                 ierr =  iMOAB_ComputeMeshIntersectionOnSphere( mbaxid, mblxid, mbintxal )
                 if (ierr .ne. 0) then
@@ -511,23 +499,24 @@ contains
                   endif
                 endif
 #endif
-              endif
-              ! we also need to compute the comm graph for the second hop, from the atm on coupler to the
-              ! lnd for the intx atm-lnd context (coverage)
-              !
-              if (atm_pg_active) then
-                type1 = 3; !  fv for atm; cgll does not work anyway
-              else
-                type1 = 1 ! this projection works (cgll to fv), but reverse does not ( fv - cgll)
-              endif
-              type2 = 3; ! land is fv in this case (separate grid)
+                ! we also need to compute the comm graph for the second hop, from the atm on coupler to the
+                ! lnd for the intx atm-lnd context (coverage)
+                !
+                if (atm_pg_active) then
+                  type1 = 3; !  fv for atm; cgll does not work anyway
+                else
+                  type1 = 1 ! this projection works (cgll to fv), but reverse does not ( fv - cgll)
+                endif
+                type2 = 3; ! land is fv in this case (separate grid)
 
-              ierr = iMOAB_ComputeCommGraph( mbaxid, mbintxal, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type1, type2, &
-                                        atm(1)%cplcompid, idintx)
-              if (ierr .ne. 0) then
-                write(logunit,*) subname,' error in computing comm graph for second hop, atm-lnd'
-                call shr_sys_abort(subname//' ERROR in computing comm graph for second hop, atm-lnd')
+                ierr = iMOAB_ComputeCommGraph( mbaxid, mbintxal, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type1, type2, &
+                                          atm(1)%cplcompid, idintx)
+                if (ierr .ne. 0) then
+                  write(logunit,*) subname,' error in computing comm graph for second hop, atm-lnd'
+                  call shr_sys_abort(subname//' ERROR in computing comm graph for second hop, atm-lnd')
+                endif
               endif
+
 
               if (compute_maps_online_a2l) then
                   volumetric = 0 ! can be 1 only for FV->DGLL or FV->CGLL;
@@ -584,11 +573,22 @@ contains
                         'seq_maps.rc', 'atm2lnd_smapname:', 'atm2lnd_smaptype:',samegrid_al, &
                         wgtIda2l_bilinear, 'mapper_Sa2l MOAB initialization', esmf_map_flag)
 
+                  ! TODO make sure it is good enough
+                  ! we are using the same coverage for 2 maps , one bilinear, one conservative
                   ! read as the second one the f map, this one has the aream for land correct, so it should be fine
                   ! the area_b for the bilinear map above is 0 ! which caused grief
                   call moab_map_init_rcfile( mbaxid, mblxid, mbintxal, type1, &
                         'seq_maps.rc', 'atm2lnd_fmapname:', 'atm2lnd_fmaptype:',samegrid_al, &
                         wgtIda2l_conservative, 'mapper_Fa2l MOAB initialization', esmf_map_flag)
+                  ! we need to do only one map migrate, should over both maps!!
+                  ! we have one coverage for both maps!
+                  ierr = iMOAB_MigrateMapMesh (mbaxid, mbintxal, mpicom_CPLID, mpigrp_CPLID, &
+                     mpigrp_CPLID, type1, atm(1)%cplcompid, idintx)
+                  if (ierr .ne. 0) then
+                     write(logunit,*) subname,' error in migrating atm mesh for map atm c2 lnd '
+                     call shr_sys_abort(subname//' ERROR in migrating atm mesh for map rof c2 lnd')
+                  endif
+
               endif
 
             else

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -14,7 +14,7 @@ module prep_ocn_mod
 
   use seq_comm_mct,     only: mboxid ! iMOAB id for mpas ocean migrated mesh to coupler pes
 !   use seq_comm_mct,     only: mbrmapro ! iMOAB id for map read from rof2ocn map file
-!   use seq_comm_mct,     only: mbrxoid ! iMOAB id for rof on coupler in ocean context;
+  use seq_comm_mct,     only: mbrxoid ! iMOAB id for rof on coupler in ocean context;
   use seq_comm_mct,     only: mbrxid   ! iMOAB id of moab rof migrated to couple pes
   use seq_comm_mct,     only: mbintxro ! iMOAB id for map read from rof2ocn map file
   use seq_comm_mct,     only : atm_pg_active  ! whether the atm uses FV mesh or not ; made true if fv_nphys > 0
@@ -752,23 +752,23 @@ contains
           ! this is a special rof mesh redistribution, for the ocean context
           ! it will be used to project from rof to ocean
           ! the mesh will be migrated, to be able to do the second hop
-         !  appname = "ROF_OCOU"//C_NULL_CHAR
-         !  ! rmapid  is a unique external number of MOAB app that identifies runoff on coupler side
-         !  rmapid2 = 100*rof(1)%cplcompid ! this is a special case, because we also have a regular coupler instance mbrxid
-         !  ierr = iMOAB_RegisterApplication(trim(appname), mpicom_CPLID, rmapid2, mbrxoid)
-         !  if (ierr .ne. 0) then
-         !     write(logunit,*) subname,' error in registering rof on coupler in ocean context '
-         !     call shr_sys_abort(subname//' ERROR in registering  rof on coupler in ocean context ')
-         !  endif
+          appname = "ROF_OCOU"//C_NULL_CHAR
+          ! rmapid  is a unique external number of MOAB app that identifies runoff on coupler side
+          rmapid2 = 100*rof(1)%cplcompid ! this is a special case, because we also have a regular coupler instance mbrxid
+          ierr = iMOAB_RegisterApplication(trim(appname), mpicom_CPLID, rmapid2, mbrxoid)
+          if (ierr .ne. 0) then
+             write(logunit,*) subname,' error in registering rof on coupler in ocean context '
+             call shr_sys_abort(subname//' ERROR in registering  rof on coupler in ocean context ')
+          endif
           ! this code was moved from prep_rof_ocn_moab, because we will do everything on coupler side, not
           ! needed to be on joint comm anymore for the second hop
 
           ! need to compute coverage of rof over ocean, and comm graph for sending from rof to rof over ocean
-          ierr = iMOAB_ComputeCoverageMesh( mbrxid, mboxid, mbintxro )
-          if (ierr .ne. 0) then
-              write(logunit,*) subname,' error in compute coverage mesh rof for ocean'
-              call shr_sys_abort(subname//' ERROR in compute coverage mesh rof for ocean ')
-          endif
+         !  ierr = iMOAB_ComputeCoverageMesh( mbrxid, mboxid, mbintxro )
+         !  if (ierr .ne. 0) then
+         !      write(logunit,*) subname,' error in compute coverage mesh rof for ocean'
+         !      call shr_sys_abort(subname//' ERROR in compute coverage mesh rof for ocean ')
+         !  endif
           if (iamroot_CPLID) then
              write(logunit,*) ' '
              write(logunit,F00) 'Initializing MOAB mapper_Rr2o_liq'
@@ -779,12 +779,12 @@ contains
                'seq_maps.rc', 'rof2ocn_liq_rmapname:', 'rof2ocn_liq_rmaptype:',samegrid_ro, &
                wgtIdr2o_conservative, 'mapper_Rr2o_liq moab initialization',esmf_map_flag)
 
-          ierr = iMOAB_ComputeCommGraph( mbrxid, mbintxro, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type_grid, &
-             type_grid, rof(1)%cplcompid, rmapid )
-          if (ierr .ne. 0) then
-              write(logunit,*) subname,' error in compute graph rof - rof cov for ocean'
-              call shr_sys_abort(subname//' ERROR in compute graph rof - rof cov for ocean ')
-         endif
+         !  ierr = iMOAB_ComputeCommGraph( mbrxid, mbintxro, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type_grid, &
+         !     type_grid, rof(1)%cplcompid, rmapid )
+         !  if (ierr .ne. 0) then
+         !      write(logunit,*) subname,' error in compute graph rof - rof cov for ocean'
+         !      call shr_sys_abort(subname//' ERROR in compute graph rof - rof cov for ocean ')
+         ! endif
          !  it read on the coupler side, from file, the scrip mosart, that has a full mesh;
          !  also migrate rof mesh on coupler pes, in ocean context, mbrxoid (this will be like coverage mesh,
          !    it will cover ocean target per process)
@@ -792,26 +792,26 @@ contains
          ! after this, the sending of tags for second hop (ocn context) will use the new par comm graph,
          !  that has more precise info, that got created
 
-         ! type1 = 3 ! fv mesh nowadays
-         ! direction = 1 !
-         ! context_id = ocn(1)%cplcompid
+         type1 = 3 ! fv mesh nowadays
+         direction = 1 !
+         context_id = ocn(1)%cplcompid
          ! this creates a par comm graph between mbrxid and mbrxoid, with ids rof(1)%cplcompid, context ocn(1)%cplcompid
          ! this will be used in send/receive mappers
-         ! ierr = iMOAB_MigrateMapMesh (mbrxid, mbrmapro, mbrxoid, mpicom_CPLID, mpigrp_CPLID, &
-         !    mpigrp_CPLID, type1, rof(1)%cplcompid, context_id, direction)
+         ierr = iMOAB_MigrateMapMesh (mbrxid, mbintxro, mbrxoid, mpicom_CPLID, mpigrp_CPLID, &
+            mpigrp_CPLID, type1, rof(1)%cplcompid, context_id, direction)
 
-         ! if (ierr .ne. 0) then
-         !    write(logunit,*) subname,' error in migrating rof mesh for map rof c2 ocn '
-         !    call shr_sys_abort(subname//' ERROR in migrating rof mesh for map rof c2 ocn ')
-         ! endif
+         if (ierr .ne. 0) then
+            write(logunit,*) subname,' error in migrating rof mesh for map rof c2 ocn '
+            call shr_sys_abort(subname//' ERROR in migrating rof mesh for map rof c2 ocn ')
+         endif
          ! if (iamroot_CPLID)  then
          !    write(logunit,*) subname,' migrated mesh for map rof 2 ocn '
          ! endif
-         if (mbrxid .ge. 0) then ! we are on coupler side pes
+         if (mbrxoid .ge. 0) then ! we are on coupler side pes
             tagname=trim(seq_flds_r2x_fields)//C_NULL_CHAR
             tagtype = 1 ! dense, double
             numco = 1 ! only 1 component DoF per node
-            ierr = iMOAB_DefineTagStorage(mbrxid, tagname, tagtype, numco,  tagindex )
+            ierr = iMOAB_DefineTagStorage(mbrxoid, tagname, tagtype, numco,  tagindex )
             if (ierr .ne. 0) then
                write(logunit,*) subname,' error in defining ' // trim(seq_flds_r2x_fields) // ' tags on coupler side in MOAB'
                call shr_sys_abort(subname//' ERROR in defining MOAB tags ')
@@ -856,11 +856,11 @@ contains
 
          ! now we have to populate the map with the right moab attributes, so that it does the right projection
 #ifdef MOABDEBUG
-         if (mbrxid.ge.0) then  ! we are on coupler PEs
+         if (mbrxoid.ge.0) then  ! we are on coupler PEs
             call mpi_comm_rank(mpicom_CPLID, rank_on_cpl  , ierr)
             if (rank_on_cpl .lt. 4) then
                prefix_output = "rof_cov"//CHAR(0)
-               ierr = iMOAB_WriteLocalMesh(mbrxid, prefix_output)
+               ierr = iMOAB_WriteLocalMesh(mbrxoid, prefix_output)
                if (ierr .ne. 0) then
                   write(logunit,*) subname,' error in writing coverage mesh rof 2 ocn '
                endif

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -2943,7 +2943,14 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
     type(mct_avect), pointer :: r2x_rx
     character(*), parameter  :: subname = '(prep_ocn_calc_r2x_ox)'
     !---------------------------------------------------------------
-
+#ifdef MOABDEBUG
+   if (mboxid .ge. 0 ) then !  we are on coupler pes, for sure
+      write(lnum,"(I0.2)")num_moab_exports
+      outfile = 'OcnCpl_Bef_r2x_ox_'//trim(lnum)//'.h5m'//C_NULL_CHAR
+      wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR
+      ierr = iMOAB_WriteMesh(mboxid, trim(outfile), trim(wopts))
+   endif
+#endif
     call t_drvstartf (trim(timer),barrier=mpicom_CPLID)
     do eri = 1,num_inst_rof
        r2x_rx => component_get_c2x_cx(rof(eri))
@@ -2960,7 +2967,7 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
 #ifdef MOABDEBUG
    if (mboxid .ge. 0 ) then !  we are on coupler pes, for sure
       write(lnum,"(I0.2)")num_moab_exports
-      outfile = 'OcnCpl_r2x_ox'//trim(lnum)//'.h5m'//C_NULL_CHAR
+      outfile = 'OcnCpl_r2x_ox_'//trim(lnum)//'.h5m'//C_NULL_CHAR
       wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR
       ierr = iMOAB_WriteMesh(mboxid, trim(outfile), trim(wopts))
    endif

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -794,7 +794,7 @@ contains
 
          type1 = 3 ! fv mesh nowadays
          direction = 1 !
-         context_id = ocn(1)%cplcompid
+         context_id = rmapid ! ocn(1)%cplcompid
          ! this creates a par comm graph between mbrxid and mbrxoid, with ids rof(1)%cplcompid, context ocn(1)%cplcompid
          ! this will be used in send/receive mappers
          ierr = iMOAB_MigrateMapMesh (mbrxid, mbintxro, mbrxoid, mpicom_CPLID, mpigrp_CPLID, &

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -2957,6 +2957,14 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
        endif
     enddo
     call t_drvstopf  (trim(timer))
+#ifdef MOABDEBUG
+   if (mboxid .ge. 0 ) then !  we are on coupler pes, for sure
+      write(lnum,"(I0.2)")num_moab_exports
+      outfile = 'OcnCpl_r2x_ox'//trim(lnum)//'.h5m'//C_NULL_CHAR
+      wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR
+      ierr = iMOAB_WriteMesh(mboxid, trim(outfile), trim(wopts))
+   endif
+#endif
 
   end subroutine prep_ocn_calc_r2x_ox
 

--- a/driver-moab/main/seq_flux_mct.F90
+++ b/driver-moab/main/seq_flux_mct.F90
@@ -191,6 +191,7 @@ module seq_flux_mct
   integer :: index_xao_So_ssq
   integer :: index_xao_So_duu10n
   integer :: index_xao_So_u10
+  integer :: index_xao_So_u10withgusts
   integer :: index_xao_So_fswpen
   integer :: index_xao_So_warm_diurn
   integer :: index_xao_So_salt_diurn
@@ -1510,6 +1511,7 @@ contains
        index_xao_So_re     = mct_aVect_indexRA(xao,'So_re')
        index_xao_So_ssq    = mct_aVect_indexRA(xao,'So_ssq')
        index_xao_So_u10    = mct_aVect_indexRA(xao,'So_u10')
+       index_xao_So_u10withgusts = mct_aVect_indexRA(xao,'So_u10withgusts')
        index_xao_So_duu10n = mct_aVect_indexRA(xao,'So_duu10n')
        index_xao_Faox_taux = mct_aVect_indexRA(xao,'Faox_taux')
        index_xao_Faox_tauy = mct_aVect_indexRA(xao,'Faox_tauy')
@@ -1787,6 +1789,7 @@ contains
           xao%rAttr(index_xao_Faox_lwup,n) = lwup(n)
           xao%rAttr(index_xao_So_duu10n,n) = duu10n(n)
           xao%rAttr(index_xao_So_u10   ,n) = sqrt(duu10n(n))
+          xao%rAttr(index_xao_So_u10withgusts,n) = sqrt(duu10n(n))
           xao%rAttr(index_xao_So_warm_diurn       ,n) = warm(n)
           xao%rAttr(index_xao_So_salt_diurn       ,n) = salt(n)
           xao%rAttr(index_xao_So_speed_diurn      ,n) = speed(n)

--- a/driver-moab/main/seq_frac_mct.F90
+++ b/driver-moab/main/seq_frac_mct.F90
@@ -288,6 +288,7 @@ contains
     !----- local -----
     type(mct_ggrid), pointer    :: dom_a
     type(mct_gsmap), pointer    :: gsmap_a ! see if we can get from here the global ids (missing from dom_a)
+    type(mct_gsmap), pointer    :: gsmap_l
     type(mct_gsmap), pointer    :: gsmap_r 
     type(mct_gsmap), pointer    :: gsmap_i ! ofrac on ice error 
     type(mct_ggrid), pointer    :: dom_i
@@ -475,13 +476,13 @@ contains
          tagname = 'lfrin'//C_NULL_CHAR ! 'lfrin'
          allocate(tagValues(lSize) )
          tagValues = dom_l%data%rAttr(kf,:)
-         kgg = mct_aVect_indexIA(dom_l%data ,"GlobGridNum" ,perrWith=subName)
+         !kgg = mct_aVect_indexIA(dom_l%data ,"GlobGridNum" ,perrWith=subName)
          !allocate(GlobalIds(lSize))
          !GlobalIds = dom_l%data%iAttr(kgg,:)
-         gsmap_a  => component_get_gsmap_cx(atm) ! gsmap_ax
+         gsmap_l  => component_get_gsmap_cx(lnd) ! gsmap_lx
          call mpi_comm_rank(mpicom,my_task,ierr)
          ! Determine global gridpoint number attribute, GlobGridNum, automatically in ggrid
-         call mct_gsMap_orderedPoints(gsmap_a, my_task, dof)
+         call mct_gsMap_orderedPoints(gsmap_l, my_task, dof)
          ! ent_type should be 3, FV
          ierr = iMOAB_SetDoubleTagStorageWithGid ( mblxid, tagname, lSize , ent_type, tagValues, dof )
          if (ierr .ne. 0) then
@@ -618,6 +619,7 @@ contains
             call shr_sys_abort(subname//' ERROR in setting ofrac on ice ')
          endif
          !deallocate(GlobalIds)
+         deallocate(tagValues)
          deallocate(dof)
        endif
 
@@ -925,7 +927,7 @@ contains
     integer                  :: n
     integer                  :: ki, kl, ko, kf
     real(r8),allocatable :: fcorr(:)
-    integer(IN), pointer :: dof(:)    !
+    integer(IN), pointer, save :: dof(:)    !
 
     logical, save :: first_time = .true.
 ! moab

--- a/driver-moab/main/seq_frac_mct.F90
+++ b/driver-moab/main/seq_frac_mct.F90
@@ -543,7 +543,7 @@ contains
          ! Determine global gridpoint number attribute, GlobGridNum, automatically in ggrid
          call mct_gsMap_orderedPoints(gsmap_r, my_task, dof)
          ! again, we are setting on the river instance that is also used for ocean coupling
-         ierr = iMOAB_SetDoubleTagStorageWithGid ( mbrxid, tagname, lSize , ent_type, tagValues, GlobalIds )
+         ierr = iMOAB_SetDoubleTagStorageWithGid ( mbrxid, tagname, lSize , ent_type, tagValues, dof )
          if (ierr .ne. 0) then
             write(logunit,*) subname,' error in setting rfrac on rof   '
             call shr_sys_abort(subname//' ERROR in setting rfrac on rof ')

--- a/driver-moab/main/seq_frac_mct.F90
+++ b/driver-moab/main/seq_frac_mct.F90
@@ -288,6 +288,7 @@ contains
     !----- local -----
     type(mct_ggrid), pointer    :: dom_a
     type(mct_gsmap), pointer    :: gsmap_a ! see if we can get from here the global ids (missing from dom_a)
+    type(mct_gsmap), pointer    :: gsmap_r 
     type(mct_ggrid), pointer    :: dom_i
     type(mct_ggrid), pointer    :: dom_l
     type(mct_ggrid), pointer    :: dom_o
@@ -534,16 +535,21 @@ contains
          tagname = 'rfrac'//C_NULL_CHAR ! 'rfrac'
          allocate(tagValues(lSize) )
          tagValues = dom_r%data%rAttr(kf,:)
-         kgg = mct_aVect_indexIA(dom_r%data ,"GlobGridNum" ,perrWith=subName)
-         allocate(GlobalIds(lSize))
-         GlobalIds = dom_r%data%iAttr(kgg,:)
+         !kgg = mct_aVect_indexIA(dom_r%data ,"GlobGridNum" ,perrWith=subName)
+         !allocate(GlobalIds(lSize))
+         !GlobalIds = dom_r%data%iAttr(kgg,:)
+         gsmap_r  => component_get_gsmap_cx(rof) ! gsmap_rx
+         call mpi_comm_rank(mpicom,my_task,ierr)
+         ! Determine global gridpoint number attribute, GlobGridNum, automatically in ggrid
+         call mct_gsMap_orderedPoints(gsmap_r, my_task, dof)
          ! again, we are setting on the river instance that is also used for ocean coupling
          ierr = iMOAB_SetDoubleTagStorageWithGid ( mbrxid, tagname, lSize , ent_type, tagValues, GlobalIds )
          if (ierr .ne. 0) then
             write(logunit,*) subname,' error in setting rfrac on rof   '
             call shr_sys_abort(subname//' ERROR in setting rfrac on rof ')
          endif
-         deallocate(GlobalIds)
+         !deallocate(GlobalIds)
+         deallocate(dof)
          deallocate(tagValues)
 
        endif

--- a/driver-moab/main/seq_frac_mct.F90
+++ b/driver-moab/main/seq_frac_mct.F90
@@ -735,16 +735,21 @@ contains
           tagname = 'lfrac'//C_NULL_CHAR ! 'lfrac
           allocate(tagValues(lSize) )
           tagValues = fractions_a%rAttr(kl,:)
-          kgg = mct_aVect_indexIA(dom_a%data ,"GlobGridNum" ,perrWith=subName)
-          allocate(GlobalIds(lSize))
-          GlobalIds = dom_a%data%iAttr(kgg,:)
+          !kgg = mct_aVect_indexIA(dom_a%data ,"GlobGridNum" ,perrWith=subName)
+          !allocate(GlobalIds(lSize))
+          !GlobalIds = dom_a%data%iAttr(kgg,:)
           ! set on atmosphere instance
-          ierr = iMOAB_SetDoubleTagStorageWithGid ( mbaxid, tagname, lSize , ent_type, tagValues, GlobalIds )
+          gsmap_a  => component_get_gsmap_cx(atm) ! gsmap_ax
+          call mpi_comm_rank(mpicom,my_task,ierr)
+            ! Determine global gridpoint number attribute, GlobGridNum, automatically in ggrid
+          call mct_gsMap_orderedPoints(gsmap_a, my_task, dof)
+          ierr = iMOAB_SetDoubleTagStorageWithGid ( mbaxid, tagname, lSize , ent_type, tagValues, dof )
           if (ierr .ne. 0) then
              write(logunit,*) subname,' error in setting lfrac on atm   '
              call shr_sys_abort(subname//' ERROR in setting lfrac on atm ')
           endif
-          deallocate(GlobalIds)
+          !deallocate(GlobalIds)
+          deallocate(dof)
           deallocate(tagValues)
         endif
        else if (lnd_present) then

--- a/driver-moab/main/seq_map_mod.F90
+++ b/driver-moab/main/seq_map_mod.F90
@@ -235,7 +235,7 @@ contains
       call shr_sys_abort(subname//' ERROR in loading map file')
     endif
    if (seq_comm_iamroot(CPLID)) then
-      write(logunit,'(2A,I6,4A)') subname,'Result: iMOAB map app ID, maptype, mapfile = ', &
+      write(logunit,'(2A,I12,4A)') subname,'Result: iMOAB map app ID, maptype, mapfile = ', &
          mbintx,' ',trim(maptype),' ',trim(mapfile), ', identifier: ', trim(sol_identifier)
       call shr_sys_flush(logunit)
    endif

--- a/driver-moab/main/seq_map_mod.F90
+++ b/driver-moab/main/seq_map_mod.F90
@@ -328,6 +328,7 @@ end subroutine moab_map_init_rcfile
     use iMOAB, only: iMOAB_GetMeshInfo, iMOAB_GetDoubleTagStorage, iMOAB_SetDoubleTagStorage, &
       iMOAB_GetIntTagStorage, iMOAB_ApplyScalarProjectionWeights, &
       iMOAB_SendElementTag, iMOAB_ReceiveElementTag, iMOAB_FreeSenderBuffers
+    use seq_comm_mct, only : num_moab_exports
 
     implicit none
     !-----------------------------------------------------
@@ -438,7 +439,7 @@ end subroutine moab_map_init_rcfile
 #ifdef MOABDEBUG
          if (seq_comm_iamroot(CPLID)) then
             write(logunit,*) subname, 'iMOAB mapper ',trim(mapper%mbname), ' iMOAB_mapper  nfields', &
-                  nfields,  ' fldlist_moab=', trim(fldlist_moab)
+                  nfields,  ' fldlist_moab=', trim(fldlist_moab), ' moab step ', num_moab_exports
             call shr_sys_flush(logunit)
          endif
 #endif
@@ -496,7 +497,7 @@ end subroutine moab_map_init_rcfile
 #ifdef MOABDEBUG
          if (seq_comm_iamroot(CPLID)) then
             write(logunit, *) subname,' iMOAB mapper rearrange or copy ', mapper%mbname, ' send/recv tags ', trim(fldlist_moab), &
-              ' mbpresent=', mbpresent, ' mbnorm=', mbnorm
+              ' mbpresent=', mbpresent, ' mbnorm=', mbnorm, ' moab step:', num_moab_exports
             call shr_sys_flush(logunit)
          endif
 #endif
@@ -550,7 +551,8 @@ end subroutine moab_map_init_rcfile
             endif
 #ifdef MOABDEBUG
             if (seq_comm_iamroot(CPLID)) then
-               write(logunit, *) subname,' iMOAB mapper ', mapper%mbname, ' set norm8wt 1  on source with app id: ', mapper%src_mbid
+               write(logunit, *) subname,' iMOAB mapper ', mapper%mbname, ' set norm8wt 1  on source with app id: ', &
+                   mapper%src_mbid, ' moab step:', num_moab_exports
                call shr_sys_flush(logunit)
             endif
 #endif
@@ -584,7 +586,8 @@ end subroutine moab_map_init_rcfile
 #ifdef MOABDEBUG
          if (seq_comm_iamroot(CPLID)) then
             write(logunit, *) subname,' iMOAB projection mapper: ', mapper%mbname, ' normalize nfields=', &
-               nfields, ' arrsize_src on root:', arrsize_src, ' shape(targtags_ini)=', shape(targtags_ini)
+               nfields, ' arrsize_src on root:', arrsize_src, ' shape(targtags_ini)=', shape(targtags_ini), &
+               ' moab step:', num_moab_exports
             call shr_sys_flush(logunit)
          endif
 #endif
@@ -613,7 +616,7 @@ end subroutine moab_map_init_rcfile
 #ifdef MOABDEBUG
          if (seq_comm_iamroot(CPLID)) then
             write(logunit, *) subname,' iMOAB mapper receiving tags with intx and intx_mbid: ', &
-               mapper%mbname, trim(fldlist_moab)
+               mapper%mbname, trim(fldlist_moab), ' moab step:', num_moab_exports
          endif
 #endif
          ierr = iMOAB_ReceiveElementTag( mapper%intx_mbid, fldlist_moab, mapper%mpicom, mapper%src_context )
@@ -634,7 +637,8 @@ end subroutine moab_map_init_rcfile
 
 #ifdef MOABDEBUG
          if (seq_comm_iamroot(CPLID)) then
-            write(logunit, *) subname,' iMOAB projection mapper: ',trim(mapper%mbname), ' between ', mapper%src_mbid, ' and ',  mapper%tgt_mbid, trim(fldlist_moab)
+            write(logunit, *) subname,' iMOAB projection mapper: ',trim(mapper%mbname), ' between ', mapper%src_mbid, ' and ',  mapper%tgt_mbid, trim(fldlist_moab), &
+               ' moab step:', num_moab_exports
             call shr_sys_flush(logunit)
          endif
 #endif

--- a/driver-moab/shr/seq_comm_mct.F90
+++ b/driver-moab/shr/seq_comm_mct.F90
@@ -240,7 +240,7 @@ module seq_comm_mct
   integer, public :: mbrxid   ! iMOAB id of moab rof read from file on coupler pes
 !   integer, public :: mbrmapro ! iMOAB id for read map between river and ocean; it exists on coupler PEs
 !                               ! similar to intx id, oa, la;
-!   integer, public :: mbrxoid  ! iMOAB id for rof migrated to coupler for ocean context (r2o mapping)
+  integer, public :: mbrxoid  ! iMOAB id for rof migrated to coupler for ocean context (r2o mapping)
   integer, public :: mbintxro ! iMOAB id for read map between river and ocean; it exists on coupler PEs
   logical, public :: mbrof_data = .false. ! made true if no rtm mesh, which means data rof ?
   integer, public :: mbintxar ! iMOAB id for intx mesh between atm and river

--- a/driver-moab/shr/seq_comm_mct.F90
+++ b/driver-moab/shr/seq_comm_mct.F90
@@ -238,9 +238,6 @@ module seq_comm_mct
   integer, public :: mbintxia ! iMOAB id for intx mesh between ice and atmosphere
   integer, public :: mrofid   ! iMOAB id of moab rof app
   integer, public :: mbrxid   ! iMOAB id of moab rof read from file on coupler pes
-!   integer, public :: mbrmapro ! iMOAB id for read map between river and ocean; it exists on coupler PEs
-!                               ! similar to intx id, oa, la;
-  integer, public :: mbrxoid  ! iMOAB id for rof migrated to coupler for ocean context (r2o mapping)
   integer, public :: mbintxro ! iMOAB id for read map between river and ocean; it exists on coupler PEs
   logical, public :: mbrof_data = .false. ! made true if no rtm mesh, which means data rof ?
   integer, public :: mbintxar ! iMOAB id for intx mesh between atm and river
@@ -678,8 +675,6 @@ contains
     mbintxia = -1 ! iMOAB id for ice intx with atm on coupler pes
     mrofid = -1   ! iMOAB id of moab rof app
     mbrxid = -1   ! iMOAB id of moab rof migrated to coupler
-   !  mbrmapro = -1 ! iMOAB id of moab instance of map read from rof2ocn map file
-   !  mbrxoid = -1  ! iMOAB id of moab instance rof to coupler in ocean context
     mbintxro = -1 ! iMOAB id of moab instance of map read from rof2ocn map file
     mbintxar = -1 ! iMOAB id for intx mesh between atm and river
     mbintxlr = -1 ! iMOAB id for intx mesh between land and river


### PR DESCRIPTION
when we read maps from file, compute the coverage set after map read; do not try to estimate it before
iMOAB_ComputeCoverage is not called explicitly anymore, migrate map method will do it; it will also compute the comm graph.
it depends on this MOAB major change:
 https://bitbucket.org/fathomteam/moab/pull-requests/736
 