### PR TITLE
 Fix a bug in coupling between zm microphys/hetfrz ice nucleation and mam aerosol

### DIFF
--- a/components/eam/src/physics/cam/hetfrz_classnuc_cam.F90
+++ b/components/eam/src/physics/cam/hetfrz_classnuc_cam.F90
@@ -1305,7 +1305,7 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
 #if ((defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE) && defined RAIN_EVAP_TO_COARSE_AERO )
          dst3_num_imm = dmc_imm/(ssmc_imm+dmc_imm+bcmc_imm+pommc_imm+soamc_imm+mommc_imm) &
                       * aer_cb(ii,kk,num_coarse)*1.0e-6_r8 ! #/cm^3
-#elif (defined MODAL_AERO_4MODE_MOM)
+#elif (defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
          dst3_num_imm = dmc_imm/(ssmc_imm+dmc_imm+mommc_imm) * aer_cb(ii,kk,num_coarse)*1.0e-6_r8 ! #/cm^3
 #elif (defined RAIN_EVAP_TO_COARSE_AERO) 
          dst3_num_imm = dmc_imm/(ssmc_imm+dmc_imm+bcmc_imm+pommc_imm+soamc_imm) &
@@ -1475,7 +1475,7 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
                      aer(ii,kk,pom_coarse)/(specdens_pom*rhoair) + & 
                      aer(ii,kk,soa_coarse)/(specdens_soa*rhoair) + & 
                      aer(ii,kk,mom_coarse)/(specdens_mom*rhoair) 
-#elif (defined MODAL_AERO_4MODE_MOM)
+#elif (defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
       vol_shell(3) = aer(ii,kk,so4_coarse)/(specdens_so4*rhoair) + & 
                      aer(ii,kk,mom_coarse)/(specdens_mom*rhoair) 
 #elif (defined RAIN_EVAP_TO_COARSE_AERO) 
@@ -1603,7 +1603,7 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
 #if ((defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE) && defined RAIN_EVAP_TO_COARSE_AERO )
          awcam(3) = (dst3_num*1.0e6_r8)/aer(ii,kk,num_coarse)* ( aer(ii,kk,so4_coarse) + & 
                      aer(ii,kk,mom_coarse) + aer(ii,kk,bc_coarse) + aer(ii,kk,pom_coarse) + aer(ii,kk,soa_coarse) ) *1.0e9_r8
-#elif (defined MODAL_AERO_4MODE_MOM)
+#elif (defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
          awcam(3) = (dst3_num*1.0e6_r8)/aer(ii,kk,num_coarse)* ( aer(ii,kk,so4_coarse) + & 
                      aer(ii,kk,mom_coarse) ) *1.0e9_r8
 #elif (defined RAIN_EVAP_TO_COARSE_AERO) 
@@ -1622,7 +1622,7 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
                        aer(ii,kk,pom_coarse) + aer(ii,kk,mom_coarse) )/ &
                      ( aer(ii,kk,soa_coarse) + aer(ii,kk,pom_coarse) + &
                        aer(ii,kk,so4_coarse) + aer(ii,kk,bc_coarse) + aer(ii,kk,mom_coarse) )
-#elif (defined MODAL_AERO_4MODE_MOM)
+#elif (defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
          awfacm(3) = ( aer(ii,kk,mom_coarse) ) / & 
                      ( aer(ii,kk,so4_coarse) + aer(ii,kk,mom_coarse) )
 #elif (defined RAIN_EVAP_TO_COARSE_AERO) 

--- a/components/eam/src/physics/cam/hetfrz_classnuc_cam.F90
+++ b/components/eam/src/physics/cam/hetfrz_classnuc_cam.F90
@@ -1617,7 +1617,7 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
       end if
 
       if (awcam(3) > 0._r8) then
