### PR TITLE
Correct pelayout config file for eamxx, begin better organization, and add basic eamxx default pelayouts

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -1732,28 +1732,28 @@
   <grid name="a%ne30np4">
     <mach name="pm-gpu|muller-gpu|alvarez-gpu">
       <pes compset="any" pesize="any">
-        <comment>"pm-gpu ne30np4 and ne30np4.pg2  2 nodes, 4x16"</comment>
+        <comment>default pm-gpu ne30np4 and ne30np4.pg2  1 node 4x1 (16 threads in lnd/ice/ocn/rof)</comment>
         <ntasks>
-          <ntasks_atm>-2</ntasks_atm>
-          <ntasks_lnd>-2</ntasks_lnd>
-          <ntasks_rof>-2</ntasks_rof>
-          <ntasks_ice>-2</ntasks_ice>
-          <ntasks_ocn>-2</ntasks_ocn>
-          <ntasks_glc>-2</ntasks_glc>
-          <ntasks_wav>-2</ntasks_wav>
-          <ntasks_cpl>-2</ntasks_cpl>
+          <ntasks_atm>-1</ntasks_atm>
+          <ntasks_lnd>-1</ntasks_lnd>
+          <ntasks_rof>-1</ntasks_rof>
+          <ntasks_ice>-1</ntasks_ice>
+          <ntasks_ocn>-1</ntasks_ocn>
+          <ntasks_glc>-1</ntasks_glc>
+          <ntasks_wav>-1</ntasks_wav>
+          <ntasks_cpl>-1</ntasks_cpl>
         </ntasks>
         <nthrds>
-          <nthrds_atm>16</nthrds_atm>
+          <nthrds_atm>1</nthrds_atm>
           <nthrds_lnd>16</nthrds_lnd>
-          <nthrds_rof>8</nthrds_rof>
-          <nthrds_ice>8</nthrds_ice>
-          <nthrds_ocn>8</nthrds_ocn>
-          <nthrds_cpl>8</nthrds_cpl>
+          <nthrds_rof>16</nthrds_rof>
+          <nthrds_ice>16</nthrds_ice>
+          <nthrds_ocn>16</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
         </nthrds>
       </pes>
       <pes compset=".*2010_SCREAM_ELM.*MPASSI_MPASO.*" pesize="any">
-        <comment>"pm-gpu ne30 for fully coupled cases with ATM on GPU, MPAS on CPU -- WCYCLXX2010 4 nodes, 4x16"</comment>
+        <comment>pm-gpu ne30 for fully coupled cases with ATM on GPU, MPAS on CPU -- WCYCLXX2010 4 nodes, 4x16</comment>
         <ntasks>
           <ntasks_atm>-4</ntasks_atm>
           <ntasks_lnd>-4</ntasks_lnd>
@@ -1770,44 +1770,6 @@
           <nthrds_rof>1</nthrds_rof>
           <nthrds_ice>16</nthrds_ice>
           <nthrds_ocn>16</nthrds_ocn>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-      </pes>
-    </mach>
-    <mach name="pm-cpu|muller-cpu|alvarez-cpu">
-      <pes compset="any" pesize="any">
-        <comment>"pm-cpu ne30np4 and ne30np4.pg2 2 nodes, stacked, 1 thread, 128x1"</comment>
-        <ntasks>
-          <ntasks_atm>-2</ntasks_atm>
-          <ntasks_lnd>-2</ntasks_lnd>
-          <ntasks_rof>-2</ntasks_rof>
-          <ntasks_ice>-2</ntasks_ice>
-          <ntasks_ocn>-2</ntasks_ocn>
-          <ntasks_glc>-2</ntasks_glc>
-          <ntasks_wav>-2</ntasks_wav>
-          <ntasks_cpl>-2</ntasks_cpl>
-        </ntasks>
-      </pes>
-    </mach>
-    <mach name="frontier">
-      <pes compset="any" pesize="any">
-        <comment>"frontier ne30np4 and ne30np4.pg2"</comment>
-        <ntasks>
-          <ntasks_atm>-2</ntasks_atm>
-          <ntasks_lnd>-2</ntasks_lnd>
-          <ntasks_rof>-2</ntasks_rof>
-          <ntasks_ice>-2</ntasks_ice>
-          <ntasks_ocn>-2</ntasks_ocn>
-          <ntasks_glc>-2</ntasks_glc>
-          <ntasks_wav>-2</ntasks_wav>
-          <ntasks_cpl>-2</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>7</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
           <nthrds_cpl>1</nthrds_cpl>
         </nthrds>
       </pes>
