### PR TITLE
Dynamical adjustment on freshwater fluxes balance for E3SM runs

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -313,6 +313,7 @@ _TESTS = {
             "SMS_P480_Ld5.TL319_IcoswISC30E3r5.GMPAS-JRA1p5-DIB-PISMF-TMIX.mpaso-jra_1958",
             "PET_P480_Ld2.TL319_IcoswISC30E3r5.GMPAS-JRA1p5-DIB-PISMF-DSGR.mpaso-jra_1958",
             "PET_P480_Ld2.TL319_IcoswISC30E3r5.GMPAS-JRA1p5-DIB-PISMF-DSGR.mpaso-freshwater_tracers_jra_1958",
+            "SMS_P480_Ld5.TL319_IcoswISC30E3r5.GMPAS-JRA1p5.mpaso-precip_scaling_jra_1958",
             )
         },
 

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -725,10 +725,11 @@ add_default($nl, 'config_sgr_salinity_prescribed');
 ##################################
 # Namelist group: precip_scaling #
 ##################################
+
 add_default($nl, 'config_use_precip_scaling');
 add_default($nl, 'config_precip_scaling_mode');
-add_default($nl, 'config_precip_scaling_constant_factor');
 add_default($nl, 'config_precip_scaling_initial_factor');
+add_default($nl, 'config_precip_scaling_constant_factor');
 add_default($nl, 'config_precip_scaling_history_years');
 add_default($nl, 'config_precip_scaling_write_to_logfile');
 

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -722,9 +722,9 @@ add_default($nl, 'config_use_sgr_opt_salt_prescribed');
 add_default($nl, 'config_sgr_temperature_prescribed');
 add_default($nl, 'config_sgr_salinity_prescribed');
 
-################################
-# Namelist group: sfwf_forcing #
-################################
+##################################
+# Namelist group: precip_scaling #
+##################################
 add_default($nl, 'config_use_precip_scaling');
 add_default($nl, 'config_precip_scaling_mode');
 add_default($nl, 'config_precip_scaling_constant_factor');
