### PR TITLE
Additional canopy air and aerodynamic output variables, ELM

### DIFF
--- a/components/elm/src/biogeophys/BareGroundFluxesMod.F90
+++ b/components/elm/src/biogeophys/BareGroundFluxesMod.F90
@@ -87,7 +87,7 @@ contains
     real(r8) :: dth(bounds%begp:bounds%endp)     ! diff of virtual temp. between ref. height and surface
     real(r8) :: dthv                             ! diff of vir. poten. temp. between ref. height and surface
     real(r8) :: dqh(bounds%begp:bounds%endp)     ! diff of humidity between ref. height and surface
-    real(r8) :: obu(bounds%begp:bounds%endp)     ! Monin-Obukhov length (m)
+    real(r8) :: obu(bounds%begp:bounds%endp)     ! Obukhov length scale (m)
     real(r8) :: ur(bounds%begp:bounds%endp)      ! wind speed at reference height [m/s]
     real(r8) :: um(bounds%begp:bounds%endp)      ! wind speed including the stablity effect [m/s]
     real(r8) :: temp1(bounds%begp:bounds%endp)   ! relation for potential temperature profile
@@ -250,7 +250,7 @@ contains
          z0hg_patch(p) = z0hg_col(c)
          z0qg_patch(p) = z0qg_col(c)
 
-         ! Initialize Monin-Obukhov length and wind speed
+         ! Initialize Obukhov length scale and wind speed
 
          call MoninObukIni(ur(p), thv(c), dthv, zldis(p), z0mg_patch(p), um(p), obu(p))
          num_iter(p) = 0._r8

--- a/components/elm/src/biogeophys/CanopyFluxesMod.F90
+++ b/components/elm/src/biogeophys/CanopyFluxesMod.F90
@@ -17,6 +17,8 @@ module CanopyFluxesMod
   use elm_varctl            , only : use_hydrstress
   use elm_varpar            , only : nlevgrnd, nlevsno
   use elm_varcon            , only : namep
+  use elm_varcon            , only : mm_epsilon
+  use elm_varcon            , only : pa_to_kpa
   use pftvarcon             , only : crop, nfixer
   use decompMod             , only : bounds_type
   use PhotosynthesisMod     , only : Photosynthesis, PhotosynthesisTotal, Fractionation, PhotoSynthesisHydraulicStress
@@ -318,6 +320,9 @@ contains
     ! Indices for raw and rah
     integer, parameter :: above_canopy = 1         ! Above canopy
     integer, parameter :: below_canopy = 2         ! Below canopy
+
+    ! Lower bound for VPD (based on CLM)
+    real(r8), parameter :: vpd_min = 50._r8
     !------------------------------------------------------------------------------
 
     associate(                                                               &
@@ -863,7 +868,7 @@ contains
             ! Done each iteration to account for differences in eah, tv.
 
             svpts(p) = el(p)                         ! Pa
-            eah(p) = forc_pbot(t) * qaf(p) / 0.622_r8   ! Pa
+            eah(p) = forc_pbot(t) * qaf(p) / mm_epsilon   ! Pa
             rhaf(p) = eah(p)/svpts(p)
 
             ! variables for history fields
@@ -871,7 +876,7 @@ contains
             raw_above(p)  = raw(p,above_canopy)
             rah_below(p)  = rah(p,below_canopy)
             raw_below(p)  = raw(p,below_canopy)
-            vpd(p)        = max((svpts(p) - eah(p)), 50._r8) * 0.001_r8 ! kPa
+            vpd(p)        = max((svpts(p) - eah(p)), vpd_min) * pa_to_kpa ! kPa
          end do
 
          ! Modification for shrubs proposed by X.D.Z

--- a/components/elm/src/biogeophys/CanopyFluxesMod.F90
+++ b/components/elm/src/biogeophys/CanopyFluxesMod.F90
@@ -230,7 +230,7 @@ contains
     real(r8) :: efpot                                ! potential latent energy flux [kg/m2/s]
     real(r8) :: efe(bounds%begp:bounds%endp)         ! water flux from leaf [mm/s]
     real(r8) :: efsh                                 ! sensible heat from leaf [mm/s]
-    real(r8) :: obuold(bounds%begp:bounds%endp)      ! monin-obukhov length from previous iteration
+    real(r8) :: obuold(bounds%begp:bounds%endp)      ! Obukhov length scale from previous iteration
     real(r8) :: tlbef(bounds%begp:bounds%endp)       ! leaf temperature from previous iteration [K]
     real(r8) :: ecidif                               ! excess energies [W/m2]
     real(r8) :: err(bounds%begp:bounds%endp)         ! balance error
@@ -452,9 +452,9 @@ contains
          uaf                  => frictionvel_vars%uaf_patch       , & ! Output: [real(r8) (:)   ]  canopy air wind speed [m/s]
          taf                  => frictionvel_vars%taf_patch       , & ! Output: [real(r8) (:)   ]  canopy air temperature [K]
          qaf                  => frictionvel_vars%qaf_patch       , & ! Output: [real(r8) (:)   ]  canopy air specific humidity [kg/kg]
-         obu                  => frictionvel_vars%obu_patch       , & ! Output: [real(r8) (:)   ]  Obukhov length [m]
+         obu                  => frictionvel_vars%obu_patch       , & ! Output: [real(r8) (:)   ]  Obukhov length scale [m]
          zeta                 => frictionvel_vars%zeta_patch      , & ! Output: [real(r8) (:)   ]  dimensionless stability parameter 
-         vpd                  => frictionvel_vars%vpd_patch       , & ! Output: [real(r8) (:)   ]  vapour pressure deficit [Pa]
+         vpd                  => frictionvel_vars%vpd_patch       , & ! Output: [real(r8) (:)   ]  vapour pressure deficit [kPa]
          begp                 => bounds%begp                               , &
          endp                 => bounds%endp                                 &
          )
