### PR TITLE
EAMxx: fix horiz remap bug in case of "sparse" output locations

### DIFF
--- a/components/eamxx/src/diagnostics/tests/precip_surf_mass_flux_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/precip_surf_mass_flux_tests.cpp
@@ -48,7 +48,7 @@ void run(std::mt19937_64& engine)
   auto gm = create_gm(comm,ncols);
 
   // Create timestep
-  const int dt=1800;
+  const double dt=1800;
 
   // Construct random input data
   using RPDF = std::uniform_real_distribution<Real>;
@@ -120,28 +120,29 @@ void run(std::mt19937_64& engine)
   diag_liq->compute_diagnostic();
   diag_ice->compute_diagnostic();
 
-  Field preicp_total_f = diag_total->get_diagnostic().clone();
-  Field preicp_liq_f   = diag_liq->get_diagnostic().clone();
-  Field preicp_ice_f   = diag_ice->get_diagnostic().clone();
-  preicp_total_f.deep_copy(0);
-  preicp_liq_f.deep_copy(0);
-  preicp_ice_f.deep_copy(0);
-  auto precip_total_v = preicp_total_f.get_view<Real*>();
-  auto precip_liq_v   = preicp_liq_f.get_view<Real*>();
-  auto precip_ice_v   = preicp_ice_f.get_view<Real*>();
+  Field precip_total_f = diag_total->get_diagnostic().clone();
+  Field precip_liq_f   = diag_liq->get_diagnostic().clone();
+  Field precip_ice_f   = diag_ice->get_diagnostic().clone();
+  precip_total_f.deep_copy(0);
+  precip_liq_f.deep_copy(0);
+  precip_ice_f.deep_copy(0);
+  auto precip_total_v = precip_total_f.get_view<Real*>();
+  auto precip_liq_v   = precip_liq_f.get_view<Real*>();
+  auto precip_ice_v   = precip_ice_f.get_view<Real*>();
   const auto rhodt = PC::RHO_H2O*dt;
   Kokkos::parallel_for("precip_total_surf_mass_flux_test",
                        typename KT::RangePolicy(0,ncols),
                        KOKKOS_LAMBDA(const int& icol) {
     precip_liq_v(icol)   = precip_liq_surf_mass_v(icol)/rhodt;
     precip_ice_v(icol)   = precip_ice_surf_mass_v(icol)/rhodt;
-    precip_total_v(icol) = precip_liq_v(icol) + precip_ice_v(icol);
+    precip_total_v(icol) = precip_ice_v(icol);
+    precip_total_v(icol) += precip_liq_surf_mass_v(icol)/rhodt;
   });
   Kokkos::fence();
 
-  REQUIRE(views_are_equal(diag_total->get_diagnostic(),preicp_total_f));
-  REQUIRE(views_are_equal(diag_liq->get_diagnostic(),preicp_liq_f));
-  REQUIRE(views_are_equal(diag_ice->get_diagnostic(),preicp_ice_f));
+  REQUIRE(views_are_equal(diag_total->get_diagnostic(),precip_total_f));
+  REQUIRE(views_are_equal(diag_liq->get_diagnostic(),precip_liq_f));
+  REQUIRE(views_are_equal(diag_ice->get_diagnostic(),precip_ice_f));
 
   // Finalize the diagnostic
   diag_total->finalize();

--- a/components/eamxx/src/diagnostics/tests/vertical_layer_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/vertical_layer_tests.cpp
@@ -134,10 +134,10 @@ void run (const std::string& diag_name, const std::string& location)
         // If interface, check value, otherwise perform int->mid averaging and check value
         auto int_val = prev_int_val + delta;
         if (location=="interfaces") {
-          REQUIRE_THAT(d_h(icol,ilev), Catch::Matchers::WithinRel(int_val,1e-5));
+          REQUIRE_THAT(d_h(icol,ilev), Catch::Matchers::WithinRel(int_val,Real(1e-5)));
         } else {
           auto mid_val = (int_val + prev_int_val) / 2;
-          REQUIRE_THAT(d_h(icol,ilev), Catch::Matchers::WithinRel(mid_val,1e-5));
+          REQUIRE_THAT(d_h(icol,ilev), Catch::Matchers::WithinRel(mid_val,Real(1e-5)));
         }
         prev_int_val = int_val;
       }

