### PR TITLE
EAMX: SYCL compiles MAM for Aurora

### DIFF
--- a/components/eamxx/CMakeLists.txt
+++ b/components/eamxx/CMakeLists.txt
@@ -205,12 +205,7 @@ set(NetCDF_Fortran_PATH ${DEFAULT_NetCDF_Fortran_PATH} CACHE FILEPATH "Path to n
 set(NetCDF_C_PATH ${DEFAULT_NetCDF_C_PATH} CACHE FILEPATH "Path to netcdf C installation")
 set(SCREAM_MACHINE ${DEFAULT_SCREAM_MACHINE} CACHE STRING "The CIME/SCREAM name for the current machine")
 option(SCREAM_MPI_ON_DEVICE "Whether to use device pointers for MPI calls" ON)
-
-if (Kokkos_ENABLE_SYCL)
-  option(SCREAM_ENABLE_MAM "Whether to enable MAM aerosol support" OFF)
-else()
-  option(SCREAM_ENABLE_MAM "Whether to enable MAM aerosol support" ON)
-endif()
+option(SCREAM_ENABLE_MAM "Whether to enable MAM aerosol support" ON)
 
 set(SCREAM_SMALL_KERNELS ${DEFAULT_SMALL_KERNELS} CACHE STRING "Use small, non-monolothic kokkos kernels for ALL components that support them")
 set(SCREAM_P3_SMALL_KERNELS ${SCREAM_SMALL_KERNELS} CACHE STRING "Use small, non-monolothic kokkos kernels for P3 only")


### PR DESCRIPTION
Removes logic to disable MAM4xx for SYCL builds.

[BFB]


