### PR TITLE
EAMxx: Fixing bug in external forcing

### DIFF
--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -296,7 +296,6 @@ void MAMMicrophysics::set_grids(
       elevated_emis_data_.push_back(data_tracer);
     }  // var_name elevated emissions
     int i               = 0;
-    int offset_emis_ver = 0;
     for(const auto &var_name : extfrc_lst_) {
       const auto file_name = elevated_emis_file_name_[var_name];
       const auto var_names = elevated_emis_var_names_[var_name];
@@ -316,19 +315,17 @@ void MAMMicrophysics::set_grids(
       elevated_emis_data_[i].init(num_cols_io_emis, num_levs_io_emis, nvars);
       elevated_emis_data_[i].allocate_temporary_views();
       forcings_[i].file_alt_data = elevated_emis_data_[i].has_altitude_;
+      EKAT_REQUIRE_MSG(
+        nvars <= int(mam_coupling::MAX_SECTION_NUM_FORCING),
+        "Error! Number of sections is bigger than "
+        "MAX_SECTION_NUM_FORCING. Increase the "
+        "MAX_SECTION_NUM_FORCING in tracer_reader_utils.hpp \n");
       for(int isp = 0; isp < nvars; ++isp) {
-        forcings_[i].offset = offset_emis_ver;
-        elevated_emis_output_[isp + offset_emis_ver] =
+        forcings_[i].fields[isp] =
             view_2d("elevated_emis_output_", ncol_, nlev_);
       }
-      offset_emis_ver += nvars;
       ++i;
     }  // end i
-    EKAT_REQUIRE_MSG(
-        offset_emis_ver <= int(mam_coupling::MAX_NUM_ELEVATED_EMISSIONS_FIELDS),
-        "Error! Number of fields is bigger than "
-        "MAX_NUM_ELEVATED_EMISSIONS_FIELDS. Increase the "
-        "MAX_NUM_ELEVATED_EMISSIONS_FIELDS in tracer_reader_utils.hpp \n");
 
   }  // Tracer external forcing data
 
@@ -663,17 +660,13 @@ void MAMMicrophysics::run_impl(const double dt) {
       linoz_output);                     // out
   Kokkos::fence();
 
