### PR TITLE
Make landIceDraft diagnostic rather than a forcing variable

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -386,14 +386,14 @@
       <mask>WCAtl12to45E2r4</mask>
     </model_grid>
 
-    <model_grid alias="T62_SOwISC12to60E2r4" compset="(DATM|XATM|SATM)">
+    <model_grid alias="T62_SOwISC12to60E3r3" compset="(DATM|XATM|SATM)">
       <grid name="atm">T62</grid>
       <grid name="lnd">T62</grid>
-      <grid name="ocnice">SOwISC12to60E2r4</grid>
+      <grid name="ocnice">SOwISC12to60E3r3</grid>
       <grid name="rof">rx1</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
-      <mask>SOwISC12to60E2r4</mask>
+      <mask>SOwISC12to30E3r3</mask>
     </model_grid>
 
     <model_grid alias="T62_ECwISC30to60E2r1" compset="(DATM|XATM|SATM)">

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -396,7 +396,7 @@ _TESTS = {
         "inherit" : "e3sm_atm_hi_res",
         "tests"   : (
             "SMS_Ld3.ne120pg2_r025_RRSwISC6to18E3r5.WCYCL1850NS.eam-cosplite",
-            "SMS.T62_SOwISC12to60E2r4.GMPAS-IAF",
+            "SMS.T62_SOwISC12to30E3r3.GMPAS-IAF",
             )
         },
 

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -815,6 +815,12 @@ if ($OCN_ISMF eq 'coupled') {
 	add_default($nl, 'config_frazil_under_land_ice');
 }
 
+############################
+# Namelist group: land_ice #
+############################
+
+add_default($nl, 'config_land_ice_rho_ocean');
+
 ###################################
 # Namelist group: land_ice_fluxes #
 ###################################
