### PR TITLE
Fixes  initialization of bgc and aerosol fields

### DIFF
--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -14996,101 +14996,106 @@ contains
              call MPAS_pool_get_subpool(block % structs, "tracers_aggregate", tracers_aggregatePool)
 
              if (config_use_vertical_tracers) then
-                call MPAS_pool_get_array(biogeochemistryPool, "primaryProduction", primaryProduction)
-                call MPAS_pool_get_array(biogeochemistryPool, "totalChlorophyll", totalChlorophyll)
-                call MPAS_pool_get_array(biogeochemistryPool, "netSpecificAlgalGrowthRate", netSpecificAlgalGrowthRate)
                 call MPAS_pool_get_array(diagnostics_biogeochemistryPool, "bgridSalinityIceCell", bgridSalinityIceCell)
                 call MPAS_pool_get_array(diagnostics_biogeochemistryPool, "bgridPorosityIceCell", bgridPorosityIceCell)
                 call MPAS_pool_get_array(diagnostics_biogeochemistryPool, "bgridTemperatureIceCell", bgridTemperatureIceCell)
-                primaryProduction             = 0.0_RKIND
-                totalChlorophyll              = 0.0_RKIND
-                netSpecificAlgalGrowthRate    = 0.0_RKIND
+                call MPAS_pool_get_array(biogeochemistryPool, "netBrineHeight", netBrineHeight)
+                call MPAS_pool_get_array(biogeochemistryPool, "oceanBioFluxes", oceanBioFluxes)
+                call MPAS_pool_get_array(biogeochemistryPool, "atmosIceBioFluxes", atmosIceBioFluxes)
+                call MPAS_pool_get_array(biogeochemistryPool, "snowIceBioFluxes", snowIceBioFluxes)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalBiologyIce", totalVerticalBiologyIce)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalBiologySnow", totalVerticalBiologySnow)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalCarbonContentCell", totalCarbonContentCell)
+
                 bgridSalinityIceCell          = 0.0_RKIND
                 bgridPorosityIceCell          = 0.0_RKIND
                 bgridTemperatureIceCell       = 0.0_RKIND
-
+                netBrineHeight                = 0.0_RKIND
+                oceanBioFluxes                = 0.0_RKIND
+                atmosIceBioFluxes             = 0.0_RKIND
+                snowIceBioFluxes              = 0.0_RKIND
+                totalVerticalBiologyIce        = 0.0_RKIND
+                totalVerticalBiologySnow       = 0.0_RKIND
+                totalCarbonContentCell         = 0.0_RKIND
              end if
 
