### PR TITLE
Fixes to allow FAN to run with dynamic crops

### DIFF
--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -3370,30 +3370,28 @@ contains
     allocate(this%prod100n              (begc:endc))                     ; this%prod100n              (:)   = spval
     allocate(this%totprodn              (begc:endc))                     ; this%totprodn              (:)   = spval
     allocate(this%dyn_nbal_adjustments  (begc:endc))                     ; this%dyn_nbal_adjustments  (:)   = spval
-    if (use_fan) then
-       allocate(this%tan_g1                (begc:endc))                     ; this%tan_g1                (:)   = spval
-       allocate(this%tan_g2                (begc:endc))                     ; this%tan_g2                (:)   = spval
-       allocate(this%tan_g3                (begc:endc))                     ; this%tan_g3                (:)   = spval
-       allocate(this%tan_s0                (begc:endc))                     ; this%tan_s0                (:)   = spval
-       allocate(this%tan_s1                (begc:endc))                     ; this%tan_s1                (:)   = spval
-       allocate(this%tan_s2                (begc:endc))                     ; this%tan_s2                (:)   = spval
-       allocate(this%tan_s3                (begc:endc))                     ; this%tan_s3                (:)   = spval
-       allocate(this%tan_f1                (begc:endc))                     ; this%tan_f1                (:)   = spval
-       allocate(this%tan_f2                (begc:endc))                     ; this%tan_f2                (:)   = spval
-       allocate(this%tan_f3                (begc:endc))                     ; this%tan_f3                (:)   = spval
-       allocate(this%tan_f4                (begc:endc))                     ; this%tan_f4                (:)   = spval 
-       allocate(this%fert_u1               (begc:endc))                     ; this%fert_u1               (:)   = spval 
-       allocate(this%fert_u2               (begc:endc))                     ; this%fert_u2               (:)   = spval 
-       allocate(this%manure_u_grz          (begc:endc))                     ; this%manure_u_grz          (:)   = spval 
-       allocate(this%manure_a_grz          (begc:endc))                     ; this%manure_a_grz          (:)   = spval 
-       allocate(this%manure_r_grz          (begc:endc))                     ; this%manure_r_grz          (:)   = spval 
-       allocate(this%manure_u_app          (begc:endc))                     ; this%manure_u_app          (:)   = spval 
-       allocate(this%manure_a_app          (begc:endc))                     ; this%manure_a_app          (:)   = spval 
-       allocate(this%manure_r_app          (begc:endc))                     ; this%manure_r_app          (:)   = spval 
-       allocate(this%manure_n_stored       (begc:endc))                     ; this%manure_n_stored       (:)   = spval 
-       allocate(this%manure_tan_stored     (begc:endc))                     ; this%manure_tan_stored     (:)   = spval 
-       allocate(this%fan_grz_fract         (begc:endc))                     ; this%fan_grz_fract         (:)   = spval 
-    end if
+    allocate(this%tan_g1                (begc:endc))                     ; this%tan_g1                (:)   = spval
+    allocate(this%tan_g2                (begc:endc))                     ; this%tan_g2                (:)   = spval
+    allocate(this%tan_g3                (begc:endc))                     ; this%tan_g3                (:)   = spval
+    allocate(this%tan_s0                (begc:endc))                     ; this%tan_s0                (:)   = spval
+    allocate(this%tan_s1                (begc:endc))                     ; this%tan_s1                (:)   = spval
+    allocate(this%tan_s2                (begc:endc))                     ; this%tan_s2                (:)   = spval
+    allocate(this%tan_s3                (begc:endc))                     ; this%tan_s3                (:)   = spval
+    allocate(this%tan_f1                (begc:endc))                     ; this%tan_f1                (:)   = spval
+    allocate(this%tan_f2                (begc:endc))                     ; this%tan_f2                (:)   = spval
+    allocate(this%tan_f3                (begc:endc))                     ; this%tan_f3                (:)   = spval
+    allocate(this%tan_f4                (begc:endc))                     ; this%tan_f4                (:)   = spval 
+    allocate(this%fert_u1               (begc:endc))                     ; this%fert_u1               (:)   = spval 
+    allocate(this%fert_u2               (begc:endc))                     ; this%fert_u2               (:)   = spval 
+    allocate(this%manure_u_grz          (begc:endc))                     ; this%manure_u_grz          (:)   = spval 
+    allocate(this%manure_a_grz          (begc:endc))                     ; this%manure_a_grz          (:)   = spval 
+    allocate(this%manure_r_grz          (begc:endc))                     ; this%manure_r_grz          (:)   = spval 
+    allocate(this%manure_u_app          (begc:endc))                     ; this%manure_u_app          (:)   = spval 
+    allocate(this%manure_a_app          (begc:endc))                     ; this%manure_a_app          (:)   = spval 
+    allocate(this%manure_r_app          (begc:endc))                     ; this%manure_r_app          (:)   = spval 
+    allocate(this%manure_n_stored       (begc:endc))                     ; this%manure_n_stored       (:)   = spval 
+    allocate(this%manure_tan_stored     (begc:endc))                     ; this%manure_tan_stored     (:)   = spval 
+    allocate(this%fan_grz_fract         (begc:endc))                     ; this%fan_grz_fract         (:)   = spval 
     allocate(this%fan_totn              (begc:endc))                     ; this%fan_totn              (:)   = spval
     allocate(this%totpftn_beg           (begc:endc))                     ; this%totpftn_beg           (:)   = spval
     allocate(this%totpftn_end           (begc:endc))                     ; this%totpftn_end           (:)   = spval