@@ -1866,6 +1872,7 @@ my @groups = qw(run_modes
                 self_attraction_loading
                 tidal_potential_forcing
                 frazil_ice
+                land_ice
                 land_ice_fluxes
                 advection
                 bottom_drag

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -819,6 +819,7 @@ if ($OCN_ISMF eq 'coupled') {
 # Namelist group: land_ice #
 ############################
 
+add_default($nl, 'config_land_ice_draft_mode');
 add_default($nl, 'config_land_ice_rho_ocean');
 
 ###################################

--- a/components/mpas-ocean/bld/build-namelist-group-list
+++ b/components/mpas-ocean/bld/build-namelist-group-list
@@ -20,6 +20,7 @@ my @groups = qw(run_modes
                 self_attraction_loading
                 tidal_potential_forcing
                 frazil_ice
+                land_ice
                 land_ice_fluxes
                 advection
                 bottom_drag

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -309,6 +309,7 @@ add_default($nl, 'config_frazil_use_surface_pressure');
 # Namelist group: land_ice #
 ############################
 
+add_default($nl, 'config_land_ice_draft_mode');
 add_default($nl, 'config_land_ice_rho_ocean');
 
 ###################################

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -305,6 +305,12 @@ add_default($nl, 'config_frazil_sea_ice_reference_salinity');
 add_default($nl, 'config_frazil_maximum_freezing_temperature');
 add_default($nl, 'config_frazil_use_surface_pressure');
 
+############################
+# Namelist group: land_ice #
+############################
+
+add_default($nl, 'config_land_ice_rho_ocean');
+
 ###################################
 # Namelist group: land_ice_fluxes #
 ###################################

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -429,7 +429,18 @@
 <config_frazil_use_surface_pressure>.false.</config_frazil_use_surface_pressure>
 
 <!-- land_ice -->
-<config_land_ice_draft_mode>"pressure-dependent"</config_land_ice_draft_mode>
+<config_land_ice_draft_mode>'pressure-dependent'</config_land_ice_draft_mode>
+<config_land_ice_draft_mode ocn_grid="oQU240wLI">'data'</config_land_ice_draft_mode>
+<config_land_ice_draft_mode ocn_grid="ECwISC30to60E1r2">'data'</config_land_ice_draft_mode>
+<config_land_ice_draft_mode ocn_grid="SOwISC12to60E2r4">'data'</config_land_ice_draft_mode>
+<config_land_ice_draft_mode ocn_grid="ECwISC30to60E2r1">'data'</config_land_ice_draft_mode>
+<config_land_ice_draft_mode ocn_grid="IcoswISC30E3r5">'data'</config_land_ice_draft_mode>
+<config_land_ice_draft_mode ocn_grid="FRISwISC08to60E3r1">'data'</config_land_ice_draft_mode>
+<config_land_ice_draft_mode ocn_grid="FRISwISC04to60E3r1">'data'</config_land_ice_draft_mode>
+<config_land_ice_draft_mode ocn_grid="FRISwISC02to60E3r1">'data'</config_land_ice_draft_mode>
+<config_land_ice_draft_mode ocn_grid="FRISwISC01to60E3r1">'data'</config_land_ice_draft_mode>
+<config_land_ice_draft_mode ocn_grid="RRSwISC6to18E3r5">'data'</config_land_ice_draft_mode>
+<config_land_ice_draft_mode ocn_grid="SOwISC12to30E2r4">'data'</config_land_ice_draft_mode>
 <config_land_ice_rho_ocean>1028</config_land_ice_rho_ocean>
 
 <!-- land_ice_fluxes -->

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -440,7 +440,8 @@
 <config_land_ice_draft_mode ocn_grid="FRISwISC02to60E3r1">'data'</config_land_ice_draft_mode>
 <config_land_ice_draft_mode ocn_grid="FRISwISC01to60E3r1">'data'</config_land_ice_draft_mode>
 <config_land_ice_draft_mode ocn_grid="RRSwISC6to18E3r5">'data'</config_land_ice_draft_mode>
-<config_land_ice_rho_ocean>1028.0</config_land_ice_rho_ocean>
+<config_land_ice_draft_mode ocn_grid="SOwISC12to30E2r4">'data'</config_land_ice_draft_mode>
+<config_land_ice_rho_ocean>1028</config_land_ice_rho_ocean>
 
 <!-- land_ice_fluxes -->
 <config_land_ice_flux_mode>'off'</config_land_ice_flux_mode>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -428,6 +428,9 @@
 <config_frazil_maximum_freezing_temperature>0.0</config_frazil_maximum_freezing_temperature>
 <config_frazil_use_surface_pressure>.false.</config_frazil_use_surface_pressure>
 
+<!-- land_ice -->
+<config_land_ice_rho_ocean>1028</config_land_ice_rho_ocean>
+
 <!-- land_ice_fluxes -->
 <config_land_ice_flux_mode>'off'</config_land_ice_flux_mode>
 <config_land_ice_flux_mode ocn_grid="oQU240wLI">'pressure_only'</config_land_ice_flux_mode>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -429,6 +429,7 @@
 <config_frazil_use_surface_pressure>.false.</config_frazil_use_surface_pressure>
 
 <!-- land_ice -->
+<config_land_ice_draft_mode>"pressure-dependent"</config_land_ice_draft_mode>
 <config_land_ice_rho_ocean>1028</config_land_ice_rho_ocean>
 
 <!-- land_ice_fluxes -->

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -440,8 +440,7 @@
 <config_land_ice_draft_mode ocn_grid="FRISwISC02to60E3r1">'data'</config_land_ice_draft_mode>
 <config_land_ice_draft_mode ocn_grid="FRISwISC01to60E3r1">'data'</config_land_ice_draft_mode>
 <config_land_ice_draft_mode ocn_grid="RRSwISC6to18E3r5">'data'</config_land_ice_draft_mode>
-<config_land_ice_draft_mode ocn_grid="SOwISC12to30E2r4">'data'</config_land_ice_draft_mode>
-<config_land_ice_rho_ocean>1028</config_land_ice_rho_ocean>
+<config_land_ice_rho_ocean>1028.0</config_land_ice_rho_ocean>
 
 <!-- land_ice_fluxes -->
 <config_land_ice_flux_mode>'off'</config_land_ice_flux_mode>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -440,7 +440,6 @@
 <config_land_ice_draft_mode ocn_grid="FRISwISC02to60E3r1">'data'</config_land_ice_draft_mode>
 <config_land_ice_draft_mode ocn_grid="FRISwISC01to60E3r1">'data'</config_land_ice_draft_mode>
 <config_land_ice_draft_mode ocn_grid="RRSwISC6to18E3r5">'data'</config_land_ice_draft_mode>
-<config_land_ice_draft_mode ocn_grid="SOwISC12to30E2r4">'data'</config_land_ice_draft_mode>
 <config_land_ice_rho_ocean>1028</config_land_ice_rho_ocean>
 
 <!-- land_ice_fluxes -->

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1646,11 +1646,11 @@ Default: Defined in namelist_defaults.xml
 
 <!-- land_ice -->
 
-<entry id="config_land_ice_draft_mode" type="char*1024"
+<entry id="config_land_ice_draft_mode" type="character"
 	category="land_ice" group="land_ice">
 Selects the mode in which land-ice draft is computed.
 
-Valid values: 'data,'pressure-dependent'
+Valid values= 'data,'pressure-dependent'
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1644,6 +1644,17 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 
+<!-- land_ice -->
+
+<entry id="config_land_ice_rho_ocean" type="real"
+	category="land_ice" group="land_ice">
+ocean density used to calculate landIceDraft at floatation (assumed constant and uniform). Should be consistent with MALI's config_ocean_density when used to determine grounding line location. This is an alternative to the coupler variable effectiveDensityInLandIce which is not currently used.
+
+Valid values: Any positive real number
+Default: Defined in namelist_defaults.xml
+</entry>
+
+
 <!-- land_ice_fluxes -->
 
 <entry id="config_land_ice_flux_mode" type="char*1024"

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1646,11 +1646,11 @@ Default: Defined in namelist_defaults.xml
 
 <!-- land_ice -->
 
-<entry id="config_land_ice_draft_mode" type="character"
+<entry id="config_land_ice_draft_mode" type="char*1024"
 	category="land_ice" group="land_ice">
 Selects the mode in which land-ice draft is computed.
 
-Valid values= 'data,'pressure-dependent'
+Valid values: 'data,'pressure-dependent'
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1646,6 +1646,14 @@ Default: Defined in namelist_defaults.xml
 
 <!-- land_ice -->
 
+<entry id="config_land_ice_draft_mode" type="character"
+	category="land_ice" group="land_ice">
+Selects the mode in which land-ice draft is computed.
+
+Valid values= 'data,'pressure-dependent'
+Default: Defined in namelist_defaults.xml
+</entry>
+
 <entry id="config_land_ice_rho_ocean" type="real"
 	category="land_ice" group="land_ice">
 ocean density used to calculate landIceDraft at floatation (assumed constant and uniform). Should be consistent with MALI's config_ocean_density when used to determine grounding line location. This is an alternative to the coupler variable effectiveDensityInLandIce which is not currently used.

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1078,6 +1078,10 @@
 					description="The density of land ice."
 					possible_values="Any positive real number"
 		/>
+		<nml_option name="config_land_ice_flux_rho_ocean" type="real" default_value="1028.0" units="kg m^-3"
+					description="ocean density used to calculate landIceDraft at floatation (assumed constant and uniform). Should be consistent with MALI's config_ocean_density. This is an alternative to the coupler variable effectiveDensityInLandIce which is not currently used."
+					possible_values="Any positive real number"
+		/>
 		<nml_option name="config_land_ice_flux_explicit_topDragCoeff" type="real" default_value="2.5e-3"
 					description="The top drag coefficient if config_use_implicit_top_drag_coeff is false."
 					possible_values="Any positive real number"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -3469,7 +3469,7 @@
 		<!-- diagnostic fields for land-ice fluxes -->
 		<var name="landIceDraftForSsh" type="real" dimensions="nCells Time" units="m"
 			description="The elevation of the interface between land ice and the ocean that is used to correct the SSH gradient passed to MPAS-SeaIce and may be used for wetting-and-drying."
-			packages="landIcePressurePKG;landIceFluxesPKG"
+			packages="landIcePressurePKG"
 		/>
 		<var name="landIceFrictionVelocity" type="real" dimensions="nCells Time" units="m s^-1"
 			description="The friction velocity $u_*$ under land ice"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -3457,6 +3457,10 @@
 			packages="topographicWaveDragPKG"
 		/>
 		<!-- diagnostic fields for land-ice fluxes -->
+		<var name="landIceDraftForSsh" type="real" dimensions="nCells Time" units="m"
+			description="The elevation of the interface between land ice and the ocean that is used to correct the SSH gradient passed to MPAS-SeaIce and may be used for wetting-and-drying."
+			packages="landIcePressurePKG;landIceFluxPKG"
+		/>
 		<var name="landIceFrictionVelocity" type="real" dimensions="nCells Time" units="m s^-1"
 			description="The friction velocity $u_*$ under land ice"
 			packages="landIceFluxesPKG"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1045,6 +1045,12 @@
 			possible_values=".true. or .false."
 		/>
 	</nml_record>
+	<nml_record name="land_ice" mode="init;forward">
+		<nml_option name="config_land_ice_rho_ocean" type="real" default_value="1028.0" units="kg m^-3"
+					description="ocean density used to calculate landIceDraft at floatation (assumed constant and uniform). Should be consistent with MALI's config_ocean_density when used to determine grounding line location. This is an alternative to the coupler variable effectiveDensityInLandIce which is not currently used."
+					possible_values="Any positive real number"
+		/>
+	</nml_record>
 	<nml_record name="land_ice_fluxes" mode="init;forward">
 		<nml_option name="config_land_ice_flux_mode" type="character" default_value="off"
 					description="Selects the mode in which land-ice fluxes are computed."
@@ -1076,10 +1082,6 @@
 		/>
 		<nml_option name="config_land_ice_flux_rho_ice" type="real" default_value="918" units="kg m^-3"
 					description="The density of land ice."
-					possible_values="Any positive real number"
-		/>
-		<nml_option name="config_land_ice_flux_rho_ocean" type="real" default_value="1028.0" units="kg m^-3"
-					description="ocean density used to calculate landIceDraft at floatation (assumed constant and uniform). Should be consistent with MALI's config_ocean_density. This is an alternative to the coupler variable effectiveDensityInLandIce which is not currently used."
 					possible_values="Any positive real number"
 		/>
 		<nml_option name="config_land_ice_flux_explicit_topDragCoeff" type="real" default_value="2.5e-3"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1046,6 +1046,10 @@
 		/>
 	</nml_record>
 	<nml_record name="land_ice" mode="init;forward">
+		<nml_option name="config_land_ice_draft_mode" type="character" default_value="pressure-dependent"
+					description="Selects the mode in which land-ice draft is computed."
+					possible_values="'data,'pressure-dependent'"
+		/>
 		<nml_option name="config_land_ice_rho_ocean" type="real" default_value="1028.0" units="kg m^-3"
 					description="ocean density used to calculate landIceDraft at floatation (assumed constant and uniform). Should be consistent with MALI's config_ocean_density when used to determine grounding line location. This is an alternative to the coupler variable effectiveDensityInLandIce which is not currently used."
 					possible_values="Any positive real number"
@@ -3465,7 +3469,7 @@
 		<!-- diagnostic fields for land-ice fluxes -->
 		<var name="landIceDraftForSsh" type="real" dimensions="nCells Time" units="m"
 			description="The elevation of the interface between land ice and the ocean that is used to correct the SSH gradient passed to MPAS-SeaIce and may be used for wetting-and-drying."
-			packages="landIcePressurePKG;landIceFluxPKG"
+			packages="landIcePressurePKG;landIceFluxesPKG"
 		/>
 		<var name="landIceFrictionVelocity" type="real" dimensions="nCells Time" units="m s^-1"
 			description="The friction velocity $u_*$ under land ice"

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -174,7 +174,7 @@ contains
 !      real (kind=RKIND), dimension(:), pointer ::  areaCell
       real (kind=RKIND), dimension(:,:), allocatable :: pressureAdjustedForLandIce 
 
-      real (kind=RKIND), dimension(:), pointer :: tThreshMLD, tGradientMLD, landIceDraftForSsh
+      real (kind=RKIND), dimension(:), pointer :: tThreshMLD, tGradientMLD
       real (kind=RKIND), dimension(:), pointer :: dGradientMLD, landIcePressure
       real (kind=RKIND), dimension(:,:,:), pointer :: tracers
       integer :: interp_local

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_depths.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_mixed_layer_depths.F
@@ -174,7 +174,7 @@ contains
 !      real (kind=RKIND), dimension(:), pointer ::  areaCell
       real (kind=RKIND), dimension(:,:), allocatable :: pressureAdjustedForLandIce 
 
-      real (kind=RKIND), dimension(:), pointer :: tThreshMLD, tGradientMLD, landIceDraft
+      real (kind=RKIND), dimension(:), pointer :: tThreshMLD, tGradientMLD, landIceDraftForSsh
       real (kind=RKIND), dimension(:), pointer :: dGradientMLD, landIcePressure
       real (kind=RKIND), dimension(:,:,:), pointer :: tracers
       integer :: interp_local
@@ -212,7 +212,7 @@ contains
 
          call mpas_pool_get_array(tracersPool, 'activeTracers', tracers, timeLevel)
          call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
-         call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
+         ! landIceDraftForSsh is present in diagnostics variables
          call mpas_pool_get_array(meshPool, 'latCell', latCell)
          call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
 
@@ -284,11 +284,11 @@ contains
                !$omp end do
                !$omp end parallel
 
-               if (associated(landIceDraft) ) then
+               if (associated(landIceDraftForSsh) ) then
                   !$omp parallel
                   !$omp do schedule(runtime)
                   do iCell = 1, nCells
-                     tThreshMLD(iCell) = tThreshMLD(iCell) - abs(landIceDraft(iCell))
+                     tThreshMLD(iCell) = tThreshMLD(iCell) - abs(landIceDraftForSsh(iCell))
                   end do
                   !$omp end do
                   !$omp end parallel
@@ -350,11 +350,11 @@ contains
          !$omp end parallel
 
          !normalize MLD to top of ice cavity
-         if (associated(landIceDraft) ) then
+         if (associated(landIceDraftForSsh) ) then
            !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
-             tGradientMLD(iCell) = tGradientMLD(iCell) - abs(landIceDraft(iCell))
+             tGradientMLD(iCell) = tGradientMLD(iCell) - abs(landIceDraftForSsh(iCell))
            end do
            !$omp end do
            !$omp end parallel
@@ -415,11 +415,11 @@ contains
          !$omp end do
          !$omp end parallel
 
-         if (associated(landIceDraft) ) then
+         if (associated(landIceDraftForSsh) ) then
            !$omp parallel
            !$omp do schedule(runtime)
            do iCell = 1, nCells
-             dGradientMLD(iCell) = dGradientMLD(iCell) - abs(landIceDraft(iCell))
+             dGradientMLD(iCell) = dGradientMLD(iCell) - abs(landIceDraftForSsh(iCell))
            end do
            !$omp end do
            !$omp end parallel

--- a/components/mpas-ocean/src/shared/Makefile
+++ b/components/mpas-ocean/src/shared/Makefile
@@ -85,7 +85,7 @@ mpas_ocn_init_routines.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o
 
 mpas_ocn_tendency.o: mpas_ocn_high_freq_thickness_hmix_del2.o mpas_ocn_tracer_surface_restoring.o mpas_ocn_thick_surface_flux.o mpas_ocn_tracer_short_wave_absorption.o mpas_ocn_tracer_advection.o mpas_ocn_tracer_hmix.o mpas_ocn_tracer_nonlocalflux.o mpas_ocn_surface_bulk_forcing.o mpas_ocn_surface_land_ice_fluxes.o mpas_ocn_tracer_surface_flux_to_tend.o mpas_ocn_tracer_interior_restoring.o mpas_ocn_tracer_exponential_decay.o mpas_ocn_tracer_ideal_age.o mpas_ocn_tracer_TTD.o mpas_ocn_vmix.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_frazil_forcing.o mpas_ocn_tidal_forcing.o mpas_ocn_tracer_ecosys.o mpas_ocn_tracer_DMS.o mpas_ocn_tracer_MacroMolecules.o mpas_ocn_tracer_CFC.o mpas_ocn_diagnostics.o mpas_ocn_wetting_drying.o mpas_ocn_vel_self_attraction_loading.o  mpas_ocn_vel_tidal_potential.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o mpas_ocn_thick_hadv.o mpas_ocn_thick_vadv.o mpas_ocn_vel_hadv_coriolis.o mpas_ocn_vel_pressure_grad.o mpas_ocn_vel_vadv.o mpas_ocn_vel_hmix.o mpas_ocn_vel_forcing.o mpas_ocn_manufactured_solution.o
 
-mpas_ocn_diagnostics.o: mpas_ocn_thick_ale.o mpas_ocn_equation_of_state.o mpas_ocn_gm.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o mpas_ocn_surface_land_ice_fluxes.o mpas_ocn_vertical_advection.o mpas_ocn_submesoscale_eddies.o mpas_ocn_subgrid.o
+mpas_ocn_diagnostics.o: mpas_ocn_thick_ale.o mpas_ocn_equation_of_state.o mpas_ocn_gm.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o mpas_ocn_surface_land_ice_fluxes.o mpas_ocn_vertical_advection.o mpas_ocn_submesoscale_eddies.o mpas_ocn_subgrid.o mpas_ocn_wetting_drying.o
 
 mpas_ocn_diagnostics_variables.o: mpas_ocn_config.o
 
@@ -219,7 +219,7 @@ mpas_ocn_framework_forcing.o:
 
 mpas_ocn_time_varying_forcing.o:  mpas_ocn_framework_forcing.o mpas_ocn_diagnostics_variables.o mpas_ocn_constants.o mpas_ocn_config.o
 
-mpas_ocn_wetting_drying.o: mpas_ocn_diagnostics.o mpas_ocn_gm.o mpas_ocn_diagnostics_variables.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_gm.o mpas_ocn_mesh.o
+mpas_ocn_wetting_drying.o: mpas_ocn_gm.o mpas_ocn_diagnostics_variables.o mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_gm.o mpas_ocn_mesh.o mpas_ocn_vel_pressure_grad.o
 
 mpas_ocn_tidal_potential_forcing.o: mpas_ocn_constants.o mpas_ocn_config.o mpas_ocn_mesh.o mpas_ocn_diagnostics_variables.o
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_config.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_config.F
@@ -47,6 +47,36 @@ contains
 
    end subroutine ocn_config_init!}}}
 
