### PR TITLE
EAMxx: simplify usage of remappers and field manager

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -537,7 +537,6 @@ void AtmosphereDriver::create_fields()
 
   // Create FM
   m_field_mgr = std::make_shared<field_mgr_type>(m_grids_manager);
-  m_field_mgr->registration_begins();
 
   // Before registering fields, check that Field Requests for tracers are compatible
   // and store the correct type of turbulence advection for each tracer

--- a/components/eamxx/src/diagnostics/tests/field_at_pressure_level_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/field_at_pressure_level_tests.cpp
@@ -168,7 +168,6 @@ std::shared_ptr<FieldManager> get_test_fm(std::shared_ptr<const AbstractGrid> gr
 
   // Register fields with fm
   // Make sure packsize isn't bigger than the packsize for this machine, but not so big that we end up with only 1 pack.
-  fm->registration_begins();
   fm->register_field(FR{fid1,Pack::n});
   fm->register_field(FR{fid2,Pack::n});
   fm->register_field(FR{fid3,Pack::n});

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_fv_phys.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_fv_phys.cpp
@@ -278,7 +278,6 @@ void HommeDynamics::fv_phys_rrtmgp_active_gases_remap (const RunType run_type) {
       for (const auto& e : trace_gases_workaround.get_active_gases())
         create_helper_field(e, {EL,GP,GP,LEV}, {nelem,NGP,NGP,nlev}, dgn);
       auto r = trace_gases_workaround.get_remapper();
-      r->registration_begins();
       for (const auto& e : trace_gases_workaround.get_active_gases())
         r->register_field(get_field_in(e, rgn), m_helper_fields.at(e));
       r->registration_ends();

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
@@ -388,8 +388,6 @@ void HommeDynamics::initialize_impl (const RunType run_type)
     fv_phys_initialize_impl();
   } else {
     // Setup the p2d and d2p remappers
-    m_p2d_remapper->registration_begins();
-    m_d2p_remapper->registration_begins();
 
     // ftype==FORCING_0:
     //  1) remap Q_pgn->FQ_dyn
@@ -996,7 +994,6 @@ void HommeDynamics::restart_homme_state () {
     return;
   }
 
-  m_ic_remapper->registration_begins();
   m_ic_remapper->register_field(m_helper_fields.at("FT_phys"),get_internal_field("vtheta_dp_dyn"));
   m_ic_remapper->register_field(m_helper_fields.at("FM_phys"),get_internal_field("v_dyn"));
   m_ic_remapper->register_field(get_field_out("pseudo_density",pgn),get_internal_field("dp3d_dyn"));
@@ -1100,7 +1097,6 @@ void HommeDynamics::initialize_homme_state () {
   // NOTE: if/when PD remapper supports remapping directly to/from subfields,
   //       you can use get_internal_field (which have a single time slice) rather than
   //       the helper fields (which have NTL time slices).
-  m_ic_remapper->registration_begins();
   m_ic_remapper->register_field(get_field_in("horiz_winds",rgn),get_internal_field("v_dyn"));
   m_ic_remapper->register_field(get_field_out("pseudo_density",rgn),get_internal_field("dp3d_dyn"));
   m_ic_remapper->register_field(get_field_in("ps",rgn),get_internal_field("ps_dyn"));

--- a/components/eamxx/src/dynamics/homme/tests/dyn_grid_io.cpp
+++ b/components/eamxx/src/dynamics/homme/tests/dyn_grid_io.cpp
@@ -120,7 +120,6 @@ TEST_CASE("dyn_grid_io")
   std::uniform_real_distribution<Real> pdf(0.01,100.0);
   auto engine = setup_random_test(&comm);
   auto dyn2ctrl = gm->create_remapper(dyn_grid,phys_grid);
-  dyn2ctrl->registration_begins();
   for (const auto& fn : fnames) {
     auto fd = fm->get_field(fn,dyn_grid->name());
     auto fc = fm_ctrl->get_field(fn,phys_grid->name());

--- a/components/eamxx/src/dynamics/homme/tests/dyn_grid_io.cpp
+++ b/components/eamxx/src/dynamics/homme/tests/dyn_grid_io.cpp
@@ -92,9 +92,6 @@ TEST_CASE("dyn_grid_io")
   // The FM we will manually remap onto
   auto fm_ctrl= std::make_shared<FieldManager> (phys_grid);
 
-  fm->registration_begins();
-  fm_ctrl->registration_begins();
-
   const int ps = HOMMEXX_PACK_SIZE;
   util::TimeStamp t0({2000,1,1},{0,0,0});
 

--- a/components/eamxx/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
+++ b/components/eamxx/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
@@ -198,7 +198,6 @@ TEST_CASE("remap", "") {
 
   // Build the remapper, and register the fields
   std::shared_ptr<Remapper> remapper(new Remapper(phys_grid,dyn_grid));
-  remapper->registration_begins();
   remapper->register_field(s_2d_field_phys, s_2d_field_dyn);
   remapper->register_field(v_2d_field_phys, v_2d_field_dyn);
   remapper->register_field(s_3d_field_phys, s_3d_field_dyn);
@@ -739,7 +738,6 @@ TEST_CASE("combo_remap", "") {
 
   // Build the remapper, and register the fields
   std::shared_ptr<Remapper> remapper(new Remapper(phys_grid,dyn_grid));
-  remapper->registration_begins();
   remapper->register_field(s_2d_field_phys, s_2d_field_dyn);
   remapper->register_field(v_2d_field_phys, v_2d_field_dyn);
   remapper->register_field(s_3d_field_phys, s_3d_field_dyn);

--- a/components/eamxx/src/physics/mam/readfiles/fractional_land_use_impl.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/fractional_land_use_impl.hpp
@@ -52,8 +52,6 @@ fracLandUseFunctions<S, D>::create_horiz_remapper(
         std::make_shared<RefiningRemapperP2P>(horiz_interp_tgt_grid, map_file);
   }
 
-  remapper->registration_begins();
-
   const auto tgt_grid = remapper->get_tgt_grid();
 
   const auto layout_2d = tgt_grid->get_2d_vector_layout(nclass_data, "class");

--- a/components/eamxx/src/physics/mam/readfiles/marine_organics_impl.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/marine_organics_impl.hpp
@@ -49,8 +49,6 @@ marineOrganicsFunctions<S, D>::create_horiz_remapper(
         std::make_shared<RefiningRemapperP2P>(horiz_interp_tgt_grid, map_file);
   }
 
-  remapper->registration_begins();
-
   const auto tgt_grid = remapper->get_tgt_grid();
 
   const auto layout_2d = tgt_grid->get_2d_scalar_layout();

--- a/components/eamxx/src/physics/mam/readfiles/soil_erodibility_impl.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/soil_erodibility_impl.hpp
@@ -50,8 +50,6 @@ soilErodibilityFunctions<S, D>::create_horiz_remapper(
         std::make_shared<RefiningRemapperP2P>(horiz_interp_tgt_grid, map_file);
   }
 
-  remapper->registration_begins();
-
   const auto tgt_grid = remapper->get_tgt_grid();
 
   const auto layout_2d = tgt_grid->get_2d_scalar_layout();

--- a/components/eamxx/src/physics/mam/readfiles/tracer_reader_utils.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/tracer_reader_utils.hpp
@@ -417,7 +417,6 @@ inline std::shared_ptr<AbstractRemapper> create_horiz_remapper(
         std::make_shared<RefiningRemapperP2P>(horiz_interp_tgt_grid, map_file);
   }
 
-  remapper->registration_begins();
   const auto tgt_grid  = remapper->get_tgt_grid();
   const auto layout_2d = tgt_grid->get_2d_scalar_layout();
 

--- a/components/eamxx/src/physics/mam/srf_emission_impl.hpp
+++ b/components/eamxx/src/physics/mam/srf_emission_impl.hpp
@@ -48,8 +48,6 @@ srfEmissFunctions<S, D>::create_horiz_remapper(
         std::make_shared<RefiningRemapperP2P>(horiz_interp_tgt_grid, map_file);
   }
 
-  remapper->registration_begins();
-
   const auto tgt_grid = remapper->get_tgt_grid();
 
   const auto layout_2d = tgt_grid->get_2d_scalar_layout();

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -236,7 +236,6 @@ void Nudging::initialize_impl (const RunType /* run_type */)
   const auto layout_ext = grid_ext->get_3d_scalar_layout(true);
   const auto layout_tmp = grid_tmp->get_3d_scalar_layout(true);
   const auto layout_atm = m_grid->get_3d_scalar_layout(true);
-  m_horiz_remapper->registration_begins();
   for (auto name : m_fields_nudge) {
     std::string name_ext = name + "_ext";
     std::string name_tmp = name + "_tmp";

--- a/components/eamxx/src/physics/nudging/tests/nudging_tests_helpers.hpp
+++ b/components/eamxx/src/physics/nudging/tests/nudging_tests_helpers.hpp
@@ -55,7 +55,6 @@ create_fm (const std::shared_ptr<const AbstractGrid>& grid)
   FieldIdentifier fid2("horiz_winds",vector3d,m/s,gn);
 
   // Register fields with fm
-  fm->registration_begins();
   fm->register_field(FR(fid1));
   fm->register_field(FR(fid2));
   fm->registration_ends();

--- a/components/eamxx/src/python/libpyeamxx/pyatmproc.hpp
+++ b/components/eamxx/src/python/libpyeamxx/pyatmproc.hpp
@@ -172,9 +172,7 @@ struct PyAtmProc {
     auto gm = PySession::get().gm;
     std::map<std::string,std::shared_ptr<FieldManager>> fms;
     for (auto it : gm->get_repo()) {
-      fms[it.first] = std::make_shared<FieldManager>(it.second);
-      fms[it.first]->registration_begins();
-      fms[it.first]->registration_ends();
+      fms[it.first] = std::make_shared<FieldManager>(it.second,RepoState::Closed);
     }
     for (auto it : fields) {
       const auto& gn = it.second.f.get_header().get_identifier().get_grid_name();

--- a/components/eamxx/src/share/atm_process/IOPDataManager.cpp
+++ b/components/eamxx/src/share/atm_process/IOPDataManager.cpp
@@ -345,7 +345,6 @@ read_fields_from_file_for_iop (const std::string& file_name,
   const auto lon = m_params.get<Real>("target_longitude");
   auto remapper = std::make_shared<IOPRemapper>(io_grid,grid,lat,lon);
 
-  remapper->registration_begins();
   for (const auto& f : fields) {
     remapper->register_field_from_tgt(f);
   }

--- a/components/eamxx/src/share/field/field_manager.hpp
+++ b/components/eamxx/src/share/field/field_manager.hpp
@@ -43,8 +43,8 @@ public:
   using group_info_map      = std::map<ci_string, std::shared_ptr<FieldGroupInfo>>;
 
   // Constructor(s)
-  explicit FieldManager (const std::shared_ptr<const AbstractGrid>& grid);
-  explicit FieldManager (const std::shared_ptr<const GridsManager>& grid);
+  explicit FieldManager (const std::shared_ptr<const AbstractGrid>& grid, const RepoState state = RepoState::Clean);
+  explicit FieldManager (const std::shared_ptr<const GridsManager>& grid, const RepoState state = RepoState::Clean);
 
   // No copies, cause the internal database is not a shared_ptr.
   // NOTE: you can change this if you find that copies are needed/useful.
@@ -52,7 +52,6 @@ public:
   FieldManager& operator= (const FieldManager&) = delete;
 
   // Change the state of the database
-  void registration_begins ();
   void register_field (const FieldRequest& req);
   void register_group (const GroupRequest& req);
   void registration_ends ();

--- a/components/eamxx/src/share/grid/remap/abstract_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/abstract_remapper.cpp
@@ -59,7 +59,7 @@ register_field (const Field& src, const Field& tgt)
   ++m_num_fields;
 }
 
-void AbstractRemapper::
+Field AbstractRemapper::
 register_field_from_src (const Field& src) {
   const auto& src_fid = src.get_header().get_identifier();
   const auto& tgt_fid = create_tgt_fid(src_fid);
@@ -71,9 +71,11 @@ register_field_from_src (const Field& src) {
   tgt.allocate_view();
 
   register_field(src,tgt);
+
+  return tgt;
 }
 
-void AbstractRemapper::
+Field AbstractRemapper::
 register_field_from_tgt (const Field& tgt) {
   const auto& tgt_fid = tgt.get_header().get_identifier();
   const auto& src_fid = create_src_fid(tgt_fid);
@@ -85,6 +87,8 @@ register_field_from_tgt (const Field& tgt) {
   src.allocate_view();
 
   register_field(src,tgt);
+
+  return src;
 }
 
 void AbstractRemapper::registration_ends ()

--- a/components/eamxx/src/share/grid/remap/abstract_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/abstract_remapper.cpp
@@ -11,20 +11,13 @@ AbstractRemapper (const grid_ptr_type& src_grid,
 }
 
 void AbstractRemapper::
-registration_begins () {
-  EKAT_REQUIRE_MSG(m_state==RepoState::Clean,
-      "Error! Cannot start registration on a non-clean repo.\n"
-      "       Did you call 'registration_begins' already?\n");
-
-  m_state = RepoState::Open;
-}
-
-void AbstractRemapper::
 register_field (const Field& src, const Field& tgt)
 {
-  EKAT_REQUIRE_MSG(m_state==RepoState::Open,
+  EKAT_REQUIRE_MSG(m_state!=RepoState::Closed,
       "Error! Cannot register fields in the remapper at this time.\n"
-      "       Did you forget to call 'registration_begins' or called 'registeration_ends' already?");
+      "       Did you already call 'registeration_ends'?");
+
+  m_state = RepoState::Open;
 
   EKAT_REQUIRE_MSG(src.is_allocated(), "Error! Source field is not yet allocated.\n");
   EKAT_REQUIRE_MSG(tgt.is_allocated(), "Error! Target field is not yet allocated.\n");
@@ -110,13 +103,11 @@ void AbstractRemapper::remap_fwd ()
       "Error! Cannot perform remapping at this time.\n"
       "       Did you forget to call 'registration_ends'?\n");
 
-  if (m_state!=RepoState::Clean) {
-    EKAT_REQUIRE_MSG (m_fwd_allowed,
-        "Error! Forward remap is not allowed by this remapper.\n");
-    EKAT_REQUIRE_MSG (not m_has_read_only_tgt_fields,
-        "Error! Forward remap IS allowed by this remapper, but some of the tgt fields are read-only\n");
-    remap_fwd_impl ();
-  }
+  EKAT_REQUIRE_MSG (m_fwd_allowed,
+      "Error! Forward remap is not allowed by this remapper.\n");
+  EKAT_REQUIRE_MSG (not m_has_read_only_tgt_fields,
+      "Error! Forward remap IS allowed by this remapper, but some of the tgt fields are read-only\n");
+  remap_fwd_impl ();
 }
 
 void AbstractRemapper::remap_bwd ()
@@ -125,13 +116,11 @@ void AbstractRemapper::remap_bwd ()
       "Error! Cannot perform remapping at this time.\n"
       "       Did you forget to call 'registration_ends'?\n");
 
-  if (m_state!=RepoState::Clean) {
-    EKAT_REQUIRE_MSG (m_bwd_allowed,
-        "Error! Backward remap is not allowed by this remapper.\n");
-    EKAT_REQUIRE_MSG (not m_has_read_only_src_fields,
-        "Error! Backward remap IS allowed by this remapper, but some of the src fields are read-only\n");
-    remap_bwd_impl ();
-  }
+  EKAT_REQUIRE_MSG (m_bwd_allowed,
+      "Error! Backward remap is not allowed by this remapper.\n");
+  EKAT_REQUIRE_MSG (not m_has_read_only_src_fields,
+      "Error! Backward remap IS allowed by this remapper, but some of the src fields are read-only\n");
+  remap_bwd_impl ();
 }
 
 void AbstractRemapper::

--- a/components/eamxx/src/share/grid/remap/abstract_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/abstract_remapper.hpp
@@ -40,8 +40,8 @@ public:
   void register_field (const Field& src, const Field& tgt);
 
   // Like the above, but create tgt/src internally
-  virtual void register_field_from_src (const Field& src);
-  virtual void register_field_from_tgt (const Field& tgt);
+  virtual Field register_field_from_src (const Field& src);
+  virtual Field register_field_from_tgt (const Field& tgt);
 
   // Call this to indicate that field registration is complete.
   void registration_ends ();

--- a/components/eamxx/src/share/grid/remap/abstract_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/abstract_remapper.hpp
@@ -33,9 +33,6 @@ public:
 
   // ----- Registration/setup methods ---- //
 
-  // Call this before you begin registering fields with this remapper.
-  void registration_begins ();
-
   // This method registers a source field to be remapped to a target field.
   void register_field (const Field& src, const Field& tgt);
 
@@ -45,7 +42,6 @@ public:
 
   // Call this to indicate that field registration is complete.
   void registration_ends ();
-
 
   //  ------- Getter methods ------- //
   RepoState get_state () const { return m_state; }

--- a/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
@@ -27,7 +27,6 @@ CoarseningRemapper (const grid_ptr_type& src_grid,
     // Replicate the src grid geo data in the tgt grid. We use this remapper to do
     // the remapping (if needed), and clean it up afterwards.
     const auto& src_geo_data_names = src_grid->get_geometry_data_names();
-    registration_begins();
     for (const auto& name : src_geo_data_names) {
       // Since different remappers may share the same data (if the map file is the same)
       // the coarse grid may already have the geo data.

--- a/components/eamxx/src/share/grid/remap/identity_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/identity_remapper.cpp
@@ -17,24 +17,26 @@ void IdentityRemapper::set_aliasing (const Aliasing aliasing) {
   m_aliasing = aliasing;
 }
 
-void IdentityRemapper::register_field_from_src (const Field& src)
+Field IdentityRemapper::register_field_from_src (const Field& src)
 {
   EKAT_REQUIRE_MSG (m_aliasing!=SrcAliasTgt,
       "Error! Makes no sense to register from src and ask that src alias tgt.\n");
   if (m_aliasing==TgtAliasSrc) {
     register_field(src,src);
+    return src;
   } else {
-    AbstractRemapper::register_field_from_src(src);
+    return AbstractRemapper::register_field_from_src(src);
   }
 }
-void IdentityRemapper::register_field_from_tgt (const Field& tgt)
+Field IdentityRemapper::register_field_from_tgt (const Field& tgt)
 {
   EKAT_REQUIRE_MSG (m_aliasing!=TgtAliasSrc,
       "Error! Makes no sense to register from tgt and ask that tgt alias src.\n");
   if (m_aliasing==SrcAliasTgt) {
     register_field(tgt,tgt);
+    return tgt;
   } else {
-    AbstractRemapper::register_field_from_tgt(tgt);
+    return AbstractRemapper::register_field_from_tgt(tgt);
   }
 }
 

--- a/components/eamxx/src/share/grid/remap/identity_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/identity_remapper.cpp
@@ -12,7 +12,7 @@ IdentityRemapper (const grid_ptr_type grid,
 }
 
 void IdentityRemapper::set_aliasing (const Aliasing aliasing) {
-  EKAT_REQUIRE_MSG (get_state()==RepoState::Clean,
+  EKAT_REQUIRE_MSG (m_num_fields==0,
       "Error! Aliasing in IdentityRemapper must be set *before* registration starts.\n");
   m_aliasing = aliasing;
 }

--- a/components/eamxx/src/share/grid/remap/identity_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/identity_remapper.hpp
@@ -33,8 +33,8 @@ public:
 
   void set_aliasing (const Aliasing aliasing);
 
-  void register_field_from_src (const Field& src) override;
-  void register_field_from_tgt (const Field& tgt) override;
+  Field register_field_from_src (const Field& src) override;
+  Field register_field_from_tgt (const Field& tgt) override;
 
 protected:
 

--- a/components/eamxx/src/share/grid/remap/inverse_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/inverse_remapper.hpp
@@ -53,7 +53,6 @@ protected:
   }
 
   void registration_ends_impl () override {
-    m_remapper->registration_begins();
     for (int i=0; i<m_num_fields; ++i) {
       m_remapper->register_field(m_tgt_fields[i],m_src_fields[i]);
     }

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -241,7 +241,6 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
     // Now create a new FM on io grid, and create copies of output fields on that grid,
     // using the remapper to get the correct identifier on the tgt grid
     auto io_fm = std::make_shared<fm_type>(io_grid);
-    io_fm->registration_begins();
     for (const auto& fname : m_fields_names) {
       const auto src = get_field(fname,"sim");
       const auto tgt_fid = m_vert_remapper->create_tgt_fid(src.get_header().get_identifier());
@@ -296,7 +295,6 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
 
     // Create a FM on the horiz remapper tgt grid, and register fields on it
     auto io_fm = std::make_shared<fm_type>(io_grid);
-    io_fm->registration_begins();
     for (const auto& fname : m_fields_names) {
       const auto src = get_field(fname,"before_horizontal_remap");
       const auto tgt_fid = m_horiz_remapper->create_tgt_fid(src.get_header().get_identifier());

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -256,7 +256,6 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
     }
 
     // Register all output fields in the remapper.
-    m_vert_remapper->registration_begins();
     for (const auto& fname : m_fields_names) {
       const auto src = get_field(fname,"sim");
       const auto tgt = io_fm->get_field(src.name(), io_grid->name());
@@ -312,7 +311,6 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
     }
 
     // Register all output fields in the remapper.
-    m_horiz_remapper->registration_begins();
     for (const auto& fname : m_fields_names) {
       const auto src = get_field(fname,"before_horizontal_remap");
       const auto tgt = io_fm->get_field(src.name(), io_grid->name());

--- a/components/eamxx/src/share/io/tests/io_remap_test.cpp
+++ b/components/eamxx/src/share/io/tests/io_remap_test.cpp
@@ -620,7 +620,6 @@ std::shared_ptr<FieldManager> get_test_fm(std::shared_ptr<const AbstractGrid> gr
 
   // Register fields with fm
   // Make sure packsize isn't bigger than the packsize for this machine, but not so big that we end up with only 1 pack.
-  fm->registration_begins();
   fm->register_field(FR{fid_ps,"output"});
   fm->register_field(FR{fid_pm,"output",Pack::n});
   fm->register_field(FR{fid_pi,"output",Pack::n});

--- a/components/eamxx/src/share/io/tests/io_se_grid.cpp
+++ b/components/eamxx/src/share/io/tests/io_se_grid.cpp
@@ -123,7 +123,6 @@ get_test_fm(const std::shared_ptr<const AbstractGrid>& grid,
   FieldIdentifier fid4("field_packed",grid->get_3d_scalar_layout(true),kg/m,gn);
 
   // Register fields with fm
-  fm->registration_begins();
   fm->register_field(FR{fid1});
   fm->register_field(FR{fid2});
   fm->register_field(FR{fid3});

--- a/components/eamxx/src/share/io/tests/output_restart.cpp
+++ b/components/eamxx/src/share/io/tests/output_restart.cpp
@@ -182,7 +182,6 @@ get_test_fm(const std::shared_ptr<const AbstractGrid>& grid)
   FieldIdentifier fid5("field_5",rad_vector_3d,m*m, gn);
 
   // Register fields with fm
-  fm->registration_begins();
   fm->register_field(FR{fid1,SL{"output"}});
   fm->register_field(FR{fid2,SL{"output"}});
   fm->register_field(FR{fid3,SL{"output"}});
@@ -203,9 +202,7 @@ get_test_fm(const std::shared_ptr<const AbstractGrid>& grid)
 
 std::shared_ptr<FieldManager>
 clone_fm(const std::shared_ptr<const FieldManager>& src) {
-  auto copy = std::make_shared<FieldManager>(src->get_grid());
-  copy->registration_begins();
-  copy->registration_ends();
+  auto copy = std::make_shared<FieldManager>(src->get_grid(),RepoState::Closed);
   for (auto it : src->get_repo()) {
     copy->add_field(it.second->clone());
   }

--- a/components/eamxx/src/share/tests/coarsening_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/coarsening_remapper_tests.cpp
@@ -337,7 +337,6 @@ TEST_CASE("coarsening_remap")
   //     Register fields in the remapper    //
   // -------------------------------------- //
 
-  remap->registration_begins();
   for (size_t i=0; i<tgt_f.size(); ++i) {
     remap->register_field(src_f[i],tgt_f[i]);
   }

--- a/components/eamxx/src/share/tests/eamxx_time_interpolation_tests.cpp
+++ b/components/eamxx/src/share/tests/eamxx_time_interpolation_tests.cpp
@@ -344,9 +344,7 @@ std::shared_ptr<FieldManager> get_fm (const std::shared_ptr<const AbstractGrid>&
     FL({COL,CMP,ILEV}, {nlcols,2,nlevs+1})
   };
 
-  auto fm = std::make_shared<FieldManager>(grid);
-  fm->registration_begins();
-  fm->registration_ends();
+  auto fm = std::make_shared<FieldManager>(grid,RepoState::Closed);
 
   const auto units = ekat::units::Units::nondimensional();
   for (const auto& fl : layouts) {

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -463,9 +463,6 @@ TEST_CASE("field_mgr", "") {
   auto gm = std::make_shared<LibraryGridsManager>(g1, g2);
   FieldManager field_mgr(gm);
 
-  // Should not be able to register fields yet
-  REQUIRE_THROWS(field_mgr.register_field(FR(fid1_1)));
-
   // === Valid registration calls === //
   field_mgr.register_field(FR(fid1_1,Pack1::n));
   field_mgr.register_field(FR{fid1_2,Pack2::n});

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -466,8 +466,6 @@ TEST_CASE("field_mgr", "") {
   // Should not be able to register fields yet
   REQUIRE_THROWS(field_mgr.register_field(FR(fid1_1)));
 
-  field_mgr.registration_begins();
-
   // === Valid registration calls === //
   field_mgr.register_field(FR(fid1_1,Pack1::n));
   field_mgr.register_field(FR{fid1_2,Pack2::n});
@@ -587,8 +585,6 @@ TEST_CASE("tracers_group", "") {
   auto g2 = create_point_grid(gn2,ncols2*comm.size(),nlevs,comm);
   auto gm = std::make_shared<LibraryGridsManager>(g1, g2);
   FieldManager field_mgr(gm);
-
-  field_mgr.registration_begins();
 
   using los = std::list<std::string>;
   field_mgr.register_field(FR{qv_id,"tracers"});

--- a/components/eamxx/src/share/tests/iop_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/iop_remapper_tests.cpp
@@ -141,8 +141,6 @@ TEST_CASE("iop_remap")
     LayoutType::Tensor3D
   };
 
-  remap->registration_begins();
-
   bool midpoints = false; // midpoints is unused for 2d layouts
   for (auto l : layouts) {
     auto n = e2str(l);

--- a/components/eamxx/src/share/tests/refining_remapper_p2p_tests.cpp
+++ b/components/eamxx/src/share/tests/refining_remapper_p2p_tests.cpp
@@ -192,7 +192,6 @@ TEST_CASE ("refining_remapper") {
   {
     auto r = std::make_shared<RefiningRemapperP2PTester>(tgt_grid,filename);
     auto src_grid = r->get_src_grid();
-    r->registration_begins();
     Field bad_src(FieldIdentifier("",src_grid->get_2d_scalar_layout(),ekat::units::m,src_grid->name(),DataType::IntType));
     Field bad_tgt(FieldIdentifier("",tgt_grid->get_2d_scalar_layout(),ekat::units::m,tgt_grid->name(),DataType::IntType));
     CHECK_THROWS (r->register_field(bad_src,bad_tgt)); // not allocated
@@ -217,7 +216,6 @@ TEST_CASE ("refining_remapper") {
   auto s3d_tgt   = create_field("s3d_tgt",LayoutType::Scalar3D,*tgt_grid);
   auto v3d_tgt   = create_field("v3d_tgt",LayoutType::Vector3D,*tgt_grid);
 
-  r->registration_begins();
   r->register_field(s2d_src,s2d_tgt);
   r->register_field(v2d_src,v2d_tgt);
   r->register_field(s3d_src,s3d_tgt);

--- a/components/eamxx/src/share/tests/refining_remapper_rma_tests.cpp
+++ b/components/eamxx/src/share/tests/refining_remapper_rma_tests.cpp
@@ -247,7 +247,6 @@ TEST_CASE ("refining_remapper") {
   {
     auto r = std::make_shared<RefiningRemapperRMATester>(tgt_grid,filename);
     auto src_grid = r->get_src_grid();
-    r->registration_begins();
     Field bad_src(FieldIdentifier("",src_grid->get_2d_scalar_layout(),ekat::units::m,src_grid->name(),DataType::IntType));
     Field bad_tgt(FieldIdentifier("",tgt_grid->get_2d_scalar_layout(),ekat::units::m,tgt_grid->name(),DataType::IntType));
     CHECK_THROWS (r->register_field(bad_src,bad_tgt)); // not allocated
@@ -272,7 +271,6 @@ TEST_CASE ("refining_remapper") {
   auto s3d_tgt   = create_field("s3d_tgt",LayoutType::Scalar3D,*tgt_grid);
   auto v3d_tgt   = create_field("v3d_tgt",LayoutType::Vector3D,*tgt_grid);
 
-  r->registration_begins();
   r->register_field(s2d_src,s2d_tgt);
   r->register_field(v2d_src,v2d_tgt);
   r->register_field(s3d_src,s3d_tgt);

--- a/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
@@ -458,7 +458,6 @@ TEST_CASE ("vertical_remapper") {
             REQUIRE_THROWS (remap->set_mask_value(std::numeric_limits<Real>::quiet_NaN()));
             remap->set_mask_value(mask_val); // Only needed if top and/or bot use etype=Mask
 
-            remap->registration_begins();
             remap->register_field(src_s2d,  tgt_s2d);
             remap->register_field(src_v2d,  tgt_v2d);
             remap->register_field(src_s3d_m,tgt_s3d_m);

--- a/components/eamxx/src/share/util/eamxx_data_interpolation.cpp
+++ b/components/eamxx/src/share/util/eamxx_data_interpolation.cpp
@@ -515,14 +515,11 @@ setup_vert_remapper (const RemapData& data)
 void DataInterpolation::register_fields_in_remappers ()
 {
   // Register fields in the remappers. Vertical first, since we only have model-grid fields
-  m_vert_remapper->registration_begins();
   for (int i=0; i<m_nfields; ++i) {
     m_vert_remapper->register_field_from_tgt(m_fields[i]);
   }
   m_vert_remapper->registration_ends();
 
-  m_horiz_remapper_beg->registration_begins();
-  m_horiz_remapper_end->registration_begins();
   for (int i=0; i<m_nfields; ++i) {
     const auto& f = m_vert_remapper->get_src_field(i);
     m_horiz_remapper_beg->register_field_from_tgt(f.clone(f.name(), m_horiz_remapper_beg->get_src_grid()->name()));

--- a/components/eamxx/src/share/util/eamxx_time_interpolation.cpp
+++ b/components/eamxx/src/share/util/eamxx_time_interpolation.cpp
@@ -12,12 +12,8 @@ TimeInterpolation::TimeInterpolation(
 )
 {
   // Given the grid initialize field managers to store interpolation data
-  m_fm_time0 = std::make_shared<FieldManager>(grid);
-  m_fm_time1 = std::make_shared<FieldManager>(grid);
-  m_fm_time0->registration_begins();
-  m_fm_time0->registration_ends();
-  m_fm_time1->registration_begins();
-  m_fm_time1->registration_ends();
+  m_fm_time0 = std::make_shared<FieldManager>(grid,RepoState::Closed);
+  m_fm_time1 = std::make_shared<FieldManager>(grid,RepoState::Closed);
 }
 /*-----------------------------------------------------------------------------------------------*/
 TimeInterpolation::TimeInterpolation(

--- a/components/eamxx/tests/single-process/surface_coupling/surface_coupling.cpp
+++ b/components/eamxx/tests/single-process/surface_coupling/surface_coupling.cpp
@@ -68,9 +68,7 @@ std::vector<std::string> create_from_file_test_data(const ekat::Comm& comm, cons
   const auto dofs_gids = grid->get_dofs_gids().get_view<const int*,Host>();
   std::vector<std::string> fnames = {"lwdn"};
   FieldLayout layout({COL},{nlcols});
-  auto fm = std::make_shared<FieldManager>(grid);
-  fm->registration_begins();
-  fm->registration_ends();
+  auto fm = std::make_shared<FieldManager>(grid,RepoState::Closed);
   auto nondim = Units::nondimensional();
   for (auto name : fnames) {
     FieldIdentifier fid(name,layout,nondim,grid->name());


### PR DESCRIPTION
Namely:

- remove `registration_begins` for remappers: it never did anything useful, and derived classes never overrode it;
- remove `registraiton_begins` for field manager: did not do anything;
- return created field when `register_field_from_tgt/src` is used in remappers;
- allow creating a field manager that is already closed: helps if the FM is only used as a "container" for manually created fields.

[BFB]

---

Note: I did some of these mods while refactoring a bit our output class. I decided to factor out these mods, to make PR review faster/easier.