### PR TITLE
migrate map mesh and glc fixes 

### DIFF
--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -1340,7 +1340,7 @@ contains
 #endif
     tagname=trim(seq_flds_x2l_fields)//C_NULL_CHAR
     ent_type = 0 ! vertices 
-    ierr = iMOAB_GetDoubleTagStorage ( mlnid, tagname, totalmblsimp , ent_type, x2l_lm(1,1) )
+    ierr = iMOAB_GetDoubleTagStorage ( mlnid, tagname, totalmblsimp , ent_type, x2l_lm )
     if ( ierr > 0) then
       call endrun('Error: fail to get seq_flds_x2l_fields for land moab instance on component')
     endif

--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -406,7 +406,7 @@ contains
     !     write out the mesh file to disk, in parallel
     outfile = 'wholeLnd.h5m'//C_NULL_CHAR
     wopts   = 'PARALLEL=WRITE_PART'//C_NULL_CHAR
-    if (mnlid >= 0) then
+    if (mlnid >= 0) then
        ierr = iMOAB_WriteMesh(mlnid, outfile, wopts)
        if (ierr > 0 )  &
          call endrun('Error: fail to write the land mesh file')

--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -1076,6 +1076,7 @@ contains
        l2x_lm(i,index_l2x_Sl_tref)     =  lnd2atm_vars%t_ref2m_grc(g)
        l2x_lm(i,index_l2x_Sl_qref)     =  lnd2atm_vars%q_ref2m_grc(g)
        l2x_lm(i,index_l2x_Sl_u10)      =  lnd2atm_vars%u_ref10m_grc(g)
+       l2x_lm(i,index_l2x_Sl_u10withgusts)=lnd2atm_vars%u_ref10m_with_gusts_grc(g) ! see commit 5813d4103
        l2x_lm(i,index_l2x_Fall_taux)   = -lnd2atm_vars%taux_grc(g)
        l2x_lm(i,index_l2x_Fall_tauy)   = -lnd2atm_vars%tauy_grc(g)
        l2x_lm(i,index_l2x_Fall_lat)    = -lnd2atm_vars%eflx_lh_tot_grc(g)

--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -406,9 +406,11 @@ contains
     !     write out the mesh file to disk, in parallel
     outfile = 'wholeLnd.h5m'//C_NULL_CHAR
     wopts   = 'PARALLEL=WRITE_PART'//C_NULL_CHAR
-    ierr = iMOAB_WriteMesh(mlnid, outfile, wopts)
-    if (ierr > 0 )  &
-      call endrun('Error: fail to write the land mesh file')
+    if (mnlid >= 0) then
+       ierr = iMOAB_WriteMesh(mlnid, outfile, wopts)
+       if (ierr > 0 )  &
+         call endrun('Error: fail to write the land mesh file')
+    endif
 #endif
 
   end subroutine lnd_init_mct

--- a/components/mosart/src/cpl/rof_comp_mct.F90
+++ b/components/mosart/src/cpl/rof_comp_mct.F90
@@ -1260,7 +1260,7 @@ end subroutine rof_export_moab
      
     !
     ! LOCAL VARIABLES
-    integer :: n2, n, nt, begr, endr, nliq, nfrz
+    integer :: n2, n, nt, begr, endr, nliq, nfrz, nmud, nsan
     real(R8) :: tmp1, tmp2
     real(R8) :: shum
     character(CXX) ::  tagname ! 
@@ -1287,7 +1287,7 @@ end subroutine rof_export_moab
     ! populate the array x2r_rm with data from MOAB tags
     tagname=trim(seq_flds_x2r_fields)//C_NULL_CHAR
     ent_type = 0 ! vertices, point cloud