+   function ocn_build_log_filename(prefix, identifier) result(filename)!{{{
+      character (len=*), intent(in) :: prefix
+      integer, intent(in) :: identifier
+
+      character (len=StrKIND) :: filename
+
+      character (len=StrKIND) :: identifierString
+
+      if ( identifier .lt. 10 ) then
+         write(identifierString, '(I1)') identifier
+      else if ( identifier .lt. 100 ) then
+         write(identifierString, '(I2)') identifier
+      else if ( identifier .lt. 1000 ) then
+         write(identifierString, '(I3)') identifier
+      else if ( identifier .lt. 10000 ) then
+         write(identifierString, '(I4)') identifier
+      else if ( identifier .lt. 100000 ) then
+         write(identifierString, '(I5)') identifier
+      else if ( identifier .lt. 1000000 ) then
+         write(identifierString, '(I6)') identifier
+      else if ( identifier .lt. 10000000 ) then
+         write(identifierString, '(I7)') identifier
+      else
+         write(identifierString, '(I99)') identifier
+      end if
+
+      filename = trim(prefix) // trim(identifierString)
+
+   end function ocn_build_log_filename!}}}
+
 !***********************************************************************
 
 end module ocn_config

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -78,6 +78,7 @@ module ocn_diagnostics
    integer :: ke_cell_flag, ke_vertex_flag
    real (kind=RKIND) ::  fCoef
    real (kind=RKIND) ::  landIceTopDragCoeff