-             call MPAS_pool_get_array(biogeochemistryPool, "netBrineHeight", netBrineHeight)
-             call MPAS_pool_get_array(biogeochemistryPool, "oceanBioFluxes", oceanBioFluxes)
-             call MPAS_pool_get_array(biogeochemistryPool, "atmosIceBioFluxes", atmosIceBioFluxes)
-             call MPAS_pool_get_array(biogeochemistryPool, "snowIceBioFluxes", snowIceBioFluxes)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalBiologyIce", totalVerticalBiologyIce)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalBiologySnow", totalVerticalBiologySnow)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalCarbonContentCell", totalCarbonContentCell)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalDiatomIce", totalVerticalDiatomIce)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalSmallPlanktonIce", totalVerticalSmallPlanktonIce)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalPhaeocystisIce", totalVerticalPhaeocystisIce)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalPolysaccharidsIce", totalVerticalPolysaccharidsIce)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalLipidsIce", totalVerticalLipidsIce)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalDICIce", totalVerticalDICIce)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalProteinsIce", totalVerticalProteinsIce)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalNitrateIce", totalVerticalNitrateIce)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalSilicateIce", totalVerticalSilicateIce)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalAmmoniumIce", totalVerticalAmmoniumIce)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalDMSIce", totalVerticalDMSIce)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalDMSPpIce", totalVerticalDMSPpIce)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalDMSPdIce", totalVerticalDMSPdIce)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalNonreactiveIce", totalVerticalNonreactiveIce)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalHumicsIce", totalVerticalHumicsIce)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalParticulateIronIce", totalVerticalParticulateIronIce)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalDissolvedIronIce", totalVerticalDissolvedIronIce)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalDissolvedIronSnow", totalVerticalDissolvedIronSnow)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalDustIce", totalVerticalDustIce)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalDustSnow", totalVerticalDustSnow)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalBC1Ice", totalVerticalBC1Ice)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalBC1Snow", totalVerticalBC1Snow)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalBC2Ice", totalVerticalBC2Ice)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalBC2Snow", totalVerticalBC2Snow)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalBCIce", totalVerticalBCIce)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalBCSnow", totalVerticalBCSnow)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalAlgaeCarbonIce", totalVerticalAlgaeCarbonIce)
-             call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalDOCLabileIce", totalVerticalDOCLabileIce)
-             call MPAS_pool_get_array(tracers_aggregatePool, "verticalBCTotalIceCell", verticalBCTotalIceCell)
-             call MPAS_pool_get_array(tracers_aggregatePool, "verticalDustTotalIceCell", verticalDustTotalIceCell)
-             call MPAS_pool_get_array(tracers_aggregatePool, "verticalDustTotalSnowCell", verticalDustTotalSnowCell)
-             call MPAS_pool_get_array(tracers_aggregatePool, "verticalBCTotalSnowCell", verticalBCTotalSnowCell)
+             if (config_use_column_biogeochemistry) then
+                call MPAS_pool_get_array(biogeochemistryPool, "primaryProduction", primaryProduction)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalChlorophyll", totalChlorophyll)
+                call MPAS_pool_get_array(biogeochemistryPool, "netSpecificAlgalGrowthRate", netSpecificAlgalGrowthRate)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalDiatomIce", totalVerticalDiatomIce)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalSmallPlanktonIce", totalVerticalSmallPlanktonIce)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalPhaeocystisIce", totalVerticalPhaeocystisIce)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalPolysaccharidsIce", totalVerticalPolysaccharidsIce)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalLipidsIce", totalVerticalLipidsIce)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalDICIce", totalVerticalDICIce)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalProteinsIce", totalVerticalProteinsIce)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalNitrateIce", totalVerticalNitrateIce)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalSilicateIce", totalVerticalSilicateIce)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalAmmoniumIce", totalVerticalAmmoniumIce)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalDMSIce", totalVerticalDMSIce)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalDMSPpIce", totalVerticalDMSPpIce)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalDMSPdIce", totalVerticalDMSPdIce)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalNonreactiveIce", totalVerticalNonreactiveIce)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalHumicsIce", totalVerticalHumicsIce)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalParticulateIronIce", totalVerticalParticulateIronIce)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalDissolvedIronIce", totalVerticalDissolvedIronIce)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalDissolvedIronSnow", totalVerticalDissolvedIronSnow)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalAlgaeCarbonIce", totalVerticalAlgaeCarbonIce)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalDOCLabileIce", totalVerticalDOCLabileIce)
 
+                primaryProduction              = 0.0_RKIND
+                totalChlorophyll               = 0.0_RKIND
+                netSpecificAlgalGrowthRate     = 0.0_RKIND
+                totalVerticalDiatomIce         = 0.0_RKIND
+                totalVerticalSmallPlanktonIce  = 0.0_RKIND
+                totalVerticalPhaeocystisIce    = 0.0_RKIND
+                totalVerticalPolysaccharidsIce = 0.0_RKIND
+                totalVerticalLipidsIce         = 0.0_RKIND
+                totalVerticalDICIce            = 0.0_RKIND
+                totalVerticalProteinsIce       = 0.0_RKIND
+                totalVerticalNitrateIce        = 0.0_RKIND
+                totalVerticalSilicateIce       = 0.0_RKIND
+                totalVerticalAmmoniumIce       = 0.0_RKIND
+                totalVerticalDMSIce            = 0.0_RKIND
+                totalVerticalDMSPpIce          = 0.0_RKIND
+                totalVerticalDMSPdIce          = 0.0_RKIND
+                totalVerticalNonreactiveIce    = 0.0_RKIND
+                totalVerticalHumicsIce         = 0.0_RKIND
+                totalVerticalParticulateIronIce= 0.0_RKIND
+                totalVerticalDissolvedIronIce  = 0.0_RKIND
+                totalVerticalDissolvedIronSnow = 0.0_RKIND
+                totalVerticalAlgaeCarbonIce    = 0.0_RKIND
+                totalVerticalDOCLabileIce      = 0.0_RKIND
+             end if
 
