### PR TITLE
Output So4 and H2So4 deposition flux diagnostics.

### DIFF
--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -161,6 +161,13 @@ void MAMMicrophysics::set_grids(
   // Downwelling solar flux at the surface [w/m2]
   add_field<Required>("SW_flux_dn", scalar3d_int, W / m2, grid_name);
 
+  // Diagnostic fluxes          
+  constexpr int gas_pcnst = mam4::gas_chemistry::gas_pcnst;
+  const FieldLayout vector2d_nmodes =
+      grid_->get_2d_vector_layout(nmodes, "mam4::gas_chemistry::gas_pcnst");
+  add_field<Computed>("dqdt_so4_aqueous_chemistry", vector2d_nmodes, kg/kg/s,  grid_name);
+  add_field<Computed>("dqdt_h2so4_uptake", vector2d_nmodes, kg/kg/s,  grid_name);
+
   // ---------------------------------------------------------------------
   // These variables are "updated" or inputs/outputs for the process
   // ---------------------------------------------------------------------
@@ -444,7 +451,9 @@ void MAMMicrophysics::initialize_impl(const RunType run_type) {
       {"ps", {-1e10, 1e10}},                    // FIXME
       {"sfc_alb_dir_vis", {-1e10, 1e10}},       // FIXME
       {"snow_depth_land", {-1e10, 1e10}},       // FIXME
-      {"surf_radiative_T", {-1e10, 1e10}}       // FIXME
+      {"surf_radiative_T", {-1e10, 1e10}},      // FIXME
+      {"dqdt_so4_aqueous_chemistry", {-1e10, 1e10}},      // FIXME
+      {"dqdt_h2so4_uptake", {-1e10, 1e10}}       // FIXME
   };
   set_ranges_process(ranges_microphysics);
   add_interval_checks();
@@ -617,6 +626,10 @@ void MAMMicrophysics::run_impl(const double dt) {
   const const_view_1d snow_depth_land =
       get_field_in("snow_depth_land").get_view<const Real *>();
 
+  // Constituent fluxes 
+  view_2d aqso4_flx = get_field_out("dqdt_so4_aqueous_chemistry").get_view<Real **>();
+  view_2d aqh2so4_flx = get_field_out("dqdt_h2so4_uptake").get_view<Real **>();
+
   // climatology data for linear stratospheric chemistry
   // ozone (climatology) [vmr]
   auto linoz_o3_clim = buffer_.scratch[0];
@@ -755,10 +768,11 @@ void MAMMicrophysics::run_impl(const double dt) {
   }
   const auto zenith_angle = acos_cosine_zenith_;
   constexpr int gas_pcnst = mam_coupling::gas_pcnst();
+  constexpr int nmodes    = mam_coupling::num_aero_modes();
 
-  const auto &extfrc               = extfrc_;
-  const auto &forcings             = forcings_;
-  constexpr int extcnt             = mam4::gas_chemistry::extcnt;
+  const auto &extfrc   = extfrc_;
+  const auto &forcings = forcings_;
+  constexpr int extcnt = mam4::gas_chemistry::extcnt;
 
   const int offset_aerosol = mam4::utils::gasses_start_ind();
   Real adv_mass_kg_per_moles[gas_pcnst];
@@ -897,6 +911,8 @@ void MAMMicrophysics::run_impl(const double dt) {
           }
         }
         // These output values need to be put somewhere:
+        Real aqso4_flx_col[nmodes] = {};  // deposition flux of so4 [mole/mole/s]
+        Real aqh2so4_flx_col[nmodes] = {};  // deposition flux of h2so4 [mole/mole/s]
         Real dflx_col[gas_pcnst] = {};  // deposition velocity [1/cm/s]
         Real dvel_col[gas_pcnst] = {};  // deposition flux [1/cm^2/s]
         // Output: values are dvel, dflx
@@ -916,7 +932,7 @@ void MAMMicrophysics::run_impl(const double dt) {
             offset_aerosol, config.linoz.o3_sfc, config.linoz.o3_tau,
             config.linoz.o3_lbl, dry_diameter_icol, wet_diameter_icol,
             wetdens_icol, dry_atm.phis(icol), cmfdqr, prain_icol, nevapr_icol,
-            work_set_het_icol, drydep_data, dvel_col, dflx_col, progs);
+            work_set_het_icol, drydep_data, aqso4_flx_col,  aqh2so4_flx_col, dvel_col, dflx_col, progs);
 
         team.team_barrier();
         // Update constituent fluxes with gas drydep fluxes (dflx)
@@ -926,7 +942,10 @@ void MAMMicrophysics::run_impl(const double dt) {
         Kokkos::parallel_for(Kokkos::TeamVectorRange(team, offset_aerosol, pcnst), [&](int ispc) {
           constituent_fluxes(icol, ispc) -= dflx_col[ispc - offset_aerosol];
         });
-
+        Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nmodes), [&](int m) {
+           aqso4_flx(icol, m) = aqso4_flx_col[m];
+           aqh2so4_flx(icol, m) = aqh2so4_flx_col[m];
+        });
       });  // parallel_for for the column loop
   Kokkos::fence();
 


### PR DESCRIPTION
Add the diagnostic output fields named:
  "dqdt_so4_aqueous_chemistry" -- Units mole/mole/s of So4
  "dqdt_h2so4_uptake" -- Units mole/mole/s of H2So4

These are intermediate values computed during the mam4xx atmospheric chemistry and microphysics calculation. Mam4 had them as output diagnostics and this just enables the same for mam4xx.

[BFB]