+   real (kind=RKIND) ::  rho_floatation
    real (kind=RKIND), pointer ::  coef_3rd_order
 
    ! Methods for computing thickness at edges for flux calculations
@@ -141,7 +142,7 @@ contains
       logical :: full_compute = .true.
 
       real (kind=RKIND), dimension(:), pointer :: &
-        frazilSurfacePressure, landIcePressure, landIceDraft, landIceFraction
+        frazilSurfacePressure, landIcePressure, landIceFraction
 
       integer, dimension(:), pointer :: &
         landIceFloatingMask
@@ -179,7 +180,6 @@ contains
 
       if (landIcePressureOn) then
          call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
-         call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
          call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
          call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
          if (nCellsAll.gt.0 .AND. landIceFloatingMask(1) == -1) then
@@ -468,11 +468,12 @@ contains
       !
       !  compute fields needed to compute land-ice fluxes, either in the ocean model or in the coupler
       !
-      ! inputs: layerThickness, normalVelocity, landIceFraction, landIceFloatingMask
+      ! inputs: layerThickness, normalVelocity, landIcePressure, landIceFraction, landIceFloatingMask
       ! outputs:
       if (landIcePressureOn) then
          call ocn_compute_land_ice_flux_input_fields(layerThickness, normalVelocity, activeTracers, &
-                landIceFraction, landIceFloatingMask, timeLevel, indexTemperature, indexSalinity)
+                landIcePressure, landIceDraft, landIceFraction, landIceFloatingMask, timeLevel, &
+                indexTemperature, indexSalinity)
       end if
 
       if ( full_compute ) then
