### PR TITLE
Updates mksurfdata_map Srcfiles

### DIFF
--- a/components/elm/tools/mksurfdata_map/src/Srcfiles
+++ b/components/elm/tools/mksurfdata_map/src/Srcfiles
@@ -26,6 +26,7 @@ mkpeatMod.F90
 mktopostatsMod.F90
 mkVICparamsMod.F90
 mkCH4inversionMod.F90
+mkFertMod.F90
 mkSedMod.F90
 mkFertMod.F90
 mktopradMod.F90


### PR DESCRIPTION
The missing mkFertMod.F90 entry is added to Srcfiles to allow
compilation of mksurfdata_map.