@@ -758,7 +758,7 @@ contains
          p = filterp(f)
          c = veg_pp%column(p)
 
-         ! Initialize Monin-Obukhov length and wind speed
+         ! Initialize Obukhov length scale and wind speed
 
          call MoninObukIni(ur(p), thv(c), dthv(p), zldis(p), z0mv(p), um(p), obu(p))
          num_iter(p) = 0._r8
@@ -862,8 +862,8 @@ contains
             ! Stomatal resistances for sunlit and shaded fractions of canopy.
             ! Done each iteration to account for differences in eah, tv.
 
-            svpts(p) = el(p)                         ! pa
-            eah(p) = forc_pbot(t) * qaf(p) / 0.622_r8   ! pa
+            svpts(p) = el(p)                         ! Pa
+            eah(p) = forc_pbot(t) * qaf(p) / 0.622_r8   ! Pa
             rhaf(p) = eah(p)/svpts(p)
 
             ! variables for history fields
@@ -871,7 +871,7 @@ contains
             raw_above(p)  = raw(p,above_canopy)
             rah_below(p)  = rah(p,below_canopy)
             raw_below(p)  = raw(p,below_canopy)
-            vpd(p)        = max((svpts(p) - eah(p)), 50._r8) * 0.001_r8
+            vpd(p)        = max((svpts(p) - eah(p)), 50._r8) * 0.001_r8 ! kPa
          end do
 
          ! Modification for shrubs proposed by X.D.Z
@@ -1130,7 +1130,7 @@ contains
             taf(p) = wtg0*t_grnd(c) + wta0(p)*thm(p) + wtl0(p)*t_veg(p)
             qaf(p) = wtlq0(p)*qsatl(p) + wtgq0*qg(c) + forc_q(t)*wtaq0(p)
 
-            ! Update Monin-Obukhov length and wind speed including the
+            ! Update Obukhov length scale and wind speed including the
             ! stability effect
 
             dth(p) = thm(p)-taf(p)

--- a/components/elm/src/biogeophys/CanopyFluxesMod.F90
+++ b/components/elm/src/biogeophys/CanopyFluxesMod.F90
@@ -168,21 +168,16 @@ contains
     real(r8), parameter :: ria  = 0.5_r8             ! free parameter for stable formulation (currently = 0.5, "gamma" in Sakaguchi&Zeng,2008)
 
     real(r8) :: zldis(bounds%begp:bounds%endp)       ! reference height "minus" zero displacement height [m]
-    real(r8) :: zeta                                 ! dimensionless height used in Monin-Obukhov theory
     real(r8) :: wc                                   ! convective velocity [m/s]
     real(r8) :: ugust_total(bounds%begp:bounds%endp) ! gustiness including convective velocity [m/s]
     real(r8) :: dth(bounds%begp:bounds%endp)         ! diff of virtual temp. between ref. height and surface
     real(r8) :: dthv(bounds%begp:bounds%endp)        ! diff of vir. poten. temp. between ref. height and surface
     real(r8) :: dqh(bounds%begp:bounds%endp)         ! diff of humidity between ref. height and surface
-    real(r8) :: obu(bounds%begp:bounds%endp)         ! Monin-Obukhov length (m)
-    real(r8) :: um(bounds%begp:bounds%endp)          ! wind speed including the stablity effect [m/s]
     real(r8) :: ur(bounds%begp:bounds%endp)          ! wind speed at reference height [m/s]
-    real(r8) :: uaf(bounds%begp:bounds%endp)         ! velocity of air within foliage [m/s]
     real(r8) :: temp1(bounds%begp:bounds%endp)       ! relation for potential temperature profile
     real(r8) :: temp12m(bounds%begp:bounds%endp)     ! relation for potential temperature profile applied at 2-m
     real(r8) :: temp2(bounds%begp:bounds%endp)       ! relation for specific humidity profile
     real(r8) :: temp22m(bounds%begp:bounds%endp)     ! relation for specific humidity profile applied at 2-m
-    real(r8) :: ustar(bounds%begp:bounds%endp)       ! friction velocity [m/s]
     real(r8) :: tstar                                ! temperature scaling parameter
     real(r8) :: qstar                                ! moisture scaling parameter
     real(r8) :: thvstar                              ! virtual potential temperature scaling parameter
