### PR TITLE
Update cube_to_target Makefile for more flexible FC settings

### DIFF
--- a/components/eam/tools/topo_tool/cube_to_target/Makefile
+++ b/components/eam/tools/topo_tool/cube_to_target/Makefile
@@ -6,7 +6,9 @@ RM = rm
 .SUFFIXES: .F90 .o
 
 # Set the compiler
-FC := gfortran
+ifeq ($(FC),$(null))
+    FC = gfortran
+endif
 
 # Set NetCDF library and include directories
 LIB_NETCDF := $(shell nf-config --prefix)/lib


### PR DESCRIPTION
As part of the v3.RRM development, an error as follows occur on chrysalis 
when building with the hard-coded gfortran in the Makefile. This appears 
to be due to too low chrysalis gfortran version.

`gfortran: error: unrecognized command line option ‘-fallow-argument-mismatch’; 
did you mean ‘-Wno-argument-mismatch’?`

This PR will allow users to specify other compilers if needed and won't change 
existing `gfortran` as the default compiler. On chrysalis, `export FC=ifort` built 
cube_to_target and created the topography file successfully.

A side benefit is that the executable runs much faster when built with `ifort` than 
with `gfortran`.

[BFB]

---------------------------------------
There may be better solutions. Suggestions are welcome.
