### PR TITLE
EAMxx: remove mpi from vert_contraction impl

### DIFF
--- a/components/eamxx/src/diagnostics/tests/vert_contract_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/vert_contract_test.cpp
@@ -174,8 +174,8 @@ TEST_CASE("vert_contract") {
 
   dp_scaled.scale(sp(1.0) / scream::physics::Constants<Real>::gravit);
 
-  vert_contraction<Real>(dps, dp_scaled, dp_ones, &comm);
-  // vert_contraction<Real>(dzs, dz_scaled, dz_ones, &comm);
+  vert_contraction<Real>(dps, dp_scaled, dp_ones);
+  // vert_contraction<Real>(dzs, dz_scaled, dz_ones);
 
   SECTION("dp_weighted_avg") {
     // scale dp_scaled by 1/dps (because we are averaging)
@@ -195,7 +195,7 @@ TEST_CASE("vert_contract") {
     dp_scaled.sync_to_dev();
 
     // calculate weighted avg directly
-    vert_contraction<Real>(diag1_m, fin2, dp_scaled, &comm);
+    vert_contraction<Real>(diag1_m, fin2, dp_scaled);
 
     // Calculate weighted avg through diagnostics
     dp_weighted_avg->set_required_field(fin2);
@@ -209,7 +209,7 @@ TEST_CASE("vert_contract") {
 
   SECTION("dp_weighted_sum") {
     // calculate weighted sum directly
-    vert_contraction<Real>(diag2_m, fin3, dp_scaled, &comm);
+    vert_contraction<Real>(diag2_m, fin3, dp_scaled);
     // Calculate weighted sum through diagnostics
     dp_weighted_sum->set_required_field(fin3);
     dp_weighted_sum->set_required_field(dp);
@@ -238,7 +238,7 @@ TEST_CASE("vert_contract") {
   //   dz_scaled.sync_to_dev();
 
   //   // calculate weighted avg directly
-  //   vert_contraction<Real>(diag1_m, fin2, dz_scaled, &comm);
+  //   vert_contraction<Real>(diag1_m, fin2, dz_scaled);
 
   //   // Calculate weighted avg through diagnostics
   //   dz_weighted_avg->set_required_field(fin2);
@@ -252,7 +252,7 @@ TEST_CASE("vert_contract") {
 
   // SECTION("dz_weighted_sum") {
   //   // calculate weighted sum directly
-  //   vert_contraction<Real>(diag2_m, fin3, dz_scaled, &comm);
+  //   vert_contraction<Real>(diag2_m, fin3, dz_scaled);
   //   // Calculate weighted sum through diagnostics
   //   dz_weighted_sum->set_required_field(fin3);
   //   dz_weighted_sum->set_required_field(dz);
@@ -265,7 +265,7 @@ TEST_CASE("vert_contract") {
 
   SECTION("unweighted_sum") {
     // calculate unweighted sum directly
-    vert_contraction<Real>(diag1_m, fin2, dp_ones, &comm);
+    vert_contraction<Real>(diag1_m, fin2, dp_ones);
 
     // Calculate unweighted sum through diagnostics
     unweighted_sum->set_required_field(fin2);
@@ -289,7 +289,7 @@ TEST_CASE("vert_contract") {
     }
     dp_ones_scaled.sync_to_dev();
     // calculate unweighted avg directly
-    vert_contraction<Real>(diag2_m, fin3, dp_ones_scaled, &comm);
+    vert_contraction<Real>(diag2_m, fin3, dp_ones_scaled);
     // Calculate unweighted avg through diagnostics
     unweighted_avg->set_required_field(fin3);
     unweighted_avg->initialize(t0, RunType::Initial);

--- a/components/eamxx/src/diagnostics/vert_contract.cpp
+++ b/components/eamxx/src/diagnostics/vert_contract.cpp
@@ -102,7 +102,7 @@ void VertContractDiag::initialize_impl(const RunType /*run_type*/) {
     m_weighting_sum.allocate_view();
     m_weighting_one = m_weighting.clone("vert_contract_wts_one");
     m_weighting_one.deep_copy(sp(1));
-    vert_contraction<Real>(m_weighting_sum, m_weighting, m_weighting_one, &m_comm);
+    vert_contraction<Real>(m_weighting_sum, m_weighting, m_weighting_one);
     VertContractDiag::scale_wts(m_weighting, m_weighting_sum);
   }
 
@@ -182,12 +182,12 @@ void VertContractDiag::compute_diagnostic_impl() {
 
   // if dp|dz_weighted and avg, we need to scale the weighting by its 1/sum
   if ((m_weighting_method == "dp" || m_weighting_method == "dz") && m_contract_method == "avg") {
-    vert_contraction<Real>(m_weighting_sum, m_weighting, m_weighting_one, &m_comm);
+    vert_contraction<Real>(m_weighting_sum, m_weighting, m_weighting_one);
     VertContractDiag::scale_wts(m_weighting, m_weighting_sum);
   }
 
   // call the vert_contraction impl that will take care of everything
-  vert_contraction<Real>(d, f, m_weighting, &m_comm);
+  vert_contraction<Real>(d, f, m_weighting);
 }
 
 }  // namespace scream

--- a/components/eamxx/src/share/field/field_utils.hpp
+++ b/components/eamxx/src/share/field/field_utils.hpp
@@ -190,9 +190,9 @@ void horiz_contraction(const Field &f_out, const Field &f_in,
 // - Weight is assumed to be (in order of checking/impl):
 //   - rank-1, with only LEV/ILEV dimension
 //   - rank-2, with only COL and LEV/ILEV dimensions
+// NOTE: we assume the LEV/ILEV dimension is NOT partitioned.
 template <typename ST>
-void vert_contraction(const Field &f_out, const Field &f_in,
-                      const Field &weight, const ekat::Comm *comm = nullptr) {
+void vert_contraction(const Field &f_out, const Field &f_in, const Field &weight) {
   using namespace ShortFieldTagsNames;
 
   const auto &l_out = f_out.get_header().get_identifier().get_layout();
@@ -266,7 +266,7 @@ void vert_contraction(const Field &f_out, const Field &f_in,
       "Error! Weight field must have the same data type as input field.");
 
   // All good, call the implementation
-  impl::vert_contraction<ST>(f_out, f_in, weight, comm);
+  impl::vert_contraction<ST>(f_out, f_in, weight);
 }
 
 template<typename ST>

--- a/components/eamxx/src/share/field/field_utils_impl.hpp
+++ b/components/eamxx/src/share/field/field_utils_impl.hpp
@@ -378,8 +378,7 @@ void horiz_contraction(const Field &f_out, const Field &f_in,
 }
 
 template <typename ST>
-void vert_contraction(const Field &f_out, const Field &f_in,
-                      const Field &weight, const ekat::Comm *comm) {
+void vert_contraction(const Field &f_out, const Field &f_in, const Field &weight) {
   using KT          = ekat::KokkosTypes<DefaultDevice>;
   using RangePolicy = Kokkos::RangePolicy<Field::device_t::execution_space>;
   using TeamPolicy  = Kokkos::TeamPolicy<Field::device_t::execution_space>;
@@ -451,17 +450,6 @@ void vert_contraction(const Field &f_out, const Field &f_in,
     } break;
     default:
       EKAT_ERROR_MSG("Error! Unsupported field rank in vert_contraction.\n");
-  }
-
-  if(comm) {
-    // TODO: use device-side MPI calls
-    // TODO: the dev ptr causes problems; revisit this later
-    // TODO: doing cuda-aware MPI allreduce would be ~10% faster
-    Kokkos::fence();
-    f_out.sync_to_host();
-    comm->all_reduce(f_out.template get_internal_view_data<ST, Host>(),
-                     l_out.size(), MPI_SUM);
-    f_out.sync_to_dev();
   }
 }
 


### PR DESCRIPTION
removes MPI communication functionality from the vertical contraction implementation in EAMxx.

Fixes #7308 