@@ -319,6 +314,10 @@ contains
     real(r8) :: prev_tau_diff(bounds%begp:bounds%endp) ! Previous difference in iteration tau
 
     character(len=64) :: event !! timing event
+
+    ! Indices for raw and rah
+    integer, parameter :: above_canopy = 1         ! Above canopy
+    integer, parameter :: below_canopy = 2         ! Below canopy
     !------------------------------------------------------------------------------
 
     associate(                                                               &
@@ -444,6 +443,18 @@ contains
          eflx_sh_soil         => veg_ef%eflx_sh_soil        , & ! Output: [real(r8) (:)   ]  sensible heat flux from soil (W/m**2) [+ to atm]
          eflx_sh_veg          => veg_ef%eflx_sh_veg         , & ! Output: [real(r8) (:)   ]  sensible heat flux from leaves (W/m**2) [+ to atm]
          eflx_sh_grnd         => veg_ef%eflx_sh_grnd        , & ! Output: [real(r8) (:)   ]  sensible heat flux from ground (W/m**2) [+ to atm]
+         rah_above            => frictionvel_vars%rah_above_patch , & ! Output: [real(r8) (:)   ]  above-canopy sensible heat flux resistance [s/m]
+         rah_below            => frictionvel_vars%rah_above_patch , & ! Output: [real(r8) (:)   ]  below-canopy sensible heat flux resistance [s/m]
+         raw_above            => frictionvel_vars%raw_below_patch , & ! Output: [real(r8) (:)   ]  above-canopy water vapour flux resistance [s/m]
+         raw_below            => frictionvel_vars%raw_below_patch , & ! Output: [real(r8) (:)   ]  below-canopy water vapour flux resistance [s/m]
+         ustar                => frictionvel_vars%ustar_patch     , & ! Output: [real(r8) (:)   ]  friction velocity [m/s]
+         um                   => frictionvel_vars%um_patch        , & ! Output: [real(r8) (:)   ]  wind speed including the stablity effect [m/s]
+         uaf                  => frictionvel_vars%uaf_patch       , & ! Output: [real(r8) (:)   ]  canopy air wind speed [m/s]
+         taf                  => frictionvel_vars%taf_patch       , & ! Output: [real(r8) (:)   ]  canopy air temperature [K]
+         qaf                  => frictionvel_vars%qaf_patch       , & ! Output: [real(r8) (:)   ]  canopy air specific humidity [kg/kg]
+         obu                  => frictionvel_vars%obu_patch       , & ! Output: [real(r8) (:)   ]  Obukhov length [m]
+         zeta                 => frictionvel_vars%zeta_patch      , & ! Output: [real(r8) (:)   ]  dimensionless stability parameter 
+         vpd                  => frictionvel_vars%vpd_patch       , & ! Output: [real(r8) (:)   ]  vapour pressure deficit [Pa]
          begp                 => bounds%begp                               , &
          endp                 => bounds%endp                                 &
          )
@@ -784,8 +795,8 @@ contains
 
             ! Determine aerodynamic resistances
             ram1(p)  = 1._r8/(ustar(p)*ustar(p)/um(p))
-            rah(p,1) = 1._r8/(temp1(p)*ustar(p))
-            raw(p,1) = 1._r8/(temp2(p)*ustar(p))
+            rah(p,above_canopy) = 1._r8/(temp1(p)*ustar(p))
+            raw(p,above_canopy) = 1._r8/(temp2(p)*ustar(p))
 
             ! Forbid removing more than 99% of wind speed in a time step.
             ! This is mainly to avoid convergence issues since this is such a
@@ -842,10 +853,10 @@ contains
 
             !! Sakaguchi changes for stability formulation ends here
 
-            rah(p,2) = 1._r8/(csoilcn*uaf(p))
-            raw(p,2) = rah(p,2)
+            rah(p,below_canopy) = 1._r8/(csoilcn*uaf(p))
+            raw(p,below_canopy) = rah(p,below_canopy)
             if (use_lch4) then
-               grnd_ch4_cond(p) = 1._r8/(raw(p,1)+raw(p,2))
+               grnd_ch4_cond(p) = 1._r8/(raw(p,above_canopy)+raw(p,below_canopy))
             end if
 
             ! Stomatal resistances for sunlit and shaded fractions of canopy.
@@ -854,6 +865,13 @@ contains
             svpts(p) = el(p)                         ! pa
             eah(p) = forc_pbot(t) * qaf(p) / 0.622_r8   ! pa
             rhaf(p) = eah(p)/svpts(p)
+
+            ! variables for history fields
+            rah_above(p)  = rah(p,above_canopy)
+            raw_above(p)  = raw(p,above_canopy)
+            rah_below(p)  = rah(p,below_canopy)
+            raw_below(p)  = raw(p,below_canopy)
+            vpd(p)        = max((svpts(p) - eah(p)), 50._r8) * 0.001_r8
          end do
 
          ! Modification for shrubs proposed by X.D.Z
@@ -941,9 +959,9 @@ contains
             ! Sensible heat conductance for air, leaf and ground
             ! Moved the original subroutine in-line...
 