@@ -2422,53 +2384,6 @@
         <nthrds>
           <nthrds_atm>1</nthrds_atm>
           <nthrds_lnd>14</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-      </pes>
-    </mach>
-    <mach name="frontier">
-      <pes compset="any" pesize="any">
-        <MAX_MPITASKS_PER_NODE>8</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>56</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>-6</ntasks_atm>
-          <ntasks_lnd>-6</ntasks_lnd>
-          <ntasks_rof>-6</ntasks_rof>
-          <ntasks_ice>-6</ntasks_ice>
-          <ntasks_ocn>-6</ntasks_ocn>
-          <ntasks_glc>-6</ntasks_glc>
-          <ntasks_wav>-6</ntasks_wav>
-          <ntasks_cpl>-6</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>7</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-      </pes>
-    </mach>
-    <mach name="pm-gpu|muller-gpu|alvarez-gpu">
-      <pes compset="any" pesize="any">
-        <comment>pm-gpu conus 2 nodes, 4x1 except 16 threads in LND</comment>
-        <MAX_MPITASKS_PER_NODE>4</MAX_MPITASKS_PER_NODE>
-        <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
-        <ntasks>
-          <ntasks_atm>-2</ntasks_atm>
-          <ntasks_lnd>-2</ntasks_lnd>
-          <ntasks_rof>-2</ntasks_rof>
-          <ntasks_ice>-2</ntasks_ice>
-          <ntasks_ocn>-2</ntasks_ocn>
-          <ntasks_cpl>-2</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>16</nthrds_lnd>
           <nthrds_rof>1</nthrds_rof>
           <nthrds_ice>1</nthrds_ice>
           <nthrds_ocn>1</nthrds_ocn>

--- a/cime_config/config_files.xml
+++ b/cime_config/config_files.xml
@@ -286,6 +286,7 @@
       <value component="allactive">$SRCROOT/cime_config/allactive/config_pesall.xml</value>
       <value component="drv"      >$COMP_ROOT_DIR_CPL/cime_config/config_pes.xml</value>
       <value component="eam"      >$SRCROOT/components/eam/cime_config/config_pes.xml</value>
+      <value component="scream"   >$SRCROOT/components/eamxx/cime_config/config_pes.xml</value>
       <value component="elm"      >$SRCROOT/components/elm/cime_config/config_pes.xml</value>
       <value component="cice"     >$SRCROOT/components/cice/cime_config/config_pes.xml</value>
       <value component="mpaso"    >$SRCROOT/components/mpas-ocean/cime_config/config_pes.xml</value>

--- a/components/eamxx/cime_config/config_pes.xml
+++ b/components/eamxx/cime_config/config_pes.xml
@@ -3,37 +3,226 @@
   <grid name="any">
     <mach name="any">
       <pes compset=".+" pesize="any">
-        <comment>none</comment>
+        <comment>default eamxx, 1 node, no threads</comment>
         <ntasks>
-          <ntasks_atm>1</ntasks_atm>
-          <ntasks_lnd>1</ntasks_lnd>
-          <ntasks_rof>1</ntasks_rof>
-          <ntasks_ice>1</ntasks_ice>
-          <ntasks_ocn>1</ntasks_ocn>
+          <ntasks_atm>-1</ntasks_atm>
+          <ntasks_lnd>-1</ntasks_lnd>
+          <ntasks_rof>-1</ntasks_rof>
+          <ntasks_ice>-1</ntasks_ice>
+          <ntasks_ocn>-1</ntasks_ocn>
+          <ntasks_glc>-1</ntasks_glc>
+          <ntasks_wav>-1</ntasks_wav>
+          <ntasks_cpl>-1</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="a%ne4np4">
+    <mach name="pm-gpu|muller-gpu|alvarez-gpu">
+      <!-- Compset longname is 2010_SCREAM_ELM%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV_SIAC_SESP -->
+      <pes compset=".*EAM.+ELM.+DOCN" pesize="any">
+        <comment>pm-gpu: ne4 eamxx F case, 1 nodes, 4x1</comment>
+        <ntasks>
+          <ntasks_atm>-1</ntasks_atm>
+          <ntasks_cpl>-1</ntasks_cpl>
+          <ntasks_ice>-1</ntasks_ice>
+          <ntasks_lnd>-1</ntasks_lnd>
+          <ntasks_rof>-1</ntasks_rof>
+          <ntasks_ocn>-1</ntasks_ocn>
           <ntasks_glc>1</ntasks_glc>
           <ntasks_wav>1</ntasks_wav>