-    ierr = iMOAB_GetDoubleTagStorage ( mrofid, tagname, totalmbls_r , ent_type, x2r_rm(1,1) )
+    ierr = iMOAB_GetDoubleTagStorage ( mrofid, tagname, totalmbls_r , ent_type, x2r_rm )
     if ( ierr > 0) then
       call shr_sys_abort(sub//'Error: fail to get  seq_flds_a2x_fields for atm physgrid moab mesh')
     endif
@@ -1295,6 +1295,8 @@ end subroutine rof_export_moab
     ! Note that ***runin are fluxes
     nliq = 0
     nfrz = 0
+    nmud = 0
+    nsan = 0
     do nt = 1,nt_rtm
        if (trim(rtm_tracers(nt)) == 'LIQ') then
           nliq = nt
@@ -1302,9 +1304,27 @@ end subroutine rof_export_moab
        if (trim(rtm_tracers(nt)) == 'ICE') then
           nfrz = nt
        endif
+       if (trim(rtm_tracers(nt)) == 'MUD') then
+          nmud = nt
+       endif
+       if (trim(rtm_tracers(nt)) == 'SAN') then
+          nsan = nt
+       endif
     enddo
-    if (nliq == 0 .or. nfrz == 0) then
-       write(iulog,*) trim(sub),': ERROR in rtm_tracers LIQ ICE ',nliq,nfrz,rtm_tracers
+    if (nliq == 0) then
+       write(iulog,*) trim(sub),': ERROR in rtm_tracers LIQ',nliq,rtm_tracers
+       call shr_sys_abort()
+    endif
+    if (nfrz == 0) then
+       write(iulog,*) trim(sub),': ERROR in rtm_tracers ICE',nfrz,rtm_tracers
+       call shr_sys_abort()
+    endif
+    if (nmud == 0) then
+       write(iulog,*) trim(sub),': ERROR in rtm_tracers MUD',nmud,rtm_tracers
+       call shr_sys_abort()
+    endif
+    if (nsan == 0) then
+       write(iulog,*) trim(sub),': ERROR in rtm_tracers SAN',nsan,rtm_tracers
        call shr_sys_abort()
     endif
 
@@ -1351,7 +1371,24 @@ end subroutine rof_export_moab
           THeat%forc_vp(n)   = shum * THeat%forc_pbot(n)  / (0.622_r8 + 0.378_r8 * shum)
           THeat%coszen(n)    = x2r_rm(n2,index_x2r_coszen_str)
        end if
+
+
+       rtmCTL%qsur(n,nmud) = 0.0_r8
+       rtmCTL%qsur(n,nsan) = 0.0_r8
+
+       if (index_x2r_Flrl_inundinf > 0) then
+          rtmCTL%inundinf(n) = x2r_rm(n2,index_x2r_Flrl_inundinf) * (rtmCTL%area(n)*0.001_r8)
+       endif
+
     enddo
+
+    if(sediflag) then
+        do n = begr,endr
+           n2 = n - begr + 1
+           rtmCTL%qsur(n,nmud) = x2r_rm(n2,index_x2r_Flrl_rofmud) * (rtmCTL%area(n)) ! kg/m2/s --> kg/s for sediment
+           rtmCTL%qsur(n,nsan) = 0.0_r8
+        enddo
+    end if
 
   end subroutine rof_import_moab
 

--- a/components/mosart/src/cpl/rof_comp_mct.F90
+++ b/components/mosart/src/cpl/rof_comp_mct.F90
@@ -388,9 +388,11 @@ contains
     !     write out the mesh file to disk, in parallel
     outfile = 'wholeRof.h5m'//C_NULL_CHAR
     wopts   = 'PARALLEL=WRITE_PART'//C_NULL_CHAR
-    ierr = iMOAB_WriteMesh(mrofid, outfile, wopts)
-    if (ierr > 0 )  &
-      call shr_sys_abort( sub//' Error: fail to write the moab runoff mesh file')
+    if (mrofid >= 0) then
+      ierr = iMOAB_WriteMesh(mrofid, outfile, wopts)
+      if (ierr > 0 )  &
+        call shr_sys_abort( sub//' Error: fail to write the moab runoff mesh file')
+    endif
 #endif
 
   end subroutine rof_init_mct

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -3692,7 +3692,7 @@ contains
    ent_type = 1 ! cells
    !  get all tags in one method
    tagname = trim(seq_flds_x2o_fields)//C_NULL_CHAR
-   ierr = iMOAB_GetDoubleTagStorage ( MPOID, tagname, totalmbls_r , ent_type, x2o_om(1, 1) )
+   ierr = iMOAB_GetDoubleTagStorage ( MPOID, tagname, totalmbls_r , ent_type, x2o_om )
    if ( ierr /= 0 ) then
       write(ocnLogUnit,*) 'Fail to get MOAB fields '
    endif

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -3550,6 +3550,7 @@ contains
                i2x_im(n, index_i2x_Si_t)  = Tsrf
                i2x_im(n, index_i2x_Si_bpress)  = basalPressure
                i2x_im(n, index_i2x_Si_u10)  = atmosReferenceSpeed10m(i)
+               i2x_im(n, index_i2x_Si_u10withgusts) = atmosReferenceSpeed10m(i)  ! see commit 5813d4103
                i2x_im(n, index_i2x_Si_tref)  = atmosReferenceTemperature2m(i)
                i2x_im(n, index_i2x_Si_qref)  = atmosReferenceHumidity2m(i)
                i2x_im(n, index_i2x_Si_snowh)  = snowVolumeCell(i) / ailohi

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -3888,7 +3888,7 @@ contains
    ent_type = 1 ! cells
   !  set all tags in one method
    tagname = trim(seq_flds_x2i_fields)//C_NULL_CHAR
-   ierr = iMOAB_GetDoubleTagStorage ( MPSIID, tagname, totalmblr , ent_type, x2i_im(1, 1) )
+   ierr = iMOAB_GetDoubleTagStorage ( MPSIID, tagname, totalmblr , ent_type, x2i_im )
    if ( ierr /= 0 ) then
       write(iceLogUnit,*) 'Fail to get seq_flds_x2i_fields '
    endif

--- a/driver-moab/cime_config/buildnml
+++ b/driver-moab/cime_config/buildnml
@@ -41,6 +41,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     config['CPL_EPBAL'] = case.get_value('CPL_EPBAL')
     config['FLDS_WISO'] = case.get_value('FLDS_WISO')
     config['FLDS_POLAR'] = case.get_value('FLDS_POLAR')
+    config['FLDS_TF'] = case.get_value('FLDS_TF')
     config['BUDGETS'] = case.get_value('BUDGETS')
     config['MACH'] = case.get_value('MACH')
     config['MPILIB'] = case.get_value('MPILIB')
@@ -68,6 +69,20 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
         config['run_type'] = 'startup'
     elif case.get_value('RUN_TYPE') == 'branch':
         config['run_type'] = 'branch'
+
+   # ---------------------------------------------------
+    # set wave coupling settings based on compset:
+    # ---------------------------------------------------
+    if case.get_value('COMP_WAV') == 'ww3':
+        config['WAVSPEC'] = case.get_value('WAV_SPEC')
+        if case.get_value('COMP_OCN') == 'mpaso':
+            config['WAV_OCN_COUP'] = 'twoway'
+        elif case.get_value('COMP_OCN') == 'docn': 
+            config['WAV_OCN_COUP'] = 'oneway'
+    elif case.get_value('COMP_WAV') == 'dwav':
+        config['WAVSPEC'] = 'sp36x36'
+    else:
+        config['WAVSPEC'] = 'none'
 
     #----------------------------------------------------
     # Initialize namelist defaults

--- a/driver-moab/cime_config/namelist_definition_drv.xml
+++ b/driver-moab/cime_config/namelist_definition_drv.xml
@@ -149,6 +149,18 @@
     </values>
   </entry>
 
+  <entry id="flds_tf">
+    <type>logical</type>
+    <category>seq_flds</category>
+    <group>seq_cplflds_inparm</group>
+    <desc>
+      If set to .true. thermal forcing fields will be passed from the ocean to the coupler.
+    </desc>
+    <values>
+      <value>$FLDS_TF</value>
+    </values>
+  </entry>
+
   <entry id="flds_polar">
     <type>logical</type>
     <category>seq_flds</category>
@@ -300,6 +312,18 @@
     </desc>
     <values>
       <value>.false.</value>
+    </values>
+  </entry>
+ 
+  <entry id="wav_ocn_coup">
+    <type>char</type>
+    <category>seq_flds</category>
+    <group>seq_cplflds_inparm</group>
+    <desc>One- or Two-way coupling between Wave and Ocn.</desc>
+    <values>
+      <value>none</value>
+      <value WAV_OCN_COUP="oneway">oneway</value>
+      <value WAV_OCN_COUP="twoway">twoway</value>
     </values>
   </entry>
 

--- a/driver-moab/main/cime_comp_mod.F90
+++ b/driver-moab/main/cime_comp_mod.F90
@@ -452,6 +452,8 @@ module cime_comp_mod
   logical  :: lnd_c2_glc             ! .true.  => lnd to glc coupling on
   logical  :: ocn_c2_atm             ! .true.  => ocn to atm coupling on
   logical  :: ocn_c2_ice             ! .true.  => ocn to ice coupling on
+  logical  :: ocn_c2_glctf           ! .true.  => ocn to glc thermal forcing coupling on
+  integer  :: glc_nzoc               ! number of z-levels for ocn/glc TF coupling
   logical  :: ocn_c2_glcshelf        ! .true.  => ocn to glc ice shelf coupling on
   logical  :: ocn_c2_wav             ! .true.  => ocn to wav coupling on
   logical  :: ocn_c2_rof             ! .true.  => ocn to rof coupling on
@@ -569,7 +571,7 @@ module cime_comp_mod
        'Sa_u:Sa_v'
 
   character(CL) :: hist_a2x3hr_flds  = &
-       'Sa_z:Sa_u:Sa_v:Sa_tbot:Sa_ptem:Sa_shum:Sa_dens:Sa_pbot:Sa_pslv:Faxa_lwdn:&
+       'Sa_z:Sa_topo:Sa_u:Sa_v:Sa_tbot:Sa_ptem:Sa_shum:Sa_dens:Sa_pbot:Sa_pslv:Faxa_lwdn:&
        &Faxa_rainc:Faxa_rainl:Faxa_snowc:Faxa_snowl:&
        &Faxa_swndr:Faxa_swvdr:Faxa_swndf:Faxa_swvdf:&
        &Sa_co2diag:Sa_co2prog'
@@ -1705,6 +1707,8 @@ contains
          ocn_prognostic=ocn_prognostic,         &
          ocnrof_prognostic=ocnrof_prognostic,   &
          ocn_c2_glcshelf=ocn_c2_glcshelf,       &
+	 ocn_c2_glctf=ocn_c2_glctf,             &
+	 glc_nzoc=glc_nzoc,                     &
          glc_prognostic=glc_prognostic,         &
          rof_prognostic=rof_prognostic,         &
          rofocn_prognostic=rofocn_prognostic,   &
@@ -1801,6 +1805,7 @@ contains
        if (atm_prognostic) ocn_c2_atm = .true.
        if (atm_present   ) ocn_c2_atm = .true. ! needed for aoflux calc if aoflux=atm
        if (ice_prognostic) ocn_c2_ice = .true.
+       if (glc_prognostic .and. (glc_nzoc > 0)) ocn_c2_glctf = .true.
        if (wav_prognostic) ocn_c2_wav = .true.
        if (rofocn_prognostic) ocn_c2_rof = .true.
 

--- a/driver-moab/main/cime_comp_mod.F90
+++ b/driver-moab/main/cime_comp_mod.F90
@@ -2544,7 +2544,7 @@ contains
           call shr_sys_flush(logunit)
        end if
        call t_startf('CPL:seq_rest_read-moab')
-       call seq_rest_mb_read(rest_file, infodata, samegrid_al)
+       call seq_rest_mb_read(rest_file, infodata, samegrid_al, samegrid_lr)
        call t_stopf('CPL:seq_rest_read-moab')
 #ifdef MOABDEBUG
        call write_moab_state(.false.)
@@ -3534,7 +3534,7 @@ contains
                call shr_sys_flush(logunit)
              end if
              call t_startf('CPL:seq_rest_read-moab')
-             call seq_rest_mb_read(drv_resume_file, infodata, samegrid_al)
+             call seq_rest_mb_read(drv_resume_file, infodata, samegrid_al, samegrid_lr)
              call t_stopf('CPL:seq_rest_read-moab')
           end if
           ! Clear the resume file so we don't try to read it again
@@ -5393,7 +5393,7 @@ contains
           call t_startf('CPL:seq_rest_mb_write')
           call seq_rest_mb_write(EClock_d, seq_SyncClock, infodata,       &
                atm, lnd, ice, ocn, rof, glc, wav, esp, iac,            &
-               trim(cpl_inst_tag), samegrid_al, drv_moab_resume_file)
+               trim(cpl_inst_tag), samegrid_al, samegrid_lr, drv_moab_resume_file)
           call t_stopf('CPL:seq_rest_mb_write')
 
           if (iamroot_CPLID) then

--- a/driver-moab/main/component_mod.F90
+++ b/driver-moab/main/component_mod.F90
@@ -470,6 +470,7 @@ contains
     use iso_c_binding
     !   character(1024)         :: domain_file        ! file containing domain info (set my input)
     use seq_comm_mct,     only: mboxid ! iMOAB id for MPAS ocean migrated mesh to coupler pes
+    use seq_comm_mct,     only: mblxid ! iMOAB id for lnd migrated mesh to coupler pes
     use seq_comm_mct,     only: mbaxid ! iMOAB id for atm migrated mesh to coupler pes
     use seq_comm_mct,     only: mbrxid ! iMOAB id for rof migrated mesh to coupler pes
 #endif
@@ -551,18 +552,6 @@ contains
          ! project now aream on ocean (from atm)
 #endif
          call seq_map_map(mapper_Fa2o, av_s=dom_s%data, av_d=dom_d%data, fldlist='aream')
-
-#ifdef HAVE_MOAB
-#ifdef MOABDEBUG
-         ierr = iMOAB_WriteMesh(mboxid, trim('recMeshOcnWithArea.h5m'//C_NULL_CHAR), &
-                                 trim(';PARALLEL=WRITE_PART'//C_NULL_CHAR))
-         if (ierr .ne. 0) then
-            write(logunit,*) subname,' error in writing ocean mesh coupler '
-            call shr_sys_abort(subname//' ERROR in writing ocean mesh coupler ')
-         endif
-#endif
-#endif
-
           
        else
           gsmap_s => component_get_gsmap_cx(ocn(1)) ! gsmap_ox
@@ -644,6 +633,40 @@ contains
 
        endif
     endif
+#ifdef MOABDEBUG
+     if(mbaxid >=0 ) then
+         ierr = iMOAB_WriteMesh(mbaxid, trim('cplAtmWithAream.h5m'//C_NULL_CHAR), &
+                                 trim(';PARALLEL=WRITE_PART'//C_NULL_CHAR))
+         if (ierr .ne. 0) then
+            write(logunit,*) subname,' error in writing atm mesh coupler '
+            call shr_sys_abort(subname//' ERROR in writing atm mesh coupler ')
+         endif
+     endif
+     if(mblxid >=0 ) then
+         ierr = iMOAB_WriteMesh(mblxid, trim('cplLndWithAream.h5m'//C_NULL_CHAR), &
+                                 trim(';PARALLEL=WRITE_PART'//C_NULL_CHAR))
+         if (ierr .ne. 0) then
+            write(logunit,*) subname,' error in writing lnd mesh coupler '
+            call shr_sys_abort(subname//' ERROR in writing lnd mesh coupler ')
+         endif
+     endif
+     if(mboxid >=0 ) then
+         ierr = iMOAB_WriteMesh(mboxid, trim('cplOcnWithAream.h5m'//C_NULL_CHAR), &
+                                 trim(';PARALLEL=WRITE_PART'//C_NULL_CHAR))
+         if (ierr .ne. 0) then
+            write(logunit,*) subname,' error in writing ocn mesh coupler '
+            call shr_sys_abort(subname//' ERROR in writing ocn mesh coupler ')
+         endif
+     endif
+     if(mbrxid >=0 ) then
+         ierr = iMOAB_WriteMesh(mbrxid, trim('cplRofWithAream.h5m'//C_NULL_CHAR), &
+                                 trim(';PARALLEL=WRITE_PART'//C_NULL_CHAR))
+         if (ierr .ne. 0) then
+            write(logunit,*) subname,' error in writing rof mesh coupler '
+            call shr_sys_abort(subname//' ERROR in writing rof mesh coupler ')
+         endif
+     endif
+#endif
 
   end subroutine component_init_aream
 
@@ -734,11 +757,15 @@ subroutine component_init_areacor_moab (comp, mbccid, mbcxid, seq_flds_c2x_fluxe
    integer :: mpi_tag
    character(*), parameter :: subname = '(component_init_areacor_moab)'
    character(CXX)          :: tagname
+   character(CXX)   :: comment
    integer                 :: tagtype, numco,  tagindex, lsize, i, j, arrsize, ierr, nfields
    real (kind=r8) , allocatable :: areas (:,:), factors(:,:), vals(:,:) ! 2 tags values, area, aream,
-   real (kind=r8)  :: rarea, raream, rmask, fact
+   real (kind=r8)  :: rarea, raream, rmask, fact, rmin1, rmax1, rmin, rmax
    integer     nvert(3), nvise(3), nbl(3), nsurf(3), nvisBC(3)
    type(mct_list) :: temp_list  ! used to count number of fields
+   integer :: mpicom
+   logical :: iamroot
+   character(len=*),parameter :: F0R = "(2A,2g23.15,A )"
    !---------------------------------------------------------------
 
    if (comp(1)%iamin_cplcompid) then
@@ -794,6 +821,23 @@ subroutine component_init_areacor_moab (comp, mbccid, mbcxid, seq_flds_c2x_fluxe
          if (ierr .ne. 0) then
            call shr_sys_abort(subname//' cannot set correction area factors  ')
          endif
+
+! print the computed values for area factors
+         rmin1 = minval(factors(:,1))
+         rmax1 = maxval(factors(:,1))
+         mpicom = comp(1)%mpicom_compid
+         iamroot= comp(1)%iamroot_compid
+         call shr_mpi_min(rmin1,rmin,mpicom)
+         call shr_mpi_max(rmax1,rmax,mpicom)
+         comment = 'areafact_'//trim(comp(1)%name)
+         if (iamroot) write(logunit,F0R) trim(subname),' : min/max mdl2drv ',rmin,rmax,trim(comment)
+
+         rmin1 = minval(factors(:,2))
+         rmax1 = maxval(factors(:,2))
+         call shr_mpi_min(rmin1,rmin,mpicom)
+         call shr_mpi_max(rmax1,rmax,mpicom)
+         if (iamroot) write(logunit,F0R) trim(subname),' : min/max drv2mdl ',rmin,rmax,trim(comment)
+         if (iamroot) call shr_sys_flush(logunit)
 
           ! Area correct component initialization output fields
           ! need to multiply fluxes (correct them) with mdl2drv (factors(i,1))

--- a/driver-moab/main/component_mod.F90
+++ b/driver-moab/main/component_mod.F90
@@ -745,7 +745,7 @@ subroutine component_init_areacor_moab (comp, mbccid, mbcxid, seq_flds_c2x_fluxe
       tagname='aream'//C_NULL_CHAR
       ! bring on the comp side the aream from maps
       ! (it is either computed by mapping routine or read from mapping files)
-      call component_exch_moab(comp(1), mbcxid, mbccid, 1, tagname)
+      call component_exch_moab(comp(1), mbcxid, mbccid, 1, tagname, context_exch='aream')
 
       ! For only component pes
       if (comp(1)%iamin_compid) then
@@ -836,7 +836,7 @@ subroutine component_init_areacor_moab (comp, mbccid, mbcxid, seq_flds_c2x_fluxe
 
       endif
        ! send data to coupler exchange ? everything, not only fluxes ?
-      call component_exch_moab(comp(1), mbccid, mbcxid, 0, seq_flds_c2x_fields)
+      call component_exch_moab(comp(1), mbccid, mbcxid, 0, seq_flds_c2x_fields, context_exch='areacor')
    endif
 
   end subroutine component_init_areacor_moab

--- a/driver-moab/main/component_type_mod.F90
+++ b/driver-moab/main/component_type_mod.F90
@@ -421,6 +421,7 @@ contains
     
     use shr_mpi_mod,       only: shr_mpi_sum
     use shr_kind_mod,     only:  CXX => shr_kind_CXX
+    use shr_kind_mod    , only:  IN=>SHR_KIND_IN
     use seq_comm_mct , only : CPLID, seq_comm_iamroot
     use seq_comm_mct, only:   seq_comm_setptrs
     use iMOAB, only : iMOAB_DefineTagStorage,  iMOAB_GetDoubleTagStorage, &
@@ -431,20 +432,22 @@ contains
     type(component_type), intent(in) :: comp
     integer , intent(in) :: appId, ent_type
     type(mct_aVect) , intent(in), pointer       :: attrVect
+    type(mct_gsmap), pointer    :: gsmap
     character(*) , intent(in)       :: mct_field
     character(*) , intent(in)       :: tagname
+    integer(IN), pointer :: dof(:) 
 
     real(r8)      , intent(out)     :: difference
     logical , intent(in)            :: first_time
 
     real(r8)  :: differenceg ! global, reduced diff
-    type(mct_ggrid), pointer    :: dom
-    integer   :: kgg, mbSize, nloc, index_avfield
+    !type(mct_ggrid), pointer    :: dom
+    integer   :: kgg, mbSize, nloc, index_avfield, my_task
 
      ! moab
      integer                  :: tagtype, numco,  tagindex, ierr
      character(CXX)           :: tagname_mct
-     integer ,    allocatable :: GlobalIds(:) ! used for setting values associated with ids
+     !integer ,    allocatable :: GlobalIds(:) ! used for setting values associated with ids
      
      real(r8) , allocatable :: values(:), mct_values(:)
      integer nvert(3), nvise(3), nbl(3), nsurf(3), nvisBC(3)
@@ -457,11 +460,15 @@ contains
      call seq_comm_setptrs(CPLID, mpicom=mpicom)
 
      nloc = mct_avect_lsize(attrVect)
-     allocate(GlobalIds(nloc))
+     !allocate(GlobalIds(nloc))
      allocate(values(nloc))
-     dom => component_get_dom_cx(comp)
-     kgg = mct_aVect_indexIA(dom%data ,"GlobGridNum" ,perrWith=subName)
-     GlobalIds = dom%data%iAttr(kgg,:)
+     !dom => component_get_dom_cx(comp)
+     !kgg = mct_aVect_indexIA(dom%data ,"GlobGridNum" ,perrWith=subName)
+     !GlobalIds = dom%data%iAttr(kgg,:)
+     gsmap  => component_get_gsmap_cx(comp) ! gsmap_x
+     call mpi_comm_rank(mpicom,my_task,ierr)
+         ! Determine global gridpoint number attribute, GlobGridNum, automatically in ggrid
+     call mct_gsMap_orderedPoints(gsmap, my_task, dof)
 
      index_avfield     = mct_aVect_indexRA(attrVect,trim(mct_field))
      values(:) = attrVect%rAttr(index_avfield,:) 
@@ -476,7 +483,7 @@ contains
         if (ierr > 0 )  &
             call shr_sys_abort(subname//'Error: fail to define new tag for mct')
      endif 
-     ierr = iMOAB_SetDoubleTagStorageWithGid ( appId, tagname_mct, nloc , ent_type, values, GlobalIds )
+     ierr = iMOAB_SetDoubleTagStorageWithGid ( appId, tagname_mct, nloc , ent_type, values, dof )
      if (ierr > 0 )  &
         call shr_sys_abort(subname//'Error: fail to set new tags')
 
@@ -511,7 +518,8 @@ contains
         print * , subname, trim(comp%ntype), ' on cpl, difference on tag ', trim(tagname), ' = ', difference
         !call shr_sys_abort(subname//'differences between mct and moab values')
      endif
-     deallocate(GlobalIds)
+     !deallocate(GlobalIds)
+     deallocate (dof) 
      deallocate(values)
      deallocate(mct_values)
 

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -1479,6 +1479,7 @@ subroutine  copy_aream_from_area(mbappid)
          endif
          ! end copy 
 #ifdef MOABDEBUG
+      if (mbofxid >= 0) then
          outfile = 'recMeshOcnF.h5m'//C_NULL_CHAR
          wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
       !  write out the mesh file to disk
@@ -1487,6 +1488,7 @@ subroutine  copy_aream_from_area(mbappid)
              write(logunit,*) subname,' error in writing ocean mesh coupler '
              call shr_sys_abort(subname//' ERROR in writing ocean mesh coupler ')
          endif
+      endif
 #endif
       endif  ! end ocean
 
@@ -1826,13 +1828,15 @@ subroutine  copy_aream_from_area(mbappid)
          ! initialize aream from area; it may have different values in the end, or reset again
          call copy_aream_from_area(mbrxid)
 #ifdef MOABDEBUG
-         outfile = 'recMeshRof.h5m'//C_NULL_CHAR
-         wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
-  !      write out the mesh file to disk
-         ierr = iMOAB_WriteMesh(mbrxid, trim(outfile), trim(wopts))
-         if (ierr .ne. 0) then
-            write(logunit,*) subname,' error in writing rof mesh on coupler '
-            call shr_sys_abort(subname//' ERROR in writing rof mesh on coupler ')
+         if (mbrxid >= 0) then
+            outfile = 'recMeshRof.h5m'//C_NULL_CHAR
+            wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
+  !         write out the mesh file to disk
+            ierr = iMOAB_WriteMesh(mbrxid, trim(outfile), trim(wopts))
+            if (ierr .ne. 0) then
+              write(logunit,*) subname,' error in writing rof mesh on coupler '
+               call shr_sys_abort(subname//' ERROR in writing rof mesh on coupler ')
+            endif
          endif
 #endif
       endif ! end for rof coupler set up 

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -1204,7 +1204,7 @@ contains
             ! this is hard to digest :(
             tagname = 'lat:lon:area:frac:mask'//C_NULL_CHAR
             call component_exch_moab(comp, mphaid, mbaxid, 0, tagname, context_exch='dom')
-
+           
          endif ! coupler pes
 
 #ifdef MOABDEBUG

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -1928,12 +1928,13 @@ subroutine  copy_aream_from_area(mbappid)
     else
        dir = 'x2c'
     endif
+    write(lnum,"(I0.2)") num_moab_exports
     if (seq_comm_iamroot(CPLID) ) then
-       write(logunit,'(A)') subname//' '//comp%ntype//' called in direction '//trim(dir)//' for fields '//trim(tagname)
+       write(logunit,'(A)') subname//' '//comp%ntype//' at moab count '//lnum//' called in direction '//trim(dir)//' for fields '//trim(tagname)
     endif
     if (mbAPPid2 .ge. 0 ) then !  we are on receiving pes, for sure
       ! number_proj = number_proj+1 ! count the number of projections
-      write(lnum,"(I0.2)") num_moab_exports
+      
       if (present(context_exch)) then
          outfile = comp%ntype//'_'//trim(context_exch)//'_'//trim(dir)//'_'//trim(lnum)//'.h5m'//C_NULL_CHAR
       else

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -60,6 +60,7 @@ module cplcomp_exchange_mod
   private :: seq_mctext_gsmapCreate
   private :: seq_mctext_avCreate
 
+  private :: copy_aream_from_area
   !--------------------------------------------------------------------------
   ! Public data
   !--------------------------------------------------------------------------
@@ -981,7 +982,34 @@ contains
 
   end function seq_mctext_gsmapIdentical
 
+subroutine  copy_aream_from_area(mbappid)
+
+      ! maybe we will move this from here
+      use iMOAB, only: iMOAB_GetDoubleTagStorage, iMOAB_SetDoubleTagStorage, iMOAB_GetMeshInfo
+
+      integer ,  intent(in) :: mbappid
+      character(CXX)           :: tagname
+      integer                  nvert(3), nvise(3), nbl(3), nsurf(3), nvisBC(3)
+      real(r8),    allocatable    :: tagValues(:) ! used for setting aream tags for atm domain read case
+      integer                     :: arrSize ! for the size of tagValues
+      integer :: ierr, ent_type
+
+      ! copy aream from area
+      if (mbappid >= 0) then  ! coupler atm procs
+         ierr  = iMOAB_GetMeshInfo ( mbappid, nvert, nvise, nbl, nsurf, nvisBC )
+         arrSize  = nvise(1) ! cells
+         allocate(tagValues(arrSize))
+         tagname = 'area'//C_NULL_CHAR
+         ent_type = 1 ! cells
+         ierr  = iMOAB_GetDoubleTagStorage( mbappid, tagname, arrsize , ent_type, tagValues )
+         tagname = 'aream'//C_NULL_CHAR
+         ierr  = iMOAB_SetDoubleTagStorage( mbappid, tagname, arrsize , ent_type, tagValues )
+         deallocate(tagValues)
+      endif
+
+      return
   !=======================================================================
+ end subroutine copy_aream_from_area
 
    subroutine cplcomp_moab_Init(infodata,comp)
 
@@ -1029,6 +1057,8 @@ contains
                                                             ! and atm spectral on coupler
       character(CXX)           :: tagname
       integer                  nvert(3), nvise(3), nbl(3), nsurf(3), nvisBC(3)
+      real(r8),    allocatable    :: tagValues(:) ! used for setting aream tags for atm domain read case
+      integer                     :: arrSize ! for the size of tagValues
       ! type(mct_list)           :: temp_list
       ! integer                  :: nfields, arrsize
       ! real(R8), allocatable, target :: values(:)
@@ -1204,7 +1234,8 @@ contains
             ! this is hard to digest :(
             tagname = 'lat:lon:area:frac:mask'//C_NULL_CHAR
             call component_exch_moab(comp, mphaid, mbaxid, 0, tagname, context_exch='dom')
-           
+            ! copy aream from area in case atm_mesh
+            call copy_aream_from_area(mbaxid)
          endif ! coupler pes
 
 #ifdef MOABDEBUG
@@ -1786,15 +1817,9 @@ contains
 
          tagname = 'area:lon:lat:frac:mask'//C_NULL_CHAR
          call component_exch_moab(comp, mrofid, mbrxid, 0, tagname)
-
-         ! if (mrofid .ge. 0) then  ! we are on component rof  pes
-         !    context_id = id_join
-         !    ierr = iMOAB_FreeSenderBuffers(mrofid, context_id)
-         !    if (ierr .ne. 0) then
-         !    write(logunit,*) subname,' error in freeing buffers '
-         !    call shr_sys_abort(subname//' ERROR in freeing buffers ')
-         !    endif
-         ! endif
+         ! copy aream from area in all cases
+         ! initialize aream from area; it may have different values in the end, or reset again
+         call copy_aream_from_area(mbrxid)
 #ifdef MOABDEBUG
          outfile = 'recMeshRof.h5m'//C_NULL_CHAR
          wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
@@ -1910,7 +1935,7 @@ contains
       ! number_proj = number_proj+1 ! count the number of projections
       write(lnum,"(I0.2)") num_moab_exports
       if (present(context_exch)) then
-         outfile = comp%ntype//trim(context_exch)//'_'//trim(dir)//'_'//trim(lnum)//'.h5m'//C_NULL_CHAR
+         outfile = comp%ntype//'_'//trim(context_exch)//'_'//trim(dir)//'_'//trim(lnum)//'.h5m'//C_NULL_CHAR
       else
          outfile = comp%ntype//'_'//trim(dir)//'_'//trim(lnum)//'.h5m'//C_NULL_CHAR
       endif

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -1912,7 +1912,7 @@ contains
       if (present(context_exch)) then
          outfile = comp%ntype//trim(context_exch)//'_'//trim(dir)//'_'//trim(lnum)//'.h5m'//C_NULL_CHAR
       else
-         outfile = comp%ntype//trim(dir)//'_'//trim(lnum)//'.h5m'//C_NULL_CHAR
+         outfile = comp%ntype//'_'//trim(dir)//'_'//trim(lnum)//'.h5m'//C_NULL_CHAR
       endif
       wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR !
       ierr = iMOAB_WriteMesh(mbAPPid2, trim(outfile), trim(wopts))

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -1044,7 +1044,7 @@ subroutine  copy_aream_from_area(mbappid)
       integer                  :: mpigrp_cplid ! coupler pes
       integer                  :: mpigrp_old   !  component group pes
       integer                  :: ierr, context_id
-      character*200            :: appname, outfile, wopts, ropts
+      character*200            :: appname, outfile, wopts, ropts, infile
       character(CL)            :: rtm_mesh, rof_domain
       character(CL)            :: lnd_domain
       character(CL)            :: ocn_domain
@@ -1143,14 +1143,16 @@ subroutine  copy_aream_from_area(mbappid)
                endif
             else   ! data atm
               ! we need to read the atm mesh on coupler, from domain file 
-               ierr = iMOAB_LoadMesh(mbaxid, trim(atm_mesh)//C_NULL_CHAR, &
-                "PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION;NO_CULLING", 0)
+               infile = trim(atm_mesh)//C_NULL_CHAR
+               ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION;NO_CULLING'//C_NULL_CHAR
+               if (seq_comm_iamroot(CPLID)) then
+                  write(logunit,'(A)') subname//' loading atm domain mesh from file '//trim(atm_mesh) &
+                   , ' with options ' // trim(ropts)
+               endif
+               ierr = iMOAB_LoadMesh(mbaxid, infile, ropts, 0)
                if ( ierr /= 0 ) then
                   write(logunit,*) 'Failed to load atm domain mesh on coupler'
                   call shr_sys_abort(subname//' ERROR Failed to load atm domain mesh on coupler  ')
-               endif
-               if (seq_comm_iamroot(CPLID)) then
-                  write(logunit,'(A)') subname//' load atm domain mesh from file '//trim(atm_mesh)
                endif
                ! right now, turn atm_pg_active to true
                atm_pg_active = .true. ! FIXME TODO 
@@ -1316,11 +1318,13 @@ subroutine  copy_aream_from_area(mbappid)
                endif
             else
               ! we need to read the ocean mesh on coupler, from domain file 
+               infile = trim(ocn_domain)//C_NULL_CHAR
+               ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION'//C_NULL_CHAR
                if (seq_comm_iamroot(CPLID)) then
-                  write(logunit,'(A)') subname//' loading ocn domain mesh from file '//trim(ocn_domain)
+                  write(logunit,'(A)') subname//' loading ocn domain mesh from file '//trim(infile) &
+                   , ' with options ' // trim(ropts)
                endif
-               ierr = iMOAB_LoadMesh(mboxid, trim(ocn_domain)//C_NULL_CHAR, &
-                "PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION", 0)
+               ierr = iMOAB_LoadMesh(mboxid, infile, ropts, 0)
                if ( ierr /= 0 ) then
                   write(logunit,*) 'Failed to load ocean domain mesh on coupler'
                   call shr_sys_abort(subname//' ERROR Failed to load ocean domain mesh on coupler  ')
@@ -1430,14 +1434,16 @@ subroutine  copy_aream_from_area(mbappid)
                endif
             else
                 ! we need to read the ocean mesh on coupler, from domain file 
-               ierr = iMOAB_LoadMesh(mbofxid, trim(ocn_domain)//C_NULL_CHAR, &
-                "PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION", 0)
+               infile = trim(ocn_domain)//C_NULL_CHAR
+               ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION'//C_NULL_CHAR
+               if (seq_comm_iamroot(CPLID)) then
+                  write(logunit,'(A)') subname//' load ocn domain mesh from file for second ocn instance '//trim(ocn_domain) &
+                  , ' with options '//trim(ropts)
+               endif
+               ierr = iMOAB_LoadMesh(mbofxid, infile, ropts, 0)
                if ( ierr /= 0 ) then
                   write(logunit,*) 'Failed to load second ocean domain mesh on coupler'
                   call shr_sys_abort(subname//' ERROR Failed to load second ocean domain mesh on coupler  ')
-               endif
-               if (seq_comm_iamroot(CPLID)) then
-                  write(logunit,'(A)') subname//' load ocn domain mesh from file for second ocn instance '//trim(ocn_domain)
                endif
                ! need to add global id tag to the app, it will be used in restart
                tagtype = 0  ! dense, integer
@@ -1507,16 +1513,13 @@ subroutine  copy_aream_from_area(mbappid)
             outfile = trim(lnd_domain)//C_NULL_CHAR
             nghlay = 0 ! no ghost layers 
             if (seq_comm_iamroot(CPLID) ) then
-               write(logunit, *) "load land domain file from file: ", trim(lnd_domain), &
+               write(logunit, *) "loading land domain file from file: ", trim(lnd_domain), &
                  " with options: ", trim(ropts)
             endif
             ierr = iMOAB_LoadMesh(mblxid, outfile, ropts, nghlay)
             if (ierr .ne. 0) then
                write(logunit,*) subname,' error in reading land coupler mesh from ', trim(lnd_domain)
                call shr_sys_abort(subname//' ERROR in reading land coupler mesh')
-            endif
-            if (seq_comm_iamroot(CPLID)) then
-               write(logunit,'(A)') subname//' load lnd domain mesh from file '//trim(lnd_domain)
             endif
             ! need to add global id tag to the app, it will be used in restart
             tagtype = 0  ! dense, integer
@@ -1635,14 +1638,16 @@ subroutine  copy_aream_from_area(mbappid)
                endif
             else
                ! we need to read the mesh ice (domain file) 
-               ierr = iMOAB_LoadMesh(mbixid, trim(ice_domain)//C_NULL_CHAR, &
-                "PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION", 0)
+               ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION'//C_NULL_CHAR
+               infile = trim(ice_domain)//C_NULL_CHAR
+               if (seq_comm_iamroot(CPLID)) then
+                  write(logunit,'(A)') subname//' loading ice domain mesh from file '//infile &
+                    , ' with options '//trim(ropts)
+               endif
+               ierr = iMOAB_LoadMesh(mbixid, infile, ropts, 0)
                if ( ierr /= 0 ) then
                   write(logunit,*) 'Failed to load ice domain mesh on coupler'
                   call shr_sys_abort(subname//' ERROR Failed to load ice domain mesh on coupler  ')
-               endif
-               if (seq_comm_iamroot(CPLID)) then
-                  write(logunit,'(A)') subname//' load ice domain mesh from file '//trim(ice_domain)
                endif
                ! need to add global id tag to the app, it will be used in restart
                tagtype = 0  ! dense, integer
@@ -1747,7 +1752,7 @@ subroutine  copy_aream_from_area(mbappid)
             appname = "COUPLE_MROF"//C_NULL_CHAR
             ierr = iMOAB_RegisterApplication(trim(appname), mpicom_new, id_join, mbrxid)
 
-            ! load mesh from scrip file passed from river model
+            ! load mesh from scrip file passed from river model, if domain file is not available
             call seq_infodata_GetData(infodata,rof_mesh=rtm_mesh,rof_domain=rof_domain)
             if ( trim(rof_domain) == 'none' ) then
                outfile = trim(rtm_mesh)//C_NULL_CHAR
@@ -1757,14 +1762,14 @@ subroutine  copy_aream_from_area(mbappid)
                ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION'//C_NULL_CHAR
             endif
             nghlay = 0 ! no ghost layers 
-            ierr = iMOAB_LoadMesh(mbrxid, outfile, ropts, nghlay)
             if (seq_comm_iamroot(CPLID)) then
-               write(logunit,'(A)') subname//' load rof from file '//trim(outfile)
+               write(logunit,'(A)') subname//' loading rof from file '//trim(outfile) &
+                  , ' with options ', trim(ropts)
             endif
+            ierr = iMOAB_LoadMesh(mbrxid, outfile, ropts, nghlay)
             if ( ierr .ne. 0  ) then
                call shr_sys_abort( subname//' ERROR: cannot read rof mesh on coupler' )
             end if
-            
              ! need to add global id tag to the app, it will be used in restart
             tagtype = 0  ! dense, integer
             numco = 1
@@ -1930,7 +1935,7 @@ subroutine  copy_aream_from_area(mbappid)
     endif
     write(lnum,"(I0.2)") num_moab_exports
     if (seq_comm_iamroot(CPLID) ) then
-       write(logunit,'(A)') subname//' '//comp%ntype//' at moab count '//lnum//' called in direction '//trim(dir)//' for fields '//trim(tagname)
+       write(logunit,'(A)') subname//' '//comp%ntype//' at moab count '//trim(lnum)//' called in direction '//trim(dir)//' for fields '//trim(tagname)
     endif
     if (mbAPPid2 .ge. 0 ) then !  we are on receiving pes, for sure
       ! number_proj = number_proj+1 ! count the number of projections

--- a/driver-moab/main/prep_lnd_mod.F90
+++ b/driver-moab/main/prep_lnd_mod.F90
@@ -36,8 +36,8 @@ module prep_lnd_mod
 #ifdef  HAVE_MOAB
   use iMOAB , only: iMOAB_ComputeCommGraph, iMOAB_ComputeMeshIntersectionOnSphere, &
     iMOAB_ComputeScalarProjectionWeights, iMOAB_DefineTagStorage, iMOAB_RegisterApplication, &
-    iMOAB_WriteMesh, iMOAB_GetMeshInfo, iMOAB_SetDoubleTagStorage, iMOAB_ComputeCoverageMesh, &
-    iMOAB_SetMapGhostLayers
+    iMOAB_WriteMesh, iMOAB_GetMeshInfo, iMOAB_SetDoubleTagStorage, &
+    iMOAB_SetMapGhostLayers, iMOAB_MigrateMapMesh
   use seq_comm_mct,     only : num_moab_exports
 #endif
 
@@ -254,12 +254,12 @@ contains
               write(logunit,*) subname,' error in registering  rof lnd intx'
               call shr_sys_abort(subname//' ERROR in registering rof lnd intx')
             endif
+            call seq_comm_getData(CPLID ,mpigrp=mpigrp_CPLID)
             if (samegrid_lr) then
                ! the same mesh , lnd and rof use the same dofs, but restricted
                ! we do not compute intersection, so we will have to just send data from lnd to rof and viceversa, by GLOBAL_ID matching
                ! so we compute just a comm graph, between lnd and rof dofs, on the coupler; target is rof
                ! land is full mesh
-               call seq_comm_getData(CPLID ,mpigrp=mpigrp_CPLID)
                type1 = 3; !  full mesh for lrofarnd now
                type2 = 3;  ! fv for target land
                ierr = iMOAB_ComputeCommGraph( mbrxid, mblxid, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type1, type2, &
@@ -281,15 +281,6 @@ contains
                mapper_Fr2l%src_context = rof(1)%cplcompid
                mapper_Fr2l%intx_context = lnd(1)%cplcompid
             else
-
-               ! compute the ROF coverage mesh here on coupler pes
-               ! ROF mesh was redistributed to cover target (LND) partition
-               ierr = iMOAB_ComputeCoverageMesh( mbrxid, mblxid, mbintxrl )
-               if (ierr .ne. 0) then
-                  write(logunit,*) subname,' cannot compute source ROF coverage mesh for LND'
-                  call shr_sys_abort(subname//' ERROR in computing ROF-LND coverage')
-               endif
-
               if (compute_maps_online_r2l) then
                   ierr =  iMOAB_ComputeMeshIntersectionOnSphere( mbrxid, mblxid, mbintxrl )
                   if (ierr .ne. 0) then
@@ -300,30 +291,29 @@ contains
                     write(logunit,*) 'iMOAB intersection between  rof and lnd with id:', idintx
                   end if
 #ifdef MOABDEBUG
-              wopts = C_NULL_CHAR
-              call shr_mpi_commrank( mpicom_CPLID, rank )
-              if (rank .lt. 5) then
-                write(lnum,"(I0.2)")rank !
-                outfile = 'intx_rl_'//trim(lnum)// '.h5m' // C_NULL_CHAR
-                ierr = iMOAB_WriteMesh(mbintxrl, outfile, wopts) ! write local intx file
-                if (ierr .ne. 0) then
-                  write(logunit,*) subname,' error in writing intx rl file '
-                  call shr_sys_abort(subname//' ERROR in writing intx rl file ')
-                endif
-              endif
+                  wopts = C_NULL_CHAR
+                  call shr_mpi_commrank( mpicom_CPLID, rank )
+                  if (rank .lt. 5) then
+                    write(lnum,"(I0.2)")rank !
+                    outfile = 'intx_rl_'//trim(lnum)// '.h5m' // C_NULL_CHAR
+                    ierr = iMOAB_WriteMesh(mbintxrl, outfile, wopts) ! write local intx file
+                    if (ierr .ne. 0) then
+                      write(logunit,*) subname,' error in writing intx rl file '
+                      call shr_sys_abort(subname//' ERROR in writing intx rl file ')
+                    endif
+                  endif
 #endif
-              endif
+                 ! we also need to compute the comm graph for the second hop, from the rof on coupler to the
+                 ! rof for the intx rof-lnd context (coverage)
 
-              ! we also need to compute the comm graph for the second hop, from the rof on coupler to the
-              ! rof for the intx rof-lnd context (coverage)
-              call seq_comm_getData(CPLID ,mpigrp=mpigrp_CPLID)
-              type1 = 3 ! land is FV now on coupler side
-              type2 = 3;
-              ierr = iMOAB_ComputeCommGraph( mbrxid, mbintxrl, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type1, type2, &
-                                          rof(1)%cplcompid, idintx)
-              if (ierr .ne. 0) then
-                write(logunit,*) subname,' error in computing comm graph for second hop, lnd-rof'
-                call shr_sys_abort(subname//' ERROR in computing comm graph for second hop, lnd-rof')
+                  type1 = 3 ! land is FV now on coupler side
+                  type2 = 3;
+                  ierr = iMOAB_ComputeCommGraph( mbrxid, mbintxrl, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type1, type2, &
+                                              rof(1)%cplcompid, idintx)
+                  if (ierr .ne. 0) then
+                    write(logunit,*) subname,' error in computing comm graph for second hop, lnd-rof'
+                    call shr_sys_abort(subname//' ERROR in computing comm graph for second hop, lnd-rof')
+                  endif
               endif
               ! now take care of the mapper
               if ( mapper_Fr2l%src_mbid .gt. -1 ) then
@@ -375,10 +365,17 @@ contains
                   endif
               else
                   type1 = 3 ! this is type of grid, maybe should be saved on imoab app ?
-
                   call moab_map_init_rcfile( mbrxid, mblxid, mbintxrl, type1, &
                         'seq_maps.rc', 'rof2lnd_fmapname:', 'rof2lnd_fmaptype:',samegrid_lr, &
                         wgtIdr2l, 'mapper_Fr2l MOAB initialization', esmf_map_flag)
+                  ! need to call migrate map mesh, which will compute the cov mesh and
+                  !  comm graph too for coverage mesh
+                  ierr = iMOAB_MigrateMapMesh (mbrxid, mbintxrl, mpicom_CPLID, mpigrp_CPLID, &
+                     mpigrp_CPLID, type1, rof(1)%cplcompid, idintx)
+                  if (ierr .ne. 0) then
+                     write(logunit,*) subname,' error in migrating rof mesh for map rof c2 lnd '
+                     call shr_sys_abort(subname//' ERROR in migrating rof mesh for map rof c2 lnd')
+                  endif
               endif
 
             endif
@@ -471,26 +468,17 @@ contains
             call seq_comm_getinfo(CPLID ,mpigrp=mpigrp_CPLID)
             if (.not. samegrid_al) then ! tri grid case
 
-               ! for bilinear maps, we need to have a layer of ghosts on source
-               nghlay = 1  ! number of ghost layers
-               nghlay_tgt = 0
-               ierr   = iMOAB_SetMapGhostLayers( mbintxal, nghlay, nghlay_tgt )
-               if (ierr .ne. 0) then
-                  write(logunit,*) subname,' error in setting the number of ghost layers'
-                  call shr_sys_abort(subname//' error in setting the number of ghost layers')
-               endif
-
-               ! compute the ATM coverage mesh here on coupler pes
-               ! ATM mesh was redistributed to cover target (LND) partition
-               ierr = iMOAB_ComputeCoverageMesh( mbaxid, mblxid, mbintxal )
-               if (ierr .ne. 0) then
-                  write(logunit,*) subname,' cannot compute source ATM coverage mesh for LND'
-                  call shr_sys_abort(subname//' ERROR in computing ATM-LND coverage')
-               endif
-
               if (compute_maps_online_a2l) then
                 if (iamroot_CPLID) then
                   write(logunit,*) 'iMOAB intersection between atm and land with id:', idintx
+                endif
+                ! for bilinear maps, we need to have a layer of ghosts on source
+                nghlay = 1  ! number of ghost layers
+                nghlay_tgt = 0
+                ierr   = iMOAB_SetMapGhostLayers( mbintxal, nghlay, nghlay_tgt )
+                if (ierr .ne. 0) then
+                  write(logunit,*) subname,' error in setting the number of ghost layers'
+                  call shr_sys_abort(subname//' error in setting the number of ghost layers')
                 endif
                 ierr =  iMOAB_ComputeMeshIntersectionOnSphere( mbaxid, mblxid, mbintxal )
                 if (ierr .ne. 0) then
@@ -511,23 +499,24 @@ contains
                   endif
                 endif
 #endif
-              endif
-              ! we also need to compute the comm graph for the second hop, from the atm on coupler to the
-              ! lnd for the intx atm-lnd context (coverage)
-              !
-              if (atm_pg_active) then
-                type1 = 3; !  fv for atm; cgll does not work anyway
-              else
-                type1 = 1 ! this projection works (cgll to fv), but reverse does not ( fv - cgll)
-              endif
-              type2 = 3; ! land is fv in this case (separate grid)
+                ! we also need to compute the comm graph for the second hop, from the atm on coupler to the
+                ! lnd for the intx atm-lnd context (coverage)
+                !
+                if (atm_pg_active) then
+                  type1 = 3; !  fv for atm; cgll does not work anyway
+                else
+                  type1 = 1 ! this projection works (cgll to fv), but reverse does not ( fv - cgll)
+                endif
+                type2 = 3; ! land is fv in this case (separate grid)
 
-              ierr = iMOAB_ComputeCommGraph( mbaxid, mbintxal, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type1, type2, &
-                                        atm(1)%cplcompid, idintx)
-              if (ierr .ne. 0) then
-                write(logunit,*) subname,' error in computing comm graph for second hop, atm-lnd'
-                call shr_sys_abort(subname//' ERROR in computing comm graph for second hop, atm-lnd')
+                ierr = iMOAB_ComputeCommGraph( mbaxid, mbintxal, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type1, type2, &
+                                          atm(1)%cplcompid, idintx)
+                if (ierr .ne. 0) then
+                  write(logunit,*) subname,' error in computing comm graph for second hop, atm-lnd'
+                  call shr_sys_abort(subname//' ERROR in computing comm graph for second hop, atm-lnd')
+                endif
               endif
+
 
               if (compute_maps_online_a2l) then
                   volumetric = 0 ! can be 1 only for FV->DGLL or FV->CGLL;
@@ -584,11 +573,22 @@ contains
                         'seq_maps.rc', 'atm2lnd_smapname:', 'atm2lnd_smaptype:',samegrid_al, &
                         wgtIda2l_bilinear, 'mapper_Sa2l MOAB initialization', esmf_map_flag)
 
+                  ! TODO make sure it is good enough
+                  ! we are using the same coverage for 2 maps , one bilinear, one conservative
                   ! read as the second one the f map, this one has the aream for land correct, so it should be fine
                   ! the area_b for the bilinear map above is 0 ! which caused grief
                   call moab_map_init_rcfile( mbaxid, mblxid, mbintxal, type1, &
                         'seq_maps.rc', 'atm2lnd_fmapname:', 'atm2lnd_fmaptype:',samegrid_al, &
                         wgtIda2l_conservative, 'mapper_Fa2l MOAB initialization', esmf_map_flag)
+                  ! we need to do only one map migrate, should over both maps!!
+                  ! we have one coverage for both maps!
+                  ierr = iMOAB_MigrateMapMesh (mbaxid, mbintxal, mpicom_CPLID, mpigrp_CPLID, &
+                     mpigrp_CPLID, type1, atm(1)%cplcompid, idintx)
+                  if (ierr .ne. 0) then
+                     write(logunit,*) subname,' error in migrating atm mesh for map atm c2 lnd '
+                     call shr_sys_abort(subname//' ERROR in migrating atm mesh for map rof c2 lnd')
+                  endif
+
               endif
 
             else

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -14,7 +14,7 @@ module prep_ocn_mod
 
   use seq_comm_mct,     only: mboxid ! iMOAB id for mpas ocean migrated mesh to coupler pes
 !   use seq_comm_mct,     only: mbrmapro ! iMOAB id for map read from rof2ocn map file
-!   use seq_comm_mct,     only: mbrxoid ! iMOAB id for rof on coupler in ocean context;
+  use seq_comm_mct,     only: mbrxoid ! iMOAB id for rof on coupler in ocean context;
   use seq_comm_mct,     only: mbrxid   ! iMOAB id of moab rof migrated to couple pes
   use seq_comm_mct,     only: mbintxro ! iMOAB id for map read from rof2ocn map file
   use seq_comm_mct,     only : atm_pg_active  ! whether the atm uses FV mesh or not ; made true if fv_nphys > 0
@@ -752,23 +752,23 @@ contains
           ! this is a special rof mesh redistribution, for the ocean context
           ! it will be used to project from rof to ocean
           ! the mesh will be migrated, to be able to do the second hop
-         !  appname = "ROF_OCOU"//C_NULL_CHAR
-         !  ! rmapid  is a unique external number of MOAB app that identifies runoff on coupler side
-         !  rmapid2 = 100*rof(1)%cplcompid ! this is a special case, because we also have a regular coupler instance mbrxid
-         !  ierr = iMOAB_RegisterApplication(trim(appname), mpicom_CPLID, rmapid2, mbrxoid)
-         !  if (ierr .ne. 0) then
-         !     write(logunit,*) subname,' error in registering rof on coupler in ocean context '
-         !     call shr_sys_abort(subname//' ERROR in registering  rof on coupler in ocean context ')
-         !  endif
+          appname = "ROF_OCOU"//C_NULL_CHAR
+          ! rmapid  is a unique external number of MOAB app that identifies runoff on coupler side
+          rmapid2 = 100*rof(1)%cplcompid ! this is a special case, because we also have a regular coupler instance mbrxid
+          ierr = iMOAB_RegisterApplication(trim(appname), mpicom_CPLID, rmapid2, mbrxoid)
+          if (ierr .ne. 0) then
+             write(logunit,*) subname,' error in registering rof on coupler in ocean context '
+             call shr_sys_abort(subname//' ERROR in registering  rof on coupler in ocean context ')
+          endif
           ! this code was moved from prep_rof_ocn_moab, because we will do everything on coupler side, not
           ! needed to be on joint comm anymore for the second hop
 
           ! need to compute coverage of rof over ocean, and comm graph for sending from rof to rof over ocean
-          ierr = iMOAB_ComputeCoverageMesh( mbrxid, mboxid, mbintxro )
-          if (ierr .ne. 0) then
-              write(logunit,*) subname,' error in compute coverage mesh rof for ocean'
-              call shr_sys_abort(subname//' ERROR in compute coverage mesh rof for ocean ')
-          endif
+         !  ierr = iMOAB_ComputeCoverageMesh( mbrxid, mboxid, mbintxro )
+         !  if (ierr .ne. 0) then
+         !      write(logunit,*) subname,' error in compute coverage mesh rof for ocean'
+         !      call shr_sys_abort(subname//' ERROR in compute coverage mesh rof for ocean ')
+         !  endif
           if (iamroot_CPLID) then
              write(logunit,*) ' '
              write(logunit,F00) 'Initializing MOAB mapper_Rr2o_liq'
@@ -779,12 +779,12 @@ contains
                'seq_maps.rc', 'rof2ocn_liq_rmapname:', 'rof2ocn_liq_rmaptype:',samegrid_ro, &
                wgtIdr2o_conservative, 'mapper_Rr2o_liq moab initialization',esmf_map_flag)
 
-          ierr = iMOAB_ComputeCommGraph( mbrxid, mbintxro, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type_grid, &
-             type_grid, rof(1)%cplcompid, rmapid )
-          if (ierr .ne. 0) then
-              write(logunit,*) subname,' error in compute graph rof - rof cov for ocean'
-              call shr_sys_abort(subname//' ERROR in compute graph rof - rof cov for ocean ')
-         endif
+         !  ierr = iMOAB_ComputeCommGraph( mbrxid, mbintxro, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type_grid, &
+         !     type_grid, rof(1)%cplcompid, rmapid )
+         !  if (ierr .ne. 0) then
+         !      write(logunit,*) subname,' error in compute graph rof - rof cov for ocean'
+         !      call shr_sys_abort(subname//' ERROR in compute graph rof - rof cov for ocean ')
+         ! endif
          !  it read on the coupler side, from file, the scrip mosart, that has a full mesh;
          !  also migrate rof mesh on coupler pes, in ocean context, mbrxoid (this will be like coverage mesh,
          !    it will cover ocean target per process)
@@ -792,26 +792,26 @@ contains
          ! after this, the sending of tags for second hop (ocn context) will use the new par comm graph,
          !  that has more precise info, that got created
 
-         ! type1 = 3 ! fv mesh nowadays
-         ! direction = 1 !
-         ! context_id = ocn(1)%cplcompid
+         type1 = 3 ! fv mesh nowadays
+         direction = 1 !
+         context_id = ocn(1)%cplcompid
          ! this creates a par comm graph between mbrxid and mbrxoid, with ids rof(1)%cplcompid, context ocn(1)%cplcompid
          ! this will be used in send/receive mappers
-         ! ierr = iMOAB_MigrateMapMesh (mbrxid, mbrmapro, mbrxoid, mpicom_CPLID, mpigrp_CPLID, &
-         !    mpigrp_CPLID, type1, rof(1)%cplcompid, context_id, direction)
+         ierr = iMOAB_MigrateMapMesh (mbrxid, mbintxro, mbrxoid, mpicom_CPLID, mpigrp_CPLID, &
+            mpigrp_CPLID, type1, rof(1)%cplcompid, context_id, direction)
 
-         ! if (ierr .ne. 0) then
-         !    write(logunit,*) subname,' error in migrating rof mesh for map rof c2 ocn '
-         !    call shr_sys_abort(subname//' ERROR in migrating rof mesh for map rof c2 ocn ')
-         ! endif
+         if (ierr .ne. 0) then
+            write(logunit,*) subname,' error in migrating rof mesh for map rof c2 ocn '
+            call shr_sys_abort(subname//' ERROR in migrating rof mesh for map rof c2 ocn ')
+         endif
          ! if (iamroot_CPLID)  then
          !    write(logunit,*) subname,' migrated mesh for map rof 2 ocn '
          ! endif
-         if (mbrxid .ge. 0) then ! we are on coupler side pes
+         if (mbrxoid .ge. 0) then ! we are on coupler side pes
             tagname=trim(seq_flds_r2x_fields)//C_NULL_CHAR
             tagtype = 1 ! dense, double
             numco = 1 ! only 1 component DoF per node
-            ierr = iMOAB_DefineTagStorage(mbrxid, tagname, tagtype, numco,  tagindex )
+            ierr = iMOAB_DefineTagStorage(mbrxoid, tagname, tagtype, numco,  tagindex )
             if (ierr .ne. 0) then
                write(logunit,*) subname,' error in defining ' // trim(seq_flds_r2x_fields) // ' tags on coupler side in MOAB'
                call shr_sys_abort(subname//' ERROR in defining MOAB tags ')
@@ -856,11 +856,11 @@ contains
 
          ! now we have to populate the map with the right moab attributes, so that it does the right projection
 #ifdef MOABDEBUG
-         if (mbrxid.ge.0) then  ! we are on coupler PEs
+         if (mbrxoid.ge.0) then  ! we are on coupler PEs
             call mpi_comm_rank(mpicom_CPLID, rank_on_cpl  , ierr)
             if (rank_on_cpl .lt. 4) then
                prefix_output = "rof_cov"//CHAR(0)
-               ierr = iMOAB_WriteLocalMesh(mbrxid, prefix_output)
+               ierr = iMOAB_WriteLocalMesh(mbrxoid, prefix_output)
                if (ierr .ne. 0) then
                   write(logunit,*) subname,' error in writing coverage mesh rof 2 ocn '
                endif

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -2943,7 +2943,14 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
     type(mct_avect), pointer :: r2x_rx
     character(*), parameter  :: subname = '(prep_ocn_calc_r2x_ox)'
     !---------------------------------------------------------------
-
+#ifdef MOABDEBUG
+   if (mboxid .ge. 0 ) then !  we are on coupler pes, for sure
+      write(lnum,"(I0.2)")num_moab_exports
+      outfile = 'OcnCpl_Bef_r2x_ox_'//trim(lnum)//'.h5m'//C_NULL_CHAR
+      wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR
+      ierr = iMOAB_WriteMesh(mboxid, trim(outfile), trim(wopts))
+   endif
+#endif
     call t_drvstartf (trim(timer),barrier=mpicom_CPLID)
     do eri = 1,num_inst_rof
        r2x_rx => component_get_c2x_cx(rof(eri))
@@ -2960,7 +2967,7 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
 #ifdef MOABDEBUG
    if (mboxid .ge. 0 ) then !  we are on coupler pes, for sure
       write(lnum,"(I0.2)")num_moab_exports
-      outfile = 'OcnCpl_r2x_ox'//trim(lnum)//'.h5m'//C_NULL_CHAR
+      outfile = 'OcnCpl_r2x_ox_'//trim(lnum)//'.h5m'//C_NULL_CHAR
       wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR
       ierr = iMOAB_WriteMesh(mboxid, trim(outfile), trim(wopts))
    endif

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -794,7 +794,7 @@ contains
 
          type1 = 3 ! fv mesh nowadays
          direction = 1 !
-         context_id = ocn(1)%cplcompid
+         context_id = rmapid ! ocn(1)%cplcompid
          ! this creates a par comm graph between mbrxid and mbrxoid, with ids rof(1)%cplcompid, context ocn(1)%cplcompid
          ! this will be used in send/receive mappers
          ierr = iMOAB_MigrateMapMesh (mbrxid, mbintxro, mbrxoid, mpicom_CPLID, mpigrp_CPLID, &

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -2957,6 +2957,14 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox)
        endif
     enddo
     call t_drvstopf  (trim(timer))
+#ifdef MOABDEBUG
+   if (mboxid .ge. 0 ) then !  we are on coupler pes, for sure
+      write(lnum,"(I0.2)")num_moab_exports
+      outfile = 'OcnCpl_r2x_ox'//trim(lnum)//'.h5m'//C_NULL_CHAR
+      wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR
+      ierr = iMOAB_WriteMesh(mboxid, trim(outfile), trim(wopts))
+   endif
+#endif
 
   end subroutine prep_ocn_calc_r2x_ox
 

--- a/driver-moab/main/seq_flux_mct.F90
+++ b/driver-moab/main/seq_flux_mct.F90
@@ -191,6 +191,7 @@ module seq_flux_mct
   integer :: index_xao_So_ssq
   integer :: index_xao_So_duu10n
   integer :: index_xao_So_u10
+  integer :: index_xao_So_u10withgusts
   integer :: index_xao_So_fswpen
   integer :: index_xao_So_warm_diurn
   integer :: index_xao_So_salt_diurn
@@ -1510,6 +1511,7 @@ contains
        index_xao_So_re     = mct_aVect_indexRA(xao,'So_re')
        index_xao_So_ssq    = mct_aVect_indexRA(xao,'So_ssq')
        index_xao_So_u10    = mct_aVect_indexRA(xao,'So_u10')
+       index_xao_So_u10withgusts = mct_aVect_indexRA(xao,'So_u10withgusts')
        index_xao_So_duu10n = mct_aVect_indexRA(xao,'So_duu10n')
        index_xao_Faox_taux = mct_aVect_indexRA(xao,'Faox_taux')
        index_xao_Faox_tauy = mct_aVect_indexRA(xao,'Faox_tauy')
@@ -1787,6 +1789,7 @@ contains
           xao%rAttr(index_xao_Faox_lwup,n) = lwup(n)
           xao%rAttr(index_xao_So_duu10n,n) = duu10n(n)
           xao%rAttr(index_xao_So_u10   ,n) = sqrt(duu10n(n))
+          xao%rAttr(index_xao_So_u10withgusts,n) = sqrt(duu10n(n))
           xao%rAttr(index_xao_So_warm_diurn       ,n) = warm(n)
           xao%rAttr(index_xao_So_salt_diurn       ,n) = salt(n)
           xao%rAttr(index_xao_So_speed_diurn      ,n) = speed(n)

--- a/driver-moab/main/seq_frac_mct.F90
+++ b/driver-moab/main/seq_frac_mct.F90
@@ -288,6 +288,7 @@ contains
     !----- local -----
     type(mct_ggrid), pointer    :: dom_a
     type(mct_gsmap), pointer    :: gsmap_a ! see if we can get from here the global ids (missing from dom_a)
+    type(mct_gsmap), pointer    :: gsmap_l
     type(mct_gsmap), pointer    :: gsmap_r 
     type(mct_gsmap), pointer    :: gsmap_i ! ofrac on ice error 
     type(mct_ggrid), pointer    :: dom_i
@@ -475,13 +476,13 @@ contains
          tagname = 'lfrin'//C_NULL_CHAR ! 'lfrin'
          allocate(tagValues(lSize) )
          tagValues = dom_l%data%rAttr(kf,:)
-         kgg = mct_aVect_indexIA(dom_l%data ,"GlobGridNum" ,perrWith=subName)
+         !kgg = mct_aVect_indexIA(dom_l%data ,"GlobGridNum" ,perrWith=subName)
          !allocate(GlobalIds(lSize))
          !GlobalIds = dom_l%data%iAttr(kgg,:)
-         gsmap_a  => component_get_gsmap_cx(atm) ! gsmap_ax
+         gsmap_l  => component_get_gsmap_cx(lnd) ! gsmap_lx
          call mpi_comm_rank(mpicom,my_task,ierr)
          ! Determine global gridpoint number attribute, GlobGridNum, automatically in ggrid
-         call mct_gsMap_orderedPoints(gsmap_a, my_task, dof)
+         call mct_gsMap_orderedPoints(gsmap_l, my_task, dof)
          ! ent_type should be 3, FV
          ierr = iMOAB_SetDoubleTagStorageWithGid ( mblxid, tagname, lSize , ent_type, tagValues, dof )
          if (ierr .ne. 0) then
@@ -618,6 +619,7 @@ contains
             call shr_sys_abort(subname//' ERROR in setting ofrac on ice ')
          endif
          !deallocate(GlobalIds)
+         deallocate(tagValues)
          deallocate(dof)
        endif
 
@@ -925,7 +927,7 @@ contains
     integer                  :: n
     integer                  :: ki, kl, ko, kf
     real(r8),allocatable :: fcorr(:)
-    integer(IN), pointer :: dof(:)    !
+    integer(IN), pointer, save :: dof(:)    !
 
     logical, save :: first_time = .true.
 ! moab

--- a/driver-moab/main/seq_frac_mct.F90
+++ b/driver-moab/main/seq_frac_mct.F90
@@ -621,12 +621,34 @@ contains
          !deallocate(GlobalIds)
          deallocate(tagValues)
          deallocate(dof)
+#ifdef MOABDEBUG
+         wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR
+         if (mbixid .ge. 0  ) then
+            outfile = 'iceCplInit1Fr.h5m'//C_NULL_CHAR
+            ierr = iMOAB_WriteMesh(mbixid, trim(outfile), trim(wopts))
+            if (ierr .ne. 0) then
+               write(logunit,*) subname,' error in writing mesh '
+               call shr_sys_abort(subname//' ERROR in writing mesh ')
+            endif
+         endif
+#endif
        endif
 
        if (atm_present) then
           mapper_i2a => prep_atm_get_mapper_Fi2a()
           call seq_map_map(mapper_i2a,fractions_i,fractions_a,fldlist='ofrac',norm=.false.)
        endif
+#ifdef MOABDEBUG
+       wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR
+       if (mbaxid .ge. 0  ) then
+          outfile = 'atmCplInit1Fr.h5m'//C_NULL_CHAR
+          ierr = iMOAB_WriteMesh(mbaxid, trim(outfile), trim(wopts))
+          if (ierr .ne. 0) then
+             write(logunit,*) subname,' error in writing mesh '
+             call shr_sys_abort(subname//' ERROR in writing mesh ')
+          endif
+       endif
+#endif
 
     end if ! end of ice_present
 
@@ -694,6 +716,17 @@ contains
           deallocate(tagValues)
           mapper_o2a => prep_atm_get_mapper_Fo2a()
           call seq_map_map(mapper_o2a, fractions_o, fractions_a, fldlist='ofrac',norm=.false.)
+#ifdef MOABDEBUG
+         wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR
+         if (mbaxid .ge. 0  ) then
+            outfile = 'atmCplInit2Fr.h5m'//C_NULL_CHAR
+            ierr = iMOAB_WriteMesh(mbaxid, trim(outfile), trim(wopts))
+            if (ierr .ne. 0) then
+               write(logunit,*) subname,' error in writing mesh '
+               call shr_sys_abort(subname//' ERROR in writing mesh ')
+            endif
+         endif
+#endif
        endif
 
        if (atm_present) then

--- a/driver-moab/main/seq_frac_mct.F90
+++ b/driver-moab/main/seq_frac_mct.F90
@@ -543,7 +543,7 @@ contains
          ! Determine global gridpoint number attribute, GlobGridNum, automatically in ggrid
          call mct_gsMap_orderedPoints(gsmap_r, my_task, dof)
          ! again, we are setting on the river instance that is also used for ocean coupling
-         ierr = iMOAB_SetDoubleTagStorageWithGid ( mbrxid, tagname, lSize , ent_type, tagValues, GlobalIds )
+         ierr = iMOAB_SetDoubleTagStorageWithGid ( mbrxid, tagname, lSize , ent_type, tagValues, dof )
          if (ierr .ne. 0) then
             write(logunit,*) subname,' error in setting rfrac on rof   '
             call shr_sys_abort(subname//' ERROR in setting rfrac on rof ')

--- a/driver-moab/main/seq_frac_mct.F90
+++ b/driver-moab/main/seq_frac_mct.F90
@@ -288,6 +288,7 @@ contains
     !----- local -----
     type(mct_ggrid), pointer    :: dom_a
     type(mct_gsmap), pointer    :: gsmap_a ! see if we can get from here the global ids (missing from dom_a)
+    type(mct_gsmap), pointer    :: gsmap_r 
     type(mct_ggrid), pointer    :: dom_i
     type(mct_ggrid), pointer    :: dom_l
     type(mct_ggrid), pointer    :: dom_o
@@ -534,16 +535,21 @@ contains
          tagname = 'rfrac'//C_NULL_CHAR ! 'rfrac'
          allocate(tagValues(lSize) )
          tagValues = dom_r%data%rAttr(kf,:)
-         kgg = mct_aVect_indexIA(dom_r%data ,"GlobGridNum" ,perrWith=subName)
-         allocate(GlobalIds(lSize))
-         GlobalIds = dom_r%data%iAttr(kgg,:)
+         !kgg = mct_aVect_indexIA(dom_r%data ,"GlobGridNum" ,perrWith=subName)
+         !allocate(GlobalIds(lSize))
+         !GlobalIds = dom_r%data%iAttr(kgg,:)
+         gsmap_r  => component_get_gsmap_cx(rof) ! gsmap_rx
+         call mpi_comm_rank(mpicom,my_task,ierr)
+         ! Determine global gridpoint number attribute, GlobGridNum, automatically in ggrid
+         call mct_gsMap_orderedPoints(gsmap_r, my_task, dof)
          ! again, we are setting on the river instance that is also used for ocean coupling
          ierr = iMOAB_SetDoubleTagStorageWithGid ( mbrxid, tagname, lSize , ent_type, tagValues, GlobalIds )
          if (ierr .ne. 0) then
             write(logunit,*) subname,' error in setting rfrac on rof   '
             call shr_sys_abort(subname//' ERROR in setting rfrac on rof ')
          endif
-         deallocate(GlobalIds)
+         !deallocate(GlobalIds)
+         deallocate(dof)
          deallocate(tagValues)
 
        endif

--- a/driver-moab/main/seq_frac_mct.F90
+++ b/driver-moab/main/seq_frac_mct.F90
@@ -735,16 +735,21 @@ contains
           tagname = 'lfrac'//C_NULL_CHAR ! 'lfrac
           allocate(tagValues(lSize) )
           tagValues = fractions_a%rAttr(kl,:)
-          kgg = mct_aVect_indexIA(dom_a%data ,"GlobGridNum" ,perrWith=subName)
-          allocate(GlobalIds(lSize))
-          GlobalIds = dom_a%data%iAttr(kgg,:)
+          !kgg = mct_aVect_indexIA(dom_a%data ,"GlobGridNum" ,perrWith=subName)
+          !allocate(GlobalIds(lSize))
+          !GlobalIds = dom_a%data%iAttr(kgg,:)
           ! set on atmosphere instance
-          ierr = iMOAB_SetDoubleTagStorageWithGid ( mbaxid, tagname, lSize , ent_type, tagValues, GlobalIds )
+          gsmap_a  => component_get_gsmap_cx(atm) ! gsmap_ax
+          call mpi_comm_rank(mpicom,my_task,ierr)
+            ! Determine global gridpoint number attribute, GlobGridNum, automatically in ggrid
+          call mct_gsMap_orderedPoints(gsmap_a, my_task, dof)
+          ierr = iMOAB_SetDoubleTagStorageWithGid ( mbaxid, tagname, lSize , ent_type, tagValues, dof )
           if (ierr .ne. 0) then
              write(logunit,*) subname,' error in setting lfrac on atm   '
              call shr_sys_abort(subname//' ERROR in setting lfrac on atm ')
           endif
-          deallocate(GlobalIds)
+          !deallocate(GlobalIds)
+          deallocate(dof)
           deallocate(tagValues)
         endif
        else if (lnd_present) then

--- a/driver-moab/main/seq_map_mod.F90
+++ b/driver-moab/main/seq_map_mod.F90
@@ -235,7 +235,7 @@ contains
       call shr_sys_abort(subname//' ERROR in loading map file')
     endif
    if (seq_comm_iamroot(CPLID)) then
-      write(logunit,'(2A,I6,4A)') subname,'Result: iMOAB map app ID, maptype, mapfile = ', &
+      write(logunit,'(2A,I12,4A)') subname,'Result: iMOAB map app ID, maptype, mapfile = ', &
          mbintx,' ',trim(maptype),' ',trim(mapfile), ', identifier: ', trim(sol_identifier)
       call shr_sys_flush(logunit)
    endif

--- a/driver-moab/main/seq_map_mod.F90
+++ b/driver-moab/main/seq_map_mod.F90
@@ -328,6 +328,7 @@ end subroutine moab_map_init_rcfile
     use iMOAB, only: iMOAB_GetMeshInfo, iMOAB_GetDoubleTagStorage, iMOAB_SetDoubleTagStorage, &
       iMOAB_GetIntTagStorage, iMOAB_ApplyScalarProjectionWeights, &
       iMOAB_SendElementTag, iMOAB_ReceiveElementTag, iMOAB_FreeSenderBuffers
+    use seq_comm_mct, only : num_moab_exports
 
     implicit none
     !-----------------------------------------------------
@@ -438,7 +439,7 @@ end subroutine moab_map_init_rcfile
 #ifdef MOABDEBUG
          if (seq_comm_iamroot(CPLID)) then
             write(logunit,*) subname, 'iMOAB mapper ',trim(mapper%mbname), ' iMOAB_mapper  nfields', &
-                  nfields,  ' fldlist_moab=', trim(fldlist_moab)
+                  nfields,  ' fldlist_moab=', trim(fldlist_moab), ' moab step ', num_moab_exports
             call shr_sys_flush(logunit)
          endif
 #endif
@@ -496,7 +497,7 @@ end subroutine moab_map_init_rcfile
 #ifdef MOABDEBUG
          if (seq_comm_iamroot(CPLID)) then
             write(logunit, *) subname,' iMOAB mapper rearrange or copy ', mapper%mbname, ' send/recv tags ', trim(fldlist_moab), &
-              ' mbpresent=', mbpresent, ' mbnorm=', mbnorm
+              ' mbpresent=', mbpresent, ' mbnorm=', mbnorm, ' moab step:', num_moab_exports
             call shr_sys_flush(logunit)
          endif
 #endif
@@ -550,7 +551,8 @@ end subroutine moab_map_init_rcfile
             endif
 #ifdef MOABDEBUG
             if (seq_comm_iamroot(CPLID)) then
-               write(logunit, *) subname,' iMOAB mapper ', mapper%mbname, ' set norm8wt 1  on source with app id: ', mapper%src_mbid
+               write(logunit, *) subname,' iMOAB mapper ', mapper%mbname, ' set norm8wt 1  on source with app id: ', &
+                   mapper%src_mbid, ' moab step:', num_moab_exports
                call shr_sys_flush(logunit)
             endif
 #endif
@@ -584,7 +586,8 @@ end subroutine moab_map_init_rcfile
 #ifdef MOABDEBUG
          if (seq_comm_iamroot(CPLID)) then
             write(logunit, *) subname,' iMOAB projection mapper: ', mapper%mbname, ' normalize nfields=', &
-               nfields, ' arrsize_src on root:', arrsize_src, ' shape(targtags_ini)=', shape(targtags_ini)
+               nfields, ' arrsize_src on root:', arrsize_src, ' shape(targtags_ini)=', shape(targtags_ini), &
+               ' moab step:', num_moab_exports
             call shr_sys_flush(logunit)
          endif
 #endif
@@ -613,7 +616,7 @@ end subroutine moab_map_init_rcfile
 #ifdef MOABDEBUG
          if (seq_comm_iamroot(CPLID)) then
             write(logunit, *) subname,' iMOAB mapper receiving tags with intx and intx_mbid: ', &
-               mapper%mbname, trim(fldlist_moab)
+               mapper%mbname, trim(fldlist_moab), ' moab step:', num_moab_exports
          endif
 #endif
          ierr = iMOAB_ReceiveElementTag( mapper%intx_mbid, fldlist_moab, mapper%mpicom, mapper%src_context )
@@ -634,7 +637,8 @@ end subroutine moab_map_init_rcfile
 
 #ifdef MOABDEBUG
          if (seq_comm_iamroot(CPLID)) then
-            write(logunit, *) subname,' iMOAB projection mapper: ',trim(mapper%mbname), ' between ', mapper%src_mbid, ' and ',  mapper%tgt_mbid, trim(fldlist_moab)
+            write(logunit, *) subname,' iMOAB projection mapper: ',trim(mapper%mbname), ' between ', mapper%src_mbid, ' and ',  mapper%tgt_mbid, trim(fldlist_moab), &
+               ' moab step:', num_moab_exports
             call shr_sys_flush(logunit)
          endif
 #endif

--- a/driver-moab/shr/CMakeLists.txt
+++ b/driver-moab/shr/CMakeLists.txt
@@ -1,5 +1,6 @@
 list(APPEND drv_sources
   glc_elevclass_mod.F90
+  glc_zocnclass_mod.F90
   seq_cdata_mod.F90
   seq_comm_mct.F90
   seq_infodata_mod.F90

--- a/driver-moab/shr/glc_zocnclass_mod.F90
+++ b/driver-moab/shr/glc_zocnclass_mod.F90
@@ -1,0 +1,343 @@
+module glc_zocnclass_mod
+
+  !---------------------------------------------------------------------
+  !
+  ! Purpose:
+  !
+  ! This module contains data and routines for operating on GLC ocean z-level classes.
+
+#include "shr_assert.h"
+  use shr_kind_mod, only : r8 => shr_kind_r8
+  use shr_sys_mod
+  use seq_comm_mct, only : logunit
+  use shr_log_mod, only : errMsg => shr_log_errMsg
+
+  implicit none
+  save
+  private
+
+  !--------------------------------------------------------------------------
+  ! Public interfaces
+  !--------------------------------------------------------------------------
+
+  public :: glc_zocnclass_init            ! initialize GLC z-ocean class data
+  public :: glc_zocnclass_clean           ! deallocate memory allocated here
+  public :: glc_get_num_zocn_classes      ! get the number of z-ocean classes
+  public :: glc_get_zlevels               ! get an array of the z-ocean levels
+  public :: glc_get_zocnclass_bounds      ! get the boundaries of all z-ocean classes
+  public :: glc_zocnclass_as_string       ! returns a string corresponding to a given z-ocean class
+  public :: glc_all_zocnclass_strings     ! returns an array of strings for all z-ocean classes
+  public :: glc_zocn_errcode_to_string    ! convert an error code into a string describing the error
+
+  interface glc_zocnclass_init
+     module procedure glc_zocnclass_init_default
+     module procedure glc_zocnclass_init_override
+  end interface glc_zocnclass_init
+
+
+  !--------------------------------------------------------------------------
+  ! Public data
+  !--------------------------------------------------------------------------
+
+  ! Possible error code values
+  integer, parameter, public :: GLC_ZOCNCLASS_ERR_NONE = 0      ! err_code indicating no error
+  integer, parameter, public :: GLC_ZOCNCLASS_ERR_UNDEFINED = 1 ! err_code indicating z-ocean classes have not been defined
+  integer, parameter, public :: GLC_ZOCNCLASS_ERR_TOO_LOW = 2   ! err_code indicating z-level below lowest z-ocean class
+  integer, parameter, public :: GLC_ZOCNCLASS_ERR_TOO_HIGH = 3  ! err_code indicating z-level above highest z-ocean class
+
+  ! String length for glc z-ocean classes represented as strings
+  integer, parameter, public :: GLC_ZOCNCLASS_STRLEN = 2
+
+  !--------------------------------------------------------------------------
+  ! Private data
+  !--------------------------------------------------------------------------
+
+  ! number of elevation classes
+  integer :: glc_nzoc  ! number of z-ocean classes
+
+  ! z-level of each class.  Units are meters above sea level, so values should be <0
+  ! indexing goes from shallowest to deepest levels
+  real(r8), allocatable :: zocn_levels(:)
+  ! upper and lower z-level limit for each class (m)
+  ! first dimension: indexing goes from shallowest to deepest levels
+  ! second dimension: index 1 is upper limit, index 2 is lower limit
+  real(r8), allocatable :: zocn_bnds(:,:)
+
+
+contains
+
+  !-----------------------------------------------------------------------
+  subroutine glc_zocnclass_init_default(my_glc_nzoc)
+    !
+    ! !DESCRIPTION:
+    ! Initialize GLC z-ocean class data to default values, based on given glc_nzoc
+    !
+    ! !USES:
+    !
+    ! !ARGUMENTS:
+    integer, intent(in) :: my_glc_nzoc  ! number of GLC z-ocean classes
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'glc_zocnclass_init'
+    integer :: i
+    !-----------------------------------------------------------------------
+
+    glc_nzoc = my_glc_nzoc
+    allocate(zocn_levels(glc_nzoc))
+
+    select case (glc_nzoc)
+    case(0)
+       ! do nothing
+    case(4)
+       zocn_levels = [-250._r8,  -750._r8,  -1250._r8, -1750._r8]
+    case(30)
+       zocn_levels = [ -30._r8,   -90._r8,  -150._r8,  -210._r8,  -270._r8, &
+                      -330._r8,  -390._r8,  -450._r8,  -510._r8,  -570._r8, &
+                      -630._r8,  -690._r8,  -750._r8,  -810._r8,  -870._r8, &
+                      -930._r8,  -990._r8, -1050._r8, -1110._r8, -1170._r8, &
+                     -1230._r8, -1290._r8, -1350._r8, -1410._r8, -1470._r8, &
+                     -1530._r8, -1590._r8, -1650._r8, -1710._r8, -1770._r8]
+    case default
+       write(logunit,*) subname,' ERROR: unknown glc_nzoc: ', glc_nzoc
+       call shr_sys_abort(subname//' ERROR: unknown glc_nzoc')
+    end select
+
+    call glc_zocnclass_init_bnds()
+
+  end subroutine glc_zocnclass_init_default
+
+  !-----------------------------------------------------------------------
+  subroutine glc_zocnclass_init_bnds()
+    integer :: i
+
+    allocate(zocn_bnds(2,glc_nzoc))
+    zocn_bnds(:,:) = 0._r8
+    if (glc_nzoc >= 2) then
+       zocn_bnds(1,1) = 0._r8
+       zocn_bnds(2,1) = 0.5_r8 * (zocn_levels(1) + zocn_levels(2))
+       do i = 2, glc_nzoc - 1
+          zocn_bnds(1,i) = 0.5_r8 * (zocn_levels(i-1) + zocn_levels(i))
+          zocn_bnds(2,i) = 0.5_r8 * (zocn_levels(i) + zocn_levels(i+1))
+       enddo
+       zocn_bnds(1,glc_nzoc) = 0.5_r8 * (zocn_levels(glc_nzoc-1) + zocn_levels(glc_nzoc))
+       zocn_bnds(2,glc_nzoc) = zocn_levels(glc_nzoc) + (zocn_levels(glc_nzoc) - zocn_bnds(1,glc_nzoc))
+    endif
+  end subroutine glc_zocnclass_init_bnds
+
+  !-----------------------------------------------------------------------
+  subroutine glc_zocnclass_init_override(my_glc_nzoc, my_zocn_levels)
+    !
+    ! !DESCRIPTION:
+    ! Initialize GLC zocn class data to the given z-values
+    !
+    ! The input, my_zocn_levels, should have my_glc_nzoc elements.
+    !
+    ! !USES:
+    !
+    ! !ARGUMENTS:
+    integer, intent(in) :: my_glc_nzoc     ! number of GLC z-ocean classes
+    real(r8), intent(in) :: my_zocn_levels(:) ! z-ocean values (m)
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'glc_zocnlass_init_override'
+    !-----------------------------------------------------------------------
+
+    SHR_ASSERT_ALL_FL((ubound(my_zocn_levels) == (/my_glc_nzoc/)), __FILE__, __LINE__)
+
+    glc_nzoc = my_glc_nzoc
+    allocate(zocn_levels(glc_nzoc))
+    zocn_levels = my_zocn_levels
+    allocate(zocn_bnds(2,glc_nzoc))
+
+    call glc_zocnclass_init_bnds()
+
+  end subroutine glc_zocnclass_init_override
+
+  !-----------------------------------------------------------------------
+  subroutine glc_zocnclass_clean()
+    !
+    ! !DESCRIPTION:
+    ! Deallocate memory allocated in this module
+
+    character(len=*), parameter :: subname = 'glc_zocnclass_clean'
+    !-----------------------------------------------------------------------
+
+    if (allocated(zocn_levels)) then
+       deallocate(zocn_levels)
+    end if
+    if (allocated(zocn_bnds)) then
+       deallocate(zocn_bnds)
+    end if
+    glc_nzoc = 0
+
+  end subroutine glc_zocnclass_clean
+
+  !-----------------------------------------------------------------------
+  function glc_get_num_zocn_classes() result(num_zocn_classes)
+    !
+    ! !DESCRIPTION:
+    ! Get the number of GLC z-ocean classes
+    !
+    ! !ARGUMENTS:
+    integer :: num_zocn_classes  ! function result
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'glc_get_num_zocn_classes'
+    !-----------------------------------------------------------------------
+
+    num_zocn_classes = glc_nzoc
+
+  end function glc_get_num_zocn_classes
+
+  !-----------------------------------------------------------------------
+  function glc_get_zlevels() result(zlevs)
+    !
+    ! !DESCRIPTION:
+    ! Get all z-levels
+    !
+    ! This returns an array of size (glc_nzoc)
+    !
+    ! !USES:
+    !
+    ! !ARGUMENTS:
+    real(r8) :: zlevs(glc_nzoc)  ! function result
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'glc_get_zlevels'
+    !-----------------------------------------------------------------------
+
+    zlevs(:) = zocn_levels(:)
+
+  end function glc_get_zlevels
+
+  !-----------------------------------------------------------------------
+  function glc_get_zocnclass_bounds() result(zocnclass_bounds)
+    !
+    ! !DESCRIPTION:
+    ! Get the boundaries of all z-ocean classes.
+    !
+    ! This returns an array of size (glc_nzoc,2)
+    !
+    ! !USES:
+    !
+    ! !ARGUMENTS:
+    real(r8) :: zocnclass_bounds(2,glc_nzoc)  ! function result
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'glc_get_zocnclass_bounds'
+    !-----------------------------------------------------------------------
+
+    zocnclass_bounds(:,:) = zocn_bnds(:,:)
+
+  end function glc_get_zocnclass_bounds
+
+  !-----------------------------------------------------------------------
+  function glc_zocnclass_as_string(zocn_class) result(zc_string)
+    !
+    ! !DESCRIPTION:
+    ! Returns a string corresponding to a given elevation class.
+    !
+    ! This string can be used as a suffix for fields in MCT attribute vectors.
+    !
+    ! !USES:
+    !
+    ! !ARGUMENTS:
+    character(len=GLC_ZOCNCLASS_STRLEN) :: zc_string  ! function result
+    integer, intent(in) :: zocn_class
+    !
+    ! !LOCAL VARIABLES:
+    character(len=16) :: format_string
+
+    character(len=*), parameter :: subname = 'glc_zocnclass_as_string'
+    !-----------------------------------------------------------------------
+
+    ! e.g., for GLC_ZOCNCLASS_STRLEN = 2, format_string will be '(i2.2)'
+    write(format_string,'(a,i0,a,i0,a)') '(i', GLC_ZOCNCLASS_STRLEN, '.', GLC_ZOCNCLASS_STRLEN, ')'
+
+    write(zc_string,trim(format_string)) zocn_class
+  end function glc_zocnclass_as_string
+
+  !-----------------------------------------------------------------------
+  function glc_all_zocnclass_strings(include_zero) result(zc_strings)
+    !
+    ! !DESCRIPTION:
+    ! Returns an array of strings corresponding to all z-ocean classes from 1 to glc_nzoc
+    !
+    ! If include_zero is present and true, then includes z-ocean class 0 - so goes from
+    ! 0 to glc_nzoc
+    !
+    ! These strings can be used as suffixes for fields in MCT attribute vectors.
+    !
+    ! !USES:
+    !
+    ! !ARGUMENTS:
+    character(len=GLC_ZOCNCLASS_STRLEN), allocatable :: zc_strings(:)  ! function result
+    logical, intent(in), optional :: include_zero   ! if present and true, include elevation class 0 (default is false)
+    !
+    ! !LOCAL VARIABLES:
+    logical :: l_include_zero  ! local version of optional include_zero argument
+    integer :: lower_bound
+    integer :: i
+
+    character(len=*), parameter :: subname = 'glc_all_zocnclass_strings'
+    !-----------------------------------------------------------------------
+
+    if (present(include_zero)) then
+       l_include_zero = include_zero
+    else
+       l_include_zero = .false.
+    end if
+
+    if (l_include_zero) then
+       lower_bound = 0
+    else
+       lower_bound = 1
+    end if
+
+    allocate(zc_strings(lower_bound:glc_nzoc))
+    do i = lower_bound, glc_nzoc
+       zc_strings(i) = glc_zocnclass_as_string(i)
+    end do
+
+  end function glc_all_zocnclass_strings
+
+
+  !-----------------------------------------------------------------------
+  function glc_zocn_errcode_to_string(err_code) result(err_string)
+    !
+    ! !DESCRIPTION:
+    !
+    !
+    ! !USES:
+    !
+    ! !ARGUMENTS:
+    character(len=256) :: err_string  ! function result
+    integer, intent(in) :: err_code   ! error code (one of the GLC_ZOCNCLASS_ERR* values)
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'glc_errcode_to_string'
+    !-----------------------------------------------------------------------
+
+    select case (err_code)
+    case (GLC_ZOCNCLASS_ERR_NONE)
+       err_string = '(no error)'
+    case (GLC_ZOCNCLASS_ERR_UNDEFINED)
+       err_string = 'Z-ocean classes have not yet been defined'
+    case (GLC_ZOCNCLASS_ERR_TOO_LOW)
+       err_string = 'Z-level below the lower bound of the lowest z-ocean class'
+    case (GLC_ZOCNCLASS_ERR_TOO_HIGH)
+       err_string = 'Z-level above the upper bound of the highest z-ocean class'
+    case default
+       err_string = 'UNKNOWN ERROR'
+    end select
+
+  end function glc_zocn_errcode_to_string
+
+
+end module glc_zocnclass_mod

--- a/driver-moab/shr/seq_comm_mct.F90
+++ b/driver-moab/shr/seq_comm_mct.F90
@@ -240,7 +240,7 @@ module seq_comm_mct
   integer, public :: mbrxid   ! iMOAB id of moab rof read from file on coupler pes
 !   integer, public :: mbrmapro ! iMOAB id for read map between river and ocean; it exists on coupler PEs
 !                               ! similar to intx id, oa, la;
-!   integer, public :: mbrxoid  ! iMOAB id for rof migrated to coupler for ocean context (r2o mapping)
+  integer, public :: mbrxoid  ! iMOAB id for rof migrated to coupler for ocean context (r2o mapping)
   integer, public :: mbintxro ! iMOAB id for read map between river and ocean; it exists on coupler PEs
   logical, public :: mbrof_data = .false. ! made true if no rtm mesh, which means data rof ?
   integer, public :: mbintxar ! iMOAB id for intx mesh between atm and river

--- a/driver-moab/shr/seq_comm_mct.F90
+++ b/driver-moab/shr/seq_comm_mct.F90
@@ -238,9 +238,6 @@ module seq_comm_mct
   integer, public :: mbintxia ! iMOAB id for intx mesh between ice and atmosphere
   integer, public :: mrofid   ! iMOAB id of moab rof app
   integer, public :: mbrxid   ! iMOAB id of moab rof read from file on coupler pes
-!   integer, public :: mbrmapro ! iMOAB id for read map between river and ocean; it exists on coupler PEs
-!                               ! similar to intx id, oa, la;
-  integer, public :: mbrxoid  ! iMOAB id for rof migrated to coupler for ocean context (r2o mapping)
   integer, public :: mbintxro ! iMOAB id for read map between river and ocean; it exists on coupler PEs
   logical, public :: mbrof_data = .false. ! made true if no rtm mesh, which means data rof ?
   integer, public :: mbintxar ! iMOAB id for intx mesh between atm and river
@@ -678,8 +675,6 @@ contains
     mbintxia = -1 ! iMOAB id for ice intx with atm on coupler pes
     mrofid = -1   ! iMOAB id of moab rof app
     mbrxid = -1   ! iMOAB id of moab rof migrated to coupler
-   !  mbrmapro = -1 ! iMOAB id of moab instance of map read from rof2ocn map file
-   !  mbrxoid = -1  ! iMOAB id of moab instance rof to coupler in ocean context
     mbintxro = -1 ! iMOAB id of moab instance of map read from rof2ocn map file
     mbintxar = -1 ! iMOAB id for intx mesh between atm and river
     mbintxlr = -1 ! iMOAB id for intx mesh between land and river

--- a/driver-moab/shr/seq_flds_mod.F90
+++ b/driver-moab/shr/seq_flds_mod.F90
@@ -309,6 +309,7 @@ contains
     use shr_string_mod, only : shr_string_listIntersect
     use shr_mpi_mod,    only : shr_mpi_bcast
     use glc_elevclass_mod, only : glc_elevclass_init
+    use glc_zocnclass_mod, only : glc_zocnclass_init
     use seq_infodata_mod, only : seq_infodata_type, seq_infodata_getdata
 
     ! !INPUT/OUTPUT PARAMETERS:
@@ -404,10 +405,11 @@ contains
     logical :: flds_polar
     logical :: flds_tf
     integer :: glc_nec
+    integer :: glc_nzoc
 
     namelist /seq_cplflds_inparm/  &
          flds_co2a, flds_co2b, flds_co2c, flds_co2_dmsa, flds_wiso, flds_polar, flds_tf, &
-         glc_nec, ice_ncat, seq_flds_i2o_per_cat, flds_bgc_oi, &
+         glc_nec, glc_nzoc, ice_ncat, seq_flds_i2o_per_cat, flds_bgc_oi, &
          nan_check_component_fields, rof_heat, atm_flux_method, atm_gustiness, &
          rof2ocn_nutrients, lnd_rof_two_way, ocn_rof_two_way, rof_sed, &
          wav_ocn_coup
@@ -447,6 +449,7 @@ contains
        flds_polar = .false.
        flds_tf = .false.
        glc_nec   = 0
+       glc_nzoc  = 0
        ice_ncat  = 1
        seq_flds_i2o_per_cat = .false.
        nan_check_component_fields = .false.
@@ -483,6 +486,7 @@ contains
     call shr_mpi_bcast(flds_polar   , mpicom)
     call shr_mpi_bcast(flds_tf      , mpicom)
     call shr_mpi_bcast(glc_nec      , mpicom)
+    call shr_mpi_bcast(glc_nzoc     , mpicom)
     call shr_mpi_bcast(ice_ncat     , mpicom)
     call shr_mpi_bcast(seq_flds_i2o_per_cat, mpicom)
     call shr_mpi_bcast(nan_check_component_fields, mpicom)
@@ -496,6 +500,7 @@ contains
     call shr_mpi_bcast(wav_ocn_coup, mpicom)
 
     call glc_elevclass_init(glc_nec)
+    call glc_zocnclass_init(glc_nzoc)
 
     !---------------------------------------------------------------------------
     ! Read in namelists for user specified new fields
@@ -3014,18 +3019,33 @@ contains
        attname  = 'So_rhoeff'
        call metadata_set(attname, longname, stdname, units)
 
-       if (flds_tf) then
+       if ((flds_tf) .and. (glc_nzoc > 0)) then
+          ! glc fields with multiple ocn z classes: ocn->glc
+          !
+          ! Note that these fields are sent in multiple elevation classes from ocn->cpl
+          ! and cpl->ocn (which differs from glc_nec variables)
 
-          name = 'So_tf2d'
-          call seq_flds_add(o2x_states,trim(name))
-          call seq_flds_add(x2g_states,trim(name))
-          call seq_flds_add(x2g_tf_states_from_ocn,trim(name))
-          longname = 'ocean thermal forcing at predefined critical depth'
-          stdname  = 'ocean_thermal_forcing_at_critical_depth'
+          name = 'So_tf3d'
+          longname = 'ocean thermal forcing at z-level'
+          stdname  = 'ocean_thermal_forcing_at_z_level'
           units    = 'C'
           attname  = name
-          call metadata_set(attname, longname, stdname, units)
+          call set_glc_zocnclass_field(name, attname, longname, stdname, units, o2x_states)
+          call set_glc_zocnclass_field(name, attname, longname, stdname, units, x2g_states, &
+               additional_list = .true.)
+          call set_glc_zocnclass_field(name, attname, longname, stdname, units, x2g_tf_states_from_ocn, &
+               additional_list = .true.)
 
+          name = 'So_tf3d_mask'
+          longname = 'mask of valid ocean thermal forcing at z-level'
+          stdname  = 'mask_ocean_thermal_forcing_at_z_level'
+          units    = 'none'
+          attname  = name
+          call set_glc_zocnclass_field(name, attname, longname, stdname, units, o2x_states)
+          call set_glc_zocnclass_field(name, attname, longname, stdname, units, x2g_states, &
+               additional_list = .true.)
+          call set_glc_zocnclass_field(name, attname, longname, stdname, units, x2g_tf_states_from_ocn, &
+               additional_list = .true.)
        end if
 
        name = 'Fogx_qicelo'
@@ -4390,6 +4410,66 @@ contains
        end do
     end if
   end subroutine set_glc_elevclass_field
+
+  !===============================================================================
+
+  subroutine set_glc_zocnclass_field(name, attname, longname, stdname, units, fieldlist, &
+       additional_list)
+
+    ! Sets a coupling field for all ocn z classes (1:glc_nzoc)
+    !
+    ! Note that, if glc_nzoc = 0, then we don't create any coupling fields
+    !
+    ! Puts the coupling fields in the given fieldlist, and also does the appropriate
+    ! metadata_set calls.
+    !
+    ! additional_list should be .false. (or absent) the first time this is called for a
+    ! given set of coupling fields. However, if this same set of coupling fields is being
+    ! added to multiple field lists, then additional_list should be set to true for the
+    ! second and subsequent calls; in this case, the metadata_set calls are not done
+    ! (because they have already been done).
+    !
+    ! name, attname and longname give the base name of the field; the ocn z class
+    ! index will be appended as a suffix
+
+    ! !USES:
+    use glc_zocnclass_mod, only : glc_get_num_zocn_classes, glc_zocnclass_as_string
+
+    ! !INPUT/OUTPUT PARAMETERS:
+    character(len=*), intent(in) :: name     ! base field name to add to fieldlist
+    character(len=*), intent(in) :: attname  ! base field name for metadata
+    character(len=*), intent(in) :: longname ! base long name for metadata
+    character(len=*), intent(in) :: stdname  ! standard name for metadata
+    character(len=*), intent(in) :: units    ! units for metadata
+    character(len=*), intent(inout) :: fieldlist  ! field list into which the fields should be added
+
+    logical, intent(in), optional :: additional_list  ! whether this is an additional list for the same set of coupling fields (see above for details; defaults to false)
+
+    !EOP
+    integer            :: num
+    character(len= 16) :: cnum
+    logical :: l_additional_list  ! local version of the optional additional_list argument
+    
+    l_additional_list = .false.
+    if (present(additional_list)) then
+       l_additional_list = additional_list
+    end if
+
+    if (glc_get_num_zocn_classes() > 0) then
+       do num = 1, glc_get_num_zocn_classes()
+          cnum = glc_zocnclass_as_string(num)
+
+          call seq_flds_add(fieldlist, trim(name) // trim(cnum))
+
+          if (.not. l_additional_list) then
+             call metadata_set(attname  = trim(attname) // trim(cnum), &
+                  longname = trim(longname) // ' of thermal forcing class ' // trim(cnum), &
+                  stdname  = stdname, &
+                  units    = units)
+          end if
+       end do
+    end if
+  end subroutine set_glc_zocnclass_field
 
   !===============================================================================
 


### PR DESCRIPTION
Some changes to driver-moab.  

Add changes to map migration to support reading in all maps.  Use iMOAB_MigrateMapMesh instead of iMOAB_ComputeCoverageMesh, modernizing and simplifying the mesh mapping workflow.   

Add more mesh output under MOABDEBUG.

Aream values are used for correction factors. Aream (area used by mapping codes) are either computed by tempestremap in compute maps workflow, or read from mapping files in read map workflows. Aream are set for both source and target meshes, and the last aream computation or reading wins. For atm and rof components, aream on coupler side are also copied during component coupler init, from area fields, before any map initialization. This is to avoid cases in which atm or rof do not participate in any maps, so aream might end up uninitialized.  
Also, report min/max for correction factors computed for moab driver, in the same way mct driver reports them

Several corrections were made for fractions computations; When set from mct fractions, global grid ids from mct are needed too, and they were missing in some data models from regular place. (domain structure in component type)

Also add new coupling features that were only in the mct driver.  
  - Changes related to sediflag for mosart were missing in moab import
  - Changes related to gustiness were missing in moab driver for land, ice and flux calculations
 .  Several changes were triggered by glc coupling with ocean in the new paradigm; default driver input is still needed, and build configuration changes are necessary for the code to be setup, compiled and run 

---

Older changes from PR iulian787/restore_migrate_map_mesh (PR #7286) were rebased on top of those glc changes

new changes were made to restart logic for moab driver, for tri-grid case; Land mesh is usually culled from river mesh in tri-grid case, and the global size / maximum dof id of land mesh is retrieved in that case from river model. In regular bigrid case, the land mesh maximum dof id is retrieved from atm mesh. samegrid_al and samefgrid_lr are used for these cases
