### PR TITLE
Fixes for Sandia machines

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2273,7 +2273,7 @@
         <command name="load">sems-archive-netcdf/4.4.1/exo</command>
       </modules>
     </module_system>
-    <RUNDIR>/nscratch/$USER/acme_scratch/sandiatoss3/$CASE/run</RUNDIR>
+    <RUNDIR>/tscratch/$USER/acme_scratch/sandiatoss3/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
     <!-- complete path to a short term archiving directory -->
     <!-- path to the cprnc tool used to compare netcdf history files in testing -->
@@ -2334,6 +2334,7 @@
         <command name="purge"/>
         <command name="use">/projects/sems/acme-boca-modulefiles/env-module</command>
         <command name="load">acme-boca-env</command>
+        <command name="load">aue/python/3.11.6</command>
         <command name="load">sems-archive-git</command>
         <command name="load">sems-archive-cmake/3.19.1</command>
         <command name="load">gnu/10.2</command>
@@ -2347,7 +2348,7 @@
         <command name="load">sems-archive-netcdf/4.4.1/exo</command>
       </modules>
     </module_system>
-    <RUNDIR>/nscratch/$USER/acme_scratch/boca/$CASE/run</RUNDIR>
+    <RUNDIR>/tscratch/$USER/acme_scratch/boca/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
     <!-- complete path to a short term archiving directory -->
     <!-- path to the cprnc tool used to compare netcdf history files in testing -->
@@ -2415,6 +2416,7 @@
         <command name="purge"/>
         <command name="use">/projects/sems/acme-boca-modulefiles/env-module</command>
         <command name="load">acme-boca-env</command>
+        <command name="load">aue/python/3.11.6</command>
         <command name="load">sems-archive-git</command>
         <command name="load">sems-archive-cmake/3.19.1</command>
         <command name="load">gnu/10.3.1</command>
@@ -2428,7 +2430,7 @@
         <command name="load">sems-archive-netcdf/4.4.1/exo</command>
       </modules>
     </module_system>
-    <RUNDIR>/nscratch/$USER/acme_scratch/flight/$CASE/run</RUNDIR>
+    <RUNDIR>/tscratch/$USER/acme_scratch/flight/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
     <!-- complete path to a short term archiving directory -->
     <!-- path to the cprnc tool used to compare netcdf history files in testing -->
@@ -2459,7 +2461,7 @@
     <MPILIBS>openmpi</MPILIBS>
     <PROJECT>fy210162</PROJECT>
 
-    <CIME_OUTPUT_ROOT>/gscratch/$USER/acme_scratch/ghost</CIME_OUTPUT_ROOT>
+    <CIME_OUTPUT_ROOT>/tscratch/$USER/acme_scratch/ghost</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/projects/ccsm/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/projects/ccsm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
@@ -2493,17 +2495,20 @@
       <cmd_path lang="sh">module</cmd_path>
       <modules>
         <command name="purge"/>
-        <command name="load">sems-env</command>
-        <command name="load">sems-git</command>
-        <command name="load">sems-python/3.5.2</command>
-        <command name="load">sems-cmake</command>
-        <command name="load">gnu/4.9.2</command>
-        <command name="load">sems-intel/16.0.2</command>
-        <command name="load">mkl/16.0</command>
-        <command name="load">sems-netcdf/4.4.1/exo_parallel</command>
+        <command name="use">/projects/sems/acme-boca-modulefiles/env-module</command>
+        <command name="load">acme-boca-env</command>
+        <command name="load">aue/python/3.11.6</command>
+        <command name="load">sems-archive-git</command>
+        <command name="load">sems-archive-cmake/3.19.1</command>
+        <command name="load">gnu/10.3.1</command>
+        <command name="load">sems-archive-intel/21.3.0</command>
       </modules>
       <modules mpilib="!mpi-serial">
-        <command name="load">sems-openmpi/1.10.5</command>
+        <command name="load">sems-archive-openmpi/4.1.4</command>
+        <command name="load">acme-netcdf/4.7.4/acme</command>
+      </modules>
+      <modules mpilib="mpi-serial">
+        <command name="load">sems-archive-netcdf/4.4.1/exo</command>
       </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>


### PR DESCRIPTION
Fixes for Sandia machines (flight, boca, sandiatoss3):

  - Change nscratch to tscratch since nscratch is being phased out and mounted read-only 
  - Load specific python version to avoid both minimum version error and also distutils deprecation
  - Share module environment between ghost and flight/boca, since ghost configuration seemed to be broken

[BFB]