### PR TITLE
ZM cleanup - bug fix for compute_cape_diags

### DIFF
--- a/components/eam/src/physics/cam/misc_diagnostics.F90
+++ b/components/eam/src/physics/cam/misc_diagnostics.F90
@@ -183,7 +183,7 @@ subroutine compute_cape_diags( state, pbuf, pcols, pver, pverp, cape_out, dcape_
   real(r8),                 intent(out) ::  cape_out(pcols)
   real(r8),optional,        intent(out) :: dcape_out(pcols,3)
 
-  ! local variables used for providing the same input to different calls of subroutine buoyan_dilute
+  ! local variables used for providing the same input to different calls of subroutine compute_dilute_cape
 
   real(r8) :: pmid_in_hPa(pcols,pver)
   real(r8) :: pint_in_hPa(pcols,pver+1)
@@ -198,29 +198,28 @@ subroutine compute_cape_diags( state, pbuf, pcols, pver, pverp, cape_out, dcape_
 
   logical :: iclosure = .true.  ! set to .true. to avoid interference with trig_dcape
 
-  ! variables that distinguish different calls of buoyan_dilute 
+  ! variables that distinguish different calls of compute_dilute_cape 
 
   real(r8),pointer ::    qv_new(:,:)  ! new qv   from current state
   real(r8),pointer ::  temp_new(:,:)  ! new temp from current state
 
   logical :: use_old_parcel_tq    ! whether or not to use old launching level and parcel T, q when calculating CAPE
 
-  integer  ::    mx_new(pcols)  ! index of launching level in new environment,  calculated by buoyan_dilute
-  real(r8) ::  q_mx_new(pcols)  ! new specific humidity at new launching level, calculated by buoyan_dilute
-  real(r8) ::  t_mx_new(pcols)  ! new temperature       at new launching level, calculated by buoyan_dilute
+  integer  ::    mx_new(pcols)  ! index of launching level in new environment,  calculated by compute_dilute_cape
+  real(r8) ::  q_mx_new(pcols)  ! new specific humidity at new launching level, calculated by compute_dilute_cape
+  real(r8) ::  t_mx_new(pcols)  ! new temperature       at new launching level, calculated by compute_dilute_cape
 
   integer, pointer ::   mx_old(:)  ! old launching level from pbuf
   real(r8),pointer :: q_mx_old(:)  ! old qv   at launching level from pbuf
   real(r8),pointer :: t_mx_old(:)  ! old temp at launching level from pbuf
 
-  ! variables returned by buoyan_dilute but not needed here
+  ! variables returned by compute_dilute_cape but not needed here
 
   real(r8) ::   ztp(pcols,pver) ! parcel temperatures.
   real(r8) :: zqstp(pcols,pver) ! grid slice of parcel temp. saturation mixing ratio.
   real(r8) ::   ztl(pcols)      ! parcel temperature at lcl.
   integer  ::  zlcl(pcols)      ! base level index of deep cumulus convection.
   integer  ::  zlel(pcols)      ! index of highest theoretical convective plume.
-  integer  ::   zmx(pcols)      ! launching level index 
 
   ! CAPE calculated using different combinations of environmental profiles and parcel properties
 
@@ -255,7 +254,7 @@ subroutine compute_cape_diags( state, pbuf, pcols, pver, pverp, cape_out, dcape_
 
   ! Surface elevation (m) is needed to calculate height above sea level (m) 
   ! Note that zm (and zi) stored in state are height above surface. 
-  ! The layer midpoint height provided to buoyan_dilute is height above sea level. 
+  ! The layer midpoint height provided to compute_dilute_cape is height above sea level. 
 
   zs(1:ncol) = state%phis(1:ncol)/gravit
 
@@ -298,7 +297,8 @@ subroutine compute_cape_diags( state, pbuf, pcols, pver, pverp, cape_out, dcape_
                             zmid_above_sealevel,              &
                             pmid_in_hPa, pint_in_hPa,         &
                             pblt, tpert,                      &
-                            ztp, zqstp, zmx, ztl, zlcl, zlel, &
+                            ztp, zqstp, mx_new,               &
+                            ztl, zlcl, zlel,                  &
                             cape_new_pcl_new_env,             &
                             zm_const, zm_param,               &
                             iclosure,                         &
@@ -330,7 +330,8 @@ subroutine compute_cape_diags( state, pbuf, pcols, pver, pverp, cape_out, dcape_
                               zmid_above_sealevel,              &
                               pmid_in_hPa, pint_in_hPa,         &
                               pblt, tpert,                      &
-                              ztp, zqstp, zmx, ztl, zlcl, zlel, &
+                              ztp, zqstp, mx_new,               &
+                              ztl, zlcl, zlel,                  &
                               cape_old_pcl_new_env,             &
                               zm_const, zm_param,               &
                               iclosure,                         &


### PR DESCRIPTION
Address bug introduced in PR #7232 in the call to `compute_dilute_cape()` in `compute_cape_diags()`. Fixes issue #7365

[BFB]