@@ -3641,7 +3642,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine ocn_compute_land_ice_flux_input_fields(layerThickness, normalVelocity, &
-      activeTracers, landIceFraction, landIceFloatingMask, &
+      activeTracers, landIcePressure, landIceDraft, landIceFraction, landIceFloatingMask, &
       timeLevel, indexTval, indexSval)!{{{
 
       !-----------------------------------------------------------------
@@ -3656,7 +3657,7 @@ contains
          layerThickness, normalVelocity
 
       real (kind=RKIND), dimension(:), intent(in) :: &
-         landIceFraction
+         landIcePressure, landIceDraft, landIceFraction
 
       real (kind=RKIND), dimension(:,:,:), intent(in) :: &
          activeTracers
@@ -3690,11 +3691,23 @@ contains
 
       !-----------------------------------------------------------------
 
-      if (( trim(config_land_ice_flux_mode) == "off" ) .or.  &
-          ( trim(config_land_ice_flux_mode) == "pressure_only")) then
-         ! nothing to do here
-         return
-      end if
+      if ( trim(config_land_ice_flux_mode) == "off" ) return
+
+#ifdef MPAS_OPENACC
+      !$acc parallel loop present(landIceDraft, landIcePressure)
+#else
+      !$omp parallel
+      !$omp do schedule(runtime)
+#endif
+      do iCell = 1, nCellsAll
+         landIceDraft(iCell) = -landIcePressure(iCell) / (rho_floatation * gravity)
+      end do
+#ifndef MPAS_OPENACC
+      !$omp end do
+      !$omp end parallel
+#endif
+
+      if ( trim(config_land_ice_flux_mode) == "pressure_only") return
 
       call mpas_timer_start("land_ice_diagnostic_fields", .false.)
 
@@ -4696,6 +4709,8 @@ contains
       else
          landIceTopDragCoeff = config_land_ice_flux_explicit_topDragCoeff
       endif
+
+      rho_floatation = config_land_ice_rho_ocean
 
       if (trim(config_thickness_drag_type) == 'centered') then
          thickEdgeDragChoice = thickEdgeDragCenter

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -39,6 +39,7 @@ module ocn_diagnostics
    use ocn_surface_land_ice_fluxes
    use ocn_vertical_advection
    use ocn_subgrid
+   use ocn_wetting_drying, only: ocn_wetting_drying_update_land_ice
 
    implicit none
    private
@@ -142,7 +143,7 @@ contains
       logical :: full_compute = .true.
 
       real (kind=RKIND), dimension(:), pointer :: &
-        frazilSurfacePressure, landIcePressure, landIceDraft, landIceFraction
+        frazilSurfacePressure, landIcePressure, landIceDraft, landIceFraction, landIceFloatingFraction
 
       integer, dimension(:), pointer :: &
         landIceFloatingMask
@@ -182,6 +183,7 @@ contains
          call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
          call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
          call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
+         call mpas_pool_get_array(forcingPool, 'landIceFloatingFraction', landIceFloatingFraction)
          call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
          if (nCellsAll.gt.0 .AND. landIceFloatingMask(1) == -1) then
             call mpas_log_write('landIceFloatingMask contains the default value which likely indicates that this field is missing in the initial condition file (e.g. because it is meant for an older E3SM version).', &
@@ -475,6 +477,9 @@ contains
          call ocn_compute_land_ice_flux_input_fields(layerThickness, normalVelocity, activeTracers, &
                 landIcePressure, landIceDraft, landIceFraction, landIceFloatingMask, timeLevel, &
                 indexTemperature, indexSalinity)
+      end if
+      if (landIcePressureOn .and. config_use_wetting_drying) then
+         call ocn_wetting_drying_update_land_ice(landIceFloatingMask, landIceFloatingFraction, err)
       end if
 
       if ( full_compute ) then
@@ -4607,36 +4612,6 @@ contains
       end if
 
    end subroutine ocn_validate_state!}}}
-
-   function ocn_build_log_filename(prefix, identifier) result(filename)!{{{
-      character (len=*), intent(in) :: prefix
-      integer, intent(in) :: identifier
-
-      character (len=StrKIND) :: filename
-
-      character (len=StrKIND) :: identifierString
-
-      if ( identifier .lt. 10 ) then
-         write(identifierString, '(I1)') identifier
-      else if ( identifier .lt. 100 ) then
-         write(identifierString, '(I2)') identifier
-      else if ( identifier .lt. 1000 ) then
-         write(identifierString, '(I3)') identifier
-      else if ( identifier .lt. 10000 ) then
-         write(identifierString, '(I4)') identifier
-      else if ( identifier .lt. 100000 ) then
-         write(identifierString, '(I5)') identifier
-      else if ( identifier .lt. 1000000 ) then
-         write(identifierString, '(I6)') identifier
-      else if ( identifier .lt. 10000000 ) then
-         write(identifierString, '(I7)') identifier
-      else
-         write(identifierString, '(I99)') identifier
-      end if
-
-      filename = trim(prefix) // trim(identifierString)
-
-   end function ocn_build_log_filename!}}}
 
    subroutine ocn_write_field_statistics(unitNumber, fieldName, minValue, maxValue)
       integer, intent(in) :: unitNumber

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -142,7 +142,7 @@ contains
       logical :: full_compute = .true.
 
       real (kind=RKIND), dimension(:), pointer :: &
-        frazilSurfacePressure, landIcePressure, landIceFraction
+        frazilSurfacePressure, landIcePressure, landIceDraft, landIceFraction
 
       integer, dimension(:), pointer :: &
         landIceFloatingMask
@@ -180,6 +180,7 @@ contains
 
       if (landIcePressureOn) then
          call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
+         call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
          call mpas_pool_get_array(forcingPool, 'landIceFloatingMask', landIceFloatingMask)
          call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
          if (nCellsAll.gt.0 .AND. landIceFloatingMask(1) == -1) then
@@ -479,11 +480,11 @@ contains
       if ( full_compute ) then
 
          !
-         ! inputs: ssh, seaIcePressure, landIceDraft
+         ! inputs: ssh, seaIcePressure, landIceDraftForSsh
          ! outputs: pressureAdjustedSSH, gradSSH
          if (landIcePressureOn) then
             call ocn_diagnostic_solve_ssh(forcingPool, ssh, seaIcePressure, &
-                   pressureAdjustedSSH, gradSSH, landIceDraft=landIceDraft )
+                   pressureAdjustedSSH, gradSSH, landIceDraftForSsh=landIceDraftForSsh )
         else
             call ocn_diagnostic_solve_ssh(forcingPool, ssh, seaIcePressure, &
                    pressureAdjustedSSH, gradSSH)