@@ -1871,7 +1871,7 @@ my @groups = qw(run_modes
                 wave_coupling
                 gotm
                 forcing
-		sfwf_forcing
+		precip_scaling
                 coupling
                 shortwaveradiation
                 self_attraction_loading

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -728,7 +728,7 @@ add_default($nl, 'config_sgr_salinity_prescribed');
 add_default($nl, 'config_sfwf_balance');
 add_default($nl, 'config_sfwf_balance_type');
 add_default($nl, 'config_precip_factor');
-add_default($nl, 'config_sfwf_history_days');
+add_default($nl, 'config_sfwf_history_years');
 
 ############################
 # Namelist group: coupling #

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -729,6 +729,8 @@ add_default($nl, 'config_sfwf_balance');
 add_default($nl, 'config_sfwf_balance_type');
 add_default($nl, 'config_precip_factor');
 add_default($nl, 'config_sfwf_history_years');
+add_default($nl, 'config_sfwf_use_prev_factor');
+add_default($nl, 'config_sfwf_balance_write_to_logfile');
 
 ############################
 # Namelist group: coupling #

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -722,6 +722,14 @@ add_default($nl, 'config_use_sgr_opt_salt_prescribed');
 add_default($nl, 'config_sgr_temperature_prescribed');
 add_default($nl, 'config_sgr_salinity_prescribed');
 
+################################
+# Namelist group: sfwf_forcing #
+################################
+add_default($nl, 'config_sfwf_balance');
+add_default($nl, 'config_sfwf_balance_type');
+add_default($nl, 'config_precip_factor');
+add_default($nl, 'config_sfwf_history_days');
+
 ############################
 # Namelist group: coupling #
 ############################
@@ -1861,6 +1869,7 @@ my @groups = qw(run_modes
                 wave_coupling
                 gotm
                 forcing
+		sfwf_forcing
                 coupling
                 shortwaveradiation
                 self_attraction_loading

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -725,11 +725,12 @@ add_default($nl, 'config_sgr_salinity_prescribed');
 ################################
 # Namelist group: sfwf_forcing #
 ################################
-add_default($nl, 'config_sfwf_balance');
-add_default($nl, 'config_sfwf_balance_type');
-add_default($nl, 'config_precip_factor');
-add_default($nl, 'config_sfwf_history_years');
-add_default($nl, 'config_sfwf_balance_write_to_logfile');
+add_default($nl, 'config_use_precip_scaling');
+add_default($nl, 'config_precip_scaling_mode');
+add_default($nl, 'config_precip_scaling_constant_factor');
+add_default($nl, 'config_precip_scaling_initial_factor');
+add_default($nl, 'config_precip_scaling_history_years');
+add_default($nl, 'config_precip_scaling_write_to_logfile');
 
 ############################
 # Namelist group: coupling #

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -729,7 +729,6 @@ add_default($nl, 'config_sfwf_balance');
 add_default($nl, 'config_sfwf_balance_type');
 add_default($nl, 'config_precip_factor');
 add_default($nl, 'config_sfwf_history_years');
-add_default($nl, 'config_sfwf_use_prev_factor');
 add_default($nl, 'config_sfwf_balance_write_to_logfile');
 
 ############################

--- a/components/mpas-ocean/bld/build-namelist-group-list
+++ b/components/mpas-ocean/bld/build-namelist-group-list
@@ -15,6 +15,7 @@ my @groups = qw(run_modes
                 wave_coupling
                 gotm
                 forcing
+                sfwf_forcing
                 coupling
                 shortwaveradiation
                 self_attraction_loading

--- a/components/mpas-ocean/bld/build-namelist-group-list
+++ b/components/mpas-ocean/bld/build-namelist-group-list
@@ -15,7 +15,7 @@ my @groups = qw(run_modes
                 wave_coupling
                 gotm
                 forcing
-                sfwf_forcing
+                precip_scaling
                 coupling
                 shortwaveradiation
                 self_attraction_loading

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -234,9 +234,9 @@ add_default($nl, 'config_use_sgr_opt_salt_prescribed');
 add_default($nl, 'config_sgr_temperature_prescribed');
 add_default($nl, 'config_sgr_salinity_prescribed');
 
-###############################
-# Namelist group: sfwf_forcing#
-###############################
+#################################
+# Namelist group: precip_scaling#
+#################################
 add_default($nl, 'config_use_precip_scaling');
 add_default($nl, 'config_precip_scaling_mode');
 add_default($nl, 'config_precip_scaling_constant_factor');

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -241,6 +241,8 @@ add_default($nl, 'config_sfwf_balance');
 add_default($nl, 'config_sfwf_balance_type');
 add_default($nl, 'config_precip_factor');
 add_default($nl, 'config_sfwf_history_years');
+add_default($nl, 'config_sfwf_use_prev_factor');
+add_default($nl, 'config_sfwf_balance_write_to_logfile');
 
 ############################
 # Namelist group: coupling #

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -240,7 +240,7 @@ add_default($nl, 'config_sgr_salinity_prescribed');
 add_default($nl, 'config_sfwf_balance');
 add_default($nl, 'config_sfwf_balance_type');
 add_default($nl, 'config_precip_factor');
-add_default($nl, 'config_sfwf_history_days');
+add_default($nl, 'config_sfwf_history_years');
 
 ############################
 # Namelist group: coupling #

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -234,6 +234,14 @@ add_default($nl, 'config_use_sgr_opt_salt_prescribed');
 add_default($nl, 'config_sgr_temperature_prescribed');
 add_default($nl, 'config_sgr_salinity_prescribed');
 
+###############################
+# Namelist group: sfwf_forcing#
+###############################
+add_default($nl, 'config_sfwf_balance');
+add_default($nl, 'config_sfwf_balance_type');
+add_default($nl, 'config_precip_factor');
+add_default($nl, 'config_sfwf_history_days');
+
 ############################
 # Namelist group: coupling #
 ############################

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -241,7 +241,6 @@ add_default($nl, 'config_sfwf_balance');
 add_default($nl, 'config_sfwf_balance_type');
 add_default($nl, 'config_precip_factor');
 add_default($nl, 'config_sfwf_history_years');
-add_default($nl, 'config_sfwf_use_prev_factor');
 add_default($nl, 'config_sfwf_balance_write_to_logfile');
 
 ############################

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -237,11 +237,12 @@ add_default($nl, 'config_sgr_salinity_prescribed');
 ###############################
 # Namelist group: sfwf_forcing#
 ###############################
-add_default($nl, 'config_sfwf_balance');
-add_default($nl, 'config_sfwf_balance_type');
-add_default($nl, 'config_precip_factor');
-add_default($nl, 'config_sfwf_history_years');
-add_default($nl, 'config_sfwf_balance_write_to_logfile');
+add_default($nl, 'config_use_precip_scaling');
+add_default($nl, 'config_precip_scaling_mode');
+add_default($nl, 'config_precip_scaling_constant_factor');
+add_default($nl, 'config_precip_scaling_initial_factor');
+add_default($nl, 'config_precip_scaling_history_years');
+add_default($nl, 'config_precip_scaling_write_to_logfile');
 
 ############################
 # Namelist group: coupling #

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -234,13 +234,14 @@ add_default($nl, 'config_use_sgr_opt_salt_prescribed');
 add_default($nl, 'config_sgr_temperature_prescribed');
 add_default($nl, 'config_sgr_salinity_prescribed');
 
-#################################
-# Namelist group: precip_scaling#
-#################################
+##################################
+# Namelist group: precip_scaling #
+##################################
+
 add_default($nl, 'config_use_precip_scaling');
 add_default($nl, 'config_precip_scaling_mode');
-add_default($nl, 'config_precip_scaling_constant_factor');
 add_default($nl, 'config_precip_scaling_initial_factor');
+add_default($nl, 'config_precip_scaling_constant_factor');
 add_default($nl, 'config_precip_scaling_history_years');
 add_default($nl, 'config_precip_scaling_write_to_logfile');
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -376,7 +376,7 @@
 <config_sfwf_balance>.false.</config_sfwf_balance>
 <config_sfwf_balance_type>0</config_sfwf_balance_type>
 <config_precip_factor>1.0</config_precip_factor>
-<config_sfwf_history_days>366</config_sfwf_history_days>
+<config_sfwf_history_years>1</config_sfwf_history_years>
 
 <!-- coupling -->
 <config_remove_ais_river_runoff>.false.</config_remove_ais_river_runoff>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -372,12 +372,13 @@
 <config_sgr_temperature_prescribed>0.0</config_sgr_temperature_prescribed>
 <config_sgr_salinity_prescribed>0.0</config_sgr_salinity_prescribed>
 
-<!-- sfwf_forcing --> 
-<config_sfwf_balance>.false.</config_sfwf_balance>
-<config_sfwf_balance_type>-99</config_sfwf_balance_type>
-<config_precip_factor>1.0</config_precip_factor>
-<config_sfwf_history_years>1</config_sfwf_history_years>
-<config_sfwf_balance_write_to_logfile>.false.</config_sfwf_balance_write_to_logfile>
+<!-- precip_scaling --> 
+<config_use_precip_scaling>.false.</config_use_precip_scaling>
+<config_precip_scaling_mode>'off'</config_precip_scaling_mode>
+<config_precip_scaling_constant_factor>1.0</config_precip_scaling_constant_factor>
+<config_precip_scaling_initial_factor>1.0</config_precip_scaling_initial_factor>
+<config_precip_scaling_history_years>1</config_precip_scaling_history_years>
+<config_precip_scaling_write_to_logfile>.false.</config_precip_scaling_write_to_logfile>
 
 <!-- coupling -->
 <config_remove_ais_river_runoff>.false.</config_remove_ais_river_runoff>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -372,6 +372,12 @@
 <config_sgr_temperature_prescribed>0.0</config_sgr_temperature_prescribed>
 <config_sgr_salinity_prescribed>0.0</config_sgr_salinity_prescribed>
 
+<!-- sfwf_forcing --> 
+<config_sfwf_balance>.false.</config_sfwf_balance>
+<config_sfwf_balance_type>0</config_sfwf_balance_type>
+<config_precip_factor>1.0</config_precip_factor>
+<config_sfwf_history_days>366</config_sfwf_history_days>
+
 <!-- coupling -->
 <config_remove_ais_river_runoff>.false.</config_remove_ais_river_runoff>
 <config_remove_ais_ice_runoff>.false.</config_remove_ais_ice_runoff>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -374,9 +374,11 @@
 
 <!-- sfwf_forcing --> 
 <config_sfwf_balance>.false.</config_sfwf_balance>
-<config_sfwf_balance_type>0</config_sfwf_balance_type>
+<config_sfwf_balance_type>-99</config_sfwf_balance_type>
 <config_precip_factor>1.0</config_precip_factor>
 <config_sfwf_history_years>1</config_sfwf_history_years>
+<config_sfwf_use_prev_factor>.false.</config_sfwf_use_prev_factor>
+<config_sfwf_balance_write_to_logfile>.false.</config_sfwf_balance_write_to_logfile>
 
 <!-- coupling -->
 <config_remove_ais_river_runoff>.false.</config_remove_ais_river_runoff>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -377,7 +377,7 @@
 <config_sfwf_balance_type>-99</config_sfwf_balance_type>
 <config_precip_factor>1.0</config_precip_factor>
 <config_sfwf_history_years>1</config_sfwf_history_years>
-<config_sfwf_use_prev_factor>.false.</config_sfwf_use_prev_factor>
+<config_sfwf_use_prev_factor>.true.</config_sfwf_use_prev_factor>
 <config_sfwf_balance_write_to_logfile>.false.</config_sfwf_balance_write_to_logfile>
 
 <!-- coupling -->

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -377,7 +377,6 @@
 <config_sfwf_balance_type>-99</config_sfwf_balance_type>
 <config_precip_factor>1.0</config_precip_factor>
 <config_sfwf_history_years>1</config_sfwf_history_years>
-<config_sfwf_use_prev_factor>.true.</config_sfwf_use_prev_factor>
 <config_sfwf_balance_write_to_logfile>.false.</config_sfwf_balance_write_to_logfile>
 
 <!-- coupling -->

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -372,11 +372,11 @@
 <config_sgr_temperature_prescribed>0.0</config_sgr_temperature_prescribed>
 <config_sgr_salinity_prescribed>0.0</config_sgr_salinity_prescribed>
 
-<!-- precip_scaling --> 
+<!-- precip_scaling -->
 <config_use_precip_scaling>.false.</config_use_precip_scaling>
 <config_precip_scaling_mode>'off'</config_precip_scaling_mode>
-<config_precip_scaling_constant_factor>1.0</config_precip_scaling_constant_factor>
 <config_precip_scaling_initial_factor>1.0</config_precip_scaling_initial_factor>
+<config_precip_scaling_constant_factor>1.0</config_precip_scaling_constant_factor>
 <config_precip_scaling_history_years>1</config_precip_scaling_history_years>
 <config_precip_scaling_write_to_logfile>.false.</config_precip_scaling_write_to_logfile>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1260,19 +1260,19 @@ Valid values: Any positive real number
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<!--sfwf balance -->
+<!--sfwf forcing -->
 
 <entry id="config_sfwf_balance" type="logical"
-        category="sfwf_forcing" group="sfwf_forcing">
-If true, precipitation fluxes from data atmosphere was adjusted to constrain the freshwater conservation. To be used with data precipitation (rain+snow) fluxes coming from the atmospehre model and runoff fluxes coming from the land model.
+	category="sfwf_forcing" group="sfwf_forcing">
+If true, precipitation fluxes from the data atmosphere are adjusted to ensure freshwater balance in the ocean model. This option should be used when the ocean model is driven by a data atmosphere with semi-prescribed precipitation (rain + snow) fluxes.
 
 Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_sfwf_balance_type" type="integer"
-        category="sfwf_forcing" group="sfwf_forcing">
-The option for the water conservation scheme. The default is 0 that used a fixed factor applied on the precipitation fluxes. option 1 used the dynamical factor calculated with the annual mean and global mean precipitation (rain + snow), runoff and evaporation fluxes over ocean using data spanned for 1-year. 
+	category="sfwf_forcing" group="sfwf_forcing">
+Option to compute scaling factors to ensure freshwater balance in the ocean model. The default (0) uses a prescribed constant factor applied to precipitation fluxes. Option 1 enables a dynamic scaling factor, computed using annual global mean precipitation (rain + snow) and sea surface height changes over one-year or multi-year period.
 
 Valid values: 0 or 1 
 Default: Defined in namelist_defaults.xml
@@ -1280,20 +1280,35 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_precip_factor" type="real"
         category="sfwf_forcing" group="sfwf_forcing">
-Factors applied on precipitation flux to adjust freshwater conservation in ocean model. 
+Initial guess scaling factors applied to precipitation fluxes to adjust the freshwater balance in the ocean model.
 
-Valid values: any non-negative value, no scaling if if set to 1.0
+Valid values: any non-negative number between 0 and 1.0. A value of 1.0 means no scaling is applied.
 Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_sfwf_history_years" type="integer"
         category="sfwf_forcing" group="sfwf_forcing">
-The number of years over for which the history span of water balance is computed. The default is 1 year.
+The number of years over which the water balance history is computed. The default is 1 year.
 
-Valid values: Any positive integer
+Valid values: must be a positive integer greater than or equal to 1.
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_sfwf_use_prev_factor" type="logical"
+        category="sfwf_forcing" group="sfwf_forcing">
+Logical flag determining whether the newly calculated SFWF factor should use values from the previous timestep.
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_sfwf_balance_write_to_logfile" type="logical"
+        category="sfwf_forcing" group="sfwf_forcing">
+Logical flag indicating whether freshwater balance adjustment information is written to the log file.
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
 
 <!-- coupling -->
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1294,14 +1294,6 @@ Valid values: must be a positive integer greater than or equal to 1.
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_sfwf_use_prev_factor" type="logical"
-        category="sfwf_forcing" group="sfwf_forcing">
-Logical flag determining whether the newly calculated SFWF factor should use values from the previous timestep.
-
-Valid values: .true. or .false.
-Default: Defined in namelist_defaults.xml
-</entry>
-
 <entry id="config_sfwf_balance_write_to_logfile" type="logical"
         category="sfwf_forcing" group="sfwf_forcing">
 Logical flag indicating whether freshwater balance adjustment information is written to the log file.

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1286,9 +1286,9 @@ Valid values: any non-negative value, no scaling if if set to 1.0
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_sfwf_history_days" type="integer"
+<entry id="config_sfwf_history_years" type="integer"
         category="sfwf_forcing" group="sfwf_forcing">
-The number of days over for which the history span of water conservation is computed. The default is 365 days (1 years).
+The number of years over for which the history span of water balance is computed. The default is 1 year.
 
 Valid values: Any positive integer
 Default: Defined in namelist_defaults.xml

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1260,8 +1260,50 @@ Valid values: Any positive real number
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<!--sfwf balance -->
+
+<entry id="config_sfwf_balance" type="logical"
+        category="sfwf_forcing" group="sfwf_forcing">
+If true, precipitation fluxes from data atmosphere was adjusted to constrain the freshwater conservation. To be used with data precipitation (rain+snow) fluxes coming from the atmospehre model and runoff fluxes coming from the land model.
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_sfwf_balance_type" type="integer"
+        category="sfwf_forcing" group="sfwf_forcing">
+The option for the water conservation scheme. The default is 0 that used a fixed factor applied on the precipitation fluxes. option 1 used the dynamical factor calculated with the annual mean and global mean precipitation (rain + snow), runoff and evaporation fluxes over ocean using data spanned for 1-year. 
+
+Valid values: 0 or 1 
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_precip_factor" type="real"
+        category="sfwf_forcing" group="sfwf_forcing">
+Factors applied on precipitation flux to adjust freshwater conservation in ocean model. 
+
+Valid values: any non-negative value, no scaling if if set to 1.0
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_sfwf_history_days" type="integer"
+        category="sfwf_forcing" group="sfwf_forcing">
+The number of days over for which the history span of water conservation is computed. The default is 365 days (1 years).
+
+Valid values: Any positive integer
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- coupling -->
+
+<entry id="config_ais_ice_runoff_history_days" type="integer"
+	category="coupling" group="coupling">
+The number of days over for which the history of removed AIS runoff is stored. The default is 731 days (2 years + 1 day).
+
+Valid values: Any positive integer
+Default: Defined in namelist_defaults.xml
+</entry>
 
 <entry id="config_remove_ais_river_runoff" type="logical"
 	category="coupling" group="coupling">

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1262,41 +1262,49 @@ Default: Defined in namelist_defaults.xml
 
 <!--sfwf forcing -->
 
-<entry id="config_sfwf_balance" type="logical"
-	category="sfwf_forcing" group="sfwf_forcing">
-If true, precipitation fluxes from the data atmosphere are adjusted to ensure freshwater balance in the ocean model. This option should be used when the ocean model is driven by a data atmosphere with semi-prescribed precipitation (rain + snow) fluxes.
+<entry id="config_use_precip_scaling" type="logical"
+	category="precip_scaling" group="precip_scaling">
+If true, precipitation fluxes are scalled to ensure freshwater balance in the ocean model. This option should be used when the ocean model is driven by a data atmosphere with prescribed precipitation (rain + snow) fluxes.
 
 Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_sfwf_balance_type" type="integer"
-	category="sfwf_forcing" group="sfwf_forcing">
-Option to compute scaling factors to ensure freshwater balance in the ocean model. The default (0) uses a prescribed constant factor applied to precipitation fluxes. Option 1 enables a dynamic scaling factor, computed using annual global mean precipitation (rain + snow) and sea surface height changes over one-year or multi-year period.
+<entry id="config_precip_scaling_mode" type="char*1024"
+	category="precip_scaling" group="precip_scaling">
+Option for precipitation scaling to ensure freshwater balance in the ocean model. config_precip_scaling_mode='constant' uses a prescribed constant factor applied to precipitation fluxes. config_precip_scaling_mode='time-dependent' enables the dynamical caclulation of scaling factors using annual and global mean precipitation (rain + snow) and sea surface height changes over one-year or multi-year period.
 
-Valid values: 0 or 1 
+Valid values: 'constant' or 'time-dependent' 
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_precip_factor" type="real"
-        category="sfwf_forcing" group="sfwf_forcing">
-Initial guess scaling factors applied to precipitation fluxes to adjust the freshwater balance in the ocean model.
+<entry id="config_precip_scaling_initial_factor" type="real"
+        category="precip_scaling" group="precip_scaling">
+Initial guess scaling factor on precipitation for config_precip_scaling_mode = 'time-dependent'.
+
+Valid values: any non-negative number between 0 and 1.0. A value of 1.0 means no scaling.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_precip_scaling_constant_factor" type="real"
+        category="precip_scaling" group="precip_scaling">
+Prescribed constant scaling factor on precipitation for config_precip_scaling_mode = 'constant'.
 
 Valid values: any non-negative number between 0 and 1.0. A value of 1.0 means no scaling is applied.
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_sfwf_history_years" type="integer"
-        category="sfwf_forcing" group="sfwf_forcing">
-The number of years over which the water balance history is computed. The default is 1 year.
+<entry id="config_precip_scaling_history_years" type="integer"
+        category="precip_scaling" group="precip_scaling">
+The number of years over which precipitation scaling factor is computed. The default is 1 year.
 
 Valid values: must be a positive integer greater than or equal to 1.
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_sfwf_balance_write_to_logfile" type="logical"
-        category="sfwf_forcing" group="sfwf_forcing">
-Logical flag indicating whether freshwater balance adjustment information is written to the log file.
+<entry id="config_precip_scaling_write_to_logfile" type="logical"
+        category="precip_scaling" group="precip_scaling">
+Logical flag indicating whether precipitation flux scaling information is written to the log file.
 
 Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1260,7 +1260,7 @@ Valid values: Any positive real number
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<!--sfwf forcing -->
+<!--precip scaling -->
 
 <entry id="config_use_precip_scaling" type="logical"
 	category="precip_scaling" group="precip_scaling">

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1260,11 +1260,12 @@ Valid values: Any positive real number
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<!--precip scaling -->
+
+<!-- precip_scaling -->
 
 <entry id="config_use_precip_scaling" type="logical"
 	category="precip_scaling" group="precip_scaling">
-If true, precipitation fluxes are scalled to ensure freshwater balance in the ocean model. This option should be used when the ocean model is driven by a data atmosphere with prescribed precipitation (rain + snow) fluxes.
+If enabled, precipitation fluxes from the data atmosphere are scalled to ensure freshwater balance in the ocean model.
 
 Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
@@ -1272,53 +1273,46 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_precip_scaling_mode" type="char*1024"
 	category="precip_scaling" group="precip_scaling">
-Option for precipitation scaling to ensure freshwater balance in the ocean model. config_precip_scaling_mode='constant' uses a prescribed constant factor applied to precipitation fluxes. config_precip_scaling_mode='time-dependent' enables the dynamical caclulation of scaling factors using annual and global mean precipitation (rain + snow) and sea surface height changes over one-year or multi-year period.
+Option for precipitation scaling to ensure freshwater balance in the ocean model.
 
-Valid values: 'constant' or 'time-dependent' 
+Valid values: 'constant' or 'time-dependent'
 Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_precip_scaling_initial_factor" type="real"
-        category="precip_scaling" group="precip_scaling">
+	category="precip_scaling" group="precip_scaling">
 Initial guess scaling factor on precipitation for config_precip_scaling_mode = 'time-dependent'.
 
-Valid values: any non-negative number between 0 and 1.0. A value of 1.0 means no scaling.
+Valid values: Any non-negative value ranged from 0 to 1.0, no scaling if set to 1.0
 Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_precip_scaling_constant_factor" type="real"
-        category="precip_scaling" group="precip_scaling">
+	category="precip_scaling" group="precip_scaling">
 Prescribed constant scaling factor on precipitation for config_precip_scaling_mode = 'constant'.
 
-Valid values: any non-negative number between 0 and 1.0. A value of 1.0 means no scaling is applied.
+Valid values: Any non-negative value ranged from 0 to 1.0, no scaling if set to 1.0
 Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_precip_scaling_history_years" type="integer"
-        category="precip_scaling" group="precip_scaling">
-The number of years over which precipitation scaling factor is computed. The default is 1 year.
+	category="precip_scaling" group="precip_scaling">
+The number of years over for which the history span of precipitational scaling factor is computed.
 
-Valid values: must be a positive integer greater than or equal to 1.
+Valid values: Must be a positive integer greater than or equal to 1.
 Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_precip_scaling_write_to_logfile" type="logical"
-        category="precip_scaling" group="precip_scaling">
+	category="precip_scaling" group="precip_scaling">
 Logical flag indicating whether precipitation flux scaling information is written to the log file.
 
 Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
+
 <!-- coupling -->
-
-<entry id="config_ais_ice_runoff_history_days" type="integer"
-	category="coupling" group="coupling">
-The number of days over for which the history of removed AIS runoff is stored. The default is 731 days (2 years + 1 day).
-
-Valid values: Any positive integer
-Default: Defined in namelist_defaults.xml
-</entry>
 
 <entry id="config_remove_ais_river_runoff" type="logical"
 	category="coupling" group="coupling">

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1261,11 +1261,11 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 
-<!-- precip_scaling -->
+<!-- precip scaling -->
 
 <entry id="config_use_precip_scaling" type="logical"
 	category="precip_scaling" group="precip_scaling">
-If enabled, precipitation fluxes from the data atmosphere are scalled to ensure freshwater balance in the ocean model.
+If true, precipitation fluxes will be scalled to ensure freshwater balance in FOSI runs referring to forced ocean-sea ice simulation where ocean model is driven by a data atmosphere with prescribed precipitation (rain + snow) fluxes.
 
 Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
@@ -1273,39 +1273,39 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_precip_scaling_mode" type="char*1024"
 	category="precip_scaling" group="precip_scaling">
-Option for precipitation scaling to ensure freshwater balance in the ocean model.
+Option for scaling precipitation fluxes to ensure freshwater balance in FOSI runs. config_precip_scaling_mode='constant' uses a prescribed constant factor applied to precipitation fluxes. config_precip_scaling_mode='time-dependent' enables the dynamical caclulation of scaling factors using annual and global mean precipitation (rain + snow) and sea surface height changes over one-year or multi-year period.
 
-Valid values: 'constant' or 'time-dependent'
+Valid values: 'off', 'constant' or 'time-dependent'
 Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_precip_scaling_initial_factor" type="real"
 	category="precip_scaling" group="precip_scaling">
-Initial guess scaling factor on precipitation for config_precip_scaling_mode = 'time-dependent'.
+Initial guess scaling factor on precipitation fluxes in FOSI runs when config_precip_scaling_mode = 'time-dependent'.
 
-Valid values: Any non-negative value ranged from 0 to 1.0, no scaling if set to 1.0
+Valid values: Non-negative number between 0 and 1.0. Default value of 1.0 means no scaling.
 Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_precip_scaling_constant_factor" type="real"
 	category="precip_scaling" group="precip_scaling">
-Prescribed constant scaling factor on precipitation for config_precip_scaling_mode = 'constant'.
+Prescribed constant scaling factor on precipitation fluxes in FOSI runs when config_precip_scaling_mode = 'constant'.
 
-Valid values: Any non-negative value ranged from 0 to 1.0, no scaling if set to 1.0
+Valid values: Non-negative number between 0 and 1.0. Default value of 1.0 means no scaling.
 Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_precip_scaling_history_years" type="integer"
 	category="precip_scaling" group="precip_scaling">
-The number of years over for which the history span of precipitational scaling factor is computed.
+The number of years over which scaling factor on precipitation fluxes is computed in FOSI runs. Default value is 1 year.
 
-Valid values: Must be a positive integer greater than or equal to 1.
+Valid values: Positive integer greater than or equal to 1.
 Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_precip_scaling_write_to_logfile" type="logical"
 	category="precip_scaling" group="precip_scaling">
-Logical flag indicating whether precipitation flux scaling information is written to the log file.
+Logical flag indicating whether information for precipitation flux scaling in FOSI runs will be written to the log file.
 
 Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1261,7 +1261,7 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 
-<!-- precip scaling -->
+<!-- precip_scaling -->
 
 <entry id="config_use_precip_scaling" type="logical"
 	category="precip_scaling" group="precip_scaling">

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/precip_scaling_jra_1958/README
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/precip_scaling_jra_1958/README
@@ -1,0 +1,10 @@
+This testdef is used to test a stealth feature in mpaso introduced by
+PR #7361. It simplies changes one mpaso namelist variable,
+    config_use_precip_scaling
+from its default value of .false. to .true.. It also sets associated
+variables,
+    config_precip_scaling_mode
+    config_precip_scaling_constant_factor
+for testing. This particular testdef also limmits the required JRA
+forcing data to a single year to reduce the number of files needed for
+testing.

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/precip_scaling_jra_1958/shell_commands
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/precip_scaling_jra_1958/shell_commands
@@ -1,0 +1,4 @@
+./xmlchange DATM_CLMNCEP_YR_START=1958
+./xmlchange DATM_CLMNCEP_YR_END=1958
+./xmlchange DROF_STRM_YR_START=1958
+./xmlchange DROF_STRM_YR_END=1958

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/precip_scaling_jra_1958/user_nl_mpaso
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/precip_scaling_jra_1958/user_nl_mpaso
@@ -1,0 +1,3 @@
+config_use_precip_scaling = .true.
+config_precip_scaling_mode = 'constant'
+config_precip_scaling_constant_factor = 0.95

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -70,7 +70,7 @@ module ocn_comp_mct
    use ocn_submesoscale_eddies
    use ocn_eddy_parameterization_helpers
    use ocn_scaled_dismf
-!  use ocn_forcing_sfwf 
+   use ocn_scaled_sfwf
 !
 ! !PUBLIC MEMBER FUNCTIONS:
   implicit none
@@ -243,6 +243,7 @@ contains
     logical, pointer :: config_sfwf_balance
     integer, pointer :: config_sfwf_balance_type
     real (kind=RKIND), pointer :: config_precip_factor
+    real (kind=RKIND), pointer :: SFWFScalingFactor ! scaling factor on freshwater fluxes 
 
 #ifdef HAVE_MOAB
     character*100 outfile, wopts
@@ -838,6 +839,10 @@ contains
 
        ! initialize scaled data ice-shelf melt fluxes based on remove ice runoff
        call ocn_init_scaled_dismf(domain)
+
+       ! initialize scaled data freshwater fluxes based on water balance relationship 
+       call ocn_init_scaled_sfwf(domain)
+
     end if
 
 !-----------------------------------------------------------------------
@@ -886,6 +891,10 @@ contains
 
       ! initialize scaled data ice-shelf melt fluxes based on remove ice runoff
        call ocn_init_scaled_dismf(domain)
+
+      ! initialize scaled data freshwater fluxes based on water balance relationship 
+       call ocn_init_scaled_sfwf(domain)
+
     end if
 
     call t_stopf ('mpaso_mct_init')
@@ -926,18 +935,18 @@ contains
     end if
 
     !configuration for freshwater conservation
-    call mpas_pool_get_config(domain % configs, 'config_sfwf_balance', &
-                              config_sfwf_balance)
-    call mpas_pool_get_config(domain % configs, 'config_sfwf_balance_type', &
-                              config_sfwf_balance_type)
-    call mpas_pool_get_config(domain % configs, 'config_precip_factor', &
-                              config_precip_factor)
-
+    call mpas_pool_get_config(domain % configs, 'config_sfwf_balance', config_sfwf_balance)
     if (config_sfwf_balance) then 
-       if (config_sfwf_balance_type == 0 ) then 
-          precFactor = config_precip_factor
-       else 
-          precFactor = 1.0
+       call mpas_pool_get_config(domain % configs, 'config_sfwf_balance_type', config_sfwf_balance_type)
+       call mpas_pool_get_config(domain % configs, 'config_precip_factor', config_precip_factor)
+       if (config_sfwf_balance_type > 0) then 
+         ! independent of space so should be no need to loop over blocks
+         block_ptr => domain % blocklist
+         call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
+         call MPAS_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
+         ! initialize the scaling factor  as config_precip_factor
+         SFWFScalingFactor = config_precip_factor 
+         call seq_infodata_PutData(infodata, precip_fact=SFWFScalingFactor)
        end if 
     end if 
 
@@ -1061,6 +1070,11 @@ contains
       real (kind=RKIND), dimension(:,:), pointer :: avgSSHGradient
       real (kind=RKIND), pointer :: &
          runningMeanRemovedIceRunoff ! the area integrated, running mean of removed ice runoff from the ocean
+
+      ! freshwater balance adjustment 
+      logical, pointer :: config_sfwf_balance
+      integer, pointer :: config_sfwf_balance_type
+      real (kind=RKIND), pointer :: SFWFScalingFactor ! scaling factor on freshwater fluxes 
 
 #ifdef HAVE_MOAB
 #ifdef MOABCOMP
@@ -1266,6 +1280,9 @@ contains
         ! update scaled data ice-shelf melt fluxes based on remove ice runoff
         call ocn_update_scaled_dismf(domain)
 
+        ! update scalling factors for freshwater fluxes 
+        call ocn_update_scaling_factor(domain)
+
          if (debugOn) call mpas_log_write('   Computing analysis members')
          call ocn_analysis_compute(domain_ptr, ierr)
          if (iam==0.and.debugOn) then
@@ -1372,6 +1389,19 @@ contains
          call MPAS_pool_get_array(forcingPool, "runningMeanRemovedIceRunoff", &
                                   runningMeanRemovedIceRunoff)
          call seq_infodata_PutData(infodata, rmean_rmv_ice_runoff=runningMeanRemovedIceRunoff)
+      end if
+
+      !configuration for freshwater conservation
+      call mpas_pool_get_config(domain % configs, 'config_sfwf_balance', config_sfwf_balance)
+      if (config_sfwf_balance) then
+         call mpas_pool_get_config(domain % configs, 'config_sfwf_balance_type', config_sfwf_balance_type)
+         if (config_sfwf_balance_type > 0) then
+           ! independent of space so should be no need to loop over blocks
+           block_ptr => domain % blocklist
+           call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
+           call MPAS_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
+           call seq_infodata_PutData(infodata, precip_fact=SFWFScalingFactor)
+         end if
       end if
 
       ! Reset I/O logs
@@ -1998,7 +2028,11 @@ contains
                                      ecosysSeaIceCoupling, &
                                      DMSSeaIceCoupling,    &
                                      MacroMoleculesSeaIceCoupling,      &
-                                     CFCAuxiliary
+                                     CFCAuxiliary, &
+                                     conservationCheckEnergyAMPool, &
+                                     conservationCheckMassAMPool, &
+                                     conservationCheckSaltAMPool, &
+                                     conservationCheckCarbonAMPool
 
    integer, pointer :: nCellsSolve
 
@@ -2110,6 +2144,12 @@ contains
 
    real (kind=RKIND) :: riverFactor
 
+   ! freshwater balance adjustment 
+   logical, pointer :: config_sfwf_balance
+   integer, pointer :: config_sfwf_balance_type
+   real (kind=RKIND), pointer :: config_precip_factor
+   real (kind=RKIND), pointer :: SFWFScalingFactor ! scaling factor on freshwater fluxes 
+
 !-----------------------------------------------------------------------
 !
 !  zero out padded cells
@@ -2140,6 +2180,23 @@ contains
    call mpas_pool_get_config(domain % configs, 'config_remove_ais_river_runoff', config_remove_ais_river_runoff)
    call mpas_pool_get_config(domain % configs, 'config_remove_ais_ice_runoff', config_remove_ais_ice_runoff)
    call mpas_pool_get_config(domain % configs, 'config_cvmix_kpp_use_theory_wave', config_cvmix_kpp_use_theory_wave)
+
+   !configuration for freshwater balance constrains 
+   call mpas_pool_get_config(domain % configs, 'config_sfwf_balance', config_sfwf_balance)
+   if (config_sfwf_balance) then
+      call mpas_pool_get_config(domain % configs, 'config_sfwf_balance_type', config_sfwf_balance_type)
+      if (config_sfwf_balance_type == 0 ) then
+        call mpas_pool_get_config(domain % configs, 'config_precip_factor', config_precip_factor)
+        precFactor = config_precip_factor
+      else 
+        ! independent of space so should be no need to loop over blocks
+        block_ptr => domain % blocklist
+        call MPAS_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
+        precFactor = SFWFScalingFactor
+      end if
+   else
+      precFactor = 1.0_RKIND 
+   end if
 
    n = 0
    removedRiverRunoffFluxThisProc = 0.0_RKIND

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -240,9 +240,10 @@ contains
        runningMeanRemovedIceRunoff ! the area integrated, running mean of removed ice runoff from the ocean
 
     ! freshwater balance adjustment 
-    logical, pointer :: config_sfwf_balance
-    integer, pointer :: config_sfwf_balance_type
-    real (kind=RKIND), pointer :: config_precip_factor
+    logical, pointer :: config_use_precip_scaling
+    character (len=StrKIND), pointer :: config_precip_scaling_mode
+    real (kind=RKIND), pointer :: config_precip_scaling_initial_factor
+    real (kind=RKIND), pointer :: config_precip_scaling_constant_factor
     real (kind=RKIND), pointer :: SFWFScalingFactor ! scaling factor on freshwater fluxes 
 
 #ifdef HAVE_MOAB
@@ -843,16 +844,16 @@ contains
        ! Initialize the freshwater flux scaling scheme based on the ocean water balance relationship
        call ocn_init_scaled_sfwf(domain)
        ! Ensure the first guess is initialized to enable dynamic adjustment of the precipitation scaling factor
-       call mpas_pool_get_config(domain % configs, 'config_sfwf_balance', config_sfwf_balance)
-       if (config_sfwf_balance) then
-          call mpas_pool_get_config(domain % configs, 'config_sfwf_balance_type', config_sfwf_balance_type)
-          if (config_sfwf_balance_type > 0) then
-            call mpas_pool_get_config(domain % configs, 'config_precip_factor', config_precip_factor)
+       call mpas_pool_get_config(domain % configs, 'config_use_precip_scaling', config_use_precip_scaling)
+       if (config_use_precip_scaling) then
+          call mpas_pool_get_config(domain % configs, 'config_precip_scaling_mode', config_precip_scaling_mode)
+          if (trim(config_precip_scaling_mode) == 'time-dependent') then 
+            call mpas_pool_get_config(domain % configs, 'config_precip_scaling_initial_factor', config_precip_scaling_initial_factor)
             ! independent of space so should be no need to loop over blocks
             block_ptr => domain % blocklist
             call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
             call mpas_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
-            SFWFScalingFactor = config_precip_factor
+            SFWFScalingFactor = config_precip_scaling_initial_factor
           end if
        end if
     end if
@@ -947,15 +948,18 @@ contains
     end if
 
     !configuration for freshwater conservation
-    call mpas_pool_get_config(domain % configs, 'config_sfwf_balance', config_sfwf_balance)
-    if (config_sfwf_balance) then 
-       call mpas_pool_get_config(domain % configs, 'config_sfwf_balance_type', config_sfwf_balance_type)
-       if (config_sfwf_balance_type > 0) then
+    call mpas_pool_get_config(domain % configs, 'config_use_precip_scaling', config_use_precip_scaling)
+    if (config_use_precip_scaling) then 
+       call mpas_pool_get_config(domain % configs, 'config_precip_scaling_mode', config_precip_scaling_mode)
+       if (trim(config_precip_scaling_mode) == 'time-dependent') then 
          ! independent of space so should be no need to loop over blocks
          block_ptr => domain % blocklist
          call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
          call mpas_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
          call seq_infodata_PutData(infodata, precip_fact=SFWFScalingFactor)
+       else if (trim(config_precip_scaling_mode) == 'constant') then
+         call mpas_pool_get_config(domain % configs, 'config_precip_scaling_constant_factor', config_precip_scaling_constant_factor)
+         call seq_infodata_PutData(infodata, precip_fact=config_precip_scaling_constant_factor)
        end if 
     end if 
 
@@ -1081,9 +1085,10 @@ contains
          runningMeanRemovedIceRunoff ! the area integrated, running mean of removed ice runoff from the ocean
 
       ! freshwater balance adjustment 
-      logical, pointer :: config_sfwf_balance
-      integer, pointer :: config_sfwf_balance_type
+      logical, pointer :: config_use_precip_scaling
+      character (len=StrKIND), pointer :: config_precip_scaling_mode
       real (kind=RKIND), pointer :: SFWFScalingFactor ! scaling factor on freshwater fluxes 
+      real (kind=RKIND), pointer :: config_precip_scaling_constant_factor
 
 #ifdef HAVE_MOAB
 #ifdef MOABCOMP
@@ -1401,15 +1406,18 @@ contains
       end if
 
       !configuration for freshwater conservation
-      call mpas_pool_get_config(domain % configs, 'config_sfwf_balance', config_sfwf_balance)
-      if (config_sfwf_balance) then
-         call mpas_pool_get_config(domain % configs, 'config_sfwf_balance_type', config_sfwf_balance_type)
-         if (config_sfwf_balance_type > 0) then
+      call mpas_pool_get_config(domain % configs, 'config_use_precip_scaling', config_use_precip_scaling)
+      if (config_use_precip_scaling) then
+         call mpas_pool_get_config(domain % configs, 'config_precip_scaling_mode', config_precip_scaling_mode)
+         if (trim(config_precip_scaling_mode)  == 'time-dependent') then
            ! independent of space so should be no need to loop over blocks
            block_ptr => domain % blocklist
            call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
            call mpas_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
            call seq_infodata_PutData(infodata, precip_fact=SFWFScalingFactor)
+         else if (trim(config_precip_scaling_mode)  == 'constant') then
+           call mpas_pool_get_config(domain % configs,'config_precip_scaling_constant_factor',config_precip_scaling_constant_factor) 
+           call seq_infodata_PutData(infodata, precip_fact=config_precip_scaling_constant_factor)
          end if
       end if
 
@@ -2154,9 +2162,7 @@ contains
    real (kind=RKIND) :: riverFactor
 
    ! freshwater balance adjustment 
-   logical, pointer :: config_sfwf_balance
-   integer, pointer :: config_sfwf_balance_type
-   real (kind=RKIND), pointer :: config_precip_factor
+   logical, pointer :: config_use_precip_scaling
 
 !-----------------------------------------------------------------------
 !
@@ -2189,18 +2195,12 @@ contains
    call mpas_pool_get_config(domain % configs, 'config_remove_ais_ice_runoff', config_remove_ais_ice_runoff)
    call mpas_pool_get_config(domain % configs, 'config_cvmix_kpp_use_theory_wave', config_cvmix_kpp_use_theory_wave)
 
-   !configuration for freshwater balance constrains 
-   call mpas_pool_get_config(domain % configs, 'config_sfwf_balance', config_sfwf_balance)
-   call mpas_pool_get_config(domain % configs, 'config_sfwf_balance_type', config_sfwf_balance_type)
-   call mpas_pool_get_config(domain % configs, 'config_precip_factor', config_precip_factor)
-   if (config_sfwf_balance) then
-      if (config_sfwf_balance_type > 0 ) then
-         call seq_infodata_GetData(infodata, precip_fact=precFactor)
-      else 
-         precFactor = config_precip_factor
-      end if
-   else
-      precFactor = 1.0_RKIND 
+   precFactor = 1.0_RKIND  ! Default to no scaling
+   !configuration for freshwater balance constrains
+   call mpas_pool_get_config(domain % configs, 'config_use_precip_scaling', config_use_precip_scaling)
+   if (config_use_precip_scaling) then
+      !extract scaling factors 
+      call seq_infodata_GetData(infodata, precip_fact=precFactor)
    end if
 
    n = 0

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -1280,9 +1280,6 @@ contains
         ! update scaled data ice-shelf melt fluxes based on remove ice runoff
         call ocn_update_scaled_dismf(domain)
 
-        ! update scalling factors for freshwater fluxes 
-        call ocn_update_scaling_factor(domain)
-
          if (debugOn) call mpas_log_write('   Computing analysis members')
          call ocn_analysis_compute(domain_ptr, ierr)
          if (iam==0.and.debugOn) then
@@ -1320,6 +1317,9 @@ contains
             call mpas_log_write('   Finished writing output streams')
             call mpas_log_write('   Validating ocean state')
          endif
+
+        ! update scalling factors for freshwater fluxes 
+        call ocn_update_scaling_factor(domain, timeLevel=1)
 
          call ocn_validate_state(domain, timeLevel=1)
          if (debugOn) call mpas_log_write('   Completed validating ocean state')

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -2148,7 +2148,6 @@ contains
    logical, pointer :: config_sfwf_balance
    integer, pointer :: config_sfwf_balance_type
    real (kind=RKIND), pointer :: config_precip_factor
-   real (kind=RKIND), pointer :: SFWFScalingFactor ! scaling factor on freshwater fluxes 
 
 !-----------------------------------------------------------------------
 !
@@ -2183,17 +2182,13 @@ contains
 
    !configuration for freshwater balance constrains 
    call mpas_pool_get_config(domain % configs, 'config_sfwf_balance', config_sfwf_balance)
+   call mpas_pool_get_config(domain % configs, 'config_sfwf_balance_type', config_sfwf_balance_type)
+   call mpas_pool_get_config(domain % configs, 'config_precip_factor', config_precip_factor)
    if (config_sfwf_balance) then
-      call mpas_pool_get_config(domain % configs, 'config_sfwf_balance_type', config_sfwf_balance_type)
       if (config_sfwf_balance_type == 0 ) then
-        call mpas_pool_get_config(domain % configs, 'config_precip_factor', config_precip_factor)
-        precFactor = config_precip_factor
+          precFactor = config_precip_factor
       else 
-        ! independent of space so should be no need to loop over blocks
-        block_ptr => domain % blocklist
-        call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
-        call mpas_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
-        precFactor = SFWFScalingFactor
+          call seq_infodata_GetData(infodata, precip_fact=precFactor)
       end if
    else
       precFactor = 1.0_RKIND 

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -841,7 +841,7 @@ contains
        call ocn_init_scaled_dismf(domain)
 
        ! Initialize the precipitation scaling scheme 
-       call ocn_init_scaled_sfwf(domain)
+       call ocn_scaled_sfwf_init(domain)
        ! Ensure a valid first guess at the initial time 
        call mpas_pool_get_config(domain % configs, 'config_use_precip_scaling', config_use_precip_scaling)
        if (config_use_precip_scaling) then
@@ -908,7 +908,7 @@ contains
        call ocn_init_scaled_dismf(domain)
 
       ! initialize scaled data freshwater fluxes based on water balance relationship 
-       call ocn_init_scaled_sfwf(domain)
+       call ocn_scaled_sfwf_init(domain)
 
     end if
 

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -840,9 +840,21 @@ contains
        ! initialize scaled data ice-shelf melt fluxes based on remove ice runoff
        call ocn_init_scaled_dismf(domain)
 
-       ! initialize scaled data freshwater fluxes based on water balance relationship 
+       ! Initialize the freshwater flux scaling scheme based on the ocean water balance relationship
        call ocn_init_scaled_sfwf(domain)
-
+       ! Ensure the first guess is initialized to enable dynamic adjustment of the precipitation scaling factor
+       call mpas_pool_get_config(domain % configs, 'config_sfwf_balance', config_sfwf_balance)
+       if (config_sfwf_balance) then
+          call mpas_pool_get_config(domain % configs, 'config_sfwf_balance_type', config_sfwf_balance_type)
+          if (config_sfwf_balance_type > 0) then
+            call mpas_pool_get_config(domain % configs, 'config_precip_factor', config_precip_factor)
+            ! independent of space so should be no need to loop over blocks
+            block_ptr => domain % blocklist
+            call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
+            call mpas_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
+            SFWFScalingFactor = config_precip_factor
+          end if
+       end if
     end if
 
 !-----------------------------------------------------------------------
@@ -939,13 +951,10 @@ contains
     if (config_sfwf_balance) then 
        call mpas_pool_get_config(domain % configs, 'config_sfwf_balance_type', config_sfwf_balance_type)
        if (config_sfwf_balance_type > 0) then
-         call mpas_pool_get_config(domain % configs, 'config_precip_factor', config_precip_factor)
          ! independent of space so should be no need to loop over blocks
          block_ptr => domain % blocklist
          call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
          call mpas_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
-         ! initialize the scaling factor  as config_precip_factor
-         SFWFScalingFactor = config_precip_factor 
          call seq_infodata_PutData(infodata, precip_fact=SFWFScalingFactor)
        end if 
     end if 
@@ -2185,10 +2194,10 @@ contains
    call mpas_pool_get_config(domain % configs, 'config_sfwf_balance_type', config_sfwf_balance_type)
    call mpas_pool_get_config(domain % configs, 'config_precip_factor', config_precip_factor)
    if (config_sfwf_balance) then
-      if (config_sfwf_balance_type == 0 ) then
-          precFactor = config_precip_factor
+      if (config_sfwf_balance_type > 0 ) then
+         call seq_infodata_GetData(infodata, precip_fact=precFactor)
       else 
-          call seq_infodata_GetData(infodata, precip_fact=precFactor)
+         precFactor = config_precip_factor
       end if
    else
       precFactor = 1.0_RKIND 

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -242,9 +242,8 @@ contains
     ! freshwater balance adjustment 
     logical, pointer :: config_use_precip_scaling
     character (len=StrKIND), pointer :: config_precip_scaling_mode
-    real (kind=RKIND), pointer :: config_precip_scaling_initial_factor
-    real (kind=RKIND), pointer :: config_precip_scaling_constant_factor
     real (kind=RKIND), pointer :: SFWFScalingFactor ! scaling factor on freshwater fluxes 
+    real(kind=RKIND), pointer :: scalingFactor
 
 #ifdef HAVE_MOAB
     character*100 outfile, wopts
@@ -841,20 +840,23 @@ contains
        ! initialize scaled data ice-shelf melt fluxes based on remove ice runoff
        call ocn_init_scaled_dismf(domain)
 
-       ! Initialize the freshwater flux scaling scheme based on the ocean water balance relationship
+       ! Initialize the precipitation scaling scheme 
        call ocn_init_scaled_sfwf(domain)
-       ! Ensure the first guess is initialized to enable dynamic adjustment of the precipitation scaling factor
+       ! Ensure a valid first guess at the initial time 
        call mpas_pool_get_config(domain % configs, 'config_use_precip_scaling', config_use_precip_scaling)
        if (config_use_precip_scaling) then
           call mpas_pool_get_config(domain % configs, 'config_precip_scaling_mode', config_precip_scaling_mode)
+          ! independent of space so should be no need to loop over blocks
+          block_ptr => domain % blocklist
+          call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
+          call mpas_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
           if (trim(config_precip_scaling_mode) == 'time-dependent') then 
-            call mpas_pool_get_config(domain % configs, 'config_precip_scaling_initial_factor', config_precip_scaling_initial_factor)
-            ! independent of space so should be no need to loop over blocks
-            block_ptr => domain % blocklist
-            call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
-            call mpas_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
-            SFWFScalingFactor = config_precip_scaling_initial_factor
+            call mpas_pool_get_config(domain % configs, 'config_precip_scaling_initial_factor', scalingFactor)
+          else if (trim(config_precip_scaling_mode) == 'constant') then
+            call mpas_pool_get_config(domain % configs, 'config_precip_scaling_constant_factor', scalingFactor) 
           end if
+          ! Broadcast the scalar to the field
+          SFWFScalingFactor = scalingFactor
        end if
     end if
 
@@ -950,17 +952,11 @@ contains
     !configuration for freshwater conservation
     call mpas_pool_get_config(domain % configs, 'config_use_precip_scaling', config_use_precip_scaling)
     if (config_use_precip_scaling) then 
-       call mpas_pool_get_config(domain % configs, 'config_precip_scaling_mode', config_precip_scaling_mode)
-       if (trim(config_precip_scaling_mode) == 'time-dependent') then 
-         ! independent of space so should be no need to loop over blocks
-         block_ptr => domain % blocklist
-         call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
-         call mpas_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
-         call seq_infodata_PutData(infodata, precip_fact=SFWFScalingFactor)
-       else if (trim(config_precip_scaling_mode) == 'constant') then
-         call mpas_pool_get_config(domain % configs, 'config_precip_scaling_constant_factor', config_precip_scaling_constant_factor)
-         call seq_infodata_PutData(infodata, precip_fact=config_precip_scaling_constant_factor)
-       end if 
+      ! independent of space so should be no need to loop over blocks
+      block_ptr => domain % blocklist
+      call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
+      call mpas_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
+      call seq_infodata_PutData(infodata, precip_fact=SFWFScalingFactor)
     end if 
 
 !-----------------------------------------------------------------------
@@ -1086,9 +1082,7 @@ contains
 
       ! freshwater balance adjustment 
       logical, pointer :: config_use_precip_scaling
-      character (len=StrKIND), pointer :: config_precip_scaling_mode
       real (kind=RKIND), pointer :: SFWFScalingFactor ! scaling factor on freshwater fluxes 
-      real (kind=RKIND), pointer :: config_precip_scaling_constant_factor
 
 #ifdef HAVE_MOAB
 #ifdef MOABCOMP
@@ -1408,17 +1402,11 @@ contains
       !configuration for freshwater conservation
       call mpas_pool_get_config(domain % configs, 'config_use_precip_scaling', config_use_precip_scaling)
       if (config_use_precip_scaling) then
-         call mpas_pool_get_config(domain % configs, 'config_precip_scaling_mode', config_precip_scaling_mode)
-         if (trim(config_precip_scaling_mode)  == 'time-dependent') then
-           ! independent of space so should be no need to loop over blocks
-           block_ptr => domain % blocklist
-           call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
-           call mpas_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
-           call seq_infodata_PutData(infodata, precip_fact=SFWFScalingFactor)
-         else if (trim(config_precip_scaling_mode)  == 'constant') then
-           call mpas_pool_get_config(domain % configs,'config_precip_scaling_constant_factor',config_precip_scaling_constant_factor) 
-           call seq_infodata_PutData(infodata, precip_fact=config_precip_scaling_constant_factor)
-         end if
+         ! independent of space so should be no need to loop over blocks
+         block_ptr => domain % blocklist
+         call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
+         call mpas_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
+         call seq_infodata_PutData(infodata, precip_fact=SFWFScalingFactor)
       end if
 
       ! Reset I/O logs

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -70,6 +70,7 @@ module ocn_comp_mct
    use ocn_submesoscale_eddies
    use ocn_eddy_parameterization_helpers
    use ocn_scaled_dismf
+!  use ocn_forcing_sfwf 
 !
 ! !PUBLIC MEMBER FUNCTIONS:
   implicit none
@@ -122,6 +123,8 @@ module ocn_comp_mct
    type (domain_type), pointer:: domain
    integer :: itimestep, &  ! time step number for MPAS
               ocn_cpl_dt    ! length of coupling interval in seconds - set by coupler/ESMF
+
+   real (kind=RKIND) :: precFactor 
 
 !=======================================================================
 
@@ -235,6 +238,11 @@ contains
     real (kind=RKIND), dimension(:,:), pointer :: avgSSHGradient
     real (kind=RKIND), pointer :: &
        runningMeanRemovedIceRunoff ! the area integrated, running mean of removed ice runoff from the ocean
+
+    ! freshwater balance adjustment 
+    logical, pointer :: config_sfwf_balance
+    integer, pointer :: config_sfwf_balance_type
+    real (kind=RKIND), pointer :: config_precip_factor
 
 #ifdef HAVE_MOAB
     character*100 outfile, wopts
@@ -916,6 +924,22 @@ contains
        call mpas_log_write('ERROR: unknown config_glc_thermal_forcing_coupling_mode: ' // &
                trim(config_glc_thermal_forcing_coupling_mode), MPAS_LOG_CRIT)
     end if
+
+    !configuration for freshwater conservation
+    call mpas_pool_get_config(domain % configs, 'config_sfwf_balance', &
+                              config_sfwf_balance)
+    call mpas_pool_get_config(domain % configs, 'config_sfwf_balance_type', &
+                              config_sfwf_balance_type)
+    call mpas_pool_get_config(domain % configs, 'config_precip_factor', &
+                              config_precip_factor)
+
+    if (config_sfwf_balance) then 
+       if (config_sfwf_balance_type == 0 ) then 
+          precFactor = config_precip_factor
+       else 
+          precFactor = 1.0
+       end if 
+    end if 
 
 !-----------------------------------------------------------------------
 !
@@ -2376,7 +2400,7 @@ contains
         end if
 
         if ( rainFluxField % isActive ) then
-           rainFlux(i) = x2o_o % rAttr(index_x2o_Faxa_rain, n)
+           rainFlux(i) = x2o_o % rAttr(index_x2o_Faxa_rain, n) * precFactor
         end if
         if ( atmosphericPressureField % isActive ) then
            atmosphericPressure(i) = x2o_o % rAttr(index_x2o_Sa_pslv,   n)
@@ -3883,7 +3907,7 @@ contains
            icebergHeatFlux(i) = x2o_om(n, index_x2o_Fioi_bergh)
         end if
         if ( snowFluxField % isActive ) then
-           snowFlux(i) = x2o_om(n, index_x2o_Faxa_snow)
+           snowFlux(i) = x2o_om(n, index_x2o_Faxa_snow) * precFactor
         end if
         if ( seaIceFreshWaterFluxField % isActive ) then
            seaIceFreshWaterFlux(i) = x2o_om(n, index_x2o_Fioi_meltw)

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -938,12 +938,12 @@ contains
     call mpas_pool_get_config(domain % configs, 'config_sfwf_balance', config_sfwf_balance)
     if (config_sfwf_balance) then 
        call mpas_pool_get_config(domain % configs, 'config_sfwf_balance_type', config_sfwf_balance_type)
-       call mpas_pool_get_config(domain % configs, 'config_precip_factor', config_precip_factor)
-       if (config_sfwf_balance_type > 0) then 
+       if (config_sfwf_balance_type > 0) then
+         call mpas_pool_get_config(domain % configs, 'config_precip_factor', config_precip_factor)
          ! independent of space so should be no need to loop over blocks
          block_ptr => domain % blocklist
          call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
-         call MPAS_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
+         call mpas_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
          ! initialize the scaling factor  as config_precip_factor
          SFWFScalingFactor = config_precip_factor 
          call seq_infodata_PutData(infodata, precip_fact=SFWFScalingFactor)
@@ -1399,7 +1399,7 @@ contains
            ! independent of space so should be no need to loop over blocks
            block_ptr => domain % blocklist
            call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
-           call MPAS_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
+           call mpas_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
            call seq_infodata_PutData(infodata, precip_fact=SFWFScalingFactor)
          end if
       end if
@@ -2191,7 +2191,8 @@ contains
       else 
         ! independent of space so should be no need to loop over blocks
         block_ptr => domain % blocklist
-        call MPAS_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
+        call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
+        call mpas_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
         precFactor = SFWFScalingFactor
       end if
    else

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -762,10 +762,6 @@
 			                description="The number of years over for which the history span of water balance is computed."
                        			possible_values="Must be a positive integer greater than or equal to 1."
 		/>
-                <nml_option name="config_sfwf_use_prev_factor" type="logical" default_value=".false."
-			                description="Logical flag determining whether the newly calculated SFWF factor should use values from the previous timestep."
-			               possible_values=".true. or .false."
-                />
                 <nml_option name="config_sfwf_balance_write_to_logfile" type="logical" default_value=".false."
 		                       description="Logical flag determining if the freshwater balance adjustment information is written to the log file."
                                        possible_values=".true. or .false."

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -756,11 +756,11 @@
 		/>
 		<nml_option name="config_precip_scaling_initial_factor" type="real" default_value="1.0" units="unitless"
 					description="Initial guess scaling factor on precipitation fluxes in FOSI runs when config_precip_scaling_mode = 'time-dependent'."
-					possible_values="Non-negative number between 0 and 1.0. Default value of 1.0 means no scaling."
+					possible_values="Non-negative number. A default value of 1.0 indicates no scaling, but values greater than 1.0 can be used to scale up precipitation fluxes in order to achieve freshwater balance in FOSI runs."
 		/>
 		<nml_option name="config_precip_scaling_constant_factor" type="real" default_value="1.0" units="unitless"
 					description="Prescribed constant scaling factor on precipitation fluxes in FOSI runs when config_precip_scaling_mode = 'constant'."
-					possible_values="Non-negative number between 0 and 1.0. Default value of 1.0 means no scaling."
+					possible_values="Non-negative number between 0 and 1.0. Default value of 1.0 means no scaling, but values greater than 1.0 can be used to scale up precipitation fluxes in order to achieve freshwater balance in FOSI runs."
 		/>
 		<nml_option name="config_precip_scaling_history_years" type="integer" default_value="1" units="years"
 					description="The number of years over which scaling factor on precipitation fluxes is computed in FOSI runs. Default value is 1 year."

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -747,27 +747,27 @@
 	</nml_record>
 	<nml_record name="precip_scaling" mode="init;forward">
 		<nml_option name="config_use_precip_scaling" type="logical" default_value=".false."
-					description="If enabled, precipitation fluxes from the data atmosphere are scalled to ensure freshwater balance in the ocean model."
+					description="If true, precipitation fluxes will be scalled to ensure freshwater balance in FOSI runs referring to forced ocean-sea ice simulation where ocean model is driven by a data atmosphere with prescribed precipitation (rain + snow) fluxes."
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_precip_scaling_mode" type="character" default_value="constant"
-					description="Option for precipitation scaling to ensure freshwater balance in the ocean model."
-					possible_values="'constant' or 'time-dependent'"
+					description="Option for scaling precipitation fluxes to ensure freshwater balance in FOSI runs. config_precip_scaling_mode='constant' uses a prescribed constant factor applied to precipitation fluxes. config_precip_scaling_mode='time-dependent' enables the dynamical caclulation of scaling factors using annual and global mean precipitation (rain + snow) and sea surface height changes over one-year or multi-year period."
+					possible_values="'off', 'constant' or 'time-dependent'"
 		/>
 		<nml_option name="config_precip_scaling_initial_factor" type="real" default_value="1.0" units="unitless"
-					description="Initial guess scaling factor on precipitation for config_precip_scaling_mode = 'time-dependent'."
-					possible_values="Any non-negative value ranged from 0 to 1.0, no scaling if set to 1.0"
+					description="Initial guess scaling factor on precipitation fluxes in FOSI runs when config_precip_scaling_mode = 'time-dependent'."
+					possible_values="Non-negative number between 0 and 1.0. Default value of 1.0 means no scaling."
 		/>
 		<nml_option name="config_precip_scaling_constant_factor" type="real" default_value="1.0" units="unitless"
-					description="Prescribed constant scaling factor on precipitation for config_precip_scaling_mode = 'constant'." 
-					possible_values="Any non-negative value ranged from 0 to 1.0, no scaling if set to 1.0"
+					description="Prescribed constant scaling factor on precipitation fluxes in FOSI runs when config_precip_scaling_mode = 'constant'."
+					possible_values="Non-negative number between 0 and 1.0. Default value of 1.0 means no scaling."
 		/>
 		<nml_option name="config_precip_scaling_history_years" type="integer" default_value="1" units="years"
-					description="The number of years over for which the history span of precipitational scaling factor is computed."
-					possible_values="Must be a positive integer greater than or equal to 1."
-		/>
+					description="The number of years over which scaling factor on precipitation fluxes is computed in FOSI runs. Default value is 1 year."
+					possible_values="Positive integer greater than or equal to 1."
+                />
 		<nml_option name="config_precip_scaling_write_to_logfile" type="logical" default_value=".false."
-					description="Logical flag indicating whether precipitation flux scaling information is written to the log file."
+					description="Logical flag indicating whether information for precipitation flux scaling in FOSI runs will be written to the log file."
 					possible_values=".true. or .false."
 		/>
 	</nml_record>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -118,7 +118,7 @@
 		/>
                 <dim name="nAccumulatedSFWFHistory" definition="namelist:config_sfwf_history_years"
                          description="The number of years stored in the history of surface freshwater fluxes."
-                />
+		/>
 	</dims>
 
 	<!--*************************************-->
@@ -737,7 +737,7 @@
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_sgr_temperature_prescribed" type="real" default_value="0.0" units="C"
-			        description="Prescribed subglacial runoff temperature value, applied when config_use_sgr_opt_temp_prescribed = .true."
+			                description="Prescribed subglacial runoff temperature value, applied when config_use_sgr_opt_temp_prescribed = .true."
 					possible_values="Any real number."
 		/>
 		<nml_option name="config_sgr_salinity_prescribed" type="real" default_value="0.0" units="1.e-3"
@@ -747,20 +747,28 @@
         </nml_record>
 	<nml_record name="sfwf_forcing" mode="init;forward">
                 <nml_option name="config_sfwf_balance" type="logical" default_value=".false."
-                                        description="If true, precipitation fluxes from data atmosphere was adjusted to constrain the freshwater conservation. To be used with data precipitation (rain+snow) fluxes coming from the atmospehre model and runoff fluxes coming from the land model."
+			                description="If enabled, precipitation fluxes from the data atmosphere are adjusted to ensure freshwater balance in the ocean model."
 					possible_values=".true. or .false."
                 />
-	        <nml_option name="config_sfwf_balance_type" type="integer" default_value="0"
-                        		description="The option for the water conservation scheme. The default is 0 that used a fixed factor on the precipitation fluxes from namelist. option 1 used the dynamical factor calculated with the surface freshwater balance relationship" 
-                        		possible_values="Any positive integer"
+	        <nml_option name="config_sfwf_balance_type" type="integer" default_value="-99"
+			                description="Option to compute scaling factors to ensure freshwater balance in the ocean model."
+                        		possible_values="0 or 1"
                 />
                 <nml_option name="config_precip_factor" type="real" default_value="1.0" units="unitless"
-					description="Factors applied on precipitation flux to adjust freshwater conservation in ocean model."
-                       		 	possible_values="Any positive integer"
+					description="First guess scaling factors applied on precipitation flux to adjust freshwater balance in ocean model."
+					possible_values="Any non-negative value ranged from 0 to 1.0, no scaling if set to 1.0"
                 />
                 <nml_option name="config_sfwf_history_years" type="integer" default_value="1" units="years"
-                       			description="The number of years. The default is 1 year."
-                       			possible_values="Any positive integer"
+			                description="The number of years over for which the history span of water balance is computed."
+                       			possible_values="Must be a positive integer greater than or equal to 1."
+		/>
+                <nml_option name="config_sfwf_use_prev_factor" type="logical" default_value=".false."
+			                description="Logical flag determining whether the newly calculated SFWF factor should use values from the previous timestep."
+			               possible_values=".true. or .false."
+                />
+                <nml_option name="config_sfwf_balance_write_to_logfile" type="logical" default_value=".false."
+		                       description="Logical flag determining if the freshwater balance adjustment information is written to the log file."
+                                       possible_values=".true. or .false."
                 />
 	</nml_record>
 	<nml_record name="time_varying_forcing" mode="init;forward">
@@ -2105,10 +2113,8 @@
 	    <var name="nAccumulatedfwFlux" packages="scaledSFWFPKG"/>
 	    <var name="avgprecFlux" packages="scaledSFWFPKG"/>
 	    <var name="avgfwFlux" packages="scaledSFWFPKG"/>
-            <var name="avgsalFlux" packages="scaledSFWFPKG"/>
 	    <var name="totalAccumulatedprecFluxHistory" packages="scaledSFWFPKG"/>
 	    <var name="totalAccumulatedfwFluxHistory" packages="scaledSFWFPKG"/>
-            <var name="totalAccumulatedsalFluxHistory" packages="scaledSFWFPKG"/>
             <var name="nValidTotalfwFluxHistory" packages="scaledSFWFPKG"/>
 	    <var name="SFWFScalingFactor" packages="scaledSFWFPKG"/> 
 		</stream>
@@ -3926,20 +3932,25 @@
 			 description="Fresh water flux from snow at cell centers from coupler. Positive into the ocean."
 			 packages="activeTracersBulkRestoringPKG;thicknessBulkPKG"
 		/>
+                <!-- Additional fields required for computing scaling factors to maintain water balance -->
                 <var name="nAccumulatedfwFlux" type="integer" dimensions="Time"
                          description="Number of accumulations in time averaging of surface water fluxes"
                          packages="scaledSFWFPKG"
                 />
                 <var name="avgprecFlux" type="real" dimensions="Time" units="kg s^-1"
-                         description="The daily mean, area integrated value of precipitation flux (rain+snow)."
+                         description="The yearly mean, area integrated value of precipitation flux (rain+snow)."
                          packages="scaledSFWFPKG"
 		/>
                 <var name="avgfwFlux" type="real" dimensions="Time" units="kg s^-1"
-                         description="The daily mean, area integrated value of freshwater flux (ssh inferred)."
+                         description="The yearly mean, area integrated value of freshwater flux (ssh inferred)."
                          packages="scaledSFWFPKG"
 		/>
-                <var name="avgsalFlux" type="real" dimensions="Time" units="kg s^-1"
-                         description="The daily mean, area integrated value of salinity flux (salinity inferred)."
+                <var name="SSHinitial" type="real" dimensions="Time" units="kg"
+			 description="The total water mass inferred from sea surface height anomalies at the beginning of a year."
+                         packages="scaledSFWFPKG"
+		/>
+                <var name="SSHfinal" type="real" dimensions="Time" units="kg"
+			 description="The total water mass inferred from sea surface height anomalies at the end of a year."
                          packages="scaledSFWFPKG"
                 />
                 <var name="totalAccumulatedprecFluxHistory" type="real" dimensions="nAccumulatedSFWFHistory Time" units="kg"
@@ -3950,10 +3961,6 @@
                          description="The history of accumulated freshwater fluxes, used to compute a running mean."
                          packages="scaledSFWFPKG"
 		/>
-                <var name="totalAccumulatedsalFluxHistory" type="real" dimensions="nAccumulatedSFWFHistory Time" units="kg"
-                         description="The history of accumulated salinity fluxes, used to compute a running mean."
-                         packages="scaledSFWFPKG"
-                />
                 <var name="nValidTotalfwFluxHistory" type="integer" dimensions="Time"
                          description="The number of valid days used for computing the surface water balance."
                          packages="scaledSFWFPKG"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -116,6 +116,9 @@
 		<dim name="nRemovedIceRunoffHistory" definition="namelist:config_ais_ice_runoff_history_days"
 			 description="The number of days stored in the history of removed ice runoff."
 		/>
+                <dim name="nAccumulatedSFWFHistory" definition="namelist:config_sfwf_history_days"
+                         description="The number of days stored in the history of surface freshwater fluxes."
+                />
 	</dims>
 
 	<!--*************************************-->
@@ -755,8 +758,8 @@
 					description="Factors applied on precipitation flux to adjust freshwater conservation in ocean model."
                        		 	possible_values="Any positive integer"
                 />
-                <nml_option name="config_sfwf_history_days" type="integer" default_value="365" units="days"
-                       			description="The number of days over one or multiple years. The default is 365 days (1 years)."
+                <nml_option name="config_sfwf_history_days" type="integer" default_value="366" units="days"
+                       			description="The number of days over one or multiple years. The default is 366 days (1 years + 1day)."
                        			possible_values="Any positive integer"
                 />
 	</nml_record>
@@ -1766,6 +1769,7 @@
 		<package name="activeWavePKG" description="This package controls variables required for wave coupling"/>
 		<package name="subgridWetDryPKG" description="This package includes variables required for subgrid wetting and drying."/>
 		<package name="scaledDISMFPKG" description="This package includes variables required scaling data ice-shelf melt fluxes based on the running mean of removed ice runoff."/>
+		<package name="scaledSFWFPKG" description="This package includes variables required deriving freshwater scaling factors to constrain the water balances."/>
 	</packages>
 
 	<streams>
@@ -2097,7 +2101,16 @@
             <var name="avgRemovedIceRunoff" packages="scaledDISMFPKG"/>
             <var name="totalRemovedIceRunoffHistory" packages="scaledDISMFPKG"/>
             <var name="nValidTotalRemovedIceRunoffHistory" packages="scaledDISMFPKG"/>
-            <var name="runningMeanRemovedIceRunoff" packages="scaledDISMFPKG"/>
+	    <var name="runningMeanRemovedIceRunoff" packages="scaledDISMFPKG"/>
+	    <var name="nAccumulatedfwFlux" packages="scaledSFWFPKG"/>
+	    <var name="avgprecFlux" packages="scaledSFWFPKG"/>
+	    <var name="avgfwFlux" packages="scaledSFWFPKG"/>
+            <var name="avgsalFlux" packages="scaledSFWFPKG"/>
+	    <var name="totalAccumulatedprecFluxHistory" packages="scaledSFWFPKG"/>
+	    <var name="totalAccumulatedfwFluxHistory" packages="scaledSFWFPKG"/>
+            <var name="totalAccumulatedsalFluxHistory" packages="scaledSFWFPKG"/>
+            <var name="nValidTotalfwFluxHistory" packages="scaledSFWFPKG"/>
+	    <var name="SFWFScalingFactor" packages="scaledSFWFPKG"/> 
 		</stream>
 
 		<stream name="output"
@@ -3913,7 +3926,42 @@
 			 description="Fresh water flux from snow at cell centers from coupler. Positive into the ocean."
 			 packages="activeTracersBulkRestoringPKG;thicknessBulkPKG"
 		/>
-
+                <var name="nAccumulatedfwFlux" type="integer" dimensions="Time"
+                         description="Number of accumulations in time averaging of surface water fluxes"
+                         packages="scaledDISMFPKG"
+                />
+                <var name="avgprecFlux" type="real" dimensions="Time" units="kg s^-1"
+                         description="The daily mean, area integrated value of precipitation flux (rain+snow)."
+                         packages="scaledDISMFPKG"
+		/>
+                <var name="avgfwFlux" type="real" dimensions="Time" units="kg s^-1"
+                         description="The daily mean, area integrated value of freshwater flux (ssh inferred)."
+                         packages="scaledDISMFPKG"
+		/>
+                <var name="avgsalFlux" type="real" dimensions="Time" units="kg s^-1"
+                         description="The daily mean, area integrated value of salinity flux (salinity inferred)."
+                         packages="scaledDISMFPKG"
+                />
+                <var name="totalAccumulatedprecFluxHistory" type="real" dimensions="nAccumulatedSFWFHistory Time" units="kg"
+                         description="The history of accumulated total precipitation fluxes(rain+snow), used to compute a running mean."
+                         packages="scaledSFWFPKG"
+		/>
+                <var name="totalAccumulatedfwFluxHistory" type="real" dimensions="nAccumulatedSFWFHistory Time" units="kg"
+                         description="The history of accumulated freshwater fluxes, used to compute a running mean."
+                         packages="scaledSFWFPKG"
+		/>
+                <var name="totalAccumulatedsalFluxHistory" type="real" dimensions="nAccumulatedSFWFHistory Time" units="kg"
+                         description="The history of accumulated salinity fluxes, used to compute a running mean."
+                         packages="scaledSFWFPKG"
+                />
+                <var name="nValidTotalfwFluxHistory" type="integer" dimensions="Time"
+                         description="The number of valid days used for computing the surface water balance."
+                         packages="scaledSFWFPKG"
+                />
+                <var name="SFWFScalingFactor" type="real" dimensions="Time" units="kg s^-1"
+                         description="The scaling factor of surface freshwater flux, derived over the nValidTotalfwFluxHistory valid entries"
+                         packages="scaledSFWFPKG"
+                />
 
 		<!-- Misc. coupling fields -->
 		<var name="iceFraction" type="real" dimensions="nCells Time" units="fractional"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -116,7 +116,7 @@
 		<dim name="nRemovedIceRunoffHistory" definition="namelist:config_ais_ice_runoff_history_days"
 			 description="The number of days stored in the history of removed ice runoff."
 		/>
-                <dim name="nAccumulatedSFWFHistory" definition="namelist:config_sfwf_history_years"
+                <dim name="nAccumulatedSFWFHistory" definition="namelist:config_precip_scaling_history_years"
                          description="The number of years stored in the history of surface freshwater fluxes."
 		/>
 	</dims>
@@ -745,26 +745,30 @@
 					possible_values="Any positive real number"
                 />
         </nml_record>
-	<nml_record name="sfwf_forcing" mode="init;forward">
-                <nml_option name="config_sfwf_balance" type="logical" default_value=".false."
-			                description="If enabled, precipitation fluxes from the data atmosphere are adjusted to ensure freshwater balance in the ocean model."
+	<nml_record name="precip_scaling" mode="init;forward">
+                <nml_option name="config_use_precip_scaling" type="logical" default_value=".false."
+			                description="If enabled, precipitation fluxes from the data atmosphere are scalled to ensure freshwater balance in the ocean model."
 					possible_values=".true. or .false."
                 />
-	        <nml_option name="config_sfwf_balance_type" type="integer" default_value="-99"
-			                description="Option to compute scaling factors to ensure freshwater balance in the ocean model."
-                        		possible_values="0 or 1"
+	        <nml_option name="config_precip_scaling_mode" type="character" default_value="constant"
+			                description="Option for precipitation scaling to ensure freshwater balance in the ocean model."
+                        		possible_values="'constant' or 'time-dependent'"
+		/>
+                <nml_option name="config_precip_scaling_initial_factor" type="real" default_value="1.0" units="unitless"
+                                        description="Initial guess scaling factor on precipitation for config_precip_scaling_mode = 'time-dependent'."
+                                        possible_values="Any non-negative value ranged from 0 to 1.0, no scaling if set to 1.0"
                 />
-                <nml_option name="config_precip_factor" type="real" default_value="1.0" units="unitless"
-					description="First guess scaling factors applied on precipitation flux to adjust freshwater balance in ocean model."
+                <nml_option name="config_precip_scaling_constant_factor" type="real" default_value="1.0" units="unitless"
+					description="Prescribed constant scaling factor on precipitation for config_precip_scaling_mode = 'constant'." 
 					possible_values="Any non-negative value ranged from 0 to 1.0, no scaling if set to 1.0"
                 />
-                <nml_option name="config_sfwf_history_years" type="integer" default_value="1" units="years"
-			                description="The number of years over for which the history span of water balance is computed."
+                <nml_option name="config_precip_scaling_history_years" type="integer" default_value="1" units="years"
+			                description="The number of years over for which the history span of precipitational scaling factor is computed."
                        			possible_values="Must be a positive integer greater than or equal to 1."
 		/>
-                <nml_option name="config_sfwf_balance_write_to_logfile" type="logical" default_value=".false."
-		                       description="Logical flag determining if the freshwater balance adjustment information is written to the log file."
-                                       possible_values=".true. or .false."
+                <nml_option name="config_precip_scaling_write_to_logfile" type="logical" default_value=".false."
+			                description="Logical flag indicating whether precipitation flux scaling information is written to the log file."
+                                        possible_values=".true. or .false."
                 />
 	</nml_record>
 	<nml_record name="time_varying_forcing" mode="init;forward">

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -740,8 +740,25 @@
 		<nml_option name="config_sgr_salinity_prescribed" type="real" default_value="0.0" units="1.e-3"
 					description="Prescribed subglacial runoff salinity value, applied when config_use_sgr_opt_salt_prescribed = .true."
 					possible_values="Any positive real number"
-		/>
-
+                />
+        </nml_record>
+	<nml_record name="sfwf_forcing" mode="init;forward">
+                <nml_option name="config_sfwf_balance" type="logical" default_value=".false."
+                                        description="If true, precipitation fluxes from data atmosphere was adjusted to constrain the freshwater conservation. To be used with data precipitation (rain+snow) fluxes coming from the atmospehre model and runoff fluxes coming from the land model."
+					possible_values=".true. or .false."
+                />
+	        <nml_option name="config_sfwf_balance_type" type="integer" default_value="0"
+                        		description="The option for the water conservation scheme. The default is 0 that used a fixed factor on the precipitation fluxes from namelist. option 1 used the dynamical factor calculated with the surface freshwater balance relationship" 
+                        		possible_values="Any positive integer"
+                />
+                <nml_option name="config_precip_factor" type="real" default_value="1.0" units="unitless"
+					description="Factors applied on precipitation flux to adjust freshwater conservation in ocean model."
+                       		 	possible_values="Any positive integer"
+                />
+                <nml_option name="config_sfwf_history_days" type="integer" default_value="365" units="days"
+                       			description="The number of days over one or multiple years. The default is 365 days (1 years)."
+                       			possible_values="Any positive integer"
+                />
 	</nml_record>
 	<nml_record name="time_varying_forcing" mode="init;forward">
 		<nml_option name="config_use_time_varying_atmospheric_forcing" type="logical" default_value=".false."
@@ -803,7 +820,7 @@
 		<nml_option name="config_time_varying_land_ice_forcing_interval" type="character" default_value="01:00:00"
 			description="Time between forcing inputs"
 			possible_values="'YYYY-MM-DD_HH:MM:SS"
-		/>
+                />
 	</nml_record>
 	<nml_record name="coupling" mode="init;forward">
 		<nml_option name="config_remove_ais_river_runoff" type="logical" default_value=".false."

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -114,10 +114,10 @@
 			description="Number of subgrid look-up table levels"
 		/>
 		<dim name="nRemovedIceRunoffHistory" definition="namelist:config_ais_ice_runoff_history_days"
-			 description="The number of days stored in the history of removed ice runoff."
+			description="The number of days stored in the history of removed ice runoff."
 		/>
-                <dim name="nAccumulatedSFWFHistory" definition="namelist:config_precip_scaling_history_years"
-                         description="The number of years stored in the history of surface freshwater fluxes."
+		<dim name="nAccumulatedSFWFHistory" definition="namelist:config_precip_scaling_history_years"
+			description="The number of years stored in the history of surface freshwater fluxes."
 		/>
 	</dims>
 
@@ -737,39 +737,39 @@
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_sgr_temperature_prescribed" type="real" default_value="0.0" units="C"
-			                description="Prescribed subglacial runoff temperature value, applied when config_use_sgr_opt_temp_prescribed = .true."
+					description="Prescribed subglacial runoff temperature value, applied when config_use_sgr_opt_temp_prescribed = .true."
 					possible_values="Any real number."
 		/>
 		<nml_option name="config_sgr_salinity_prescribed" type="real" default_value="0.0" units="1.e-3"
 					description="Prescribed subglacial runoff salinity value, applied when config_use_sgr_opt_salt_prescribed = .true."
 					possible_values="Any positive real number"
-                />
-        </nml_record>
-	<nml_record name="precip_scaling" mode="init;forward">
-                <nml_option name="config_use_precip_scaling" type="logical" default_value=".false."
-			                description="If enabled, precipitation fluxes from the data atmosphere are scalled to ensure freshwater balance in the ocean model."
-					possible_values=".true. or .false."
-                />
-	        <nml_option name="config_precip_scaling_mode" type="character" default_value="constant"
-			                description="Option for precipitation scaling to ensure freshwater balance in the ocean model."
-                        		possible_values="'constant' or 'time-dependent'"
 		/>
-                <nml_option name="config_precip_scaling_initial_factor" type="real" default_value="1.0" units="unitless"
-                                        description="Initial guess scaling factor on precipitation for config_precip_scaling_mode = 'time-dependent'."
-                                        possible_values="Any non-negative value ranged from 0 to 1.0, no scaling if set to 1.0"
-                />
-                <nml_option name="config_precip_scaling_constant_factor" type="real" default_value="1.0" units="unitless"
+	</nml_record>
+	<nml_record name="precip_scaling" mode="init;forward">
+		<nml_option name="config_use_precip_scaling" type="logical" default_value=".false."
+					description="If enabled, precipitation fluxes from the data atmosphere are scalled to ensure freshwater balance in the ocean model."
+					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_precip_scaling_mode" type="character" default_value="constant"
+					description="Option for precipitation scaling to ensure freshwater balance in the ocean model."
+					possible_values="'constant' or 'time-dependent'"
+		/>
+		<nml_option name="config_precip_scaling_initial_factor" type="real" default_value="1.0" units="unitless"
+					description="Initial guess scaling factor on precipitation for config_precip_scaling_mode = 'time-dependent'."
+					possible_values="Any non-negative value ranged from 0 to 1.0, no scaling if set to 1.0"
+		/>
+		<nml_option name="config_precip_scaling_constant_factor" type="real" default_value="1.0" units="unitless"
 					description="Prescribed constant scaling factor on precipitation for config_precip_scaling_mode = 'constant'." 
 					possible_values="Any non-negative value ranged from 0 to 1.0, no scaling if set to 1.0"
-                />
-                <nml_option name="config_precip_scaling_history_years" type="integer" default_value="1" units="years"
-			                description="The number of years over for which the history span of precipitational scaling factor is computed."
-                       			possible_values="Must be a positive integer greater than or equal to 1."
 		/>
-                <nml_option name="config_precip_scaling_write_to_logfile" type="logical" default_value=".false."
-			                description="Logical flag indicating whether precipitation flux scaling information is written to the log file."
-                                        possible_values=".true. or .false."
-                />
+		<nml_option name="config_precip_scaling_history_years" type="integer" default_value="1" units="years"
+					description="The number of years over for which the history span of precipitational scaling factor is computed."
+					possible_values="Must be a positive integer greater than or equal to 1."
+		/>
+		<nml_option name="config_precip_scaling_write_to_logfile" type="logical" default_value=".false."
+					description="Logical flag indicating whether precipitation flux scaling information is written to the log file."
+					possible_values=".true. or .false."
+		/>
 	</nml_record>
 	<nml_record name="time_varying_forcing" mode="init;forward">
 		<nml_option name="config_use_time_varying_atmospheric_forcing" type="logical" default_value=".false."
@@ -831,7 +831,7 @@
 		<nml_option name="config_time_varying_land_ice_forcing_interval" type="character" default_value="01:00:00"
 			description="Time between forcing inputs"
 			possible_values="'YYYY-MM-DD_HH:MM:SS"
-                />
+		/>
 	</nml_record>
 	<nml_record name="coupling" mode="init;forward">
 		<nml_option name="config_remove_ais_river_runoff" type="logical" default_value=".false."
@@ -1327,7 +1327,7 @@
 					possible_values="Any positive integer greater than or equal to one. A value of one employs the same dt in all regions."
 		/>
 	</nml_record>
-    <nml_record name="forward_backward" mode="forward">
+	<nml_record name="forward_backward" mode="forward">
 		<nml_option name="config_fb_weight_1" type="real" default_value="0.531"
 					description="The forward-backward weight for the first stage of FB-RK(3,2), used in FB_LTS."
 					possible_values="Any positive real number less than or equal to one."
@@ -1490,10 +1490,10 @@
 					description="Tolerance for the barotropic mode solver"
 					possible_values="any positive real, but typically less than 1.0e-9"
 		/>
-                <nml_option name="config_n_btr_si_large_iter" type="integer" default_value="1"
-                                        description="number of large barotropic system iterations"
-                                        possible_values="any positive integer, but typically 1 and less than 2"
-                />
+		<nml_option name="config_n_btr_si_large_iter" type="integer" default_value="1"
+					description="number of large barotropic system iterations"
+					possible_values="any positive integer, but typically 1 and less than 2"
+		/>
 		<nml_option name="config_btr_si_partition_match_mode" type="logical" default_value=".false."
 					description="If true, the split-implicit method uses the Jacobi preconditioner with the bit-for-bit all-reduce. This is less performant, so should only be used for testing."
 					possible_values=".true. or .false."
@@ -2097,28 +2097,28 @@
 			<var_array name="avgSSHGradient"/>
 			<var name="forcingGroupNames"/>
 			<var name="forcingGroupRestartTimes"/>
-            <var name="gotmVertViscTopOfCell"/>
-            <var name="gotmVertDiffTopOfCell"/>
-            <var name="gotmTKETopOfCell"/>
-            <var name="gotmKbTopOfCell"/>
-            <var name="gotmEpsbTopOfCell"/>
-            <var name="gotmDissTopOfCell"/>
-            <var name="gotmLengthTopOfCell"/>
-            <var name="pgf_sal"/>
-            <var name="nAccumulatedRemovedIceRunoff" packages="scaledDISMFPKG"/>
-            <var name="avgRemovedIceRunoff" packages="scaledDISMFPKG"/>
-            <var name="totalRemovedIceRunoffHistory" packages="scaledDISMFPKG"/>
-            <var name="nValidTotalRemovedIceRunoffHistory" packages="scaledDISMFPKG"/>
-	    <var name="runningMeanRemovedIceRunoff" packages="scaledDISMFPKG"/>
-	    <var name="nAccumulatedfwFlux" packages="scaledSFWFPKG"/>
-	    <var name="avgprecFlux" packages="scaledSFWFPKG"/>
-	    <var name="avgfwFlux" packages="scaledSFWFPKG"/>
-	    <var name="totalAccumulatedprecFluxHistory" packages="scaledSFWFPKG"/>
-	    <var name="totalAccumulatedfwFluxHistory" packages="scaledSFWFPKG"/>
-	    <var name="SSHinitial" packages="scaledSFWFPKG"/>
-	    <var name="SSHfinal" packages="scaledSFWFPKG"/>
-            <var name="nValidTotalfwFluxHistory" packages="scaledSFWFPKG"/>
-	    <var name="SFWFScalingFactor" packages="scaledSFWFPKG"/> 
+			<var name="gotmVertViscTopOfCell"/>
+			<var name="gotmVertDiffTopOfCell"/>
+			<var name="gotmTKETopOfCell"/>
+			<var name="gotmKbTopOfCell"/>
+			<var name="gotmEpsbTopOfCell"/>
+			<var name="gotmDissTopOfCell"/>
+			<var name="gotmLengthTopOfCell"/>
+			<var name="pgf_sal"/>
+	 		<var name="nAccumulatedRemovedIceRunoff" packages="scaledDISMFPKG"/>
+			<var name="avgRemovedIceRunoff" packages="scaledDISMFPKG"/>
+			<var name="totalRemovedIceRunoffHistory" packages="scaledDISMFPKG"/>
+			<var name="nValidTotalRemovedIceRunoffHistory" packages="scaledDISMFPKG"/>
+			<var name="runningMeanRemovedIceRunoff" packages="scaledDISMFPKG"/>
+			<var name="nAccumulatedfwFlux" packages="scaledSFWFPKG"/>
+			<var name="avgprecFlux" packages="scaledSFWFPKG"/>
+			<var name="avgfwFlux" packages="scaledSFWFPKG"/>
+			<var name="totalAccumulatedprecFluxHistory" packages="scaledSFWFPKG"/>
+			<var name="totalAccumulatedfwFluxHistory" packages="scaledSFWFPKG"/>
+			<var name="SSHinitial" packages="scaledSFWFPKG"/>
+			<var name="SSHfinal" packages="scaledSFWFPKG"/>
+			<var name="nValidTotalfwFluxHistory" packages="scaledSFWFPKG"/>
+			<var name="SFWFScalingFactor" packages="scaledSFWFPKG"/> 
 		</stream>
 
 		<stream name="output"
@@ -2507,7 +2507,7 @@
 			description="The effective ocean density within ice shelves based on Archimedes' principle."
 			packages="landIceCouplingPKG"
 		/>
-        <!-- FIELDS FOR GOTM -->
+		<!-- FIELDS FOR GOTM -->
 		<var name="gotmVertViscTopOfCell" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2 s^-1"
 			 description="GOTM: vertical viscosity defined at the cell center (horizontally) and top (vertically)"
 			 packages="gotmPKG"
@@ -2536,7 +2536,7 @@
 			 description="GOTM: turbulent length scale defined at the cell center (horizontally) and top (vertically)"
 			 packages="gotmPKG"
 		/>
-                <!-- FIELDS FOR VERTICAL REMAPPING -->
+		<!-- FIELDS FOR VERTICAL REMAPPING -->
 		<var name="layerThicknessLag" type="real" dimensions="nVertLevels nCells Time" units="m"
 			 description="The layerThickness after the Lagrangian step, prior to remapping."
 			 packages="verticalRemapPKG"
@@ -2776,7 +2776,7 @@
 		<var name="distanceToCoast" type="real" dimensions="nCells" units="m"
 			 description="Distance of each cell to nearest coastline cell."
 		/>
-                <!-- FIELDS FOR SUBGIRD WETTING AND DRYING-->
+		<!-- FIELDS FOR SUBGIRD WETTING AND DRYING-->
 		<var name="subgridWetVolumeCellTable" type="real" dimensions="nSubgridTableLevels nCells" units="m"
 			 description="Pre-computed wet volume per unit area for each cell at given ssh value"
 			 packages="subgridWetDryPKG"
@@ -3690,11 +3690,11 @@
 		/>
 		<!-- FIELD split_explicit AB2 time stepping -->
 		<var name="normalVelocityTendOld" type="real" dimensions="nVertLevels nEdges Time" units="m s^-2"
-                        description="time tendency of normal component of velocity at the previous time step used in the split-explicit AB2 time stepping"
+			description="time tendency of normal component of velocity at the previous time step used in the split-explicit AB2 time stepping"
 			packages="splitAB2TimeIntegrator"
 		/>
 		<var name="CoriolisTermOld" type="real" dimensions="nVertLevels nEdges Time" units="m s^-2"
-                        description="Coriolis term at the previous time step used in the split-explicit AB2 time stepping"
+			description="Coriolis term at the previous time step used in the split-explicit AB2 time stepping"
 			packages="splitAB2TimeIntegrator"
 		/>
 		<var name="layerThicknessCellWetDry" type="real" dimensions="nVertLevels nCells Time" units="m"
@@ -3934,43 +3934,43 @@
 			 description="Fresh water flux from snow at cell centers from coupler. Positive into the ocean."
 			 packages="activeTracersBulkRestoringPKG;thicknessBulkPKG"
 		/>
-                <!-- Additional fields required for computing scaling factors to maintain water balance -->
-                <var name="nAccumulatedfwFlux" type="integer" dimensions="Time"
-                         description="Number of accumulations in time averaging of surface water fluxes"
-                         packages="scaledSFWFPKG"
-                />
-                <var name="avgprecFlux" type="real" dimensions="Time" units="kg s^-1"
-                         description="The yearly mean, area integrated value of precipitation flux (rain+snow)."
-                         packages="scaledSFWFPKG"
+		<!-- Additional fields required for computing scaling factors to maintain water balance -->
+		<var name="nAccumulatedfwFlux" type="integer" dimensions="Time"
+			 description="Number of accumulations in time averaging of surface water fluxes"
+			 packages="scaledSFWFPKG"
 		/>
-                <var name="avgfwFlux" type="real" dimensions="Time" units="kg s^-1"
-                         description="The yearly mean, area integrated value of freshwater flux (ssh inferred)."
-                         packages="scaledSFWFPKG"
+		<var name="avgprecFlux" type="real" dimensions="Time" units="kg s^-1"
+			 description="The yearly mean, area integrated value of precipitation flux (rain+snow)."
+			 packages="scaledSFWFPKG"
 		/>
-                <var name="SSHinitial" type="real" dimensions="Time" units="kg"
+		<var name="avgfwFlux" type="real" dimensions="Time" units="kg s^-1"
+			 description="The yearly mean, area integrated value of freshwater flux (ssh inferred)."
+			 packages="scaledSFWFPKG"
+		/>
+		<var name="SSHinitial" type="real" dimensions="Time" units="kg"
 			 description="The total water mass inferred from sea surface height anomalies at the beginning of a year."
-                         packages="scaledSFWFPKG"
+			 packages="scaledSFWFPKG"
 		/>
-                <var name="SSHfinal" type="real" dimensions="Time" units="kg"
+		<var name="SSHfinal" type="real" dimensions="Time" units="kg"
 			 description="The total water mass inferred from sea surface height anomalies at the end of a year."
-                         packages="scaledSFWFPKG"
-                />
-                <var name="totalAccumulatedprecFluxHistory" type="real" dimensions="nAccumulatedSFWFHistory Time" units="kg"
-                         description="The history of accumulated total precipitation fluxes(rain+snow), used to compute a running mean."
-                         packages="scaledSFWFPKG"
+			 packages="scaledSFWFPKG"
 		/>
-                <var name="totalAccumulatedfwFluxHistory" type="real" dimensions="nAccumulatedSFWFHistory Time" units="kg"
-                         description="The history of accumulated freshwater fluxes, used to compute a running mean."
-                         packages="scaledSFWFPKG"
+		<var name="totalAccumulatedprecFluxHistory" type="real" dimensions="nAccumulatedSFWFHistory Time" units="kg"
+			 description="The history of accumulated total precipitation fluxes(rain+snow), used to compute a running mean."
+			 packages="scaledSFWFPKG"
 		/>
-                <var name="nValidTotalfwFluxHistory" type="integer" dimensions="Time"
-                         description="The number of valid days used for computing the surface water balance."
-                         packages="scaledSFWFPKG"
-                />
-                <var name="SFWFScalingFactor" type="real" dimensions="Time" units="fractional"
-                         description="The scaling factor of surface freshwater flux, derived over the nValidTotalfwFluxHistory valid entries"
-                         packages="scaledSFWFPKG"
-                />
+		<var name="totalAccumulatedfwFluxHistory" type="real" dimensions="nAccumulatedSFWFHistory Time" units="kg"
+			 description="The history of accumulated freshwater fluxes, used to compute a running mean."
+			 packages="scaledSFWFPKG"
+		/>
+		<var name="nValidTotalfwFluxHistory" type="integer" dimensions="Time"
+			 description="The number of valid days used for computing the surface water balance."
+			 packages="scaledSFWFPKG"
+		/>
+		<var name="SFWFScalingFactor" type="real" dimensions="Time" units="fractional"
+			 description="The scaling factor of surface freshwater flux, derived over the nValidTotalfwFluxHistory valid entries"
+			 packages="scaledSFWFPKG"
+		/>
 
 		<!-- Misc. coupling fields -->
 		<var name="iceFraction" type="real" dimensions="nCells Time" units="fractional"
@@ -3980,7 +3980,7 @@
 			 description="Wind speed at 10 meter."
 		/>
 
-                <!-- Waves coupling fields -->
+		<!-- Waves coupling fields -->
 		<var name="stokesDriftZonal" type="real" dimensions="nVertLevels nCells Time" units="m s^-1"
 			 description="Zonal component of the wave-induced Stokes drift current."
 			 packages="activeWavePKG"
@@ -4054,7 +4054,7 @@
 			 description="Sum of heat fluxes associated with water fluxes cell centers sent to coupler. Positive into the ocean."
 		/>
 		<var name="avgLandIceFreshwaterFlux" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
-		         description="Time-averaged sum of freshwater fluxes associated with ice shelf basal melt fluxes cell centers sent to coupler. Positive into the ocean."
+			 description="Time-averaged sum of freshwater fluxes associated with ice shelf basal melt fluxes cell centers sent to coupler. Positive into the ocean."
 		/>
 		<var name="avgLandIceHeatFlux" type="real" dimensions="nCells Time" units="W m^-2"
 			 description="Time-averaged sum of heat fluxes associated with ice shelf basal melt fluxes cell centers sent to coupler. Positive into the ocean."
@@ -4064,7 +4064,7 @@
 		/>
 		<var name="avgRemovedIceRunoffFlux" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
 			 description="Time-averaged sum of freshwater fluxes associated with removed ice runoff fluxes cell centers sent to coupler. Positive into the ocean."
-	        />
+		/>
 		<var name="avgRemovedIceRunoffHeatFlux" type="real" dimensions="nCells Time" units="W m^-2"
 			 description="Time-averaged sum of heat fluxes associated with removed ice runoff fluxes cell centers sent to coupler. Positive into the ocean."
 		/>
@@ -4277,7 +4277,7 @@
 			 description="Multiplication factors to smooth ssh at coastlines for SAL caculation"
 			 packages="tidalPotentialForcingPKG"
 		/>
-               	<var name="forcingTimeIncrement" type="real" dimensions="" units="s"
+		<var name="forcingTimeIncrement" type="real" dimensions="" units="s"
 			description="Time increment to compute forcing terms at intermediate time intervals"
 			packages="forwardMode"
 		/>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -3928,19 +3928,19 @@
 		/>
                 <var name="nAccumulatedfwFlux" type="integer" dimensions="Time"
                          description="Number of accumulations in time averaging of surface water fluxes"
-                         packages="scaledDISMFPKG"
+                         packages="scaledSFWFPKG"
                 />
                 <var name="avgprecFlux" type="real" dimensions="Time" units="kg s^-1"
                          description="The daily mean, area integrated value of precipitation flux (rain+snow)."
-                         packages="scaledDISMFPKG"
+                         packages="scaledSFWFPKG"
 		/>
                 <var name="avgfwFlux" type="real" dimensions="Time" units="kg s^-1"
                          description="The daily mean, area integrated value of freshwater flux (ssh inferred)."
-                         packages="scaledDISMFPKG"
+                         packages="scaledSFWFPKG"
 		/>
                 <var name="avgsalFlux" type="real" dimensions="Time" units="kg s^-1"
                          description="The daily mean, area integrated value of salinity flux (salinity inferred)."
-                         packages="scaledDISMFPKG"
+                         packages="scaledSFWFPKG"
                 />
                 <var name="totalAccumulatedprecFluxHistory" type="real" dimensions="nAccumulatedSFWFHistory Time" units="kg"
                          description="The history of accumulated total precipitation fluxes(rain+snow), used to compute a running mean."
@@ -3958,7 +3958,7 @@
                          description="The number of valid days used for computing the surface water balance."
                          packages="scaledSFWFPKG"
                 />
-                <var name="SFWFScalingFactor" type="real" dimensions="Time" units="kg s^-1"
+                <var name="SFWFScalingFactor" type="real" dimensions="Time" units="fractional"
                          description="The scaling factor of surface freshwater flux, derived over the nValidTotalfwFluxHistory valid entries"
                          packages="scaledSFWFPKG"
                 />

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -116,8 +116,8 @@
 		<dim name="nRemovedIceRunoffHistory" definition="namelist:config_ais_ice_runoff_history_days"
 			 description="The number of days stored in the history of removed ice runoff."
 		/>
-                <dim name="nAccumulatedSFWFHistory" definition="namelist:config_sfwf_history_days"
-                         description="The number of days stored in the history of surface freshwater fluxes."
+                <dim name="nAccumulatedSFWFHistory" definition="namelist:config_sfwf_history_years"
+                         description="The number of years stored in the history of surface freshwater fluxes."
                 />
 	</dims>
 
@@ -758,8 +758,8 @@
 					description="Factors applied on precipitation flux to adjust freshwater conservation in ocean model."
                        		 	possible_values="Any positive integer"
                 />
-                <nml_option name="config_sfwf_history_days" type="integer" default_value="366" units="days"
-                       			description="The number of days over one or multiple years. The default is 366 days (1 years + 1day)."
+                <nml_option name="config_sfwf_history_years" type="integer" default_value="1" units="years"
+                       			description="The number of years. The default is 1 year."
                        			possible_values="Any positive integer"
                 />
 	</nml_record>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -2115,6 +2115,8 @@
 	    <var name="avgfwFlux" packages="scaledSFWFPKG"/>
 	    <var name="totalAccumulatedprecFluxHistory" packages="scaledSFWFPKG"/>
 	    <var name="totalAccumulatedfwFluxHistory" packages="scaledSFWFPKG"/>
+	    <var name="SSHinitial" packages="scaledSFWFPKG"/>
+	    <var name="SSHfinal" packages="scaledSFWFPKG"/>
             <var name="nValidTotalfwFluxHistory" packages="scaledSFWFPKG"/>
 	    <var name="SFWFScalingFactor" packages="scaledSFWFPKG"/> 
 		</stream>

--- a/components/mpas-ocean/src/analysis_members/Registry_global_stats.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_global_stats.xml
@@ -814,6 +814,10 @@
 			 description="Global stats copy of the running mean of the daily averaged removed ice runoff"
 			 packages="scaledDISMFPKG"
 		/>
+                <var name="gsSFWFScalingFactor" type="real" dimensions="Time" units="kg s^-1"
+                         description="Global stats copy of the scaling factors on freshwater fluxes"
+                         packages="scaledSFWFPKG"
+                />
 	</var_struct>
 	<streams>
 		<stream name="globalStatsOutput" type="output"

--- a/components/mpas-ocean/src/analysis_members/Registry_global_stats.xml
+++ b/components/mpas-ocean/src/analysis_members/Registry_global_stats.xml
@@ -814,10 +814,10 @@
 			 description="Global stats copy of the running mean of the daily averaged removed ice runoff"
 			 packages="scaledDISMFPKG"
 		/>
-                <var name="gsSFWFScalingFactor" type="real" dimensions="Time" units="kg s^-1"
-                         description="Global stats copy of the scaling factors on freshwater fluxes"
-                         packages="scaledSFWFPKG"
-                />
+		<var name="gsSFWFScalingFactor" type="real" dimensions="Time" units="kg s^-1"
+			 description="Global stats copy of the scaling factors on freshwater fluxes"
+			 packages="scaledSFWFPKG"
+		/>
 	</var_struct>
 	<streams>
 		<stream name="globalStatsOutput" type="output"

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_global_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_global_stats.F
@@ -1395,7 +1395,7 @@ contains
          gsRunningMeanRemovedIceRunoff = runningMeanRemovedIceRunoff
       end if
 
-      if (config_sfwf_balance) then
+      if (config_use_precip_scaling) then
          block => domain % blocklist
          call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
          call mpas_pool_get_array(globalStatsAMPool, 'gsSFWFScalingFactor', gsSFWFScalingFactor)

--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_global_stats.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_global_stats.F
@@ -243,7 +243,9 @@ contains
       real (kind=RKIND), pointer :: volumeCellGlobal, volumeEdgeGlobal, CFLNumberGlobal, areaCellGlobal, &
                                     areaEdgeGlobal, areaTriangleGlobal, totalVolumeChange, netFreshwaterInput, &
                                     absoluteFreshWaterConservation, relativeFreshWaterConservation, &
-                                    landIceFloatingAreaSum, gsRunningMeanRemovedIceRunoff, runningMeanRemovedIceRunoff
+                                    landIceFloatingAreaSum, gsRunningMeanRemovedIceRunoff, runningMeanRemovedIceRunoff, & 
+                                    gsSFWFScalingFactor,SFWFScalingFactor  
+
       real (kind=RKIND), dimension(:), pointer ::  areaCell, dcEdge, dvEdge, areaTriangle, areaEdge, landIceFloatingArea
       real (kind=RKIND), dimension(:,:), pointer :: layerThickness, normalVelocity, &
             lowFreqDivergence, highFreqThickness, &
@@ -1392,6 +1394,14 @@ contains
          call mpas_pool_get_array(forcingPool, 'runningMeanRemovedIceRunoff', runningMeanRemovedIceRunoff)
          gsRunningMeanRemovedIceRunoff = runningMeanRemovedIceRunoff
       end if
+
+      if (config_sfwf_balance) then
+         block => domain % blocklist
+         call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
+         call mpas_pool_get_array(globalStatsAMPool, 'gsSFWFScalingFactor', gsSFWFScalingFactor)
+         call mpas_pool_get_array(forcingPool, 'SFWFScalingFactor', SFWFScalingFactor)
+         gsSFWFScalingFactor = SFWFScalingFactor
+      end if 
 
       ! calculate fresh water conservation check quantities
       absoluteFreshWaterConservation = totalVolumeChange - netFreshwaterInput

--- a/components/mpas-ocean/src/driver/mpas_ocn_core_interface.F
+++ b/components/mpas-ocean/src/driver/mpas_ocn_core_interface.F
@@ -141,6 +141,7 @@ module ocn_core_interface
       logical, pointer :: activeWavePKGActive
       logical, pointer :: subgridWetDryPKGActive
       logical, pointer :: scaledDISMFPKGActive
+      logical, pointer :: scaledSFWFPKGActive
 
       type (mpas_pool_iterator_type) :: pkgItr
       logical, pointer :: packageActive
@@ -177,6 +178,10 @@ module ocn_core_interface
       logical, pointer :: config_use_active_wave
       logical, pointer :: config_use_subgrid_wetting_drying
       logical, pointer :: config_scale_dismf_by_removed_ice_runoff
+
+      ! freshwater balance adjustment 
+      logical, pointer :: config_sfwf_balance
+      integer, pointer :: config_sfwf_balance_type
 
       character (len=StrKIND), pointer :: config_time_integrator
       character (len=StrKIND), pointer :: config_ocean_run_mode
@@ -460,6 +465,16 @@ module ocn_core_interface
                                 config_scale_dismf_by_removed_ice_runoff)
       if (config_scale_dismf_by_removed_ice_runoff) then
          scaledDISMFPKGActive = .true.
+      end if
+
+      !
+      ! test for scaling precipitation fluxes to ensure a balance of fresh water
+      !
+      call mpas_pool_get_package(packagePool, 'scaledSFWFPKGActive', scaledSFWFPKGActive)
+      call mpas_pool_get_config(configPool, 'config_sfwf_balance', config_sfwf_balance)
+      call mpas_pool_get_config(configPool, 'config_sfwf_balance_type', config_sfwf_balance_type)
+      if (config_sfwf_balance .and. (config_sfwf_balance_type > 0) ) then
+         scaledSFWFPKGActive = .true.
       end if
 
       !

--- a/components/mpas-ocean/src/driver/mpas_ocn_core_interface.F
+++ b/components/mpas-ocean/src/driver/mpas_ocn_core_interface.F
@@ -179,9 +179,8 @@ module ocn_core_interface
       logical, pointer :: config_use_subgrid_wetting_drying
       logical, pointer :: config_scale_dismf_by_removed_ice_runoff
 
-      ! freshwater balance adjustment 
-      logical, pointer :: config_sfwf_balance
-      integer, pointer :: config_sfwf_balance_type
+      ! flag to turn on freshwater balance adjustment 
+      logical, pointer :: config_use_precip_scaling
 
       character (len=StrKIND), pointer :: config_time_integrator
       character (len=StrKIND), pointer :: config_ocean_run_mode
@@ -471,9 +470,8 @@ module ocn_core_interface
       ! test for scaling precipitation fluxes to ensure a balance of fresh water
       !
       call mpas_pool_get_package(packagePool, 'scaledSFWFPKGActive', scaledSFWFPKGActive)
-      call mpas_pool_get_config(configPool, 'config_sfwf_balance', config_sfwf_balance)
-      call mpas_pool_get_config(configPool, 'config_sfwf_balance_type', config_sfwf_balance_type)
-      if (config_sfwf_balance .and. (config_sfwf_balance_type > 0) ) then
+      call mpas_pool_get_config(configPool, 'config_use_precip_scaling', config_use_precip_scaling)
+      if (config_use_precip_scaling) then
          scaledSFWFPKGActive = .true.
       end if
 

--- a/components/mpas-ocean/src/ocean.cmake
+++ b/components/mpas-ocean/src/ocean.cmake
@@ -115,6 +115,7 @@ list(APPEND RAW_SOURCES
   core_ocean/shared/mpas_ocn_manufactured_solution.F
   core_ocean/shared/mpas_ocn_subgrid.F
   core_ocean/shared/mpas_ocn_scaled_dismf.F
+  core_ocean/shared/mpas_ocn_scaled_sfwf.F
 )
 
 set(OCEAN_DRIVER

--- a/components/mpas-ocean/src/shared/mpas_ocn_constants.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_constants.F
@@ -50,7 +50,6 @@ module ocn_constants
       sound                 ,&! speed of sound (m/s)
       vonkar                ,&! von Karman constant
       emissivity            ,&!
-      earthRadius           ,&! radius of earth, m 
       stefan_boltzmann      ,&! W/m^2/K^4
       latent_heat_vapor     ,&! lat heat of vaporization (erg/g)
       latent_heat_vapor_mks ,&! lat heat of vaporization (J/kg)
@@ -129,7 +128,6 @@ contains
        sound     = 1.5e2_RKIND                ! speed of sound (m/s)
        vonkar    = 0.4_RKIND                  ! von Karman constant
        emissivity         = 1.0_RKIND         !
-       earthRadius        = 6.37122e6_RKIND   ! radius of earth ~ m
        stefan_boltzmann   = 567.0e-10_RKIND   !  W/m^2/K^4
        latent_heat_vapor_mks  = 2.5e6_RKIND   ! lat heat of vaporization (J/kg)
        latent_heat_fusion = 3.34e6_RKIND      ! lat heat of fusion (erg/kg)
@@ -178,7 +176,6 @@ contains
        sea_ice_salinity       = SHR_CONST_ICE_REF_SAL   ! psu
        molecular_weight_C     = SHR_CONST_MWC           ! molecular weight carbon
        molecular_weight_O2    = SHR_CONST_MWO           ! molecular weight oxygen
-       earthRadius            = SHR_CONST_REARTH        ! m
 #endif
 
 !#ifdef ZERO_SEA_ICE_REF_SAL

--- a/components/mpas-ocean/src/shared/mpas_ocn_constants.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_constants.F
@@ -50,6 +50,7 @@ module ocn_constants
       sound                 ,&! speed of sound (m/s)
       vonkar                ,&! von Karman constant
       emissivity            ,&!
+      earthRadius           ,&! radius of earth, m 
       stefan_boltzmann      ,&! W/m^2/K^4
       latent_heat_vapor     ,&! lat heat of vaporization (erg/g)
       latent_heat_vapor_mks ,&! lat heat of vaporization (J/kg)
@@ -128,6 +129,7 @@ contains
        sound     = 1.5e2_RKIND                ! speed of sound (m/s)
        vonkar    = 0.4_RKIND                  ! von Karman constant
        emissivity         = 1.0_RKIND         !
+       earthRadius        = 6.37122e6_RKIND   ! radius of earth ~ m
        stefan_boltzmann   = 567.0e-10_RKIND   !  W/m^2/K^4
        latent_heat_vapor_mks  = 2.5e6_RKIND   ! lat heat of vaporization (J/kg)
        latent_heat_fusion = 3.34e6_RKIND      ! lat heat of fusion (erg/kg)
@@ -176,6 +178,7 @@ contains
        sea_ice_salinity       = SHR_CONST_ICE_REF_SAL   ! psu
        molecular_weight_C     = SHR_CONST_MWC           ! molecular weight carbon
        molecular_weight_O2    = SHR_CONST_MWO           ! molecular weight oxygen
+       earthRadius            = SHR_CONST_REARTH        ! m
 #endif
 
 !#ifdef ZERO_SEA_ICE_REF_SAL

--- a/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
@@ -177,10 +177,6 @@ contains
            return
        end if
 
-       if (trim(config_precip_scaling_mode) == 'constant') then
-           return
-       end if 
-
        if ( present(timeLevel) ) then
           timeLevelLocal = timeLevel
        else
@@ -501,14 +497,27 @@ contains
             totalAccumulatedfwFluxHistory(nValidHistory) = avgfwFlux 
         end if
 
-        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-        ! Scaling factors are computed as the ratio of ssh-inferred mass flux to precipitation flux.
-        ! Average values are used when nHistory > 1
-        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-        precFluxMean = sum(totalAccumulatedprecFluxHistory(1:nHistory)) / nHistory
-        fwFluxMean = sum(totalAccumulatedfwFluxHistory(1:nHistory)) / nHistory 
 
-        SFWFScalingFactor = SFWFScalingFactor - fwFluxMean / precFluxMean
+        if (trim(config_precip_scaling_mode) == 'constant') then 
+          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+          ! constant factors setup by user via namelist!
+          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+          SFWFScalingFactor = config_precip_scaling_constant_factor
+
+        else if (trim(config_precip_scaling_mode) == 'time-dependent') then
+          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+          ! computed as the ratio of ssh-inferred      !
+          ! mass flux to precipitation flux.
+          ! Average values are used when nHistory > 1  !
+          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+          precFluxMean = sum(totalAccumulatedprecFluxHistory(1:nHistory)) / nHistory
+          fwFluxMean = sum(totalAccumulatedfwFluxHistory(1:nHistory)) / nHistory
+
+          SFWFScalingFactor = SFWFScalingFactor - fwFluxMean / precFluxMean
+
+        end if 
 
         ! reset yearly averaging of the precipitation and freshwater fluxes 
         nAccumulated = 0
@@ -518,6 +527,7 @@ contains
         ! Output to log file
         !-------------------------------------------------------------
         if (config_precip_scaling_write_to_logfile) then
+
             call mpas_log_write('----------------------------------------------------------')
             call mpas_log_write('WATER CONSERVATION CHECK')
             A = earthAreaE3SM
@@ -530,11 +540,16 @@ contains
                     fwFluxMean,fwFluxMean*c; call mpas_log_write(m)
 
             call mpas_log_write('SCALING FACTOR ON PRECIPITATION FLUXES')
+
+            call mpas_log_write(' ')
+            write(m, '(A)') 'SFWFScalingMethod       '//trim(config_precip_scaling_mode); call mpas_log_write(m) 
+
             call mpas_log_write(' ')
             write(m,"('SFWFScalingFactor       ',es16.8,'       precip_fact              fact      ',f16.8)") &
                     SFWFScalingFactor,1.0_RKIND - fwFluxMean / precFluxMean; call mpas_log_write(m)
             call mpas_log_write(' ')
             call mpas_log_write('----------------------------------------------------------')
+
         end if 
 
     end subroutine update_scaling_factor!}}}

--- a/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
@@ -1,0 +1,430 @@
+! Copyright (c) 2013,  Pacific Northwest National Laboratory, (PNNL)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.io/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_scaled_sfwf
+!> \brief MPAS ocean scale data freshwater fluxes
+!> \author Shixuan Zhang 
+!> \date   May 2025
+!> \details
+!>  Computes a precipitation factor to multiply the fresh water flux
+!>  due to precipitation uniformly to insure a balance of fresh water
+!>  at the ocean surface.
+!>  Designed following precip_adjustment subroutine located at:
+!>    https://github.com/ESCOMP/POP2-CESM/blob/master/source/forcing_sfwf.F90
+!
+!-----------------------------------------------------------------------
+
+module ocn_scaled_sfwf
+
+    use mpas_kind_types
+    use mpas_derived_types
+    use mpas_global_sum_mod
+    use mpas_timekeeping
+    use mpas_timer
+
+    use ocn_config
+    use ocn_mesh
+
+    use shr_const_mod
+
+    use ocn_constants, only: rho_fw, ocn_ref_salinity
+
+    implicit none
+    private
+    save
+
+    !--------------------------------------------------------------------
+    !
+    ! Public parameters
+    !
+    !--------------------------------------------------------------------
+
+    !--------------------------------------------------------------------
+    !
+    ! Public member functions
+    !
+    !--------------------------------------------------------------------
+
+    public :: ocn_init_scaled_sfwf, &
+              ocn_update_scaling_factor
+
+    !--------------------------------------------------------------------
+    !
+    ! Private module variables
+    !
+    !--------------------------------------------------------------------
+
+    logical :: scaledSFWFOn
+    character (len=*), parameter :: alarmID = 'scaledSFWFUpdateAlarm'
+
+!***********************************************************************
+
+contains
+
+
+!***********************************************************************
+!
+!  routine ocn_init_scaled_sfwf
+!
+!> \brief   Initialize scaling of data freshwater fluxes
+!> \author Shixuan Zhang 
+!> \date   May 2025
+!> \details
+!>  Set alarms needed to compute daily and running means of water fluxes 
+!
+!-----------------------------------------------------------------------
+
+    subroutine ocn_init_scaled_sfwf(domain)!{{{
+
+        type (domain_type), intent(inout) :: domain
+
+        ! Alarm variables
+        type (mpas_Time_Type) :: alarmTime
+        type (mpas_TimeInterval_type) :: alarmTimeStep
+
+        integer :: err_tmp
+
+        if (config_sfwf_balance) then
+            scaledSFWFOn = .true.
+        else
+            scaledSFWFOn = .false.
+            return
+        endif
+
+        if (config_sfwf_balance_type < 0) then
+            call mpas_log_write('scaledSFWFOn = .true. requires config_sfwf_balance_type >= 0', &
+                                mpas_LOG_CRIT)
+        endif
+
+        ! Setup Alarm for updating of scaled SFWF
+        alarmTime = mpas_get_clock_time(domain % clock, &
+                                        mpas_START_TIME, &
+                                        ierr=err_tmp)
+        call mpas_set_timeInterval(alarmTimeStep, &
+                                   timeString='0000-00-01_00:00:00', &
+                                   ierr=err_tmp)
+        call mpas_add_clock_alarm(domain % clock, alarmID, alarmTime + alarmTimeStep, &
+                                  alarmTimeInterval=alarmTimeStep, ierr=err_tmp)
+
+    end subroutine ocn_init_scaled_sfwf!}}}
+
+
+!***********************************************************************
+!
+!  routine ocn_update_scaling_factor
+!
+!> \brief  Update scaling factors for data freshwater fluxes
+!> \author Shixuan Zhang 
+!> \date   May 2025
+!> \details
+!>  Accumulate daily mean of surface freshwater fluxes. 
+!>  If we are at the end of a day, used it to derive a factor to scale 
+!>  down/up precipitation fluxes and maintain freshwater balance.  
+!
+!-----------------------------------------------------------------------
+
+    subroutine ocn_update_scaling_factor(domain)!{{{
+
+        type (domain_type), intent(inout) :: domain
+
+        integer :: err_tmp
+
+        if (.not. scaledSFWFOn) then
+            return
+        end if
+
+        ! since the current clock time is for the end of the accumulation
+        ! intereval, first, accumulate the daily mean
+        call accumulate_mean_fw_fluxes(domain)
+
+       ! then, compute update the history and running mean if we are at the
+       ! end of a day
+       if(mpas_is_alarm_ringing(domain % clock, alarmID, ierr=err_tmp)) then
+#ifdef mpas_DEBUG
+            call mpas_log_write('       Computing Scaling Factor For SFWF')
+#endif
+            call update_scaling_factor(domain)
+            call mpas_reset_clock_alarm(domain % clock, alarmID, ierr=err_tmp)
+        endif
+
+    end subroutine ocn_update_scaling_factor!}}}
+
+
+!***********************************************************************
+!
+!  routine accumulate_mean_fw_fluxes
+!
+!> \brief  Accumulate surface water fluxes 
+!> \author Shixuan Zhang
+!> \date   May 2025
+!> \details
+!>  Accumulate current surface freshwater and precipitation fluxes 
+!>  into the daily mean value
+!
+!-----------------------------------------------------------------------
+
+    subroutine accumulate_mean_fw_fluxes(domain)!{{{
+
+        type (domain_type), intent(inout) :: domain
+
+        type (block_type), pointer :: block_ptr
+
+        type (mpas_pool_type), pointer ::  & 
+                forcingPool, & 
+                statePool, &
+                tracersPool, &
+                meshPool
+
+        type (MPAS_timeInterval_type) :: &
+                timeStepESMF
+
+        real(kind=RKIND), dimension(:), pointer :: &
+                areaCell, &
+                rainFlux, &
+                snowFlux, &
+                sshOld, &
+                sshNew
+
+        real(kind=RKIND), dimension(:,:,:), pointer :: &
+                activeTracersNew, &
+                activeTracersOld
+  
+        integer, dimension(:), pointer :: & 
+                minLevelCell, & 
+                maxLevelCell
+
+        real (kind=RKIND), pointer :: &
+                avgprecFlux,  &
+                avgfwFlux, &
+                avgsalFlux
+
+        integer, pointer :: & 
+                nCellsSolve, & 
+                nVertLevels, &
+                indexSalinity, &
+                nAccumulated
+
+        real (kind=RKIND) :: & 
+                precFlux, & 
+                fwFlux, &
+                salFlux
+
+        real(kind=RKIND) :: dt
+
+        real (kind=RKIND), dimension(:), allocatable :: & 
+             localArrayForPrecSum, &
+             localArrayForSSHSum, &
+             localArrayForSalinitySum
+
+        integer :: &
+             iCell, &
+             k
+
+        call mpas_get_timeInterval(timeStepESMF, dt=dt)
+
+        block_ptr => domain % blocklist
+
+        call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
+
+        ! independent of blocks
+        call mpas_pool_get_array(forcingPool, 'avgprecFlux', avgprecFlux)
+        call mpas_pool_get_array(forcingPool, 'avgfwFlux', avgfwFlux)
+
+        call mpas_pool_get_dimension(forcingPool, 'nCellsSolve', nCellsSolve)
+        call mpas_pool_get_array(forcingPool, 'nAccumulatedfwFlux', nAccumulated)
+
+        do while (associated(block_ptr))
+
+           call mpas_pool_get_dimension(block_ptr % dimensions, "nCellsSolve", nCellsSolve)
+           call mpas_pool_get_subpool(block_ptr % structs, "mesh", meshPool)
+           call mpas_pool_get_subpool(block_ptr % structs, "forcing", forcingPool)
+           call mpas_pool_get_subpool(block_ptr % structs, "state", statePool)
+
+           call mpas_pool_get_array(meshPool, "areaCell", areaCell)
+           call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
+           call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
+
+           call mpas_pool_get_array(statePool, "layerThickness", layerThickness, 1)
+           call mpas_pool_get_array(statePool, 'ssh', sshNew, 2)
+           call mpas_pool_get_array(statePool, 'ssh', sshOld, 1)
+
+           call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
+           call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
+           call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracersNew, 2) 
+           call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracersOld, 1) 
+
+           call mpas_pool_get_array(forcingPool, 'rainFlux',               rainFlux)
+           call mpas_pool_get_array(forcingPool, 'snowFlux',               snowFlux)
+
+           call mpas_pool_get_array(forcingPool, 'avgprecFlux', avgprecFlux)
+           call mpas_pool_get_array(forcingPool, 'avgfwFlux', avgfwFlux)
+
+           call mpas_pool_get_array(forcingPool, 'nAccumulatedfwFlux', nAccumulated)
+
+           allocate(localArrayForPrecSum(nCellsSolve))
+           allocate(localArrayForSSHSum(nCellsSolve))
+           localArrayForPrecSum(:) = 0.0_RKIND
+           localArrayForSSHSum(:) = 0.0_RKIND
+
+           !precipitation flux and ssh 
+           !$omp parallel
+           !$omp do schedule(runtime)
+           do iCell=1,nCellsSolve
+               localArrayForPrecSum(iCell) = (rainFlux(iCell)+snowFlux(iCell)) * areaCell(iCell) ! unit: kg/s
+               localArrayForSSHSum(iCell) = (sshNew(iCell)-sshOld(iCell))* areaCell(iCell) * rho_fw / dt ! unit: kg/s
+           enddo
+           !$omp end do
+           !$omp end parallel
+
+           allocate(localArraySalinitySum(nCellsSolve))
+           localArraySalinitySum(:) = 0.0_RKIND
+           
+           !salinity flux
+           !convert to 
+           !$omp parallel
+           !$omp do schedule(runtime) private(k)
+           do iCell = 1,nCells
+             do k = minLevelCell(iCell), maxLevelCell(iCell)
+                localArraySalinitySum(iCell) = localArraySalinitySum(iCell) - & 
+                     areaCell(iCell) * layerThickness(k,iCell) * & ! cell volume
+                     (activeTracersNew(indexSalinity,k,iCell) - activeTracersOld(indexSalinity,k,iCell)) * & ! * ! cell salinity
+                     rho_fw * 1.e3_RKIND / ocn_ref_salinity / dt ! F = - rho * h * 1/S * dS/dt 
+             end do
+           end do
+           !$omp end do
+           !$omp end parallel
+
+            block_ptr => block_ptr % next
+        end do ! block_ptr
+
+        precFlux = mpas_global_sum(localArrayForPrecSum, domain % dminfo % comm)
+        fwFlux = mpas_global_sum(localArrayForSSHSum, domain % dminfo % comm)
+        salFlux = mpas_global_sum(localArraySalinitySum, domain % dminfo % comm)
+
+        deallocate (localArrayForPrecSum)
+        deallocate (localArrayForSSHSum)
+        deallocate (localArraySalinitySum)
+
+        avgprecFlux = (avgprecFlux * nAccumulated + precFlux) / ( nAccumulated + 1 )
+        avgfwFlux = (avgfwFlux * nAccumulated + fwFlux) / ( nAccumulated + 1 )
+        avgsalFlux = (avgsalFlux * nAccumulated + salFlux) / ( nAccumulated + 1 )
+
+        nAccumulated = nAccumulated + 1
+
+    end subroutine accumulate_mean_fw_fluxes!}}}
+
+
+!***********************************************************************
+!
+!  routine update_scaling_factor
+!
+!> \brief  Update scaling factors for data freshwater fluxes 
+!> \author Shixuan Zhang 
+!> \date   May 2025
+!> \details
+!>  Update the net mass fluxes, and use it to scale the freshwater 
+!>  fluxes based on the water flux balance relationship
+!
+!-----------------------------------------------------------------------
+
+    subroutine update_scaling_factor(domain)!{{{
+
+        type (domain_type), intent(inout) :: domain
+
+        type (block_type), pointer :: block_ptr
+        type (mpas_pool_type), pointer :: forcingPool
+
+        real (kind=RKIND), pointer :: & 
+                avgprecFlux, & 
+                avgfwFlux, & 
+                avgsalFlux, & 
+                SFWFScalingFactor
+
+        real (kind=RKIND), dimension(:), pointer :: & 
+                totalAccumulatedprecFluxHistory, &
+                totalAccumulatedfwFluxHistory, &
+                totalAccumulatedsalFluxHistory
+
+        integer, pointer :: nValidHistory, nAccumulated
+
+        real (kind=RKIND), dimension(:), allocatable :: &
+                tmpprecHistory, &
+                tmpfwHistory, &
+                tmpsalHistory 
+
+        real (kind=RKIND) :: timeInterval
+        real (kind=RKIND) :: previousprecFlux, previousfwFlux, previoussalFlux
+        real (kind=RKIND) :: precFluxMean, fwFluxMean, salFluxMean
+        integer :: nHistory
+
+        block_ptr => domain % blocklist
+        call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
+        call mpas_pool_get_array(forcingPool, 'nAccumulatedfwFlux', nAccumulated)
+        call mpas_pool_get_array(forcingPool, 'nValidTotalfwFluxHistory', nValidHistory)
+        call mpas_pool_get_array(forcingPool, 'avgprecFlux', avgprecFlux)
+        call mpas_pool_get_array(forcingPool, 'avgfwFlux', avgfwFlux)
+        call mpas_pool_get_array(forcingPool, 'avgsalFlux', avgsalFlux)
+        call mpas_pool_get_array(forcingPool, 'totalAccumulatedprecFluxHistory', totalAccumulatedprecFluxHistory)
+        call mpas_pool_get_array(forcingPool, 'totalAccumulatedfwFluxHistory', totalAccumulatedfwFluxHistory)
+        call mpas_pool_get_array(forcingPool, 'totalAccumulatedsalFluxHistory', totalAccumulatedsalFluxHistory)
+        call mpas_pool_get_array(forcingPool, 'SFWFScalingFactor', SFWFScalingFactor)
+
+        nHistory = config_sfwf_history_days 
+
+        previousprecFlux = totalAccumulatedprecFluxHistory(nValidHistory)
+        previousfwFlux = totalAccumulatedfwFluxHistory(nValidHistory)
+        previoussalFlux = totalAccumulatedsalFluxHistory(nValidHistory)
+
+        if (nValidHistory == 0) then
+            ! here followed the module mpas_ocn_scaled_dismf.F
+            nValidHistory = 1
+        end if
+
+        if (nValidHistory == nHistory) then
+            ! we need to shift the history, since it's full
+            allocate(tmpprecHistory(nHistory))
+            allocate(tmpfwHistory(nHistory))
+            allocate(tmpsalHistory(nHistory))
+            tmpprecHistory(:) = totalAccumulatedprecFluxHistory(:)
+            tmpfwHistory(:) = totalAccumulatedfwFluxHistory(:)
+            tmpsalHistory(:) = totalAccumulatedsalFluxHistory(:)
+            totalAccumulatedprecFluxHistory(1:nHistory - 1) = tmpprecHistory(2:nHistory)
+            totalAccumulatedfwFluxHistory(1:nHistory - 1) = tmpfwHistory(2:nHistory)
+            totalAccumulatedsalFluxHistory(1:nHistory - 1) = tmpsalHistory(2:nHistory)
+        else
+            ! the history isn't full yet, so we just add to the end
+            nValidHistory = nValidHistory + 1
+        end if
+
+        ! add the new total, the previous total plus the new daily average
+        totalAccumulatedprecFluxHistory(nValidHistory) = previousprecFlux + SHR_CONST_CDAY * avgprecFlux
+        totalAccumulatedfwFluxHistory(nValidHistory) = previousfwFlux + SHR_CONST_CDAY * avgfwFlux
+        totalAccumulatedsalFluxHistory(nValidHistory) = previoussalFlux + SHR_CONST_CDAY * avgsalFlux
+
+        timeInterval = SHR_CONST_CDAY * (nValidHistory - 1)
+        ! the running mean is the difference between the newest and oldest
+        ! totals divided by the time between them
+        precFluxMean = (totalAccumulatedprecFluxHistory(nValidHistory) - totalAccumulatedprecFluxHistory(1)) &
+                       / timeInterval
+        fwFluxMean = (totalAccumulatedfwFluxHistory(nValidHistory) - totalAccumulatedfwFluxHistory(1)) &
+                      / timeInterval
+        salFluxMean = (totalAccumulatedsalFluxHistory(nValidHistory) - totalAccumulatedsalFluxHistory(1)) &
+                      / timeInterval
+
+        SFWFScalingFactor = SFWFScalingFactor - (fwFluxMean + salFluxMean) / precFluxMean
+
+        ! reset daily averaging of the precipitation and freshwater fluxes 
+        nAccumulated = 0
+        avgprecFlux = 0.0_RKIND 
+        avgfwFlux = 0.0_RKIND
+        avgsalFlux = 0.0_RKIND
+
+    end subroutine update_scaling_factor!}}}
+
+end module ocn_scaled_sfwf

