### PR TITLE
EAMxx: refactor IO to more heavily rely on Field interfaces

### DIFF
--- a/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
@@ -210,8 +210,6 @@ void MAMOptics::initialize_impl(const RunType run_type) {
   {
     using namespace ShortFieldTagsNames;
 
-    using view_1d_host = typename KT::view_1d<Real>::HostMirror;
-
     // Note: these functions do not set values for aerosol_optics_device_data_.
     mam4::modal_aer_opt::set_complex_views_modal_aero(
         aerosol_optics_device_data_);
@@ -220,14 +218,7 @@ void MAMOptics::initialize_impl(const RunType run_type) {
     mam4::modal_aer_opt::set_aerosol_optics_data_for_modal_aero_lw_views(
         aerosol_optics_device_data_);
 
-    mam_coupling::AerosolOpticsHostData aerosol_optics_host_data;
-
-    std::map<std::string, FieldLayout> layouts;
-    std::map<std::string, view_1d_host> host_views;
-    ekat::ParameterList rrtmg_params;
-
-    mam_coupling::set_parameters_table(aerosol_optics_host_data, rrtmg_params,
-                                       layouts, host_views);
+    auto aerosol_optics_fields = mam_coupling::create_optics_fields(grid_);
 
     for(int imode = 0; imode < ntot_amode; imode++) {
       const auto key =
@@ -235,8 +226,8 @@ void MAMOptics::initialize_impl(const RunType run_type) {
       const auto &fname = m_params.get<std::string>(key);
       mam_coupling::read_rrtmg_table(fname,
                                      imode,  // mode No
-                                     rrtmg_params, grid_, host_views, layouts,
-                                     aerosol_optics_host_data,
+                                     grid_,
+                                     aerosol_optics_fields,
                                      aerosol_optics_device_data_);
     }
 
@@ -249,14 +240,8 @@ void MAMOptics::initialize_impl(const RunType run_type) {
                                       aerosol_optics_device_data_.crefwsw);
     //
     {
-      // make a list of host views
-      std::map<std::string, view_1d_host> host_views_aero;
-      // defines layouts
-      std::map<std::string, FieldLayout> layouts_aero;
-      ekat::ParameterList params_aero;
       std::string surname_aero = "aer";
-      mam_coupling::set_refindex_names(surname_aero, params_aero,
-                                       host_views_aero, layouts_aero);
+      auto refindex_fields = mam_coupling::create_refindex_fields (surname_aero,grid_);
 
       constexpr int maxd_aspectype = mam4::ndrop::maxd_aspectype;
       auto specrefndxsw_host       = mam_coupling::complex_view_2d::HostMirror(
@@ -283,14 +268,12 @@ void MAMOptics::initialize_impl(const RunType run_type) {
         const auto &fname = m_params.get<std::string>(table_name);
         // read data
         // need to update table name
-        params_aero.set("filename", fname);
-        AtmosphereInput refindex_aerosol(params_aero, grid_, host_views_aero,
-                                         layouts_aero);
+        AtmosphereInput refindex_aerosol(fname, grid_, refindex_fields);
         refindex_aerosol.read_variables();
         refindex_aerosol.finalize();
         // copy data to device
         mam_coupling::set_refindex_aerosol(
-            species_id, host_views_aero,
+            species_id, refindex_fields,
             specrefndxsw_host,  // complex refractive index for water visible
             specrefndxlw_host);
       }  // done ispec

--- a/components/eamxx/src/share/CMakeLists.txt
+++ b/components/eamxx/src/share/CMakeLists.txt
@@ -82,6 +82,30 @@ list (APPEND SHARE_SRC
   field/eti/field_eti_update_impl_int_host.cpp
   field/eti/field_eti_update_int_device.cpp
   field/eti/field_eti_update_int_host.cpp
+  field/eti/field_utils_eti_compute_mask_lt_int.cpp
+  field/eti/field_utils_eti_compute_mask_lt_float.cpp
+  field/eti/field_utils_eti_compute_mask_lt_double.cpp
+  field/eti/field_utils_eti_compute_mask_ne_int.cpp
+  field/eti/field_utils_eti_compute_mask_ne_float.cpp
+  field/eti/field_utils_eti_compute_mask_ne_double.cpp
+  field/eti/field_eti_update_max_min_double_device.cpp
+  field/eti/field_eti_update_max_min_double_host.cpp
+  field/eti/field_eti_update_max_min_float_device.cpp
+  field/eti/field_eti_update_max_min_float_host.cpp
+  field/eti/field_eti_update_max_min_impl_double_device.cpp
+  field/eti/field_eti_update_max_min_impl_double_host.cpp
+  field/eti/field_eti_update_max_min_impl_fill_double_device.cpp
+  field/eti/field_eti_update_max_min_impl_fill_double_host.cpp
+  field/eti/field_eti_update_max_min_impl_fill_float_device.cpp
+  field/eti/field_eti_update_max_min_impl_fill_float_host.cpp
+  field/eti/field_eti_update_max_min_impl_fill_int_device.cpp
+  field/eti/field_eti_update_max_min_impl_fill_int_host.cpp
+  field/eti/field_eti_update_max_min_impl_float_device.cpp
+  field/eti/field_eti_update_max_min_impl_float_host.cpp
+  field/eti/field_eti_update_max_min_impl_int_device.cpp
+  field/eti/field_eti_update_max_min_impl_int_host.cpp
+  field/eti/field_eti_update_max_min_int_device.cpp
+  field/eti/field_eti_update_max_min_int_host.cpp
 )
 
 if (EAMXX_ENABLE_EXPERIMENTAL_CODE)

--- a/components/eamxx/src/share/CMakeLists.txt
+++ b/components/eamxx/src/share/CMakeLists.txt
@@ -82,9 +82,9 @@ list (APPEND SHARE_SRC
   field/eti/field_eti_update_impl_int_host.cpp
   field/eti/field_eti_update_int_device.cpp
   field/eti/field_eti_update_int_host.cpp
-  field/eti/field_utils_eti_compute_mask_lt_int.cpp
-  field/eti/field_utils_eti_compute_mask_lt_float.cpp
-  field/eti/field_utils_eti_compute_mask_lt_double.cpp
+  field/eti/field_utils_eti_compute_mask_le_int.cpp
+  field/eti/field_utils_eti_compute_mask_le_float.cpp
+  field/eti/field_utils_eti_compute_mask_le_double.cpp
   field/eti/field_utils_eti_compute_mask_ne_int.cpp
   field/eti/field_utils_eti_compute_mask_ne_float.cpp
   field/eti/field_utils_eti_compute_mask_ne_double.cpp

--- a/components/eamxx/src/share/atm_process/IOPDataManager.cpp
+++ b/components/eamxx/src/share/atm_process/IOPDataManager.cpp
@@ -311,9 +311,11 @@ setup_io_info(const std::string& file_name,
     auto grid = create_point_grid(grid_name,nc_file_ncols,nlevs,m_comm);
 
     // Read lat/lon fields from dile
-    auto lat = grid->create_geometry_data("lat",grid->get_2d_scalar_layout());
-    auto lon = grid->create_geometry_data("lon",grid->get_2d_scalar_layout());
-    AtmosphereInput latlon_reader (file_name,grid,{lat,lon});
+    std::vector<Field> latlon = {
+      grid->create_geometry_data("lat",grid->get_2d_scalar_layout()),
+      grid->create_geometry_data("lon",grid->get_2d_scalar_layout())
+    };
+    AtmosphereInput latlon_reader (file_name,grid,latlon);
     latlon_reader.read_variables();
 
     m_io_grids[grid_name] = grid;

--- a/components/eamxx/src/share/field/eti/field_eti_update_max_min_double_device.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_max_min_double_device.cpp
@@ -1,0 +1,8 @@
+#include "share/field/field.hpp"
+
+namespace scream {
+
+template void Field::update<CombineMode::Max, Device, double>(const Field&, const double, const double);
+template void Field::update<CombineMode::Min, Device, double>(const Field&, const double, const double);
+
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_max_min_double_host.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_max_min_double_host.cpp
@@ -1,0 +1,8 @@
+#include "share/field/field.hpp"
+
+namespace scream {
+
+template void Field::update<CombineMode::Max, Host, double>(const Field&, const double, const double);
+template void Field::update<CombineMode::Min, Host, double>(const Field&, const double, const double);
+
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_max_min_float_device.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_max_min_float_device.cpp
@@ -1,0 +1,8 @@
+#include "share/field/field.hpp"
+
+namespace scream {
+
+template void Field::update<CombineMode::Max, Device, float>(const Field&, const float, const float);
+template void Field::update<CombineMode::Min, Device, float>(const Field&, const float, const float);
+
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_max_min_float_host.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_max_min_float_host.cpp
@@ -1,0 +1,8 @@
+#include "share/field/field.hpp"
+
+namespace scream {
+
+template void Field::update<CombineMode::Max, Host, float>(const Field&, const float, const float);
+template void Field::update<CombineMode::Min, Host, float>(const Field&, const float, const float);
+
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_double_device.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_double_device.cpp
@@ -1,0 +1,14 @@
+#include "share/field/field.hpp"
+
+namespace scream {
+
+template void Field::update_impl<CombineMode::Max, Device, false, double, double>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Min, Device, false, double, double>(const Field&, const double, const double);
+
+template void Field::update_impl<CombineMode::Max, Device, false, double, float>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Min, Device, false, double, float>(const Field&, const double, const double);
+
+template void Field::update_impl<CombineMode::Max, Device, false, double, int>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Min, Device, false, double, int>(const Field&, const double, const double);
+
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_double_host.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_double_host.cpp
@@ -1,0 +1,14 @@
+#include "share/field/field.hpp"
+
+namespace scream {
+
+template void Field::update_impl<CombineMode::Max, Host, false, double, double>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Min, Host, false, double, double>(const Field&, const double, const double);
+
+template void Field::update_impl<CombineMode::Max, Host, false, double, float>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Min, Host, false, double, float>(const Field&, const double, const double);
+
+template void Field::update_impl<CombineMode::Max, Host, false, double, int>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Min, Host, false, double, int>(const Field&, const double, const double);
+
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_fill_double_device.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_fill_double_device.cpp
@@ -1,0 +1,14 @@
+#include "share/field/field.hpp"
+
+namespace scream {
+
+template void Field::update_impl<CombineMode::Max, Device, true, double, double>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Min, Device, true, double, double>(const Field&, const double, const double);
+
+template void Field::update_impl<CombineMode::Max, Device, true, double, float>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Min, Device, true, double, float>(const Field&, const double, const double);
+
+template void Field::update_impl<CombineMode::Max, Device, true, double, int>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Min, Device, true, double, int>(const Field&, const double, const double);
+
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_fill_double_host.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_fill_double_host.cpp
@@ -1,0 +1,14 @@
+#include "share/field/field.hpp"
+
+namespace scream {
+
+template void Field::update_impl<CombineMode::Max, Host, true, double, double>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Min, Host, true, double, double>(const Field&, const double, const double);
+
+template void Field::update_impl<CombineMode::Max, Host, true, double, float>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Min, Host, true, double, float>(const Field&, const double, const double);
+
+template void Field::update_impl<CombineMode::Max, Host, true, double, int>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Min, Host, true, double, int>(const Field&, const double, const double);
+
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_fill_float_device.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_fill_float_device.cpp
@@ -1,0 +1,11 @@
+#include "share/field/field.hpp"
+
+namespace scream {
+
+template void Field::update_impl<CombineMode::Max, Device, true, float, float>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Min, Device, true, float, float>(const Field&, const float, const float);
+
+template void Field::update_impl<CombineMode::Max, Device, true, float, int>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Min, Device, true, float, int>(const Field&, const float, const float);
+
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_fill_float_host.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_fill_float_host.cpp
@@ -1,0 +1,11 @@
+#include "share/field/field.hpp"
+
+namespace scream {
+
+template void Field::update_impl<CombineMode::Max, Host, true, float, float>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Min, Host, true, float, float>(const Field&, const float, const float);
+
+template void Field::update_impl<CombineMode::Max, Host, true, float, int>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Min, Host, true, float, int>(const Field&, const float, const float);
+
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_fill_int_device.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_fill_int_device.cpp
@@ -1,0 +1,8 @@
+#include "share/field/field.hpp"
+
+namespace scream {
+
+template void Field::update_impl<CombineMode::Max, Device, true, int, int>(const Field&, const int, const int);
+template void Field::update_impl<CombineMode::Min, Device, true, int, int>(const Field&, const int, const int);
+
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_fill_int_host.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_fill_int_host.cpp
@@ -1,0 +1,8 @@
+#include "share/field/field.hpp"
+
+namespace scream {
+
+template void Field::update_impl<CombineMode::Max, Host, true, int, int>(const Field&, const int, const int);
+template void Field::update_impl<CombineMode::Min, Host, true, int, int>(const Field&, const int, const int);
+
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_float_device.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_float_device.cpp
@@ -1,0 +1,11 @@
+#include "share/field/field.hpp"
+
+namespace scream {
+
+template void Field::update_impl<CombineMode::Max, Device, false, float, float>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Min, Device, false, float, float>(const Field&, const float, const float);
+
+template void Field::update_impl<CombineMode::Max, Device, false, float, int>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Min, Device, false, float, int>(const Field&, const float, const float);
+
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_float_host.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_float_host.cpp
@@ -1,0 +1,11 @@
+#include "share/field/field.hpp"
+
+namespace scream {
+
+template void Field::update_impl<CombineMode::Max, Host, false, float, float>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Min, Host, false, float, float>(const Field&, const float, const float);
+
+template void Field::update_impl<CombineMode::Max, Host, false, float, int>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Min, Host, false, float, int>(const Field&, const float, const float);
+
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_int_device.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_int_device.cpp
@@ -1,0 +1,8 @@
+#include "share/field/field.hpp"
+
+namespace scream {
+
+template void Field::update_impl<CombineMode::Max, Device, false, int, int>(const Field&, const int, const int);
+template void Field::update_impl<CombineMode::Min, Device, false, int, int>(const Field&, const int, const int);
+
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_int_host.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_max_min_impl_int_host.cpp
@@ -1,0 +1,8 @@
+#include "share/field/field.hpp"
+
+namespace scream {
+
+template void Field::update_impl<CombineMode::Max, Host, false, int, int>(const Field&, const int, const int);
+template void Field::update_impl<CombineMode::Min, Host, false, int, int>(const Field&, const int, const int);
+
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_max_min_int_device.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_max_min_int_device.cpp
@@ -1,0 +1,8 @@
+#include "share/field/field.hpp"
+
+namespace scream {
+
+template void Field::update<CombineMode::Max, Device, int>(const Field&, const int, const int);
+template void Field::update<CombineMode::Min, Device, int>(const Field&, const int, const int);
+
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_eti_update_max_min_int_host.cpp
+++ b/components/eamxx/src/share/field/eti/field_eti_update_max_min_int_host.cpp
@@ -1,0 +1,8 @@
+#include "share/field/field.hpp"
+
+namespace scream {
+
+template void Field::update<CombineMode::Max, Host, int>(const Field&, const int, const int);
+template void Field::update<CombineMode::Min, Host, int>(const Field&, const int, const int);
+
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_utils_eti_compute_mask_le_double.cpp
+++ b/components/eamxx/src/share/field/eti/field_utils_eti_compute_mask_le_double.cpp
@@ -3,7 +3,7 @@
 namespace scream {
 namespace impl {
 
-template void compute_mask<Comparison::LT,double>(const Field&, double, Field&);
+template void compute_mask<Comparison::LE,double>(const Field&, double, Field&);
 
 } // namespace impl
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_utils_eti_compute_mask_le_float.cpp
+++ b/components/eamxx/src/share/field/eti/field_utils_eti_compute_mask_le_float.cpp
@@ -3,7 +3,7 @@
 namespace scream {
 namespace impl {
 
-template void compute_mask<Comparison::LT,float>(const Field&, float, Field&);
+template void compute_mask<Comparison::LE,float>(const Field&, float, Field&);
 
 } // namespace impl
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_utils_eti_compute_mask_le_int.cpp
+++ b/components/eamxx/src/share/field/eti/field_utils_eti_compute_mask_le_int.cpp
@@ -3,7 +3,7 @@
 namespace scream {
 namespace impl {
 
-template void compute_mask<Comparison::LT,int>(const Field&, int, Field&);
+template void compute_mask<Comparison::LE,int>(const Field&, int, Field&);
 
 } // namespace impl
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_utils_eti_compute_mask_lt_double.cpp
+++ b/components/eamxx/src/share/field/eti/field_utils_eti_compute_mask_lt_double.cpp
@@ -1,0 +1,9 @@
+#include "share/field/field_utils_impl.hpp"
+
+namespace scream {
+namespace impl {
+
+template void compute_mask<Comparison::LT,double>(const Field&, double, Field&);
+
+} // namespace impl
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_utils_eti_compute_mask_lt_float.cpp
+++ b/components/eamxx/src/share/field/eti/field_utils_eti_compute_mask_lt_float.cpp
@@ -1,0 +1,9 @@
+#include "share/field/field_utils_impl.hpp"
+
+namespace scream {
+namespace impl {
+
+template void compute_mask<Comparison::LT,float>(const Field&, float, Field&);
+
+} // namespace impl
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_utils_eti_compute_mask_lt_int.cpp
+++ b/components/eamxx/src/share/field/eti/field_utils_eti_compute_mask_lt_int.cpp
@@ -1,0 +1,9 @@
+#include "share/field/field_utils_impl.hpp"
+
+namespace scream {
+namespace impl {
+
+template void compute_mask<Comparison::LT,int>(const Field&, int, Field&);
+
+} // namespace impl
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_utils_eti_compute_mask_ne_double.cpp
+++ b/components/eamxx/src/share/field/eti/field_utils_eti_compute_mask_ne_double.cpp
@@ -1,0 +1,9 @@
+#include "share/field/field_utils_impl.hpp"
+
+namespace scream {
+namespace impl {
+
+template void compute_mask<Comparison::NE,double>(const Field&, double, Field&);
+
+} // namespace impl
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_utils_eti_compute_mask_ne_float.cpp
+++ b/components/eamxx/src/share/field/eti/field_utils_eti_compute_mask_ne_float.cpp
@@ -1,0 +1,9 @@
+#include "share/field/field_utils_impl.hpp"
+
+namespace scream {
+namespace impl {
+
+template void compute_mask<Comparison::NE,float>(const Field&, float, Field&);
+
+} // namespace impl
+} // namespace scream

--- a/components/eamxx/src/share/field/eti/field_utils_eti_compute_mask_ne_int.cpp
+++ b/components/eamxx/src/share/field/eti/field_utils_eti_compute_mask_ne_int.cpp
@@ -1,0 +1,9 @@
+#include "share/field/field_utils_impl.hpp"
+
+namespace scream {
+namespace impl {
+
+template void compute_mask<Comparison::NE,int>(const Field&, int, Field&);
+
+} // namespace impl
+} // namespace scream

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -425,6 +425,10 @@ extern template void Field::update<CombineMode::Update, S, T>(const Field&, cons
 extern template void Field::update<CombineMode::Multiply, S, T>(const Field&, const T, const T);            \
 extern template void Field::update<CombineMode::Divide, S, T>(const Field&, const T, const T)
 
+#define EAMXX_FIELD_ETI_DECL_UPDATE_MAX_MIN(S,T) \
+extern template void Field::update<CombineMode::Max, S, T>(const Field&, const T, const T);            \
+extern template void Field::update<CombineMode::Min, S, T>(const Field&, const T, const T)
+
 #define EAMXX_FIELD_ETI_DECL_UPDATE_IMPL(S,T1,T2) \
 extern template void Field::update_impl<CombineMode::Update,  S, true, T1, T2>(const Field&, const T1, const T1);  \
 extern template void Field::update_impl<CombineMode::Multiply,S, true, T1, T2>(const Field&, const T1, const T1);  \
@@ -432,6 +436,12 @@ extern template void Field::update_impl<CombineMode::Divide,  S, true, T1, T2>(c
 extern template void Field::update_impl<CombineMode::Update,  S, false, T1, T2>(const Field&, const T1, const T1); \
 extern template void Field::update_impl<CombineMode::Multiply,S, false, T1, T2>(const Field&, const T1, const T1); \
 extern template void Field::update_impl<CombineMode::Divide,  S, false, T1, T2>(const Field&, const T1, const T1)
+
+#define EAMXX_FIELD_ETI_DECL_UPDATE_MAX_MIN_IMPL(S,T1,T2) \
+extern template void Field::update_impl<CombineMode::Max, S, true, T1, T2>(const Field&, const T1, const T1);  \
+extern template void Field::update_impl<CombineMode::Min, S, true, T1, T2>(const Field&, const T1, const T1);  \
+extern template void Field::update_impl<CombineMode::Max, S, false, T1, T2>(const Field&, const T1, const T1); \
+extern template void Field::update_impl<CombineMode::Min, S, false, T1, T2>(const Field&, const T1, const T1)
 
 #define EAMXX_FIELD_ETI_DECL_DEEP_COPY(S,T) \
 extern template void Field::deep_copy_impl<S,true,T>(const T, const Field&); \
@@ -456,6 +466,8 @@ extern template Field::get_strided_view_type<T******,S> Field::get_strided_view<
 #define EAMXX_FIELD_ETI_DECL_FOR_ONE_TYPE(T) \
 EAMXX_FIELD_ETI_DECL_UPDATE(Device,T);          \
 EAMXX_FIELD_ETI_DECL_UPDATE(Host,T);            \
+EAMXX_FIELD_ETI_DECL_UPDATE_MAX_MIN(Device,T);  \
+EAMXX_FIELD_ETI_DECL_UPDATE_MAX_MIN(Host,T);    \
 EAMXX_FIELD_ETI_DECL_DEEP_COPY(Device,T);       \
 EAMXX_FIELD_ETI_DECL_DEEP_COPY(Host,T);         \
 EAMXX_FIELD_ETI_DECL_GET_VIEW(Device,T);        \
@@ -464,8 +476,10 @@ EAMXX_FIELD_ETI_DECL_GET_VIEW(Device,const T);  \
 EAMXX_FIELD_ETI_DECL_GET_VIEW(Host,const T)
 
 #define EAMXX_FIELD_ETI_DECL_FOR_TWO_TYPES(T1,T2) \
-EAMXX_FIELD_ETI_DECL_UPDATE_IMPL(Device,T1,T2);   \
-EAMXX_FIELD_ETI_DECL_UPDATE_IMPL(Host,T1,T2)
+EAMXX_FIELD_ETI_DECL_UPDATE_IMPL(Device,T1,T2);           \
+EAMXX_FIELD_ETI_DECL_UPDATE_IMPL(Host,T1,T2);             \
+EAMXX_FIELD_ETI_DECL_UPDATE_MAX_MIN_IMPL(Device,T1,T2);   \
+EAMXX_FIELD_ETI_DECL_UPDATE_MAX_MIN_IMPL(Host,T1,T2)
 
 // TODO: should we ETI other scalar types too? E.g. Pack<Real,SCREAM_PACK_SIZE??
 //       Real is by far the most common, so it'd be nice to just to that. But

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -247,6 +247,14 @@ public:
   template<HostOrDevice HD = Device>
   void scale_inv (const Field& x) { update<CombineMode::Divide,HD>(x,1,1); }
 
+  // Replace *this with max(*this, x)
+  template<HostOrDevice HD = Device>
+  void max (const Field& x) { update<CombineMode::Max,HD>(x,1,1); }
+
+  // Replace *this with min(*this, x)
+  template<HostOrDevice HD = Device>
+  void min (const Field& x) { update<CombineMode::Min,HD>(x,1,1); }
+
   // Returns a subview of this field, slicing at entry k along dimension idim
   // NOTES:
   //   - the output field stores *the same* 1d view as this field. In order

--- a/components/eamxx/src/share/field/field_impl_details.hpp
+++ b/components/eamxx/src/share/field/field_impl_details.hpp
@@ -54,9 +54,9 @@ struct CombineViewsHelper {
   void operator() (int i) const {
     if constexpr (use_fill)
       if constexpr (N==0)
-        combine_and_fill<CM>(rhs(),lhs(),fill_val,alpha,beta);
+        fill_aware_combine<CM>(rhs(),lhs(),fill_val,alpha,beta);
       else
-        combine_and_fill<CM>(rhs(i),lhs(i),fill_val,alpha,beta);
+        fill_aware_combine<CM>(rhs(i),lhs(i),fill_val,alpha,beta);
     else
       if constexpr (N==0)
         combine<CM>(rhs(),lhs(),alpha,beta);
@@ -67,7 +67,7 @@ struct CombineViewsHelper {
   KOKKOS_INLINE_FUNCTION
   void operator() (int i, int j) const {
     if constexpr (use_fill)
-      combine_and_fill<CM>(rhs(i,j),lhs(i,j),fill_val,alpha,beta);
+      fill_aware_combine<CM>(rhs(i,j),lhs(i,j),fill_val,alpha,beta);
     else
       combine<CM>(rhs(i,j),lhs(i,j),alpha,beta);
   }
@@ -75,7 +75,7 @@ struct CombineViewsHelper {
   KOKKOS_INLINE_FUNCTION
   void operator() (int i, int j, int k) const {
     if constexpr (use_fill)
-      combine_and_fill<CM>(rhs(i,j,k),lhs(i,j,k),fill_val,alpha,beta);
+      fill_aware_combine<CM>(rhs(i,j,k),lhs(i,j,k),fill_val,alpha,beta);
     else
       combine<CM>(rhs(i,j,k),lhs(i,j,k),alpha,beta);
   }
@@ -83,7 +83,7 @@ struct CombineViewsHelper {
   KOKKOS_INLINE_FUNCTION
   void operator() (int i, int j, int k, int l) const {
     if constexpr (use_fill)
-      combine_and_fill<CM>(rhs(i,j,k,l),lhs(i,j,k,l),fill_val,alpha,beta);
+      fill_aware_combine<CM>(rhs(i,j,k,l),lhs(i,j,k,l),fill_val,alpha,beta);
     else
       combine<CM>(rhs(i,j,k,l),lhs(i,j,k,l),alpha,beta);
   }
@@ -91,7 +91,7 @@ struct CombineViewsHelper {
   KOKKOS_INLINE_FUNCTION
   void operator() (int i, int j, int k, int l, int m) const {
     if constexpr (use_fill)
-      combine_and_fill<CM>(rhs(i,j,k,l,m),lhs(i,j,k,l,m),fill_val,alpha,beta);
+      fill_aware_combine<CM>(rhs(i,j,k,l,m),lhs(i,j,k,l,m),fill_val,alpha,beta);
     else
       combine<CM>(rhs(i,j,k,l,m),lhs(i,j,k,l,m),alpha,beta);
   }
@@ -99,7 +99,7 @@ struct CombineViewsHelper {
   KOKKOS_INLINE_FUNCTION
   void operator() (int i, int j, int k, int l, int m, int n) const {
     if constexpr (use_fill)
-      combine_and_fill<CM>(rhs(i,j,k,l,m,n),lhs(i,j,k,l,m,n),fill_val,alpha,beta);
+      fill_aware_combine<CM>(rhs(i,j,k,l,m,n),lhs(i,j,k,l,m,n),fill_val,alpha,beta);
     else
       combine<CM>(rhs(i,j,k,l,m,n),lhs(i,j,k,l,m,n),alpha,beta);
   }

--- a/components/eamxx/src/share/field/field_manager.cpp
+++ b/components/eamxx/src/share/field/field_manager.cpp
@@ -163,7 +163,7 @@ add_to_group (const std::string& field_name, const std::string& grid_name, const
   }
 
   auto& ft = get_field(field_name, grid_name).get_header().get_tracking();
-  ft.add_to_group(group);
+  ft.add_group(group_name);
 }
 
 bool FieldManager::
@@ -743,7 +743,7 @@ void FieldManager::registration_ends ()
         const auto& fnames = group_info->m_fields_names;
         for (const auto& fn : fnames) {
           // Update the field tracking
-          m_fields.at(grid_name).at(fn)->get_header().get_tracking().add_to_group(group_info);
+          m_fields.at(grid_name).at(fn)->get_header().get_tracking().add_group(group_info->m_group_name);
         }
       }
     }
@@ -790,7 +790,7 @@ void FieldManager::add_field (const Field& f) {
   EKAT_REQUIRE_MSG (not has_field(f.name(), grid_name),
       "Error! The method 'add_field' requires the input field to not be already existing.\n"
       "  - field name: " + f.get_header().get_identifier().name() + "\n");
-  EKAT_REQUIRE_MSG (f.get_header().get_tracking().get_groups_info().size()==0 ||
+  EKAT_REQUIRE_MSG (f.get_header().get_tracking().get_groups_names().size()==0 ||
                     m_group_requests.at(grid_name).size()==0,
       "Error! When calling 'add_field', one of the following must be true:\n"
       "  - the input field is not be part of any group,\n"

--- a/components/eamxx/src/share/field/field_manager.hpp
+++ b/components/eamxx/src/share/field/field_manager.hpp
@@ -70,6 +70,13 @@ public:
   // Adds $field_name on $grid_name to group $group_name (creating the group, if necessary).
   // NOTE: if $group_name is allocated as a monolithic field, this throws.
   // NOTE: must be called after registration ends
+  void add_to_group (const std::string& field_name, const std::string& group_name) {
+    EKAT_ASSERT_MSG(m_grids_mgr->size() == 1,
+      "Error! More than one grid exists for FieldManager, must specify grid name to query for adding field to group.\n"
+      "  - Field name: " + field_name + "\n"
+      "  - Grids in FM: " + m_grids_mgr->print_available_grids() + "\n");
+    return add_to_group(field_name, m_grids_mgr->get_repo().begin()->second->name(),group_name);
+  }
   void add_to_group (const std::string& field_name, const std::string& grid_name, const std::string& group_name);
   void add_to_group (const identifier_type& id, const std::string& group_name) { add_to_group(id.name(), id.get_grid_name(), group_name); }
 

--- a/components/eamxx/src/share/field/field_tracking.cpp
+++ b/components/eamxx/src/share/field/field_tracking.cpp
@@ -11,8 +11,8 @@ void FieldTracking::add_customer (const std::weak_ptr<AtmosphereProcess>& custom
 }
 
 void FieldTracking::
-add_to_group (const std::shared_ptr<const FieldGroupInfo>& group) {
-  m_groups.insert(group);
+add_group (const std::string& group_name) {
+  m_groups.insert(group_name);
 }
 
 void FieldTracking::update_time_stamp (const TimeStamp& ts) {

--- a/components/eamxx/src/share/field/field_tracking.hpp
+++ b/components/eamxx/src/share/field/field_tracking.hpp
@@ -45,7 +45,7 @@ public:
   const atm_proc_set_type& get_customers () const { return m_customers; }
 
   // List of field groups that this field belongs to
-  const ekat::WeakPtrSet<const FieldGroupInfo>& get_groups_info () const { return m_groups; }
+  const std::set<ci_string>& get_groups_names () const { return m_groups; }
 
   // ----- Setters ----- //
 
@@ -53,8 +53,8 @@ public:
   void add_provider (const std::weak_ptr<AtmosphereProcess>& provider);
   void add_customer (const std::weak_ptr<AtmosphereProcess>& customer);
 
-  // Add the field to a given group
-  void add_to_group (const std::shared_ptr<const FieldGroupInfo>& group);
+  // Add group name to the list of groups we belong to
+  void add_group (const std::string& group_name);
 
   // Set the time stamp for this field. This can only be called once, due to TimeStamp implementation.
   // NOTE: if the field has 'children' (see FamilyTracking), their ts will be updated too.
@@ -89,8 +89,8 @@ protected:
   // get all tracers, which need to be advected. However, dynamics has no idea (a priori)
   // of what are the tracers names or how many there are, and neither should it care.
   // FieldGroup's allow atm procs to request all fields that have been marked as 'tracers'.
-  // Here, we keep track of all the groups that this field belongs to.
-  ekat::WeakPtrSet<const FieldGroupInfo>    m_groups;
+  // Here, we keep track of the names of all the groups that this field belongs to.
+  std::set<ci_string> m_groups;
 };
 
 // Use this free function to exploit features of enable_shared_from_this,

--- a/components/eamxx/src/share/field/field_utils_impl.hpp
+++ b/components/eamxx/src/share/field/field_utils_impl.hpp
@@ -1224,6 +1224,15 @@ void compute_mask (const Field& x, const ST value, Field& m)
   }
 }
 
+#define EAMXX_FIELD_UTILS_ETI_DECL_COMPUTE_MASK(C) \
+extern template void impl::compute_mask<C, int>(const Field&, const int, Field&); \
+extern template void impl::compute_mask<C, float>(const Field&, const float, Field&); \
+extern template void impl::compute_mask<C, double>(const Field&, const double, Field&)
+
+// Only these two, since they are the only ones used so far (in IO)
+EAMXX_FIELD_UTILS_ETI_DECL_COMPUTE_MASK(Comparison::NE);
+EAMXX_FIELD_UTILS_ETI_DECL_COMPUTE_MASK(Comparison::LT);
+
 } // namespace impl
 
 } // namespace scream

--- a/components/eamxx/src/share/field/field_utils_impl.hpp
+++ b/components/eamxx/src/share/field/field_utils_impl.hpp
@@ -1231,7 +1231,7 @@ extern template void impl::compute_mask<C, double>(const Field&, const double, F
 
 // Only these two, since they are the only ones used so far (in IO)
 EAMXX_FIELD_UTILS_ETI_DECL_COMPUTE_MASK(Comparison::NE);
-EAMXX_FIELD_UTILS_ETI_DECL_COMPUTE_MASK(Comparison::LT);
+EAMXX_FIELD_UTILS_ETI_DECL_COMPUTE_MASK(Comparison::LE);
 
 } // namespace impl
 

--- a/components/eamxx/src/share/grid/mesh_free_grids_manager.cpp
+++ b/components/eamxx/src/share/grid/mesh_free_grids_manager.cpp
@@ -192,22 +192,22 @@ load_lat_lon (const nonconstgrid_ptr_type& grid, const std::string& filename) co
 {
   const auto units = ekat::units::Units::nondimensional();
 
-  auto lat  = grid->create_geometry_data("lat" , grid->get_2d_scalar_layout(), units);
-  auto lon  = grid->create_geometry_data("lon" , grid->get_2d_scalar_layout(), units);
+  auto lat = grid->create_geometry_data("lat" , grid->get_2d_scalar_layout(), units);
+  auto lon = grid->create_geometry_data("lon" , grid->get_2d_scalar_layout(), units);
 
-  AtmosphereInput lat_lon_reader(filename, grid, {lat,lon});
+  std::vector<Field> latlon = {lat,lon};
+
+  AtmosphereInput lat_lon_reader(filename, grid, latlon);
   lat_lon_reader.read_variables();
   lat_lon_reader.finalize();
 
 #ifndef NDEBUG
-  for (auto f : {lat, lon}) {
-    auto lat_check = std::make_shared<FieldNaNCheck>(lat,grid)->check();
-    EKAT_REQUIRE_MSG (lat_check.result==CheckResult::Pass,
-        "ERROR! NaN values detected in latitude field.\n" + lat_check.msg);
-    auto lon_check = std::make_shared<FieldNaNCheck>(lon,grid)->check();
-    EKAT_REQUIRE_MSG (lon_check.result==CheckResult::Pass,
-        "ERROR! NaN values detected in longitude field.\n" + lon_check.msg);
-  }
+  auto lat_check = std::make_shared<FieldNaNCheck>(lat,grid)->check();
+  EKAT_REQUIRE_MSG (lat_check.result==CheckResult::Pass,
+      "ERROR! NaN values detected in latitude field.\n" + lat_check.msg);
+  auto lon_check = std::make_shared<FieldNaNCheck>(lon,grid)->check();
+  EKAT_REQUIRE_MSG (lon_check.result==CheckResult::Pass,
+      "ERROR! NaN values detected in longitude field.\n" + lon_check.msg);
 #endif
 }
 

--- a/components/eamxx/src/share/io/eamxx_output_manager.cpp
+++ b/components/eamxx/src/share/io/eamxx_output_manager.cpp
@@ -497,9 +497,9 @@ void OutputManager::run(const util::TimeStamp& timestamp)
     }
 
     // If we write output, reset local views
-    if (is_output_step) {
+    if (is_output_step and m_avg_type!=OutputAvgType::Instant) {
       for (auto& it : m_output_streams) {
-        it->reset_dev_views();
+        it->reset_scorpio_fields();
       }
     }
 

--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -39,6 +39,26 @@ AtmosphereInput (const std::string& filename,
 }
 
 AtmosphereInput::
+AtmosphereInput (const std::string& filename,
+                 const std::shared_ptr<const grid_type>& grid,
+                 const std::map<std::string,Field>& fields,
+                 const bool skip_grid_checks)
+{
+  // Create param list and field manager on the fly
+  ekat::ParameterList params;
+  params.set("filename",filename);
+  params.set("skip_grid_checks",skip_grid_checks);
+  auto& names = params.get<std::vector<std::string>>("field_names",{});
+
+  auto fm = std::make_shared<fm_type>(grid);
+  for (const auto& [name, f] : fields) {
+    fm->add_field(f);
+    names.push_back(name);
+  }
+  init(params,fm);
+}
+
+AtmosphereInput::
 AtmosphereInput (const std::vector<std::string>& fields_names,
                  const std::shared_ptr<const grid_type>& grid)
 {

--- a/components/eamxx/src/share/io/scorpio_input.hpp
+++ b/components/eamxx/src/share/io/scorpio_input.hpp
@@ -57,6 +57,10 @@ public:
                    const std::shared_ptr<const grid_type>& grid,
                    const std::vector<Field>& fields,
                    const bool skip_grid_checks = false);
+  AtmosphereInput (const std::string& filename,
+                   const std::shared_ptr<const grid_type>& grid,
+                   const std::map<std::string,Field>& fields,
+                   const bool skip_grid_checks = false);
   // This constructor only sets the minimal info, deferring initialization
   // to when set_field_manager/reset_fields and reset_filename are called
   AtmosphereInput (const std::vector<std::string>& fields_names,

--- a/components/eamxx/src/share/io/scorpio_input.hpp
+++ b/components/eamxx/src/share/io/scorpio_input.hpp
@@ -53,10 +53,6 @@ public:
   AtmosphereInput () = default;
   AtmosphereInput (const ekat::ParameterList& params,
                    const std::shared_ptr<const fm_type>& field_mgr);
-  AtmosphereInput (const ekat::ParameterList& params,
-                   const std::shared_ptr<const grid_type>& grid,
-                   const std::map<std::string,view_1d_host>& host_views_1d,
-                   const std::map<std::string,FieldLayout>&  layouts);
   AtmosphereInput (const std::string& filename,
                    const std::shared_ptr<const grid_type>& grid,
                    const std::vector<Field>& fields,
@@ -81,17 +77,6 @@ public:
   //               Fields can be padded/strided.
   void init (const ekat::ParameterList& params,
              const std::shared_ptr<const fm_type>& field_mgr);
-
-  // Initialize the class for reading into user-provided flattened 1d host views.
-  //  - params: input parameters (must contain at least "filename")
-  //  - grid: the grid where the variables live
-  //  - host_views_1d: the 1d flattened views where data will be read into.
-  //                   These views must be contiguous (no padding/striding).
-  //  - layouts: the layout of the vars (used to reshape the views).
-  void init (const ekat::ParameterList& params,
-             const std::shared_ptr<const grid_type>& grid,
-             const std::map<std::string,view_1d_host>& host_views_1d,
-             const std::map<std::string,FieldLayout>&  layouts);
 
   // Read fields that were required via parameter list.
   void read_variables (const int time_index = -1);
@@ -126,17 +111,15 @@ protected:
   // Internal variables
   ekat::ParameterList   m_params;
 
-  std::shared_ptr<const fm_type>        m_field_mgr;
+  std::shared_ptr<const fm_type>        m_fm_from_user;
+  std::shared_ptr<fm_type>              m_fm_for_scorpio;
   std::shared_ptr<const AbstractGrid>   m_io_grid;
 
-  std::map<std::string, view_1d_host>   m_host_views_1d;
-  std::map<std::string, FieldLayout>    m_layouts;
-  
   std::string               m_filename;
   std::vector<std::string>  m_fields_names;
 
-  bool m_inited_with_fields        = false;
-  bool m_inited_with_views         = false;
+  bool m_fields_inited  = false;
+  bool m_scorpio_inited = false;
 
   // The logger to be used throughout the ATM to log message
   std::shared_ptr<ekat::logger::LoggerBase> m_atm_logger;

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -586,8 +586,6 @@ void AtmosphereOutput::set_avg_cnt_tracking(const std::string& name, const Field
 
   // We will use a helper field for updating cnt, so store it inside the field header
   auto mask = count.clone(count.name()+"_mask");
-  mask.get_header().set_extra_data("true_value",int(1));
-  mask.get_header().set_extra_data("false_value",int(0));
   count.get_header().set_extra_data("mask",mask);
 
   m_avg_counts.push_back(count);

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -440,7 +440,7 @@ run (const std::string& filename,
         // If count<=threshold, we set count=fill_value, so that fill_val propagates
         // to the output fields when we divide by count later
         if (output_step and m_avg_type==OutputAvgType::Average) {
-          int min_count = static_cast<int>(std::ceil(m_avg_coeff_threshold*nsteps_since_last_output));
+          int min_count = static_cast<int>(std::floor(m_avg_coeff_threshold*nsteps_since_last_output));
 
           // Recycle mask to find where count<thresh
           compute_mask<Comparison::LE>(count,min_count,mask);

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -443,7 +443,7 @@ run (const std::string& filename,
           int min_count = static_cast<int>(std::ceil(m_avg_coeff_threshold*nsteps_since_last_output));
 
           // Recycle mask to find where count<thresh
-          compute_mask<Comparison::LT>(count,min_count,mask);
+          compute_mask<Comparison::LE>(count,min_count,mask);
 
           // Later, we divide fields by count. By setting count=1 where count<thresholt,
           // we can later do

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -275,7 +275,7 @@ void AtmosphereOutput::init()
     // when calling Field's update methods
     if (m_avg_type!=OutputAvgType::Instant or
         fh.get_alloc_properties().get_padding()>0 or
-        m_track_avg_cnt) {
+        fh.get_parent()!=nullptr) {
       Field copy(fid);
       copy.allocate_view();
       transfer_io_str_atts (f,copy);

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -1,85 +1,39 @@
 #include "share/io/scorpio_output.hpp"
 #include "share/io/scorpio_input.hpp"
-#include "share/util/eamxx_array_utils.hpp"
+#include "share/io/eamxx_io_utils.hpp"
 #include "share/grid/remap/coarsening_remapper.hpp"
 #include "share/grid/remap/vertical_remapper.hpp"
 #include "share/util/eamxx_timing.hpp"
 #include "share/field/field_utils.hpp"
 
-#include "diagnostics/register_diagnostics.hpp"
-
-#include "ekat/util/ekat_units.hpp"
-#include "ekat/util/ekat_string_utils.hpp"
-#include "ekat/std_meta/ekat_std_utils.hpp"
+#include <ekat/util/ekat_units.hpp>
+#include <ekat/util/ekat_string_utils.hpp>
+#include <ekat/std_meta/ekat_std_utils.hpp>
 
 #include <numeric>
-#include <fstream>
+
+namespace {
+  // Helper lambda, to copy io string attributes. This will be used if any
+  // remapper is created, to ensure atts set by atm_procs are not lost
+  void transfer_io_str_atts  (const scream::Field& src, scream::Field& tgt) {
+    const std::string io_string_atts_key ="io: string attributes";
+    using stratts_t = std::map<std::string,std::string>;
+    const auto& src_atts = src.get_header().get_extra_data<stratts_t>(io_string_atts_key);
+          auto& dst_atts = tgt.get_header().get_extra_data<stratts_t>(io_string_atts_key);
+    for (const auto& [name,val] : src_atts) {
+      dst_atts[name] = val;
+    }
+  };
+}
 
 namespace scream
 {
 
-// This helper function updates the current output val with a new one,
-// according to the "averaging" type, and according to the number of
-// model time steps since the last output step.
-KOKKOS_INLINE_FUNCTION
-void combine (const Real& new_val, Real& curr_val, const OutputAvgType avg_type)
+template<typename T>
+bool has_duplicates (const std::vector<T>& c)
 {
-  switch (avg_type) {
-    case OutputAvgType::Instant:
-      curr_val = new_val;
-      break;
-    case OutputAvgType::Max:
-      curr_val = ekat::impl::max(curr_val,new_val);
-      break;
-    case OutputAvgType::Min:
-      curr_val = ekat::impl::min(curr_val,new_val);
-      break;
-    case OutputAvgType::Average:
-      curr_val += new_val;
-      break;
-    default:
-      EKAT_KERNEL_ERROR_MSG ("Unexpected value for m_avg_type. Please, contact developers.\n");
-  }
-}
-// This one covers cases where a variable might be masked.
-KOKKOS_INLINE_FUNCTION
-void combine_and_fill (const Real& new_val, Real& curr_val, const OutputAvgType avg_type, const Real fill_value)
-{
-  const bool new_fill  = new_val  == fill_value;
-  const bool curr_fill = curr_val == fill_value;
-  if (curr_fill && new_fill) {
-    // Then the value is already set to be filled and the new value doesn't change things.
-    return;
-  } else if (curr_fill) {
-    // Then the current value is filled but the new value will replace that for all cases.
-    curr_val = new_val;
-  } else {
-    switch (avg_type) {
-      case OutputAvgType::Instant:
-        curr_val = new_val;
-        break;
-      case OutputAvgType::Max:
-        curr_val = new_fill ? curr_val : ekat::impl::max(curr_val,new_val);
-        break;
-      case OutputAvgType::Min:
-        curr_val = new_fill ? curr_val : ekat::impl::min(curr_val,new_val);
-        break;
-      case OutputAvgType::Average:
-        curr_val += (new_fill ? 0.0 : new_val);
-        break;
-      default:
-        EKAT_KERNEL_ERROR_MSG ("Unexpected value for m_avg_type. Please, contact developers.\n");
-    }
-  }
-}
-
-// This helper function is used to make sure that the list of fields in
-// m_fields_names is a list of unique strings, otherwise throw an error.
-void sort_and_check(std::vector<std::string>& fields)
-{
-  std::sort(fields.begin(),fields.end());
-  const bool hasDuplicates = std::adjacent_find(fields.begin(),fields.end()) != fields.end();
-  EKAT_REQUIRE_MSG(!hasDuplicates,"ERROR!!! scorpio_output::check_for_duplicates - One of the output yaml files has duplicate field entries.  Please check");
+  std::set<T> s(c.begin(),c.end());
+  return c.size()>s.size();
 }
 
 AtmosphereOutput::
@@ -88,7 +42,7 @@ AtmosphereOutput (const ekat::Comm& comm,
                   const std::shared_ptr<const grid_type>& grid)
  : m_comm (comm)
 {
-  // This version of AtmosphereOutput is for quick output of fields
+  // This version of AtmosphereOutput is for quick output of fields (no remaps, no time dim)
   m_avg_type = OutputAvgType::Instant;
   m_add_time_dim = false;
 
@@ -96,17 +50,11 @@ AtmosphereOutput (const ekat::Comm& comm,
   auto fm = std::make_shared<FieldManager> (grid);
   for (auto f : fields) {
     fm->add_field(f);
-  }
-
-  set_field_manager (fm,grid->name(),"sim");
-
-  for (auto f : fields) {
     m_fields_names.push_back(f.name());
   }
-  sort_and_check(m_fields_names);
 
-  set_grid (grid);
-  set_field_manager (fm,grid->name(),"io");
+  // No remaps: set all FM except the one for scorpio (created in init())
+  m_field_mgrs[FromModel] = m_field_mgrs[AfterVertRemap] = m_field_mgrs[AfterHorizRemap] = fm;
 
   // Setup I/O structures
   init ();
@@ -121,6 +69,8 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
 {
   using vos_t = std::vector<std::string>;
 
+  auto gm = field_mgr->get_grids_manager();
+
   // Figure out what kind of averaging is requested
   auto avg_type = params.get<std::string>("averaging_type");
   m_avg_type = str2avg(avg_type);
@@ -128,14 +78,9 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
       "Error! Unsupported averaging type '" + avg_type + "'.\n"
       "       Valid options: instant, Max, Min, Average. Case insensitive.\n");
 
-  // Set all internal field managers to the simulation field manager to start with.  If
-  // vertical remapping, horizontal remapping or both are used then those remapper will
-  // set things accordingly.
-  set_field_manager (field_mgr,grid_name,std::vector<std::string>{"sim","io"});
-
   // By default, IO is done directly on the field mgr grid
-  std::shared_ptr<const grid_type> fm_grid, io_grid;
-  io_grid = fm_grid = field_mgr->get_grids_manager()->get_grid(grid_name);
+  auto fm_grid = field_mgr->get_grids_manager()->get_grid(grid_name);
+  std::string io_grid_name = fm_grid->name();
   if (params.isParameter("field_names")) {
     // This simple parameter list option does *not* allow to remap fields
     // to an io grid different from that of the field manager. In order to
@@ -143,9 +88,8 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
     m_fields_names = params.get<vos_t>("field_names");
   } else if (params.isSublist("fields")){
     const auto& f_pl = params.sublist("fields");
-    const auto& io_grid_aliases = io_grid->aliases();
     bool grid_found = false;
-    for (const auto& grid_name : io_grid_aliases) {
+    for (const auto& grid_name : fm_grid->aliases()) {
       if (f_pl.isSublist(grid_name)) {
         grid_found = true;
         const auto& pl = f_pl.sublist(grid_name);
@@ -160,7 +104,7 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
 
         // Check if the user wants to remap fields on a different grid first
         if (pl.isParameter("io_grid_name")) {
-          io_grid = field_mgr->get_grids_manager()->get_grid(pl.get<std::string>("io_grid_name"));
+          io_grid_name = pl.get<std::string>("io_grid_name");
         }
         break;
       }
@@ -168,7 +112,11 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
     EKAT_REQUIRE_MSG (grid_found,
         "Error! Bad formatting of output yaml file. Missing 'fields->$grid_name` sublist.\n");
   }
-  sort_and_check(m_fields_names);
+
+  EKAT_REQUIRE_MSG (not has_duplicates(m_fields_names),
+      "[AtmosphereOutput] Error! One of the output yaml files has duplicate field entries.\n"
+      " - yaml file: " + params.name() + "\n"
+      " - fields names; " + ekat::join(m_fields_names,",") + "\n");
 
   // Check if remapping and if so create the appropriate remapper
   // Note: We currently support three remappers
@@ -177,14 +125,38 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
   //   - online remapping which is setup using the create_remapper function
   const bool use_vertical_remap_from_file = params.isParameter("vertical_remap_file");
   const bool use_horiz_remap_from_file = params.isParameter("horiz_remap_file");
-  const bool use_online_remapper = io_grid->name()!=fm_grid->name();  // TODO: QUESTION, Do we anticipate online remapping w/ horiz_remap_from file?
-  // Check that we are not requesting online remapping w/ horiz and/or vertical remapping.  Which is not currently supported.
+  const bool use_online_remapper = io_grid_name!=fm_grid->name();
   if (use_online_remapper) {
-    EKAT_REQUIRE_MSG(!use_vertical_remap_from_file and !use_horiz_remap_from_file,"ERROR: scorpio_output - online remapping not supported with vertical and/or horizontal remapping from file");
+    EKAT_REQUIRE_MSG(!use_vertical_remap_from_file and !use_horiz_remap_from_file,
+        "[AtmosphereOutput] Error! Online Dyn->PhysGLL remapping not supported along with vertical and/or horizontal remapping from file");
   }
 
-  // Try to set the IO grid (checks will be performed)
-  set_grid (io_grid);
+  auto& fm_model = m_field_mgrs[FromModel];
+  auto& fm_after_vr = m_field_mgrs[AfterVertRemap];
+  auto& fm_after_hr = m_field_mgrs[AfterHorizRemap];
+
+  // For simplicity, we create a "copy" of the input fm, so we can stuff also diags in it
+  fm_model = std::make_shared<FieldManager>(field_mgr->get_grids_manager(),RepoState::Closed);
+  for (auto& fname : m_fields_names) {
+    if (field_mgr->has_field(fname)) {
+      fm_model->add_field(field_mgr->get_field(fname));
+    } else {
+      // This must be a diagnostic field. Crate the diag, and set the diag_field
+      // in the "FromModel" field manager
+      auto diag = create_diagnostic(fname);
+      const auto& diag_fname = diag->get_diagnostic().name();
+      m_diagnostics[diag_fname] = diag;
+
+      // Note: some diag fields have a name different from what was used
+      //       in the yaml file, so update the name with the actual
+      //       diagnostic field name.
+      // TODO: we should change this. The name used in the yaml file should
+      //       MATCH the diag field name. This is confusing.
+      fname = diag_fname;
+
+      fm_model->add_field(m_diagnostics.at(fname)->get_diagnostic());
+    }
+  }
 
   // Register any diagnostics needed by this output stream
   set_diagnostics();
@@ -212,117 +184,64 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
     m_avg_coeff_threshold = params.get<Real>("fill_threshold");
   }
 
-  // Helper lambda, to copy io string attributes. This will be used if any
-  // remapper is created, to ensure atts set by atm_procs are not lost
-  auto transfer_io_str_atts = [&] (const Field& src, Field& tgt) {
-    const std::string io_string_atts_key ="io: string attributes";
-    using stratts_t = std::map<std::string,std::string>;
-    const auto& src_atts = src.get_header().get_extra_data<stratts_t>(io_string_atts_key);
-          auto& dst_atts = tgt.get_header().get_extra_data<stratts_t>(io_string_atts_key);
-    for (const auto& [name,val] : src_atts) {
-      dst_atts[name] = val;
-    }
-  };
-
   // Setup remappers - if needed
+  auto grid_after_vr = fm_grid;
   if (use_vertical_remap_from_file) {
     // We build a remapper, to remap fields from the fm grid to the io grid
     auto vert_remap_file   = params.get<std::string>("vertical_remap_file");
-    auto p_mid = get_field("p_mid","sim");
-    auto p_int = get_field("p_int","sim");
-    auto vert_remapper = std::make_shared<VerticalRemapper>(io_grid,vert_remap_file);
+    auto p_mid = field_mgr->get_field("p_mid");
+    auto p_int = field_mgr->get_field("p_int");
+    auto vert_remapper = std::make_shared<VerticalRemapper>(fm_model->get_grid(),vert_remap_file);
     vert_remapper->set_source_pressure (p_mid,p_int);
     vert_remapper->set_mask_value(m_fill_value);
     vert_remapper->set_extrapolation_type(VerticalRemapper::Mask); // both Top AND Bot
     m_vert_remapper = vert_remapper;
-    io_grid = m_vert_remapper->get_tgt_grid();
-    set_grid(io_grid);
 
-    // Now create a new FM on io grid, and create copies of output fields on that grid,
-    // using the remapper to get the correct identifier on the tgt grid
-    auto io_fm = std::make_shared<fm_type>(io_grid);
+    grid_after_vr = m_vert_remapper->get_tgt_grid();
+    fm_after_vr = std::make_shared<FieldManager>(grid_after_vr,RepoState::Closed);
+
     for (const auto& fname : m_fields_names) {
-      const auto src = get_field(fname,"sim");
-      const auto tgt_fid = m_vert_remapper->create_tgt_fid(src.get_header().get_identifier());
-      const auto packsize = src.get_header().get_alloc_properties().get_largest_pack_size();
-      io_fm->register_field(FieldRequest(tgt_fid,packsize));
-    }
-    io_fm->registration_ends();
-    for (const auto& fname : m_fields_names) {
-      const auto& src = get_field(fname,"sim");
-            auto& tgt = io_fm->get_field(fname, io_grid->name());
+      auto src = fm_model->get_field(fname,fm_grid->name());
+      auto tgt = m_vert_remapper->register_field_from_src(src);
       transfer_io_str_atts (src,tgt);
-    }
-
-    // Register all output fields in the remapper.
-    for (const auto& fname : m_fields_names) {
-      const auto src = get_field(fname,"sim");
-      const auto tgt = io_fm->get_field(src.name(), io_grid->name());
-      m_vert_remapper->register_field(src,tgt);
+      fm_after_vr->add_field(tgt);
     }
     m_vert_remapper->registration_ends();
-
-    // Reet the field manager for IO
-    set_field_manager(io_fm,io_grid->name(),"io");
-
-    // Store a handle to 'after-vremap' FM
-    set_field_manager(io_fm,io_grid->name(),"after_vertical_remap");
+  } else {
+    // No vert remap. Simply alias the fm from the model
+    fm_after_vr = fm_model;
   }
 
   // Online remapper and horizontal remapper follow a similar pattern so we check in the same conditional.
+  auto grid_after_hr = grid_after_vr;
   if (use_online_remapper || use_horiz_remap_from_file) {
-
-    // Whic FM is the one pre-horiz-remap depends on whether we did vert remap or not
-    const auto fm_pre_hremap = use_vertical_remap_from_file
-                             ? get_field_manager("after_vertical_remap")
-                             : get_field_manager("sim");
-    const auto gn = use_vertical_remap_from_file
-                  ? m_fm_grid_name.at("after_vertical_remap")
-                  : m_fm_grid_name.at("sim");
-    set_field_manager(fm_pre_hremap,gn,"before_horizontal_remap");
-
     // We build a remapper, to remap fields from the fm grid to the io grid
     if (use_horiz_remap_from_file) {
       // Construct the coarsening remapper
       auto horiz_remap_file   = params.get<std::string>("horiz_remap_file");
-      m_horiz_remapper = std::make_shared<CoarseningRemapper>(io_grid,horiz_remap_file,true);
-      io_grid = m_horiz_remapper->get_tgt_grid();
-      set_grid(io_grid);
+      m_horiz_remapper = std::make_shared<CoarseningRemapper>(grid_after_vr,horiz_remap_file,true);
     } else {
-      // Construct a generic remapper (likely, SE->Point)
-      m_horiz_remapper = field_mgr->get_grids_manager()->create_remapper(fm_grid,io_grid);
+      // Construct a generic remapper (likely, Dyn->PhysicsGLL)
+      grid_after_hr = gm->get_grid(io_grid_name);
+      m_horiz_remapper = gm->create_remapper(grid_after_vr,grid_after_hr);
     }
 
-    // Create a FM on the horiz remapper tgt grid, and register fields on it
-    auto io_fm = std::make_shared<fm_type>(io_grid);
+    grid_after_hr = m_horiz_remapper->get_tgt_grid();
+    fm_after_hr = std::make_shared<FieldManager>(grid_after_hr,RepoState::Closed);
+
     for (const auto& fname : m_fields_names) {
-      const auto src = get_field(fname,"before_horizontal_remap");
-      const auto tgt_fid = m_horiz_remapper->create_tgt_fid(src.get_header().get_identifier());
-      const auto packsize = src.get_header().get_alloc_properties().get_largest_pack_size();
-      io_fm->register_field(FieldRequest(tgt_fid,packsize));
-    }
-    io_fm->registration_ends();
-    for (const auto& fname : m_fields_names) {
-      const auto& src = get_field(fname,"before_horizontal_remap");
-            auto& tgt = io_fm->get_field(fname, io_grid->name());
+      auto src = fm_after_vr->get_field(fname,grid_after_vr->name());
+      auto tgt = m_horiz_remapper->register_field_from_src(src);
       transfer_io_str_atts (src,tgt);
-    }
-
-    // Register all output fields in the remapper.
-    for (const auto& fname : m_fields_names) {
-      const auto src = get_field(fname,"before_horizontal_remap");
-      const auto tgt = io_fm->get_field(src.name(), io_grid->name());
-      EKAT_REQUIRE_MSG(src.data_type()==DataType::RealType,
-          "Error! I/O supports only Real data, for now.\n");
-      m_horiz_remapper->register_field(src,tgt);
+      fm_after_hr->add_field(tgt);
     }
     m_horiz_remapper->registration_ends();
-
-    // Reset the IO field manager
-    set_field_manager(io_fm,io_grid->name(),"io");
+  } else {
+    // No vert remap. Simply alias the fm after vr
+    fm_after_hr = fm_after_vr;
   }
 
-  // Setup I/O structures
+  // Setup I/O structures (including the scorpio FM)
   init ();
 }
 
@@ -330,38 +249,101 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
 void AtmosphereOutput::restart (const std::string& filename)
 {
   // Create an input stream on the fly, and init averaging data
-  ekat::ParameterList res_params("Input Parameters");
-  res_params.set<std::string>("filename",filename);
-  std::vector<std::string> input_field_names = m_fields_names;
-  input_field_names.insert(input_field_names.end(),m_avg_cnt_names.begin(),m_avg_cnt_names.end());
-  res_params.set("field_names",input_field_names);
-
-  AtmosphereInput hist_restart (res_params,m_io_grid,m_host_views_1d,m_layouts);
-  hist_restart.read_variables();
-  hist_restart.finalize();
-  for (auto& it : m_host_views_1d) {
-    const auto& name = it.first;
-    const auto& host = it.second;
-    const auto& dev  = m_dev_views_1d.at(name);
-    Kokkos::deep_copy(dev,host);
+  const auto& fm = m_field_mgrs[Scorpio];
+  std::vector<Field> fields;
+  for (const auto& [name,f_ptr] : fm->get_repo()) {
+    fields.push_back(*f_ptr);
   }
+
+  AtmosphereInput hist_restart (filename, fm->get_grid(), fields);
+  hist_restart.read_variables();
 }
 
 void AtmosphereOutput::init()
 {
-  for (const auto& var_name : m_fields_names) {
-    register_dimensions(var_name);
+  auto fm_after_hr = m_field_mgrs[AfterHorizRemap];
+  m_io_grid  = fm_after_hr->get_grid();
+
+  EKAT_REQUIRE_MSG (m_io_grid->is_unique(),
+      "Error! I/O only supports grids which are 'unique', meaning that the\n"
+      "       map dof_gid->proc_id is well defined.\n");
+  EKAT_REQUIRE_MSG (
+      (m_io_grid->get_global_max_dof_gid()-m_io_grid->get_global_min_dof_gid()+1)==m_io_grid->get_num_global_dofs(),
+      "Error! In order for IO to work, the grid must (globally) have dof gids in interval [gid_0,gid_0+num_global_dofs).\n");
+
+  // Create FM for scorpio. The fields in this FM are guaranteed to NOT have parents/padding
+  auto fm_scorpio = m_field_mgrs[Scorpio] = std::make_shared<FieldManager>(fm_after_hr->get_grid(),RepoState::Closed);
+  for (const auto& fname : m_fields_names) {
+    const auto& f = fm_after_hr->get_field(fname);
+    const auto& fh = f.get_header();
+    const auto& fid = fh.get_identifier();
+
+    // Check if the field for scorpio can alias the field after hremap.
+    // It can do so only for Instant output, and if the field is NOT a subfield ant NOT padded
+    // Also, if we track avg cnt, we MUST add the mask_value extra data, to trigger fill-value logic
+    // when calling Field's update methods
+    if (m_avg_type!=OutputAvgType::Instant or
+        fh.get_alloc_properties().get_padding()>0 or
+        m_track_avg_cnt) {
+      Field copy(fid);
+      copy.allocate_view();
+      transfer_io_str_atts (f,copy);
+      if (m_track_avg_cnt) {
+        copy.get_header().set_extra_data("mask_value",Real(m_fill_value));
+      }
+      fm_scorpio->add_field(copy);
+    } else {
+      fm_scorpio->add_field(f);
+    }
+
+    // Store the field layout, so that calls to setup_output_file are easier
+    const auto& layout = fid.get_layout();
+    m_layouts.emplace(fname,layout);
+
+    // Now check that all the dims of this field are already set to be registered.
+    const auto& tags = layout.tags();
+    const auto& dims = layout.dims();
+    for (int i=0; i<layout.rank(); ++i) {
+      // check tag against m_dims map.  If not in there, then add it.
+      std::string tag_name = m_io_grid->has_special_tag_name(tags[i])
+                           ? m_io_grid->get_special_tag_name(tags[i])
+                           : layout.names()[i];
+
+      // If t==CMP, and the name stored in the layout is "dim" (the default) or "bin",
+      // we append also the extent, to allow different vector dims in the file
+      // TODO: generalize this to all tags, for now hardcoding to dim and bin only
+      tag_name += (tag_name=="dim" or tag_name=="bin") ? std::to_string(dims[i]) : "";
+
+      auto is_partitioned = m_io_grid->get_partitioned_dim_tag()==tags[i];
+      int dim_len = is_partitioned
+                  ? m_io_grid->get_partitioned_dim_global_size()
+                  : layout.dim(i);
+      auto it_bool = m_dims.emplace(tag_name,dim_len);
+      EKAT_REQUIRE_MSG(it_bool.second or it_bool.first->second==dim_len,
+        "Error! Dimension " + tag_name + " on field " + fname + " has conflicting lengths.\n"
+        "  - old length: " + std::to_string(m_dims[tag_name]) + "\n"
+        "  - new length: " + std::to_string(dim_len) + "\n"
+        "If same name applies to different dims (e.g. PhysicsGLL and PhysicsPG2 define "
+        "\"ncol\" at different lengths), reset tag name for one of the grids.\n");
+    }
+
+    if (m_track_avg_cnt) {
+      // Create and store a Field to track the averaging count for this layout
+      set_avg_cnt_tracking(fname,layout);
+    }
   }
 
-  // Now that the fields have been gathered register the local views which will be used to determine output data to be written.
-  register_views();
+  // For non-instantaneous output, ensure scorpio fields are
+  // inited with correct value for accumulation
+  if (m_avg_type!=OutputAvgType::Instant)
+    reset_scorpio_fields();
 }
 
 void AtmosphereOutput::
 init_timestep (const util::TimeStamp& start_of_step)
 {
-  for (auto& it : m_diagnostics) {
-    it.second->init_timestep(start_of_step);
+  for (auto& [name,diag] : m_diagnostics) {
+    diag->init_timestep(start_of_step);
   }
 }
 
@@ -391,19 +373,19 @@ run (const std::string& filename,
   // to make sure that the remapped fields are the most up to date.
   // First we reset the diag computed map so that all diags are recomputed.
   m_diag_computed.clear();
-  for (auto& it : m_diagnostics) {
-    compute_diagnostic(it.first,allow_invalid_fields);
+  for (auto& [name,diag] : m_diagnostics) {
+    compute_diagnostic(name,allow_invalid_fields);
   }
 
-  auto apply_remap = [&](const std::shared_ptr<AbstractRemapper> remapper)
+  auto apply_remap = [&](AbstractRemapper& remapper)
   {
-    remapper->remap_fwd();
+    remapper.remap_fwd();
 
-    for (int i=0; i<remapper->get_num_fields(); ++i) {
+    for (int i=0; i<remapper.get_num_fields(); ++i) {
       // Need to update the time stamp of the fields on the IO grid,
       // to avoid throwing an exception later
-      auto src = remapper->get_src_field(i);
-      auto tgt = remapper->get_tgt_field(i);
+      auto src = remapper.get_src_field(i);
+      auto tgt = remapper.get_tgt_field(i);
 
       auto src_t = src.get_header().get_tracking().get_time_stamp();
       tgt.get_header().get_tracking().update_time_stamp(src_t);
@@ -413,243 +395,119 @@ run (const std::string& filename,
   // If needed, remap fields from their grid to the unique grid, for I/O
   if (m_vert_remapper) {
     start_timer("EAMxx::IO::vert_remap");
-    apply_remap(m_vert_remapper);
+    apply_remap(*m_vert_remapper);
     stop_timer("EAMxx::IO::vert_remap");
   }
 
   if (m_horiz_remapper) {
     start_timer("EAMxx::IO::horiz_remap");
-    apply_remap(m_horiz_remapper);
+    apply_remap(*m_horiz_remapper);
     stop_timer("EAMxx::IO::horiz_remap");
   }
 
-  // Update all of the averaging count views (if needed)
-  // The strategy is as follows:
-  // For the update to the averaged value for this timestep we need to track if
-  // a point in a specific layout is "filled" or not.  So we create a set of local
-  // temporary views for each layout that are either 0 or 1 depending on if the
-  // value is filled or unfilled.
-  // We then use these values to update the overall average count views for that layout.
+  auto fm_scorpio = m_field_mgrs[Scorpio];
+  auto fm_after_hr = m_field_mgrs[AfterHorizRemap];
+
+  // If tracking avg count, update the count at each field location separately.
+  // We do count++ only where the fields are NOT equal to the fill value.
+  // Note, we assume that all fields that share a layout are also masked/filled in the same way.
   if (m_track_avg_cnt) {
-    // Note, we assume that all fields that share a layout are also masked/filled in the same
-    // way. If we need to handle a case where only a subset of output variables are expected to
-    // be masked/filled then the recommendation is to request those variables in a separate output
-    // stream.
-    // We cycle through all fields and we
-    //  1. Find the avg_cnt view for this field.
-    //  2. If we already processed the avg_cnt view, go to next field, and start from 1 again.
-    //  3. Add 1 to all entries of avg_cnt where field!=fill_value
+    // Since 2+ fields may have same avg count, make sure we update the counts only ONCE.
     std::set<std::string> avg_updated;
-    for (const auto& name : m_fields_names) {
-      auto avg_cnt_name = m_field_to_avg_cnt_map.at(name);
+    for (const auto& [fname, avg_cnt_name] : m_field_to_avg_cnt_map) {
       if (avg_updated.count(avg_cnt_name)==1) {
-        // We updated this avg_cnt by checking another field
         continue;
       }
-      auto field = get_field(name,"io");
-      update_avg_cnt_view(field,m_dev_views_1d.at(avg_cnt_name));
-
-      // Make sure we don't double update this avg cnt
       avg_updated.insert(avg_cnt_name);
+
+      auto field = fm_after_hr->get_field(fname);
+      auto count = fm_scorpio->get_field(avg_cnt_name);
+      auto mask  = count.get_header().get_extra_data<Field>("mask");
+
+      // Find where the field is NOT equal to m_fill_value
+      compute_mask<Comparison::NE>(field,m_fill_value,mask);
+
+      // mask=1 for "good" entries, and mask=0 otherwise.
+      count.update(mask,1,1);
+
+      // Handle writing the average count variables to file
+      if (is_write_step) {
+        // Bring data to host
+        count.sync_to_host();
+
+        auto func_start = std::chrono::steady_clock::now();
+        scorpio::write_var(filename,avg_cnt_name,count.get_internal_view_data<int,Host>());
+        auto func_finish = std::chrono::steady_clock::now();
+        auto duration_loc = std::chrono::duration_cast<std::chrono::milliseconds>(func_finish - func_start);
+        duration_write += duration_loc.count();
+
+        // If it's an output step, for Avg we need to ensure count>threshold.
+        // If count<=threshold, we set count=fill_value, so that fill_val propagates
+        // to the output fields when we divide by count later
+        if (output_step and m_avg_type==OutputAvgType::Average) {
+          int min_count = m_avg_coeff_threshold*nsteps_since_last_output;
+
+          // Recycle mask to find where count<thresh
+          compute_mask<Comparison::LT>(count,min_count,mask);
+
+          // Later, we divide fields by count. By setting count=1 where count<thresholt,
+          // we can later do
+          //   f.scale_inv(count); // Requires count!=0 anywhere
+          //   f.deep_copy(fill_val,mask)
+          count.deep_copy(1,mask);
+        }
+      }
     }
   }
 
   // Take care of updating and possibly writing fields.
-  // These are needed inside kernels, so crate local copies
-  auto do_avg_cnt = m_track_avg_cnt;
-  auto avg_type = m_avg_type;
-  auto fill_value = m_fill_value;
-  auto avg_coeff_threshold = m_avg_coeff_threshold;
   for (auto const& name : m_fields_names) {
     // Get all the info for this field.
-          auto  field = get_field(name,"io");
-    const auto& layout = m_layouts.at(field.name());
-    const auto& dims = layout.dims();
-    const auto  rank = layout.rank();
+    const auto& f_in  = fm_after_hr->get_field(name);
+          auto& f_out = fm_scorpio->get_field(name);
 
-    if (not field.get_header().get_tracking().get_time_stamp().is_valid()) {
-      // Safety check: make sure that the user is ok with this
-      if (allow_invalid_fields) {
-        field.deep_copy(m_fill_value);
-      } else {
-        EKAT_REQUIRE_MSG (!m_add_time_dim,
-            "Error! Time-dependent output field '" + name + "' has not been initialized yet\n.");
-      }
-    }
-
-    const bool is_diagnostic = (m_diagnostics.find(name) != m_diagnostics.end());
-    const bool is_aliasing_field_view =
-        m_avg_type==OutputAvgType::Instant &&
-        field.get_header().get_alloc_properties().get_padding()==0 &&
-        field.get_header().get_parent()==nullptr &&
-        not is_diagnostic;
-
-    // Manually update the 'running-tally' views with data from the field,
-    // by combining new data with current avg values.
-    // NOTE: this is skipped for instant output, if IO view is aliasing Field view.
-    auto view_dev = m_dev_views_1d.at(name);
-    auto data = view_dev.data();
-    KT::RangePolicy policy(0,layout.size());
-    const auto extents = layout.extents();
-
-    // If the dev_view_1d is aliasing the field device view (must be Instant output),
-    // then there's no point in copying from the field's view to dev_view
-    if (not is_aliasing_field_view) {
-      switch (rank) {
-        case 0:
-        {
-          auto new_view_0d = field.get_view<const Real,Device>();
-          auto avg_view_0d = view_Nd_dev<0>(data);
-          Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int) {
-            if (do_avg_cnt) {
-              combine_and_fill(new_view_0d(),avg_view_0d(),avg_type,fill_value);
-            } else {
-              combine(new_view_0d(),avg_view_0d(),avg_type);
-            }
-          });
-          break;
-        }
-        case 1:
-        {
-          // For rank-1 views, we use strided layout, since it helps us
-          // handling a few more scenarios
-          auto new_view_1d = field.get_strided_view<const Real*,Device>();
-          auto avg_view_1d = view_Nd_dev<1>(data,dims[0]);
-          Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int i) {
-            if (do_avg_cnt) {
-              combine_and_fill(new_view_1d(i),avg_view_1d(i),avg_type,fill_value);
-            } else {
-              combine(new_view_1d(i),avg_view_1d(i),avg_type);
-            }
-          });
-          break;
-        }
-        case 2:
-        {
-          auto new_view_2d = field.get_view<const Real**,Device>();
-          auto avg_view_2d = view_Nd_dev<2>(data,dims[0],dims[1]);
-          Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int idx) {
-            int i,j;
-            unflatten_idx(idx,extents,i,j);
-            if (do_avg_cnt) {
-              combine_and_fill(new_view_2d(i,j),avg_view_2d(i,j),avg_type,fill_value);
-            } else {
-              combine(new_view_2d(i,j), avg_view_2d(i,j),avg_type);
-            }
-          });
-          break;
-        }
-        case 3:
-        {
-          auto new_view_3d = field.get_view<const Real***,Device>();
-          auto avg_view_3d = view_Nd_dev<3>(data,dims[0],dims[1],dims[2]);
-          Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int idx) {
-            int i,j,k;
-            unflatten_idx(idx,extents,i,j,k);
-            if (do_avg_cnt) {
-              combine_and_fill(new_view_3d(i,j,k),avg_view_3d(i,j,k),avg_type,fill_value);
-            } else {
-              combine(new_view_3d(i,j,k), avg_view_3d(i,j,k),avg_type);
-            }
-          });
-          break;
-        }
-        case 4:
-        {
-          auto new_view_4d = field.get_view<const Real****,Device>();
-          auto avg_view_4d = view_Nd_dev<4>(data,dims[0],dims[1],dims[2],dims[3]);
-          Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int idx) {
-            int i,j,k,l;
-            unflatten_idx(idx,extents,i,j,k,l);
-            if (do_avg_cnt) {
-              combine_and_fill(new_view_4d(i,j,k,l), avg_view_4d(i,j,k,l),avg_type,fill_value);
-            } else {
-              combine(new_view_4d(i,j,k,l), avg_view_4d(i,j,k,l),avg_type);
-            }
-          });
-          break;
-        }
-        case 5:
-        {
-          auto new_view_5d = field.get_view<const Real*****,Device>();
-          auto avg_view_5d = view_Nd_dev<5>(data,dims[0],dims[1],dims[2],dims[3],dims[4]);
-          Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int idx) {
-            int i,j,k,l,m;
-            unflatten_idx(idx,extents,i,j,k,l,m);
-            if (do_avg_cnt) {
-              combine_and_fill(new_view_5d(i,j,k,l,m), avg_view_5d(i,j,k,l,m),avg_type,fill_value);
-            } else {
-              combine(new_view_5d(i,j,k,l,m), avg_view_5d(i,j,k,l,m),avg_type);
-            }
-          });
-          break;
-        }
-        case 6:
-        {
-          auto new_view_6d = field.get_view<const Real******,Device>();
-          auto avg_view_6d = view_Nd_dev<6>(data,dims[0],dims[1],dims[2],dims[3],dims[4],dims[5]);
-          Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int idx) {
-            int i,j,k,l,m,n;
-            unflatten_idx(idx,extents,i,j,k,l,m,n);
-            if (do_avg_cnt) {
-              combine_and_fill(new_view_6d(i,j,k,l,m,n), avg_view_6d(i,j,k,l,m,n), avg_type,fill_value);
-            } else {
-              combine(new_view_6d(i,j,k,l,m,n), avg_view_6d(i,j,k,l,m,n),avg_type);
-            }
-          });
-          break;
-        }
-        default:
-          EKAT_ERROR_MSG ("Error! Field rank (" + std::to_string(rank) + ") not supported by AtmosphereOutput.\n");
-      }
+    switch (m_avg_type) {
+      case OutputAvgType::Instant:
+        f_out.deep_copy(f_in);  break; // Note: if f_in aliases f_out, this is a no-op
+      case OutputAvgType::Max:
+        f_out.max(f_in);        break;
+      case OutputAvgType::Min:
+        f_out.min(f_in);        break;
+      case OutputAvgType::Average:
+        f_out.update(f_in,1,1); break;
+      default:
+        EKAT_ERROR_MSG ("Unexpected/unsupported averaging type.\n");
     }
 
     if (is_write_step) {
-      if (output_step and avg_type==OutputAvgType::Average) {
-        if (do_avg_cnt) {
-          const auto avg_cnt_lookup = m_field_to_avg_cnt_map.at(name);
-          const auto avg_cnt_view = m_dev_views_1d.at(avg_cnt_lookup);
-          const auto avg_nsteps = avg_cnt_view.data();
-          // Divide by steps count only when the summation is complete
-          Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int i) {
-            Real coeff_percentage = Real(avg_nsteps[i])/nsteps_since_last_output;
-            if (data[i] != fill_value && coeff_percentage > avg_coeff_threshold) {
-              data[i] /= avg_nsteps[i];
-            } else {
-              data[i] = fill_value;
-            }
-          });
+      if (output_step and m_avg_type==OutputAvgType::Average) {
+        // NOTE: we don't divide by the avg cnt for checkpoint output
+        if (m_track_avg_cnt) {
+          const auto& avg_cnt_name = m_field_to_avg_cnt_map.at(name);
+          auto avg_cnt = fm_scorpio->get_field(avg_cnt_name);
+
+          f_out.scale_inv(avg_cnt);
+
+          const auto& mask = avg_cnt.get_header().get_extra_data<Field>("mask");
+          f_out.deep_copy(m_fill_value,mask);
         } else {
           // Divide by steps count only when the summation is complete
-          Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int i) {
-            data[i] /= nsteps_since_last_output;
-          });
+          f_out.scale(1.0 / nsteps_since_last_output);
         }
       }
+
       // Bring data to host
-      auto view_host = m_host_views_1d.at(name);
-      Kokkos::deep_copy (view_host,view_dev);
+      f_out.sync_to_host();
+
+      // Write
       auto func_start = std::chrono::steady_clock::now();
-      scorpio::write_var(filename,name,view_host.data());
+      scorpio::write_var(filename,name,f_out.get_internal_view_data<Real,Host>());
       auto func_finish = std::chrono::steady_clock::now();
       auto duration_loc = std::chrono::duration_cast<std::chrono::milliseconds>(func_finish - func_start);
       duration_write += duration_loc.count();
     }
   }
-  // Handle writing the average count variables to file
-  if (is_write_step) {
-    for (const auto& name : m_avg_cnt_names) {
-      auto& view_dev = m_dev_views_1d.at(name);
-      // Bring data to host
-      auto view_host = m_host_views_1d.at(name);
-      Kokkos::deep_copy (view_host,view_dev);
-      auto func_start = std::chrono::steady_clock::now();
-      scorpio::write_var(filename,name,view_host.data());
-      auto func_finish = std::chrono::steady_clock::now();
-      auto duration_loc = std::chrono::duration_cast<std::chrono::milliseconds>(func_finish - func_start);
-      duration_write += duration_loc.count();
-    }
-  }
+
   if (is_write_step) {
     if (m_atm_logger) {
       m_atm_logger->info("  Done! Elapsed time: " + std::to_string(duration_write/1000.0) +" seconds");
@@ -658,202 +516,36 @@ run (const std::string& filename,
 } // run
 
 long long AtmosphereOutput::
-res_dep_memory_footprint () const {
+res_dep_memory_footprint () const
+{
   long long rdmf = 0;
-  const auto sim_field_mgr = get_field_manager("sim");
 
-  // Cycle through all unique field managers in this output,
-  // first make a copy so we can grab just unique pointers.
-  std::set<std::string> grids;
-  for (auto fm : m_field_mgrs) {
-    auto mode = fm.first;
-    auto field_mgr = fm.second;
-    if (field_mgr != sim_field_mgr) {
-      const auto& gn = field_mgr->get_grids_manager()->get_grid(m_fm_grid_name.at(mode))->name();
-      if (grids.count(gn)>0) {
-        continue; // Grid has already been parsed
+  // Loop over ALL field mgr, and ALL fields in each of them.
+  // Keep track of Field obj we parse, so we don't count them twice
+  std::set<Field*> fields;
+  for (const auto& [phase,fm] : m_field_mgrs) {
+    for (const auto& [fname,f_ptr] : fm->get_repo()) {
+      auto [it, inserted] = fields.insert(f_ptr.get());
+      if (not inserted) {
+        // We already parsed this field
+        continue;
       }
-      grids.insert(gn);
-      // This FM is done on a different grid than SIM and hasn't been included in
-      // the memory calculation yet.  So we can safely add its footprint
-      for (const auto& it : field_mgr->get_repo(gn)) {
-        const auto& fap = it.second->get_header().get_alloc_properties();
-        if (fap.is_subfield()) {
-          continue;
-        }
-        rdmf += fap.get_alloc_size();
+      const auto& fap = f_ptr->get_header().get_alloc_properties();
+      if (fap.is_subfield()) {
+        // We don't count subfields
+        continue;
       }
-    }
-  }
-
-  const auto io_field_mgr = get_field_manager("io");
-  const auto gn = m_fm_grid_name.at("io");
-  for (const auto& fn : m_fields_names) {
-    bool is_diagnostic = (m_diagnostics.find(fn) != m_diagnostics.end());
-    bool can_alias_field_view =
-        m_avg_type==OutputAvgType::Instant && not is_diagnostic &&
-        io_field_mgr->get_field(fn, gn).get_header().get_alloc_properties().get_padding()==0 &&
-        io_field_mgr->get_field(fn, gn).get_header().get_parent()==nullptr;
-
-    if (not can_alias_field_view) {
-      rdmf += m_dev_views_1d.size()*sizeof(Real);
+      if (phase==FromModel and m_diagnostics.count(fname)==0) {
+        // We don't count fields from the model
+        continue;
+      }
+      rdmf += fap.get_alloc_size();
     }
   }
 
   return rdmf;
 }
-/* ---------------------------------------------------------- */
-void AtmosphereOutput::
-set_field_manager (const std::shared_ptr<const fm_type>& field_mgr,
-                   const std::string& grid_name,
-                   const std::vector<std::string>& modes)
-{
 
-  // Sanity checks
-  EKAT_REQUIRE_MSG (field_mgr, "Error! Invalid field manager pointer.\n");
-  EKAT_REQUIRE_MSG (field_mgr->get_grids_manager()->has_grid(grid_name),
-    "Error! Field manager does not contain the selected grid: " + grid_name + ".\n");
-
-  for (unsigned ii=0; ii<modes.size(); ii++) {
-    const auto mode = modes[ii];
-    if (m_field_mgrs.count(mode)) {
-      // We must redefine the field manager for this location in the map.
-      m_field_mgrs[mode] = field_mgr;
-      m_fm_grid_name[mode] = grid_name;
-    } else {
-      m_field_mgrs.emplace(mode, field_mgr);
-      m_fm_grid_name.emplace(mode, grid_name);
-    }
-  }
-
-}
-/* ---------------------------------------------------------- */
-void AtmosphereOutput::
-set_field_manager (const std::shared_ptr<const fm_type>& field_mgr,
-                   const std::string& grid_name,
-                   const std::string& mode)
-{
-  const std::vector<std::string> modes = {mode};
-  set_field_manager(field_mgr,grid_name,modes);
-}
-
-std::shared_ptr<const FieldManager>
-AtmosphereOutput::get_field_manager (const std::string& mode) const
-{
-  auto it = m_field_mgrs.find(mode);
-  EKAT_REQUIRE_MSG (it!=m_field_mgrs.end(),
-    "ERROR! AtmosphereOutput::get_field_manager FM for mode = " + mode + " not found in list of available field managers!.");
-  return it->second;
-}
-
-/* ---------------------------------------------------------- */
-
-void AtmosphereOutput::
-set_grid (const std::shared_ptr<const AbstractGrid>& grid)
-{
-  // Sanity checks
-  EKAT_REQUIRE_MSG (grid, "Error! Input grid pointer is invalid.\n");
-  EKAT_REQUIRE_MSG (grid->is_unique(),
-      "Error! I/O only supports grids which are 'unique', meaning that the\n"
-      "       map dof_gid->proc_id is well defined.\n");
-  EKAT_REQUIRE_MSG (
-      (grid->get_global_max_dof_gid()-grid->get_global_min_dof_gid()+1)==grid->get_num_global_dofs(),
-      "Error! In order for IO to work, the grid must (globally) have dof gids in interval [gid_0,gid_0+num_global_dofs).\n");
-
-  // The grid is good. Store it.
-  m_io_grid = grid;
-}
-
-void AtmosphereOutput::register_dimensions(const std::string& name)
-{
-/*
- * Checks that the dimensions associated with a specific variable will be registered with IO file.
- * INPUT:
- *   field_manager: is a pointer to the field_manager for this simulation.
- *   name: is a string name of the variable who is to be added to the list of variables in this IO stream.
- */
-  using namespace ShortFieldTagsNames;
-
-  // Store the field layout
-  const auto& fid = get_field(name,"io").get_header().get_identifier();
-  const auto& layout = fid.get_layout();
-  m_layouts.emplace(fid.name(),layout);
-
-  // Now check taht all the dims of this field are already set to be registered.
-  const auto& tags = layout.tags();
-  const auto& dims = layout.dims();
-  for (int i=0; i<layout.rank(); ++i) {
-    // check tag against m_dims map.  If not in there, then add it.
-    std::string tag_name = m_io_grid->has_special_tag_name(tags[i])
-                         ? m_io_grid->get_special_tag_name(tags[i])
-                         : layout.names()[i];
-
-    // If t==CMP, and the name stored in the layout is the default ("dim"),
-    // we append also the extent, to allow different vector dims in the file
-    // TODO: generalie this to all tags, for now hardcoding to dim and bin only
-    tag_name += (tag_name == "dim" or tag_name=="bin") ? std::to_string(dims[i]) : "";
-
-    auto is_partitioned = m_io_grid->get_partitioned_dim_tag()==tags[i];
-    int dim_len = is_partitioned
-                ? m_io_grid->get_partitioned_dim_global_size()
-                : layout.dim(i);
-    auto it_bool = m_dims.emplace(tag_name,dim_len);
-    EKAT_REQUIRE_MSG(it_bool.second or it_bool.first->second==dim_len,
-      "Error! Dimension " + tag_name + " on field " + name + " has conflicting lengths.\n"
-      "  - old length: " + std::to_string(m_dims[tag_name]) + "\n"
-      "  - new length: " + std::to_string(dim_len) + "\n"
-      "If same name applies to different dims (e.g. physics_gll and physics_pg2 define "
-      "\"ncol\" at different lengths), reset tag name for one of the grids.\n");
-  }
-} // register_dimensions
-/* ---------------------------------------------------------- */
-void AtmosphereOutput::register_views()
-{
-  // Cycle through all fields and register.
-  for (auto const& name : m_fields_names) {
-    auto field = get_field(name,"io");
-    bool is_diagnostic = (m_diagnostics.find(name) != m_diagnostics.end());
-
-    // These local views are really only needed if the averaging time is not 'instant',
-    // to store running tallies for the average operation. However, we create them
-    // also for instant avg_type, for simplicity later on.
-
-    // If we have an 'instant' avg type, we can alias the 1d views with the
-    // views of the field, provided that the field does not have padding,
-    // and that it is not a subfield of another field (or else the view
-    // would be strided).
-    //
-    // We also don't want to alias to a diagnostic output since it could share memory
-    // with another diagnostic.
-    bool can_alias_field_view =
-        m_avg_type==OutputAvgType::Instant &&
-        field.get_header().get_alloc_properties().get_padding()==0 &&
-        field.get_header().get_parent()==nullptr &&
-        not is_diagnostic;
-
-    const auto layout = m_layouts.at(field.name());
-    const auto size = layout.size();
-    if (can_alias_field_view) {
-      // Alias field's data, to save storage.
-      m_dev_views_1d.emplace(name,view_1d_dev(field.get_internal_view_data<Real,Device>(),size));
-      m_host_views_1d.emplace(name,view_1d_host(field.get_internal_view_data<Real,Host>(),size));
-    } else {
-      // Create a local view.
-      m_dev_views_1d.emplace(name,view_1d_dev("",size));
-      m_host_views_1d.emplace(name,Kokkos::create_mirror(m_dev_views_1d[name]));
-    }
-
-    if (m_track_avg_cnt) {
-      // Now create and store a dev view to track the averaging count for this layout (if we are tracking)
-      // We don't need to track average counts for files that are not tracking the time dim
-      set_avg_cnt_tracking(name,layout);
-    }
-  }
-
-  // Initialize the local views
-  reset_dev_views();
-}
-/* ---------------------------------------------------------- */
 void AtmosphereOutput::set_avg_cnt_tracking(const std::string& name, const FieldLayout& layout)
 {
   // Make sure this field "name" hasn't already been registered with avg_cnt tracking.
@@ -872,64 +564,74 @@ void AtmosphereOutput::set_avg_cnt_tracking(const std::string& name, const Field
     return;
   }
 
-  // Now create and store a dev view to track the averaging count for this layout (if we are tracking)
-  // We don't need to track average counts for files that are not tracking the time dim
-  using namespace ShortFieldTagsNames;
+  // Now create a Field to track the averaging count for this layout
   const auto& avg_cnt_suffix = m_field_to_avg_cnt_suffix[name];
-  const auto size = layout.size();
   const auto tags = layout.tags();
-  if (m_track_avg_cnt) {
-    std::string avg_cnt_name = "avg_count" + avg_cnt_suffix;
-    for (int i=0; i<layout.rank(); ++i) {
-      const auto t = layout.tag(i);
-      std::string tag_name = m_io_grid->has_special_tag_name(t)
-                           ? m_io_grid->get_special_tag_name(t)
-                           : layout.names()[i];
+  std::string avg_cnt_name = "avg_count" + avg_cnt_suffix;
+  for (int i=0; i<layout.rank(); ++i) {
+    const auto t = layout.tag(i);
+    std::string tag_name = m_io_grid->has_special_tag_name(t)
+                         ? m_io_grid->get_special_tag_name(t)
+                         : layout.names()[i];
 
-      // If t==CMP, and the name stored in the layout is the default ("dim"),
-      // we append also the extent, to allow different vector dims in the file
-      // TODO: generalize this to all tags, for now hardcoding to dim and bin only
-      tag_name += (tag_name=="dim" or tag_name=="bin") ? std::to_string(layout.dim(i)) : "";
+    // If t==CMP, and the name stored in the layout is "dim" (the default) or "bin",
+    // we append also the extent, to allow different vector dims in the file
+    // TODO: generalize this to all tags, for now hardcoding to dim and bin only
+    tag_name += (tag_name=="dim" or tag_name=="bin") ? std::to_string(layout.dim(i)) : "";
 
-      avg_cnt_name += "_" + tag_name;
-    }
-    if (std::find(m_avg_cnt_names.begin(),m_avg_cnt_names.end(),avg_cnt_name)==m_avg_cnt_names.end()) {
-      m_avg_cnt_names.push_back(avg_cnt_name);
-    }
-    m_field_to_avg_cnt_map.emplace(name,avg_cnt_name);
-    m_dev_views_1d.emplace(avg_cnt_name,view_1d_dev("",size));  // Note, emplace will only add a new key if one isn't already there
-    m_host_views_1d.emplace(avg_cnt_name,Kokkos::create_mirror(m_dev_views_1d[avg_cnt_name]));
-    m_layouts.emplace(avg_cnt_name,layout);
+    avg_cnt_name += "_" + tag_name;
   }
+
+  auto [it, inserted] = m_field_to_avg_cnt_map.emplace(name,avg_cnt_name);
+  if (not inserted) {
+    // We already created this avg cnt field
+    return;
+  }
+  m_layouts.emplace(avg_cnt_name,layout);
+  m_avg_cnt_names.push_back(avg_cnt_name);
+
+  auto fm_scorpio = m_field_mgrs[Scorpio];
+
+  // NOTE: while it seems right to use IntType as data type for cnt, we later use
+  //       it in arithmetic updates of the avg field, where we need both fields
+  //       to have the same data type
+  auto nondim = ekat::units::Units::nondimensional();
+  FieldIdentifier cnt_id (avg_cnt_name,layout,nondim,fm_scorpio->get_grid()->name(),DataType::IntType);
+  Field cnt (cnt_id);
+  cnt.allocate_view();
+
+  // We will use a helper field for updating cnt, so store it inside the field header
+  auto mask = cnt.clone(cnt.name()+"_mask");
+  mask.get_header().set_extra_data("true_value",int(1));
+  mask.get_header().set_extra_data("false_value",int(0));
+  cnt.get_header().set_extra_data("mask",mask);
+  
+  fm_scorpio->add_field(cnt);
 }
 /* ---------------------------------------------------------- */
 void AtmosphereOutput::
-reset_dev_views()
+reset_scorpio_fields()
 {
-  // Reset the local device views depending on the averaging type
-  // Init dev view with an "identity" for avg_type
-  const Real fill_for_average = m_track_avg_cnt ? m_fill_value : 0.0;
-  for (auto const& name : m_fields_names) {
-    switch (m_avg_type) {
-      case OutputAvgType::Instant:
-        // No averaging
-        break;
-      case OutputAvgType::Max:
-        Kokkos::deep_copy(m_dev_views_1d[name],-std::numeric_limits<Real>::infinity());
-        break;
-      case OutputAvgType::Min:
-        Kokkos::deep_copy(m_dev_views_1d[name],std::numeric_limits<Real>::infinity());
-        break;
-      case OutputAvgType::Average:
-        Kokkos::deep_copy(m_dev_views_1d[name],fill_for_average);
-        break;
-      default:
-        EKAT_ERROR_MSG ("Unrecognized averaging type.\n");
-    }
+  // Reset the fields for scorpio to whatever is the proper accumulation value (if avg!=Instant)
+  Real value;
+  switch (m_avg_type) {
+    case OutputAvgType::Max:
+      value = -std::numeric_limits<Real>::infinity(); break;
+    case OutputAvgType::Min:
+      value =  std::numeric_limits<Real>::infinity(); break;
+    case OutputAvgType::Average:
+      value =  m_track_avg_cnt ? m_fill_value : 0.0;  break;
+      break;
+    default:
+      EKAT_ERROR_MSG ("Unrecognized/unexpected averaging type.\n");
   }
-  // Reset all views for averaging count to 0
-  for (auto const& name : m_avg_cnt_names) {
-    Kokkos::deep_copy(m_dev_views_1d[name],0);
+
+  auto fm = m_field_mgrs[Scorpio];
+  for (const auto& name : m_fields_names) {
+    fm->get_field(name).deep_copy(value);
+  }
+  for (const auto& name : m_avg_cnt_names) {
+    fm->get_field(name).deep_copy(0);
   }
 }
 /* ---------------------------------------------------------- */
@@ -964,8 +666,8 @@ register_variables(const std::string& filename,
 
   // Cycle through all fields and register.
   for (auto const& name : m_fields_names) {
-    auto field = get_field(name,"io");
-    auto& fid  = field.get_header().get_identifier();
+    const auto& f = m_field_mgrs[Scorpio]->get_field(name);
+    const auto& fid  = f.get_header().get_identifier();
     // Make a unique tag for each decomposition. To reuse decomps successfully,
     // we must be careful to make the tags 1-1 with the intended decomp. Here we
     // use the I/O grid name and its global #DOFs, then append the local
@@ -1021,7 +723,7 @@ register_variables(const std::string& filename,
       }
 
       // If this is has subfields, add list of its children
-      const auto& children = field.get_header().get_children();
+      const auto& children = f.get_header().get_children();
       if (children.size()>0) {
         // This field is a parent to a set of subfields
         std::string children_list;
@@ -1039,13 +741,13 @@ register_variables(const std::string& filename,
 
       // If tracking average count variables then add the name of the tracking variable for this variable
       if (m_track_avg_cnt) {
-        const auto lookup = m_field_to_avg_cnt_map.at(name);
+        const auto& lookup = m_field_to_avg_cnt_map.at(name);
         scorpio::set_attribute(filename,name,"averaging_count_tracker",lookup);
       }
 
       // Atm procs may have set some request for metadata.
       using stratts_t = std::map<std::string,std::string>;
-      const auto& str_atts = field.get_header().get_extra_data<stratts_t>("io: string attributes");
+      const auto& str_atts = f.get_header().get_extra_data<stratts_t>("io: string attributes");
       for (const auto& [att_name,att_val] : str_atts) {
         scorpio::set_attribute(filename,name,att_name,att_val);
       }
@@ -1095,98 +797,15 @@ register_variables(const std::string& filename,
             "  - var time dep: " + (m_add_time_dim ? "yes" : "no") + "\n"
             "  - var time dep from file: " + (var.time_dep ? "yes" : "no") + "\n");
       } else {
-	// Note, unlike with regular output variables, for the average counting
-	// variables we don't need to add all of the extra metadata.  So we simply
-	// define the variable.
+        // Note, unlike with regular output variables, for the average counting
+        // variables we don't need to add all of the extra metadata.  So we simply
+        // define the variable.
         scorpio::define_var(filename, name, unitless, vec_of_dims,
                             "real",fp_precision, m_add_time_dim);
       }
     }
   }
 } // register_variables
-/* ---------------------------------------------------------- */
-std::vector<scorpio::offset_t>
-AtmosphereOutput::get_var_dof_offsets(const FieldLayout& layout)
-{
-  using namespace ShortFieldTagsNames;
-
-  // Precompute this *before* the early return, since it involves collectives.
-  // If one rank owns zero cols, and returns prematurely, the others will be left waiting.
-  AbstractGrid::gid_type min_gid = -1;
-  if (layout.has_tag(COL) or layout.has_tag(EL)) {
-    min_gid = m_io_grid->get_global_min_dof_gid();
-  }
-
-  // It may be that this MPI rank owns no chunk of the field
-  if (layout.size()==0) {
-    return {};
-  }
-
-  std::vector<scorpio::offset_t> var_dof(layout.size());
-
-  // Gather the offsets of the dofs of this variable w.r.t. the *global* array.
-  // Since we order the global array based on dof gid, and we *assume* (we actually
-  // check this during set_grid) that the grid global gids are in the interval
-  // [gid_0, gid_0+num_global_dofs), the offset is simply given by
-  // (dof_gid-gid_0)*column_size (for partitioned arrays).
-  // NOTE: we allow gid_0!=0, so that we don't have to worry about 1-based numbering
-  //       vs 0-based numbering. The key feature is that the global gids are a
-  //       contiguous array. The starting point doesn't matter.
-  // NOTE: a "dof" in the grid object is not the same as a "dof" in scorpio.
-  //       For a SEGrid 3d vector field with (MPI local) layout (nelem,2,np,np,nlev),
-  //       scorpio sees nelem*2*np*np*nlev dofs, while the SE grid sees nelem*np*np dofs.
-  //       All we need to do in this routine is to compute the offset of all the entries
-  //       of the MPI-local array w.r.t. the global array. So long as the offsets are in
-  //       the same order as the corresponding entry in the data to be read/written, we're good.
-  // NOTE: In the case of regional output this rank may have 0 columns to write, thus, var_dof
-  //       should be empty, we check for this special case and return an empty var_dof.
-  auto dofs_h = m_io_grid->get_dofs_gids().get_view<const AbstractGrid::gid_type*,Host>();
-  if (layout.has_tag(COL)) {
-    const int num_cols = m_io_grid->get_num_local_dofs();
-
-    // Note: col_size might be *larger* than the number of vertical levels, or even smaller.
-    //       E.g., (ncols,2,nlevs), or (ncols,2) respectively.
-    scorpio::offset_t col_size = layout.size() / num_cols;
-
-    for (int icol=0; icol<num_cols; ++icol) {
-      // Get chunk of var_dof to fill
-      auto start = var_dof.begin()+icol*col_size;
-      auto end   = start+col_size;
-
-      // Compute start of the column offset, then fill column adding 1 to each entry
-      auto gid = dofs_h(icol);
-      auto offset = (gid-min_gid)*col_size;
-      std::iota(start,end,offset);
-    }
-  } else if (layout.has_tag(EL)) {
-    auto layout2d = m_io_grid->get_2d_scalar_layout();
-    const int num_my_elems = layout2d.dim(0);
-    const int ngp = layout2d.dim(1);
-    const int num_cols = num_my_elems*ngp*ngp;
-
-    // Note: col_size might be *larger* than the number of vertical levels, or even smaller.
-    //       E.g., (ncols,2,nlevs), or (ncols,2) respectively.
-    scorpio::offset_t col_size = layout.size() / num_cols;
-
-    for (int ie=0,icol=0; ie<num_my_elems; ++ie) {
-      for (int igp=0; igp<ngp; ++igp) {
-        for (int jgp=0; jgp<ngp; ++jgp,++icol) {
-          // Get chunk of var_dof to fill
-          auto start = var_dof.begin()+icol*col_size;
-          auto end   = start+col_size;
-
-          // Compute start of the column offset, then fill column adding 1 to each entry
-          auto gid = dofs_h(icol);
-          auto offset = (gid-min_gid)*col_size;
-          std::iota(start,end,offset);
-    }}}
-  } else {
-    // This field is *not* defined over columns, so it is not partitioned.
-    std::iota(var_dof.begin(),var_dof.end(),0);
-  }
-
-  return var_dof;
-}
 
 void AtmosphereOutput::set_decompositions(const std::string& filename)
 {
@@ -1297,37 +916,12 @@ compute_diagnostic(const std::string& name, const bool allow_invalid_fields)
   }
 }
 /* ---------------------------------------------------------- */
-// General get_field routine for output.
-// This routine will first check if a field is in the local field
-// manager.  If not it will next check to see if it is in the list
-// of available diagnostics.  If neither of these two options it
-// will throw an error.
-Field AtmosphereOutput::
-get_field(const std::string& name, const std::string& mode) const
-{
-  const auto field_mgr = get_field_manager(mode);
-  const auto gn = m_fm_grid_name.at(mode);
-  const auto sim_field_mgr = get_field_manager("sim");
-  const bool can_be_diag = field_mgr == sim_field_mgr;
-  if (field_mgr->has_field(name, gn)) {
-    return field_mgr->get_field(name, gn);
-  } else if (m_diagnostics.find(name) != m_diagnostics.end() && can_be_diag) {
-    const auto& diag = m_diagnostics.at(name);
-    return diag->get_diagnostic();
-  } else {
-    EKAT_ERROR_MSG ("ERROR::AtmosphereOutput::get_field Field " + name + " not found in " + mode + " field manager or diagnostics list.");
-  }
-  static Field f;
-  return f;
-}
-/* ---------------------------------------------------------- */
 void AtmosphereOutput::set_diagnostics()
 {
-  const auto sim_field_mgr = get_field_manager("sim");
-  const auto gn = m_fm_grid_name.at("sim");
+  auto fm_model = m_field_mgrs[FromModel];
   // Create all diagnostics
   for (const auto& fname : m_fields_names) {
-    if (!sim_field_mgr->has_field(fname, gn)) {
+    if (fm_model->has_field(fname)) {
       m_diagnostics[fname] = create_diagnostic(fname);
     }
   }
@@ -1338,8 +932,8 @@ std::shared_ptr<AtmosphereDiagnostic>
 AtmosphereOutput::create_diagnostic (const std::string& diag_field_name)
 {
   // We need scream scope resolution, since this->create_diagnostic is hiding it
-  auto sim_grid = get_field_manager("sim")->get_grids_manager()->get_grid(m_fm_grid_name.at("sim"));
-  auto diag = scream::create_diagnostic(diag_field_name,sim_grid);
+  auto fm_model = m_field_mgrs[FromModel];
+  auto diag = scream::create_diagnostic(diag_field_name,fm_model->get_grid());
 
   // Some diags need some extra setup or trigger extra behaviors
   // TODO: move this to the diag class itself, then query bool + string
@@ -1368,18 +962,16 @@ AtmosphereOutput::create_diagnostic (const std::string& diag_field_name)
   auto& deps = m_diag_depends_on_diags[diag_field_name];
 
   // Initialize the diagnostic
-  const auto sim_field_mgr = get_field_manager("sim");
-  const auto gn = m_fm_grid_name.at("sim");
   for (const auto& freq : diag->get_required_field_requests()) {
     const auto& fname = freq.fid.name();
-    if (!sim_field_mgr->has_field(fname, gn)) {
+    if (not fm_model->has_field(fname)) {
       // This diag depends on another diag. Create and init the dependency
       if (m_diagnostics.count(fname)==0) {
         m_diagnostics[fname] = create_diagnostic(fname);
       }
       deps.push_back(fname);
     }
-    diag->set_required_field (get_field(fname,"sim"));
+    diag->set_required_field (fm_model->get_field(fname));
   }
 
   diag->initialize(util::TimeStamp(),RunType::Initial);
@@ -1392,115 +984,6 @@ AtmosphereOutput::create_diagnostic (const std::string& diag_field_name)
   }
 
   return diag;
-}
-
-// Helper function to mark filled points in a specific layout
-void AtmosphereOutput::
-update_avg_cnt_view(const Field& field, view_1d_dev& dev_view) {
-  const auto& name   = field.name();
-  const auto& layout = m_layouts.at(name);
-  const auto& dims   = layout.dims();
-        auto  data   = dev_view.data();
-  const auto fill_value = m_fill_value;
-
-  KT::RangePolicy policy(0,layout.size());
-  const auto extents = layout.extents();
-  switch (layout.rank()) {
-    case 0:
-    {
-      auto src_view_0d = field.get_view<const Real,Device>();
-      auto tgt_view_0d = view_Nd_dev<0>(data);
-      Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int) {
-        if (src_view_0d()!=fill_value) {
-          tgt_view_0d() += 1;
-        }
-      });
-      break;
-    }
-    case 1:
-    {
-      // For rank-1 views, we use strided layout, since it helps us
-      // handling a few more scenarios
-      auto src_view_1d = field.get_strided_view<const Real*,Device>();
-      auto tgt_view_1d = view_Nd_dev<1>(data,dims[0]);
-      Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int i) {
-        if (src_view_1d(i)!=fill_value) {
-          tgt_view_1d(i) += 1;
-        }
-      });
-      break;
-    }
-    case 2:
-    {
-      auto src_view_2d = field.get_view<const Real**,Device>();
-      auto tgt_view_2d = view_Nd_dev<2>(data,dims[0],dims[1]);
-      Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int idx) {
-        int i,j;
-        unflatten_idx(idx,extents,i,j);
-        if (src_view_2d(i,j)!=fill_value) {
-          tgt_view_2d(i,j) += 1;
-        }
-      });
-      break;
-    }
-    case 3:
-    {
-      auto src_view_3d = field.get_view<const Real***,Device>();
-      auto tgt_view_3d = view_Nd_dev<3>(data,dims[0],dims[1],dims[2]);
-      Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int idx) {
-        int i,j,k;
-        unflatten_idx(idx,extents,i,j,k);
-        if (src_view_3d(i,j,k)!=fill_value) {
-          tgt_view_3d(i,j,k) += 1;
-        }
-      });
-      break;
-    }
-    case 4:
-    {
-      auto src_view_4d = field.get_view<const Real****,Device>();
-      auto tgt_view_4d = view_Nd_dev<4>(data,dims[0],dims[1],dims[2],dims[3]);
-      Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int idx) {
-        int i,j,k,l;
-        unflatten_idx(idx,extents,i,j,k,l);
-        if (src_view_4d(i,j,k,l)!=fill_value) {
-          tgt_view_4d(i,j,k,l) += 1;
-        }
-      });
-      break;
-    }
-    case 5:
-    {
-      auto src_view_5d = field.get_view<const Real*****,Device>();
-      auto tgt_view_5d = view_Nd_dev<5>(data,dims[0],dims[1],dims[2],dims[3],dims[4]);
-      Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int idx) {
-        int i,j,k,l,m;
-        unflatten_idx(idx,extents,i,j,k,l,m);
-        if (src_view_5d(i,j,k,l,m)!=fill_value) {
-          tgt_view_5d(i,j,k,l,m) += 1;
-        }
-      });
-      break;
-    }
-    case 6:
-    {
-      auto src_view_6d = field.get_view<const Real******,Device>();
-      auto tgt_view_6d = view_Nd_dev<6>(data,dims[0],dims[1],dims[2],dims[3],dims[4],dims[5]);
-      Kokkos::parallel_for(policy, KOKKOS_LAMBDA(int idx) {
-        int i,j,k,l,m,n;
-        unflatten_idx(idx,extents,i,j,k,l,m,n);
-        if (src_view_6d(i,j,k,l,m,n)!=fill_value) {
-          tgt_view_6d(i,j,k,l,m,n) += 1;
-        }
-      });
-      break;
-    }
-    default:
-      EKAT_ERROR_MSG (
-            "Error! Field rank not not supported by AtmosphereOutput.\n"
-          "  - field name:   " + field.name() + "\n"
-          "  - field layout: " + layout.to_string() + "\n");
-  }
 }
 
 } // namespace scream

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -488,7 +488,7 @@ run (const std::string& filename,
           f_out.deep_copy(m_fill_value,mask);
         } else {
           // Divide by steps count only when the summation is complete
-          f_out.scale(1.0 / nsteps_since_last_output);
+          f_out.scale(Real(1.0) / nsteps_since_last_output);
         }
       }
 

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -159,7 +159,7 @@ protected:
   void register_variables(const std::string& filename, const std::string& fp_precision, const scorpio::FileMode mode);
   void set_decompositions(const std::string& filename);
   void compute_diagnostics (const bool allow_invalid_fields);
-  void init_diagnostics (const std::shared_ptr<const FieldManager>& fm_model);
+  void init_diagnostics ();
   strvec_t get_var_dimnames (const FieldLayout& layout) const;
 
   // Tracking the averaging of any filled values:

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -187,8 +187,8 @@ protected:
 
   // Internal maps to the output fields, how the columns are distributed, the file dimensions and the global ids.
   strvec_t                              m_fields_names;
-  strvec_t                              m_avg_cnt_names;
-  strmap_t<std::string>                 m_field_to_avg_cnt_map;
+  strmap_t<Field>                       m_field_to_avg_count;
+  std::vector<Field>                    m_avg_counts;
   strmap_t<std::string>                 m_field_to_avg_cnt_suffix;
   strmap_t<strvec_t>                    m_vars_dims;
   strmap_t<int>                         m_dims_len;

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -113,15 +113,6 @@ public:
   using remapper_type = AbstractRemapper;
   using atm_diag_type = AtmosphereDiagnostic;
 
-  using KT = KokkosTypes<DefaultDevice>;
-  template<int N>
-  using view_Nd_dev  = typename KT::template view_ND<Real,N>;
-  template<int N>
-  using view_Nd_host = typename KT::template view_ND<Real,N>::HostMirror;
-
-  using view_1d_dev  = view_Nd_dev<1>;
-  using view_1d_host = view_Nd_host<1>;
-
   virtual ~AtmosphereOutput () = default;
 
   // Constructor
@@ -137,8 +128,7 @@ public:
   // Main Functions
   void restart (const std::string& filename);
   void init();
-  void reset_dev_views();
-  void update_avg_cnt_view(const Field&, view_1d_dev& dev_view);
+  void reset_scorpio_fields();
   void setup_output_file (const std::string& filename, const std::string& fp_precision, const scorpio::FileMode mode);
 
   void init_timestep (const util::TimeStamp& start_of_step);
@@ -159,23 +149,10 @@ public:
   }
 
 protected:
+
   // Internal functions
-  void set_grid (const std::shared_ptr<const AbstractGrid>& grid);
-  void set_field_manager (const std::shared_ptr<const fm_type>& field_mgr,
-                          const std::string& grid_name,
-                          const std::string& mode);
-  void set_field_manager (const std::shared_ptr<const fm_type>& field_mgr,
-                          const std::string& grid_name,
-                          const std::vector<std::string>& modes);
-
-  std::shared_ptr<const fm_type> get_field_manager (const std::string& mode) const;
-
-  void register_dimensions(const std::string& name);
   void register_variables(const std::string& filename, const std::string& fp_precision, const scorpio::FileMode mode);
   void set_decompositions(const std::string& filename);
-  std::vector<scorpio::offset_t> get_var_dof_offsets (const FieldLayout& layout);
-  void register_views();
-  Field get_field(const std::string& name, const std::string& mode) const;
   void compute_diagnostic (const std::string& name, const bool allow_invalid_fields = false);
   void set_diagnostics();
   std::shared_ptr<AtmosphereDiagnostic>
@@ -187,15 +164,14 @@ protected:
   // --- Internal variables --- //
   ekat::Comm                          m_comm;
 
-  // We store two shared pointers for field managers:
-  // io_field_manager stores the fields in the layout for output
-  // sim_field_manager points to the simulation field manager
-  // when remapping horizontally these two field managers may be different.
-  std::map<std::string,std::shared_ptr<const fm_type>> m_field_mgrs;
-
-  // Field managers can have multiple grids associated with it,
-  // for each FM store which grid we intend to use
-  std::map<std::string,std::string> m_fm_grid_name;
+  // We store separate shared pointers for field managers at different stages
+  enum Phase {
+    FromModel,        // Output fields as from the model (or diags computed from model fields)
+    AfterVertRemap,   // Output fields after vertical remap
+    AfterHorizRemap,  // Output fields after horiz remap
+    Scorpio           // Output fields to pass to scorpio (may differ from the above in case of packing)
+  };
+  std::map<Phase,std::shared_ptr<fm_type>> m_field_mgrs;
 
   std::shared_ptr<const grid_type>            m_io_grid;
   std::shared_ptr<remapper_type>              m_horiz_remapper;
@@ -215,6 +191,7 @@ protected:
   std::map<std::string,std::shared_ptr<atm_diag_type>>  m_diagnostics;
   std::map<std::string,std::vector<std::string>>        m_diag_depends_on_diags;
   std::map<std::string,bool>                            m_diag_computed;
+
   DefaultMetadata                                       m_default_metadata;
 
   // Use float, so that if output fp_precision=float, this is a representable value.
@@ -223,10 +200,6 @@ protected:
   // Also, by default, don't pick max float, to avoid any overflow if the value
   // is used inside other calculation and/or remap.
   float m_fill_value = constants::DefaultFillValue<float>().value;
-
-  // Local views of each field to be used for "averaging" output and writing to file.
-  std::map<std::string,view_1d_host>    m_host_views_1d;
-  std::map<std::string,view_1d_dev>     m_dev_views_1d;
 
   bool m_add_time_dim;
   bool m_track_avg_cnt = false;

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -153,11 +153,14 @@ protected:
   template<typename T>
   using strmap_t = std::map<std::string,T>;
 
+  using strvec_t = std::vector<std::string>;
+
   // Internal functions
   void register_variables(const std::string& filename, const std::string& fp_precision, const scorpio::FileMode mode);
   void set_decompositions(const std::string& filename);
   void compute_diagnostics (const bool allow_invalid_fields);
   void init_diagnostics (const std::shared_ptr<const FieldManager>& fm_model);
+  strvec_t get_var_dimnames (const FieldLayout& layout) const;
 
   // Tracking the averaging of any filled values:
   void set_avg_cnt_tracking(const std::string& name, const FieldLayout& layout);
@@ -174,21 +177,21 @@ protected:
   };
   std::map<Phase,std::shared_ptr<fm_type>> m_field_mgrs;
 
-  std::shared_ptr<const grid_type>            m_io_grid;
-  std::shared_ptr<remapper_type>              m_horiz_remapper;
-  std::shared_ptr<remapper_type>              m_vert_remapper;
+  std::shared_ptr<const grid_type>      m_io_grid;
+  std::shared_ptr<remapper_type>        m_horiz_remapper;
+  std::shared_ptr<remapper_type>        m_vert_remapper;
 
   // How to combine multiple snapshots in the output: instant, Max, Min, Average
-  OutputAvgType     m_avg_type;
-  Real              m_avg_coeff_threshold = 0.5; // % of unfilled values required to not just assign value as FillValue
+  OutputAvgType                         m_avg_type;
+  Real                                  m_avg_coeff_threshold = 0.5; // % of unfilled values required to not just assign value as FillValue
 
   // Internal maps to the output fields, how the columns are distributed, the file dimensions and the global ids.
-  std::vector<std::string>              m_fields_names;
-  std::vector<std::string>              m_avg_cnt_names;
+  strvec_t                              m_fields_names;
+  strvec_t                              m_avg_cnt_names;
   strmap_t<std::string>                 m_field_to_avg_cnt_map;
   strmap_t<std::string>                 m_field_to_avg_cnt_suffix;
-  strmap_t<FieldLayout>                 m_layouts;
-  strmap_t<int>                         m_dims;
+  strmap_t<strvec_t>                    m_vars_dims;
+  strmap_t<int>                         m_dims_len;
   std::list<diag_ptr_type>              m_diagnostics;
 
   DefaultMetadata                       m_default_metadata;
@@ -202,6 +205,7 @@ protected:
 
   bool m_add_time_dim;
   bool m_track_avg_cnt = false;
+  std::string m_decomp_dimname = "";
 
   // The logger to be used throughout the ATM to log message
   std::shared_ptr<ekat::logger::LoggerBase> m_atm_logger;

--- a/components/eamxx/src/share/io/scorpio_scm_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_scm_input.cpp
@@ -102,8 +102,10 @@ void SCMInput::create_closest_col_info (double target_lat, double target_lon)
   auto lat = m_io_grid->create_geometry_data("lat",m_io_grid->get_2d_scalar_layout(),nondim);
   auto lon = m_io_grid->create_geometry_data("lon",m_io_grid->get_2d_scalar_layout(),nondim);
 
+  std::vector<Field> latlon = {lat,lon};
+
   // Read from file
-  AtmosphereInput file_reader(m_filename, m_io_grid, {lat,lon});
+  AtmosphereInput file_reader(m_filename, m_io_grid, latlon);
   file_reader.read_variables();
   file_reader.finalize();
 

--- a/components/eamxx/src/share/io/tests/io_filled.cpp
+++ b/components/eamxx/src/share/io/tests/io_filled.cpp
@@ -101,6 +101,7 @@ get_fm (const std::shared_ptr<const AbstractGrid>& grid,
     f.allocate_view();
     f.deep_copy(0.0); // For the "filled" field we start with a filled value.
     f.get_header().get_tracking().update_time_stamp(t0);
+    f.get_header().set_extra_data("mask_value",FillValue);
     fm->add_field(f);
   }
 
@@ -152,7 +153,9 @@ void write (const std::string& avg_type, const std::string& freq_units,
     // Update time
     t += dt;
 
-    // Set fields to n or the FillValue, depending on timesnap
+    // Set fields to n+1 or the FillValue, depending on step:
+    //  - n+1 if n+1 is odd
+    //  - FillValue if n+1 is even
     Real setval = ((n+1) % 2 == 0) ? 1.0*(n+1) : FillValue;
     for (const auto& n : fnames) {
       auto f = fm->get_field(n);
@@ -237,6 +240,7 @@ void read (const std::string& avg_type, const std::string& freq_units,
         // Note, for AVERAGE type output with filling we need to check that the
         // number of contributing fill steps surpasses the fill_threshold, if not
         // then we know that the snap will reflect the fill value.
+
         Real test_val;
         Real M = freq/2 + (n%2==0 ? 0.0 :  1.0);
         Real a = n*freq + (n%2==0 ? 0.0 : -1.0);

--- a/components/eamxx/src/share/io/tests/io_horiz_sampling.cpp
+++ b/components/eamxx/src/share/io/tests/io_horiz_sampling.cpp
@@ -138,10 +138,13 @@ TEST_CASE("io_remap_test","io_remap_test")
   // Read output file
   std::string filename = "horiz_sampling.INSTANT.nsteps_x1.np" + std::to_string(comm.size()) + "." + t0.to_string() + ".nc";
   auto tgt_grid = create_point_grid(gname + "_tgt",ngcols_tgt,nlevs,comm);
+
   auto s2d_tgt = create_f("s2d",tgt_grid->get_2d_scalar_layout(),gname+"_tgt");
   auto s3d_tgt = create_f("s3d",tgt_grid->get_3d_scalar_layout(true),gname+"_tgt");
 
-  AtmosphereInput reader(filename,tgt_grid,{s2d_tgt,s3d_tgt});
+  std::vector<Field> fields = {s2d_tgt,s3d_tgt};
+
+  AtmosphereInput reader(filename,tgt_grid,fields);
   reader.read_variables();
   reader.finalize(); // manually finalize, or scorpio cleanup will complain about a file still open
 

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -512,18 +512,9 @@ TEST_CASE("field_mgr", "") {
   REQUIRE_THROWS(field_mgr.get_field("field1", "grid3")); // Wrong grid
 
   // Check that the groups names are in the header. While at it, make sure that case insensitive works fine.
-  auto has_group = [](const ekat::WeakPtrSet<const FieldGroupInfo>& groups,
-                      const std::string& name)->bool {
-    for (auto it : groups) {
-      if (it.lock()->m_group_name==name) {
-        return true;
-      }
-    }
-    return false;
-  };
-  REQUIRE (has_group(f2_1.get_header().get_tracking().get_groups_info(),"gRouP_1"));
-  REQUIRE (has_group(f1_2.get_header().get_tracking().get_groups_info(),"Group_2"));
-  REQUIRE (has_group(f1_2.get_header().get_tracking().get_groups_info(),"Group_1"));
+  REQUIRE (ekat::contains(f2_1.get_header().get_tracking().get_groups_names(),"gRouP_1"));
+  REQUIRE (ekat::contains(f1_2.get_header().get_tracking().get_groups_names(),"Group_2"));
+  REQUIRE (ekat::contains(f1_2.get_header().get_tracking().get_groups_names(),"Group_1"));
 
   // Check that correct grids requested groups
   REQUIRE (field_mgr.has_group("group_1", "grid1"));

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -880,6 +880,42 @@ TEST_CASE ("update") {
     }
   }
 
+  SECTION ("max-min") {
+    SECTION ("real") {
+      Field one = f_real.clone();
+      Field two = f_real.clone();
+      one.deep_copy(1.0);
+      two.deep_copy(2.0);
+
+      Field f1 = one.clone();
+      Field f2 = two.clone();
+      f1.max(f2);
+      REQUIRE (views_are_equal(f1, f2));
+
+      Field f3 = one.clone();
+      Field f4 = two.clone();
+      f4.min(f3);
+      REQUIRE (views_are_equal(f3, f4));
+    }
+
+    SECTION ("int") {
+      Field one = f_int.clone();
+      Field two = f_int.clone();
+      one.deep_copy(1);
+      two.deep_copy(2);
+
+      Field f1 = one.clone();
+      Field f2 = two.clone();
+      f1.max(f2);
+      REQUIRE (views_are_equal(f1, f2));
+
+      Field f3 = one.clone();
+      Field f4 = two.clone();
+      f4.min(f3);
+      REQUIRE (views_are_equal(f3, f4));
+    }
+  }
+
   SECTION ("scale_inv") {
     SECTION ("real") {
       Field f1 = f_real.clone();

--- a/components/eamxx/src/share/util/eamxx_combine_ops.hpp
+++ b/components/eamxx/src/share/util/eamxx_combine_ops.hpp
@@ -79,7 +79,7 @@ void combine (const ScalarIn& newVal, ScalarOut& result,
 template<CombineMode CM, typename ScalarIn, typename ScalarOut,
          typename CoeffType = typename ekat::ScalarTraits<ScalarIn>::scalar_type>
 KOKKOS_FORCEINLINE_FUNCTION
-void combine_and_fill (const ScalarIn& newVal, ScalarOut& result, const ScalarOut fill_val,
+void fill_aware_combine (const ScalarIn& newVal, ScalarOut& result, const ScalarOut fill_val,
               const CoeffType alpha, const CoeffType beta)
 {
   switch (CM) {
@@ -89,17 +89,14 @@ void combine_and_fill (const ScalarIn& newVal, ScalarOut& result, const ScalarOu
     case CombineMode::Update:
     case CombineMode::Multiply:
     case CombineMode::Divide:
-      if (result == fill_val || newVal == fill_val) {
-        result = fill_val;
-      } else {
-        combine<CM>(newVal,result,alpha,beta);
-      }
-      break;
     case CombineMode::Max:
     case CombineMode::Min:
       if (newVal != fill_val)
         combine<CM>(newVal,result,alpha,beta);
+      break;
         
+    default:
+      EKAT_KERNEL_ERROR_MSG("Unsupported combine mode for 'fill_aware_combine' overload");
   }
 }
 

--- a/components/eamxx/src/share/util/eamxx_combine_ops.hpp
+++ b/components/eamxx/src/share/util/eamxx_combine_ops.hpp
@@ -3,10 +3,12 @@
 
 #include "share/util/eamxx_universal_constants.hpp"
 
+#include <ekat/ekat_scalar_traits.hpp>
+#include <ekat/util/ekat_math_utils.hpp>
+
 // For KOKKOS_INLINE_FUNCTION
 #include <Kokkos_Core.hpp>
 #include <type_traits>
-#include "ekat/ekat_scalar_traits.hpp"
 
 namespace scream {
 
@@ -30,14 +32,16 @@ enum class CombineMode {
   Replace,    // out = alpha*in
   Update,     // out = beta*out + alpha*in
   Multiply,   // out = (beta*out)*(alpha*in)
-  Divide      // out = (beta*out)/(alpha*in)
+  Divide,     // out = (beta*out)/(alpha*in)
+  Max,        // out = max(beta*out,alpha*in)
+  Min         // out = min(beta*out,alpha*in)
 };
 
 // Small helper functions to combine a new value with an old one.
 // The template argument help reducing the number of operations
 // performed (the if is resolved at compile time). In the most
-// complete form, the function performs
-//    result = beta*result + alpha*newVal
+// complete form, the function performs (in functional programming notation):
+//    result = (op beta*result alpha*newVal) (where op can be +, *, /, max, min)
 // This routine should have no overhead compared to a manual
 // update (assuming you call it with the proper CM)
 
@@ -47,6 +51,8 @@ KOKKOS_FORCEINLINE_FUNCTION
 void combine (const ScalarIn& newVal, ScalarOut& result,
               const CoeffType alpha, const CoeffType beta)
 {
+  using ekat::impl::max;
+  using ekat::impl::min;
   switch (CM) {
     case CombineMode::Replace:
       result = alpha*newVal;
@@ -60,6 +66,12 @@ void combine (const ScalarIn& newVal, ScalarOut& result,
       break;
     case CombineMode::Divide:
       result /= (alpha/beta) * newVal;
+      break;
+    case CombineMode::Max:
+      result  = max(beta*result,static_cast<const ScalarOut&>(alpha*newVal));
+      break;
+    case CombineMode::Min:
+      result  = min(beta*result,static_cast<const ScalarOut&>(alpha*newVal));
       break;
   }
 }
@@ -83,6 +95,11 @@ void combine_and_fill (const ScalarIn& newVal, ScalarOut& result, const ScalarOu
         combine<CM>(newVal,result,alpha,beta);
       }
       break;
+    case CombineMode::Max:
+    case CombineMode::Min:
+      if (newVal != fill_val)
+        combine<CM>(newVal,result,alpha,beta);
+        
   }
 }
 

--- a/components/eamxx/src/share/util/eamxx_data_interpolation.cpp
+++ b/components/eamxx/src/share/util/eamxx_data_interpolation.cpp
@@ -438,9 +438,11 @@ create_horiz_remappers (const Real iop_lat, const Real iop_lon)
 
   // Create grid for IO and load lat/lon field in IO grid from any data file
   auto data_grid = create_point_grid("data",ncols_data,nlevs_data,m_model_grid->get_comm());
-  auto lat_f = data_grid->create_geometry_data("lat",data_grid->get_2d_scalar_layout());
-  auto lon_f = data_grid->create_geometry_data("lon",data_grid->get_2d_scalar_layout());
-  AtmosphereInput latlon_reader (m_time_database.files.front(),data_grid,{lat_f,lon_f});
+  std::vector<Field> latlon = {
+    data_grid->create_geometry_data("lat",data_grid->get_2d_scalar_layout()),
+    data_grid->create_geometry_data("lon",data_grid->get_2d_scalar_layout())
+  };
+  AtmosphereInput latlon_reader (m_time_database.files.front(),data_grid,latlon);
   latlon_reader.read_variables();
 
   // Create iop remap tgt grid
@@ -573,13 +575,16 @@ create_vert_remapper (const VertRemapData& data)
       auto layout = m_grid_after_hremap->get_vertical_layout(true);
       auto nondim = ekat::units::Units::nondimensional();
       DataType real_t = DataType::RealType;
-      auto hyam = m_grid_after_hremap->create_geometry_data("hyam",layout,nondim,real_t,SCREAM_PACK_SIZE);
-      auto hybm = m_grid_after_hremap->create_geometry_data("hybm",layout,nondim,real_t,SCREAM_PACK_SIZE);
-      AtmosphereInput hvcoord_reader (m_time_database.files.front(),m_grid_after_hremap,{hyam,hybm},true);
+      std::vector<Field> fields = {
+        m_grid_after_hremap->create_geometry_data("hyam",layout,nondim,real_t,SCREAM_PACK_SIZE),
+        m_grid_after_hremap->create_geometry_data("hybm",layout,nondim,real_t,SCREAM_PACK_SIZE)
+      };
+      AtmosphereInput hvcoord_reader (m_time_database.files.front(),m_grid_after_hremap,fields,true);
       hvcoord_reader.read_variables();
     } else if (m_vr_type==Static1D) {
       // Can load p now, since it's static
-      AtmosphereInput p_data_reader (m_time_database.files.front(),m_grid_after_hremap,{p_data.alias(data.pname)},true);
+      std::vector<Field> fields = {p_data.alias(data.pname)};
+      AtmosphereInput p_data_reader (m_time_database.files.front(),m_grid_after_hremap,fields,true);
       p_data_reader.read_variables();
     }
     vremap->set_source_pressure (m_helper_pressure_fields["p_data"],VerticalRemapper::Both);

--- a/components/eamxx/tests/single-process/surface_coupling/surface_coupling.cpp
+++ b/components/eamxx/tests/single-process/surface_coupling/surface_coupling.cpp
@@ -20,7 +20,6 @@ namespace scream {
 using vos_type = std::vector<std::string>;
 using vor_type = std::vector<Real>;
 constexpr Real test_tol = std::numeric_limits<Real>::epsilon()*1e4;
-constexpr Real FillValue = -99999.0;
 
 // Test function for prescribed values
 Real test_func(const int col, const int t) {
@@ -92,7 +91,6 @@ std::vector<std::string> create_from_file_test_data(const ekat::Comm& comm, cons
   om_pl.set("field_names",fnames);
   om_pl.set("averaging_type", std::string("INSTANT"));
   om_pl.set("max_snapshots_per_file",2);
-  om_pl.set<double>("fill_value",FillValue);
   auto& ctrl_pl = om_pl.sublist("output_control");
   ctrl_pl.set("frequency_units",std::string("nsteps"));
   ctrl_pl.set("frequency",1);
@@ -260,24 +258,24 @@ void test_imports(const FieldManager& fm,
 
     // The following are only imported during run phase. If this test is called
     // during initialization, all values should be the default value.
-    // TODO: Why are some of these FillValue and others are 0.0?  For the former,
-    // they are gathered from output it seems, so they take the FillValue.  While
-    // the few ones with 0.0 seem to take there initial value from the field initialization
-    // which is 0.0 I believe.  Still, based on the comment none of these should be read in
-    // yet right?
     if (called_directly_after_init) {
-      EKAT_REQUIRE(sfc_alb_dir_vis(i)  == FillValue);
-      EKAT_REQUIRE(sfc_alb_dir_nir(i)  == FillValue);
-      EKAT_REQUIRE(sfc_alb_dif_vis(i)  == FillValue);
-      EKAT_REQUIRE(sfc_alb_dif_nir(i)  == FillValue);
+      // Right now, FieldManager allocates fields without setting a special value
+      // for uninitialized, so it just gets whatever is the default allocation.
+      // If we change what the FM does, we need to change this value.
+      const Real UninitedValue = 0.0;
+
+      EKAT_REQUIRE(sfc_alb_dir_vis(i)  == UninitedValue);
+      EKAT_REQUIRE(sfc_alb_dir_nir(i)  == UninitedValue);
+      EKAT_REQUIRE(sfc_alb_dif_vis(i)  == UninitedValue);
+      EKAT_REQUIRE(sfc_alb_dif_nir(i)  == UninitedValue);
       EKAT_REQUIRE(surf_radiative_T(i) == 0.0);
       EKAT_REQUIRE(T_2m(i)             == 0.0);
       EKAT_REQUIRE(qv_2m(i)            == 0.0);
       EKAT_REQUIRE(wind_speed_10m(i)   == 0.0);
       EKAT_REQUIRE(snow_depth_land(i)  == 0.0);
-      EKAT_REQUIRE(surf_lw_flux_up(i)  == FillValue);
-      EKAT_REQUIRE(ocnfrac(i)          == FillValue);
-      EKAT_REQUIRE(landfrac(i)         == FillValue);
+      EKAT_REQUIRE(surf_lw_flux_up(i)  == UninitedValue);
+      EKAT_REQUIRE(ocnfrac(i)          == UninitedValue);
+      EKAT_REQUIRE(landfrac(i)         == UninitedValue);
     } else {
       EKAT_REQUIRE(sfc_alb_dir_vis(i)  == import_constant_multiple_view(0 )*import_data_view(i, import_cpl_indices_view(0)));
       EKAT_REQUIRE(sfc_alb_dir_nir(i)  == import_constant_multiple_view(1 )*import_data_view(i, import_cpl_indices_view(1)));


### PR DESCRIPTION
Replaces manual parallel loops with usage of Field and Field utilities functions.

[BFB]

---

Summary of major mods:

- add `Max` and `Min` as values for `CombineMode` enum
- add shortcut `min`/`max` methods to `Field` (they call `update`, just like `scale` does)
- change how we handle fillVal in combine operations: before, x+=fillVal gave x==fillVal. Now, fillVal on the rhs is always ignored, while we should NOT have fillVal on the lhs
- simplified creation of diagnostics, ensuring that they can be evaluated in order
- simplified handling of avg count: use masked operations to update the count, as well as to set FillValue where the count is too low)

For now, I marked the PR as BFB, although it's possible it won't be, since the avg count is now a field with `IntType` data type (instead of Real). But I still think it should be, since a) count is a small integer (so the double representation should have no truncation), and b) `my_real / my_int` makes `my_int` undergo int->real promotion before the calculation happens. Still, I'll keep an eye out for non-BFB results.

I've had this branch in the works for months, and decided it's time to get it going. Once this is in, I think it may become easier to handle fields with FillValue in a more agnostic way (that is, IO should not have to check if a field is a FieldAtPressureLevel diag, to toggle `m_track_avg_cnt=true`).

Fixes #7035 
Closes #6965 