### PR TITLE
Updates Chicoma machine files to enable intel compiler

### DIFF
--- a/cime_config/machines/cmake_macros/intel_chicoma-cpu.cmake
+++ b/cime_config/machines/cmake_macros/intel_chicoma-cpu.cmake
@@ -1,7 +1,8 @@
 set(PIO_FILESYSTEM_HINTS "lustre")
 string(APPEND CONFIG_ARGS " --host=cray")
 string(APPEND CMAKE_EXE_LINKER_FLAGS " -qmkl")
-
+string(REPLACE "-fp-model source" "-fp-model precise" CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS}")
+string(REPLACE "-fp-model source" "-fp-model precise" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 set(MPICC "cc")
 set(MPICXX "CC")
 set(MPIFC "ftn")

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -4356,7 +4356,7 @@
       <modules compiler="intel">
         <command name="load">PrgEnv-intel/8.5.0</command>
         <command name="load">intel/2023.2.0</command>
-		<command name="load">intel-mkl/2023.2.0</command>
+        <command name="load">intel-mkl/2023.2.0</command>
       </modules>
 
       <modules compiler="amdclang">

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -4280,8 +4280,8 @@
     <COMPILERS>gnu,intel,nvidia,amdclang</COMPILERS>
     <MPILIBS>mpich</MPILIBS>
     <CIME_OUTPUT_ROOT>/lustre/scratch5/$ENV{USER}/E3SM/scratch/chicoma-cpu</CIME_OUTPUT_ROOT>
-	<DIN_LOC_ROOT>/lustre/scratch5/$ENV{USER}/inputdata</DIN_LOC_ROOT>
-	<DIN_LOC_ROOT_CLMFORC>/lustre/scratch5/$ENV{USER}/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DIN_LOC_ROOT>/lustre/scratch5/$ENV{USER}/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/lustre/scratch5/$ENV{USER}/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>/lustre/scratch5/$ENV{USER}/E3SM/archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>/lustre/scratch5/$ENV{USER}/E3SM/input_data/ccsm_baselines/$COMPILER</BASELINE_ROOT>
     <CCSM_CPRNC>/usr/projects/e3sm/software/chicoma-cpu/cprnc</CCSM_CPRNC>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -4356,6 +4356,7 @@
       <modules compiler="intel">
         <command name="load">PrgEnv-intel/8.5.0</command>
         <command name="load">intel/2023.2.0</command>
+		<command name="load">intel-mkl/2023.2.0</command>
       </modules>
 
       <modules compiler="amdclang">

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -4280,8 +4280,8 @@
     <COMPILERS>gnu,intel,nvidia,amdclang</COMPILERS>
     <MPILIBS>mpich</MPILIBS>
     <CIME_OUTPUT_ROOT>/lustre/scratch5/$ENV{USER}/E3SM/scratch/chicoma-cpu</CIME_OUTPUT_ROOT>
-    <DIN_LOC_ROOT>/usr/projects/e3sm/inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/usr/projects/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+	<DIN_LOC_ROOT>/lustre/scratch5/$ENV{USER}/inputdata</DIN_LOC_ROOT>
+	<DIN_LOC_ROOT_CLMFORC>/lustre/scratch5/$ENV{USER}/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>/lustre/scratch5/$ENV{USER}/E3SM/archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>/lustre/scratch5/$ENV{USER}/E3SM/input_data/ccsm_baselines/$COMPILER</BASELINE_ROOT>
     <CCSM_CPRNC>/usr/projects/e3sm/software/chicoma-cpu/cprnc</CCSM_CPRNC>


### PR DESCRIPTION
This PR updates the cmake macros for intel_chicoma-cpu to enable functionality of the intel compiler on the LANL chicoma machine.  I have tested this with the V3 HR WCYCL test and it runs successfully.  I've also run `SMS_D.ne30pg2_EC30to60E2r2.WCYCL1850NS.chicoma-cpu_intel.20250528_225505_nqize3` and it passes