--- a/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
@@ -35,7 +35,6 @@ module ocn_scaled_sfwf
 
     use ocn_constants, only: & 
         pi, &      
-        earthRadius, & 
         rho_fw, & 
         rho_sw, &
         ocn_ref_salinity
@@ -68,7 +67,7 @@ module ocn_scaled_sfwf
     logical :: scaledSFWFOn
     character (len=*), parameter :: alarmID = 'scaledSFWFUpdateAlarm'
 
-    real (kind=RKIND) :: earthArea ! surface area of earth in coupler
+    real (kind=RKIND) :: earthArea ! surface area of earth (m2)
 
     real(kind=RKIND) :: rhow, areaCellGlobal, volumeCellGlobal
 
@@ -96,6 +95,11 @@ contains
         ! Alarm variables
         type (mpas_Time_Type) :: alarmTime
         type (mpas_TimeInterval_type) :: alarmTimeStep
+
+        type (block_type), pointer :: block_ptr
+        type (mpas_pool_type), pointer :: meshPool
+
+        real (kind=RKIND), pointer :: sphere_radius
 
         integer :: err_tmp
 
@@ -133,12 +137,24 @@ contains
 
         call mpas_add_clock_alarm(domain % clock, alarmID, alarmTime + alarmTimeStep, &
                                   alarmTimeInterval=alarmTimeStep, ierr=err_tmp)
