### PR TITLE
Dengwirda/add-wall-slip

### DIFF
--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -203,9 +203,9 @@
 		/>
 	</nml_record>
 	<nml_record name="lateral_walls" mode="forward">
-		<nml_option name="config_wall_slip_factor" type="real" default_value="1.0"
-					description="Lateral wall slip boundary condition: no-slip=1.0, free-slip=0.0, with partial-slip lying in-between. This factor multiplies relative vorticity computed at vertices positioned on lateral boundaries."
-					possible_values="0.0 - 1.0"
+		<nml_option name="config_wall_slip_factor" type="real" default_value="0.0"
+					description="Lateral wall slip boundary condition: no-slip=0.0, free-slip=1.0, with partial-slip lying in-between. This factor multiplies relative vorticity computed at vertices positioned on lateral boundaries."
+					possible_values="Any real number between 0.0 and 1.0"
 		/>
 	</nml_record>
 	<nml_record name="hmix" mode="forward">

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -203,7 +203,7 @@
 		/>
 	</nml_record>
 	<nml_record name="lateral_walls" mode="forward">
-		<nml_option name="config_wall_slip_factor" type="real" default_value="0.0"
+		<nml_option name="config_wall_slip_factor" type="real" default_value="1.0"
 					description="Lateral wall slip boundary condition: no-slip=1.0, free-slip=0.0, with partial-slip lying in-between. This factor multiplies relative vorticity computed at vertices positioned on lateral boundaries."
 					possible_values="0.0 - 1.0"
 		/>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -202,6 +202,12 @@
 					possible_values="'split_explicit', 'RK4', 'unsplit_explicit', 'split_implicit'"
 		/>
 	</nml_record>
+	<nml_record name="lateral_walls" mode="forward">
+		<nml_option name="config_wall_slip_factor" type="real" default_value="0.0"
+					description="Lateral wall slip boundary condition: no-slip=1.0, free-slip=0.0, with partial-slip lying in-between. This factor multiplies relative vorticity computed at vertices positioned on lateral boundaries."
+					possible_values="0.0 - 1.0"
+		/>
+	</nml_record>
 	<nml_record name="hmix" mode="forward">
 		<nml_option name="config_hmix_scaleWithMesh" type="logical" default_value=".false."
 					description="If false, del2 and del4 coefficients are constant throughout the mesh (equivalent to setting $\rho_m=1$ throughout the mesh).  If true, these coefficients scale as mesh density to the -3/4 power."

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -567,7 +567,7 @@ contains
 !  routine ocn_relativeVorticity_circulation
 !
 !> \brief   Computes relative vorticity and circulation
-!> \author  Mark Petersen, Doug Jacobsen, Todd Ringler
+!> \author  Mark Petersen, Doug Jacobsen, Todd Ringler, Darren Engwirda
 !> \date    November 2013
 !> \details
 !>  Computes relative vorticity and circulation
@@ -627,24 +627,25 @@ contains
       !$omp end do
 #endif
 
-      ! no-slip = 1.0
-      ! free-slip = 0.0
+      ! no-slip = 0.0
+      ! free-slip = 1.0
       ! partial-slip in-between
       wall_slip_factor = config_wall_slip_factor
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
       !$acc          present(circulation, relativeVorticity, edgesOnVertex, &
-      !$acc                  maxLevelVertexBot, dcEdge, normalVelocity, edgeSignOnVertex, &
-      !$acc                  minLevelVertexTop, kiteAreasOnVertex, cellMask) &
-      !$acc          private(areaDual, i, iVertex, iEdge, iCell, k, r_tmp, wall_slip_factor)
+      !$acc                  maxLevelVertexBot, dcEdge, normalVelocity, &
+      !$acc                  edgeSignOnVertex, cellMask, &
+      !$acc                  minLevelVertexTop, kiteAreasOnVertex) &
+      !$acc          private(areaDual, i, iEdge, iCell, k, r_tmp, wall_slip_factor)
 #else
       !$omp do schedule(runtime) &
       !$omp          private(areaDual, i, iEdge, iCell, k, r_tmp, wall_slip_factor)
 #endif
       do iVertex = 1, nVerticesAll
          do k = minLevelVertexTop(iVertex), maxLevelVertexBot(iVertex)
-            areaDual = 0.0_RKIND
+            areaDual = 0.0_RKIND  ! only unmaksed kites
             do i = 1, vertexDegree
                iEdge = edgesOnVertex(i, iVertex)
                iCell = cellsOnVertex(i, iVertex)