-            wta    = 1._r8/rah(p,1)             ! air
+            wta    = 1._r8/rah(p,above_canopy)  ! air
             wtl    = (elai(p)+esai(p))/rb(p)    ! leaf
-            wtg(p) = 1._r8/rah(p,2)             ! ground
+            wtg(p) = 1._r8/rah(p,below_canopy)  ! ground
             wtshi  = 1._r8/(wta+wtl+wtg(p))
             wtl0(p) = wtl*wtshi         ! leaf
             wtg0    = wtg(p)*wtshi      ! ground
@@ -1005,7 +1023,7 @@ contains
             ! Air has same conductance for both sensible and latent heat.
             ! Moved the original subroutine in-line...
 
-            wtaq    = frac_veg_nosno(p)/raw(p,1)                        ! air
+            wtaq    = frac_veg_nosno(p)/raw(p,above_canopy)             ! air
             wtlq    = frac_veg_nosno(p)*(elai(p)+esai(p))/rb(p) * rpp   ! leaf
 
             !Litter layer resistance. Added by K.Sakaguchi
@@ -1016,10 +1034,10 @@ contains
 
             ! add litter resistance and Lee and Pielke 1992 beta
             if (delq(p) < 0._r8) then  !dew. Do not apply beta for negative flux (follow old rsoil)
-               wtgq(p) = frac_veg_nosno(p)/(raw(p,2)+rdl)
+               wtgq(p) = frac_veg_nosno(p)/(raw(p,below_canopy)+rdl)
             else
                if (do_soilevap_beta()) then
-                  wtgq(p) = soilbeta(c)*frac_veg_nosno(p)/(raw(p,2)+rdl)
+                  wtgq(p) = soilbeta(c)*frac_veg_nosno(p)/(raw(p,below_canopy)+rdl)
                endif
             end if
 
@@ -1123,13 +1141,13 @@ contains
             qstar = temp2(p)*dqh(p)
 
             thvstar = tstar*(1._r8+0.61_r8*forc_q(t)) + 0.61_r8*forc_th(t)*qstar
-            zeta = zldis(p)*vkc*grav*thvstar/(ustar(p)**2*thv(c))
+            zeta(p) = zldis(p)*vkc*grav*thvstar/(ustar(p)**2*thv(c))
 
-            if (zeta >= 0._r8) then     !stable
-               zeta = min(2._r8,max(zeta,0.01_r8))
+            if (zeta(p) >= 0._r8) then     !stable
+               zeta(p) = min(2._r8,max(zeta(p),0.01_r8))
                um(p) = max(ur(p),0.1_r8)
             else                     !unstable
-               zeta = max(-100._r8,min(zeta,-0.01_r8))
+               zeta(p) = max(-100._r8,min(zeta(p),-0.01_r8))
                if ((.not. atm_gustiness) .or. force_land_gustiness) then
                   wc = beta*(-grav*ustar(p)*thvstar*zii/thv(c))**0.333_r8
                   ugust_total(p) = sqrt(ugust(t)**2 + wc**2)
@@ -1138,7 +1156,7 @@ contains
                   um(p) = max(ur(p),0.1_r8)
                end if
             end if
-            obu(p) = zldis(p)/zeta
+            obu(p) = zldis(p)/zeta(p)
 
             if (obuold(p)*obu(p) < 0._r8) nmozsgn(p) = nmozsgn(p)+1
             if (nmozsgn(p) >= 4) obu(p) = zldis(p)/(-0.01_r8)

--- a/components/elm/src/biogeophys/FrictionVelocityMod.F90
+++ b/components/elm/src/biogeophys/FrictionVelocityMod.F90
@@ -24,7 +24,7 @@ module FrictionVelocityMod
   !
   ! !PUBLIC MEMBER FUNCTIONS:
   public :: FrictionVelocity       ! Calculate friction velocity
-  public :: MoninObukIni           ! Initialization of the Obukhov length
+  public :: MoninObukIni           ! Initialization of the Obukhov length scale
   !
   ! !PRIVATE MEMBER FUNCTIONS:
   private :: StabilityFunc1        ! Stability function for rib < 0.
@@ -62,7 +62,7 @@ contains
     real(r8) , intent(in)    :: z0m     ( lbn: )         ! roughness length over vegetation, momentum [m] [lbn:ubn]
     real(r8) , intent(in)    :: z0h     ( lbn: )         ! roughness length over vegetation, sensible heat [m] [lbn:ubn]
     real(r8) , intent(in)    :: z0q     ( lbn: )         ! roughness length over vegetation, latent heat [m] [lbn:ubn]
-    real(r8) , intent(in)    :: obu     ( lbn: )         ! Obukhov length (m) [lbn:ubn]
+    real(r8) , intent(in)    :: obu     ( lbn: )         ! Obukhov length scale (m) [lbn:ubn]
     integer  , intent(in)    :: iter                     ! iteration number
     real(r8) , intent(in)    :: ur      ( lbn: )         ! wind speed at reference height [m/s] [lbn:ubn]
     real(r8) , intent(in)    :: um      ( lbn: )         ! wind speed including the stablity effect [m/s] [lbn:ubn]