-                          
-        ! Compute Earth's surface area (used for normalizing fluxes)
-        earthArea = 4.0_RKIND * pi * earthRadius * earthRadius
-
         ! Density of sea water
         rhow = rho_sw
+
+        ! Compute Earth's surface area (used for normalizing fluxes)
+        if (config_precip_scaling_write_to_logfile) then
+           block_ptr => domain % blocklist
+           do while(associated(block_ptr))
+              call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+
+              ! Extract earth radius 
+              call mpas_pool_get_config(meshPool, 'sphere_radius', sphere_radius)
+
+              ! Compute Earth's surface area (used for normalizing fluxes)
+              earthArea = 4.0_RKIND * pi * sphere_radius * sphere_radius
+
+              block_ptr => block_ptr % next
+           end do
+        end if
 
     end subroutine ocn_scaled_sfwf_init!}}}
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
@@ -76,7 +76,7 @@ contains
 !> \author Shixuan Zhang 
 !> \date   May 2025
 !> \details
-!>  Set alarms needed to compute daily and running means of water fluxes 
+!>  Set alarms needed to compute yearly and running means of water fluxes 
 !
 !-----------------------------------------------------------------------
 
@@ -90,15 +90,15 @@ contains
 
         integer :: err_tmp
 
-        if (config_sfwf_balance) then
+        if (config_sfwf_balance .and. config_sfwf_balance_type > 0) then
             scaledSFWFOn = .true.
         else
             scaledSFWFOn = .false.
             return
         endif
 
