### PR TITLE
EAMxx: update EKAT submodule and adapt EAMxx

### DIFF
--- a/components/eamxx/CMakeLists.txt
+++ b/components/eamxx/CMakeLists.txt
@@ -466,6 +466,8 @@ endif()
 #               Configure all tpls and subfolders                  #
 ####################################################################
 
+set (EKAT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../externals/ekat)
+
 if (DEFINED ENV{SCREAM_FAKE_ONLY})
   # We don't really need to build ekat, but we do need to configure the test-launcher
 
@@ -489,8 +491,6 @@ if (DEFINED ENV{SCREAM_FAKE_ONLY})
   else()
     set (TEST_LAUNCHER_ON_GPU False)
   endif()
-
-  set (EKAT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../externals/ekat)
 
   if (EKAT_ENABLE_MPI)
     find_package(MPI REQUIRED COMPONENTS C)
@@ -520,11 +520,13 @@ if (DEFINED ENV{SCREAM_FAKE_ONLY})
   endif()
 
 else()
-  include(EkatBuildEkat)
-  BuildEkat(PREFIX "SCREAM"
-    ENABLE_TESTS OFF
-    ENABLE_FPE   ON
-    ENABLE_FPE_DEFAULT_MASK OFF)
+  # Enable all EKAT packages
+  set(EKAT_ENABLE_KOKKOS ON)
+  set(EKAT_ENABLE_PACK ON)
+  set(EKAT_ENABLE_ALGORITHM ON)
+  set(EKAT_ENABLE_LOGGING ON)
+  set(EKAT_ENABLE_YAML_PARSER ON)
+  add_subdirectory(${EKAT_SOURCE_DIR} ${CMAKE_BINARY_DIR}/externals/ekat)
 endif()
 
 # Set compiler-specific flags

--- a/components/eamxx/cmake/ScreamUtils.cmake
+++ b/components/eamxx/cmake/ScreamUtils.cmake
@@ -81,14 +81,14 @@ set(SCREAM_CUT_TEST_MV_ARGS ${CUT_TEST_MV_ARGS})
 #
 
 # Scream always excludes the ekat test session since it has its own
-list(REMOVE_ITEM SCREAM_CUT_EXEC_OPTIONS EXCLUDE_TEST_SESSION)
+list(REMOVE_ITEM SCREAM_CUT_EXEC_OPTIONS USER_DEFINED_TEST_SESSION)
 
 ###############################################################################
 function(CreateUnitTestExec exec_name test_srcs)
 ###############################################################################
   # Call Ekat function, with a couple of extra params
   EkatCreateUnitTestExec("${exec_name}" "${test_srcs}" ${ARGN}
-    EXCLUDE_TEST_SESSION LIBS scream_share scream_test_support)
+    USER_DEFINED_TEST_SESSION LIBS scream_share scream_test_support)
 endfunction(CreateUnitTestExec)
 
 ###############################################################################

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -14,11 +14,11 @@
 #include "share/io/eamxx_io_utils.hpp"
 #include "share/property_checks/mass_and_energy_column_conservation_check.hpp"
 
-#include "ekat/ekat_assert.hpp"
-#include "ekat/util/ekat_string_utils.hpp"
-#include "ekat/ekat_parameter_list.hpp"
-#include "ekat/ekat_parse_yaml_file.hpp"
-#include "ekat/std_meta/ekat_std_utils.hpp"
+#include <ekat_assert.hpp>
+#include <ekat_string_utils.hpp>
+#include <ekat_parameter_list.hpp>
+#include <ekat_yaml.hpp>
+#include <ekat_std_utils.hpp>
 
 // The global variable fvphyshack is used to help the initial pgN implementation
 // work around some current AD constraints. Search the code for "fvphyshack" to

--- a/components/eamxx/src/control/atmosphere_driver.hpp
+++ b/components/eamxx/src/control/atmosphere_driver.hpp
@@ -12,9 +12,9 @@
 #include "share/atm_process/SCDataManager.hpp"
 #include "share/atm_process/IOPDataManager.hpp"
 
-#include "ekat/logging/ekat_logger.hpp"
-#include "ekat/mpi/ekat_comm.hpp"
-#include "ekat/ekat_parameter_list.hpp"
+#include <ekat_logger.hpp>
+#include <ekat_comm.hpp>
+#include <ekat_parameter_list.hpp>
 
 #include <memory>
 

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
@@ -1,7 +1,7 @@
 #include "atmosphere_surface_coupling_exporter.hpp"
 
-#include "ekat/ekat_assert.hpp"
-#include "ekat/util/ekat_units.hpp"
+#include <ekat_assert.hpp>
+#include <ekat_units.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
@@ -1,5 +1,6 @@
 #include "atmosphere_surface_coupling_exporter.hpp"
 
+#include <ekat_team_policy_utils.hpp>
 #include <ekat_assert.hpp>
 #include <ekat_units.hpp>
 
@@ -364,7 +365,8 @@ void SurfaceCouplingExporter::set_from_file_exports()
 // index query in the below.
 void SurfaceCouplingExporter::compute_eamxx_exports(const double dt, const bool called_during_initialization)
 {
-  using PC = physics::Constants<Real>;
+  using PC  = physics::Constants<Real>;
+  using TPF = ekat::TeamPolicyFactory<KT::ExeSpace>;
 
   const auto& p_int                = get_field_in("p_int").get_view<const Real**>();
   const auto& pseudo_density       = get_field_in("pseudo_density").get_view<const Spack**>();
@@ -432,7 +434,7 @@ void SurfaceCouplingExporter::compute_eamxx_exports(const double dt, const bool 
 
   // Preprocess exports
   auto export_source = m_export_source;
-  const auto setup_policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_thread_range_parallel_scan_team_policy(num_cols, num_levs);
+  const auto setup_policy = TPF::get_thread_range_parallel_scan_team_policy(num_cols, num_levs);
   Kokkos::parallel_for(setup_policy, KOKKOS_LAMBDA(const Kokkos::TeamPolicy<KT::ExeSpace>::member_type& team) {
     const int i = team.league_rank();
 

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
@@ -87,7 +87,7 @@ void SurfaceCouplingExporter::create_helper_field (const std::string& name,
   Field f(id);
   f.get_header().get_alloc_properties().request_allocation();
   f.allocate_view();
-  f.deep_copy(ekat::ScalarTraits<Real>::invalid());
+  f.deep_copy(Kokkos::Experimental::quiet_NaN_v<Real>);
 
   m_helper_fields[name] = f;
 }

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.hpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.hpp
@@ -9,7 +9,8 @@
 #include "share/atm_process/ATMBufferManager.hpp"
 #include "share/atm_process/SCDataManager.hpp"
 
-#include <ekat/ekat_parameter_list.hpp>
+#include <ekat_parameter_list.hpp>
+
 #include <string>
 
 namespace scream

--- a/components/eamxx/src/control/atmosphere_surface_coupling_importer.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_importer.cpp
@@ -3,8 +3,8 @@
 #include "share/property_checks/field_within_interval_check.hpp"
 #include "physics/share/physics_constants.hpp"
 
-#include "ekat/ekat_assert.hpp"
-#include "ekat/util/ekat_units.hpp"
+#include <ekat_assert.hpp>
+#include <ekat_units.hpp>
 
 #include <array>
 

--- a/components/eamxx/src/control/atmosphere_surface_coupling_importer.hpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_importer.hpp
@@ -1,11 +1,12 @@
 #ifndef SCREAM_IMPORTER_HPP
 #define SCREAM_IMPORTER_HPP
 
+#include "surface_coupling_utils.hpp"
+
 #include "share/atm_process/atmosphere_process.hpp"
-#include "ekat/ekat_parameter_list.hpp"
 #include "share/atm_process/SCDataManager.hpp"
 
-#include "surface_coupling_utils.hpp"
+#include <ekat_parameter_list.hpp>
 
 #include <string>
 

--- a/components/eamxx/src/control/tests/ad_tests.cpp
+++ b/components/eamxx/src/control/tests/ad_tests.cpp
@@ -4,8 +4,8 @@
 #include "share/atm_process/atmosphere_process_group.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/ekat_parameter_list.hpp"
-#include "ekat/ekat_parse_yaml_file.hpp"
+#include <ekat_parameter_list.hpp>
+#include <ekat_yaml.hpp>
 
 #include <catch2/catch.hpp>
 

--- a/components/eamxx/src/control/tests/dummy_atm_proc.hpp
+++ b/components/eamxx/src/control/tests/dummy_atm_proc.hpp
@@ -2,8 +2,6 @@
 
 #include "share/atm_process/atmosphere_process.hpp"
 
-#include "ekat/ekat_pack.hpp"
-
 namespace scream {
 
 // === A dummy atm process, on Physics grid === //

--- a/components/eamxx/src/diagnostics/aerocom_cld.cpp
+++ b/components/eamxx/src/diagnostics/aerocom_cld.cpp
@@ -1,10 +1,10 @@
 #include "diagnostics/aerocom_cld.hpp"
 
-#include <ekat/kokkos/ekat_kokkos_utils.hpp>
-#include <string>
-
 #include "diagnostics/aerocom_cld_util.hpp"
 #include "share/util/eamxx_common_physics_functions.hpp"
+
+#include <ekat_team_policy_utils.hpp>
+#include <string>
 
 namespace scream {
 
@@ -98,7 +98,7 @@ void AeroComCld::compute_diagnostic_impl() {
    */
   using KT  = KokkosTypes<DefaultDevice>;
   using MT  = typename KT::MemberType;
-  using ESU = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
+  using TPF = ekat::TeamPolicyFactory<typename KT::ExeSpace>;
 
   using PF = scream::PhysicsFunctions<DefaultDevice>;
 
@@ -124,7 +124,7 @@ void AeroComCld::compute_diagnostic_impl() {
   auto q_threshold           = q_thresh_set();
   auto cldfrac_tot_threshold = cldfrac_tot_thresh_set();
 
-  const auto policy = ESU::get_default_team_policy(m_ncols, m_nlevs);
+  const auto policy = TPF::get_default_team_policy(m_ncols, m_nlevs);
 
   const auto out = m_diagnostic_output.get_view<Real **>();
 

--- a/components/eamxx/src/diagnostics/aodvis.cpp
+++ b/components/eamxx/src/diagnostics/aodvis.cpp
@@ -1,8 +1,9 @@
 #include "diagnostics/aodvis.hpp"
 
-#include <ekat/kokkos/ekat_kokkos_utils.hpp>
-
 #include "share/util/eamxx_universal_constants.hpp"
+
+#include <ekat_team_policy_utils.hpp>
+#include <ekat_reduction_utils.hpp>
 
 namespace scream {
 
@@ -64,7 +65,8 @@ void AODVis::initialize_impl(const RunType /*run_type*/) {
 void AODVis::compute_diagnostic_impl() {
   using KT  = KokkosTypes<DefaultDevice>;
   using MT  = typename KT::MemberType;
-  using ESU = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
+  using TPF = ekat::TeamPolicyFactory<typename KT::ExeSpace>;
+  using RU  = ekat::ReductionUtils<typename KT::ExeSpace>;
 
   const auto aod     = m_diagnostic_output.get_view<Real *>();
   const auto mask    = m_diagnostic_output.get_header()
@@ -77,7 +79,7 @@ void AODVis::compute_diagnostic_impl() {
 
   const auto num_levs = m_nlevs;
   const auto var_fill_value = m_mask_val;
-  const auto policy   = ESU::get_default_team_policy(m_ncols, m_nlevs);
+  const auto policy   = TPF::get_default_team_policy(m_ncols, m_nlevs);
   Kokkos::parallel_for(
       "Compute " + m_diagnostic_output.name(), policy, KOKKOS_LAMBDA(const MT &team) {
         const int icol = team.league_rank();
@@ -86,7 +88,7 @@ void AODVis::compute_diagnostic_impl() {
           Kokkos::single(Kokkos::PerTeam(team), [&] { mask(icol) = 0; });
         } else {
           auto tau_icol = ekat::subview(tau_vis, icol);
-          aod(icol)     = ESU::view_reduction(team, 0, num_levs, tau_icol);
+          aod(icol)     = RU::view_reduction(team, 0, num_levs, tau_icol);
           Kokkos::single(Kokkos::PerTeam(team), [&] { mask(icol) = 1; });
         }
       });

--- a/components/eamxx/src/diagnostics/atm_backtend.cpp
+++ b/components/eamxx/src/diagnostics/atm_backtend.cpp
@@ -1,7 +1,5 @@
 #include "diagnostics/atm_backtend.hpp"
 
-#include <ekat/kokkos/ekat_kokkos_utils.hpp>
-
 #include "share/util/eamxx_universal_constants.hpp"
 
 namespace scream {

--- a/components/eamxx/src/diagnostics/dry_static_energy.cpp
+++ b/components/eamxx/src/diagnostics/dry_static_energy.cpp
@@ -1,7 +1,7 @@
 #include "diagnostics/dry_static_energy.hpp"
 #include "share/util/eamxx_common_physics_functions.hpp"
 
-#include <ekat/kokkos/ekat_kokkos_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream
 {
@@ -51,8 +51,9 @@ void DryStaticEnergyDiagnostic::compute_diagnostic_impl()
 {
   using MemberType = typename KT::MemberType;
   using PF = PhysicsFunctions<DefaultDevice>;
+  using TPF = ekat::TeamPolicyFactory<typename KT::ExeSpace>;
 
-  const auto default_policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_thread_range_parallel_scan_team_policy(m_num_cols, m_num_levs);
+  const auto default_policy = TPF::get_thread_range_parallel_scan_team_policy(m_num_cols, m_num_levs);
 
   const auto& dse                = m_diagnostic_output.get_view<Real**>();
   const auto& T_mid              = get_field_in("T_mid").get_view<const Real**>();

--- a/components/eamxx/src/diagnostics/field_at_height.cpp
+++ b/components/eamxx/src/diagnostics/field_at_height.cpp
@@ -1,7 +1,7 @@
 #include "diagnostics/field_at_height.hpp"
 
-#include "ekat/std_meta/ekat_std_utils.hpp"
-#include "ekat/util/ekat_units.hpp"
+#include <ekat_std_utils.hpp>
+#include <ekat_units.hpp>
 
 namespace
 {

--- a/components/eamxx/src/diagnostics/field_at_level.cpp
+++ b/components/eamxx/src/diagnostics/field_at_level.cpp
@@ -1,6 +1,6 @@
 #include "diagnostics/field_at_level.hpp"
 
-#include "ekat/std_meta/ekat_std_utils.hpp"
+#include <ekat_std_utils.hpp>
 
 namespace scream
 {

--- a/components/eamxx/src/diagnostics/field_at_pressure_level.cpp
+++ b/components/eamxx/src/diagnostics/field_at_pressure_level.cpp
@@ -1,9 +1,9 @@
 #include "diagnostics/field_at_pressure_level.hpp"
 #include "share/util/eamxx_universal_constants.hpp"
 
-#include "ekat/std_meta/ekat_std_utils.hpp"
-#include "ekat/util/ekat_upper_bound.hpp"
-#include "ekat/util/ekat_units.hpp"
+#include <ekat_std_utils.hpp>
+#include <ekat_upper_bound.hpp>
+#include <ekat_units.hpp>
 
 namespace scream
 {

--- a/components/eamxx/src/diagnostics/field_at_pressure_level.hpp
+++ b/components/eamxx/src/diagnostics/field_at_pressure_level.hpp
@@ -3,8 +3,6 @@
 
 #include "share/atm_process/atmosphere_diagnostic.hpp"
 
-#include <ekat/ekat_pack.hpp>
-
 namespace scream
 {
 

--- a/components/eamxx/src/diagnostics/longwave_cloud_forcing.cpp
+++ b/components/eamxx/src/diagnostics/longwave_cloud_forcing.cpp
@@ -1,6 +1,6 @@
 #include "diagnostics/longwave_cloud_forcing.hpp"
 
-#include <ekat/kokkos/ekat_kokkos_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream
 {
@@ -43,10 +43,10 @@ void LongwaveCloudForcingDiagnostic::set_grids(const std::shared_ptr<const Grids
 void LongwaveCloudForcingDiagnostic::compute_diagnostic_impl()
 {
   using KT         = KokkosTypes<DefaultDevice>;
-  using ESU        = ekat::ExeSpaceUtils<KT::ExeSpace>;
+  using TPF        = ekat::TeamPolicyFactory<KT::ExeSpace>;
   using MemberType = typename KT::MemberType;
 
-  const auto default_policy = ESU::get_default_team_policy(m_num_cols,1);
+  const auto default_policy = TPF::get_default_team_policy(m_num_cols,1);
 
   const auto& LWCF              = m_diagnostic_output.get_view<Real*>();
   const auto& LW_flux_up        = get_field_in("LW_flux_up").get_view<const Real**>();

--- a/components/eamxx/src/diagnostics/number_path.cpp
+++ b/components/eamxx/src/diagnostics/number_path.cpp
@@ -1,6 +1,6 @@
 #include "diagnostics/number_path.hpp"
 
-#include <ekat/kokkos/ekat_kokkos_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 #include "physics/share/physics_constants.hpp"
 
@@ -62,7 +62,7 @@ void NumberPathDiagnostic::compute_diagnostic_impl() {
   using PC  = scream::physics::Constants<Real>;
   using KT  = KokkosTypes<DefaultDevice>;
   using MT  = typename KT::MemberType;
-  using ESU = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
+  using TPF = ekat::TeamPolicyFactory<typename KT::ExeSpace>;
 
   constexpr Real g = PC::gravit;
 
@@ -72,7 +72,7 @@ void NumberPathDiagnostic::compute_diagnostic_impl() {
   const auto rho = get_field_in("pseudo_density").get_view<const Real **>();
 
   const auto num_levs = m_num_levs;
-  const auto policy   = ESU::get_default_team_policy(m_num_cols, m_num_levs);
+  const auto policy   = TPF::get_default_team_policy(m_num_cols, m_num_levs);
   Kokkos::parallel_for(
       "Compute " + m_kind + name(), policy, KOKKOS_LAMBDA(const MT &team) {
         const int icol = team.league_rank();

--- a/components/eamxx/src/diagnostics/relative_humidity.cpp
+++ b/components/eamxx/src/diagnostics/relative_humidity.cpp
@@ -2,6 +2,8 @@
 #include "physics/share/physics_functions.hpp" // also for ETI not on GPUs
 #include "physics/share/physics_saturation_impl.hpp"
 
+#include <ekat_pack.hpp>
+
 namespace scream
 {
 

--- a/components/eamxx/src/diagnostics/shortwave_cloud_forcing.cpp
+++ b/components/eamxx/src/diagnostics/shortwave_cloud_forcing.cpp
@@ -1,6 +1,6 @@
 #include "diagnostics/shortwave_cloud_forcing.hpp"
 
-#include <ekat/kokkos/ekat_kokkos_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream
 {
@@ -41,10 +41,10 @@ void ShortwaveCloudForcingDiagnostic::set_grids(const std::shared_ptr<const Grid
 void ShortwaveCloudForcingDiagnostic::compute_diagnostic_impl()
 {
   using KT         = KokkosTypes<DefaultDevice>;
-  using ESU        = ekat::ExeSpaceUtils<KT::ExeSpace>;
+  using TPF        = ekat::TeamPolicyFactory<KT::ExeSpace>;
   using MemberType = typename KT::MemberType;
 
-  const auto default_policy = ESU::get_default_team_policy(m_num_cols,1);
+  const auto default_policy = TPF::get_default_team_policy(m_num_cols,1);
 
   const auto& SWCF              = m_diagnostic_output.get_view<Real*>();
   const auto& SW_flux_dn        = get_field_in("SW_flux_dn").get_view<const Real**>();

--- a/components/eamxx/src/diagnostics/tests/aodvis_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/aodvis_test.cpp
@@ -6,6 +6,7 @@
 #include "share/grid/mesh_free_grids_manager.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 #include "share/util/eamxx_universal_constants.hpp"
+
 namespace scream {
 
 std::shared_ptr<GridsManager> create_gm(const ekat::Comm &comm, const int ncols,

--- a/components/eamxx/src/diagnostics/tests/atm_density_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/atm_density_test.cpp
@@ -10,9 +10,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/util/ekat_test_utils.hpp"
 #include <ekat_pack.hpp>
 #include <ekat_team_policy_utils.hpp>
+#include <ekat_view_utils.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/diagnostics/tests/atm_density_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/atm_density_test.cpp
@@ -10,9 +10,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
 #include <ekat_pack.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 #include <iomanip>
 
@@ -47,6 +47,7 @@ void run(std::mt19937_64& engine)
   using KT         = ekat::KokkosTypes<DeviceT>;
   using ExecSpace  = typename KT::ExeSpace;
   using MemberType = typename KT::MemberType;
+  using TPF        = ekat::TeamPolicyFactory<ExecSpace>;
 
   const     int packsize = SCREAM_PACK_SIZE;
   constexpr int num_levs = packsize*2 + 1; // Number of levels to use for tests, make sure the last pack can also have some empty slots (packsize>1).
@@ -59,7 +60,7 @@ void run(std::mt19937_64& engine)
   auto gm = create_gm(comm,ncols,num_levs);
 
   // Kokkos Policy
-  auto policy = ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(ncols, num_levs);
+  auto policy = TPF::get_default_team_policy(ncols, num_levs);
 
   // Construct random input data
   using RPDF = std::uniform_real_distribution<Real>;

--- a/components/eamxx/src/diagnostics/tests/atm_density_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/atm_density_test.cpp
@@ -10,9 +10,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/ekat_pack.hpp"
 #include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_pack.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/diagnostics/tests/dry_static_energy_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/dry_static_energy_test.cpp
@@ -10,9 +10,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/util/ekat_test_utils.hpp"
 #include <ekat_pack.hpp>
 #include <ekat_team_policy_utils.hpp>
+#include <ekat_view_utils.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/diagnostics/tests/dry_static_energy_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/dry_static_energy_test.cpp
@@ -10,9 +10,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/ekat_pack.hpp"
 #include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_pack.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/diagnostics/tests/dry_static_energy_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/dry_static_energy_test.cpp
@@ -10,9 +10,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
 #include <ekat_pack.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 #include <iomanip>
 
@@ -48,6 +48,7 @@ void run(std::mt19937_64& engine)
   using ExecSpace  = typename KT::ExeSpace;
   using MemberType = typename KT::MemberType;
   using view_1d    = typename KT::template view_1d<Real>;
+  using TPF        = ekat::TeamPolicyFactory<ExecSpace>;
 
   const     int packsize = SCREAM_PACK_SIZE;
   constexpr int num_levs = packsize*2 + 1; // Number of levels to use for tests, make sure the last pack can also have some empty slots (packsize>1).
@@ -60,7 +61,7 @@ void run(std::mt19937_64& engine)
   auto gm = create_gm(comm,ncols,num_levs);
 
   // Kokkos Policy
-  auto policy = ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(ncols, num_levs);
+  auto policy = TPF::get_default_team_policy(ncols, num_levs);
 
   // Construct random input data
   using RPDF = std::uniform_real_distribution<Real>;

--- a/components/eamxx/src/diagnostics/tests/exner_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/exner_test.cpp
@@ -10,9 +10,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/util/ekat_test_utils.hpp"
 #include <ekat_pack.hpp>
 #include <ekat_team_policy_utils.hpp>
+#include <ekat_view_utils.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/diagnostics/tests/exner_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/exner_test.cpp
@@ -10,9 +10,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
 #include <ekat_pack.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 #include <iomanip>
 
@@ -47,6 +47,7 @@ void run(std::mt19937_64& engine)
   using KT         = ekat::KokkosTypes<DeviceT>;
   using ExecSpace  = typename KT::ExeSpace;
   using MemberType = typename KT::MemberType;
+  using TPF        = ekat::TeamPolicyFactory<ExecSpace>;
 
   const     int packsize = SCREAM_PACK_SIZE;
   constexpr int num_levs = packsize*2 + 1; // Number of levels to use for tests, make sure the last pack can also have some empty slots (packsize>1).
@@ -59,7 +60,7 @@ void run(std::mt19937_64& engine)
   auto gm = create_gm(comm,ncols,num_levs);
 
   // Kokkos Policy
-  auto policy = ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(ncols, num_levs);
+  auto policy = TPF::get_default_team_policy(ncols, num_levs);
 
   // Construct random input data
   using RPDF = std::uniform_real_distribution<Real>;

--- a/components/eamxx/src/diagnostics/tests/exner_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/exner_test.cpp
@@ -10,9 +10,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/ekat_pack.hpp"
 #include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_pack.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/diagnostics/tests/field_at_pressure_level_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/field_at_pressure_level_tests.cpp
@@ -1,12 +1,12 @@
 #include "catch2/catch.hpp"
 
-#include "ekat/ekat_pack_utils.hpp"
-
 #include "diagnostics/field_at_pressure_level.hpp"
 
 #include "share/grid/mesh_free_grids_manager.hpp"
 #include "share/field/field_utils.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
+
+#include <ekat_pack.hpp>
 
 namespace scream {
 

--- a/components/eamxx/src/diagnostics/tests/longwave_cloud_forcing_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/longwave_cloud_forcing_tests.cpp
@@ -10,9 +10,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/util/ekat_test_utils.hpp"
 #include <ekat_pack.hpp>
 #include <ekat_team_policy_utils.hpp>
+#include <ekat_view_utils.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/diagnostics/tests/longwave_cloud_forcing_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/longwave_cloud_forcing_tests.cpp
@@ -10,9 +10,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
 #include <ekat_pack.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 #include <iomanip>
 
@@ -48,6 +48,7 @@ void run(std::mt19937_64& engine)
   using MemberType = typename KT::MemberType;
   using view_1d    = typename KT::template view_1d<Pack>;
   using rview_1d   = typename KT::template view_1d<Real>;
+  using TPF        = ekat::TeamPolicyFactory<ExecSpace>;
 
   const     int packsize = SCREAM_PACK_SIZE;
   constexpr int num_levs = packsize*2 + 1; // Number of levels to use for tests, make sure the last pack can also have some empty slots (packsize>1).
@@ -61,7 +62,7 @@ void run(std::mt19937_64& engine)
   auto gm = create_gm(comm,ncols,num_levs);
 
   // Kokkos Policy
-  auto policy = ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(ncols, num_mid_packs);
+  auto policy = TPF::get_default_team_policy(ncols, num_mid_packs);
 
   // Input (randomized) views
   view_1d LW_flux_up("LW_flux_up",num_mid_packs),
@@ -116,8 +117,8 @@ void run(std::mt19937_64& engine)
       const auto& LW_flux_up_sub      = ekat::subview(LW_flux_up_v,icol);
       const auto& LW_clrsky_flux_up_sub      = ekat::subview(LW_clrsky_flux_up_v,icol);
 
-      ekat::genRandArray(dview_as_real(LW_flux_up),              engine, pdf_LW_flux_x);
-      ekat::genRandArray(dview_as_real(LW_clrsky_flux_up),              engine, pdf_LW_flux_x);
+      ekat::genRandArray(dview_as_real(LW_flux_up),        engine, pdf_LW_flux_x);
+      ekat::genRandArray(dview_as_real(LW_clrsky_flux_up), engine, pdf_LW_flux_x);
       Kokkos::deep_copy(LW_flux_up_sub,LW_flux_up);
       Kokkos::deep_copy(LW_clrsky_flux_up_sub,LW_clrsky_flux_up);
 

--- a/components/eamxx/src/diagnostics/tests/longwave_cloud_forcing_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/longwave_cloud_forcing_tests.cpp
@@ -10,9 +10,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/ekat_pack.hpp"
 #include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_pack.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/diagnostics/tests/number_paths_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/number_paths_tests.cpp
@@ -2,7 +2,6 @@
 
 #include "catch2/catch.hpp"
 #include "diagnostics/register_diagnostics.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
 #include "physics/share/physics_constants.hpp"
 #include "share/field/field_utils.hpp"

--- a/components/eamxx/src/diagnostics/tests/number_paths_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/number_paths_tests.cpp
@@ -2,13 +2,14 @@
 
 #include "catch2/catch.hpp"
 #include "diagnostics/register_diagnostics.hpp"
-#include "ekat/util/ekat_test_utils.hpp"
 #include "physics/share/physics_constants.hpp"
 #include "share/field/field_utils.hpp"
 #include "share/grid/mesh_free_grids_manager.hpp"
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 #include "share/util/eamxx_utils.hpp"
+
+#include <ekat_view_utils.hpp>
 
 namespace scream {
 

--- a/components/eamxx/src/diagnostics/tests/potential_temperature_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/potential_temperature_test.cpp
@@ -10,9 +10,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/util/ekat_test_utils.hpp"
 #include <ekat_pack.hpp>
 #include <ekat_team_policy_utils.hpp>
+#include <ekat_view_utils.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/diagnostics/tests/potential_temperature_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/potential_temperature_test.cpp
@@ -10,9 +10,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
 #include <ekat_pack.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 #include <iomanip>
 
@@ -47,6 +47,7 @@ void run(std::mt19937_64& engine, int int_ptype)
   using KT         = ekat::KokkosTypes<DeviceT>;
   using ExecSpace  = typename KT::ExeSpace;
   using MemberType = typename KT::MemberType;
+  using TPF        = ekat::TeamPolicyFactory<ExecSpace>;
 
   const     int packsize = SCREAM_PACK_SIZE;
   constexpr int num_levs = packsize*2 + 1; // Number of levels to use for tests, make sure the last pack can also have some empty slots (packsize>1).
@@ -59,7 +60,7 @@ void run(std::mt19937_64& engine, int int_ptype)
   auto gm = create_gm(comm,ncols,num_levs);
 
   // Kokkos Policy
-  auto policy = ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(ncols, num_levs);
+  auto policy = TPF::get_default_team_policy(ncols, num_levs);
 
   // Construct random input data
   using RPDF = std::uniform_real_distribution<Real>;

--- a/components/eamxx/src/diagnostics/tests/potential_temperature_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/potential_temperature_test.cpp
@@ -10,9 +10,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/ekat_pack.hpp"
 #include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_pack.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/diagnostics/tests/precip_surf_mass_flux_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/precip_surf_mass_flux_tests.cpp
@@ -8,7 +8,6 @@
 #include "share/util/eamxx_setup_random_test.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
 
 namespace scream {

--- a/components/eamxx/src/diagnostics/tests/precip_surf_mass_flux_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/precip_surf_mass_flux_tests.cpp
@@ -8,7 +8,7 @@
 #include "share/util/eamxx_setup_random_test.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_view_utils.hpp>
 
 namespace scream {
 

--- a/components/eamxx/src/diagnostics/tests/relative_humidity_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/relative_humidity_tests.cpp
@@ -11,9 +11,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
 #include <ekat_pack.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 #include <iomanip>
 
@@ -50,6 +50,7 @@ void run(std::mt19937_64& engine)
   using MemberType = typename KT::MemberType;
   using view_1d    = typename KT::template view_1d<Pack>;
   using rview_1d   = typename KT::template view_1d<Real>;
+  using TPF        = ekat::TeamPolicyFactory<ExecSpace>;
 
   const     int packsize = SCREAM_PACK_SIZE;
   constexpr int num_levs = packsize*2 + 1; // Number of levels to use for tests, make sure the last pack can also have some empty slots (packsize>1).
@@ -63,7 +64,7 @@ void run(std::mt19937_64& engine)
   auto gm = create_gm(comm,ncols,num_levs);
 
   // Kokkos Policy
-  auto policy = ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(ncols, num_mid_packs);
+  auto policy = TPF::get_default_team_policy(ncols, num_mid_packs);
 
   // Input (randomized) views, device
   view_1d temperature("temperature",num_mid_packs),

--- a/components/eamxx/src/diagnostics/tests/relative_humidity_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/relative_humidity_tests.cpp
@@ -11,9 +11,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/ekat_pack.hpp"
 #include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_pack.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/diagnostics/tests/relative_humidity_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/relative_humidity_tests.cpp
@@ -11,9 +11,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/util/ekat_test_utils.hpp"
 #include <ekat_pack.hpp>
 #include <ekat_team_policy_utils.hpp>
+#include <ekat_view_utils.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/diagnostics/tests/sea_level_pressure_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/sea_level_pressure_test.cpp
@@ -10,8 +10,8 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/util/ekat_test_utils.hpp"
 #include <ekat_pack.hpp>
+#include <ekat_view_utils.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/diagnostics/tests/sea_level_pressure_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/sea_level_pressure_test.cpp
@@ -10,9 +10,8 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_pack.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/diagnostics/tests/shortwave_cloud_forcing_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/shortwave_cloud_forcing_tests.cpp
@@ -10,9 +10,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
 #include <ekat_pack.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 #include <iomanip>
 
@@ -48,6 +48,7 @@ void run(std::mt19937_64& engine)
   using MemberType = typename KT::MemberType;
   using view_1d    = typename KT::template view_1d<Pack>;
   using rview_1d   = typename KT::template view_1d<Real>;
+  using TPF        = ekat::TeamPolicyFactory<ExecSpace>;
 
   const     int packsize = SCREAM_PACK_SIZE;
   constexpr int num_levs = packsize*2 + 1; // Number of levels to use for tests, make sure the last pack can also have some empty slots (packsize>1).
@@ -61,7 +62,7 @@ void run(std::mt19937_64& engine)
   auto gm = create_gm(comm,ncols,num_levs);
 
   // Kokkos Policy
-  auto policy = ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(ncols, num_mid_packs);
+  auto policy = TPF::get_default_team_policy(ncols, num_mid_packs);
 
   // Input (randomized) views
   view_1d SW_flux_dn("SW_flux_dn",num_mid_packs),

--- a/components/eamxx/src/diagnostics/tests/shortwave_cloud_forcing_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/shortwave_cloud_forcing_tests.cpp
@@ -10,9 +10,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/util/ekat_test_utils.hpp"
 #include <ekat_pack.hpp>
 #include <ekat_team_policy_utils.hpp>
+#include <ekat_view_utils.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/diagnostics/tests/shortwave_cloud_forcing_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/shortwave_cloud_forcing_tests.cpp
@@ -10,9 +10,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/ekat_pack.hpp"
 #include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_pack.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/diagnostics/tests/surf_upward_latent_heat_flux_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/surf_upward_latent_heat_flux_tests.cpp
@@ -9,9 +9,8 @@
 #include "share/util/eamxx_setup_random_test.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
-#include "ekat/logging/ekat_logger.hpp"
+#include <ekat_logger.hpp>
 
 namespace scream {
 

--- a/components/eamxx/src/diagnostics/tests/surf_upward_latent_heat_flux_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/surf_upward_latent_heat_flux_tests.cpp
@@ -9,8 +9,8 @@
 #include "share/util/eamxx_setup_random_test.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/util/ekat_test_utils.hpp"
 #include <ekat_logger.hpp>
+#include <ekat_view_utils.hpp>
 
 namespace scream {
 

--- a/components/eamxx/src/diagnostics/tests/vapor_flux_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/vapor_flux_tests.cpp
@@ -10,8 +10,8 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/util/ekat_test_utils.hpp"
 #include <ekat_team_policy_utils.hpp>
+#include <ekat_view_utils.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/diagnostics/tests/vapor_flux_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/vapor_flux_tests.cpp
@@ -10,8 +10,8 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_team_policy_utils.hpp>
 
 #include <iomanip>
 
@@ -44,7 +44,7 @@ void run(std::mt19937_64& engine)
   using PC         = scream::physics::Constants<Real>;
   using KT         = ekat::KokkosTypes<DeviceT>;
   using ExecSpace  = typename KT::ExeSpace;
-  using ESU        = ekat::ExeSpaceUtils<ExecSpace>;
+  using TPF        = ekat::TeamPolicyFactory<ExecSpace>;
   using MemberType = typename KT::MemberType;
   using view_1d    = typename KT::template view_1d<Real>;
 
@@ -58,7 +58,7 @@ void run(std::mt19937_64& engine)
   auto gm = create_gm(comm,ncols,num_levs);
 
   // Kokkos Policy
-  auto policy = ESU::get_default_team_policy(ncols, num_levs);
+  auto policy = TPF::get_default_team_policy(ncols, num_levs);
 
   // Input (randomized) views
   view_1d qv("qv",num_levs),

--- a/components/eamxx/src/diagnostics/tests/virtual_temperature_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/virtual_temperature_test.cpp
@@ -10,9 +10,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
 #include <ekat_pack.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 #include <iomanip>
 
@@ -46,6 +46,7 @@ void run(std::mt19937_64& engine)
   using KT         = ekat::KokkosTypes<DeviceT>;
   using ExecSpace  = typename KT::ExeSpace;
   using MemberType = typename KT::MemberType;
+  using TPF        = ekat::TeamPolicyFactory<ExecSpace>;
 
   const     int packsize = SCREAM_PACK_SIZE;
   constexpr int num_levs = packsize*2 + 1; // Number of levels to use for tests, make sure the last pack can also have some empty slots (packsize>1).
@@ -58,7 +59,7 @@ void run(std::mt19937_64& engine)
   auto gm = create_gm(comm,ncols,num_levs);
 
   // Kokkos Policy
-  auto policy = ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(ncols, num_levs);
+  auto policy = TPF::get_default_team_policy(ncols, num_levs);
 
   // Construct random input data
   using RPDF = std::uniform_real_distribution<Real>;

--- a/components/eamxx/src/diagnostics/tests/virtual_temperature_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/virtual_temperature_test.cpp
@@ -10,9 +10,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/util/ekat_test_utils.hpp"
 #include <ekat_pack.hpp>
 #include <ekat_team_policy_utils.hpp>
+#include <ekat_view_utils.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/diagnostics/tests/virtual_temperature_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/virtual_temperature_test.cpp
@@ -10,9 +10,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/ekat_pack.hpp"
 #include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_pack.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/diagnostics/tests/water_path_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/water_path_tests.cpp
@@ -10,8 +10,8 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/util/ekat_test_utils.hpp"
 #include <ekat_team_policy_utils.hpp>
+#include <ekat_view_utils.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/diagnostics/tests/water_path_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/water_path_tests.cpp
@@ -10,8 +10,8 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_team_policy_utils.hpp>
 
 #include <iomanip>
 
@@ -43,7 +43,7 @@ void run(std::mt19937_64& engine)
 {
   using PC         = scream::physics::Constants<Real>;
   using KT         = ekat::KokkosTypes<DeviceT>;
-  using ESU        = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
+  using TPF        = ekat::TeamPolicyFactory<typename KT::ExeSpace>;
   using MemberType = typename KT::MemberType;
   using view_1d    = typename KT::template view_1d<Real>;
 
@@ -59,7 +59,7 @@ void run(std::mt19937_64& engine)
   auto gm = create_gm(comm,ncols,num_levs);
 
   // Kokkos Policy
-  auto policy = ESU::get_default_team_policy(ncols, num_levs);
+  auto policy = TPF::get_default_team_policy(ncols, num_levs);
 
   // Input (randomized) views
   view_1d

--- a/components/eamxx/src/diagnostics/vapor_flux.cpp
+++ b/components/eamxx/src/diagnostics/vapor_flux.cpp
@@ -1,7 +1,7 @@
 #include "diagnostics/vapor_flux.hpp"
 #include "physics/share/physics_constants.hpp"
 
-#include <ekat/kokkos/ekat_kokkos_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream
 {
@@ -56,7 +56,7 @@ void VaporFluxDiagnostic::compute_diagnostic_impl()
   using PC  = scream::physics::Constants<Real>;
   using KT  = KokkosTypes<DefaultDevice>;
   using MT  = typename KT::MemberType;
-  using ESU = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
+  using TPF = ekat::TeamPolicyFactory<typename KT::ExeSpace>;
 
   constexpr Real g = PC::gravit;
 
@@ -66,7 +66,7 @@ void VaporFluxDiagnostic::compute_diagnostic_impl()
   const auto wind  = get_field_in("horiz_winds").get_component(m_component).get_view<const Real**>();
 
   const auto num_levs = m_num_levs;
-  const auto policy = ESU::get_default_team_policy(m_num_cols, m_num_levs);
+  const auto policy = TPF::get_default_team_policy(m_num_cols, m_num_levs);
   Kokkos::parallel_for("Compute " + m_name, policy,
                        KOKKOS_LAMBDA(const MT& team) {
     const int icol = team.league_rank();

--- a/components/eamxx/src/diagnostics/vert_contract.cpp
+++ b/components/eamxx/src/diagnostics/vert_contract.cpp
@@ -4,6 +4,8 @@
 #include "share/field/field_utils.hpp"
 #include "share/util/eamxx_common_physics_functions.hpp"
 
+#include <ekat_team_policy_utils.hpp>
+
 namespace scream {
 
 VertContractDiag::VertContractDiag(const ekat::Comm &comm,
@@ -157,11 +159,11 @@ void VertContractDiag::compute_diagnostic_impl() {
     // m_weighting.update(get_field_in("dz"), 1.0, 0.0);
     using KT  = KokkosTypes<DefaultDevice>;
     using MT  = typename KT::MemberType;
-    using ESU = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
+    using TPF = ekat::TeamPolicyFactory<typename KT::ExeSpace>;
     using PF = scream::PhysicsFunctions<DefaultDevice>;
     const int ncols = m_weighting.get_header().get_identifier().get_layout().dim(0);
     const int nlevs = m_weighting.get_header().get_identifier().get_layout().dim(1);
-    const auto policy = ESU::get_default_team_policy(ncols, nlevs);
+    const auto policy = TPF::get_default_team_policy(ncols, nlevs);
 
     auto dz_v = m_weighting.get_view<Real**>();
     auto dp_v = get_field_in("pseudo_density").get_view<const Real**>();

--- a/components/eamxx/src/diagnostics/vertical_layer.cpp
+++ b/components/eamxx/src/diagnostics/vertical_layer.cpp
@@ -4,6 +4,8 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/util/eamxx_column_ops.hpp"
 
+#include <ekat_team_policy_utils.hpp>
+
 namespace scream
 {
 
@@ -164,12 +166,13 @@ void VerticalLayerDiagnostic::do_compute_diagnostic_impl()
   using KT    = KokkosTypes<DefaultDevice>;
   using MemberType = typename KT::MemberType;
   using PF    = PhysicsFunctions<DefaultDevice>;
+  using TPF   = ekat::TeamPolicyFactory<KT::ExeSpace>;
 
   // To use in column_ops, since we integrate from surface
   constexpr bool FromTop = false;
 
   const auto npacks = ekat::npack<PackT>(m_num_levs);
-  const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_thread_range_parallel_scan_team_policy(m_num_cols, npacks);
+  const auto policy = TPF::get_thread_range_parallel_scan_team_policy(m_num_cols, npacks);
 
   const auto& T    = get_field_in("T_mid").get_view<const PackT**>();
   const auto& p    = get_field_in("p_mid").get_view<const PackT**>();

--- a/components/eamxx/src/diagnostics/water_path.cpp
+++ b/components/eamxx/src/diagnostics/water_path.cpp
@@ -1,7 +1,7 @@
 #include "diagnostics/water_path.hpp"
 #include "physics/share/physics_constants.hpp"
 
-#include <ekat/kokkos/ekat_kokkos_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream
 {
@@ -62,7 +62,7 @@ void WaterPathDiagnostic::compute_diagnostic_impl()
   using PC  = scream::physics::Constants<Real>;
   using KT  = KokkosTypes<DefaultDevice>;
   using MT  = typename KT::MemberType;
-  using ESU = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
+  using TPF = ekat::TeamPolicyFactory<typename KT::ExeSpace>;
 
   constexpr Real g = PC::gravit;
 
@@ -71,7 +71,7 @@ void WaterPathDiagnostic::compute_diagnostic_impl()
   const auto rho    = get_field_in("pseudo_density").get_view<const Real**>();
 
   const auto num_levs = m_num_levs;
-  const auto policy = ESU::get_default_team_policy(m_num_cols, m_num_levs);
+  const auto policy = TPF::get_default_team_policy(m_num_cols, m_num_levs);
   Kokkos::parallel_for("Compute " + m_kind + name(), policy,
                        KOKKOS_LAMBDA(const MT& team) {
     const int icol = team.league_rank();

--- a/components/eamxx/src/diagnostics/wind_speed.cpp
+++ b/components/eamxx/src/diagnostics/wind_speed.cpp
@@ -1,7 +1,5 @@
 #include "diagnostics/wind_speed.hpp"
 
-#include <ekat/kokkos/ekat_kokkos_utils.hpp>
-
 namespace scream
 {
 

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_fv_phys.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_fv_phys.cpp
@@ -15,9 +15,9 @@
 
 // Ekat includes
 #include <ekat_assert.hpp>
+#include <ekat_team_policy_utils.hpp>
 #include <ekat_subview_utils.hpp>
 #include <ekat_pack.hpp>
-#include <ekat_pack_kokkos.hpp>
 #include <ekat_pack_utils.hpp>
 
 extern "C" void gfr_init_hxx();
@@ -79,8 +79,9 @@ static void copy_prev (const int ncols, const int npacks,
                        const T_t& T, const uv_t& uv,
                        const FT_t& FT, const FM_t& FM) {
   using KT = KokkosTypes<DefaultDevice>;
-  using ESU = ekat::ExeSpaceUtils<KT::ExeSpace>;
-  const auto policy = ESU::get_default_team_policy(ncols, npacks);
+  using TPF = ekat::TeamPolicyFactory<KT::ExeSpace>;
+
+  const auto policy = TPF::get_default_team_policy(ncols, npacks);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA (const KT::MemberType& team) {
     const int& icol = team.league_rank();
     Kokkos::parallel_for(Kokkos::TeamVectorRange(team, npacks),

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_fv_phys.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_fv_phys.cpp
@@ -14,11 +14,11 @@
 #include "dynamics/homme/homme_dimensions.hpp"
 
 // Ekat includes
-#include "ekat/ekat_assert.hpp"
-#include "ekat/kokkos/ekat_subview_utils.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/ekat_pack_kokkos.hpp"
-#include "ekat/ekat_pack_utils.hpp"
+#include <ekat_assert.hpp>
+#include <ekat_subview_utils.hpp>
+#include <ekat_pack.hpp>
+#include <ekat_pack_kokkos.hpp>
+#include <ekat_pack_utils.hpp>
 
 extern "C" void gfr_init_hxx();
 

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
@@ -34,14 +34,14 @@
 #include "share/property_checks/field_lower_bound_check.hpp"
 
 // Ekat includes
-#include "ekat/ekat_assert.hpp"
-#include "ekat/kokkos//ekat_subview_utils.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/ekat_pack_kokkos.hpp"
-#include "ekat/ekat_scalar_traits.hpp"
-#include "ekat/util/ekat_units.hpp"
-#include "ekat/ekat_pack_utils.hpp"
-#include "ekat/ekat_workspace.hpp"
+#include <ekat_assert.hpp>
+#include <ekat_subview_utils.hpp>
+#include <ekat_pack.hpp>
+#include <ekat_pack_kokkos.hpp>
+#include <ekat_scalar_traits.hpp>
+#include <ekat_units.hpp>
+#include <ekat_pack_utils.hpp>
+#include <ekat_workspace.hpp>
 
 namespace scream
 {
@@ -1052,10 +1052,11 @@ void HommeDynamics::restart_homme_state () {
 
 void HommeDynamics::initialize_homme_state () {
   // Some types
-  using ColOps = ColumnOps<DefaultDevice,Real>;
-  using PF = PhysicsFunctions<DefaultDevice>;
-  using ESU = ekat::ExeSpaceUtils<KT::ExeSpace>;
-  using EOS = Homme::EquationOfState;
+  using ColOps       = ColumnOps<DefaultDevice,Real>;
+  using PF           = PhysicsFunctions<DefaultDevice>;
+  using ESU          = ekat::ExeSpaceUtils<KT::ExeSpace>;
+  using EOS          = Homme::EquationOfState;
+  using WorkspaceMgr = ekat::WorkspaceManager<Pack, DefaultDevice>;
 
   const auto& rgn = m_cgll_grid->name();
 

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
@@ -37,8 +37,7 @@
 #include <ekat_assert.hpp>
 #include <ekat_subview_utils.hpp>
 #include <ekat_pack.hpp>
-#include <ekat_pack_kokkos.hpp>
-#include <ekat_scalar_traits.hpp>
+#include <ekat_math_utils.hpp>
 #include <ekat_units.hpp>
 #include <ekat_pack_utils.hpp>
 #include <ekat_workspace.hpp>
@@ -773,7 +772,7 @@ create_helper_field (const std::string& name,
   Field f(id);
   f.get_header().get_alloc_properties().request_allocation(pack_size);
   f.allocate_view();
-  f.deep_copy(ekat::ScalarTraits<Real>::invalid());
+  f.deep_copy(ekat::quiet_NaN<Real>());
 
   m_helper_fields[name] = f;
 }

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.hpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.hpp
@@ -4,9 +4,8 @@
 #include "share/atm_process/atmosphere_process.hpp"
 #include "share/grid/remap/abstract_remapper.hpp"
 
-#include "ekat/ekat_parameter_list.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/ekat_workspace.hpp"
+#include <ekat_parameter_list.hpp>
+#include <ekat_pack.hpp>
 
 #include <string>
 
@@ -25,8 +24,6 @@ class HommeDynamics : public AtmosphereProcess
 {
   // Define some types needed by class
   using Pack = ekat::Pack<Real, SCREAM_PACK_SIZE>;
-  using IntPack = ekat::Pack<int, SCREAM_PACK_SIZE>;
-  using Mask = ekat::Mask<SCREAM_PACK_SIZE>;
 
   using KT = KokkosTypes<DefaultDevice>;
   template<typename ScalarT>
@@ -39,9 +36,6 @@ class HommeDynamics : public AtmosphereProcess
   using uview_1d = ekat::Unmanaged<view_1d<ST>>;
   template<typename ST>
   using uview_2d = ekat::Unmanaged<view_2d<ST>>;
-
-  using WorkspaceMgr = ekat::WorkspaceManager<Pack, DefaultDevice>;
-  using Workspace = WorkspaceMgr::Workspace;
 
 public:
 

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_rayleigh_friction.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_rayleigh_friction.cpp
@@ -6,6 +6,8 @@
 // Homme includes
 #include "dynamics/homme/homme_dimensions.hpp"
 
+#include <ekat_team_policy_utils.hpp>
+
 namespace scream {
 
 void HommeDynamics::rayleigh_friction_init()
@@ -54,7 +56,7 @@ void HommeDynamics::rayleigh_friction_init()
 void HommeDynamics::rayleigh_friction_apply(const Real dt) const
 {
   using PF = PhysicsFunctions<DefaultDevice>;
-  using ESU = ekat::ExeSpaceUtils<KT::ExeSpace>;
+  using TPF = ekat::TeamPolicyFactory<KT::ExeSpace>;
 
   // If m_raytau0==0, then no Rayleigh friction is applied. Return.
   if (m_raytau0 == 0) return;
@@ -69,7 +71,7 @@ void HommeDynamics::rayleigh_friction_apply(const Real dt) const
   // local for lambda captures to avoid issues on GPU
   auto otau = m_otau;
 
-  const auto policy = ESU::get_default_team_policy(ncols, npacks);
+  const auto policy = TPF::get_default_team_policy(ncols, npacks);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA (const KT::MemberType& team) {
     const int& icol = team.league_rank();
 

--- a/components/eamxx/src/dynamics/homme/homme_dynamics_helpers.hpp
+++ b/components/eamxx/src/dynamics/homme/homme_dynamics_helpers.hpp
@@ -3,7 +3,7 @@
 
 #include "Context.hpp"
 
-#include "ekat/ekat_scalar_traits.hpp"
+#include <ekat_scalar_traits.hpp>
 
 // Homme includes
 #include "Types.hpp"

--- a/components/eamxx/src/dynamics/homme/homme_dynamics_helpers.hpp
+++ b/components/eamxx/src/dynamics/homme/homme_dynamics_helpers.hpp
@@ -19,20 +19,6 @@ struct ScalarTraits<Homme::Scalar> {
   using inner_traits = ScalarTraits<Homme::Real>;
 
   static constexpr bool is_simd = true;
-
-  static std::string name () {
-    return "Homme::Scalar";
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static const value_type quiet_NaN () {
-    return value_type(inner_traits::quiet_NaN());
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  static const value_type invalid () {
-    return value_type(inner_traits::invalid());
-  }
 };
 
 } // namespace ekat

--- a/components/eamxx/src/dynamics/homme/homme_grids_manager.cpp
+++ b/components/eamxx/src/dynamics/homme/homme_grids_manager.cpp
@@ -83,7 +83,7 @@ HommeGridsManager::do_create_remapper (const grid_ptr_type from_grid,
       return std::make_shared<InverseRemapper>(pd_remapper);
     }
   } else {
-    ekat::error::runtime_abort("Error! P-D remapping only implemented for 'physics_gll' phys grid.\n");
+    EKAT_ERROR_MSG("Error! P-D remapping only implemented for 'physics_gll' phys grid.\n");
   }
   return nullptr;
 }

--- a/components/eamxx/src/dynamics/homme/homme_grids_manager.cpp
+++ b/components/eamxx/src/dynamics/homme/homme_grids_manager.cpp
@@ -20,7 +20,7 @@
 #include "homme_dimensions.hpp"
 #include "PhysicalConstants.hpp"
 
-#include "ekat/std_meta/ekat_std_utils.hpp"
+#include <ekat_std_utils.hpp>
 
 namespace scream
 {

--- a/components/eamxx/src/dynamics/homme/interface/eamxx_homme_interface.hpp
+++ b/components/eamxx/src/dynamics/homme/interface/eamxx_homme_interface.hpp
@@ -8,8 +8,8 @@
 #include "Context.hpp"
 #include "mpi/Comm.hpp"
 
-#include "ekat/mpi/ekat_comm.hpp"
-#include "ekat/ekat_assert.hpp"
+#include <ekat_comm.hpp>
+#include <ekat_assert.hpp>
 
 #include <mpi.h>
 #include <string>

--- a/components/eamxx/src/dynamics/homme/physics_dynamics_remapper.cpp
+++ b/components/eamxx/src/dynamics/homme/physics_dynamics_remapper.cpp
@@ -13,8 +13,8 @@
 #include "share/grid/se_grid.hpp"
 #include "share/util/eamxx_utils.hpp"
 
-#include "ekat/ekat_pack_utils.hpp"
-#include "ekat/ekat_assert.hpp"
+#include <ekat_pack_utils.hpp>
+#include <ekat_assert.hpp>
 
 namespace {
 

--- a/components/eamxx/src/dynamics/homme/physics_dynamics_remapper.hpp
+++ b/components/eamxx/src/dynamics/homme/physics_dynamics_remapper.hpp
@@ -5,7 +5,7 @@
 
 #include "share/grid/remap/abstract_remapper.hpp"
 
-#include "ekat/ekat_pack.hpp"
+#include <ekat_pack.hpp>
 
 namespace Homme {
 class BoundaryExchange;

--- a/components/eamxx/src/dynamics/homme/tests/dyn_grid_io.cpp
+++ b/components/eamxx/src/dynamics/homme/tests/dyn_grid_io.cpp
@@ -15,9 +15,9 @@
 #include "share/util/eamxx_setup_random_test.hpp"
 #include "share/util/eamxx_time_stamp.hpp"
 
-#include "ekat/util/ekat_units.hpp"
-#include "ekat/ekat_parameter_list.hpp"
-#include "ekat/mpi/ekat_comm.hpp"
+#include <ekat_units.hpp>
+#include <ekat_parameter_list.hpp>
+#include <ekat_comm.hpp>
 
 extern "C" {
 // These are specific C/F calls for these tests (i.e., not part of eamxx_homme_interface.hpp)

--- a/components/eamxx/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
+++ b/components/eamxx/src/dynamics/homme/tests/homme_pd_remap_tests.cpp
@@ -13,9 +13,9 @@
 #include "dynamics/homme/homme_dimensions.hpp"
 #include "dynamics/homme/homme_grids_manager.hpp"
 
-#include "ekat/mpi/ekat_comm.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_comm.hpp>
+#include <ekat_pack.hpp>
+#include <ekat_test_utils.hpp>
 
 #include <memory>
 #include <random>

--- a/components/eamxx/src/physics/cld_fraction/cld_fraction_functions.hpp
+++ b/components/eamxx/src/physics/cld_fraction/cld_fraction_functions.hpp
@@ -3,8 +3,8 @@
 
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack_kokkos.hpp"
-#include "ekat/ekat_workspace.hpp"
+#include <ekat_pack_kokkos.hpp>
+#include <ekat_workspace.hpp>
 
 namespace scream {
 namespace cld_fraction {

--- a/components/eamxx/src/physics/cld_fraction/cld_fraction_main_impl.hpp
+++ b/components/eamxx/src/physics/cld_fraction/cld_fraction_main_impl.hpp
@@ -2,7 +2,8 @@
 #define CLD_FRACTION_MAIN_IMPL_HPP
 
 #include "physics/cld_fraction/cld_fraction_functions.hpp"
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace cld_fraction {

--- a/components/eamxx/src/physics/cld_fraction/cld_fraction_main_impl.hpp
+++ b/components/eamxx/src/physics/cld_fraction/cld_fraction_main_impl.hpp
@@ -3,6 +3,7 @@
 
 #include "physics/cld_fraction/cld_fraction_functions.hpp"
 
+#include <ekat_team_policy_utils.hpp>
 #include <ekat_subview_utils.hpp>
 
 namespace scream {
@@ -24,8 +25,10 @@ void CldFractionFunctions<S,D>
   const view_2d<Spack>& tot_cld_frac_4out)
 {
   using ExeSpace = typename KT::ExeSpace;
+  using TPF = ekat::TeamPolicyFactory<ExeSpace>;
+
   const Int nk_pack = ekat::npack<Spack>(nk);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(nj, nk_pack);
+  const auto policy = TPF::get_default_team_policy(nj, nk_pack);
   Kokkos::parallel_for(
     "cld fraction main loop",
     policy,

--- a/components/eamxx/src/physics/cld_fraction/eamxx_cld_fraction_process_interface.cpp
+++ b/components/eamxx/src/physics/cld_fraction/eamxx_cld_fraction_process_interface.cpp
@@ -1,8 +1,8 @@
 #include "eamxx_cld_fraction_process_interface.hpp"
 #include "share/property_checks/field_within_interval_check.hpp"
 
-#include "ekat/ekat_assert.hpp"
-#include "ekat/util/ekat_units.hpp"
+#include <ekat_assert.hpp>
+#include <ekat_units.hpp>
 
 #include <array>
 

--- a/components/eamxx/src/physics/cld_fraction/eamxx_cld_fraction_process_interface.hpp
+++ b/components/eamxx/src/physics/cld_fraction/eamxx_cld_fraction_process_interface.hpp
@@ -3,7 +3,8 @@
 
 #include "physics/cld_fraction/cld_fraction_functions.hpp"
 #include "share/atm_process/atmosphere_process.hpp"
-#include "ekat/ekat_parameter_list.hpp"
+
+#include <ekat_parameter_list.hpp>
 
 #include <string>
 

--- a/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
+++ b/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
@@ -174,10 +174,10 @@ void Cosp::run_impl (const double dt)
 
     using KT       = KokkosTypes<DefaultDevice>;
     using ExeSpace = typename KT::ExeSpace;
-    using ESU      = ekat::ExeSpaceUtils<ExeSpace>;
+    using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
     using PF       = scream::PhysicsFunctions<DefaultDevice>;
 
-    const auto scan_policy = ESU::get_thread_range_parallel_scan_team_policy(ncol, nlev);
+    const auto scan_policy = TPF::get_thread_range_parallel_scan_team_policy(ncol, nlev);
     const auto g = physics::Constants<Real>::gravit;
     Kokkos::parallel_for(scan_policy, KOKKOS_LAMBDA (const KT::MemberType& team) {
         const int i = team.league_rank();

--- a/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
+++ b/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
@@ -1,12 +1,11 @@
 #include "eamxx_cosp.hpp"
 #include "cosp_functions.hpp"
-#include "share/property_checks/field_within_interval_check.hpp"
 #include "physics/share/physics_constants.hpp"
-
-#include "ekat/ekat_assert.hpp"
-#include "ekat/util/ekat_units.hpp"
-
+#include "share/property_checks/field_within_interval_check.hpp"
 #include "share/field/field_utils.hpp"
+
+#include <ekat_assert.hpp>
+#include <ekat_units.hpp>
 
 #include <array>
 

--- a/components/eamxx/src/physics/cosp/eamxx_cosp.hpp
+++ b/components/eamxx/src/physics/cosp/eamxx_cosp.hpp
@@ -3,7 +3,8 @@
 
 #include "share/atm_process/atmosphere_process.hpp"
 #include "share/util/eamxx_common_physics_functions.hpp"
-#include "ekat/ekat_parameter_list.hpp"
+
+#include <ekat_parameter_list.hpp>
 
 #include <string>
 

--- a/components/eamxx/src/physics/gw/gw_functions.hpp
+++ b/components/eamxx/src/physics/gw/gw_functions.hpp
@@ -5,9 +5,9 @@
 
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack_kokkos.hpp"
-#include "ekat/ekat_workspace.hpp"
-#include "ekat/ekat_parameter_list.hpp"
+#include <ekat_pack_kokkos.hpp>
+#include <ekat_workspace.hpp>
+#include <ekat_parameter_list.hpp>
 
 namespace scream {
 namespace gw {

--- a/components/eamxx/src/physics/gw/tests/gw_gwd_compute_tendencies_from_stress_divergence_tests.cpp
+++ b/components/eamxx/src/physics/gw/tests/gw_gwd_compute_tendencies_from_stress_divergence_tests.cpp
@@ -1,13 +1,12 @@
 #include "catch2/catch.hpp"
 
 #include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "physics/gw/gw_functions.hpp"
 #include "physics/gw/tests/infra/gw_test_data.hpp"
 
 #include "gw_unit_tests_common.hpp"
 
+#include <ekat_pack.hpp>
 namespace scream {
 namespace gw {
 namespace unit_test {

--- a/components/eamxx/src/physics/gw/tests/gw_gwd_compute_tendencies_from_stress_divergence_tests.cpp
+++ b/components/eamxx/src/physics/gw/tests/gw_gwd_compute_tendencies_from_stress_divergence_tests.cpp
@@ -7,6 +7,7 @@
 #include "gw_unit_tests_common.hpp"
 
 #include <ekat_pack.hpp>
+
 namespace scream {
 namespace gw {
 namespace unit_test {
@@ -60,7 +61,7 @@ struct UnitWrap::UnitTest<D>::TestGwdComputeTendenciesFromStressDivergence : pub
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -93,7 +94,7 @@ struct UnitWrap::UnitTest<D>::TestGwdComputeTendenciesFromStressDivergence : pub
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        test_data[i].write(Base::m_fid);
+        test_data[i].write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/gw/tests/infra/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/tests/infra/CMakeLists.txt
@@ -4,5 +4,5 @@ set(INFRA_SRCS
 )
 
 add_library(gw_test_infra ${INFRA_SRCS})
-target_link_libraries(gw_test_infra gw)
+target_link_libraries(gw_test_infra PUBLIC gw scream_test_support)
 target_include_directories(gw_test_infra PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
@@ -1,9 +1,8 @@
 #include "gw_test_data.hpp"
-#include "ekat/kokkos/ekat_kokkos_types.hpp"
 
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
-#include "ekat/ekat_pack_kokkos.hpp"
-#include "ekat/ekat_assert.hpp"
+#include <ekat_math_utils.hpp>
+#include <ekat_kokkos_types.hpp>
+#include <ekat_assert.hpp>
 
 #include <random>
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
@@ -1,11 +1,11 @@
 #ifndef GW_UNIT_TESTS_COMMON_HPP
 #define GW_UNIT_TESTS_COMMON_HPP
 
+#include "gw_functions.hpp"
+#include "gw_test_data.hpp"
+
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
-#include "gw_functions.hpp"
-#include "ekat/util/ekat_test_utils.hpp"
-#include "gw_test_data.hpp"
 
 #include <vector>
 #include <sstream>

--- a/components/eamxx/src/physics/iop_forcing/eamxx_iop_forcing_process_interface.cpp
+++ b/components/eamxx/src/physics/iop_forcing/eamxx_iop_forcing_process_interface.cpp
@@ -3,6 +3,8 @@
 #include "share/field/field_utils.hpp"
 #include "share/property_checks/field_within_interval_check.hpp"
 
+#include <ekat_math_utils.hpp>
+
 namespace scream
 {
 // =========================================================================================
@@ -111,7 +113,7 @@ void IOPForcing::create_helper_field (const std::string& name,
   Field f(id);
   f.get_header().get_alloc_properties().request_allocation(ps);
   f.allocate_view();
-  f.deep_copy(ekat::ScalarTraits<Real>::invalid());
+  f.deep_copy(ekat::quiet_NaN<Real>());
 
   m_helper_fields[name] = f;
 }

--- a/components/eamxx/src/physics/iop_forcing/eamxx_iop_forcing_process_interface.hpp
+++ b/components/eamxx/src/physics/iop_forcing/eamxx_iop_forcing_process_interface.hpp
@@ -1,14 +1,14 @@
 #ifndef SCREAM_IOP_FORCING_HPP
 #define SCREAM_IOP_FORCING_HPP
 
-#include "ekat/ekat_parameter_list.hpp"
-#include "ekat/ekat_workspace.hpp"
-
 #include "share/atm_process/atmosphere_process.hpp"
 #include "share/atm_process/ATMBufferManager.hpp"
 #include "share/util/eamxx_column_ops.hpp"
 
 #include "physics/share/physics_constants.hpp"
+
+#include <ekat_parameter_list.hpp>
+#include <ekat_workspace.hpp>
 
 #include <string>
 

--- a/components/eamxx/src/physics/iop_forcing/eamxx_iop_forcing_process_interface.hpp
+++ b/components/eamxx/src/physics/iop_forcing/eamxx_iop_forcing_process_interface.hpp
@@ -29,7 +29,6 @@ class IOPForcing : public scream::AtmosphereProcess
 {
   // Typedefs for process
   using KT           = ekat::KokkosTypes<DefaultDevice>;
-  using ESU          = ekat::ExeSpaceUtils<KT::ExeSpace>;
   using Pack         = ekat::Pack<Real, SCREAM_PACK_SIZE>;
   using IntPack      = ekat::Pack<int, Pack::n>;
   using Mask         = ekat::Mask<Pack::n>;

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -5,9 +5,9 @@
 #include "share/util/eamxx_utils.hpp"
 #include "share/io/eamxx_scorpio_interface.hpp"
 
-#include <ekat/kokkos/ekat_kokkos_utils.hpp>
 #include <ekat_lin_interp.hpp>
 #include <ekat_math_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream
 {
@@ -322,7 +322,7 @@ void Nudging::run_impl (const double dt)
   using KT            = KokkosTypes<DefaultDevice>;
   using RangePolicy   = typename KT::RangePolicy;
   using MemberType    = typename KT::MemberType;
-  using ESU           = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
+  using TPF           = ekat::TeamPolicyFactory<typename KT::ExeSpace>;
   using PackT         = ekat::Pack<Real,1>;
   using view_1d       = KT::view_1d<PackT>;
   using view_2d       = KT::view_2d<PackT>;
@@ -437,7 +437,7 @@ void Nudging::run_impl (const double dt)
       });
     };
 
-    auto policy = ESU::get_default_team_policy(ncols,nlevs_src);
+    auto policy = TPF::get_default_team_policy(ncols,nlevs_src);
     Kokkos::parallel_for("", policy, copy_3d);
   };
 
@@ -476,7 +476,7 @@ void Nudging::run_impl (const double dt)
   using LI = ekat::LinInterp<Real,1>;
   const int nlevs_tgt = m_num_levs;
   LI vert_interp(ncols,nlevs_src+2,nlevs_tgt);
-  const auto policy_vinterp = ESU::get_default_team_policy(ncols, nlevs_tgt);
+  const auto policy_vinterp = TPF::get_default_team_policy(ncols, nlevs_tgt);
   auto p_tgt = get_field_in("p_mid").get_view<const PackT**>();
   Kokkos::parallel_for("nudging_vert_interp_setup_loop", policy_vinterp,
     KOKKOS_LAMBDA(const MemberType& team) {

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -5,9 +5,9 @@
 #include "share/util/eamxx_utils.hpp"
 #include "share/io/eamxx_scorpio_interface.hpp"
 
-#include <ekat/util/ekat_lin_interp.hpp>
-#include <ekat/util/ekat_math_utils.hpp>
 #include <ekat/kokkos/ekat_kokkos_utils.hpp>
+#include <ekat_lin_interp.hpp>
+#include <ekat_math_utils.hpp>
 
 namespace scream
 {

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -552,7 +552,7 @@ Field Nudging::create_helper_field (const std::string& name,
   Field f(id);
   f.get_header().get_alloc_properties().request_allocation(ps);
   f.allocate_view();
-  f.deep_copy(ekat::ScalarTraits<Real>::invalid());
+  f.deep_copy(ekat::quiet_NaN<Real>());
 
   m_helper_fields[name] = f;
   return m_helper_fields[name];

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.hpp
@@ -6,7 +6,7 @@
 #include "share/util/eamxx_time_interpolation.hpp"
 #include "share/grid/remap/abstract_remapper.hpp"
 
-#include <ekat/ekat_parameter_list.hpp>
+#include <ekat_parameter_list.hpp>
 #include <string>
 
 namespace scream

--- a/components/eamxx/src/physics/p3/disp/p3_check_values_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_check_values_impl_disp.cpp
@@ -1,7 +1,6 @@
-
-
 #include "p3_functions.hpp" // for ETI only but harmless for GPU
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace p3 {

--- a/components/eamxx/src/physics/p3/disp/p3_check_values_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_check_values_impl_disp.cpp
@@ -1,6 +1,7 @@
 #include "p3_functions.hpp" // for ETI only but harmless for GPU
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace p3 {
@@ -13,8 +14,10 @@ void Functions<Real, DefaultDevice>
 {
 
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
+
   const Int nk_pack = ekat::npack<Spack>(nk);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(nj, nk_pack);
+  const auto policy = TPF::get_default_team_policy(nj, nk_pack);
 
   Kokkos::parallel_for(
     "p3_check_values",

--- a/components/eamxx/src/physics/p3/disp/p3_cloud_sed_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_cloud_sed_impl_disp.cpp
@@ -1,6 +1,7 @@
 #include "p3_functions.hpp" // for ETI only but harmless for GPU
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace p3 {
@@ -34,8 +35,10 @@ void Functions<Real,DefaultDevice>
     const uview_1d<bool>& hydrometeorsPresent)
 {
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
+
   const Int nk_pack = ekat::npack<Spack>(nk);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(nj, nk_pack);
+  const auto policy = TPF::get_default_team_policy(nj, nk_pack);
   // p3_cloud_sedimentation loop
   Kokkos::parallel_for(
     "p3_cloud_sedimentation",

--- a/components/eamxx/src/physics/p3/disp/p3_cloud_sed_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_cloud_sed_impl_disp.cpp
@@ -1,6 +1,6 @@
-
 #include "p3_functions.hpp" // for ETI only but harmless for GPU
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace p3 {

--- a/components/eamxx/src/physics/p3/disp/p3_ice_sed_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_ice_sed_impl_disp.cpp
@@ -1,6 +1,7 @@
 #include "p3_functions.hpp" // for ETI only but harmless for GPU
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace p3 {
@@ -32,8 +33,10 @@ void Functions<Real,DefaultDevice>
   const P3Runtime& runtime_options)
 {
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
+
   const Int nk_pack = ekat::npack<Spack>(nk);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(nj, nk_pack);
+  const auto policy = TPF::get_default_team_policy(nj, nk_pack);
   // p3_ice_sedimentation loop
   Kokkos::parallel_for("p3_ice_sedimentation",
     policy, KOKKOS_LAMBDA(const MemberType& team) {
@@ -74,8 +77,10 @@ void Functions<Real,DefaultDevice>
   const uview_1d<bool>& hydrometeorsPresent)
 {
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
+
   const Int nk_pack = ekat::npack<Spack>(nk);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(nj, nk_pack);
+  const auto policy = TPF::get_default_team_policy(nj, nk_pack);
   // p3_cloud_sedimentation loop
   Kokkos::parallel_for(
     "p3_homogeneous",

--- a/components/eamxx/src/physics/p3/disp/p3_ice_sed_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_ice_sed_impl_disp.cpp
@@ -1,6 +1,6 @@
-
 #include "p3_functions.hpp" // for ETI only but harmless for GPU
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace p3 {

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
@@ -3,6 +3,7 @@
 #include "physics/share/physics_saturation_impl.hpp"
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace p3 {
@@ -34,7 +35,9 @@ void Functions<Real,DefaultDevice>
   const uview_2d<Spack>& nevapr, const uview_2d<Spack>& precip_liq_flux, const uview_2d<Spack>& precip_ice_flux)
 {
   using ExeSpace = typename KT::ExeSpace;
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(nj, nk_pack);
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
+
+  const auto policy = TPF::get_default_team_policy(nj, nk_pack);
 
   Kokkos::parallel_for("p3_main_init",
          policy, KOKKOS_LAMBDA(const MemberType& team) {

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
@@ -1,8 +1,8 @@
-
 #include "p3_functions.hpp" // for ETI only but harmless for GPU
 #include "physics/share/physics_functions.hpp" // also for ETI not on GPUs
 #include "physics/share/physics_saturation_impl.hpp"
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace p3 {

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_part1_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_part1_disp.cpp
@@ -3,6 +3,7 @@
 #include "physics/share/physics_saturation_impl.hpp"
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace p3 {
@@ -62,8 +63,10 @@ void Functions<Real,DefaultDevice>
   const P3Runtime& runtime_options)
 {
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
+
   const Int nk_pack = ekat::npack<Spack>(nk);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(nj, nk_pack);
+  const auto policy = TPF::get_default_team_policy(nj, nk_pack);
   // p3_cloud_sedimentation loop
   Kokkos::parallel_for("p3_main_part1",
       policy, KOKKOS_LAMBDA(const MemberType& team) {

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_part1_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_part1_disp.cpp
@@ -1,9 +1,8 @@
-
 #include "p3_functions.hpp" // for ETI only but harmless for GPU
 #include "physics/share/physics_functions.hpp" // also for ETI not on GPUs
 #include "physics/share/physics_saturation_impl.hpp"
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace p3 {

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_part2_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_part2_disp.cpp
@@ -1,6 +1,6 @@
-
 #include "p3_functions.hpp" // for ETI only but harmless for GPU
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace p3 {

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_part2_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_part2_disp.cpp
@@ -1,6 +1,7 @@
 #include "p3_functions.hpp" // for ETI only but harmless for GPU
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace p3 {
@@ -108,8 +109,10 @@ void Functions<Real,DefaultDevice>
   const P3Runtime& runtime_options)
 {
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
+
   const Int nk_pack = ekat::npack<Spack>(nk);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(nj, nk_pack);
+  const auto policy = TPF::get_default_team_policy(nj, nk_pack);
 
 
   // p3_cloud_sedimentation loop

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_part3_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_part3_disp.cpp
@@ -1,9 +1,8 @@
-
 #include "p3_functions.hpp" // for ETI only but harmless for GPU
 #include "physics/share/physics_functions.hpp" // also for ETI not on GPUs
 #include "physics/share/physics_saturation_impl.hpp"
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace p3 {

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_part3_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_part3_disp.cpp
@@ -3,6 +3,7 @@
 #include "physics/share/physics_saturation_impl.hpp"
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace p3 {
@@ -57,7 +58,9 @@ void Functions<Real,DefaultDevice>
   const P3Runtime& runtime_options)
 {
   using ExeSpace = typename KT::ExeSpace;
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(nj, nk_pack);
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
+
+  const auto policy = TPF::get_default_team_policy(nj, nk_pack);
   // p3_cloud_sedimentation loop
   Kokkos::parallel_for(
     "p3_main_part3_disp",

--- a/components/eamxx/src/physics/p3/disp/p3_rain_sed_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_rain_sed_impl_disp.cpp
@@ -1,6 +1,6 @@
-
 #include "p3_functions.hpp" // for ETI only but harmless for GPU
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace p3 {

--- a/components/eamxx/src/physics/p3/disp/p3_rain_sed_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_rain_sed_impl_disp.cpp
@@ -1,6 +1,7 @@
 #include "p3_functions.hpp" // for ETI only but harmless for GPU
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace p3 {
@@ -31,8 +32,10 @@ void Functions<Real,DefaultDevice>
   const P3Runtime& runtime_options)
 {
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
+
   const Int nk_pack = ekat::npack<Spack>(nk);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(nj, nk_pack);
+  const auto policy = TPF::get_default_team_policy(nj, nk_pack);
   // p3_rain_sedimentation loop
   Kokkos::parallel_for("p3_rain_sed_disp",
     policy, KOKKOS_LAMBDA(const MemberType& team) {

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -3,8 +3,8 @@
 #include "p3_functions.hpp"
 #include "eamxx_p3_process_interface.hpp"
 
-#include "ekat/ekat_assert.hpp"
-#include "ekat/util/ekat_units.hpp"
+#include <ekat_assert.hpp>
+#include <ekat_units.hpp>
 
 #include <array>
 

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -165,6 +165,8 @@ void P3Microphysics::set_grids(const std::shared_ptr<const GridsManager> grids_m
 // =========================================================================================
 size_t P3Microphysics::requested_buffer_size_in_bytes() const
 {
+  using TPF = ekat::TeamPolicyFactory<KT::ExeSpace>;
+
   const Int nk_pack    = ekat::npack<Spack>(m_num_levs);
   const Int nk_pack_p1 = ekat::npack<Spack>(m_num_levs+1);
 
@@ -179,8 +181,8 @@ size_t P3Microphysics::requested_buffer_size_in_bytes() const
       m_num_cols*3*sizeof(Real);
 
   // Number of Reals needed by the WorkspaceManager passed to p3_main
-  const auto policy       = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nk_pack);
-  const size_t wsm_request   = WSM::get_total_bytes_needed(nk_pack_p1, 52, policy);
+  const auto policy        = TPF::get_default_team_policy(m_num_cols, nk_pack);
+  const size_t wsm_request = WSM::get_total_bytes_needed(nk_pack_p1, 52, policy);
 
   return interface_request + wsm_request;
 }
@@ -188,6 +190,8 @@ size_t P3Microphysics::requested_buffer_size_in_bytes() const
 // =========================================================================================
 void P3Microphysics::init_buffers(const ATMBufferManager &buffer_manager)
 {
+  using TPF = ekat::TeamPolicyFactory<KT::ExeSpace>;
+
   EKAT_REQUIRE_MSG(buffer_manager.allocated_bytes() >= requested_buffer_size_in_bytes(), "Error! Buffers size not sufficient.\n");
 
   Real* mem = reinterpret_cast<Real*>(buffer_manager.get_memory());
@@ -250,7 +254,7 @@ void P3Microphysics::init_buffers(const ATMBufferManager &buffer_manager)
 
   // Compute workspace manager size to check used memory
   // vs. requested memory
-  const auto policy  = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nk_pack);
+  const auto policy  = TPF::get_default_team_policy(m_num_cols, nk_pack);
   const int wsm_size = WSM::get_total_bytes_needed(nk_pack_p1, 52, policy)/sizeof(Spack);
   s_mem += wsm_size;
 
@@ -261,6 +265,7 @@ void P3Microphysics::init_buffers(const ATMBufferManager &buffer_manager)
 // =========================================================================================
 void P3Microphysics::initialize_impl (const RunType /* run_type */)
 {
+  using TPF = ekat::TeamPolicyFactory<KT::ExeSpace>;
 
   // Set property checks for fields in this process
   add_invariant_check<FieldWithinIntervalCheck>(get_field_out("T_mid"),m_grid,100.0,500.0,false);
@@ -512,7 +517,7 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
   }
 
   // Setup WSM for internal local variables
-  const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nk_pack);
+  const auto policy = TPF::get_default_team_policy(m_num_cols, nk_pack);
   workspace_mgr.setup(m_buffer.wsm_data, nk_pack_p1, 52, policy);
 }
 

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.hpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.hpp
@@ -2,9 +2,10 @@
 #define SCREAM_P3_MICROPHYSICS_HPP
 
 #include "share/atm_process/atmosphere_process.hpp"
-#include "ekat/ekat_parameter_list.hpp"
 #include "physics/p3/p3_functions.hpp"
 #include "share/util/eamxx_common_physics_functions.hpp"
+
+#include <ekat_parameter_list.hpp>
 
 #include <string>
 

--- a/components/eamxx/src/physics/p3/eamxx_p3_run.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_run.cpp
@@ -1,15 +1,19 @@
 #include "physics/p3/eamxx_p3_process_interface.hpp"
 
+#include <ekat_team_policy_utils.hpp>
+
 namespace scream {
 
 void P3Microphysics::run_impl (const double dt)
 {
+  using TPF = ekat::TeamPolicyFactory<KT::ExeSpace>;
+
   // Set the dt for p3 postprocessing
   p3_postproc.m_dt = dt;
 
   // Create policy for pre and post process pfor
   const auto nlev_packs  = ekat::npack<Spack>(m_num_levs);
-  const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(m_num_cols, nlev_packs);
 
   // Assign values to local arrays used by P3, these are now stored in p3_loc.
   Kokkos::parallel_for(

--- a/components/eamxx/src/physics/p3/impl/p3_init_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_init_impl.hpp
@@ -3,8 +3,6 @@
 
 #include "p3_functions.hpp" // for ETI only but harmless for GPU
 
-#include "ekat/util/ekat_file_utils.hpp"
-
 #include <fstream>
 
 namespace scream {
@@ -201,14 +199,16 @@ void compute_tables(const bool masterproc, MuRT& mu_r_table_vals, VNT& vn_table_
   revap_table_vals = revap_table_vals_nc;
 }
 
-template <bool IsRead, typename S>
-static void action(const ekat::FILEPtr& fid, S* data, const size_t size)
+template <typename StreamT, typename S>
+static void action(StreamT& stream, S* data, const size_t size)
 {
-  if constexpr (IsRead) {
-    ekat::read(data, size, fid);
-  }
-  else {
-    ekat::write(data, size, fid);
+  constexpr bool IsRead = std::is_same_v<StreamT,std::ifstream>;
+  for (size_t i=0; i<size; ++i) {
+    if constexpr (IsRead) {
+      stream >> data[i];
+    } else {
+      stream << data[i];
+    }
   }
 }
 
@@ -227,8 +227,6 @@ void io_impl(const bool masterproc, const char* dir, MuRT& mu_r_table_vals, VNT&
 #endif
     ;
 
-  const char* rw_flag = IsRead ? "r" : "w";
-
   // Get host views
   auto mu_r_table_vals_h  = Kokkos::create_mirror_view(mu_r_table_vals);
   auto revap_table_vals_h = Kokkos::create_mirror_view(revap_table_vals);
@@ -242,16 +240,18 @@ void io_impl(const bool masterproc, const char* dir, MuRT& mu_r_table_vals, VNT&
   std::string vn_filename    = std::string(dir) + "/vn_table_vals_v2.dat" + extension;
   std::string vm_filename    = std::string(dir) + "/vm_table_vals_v2.dat" + extension;
 
-  ekat::FILEPtr mu_r_file(fopen(mu_r_filename.c_str(), rw_flag));
-  ekat::FILEPtr revap_file(fopen(revap_filename.c_str(), rw_flag));
-  ekat::FILEPtr vn_file(fopen(vn_filename.c_str(), rw_flag));
-  ekat::FILEPtr vm_file(fopen(vm_filename.c_str(), rw_flag));
+  using stream_t = std::conditional_t<IsRead,std::ifstream,std::ofstream>;
+
+  stream_t mu_r_file(mu_r_filename.c_str(), std::ios::binary);
+  stream_t revap_file(revap_filename.c_str(), std::ios::binary);
+  stream_t vn_file(vn_filename.c_str(), std::ios::binary);
+  stream_t vm_file(vm_filename, std::ios::binary);
 
   // Read files
-  action<IsRead>(mu_r_file, mu_r_table_vals_h.data(), mu_r_table_vals.size());
-  action<IsRead>(revap_file, revap_table_vals_h.data(), revap_table_vals.size());
-  action<IsRead>(vn_file, vn_table_vals_h.data(), vn_table_vals.size());
-  action<IsRead>(vm_file, vm_table_vals_h.data(), vm_table_vals.size());
+  action(mu_r_file, mu_r_table_vals_h.data(), mu_r_table_vals.size());
+  action(revap_file, revap_table_vals_h.data(), revap_table_vals.size());
+  action(vn_file, vn_table_vals_h.data(), vn_table_vals.size());
+  action(vm_file, vm_table_vals_h.data(), vm_table_vals.size());
 
   // Copy back to device
   if constexpr (IsRead) {

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
@@ -5,7 +5,7 @@
 #include "physics/share/physics_functions.hpp" // also for ETI not on GPUs
 #include "physics/share/physics_saturation_impl.hpp"
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace p3 {

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
@@ -6,6 +6,7 @@
 #include "physics/share/physics_saturation_impl.hpp"
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace p3 {
@@ -86,11 +87,12 @@ Int Functions<S,D>
   Int nk)
 {
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
   using ScratchViewType = Kokkos::View<bool*, typename ExeSpace::scratch_memory_space>;
 
   const Int nk_pack = ekat::npack<Spack>(nk);
   const auto scratch_size = ScratchViewType::shmem_size(2);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(nj, nk_pack).set_scratch_size(0, Kokkos::PerTeam(scratch_size));
+  const auto policy = TPF::get_default_team_policy(nj, nk_pack).set_scratch_size(0, Kokkos::PerTeam(scratch_size));
 
   // load constants into local vars
   const     Scalar inv_dt          = 1 / infrastructure.dt;

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part1.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part1.hpp
@@ -5,7 +5,7 @@
 #include "physics/share/physics_functions.hpp" // also for ETI not on GPUs
 #include "physics/share/physics_saturation_impl.hpp"
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace p3 {

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
@@ -5,7 +5,7 @@
 #include "physics/share/physics_functions.hpp" // also for ETI not on GPUs
 #include "physics/share/physics_saturation_impl.hpp"
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace p3 {

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part3.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part3.hpp
@@ -5,7 +5,7 @@
 #include "physics/share/physics_functions.hpp" // also for ETI not on GPUs
 #include "physics/share/physics_saturation_impl.hpp"
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace p3 {

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -5,9 +5,9 @@
 
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack_kokkos.hpp"
-#include "ekat/ekat_workspace.hpp"
-#include "ekat/ekat_parameter_list.hpp"
+#include <ekat_pack_kokkos.hpp>
+#include <ekat_workspace.hpp>
+#include <ekat_parameter_list.hpp>
 
 namespace scream {
 namespace p3 {

--- a/components/eamxx/src/physics/p3/tests/infra/CMakeLists.txt
+++ b/components/eamxx/src/physics/p3/tests/infra/CMakeLists.txt
@@ -7,9 +7,9 @@ set(INFRA_SRCS
 
 #crusher change
 if (Kokkos_ENABLE_HIP)
-set_source_files_properties(p3_test_data.cpp  PROPERTIES COMPILE_FLAGS -O0)
+  set_source_files_properties(p3_test_data.cpp  PROPERTIES COMPILE_FLAGS -O0)
 endif()
 
 add_library(p3_test_infra ${INFRA_SRCS})
-target_link_libraries(p3_test_infra p3)
+target_link_libraries(p3_test_infra PUBLIC p3 scream_test_support)
 target_include_directories(p3_test_infra PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/components/eamxx/src/physics/p3/tests/infra/p3_data.cpp
+++ b/components/eamxx/src/physics/p3/tests/infra/p3_data.cpp
@@ -2,7 +2,7 @@
 #include "physics_constants.hpp"
 #include "p3_ic_cases.hpp"
 
-#include "ekat/ekat_assert.hpp"
+#include <ekat_assert.hpp>
 
 using scream::Real;
 using scream::Int;

--- a/components/eamxx/src/physics/p3/tests/infra/p3_ic_cases.cpp
+++ b/components/eamxx/src/physics/p3/tests/infra/p3_ic_cases.cpp
@@ -1,7 +1,7 @@
 #include "p3_ic_cases.hpp"
 #include "physics_constants.hpp"
 
-#include "ekat/ekat_assert.hpp"
+#include <ekat_assert.hpp>
 
 namespace scream {
 namespace p3 {

--- a/components/eamxx/src/physics/p3/tests/infra/p3_main_wrap.cpp
+++ b/components/eamxx/src/physics/p3/tests/infra/p3_main_wrap.cpp
@@ -4,7 +4,7 @@
 #include "physics_constants.hpp"
 #include "p3_ic_cases.hpp"
 
-#include "ekat/ekat_assert.hpp"
+#include <ekat_assert.hpp>
 
 using scream::Real;
 using scream::Int;

--- a/components/eamxx/src/physics/p3/tests/infra/p3_test_data.cpp
+++ b/components/eamxx/src/physics/p3/tests/infra/p3_test_data.cpp
@@ -1,8 +1,8 @@
 #include "p3_test_data.hpp"
 #include "p3_data.hpp"
 
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include <ekat_kokkos_types.hpp>
+#include <ekat_team_policy_utils.hpp>
 #include <ekat_pack_kokkos.hpp>
 #include <ekat_assert.hpp>
 
@@ -341,6 +341,7 @@ void calc_first_order_upwind_step_host_impl(
   using view_1d = typename P3F::view_1d<Spack>;
   using KT = typename P3F::KT;
   using ExeSpace = typename KT::ExeSpace;
+  using TPF = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename P3F::MemberType;
   using view_1d_ptr_array = typename P3F::view_1d_ptr_array<Spack, N>;
   using uview_1d = typename P3F::uview_1d<Spack>;
@@ -376,7 +377,7 @@ void calc_first_order_upwind_step_host_impl(
   }
 
   // Call core function from kernel
-  auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(1, nk_pack);
+  auto policy = TPF::get_default_team_policy(1, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     view_1d_ptr_array fluxes_ptr, vs_ptr, qnx_ptr;
     for (int i = 0; i < N; ++i) {
@@ -407,6 +408,7 @@ void generalized_sedimentation_host_impl(
   using view_1ds = typename P3F::view_1d<Singlep>;
   using KT = typename P3F::KT;
   using ExeSpace = typename KT::ExeSpace;
+  using TPF = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename P3F::MemberType;
   using view_1d_ptr_array = typename P3F::view_1d_ptr_array<Spack, N>;
   using uview_1d = typename P3F::uview_1d<Spack>;
@@ -449,7 +451,7 @@ void generalized_sedimentation_host_impl(
   }
 
   // Call core function from kernel
-  auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(1, nk_pack);
+  auto policy = TPF::get_default_team_policy(1, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     view_1d_ptr_array fluxes_ptr, vs_ptr, qnx_ptr;
     for (int i = 0; i < N; ++i) {
@@ -536,6 +538,7 @@ void cloud_sedimentation_host(
   using view_1d = typename P3F::view_1d<Spack>;
   using KT = typename P3F::KT;
   using ExeSpace = typename KT::ExeSpace;
+  using TPF = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename P3F::MemberType;
 
   EKAT_REQUIRE_MSG(kts == 1, "kts must be 1, got " << kts);
@@ -573,7 +576,7 @@ void cloud_sedimentation_host(
     nc_tend_d (temp_d[12]);
 
   // Call core function from kernel
-  auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(1, nk_pack);
+  auto policy = TPF::get_default_team_policy(1, nk_pack);
   ekat::WorkspaceManager<Spack> wsm(rho_d.extent(0), 4, policy);
   Kokkos::parallel_reduce(policy, KOKKOS_LAMBDA(const MemberType& team, Real& precip_liq_surf_k) {
 
@@ -604,6 +607,7 @@ void ice_sedimentation_host(
   using view_1d    = typename P3F::view_1d<Spack>;
   using KT         = typename P3F::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename P3F::MemberType;
 
   EKAT_REQUIRE_MSG(kts == 1, "kts must be 1, got " << kts);
@@ -642,7 +646,7 @@ void ice_sedimentation_host(
 
   // Call core function from kernel
   auto ice_table_vals = P3F::p3_init().ice_table_vals;
-  auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(1, nk_pack);
+  auto policy = TPF::get_default_team_policy(1, nk_pack);
   ekat::WorkspaceManager<Spack> wsm(rho_d.extent(0), 6, policy);
   Real my_precip_ice_surf = 0;
   Kokkos::parallel_reduce(policy, KOKKOS_LAMBDA(const MemberType& team, Real& precip_ice_surf_k) {
@@ -676,6 +680,7 @@ void rain_sedimentation_host(
   using view_1d    = typename P3F::view_1d<Spack>;
   using KT         = typename P3F::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename P3F::MemberType;
 
   EKAT_REQUIRE_MSG(kts == 1, "kts must be 1, got " << kts);
@@ -717,7 +722,7 @@ void rain_sedimentation_host(
   auto tables = P3F::p3_init();
   auto vn_table_vals = tables.vn_table_vals;
   auto vm_table_vals = tables.vm_table_vals;
-  auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(1, nk_pack);
+  auto policy = TPF::get_default_team_policy(1, nk_pack);
   ekat::WorkspaceManager<Spack> wsm(rho_d.extent(0), 4, policy);
   Real my_precip_liq_surf = 0;
   Kokkos::parallel_reduce(policy, KOKKOS_LAMBDA(const MemberType& team, Real& precip_liq_surf_k) {
@@ -751,6 +756,7 @@ void homogeneous_freezing_host(
   using view_1d    = typename P3F::view_1d<Spack>;
   using KT         = typename P3F::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename P3F::MemberType;
 
   EKAT_REQUIRE_MSG(kts == 1, "kts must be 1, got " << kts);
@@ -785,7 +791,7 @@ void homogeneous_freezing_host(
     th_atm_d              (temp_d[current_index++]);
 
   // Call core function from kernel
-  auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(1, nk_pack);
+  auto policy = TPF::get_default_team_policy(1, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
 
     P3F::homogeneous_freezing(
@@ -810,6 +816,7 @@ void check_values_host(Real* qv, Real* temp, Int kstart, Int kend,
   using suview_1d  = typename P3F::uview_1d<Real>;
   using KT         = typename P3F::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename P3F::MemberType;
 
   EKAT_REQUIRE_MSG(kend > kstart,
@@ -826,7 +833,7 @@ void check_values_host(Real* qv, Real* temp, Int kstart, Int kend,
   view_1d qv_d(cvd_d[0]), temp_d(cvd_d[1]), col_loc_d(cvd_d[2]);
   suview_1d ucol_loc_d(reinterpret_cast<Real*>(col_loc_d.data()), 3);
 
-  auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(1, nk_pack);
+  auto policy = TPF::get_default_team_policy(1, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
 
     P3F::check_values(qv_d, temp_d, kstart, kend, timestepcount, force_abort, source_ind, team,
@@ -852,6 +859,7 @@ void p3_main_part1_host(
   using bview_1d   = typename P3F::view_1d<bool>;
   using KT         = typename P3F::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename P3F::MemberType;
 
   EKAT_REQUIRE_MSG(kts == 1, "kts must be 1, got " << kts);
@@ -915,7 +923,7 @@ void p3_main_part1_host(
 
   // Call core function from kernel
   bview_1d bools_d("bools", 2);
-  auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(1, nk_pack);
+  auto policy = TPF::get_default_team_policy(1, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
 
     P3F::p3_main_part1(
@@ -968,6 +976,7 @@ void p3_main_part2_host(
   using bview_1d   = typename P3F::view_1d<bool>;
   using KT         = typename P3F::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename P3F::MemberType;
 
   EKAT_REQUIRE_MSG(kts == 1, "kts must be 1, got " << kts);
@@ -1103,7 +1112,7 @@ void p3_main_part2_host(
   const auto collect_table_vals     = tables.collect_table_vals;
   const auto revap_table_vals = tables.revap_table_vals;
   bview_1d bools_d("bools", 1);
-  auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(1, nk_pack);
+  auto policy = TPF::get_default_team_policy(1, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
 
     P3F::p3_main_part2(
@@ -1175,6 +1184,7 @@ void p3_main_part3_host(
   using view_1d    = typename P3F::view_1d<Spack>;
   using KT         = typename P3F::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename P3F::MemberType;
 
   EKAT_REQUIRE_MSG(kts == 1, "kts must be 1, got " << kts);
@@ -1238,7 +1248,7 @@ void p3_main_part3_host(
   auto tables = P3F::p3_init();
   const auto dnu            = tables.dnu_table_vals;
   const auto ice_table_vals = tables.ice_table_vals;
-  auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(1, nk_pack);
+  auto policy = TPF::get_default_team_policy(1, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
 
     P3F::p3_main_part3(team, nk_pack, max_total_ni, dnu, ice_table_vals,
@@ -1281,6 +1291,7 @@ Int p3_main_host(
 
   using Spack      = typename P3F::Spack;
   using KT         = typename P3F::KT;
+  using TPF = ekat::TeamPolicyFactory<KT::ExeSpace>;
   using view_2d    = typename P3F::view_2d<Spack>;
   using sview_1d   = typename P3F::view_1d<Real>;
   using sview_2d   = typename P3F::view_2d<Real>;
@@ -1489,7 +1500,7 @@ Int p3_main_host(
   P3F::P3Runtime runtime_options{740.0e3};
 
   // Create local workspace
-  const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(nj, nk_pack);
+  const auto policy = TPF::get_default_team_policy(nj, nk_pack);
   ekat::WorkspaceManager<Spack, KT::Device> workspace_mgr(nk_pack, 52, policy);
 
   auto elapsed_microsec = P3F::p3_main(runtime_options, prog_state, diag_inputs, diag_outputs, infrastructure,

--- a/components/eamxx/src/physics/p3/tests/infra/p3_test_data.cpp
+++ b/components/eamxx/src/physics/p3/tests/infra/p3_test_data.cpp
@@ -1,10 +1,10 @@
 #include "p3_test_data.hpp"
-#include "ekat/kokkos/ekat_kokkos_types.hpp"
 #include "p3_data.hpp"
 
 #include "ekat/kokkos/ekat_kokkos_utils.hpp"
-#include "ekat/ekat_pack_kokkos.hpp"
-#include "ekat/ekat_assert.hpp"
+#include <ekat_kokkos_types.hpp>
+#include <ekat_pack_kokkos.hpp>
+#include <ekat_assert.hpp>
 
 #include <random>
 

--- a/components/eamxx/src/physics/p3/tests/infra/p3_test_data.hpp
+++ b/components/eamxx/src/physics/p3/tests/infra/p3_test_data.hpp
@@ -4,7 +4,6 @@
 #include "physics/p3/p3_functions.hpp"
 #include "physics/share/physics_test_data.hpp"
 #include "share/eamxx_types.hpp"
-#include "ekat/util/ekat_file_utils.hpp"
 
 #include <array>
 #include <utility>

--- a/components/eamxx/src/physics/p3/tests/p3_autoconversion_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_autoconversion_unit_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_autoconversion_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_autoconversion_unit_tests.cpp
@@ -60,7 +60,7 @@ void cloud_water_autoconversion_unit_bfb_tests() {
   // Read baseline data
   if (this->m_baseline_action == COMPARE) {
     for (Int i = 0; i < max_pack_size; ++i) {
-      cwadc[i].read(Base::m_fid);
+      cwadc[i].read(Base::m_ifile);
     }
   }
 
@@ -114,7 +114,7 @@ void cloud_water_autoconversion_unit_bfb_tests() {
   }
   else if (this->m_baseline_action == GENERATE) {
     for (Int s = 0; s < max_pack_size; ++s) {
-      cwadc_host(s).write(Base::m_fid);
+      cwadc_host(s).write(Base::m_ofile);
     }
   }
 }

--- a/components/eamxx/src/physics/p3/tests/p3_back_to_cell_average_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_back_to_cell_average_unit_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_back_to_cell_average_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_back_to_cell_average_unit_tests.cpp
@@ -44,7 +44,7 @@ void run_bfb()
   // Read baseline data
   if (this->m_baseline_action == COMPARE) {
     for (Int i = 0; i < max_pack_size; ++i) {
-      back_to_cell_average_data[i].read(Base::m_fid);
+      back_to_cell_average_data[i].read(Base::m_ifile);
     }
   }
 
@@ -181,7 +181,7 @@ void run_bfb()
   }
   else if (this->m_baseline_action == GENERATE) {
     for (Int s = 0; s < max_pack_size; ++s) {
-      host_data(s).write(Base::m_fid);
+      host_data(s).write(Base::m_ofile);
     }
   }
 }

--- a/components/eamxx/src/physics/p3/tests/p3_calc_liq_relaxation_timescale_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_calc_liq_relaxation_timescale_unit_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_calc_liq_relaxation_timescale_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_calc_liq_relaxation_timescale_unit_tests.cpp
@@ -51,7 +51,7 @@ struct UnitWrap::UnitTest<D>::TestCalcLiqRelaxationTimescale : public UnitWrap::
   // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        self[i].read(Base::m_fid);
+        self[i].read(Base::m_ifile);
       }
     }
 
@@ -101,7 +101,7 @@ struct UnitWrap::UnitTest<D>::TestCalcLiqRelaxationTimescale : public UnitWrap::
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        self_host(s).write(Base::m_fid);
+        self_host(s).write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/p3/tests/p3_calc_rime_density_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_calc_rime_density_unit_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_calc_rime_density_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_calc_rime_density_unit_tests.cpp
@@ -88,7 +88,7 @@ void run_bfb()
   // Read baseline data
   if (this->m_baseline_action == COMPARE) {
     for (Int i = 0; i < max_pack_size; ++i) {
-      calc_rime_density_data[i].read(Base::m_fid);
+      calc_rime_density_data[i].read(Base::m_ifile);
     }
   }
 
@@ -134,7 +134,7 @@ void run_bfb()
   }
   else if (this->m_baseline_action == GENERATE) {
     for (Int s = 0; s < max_pack_size; ++s) {
-      host_data(s).write(Base::m_fid);
+      host_data(s).write(Base::m_ofile);
     }
   }
 }

--- a/components/eamxx/src/physics/p3/tests/p3_check_values_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_check_values_unit_tests.cpp
@@ -1,13 +1,11 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
 #include "p3_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
@@ -71,7 +71,7 @@ void run_bfb()
   // Read baseline data
   if (this->m_baseline_action == COMPARE) {
     for (Int i = 0; i < max_pack_size; ++i) {
-      cldliq_imm_freezing_data[i].read(Base::m_fid);
+      cldliq_imm_freezing_data[i].read(Base::m_ifile);
     }
   }
 
@@ -117,7 +117,7 @@ void run_bfb()
   }
   else if (this->m_baseline_action == GENERATE) {
     for (Int s = 0; s < max_pack_size; ++s) {
-      host_data(s).write(Base::m_fid);
+      host_data(s).write(Base::m_ofile);
     }
   }
 }

--- a/components/eamxx/src/physics/p3/tests/p3_cloud_rain_acc_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_cloud_rain_acc_unit_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_cloud_rain_acc_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_cloud_rain_acc_unit_tests.cpp
@@ -74,7 +74,7 @@ void run_bfb()
   // Read baseline data
   if (this->m_baseline_action == COMPARE) {
     for (Int i = 0; i < max_pack_size; ++i) {
-      cloud_rain_acc_data[i].read(Base::m_fid);
+      cloud_rain_acc_data[i].read(Base::m_ifile);
     }
   }
 
@@ -120,7 +120,7 @@ void run_bfb()
   }
   else if (this->m_baseline_action == GENERATE) {
     for (Int s = 0; s < max_pack_size; ++s) {
-      host_data(s).write(Base::m_fid);
+      host_data(s).write(Base::m_ofile);
     }
   }
 }

--- a/components/eamxx/src/physics/p3/tests/p3_cloud_sed_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_cloud_sed_unit_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_cloud_sed_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_cloud_sed_unit_tests.cpp
@@ -56,7 +56,7 @@ void run_bfb()
   // Read baseline data
   if (this->m_baseline_action == COMPARE) {
     for (auto& d : csds_baseline) {
-      d.read(Base::m_fid);
+      d.read(Base::m_ifile);
     }
   }
 
@@ -87,7 +87,7 @@ void run_bfb()
   }
   else if (this->m_baseline_action == GENERATE) {
     for (Int i = 0; i < num_runs; ++i) {
-      csds_cxx[i].write(Base::m_fid);
+      csds_cxx[i].write(Base::m_ofile);
     }
   }
 }

--- a/components/eamxx/src/physics/p3/tests/p3_droplet_self_coll_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_droplet_self_coll_unit_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_droplet_self_coll_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_droplet_self_coll_unit_tests.cpp
@@ -73,7 +73,7 @@ void run_bfb()
   // Read baseline data
   if (this->m_baseline_action == COMPARE) {
     for (Int i = 0; i < max_pack_size; ++i) {
-      droplet_self_coll_data[i].read(Base::m_fid);
+      droplet_self_coll_data[i].read(Base::m_ifile);
     }
   }
 
@@ -114,7 +114,7 @@ void run_bfb()
   }
   else if (this->m_baseline_action == GENERATE) {
     for (Int s = 0; s < max_pack_size; ++s) {
-      host_data(s).write(Base::m_fid);
+      host_data(s).write(Base::m_ofile);
     }
   }
 

--- a/components/eamxx/src/physics/p3/tests/p3_dsd2_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_dsd2_unit_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_dsd2_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_dsd2_unit_tests.cpp
@@ -61,7 +61,7 @@ struct UnitWrap::UnitTest<D>::TestDsd2 : public UnitWrap::UnitTest<D>::Base {
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        gcdd[i].read(Base::m_fid);
+        gcdd[i].read(Base::m_ifile);
       }
     }
 
@@ -107,7 +107,7 @@ struct UnitWrap::UnitTest<D>::TestDsd2 : public UnitWrap::UnitTest<D>::Base {
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        gcdd_host(s).write(Base::m_fid);
+        gcdd_host(s).write(Base::m_ofile);
       }
     }
   }
@@ -152,7 +152,7 @@ struct UnitWrap::UnitTest<D>::TestDsd2 : public UnitWrap::UnitTest<D>::Base {
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        grdd[i].read(Base::m_fid);
+        grdd[i].read(Base::m_ifile);
       }
     }
 
@@ -197,7 +197,7 @@ struct UnitWrap::UnitTest<D>::TestDsd2 : public UnitWrap::UnitTest<D>::Base {
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        grdd_host(s).write(Base::m_fid);
+        grdd_host(s).write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/p3/tests/p3_evaporate_rain_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_evaporate_rain_unit_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 namespace scream {
 namespace p3 {

--- a/components/eamxx/src/physics/p3/tests/p3_evaporate_rain_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_evaporate_rain_unit_tests.cpp
@@ -174,7 +174,7 @@ struct UnitWrap::UnitTest<D>::TestEvapSublPrecip : public UnitWrap::UnitTest<D>:
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        espd[i].read(Base::m_fid);
+        espd[i].read(Base::m_ifile);
       }
     }
 
@@ -249,7 +249,7 @@ struct UnitWrap::UnitTest<D>::TestEvapSublPrecip : public UnitWrap::UnitTest<D>:
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        espd_host(s).write(Base::m_fid);
+        espd_host(s).write(Base::m_ofile);
       }
     }
   } // end run_bfb

--- a/components/eamxx/src/physics/p3/tests/p3_find_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_find_unit_tests.cpp
@@ -1,11 +1,12 @@
 #include "catch2/catch.hpp"
 
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
 #include "p3_unit_tests_common.hpp"
 
 #include "share/eamxx_types.hpp"
+
+#include <ekat_team_policy_utils.hpp>
 
 #include <thread>
 #include <array>
@@ -25,6 +26,8 @@ struct UnitWrap::UnitTest<D>::TestFind : public UnitWrap::UnitTest<D>::Base {
 
 void run()
 {
+  using TPF = ekat::TeamPolicyFactory<ExeSpace>;
+
   const int max_threads =
 #ifdef KOKKOS_ENABLE_OPENMP
     Kokkos::OpenMP().concurrency()
@@ -57,7 +60,7 @@ void run()
   Kokkos::deep_copy(qr_not_present, mirror_qrnp);
 
   for (int team_size : {1, max_threads}) {
-    const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_team_policy_force_team_size(1, team_size);
+    const auto policy = TPF::get_team_policy_force_team_size(1, team_size);
 
     int errs_for_this_ts = 0;
     Kokkos::parallel_reduce("unittest_find_top_bottom",

--- a/components/eamxx/src/physics/p3/tests/p3_find_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_find_unit_tests.cpp
@@ -1,12 +1,11 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
 #include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_ice_cldliq_wet_growth_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_cldliq_wet_growth_unit_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_ice_cldliq_wet_growth_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_cldliq_wet_growth_unit_tests.cpp
@@ -58,7 +58,7 @@ struct UnitWrap::UnitTest<D>::TestIceCldliqWetGrowth : public UnitWrap::UnitTest
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        self[i].read(Base::m_fid);
+        self[i].read(Base::m_ifile);
       }
     }
 
@@ -127,7 +127,7 @@ struct UnitWrap::UnitTest<D>::TestIceCldliqWetGrowth : public UnitWrap::UnitTest
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        self_host(s).write(Base::m_fid);
+        self_host(s).write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/p3/tests/p3_ice_collection_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_collection_unit_tests.cpp
@@ -1,7 +1,6 @@
 #include "catch2/catch.hpp"
 
 #include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
 #include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"

--- a/components/eamxx/src/physics/p3/tests/p3_ice_collection_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_collection_unit_tests.cpp
@@ -1,7 +1,6 @@
 #include "catch2/catch.hpp"
 
 #include "share/eamxx_types.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
 

--- a/components/eamxx/src/physics/p3/tests/p3_ice_collection_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_collection_unit_tests.cpp
@@ -64,7 +64,7 @@ struct UnitWrap::UnitTest<D>::TestIceCollection : public UnitWrap::UnitTest<D>::
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        cldliq[i].read(Base::m_fid);
+        cldliq[i].read(Base::m_ifile);
       }
     }
 
@@ -119,7 +119,7 @@ struct UnitWrap::UnitTest<D>::TestIceCollection : public UnitWrap::UnitTest<D>::
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        cldliq_host(s).write(Base::m_fid);
+        cldliq_host(s).write(Base::m_ofile);
       }
     }
   }
@@ -165,7 +165,7 @@ struct UnitWrap::UnitTest<D>::TestIceCollection : public UnitWrap::UnitTest<D>::
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        rain[i].read(Base::m_fid);
+        rain[i].read(Base::m_ifile);
       }
     }
 
@@ -213,7 +213,7 @@ struct UnitWrap::UnitTest<D>::TestIceCollection : public UnitWrap::UnitTest<D>::
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        rain_host(s).write(Base::m_fid);
+        rain_host(s).write(Base::m_ofile);
       }
     }
   }
@@ -259,7 +259,7 @@ struct UnitWrap::UnitTest<D>::TestIceCollection : public UnitWrap::UnitTest<D>::
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        self[i].read(Base::m_fid);
+        self[i].read(Base::m_ifile);
       }
     }
 
@@ -297,7 +297,7 @@ struct UnitWrap::UnitTest<D>::TestIceCollection : public UnitWrap::UnitTest<D>::
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        self_host(s).write(Base::m_fid);
+        self_host(s).write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/p3/tests/p3_ice_deposition_sublimation_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_deposition_sublimation_tests.cpp
@@ -1,12 +1,11 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-#include "physics/share/physics_constants.hpp"
 #include "p3_unit_tests_common.hpp"
+
+#include "physics/share/physics_constants.hpp"
+#include "share/eamxx_types.hpp"
 
 namespace scream {
 namespace p3 {

--- a/components/eamxx/src/physics/p3/tests/p3_ice_deposition_sublimation_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_deposition_sublimation_tests.cpp
@@ -83,7 +83,7 @@ struct UnitWrap::UnitTest<D>::TestIceDepositionSublimation : public UnitWrap::Un
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        baseline_data[i].read(Base::m_fid);
+        baseline_data[i].read(Base::m_ifile);
       }
     }
 
@@ -150,7 +150,7 @@ struct UnitWrap::UnitTest<D>::TestIceDepositionSublimation : public UnitWrap::Un
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        cxx_host(s).write(Base::m_fid);
+        cxx_host(s).write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/p3/tests/p3_ice_melting_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_melting_unit_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_ice_melting_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_melting_unit_tests.cpp
@@ -58,7 +58,7 @@ void ice_melting_bfb() {
   // Read baseline data
   if (this->m_baseline_action == COMPARE) {
     for (Int i = 0; i < max_pack_size; ++i) {
-      IceMelt[i].read(Base::m_fid);
+      IceMelt[i].read(Base::m_ifile);
     }
   }
 
@@ -107,7 +107,7 @@ void ice_melting_bfb() {
   }
   else if (this->m_baseline_action == GENERATE) {
     for (Int s = 0; s < max_pack_size; ++s) {
-      IceMelt_host(s).write(Base::m_fid);
+      IceMelt_host(s).write(Base::m_ofile);
     }
   }
 

--- a/components/eamxx/src/physics/p3/tests/p3_ice_nucleation_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_nucleation_unit_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_ice_nucleation_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_nucleation_unit_tests.cpp
@@ -56,7 +56,7 @@ struct UnitWrap::UnitTest<D>::TestIceNucleation : public UnitWrap::UnitTest<D>::
         std::string file_name = root_name + (do_predict_nc ? "1" : "0") + (do_prescribed_CCN ? "1" : "0");
         if (this->m_baseline_action == COMPARE) {
           for (Int i = 0; i < max_pack_size; ++i) {
-            self[i].read(Base::m_fid);
+            self[i].read(Base::m_ifile);
           }
         }
 
@@ -103,7 +103,7 @@ struct UnitWrap::UnitTest<D>::TestIceNucleation : public UnitWrap::UnitTest<D>::
         }
         else if (this->m_baseline_action == GENERATE) {
           for (Int s = 0; s < max_pack_size; ++s) {
-            self_host(s).write(Base::m_fid);
+            self_host(s).write(Base::m_ofile);
           }
         }
       } //end for do_predict_nc

--- a/components/eamxx/src/physics/p3/tests/p3_ice_relaxation_timescale_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_relaxation_timescale_unit_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_ice_relaxation_timescale_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_relaxation_timescale_unit_tests.cpp
@@ -50,7 +50,7 @@ struct UnitWrap::UnitTest<D>::TestIceRelaxationTimescale : public UnitWrap::Unit
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        self[i].read(Base::m_fid);
+        self[i].read(Base::m_ifile);
       }
     }
 
@@ -101,7 +101,7 @@ struct UnitWrap::UnitTest<D>::TestIceRelaxationTimescale : public UnitWrap::Unit
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        self_host(s).write(Base::m_fid);
+        self_host(s).write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/p3/tests/p3_ice_sed_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_sed_unit_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_ice_sed_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_sed_unit_tests.cpp
@@ -78,7 +78,7 @@ void run_bfb_calc_bulk_rhime()
   // Read baseline data
   if (this->m_baseline_action == COMPARE) {
     for (Int i = 0; i < max_pack_size; ++i) {
-      cbrr_baseline[i].read(Base::m_fid);
+      cbrr_baseline[i].read(Base::m_ifile);
     }
   }
 
@@ -120,7 +120,7 @@ void run_bfb_calc_bulk_rhime()
   }
   else if (this->m_baseline_action == GENERATE) {
     for (Int s = 0; s < max_pack_size; ++s) {
-      cbrr_host(s).write(Base::m_fid);
+      cbrr_host(s).write(Base::m_ofile);
     }
   }
 }
@@ -156,7 +156,7 @@ void run_bfb_ice_sed()
   // Read baseline data
   if (this->m_baseline_action == COMPARE) {
     for (Int i = 0; i < num_runs; ++i) {
-      isds_baseline[i].read(Base::m_fid);
+      isds_baseline[i].read(Base::m_ifile);
     }
   }
 
@@ -191,7 +191,7 @@ void run_bfb_ice_sed()
   }
   else if (this->m_baseline_action == GENERATE) {
     for (Int i = 0; i < num_runs; ++i) {
-      isds_cxx[i].write(Base::m_fid);
+      isds_cxx[i].write(Base::m_ofile);
     }
   }
 }
@@ -236,7 +236,7 @@ void run_bfb_homogeneous_freezing()
   // Read baseline data
   if (this->m_baseline_action == COMPARE) {
     for (auto& d : hfds_baseline) {
-      d.read(Base::m_fid);
+      d.read(Base::m_ifile);
     }
   }
 
@@ -267,7 +267,7 @@ void run_bfb_homogeneous_freezing()
   }
   else if (this->m_baseline_action == GENERATE) {
     for (Int i = 0; i < num_runs; ++i) {
-      hfds_cxx[i].write(Base::m_fid);
+      hfds_cxx[i].write(Base::m_ofile);
     }
   }
 

--- a/components/eamxx/src/physics/p3/tests/p3_ice_supersat_conservation_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_supersat_conservation_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 namespace scream {
 namespace p3 {

--- a/components/eamxx/src/physics/p3/tests/p3_ice_supersat_conservation_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_supersat_conservation_tests.cpp
@@ -42,7 +42,7 @@ struct UnitWrap::UnitTest<D>::TestIceSupersatConservation : public UnitWrap::Uni
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        baseline_data[i].read(Base::m_fid);
+        baseline_data[i].read(Base::m_ifile);
       }
     }
 
@@ -88,7 +88,7 @@ struct UnitWrap::UnitTest<D>::TestIceSupersatConservation : public UnitWrap::Uni
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        cxx_host(s).write(Base::m_fid);
+        cxx_host(s).write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/p3/tests/p3_ice_tables_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_tables_unit_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_ice_tables_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_tables_unit_tests.cpp
@@ -173,10 +173,10 @@ struct UnitWrap::UnitTest<D>::TestTableIce : public UnitWrap::UnitTest<D>::Base 
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        lid[i].read(Base::m_fid);
-        lidb[i].read(Base::m_fid);
-        altd[i].read(Base::m_fid);
-        altcd[i].read(Base::m_fid);
+        lid[i].read(Base::m_ifile);
+        lidb[i].read(Base::m_ifile);
+        altd[i].read(Base::m_ifile);
+        altcd[i].read(Base::m_ifile);
       }
     }
 
@@ -274,10 +274,10 @@ struct UnitWrap::UnitTest<D>::TestTableIce : public UnitWrap::UnitTest<D>::Base 
 
         altcd[s].proc = real_results_mirror(6, s);
 
-        lid[s].write(Base::m_fid);
-        lidb[s].write(Base::m_fid);
-        altd[s].write(Base::m_fid);
-        altcd[s].write(Base::m_fid);
+        lid[s].write(Base::m_ofile);
+        lidb[s].write(Base::m_ofile);
+        altd[s].write(Base::m_ofile);
+        altcd[s].write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/p3/tests/p3_incloud_mixingratios_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_incloud_mixingratios_unit_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_incloud_mixingratios_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_incloud_mixingratios_unit_tests.cpp
@@ -70,7 +70,7 @@ struct UnitWrap::UnitTest<D>::TestIncloudMixing : public UnitWrap::UnitTest<D>::
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        self[i].read(Base::m_fid);
+        self[i].read(Base::m_ifile);
       }
     }
 
@@ -129,7 +129,7 @@ struct UnitWrap::UnitTest<D>::TestIncloudMixing : public UnitWrap::UnitTest<D>::
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        self_host(s).write(Base::m_fid);
+        self_host(s).write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/p3/tests/p3_main_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_main_unit_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_main_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_main_unit_tests.cpp
@@ -95,7 +95,7 @@ void run_bfb_p3_main_part1()
   // Read baseline data
   if (this->m_baseline_action == COMPARE) {
     for (auto& d : isds_baseline) {
-      d.read(Base::m_fid);
+      d.read(Base::m_ifile);
     }
   }
 
@@ -149,7 +149,7 @@ void run_bfb_p3_main_part1()
   }
   else if (this->m_baseline_action == GENERATE) {
     for (Int i = 0; i < num_runs; ++i) {
-      isds_cxx[i].write(Base::m_fid);
+      isds_cxx[i].write(Base::m_ofile);
     }
   }
 }
@@ -210,7 +210,7 @@ void run_bfb_p3_main_part2()
   // Read baseline data
   if (this->m_baseline_action == COMPARE) {
     for (auto& d : isds_baseline) {
-      d.read(Base::m_fid);
+      d.read(Base::m_ifile);
     }
   }
 
@@ -290,7 +290,7 @@ void run_bfb_p3_main_part2()
   }
   else if (this->m_baseline_action == GENERATE) {
     for (Int i = 0; i < num_runs; ++i) {
-      isds_cxx[i].write(Base::m_fid);
+      isds_cxx[i].write(Base::m_ofile);
     }
   }
 }
@@ -338,7 +338,7 @@ void run_bfb_p3_main_part3()
   // Read baseline data
   if (this->m_baseline_action == COMPARE) {
     for (auto& d : isds_baseline) {
-      d.read(Base::m_fid);
+      d.read(Base::m_ifile);
     }
   }
 
@@ -392,7 +392,7 @@ void run_bfb_p3_main_part3()
   }
   else if (this->m_baseline_action == GENERATE) {
     for (Int i = 0; i < num_runs; ++i) {
-      isds_cxx[i].write(Base::m_fid);
+      isds_cxx[i].write(Base::m_ofile);
     }
   }
 }
@@ -447,7 +447,7 @@ void run_bfb_p3_main()
   // Read baseline data
   if (this->m_baseline_action == COMPARE) {
     for (auto& d : isds_baseline) {
-      d.read(Base::m_fid);
+      d.read(Base::m_ifile);
     }
   }
 
@@ -504,7 +504,7 @@ void run_bfb_p3_main()
   }
   else if (this->m_baseline_action == GENERATE) {
     for (Int i = 0; i < num_runs; ++i) {
-      isds_cxx[i].write(Base::m_fid);
+      isds_cxx[i].write(Base::m_ofile);
     }
   }
 }

--- a/components/eamxx/src/physics/p3/tests/p3_nc_conservation_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_nc_conservation_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 namespace scream {
 namespace p3 {

--- a/components/eamxx/src/physics/p3/tests/p3_nc_conservation_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_nc_conservation_tests.cpp
@@ -36,7 +36,7 @@ struct UnitWrap::UnitTest<D>::TestNcConservation : public UnitWrap::UnitTest<D>:
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        baseline_data[i].read(Base::m_fid);
+        baseline_data[i].read(Base::m_ifile);
       }
     }
 
@@ -88,7 +88,7 @@ struct UnitWrap::UnitTest<D>::TestNcConservation : public UnitWrap::UnitTest<D>:
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        cxx_host(s).write(Base::m_fid);
+        cxx_host(s).write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/p3/tests/p3_ni_conservation_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ni_conservation_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 namespace scream {
 namespace p3 {

--- a/components/eamxx/src/physics/p3/tests/p3_ni_conservation_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ni_conservation_tests.cpp
@@ -36,7 +36,7 @@ struct UnitWrap::UnitTest<D>::TestNiConservation : public UnitWrap::UnitTest<D>:
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        baseline_data[i].read(Base::m_fid);
+        baseline_data[i].read(Base::m_ifile);
       }
     }
 
@@ -88,7 +88,7 @@ struct UnitWrap::UnitTest<D>::TestNiConservation : public UnitWrap::UnitTest<D>:
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        cxx_host(s).write(Base::m_fid);
+        cxx_host(s).write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/p3/tests/p3_nr_conservation_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_nr_conservation_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 namespace scream {
 namespace p3 {

--- a/components/eamxx/src/physics/p3/tests/p3_nr_conservation_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_nr_conservation_tests.cpp
@@ -37,7 +37,7 @@ struct UnitWrap::UnitTest<D>::TestNrConservation : public UnitWrap::UnitTest<D>:
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        baseline_data[i].read(Base::m_fid);
+        baseline_data[i].read(Base::m_ifile);
       }
     }
 
@@ -86,7 +86,7 @@ struct UnitWrap::UnitTest<D>::TestNrConservation : public UnitWrap::UnitTest<D>:
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        cxx_host(s).write(Base::m_fid);
+        cxx_host(s).write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/p3/tests/p3_prevent_liq_supersaturation_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_prevent_liq_supersaturation_tests.cpp
@@ -1,13 +1,11 @@
 #include "catch2/catch.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-#include "share/eamxx_types.hpp"
-#include "physics/share/physics_functions.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "physics/share/physics_functions.hpp"
+#include "share/eamxx_types.hpp"
 
 namespace scream {
 namespace p3 {

--- a/components/eamxx/src/physics/p3/tests/p3_prevent_liq_supersaturation_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_prevent_liq_supersaturation_tests.cpp
@@ -123,7 +123,7 @@ struct UnitWrap::UnitTest<D>::TestPreventLiqSupersaturation : public UnitWrap::U
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        baseline_data[i].read(Base::m_fid);
+        baseline_data[i].read(Base::m_ifile);
       }
     }
 
@@ -176,7 +176,7 @@ struct UnitWrap::UnitTest<D>::TestPreventLiqSupersaturation : public UnitWrap::U
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        cxx_host(s).write(Base::m_fid);
+        cxx_host(s).write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/p3/tests/p3_rain_imm_freezing_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_rain_imm_freezing_unit_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_rain_imm_freezing_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_rain_imm_freezing_unit_tests.cpp
@@ -70,7 +70,7 @@ void run_bfb()
   // Read baseline data
   if (this->m_baseline_action == COMPARE) {
     for (Int i = 0; i < max_pack_size; ++i) {
-      rain_imm_freezing_data[i].read(Base::m_fid);
+      rain_imm_freezing_data[i].read(Base::m_ifile);
     }
   }
 
@@ -114,7 +114,7 @@ void run_bfb()
   }
   else if (this->m_baseline_action == GENERATE) {
     for (Int s = 0; s < max_pack_size; ++s) {
-      host_data(s).write(Base::m_fid);
+      host_data(s).write(Base::m_ofile);
     }
   }
 }

--- a/components/eamxx/src/physics/p3/tests/p3_rain_sed_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_rain_sed_unit_tests.cpp
@@ -1,13 +1,11 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
 #include "p3_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_rain_sed_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_rain_sed_unit_tests.cpp
@@ -77,7 +77,7 @@ void run_bfb_rain_vel()
   // Read baseline data
   if (this->m_baseline_action == COMPARE) {
     for (Int i = 0; i < max_pack_size; ++i) {
-      crfv_baseline[i].read(Base::m_fid);
+      crfv_baseline[i].read(Base::m_ifile);
     }
   }
 
@@ -123,7 +123,7 @@ void run_bfb_rain_vel()
   }
   else if (this->m_baseline_action == GENERATE) {
     for (Int s = 0; s < max_pack_size; ++s) {
-      crfv_host(s).write(Base::m_fid);
+      crfv_host(s).write(Base::m_ofile);
     }
   }
 }
@@ -168,7 +168,7 @@ void run_bfb_rain_sed()
   // Read baseline data
   if (this->m_baseline_action == COMPARE) {
     for (auto& d : rsds_baseline) {
-      d.read(Base::m_fid);
+      d.read(Base::m_ifile);
     }
   }
 
@@ -208,7 +208,7 @@ void run_bfb_rain_sed()
   }
   else if (this->m_baseline_action == GENERATE) {
     for (Int i = 0; i < num_runs; ++i) {
-      rsds_cxx[i].write(Base::m_fid);
+      rsds_cxx[i].write(Base::m_ofile);
     }
   }
 }

--- a/components/eamxx/src/physics/p3/tests/p3_rain_self_collection_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_rain_self_collection_tests.cpp
@@ -1,12 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_rain_self_collection_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_rain_self_collection_tests.cpp
@@ -57,7 +57,7 @@ struct UnitWrap::UnitTest<D>::TestRainSelfCollection : public UnitWrap::UnitTest
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        dc[i].read(Base::m_fid);
+        dc[i].read(Base::m_ifile);
       }
     }
 
@@ -101,7 +101,7 @@ struct UnitWrap::UnitTest<D>::TestRainSelfCollection : public UnitWrap::UnitTest
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        dc_host(s).write(Base::m_fid);
+        dc_host(s).write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/p3/tests/p3_run_and_cmp.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_run_and_cmp.cpp
@@ -73,8 +73,9 @@ struct Baseline {
   }
 
   Int generate_baseline (const std::string& filename) {
-    auto fid = ekat::FILEPtr(fopen(filename.c_str(), "w"));
-    EKAT_REQUIRE_MSG( fid, "generate_baseline can't write " << filename);
+    std::ofstream ofile (filename, std::ios::binary);
+    EKAT_REQUIRE_MSG (ofile.good(), "generate_baseline can't write '" + filename + "'\n");
+
     Int nerr = 0;
 
     Int total_duration_microsec = 0;
@@ -103,7 +104,7 @@ struct Baseline {
           }
 
           if (ps.repeat == 0) {
-            write(fid, d); // Save the fields to the baseline file.
+            write(ofile, d); // Save the fields to the baseline file.
           }
         }
       }
@@ -118,10 +119,10 @@ struct Baseline {
   }
 
   Int run_and_cmp (const std::string& filename, const double& tol, bool no_baseline) {
-    ekat::FILEPtr fid;
+    std::ifstream ifile;
     if (!no_baseline) {
-      fid = ekat::FILEPtr(fopen(filename.c_str(), "r"));
-      EKAT_REQUIRE_MSG( fid, "generate_baseline can't read " << filename);
+      ifile.open(filename,std::ios::binary);
+      EKAT_REQUIRE_MSG( ifile.good(), "run_and_cmp can't read '" + filename + "'\n");
     }
     Int nerr = 0, ne;
     int case_num = 0;
@@ -148,7 +149,7 @@ struct Baseline {
           P3F::p3_init();
           for (int it=0; it<ps.nsteps; it++) {
             std::cout << "--- checking case # " << case_num << ", timestep # " << it+1 << " of " << ps.nsteps << " ---\n" << std::flush;
-            read(fid, d_ref);
+            read(ifile, d_ref);
             p3_main_wrap(*d);
             ne = compare(tol, d_ref, d);
             if (ne) std::cout << "Ref impl failed.\n";
@@ -180,32 +181,32 @@ private:
 
   std::vector<ParamSet> params_;
 
-  static void write (const ekat::FILEPtr& fid, const P3Data::Ptr& d) {
+  static void write (std::ofstream& ofile, const P3Data::Ptr& d) {
     P3DataIterator fdi(d);
     for (Int i = 0, n = fdi.nfield(); i < n; ++i) {
       const auto& f = fdi.getfield(i);
-      ekat::write(&f.dim, 1, fid);
-      ekat::write(f.extent, f.dim, fid);
-      ekat::write(f.data, f.size, fid);
+      impl::write_scalars(ofile,f.dim);
+      impl::write_scalars(ofile,f.extent);
+      impl::write_scalars(ofile,f.data,f.size);
     }
   }
 
-  static void read (const ekat::FILEPtr& fid, const P3Data::Ptr& d) {
+  static void read (std::ifstream& ifile, const P3Data::Ptr& d) {
     P3DataIterator fdi(d);
     for (Int i = 0, n = fdi.nfield(); i < n; ++i) {
       const auto& f = fdi.getfield(i);
       int dim, ds[3];
-      ekat::read(&dim, 1, fid);
+      impl::read_scalars(ifile,dim);
       EKAT_REQUIRE_MSG(dim == f.dim,
                       "For field " << f.name << " read expected dim " <<
                       f.dim << " but got " << dim);
-      ekat::read(ds, dim, fid);
+      impl::read_scalars(ifile,ds);
       for (int i = 0; i < dim; ++i)
         EKAT_REQUIRE_MSG(ds[i] == f.extent[i],
                         "For field " << f.name << " read expected dim "
                         << i << " to have extent " << f.extent[i] << " but got "
                         << ds[i]);
-      ekat::read(f.data, f.size, fid);
+      impl::read_scalars(ifile,f.data, f.size);
     // The code below is to force a result difference. This is used by the
     // scream/scripts internal testing to verify that various DIFFs are detected.
 #if defined(SCREAM_FORCE_RUN_DIFF)

--- a/components/eamxx/src/physics/p3/tests/p3_run_and_cmp.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_run_and_cmp.cpp
@@ -1,14 +1,10 @@
-#include "share/eamxx_types.hpp"
-#include "share/eamxx_session.hpp"
-#include "share/util/eamxx_utils.hpp"
-
 #include "p3_main_wrap.hpp"
 #include "p3_test_data.hpp"
 #include "p3_ic_cases.hpp"
 
-#include "ekat/util/ekat_file_utils.hpp"
-#include "ekat/util/ekat_test_utils.hpp"
-#include "ekat/ekat_assert.hpp"
+#include "share/eamxx_types.hpp"
+#include "share/eamxx_session.hpp"
+#include "share/util/eamxx_utils.hpp"
 
 #include <chrono>
 #include <vector>

--- a/components/eamxx/src/physics/p3/tests/p3_subgrid_variance_scaling_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_subgrid_variance_scaling_unit_tests.cpp
@@ -1,12 +1,12 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
 #include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_subgrid_variance_scaling_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_subgrid_variance_scaling_unit_tests.cpp
@@ -49,7 +49,7 @@ struct UnitWrap::UnitTest<D>::TestP3SubgridVarianceScaling : public UnitWrap::Un
         // Get baseline solution
         // ----------------------------------
         if (this->m_baseline_action == COMPARE) {
-          ekat::read(&baseline_scaling, 1, Base::m_fid);
+          impl::read_scalars(Base::m_ifile,baseline_scaling);
         }
 
         // Get C++ solution
@@ -75,7 +75,7 @@ struct UnitWrap::UnitTest<D>::TestP3SubgridVarianceScaling : public UnitWrap::Un
           REQUIRE(baseline_scaling == scaling_host(0) );
         }
         else if (this->m_baseline_action == GENERATE) {
-          ekat::write(&scaling_host(0), 1, Base::m_fid);
+          impl::write_scalars(Base::m_ofile,scaling_host(0));
         }
       } //end loop over relvar[j]
     } //end loop over expons[i]

--- a/components/eamxx/src/physics/p3/tests/p3_subgrid_variance_scaling_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_subgrid_variance_scaling_unit_tests.cpp
@@ -2,11 +2,11 @@
 
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
-
 #include "p3_unit_tests_common.hpp"
 
 #include "share/eamxx_types.hpp"
+
+#include <ekat_team_policy_utils.hpp>
 
 #include <thread>
 #include <array>
@@ -21,6 +21,7 @@ namespace unit_test {
 template <typename D>
 struct UnitWrap::UnitTest<D>::TestP3SubgridVarianceScaling : public UnitWrap::UnitTest<D>::Base
 {
+  using TPF = ekat::TeamPolicyFactory<ExeSpace>;
 
   //-----------------------------------------------------------------
   void run_bfb_tests() {
@@ -45,31 +46,31 @@ struct UnitWrap::UnitTest<D>::TestP3SubgridVarianceScaling : public UnitWrap::Un
     for (Int i = 0; i < 3; ++i) {  // loop over exponents
       for (Int j = 0; j < 16; ++j) { // loop over relvars
 
-	// Get baseline solution
-	// ----------------------------------
+        // Get baseline solution
+        // ----------------------------------
         if (this->m_baseline_action == COMPARE) {
           ekat::read(&baseline_scaling, 1, Base::m_fid);
         }
 
-	// Get C++ solution
-	// ----------------------------------
+        // Get C++ solution
+        // ----------------------------------
 
-	//Make scalar copies so available on device
-	Scalar expon = expons[i];
-	Scalar relvar = relvars[j];
+        //Make scalar copies so available on device
+        Scalar expon = expons[i];
+        Scalar relvar = relvars[j];
 
-	RangePolicy my_policy(0,1);
-	Kokkos::parallel_for(my_policy,KOKKOS_LAMBDA(int /* i */){
-	    Spack scalings = Functions::subgrid_variance_scaling(Spack(relvar),expon );
+        RangePolicy my_policy(0,1);
+        Kokkos::parallel_for(my_policy,KOKKOS_LAMBDA(int /* i */){
+            Spack scalings = Functions::subgrid_variance_scaling(Spack(relvar),expon );
 
-	    //all elements of scalings are identical. just copy 1 back to host.
-	    scaling_device(0) = scalings[0];
-	  });
+            //all elements of scalings are identical. just copy 1 back to host.
+            scaling_device(0) = scalings[0];
+          });
 
-	// Copy results back to host
-	Kokkos::deep_copy(scaling_host, scaling_device);
+        // Copy results back to host
+        Kokkos::deep_copy(scaling_host, scaling_device);
 
-	// Validate results
+        // Validate results
         if (SCREAM_BFB_TESTING && this->m_baseline_action == COMPARE) {
           REQUIRE(baseline_scaling == scaling_host(0) );
         }
@@ -161,7 +162,7 @@ struct UnitWrap::UnitTest<D>::TestP3SubgridVarianceScaling : public UnitWrap::Un
     int nerr = 0;
 
     //functions below use Spack size <16 but can't deal w/ exceptions on GPU, so do it here.
-    TeamPolicy policy(ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(1, 1));
+    auto policy = TPF::get_default_team_policy(1, 1);
     Kokkos::parallel_reduce("SGSvarScaling::run", policy,
       KOKKOS_LAMBDA(const MemberType& /* team */, int& errors) {
         errors = 0;

--- a/components/eamxx/src/physics/p3/tests/p3_table3_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_table3_unit_tests.cpp
@@ -1,16 +1,11 @@
 #include "catch2/catch.hpp"
 
 #include "p3_unit_tests_common.hpp"
-
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
 #include "p3_data.hpp"
-#include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
-#include "ekat/util/ekat_file_utils.hpp"
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_unit_tests.cpp
@@ -1,13 +1,10 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
-#include "ekat/util/ekat_arch.hpp"
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
-
 #include "p3_unit_tests_common.hpp"
+
+#include "share/eamxx_types.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/p3/tests/p3_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_unit_tests.cpp
@@ -236,7 +236,7 @@ struct UnitWrap::UnitTest<D>::TestP3Conservation : public UnitWrap::UnitTest<D>:
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        cwdc[i].read(Base::m_fid);
+        cwdc[i].read(Base::m_ifile);
       }
     }
 
@@ -300,7 +300,7 @@ struct UnitWrap::UnitTest<D>::TestP3Conservation : public UnitWrap::UnitTest<D>:
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        cwdc_host(s).write(Base::m_fid);
+        cwdc_host(s).write(Base::m_ofile);
       }
     }
   }
@@ -343,7 +343,7 @@ struct UnitWrap::UnitTest<D>::TestP3Conservation : public UnitWrap::UnitTest<D>:
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        iwdc[i].read(Base::m_fid);
+        iwdc[i].read(Base::m_ifile);
       }
     }
 
@@ -408,7 +408,7 @@ struct UnitWrap::UnitTest<D>::TestP3Conservation : public UnitWrap::UnitTest<D>:
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        iwdc_host(s).write(Base::m_fid);
+        iwdc_host(s).write(Base::m_ofile);
       }
     }
   }
@@ -451,7 +451,7 @@ struct UnitWrap::UnitTest<D>::TestP3Conservation : public UnitWrap::UnitTest<D>:
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        rwdc[i].read(Base::m_fid);
+        rwdc[i].read(Base::m_ifile);
       }
     }
 
@@ -505,7 +505,7 @@ struct UnitWrap::UnitTest<D>::TestP3Conservation : public UnitWrap::UnitTest<D>:
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        rwdc_host(s).write(Base::m_fid);
+        rwdc_host(s).write(Base::m_ofile);
       }
     }
   }
@@ -642,7 +642,7 @@ struct UnitWrap::UnitTest<D>::TestP3UpdatePrognosticIce : public UnitWrap::UnitT
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        pupidc[i].read(Base::m_fid);
+        pupidc[i].read(Base::m_ifile);
       }
     }
 
@@ -751,7 +751,7 @@ struct UnitWrap::UnitTest<D>::TestP3UpdatePrognosticIce : public UnitWrap::UnitT
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        pupidc_host(s).write(Base::m_fid);
+        pupidc_host(s).write(Base::m_ofile);
       }
     }
   }
@@ -801,7 +801,7 @@ struct UnitWrap::UnitTest<D>::TestGetTimeSpacePhysVariables : public UnitWrap::U
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        gtspvd[i].read(Base::m_fid);
+        gtspvd[i].read(Base::m_ifile);
       }
     }
 
@@ -872,7 +872,7 @@ struct UnitWrap::UnitTest<D>::TestGetTimeSpacePhysVariables : public UnitWrap::U
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        gtspvd_host(s).write(Base::m_fid);
+        gtspvd_host(s).write(Base::m_ofile);
       }
     }
   }
@@ -967,7 +967,7 @@ struct UnitWrap::UnitTest<D>::TestP3UpdatePrognosticLiq : public UnitWrap::UnitT
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        pupldc[i].read(Base::m_fid);
+        pupldc[i].read(Base::m_ifile);
       }
     }
 
@@ -1053,7 +1053,7 @@ struct UnitWrap::UnitTest<D>::TestP3UpdatePrognosticLiq : public UnitWrap::UnitT
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        pupldc_host(s).write(Base::m_fid);
+        pupldc_host(s).write(Base::m_ofile);
       }
     }
   }
@@ -1104,7 +1104,7 @@ struct UnitWrap::UnitTest<D>::TestP3FunctionsImposeMaxTotalNi : public UnitWrap:
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
-        dc[i].read(Base::m_fid);
+        dc[i].read(Base::m_ifile);
       }
     }
 
@@ -1139,7 +1139,7 @@ struct UnitWrap::UnitTest<D>::TestP3FunctionsImposeMaxTotalNi : public UnitWrap:
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int s = 0; s < max_pack_size; ++s) {
-        dc_host(s).write(Base::m_fid);
+        dc_host(s).write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/p3/tests/p3_upwind_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_upwind_unit_tests.cpp
@@ -7,7 +7,6 @@
 
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack.hpp"
 #include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/ekat_pack_kokkos.hpp"
 #include "ekat/util/ekat_file_utils.hpp"

--- a/components/eamxx/src/physics/p3/tests/p3_upwind_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_upwind_unit_tests.cpp
@@ -1,15 +1,13 @@
 #include "catch2/catch.hpp"
 
 #include "p3_unit_tests_common.hpp"
-
 #include "p3_functions.hpp"
 #include "p3_test_data.hpp"
 
 #include "share/eamxx_types.hpp"
 
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
-#include "ekat/ekat_pack_kokkos.hpp"
 #include "ekat/util/ekat_file_utils.hpp"
+#include <ekat_team_policy_utils.hpp>
 
 #include <thread>
 #include <array>
@@ -38,6 +36,8 @@ struct UnitWrap::UnitTest<D>::TestUpwind : public UnitWrap::UnitTest<D>::Base {
 void run_phys()
 {
   using ekat::repack;
+  using TPF = ekat::TeamPolicyFactory<ExeSpace>;
+
   constexpr auto SPS = SCREAM_SMALL_PACK_SIZE;
 
   static const Int nfield = 2;
@@ -94,7 +94,7 @@ void run_phys()
         Kokkos::parallel_for(Kokkos::TeamVectorRange(team, npack), set_fields);
         team.team_barrier();
       };
-      Kokkos::parallel_for(ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(1, npack),
+      Kokkos::parallel_for(TPF::get_default_team_policy(1, npack),
                            init_fields);
 
       const auto sflux = scalarize(flux[1]);
@@ -188,7 +188,7 @@ void run_phys()
           if (r_max1 > r_max0 + 10*eps) ++nerr;
         };
         Int lnerr;
-        Kokkos::parallel_reduce(ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(1, npack),
+        Kokkos::parallel_reduce(TPF::get_default_team_policy(1, npack),
                                 step, lnerr);
         nerr += lnerr;
         Kokkos::fence();

--- a/components/eamxx/src/physics/p3/tests/p3_upwind_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_upwind_unit_tests.cpp
@@ -6,7 +6,6 @@
 
 #include "share/eamxx_types.hpp"
 
-#include "ekat/util/ekat_file_utils.hpp"
 #include <ekat_team_policy_utils.hpp>
 
 #include <thread>
@@ -236,7 +235,7 @@ void run_bfb()
   // Read baseline data
   if (this->m_baseline_action == COMPARE) {
     for (auto& d : cuds_baseline) {
-      d.read(Base::m_fid);
+      d.read(Base::m_ifile);
     }
   }
 
@@ -271,7 +270,7 @@ void run_bfb()
   }
   else if (this->m_baseline_action == GENERATE) {
     for (Int i = 0; i < num_runs; ++i) {
-      cuds_cxx[i].write(Base::m_fid);
+      cuds_cxx[i].write(Base::m_ofile);
     }
   }
 }
@@ -318,7 +317,7 @@ void run_bfb()
   // Read baseline data
   if (this->m_baseline_action == COMPARE) {
     for (auto& d : gsds_baseline) {
-      d.read(Base::m_fid);
+      d.read(Base::m_ifile);
     }
   }
 
@@ -356,7 +355,7 @@ void run_bfb()
   }
   else if (this->m_baseline_action == GENERATE) {
     for (Int i = 0; i < num_runs; ++i) {
-      gsds_cxx[i].write(Base::m_fid);
+      gsds_cxx[i].write(Base::m_ofile);
     }
   }
 }

--- a/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_interface.hpp
+++ b/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_interface.hpp
@@ -17,9 +17,9 @@
 
 #include "physics/share/physics_constants.hpp"
 
-#include "ekat/mpi/ekat_comm.hpp"
-#include "ekat/logging/ekat_logger.hpp"
-#include "ekat/util/ekat_math_utils.hpp"
+#include <ekat_comm.hpp>
+#include <ekat_logger.hpp>
+#include <ekat_math_utils.hpp>
 
 #include "Kokkos_Random.hpp"
 

--- a/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
+++ b/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
@@ -10,7 +10,7 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/util/eamxx_column_ops.hpp"
 
-#include "ekat/ekat_assert.hpp"
+#include <ekat_assert.hpp>
 
 #include "cpp/rrtmgp/mo_gas_concentrations.h"
 

--- a/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
+++ b/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
@@ -10,6 +10,7 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/util/eamxx_column_ops.hpp"
 
+#include <ekat_team_policy_utils.hpp>
 #include <ekat_assert.hpp>
 
 #include "cpp/rrtmgp/mo_gas_concentrations.h"
@@ -19,6 +20,7 @@ namespace scream {
 using KT = KokkosTypes<DefaultDevice>;
 using ExeSpace = KT::ExeSpace;
 using MemberType = KT::MemberType;
+using TPF = ekat::TeamPolicyFactory<ExeSpace>;
 
 namespace {
 
@@ -697,7 +699,7 @@ void RRTMGPRadiation::run_impl (const double dt) {
       if (name == "h2o") {
         // h2o is (wet) mass mixing ratio in FM, otherwise known as "qv", which we've already read in above
         // Convert to vmr
-        const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(m_ncol, m_nlay);
+        const auto policy = TPF::get_default_team_policy(m_ncol, m_nlay);
         Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
           const int icol = team.league_rank();
           Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlay), [&] (const int& k) {
@@ -713,7 +715,7 @@ void RRTMGPRadiation::run_impl (const double dt) {
         );
         // Back out volume mixing ratios
         const auto air_mol_weight = PC::MWdry;
-        const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(m_ncol, m_nlay);
+        const auto policy = TPF::get_default_team_policy(m_ncol, m_nlay);
         Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
           const int i = team.league_rank();
           Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlay), [&] (const int& k) {
@@ -823,7 +825,7 @@ void RRTMGPRadiation::run_impl (const double dt) {
         }
         Kokkos::deep_copy(d_mu0,h_mu0);
 
-        const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, m_nlay);
+        const auto policy = TPF::get_default_team_policy(ncol, m_nlay);
         TIMED_KERNEL(
         Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
           const int i = team.league_rank();
@@ -949,7 +951,7 @@ void RRTMGPRadiation::run_impl (const double dt) {
       auto lwp_k = m_buffer.lwp_k;
       auto iwp_k = m_buffer.iwp_k;
       if (not do_subcol_sampling) {
-        const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, m_nlay);
+        const auto policy = TPF::get_default_team_policy(ncol, m_nlay);
         Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
           const int i = team.league_rank();
           const int icol = i + beg;
@@ -963,7 +965,7 @@ void RRTMGPRadiation::run_impl (const double dt) {
           });
         });
       } else {
-        const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, m_nlay);
+        const auto policy = TPF::get_default_team_policy(ncol, m_nlay);
         Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
           const int i = team.league_rank();
           const int icol = i + beg;
@@ -980,7 +982,7 @@ void RRTMGPRadiation::run_impl (const double dt) {
       interface_t::mixing_ratio_to_cloud_mass(qi_k, cldfrac_tot_k, p_del_k, iwp_k);
       // Convert to g/m2 (needed by RRTMGP)
       {
-      const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, m_nlay);
+      const auto policy = TPF::get_default_team_policy(ncol, m_nlay);
       Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
         const int i = team.league_rank();
         Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlay), [&] (const int& k) {
@@ -1037,7 +1039,7 @@ void RRTMGPRadiation::run_impl (const double dt) {
         lw_flux_up_k, lw_flux_dn_k, p_del_k, lw_heating_k
       );
       {
-        const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, m_nlay);
+        const auto policy = TPF::get_default_team_policy(ncol, m_nlay);
         Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
           const int idx = team.league_rank();
           const int icol = idx+beg;
@@ -1113,6 +1115,7 @@ void RRTMGPRadiation::run_impl (const double dt) {
                           );
 
       // Copy output data back to FieldManager
+      const auto policy = TPF::get_default_team_policy(ncol, m_nlay);
       const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, m_nlay);
       TIMED_KERNEL(
       Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
@@ -1170,7 +1173,7 @@ void RRTMGPRadiation::run_impl (const double dt) {
   // across timesteps to conserve energy.
   const int ncols = m_ncol;
   const int nlays = m_nlay;
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncols, nlays);
+  const auto policy = TPF::get_default_team_policy(ncols, nlays);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const int i = team.league_rank();
     Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlays), [&] (const int& k) {
@@ -1194,7 +1197,7 @@ void RRTMGPRadiation::run_impl (const double dt) {
 
     const int ncols = m_ncol;
     const int nlays = m_nlay;
-    const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncols, nlays);
+    const auto policy = TPF::get_default_team_policy(ncols, nlays);
     Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
       const int icol = team.league_rank();
 

--- a/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.hpp
+++ b/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.hpp
@@ -4,8 +4,10 @@
 #include "cpp/rrtmgp/mo_gas_concentrations.h"
 #include "physics/rrtmgp/eamxx_rrtmgp_interface.hpp"
 #include "share/atm_process/atmosphere_process.hpp"
-#include "ekat/ekat_parameter_list.hpp"
-#include "ekat/util/ekat_string_utils.hpp"
+
+#include <ekat_parameter_list.hpp>
+#include <ekat_string_utils.hpp>
+
 #include <string>
 
 namespace scream {

--- a/components/eamxx/src/physics/share/CMakeLists.txt
+++ b/components/eamxx/src/physics/share/CMakeLists.txt
@@ -1,7 +1,6 @@
 set(PHYSICS_SHARE_SRCS
   physics_share_f2c.F90
   physics_share.cpp
-  physics_test_data.cpp
   eamxx_trcmix.cpp
 )
 
@@ -22,6 +21,11 @@ target_include_directories(physics_share PUBLIC
 target_link_libraries(physics_share scream_share)
 
 if (NOT SCREAM_LIB_ONLY)
+
+  target_sources(scream_test_support PRIVATE
+    physics_test_data.cpp
+  )
+
   add_subdirectory(tests)
 endif()
 

--- a/components/eamxx/src/physics/share/eamxx_trcmix.cpp
+++ b/components/eamxx/src/physics/share/eamxx_trcmix.cpp
@@ -1,7 +1,7 @@
 #include "eamxx_trcmix.hpp"
 #include "physics_constants.hpp"
 
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+#include <ekat_team_policy_utils.hpp>
 #include <ekat_math_utils.hpp>
 
 #include <cmath>
@@ -50,7 +50,7 @@ void trcmix(
     {"cfc12",{rmwf12*f12vmr, 0.4000, 0.00222, 0.5   , 0.024444 }}
   };
 
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncols, nlevs);
+  const auto policy = ekat::TeamPolicyFactory<ExeSpace>::get_default_team_policy(ncols, nlevs);
 
   if (name == "o2" || name == "co2") {
     const auto val = name == "o2" ? C::o2mmr : rmwco2 * co2vmr;

--- a/components/eamxx/src/physics/share/eamxx_trcmix.cpp
+++ b/components/eamxx/src/physics/share/eamxx_trcmix.cpp
@@ -1,8 +1,8 @@
 #include "eamxx_trcmix.hpp"
 #include "physics_constants.hpp"
 
-#include "ekat/util/ekat_math_utils.hpp"
 #include "ekat/kokkos/ekat_kokkos_utils.hpp"
+#include <ekat_math_utils.hpp>
 
 #include <cmath>
 

--- a/components/eamxx/src/physics/share/physics_constants.hpp
+++ b/components/eamxx/src/physics/share/physics_constants.hpp
@@ -3,9 +3,7 @@
 
 #include "share/eamxx_types.hpp"
 
-#include "ekat/util/ekat_string_utils.hpp"
-#include "ekat/ekat_scalar_traits.hpp"
-#include "ekat/logging/ekat_logger.hpp"
+#include <ekat_string_utils.hpp>
 
 #include <vector>
 

--- a/components/eamxx/src/physics/share/physics_constants.hpp
+++ b/components/eamxx/src/physics/share/physics_constants.hpp
@@ -5,6 +5,7 @@
 
 #include <ekat_string_utils.hpp>
 
+#include <Kokkos_NumericTraits.hpp>
 #include <vector>
 
 namespace scream {
@@ -147,7 +148,7 @@ Scalar Constants<Scalar>::get_gas_mol_weight(ci_string gas_name) {
   } else if (gas_name == "cfc12" ) {
     return 120.;
   }
-  return ekat::ScalarTraits<Scalar>::invalid();
+  return Kokkos::Experimental::quiet_NaN_v<Scalar>;
 }
 
 template <typename Scalar>

--- a/components/eamxx/src/physics/share/physics_functions.hpp
+++ b/components/eamxx/src/physics/share/physics_functions.hpp
@@ -5,8 +5,8 @@
 
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack_kokkos.hpp"
-#include "ekat/ekat_workspace.hpp"
+#include <ekat_pack_kokkos.hpp>
+#include <ekat_workspace.hpp>
 
 namespace scream {
 namespace physics {

--- a/components/eamxx/src/physics/share/physics_share.cpp
+++ b/components/eamxx/src/physics/share/physics_share.cpp
@@ -1,8 +1,6 @@
 #include "physics_share.hpp"
 
-#include "ekat/ekat_assert.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
-#include "ekat/ekat_pack_kokkos.hpp"
+#include <ekat_assert.hpp>
 
 #include <random>
 

--- a/components/eamxx/src/physics/share/physics_test_data.cpp
+++ b/components/eamxx/src/physics/share/physics_test_data.cpp
@@ -1,8 +1,6 @@
 #include "physics_test_data.hpp"
 
-#include "ekat/ekat_assert.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
-#include "ekat/ekat_pack_kokkos.hpp"
+#include <ekat_assert.hpp>
 
 namespace scream {
 

--- a/components/eamxx/src/physics/share/physics_test_data.cpp
+++ b/components/eamxx/src/physics/share/physics_test_data.cpp
@@ -24,20 +24,21 @@ PhysicsTestData& PhysicsTestData::assignment_impl(const PhysicsTestData& rhs)
   return *this;
 }
 
-void PhysicsTestData::read(const ekat::FILEPtr& fid)
+void PhysicsTestData::read(std::ifstream& ifile)
 {
-  EKAT_REQUIRE_MSG(fid,
-                   "Tried to read from missing file. You may have forgotten to generate baselines for some BFB unit tests");
-  m_reals.read(fid);
-  m_ints.read(fid);
-  m_bools.read(fid);
+  EKAT_REQUIRE_MSG (ifile.good(), "Cannot read from input file. Did you forget to open it?\n");
+  m_reals.read(ifile);
+  m_ints.read(ifile);
+  m_bools.read(ifile);
 }
 
-void PhysicsTestData::write(const ekat::FILEPtr& fid) const
+void PhysicsTestData::write(std::ofstream& ofile) const
 {
-  m_reals.write(fid);
-  m_ints.write(fid);
-  m_bools.write(fid);
+  EKAT_REQUIRE_MSG (ofile.good(), "Cannot write to input file. Did you forget to open it?\n");
+
+  m_reals.write(ofile);
+  m_ints.write(ofile);
+  m_bools.write(ofile);
 }
 
 

--- a/components/eamxx/src/physics/share/physics_test_data.hpp
+++ b/components/eamxx/src/physics/share/physics_test_data.hpp
@@ -6,12 +6,12 @@
 
 #include <ekat_math_utils.hpp>
 #include <ekat_assert.hpp>
-#include <ekat_file_utils.hpp>
 #include <ekat_test_utils.hpp>
 
 #include <random>
 #include <vector>
 #include <utility>
+#include <fstream>
 
 /*
 PhysicsTestData is meant to offer the client something they can inherit to provide
@@ -41,6 +41,85 @@ struct SHOCGridData : public PhysicsTestData {
   PTD_STD_DEF(SHOCGridData, 3, dim1, dim2, dim3); // 3 => number of scalars followed by their names
 };
 */
+
+namespace scream {
+namespace impl {
+
+template <typename T>
+void read_scalars(std::ifstream& ifile, T& data)
+{
+  ifile >> data;
+}
+
+template <typename T>
+void read_scalars(std::ifstream& ifile, std::vector<T>& data)
+{
+  for (auto& entry : data) {
+    ifile >> entry;
+  }
+}
+
+template <typename T, int N>
+void read_scalars(std::ifstream& ifile, T (&data)[N]) {
+  for (int i=0; i<N; ++i) {
+      ifile >> data[i];
+  }
+}
+
+template <typename T, typename I>
+std::enable_if_t<std::is_integral<I>::value>
+read_scalars(std::ifstream& ifile, T* const data, I N) {
+  for (I i=0; i<N; ++i) {
+    read_scalars(ifile,data[i]);
+  }
+}
+
+template <typename T, typename... S>
+void read_scalars(std::ifstream& ifile, T& data, S&... tail)
+{
+  read_scalars(ifile,data);
+  read_scalars(ifile,tail...);
+}
+
+template <typename T>
+void write_scalars(std::ofstream& ofile, const T& data)
+{
+  ofile << data;
+}
+
+template <typename T>
+void write_scalars(std::ofstream& ofile, const std::vector<T>& data)
+{
+  for (const auto& entry : data) {
+    ofile << entry;
+  }
+}
+
+template <typename T, int N>
+void write_scalars(std::ofstream& ofile, const T (&data)[N]) {
+  for (int i=0; i<N; ++i) {
+      ofile << data[i];
+  }
+}
+
+template <typename T, typename I>
+std::enable_if_t<std::is_integral<I>::value>
+write_scalars(std::ofstream& ofile, const T* const data, I N) {
+  for (I i=0; i<N; ++i) {
+    write_scalars(ofile,data[i]);
+  }
+}
+
+
+template <typename T, typename... S>
+void write_scalars(std::ofstream& ofile, const T& data, const S&... tail)
+{
+  write_scalars(ofile,data);
+  write_scalars(ofile,tail...);
+}
+
+} // namespace impl
+} // namespace scream
 
 // Convenience macros for up to 20 arguments, beyond that, you're on your own :)
 
@@ -96,56 +175,45 @@ struct SHOCGridData : public PhysicsTestData {
 #define PTD_ASS19(first, ...) first = rhs.first; PTD_ASS18(__VA_ARGS__)
 #define PTD_ASS20(first, ...) first = rhs.first; PTD_ASS19(__VA_ARGS__)
 
-#define  PTD_RW0(action)             ((void) (0))
-#define  PTD_RW1(action, first)      ekat::action(&first, 1, fid); PTD_RW0(action)
-#define  PTD_RW2(action, first, ...) ekat::action(&first, 1, fid); PTD_RW1(action, __VA_ARGS__)
-#define  PTD_RW3(action, first, ...) ekat::action(&first, 1, fid); PTD_RW2(action, __VA_ARGS__)
-#define  PTD_RW4(action, first, ...) ekat::action(&first, 1, fid); PTD_RW3(action, __VA_ARGS__)
-#define  PTD_RW5(action, first, ...) ekat::action(&first, 1, fid); PTD_RW4(action, __VA_ARGS__)
-#define  PTD_RW6(action, first, ...) ekat::action(&first, 1, fid); PTD_RW5(action, __VA_ARGS__)
-#define  PTD_RW7(action, first, ...) ekat::action(&first, 1, fid); PTD_RW6(action, __VA_ARGS__)
-#define  PTD_RW8(action, first, ...) ekat::action(&first, 1, fid); PTD_RW7(action, __VA_ARGS__)
-#define  PTD_RW9(action, first, ...) ekat::action(&first, 1, fid); PTD_RW8(action, __VA_ARGS__)
-#define PTD_RW10(action, first, ...) ekat::action(&first, 1, fid); PTD_RW9(action, __VA_ARGS__)
-#define PTD_RW11(action, first, ...) ekat::action(&first, 1, fid); PTD_RW10(action, __VA_ARGS__)
-#define PTD_RW12(action, first, ...) ekat::action(&first, 1, fid); PTD_RW11(action, __VA_ARGS__)
-#define PTD_RW13(action, first, ...) ekat::action(&first, 1, fid); PTD_RW12(action, __VA_ARGS__)
-#define PTD_RW14(action, first, ...) ekat::action(&first, 1, fid); PTD_RW13(action, __VA_ARGS__)
-#define PTD_RW15(action, first, ...) ekat::action(&first, 1, fid); PTD_RW14(action, __VA_ARGS__)
-#define PTD_RW16(action, first, ...) ekat::action(&first, 1, fid); PTD_RW15(action, __VA_ARGS__)
-#define PTD_RW17(action, first, ...) ekat::action(&first, 1, fid); PTD_RW16(action, __VA_ARGS__)
-#define PTD_RW18(action, first, ...) ekat::action(&first, 1, fid); PTD_RW17(action, __VA_ARGS__)
-#define PTD_RW19(action, first, ...) ekat::action(&first, 1, fid); PTD_RW18(action, __VA_ARGS__)
-#define PTD_RW20(action, first, ...) ekat::action(&first, 1, fid); PTD_RW19(action, __VA_ARGS__)
-#define PTD_RW21(action, first, ...) ekat::action(&first, 1, fid); PTD_RW20(action, __VA_ARGS__)
-#define PTD_RW22(action, first, ...) ekat::action(&first, 1, fid); PTD_RW21(action, __VA_ARGS__)
-#define PTD_RW23(action, first, ...) ekat::action(&first, 1, fid); PTD_RW22(action, __VA_ARGS__)
-#define PTD_RW24(action, first, ...) ekat::action(&first, 1, fid); PTD_RW23(action, __VA_ARGS__)
-#define PTD_RW25(action, first, ...) ekat::action(&first, 1, fid); PTD_RW24(action, __VA_ARGS__)
-#define PTD_RW26(action, first, ...) ekat::action(&first, 1, fid); PTD_RW25(action, __VA_ARGS__)
-#define PTD_RW27(action, first, ...) ekat::action(&first, 1, fid); PTD_RW26(action, __VA_ARGS__)
-#define PTD_RW28(action, first, ...) ekat::action(&first, 1, fid); PTD_RW27(action, __VA_ARGS__)
-#define PTD_RW29(action, first, ...) ekat::action(&first, 1, fid); PTD_RW28(action, __VA_ARGS__)
-#define PTD_RW30(action, first, ...) ekat::action(&first, 1, fid); PTD_RW29(action, __VA_ARGS__)
-#define PTD_RW31(action, first, ...) ekat::action(&first, 1, fid); PTD_RW30(action, __VA_ARGS__)
-
 #define PTD_ASSIGN_OP(name, num_scalars, ...)                                  \
   name& operator=(const name& rhs) { PTD_ASS##num_scalars(__VA_ARGS__); assignment_impl(rhs); return *this; }
 
 #define PTD_ASSIGN_OP_INIT(name, num_scalars, ...)                      \
   name& operator=(const name& rhs) { PTD_ASS##num_scalars(__VA_ARGS__); assignment_impl(rhs); init = rhs.init; return *this; }
 
-#define PTD_RW_SCALARS(num_scalars, ...) \
-  void read_scalars(const ekat::FILEPtr& fid) { EKAT_REQUIRE_MSG(fid, "Tried to read from missing file. You may have forgotten to generate baselines for some BFB unit tests"); PTD_RW##num_scalars(read, __VA_ARGS__); } \
-  void write_scalars(const ekat::FILEPtr& fid) const { PTD_RW##num_scalars(write, __VA_ARGS__); }
+#define PTD_RW_SCALARS(num_scalars, ...)                                \
+  void read_scalars (std::ifstream& ifile) {                            \
+    EKAT_REQUIRE_MSG (ifile.good(),                                     \
+        "Cannot read from input file. Did you forget to open it?\n");   \
+    ::scream::impl::read_scalars(ifile,__VA_ARGS__);                    \
+  }                                                                     \
+  void write_scalars (std::ofstream& ofile) {                           \
+    EKAT_REQUIRE_MSG (ofile.good(),                                     \
+        "Cannot write to output file. Did you forget to open it?\n");   \
+    ::scream::impl::write_scalars(ofile,__VA_ARGS__);                   \
+  }
 
-#define PTD_RW_SCALARS_ONLY(num_scalars, ...) \
-  void read(const ekat::FILEPtr& fid) { EKAT_REQUIRE_MSG(fid, "Tried to read from missing file. You may have forgotten to generate baselines for some BFB unit tests"); PTD_RW##num_scalars(read, __VA_ARGS__); } \
-  void write(const ekat::FILEPtr& fid) const { PTD_RW##num_scalars(write, __VA_ARGS__); }
+#define PTD_RW_SCALARS_ONLY(num_scalars, ...)                           \
+  void read(std::ifstream& ifile) {                                     \
+    EKAT_REQUIRE_MSG (ifile.good(),                                     \
+        "Cannot read from input file. Did you forget to open it?\n");   \
+    ::scream::impl::read_scalars(ifile,__VA_ARGS__);                    \
+  }                                                                     \
+  void write(std::ofstream& ofile) {                                    \
+    EKAT_REQUIRE_MSG (ofile.good(),                                     \
+        "Cannot write to output file. Did you forget to open it?\n");   \
+    ::scream::impl::write_scalars(ofile,__VA_ARGS__);                   \
+  }
 
 #define PTD_RW() \
-  void read(const ekat::FILEPtr& fid) { read_scalars(fid); PhysicsTestData::read(fid); } \
-  void write(const ekat::FILEPtr& fid) const { write_scalars(fid); PhysicsTestData::write(fid); }
+  void read(std::ifstream& ifile) {           \
+    read_scalars(ifile);                      \
+    PhysicsTestData::read(ifile);             \
+  }                                           \
+  void write(std::ofstream& ofile) {          \
+    write_scalars(ofile);                     \
+    PhysicsTestData::write(ofile);            \
+  }
 
 #define PTD_STD_DEF(name, num_scalars, ...) \
   PTD_DATA_COPY_CTOR(name, num_scalars);     \
@@ -303,14 +371,14 @@ class PhysicsTestData
       m_data = new_data;
     }
 
-    void read(const ekat::FILEPtr& fid)
+    void read(std::ifstream& ifile)
     {
-      ekat::read(m_data.data(), m_data.size(), fid);
+      impl::read_scalars(ifile,m_data);
     }
 
-    void write(const ekat::FILEPtr& fid) const
+    void write(std::ofstream& ofile) const
     {
-      ekat::write(m_data.data(), m_data.size(), fid);
+      impl::write_scalars(ofile,m_data);
     }
 
     std::vector<std::vector<Int> > m_dims_list;    // list of dims, one per unique set of dims
@@ -408,9 +476,9 @@ class PhysicsTestData
     }
   }
 
-  void read(const ekat::FILEPtr& fid);
+  void read(std::ifstream& ifile);
 
-  void write(const ekat::FILEPtr& fid) const;
+  void write(std::ofstream& ofile) const;
 
  protected:
 
@@ -444,13 +512,13 @@ struct UnitBase
   std::string     m_baseline_path;
   std::string     m_test_name;
   BASELINE_ACTION m_baseline_action;
-  ekat::FILEPtr   m_fid;
+  std::ifstream   m_ifile;
+  std::ofstream   m_ofile;
 
   UnitBase() :
     m_baseline_path(""),
     m_test_name(Catch::getResultCapture().getCurrentTestName()),
-    m_baseline_action(NONE),
-    m_fid()
+    m_baseline_action(NONE)
   {
     auto& ts = ekat::TestSession::get();
     if (ts.flags["c"]) {
@@ -469,11 +537,12 @@ struct UnitBase
 
     std::string baseline_name = m_baseline_path + "/" + m_test_name;
     if (m_baseline_action == COMPARE) {
-      m_fid = ekat::FILEPtr(fopen(baseline_name.c_str(), "r"));
-      EKAT_REQUIRE_MSG(m_fid, "Missing baselines: " << baseline_name);
+      m_ifile.open(baseline_name,std::ios::binary);
+      EKAT_REQUIRE_MSG(m_ifile.good(), "Missing baselines: " + baseline_name << "\n");
     }
     else if (m_baseline_action == GENERATE) {
-      m_fid = ekat::FILEPtr(fopen(baseline_name.c_str(), "w"));
+      m_ofile.open(baseline_name,std::ios::binary);
+      EKAT_REQUIRE_MSG(m_ofile.good(), "Coult not open baseline file for write: " + baseline_name << "\n");
     }
   }
 
@@ -487,14 +556,14 @@ struct UnitBase
       auto engine = setup_random_test(nullptr, &seed);
       if (m_baseline_action == GENERATE) {
         // Write the seed
-        ekat::write(&seed, 1, m_fid);
+        m_ofile << seed;
       }
       return engine;
     }
     else {
       // Read the seed
       int seed;
-      ekat::read(&seed, 1, m_fid);
+      m_ifile >> seed;
       return setup_random_test(seed);
     }
   }

--- a/components/eamxx/src/physics/share/physics_test_data.hpp
+++ b/components/eamxx/src/physics/share/physics_test_data.hpp
@@ -1,13 +1,13 @@
 #ifndef SCREAM_PHYSICS_TEST_DATA_HPP
 #define SCREAM_PHYSICS_TEST_DATA_HPP
 
+#include "share/util/eamxx_setup_random_test.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/util/ekat_math_utils.hpp"
-#include "ekat/ekat_assert.hpp"
-#include "ekat/util/ekat_file_utils.hpp"
-#include "ekat/util/ekat_test_utils.hpp"
-#include "share/util/eamxx_setup_random_test.hpp"
+#include <ekat_math_utils.hpp>
+#include <ekat_assert.hpp>
+#include <ekat_file_utils.hpp>
+#include <ekat_test_utils.hpp>
 
 #include <random>
 #include <vector>

--- a/components/eamxx/src/physics/share/tests/CMakeLists.txt
+++ b/components/eamxx/src/physics/share/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ if (SCREAM_ENABLE_BASELINE_TESTS)
   # The comparison test. Expects baseline to exist. All thread configurations
   # will use the same baseline.
   CreateUnitTest(physics_saturation_run_and_cmp "physics_saturation_run_and_cmp.cpp"
-    LIBS physics_share
+    LIBS physics_share physics_test
     EXE_ARGS "${BASELINE_FILE_ARG}"
     LABELS "physics")
 

--- a/components/eamxx/src/physics/share/tests/physics_test_data_unit_tests.cpp
+++ b/components/eamxx/src/physics/share/tests/physics_test_data_unit_tests.cpp
@@ -3,7 +3,6 @@
 #include "physics/share/physics_test_data.hpp"
 #include "share/eamxx_types.hpp"
 #include "physics_unit_tests_common.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
 namespace scream {

--- a/components/eamxx/src/physics/shoc/disp/shoc_assumed_pdf_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_assumed_pdf_disp.cpp
@@ -1,6 +1,6 @@
 #include "shoc_functions.hpp"
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace shoc {

--- a/components/eamxx/src/physics/shoc/disp/shoc_assumed_pdf_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_assumed_pdf_disp.cpp
@@ -1,6 +1,7 @@
 #include "shoc_functions.hpp"
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace shoc {
@@ -32,9 +33,10 @@ void Functions<Real,DefaultDevice>
   const view_2d<Spack>&       shoc_ql2)
 {
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
 
   const auto nlev_packs = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 

--- a/components/eamxx/src/physics/shoc/disp/shoc_check_tke_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_check_tke_disp.cpp
@@ -1,6 +1,6 @@
 #include "shoc_functions.hpp"
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace shoc {

--- a/components/eamxx/src/physics/shoc/disp/shoc_check_tke_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_check_tke_disp.cpp
@@ -1,6 +1,7 @@
 #include "shoc_functions.hpp"
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace shoc {
@@ -13,9 +14,10 @@ void Functions<Real,DefaultDevice>
   const view_2d<Spack>& tke)
 {
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
 
   const auto nlev_packs = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 

--- a/components/eamxx/src/physics/shoc/disp/shoc_compute_shoc_temperature_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_compute_shoc_temperature_disp.cpp
@@ -1,6 +1,6 @@
 #include "shoc_functions.hpp"
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace shoc {

--- a/components/eamxx/src/physics/shoc/disp/shoc_compute_shoc_temperature_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_compute_shoc_temperature_disp.cpp
@@ -1,6 +1,7 @@
 #include "shoc_functions.hpp"
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace shoc {
@@ -16,9 +17,10 @@ void Functions<Real,DefaultDevice>
   const view_2d<Spack>&       tabs)
 {
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
 
   const auto nlev_packs = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 

--- a/components/eamxx/src/physics/shoc/disp/shoc_compute_shoc_vapor_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_compute_shoc_vapor_disp.cpp
@@ -1,6 +1,6 @@
 #include "shoc_functions.hpp"
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace shoc {

--- a/components/eamxx/src/physics/shoc/disp/shoc_compute_shoc_vapor_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_compute_shoc_vapor_disp.cpp
@@ -1,6 +1,7 @@
 #include "shoc_functions.hpp"
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace shoc {
@@ -15,9 +16,10 @@ void Functions<Real,DefaultDevice>
   const view_2d<Spack>&       qv)
 {
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
 
   const auto nlev_packs = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 

--- a/components/eamxx/src/physics/shoc/disp/shoc_diag_obklen_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_diag_obklen_disp.cpp
@@ -1,6 +1,6 @@
 #include "shoc_functions.hpp"
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace shoc {

--- a/components/eamxx/src/physics/shoc/disp/shoc_diag_second_shoc_moments_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_diag_second_shoc_moments_disp.cpp
@@ -1,6 +1,6 @@
 #include "shoc_functions.hpp"
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace shoc {

--- a/components/eamxx/src/physics/shoc/disp/shoc_diag_second_shoc_moments_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_diag_second_shoc_moments_disp.cpp
@@ -1,6 +1,7 @@
 #include "shoc_functions.hpp"
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace shoc {
@@ -40,9 +41,10 @@ void Functions<Real,DefaultDevice>
   const view_2d<Spack>& w_sec)
 {
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
 
   const auto nlev_packs = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 

--- a/components/eamxx/src/physics/shoc/disp/shoc_diag_third_shoc_moments_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_diag_third_shoc_moments_disp.cpp
@@ -1,6 +1,6 @@
 #include "shoc_functions.hpp"
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace shoc {

--- a/components/eamxx/src/physics/shoc/disp/shoc_diag_third_shoc_moments_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_diag_third_shoc_moments_disp.cpp
@@ -1,6 +1,7 @@
 #include "shoc_functions.hpp"
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace shoc {
@@ -27,9 +28,10 @@ void Functions<Real,DefaultDevice>
   const view_2d<Spack>&       w3)
 {
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
 
   const auto nlev_packs = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 

--- a/components/eamxx/src/physics/shoc/disp/shoc_energy_fixer_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_energy_fixer_disp.cpp
@@ -1,6 +1,6 @@
 #include "shoc_functions.hpp"
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace shoc {

--- a/components/eamxx/src/physics/shoc/disp/shoc_energy_fixer_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_energy_fixer_disp.cpp
@@ -1,6 +1,7 @@
 #include "shoc_functions.hpp"
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace shoc {
@@ -32,9 +33,10 @@ void Functions<Real,DefaultDevice>
   const view_2d<Spack>&        host_dse)
 {
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
 
   const auto nlev_packs = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 

--- a/components/eamxx/src/physics/shoc/disp/shoc_energy_integrals_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_energy_integrals_disp.cpp
@@ -1,6 +1,6 @@
 #include "shoc_functions.hpp"
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace shoc {

--- a/components/eamxx/src/physics/shoc/disp/shoc_energy_integrals_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_energy_integrals_disp.cpp
@@ -1,6 +1,7 @@
 #include "shoc_functions.hpp"
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace shoc {
@@ -22,9 +23,10 @@ void Functions<Real,DefaultDevice>
   const view_1d<Scalar>& wl_b)
 {
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
 
   const auto nlev_packs = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 

--- a/components/eamxx/src/physics/shoc/disp/shoc_grid_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_grid_disp.cpp
@@ -1,6 +1,6 @@
 #include "shoc_functions.hpp"
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace shoc {

--- a/components/eamxx/src/physics/shoc/disp/shoc_grid_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_grid_disp.cpp
@@ -1,6 +1,7 @@
 #include "shoc_functions.hpp"
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace shoc {
@@ -19,9 +20,10 @@ void Functions<Real,DefaultDevice>
   const view_2d<Spack>&       rho_zt)
 {
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
 
   const auto nlev_packs = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 

--- a/components/eamxx/src/physics/shoc/disp/shoc_length_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_length_disp.cpp
@@ -1,6 +1,6 @@
 #include "shoc_functions.hpp"
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace shoc {

--- a/components/eamxx/src/physics/shoc/disp/shoc_length_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_length_disp.cpp
@@ -1,6 +1,7 @@
 #include "shoc_functions.hpp"
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace shoc {
@@ -24,9 +25,10 @@ void Functions<Real,DefaultDevice>
   const view_2d<Spack>&        shoc_mix)
 {
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
 
   const auto nlev_packs = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 

--- a/components/eamxx/src/physics/shoc/disp/shoc_pblintd_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_pblintd_disp.cpp
@@ -1,6 +1,6 @@
 #include "shoc_functions.hpp"
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace shoc {

--- a/components/eamxx/src/physics/shoc/disp/shoc_pblintd_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_pblintd_disp.cpp
@@ -1,6 +1,7 @@
 #include "shoc_functions.hpp"
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace shoc {
@@ -27,9 +28,10 @@ void Functions<Real,DefaultDevice>
   const view_1d<Scalar>&       pblh)
 {
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
 
   const auto nlev_packs = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 

--- a/components/eamxx/src/physics/shoc/disp/shoc_tke_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_tke_disp.cpp
@@ -1,6 +1,6 @@
 #include "shoc_functions.hpp"
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace shoc {

--- a/components/eamxx/src/physics/shoc/disp/shoc_tke_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_tke_disp.cpp
@@ -1,6 +1,7 @@
 #include "shoc_functions.hpp"
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace shoc {
@@ -37,9 +38,10 @@ void Functions<Real,DefaultDevice>
   const view_2d<Spack>&        isotropy)
 {
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
 
   const auto nlev_packs = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 

--- a/components/eamxx/src/physics/shoc/disp/shoc_update_host_dse_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_update_host_dse_disp.cpp
@@ -1,6 +1,6 @@
 #include "shoc_functions.hpp"
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace shoc {

--- a/components/eamxx/src/physics/shoc/disp/shoc_update_host_dse_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_update_host_dse_disp.cpp
@@ -1,6 +1,7 @@
 #include "shoc_functions.hpp"
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace shoc {
@@ -18,9 +19,10 @@ void Functions<Real,DefaultDevice>
   const view_2d<Spack>& host_dse)
 {
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
 
   const auto nlev_packs = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 

--- a/components/eamxx/src/physics/shoc/disp/shoc_update_prognostics_implicit_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_update_prognostics_implicit_disp.cpp
@@ -1,6 +1,6 @@
 #include "shoc_functions.hpp"
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 namespace shoc {

--- a/components/eamxx/src/physics/shoc/disp/shoc_update_prognostics_implicit_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_update_prognostics_implicit_disp.cpp
@@ -1,6 +1,7 @@
 #include "shoc_functions.hpp"
 
 #include <ekat_subview_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 namespace scream {
 namespace shoc {
@@ -34,9 +35,10 @@ void Functions<Real,DefaultDevice>
   const view_2d<Spack>&        v_wind)
 {
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
 
   const auto nlev_packs = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -1,10 +1,11 @@
-#include "ekat/ekat_assert.hpp"
 #include "physics/shoc/eamxx_shoc_process_interface.hpp"
 
 #include "share/property_checks/field_lower_bound_check.hpp"
 #include "share/property_checks/field_within_interval_check.hpp"
 
 #include "eamxx_config.h" // for SCREAM_CIME_BUILD
+
+#include <ekat_assert.hpp>
 
 namespace scream
 {

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -6,6 +6,8 @@
 #include "eamxx_config.h" // for SCREAM_CIME_BUILD
 
 #include <ekat_assert.hpp>
+#include <ekat_team_policy_utils.hpp>
+#include <ekat_reduction_utils.hpp>
 
 namespace scream
 {
@@ -145,6 +147,8 @@ set_computed_group_impl (const FieldGroup& group)
 // =========================================================================================
 size_t SHOCMacrophysics::requested_buffer_size_in_bytes() const
 {
+  using TPF = ekat::TeamPolicyFactory<KT::ExeSpace>;
+
   const int nlev_packs       = ekat::npack<Spack>(m_num_levs);
   const int nlevi_packs      = ekat::npack<Spack>(m_num_levs+1);
   const int num_tracer_packs = ekat::npack<Spack>(m_num_tracers);
@@ -157,7 +161,7 @@ size_t SHOCMacrophysics::requested_buffer_size_in_bytes() const
                                    Buffer::num_2d_vector_tr*m_num_cols*num_tracer_packs*sizeof(Spack);
 
   // Number of Reals needed by the WorkspaceManager passed to shoc_main
-  const auto policy       = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nlev_packs);
+  const auto policy       = TPF::get_default_team_policy(m_num_cols, nlev_packs);
   const int n_wind_slots  = ekat::npack<Spack>(2)*Spack::n;
   const int n_trac_slots  = ekat::npack<Spack>(m_num_tracers+3)*Spack::n;
   const size_t wsm_request= WSM::get_total_bytes_needed(nlevi_packs, 14+(n_wind_slots+n_trac_slots), policy);
@@ -168,6 +172,8 @@ size_t SHOCMacrophysics::requested_buffer_size_in_bytes() const
 // =========================================================================================
 void SHOCMacrophysics::init_buffers(const ATMBufferManager &buffer_manager)
 {
+  using TPF = ekat::TeamPolicyFactory<KT::ExeSpace>;
+
   EKAT_REQUIRE_MSG(buffer_manager.allocated_bytes() >= requested_buffer_size_in_bytes(), "Error! Buffers size not sufficient.\n");
 
   Real* mem = reinterpret_cast<Real*>(buffer_manager.get_memory());
@@ -233,7 +239,7 @@ void SHOCMacrophysics::init_buffers(const ATMBufferManager &buffer_manager)
 
   // Compute workspace manager size to check used memory
   // vs. requested memory
-  const auto policy      = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nlev_packs);
+  const auto policy      = TPF::get_default_team_policy(m_num_cols, nlev_packs);
   const int n_wind_slots = ekat::npack<Spack>(2)*Spack::n;
   const int n_trac_slots = ekat::npack<Spack>(m_num_tracers+3)*Spack::n;
   const int wsm_size     = WSM::get_total_bytes_needed(nlevi_packs, 14+(n_wind_slots+n_trac_slots), policy)/sizeof(Spack);
@@ -246,6 +252,8 @@ void SHOCMacrophysics::init_buffers(const ATMBufferManager &buffer_manager)
 // =========================================================================================
 void SHOCMacrophysics::initialize_impl (const RunType run_type)
 {
+  using TPF = ekat::TeamPolicyFactory<KT::ExeSpace>;
+
   // Gather runtime options
   runtime_options.lambda_low    = m_params.get<double>("lambda_low");
   runtime_options.lambda_high   = m_params.get<double>("lambda_high");
@@ -426,7 +434,7 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   const auto nlevi_packs = ekat::npack<Spack>(m_num_levs+1);
   const int n_wind_slots = ekat::npack<Spack>(2)*Spack::n;
   const int n_trac_slots = ekat::npack<Spack>(m_num_tracers+3)*Spack::n;
-  const auto default_policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nlev_packs);
+  const auto default_policy = TPF::get_default_team_policy(m_num_cols, nlev_packs);
   workspace_mgr.setup(m_buffer.wsm_data, nlevi_packs, 14+(n_wind_slots+n_trac_slots), default_policy);
 
   // Calculate pref_mid, and use that to calculate
@@ -470,13 +478,15 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
 // =========================================================================================
 void SHOCMacrophysics::run_impl (const double dt)
 {
+  using TPF = ekat::TeamPolicyFactory<KT::ExeSpace>;
+
   EKAT_REQUIRE_MSG (dt<=300,
       "Error! SHOC is intended to run with a timestep no longer than 5 minutes.\n"
       "       Please, reduce timestep (perhaps increasing subcycling iterations).\n");
 
   const auto nlev_packs  = ekat::npack<Spack>(m_num_levs);
-  const auto scan_policy    = ekat::ExeSpaceUtils<KT::ExeSpace>::get_thread_range_parallel_scan_team_policy(m_num_cols, nlev_packs);
-  const auto default_policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nlev_packs);
+  const auto scan_policy    = TPF::get_thread_range_parallel_scan_team_policy(m_num_cols, nlev_packs);
+  const auto default_policy = TPF::get_default_team_policy(m_num_cols, nlev_packs);
 
   // Preprocessing of SHOC inputs. Kernel contains a parallel_scan,
   // so a special TeamPolicy is required.
@@ -583,6 +593,9 @@ void SHOCMacrophysics::apply_turbulent_mountain_stress()
 void SHOCMacrophysics::check_flux_state_consistency(const double dt)
 {
   using PC = scream::physics::Constants<Real>;
+  using RU = ekat::ReductionUtils<KT::ExeSpace>;
+  using TPF = ekat::TeamPolicyFactory<KT::ExeSpace>;
+
   const Real gravit = PC::gravit;
   const Real qmin   = 1e-12; // minimum permitted constituent concentration (kg/kg)
 
@@ -594,7 +607,7 @@ void SHOCMacrophysics::check_flux_state_consistency(const double dt)
   const auto nlev_packs      = ekat::npack<Spack>(nlevs);
   const auto last_pack_idx   = (nlevs-1)/Spack::n;
   const auto last_pack_entry = (nlevs-1)%Spack::n;
-  const auto policy          = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(m_num_cols, nlev_packs);
+  const auto policy          = TPF::get_default_team_policy(m_num_cols, nlev_packs);
   Kokkos::parallel_for("check_flux_state_consistency",
                        policy,
                        KOKKOS_LAMBDA (const KT::MemberType& team) {
@@ -615,7 +628,7 @@ void SHOCMacrophysics::check_flux_state_consistency(const double dt)
       auto tracer_mass = [&](const int k) {
         return qv_i(k)*pseudo_density_i(k);
       };
-      Real mm = ekat::ExeSpaceUtils<KT::ExeSpace>::view_reduction(team, 0, nlevs, tracer_mass);
+      Real mm = RU::view_reduction(team, 0, nlevs, tracer_mass);
 
       EKAT_KERNEL_ASSERT_MSG(mm >= cc, "Error! Total mass of column vapor should be greater than mass of surf_evap.\n");
 

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.hpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.hpp
@@ -2,10 +2,11 @@
 #define SCREAM_SHOC_MACROPHYSICS_HPP
 
 #include "share/atm_process/atmosphere_process.hpp"
-#include "ekat/ekat_parameter_list.hpp"
 #include "physics/shoc/shoc_functions.hpp"
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/atm_process/ATMBufferManager.hpp"
+
+#include <ekat_parameter_list.hpp>
 
 #include <string>
 

--- a/components/eamxx/src/physics/shoc/impl/shoc_energy_integrals_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_energy_integrals_impl.hpp
@@ -3,6 +3,8 @@
 
 #include "shoc_functions.hpp" // for ETI only but harmless for GPU
 
+#include <ekat_reduction_utils.hpp>
+
 namespace scream {
 namespace shoc {
 
@@ -23,7 +25,8 @@ void Functions<S,D>
   Scalar&                      wv_int,
   Scalar&                      wl_int)
 {
-  using ExeSpaceUtils = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
+  using RU = ekat::ReductionUtils<typename KT::ExeSpace>;
+
   const auto ggr = C::gravit;
 
   // The team_barriers protect what we think is unexpected behavior in
@@ -39,28 +42,28 @@ void Functions<S,D>
   // Kokkos::parallel_reduce calls acting on doubles and saw the same results.
 
   // Compute se_int
-  se_int = ExeSpaceUtils::view_reduction(team,0,nlev,
+  se_int = RU::view_reduction(team,0,nlev,
                                 [&] (const int k) -> Spack {
     return host_dse(k)*pdel(k)/ggr;
   });
   team.team_barrier();
 
   // Compute ke_int
-  ke_int = ExeSpaceUtils::view_reduction(team,0,nlev,
+  ke_int = RU::view_reduction(team,0,nlev,
                                 [&] (const int k) -> Spack {
     return sp(0.5)*(ekat::square(u_wind(k))+ekat::square(v_wind(k)))*pdel(k)/ggr;
   });
   team.team_barrier();
 
   // Compute wv_int
-  wv_int = ExeSpaceUtils::view_reduction(team,0,nlev,
+  wv_int = RU::view_reduction(team,0,nlev,
                                 [&] (const int k) -> Spack {
     return (rtm(k)-rcm(k))*pdel(k)/ggr;
   });
   team.team_barrier();
 
   // Compute wl_int
-  wl_int = ExeSpaceUtils::view_reduction(team,0,nlev,
+  wl_int = RU::view_reduction(team,0,nlev,
                                 [&] (const int k) -> Spack {
     return rcm(k)*pdel(k)/ggr;
   });

--- a/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
@@ -3,7 +3,7 @@
 
 #include "shoc_functions.hpp" // for ETI only but harmless for GPU
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
@@ -3,6 +3,7 @@
 
 #include "shoc_functions.hpp" // for ETI only but harmless for GPU
 
+#include <ekat_team_policy_utils.hpp>
 #include <ekat_subview_utils.hpp>
 
 #include <iomanip>
@@ -21,13 +22,15 @@ Int Functions<S,D>::shoc_init(
   const Int&                  ntop_shoc,
   const view_1d<const Spack>& pref_mid)
 {
+  using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
+
   // This function calculates the maximum number of levels
   // in pbl from surface
 
-  using ExeSpace = typename KT::ExeSpace;
   view_1d<Int> npbl_d("npbl",1);
 
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(1, 1);
+  const auto policy = TPF::get_default_team_policy(1, 1);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
 
     const Scalar pblmaxp = SC::pblmaxp;
@@ -610,10 +613,11 @@ Int Functions<S,D>::shoc_main(
 
 #ifndef SCREAM_SHOC_SMALL_KERNELS
   using ExeSpace = typename KT::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
 
   // SHOC main loop
   const auto nlev_packs = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 

--- a/components/eamxx/src/physics/shoc/impl/shoc_tridiag_solver_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_tridiag_solver_impl.hpp
@@ -2,7 +2,8 @@
 #define SHOC_TRIDIAG_SOLVER_IMPL_HPP
 
 #include "shoc_functions.hpp" // for ETI only but harmless for GPU
-#include "ekat/util/ekat_tridiag.hpp"
+
+#include <ekat_tridiag.hpp>
 
 namespace scream {
 namespace shoc {

--- a/components/eamxx/src/physics/shoc/shoc_functions.hpp
+++ b/components/eamxx/src/physics/shoc/shoc_functions.hpp
@@ -6,8 +6,8 @@
 
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack_kokkos.hpp"
-#include "ekat/ekat_workspace.hpp"
+#include <ekat_pack_kokkos.hpp>
+#include <ekat_workspace.hpp>
 
 namespace scream {
 namespace shoc {

--- a/components/eamxx/src/physics/shoc/tests/infra/CMakeLists.txt
+++ b/components/eamxx/src/physics/shoc/tests/infra/CMakeLists.txt
@@ -6,5 +6,5 @@ set(INFRA_SRCS
 )
 
 add_library(shoc_test_infra ${INFRA_SRCS})
-target_link_libraries(shoc_test_infra shoc)
+target_link_libraries(shoc_test_infra PUBLIC shoc scream_test_support)
 target_include_directories(shoc_test_infra PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/components/eamxx/src/physics/shoc/tests/infra/shoc_data.cpp
+++ b/components/eamxx/src/physics/shoc/tests/infra/shoc_data.cpp
@@ -1,8 +1,9 @@
 #include "shoc_data.hpp"
-#include "physics_constants.hpp"
 #include "shoc_ic_cases.hpp"
 
-#include "ekat/ekat_assert.hpp"
+#include "physics_constants.hpp"
+
+#include <ekat_assert.hpp>
 
 using scream::Real;
 using scream::Int;

--- a/components/eamxx/src/physics/shoc/tests/infra/shoc_ic_cases.cpp
+++ b/components/eamxx/src/physics/shoc/tests/infra/shoc_ic_cases.cpp
@@ -1,6 +1,7 @@
 #include "shoc_ic_cases.hpp"
 #include "physics_constants.hpp"
-#include "ekat/ekat_assert.hpp"
+
+#include <ekat_assert.hpp>
 
 namespace scream {
 namespace shoc {

--- a/components/eamxx/src/physics/shoc/tests/infra/shoc_main_wrap.cpp
+++ b/components/eamxx/src/physics/shoc/tests/infra/shoc_main_wrap.cpp
@@ -1,10 +1,10 @@
 #include "shoc_main_wrap.hpp"
 #include "shoc_data.hpp"
 #include "shoc_test_data.hpp"
-#include "physics_constants.hpp"
 #include "shoc_ic_cases.hpp"
+#include "physics_constants.hpp"
 
-#include "ekat/ekat_assert.hpp"
+#include <ekat_assert.hpp>
 
 using scream::Real;
 using scream::Int;

--- a/components/eamxx/src/physics/shoc/tests/infra/shoc_main_wrap.hpp
+++ b/components/eamxx/src/physics/shoc/tests/infra/shoc_main_wrap.hpp
@@ -12,7 +12,7 @@ namespace shoc {
 struct FortranData;
 
 // Run SHOC subroutines, populating inout and out fields of d.
-ekat::Int shoc_main(FortranData& d);
+int shoc_main(FortranData& d);
 
 // Test SHOC by running initial conditions for a number of steps and comparing
 // against reference data. If gen_plot_scripts is true, Python scripts are

--- a/components/eamxx/src/physics/shoc/tests/infra/shoc_test_data.cpp
+++ b/components/eamxx/src/physics/shoc/tests/infra/shoc_test_data.cpp
@@ -2,10 +2,9 @@
 
 #include "shoc_data.hpp"
 
-#include "ekat/ekat_assert.hpp"
 #include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/ekat_pack_kokkos.hpp"
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 #include "share/util/eamxx_deep_copy.hpp"
 

--- a/components/eamxx/src/physics/shoc/tests/infra/shoc_test_data.cpp
+++ b/components/eamxx/src/physics/shoc/tests/infra/shoc_test_data.cpp
@@ -2,8 +2,7 @@
 
 #include "shoc_data.hpp"
 
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
-#include "ekat/ekat_pack_kokkos.hpp"
+#include <ekat_team_policy_utils.hpp>
 #include <ekat_subview_utils.hpp>
 
 #include "share/util/eamxx_deep_copy.hpp"
@@ -321,6 +320,7 @@ void calc_shoc_varorcovar_host(Int shcol, Int nlev, Int nlevi, Real tunefac,
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   static constexpr Int num_arrays = 6;
@@ -342,7 +342,7 @@ void calc_shoc_varorcovar_host(Int shcol, Int nlev, Int nlevi, Real tunefac,
     varorcovar_d(temp_d[5]);
 
   const Int nk_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 
@@ -371,6 +371,7 @@ void calc_shoc_vertflux_host(Int shcol, Int nlev, Int nlevi, Real *tkh_zi,
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   static constexpr Int num_arrays = 4;
@@ -390,7 +391,7 @@ void calc_shoc_vertflux_host(Int shcol, Int nlev, Int nlevi, Real *tkh_zi,
     vertflux_d(temp_d[3]);
 
   const Int nk_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 
@@ -501,6 +502,7 @@ void update_host_dse_host(Int shcol, Int nlev, Real* thlm, Real* shoc_ql, Real* 
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   std::vector<view_1d> temp_1d_d(1);
@@ -521,7 +523,7 @@ void update_host_dse_host(Int shcol, Int nlev, Real* thlm, Real* shoc_ql, Real* 
     host_dse_d (temp_2d_d[4]);
 
   const Int nk_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 
@@ -552,6 +554,7 @@ void compute_diag_third_shoc_moment_host(Int shcol, Int nlev, Int nlevi, Real* w
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   std::vector<view_2d> temp_d(11);
@@ -586,7 +589,7 @@ void compute_diag_third_shoc_moment_host(Int shcol, Int nlev, Int nlevi, Real* w
     w3_d         (temp_d[10]);
 
   const Int nk_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 
@@ -622,6 +625,7 @@ void shoc_pblintd_init_pot_host(Int shcol, Int nlev, Real *thl, Real* ql, Real* 
   using view_2d    = typename SHOC::view_2d<Spack>;
   using KT         = typename SHOC::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHOC::MemberType;
 
   static constexpr Int num_arrays = 3;
@@ -636,7 +640,7 @@ void shoc_pblintd_init_pot_host(Int shcol, Int nlev, Real *thl, Real* ql, Real* 
   view_2d thv_d("thv", shcol, nlev);
 
   const Int nlev_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 
@@ -663,6 +667,7 @@ void compute_shoc_mix_shoc_length_host(Int nlev, Int shcol, Real* tke, Real* bru
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   std::vector<view_1d> temp_1d_d(1);
@@ -683,7 +688,7 @@ void compute_shoc_mix_shoc_length_host(Int nlev, Int shcol, Real* tke, Real* bru
     shoc_mix_d  (temp_2d_d[3]);
 
   const Int nk_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 
@@ -711,6 +716,7 @@ void check_tke_host(Int shcol, Int nlev, Real* tke)
   using view_2d    = typename SHOC::view_2d<Spack>;
   using KT         = typename SHOC::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHOC::MemberType;
 
   std::vector<view_2d> temp_2d_d(1);
@@ -722,7 +728,7 @@ void check_tke_host(Int shcol, Int nlev, Real* tke)
     tke_d(temp_2d_d[0]);
 
   const Int nk_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 
@@ -744,6 +750,7 @@ void linear_interp_host(Real* x1, Real* x2, Real* y1, Real* y2, Int km1, Int km2
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   std::vector<view_2d> temp_2d_d(3);
@@ -761,7 +768,7 @@ void linear_interp_host(Real* x1, Real* x2, Real* y1, Real* y2, Int km1, Int km2
     y2_d("y2_d", ncol, km2);
 
   const Int nk_pack = ekat::npack<Spack>(km1);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(ncol, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 
@@ -787,6 +794,7 @@ void clipping_diag_third_shoc_moments_host(Int nlevi, Int shcol, Real *w_sec_zi,
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   // Sync to device
@@ -798,7 +806,7 @@ void clipping_diag_third_shoc_moments_host(Int nlevi, Int shcol, Real *w_sec_zi,
     w3_d      (temp_d[1]);
 
   const Int nk_pack = ekat::npack<Spack>(nlevi);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 
@@ -825,6 +833,7 @@ void shoc_energy_integrals_host(Int shcol, Int nlev, Real *host_dse, Real *pdel,
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   std::vector<view_2d> temp_d(6);
@@ -850,7 +859,7 @@ void shoc_energy_integrals_host(Int shcol, Int nlev, Real *host_dse, Real *pdel,
     wl_int_d("wl_int", shcol);
 
   const Int nk_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 
@@ -953,6 +962,7 @@ void diag_second_moments_host(Int shcol, Int nlev, Int nlevi, Real* thetal, Real
   using view_2d    = typename SHOC::view_2d<Spack>;
   using KT         = typename SHOC::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHOC::MemberType;
 
   std::vector<Int> dim1_array(20, shcol);
@@ -995,7 +1005,7 @@ void diag_second_moments_host(Int shcol, Int nlev, Int nlevi, Real* thetal, Real
           tk_zi_2d("tk_zi", shcol, nlevi_packs);
 
   const Int nk_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
     // Hardcode runtime options for F90
@@ -1055,8 +1065,9 @@ void diag_second_shoc_moments_host(Int shcol, Int nlev, Int nlevi, Real* thetal,
   using view_2d       = typename SHOC::view_2d<Spack>;
   using KT            = typename SHOC::KT;
   using ExeSpace      = typename KT::ExeSpace;
+  using TPF           = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType    = typename SHOC::MemberType;
-  using view_1d = typename SHOC::view_1d<Scalar>;
+  using view_1d       = typename SHOC::view_1d<Scalar>;
 
   std::vector<view_1d> temp_1d(4);
   ScreamDeepCopy::copy_to_device({wthl_sfc, wqw_sfc, uw_sfc, vw_sfc}, shcol, temp_1d);
@@ -1104,7 +1115,7 @@ void diag_second_shoc_moments_host(Int shcol, Int nlev, Int nlevi, Real* thetal,
 
   const Int nlev_packs = ekat::npack<Spack>(nlev);
   const Int nlevi_packs = ekat::npack<Spack>(nlevi);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
 
   // Local variable workspace
   ekat::WorkspaceManager<Spack, KT::Device> workspace_mgr(nlevi_packs, 3, policy);
@@ -1170,6 +1181,7 @@ void compute_brunt_shoc_length_host(Int nlev, Int nlevi, Int shcol, Real* dz_zt,
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   std::vector<view_2d> temp_d(4);
@@ -1187,7 +1199,7 @@ void compute_brunt_shoc_length_host(Int nlev, Int nlevi, Int shcol, Real* dz_zt,
     brunt_d (temp_d[3]);
 
   const Int nk_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 
@@ -1215,6 +1227,7 @@ void compute_l_inf_shoc_length_host(Int nlev, Int shcol, Real *zt_grid, Real *dz
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   // Sync to device
@@ -1232,7 +1245,7 @@ void compute_l_inf_shoc_length_host(Int nlev, Int shcol, Real *zt_grid, Real *dz
     l_inf_d("l_inf", shcol);
 
   const Int nk_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 
@@ -1262,6 +1275,7 @@ void check_length_scale_shoc_length_host(Int nlev, Int shcol, Real* host_dx, Rea
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   // Sync to device
@@ -1278,7 +1292,7 @@ void check_length_scale_shoc_length_host(Int nlev, Int shcol, Real* host_dx, Rea
     shoc_mix_d(temp_2d_d[0]);
 
   const Int nk_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 
@@ -1401,6 +1415,7 @@ void shoc_length_host(Int shcol, Int nlev, Int nlevi, Real* host_dx, Real* host_
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   std::vector<view_1d> temp_1d_d(2);
@@ -1430,7 +1445,7 @@ void shoc_length_host(Int shcol, Int nlev, Int nlevi, Real* host_dx, Real* host_
 
   const Int nlev_packs = ekat::npack<Spack>(nlev);
   const Int nlevi_packs = ekat::npack<Spack>(nlevi);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
 
   // Local variable workspace
   ekat::WorkspaceManager<Spack, KT::Device> workspace_mgr(nlevi_packs, 1, policy);
@@ -1478,6 +1493,7 @@ void shoc_energy_fixer_host(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   std::vector<view_1d> temp_1d_d(10);
@@ -1517,7 +1533,7 @@ void shoc_energy_fixer_host(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv
 
   const Int nlev_packs = ekat::npack<Spack>(nlev);
   const Int nlevi_packs = ekat::npack<Spack>(nlevi);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
 
   // Local variable workspace
   ekat::WorkspaceManager<Spack, KT::Device> workspace_mgr(nlevi_packs, 1, policy);
@@ -1563,6 +1579,7 @@ void compute_shoc_vapor_host(Int shcol, Int nlev, Real* qw, Real* ql, Real* qv)
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   static constexpr Int num_arrays = 3;
@@ -1578,7 +1595,7 @@ void compute_shoc_vapor_host(Int shcol, Int nlev, Real* qw, Real* ql, Real* qv)
     qv_d(temp_d[2]);
 
   const Int nk_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 
@@ -1609,6 +1626,7 @@ void update_prognostics_implicit_host(Int shcol, Int nlev, Int nlevi, Int num_tr
   using view_3d    = typename SHF::view_3d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   static constexpr Int num_2d_arrays = 13;
@@ -1657,7 +1675,7 @@ void update_prognostics_implicit_host(Int shcol, Int nlev, Int nlevi, Int num_tr
   // Local variables
   const Int nlev_packs = ekat::npack<Spack>(nlev);
   const Int nlevi_packs = ekat::npack<Spack>(nlevi);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
 
   // CXX version of shoc qtracers is the transpose of the fortran version.
   view_3d qtracers_cxx_d("",shcol,num_tracer,nlev_packs);
@@ -1743,6 +1761,7 @@ void diag_third_shoc_moments_host(Int shcol, Int nlev, Int nlevi, Real* w_sec, R
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   std::vector<view_2d> temp_d(12);
@@ -1774,7 +1793,7 @@ void diag_third_shoc_moments_host(Int shcol, Int nlev, Int nlevi, Real* w_sec, R
   // Local variables
   const Int nlev_packs = ekat::npack<Spack>(nlev);
   const Int nlevi_packs = ekat::npack<Spack>(nlevi);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
 
   // Local variable workspace
   ekat::WorkspaceManager<Spack, KT::Device> workspace_mgr(nlevi_packs, 4, policy);
@@ -1820,6 +1839,7 @@ void adv_sgs_tke_host(Int nlev, Int shcol, Real dtime, Real* shoc_mix, Real* wth
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   static constexpr Int num_arrays = 6;
@@ -1841,7 +1861,7 @@ void adv_sgs_tke_host(Int nlev, Int shcol, Real dtime, Real* shoc_mix, Real* wth
     a_diss_d   (temp_d[5]); //out
 
   const Int nk_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
 
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
       const Int i = team.league_rank();
@@ -1873,6 +1893,7 @@ void shoc_assumed_pdf_host(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* q
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   static constexpr Int num_arrays = 18;
@@ -1910,7 +1931,7 @@ void shoc_assumed_pdf_host(Int shcol, Int nlev, Int nlevi, Real* thetal, Real* q
     shoc_ql2_d(temp_d[17]);
 
   const Int nlev_packs = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
 
   // Local variable workspace
   ekat::WorkspaceManager<Spack, KT::Device> workspace_mgr(nlev_packs, 6, policy);
@@ -1957,6 +1978,7 @@ void compute_shr_prod_host(Int nlevi, Int nlev, Int shcol, Real* dz_zi, Real* u_
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   static constexpr Int num_arrays = 4;
@@ -1978,7 +2000,7 @@ void compute_shr_prod_host(Int nlevi, Int nlev, Int shcol, Real* dz_zi, Real* u_
     sterm_d (temp_d[3]);
 
   const Int nk_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
 
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
       const Int i = team.league_rank();
@@ -2006,6 +2028,7 @@ void compute_tmpi_host(Int nlevi, Int shcol, Real dtime, Real *rho_zi, Real *dz_
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   static constexpr Int num_arrays = 3;
@@ -2021,7 +2044,7 @@ void compute_tmpi_host(Int nlevi, Int shcol, Real dtime, Real *rho_zi, Real *dz_
     tmpi_d(temp_d[2]);
 
   const Int nk_pack = ekat::npack<Spack>(nlevi);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 
@@ -2048,6 +2071,7 @@ void integ_column_stability_host(Int nlev, Int shcol, Real *dz_zt,
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   static constexpr Int num_arrays = 3;
@@ -2066,7 +2090,7 @@ void integ_column_stability_host(Int nlev, Int shcol, Real *dz_zt,
   view_1d brunt_int_d("brunt_int", shcol);
 
   const Int nk_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
 
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
       const Int i = team.league_rank();
@@ -2100,6 +2124,7 @@ void isotropic_ts_host(Int nlev, Int shcol, Real* brunt_int, Real* tke,
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   std::vector<view_1d> temp_1d(1); // for 1d array
@@ -2123,7 +2148,7 @@ void isotropic_ts_host(Int nlev, Int shcol, Real* brunt_int, Real* tke,
     isotropy_d(temp_2d[3]);
 
   const Int nk_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
 
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
       const Int i = team.league_rank();
@@ -2160,6 +2185,7 @@ void dp_inverse_host(Int nlev, Int shcol, Real *rho_zt, Real *dz_zt, Real *rdp_z
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   static constexpr Int num_arrays = 3;
@@ -2175,7 +2201,7 @@ void dp_inverse_host(Int nlev, Int shcol, Real *rho_zt, Real *dz_zt, Real *rdp_z
     rdp_zt_d(temp_d[2]);
 
   const Int nk_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 
@@ -2222,6 +2248,7 @@ Int shoc_main_host(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Int npb
   using view_2d    = typename SHF::view_2d<Spack>;
   using view_3d    = typename SHF::view_3d<Spack>;
   using ExeSpace   = typename SHF::KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   // Initialize Kokkos views, sync to device
@@ -2329,7 +2356,7 @@ Int shoc_main_host(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Int npb
   const auto qtracers_cxx_d_s = ekat::scalarize(qtracers_cxx_d);
   const auto qtracers_f90_d_s = ekat::scalarize(qtracers_f90_d);
 
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
     Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev), [&] (const Int& k) {
@@ -2460,6 +2487,7 @@ void pblintd_height_host(Int shcol, Int nlev, Int npbl, Real* z, Real* u, Real* 
   using bview_1d   = typename SHOC::view_1d<bool>;
   using view_2d    = typename SHOC::view_2d<Spack>;
   using ExeSpace   = typename SHOC::KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHOC::MemberType;
 
   std::vector<view_2d> views_2d(5);
@@ -2482,7 +2510,7 @@ void pblintd_height_host(Int shcol, Int nlev, Int npbl, Real* z, Real* u, Real* 
   bview_1d check_1d (views_bool_1d[0]);
 
   const Int nlev_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 
@@ -2522,6 +2550,7 @@ void vd_shoc_decomp_and_solve_host(Int shcol, Int nlev, Int nlevi, Int num_rhs, 
   using view_3d        = typename SHF::view_3d<Spack>;
   using KT             = typename SHF::KT;
   using ExeSpace       = typename KT::ExeSpace;
+  using TPF            = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType     = typename SHF::MemberType;
 
   static constexpr Int num_1d_arrays = 1;
@@ -2558,7 +2587,7 @@ void vd_shoc_decomp_and_solve_host(Int shcol, Int nlev, Int nlevi, Int num_rhs, 
     var_d(temp_3d_d[0]);
 
   const Int nk_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 
@@ -2589,6 +2618,7 @@ void shoc_grid_host(Int shcol, Int nlev, Int nlevi, Real* zt_grid, Real* zi_grid
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   static constexpr Int num_2d_arrays = 6;
@@ -2611,7 +2641,7 @@ void shoc_grid_host(Int shcol, Int nlev, Int nlevi, Real* zt_grid, Real* zi_grid
     rho_zt_d(temp_2d_d[5]);
 
   const Int nk_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 
@@ -2641,6 +2671,7 @@ void eddy_diffusivities_host(Int nlev, Int shcol, Real* pblh, Real* zt_grid, Rea
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   static constexpr Int num_1d_arrays = 1;
@@ -2669,7 +2700,7 @@ void eddy_diffusivities_host(Int nlev, Int shcol, Real* pblh, Real* zt_grid, Rea
     tk_d(temp_2d_d[7]);
 
   const Int nk_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 
@@ -2798,6 +2829,7 @@ void pblintd_host(Int shcol, Int nlev, Int nlevi, Int npbl, Real* z, Real* zi, R
     using view_2d    = typename SHF::view_2d<Spack>;
     using KT         = typename SHF::KT;
     using ExeSpace   = typename KT::ExeSpace;
+    using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
     using MemberType = typename SHF::MemberType;
 
     static constexpr Int num_1d_arrays = 3;
@@ -2833,7 +2865,7 @@ void pblintd_host(Int shcol, Int nlev, Int nlevi, Int npbl, Real* z, Real* zi, R
       cldn_d(temp_2d_d[7]);
 
     const Int nlev_pack = ekat::npack<Spack>(nlev);
-    const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_pack);
+    const auto policy = TPF::get_default_team_policy(shcol, nlev_pack);
 
     // Local variable workspace
     ekat::WorkspaceManager<Spack, KT::Device> workspace_mgr(nlev_pack, 2, policy);
@@ -2880,6 +2912,7 @@ void shoc_tke_host(Int shcol, Int nlev, Int nlevi, Real dtime, Real* wthv_sec, R
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   static constexpr Int num_1d_arrays = 1;
@@ -2919,7 +2952,7 @@ void shoc_tke_host(Int shcol, Int nlev, Int nlevi, Real dtime, Real* wthv_sec, R
 
   const Int nlev_packs = ekat::npack<Spack>(nlev);
   const Int nlevi_packs = ekat::npack<Spack>(nlevi);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(shcol, nlev_packs);
 
   // Local variable workspace
   ekat::WorkspaceManager<Spack, KT::Device> workspace_mgr(nlevi_packs, 3, policy);
@@ -2976,6 +3009,7 @@ void compute_shoc_temperature_host(Int shcol, Int nlev, Real *thetal, Real *ql, 
   using view_2d    = typename SHF::view_2d<Spack>;
   using KT         = typename SHF::KT;
   using ExeSpace   = typename KT::ExeSpace;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
   using MemberType = typename SHF::MemberType;
 
   static constexpr Int num_arrays = 4;
@@ -2992,7 +3026,7 @@ void compute_shoc_temperature_host(Int shcol, Int nlev, Real *thetal, Real *ql, 
     tabs_d(temp_d[3]);
 
   const Int nk_pack = ekat::npack<Spack>(nlev);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(shcol, nk_pack);
+  const auto policy = TPF::get_default_team_policy(shcol, nk_pack);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const Int i = team.league_rank();
 

--- a/components/eamxx/src/physics/shoc/tests/infra/shoc_unit_tests_common.hpp
+++ b/components/eamxx/src/physics/shoc/tests/infra/shoc_unit_tests_common.hpp
@@ -3,10 +3,7 @@
 
 #include "shoc_functions.hpp"
 #include "share/eamxx_types.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
-#include "ekat/util/ekat_file_utils.hpp"
-#include "ekat/util/ekat_test_utils.hpp"
 #include "physics/share/physics_test_data.hpp"
 
 namespace scream {

--- a/components/eamxx/src/physics/shoc/tests/shoc_assumed_pdf_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_assumed_pdf_tests.cpp
@@ -7,9 +7,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_assumed_pdf_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_assumed_pdf_tests.cpp
@@ -424,7 +424,7 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf : public UnitWrap::UnitTest<D>:
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : SDS_baseline) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -449,7 +449,7 @@ struct UnitWrap::UnitTest<D>::TestShocAssumedPdf : public UnitWrap::UnitTest<D>:
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        SDS_cxx[i].write(Base::m_fid);
+        SDS_cxx[i].write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/shoc/tests/shoc_brunt_length_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_brunt_length_tests.cpp
@@ -8,9 +8,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_brunt_length_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_brunt_length_tests.cpp
@@ -151,7 +151,7 @@ struct UnitWrap::UnitTest<D>::TestCompBruntShocLength : public UnitWrap::UnitTes
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : SDS_baseline) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -172,7 +172,7 @@ struct UnitWrap::UnitTest<D>::TestCompBruntShocLength : public UnitWrap::UnitTes
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        SDS_cxx[i].write(Base::m_fid);
+        SDS_cxx[i].write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/shoc/tests/shoc_check_length_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_check_length_tests.cpp
@@ -7,9 +7,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_check_length_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_check_length_tests.cpp
@@ -121,7 +121,7 @@ struct UnitWrap::UnitTest<D>::TestCheckShocLength : public UnitWrap::UnitTest<D>
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : SDS_baseline) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -142,7 +142,7 @@ struct UnitWrap::UnitTest<D>::TestCheckShocLength : public UnitWrap::UnitTest<D>
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        SDS_cxx[i].write(Base::m_fid);
+        SDS_cxx[i].write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/shoc/tests/shoc_check_tke_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_check_tke_tests.cpp
@@ -7,9 +7,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_check_tke_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_check_tke_tests.cpp
@@ -103,7 +103,7 @@ struct UnitWrap::UnitTest<D>::TestShocCheckTke : public UnitWrap::UnitTest<D>::B
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : SDS_baseline) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -124,7 +124,7 @@ struct UnitWrap::UnitTest<D>::TestShocCheckTke : public UnitWrap::UnitTest<D>::B
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        SDS_cxx[i].write(Base::m_fid);
+        SDS_cxx[i].write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/shoc/tests/shoc_clip_third_moms_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_clip_third_moms_tests.cpp
@@ -7,9 +7,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_clip_third_moms_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_clip_third_moms_tests.cpp
@@ -130,7 +130,7 @@ struct UnitWrap::UnitTest<D>::TestClipThirdMoms : public UnitWrap::UnitTest<D>::
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : SDS_baseline) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -151,7 +151,7 @@ struct UnitWrap::UnitTest<D>::TestClipThirdMoms : public UnitWrap::UnitTest<D>::
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        SDS_cxx[i].write(Base::m_fid);
+        SDS_cxx[i].write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/shoc/tests/shoc_compute_diag_third_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_compute_diag_third_tests.cpp
@@ -7,9 +7,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_compute_diag_third_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_compute_diag_third_tests.cpp
@@ -216,7 +216,7 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird : public UnitWrap::UnitTest<
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : SDS_baseline) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -237,7 +237,7 @@ struct UnitWrap::UnitTest<D>::TestShocCompDiagThird : public UnitWrap::UnitTest<
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        SDS_cxx[i].write(Base::m_fid);
+        SDS_cxx[i].write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/shoc/tests/shoc_compute_shoc_temperature_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_compute_shoc_temperature_tests.cpp
@@ -7,9 +7,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_compute_shoc_temperature_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_compute_shoc_temperature_tests.cpp
@@ -224,7 +224,7 @@ struct UnitWrap::UnitTest<D>::TestComputeShocTemp : public UnitWrap::UnitTest<D>
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -246,7 +246,7 @@ struct UnitWrap::UnitTest<D>::TestComputeShocTemp : public UnitWrap::UnitTest<D>
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (auto& d : cxx_data) {
-        d.write(Base::m_fid);
+        d.write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/shoc/tests/shoc_compute_shoc_vapor_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_compute_shoc_vapor_tests.cpp
@@ -1,8 +1,6 @@
 #include "catch2/catch.hpp"
 
 #include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "shoc_functions.hpp"
 #include "shoc_test_data.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"

--- a/components/eamxx/src/physics/shoc/tests/shoc_compute_shoc_vapor_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_compute_shoc_vapor_tests.cpp
@@ -115,7 +115,7 @@ struct UnitWrap::UnitTest<D>::TestComputeShocVapor : public UnitWrap::UnitTest<D
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -137,7 +137,7 @@ struct UnitWrap::UnitTest<D>::TestComputeShocVapor : public UnitWrap::UnitTest<D
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (auto& d : cxx_data) {
-        d.write(Base::m_fid);
+        d.write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/shoc/tests/shoc_diag_obklen_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_diag_obklen_tests.cpp
@@ -7,9 +7,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_diag_obklen_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_diag_obklen_tests.cpp
@@ -192,7 +192,7 @@ struct UnitWrap::UnitTest<D>::TestShocDiagObklen : public UnitWrap::UnitTest<D>:
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : SDS_baseline) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -215,7 +215,7 @@ struct UnitWrap::UnitTest<D>::TestShocDiagObklen : public UnitWrap::UnitTest<D>:
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        SDS_cxx[i].write(Base::m_fid);
+        SDS_cxx[i].write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/shoc/tests/shoc_diag_second_mom_srf_test.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_diag_second_mom_srf_test.cpp
@@ -8,9 +8,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_diag_second_mom_srf_test.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_diag_second_mom_srf_test.cpp
@@ -124,7 +124,7 @@ struct UnitWrap::UnitTest<D>::TestSecondMomSrf : public UnitWrap::UnitTest<D>::B
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        cxx_data[i].write(Base::m_fid);
+        cxx_data[i].write(Base::m_ofile);
       }
     }
 #endif

--- a/components/eamxx/src/physics/shoc/tests/shoc_diag_second_mom_ubycond_test.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_diag_second_mom_ubycond_test.cpp
@@ -8,9 +8,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 //#include "share/eamxx_types.hpp"
 #include <algorithm>

--- a/components/eamxx/src/physics/shoc/tests/shoc_diag_second_mom_ubycond_test.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_diag_second_mom_ubycond_test.cpp
@@ -87,7 +87,7 @@ struct UnitWrap::UnitTest<D>::TestSecondMomUbycond : public UnitWrap::UnitTest<D
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : uby_fortran) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -112,7 +112,7 @@ struct UnitWrap::UnitTest<D>::TestSecondMomUbycond : public UnitWrap::UnitTest<D
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        uby_cxx[i].write(Base::m_fid);
+        uby_cxx[i].write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/shoc/tests/shoc_diag_second_moments_lbycond_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_diag_second_moments_lbycond_tests.cpp
@@ -1,8 +1,6 @@
 #include "catch2/catch.hpp"
 
 #include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "shoc_functions.hpp"
 #include "shoc_test_data.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"

--- a/components/eamxx/src/physics/shoc/tests/shoc_diag_second_moments_lbycond_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_diag_second_moments_lbycond_tests.cpp
@@ -143,7 +143,7 @@ struct UnitWrap::UnitTest<D>::TestDiagSecondMomentsLbycond : public UnitWrap::Un
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -172,7 +172,7 @@ struct UnitWrap::UnitTest<D>::TestDiagSecondMomentsLbycond : public UnitWrap::Un
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (auto& d : cxx_data) {
-        d.write(Base::m_fid);
+        d.write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/shoc/tests/shoc_diag_second_moments_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_diag_second_moments_tests.cpp
@@ -1,8 +1,6 @@
 #include "catch2/catch.hpp"
 
 #include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "shoc_functions.hpp"
 #include "shoc_test_data.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"

--- a/components/eamxx/src/physics/shoc/tests/shoc_diag_second_moments_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_diag_second_moments_tests.cpp
@@ -277,7 +277,7 @@ struct UnitWrap::UnitTest<D>::TestDiagSecondMoments : public UnitWrap::UnitTest<
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -309,7 +309,7 @@ struct UnitWrap::UnitTest<D>::TestDiagSecondMoments : public UnitWrap::UnitTest<
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (auto& d : cxx_data) {
-        d.write(Base::m_fid);
+        d.write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/shoc/tests/shoc_diag_second_shoc_moments_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_diag_second_shoc_moments_tests.cpp
@@ -1,8 +1,6 @@
 #include "catch2/catch.hpp"
 
 #include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "shoc_functions.hpp"
 #include "shoc_test_data.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"

--- a/components/eamxx/src/physics/shoc/tests/shoc_diag_second_shoc_moments_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_diag_second_shoc_moments_tests.cpp
@@ -290,7 +290,7 @@ struct UnitWrap::UnitTest<D>::TestDiagSecondShocMoments : public UnitWrap::UnitT
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -322,7 +322,7 @@ struct UnitWrap::UnitTest<D>::TestDiagSecondShocMoments : public UnitWrap::UnitT
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (auto& d : cxx_data) {
-        d.write(Base::m_fid);
+        d.write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/shoc/tests/shoc_diag_third_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_diag_third_tests.cpp
@@ -7,10 +7,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
-
 #include <algorithm>
 #include <array>
 #include <random>

--- a/components/eamxx/src/physics/shoc/tests/shoc_diag_third_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_diag_third_tests.cpp
@@ -231,7 +231,7 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird : public UnitWrap::UnitTest<D>::
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : SDS_baseline) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -252,7 +252,7 @@ struct UnitWrap::UnitTest<D>::TestShocDiagThird : public UnitWrap::UnitTest<D>::
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        SDS_cxx[i].write(Base::m_fid);
+        SDS_cxx[i].write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/shoc/tests/shoc_eddy_diffusivities_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_eddy_diffusivities_tests.cpp
@@ -7,9 +7,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_eddy_diffusivities_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_eddy_diffusivities_tests.cpp
@@ -282,7 +282,7 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff : public UnitWrap::UnitTest<D>::B
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -305,7 +305,7 @@ struct UnitWrap::UnitTest<D>::TestShocEddyDiff : public UnitWrap::UnitTest<D>::B
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (auto& d : cxx_data) {
-        d.write(Base::m_fid);
+        d.write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/shoc/tests/shoc_energy_fixer_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_energy_fixer_tests.cpp
@@ -9,9 +9,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_energy_fixer_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_energy_fixer_tests.cpp
@@ -291,7 +291,7 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyFixer : public UnitWrap::UnitTest<D>
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : SDS_baseline) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -312,7 +312,7 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyFixer : public UnitWrap::UnitTest<D>
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        SDS_cxx[i].write(Base::m_fid);
+        SDS_cxx[i].write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/shoc/tests/shoc_energy_integral_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_energy_integral_tests.cpp
@@ -8,9 +8,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_energy_integral_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_energy_integral_tests.cpp
@@ -157,7 +157,7 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyInt : public UnitWrap::UnitTest<D>::
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : SDS_baseline) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -181,7 +181,7 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyInt : public UnitWrap::UnitTest<D>::
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        SDS_cxx[i].write(Base::m_fid);
+        SDS_cxx[i].write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/shoc/tests/shoc_energy_update_dse_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_energy_update_dse_tests.cpp
@@ -8,9 +8,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_energy_update_dse_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_energy_update_dse_tests.cpp
@@ -166,7 +166,7 @@ struct UnitWrap::UnitTest<D>::TestShocUpdateDse : public UnitWrap::UnitTest<D>::
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : SDS_baseline) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -187,7 +187,7 @@ struct UnitWrap::UnitTest<D>::TestShocUpdateDse : public UnitWrap::UnitTest<D>::
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        SDS_cxx[i].write(Base::m_fid);
+        SDS_cxx[i].write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/shoc/tests/shoc_grid_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_grid_tests.cpp
@@ -9,9 +9,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_grid_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_grid_tests.cpp
@@ -157,7 +157,7 @@ struct UnitWrap::UnitTest<D>::TestShocGrid : public UnitWrap::UnitTest<D>::Base 
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -182,7 +182,7 @@ struct UnitWrap::UnitTest<D>::TestShocGrid : public UnitWrap::UnitTest<D>::Base 
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        cxx_data[i].write(Base::m_fid);
+        cxx_data[i].write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/shoc/tests/shoc_impli_comp_tmpi_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_impli_comp_tmpi_tests.cpp
@@ -7,9 +7,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_impli_comp_tmpi_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_impli_comp_tmpi_tests.cpp
@@ -146,7 +146,7 @@ struct UnitWrap::UnitTest<D>::TestImpCompTmpi : public UnitWrap::UnitTest<D>::Ba
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -167,7 +167,7 @@ struct UnitWrap::UnitTest<D>::TestImpCompTmpi : public UnitWrap::UnitTest<D>::Ba
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        cxx_data[i].write(Base::m_fid);
+        cxx_data[i].write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/shoc/tests/shoc_impli_dp_inverse_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_impli_dp_inverse_tests.cpp
@@ -7,9 +7,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_impli_dp_inverse_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_impli_dp_inverse_tests.cpp
@@ -126,7 +126,7 @@ struct UnitWrap::UnitTest<D>::TestImpDpInverse : public UnitWrap::UnitTest<D>::B
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -147,7 +147,7 @@ struct UnitWrap::UnitTest<D>::TestImpDpInverse : public UnitWrap::UnitTest<D>::B
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        cxx_data[i].write(Base::m_fid);
+        cxx_data[i].write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/shoc/tests/shoc_l_inf_length_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_l_inf_length_tests.cpp
@@ -7,9 +7,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
-#include "ekat/util/ekat_arch.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_l_inf_length_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_l_inf_length_tests.cpp
@@ -135,7 +135,7 @@ struct UnitWrap::UnitTest<D>::TestLInfShocLength : public UnitWrap::UnitTest<D>:
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : SDS_baseline) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -156,7 +156,7 @@ struct UnitWrap::UnitTest<D>::TestLInfShocLength : public UnitWrap::UnitTest<D>:
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        SDS_cxx[i].write(Base::m_fid);
+        SDS_cxx[i].write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/shoc/tests/shoc_length_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_length_tests.cpp
@@ -7,9 +7,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_length_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_length_tests.cpp
@@ -216,7 +216,7 @@ struct UnitWrap::UnitTest<D>::TestShocLength : public UnitWrap::UnitTest<D>::Bas
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : SDS_baseline) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -238,7 +238,7 @@ struct UnitWrap::UnitTest<D>::TestShocLength : public UnitWrap::UnitTest<D>::Bas
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        SDS_cxx[i].write(Base::m_fid);
+        SDS_cxx[i].write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/shoc/tests/shoc_linear_interp_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_linear_interp_tests.cpp
@@ -8,9 +8,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_linear_interp_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_linear_interp_tests.cpp
@@ -366,7 +366,7 @@ struct UnitWrap::UnitTest<D>::TestShocLinearInt : public UnitWrap::UnitTest<D>::
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -388,7 +388,7 @@ struct UnitWrap::UnitTest<D>::TestShocLinearInt : public UnitWrap::UnitTest<D>::
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (auto& d : cxx_data) {
-        d.write(Base::m_fid);
+        d.write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/shoc/tests/shoc_main_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_main_tests.cpp
@@ -1,8 +1,6 @@
 #include "catch2/catch.hpp"
 
 #include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "shoc_functions.hpp"
 #include "shoc_test_data.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"

--- a/components/eamxx/src/physics/shoc/tests/shoc_main_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_main_tests.cpp
@@ -375,7 +375,7 @@ struct UnitWrap::UnitTest<D>::TestShocMain : public UnitWrap::UnitTest<D>::Base 
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -461,7 +461,7 @@ struct UnitWrap::UnitTest<D>::TestShocMain : public UnitWrap::UnitTest<D>::Base 
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (auto& d : cxx_data) {
-        d.write(Base::m_fid);
+        d.write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/shoc/tests/shoc_mix_length_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_mix_length_tests.cpp
@@ -7,9 +7,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_mix_length_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_mix_length_tests.cpp
@@ -144,7 +144,7 @@ struct UnitWrap::UnitTest<D>::TestCompShocMixLength : public UnitWrap::UnitTest<
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : SDS_baseline) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -165,7 +165,7 @@ struct UnitWrap::UnitTest<D>::TestCompShocMixLength : public UnitWrap::UnitTest<
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        SDS_cxx[i].write(Base::m_fid);
+        SDS_cxx[i].write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/shoc/tests/shoc_pblintd_check_pblh_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pblintd_check_pblh_tests.cpp
@@ -1,8 +1,6 @@
 #include "catch2/catch.hpp"
 
 #include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "shoc_functions.hpp"
 #include "shoc_test_data.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"

--- a/components/eamxx/src/physics/shoc/tests/shoc_pblintd_check_pblh_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pblintd_check_pblh_tests.cpp
@@ -107,7 +107,7 @@ struct UnitWrap::UnitTest<D>::TestPblintdCheckPblh : public UnitWrap::UnitTest<D
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -130,7 +130,7 @@ struct UnitWrap::UnitTest<D>::TestPblintdCheckPblh : public UnitWrap::UnitTest<D
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (auto& d : cxx_data) {
-        d.write(Base::m_fid);
+        d.write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/shoc/tests/shoc_pblintd_cldcheck_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pblintd_cldcheck_tests.cpp
@@ -8,10 +8,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
-
 #include <algorithm>
 #include <array>
 #include <random>

--- a/components/eamxx/src/physics/shoc/tests/shoc_pblintd_cldcheck_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pblintd_cldcheck_tests.cpp
@@ -115,7 +115,7 @@ struct UnitWrap::UnitTest<D>::TestPblintdCldCheck : public UnitWrap::UnitTest<D>
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : cldcheck_data_baseline) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -134,7 +134,7 @@ struct UnitWrap::UnitTest<D>::TestPblintdCldCheck : public UnitWrap::UnitTest<D>
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (auto& d : cldcheck_data_cxx) {
-        d.write(Base::m_fid);
+        d.write(Base::m_ofile);
       }
     }
   }  // run_bfb

--- a/components/eamxx/src/physics/shoc/tests/shoc_pblintd_height_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pblintd_height_tests.cpp
@@ -1,8 +1,6 @@
 #include "catch2/catch.hpp"
 
 #include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "shoc_functions.hpp"
 #include "shoc_test_data.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"

--- a/components/eamxx/src/physics/shoc/tests/shoc_pblintd_height_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pblintd_height_tests.cpp
@@ -202,7 +202,7 @@ struct UnitWrap::UnitTest<D>::TestPblintdHeight : public UnitWrap::UnitTest<D>::
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -227,7 +227,7 @@ struct UnitWrap::UnitTest<D>::TestPblintdHeight : public UnitWrap::UnitTest<D>::
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (auto& d : cxx_data) {
-        d.write(Base::m_fid);
+        d.write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/shoc/tests/shoc_pblintd_init_pot_test.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pblintd_init_pot_test.cpp
@@ -8,9 +8,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_pblintd_init_pot_test.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pblintd_init_pot_test.cpp
@@ -172,7 +172,7 @@ struct UnitWrap::UnitTest<D>::TestPblintdInitPot : public UnitWrap::UnitTest<D>:
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : pblintd_init_pot_data_baseline) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -194,7 +194,7 @@ struct UnitWrap::UnitTest<D>::TestPblintdInitPot : public UnitWrap::UnitTest<D>:
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (auto& d : pblintd_init_pot_data_cxx) {
-        d.write(Base::m_fid);
+        d.write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/shoc/tests/shoc_pblintd_surf_temp_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pblintd_surf_temp_tests.cpp
@@ -1,8 +1,6 @@
 #include "catch2/catch.hpp"
 
 #include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "shoc_functions.hpp"
 #include "shoc_test_data.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"

--- a/components/eamxx/src/physics/shoc/tests/shoc_pblintd_surf_temp_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pblintd_surf_temp_tests.cpp
@@ -138,7 +138,7 @@ struct UnitWrap::UnitTest<D>::TestPblintdSurfTemp : public UnitWrap::UnitTest<D>
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -169,7 +169,7 @@ struct UnitWrap::UnitTest<D>::TestPblintdSurfTemp : public UnitWrap::UnitTest<D>
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (auto& d : cxx_data) {
-        d.write(Base::m_fid);
+        d.write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/shoc/tests/shoc_pblintd_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pblintd_tests.cpp
@@ -1,8 +1,6 @@
 #include "catch2/catch.hpp"
 
 #include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "shoc_functions.hpp"
 #include "shoc_test_data.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"

--- a/components/eamxx/src/physics/shoc/tests/shoc_pblintd_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pblintd_tests.cpp
@@ -171,7 +171,7 @@ struct UnitWrap::UnitTest<D>::TestPblintd : public UnitWrap::UnitTest<D>::Base {
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -193,7 +193,7 @@ struct UnitWrap::UnitTest<D>::TestPblintd : public UnitWrap::UnitTest<D>::Base {
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (auto& d : cxx_data) {
-        d.write(Base::m_fid);
+        d.write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/shoc/tests/shoc_pdf_compute_buoyflux_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pdf_compute_buoyflux_tests.cpp
@@ -6,9 +6,6 @@
 #include "physics/share/physics_constants.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_pdf_compute_cloudvar_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pdf_compute_cloudvar_tests.cpp
@@ -6,9 +6,6 @@
 #include "physics/share/physics_constants.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_pdf_compute_liqflux_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pdf_compute_liqflux_tests.cpp
@@ -6,9 +6,6 @@
 #include "physics/share/physics_constants.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_pdf_compute_qs_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pdf_compute_qs_tests.cpp
@@ -6,9 +6,6 @@
 #include "physics/share/physics_constants.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_pdf_compute_s_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pdf_compute_s_tests.cpp
@@ -6,9 +6,6 @@
 #include "physics/share/physics_constants.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_pdf_compute_sgsliq_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pdf_compute_sgsliq_tests.cpp
@@ -6,9 +6,6 @@
 #include "physics/share/physics_constants.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_pdf_computetemp_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pdf_computetemp_tests.cpp
@@ -6,9 +6,6 @@
 #include "physics/share/physics_constants.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_pdf_inplume_corr_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pdf_inplume_corr_tests.cpp
@@ -6,9 +6,6 @@
 #include "physics/share/physics_constants.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_pdf_qw_parameters_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pdf_qw_parameters_tests.cpp
@@ -6,9 +6,6 @@
 #include "physics/share/physics_constants.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_pdf_thl_parameters_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pdf_thl_parameters_tests.cpp
@@ -6,9 +6,6 @@
 #include "physics/share/physics_constants.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_pdf_tildetoreal_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pdf_tildetoreal_tests.cpp
@@ -6,9 +6,6 @@
 #include "physics/share/physics_constants.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_pdf_vv_parameters_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pdf_vv_parameters_tests.cpp
@@ -6,9 +6,6 @@
 #include "physics/share/physics_constants.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_run_and_cmp.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_run_and_cmp.cpp
@@ -6,9 +6,6 @@
 #include "share/eamxx_session.hpp"
 #include "share/util/eamxx_utils.hpp"
 
-#include "ekat/util/ekat_file_utils.hpp"
-#include "ekat/util/ekat_test_utils.hpp"
-#include "ekat/ekat_assert.hpp"
 
 #include <vector>
 

--- a/components/eamxx/src/physics/shoc/tests/shoc_run_and_cmp.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_run_and_cmp.cpp
@@ -59,8 +59,8 @@ struct Baseline {
   }
 
   Int generate_baseline (const std::string& filename) {
-    auto fid = ekat::FILEPtr(fopen(filename.c_str(), "w"));
-    EKAT_REQUIRE_MSG( fid, "generate_baseline can't write " << filename);
+    std::ofstream ofile (filename, std::ios::binary);
+    EKAT_REQUIRE_MSG (ofile.good(), "generate_baseline can't write '" + filename + "'\n");
     Int nerr = 0;
 
     // These times are thrown out, I just wanted to be able to use auto
@@ -88,7 +88,7 @@ struct Baseline {
           }
 
           if (ps.repeat == 0) {
-            write(fid, d);
+            write(ofile, d);
           }
         }
       }
@@ -102,10 +102,10 @@ struct Baseline {
   }
 
   Int run_and_cmp (const std::string& filename, const double& tol, bool no_baseline) {
-    ekat::FILEPtr fid;
+    std::ifstream ifile;
     if (!no_baseline) {
-      fid = ekat::FILEPtr(fopen(filename.c_str(), "r"));
-      EKAT_REQUIRE_MSG( fid, "generate_baseline can't read " << filename);
+      ifile.open(filename,std::ios::binary);
+      EKAT_REQUIRE_MSG( ifile.good(), "run_and_cmp can't read '" + filename + "'\n");
     }
     Int nerr = 0, ne;
     int case_num = 0;
@@ -131,7 +131,7 @@ struct Baseline {
           for (int it = 0; it < ps.nsteps; it++) {
             std::cout << "--- checking case # " << case_num << ", timestep # = " << (it+1)*ps.nadv
                       << " ---\n" << std::flush;
-            read(fid, d_ref);
+            read(ifile, d_ref);
             shoc_main(*d);
             ne = compare(tol, d_ref, d);
             if (ne) std::cout << "Ref impl failed.\n";
@@ -158,32 +158,32 @@ private:
 
   std::vector<ParamSet> params_;
 
-  static void write (const ekat::FILEPtr& fid, const FortranData::Ptr& d) {
+  static void write (std::ofstream& ofile, const FortranData::Ptr& d) {
     FortranDataIterator fdi(d);
     for (Int i = 0, n = fdi.nfield(); i < n; ++i) {
       const auto& f = fdi.getfield(i);
-      ekat::write(&f.dim, 1, fid);
-      ekat::write(f.extent, f.dim, fid);
-      ekat::write(f.data, f.size, fid);
+      impl::write_scalars(ofile,f.dim);
+      impl::write_scalars(ofile,f.extent);
+      impl::write_scalars(ofile,f.data,f.size);
     }
   }
 
-  static void read (const ekat::FILEPtr& fid, const FortranData::Ptr& d) {
+  static void read (std::ifstream& ifile, const FortranData::Ptr& d) {
     FortranDataIterator fdi(d);
     for (Int i = 0, n = fdi.nfield(); i < n; ++i) {
       const auto& f = fdi.getfield(i);
       int dim, ds[3];
-      ekat::read(&dim, 1, fid);
+      impl::read_scalars(ifile,dim);
       EKAT_REQUIRE_MSG(dim == f.dim,
                       "For field " << f.name << " read expected dim " <<
                       f.dim << " but got " << dim);
-      ekat::read(ds, dim, fid);
+      impl::read_scalars(ifile,ds);
       for (int i = 0; i < dim; ++i)
         EKAT_REQUIRE_MSG(ds[i] == f.extent[i],
                         "For field " << f.name << " read expected dim "
                         << i << " to have extent " << f.extent[i] << " but got "
                         << ds[i]);
-      ekat::read(f.data, f.size, fid);
+      impl::read_scalars(ifile,f.data,f.size);
     }
   }
 };

--- a/components/eamxx/src/physics/shoc/tests/shoc_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_tests.cpp
@@ -3,8 +3,6 @@
 #include "shoc_main_wrap.hpp"
 #include "shoc_ic_cases.hpp"
 
-#include "ekat/util/ekat_test_utils.hpp"
-
 namespace {
 
 TEST_CASE("FortranData", "shoc") {

--- a/components/eamxx/src/physics/shoc/tests/shoc_tke_adv_sgs_tke_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_tke_adv_sgs_tke_tests.cpp
@@ -7,9 +7,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_tke_adv_sgs_tke_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_tke_adv_sgs_tke_tests.cpp
@@ -218,7 +218,7 @@ struct UnitWrap::UnitTest<D>::TestShocAdvSgsTke : public UnitWrap::UnitTest<D>::
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -241,7 +241,7 @@ struct UnitWrap::UnitTest<D>::TestShocAdvSgsTke : public UnitWrap::UnitTest<D>::
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (auto& d : cxx_data) {
-        d.write(Base::m_fid);
+        d.write(Base::m_ofile);
       }
     }
   }//run_bfb

--- a/components/eamxx/src/physics/shoc/tests/shoc_tke_column_stab_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_tke_column_stab_tests.cpp
@@ -7,9 +7,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_tke_column_stab_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_tke_column_stab_tests.cpp
@@ -145,7 +145,7 @@ struct UnitWrap::UnitTest<D>::TestShocIntColStab : public UnitWrap::UnitTest<D>:
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto &d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -167,7 +167,7 @@ struct UnitWrap::UnitTest<D>::TestShocIntColStab : public UnitWrap::UnitTest<D>:
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (auto &d : cxx_data) {
-        d.write(Base::m_fid);
+        d.write(Base::m_ofile);
       }
     }
   } //run_bfb

--- a/components/eamxx/src/physics/shoc/tests/shoc_tke_isotropic_ts_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_tke_isotropic_ts_tests.cpp
@@ -7,9 +7,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_tke_isotropic_ts_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_tke_isotropic_ts_tests.cpp
@@ -202,7 +202,7 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs : public UnitWrap::UnitTest<D>
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -224,7 +224,7 @@ struct UnitWrap::UnitTest<D>::TestShocIsotropicTs : public UnitWrap::UnitTest<D>
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (auto& d : cxx_data) {
-        d.write(Base::m_fid);
+        d.write(Base::m_ofile);
       }
     }
   }//run_bfb

--- a/components/eamxx/src/physics/shoc/tests/shoc_tke_shr_prod_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_tke_shr_prod_tests.cpp
@@ -7,9 +7,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_tke_shr_prod_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_tke_shr_prod_tests.cpp
@@ -183,7 +183,7 @@ struct UnitWrap::UnitTest<D>::TestShocShearProd : public UnitWrap::UnitTest<D>::
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -205,7 +205,7 @@ struct UnitWrap::UnitTest<D>::TestShocShearProd : public UnitWrap::UnitTest<D>::
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (auto& d : cxx_data) {
-        d.write(Base::m_fid);
+        d.write(Base::m_ofile);
       }
     }
   } //run_bfb

--- a/components/eamxx/src/physics/shoc/tests/shoc_tke_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_tke_tests.cpp
@@ -7,9 +7,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_tke_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_tke_tests.cpp
@@ -274,7 +274,7 @@ struct UnitWrap::UnitTest<D>::TestShocTke : public UnitWrap::UnitTest<D>::Base {
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -303,7 +303,7 @@ struct UnitWrap::UnitTest<D>::TestShocTke : public UnitWrap::UnitTest<D>::Base {
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (auto& d : cxx_data) {
-        d.write(Base::m_fid);
+        d.write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/shoc/tests/shoc_unit_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_unit_tests.cpp
@@ -7,9 +7,6 @@
 
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
-#include "ekat/util/ekat_arch.hpp"
 
 #include <thread>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_update_prognostics_implicit_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_update_prognostics_implicit_tests.cpp
@@ -1,8 +1,6 @@
 #include "catch2/catch.hpp"
 
 #include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "shoc_functions.hpp"
 #include "shoc_test_data.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"

--- a/components/eamxx/src/physics/shoc/tests/shoc_update_prognostics_implicit_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_update_prognostics_implicit_tests.cpp
@@ -362,7 +362,7 @@ struct UnitWrap::UnitTest<D>::TestUpdatePrognosticsImplicit : public UnitWrap::U
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -399,7 +399,7 @@ struct UnitWrap::UnitTest<D>::TestUpdatePrognosticsImplicit : public UnitWrap::U
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (auto& d : cxx_data) {
-        d.write(Base::m_fid);
+        d.write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/shoc/tests/shoc_varorcovar_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_varorcovar_tests.cpp
@@ -9,9 +9,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_varorcovar_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_varorcovar_tests.cpp
@@ -296,7 +296,7 @@ void run_bfb()
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : SDS_baseline) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -317,7 +317,7 @@ void run_bfb()
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        SDS_cxx[i].write(Base::m_fid);
+        SDS_cxx[i].write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/shoc/tests/shoc_vd_shoc_decomp_and_solve_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_vd_shoc_decomp_and_solve_tests.cpp
@@ -1,8 +1,6 @@
 #include "catch2/catch.hpp"
 
 #include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "shoc_functions.hpp"
 #include "shoc_test_data.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"

--- a/components/eamxx/src/physics/shoc/tests/shoc_vd_shoc_decomp_and_solve_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_vd_shoc_decomp_and_solve_tests.cpp
@@ -49,7 +49,7 @@ struct UnitWrap::UnitTest<D>::TestVdShocDecompandSolve : public UnitWrap::UnitTe
     // Read baseline data.
     if (this->m_baseline_action == COMPARE) {
       for (auto& d: baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -72,7 +72,7 @@ struct UnitWrap::UnitTest<D>::TestVdShocDecompandSolve : public UnitWrap::UnitTe
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        cxx_data[i].write(Base::m_fid);
+        cxx_data[i].write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/shoc/tests/shoc_vertflux_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_vertflux_tests.cpp
@@ -7,9 +7,6 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 
 #include <algorithm>
 #include <array>

--- a/components/eamxx/src/physics/shoc/tests/shoc_vertflux_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_vertflux_tests.cpp
@@ -160,7 +160,7 @@ struct UnitWrap::UnitTest<D>::TestCalcShocVertflux : public UnitWrap::UnitTest<D
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : SDS_baseline) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -181,7 +181,7 @@ struct UnitWrap::UnitTest<D>::TestCalcShocVertflux : public UnitWrap::UnitTest<D
     } // SCREAM_BFB_TESTING
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        SDS_cxx[i].write(Base::m_fid);
+        SDS_cxx[i].write(Base::m_ofile);
       }
     }
   }

--- a/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
+++ b/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
@@ -4,8 +4,8 @@
 #include "share/io/eamxx_scorpio_interface.hpp"
 #include "share/property_checks/field_within_interval_check.hpp"
 
-#include <ekat/ekat_assert.hpp>
-#include <ekat/util/ekat_units.hpp>
+#include <ekat_assert.hpp>
+#include <ekat_units.hpp>
 
 namespace scream
 {

--- a/components/eamxx/src/physics/tms/eamxx_tms_process_interface.cpp
+++ b/components/eamxx/src/physics/tms/eamxx_tms_process_interface.cpp
@@ -2,6 +2,7 @@
 
 #include "physics/tms/tms_functions.hpp"
 
+#include <ekat_team_policy_utils.hpp>
 #include <ekat_assert.hpp>
 #include <ekat_units.hpp>
 
@@ -67,6 +68,8 @@ void TurbulentMountainStress::initialize_impl (const RunType /* run_type */)
 // =========================================================================================
 void TurbulentMountainStress::run_impl (const double /* dt */)
 {
+  using TPF = ekat::TeamPolicyFactory<TMSFunctions::KT::ExeSpace>;
+
   // Helper views
   const auto pseudo_density = get_field_in("pseudo_density").get_view<const Spack**>();
   const auto qv             = get_field_in("qv").get_view<const Spack**>();
@@ -91,7 +94,7 @@ void TurbulentMountainStress::run_impl (const double /* dt */)
   const int nlevs = m_nlevs;
   const int nlev_packs = ekat::npack<Spack>(nlevs);
   // calculate_z_int contains a team-level parallel_scan, which requires a special policy
-  const auto scan_policy = ekat::ExeSpaceUtils<TMSFunctions::KT::ExeSpace>::get_thread_range_parallel_scan_team_policy(ncols, nlev_packs);
+  const auto scan_policy = TPF::get_thread_range_parallel_scan_team_policy(ncols, nlev_packs);
   Kokkos::parallel_for(scan_policy, KOKKOS_LAMBDA (const TMSFunctions::KT::MemberType& team) {
     const int i = team.league_rank();
 

--- a/components/eamxx/src/physics/tms/eamxx_tms_process_interface.cpp
+++ b/components/eamxx/src/physics/tms/eamxx_tms_process_interface.cpp
@@ -2,8 +2,8 @@
 
 #include "physics/tms/tms_functions.hpp"
 
-#include "ekat/ekat_assert.hpp"
-#include "ekat/util/ekat_units.hpp"
+#include <ekat_assert.hpp>
+#include <ekat_units.hpp>
 
 #include <array>
 

--- a/components/eamxx/src/physics/tms/eamxx_tms_process_interface.hpp
+++ b/components/eamxx/src/physics/tms/eamxx_tms_process_interface.hpp
@@ -4,7 +4,8 @@
 #include "physics/tms/tms_functions.hpp"
 #include "share/atm_process/atmosphere_process.hpp"
 #include "share/util/eamxx_common_physics_functions.hpp"
-#include "ekat/ekat_parameter_list.hpp"
+
+#include <ekat_parameter_list.hpp>
 
 #include <string>
 

--- a/components/eamxx/src/physics/tms/tests/compute_tms_tests.cpp
+++ b/components/eamxx/src/physics/tms/tests/compute_tms_tests.cpp
@@ -1,13 +1,11 @@
 #include "catch2/catch.hpp"
 
 #include "tms_unit_tests_common.hpp"
-
-#include "share/eamxx_types.hpp"
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "tms_functions.hpp"
 #include "tms_test_data.hpp"
+
 #include "share/util/eamxx_setup_random_test.hpp"
+#include "share/eamxx_types.hpp"
 
 namespace scream {
 namespace tms {

--- a/components/eamxx/src/physics/tms/tests/compute_tms_tests.cpp
+++ b/components/eamxx/src/physics/tms/tests/compute_tms_tests.cpp
@@ -52,7 +52,7 @@ struct UnitWrap::UnitTest<D>::TestComputeTMS : public UnitWrap::UnitTest<D>::Bas
     // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (auto& d : baseline_data) {
-        d.read(Base::m_fid);
+        d.read(Base::m_ifile);
       }
     }
 
@@ -79,7 +79,7 @@ struct UnitWrap::UnitTest<D>::TestComputeTMS : public UnitWrap::UnitTest<D>::Bas
     }
     else if (this->m_baseline_action == GENERATE) {
       for (Int i = 0; i < num_runs; ++i) {
-        cxx_data[i].write(Base::m_fid);
+        cxx_data[i].write(Base::m_ofile);
       }
     }
   } // run_bfb

--- a/components/eamxx/src/physics/tms/tests/infra/CMakeLists.txt
+++ b/components/eamxx/src/physics/tms/tests/infra/CMakeLists.txt
@@ -3,5 +3,5 @@ set(INFRA_SRCS
 )
 
 add_library(tms_test_infra ${INFRA_SRCS})
-target_link_libraries(tms_test_infra tms)
+target_link_libraries(tms_test_infra PUBLIC tms scream_test_support)
 target_include_directories(tms_test_infra PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/components/eamxx/src/physics/tms/tests/infra/tms_test_data.cpp
+++ b/components/eamxx/src/physics/tms/tests/infra/tms_test_data.cpp
@@ -1,9 +1,6 @@
 #include "tms_test_data.hpp"
 
-#include "ekat/ekat_assert.hpp"
 #include "ekat/kokkos/ekat_kokkos_utils.hpp"
-#include "ekat/ekat_pack_kokkos.hpp"
-#include "ekat/kokkos/ekat_subview_utils.hpp"
 
 #include "share/util/eamxx_deep_copy.hpp"
 

--- a/components/eamxx/src/physics/tms/tests/infra/tms_test_data.cpp
+++ b/components/eamxx/src/physics/tms/tests/infra/tms_test_data.cpp
@@ -1,8 +1,8 @@
 #include "tms_test_data.hpp"
 
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
-
 #include "share/util/eamxx_deep_copy.hpp"
+
+#include <ekat_team_policy_utils.hpp>
 
 #include <random>
 
@@ -28,6 +28,7 @@ void compute_tms_f(int ncols, int nlevs,
   using view_3d    = typename TMSFunc::view_3d<Spack>;
   using ExeSpace   = typename TMSFunc::KT::ExeSpace;
   using MemberType = typename TMSFunc::KT::MemberType;
+  using TPF        = ekat::TeamPolicyFactory<ExeSpace>;
 
   // Initialize Kokkos views, sync to device
   std::vector<view_1d> temp_d_1d(2);
@@ -55,7 +56,7 @@ void compute_tms_f(int ncols, int nlevs,
   const auto nlev_packs = ekat::npack<Spack>(nlevs);
   view_3d   horiz_wind_d("horiz_wind_d", ncols, 2, nlev_packs);
   view_2d_s tau_d("tau_d", ncols, 2);
-  const auto policy = ekat::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncols, nlev_packs);
+  const auto policy = TPF::get_default_team_policy(ncols, nlev_packs);
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
     const int i = team.league_rank();
     tau_d(i, 0) = taux_d(i);

--- a/components/eamxx/src/physics/tms/tests/infra/tms_unit_tests_common.hpp
+++ b/components/eamxx/src/physics/tms/tests/infra/tms_unit_tests_common.hpp
@@ -3,7 +3,6 @@
 
 #include "tms_functions.hpp"
 #include "share/eamxx_types.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "physics/share/physics_test_data.hpp"
 
 namespace scream {

--- a/components/eamxx/src/physics/tms/tms_functions.hpp
+++ b/components/eamxx/src/physics/tms/tms_functions.hpp
@@ -5,9 +5,9 @@
 
 #include "share/eamxx_types.hpp"
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
-#include "ekat/ekat_pack_kokkos.hpp"
-#include "ekat/ekat_workspace.hpp"
+#include <ekat_subview_utils.hpp>
+#include <ekat_pack_kokkos.hpp>
+#include <ekat_workspace.hpp>
 
 namespace scream {
 namespace tms {

--- a/components/eamxx/src/share/CMakeLists.txt
+++ b/components/eamxx/src/share/CMakeLists.txt
@@ -107,7 +107,8 @@ else()
   target_include_directories(scream_share PUBLIC ${INSTALL_SHAREDPATH}/include)
 endif()
 
-target_link_libraries(scream_share PUBLIC ekat pioc)
+target_link_libraries(scream_share PUBLIC ekat::AllLibs pioc)
+
 target_compile_options(scream_share PUBLIC
   $<$<COMPILE_LANGUAGE:Fortran>:${SCREAM_Fortran_FLAGS}>
 )

--- a/components/eamxx/src/share/CMakeLists.txt
+++ b/components/eamxx/src/share/CMakeLists.txt
@@ -156,6 +156,7 @@ if (NOT SCREAM_LIB_ONLY)
     util/eamxx_test_session.cpp
   )
   target_link_libraries(scream_test_support PUBLIC scream_share scream_io)
+  target_include_directories (scream_test_support PUBLIC ${EKAT_SOURCE_DIR}/extern/Catch2/single_include)
 
   add_subdirectory(tests)
 endif()

--- a/components/eamxx/src/share/atm_process/ATMBufferManager.hpp
+++ b/components/eamxx/src/share/atm_process/ATMBufferManager.hpp
@@ -27,8 +27,8 @@ struct ATMBufferManager {
   // the same time, the total allocation will be the maximum
   // of each request.
   void request_bytes (const size_t num_bytes) {
-    ekat::error::runtime_check(num_bytes%sizeof(Real)==0,
-                               "Error! Must request number of bytes which is divisible by sizeof(Real).\n");
+    EKAT_REQUIRE_MSG (num_bytes%sizeof(Real)==0,
+        "Error! Must request number of bytes which is divisible by sizeof(Real).\n");
 
     const size_t num_reals = num_bytes/sizeof(Real);
     m_size = std::max(num_reals, m_size);
@@ -39,7 +39,7 @@ struct ATMBufferManager {
   size_t allocated_bytes () const { return m_size*sizeof(Real); }
 
   void allocate () {
-    ekat::error::runtime_check(!m_allocated, "Error! Cannot call 'allocate' more than once.\n");
+    EKAT_REQUIRE_MSG (!m_allocated, "Error! Cannot call 'allocate' more than once.\n");
 
     m_buffer = view_1d<Real>("",m_size);
     m_allocated = true;

--- a/components/eamxx/src/share/atm_process/ATMBufferManager.hpp
+++ b/components/eamxx/src/share/atm_process/ATMBufferManager.hpp
@@ -2,7 +2,8 @@
 #define SCREAM_ATM_BUFFERS_MANAGER_HPP
 
 #include "share/eamxx_types.hpp"
-#include "ekat/ekat_assert.hpp"
+
+#include <ekat_assert.hpp>
 
 namespace scream {
 

--- a/components/eamxx/src/share/atm_process/IOPDataManager.cpp
+++ b/components/eamxx/src/share/atm_process/IOPDataManager.cpp
@@ -4,8 +4,8 @@
 #include "share/io/eamxx_scorpio_interface.hpp"
 #include "share/atm_process/IOPDataManager.hpp"
 
-#include "ekat/ekat_assert.hpp"
-#include "ekat/util/ekat_lin_interp.hpp"
+#include <ekat_assert.hpp>
+#include <ekat_lin_interp.hpp>
 
 #include <numeric>
 

--- a/components/eamxx/src/share/atm_process/IOPDataManager.hpp
+++ b/components/eamxx/src/share/atm_process/IOPDataManager.hpp
@@ -7,10 +7,10 @@
 #include "share/grid/remap/abstract_remapper.hpp"
 #include "share/util/eamxx_time_stamp.hpp"
 
-#include "ekat/ekat_parameter_list.hpp"
 #include "ekat/ekat_pack.hpp"
-#include "ekat/mpi/ekat_comm.hpp"
 #include "ekat/kokkos/ekat_kokkos_utils.hpp"
+#include <ekat_parameter_list.hpp>
+#include <ekat_comm.hpp>
 
 namespace scream {
 namespace control {

--- a/components/eamxx/src/share/atm_process/IOPDataManager.hpp
+++ b/components/eamxx/src/share/atm_process/IOPDataManager.hpp
@@ -7,8 +7,6 @@
 #include "share/grid/remap/abstract_remapper.hpp"
 #include "share/util/eamxx_time_stamp.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include <ekat_parameter_list.hpp>
 #include <ekat_comm.hpp>
 
@@ -23,9 +21,6 @@ class IOPDataManager
   using grid_ptr = std::shared_ptr<const AbstractGrid>;
 
   using KT = ekat::KokkosTypes<DefaultDevice>;
-  using ESU = ekat::ExeSpaceUtils<KT::ExeSpace>;
-  using Pack = ekat::Pack<Real, SCREAM_PACK_SIZE>;
-  using Pack1d = ekat::Pack<Real, 1>;
 
   template<typename ScalarT>
   using view_1d = KT::template view_1d<ScalarT>;

--- a/components/eamxx/src/share/atm_process/SCDataManager.hpp
+++ b/components/eamxx/src/share/atm_process/SCDataManager.hpp
@@ -2,7 +2,8 @@
 #define SCREAM_SC_DATA_MANAGER_HPP
 
 #include "share/eamxx_types.hpp"
-#include "ekat/ekat_assert.hpp"
+
+#include <ekat_assert.hpp>
 
 namespace scream {
 

--- a/components/eamxx/src/share/atm_process/atmosphere_process.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.cpp
@@ -3,7 +3,7 @@
 #include "share/property_checks/mass_and_energy_column_conservation_check.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/ekat_assert.hpp"
+#include <ekat_assert.hpp>
 
 #include <set>
 #include <stdexcept>

--- a/components/eamxx/src/share/atm_process/atmosphere_process.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.hpp
@@ -13,13 +13,13 @@
 #include "share/field/field_group.hpp"
 #include "share/grid/grids_manager.hpp"
 
-#include "ekat/mpi/ekat_comm.hpp"
-#include "ekat/ekat_parameter_list.hpp"
-#include "ekat/util/ekat_factory.hpp"
-#include "ekat/util/ekat_string_utils.hpp"
-#include "ekat/std_meta/ekat_std_enable_shared_from_this.hpp"
-#include "ekat/std_meta/ekat_std_any.hpp"
-#include "ekat/logging/ekat_logger.hpp"
+#include <ekat_comm.hpp>
+#include <ekat_parameter_list.hpp>
+#include <ekat_factory.hpp>
+#include <ekat_string_utils.hpp>
+#include <ekat_std_enable_shared_from_this.hpp>
+#include <ekat_std_any.hpp>
+#include <ekat_logger.hpp>
 
 #include <memory>
 #include <string>

--- a/components/eamxx/src/share/atm_process/atmosphere_process_dag.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_dag.hpp
@@ -1,10 +1,11 @@
 #ifndef SCREAM_ATMOSPHERE_PROCESS_DAG_HPP
 #define SCREAM_ATMOSPHERE_PROCESS_DAG_HPP
 
-#include <memory>
-#include <string>
 #include "share/atm_process/atmosphere_process_group.hpp"
 #include "share/field/field_group.hpp"
+
+#include <memory>
+#include <string>
 
 namespace scream {
 

--- a/components/eamxx/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_group.cpp
@@ -5,6 +5,7 @@
 
 #include <ekat_std_utils.hpp>
 #include <ekat_string_utils.hpp>
+#include <ekat_assert.hpp>
 
 #include <memory>
 
@@ -24,9 +25,9 @@ AtmosphereProcessGroup (const ekat::Comm& comm, const ekat::ParameterList& param
       m_group_schedule_type = ScheduleType::Sequential;
     } else if (m_params.get<std::string>("schedule_type") == "parallel") {
       m_group_schedule_type = ScheduleType::Parallel;
-      ekat::error::runtime_abort("Error! Parallel schedule not yet implemented.\n");
+      EKAT_ERROR_MSG("Error! Parallel schedule not yet implemented.\n");
     } else {
-      ekat::error::runtime_abort("Error! Invalid 'schedule_type'. Available choices are 'parallel' and 'sequential'.\n");
+      EKAT_ERROR_MSG("Error! Invalid 'schedule_type'. Available choices are 'parallel' and 'sequential'.\n");
     }
   } else {
     // Pointless to handle this group as parallel, if only one process is in it

--- a/components/eamxx/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_group.cpp
@@ -3,8 +3,8 @@
 
 #include "share/property_checks/field_nan_check.hpp"
 
-#include "ekat/std_meta/ekat_std_utils.hpp"
-#include "ekat/util/ekat_string_utils.hpp"
+#include <ekat_std_utils.hpp>
+#include <ekat_string_utils.hpp>
 
 #include <memory>
 

--- a/components/eamxx/src/share/atm_process/atmosphere_process_group.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_group.hpp
@@ -5,7 +5,7 @@
 #include "share/property_checks/mass_and_energy_column_conservation_check.hpp"
 #include "control/surface_coupling_utils.hpp"
 
-#include "ekat/ekat_parameter_list.hpp"
+#include <ekat_parameter_list.hpp>
 
 #include <string>
 #include <list>

--- a/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
@@ -2,7 +2,8 @@
 #include "share/field/field_utils.hpp"
 #include "share/util/eamxx_array_utils.hpp"
 #include "share/util/eamxx_bfbhash.hpp"
-#include "ekat/ekat_assert.hpp"
+
+#include <ekat_assert.hpp>
 
 #include <cstdint>
 #include <iomanip>

--- a/components/eamxx/src/share/atm_process/atmosphere_process_utils.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_utils.hpp
@@ -1,7 +1,7 @@
 #ifndef SCREAM_ATMOSPHERE_PROCESS_UTILS_HPP
 #define SCREAM_ATMOSPHERE_PROCESS_UTILS_HPP
 
-#include "ekat/ekat_assert.hpp"
+#include <ekat_assert.hpp>
 
 #include <string>
 

--- a/components/eamxx/src/share/atm_process/atmosphere_process_utils.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_utils.hpp
@@ -30,7 +30,7 @@ inline std::string e2str (const AtmosphereProcessType ap_type) {
     case AtmosphereProcessType::Group:                   return "Atmosphere Process Group";
     case AtmosphereProcessType::Diagnostic:              return "Atmosphere Diagnostic";
     default:
-      ekat::error::runtime_abort("Error! Unrecognized atmosphere process type.\n");
+      EKAT_ERROR_MSG("Error! Unrecognized atmosphere process type.\n");
   }
   return "INVALID";
 }

--- a/components/eamxx/src/share/eamxx_config.cpp
+++ b/components/eamxx/src/share/eamxx_config.cpp
@@ -2,14 +2,19 @@
 #include "eamxx_session.hpp"
 #include "eamxx_types.hpp"
 
-#include "ekat/util/ekat_arch.hpp"
-#include "ekat/ekat_assert.hpp"
+#include <ekat_kokkos_session.hpp>
+#include <ekat_arch.hpp>
+#include <ekat_fpe.hpp>
+#include <ekat_assert.hpp>
 
 namespace scream {
 
 std::string eamxx_config_string() {
   std::string config = "\n-------- EKAT CONFIGS --------\n\n";
-  config += ekat::ekat_config_string();
+  config += ekat::active_avx_string ();
+  config += ekat::compiler_id_string ();
+  config += ekat::fpe_config_string ();
+  config += ekat::kokkos_config_string();
   config += "\n-------- SCREAM CONFIGS --------\n\n";
   config += " sizeof(Real) = " + std::to_string(sizeof(Real)) + "\n";
   config += " default pack size = " + std::to_string(SCREAM_PACK_SIZE) + "\n";

--- a/components/eamxx/src/share/eamxx_session.cpp
+++ b/components/eamxx/src/share/eamxx_session.cpp
@@ -1,8 +1,9 @@
 #include "eamxx_session.hpp"
 #include "eamxx_config.hpp"
 
-#include "ekat/ekat_assert.hpp"
-#include "ekat/ekat_session.hpp"
+#include <ekat_fpe.hpp>
+#include <ekat_assert.hpp>
+#include <ekat_kokkos_session.hpp>
 
 #include <iostream>
 #include <cfenv>
@@ -20,7 +21,7 @@ int get_default_fpes () {
 }
 
 void initialize_eamxx_session (bool print_config) {
-  ekat::initialize_ekat_session(print_config);
+  ekat::initialize_kokkos_session(print_config);
 
   // Make sure scream only has its FPEs
   ekat::disable_all_fpes();
@@ -31,7 +32,7 @@ void initialize_eamxx_session (bool print_config) {
 }
 
 void initialize_eamxx_session (int argc, char **argv, bool print_config) {
-  ekat::initialize_ekat_session(argc,argv,print_config);
+  ekat::initialize_kokkos_session(argc,argv,print_config);
 
   // Make sure scream only has its FPEs
   ekat::disable_all_fpes();
@@ -43,7 +44,7 @@ void initialize_eamxx_session (int argc, char **argv, bool print_config) {
 
 extern "C" {
 void finalize_eamxx_session () {
-  ekat::finalize_ekat_session();
+  ekat::finalize_kokkos_session();
 }
 } // extern "C"
 

--- a/components/eamxx/src/share/eamxx_types.hpp
+++ b/components/eamxx/src/share/eamxx_types.hpp
@@ -1,15 +1,15 @@
 #ifndef SCREAM_TYPES_HPP
 #define SCREAM_TYPES_HPP
 
-#include "ekat/ekat.hpp"
-#include "ekat/kokkos/ekat_kokkos_types.hpp"
 #include "eamxx_config.h"
+
+#include <ekat_kokkos_types.hpp>
 
 namespace scream
 {
 
 // Scalar types
-using ekat::Int;
+using Int = int;
 #ifdef SCREAM_DOUBLE_PRECISION
 using Real = double;
 #else

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -5,8 +5,8 @@
 #include "share/util/eamxx_combine_ops.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/std_meta/ekat_std_type_traits.hpp"
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_std_type_traits.hpp>
+#include <ekat_subview_utils.hpp>
 
 #include <memory>   // For std::shared_ptr
 #include <string>

--- a/components/eamxx/src/share/field/field_alloc_prop.hpp
+++ b/components/eamxx/src/share/field/field_alloc_prop.hpp
@@ -4,8 +4,8 @@
 #include "share/field/field_layout.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_scalar_traits.hpp"
-#include "ekat/ekat_assert.hpp"
+#include <ekat_scalar_traits.hpp>
+#include <ekat_assert.hpp>
 
 #include <vector>
 #include <memory>

--- a/components/eamxx/src/share/field/field_group_info.hpp
+++ b/components/eamxx/src/share/field/field_group_info.hpp
@@ -1,7 +1,7 @@
 #ifndef SCREAM_FIELD_GROUP_INFO_HPP
 #define SCREAM_FIELD_GROUP_INFO_HPP
 
-#include <ekat/util/ekat_string_utils.hpp>
+#include <ekat_string_utils.hpp>
 
 #include <list>
 #include <map>

--- a/components/eamxx/src/share/field/field_header.cpp
+++ b/components/eamxx/src/share/field/field_header.cpp
@@ -1,6 +1,6 @@
 #include "share/field/field_header.hpp"
 
-#include "ekat/std_meta/ekat_std_utils.hpp"
+#include <ekat_std_utils.hpp>
 
 namespace scream {
 

--- a/components/eamxx/src/share/field/field_header.hpp
+++ b/components/eamxx/src/share/field/field_header.hpp
@@ -6,9 +6,9 @@
 #include "share/field/field_alloc_prop.hpp"
 #include "share/util/eamxx_family_tracking.hpp"
 #include "share/eamxx_types.hpp"
-
 #include "share/util/eamxx_time_stamp.hpp"
-#include "ekat/std_meta/ekat_std_any.hpp"
+
+#include <ekat_std_any.hpp>
 
 #include <vector>
 #include <map>

--- a/components/eamxx/src/share/field/field_identifier.cpp
+++ b/components/eamxx/src/share/field/field_identifier.cpp
@@ -1,5 +1,6 @@
 #include "share/field/field_identifier.hpp"
-#include "ekat/util/ekat_string_utils.hpp"
+
+#include <ekat_string_utils.hpp>
 
 namespace scream
 {

--- a/components/eamxx/src/share/field/field_identifier.hpp
+++ b/components/eamxx/src/share/field/field_identifier.hpp
@@ -4,9 +4,9 @@
 #include "share/field/field_layout.hpp"
 #include "share/util/eamxx_data_type.hpp"
 
-#include "ekat/util/ekat_string_utils.hpp"
-#include "ekat/util/ekat_units.hpp"
-#include "ekat/util/ekat_meta_utils.hpp"
+#include <ekat_string_utils.hpp>
+#include <ekat_units.hpp>
+#include <ekat_meta_utils.hpp>
 
 #include <vector>
 

--- a/components/eamxx/src/share/field/field_impl.hpp
+++ b/components/eamxx/src/share/field/field_impl.hpp
@@ -6,7 +6,7 @@
 #include "share/util/eamxx_array_utils.hpp"
 #include "share/util/eamxx_universal_constants.hpp"
 
-#include <ekat/ekat_type_traits.hpp>
+#include <ekat_type_traits.hpp>
 
 namespace scream
 {

--- a/components/eamxx/src/share/field/field_impl.hpp
+++ b/components/eamxx/src/share/field/field_impl.hpp
@@ -337,21 +337,21 @@ deep_copy (const ST value) {
     case DataType::IntType:
       EKAT_REQUIRE_MSG( (std::is_convertible<ST,int>::value),
           "Error! Input value type is not convertible to field data type.\n"
-          "   - Input value type: " + ekat::ScalarTraits<ST>::name() + "\n"
+          "   - Input value type: " + std::string(typeid(ST).name()) + "\n"
           "   - Field data type : " + e2str(my_data_type) + "\n");
       deep_copy_impl<HD,false,int>(value,*this); // 2nd arg unused
       break;
     case DataType::FloatType:
       EKAT_REQUIRE_MSG( (std::is_convertible<ST,float>::value),
           "Error! Input value type is not convertible to field data type.\n"
-          "   - Input value type: " + ekat::ScalarTraits<ST>::name() + "\n"
+          "   - Input value type: " + std::string(typeid(ST).name()) + "\n"
           "   - Field data type : " + e2str(my_data_type) + "\n");
       deep_copy_impl<HD,false,float>(value,*this); // 2nd arg unused
       break;
     case DataType::DoubleType:
       EKAT_REQUIRE_MSG( (std::is_convertible<ST,double>::value),
           "Error! Input value type is not convertible to field data type.\n"
-          "   - Input value type: " + ekat::ScalarTraits<ST>::name() + "\n"
+          "   - Input value type: " + std::string(typeid(ST).name()) + "\n"
           "   - Field data type : " + e2str(my_data_type) + "\n");
       deep_copy_impl<HD,false,double>(value,*this); // 2nd arg unused
       break;
@@ -372,21 +372,21 @@ deep_copy (const ST value, const Field& mask)
     case DataType::IntType:
       EKAT_REQUIRE_MSG( (std::is_convertible<ST,int>::value),
           "Error! Input value type is not convertible to field data type.\n"
-          "   - Input value type: " + ekat::ScalarTraits<ST>::name() + "\n"
+          "   - Input value type: " + std::string(typeid(ST).name()) + "\n"
           "   - Field data type : " + e2str(my_data_type) + "\n");
       deep_copy_impl<HD,true,int>(value,mask);
       break;
     case DataType::FloatType:
       EKAT_REQUIRE_MSG( (std::is_convertible<ST,float>::value),
           "Error! Input value type is not convertible to field data type.\n"
-          "   - Input value type: " + ekat::ScalarTraits<ST>::name() + "\n"
+          "   - Input value type: " + std::string(typeid(ST).name()) + "\n"
           "   - Field data type : " + e2str(my_data_type) + "\n");
       deep_copy_impl<HD,true,float>(value,mask);
       break;
     case DataType::DoubleType:
       EKAT_REQUIRE_MSG( (std::is_convertible<ST,double>::value),
           "Error! Input value type is not convertible to field data type.\n"
-          "   - Input value type: " + ekat::ScalarTraits<ST>::name() + "\n"
+          "   - Input value type: " + std::string(typeid(ST).name()) + "\n"
           "   - Field data type : " + e2str(my_data_type) + "\n");
       deep_copy_impl<HD,true,double>(value,mask);
       break;

--- a/components/eamxx/src/share/field/field_impl_details.hpp
+++ b/components/eamxx/src/share/field/field_impl_details.hpp
@@ -1,7 +1,7 @@
 #ifndef SCREAM_FIELD_IMPL_DETAILS_HPP
 #define SCREAM_FIELD_IMPL_DETAILS_HPP
 
-#include <ekat/kokkos/ekat_kokkos_types.hpp>
+#include <ekat_kokkos_types.hpp>
 
 #include <vector>
 

--- a/components/eamxx/src/share/field/field_layout.cpp
+++ b/components/eamxx/src/share/field/field_layout.cpp
@@ -1,6 +1,6 @@
 #include "field_layout.hpp"
 
-#include <ekat/util/ekat_string_utils.hpp>
+#include <ekat_string_utils.hpp>
 
 namespace scream
 {

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -4,9 +4,9 @@
 #include "share/field/field_tag.hpp"
 #include "share/eamxx_types.hpp"
 
-#include <ekat/std_meta/ekat_std_utils.hpp>
-#include <ekat/util/ekat_string_utils.hpp>
-#include <ekat/ekat_assert.hpp>
+#include <ekat_std_utils.hpp>
+#include <ekat_string_utils.hpp>
+#include <ekat_assert.hpp>
 
 #include <string>
 #include <vector>

--- a/components/eamxx/src/share/field/field_tag.hpp
+++ b/components/eamxx/src/share/field/field_tag.hpp
@@ -1,7 +1,7 @@
 #ifndef SCREAM_FIELD_TAG_HPP
 #define SCREAM_FIELD_TAG_HPP
 
-#include "ekat/ekat_assert.hpp"
+#include <ekat_assert.hpp>
 
 #include <string>
 #include <vector>

--- a/components/eamxx/src/share/field/field_tracking.hpp
+++ b/components/eamxx/src/share/field/field_tracking.hpp
@@ -6,9 +6,9 @@
 #include "share/util/eamxx_time_stamp.hpp"
 #include "share/util/eamxx_family_tracking.hpp"
 
-#include "ekat/util/ekat_string_utils.hpp"
-#include "ekat/std_meta/ekat_std_utils.hpp"
-#include "ekat/ekat_assert.hpp"
+#include <ekat_string_utils.hpp>
+#include <ekat_std_utils.hpp>
+#include <ekat_assert.hpp>
 
 #include <memory>   // For std::weak_ptr
 #include <string>

--- a/components/eamxx/src/share/field/field_utils_impl.hpp
+++ b/components/eamxx/src/share/field/field_utils_impl.hpp
@@ -3,9 +3,9 @@
 
 #include "share/field/field.hpp"
 
-#include "ekat/mpi/ekat_comm.hpp"
 
 #include "ekat/kokkos/ekat_kokkos_utils.hpp"
+#include <ekat_comm.hpp>
 
 #include <limits>
 #include <type_traits>

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -2,7 +2,7 @@
 
 #include "share/field/field_utils.hpp"
 
-#include <ekat/ekat_assert.hpp>
+#include <ekat_assert.hpp>
 
 #include <algorithm>
 #include <cstring>

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -1,12 +1,12 @@
 #ifndef SCREAM_ABSTRACT_GRID_HPP
 #define SCREAM_ABSTRACT_GRID_HPP
 
-#include "ekat/std_meta/ekat_std_enable_shared_from_this.hpp"
 #include "share/grid/grid_utils.hpp"
 #include "share/field/field_layout.hpp"
 #include "share/field/field.hpp"
 
-#include "ekat/mpi//ekat_comm.hpp"
+#include <ekat_std_enable_shared_from_this.hpp>
+#include <ekat_comm.hpp>
 
 #include <map>
 #include <list>

--- a/components/eamxx/src/share/grid/grid_import_export.hpp
+++ b/components/eamxx/src/share/grid/grid_import_export.hpp
@@ -5,7 +5,8 @@
 #include "share/eamxx_types.hpp"       // For KokkosTypes
 #include "share/util/eamxx_utils.hpp"  // For check_mpi_call
 
-#include <ekat/mpi/ekat_comm.hpp>
+#include <ekat_comm.hpp>
+
 #include <mpi.h> // We do some direct MPI calls
 #include <memory>
 #include <map>

--- a/components/eamxx/src/share/grid/grids_manager.hpp
+++ b/components/eamxx/src/share/grid/grids_manager.hpp
@@ -5,11 +5,11 @@
 #include "share/grid/remap/abstract_remapper.hpp"
 #include "share/grid/remap/identity_remapper.hpp"
 
-#include "ekat/util/ekat_factory.hpp"
-#include "ekat/util/ekat_string_utils.hpp"
-#include "ekat/ekat_parameter_list.hpp"
-#include "ekat/ekat_assert.hpp"
-#include "ekat/mpi/ekat_comm.hpp"
+#include <ekat_factory.hpp>
+#include <ekat_string_utils.hpp>
+#include <ekat_parameter_list.hpp>
+#include <ekat_assert.hpp>
+#include <ekat_comm.hpp>
 
 #include <map>
 #include <set>

--- a/components/eamxx/src/share/grid/mesh_free_grids_manager.cpp
+++ b/components/eamxx/src/share/grid/mesh_free_grids_manager.cpp
@@ -8,7 +8,7 @@
 
 #include "physics/share/physics_constants.hpp"
 
-#include "ekat/std_meta/ekat_std_utils.hpp"
+#include <ekat_std_utils.hpp>
 
 #include <memory>
 #include <numeric>

--- a/components/eamxx/src/share/grid/mesh_free_grids_manager.cpp
+++ b/components/eamxx/src/share/grid/mesh_free_grids_manager.cpp
@@ -159,12 +159,13 @@ add_geo_data (const nonconstgrid_ptr_type& grid) const
     auto lev  = grid->create_geometry_data("lev" ,  layout_mid, units);
     auto ilev = grid->create_geometry_data("ilev" , layout_int, units);
 
-    lat.deep_copy(ekat::ScalarTraits<Real>::invalid());
-    lon.deep_copy(ekat::ScalarTraits<Real>::invalid());
-    hyam.deep_copy(ekat::ScalarTraits<Real>::invalid());
-    hybm.deep_copy(ekat::ScalarTraits<Real>::invalid());
-    lev.deep_copy(ekat::ScalarTraits<Real>::invalid());
-    ilev.deep_copy(ekat::ScalarTraits<Real>::invalid());
+    const auto invalid = Kokkos::Experimental::quiet_NaN_v<Real>;
+    lat.deep_copy(invalid);;
+    lon.deep_copy(invalid);
+    hyam.deep_copy(invalid);
+    hybm.deep_copy(invalid);
+    lev.deep_copy(invalid);
+    ilev.deep_copy(invalid);
     lat.sync_to_dev();
     lon.sync_to_dev();
     hyam.sync_to_dev();

--- a/components/eamxx/src/share/grid/mesh_free_grids_manager.hpp
+++ b/components/eamxx/src/share/grid/mesh_free_grids_manager.hpp
@@ -3,7 +3,7 @@
 
 #include "share/grid/grids_manager.hpp"
 
-#include "ekat/mpi/ekat_comm.hpp"
+#include <ekat_comm.hpp>
 
 namespace scream {
 

--- a/components/eamxx/src/share/grid/point_grid.cpp
+++ b/components/eamxx/src/share/grid/point_grid.cpp
@@ -1,5 +1,4 @@
 #include "share/grid/point_grid.hpp"
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "physics/share/physics_constants.hpp"
 
 #include <numeric>

--- a/components/eamxx/src/share/grid/point_grid.hpp
+++ b/components/eamxx/src/share/grid/point_grid.hpp
@@ -1,11 +1,12 @@
 #ifndef SCREAM_POINT_GRID_HPP
 #define SCREAM_POINT_GRID_HPP
 
-#include <memory>
 #include "share/grid/abstract_grid.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/mpi/ekat_comm.hpp"
+#include <ekat_comm.hpp>
+
+#include <memory>
 
 namespace scream
 {

--- a/components/eamxx/src/share/grid/remap/abstract_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/abstract_remapper.hpp
@@ -4,10 +4,10 @@
 #include "share/field/field.hpp"
 #include "share/grid/abstract_grid.hpp"
 
-#include "ekat/util/ekat_factory.hpp"
-#include "ekat/util/ekat_string_utils.hpp"
-#include "ekat/std_meta/ekat_std_utils.hpp"
-#include "ekat/ekat_parameter_list.hpp"
+#include <ekat_factory.hpp>
+#include <ekat_string_utils.hpp>
+#include <ekat_std_utils.hpp>
+#include <ekat_parameter_list.hpp>
 
 namespace scream
 {

--- a/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
@@ -5,7 +5,7 @@
 #include "share/io/scorpio_input.hpp"
 #include "share/field/field.hpp"
 
-#include <ekat/kokkos/ekat_kokkos_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 #include <ekat_pack_utils.hpp>
 
 #include <numeric>
@@ -267,7 +267,7 @@ rescale_masked_fields (const Field& x, const Field& mask) const
 {
   using RangePolicy = typename KT::RangePolicy;
   using MemberType  = typename KT::MemberType;
-  using ESU         = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
+  using TPF         = ekat::TeamPolicyFactory<DefaultDevice::execution_space>;
   using Pack        = ekat::Pack<Real,PackSize>;
   using PackInfo    = ekat::PackInfo<PackSize>;
 
@@ -314,7 +314,7 @@ rescale_masked_fields (const Field& x, const Field& mask) const
         mask_2d = mask.get_view<const Pack**>();
       }
       const int dim1 = PackInfo::num_packs(layout.dim(1));
-      auto policy = ESU::get_default_team_policy(ncols,dim1);
+      auto policy = TPF::get_default_team_policy(ncols,dim1);
       Kokkos::parallel_for(policy,
                            KOKKOS_LAMBDA(const MemberType& team) {
         const auto icol = team.league_rank();
@@ -356,7 +356,7 @@ rescale_masked_fields (const Field& x, const Field& mask) const
       }
       const int dim1 = layout.dim(1);
       const int dim2 = PackInfo::num_packs(layout.dim(2));
-      auto policy = ESU::get_default_team_policy(ncols,dim1*dim2);
+      auto policy = TPF::get_default_team_policy(ncols,dim1*dim2);
       Kokkos::parallel_for(policy,
                            KOKKOS_LAMBDA(const MemberType& team) {
         const auto icol = team.league_rank();
@@ -405,7 +405,7 @@ rescale_masked_fields (const Field& x, const Field& mask) const
       const int dim1 = layout.dim(1);
       const int dim2 = layout.dim(2);
       const int dim3 = PackInfo::num_packs(layout.dim(3));
-      auto policy = ESU::get_default_team_policy(ncols,dim1*dim2*dim3);
+      auto policy = TPF::get_default_team_policy(ncols,dim1*dim2*dim3);
       Kokkos::parallel_for(policy,
                            KOKKOS_LAMBDA(const MemberType& team) {
         const auto icol = team.league_rank();
@@ -449,7 +449,7 @@ local_mat_vec (const Field& x, const Field& y, const Field& mask) const
 {
   using RangePolicy = typename KT::RangePolicy;
   using MemberType  = typename KT::MemberType;
-  using ESU         = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
+  using TPF         = ekat::TeamPolicyFactory<DefaultDevice::execution_space>;
   using Pack        = ekat::Pack<Real,PackSize>;
   using PackInfo    = ekat::PackInfo<PackSize>;
 
@@ -497,7 +497,7 @@ local_mat_vec (const Field& x, const Field& y, const Field& mask) const
         mask_2d = mask.get_view<const Pack**>();
       }
       const int dim1 = PackInfo::num_packs(src_layout.dim(1));
-      auto policy = ESU::get_default_team_policy(nrows,dim1);
+      auto policy = TPF::get_default_team_policy(nrows,dim1);
       Kokkos::parallel_for(policy,
                            KOKKOS_LAMBDA(const MemberType& team) {
         const auto row = team.league_rank();
@@ -533,7 +533,7 @@ local_mat_vec (const Field& x, const Field& y, const Field& mask) const
       }
       const int dim1 = src_layout.dim(1);
       const int dim2 = PackInfo::num_packs(src_layout.dim(2));
-      auto policy = ESU::get_default_team_policy(nrows,dim1*dim2);
+      auto policy = TPF::get_default_team_policy(nrows,dim1*dim2);
       Kokkos::parallel_for(policy,
                            KOKKOS_LAMBDA(const MemberType& team) {
         const auto row = team.league_rank();
@@ -572,7 +572,7 @@ local_mat_vec (const Field& x, const Field& y, const Field& mask) const
       const int dim1 = src_layout.dim(1);
       const int dim2 = src_layout.dim(2);
       const int dim3 = PackInfo::num_packs(src_layout.dim(3));
-      auto policy = ESU::get_default_team_policy(nrows,dim1*dim2*dim3);
+      auto policy = TPF::get_default_team_policy(nrows,dim1*dim2*dim3);
       Kokkos::parallel_for(policy,
                            KOKKOS_LAMBDA(const MemberType& team) {
         const auto row = team.league_rank();
@@ -605,7 +605,7 @@ void CoarseningRemapper::pack_and_send ()
 {
   using RangePolicy = typename KT::RangePolicy;
   using MemberType  = typename KT::MemberType;
-  using ESU         = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
+  using TPF         = ekat::TeamPolicyFactory<DefaultDevice::execution_space>;
 
   const int num_send_gids = m_ov_coarse_grid->get_num_local_dofs();
   const auto pid_lid_start = m_send_pid_lids_start;
@@ -642,7 +642,7 @@ void CoarseningRemapper::pack_and_send ()
       {
         auto v = f.get_view<const Real**>();
         const int dim1 = fl.dim(1);
-        auto policy = ESU::get_default_team_policy(num_send_gids,dim1);
+        auto policy = TPF::get_default_team_policy(num_send_gids,dim1);
         Kokkos::parallel_for(policy,
                              KOKKOS_LAMBDA(const MemberType& team){
           const int i = team.league_rank();
@@ -662,7 +662,7 @@ void CoarseningRemapper::pack_and_send ()
         auto v = f.get_view<const Real***>();
         const int dim1 = fl.dim(1);
         const int dim2 = fl.dim(2);
-        auto policy = ESU::get_default_team_policy(num_send_gids,dim1*dim2);
+        auto policy = TPF::get_default_team_policy(num_send_gids,dim1*dim2);
         Kokkos::parallel_for(policy,
                              KOKKOS_LAMBDA(const MemberType& team){
           const int i = team.league_rank();
@@ -685,7 +685,7 @@ void CoarseningRemapper::pack_and_send ()
         const int dim1 = fl.dim(1);
         const int dim2 = fl.dim(2);
         const int dim3 = fl.dim(3);
-        auto policy = ESU::get_default_team_policy(num_send_gids,dim1*dim2*dim3);
+        auto policy = TPF::get_default_team_policy(num_send_gids,dim1*dim2*dim3);
         Kokkos::parallel_for(policy,
                              KOKKOS_LAMBDA(const MemberType& team){
           const int i = team.league_rank();
@@ -743,7 +743,7 @@ void CoarseningRemapper::recv_and_unpack ()
 
   using RangePolicy = typename KT::RangePolicy;
   using MemberType  = typename KT::MemberType;
-  using ESU         = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
+  using TPF         = ekat::TeamPolicyFactory<DefaultDevice::execution_space>;
 
   const int num_tgt_dofs = m_tgt_grid->get_num_local_dofs();
 
@@ -780,7 +780,7 @@ void CoarseningRemapper::recv_and_unpack ()
       {
         auto v = f.get_view<Real**>();
         const int dim1 = fl.dim(1);
-        auto policy = ESU::get_default_team_policy(num_tgt_dofs,dim1);
+        auto policy = TPF::get_default_team_policy(num_tgt_dofs,dim1);
         Kokkos::parallel_for(policy,
                              KOKKOS_LAMBDA(const MemberType& team){
           const int lid = team.league_rank();
@@ -802,7 +802,7 @@ void CoarseningRemapper::recv_and_unpack ()
         auto v = f.get_view<Real***>();
         const int dim1 = fl.dim(1);
         const int dim2 = fl.dims().back();
-        auto policy = ESU::get_default_team_policy(num_tgt_dofs,dim2*dim1);
+        auto policy = TPF::get_default_team_policy(num_tgt_dofs,dim2*dim1);
         Kokkos::parallel_for(policy,
                              KOKKOS_LAMBDA(const MemberType& team){
           const int lid = team.league_rank();
@@ -829,7 +829,7 @@ void CoarseningRemapper::recv_and_unpack ()
         const int dim1 = fl.dim(1);
         const int dim2 = fl.dim(2);
         const int dim3 = fl.dim(3);
-        auto policy = ESU::get_default_team_policy(num_tgt_dofs,dim1*dim2*dim3);
+        auto policy = TPF::get_default_team_policy(num_tgt_dofs,dim1*dim2*dim3);
         Kokkos::parallel_for(policy,
                              KOKKOS_LAMBDA(const MemberType& team){
           const int lid = team.league_rank();

--- a/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/coarsening_remapper.cpp
@@ -6,7 +6,7 @@
 #include "share/field/field.hpp"
 
 #include <ekat/kokkos/ekat_kokkos_utils.hpp>
-#include <ekat/ekat_pack_utils.hpp>
+#include <ekat_pack_utils.hpp>
 
 #include <numeric>
 

--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
@@ -5,7 +5,7 @@
 #include "share/io/scorpio_input.hpp"
 
 #include <ekat/kokkos/ekat_kokkos_utils.hpp>
-#include <ekat/ekat_pack_utils.hpp>
+#include <ekat_pack_utils.hpp>
 #include <numeric>
 
 namespace scream

--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_base.cpp
@@ -4,7 +4,7 @@
 #include "share/grid/grid_import_export.hpp"
 #include "share/io/scorpio_input.hpp"
 
-#include <ekat/kokkos/ekat_kokkos_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 #include <ekat_pack_utils.hpp>
 #include <numeric>
 
@@ -132,7 +132,7 @@ local_mat_vec (const Field& x, const Field& y) const
 {
   using RangePolicy = typename KT::RangePolicy;
   using MemberType  = typename KT::MemberType;
-  using ESU         = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
+  using TPF         = ekat::TeamPolicyFactory<DefaultDevice::execution_space>;
   using Pack        = ekat::Pack<Real,PackSize>;
   using PackInfo    = ekat::PackInfo<PackSize>;
 
@@ -173,7 +173,7 @@ local_mat_vec (const Field& x, const Field& y) const
       auto x_view = x.get_view<const Pack**>();
       auto y_view = y.get_view<      Pack**>();
       const int dim1 = PackInfo::num_packs(src_layout.dim(1));
-      auto policy = ESU::get_default_team_policy(nrows,dim1);
+      auto policy = TPF::get_default_team_policy(nrows,dim1);
       Kokkos::parallel_for(policy,
                            KOKKOS_LAMBDA(const MemberType& team) {
         const auto row = team.league_rank();
@@ -196,7 +196,7 @@ local_mat_vec (const Field& x, const Field& y) const
       auto y_view = y.get_view<      Pack***>();
       const int dim1 = src_layout.dim(1);
       const int dim2 = PackInfo::num_packs(src_layout.dim(2));
-      auto policy = ESU::get_default_team_policy(nrows,dim1*dim2);
+      auto policy = TPF::get_default_team_policy(nrows,dim1*dim2);
       Kokkos::parallel_for(policy,
                            KOKKOS_LAMBDA(const MemberType& team) {
         const auto row = team.league_rank();
@@ -222,7 +222,7 @@ local_mat_vec (const Field& x, const Field& y) const
       const int dim1 = src_layout.dim(1);
       const int dim2 = src_layout.dim(2);
       const int dim3 = PackInfo::num_packs(src_layout.dim(3));
-      auto policy = ESU::get_default_team_policy(nrows,dim1*dim2*dim3);
+      auto policy = TPF::get_default_team_policy(nrows,dim1*dim2*dim3);
       Kokkos::parallel_for(policy,
                            KOKKOS_LAMBDA(const MemberType& team) {
         const auto row = team.league_rank();

--- a/components/eamxx/src/share/grid/remap/horiz_interp_remapper_data.hpp
+++ b/components/eamxx/src/share/grid/remap/horiz_interp_remapper_data.hpp
@@ -4,7 +4,7 @@
 #include "share/grid/abstract_grid.hpp"
 #include "share/grid/remap/abstract_remapper.hpp"
 
-#include <ekat/mpi/ekat_comm.hpp>
+#include <ekat_comm.hpp>
 
 #include <memory>
 #include <map>

--- a/components/eamxx/src/share/grid/remap/refining_remapper_p2p.cpp
+++ b/components/eamxx/src/share/grid/remap/refining_remapper_p2p.cpp
@@ -5,7 +5,7 @@
 #include "share/io/scorpio_input.hpp"
 #include "share/util/eamxx_utils.hpp"
 
-#include <ekat/kokkos/ekat_kokkos_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 #include <ekat_pack_utils.hpp>
 
 #include <numeric>
@@ -164,7 +164,7 @@ void RefiningRemapperP2P::pack_and_send ()
 {
   using RangePolicy = typename KT::RangePolicy;
   using TeamMember  = typename KT::MemberType;
-  using ESU         = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
+  using TPF         = ekat::TeamPolicyFactory<typename KT::ExeSpace>;
 
   constexpr auto COL = ShortFieldTagsNames::COL;
 
@@ -204,7 +204,7 @@ void RefiningRemapperP2P::pack_and_send ()
       {
         const auto v = f.get_view<const Real**>();
         const int dim1 = fl.dim(1);
-        auto policy = ESU::get_default_team_policy(num_exports,dim1);
+        auto policy = TPF::get_default_team_policy(num_exports,dim1);
         auto pack = KOKKOS_LAMBDA(const TeamMember& team) {
           const int iexp = team.league_rank();
           const int icol = export_lids(iexp);
@@ -229,7 +229,7 @@ void RefiningRemapperP2P::pack_and_send ()
         const int dim1 = fl.dim(1);
         const int dim2 = fl.dim(2);
         const int f_col_size = dim1*dim2;
-        auto policy = ESU::get_default_team_policy(num_exports,dim1*dim2);
+        auto policy = TPF::get_default_team_policy(num_exports,dim1*dim2);
         auto pack = KOKKOS_LAMBDA(const TeamMember& team) {
           const int iexp = team.league_rank();
           const int icol = export_lids(iexp);
@@ -257,7 +257,7 @@ void RefiningRemapperP2P::pack_and_send ()
         const int dim2 = fl.dim(2);
         const int dim3 = fl.dim(3);
         const int f_col_size = dim1*dim2*dim3;
-        auto policy = ESU::get_default_team_policy(num_exports,dim1*dim2*dim3);
+        auto policy = TPF::get_default_team_policy(num_exports,dim1*dim2*dim3);
         auto pack = KOKKOS_LAMBDA(const TeamMember& team) {
           const int iexp = team.league_rank();
           const int icol = export_lids(iexp);
@@ -314,7 +314,7 @@ void RefiningRemapperP2P::recv_and_unpack ()
 
   using RangePolicy = typename KT::RangePolicy;
   using TeamMember  = typename KT::MemberType;
-  using ESU         = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
+  using TPF         = ekat::TeamPolicyFactory<typename KT::ExeSpace>;
 
   constexpr auto COL = ShortFieldTagsNames::COL;
 
@@ -354,7 +354,7 @@ void RefiningRemapperP2P::recv_and_unpack ()
       {
         auto v = f.get_view<Real**>();
         const int dim1 = fl.dim(1);
-        auto policy = ESU::get_default_team_policy(num_imports,dim1);
+        auto policy = TPF::get_default_team_policy(num_imports,dim1);
         auto unpack = KOKKOS_LAMBDA (const TeamMember& team) {
           const int idx  = team.league_rank();
           const int pid  = import_pids(idx);
@@ -379,7 +379,7 @@ void RefiningRemapperP2P::recv_and_unpack ()
         const int dim1 = fl.dim(1);
         const int dim2 = fl.dim(2);
         const int f_col_size = dim1*dim2;
-        auto policy = ESU::get_default_team_policy(num_imports,dim1*dim2);
+        auto policy = TPF::get_default_team_policy(num_imports,dim1*dim2);
         auto unpack = KOKKOS_LAMBDA (const TeamMember& team) {
           const int idx  = team.league_rank();
           const int pid  = import_pids(idx);
@@ -407,7 +407,7 @@ void RefiningRemapperP2P::recv_and_unpack ()
         const int dim2 = fl.dim(2);
         const int dim3 = fl.dim(3);
         const int f_col_size = dim1*dim2*dim3;
-        auto policy = ESU::get_default_team_policy(num_imports,dim1*dim2*dim3);
+        auto policy = TPF::get_default_team_policy(num_imports,dim1*dim2*dim3);
         auto unpack = KOKKOS_LAMBDA (const TeamMember& team) {
           const int idx  = team.league_rank();
           const int pid  = import_pids(idx);

--- a/components/eamxx/src/share/grid/remap/refining_remapper_p2p.cpp
+++ b/components/eamxx/src/share/grid/remap/refining_remapper_p2p.cpp
@@ -6,7 +6,7 @@
 #include "share/util/eamxx_utils.hpp"
 
 #include <ekat/kokkos/ekat_kokkos_utils.hpp>
-#include <ekat/ekat_pack_utils.hpp>
+#include <ekat_pack_utils.hpp>
 
 #include <numeric>
 

--- a/components/eamxx/src/share/grid/remap/refining_remapper_p2p.hpp
+++ b/components/eamxx/src/share/grid/remap/refining_remapper_p2p.hpp
@@ -5,7 +5,7 @@
 #include "share/grid/remap/horiz_interp_remapper_base.hpp"
 #include "eamxx_config.h"
 
-#include "ekat/ekat_pack.hpp"
+#include <ekat_pack.hpp>
 
 #include <mpi.h>
 

--- a/components/eamxx/src/share/grid/remap/refining_remapper_rma.cpp
+++ b/components/eamxx/src/share/grid/remap/refining_remapper_rma.cpp
@@ -3,7 +3,6 @@
 #include "share/grid/point_grid.hpp"
 #include "share/io/scorpio_input.hpp"
 
-#include <ekat/kokkos/ekat_kokkos_utils.hpp>
 #include <ekat_pack_utils.hpp>
 
 #include <numeric>

--- a/components/eamxx/src/share/grid/remap/refining_remapper_rma.cpp
+++ b/components/eamxx/src/share/grid/remap/refining_remapper_rma.cpp
@@ -4,7 +4,7 @@
 #include "share/io/scorpio_input.hpp"
 
 #include <ekat/kokkos/ekat_kokkos_utils.hpp>
-#include <ekat/ekat_pack_utils.hpp>
+#include <ekat_pack_utils.hpp>
 
 #include <numeric>
 

--- a/components/eamxx/src/share/grid/remap/refining_remapper_rma.hpp
+++ b/components/eamxx/src/share/grid/remap/refining_remapper_rma.hpp
@@ -6,7 +6,7 @@
 #include "share/util/eamxx_utils.hpp"
 #include "eamxx_config.h"
 
-#include "ekat/ekat_pack.hpp"
+#include <ekat_pack.hpp>
 
 #include <mpi.h>
 

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -7,10 +7,10 @@
 #include "share/util/eamxx_universal_constants.hpp"
 #include "share/io/eamxx_scorpio_interface.hpp"
 
-#include <ekat/util/ekat_units.hpp>
 #include <ekat/kokkos/ekat_kokkos_utils.hpp>
-#include <ekat/ekat_pack_utils.hpp>
-#include <ekat/ekat_pack_kokkos.hpp>
+#include <ekat_units.hpp>
+#include <ekat_pack_utils.hpp>
+#include <ekat_pack_kokkos.hpp>
 
 #include <numeric>
 

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -82,7 +82,7 @@ set_extrapolation_type (const ExtrapType etype, const TopBot where)
 void VerticalRemapper::
 set_mask_value (const Real mask_val)
 {
-  EKAT_REQUIRE_MSG (not ekat::is_invalid(mask_val),
+  EKAT_REQUIRE_MSG (not Kokkos::isnan(mask_val),
       "[VerticalRemapper::set_mask_value] Error! Input mask value must be a valid number.\n");
 
   m_mask_val = mask_val;

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
@@ -3,7 +3,7 @@
 
 #include "share/grid/remap/abstract_remapper.hpp"
 
-#include <ekat/util/ekat_lin_interp.hpp>
+#include <ekat_lin_interp.hpp>
 
 namespace scream
 {

--- a/components/eamxx/src/share/grid/se_grid.cpp
+++ b/components/eamxx/src/share/grid/se_grid.cpp
@@ -1,7 +1,7 @@
 #include "share/grid/se_grid.hpp"
 #include "share/field/field_utils.hpp"
 
-#include <ekat/kokkos/ekat_subview_utils.hpp>
+#include <ekat_subview_utils.hpp>
 
 namespace scream {
 

--- a/components/eamxx/src/share/io/CMakeLists.txt
+++ b/components/eamxx/src/share/io/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(eamxx_scorpio_interface
   eamxx_scorpio_types.cpp
   eamxx_scorpio_interface.cpp
 )
-target_link_libraries(eamxx_scorpio_interface PUBLIC ekat)
+target_link_libraries(eamxx_scorpio_interface PUBLIC ekat::AllLibs)
 target_link_libraries(eamxx_scorpio_interface PRIVATE pioc)
 target_include_directories(eamxx_scorpio_interface PUBLIC
   ${SCREAM_BIN_DIR}/src   # For eamxx_config.h

--- a/components/eamxx/src/share/io/eamxx_io_control.hpp
+++ b/components/eamxx/src/share/io/eamxx_io_control.hpp
@@ -3,7 +3,7 @@
 
 #include "share/util/eamxx_time_stamp.hpp"
 
-#include <ekat/ekat_assert.hpp>
+#include <ekat_assert.hpp>
 
 #include <string>
 

--- a/components/eamxx/src/share/io/eamxx_io_file_specs.hpp
+++ b/components/eamxx/src/share/io/eamxx_io_file_specs.hpp
@@ -5,7 +5,7 @@
 #include "share/io/eamxx_io_utils.hpp"
 #include "share/util/eamxx_time_stamp.hpp"
 
-#include <ekat/ekat_assert.hpp>
+#include <ekat_assert.hpp>
 
 #include <string>
 #include <limits>

--- a/components/eamxx/src/share/io/eamxx_io_utils.hpp
+++ b/components/eamxx/src/share/io/eamxx_io_utils.hpp
@@ -6,8 +6,8 @@
 #include "share/atm_process/atmosphere_diagnostic.hpp"
 #include "share/grid/abstract_grid.hpp"
 
-#include <ekat/util/ekat_string_utils.hpp>
-#include <ekat/mpi/ekat_comm.hpp>
+#include <ekat_string_utils.hpp>
+#include <ekat_comm.hpp>
 
 #include <string>
 #include <memory>

--- a/components/eamxx/src/share/io/eamxx_output_manager.cpp
+++ b/components/eamxx/src/share/io/eamxx_output_manager.cpp
@@ -5,9 +5,9 @@
 #include "share/util/eamxx_timing.hpp"
 #include "share/eamxx_config.hpp"
 
-#include "ekat/ekat_parameter_list.hpp"
-#include "ekat/mpi/ekat_comm.hpp"
-#include "ekat/util/ekat_string_utils.hpp"
+#include <ekat_parameter_list.hpp>
+#include <ekat_comm.hpp>
+#include <ekat_string_utils.hpp>
 
 #include <fstream>
 #include <memory>

--- a/components/eamxx/src/share/io/eamxx_output_manager.hpp
+++ b/components/eamxx/src/share/io/eamxx_output_manager.hpp
@@ -11,10 +11,9 @@
 #include "share/grid/grids_manager.hpp"
 #include "share/util/eamxx_time_stamp.hpp"
 
-#include "ekat/logging/ekat_logger.hpp"
-#include "ekat/mpi/ekat_comm.hpp"
-#include "ekat/ekat_parameter_list.hpp"
-#include "ekat/ekat_parse_yaml_file.hpp"
+#include <ekat_logger.hpp>
+#include <ekat_comm.hpp>
+#include <ekat_parameter_list.hpp>
 
 namespace scream
 {

--- a/components/eamxx/src/share/io/eamxx_scorpio_interface.cpp
+++ b/components/eamxx/src/share/io/eamxx_scorpio_interface.cpp
@@ -3,11 +3,13 @@
 
 #include "eamxx_config.h"
 
-#include <ekat/ekat_assert.hpp>
-#include <ekat/util/ekat_string_utils.hpp>
+#include <ekat_std_utils.hpp>
+#include <ekat_string_utils.hpp>
+#include <ekat_assert.hpp>
 
 #include <pio.h>
 
+#include <set>
 #include <numeric>
 
 namespace scream {

--- a/components/eamxx/src/share/io/eamxx_scorpio_interface.hpp
+++ b/components/eamxx/src/share/io/eamxx_scorpio_interface.hpp
@@ -3,8 +3,8 @@
 
 #include "eamxx_scorpio_types.hpp"
 
-#include <ekat/mpi/ekat_comm.hpp>
-#include <ekat/ekat_assert.hpp>
+#include <ekat_comm.hpp>
+#include <ekat_assert.hpp>
 
 #include <string>
 #include <vector>

--- a/components/eamxx/src/share/io/eamxx_scorpio_types.cpp
+++ b/components/eamxx/src/share/io/eamxx_scorpio_types.cpp
@@ -1,6 +1,6 @@
 #include "eamxx_scorpio_types.hpp"
 
-#include <ekat/ekat_assert.hpp>
+#include <ekat_assert.hpp>
 
 namespace scream {
 namespace scorpio {

--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -2,7 +2,7 @@
 
 #include "share/io/eamxx_scorpio_interface.hpp"
 
-#include <ekat/util/ekat_string_utils.hpp>
+#include <ekat_string_utils.hpp>
 
 #include <memory>
 #include <numeric>

--- a/components/eamxx/src/share/io/scorpio_input.hpp
+++ b/components/eamxx/src/share/io/scorpio_input.hpp
@@ -4,8 +4,8 @@
 #include "share/field/field_manager.hpp"
 #include "share/grid/abstract_grid.hpp"
 
-#include "ekat/ekat_parameter_list.hpp"
-#include "ekat/logging/ekat_logger.hpp"
+#include <ekat_parameter_list.hpp>
+#include <ekat_logger.hpp>
 
 /*  The AtmosphereInput class handles all input streams to SCREAM.
  *  It is important to note that there does not exist an InputManager,

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -8,9 +8,9 @@
 
 #include "diagnostics/register_diagnostics.hpp"
 
-#include "ekat/util/ekat_units.hpp"
-#include "ekat/util/ekat_string_utils.hpp"
-#include "ekat/std_meta/ekat_std_utils.hpp"
+#include <ekat_units.hpp>
+#include <ekat_string_utils.hpp>
+#include <ekat_std_utils.hpp>
 
 #include <numeric>
 #include <fstream>

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -10,8 +10,9 @@
 #include "share/util/eamxx_utils.hpp"
 #include "share/atm_process/atmosphere_diagnostic.hpp"
 
-#include "ekat/ekat_parameter_list.hpp"
-#include "ekat/mpi/ekat_comm.hpp"
+#include <ekat_parameter_list.hpp>
+#include <ekat_comm.hpp>
+
 /*  The AtmosphereOutput class handles an output stream in SCREAM.
  *  Typical usage is to register an AtmosphereOutput object with the OutputManager (see eamxx_output_manager.hpp
  *

--- a/components/eamxx/src/share/io/scorpio_scm_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_scm_input.cpp
@@ -4,7 +4,7 @@
 #include "share/io/eamxx_scorpio_interface.hpp"
 #include "share/grid/point_grid.hpp"
 
-#include <ekat/util/ekat_string_utils.hpp>
+#include <ekat_string_utils.hpp>
 
 #include <memory>
 

--- a/components/eamxx/src/share/io/scorpio_scm_input.hpp
+++ b/components/eamxx/src/share/io/scorpio_scm_input.hpp
@@ -3,7 +3,7 @@
 
 #include "share/grid/abstract_grid.hpp"
 
-#include <ekat/logging/ekat_logger.hpp>
+#include <ekat_logger.hpp>
 
 namespace scream
 {

--- a/components/eamxx/src/share/io/tests/io_basic.cpp
+++ b/components/eamxx/src/share/io/tests/io_basic.cpp
@@ -14,11 +14,10 @@
 #include "share/util/eamxx_time_stamp.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/util/ekat_units.hpp"
-#include "ekat/ekat_parameter_list.hpp"
-#include "ekat/ekat_assert.hpp"
-#include "ekat/mpi/ekat_comm.hpp"
-#include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_units.hpp>
+#include <ekat_parameter_list.hpp>
+#include <ekat_assert.hpp>
+#include <ekat_comm.hpp>
 
 #include <iomanip>
 #include <memory>

--- a/components/eamxx/src/share/io/tests/io_diags.cpp
+++ b/components/eamxx/src/share/io/tests/io_diags.cpp
@@ -15,11 +15,10 @@
 #include "share/util/eamxx_time_stamp.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/util/ekat_units.hpp"
-#include "ekat/ekat_parameter_list.hpp"
-#include "ekat/ekat_assert.hpp"
-#include "ekat/mpi/ekat_comm.hpp"
-#include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_units.hpp>
+#include <ekat_parameter_list.hpp>
+#include <ekat_assert.hpp>
+#include <ekat_comm.hpp>
 
 #include <iomanip>
 #include <memory>

--- a/components/eamxx/src/share/io/tests/io_filled.cpp
+++ b/components/eamxx/src/share/io/tests/io_filled.cpp
@@ -15,11 +15,10 @@
 #include "share/util/eamxx_time_stamp.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/util/ekat_units.hpp"
-#include "ekat/ekat_parameter_list.hpp"
-#include "ekat/ekat_assert.hpp"
-#include "ekat/mpi/ekat_comm.hpp"
-#include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_units.hpp>
+#include <ekat_parameter_list.hpp>
+#include <ekat_assert.hpp>
+#include <ekat_comm.hpp>
 
 #include <iomanip>
 #include <memory>

--- a/components/eamxx/src/share/io/tests/io_monthly.cpp
+++ b/components/eamxx/src/share/io/tests/io_monthly.cpp
@@ -14,11 +14,10 @@
 #include "share/util/eamxx_time_stamp.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/util/ekat_units.hpp"
-#include "ekat/ekat_parameter_list.hpp"
-#include "ekat/ekat_assert.hpp"
-#include "ekat/mpi/ekat_comm.hpp"
-#include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_units.hpp>
+#include <ekat_parameter_list.hpp>
+#include <ekat_assert.hpp>
+#include <ekat_comm.hpp>
 
 #include <iomanip>
 #include <memory>

--- a/components/eamxx/src/share/io/tests/io_packed.cpp
+++ b/components/eamxx/src/share/io/tests/io_packed.cpp
@@ -13,11 +13,10 @@
 #include "share/util/eamxx_time_stamp.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/util/ekat_units.hpp"
-#include "ekat/ekat_parameter_list.hpp"
-#include "ekat/ekat_assert.hpp"
-#include "ekat/mpi/ekat_comm.hpp"
-#include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_units.hpp>
+#include <ekat_parameter_list.hpp>
+#include <ekat_assert.hpp>
+#include <ekat_comm.hpp>
 
 #include <iomanip>
 #include <memory>

--- a/components/eamxx/src/share/io/tests/io_remap_test.cpp
+++ b/components/eamxx/src/share/io/tests/io_remap_test.cpp
@@ -9,6 +9,8 @@
 
 #include "share/grid/mesh_free_grids_manager.hpp"
 
+#include <ekat_pack.hpp>
+
 namespace {
 
 using namespace scream;

--- a/components/eamxx/src/share/io/tests/io_se_grid.cpp
+++ b/components/eamxx/src/share/io/tests/io_se_grid.cpp
@@ -15,10 +15,10 @@
 #include "share/util/eamxx_time_stamp.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/util/ekat_units.hpp"
-#include "ekat/io/ekat_yaml.hpp"
-#include "ekat/ekat_parameter_list.hpp"
+#include <ekat_pack.hpp>
+#include <ekat_parameter_list.hpp>
+#include <ekat_assert.hpp>
+#include <ekat_comm.hpp>
 
 namespace {
 

--- a/components/eamxx/src/share/io/tests/io_se_grid.cpp
+++ b/components/eamxx/src/share/io/tests/io_se_grid.cpp
@@ -80,7 +80,7 @@ TEST_CASE("se_grid_io")
   const auto fnames = {"field_1", "field_2", "field_3", "field_packed"};
   for (const auto& fname : fnames) {
     auto f = fm1->get_field(fname);
-    f.deep_copy(ekat::ScalarTraits<Real>::invalid());
+    f.deep_copy(Kokkos::Experimental::quiet_NaN_v<Real>);
   }
 
   // Check fields were written correctly

--- a/components/eamxx/src/share/io/tests/output_restart.cpp
+++ b/components/eamxx/src/share/io/tests/output_restart.cpp
@@ -17,9 +17,7 @@
 
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_parameter_list.hpp"
-#include "ekat/util/ekat_string_utils.hpp"
-#include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_parameter_list.hpp>
 
 #include <iostream>
 #include <iomanip>

--- a/components/eamxx/src/share/io/tests/scorpio_interface_tests.cpp
+++ b/components/eamxx/src/share/io/tests/scorpio_interface_tests.cpp
@@ -1,7 +1,6 @@
 #include <catch2/catch.hpp>
 
 #include "share/io/eamxx_scorpio_interface.hpp"
-#include <ekat/util/ekat_string_utils.hpp>
 
 namespace scream {
 

--- a/components/eamxx/src/share/property_checks/field_nan_check.cpp
+++ b/components/eamxx/src/share/property_checks/field_nan_check.cpp
@@ -2,8 +2,6 @@
 #include "share/field/field_utils.hpp"
 #include "share/util//eamxx_array_utils.hpp"
 
-#include "ekat/util/ekat_math_utils.hpp"
-
 namespace scream
 {
 
@@ -51,7 +49,7 @@ PropertyCheck::ResultAndMsg FieldNaNCheck::check_impl() const {
       {
         auto v = f.template get_strided_view<const_ST*>();
         Kokkos::parallel_reduce(size, KOKKOS_LAMBDA(int i, int& result) {
-          if (ekat::is_invalid(v(i))) {
+          if (Kokkos::isnan(v(i))) {
             result = i;
           }
         }, max_t(invalid_idx));
@@ -63,7 +61,7 @@ PropertyCheck::ResultAndMsg FieldNaNCheck::check_impl() const {
         Kokkos::parallel_reduce(size, KOKKOS_LAMBDA(int idx, int& result) {
           int i,j;
           unflatten_idx(idx,extents,i,j);
-          if (ekat::is_invalid(v(i,j))) {
+          if (Kokkos::isnan(v(i,j))) {
             result = idx;
           }
         }, max_t(invalid_idx));
@@ -75,7 +73,7 @@ PropertyCheck::ResultAndMsg FieldNaNCheck::check_impl() const {
         Kokkos::parallel_reduce(size, KOKKOS_LAMBDA(int idx, int& result) {
           int i,j,k;
           unflatten_idx(idx,extents,i,j,k);
-          if (ekat::is_invalid(v(i,j,k))) {
+          if (Kokkos::isnan(v(i,j,k))) {
             result = idx;
           }
         }, max_t(invalid_idx));
@@ -87,7 +85,7 @@ PropertyCheck::ResultAndMsg FieldNaNCheck::check_impl() const {
         Kokkos::parallel_reduce(size, KOKKOS_LAMBDA(int idx, int& result) {
           int i,j,k,l;
           unflatten_idx(idx,extents,i,j,k,l);
-          if (ekat::is_invalid(v(i,j,k,l))) {
+          if (Kokkos::isnan(v(i,j,k,l))) {
             result = idx;
           }
         }, max_t(invalid_idx));
@@ -99,7 +97,7 @@ PropertyCheck::ResultAndMsg FieldNaNCheck::check_impl() const {
         Kokkos::parallel_reduce(size, KOKKOS_LAMBDA(int idx, int& result) {
           int i,j,k,l,m;
           unflatten_idx(idx,extents,i,j,k,l,m);
-          if (ekat::is_invalid(v(i,j,k,l,m))) {
+          if (Kokkos::isnan(v(i,j,k,l,m))) {
             result = idx;
           }
         }, max_t(invalid_idx));
@@ -111,7 +109,7 @@ PropertyCheck::ResultAndMsg FieldNaNCheck::check_impl() const {
         Kokkos::parallel_reduce(size, KOKKOS_LAMBDA(int idx, int& result) {
           int i,j,k,l,m,n;
           unflatten_idx(idx,extents,i,j,k,l,m,n);
-          if (ekat::is_invalid(v(i,j,k,l,m,n))) {
+          if (Kokkos::isnan(v(i,j,k,l,m,n))) {
             result = idx;
           }
         }, max_t(invalid_idx));
@@ -175,8 +173,6 @@ PropertyCheck::ResultAndMsg FieldNaNCheck::check() const {
   const auto& f = fields().front();
 
   switch (f.data_type()) {
-    case DataType::IntType:
-      return check_impl<int>();
     case DataType::FloatType:
       return check_impl<float>();
     case DataType::DoubleType:

--- a/components/eamxx/src/share/property_checks/field_within_interval_check.cpp
+++ b/components/eamxx/src/share/property_checks/field_within_interval_check.cpp
@@ -2,7 +2,7 @@
 #include "share/util/eamxx_array_utils.hpp"
 #include "share/field/field_utils.hpp"
 
-#include <ekat/util/ekat_math_utils.hpp>
+#include <ekat_math_utils.hpp>
 
 #include <sstream>
 

--- a/components/eamxx/src/share/property_checks/field_within_interval_check.hpp
+++ b/components/eamxx/src/share/property_checks/field_within_interval_check.hpp
@@ -5,8 +5,6 @@
 #include "share/grid/abstract_grid.hpp"
 #include "share/field/field.hpp"
 
-#include "ekat/util/ekat_math_utils.hpp"
-
 namespace scream
 {
 

--- a/components/eamxx/src/share/property_checks/mass_and_energy_column_conservation_check.hpp
+++ b/components/eamxx/src/share/property_checks/mass_and_energy_column_conservation_check.hpp
@@ -5,8 +5,6 @@
 #include "share/grid/abstract_grid.hpp"
 #include "share/field/field.hpp"
 
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
-
 namespace scream {
 
 // This property check ensures that energy has been conserved.
@@ -14,7 +12,6 @@ namespace scream {
 class MassAndEnergyColumnConservationCheck: public PropertyCheck {
 
   using KT = KokkosTypes<DefaultDevice>;
-  using ExeSpaceUtils = ekat::ExeSpaceUtils<KT::ExeSpace>;
 
   template<typename ScalarT>
   using view_1d = typename KT::template view_1d<ScalarT>;

--- a/components/eamxx/src/share/property_checks/property_check.cpp
+++ b/components/eamxx/src/share/property_checks/property_check.cpp
@@ -1,6 +1,6 @@
 #include "share/property_checks/property_check.hpp"
 
-#include <ekat/ekat_assert.hpp>
+#include <ekat_assert.hpp>
 
 #include <string>
 #include <list>

--- a/components/eamxx/src/share/property_checks/property_check.hpp
+++ b/components/eamxx/src/share/property_checks/property_check.hpp
@@ -3,7 +3,7 @@
 
 #include "share/field/field.hpp"
 
-#include <ekat/ekat_assert.hpp>
+#include <ekat_assert.hpp>
 
 #include <string>
 #include <list>

--- a/components/eamxx/src/share/tests/atm_process_tests.cpp
+++ b/components/eamxx/src/share/tests/atm_process_tests.cpp
@@ -13,10 +13,9 @@
 #include "share/grid/remap/inverse_remapper.hpp"
 #include "share/util/eamxx_time_stamp.hpp"
 
-#include "ekat/ekat_parameter_list.hpp"
-#include "ekat/ekat_parse_yaml_file.hpp"
-#include "ekat/ekat_parameter_list.hpp"
-#include "ekat/ekat_scalar_traits.hpp"
+#include <ekat_parameter_list.hpp>
+#include <ekat_yaml.hpp>
+#include <ekat_scalar_traits.hpp>
 
 namespace scream {
 

--- a/components/eamxx/src/share/tests/column_ops.cpp
+++ b/components/eamxx/src/share/tests/column_ops.cpp
@@ -1,9 +1,10 @@
 #include <catch2/catch.hpp>
 
-#include "ekat/kokkos/ekat_kokkos_types.hpp"
-#include "ekat/kokkos/ekat_subview_utils.hpp"
-#include "ekat/util/ekat_arch.hpp"
 #include "share/util/eamxx_column_ops.hpp"
+
+#include <ekat_kokkos_types.hpp>
+#include <ekat_subview_utils.hpp>
+#include <ekat_arch.hpp>
 
 namespace {
 

--- a/components/eamxx/src/share/tests/common_physics_functions_tests.cpp
+++ b/components/eamxx/src/share/tests/common_physics_functions_tests.cpp
@@ -6,9 +6,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/util/eamxx_utils.hpp"
 
-#include "ekat/ekat_pack.hpp"
 #include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_pack.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/share/tests/common_physics_functions_tests.cpp
+++ b/components/eamxx/src/share/tests/common_physics_functions_tests.cpp
@@ -6,9 +6,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/util/eamxx_utils.hpp"
 
-#include "ekat/util/ekat_test_utils.hpp"
 #include <ekat_pack.hpp>
 #include <ekat_team_policy_utils.hpp>
+#include <ekat_view_utils.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/share/tests/common_physics_functions_tests.cpp
+++ b/components/eamxx/src/share/tests/common_physics_functions_tests.cpp
@@ -6,9 +6,9 @@
 #include "share/util/eamxx_common_physics_functions.hpp"
 #include "share/util/eamxx_utils.hpp"
 
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
 #include "ekat/util/ekat_test_utils.hpp"
 #include <ekat_pack.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 #include <iomanip>
 
@@ -180,10 +180,10 @@ void run(std::mt19937_64& engine)
 
   using KT         = ekat::KokkosTypes<DeviceT>;
   using ExecSpace  = typename KT::ExeSpace;
-  using TeamPolicy = typename KT::TeamPolicy;
   using MemberType = typename KT::MemberType;
   using view_1d    = typename KT::template view_1d<ScalarT>;
   using rview_1d   = typename KT::template view_1d<RealType>;
+  using TPF        = ekat::TeamPolicyFactory<ExecSpace>;
 
   static constexpr auto Rd       = PC::RD;
   static constexpr auto cp       = PC::CP;
@@ -419,7 +419,7 @@ void run(std::mt19937_64& engine)
   REQUIRE( !Check::approx_equal(PF::calculate_vmr_from_mmr(o2_mol,qv0,tmp),vmr0,test_tol) );
 
   // --------- Run tests on full columns of data ----------- //
-  TeamPolicy policy(ekat::ExeSpaceUtils<ExecSpace>::get_default_team_policy(1, 1));
+  auto policy = TPF::get_default_team_policy(1, 1);
   Kokkos::parallel_for("test_universal_physics", policy, KOKKOS_LAMBDA(const MemberType& team) {
 
     // Compute density(dp,dz)

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -1,7 +1,6 @@
 #include <catch2/catch.hpp>
 #include <numeric>
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
 #include "share/field/field_identifier.hpp"
 #include "share/field/field_header.hpp"
 #include "share/field/field.hpp"
@@ -11,9 +10,10 @@
 
 #include "share/grid/point_grid.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/ekat_pack_utils.hpp"
-#include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_pack.hpp>
+#include <ekat_pack_utils.hpp>
+#include <ekat_test_utils.hpp>
+#include <ekat_subview_utils.hpp>
 
 namespace {
 

--- a/components/eamxx/src/share/tests/field_utils.cpp
+++ b/components/eamxx/src/share/tests/field_utils.cpp
@@ -1,7 +1,6 @@
 #include <catch2/catch.hpp>
 #include <numeric>
 
-#include "ekat/kokkos/ekat_subview_utils.hpp"
 #include "share/field/field_identifier.hpp"
 #include "share/field/field_header.hpp"
 #include "share/field/field.hpp"
@@ -11,9 +10,8 @@
 
 #include "share/grid/point_grid.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/ekat_pack_utils.hpp"
-#include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_pack.hpp>
+#include <ekat_subview_utils.hpp>
 
 namespace {
 

--- a/components/eamxx/src/share/tests/grid_tests.cpp
+++ b/components/eamxx/src/share/tests/grid_tests.cpp
@@ -7,7 +7,7 @@
 #include "share/util/eamxx_setup_random_test.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack.hpp"
+#include <ekat_pack.hpp>
 
 #include <algorithm>
 

--- a/components/eamxx/src/share/tests/property_checks.cpp
+++ b/components/eamxx/src/share/tests/property_checks.cpp
@@ -9,9 +9,7 @@
 #include "share/grid/point_grid.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/ekat_pack_utils.hpp"
-#include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_test_utils.hpp>
 
 namespace {
 

--- a/components/eamxx/src/share/tests/subfield_tests.cpp
+++ b/components/eamxx/src/share/tests/subfield_tests.cpp
@@ -5,8 +5,6 @@
 #include "share/field/field_utils.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include "ekat/util/ekat_test_utils.hpp"
-
 namespace {
 
 TEST_CASE("field", "") {

--- a/components/eamxx/src/share/util/eamxx_ad_test.cpp
+++ b/components/eamxx/src/share/util/eamxx_ad_test.cpp
@@ -10,8 +10,8 @@
 #include "share/grid/mesh_free_grids_manager.hpp"
 
 // EKAT headers
-#include "ekat/ekat_parse_yaml_file.hpp"
-#include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_yaml.hpp>
+#include <ekat_test_utils.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/src/share/util/eamxx_array_utils.hpp
+++ b/components/eamxx/src/share/util/eamxx_array_utils.hpp
@@ -3,7 +3,8 @@
 
 #include "share/eamxx_types.hpp"
 
-#include <ekat/ekat_assert.hpp>
+#include <ekat_assert.hpp>
+#include <ekat_kernel_assert.hpp>
 
 namespace scream {
 

--- a/components/eamxx/src/share/util/eamxx_bfbhash.hpp
+++ b/components/eamxx/src/share/util/eamxx_bfbhash.hpp
@@ -3,8 +3,8 @@
 
 #include <cstdint>
 
-#include <ekat/kokkos/ekat_kokkos_types.hpp>
-#include <ekat/mpi/ekat_comm.hpp>
+#include <ekat_kokkos_types.hpp>
+#include <ekat_comm.hpp>
 
 namespace scream {
 namespace bfbhash {

--- a/components/eamxx/src/share/util/eamxx_column_ops.hpp
+++ b/components/eamxx/src/share/util/eamxx_column_ops.hpp
@@ -4,14 +4,14 @@
 #include "share/util/eamxx_combine_ops.hpp"
 #include "share/eamxx_types.hpp"
 
-#include "ekat/ekat_pack.hpp"
-#include "ekat/ekat_pack_math.hpp"
-#include "ekat/ekat_scalar_traits.hpp"
-#include "ekat/kokkos/ekat_kokkos_types.hpp"
-#include "ekat/ekat_pack_utils.hpp"
-#include "ekat/ekat_pack_kokkos.hpp"
-#include "ekat/util//ekat_arch.hpp"
-#include "ekat/ekat_pack.hpp"
+#include <ekat_pack.hpp>
+#include <ekat_pack_math.hpp>
+#include <ekat_scalar_traits.hpp>
+#include <ekat_kokkos_types.hpp>
+#include <ekat_pack_utils.hpp>
+#include <ekat_pack_kokkos.hpp>
+#include <ekat_arch.hpp>
+#include <ekat_pack.hpp>
 
 #include <type_traits>
 

--- a/components/eamxx/src/share/util/eamxx_combine_ops.hpp
+++ b/components/eamxx/src/share/util/eamxx_combine_ops.hpp
@@ -3,10 +3,11 @@
 
 #include "share/util/eamxx_universal_constants.hpp"
 
+#include <ekat_scalar_traits.hpp>
+
 // For KOKKOS_INLINE_FUNCTION
 #include <Kokkos_Core.hpp>
 #include <type_traits>
-#include "ekat/ekat_scalar_traits.hpp"
 
 namespace scream {
 

--- a/components/eamxx/src/share/util/eamxx_data_interpolation.cpp
+++ b/components/eamxx/src/share/util/eamxx_data_interpolation.cpp
@@ -11,6 +11,8 @@
 #include "share/util/eamxx_universal_constants.hpp"
 #include "physics/share/physics_constants.hpp"
 
+#include <ekat_team_policy_utils.hpp>
+
 #include <filesystem>
 #include <fstream>
 #include <regex>
@@ -89,7 +91,7 @@ void DataInterpolation::run (const util::TimeStamp& ts)
     using KT = KokkosTypes<DefaultDevice>;
     using ExeSpace = typename KT::ExeSpace;
     using MemberType = typename KT::MemberType;
-    using ESU = ekat::ExeSpaceUtils<ExeSpace>;
+    using TPF = ekat::TeamPolicyFactory<ExeSpace>;
     using C = scream::physics::Constants<Real>;
     using PT = ekat::Pack<Real,SCREAM_PACK_SIZE>;
 
@@ -102,7 +104,7 @@ void DataInterpolation::run (const util::TimeStamp& ts)
 
     const int ncols = ps_v.extent(0);
     const int num_vert_packs = p_v.extent(1);
-    const auto policy = ESU::get_default_team_policy(ncols, num_vert_packs);
+    const auto policy = TPF::get_default_team_policy(ncols, num_vert_packs);
 
     Kokkos::parallel_for("spa_compute_p_src_loop", policy,
       KOKKOS_LAMBDA (const MemberType& team) {

--- a/components/eamxx/src/share/util/eamxx_data_interpolation.cpp
+++ b/components/eamxx/src/share/util/eamxx_data_interpolation.cpp
@@ -395,7 +395,7 @@ setup_horiz_remappers (const RemapData& data)
   m_grid_after_hremap->reset_num_vertical_lev(nlevs_data);
 
   if (data.has_iop) {
-    EKAT_REQUIRE_MSG (not ekat::is_invalid(data.iop_lat) and not ekat::is_invalid(data.iop_lon),
+    EKAT_REQUIRE_MSG (not Kokkos::isnan(data.iop_lat) and not Kokkos::isnan(data.iop_lon),
         "Error! At least one between iop_lat and iop_lon appears to be valid in RemapData.\n"
         "  - iop_lat: " << data.iop_lat << "\n"
         "  - iop_lon: " << data.iop_lon << "\n");

--- a/components/eamxx/src/share/util/eamxx_data_type.hpp
+++ b/components/eamxx/src/share/util/eamxx_data_type.hpp
@@ -3,7 +3,7 @@
 
 #include "share/util/eamxx_utils.hpp"
 
-#include <ekat/ekat_assert.hpp>
+#include <ekat_assert.hpp>
 
 #include <string>
 

--- a/components/eamxx/src/share/util/eamxx_deep_copy.hpp
+++ b/components/eamxx/src/share/util/eamxx_deep_copy.hpp
@@ -1,8 +1,8 @@
 #ifndef SCREAM_DEEP_COPY_HPP
 #define SCREAM_DEEP_COPY_HPP
 
-#include "ekat/kokkos/ekat_kokkos_utils.hpp"
-#include "ekat/ekat_assert.hpp"
+#include <ekat_assert.hpp>
+
 #include <vector>
 
 namespace scream {

--- a/components/eamxx/src/share/util/eamxx_family_tracking.hpp
+++ b/components/eamxx/src/share/util/eamxx_family_tracking.hpp
@@ -1,8 +1,8 @@
 #ifndef SCREAM_FAMILY_TRACKING_CLASS
 #define SCREAM_FAMILY_TRACKING_CLASS
 
-#include "ekat/std_meta/ekat_std_enable_shared_from_this.hpp"
-#include "ekat/ekat_assert.hpp"
+#include <ekat_std_enable_shared_from_this.hpp>
+#include <ekat_assert.hpp>
 
 #include <list>
 #include <memory>

--- a/components/eamxx/src/share/util/eamxx_setup_random_test.hpp
+++ b/components/eamxx/src/share/util/eamxx_setup_random_test.hpp
@@ -2,7 +2,8 @@
 #define SCREAM_SETUP_RANDOM_TEST_HPP
 
 #include "catch2/catch.hpp"
-#include "ekat/mpi/ekat_comm.hpp"
+
+#include <ekat_comm.hpp>
 
 #include <random>
 #include <iostream>

--- a/components/eamxx/src/share/util/eamxx_time_stamp.cpp
+++ b/components/eamxx/src/share/util/eamxx_time_stamp.cpp
@@ -2,7 +2,8 @@
 
 #include "share/util/eamxx_universal_constants.hpp"
 #include "share/eamxx_config.hpp"
-#include "ekat/ekat_assert.hpp"
+
+#include <ekat_assert.hpp>
 
 #include <limits>
 #include <numeric>

--- a/components/eamxx/src/share/util/eamxx_timing.hpp
+++ b/components/eamxx/src/share/util/eamxx_timing.hpp
@@ -1,7 +1,7 @@
 #ifndef SCREAM_TIMING_HPP
 #define SCREAM_TIMING_HPP
 
-#include <ekat/mpi/ekat_comm.hpp>
+#include <ekat_comm.hpp>
 
 #include <string>
 

--- a/components/eamxx/src/share/util/eamxx_utils.hpp
+++ b/components/eamxx/src/share/util/eamxx_utils.hpp
@@ -3,9 +3,9 @@
 
 #include "share/eamxx_types.hpp"
 
-#include <ekat/ekat_assert.hpp>
-#include <ekat/kokkos/ekat_kokkos_types.hpp>
-#include <ekat/mpi/ekat_comm.hpp>
+#include <ekat_assert.hpp>
+#include <ekat_kokkos_types.hpp>
+#include <ekat_comm.hpp>
 
 #include <iterator>
 #include <list>

--- a/components/eamxx/tests/generic/fail_check/kokkos_fail.cpp
+++ b/components/eamxx/tests/generic/fail_check/kokkos_fail.cpp
@@ -1,5 +1,5 @@
-#include "ekat/kokkos/ekat_kokkos_types.hpp"
-#include "ekat/kokkos/ekat_subview_utils.hpp"
+#include <ekat_kokkos_types.hpp>
+#include <ekat_subview_utils.hpp>
 
 #include <catch2/catch.hpp>
 

--- a/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2_dp/homme_shoc_cld_spa_p3_rrtmgp_pg2_dp.cpp
+++ b/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2_dp/homme_shoc_cld_spa_p3_rrtmgp_pg2_dp.cpp
@@ -15,7 +15,8 @@
 #include "control/atmosphere_surface_coupling_importer.hpp"
 
 // EKAT headers
-#include "ekat/kokkos/ekat_kokkos_types.hpp"
+#include <ekat_kokkos_types.hpp>
+#include <ekat_yaml.hpp>
 
 TEST_CASE("scream_homme_physics", "scream_homme_physics") {
   using namespace scream;

--- a/components/eamxx/tests/single-process/rrtmgp/rrtmgp_standalone.cpp
+++ b/components/eamxx/tests/single-process/rrtmgp/rrtmgp_standalone.cpp
@@ -6,8 +6,8 @@
 #include "share/grid/mesh_free_grids_manager.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "ekat/ekat_parse_yaml_file.hpp"
-#include "ekat/util/ekat_test_utils.hpp"
+#include <ekat_yaml.hpp>
+#include <ekat_test_utils.hpp>
 
 #include <iomanip>
 

--- a/components/eamxx/tests/single-process/surface_coupling/surface_coupling.cpp
+++ b/components/eamxx/tests/single-process/surface_coupling/surface_coupling.cpp
@@ -12,6 +12,7 @@
 
 #include <ekat_yaml.hpp>
 #include <ekat_view_utils.hpp>
+#include <ekat_team_policy_utils.hpp>
 
 #include <iomanip>
 
@@ -303,8 +304,10 @@ void test_exports(const FieldManager& fm,
                   const int dt,
                   const bool called_directly_after_init = false)
 {
-  using PF = PhysicsFunctions<DefaultDevice>;
-  using PC = physics::Constants<Real>;
+  using PF       = PhysicsFunctions<DefaultDevice>;
+  using PC       = physics::Constants<Real>;
+  using ExeSpace = typename KokkosTypes<DefaultDevice>::ExeSpace;
+  using TPF      = ekat::TeamPolicyFactory<ExeSpace>;
 
   // Some computed fields rely on calculations that are done in the AD.
   // Recompute here and verify that they were exported correctly.
@@ -331,8 +334,7 @@ void test_exports(const FieldManager& fm,
   KokkosTypes<DefaultDevice>::view_1d<Real> Faxa_rainl("Faxa_rainl", ncols);
   KokkosTypes<DefaultDevice>::view_1d<Real> Faxa_snowl("Faxa_snowl", ncols);
 
-  const auto setup_policy =
-      ekat::ExeSpaceUtils<KokkosTypes<DefaultDevice>::ExeSpace>::get_thread_range_parallel_scan_team_policy(ncols, nlevs);
+  const auto setup_policy = TPF::get_thread_range_parallel_scan_team_policy(ncols, nlevs);
   Kokkos::parallel_for(setup_policy, KOKKOS_LAMBDA(const Kokkos::TeamPolicy<KokkosTypes<DefaultDevice>::ExeSpace>::member_type& team) {
     const int i = team.league_rank();
 

--- a/components/eamxx/tests/single-process/surface_coupling/surface_coupling.cpp
+++ b/components/eamxx/tests/single-process/surface_coupling/surface_coupling.cpp
@@ -10,8 +10,8 @@
 #include "share/eamxx_types.hpp"
 #include "share/util/eamxx_setup_random_test.hpp"
 
-#include <ekat/ekat_parse_yaml_file.hpp>
-#include <ekat/util/ekat_test_utils.hpp>
+#include <ekat_yaml.hpp>
+#include <ekat_view_utils.hpp>
 
 #include <iomanip>
 
@@ -456,7 +456,7 @@ TEST_CASE("surface-coupling", "") {
   // Load ad parameter list
   std::string fname = "input.yaml";
   ekat::ParameterList ad_params("Atmosphere Driver");
-  parse_yaml_file(fname,ad_params);
+  ekat::parse_yaml_file(fname,ad_params);
 
   // Parameters
   auto& ts          = ad_params.sublist("time_stepping");


### PR DESCRIPTION
Update the EKAT submodule and change EAMxx to conform to the new version of EKAT.

---

A (very disruptive) PR in EKAT (not yet integrated)  will break EKAT into sub-packages, to facilitate its use in other applications without the need to bring in every single ekat dependency.

This PR adapts to those changes, which can be summarized in the following points:

- There is no longer an `ekat` library, but a bunch of `ekat::XYZ` libraries, including a `ekat::AllLibs` one (for convenience).
- No longer use paths in includes: customer should just include <ekat_blah.hpp>, without any path (they should not care how ekat files are organized in the ekat repo)
- `ekat_kokkos_utils.hpp` broken in two: `ekat_reduction_utils.hpp` and `ekat_team_policy_utils.hpp`
- `ExeSpaceUtils` no longer persent. In its place, use `TeamPolicyFactory` (from `ekat_team_policy_utils.hpp`) for team policy creation, and `ReductionUtils` (from `ekat_reduction_utils.hpp`) for reduction utilities; both are templated on exec space, just like `ExeSpaceUtils` was.
- `ScalarTraits` no longer provides `invalid()` and `quiet_NaN()`, but only provides type info. The functions `quiet_NaN()` and `finite_max()` have been added in `ekat_math_utils.hpp`, but may disappear once we have C++20 (see comment in `ekat_pack.hpp` about "introspective" constepxr)
- `ekat_file_utils.hpp` has been purged, and all tests now simply use the standard library `ifstream`/`ofstream` capabilities.
- There is no more an "ekat" session. The `ekat::KokkosUtils` has `initialize_kokkos_session` (and its finalize).
- Minor changes related to how we print the current session configuration (some are in ekat::Core, some in ekat::KokkosUtils).
- `EkatCreateUnitTestExec` no longer has `EXCLUDE_TEST_SESSION`, but instead has `USER_DEFINED_TEST_SESSION`, for more expressivity.

The biggest challenge was how to break ekat into N packages, since some utilities were "generic enough", but required knowledge about kokkos (e.g., printing the current arch configuration seems generic enough to be in ekat::Core, but the kokkos backend info requires kokkos to be compiled).

The current result seems to be the best compromise between flexibility (for new customers) and robustness (for existing customers).

I have NOT updated mam4xx/haero to use the new ekat, so all their tests may fail to build (or even configure). I am opening the PR anyways, in the hope to get a build of all the rest until mam4xx is update too.

IMPORTANT NOTE FOR REVIEWERS: I _strongly_ recommend to review the commits individually. I tried to group changes by topic, so reviewing one commit may be simpler; ha couple of commits are quite large, but seeing the same pattern over and over may make it easier to review. 