@@ -3755,6 +3753,7 @@ contains
           this%prod100n(c)      = 0._r8
           this%totprodn(c)      = 0._r8
           this%cropseedn_deficit(c) = 0._r8
+          this%fan_totn(c) = 0._r8
        end if
 
        if ( use_fan ) then
@@ -4241,6 +4240,9 @@ contains
           this%manure_u_app(i) = value_column
           this%manure_a_app(i) = value_column
           this%manure_r_app(i) = value_column
+          this%manure_tan_stored(i) = value_column
+          this%manure_n_stored(i)   = value_column
+          this%fan_grz_fract(i)     = value_column
        end if
        this%fan_totn(i)    = value_column
 
@@ -8459,35 +8461,33 @@ contains
     allocate(this%decomp_npools_sourcesink        (begc:endc,1:nlevdecomp_full,1:ndecomp_pools              )) ; this%decomp_npools_sourcesink         (:,:,:) = spval
     allocate(this%externaln_to_decomp_npools      (begc:endc,1:nlevdecomp_full, 1:ndecomp_pools             )) ; this%externaln_to_decomp_npools       (:,:,:) = spval
     allocate(this%pmnf_decomp_cascade             (begc:endc,1:nlevdecomp,1:ndecomp_cascade_transitions     )) ; this%pmnf_decomp_cascade              (:,:,:) = spval