-        if (config_sfwf_balance_type < 0) then
-            call mpas_log_write('scaledSFWFOn = .true. requires config_sfwf_balance_type >= 0', &
+        if (config_sfwf_history_years < 1) then
+            call mpas_log_write('scaledSFWFOn = .true. requires config_sfwf_history_years >= 1', &
                                 mpas_LOG_CRIT)
         endif
 
@@ -107,7 +107,7 @@ contains
                                         mpas_START_TIME, &
                                         ierr=err_tmp)
         call mpas_set_timeInterval(alarmTimeStep, &
-                                   timeString='0000-00-01_00:00:00', &
+                                   timeString='0001-00-00_00:00:00', &
                                    ierr=err_tmp)
         call mpas_add_clock_alarm(domain % clock, alarmID, alarmTime + alarmTimeStep, &
                                   alarmTimeInterval=alarmTimeStep, ierr=err_tmp)
@@ -123,8 +123,8 @@ contains
 !> \author Shixuan Zhang 
 !> \date   May 2025
 !> \details
-!>  Accumulate daily mean of surface freshwater fluxes. 
-!>  If we are at the end of a day, used it to derive a factor to scale 
+!>  Accumulate yearly mean of surface freshwater fluxes. 
+!>  If we are at the end of a year, used it to derive a factor to scale 
 !>  down/up precipitation fluxes and maintain freshwater balance.  
 !
 !-----------------------------------------------------------------------