@@ -654,9 +655,11 @@ contains
                areaDual = areaDual + &
                           cellMask(k, iCell) * kiteAreasOnVertex(i, iVertex)
             end do
-            if (boundaryVertex(k, iVertex) .gt. 0.0_RKIND) then
-               circulation(k, iVertex) = wall_slip_factor * circulation(k, iVertex)
-            end if
+            ! no-slip: curl(u) unchanged
+            ! free-slip: curl(u) = 0.0
+            ! partial-slip: curl(u) reduced
+            circulation(k, iVertex) = circulation(k, iVertex) * &
+               (1.0_RKIND - wall_slip_factor * boundaryVertex(k, iVertex))
             relativeVorticity(k, iVertex) = circulation(k, iVertex) / areaDual
          end do
       end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -605,7 +605,7 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: iVertex, iEdge, i, k
+      integer :: iVertex, iEdge, iCell, i, k
 
       real (kind=RKIND) :: r_tmp, wall_slip_factor
       real (kind=RKIND), dimension(:), allocatable :: areaDual
@@ -640,7 +640,7 @@ contains
       !$acc          present(circulation, relativeVorticity, areaTriangle, edgesOnVertex, &
       !$acc                  maxLevelVertexBot, dcEdge, normalVelocity, edgeSignOnVertex, &
       !$acc                  minLevelVertexTop) &
-      !$acc          private(areaDual, iVertex, iEdge, k, r_tmp, wall_slip_factor)
+      !$acc          private(areaDual, i, iVertex, iEdge, iCell, k, r_tmp, wall_slip_factor)
 #else
       !$omp do schedule(runtime) private(areaDual, i, iEdge, iCell, k, r_tmp, wall_slip_factor)
 #endif

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -607,7 +607,7 @@ contains
 
       integer :: iVertex, iEdge, i, k
 
-      real (kind=RKIND) :: invAreaTri1, r_tmp
+      real (kind=RKIND) :: invAreaTri1, r_tmp, wall_slip_factor
 
       err = 0
 
@@ -627,14 +627,19 @@ contains
       !$omp end do
 #endif
 
+      ! no-slip = 1.0
+      ! free-slip = 0.0
+      ! partial-slip in-between
+      wall_slip_factor = config_wall_slip_factor
+
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
       !$acc          present(circulation, relativeVorticity, areaTriangle, edgesOnVertex, &
       !$acc                  maxLevelVertexBot, dcEdge, normalVelocity, edgeSignOnVertex, &
       !$acc                  minLevelVertexTop) &
-      !$acc          private(invAreaTri1, iVertex, iEdge, k, r_tmp)
+      !$acc          private(invAreaTri1, iVertex, iEdge, k, r_tmp, wall_slip_factor)
 #else
-      !$omp do schedule(runtime) private(invAreaTri1, i, iEdge, k, r_tmp)
+      !$omp do schedule(runtime) private(invAreaTri1, i, iEdge, k, r_tmp, wall_slip_factor)
 #endif
       do iVertex = 1, nVerticesAll
          invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
@@ -645,6 +650,12 @@ contains
               circulation(k, iVertex) = circulation(k, iVertex) + edgeSignOnVertex(i, iVertex) * r_tmp
               relativeVorticity(k, iVertex) = relativeVorticity(k, iVertex) + edgeSignOnVertex(i, iVertex) * r_tmp * invAreaTri1
             end do
+         end do
+         do k = minLevelVertexTop(iVertex), maxLevelVertexBot(iVertex)
+            if (boundaryVertex(k, iVertex)) then
+               circulation(k, iVertex) = wall_slip_factor * circulation(k, iVertex)
+               relativeVorticity(k, iVertex) = wall_slip_factor * relativeVorticity(k, iVertex)
+            end if
          end do
       end do
 #ifndef MPAS_OPENACC

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -605,9 +605,9 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: iVertex, iEdge, iCell, i, k
+      integer :: iVertex, iEdge, i, k
 
-      real (kind=RKIND) :: r_tmp, wall_slip_factor, areaDual
+      real (kind=RKIND) :: invAreaTri1, r_tmp, wall_slip_factor
 
       err = 0
 
@@ -636,31 +636,27 @@ contains
       !$acc parallel loop &
       !$acc          present(circulation, relativeVorticity, edgesOnVertex, &
       !$acc                  maxLevelVertexBot, dcEdge, normalVelocity, &
-      !$acc                  edgeSignOnVertex, cellMask, &
-      !$acc                  minLevelVertexTop, kiteAreasOnVertex) &
-      !$acc          private(areaDual, i, iEdge, iCell, k, r_tmp, wall_slip_factor)
+      !$acc                  minLevelVertexTop, areaTriangle, edgeSignOnVertex) &
+      !$acc          private(invAreaTri1, i, iEdge, k, r_tmp, wall_slip_factor)
 #else
       !$omp do schedule(runtime) &