@@ -445,7 +445,7 @@ contains
   subroutine MoninObukIni (ur, thv, dthv, zldis, z0m, um, obu)
     !$acc routine seq
     ! !DESCRIPTION:
-    ! Initialization of the Obukhov length.
+    ! Initialization of the Obukhov length scale.
     ! The scheme is based on the work of Zeng et al. (1998):
     ! Intercomparison of bulk aerodynamic algorithms for the computation
     ! of sea surface fluxes using TOGA CORE and TAO data. J. Climate,
@@ -462,7 +462,7 @@ contains
     real(r8), intent(in)  :: zldis ! reference height "minus" zero displacement heght [m]
     real(r8), intent(in)  :: z0m   ! roughness length, momentum [m]
     real(r8), intent(out) :: um    ! wind speed including the stability effect [m/s]
-    real(r8), intent(out) :: obu   ! Obukhov length (m)
+    real(r8), intent(out) :: obu   ! Obukhov length scale (m)
     !
     ! !LOCAL VARIABLES:
     real(r8) :: wc    ! convective velocity [m/s]

--- a/components/elm/src/biogeophys/FrictionVelocityMod.F90
+++ b/components/elm/src/biogeophys/FrictionVelocityMod.F90
@@ -24,7 +24,7 @@ module FrictionVelocityMod
   !
   ! !PUBLIC MEMBER FUNCTIONS:
   public :: FrictionVelocity       ! Calculate friction velocity
-  public :: MoninObukIni           ! Initialization of the Monin-Obukhov length
+  public :: MoninObukIni           ! Initialization of the Obukhov length
   !
   ! !PRIVATE MEMBER FUNCTIONS:
   private :: StabilityFunc1        ! Stability function for rib < 0.
@@ -62,7 +62,7 @@ contains
     real(r8) , intent(in)    :: z0m     ( lbn: )         ! roughness length over vegetation, momentum [m] [lbn:ubn]
     real(r8) , intent(in)    :: z0h     ( lbn: )         ! roughness length over vegetation, sensible heat [m] [lbn:ubn]
     real(r8) , intent(in)    :: z0q     ( lbn: )         ! roughness length over vegetation, latent heat [m] [lbn:ubn]
-    real(r8) , intent(in)    :: obu     ( lbn: )         ! monin-obukhov length (m) [lbn:ubn]
+    real(r8) , intent(in)    :: obu     ( lbn: )         ! Obukhov length (m) [lbn:ubn]
     integer  , intent(in)    :: iter                     ! iteration number
     real(r8) , intent(in)    :: ur      ( lbn: )         ! wind speed at reference height [m/s] [lbn:ubn]
     real(r8) , intent(in)    :: um      ( lbn: )         ! wind speed including the stablity effect [m/s] [lbn:ubn]
@@ -445,7 +445,7 @@ contains
   subroutine MoninObukIni (ur, thv, dthv, zldis, z0m, um, obu)
     !$acc routine seq
     ! !DESCRIPTION:
-    ! Initialization of the Monin-Obukhov length.
+    ! Initialization of the Obukhov length.
     ! The scheme is based on the work of Zeng et al. (1998):
     ! Intercomparison of bulk aerodynamic algorithms for the computation
     ! of sea surface fluxes using TOGA CORE and TAO data. J. Climate,
@@ -462,7 +462,7 @@ contains
     real(r8), intent(in)  :: zldis ! reference height "minus" zero displacement heght [m]
     real(r8), intent(in)  :: z0m   ! roughness length, momentum [m]
     real(r8), intent(out) :: um    ! wind speed including the stability effect [m/s]
-    real(r8), intent(out) :: obu   ! monin-obukhov length (m)
+    real(r8), intent(out) :: obu   ! Obukhov length (m)
     !
     ! !LOCAL VARIABLES:
     real(r8) :: wc    ! convective velocity [m/s]

--- a/components/elm/src/biogeophys/FrictionVelocityType.F90
+++ b/components/elm/src/biogeophys/FrictionVelocityType.F90
@@ -43,6 +43,19 @@ module FrictionVelocityType
      real(r8), pointer :: z0qg_col         (:)   ! col roughness length over ground, latent heat [m]
      real(r8), pointer :: num_iter_patch   (:)   ! number of iterations performed to find a solution
                                                  ! to the land-energy flux balance in CanopyFluxes()
+     ! variables to add history output from CanopyFluxesMod
+     real(r8), pointer :: rah_above_patch  (:)   ! patch above-canopy sensible heat flux resistance [s/m]
+     real(r8), pointer :: rah_below_patch  (:)   ! patch below-canopy sensible heat flux resistance [s/m]
+     real(r8), pointer :: raw_above_patch  (:)   ! patch above-canopy water vapour flux resistance [s/m]
+     real(r8), pointer :: raw_below_patch  (:)   ! patch below-canopy water vapour flux resistance [s/m]
+     real(r8), pointer :: ustar_patch      (:)   ! patch friction velocity [m/s]
+     real(r8), pointer :: um_patch         (:)   ! patch wind speed including the stability effect [m/s]
+     real(r8), pointer :: uaf_patch        (:)   ! patch canopy air wind speed [m/s]
+     real(r8), pointer :: taf_patch        (:)   ! patch canopy air temperature [K]
+     real(r8), pointer :: qaf_patch        (:)   ! patch canopy specific humidity [kg/kg]
+     real(r8), pointer :: obu_patch        (:)   ! patch Obukhov length [m]
+     real(r8), pointer :: zeta_patch       (:)   ! patch dimensionless stability parameter
+     real(r8), pointer :: vpd_patch        (:)   ! patch vapour pressure deficit [Pa]
      
    contains
 
