### PR TITLE
Clean up Aurora cmake for Omega

### DIFF
--- a/cime_config/machines/cmake_macros/oneapi-ifxgpu_aurora.cmake
+++ b/cime_config/machines/cmake_macros/oneapi-ifxgpu_aurora.cmake
@@ -5,7 +5,7 @@ if (compile_threaded)
 endif()
 
 string(APPEND KOKKOS_OPTIONS " -DCMAKE_CXX_STANDARD=17 -DKokkos_ENABLE_SERIAL=On -DKokkos_ARCH_INTEL_PVC=On -DKokkos_ENABLE_SYCL=On -DKokkos_ENABLE_EXPLICIT_INSTANTIATION=Off")
-string(APPEND SYCL_FLAGS " -\-intel -fsycl -fsycl-targets=spir64_gen -mlong-double-64 -Xsycl-target-backend \"-device 12.60.7\"")
+string(APPEND SYCL_FLAGS " -\-intel -fsycl -fsycl-targets=spir64_gen -mlong-double-64 ")
 string(APPEND OMEGA_SYCL_EXE_LINKER_FLAGS " -Xsycl-target-backend \"-device 12.60.7\" ")
 
 # Let's start with the best case: using device buffers in MPI calls by default.


### PR DESCRIPTION
Remove link-flag -Xsycl-target-backend from compile flags.

[BFB]

---
This has no effect on EAMxx and fixes Omega builds.