### PR TITLE
EAMxx: ensure iop process name matches what's used to register in the atm proc factory

### DIFF
--- a/components/eamxx/src/physics/iop_forcing/eamxx_iop_forcing_process_interface.hpp
+++ b/components/eamxx/src/physics/iop_forcing/eamxx_iop_forcing_process_interface.hpp
@@ -61,7 +61,7 @@ public:
   AtmosphereProcessType type () const { return AtmosphereProcessType::Physics; }
 
   // The name of the subcomponent
-  std::string name () const { return "iop"; }
+  std::string name () const { return "iop_forcing"; }
 
   // Set the grid
   void set_grids (const std::shared_ptr<const GridsManager> grids_manager);


### PR DESCRIPTION
This avoids issues when requesting outputs that have the iop process name in it (see linked issue).

Fixes #7330 

---