### PR TITLE
Adding option to add extra args to the ADIOS to NetCDF conversion tool

### DIFF
--- a/cime_config/customize/case_post_run_io.py
+++ b/cime_config/customize/case_post_run_io.py
@@ -35,6 +35,10 @@ def _convert_adios_to_nc(case):
     adios_conv_tool_args = "--idir=" + rundir
     adios_conv_tool_cmd = adios_conv_tool_exe + " " + adios_conv_tool_args
 
+    adios_conv_tool_extra_args = os.environ.get('SPIO_ADIOSBP2NC_CONVERSION_TOOL_EXTRA_ARGS', '')
+    if adios_conv_tool_extra_args.strip():
+      adios_conv_tool_cmd += " " + adios_conv_tool_extra_args.strip()
+
     # Replace logfile name, "e3sm.log.*" with "e3sm_adios_post_io.log.*"
     # The logfile name is part of the run command suffix
     adios_conv_tool_cmd_suffix = env_mach_specific.get_value("run_misc_suffix")

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2034,6 +2034,7 @@
     </environment_variables>
     <!--environment_variables>
       <env name="SPIO_ENABLE_ADIOSBP2NC_CONVERSION">1</env>
+      <env name="SPIO_ADIOSBP2NC_CONVERSION_TOOL_EXTRA_ARGS">\-\-rm-bp-file-after-conv="(.*)(.eam.)(.*)"</env>
     </environment_variables-->
   </machine>
 


### PR DESCRIPTION
Users can now add extra command line arguments to the
conversion tool via an environment variable,
SPIO_ADIOSBP2NC_CONVERSION_TOOL_EXTRA_ARGS

[BFB]