-
-    if (use_fan) then
-       allocate(this%manure_tan_appl                 (begc:endc)) ; this%manure_tan_appl               (:)   = spval
-       allocate(this%manure_n_appl                   (begc:endc)) ; this%manure_n_appl                 (:)   = spval
-       allocate(this%manure_n_grz                    (begc:endc)) ; this%manure_n_grz                  (:)   = spval
-       allocate(this%manure_n_mix                    (begc:endc)) ; this%manure_n_mix                  (:)   = spval
-       allocate(this%manure_n_barns                  (begc:endc)) ; this%manure_n_barns                (:)   = spval
-       allocate(this%fert_n_appl                     (begc:endc)) ; this%fert_n_appl                   (:)   = spval
-       allocate(this%otherfert_n_appl                (begc:endc)) ; this%otherfert_n_appl              (:)   = spval
-       allocate(this%manure_n_transf                 (begc:endc)) ; this%manure_n_transf               (:)   = spval
-       allocate(this%nh3_barns                       (begc:endc)) ; this%nh3_barns                     (:)   = spval
-       allocate(this%nh3_stores                      (begc:endc)) ; this%nh3_stores                    (:)   = spval
-       allocate(this%nh3_grz                         (begc:endc)) ; this%nh3_grz                       (:)   = spval
-       allocate(this%nh3_manure_app                  (begc:endc)) ; this%nh3_manure_app                (:)   = spval
-       allocate(this%nh3_fert                        (begc:endc)) ; this%nh3_fert                      (:)   = spval
-       allocate(this%nh3_otherfert                   (begc:endc)) ; this%nh3_otherfert                 (:)   = spval
-       allocate(this%nh3_total                       (begc:endc)) ; this%nh3_total                     (:)   = spval
-       allocate(this%manure_no3_to_soil              (begc:endc)) ; this%manure_no3_to_soil            (:)   = spval
-       allocate(this%fert_no3_to_soil                (begc:endc)) ; this%fert_no3_to_soil              (:)   = spval
-       allocate(this%manure_nh4_to_soil              (begc:endc)) ; this%manure_nh4_to_soil            (:)   = spval
-       allocate(this%fert_nh4_to_soil                (begc:endc)) ; this%fert_nh4_to_soil              (:)   = spval
-       allocate(this%manure_nh4_runoff               (begc:endc)) ; this%manure_nh4_runoff             (:)   = spval
-       allocate(this%fert_nh4_runoff                 (begc:endc)) ; this%fert_nh4_runoff               (:)   = spval
-       allocate(this%manure_n_to_sminn               (begc:endc)) ; this%manure_n_to_sminn             (:)   = spval
-       allocate(this%synthfert_n_to_sminn            (begc:endc)) ; this%synthfert_n_to_sminn          (:)   = spval
-       allocate(this%manure_n_total                  (begc:endc)) ; this%manure_n_total                (:)   = spval
-       allocate(this%fan_totnin                      (begc:endc)) ; this%fan_totnin                    (:)   = spval
-       allocate(this%fan_totnout                     (begc:endc)) ; this%fan_totnout                   (:)   = spval
-    end if
+    !FAN
+    allocate(this%manure_tan_appl                 (begc:endc)) ; this%manure_tan_appl               (:)   = spval
+    allocate(this%manure_n_appl                   (begc:endc)) ; this%manure_n_appl                 (:)   = spval
+    allocate(this%manure_n_grz                    (begc:endc)) ; this%manure_n_grz                  (:)   = spval
+    allocate(this%manure_n_mix                    (begc:endc)) ; this%manure_n_mix                  (:)   = spval
+    allocate(this%manure_n_barns                  (begc:endc)) ; this%manure_n_barns                (:)   = spval
+    allocate(this%fert_n_appl                     (begc:endc)) ; this%fert_n_appl                   (:)   = spval
+    allocate(this%otherfert_n_appl                (begc:endc)) ; this%otherfert_n_appl              (:)   = spval
+    allocate(this%manure_n_transf                 (begc:endc)) ; this%manure_n_transf               (:)   = spval
+    allocate(this%nh3_barns                       (begc:endc)) ; this%nh3_barns                     (:)   = spval
+    allocate(this%nh3_stores                      (begc:endc)) ; this%nh3_stores                    (:)   = spval
+    allocate(this%nh3_grz                         (begc:endc)) ; this%nh3_grz                       (:)   = spval
+    allocate(this%nh3_manure_app                  (begc:endc)) ; this%nh3_manure_app                (:)   = spval
+    allocate(this%nh3_fert                        (begc:endc)) ; this%nh3_fert                      (:)   = spval
+    allocate(this%nh3_otherfert                   (begc:endc)) ; this%nh3_otherfert                 (:)   = spval
+    allocate(this%nh3_total                       (begc:endc)) ; this%nh3_total                     (:)   = spval
+    allocate(this%manure_no3_to_soil              (begc:endc)) ; this%manure_no3_to_soil            (:)   = spval
+    allocate(this%fert_no3_to_soil                (begc:endc)) ; this%fert_no3_to_soil              (:)   = spval
+    allocate(this%manure_nh4_to_soil              (begc:endc)) ; this%manure_nh4_to_soil            (:)   = spval
+    allocate(this%fert_nh4_to_soil                (begc:endc)) ; this%fert_nh4_to_soil              (:)   = spval
+    allocate(this%manure_nh4_runoff               (begc:endc)) ; this%manure_nh4_runoff             (:)   = spval
+    allocate(this%fert_nh4_runoff                 (begc:endc)) ; this%fert_nh4_runoff               (:)   = spval
+    allocate(this%manure_n_to_sminn               (begc:endc)) ; this%manure_n_to_sminn             (:)   = spval
+    allocate(this%synthfert_n_to_sminn            (begc:endc)) ; this%synthfert_n_to_sminn          (:)   = spval
+    allocate(this%manure_n_total                  (begc:endc)) ; this%manure_n_total                (:)   = spval
+    allocate(this%fan_totnin                      (begc:endc)) ; this%fan_totnin                    (:)   = spval
+    allocate(this%fan_totnout                     (begc:endc)) ; this%fan_totnout                   (:)   = spval
  
     !-----------------------------------------------------------------------
     ! initialize history fields for select members of col_nf