@@ -2898,7 +2899,7 @@ contains
 !
 !-----------------------------------------------------------------------
    subroutine ocn_diagnostic_solve_ssh(forcingPool, ssh, seaIcePressure, &
-                pressureAdjustedSSH, gradSSH, landIceDraft)!{{{
+                pressureAdjustedSSH, gradSSH, landIceDraftForSsh)!{{{
 
       implicit none
 
@@ -2914,7 +2915,7 @@ contains
       real (kind=RKIND), dimension(:), intent(in) :: &
          seaIcePressure
       real (kind=RKIND), dimension(:), optional, intent(in) :: &
-         landIceDraft
+         landIceDraftForSsh
 
       !-----------------------------------------------------------------
       !
@@ -2957,7 +2958,7 @@ contains
          !! This first directive should be correct, but there may
          !! be a problem with the optional argument. Removing optional
          !! landIceDraft from the present list for now.
-         !!acc parallel loop present(pressureAdjustedSSH, landIceDraft)
+         !!acc parallel loop present(pressureAdjustedSSH, landIceDraftForSsh)
          !$acc parallel loop present(pressureAdjustedSSH)
 #else
          !$omp parallel
@@ -2966,7 +2967,7 @@ contains
          do iCell = 1, nCells
             ! subtract the land ice draft from the SSH so sea ice doesn't experience tilt
             ! toward land ice
-            pressureAdjustedSSH(iCell) = pressureAdjustedSSH(iCell) - landIceDraft(iCell)
+            pressureAdjustedSSH(iCell) = pressureAdjustedSSH(iCell) - landIceDraftForSsh(iCell)
          end do
 #ifndef MPAS_OPENACC
          !$omp end do
@@ -3693,19 +3694,26 @@ contains
 
       if ( trim(config_land_ice_flux_mode) == "off" ) return
 
+      if ( trim(config_land_ice_draft_mode) == "data" ) then
+
+         landIceDraftForSsh = landIceDraft
+
+      elseif ( trim(config_land_ice_draft_mode) == "pressure-dependent" ) then
+
 #ifdef MPAS_OPENACC
-      !$acc parallel loop present(landIceDraft, landIcePressure)
+         !$acc parallel loop present(landIceDraftForSsh, landIcePressure)
 #else
-      !$omp parallel
-      !$omp do schedule(runtime)
+         !$omp parallel
+         !$omp do schedule(runtime)
 #endif
-      do iCell = 1, nCellsAll
-         landIceDraft(iCell) = -landIcePressure(iCell) / (rho_floatation * gravity)
-      end do
+         do iCell = 1, nCellsAll
+            landIceDraftForSsh(iCell) = -landIcePressure(iCell) / (rho_floatation * gravity)
+         end do
 #ifndef MPAS_OPENACC
-      !$omp end do
-      !$omp end parallel
+         !$omp end do
+         !$omp end parallel
 #endif
+      endif
 
       if ( trim(config_land_ice_flux_mode) == "pressure_only") return
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -79,7 +79,6 @@ module ocn_diagnostics
    integer :: ke_cell_flag, ke_vertex_flag
    real (kind=RKIND) ::  fCoef
    real (kind=RKIND) ::  landIceTopDragCoeff
-   real (kind=RKIND) ::  rho_floatation
    real (kind=RKIND), pointer ::  coef_3rd_order
 
    ! Methods for computing thickness at edges for flux calculations
@@ -3679,7 +3678,8 @@ contains
 
       integer :: iCell, iEdge, cell1, cell2, iLevel, i
 
-      real (kind=RKIND) :: blThickness, dz, weightSum, h_nu, Gamma_turb, landIceEdgeFraction, velocityMagnitude
+      real (kind=RKIND) :: blThickness, dz, weightSum, h_nu, Gamma_turb, landIceEdgeFraction, &
+                           velocityMagnitude, rho_floatation
 
       ! Scratch Arrays
       real (kind=RKIND), dimension(:), allocatable ::  &
@@ -3704,6 +3704,8 @@ contains
          landIceDraftForSsh = landIceDraft
 
       elseif ( trim(config_land_ice_draft_mode) == "pressure-dependent" ) then
+
+         rho_floatation = config_land_ice_rho_ocean
 
 #ifdef MPAS_OPENACC
          !$acc parallel loop present(landIceDraftForSsh, landIcePressure)
@@ -4692,8 +4694,6 @@ contains
       else
          landIceTopDragCoeff = config_land_ice_flux_explicit_topDragCoeff
       endif
-
-      rho_floatation = config_land_ice_rho_ocean
 
       if (trim(config_thickness_drag_type) == 'centered') then
          thickEdgeDragChoice = thickEdgeDragCenter

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -87,6 +87,7 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficientRunoff
    real (kind=RKIND), dimension(:), pointer :: surfaceFluxAttenuationCoefficientSubglacialRunoff
 
+   real (kind=RKIND), dimension(:), pointer :: landIceDraftForSsh
    real (kind=RKIND), dimension(:), pointer :: landIceFrictionVelocity
    real (kind=RKIND), dimension(:), pointer :: velocityTidalRMS
 
@@ -355,6 +356,7 @@ contains
       ! Retrieve pointers for configurations where land_ice_flux_mode is enabled
       if ( trim(config_land_ice_flux_mode) /= 'off' ) then
          call mpas_pool_get_array(diagnosticsPool, 'topDrag', topDrag)
+         call mpas_pool_get_array(diagnosticsPool, 'landIceDraftForSsh', landIceDraftForSsh)
          call mpas_pool_get_array(diagnosticsPool, 'topDragMagnitude', topDragMag)
          call mpas_pool_get_dimension(diagnosticsPool, &
                    'index_landIceBoundaryLayerTemperature', indexBLTPtr)
@@ -751,6 +753,7 @@ contains
          !$acc                   landIceBoundaryLayerTracers,     &
          !$acc                   landIceTracerTransferVelocities, &
          !$acc                   landIceFrictionVelocity,         &
+         !$acc                   landIceDraftForSsh,              &
          !$acc                   velocityTidalRMS)
       end if
       if (config_use_topographic_wave_drag) then
@@ -1010,6 +1013,7 @@ contains
          !$acc                   topDragMag,                      &
          !$acc                   landIceBoundaryLayerTracers,     &
          !$acc                   landIceTracerTransferVelocities, &
+         !$acc                   landIceDraftForSsh,              &
          !$acc                   landIceFrictionVelocity,         &
          !$acc                   velocityTidalRMS)
       end if
@@ -1239,6 +1243,7 @@ contains
                  landIceBoundaryLayerTracers,     &
                  landIceTracerTransferVelocities, &
                  landIceFrictionVelocity,         &
+                 landIceDraftForSsh,              &
                  velocityTidalRMS)
       end if
       if ( trim(config_ocean_run_mode) == 'init' ) then

--- a/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_eddy_parameterization_helpers.F
@@ -198,7 +198,7 @@ module ocn_eddy_parameterization_helpers
      real(kind=RKIND) :: dDenThres, den_ref_lev
      real(kind=RKIND),dimension(:), allocatable :: depth
      real (kind=RKIND), dimension(:,:), pointer :: layerThickness
-     real (kind=RKIND), dimension(:), pointer :: landIceDraft, landIcePressure
+     real (kind=RKIND), dimension(:), pointer :: landIcePressure
      logical :: found_den_mld
      real (kind=RKIND) :: dV, dVp1, refDepth, coeffs(2), mldTemp, dz
      real (kind=RKIND), dimension(:,:), allocatable :: pressureAdjustedForLandIce
@@ -207,7 +207,6 @@ module ocn_eddy_parameterization_helpers
 
      if ( config_eddyMLD_use_old ) then
        call mpas_pool_get_array(forcingPool, 'landIcePressure', landIcePressure)
-       call mpas_pool_get_array(forcingPool, 'landIceDraft', landIceDraft)
 
        allocate(pressureAdjustedForLandIce(nVertLevels, size(pressure,2)))
 
@@ -279,11 +278,11 @@ module ocn_eddy_parameterization_helpers
         !$omp end do
         !$omp end parallel
 
-        if (associated(landIceDraft) ) then
+        if (associated(landIceDraftForSsh) ) then
           !$omp parallel
           !$omp do schedule(runtime)
           do iCell = 1, nCells
-             dThreshMLD(iCell) = dThreshMLD(iCell) - abs(landIceDraft(iCell))
+             dThreshMLD(iCell) = dThreshMLD(iCell) - abs(landIceDraftForSsh(iCell))
           end do
           !$omp end do
           !$omp end parallel

--- a/components/mpas-ocean/src/shared/mpas_ocn_wetting_drying.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_wetting_drying.F
@@ -29,7 +29,6 @@ module ocn_wetting_drying
 
    use ocn_constants
    use ocn_config
-   use ocn_diagnostics
    use ocn_diagnostics_variables
    use ocn_gm
    use ocn_mesh
@@ -54,6 +53,7 @@ module ocn_wetting_drying
 
    public :: ocn_wetting_drying_verify, ocn_prevent_drying_rk4
    public :: ocn_wetting_velocity_factor_on_cell_edges
+   public :: ocn_wetting_drying_update_land_ice
 
    !--------------------------------------------------------------------
    !
@@ -636,6 +636,57 @@ contains
       end if
 
    end subroutine ocn_wetting_velocity_factor_on_cell_edges!}}}
