### PR TITLE
Port eamxx standalone to lychee

### DIFF
--- a/components/eamxx/cmake/machine-files/lychee.cmake
+++ b/components/eamxx/cmake/machine-files/lychee.cmake
@@ -1,0 +1,13 @@
+include(${CMAKE_CURRENT_LIST_DIR}/common.cmake)
+common_setup()
+
+set(SCREAM_INPUT_ROOT "/home/projects/e3sm/eamxx/data" CACHE STRING "")
+
+set(CMAKE_Fortran_FLAGS "-fallow-argument-mismatch"  CACHE STRING "" FORCE)
+
+# Things take forever to build without this
+set(SCREAM_SMALL_KERNELS On CACHE BOOL "" FORCE)
+
+# Load H100/HOPPER arch and cuda backend for kokkos
+include (${EKAT_MACH_FILES_PATH}/kokkos/nvidia-h100.cmake)
+include (${EKAT_MACH_FILES_PATH}/kokkos/cuda.cmake)

--- a/components/eamxx/scripts/machines_specs.py
+++ b/components/eamxx/scripts/machines_specs.py
@@ -230,6 +230,25 @@ class Weaver(Machine):
         cls.gpu_arch = "cuda"
 
 ###############################################################################
+class Lychee(Machine):
+###############################################################################
+    concrete = True
+    @classmethod
+    def setup(cls):
+        super().setup_base("lychee")
+
+        cls.env_setup = ["source /projects/sems/install/rhel9-x86_64/sems/lmod/lmod/8.7.24/gcc/11.4.1/base/lnirq74/lmod/lmod/init/sh",
+                         "module purge",
+                         "module load sems-gcc/12.3.0 sems-cuda/12.6.2 sems-cmake/3.30.5 sems-openmpi/4.1.6 sems-netlib-lapack/3.11.0 sems-netcdf-c/4.9.2 sems-netcdf-fortran/4.6.1 sems-parallel-netcdf/1.12.3",
+                         "export HDF5_USE_FILE_LOCKING=FALSE"
+                         ]
+        cls.baselines_dir = "/home/projects/e3sm/eamxx/baselines"
+        #cls.batch = "bsub -I -q rhel8 -n 4 -gpu num=4"
+
+        cls.num_run_res = 4 # four gpus
+        cls.gpu_arch = "cuda"
+
+###############################################################################
 class Compy(Machine):
 ###############################################################################
     concrete = True

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -315,7 +315,7 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
     Kokkos::deep_copy(cldfrac_liq,0.0);
   }
 
-  shoc_preprocess.set_variables(m_num_cols,m_num_levs,m_num_tracers,z_surf,
+  shoc_preprocess.set_variables(m_num_cols,m_num_levs,z_surf,
                                 T_mid,p_mid,p_int,pseudo_density,omega,phis,surf_sens_flux,surf_evap,
                                 surf_mom_flux,qtracers,qv,qc,qc_copy,tke,tke_copy,z_mid,z_int,
                                 dse,rrho,rrho_i,thv,dz,zt_grid,zi_grid,wpthlp_sfc,wprtp_sfc,upwp_sfc,vpwp_sfc,
@@ -392,7 +392,7 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   temporaries.dz_zi = m_buffer.dz_zi;
 #endif
 
-  shoc_postprocess.set_variables(m_num_cols,m_num_levs,m_num_tracers,
+  shoc_postprocess.set_variables(m_num_cols,m_num_levs,
                                  rrho,qv,qw,qc,qc_copy,tke,tke_copy,qtracers,shoc_ql2,
                                  cldfrac_liq,inv_qc_relvar,
                                  T_mid, dse, z_mid, phis);

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -484,6 +484,9 @@ void SHOCMacrophysics::run_impl (const double dt)
                        shoc_preprocess);
   Kokkos::fence();
 
+  auto wtracer_sfc = shoc_preprocess.wtracer_sfc;
+  Kokkos::deep_copy(wtracer_sfc, 0);
+
   if (m_params.get<bool>("apply_tms", false)) {
     apply_turbulent_mountain_stress();
   }

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.hpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.hpp
@@ -161,7 +161,7 @@ public:
     } // operator
 
     // Local variables
-    int ncol, nlev, num_qtracers;
+    int ncol, nlev;
     Real z_surf;
     view_2d_const  T_mid;
     view_2d_const  p_mid;
@@ -201,7 +201,7 @@ public:
     view_2d        cldfrac_liq_prev;
 
     // Assigning local variables
-    void set_variables(const int ncol_, const int nlev_, const int num_qtracers_,
+    void set_variables(const int ncol_, const int nlev_,
                        const Real z_surf_,
                        const view_2d_const& T_mid_, const view_2d_const& p_mid_, const view_2d_const& p_int_, const view_2d_const& pseudo_density_,
                        const view_2d_const& omega_,
@@ -219,7 +219,6 @@ public:
     {
       ncol = ncol_;
       nlev = nlev_;
-      num_qtracers = num_qtracers_;
       z_surf = z_surf_;
       // IN
       T_mid = T_mid_;
@@ -315,7 +314,7 @@ public:
     } // operator
 
     // Local variables
-    int ncol, nlev, num_qtracers;
+    int ncol, nlev;
     view_2d_const rrho;
     view_2d qv, qc, tke;
     view_2d_const tke_copy, qc_copy, qw;
@@ -335,7 +334,7 @@ public:
     view_1d heat_flux;
 
     // Assigning local variables
-    void set_variables(const int ncol_, const int nlev_, const int num_qtracers_,
+    void set_variables(const int ncol_, const int nlev_,
                        const view_2d_const& rrho_,
                        const view_2d& qv_, const view_2d_const& qw_, const view_2d& qc_, const view_2d_const& qc_copy_,
                        const view_2d& tke_, const view_2d_const& tke_copy_, const view_3d_strided& qtracers_, const view_2d_const& qc2_,
@@ -344,7 +343,6 @@ public:
     {
       ncol = ncol_;
       nlev = nlev_;
-      num_qtracers = num_qtracers_;
       rrho = rrho_;
       qv = qv_;
       qw = qw_;

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.hpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.hpp
@@ -158,11 +158,6 @@ public:
       wprtp_sfc(i)  = surf_evap(i)/rrho_i(i,nlevi_v)[nlevi_p];
       upwp_sfc(i) = surf_mom_flux(i,0)/rrho_i(i,nlevi_v)[nlevi_p];
       vpwp_sfc(i) = surf_mom_flux(i,1)/rrho_i(i,nlevi_v)[nlevi_p];
-
-      const int num_qtracer_packs = ekat::npack<Spack>(num_qtracers);
-      Kokkos::parallel_for(Kokkos::TeamVectorRange(team, num_qtracer_packs), [&] (const Int& q) {
-        wtracer_sfc(i,q) = 0;
-      });
     } // operator
 
     // Local variables


### PR DESCRIPTION
I was getting memory errors in SHOC at first. I think the issue is that the last kernel in `SHOCPreprocess::operator()` is not over nlev_packs, so I replaced it with a deep copy since it was just setting things to zero.