### PR TITLE
Workflows: automate merging to next

### DIFF
--- a/.github/workflows/e3sm-merge-to-next.yaml
+++ b/.github/workflows/e3sm-merge-to-next.yaml
@@ -70,6 +70,30 @@ jobs:
               core.exportVariable('proceed', 'no');
               console.log(`The label ${process.env.LABEL_NAME} will be removed.`);
             }
+      - name: Check actor is an assignee
+        if: ${{ env.proceed == 'yes' }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const assignees = context.payload.pull_request.assignees;
+            let isAssignee = false;
+
+            if (assignees && assignees.length > 0) {
+              for (const assignee of assignees) {
+                if (assignee.login === ${context.actor}) {
+                  isAssignee = true;
+                  break;
+                }
+              }
+            }
+
+            if (isAssignee) {
+              console.log(`${context.actor} is one of the assignees of the PR. Will proceed.`);
+            } else {
+              console.log(`${context.actor} is NOT an assignee of the PR.`);
+              console.log(`The label ${process.env.LABEL_NAME} will be removed.`);
+              core.exportVariable('proceed', 'no');
+            }
 
       - name: Check mergeability
         if: ${{ env.proceed == 'yes' }}


### PR DESCRIPTION
This is an attempt to create a workflow to automate the merging to next. The worflow runs whenever a label is set, and it does the following steps.

1. Check if the label set was 'CI: merge-to-next'.
2. Check if the user that set it is part of "e3sm-integrators" team
3. Check for at least one approval and no requests for changes
4. Check for PR mergeability
5. Cook up the merge commit, merge, and push

The merge commit is formatted as follows, where `{blah}` expands to the content of `blah`:

```
Merge branch '{branch}' into next (PR # {pr number})

PR Author: {author}
PR Labels: {labels}

{body}
```
where we trim body to only contain what's up to the first occurence of the line "---" (if any). I added author/labels, but they can be removed. I figured that adding labels automatically would help picking up the BFB prs, even if the PR opener forgot to add [BFB] to the pr body (assuming they did not forget to add the BFB label).

This is a tentative impl. I would like to verify it works correctly using a test repo. @rljacob, what are your thoughts?