### PR TITLE
Change land domain file for `r05_SOwISC12to30E3r3`

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -3576,8 +3576,8 @@
       <file grid="lnd" mask="IcosXISC30E3r7">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_IcosXISC30E3r7.240326.nc</file>
       <file grid="atm" mask="RRSwISC6to18E3r5">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_RRSwISC6to18E3r5.240328.nc</file>
       <file grid="lnd" mask="RRSwISC6to18E3r5">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_RRSwISC6to18E3r5.240328.nc</file>
-      <file grid="atm" mask="SOwISC12to30E3r3">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_SOwISC12to30E3r3.240808.nc</file>
-      <file grid="lnd" mask="SOwISC12to30E3r3">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_SOwISC12to30E3r3.240808.nc</file>
+      <file grid="atm" mask="SOwISC12to30E3r3">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_SOwISC12to30E3r3.250515.nc</file>
+      <file grid="lnd" mask="SOwISC12to30E3r3">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_SOwISC12to30E3r3.250515.nc</file>
       <file grid="atm" mask="SOwISC12to30E3r4">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_SOwISC12to30E3r4.250122.nc</file>
       <file grid="lnd" mask="SOwISC12to30E3r4">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_SOwISC12to30E3r4.250122.nc</file>
       <file grid="lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.r05_gx1v6.191014.nc</file>

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -235,7 +235,7 @@ ic_tod="0" sim_year="2000" glc_nec="0" use_crop=".false." >lnd/clm2/initdata_map
 <!-- r05 resolution -->
 
 <finidat hgrid="r05" maxpft="17" mask="SOwISC12to30E3r3" use_cn=".true." ic_ymd="18500101" more_vertlayers=".false."
-sim_year="1850" glc_nec="0" use_crop=".false.">lnd/clm2/initdata/elmi.v3-SORRM.ne30pg2_r05_SOwISC12to30E3r3.1850-01-01-00000.c20240923.nc
+sim_year="1850" glc_nec="0" use_crop=".false.">lnd/clm2/initdata/elmi.v3-SORRM.ne30pg2_r05_SOwISC12to30E3r3.1850-01-01-00000.c20250524.nc
 </finidat>
 
 <!-- r025 resolution -->


### PR DESCRIPTION
Changes land domain file for `r05_SOwISC12to30E3r3` such that grid cell areas are not truncated to 3 decimal points, which led to small errors in conservation of grid cell areas. This also updates the `finidat` file to be consistent with the new domain file, which was interpolated from the end of the v3 LR spinup.

New inputdata files are staged in public inputdata and world readable.

[BFB] except
[non-BFB] for configurations with `ne30pg2_r05_SOwISC12to30E3r3` grid (not in current testing).