-      !$omp          private(areaDual, i, iEdge, iCell, k, r_tmp, wall_slip_factor)
+      !$omp          private(invAreaTri1, i, iEdge, k, r_tmp, wall_slip_factor)
 #endif
       do iVertex = 1, nVerticesAll
+         invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
          do k = minLevelVertexTop(iVertex), maxLevelVertexBot(iVertex)
-            areaDual = 0.0_RKIND  ! only unmaksed kites
             do i = 1, vertexDegree
                iEdge = edgesOnVertex(i, iVertex)
-               iCell = cellsOnVertex(i, iVertex)
                r_tmp = edgeSignOnVertex(i, iVertex) * &
                        dcEdge(iEdge) * normalVelocity(k, iEdge)
                circulation(k, iVertex) = circulation(k, iVertex) + r_tmp
-               areaDual = areaDual + &
-                          cellMask(k, iCell) * kiteAreasOnVertex(i, iVertex)
             end do
             ! no-slip: curl(u) unchanged
             ! free-slip: curl(u) = 0.0
             ! partial-slip: curl(u) reduced
             circulation(k, iVertex) = circulation(k, iVertex) * &
                (1.0_RKIND - wall_slip_factor * boundaryVertex(k, iVertex))
-            relativeVorticity(k, iVertex) = circulation(k, iVertex) / areaDual
+            relativeVorticity(k, iVertex) = circulation(k, iVertex) * invAreaTri1
          end do
       end do
 #ifndef MPAS_OPENACC

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -652,9 +652,9 @@ contains
             end do
          end do
          do k = minLevelVertexTop(iVertex), maxLevelVertexBot(iVertex)
-            if (boundaryVertex(k, iVertex)) then
-               circulation(k, iVertex) = wall_slip_factor * circulation(k, iVertex)
-               relativeVorticity(k, iVertex) = wall_slip_factor * relativeVorticity(k, iVertex)
+            if (boundaryVertex(k, iVertex) .gt. 0.0_RKIND) then
+              circulation(k, iVertex) = wall_slip_factor * circulation(k, iVertex)
+              relativeVorticity(k, iVertex) = wall_slip_factor * relativeVorticity(k, iVertex)
             end if
          end do
       end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -607,7 +607,8 @@ contains
 
       integer :: iVertex, iEdge, i, k
 
-      real (kind=RKIND) :: invAreaTri1, r_tmp, wall_slip_factor
+      real (kind=RKIND) :: r_tmp, wall_slip_factor
+      real (kind=RKIND), dimension(:), allocatable :: areaDual
 
       err = 0
 
@@ -631,27 +632,31 @@ contains
       ! free-slip = 0.0
       ! partial-slip in-between
       wall_slip_factor = config_wall_slip_factor
+      
+      allocate(areaDual(nVertLevels))
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
       !$acc          present(circulation, relativeVorticity, areaTriangle, edgesOnVertex, &
       !$acc                  maxLevelVertexBot, dcEdge, normalVelocity, edgeSignOnVertex, &
       !$acc                  minLevelVertexTop) &
-      !$acc          private(invAreaTri1, iVertex, iEdge, k, r_tmp, wall_slip_factor)
+      !$acc          private(areaDual, iVertex, iEdge, k, r_tmp, wall_slip_factor)
 #else
-      !$omp do schedule(runtime) private(invAreaTri1, i, iEdge, k, r_tmp, wall_slip_factor)
+      !$omp do schedule(runtime) private(areaDual, i, iEdge, iCell, k, r_tmp, wall_slip_factor)
 #endif
       do iVertex = 1, nVerticesAll
-         invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
+         areaDual(:) = 0.0_RKIND  ! only the unmasked kites
          do i = 1, vertexDegree
             iEdge = edgesOnVertex(i, iVertex)
+            iCell = cellsOnVertex(i, iVertex)
             do k = minLevelVertexTop(iVertex), maxLevelVertexBot(iVertex)