@@ -9557,35 +9557,34 @@ contains
        ! bgc-interface
        this%plant_ndemand(i) = value_column
 
-       if ( use_fan ) then
-          this%manure_tan_appl(i)    = value_column
-          this%manure_n_appl(i)      = value_column
-          this%manure_n_grz(i)       = value_column
-          this%manure_n_mix(i)       = value_column
-          this%manure_n_barns(i)     = value_column
-          this%fert_n_appl(i)        = value_column
-          this%otherfert_n_appl(i)   = value_column
-          this%manure_n_transf(i)    = value_column
-          this%nh3_barns(i)          = value_column
-          this%nh3_stores(i)         = value_column
-          this%nh3_grz(i)            = value_column
-          this%nh3_manure_app(i)     = value_column
-          this%nh3_fert(i)           = value_column
-          this%nh3_otherfert(i)      = value_column
-          this%nh3_total(i)          = value_column
-          this%manure_no3_to_soil(i) = value_column
-          this%fert_no3_to_soil(i)   = value_column
-          this%manure_nh4_to_soil(i) = value_column
-          this%fert_nh4_to_soil(i)   = value_column
-          this%fert_nh4_to_soil(i)   = value_column
-          this%manure_nh4_runoff(i)  = value_column
-          this%fert_nh4_runoff(i)    = value_column
-          this%manure_n_to_sminn(i)  = value_column
-          this%manure_n_total(i)     = value_column
-          this%synthfert_n_to_sminn(i) = value_column
-          this%fan_totnin(i)         = value_column
-          this%fan_totnout(i)        = value_column
-       end if
+       ! FAN
+       this%manure_tan_appl(i)    = value_column
+       this%manure_n_appl(i)      = value_column
+       this%manure_n_grz(i)       = value_column
+       this%manure_n_mix(i)       = value_column
+       this%manure_n_barns(i)     = value_column
+       this%fert_n_appl(i)        = value_column
+       this%otherfert_n_appl(i)   = value_column
+       this%manure_n_transf(i)    = value_column
+       this%nh3_barns(i)          = value_column
+       this%nh3_stores(i)         = value_column
+       this%nh3_grz(i)            = value_column
+       this%nh3_manure_app(i)     = value_column
+       this%nh3_fert(i)           = value_column
+       this%nh3_otherfert(i)      = value_column
+       this%nh3_total(i)          = value_column
+       this%manure_no3_to_soil(i) = value_column
+       this%fert_no3_to_soil(i)   = value_column
+       this%manure_nh4_to_soil(i) = value_column
+       this%fert_nh4_to_soil(i)   = value_column
+       this%fert_nh4_to_soil(i)   = value_column
+       this%manure_nh4_runoff(i)  = value_column
+       this%fert_nh4_runoff(i)    = value_column
+       this%manure_n_to_sminn(i)  = value_column
+       this%manure_n_total(i)     = value_column
+       this%synthfert_n_to_sminn(i) = value_column
+       this%fan_totnin(i)         = value_column
+       this%fan_totnout(i)        = value_column
 
     end do
     do k = 1, ndecomp_pools