@@ -140,11 +140,11 @@ contains
         end if
 
         ! since the current clock time is for the end of the accumulation
-        ! intereval, first, accumulate the daily mean
+        ! intereval, first, accumulate the yearly mean
         call accumulate_mean_fw_fluxes(domain)
 
        ! then, compute update the history and running mean if we are at the
-       ! end of a day
+       ! end of a year
        if(mpas_is_alarm_ringing(domain % clock, alarmID, ierr=err_tmp)) then
 #ifdef mpas_DEBUG
             call mpas_log_write('       Computing Scaling Factor For SFWF')
@@ -165,7 +165,7 @@ contains
 !> \date   May 2025
 !> \details
 !>  Accumulate current surface freshwater and precipitation fluxes 
-!>  into the daily mean value
+!>  into the yearly mean value
 !
 !-----------------------------------------------------------------------
 
@@ -364,7 +364,6 @@ contains
                 tmpfwHistory, &
                 tmpsalHistory 
 
-        real (kind=RKIND) :: timeInterval
         real (kind=RKIND) :: previousprecFlux, previousfwFlux, previoussalFlux
         real (kind=RKIND) :: precFluxMean, fwFluxMean, salFluxMean
         integer :: nHistory
@@ -381,7 +380,7 @@ contains
         call mpas_pool_get_array(forcingPool, 'totalAccumulatedsalFluxHistory', totalAccumulatedsalFluxHistory)
         call mpas_pool_get_array(forcingPool, 'SFWFScalingFactor', SFWFScalingFactor)
 
-        nHistory = config_sfwf_history_days 
+        nHistory = config_sfwf_history_years
 
         previousprecFlux = totalAccumulatedprecFluxHistory(nValidHistory)
         previousfwFlux = totalAccumulatedfwFluxHistory(nValidHistory)
@@ -389,43 +388,45 @@ contains
 
         if (nValidHistory == 0) then
             ! here followed the module mpas_ocn_scaled_dismf.F
+            ! we keep zero as the first entry in totalAccumulated fluxes 
             nValidHistory = 1
         end if
 
-        if (nValidHistory == nHistory) then
-            ! we need to shift the history, since it's full
-            allocate(tmpprecHistory(nHistory))
-            allocate(tmpfwHistory(nHistory))
-            allocate(tmpsalHistory(nHistory))
-            tmpprecHistory(:) = totalAccumulatedprecFluxHistory(:)
-            tmpfwHistory(:) = totalAccumulatedfwFluxHistory(:)
-            tmpsalHistory(:) = totalAccumulatedsalFluxHistory(:)
-            totalAccumulatedprecFluxHistory(1:nHistory - 1) = tmpprecHistory(2:nHistory)
-            totalAccumulatedfwFluxHistory(1:nHistory - 1) = tmpfwHistory(2:nHistory)
-            totalAccumulatedsalFluxHistory(1:nHistory - 1) = tmpsalHistory(2:nHistory)
-        else
-            ! the history isn't full yet, so we just add to the end
-            nValidHistory = nValidHistory + 1
+        if (nHistory > 1) then 
+            if (nValidHistory == nHistory) then
+                ! we need to shift the history, since it's full
+                allocate(tmpprecHistory(nHistory))
+                allocate(tmpfwHistory(nHistory))
+                allocate(tmpsalHistory(nHistory))
+                tmpprecHistory(:) = totalAccumulatedprecFluxHistory(:)
+                tmpfwHistory(:) = totalAccumulatedfwFluxHistory(:)
+                tmpsalHistory(:) = totalAccumulatedsalFluxHistory(:)
+                totalAccumulatedprecFluxHistory(1:nHistory - 1) = tmpprecHistory(2:nHistory)
+                totalAccumulatedfwFluxHistory(1:nHistory - 1) = tmpfwHistory(2:nHistory)
+                totalAccumulatedsalFluxHistory(1:nHistory - 1) = tmpsalHistory(2:nHistory)
+            else
+                ! the history isn't full yet, so we just add to the end
+                nValidHistory = nValidHistory + 1
+            end if
+            ! add the new total, the previous total plus the new yearly average
+            totalAccumulatedprecFluxHistory(nValidHistory) = previousprecFlux + avgprecFlux
+            totalAccumulatedfwFluxHistory(nValidHistory) = previousfwFlux + avgfwFlux
+            totalAccumulatedsalFluxHistory(nValidHistory) = previoussalFlux + avgsalFlux
+        else 
+            totalAccumulatedprecFluxHistory(nValidHistory) = avgprecFlux
+            totalAccumulatedfwFluxHistory(nValidHistory) = avgfwFlux
+            totalAccumulatedsalFluxHistory(nValidHistory) = avgsalFlux
         end if
 