-              r_tmp = dcEdge(iEdge) * normalVelocity(k, iEdge)
-              circulation(k, iVertex) = circulation(k, iVertex) + edgeSignOnVertex(i, iVertex) * r_tmp
-              relativeVorticity(k, iVertex) = relativeVorticity(k, iVertex) + edgeSignOnVertex(i, iVertex) * r_tmp * invAreaTri1
+              r_tmp = edgeSignOnVertex(i, iVertex) * dcEdge(iEdge) * normalVelocity(k, iEdge)
+              circulation(k, iVertex) = circulation(k, iVertex) + r_tmp
+              areaDual(k) = areaDual(k) + cellMask(k, iCell) * kiteAreasOnVertex(i, iVertex)
             end do
          end do
          do k = minLevelVertexTop(iVertex), maxLevelVertexBot(iVertex)
+            relativeVorticity(k, iVertex) = circulation(k, iVertex) / areaDual(k)
             if (boundaryVertex(k, iVertex) .gt. 0.0_RKIND) then
               circulation(k, iVertex) = wall_slip_factor * circulation(k, iVertex)
               relativeVorticity(k, iVertex) = wall_slip_factor * relativeVorticity(k, iVertex)
@@ -662,6 +667,8 @@ contains
       !$omp end do
       !$omp end parallel
 #endif
+
+      deallocate(areaDual)
 
    !--------------------------------------------------------------------
 
@@ -1023,7 +1030,8 @@ contains
          invAreaCell1,         &! 1/cell area
          invLength,            &! 1/length
          layerThicknessVertex, &! layer thickness at vertex
-         apvm_scale_factor      ! scale factor for APVM form
+         apvm_scale_factor,    &! scale factor for APVM form
+         areaDual
 
       ! Local arrays
       ! normalizedPlanetaryVorticityVertex: earth's rotational rate
@@ -1063,25 +1071,29 @@ contains
       !$acc    present(normalizedRelativeVorticityVertex, &
       !$acc            normalizedPlanetaryVorticityVertex, &
       !$acc            relativeVorticity, fVertex, layerThickness, &
-      !$acc            areaTriangle, kiteAreasOnVertex, cellsOnVertex, &
+      !$acc            kiteAreasOnVertex, cellsOnVertex, &
       !$acc            maxLevelVertexBot) &
-      !$acc    private(i, k, iCell, invAreaTri1, layerThicknessVertex)
+      !$acc    private(i, k, iCell, areaDual, layerThicknessVertex)
 #else
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp    private(i, k, iCell, invAreaTri1, layerThicknessVertex)
+      !$omp    private(i, k, iCell, areaDual, layerThicknessVertex)
 #endif
       do iVertex = 1, nVertices
-         invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
-         do k = 1, maxLevelVertexBot(iVertex)
+         normalizedRelativeVorticityVertex(:,iVertex) = 0.0_RKIND
+         normalizedPlanetaryVorticityVertex(:,iVertex) = 0.0_RKIND
+         do k = minLevelVertexTop(iVertex), maxLevelVertexBot(iVertex)
             layerThicknessVertex = 0.0_RKIND
+            areaDual = 0.0_RKIND  ! only the unmasked kites
             do i = 1, vertexDegree
                iCell = cellsOnVertex(i,iVertex)
                layerThicknessVertex = layerThicknessVertex &
                                     + layerThickness(k,iCell) &
                                     * kiteAreasOnVertex(i,iVertex)
+               areaDual = areaDual + cellMask(k,iCell) &
+                                    * kiteAreasOnVertex(i,iVertex)
             end do
-            layerThicknessVertex = layerThicknessVertex*invAreaTri1
+            layerThicknessVertex = layerThicknessVertex/areaDual
             if (layerThicknessVertex == 0) cycle
 
             normalizedRelativeVorticityVertex(k,iVertex) = &

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -607,8 +607,7 @@ contains
 
       integer :: iVertex, iEdge, iCell, i, k
 
-      real (kind=RKIND) :: r_tmp, wall_slip_factor
-      real (kind=RKIND), dimension(:), allocatable :: areaDual
+      real (kind=RKIND) :: r_tmp, wall_slip_factor, areaDual
 
       err = 0
 
@@ -632,43 +631,39 @@ contains
       ! free-slip = 0.0
       ! partial-slip in-between
       wall_slip_factor = config_wall_slip_factor
-      
-      allocate(areaDual(nVertLevels))
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
-      !$acc          present(circulation, relativeVorticity, areaTriangle, edgesOnVertex, &
+      !$acc          present(circulation, relativeVorticity, edgesOnVertex, &
       !$acc                  maxLevelVertexBot, dcEdge, normalVelocity, edgeSignOnVertex, &
-      !$acc                  minLevelVertexTop) &
+      !$acc                  minLevelVertexTop, kiteAreasOnVertex, cellMask) &
       !$acc          private(areaDual, i, iVertex, iEdge, iCell, k, r_tmp, wall_slip_factor)
 #else