-#if (defined MODAL_AERO_4MODE_MOM && defined RAIN_EVAP_TO_COARSE_AERO )
+#if ( (defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE) && defined RAIN_EVAP_TO_COARSE_AERO )
          awfacm(3) = ( aer(ii,kk,bc_coarse) + aer(ii,kk,soa_coarse) + &
                        aer(ii,kk,pom_coarse) + aer(ii,kk,mom_coarse) )/ &
                      ( aer(ii,kk,soa_coarse) + aer(ii,kk,pom_coarse) + &

--- a/components/eam/src/physics/cam/nucleate_ice_cam.F90
+++ b/components/eam/src/physics/cam/nucleate_ice_cam.F90
@@ -777,11 +777,9 @@ subroutine nucleate_ice_cam_calc( &
                   else
                      ! 3-mode -- needs weighting for dust since dust and seasalt
                      !           are combined in the "coarse" mode type
-#if (defined MODAL_AERO_4MODE_MOM && defined RAIN_EVAP_TO_COARSE_AERO )
+#if ((defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE) && defined RAIN_EVAP_TO_COARSE_AERO )
                      wght = dmc/(ssmc + dmc + so4mc + bcmc + pommc + soamc + mommc)
-#elif (defined MODAL_AERO_5MODE && defined RAIN_EVAP_TO_COARSE_AERO)
-                     wght = dmc/(ssmc + dmc + so4mc + bcmc + pommc + soamc + mommc)
-#elif (defined MODAL_AERO_4MODE_MOM)
+#elif (defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
                      wght = dmc/(ssmc + dmc + so4mc + mommc)
 #elif (defined RAIN_EVAP_TO_COARSE_AERO) 
                      wght = dmc/(ssmc + dmc + so4mc + bcmc + pommc + soamc)

--- a/components/eam/src/physics/cam/zm_aero.F90
+++ b/components/eam/src/physics/cam/zm_aero.F90
@@ -55,6 +55,17 @@ type :: zm_aero_t
    integer :: coarse_dust_idx = -1  ! index of dust in coarse mode
    integer :: coarse_nacl_idx = -1  ! index of nacl in coarse mode
 
+   integer :: coarse_so4_idx = -1  ! index of so4 in coarse mode
+#if (defined MODAL_AERO_4MODE_MOM  || defined MODAL_AERO_5MODE)
+   integer :: coarse_mom_idx = -1  ! index of mom in coarse mode
+#endif
+
+#if (defined RAIN_EVAP_TO_COARSE_AERO)
+   integer :: coarse_bc_idx  = -1  ! index of bc in coarse mode
+   integer :: coarse_pom_idx = -1  ! index of pom in coarse mode
+   integer :: coarse_soa_idx = -1  ! index of soa in coarse mode
+#endif
+
    type(ptr2d), allocatable :: dgnum(:)        ! mode dry radius
    real(r8),    allocatable :: dgnumg(:,:,:)   ! gathered mode dry radius
 
@@ -131,16 +142,49 @@ subroutine zm_aero_init(nmodes, nbulk, aero)
             aero%coarse_dust_idx = l
          case ('seasalt')
             aero%coarse_nacl_idx = l
+         case ('sulfate')
+            aero%coarse_so4_idx = l
+#if ( defined MODAL_AERO_4MODE_MOM  || defined MODAL_AERO_5MODE )
+         case ('m-organic')
+            aero%coarse_mom_idx  = l
+#endif
+#if ( defined RAIN_EVAP_TO_COARSE_AERO )
+         case ('black-c')
+            aero%coarse_bc_idx   = l
+         case ('p-organic')
+            aero%coarse_pom_idx  = l
+         case ('s-organic')
+            aero%coarse_soa_idx  = l
+#endif
          end select
       end do
 
       ! Check that required modal species types were found
       if (aero%coarse_dust_idx == -1 .or. &
-          aero%coarse_nacl_idx == -1) then
+          aero%coarse_nacl_idx == -1 .or. &
+          aero%coarse_so4_idx == -1) then
          write(iulog,*) routine//': ERROR required mode-species type not found - indicies:', &
-            aero%coarse_dust_idx, aero%coarse_nacl_idx
+            aero%coarse_dust_idx, aero%coarse_nacl_idx, aero%coarse_so4_idx
          call endrun(routine//': ERROR required mode-species type not found')
       end if
+
+#if ( defined MODAL_AERO_4MODE_MOM  || defined MODAL_AERO_5MODE )
+      if (aero%coarse_mom_idx == -1) then
+         write(iulog,*) routine//': ERROR required mode-species type not found - indicies:', &
+            aero%coarse_mom_idx
+         call endrun(routine//': ERROR required mode-species type not found')
+      end if
+#endif
+
+#if ( defined RAIN_EVAP_TO_COARSE_AERO )
+      if (aero%coarse_bc_idx == -1 .or. &
+          aero%coarse_pom_idx == -1 .or. &
+          aero%coarse_soa_idx == -1) then
+         write(iulog,*) routine//': ERROR required mode-species type not found - indicies:', &
+            aero%coarse_bc_idx, aero%coarse_pom_idx, aero%coarse_soa_idx
+         call endrun(routine//': ERROR required mode-species type not found')
+      end if
+#endif
 
       allocate( &
          aero%num_a(nmodes), &

--- a/components/eam/src/physics/cam/zm_microphysics.F90
+++ b/components/eam/src/physics/cam/zm_microphysics.F90
@@ -2060,12 +2060,12 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                     if (dmc > 0._r8) then
 #if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) )
                        wght = dmc/(ssmc + dmc + so4mc + bcmc + pommc + soamc + mommc)
-#elif (defined MODAL_AERO_4MODE_MOM)
+#elif ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE )
                        wght = dmc/(ssmc + dmc + so4mc + mommc)
 #elif (defined RAIN_EVAP_TO_COARSE_AERO)
                        wght = dmc/(ssmc + dmc + so4mc + bcmc + pommc + soamc)
 #else
-                       wght = dmc/(ssmc + dmc)
+                       wght = dmc/(ssmc + dmc + so4mc)
 #endif
                        dst_num = wght *(aero%numg_a(i,k-1,aero%mode_coarse_idx)         &
                                   + aero%numg_a(i,k,aero%mode_coarse_idx))*0.5_r8*rho(i,k)*1.0e-6_r8

--- a/components/eam/src/physics/cam/zm_microphysics.F90
+++ b/components/eam/src/physics/cam/zm_microphysics.F90
@@ -515,6 +515,12 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
   real(r8) :: flux_fullact            ! flux of activated aerosol fraction assuming 100% activation (cm/s)
   real(r8) :: dmc
   real(r8) :: ssmc
+  real(r8) :: so4mc
+  real(r8) :: mommc
+  real(r8) :: bcmc
+  real(r8) :: pommc
+  real(r8) :: soamc
+  real(r8) :: wght
   real(r8) :: dgnum_aitken
 
 ! bulk aerosol variables
@@ -2036,9 +2042,32 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                     dmc  = 0.5_r8*(aero%mmrg_a(i,k-1,aero%coarse_dust_idx,aero%mode_coarse_idx)      &
                                   +aero%mmrg_a(i,k,aero%coarse_dust_idx,aero%mode_coarse_idx))
                     ssmc = 0.5_r8*(aero%mmrg_a(i,k-1,aero%coarse_nacl_idx,aero%mode_coarse_idx)      &
-                                  +aero%mmrg_a(i,k,aero%coarse_nacl_idx,aero%mode_coarse_idx))  
+                                  +aero%mmrg_a(i,k,aero%coarse_nacl_idx,aero%mode_coarse_idx)) 
+                    so4mc = 0.5_r8*(aero%mmrg_a(i,k-1,aero%coarse_so4_idx,aero%mode_coarse_idx)     &
+                                   +aero%mmrg_a(i,k,aero%coarse_so4_idx,aero%mode_coarse_idx)) 
+#if (defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE)
+                    mommc = 0.5_r8*(aero%mmrg_a(i,k-1,aero%coarse_mom_idx,aero%mode_coarse_idx)     &
+                                   +aero%mmrg_a(i,k,aero%coarse_mom_idx,aero%mode_coarse_idx))
+#endif 
+#if (defined RAIN_EVAP_TO_COARSE_AERO)
+                    bcmc  = 0.5_r8*(aero%mmrg_a(i,k-1,aero%coarse_bc_idx,aero%mode_coarse_idx)     &
+                                   +aero%mmrg_a(i,k,aero%coarse_bc_idx,aero%mode_coarse_idx))
+                    pommc = 0.5_r8*(aero%mmrg_a(i,k-1,aero%coarse_pom_idx,aero%mode_coarse_idx)     &
+                                   +aero%mmrg_a(i,k,aero%coarse_pom_idx,aero%mode_coarse_idx))
+                    soamc = 0.5_r8*(aero%mmrg_a(i,k-1,aero%coarse_soa_idx,aero%mode_coarse_idx)     &
+                                   +aero%mmrg_a(i,k,aero%coarse_soa_idx,aero%mode_coarse_idx))
+#endif
                     if (dmc > 0._r8) then
-                        dst_num = dmc/(ssmc + dmc) *(aero%numg_a(i,k-1,aero%mode_coarse_idx)         & 
+#if ( ( defined MODAL_AERO_4MODE_MOM || defined MODAL_AERO_5MODE ) && ( defined RAIN_EVAP_TO_COARSE_AERO ) )
+                       wght = dmc/(ssmc + dmc + so4mc + bcmc + pommc + soamc + mommc)
+#elif (defined MODAL_AERO_4MODE_MOM)
+                       wght = dmc/(ssmc + dmc + so4mc + mommc)
+#elif (defined RAIN_EVAP_TO_COARSE_AERO)
+                       wght = dmc/(ssmc + dmc + so4mc + bcmc + pommc + soamc)
+#else
+                       wght = dmc/(ssmc + dmc)
+#endif
+                       dst_num = wght *(aero%numg_a(i,k-1,aero%mode_coarse_idx)         &
                                   + aero%numg_a(i,k,aero%mode_coarse_idx))*0.5_r8*rho(i,k)*1.0e-6_r8
                     else 
                        dst_num = 0.0_r8
@@ -2237,13 +2266,8 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
                     !  use size '3' for dust coarse mode...
                     !  scale by dust fraction in coarse mode
 
-                    dmc  = 0.5_r8*(aero%mmrg_a(i,k,aero%coarse_dust_idx,aero%mode_coarse_idx)     &
-                                  +aero%mmrg_a(i,k-1,aero%coarse_dust_idx,aero%mode_coarse_idx))
-                    ssmc = 0.5_r8*(aero%mmrg_a(i,k,aero%coarse_nacl_idx,aero%mode_coarse_idx)     &
-                                  +aero%mmrg_a(i,k-1,aero%coarse_nacl_idx,aero%mode_coarse_idx)) 
                     if (dmc > 0.0_r8) then
-                        nacon3 = dmc/(ssmc + dmc) * (aero%numg_a(i,k,aero%mode_coarse_idx)     &
-                                 + aero%numg_a(i,k-1,aero%mode_coarse_idx))*0.5_r8*rho(i,k)
+                        nacon3 = dst_num*tcnt*1.0e6_r8
                     end if
 
                  else if (aero%scheme == 'bulk') then


### PR DESCRIPTION
This PR fixes a bug in coupling between zm microphys and mam aerosol 
and a bug in coupling between heterogeneous ice nucleation and mam aerosol. 

There are minimal changes between two 10yr F2010 runs.

Fixes #7353. 

[non-BFB]

--------------------------------------
model vs obs
[CNTL](https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.mwu/E3SMv3/20250522.v3.LR.F2010.CNTL.PD.chrysalis/e3sm_diags/atm_monthly_180x360_aave/model_vs_obs_0002-0011/viewer/index.html)
[ZM Microphys bug fix](https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.mwu/E3SMv3/20250526.v3.LR.F2010.ZMMicrophys_bugfix.PD.chrysalis/e3sm_diags/atm_monthly_180x360_aave/model_vs_obs_0002-0011/viewer/index.html)

model vs model
[ZM Microphys bug fix vs CNTL](https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.mwu/E3SMv3/20250526.v3.LR.F2010.ZMMicrophys_bugfix.PD.chrysalis/e3sm_diags/atm_monthly_180x360_aave_mvm/model_vs_model_0002-0011/viewer/index.html)

[IICE results](https://portal.nersc.gov/project/m2136/bin/iice/iice.cgi?url1=https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.mwu/E3SMv3/20250522.v3.LR.F2010.CNTL.PD.chrysalis/e3sm_diags/atm_monthly_180x360_aave/model_vs_obs_0002-0011/viewer&label1=CNTL&url2=https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.mwu/E3SMv3/20250526.v3.LR.F2010.ZMMicrophys_bugfix.PD.chrysalis/e3sm_diags/atm_monthly_180x360_aave/model_vs_obs_0002-0011/viewer&label2=ZMmicro%20bug%20fix&category=&plot=&diff=0&dconfig=vsObs&)

atm_nbfb tests suggest the model with the changes introduced still produces statistically identical results with respect to the baselines.

-  [MVK test](https://web.lcrc.anl.gov/public/e3sm/ac.wlin/evv/MVK_PS.ne4pg2_oQU480.F2010.chrysalis_intel.C.20250601_105918_12toly/)
- [PGN test](https://web.lcrc.anl.gov/public/e3sm/ac.wlin/evv/PGN_P1x1.ne4pg2_oQU480.F2010.chrysalis_intel.C.20250529_121927_axld0g/)
- [TSC test](https://web.lcrc.anl.gov/public/e3sm/ac.wlin/evv/TSC_PS.ne4pg2_oQU480.F2010.chrysalis_intel.C.20250529_121927_axld0g/)