@@ -108,6 +121,18 @@ contains
     allocate(this%z0mg_col         (begc:endc)) ; this%z0mg_col         (:)   = spval
     allocate(this%z0qg_col         (begc:endc)) ; this%z0qg_col         (:)   = spval
     allocate(this%z0hg_col         (begc:endc)) ; this%z0hg_col         (:)   = spval
+    allocate(this%rah_above_patch  (begp:endp)) ; this%rah_above_patch  (:)   = spval
+    allocate(this%rah_below_patch  (begp:endp)) ; this%rah_below_patch  (:)   = spval
+    allocate(this%raw_above_patch  (begp:endp)) ; this%raw_above_patch  (:)   = spval
+    allocate(this%raw_below_patch  (begp:endp)) ; this%raw_below_patch  (:)   = spval
+    allocate(this%um_patch         (begp:endp)) ; this%um_patch         (:)   = spval
+    allocate(this%uaf_patch        (begp:endp)) ; this%uaf_patch        (:)   = spval
+    allocate(this%taf_patch        (begp:endp)) ; this%taf_patch        (:)   = spval
+    allocate(this%qaf_patch        (begp:endp)) ; this%qaf_patch        (:)   = spval
+    allocate(this%ustar_patch      (begp:endp)) ; this%ustar_patch      (:)   = spval
+    allocate(this%obu_patch        (begp:endp)) ; this%obu_patch        (:)   = spval
+    allocate(this%zeta_patch       (begp:endp)) ; this%zeta_patch       (:)   = spval
+    allocate(this%vpd_patch        (begp:endp)) ; this%vpd_patch        (:)   = spval
 
   end subroutine InitAllocate
   !-----------------------------------------------------------------------
@@ -177,11 +202,12 @@ contains
             ptr_patch=this%ram1_patch, default='inactive')
     end if
 
-    ! Removed use_cn because friction velocity can be useful for other configurations
-    this%fv_patch(begp:endp) = spval
-    call hist_addfld1d (fname='FV', units='m/s', &
-         avgflag='A', long_name='friction velocity', &
-         ptr_patch=this%fv_patch, default='inactive')
+    if (use_cn) then
+       this%fv_patch(begp:endp) = spval
+       call hist_addfld1d (fname='FV', units='m/s', &
+            avgflag='A', long_name='friction velocity for dust model', &
+            ptr_patch=this%fv_patch, default='inactive')
+    end if
 
     if (use_cn) then
        this%z0hv_patch(begp:endp) = spval
@@ -215,7 +241,67 @@ contains
     call hist_addfld1d(fname='ITER_LND_EBAL_AVG', units='count', &
          avgflag='A', long_name='average number of iterations performed in land-energy balance', &
          ptr_patch=this%num_iter_patch, default = 'inactive')
-    
+
+    this%rah_above_patch(begp:endp) = spval
+    call hist_addfld1d (fname='RAH_ABOVE', units='s/m', &
+         avgflag='A', long_name='above-canopy aerodynamical resistance for sensible heat flux', &
+         ptr_patch=this%rah_above_patch, default='inactive')
+
+    this%rah_below_patch(begp:endp) = spval
+    call hist_addfld1d (fname='RAH_BELOW', units='s/m', &
+         avgflag='A', long_name='below-canopy aerodynamical resistance for sensible heat flux', &
+         ptr_patch=this%rah_below_patch, default='inactive')
+
+    this%raw_above_patch(begp:endp) = spval
+    call hist_addfld1d (fname='RAW_ABOVE', units='s/m', &
+         avgflag='A', long_name='above-canopy aerodynamical resistance for water vapour flux', &
+         ptr_patch=this%raw_above_patch, default='inactive')
+
+    this%raw_below_patch(begp:endp) = spval
+    call hist_addfld1d (fname='RAW_BELOW', units='s/m', &
+         avgflag='A', long_name='below-canopy aerodynamical resistance for water vapour flux', &
+         ptr_patch=this%raw_below_patch, default='inactive')
+
+    this%ustar_patch(begp:endp) = spval
+    call hist_addfld1d (fname='USTAR', units='m/s', &
+         avgflag='A', long_name='friction velocity', &
+         ptr_patch=this%ustar_patch, default='inactive')
+
+    this%um_patch(begp:endp) = spval
+    call hist_addfld1d (fname='UM', units='m/s', &
+         avgflag='A', long_name='wind speed including the stability effect', &
+         ptr_patch=this%um_patch, default='inactive')
+
+    this%uaf_patch(begp:endp) = spval
+    call hist_addfld1d (fname='UAF', units='m/s', &
+         avgflag='A', long_name='canopy air wind speed ', &
+         ptr_patch=this%uaf_patch, default='inactive')
+
+    this%taf_patch(begp:endp) = spval
+    call hist_addfld1d (fname='TAF', units='K', &
+         avgflag='A', long_name='canopy air temperature', &
+         ptr_patch=this%taf_patch, default='inactive')
+
+    this%qaf_patch(begp:endp) = spval
+    call hist_addfld1d (fname='QAF', units='kg/kg', &
+         avgflag='A', long_name='canopy air specific humidity', &
+         ptr_patch=this%qaf_patch, default='inactive')
+
+    this%obu_patch(begp:endp) = spval
+    call hist_addfld1d (fname='OBU', units='m', &
+         avgflag='A', long_name='Obukhov length', &
+         ptr_patch=this%obu_patch, default='inactive')
+
+    this%zeta_patch(begp:endp) = spval
+    call hist_addfld1d (fname='ZETA', units='unitless', &
+         avgflag='A', long_name='dimensionless stability parameter', &
+         ptr_patch=this%zeta_patch, default='inactive')
+
+    this%vpd_patch(begp:endp) = spval
+    call hist_addfld1d (fname='VPD', units='Pa', &
+         avgflag='A', long_name='vapour pressure deficit', &
+         ptr_patch=this%vpd_patch, default='inactive')
+
   end subroutine InitHistory
 
   !-----------------------------------------------------------------------