-          <ntasks_cpl>1</ntasks_cpl>
         </ntasks>
         <nthrds>
-          <nthrds_atm>16</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_lnd>16</nthrds_lnd>
+          <nthrds_ice>16</nthrds_ice>
+        </nthrds>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="a%ne30np4">
+    <mach name="pm-gpu|muller-gpu|alvarez-gpu">
+      <pes compset=".*EAM.+ELM.+DOCN" pesize="any">
+        <comment>pm-gpu: ne30 eamxx F case, 2 nodes, 4x1</comment>
+        <ntasks>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_cpl>-2</ntasks_cpl>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_glc>1</ntasks_glc>
+          <ntasks_wav>1</ntasks_wav>
+        </ntasks>
+        <nthrds>
+          <nthrds_lnd>16</nthrds_lnd>
+          <nthrds_ice>16</nthrds_ice>
+        </nthrds>
+      </pes>
+    </mach>
+    <mach name="frontier">
+      <pes compset="any" pesize="any">
+        <comment>frontier: ne30 eamxx 2 nodes, 7 threads in LND/ICE</comment>
+        <ntasks>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_cpl>-2</ntasks_cpl>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_glc>1</ntasks_glc>
+          <ntasks_wav>1</ntasks_wav>
+        </ntasks>
+        <nthrds>
+          <nthrds_lnd>7</nthrds_lnd>
+          <nthrds_ice>7</nthrds_ice>
+        </nthrds>
+      </pes>
+    </mach>
+    <mach name="pm-cpu|muller-cpu|alvarez-cpu">
+      <pes compset="any" pesize="any">
+        <comment>pm-cpu: ne30 eamxx 2 nodes, 128x1</comment>
+        <ntasks>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_cpl>-2</ntasks_cpl>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_glc>1</ntasks_glc>
+          <ntasks_wav>1</ntasks_wav>
+        </ntasks>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="a%ne120np4">
+    <mach name="pm-gpu|muller-gpu|alvarez-gpu">
+      <pes compset=".*EAM.+ELM.+DOCN" pesize="any">
+        <comment>pm-gpu: ne120 eamxx F case, 8 nodes, 4x1</comment>
+        <ntasks>
+          <ntasks_atm>32</ntasks_atm>
+          <ntasks_cpl>32</ntasks_cpl>
+          <ntasks_ice>32</ntasks_ice>
+          <ntasks_lnd>32</ntasks_lnd>
+          <ntasks_rof>32</ntasks_rof>
+          <ntasks_ocn>32</ntasks_ocn>
+          <ntasks_glc>1</ntasks_glc>
+          <ntasks_wav>1</ntasks_wav>
+        </ntasks>
+        <nthrds>
+          <nthrds_lnd>16</nthrds_lnd>
+          <nthrds_ice>16</nthrds_ice>
+        </nthrds>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="a%ne256np4">
+    <mach name="pm-gpu|muller-gpu|alvarez-gpu">
+      <pes compset=".*EAM.+ELM.+DOCN" pesize="any">
+        <comment>pm-gpu: ne256 eamxx F case, 32 nodes, 4x1, 16 threads for LND/ICE</comment>
+        <ntasks>
+          <ntasks_atm>128</ntasks_atm>
+          <ntasks_cpl>128</ntasks_cpl>
+          <ntasks_ice>128</ntasks_ice>
+          <ntasks_lnd>128</ntasks_lnd>
+          <ntasks_rof>128</ntasks_rof>
+          <ntasks_ocn>128</ntasks_ocn>
+          <ntasks_glc>1</ntasks_glc>
+          <ntasks_wav>1</ntasks_wav>
+        </ntasks>
+        <nthrds>
+          <nthrds_lnd>16</nthrds_lnd>
+          <nthrds_ice>16</nthrds_ice>
+        </nthrds>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="a%ne512np4">
+    <mach name="pm-gpu|muller-gpu|alvarez-gpu">
+      <pes compset=".*EAM.+ELM.+DOCN" pesize="any">
+        <comment>pm-gpu: ne512 eamxx F case, 128 nodes, 4x1, 16 threads for LND/ICE</comment>
+        <ntasks>
+          <ntasks_atm>512</ntasks_atm>
+          <ntasks_cpl>512</ntasks_cpl>
+          <ntasks_ice>512</ntasks_ice>
+          <ntasks_lnd>512</ntasks_lnd>
+          <ntasks_rof>512</ntasks_rof>
+          <ntasks_ocn>512</ntasks_ocn>
+          <ntasks_glc>1</ntasks_glc>
+          <ntasks_wav>1</ntasks_wav>
+        </ntasks>
+        <nthrds>
+          <nthrds_lnd>16</nthrds_lnd>
+          <nthrds_ice>16</nthrds_ice>
+        </nthrds>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="a%ne1024np4">
+    <mach name="pm-gpu|muller-gpu|alvarez-gpu">
+      <pes compset=".*EAM.+ELM.+DOCN" pesize="any">
+        <comment>pm-gpu: ne1024 eamxx F case, 512 nodes, 4x1, 16 threads for LND/ICE</comment>
+        <ntasks>
+          <ntasks_atm>2048</ntasks_atm>
+          <ntasks_cpl>2048</ntasks_cpl>
+          <ntasks_ice>2048</ntasks_ice>
+          <ntasks_lnd>2048</ntasks_lnd>
+          <ntasks_rof>2048</ntasks_rof>
+          <ntasks_ocn>2048</ntasks_ocn>
+          <ntasks_glc>1</ntasks_glc>
+          <ntasks_wav>1</ntasks_wav>
+        </ntasks>
+        <nthrds>
+          <nthrds_lnd>16</nthrds_lnd>
+          <nthrds_ice>16</nthrds_ice>
+        </nthrds>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="a%ne0np4_conus_x4v1_lowcon.pg2_l%r05_oi%oEC60to30v3_r%null_g%null_w%null_z%null_m%oEC60to30v3">
+    <mach name="frontier">
+      <pes compset="any" pesize="any">
+        <comment>frontier conus 2 nodes, 8x1 except 7 threads in LND</comment>
+        <ntasks>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_cpl>-2</ntasks_cpl>
+          <ntasks_glc>-1</ntasks_glc>
+          <ntasks_wav>-1</ntasks_wav>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>7</nthrds_lnd>
           <nthrds_rof>1</nthrds_rof>
           <nthrds_ice>1</nthrds_ice>
           <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>16</nthrds_cpl>