-        ! add the new total, the previous total plus the new daily average
-        totalAccumulatedprecFluxHistory(nValidHistory) = previousprecFlux + SHR_CONST_CDAY * avgprecFlux
-        totalAccumulatedfwFluxHistory(nValidHistory) = previousfwFlux + SHR_CONST_CDAY * avgfwFlux
-        totalAccumulatedsalFluxHistory(nValidHistory) = previoussalFlux + SHR_CONST_CDAY * avgsalFlux
-
-        timeInterval = SHR_CONST_CDAY * (nValidHistory - 1)
-        ! the running mean is the difference between the newest and oldest
-        ! totals divided by the time between them
-        precFluxMean = (totalAccumulatedprecFluxHistory(nValidHistory) - totalAccumulatedprecFluxHistory(1)) &
-                       / timeInterval
-        fwFluxMean = (totalAccumulatedfwFluxHistory(nValidHistory) - totalAccumulatedfwFluxHistory(1)) &
-                      / timeInterval
-        salFluxMean = (totalAccumulatedsalFluxHistory(nValidHistory) - totalAccumulatedsalFluxHistory(1)) &
-                      / timeInterval
+        ! Scaling factors are ratio of (freshwater flux + salinity flux) to precipitation flux 
+        ! Therefore is independent of the time invervals for the accumulated fluxes 
+        precFluxMean = totalAccumulatedprecFluxHistory(nValidHistory) 
+        fwFluxMean = totalAccumulatedfwFluxHistory(nValidHistory) 
+        salFluxMean = totalAccumulatedsalFluxHistory(nValidHistory) 
 
         SFWFScalingFactor = SFWFScalingFactor - (fwFluxMean + salFluxMean) / precFluxMean
 
-        ! reset daily averaging of the precipitation and freshwater fluxes 
+        ! reset yearly averaging of the precipitation and freshwater fluxes 
         nAccumulated = 0
         avgprecFlux = 0.0_RKIND 
         avgfwFlux = 0.0_RKIND

--- a/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
@@ -239,6 +239,7 @@ contains
         ! independent of blocks
         call mpas_pool_get_array(forcingPool, 'avgprecFlux', avgprecFlux)
         call mpas_pool_get_array(forcingPool, 'avgfwFlux', avgfwFlux)
+        call mpas_pool_get_array(forcingPool, 'avgsalFlux', avgsalFlux)
 
         call mpas_pool_get_dimension(forcingPool, 'nCellsSolve', nCellsSolve)
         call mpas_pool_get_array(forcingPool, 'nAccumulatedfwFlux', nAccumulated)
@@ -268,6 +269,7 @@ contains
 
            call mpas_pool_get_array(forcingPool, 'avgprecFlux', avgprecFlux)
            call mpas_pool_get_array(forcingPool, 'avgfwFlux', avgfwFlux)
+           call mpas_pool_get_array(forcingPool, 'avgsalFlux', avgsalFlux)
 
            call mpas_pool_get_array(forcingPool, 'nAccumulatedfwFlux', nAccumulated)
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
@@ -96,11 +96,6 @@ contains
         type (mpas_Time_Type) :: alarmTime
         type (mpas_TimeInterval_type) :: alarmTimeStep
 
-        type (block_type), pointer :: block_ptr
-        type (mpas_pool_type), pointer :: meshPool
-
-        real (kind=RKIND), pointer :: sphere_radius
-
         integer :: err_tmp
 
         character(len=19) :: timeString
@@ -141,20 +136,8 @@ contains
         rhow = rho_sw
 
         ! Compute Earth's surface area (used for normalizing fluxes)
-        if (config_precip_scaling_write_to_logfile) then
-           block_ptr => domain % blocklist
-           do while(associated(block_ptr))
-              call mpas_pool_get_subpool(block_ptr % structs, 'mesh', meshPool)
+        earthArea = 4.0_RKIND * pi * sphereRadius * sphereRadius
 
-              ! Extract earth radius 
-              call mpas_pool_get_config(meshPool, 'sphere_radius', sphere_radius)
-
-              ! Compute Earth's surface area (used for normalizing fluxes)
-              earthArea = 4.0_RKIND * pi * sphere_radius * sphere_radius
-
-              block_ptr => block_ptr % next
-           end do
-        end if
 
     end subroutine ocn_scaled_sfwf_init!}}}
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
@@ -31,9 +31,15 @@ module ocn_scaled_sfwf
     use ocn_config
     use ocn_mesh
 
+    use shr_kind_mod, only: & 
+        SHR_KIND_R8
+
     use shr_const_mod
 
-    use ocn_constants, only: rho_fw, ocn_ref_salinity
+    use ocn_constants, only: & 
+        rho_fw, & 
+        rho_sw, &
+        ocn_ref_salinity
 
     implicit none
     private
@@ -63,6 +69,10 @@ module ocn_scaled_sfwf
     logical :: scaledSFWFOn
     character (len=*), parameter :: alarmID = 'scaledSFWFUpdateAlarm'
 
+    real (kind=RKIND) :: earthAreaE3SM ! surface area of earth in coupler
+
+    real(kind=RKIND) :: rhow, areaCellGlobal, volumeCellGlobal
+
 !***********************************************************************
 
 contains
@@ -90,6 +100,13 @@ contains
 
         integer :: err_tmp
 
+        ! taking PI from SHR_CONST_PI in share/util/shr_const_mod.F90 to match coupler
+        real (kind=RKIND), parameter :: piE3SM = SHR_CONST_PI
+        ! taking earth radius from SHR_CONST_REARTH in share/util/shr_const_mod.F90 to match coupler
+        real (kind=RKIND), parameter :: earthRadiusE3SM = SHR_CONST_REARTH ! radius of earth, m
+
+        character(len=19) :: timeString
+
         if (config_sfwf_balance .and. config_sfwf_balance_type > 0) then
             scaledSFWFOn = .true.
         else
@@ -101,16 +118,27 @@ contains
             call mpas_log_write('scaledSFWFOn = .true. requires config_sfwf_history_years >= 1', &
                                 mpas_LOG_CRIT)
         endif
+        
+        ! Setup time interval string based on config_sfwf_history_years (treated as "years")
+        write(timeString, '( I4.4,"-00-00_00:00:00" )') config_sfwf_history_years
 
-        ! Setup Alarm for updating of scaled SFWF
+        ! Setup Alarm for updating of scaling factors for precipitation flux
         alarmTime = mpas_get_clock_time(domain % clock, &
                                         mpas_START_TIME, &
                                         ierr=err_tmp)
+        
         call mpas_set_timeInterval(alarmTimeStep, &
-                                   timeString='0001-00-00_00:00:00', &
+                                   timeString=timeString,& 
                                    ierr=err_tmp)
+
         call mpas_add_clock_alarm(domain % clock, alarmID, alarmTime + alarmTimeStep, &
                                   alarmTimeInterval=alarmTimeStep, ierr=err_tmp)
+                          
+        ! Compute Earth's surface area (used for normalizing fluxes)
+        earthAreaE3SM = 4.0_RKIND * piE3SM * earthRadiusE3SM*earthRadiusE3SM
+
+        ! Density of sea water
+        rhow = rho_sw
 
     end subroutine ocn_init_scaled_sfwf!}}}
 
@@ -129,32 +157,134 @@ contains
 !
 !-----------------------------------------------------------------------
 