--- a/components/elm/src/dyn_subgrid/dynSubgridAdjustmentsMod.F90
+++ b/components/elm/src/dyn_subgrid/dynSubgridAdjustmentsMod.F90
@@ -837,7 +837,30 @@ contains
       smin_no3_vr         => col_ns%smin_no3_vr  , &
       prod1n              => col_ns%prod1n       , &
       prod10n             => col_ns%prod10n      , &
-      prod100n            => col_ns%prod100n     &
+      prod100n            => col_ns%prod100n     , &
+      tan_g1              => col_ns%tan_g1       , &
+      tan_g2              => col_ns%tan_g2       , &
+      tan_g3              => col_ns%tan_g3       , &
+      tan_s0              => col_ns%tan_s0       , &
+      tan_s1              => col_ns%tan_s1       , &
+      tan_s2              => col_ns%tan_s2       , &
+      tan_s3              => col_ns%tan_s3       , &
+      tan_f1              => col_ns%tan_f1       , &
+      tan_f2              => col_ns%tan_f2       , &
+      tan_f3              => col_ns%tan_f3       , &
+      tan_f4              => col_ns%tan_f4       , &
+      fert_u1             => col_ns%fert_u1      , &
+      fert_u2             => col_ns%fert_u2      , &
+      manure_u_grz        => col_ns%manure_u_grz , &
+      manure_a_grz        => col_ns%manure_a_grz , &
+      manure_r_grz        => col_ns%manure_r_grz , &
+      manure_u_app        => col_ns%manure_u_app , &
+      manure_a_app        => col_ns%manure_a_app , &
+      manure_r_app        => col_ns%manure_r_app , &
+      manure_tan_stored   => col_ns%manure_tan_stored , &
+      manure_n_stored     => col_ns%manure_n_stored , &
+      fan_grz_fract       => col_ns%fan_grz_fract, &
+      fan_totn            => col_ns%fan_totn     &
       )
 
     begc = bounds%begc
@@ -921,6 +944,237 @@ contains
     col_ns%dyn_nbal_adjustments(begc:endc) = &
          col_ns%dyn_nbal_adjustments(begc:endc) + &
          adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = fan_totn(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = tan_g1(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = tan_g2(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = tan_g3(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = tan_s0(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = tan_s1(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = tan_s2(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = tan_s3(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = tan_f1(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = tan_f2(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = tan_f3(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = tan_f4(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = fert_u1(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = fert_u2(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = manure_u_grz(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = manure_a_grz(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = manure_r_grz(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = manure_u_app(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = manure_a_app(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = manure_r_app(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = manure_tan_stored(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = manure_n_stored(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
+    call update_column_state_no_special_handling(column_state_updater, &
+         bounds      = bounds,                                         &
+         clump_index = clump_index,                                    &
+         var         = fan_grz_fract(begc:endc),     &
+         adjustment  = adjustment_one_level(begc:endc))
+
+    col_ns%dyn_nbal_adjustments(begc:endc) = &
+         col_ns%dyn_nbal_adjustments(begc:endc) + &
+         adjustment_one_level(begc:endc)
+
     !=======================================================!
     end associate
 


### PR DESCRIPTION
Adds instructions to handle FAN pools during transient land use and skip cells that have small column or landunit weight.

Fixes #6743

[BFB] (except for configurations with FAN and transient crops)