### PR TITLE
EAMxx: fix bug when aliasing subfields

### DIFF
--- a/components/eamxx/src/share/field/field_header.cpp
+++ b/components/eamxx/src/share/field/field_header.cpp
@@ -34,6 +34,10 @@ set_extra_data (const std::string& key,
 
 std::shared_ptr<FieldHeader> FieldHeader::alias(const std::string& name) const {
   auto fh = create_header(get_identifier().alias(name));
+  if (get_parent() != nullptr) {
+    // If we're aliasing, we MUST keep track of the parent
+    fh->create_parent_child_link(get_parent());
+  }
   fh->m_tracking = m_tracking;
   fh->m_alloc_prop = m_alloc_prop;
   fh->m_extra_data = m_extra_data;

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -271,6 +271,10 @@ TEST_CASE("field", "") {
     auto g1_x0 = f1.subfield(1,0);
     auto g1_x1 = f1.subfield(1,1);
 
+    // Check we preserve parent info
+    auto f1_0x_p = f1_0x.get_header().get_parent();
+    REQUIRE (f1_0x.alias("foo").get_header().get_parent()==f1_0x_p);
+
     REQUIRE (f1_0x.is_aliasing(g1_0x));
     REQUIRE (f1_1x.is_aliasing(g1_1x));
     REQUIRE (f1_x0.is_aliasing(g1_x0));


### PR DESCRIPTION
Add parent of source field to the newly created fields. Add test to ensure this works as expected.

[BFB]

---

This bug was sneaky to find. Should not affect any existing code, since if this affected your code, it would have likely caused a crash somewhere (not guaranteed, though, so it may indeed improve someone's life).