+
+   subroutine ocn_wetting_drying_update_land_ice(landIceFloatingMask, landIceFloatingFraction, err)
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      ! landIceDraftForSsh is supplied by diagnostic_variables
+
+      integer, dimension(:), intent(inout) :: &
+         landIceFloatingMask     !< Input/Output: land ice floating mask
+
+      real (kind=RKIND), dimension(:), intent(inout) :: &
+         landIceFloatingFraction !< Input/Output: land ice floating fraction
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell
+
+      err = 0
+
+      !$omp parallel
+      !$omp do schedule(runtime)
+      do iCell = 1, nCellsAll
+         if (landIceDraftForSsh(iCell) < -bottomDepth(iCell)) then
+            landIceFloatingMask(iCell) = 0
+            landIceFloatingFraction(iCell) = 0.0_RKIND
+         else
+            landIceFloatingMask(iCell) = 1
+            ! For a simulation with wetting and drying, we do not retain fractional floating areas
+            landIceFloatingFraction(iCell) = 1.0_RKIND
+         endif
+      enddo
+      !$omp end do
+      !$omp end parallel
+
+   end subroutine ocn_wetting_drying_update_land_ice
 
 end module ocn_wetting_drying
 


### PR DESCRIPTION
This PR changes the default way the sea-surface height gradient is computed near land ice in MPAS-Ocean for MPAS-SeaIce. In the absence of land ice, this PR has no effect [BFB]. A new ocean config option, `config_land_ice_draft_mode`, determines whether to use the new default method or the current method:

