### PR TITLE
Unset HDF5_ROOT for pm-gpu to avoid potential HDF5 version mismatch errors

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -463,6 +463,7 @@
       <env name="MPICH_COLL_SYNC">MPI_Bcast</env>
       <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
+      <env name="HDF5_ROOT"/> <!-- Temporary workaround to avoid runtime errors in certain tests on pm-gpu; possibly due to an HDF5 version mismatch -->
     </environment_variables>
     <environment_variables compiler="gnugpu">
       <env name="MPICH_GPU_SUPPORT_ENABLED">1</env>


### PR DESCRIPTION
Workaround for fixing HDF5 version mismatch errors on pm-gpu
after PR #7282 

PR #7282 works on pm-cpu, frontier, and chrysalis, but recently
triggered HDF5 version mismatch errors on pm-gpu. The root
cause is still unclear, possibly due to netcdf/hdf5 module
issues on Perlmutter. Notably, issue #7076 reported similar
HDF5 version issues before PR #7282 was merged.

This workaround unsets HDF5_ROOT for pm-gpu

See related Issues #7341, #7076

[BFB]