-      !$omp do schedule(runtime) private(areaDual, i, iEdge, iCell, k, r_tmp, wall_slip_factor)
+      !$omp do schedule(runtime) &
+      !$omp          private(areaDual, i, iEdge, iCell, k, r_tmp, wall_slip_factor)
 #endif
       do iVertex = 1, nVerticesAll
-         areaDual(:) = 0.0_RKIND  ! only the unmasked kites
-         do i = 1, vertexDegree
-            iEdge = edgesOnVertex(i, iVertex)
-            iCell = cellsOnVertex(i, iVertex)
-            do k = minLevelVertexTop(iVertex), maxLevelVertexBot(iVertex)
-              r_tmp = edgeSignOnVertex(i, iVertex) * dcEdge(iEdge) * normalVelocity(k, iEdge)
-              circulation(k, iVertex) = circulation(k, iVertex) + r_tmp
-              areaDual(k) = areaDual(k) + cellMask(k, iCell) * kiteAreasOnVertex(i, iVertex)
-            end do
-         end do
          do k = minLevelVertexTop(iVertex), maxLevelVertexBot(iVertex)
-            relativeVorticity(k, iVertex) = circulation(k, iVertex) / areaDual(k)
+            areaDual = 0.0_RKIND
+            do i = 1, vertexDegree
+               iEdge = edgesOnVertex(i, iVertex)
+               iCell = cellsOnVertex(i, iVertex)
+               r_tmp = edgeSignOnVertex(i, iVertex) * &
+                       dcEdge(iEdge) * normalVelocity(k, iEdge)
+               circulation(k, iVertex) = circulation(k, iVertex) + r_tmp
+               areaDual = areaDual + &
+                          cellMask(k, iCell) * kiteAreasOnVertex(i, iVertex)
+            end do
             if (boundaryVertex(k, iVertex) .gt. 0.0_RKIND) then
-              circulation(k, iVertex) = wall_slip_factor * circulation(k, iVertex)
-              relativeVorticity(k, iVertex) = wall_slip_factor * relativeVorticity(k, iVertex)
+               circulation(k, iVertex) = wall_slip_factor * circulation(k, iVertex)
             end if
+            relativeVorticity(k, iVertex) = circulation(k, iVertex) / areaDual
          end do
       end do
 #ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
 #endif
-
-      deallocate(areaDual)
 
    !--------------------------------------------------------------------
 
@@ -1026,12 +1021,11 @@ contains
          cell1, cell2                ! neighbor cell   addresses
 
       real(kind=RKIND) :: &
-         invAreaTri1,          &! 1/triangle area
          invAreaCell1,         &! 1/cell area
          invLength,            &! 1/length
          layerThicknessVertex, &! layer thickness at vertex
          apvm_scale_factor,    &! scale factor for APVM form
-         areaDual
+         areaDual               ! unmaksed dual-cell overlap
 
       ! Local arrays
       ! normalizedPlanetaryVorticityVertex: earth's rotational rate
@@ -1072,7 +1066,7 @@ contains
       !$acc            normalizedPlanetaryVorticityVertex, &
       !$acc            relativeVorticity, fVertex, layerThickness, &
       !$acc            kiteAreasOnVertex, cellsOnVertex, &
-      !$acc            maxLevelVertexBot) &
+      !$acc            minLevelVertexTop, maxLevelVertexBot) &
       !$acc    private(i, k, iCell, areaDual, layerThicknessVertex)
 #else
       !$omp parallel


### PR DESCRIPTION
Merges Darren's branch for the submesoscale baroclinic channel (bichan). The branch is old and I want to get this merged because it will be used by 2025 LANL summer students for numerical mixing. Bichan is used to study MPAS-O's ability to resolve submesoscale dynamics and compared with ROMS for a JAMES manuscript. Details can be found [here](https://www.authorea.com/doi/full/10.22541/au.172124429.92585368). 

The code adds no-,partial-, and free-slip options for lateral boundary conditions in idealized configurations. Bichan uses free-slip boundary conditions in the along-channel (north-south) directions and is periodic in the across-shore (east-west) directions. Bichan runs on perlmutter, the preprint figures are proof of concept. Currently used by Kyle Hinson, who I can't tag. 

Question(s): Does the code need quality of life improvements? Should we add a config option directly to the namelist so it's setup as a proper stealth feature? Bichan could be a great test case for Omega once it is primitive equation!  

