### PR TITLE
Revert spun-up ocean IC back to cold-start for SORRME3r3

### DIFF
--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -414,8 +414,8 @@ def buildnml(case, caseroot, compname):
         ic_date = '20240829'
         ic_prefix = 'mpaso.SOwISC12to30E3r3'
         if ocn_ic_mode == 'spunup':
-            ic_date = '20241023'
-            ic_prefix = 'mpaso.SOwISC12to30E3r3.interpFrom2p1-anvil'
+            ic_date = '20240829'
+            ic_prefix = 'mpaso.SOwISC12to30E3r3.rstFromG-chrysalis'
         if ocn_ismf == 'data':
             data_ismf_file = 'prescribed_ismf_paolo2023.SOwISC12to30E3r3.20241017.nc'
 


### PR DESCRIPTION
Changes the ocean spun-up initial condition that was set in https://github.com/E3SM-Project/E3SM/pull/6758 back to the 'cold-start' initial condition. There was concern using the initial condition interpolated from the v2.1 spinup was baking in warm biases in the Southern Ocean.

Ocean initial condition file is staged in public inputdata repo, world-readable.

[BFB] except
[non-BFB] for B-cases with the SOwISC12to30E3r3 ocean mesh (not in current testing).