--- a/components/elm/src/biogeophys/FrictionVelocityType.F90
+++ b/components/elm/src/biogeophys/FrictionVelocityType.F90
@@ -53,9 +53,9 @@ module FrictionVelocityType
      real(r8), pointer :: uaf_patch        (:)   ! patch canopy air wind speed [m/s]
      real(r8), pointer :: taf_patch        (:)   ! patch canopy air temperature [K]
      real(r8), pointer :: qaf_patch        (:)   ! patch canopy specific humidity [kg/kg]
-     real(r8), pointer :: obu_patch        (:)   ! patch Obukhov length [m]
+     real(r8), pointer :: obu_patch        (:)   ! patch Obukhov length scale [m]
      real(r8), pointer :: zeta_patch       (:)   ! patch dimensionless stability parameter
-     real(r8), pointer :: vpd_patch        (:)   ! patch vapour pressure deficit [Pa]
+     real(r8), pointer :: vpd_patch        (:)   ! patch vapour pressure deficit [kPa]
      
    contains
 
@@ -289,7 +289,7 @@ contains
 
     this%obu_patch(begp:endp) = spval
     call hist_addfld1d (fname='OBU', units='m', &
-         avgflag='A', long_name='Obukhov length', &
+         avgflag='A', long_name='Obukhov length scale', &
          ptr_patch=this%obu_patch, default='inactive')
 
     this%zeta_patch(begp:endp) = spval
@@ -298,7 +298,7 @@ contains
          ptr_patch=this%zeta_patch, default='inactive')
 
     this%vpd_patch(begp:endp) = spval
-    call hist_addfld1d (fname='VPD', units='Pa', &
+    call hist_addfld1d (fname='VPD', units='kPa', &
          avgflag='A', long_name='vapour pressure deficit', &
          ptr_patch=this%vpd_patch, default='inactive')
 

--- a/components/elm/src/biogeophys/FrictionVelocityType.F90
+++ b/components/elm/src/biogeophys/FrictionVelocityType.F90
@@ -177,12 +177,11 @@ contains
             ptr_patch=this%ram1_patch, default='inactive')
     end if
 
-    if (use_cn) then
-       this%fv_patch(begp:endp) = spval
-       call hist_addfld1d (fname='FV', units='m/s', &
-            avgflag='A', long_name='friction velocity for dust model', &
-            ptr_patch=this%fv_patch, default='inactive')
-    end if
+    ! Removed use_cn because friction velocity can be useful for other configurations
+    this%fv_patch(begp:endp) = spval
+    call hist_addfld1d (fname='FV', units='m/s', &
+         avgflag='A', long_name='friction velocity', &
+         ptr_patch=this%fv_patch, default='inactive')
 
     if (use_cn) then
        this%z0hv_patch(begp:endp) = spval

--- a/components/elm/src/biogeophys/LakeFluxesMod.F90
+++ b/components/elm/src/biogeophys/LakeFluxesMod.F90
@@ -100,8 +100,8 @@ contains
     real(r8) :: dzsur(bounds%begc:bounds%endc)     ! 1/2 the top layer thickness (m)
     real(r8) :: eg                                 ! water vapor pressure at temperature T [pa]
     real(r8) :: htvp(bounds%begc:bounds%endc)      ! latent heat of vapor of water (or sublimation) [j/kg]
