### PR TITLE
Fix the 0.01x0.01 res error of the mkmapdata tool

### DIFF
--- a/components/elm/bld/namelist_files/namelist_defaults_tools.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults_tools.xml
@@ -89,6 +89,8 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
    >lnd/clm2/mappingdata/grids/SCRIPgrid_0.9x1.25_GRDC_c130307.nc</scripgriddata>
 <scripgriddata hgrid="0.5x0.5"  lmask="GSDTG2000"
    >lnd/clm2/mappingdata/grids/SCRIPgrid_0.5x0.5_GSDTG2000_c161010.nc</scripgriddata>
+<scripgriddata hgrid="0.01x0.01"  lmask="nomask"
+   >lnd/clm2/mappingdata/grids/SCRIPgrid_0.01x0.01_nomask_c240501.nc</scripgriddata>
 
 <!-- Other raw data grids -->
 <!-- Note that the following is a UGRID file rather than a SCRIP grid file -->

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -1451,7 +1451,7 @@ Land mask description for mksurfdata input files
 
 <entry id="hgrid" type="char*10" category="mksurfdata"
        group="default_settings"
-       valid_values="0.1x0.1,0.5x0.5,10x10min,5x5min,360x720cru,0.9x1.25,19basin,1km-merge-10min">
+       valid_values="0.1x0.1,0.5x0.5,10x10min,5x5min,360x720cru,0.9x1.25,19basin,1km-merge-10min,0.01x0.01">
 Horizontal grid resolutions for mksurfdata input files
 </entry>
 
@@ -1484,7 +1484,7 @@ CLM run type.
 <entry id="res" type="char*30" category="default_settings"
        group="default_settings"
        valid_values=
-"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_tropicAtl,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_icycape,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,ne4np4,ne4np4.pg2,ne11np4,ne16np4,ne30np4,ne30np4.pg2,ne60np4,ne120np4,ne120np4.pg2,ne240np4,ne256np4,ne256np4.pg2,ne512np4.pg2,ne1024np4,ne1024np4.pg2,1km-merge-10min,ne0np4_CAx32v1.pg2,ne0np4_arm_x8v3_lowcon,ne0np4_conus_x4v1_lowcon,ne0np4_enax4v1,ne0np4_twpx4v1,r2,r05,r0125,NLDAS,ne0np4_northamericax4v1.pg2,ne0np4_arcticx4v1.pg2,r025">
+"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_tropicAtl,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_icycape,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,ne4np4,ne4np4.pg2,ne11np4,ne16np4,ne30np4,ne30np4.pg2,ne60np4,ne120np4,ne120np4.pg2,ne240np4,ne256np4,ne256np4.pg2,ne512np4.pg2,ne1024np4,ne1024np4.pg2,1km-merge-10min,ne0np4_CAx32v1.pg2,ne0np4_arm_x8v3_lowcon,ne0np4_conus_x4v1_lowcon,ne0np4_enax4v1,ne0np4_twpx4v1,r2,r05,r0125,NLDAS,ne0np4_northamericax4v1.pg2,ne0np4_arcticx4v1.pg2,r025,0.01x0.01">
 Horizontal resolutions
 Note: 0.1x0.1, 0.5x0.5, 5x5min, 10x10min, 3x3min and 0.33x0.33 are only used for CLM tools
 </entry>

--- a/components/elm/tools/mkmapdata/mkmapdata.sh
+++ b/components/elm/tools/mkmapdata/mkmapdata.sh
@@ -314,6 +314,7 @@ fi
       "360x720cru_cruncep"                    \
       "1km-merge-10min_HYDRO1K-merge-nomask"  \
       "0.5x0.5_GSDTG2000"                     \
+      "0.01x0.01_nomask"                      \
     )
 
 # Set timestamp for names below 


### PR DESCRIPTION
This error was originally reported in [this issue](https://github.com/E3SM-Project/E3SM/issues/6577).

The v3 default configuration uses the TOP solar radiation parameterization, which requires four new variables (SINSL_COSAS, SINSL_SINAS, SKY_VIEW, and TERRAIN_CONFIG?) in the land surface file `fsurdat`. These four variables are generated from the 0.01x0.01 grid to the model grids by the mkmapdata tool. This PR fixes the missing 0.01x0.01 grid in the mkmapdata tool.

@jsbamboo and @bogensch(?) tested this fix successfully (Please weigh in if I misunderstood something). We need this fix to create new v3 RRM tests.