-  elevated_emiss_time_state_.t_now = ts.frac_of_year_in_days();
+
   int i                            = 0;
   for(const auto &var_name : extfrc_lst_) {
+    elevated_emiss_time_state_[i].t_now = ts.frac_of_year_in_days();
     const auto file_name = elevated_emis_file_name_[var_name];
     const auto var_names = elevated_emis_var_names_[var_name];
-    const int nsectors   = int(var_names.size());
-    view_2d elevated_emis_output[nsectors];
-    for(int isp = 0; isp < nsectors; ++isp) {
-      elevated_emis_output[isp] =
-          elevated_emis_output_[isp + forcings_[i].offset];
-    }
+    auto& elevated_emis_output= forcings_[i].fields;
     scream::mam_coupling::advance_tracer_data(
         ElevatedEmissionsDataReader_[i], *ElevatedEmissionsHorizInterp_[i], ts,
         elevated_emiss_time_state_[i], elevated_emis_data_[i], dry_atm_.p_mid,
@@ -751,7 +744,6 @@ void MAMMicrophysics::run_impl(const double dt) {
   const auto zenith_angle = acos_cosine_zenith_;
   constexpr int gas_pcnst = mam_coupling::gas_pcnst();
 
-  const auto &elevated_emis_output = elevated_emis_output_;
   const auto &extfrc               = extfrc_;
   const auto &forcings             = forcings_;
   constexpr int extcnt             = mam4::gas_chemistry::extcnt;
@@ -816,7 +808,7 @@ void MAMMicrophysics::run_impl(const double dt) {
           // We may need to move this line where we read files.
           forcings_in[i].file_alt_data = file_alt_data;
           for(int isec = 0; isec < forcings[i].nsectors; ++isec) {
-            const auto field = elevated_emis_output[isec + forcings[i].offset];
+            const auto& field = forcings[i].fields[isec];
             forcings_in[i].fields_data[isec] = ekat::subview(field, icol);
           }
         }  // extcnt for loop

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -676,7 +676,7 @@ void MAMMicrophysics::run_impl(const double dt) {
     }
     scream::mam_coupling::advance_tracer_data(
         ElevatedEmissionsDataReader_[i], *ElevatedEmissionsHorizInterp_[i], ts,
-        elevated_emiss_time_state_, elevated_emis_data_[i], dry_atm_.p_mid,
+        elevated_emiss_time_state_[i], elevated_emis_data_[i], dry_atm_.p_mid,
         dry_atm_.z_iface, elevated_emis_output);
     i++;
     Kokkos::fence();

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
@@ -132,8 +132,6 @@ class MAMMicrophysics final : public MAMGenericInterface {
   std::vector<mam_coupling::TracerData> elevated_emis_data_;
   std::map<std::string, std::string> elevated_emis_file_name_;
   std::map<std::string, std::vector<std::string>> elevated_emis_var_names_;
-  view_2d
-      elevated_emis_output_[mam_coupling::MAX_NUM_ELEVATED_EMISSIONS_FIELDS];
   view_3d extfrc_;
   mam_coupling::ForcingHelper forcings_[mam4::gas_chemistry::extcnt];
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
@@ -125,7 +125,7 @@ class MAMMicrophysics final : public MAMGenericInterface {
 
   // Vertical emission uses 9 files, here I am using std::vector to stote
   // instance of each file.
-  mam_coupling::TracerTimeState elevated_emiss_time_state_;
+  mam_coupling::TracerTimeState elevated_emiss_time_state_[mam4::gas_chemistry::extcnt];
   std::vector<std::shared_ptr<AtmosphereInput>> ElevatedEmissionsDataReader_;
   std::vector<std::shared_ptr<AbstractRemapper>> ElevatedEmissionsHorizInterp_;
   std::vector<std::string> extfrc_lst_;

--- a/components/eamxx/src/physics/mam/readfiles/tracer_reader_utils.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/tracer_reader_utils.hpp
@@ -54,6 +54,7 @@ inline void compute_p_src_zonal_files(const view_1d &levs,
 // inside the parallel_for.
 // This struct will be used in init while reading nc files.
 // The MAM4xx version will be used instead of parallel_for that loops over cols.
+constexpr int MAX_SECTION_NUM_FORCING=4;
 struct ForcingHelper {
   // This index is in Fortran format. i.e. starts in 1
   int frc_ndx;
@@ -61,8 +62,8 @@ struct ForcingHelper {
   bool file_alt_data;
   // number of sectors per forcing
   int nsectors;
-  // offset in output vector from reader
-  int offset;
+  // data of views
+  view_2d fields[MAX_SECTION_NUM_FORCING];
 };
 
 enum TracerFileType {
@@ -88,7 +89,6 @@ enum TracerDataIndex { BEG = 0, END = 1, OUT = 2 };
  Therefore, if a file contains more than this number, it is acceptable to
  increase this limit. Currently, Linoz files have 8 fields. */
 constexpr int MAX_NVARS_TRACER                  = 10;
-constexpr int MAX_NUM_ELEVATED_EMISSIONS_FIELDS = 25;
 
 // Linoz structures to help manage all of the variables:
 struct TracerTimeState {


### PR DESCRIPTION
@singhbalwinder 
Taufiq has added vertical emissions (external forcing) diagnostics to the code. As we are just reading files and interpolating them, the read-in values should be very close to the diagnostics output. Taufiq is seeing differences that look much more than expected. 

@TaufiqHassan :
The elevated emission fluxes for BC/POM between EAMxx and prescribed emissions data are>50%. In contrast, SO2 mean difference between EAMxx and prescribed emissions data is <1%.

@TaufiqHassan performed a verification of `extfrc_vert_sum_dz_weighted` (see [PR 7284](https://github.com/E3SM-Project/E3SM/pull/7284) ). 
```
  species         prescribed_emis     eamxx_emis
0     so2       3952.337528087315      3919.2534
1  so4_a1       164.1166022679014        81.9451
2  so4_a2      17.967874885317006       8.971543
3  pom_a4      503.64561857829256      251.47543
4   bc_a4      50.720847076634016      25.325436
5  num_a1  1.5081873428440138e+19   7.530533e+18
6  num_a2  1.2723405815977971e+20  6.3529267e+19
7  num_a4  4.2619691274178514e+20  2.1280446e+20
8    soag      2803.8477596519087      1399.9897
```

After bug fix:

```
  species         prescribed_emis eamxx_automated eamxx_extfrcInt
0     so2       3952.337528087315       3919.1548       3918.7275
1  so4_a1       164.1166022679014        162.5891       162.57228
2  so4_a2      17.967874885317006       17.966644       17.963781
3  pom_a4      503.64561857829256       431.20523       431.34055
4   bc_a4      50.720847076634016       41.872025       41.888027
5  num_a1  1.5081873428440138e+19   1.4851163e+19   1.4849639e+19
6  num_a2  1.2723405815977971e+20   1.2722535e+20   1.2720508e+20
7  num_a4  4.2619691274178514e+20   3.6416606e+20   3.6428164e+20
8    soag      2803.8477596519087       2742.7026       2742.5098
```

The bug was that we were using the same TracerTimeState in a loop. This time structure was modified in each iteration, producing incorrect values.

I expected the baseline tests to fail for all tests where the microphysics interface is involved. In the single-process standalone test, this `mam4_aero_microphys_standalone_baseline_cmp` should fail.

The test [cpu-gcc / SMS_D_Ln5.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.eamxx-mam4xx-all_mam4xx_procs](https://github.com/E3SM-Project/E3SM/pull/7315#logs) should fail with DIFFs.

In addition, I modified the forcing structure to remove an offset parameter that made the code hard to understand.

[NBFB]