-    real(r8) :: obu(bounds%begp:bounds%endp)       ! monin-obukhov length (m)
-    real(r8) :: obuold(bounds%begp:bounds%endp)    ! monin-obukhov length of previous iteration
+    real(r8) :: obu(bounds%begp:bounds%endp)       ! Obukhov length scale (m)
+    real(r8) :: obuold(bounds%begp:bounds%endp)    ! Obukhov length scale of previous iteration
     real(r8) :: qsatg(bounds%begc:bounds%endc)     ! saturated humidity [kg/kg]
     real(r8) :: qsatgdT(bounds%begc:bounds%endc)   ! d(qsatg)/dT
     real(r8) :: qstar                              ! moisture scaling parameter
@@ -370,7 +370,7 @@ contains
          dthv     = dth(p)*(1._r8+0.61_r8*forc_q(t))+0.61_r8*forc_th(t)*dqh(p)
          zldis(p) = forc_hgt_u_patch(p) - 0._r8
 
-         ! Initialize Monin-Obukhov length and wind speed
+         ! Initialize Obukhov length scale and wind speed
 
          call MoninObukIni(ur(p), thv(c), dthv, zldis(p), z0mg(p), um(p), obu(p))
       end do

--- a/components/elm/src/biogeophys/UrbanFluxesMod.F90
+++ b/components/elm/src/biogeophys/UrbanFluxesMod.F90
@@ -118,7 +118,7 @@ contains
     real(r8) :: dqh(bounds%begl:bounds%endl)                         ! diff of humidity between ref. height and surface
     real(r8) :: zldis(bounds%begl:bounds%endl)                       ! reference height "minus" zero displacement height (m)
     real(r8) :: um(bounds%begl:bounds%endl)                          ! wind speed including the stablity effect (m/s)
-    real(r8) :: obu(bounds%begl:bounds%endl)                         ! Monin-Obukhov length (m)
+    real(r8) :: obu(bounds%begl:bounds%endl)                         ! Obukhov length scale (m)
     real(r8) :: taf_numer(bounds%begl:bounds%endl)                   ! numerator of taf equation (K m/s)
     real(r8) :: taf_denom(bounds%begl:bounds%endl)                   ! denominator of taf equation (m/s)
     real(r8) :: qaf_numer(bounds%begl:bounds%endl)                   ! numerator of qaf equation (kg m/kg s)
@@ -365,7 +365,7 @@ contains
          dthv     = dth(l)*(1._r8+0.61_r8*forc_q(t))+0.61_r8*forc_th(t)*dqh(l)
          zldis(l) = forc_hgt_u_patch(lun_pp%pfti(l)) - z_d_town(l)
 
-         ! Initialize Monin-Obukhov length and wind speed including convective velocity
+         ! Initialize Obukhov length scale and wind speed including convective velocity
 
          call MoninObukIni(ur(l), thv_g(l), dthv, zldis(l), z_0_town(l), um(l), obu(l))
 

--- a/components/elm/src/main/elm_varcon.F90
+++ b/components/elm/src/main/elm_varcon.F90
@@ -72,6 +72,10 @@ module elm_varcon
   real(r8) :: tlsai_crit = 2.0_r8                           ! critical value of elai+esai for which aerodynamic parameters are maximum
   real(r8) :: watmin = 0.01_r8                              ! minimum soil moisture (mm)
 
+  real(r8), parameter :: mm_epsilon = 0.622_r8              ! Molar mass ratio (water:dry air)
+                                                            !   This is set to 0.622 for bit-for-bit compatibility, but
+                                                            !   this should be defined as SHR_CONST_MWWV/SHR_CONST_MWDAIR
+
   real(r8) :: re = SHR_CONST_REARTH*0.001_r8                ! radius of earth (km)
 
   real(r8), public, parameter :: degpsec = 15._r8/3600.0_r8 ! Degree's earth rotates per second
@@ -80,6 +84,13 @@ module elm_varcon
   real(r8), public, parameter ::  spval = 1.e36_r8          ! special value for real data
   integer , public, parameter :: ispval = -9999             ! special value for int data 
                                                             ! (keep this negative to avoid conflicts with possible valid values)
+
+
+  !------------------------------------------------------------------
+  ! Unit conversion constants
+  !------------------------------------------------------------------
+
+  real(r8), parameter :: pa_to_kpa = 0.001_r8               ! Conversion factor (Pa to kPa) [kPa/Pa]
 
   ! These are tunable constants from clm2_3
 


### PR DESCRIPTION
This pull request expands the list of variables in the ELM output, and most changes were taken from CLM5.
 This adds aerodynamic resistances, friction velocity, and canopy air properties to the ELM output (temperature, humidity, wind speed) to the history file.
 These are helpful for assessing the model representation of turbulent fluxes. All new variables are set as "inactive" by default.

The pull request has two very minor additional edits:
1. Also borrowed from CLM5, this replaces the indices 1 and 2 for the resistances with local variables `"above_canopy"` and `"below_canopy"`. This change is simply to improve code readability.
2. Revised the comments and variable output names for variable `obu`. I simply replaced "Monin-Obukhov length" with "Obukhov length", which is the correct name of the variable according to the [American Meteorological Society](https://glossary.ametsoc.org/wiki/Obukhov_length).

[BFB]