--- a/components/eamxx/src/dynamics/homme/interface/dyn_grid_mod.F90
+++ b/components/eamxx/src/dynamics/homme/interface/dyn_grid_mod.F90
@@ -4,12 +4,10 @@ module dyn_grid_mod
   use shr_kind_mod,       only: r8 => shr_kind_r8
   use dimensions_mod,     only: nelem, nelemd, nelemdmax, np
   use edgetype_mod,       only: EdgeBuffer_t
+  use mpi
 
   implicit none
   private
-
-! We need MPI in here, so include it
-#include <mpif.h>
 
   public :: dyn_grid_init, get_my_dyn_data, cleanup_grid_init_data
 

--- a/components/eamxx/src/dynamics/homme/interface/phys_grid_mod.F90
+++ b/components/eamxx/src/dynamics/homme/interface/phys_grid_mod.F90
@@ -3,6 +3,7 @@ module phys_grid_mod
   use iso_c_binding, only: c_int, c_double
   use parallel_mod,  only: abortmp, MPIinteger_t, MPIreal_t
   use kinds,         only: iulog
+  use mpi
 
   implicit none
   private
@@ -55,8 +56,6 @@ module phys_grid_mod
 
   type(pg_specs_t), target :: pg_specs (pgN_min:pgN_max)
 
-! To get MPI_IN_PLACE and MPI_DATATYPE_NULL
-#include <mpif.h>
   ! Note: in this module, we often use MPI_IN_PLACE,0,MPI_DATATYPE_NULL
   !       for the src array specs in Allgatherv calls. These special values 
   !       inform MPI that src array is aliasing the dst one, so MPI will

--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_data.cpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_data.cpp
@@ -98,13 +98,9 @@ get_my_triplets (const std::string& map_file) const
   }
 
   // Create a grid based on the row gids I read in (may be duplicated across ranks)
-  std::vector<gid_type> unique_gids;
   const auto& gids = type==InterpType::Refine ? rows : cols;
-  for (auto gid : gids) {
-    if (not ekat::contains(unique_gids,gid)) {
-      unique_gids.push_back(gid);
-    }
-  }
+  std::set<gid_type> temp (gids.begin(),gids.end());
+  std::vector<gid_type> unique_gids (temp.begin(),temp.end());
   auto io_grid = std::make_shared<PointGrid> ("helper",unique_gids.size(),0,comm);
   auto io_grid_gids_h = io_grid->get_dofs_gids().get_view<gid_type*,Host>();
   int k = 0;

--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_data.cpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_data.cpp
@@ -88,31 +88,13 @@ get_my_triplets (const std::string& map_file) const
 
   scorpio::release_file(map_file);
 
-  // 1.2 Dofs in grid are likely 0-based, while row/col ids in map file
-  // are likely 1-based. To match dofs, we need to offset the row/cols
-  // ids we just read in.
-  int map_file_min_row = std::numeric_limits<int>::max();
-  int map_file_min_col = std::numeric_limits<int>::max();
-  for (int id=0; id<nlweights; id++) {
-    map_file_min_row = std::min(rows[id],map_file_min_row);
-    map_file_min_col = std::min(cols[id],map_file_min_col);
-  }
-  int global_map_file_min_row, global_map_file_min_col;
-  comm.all_reduce(&map_file_min_row,&global_map_file_min_row,1,MPI_MIN);
-  comm.all_reduce(&map_file_min_col,&global_map_file_min_col,1,MPI_MIN);
-
-  gid_type row_offset = global_map_file_min_row;
-  gid_type col_offset = global_map_file_min_col;
-  if (type==InterpType::Refine) {
-    row_offset -= fine_grid->get_global_min_dof_gid();
-  } else {
-    col_offset -= fine_grid->get_global_min_dof_gid();
-  }
+  // 1.2 Dofs in grid are 0-based, while row/col ids in map file are 1-based.
+  // To match dofs, we need to offset the row/cols ids we just read in.
   for (auto& id : rows) {
-    id -= row_offset;
+    id -= 1;
   }
   for (auto& id : cols) {
-    id -= col_offset;
+    id -= 1;
   }
 
   // Create a grid based on the row gids I read in (may be duplicated across ranks)

--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_data.cpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_data.cpp
@@ -88,15 +88,6 @@ get_my_triplets (const std::string& map_file) const
 
   scorpio::release_file(map_file);
 