-             netBrineHeight             = 0.0_RKIND
-             oceanBioFluxes             = 0.0_RKIND
-             atmosIceBioFluxes          = 0.0_RKIND
-             snowIceBioFluxes           = 0.0_RKIND
-             totalVerticalBiologyIce    = 0.0_RKIND
-             totalVerticalBiologySnow   = 0.0_RKIND
-             totalCarbonContentCell     = 0.0_RKIND
-             totalVerticalDiatomIce       = 0.0_RKIND
-             totalVerticalSmallPlanktonIce = 0.0_RKIND
-             totalVerticalPhaeocystisIce   = 0.0_RKIND
-             totalVerticalPolysaccharidsIce = 0.0_RKIND
-             totalVerticalLipidsIce        = 0.0_RKIND
-             totalVerticalDICIce           = 0.0_RKIND
-             totalVerticalProteinsIce      = 0.0_RKIND
-             totalVerticalNitrateIce       = 0.0_RKIND
-             totalVerticalSilicateIce      = 0.0_RKIND
-             totalVerticalAmmoniumIce      = 0.0_RKIND
-             totalVerticalDMSIce           = 0.0_RKIND
-             totalVerticalDMSPpIce         = 0.0_RKIND
-             totalVerticalDMSPdIce         = 0.0_RKIND
-             totalVerticalNonreactiveIce   = 0.0_RKIND
-             totalVerticalHumicsIce        = 0.0_RKIND
-             totalVerticalParticulateIronIce = 0.0_RKIND
-             totalVerticalDissolvedIronIce    = 0.0_RKIND
-             totalVerticalDissolvedIronSnow   = 0.0_RKIND
-             totalVerticalBC1Ice              = 0.0_RKIND
-             totalVerticalBC2Ice           = 0.0_RKIND
-             totalVerticalDustIce          = 0.0_RKIND
-             totalVerticalBC1Snow          = 0.0_RKIND
-             totalVerticalBC2Snow          = 0.0_RKIND
-             totalVerticalBCSnow           = 0.0_RKIND
-             totalVerticalBCIce            = 0.0_RKIND
-             totalVerticalDustSnow         = 0.0_RKIND
-             totalVerticalAlgaeCarbonIce   = 0.0_RKIND
-             totalVerticalDOCLabileIce     = 0.0_RKIND
-             verticalBCTotalIceCell        = 0.0_RKIND
-             verticalDustTotalIceCell      = 0.0_RKIND
-             verticalBCTotalSnowCell       = 0.0_RKIND
-             verticalDustTotalSnowCell     = 0.0_RKIND
+             if (config_use_zaerosols) then
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalDustIce", totalVerticalDustIce)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalDustSnow", totalVerticalDustSnow)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalBC1Ice", totalVerticalBC1Ice)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalBC1Snow", totalVerticalBC1Snow)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalBC2Ice", totalVerticalBC2Ice)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalBC2Snow", totalVerticalBC2Snow)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalBCIce", totalVerticalBCIce)
+                call MPAS_pool_get_array(biogeochemistryPool, "totalVerticalBCSnow", totalVerticalBCSnow)
+                call MPAS_pool_get_array(tracers_aggregatePool, "verticalBCTotalIceCell", verticalBCTotalIceCell)
+                call MPAS_pool_get_array(tracers_aggregatePool, "verticalDustTotalIceCell", verticalDustTotalIceCell)
+                call MPAS_pool_get_array(tracers_aggregatePool, "verticalDustTotalSnowCell", verticalDustTotalSnowCell)
+                call MPAS_pool_get_array(tracers_aggregatePool, "verticalBCTotalSnowCell", verticalBCTotalSnowCell)
+
+                totalVerticalBC1Ice           = 0.0_RKIND
+                totalVerticalBC2Ice           = 0.0_RKIND
+                totalVerticalDustIce          = 0.0_RKIND
+                totalVerticalBC1Snow          = 0.0_RKIND
+                totalVerticalBC2Snow          = 0.0_RKIND
+                totalVerticalBCSnow           = 0.0_RKIND
+                totalVerticalBCIce            = 0.0_RKIND
+                totalVerticalDustSnow         = 0.0_RKIND
+                verticalBCTotalIceCell        = 0.0_RKIND
+                verticalDustTotalIceCell      = 0.0_RKIND
+                verticalBCTotalSnowCell       = 0.0_RKIND
+                verticalDustTotalSnowCell     = 0.0_RKIND
+             endif
 
           endif
 


### PR DESCRIPTION
Added appropriate if statements around fields before initialization.
Gnu compiler build was failing for tests with bgc but no z-aerosols. 

Passed tests of 2x5day runs in two configurations (bgc but no zaerosols and zaerosols but no bgc) with gnu compiler  

Fixes #7275
Fixes #7277 

[BFB]