### PR TITLE
EAMxx: enhance TimeStamp update method

### DIFF
--- a/components/eamxx/src/share/tests/utils_tests.cpp
+++ b/components/eamxx/src/share/tests/utils_tests.cpp
@@ -144,6 +144,12 @@ TEST_CASE ("time_stamp") {
     REQUIRE (ts2.get_num_steps()==6);
   }
 
+  SECTION ("fractional_update") {
+    // Check update with fractional seconds
+    REQUIRE ((ts1+0.999)==ts1);
+    REQUIRE ((ts1+0.9999)!=ts1); // When seconds frac is <0.001 or >0.999 we round
+  }
+
   SECTION ("leap_years") {
     // Check leap year correctness
     TS ts2({2000,2,28},{23,59,59});

--- a/components/eamxx/src/share/util/eamxx_time_stamp.hpp
+++ b/components/eamxx/src/share/util/eamxx_time_stamp.hpp
@@ -58,7 +58,7 @@ public:
   TimeStamp& operator= (const TimeStamp&) = default;
 
   // This method checks that time shifts forward (i.e. that seconds is positive)
-  TimeStamp& operator+= (const double seconds);
+  TimeStamp& operator+= (double seconds);
 
   // Clones the stamps and sets num steps to given value. If -1, clones num steps too
   TimeStamp clone (const int num_steps);
@@ -67,15 +67,20 @@ protected:
 
   std::vector<int> m_date;  // [year, month, day]
   std::vector<int> m_time;  // [hour, min, sec]
+  double           m_sec_fraction = 0;
 
   int m_num_steps = std::numeric_limits<int>::lowest(); // Number of steps since simulation started
 };
 
 // Overload operators for TimeStamp
 bool operator== (const TimeStamp& ts1, const TimeStamp& ts2);
+inline bool operator!= (const TimeStamp& ts1, const TimeStamp& ts2)
+{
+  return not (ts1==ts2);
+}
 bool operator<  (const TimeStamp& ts1, const TimeStamp& ts2);
 bool operator<= (const TimeStamp& ts1, const TimeStamp& ts2);
-TimeStamp operator+ (const TimeStamp& ts, const int dt);
+TimeStamp operator+ (const TimeStamp& ts, const double dt);
 
 // Difference (in seconds) between two timestamps
 std::int64_t operator- (const TimeStamp& ts1, const TimeStamp& ts2);


### PR DESCRIPTION
Allow to keep a tally of seconds fractions. We round to nearest second whenever the seconds fraction is <1ms or >999ms.

[BFB]

Closes #6906 

---

I am not sure why we open the issue linked. I think MAM was running into problems when doing aggressive subcycling, to the point that the process dt was fractional. Anyhow, I found this PR hidden on my laptop, so I polished it quickly, so we can close the issue.