-  // 1.2 Dofs in grid are 0-based, while row/col ids in map file are 1-based.
-  // To match dofs, we need to offset the row/cols ids we just read in.
-  for (auto& id : rows) {
-    id -= 1;
-  }
-  for (auto& id : cols) {
-    id -= 1;
-  }
-
   // Create a grid based on the row gids I read in (may be duplicated across ranks)
   const auto& gids = type==InterpType::Refine ? rows : cols;
   std::set<gid_type> temp (gids.begin(),gids.end());

--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_data.cpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_data.cpp
@@ -128,10 +128,18 @@ get_my_triplets (const std::string& map_file) const
   MPI_Type_create_struct (3,lengths,displacements,types,&mpi_triplet_t);
   MPI_Type_commit(&mpi_triplet_t);
 
-  // Create import-export
-  GridImportExport imp_exp (fine_grid,io_grid);
+  // Create import-export and gather my triplets
   std::map<int,std::vector<Triplet>> my_triplets_map;
-  imp_exp.gather(mpi_triplet_t,io_triplets,my_triplets_map);
+  try {
+    GridImportExport imp_exp (fine_grid,io_grid);
+    imp_exp.gather(mpi_triplet_t,io_triplets,my_triplets_map);
+  } catch (...) {
+    // Print the map file name, to help debugging
+    std::cout << "[HorizRemapperData] Something went wrong while performing a grid import-export operation.\n"
+              << " - map file name : " << map_file << "\n"
+              << " - fine grid name: " << fine_grid->name() << "\n";
+    throw;
+  }
   MPI_Type_free(&mpi_triplet_t);
 
   std::vector<Triplet> my_triplets;

--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_data.hpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_data.hpp
@@ -17,13 +17,16 @@ enum class InterpType {
   Coarsen
 };
 
