### PR TITLE
Adding support for NCZarr format

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2084,6 +2084,7 @@
       <env name="PATH">/nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/mpich/4.1.2/gcc-12.1.0/bin:$ENV{PATH}</env>
       <env name="ZLIB_ROOT">/nfs/gce/software/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/zlib-1.2.11-p7dmb5p</env>
       <env name="HDF5_ROOT">/nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/hdf5/1.12.2/mpich-4.1.2/gcc-12.1.0</env>
+      <!--env name="NETCDF_PATH">/nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/netcdf/4.9.3c-4.3.1cxx-4.5.3f-parallel-nczarr/mpich-4.1.2/gcc-12.1.0</env-->
       <env name="NETCDF_PATH">/nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/netcdf/4.8.0c-4.3.1cxx-4.5.3f-parallel/mpich-4.1.2/gcc-12.1.0</env>
       <env name="PNETCDF_PATH">/nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/pnetcdf/1.12.3/mpich-4.1.2/gcc-12.1.0</env>
       <env name="MOAB_ROOT">$SHELL{if [ -z "$MOAB_ROOT" ]; then echo /nfs/gce/projects/climate/software/moab/devel/mpich-4.1.2/gcc-12.1.0; else echo "$MOAB_ROOT"; fi}</env>

--- a/share/build/buildlib.spio
+++ b/share/build/buildlib.spio
@@ -209,11 +209,13 @@ def buildlib(bldroot, installpath, case):
         pnetcdf_string = "WITH_PNETCDF:BOOL=ON"
         netcdf4_string = "NetCDF_C_HAS_PARALLEL:BOOL=TRUE"
 
+    netcdf4_nczarr_string = "NetCDF_C_HAS_NCZARR:BOOL=TRUE"
     adios_string = "WITH_ADIOS2:BOOL=ON"
     hdf5_string = "WITH_HDF5:BOOL=ON"
     expect_string_found = False
     pnetcdf_found = False
     netcdf4_parallel_found = False
+    netcdf4_nczarr_found = False
     adios_found = False
     hdf5_found = False
 
@@ -225,6 +227,8 @@ def buildlib(bldroot, installpath, case):
             pnetcdf_found = True
         if re.search(netcdf4_string, line):
             netcdf4_parallel_found = True
+        if re.search(netcdf4_nczarr_string, line):
+            netcdf4_nczarr_found = True
         if re.search(adios_string, line):
             adios_found = True
         if re.search(hdf5_string, line):
@@ -283,6 +287,8 @@ def buildlib(bldroot, installpath, case):
         valid_values += ",pnetcdf"
     if netcdf4_parallel_found:
         valid_values += ",netcdf4p,netcdf4c"
+    if netcdf4_nczarr_found:
+        valid_values += ",netcdf4z"
     if adios_found:
         valid_values += ",adios"
         if adiosc_found:

--- a/share/util/shr_pio_mod.F90
+++ b/share/util/shr_pio_mod.F90
@@ -674,6 +674,8 @@ contains
        iotype = pio_iotype_pnetcdf
     else if ( typename .eq. 'NETCDF4P') then
        iotype = pio_iotype_netcdf4p
+    else if ( typename .eq. 'NETCDF4Z') then
+       iotype = pio_iotype_netcdf4p_nczarr
     else if ( typename .eq. 'NETCDF4C') then
        iotype = pio_iotype_netcdf4c
 #ifndef PIO1


### PR DESCRIPTION
Adding support in CIME for the experimental new NCZarr format

If NetCDF with NCZarr support is installed on a system, users can
now change the PIO_TYPENAME to "netcdf4z" to write the output
files in NetCDF NCZarr file format.

Support for NCZarr format is available from SCORPIO v1.7.0

[BFB]