+          <nthrds_cpl>1</nthrds_cpl>
         </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>0</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
+      </pes>
+    </mach>
+    <mach name="pm-gpu|muller-gpu|alvarez-gpu">
+      <pes compset="any" pesize="any">
+        <comment>pm-gpu conus 2 nodes, 4x1 except 16 threads in LND</comment>
+        <ntasks>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_cpl>-2</ntasks_cpl>
+          <ntasks_glc>-1</ntasks_glc>
+          <ntasks_wav>-1</ntasks_wav>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>16</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
       </pes>
     </mach>
   </grid>

--- a/components/eamxx/cime_config/config_pes.xml
+++ b/components/eamxx/cime_config/config_pes.xml
@@ -19,7 +19,6 @@
   </grid>
   <grid name="a%ne4np4">
     <mach name="pm-gpu|muller-gpu|alvarez-gpu">
-      <!-- Compset longname is 2010_SCREAM_ELM%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV_SIAC_SESP -->
       <pes compset=".*EAM.+ELM.+DOCN" pesize="any">
         <comment>pm-gpu: ne4 eamxx F case, 1 nodes, 4x1</comment>
         <ntasks>
@@ -55,6 +54,51 @@
           <nthrds_lnd>7</nthrds_lnd>
           <nthrds_ice>7</nthrds_ice>
         </nthrds>
+      </pes>
+    </mach>
+    <mach name="anvil|compy">
+      <pes compset="any" pesize="any">
+        <comment>anvil/compy: ne4 eamxx 1 node CPU</comment>
+        <ntasks>
+          <ntasks_atm>-1</ntasks_atm>
+          <ntasks_lnd>-1</ntasks_lnd>
+          <ntasks_rof>-1</ntasks_rof>
+          <ntasks_ice>-1</ntasks_ice>
+          <ntasks_ocn>-1</ntasks_ocn>
+          <ntasks_glc>-1</ntasks_glc>
+          <ntasks_wav>-1</ntasks_wav>
+          <ntasks_cpl>-1</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
+    <mach name="chrysalis">
+      <pes compset="any" pesize="any">
+        <comment>chrysalis: ne4 eamxx 1 node CPU</comment>
+        <ntasks>
+          <ntasks_atm>-1</ntasks_atm>
+          <ntasks_lnd>-1</ntasks_lnd>
+          <ntasks_rof>-1</ntasks_rof>
+          <ntasks_ice>-1</ntasks_ice>
+          <ntasks_ocn>-1</ntasks_ocn>
+          <ntasks_glc>-1</ntasks_glc>
+          <ntasks_wav>-1</ntasks_wav>
+          <ntasks_cpl>-1</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
+    <mach name="gcp12">
+      <pes compset=".*EAM.+ELM.+DOCN" pesize="any">
+        <comment>gcp12: ne4 eamxx F case, 1 nodes, 56x1</comment>
+        <ntasks>
+          <ntasks_atm>-1</ntasks_atm>
+          <ntasks_cpl>-1</ntasks_cpl>
+          <ntasks_ice>-1</ntasks_ice>
+          <ntasks_lnd>-1</ntasks_lnd>
+          <ntasks_rof>-1</ntasks_rof>
+          <ntasks_ocn>-1</ntasks_ocn>
+          <ntasks_glc>1</ntasks_glc>
+          <ntasks_wav>1</ntasks_wav>
+        </ntasks>
       </pes>
     </mach>
   </grid>
