### PR TITLE
Update CIME submodule

### DIFF
--- a/driver-mct/cime_config/config_archive.xml
+++ b/driver-mct/cime_config/config_archive.xml
@@ -17,7 +17,7 @@
       <tfile disposition="move">casename.cpl.ha2x1d.1976-01-01-00000.nc</tfile>
       <tfile disposition="move">casename.cpl.ha2x1h.1976-01-01-00000.nc</tfile>
       <tfile disposition="move">casename.cpl.hl2x1yr_glc.1976-01-01-00000.nc</tfile>
-      <tfile disposition="copy">rpointer.drv_0001</tfile>
+      <tfile disposition="ignore">rpointer.drv_0001</tfile>
       <tfile disposition="copy">rpointer.drv</tfile>
       <tfile disposition="ignore">casenamenot.cpl.r.1976-01-01-00000.nc</tfile>
     </test_file_names>

--- a/driver-moab/cime_config/config_archive.xml
+++ b/driver-moab/cime_config/config_archive.xml
@@ -17,7 +17,7 @@
       <tfile disposition="move">casename.cpl.ha2x1d.1976-01-01-00000.nc</tfile>
       <tfile disposition="move">casename.cpl.ha2x1h.1976-01-01-00000.nc</tfile>
       <tfile disposition="move">casename.cpl.hl2x1yr_glc.1976-01-01-00000.nc</tfile>
-      <tfile disposition="copy">rpointer.drv_0001</tfile>
+      <tfile disposition="ignore">rpointer.drv_0001</tfile>
       <tfile disposition="copy">rpointer.drv</tfile>
       <tfile disposition="ignore">casenamenot.cpl.r.1976-01-01-00000.nc</tfile>
     </test_file_names>


### PR DESCRIPTION
... to f9db6d97518a29b4dd0878cd9189cd78e547b1c1

Fixes:
1) bless_test_results: fix stale baseline file use case - This is urgently needed to get DIFFs off cdash
2) fix math in calculation of startdate in system tests
3) st.archiver fixes: too many rpointer files to be copied to the restart directory

Changes:
1) Adjust driver guard for kokkos build, only nuopc will skip

[BFB]