### PR TITLE
add glc_nzoc configuration to moab driver

### DIFF
--- a/driver-moab/cime_config/buildnml
+++ b/driver-moab/cime_config/buildnml
@@ -47,6 +47,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     config['MULTI_DRIVER'] = '.true.' if case.get_value('MULTI_DRIVER') else '.false.'
     config['OS'] = case.get_value('OS')
     config['glc_nec'] = 0 if case.get_value('GLC_NEC') == 0 else case.get_value('GLC_NEC')
+    config['glc_nzoc'] = 0 if case.get_value('GLC_NZOC') == 0 else case.get_value('GLC_NZOC')
     config['single_column'] = 'true' if case.get_value('PTS_MODE') else 'false'
     config['timer_level'] = 'pos' if case.get_value('TIMER_LEVEL') >= 1 else 'neg'
     config['bfbflag'] = 'on' if case.get_value('BFBFLAG') else 'off'

--- a/driver-moab/cime_config/config_component_e3sm.xml
+++ b/driver-moab/cime_config/config_component_e3sm.xml
@@ -847,6 +847,24 @@
     Used by both ELM and CISM (even if CISM is not running, and only SGLC is used).</desc>
   </entry>
 
+  <entry id="GLC_NZOC">
+    <type>integer</type>
+    <valid_values>0,4,30</valid_values>
+    <default_value>0</default_value>
+    <values match="last">
+      <value compset="_MPASO.+_MALI">30</value>
+      <value compset="_MPASO.+_MALI%SIASTATIC">0</value>
+      <value compset="_MPASO.+_MALI%STATIC">0</value>
+      <value compset="_MPASO.+_MALI%SIADATA">0</value>
+      <value compset="_MPASO.+_MALI%DATA">0</value>
+    </values>
+    <group>run_glc</group>
+    <file>env_run.xml</file>
+    <desc>Glacier model number of z-ocean classes, 0 implies no OCN z-level coupling to GLC or
+    GLC is inactive.
+    Used by both OCN and GLC components.</desc>
+  </entry>
+
   <entry id="GLC_TWO_WAY_COUPLING">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>

--- a/driver-moab/cime_config/namelist_definition_drv.xml
+++ b/driver-moab/cime_config/namelist_definition_drv.xml
@@ -193,6 +193,18 @@
     </values>
   </entry>
 
+  <entry  id="glc_nzoc" modify_via_xml="GLC_NZOC">
+    <type>integer</type>
+    <category>seq_flds</category>
+    <group>seq_cplflds_inparm</group>
+    <desc>
+      Number of GLC z-ocean classes. Set by the xml variable GLC_NZOC in env_run.xml
+    </desc>
+    <values>
+      <value>$GLC_NZOC</value>
+    </values>
+  </entry>
+  
   <entry id="ice_ncat" modify_via_xml="ICE_NCAT">
     <type>integer</type>
     <category>seq_flds</category>


### PR DESCRIPTION
add glc_nzoc configuration to moab driver.
It is not configuring even non glc cases without this 
more changes will be needed for glc port to moab.

[BFB]