@@ -107,6 +151,21 @@
           <ntasks_lnd>-2</ntasks_lnd>
           <ntasks_rof>-2</ntasks_rof>
           <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_glc>1</ntasks_glc>
+          <ntasks_wav>1</ntasks_wav>
+        </ntasks>
+      </pes>
+    </mach>
+    <mach name="gcp12">
+      <pes compset=".*EAM.+ELM.+DOCN" pesize="any">
+        <comment>gcp12: ne30 eamxx F case, 4 nodes, 56x1 CPU</comment>
+        <ntasks>
+          <ntasks_atm>-4</ntasks_atm>
+          <ntasks_cpl>-4</ntasks_cpl>
+          <ntasks_ice>-4</ntasks_ice>
+          <ntasks_lnd>-4</ntasks_lnd>
+          <ntasks_rof>-4</ntasks_rof>
+          <ntasks_ocn>-4</ntasks_ocn>
           <ntasks_glc>1</ntasks_glc>
           <ntasks_wav>1</ntasks_wav>
         </ntasks>

--- a/components/eamxx/cime_config/config_pes.xml
+++ b/components/eamxx/cime_config/config_pes.xml
@@ -38,6 +38,25 @@
         </nthrds>
       </pes>
     </mach>
+    <mach name="frontier">
+      <pes compset="any" pesize="any">
+        <comment>frontier: ne4 eamxx 1 node, 7 threads in LND/ICE</comment>
+        <ntasks>
+          <ntasks_atm>-1</ntasks_atm>
+          <ntasks_cpl>-1</ntasks_cpl>
+          <ntasks_ice>-1</ntasks_ice>
+          <ntasks_lnd>-1</ntasks_lnd>
+          <ntasks_rof>-1</ntasks_rof>
+          <ntasks_ocn>-1</ntasks_ocn>
+          <ntasks_glc>1</ntasks_glc>
+          <ntasks_wav>1</ntasks_wav>
+        </ntasks>
+        <nthrds>
+          <nthrds_lnd>7</nthrds_lnd>
+          <nthrds_ice>7</nthrds_ice>
+        </nthrds>
+      </pes>
+    </mach>
   </grid>
   <grid name="a%ne30np4">
     <mach name="pm-gpu|muller-gpu|alvarez-gpu">

--- a/components/eamxx/cime_config/config_pes.xml
+++ b/components/eamxx/cime_config/config_pes.xml
@@ -156,21 +156,6 @@
         </ntasks>
       </pes>
     </mach>
-    <mach name="gcp12">
-      <pes compset=".*EAM.+ELM.+DOCN" pesize="any">
-        <comment>gcp12: ne30 eamxx F case, 4 nodes, 56x1 CPU</comment>
-        <ntasks>
-          <ntasks_atm>-4</ntasks_atm>
-          <ntasks_cpl>-4</ntasks_cpl>
-          <ntasks_ice>-4</ntasks_ice>
-          <ntasks_lnd>-4</ntasks_lnd>
-          <ntasks_rof>-4</ntasks_rof>
-          <ntasks_ocn>-4</ntasks_ocn>
-          <ntasks_glc>1</ntasks_glc>
-          <ntasks_wav>1</ntasks_wav>
-        </ntasks>
-      </pes>
-    </mach>
   </grid>
   <grid name="a%ne120np4">
     <mach name="pm-gpu|muller-gpu|alvarez-gpu">


### PR DESCRIPTION
We were not using a separate pelayout config xml file and this PR corrects that.
Doing this means that current eamxx default pelayouts needed to be specified in this new file.
Did some basic cleanup and improvements to those existing layouts.
Should be BFB, except for NML diffs where node count and especially thread count may be different now.

Also add simple default for higher resolutions (ne120,ne256,ne512,ne1024) for pm-gpu.

Fixes #7268