### PR TITLE
EAMxx: fix check on whether to run cosp or not

### DIFF
--- a/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
+++ b/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
@@ -138,7 +138,7 @@ void Cosp::run_impl (const double dt)
   // Make sure cosp frequency is multiple of rad frequency?
 
   // Compare frequency in steps with current timestep
-  auto update_cosp = cosp_do(cosp_freq_in_steps, end_of_step_ts().get_num_steps());
+  auto update_cosp = cosp_do(cosp_freq_in_steps, start_of_step_ts().get_num_steps());
 
   // Call COSP wrapper routines
   if (update_cosp) {


### PR DESCRIPTION
This was erroneously changed in 80959a0.

Fixes #7258 

[non-BFB] only for eamxx+COSP cases
---