* [NCC] `config_land_ice_draft_mode = 'pressure-dependent'` is the new default whereby `landIceDraft` is computed from `landIcePressure`. The (spatially and temporally) constant ice density to use for this computation is provided by the new ocean config option `config_land_ice_rho_ocean`. 
* [BFB] `config_land_ice_draft_mode = 'data'` preserves the current method whereby `landIceDraft` is provided as a forcing variable. It is applied to the following meshes
    * oQU240wLI
    * ECwISC30to60E1r2
    * SOwISC12to60E2r4
    * ECwISC30to60E2r1
    * IcoswISC30E3r5
    * FRISwISC08to60E3r1
    * FRISwISC04to60E3r1
    * FRISwISC02to60E3r1
    * FRISwISC01to60E3r1
    * RRSwISC6to18E3r5

`config_land_ice_draft_mode = 'pressure-dependent'` provides a more accurate determination of the SSH gradient near ice shelves when the SSH is adjusted during initialization. This is now done by default for new meshes https://github.com/E3SM-Project/E3SM/pull/6375, which is why this option is the default here.

`config_land_ice_draft_mode = 'data'` provides a more accurate determination of the SSH gradient near ice shelves when the land ice pressure is adjusted during initialization. This config option is set for all meshes with ice shelf cavities employed in e3sm tests that were created prior to https://github.com/E3SM-Project/E3SM/pull/6375. 

The use of `landIceDraft` is:
* [NCC] Computing the pressure-adjusted SSH gradient for MPAS-Seaice. Formerly, `landIceDraft` was computed in compass using `SHR_CONST_RHOSW`. To increase accuracy, a representative ocean density near ice shelf fronts should be used. The separate config option `config_land_ice_rho_ocean` is used for this purpose.
* [Stealth, MPAS-Ocean standalone] For wetting-and-drying configurations in which there are ice shelf cavities, it is used to update the ice shelf area over which melting occurs. In coupled MALI configurations, this area will be determined in the coupler on the MALI mesh and this code will not be used.

[NML]
[NCC]