### PR TITLE
EAMxx: Change DPxx large scale subsidence routine to semi Lagrangian formulation (draft)

### DIFF
--- a/components/eamxx/src/physics/iop_forcing/eamxx_iop_forcing_process_interface.cpp
+++ b/components/eamxx/src/physics/iop_forcing/eamxx_iop_forcing_process_interface.cpp
@@ -192,8 +192,6 @@ advance_iop_subsidence(const MemberType& team,
     }
   });
 }
-
-
 // =========================================================================================
 KOKKOS_FUNCTION
 void IOPForcing::

--- a/components/eamxx/src/physics/iop_forcing/eamxx_iop_forcing_process_interface.cpp
+++ b/components/eamxx/src/physics/iop_forcing/eamxx_iop_forcing_process_interface.cpp
@@ -174,7 +174,7 @@ advance_iop_subsidence(const MemberType& team,
                        const view_1d<Pack>& T,
                        const view_2d<Pack>& Q)
 {
-  constexpr Real Rair  = C::Rair;
+  constexpr Real Rair = C::Rair;
   constexpr Real Cpair = C::Cpair;
 
   const int n_q_tracers = Q.extent_int(0);
@@ -185,10 +185,10 @@ advance_iop_subsidence(const MemberType& team,
   auto s_u         = ekat::scalarize(u);
   auto s_v         = ekat::scalarize(v);
   auto s_T         = ekat::scalarize(T);
-  auto s_Q         = ekat::scalarize(Q);  // Flattened as (n_q_tracers * nlevs)
+  auto s_Q         = ekat::scalarize(Q);
 
-  const Real* x_ptr     = s_ref_p_mid.data();  // now properly const
-  const Real* omega_ptr = s_omega.data();      // now properly const
+  const Real* x_ptr     = s_ref_p_mid.data();
+  const Real* omega_ptr = s_omega.data();
   Real* u_ptr           = s_u.data();
   Real* v_ptr           = s_v.data();
   Real* T_ptr           = s_T.data();
@@ -198,6 +198,10 @@ advance_iop_subsidence(const MemberType& team,
     const Real p_ref   = x_ptr[k];
     const Real omega_k = omega_ptr[k];
     const Real p_dep   = p_ref - dt * omega_k;
+
+    // Note that I know I should probably be using ekat's linear interp
+    //  routine but I couldn't figure out for the life of me how to interface
+    //  with this without getting an onslaught of compile issues.  HELP!?
 
     // Interpolate u, v, T at departure level
     u_ptr[k] = linear_interp_1d(x_ptr, u_ptr, nlevs, p_dep);

--- a/components/eamxx/src/physics/iop_forcing/eamxx_iop_forcing_process_interface.cpp
+++ b/components/eamxx/src/physics/iop_forcing/eamxx_iop_forcing_process_interface.cpp
@@ -167,6 +167,9 @@ advance_iop_subsidence(const MemberType& team,
   auto s_v          = ekat::scalarize(v);
   auto s_T          = ekat::scalarize(T);
 
+  // Init linear interpolation routine
+  ekat::LinInterp<Real,Pack::n> vert_interp(1, nlev_packs, nlev_packs);
+
   // Semi-Lagrangian update loop
   Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlevs), [&](const int k) {
     const Real omega_k = s_omega(k);
@@ -174,7 +177,6 @@ advance_iop_subsidence(const MemberType& team,
     const Real p_tgt = p_ref - dt * omega_k; // target pressure
 
     // Set up linear interpolation
-    ekat::LinInterp<Real,Pack::n> vert_interp(1, nlev_packs, nlev_packs);
     vert_interp.setup(team, p_ref, p_tgt);
 
     // Interpolate each field at the departure point


### PR DESCRIPTION
This PR updates the large-scale (LS) subsidence routine used in DPxx, replacing the centered-difference scheme with a semi-Lagrangian approach. This change addresses an issue observed in an edge case with strong LS subsidence, where the original method produced an unstable signature in the water vapor (qv) profile. A comparison plot illustrating this issue—contrasting the control simulation with the new solution implemented in this PR—can be found here: [Full diagnostics](https://portal.nersc.gov/cfs/e3sm/bogensch/DPxx_CGILS/CGILS_s12_stratus_SL_subsidence/)

The updated code compiles and runs as expected. However, I acknowledge that it likely does not yet conform to EAMxx coding standards. In particular, I implemented a custom inline linear interpolation routine, as I was unable to get EKAT’s interpolation utility to compile properly when interfacing with it. I’m submitting this as a draft PR to request feedback and guidance on making the code PR-ready. Assistance with integrating the EKAT interpolation routine—or any other suggestions for bringing the code up to standard—would be greatly appreciated.

![qv_profile_subsidence](https://github.com/user-attachments/assets/447c3f48-2f33-40dd-9fbb-b1f36a47453c)