-    subroutine ocn_update_scaling_factor(domain)!{{{
+    subroutine ocn_update_scaling_factor(domain,timeLevel)!{{{
 
-        type (domain_type), intent(inout) :: domain
+       type (domain_type), intent(inout) :: domain
+       
+       integer, intent(in), optional :: timeLevel
 
-        integer :: err_tmp
+       integer :: timeLevelLocal
+       
+       integer :: err_tmp
 
-        if (.not. scaledSFWFOn) then
-            return
-        end if
+       if (.not. scaledSFWFOn) then
+           return
+       end if
 
-        ! since the current clock time is for the end of the accumulation
-        ! intereval, first, accumulate the yearly mean
-        call accumulate_mean_fw_fluxes(domain)
+       if ( present(timeLevel) ) then
+          timeLevelLocal = timeLevel
+       else
+          timeLevelLocal = 1
+       end if
+
+       ! since the current clock time is for the end of the accumulation
+       ! intereval, first, accumulate the yearly mean
+       call accumulate_mean_fw_fluxes(domain,timeLevelLocal)
 
        ! then, compute update the history and running mean if we are at the
        ! end of a year
        if(mpas_is_alarm_ringing(domain % clock, alarmID, ierr=err_tmp)) then
 #ifdef mpas_DEBUG
-            call mpas_log_write('       Computing Scaling Factor For SFWF')
+            call mpas_log_write('       Computing Scaling Factor For Water Fluxes')
 #endif
-            call update_scaling_factor(domain)
+            call update_scaling_factor(domain,timeLevelLocal)
             call mpas_reset_clock_alarm(domain % clock, alarmID, ierr=err_tmp)
-        endif
+       endif
 
     end subroutine ocn_update_scaling_factor!}}}
 
+!***********************************************************************
+!
+!  routine compute_ssh_mass
+!
+!> \brief  Derive ssh inferred freshwater mass 
+!> \author Shixuan Zhang
+!> \date   May 2025
+!> \details
+!>  calculate ssh equivalent total mass over ocean grid point 
+!
+!-----------------------------------------------------------------------
+    subroutine compute_ssh_mass(domain,timeLevel,sshMass)!{{{
+
+        type (domain_type), intent(inout) :: domain
+
+        integer, intent(in) :: timeLevel
+
+        real(kind=RKIND), intent(out) :: &
+                sshMass
+
+        type (block_type), pointer :: & 
+                block_ptr
+
+        type (mpas_pool_type), pointer ::  &
+                statePool, &
+                meshPool
+
+        integer, pointer :: &
+                nCellsSolve, &
+                nVertLevels
+
+        real(kind=RKIND), dimension(:), pointer :: &
+                areaCell, & 
+                ssh
+
+        real (kind=RKIND), dimension(:), allocatable :: &
+                localArrayForsshSum
+
+        integer :: iCell, k
+
+        character(len=160) :: m
+        
+        real (kind=RKIND) :: A, c
+
+        block_ptr => domain % blocklist
+
+        do while (associated(block_ptr))
+
+           call mpas_pool_get_dimension(block_ptr % dimensions, "nCellsSolve", nCellsSolve)
+           call mpas_pool_get_dimension(block_ptr % dimensions, "nVertLevels", nVertLevels)
+
+           call mpas_pool_get_subpool(block_ptr % structs, "mesh", meshPool)
+           call mpas_pool_get_array(meshPool, "areaCell", areaCell)
+
+           call mpas_pool_get_subpool(block_ptr % structs, "state", statePool)
+           call mpas_pool_get_array(statePool, "ssh", ssh, timeLevel) 
+
+           allocate(localArrayForsshSum(nCellsSolve))
+           
+           localArrayForsshSum(:) = 0.0_RKIND
+           
+           !$omp parallel
+           !$omp do schedule(runtime)
+           do iCell=1,nCellsSolve
+               localArrayForsshSum(iCell) = ssh(iCell) * areaCell(iCell) * rhow
+           enddo
+           !$omp end do
+           !$omp end parallel
+
+            block_ptr => block_ptr % next
+        end do ! block_ptr
+
+        sshMass = mpas_global_sum(localArrayForsshSum, domain % dminfo % comm)
+
+        !-------------------------------------------------------------
+        ! Output to log file
+        !-------------------------------------------------------------
+        if (config_sfwf_balance_write_to_logfile) then
+            A = earthAreaE3SM
+            c = 1._RKIND / A 
+            call mpas_log_write('----------------------------------------------------------')
+            call mpas_log_write('WATER CONSERVATION CHECK')
+            call mpas_log_write(' ')
+            call mpas_log_write('Total Mass Equivalent to SSH')
+            call mpas_log_write('MPAS-Ocean name          Mass(kg)          Mass(kg/m2)')
+            write(m,"('sshMass           ',es16.8,'          ',es16.8)") sshMass,sshMass * c
+            call mpas_log_write(m)
+            call mpas_log_write(' ')
+            call mpas_log_write('----------------------------------------------------------')
+        end if
+
+    end subroutine compute_ssh_mass!}}}
 
 !***********************************************************************
 !
@@ -169,68 +299,38 @@ contains
 !
 !-----------------------------------------------------------------------
 
-    subroutine accumulate_mean_fw_fluxes(domain)!{{{
+    subroutine accumulate_mean_fw_fluxes(domain,timeLevel)!{{{
 
         type (domain_type), intent(inout) :: domain
+
+        integer, intent(in) :: timeLevel
 
         type (block_type), pointer :: block_ptr
 
         type (mpas_pool_type), pointer ::  & 
                 forcingPool, & 
-                statePool, &
-                tracersPool, &
                 meshPool
-
-        type (MPAS_timeInterval_type) :: &
-                timeStepESMF
 
         real(kind=RKIND), dimension(:), pointer :: &
                 areaCell, &
                 rainFlux, &
-                snowFlux, &
-                sshOld, &
-                sshNew
-
-      
-        real(kind=RKIND), dimension(:,:), pointer :: &
-                layerThickness
-
-        real(kind=RKIND), dimension(:,:,:), pointer :: &
-                activeTracersNew, &
-                activeTracersOld
-  
-        integer, dimension(:), pointer :: & 
-                minLevelCell, & 
-                maxLevelCell
+                snowFlux
 
         real (kind=RKIND), pointer :: &
                 avgprecFlux,  &
-                avgfwFlux, &
-                avgsalFlux
+                SSHinitial
 
         integer, pointer :: & 
                 nCellsSolve, & 
-                nVertLevels, &
-                indexSalinity, &
                 nAccumulated
 
         real (kind=RKIND) :: & 
-                precFlux, & 
-                fwFlux, &
-                salFlux
-
-        real(kind=RKIND) :: dt
+                precFlux
 
         real (kind=RKIND), dimension(:), allocatable :: & 
-             localArrayForPrecSum, &
-             localArrayForSSHSum, &
-             localArrayForSalinitySum
+             localArrayForPrecSum
 
-        integer :: &
-             iCell, &
-             k
-
-        call mpas_get_timeInterval(timeStepESMF, dt=dt)
+        integer :: iCell, k
 
         block_ptr => domain % blocklist
 
@@ -238,93 +338,53 @@ contains
 
         ! independent of blocks
         call mpas_pool_get_array(forcingPool, 'avgprecFlux', avgprecFlux)
-        call mpas_pool_get_array(forcingPool, 'avgfwFlux', avgfwFlux)
-        call mpas_pool_get_array(forcingPool, 'avgsalFlux', avgsalFlux)
 
         call mpas_pool_get_dimension(forcingPool, 'nCellsSolve', nCellsSolve)
         call mpas_pool_get_array(forcingPool, 'nAccumulatedfwFlux', nAccumulated)
 
+        if ( nAccumulated == 0 ) then 
+           call mpas_pool_get_array(forcingPool, "SSHinitial", SSHinitial)
+           call compute_ssh_mass(domain,timeLevel,SSHinitial)
+        end if
+
         do while (associated(block_ptr))
 
            call mpas_pool_get_dimension(block_ptr % dimensions, "nCellsSolve", nCellsSolve)
+
            call mpas_pool_get_subpool(block_ptr % structs, "mesh", meshPool)
-           call mpas_pool_get_subpool(block_ptr % structs, "forcing", forcingPool)
-           call mpas_pool_get_subpool(block_ptr % structs, "state", statePool)
-
            call mpas_pool_get_array(meshPool, "areaCell", areaCell)
-           call mpas_pool_get_array(meshPool, 'minLevelCell', minLevelCell)
-           call mpas_pool_get_array(meshPool, 'maxLevelCell', maxLevelCell)
 
-           call mpas_pool_get_array(statePool, "layerThickness", layerThickness, 1)
-           call mpas_pool_get_array(statePool, 'ssh', sshNew, 2)
-           call mpas_pool_get_array(statePool, 'ssh', sshOld, 1)
-
-           call mpas_pool_get_subpool(statePool, 'tracers', tracersPool)
-           call mpas_pool_get_dimension(tracersPool, 'index_salinity', indexSalinity)
-           call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracersNew, 2) 
-           call mpas_pool_get_array(tracersPool, 'activeTracers', activeTracersOld, 1) 
-
-           call mpas_pool_get_array(forcingPool, 'rainFlux',               rainFlux)
-           call mpas_pool_get_array(forcingPool, 'snowFlux',               snowFlux)
-
+           call mpas_pool_get_subpool(block_ptr % structs, "forcing", forcingPool)
+           call mpas_pool_get_array(forcingPool, 'rainFlux', rainFlux)
+           call mpas_pool_get_array(forcingPool, 'snowFlux', snowFlux)
            call mpas_pool_get_array(forcingPool, 'avgprecFlux', avgprecFlux)
-           call mpas_pool_get_array(forcingPool, 'avgfwFlux', avgfwFlux)
-           call mpas_pool_get_array(forcingPool, 'avgsalFlux', avgsalFlux)
-
            call mpas_pool_get_array(forcingPool, 'nAccumulatedfwFlux', nAccumulated)
 
            allocate(localArrayForPrecSum(nCellsSolve))
-           allocate(localArrayForSSHSum(nCellsSolve))
+
            localArrayForPrecSum(:) = 0.0_RKIND
-           localArrayForSSHSum(:) = 0.0_RKIND
 
            !precipitation flux and ssh 
            !$omp parallel
            !$omp do schedule(runtime)
            do iCell=1,nCellsSolve
-               localArrayForPrecSum(iCell) = (rainFlux(iCell)+snowFlux(iCell)) * areaCell(iCell) ! unit: kg/s
-               localArrayForSSHSum(iCell) = (sshNew(iCell)-sshOld(iCell))* areaCell(iCell) * rho_fw / dt ! unit: kg/s
+               localArrayForPrecSum(iCell) = (rainFlux(iCell) + snowFlux(iCell)) * areaCell(iCell) ! unit: kg/s
            enddo
            !$omp end do
            !$omp end parallel
 
-           allocate(localArrayForSalinitySum(nCellsSolve))
-           localArrayForSalinitySum(:) = 0.0_RKIND
-           
-           !salinity flux
-           !convert to 
-           !$omp parallel
-           !$omp do schedule(runtime) private(k)
-           do iCell = 1,nCellsSolve
-             do k = minLevelCell(iCell), maxLevelCell(iCell)
-                localArrayForSalinitySum(iCell) = localArrayForSalinitySum(iCell) - & 
-                     areaCell(iCell) * layerThickness(k,iCell) * & ! cell volume
-                     (activeTracersNew(indexSalinity,k,iCell) - activeTracersOld(indexSalinity,k,iCell)) * & ! * ! cell salinity
-                     rho_fw * 1.e3_RKIND / ocn_ref_salinity / dt ! F = - rho * h * 1/S * dS/dt 
-             end do
-           end do
-           !$omp end do
-           !$omp end parallel
-
-            block_ptr => block_ptr % next
+           block_ptr => block_ptr % next
         end do ! block_ptr
 
-        precFlux = mpas_global_sum(localArrayForPrecSum, domain % dminfo % comm)
-        fwFlux = mpas_global_sum(localArrayForSSHSum, domain % dminfo % comm)
-        salFlux = mpas_global_sum(localArrayForSalinitySum, domain % dminfo % comm)
-
-        deallocate (localArrayForPrecSum)
-        deallocate (localArrayForSSHSum)
-        deallocate (localArrayForSalinitySum)
+        precFlux = mpas_global_sum(localArrayForPrecSum, domain % dminfo % comm) 
 
         avgprecFlux = (avgprecFlux * nAccumulated + precFlux) / ( nAccumulated + 1 )
-        avgfwFlux = (avgfwFlux * nAccumulated + fwFlux) / ( nAccumulated + 1 )
-        avgsalFlux = (avgsalFlux * nAccumulated + salFlux) / ( nAccumulated + 1 )
+
+        deallocate (localArrayForPrecSum)
 
         nAccumulated = nAccumulated + 1
 
     end subroutine accumulate_mean_fw_fluxes!}}}
-
 
 !***********************************************************************
 !
@@ -339,98 +399,137 @@ contains
 !
 !-----------------------------------------------------------------------
 
-    subroutine update_scaling_factor(domain)!{{{
+    subroutine update_scaling_factor(domain,timeLevel)!{{{
 
         type (domain_type), intent(inout) :: domain
 
+        integer, intent(in) :: timeLevel
+
         type (block_type), pointer :: block_ptr
+
         type (mpas_pool_type), pointer :: forcingPool
+        
+        type (mpas_timeInterval_type) :: &
+                timeStepESMF
 
         real (kind=RKIND), pointer :: & 
                 avgprecFlux, & 
-                avgfwFlux, & 
-                avgsalFlux, & 
+                avgfwFlux, &
+                SSHinitial, &
+                SSHfinal, & 
                 SFWFScalingFactor
 
         real (kind=RKIND), dimension(:), pointer :: & 
                 totalAccumulatedprecFluxHistory, &
-                totalAccumulatedfwFluxHistory, &
-                totalAccumulatedsalFluxHistory
+                totalAccumulatedfwFluxHistory
 
         integer, pointer :: nValidHistory, nAccumulated
 
         real (kind=RKIND), dimension(:), allocatable :: &
                 tmpprecHistory, &
-                tmpfwHistory, &
-                tmpsalHistory 
+                tmpfwHistory
 
-        real (kind=RKIND) :: previousprecFlux, previousfwFlux, previoussalFlux
-        real (kind=RKIND) :: precFluxMean, fwFluxMean, salFluxMean
-        integer :: nHistory
+        real (kind=RKIND) :: previousprecFlux, previousfwFlux
+        real (kind=RKIND) :: precFluxMean, fwFluxMean
 
+        integer :: nHistory, err_tmp        
+
+        real(kind=RKIND) :: dt, dtAvg, v, A, c
+
+        character(len=160) :: m
+  
+        call mpas_set_timeInterval(timeStepESMF, timeString=config_dt, ierr=err_tmp)
+        call mpas_get_timeInterval(timeStepESMF, dt=dt)
+
+        ! independent of blocks
         block_ptr => domain % blocklist
         call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
         call mpas_pool_get_array(forcingPool, 'nAccumulatedfwFlux', nAccumulated)
         call mpas_pool_get_array(forcingPool, 'nValidTotalfwFluxHistory', nValidHistory)
         call mpas_pool_get_array(forcingPool, 'avgprecFlux', avgprecFlux)
         call mpas_pool_get_array(forcingPool, 'avgfwFlux', avgfwFlux)
-        call mpas_pool_get_array(forcingPool, 'avgsalFlux', avgsalFlux)
         call mpas_pool_get_array(forcingPool, 'totalAccumulatedprecFluxHistory', totalAccumulatedprecFluxHistory)
         call mpas_pool_get_array(forcingPool, 'totalAccumulatedfwFluxHistory', totalAccumulatedfwFluxHistory)
-        call mpas_pool_get_array(forcingPool, 'totalAccumulatedsalFluxHistory', totalAccumulatedsalFluxHistory)
         call mpas_pool_get_array(forcingPool, 'SFWFScalingFactor', SFWFScalingFactor)
 
+        call mpas_pool_get_array(forcingPool, "SSHinitial", SSHinitial)
+        call mpas_pool_get_array(forcingPool, "SSHfinal", SSHfinal)
+        call compute_ssh_mass(domain,timeLevel,SSHfinal)
+
         nHistory = config_sfwf_history_years
+        dtAvg = dt * nAccumulated
 
-        previousprecFlux = totalAccumulatedprecFluxHistory(nValidHistory)
-        previousfwFlux = totalAccumulatedfwFluxHistory(nValidHistory)
-        previoussalFlux = totalAccumulatedsalFluxHistory(nValidHistory)
+        avgfwFlux = (SSHfinal - SSHinitial) / dtAvg ! unit: kg / s 
 
+        previousprecFlux = totalAccumulatedprecFluxHistory(nValidHistory) 
+        previousfwFlux = totalAccumulatedfwFluxHistory(nValidHistory) 
+        
         if (nValidHistory == 0) then
-            ! here followed the module mpas_ocn_scaled_dismf.F
-            ! we keep zero as the first entry in totalAccumulated fluxes 
+            ! Followed the module mpas_ocn_scaled_dismf.F
+            ! We keep zero as the first entry in totalAccumulated fluxes 
             nValidHistory = 1
         end if
 
         if (nHistory > 1) then 
             if (nValidHistory == nHistory) then
-                ! we need to shift the history, since it's full
+                ! We need to shift the history, since it's full
                 allocate(tmpprecHistory(nHistory))
                 allocate(tmpfwHistory(nHistory))
-                allocate(tmpsalHistory(nHistory))
                 tmpprecHistory(:) = totalAccumulatedprecFluxHistory(:)
                 tmpfwHistory(:) = totalAccumulatedfwFluxHistory(:)
-                tmpsalHistory(:) = totalAccumulatedsalFluxHistory(:)
                 totalAccumulatedprecFluxHistory(1:nHistory - 1) = tmpprecHistory(2:nHistory)
                 totalAccumulatedfwFluxHistory(1:nHistory - 1) = tmpfwHistory(2:nHistory)
-                totalAccumulatedsalFluxHistory(1:nHistory - 1) = tmpsalHistory(2:nHistory)
             else
                 ! the history isn't full yet, so we just add to the end
                 nValidHistory = nValidHistory + 1
             end if
             ! add the new total, the previous total plus the new yearly average
-            totalAccumulatedprecFluxHistory(nValidHistory) = previousprecFlux + avgprecFlux
-            totalAccumulatedfwFluxHistory(nValidHistory) = previousfwFlux + avgfwFlux
-            totalAccumulatedsalFluxHistory(nValidHistory) = previoussalFlux + avgsalFlux
-        else 
             totalAccumulatedprecFluxHistory(nValidHistory) = avgprecFlux
-            totalAccumulatedfwFluxHistory(nValidHistory) = avgfwFlux
-            totalAccumulatedsalFluxHistory(nValidHistory) = avgsalFlux
+            totalAccumulatedfwFluxHistory(nValidHistory) = avgfwFlux 
+        else 
+            totalAccumulatedprecFluxHistory(nValidHistory) = avgprecFlux 
+            totalAccumulatedfwFluxHistory(nValidHistory) = avgfwFlux 
         end if
 
-        ! Scaling factors are ratio of (freshwater flux + salinity flux) to precipitation flux 
-        ! Therefore is independent of the time invervals for the accumulated fluxes 
-        precFluxMean = totalAccumulatedprecFluxHistory(nValidHistory) 
-        fwFluxMean = totalAccumulatedfwFluxHistory(nValidHistory) 
-        salFluxMean = totalAccumulatedsalFluxHistory(nValidHistory) 
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        ! Scaling factors are computed as the ratio of ssh-inferred mass flux to precipitation flux.
+        ! Average values are used when nHistory > 1
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        precFluxMean = sum(totalAccumulatedprecFluxHistory(1:nHistory)) / nHistory
+        fwFluxMean = sum(totalAccumulatedfwFluxHistory(1:nHistory)) / nHistory 
 
-        SFWFScalingFactor = SFWFScalingFactor - (fwFluxMean + salFluxMean) / precFluxMean
+        if (config_sfwf_use_prev_factor) then 
+           SFWFScalingFactor = SFWFScalingFactor - fwFluxMean / precFluxMean
+        else
+           SFWFScalingFactor = 1.0_RKIND - fwFluxMean / precFluxMean 
+        end if 
 
         ! reset yearly averaging of the precipitation and freshwater fluxes 
         nAccumulated = 0
         avgprecFlux = 0.0_RKIND 
-        avgfwFlux = 0.0_RKIND
-        avgsalFlux = 0.0_RKIND
+
+        !-------------------------------------------------------------
+        ! Output to log file
+        !-------------------------------------------------------------
+        if (config_sfwf_balance_write_to_logfile) then
+            call mpas_log_write('----------------------------------------------------------')
+            call mpas_log_write('WATER CONSERVATION CHECK')
+            A = earthAreaE3SM
+            c = 1.0_RKIND / A
+            call mpas_log_write('WATER FLUXES')
+            call mpas_log_write('MPAS-Ocean name          kg/s (F)                coupler name     short name     kg/m^2/s (F/A)')
+            write(m,"('precFluxMean            ',es16.8,'       x2o_Faxa_(rain/snow)     prect     ',f16.8)") & 
+                    precFluxMean,precFluxMean*c; call mpas_log_write(m)
+            write(m,"('fwFluxMean              ',es16.8,'       ssh                      ssh       ',f16.8)") &
+                    fwFluxMean,fwFluxMean*c; call mpas_log_write(m)
+
+            call mpas_log_write('SCALING FACTOR ON PRECIPITATION FLUXES')
+            call mpas_log_write(' ')
+            write(m,"('SFWFScalingFactor       ',es16.8,'       precip_fact              fact      ',f16.8)") &
+                    SFWFScalingFactor,1.0_RKIND - fwFluxMean / precFluxMean; call mpas_log_write(m)
+            call mpas_log_write(' ')
+            call mpas_log_write('----------------------------------------------------------')
+        end if 
 
     end subroutine update_scaling_factor!}}}
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
@@ -187,7 +187,7 @@ contains
 #ifdef mpas_DEBUG
             call mpas_log_write('       Computing Scaling Factor For Water Fluxes')
 #endif
-            call ocn_update_scaling_factor(domain,timeLevelLocal)
+            call compute_scaling_factor(domain,timeLevelLocal)
             call mpas_reset_clock_alarm(domain % clock, alarmID, ierr=err_tmp)
        endif
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
@@ -191,6 +191,10 @@ contains
                 sshOld, &
                 sshNew
 
+      
+        real(kind=RKIND), dimension(:,:), pointer :: &
+                layerThickness
+
         real(kind=RKIND), dimension(:,:,:), pointer :: &
                 activeTracersNew, &
                 activeTracersOld
@@ -282,16 +286,16 @@ contains
            !$omp end do
            !$omp end parallel
 
-           allocate(localArraySalinitySum(nCellsSolve))
-           localArraySalinitySum(:) = 0.0_RKIND
+           allocate(localArrayForSalinitySum(nCellsSolve))
+           localArrayForSalinitySum(:) = 0.0_RKIND
            
            !salinity flux
            !convert to 
            !$omp parallel
            !$omp do schedule(runtime) private(k)
-           do iCell = 1,nCells
+           do iCell = 1,nCellsSolve
              do k = minLevelCell(iCell), maxLevelCell(iCell)
-                localArraySalinitySum(iCell) = localArraySalinitySum(iCell) - & 
+                localArrayForSalinitySum(iCell) = localArrayForSalinitySum(iCell) - & 
                      areaCell(iCell) * layerThickness(k,iCell) * & ! cell volume
                      (activeTracersNew(indexSalinity,k,iCell) - activeTracersOld(indexSalinity,k,iCell)) * & ! * ! cell salinity
                      rho_fw * 1.e3_RKIND / ocn_ref_salinity / dt ! F = - rho * h * 1/S * dS/dt 
@@ -305,11 +309,11 @@ contains
 
         precFlux = mpas_global_sum(localArrayForPrecSum, domain % dminfo % comm)
         fwFlux = mpas_global_sum(localArrayForSSHSum, domain % dminfo % comm)
-        salFlux = mpas_global_sum(localArraySalinitySum, domain % dminfo % comm)
+        salFlux = mpas_global_sum(localArrayForSalinitySum, domain % dminfo % comm)
 
         deallocate (localArrayForPrecSum)
         deallocate (localArrayForSSHSum)
-        deallocate (localArraySalinitySum)
+        deallocate (localArrayForSalinitySum)
 
         avgprecFlux = (avgprecFlux * nAccumulated + precFlux) / ( nAccumulated + 1 )
         avgfwFlux = (avgfwFlux * nAccumulated + fwFlux) / ( nAccumulated + 1 )

--- a/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
@@ -16,7 +16,7 @@
 !>  due to precipitation uniformly to ensure a balance of fresh water
 !>  at the ocean surface.
 !>  Designed following precip_adjustment subroutine located at:
-!>    https://github.com/ESCOMP/POP2-CESM/blob/master/source/forcing_sfwf.F90
+!>  https://github.com/ESCOMP/POP2-CESM/blob/master/source/forcing_sfwf.F90
 !
 !-----------------------------------------------------------------------
 
@@ -31,12 +31,11 @@ module ocn_scaled_sfwf
     use ocn_config
     use ocn_mesh
 
-    use shr_kind_mod, only: & 
-        SHR_KIND_R8
-
     use shr_const_mod
 
     use ocn_constants, only: & 
+        pi, &      
+        earthRadius, & 
         rho_fw, & 
         rho_sw, &
         ocn_ref_salinity
@@ -57,7 +56,7 @@ module ocn_scaled_sfwf
     !
     !--------------------------------------------------------------------
 
-    public :: ocn_init_scaled_sfwf, &
+    public :: ocn_scaled_sfwf_init, &
               ocn_update_scaling_factor
 
     !--------------------------------------------------------------------
@@ -69,7 +68,7 @@ module ocn_scaled_sfwf
     logical :: scaledSFWFOn
     character (len=*), parameter :: alarmID = 'scaledSFWFUpdateAlarm'
 
-    real (kind=RKIND) :: earthAreaE3SM ! surface area of earth in coupler
+    real (kind=RKIND) :: earthArea ! surface area of earth in coupler
 
     real(kind=RKIND) :: rhow, areaCellGlobal, volumeCellGlobal
 
@@ -80,7 +79,7 @@ contains
 
 !***********************************************************************
 !
-!  routine ocn_init_scaled_sfwf
+!  routine ocn_scaled_sfwf_init
 !
 !> \brief   Initialize scaling of data freshwater fluxes
 !> \author Shixuan Zhang 
@@ -90,7 +89,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-    subroutine ocn_init_scaled_sfwf(domain)!{{{
+    subroutine ocn_scaled_sfwf_init(domain)!{{{
 
         type (domain_type), intent(inout) :: domain
 
@@ -99,11 +98,6 @@ contains
         type (mpas_TimeInterval_type) :: alarmTimeStep
 
         integer :: err_tmp
-
-        ! taking PI from SHR_CONST_PI in share/util/shr_const_mod.F90 to match coupler
-        real (kind=RKIND), parameter :: piE3SM = SHR_CONST_PI
-        ! taking earth radius from SHR_CONST_REARTH in share/util/shr_const_mod.F90 to match coupler
-        real (kind=RKIND), parameter :: earthRadiusE3SM = SHR_CONST_REARTH ! radius of earth, m
 
         character(len=19) :: timeString
 
@@ -141,12 +135,12 @@ contains
                                   alarmTimeInterval=alarmTimeStep, ierr=err_tmp)
                           
         ! Compute Earth's surface area (used for normalizing fluxes)
-        earthAreaE3SM = 4.0_RKIND * piE3SM * earthRadiusE3SM*earthRadiusE3SM
+        earthArea = 4.0_RKIND * pi * earthRadius * earthRadius
 
         ! Density of sea water
         rhow = rho_sw
 
-    end subroutine ocn_init_scaled_sfwf!}}}
+    end subroutine ocn_scaled_sfwf_init!}}}
 
 
 !***********************************************************************
@@ -193,7 +187,7 @@ contains
 #ifdef mpas_DEBUG
             call mpas_log_write('       Computing Scaling Factor For Water Fluxes')
 #endif
-            call update_scaling_factor(domain,timeLevelLocal)
+            call ocn_update_scaling_factor(domain,timeLevelLocal)
             call mpas_reset_clock_alarm(domain % clock, alarmID, ierr=err_tmp)
        endif
 
@@ -201,7 +195,7 @@ contains
 
 !***********************************************************************
 !
-!  routine compute_ssh_mass
+!  routine compute_mass_from_ssh
 !
 !> \brief  Derive ssh inferred freshwater mass 
 !> \author Shixuan Zhang
@@ -210,7 +204,7 @@ contains
 !>  calculate ssh equivalent total mass over ocean grid point 
 !
 !-----------------------------------------------------------------------
-    subroutine compute_ssh_mass(domain,timeLevel,sshMass)!{{{
+    subroutine compute_mass_from_ssh(domain,timeLevel,sshMass)!{{{
 
         type (domain_type), intent(inout) :: domain
 
@@ -277,7 +271,7 @@ contains
         ! Output to log file
         !-------------------------------------------------------------
         if (config_precip_scaling_write_to_logfile) then
-            A = earthAreaE3SM
+            A = earthArea
             c = 1._RKIND / A 
             call mpas_log_write('----------------------------------------------------------')
             call mpas_log_write('WATER CONSERVATION CHECK')
@@ -290,7 +284,7 @@ contains
             call mpas_log_write('----------------------------------------------------------')
         end if
 
-    end subroutine compute_ssh_mass!}}}
+    end subroutine compute_mass_from_ssh!}}}
 
 !***********************************************************************
 !
@@ -350,7 +344,7 @@ contains
 
         if ( nAccumulated == 0 ) then 
            call mpas_pool_get_array(forcingPool, "SSHinitial", SSHinitial)
-           call compute_ssh_mass(domain,timeLevel,SSHinitial)
+           call compute_mass_from_ssh(domain,timeLevel,SSHinitial)
         end if
 
         do while (associated(block_ptr))
@@ -394,7 +388,7 @@ contains
 
 !***********************************************************************
 !
-!  routine update_scaling_factor
+!  routine ocn_update_scaling_factor
 !
 !> \brief  Update scaling factors for data freshwater fluxes 
 !> \author Shixuan Zhang 
@@ -405,7 +399,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-    subroutine update_scaling_factor(domain,timeLevel)!{{{
+    subroutine ocn_update_scaling_factor(domain,timeLevel)!{{{
 
         type (domain_type), intent(inout) :: domain
 
@@ -460,7 +454,7 @@ contains
 
         call mpas_pool_get_array(forcingPool, "SSHinitial", SSHinitial)
         call mpas_pool_get_array(forcingPool, "SSHfinal", SSHfinal)
-        call compute_ssh_mass(domain,timeLevel,SSHfinal)
+        call compute_mass_from_ssh(domain,timeLevel,SSHfinal)
 
         nHistory = config_precip_scaling_history_years
         dtAvg = dt * nAccumulated
@@ -530,7 +524,7 @@ contains
 
             call mpas_log_write('----------------------------------------------------------')
             call mpas_log_write('WATER CONSERVATION CHECK')
-            A = earthAreaE3SM
+            A = earthArea
             c = 1.0_RKIND / A
             call mpas_log_write('WATER FLUXES')
             call mpas_log_write('MPAS-Ocean name          kg/s (F)                coupler name     short name     kg/m^2/s (F/A)')
@@ -552,6 +546,6 @@ contains
 
         end if 
 
-    end subroutine update_scaling_factor!}}}
+    end subroutine ocn_update_scaling_factor!}}}
 
 end module ocn_scaled_sfwf

--- a/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
@@ -13,7 +13,7 @@
 !> \date   May 2025
 !> \details
 !>  Computes a precipitation factor to multiply the fresh water flux
-!>  due to precipitation uniformly to insure a balance of fresh water
+!>  due to precipitation uniformly to ensure a balance of fresh water
 !>  at the ocean surface.
 !>  Designed following precip_adjustment subroutine located at:
 !>    https://github.com/ESCOMP/POP2-CESM/blob/master/source/forcing_sfwf.F90

--- a/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
@@ -498,11 +498,7 @@ contains
         precFluxMean = sum(totalAccumulatedprecFluxHistory(1:nHistory)) / nHistory
         fwFluxMean = sum(totalAccumulatedfwFluxHistory(1:nHistory)) / nHistory 
 
-        if (config_sfwf_use_prev_factor) then 
-           SFWFScalingFactor = SFWFScalingFactor - fwFluxMean / precFluxMean
-        else
-           SFWFScalingFactor = 1.0_RKIND - fwFluxMean / precFluxMean 
-        end if 
+        SFWFScalingFactor = SFWFScalingFactor - fwFluxMean / precFluxMean
 
         ! reset yearly averaging of the precipitation and freshwater fluxes 
         nAccumulated = 0

--- a/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
@@ -107,20 +107,26 @@ contains
 
         character(len=19) :: timeString
 
-        if (config_sfwf_balance .and. config_sfwf_balance_type > 0) then
+        if (config_use_precip_scaling) then
             scaledSFWFOn = .true.
         else
             scaledSFWFOn = .false.
             return
         endif
 
-        if (config_sfwf_history_years < 1) then
-            call mpas_log_write('scaledSFWFOn = .true. requires config_sfwf_history_years >= 1', &
+        if (trim(config_precip_scaling_mode) /= 'time-dependent' .and.  &
+            trim(config_precip_scaling_mode) /= 'constant') then
+            call mpas_log_write('scaledSFWFOn = .true. requires config_precip_scaling_mode = time-dependent or constant', &
+                                mpas_LOG_CRIT)
+        end if
+
+        if (config_precip_scaling_history_years < 1) then
+            call mpas_log_write('scaledSFWFOn = .true. requires config_precip_scaling_history_years >= 1', &
                                 mpas_LOG_CRIT)
         endif
         
-        ! Setup time interval string based on config_sfwf_history_years (treated as "years")
-        write(timeString, '( I4.4,"-00-00_00:00:00" )') config_sfwf_history_years
+        ! Setup time interval string based on config_precip_scaling_history_years (treated as "years")
+        write(timeString, '( I4.4,"-00-00_00:00:00" )') config_precip_scaling_history_years
 
         ! Setup Alarm for updating of scaling factors for precipitation flux
         alarmTime = mpas_get_clock_time(domain % clock, &
@@ -170,6 +176,10 @@ contains
        if (.not. scaledSFWFOn) then
            return
        end if
+
+       if (trim(config_precip_scaling_mode) == 'constant') then
+           return
+       end if 
 
        if ( present(timeLevel) ) then
           timeLevelLocal = timeLevel
@@ -270,7 +280,7 @@ contains
         !-------------------------------------------------------------
         ! Output to log file
         !-------------------------------------------------------------
-        if (config_sfwf_balance_write_to_logfile) then
+        if (config_precip_scaling_write_to_logfile) then
             A = earthAreaE3SM
             c = 1._RKIND / A 
             call mpas_log_write('----------------------------------------------------------')
@@ -456,7 +466,7 @@ contains
         call mpas_pool_get_array(forcingPool, "SSHfinal", SSHfinal)
         call compute_ssh_mass(domain,timeLevel,SSHfinal)
 
-        nHistory = config_sfwf_history_years
+        nHistory = config_precip_scaling_history_years
         dtAvg = dt * nAccumulated
 
         avgfwFlux = (SSHfinal - SSHinitial) / dtAvg ! unit: kg / s 
@@ -507,7 +517,7 @@ contains
         !-------------------------------------------------------------
         ! Output to log file
         !-------------------------------------------------------------
-        if (config_sfwf_balance_write_to_logfile) then
+        if (config_precip_scaling_write_to_logfile) then
             call mpas_log_write('----------------------------------------------------------')
             call mpas_log_write('WATER CONSERVATION CHECK')
             A = earthAreaE3SM

--- a/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_scaled_sfwf.F
@@ -388,7 +388,7 @@ contains
 
 !***********************************************************************
 !
-!  routine ocn_update_scaling_factor
+!  routine compute_scaling_factor
 !
 !> \brief  Update scaling factors for data freshwater fluxes 
 !> \author Shixuan Zhang 
@@ -399,7 +399,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-    subroutine ocn_update_scaling_factor(domain,timeLevel)!{{{
+    subroutine compute_scaling_factor(domain,timeLevel)!{{{
 
         type (domain_type), intent(inout) :: domain
 
@@ -546,6 +546,6 @@ contains
 
         end if 
 
-    end subroutine ocn_update_scaling_factor!}}}
+    end subroutine compute_scaling_factor!}}}
 
 end module ocn_scaled_sfwf


### PR DESCRIPTION
This pull request introduces a new module and function in the MPAS-Ocean (MPAS-O) model to compute and apply a scaling factor on precipitation fluxes. The goal of this feature is to help maintain freshwater balance in ocean-only simulations by mitigating the spurious linear trend observed in sea surface height (SSH) over time. The updates specifically target uncoupled ocean configurations, including:
- G-case: ocean + sea ice with data atmosphere
- J-case: land + river + ocean + sea ice with data atmosphere

These configurations do not include a dynamically coupled atmosphere, and thus lack the feedback mechanisms necessary for naturally maintaining freshwater balance. This PR provides a workaround by dynamically adjusting the precipitation flux.

[NML]
[BFB] - stealth feature, off by default

---

**Problem Overview**

In E3SM preindustrial (1850) spin-up simulations using standalone ocean or ocean-plus-land configurations—particularly when driven by prescribed historical atmospheric forcing—a pronounced linear trend appears in the sea surface height (SSH) anomaly fields (Figure 1). This trend signals a breakdown in the freshwater budget, which is normally maintained in fully coupled simulations. Without an interactive atmosphere, the ocean component cannot influence freshwater fluxes such as precipitation and snowfall, eliminating the feedback mechanisms necessary for a balanced system. As a result, the standalone spin-up generates unrealistic SSH states, degrading the initial conditions used for fully coupled production runs.
![Figure 1](https://github.com/user-attachments/assets/f8303100-7bfc-4a7b-8108-d369f893f832)

**Solution Summary**
This pull request introduces a mechanism to dynamically enforce freshwater balance in standalone ocean configurations of E3SM. It implements a scaling scheme that adjusts the atmospheric precipitation fluxes (rain + snow) passed to the ocean model. The scaling factor is derived from the diagnosed imbalance between precipitation, evaporation, and river runoff, ensuring that the net freshwater input to the ocean evolves conservatively over time. This approach helps mitigate the spurious sea surface height drift typically observed in long spin-up simulations without interactive atmospheric feedbacks (see example in Figure 2 for time evolution of SSH after applying the scaling scheme in this pull request).
![Figure 2](https://github.com/user-attachments/assets/b3bd0517-ef32-4b10-b534-bcf634e523e9)

**Key Features**
- **Precipitation scaling logic**: Applies a time-evolving or constant scaling factor to rain and snow fluxes from the prescribed atmosphere to maintain freshwater balance.

- **Runtime diagnostics**: Tracks and reports freshwater flux terms to evaluate the effectiveness of the adjustment.

- **Targeted simulation**: Designed for use in standalone ocean and ocean-land E3SM configurations, particularly during long spin-up phases.

**Design and Documentation**
Full technical details, including derivation of the scaling algorithm, code structure, verification strategy, and validation results, are documented at:
[Design Document: Dynamical adjustment on freshwater fluxes balance for E3SM runs](https://acme-climate.atlassian.net/wiki/spaces/CM/pages/5209489517/Design+Document+Dynamical+adjustment+on+freshwater+fluxes+balance+for+E3SM+runs)