-// A small struct to hold horiz remap data, which can
-// be shared across multiple horiz remappers
+// A small struct to hold horiz remap data, which can be shared across multiple horiz remappers
+// NOTE: the client will call the build method, which will read the map file, and create the
+//       CRS matrix data for online interpolation.
 struct HorizRemapperData {
   using KT = KokkosTypes<DefaultDevice>;
   template<typename T>
   using view_1d = typename KT::template view_1d<T>;
 
+  // The last argument specifies the base index for gids in the map file
+  // For ncremap-type files, all indices are 1-based
   void build (const std::string& map_file,
               const std::shared_ptr<const AbstractGrid>& fine_grid,
               const ekat::Comm& comm,

--- a/components/eamxx/src/share/io/tests/CMakeLists.txt
+++ b/components/eamxx/src/share/io/tests/CMakeLists.txt
@@ -88,6 +88,12 @@ CreateUnitTest(io_remap_test "io_remap_test.cpp"
   MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
 )
 
+## Test remap output when map file is sub-sampling (ARM-style)
+CreateUnitTest(io_horiz_sampling "io_horiz_sampling.cpp"
+  LIBS scream_io LABELS io remap
+  MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
+)
+
 ## Test single-column reader
 CreateUnitTest(io_scm_reader "io_scm_reader.cpp"
   LIBS scream_io LABELS io

--- a/components/eamxx/src/share/io/tests/io_horiz_sampling.cpp
+++ b/components/eamxx/src/share/io/tests/io_horiz_sampling.cpp
@@ -1,0 +1,165 @@
+#include <catch2/catch.hpp>
+#include <memory>
+
+#include "diagnostics/register_diagnostics.hpp"
+
+#include "share/io/eamxx_output_manager.hpp"
+#include "share/io/scorpio_input.hpp"
+#include "share/io/eamxx_scorpio_interface.hpp"
+#include "share/field/field_utils.hpp"
+#include "share/util/eamxx_setup_random_test.hpp"
+
+#include "share/grid/point_grid.hpp"
+
+namespace scream {
+
+Field create_f (const std::string& name,
+                const FieldLayout layout,
+                const std::string& grid_name)
+{
+  const auto nondim = ekat::units::Units::nondimensional();
+  FieldIdentifier fid(name,layout,nondim,grid_name);
+  Field f(fid);
+  f.allocate_view();
+  return f;
+}
+
+ekat::ParameterList output_params(const std::string& map_file)
+{
+  using strvec_t = std::vector<std::string>;
+
+  ekat::ParameterList params;
+  params.set<std::string>("filename_prefix","horiz_sampling");
+  params.set<std::string>("averaging_type","instant");
+  params.set<std::string>("floating_point_precision","real");
+  auto& oc = params.sublist("output_control");
+  oc.set<int>("frequency",1);
+  oc.set<std::string>("frequency_units","nsteps");
+  params.set<strvec_t>("field_names",{"s2d","s3d"});
+  params.set<std::string>("horiz_remap_file",map_file);
+
+  return params;
+}
+
+void print (const std::string& msg, const ekat::Comm& comm) {
+  if (comm.am_i_root()) {
+    printf("%s",msg.c_str());
+  }
+}
+
+TEST_CASE("io_remap_test","io_remap_test")
+{
+  using gid_type = AbstractGrid::gid_type;
+
+  // Init scorpio
+  ekat::Comm comm(MPI_COMM_WORLD);
+  scorpio::init_subsystem(comm);
+
+  util::TimeStamp t0 ({2000,1,1},{0,0,0});
+
+  // Random number generation
+  using RPDF  = std::uniform_real_distribution<Real>;
+  auto engine = setup_random_test(&comm);
+  RPDF pdf(0, 1);
+
+  // Create src grid
+  const std::string& gname = "point_grid";
+  const int ngcols_src = 10*comm.size();
+  const int nlevs = 4;
+  const auto src_grid = create_point_grid (gname,ngcols_src,nlevs,comm);
+  const int  nlcols_src = src_grid->get_num_local_dofs();
+  const auto gids_src_h = src_grid->get_dofs_gids().get_view<const gid_type*,Host>();
+
+  // Create remap file. The mapping strategy is simply to take every other column,
+  // but making sure to NOT pick the 1st one, so that the min col GID in map file is 2
+  print (" -> Create remap file ... \n",comm);
+  const int ngcols_tgt = ngcols_src / 2;
+  const int nlcols_tgt = nlcols_src / 2;
+  std::vector<int> col(nlcols_tgt), row(nlcols_tgt);
+  std::vector<Real> S(nlcols_tgt,1.0);
+  for (int i=0; i<nlcols_tgt; ++i) {
+    row[i] = 1 + i + nlcols_tgt*comm.rank();
+    col[i] = 1 + gids_src_h[2*i] + 1;
+  }
+
+  // Write remap data to file
+  const std::string remap_filename = "horiz_sampling_remap_np"+std::to_string(comm.size())+".nc";
+  scorpio::register_file(remap_filename, scorpio::FileMode::Write);
+
+  scorpio::define_dim(remap_filename,"n_a",ngcols_src);
+  scorpio::define_dim(remap_filename,"n_b",ngcols_tgt);
+  scorpio::define_dim(remap_filename,"n_s",ngcols_tgt);
+
+  scorpio::define_var(remap_filename,"col",   {"n_s"},"int");
+  scorpio::define_var(remap_filename,"row",   {"n_s"},"int");
+  scorpio::define_var(remap_filename,"S",     {"n_s"},"real");
+
+  // Linear decomposition
+  scorpio::set_dim_decomp(remap_filename,"n_s",comm.rank()*nlcols_tgt,nlcols_tgt);
+  scorpio::enddef(remap_filename);
+
+  scorpio::write_var(remap_filename,"row",   row.data());
+  scorpio::write_var(remap_filename,"col",   col.data());
+  scorpio::write_var(remap_filename,"S",     S.data());
+
+  scorpio::release_file(remap_filename);
+  print (" -> Create remap file ... done\n",comm);
+
+  // Create random source data
+  print (" -> Create source data ... \n",comm);
+
+  // Create the fields and randomize
+  auto s2d_src = create_f("s2d",src_grid->get_2d_scalar_layout(),gname);
+  auto s3d_src = create_f("s3d",src_grid->get_3d_scalar_layout(true),gname);
+  randomize(s2d_src,engine,pdf);
+  randomize(s3d_src,engine,pdf);
+
+  // Stuff fields in a FieldManager, since that's what OuputManager wants
+  auto fm = std::make_shared<FieldManager> (src_grid,RepoState::Closed);
+  fm->add_field(s2d_src);
+  fm->add_field(s3d_src);
+  fm->init_fields_time_stamp(t0);
+  print (" -> Create source data ... done\n",comm);
+
+  print (" -> Write output ... \n",comm);
+  double dt = 1.5;
+  OutputManager om;
+  auto params = output_params(remap_filename);
+  om.initialize (comm, params, t0, false);
+  om.setup(fm,{gname});
+
+  om.init_timestep(t0,dt);
+  om.run(t0+dt);
+  om.finalize();
+  print (" -> Write output ... done\n",comm);
+
+  print (" -> Check output ... \n",comm);
+
+  // Read output file
+  std::string filename = "horiz_sampling.INSTANT.nsteps_x1.np" + std::to_string(comm.size()) + "." + t0.to_string() + ".nc";
+  auto tgt_grid = create_point_grid(gname + "_tgt",ngcols_tgt,nlevs,comm);
+  auto s2d_tgt = create_f("s2d",tgt_grid->get_2d_scalar_layout(),gname+"_tgt");
+  auto s3d_tgt = create_f("s3d",tgt_grid->get_3d_scalar_layout(true),gname+"_tgt");
+
+  AtmosphereInput reader(filename,tgt_grid,{s2d_tgt,s3d_tgt});
+  reader.read_variables();
+  reader.finalize(); // manually finalize, or scorpio cleanup will complain about a file still open
+
+  // Check values
+  auto s2d_src_h = s2d_src.get_view<const Real* ,Host>();
+  auto s3d_src_h = s3d_src.get_view<const Real**,Host>();
+  auto s2d_tgt_h = s2d_tgt.get_view<const Real* ,Host>();
+  auto s3d_tgt_h = s3d_tgt.get_view<const Real**,Host>();
+  for (int i=0; i<nlcols_tgt; ++i) {
+    REQUIRE (s2d_tgt_h(i)==s2d_src_h(2*i+1));
+    for (int k=0; k<nlevs; ++k) {
+      REQUIRE (s3d_tgt_h(i,k)==s3d_src_h(2*i+1,k));
+    }
+  }
+  print (" -> Check output ... done\n",comm);
+  
+  // Cleanup scorpio
+  scorpio::finalize_subsystem();
+}
+
+} //namespace scream

--- a/components/eamxx/src/share/io/tests/io_horiz_sampling.cpp
+++ b/components/eamxx/src/share/io/tests/io_horiz_sampling.cpp
@@ -78,8 +78,8 @@ TEST_CASE("io_remap_test","io_remap_test")
   std::vector<int> col(nlcols_tgt), row(nlcols_tgt);
   std::vector<Real> S(nlcols_tgt,1.0);
   for (int i=0; i<nlcols_tgt; ++i) {
-    row[i] = 1 + i + nlcols_tgt*comm.rank();
-    col[i] = 1 + gids_src_h[2*i] + 1;
+    row[i] = i + nlcols_tgt*comm.rank();
+    col[i] = gids_src_h[2*i] + 1;
   }
 
   // Write remap data to file

--- a/components/eamxx/src/share/io/tests/io_remap_test.cpp
+++ b/components/eamxx/src/share/io/tests/io_remap_test.cpp
@@ -87,10 +87,10 @@ TEST_CASE("io_remap_test","io_remap_test")
   const Real wgt = 0.4;
   for (int ii=0; ii<ncols_tgt_l; ii++) {
     const int src_col = 2*ii + ncols_src_l*io_comm.rank();
-    row.push_back(1+ii+ncols_tgt_l*io_comm.rank());
-    row.push_back(1+ii+ncols_tgt_l*io_comm.rank());
-    col.push_back(1+src_col);
-    col.push_back(1+src_col+1);
+    row.push_back(ii+ncols_tgt_l*io_comm.rank());
+    row.push_back(ii+ncols_tgt_l*io_comm.rank());
+    col.push_back(src_col);
+    col.push_back(src_col+1);
     S.push_back(wgt);
     S.push_back(1.0-wgt);
   }


### PR DESCRIPTION
Fixes an issue in coarsening remap in case not all the fine grid cols participate to the remap. This bug affected ARM site output.

Fixes #7346 

[BFB]

---

I also changed HommeGridsManager, so that it generates grids with 0-based GIDs rather than 1-based. This is not too important for IO (as the IO layer is already subtracting the grid min GID when computing PIO decomp offsets), but it was making the horiz remapping a bit more brittle.

I will push a unit test for "sampling"-style coarsening remapping soon.